### PR TITLE
ci: reduce disk usage for daily build

### DIFF
--- a/.buildkite/run.sh
+++ b/.buildkite/run.sh
@@ -54,7 +54,7 @@ ccache -s
 
 
 if [ -n "${DAILY_BUILD}" ]; then
-   TWISTER_OPTIONS=" --inline-logs -N --build-only --all --retry-failed 3 -v "
+   TWISTER_OPTIONS=" --inline-logs -M -N --build-only --all --retry-failed 3 -v "
    echo "--- DAILY BUILD"
    west init -l .
    west update 1> west.update.log || west update 1> west.update-2.log


### PR DESCRIPTION
Avoid some cases of running out of disk space in the daily build.  Add
setting -M option to remove artifacts as we build.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>