### PR TITLE
drivers: usb: dc: stm32: Added implementation to functions

### DIFF
--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -498,6 +498,9 @@ static int usb_dc_stm32_init(void)
 	}
 #endif /* USB */
 
+	/* Disable soft disconnect */
+	HAL_PCD_DevConnect(&usb_dc_stm32_state.pcd);
+
 	IRQ_CONNECT(USB_IRQ, USB_IRQ_PRI,
 		    usb_dc_stm32_isr, 0, 0);
 	irq_enable(USB_IRQ);
@@ -1013,10 +1016,14 @@ int usb_dc_ep_mps(const uint8_t ep)
 
 int usb_dc_detach(void)
 {
-	LOG_ERR("Not implemented");
 	if (!usb_dc_stm32_state.attached) {
 		return 0;
 	}
+
+	irq_disable(USB_IRQ);
+
+	/* Enable soft disconnect */
+	HAL_PCD_DevDisconnect(&usb_dc_stm32_state.pcd);
 
 #ifdef CONFIG_SOC_SERIES_STM32WBX
 	/* Specially for STM32WB, unlock the HSEM when USB is no more used. */

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -997,7 +997,7 @@ int usb_dc_ep_flush(const uint8_t ep)
 		return -EINVAL;
 	}
 
-	LOG_ERR("Not implemented");
+	HAL_PCD_EP_Flush(&usb_dc_stm32_state.pcd, ep);
 
 	return 0;
 }

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -585,6 +585,7 @@ int usb_dc_ep_set_callback(const uint8_t ep, const usb_dc_ep_callback cb)
 	LOG_DBG("ep 0x%02x", ep);
 
 	if (!usb_dc_stm32_state.attached || !ep_state) {
+		LOG_ERR("Not attached / Invalid endpoint: EP 0x%02x", ep);
 		return -EINVAL;
 	}
 
@@ -682,6 +683,7 @@ int usb_dc_ep_configure(const struct usb_dc_ep_cfg_data * const ep_cfg)
 	struct usb_dc_stm32_ep_state *ep_state = usb_dc_stm32_get_ep_state(ep);
 
 	if (!usb_dc_stm32_state.attached || !ep_state) {
+		LOG_ERR("Not attached / Invalid endpoint: EP 0x%02x", ep);
 		return -EINVAL;
 	}
 
@@ -731,6 +733,7 @@ int usb_dc_ep_set_stall(const uint8_t ep)
 	LOG_DBG("ep 0x%02x", ep);
 
 	if (!usb_dc_stm32_state.attached || !ep_state) {
+		LOG_ERR("Not attached / Invalid endpoint: EP 0x%02x", ep);
 		return -EINVAL;
 	}
 
@@ -754,6 +757,7 @@ int usb_dc_ep_clear_stall(const uint8_t ep)
 	LOG_DBG("ep 0x%02x", ep);
 
 	if (!usb_dc_stm32_state.attached || !ep_state) {
+		LOG_ERR("Not attached / Invalid endpoint: EP 0x%02x", ep);
 		return -EINVAL;
 	}
 
@@ -777,6 +781,7 @@ int usb_dc_ep_is_stalled(const uint8_t ep, uint8_t *const stalled)
 	LOG_DBG("ep 0x%02x", ep);
 
 	if (!usb_dc_stm32_state.attached || !ep_state) {
+		LOG_ERR("Not attached / Invalid endpoint: EP 0x%02x", ep);
 		return -EINVAL;
 	}
 
@@ -797,6 +802,7 @@ int usb_dc_ep_enable(const uint8_t ep)
 	LOG_DBG("ep 0x%02x", ep);
 
 	if (!usb_dc_stm32_state.attached || !ep_state) {
+		LOG_ERR("Not attached / Invalid endpoint: EP 0x%02x", ep);
 		return -EINVAL;
 	}
 
@@ -828,6 +834,7 @@ int usb_dc_ep_disable(const uint8_t ep)
 	LOG_DBG("ep 0x%02x", ep);
 
 	if (!usb_dc_stm32_state.attached || !ep_state) {
+		LOG_ERR("Not attached / Invalid endpoint: EP 0x%02x", ep);
 		return -EINVAL;
 	}
 
