### PR TITLE
Enable entropy wb55

### DIFF
--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -165,6 +165,10 @@
 	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
 };
 
+&rng {
+	status = "okay";
+};
+
 &flash0 {
 	/*
 	 * For more information, see:

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -401,12 +401,17 @@ static int entropy_stm32_rng_init(const struct device *dev)
 		/* Wait for HSI48 to become ready */
 	}
 
-	LL_RCC_SetRNGClockSource(LL_RCC_RNG_CLKSOURCE_HSI48);
+#if defined(CONFIG_SOC_SERIES_STM32WBX)
+	LL_RCC_SetRNGClockSource(LL_RCC_RNG_CLKSOURCE_CLK48);
+	LL_RCC_SetCLK48ClockSource(LL_RCC_CLK48_CLKSOURCE_HSI48);
 
-#if !defined(CONFIG_SOC_SERIES_STM32WBX)
-	/* Specially for STM32WB, don't unlock the HSEM to prevent M0 core
+	/* Don't unlock the HSEM to prevent M0 core
 	 * to disable HSI48 clock used for RNG.
 	 */
+#else
+	LL_RCC_SetRNGClockSource(LL_RCC_RNG_CLKSOURCE_HSI48);
+
+	/* Unlock the HSEM if it is not STM32WB */
 	z_stm32_hsem_unlock(CFG_HW_CLK48_CONFIG_SEMID);
 #endif /* CONFIG_SOC_SERIES_STM32WBX */
 

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -14,6 +14,7 @@
 
 / {
 	chosen {
+		zephyr,entropy = &rng;
 		zephyr,flash-controller = &flash;
 	};
 
@@ -435,6 +436,14 @@
 			label = "QUADSPI";
 		};
 
+		rng: rng@58001000 {
+			compatible = "st,stm32-rng";
+			reg = <0x58001000 0x400>;
+			interrupts = <53 0>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x00040000>;
+			status = "disabled";
+			label = "RNG";
+		};
 	};
 
 	usb_fs_phy: usbphy {


### PR DESCRIPTION
These commits enable entropy in nucleo_wb55rg platform.
This has been tested with tests/drivers/entropy/api/ and is working as expected.

```
Running test suite entropy_api
===================================================================
START - test_entropy_get_entropy
random device is 0x8004ef0, name is RNG
  0xff
  0xe3
  0xf7
  0xc6
  0x22
  0xce
  0x29
  0x7d
  0xe1
 PASS - test_entropy_get_entropy in 0.10 seconds
===================================================================
Test suite entropy_api succeeded
===================================================================
PROJECT EXECUTION SUCCESSFUL
*** Booting Zephyr OS build zephyr-v2.6.0-761-g17a2873897fe  ***
Running test suite entropy_api
===================================================================
START - test_entropy_get_entropy
random device is 0x8004ee4, name is RNG
  0x60
  0xab
  0xe8
  0xb0
  0x23
  0x2b
  0x00
  0xc1
  0x35
 PASS - test_entropy_get_entropy in 0.10 seconds
===================================================================
Test suite entropy_api succeeded
===================================================================
PROJECT EXECUTION SUCCESSFUL
```