### PR TITLE
drivers: pinmux: stm32: fix name clashes with G4 series

### DIFF
--- a/drivers/pinmux/pinmux_stm32.c
+++ b/drivers/pinmux/pinmux_stm32.c
@@ -114,9 +114,9 @@ int stm32_dt_pinctrl_configure(const struct soc_gpio_pinctrl *pinctrl,
 			__ASSERT_NO_MSG(STM32_DT_PINMUX_FUNC(mux));
 		}
 #else
-		if (STM32_DT_PINMUX_FUNC(mux) < ANALOG) {
+		if (STM32_DT_PINMUX_FUNC(mux) < STM32_ANALOG) {
 			func = pinctrl[i].pincfg | STM32_MODER_ALT_MODE;
-		} else if (STM32_DT_PINMUX_FUNC(mux) == ANALOG) {
+		} else if (STM32_DT_PINMUX_FUNC(mux) == STM32_ANALOG) {
 			func = STM32_MODER_ANALOG_MODE;
 		} else {
 			/* Not supported */

--- a/include/dt-bindings/pinctrl/stm32-pinctrl.h
+++ b/include/dt-bindings/pinctrl/stm32-pinctrl.h
@@ -15,23 +15,23 @@
  * @brief Pin modes
  */
 
-#define AF0     0x0
-#define AF1     0x1
-#define AF2     0x2
-#define AF3     0x3
-#define AF4     0x4
-#define AF5     0x5
-#define AF6     0x6
-#define AF7     0x7
-#define AF8     0x8
-#define AF9     0x9
-#define AF10    0xa
-#define AF11    0xb
-#define AF12    0xc
-#define AF13    0xd
-#define AF14    0xe
-#define AF15    0xf
-#define ANALOG  0x10
+#define STM32_AF0     0x0
+#define STM32_AF1     0x1
+#define STM32_AF2     0x2
+#define STM32_AF3     0x3
+#define STM32_AF4     0x4
+#define STM32_AF5     0x5
+#define STM32_AF6     0x6
+#define STM32_AF7     0x7
+#define STM32_AF8     0x8
+#define STM32_AF9     0x9
+#define STM32_AF10    0xa
+#define STM32_AF11    0xb
+#define STM32_AF12    0xc
+#define STM32_AF13    0xd
+#define STM32_AF14    0xe
+#define STM32_AF15    0xf
+#define STM32_ANALOG  0x10
 
 /**
  * @brief Macro to generate pinmux int using port, pin number and mode arguments
@@ -39,7 +39,7 @@
  */
 
 #define PIN_NO(port, line)	(((port) - 'A') * 0x10 + (line))
-#define STM32_PINMUX(port, line, mode) (((PIN_NO(port, line)) << 8) | (mode))
+#define STM32_PINMUX(port, line, mode) (((PIN_NO(port, line)) << 8) | (STM32_ ## mode))
 
 /**
  * @brief PIN configuration bitfield


### PR DESCRIPTION
There is a name clash when using G4 series LL TIM driver depending on
the inclusion order of the LL TIM and pinmux headers. If the LL headers
are included after pinmux is included, AF1 and AF2 definitions used by
pinmux clash with the AF1 and AF2 TIMx register names.

In order to solve this problem with minimum impact, the following has
been done:

1. Prefix the AFx and ANALOG definitions with STM32
2. In order to avoid changing all *-pinctrl.dtsi files, the STM32_PINMUX
   macro contatenates STM32_ with the provided mode.

Ref. This driver will not compile if headers inclusion order is not changed: https://github.com/teslabs/spinner/blob/main/drivers/svpwm/svpwm_stm32.c#L13
https://github.com/gmarull/spinner/commit/6c038eab4dbb9a1bfbaa361b43029bee0bb59c29