### PR TITLE
Bluetooth: Iso: Do not remove iso data path on disconnect

### DIFF
--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -332,7 +332,7 @@ void bt_iso_connected(struct bt_conn *conn)
 	}
 }
 
-static void bt_iso_remove_data_path(struct bt_conn *conn)
+void bt_iso_remove_data_path(struct bt_conn *conn)
 {
 	BT_DBG("%p", conn);
 
@@ -413,8 +413,6 @@ void bt_iso_disconnected(struct bt_conn *conn)
 	if (sys_slist_is_empty(&conn->channels)) {
 		return;
 	}
-
-	bt_iso_remove_data_path(conn);
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&conn->channels, chan, next, node) {
 		bt_iso_chan_disconnected(chan, conn->err);

--- a/subsys/bluetooth/host/iso_internal.h
+++ b/subsys/bluetooth/host/iso_internal.h
@@ -143,3 +143,5 @@ void bt_iso_chan_set_state(struct bt_iso_chan *chan, uint8_t state);
 void bt_iso_recv(struct bt_conn *conn, struct net_buf *buf, uint8_t flags);
 
 struct bt_conn_iso *bt_conn_iso(struct bt_conn *conn);
+
+void bt_iso_remove_data_path(struct bt_conn *conn);


### PR DESCRIPTION
We previously removed the iso data path when the iso channel
disconnected. Since the iso data path is unique for a given
iso channel (by handle), it does not make sense to remove
it for a disconnected channel, as the channel is, in
a sense, not existing anymore.

This update is to better comply with the bluetooth
core spec, and to avoid getting errors from the
controller on disconnect.

Rather than removing the implementation of being able
to remove the data path, the function was made non-static
and moved to the internal header file, in case we ever
want to use it. This should not affect compile size.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

fixes #34829 