### PR TITLE
drivers: intc_arcv2_irq_unit: Fix arc_v2_irq_unit_device_ctrl

### DIFF
--- a/drivers/interrupt_controller/intc_arcv2_irq_unit.c
+++ b/drivers/interrupt_controller/intc_arcv2_irq_unit.c
@@ -32,7 +32,8 @@ extern void *_VectorTable;
 #define _ARC_V2_IRQ_VECT_BASE _ARC_V2_IRQ_VECT_BASE_S
 #endif
 
-static uint32_t _arc_v2_irq_unit_device_power_state = PM_DEVICE_STATE_ACTIVE;
+static enum pm_device_state _arc_v2_irq_unit_device_power_state =
+	PM_DEVICE_STATE_ACTIVE;
 struct arc_v2_irq_unit_ctx {
 	uint32_t irq_ctrl; /* Interrupt Context Saving Control Register. */
 	uint32_t irq_vect_base; /* Interrupt Vector Base. */
@@ -176,7 +177,7 @@ static int arc_v2_irq_unit_resume(const struct device *dev)
  *
  * @return the power state of interrupt unit
  */
-static int arc_v2_irq_unit_get_state(const struct device *dev)
+static enum pm_device_state arc_v2_irq_unit_get_state(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 
@@ -206,13 +207,13 @@ static int arc_v2_irq_unit_device_ctrl(const struct device *dev,
 			ret = arc_v2_irq_unit_resume(dev);
 		}
 	} else if (ctrl_command == PM_DEVICE_STATE_GET) {
-		*((uint32_t *)context) = arc_v2_irq_unit_get_state(dev);
+		*state = arc_v2_irq_unit_get_state(dev);
 	}
 
 	arch_irq_unlock(key);
 
 	if (cb) {
-		cb(dev, ret, context, arg);
+		cb(dev, ret, state, arg);
 	}
 
 	return ret;


### PR DESCRIPTION
Fix some leftovers from the pm_device_state changes.

Fixes build problem introduced in
cc2f0e9c08dcad59a4cc0117028a5fcf9d73f433.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>