### PR TITLE
Add support of ARC MWDT libc to Zephyr

### DIFF
--- a/cmake/compiler/arcmwdt/target.cmake
+++ b/cmake/compiler/arcmwdt/target.cmake
@@ -39,3 +39,11 @@ endforeach()
 # common compile options, no copyright msg, little-endian, no small data,
 # no MWDT stack checking
 list(APPEND TOOLCHAIN_C_FLAGS -Hnocopyr -HL -Hnosdata -Hoff=Stackcheck_alloca)
+
+# The MWDT compiler can replace some code with call to builtin functions.
+# We can't rely on these functions presence if we don't use MWDT libc.
+# NOTE: the option name '-fno-builtin' is misleading a bit - we still can
+# manually call __builtin_** functions even if we specify it.
+if(NOT CONFIG_ARCMWDT_LIBC)
+  list(APPEND TOOLCHAIN_C_FLAGS -fno-builtin)
+endif()

--- a/cmake/linker/arcmwdt/target.cmake
+++ b/cmake/linker/arcmwdt/target.cmake
@@ -115,6 +115,7 @@ macro(toolchain_ld_baremetal)
     -Xtimer0 # to suppress the warning message
     -Hnoxcheck_obj
     -Hnocplus
+    -Hhostlib=
     -Hheap=0
     -Hnoivt
   )

--- a/cmake/linker/arcmwdt/target.cmake
+++ b/cmake/linker/arcmwdt/target.cmake
@@ -125,6 +125,18 @@ macro(toolchain_ld_baremetal)
     zephyr_ld_options(-Hnocrt)
   endif()
 
+  # There are two options:
+  # - We have full MWDT libc support and we link MWDT libc - this is default
+  #   behavior and we don't need to do something for that.
+  # - We use minimal libc provided by Zephyr itself. In that case we must not
+  #   link MWDT libc, but we still need to link libmw
+  if(CONFIG_MINIMAL_LIBC)
+    zephyr_ld_options(
+      -Hnolib
+      -Hldopt=-lmw
+    )
+  endif()
+
   # Funny thing is if this is set to =error, some architectures will
   # skip this flag even though the compiler flag check passes
   # (e.g. ARC and Xtensa). So warning should be the default for now.

--- a/include/arch/arc/arc_addr_types.h
+++ b/include/arch/arc/arc_addr_types.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 Synopsys.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_ARCH_ARC_ADDR_TYPES_H_
+#define ZEPHYR_INCLUDE_ARCH_ARC_ADDR_TYPES_H_
+#ifndef _ASMLANGUAGE
+
+/*
+ * MWDT provides paddr_t type and it conflicts witn Zephyr definition:
+ * - Zephyr defines paddr_t as a uintptr_t
+ * - MWDT defines paddr_t as a unsigned long
+ * This causes extra warnings. However we can safely define
+ * paddr_t as a unsigned long for the case when MWDT toolchain is used as
+ * they are both unsighned, have same size and aligning.
+ */
+#ifdef __CCAC__
+typedef unsigned long paddr_t;
+typedef void *vaddr_t;
+#else
+#include <arch/common/addr_types.h>
+#endif
+
+#endif /* _ASMLANGUAGE */
+#endif /* ZEPHYR_INCLUDE_ARCH_ARC_ADDR_TYPES_H_ */

--- a/include/arch/arc/arch.h
+++ b/include/arch/arc/arch.h
@@ -29,7 +29,7 @@
 #include <arch/arc/v2/aux_regs.h>
 #include <arch/arc/v2/arcv2_irq_unit.h>
 #include <arch/arc/v2/asm_inline.h>
-#include <arch/common/addr_types.h>
+#include <arch/arc/arc_addr_types.h>
 #include <arch/arc/v2/error.h>
 
 #ifdef CONFIG_ARC_CONNECT

--- a/include/posix/posix_types.h
+++ b/include/posix/posix_types.h
@@ -22,11 +22,11 @@ typedef unsigned long useconds_t;
 #endif
 
 /* time related attributes */
-#ifndef CONFIG_NEWLIB_LIBC
+#if !defined(CONFIG_NEWLIB_LIBC) && !defined(CONFIG_ARCMWDT_LIBC)
 #ifndef __clockid_t_defined
 typedef uint32_t clockid_t;
 #endif
-#endif /*CONFIG_NEWLIB_LIBC */
+#endif /* !CONFIG_NEWLIB_LIBC && !CONFIG_ARCMWDT_LIBC */
 #ifndef __timer_t_defined
 typedef unsigned long timer_t;
 #endif

