### PR TITLE
dts: rt600: Add TRNG support

### DIFF
--- a/dts/arm/nxp/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx_common.dtsi
@@ -11,6 +11,10 @@
 #include <dt-bindings/i2c/i2c.h>
 
 / {
+	chosen {
+		zephyr,entropy = &trng;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -51,6 +55,12 @@
 &peripheral {
 	#address-cells = <1>;
 	#size-cells = <1>;
+	/*
+	 * Note that the offsets here are relative to the base address
+	 * defined in either nxp_rt6xx_ns.dtsi or nxp_rt6xx.dtsi. The base
+	 * addresses differ between non-secure (0x40000000) and secure
+	 * modes (0x50000000).
+	 */
 
 	clkctl0: clkctl@1000 {
 		compatible = "nxp,lpc-syscon";
@@ -221,6 +231,14 @@
 		interrupts = <32 0>;
 		status = "disabled";
 		label = "RTC_0";
+	};
+
+	trng: random@138000 {
+		compatible = "nxp,kinetis-trng";
+		reg = <0x138000 0x4000>;
+		status = "okay";
+		interrupts = <31 0>;
+		label = "TRNG";
 	};
 };
 

--- a/soc/arm/nxp_imx/rt6xx/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt6xx/Kconfig.defconfig.series
@@ -23,6 +23,10 @@ config FLASH_SIZE
 config FLASH_BASE_ADDRESS
 	default $(dt_node_reg_addr_hex,/soc/peripheral@50000000/spi@134000,1)
 
+config ENTROPY_MCUX_TRNG
+	default y if HAS_MCUX_TRNG
+	depends on ENTROPY_GENERATOR
+
 source "soc/arm/nxp_imx/rt6xx/Kconfig.defconfig.mimxrt6*"
 
 endif # SOC_SERIES_MIMXRT6XX

--- a/soc/arm/nxp_imx/rt6xx/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt6xx/Kconfig.soc
@@ -23,6 +23,7 @@ config SOC_MIMXRT685S_CM33
 	select HAS_MCUX_LPC_DMA
 	select HAS_MCUX_OS_TIMER
 	select HAS_MCUX_LPC_RTC
+	select HAS_MCUX_TRNG
 	select INIT_SYS_PLL
 
 endchoice


### PR DESCRIPTION
Add RT6xx TRNG support to enable the entropy driver.

Signed-off-by: David Leach <david.leach@nxp.com>