### PR TITLE
Bluetooth: SDP: judge the buf->len before sys_get_be16

### DIFF
--- a/subsys/bluetooth/host/sdp.c
+++ b/subsys/bluetooth/host/sdp.c
@@ -2217,6 +2217,9 @@ static int bt_sdp_get_attr(const struct net_buf *buf,
 		}
 
 		data += sizeof(uint8_t);
+		if ((data + sizeof(id) - buf->data) > buf->len) {
+			return -EINVAL;
+		}
 		id = sys_get_be16(data);
 		BT_DBG("Attribute ID 0x%04x", id);
 		data += sizeof(uint16_t);


### PR DESCRIPTION
There may be less than 2 bytes in buf before calling sys_get_be16.

Signed-off-by: Mark Wang <yichang.wang@nxp.com>