### PR TITLE
west: update west.yml to get updated hal_stm32 modules

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -84,7 +84,7 @@ manifest:
       revision: 575de9d461aa6f430cf62c58a053675377e700f3
       path: modules/hal/st
     - name: hal_stm32
-      revision: dc83915685a5b32a299388e54e0fd259ded86bc4
+      revision: 91054cd84aaffa260efcbf3b591badcc4fa013ab
       path: modules/hal/stm32
     - name: hal_ti
       revision: 3da6fae25fc44ec830fac4a92787b585ff55435e


### PR DESCRIPTION
This commit changes the entry referencing the hal_stm32 module
into west.yml. This brings the fixes to build issues when stm32
asserts are enabled.

Signed-off-by: Krishna Mohan Dani <krishnamohan.d@hcl.com>