### PR TITLE
doc, cpp: Update CXX support to show exception support

### DIFF
--- a/doc/reference/kernel/other/cxx_support.rst
+++ b/doc/reference/kernel/other/cxx_support.rst
@@ -16,7 +16,6 @@ following features are *not* supported:
 
 * Dynamic object management with the **new** and **delete** operators
 * :abbr:`RTTI (runtime type information)`
-* Exceptions
 * Static global object destruction
 
 While not an exhaustive list, support for the following functionality is
@@ -26,6 +25,7 @@ included:
 * Virtual functions
 * Virtual tables
 * Static global object constructors
+* Exceptions
 
 Static global object constructors are initialized after the drivers are
 initialized but before the application :c:func:`main()` function. Therefore,


### PR DESCRIPTION
Updates CXX support documentation to reflect exception support added in fixes for #32448 and #35772.

Signed-off-by: Lauren Murphy <lauren.murphy@intel.com>