### PR TITLE
tests: test_build: Exclude some NS platforms from debug builds

### DIFF
--- a/tests/misc/test_build/testcase.yaml
+++ b/tests/misc/test_build/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   buildsystem.debug.build:
-    platform_exclude: lpcxpresso55s69_ns
+    platform_exclude: lpcxpresso55s69_ns nrf9160dk_nrf9160_ns nrf5340dk_nrf5340_cpuapp_ns
     build_only: true
     extra_args: CONF_FILE=debug.conf
     tags: debug


### PR DESCRIPTION
The nrf9160dk_nrf9160_ns and nrf5340dk_nrf5340_cpuapp_ns don't have
enough space for debug builds as configured so excluded them from
this specific test.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>