### PR TITLE
boards: fixing typo from MX24R64 to MX25R64

### DIFF
--- a/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp_common.dts
+++ b/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp_common.dts
@@ -175,9 +175,9 @@
 	mx25r64: mx25r6435f@0 {
 		compatible = "nordic,qspi-nor";
 		reg = <0>;
-		/* MX24R64 supports only pp and pp4io */
+		/* MX25R64 supports only pp and pp4io */
 		writeoc = "pp4io";
-		/* MX24R64 supports all readoc options */
+		/* MX25R64 supports all readoc options */
 		readoc = "read4io";
 		sck-frequency = <8000000>;
 		label = "MX25R64";

--- a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
+++ b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
@@ -212,9 +212,9 @@ arduino_i2c: &i2c0 {
 	mx25r64: mx25r6435f@0 {
 		compatible = "nordic,qspi-nor";
 		reg = <0>;
-		/* MX24R64 supports only pp and pp4io */
+		/* MX25R64 supports only pp and pp4io */
 		writeoc = "pp4io";
-		/* MX24R64 supports all readoc options */
+		/* MX25R64 supports all readoc options */
 		readoc = "read4io";
 		sck-frequency = <8000000>;
 		label = "MX25R64";

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
@@ -161,9 +161,9 @@
 	mx25r64: mx25r6435f@0 {
 		compatible = "nordic,qspi-nor";
 		reg = <0>;
-		/* MX24R64 supports only pp and pp4io */
+		/* MX25R64 supports only pp and pp4io */
 		writeoc = "pp4io";
-		/* MX24R64 supports all readoc options */
+		/* MX25R64 supports all readoc options */
 		readoc = "read4io";
 		sck-frequency = <8000000>;
 		label = "MX25R64";

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
@@ -207,10 +207,10 @@
 	mx25r64: mx25r6435f@0 {
 		compatible = "nordic,qspi-nor";
 		reg = <0>;
-		/* MX24R64 supports only pp and pp4io */
+		/* MX25R64 supports only pp and pp4io */
 		/* Thingy:53 supports only pp and pp2o options */
 		writeoc = "pp";
-		/* MX24R64 supports all readoc options */
+		/* MX25R64 supports all readoc options */
 		/* Thingy:53 supports only fastread and read2io options */
 		readoc = "read2io";
 		sck-frequency = <8000000>;

--- a/boards/arm/ubx_bmd340eval_nrf52840/ubx_bmd340eval_nrf52840.dts
+++ b/boards/arm/ubx_bmd340eval_nrf52840/ubx_bmd340eval_nrf52840.dts
@@ -215,9 +215,9 @@ arduino_i2c: &i2c0 {
 	mx25r64: mx25r6435f@0 {
 		compatible = "nordic,qspi-nor";
 		reg = <0>;
-		/* MX24R64 supports only pp and pp4io */
+		/* MX25R64 supports only pp and pp4io */
 		writeoc = "pp4io";
-		/* MX24R64 supports all readoc options */
+		/* MX25R64 supports all readoc options */
 		readoc = "read4io";
 		sck-frequency = <8000000>;
 		label = "MX25R64";

--- a/boards/arm/ubx_bmd345eval_nrf52840/ubx_bmd345eval_nrf52840.dts
+++ b/boards/arm/ubx_bmd345eval_nrf52840/ubx_bmd345eval_nrf52840.dts
@@ -218,9 +218,9 @@ arduino_spi: &spi3 {
 	mx25r64: mx25r6435f@0 {
 		compatible = "nordic,qspi-nor";
 		reg = <0>;
-		/* MX24R64 supports only pp and pp4io */
+		/* MX25R64 supports only pp and pp4io */
 		writeoc = "pp4io";
-		/* MX24R64 supports all readoc options */
+		/* MX25R64 supports all readoc options */
 		readoc = "read4io";
 		sck-frequency = <8000000>;
 		label = "MX25R64";


### PR DESCRIPTION
Comments in .dts files with MX25R64 and QSPI contained a typo

Signed-off-by: Akash Patel <akash.patel@nordicsemi.no>