### PR TITLE
net: lib: sockets: Fix assertion failure when zsock_close()

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -279,11 +279,11 @@ int z_impl_zsock_close(int sock)
 
 	NET_DBG("close: ctx=%p, fd=%d", ctx, sock);
 
-	z_free_fd(sock);
-
 	ret = vtable->fd_vtable.close(ctx);
 
 	k_mutex_unlock(lock);
+
+	z_free_fd(sock);
 
 	return ret;
 }


### PR DESCRIPTION
When zsock_close() is called, socket is freed before the mutex for the
socket is unlocked. If the freed socket is given to another thread
immediately, the mutex for the socket will be initialized by the new
socket owner, while the mutex is still locked by the thread calling
zosck_close().

Fixes #36568

Signed-off-by: Chih Hung Yu <chyu313@gmail.com>