### PR TITLE
riscv: linker: fix power-of-two PMPs alignment on non-XIP system

### DIFF
--- a/include/arch/riscv/common/linker.ld
+++ b/include/arch/riscv/common/linker.ld
@@ -187,7 +187,6 @@ SECTIONS
 
 #include <linker/cplusplus-rom.ld>
 	__rodata_region_end = .;
-	MPU_ALIGN(__rodata_region_end - __rom_region_start);
 
 	/* For non-XIP system, __rom_region_end symbol should be set to
 	 * the end of common ROMABLE_REGIONs (text and rodata) instead of
@@ -195,6 +194,13 @@ SECTIONS
 	 * RAMABLE_REGION in it.
 	 */
 #ifndef CONFIG_XIP
+#ifdef CONFIG_RISCV_PMP
+	SECTION_PROLOGUE(rom_mpu_padding,,)
+	{
+		MPU_ALIGN(__rodata_region_end - __rom_region_start);
+	} GROUP_LINK_IN(ROMABLE_REGION)
+#endif /* CONFIG_RISCV_PMP */
+
 	__rom_region_end = .;
 	__rom_region_size = __rom_region_end - __rom_region_start;
 #endif /* CONFIG_XIP */

--- a/include/arch/riscv/common/linker.ld
+++ b/include/arch/riscv/common/linker.ld
@@ -188,6 +188,16 @@ SECTIONS
 #include <linker/cplusplus-rom.ld>
 	__rodata_region_end = .;
 	MPU_ALIGN(__rodata_region_end - __rom_region_start);
+
+	/* For non-XIP system, __rom_region_end symbol should be set to
+	 * the end of common ROMABLE_REGIONs (text and rodata) instead of
+	 * the linker script end, so it wouldn't mistakely contain
+	 * RAMABLE_REGION in it.
+	 */
+#ifndef CONFIG_XIP
+	__rom_region_end = .;
+	__rom_region_size = __rom_region_end - __rom_region_start;
+#endif /* CONFIG_XIP */
     GROUP_END(ROMABLE_REGION)
 
     GROUP_START(RAMABLE_REGION)
@@ -362,6 +372,11 @@ GROUP_END(DTCM)
 	KEEP(*(.gnu.attributes))
 	}
 
+/* Because ROMABLE_REGION != RAMABLE_REGION in XIP-system, it is valid
+ * to set __rom_region_end symbol at the end of linker script and
+ * doesn't mistakely contain the RAMABLE_REGION in it.
+ */
+#ifdef CONFIG_XIP
 /* Must be last in romable region */
 SECTION_PROLOGUE(.last_section,(NOLOAD),)
 {
@@ -371,5 +386,6 @@ SECTION_PROLOGUE(.last_section,(NOLOAD),)
  * calculate this value here. */
 __rom_region_end = LOADADDR(.last_section);
 __rom_region_size = __rom_region_end - __rom_region_start;
+#endif
 
 }


### PR DESCRIPTION
In #15558 design, .text/.rodata needs to be padded out to the power-of-two alignment of size in non-XIP system with power-of-two MPU(PMP) so that .data section starts at the end of this region.

In #15656 fix, although `_image_rom_end `has power-of-two padding, `_image_ram_start `doesn't start at `_image_rom_end`. It still causes that RAM region overlap ROM region.

To fix it, add new output section, rom_mpu_padding, to `MPU_ALIGN()` statement to update the next free address in the linker script so that `_image_ram_start `will really start at `_image_rom_end`.

I have check this issue on` tests/kernel/mem_protect/protection` test on `qemu_riscv32 `platform.
`qemu_riscv32 `platform needs to enable CONFIG_RISCV_PMP=y and CONFIG_PMP_POWER_OF_TWO_ALIGNMENT=y.

Before fix:
```
$ nm -n zephyr/zephyr.elf | grep _image
80000000 A _image_rom_start
00008000 A _image_rom_size
80008000 B _image_rom_end
800054a0 B _image_ram_start
800069b8 D _image_ram_end
```

After fix:
```
$ nm -n zephyr/zephyr.elf | grep _image
00008000 A _image_rom_size
80000000 A _image_rom_start
80008000 B _image_rom_end
80008000 B _image_ram_start
80009518 D _image_ram_end
```

I guess the linker script in ARM/ARC arch also have this issue, but I only try it on RISC-V arch.

Related to #31811