### PR TITLE
drivers: display: ili9xxx: multiple improvements

### DIFF
--- a/drivers/display/display_ili9xxx.c
+++ b/drivers/display/display_ili9xxx.c
@@ -24,8 +24,7 @@ struct ili9xxx_data {
 int ili9xxx_transmit(const struct device *dev, uint8_t cmd, const void *tx_data,
 		     size_t tx_len)
 {
-	const struct ili9xxx_config *config =
-		(struct ili9xxx_config *)dev->config;
+	const struct ili9xxx_config *config = dev->config;
 
 	int r;
 	struct spi_buf tx_buf;
@@ -72,8 +71,7 @@ static int ili9xxx_exit_sleep(const struct device *dev)
 
 static void ili9xxx_hw_reset(const struct device *dev)
 {
-	const struct ili9xxx_config *config =
-		(struct ili9xxx_config *)dev->config;
+	const struct ili9xxx_config *config = dev->config;
 
 	if (config->reset.port == NULL) {
 		return;
@@ -115,9 +113,8 @@ static int ili9xxx_write(const struct device *dev, const uint16_t x,
 			 const struct display_buffer_descriptor *desc,
 			 const void *buf)
 {
-	const struct ili9xxx_config *config =
-		(struct ili9xxx_config *)dev->config;
-	struct ili9xxx_data *data = (struct ili9xxx_data *)dev->data;
+	const struct ili9xxx_config *config = dev->config;
+	struct ili9xxx_data *data = dev->data;
 
 	int r;
 	const uint8_t *write_data_start = (const uint8_t *)buf;
@@ -216,7 +213,7 @@ static int
 ili9xxx_set_pixel_format(const struct device *dev,
 			 const enum display_pixel_format pixel_format)
 {
-	struct ili9xxx_data *data = (struct ili9xxx_data *)dev->data;
+	struct ili9xxx_data *data = dev->data;
 
 	int r;
 	uint8_t tx_data;
@@ -247,7 +244,7 @@ ili9xxx_set_pixel_format(const struct device *dev,
 static int ili9xxx_set_orientation(const struct device *dev,
 				   const enum display_orientation orientation)
 {
-	struct ili9xxx_data *data = (struct ili9xxx_data *)dev->data;
+	struct ili9xxx_data *data = dev->data;
 
 	int r;
 	uint8_t tx_data = ILI9XXX_MADCTL_BGR;
@@ -276,9 +273,8 @@ static int ili9xxx_set_orientation(const struct device *dev,
 static void ili9xxx_get_capabilities(const struct device *dev,
 				     struct display_capabilities *capabilities)
 {
-	struct ili9xxx_data *data = (struct ili9xxx_data *)dev->data;
-	const struct ili9xxx_config *config =
-		(struct ili9xxx_config *)dev->config;
+	struct ili9xxx_data *data = dev->data;
+	const struct ili9xxx_config *config = dev->config;
 
 	memset(capabilities, 0, sizeof(struct display_capabilities));
 
@@ -300,8 +296,7 @@ static void ili9xxx_get_capabilities(const struct device *dev,
 
 static int ili9xxx_configure(const struct device *dev)
 {
-	const struct ili9xxx_config *config =
-		(struct ili9xxx_config *)dev->config;
+	const struct ili9xxx_config *config = dev->config;
 
 	int r;
 	enum display_pixel_format pixel_format;
@@ -352,8 +347,7 @@ static int ili9xxx_configure(const struct device *dev)
 
 static int ili9xxx_init(const struct device *dev)
 {
-	const struct ili9xxx_config *config =
-		(struct ili9xxx_config *)dev->config;
+	const struct ili9xxx_config *config = dev->config;
 
 	int r;
 

--- a/drivers/display/display_ili9xxx.h
+++ b/drivers/display/display_ili9xxx.h
@@ -60,12 +60,8 @@ struct ili9xxx_config {
 	const char *spi_cs_label;
 	gpio_pin_t spi_cs_pin;
 	gpio_dt_flags_t spi_cs_flags;
-	const char *cmd_data_label;
-	gpio_pin_t cmd_data_pin;
-	gpio_dt_flags_t cmd_data_flags;
-	const char *reset_label;
-	gpio_pin_t reset_pin;
-	gpio_dt_flags_t reset_flags;
+	struct gpio_dt_spec cmd_data;
+	struct gpio_dt_spec reset;
 	uint8_t pixel_format;
 	uint16_t rotation;
 	uint16_t x_resolution;

--- a/drivers/display/display_ili9xxx.h
+++ b/drivers/display/display_ili9xxx.h
@@ -10,6 +10,7 @@
 #define ZEPHYR_DRIVERS_DISPLAY_DISPLAY_ILI9XXX_H_
 
 #include <drivers/gpio.h>
+#include <drivers/spi.h>
 #include <sys/util.h>
 
 /* Commands/registers. */
@@ -54,12 +55,7 @@
 #define ILI9XXX_RESET_WAIT_TIME 5
 
 struct ili9xxx_config {
-	const char *spi_name;
-	uint16_t spi_addr;
-	uint32_t spi_max_freq;
-	const char *spi_cs_label;
-	gpio_pin_t spi_cs_pin;
-	gpio_dt_flags_t spi_cs_flags;
+	struct spi_dt_spec spi;
 	struct gpio_dt_spec cmd_data;
 	struct gpio_dt_spec reset;
 	uint8_t pixel_format;


### PR DESCRIPTION
```
drivers: display: ili9xxx: use gpio_dt_spec

Use the recently introduced struct gpio_dt_spec to store GPIO
information and operate with them.
```
```
drivers: display: ili9xxx: use spi_dt_spec

Use the recently introduced struct spi_dt_spec to store SPI information
and operate with it.
```
```
drivers: display: ili9xxx: remove unnecessary casts

The config/data casts are not strictly necessary. Furthermore, config
was being cast to non-const.
```

Tested with the LVGL sample on the Buydisplay 2.8" TFT shield.

ROM/RAM stats:

Before:
```
Memory region         Used Size  Region Size  %age Used
           FLASH:       95244 B         1 MB      9.08%
            SRAM:      126240 B       256 KB     48.16%
        IDT_LIST:          0 GB         2 KB      0.00%

```

After:
```
Memory region         Used Size  Region Size  %age Used
           FLASH:       95260 B         1 MB      9.08%
            SRAM:      126208 B       256 KB     48.14%
        IDT_LIST:          0 GB         2 KB      0.00%

```