### PR TITLE
Revert "boards: thingy53_nrf5340: Enable uart0 on network core"

### DIFF
--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpunet.dts
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpunet.dts
@@ -89,7 +89,7 @@
 
 &uart0 {
 	compatible = "nordic,nrf-uarte";
-	status = "okay";
+	status = "disabled";
 	current-speed = <115200>;
 	tx-pin = <12>;
 	rx-pin = <11>;

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpunet_defconfig
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpunet_defconfig
@@ -13,9 +13,5 @@ CONFIG_HW_STACK_PROTECTION=y
 # Enable GPIO
 CONFIG_GPIO=y
 
-# Enable uart driver
-CONFIG_SERIAL=y
-
 # Enable console
 CONFIG_CONSOLE=y
-CONFIG_UART_CONSOLE=y


### PR DESCRIPTION
This reverts commit a6a7a0d888e9dffa0c3d1a7a22681a1601c53db7. Both application and network core define the same pins for uart0. The pins should not be used simultaneously by both cores.