### PR TITLE
boards: thingy53_nrf5340: Enable uart0 on network core

### DIFF
--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpunet.dts
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpunet.dts
@@ -89,7 +89,7 @@
 
 &uart0 {
 	compatible = "nordic,nrf-uarte";
-	status = "disabled";
+	status = "okay";
 	current-speed = <115200>;
 	tx-pin = <12>;
 	rx-pin = <11>;

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpunet_defconfig
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpunet_defconfig
@@ -13,5 +13,9 @@ CONFIG_HW_STACK_PROTECTION=y
 # Enable GPIO
 CONFIG_GPIO=y
 
+# Enable uart driver
+CONFIG_SERIAL=y
+
 # Enable console
 CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y


### PR DESCRIPTION
uart0 is used as default console output in Zephyr. Change prevents assertion fail in default configuration of hci_rpmsg sample. The
failing assertion is related to enabling logger without backend.