### PR TITLE
futex: Avoid unnecessary lock

### DIFF
--- a/kernel/futex.c
+++ b/kernel/futex.c
@@ -74,12 +74,11 @@ int z_impl_k_futex_wait(struct k_futex *futex, int expected,
 		return -EINVAL;
 	}
 
-	key = k_spin_lock(&futex_data->lock);
-
 	if (atomic_get(&futex->val) != (atomic_val_t)expected) {
-		k_spin_unlock(&futex_data->lock, key);
 		return -EAGAIN;
 	}
+
+	key = k_spin_lock(&futex_data->lock);
 
 	ret = z_pend_curr(&futex_data->lock,
 			key, &futex_data->wait_q, timeout);


### PR DESCRIPTION
It is not necessary the spin lock to protect atomic operation.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>