### PR TITLE
drivers: pwm: nrf_sw: drop deprecated 'timer-instance' DT prop

### DIFF
--- a/drivers/pwm/pwm_nrf5_sw.c
+++ b/drivers/pwm/pwm_nrf5_sw.c
@@ -16,19 +16,6 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(pwm_nrf5_sw);
 
-BUILD_ASSERT(DT_INST_NODE_HAS_PROP(0, timer_instance) !=
-	     DT_INST_NODE_HAS_PROP(0, generator),
-	     "Please define either the timer-instance or generator property, but not both");
-
-#if DT_INST_NODE_HAS_PROP(0, timer_instance)
-
-#define USE_RTC		0
-#define GENERATOR_ADDR	_CONCAT(NRF_TIMER, DT_INST_PROP(0, timer_instance))
-#define GENERATOR_CC_NUM \
-	_CONCAT(_CONCAT(TIMER, DT_INST_PROP(0, timer_instance)), _CC_NUM)
-
-#else /* DT_INST_NODE_HAS_PROP(0, timer_instance) */
-
 #define GENERATOR_NODE	DT_PHANDLE(DT_DRV_INST(0), generator)
 #define GENERATOR_CC_NUM	DT_PROP(GENERATOR_NODE, cc_num)
 
@@ -41,8 +28,6 @@ BUILD_ASSERT(DT_INST_PROP(0, clock_prescaler) == 0,
 #define USE_RTC		0
 #define GENERATOR_ADDR	((NRF_TIMER_Type *) DT_REG_ADDR(GENERATOR_NODE))
 #endif
-
-#endif /* DT_INST_NODE_HAS_PROP(0, timer_instance) */
 
 /* One compare channel is needed to set the PWM period, hence +1. */
 #if ((DT_INST_PROP(0, channel_count) + 1) > GENERATOR_CC_NUM)

--- a/dts/bindings/pwm/nordic,nrf-sw-pwm.yaml
+++ b/dts/bindings/pwm/nordic,nrf-sw-pwm.yaml
@@ -9,15 +9,7 @@ properties:
       type: phandle
       description: |
         Reference to TIMER or RTC instance for generating PWM output signals
-      required: false
-
-    timer-instance:
-      type: int
-      description: |
-        Timer instance to use for generating the PWM output signals. Deprecated
-        in favour of 'generator' property.
-      required: false
-      deprecated: true
+      required: true
 
     channel-count:
       type: int


### PR DESCRIPTION
This property has been marked as deprecated in 2.5.0 and was replaced by
'generator' property.