### PR TITLE
Bluetooth: Mesh: Split Proxy services

### DIFF
--- a/subsys/bluetooth/mesh/CMakeLists.txt
+++ b/subsys/bluetooth/mesh/CMakeLists.txt
@@ -39,9 +39,12 @@ zephyr_library_sources_ifdef(CONFIG_BT_MESH_PROVISIONER provisioner.c)
 
 zephyr_library_sources_ifdef(CONFIG_BT_MESH_PB_ADV pb_adv.c)
 
-zephyr_library_sources_ifdef(CONFIG_BT_MESH_PB_GATT pb_gatt.c)
+zephyr_library_sources_ifdef(CONFIG_BT_MESH_PB_GATT
+    pb_gatt.c
+    pb_gatt_srv.c
+)
 
-zephyr_library_sources_ifdef(CONFIG_BT_MESH_GATT_SERVER gatt_services.c)
+zephyr_library_sources_ifdef(CONFIG_BT_MESH_GATT_PROXY proxy_srv.c)
 
 zephyr_library_sources_ifdef(CONFIG_BT_MESH_GATT proxy_msg.c)
 

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -158,10 +158,9 @@ config BT_MESH_PROXY_USE_DEVICE_NAME
 
 config BT_MESH_PROXY_FILTER_SIZE
 	int "Maximum number of filter entries per Proxy Client"
-	default 3 if BT_MESH_GATT_PROXY
-	default 1
+	default 3
 	range 1 32767
-	depends on BT_MESH_GATT_SERVER
+	depends on BT_MESH_GATT_PROXY
 	help
 	  This option specifies how many Proxy Filter entries the local
 	  node supports.

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -120,6 +120,14 @@ config BT_MESH_PB_GATT
 	  Enable this option to allow the device to be provisioned over
 	  GATT.
 
+config BT_MESH_PB_GATT_USE_DEVICE_NAME
+	bool "Include Bluetooth device name in scan response"
+	depends on BT_MESH_PB_GATT
+	default y
+	help
+	  This option includes GAP device name in scan response when
+	  the PB-GATT is enabled.
+
 config BT_MESH_GATT_PROXY
 	bool "GATT Proxy Service support"
 	select BT_MESH_GATT_SERVER

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -107,6 +107,12 @@ config BT_MESH_PROXY
 config BT_MESH_GATT
 	bool
 
+config BT_MESH_PROXY_MSG_LEN
+	int
+	depends on BT_MESH_GATT
+	default 66 if BT_MESH_PB_GATT
+	default 33 if BT_MESH_GATT_PROXY
+
 config BT_MESH_GATT_SERVER
 	bool
 	select BT_MESH_GATT

--- a/subsys/bluetooth/mesh/adv_ext.c
+++ b/subsys/bluetooth/mesh/adv_ext.c
@@ -21,6 +21,7 @@
 #include "adv.h"
 #include "net.h"
 #include "proxy.h"
+#include "pb_gatt_srv.h"
 
 /* Convert from ms to 0.625ms units */
 #define ADV_INT_FAST_MS    20
@@ -182,7 +183,7 @@ static void send_pending_adv(struct k_work *work)
 			BT_DBG("Proxy Advertising");
 		}
 	} else if (IS_ENABLED(CONFIG_BT_MESH_PB_GATT)) {
-		err = bt_mesh_prov_adv_start();
+		err = bt_mesh_pb_gatt_adv_start();
 		BT_DBG("PB-GATT Advertising");
 	}
 

--- a/subsys/bluetooth/mesh/adv_ext.c
+++ b/subsys/bluetooth/mesh/adv_ext.c
@@ -171,13 +171,23 @@ static void send_pending_adv(struct k_work *work)
 		}
 	}
 
+	if (!IS_ENABLED(CONFIG_BT_MESH_GATT_SERVER)) {
+		return;
+	}
+
 	/* No more pending buffers */
