### PR TITLE
soc: npcx: Add soc log register

### DIFF
--- a/soc/arm/nuvoton_npcx/npcx7/soc.c
+++ b/soc/arm/nuvoton_npcx/npcx7/soc.c
@@ -8,6 +8,9 @@
 #include <device.h>
 #include <init.h>
 #include <soc.h>
+#include <logging/log.h>
+
+LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 
 static int soc_init(const struct device *dev)
 {

--- a/soc/arm/nuvoton_npcx/npcx9/soc.c
+++ b/soc/arm/nuvoton_npcx/npcx9/soc.c
@@ -8,6 +8,9 @@
 #include <device.h>
 #include <init.h>
 #include <soc.h>
+#include <logging/log.h>
+
+LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 
 static int soc_init(const struct device *dev)
 {


### PR DESCRIPTION
NPCX power.c use LOG_MODULE_DECLARE(soc), but NPCX chip doesn't
register soc log module. This CL register soc log in soc.c to fix NPCX
build error for power management & log system.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zephyrproject-rtos/zephyr/36878)
<!-- Reviewable:end -->