@@ -852,7 +859,7 @@ int usb_dc_ep_write(const uint8_t ep, const uint8_t *const data,
 	LOG_DBG("ep 0x%02x, len %u", ep, data_len);
 
 	if (!usb_dc_stm32_state.attached || !ep_state || !USB_EP_DIR_IS_IN(ep)) {
-		LOG_ERR("invalid ep 0x%02x", ep);
+		LOG_ERR("Not attached / Invalid endpoint: EP 0x%02x", ep);
 		return -EINVAL;
 	}
 
@@ -904,7 +911,7 @@ int usb_dc_ep_read_wait(uint8_t ep, uint8_t *data, uint32_t max_data_len,
 	uint32_t read_count;
 
 	if (!usb_dc_stm32_state.attached || !ep_state) {
-		LOG_ERR("Invalid Endpoint %x", ep);
+		LOG_ERR("Not attached / Invalid endpoint: EP 0x%02x", ep);
 		return -EINVAL;
 	}
 
@@ -944,7 +951,7 @@ int usb_dc_ep_read_continue(uint8_t ep)
 	struct usb_dc_stm32_ep_state *ep_state = usb_dc_stm32_get_ep_state(ep);
 
 	if (!usb_dc_stm32_state.attached || !ep_state || !USB_EP_DIR_IS_OUT(ep)) {
-		LOG_ERR("Not valid endpoint: %02x", ep);
+		LOG_ERR("Not attached / Invalid endpoint: EP 0x%02x", ep);
 		return -EINVAL;
 	}
 
@@ -983,6 +990,7 @@ int usb_dc_ep_flush(const uint8_t ep)
 	struct usb_dc_stm32_ep_state *ep_state = usb_dc_stm32_get_ep_state(ep);
 
 	if (!usb_dc_stm32_state.attached || !ep_state) {
+		LOG_ERR("Not attached / Invalid endpoint: EP 0x%02x", ep);
 		return -EINVAL;
 	}
 
@@ -996,6 +1004,7 @@ int usb_dc_ep_mps(const uint8_t ep)
 	struct usb_dc_stm32_ep_state *ep_state = usb_dc_stm32_get_ep_state(ep);
 
 	if (!usb_dc_stm32_state.attached || !ep_state) {
+		LOG_ERR("Not attached / Invalid endpoint: EP 0x%02x", ep);
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Added the attached state to the USB stm32 driver,
and logging for when the device is not attached.
Also added implementation for the **usb_dc_detach**,
**usb_dc_reset** and **usb_dc_ep_flush** functions.
The **usb_dc_ep_flush** uses HAL_PCD_EP_Flush under the hood, that
uses the ll_usb. It doesn't return an error if a timeout occurred (T/RXFFLSH bit stays 1),
and it also doesn't check before doing flush if the core is reading/writing to the FIFOs.
The usb_dc_ep_disable should also AFAIK flush the FIFO, but the HAL_PCD_EP_Close
doesn't do it. I think that the usb_dc_ep_set_stall should also flush the TxFIFO (for IN endpoints).
The **usb_dc_reset** will return timeout, after **USB_STM32_CORE_RST_TIMEOUT_US** microseconds,
that parameter may be converted to a Kconfig configuration, or changed as needed.
Also the reference manual says we need to wait 3 PHY clock cycles, that I don't know how much that is,
and how to calculate, so I just took what I saw in another driver. Would like to be corrected here.
I ran a simple project that enables and disables the USB device, and resets it.
Checked with lsusb, and dmesg, and for enable/disable, show the events in dmesg,
but for reset didn't saw anything.
Did not check flush, but it is the same implementation of flush as in the ll drivers, just without checking for
timeout.
Are we supposed to see an event when we reset the USB device? It didn't return a timeout error, so I believe it works
I based my implementation on the reference manual, HAL's and ll's, and other drivers, but I believe there may still be things missing, so would happy to get some critique.

Closes #36211

Signed-off-by: Prema Jonathan van Win <jonathanvanwin@gmail.com>