### PR TITLE
soc: boards: Enable Segger RTT/SystemView on mimxrt1170_evk_cm7

### DIFF
--- a/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm7.dts
+++ b/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm7.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,sram = &sdram0;
+		zephyr,dtcm = &dtcm;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 	};

--- a/soc/arm/nxp_imx/rt/soc_rt11xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt11xx.c
@@ -349,6 +349,13 @@ static ALWAYS_INLINE void clock_init(void)
 	GPC_CM_SetNextCpuMode(GPC_CPU_MODE_CTRL_1, kGPC_RunMode);
 	GPC_CM_EnableCpuSleepHold(GPC_CPU_MODE_CTRL_0, false);
 	GPC_CM_EnableCpuSleepHold(GPC_CPU_MODE_CTRL_1, false);
+
+#ifdef CONFIG_SEGGER_RTT_SECTION_DTCM
+	/* Enable the AHB clock while the CM7 is sleeping to allow debug access
+	 * to TCM
+	 */
+	IOMUXC_GPR->GPR16 |= IOMUXC_GPR_GPR16_CM7_FORCE_HCLK_EN_MASK;
+#endif
 }
 
 /**


### PR DESCRIPTION
Adds a devicetree chosen node to the mimxrt1170_evk_cm7 board to link
Segger RTT and SystemView sections in DTCM by default. Enables the AHB
clock while the CM7 is sleeping to allow debug access to the TCM.

Note that automatic RTT control block detection may not search the DTCM
address region, therefore you may need to manually set the RTT control
block address or search range in the Segger host tools (SystemView or
RTT Viewer). For example,

$ JLinkRTTViewer -ra 0x20000000

Tested with:
  - samples/subsys/shell/shell_module/
  - samples/subsys/tracing/

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Follow up to #36704