### PR TITLE
samples: jesd216: Exclude hifive1 board from sample

### DIFF
--- a/samples/drivers/jesd216/sample.yaml
+++ b/samples/drivers/jesd216/sample.yaml
@@ -3,6 +3,7 @@ sample:
 tests:
   sample.drivers.jesd216:
     tags: spi flash
+    platform_exclude: hifive1
     filter: dt_compat_enabled("jedec,spi-nor")
     harness: console
     harness_config:


### PR DESCRIPTION
By default the hifive1 board doesn't enable the SPI controller that
the flash is on.  As such this test will not build on that platform
due to lack of a missing SPI bus controller device.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>