### PR TITLE
ITE: drivers/i2c: create pinmux phandle to the I2C driver node

### DIFF
--- a/dts/bindings/i2c/ite,it8xxx2-i2c.yaml
+++ b/dts/bindings/i2c/ite,it8xxx2-i2c.yaml
@@ -21,3 +21,13 @@ properties:
       type: int
       required: true
       description: Ordinal identifying the port
+
+    pinctrl-0:
+      type: phandle
+      required: true
+      description: Configuration of I2C clock pinmux controller
+
+    pinctrl-1:
+      type: phandle
+      required: true
+      description: Configuration of I2C data pinmux controller

--- a/dts/bindings/i2c/ite,it8xxx2-i2c.yaml
+++ b/dts/bindings/i2c/ite,it8xxx2-i2c.yaml
@@ -22,6 +22,11 @@ properties:
       required: true
       description: Ordinal identifying the port
 
+    gpio-dev:
+        type: phandle
+        required: true
+        description: Get the handle of the GPIO device
+
     pinctrl-0:
       type: phandle
       required: true

--- a/dts/riscv/it8xxx2-alts-map.dtsi
+++ b/dts/riscv/it8xxx2-alts-map.dtsi
@@ -61,5 +61,43 @@
 		pinctrl_pwm7: pwm7 {
 			pinctrls = <&pinmuxa 7 IT8XXX2_PINMUX_FUNC_1>;
 		};
+
+		/* I2C alternate function */
+		pinctrl_i2c_clk0: i2c_clk0 {
+			pinctrls = <&pinmuxb 3 IT8XXX2_PINMUX_FUNC_1>;
+		};
+		pinctrl_i2c_data0: i2c_data0 {
+			pinctrls = <&pinmuxb 4 IT8XXX2_PINMUX_FUNC_1>;
+		};
+		pinctrl_i2c_clk1: i2c_clk1 {
+			pinctrls = <&pinmuxc 1 IT8XXX2_PINMUX_FUNC_1>;
+		};
+		pinctrl_i2c_data1: i2c_data1 {
+			pinctrls = <&pinmuxc 2 IT8XXX2_PINMUX_FUNC_1>;
+		};
+		pinctrl_i2c_clk2: i2c_clk2 {
+			pinctrls = <&pinmuxf 6 IT8XXX2_PINMUX_FUNC_1>;
+		};
+		pinctrl_i2c_data2: i2c_data2 {
+			pinctrls = <&pinmuxf 7 IT8XXX2_PINMUX_FUNC_1>;
+		};
+		pinctrl_i2c_clk3: i2c_clk3 {
+			pinctrls = <&pinmuxh 1 IT8XXX2_PINMUX_FUNC_3>;
+		};
+		pinctrl_i2c_data3: i2c_data3 {
+			pinctrls = <&pinmuxh 2 IT8XXX2_PINMUX_FUNC_3>;
+		};
+		pinctrl_i2c_clk4: i2c_clk4 {
+			pinctrls = <&pinmuxe 0 IT8XXX2_PINMUX_FUNC_3>;
+		};
+		pinctrl_i2c_data4: i2c_data4 {
+			pinctrls = <&pinmuxe 7 IT8XXX2_PINMUX_FUNC_3>;
+		};
+		pinctrl_i2c_clk5: i2c_clk5 {
+			pinctrls = <&pinmuxa 4 IT8XXX2_PINMUX_FUNC_3>;
+		};
+		pinctrl_i2c_data5: i2c_data5 {
+			pinctrls = <&pinmuxa 5 IT8XXX2_PINMUX_FUNC_3>;
+		};
 	};
 };

--- a/dts/riscv/it8xxx2.dtsi
+++ b/dts/riscv/it8xxx2.dtsi
@@ -603,6 +603,7 @@
 			status = "disabled";
 			label = "I2C_0";
 			port-num = <0>;
+			gpio-dev = <&gpiob>;
 			pinctrl-0 = <&pinctrl_i2c_clk0>;  /* GPB3 */
 			pinctrl-1 = <&pinctrl_i2c_data0>; /* GPB4 */
 		};
@@ -616,6 +617,7 @@
 			status = "disabled";
 			label = "I2C_1";
 			port-num = <1>;
+			gpio-dev = <&gpioc>;
 			pinctrl-0 = <&pinctrl_i2c_clk1>;  /* GPC1 */
 			pinctrl-1 = <&pinctrl_i2c_data1>; /* GPC2 */
 		};
