### PR TITLE
drivers: flash: mcux flexspi nor: Fix write on arbitrary offset

### DIFF
--- a/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
+++ b/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
@@ -335,7 +335,11 @@ static int flash_flexspi_nor_write(const struct device *dev, off_t offset,
 	}
 
 	while (len) {
-		i = MIN(SPI_NOR_PAGE_SIZE, len);
+		/* If the offset isn't a multiple of the NOR page size, we first need
+		 * to write the remaining part that fits, otherwise the write could
+		 * be wrapped around within the same page
+		 */
+		i = MIN(SPI_NOR_PAGE_SIZE - (offset % SPI_NOR_PAGE_SIZE), len);
 #ifdef CONFIG_FLASH_MCUX_FLEXSPI_NOR_WRITE_BUFFER
 		memcpy(nor_write_buf, src, i);
 #endif

--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -349,7 +349,11 @@ static int flash_flexspi_nor_write(const struct device *dev, off_t offset,
 	}
 
 	while (len) {
-		i = MIN(SPI_NOR_PAGE_SIZE, len);
+		/* If the offset isn't a multiple of the NOR page size, we first need
+		 * to write the remaining part that fits, otherwise the write could
+		 * be wrapped around within the same page
+		 */
+		i = MIN(SPI_NOR_PAGE_SIZE - (offset % SPI_NOR_PAGE_SIZE), len);
 #ifdef CONFIG_FLASH_MCUX_FLEXSPI_NOR_WRITE_BUFFER
 		memcpy(nor_write_buf, src, i);
 #endif


### PR DESCRIPTION
If a write offset isn't a multiple of the nor page size, and the length is too large to fit within a single page, it could wrap around in that page.

Tested on i.MX RT1064 internal flash using NVS settings