--- a/include/sys/libc-hooks.h
+++ b/include/sys/libc-hooks.h
@@ -16,7 +16,7 @@
  * that need to call into the kernel as system calls
  */
 
-#ifdef CONFIG_NEWLIB_LIBC
+#if defined(CONFIG_NEWLIB_LIBC) || defined(CONFIG_ARCMWDT_LIBC)
 
 /* syscall generation ignores preprocessor, ensure this is defined to ensure
  * we don't have compile errors

--- a/include/toolchain/mwdt.h
+++ b/include/toolchain/mwdt.h
@@ -61,6 +61,17 @@
 
 #else /* defined(_ASMLANGUAGE) */
 
+/* MWDT toolchain misses ssize_t definition which is used by Zephyr */
+#ifndef _SSIZE_T_DEFINED
+#define _SSIZE_T_DEFINED
+#ifdef CONFIG_64BIT
+	typedef long ssize_t;
+#else
+	typedef int ssize_t;
+#endif
+#endif /* _SSIZE_T_DEFINED */
+
+
 #define __no_optimization __attribute__((optnone))
 
 #include <toolchain/gcc.h>

--- a/lib/libc/CMakeLists.txt
+++ b/lib/libc/CMakeLists.txt
@@ -2,6 +2,8 @@
 
 if(CONFIG_NEWLIB_LIBC)
   add_subdirectory(newlib)
+elseif(CONFIG_ARCMWDT_LIBC)
+  add_subdirectory(arcmwdt)
 else()
   add_subdirectory(minimal)
 endif()

--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -31,6 +31,13 @@ config NEWLIB_LIBC
 	  Build with newlib library. The newlib library is expected to be
 	  part of the SDK in this case.
 
+config ARCMWDT_LIBC
+	bool "ARC MWDT C library"
+	depends on !NATIVE_APPLICATION
+	depends on "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "arcmwdt"
+	help
+	  C library provided by ARC MWDT toolchain.
+
 config EXTERNAL_LIBC
 	bool "External C library"
 	help

--- a/lib/libc/arcmwdt/CMakeLists.txt
+++ b/lib/libc/arcmwdt/CMakeLists.txt
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+zephyr_library_sources(
+  arcmwdt-string.c
+)

--- a/lib/libc/arcmwdt/CMakeLists.txt
+++ b/lib/libc/arcmwdt/CMakeLists.txt
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
+zephyr_system_include_directories(include)
+
 zephyr_library()
 zephyr_library_sources(
   arcmwdt-string.c
+  libc-hooks.c
 )

--- a/lib/libc/arcmwdt/arcmwdt-string.c
+++ b/lib/libc/arcmwdt/arcmwdt-string.c
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2021 Synopsys.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define __STDC_WANT_LIB_EXT1__ 1
+
+#include <string.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+size_t strnlen(const char *s, size_t maxlen)
+{
+	return strnlen_s(s, maxlen);
+}

--- a/lib/libc/arcmwdt/include/fcntl.h
+++ b/lib/libc/arcmwdt/include/fcntl.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021 Synopsys
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_LIB_LIBC_ARCMWDT_INCLUDE_FCNTL_H_
+#define ZEPHYR_LIB_LIBC_ARCMWDT_INCLUDE_FCNTL_H_
+
+#include_next <fcntl.h>
+
+#define F_DUPFD 0
+#define F_GETFL 3
+#define F_SETFL 4
+
+/*
+ * MWDT fcntl.h doesn't provide O_NONBLOCK, however it provides other file IO
+ * definitions. Let's define O_NONBLOCK and check that it doesn't overlap with
+ * any other file IO defines.
+ */
+#ifndef O_NONBLOCK
+  #define O_NONBLOCK 0x4000
+  #if O_NONBLOCK & (O_RDONLY | O_WRONLY | O_RDWR | O_NDELAY | O_CREAT | O_APPEND | O_TRUNC | O_EXCL)
+    #error "O_NONBLOCK conflicts with other O_*** file IO defines!"
+  #endif
+#endif
+
+#endif /* ZEPHYR_LIB_LIBC_ARCMWDT_INCLUDE_FCNTL_H_ */

--- a/lib/libc/arcmwdt/include/sys/timespec.h
+++ b/lib/libc/arcmwdt/include/sys/timespec.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2019, 2021 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_LIB_LIBC_ARCMWDT_INCLUDE_SYS_TIMESPEC_H_
+#define ZEPHYR_LIB_LIBC_ARCMWDT_INCLUDE_SYS_TIMESPEC_H_
+
+#include <sys/_timespec.h>
+
+struct itimerspec {
+	struct timespec it_interval;  /* Timer interval */
+	struct timespec it_value;     /* Timer expiration */
+};
+
+#endif /* ZEPHYR_LIB_LIBC_ARCMWDT_INCLUDE_SYS_TIMESPEC_H_ */

