### PR TITLE
soc: arm: stm32l0: enable clock before accessing DBGMCU registers

### DIFF
--- a/soc/arm/st_stm32/stm32l0/power.c
+++ b/soc/arm/st_stm32/stm32l0/power.c
@@ -86,6 +86,7 @@ static int stm32_power_init(const struct device *dev)
 
 #ifdef CONFIG_DEBUG
 	/* Enable the Debug Module during STOP mode */
+	LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_DBGMCU);
 	LL_DBGMCU_EnableDBGStopMode();
 #endif /* CONFIG_DEBUG */
 


### PR DESCRIPTION
soc: arm: stm32l0: enable clock before accessing DBGMCU registers

Some STM32 series (l0, g0, f0) need to enable clock of
DBGMCU peripheral, before accessing registers.
Currently only L0 is concerned.