### PR TITLE
dts: bindings: jedec,jesd216: remove deprecated 'has-be32k' prop

### DIFF
--- a/dts/bindings/mtd/jedec,jesd216.yaml
+++ b/dts/bindings/mtd/jedec,jesd216.yaml
@@ -38,12 +38,6 @@ properties:
       information in cases were runtime retrieval of SFDP data
       is not desired.
 
-  has-be32k:
-    type: boolean
-    required: false
-    deprecated: true
-    description: Not used after Zephyr 2.3.0
-
   quad-enable-requirements:
     type: string
     enum:


### PR DESCRIPTION
This property has been marked as deprecated in 2.5.0 and was not
actually used for even longer time.