### PR TITLE
tests: remove kernel tag from key tests/samples

### DIFF
--- a/samples/synchronization/sample.yaml
+++ b/samples/synchronization/sample.yaml
@@ -5,7 +5,7 @@ sample:
 tests:
   sample.kernel.synchronization:
     build_on_all: true
-    tags: kernel synchronization
+    tags: synchronization
     harness: console
     harness_config:
       type: multi_line

--- a/tests/kernel/common/testcase.yaml
+++ b/tests/kernel/common/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: kernel userspace
+  tags: base userspace
   min_flash: 33
 tests:
   kernel.common:
@@ -16,14 +16,12 @@ tests:
     extra_configs:
       - CONFIG_MISRA_SANE=y
   kernel.common.nano32:
-    tags: kernel userspace
     filter: not CONFIG_KERNEL_COHERENCE
     extra_configs:
       - CONFIG_CBPRINTF_NANO=y
       - CONFIG_CBPRINTF_REDUCED_INTEGRAL=y
     platform_exclude: qemu_arc_hs6x
   kernel.common.nano64:
-    tags: kernel userspace
     filter: not CONFIG_KERNEL_COHERENCE
     extra_configs:
       - CONFIG_CBPRINTF_NANO=y


### PR DESCRIPTION
Thos tests/samples are used to build any PR onl all available boards to
verify basic sanity. Having the kernel tag means they can get excluded
for random non-kernel changes causing regressions. so remove kernel tag
to keep them in all CI runs.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