@@ -629,6 +631,7 @@
 			status = "disabled";
 			label = "I2C_2";
 			port-num = <2>;
+			gpio-dev = <&gpiof>;
 			pinctrl-0 = <&pinctrl_i2c_clk2>;  /* GPF6 */
 			pinctrl-1 = <&pinctrl_i2c_data2>; /* GPF7 */
 		};
@@ -642,6 +645,7 @@
 			status = "disabled";
 			label = "I2C_3";
 			port-num = <3>;
+			gpio-dev = <&gpioh>;
 			pinctrl-0 = <&pinctrl_i2c_clk3>;  /* GPH1 */
 			pinctrl-1 = <&pinctrl_i2c_data3>; /* GPH2 */
 		};
@@ -655,6 +659,7 @@
 			status = "disabled";
 			label = "I2C_4";
 			port-num = <4>;
+			gpio-dev = <&gpioe>;
 			pinctrl-0 = <&pinctrl_i2c_clk4>;  /* GPE0 */
 			pinctrl-1 = <&pinctrl_i2c_data4>; /* GPE7 */
 		};
@@ -668,6 +673,7 @@
 			status = "disabled";
 			label = "I2C_5";
 			port-num = <5>;
+			gpio-dev = <&gpioa>;
 			pinctrl-0 = <&pinctrl_i2c_clk5>;  /* GPA4 */
 			pinctrl-1 = <&pinctrl_i2c_data5>; /* GPA5 */
 		};

--- a/dts/riscv/it8xxx2.dtsi
+++ b/dts/riscv/it8xxx2.dtsi
@@ -603,6 +603,8 @@
 			status = "disabled";
 			label = "I2C_0";
 			port-num = <0>;
+			pinctrl-0 = <&pinctrl_i2c_clk0>;  /* GPB3 */
+			pinctrl-1 = <&pinctrl_i2c_data0>; /* GPB4 */
 		};
 		i2c1: i2c@f01c80 {
 			compatible = "ite,it8xxx2-i2c";
@@ -614,6 +616,8 @@
 			status = "disabled";
 			label = "I2C_1";
 			port-num = <1>;
+			pinctrl-0 = <&pinctrl_i2c_clk1>;  /* GPC1 */
+			pinctrl-1 = <&pinctrl_i2c_data1>; /* GPC2 */
 		};
 		i2c2: i2c@f01cc0 {
 			compatible = "ite,it8xxx2-i2c";
@@ -625,6 +629,8 @@
 			status = "disabled";
 			label = "I2C_2";
 			port-num = <2>;
+			pinctrl-0 = <&pinctrl_i2c_clk2>;  /* GPF6 */
+			pinctrl-1 = <&pinctrl_i2c_data2>; /* GPF7 */
 		};
 		i2c3: i2c@f03680 {
 			compatible = "ite,it8xxx2-i2c";
@@ -636,6 +642,8 @@
 			status = "disabled";
 			label = "I2C_3";
 			port-num = <3>;
+			pinctrl-0 = <&pinctrl_i2c_clk3>;  /* GPH1 */
+			pinctrl-1 = <&pinctrl_i2c_data3>; /* GPH2 */
 		};
 		i2c4: i2c@f03500 {
 			compatible = "ite,it8xxx2-i2c";
@@ -647,6 +655,8 @@
 			status = "disabled";
 			label = "I2C_4";
 			port-num = <4>;
+			pinctrl-0 = <&pinctrl_i2c_clk4>;  /* GPE0 */
+			pinctrl-1 = <&pinctrl_i2c_data4>; /* GPE7 */
 		};
 		i2c5: i2c@f03580 {
 			compatible = "ite,it8xxx2-i2c";
@@ -658,6 +668,8 @@
 			status = "disabled";
 			label = "I2C_5";
 			port-num = <5>;
+			pinctrl-0 = <&pinctrl_i2c_clk5>;  /* GPA4 */
+			pinctrl-1 = <&pinctrl_i2c_data5>; /* GPA5 */
 		};
 
 		ecpm: clock-controller@f01e00 {


### PR DESCRIPTION
Create the pinmux phandle to the I2C driver node in the
devicetree. When the pinmux_pin_set function in
i2c_it8xxx2_init can refer to the setting of this phandle.
It is more flexible to use.

Signed-off-by: Tim Lin <tim2.lin@ite.corp-partner.google.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zephyrproject-rtos/zephyr/36831)
<!-- Reviewable:end -->
