### PR TITLE
samples/bluetooth: st_ble_sensor: Fixes the button activity notification

### DIFF
--- a/samples/bluetooth/st_ble_sensor/src/main.c
+++ b/samples/bluetooth/st_ble_sensor/src/main.c
@@ -118,7 +118,7 @@ static void button_callback(const struct device *gpiob, struct gpio_callback *cb
 	LOG_INF("Button pressed");
 	if (conn) {
 		if (notify_enable) {
-			err = bt_gatt_notify(NULL, &stsensor_svc.attrs[2],
+			err = bt_gatt_notify(NULL, &stsensor_svc.attrs[4],
 					     &but_val, sizeof(but_val));
 			if (err) {
 				LOG_ERR("Notify error: %d", err);


### PR DESCRIPTION
This commit fixes the button activity notification not working issue.
The right attribute(4) is used for the button service.
This has been tested on nucleo_wb55rg and disco_l475_iot1 platforms.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/36718

Signed-off-by: Krishna Mohan Dani <krishnamohan.d@hcl.com>