### PR TITLE
Bluetooth: host: Move bt_data_parse to hci_core.c

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3738,3 +3738,34 @@ int bt_le_set_chan_map(uint8_t chan_map[5])
 	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_SET_HOST_CHAN_CLASSIF,
 				    buf, NULL);
 }
+
+void bt_data_parse(struct net_buf_simple *ad,
+		   bool (*func)(struct bt_data *data, void *user_data),
+		   void *user_data)
+{
+	while (ad->len > 1) {
+		struct bt_data data;
+		uint8_t len;
+
+		len = net_buf_simple_pull_u8(ad);
+		if (len == 0U) {
+			/* Early termination */
+			return;
+		}
+
+		if (len > ad->len) {
+			BT_WARN("Malformed data");
+			return;
+		}
+
+		data.type = net_buf_simple_pull_u8(ad);
+		data.data_len = len - 1;
+		data.data = ad->data;
+
+		if (!func(&data, user_data)) {
+			return;
+		}
+
+		net_buf_simple_pull(ad, len - 1);
+	}
+}

--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -316,37 +316,6 @@ int bt_le_scan_update(bool fast_scan)
 	return 0;
 }
 
-void bt_data_parse(struct net_buf_simple *ad,
-		   bool (*func)(struct bt_data *data, void *user_data),
-		   void *user_data)
-{
-	while (ad->len > 1) {
-		struct bt_data data;
-		uint8_t len;
-
-		len = net_buf_simple_pull_u8(ad);
-		if (len == 0U) {
-			/* Early termination */
-			return;
-		}
-
-		if (len > ad->len) {
-			BT_WARN("Malformed data");
-			return;
-		}
-
-		data.type = net_buf_simple_pull_u8(ad);
-		data.data_len = len - 1;
-		data.data = ad->data;
-
-		if (!func(&data, user_data)) {
-			return;
-		}
-
-		net_buf_simple_pull(ad, len - 1);
-	}
-}
-
 #if defined(CONFIG_BT_CENTRAL)
 static void check_pending_conn(const bt_addr_le_t *id_addr,
 			       const bt_addr_le_t *addr, uint8_t adv_props)


### PR DESCRIPTION
Move the function from scan.c to hci_core.c.
When in scan.c, the function is only available if
CONFIG_BT_OBSERVER was enabled. Since the function
can be used in other scenarioes where we need to parse
LTV data, it has been moved to a more generic place.

hci_core.c might not be the ideal place, but it is
where most other common bluetooth functions
are located.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

fixes https://github.com/zephyrproject-rtos/zephyr-bt-sig/issues/107