### PR TITLE
lib: add explanation comment in "work->handler" case

### DIFF
--- a/kernel/work.c
+++ b/kernel/work.c
@@ -597,6 +597,19 @@ static void work_queue_main(void *workq_ptr, void *p2, void *p3)
 			work = CONTAINER_OF(node, struct k_work, node);
 			flag_set(&work->flags, K_WORK_RUNNING_BIT);
 			flag_clear(&work->flags, K_WORK_QUEUED_BIT);
+
+			/* Static code analysis tool can raise a false-positive violation
+			 * in the line below that 'work' is checked for null after being
+			 * dereferenced.
+			 *
+			 * The work is figured out by CONTAINER_OF, as a container
+			 * of type struct k_work that contains the node.
+			 * The only way for it to be NULL is if node would be a member
+			 * of struct k_work object that has been placed at address NULL,
+			 * which should never happen, even line 'if (work != NULL)'
+			 * ensures that.
+			 * This means that if node is not NULL, then work will not be NULL.
+			 */
 			handler = work->handler;
 		} else if (flag_test_and_clear(&queue->flags,
 					       K_WORK_QUEUE_DRAIN_BIT)) {


### PR DESCRIPTION
Coding scanning tool raises a violation that happens dereferencing
of the "work" pointer in the expression "work->handler"

As were discussed before in PR #35664 it is not true.
Add explanation comment, because static code analysis tool raised false-positive
violation there.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>