### PR TITLE
ipv6: improve compliance with RFC2460

### DIFF
--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -567,6 +567,8 @@ union net_proto_header {
 
 #define NET_IPV6H_LENGTH_OFFSET		0x04	/* Offset of the Length field in the IPv6 header */
 
+#define NET_IPV6_FRAGH_OFFSET_MASK	0xfff8	/* Mask for the 13-bit Fragment Offset field */
+
 /** @endcond */
 
 /**

--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -565,6 +565,8 @@ union net_proto_header {
 #define NET_IPV4TCPH_LEN   (NET_TCPH_LEN + NET_IPV4H_LEN) /* IPv4 + TCP */
 #define NET_IPV4ICMPH_LEN  (NET_IPV4H_LEN + NET_ICMPH_LEN) /* ICMPv4 + IPv4 */
 
+#define NET_IPV6H_LENGTH_OFFSET		0x04	/* Offset of the Length field in the IPv6 header */
+
 /** @endcond */
 
 /**

--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -232,7 +232,7 @@ struct net_pkt {
 	uint16_t ipv6_prev_hdr_start;
 
 #if defined(CONFIG_NET_IPV6_FRAGMENT)
-	uint16_t ipv6_fragment_offset;	/* Fragment offset of this packet */
+	uint16_t ipv6_fragment_flags;	/* Fragment offset and M (More Fragment) flag */
 	uint32_t ipv6_fragment_id;	/* Fragment id */
 	uint16_t ipv6_frag_hdr_start;	/* Where starts the fragment header */
 #endif /* CONFIG_NET_IPV6_FRAGMENT */
@@ -649,13 +649,17 @@ static inline void net_pkt_set_ipv6_fragment_start(struct net_pkt *pkt,
 
 static inline uint16_t net_pkt_ipv6_fragment_offset(struct net_pkt *pkt)
 {
-	return pkt->ipv6_fragment_offset;
+	return pkt->ipv6_fragment_flags & NET_IPV6_FRAGH_OFFSET_MASK;
+}
+static inline bool net_pkt_ipv6_fragment_more(struct net_pkt *pkt)
+{
+	return (pkt->ipv6_fragment_flags & 0x01) != 0;
 }
 
-static inline void net_pkt_set_ipv6_fragment_offset(struct net_pkt *pkt,
-						    uint16_t offset)
+static inline void net_pkt_set_ipv6_fragment_flags(struct net_pkt *pkt,
+						   uint16_t flags)
 {
-	pkt->ipv6_fragment_offset = offset;
+	pkt->ipv6_fragment_flags = flags;
 }
 
 static inline uint32_t net_pkt_ipv6_fragment_id(struct net_pkt *pkt)
@@ -690,11 +694,18 @@ static inline uint16_t net_pkt_ipv6_fragment_offset(struct net_pkt *pkt)
 	return 0;
 }
 
-static inline void net_pkt_set_ipv6_fragment_offset(struct net_pkt *pkt,
-						    uint16_t offset)
+static inline bool net_pkt_ipv6_fragment_more(struct net_pkt *pkt)
 {
 	ARG_UNUSED(pkt);
-	ARG_UNUSED(offset);
+
+	return 0;
+}
+
+static inline void net_pkt_set_ipv6_fragment_flags(struct net_pkt *pkt,
+						   uint16_t flags)
+{
+	ARG_UNUSED(pkt);
+	ARG_UNUSED(flags);
 }
 
 static inline uint32_t net_pkt_ipv6_fragment_id(struct net_pkt *pkt)

--- a/subsys/net/ip/Kconfig.ipv6
+++ b/subsys/net/ip/Kconfig.ipv6
@@ -68,6 +68,23 @@ config NET_IPV6_FRAGMENT_MAX_COUNT
 	  of memory so you need to plan this and increase the network buffer
 	  count.
 
+config NET_IPV6_FRAGMENT_MAX_PKT
+	int "How many fragments can be handled to reassemble a packet"
+	default 2
+	depends on NET_IPV6_FRAGMENT
+	help
+	  Incoming fragments are stored in per-packet queue before being
+	  reassembled. This value defines the number of fragments that
+	  can be handled at the same time to reassemble a single packet.
+
+	  We do not have to accept IPv6 packets larger than 1500 bytes
+	  (RFC 2460 ch 5). This means that we should receive everything
+	  within the first two fragments. The first one being 1280 bytes and
+	  the second one 220 bytes.
+
+	  You can increase this value if you expect packets with more
+	  than two fragments.
+
 config NET_IPV6_FRAGMENT_TIMEOUT
 	int "How long to wait the fragments to receive"
 	range 1 60

--- a/subsys/net/ip/icmpv6.c
+++ b/subsys/net/ip/icmpv6.c
@@ -254,8 +254,6 @@ int net_icmpv6_send_error(struct net_pkt *orig, uint8_t type, uint8_t code,
 	 * extra space for link addresses so that we can set the lladdr
 	 * pointers in net_pkt.
 	 */
-	net_pkt_set_overwrite(pkt, true);
-
 	ret = net_pkt_write(pkt, net_pkt_lladdr_src(orig)->addr,
 			    net_pkt_lladdr_src(orig)->len);
 	if (ret < 0) {
@@ -280,9 +278,6 @@ int net_icmpv6_send_error(struct net_pkt *orig, uint8_t type, uint8_t code,
 
 	net_pkt_lladdr_src(pkt)->len = net_pkt_lladdr_dst(orig)->len;
 	net_pkt_lladdr_dst(pkt)->len = net_pkt_lladdr_src(orig)->len;
-
-	net_pkt_set_overwrite(pkt, false);
-	net_pkt_cursor_init(pkt);
 
 	if (net_ipv6_is_addr_mcast(&ip_hdr->dst)) {
 		src = net_if_ipv6_select_src_addr(net_pkt_iface(pkt),

--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -545,6 +545,15 @@ enum net_verdict net_ipv6_input(struct net_pkt *pkt, bool is_loopback)
 
 		NET_DBG("IPv6 next header %d", current_hdr);
 
+		if (current_hdr == NET_IPV6_NEXTHDR_NONE) {
+			/* There is nothing after this header (see RFC 2460,
+			 * ch 4.7), so we can drop the packet now.
+			 * This is not an error case so do not update drop
+			 * statistics.
+			 */
+			return NET_DROP;
+		}
+
 		if (net_pkt_read_u8(pkt, &nexthdr)) {
 			goto drop;
 		}
@@ -591,14 +600,6 @@ enum net_verdict net_ipv6_input(struct net_pkt *pkt, bool is_loopback)
 			}
 
 			goto bad_hdr;
-
-		case NET_IPV6_NEXTHDR_NONE:
-			/* There is nothing after this header (see RFC 2460,
-			 * ch 4.7), so we can drop the packet now.
-			 * This is not an error case so do not update drop
-			 * statistics.
-			 */
-			return NET_DROP;
 
 		default:
 			goto bad_hdr;

--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -193,7 +193,9 @@ static inline int ipv6_handle_ext_hdr_options(struct net_pkt *pkt,
 	while (length < exthdr_len) {
 		uint8_t opt_type, opt_len;
 
-		/* Each extension option has type and length */
+		/* Each extension option has type and length - except
+		 * Pad1 which has only a type without any length
+		 */
 		if (net_pkt_read_u8(pkt, &opt_type)) {
 			return -ENOBUFS;
 		}
@@ -206,12 +208,13 @@ static inline int ipv6_handle_ext_hdr_options(struct net_pkt *pkt,
 
 		switch (opt_type) {
 		case NET_IPV6_EXT_HDR_OPT_PAD1:
+			NET_DBG("PAD1 option");
 			length++;
 			break;
 		case NET_IPV6_EXT_HDR_OPT_PADN:
 			NET_DBG("PADN option");
 			length += opt_len + 2;
-
+			net_pkt_skip(pkt, opt_len);
 			break;
 		default:
 			/* Make sure that the option length is not too large.

--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -126,7 +126,7 @@ int net_ipv6_finalize(struct net_pkt *pkt, uint8_t next_header_proto)
 static inline bool ipv6_drop_on_unknown_option(struct net_pkt *pkt,
 					       struct net_ipv6_hdr *hdr,
 					       uint8_t opt_type,
-					       uint16_t length)
+					       uint16_t opt_type_offset)
 {
 	/* RFC 2460 chapter 4.2 tells how to handle the unknown
 	 * options by the two highest order bits of the option:
@@ -159,7 +159,7 @@ static inline bool ipv6_drop_on_unknown_option(struct net_pkt *pkt,
 	case 0x80:
 		net_icmpv6_send_error(pkt, NET_ICMPV6_PARAM_PROBLEM,
 				      NET_ICMPV6_PARAM_PROB_OPTION,
-				      (uint32_t)length);
+				      (uint32_t)opt_type_offset);
 		break;
 	}
 
@@ -191,7 +191,10 @@ static inline int ipv6_handle_ext_hdr_options(struct net_pkt *pkt,
 	length += 2U;
 
 	while (length < exthdr_len) {
+		uint16_t opt_type_offset;
 		uint8_t opt_type, opt_len;
+
+		opt_type_offset = net_pkt_get_current_offset(pkt);
 
 		/* Each extension option has type and length - except
 		 * Pad1 which has only a type without any length
@@ -228,7 +231,7 @@ static inline int ipv6_handle_ext_hdr_options(struct net_pkt *pkt,
 			}
 
 			if (ipv6_drop_on_unknown_option(pkt, hdr,
-							opt_type, length)) {
+							opt_type, opt_type_offset)) {
 				return -ENOTSUP;
 			}
 

--- a/subsys/net/ip/ipv6.h
+++ b/subsys/net/ip/ipv6.h
@@ -384,14 +384,7 @@ static inline void net_ipv6_nbr_set_reachable_timer(struct net_if *iface,
 }
 #endif
 
-/* We do not have to accept larger than 1500 byte IPv6 packet (RFC 2460 ch 5).
- * This means that we should receive everything within first two fragments.
- * The first one being 1280 bytes and the second one 220 bytes.
- */
-#if !defined(NET_IPV6_FRAGMENTS_MAX_PKT)
-#define NET_IPV6_FRAGMENTS_MAX_PKT 2
-#endif
-
+#if defined(CONFIG_NET_IPV6_FRAGMENT)
 /** Store pending IPv6 fragment information that is needed for reassembly. */
 struct net_ipv6_reassembly {
 	/** IPv6 source address of the fragment */
@@ -407,11 +400,14 @@ struct net_ipv6_reassembly {
 	struct k_work_delayable timer;
 
 	/** Pointers to pending fragments */
-	struct net_pkt *pkt[NET_IPV6_FRAGMENTS_MAX_PKT];
+	struct net_pkt *pkt[CONFIG_NET_IPV6_FRAGMENT_MAX_PKT];
 
 	/** IPv6 fragment identification */
 	uint32_t id;
 };
+#else
+struct net_ipv6_reassembly;
+#endif
 
 /**
  * @typedef net_ipv6_frag_cb_t

--- a/subsys/net/ip/ipv6_fragment.c
+++ b/subsys/net/ip/ipv6_fragment.c
@@ -184,7 +184,7 @@ static bool reassembly_cancel(uint32_t id,
 
 		reassembly[i].id = 0U;
 
-		for (j = 0; j < NET_IPV6_FRAGMENTS_MAX_PKT; j++) {
+		for (j = 0; j < CONFIG_NET_IPV6_FRAGMENT_MAX_PKT; j++) {
 			if (!reassembly[i].pkt[j]) {
 				continue;
 			}
@@ -245,7 +245,7 @@ static void reassemble_packet(struct net_ipv6_reassembly *reass)
 	/* We start from 2nd packet which is then appended to
 	 * the first one.
 	 */
-	for (i = 1; i < NET_IPV6_FRAGMENTS_MAX_PKT; i++) {
+	for (i = 1; i < CONFIG_NET_IPV6_FRAGMENT_MAX_PKT; i++) {
 		int removed_len;
 
 		pkt = reass->pkt[i];
@@ -377,7 +377,7 @@ static bool fragment_verify(struct net_ipv6_reassembly *reass)
 		return false;
 	}
 
-	for (i = 1; i < NET_IPV6_FRAGMENTS_MAX_PKT; i++) {
+	for (i = 1; i < CONFIG_NET_IPV6_FRAGMENT_MAX_PKT; i++) {
 		offset = net_pkt_ipv6_fragment_offset(reass->pkt[i]);
 
 		NET_DBG("pkt %p offset %u prev_len %d", reass->pkt[i],
@@ -398,7 +398,7 @@ static int shift_packets(struct net_ipv6_reassembly *reass, int pos)
 {
 	int i;
 
-	for (i = pos + 1; i < NET_IPV6_FRAGMENTS_MAX_PKT; i++) {
+	for (i = pos + 1; i < CONFIG_NET_IPV6_FRAGMENT_MAX_PKT; i++) {
 		if (!reass->pkt[i]) {
 			NET_DBG("Moving [%d] %p (offset 0x%x) to [%d]",
 				pos, reass->pkt[pos],
@@ -480,7 +480,7 @@ enum net_verdict net_ipv6_handle_fragment_hdr(struct net_pkt *pkt,
 	/* The fragments might come in wrong order so place them
 	 * in reassembly chain in correct order.
 	 */
-	for (i = 0, found = false; i < NET_IPV6_FRAGMENTS_MAX_PKT; i++) {
+	for (i = 0, found = false; i < CONFIG_NET_IPV6_FRAGMENT_MAX_PKT; i++) {
 		if (reass->pkt[i]) {
 			if (net_pkt_ipv6_fragment_offset(reass->pkt[i]) <
 			    net_pkt_ipv6_fragment_offset(pkt)) {
@@ -535,7 +535,7 @@ enum net_verdict net_ipv6_handle_fragment_hdr(struct net_pkt *pkt,
 			reass->id);
 
 		/* Let the caller release the already inserted pkt */
-		if (i < NET_IPV6_FRAGMENTS_MAX_PKT) {
+		if (i < CONFIG_NET_IPV6_FRAGMENT_MAX_PKT) {
 			reass->pkt[i] = NULL;
 		}
 

--- a/subsys/net/ip/ipv6_fragment.c
+++ b/subsys/net/ip/ipv6_fragment.c
@@ -432,24 +432,23 @@ static int shift_packets(struct net_ipv6_reassembly *reass, int pos)
 			NET_DBG("Moving [%d] %p (offset 0x%x) to [%d]",
 				pos, reass->pkt[pos],
 				net_pkt_ipv6_fragment_offset(reass->pkt[pos]),
-				i);
+				pos + 1);
 
-			/* Do we have enough space in packet array to make
-			 * the move?
+			/* pkt[i] is free, so shift everything between
+			 * [pos] and [i - 1] by one element
 			 */
-			if (((i - pos) + 1) >
-			    (NET_IPV6_FRAGMENTS_MAX_PKT - i)) {
-				return -ENOMEM;
-			}
-
-			memmove(&reass->pkt[i], &reass->pkt[pos],
+			memmove(&reass->pkt[pos + 1], &reass->pkt[pos],
 				sizeof(void *) * (i - pos));
+
+			/* pkt[pos] is now free */
+			reass->pkt[pos] = NULL;
 
 			return 0;
 		}
 	}
 
-	return -EINVAL;
+	/* We do not have free space left in the array */
+	return -ENOMEM;
 }
 
 enum net_verdict net_ipv6_handle_fragment_hdr(struct net_pkt *pkt,

--- a/subsys/net/ip/ipv6_fragment.c
+++ b/subsys/net/ip/ipv6_fragment.c
@@ -482,17 +482,6 @@ enum net_verdict net_ipv6_handle_fragment_hdr(struct net_pkt *pkt,
 		goto drop;
 	}
 
-	if (!reass->pkt[0]) {
-		NET_DBG("Storing pkt %p to slot %d offset %d",
-			pkt, 0, net_pkt_ipv6_fragment_offset(pkt));
-		reass->pkt[0] = pkt;
-
-		reassembly_info("Reassembly 1st pkt", reass);
-
-		/* Wait for more fragments to receive. */
-		goto accept;
-	}
-
 	/* The fragments might come in wrong order so place them
 	 * in reassembly chain in correct order.
 	 */

--- a/subsys/net/ip/ipv6_fragment.c
+++ b/subsys/net/ip/ipv6_fragment.c
@@ -249,6 +249,9 @@ static void reassemble_packet(struct net_ipv6_reassembly *reass)
 		int removed_len;
 
 		pkt = reass->pkt[i];
+		if (!pkt) {
+			break;
+		}
 
 		net_pkt_cursor_init(pkt);
 
@@ -378,6 +381,9 @@ static bool fragment_verify(struct net_ipv6_reassembly *reass)
 	}
 
 	for (i = 1; i < CONFIG_NET_IPV6_FRAGMENT_MAX_PKT; i++) {
+		if (!reass->pkt[i]) {
+			break;
+		}
 		offset = net_pkt_ipv6_fragment_offset(reass->pkt[i]);
 
 		NET_DBG("pkt %p offset %u prev_len %d", reass->pkt[i],

--- a/subsys/net/ip/ipv6_fragment.c
+++ b/subsys/net/ip/ipv6_fragment.c
@@ -219,6 +219,11 @@ static void reassembly_timeout(struct k_work *work)
 
 	reassembly_info("Reassembly cancelled", reass);
 
+	/* Send a ICMPv6 Time Exceeded only if we received the first fragment (RFC 2460 Sec. 5) */
+	if (reass->pkt[0] && net_pkt_ipv6_fragment_offset(reass->pkt[0]) == 0) {
+		net_icmpv6_send_error(reass->pkt[0], NET_ICMPV6_TIME_EXCEEDED, 1, 0);
+	}
+
 	reassembly_cancel(reass->id, &reass->src, &reass->dst);
 }
 

--- a/subsys/net/ip/ipv6_fragment.c
+++ b/subsys/net/ip/ipv6_fragment.c
@@ -470,7 +470,7 @@ enum net_verdict net_ipv6_handle_fragment_hdr(struct net_pkt *pkt,
 	}
 
 	more = flag & 0x01;
-	net_pkt_set_ipv6_fragment_offset(pkt, flag & 0xfff8);
+	net_pkt_set_ipv6_fragment_flags(pkt, flag);
 
 	if (more && net_pkt_get_len(pkt) % 8) {
 		/* Fragment length is not multiple of 8, discard

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -1577,7 +1577,7 @@ static void ipv6_frag_cb(struct net_ipv6_reassembly *reass,
 	   k_ticks_to_ms_ceil32(k_work_delayable_remaining_get(&reass->timer)),
 	   src, net_sprint_ipv6_addr(&reass->dst));
 
-	for (i = 0; i < NET_IPV6_FRAGMENTS_MAX_PKT; i++) {
+	for (i = 0; i < CONFIG_NET_IPV6_FRAGMENT_MAX_PKT; i++) {
 		if (reass->pkt[i]) {
 			struct net_buf *frag = reass->pkt[i]->frags;
 


### PR DESCRIPTION
The IPv6 stack does not pass some of the IPv6Ready compliance tests (see the tests specification: https://www.ipv6ready.org/docs/Core_Conformance_5_1_0.pdf). This pull request allows to address 18 of these failures from the "Group 2: Extension Headers and Options" and "Group 3: Fragmentation" subsets:
- Test v6LC.1.2.1: Next Header Zero 
- Test v6LC.1.2.3: Part A: Unrecognized Next Header in Extension Header (Multiple Values) 
- Test v6LC.1.2.3: Part B: Unexpected Next Header in Extension Header 
- Test v6LC.1.2.4: Part A: Destination Options Header precedes Fragment Header, Error from Destination Options Header 
- Test v6LC.1.2.4: Part B: Destination Options Header precedes Fragment Header, Error from Fragment Header 
- Test v6LC.1.2.4: Part C: Fragment Header precedes Destination Options Header, Error from Fragment Header 
- Test v6LC.1.2.4: Part D: Fragment Header precedes Destination Options Header, Error from Destination Options Header 
- Test v6LC.1.2.5: Part B: First Option has Most Significant Bits 00b, Next has Most Significant Bits 10b 
- Test v6LC.1.2.5: Part C: First Option has Most Significant Bits 00b, Next has Most Significant Bits 11b 
- Test v6LC.1.2.8: Part B: PadN Option 
- Test v6LC.1.2.8: Part E: Most Significant Bits 10b, unicast destination 
- Test v6LC.1.2.8: Part F: Most Significant Bits 11b, unicast destination 
- Test v6LC.1.3.1: Part A: All Fragments are Valid 
- Test v6LC.1.3.1: Part B: All Fragments are Valid, reverse order 
- Test v6LC.1.3.2: Part A: Time Elapsed Between Fragments less than Sixty Seconds 
- Test v6LC.1.3.2: Part B: Time Exceeded Before Last Fragments Arrive 
- Test v6LC.1.3.2: Part C: Time Exceeded (Global), Only First Fragment Received 
- Test v6LC.1.3.3: Fragment Header M-Bit Set, Payload Length Invalid 

See the individual commits for more details.

I tested using `samples/net/eth_native_posix/build` and a custom Python script to inject the test payloads. I did the following changes to the config in order to have a successful run (we could probably go with a lower CONFIG_NET_BUF_RX_COUNT):

```
CONFIG_NET_IPV6_FRAGMENT=y
CONFIG_NET_IPV6_FRAGMENT_MAX_COUNT=2
CONFIG_NET_IPV6_FRAGMENT_MAX_PKT=4
CONFIG_NET_IPV6_FRAGMENT_TIMEOUT=60
CONFIG_NET_BUF_RX_COUNT=30
```

I also executed `tests/net/ipv6/` and `tests/net/ipv6_fragment` on native_posix.

Fixes #36593 