### PR TITLE
testsuite: suppress usage of setjmp in a testcode (rule 21_4-a)

### DIFF
--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -207,8 +207,14 @@ static void run_test_functions(struct unit_test *test)
 }
 
 #ifndef KERNEL
-/* parasoft suppress item MISRAC2012-RULE_21_4-b "setjmp using in test code" */
-#include <setjmp.h>
+
+/* Static code analysis tool can raise a violation that the standard header
+ * <setjmp.h> shall not be used.
+ *
+ * setjmp is using in a test code, not in a runtime code, it is acceptable.
+ * It is a deliberate deviation.
+ */
+#include <setjmp.h> /* parasoft-suppress MISRAC2012-RULE_21_4-a MISRAC2012-RULE_21_4-b*/
 #include <signal.h>
 #include <string.h>
 #include <stdlib.h>


### PR DESCRIPTION
According to the rule MISRAC-2012 21.4.a the standard header
file <setjmp.h> shall not be used. Suppress it, because it raises
violation in a testcode, not in a runtime code.
Tag suppresses reporting of violation for the current file,
starting from the line where the suppression is located.
It is a deliberate deviation.

Found as a coding guideline violation (MISRA R21.4.a) by static
coding scanning tool.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>