### PR TITLE
pcie: msi: Map only actual table

### DIFF
--- a/drivers/pcie/host/msi.c
+++ b/drivers/pcie/host/msi.c
@@ -69,7 +69,7 @@ static bool map_msix_table_entries(pcie_bdf_t bdf,
 
 	z_phys_map((uint8_t **)&mapped_table,
 		   bar.phys_addr + table_offset,
-		   bar.size, K_MEM_PERM_RW);
+		   n_vector * PCIE_MSIR_TABLE_ENTRY_SIZE, K_MEM_PERM_RW);
 
 	for (i = 0; i < n_vector; i++) {
 		vectors[i].msix_vector = (struct msix_vector *)


### PR DESCRIPTION
Map only actual table of size n_vector * PCIE_MSIR_TABLE_ENTRY_SIZE.