### PR TITLE
lib: os: cbprinf prevent circular includes

### DIFF
--- a/include/sys/cbprintf_internal.h
+++ b/include/sys/cbprintf_internal.h
@@ -13,7 +13,10 @@
 #include <stdint.h>
 #include <toolchain.h>
 #include <sys/util.h>
+
+#ifdef CONFIG_CBPRINTF_STATIC_PACKAGE_CHECK_ALIGNMENT
 #include <sys/__assert.h>
+#endif
 
 /*
  * Special alignment cases
@@ -336,10 +339,9 @@ do { \
 			"Xtensa requires aligned package."); \
 	BUILD_ASSERT((_align_offset % sizeof(int)) == 0, \
 			"Alignment offset must be multiply of a word."); \
-	if (IS_ENABLED(CONFIG_CBPRINTF_STATIC_PACKAGE_CHECK_ALIGNMENT)) { \
-		__ASSERT(!((uintptr_t)buf & (CBPRINTF_PACKAGE_ALIGNMENT - 1)), \
-			"Buffer must be aligned."); \
-	} \
+	IF_ENABLED(CONFIG_CBPRINTF_STATIC_PACKAGE_CHECK_ALIGNMENT, \
+		(__ASSERT(!((uintptr_t)buf & (CBPRINTF_PACKAGE_ALIGNMENT - 1)), \
+			  "Buffer must be aligned.");)) \
 	uint8_t *_pbuf = buf; \
 	size_t _pmax = (buf != NULL) ? _inlen : INT32_MAX; \
 	int _pkg_len = 0; \

--- a/lib/os/Kconfig.cbprintf
+++ b/lib/os/Kconfig.cbprintf
@@ -127,6 +127,8 @@ config CBPRINTF_PACKAGE_LONGDOUBLE
 
 config CBPRINTF_STATIC_PACKAGE_CHECK_ALIGNMENT
 	bool "Validate alignment of a static package buffer"
+	# To avoid self referential macro when printk is redirected to logging
+	depends on !LOG_PRINTK
 	help
 	  When enabled, CBPRINTF_STATIC_PACKAGE asserts when buffer is not
 	  properly aligned. If macro is widely used then assert may impact


### PR DESCRIPTION
When printk is redirected to logging (`CONFIG_LOG_PRINTK`) then `printk.h` includes `log_msg2.h` which includes `cbprintf_internal.h` which includes `__assert.h` which includes `printk.h`.

Fixing it by adding compile time switches for including and using asserts in cbprintf and forcing to not use them when `LOG_PRINTK` is set.

Fixes #36486.