### PR TITLE
dts: stm32l0: add usart4 and usart5

### DIFF
--- a/dts/arm/st/l0/stm32l071.dtsi
+++ b/dts/arm/st/l0/stm32l071.dtsi
@@ -137,6 +137,24 @@
 			label = "UART_1";
 		};
 
+		usart4: serial@40004c00 {
+			compatible = "st,stm32-usart", "st,stm32-uart";
+			reg = <0x40004c00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00080000>;
+			interrupts = <14 0>;
+			status = "disabled";
+			label = "UART_4";
+		};
+
+		usart5: serial@40005000 {
+			compatible = "st,stm32-usart", "st,stm32-uart";
+			reg = <0x40005000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00100000>;
+			interrupts = <14 0>;
+			status = "disabled";
+			label = "UART_5";
+		};
+
 		eeprom: eeprom@8080000{
 			reg = <0x08080000 DT_SIZE_K(6)>;
 		};


### PR DESCRIPTION
add devicetree node for usart4 and usart5.  usart4 and 5
shares the same interrupt line (14), hence both can't be enabled
at the same time.

Signed-off-by: Parthiban Nallathambi <parthiban@linumiz.com>