### PR TITLE
drivers: usb: device: Rename usb_dc_sam to usb_dc_sam_usbhs

### DIFF
--- a/drivers/usb/device/CMakeLists.txt
+++ b/drivers/usb/device/CMakeLists.txt
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_sources_ifdef(CONFIG_USB_DW       usb_dc_dw.c)
-zephyr_sources_ifdef(CONFIG_USB_DC_STM32 usb_dc_stm32.c)
-zephyr_sources_ifdef(CONFIG_USB_DC_SAM0  usb_dc_sam0.c)
-zephyr_sources_ifdef(CONFIG_USB_DC_SAM   usb_dc_sam.c)
-zephyr_sources_ifdef(CONFIG_USB_NRFX     usb_dc_nrfx.c)
-zephyr_sources_ifdef(CONFIG_USB_KINETIS  usb_dc_kinetis.c)
+zephyr_sources_ifdef(CONFIG_USB_DW           usb_dc_dw.c)
+zephyr_sources_ifdef(CONFIG_USB_DC_STM32     usb_dc_stm32.c)
+zephyr_sources_ifdef(CONFIG_USB_DC_SAM0      usb_dc_sam0.c)
+zephyr_sources_ifdef(CONFIG_USB_DC_SAM_USBHS usb_dc_sam_usbhs.c)
+zephyr_sources_ifdef(CONFIG_USB_NRFX         usb_dc_nrfx.c)
+zephyr_sources_ifdef(CONFIG_USB_KINETIS      usb_dc_kinetis.c)
 zephyr_sources_ifdef(CONFIG_USB_NATIVE_POSIX
 	usb_dc_native_posix.c
 	usb_dc_native_posix_adapt.c

--- a/drivers/usb/device/Kconfig
+++ b/drivers/usb/device/Kconfig
@@ -39,7 +39,7 @@ config USB_DC_SAM0
 	help
 	  SAM0 family USB device controller Driver.
 
-config USB_DC_SAM
+config USB_DC_SAM_USBHS
 	bool "SAM series USB HS Device Controller driver"
 	depends on SOC_SERIES_SAME70 || \
 		   SOC_SERIES_SAMV71

--- a/drivers/usb/device/usb_dc_sam_usbhs.c
+++ b/drivers/usb/device/usb_dc_sam_usbhs.c
@@ -12,7 +12,7 @@
 
 #define LOG_LEVEL CONFIG_USB_DRIVER_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(usb_dc_sam);
+LOG_MODULE_REGISTER(usb_dc_sam_usbhs);
 
 /*
  * This is defined in the support files for the SAM S7x, but not for

--- a/soc/arm/atmel_sam/same70/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam/same70/Kconfig.defconfig.series
@@ -65,7 +65,7 @@ config SPI_SAM
 	default y
 	depends on SPI
 
-config USB_DC_SAM
+config USB_DC_SAM_USBHS
 	default y
 	depends on USB
 

--- a/soc/arm/atmel_sam/samv71/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam/samv71/Kconfig.defconfig.series
@@ -66,7 +66,7 @@ config SPI_SAM
 	default y
 	depends on SPI
 
-config USB_DC_SAM
+config USB_DC_SAM_USBHS
 	default y
 	depends on USB
 


### PR DESCRIPTION
The SoC driver name is 'USB High-Speed Interface (USBHS)'. This rename from usb_dc_sam to usb_dc_sam_usbhs allowing add others SoC drivers like 'USB Device Port (UDP)' that is found at SAM4S/E variations.

Signed-off-by: Gerson Fernando Budke <nandojve@gmail.com>