### PR TITLE
Bluetooth: host: disallow MPS decrease for multiple CIDs in Reconf Req

### DIFF
--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -1224,10 +1224,13 @@ static void le_ecred_reconf_req(struct bt_l2cap *l2cap, uint8_t ident,
 				struct net_buf *buf)
 {
 	struct bt_conn *conn = l2cap->chan.chan.conn;
+	struct bt_l2cap_chan *chans[L2CAP_ECRED_CHAN_MAX];
 	struct bt_l2cap_ecred_reconf_req *req;
 	struct bt_l2cap_ecred_reconf_rsp *rsp;
 	uint16_t mtu, mps;
 	uint16_t scid, result = BT_L2CAP_RECONF_SUCCESS;
+	int chan_count = 0;
+	bool mps_reduced;
 
 	if (buf->len < sizeof(*req)) {
 		BT_ERR("Too small ecred reconf req packet size");
@@ -1251,15 +1254,7 @@ static void le_ecred_reconf_req(struct bt_l2cap *l2cap, uint8_t ident,
 
 	while (buf->len >= sizeof(scid)) {
 		struct bt_l2cap_chan *chan;
-
 		scid = net_buf_pull_le16(buf);
-
-		BT_DBG("scid 0x%04x", scid);
-
-		if (!scid) {
-			continue;
-		}
-
 		chan = bt_l2cap_le_lookup_tx_cid(conn, scid);
 		if (!chan) {
 			result = BT_L2CAP_RECONF_INVALID_CID;
@@ -1278,8 +1273,26 @@ static void le_ecred_reconf_req(struct bt_l2cap *l2cap, uint8_t ident,
 			goto response;
 		}
 
-		BT_L2CAP_LE_CHAN(chan)->tx.mtu = mtu;
-		BT_L2CAP_LE_CHAN(chan)->tx.mps = mps;
+		if (BT_L2CAP_LE_CHAN(chan)->tx.mps > mps) {
+			mps_reduced = true;
+		}
+
+		chans[chan_count] = chan;
+		chan_count++;
+	}
+
+	/* As per BT Core Spec V5.2 Vol. 3, Part A, section 7.11
+	 * The request (...) shall not decrease the MPS of a channel
+	 * if more than one channel is specified.
+	 */
+	if (mps_reduced && chan_count > 1) {
+		result = BT_L2CAP_RECONF_INVALID_MPS;
+		goto response;
+	}
+
+	while (chan_count-- >= 0) {
+		BT_L2CAP_LE_CHAN(chans[chan_count])->tx.mtu = mtu;
+		BT_L2CAP_LE_CHAN(chans[chan_count])->tx.mps = mps;
 	}
 
 	BT_DBG("mtu %u mps %u", mtu, mps);


### PR DESCRIPTION
When in `le_ecred_reconf_req` multiple CIDs are received host should
return  0x0002 error (Reconfiguration failed - reduction in size of
MPS not allowed for more than one channel at a time).

This affects test L2CAP/ECFC/BI-04-C

Signed-off-by: Krzysztof Kopyściński <krzysztof.kopyscinski@codecoup.pl>