-	if (IS_ENABLED(CONFIG_BT_MESH_GATT_SERVER)) {
-		BT_DBG("Proxy Advertising");
-		err = bt_mesh_proxy_adv_start();
-		if (!err) {
-			atomic_set_bit(adv.flags, ADV_FLAG_PROXY);
+	if (bt_mesh_is_provisioned()) {
+		if (IS_ENABLED(CONFIG_BT_MESH_GATT_PROXY)) {
+			err = bt_mesh_proxy_adv_start();
+			BT_DBG("Proxy Advertising");
 		}
+	} else if (IS_ENABLED(CONFIG_BT_MESH_PB_GATT)) {
+		err = bt_mesh_prov_adv_start();
+		BT_DBG("PB-GATT Advertising");
+	}
+
+	if (!err) {
+		atomic_set_bit(adv.flags, ADV_FLAG_PROXY);
 	}
 }
 

--- a/subsys/bluetooth/mesh/adv_legacy.c
+++ b/subsys/bluetooth/mesh/adv_legacy.c
@@ -137,8 +137,15 @@ static void adv_thread(void *p1, void *p2, void *p3)
 				 * to bt_mesh_adv_start:
 				 */
 				adv_timeout = SYS_FOREVER_MS;
-				bt_mesh_proxy_adv_start();
-				BT_DBG("Proxy Advertising");
+				if (bt_mesh_is_provisioned()) {
+					if (IS_ENABLED(CONFIG_BT_MESH_GATT_PROXY)) {
+						(void)bt_mesh_proxy_adv_start();
+						BT_DBG("Proxy Advertising");
+					}
+				} else if (IS_ENABLED(CONFIG_BT_MESH_PB_GATT)) {
+					(void)bt_mesh_prov_adv_start();
+					BT_DBG("PB-GATT Advertising");
+				}
 
 				buf = net_buf_get(&bt_mesh_adv_queue,
 						  SYS_TIMEOUT_MS(adv_timeout));

--- a/subsys/bluetooth/mesh/adv_legacy.c
+++ b/subsys/bluetooth/mesh/adv_legacy.c
@@ -28,6 +28,7 @@
 #include "host/ecc.h"
 #include "prov.h"
 #include "proxy.h"
+#include "pb_gatt_srv.h"
 
 /* Pre-5.0 controllers enforce a minimum interval of 100ms
  * whereas 5.0+ controllers can go down to 20ms.
@@ -143,7 +144,7 @@ static void adv_thread(void *p1, void *p2, void *p3)
 						BT_DBG("Proxy Advertising");
 					}
 				} else if (IS_ENABLED(CONFIG_BT_MESH_PB_GATT)) {
-					(void)bt_mesh_prov_adv_start();
+					(void)bt_mesh_pb_gatt_adv_start();
 					BT_DBG("PB-GATT Advertising");
 				}
 

--- a/subsys/bluetooth/mesh/main.c
+++ b/subsys/bluetooth/mesh/main.c
@@ -305,7 +305,7 @@ int bt_mesh_init(const struct bt_mesh_prov *prov,
 		return err;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_MESH_GATT)) {
+	if (IS_ENABLED(CONFIG_BT_MESH_GATT_PROXY)) {
 		bt_mesh_proxy_init();
 	}
 
@@ -354,14 +354,13 @@ int bt_mesh_start(void)
 		bt_mesh_beacon_disable();
 	}
 
-	/* For PB-GATT provision, will enable in le disconnect handler. */
-	if (bt_mesh_prov_link.bearer->type == BT_MESH_PROV_ADV) {
+	if (!IS_ENABLED(CONFIG_BT_MESH_PROV) || !bt_mesh_prov_active() ||
+	    bt_mesh_prov_link.bearer->type == BT_MESH_PROV_ADV) {
 		if (IS_ENABLED(CONFIG_BT_MESH_PB_GATT)) {
 			(void)bt_mesh_proxy_prov_disable();
 		}
 
-		if (IS_ENABLED(CONFIG_BT_MESH_GATT_PROXY) &&
-		    bt_mesh_gatt_proxy_get() != BT_MESH_GATT_PROXY_NOT_SUPPORTED) {
+		if (IS_ENABLED(CONFIG_BT_MESH_GATT_PROXY)) {
 			(void)bt_mesh_proxy_gatt_enable();
 			bt_mesh_adv_update();
 		}

--- a/subsys/bluetooth/mesh/main.c
+++ b/subsys/bluetooth/mesh/main.c
@@ -43,7 +43,6 @@ int bt_mesh_provision(const uint8_t net_key[16], uint16_t net_idx,
 		      uint8_t flags, uint32_t iv_index, uint16_t addr,
 		      const uint8_t dev_key[16])
 {
-	bool pb_gatt_enabled;
 	int err;
 
 	BT_INFO("Primary Element: 0x%04x", addr);
@@ -52,16 +51,6 @@ int bt_mesh_provision(const uint8_t net_key[16], uint16_t net_idx,
 
 	if (atomic_test_and_set_bit(bt_mesh.flags, BT_MESH_VALID)) {
 		return -EALREADY;
-	}
-
-	if (IS_ENABLED(CONFIG_BT_MESH_PB_GATT)) {
-		if (bt_mesh_proxy_prov_disable(false) == 0) {
-			pb_gatt_enabled = true;
-		} else {
-			pb_gatt_enabled = false;
-		}
-	} else {
-		pb_gatt_enabled = false;
 	}
 
 	/*
@@ -108,11 +97,6 @@ int bt_mesh_provision(const uint8_t net_key[16], uint16_t net_idx,
 	err = bt_mesh_net_create(net_idx, flags, net_key, iv_index);
 	if (err) {
 		atomic_clear_bit(bt_mesh.flags, BT_MESH_VALID);
-
-		if (IS_ENABLED(CONFIG_BT_MESH_PB_GATT) && pb_gatt_enabled) {
-			(void)bt_mesh_proxy_prov_enable();
-		}
-
 		return err;
 	}
 
@@ -197,7 +181,7 @@ void bt_mesh_reset(void)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_MESH_GATT_PROXY)) {
-		bt_mesh_proxy_gatt_disable();
+		(void)bt_mesh_proxy_gatt_disable();
 	}
 
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
@@ -370,10 +354,17 @@ int bt_mesh_start(void)
 		bt_mesh_beacon_disable();
 	}
 
-	if (IS_ENABLED(CONFIG_BT_MESH_GATT_PROXY) &&
-	    bt_mesh_gatt_proxy_get() != BT_MESH_GATT_PROXY_NOT_SUPPORTED) {
-		bt_mesh_proxy_gatt_enable();
-		bt_mesh_adv_update();
+	/* For PB-GATT provision, will enable in le disconnect handler. */
+	if (bt_mesh_prov_link.bearer->type == BT_MESH_PROV_ADV) {
+		if (IS_ENABLED(CONFIG_BT_MESH_PB_GATT)) {
+			(void)bt_mesh_proxy_prov_disable();
+		}
+
+		if (IS_ENABLED(CONFIG_BT_MESH_GATT_PROXY) &&
+		    bt_mesh_gatt_proxy_get() != BT_MESH_GATT_PROXY_NOT_SUPPORTED) {
+			(void)bt_mesh_proxy_gatt_enable();
+			bt_mesh_adv_update();
+		}
 	}
 
 	if (IS_ENABLED(CONFIG_BT_MESH_LOW_POWER)) {

--- a/subsys/bluetooth/mesh/main.c
+++ b/subsys/bluetooth/mesh/main.c
@@ -36,6 +36,7 @@
 #include "access.h"
 #include "foundation.h"
 #include "proxy.h"
+#include "pb_gatt_srv.h"
 #include "settings.h"
 #include "mesh.h"
 
@@ -357,7 +358,7 @@ int bt_mesh_start(void)
 	if (!IS_ENABLED(CONFIG_BT_MESH_PROV) || !bt_mesh_prov_active() ||
 	    bt_mesh_prov_link.bearer->type == BT_MESH_PROV_ADV) {
 		if (IS_ENABLED(CONFIG_BT_MESH_PB_GATT)) {
-			(void)bt_mesh_proxy_prov_disable();
+			(void)bt_mesh_pb_gatt_disable();
 		}
 
 		if (IS_ENABLED(CONFIG_BT_MESH_GATT_PROXY)) {

--- a/subsys/bluetooth/mesh/main.c
+++ b/subsys/bluetooth/mesh/main.c
@@ -306,10 +306,6 @@ int bt_mesh_init(const struct bt_mesh_prov *prov,
 		return err;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_MESH_GATT_PROXY)) {
-		bt_mesh_proxy_init();
-	}
-
 	if (IS_ENABLED(CONFIG_BT_MESH_PROV)) {
 		err = bt_mesh_prov_init(prov);
 		if (err) {

--- a/subsys/bluetooth/mesh/pb_gatt.c
+++ b/subsys/bluetooth/mesh/pb_gatt.c
@@ -11,6 +11,7 @@
 #include "adv.h"
 #include "host/ecc.h"
 #include "prov.h"
+#include "pb_gatt_srv.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_MESH_DEBUG_PROV)
 #define LOG_MODULE_NAME bt_mesh_pb_gatt
@@ -42,7 +43,7 @@ static void reset_state(void)
 	/* If this fails, the protocol timeout handler will exit early. */
 	(void)k_work_cancel_delayable(&link.prot_timer);
 
-	link.rx_buf = bt_mesh_proxy_get_buf();
+	link.rx_buf = bt_mesh_pb_gatt_get_buf();
 }
 
 static void link_closed(enum prov_bearer_link_status status)
@@ -119,7 +120,7 @@ int bt_mesh_pb_gatt_close(struct bt_conn *conn)
 
 static int link_accept(const struct prov_bearer_cb *cb, void *cb_data)
 {
-	(void)bt_mesh_proxy_prov_enable();
+	(void)bt_mesh_pb_gatt_enable();
 	bt_mesh_adv_update();
 
 	link.cb = cb;

--- a/subsys/bluetooth/mesh/pb_gatt.c
+++ b/subsys/bluetooth/mesh/pb_gatt.c
@@ -27,7 +27,6 @@ struct prov_link {
 	const struct prov_bearer_cb *cb;
 	void *cb_data;
 	struct prov_bearer_send_cb comp;
-	struct net_buf_simple *rx_buf;
 	struct k_work_delayable prot_timer;
 };
 
@@ -42,8 +41,6 @@ static void reset_state(void)
 
 	/* If this fails, the protocol timeout handler will exit early. */
 	(void)k_work_cancel_delayable(&link.prot_timer);
-
-	link.rx_buf = bt_mesh_pb_gatt_get_buf();
 }
 
 static void link_closed(enum prov_bearer_link_status status)

--- a/subsys/bluetooth/mesh/pb_gatt_srv.c
+++ b/subsys/bluetooth/mesh/pb_gatt_srv.c
@@ -32,6 +32,17 @@
 #include "proxy_msg.h"
 #include "pb_gatt_srv.h"
 
+#if defined(CONFIG_BT_MESH_PB_GATT_USE_DEVICE_NAME)
+#define ADV_OPT_USE_NAME BT_LE_ADV_OPT_USE_NAME
+#else
+#define ADV_OPT_USE_NAME 0
+#endif
+
+#define ADV_OPT_PROV                                                           \
+	(BT_LE_ADV_OPT_CONNECTABLE | BT_LE_ADV_OPT_SCANNABLE |                 \
+	 BT_LE_ADV_OPT_ONE_TIME | ADV_OPT_USE_IDENTITY |                       \
+	 ADV_OPT_USE_NAME)
+
 static bool prov_fast_adv;
 
 static int gatt_send(struct bt_conn *conn,

--- a/subsys/bluetooth/mesh/pb_gatt_srv.c
+++ b/subsys/bluetooth/mesh/pb_gatt_srv.c
@@ -30,6 +30,7 @@
 #include "access.h"
 #include "proxy.h"
 #include "proxy_msg.h"
+#include "pb_gatt_srv.h"
 
 #define CLIENT_BUF_SIZE 66
 
@@ -113,7 +114,7 @@ static void gatt_disconnected(struct bt_conn *conn, uint8_t reason)
 	bt_mesh_pb_gatt_close(conn);
 
 	if (bt_mesh_is_provisioned()) {
-		(void)bt_mesh_proxy_prov_disable();
+		(void)bt_mesh_pb_gatt_disable();
 
 		if (IS_ENABLED(CONFIG_BT_MESH_GATT_PROXY)) {
 			(void)bt_mesh_proxy_gatt_enable();
@@ -126,7 +127,7 @@ static void gatt_disconnected(struct bt_conn *conn, uint8_t reason)
 	bt_mesh_adv_update();
 }
 
-struct net_buf_simple *bt_mesh_proxy_get_buf(void)
+struct net_buf_simple *bt_mesh_pb_gatt_get_buf(void)
 {
 	struct net_buf_simple *buf = &cli.buf;
 
@@ -181,7 +182,7 @@ static struct bt_gatt_attr prov_attrs[] = {
 
 static struct bt_gatt_service prov_svc = BT_GATT_SERVICE(prov_attrs);
 
-int bt_mesh_proxy_prov_enable(void)
+int bt_mesh_pb_gatt_enable(void)
 {
 	BT_DBG("");
 
@@ -200,7 +201,7 @@ int bt_mesh_proxy_prov_enable(void)
 	return 0;
 }
 
-int bt_mesh_proxy_prov_disable(void)
+int bt_mesh_pb_gatt_disable(void)
 {
 	BT_DBG("");
 
@@ -281,7 +282,7 @@ static int gatt_send(struct bt_conn *conn,
 	return bt_gatt_notify_cb(conn, &params);
 }
 
-int bt_mesh_prov_adv_start(void)
+int bt_mesh_pb_gatt_adv_start(void)
 {
 	BT_DBG("");
 

--- a/subsys/bluetooth/mesh/pb_gatt_srv.c
+++ b/subsys/bluetooth/mesh/pb_gatt_srv.c
@@ -127,15 +127,6 @@ static void gatt_disconnected(struct bt_conn *conn, uint8_t reason)
 	bt_mesh_adv_update();
 }
 
-struct net_buf_simple *bt_mesh_pb_gatt_get_buf(void)
-{
-	struct net_buf_simple *buf = &cli.buf;
-
-	net_buf_simple_reset(buf);
-
-	return buf;
-}
-
 static void prov_ccc_changed(const struct bt_gatt_attr *attr, uint16_t value)
 {
 	BT_DBG("value 0x%04x", value);

--- a/subsys/bluetooth/mesh/pb_gatt_srv.c
+++ b/subsys/bluetooth/mesh/pb_gatt_srv.c
@@ -84,7 +84,7 @@ static void gatt_connected(struct bt_conn *conn, uint8_t err)
 	struct bt_conn_info info;
 
 	bt_conn_get_info(conn, &info);
-	if (info.role != BT_CONN_ROLE_SLAVE ||
+	if (info.role != BT_CONN_ROLE_PERIPHERAL ||
 	    !service_registered || bt_mesh_is_provisioned()) {
 		return;
 	}
@@ -99,7 +99,7 @@ static void gatt_disconnected(struct bt_conn *conn, uint8_t reason)
 	struct bt_conn_info info;
 
 	bt_conn_get_info(conn, &info);
-	if (info.role != BT_CONN_ROLE_SLAVE ||
+	if (info.role != BT_CONN_ROLE_PERIPHERAL ||
 	    !service_registered) {
 		return;
 	}
@@ -108,14 +108,8 @@ static void gatt_disconnected(struct bt_conn *conn, uint8_t reason)
 
 	bt_mesh_pb_gatt_close(conn);
 
-	if (!bt_mesh_is_provisioned()) {
-		return;
-	}
-
-	(void)bt_mesh_pb_gatt_disable();
-
-	if (IS_ENABLED(CONFIG_BT_MESH_GATT_PROXY)) {
-		(void)bt_mesh_proxy_gatt_enable();
+	if (bt_mesh_is_provisioned()) {
+		(void)bt_mesh_pb_gatt_disable();
 	}
 }
 
@@ -304,10 +298,7 @@ int bt_mesh_pb_gatt_adv_start(void)
 	return err;
 }
 
-/* Add `_2` suffix forces this callback to be called
- * after proxy_srv's conn_cb.
- */
-BT_CONN_CB_DEFINE(conn_callbacks_2) = {
+BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.connected = gatt_connected,
 	.disconnected = gatt_disconnected,
 };

--- a/subsys/bluetooth/mesh/pb_gatt_srv.c
+++ b/subsys/bluetooth/mesh/pb_gatt_srv.c
@@ -1,0 +1,329 @@
+/*
+ * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2021 Lingao Meng
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <sys/byteorder.h>
+
+#include <net/buf.h>
+#include <bluetooth/bluetooth.h>
+#include <bluetooth/conn.h>
+#include <bluetooth/gatt.h>
+#include <bluetooth/mesh.h>
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_MESH_DEBUG_PROV)
+#define LOG_MODULE_NAME bt_mesh_pb_gatt_srv
+#include "common/log.h"
+
+#include "mesh.h"
+#include "adv.h"
+#include "net.h"
+#include "rpl.h"
+#include "transport.h"
+#include "host/ecc.h"
+#include "prov.h"
+#include "beacon.h"
+#include "foundation.h"
+#include "access.h"
+#include "proxy.h"
+#include "proxy_msg.h"
+
+#define CLIENT_BUF_SIZE 66
+
+static bool prov_fast_adv;
+
+static int gatt_send(struct bt_conn *conn,
+		     const void *data, uint16_t len,
+		     bt_gatt_complete_func_t end, void *user_data);
+
+static uint8_t __noinit client_buf_data[CLIENT_BUF_SIZE];
+static struct bt_mesh_proxy_role cli = {
+	.cb.send = gatt_send,
+	.buf = {
+		.__buf = client_buf_data,
+		.data  = client_buf_data,
+		.size  = CLIENT_BUF_SIZE,
+		.len   = CLIENT_BUF_SIZE,
+	},
+};
+
+static bool service_registered;
+
+static ssize_t gatt_recv(struct bt_conn *conn,
+			 const struct bt_gatt_attr *attr, const void *buf,
+			 uint16_t len, uint16_t offset, uint8_t flags)
+{
+	const uint8_t *data = buf;
+
+	if (cli.conn != conn) {
+		BT_ERR("No PB-GATT Client found");
+		return -ENOTCONN;
+	}
+
+	if (len < 1) {
+		BT_WARN("Too small Proxy PDU");
+		return -EINVAL;
+	}
+
+	if (PDU_TYPE(data) != BT_MESH_PROXY_PROV) {
+		BT_WARN("Proxy PDU type doesn't match GATT service");
+		return -EINVAL;
+	}
+
+	return bt_mesh_proxy_msg_recv(&cli, buf, len);
+}
+
+static void gatt_connected(struct bt_conn *conn, uint8_t err)
+{
+	struct bt_conn_info info;
+
+	bt_conn_get_info(conn, &info);
+	if (info.role != BT_CONN_ROLE_SLAVE ||
+	    !service_registered || bt_mesh_is_provisioned()) {
+		return;
+	}
+
+	cli.conn = bt_conn_ref(conn);
+
+	BT_DBG("conn %p err 0x%02x", (void *)conn, err);
+
+	net_buf_simple_reset(&cli.buf);
+}
+
+static void gatt_disconnected(struct bt_conn *conn, uint8_t reason)
+{
+	struct bt_conn_info info;
+
+	bt_conn_get_info(conn, &info);
+	if (info.role != BT_CONN_ROLE_SLAVE ||
+	    !service_registered) {
+		return;
+	}
+
+	if (cli.conn != conn) {
+		BT_WARN("No PB-GATT Client found");
+		return;
+	}
+
+	BT_DBG("conn %p reason 0x%02x", (void *)conn, reason);
+
+	bt_mesh_pb_gatt_close(conn);
+
+	if (bt_mesh_is_provisioned()) {
+		(void)bt_mesh_proxy_prov_disable();
+
+		if (IS_ENABLED(CONFIG_BT_MESH_GATT_PROXY)) {
+			(void)bt_mesh_proxy_gatt_enable();
+		}
+	}
+
+	bt_conn_unref(cli.conn);
+	cli.conn = NULL;
+
+	bt_mesh_adv_update();
+}
+
+struct net_buf_simple *bt_mesh_proxy_get_buf(void)
+{
+	struct net_buf_simple *buf = &cli.buf;
+
+	net_buf_simple_reset(buf);
+
+	return buf;
+}
+
+static void prov_ccc_changed(const struct bt_gatt_attr *attr, uint16_t value)
+{
+	BT_DBG("value 0x%04x", value);
+}
+
+static ssize_t prov_ccc_write(struct bt_conn *conn,
+			      const struct bt_gatt_attr *attr, uint16_t value)
+{
+	if (cli.conn != conn) {
+		BT_ERR("No PB-GATT Client found");
+		return -ENOTCONN;
+	}
+
+	BT_DBG("value 0x%04x", value);
+
+	if (value != BT_GATT_CCC_NOTIFY) {
+		BT_WARN("Client wrote 0x%04x instead enabling notify", value);
+		return BT_GATT_ERR(BT_ATT_ERR_VALUE_NOT_ALLOWED);
+	}
+
+	bt_mesh_pb_gatt_open(conn);
+
+	return sizeof(value);
+}
+
+/* Mesh Provisioning Service Declaration */
+static struct _bt_gatt_ccc prov_ccc =
+	BT_GATT_CCC_INITIALIZER(prov_ccc_changed, prov_ccc_write, NULL);
+
+static struct bt_gatt_attr prov_attrs[] = {
+	BT_GATT_PRIMARY_SERVICE(BT_UUID_MESH_PROV),
+
+	BT_GATT_CHARACTERISTIC(BT_UUID_MESH_PROV_DATA_IN,
+			       BT_GATT_CHRC_WRITE_WITHOUT_RESP,
+			       BT_GATT_PERM_WRITE, NULL, gatt_recv,
+			       NULL),
+
+	BT_GATT_CHARACTERISTIC(BT_UUID_MESH_PROV_DATA_OUT,
+			       BT_GATT_CHRC_NOTIFY, BT_GATT_PERM_NONE,
+			       NULL, NULL, NULL),
+	BT_GATT_CCC_MANAGED(&prov_ccc,
+			    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),
+};
+
+static struct bt_gatt_service prov_svc = BT_GATT_SERVICE(prov_attrs);
+
+int bt_mesh_proxy_prov_enable(void)
+{
+	BT_DBG("");
+
+	if (bt_mesh_is_provisioned()) {
+		return -ENOTSUP;
+	}
+
+	if (service_registered) {
+		return -EBUSY;
+	}
+
+	(void)bt_gatt_service_register(&prov_svc);
+	service_registered = true;
+	prov_fast_adv = true;
+
+	return 0;
+}
+
+int bt_mesh_proxy_prov_disable(void)
+{
+	BT_DBG("");
+
+	if (!service_registered) {
+		return -EALREADY;
+	}
+
+	bt_gatt_service_unregister(&prov_svc);
+	service_registered = false;
+
+	bt_mesh_adv_update();
+
+	return 0;
+}
+
+static uint8_t prov_svc_data[20] = {
+	BT_UUID_16_ENCODE(BT_UUID_MESH_PROV_VAL),
+};
+
+static const struct bt_data prov_ad[] = {
+	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
+	BT_DATA_BYTES(BT_DATA_UUID16_ALL,
+		      BT_UUID_16_ENCODE(BT_UUID_MESH_PROV_VAL)),
+	BT_DATA(BT_DATA_SVC_DATA16, prov_svc_data, sizeof(prov_svc_data)),
+};
+
+int bt_mesh_pb_gatt_send(struct bt_conn *conn, struct net_buf_simple *buf,
+			 bt_gatt_complete_func_t end, void *user_data)
+{
+	if (cli.conn != conn) {
+		BT_ERR("No PB-GATT Client found");
+		return -ENOTCONN;
+	}
+
+	return bt_mesh_proxy_msg_send(&cli, BT_MESH_PROXY_PROV, buf, end, user_data);
+}
+
+static size_t gatt_prov_adv_create(struct bt_data prov_sd[1])
+{
+	const struct bt_mesh_prov *prov = bt_mesh_prov_get();
+	size_t uri_len;
+
+	memcpy(prov_svc_data + 2, prov->uuid, 16);
+	sys_put_be16(prov->oob_info, prov_svc_data + 18);
+
+	if (!prov->uri) {
+		return 0;
+	}
+
+	uri_len = strlen(prov->uri);
+	if (uri_len > 29) {
+		/* There's no way to shorten an URI */
+		BT_WARN("Too long URI to fit advertising packet");
+		return 0;
+	}
+
+	prov_sd[0].type = BT_DATA_URI;
+	prov_sd[0].data_len = uri_len;
+	prov_sd[0].data = (const uint8_t *)prov->uri;
+
+	return 1;
+}
+
+static int gatt_send(struct bt_conn *conn,
+		     const void *data, uint16_t len,
+		     bt_gatt_complete_func_t end, void *user_data)
+{
+	BT_DBG("%u bytes: %s", len, bt_hex(data, len));
+
+	struct bt_gatt_notify_params params = {
+		.data = data,
+		.len = len,
+		.attr = &prov_attrs[3],
+		.user_data = user_data,
+		.func = end,
+	};
+
+	return bt_gatt_notify_cb(conn, &params);
+}
+
+int bt_mesh_prov_adv_start(void)
+{
+	BT_DBG("");
+
+	if (!service_registered || bt_mesh_is_provisioned()) {
+		return -ENOTSUP;
+	}
+
+	struct bt_le_adv_param fast_adv_param = {
+		.options = ADV_OPT_PROV,
+		ADV_FAST_INT,
+	};
+	struct bt_data prov_sd[1];
+	size_t prov_sd_len;
+	int err;
+
+	prov_sd_len = gatt_prov_adv_create(prov_sd);
+
+	if (!prov_fast_adv) {
+		struct bt_le_adv_param slow_adv_param = {
+			.options = ADV_OPT_PROV,
+			ADV_SLOW_INT,
+		};
+
+		return bt_mesh_adv_start(&slow_adv_param, SYS_FOREVER_MS, prov_ad,
+					 ARRAY_SIZE(prov_ad), prov_sd, prov_sd_len);
+	}
+
+	/* Advertise 60 seconds using fast interval */
+	err = bt_mesh_adv_start(&fast_adv_param, (60 * MSEC_PER_SEC),
+				prov_ad, ARRAY_SIZE(prov_ad),
+				prov_sd, prov_sd_len);
+	if (!err) {
+		prov_fast_adv = false;
+	}
+
+	return err;
+}
+
+/* Add `_2` suffix forces this callback to be called
+ * after proxy_srv's conn_cb.
+ */
+BT_CONN_CB_DEFINE(conn_callbacks_2) = {
+	.connected = gatt_connected,
+	.disconnected = gatt_disconnected,
+};

--- a/subsys/bluetooth/mesh/pb_gatt_srv.c
+++ b/subsys/bluetooth/mesh/pb_gatt_srv.c
@@ -32,23 +32,14 @@
 #include "proxy_msg.h"
 #include "pb_gatt_srv.h"
 
-#define CLIENT_BUF_SIZE 66
-
 static bool prov_fast_adv;
 
 static int gatt_send(struct bt_conn *conn,
 		     const void *data, uint16_t len,
 		     bt_gatt_complete_func_t end, void *user_data);
 
-static uint8_t __noinit client_buf_data[CLIENT_BUF_SIZE];
 static struct bt_mesh_proxy_role cli = {
 	.cb.send = gatt_send,
-	.buf = {
-		.__buf = client_buf_data,
-		.data  = client_buf_data,
-		.size  = CLIENT_BUF_SIZE,
-		.len   = CLIENT_BUF_SIZE,
-	},
 };
 
 static bool service_registered;
@@ -91,7 +82,7 @@ static void gatt_connected(struct bt_conn *conn, uint8_t err)
 
 	BT_DBG("conn %p err 0x%02x", (void *)conn, err);
 
-	net_buf_simple_reset(&cli.buf);
+	bt_mesh_proxy_msg_init(&cli);
 }
 
 static void gatt_disconnected(struct bt_conn *conn, uint8_t reason)

--- a/subsys/bluetooth/mesh/pb_gatt_srv.h
+++ b/subsys/bluetooth/mesh/pb_gatt_srv.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2021 Lingao Meng
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_SUBSYS_BLUETOOTH_MESH_PB_GATT_SRV_H_
+#define ZEPHYR_SUBSYS_BLUETOOTH_MESH_PB_GATT_SRV_H_
+
+#include <bluetooth/gatt.h>
+
+int bt_mesh_pb_gatt_send(struct bt_conn *conn, struct net_buf_simple *buf,
+			 bt_gatt_complete_func_t end, void *user_data);
+
+int bt_mesh_pb_gatt_enable(void);
+int bt_mesh_pb_gatt_disable(void);
+
+struct net_buf_simple *bt_mesh_pb_gatt_get_buf(void);
+
+int bt_mesh_pb_gatt_adv_start(void);
+
+#endif /* ZEPHYR_SUBSYS_BLUETOOTH_MESH_PB_GATT_SRV_H_ */

--- a/subsys/bluetooth/mesh/pb_gatt_srv.h
+++ b/subsys/bluetooth/mesh/pb_gatt_srv.h
@@ -16,8 +16,6 @@ int bt_mesh_pb_gatt_send(struct bt_conn *conn, struct net_buf_simple *buf,
 int bt_mesh_pb_gatt_enable(void);
 int bt_mesh_pb_gatt_disable(void);
 
-struct net_buf_simple *bt_mesh_pb_gatt_get_buf(void);
-
 int bt_mesh_pb_gatt_adv_start(void);
 
 #endif /* ZEPHYR_SUBSYS_BLUETOOTH_MESH_PB_GATT_SRV_H_ */

--- a/subsys/bluetooth/mesh/prov_device.c
+++ b/subsys/bluetooth/mesh/prov_device.c
@@ -37,6 +37,7 @@
 #include "access.h"
 #include "foundation.h"
 #include "proxy.h"
+#include "pb_gatt_srv.h"
 #include "prov.h"
 #include "settings.h"
 
@@ -646,7 +647,7 @@ int bt_mesh_prov_disable(bt_mesh_prov_bearer_t bearers)
 
 	if (IS_ENABLED(CONFIG_BT_MESH_PB_GATT) &&
 	    (bearers & BT_MESH_PROV_GATT)) {
-		(void)bt_mesh_proxy_prov_disable();
+		(void)bt_mesh_pb_gatt_disable();
 	}
 
 	return 0;

--- a/subsys/bluetooth/mesh/prov_device.c
+++ b/subsys/bluetooth/mesh/prov_device.c
@@ -634,6 +634,10 @@ int bt_mesh_prov_disable(bt_mesh_prov_bearer_t bearers)
 		return -EALREADY;
 	}
 
+	if (bt_mesh_prov_active()) {
+		return -EBUSY;
+	}
+
 	if (IS_ENABLED(CONFIG_BT_MESH_PB_ADV) &&
 	    (bearers & BT_MESH_PROV_ADV)) {
 		bt_mesh_beacon_disable();
@@ -642,7 +646,7 @@ int bt_mesh_prov_disable(bt_mesh_prov_bearer_t bearers)
 
 	if (IS_ENABLED(CONFIG_BT_MESH_PB_GATT) &&
 	    (bearers & BT_MESH_PROV_GATT)) {
-		bt_mesh_proxy_prov_disable(true);
+		(void)bt_mesh_proxy_prov_disable();
 	}
 
 	return 0;

--- a/subsys/bluetooth/mesh/proxy.h
+++ b/subsys/bluetooth/mesh/proxy.h
@@ -4,21 +4,35 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_SUBSYS_BLUETOOTH_MESH_PROXY_H_
-#define ZEPHYR_SUBSYS_BLUETOOTH_MESH_PROXY_H_
+#if defined(CONFIG_BT_MESH_DEBUG_USE_ID_ADDR)
+#define ADV_OPT_USE_IDENTITY BT_LE_ADV_OPT_USE_IDENTITY
+#else
+#define ADV_OPT_USE_IDENTITY 0
+#endif
 
-#include <bluetooth/gatt.h>
+#if defined(CONFIG_BT_MESH_PROXY_USE_DEVICE_NAME)
+#define ADV_OPT_USE_NAME BT_LE_ADV_OPT_USE_NAME
+#else
+#define ADV_OPT_USE_NAME 0
+#endif
 
-#define BT_MESH_PROXY_NET_PDU   0x00
-#define BT_MESH_PROXY_BEACON    0x01
-#define BT_MESH_PROXY_CONFIG    0x02
-#define BT_MESH_PROXY_PROV      0x03
+#define ADV_OPT_PROXY                                                          \
+	(BT_LE_ADV_OPT_CONNECTABLE | BT_LE_ADV_OPT_SCANNABLE |                 \
+	 BT_LE_ADV_OPT_ONE_TIME | ADV_OPT_USE_IDENTITY |                       \
+	 ADV_OPT_USE_NAME)
 
-int bt_mesh_pb_gatt_send(struct bt_conn *conn, struct net_buf_simple *buf,
-			 bt_gatt_complete_func_t end, void *user_data);
+#define ADV_OPT_PROV                                                           \
+	(BT_LE_ADV_OPT_CONNECTABLE | BT_LE_ADV_OPT_SCANNABLE |                 \
+	 BT_LE_ADV_OPT_ONE_TIME | ADV_OPT_USE_IDENTITY |                       \
+	 BT_LE_ADV_OPT_USE_NAME)
 
-int bt_mesh_proxy_prov_enable(void);
-int bt_mesh_proxy_prov_disable(void);
+#define ADV_SLOW_INT                                                           \
+	.interval_min = BT_GAP_ADV_SLOW_INT_MIN,                               \
+	.interval_max = BT_GAP_ADV_SLOW_INT_MAX
+
+#define ADV_FAST_INT                                                           \
+	.interval_min = BT_GAP_ADV_FAST_INT_MIN_2,                             \
+	.interval_max = BT_GAP_ADV_FAST_INT_MAX_2
 
 int bt_mesh_proxy_gatt_enable(void);
 int bt_mesh_proxy_gatt_disable(void);
@@ -29,6 +43,7 @@ void bt_mesh_proxy_beacon_send(struct bt_mesh_subnet *sub);
 struct net_buf_simple *bt_mesh_proxy_get_buf(void);
 
 int bt_mesh_proxy_adv_start(void);
+int bt_mesh_prov_adv_start(void);
 
 void bt_mesh_proxy_identity_start(struct bt_mesh_subnet *sub);
 void bt_mesh_proxy_identity_stop(struct bt_mesh_subnet *sub);

--- a/subsys/bluetooth/mesh/proxy.h
+++ b/subsys/bluetooth/mesh/proxy.h
@@ -10,22 +10,6 @@
 #define ADV_OPT_USE_IDENTITY 0
 #endif
 
-#if defined(CONFIG_BT_MESH_PROXY_USE_DEVICE_NAME)
-#define ADV_OPT_USE_NAME BT_LE_ADV_OPT_USE_NAME
-#else
-#define ADV_OPT_USE_NAME 0
-#endif
-
-#define ADV_OPT_PROXY                                                          \
-	(BT_LE_ADV_OPT_CONNECTABLE | BT_LE_ADV_OPT_SCANNABLE |                 \
-	 BT_LE_ADV_OPT_ONE_TIME | ADV_OPT_USE_IDENTITY |                       \
-	 ADV_OPT_USE_NAME)
-
-#define ADV_OPT_PROV                                                           \
-	(BT_LE_ADV_OPT_CONNECTABLE | BT_LE_ADV_OPT_SCANNABLE |                 \
-	 BT_LE_ADV_OPT_ONE_TIME | ADV_OPT_USE_IDENTITY |                       \
-	 BT_LE_ADV_OPT_USE_NAME)
-
 #define ADV_SLOW_INT                                                           \
 	.interval_min = BT_GAP_ADV_SLOW_INT_MIN,                               \
 	.interval_max = BT_GAP_ADV_SLOW_INT_MAX

--- a/subsys/bluetooth/mesh/proxy.h
+++ b/subsys/bluetooth/mesh/proxy.h
@@ -47,5 +47,3 @@ void bt_mesh_proxy_identity_stop(struct bt_mesh_subnet *sub);
 
 bool bt_mesh_proxy_relay(struct net_buf *buf, uint16_t dst);
 void bt_mesh_proxy_addr_add(struct net_buf_simple *buf, uint16_t addr);
-
-int bt_mesh_proxy_init(void);

--- a/subsys/bluetooth/mesh/proxy.h
+++ b/subsys/bluetooth/mesh/proxy.h
@@ -40,10 +40,7 @@ void bt_mesh_proxy_gatt_disconnect(void);
 
 void bt_mesh_proxy_beacon_send(struct bt_mesh_subnet *sub);
 
-struct net_buf_simple *bt_mesh_proxy_get_buf(void);
-
 int bt_mesh_proxy_adv_start(void);
-int bt_mesh_prov_adv_start(void);
 
 void bt_mesh_proxy_identity_start(struct bt_mesh_subnet *sub);
 void bt_mesh_proxy_identity_stop(struct bt_mesh_subnet *sub);
@@ -52,5 +49,3 @@ bool bt_mesh_proxy_relay(struct net_buf *buf, uint16_t dst);
 void bt_mesh_proxy_addr_add(struct net_buf_simple *buf, uint16_t addr);
 
 int bt_mesh_proxy_init(void);
-
-#endif /* ZEPHYR_SUBSYS_BLUETOOTH_MESH_PROXY_H_ */

--- a/subsys/bluetooth/mesh/proxy.h
+++ b/subsys/bluetooth/mesh/proxy.h
@@ -18,7 +18,7 @@ int bt_mesh_pb_gatt_send(struct bt_conn *conn, struct net_buf_simple *buf,
 			 bt_gatt_complete_func_t end, void *user_data);
 
 int bt_mesh_proxy_prov_enable(void);
-int bt_mesh_proxy_prov_disable(bool disconnect);
+int bt_mesh_proxy_prov_disable(void);
 
 int bt_mesh_proxy_gatt_enable(void);
 int bt_mesh_proxy_gatt_disable(void);

--- a/subsys/bluetooth/mesh/proxy_msg.c
+++ b/subsys/bluetooth/mesh/proxy_msg.c
@@ -48,16 +48,7 @@
 
 #define PDU_HDR(sar, type) (sar << 6 | (type & BIT_MASK(6)))
 
-#define PB_GATT_BUF_LEN_MAX	66
-#define PROXY_BUF_LEN_MAX	30
-
-#if defined(CONFIG_BT_MESH_PB_GATT)
-#define PROXY_MSG_BUF_LEN PB_GATT_BUF_LEN_MAX
-#else
-#define PROXY_MSG_BUF_LEN PROXY_BUF_LEN_MAX
-#endif
-
-static uint8_t __noinit bufs[CONFIG_BT_MAX_CONN * PROXY_MSG_BUF_LEN];
+static uint8_t __noinit bufs[CONFIG_BT_MAX_CONN * CONFIG_BT_MESH_PROXY_MSG_LEN];
 
 static struct bt_mesh_proxy_role roles[CONFIG_BT_MAX_CONN];
 
@@ -202,8 +193,9 @@ static void proxy_msg_init(struct bt_mesh_proxy_role *role)
 	}
 
 	net_buf_simple_init_with_data(&role->buf,
-				      &bufs[bt_conn_index(role->conn) * PROXY_MSG_BUF_LEN],
-				      PROXY_MSG_BUF_LEN);
+				      &bufs[bt_conn_index(role->conn) *
+					    CONFIG_BT_MESH_PROXY_MSG_LEN],
+				      CONFIG_BT_MESH_PROXY_MSG_LEN);
 
 	net_buf_simple_reset(&role->buf);
 

--- a/subsys/bluetooth/mesh/proxy_msg.c
+++ b/subsys/bluetooth/mesh/proxy_msg.c
@@ -52,13 +52,12 @@
 #define PROXY_BUF_LEN_MAX	30
 
 #if defined(CONFIG_BT_MESH_PB_GATT)
-#define PROXY_MSG_FIRST_BUF_LEN PB_GATT_BUF_LEN_MAX
+#define PROXY_MSG_BUF_LEN PB_GATT_BUF_LEN_MAX
 #else
-#define PROXY_MSG_FIRST_BUF_LEN PROXY_BUF_LEN_MAX
+#define PROXY_MSG_BUF_LEN PROXY_BUF_LEN_MAX
 #endif
 
-static uint8_t __noinit bufs[PROXY_MSG_FIRST_BUF_LEN +
-			     ((CONFIG_BT_MAX_CONN - 1) * PROXY_BUF_LEN_MAX)];
+static uint8_t __noinit bufs[CONFIG_BT_MAX_CONN * PROXY_MSG_BUF_LEN];
 
 static struct bt_mesh_proxy_role roles[CONFIG_BT_MAX_CONN];
 
@@ -194,9 +193,6 @@ int bt_mesh_proxy_msg_send(struct bt_mesh_proxy_role *role, uint8_t type,
 
 static void proxy_msg_init(struct bt_mesh_proxy_role *role)
 {
-	uint8_t i, len;
-	uint8_t *buf;
-
 	/* Check if buf has been allocated, in this way, we no longer need
 	 * to repeat the operation.
 	 */
@@ -205,16 +201,9 @@ static void proxy_msg_init(struct bt_mesh_proxy_role *role)
 		return;
 	}
 
-	i = bt_conn_index(role->conn);
-	if (!i) {
-		len = PROXY_MSG_FIRST_BUF_LEN;
-		buf = bufs;
-	} else {
-		len = PROXY_BUF_LEN_MAX;
-		buf = &bufs[PROXY_MSG_FIRST_BUF_LEN + (PROXY_BUF_LEN_MAX * (i - 1))];
-	}
-
-	net_buf_simple_init_with_data(&role->buf, buf, len);
+	net_buf_simple_init_with_data(&role->buf,
+				      &bufs[bt_conn_index(role->conn) * PROXY_MSG_BUF_LEN],
+				      PROXY_MSG_BUF_LEN);
 
 	net_buf_simple_reset(&role->buf);
 

--- a/subsys/bluetooth/mesh/proxy_msg.h
+++ b/subsys/bluetooth/mesh/proxy_msg.h
@@ -51,6 +51,8 @@ ssize_t bt_mesh_proxy_msg_recv(struct bt_mesh_proxy_role *role,
 int bt_mesh_proxy_msg_send(struct bt_mesh_proxy_role *role, uint8_t type,
 			   struct net_buf_simple *msg,
 			   bt_gatt_complete_func_t end, void *user_data);
-void bt_mesh_proxy_msg_init(struct bt_mesh_proxy_role *role);
+struct bt_mesh_proxy_role *bt_mesh_proxy_role_setup(struct bt_conn *conn,
+						    proxy_send_cb_t send,
+						    proxy_recv_cb_t recv);
 
 #endif /* ZEPHYR_SUBSYS_BLUETOOTH_MESH_PROXY_MSG_H_ */

--- a/subsys/bluetooth/mesh/proxy_msg.h
+++ b/subsys/bluetooth/mesh/proxy_msg.h
@@ -18,6 +18,11 @@
 #define CFG_FILTER_REMOVE  0x02
 #define CFG_FILTER_STATUS  0x03
 
+#define BT_MESH_PROXY_NET_PDU   0x00
+#define BT_MESH_PROXY_BEACON    0x01
+#define BT_MESH_PROXY_CONFIG    0x02
+#define BT_MESH_PROXY_PROV      0x03
+
 #define PDU_HDR(sar, type) (sar << 6 | (type & BIT_MASK(6)))
 
 typedef int (*proxy_send_cb_t)(struct bt_conn *conn,

--- a/subsys/bluetooth/mesh/proxy_msg.h
+++ b/subsys/bluetooth/mesh/proxy_msg.h
@@ -25,13 +25,13 @@
 
 #define PDU_HDR(sar, type) (sar << 6 | (type & BIT_MASK(6)))
 
+struct bt_mesh_proxy_role;
+
 typedef int (*proxy_send_cb_t)(struct bt_conn *conn,
 			       const void *data, uint16_t len,
 			       bt_gatt_complete_func_t end, void *user_data);
 
-typedef void (*proxy_recv_cb_t)(struct bt_conn *conn,
-				struct bt_mesh_net_rx *rx,
-				struct net_buf_simple *buf);
+typedef void (*proxy_recv_cb_t)(struct bt_mesh_proxy_role *role);
 
 struct bt_mesh_proxy_role {
 	struct bt_conn *conn;

--- a/subsys/bluetooth/mesh/proxy_srv.c
+++ b/subsys/bluetooth/mesh/proxy_srv.c
@@ -58,8 +58,6 @@ static struct bt_mesh_proxy_client {
 	},
 };
 
-static uint8_t __noinit client_buf_data[CLIENT_BUF_SIZE * CONFIG_BT_MAX_CONN];
-
 static bool service_registered;
 static int conn_count;
 
@@ -824,7 +822,8 @@ static void gatt_connected(struct bt_conn *conn, uint8_t err)
 	client->cli.conn = bt_conn_ref(conn);
 	client->filter_type = NONE;
 	(void)memset(client->filter, 0, sizeof(client->filter));
-	net_buf_simple_reset(&client->cli.buf);
+
+	bt_mesh_proxy_msg_init(&client->cli);
 }
 
 static void gatt_disconnected(struct bt_conn *conn, uint8_t reason)
@@ -893,20 +892,3 @@ BT_CONN_CB_DEFINE(conn_callbacks_1) = {
 	.connected = gatt_connected,
 	.disconnected = gatt_disconnected,
 };
-
-int bt_mesh_proxy_init(void)
-{
-	int i;
-
-	/* Initialize the client receive buffers */
-	for (i = 0; i < ARRAY_SIZE(clients); i++) {
-		struct bt_mesh_proxy_client *client = &clients[i];
-
-		net_buf_simple_init_with_data(&client->cli.buf,
-			client_buf_data + (i * CLIENT_BUF_SIZE), CLIENT_BUF_SIZE);
-
-		bt_mesh_proxy_msg_init(&client->cli);
-	}
-
-	return 0;
-}

--- a/subsys/bluetooth/mesh/proxy_srv.c
+++ b/subsys/bluetooth/mesh/proxy_srv.c
@@ -32,8 +32,7 @@
 #include "proxy_msg.h"
 
 static void proxy_send_beacons(struct k_work *work);
-static void proxy_filter_recv(struct bt_conn *conn,
-			      struct bt_mesh_net_rx *rx, struct net_buf_simple *buf);
+static void proxy_complete_pdu(struct bt_mesh_proxy_role *role);
 static int proxy_send(struct bt_conn *conn,
 		      const void *data, uint16_t len,
 		      bt_gatt_complete_func_t end, void *user_data);
@@ -53,7 +52,7 @@ static struct bt_mesh_proxy_client {
 		.send_beacons = Z_WORK_INITIALIZER(proxy_send_beacons),
 		.cli.cb = {
 			.send = proxy_send,
-			.recv = proxy_filter_recv,
+			.recv = proxy_complete_pdu,
 		},
 	},
 };
@@ -259,6 +258,61 @@ static void proxy_filter_recv(struct bt_conn *conn,
 		break;
 	default:
 		BT_WARN("Unhandled configuration OpCode 0x%02x", opcode);
+		break;
+	}
+}
+
+static void proxy_cfg(struct bt_mesh_proxy_role *role)
+{
+	NET_BUF_SIMPLE_DEFINE(buf, BT_MESH_NET_MAX_PDU_LEN);
+	struct bt_mesh_net_rx rx;
+	int err;
+
+	err = bt_mesh_net_decode(&role->buf, BT_MESH_NET_IF_PROXY_CFG,
+				 &rx, &buf);
+	if (err) {
+		BT_ERR("Failed to decode Proxy Configuration (err %d)", err);
+		return;
+	}
+
+	rx.local_match = 1U;
+
+	if (bt_mesh_rpl_check(&rx, NULL)) {
+		BT_WARN("Replay: src 0x%04x dst 0x%04x seq 0x%06x",
+			rx.ctx.addr, rx.ctx.recv_dst, rx.seq);
+		return;
+	}
+
+	/* Remove network headers */
+	net_buf_simple_pull(&buf, BT_MESH_NET_HDR_LEN);
+
+	BT_DBG("%u bytes: %s", buf.len, bt_hex(buf.data, buf.len));
+
+	if (buf.len < 1) {
+		BT_WARN("Too short proxy configuration PDU");
+		return;
+	}
+
+	proxy_filter_recv(role->conn, &rx, &buf);
+}
+
+static void proxy_complete_pdu(struct bt_mesh_proxy_role *role)
+{
+	switch (role->msg_type) {
+	case BT_MESH_PROXY_NET_PDU:
+		BT_DBG("Mesh Network PDU");
+		bt_mesh_net_recv(&role->buf, 0, BT_MESH_NET_IF_PROXY);
+		break;
+	case BT_MESH_PROXY_BEACON:
+		BT_DBG("Mesh Beacon PDU");
+		bt_mesh_beacon_recv(&role->buf);
+		break;
+	case BT_MESH_PROXY_CONFIG:
+		BT_DBG("Mesh Configuration PDU");
+		proxy_cfg(role);
+		break;
+	default:
+		BT_WARN("Unhandled Message Type 0x%02x", role->msg_type);
 		break;
 	}
 }

--- a/subsys/bluetooth/mesh/proxy_srv.c
+++ b/subsys/bluetooth/mesh/proxy_srv.c
@@ -861,8 +861,12 @@ static void gatt_disconnected(struct bt_conn *conn, uint8_t reason)
 	struct bt_mesh_proxy_client *client;
 
 	bt_conn_get_info(conn, &info);
-	if (info.role != BT_CONN_ROLE_PERIPHERAL ||
-	    !service_registered) {
+	if (info.role != BT_CONN_ROLE_PERIPHERAL) {
+		return;
+	}
+
+	if (!service_registered && bt_mesh_is_provisioned()) {
+		(void)bt_mesh_proxy_gatt_enable();
 		return;
 	}
 
@@ -900,10 +904,7 @@ int bt_mesh_proxy_adv_start(void)
 	return gatt_proxy_advertise(next_sub());
 }
 
-/* Add `_1` suffix forces proxy conn_cb to precede pb_gatt conn_cb.
- * As we may register proxy services in pb_gatt disconnect cb.
- */
-BT_CONN_CB_DEFINE(conn_callbacks_1) = {
+BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.connected = gatt_connected,
 	.disconnected = gatt_disconnected,
 };

--- a/subsys/bluetooth/mesh/settings.c
+++ b/subsys/bluetooth/mesh/settings.c
@@ -61,7 +61,7 @@ static int mesh_commit(void)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_MESH_PB_GATT)) {
-		bt_mesh_proxy_prov_disable(true);
+		(void)bt_mesh_proxy_prov_disable();
 	}
 
 	bt_mesh_net_settings_commit();

--- a/subsys/bluetooth/mesh/settings.c
+++ b/subsys/bluetooth/mesh/settings.c
@@ -26,6 +26,7 @@
 #include "heartbeat.h"
 #include "access.h"
 #include "proxy.h"
+#include "pb_gatt_srv.h"
 #include "settings.h"
 #include "cfg.h"
 
@@ -61,7 +62,7 @@ static int mesh_commit(void)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_MESH_PB_GATT)) {
-		(void)bt_mesh_proxy_prov_disable();
+		(void)bt_mesh_pb_gatt_disable();
 	}
 
 	bt_mesh_net_settings_commit();


### PR DESCRIPTION
we will no longer need the additional `disconnect` parameter,
such as we only process gatt database from disconnect handler.

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>