--- a/lib/libc/arcmwdt/libc-hooks.c
+++ b/lib/libc/arcmwdt/libc-hooks.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2015, 2021 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <sys/libc-hooks.h>
+#include <syscall_handler.h>
+#include <string.h>
+#include <sys/errno_private.h>
+#include <errno.h>
+
+static int _stdout_hook_default(int c)
+{
+	ARG_UNUSED(c);
+
+	return EOF;
+}
+
+static int (*_stdout_hook)(int) = _stdout_hook_default;
+
+void __stdout_hook_install(int (*hook)(int))
+{
+	_stdout_hook = hook;
+}
+
+int z_impl_zephyr_write_stdout(const void *buffer, int nbytes)
+{
+	const char *buf = buffer;
+	int i;
+
+	for (i = 0; i < nbytes; i++) {
+		if (*(buf + i) == '\n') {
+			_stdout_hook('\r');
+		}
+		_stdout_hook(*(buf + i));
+	}
+	return nbytes;
+}
+
+#ifdef CONFIG_USERSPACE
+static inline int z_vrfy_z_zephyr_write_stdout(const void *buf, int nbytes)
+{
+	Z_OOPS(Z_SYSCALL_MEMORY_READ(buf, nbytes));
+	return z_impl_zephyr_write_stdout(buf, nbytes);
+}
+#include <syscalls/z_zephyr_write_stdout_mrsh.c>
+#endif
+
+#ifndef CONFIG_POSIX_API
+int _write(int fd, const char *buf, unsigned int nbytes)
+{
+	ARG_UNUSED(fd);
+
+	return z_impl_zephyr_write_stdout(buf, nbytes);
+}
+#endif

--- a/lib/libc/arcmwdt/libc-hooks.c
+++ b/lib/libc/arcmwdt/libc-hooks.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2015, 2021 Intel Corporation.
+ * Copyright (c) 2021 Synopsys.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -56,3 +57,8 @@ int _write(int fd, const char *buf, unsigned int nbytes)
 	return z_impl_zephyr_write_stdout(buf, nbytes);
 }
 #endif
+
+int *___errno(void)
+{
+	return z_errno();
+}

--- a/lib/libc/arcmwdt/libc-hooks.c
+++ b/lib/libc/arcmwdt/libc-hooks.c
@@ -10,6 +10,7 @@
 #include <syscall_handler.h>
 #include <string.h>
 #include <sys/errno_private.h>
+#include <unistd.h>
 #include <errno.h>
 
 static int _stdout_hook_default(int c)
@@ -57,6 +58,19 @@ int _write(int fd, const char *buf, unsigned int nbytes)
 	return z_impl_zephyr_write_stdout(buf, nbytes);
 }
 #endif
+
+/*
+ * It's require to implement _isatty to have STDIN/STDOUT/STDERR buffered
+ * properly.
+ */
+int _isatty(int file)
+{
+	if (file == STDIN_FILENO || file == STDOUT_FILENO || file == STDERR_FILENO) {
+		return 1;
+	}
+
+	return 0;
+}
 
 int *___errno(void)
 {

--- a/lib/os/fdtable.c
+++ b/lib/os/fdtable.c
@@ -333,7 +333,7 @@ static ssize_t stdinout_write_vmeth(void *obj, const void *buffer, size_t count)
 {
 #if defined(CONFIG_BOARD_NATIVE_POSIX)
 	return write(1, buffer, count);
-#elif defined(CONFIG_NEWLIB_LIBC)
+#elif defined(CONFIG_NEWLIB_LIBC) || defined(CONFIG_ARCMWDT_LIBC)
 	return z_impl_zephyr_write_stdout(buffer, count);
 #else
 	return 0;

--- a/tests/posix/common/testcase.yaml
+++ b/tests/posix/common/testcase.yaml
@@ -14,6 +14,10 @@ tests:
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
+  portability.posix.common.arcmwdtlib:
+    toolchain_allow: arcmwdt
+    extra_configs:
+      - CONFIG_ARCMWDT_LIBC=y
   portability.posix.common.tls:
     platform_exclude: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard ehl_crb
     filter: CONFIG_ARCH_HAS_THREAD_LOCAL_STORAGE and CONFIG_TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE


### PR DESCRIPTION
ARC MWDT toolchain doesn't provide NEWLIB libc. Let's add support of of ARC MWDT libc to Zephyr.

This is prerequisite of adding ARC MWDT C++ library support to Zephyr.