### PR TITLE
tests: common: skip arch_nop testing on ehl_crb board

### DIFF
--- a/tests/kernel/common/src/irq_offload.c
+++ b/tests/kernel/common/src/irq_offload.c
@@ -148,7 +148,9 @@ __no_optimization void test_nop(void)
 	arch_nop();
 	arch_nop();
 	arch_nop();
-#elif defined(CONFIG_ARMV8_A)
+
+#elif defined(CONFIG_ARMV8_A) || defined(CONFIG_BOARD_EHL_CRB)	\
+	|| (CONFIG_BOARD_UP_SQUARED) || (CONFIG_SOC_FAMILY_INTEL_ADSP)
 	/* the ARMv8-A ARM states the following:
 	 * No Operation does nothing, other than advance the value of
 	 * the program counter by 4. This instruction can be used for
@@ -159,6 +161,9 @@ __no_optimization void test_nop(void)
 	 * instructions are not suitable for timing loops.
 	 *
 	 * So we skip the this test, it will get a negative cycles.
+	 *
+	 * And on physical EHL_CRB, up squared and INTEL ADSP boards,
+	 * we also got a similar situation, we skip the check as well.
 	 */
 	ztest_test_skip();
 #endif


### PR DESCRIPTION
Using the NOP instructions to do timing control on the physical board such as
x86 ehl_crb, up squared and intel ADSP board, that doesn't work. It seems like
it can only be used for instruction alignment purposes. We skip this test on this
board because it's not meaningful.

Fixes #35971

Signed-off-by: Enjia Mai <enjiax.mai@intel.com>