### PR TITLE
 soc: arm: stm32l0/stm32l1: set voltage scaling to range1

### DIFF
--- a/soc/arm/st_stm32/stm32l0/soc.c
+++ b/soc/arm/st_stm32/stm32l0/soc.c
@@ -15,6 +15,8 @@
 #include <arch/arm/aarch32/cortex_m/cmsis.h>
 #include <linker/linker-defs.h>
 #include <string.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_pwr.h>
 
 /**
  * @brief Perform basic hardware initialization at boot.
@@ -42,6 +44,13 @@ static int stm32l0_init(const struct device *arg)
 	/* Update CMSIS SystemCoreClock variable (HCLK) */
 	/* At reset, system core clock is set to 2.1 MHz from MSI */
 	SystemCoreClock = 2097152;
+
+	/* Default Voltage scaling range selection (range2)
+	 * doesn't allow to configure Max frequency
+	 * switch to range1 to match any frequency
+	 */
+	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
+	LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE1);
 
 	return 0;
 }

--- a/soc/arm/st_stm32/stm32l1/soc.c
+++ b/soc/arm/st_stm32/stm32l1/soc.c
@@ -15,6 +15,8 @@
 #include <arch/arm/aarch32/cortex_m/cmsis.h>
 #include <linker/linker-defs.h>
 #include <string.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_pwr.h>
 
 /**
  * @brief Perform basic hardware initialization at boot.
@@ -42,6 +44,13 @@ static int stm32l1_init(const struct device *arg)
 	/* Update CMSIS SystemCoreClock variable (HCLK) */
 	/* At reset, system core clock is set to 2.1 MHz from MSI */
 	SystemCoreClock = 2097000;
+
+	/* Default Voltage scaling range selection (range2)
+	 * doesn't allow to configure Max frequency
+	 * switch to range1 to match any frequency
+	 */
+	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
+	LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE1);
 
 	return 0;
 }


### PR DESCRIPTION
 soc: arm: stm32l0/stm32l0: set voltage scaling to range1

Default Voltage scaling range selection (range2)
doesn't allow to configure Max frequency
switch to range1 to match any frequency

Applicable to both stm32l0 and stm32l1