### PR TITLE
pm: device power management improvements

### DIFF
--- a/doc/reference/power_management/index.rst
+++ b/doc/reference/power_management/index.rst
@@ -273,13 +273,8 @@ Device Power Management Operations
 ==================================
 
 Zephyr RTOS power management subsystem provides a control function interface
-to device drivers to indicate power management operations to perform.
-The supported PM control commands are:
-
-* PM_DEVICE_STATE_SET
-* PM_DEVICE_STATE_GET
-
-Each device driver defines:
+to device drivers to indicate power management operations to perform. Each
+device driver defines:
 
 * The device's supported power states.
 * The device's supported transitions between power states.
@@ -330,20 +325,17 @@ Device Set Power State
 
 .. code-block:: c
 
-   int pm_device_state_set(const struct device *dev, uint32_t device_power_state, pm_device_cb cb, void *arg);
+   int pm_device_state_set(const struct device *dev, enum pm_device_state state);
 
 Calls the :c:func:`pm_control()` handler function implemented by the
-device driver with PM_DEVICE_STATE_SET command.
+device driver with the provided state.
 
 Device Get Power State
 ----------------------
 
 .. code-block:: c
 
-   int pm_device_state_get(const struct device *dev, uint32_t * device_power_state);
-
-Calls the :c:func:`pm_control()` handler function implemented by the
-device driver with PM_DEVICE_STATE_GET command.
+   int pm_device_state_get(const struct device *dev, enum pm_device_state *state);
 
 Busy Status Indication
 ======================

--- a/doc/reference/power_management/index.rst
+++ b/doc/reference/power_management/index.rst
@@ -248,7 +248,7 @@ The four device power states:
 
    Device context is preserved by the HW and need not be restored by the driver.
 
-:code:`PM_DEVICE_STATE_SUSPEND`
+:code:`PM_DEVICE_STATE_SUSPENDED`
 
    Most device context is lost by the hardware. Device drivers must save and
    restore or reinitialize any context lost by the hardware.
@@ -256,12 +256,12 @@ The four device power states:
 :code:`PM_DEVICE_STATE_SUSPENDING`
 
    Device is currently transitioning from :c:macro:`PM_DEVICE_STATE_ACTIVE` to
-   :c:macro:`PM_DEVICE_STATE_SUSPEND`.
+   :c:macro:`PM_DEVICE_STATE_SUSPENDED`.
 
 :code:`PM_DEVICE_STATE_RESUMING`
 
-   Device is currently transitioning from :c:macro:`PM_DEVICE_STATE_SUSPEND` to
-   :c:macro:`PM_DEVICE_STATE_ACTIVE`.
+   Device is currently transitioning from :c:macro:`PM_DEVICE_STATE_SUSPENDED`
+   to :c:macro:`PM_DEVICE_STATE_ACTIVE`.
 
 :code:`PM_DEVICE_STATE_OFF`
 

--- a/drivers/display/display_st7735r.c
+++ b/drivers/display/display_st7735r.c
@@ -67,9 +67,6 @@ struct st7735r_data {
 	const struct device *reset_dev;
 	uint16_t x_offset;
 	uint16_t y_offset;
-#ifdef CONFIG_PM_DEVICE
-	enum pm_device_state pm_state;
-#endif
 };
 
 static void st7735r_set_lcd_margins(struct st7735r_data *data,
@@ -475,10 +472,6 @@ static int st7735r_init(const struct device *dev)
 		}
 	}
 
-#ifdef CONFIG_PM_DEVICE
-	data->pm_state = PM_DEVICE_STATE_ACTIVE;
-#endif
-
 	data->cmd_data_dev = device_get_binding(config->cmd_data.name);
 	if (data->cmd_data_dev == NULL) {
 		LOG_ERR("Could not get GPIO port for cmd/DATA port");
@@ -532,22 +525,14 @@ static int st7735r_pm_control(const struct device *dev, uint32_t ctrl_command,
 			if (ret < 0) {
 				return ret;
 			}
-			data->pm_state = PM_DEVICE_STATE_ACTIVE;
 		} else {
 			ret = st7735r_enter_sleep(data);
 			if (ret < 0) {
 				return ret;
 			}
-			data->pm_state = PM_DEVICE_STATE_LOW_POWER;
 		}
 
 		break;
-
-	case PM_DEVICE_STATE_GET:
-		*state = data->pm_state;
-
-		break;
-
 	default:
 		ret = -EINVAL;
 	}

