### PR TITLE
device: pm: Make busy API consistent

### DIFF
--- a/include/device.h
+++ b/include/device.h
@@ -609,7 +609,6 @@ void device_busy_set(const struct device *dev);
  */
 void device_busy_clear(const struct device *dev);
 
-#ifdef CONFIG_PM_DEVICE
 /**
  * @brief Check if any device is in the middle of a transaction
  *
@@ -633,8 +632,6 @@ int device_any_busy_check(void);
  * @retval -EBUSY if the device is busy
  */
 int device_busy_check(const struct device *chk_dev);
-
-#endif
 
 /**
  * @}

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -196,9 +196,9 @@ int device_required_foreach(const struct device *dev,
 	return handle_count;
 }
 
-#ifdef CONFIG_PM_DEVICE
 int device_any_busy_check(void)
 {
+#ifdef CONFIG_PM_DEVICE
 	const struct device *dev = __device_start;
 
 	while (dev < __device_end) {
@@ -210,18 +210,23 @@ int device_any_busy_check(void)
 	}
 
 	return 0;
+#else
+	return -ENOSYS;
+#endif
 }
 
 int device_busy_check(const struct device *dev)
 {
+#ifdef CONFIG_PM_DEVICE
 	if (atomic_test_bit(&dev->pm->atomic_flags,
 			    PM_DEVICE_ATOMIC_FLAGS_BUSY_BIT)) {
 		return -EBUSY;
 	}
 	return 0;
-}
-
+#else
+	return -ENOSYS;
 #endif
+}
 
 void device_busy_set(const struct device *dev)
 {


### PR DESCRIPTION
Two functions of device busy API were only defined if CONFIG_PM, while
others were always defined.

Now these APIs are always implemented but they return ENOSYS when
CONFIG_PM is not defined.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>