### PR TITLE
mgmt/mcumgr: Allow using UART async API

### DIFF
--- a/drivers/console/uart_mcumgr.c
+++ b/drivers/console/uart_mcumgr.c
@@ -33,6 +33,11 @@ static bool uart_mcumgr_ignoring;
 K_MEM_SLAB_DEFINE(uart_mcumgr_slab, sizeof(struct uart_mcumgr_rx_buf),
 		  CONFIG_UART_MCUMGR_RX_BUF_COUNT, 1);
 
+#if defined(CONFIG_MCUMGR_SMP_UART_ASYNC)
+uint8_t async_buffer[CONFIG_MCUMGR_SMP_UART_ASYNC_BUFS][CONFIG_MCUMGR_SMP_UART_ASYNC_BUF_SIZE];
+static int async_current;
+#endif
+
 static struct uart_mcumgr_rx_buf *uart_mcumgr_alloc_rx_buf(void)
 {
 	struct uart_mcumgr_rx_buf *rx_buf;
@@ -57,6 +62,7 @@ void uart_mcumgr_free_rx_buf(struct uart_mcumgr_rx_buf *rx_buf)
 	k_mem_slab_free(&uart_mcumgr_slab, &block);
 }
 
+#if !defined(CONFIG_MCUMGR_SMP_UART_ASYNC)
 /**
  * Reads a chunk of received data from the UART.
  */
@@ -68,6 +74,7 @@ static int uart_mcumgr_read_chunk(void *buf, int capacity)
 
 	return uart_fifo_read(uart_mcumgr_dev, buf, capacity);
 }
+#endif
 
 /**
  * Processes a single incoming byte.
@@ -111,6 +118,52 @@ static struct uart_mcumgr_rx_buf *uart_mcumgr_rx_byte(uint8_t byte)
 	return NULL;
 }
 
+#if defined(CONFIG_MCUMGR_SMP_UART_ASYNC)
+static void uart_mcumgr_async(const struct device *dev, struct uart_event *evt, void *user_data)
+{
+	struct uart_mcumgr_rx_buf *rx_buf;
+	uint8_t *p;
+	int len;
+
+	ARG_UNUSED(dev);
+
+	switch (evt->type) {
+	case UART_TX_DONE:
+	case UART_TX_ABORTED:
+		break;
+	case UART_RX_RDY:
+		len = evt->data.rx.len;
+		p = &evt->data.rx.buf[evt->data.rx.offset];
+
+		for (int i = 0; i < len; i++) {
+			rx_buf = uart_mcumgr_rx_byte(p[i]);
+			if (rx_buf != NULL) {
+				uart_mgumgr_recv_cb(rx_buf);
+			}
+		}
+		break;
+	case UART_RX_DISABLED:
+		async_current = 0;
+		break;
+	case UART_RX_BUF_REQUEST:
+		/*
+		 * Note that when buffer gets filled, the UART_RX_BUF_RELEASED will be reported,
+		 * aside to UART_RX_RDY.  The UART_RX_BUF_RELEASED is not processed because
+		 * it has been assumed that the mcumgr will be able to consume bytes faster
+		 * than UART will receive them and, since there is nothing to release, only
+		 * UART_RX_BUF_REQUEST is processed.
+		 */
+		++async_current;
+		async_current %= CONFIG_MCUMGR_SMP_UART_ASYNC_BUFS;
+		uart_rx_buf_rsp(dev, async_buffer[async_current],
+				sizeof(async_buffer[async_current]));
+		break;
+	case UART_RX_BUF_RELEASED:
+	case UART_RX_STOPPED:
+		break;
+	}
+}
+#else
 /**
  * ISR that is called when UART bytes are received.
  */
@@ -140,6 +193,7 @@ static void uart_mcumgr_isr(const struct device *unused, void *user_data)
 		}
 	}
 }
+#endif
 
 /**
  * Sends raw data over the UART.
@@ -161,6 +215,15 @@ int uart_mcumgr_send(const uint8_t *data, int len)
 	return mcumgr_serial_tx_pkt(data, len, uart_mcumgr_send_raw, NULL);
 }
 
+
+#if defined(CONFIG_MCUMGR_SMP_UART_ASYNC)
+static void uart_mcumgr_setup(const struct device *uart)
+{
+	uart_callback_set(uart, uart_mcumgr_async, NULL);
+
+	uart_rx_enable(uart, async_buffer[0], sizeof(async_buffer[0]), 0);
+}
+#else
 static void uart_mcumgr_setup(const struct device *uart)
 {
 	uint8_t c;
@@ -177,6 +240,7 @@ static void uart_mcumgr_setup(const struct device *uart)
 
 	uart_irq_rx_enable(uart);
 }
+#endif
 
 void uart_mcumgr_register(uart_mcumgr_recv_fn *cb)
 {

--- a/subsys/mgmt/mcumgr/Kconfig
+++ b/subsys/mgmt/mcumgr/Kconfig
@@ -279,6 +279,33 @@ config MCUMGR_SMP_UART
 	  commands to be received over UART without requiring an additional
 	  thread.
 
+if UART_ASYNC_API && MCUMGR_SMP_UART
+
+menuconfig MCUMGR_SMP_UART_ASYNC
+	bool "Use async UART API when available"
+	help
+	  The option enables use of UART async API when available for selected mcumgr uart port.
+
+if MCUMGR_SMP_UART_ASYNC
+config MCUMGR_SMP_UART_ASYNC_BUFS
+	int "Number of async RX UART buffers"
+	range 2 8
+	default 2
+	help
+	  The asynchronous UART API requires registering RX buffers for received data; when the RX
+	  reaches the end of a buffer, it will send event requesting next buffer, to be able to
+	  receive data without stopping due to running out of buffer space.  At least two buffers
+	  area required for smooth RX operation.
+
+config MCUMGR_SMP_UART_ASYNC_BUF_SIZE
+	int "Size of single async RX UART buffer"
+	default 64
+	help
+	  The size of single buffer for asynchronous RX.
+
+endif # MCUMGR_SMP_UART_ASYNC
+endif # UART_ASYNC_API
+
 config MCUMGR_SMP_UART_MTU
 	int "UART SMP MTU"
 	default 256


### PR DESCRIPTION
The commit provides preliminary support for async UART within
mcumgr.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>