### PR TITLE
libc: types: suppress deviation

### DIFF
--- a/lib/libc/minimal/include/sys/types.h
+++ b/lib/libc/minimal/include/sys/types.h
@@ -16,11 +16,15 @@ typedef unsigned int mode_t;
 #if !defined(__ssize_t_defined)
 #define __ssize_t_defined
 
-/* parasoft suppress item MISRAC2012-RULE_20_4-a item MISRAC2012-RULE_20_4-b
- * "Trick compiler to make sure the type of ssize_t won't be
- * unsigned long. View details in commit b889120"
+/* Static code analysis tool can raise a violation
+ * in the line below where name of macro 'unsigned' is the same
+ * as keyword. It is made on purpose, deliberated deviation.
+ *
+ * We trick compiler to make sure the type of ssize_t won't be unsigned long.
+ * As otherwise the type of ssize_t will be unsigned long
+ * which is not correct. More details view in commit b889120
  */
-#define unsigned signed
+#define unsigned signed /* parasoft-suppress MISRAC2012-RULE_20_4-a MISRAC2012-RULE_20_4-b */
 typedef __SIZE_TYPE__ ssize_t;
 #undef unsigned
 


### PR DESCRIPTION
Suppress violation, because it is a deliberated deviation.
Noticed, that my previous PR #36420 comments were not correctly
detected by a static analysis tool. Only the first one item
"MISRAC2012-RULE_20_4-a" was detected and suppressed.

Change comment style, so each item will be suppressed.
Comment style defined in PR #36911 as the most suitable for the analysis tool.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>