--- a/drivers/display/display_st7735r.c
+++ b/drivers/display/display_st7735r.c
@@ -518,23 +518,16 @@ static int st7735r_pm_control(const struct device *dev, uint32_t ctrl_command,
 	int ret = 0;
 	struct st7735r_data *data = (struct st7735r_data *)dev->data;
 
-	switch (ctrl_command) {
-	case PM_DEVICE_STATE_SET:
-		if (*state == PM_DEVICE_STATE_ACTIVE) {
-			ret = st7735r_exit_sleep(data);
-			if (ret < 0) {
-				return ret;
-			}
-		} else {
-			ret = st7735r_enter_sleep(data);
-			if (ret < 0) {
-				return ret;
-			}
+	if (*state == PM_DEVICE_STATE_ACTIVE) {
+		ret = st7735r_exit_sleep(data);
+		if (ret < 0) {
+			return ret;
 		}
-
-		break;
-	default:
-		ret = -EINVAL;
+	} else {
+		ret = st7735r_enter_sleep(data);
+		if (ret < 0) {
+			return ret;
+		}
 	}
 
 	return ret;

--- a/drivers/display/display_st7735r.c
+++ b/drivers/display/display_st7735r.c
@@ -513,12 +513,12 @@ static int st7735r_enter_sleep(struct st7735r_data *data)
 }
 
 static int st7735r_pm_control(const struct device *dev,
-			      enum pm_device_state *state)
+			      enum pm_device_state state)
 {
 	int ret = 0;
 	struct st7735r_data *data = (struct st7735r_data *)dev->data;
 
-	if (*state == PM_DEVICE_STATE_ACTIVE) {
+	if (state == PM_DEVICE_STATE_ACTIVE) {
 		ret = st7735r_exit_sleep(data);
 		if (ret < 0) {
 			return ret;

--- a/drivers/display/display_st7735r.c
+++ b/drivers/display/display_st7735r.c
@@ -512,7 +512,7 @@ static int st7735r_enter_sleep(struct st7735r_data *data)
 	return st7735r_transmit(data, ST7735R_CMD_SLEEP_IN, NULL, 0);
 }
 
-static int st7735r_pm_control(const struct device *dev, uint32_t ctrl_command,
+static int st7735r_pm_control(const struct device *dev,
 			      enum pm_device_state *state)
 {
 	int ret = 0;

--- a/drivers/display/display_st7735r.c
+++ b/drivers/display/display_st7735r.c
@@ -507,27 +507,22 @@ static int st7735r_init(const struct device *dev)
 }
 
 #ifdef CONFIG_PM_DEVICE
-static int st7735r_enter_sleep(struct st7735r_data *data)
-{
-	return st7735r_transmit(data, ST7735R_CMD_SLEEP_IN, NULL, 0);
-}
-
 static int st7735r_pm_control(const struct device *dev,
 			      enum pm_device_state state)
 {
 	int ret = 0;
 	struct st7735r_data *data = (struct st7735r_data *)dev->data;
 
-	if (state == PM_DEVICE_STATE_ACTIVE) {
+	switch (state) {
+	case PM_DEVICE_STATE_ACTIVE:
 		ret = st7735r_exit_sleep(data);
-		if (ret < 0) {
-			return ret;
-		}
-	} else {
-		ret = st7735r_enter_sleep(data);
-		if (ret < 0) {
-			return ret;
-		}
+		break;
+	case PM_DEVICE_STATE_SUSPENDED:
+		ret = st7735r_transmit(data, ST7735R_CMD_SLEEP_IN, NULL, 0);
+		break;
+	default:
+		ret = -ENOTSUP;
+		break;
 	}
 
 	return ret;

--- a/drivers/display/display_st7735r.c
+++ b/drivers/display/display_st7735r.c
@@ -508,16 +508,16 @@ static int st7735r_init(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 static int st7735r_pm_control(const struct device *dev,
-			      enum pm_device_state state)
+			      enum pm_device_action action)
 {
 	int ret = 0;
 	struct st7735r_data *data = (struct st7735r_data *)dev->data;
 
-	switch (state) {
-	case PM_DEVICE_STATE_ACTIVE:
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
 		ret = st7735r_exit_sleep(data);
 		break;
-	case PM_DEVICE_STATE_SUSPENDED:
+	case PM_DEVICE_ACTION_SUSPEND:
 		ret = st7735r_transmit(data, ST7735R_CMD_SLEEP_IN, NULL, 0);
 		break;
 	default:

--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -396,23 +396,25 @@ static int st7789v_init(const struct device *dev)
 }
 
 #ifdef CONFIG_PM_DEVICE
-static void st7789v_enter_sleep(struct st7789v_data *data)
-{
-	st7789v_transmit(data, ST7789V_CMD_SLEEP_IN, NULL, 0);
-}
-
 static int st7789v_pm_control(const struct device *dev,
 			      enum pm_device_state state)
 {
 	struct st7789v_data *data = (struct st7789v_data *)dev->data;
+	int ret = 0;
 
-	if (state == PM_DEVICE_STATE_ACTIVE) {
+	switch (state) {
+	case PM_DEVICE_STATE_ACTIVE:
 		st7789v_exit_sleep(data);
-	} else {
-		st7789v_enter_sleep(data);
+		break;
+	case PM_DEVICE_STATE_SUSPENDED:
+		ret = st7789v_transmit(data, ST7789V_CMD_SLEEP_IN, NULL, 0);
+		break;
+	default:
+		ret = -ENOTSUP;
+		break;
 	}
 
-	return 0;
+	return ret;
 }
 #endif /* CONFIG_PM_DEVICE */
 

--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -52,9 +52,6 @@ struct st7789v_data {
 	uint16_t width;
 	uint16_t x_offset;
 	uint16_t y_offset;
-#ifdef CONFIG_PM_DEVICE
-	enum pm_device_state pm_state;
-#endif
 };
 
 #ifdef CONFIG_ST7789V_RGB565
@@ -375,10 +372,6 @@ static int st7789v_init(const struct device *dev)
 	}
 #endif
 
-#ifdef CONFIG_PM_DEVICE
-	data->pm_state = PM_DEVICE_STATE_ACTIVE;
-#endif
-
 	data->cmd_data_gpio = device_get_binding(
 			DT_INST_GPIO_LABEL(0, cmd_data_gpios));
 	if (data->cmd_data_gpio == NULL) {
@@ -418,16 +411,11 @@ static int st7789v_pm_control(const struct device *dev, uint32_t ctrl_command,
 	case DEVICE_PM_SET_POWER_STATE:
 		if (*state == PM_DEVICE_STATE_ACTIVE) {
 			st7789v_exit_sleep(data);
-			data->pm_state = PM_DEVICE_STATE_ACTIVE;
 			ret = 0;
 		} else {
 			st7789v_enter_sleep(data);
-			data->pm_state = PM_DEVICE_STATE_LOW_POWER;
 			ret = 0;
 		}
-		break;
-	case PM_DEVICE_STATE_GET:
-		*state = data->pm_state;
 		break;
 	default:
 		ret = -EINVAL;

--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -402,11 +402,11 @@ static void st7789v_enter_sleep(struct st7789v_data *data)
 }
 
 static int st7789v_pm_control(const struct device *dev,
-			      enum pm_device_state *state)
+			      enum pm_device_state state)
 {
 	struct st7789v_data *data = (struct st7789v_data *)dev->data;
 
-	if (*state == PM_DEVICE_STATE_ACTIVE) {
+	if (state == PM_DEVICE_STATE_ACTIVE) {
 		st7789v_exit_sleep(data);
 	} else {
 		st7789v_enter_sleep(data);

--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -397,16 +397,16 @@ static int st7789v_init(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 static int st7789v_pm_control(const struct device *dev,
-			      enum pm_device_state state)
+			      enum pm_device_action action)
 {
 	struct st7789v_data *data = (struct st7789v_data *)dev->data;
 	int ret = 0;
 
-	switch (state) {
-	case PM_DEVICE_STATE_ACTIVE:
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
 		st7789v_exit_sleep(data);
 		break;
-	case PM_DEVICE_STATE_SUSPENDED:
+	case PM_DEVICE_ACTION_SUSPEND:
 		ret = st7789v_transmit(data, ST7789V_CMD_SLEEP_IN, NULL, 0);
 		break;
 	default:

--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -404,24 +404,15 @@ static void st7789v_enter_sleep(struct st7789v_data *data)
 static int st7789v_pm_control(const struct device *dev, uint32_t ctrl_command,
 				 enum pm_device_state *state)
 {
-	int ret = 0;
 	struct st7789v_data *data = (struct st7789v_data *)dev->data;
 
-	switch (ctrl_command) {
-	case DEVICE_PM_SET_POWER_STATE:
-		if (*state == PM_DEVICE_STATE_ACTIVE) {
-			st7789v_exit_sleep(data);
-			ret = 0;
-		} else {
-			st7789v_enter_sleep(data);
-			ret = 0;
-		}
-		break;
-	default:
-		ret = -EINVAL;
+	if (*state == PM_DEVICE_STATE_ACTIVE) {
+		st7789v_exit_sleep(data);
+	} else {
+		st7789v_enter_sleep(data);
 	}
 
-	return ret;
+	return 0;
 }
 #endif /* CONFIG_PM_DEVICE */
 

--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -401,8 +401,8 @@ static void st7789v_enter_sleep(struct st7789v_data *data)
 	st7789v_transmit(data, ST7789V_CMD_SLEEP_IN, NULL, 0);
 }
 
-static int st7789v_pm_control(const struct device *dev, uint32_t ctrl_command,
-				 enum pm_device_state *state)
+static int st7789v_pm_control(const struct device *dev,
+			      enum pm_device_state *state)
 {
 	struct st7789v_data *data = (struct st7789v_data *)dev->data;
 

--- a/drivers/entropy/entropy_cc13xx_cc26xx.c
+++ b/drivers/entropy/entropy_cc13xx_cc26xx.c
@@ -264,26 +264,25 @@ static int post_notify_fxn(unsigned int eventType, uintptr_t eventArg,
 #endif
 
 #ifdef CONFIG_PM_DEVICE
-static int entropy_cc13xx_cc26xx_set_power_state(const struct device *dev,
-						 enum pm_device_state state)
-{
-	struct entropy_cc13xx_cc26xx_data *data = get_dev_data(dev);
-
-	if (state == PM_DEVICE_STATE_ACTIVE) {
-		Power_setDependency(PowerCC26XX_PERIPH_TRNG);
-		start_trng(data);
-	} else {
-		stop_trng(data);
-		Power_releaseDependency(PowerCC26XX_PERIPH_TRNG);
-	}
-
-	return 0;
-}
-
 static int entropy_cc13xx_cc26xx_pm_control(const struct device *dev,
 					    enum pm_device_state state)
 {
-	return entropy_cc13xx_cc26xx_set_power_state(dev, state);
+	struct entropy_cc13xx_cc26xx_data *data = get_dev_data(dev);
+
+	switch (state) {
+	case PM_DEVICE_STATE_ACTIVE:
+		Power_setDependency(PowerCC26XX_PERIPH_TRNG);
+		start_trng(data);
+		break;
+	case PM_DEVICE_STATE_SUSPENDED:
+		stop_trng(data);
+		Power_releaseDependency(PowerCC26XX_PERIPH_TRNG);
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
 }
 #endif /* CONFIG_PM_DEVICE */
 

--- a/drivers/entropy/entropy_cc13xx_cc26xx.c
+++ b/drivers/entropy/entropy_cc13xx_cc26xx.c
@@ -291,7 +291,6 @@ static int entropy_cc13xx_cc26xx_set_power_state(const struct device *dev,
 }
 
 static int entropy_cc13xx_cc26xx_pm_control(const struct device *dev,
-					    uint32_t ctrl_command,
 					    enum pm_device_state *state)
 {
 	int ret = 0;

--- a/drivers/entropy/entropy_cc13xx_cc26xx.c
+++ b/drivers/entropy/entropy_cc13xx_cc26xx.c
@@ -295,14 +295,11 @@ static int entropy_cc13xx_cc26xx_pm_control(const struct device *dev,
 					    enum pm_device_state *state)
 {
 	int ret = 0;
+	enum pm_device_state curr_state;
 
-	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		enum pm_device_state curr_state;
-
-		(void)pm_device_state_get(dev, &curr_state);
-		if (*state != curr_state) {
-			ret = entropy_cc13xx_cc26xx_set_power_state(dev, *state);
-		}
+	(void)pm_device_state_get(dev, &curr_state);
+	if (*state != curr_state) {
+		ret = entropy_cc13xx_cc26xx_set_power_state(dev, *state);
 	}
 
 	return ret;

--- a/drivers/entropy/entropy_cc13xx_cc26xx.c
+++ b/drivers/entropy/entropy_cc13xx_cc26xx.c
@@ -265,16 +265,16 @@ static int post_notify_fxn(unsigned int eventType, uintptr_t eventArg,
 
 #ifdef CONFIG_PM_DEVICE
 static int entropy_cc13xx_cc26xx_pm_control(const struct device *dev,
-					    enum pm_device_state state)
+					    enum pm_device_action action)
 {
 	struct entropy_cc13xx_cc26xx_data *data = get_dev_data(dev);
 
-	switch (state) {
-	case PM_DEVICE_STATE_ACTIVE:
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
 		Power_setDependency(PowerCC26XX_PERIPH_TRNG);
 		start_trng(data);
 		break;
-	case PM_DEVICE_STATE_SUSPENDED:
+	case PM_DEVICE_ACTION_SUSPEND:
 		stop_trng(data);
 		Power_releaseDependency(PowerCC26XX_PERIPH_TRNG);
 		break;

--- a/drivers/entropy/entropy_cc13xx_cc26xx.c
+++ b/drivers/entropy/entropy_cc13xx_cc26xx.c
@@ -265,43 +265,25 @@ static int post_notify_fxn(unsigned int eventType, uintptr_t eventArg,
 
 #ifdef CONFIG_PM_DEVICE
 static int entropy_cc13xx_cc26xx_set_power_state(const struct device *dev,
-						 enum pm_device_state new_state)
+						 enum pm_device_state state)
 {
 	struct entropy_cc13xx_cc26xx_data *data = get_dev_data(dev);
-	int ret = 0;
-	enum pm_device_state state;
 
-	(void)pm_device_state_get(dev, &state);
-
-	if ((new_state == PM_DEVICE_STATE_ACTIVE) && (new_state != state)) {
+	if (state == PM_DEVICE_STATE_ACTIVE) {
 		Power_setDependency(PowerCC26XX_PERIPH_TRNG);
 		start_trng(data);
 	} else {
-		__ASSERT_NO_MSG(new_state == PM_DEVICE_STATE_LOW_POWER ||
-			new_state == PM_DEVICE_STATE_SUSPEND ||
-			new_state == PM_DEVICE_STATE_OFF);
-
-		if (state == PM_DEVICE_STATE_ACTIVE) {
-			stop_trng(data);
-			Power_releaseDependency(PowerCC26XX_PERIPH_TRNG);
-		}
+		stop_trng(data);
+		Power_releaseDependency(PowerCC26XX_PERIPH_TRNG);
 	}
 
-	return ret;
+	return 0;
 }
 
 static int entropy_cc13xx_cc26xx_pm_control(const struct device *dev,
 					    enum pm_device_state state)
 {
-	int ret = 0;
-	enum pm_device_state curr_state;
-
-	(void)pm_device_state_get(dev, &curr_state);
-	if (state != curr_state) {
-		ret = entropy_cc13xx_cc26xx_set_power_state(dev, state);
-	}
-
-	return ret;
+	return entropy_cc13xx_cc26xx_set_power_state(dev, state);
 }
 #endif /* CONFIG_PM_DEVICE */
 

--- a/drivers/entropy/entropy_cc13xx_cc26xx.c
+++ b/drivers/entropy/entropy_cc13xx_cc26xx.c
@@ -291,14 +291,14 @@ static int entropy_cc13xx_cc26xx_set_power_state(const struct device *dev,
 }
 
 static int entropy_cc13xx_cc26xx_pm_control(const struct device *dev,
-					    enum pm_device_state *state)
+					    enum pm_device_state state)
 {
 	int ret = 0;
 	enum pm_device_state curr_state;
 
 	(void)pm_device_state_get(dev, &curr_state);
-	if (*state != curr_state) {
-		ret = entropy_cc13xx_cc26xx_set_power_state(dev, *state);
+	if (state != curr_state) {
+		ret = entropy_cc13xx_cc26xx_set_power_state(dev, state);
 	}
 
 	return ret;

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -185,7 +185,6 @@ static void eth_mcux_phy_enter_reset(struct eth_context *context);
 void eth_mcux_phy_stop(struct eth_context *context);
 
 static int eth_mcux_device_pm_control(const struct device *dev,
-				      uint32_t command,
 				      enum pm_device_state *state)
 {
 	struct eth_context *eth_ctx = (struct eth_context *)dev->data;

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -185,7 +185,7 @@ static void eth_mcux_phy_enter_reset(struct eth_context *context);
 void eth_mcux_phy_stop(struct eth_context *context);
 
 static int eth_mcux_device_pm_control(const struct device *dev,
-				      enum pm_device_state *state)
+				      enum pm_device_state state)
 {
 	struct eth_context *eth_ctx = (struct eth_context *)dev->data;
 	int ret = 0;
@@ -197,7 +197,7 @@ static int eth_mcux_device_pm_control(const struct device *dev,
 		goto out;
 	}
 
-	if (*state == PM_DEVICE_STATE_SUSPEND) {
+	if (state == PM_DEVICE_STATE_SUSPEND) {
 		LOG_DBG("Suspending");
 
 		ret = net_if_suspend(eth_ctx->iface);
@@ -212,7 +212,7 @@ static int eth_mcux_device_pm_control(const struct device *dev,
 		ENET_Deinit(eth_ctx->base);
 		clock_control_off(eth_ctx->clock_dev,
 			(clock_control_subsys_t)eth_ctx->clock);
-	} else if (*state == PM_DEVICE_STATE_ACTIVE) {
+	} else if (state == PM_DEVICE_STATE_ACTIVE) {
 		LOG_DBG("Resuming");
 
 		clock_control_on(eth_ctx->clock_dev,

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -198,32 +198,28 @@ static int eth_mcux_device_pm_control(const struct device *dev,
 		goto out;
 	}
 
-	if (command == PM_DEVICE_STATE_SET) {
-		if (*state == PM_DEVICE_STATE_SUSPEND) {
-			LOG_DBG("Suspending");
+	if (*state == PM_DEVICE_STATE_SUSPEND) {
+		LOG_DBG("Suspending");
 
-			ret = net_if_suspend(eth_ctx->iface);
-			if (ret == -EBUSY) {
-				goto out;
-			}
-
-			eth_mcux_phy_enter_reset(eth_ctx);
-			eth_mcux_phy_stop(eth_ctx);
-
-			ENET_Reset(eth_ctx->base);
-			ENET_Deinit(eth_ctx->base);
-			clock_control_off(eth_ctx->clock_dev,
-				(clock_control_subsys_t)eth_ctx->clock);
-		} else if (*state == PM_DEVICE_STATE_ACTIVE) {
-			LOG_DBG("Resuming");
-
-			clock_control_on(eth_ctx->clock_dev,
-				(clock_control_subsys_t)eth_ctx->clock);
-			eth_mcux_init(dev);
-			net_if_resume(eth_ctx->iface);
+		ret = net_if_suspend(eth_ctx->iface);
+		if (ret == -EBUSY) {
+			goto out;
 		}
-	} else {
-		return -EINVAL;
+
+		eth_mcux_phy_enter_reset(eth_ctx);
+		eth_mcux_phy_stop(eth_ctx);
+
+		ENET_Reset(eth_ctx->base);
+		ENET_Deinit(eth_ctx->base);
+		clock_control_off(eth_ctx->clock_dev,
+			(clock_control_subsys_t)eth_ctx->clock);
+	} else if (*state == PM_DEVICE_STATE_ACTIVE) {
+		LOG_DBG("Resuming");
+
+		clock_control_on(eth_ctx->clock_dev,
+			(clock_control_subsys_t)eth_ctx->clock);
+		eth_mcux_init(dev);
+		net_if_resume(eth_ctx->iface);
 	}
 
 out:

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -185,7 +185,7 @@ static void eth_mcux_phy_enter_reset(struct eth_context *context);
 void eth_mcux_phy_stop(struct eth_context *context);
 
 static int eth_mcux_device_pm_control(const struct device *dev,
-				      enum pm_device_state state)
+				      enum pm_device_action action)
 {
 	struct eth_context *eth_ctx = (struct eth_context *)dev->data;
 	int ret = 0;
@@ -197,8 +197,8 @@ static int eth_mcux_device_pm_control(const struct device *dev,
 		goto out;
 	}
 
-	switch (state) {
-	case PM_DEVICE_STATE_SUSPENDED:
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
 		LOG_DBG("Suspending");
 
 		ret = net_if_suspend(eth_ctx->iface);
@@ -214,7 +214,7 @@ static int eth_mcux_device_pm_control(const struct device *dev,
 		clock_control_off(eth_ctx->clock_dev,
 			(clock_control_subsys_t)eth_ctx->clock);
 		break;
-	case PM_DEVICE_STATE_ACTIVE:
+	case PM_DEVICE_ACTION_RESUME:
 		LOG_DBG("Resuming");
 
 		clock_control_on(eth_ctx->clock_dev,

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -197,7 +197,7 @@ static int eth_mcux_device_pm_control(const struct device *dev,
 		goto out;
 	}
 
-	if (state == PM_DEVICE_STATE_SUSPEND) {
+	if (state == PM_DEVICE_STATE_SUSPENDED) {
 		LOG_DBG("Suspending");
 
 		ret = net_if_suspend(eth_ctx->iface);

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -197,7 +197,8 @@ static int eth_mcux_device_pm_control(const struct device *dev,
 		goto out;
 	}
 
-	if (state == PM_DEVICE_STATE_SUSPENDED) {
+	switch (state) {
+	case PM_DEVICE_STATE_SUSPENDED:
 		LOG_DBG("Suspending");
 
 		ret = net_if_suspend(eth_ctx->iface);
@@ -212,13 +213,18 @@ static int eth_mcux_device_pm_control(const struct device *dev,
 		ENET_Deinit(eth_ctx->base);
 		clock_control_off(eth_ctx->clock_dev,
 			(clock_control_subsys_t)eth_ctx->clock);
-	} else if (state == PM_DEVICE_STATE_ACTIVE) {
+		break;
+	case PM_DEVICE_STATE_ACTIVE:
 		LOG_DBG("Resuming");
 
 		clock_control_on(eth_ctx->clock_dev,
 			(clock_control_subsys_t)eth_ctx->clock);
 		eth_mcux_init(dev);
 		net_if_resume(eth_ctx->iface);
+		break;
+	default:
+		ret = -ENOTSUP;
+		break;
 	}
 
 out:

--- a/drivers/flash/spi_flash_at45.c
+++ b/drivers/flash/spi_flash_at45.c
@@ -637,8 +637,6 @@ static int spi_flash_at45_pm_control(const struct device *dev,
 		break;
 
 	case PM_DEVICE_STATE_SUSPENDED:
-		__fallthrough;
-	case PM_DEVICE_STATE_OFF:
 		acquire(dev);
 		power_down_op(dev,
 			dev_config->use_udpd ? CMD_ENTER_UDPD : CMD_ENTER_DPD,

--- a/drivers/flash/spi_flash_at45.c
+++ b/drivers/flash/spi_flash_at45.c
@@ -625,15 +625,15 @@ static int spi_flash_at45_init(const struct device *dev)
 
 #if IS_ENABLED(CONFIG_PM_DEVICE)
 static int spi_flash_at45_pm_control(const struct device *dev,
-				     enum pm_device_state *state)
+				     enum pm_device_state state)
 {
 	const struct spi_flash_at45_config *dev_config = get_dev_config(dev);
 	int err = 0;
 	enum pm_device_state curr_state;
 
 	(void)pm_device_state_get(dev, &curr_state);
-	if (*state != curr_state) {
-		switch (*state) {
+	if (state != curr_state) {
+		switch (state) {
 		case PM_DEVICE_STATE_ACTIVE:
 			acquire(dev);
 			power_down_op(dev, CMD_EXIT_DPD,

--- a/drivers/flash/spi_flash_at45.c
+++ b/drivers/flash/spi_flash_at45.c
@@ -636,7 +636,7 @@ static int spi_flash_at45_pm_control(const struct device *dev,
 		release(dev);
 		break;
 
-	case PM_DEVICE_STATE_SUSPEND:
+	case PM_DEVICE_STATE_SUSPENDED:
 	case PM_DEVICE_STATE_OFF:
 		acquire(dev);
 		power_down_op(dev,

--- a/drivers/flash/spi_flash_at45.c
+++ b/drivers/flash/spi_flash_at45.c
@@ -625,7 +625,6 @@ static int spi_flash_at45_init(const struct device *dev)
 
 #if IS_ENABLED(CONFIG_PM_DEVICE)
 static int spi_flash_at45_pm_control(const struct device *dev,
-				     uint32_t ctrl_command,
 				     enum pm_device_state *state)
 {
 	const struct spi_flash_at45_config *dev_config = get_dev_config(dev);

--- a/drivers/flash/spi_flash_at45.c
+++ b/drivers/flash/spi_flash_at45.c
@@ -637,6 +637,7 @@ static int spi_flash_at45_pm_control(const struct device *dev,
 		break;
 
 	case PM_DEVICE_STATE_SUSPENDED:
+		__fallthrough;
 	case PM_DEVICE_STATE_OFF:
 		acquire(dev);
 		power_down_op(dev,

--- a/drivers/flash/spi_flash_at45.c
+++ b/drivers/flash/spi_flash_at45.c
@@ -625,18 +625,18 @@ static int spi_flash_at45_init(const struct device *dev)
 
 #if IS_ENABLED(CONFIG_PM_DEVICE)
 static int spi_flash_at45_pm_control(const struct device *dev,
-				     enum pm_device_state state)
+				     enum pm_device_action action)
 {
 	const struct spi_flash_at45_config *dev_config = get_dev_config(dev);
 
-	switch (state) {
-	case PM_DEVICE_STATE_ACTIVE:
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
 		acquire(dev);
 		power_down_op(dev, CMD_EXIT_DPD, dev_config->t_exit_dpd);
 		release(dev);
 		break;
 
-	case PM_DEVICE_STATE_SUSPENDED:
+	case PM_DEVICE_ACTION_SUSPEND:
 		acquire(dev);
 		power_down_op(dev,
 			dev_config->use_udpd ? CMD_ENTER_UDPD : CMD_ENTER_DPD,

--- a/drivers/flash/spi_flash_at45.c
+++ b/drivers/flash/spi_flash_at45.c
@@ -628,36 +628,29 @@ static int spi_flash_at45_pm_control(const struct device *dev,
 				     enum pm_device_state state)
 {
 	const struct spi_flash_at45_config *dev_config = get_dev_config(dev);
-	int err = 0;
-	enum pm_device_state curr_state;
 
-	(void)pm_device_state_get(dev, &curr_state);
-	if (state != curr_state) {
-		switch (state) {
-		case PM_DEVICE_STATE_ACTIVE:
-			acquire(dev);
-			power_down_op(dev, CMD_EXIT_DPD,
-					dev_config->t_exit_dpd);
-			release(dev);
-			break;
+	switch (state) {
+	case PM_DEVICE_STATE_ACTIVE:
+		acquire(dev);
+		power_down_op(dev, CMD_EXIT_DPD, dev_config->t_exit_dpd);
+		release(dev);
+		break;
 
-		case PM_DEVICE_STATE_LOW_POWER:
-		case PM_DEVICE_STATE_SUSPEND:
-		case PM_DEVICE_STATE_OFF:
-			acquire(dev);
-			power_down_op(dev,
-				dev_config->use_udpd ? CMD_ENTER_UDPD
-							: CMD_ENTER_DPD,
-				dev_config->t_enter_dpd);
-			release(dev);
-			break;
+	case PM_DEVICE_STATE_LOW_POWER:
+	case PM_DEVICE_STATE_SUSPEND:
+	case PM_DEVICE_STATE_OFF:
+		acquire(dev);
+		power_down_op(dev,
+			dev_config->use_udpd ? CMD_ENTER_UDPD : CMD_ENTER_DPD,
+			dev_config->t_enter_dpd);
+		release(dev);
+		break;
 
-		default:
-			return -ENOTSUP;
-		}
+	default:
+		return -ENOTSUP;
 	}
 
-	return err;
+	return 0;
 }
 #endif /* IS_ENABLED(CONFIG_PM_DEVICE) */
 

--- a/drivers/flash/spi_flash_at45.c
+++ b/drivers/flash/spi_flash_at45.c
@@ -636,7 +636,6 @@ static int spi_flash_at45_pm_control(const struct device *dev,
 		release(dev);
 		break;
 
-	case PM_DEVICE_STATE_LOW_POWER:
 	case PM_DEVICE_STATE_SUSPEND:
 	case PM_DEVICE_STATE_OFF:
 		acquire(dev);

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -38,8 +38,8 @@ LOG_MODULE_REGISTER(spi_nor, CONFIG_FLASH_LOG_LEVEL);
  *
  * When mapped to the Zephyr Device Power Management states:
  * * PM_DEVICE_STATE_ACTIVE covers both active and standby modes;
- * * PM_DEVICE_STATE_SUSPEND, and PM_DEVICE_STATE_OFF all correspond
- *   to deep-power-down mode.
+ * * PM_DEVICE_STATE_SUSPENDED, and PM_DEVICE_STATE_OFF all correspond to
+ *   deep-power-down mode.
  */
 
 #define SPI_NOR_MAX_ADDR_WIDTH 4

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -38,8 +38,8 @@ LOG_MODULE_REGISTER(spi_nor, CONFIG_FLASH_LOG_LEVEL);
  *
  * When mapped to the Zephyr Device Power Management states:
  * * PM_DEVICE_STATE_ACTIVE covers both active and standby modes;
- * * PM_DEVICE_STATE_LOW_POWER, PM_DEVICE_STATE_SUSPEND, and
- *   PM_DEVICE_STATE_OFF all correspond to deep-power-down mode.
+ * * PM_DEVICE_STATE_SUSPEND, and PM_DEVICE_STATE_OFF all correspond
+ *   to deep-power-down mode.
  */
 
 #define SPI_NOR_MAX_ADDR_WIDTH 4

--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -446,7 +446,7 @@ static int gpio_dw_device_ctrl(const struct device *port,
 {
 	int ret = 0;
 
-	if (state == PM_DEVICE_STATE_SUSPEND) {
+	if (state == PM_DEVICE_STATE_SUSPENDED) {
 		ret = gpio_dw_suspend_port(port);
 	} else if (state == PM_DEVICE_STATE_ACTIVE) {
 		ret = gpio_dw_resume_from_suspend_port(port);

--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -442,7 +442,6 @@ static inline int gpio_dw_resume_from_suspend_port(const struct device *port)
 * the *context may include IN data or/and OUT data
 */
 static int gpio_dw_device_ctrl(const struct device *port,
-			       uint32_t ctrl_command,
 			       enum pm_device_state *state)
 {
 	int ret = 0;

--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -430,13 +430,13 @@ static inline int gpio_dw_manage_callback(const struct device *port,
 * the *context may include IN data or/and OUT data
 */
 static int gpio_dw_device_ctrl(const struct device *dev,
-			       enum pm_device_state state)
+			       enum pm_device_action action)
 {
-	switch (state) {
-	case PM_DEVICE_STATE_SUSPENDED:
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
 		gpio_dw_clock_off(dev);
 		break;
-	case PM_DEVICE_STATE_ACTIVE:
+	case PM_DEVICE_ACTION_RESUME:
 		gpio_dw_clock_on(dev);
 		break;
 	default:

--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -447,12 +447,10 @@ static int gpio_dw_device_ctrl(const struct device *port,
 {
 	int ret = 0;
 
-	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		if (*state == PM_DEVICE_STATE_SUSPEND) {
-			ret = gpio_dw_suspend_port(port);
-		} else if (*state == PM_DEVICE_STATE_ACTIVE) {
-			ret = gpio_dw_resume_from_suspend_port(port);
-		}
+	if (*state == PM_DEVICE_STATE_SUSPEND) {
+		ret = gpio_dw_suspend_port(port);
+	} else if (*state == PM_DEVICE_STATE_ACTIVE) {
+		ret = gpio_dw_resume_from_suspend_port(port);
 	}
 
 	return ret;

--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -425,34 +425,25 @@ static inline int gpio_dw_manage_callback(const struct device *port,
 }
 
 #ifdef CONFIG_PM_DEVICE
-static inline int gpio_dw_suspend_port(const struct device *port)
-{
-	gpio_dw_clock_off(port);
-	return 0;
-}
-
-static inline int gpio_dw_resume_from_suspend_port(const struct device *port)
-{
-	gpio_dw_clock_on(port);
-	return 0;
-}
-
 /*
 * Implements the driver control management functionality
 * the *context may include IN data or/and OUT data
 */
-static int gpio_dw_device_ctrl(const struct device *port,
+static int gpio_dw_device_ctrl(const struct device *dev,
 			       enum pm_device_state state)
 {
-	int ret = 0;
-
-	if (state == PM_DEVICE_STATE_SUSPENDED) {
-		ret = gpio_dw_suspend_port(port);
-	} else if (state == PM_DEVICE_STATE_ACTIVE) {
-		ret = gpio_dw_resume_from_suspend_port(port);
+	switch (state) {
+	case PM_DEVICE_STATE_SUSPENDED:
+		gpio_dw_clock_off(dev);
+		break;
+	case PM_DEVICE_STATE_ACTIVE:
+		gpio_dw_clock_on(dev);
+		break;
+	default:
+		return -ENOTSUP;
 	}
 
-	return ret;
+	return 0;
 }
 #endif
 

--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -425,33 +425,15 @@ static inline int gpio_dw_manage_callback(const struct device *port,
 }
 
 #ifdef CONFIG_PM_DEVICE
-static void gpio_dw_set_power_state(const struct device *port,
-				    uint32_t power_state)
-{
-	struct gpio_dw_runtime *context = port->data;
-
-	context->device_power_state = power_state;
-}
-
-static uint32_t gpio_dw_get_power_state(const struct device *port)
-{
-	struct gpio_dw_runtime *context = port->data;
-
-	return context->device_power_state;
-}
-
 static inline int gpio_dw_suspend_port(const struct device *port)
 {
 	gpio_dw_clock_off(port);
-	gpio_dw_set_power_state(port, PM_DEVICE_STATE_SUSPEND);
-
 	return 0;
 }
 
 static inline int gpio_dw_resume_from_suspend_port(const struct device *port)
 {
 	gpio_dw_clock_on(port);
-	gpio_dw_set_power_state(port, PM_DEVICE_STATE_ACTIVE);
 	return 0;
 }
 
@@ -471,15 +453,10 @@ static int gpio_dw_device_ctrl(const struct device *port,
 		} else if (*state == PM_DEVICE_STATE_ACTIVE) {
 			ret = gpio_dw_resume_from_suspend_port(port);
 		}
-	} else if (ctrl_command == PM_DEVICE_STATE_GET) {
-		*state = gpio_dw_get_power_state(port);
 	}
 
 	return ret;
 }
-
-#else
-#define gpio_dw_set_power_state(...)
 #endif
 
 #define gpio_dw_unmask_int(...)
@@ -540,8 +517,6 @@ static int gpio_dw_initialize(const struct device *port)
 
 		config->config_func(port);
 	}
-
-	gpio_dw_set_power_state(port, PM_DEVICE_STATE_ACTIVE);
 
 	return 0;
 }

--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -442,13 +442,13 @@ static inline int gpio_dw_resume_from_suspend_port(const struct device *port)
 * the *context may include IN data or/and OUT data
 */
 static int gpio_dw_device_ctrl(const struct device *port,
-			       enum pm_device_state *state)
+			       enum pm_device_state state)
 {
 	int ret = 0;
 
-	if (*state == PM_DEVICE_STATE_SUSPEND) {
+	if (state == PM_DEVICE_STATE_SUSPEND) {
 		ret = gpio_dw_suspend_port(port);
-	} else if (*state == PM_DEVICE_STATE_ACTIVE) {
+	} else if (state == PM_DEVICE_STATE_ACTIVE) {
 		ret = gpio_dw_resume_from_suspend_port(port);
 	}
 

--- a/drivers/gpio/gpio_dw.h
+++ b/drivers/gpio/gpio_dw.h
@@ -41,9 +41,6 @@ struct gpio_dw_runtime {
 	const struct device *clock;
 #endif
 	sys_slist_t callbacks;
-#ifdef CONFIG_PM_DEVICE
-	enum pm_device_state device_power_state;
-#endif
 };
 
 #ifdef __cplusplus

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -595,14 +595,14 @@ static int gpio_stm32_set_power_state(const struct device *dev,
 }
 
 static int gpio_stm32_pm_device_ctrl(const struct device *dev,
-				     enum pm_device_state *state)
+				     enum pm_device_state state)
 {
 	int ret = 0;
 	enum pm_device_state curr_state;
 
 	(void)pm_device_state_get(dev, &curr_state);
-	if (*state != curr_state) {
-		ret = gpio_stm32_set_power_state(dev, *state);
+	if (state != curr_state) {
+		ret = gpio_stm32_set_power_state(dev, state);
 	}
 
 	return ret;

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -595,7 +595,6 @@ static int gpio_stm32_set_power_state(const struct device *dev,
 }
 
 static int gpio_stm32_pm_device_ctrl(const struct device *dev,
-				     uint32_t ctrl_command,
 				     enum pm_device_state *state)
 {
 	int ret = 0;

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -583,8 +583,6 @@ static int gpio_stm32_set_power_state(const struct device *dev,
 		ret = gpio_stm32_clock_request(dev, true);
 	} else if (state == PM_DEVICE_STATE_SUSPEND) {
 		ret = gpio_stm32_clock_request(dev, false);
-	} else if (state == PM_DEVICE_STATE_LOW_POWER) {
-		ret = gpio_stm32_clock_request(dev, false);
 	}
 
 	if (ret < 0) {

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -574,28 +574,19 @@ static const struct gpio_driver_api gpio_stm32_driver = {
 };
 
 #ifdef CONFIG_PM_DEVICE
-static int gpio_stm32_set_power_state(const struct device *dev,
-				      enum pm_device_state state)
-{
-	int ret = 0;
-
-	if (state == PM_DEVICE_STATE_ACTIVE) {
-		ret = gpio_stm32_clock_request(dev, true);
-	} else if (state == PM_DEVICE_STATE_SUSPENDED) {
-		ret = gpio_stm32_clock_request(dev, false);
-	}
-
-	if (ret < 0) {
-		return ret;
-	}
-
-	return 0;
-}
-
 static int gpio_stm32_pm_device_ctrl(const struct device *dev,
 				     enum pm_device_state state)
 {
-	return gpio_stm32_set_power_state(dev, state);
+	switch (state) {
+	case PM_DEVICE_STATE_ACTIVE:
+		return gpio_stm32_clock_request(dev, true);
+	case PM_DEVICE_STATE_SUSPENDED:
+		return gpio_stm32_clock_request(dev, false);
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
 }
 #endif /* CONFIG_PM_DEVICE */
 

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -575,12 +575,12 @@ static const struct gpio_driver_api gpio_stm32_driver = {
 
 #ifdef CONFIG_PM_DEVICE
 static int gpio_stm32_pm_device_ctrl(const struct device *dev,
-				     enum pm_device_state state)
+				     enum pm_device_action action)
 {
-	switch (state) {
-	case PM_DEVICE_STATE_ACTIVE:
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
 		return gpio_stm32_clock_request(dev, true);
-	case PM_DEVICE_STATE_SUSPENDED:
+	case PM_DEVICE_ACTION_SUSPEND:
 		return gpio_stm32_clock_request(dev, false);
 	default:
 		return -ENOTSUP;

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -575,15 +575,15 @@ static const struct gpio_driver_api gpio_stm32_driver = {
 
 #ifdef CONFIG_PM_DEVICE
 static int gpio_stm32_set_power_state(const struct device *dev,
-					      enum pm_device_state new_state)
+				      enum pm_device_state state)
 {
 	int ret = 0;
 
-	if (new_state == PM_DEVICE_STATE_ACTIVE) {
+	if (state == PM_DEVICE_STATE_ACTIVE) {
 		ret = gpio_stm32_clock_request(dev, true);
-	} else if (new_state == PM_DEVICE_STATE_SUSPEND) {
+	} else if (state == PM_DEVICE_STATE_SUSPEND) {
 		ret = gpio_stm32_clock_request(dev, false);
-	} else if (new_state == PM_DEVICE_STATE_LOW_POWER) {
+	} else if (state == PM_DEVICE_STATE_LOW_POWER) {
 		ret = gpio_stm32_clock_request(dev, false);
 	}
 
@@ -597,15 +597,7 @@ static int gpio_stm32_set_power_state(const struct device *dev,
 static int gpio_stm32_pm_device_ctrl(const struct device *dev,
 				     enum pm_device_state state)
 {
-	int ret = 0;
-	enum pm_device_state curr_state;
-
-	(void)pm_device_state_get(dev, &curr_state);
-	if (state != curr_state) {
-		ret = gpio_stm32_set_power_state(dev, state);
-	}
-
-	return ret;
+	return gpio_stm32_set_power_state(dev, state);
 }
 #endif /* CONFIG_PM_DEVICE */
 

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -599,19 +599,11 @@ static int gpio_stm32_pm_device_ctrl(const struct device *dev,
 				     enum pm_device_state *state)
 {
 	int ret = 0;
+	enum pm_device_state curr_state;
 
-	switch (ctrl_command) {
-	case PM_DEVICE_STATE_SET:
-		enum pm_device_state curr_state;
-
-		(void)pm_device_state_get(dev, &curr_state);
-		if (*state != curr_state) {
-			ret = gpio_stm32_set_power_state(dev, *state);
-		}
-		break;
-	default:
-		ret = -EINVAL;
-
+	(void)pm_device_state_get(dev, &curr_state);
+	if (*state != curr_state) {
+		ret = gpio_stm32_set_power_state(dev, *state);
 	}
 
 	return ret;

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -581,7 +581,7 @@ static int gpio_stm32_set_power_state(const struct device *dev,
 
 	if (state == PM_DEVICE_STATE_ACTIVE) {
 		ret = gpio_stm32_clock_request(dev, true);
-	} else if (state == PM_DEVICE_STATE_SUSPEND) {
+	} else if (state == PM_DEVICE_STATE_SUSPENDED) {
 		ret = gpio_stm32_clock_request(dev, false);
 	}
 

--- a/drivers/gpio/gpio_stm32.h
+++ b/drivers/gpio/gpio_stm32.h
@@ -229,10 +229,6 @@ struct gpio_stm32_data {
 	const struct device *dev;
 	/* user ISR cb */
 	sys_slist_t cb;
-#ifdef CONFIG_PM_DEVICE
-	/* device power state */
-	enum pm_device_state power_state;
-#endif
 };
 
 /**

--- a/drivers/i2c/i2c_cc13xx_cc26xx.c
+++ b/drivers/i2c/i2c_cc13xx_cc26xx.c
@@ -365,7 +365,6 @@ static int i2c_cc13xx_cc26xx_set_power_state(const struct device *dev,
 }
 
 static int i2c_cc13xx_cc26xx_pm_control(const struct device *dev,
-					uint32_t ctrl_command,
 					enum pm_device_state *state)
 {
 	int ret = 0;

--- a/drivers/i2c/i2c_cc13xx_cc26xx.c
+++ b/drivers/i2c/i2c_cc13xx_cc26xx.c
@@ -365,13 +365,13 @@ static int i2c_cc13xx_cc26xx_set_power_state(const struct device *dev,
 }
 
 static int i2c_cc13xx_cc26xx_pm_control(const struct device *dev,
-					enum pm_device_state *state)
+					enum pm_device_state state)
 {
 	int ret = 0;
 	enum pm_device_state curr_state;
 
 	(void)pm_device_state_get(dev, &curr_state);
-	if (*state != curr_state) {
+	if (state != curr_state) {
 		ret = i2c_cc13xx_cc26xx_set_power_state(dev,
 			new_state);
 	}

--- a/drivers/i2c/i2c_cc13xx_cc26xx.c
+++ b/drivers/i2c/i2c_cc13xx_cc26xx.c
@@ -327,14 +327,11 @@ static int postNotifyFxn(unsigned int eventType, uintptr_t eventArg,
 
 #ifdef CONFIG_PM_DEVICE
 static int i2c_cc13xx_cc26xx_set_power_state(const struct device *dev,
-					     enum pm_device_state new_state)
+					     enum pm_device_state state)
 {
 	int ret = 0;
-	enum pm_device_state state;
 
-	(void)pm_device_state_get(dev, &state);
-
-	if ((new_state == PM_DEVICE_STATE_ACTIVE) && (new_state != state) {
+	if (state == PM_DEVICE_STATE_ACTIVE) {
 		Power_setDependency(PowerCC26XX_PERIPH_I2C0);
 		IOCPinTypeI2c(get_dev_config(dev)->base,
 			get_dev_config(dev)->sda_pin,
@@ -345,20 +342,14 @@ static int i2c_cc13xx_cc26xx_set_power_state(const struct device *dev,
 			I2CMasterIntEnable(get_dev_config(dev)->base);
 		}
 	} else {
-		__ASSERT_NO_MSG(new_state == PM_DEVICE_STATE_LOW_POWER ||
-			new_state == PM_DEVICE_STATE_SUSPEND ||
-			new_state == PM_DEVICE_STATE_OFF);
-
-		if (state == PM_DEVICE_STATE_ACTIVE) {
-			I2CMasterIntDisable(get_dev_config(dev)->base);
-			I2CMasterDisable(get_dev_config(dev)->base);
-			/* Reset pin type to default GPIO configuration */
-			IOCPortConfigureSet(get_dev_config(dev)->scl_pin,
-				IOC_PORT_GPIO, IOC_STD_OUTPUT);
-			IOCPortConfigureSet(get_dev_config(dev)->sda_pin,
-				IOC_PORT_GPIO, IOC_STD_OUTPUT);
-			Power_releaseDependency(PowerCC26XX_PERIPH_I2C0);
-		}
+		I2CMasterIntDisable(get_dev_config(dev)->base);
+		I2CMasterDisable(get_dev_config(dev)->base);
+		/* Reset pin type to default GPIO configuration */
+		IOCPortConfigureSet(get_dev_config(dev)->scl_pin,
+			IOC_PORT_GPIO, IOC_STD_OUTPUT);
+		IOCPortConfigureSet(get_dev_config(dev)->sda_pin,
+			IOC_PORT_GPIO, IOC_STD_OUTPUT);
+		Power_releaseDependency(PowerCC26XX_PERIPH_I2C0);
 	}
 
 	return ret;
@@ -367,16 +358,7 @@ static int i2c_cc13xx_cc26xx_set_power_state(const struct device *dev,
 static int i2c_cc13xx_cc26xx_pm_control(const struct device *dev,
 					enum pm_device_state state)
 {
-	int ret = 0;
-	enum pm_device_state curr_state;
-
-	(void)pm_device_state_get(dev, &curr_state);
-	if (state != curr_state) {
-		ret = i2c_cc13xx_cc26xx_set_power_state(dev,
-			new_state);
-	}
-
-	return ret;
+	return i2c_cc13xx_cc26xx_set_power_state(dev, state);
 }
 #endif /* CONFIG_PM_DEVICE */
 

--- a/drivers/i2c/i2c_cc13xx_cc26xx.c
+++ b/drivers/i2c/i2c_cc13xx_cc26xx.c
@@ -369,15 +369,12 @@ static int i2c_cc13xx_cc26xx_pm_control(const struct device *dev,
 					enum pm_device_state *state)
 {
 	int ret = 0;
+	enum pm_device_state curr_state;
 
-	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		enum pm_device_state curr_state;
-
-		(void)pm_device_state_get(dev, &curr_state);
-		if (*state != curr_state) {
-			ret = i2c_cc13xx_cc26xx_set_power_state(dev,
-				new_state);
-		}
+	(void)pm_device_state_get(dev, &curr_state);
+	if (*state != curr_state) {
+		ret = i2c_cc13xx_cc26xx_set_power_state(dev,
+			new_state);
 	}
 
 	return ret;

--- a/drivers/i2c/i2c_cc13xx_cc26xx.c
+++ b/drivers/i2c/i2c_cc13xx_cc26xx.c
@@ -327,12 +327,12 @@ static int postNotifyFxn(unsigned int eventType, uintptr_t eventArg,
 
 #ifdef CONFIG_PM_DEVICE
 static int i2c_cc13xx_cc26xx_pm_control(const struct device *dev,
-					enum pm_device_state state)
+					enum pm_device_action action)
 {
 	int ret = 0;
 
-	switch (state) {
-	case PM_DEVICE_STATE_ACTIVE:
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
 		Power_setDependency(PowerCC26XX_PERIPH_I2C0);
 		IOCPinTypeI2c(get_dev_config(dev)->base,
 			get_dev_config(dev)->sda_pin,
@@ -343,7 +343,7 @@ static int i2c_cc13xx_cc26xx_pm_control(const struct device *dev,
 			I2CMasterIntEnable(get_dev_config(dev)->base);
 		}
 		break;
-	case PM_DEVICE_STATE_SUSPENDED:
+	case PM_DEVICE_ACTION_SUSPEND:
 		I2CMasterIntDisable(get_dev_config(dev)->base);
 		I2CMasterDisable(get_dev_config(dev)->base);
 		/* Reset pin type to default GPIO configuration */

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -221,33 +221,30 @@ static int twi_nrfx_pm_control(const struct device *dev,
 				enum pm_device_state *state)
 {
 	int ret = 0;
+	enum pm_device_state curr_state;
 
-	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		enum pm_device_state curr_state;
-
-		(void)pm_device_state_get(dev, &curr_state);
-		if (*state != curr_state) {
-			switch (*state) {
-			case PM_DEVICE_STATE_ACTIVE:
-				init_twi(dev);
-				if (get_dev_data(dev)->dev_config) {
-					i2c_nrfx_twi_configure(
-						dev,
-						get_dev_data(dev)->dev_config);
-				}
-				break;
-
-			case PM_DEVICE_STATE_LOW_POWER:
-			case PM_DEVICE_STATE_SUSPEND:
-			case PM_DEVICE_STATE_OFF:
-				if (curr_state == PM_DEVICE_STATE_ACTIVE) {
-					nrfx_twi_uninit(&get_dev_config(dev)->twi);
-				}
-				break;
-
-			default:
-				ret = -ENOTSUP;
+	(void)pm_device_state_get(dev, &curr_state);
+	if (*state != curr_state) {
+		switch (*state) {
+		case PM_DEVICE_STATE_ACTIVE:
+			init_twi(dev);
+			if (get_dev_data(dev)->dev_config) {
+				i2c_nrfx_twi_configure(
+					dev,
+					get_dev_data(dev)->dev_config);
 			}
+			break;
+
+		case PM_DEVICE_STATE_LOW_POWER:
+		case PM_DEVICE_STATE_SUSPEND:
+		case PM_DEVICE_STATE_OFF:
+			if (curr_state == PM_DEVICE_STATE_ACTIVE) {
+				nrfx_twi_uninit(&get_dev_config(dev)->twi);
+			}
+			break;
+
+		default:
+			ret = -ENOTSUP;
 		}
 	}
 

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -220,31 +220,24 @@ static int twi_nrfx_pm_control(const struct device *dev,
 			       enum pm_device_state state)
 {
 	int ret = 0;
-	enum pm_device_state curr_state;
 
-	(void)pm_device_state_get(dev, &curr_state);
-	if (state != curr_state) {
-		switch (state) {
-		case PM_DEVICE_STATE_ACTIVE:
-			init_twi(dev);
-			if (get_dev_data(dev)->dev_config) {
-				i2c_nrfx_twi_configure(
-					dev,
-					get_dev_data(dev)->dev_config);
-			}
-			break;
-
-		case PM_DEVICE_STATE_LOW_POWER:
-		case PM_DEVICE_STATE_SUSPEND:
-		case PM_DEVICE_STATE_OFF:
-			if (curr_state == PM_DEVICE_STATE_ACTIVE) {
-				nrfx_twi_uninit(&get_dev_config(dev)->twi);
-			}
-			break;
-
-		default:
-			ret = -ENOTSUP;
+	switch (state) {
+	case PM_DEVICE_STATE_ACTIVE:
+		init_twi(dev);
+		if (get_dev_data(dev)->dev_config) {
+			i2c_nrfx_twi_configure(dev,
+					       get_dev_data(dev)->dev_config);
 		}
+		break;
+
+	case PM_DEVICE_STATE_LOW_POWER:
+	case PM_DEVICE_STATE_SUSPEND:
+	case PM_DEVICE_STATE_OFF:
+		nrfx_twi_uninit(&get_dev_config(dev)->twi);
+		break;
+
+	default:
+		ret = -ENOTSUP;
 	}
 
 	return ret;

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -217,12 +217,12 @@ static int init_twi(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 static int twi_nrfx_pm_control(const struct device *dev,
-			       enum pm_device_state state)
+			       enum pm_device_action action)
 {
 	int ret = 0;
 
-	switch (state) {
-	case PM_DEVICE_STATE_ACTIVE:
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
 		init_twi(dev);
 		if (get_dev_data(dev)->dev_config) {
 			i2c_nrfx_twi_configure(dev,
@@ -230,7 +230,7 @@ static int twi_nrfx_pm_control(const struct device *dev,
 		}
 		break;
 
-	case PM_DEVICE_STATE_SUSPENDED:
+	case PM_DEVICE_ACTION_SUSPEND:
 		nrfx_twi_uninit(&get_dev_config(dev)->twi);
 		break;
 

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -19,9 +19,6 @@ struct i2c_nrfx_twi_data {
 	struct k_sem completion_sync;
 	volatile nrfx_err_t res;
 	uint32_t dev_config;
-#ifdef CONFIG_PM_DEVICE
-	enum pm_device_state pm_state;
-#endif
 };
 
 struct i2c_nrfx_twi_config {
@@ -214,9 +211,6 @@ static int init_twi(const struct device *dev)
 			    dev->name);
 		return -EBUSY;
 	}
-#ifdef CONFIG_PM_DEVICE
-	get_dev_data(dev)->pm_state = PM_DEVICE_STATE_ACTIVE;
-#endif
 
 	return 0;
 }
@@ -227,13 +221,13 @@ static int twi_nrfx_pm_control(const struct device *dev,
 				enum pm_device_state *state)
 {
 	int ret = 0;
-	enum pm_device_state pm_current_state = get_dev_data(dev)->pm_state;
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		enum pm_device_state new_state = *state;
+		enum pm_device_state curr_state;
 
-		if (new_state != pm_current_state) {
-			switch (new_state) {
+		(void)pm_device_state_get(dev, &curr_state);
+		if (*state != curr_state) {
+			switch (*state) {
 			case PM_DEVICE_STATE_ACTIVE:
 				init_twi(dev);
 				if (get_dev_data(dev)->dev_config) {
@@ -246,7 +240,7 @@ static int twi_nrfx_pm_control(const struct device *dev,
 			case PM_DEVICE_STATE_LOW_POWER:
 			case PM_DEVICE_STATE_SUSPEND:
 			case PM_DEVICE_STATE_OFF:
-				if (pm_current_state == PM_DEVICE_STATE_ACTIVE) {
+				if (curr_state == PM_DEVICE_STATE_ACTIVE) {
 					nrfx_twi_uninit(&get_dev_config(dev)->twi);
 				}
 				break;
@@ -254,13 +248,7 @@ static int twi_nrfx_pm_control(const struct device *dev,
 			default:
 				ret = -ENOTSUP;
 			}
-			if (!ret) {
-				get_dev_data(dev)->pm_state = new_state;
-			}
 		}
-	} else {
-		__ASSERT_NO_MSG(ctrl_command == PM_DEVICE_STATE_GET);
-		*state = get_dev_data(dev)->pm_state;
 	}
 
 	return ret;

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -230,7 +230,7 @@ static int twi_nrfx_pm_control(const struct device *dev,
 		}
 		break;
 
-	case PM_DEVICE_STATE_SUSPEND:
+	case PM_DEVICE_STATE_SUSPENDED:
 	case PM_DEVICE_STATE_OFF:
 		nrfx_twi_uninit(&get_dev_config(dev)->twi);
 		break;

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -231,6 +231,7 @@ static int twi_nrfx_pm_control(const struct device *dev,
 		break;
 
 	case PM_DEVICE_STATE_SUSPENDED:
+		__fallthrough;
 	case PM_DEVICE_STATE_OFF:
 		nrfx_twi_uninit(&get_dev_config(dev)->twi);
 		break;

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -217,14 +217,14 @@ static int init_twi(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 static int twi_nrfx_pm_control(const struct device *dev,
-			       enum pm_device_state *state)
+			       enum pm_device_state state)
 {
 	int ret = 0;
 	enum pm_device_state curr_state;
 
 	(void)pm_device_state_get(dev, &curr_state);
-	if (*state != curr_state) {
-		switch (*state) {
+	if (state != curr_state) {
+		switch (state) {
 		case PM_DEVICE_STATE_ACTIVE:
 			init_twi(dev);
 			if (get_dev_data(dev)->dev_config) {

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -230,7 +230,6 @@ static int twi_nrfx_pm_control(const struct device *dev,
 		}
 		break;
 
-	case PM_DEVICE_STATE_LOW_POWER:
 	case PM_DEVICE_STATE_SUSPEND:
 	case PM_DEVICE_STATE_OFF:
 		nrfx_twi_uninit(&get_dev_config(dev)->twi);

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -217,8 +217,7 @@ static int init_twi(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 static int twi_nrfx_pm_control(const struct device *dev,
-				uint32_t ctrl_command,
-				enum pm_device_state *state)
+			       enum pm_device_state *state)
 {
 	int ret = 0;
 	enum pm_device_state curr_state;

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -231,8 +231,6 @@ static int twi_nrfx_pm_control(const struct device *dev,
 		break;
 
 	case PM_DEVICE_STATE_SUSPENDED:
-		__fallthrough;
-	case PM_DEVICE_STATE_OFF:
 		nrfx_twi_uninit(&get_dev_config(dev)->twi);
 		break;
 

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -268,7 +268,6 @@ static int twim_nrfx_pm_control(const struct device *dev,
 		}
 		break;
 
-	case PM_DEVICE_STATE_LOW_POWER:
 	case PM_DEVICE_STATE_SUSPEND:
 	case PM_DEVICE_STATE_OFF:
 		nrfx_twim_uninit(&get_dev_config(dev)->twim);

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -269,6 +269,7 @@ static int twim_nrfx_pm_control(const struct device *dev,
 		break;
 
 	case PM_DEVICE_STATE_SUSPENDED:
+		__fallthrough;
 	case PM_DEVICE_STATE_OFF:
 		nrfx_twim_uninit(&get_dev_config(dev)->twim);
 		break;

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -268,7 +268,7 @@ static int twim_nrfx_pm_control(const struct device *dev,
 		}
 		break;
 
-	case PM_DEVICE_STATE_SUSPEND:
+	case PM_DEVICE_STATE_SUSPENDED:
 	case PM_DEVICE_STATE_OFF:
 		nrfx_twim_uninit(&get_dev_config(dev)->twim);
 		break;

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -258,32 +258,24 @@ static int twim_nrfx_pm_control(const struct device *dev,
 				enum pm_device_state state)
 {
 	int ret = 0;
-	enum pm_device_state curr_state;
 
-	(void)pm_device_state_get(dev, &curr_state);
-	if (state != curr_state) {
-		switch (state) {
-		case PM_DEVICE_STATE_ACTIVE:
-			init_twim(dev);
-			if (get_dev_data(dev)->dev_config) {
-				i2c_nrfx_twim_configure(
-					dev,
-					get_dev_data(dev)->dev_config);
-			}
-			break;
-
-		case PM_DEVICE_STATE_LOW_POWER:
-		case PM_DEVICE_STATE_SUSPEND:
-		case PM_DEVICE_STATE_OFF:
-			if (curr_state != PM_DEVICE_STATE_ACTIVE) {
-				break;
-			}
-			nrfx_twim_uninit(&get_dev_config(dev)->twim);
-			break;
-
-		default:
-			ret = -ENOTSUP;
+	switch (state) {
+	case PM_DEVICE_STATE_ACTIVE:
+		init_twim(dev);
+		if (get_dev_data(dev)->dev_config) {
+			i2c_nrfx_twim_configure(dev,
+						get_dev_data(dev)->dev_config);
 		}
+		break;
+
+	case PM_DEVICE_STATE_LOW_POWER:
+	case PM_DEVICE_STATE_SUSPEND:
+	case PM_DEVICE_STATE_OFF:
+		nrfx_twim_uninit(&get_dev_config(dev)->twim);
+		break;
+
+	default:
+		ret = -ENOTSUP;
 	}
 
 	return ret;

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -259,34 +259,31 @@ static int twim_nrfx_pm_control(const struct device *dev,
 				enum pm_device_state *state)
 {
 	int ret = 0;
+	enum pm_device_state curr_state;
 
-	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		enum pm_device_state curr_state;
-
-		(void)pm_device_state_get(dev, &curr_state);
-		if (*state != curr_state) {
-			switch (*state) {
-			case PM_DEVICE_STATE_ACTIVE:
-				init_twim(dev);
-				if (get_dev_data(dev)->dev_config) {
-					i2c_nrfx_twim_configure(
-						dev,
-						get_dev_data(dev)->dev_config);
-				}
-				break;
-
-			case PM_DEVICE_STATE_LOW_POWER:
-			case PM_DEVICE_STATE_SUSPEND:
-			case PM_DEVICE_STATE_OFF:
-				if (curr_state != PM_DEVICE_STATE_ACTIVE) {
-					break;
-				}
-				nrfx_twim_uninit(&get_dev_config(dev)->twim);
-				break;
-
-			default:
-				ret = -ENOTSUP;
+	(void)pm_device_state_get(dev, &curr_state);
+	if (*state != curr_state) {
+		switch (*state) {
+		case PM_DEVICE_STATE_ACTIVE:
+			init_twim(dev);
+			if (get_dev_data(dev)->dev_config) {
+				i2c_nrfx_twim_configure(
+					dev,
+					get_dev_data(dev)->dev_config);
 			}
+			break;
+
+		case PM_DEVICE_STATE_LOW_POWER:
+		case PM_DEVICE_STATE_SUSPEND:
+		case PM_DEVICE_STATE_OFF:
+			if (curr_state != PM_DEVICE_STATE_ACTIVE) {
+				break;
+			}
+			nrfx_twim_uninit(&get_dev_config(dev)->twim);
+			break;
+
+		default:
+			ret = -ENOTSUP;
 		}
 	}
 

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -255,12 +255,12 @@ static int init_twim(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 static int twim_nrfx_pm_control(const struct device *dev,
-				enum pm_device_state state)
+				enum pm_device_action action)
 {
 	int ret = 0;
 
-	switch (state) {
-	case PM_DEVICE_STATE_ACTIVE:
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
 		init_twim(dev);
 		if (get_dev_data(dev)->dev_config) {
 			i2c_nrfx_twim_configure(dev,
@@ -268,7 +268,7 @@ static int twim_nrfx_pm_control(const struct device *dev,
 		}
 		break;
 
-	case PM_DEVICE_STATE_SUSPENDED:
+	case PM_DEVICE_ACTION_SUSPEND:
 		nrfx_twim_uninit(&get_dev_config(dev)->twim);
 		break;
 

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -255,14 +255,14 @@ static int init_twim(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 static int twim_nrfx_pm_control(const struct device *dev,
-				enum pm_device_state *state)
+				enum pm_device_state state)
 {
 	int ret = 0;
 	enum pm_device_state curr_state;
 
 	(void)pm_device_state_get(dev, &curr_state);
-	if (*state != curr_state) {
-		switch (*state) {
+	if (state != curr_state) {
+		switch (state) {
 		case PM_DEVICE_STATE_ACTIVE:
 			init_twim(dev);
 			if (get_dev_data(dev)->dev_config) {

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -269,8 +269,6 @@ static int twim_nrfx_pm_control(const struct device *dev,
 		break;
 
 	case PM_DEVICE_STATE_SUSPENDED:
-		__fallthrough;
-	case PM_DEVICE_STATE_OFF:
 		nrfx_twim_uninit(&get_dev_config(dev)->twim);
 		break;
 

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -255,7 +255,6 @@ static int init_twim(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 static int twim_nrfx_pm_control(const struct device *dev,
-				uint32_t ctrl_command,
 				enum pm_device_state *state)
 {
 	int ret = 0;

--- a/drivers/interrupt_controller/intc_arcv2_irq_unit.c
+++ b/drivers/interrupt_controller/intc_arcv2_irq_unit.c
@@ -181,12 +181,10 @@ static int arc_v2_irq_unit_device_ctrl(const struct device *dev,
 	int ret = 0;
 	unsigned int key = arch_irq_lock();
 
-	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		if (*state == PM_DEVICE_STATE_SUSPEND) {
-			ret = arc_v2_irq_unit_suspend(dev);
-		} else if (*state == PM_DEVICE_STATE_ACTIVE) {
-			ret = arc_v2_irq_unit_resume(dev);
-		}
+	if (*state == PM_DEVICE_STATE_SUSPEND) {
+		ret = arc_v2_irq_unit_suspend(dev);
+	} else if (*state == PM_DEVICE_STATE_ACTIVE) {
+		ret = arc_v2_irq_unit_resume(dev);
 	}
 
 	arch_irq_unlock(key);

--- a/drivers/interrupt_controller/intc_arcv2_irq_unit.c
+++ b/drivers/interrupt_controller/intc_arcv2_irq_unit.c
@@ -180,7 +180,7 @@ static int arc_v2_irq_unit_device_ctrl(const struct device *dev,
 	int ret = 0;
 	unsigned int key = arch_irq_lock();
 
-	if (state == PM_DEVICE_STATE_SUSPEND) {
+	if (state == PM_DEVICE_STATE_SUSPENDED) {
 		ret = arc_v2_irq_unit_suspend(dev);
 	} else if (state == PM_DEVICE_STATE_ACTIVE) {
 		ret = arc_v2_irq_unit_resume(dev);

--- a/drivers/interrupt_controller/intc_arcv2_irq_unit.c
+++ b/drivers/interrupt_controller/intc_arcv2_irq_unit.c
@@ -175,14 +175,14 @@ static int arc_v2_irq_unit_resume(const struct device *dev)
  * @return operation result
  */
 static int arc_v2_irq_unit_device_ctrl(const struct device *dev,
-				       enum pm_device_state *state)
+				       enum pm_device_state state)
 {
 	int ret = 0;
 	unsigned int key = arch_irq_lock();
 
-	if (*state == PM_DEVICE_STATE_SUSPEND) {
+	if (state == PM_DEVICE_STATE_SUSPEND) {
 		ret = arc_v2_irq_unit_suspend(dev);
-	} else if (*state == PM_DEVICE_STATE_ACTIVE) {
+	} else if (state == PM_DEVICE_STATE_ACTIVE) {
 		ret = arc_v2_irq_unit_resume(dev);
 	}
 

--- a/drivers/interrupt_controller/intc_arcv2_irq_unit.c
+++ b/drivers/interrupt_controller/intc_arcv2_irq_unit.c
@@ -175,7 +175,6 @@ static int arc_v2_irq_unit_resume(const struct device *dev)
  * @return operation result
  */
 static int arc_v2_irq_unit_device_ctrl(const struct device *dev,
-				       uint32_t ctrl_command,
 				       enum pm_device_state *state)
 {
 	int ret = 0;

--- a/drivers/interrupt_controller/intc_arcv2_irq_unit.c
+++ b/drivers/interrupt_controller/intc_arcv2_irq_unit.c
@@ -175,16 +175,16 @@ static int arc_v2_irq_unit_resume(const struct device *dev)
  * @return operation result
  */
 static int arc_v2_irq_unit_device_ctrl(const struct device *dev,
-				       enum pm_device_state state)
+				       enum pm_device_action action)
 {
 	int ret = 0;
 	unsigned int key = arch_irq_lock();
 
-	switch (state) {
-	case PM_DEVICE_STATE_SUSPENDED:
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
 		ret = arc_v2_irq_unit_suspend(dev);
 		break;
-	case PM_DEVICE_STATE_ACTIVE:
+	case PM_DEVICE_ACTION_RESUME:
 		ret = arc_v2_irq_unit_resume(dev);
 		break;
 	default:

--- a/drivers/interrupt_controller/intc_arcv2_irq_unit.c
+++ b/drivers/interrupt_controller/intc_arcv2_irq_unit.c
@@ -180,10 +180,16 @@ static int arc_v2_irq_unit_device_ctrl(const struct device *dev,
 	int ret = 0;
 	unsigned int key = arch_irq_lock();
 
-	if (state == PM_DEVICE_STATE_SUSPENDED) {
+	switch (state) {
+	case PM_DEVICE_STATE_SUSPENDED:
 		ret = arc_v2_irq_unit_suspend(dev);
-	} else if (state == PM_DEVICE_STATE_ACTIVE) {
+		break;
+	case PM_DEVICE_STATE_ACTIVE:
 		ret = arc_v2_irq_unit_resume(dev);
+		break;
+	default:
+		ret = -ENOTSUP;
+		break;
 	}
 
 	arch_irq_unlock(key);

--- a/drivers/interrupt_controller/intc_arcv2_irq_unit.c
+++ b/drivers/interrupt_controller/intc_arcv2_irq_unit.c
@@ -32,8 +32,6 @@ extern void *_VectorTable;
 #define _ARC_V2_IRQ_VECT_BASE _ARC_V2_IRQ_VECT_BASE_S
 #endif
 
-static enum pm_device_state _arc_v2_irq_unit_device_power_state =
-	PM_DEVICE_STATE_ACTIVE;
 struct arc_v2_irq_unit_ctx {
 	uint32_t irq_ctrl; /* Interrupt Context Saving Control Register. */
 	uint32_t irq_vect_base; /* Interrupt Vector Base. */
@@ -121,8 +119,6 @@ static int arc_v2_irq_unit_suspend(const struct device *dev)
 	ctx.irq_ctrl = z_arc_v2_aux_reg_read(_ARC_V2_AUX_IRQ_CTRL);
 	ctx.irq_vect_base = z_arc_v2_aux_reg_read(_ARC_V2_IRQ_VECT_BASE);
 
-	_arc_v2_irq_unit_device_power_state = PM_DEVICE_STATE_SUSPEND;
-
 	return 0;
 }
 
@@ -167,21 +163,7 @@ static int arc_v2_irq_unit_resume(const struct device *dev)
 #endif
 	z_arc_v2_aux_reg_write(_ARC_V2_IRQ_VECT_BASE, ctx.irq_vect_base);
 
-	_arc_v2_irq_unit_device_power_state = PM_DEVICE_STATE_ACTIVE;
-
 	return 0;
-}
-
-/*
- * @brief Get the power state of interrupt unit
- *
- * @return the power state of interrupt unit
- */
-static enum pm_device_state arc_v2_irq_unit_get_state(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return _arc_v2_irq_unit_device_power_state;
 }
 
 /*
@@ -205,8 +187,6 @@ static int arc_v2_irq_unit_device_ctrl(const struct device *dev,
 		} else if (*state == PM_DEVICE_STATE_ACTIVE) {
 			ret = arc_v2_irq_unit_resume(dev);
 		}
-	} else if (ctrl_command == PM_DEVICE_STATE_GET) {
-		*state = arc_v2_irq_unit_get_state(dev);
 	}
 
 	arch_irq_unlock(key);

--- a/drivers/interrupt_controller/intc_ioapic.c
+++ b/drivers/interrupt_controller/intc_ioapic.c
@@ -314,27 +314,24 @@ static int ioapic_device_ctrl(const struct device *dev,
 			      enum pm_device_state *state)
 {
 	int ret = 0;
+	enum pm_device_state curr_state;
 
-	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		enum pm_device_state curr_state;
-
-		(void)pm_device_state_get(dev, &curr_state);
-		switch (*state) {
-		case PM_DEVICE_STATE_LOW_POWER:
-			break;
-		case PM_DEVICE_STATE_ACTIVE:
-			if (curr_state != PM_DEVICE_STATE_LOW_POWER) {
-				ret = ioapic_resume_from_suspend(dev);
-			}
-			break;
-		case PM_DEVICE_STATE_SUSPEND:
-		case PM_DEVICE_STATE_FORCE_SUSPEND:
-		case PM_DEVICE_STATE_OFF:
-			ret = ioapic_suspend(dev);
-			break;
-		default:
-			ret = -ENOTSUP;
+	(void)pm_device_state_get(dev, &curr_state);
+	switch (*state) {
+	case PM_DEVICE_STATE_LOW_POWER:
+		break;
+	case PM_DEVICE_STATE_ACTIVE:
+		if (curr_state != PM_DEVICE_STATE_LOW_POWER) {
+			ret = ioapic_resume_from_suspend(dev);
 		}
+		break;
+	case PM_DEVICE_STATE_SUSPEND:
+	case PM_DEVICE_STATE_FORCE_SUSPEND:
+	case PM_DEVICE_STATE_OFF:
+		ret = ioapic_suspend(dev);
+		break;
+	default:
+		ret = -ENOTSUP;
 	}
 
 	return ret;

--- a/drivers/interrupt_controller/intc_ioapic.c
+++ b/drivers/interrupt_controller/intc_ioapic.c
@@ -321,7 +321,6 @@ static int ioapic_device_ctrl(const struct device *dev,
 		ret = ioapic_resume_from_suspend(dev);
 		break;
 	case PM_DEVICE_STATE_SUSPEND:
-	case PM_DEVICE_STATE_FORCE_SUSPEND:
 	case PM_DEVICE_STATE_OFF:
 		ret = ioapic_suspend(dev);
 		break;

--- a/drivers/interrupt_controller/intc_ioapic.c
+++ b/drivers/interrupt_controller/intc_ioapic.c
@@ -319,6 +319,7 @@ static int ioapic_device_ctrl(const struct device *dev,
 		ret = ioapic_resume_from_suspend(dev);
 		break;
 	case PM_DEVICE_STATE_SUSPENDED:
+		__fallthrough;
 	case PM_DEVICE_STATE_OFF:
 		ret = ioapic_suspend(dev);
 		break;
@@ -328,7 +329,6 @@ static int ioapic_device_ctrl(const struct device *dev,
 
 	return ret;
 }
-
 
 #endif  /*CONFIG_PM_DEVICE*/
 

--- a/drivers/interrupt_controller/intc_ioapic.c
+++ b/drivers/interrupt_controller/intc_ioapic.c
@@ -310,7 +310,6 @@ int ioapic_resume_from_suspend(const struct device *port)
 */
 __pinned_func
 static int ioapic_device_ctrl(const struct device *dev,
-			      uint32_t ctrl_command,
 			      enum pm_device_state *state)
 {
 	int ret = 0;

--- a/drivers/interrupt_controller/intc_ioapic.c
+++ b/drivers/interrupt_controller/intc_ioapic.c
@@ -313,16 +313,12 @@ static int ioapic_device_ctrl(const struct device *dev,
 			      enum pm_device_state state)
 {
 	int ret = 0;
-	enum pm_device_state curr_state;
 
-	(void)pm_device_state_get(dev, &curr_state);
 	switch (state) {
 	case PM_DEVICE_STATE_LOW_POWER:
 		break;
 	case PM_DEVICE_STATE_ACTIVE:
-		if (curr_state != PM_DEVICE_STATE_LOW_POWER) {
-			ret = ioapic_resume_from_suspend(dev);
-		}
+		ret = ioapic_resume_from_suspend(dev);
 		break;
 	case PM_DEVICE_STATE_SUSPEND:
 	case PM_DEVICE_STATE_FORCE_SUSPEND:

--- a/drivers/interrupt_controller/intc_ioapic.c
+++ b/drivers/interrupt_controller/intc_ioapic.c
@@ -318,7 +318,7 @@ static int ioapic_device_ctrl(const struct device *dev,
 	case PM_DEVICE_STATE_ACTIVE:
 		ret = ioapic_resume_from_suspend(dev);
 		break;
-	case PM_DEVICE_STATE_SUSPEND:
+	case PM_DEVICE_STATE_SUSPENDED:
 	case PM_DEVICE_STATE_OFF:
 		ret = ioapic_suspend(dev);
 		break;

--- a/drivers/interrupt_controller/intc_ioapic.c
+++ b/drivers/interrupt_controller/intc_ioapic.c
@@ -310,13 +310,13 @@ int ioapic_resume_from_suspend(const struct device *port)
 */
 __pinned_func
 static int ioapic_device_ctrl(const struct device *dev,
-			      enum pm_device_state *state)
+			      enum pm_device_state state)
 {
 	int ret = 0;
 	enum pm_device_state curr_state;
 
 	(void)pm_device_state_get(dev, &curr_state);
-	switch (*state) {
+	switch (state) {
 	case PM_DEVICE_STATE_LOW_POWER:
 		break;
 	case PM_DEVICE_STATE_ACTIVE:

--- a/drivers/interrupt_controller/intc_ioapic.c
+++ b/drivers/interrupt_controller/intc_ioapic.c
@@ -315,8 +315,6 @@ static int ioapic_device_ctrl(const struct device *dev,
 	int ret = 0;
 
 	switch (state) {
-	case PM_DEVICE_STATE_LOW_POWER:
-		break;
 	case PM_DEVICE_STATE_ACTIVE:
 		ret = ioapic_resume_from_suspend(dev);
 		break;

--- a/drivers/interrupt_controller/intc_ioapic.c
+++ b/drivers/interrupt_controller/intc_ioapic.c
@@ -310,15 +310,15 @@ int ioapic_resume_from_suspend(const struct device *port)
 */
 __pinned_func
 static int ioapic_device_ctrl(const struct device *dev,
-			      enum pm_device_state state)
+			      enum pm_device_action action)
 {
 	int ret = 0;
 
-	switch (state) {
-	case PM_DEVICE_STATE_ACTIVE:
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
 		ret = ioapic_resume_from_suspend(dev);
 		break;
-	case PM_DEVICE_STATE_SUSPENDED:
+	case PM_DEVICE_ACTION_SUSPEND:
 		ret = ioapic_suspend(dev);
 		break;
 	default:

--- a/drivers/interrupt_controller/intc_ioapic.c
+++ b/drivers/interrupt_controller/intc_ioapic.c
@@ -319,8 +319,6 @@ static int ioapic_device_ctrl(const struct device *dev,
 		ret = ioapic_resume_from_suspend(dev);
 		break;
 	case PM_DEVICE_STATE_SUSPENDED:
-		__fallthrough;
-	case PM_DEVICE_STATE_OFF:
 		ret = ioapic_suspend(dev);
 		break;
 	default:

--- a/drivers/interrupt_controller/intc_loapic.c
+++ b/drivers/interrupt_controller/intc_loapic.c
@@ -409,7 +409,6 @@ int loapic_resume(const struct device *port)
 */
 __pinned_func
 static int loapic_device_ctrl(const struct device *port,
-			      uint32_t ctrl_command,
 			      enum pm_device_state *state)
 {
 	int ret = 0;

--- a/drivers/interrupt_controller/intc_loapic.c
+++ b/drivers/interrupt_controller/intc_loapic.c
@@ -414,12 +414,10 @@ static int loapic_device_ctrl(const struct device *port,
 {
 	int ret = 0;
 
-	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		if (*state == PM_DEVICE_STATE_SUSPEND) {
-			ret = loapic_suspend(port);
-		} else if (*state == PM_DEVICE_STATE_ACTIVE) {
-			ret = loapic_resume(port);
-		}
+	if (*state == PM_DEVICE_STATE_SUSPEND) {
+		ret = loapic_suspend(port);
+	} else if (*state == PM_DEVICE_STATE_ACTIVE) {
+		ret = loapic_resume(port);
 	}
 
 	return ret;

--- a/drivers/interrupt_controller/intc_loapic.c
+++ b/drivers/interrupt_controller/intc_loapic.c
@@ -409,15 +409,15 @@ int loapic_resume(const struct device *port)
 */
 __pinned_func
 static int loapic_device_ctrl(const struct device *dev,
-			      enum pm_device_state state)
+			      enum pm_device_action action)
 {
 	int ret = 0;
 
-	switch (state) {
-	case PM_DEVICE_STATE_SUSPENDED:
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
 		ret = loapic_suspend(dev);
 		break;
-	case PM_DEVICE_STATE_ACTIVE:
+	case PM_DEVICE_ACTION_RESUME:
 		ret = loapic_resume(dev);
 		break;
 	default:

--- a/drivers/interrupt_controller/intc_loapic.c
+++ b/drivers/interrupt_controller/intc_loapic.c
@@ -408,15 +408,20 @@ int loapic_resume(const struct device *port)
 * the *context may include IN data or/and OUT data
 */
 __pinned_func
-static int loapic_device_ctrl(const struct device *port,
+static int loapic_device_ctrl(const struct device *dev,
 			      enum pm_device_state state)
 {
 	int ret = 0;
 
-	if (state == PM_DEVICE_STATE_SUSPENDED) {
-		ret = loapic_suspend(port);
-	} else if (state == PM_DEVICE_STATE_ACTIVE) {
-		ret = loapic_resume(port);
+	switch (state) {
+	case PM_DEVICE_STATE_SUSPENDED:
+		ret = loapic_suspend(dev);
+		break;
+	case PM_DEVICE_STATE_ACTIVE:
+		ret = loapic_resume(dev);
+		break;
+	default:
+		return -ENOTSUP;
 	}
 
 	return ret;

--- a/drivers/interrupt_controller/intc_loapic.c
+++ b/drivers/interrupt_controller/intc_loapic.c
@@ -64,9 +64,6 @@
 #include <pm/device.h>
 __pinned_bss
 uint32_t loapic_suspend_buf[LOPIC_SUSPEND_BITS_REQD / 32] = {0};
-
-__pinned_data
-static uint32_t loapic_device_power_state = PM_DEVICE_STATE_ACTIVE;
 #endif
 
 #ifdef DEVICE_MMIO_IS_IN_RAM
@@ -372,7 +369,7 @@ static int loapic_suspend(const struct device *port)
 			}
 		}
 	}
-	loapic_device_power_state = PM_DEVICE_STATE_SUSPEND;
+
 	return 0;
 }
 
@@ -402,7 +399,6 @@ int loapic_resume(const struct device *port)
 			}
 		}
 	}
-	loapic_device_power_state = PM_DEVICE_STATE_ACTIVE;
 
 	return 0;
 }
@@ -424,8 +420,6 @@ static int loapic_device_ctrl(const struct device *port,
 		} else if (*state == PM_DEVICE_STATE_ACTIVE) {
 			ret = loapic_resume(port);
 		}
-	} else if (ctrl_command == PM_DEVICE_STATE_GET) {
-		*state = loapic_device_power_state;
 	}
 
 	return ret;

--- a/drivers/interrupt_controller/intc_loapic.c
+++ b/drivers/interrupt_controller/intc_loapic.c
@@ -413,7 +413,7 @@ static int loapic_device_ctrl(const struct device *port,
 {
 	int ret = 0;
 
-	if (state == PM_DEVICE_STATE_SUSPEND) {
+	if (state == PM_DEVICE_STATE_SUSPENDED) {
 		ret = loapic_suspend(port);
 	} else if (state == PM_DEVICE_STATE_ACTIVE) {
 		ret = loapic_resume(port);

--- a/drivers/interrupt_controller/intc_loapic.c
+++ b/drivers/interrupt_controller/intc_loapic.c
@@ -409,13 +409,13 @@ int loapic_resume(const struct device *port)
 */
 __pinned_func
 static int loapic_device_ctrl(const struct device *port,
-			      enum pm_device_state *state)
+			      enum pm_device_state state)
 {
 	int ret = 0;
 
-	if (*state == PM_DEVICE_STATE_SUSPEND) {
+	if (state == PM_DEVICE_STATE_SUSPEND) {
 		ret = loapic_suspend(port);
-	} else if (*state == PM_DEVICE_STATE_ACTIVE) {
+	} else if (state == PM_DEVICE_STATE_ACTIVE) {
 		ret = loapic_resume(port);
 	}
 

--- a/drivers/led/led_pwm.c
+++ b/drivers/led/led_pwm.c
@@ -21,7 +21,6 @@
 LOG_MODULE_REGISTER(led_pwm, CONFIG_LED_LOG_LEVEL);
 
 #define DEV_CFG(dev)	((const struct led_pwm_config *) ((dev)->config))
-#define DEV_DATA(dev)	((struct led_pwm_data *) ((dev)->data))
 
 struct led_pwm {
 	const struct device *dev;
@@ -33,12 +32,6 @@ struct led_pwm {
 struct led_pwm_config {
 	int num_leds;
 	const struct led_pwm *led;
-};
-
-struct led_pwm_data {
-#ifdef CONFIG_PM_DEVICE
-	enum pm_device_state pm_state;
-#endif
 };
 
 static int led_pwm_blink(const struct device *dev, uint32_t led,
@@ -117,43 +110,20 @@ static int led_pwm_init(const struct device *dev)
 		}
 	}
 
-#ifdef CONFIG_PM_DEVICE
-	struct led_pwm_data *data = DEV_DATA(dev);
-
-	data->pm_state = PM_DEVICE_STATE_ACTIVE;
-#endif
-
 	return 0;
 }
 
 #ifdef CONFIG_PM_DEVICE
-
-static int led_pwm_pm_get_state(const struct device *dev,
-				enum pm_device_state *state)
-{
-	struct led_pwm_data *data = DEV_DATA(dev);
-
-	unsigned int key = irq_lock();
-	*state = data->pm_state;
-	irq_unlock(key);
-
-	return 0;
-}
 
 static int led_pwm_pm_set_state(const struct device *dev,
 				enum pm_device_state new_state)
 {
 	const struct led_pwm_config *config = DEV_CFG(dev);
-	struct led_pwm_data *data = DEV_DATA(dev);
-	enum pm_device_state old_state;
-	unsigned int key;
+	enum pm_device_state curr_state;
 
-	key = irq_lock();
-	old_state = data->pm_state;
-	irq_unlock(key);
+	(void)pm_device_state_get(dev, &curr_state);
 
-	if (old_state == new_state) {
-		/* leave unchanged */
+	if (curr_state == new_state) {
 		return 0;
 	}
 
@@ -169,11 +139,6 @@ static int led_pwm_pm_set_state(const struct device *dev,
 		}
 	}
 
-	/* record the new state */
-	key = irq_lock();
-	data->pm_state = new_state;
-	irq_unlock(key);
-
 	return 0;
 }
 
@@ -183,10 +148,6 @@ static int led_pwm_pm_control(const struct device *dev, uint32_t ctrl_command,
 	int err;
 
 	switch (ctrl_command) {
-	case PM_DEVICE_STATE_GET:
-		err = led_pwm_pm_get_state(dev, state);
-		break;
-
 	case PM_DEVICE_STATE_SET:
 		err = led_pwm_pm_set_state(dev, *state);
 		break;
@@ -228,11 +189,8 @@ static const struct led_pwm_config led_pwm_config_##id = {	\
 	.led		= led_pwm_##id,				\
 };								\
 								\
-static struct led_pwm_data led_pwm_data_##id;			\
-								\
 DEVICE_DT_INST_DEFINE(id, &led_pwm_init, led_pwm_pm_control,	\
-		      &led_pwm_data_##id, &led_pwm_config_##id,	\
-		      POST_KERNEL, CONFIG_LED_INIT_PRIORITY,	\
-		      &led_pwm_api);
+		      NULL, &led_pwm_config_##id, POST_KERNEL,	\
+		      CONFIG_LED_INIT_PRIORITY, &led_pwm_api);
 
 DT_INST_FOREACH_STATUS_OKAY(LED_PWM_DEVICE)

--- a/drivers/led/led_pwm.c
+++ b/drivers/led/led_pwm.c
@@ -145,19 +145,7 @@ static int led_pwm_pm_set_state(const struct device *dev,
 static int led_pwm_pm_control(const struct device *dev, uint32_t ctrl_command,
 			      enum pm_device_state *state)
 {
-	int err;
-
-	switch (ctrl_command) {
-	case PM_DEVICE_STATE_SET:
-		err = led_pwm_pm_set_state(dev, *state);
-		break;
-
-	default:
-		err = -ENOTSUP;
-		break;
-	}
-
-	return err;
+	return led_pwm_pm_set_state(dev, *state);
 }
 
 #endif /* CONFIG_PM_DEVICE */

--- a/drivers/led/led_pwm.c
+++ b/drivers/led/led_pwm.c
@@ -119,13 +119,6 @@ static int led_pwm_pm_set_state(const struct device *dev,
 				enum pm_device_state new_state)
 {
 	const struct led_pwm_config *config = DEV_CFG(dev);
-	enum pm_device_state curr_state;
-
-	(void)pm_device_state_get(dev, &curr_state);
-
-	if (curr_state == new_state) {
-		return 0;
-	}
 
 	/* switch all underlying PWM devices to the new state */
 	for (size_t i = 0; i < config->num_leds; i++) {

--- a/drivers/led/led_pwm.c
+++ b/drivers/led/led_pwm.c
@@ -115,17 +115,31 @@ static int led_pwm_init(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 static int led_pwm_pm_control(const struct device *dev,
-			      enum pm_device_state state)
+			      enum pm_device_action action)
 {
 	const struct led_pwm_config *config = DEV_CFG(dev);
 
 	/* switch all underlying PWM devices to the new state */
 	for (size_t i = 0; i < config->num_leds; i++) {
+		int err;
+		enum pm_device_state state;
 		const struct led_pwm *led_pwm = &config->led[i];
 
 		LOG_DBG("Switching PWM %p to state %" PRIu32, led_pwm->dev, state);
-		int err = pm_device_state_set(led_pwm->dev, state);
 
+		/* NOTE: temporary solution, deserves proper fix */
+		switch (action) {
+		case PM_DEVICE_ACTION_RESUME:
+			state = PM_DEVICE_STATE_ACTIVE;
+			break;
+		case PM_DEVICE_ACTION_SUSPEND:
+			state = PM_DEVICE_STATE_SUSPENDED;
+			break;
+		default:
+			return -ENOTSUP;
+		}
+
+		err = pm_device_state_set(led_pwm->dev, state);
 		if (err) {
 			LOG_ERR("Cannot switch PWM %p power state", led_pwm->dev);
 		}

--- a/drivers/led/led_pwm.c
+++ b/drivers/led/led_pwm.c
@@ -114,9 +114,8 @@ static int led_pwm_init(const struct device *dev)
 }
 
 #ifdef CONFIG_PM_DEVICE
-
-static int led_pwm_pm_set_state(const struct device *dev,
-				enum pm_device_state new_state)
+static int led_pwm_pm_control(const struct device *dev,
+			      enum pm_device_state state)
 {
 	const struct led_pwm_config *config = DEV_CFG(dev);
 
@@ -124,8 +123,8 @@ static int led_pwm_pm_set_state(const struct device *dev,
 	for (size_t i = 0; i < config->num_leds; i++) {
 		const struct led_pwm *led_pwm = &config->led[i];
 
-		LOG_DBG("Switching PWM %p to state %" PRIu32, led_pwm->dev, new_state);
-		int err = pm_device_state_set(led_pwm->dev, new_state);
+		LOG_DBG("Switching PWM %p to state %" PRIu32, led_pwm->dev, state);
+		int err = pm_device_state_set(led_pwm->dev, state);
 
 		if (err) {
 			LOG_ERR("Cannot switch PWM %p power state", led_pwm->dev);
@@ -134,13 +133,6 @@ static int led_pwm_pm_set_state(const struct device *dev,
 
 	return 0;
 }
-
-static int led_pwm_pm_control(const struct device *dev,
-			      enum pm_device_state state)
-{
-	return led_pwm_pm_set_state(dev, state);
-}
-
 #endif /* CONFIG_PM_DEVICE */
 
 static const struct led_driver_api led_pwm_api = {

--- a/drivers/led/led_pwm.c
+++ b/drivers/led/led_pwm.c
@@ -142,7 +142,7 @@ static int led_pwm_pm_set_state(const struct device *dev,
 	return 0;
 }
 
-static int led_pwm_pm_control(const struct device *dev, uint32_t ctrl_command,
+static int led_pwm_pm_control(const struct device *dev,
 			      enum pm_device_state *state)
 {
 	return led_pwm_pm_set_state(dev, *state);

--- a/drivers/led/led_pwm.c
+++ b/drivers/led/led_pwm.c
@@ -143,9 +143,9 @@ static int led_pwm_pm_set_state(const struct device *dev,
 }
 
 static int led_pwm_pm_control(const struct device *dev,
-			      enum pm_device_state *state)
+			      enum pm_device_state state)
 {
-	return led_pwm_pm_set_state(dev, *state);
+	return led_pwm_pm_set_state(dev, state);
 }
 
 #endif /* CONFIG_PM_DEVICE */

--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -3505,7 +3505,7 @@ static void shutdown_uart(void)
 		HL7800_IO_DBG_LOG("Power OFF the UART");
 		uart_irq_rx_disable(ictx.mdm_ctx.uart_dev);
 		rc = pm_device_state_set(ictx.mdm_ctx.uart_dev,
-					 PM_DEVICE_STATE_OFF);
+					 PM_DEVICE_STATE_SUSPENDED);
 		if (rc) {
 			LOG_ERR("Error disabling UART peripheral (%d)", rc);
 		}

--- a/drivers/modem/modem_receiver.c
+++ b/drivers/modem/modem_receiver.c
@@ -199,7 +199,7 @@ int mdm_receiver_sleep(struct mdm_receiver_context *ctx)
 {
 	uart_irq_rx_disable(ctx->uart_dev);
 #ifdef CONFIG_PM_DEVICE
-	pm_device_state_set(ctx->uart_dev, PM_DEVICE_STATE_SUSPEND);
+	pm_device_state_set(ctx->uart_dev, PM_DEVICE_STATE_SUSPENDED);
 #endif
 	return 0;
 }

--- a/drivers/modem/modem_receiver.c
+++ b/drivers/modem/modem_receiver.c
@@ -198,15 +198,15 @@ int mdm_receiver_send(struct mdm_receiver_context *ctx,
 int mdm_receiver_sleep(struct mdm_receiver_context *ctx)
 {
 	uart_irq_rx_disable(ctx->uart_dev);
-#ifdef PM_DEVICE_STATE_LOW_POWER
-	pm_device_state_set(ctx->uart_dev, PM_DEVICE_STATE_LOW_POWER);
+#ifdef CONFIG_PM_DEVICE
+	pm_device_state_set(ctx->uart_dev, PM_DEVICE_STATE_SUSPEND);
 #endif
 	return 0;
 }
 
 int mdm_receiver_wake(struct mdm_receiver_context *ctx)
 {
-#ifdef PM_DEVICE_STATE_LOW_POWER
+#ifdef CONFIG_PM_DEVICE
 	pm_device_state_set(ctx->uart_dev, PM_DEVICE_STATE_ACTIVE);
 #endif
 	uart_irq_rx_enable(ctx->uart_dev);

--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -318,14 +318,14 @@ static int pwm_nrfx_set_power_state(enum pm_device_state new_state,
 }
 
 static int pwm_nrfx_pm_control(const struct device *dev,
-			       enum pm_device_state *state)
+			       enum pm_device_state state)
 {
 	int err = 0;
 	enum pm_device_state curr_state;
 
 	(void)pm_device_state_get(dev, &curr_state);
-	if (*state != current_state) {
-		err = pwm_nrfx_set_power_state(*state, current_state, dev);
+	if (state != current_state) {
+		err = pwm_nrfx_set_power_state(state, current_state, dev);
 	}
 
 	return err;
@@ -333,7 +333,7 @@ static int pwm_nrfx_pm_control(const struct device *dev,
 
 #define PWM_NRFX_PM_CONTROL(idx)					       \
 	static int pwm_##idx##_nrfx_pm_control(const struct device *dev,       \
-					       enum pm_device_state *state)    \
+					       enum pm_device_state state)     \
 	{								       \
 		return pwm_nrfx_pm_control(dev, state)			       \
 	}

--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -301,8 +301,6 @@ static int pwm_nrfx_pm_control(const struct device *dev,
 		err = pwm_nrfx_init(dev);
 		break;
 	case PM_DEVICE_STATE_SUSPENDED:
-		__fallthrough;
-	case PM_DEVICE_STATE_OFF:
 		pwm_nrfx_uninit(dev);
 		break;
 	default:

--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -292,13 +292,12 @@ static void pwm_nrfx_uninit(const struct device *dev)
 	memset(dev->data, 0, sizeof(struct pwm_nrfx_data));
 }
 
-static int pwm_nrfx_set_power_state(enum pm_device_state new_state,
-				    enum pm_device_state current_state,
+static int pwm_nrfx_set_power_state(enum pm_device_state state,
 				    const struct device *dev)
 {
 	int err = 0;
 
-	switch (new_state) {
+	switch (state) {
 	case PM_DEVICE_STATE_ACTIVE:
 		err = pwm_nrfx_init(dev);
 		break;
@@ -306,9 +305,7 @@ static int pwm_nrfx_set_power_state(enum pm_device_state new_state,
 	case PM_DEVICE_STATE_SUSPEND:
 	case PM_DEVICE_STATE_FORCE_SUSPEND:
 	case PM_DEVICE_STATE_OFF:
-		if (current_state == PM_DEVICE_STATE_ACTIVE) {
-			pwm_nrfx_uninit(dev);
-		}
+		pwm_nrfx_uninit(dev);
 		break;
 	default:
 		__ASSERT_NO_MSG(false);
@@ -320,15 +317,7 @@ static int pwm_nrfx_set_power_state(enum pm_device_state new_state,
 static int pwm_nrfx_pm_control(const struct device *dev,
 			       enum pm_device_state state)
 {
-	int err = 0;
-	enum pm_device_state curr_state;
-
-	(void)pm_device_state_get(dev, &curr_state);
-	if (state != current_state) {
-		err = pwm_nrfx_set_power_state(state, current_state, dev);
-	}
-
-	return err;
+	return pwm_nrfx_set_power_state(state, dev);
 }
 
 #define PWM_NRFX_PM_CONTROL(idx)					       \

--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -322,15 +322,11 @@ static int pwm_nrfx_pm_control(const struct device *dev,
 			       enum pm_device_state *state)
 {
 	int err = 0;
+	enum pm_device_state curr_state;
 
-	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		enum pm_device_state curr_state;
-
-		(void)pm_device_state_get(dev, &curr_state);
-		if (*state != current_state) {
-			err = pwm_nrfx_set_power_state(*state, current_state,
-						       dev);
-		}
+	(void)pm_device_state_get(dev, &curr_state);
+	if (*state != current_state) {
+		err = pwm_nrfx_set_power_state(*state, current_state, dev);
 	}
 
 	return err;

--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -303,11 +303,11 @@ static int pwm_nrfx_set_power_state(enum pm_device_state state,
 		break;
 	case PM_DEVICE_STATE_LOW_POWER:
 	case PM_DEVICE_STATE_SUSPEND:
-	case PM_DEVICE_STATE_FORCE_SUSPEND:
 	case PM_DEVICE_STATE_OFF:
 		pwm_nrfx_uninit(dev);
 		break;
 	default:
+
 		__ASSERT_NO_MSG(false);
 		break;
 	}

--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -318,7 +318,6 @@ static int pwm_nrfx_set_power_state(enum pm_device_state new_state,
 }
 
 static int pwm_nrfx_pm_control(const struct device *dev,
-			       uint32_t ctrl_command,
 			       enum pm_device_state *state)
 {
 	int err = 0;
@@ -334,10 +333,9 @@ static int pwm_nrfx_pm_control(const struct device *dev,
 
 #define PWM_NRFX_PM_CONTROL(idx)					       \
 	static int pwm_##idx##_nrfx_pm_control(const struct device *dev,       \
-					       uint32_t ctrl_command,	       \
 					       enum pm_device_state *state)    \
 	{								       \
-		return pwm_nrfx_pm_control(dev, ctrl_command, state)	       \
+		return pwm_nrfx_pm_control(dev, state)			       \
 	}
 #else
 

--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -301,7 +301,7 @@ static int pwm_nrfx_set_power_state(enum pm_device_state state,
 	case PM_DEVICE_STATE_ACTIVE:
 		err = pwm_nrfx_init(dev);
 		break;
-	case PM_DEVICE_STATE_SUSPEND:
+	case PM_DEVICE_STATE_SUSPENDED:
 	case PM_DEVICE_STATE_OFF:
 		pwm_nrfx_uninit(dev);
 		break;

--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -301,7 +301,6 @@ static int pwm_nrfx_set_power_state(enum pm_device_state state,
 	case PM_DEVICE_STATE_ACTIVE:
 		err = pwm_nrfx_init(dev);
 		break;
-	case PM_DEVICE_STATE_LOW_POWER:
 	case PM_DEVICE_STATE_SUSPEND:
 	case PM_DEVICE_STATE_OFF:
 		pwm_nrfx_uninit(dev);

--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -292,15 +292,15 @@ static void pwm_nrfx_uninit(const struct device *dev)
 }
 
 static int pwm_nrfx_pm_control(const struct device *dev,
-			       enum pm_device_state state)
+			       enum pm_device_action action)
 {
 	int err = 0;
 
-	switch (state) {
-	case PM_DEVICE_STATE_ACTIVE:
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
 		err = pwm_nrfx_init(dev);
 		break;
-	case PM_DEVICE_STATE_SUSPENDED:
+	case PM_DEVICE_ACTION_SUSPEND:
 		pwm_nrfx_uninit(dev);
 		break;
 	default:

--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -319,40 +319,29 @@ static int pwm_nrfx_set_power_state(enum pm_device_state new_state,
 
 static int pwm_nrfx_pm_control(const struct device *dev,
 			       uint32_t ctrl_command,
-			       enum pm_device_state *state,
-			       enum pm_device_state *current_state)
+			       enum pm_device_state *state)
 {
 	int err = 0;
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		enum pm_device_state new_state = *state;
+		enum pm_device_state curr_state;
 
-		if (new_state != (*current_state)) {
-			err = pwm_nrfx_set_power_state(new_state,
-						       *current_state,
+		(void)pm_device_state_get(dev, &curr_state);
+		if (*state != current_state) {
+			err = pwm_nrfx_set_power_state(*state, current_state,
 						       dev);
-			if (!err) {
-				*current_state = new_state;
-			}
 		}
-	} else {
-		__ASSERT_NO_MSG(ctrl_command == PM_DEVICE_STATE_GET);
-		*state = *current_state;
 	}
 
 	return err;
 }
 
-#define PWM_NRFX_PM_CONTROL(idx)					\
-	static int pwm_##idx##_nrfx_pm_control(const struct device *dev,	\
-					       uint32_t ctrl_command,	\
-					       enum pm_device_state *state)	\
-	{								\
-		static enum pm_device_state current_state = PM_DEVICE_STATE_ACTIVE; \
-		int ret = 0;                                            \
-		ret = pwm_nrfx_pm_control(dev, ctrl_command, state,	\
-					   &current_state);		\
-		return ret;                                             \
+#define PWM_NRFX_PM_CONTROL(idx)					       \
+	static int pwm_##idx##_nrfx_pm_control(const struct device *dev,       \
+					       uint32_t ctrl_command,	       \
+					       enum pm_device_state *state)    \
+	{								       \
+		return pwm_nrfx_pm_control(dev, ctrl_command, state)	       \
 	}
 #else
 

--- a/drivers/sensor/apds9960/apds9960.c
+++ b/drivers/sensor/apds9960/apds9960.c
@@ -415,26 +415,29 @@ static int apds9960_device_ctrl(const struct device *dev,
 	struct apds9960_data *data = dev->data;
 	int ret = 0;
 
-	if (state == PM_DEVICE_STATE_ACTIVE) {
+	switch (state) {
+	case PM_DEVICE_STATE_ACTIVE:
 		if (i2c_reg_update_byte(data->i2c, config->i2c_address,
 					APDS9960_ENABLE_REG,
 					APDS9960_ENABLE_PON,
 					APDS9960_ENABLE_PON)) {
 			ret = -EIO;
 		}
-
-	} else {
-
+		break;
+	case PM_DEVICE_STATE_SUSPENDED:
 		if (i2c_reg_update_byte(data->i2c, config->i2c_address,
-				APDS9960_ENABLE_REG,
-				APDS9960_ENABLE_PON, 0)) {
+					APDS9960_ENABLE_REG,
+					APDS9960_ENABLE_PON, 0)) {
 			ret = -EIO;
 		}
 
 		if (i2c_reg_write_byte(data->i2c, config->i2c_address,
-				APDS9960_AICLEAR_REG, 0)) {
+				       APDS9960_AICLEAR_REG, 0)) {
 			ret = -EIO;
 		}
+		break;
+	default:
+		return -ENOTSUP;
 	}
 
 	return ret;

--- a/drivers/sensor/apds9960/apds9960.c
+++ b/drivers/sensor/apds9960/apds9960.c
@@ -416,29 +416,26 @@ static int apds9960_device_ctrl(const struct device *dev,
 	struct apds9960_data *data = dev->data;
 	int ret = 0;
 
-	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		if (*state == PM_DEVICE_STATE_ACTIVE) {
-			if (i2c_reg_update_byte(data->i2c, config->i2c_address,
-						APDS9960_ENABLE_REG,
-						APDS9960_ENABLE_PON,
-						APDS9960_ENABLE_PON)) {
-				ret = -EIO;
-			}
-
-		} else {
-
-			if (i2c_reg_update_byte(data->i2c, config->i2c_address,
+	if (*state == PM_DEVICE_STATE_ACTIVE) {
+		if (i2c_reg_update_byte(data->i2c, config->i2c_address,
 					APDS9960_ENABLE_REG,
-					APDS9960_ENABLE_PON, 0)) {
-				ret = -EIO;
-			}
-
-			if (i2c_reg_write_byte(data->i2c, config->i2c_address,
-				       APDS9960_AICLEAR_REG, 0)) {
-				ret = -EIO;
-			}
+					APDS9960_ENABLE_PON,
+					APDS9960_ENABLE_PON)) {
+			ret = -EIO;
 		}
 
+	} else {
+
+		if (i2c_reg_update_byte(data->i2c, config->i2c_address,
+				APDS9960_ENABLE_REG,
+				APDS9960_ENABLE_PON, 0)) {
+			ret = -EIO;
+		}
+
+		if (i2c_reg_write_byte(data->i2c, config->i2c_address,
+				APDS9960_AICLEAR_REG, 0)) {
+			ret = -EIO;
+		}
 	}
 
 	return ret;

--- a/drivers/sensor/apds9960/apds9960.c
+++ b/drivers/sensor/apds9960/apds9960.c
@@ -409,13 +409,13 @@ static int apds9960_init_interrupt(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 static int apds9960_device_ctrl(const struct device *dev,
-				enum pm_device_state *state)
+				enum pm_device_state state)
 {
 	const struct apds9960_config *config = dev->config;
 	struct apds9960_data *data = dev->data;
 	int ret = 0;
 
-	if (*state == PM_DEVICE_STATE_ACTIVE) {
+	if (state == PM_DEVICE_STATE_ACTIVE) {
 		if (i2c_reg_update_byte(data->i2c, config->i2c_address,
 					APDS9960_ENABLE_REG,
 					APDS9960_ENABLE_PON,

--- a/drivers/sensor/apds9960/apds9960.c
+++ b/drivers/sensor/apds9960/apds9960.c
@@ -409,7 +409,6 @@ static int apds9960_init_interrupt(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 static int apds9960_device_ctrl(const struct device *dev,
-				uint32_t ctrl_command,
 				enum pm_device_state *state)
 {
 	const struct apds9960_config *config = dev->config;

--- a/drivers/sensor/apds9960/apds9960.c
+++ b/drivers/sensor/apds9960/apds9960.c
@@ -409,14 +409,14 @@ static int apds9960_init_interrupt(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 static int apds9960_device_ctrl(const struct device *dev,
-				enum pm_device_state state)
+				enum pm_device_action action)
 {
 	const struct apds9960_config *config = dev->config;
 	struct apds9960_data *data = dev->data;
 	int ret = 0;
 
-	switch (state) {
-	case PM_DEVICE_STATE_ACTIVE:
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
 		if (i2c_reg_update_byte(data->i2c, config->i2c_address,
 					APDS9960_ENABLE_REG,
 					APDS9960_ENABLE_PON,
@@ -424,7 +424,7 @@ static int apds9960_device_ctrl(const struct device *dev,
 			ret = -EIO;
 		}
 		break;
-	case PM_DEVICE_STATE_SUSPENDED:
+	case PM_DEVICE_ACTION_SUSPEND:
 		if (i2c_reg_update_byte(data->i2c, config->i2c_address,
 					APDS9960_ENABLE_REG,
 					APDS9960_ENABLE_PON, 0)) {

--- a/drivers/sensor/apds9960/apds9960.c
+++ b/drivers/sensor/apds9960/apds9960.c
@@ -439,8 +439,6 @@ static int apds9960_device_ctrl(const struct device *dev,
 			}
 		}
 
-	} else if (ctrl_command == PM_DEVICE_STATE_GET) {
-		*state = PM_DEVICE_STATE_ACTIVE;
 	}
 
 	return ret;

--- a/drivers/sensor/bme280/bme280.c
+++ b/drivers/sensor/bme280/bme280.c
@@ -55,10 +55,6 @@ struct bme280_data {
 	int32_t t_fine;
 
 	uint8_t chip_id;
-
-#ifdef CONFIG_PM_DEVICE
-	enum pm_device_state pm_state; /* Current power state */
-#endif
 };
 
 struct bme280_config {
@@ -199,8 +195,10 @@ static int bme280_sample_fetch(const struct device *dev,
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL);
 
 #ifdef CONFIG_PM_DEVICE
+	enum pm_device_state state;
+	(void)pm_device_state_get(dev, &state);
 	/* Do not allow sample fetching from OFF state */
-	if (data->pm_state == PM_DEVICE_STATE_OFF)
+	if (state == PM_DEVICE_STATE_OFF)
 		return -EIO;
 #endif
 
@@ -407,10 +405,6 @@ static int bme280_chip_init(const struct device *dev)
 	/* Wait for the sensor to be ready */
 	k_sleep(K_MSEC(1));
 
-#ifdef CONFIG_PM_DEVICE
-	/* Set power state to ACTIVE */
-	data->pm_state = PM_DEVICE_STATE_ACTIVE;
-#endif
 	LOG_DBG("\"%s\" OK", dev->name);
 	return 0;
 }
@@ -419,16 +413,17 @@ static int bme280_chip_init(const struct device *dev)
 int bme280_pm_ctrl(const struct device *dev, uint32_t ctrl_command,
 		   enum pm_device_state *state)
 {
-	struct bme280_data *data = to_data(dev);
-
 	int ret = 0;
 
 	/* Set power state */
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		if (*state != data->pm_state) {
+		enum pm_device_state curr_state;
+
+		pm_device_state_get(dev, &curr_state);
+		if (*state != curr_state) {
 
 			/* Switching from OFF to any */
-			if (data->pm_state == PM_DEVICE_STATE_OFF) {
+			if (curr_state == PM_DEVICE_STATE_OFF) {
 
 				/* Re-initialize the chip */
 				ret = bme280_chip_init(dev);
@@ -445,16 +440,7 @@ int bme280_pm_ctrl(const struct device *dev, uint32_t ctrl_command,
 					LOG_DBG("CTRL_MEAS write failed: %d",
 						ret);
 			}
-
-			/* Store the new state */
-			if (!ret)
-				data->pm_state = *state;
 		}
-	}
-	/* Get power state */
-	else {
-		__ASSERT_NO_MSG(ctrl_command == PM_DEVICE_STATE_GET);
-		*state = data->pm_state;
 	}
 
 	return ret;

--- a/drivers/sensor/bme280/bme280.c
+++ b/drivers/sensor/bme280/bme280.c
@@ -410,8 +410,7 @@ static int bme280_chip_init(const struct device *dev)
 }
 
 #ifdef CONFIG_PM_DEVICE
-int bme280_pm_ctrl(const struct device *dev, uint32_t ctrl_command,
-		   enum pm_device_state *state)
+int bme280_pm_ctrl(const struct device *dev, enum pm_device_state *state)
 {
 	int ret = 0;
 	enum pm_device_state curr_state;

--- a/drivers/sensor/bme280/bme280.c
+++ b/drivers/sensor/bme280/bme280.c
@@ -410,13 +410,13 @@ static int bme280_chip_init(const struct device *dev)
 }
 
 #ifdef CONFIG_PM_DEVICE
-int bme280_pm_ctrl(const struct device *dev, enum pm_device_state *state)
+int bme280_pm_ctrl(const struct device *dev, enum pm_device_state state)
 {
 	int ret = 0;
 	enum pm_device_state curr_state;
 
 	pm_device_state_get(dev, &curr_state);
-	if (*state != curr_state) {
+	if (state != curr_state) {
 
 		/* Switching from OFF to any */
 		if (curr_state == PM_DEVICE_STATE_OFF) {
@@ -425,7 +425,7 @@ int bme280_pm_ctrl(const struct device *dev, enum pm_device_state *state)
 			ret = bme280_chip_init(dev);
 		}
 		/* Switching to OFF from any */
-		else if (*state == PM_DEVICE_STATE_OFF) {
+		else if (state == PM_DEVICE_STATE_OFF) {
 
 			/* Put the chip into sleep mode */
 			ret = bme280_reg_write(dev,

--- a/drivers/sensor/bme280/bme280.c
+++ b/drivers/sensor/bme280/bme280.c
@@ -197,8 +197,8 @@ static int bme280_sample_fetch(const struct device *dev,
 #ifdef CONFIG_PM_DEVICE
 	enum pm_device_state state;
 	(void)pm_device_state_get(dev, &state);
-	/* Do not allow sample fetching from OFF state */
-	if (state == PM_DEVICE_STATE_OFF)
+	/* Do not allow sample fetching from suspended state */
+	if (state == PM_DEVICE_STATE_SUSPENDED)
 		return -EIO;
 #endif
 
@@ -420,8 +420,6 @@ int bme280_pm_ctrl(const struct device *dev, enum pm_device_state state)
 		ret = bme280_chip_init(dev);
 		break;
 	case PM_DEVICE_STATE_SUSPENDED:
-		__fallthrough;
-	case PM_DEVICE_STATE_OFF:
 		/* Put the chip into sleep mode */
 		ret = bme280_reg_write(dev,
 			BME280_REG_CTRL_MEAS,

--- a/drivers/sensor/bme280/bme280.c
+++ b/drivers/sensor/bme280/bme280.c
@@ -410,16 +410,16 @@ static int bme280_chip_init(const struct device *dev)
 }
 
 #ifdef CONFIG_PM_DEVICE
-int bme280_pm_ctrl(const struct device *dev, enum pm_device_state state)
+int bme280_pm_ctrl(const struct device *dev, enum pm_device_action action)
 {
 	int ret = 0;
 
-	switch (state) {
-	case PM_DEVICE_STATE_ACTIVE:
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
 		/* Re-initialize the chip */
 		ret = bme280_chip_init(dev);
 		break;
-	case PM_DEVICE_STATE_SUSPENDED:
+	case PM_DEVICE_ACTION_SUSPEND:
 		/* Put the chip into sleep mode */
 		ret = bme280_reg_write(dev,
 			BME280_REG_CTRL_MEAS,

--- a/drivers/sensor/bme280/bme280.c
+++ b/drivers/sensor/bme280/bme280.c
@@ -414,21 +414,25 @@ int bme280_pm_ctrl(const struct device *dev, enum pm_device_state state)
 {
 	int ret = 0;
 
-	/* Switching from OFF to any */
-	if (state != PM_DEVICE_STATE_OFF) {
+	switch (state) {
+	case PM_DEVICE_STATE_ACTIVE:
 		/* Re-initialize the chip */
 		ret = bme280_chip_init(dev);
-	}
-	/* Switching to OFF from any */
-	else if (state == PM_DEVICE_STATE_OFF) {
-
+		break;
+	case PM_DEVICE_STATE_SUSPENDED:
+		__fallthrough;
+	case PM_DEVICE_STATE_OFF:
 		/* Put the chip into sleep mode */
 		ret = bme280_reg_write(dev,
 			BME280_REG_CTRL_MEAS,
 			BME280_CTRL_MEAS_OFF_VAL);
 
-		if (ret < 0)
+		if (ret < 0) {
 			LOG_DBG("CTRL_MEAS write failed: %d", ret);
+		}
+		break;
+	default:
+		return -ENOTSUP;
 	}
 
 	return ret;

--- a/drivers/sensor/bmp388/bmp388.c
+++ b/drivers/sensor/bmp388/bmp388.c
@@ -550,15 +550,15 @@ static int bmp388_get_calibration_data(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 static int bmp388_device_ctrl(const struct device *dev,
-			      enum pm_device_state state)
+			      enum pm_device_action action)
 {
 	uint8_t reg_val;
 
-	switch (state) {
-	case PM_DEVICE_STATE_ACTIVE:
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
 		reg_val = BMP388_PWR_CTRL_MODE_NORMAL;
 		break;
-	case PM_DEVICE_STATE_SUSPENDED:
+	case PM_DEVICE_ACTION_SUSPEND:
 		reg_val = BMP388_PWR_CTRL_MODE_SLEEP;
 		break;
 	default:

--- a/drivers/sensor/bmp388/bmp388.c
+++ b/drivers/sensor/bmp388/bmp388.c
@@ -583,11 +583,11 @@ static int bmp388_set_power_state(const struct device *dev,
 
 static int bmp388_device_ctrl(
 	const struct device *dev,
-	enum pm_device_state *state)
+	enum pm_device_state state)
 {
 	int ret = 0;
 
-	ret = bmp388_set_power_state(dev, *state);
+	ret = bmp388_set_power_state(dev, state);
 
 	return ret;
 }

--- a/drivers/sensor/bmp388/bmp388.c
+++ b/drivers/sensor/bmp388/bmp388.c
@@ -583,7 +583,6 @@ static int bmp388_set_power_state(const struct device *dev,
 
 static int bmp388_device_ctrl(
 	const struct device *dev,
-	uint32_t ctrl_command,
 	enum pm_device_state *state)
 {
 	int ret = 0;

--- a/drivers/sensor/bmp388/bmp388.c
+++ b/drivers/sensor/bmp388/bmp388.c
@@ -588,9 +588,7 @@ static int bmp388_device_ctrl(
 {
 	int ret = 0;
 
-	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		ret = bmp388_set_power_state(dev, *state);
-	}
+	ret = bmp388_set_power_state(dev, *state);
 
 	return ret;
 }

--- a/drivers/sensor/bmp388/bmp388.c
+++ b/drivers/sensor/bmp388/bmp388.c
@@ -549,18 +549,22 @@ static int bmp388_get_calibration_data(const struct device *dev)
 }
 
 #ifdef CONFIG_PM_DEVICE
-static int bmp388_set_power_state(const struct device *dev,
-				  enum pm_device_state state)
+static int bmp388_device_ctrl(const struct device *dev,
+			      enum pm_device_state state)
 {
 	uint8_t reg_val;
 
-	if (state == PM_DEVICE_STATE_ACTIVE) {
+	switch (state) {
+	case PM_DEVICE_STATE_ACTIVE:
 		reg_val = BMP388_PWR_CTRL_MODE_NORMAL;
-	} else if ((state == PM_DEVICE_STATE_SUSPENDED) ||
-		   (state == PM_DEVICE_STATE_OFF)) {
+		break;
+	case PM_DEVICE_STATE_SUSPENDED:
+		__fallthrough;
+	case PM_DEVICE_STATE_OFF:
 		reg_val = BMP388_PWR_CTRL_MODE_SLEEP;
-	} else {
-		return 0;
+		break;
+	default:
+		return -ENOTSUP;
 	}
 
 	if (bmp388_reg_field_update(dev,
@@ -572,17 +576,6 @@ static int bmp388_set_power_state(const struct device *dev,
 	}
 
 	return 0;
-}
-
-static int bmp388_device_ctrl(
-	const struct device *dev,
-	enum pm_device_state state)
-{
-	int ret = 0;
-
-	ret = bmp388_set_power_state(dev, state);
-
-	return ret;
 }
 #endif /* CONFIG_PM_DEVICE */
 

--- a/drivers/sensor/bmp388/bmp388.c
+++ b/drivers/sensor/bmp388/bmp388.c
@@ -559,8 +559,6 @@ static int bmp388_device_ctrl(const struct device *dev,
 		reg_val = BMP388_PWR_CTRL_MODE_NORMAL;
 		break;
 	case PM_DEVICE_STATE_SUSPENDED:
-		__fallthrough;
-	case PM_DEVICE_STATE_OFF:
 		reg_val = BMP388_PWR_CTRL_MODE_SLEEP;
 		break;
 	default:

--- a/drivers/sensor/bmp388/bmp388.c
+++ b/drivers/sensor/bmp388/bmp388.c
@@ -556,7 +556,7 @@ static int bmp388_set_power_state(const struct device *dev,
 
 	if (state == PM_DEVICE_STATE_ACTIVE) {
 		reg_val = BMP388_PWR_CTRL_MODE_NORMAL;
-	} else if ((state == PM_DEVICE_STATE_SUSPEND) ||
+	} else if ((state == PM_DEVICE_STATE_SUSPENDED) ||
 		   (state == PM_DEVICE_STATE_OFF)) {
 		reg_val = BMP388_PWR_CTRL_MODE_SLEEP;
 	} else {

--- a/drivers/sensor/bmp388/bmp388.c
+++ b/drivers/sensor/bmp388/bmp388.c
@@ -550,21 +550,14 @@ static int bmp388_get_calibration_data(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 static int bmp388_set_power_state(const struct device *dev,
-				  enum pm_device_state power_state)
+				  enum pm_device_state state)
 {
 	uint8_t reg_val;
-	enum pm_device_state state;
 
-	(void)pm_device_state_get(dev, &state);
-	if (state == power_state) {
-		/* We are already in the desired state. */
-		return 0;
-	}
-
-	if (power_state == PM_DEVICE_STATE_ACTIVE) {
+	if (state == PM_DEVICE_STATE_ACTIVE) {
 		reg_val = BMP388_PWR_CTRL_MODE_NORMAL;
-	} else if ((power_state == PM_DEVICE_STATE_SUSPEND) ||
-		   (power_state == PM_DEVICE_STATE_OFF)) {
+	} else if ((state == PM_DEVICE_STATE_SUSPEND) ||
+		   (state == PM_DEVICE_STATE_OFF)) {
 		reg_val = BMP388_PWR_CTRL_MODE_SLEEP;
 	} else {
 		return 0;

--- a/drivers/sensor/bmp388/bmp388.h
+++ b/drivers/sensor/bmp388/bmp388.h
@@ -163,10 +163,6 @@ struct bmp388_data {
 	uint8_t osr_temp;
 	struct bmp388_cal_data cal;
 
-#ifdef CONFIG_PM_DEVICE
-	enum pm_device_state device_power_state;
-#endif
-
 #if defined(CONFIG_BMP388_TRIGGER)
 	struct gpio_callback gpio_cb;
 #endif

--- a/drivers/sensor/bmp388/bmp388_trigger.c
+++ b/drivers/sensor/bmp388/bmp388_trigger.c
@@ -92,7 +92,10 @@ int bmp388_trigger_set(
 	struct bmp388_data *data = DEV_DATA(dev);
 
 #ifdef CONFIG_PM_DEVICE
-	if (data->device_power_state != PM_DEVICE_STATE_ACTIVE) {
+	enum pm_device_state state;
+
+	(void)pm_device_state_get(dev, &state);
+	if (state != PM_DEVICE_STATE_ACTIVE) {
 		return -EBUSY;
 	}
 #endif

--- a/drivers/sensor/bq274xx/bq274xx.c
+++ b/drivers/sensor/bq274xx/bq274xx.c
@@ -732,16 +732,16 @@ static int bq274xx_exit_shutdown_mode(const struct device *dev)
 }
 
 static int bq274xx_pm_control(const struct device *dev,
-			      enum pm_device_state state)
+			      enum pm_device_action action)
 {
 	int ret;
 	struct bq274xx_data *data = dev->data;
 
-	switch (state) {
-	case PM_DEVICE_STATE_OFF:
+	switch (action) {
+	case PM_DEVICE_ACTION_TURN_OFF:
 		ret = bq274xx_enter_shutdown_mode(data);
 		break;
-	case PM_DEVICE_STATE_ACTIVE:
+	case PM_DEVICE_ACTION_RESUME:
 		ret = bq274xx_exit_shutdown_mode(dev);
 		break;
 	default:

--- a/drivers/sensor/bq274xx/bq274xx.c
+++ b/drivers/sensor/bq274xx/bq274xx.c
@@ -734,22 +734,19 @@ static int bq274xx_exit_shutdown_mode(const struct device *dev)
 static int bq274xx_pm_control(const struct device *dev,
 			      enum pm_device_state state)
 {
-	int ret = 0;
+	int ret;
 	struct bq274xx_data *data = dev->data;
 
-	if (state == PM_DEVICE_STATE_OFF) {
+	switch (state) {
+	case PM_DEVICE_STATE_OFF:
 		ret = bq274xx_enter_shutdown_mode(data);
-		if (ret < 0) {
-			LOG_ERR("Unable to enter off state");
-		}
-	} else if (state == PM_DEVICE_STATE_ACTIVE) {
+		break;
+	case PM_DEVICE_STATE_ACTIVE:
 		ret = bq274xx_exit_shutdown_mode(dev);
-		if (ret < 0) {
-			LOG_ERR("Unable to enter active state");
-		}
-	} else {
-		LOG_ERR("State to set is not implemented");
+		break;
+	default:
 		ret = -ENOTSUP;
+		break;
 	}
 
 	return ret;

--- a/drivers/sensor/bq274xx/bq274xx.c
+++ b/drivers/sensor/bq274xx/bq274xx.c
@@ -737,25 +737,19 @@ static int bq274xx_pm_control(const struct device *dev, uint32_t ctrl_command,
 	int ret = 0;
 	struct bq274xx_data *data = dev->data;
 
-	switch (ctrl_command) {
-	case PM_DEVICE_STATE_SET:
-		if (*state == PM_DEVICE_STATE_OFF) {
-			ret = bq274xx_enter_shutdown_mode(data);
-			if (ret < 0) {
-				LOG_ERR("Unable to enter off state");
-			}
-		} else if (*state == PM_DEVICE_STATE_ACTIVE) {
-			ret = bq274xx_exit_shutdown_mode(dev);
-			if (ret < 0) {
-				LOG_ERR("Unable to enter active state");
-			}
-		} else {
-			LOG_ERR("State to set is not implemented");
-			ret = -ENOTSUP;
+	if (*state == PM_DEVICE_STATE_OFF) {
+		ret = bq274xx_enter_shutdown_mode(data);
+		if (ret < 0) {
+			LOG_ERR("Unable to enter off state");
 		}
-		break;
-	default:
-		ret = -EINVAL;
+	} else if (*state == PM_DEVICE_STATE_ACTIVE) {
+		ret = bq274xx_exit_shutdown_mode(dev);
+		if (ret < 0) {
+			LOG_ERR("Unable to enter active state");
+		}
+	} else {
+		LOG_ERR("State to set is not implemented");
+		ret = -ENOTSUP;
 	}
 
 	return ret;

--- a/drivers/sensor/bq274xx/bq274xx.c
+++ b/drivers/sensor/bq274xx/bq274xx.c
@@ -691,8 +691,6 @@ static int bq274xx_enter_shutdown_mode(struct bq274xx_data *data)
 		return status;
 	}
 
-	data->pm_state = PM_DEVICE_STATE_OFF;
-
 	return 0;
 }
 
@@ -755,9 +753,6 @@ static int bq274xx_pm_control(const struct device *dev, uint32_t ctrl_command,
 			LOG_ERR("State to set is not implemented");
 			ret = -ENOTSUP;
 		}
-		break;
-	case PM_DEVICE_STATE_GET:
-		*state = data->pm_state;
 		break;
 	default:
 		ret = -EINVAL;

--- a/drivers/sensor/bq274xx/bq274xx.c
+++ b/drivers/sensor/bq274xx/bq274xx.c
@@ -732,17 +732,17 @@ static int bq274xx_exit_shutdown_mode(const struct device *dev)
 }
 
 static int bq274xx_pm_control(const struct device *dev,
-			      enum pm_device_state *state)
+			      enum pm_device_state state)
 {
 	int ret = 0;
 	struct bq274xx_data *data = dev->data;
 
-	if (*state == PM_DEVICE_STATE_OFF) {
+	if (state == PM_DEVICE_STATE_OFF) {
 		ret = bq274xx_enter_shutdown_mode(data);
 		if (ret < 0) {
 			LOG_ERR("Unable to enter off state");
 		}
-	} else if (*state == PM_DEVICE_STATE_ACTIVE) {
+	} else if (state == PM_DEVICE_STATE_ACTIVE) {
 		ret = bq274xx_exit_shutdown_mode(dev);
 		if (ret < 0) {
 			LOG_ERR("Unable to enter active state");

--- a/drivers/sensor/bq274xx/bq274xx.c
+++ b/drivers/sensor/bq274xx/bq274xx.c
@@ -731,8 +731,8 @@ static int bq274xx_exit_shutdown_mode(const struct device *dev)
 	return 0;
 }
 
-static int bq274xx_pm_control(const struct device *dev, uint32_t ctrl_command,
-				  enum pm_device_state *state)
+static int bq274xx_pm_control(const struct device *dev,
+			      enum pm_device_state *state)
 {
 	int ret = 0;
 	struct bq274xx_data *data = dev->data;

--- a/drivers/sensor/bq274xx/bq274xx.h
+++ b/drivers/sensor/bq274xx/bq274xx.h
@@ -96,9 +96,6 @@ struct bq274xx_data {
 	uint16_t remaining_charge_capacity;
 	uint16_t nom_avail_capacity;
 	uint16_t full_avail_capacity;
-#ifdef CONFIG_PM_DEVICE
-	enum pm_device_state pm_state;
-#endif
 };
 
 struct bq274xx_config {

--- a/drivers/sensor/fdc2x1x/fdc2x1x.c
+++ b/drivers/sensor/fdc2x1x/fdc2x1x.c
@@ -482,7 +482,7 @@ static int fdc2x1x_set_shutdown(const struct device *dev, bool enable)
  * @return 0 in case of success, negative error code otherwise.
  */
 static int fdc2x1x_device_pm_ctrl(const struct device *dev,
-				  enum pm_device_state state)
+				  enum pm_device_action action)
 {
 	int ret;
 	struct fdc2x1x_data *data = dev->data;
@@ -491,8 +491,8 @@ static int fdc2x1x_device_pm_ctrl(const struct device *dev,
 
 	(void)pm_device_state_get(dev, &curr_state);
 
-	switch (state) {
-	case PM_DEVICE_STATE_ACTIVE:
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
 		if (curr_state == PM_DEVICE_STATE_OFF) {
 			ret = fdc2x1x_set_shutdown(dev, false);
 			if (ret) {
@@ -506,7 +506,7 @@ static int fdc2x1x_device_pm_ctrl(const struct device *dev,
 		}
 
 		break;
-	case PM_DEVICE_STATE_SUSPENDED:
+	case PM_DEVICE_ACTION_SUSPEND:
 		if (curr_state == PM_DEVICE_STATE_OFF) {
 			ret = fdc2x1x_set_shutdown(dev, false);
 			if (ret) {
@@ -519,7 +519,7 @@ static int fdc2x1x_device_pm_ctrl(const struct device *dev,
 		}
 
 		break;
-	case PM_DEVICE_STATE_OFF:
+	case PM_DEVICE_ACTION_TURN_OFF:
 		if (cfg->sd_gpio->name) {
 			ret = fdc2x1x_set_shutdown(dev, true);
 		} else {

--- a/drivers/sensor/fdc2x1x/fdc2x1x.c
+++ b/drivers/sensor/fdc2x1x/fdc2x1x.c
@@ -535,7 +535,7 @@ static int fdc2x1x_set_pm_state(const struct device *dev,
 }
 
 static int fdc2x1x_device_pm_ctrl(const struct device *dev,
-				  enum pm_device_state *state)
+				  enum pm_device_state state)
 {
 	struct fdc2x1x_data *data = dev->data;
 	int ret = 0;
@@ -543,12 +543,12 @@ static int fdc2x1x_device_pm_ctrl(const struct device *dev,
 
 	(void)pm_device_state_get(dev, &curr_state);
 
-	if (*state != curr_state) {
-		switch (*state) {
+	if (state != curr_state) {
+		switch (state) {
 		case PM_DEVICE_STATE_ACTIVE:
 		case PM_DEVICE_STATE_LOW_POWER:
 		case PM_DEVICE_STATE_OFF:
-			ret = fdc2x1x_set_pm_state(dev, *state);
+			ret = fdc2x1x_set_pm_state(dev, state);
 			break;
 		default:
 			LOG_ERR("PM state not supported");

--- a/drivers/sensor/fdc2x1x/fdc2x1x.c
+++ b/drivers/sensor/fdc2x1x/fdc2x1x.c
@@ -506,7 +506,7 @@ static int fdc2x1x_set_pm_state(const struct device *dev,
 		}
 
 		break;
-	case PM_DEVICE_STATE_LOW_POWER:
+	case PM_DEVICE_STATE_SUSPEND:
 		if (curr_state == PM_DEVICE_STATE_OFF) {
 			ret = fdc2x1x_set_shutdown(dev, false);
 			if (ret) {
@@ -542,7 +542,6 @@ static int fdc2x1x_device_pm_ctrl(const struct device *dev,
 
 	switch (state) {
 	case PM_DEVICE_STATE_ACTIVE:
-	case PM_DEVICE_STATE_LOW_POWER:
 	case PM_DEVICE_STATE_OFF:
 		ret = fdc2x1x_set_pm_state(dev, state);
 		break;

--- a/drivers/sensor/fdc2x1x/fdc2x1x.c
+++ b/drivers/sensor/fdc2x1x/fdc2x1x.c
@@ -540,22 +540,20 @@ static int fdc2x1x_device_pm_ctrl(const struct device *dev,
 {
 	struct fdc2x1x_data *data = dev->data;
 	int ret = 0;
+	enum pm_device_state curr_state;
 
-	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		enum pm_device_state curr_state;
-		(void)pm_device_state_get(dev, &curr_state);
+	(void)pm_device_state_get(dev, &curr_state);
 
-		if (*state != curr_state) {
-			switch (*state) {
-			case PM_DEVICE_STATE_ACTIVE:
-			case PM_DEVICE_STATE_LOW_POWER:
-			case PM_DEVICE_STATE_OFF:
-				ret = fdc2x1x_set_pm_state(dev, *state);
-				break;
-			default:
-				LOG_ERR("PM state not supported");
-				ret = -EINVAL;
-			}
+	if (*state != curr_state) {
+		switch (*state) {
+		case PM_DEVICE_STATE_ACTIVE:
+		case PM_DEVICE_STATE_LOW_POWER:
+		case PM_DEVICE_STATE_OFF:
+			ret = fdc2x1x_set_pm_state(dev, *state);
+			break;
+		default:
+			LOG_ERR("PM state not supported");
+			ret = -EINVAL;
 		}
 	}
 

--- a/drivers/sensor/fdc2x1x/fdc2x1x.c
+++ b/drivers/sensor/fdc2x1x/fdc2x1x.c
@@ -506,7 +506,7 @@ static int fdc2x1x_set_pm_state(const struct device *dev,
 		}
 
 		break;
-	case PM_DEVICE_STATE_SUSPEND:
+	case PM_DEVICE_STATE_SUSPENDED:
 		if (curr_state == PM_DEVICE_STATE_OFF) {
 			ret = fdc2x1x_set_shutdown(dev, false);
 			if (ret) {

--- a/drivers/sensor/fdc2x1x/fdc2x1x.c
+++ b/drivers/sensor/fdc2x1x/fdc2x1x.c
@@ -539,21 +539,16 @@ static int fdc2x1x_device_pm_ctrl(const struct device *dev,
 {
 	struct fdc2x1x_data *data = dev->data;
 	int ret = 0;
-	enum pm_device_state curr_state;
 
-	(void)pm_device_state_get(dev, &curr_state);
-
-	if (state != curr_state) {
-		switch (state) {
-		case PM_DEVICE_STATE_ACTIVE:
-		case PM_DEVICE_STATE_LOW_POWER:
-		case PM_DEVICE_STATE_OFF:
-			ret = fdc2x1x_set_pm_state(dev, state);
-			break;
-		default:
-			LOG_ERR("PM state not supported");
-			ret = -EINVAL;
-		}
+	switch (state) {
+	case PM_DEVICE_STATE_ACTIVE:
+	case PM_DEVICE_STATE_LOW_POWER:
+	case PM_DEVICE_STATE_OFF:
+		ret = fdc2x1x_set_pm_state(dev, state);
+		break;
+	default:
+		LOG_ERR("PM state not supported");
+		ret = -EINVAL;
 	}
 
 	return ret;

--- a/drivers/sensor/fdc2x1x/fdc2x1x.c
+++ b/drivers/sensor/fdc2x1x/fdc2x1x.c
@@ -481,8 +481,8 @@ static int fdc2x1x_set_shutdown(const struct device *dev, bool enable)
  * @param pm_state - power management state
  * @return 0 in case of success, negative error code otherwise.
  */
-static int fdc2x1x_set_pm_state(const struct device *dev,
-				enum pm_device_state pm_state)
+static int fdc2x1x_device_pm_ctrl(const struct device *dev,
+				  enum pm_device_state state)
 {
 	int ret;
 	struct fdc2x1x_data *data = dev->data;
@@ -491,7 +491,7 @@ static int fdc2x1x_set_pm_state(const struct device *dev,
 
 	(void)pm_device_state_get(dev, &curr_state);
 
-	switch (pm_state) {
+	switch (state) {
 	case PM_DEVICE_STATE_ACTIVE:
 		if (curr_state == PM_DEVICE_STATE_OFF) {
 			ret = fdc2x1x_set_shutdown(dev, false);
@@ -524,30 +524,11 @@ static int fdc2x1x_set_pm_state(const struct device *dev,
 			ret = fdc2x1x_set_shutdown(dev, true);
 		} else {
 			LOG_ERR("SD pin not defined");
-			ret = -EINVAL;
+			ret = -ENOTSUP;
 		}
 		break;
 	default:
-		return -EINVAL;
-	}
-
-	return ret;
-}
-
-static int fdc2x1x_device_pm_ctrl(const struct device *dev,
-				  enum pm_device_state state)
-{
-	struct fdc2x1x_data *data = dev->data;
-	int ret = 0;
-
-	switch (state) {
-	case PM_DEVICE_STATE_ACTIVE:
-	case PM_DEVICE_STATE_OFF:
-		ret = fdc2x1x_set_pm_state(dev, state);
-		break;
-	default:
-		LOG_ERR("PM state not supported");
-		ret = -EINVAL;
+		return -ENOTSUP;
 	}
 
 	return ret;

--- a/drivers/sensor/fdc2x1x/fdc2x1x.c
+++ b/drivers/sensor/fdc2x1x/fdc2x1x.c
@@ -535,7 +535,6 @@ static int fdc2x1x_set_pm_state(const struct device *dev,
 }
 
 static int fdc2x1x_device_pm_ctrl(const struct device *dev,
-				  uint32_t ctrl_command,
 				  enum pm_device_state *state)
 {
 	struct fdc2x1x_data *data = dev->data;

--- a/drivers/sensor/fdc2x1x/fdc2x1x.h
+++ b/drivers/sensor/fdc2x1x/fdc2x1x.h
@@ -149,10 +149,6 @@ enum fdc2x1x_op_mode {
 struct fdc2x1x_data {
 	bool fdc221x;
 
-#ifdef CONFIG_PM_DEVICE
-	enum pm_device_state pm_state;
-#endif
-
 #ifdef CONFIG_FDC2X1X_TRIGGER
 	struct gpio_callback gpio_cb;
 	uint16_t int_config;

--- a/drivers/sensor/fdc2x1x/fdc2x1x_trigger.c
+++ b/drivers/sensor/fdc2x1x/fdc2x1x_trigger.c
@@ -24,8 +24,11 @@ static void fdc2x1x_thread_cb(const struct device *dev)
 	uint16_t status;
 
 #ifdef CONFIG_PM_DEVICE
+	enum pm_device_state state;
+
 	/* INTB asserts after exiting shutdown mode. Drop this interrupt */
-	if (drv_data->pm_state == PM_DEVICE_STATE_OFF) {
+	(void)pm_device_state_get(dev, &state);
+	if (state == PM_DEVICE_STATE_OFF) {
 		return;
 	}
 #endif

--- a/drivers/sensor/lis2mdl/lis2mdl.c
+++ b/drivers/sensor/lis2mdl/lis2mdl.c
@@ -443,14 +443,14 @@ static int lis2mdl_init(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 static int lis2mdl_pm_control(const struct device *dev,
-			      enum pm_device_state state)
+			      enum pm_device_action action)
 {
 	const struct lis2mdl_config *config = dev->config;
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&config->ctx;
 	int status = 0;
 
-	switch (state) {
-	case PM_DEVICE_STATE_ACTIVE:
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
 		if (config->single_mode) {
 			status = lis2mdl_operating_mode_set(ctx,
 						LIS2MDL_SINGLE_TRIGGER);
@@ -463,7 +463,7 @@ static int lis2mdl_pm_control(const struct device *dev,
 		}
 		LOG_DBG("State changed to active");
 		break;
-	case PM_DEVICE_STATE_SUSPENDED:
+	case PM_DEVICE_ACTION_SUSPEND:
 		status = lis2mdl_operating_mode_set(ctx, LIS2MDL_POWER_DOWN);
 		if (status) {
 			LOG_ERR("Power down failed");

--- a/drivers/sensor/lis2mdl/lis2mdl.c
+++ b/drivers/sensor/lis2mdl/lis2mdl.c
@@ -481,20 +481,11 @@ static int lis2mdl_pm_control(const struct device *dev, uint32_t ctrl_command,
 	struct lis2mdl_data *lis2mdl = dev->data;
 	const struct lis2mdl_config *const config = dev->config;
 	int status = 0;
+	enum pm_device_state curr_state;
 
-	switch (ctrl_command) {
-	case PM_DEVICE_STATE_SET:
-		enum pm_device_state curr_state;
-
-		(void)pm_device_state_get(dev, &curr_state);
-		if (*state != curr_state) {
-			status = lis2mdl_set_power_state(lis2mdl, config,
-							 *state);
-		}
-		break;
-	default:
-		LOG_ERR("Got unknown power management control command");
-		status = -EINVAL;
+	(void)pm_device_state_get(dev, &curr_state);
+	if (*state != curr_state) {
+		status = lis2mdl_set_power_state(lis2mdl, config, *state);
 	}
 
 	return status;

--- a/drivers/sensor/lis2mdl/lis2mdl.c
+++ b/drivers/sensor/lis2mdl/lis2mdl.c
@@ -429,10 +429,6 @@ static int lis2mdl_init(const struct device *dev)
 		}
 	}
 
-#ifdef CONFIG_PM_DEVICE
-	lis2mdl->power_state = PM_DEVICE_STATE_ACTIVE;
-#endif
-
 #ifdef CONFIG_LIS2MDL_TRIGGER
 	if (cfg->trig_enabled) {
 		if (lis2mdl_init_interrupt(dev) < 0) {
@@ -464,7 +460,6 @@ static int lis2mdl_set_power_state(struct lis2mdl_data *lis2mdl,
 		if (status) {
 			LOG_ERR("Power up failed");
 		}
-		lis2mdl->power_state = PM_DEVICE_STATE_ACTIVE;
 		LOG_DBG("State changed to active");
 	} else {
 		__ASSERT_NO_MSG(new_state == PM_DEVICE_STATE_LOW_POWER ||
@@ -474,7 +469,6 @@ static int lis2mdl_set_power_state(struct lis2mdl_data *lis2mdl,
 		if (status) {
 			LOG_ERR("Power down failed");
 		}
-		lis2mdl->power_state = new_state;
 		LOG_DBG("State changed to inactive");
 	}
 
@@ -486,20 +480,17 @@ static int lis2mdl_pm_control(const struct device *dev, uint32_t ctrl_command,
 {
 	struct lis2mdl_data *lis2mdl = dev->data;
 	const struct lis2mdl_config *const config = dev->config;
-	enum pm_device_state current_state = lis2mdl->power_state;
 	int status = 0;
-	enum pm_device_state new_state;
 
 	switch (ctrl_command) {
 	case PM_DEVICE_STATE_SET:
-		new_state = *state;
-		if (new_state != current_state) {
+		enum pm_device_state curr_state;
+
+		(void)pm_device_state_get(dev, &curr_state);
+		if (*state != curr_state) {
 			status = lis2mdl_set_power_state(lis2mdl, config,
-							new_state);
+							 *state);
 		}
-		break;
-	case PM_DEVICE_STATE_GET:
-		*state = current_state;
 		break;
 	default:
 		LOG_ERR("Got unknown power management control command");

--- a/drivers/sensor/lis2mdl/lis2mdl.c
+++ b/drivers/sensor/lis2mdl/lis2mdl.c
@@ -475,8 +475,8 @@ static int lis2mdl_set_power_state(struct lis2mdl_data *lis2mdl,
 	return status;
 }
 
-static int lis2mdl_pm_control(const struct device *dev, uint32_t ctrl_command,
-				enum pm_device_state *state)
+static int lis2mdl_pm_control(const struct device *dev,
+			      enum pm_device_state *state)
 {
 	struct lis2mdl_data *lis2mdl = dev->data;
 	const struct lis2mdl_config *const config = dev->config;

--- a/drivers/sensor/lis2mdl/lis2mdl.c
+++ b/drivers/sensor/lis2mdl/lis2mdl.c
@@ -476,7 +476,7 @@ static int lis2mdl_set_power_state(struct lis2mdl_data *lis2mdl,
 }
 
 static int lis2mdl_pm_control(const struct device *dev,
-			      enum pm_device_state *state)
+			      enum pm_device_state state)
 {
 	struct lis2mdl_data *lis2mdl = dev->data;
 	const struct lis2mdl_config *const config = dev->config;
@@ -484,8 +484,8 @@ static int lis2mdl_pm_control(const struct device *dev,
 	enum pm_device_state curr_state;
 
 	(void)pm_device_state_get(dev, &curr_state);
-	if (*state != curr_state) {
-		status = lis2mdl_set_power_state(lis2mdl, config, *state);
+	if (state != curr_state) {
+		status = lis2mdl_set_power_state(lis2mdl, config, state);
 	}
 
 	return status;

--- a/drivers/sensor/lis2mdl/lis2mdl.c
+++ b/drivers/sensor/lis2mdl/lis2mdl.c
@@ -444,12 +444,12 @@ static int lis2mdl_init(const struct device *dev)
 #ifdef CONFIG_PM_DEVICE
 static int lis2mdl_set_power_state(struct lis2mdl_data *lis2mdl,
 		const struct lis2mdl_config *const config,
-		enum pm_device_state new_state)
+		enum pm_device_state state)
 {
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&config->ctx;
 	int status = 0;
 
-	if (new_state == PM_DEVICE_STATE_ACTIVE) {
+	if (state == PM_DEVICE_STATE_ACTIVE) {
 		if (config->single_mode) {
 			status = lis2mdl_operating_mode_set(ctx,
 						LIS2MDL_SINGLE_TRIGGER);
@@ -462,9 +462,6 @@ static int lis2mdl_set_power_state(struct lis2mdl_data *lis2mdl,
 		}
 		LOG_DBG("State changed to active");
 	} else {
-		__ASSERT_NO_MSG(new_state == PM_DEVICE_STATE_LOW_POWER ||
-				new_state == PM_DEVICE_STATE_SUSPEND ||
-				new_state == PM_DEVICE_STATE_OFF);
 		status = lis2mdl_operating_mode_set(ctx, LIS2MDL_POWER_DOWN);
 		if (status) {
 			LOG_ERR("Power down failed");
@@ -480,15 +477,8 @@ static int lis2mdl_pm_control(const struct device *dev,
 {
 	struct lis2mdl_data *lis2mdl = dev->data;
 	const struct lis2mdl_config *const config = dev->config;
-	int status = 0;
-	enum pm_device_state curr_state;
 
-	(void)pm_device_state_get(dev, &curr_state);
-	if (state != curr_state) {
-		status = lis2mdl_set_power_state(lis2mdl, config, state);
-	}
-
-	return status;
+	return lis2mdl_set_power_state(lis2mdl, config, state);
 }
 #endif /* CONFIG_PM_DEVICE */
 

--- a/drivers/sensor/lis2mdl/lis2mdl.h
+++ b/drivers/sensor/lis2mdl/lis2mdl.h
@@ -50,11 +50,6 @@ struct lis2mdl_data {
 	const struct device *dev;
 	int16_t mag[3];
 	int16_t temp_sample;
-
-#ifdef CONFIG_PM_DEVICE
-	enum pm_device_state power_state;
-#endif
-
 	struct k_sem fetch_sem;
 
 #ifdef CONFIG_LIS2MDL_TRIGGER

--- a/drivers/sensor/qdec_nrfx/qdec_nrfx.c
+++ b/drivers/sensor/qdec_nrfx/qdec_nrfx.c
@@ -248,15 +248,7 @@ static int qdec_nrfx_pm_control(const struct device *dev,
 
 	LOG_DBG("");
 
-	switch (ctrl_command) {
-	case PM_DEVICE_STATE_SET:
-		err = qdec_nrfx_pm_set_state(data, *state);
-		break;
-
-	default:
-		err = -ENOTSUP;
-		break;
-	}
+	err = qdec_nrfx_pm_set_state(data, *state);
 
 	return err;
 }

--- a/drivers/sensor/qdec_nrfx/qdec_nrfx.c
+++ b/drivers/sensor/qdec_nrfx/qdec_nrfx.c
@@ -209,31 +209,18 @@ static int qdec_nrfx_init(const struct device *dev)
 #ifdef CONFIG_PM_DEVICE
 
 static int qdec_nrfx_pm_set_state(struct qdec_nrfx_data *data,
-				  enum pm_device_state new_state)
+				  enum pm_device_state state)
 {
-	enum pm_device_state curr_state;
-
-	(void)pm_device_state_get(dev, &curr_state);
-
-	if (curr_state == new_state) {
-		/* leave unchanged */
-		return 0;
-	}
-
-	if (curr_state == PM_DEVICE_STATE_ACTIVE) {
+	if (state == PM_DEVICE_STATE_ACTIVE) {
+		qdec_nrfx_gpio_ctrl(true);
+		nrfx_qdec_enable();
+	} else if (state == PM_DEVICE_STATE_OFF) {
+		/* device must be uninitialized */
+		nrfx_qdec_uninit();
+	} else {
 		/* device must be suspended */
 		nrfx_qdec_disable();
 		qdec_nrfx_gpio_ctrl(false);
-	}
-
-	if (new_state == PM_DEVICE_STATE_OFF) {
-		/* device must be uninitialized */
-		nrfx_qdec_uninit();
-	}
-
-	if (new_state == PM_DEVICE_STATE_ACTIVE) {
-		qdec_nrfx_gpio_ctrl(true);
-		nrfx_qdec_enable();
 	}
 
 	return 0;

--- a/drivers/sensor/qdec_nrfx/qdec_nrfx.c
+++ b/drivers/sensor/qdec_nrfx/qdec_nrfx.c
@@ -240,7 +240,6 @@ static int qdec_nrfx_pm_set_state(struct qdec_nrfx_data *data,
 }
 
 static int qdec_nrfx_pm_control(const struct device *dev,
-				uint32_t ctrl_command,
 				enum pm_device_state *state)
 {
 	struct qdec_nrfx_data *data = &qdec_nrfx_data;

--- a/drivers/sensor/qdec_nrfx/qdec_nrfx.c
+++ b/drivers/sensor/qdec_nrfx/qdec_nrfx.c
@@ -207,38 +207,29 @@ static int qdec_nrfx_init(const struct device *dev)
 }
 
 #ifdef CONFIG_PM_DEVICE
-
-static int qdec_nrfx_pm_set_state(struct qdec_nrfx_data *data,
-				  enum pm_device_state state)
+static int qdec_nrfx_pm_control(struct qdec_nrfx_data *data,
+				enum pm_device_state state)
 {
-	if (state == PM_DEVICE_STATE_ACTIVE) {
+	switch (state) {
+	case PM_DEVICE_STATE_ACTIVE:
 		qdec_nrfx_gpio_ctrl(true);
 		nrfx_qdec_enable();
-	} else if (state == PM_DEVICE_STATE_OFF) {
+		break;
+	case PM_DEVICE_STATE_OFF:
 		/* device must be uninitialized */
 		nrfx_qdec_uninit();
-	} else {
+		break;
+	case PM_DEVICE_STATE_SUSPENDED:
 		/* device must be suspended */
 		nrfx_qdec_disable();
 		qdec_nrfx_gpio_ctrl(false);
+		break;
+	default:
+		return -ENOTSUP;
 	}
 
 	return 0;
 }
-
-static int qdec_nrfx_pm_control(const struct device *dev,
-				enum pm_device_state state)
-{
-	struct qdec_nrfx_data *data = &qdec_nrfx_data;
-	int err;
-
-	LOG_DBG("");
-
-	err = qdec_nrfx_pm_set_state(data, state);
-
-	return err;
-}
-
 #endif /* CONFIG_PM_DEVICE */
 
 

--- a/drivers/sensor/qdec_nrfx/qdec_nrfx.c
+++ b/drivers/sensor/qdec_nrfx/qdec_nrfx.c
@@ -208,18 +208,18 @@ static int qdec_nrfx_init(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 static int qdec_nrfx_pm_control(struct qdec_nrfx_data *data,
-				enum pm_device_state state)
+				enum pm_device_action action)
 {
-	switch (state) {
-	case PM_DEVICE_STATE_ACTIVE:
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
 		qdec_nrfx_gpio_ctrl(true);
 		nrfx_qdec_enable();
 		break;
-	case PM_DEVICE_STATE_OFF:
+	case PM_DEVICE_ACTION_TURN_OFF:
 		/* device must be uninitialized */
 		nrfx_qdec_uninit();
 		break;
-	case PM_DEVICE_STATE_SUSPENDED:
+	case PM_DEVICE_ACTION_SUSPEND:
 		/* device must be suspended */
 		nrfx_qdec_disable();
 		qdec_nrfx_gpio_ctrl(false);

--- a/drivers/sensor/qdec_nrfx/qdec_nrfx.c
+++ b/drivers/sensor/qdec_nrfx/qdec_nrfx.c
@@ -240,14 +240,14 @@ static int qdec_nrfx_pm_set_state(struct qdec_nrfx_data *data,
 }
 
 static int qdec_nrfx_pm_control(const struct device *dev,
-				enum pm_device_state *state)
+				enum pm_device_state state)
 {
 	struct qdec_nrfx_data *data = &qdec_nrfx_data;
 	int err;
 
 	LOG_DBG("");
 
-	err = qdec_nrfx_pm_set_state(data, *state);
+	err = qdec_nrfx_pm_set_state(data, state);
 
 	return err;
 }

--- a/drivers/sensor/sgp40/sgp40.c
+++ b/drivers/sensor/sgp40/sgp40.c
@@ -189,11 +189,12 @@ static int sgp40_channel_get(const struct device *dev,
 static int sgp40_set_power_state(const struct device *dev,
 				  enum pm_device_state power_state)
 {
-	struct sgp40_data *data = dev->data;
 	uint16_t cmd;
 	int rc;
+	enum pm_device_state state;
 
-	if (data->pm_state == power_state) {
+	(void)pm_device_state_get(dev, &state);
+	if (state == power_state) {
 		LOG_DBG("Device already in requested PM_STATE.");
 		return 0;
 	}
@@ -214,18 +215,6 @@ static int sgp40_set_power_state(const struct device *dev,
 		return rc;
 	}
 
-	data->pm_state = power_state;
-
-	return 0;
-}
-
-static uint32_t sgp40_get_power_state(const struct device *dev,
-		enum pm_device_state *state)
-{
-	struct sgp40_data *data = dev->data;
-
-	*state = data->pm_state;
-
 	return 0;
 }
 
@@ -237,8 +226,6 @@ static int sgp40_pm_ctrl(const struct device *dev,
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
 		rc = sgp40_set_power_state(dev, *state);
-	} else if (ctrl_command == PM_DEVICE_STATE_GET) {
-		rc = sgp40_get_power_state(dev, state);
 	}
 
 	return rc;

--- a/drivers/sensor/sgp40/sgp40.c
+++ b/drivers/sensor/sgp40/sgp40.c
@@ -186,16 +186,16 @@ static int sgp40_channel_get(const struct device *dev,
 
 
 #ifdef CONFIG_PM_DEVICE
-static int sgp40_pm_ctrl(const struct device *dev, enum pm_device_state state)
+static int sgp40_pm_ctrl(const struct device *dev, enum pm_device_action action)
 {
 	uint16_t cmd;
 
-	switch (state) {
-	case PM_DEVICE_STATE_ACTIVE:
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
 		/* activate the hotplate by sending a measure command */
 		cmd = SGP40_CMD_MEASURE_RAW;
 		break;
-	case PM_DEVICE_STATE_SUSPENDED:
+	case PM_DEVICE_ACTION_SUSPEND:
 		cmd = SGP40_CMD_HEATER_OFF;
 		break;
 	default:

--- a/drivers/sensor/sgp40/sgp40.c
+++ b/drivers/sensor/sgp40/sgp40.c
@@ -218,9 +218,9 @@ static int sgp40_set_power_state(const struct device *dev,
 	return 0;
 }
 
-static int sgp40_pm_ctrl(const struct device *dev, enum pm_device_state *state)
+static int sgp40_pm_ctrl(const struct device *dev, enum pm_device_state state)
 {
-	return sgp40_set_power_state(dev, *state);
+	return sgp40_set_power_state(dev, state);
 }
 #endif /* CONFIG_PM_DEVICE */
 

--- a/drivers/sensor/sgp40/sgp40.c
+++ b/drivers/sensor/sgp40/sgp40.c
@@ -186,34 +186,23 @@ static int sgp40_channel_get(const struct device *dev,
 
 
 #ifdef CONFIG_PM_DEVICE
-static int sgp40_set_power_state(const struct device *dev,
-				  enum pm_device_state power_state)
+static int sgp40_pm_ctrl(const struct device *dev, enum pm_device_state state)
 {
 	uint16_t cmd;
-	int rc;
 
-	if (power_state == PM_DEVICE_STATE_ACTIVE) {
+	switch (state) {
+	case PM_DEVICE_STATE_ACTIVE:
 		/* activate the hotplate by sending a measure command */
 		cmd = SGP40_CMD_MEASURE_RAW;
-	} else if (power_state == PM_DEVICE_STATE_SUSPENDED) {
+		break;
+	case PM_DEVICE_STATE_SUSPENDED:
 		cmd = SGP40_CMD_HEATER_OFF;
-	} else {
-		LOG_DBG("Power state not implemented.");
+		break;
+	default:
 		return -ENOTSUP;
 	}
 
-	rc = sgp40_write_command(dev, cmd);
-	if (rc < 0) {
-		LOG_ERR("Failed to set power state.");
-		return rc;
-	}
-
-	return 0;
-}
-
-static int sgp40_pm_ctrl(const struct device *dev, enum pm_device_state state)
-{
-	return sgp40_set_power_state(dev, state);
+	return sgp40_write_command(dev, cmd);
 }
 #endif /* CONFIG_PM_DEVICE */
 

--- a/drivers/sensor/sgp40/sgp40.c
+++ b/drivers/sensor/sgp40/sgp40.c
@@ -222,13 +222,7 @@ static int sgp40_pm_ctrl(const struct device *dev,
 	uint32_t ctrl_command,
 	enum pm_device_state *state)
 {
-	int rc = 0;
-
-	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		rc = sgp40_set_power_state(dev, *state);
-	}
-
-	return rc;
+	return sgp40_set_power_state(dev, *state);
 }
 #endif /* CONFIG_PM_DEVICE */
 

--- a/drivers/sensor/sgp40/sgp40.c
+++ b/drivers/sensor/sgp40/sgp40.c
@@ -191,13 +191,6 @@ static int sgp40_set_power_state(const struct device *dev,
 {
 	uint16_t cmd;
 	int rc;
-	enum pm_device_state state;
-
-	(void)pm_device_state_get(dev, &state);
-	if (state == power_state) {
-		LOG_DBG("Device already in requested PM_STATE.");
-		return 0;
-	}
 
 	if (power_state == PM_DEVICE_STATE_ACTIVE) {
 		/* activate the hotplate by sending a measure command */

--- a/drivers/sensor/sgp40/sgp40.c
+++ b/drivers/sensor/sgp40/sgp40.c
@@ -218,9 +218,7 @@ static int sgp40_set_power_state(const struct device *dev,
 	return 0;
 }
 
-static int sgp40_pm_ctrl(const struct device *dev,
-	uint32_t ctrl_command,
-	enum pm_device_state *state)
+static int sgp40_pm_ctrl(const struct device *dev, enum pm_device_state *state)
 {
 	return sgp40_set_power_state(dev, *state);
 }

--- a/drivers/sensor/sgp40/sgp40.c
+++ b/drivers/sensor/sgp40/sgp40.c
@@ -195,7 +195,7 @@ static int sgp40_set_power_state(const struct device *dev,
 	if (power_state == PM_DEVICE_STATE_ACTIVE) {
 		/* activate the hotplate by sending a measure command */
 		cmd = SGP40_CMD_MEASURE_RAW;
-	} else if (power_state == PM_DEVICE_STATE_SUSPEND) {
+	} else if (power_state == PM_DEVICE_STATE_SUSPENDED) {
 		cmd = SGP40_CMD_HEATER_OFF;
 	} else {
 		LOG_DBG("Power state not implemented.");

--- a/drivers/sensor/sgp40/sgp40.h
+++ b/drivers/sensor/sgp40/sgp40.h
@@ -47,10 +47,6 @@ struct sgp40_data {
 	uint16_t raw_sample;
 	int8_t rh_param[3];
 	int8_t t_param[3];
-
-#ifdef CONFIG_PM_DEVICE
-	enum pm_device_state pm_state;
-#endif
 };
 
 #endif /* ZEPHYR_DRIVERS_SENSOR_SGP40_SGP40_H_ */

--- a/drivers/sensor/vcnl4040/vcnl4040.c
+++ b/drivers/sensor/vcnl4040/vcnl4040.c
@@ -219,7 +219,7 @@ static int vcnl4040_ambient_setup(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 static int vcnl4040_device_ctrl(const struct device *dev,
-				enum pm_device_state state)
+				enum pm_device_action action)
 {
 	int ret = 0;
 	uint16_t ps_conf;
@@ -234,8 +234,8 @@ static int vcnl4040_device_ctrl(const struct device *dev,
 	if (ret < 0)
 		return ret;
 #endif
-	switch (state) {
-	case PM_DEVICE_STATE_ACTIVE:
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
 		/* Clear proximity shutdown */
 		ps_conf &= ~VCNL4040_PS_SD_MASK;
 
@@ -253,7 +253,7 @@ static int vcnl4040_device_ctrl(const struct device *dev,
 			return ret;
 #endif
 		break;
-	case PM_DEVICE_STATE_SUSPENDED:
+	case PM_DEVICE_ACTION_SUSPEND:
 		/* Set proximity shutdown bit 0 */
 		ps_conf |= VCNL4040_PS_SD_MASK;
 

--- a/drivers/sensor/vcnl4040/vcnl4040.c
+++ b/drivers/sensor/vcnl4040/vcnl4040.c
@@ -234,7 +234,8 @@ static int vcnl4040_device_ctrl(const struct device *dev,
 	if (ret < 0)
 		return ret;
 #endif
-	if (state == PM_DEVICE_STATE_ACTIVE) {
+	switch (state) {
+	case PM_DEVICE_STATE_ACTIVE:
 		/* Clear proximity shutdown */
 		ps_conf &= ~VCNL4040_PS_SD_MASK;
 
@@ -251,7 +252,8 @@ static int vcnl4040_device_ctrl(const struct device *dev,
 		if (ret < 0)
 			return ret;
 #endif
-	} else {
+		break;
+	case PM_DEVICE_STATE_SUSPENDED:
 		/* Set proximity shutdown bit 0 */
 		ps_conf |= VCNL4040_PS_SD_MASK;
 
@@ -268,6 +270,9 @@ static int vcnl4040_device_ctrl(const struct device *dev,
 		if (ret < 0)
 			return ret;
 #endif
+		break;
+	default:
+		return -ENOTSUP;
 	}
 
 	return ret;

--- a/drivers/sensor/vcnl4040/vcnl4040.c
+++ b/drivers/sensor/vcnl4040/vcnl4040.c
@@ -219,7 +219,7 @@ static int vcnl4040_ambient_setup(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 static int vcnl4040_device_ctrl(const struct device *dev,
-				enum pm_device_state *state)
+				enum pm_device_state state)
 {
 	int ret = 0;
 	uint16_t ps_conf;
@@ -234,7 +234,7 @@ static int vcnl4040_device_ctrl(const struct device *dev,
 	if (ret < 0)
 		return ret;
 #endif
-	if (*state == PM_DEVICE_STATE_ACTIVE) {
+	if (state == PM_DEVICE_STATE_ACTIVE) {
 		/* Clear proximity shutdown */
 		ps_conf &= ~VCNL4040_PS_SD_MASK;
 

--- a/drivers/sensor/vcnl4040/vcnl4040.c
+++ b/drivers/sensor/vcnl4040/vcnl4040.c
@@ -219,7 +219,6 @@ static int vcnl4040_ambient_setup(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 static int vcnl4040_device_ctrl(const struct device *dev,
-				uint32_t ctrl_command,
 				enum pm_device_state *state)
 {
 	int ret = 0;

--- a/drivers/sensor/vcnl4040/vcnl4040.c
+++ b/drivers/sensor/vcnl4040/vcnl4040.c
@@ -273,8 +273,6 @@ static int vcnl4040_device_ctrl(const struct device *dev,
 #endif
 		}
 
-	} else if (ctrl_command == PM_DEVICE_STATE_GET) {
-		*state = PM_DEVICE_STATE_ACTIVE;
 	}
 
 	return ret;

--- a/drivers/serial/uart_cc13xx_cc26xx.c
+++ b/drivers/serial/uart_cc13xx_cc26xx.c
@@ -441,14 +441,14 @@ static int uart_cc13xx_cc26xx_set_power_state(const struct device *dev,
 }
 
 static int uart_cc13xx_cc26xx_pm_control(const struct device *dev,
-					 enum pm_device_state *state)
+					 enum pm_device_state state)
 {
 	int ret = 0;
 	enum pm_device_state curr_state;
 
 	(void)pm_device_state_get(dev, &curr_state);
-	if (*state != curr_state) {
-		ret = uart_cc13xx_cc26xx_set_power_state(dev, *state);
+	if (state != curr_state) {
+		ret = uart_cc13xx_cc26xx_set_power_state(dev, state);
 	}
 
 	return ret;

--- a/drivers/serial/uart_cc13xx_cc26xx.c
+++ b/drivers/serial/uart_cc13xx_cc26xx.c
@@ -441,7 +441,6 @@ static int uart_cc13xx_cc26xx_set_power_state(const struct device *dev,
 }
 
 static int uart_cc13xx_cc26xx_pm_control(const struct device *dev,
-					 uint32_t ctrl_command,
 					 enum pm_device_state *state)
 {
 	int ret = 0;

--- a/drivers/serial/uart_cc13xx_cc26xx.c
+++ b/drivers/serial/uart_cc13xx_cc26xx.c
@@ -398,12 +398,12 @@ static int postNotifyFxn(unsigned int eventType, uintptr_t eventArg,
 
 #ifdef CONFIG_PM_DEVICE
 static int uart_cc13xx_cc26xx_pm_control(const struct device *dev,
-					 enum pm_device_state state)
+					 enum pm_device_action action)
 {
 	int ret = 0;
 
-	switch (state) {
-	case PM_DEVICE_STATE_ACTIVE:
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
 		if (get_dev_conf(dev)->regs == DT_INST_REG_ADDR(0)) {
 			Power_setDependency(PowerCC26XX_PERIPH_UART0);
 		} else {
@@ -413,7 +413,7 @@ static int uart_cc13xx_cc26xx_pm_control(const struct device *dev,
 		ret = uart_cc13xx_cc26xx_configure(dev,
 			&get_dev_data(dev)->uart_config);
 		break;
-	case PM_DEVICE_STATE_SUSPENDED:
+	case PM_DEVICE_ACTION_SUSPEND:
 		UARTDisable(get_dev_conf(dev)->regs);
 		/*
 		 * Release power dependency - i.e. potentially power

--- a/drivers/serial/uart_cc13xx_cc26xx.c
+++ b/drivers/serial/uart_cc13xx_cc26xx.c
@@ -445,14 +445,11 @@ static int uart_cc13xx_cc26xx_pm_control(const struct device *dev,
 					 enum pm_device_state *state)
 {
 	int ret = 0;
+	enum pm_device_state curr_state;
 
-	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		enum pm_device_state curr_state;
-
-		(void)pm_device_state_get(dev, &curr_state);
-		if (*state != curr_state) {
-			ret = uart_cc13xx_cc26xx_set_power_state(dev, *state);
-		}
+	(void)pm_device_state_get(dev, &curr_state);
+	if (*state != curr_state) {
+		ret = uart_cc13xx_cc26xx_set_power_state(dev, *state);
 	}
 
 	return ret;

--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -442,8 +442,7 @@ static inline int uart_npcx_set_power_state(const struct device *dev,
 					    enum pm_device_state next_state)
 {
 	/* If next device power state is LOW or SUSPEND power state */
-	if (next_state == PM_DEVICE_STATE_LOW_POWER ||
-	    next_state == PM_DEVICE_STATE_SUSPEND) {
+	if (next_state == PM_DEVICE_STATE_SUSPEND) {
 		/*
 		 * If uart device is busy with transmitting, the driver will
 		 * stay in while loop and wait for the transaction is completed.

--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -40,9 +40,6 @@ struct uart_npcx_data {
 	uart_irq_callback_user_data_t user_cb;
 	void *user_data;
 #endif
-#ifdef CONFIG_PM_DEVICE
-	enum pm_device_state pm_state;
-#endif
 };
 
 /* Driver convenience defines */
@@ -441,20 +438,9 @@ static inline bool uart_npcx_device_is_transmitting(const struct device *dev)
 	return 0;
 }
 
-static inline int uart_npcx_get_power_state(const struct device *dev,
-					    enum pm_device_state *state)
-{
-	const struct uart_npcx_data *const data = DRV_DATA(dev);
-
-	*state = data->pm_state;
-	return 0;
-}
-
 static inline int uart_npcx_set_power_state(const struct device *dev,
 					    enum pm_device_state next_state)
 {
-	struct uart_npcx_data *const data = DRV_DATA(dev);
-
 	/* If next device power state is LOW or SUSPEND power state */
 	if (next_state == PM_DEVICE_STATE_LOW_POWER ||
 	    next_state == PM_DEVICE_STATE_SUSPEND) {
@@ -467,7 +453,6 @@ static inline int uart_npcx_set_power_state(const struct device *dev,
 		}
 	}
 
-	data->pm_state = next_state;
 	return 0;
 }
 
@@ -480,9 +465,6 @@ static int uart_npcx_pm_control(const struct device *dev, uint32_t ctrl_command,
 	switch (ctrl_command) {
 	case PM_DEVICE_STATE_SET:
 		ret = uart_npcx_set_power_state(dev, *state);
-		break;
-	case PM_DEVICE_STATE_GET:
-		ret = uart_npcx_get_power_state(dev, state);
 		break;
 	default:
 		ret = -EINVAL;

--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -457,8 +457,8 @@ static inline int uart_npcx_set_power_state(const struct device *dev,
 }
 
 /* Implements the device power management control functionality */
-static int uart_npcx_pm_control(const struct device *dev, uint32_t ctrl_command,
-				 enum pm_device_state *state)
+static int uart_npcx_pm_control(const struct device *dev,
+				enum pm_device_state *state)
 {
 	return uart_npcx_set_power_state(dev, *state);
 }

--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -460,17 +460,7 @@ static inline int uart_npcx_set_power_state(const struct device *dev,
 static int uart_npcx_pm_control(const struct device *dev, uint32_t ctrl_command,
 				 enum pm_device_state *state)
 {
-	int ret = 0;
-
-	switch (ctrl_command) {
-	case PM_DEVICE_STATE_SET:
-		ret = uart_npcx_set_power_state(dev, *state);
-		break;
-	default:
-		ret = -EINVAL;
-	}
-
-	return ret;
+	return uart_npcx_set_power_state(dev, *state);
 }
 #endif /* CONFIG_PM_DEVICE */
 

--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -439,11 +439,11 @@ static inline bool uart_npcx_device_is_transmitting(const struct device *dev)
 }
 
 static inline int uart_npcx_pm_control(const struct device *dev,
-				       enum pm_device_state state)
+				       enum pm_device_action action)
 {
 	/* If next device power state is SUSPEND power state */
-	switch (state) {
-	case PM_DEVICE_STATE_SUSPENDED:
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
 		/*
 		 * If uart device is busy with transmitting, the driver will
 		 * stay in while loop and wait for the transaction is completed.

--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -442,7 +442,7 @@ static inline int uart_npcx_set_power_state(const struct device *dev,
 					    enum pm_device_state next_state)
 {
 	/* If next device power state is LOW or SUSPEND power state */
-	if (next_state == PM_DEVICE_STATE_SUSPEND) {
+	if (next_state == PM_DEVICE_STATE_SUSPENDED) {
 		/*
 		 * If uart device is busy with transmitting, the driver will
 		 * stay in while loop and wait for the transaction is completed.

--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -458,9 +458,9 @@ static inline int uart_npcx_set_power_state(const struct device *dev,
 
 /* Implements the device power management control functionality */
 static int uart_npcx_pm_control(const struct device *dev,
-				enum pm_device_state *state)
+				enum pm_device_state state)
 {
-	return uart_npcx_set_power_state(dev, *state);
+	return uart_npcx_set_power_state(dev, state);
 }
 #endif /* CONFIG_PM_DEVICE */
 

--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -438,11 +438,12 @@ static inline bool uart_npcx_device_is_transmitting(const struct device *dev)
 	return 0;
 }
 
-static inline int uart_npcx_set_power_state(const struct device *dev,
-					    enum pm_device_state next_state)
+static inline int uart_npcx_pm_control(const struct device *dev,
+				       enum pm_device_state state)
 {
-	/* If next device power state is LOW or SUSPEND power state */
-	if (next_state == PM_DEVICE_STATE_SUSPENDED) {
+	/* If next device power state is SUSPEND power state */
+	switch (state) {
+	case PM_DEVICE_STATE_SUSPENDED:
 		/*
 		 * If uart device is busy with transmitting, the driver will
 		 * stay in while loop and wait for the transaction is completed.
@@ -450,16 +451,12 @@ static inline int uart_npcx_set_power_state(const struct device *dev,
 		while (uart_npcx_device_is_transmitting(dev)) {
 			continue;
 		}
+		break;
+	default:
+		return -ENOTSUP;
 	}
 
 	return 0;
-}
-
-/* Implements the device power management control functionality */
-static int uart_npcx_pm_control(const struct device *dev,
-				enum pm_device_state state)
-{
-	return uart_npcx_set_power_state(dev, state);
 }
 #endif /* CONFIG_PM_DEVICE */
 

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -1139,26 +1139,25 @@ static void uart_nrfx_pins_enable(const struct device *dev, bool enable)
 	}
 }
 
-static void uart_nrfx_set_power_state(const struct device *dev,
-				      enum pm_device_state state)
+static int uart_nrfx_pm_control(const struct device *dev,
+				enum pm_device_state state)
 {
-	if (state == PM_DEVICE_STATE_ACTIVE) {
+	switch (state) {
+	case PM_DEVICE_STATE_ACTIVE:
 		uart_nrfx_pins_enable(dev, true);
 		nrf_uart_enable(uart0_addr);
 		if (RX_PIN_USED) {
 			nrf_uart_task_trigger(uart0_addr,
 					      NRF_UART_TASK_STARTRX);
 		}
-	} else {
+		break;
+	case PM_DEVICE_STATE_SUSPENDED:
 		nrf_uart_disable(uart0_addr);
 		uart_nrfx_pins_enable(dev, false);
+		break;
+	default:
+		return -ENOTSUP;
 	}
-}
-
-static int uart_nrfx_pm_control(const struct device *dev,
-				enum pm_device_state state)
-{
-	uart_nrfx_set_power_state(dev, state);
 
 	return 0;
 }

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -1140,10 +1140,10 @@ static void uart_nrfx_pins_enable(const struct device *dev, bool enable)
 }
 
 static int uart_nrfx_pm_control(const struct device *dev,
-				enum pm_device_state state)
+				enum pm_device_action action)
 {
-	switch (state) {
-	case PM_DEVICE_STATE_ACTIVE:
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
 		uart_nrfx_pins_enable(dev, true);
 		nrf_uart_enable(uart0_addr);
 		if (RX_PIN_USED) {
@@ -1151,7 +1151,7 @@ static int uart_nrfx_pm_control(const struct device *dev,
 					      NRF_UART_TASK_STARTRX);
 		}
 		break;
-	case PM_DEVICE_STATE_SUSPENDED:
+	case PM_DEVICE_ACTION_SUSPEND:
 		nrf_uart_disable(uart0_addr);
 		uart_nrfx_pins_enable(dev, false);
 		break;

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -1159,7 +1159,6 @@ static void uart_nrfx_set_power_state(const struct device *dev,
 }
 
 static int uart_nrfx_pm_control(const struct device *dev,
-				uint32_t ctrl_command,
 				enum pm_device_state *state)
 {
 	enum pm_device_state current_state;

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -1162,18 +1162,13 @@ static int uart_nrfx_pm_control(const struct device *dev,
 				uint32_t ctrl_command,
 				enum pm_device_state *state)
 {
-	static enum pm_device_state current_state = PM_DEVICE_STATE_ACTIVE;
-
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		enum pm_device_state new_state = *state;
+		enum pm_device_state current_state;
 
-		if (new_state != current_state) {
-			uart_nrfx_set_power_state(dev, new_state);
-			current_state = new_state;
+		(void)pm_device_state_get(dev, &current_state);
+		if (*state != current_state) {
+			uart_nrfx_set_power_state(dev, *state);
 		}
-	} else {
-		__ASSERT_NO_MSG(ctrl_command == PM_DEVICE_STATE_GET);
-		*state = current_state;
 	}
 
 	return 0;

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -1162,13 +1162,11 @@ static int uart_nrfx_pm_control(const struct device *dev,
 				uint32_t ctrl_command,
 				enum pm_device_state *state)
 {
-	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		enum pm_device_state current_state;
+	enum pm_device_state current_state;
 
-		(void)pm_device_state_get(dev, &current_state);
-		if (*state != current_state) {
-			uart_nrfx_set_power_state(dev, *state);
-		}
+	(void)pm_device_state_get(dev, &current_state);
+	if (*state != current_state) {
+		uart_nrfx_set_power_state(dev, *state);
 	}
 
 	return 0;

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -1140,9 +1140,9 @@ static void uart_nrfx_pins_enable(const struct device *dev, bool enable)
 }
 
 static void uart_nrfx_set_power_state(const struct device *dev,
-				      enum pm_device_state new_state)
+				      enum pm_device_state state)
 {
-	if (new_state == PM_DEVICE_STATE_ACTIVE) {
+	if (state == PM_DEVICE_STATE_ACTIVE) {
 		uart_nrfx_pins_enable(dev, true);
 		nrf_uart_enable(uart0_addr);
 		if (RX_PIN_USED) {
@@ -1150,9 +1150,6 @@ static void uart_nrfx_set_power_state(const struct device *dev,
 					      NRF_UART_TASK_STARTRX);
 		}
 	} else {
-		__ASSERT_NO_MSG(new_state == PM_DEVICE_STATE_LOW_POWER ||
-				new_state == PM_DEVICE_STATE_SUSPEND ||
-				new_state == PM_DEVICE_STATE_OFF);
 		nrf_uart_disable(uart0_addr);
 		uart_nrfx_pins_enable(dev, false);
 	}
@@ -1161,12 +1158,7 @@ static void uart_nrfx_set_power_state(const struct device *dev,
 static int uart_nrfx_pm_control(const struct device *dev,
 				enum pm_device_state state)
 {
-	enum pm_device_state current_state;
-
-	(void)pm_device_state_get(dev, &current_state);
-	if (state != current_state) {
-		uart_nrfx_set_power_state(dev, state);
-	}
+	uart_nrfx_set_power_state(dev, state);
 
 	return 0;
 }

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -1159,13 +1159,13 @@ static void uart_nrfx_set_power_state(const struct device *dev,
 }
 
 static int uart_nrfx_pm_control(const struct device *dev,
-				enum pm_device_state *state)
+				enum pm_device_state state)
 {
 	enum pm_device_state current_state;
 
 	(void)pm_device_state_get(dev, &current_state);
-	if (*state != current_state) {
-		uart_nrfx_set_power_state(dev, *state);
+	if (state != current_state) {
+		uart_nrfx_set_power_state(dev, state);
 	}
 
 	return 0;

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1927,13 +1927,9 @@ static int uarte_nrfx_pm_control(const struct device *dev,
 {
 	enum pm_device_state curr_state;
 
-	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		enum pm_device_state curr_state;
-
-		(void)pm_device_state_get(dev, &curr_state);
-		if (*state != curr_state) {
-			uarte_nrfx_set_power_state(dev, *state);
-		}
+	(void)pm_device_state_get(dev, &curr_state);
+	if (*state != curr_state) {
+		uarte_nrfx_set_power_state(dev, *state);
 	}
 
 	return 0;

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1832,14 +1832,14 @@ static void wait_for_tx_stopped(const struct device *dev)
 
 
 static void uarte_nrfx_set_power_state(const struct device *dev,
-				       enum pm_device_state new_state)
+				       enum pm_device_state state)
 {
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
 #if defined(CONFIG_UART_ASYNC_API) || defined(UARTE_INTERRUPT_DRIVEN)
 	struct uarte_nrfx_data *data = get_dev_data(dev);
 #endif
 
-	if (new_state == PM_DEVICE_STATE_ACTIVE) {
+	if (state == PM_DEVICE_STATE_ACTIVE) {
 		uarte_nrfx_pins_enable(dev, true);
 		nrf_uarte_enable(uarte);
 
@@ -1864,20 +1864,6 @@ static void uarte_nrfx_set_power_state(const struct device *dev,
 #endif
 		}
 	} else {
-		enum pm_device_state state;
-
-		__ASSERT_NO_MSG(new_state == PM_DEVICE_STATE_LOW_POWER ||
-				new_state == PM_DEVICE_STATE_SUSPEND ||
-				new_state == PM_DEVICE_STATE_OFF);
-
-		/* if pm is already not active, driver will stay indefinitely
-		 * in while loop waiting for event NRF_UARTE_EVENT_RXTO
-		 */
-		(void)pm_device_state_get(dev, &state);
-		if (state != PM_DEVICE_STATE_ACTIVE) {
-			return;
-		}
-
 		/* Disabling UART requires stopping RX, but stop RX event is
 		 * only sent after each RX if async UART API is used.
 		 */
@@ -1924,12 +1910,7 @@ static void uarte_nrfx_set_power_state(const struct device *dev,
 static int uarte_nrfx_pm_control(const struct device *dev,
 				 enum pm_device_state state)
 {
-	enum pm_device_state curr_state;
-
-	(void)pm_device_state_get(dev, &curr_state);
-	if (state != curr_state) {
-		uarte_nrfx_set_power_state(dev, state);
-	}
+	uarte_nrfx_set_power_state(dev, state);
 
 	return 0;
 }

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1832,15 +1832,15 @@ static void wait_for_tx_stopped(const struct device *dev)
 
 
 static int uarte_nrfx_pm_control(const struct device *dev,
-				 enum pm_device_state state)
+				 enum pm_device_action action)
 {
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
 #if defined(CONFIG_UART_ASYNC_API) || defined(UARTE_INTERRUPT_DRIVEN)
 	struct uarte_nrfx_data *data = get_dev_data(dev);
 #endif
 
-	switch (state) {
-	case PM_DEVICE_STATE_ACTIVE:
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
 		uarte_nrfx_pins_enable(dev, true);
 		nrf_uarte_enable(uarte);
 
@@ -1865,7 +1865,7 @@ static int uarte_nrfx_pm_control(const struct device *dev,
 #endif
 		}
 		break;
-	case PM_DEVICE_STATE_SUSPENDED:
+	case PM_DEVICE_ACTION_SUSPEND:
 		/* Disabling UART requires stopping RX, but stop RX event is
 		 * only sent after each RX if async UART API is used.
 		 */

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1922,7 +1922,6 @@ static void uarte_nrfx_set_power_state(const struct device *dev,
 }
 
 static int uarte_nrfx_pm_control(const struct device *dev,
-				 uint32_t ctrl_command,
 				 enum pm_device_state *state)
 {
 	enum pm_device_state curr_state;

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1922,13 +1922,13 @@ static void uarte_nrfx_set_power_state(const struct device *dev,
 }
 
 static int uarte_nrfx_pm_control(const struct device *dev,
-				 enum pm_device_state *state)
+				 enum pm_device_state state)
 {
 	enum pm_device_state curr_state;
 
 	(void)pm_device_state_get(dev, &curr_state);
-	if (*state != curr_state) {
-		uarte_nrfx_set_power_state(dev, *state);
+	if (state != curr_state) {
+		uarte_nrfx_set_power_state(dev, state);
 	}
 
 	return 0;

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1423,13 +1423,13 @@ static int uart_stm32_init(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 static int uart_stm32_pm_control(const struct device *dev,
-				 enum pm_device_state state)
+				 enum pm_device_action action)
 {
 	USART_TypeDef *UartInstance = UART_STRUCT(dev);
 
 	/* setting a low power mode */
-	switch (state) {
-	case PM_DEVICE_STATE_SUSPENDED:
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
 #ifdef USART_ISR_BUSY
 		/* Make sure that no USART transfer is on-going */
 		while (LL_USART_IsActiveFlag_BUSY(UartInstance) == 1) {

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1463,13 +1463,11 @@ static int uart_stm32_pm_control(const struct device *dev,
 					 uint32_t ctrl_command,
 					 enum pm_device_state *state)
 {
-	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		enum pm_device_state curr_state;
+	enum pm_device_state curr_state;
 
-		(void)pm_device_state_get(dev, &curr_state);
-		if (*state != curr_state) {
-			uart_stm32_set_power_state(dev, *state);
-		}
+	(void)pm_device_state_get(dev, &curr_state);
+	if (*state != curr_state) {
+		uart_stm32_set_power_state(dev, *state);
 	}
 
 	return 0;

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1423,12 +1423,12 @@ static int uart_stm32_init(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 static int uart_stm32_set_power_state(const struct device *dev,
-					      enum pm_device_state new_state)
+				      enum pm_device_state state)
 {
 	USART_TypeDef *UartInstance = UART_STRUCT(dev);
 
 	/* setting a low power mode */
-	if (new_state != PM_DEVICE_STATE_ACTIVE) {
+	if (state != PM_DEVICE_STATE_ACTIVE) {
 #ifdef USART_ISR_BUSY
 		/* Make sure that no USART transfer is on-going */
 		while (LL_USART_IsActiveFlag_BUSY(UartInstance) == 1) {
@@ -1462,12 +1462,7 @@ static int uart_stm32_set_power_state(const struct device *dev,
 static int uart_stm32_pm_control(const struct device *dev,
 				 enum pm_device_state state)
 {
-	enum pm_device_state curr_state;
-
-	(void)pm_device_state_get(dev, &curr_state);
-	if (state != curr_state) {
-		uart_stm32_set_power_state(dev, state);
-	}
+	uart_stm32_set_power_state(dev, state);
 
 	return 0;
 }

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1460,8 +1460,7 @@ static int uart_stm32_set_power_state(const struct device *dev,
  * @return 0
  */
 static int uart_stm32_pm_control(const struct device *dev,
-					 uint32_t ctrl_command,
-					 enum pm_device_state *state)
+				 enum pm_device_state *state)
 {
 	enum pm_device_state curr_state;
 

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1460,13 +1460,13 @@ static int uart_stm32_set_power_state(const struct device *dev,
  * @return 0
  */
 static int uart_stm32_pm_control(const struct device *dev,
-				 enum pm_device_state *state)
+				 enum pm_device_state state)
 {
 	enum pm_device_state curr_state;
 
 	(void)pm_device_state_get(dev, &curr_state);
-	if (*state != curr_state) {
-		uart_stm32_set_power_state(dev, *state);
+	if (state != curr_state) {
+		uart_stm32_set_power_state(dev, state);
 	}
 
 	return 0;

--- a/drivers/serial/uart_stm32.h
+++ b/drivers/serial/uart_stm32.h
@@ -67,9 +67,6 @@ struct uart_stm32_data {
 	uint8_t *rx_next_buffer;
 	size_t rx_next_buffer_len;
 #endif
-#ifdef CONFIG_PM_DEVICE
-	enum pm_device_state pm_state;
-#endif
 };
 
 #endif	/* ZEPHYR_DRIVERS_SERIAL_UART_STM32_H_ */

--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -252,14 +252,11 @@ static int spi_cc13xx_cc26xx_pm_control(const struct device *dev,
 					enum pm_device_state *state)
 {
 	int ret = 0;
+	enum pm_device_state curr_state;
 
-	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		enum pm_device_state curr_state;
-
-		(void)pm_device_state_get(dev, &curr_state);
-		if (*state != curr_state) {
-			ret = spi_cc13xx_cc26xx_set_power_state(dev, *state);
-		}
+	(void)pm_device_state_get(dev, &curr_state);
+	if (*state != curr_state) {
+		ret = spi_cc13xx_cc26xx_set_power_state(dev, *state);
 	}
 
 	return ret;

--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -208,16 +208,18 @@ static int spi_cc13xx_cc26xx_release(const struct device *dev,
 }
 
 #ifdef CONFIG_PM_DEVICE
-static int spi_cc13xx_cc26xx_set_power_state(const struct device *dev,
-					     enum pm_device_state state)
+static int spi_cc13xx_cc26xx_pm_control(const struct device *dev,
+					enum pm_device_state state)
 {
-	if (state == PM_DEVICE_STATE_ACTIVE) {
+	switch (state) {
+	case PM_DEVICE_STATE_ACTIVE:
 		if (get_dev_config(dev)->base == DT_INST_REG_ADDR(0)) {
 			Power_setDependency(PowerCC26XX_PERIPH_SSI0);
 		} else {
 			Power_setDependency(PowerCC26XX_PERIPH_SSI1);
 		}
-	} else {
+		break;
+	case PM_DEVICE_STATE_SUSPENDED:
 		SSIDisable(get_dev_config(dev)->base);
 		/*
 		 * Release power dependency
@@ -227,15 +229,12 @@ static int spi_cc13xx_cc26xx_set_power_state(const struct device *dev,
 		} else {
 			Power_releaseDependency(PowerCC26XX_PERIPH_SSI1);
 		}
+		break;
+	default:
+		return -ENOTSUP;
 	}
 
 	return 0;
-}
-
-static int spi_cc13xx_cc26xx_pm_control(const struct device *dev,
-					enum pm_device_state state)
-{
-	return spi_cc13xx_cc26xx_set_power_state(dev, state);
 }
 #endif /* CONFIG_PM_DEVICE */
 

--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -209,56 +209,33 @@ static int spi_cc13xx_cc26xx_release(const struct device *dev,
 
 #ifdef CONFIG_PM_DEVICE
 static int spi_cc13xx_cc26xx_set_power_state(const struct device *dev,
-					     enum pm_device_state new_state)
+					     enum pm_device_state state)
 {
-	int ret = 0;
-	enum pm_device_state state;
-
-	(void)pm_device_state_get(dev, &state);
-
-	if ((new_state == PM_DEVICE_STATE_ACTIVE) && (new_state != state)) {
-		if (get_dev_config(dev)->base ==
-			DT_INST_REG_ADDR(0)) {
+	if (state == PM_DEVICE_STATE_ACTIVE) {
+		if (get_dev_config(dev)->base == DT_INST_REG_ADDR(0)) {
 			Power_setDependency(PowerCC26XX_PERIPH_SSI0);
 		} else {
 			Power_setDependency(PowerCC26XX_PERIPH_SSI1);
 		}
 	} else {
-		__ASSERT_NO_MSG(new_state == PM_DEVICE_STATE_LOW_POWER ||
-			new_state == PM_DEVICE_STATE_SUSPEND ||
-			new_state == PM_DEVICE_STATE_OFF);
-
-		if (state == PM_DEVICE_STATE_ACTIVE) {
-			SSIDisable(get_dev_config(dev)->base);
-			/*
-			 * Release power dependency
-			 */
-			if (get_dev_config(dev)->base ==
-				DT_INST_REG_ADDR(0)) {
-				Power_releaseDependency(
-					PowerCC26XX_PERIPH_SSI0);
-			} else {
-				Power_releaseDependency(
-					PowerCC26XX_PERIPH_SSI1);
-			}
+		SSIDisable(get_dev_config(dev)->base);
+		/*
+		 * Release power dependency
+		 */
+		if (get_dev_config(dev)->base == DT_INST_REG_ADDR(0)) {
+			Power_releaseDependency(PowerCC26XX_PERIPH_SSI0);
+		} else {
+			Power_releaseDependency(PowerCC26XX_PERIPH_SSI1);
 		}
 	}
 
-	return ret;
+	return 0;
 }
 
 static int spi_cc13xx_cc26xx_pm_control(const struct device *dev,
 					enum pm_device_state state)
 {
-	int ret = 0;
-	enum pm_device_state curr_state;
-
-	(void)pm_device_state_get(dev, &curr_state);
-	if (state != curr_state) {
-		ret = spi_cc13xx_cc26xx_set_power_state(dev, state);
-	}
-
-	return ret;
+	return spi_cc13xx_cc26xx_set_power_state(dev, state);
 }
 #endif /* CONFIG_PM_DEVICE */
 

--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -33,9 +33,6 @@ struct spi_cc13xx_cc26xx_config {
 
 struct spi_cc13xx_cc26xx_data {
 	struct spi_context ctx;
-#ifdef CONFIG_PM_DEVICE
-	enum pm_device_state pm_state;
-#endif
 };
 
 #define CPU_FREQ DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency)
@@ -215,22 +212,23 @@ static int spi_cc13xx_cc26xx_set_power_state(const struct device *dev,
 					     enum pm_device_state new_state)
 {
 	int ret = 0;
+	enum pm_device_state state;
 
-	if ((new_state == PM_DEVICE_STATE_ACTIVE) &&
-		(new_state != get_dev_data(dev)->pm_state)) {
+	(void)pm_device_state_get(dev, &state);
+
+	if ((new_state == PM_DEVICE_STATE_ACTIVE) && (new_state != state)) {
 		if (get_dev_config(dev)->base ==
 			DT_INST_REG_ADDR(0)) {
 			Power_setDependency(PowerCC26XX_PERIPH_SSI0);
 		} else {
 			Power_setDependency(PowerCC26XX_PERIPH_SSI1);
 		}
-		get_dev_data(dev)->pm_state = new_state;
 	} else {
 		__ASSERT_NO_MSG(new_state == PM_DEVICE_STATE_LOW_POWER ||
 			new_state == PM_DEVICE_STATE_SUSPEND ||
 			new_state == PM_DEVICE_STATE_OFF);
 
-		if (get_dev_data(dev)->pm_state == PM_DEVICE_STATE_ACTIVE) {
+		if (state == PM_DEVICE_STATE_ACTIVE) {
 			SSIDisable(get_dev_config(dev)->base);
 			/*
 			 * Release power dependency
@@ -243,7 +241,6 @@ static int spi_cc13xx_cc26xx_set_power_state(const struct device *dev,
 				Power_releaseDependency(
 					PowerCC26XX_PERIPH_SSI1);
 			}
-			get_dev_data(dev)->pm_state = new_state;
 		}
 	}
 
@@ -257,15 +254,12 @@ static int spi_cc13xx_cc26xx_pm_control(const struct device *dev,
 	int ret = 0;
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		uint32_t new_state = *state;
+		enum pm_device_state curr_state;
 
-		if (new_state != get_dev_data(dev)->pm_state) {
-			ret = spi_cc13xx_cc26xx_set_power_state(dev,
-				new_state);
+		(void)pm_device_state_get(dev, &curr_state);
+		if (*state != curr_state) {
+			ret = spi_cc13xx_cc26xx_set_power_state(dev, *state);
 		}
-	} else {
-		__ASSERT_NO_MSG(ctrl_command == PM_DEVICE_STATE_GET);
-		*state = get_dev_data(dev)->pm_state;
 	}
 
 	return ret;
@@ -331,20 +325,9 @@ static const struct spi_driver_api spi_cc13xx_cc26xx_driver_api = {
 		POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,			    \
 		&spi_cc13xx_cc26xx_driver_api)
 
-#ifdef CONFIG_PM_DEVICE
-#define SPI_CC13XX_CC26XX_INIT_PM_STATE					    \
-	do {								    \
-		get_dev_data(dev)->pm_state = PM_DEVICE_STATE_ACTIVE;	    \
-	} while (0)
-#else
-#define SPI_CC13XX_CC26XX_INIT_PM_STATE
-#endif
-
 #define SPI_CC13XX_CC26XX_INIT_FUNC(n)					    \
 	static int spi_cc13xx_cc26xx_init_##n(const struct device *dev)	    \
 	{								    \
-		SPI_CC13XX_CC26XX_INIT_PM_STATE;			    \
-									    \
 		SPI_CC13XX_CC26XX_POWER_SPI(n);				    \
 									    \
 		spi_context_unlock_unconditionally(&get_dev_data(dev)->ctx);\

--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -209,17 +209,17 @@ static int spi_cc13xx_cc26xx_release(const struct device *dev,
 
 #ifdef CONFIG_PM_DEVICE
 static int spi_cc13xx_cc26xx_pm_control(const struct device *dev,
-					enum pm_device_state state)
+					enum pm_device_action action)
 {
-	switch (state) {
-	case PM_DEVICE_STATE_ACTIVE:
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
 		if (get_dev_config(dev)->base == DT_INST_REG_ADDR(0)) {
 			Power_setDependency(PowerCC26XX_PERIPH_SSI0);
 		} else {
 			Power_setDependency(PowerCC26XX_PERIPH_SSI1);
 		}
 		break;
-	case PM_DEVICE_STATE_SUSPENDED:
+	case PM_DEVICE_ACTION_SUSPEND:
 		SSIDisable(get_dev_config(dev)->base);
 		/*
 		 * Release power dependency

--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -248,14 +248,14 @@ static int spi_cc13xx_cc26xx_set_power_state(const struct device *dev,
 }
 
 static int spi_cc13xx_cc26xx_pm_control(const struct device *dev,
-					enum pm_device_state *state)
+					enum pm_device_state state)
 {
 	int ret = 0;
 	enum pm_device_state curr_state;
 
 	(void)pm_device_state_get(dev, &curr_state);
-	if (*state != curr_state) {
-		ret = spi_cc13xx_cc26xx_set_power_state(dev, *state);
+	if (state != curr_state) {
+		ret = spi_cc13xx_cc26xx_set_power_state(dev, state);
 	}
 
 	return ret;

--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -248,7 +248,6 @@ static int spi_cc13xx_cc26xx_set_power_state(const struct device *dev,
 }
 
 static int spi_cc13xx_cc26xx_pm_control(const struct device *dev,
-					uint32_t ctrl_command,
 					enum pm_device_state *state)
 {
 	int ret = 0;

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -278,7 +278,7 @@ static int init_spi(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 static int spi_nrfx_pm_control(const struct device *dev,
-			       enum pm_device_state *state)
+			       enum pm_device_state state)
 {
 	int ret = 0;
 	struct spi_nrfx_data *data = get_dev_data(dev);
@@ -286,8 +286,8 @@ static int spi_nrfx_pm_control(const struct device *dev,
 	enum pm_device_state curr_state;
 
 	(void)pm_device_state_get(dev, &curr_state);
-	if (*state != curr_state) {
-		switch (*state) {
+	if (state != curr_state) {
+		switch (state) {
 		case PM_DEVICE_STATE_ACTIVE:
 			ret = init_spi(dev);
 			/* Force reconfiguration before next transfer */

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -292,7 +292,6 @@ static int spi_nrfx_pm_control(const struct device *dev,
 		break;
 
 	case PM_DEVICE_STATE_SUSPENDED:
-	case PM_DEVICE_STATE_OFF:
 		nrfx_spi_uninit(&config->spi);
 		break;
 

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -284,30 +284,27 @@ static int spi_nrfx_pm_control(const struct device *dev,
 	int ret = 0;
 	struct spi_nrfx_data *data = get_dev_data(dev);
 	const struct spi_nrfx_config *config = get_dev_config(dev);
+	enum pm_device_state curr_state;
 
-	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		enum pm_device_state curr_state;
+	(void)pm_device_state_get(dev, &curr_state);
+	if (*state != curr_state) {
+		switch (*state) {
+		case PM_DEVICE_STATE_ACTIVE:
+			ret = init_spi(dev);
+			/* Force reconfiguration before next transfer */
+			data->ctx.config = NULL;
+			break;
 
-		(void)pm_device_state_get(dev, &curr_state);
-		if (*state != curr_state) {
-			switch (*state) {
-			case PM_DEVICE_STATE_ACTIVE:
-				ret = init_spi(dev);
-				/* Force reconfiguration before next transfer */
-				data->ctx.config = NULL;
-				break;
-
-			case PM_DEVICE_STATE_LOW_POWER:
-			case PM_DEVICE_STATE_SUSPEND:
-			case PM_DEVICE_STATE_OFF:
-				if (curr_state == PM_DEVICE_STATE_ACTIVE) {
-					nrfx_spi_uninit(&config->spi);
-				}
-				break;
-
-			default:
-				ret = -ENOTSUP;
+		case PM_DEVICE_STATE_LOW_POWER:
+		case PM_DEVICE_STATE_SUSPEND:
+		case PM_DEVICE_STATE_OFF:
+			if (curr_state == PM_DEVICE_STATE_ACTIVE) {
+				nrfx_spi_uninit(&config->spi);
 			}
+			break;
+
+		default:
+			ret = -ENOTSUP;
 		}
 	}
 

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -291,7 +291,6 @@ static int spi_nrfx_pm_control(const struct device *dev,
 		data->ctx.config = NULL;
 		break;
 
-	case PM_DEVICE_STATE_LOW_POWER:
 	case PM_DEVICE_STATE_SUSPEND:
 	case PM_DEVICE_STATE_OFF:
 		nrfx_spi_uninit(&config->spi);

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -278,8 +278,7 @@ static int init_spi(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 static int spi_nrfx_pm_control(const struct device *dev,
-				uint32_t ctrl_command,
-				enum pm_device_state *state)
+			       enum pm_device_state *state)
 {
 	int ret = 0;
 	struct spi_nrfx_data *data = get_dev_data(dev);

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -278,20 +278,20 @@ static int init_spi(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 static int spi_nrfx_pm_control(const struct device *dev,
-			       enum pm_device_state state)
+			       enum pm_device_action action)
 {
 	int ret = 0;
 	struct spi_nrfx_data *data = get_dev_data(dev);
 	const struct spi_nrfx_config *config = get_dev_config(dev);
 
-	switch (state) {
-	case PM_DEVICE_STATE_ACTIVE:
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
 		ret = init_spi(dev);
 		/* Force reconfiguration before next transfer */
 		data->ctx.config = NULL;
 		break;
 
-	case PM_DEVICE_STATE_SUSPENDED:
+	case PM_DEVICE_ACTION_SUSPEND:
 		nrfx_spi_uninit(&config->spi);
 		break;
 

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -291,7 +291,7 @@ static int spi_nrfx_pm_control(const struct device *dev,
 		data->ctx.config = NULL;
 		break;
 
-	case PM_DEVICE_STATE_SUSPEND:
+	case PM_DEVICE_STATE_SUSPENDED:
 	case PM_DEVICE_STATE_OFF:
 		nrfx_spi_uninit(&config->spi);
 		break;

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -283,28 +283,22 @@ static int spi_nrfx_pm_control(const struct device *dev,
 	int ret = 0;
 	struct spi_nrfx_data *data = get_dev_data(dev);
 	const struct spi_nrfx_config *config = get_dev_config(dev);
-	enum pm_device_state curr_state;
 
-	(void)pm_device_state_get(dev, &curr_state);
-	if (state != curr_state) {
-		switch (state) {
-		case PM_DEVICE_STATE_ACTIVE:
-			ret = init_spi(dev);
-			/* Force reconfiguration before next transfer */
-			data->ctx.config = NULL;
-			break;
+	switch (state) {
+	case PM_DEVICE_STATE_ACTIVE:
+		ret = init_spi(dev);
+		/* Force reconfiguration before next transfer */
+		data->ctx.config = NULL;
+		break;
 
-		case PM_DEVICE_STATE_LOW_POWER:
-		case PM_DEVICE_STATE_SUSPEND:
-		case PM_DEVICE_STATE_OFF:
-			if (curr_state == PM_DEVICE_STATE_ACTIVE) {
-				nrfx_spi_uninit(&config->spi);
-			}
-			break;
+	case PM_DEVICE_STATE_LOW_POWER:
+	case PM_DEVICE_STATE_SUSPEND:
+	case PM_DEVICE_STATE_OFF:
+		nrfx_spi_uninit(&config->spi);
+		break;
 
-		default:
-			ret = -ENOTSUP;
-		}
+	default:
+		ret = -ENOTSUP;
 	}
 
 	return ret;

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -325,7 +325,6 @@ static int init_spim(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 static int spim_nrfx_pm_control(const struct device *dev,
-				uint32_t ctrl_command,
 				enum pm_device_state *state)
 {
 	int ret = 0;

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -338,7 +338,7 @@ static int spim_nrfx_pm_control(const struct device *dev,
 		data->ctx.config = NULL;
 		break;
 
-	case PM_DEVICE_STATE_SUSPEND:
+	case PM_DEVICE_STATE_SUSPENDED:
 	case PM_DEVICE_STATE_OFF:
 		nrfx_spim_uninit(&config->spim);
 		break;

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -338,7 +338,6 @@ static int spim_nrfx_pm_control(const struct device *dev,
 		data->ctx.config = NULL;
 		break;
 
-	case PM_DEVICE_STATE_LOW_POWER:
 	case PM_DEVICE_STATE_SUSPEND:
 	case PM_DEVICE_STATE_OFF:
 		nrfx_spim_uninit(&config->spim);

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -325,7 +325,7 @@ static int init_spim(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 static int spim_nrfx_pm_control(const struct device *dev,
-				enum pm_device_state *state)
+				enum pm_device_state state)
 {
 	int ret = 0;
 	struct spi_nrfx_data *data = get_dev_data(dev);
@@ -333,8 +333,8 @@ static int spim_nrfx_pm_control(const struct device *dev,
 	enum pm_device_state curr_state;
 
 	(void)pm_device_state_get(dev, &curr_state);
-	if (*state != curr_state) {
-		switch (*state) {
+	if (state != curr_state) {
+		switch (state) {
 		case PM_DEVICE_STATE_ACTIVE:
 			ret = init_spim(dev);
 			/* Force reconfiguration before next transfer */

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -325,20 +325,20 @@ static int init_spim(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 static int spim_nrfx_pm_control(const struct device *dev,
-				enum pm_device_state state)
+				enum pm_device_action action)
 {
 	int ret = 0;
 	struct spi_nrfx_data *data = get_dev_data(dev);
 	const struct spi_nrfx_config *config = get_dev_config(dev);
 
-	switch (state) {
-	case PM_DEVICE_STATE_ACTIVE:
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
 		ret = init_spim(dev);
 		/* Force reconfiguration before next transfer */
 		data->ctx.config = NULL;
 		break;
 
-	case PM_DEVICE_STATE_SUSPENDED:
+	case PM_DEVICE_ACTION_SUSPEND:
 		nrfx_spim_uninit(&config->spim);
 		break;
 

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -339,7 +339,6 @@ static int spim_nrfx_pm_control(const struct device *dev,
 		break;
 
 	case PM_DEVICE_STATE_SUSPENDED:
-	case PM_DEVICE_STATE_OFF:
 		nrfx_spim_uninit(&config->spim);
 		break;
 

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -330,28 +330,22 @@ static int spim_nrfx_pm_control(const struct device *dev,
 	int ret = 0;
 	struct spi_nrfx_data *data = get_dev_data(dev);
 	const struct spi_nrfx_config *config = get_dev_config(dev);
-	enum pm_device_state curr_state;
 
-	(void)pm_device_state_get(dev, &curr_state);
-	if (state != curr_state) {
-		switch (state) {
-		case PM_DEVICE_STATE_ACTIVE:
-			ret = init_spim(dev);
-			/* Force reconfiguration before next transfer */
-			data->ctx.config = NULL;
-			break;
+	switch (state) {
+	case PM_DEVICE_STATE_ACTIVE:
+		ret = init_spim(dev);
+		/* Force reconfiguration before next transfer */
+		data->ctx.config = NULL;
+		break;
 
-		case PM_DEVICE_STATE_LOW_POWER:
-		case PM_DEVICE_STATE_SUSPEND:
-		case PM_DEVICE_STATE_OFF:
-			if (curr_state == PM_DEVICE_STATE_ACTIVE) {
-				nrfx_spim_uninit(&config->spim);
-			}
-			break;
+	case PM_DEVICE_STATE_LOW_POWER:
+	case PM_DEVICE_STATE_SUSPEND:
+	case PM_DEVICE_STATE_OFF:
+		nrfx_spim_uninit(&config->spim);
+		break;
 
-		default:
-			ret = -ENOTSUP;
-		}
+	default:
+		ret = -ENOTSUP;
 	}
 
 	return ret;

--- a/drivers/timer/sys_clock_init.c
+++ b/drivers/timer/sys_clock_init.c
@@ -31,7 +31,7 @@ int __weak sys_clock_driver_init(const struct device *dev)
 }
 
 int __weak sys_clock_device_ctrl(const struct device *dev,
-				 enum pm_device_state state)
+				 enum pm_device_action action)
 {
 	return -ENOSYS;
 }

--- a/drivers/timer/sys_clock_init.c
+++ b/drivers/timer/sys_clock_init.c
@@ -31,7 +31,6 @@ int __weak sys_clock_driver_init(const struct device *dev)
 }
 
 int __weak sys_clock_device_ctrl(const struct device *dev,
-				 uint32_t ctrl_command,
 				 enum pm_device_state *state)
 {
 	return -ENOSYS;

--- a/drivers/timer/sys_clock_init.c
+++ b/drivers/timer/sys_clock_init.c
@@ -31,7 +31,7 @@ int __weak sys_clock_driver_init(const struct device *dev)
 }
 
 int __weak sys_clock_device_ctrl(const struct device *dev,
-				 enum pm_device_state *state)
+				 enum pm_device_state state)
 {
 	return -ENOSYS;
 }

--- a/include/device.h
+++ b/include/device.h
@@ -384,8 +384,7 @@ struct device {
 	const device_handle_t *const handles;
 #ifdef CONFIG_PM_DEVICE
 	/** Power Management function */
-	int (*pm_control)(const struct device *dev,
-			  enum pm_device_state state);
+	pm_device_control_callback_t pm_control;
 	/** Pointer to device instance power management data */
 	struct pm_device * const pm;
 #endif

--- a/include/device.h
+++ b/include/device.h
@@ -384,7 +384,7 @@ struct device {
 	const device_handle_t *const handles;
 #ifdef CONFIG_PM_DEVICE
 	/** Power Management function */
-	int (*pm_control)(const struct device *dev, uint32_t command,
+	int (*pm_control)(const struct device *dev,
 			  enum pm_device_state *state);
 	/** Pointer to device instance power management data */
 	struct pm_device * const pm;

--- a/include/device.h
+++ b/include/device.h
@@ -385,7 +385,7 @@ struct device {
 #ifdef CONFIG_PM_DEVICE
 	/** Power Management function */
 	int (*pm_control)(const struct device *dev,
-			  enum pm_device_state *state);
+			  enum pm_device_state state);
 	/** Pointer to device instance power management data */
 	struct pm_device * const pm;
 #endif

--- a/include/drivers/timer/system_timer.h
+++ b/include/drivers/timer/system_timer.h
@@ -47,7 +47,7 @@ extern int sys_clock_driver_init(const struct device *dev);
  * if undefined in the clock driver.
  */
 extern int clock_device_ctrl(const struct device *dev,
-			     enum pm_device_state *state);
+			     enum pm_device_state state);
 
 /**
  * @brief Set system clock timeout

--- a/include/drivers/timer/system_timer.h
+++ b/include/drivers/timer/system_timer.h
@@ -46,7 +46,7 @@ extern int sys_clock_driver_init(const struct device *dev);
  * management.  It is a weak symbol that will be implemented as a noop
  * if undefined in the clock driver.
  */
-extern int clock_device_ctrl(const struct device *dev, uint32_t ctrl_command,
+extern int clock_device_ctrl(const struct device *dev,
 			     enum pm_device_state *state);
 
 /**

--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -121,20 +121,16 @@ int pm_device_state_set(const struct device *dev,
 			enum pm_device_state device_power_state);
 
 /**
- * @brief Call the get power state function of a device
+ * @brief Obtain the power state of a device.
  *
- * This function lets the caller know the current device
- * power state at any time. This state will be one of the defined
- * power states allowed for the devices in that system
- *
- * @param dev pointer to device structure of the driver instance.
- * @param device_power_state Device power state to be filled by the device
+ * @param dev Device instance.
+ * @param state Pointer where device power state will be stored.
  *
  * @retval 0 If successful.
- * @retval Errno Negative errno code if failure.
+ * @retval -ENOSYS If device does not implement power management.
  */
 int pm_device_state_get(const struct device *dev,
-			enum pm_device_state *device_power_state);
+			enum pm_device_state *state);
 
 #ifdef CONFIG_PM_DEVICE
 /**

--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -70,6 +70,16 @@ enum pm_device_flag {
 	PM_DEVICE_FLAG_COUNT
 };
 
+/** @brief Device PM actions. */
+enum pm_device_action {
+	/** Suspend. */
+	PM_DEVICE_ACTION_SUSPEND,
+	/** Resume. */
+	PM_DEVICE_ACTION_RESUME,
+	/** Turn off. */
+	PM_DEVICE_ACTION_TURN_OFF,
+};
+
 /**
  * @brief Device PM info
  */
@@ -97,14 +107,14 @@ struct pm_device {
  * @brief Device power management control function callback.
  *
  * @param dev Device instance.
- * @param state Requested state.
+ * @param action Requested action.
  *
  * @retval 0 If successful.
- * @retval -ENOTSUP If the requested state is not supported.
+ * @retval -ENOTSUP If the requested action is not supported.
  * @retval Errno Other negative errno on failure.
  */
 typedef int (*pm_device_control_callback_t)(const struct device *dev,
-					    enum pm_device_state state);
+					    enum pm_device_action action);
 
 /**
  * @brief Get name of device PM state

--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -101,19 +101,21 @@ struct pm_device {
 const char *pm_device_state_str(enum pm_device_state state);
 
 /**
- * @brief Call the set power state function of a device
+ * @brief Set the power state of a device.
  *
- * Called by the application or power management service to let the device do
- * required operations when moving to the required power state
- * Note that devices may support just some of the device power states
- * @param dev Pointer to device structure of the driver instance.
- * @param device_power_state Device power state to be set
+ * This function calls the device PM control callback so that the device does
+ * the necessary operations to put the device into the given state.
  *
- * @retval 0 If successful in queuing the request or changing the state.
- * @retval Errno Negative errno code if failure.
+ * @note Some devices may not support all device power states.
+ *
+ * @param dev Device instance.
+ * @param state Device power state to be set.
+ *
+ * @retval 0 If successful.
+ * @retval Errno Negative errno code in case of failure.
  */
 int pm_device_state_set(const struct device *dev,
-			enum pm_device_state device_power_state);
+			enum pm_device_state state);
 
 /**
  * @brief Obtain the power state of a device.

--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -62,11 +62,6 @@ enum pm_device_state {
 	PM_DEVICE_STATE_SUSPENDING,
 };
 
-/** Device PM set state control command. */
-#define PM_DEVICE_STATE_SET 0
-/** Device PM get state control command. */
-#define PM_DEVICE_STATE_GET 1
-
 /** @brief Device PM flags. */
 enum pm_device_flag {
 	/** Indicate if the device is busy or not. */

--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -94,6 +94,19 @@ struct pm_device {
 };
 
 /**
+ * @brief Device power management control function callback.
+ *
+ * @param dev Device instance.
+ * @param state Requested state.
+ *
+ * @retval 0 If successful.
+ * @retval -ENOTSUP If the requested state is not supported.
+ * @retval Errno Other negative errno on failure.
+ */
+typedef int (*pm_device_control_callback_t)(const struct device *dev,
+					    enum pm_device_state state);
+
+/**
  * @brief Get name of device PM state
  *
  * @param state State id which name should be returned

--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -112,7 +112,9 @@ const char *pm_device_state_str(enum pm_device_state state);
  * @param state Device power state to be set.
  *
  * @retval 0 If successful.
- * @retval Errno Negative errno code in case of failure.
+ * @retval -ENOTSUP If requested state is not supported.
+ * @retval -EALREADY If device is already at (or transitioning to) the requested
+ *         state.
  */
 int pm_device_state_set(const struct device *dev,
 			enum pm_device_state state);

--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -41,7 +41,7 @@ enum pm_device_state {
 	 * @note
 	 *     Device context may be lost.
 	 */
-	PM_DEVICE_STATE_SUSPEND,
+	PM_DEVICE_STATE_SUSPENDED,
 	/**
 	 * Device is suspended (forced).
 	 *

--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -78,6 +78,10 @@ enum pm_device_action {
 	PM_DEVICE_ACTION_RESUME,
 	/** Turn off. */
 	PM_DEVICE_ACTION_TURN_OFF,
+	/** Force suspend. */
+	PM_DEVICE_ACTION_FORCE_SUSPEND,
+	/** Low power. */
+	PM_DEVICE_ACTION_LOW_POWER,
 };
 
 /**

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -32,6 +32,7 @@ static inline void device_pm_state_init(const struct device *dev)
 		.usage = ATOMIC_INIT(0),
 		.lock = Z_MUTEX_INITIALIZER(dev->pm->lock),
 		.condvar = Z_CONDVAR_INITIALIZER(dev->pm->condvar),
+		.state = PM_DEVICE_STATE_ACTIVE,
 	};
 #endif /* CONFIG_PM_DEVICE */
 }

--- a/samples/boards/nrf/system_off/src/main.c
+++ b/samples/boards/nrf/system_off/src/main.c
@@ -66,7 +66,7 @@ void main(void)
 	k_busy_wait(BUSY_WAIT_S * USEC_PER_SEC);
 
 	printk("Busy-wait %u s with UART off\n", BUSY_WAIT_S);
-	rc = pm_device_state_set(cons, PM_DEVICE_STATE_LOW_POWER);
+	rc = pm_device_state_set(cons, PM_DEVICE_STATE_SUSPEND);
 	k_busy_wait(BUSY_WAIT_S * USEC_PER_SEC);
 	rc = pm_device_state_set(cons, PM_DEVICE_STATE_ACTIVE);
 
@@ -74,7 +74,7 @@ void main(void)
 	k_sleep(K_SECONDS(SLEEP_S));
 
 	printk("Sleep %u s with UART off\n", SLEEP_S);
-	rc = pm_device_state_set(cons, PM_DEVICE_STATE_LOW_POWER);
+	rc = pm_device_state_set(cons, PM_DEVICE_STATE_SUSPEND);
 	k_sleep(K_SECONDS(SLEEP_S));
 	rc = pm_device_state_set(cons, PM_DEVICE_STATE_ACTIVE);
 

--- a/samples/boards/nrf/system_off/src/main.c
+++ b/samples/boards/nrf/system_off/src/main.c
@@ -66,7 +66,7 @@ void main(void)
 	k_busy_wait(BUSY_WAIT_S * USEC_PER_SEC);
 
 	printk("Busy-wait %u s with UART off\n", BUSY_WAIT_S);
-	rc = pm_device_state_set(cons, PM_DEVICE_STATE_SUSPEND);
+	rc = pm_device_state_set(cons, PM_DEVICE_STATE_SUSPENDED);
 	k_busy_wait(BUSY_WAIT_S * USEC_PER_SEC);
 	rc = pm_device_state_set(cons, PM_DEVICE_STATE_ACTIVE);
 
@@ -74,7 +74,7 @@ void main(void)
 	k_sleep(K_SECONDS(SLEEP_S));
 
 	printk("Sleep %u s with UART off\n", SLEEP_S);
-	rc = pm_device_state_set(cons, PM_DEVICE_STATE_SUSPEND);
+	rc = pm_device_state_set(cons, PM_DEVICE_STATE_SUSPENDED);
 	k_sleep(K_SECONDS(SLEEP_S));
 	rc = pm_device_state_set(cons, PM_DEVICE_STATE_ACTIVE);
 

--- a/samples/drivers/spi_flash_at45/src/main.c
+++ b/samples/drivers/spi_flash_at45/src/main.c
@@ -151,7 +151,7 @@ void main(void)
 
 #if IS_ENABLED(CONFIG_PM_DEVICE)
 	printk("Putting the flash device into suspended state... ");
-	err = pm_device_state_set(flash_dev, PM_DEVICE_STATE_SUSPEND);
+	err = pm_device_state_set(flash_dev, PM_DEVICE_STATE_SUSPENDED);
 	if (err != 0) {
 		printk("FAILED\n");
 		return;

--- a/samples/drivers/spi_flash_at45/src/main.c
+++ b/samples/drivers/spi_flash_at45/src/main.c
@@ -150,8 +150,8 @@ void main(void)
 	printk("OK\n");
 
 #if IS_ENABLED(CONFIG_PM_DEVICE)
-	printk("Putting the flash device into low power state... ");
-	err = pm_device_state_set(flash_dev, PM_DEVICE_STATE_LOW_POWER);
+	printk("Putting the flash device into suspended state... ");
+	err = pm_device_state_set(flash_dev, PM_DEVICE_STATE_SUSPEND);
 	if (err != 0) {
 		printk("FAILED\n");
 		return;

--- a/samples/sensor/apds9960/src/main.c
+++ b/samples/sensor/apds9960/src/main.c
@@ -79,7 +79,7 @@ void main(void)
 #ifdef CONFIG_PM_DEVICE
 		enum pm_device_state p_state;
 
-		p_state = PM_DEVICE_STATE_SUSPEND;
+		p_state = PM_DEVICE_STATE_SUSPENDED;
 		pm_device_state_set(dev, p_state);
 		printk("set low power state for 2s\n");
 		k_sleep(K_MSEC(2000));

--- a/samples/sensor/apds9960/src/main.c
+++ b/samples/sensor/apds9960/src/main.c
@@ -79,7 +79,7 @@ void main(void)
 #ifdef CONFIG_PM_DEVICE
 		enum pm_device_state p_state;
 
-		p_state = PM_DEVICE_STATE_LOW_POWER;
+		p_state = PM_DEVICE_STATE_SUSPEND;
 		pm_device_state_set(dev, p_state);
 		printk("set low power state for 2s\n");
 		k_sleep(K_MSEC(2000));

--- a/samples/sensor/fdc2x1x/src/main.c
+++ b/samples/sensor/fdc2x1x/src/main.c
@@ -43,7 +43,7 @@ static void pm_info(enum pm_device_state state, int status)
 	case PM_DEVICE_STATE_ACTIVE:
 		printk("Enter ACTIVE_STATE ");
 		break;
-	case PM_DEVICE_STATE_SUSPEND:
+	case PM_DEVICE_STATE_SUSPENDED:
 		printk("Enter SUSPEND_STATE ");
 		break;
 	case PM_DEVICE_STATE_OFF:
@@ -95,7 +95,7 @@ void main(void)
 	enum pm_device_state p_state;
 	int ret;
 
-	p_state = PM_DEVICE_STATE_SUSPEND;
+	p_state = PM_DEVICE_STATE_SUSPENDED;
 	ret = pm_device_state_set(dev, p_state);
 	pm_info(p_state, ret);
 

--- a/samples/sensor/fdc2x1x/src/main.c
+++ b/samples/sensor/fdc2x1x/src/main.c
@@ -43,8 +43,8 @@ static void pm_info(enum pm_device_state state, int status)
 	case PM_DEVICE_STATE_ACTIVE:
 		printk("Enter ACTIVE_STATE ");
 		break;
-	case PM_DEVICE_STATE_LOW_POWER:
-		printk("Enter LOW_POWER_STATE ");
+	case PM_DEVICE_STATE_SUSPEND:
+		printk("Enter SUSPEND_STATE ");
 		break;
 	case PM_DEVICE_STATE_OFF:
 		printk("Enter OFF_STATE ");
@@ -95,7 +95,7 @@ void main(void)
 	enum pm_device_state p_state;
 	int ret;
 
-	p_state = PM_DEVICE_STATE_LOW_POWER;
+	p_state = PM_DEVICE_STATE_SUSPEND;
 	ret = pm_device_state_set(dev, p_state);
 	pm_info(p_state, ret);
 

--- a/samples/subsys/pm/device_pm/src/dummy_driver.c
+++ b/samples/subsys/pm/device_pm/src/dummy_driver.c
@@ -87,9 +87,9 @@ static int dummy_close(const struct device *dev)
 }
 
 static int dummy_device_pm_ctrl(const struct device *dev,
-				enum pm_device_state *state)
+				enum pm_device_state state)
 {
-	if (*state == PM_DEVICE_STATE_ACTIVE) {
+	if (state == PM_DEVICE_STATE_ACTIVE) {
 		printk("child resuming..\n");
 	} else {
 		printk("child suspending..\n");

--- a/samples/subsys/pm/device_pm/src/dummy_driver.c
+++ b/samples/subsys/pm/device_pm/src/dummy_driver.c
@@ -87,13 +87,13 @@ static int dummy_close(const struct device *dev)
 }
 
 static int dummy_device_pm_ctrl(const struct device *dev,
-				enum pm_device_state state)
+				enum pm_device_action action)
 {
-	switch (state) {
-	case PM_DEVICE_STATE_ACTIVE:
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
 		printk("child resuming..\n");
 		break;
-	case PM_DEVICE_STATE_SUSPENDED:
+	case PM_DEVICE_ACTION_SUSPEND:
 		printk("child suspending..\n");
 		break;
 	default:

--- a/samples/subsys/pm/device_pm/src/dummy_driver.c
+++ b/samples/subsys/pm/device_pm/src/dummy_driver.c
@@ -87,7 +87,6 @@ static int dummy_close(const struct device *dev)
 }
 
 static int dummy_device_pm_ctrl(const struct device *dev,
-				uint32_t ctrl_command,
 				enum pm_device_state *state)
 {
 	if (*state == PM_DEVICE_STATE_ACTIVE) {

--- a/samples/subsys/pm/device_pm/src/dummy_driver.c
+++ b/samples/subsys/pm/device_pm/src/dummy_driver.c
@@ -89,10 +89,15 @@ static int dummy_close(const struct device *dev)
 static int dummy_device_pm_ctrl(const struct device *dev,
 				enum pm_device_state state)
 {
-	if (state == PM_DEVICE_STATE_ACTIVE) {
+	switch (state) {
+	case PM_DEVICE_STATE_ACTIVE:
 		printk("child resuming..\n");
-	} else {
+		break;
+	case PM_DEVICE_STATE_SUSPENDED:
 		printk("child suspending..\n");
+		break;
+	default:
+		return -ENOTSUP;
 	}
 
 	return 0;

--- a/samples/subsys/pm/device_pm/src/dummy_driver.c
+++ b/samples/subsys/pm/device_pm/src/dummy_driver.c
@@ -90,24 +90,13 @@ static int dummy_device_pm_ctrl(const struct device *dev,
 				uint32_t ctrl_command,
 				enum pm_device_state *state)
 {
-	int ret = 0;
-
-	switch (ctrl_command) {
-	case PM_DEVICE_STATE_SET:
-		if (*state == PM_DEVICE_STATE_ACTIVE) {
-			printk("child resuming..\n");
-			return 0;
-		} else {
-			printk("child suspending..\n");
-			return 0;
-		}
-		break;
-	default:
-		ret = -EINVAL;
-
+	if (*state == PM_DEVICE_STATE_ACTIVE) {
+		printk("child resuming..\n");
+	} else {
+		printk("child suspending..\n");
 	}
 
-	return ret;
+	return 0;
 }
 
 static const struct dummy_driver_api funcs = {

--- a/samples/subsys/pm/device_pm/src/dummy_parent.c
+++ b/samples/subsys/pm/device_pm/src/dummy_parent.c
@@ -25,9 +25,9 @@ static int dummy_transfer(const struct device *dev, uint32_t cmd,
 }
 
 static int dummy_parent_pm_ctrl(const struct device *dev,
-				enum pm_device_state *state)
+				enum pm_device_state state)
 {
-	if (*state == PM_DEVICE_STATE_ACTIVE) {
+	if (state == PM_DEVICE_STATE_ACTIVE) {
 		printk("parent resuming..\n");
 	} else {
 		printk("parent suspending..\n");

--- a/samples/subsys/pm/device_pm/src/dummy_parent.c
+++ b/samples/subsys/pm/device_pm/src/dummy_parent.c
@@ -25,7 +25,6 @@ static int dummy_transfer(const struct device *dev, uint32_t cmd,
 }
 
 static int dummy_parent_pm_ctrl(const struct device *dev,
-				uint32_t ctrl_command,
 				enum pm_device_state *state)
 {
 	if (*state == PM_DEVICE_STATE_ACTIVE) {

--- a/samples/subsys/pm/device_pm/src/dummy_parent.c
+++ b/samples/subsys/pm/device_pm/src/dummy_parent.c
@@ -27,10 +27,15 @@ static int dummy_transfer(const struct device *dev, uint32_t cmd,
 static int dummy_parent_pm_ctrl(const struct device *dev,
 				enum pm_device_state state)
 {
-	if (state == PM_DEVICE_STATE_ACTIVE) {
+	switch (state) {
+	case PM_DEVICE_STATE_ACTIVE:
 		printk("parent resuming..\n");
-	} else {
+		break;
+	case PM_DEVICE_STATE_SUSPENDED:
 		printk("parent suspending..\n");
+		break;
+	default:
+		return -ENOTSUP;
 	}
 
 	return 0;

--- a/samples/subsys/pm/device_pm/src/dummy_parent.c
+++ b/samples/subsys/pm/device_pm/src/dummy_parent.c
@@ -25,13 +25,13 @@ static int dummy_transfer(const struct device *dev, uint32_t cmd,
 }
 
 static int dummy_parent_pm_ctrl(const struct device *dev,
-				enum pm_device_state state)
+				enum pm_device_action action)
 {
-	switch (state) {
-	case PM_DEVICE_STATE_ACTIVE:
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
 		printk("parent resuming..\n");
 		break;
-	case PM_DEVICE_STATE_SUSPENDED:
+	case PM_DEVICE_ACTION_SUSPEND:
 		printk("parent suspending..\n");
 		break;
 	default:

--- a/samples/subsys/pm/device_pm/src/dummy_parent.c
+++ b/samples/subsys/pm/device_pm/src/dummy_parent.c
@@ -28,24 +28,13 @@ static int dummy_parent_pm_ctrl(const struct device *dev,
 				uint32_t ctrl_command,
 				enum pm_device_state *state)
 {
-	int ret = 0;
-
-	switch (ctrl_command) {
-	case PM_DEVICE_STATE_SET:
-		if (*state == PM_DEVICE_STATE_ACTIVE) {
-			printk("parent resuming..\n");
-			return 0;
-		} else {
-			printk("parent suspending..\n");
-			return 0;
-		}
-		break;
-	default:
-		ret = -EINVAL;
-
+	if (*state == PM_DEVICE_STATE_ACTIVE) {
+		printk("parent resuming..\n");
+	} else {
+		printk("parent suspending..\n");
 	}
 
-	return ret;
+	return 0;
 }
 
 static const struct dummy_parent_api funcs = {

--- a/samples/subsys/pm/device_pm/src/dummy_parent.c
+++ b/samples/subsys/pm/device_pm/src/dummy_parent.c
@@ -9,7 +9,6 @@
 #include "dummy_parent.h"
 
 static uint32_t store_value;
-enum pm_device_state parent_power_state;
 
 static int dummy_transfer(const struct device *dev, uint32_t cmd,
 			  uint32_t *val)
@@ -25,27 +24,6 @@ static int dummy_transfer(const struct device *dev, uint32_t cmd,
 	return 0;
 }
 
-static enum pm_device_state dummy_get_power_state(const struct device *dev)
-{
-	return parent_power_state;
-}
-
-static int dummy_suspend(const struct device *dev)
-{
-	printk("parent suspending..\n");
-	parent_power_state = PM_DEVICE_STATE_SUSPEND;
-
-	return 0;
-}
-
-static int dummy_resume_from_suspend(const struct device *dev)
-{
-	printk("parent resuming..\n");
-	parent_power_state = PM_DEVICE_STATE_ACTIVE;
-
-	return 0;
-}
-
 static int dummy_parent_pm_ctrl(const struct device *dev,
 				uint32_t ctrl_command,
 				enum pm_device_state *state)
@@ -55,13 +33,12 @@ static int dummy_parent_pm_ctrl(const struct device *dev,
 	switch (ctrl_command) {
 	case PM_DEVICE_STATE_SET:
 		if (*state == PM_DEVICE_STATE_ACTIVE) {
-			ret = dummy_resume_from_suspend(dev);
+			printk("parent resuming..\n");
+			return 0;
 		} else {
-			ret = dummy_suspend(dev);
+			printk("parent suspending..\n");
+			return 0;
 		}
-		break;
-	case PM_DEVICE_STATE_GET:
-		*state = dummy_get_power_state(dev);
 		break;
 	default:
 		ret = -EINVAL;
@@ -78,7 +55,6 @@ static const struct dummy_parent_api funcs = {
 int dummy_parent_init(const struct device *dev)
 {
 	pm_device_enable(dev);
-	parent_power_state = PM_DEVICE_STATE_ACTIVE;
 	return 0;
 }
 

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -5532,7 +5532,7 @@ static int cmd_net_suspend(const struct shell *shell, size_t argc,
 
 		dev = net_if_get_device(iface);
 
-		ret = pm_device_state_set(dev, PM_DEVICE_STATE_SUSPEND);
+		ret = pm_device_state_set(dev, PM_DEVICE_STATE_SUSPENDED);
 		if (ret != 0) {
 			PR_INFO("Iface could not be suspended: ");
 

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -137,6 +137,32 @@ int pm_device_state_set(const struct device *dev,
 		return -ENOSYS;
 	}
 
+	switch (state) {
+	case PM_DEVICE_STATE_SUSPEND:
+		if ((dev->pm->state == PM_DEVICE_STATE_SUSPEND) ||
+		    (dev->pm->state == PM_DEVICE_STATE_SUSPENDING)) {
+			return -EALREADY;
+		}
+		break;
+	case PM_DEVICE_STATE_ACTIVE:
+		if ((dev->pm->state == PM_DEVICE_STATE_ACTIVE) ||
+		    (dev->pm->state == PM_DEVICE_STATE_RESUMING)) {
+			return -EALREADY;
+		}
+		break;
+	case PM_DEVICE_STATE_FORCE_SUSPEND:
+		__fallthrough;
+	case PM_DEVICE_STATE_LOW_POWER:
+		__fallthrough;
+	case PM_DEVICE_STATE_OFF:
+		if (dev->pm->state == state) {
+			return -EALREADY;
+		}
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
 	ret = dev->pm_control(dev, state);
 	if (ret < 0) {
 		return ret;

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -132,6 +132,7 @@ int pm_device_state_set(const struct device *dev,
 			enum pm_device_state state)
 {
 	int ret;
+	enum pm_device_action action;
 
 	if (dev->pm_control == NULL) {
 		return -ENOSYS;
@@ -143,12 +144,16 @@ int pm_device_state_set(const struct device *dev,
 		    (dev->pm->state == PM_DEVICE_STATE_SUSPENDING)) {
 			return -EALREADY;
 		}
+
+		action = PM_DEVICE_ACTION_SUSPEND;
 		break;
 	case PM_DEVICE_STATE_ACTIVE:
 		if ((dev->pm->state == PM_DEVICE_STATE_ACTIVE) ||
 		    (dev->pm->state == PM_DEVICE_STATE_RESUMING)) {
 			return -EALREADY;
 		}
+
+		action = PM_DEVICE_ACTION_RESUME;
 		break;
 	case PM_DEVICE_STATE_FORCE_SUSPEND:
 		__fallthrough;
@@ -158,12 +163,14 @@ int pm_device_state_set(const struct device *dev,
 		if (dev->pm->state == state) {
 			return -EALREADY;
 		}
+
+		action = PM_DEVICE_ACTION_TURN_OFF;
 		break;
 	default:
 		return -ENOTSUP;
 	}
 
-	ret = dev->pm_control(dev, state);
+	ret = dev->pm_control(dev, action);
 	if (ret < 0) {
 		return ret;
 	}

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -158,9 +158,19 @@ int pm_device_state_set(const struct device *dev,
 		action = PM_DEVICE_ACTION_RESUME;
 		break;
 	case PM_DEVICE_STATE_FORCE_SUSPEND:
-		__fallthrough;
+		if (dev->pm->state == state) {
+			return -EALREADY;
+		}
+
+		action = PM_DEVICE_ACTION_FORCE_SUSPEND;
+		break;
 	case PM_DEVICE_STATE_LOW_POWER:
-		__fallthrough;
+		if (dev->pm->state == state) {
+			return -EALREADY;
+		}
+
+		action = PM_DEVICE_ACTION_LOW_POWER;
+		break;
 	case PM_DEVICE_STATE_OFF:
 		if (dev->pm->state == state) {
 			return -EALREADY;

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -129,7 +129,7 @@ const char *pm_device_state_str(enum pm_device_state state)
 }
 
 int pm_device_state_set(const struct device *dev,
-			enum pm_device_state device_power_state)
+			enum pm_device_state state)
 {
 	int ret;
 
@@ -137,12 +137,12 @@ int pm_device_state_set(const struct device *dev,
 		return -ENOSYS;
 	}
 
-	ret = dev->pm_control(dev, device_power_state);
+	ret = dev->pm_control(dev, state);
 	if (ret < 0) {
 		return ret;
 	}
 
-	dev->pm->state = device_power_state;
+	dev->pm->state = state;
 
 	return 0;
 }

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -84,7 +84,7 @@ static int _pm_devices(uint32_t state)
 
 int pm_suspend_devices(void)
 {
-	return _pm_devices(PM_DEVICE_STATE_SUSPEND);
+	return _pm_devices(PM_DEVICE_STATE_SUSPENDED);
 }
 
 int pm_low_power_devices(void)
@@ -117,8 +117,8 @@ const char *pm_device_state_str(enum pm_device_state state)
 		return "active";
 	case PM_DEVICE_STATE_LOW_POWER:
 		return "low power";
-	case PM_DEVICE_STATE_SUSPEND:
-		return "suspend";
+	case PM_DEVICE_STATE_SUSPENDED:
+		return "suspended";
 	case PM_DEVICE_STATE_FORCE_SUSPEND:
 		return "force suspend";
 	case PM_DEVICE_STATE_OFF:
@@ -138,8 +138,8 @@ int pm_device_state_set(const struct device *dev,
 	}
 
 	switch (state) {
-	case PM_DEVICE_STATE_SUSPEND:
-		if ((dev->pm->state == PM_DEVICE_STATE_SUSPEND) ||
+	case PM_DEVICE_STATE_SUSPENDED:
+		if ((dev->pm->state == PM_DEVICE_STATE_SUSPENDED) ||
 		    (dev->pm->state == PM_DEVICE_STATE_SUSPENDING)) {
 			return -EALREADY;
 		}

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -137,7 +137,7 @@ int pm_device_state_set(const struct device *dev,
 		return -ENOSYS;
 	}
 
-	ret = dev->pm_control(dev, PM_DEVICE_STATE_SET, &device_power_state);
+	ret = dev->pm_control(dev, &device_power_state);
 	if (ret < 0) {
 		return ret;
 	}

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -137,7 +137,7 @@ int pm_device_state_set(const struct device *dev,
 		return -ENOSYS;
 	}
 
-	ret = dev->pm_control(dev, &device_power_state);
+	ret = dev->pm_control(dev, device_power_state);
 	if (ret < 0) {
 		return ret;
 	}

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -131,23 +131,32 @@ const char *pm_device_state_str(enum pm_device_state state)
 int pm_device_state_set(const struct device *dev,
 			enum pm_device_state device_power_state)
 {
+	int ret;
+
 	if (dev->pm_control == NULL) {
 		return -ENOSYS;
 	}
 
-	return dev->pm_control(dev, PM_DEVICE_STATE_SET,
-			       &device_power_state);
+	ret = dev->pm_control(dev, PM_DEVICE_STATE_SET, &device_power_state);
+	if (ret < 0) {
+		return ret;
+	}
+
+	dev->pm->state = device_power_state;
+
+	return 0;
 }
 
 int pm_device_state_get(const struct device *dev,
-			enum pm_device_state *device_power_state)
+			enum pm_device_state *state)
 {
 	if (dev->pm_control == NULL) {
 		return -ENOSYS;
 	}
 
-	return dev->pm_control(dev, PM_DEVICE_STATE_GET,
-			       device_power_state);
+	*state = dev->pm->state;
+
+	return 0;
 }
 
 bool pm_device_is_any_busy(void)

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -67,7 +67,9 @@ static int _pm_devices(uint32_t state)
 			 * in the right state.
 			 */
 			rc = pm_device_state_set(dev, state);
-			if ((rc != -ENOSYS) && (rc != 0)) {
+			if (rc == -ENOTSUP) {
+				continue;
+			} else if ((rc != -ENOSYS) && (rc != 0)) {
 				LOG_DBG("%s did not enter %s state: %d",
 					dev->name, pm_device_state_str(state),
 					rc);

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -27,13 +27,13 @@ static void pm_device_runtime_state_set(struct pm_device *pm)
 	switch (dev->pm->state) {
 	case PM_DEVICE_STATE_ACTIVE:
 		if ((dev->pm->usage == 0) && dev->pm->enable) {
-			ret = pm_device_state_set(dev, PM_DEVICE_STATE_SUSPEND);
+			ret = pm_device_state_set(dev, PM_DEVICE_STATE_SUSPENDED);
 			if (ret == 0) {
-				dev->pm->state = PM_DEVICE_STATE_SUSPEND;
+				dev->pm->state = PM_DEVICE_STATE_SUSPENDED;
 			}
 		}
 		break;
-	case PM_DEVICE_STATE_SUSPEND:
+	case PM_DEVICE_STATE_SUSPENDED:
 		if ((dev->pm->usage > 0) || !dev->pm->enable) {
 			ret = pm_device_state_set(dev, PM_DEVICE_STATE_ACTIVE);
 			if (ret == 0) {
@@ -77,7 +77,7 @@ static int pm_device_request(const struct device *dev,
 	SYS_PORT_TRACING_FUNC_ENTER(pm, device_request, dev, target_state);
 
 	__ASSERT((target_state == PM_DEVICE_STATE_ACTIVE) ||
-			(target_state == PM_DEVICE_STATE_SUSPEND),
+			(target_state == PM_DEVICE_STATE_SUSPENDED),
 			"Invalid device PM state requested");
 
 	if (k_is_pre_kernel()) {
@@ -101,7 +101,7 @@ static int pm_device_request(const struct device *dev,
 		if (dev->pm->usage == 1) {
 			(void)pm_device_state_set(dev, PM_DEVICE_STATE_ACTIVE);
 		} else if (dev->pm->usage == 0) {
-			(void)pm_device_state_set(dev, PM_DEVICE_STATE_SUSPEND);
+			(void)pm_device_state_set(dev, PM_DEVICE_STATE_SUSPENDED);
 		}
 		goto out;
 	}
@@ -164,12 +164,12 @@ int pm_device_get_async(const struct device *dev)
 
 int pm_device_put(const struct device *dev)
 {
-	return pm_device_request(dev, PM_DEVICE_STATE_SUSPEND, 0);
+	return pm_device_request(dev, PM_DEVICE_STATE_SUSPENDED, 0);
 }
 
 int pm_device_put_async(const struct device *dev)
 {
-	return pm_device_request(dev, PM_DEVICE_STATE_SUSPEND, PM_DEVICE_ASYNC);
+	return pm_device_request(dev, PM_DEVICE_STATE_SUSPENDED, PM_DEVICE_ASYNC);
 }
 
 void pm_device_enable(const struct device *dev)
@@ -179,7 +179,7 @@ void pm_device_enable(const struct device *dev)
 		dev->pm->dev = dev;
 		if (dev->pm_control != NULL) {
 			dev->pm->enable = true;
-			dev->pm->state = PM_DEVICE_STATE_SUSPEND;
+			dev->pm->state = PM_DEVICE_STATE_SUSPENDED;
 			k_work_init_delayable(&dev->pm->work, pm_work_handler);
 		}
 		goto out;
@@ -199,7 +199,7 @@ void pm_device_enable(const struct device *dev)
 	 */
 	if (!dev->pm->dev) {
 		dev->pm->dev = dev;
-		dev->pm->state = PM_DEVICE_STATE_SUSPEND;
+		dev->pm->state = PM_DEVICE_STATE_SUSPENDED;
 		k_work_init_delayable(&dev->pm->work, pm_work_handler);
 	} else {
 		k_work_schedule(&dev->pm->work, K_NO_WAIT);

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -27,7 +27,6 @@ static void pm_device_runtime_state_set(struct pm_device *pm)
 	switch (dev->pm->state) {
 	case PM_DEVICE_STATE_ACTIVE:
 		if ((dev->pm->usage == 0) && dev->pm->enable) {
-			dev->pm->state = PM_DEVICE_STATE_SUSPENDING;
 			ret = pm_device_state_set(dev, PM_DEVICE_STATE_SUSPEND);
 			if (ret == 0) {
 				dev->pm->state = PM_DEVICE_STATE_SUSPEND;
@@ -36,7 +35,6 @@ static void pm_device_runtime_state_set(struct pm_device *pm)
 		break;
 	case PM_DEVICE_STATE_SUSPEND:
 		if ((dev->pm->usage > 0) || !dev->pm->enable) {
-			dev->pm->state = PM_DEVICE_STATE_RESUMING;
 			ret = pm_device_state_set(dev, PM_DEVICE_STATE_ACTIVE);
 			if (ret == 0) {
 				dev->pm->state = PM_DEVICE_STATE_ACTIVE;
@@ -77,6 +75,7 @@ static int pm_device_request(const struct device *dev,
 	int ret = 0;
 
 	SYS_PORT_TRACING_FUNC_ENTER(pm, device_request, dev, target_state);
+
 	__ASSERT((target_state == PM_DEVICE_STATE_ACTIVE) ||
 			(target_state == PM_DEVICE_STATE_SUSPEND),
 			"Invalid device PM state requested");

--- a/tests/drivers/uart/uart_pm/src/main.c
+++ b/tests/drivers/uart/uart_pm/src/main.c
@@ -148,13 +148,13 @@ static void test_uart_pm_in_idle(void)
 	state_verify(dev, PM_DEVICE_STATE_ACTIVE);
 	communication_verify(dev, true);
 
-	state_set(dev, PM_DEVICE_STATE_LOW_POWER, 0);
+	state_set(dev, PM_DEVICE_STATE_SUSPEND, 0);
 	communication_verify(dev, false);
 
 	state_set(dev, PM_DEVICE_STATE_ACTIVE, 0);
 	communication_verify(dev, true);
 
-	state_set(dev, PM_DEVICE_STATE_LOW_POWER, 0);
+	state_set(dev, PM_DEVICE_STATE_SUSPEND, 0);
 	communication_verify(dev, false);
 
 	state_set(dev, PM_DEVICE_STATE_ACTIVE, 0);
@@ -171,7 +171,7 @@ static void test_uart_pm_poll_tx(void)
 	communication_verify(dev, true);
 
 	uart_poll_out(dev, 'a');
-	state_set(dev, PM_DEVICE_STATE_LOW_POWER, 0);
+	state_set(dev, PM_DEVICE_STATE_SUSPEND, 0);
 
 	communication_verify(dev, false);
 
@@ -181,7 +181,7 @@ static void test_uart_pm_poll_tx(void)
 
 	/* Now same thing but with callback */
 	uart_poll_out(dev, 'a');
-	state_set(dev, PM_DEVICE_STATE_LOW_POWER, 0);
+	state_set(dev, PM_DEVICE_STATE_SUSPEND, 0);
 
 	communication_verify(dev, false);
 
@@ -194,7 +194,7 @@ static void timeout(struct k_timer *timer)
 {
 	const struct device *uart = k_timer_user_data_get(timer);
 
-	state_set(uart, PM_DEVICE_STATE_LOW_POWER, 0);
+	state_set(uart, PM_DEVICE_STATE_SUSPEND, 0);
 }
 
 static K_TIMER_DEFINE(pm_timer, timeout, NULL);

--- a/tests/drivers/uart/uart_pm/src/main.c
+++ b/tests/drivers/uart/uart_pm/src/main.c
@@ -148,13 +148,13 @@ static void test_uart_pm_in_idle(void)
 	state_verify(dev, PM_DEVICE_STATE_ACTIVE);
 	communication_verify(dev, true);
 
-	state_set(dev, PM_DEVICE_STATE_SUSPEND, 0);
+	state_set(dev, PM_DEVICE_STATE_SUSPENDED, 0);
 	communication_verify(dev, false);
 
 	state_set(dev, PM_DEVICE_STATE_ACTIVE, 0);
 	communication_verify(dev, true);
 
-	state_set(dev, PM_DEVICE_STATE_SUSPEND, 0);
+	state_set(dev, PM_DEVICE_STATE_SUSPENDED, 0);
 	communication_verify(dev, false);
 
 	state_set(dev, PM_DEVICE_STATE_ACTIVE, 0);
@@ -171,7 +171,7 @@ static void test_uart_pm_poll_tx(void)
 	communication_verify(dev, true);
 
 	uart_poll_out(dev, 'a');
-	state_set(dev, PM_DEVICE_STATE_SUSPEND, 0);
+	state_set(dev, PM_DEVICE_STATE_SUSPENDED, 0);
 
 	communication_verify(dev, false);
 
@@ -181,7 +181,7 @@ static void test_uart_pm_poll_tx(void)
 
 	/* Now same thing but with callback */
 	uart_poll_out(dev, 'a');
-	state_set(dev, PM_DEVICE_STATE_SUSPEND, 0);
+	state_set(dev, PM_DEVICE_STATE_SUSPENDED, 0);
 
 	communication_verify(dev, false);
 
@@ -194,7 +194,7 @@ static void timeout(struct k_timer *timer)
 {
 	const struct device *uart = k_timer_user_data_get(timer);
 
-	state_set(uart, PM_DEVICE_STATE_SUSPEND, 0);
+	state_set(uart, PM_DEVICE_STATE_SUSPENDED, 0);
 }
 
 static K_TIMER_DEFINE(pm_timer, timeout, NULL);

--- a/tests/kernel/device/src/main.c
+++ b/tests/kernel/device/src/main.c
@@ -287,7 +287,7 @@ void test_dummy_device_pm(void)
 {
 	const struct device *dev;
 	int busy, ret;
-	enum pm_device_state device_power_state = PM_DEVICE_STATE_SUSPEND;
+	enum pm_device_state device_power_state = PM_DEVICE_STATE_SUSPENDED;
 
 	dev = device_get_binding(DUMMY_PORT_2);
 	zassert_false((dev == NULL), NULL);

--- a/tests/net/pm/src/main.c
+++ b/tests/net/pm/src/main.c
@@ -22,19 +22,19 @@ struct fake_dev_context {
 };
 
 static int fake_dev_pm_control(const struct device *dev,
-			       enum pm_device_state state)
+			       enum pm_device_action action)
 {
 	struct fake_dev_context *ctx = dev->data;
 	int ret;
 
-	switch (state) {
-	case PM_DEVICE_STATE_SUSPENDED:
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
 		ret = net_if_suspend(ctx->iface);
 		if (ret == -EBUSY) {
 			goto out;
 		}
 		break;
-	case PM_DEVICE_STATE_ACTIVE:
+	case PM_DEVICE_ACTION_RESUME:
 		ret = net_if_resume(ctx->iface);
 		break;
 	default:

--- a/tests/net/pm/src/main.c
+++ b/tests/net/pm/src/main.c
@@ -25,15 +25,21 @@ static int fake_dev_pm_control(const struct device *dev,
 			       enum pm_device_state state)
 {
 	struct fake_dev_context *ctx = dev->data;
-	int ret = 0;
+	int ret;
 
-	if (state == PM_DEVICE_STATE_SUSPENDED) {
+	switch (state) {
+	case PM_DEVICE_STATE_SUSPENDED:
 		ret = net_if_suspend(ctx->iface);
 		if (ret == -EBUSY) {
 			goto out;
 		}
-	} else if (state == PM_DEVICE_STATE_ACTIVE) {
+		break;
+	case PM_DEVICE_STATE_ACTIVE:
 		ret = net_if_resume(ctx->iface);
+		break;
+	default:
+		ret = -ENOTSUP;
+		break;
 	}
 
 out:

--- a/tests/net/pm/src/main.c
+++ b/tests/net/pm/src/main.c
@@ -27,17 +27,13 @@ static int fake_dev_pm_control(const struct device *dev, uint32_t command,
 	struct fake_dev_context *ctx = dev->data;
 	int ret = 0;
 
-	if (command == PM_DEVICE_STATE_SET) {
-		if (*state == PM_DEVICE_STATE_SUSPEND) {
-			ret = net_if_suspend(ctx->iface);
-			if (ret == -EBUSY) {
-				goto out;
-			}
-		} else if (*state == PM_DEVICE_STATE_ACTIVE) {
-			ret = net_if_resume(ctx->iface);
+	if (*state == PM_DEVICE_STATE_SUSPEND) {
+		ret = net_if_suspend(ctx->iface);
+		if (ret == -EBUSY) {
+			goto out;
 		}
-	} else {
-		return -EINVAL;
+	} else if (*state == PM_DEVICE_STATE_ACTIVE) {
+		ret = net_if_resume(ctx->iface);
 	}
 
 out:

--- a/tests/net/pm/src/main.c
+++ b/tests/net/pm/src/main.c
@@ -21,7 +21,7 @@ struct fake_dev_context {
 	struct net_if *iface;
 };
 
-static int fake_dev_pm_control(const struct device *dev, uint32_t command,
+static int fake_dev_pm_control(const struct device *dev,
 			       enum pm_device_state *state)
 {
 	struct fake_dev_context *ctx = dev->data;

--- a/tests/net/pm/src/main.c
+++ b/tests/net/pm/src/main.c
@@ -27,7 +27,7 @@ static int fake_dev_pm_control(const struct device *dev,
 	struct fake_dev_context *ctx = dev->data;
 	int ret = 0;
 
-	if (state == PM_DEVICE_STATE_SUSPEND) {
+	if (state == PM_DEVICE_STATE_SUSPENDED) {
 		ret = net_if_suspend(ctx->iface);
 		if (ret == -EBUSY) {
 			goto out;
@@ -142,13 +142,13 @@ void test_pm(void)
 	 */
 	k_yield();
 
-	ret = pm_device_state_set(dev, PM_DEVICE_STATE_SUSPEND);
+	ret = pm_device_state_set(dev, PM_DEVICE_STATE_SUSPENDED);
 	zassert_true(ret == 0, "Could not set state");
 
 	zassert_true(net_if_is_suspended(iface), "net iface is not suspended");
 
 	/* Let's try to suspend it again, it should fail relevantly */
-	ret = pm_device_state_set(dev, PM_DEVICE_STATE_SUSPEND);
+	ret = pm_device_state_set(dev, PM_DEVICE_STATE_SUSPENDED);
 	zassert_true(ret == -EALREADY, "Could change state");
 
 	zassert_true(net_if_is_suspended(iface), "net iface is not suspended");

--- a/tests/net/pm/src/main.c
+++ b/tests/net/pm/src/main.c
@@ -22,17 +22,17 @@ struct fake_dev_context {
 };
 
 static int fake_dev_pm_control(const struct device *dev,
-			       enum pm_device_state *state)
+			       enum pm_device_state state)
 {
 	struct fake_dev_context *ctx = dev->data;
 	int ret = 0;
 
-	if (*state == PM_DEVICE_STATE_SUSPEND) {
+	if (state == PM_DEVICE_STATE_SUSPEND) {
 		ret = net_if_suspend(ctx->iface);
 		if (ret == -EBUSY) {
 			goto out;
 		}
-	} else if (*state == PM_DEVICE_STATE_ACTIVE) {
+	} else if (state == PM_DEVICE_STATE_ACTIVE) {
 		ret = net_if_resume(ctx->iface);
 	}
 

--- a/tests/subsys/pm/device_runtime/src/dummy_driver.c
+++ b/tests/subsys/pm/device_runtime/src/dummy_driver.c
@@ -38,18 +38,7 @@ static int dummy_device_pm_ctrl(const struct device *dev,
 				uint32_t ctrl_command,
 				enum pm_device_state *state)
 {
-	int ret;
-
-	switch (ctrl_command) {
-	case PM_DEVICE_STATE_SET:
-		ret = 0;
-		break;
-	default:
-		ret = -EINVAL;
-
-	}
-
-	return ret;
+	return 0;
 }
 
 static const struct dummy_driver_api funcs = {

--- a/tests/subsys/pm/device_runtime/src/dummy_driver.c
+++ b/tests/subsys/pm/device_runtime/src/dummy_driver.c
@@ -35,7 +35,7 @@ static int dummy_close_sync(const struct device *dev)
 }
 
 static int dummy_device_pm_ctrl(const struct device *dev,
-				enum pm_device_state *state)
+				enum pm_device_state state)
 {
 	return 0;
 }

--- a/tests/subsys/pm/device_runtime/src/dummy_driver.c
+++ b/tests/subsys/pm/device_runtime/src/dummy_driver.c
@@ -9,8 +9,6 @@
 #include <pm/device_runtime.h>
 #include "dummy_driver.h"
 
-static uint32_t device_power_state;
-
 static int dummy_wait(const struct device *dev)
 {
 	return pm_device_wait(dev, K_FOREVER);
@@ -36,39 +34,15 @@ static int dummy_close_sync(const struct device *dev)
 	return pm_device_put(dev);
 }
 
-static uint32_t dummy_get_power_state(const struct device *dev)
-{
-	return device_power_state;
-}
-
-static int dummy_suspend(const struct device *dev)
-{
-	device_power_state = PM_DEVICE_STATE_SUSPEND;
-	return 0;
-}
-
-static int dummy_resume_from_suspend(const struct device *dev)
-{
-	device_power_state = PM_DEVICE_STATE_ACTIVE;
-	return 0;
-}
-
 static int dummy_device_pm_ctrl(const struct device *dev,
 				uint32_t ctrl_command,
 				enum pm_device_state *state)
 {
-	int ret = 0;
+	int ret;
 
 	switch (ctrl_command) {
 	case PM_DEVICE_STATE_SET:
-		if (*state == PM_DEVICE_STATE_ACTIVE) {
-			ret = dummy_resume_from_suspend(dev);
-		} else {
-			ret = dummy_suspend(dev);
-		}
-		break;
-	case PM_DEVICE_STATE_GET:
-		*state = dummy_get_power_state(dev);
+		ret = 0;
 		break;
 	default:
 		ret = -EINVAL;

--- a/tests/subsys/pm/device_runtime/src/dummy_driver.c
+++ b/tests/subsys/pm/device_runtime/src/dummy_driver.c
@@ -35,7 +35,7 @@ static int dummy_close_sync(const struct device *dev)
 }
 
 static int dummy_device_pm_ctrl(const struct device *dev,
-				enum pm_device_state state)
+				enum pm_device_action action)
 {
 	return 0;
 }

--- a/tests/subsys/pm/device_runtime/src/dummy_driver.c
+++ b/tests/subsys/pm/device_runtime/src/dummy_driver.c
@@ -35,7 +35,6 @@ static int dummy_close_sync(const struct device *dev)
 }
 
 static int dummy_device_pm_ctrl(const struct device *dev,
-				uint32_t ctrl_command,
 				enum pm_device_state *state)
 {
 	return 0;

--- a/tests/subsys/pm/device_runtime/src/main.c
+++ b/tests/subsys/pm/device_runtime/src/main.c
@@ -48,7 +48,7 @@ void threadA_func(void *arg1, void *arg2, void *arg3)
 	/* At this point threadB should have put the device and
 	 * the current state should be SUSPENDED.
 	 */
-	zassert_true(dev->pm->state == PM_DEVICE_STATE_SUSPEND, "Wrong state");
+	zassert_true(dev->pm->state == PM_DEVICE_STATE_SUSPENDED, "Wrong state");
 
 	k_sem_take(&sem, K_FOREVER);
 
@@ -81,7 +81,7 @@ void threadB_func(void *arg1, void *arg2, void *arg3)
 	zassert_true(ret == 0, "Fail to wait transaction");
 
 	/* Check the state */
-	zassert_true(dev->pm->state == PM_DEVICE_STATE_SUSPEND, "Wrong state");
+	zassert_true(dev->pm->state == PM_DEVICE_STATE_SUSPENDED, "Wrong state");
 }
 
 /*
@@ -135,7 +135,7 @@ void test_teardown(void)
 	ret = api->close_sync(dev);
 	zassert_true(ret == 0, "Fail to suspend device");
 
-	zassert_true(dev->pm->state == PM_DEVICE_STATE_SUSPEND, "Wrong state");
+	zassert_true(dev->pm->state == PM_DEVICE_STATE_SUSPENDED, "Wrong state");
 }
 
 /*
@@ -161,7 +161,7 @@ void test_sync(void)
 	ret = api->close_sync(dev);
 	zassert_true(ret == 0, "Fail to suspend device");
 
-	zassert_true(dev->pm->state == PM_DEVICE_STATE_SUSPEND, "Wrong state");
+	zassert_true(dev->pm->state == PM_DEVICE_STATE_SUSPENDED, "Wrong state");
 }
 
 /*
@@ -186,7 +186,7 @@ void test_multiple_times(void)
 		ret = api->close_sync(dev);
 		zassert_true(ret == 0, "Fail to suspend device");
 
-		zassert_true(dev->pm->state == PM_DEVICE_STATE_SUSPEND, "Wrong state");
+		zassert_true(dev->pm->state == PM_DEVICE_STATE_SUSPENDED, "Wrong state");
 	}
 
 	/* Now do all requests for get and then all for put*/
@@ -204,7 +204,7 @@ void test_multiple_times(void)
 	zassert_true(ret == 0, "Fail to wait transaction");
 
 	/* Check the state */
-	zassert_true(dev->pm->state == PM_DEVICE_STATE_SUSPEND, "Wrong state");
+	zassert_true(dev->pm->state == PM_DEVICE_STATE_SUSPENDED, "Wrong state");
 
 	/* Finally off by one to keep the device active*/
 	for (i = 0; i < MAX_TIMES; i++) {

--- a/tests/subsys/pm/power_mgmt/src/dummy_driver.c
+++ b/tests/subsys/pm/power_mgmt/src/dummy_driver.c
@@ -23,18 +23,7 @@ static int dummy_device_pm_ctrl(const struct device *dev,
 				uint32_t ctrl_command,
 				enum pm_device_state *state)
 {
-	int ret;
-
-	switch (ctrl_command) {
-	case PM_DEVICE_STATE_SET:
-		ret = 0;
-		break;
-	default:
-		ret = -EINVAL;
-
-	}
-
-	return ret;
+	return 0;
 }
 
 static const struct dummy_driver_api funcs = {

--- a/tests/subsys/pm/power_mgmt/src/dummy_driver.c
+++ b/tests/subsys/pm/power_mgmt/src/dummy_driver.c
@@ -20,7 +20,7 @@ static int dummy_close(const struct device *dev)
 }
 
 static int dummy_device_pm_ctrl(const struct device *dev,
-				enum pm_device_state state)
+				enum pm_device_action action)
 {
 	return 0;
 }

--- a/tests/subsys/pm/power_mgmt/src/dummy_driver.c
+++ b/tests/subsys/pm/power_mgmt/src/dummy_driver.c
@@ -20,7 +20,6 @@ static int dummy_close(const struct device *dev)
 }
 
 static int dummy_device_pm_ctrl(const struct device *dev,
-				uint32_t ctrl_command,
 				enum pm_device_state *state)
 {
 	return 0;

--- a/tests/subsys/pm/power_mgmt/src/dummy_driver.c
+++ b/tests/subsys/pm/power_mgmt/src/dummy_driver.c
@@ -9,8 +9,6 @@
 #include <pm/device_runtime.h>
 #include "dummy_driver.h"
 
-static enum pm_device_state device_power_state;
-
 static int dummy_open(const struct device *dev)
 {
 	return pm_device_get(dev);
@@ -21,39 +19,15 @@ static int dummy_close(const struct device *dev)
 	return pm_device_put(dev);
 }
 
-static uint32_t dummy_get_power_state(const struct device *dev)
-{
-	return device_power_state;
-}
-
-static int dummy_suspend(const struct device *dev)
-{
-	device_power_state = PM_DEVICE_STATE_SUSPEND;
-	return 0;
-}
-
-static int dummy_resume_from_suspend(const struct device *dev)
-{
-	device_power_state = PM_DEVICE_STATE_ACTIVE;
-	return 0;
-}
-
 static int dummy_device_pm_ctrl(const struct device *dev,
 				uint32_t ctrl_command,
 				enum pm_device_state *state)
 {
-	int ret = 0;
+	int ret;
 
 	switch (ctrl_command) {
 	case PM_DEVICE_STATE_SET:
-		if (*state == PM_DEVICE_STATE_ACTIVE) {
-			ret = dummy_resume_from_suspend(dev);
-		} else {
-			ret = dummy_suspend(dev);
-		}
-		break;
-	case PM_DEVICE_STATE_GET:
-		*state = dummy_get_power_state(dev);
+		ret = 0;
 		break;
 	default:
 		ret = -EINVAL;

--- a/tests/subsys/pm/power_mgmt/src/dummy_driver.c
+++ b/tests/subsys/pm/power_mgmt/src/dummy_driver.c
@@ -20,7 +20,7 @@ static int dummy_close(const struct device *dev)
 }
 
 static int dummy_device_pm_ctrl(const struct device *dev,
-				enum pm_device_state *state)
+				enum pm_device_state state)
 {
 	return 0;
 }

--- a/tests/subsys/pm/power_mgmt/src/main.c
+++ b/tests/subsys/pm/power_mgmt/src/main.c
@@ -181,7 +181,7 @@ void test_power_state_notification(void)
 
 	api->close(dev);
 	pm_device_state_get(dev, &device_power_state);
-	zassert_equal(device_power_state, PM_DEVICE_STATE_SUSPEND, NULL);
+	zassert_equal(device_power_state, PM_DEVICE_STATE_SUSPENDED, NULL);
 	/* reopen device as it will be closed in teardown */
 	api->open(dev);
 }


### PR DESCRIPTION
Summary:

- Remove usage of local states, the device PM subsystem already holds device PM state
- The "ctrl_command" is removed, since the PM control callback will now always be called to set the state, not to retrieve it.
- The state is passed as a value, since it does not need to be written by the PM control callback
- The callback is only called for a state change, thus simplifying driver operation (no need for state change checks)
- Converged _low power_ states to `PM_DEVICE_STATE_SUSPEND`. This makes interoperability between system and device PM easier. The low power state is still kept, but its future is unclear and needs some discussion.
- Device PM control function return codes are now documented.
- Multiple implementation cleanups.
- Introduction of the _actions_ concept. Devices will now receive actions instead of states, for example, a device will be told to "suspend" or to "resume".