### PR TITLE
Bluetooth: host: introduce timeout in limited advertising

### DIFF
--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -106,6 +106,16 @@ config BT_BROADCASTER
 
 endmenu
 
+config BT_LIM_ADV_TIMEOUT
+	int "Timeout for limited advertising in 1s units"
+	default 30
+	range 1 180
+	help
+	  After this timeout is reached, advertisement with BT_LE_AD_LIMITED flag
+	  set shall be terminated. As per BT Core Spec 5.2, Vol 3, Part C,
+	  Appendix A (NORMATIVE): TIMERS AND CONSTANTS it's required to be no more
+	  than 180s.
+
 config BT_EXT_ADV
 	bool "Extended Advertising and Scanning support [EXPERIMENTAL]"
 	help

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -150,6 +150,8 @@ struct bt_le_ext_adv {
 	/* TX Power in use by the controller */
 	int8_t                    tx_power;
 #endif /* defined(CONFIG_BT_EXT_ADV) */
+
+	struct k_work_delayable	timeout_work;
 };
 
 enum {


### PR DESCRIPTION
In limited advertising advertising should end after certain timeout.
Previously, limited advertising was just general advertising with
BT_LE_AD_LIMITED flag set. Now, if this flag is set the work is
scheduled, that will disable advertising after timeout.

This affects tests GAP/DISC/LIMM/BV-03-C and GAP/DISC/LIMM/BV-04-C

Signed-off-by: Krzysztof Kopyściński krzysztof.kopyscinski@codecoup.pl