### PR TITLE
kernel: use thread local storage for k_current_get()

### DIFF
--- a/arch/arm/core/aarch32/thread.c
+++ b/arch/arm/core/aarch32/thread.c
@@ -509,6 +509,19 @@ void arch_switch_to_main_thread(struct k_thread *main_thread, char *stack_ptr,
 	z_arm_prepare_switch_to_main();
 
 	_current = main_thread;
+
+#if defined(CONFIG_THREAD_LOCAL_STORAGE) && defined(CONFIG_CPU_CORTEX_M)
+	/* On Cortex-M, TLS uses a global variable as pointer to
+	 * the thread local storage area. So this needs to point
+	 * to the main thread's TLS area before switching to any
+	 * thread for the first time, as the pointer is only set
+	 * during context switching.
+	 */
+	extern uintptr_t z_arm_tls_ptr;
+
+	z_arm_tls_ptr = main_thread->tls;
+#endif
+
 #ifdef CONFIG_INSTRUMENT_THREAD_SWITCHING
 	z_thread_mark_switched_in();
 #endif

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -490,10 +490,32 @@ __syscall void k_wakeup(k_tid_t thread);
 /**
  * @brief Get thread ID of the current thread.
  *
+ * This unconditionally queries the kernel via a system call.
+ *
+ * @return ID of current thread.
+ */
+__syscall k_tid_t z_current_get(void);
+
+#ifdef CONFIG_THREAD_LOCAL_STORAGE
+/* Thread-local cache of current thread ID, set in z_thread_entry() */
+extern __thread k_tid_t z_tls_current;
+#endif
+
+/**
+ * @brief Get thread ID of the current thread.
+ *
  * @return ID of current thread.
  *
  */
-__syscall k_tid_t k_current_get(void) __attribute_const__;
+__attribute_const__
+static inline k_tid_t k_current_get(void)
+{
+#ifdef CONFIG_THREAD_LOCAL_STORAGE
+	return z_tls_current;
+#else
+	return z_current_get();
+#endif
+}
 
 /**
  * @brief Abort a thread.

--- a/include/kernel_structs.h
+++ b/include/kernel_structs.h
@@ -187,7 +187,7 @@ bool z_smp_cpu_mobile(void);
 
 #define _current_cpu ({ __ASSERT_NO_MSG(!z_smp_cpu_mobile()); \
 			arch_curr_cpu(); })
-#define _current k_current_get()
+#define _current z_current_get()
 
 #else
 #define _current_cpu (&_kernel.cpus[0])

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1365,7 +1365,7 @@ static inline void z_vrfy_k_wakeup(k_tid_t thread)
 #include <syscalls/k_wakeup_mrsh.c>
 #endif
 
-k_tid_t z_impl_k_current_get(void)
+k_tid_t z_impl_z_current_get(void)
 {
 #ifdef CONFIG_SMP
 	/* In SMP, _current is a field read from _current_cpu, which
@@ -1384,11 +1384,11 @@ k_tid_t z_impl_k_current_get(void)
 }
 
 #ifdef CONFIG_USERSPACE
-static inline k_tid_t z_vrfy_k_current_get(void)
+static inline k_tid_t z_vrfy_z_current_get(void)
 {
-	return z_impl_k_current_get();
+	return z_impl_z_current_get();
 }
-#include <syscalls/k_current_get_mrsh.c>
+#include <syscalls/z_current_get_mrsh.c>
 #endif
 
 int z_impl_k_is_preempt_thread(void)

--- a/lib/os/thread_entry.c
+++ b/lib/os/thread_entry.c
@@ -13,6 +13,10 @@
 
 #include <kernel.h>
 
+#ifdef CONFIG_THREAD_LOCAL_STORAGE
+__thread k_tid_t z_tls_current;
+#endif
+
 /*
  * Common thread entry point function (used by all threads)
  *
@@ -26,6 +30,9 @@
 FUNC_NORETURN void z_thread_entry(k_thread_entry_t entry,
 				 void *p1, void *p2, void *p3)
 {
+#ifdef CONFIG_THREAD_LOCAL_STORAGE
+	z_tls_current = z_current_get();
+#endif
 	entry(p1, p2, p3);
 
 	k_thread_abort(k_current_get());


### PR DESCRIPTION
This uses thread local storage (if enabled) for `k_current_get()` so there is no need to do a syscall just to grab the thread ID of the current thread. This avoids the performance penalty of going through the syscall path.

Fixes #29520