### PR TITLE
tests: kernel: device: Exclude beaglev_starlight_jh7100

### DIFF
--- a/tests/kernel/device/testcase.yaml
+++ b/tests/kernel/device/testcase.yaml
@@ -5,6 +5,7 @@ common:
 tests:
   kernel.device:
     tags: kernel device
+    platform_exclude: beaglev_starlight_jh7100
   kernel.device.pm:
     tags: kernel device
     platform_exclude: mec15xxevb_assy6853 beaglev_starlight_jh7100


### PR DESCRIPTION
We excluded the beaglev_starlight_jh7100 from this test but only did
the kernel.device.pm test.  We should have excluded the platform
from both tests.

The beaglev_starlight_jh7100 uses a full 64-bit devicetree map
which uses #{address/size}-cells = 2.  The device test expects
that #{address/size}-cells = 1 so exclude beaglev_starlight_jh7100
from the test.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>