### PR TITLE
ISO unbind check

### DIFF
--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -697,7 +697,11 @@ void bt_iso_cleanup(struct bt_conn *conn)
 		}
 
 		if (i == CONFIG_BT_ISO_MAX_CHAN) {
-			hci_le_remove_cig(conn->iso.cig_id);
+			int err = hci_le_remove_cig(conn->iso.cig_id);
+
+			if (err != 0) {
+				BT_WARN("Failed to remove CIG: %d", err);
+			}
 		}
 	}
 }

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -1270,6 +1270,11 @@ int bt_iso_chan_unbind(struct bt_iso_chan *chan)
 		return -EINVAL;
 	}
 
+	if (chan->state != BT_ISO_BOUND) {
+		BT_DBG("Channel is not in BT_ISO_BOUND state");
+		return -EINVAL;
+	}
+
 	if (!chan->conn) {
 		return -EINVAL;
 	}

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -1049,7 +1049,7 @@ failed:
 		conn = param->conns[i];
 
 		if (conn->type == BT_CONN_TYPE_ISO) {
-			bt_iso_cleanup(conn);
+			bt_conn_unref(conn);
 		}
 	}
 


### PR DESCRIPTION
Adds a iso channel state check when unbinding a channel. 

Also adds a log message if we fail to remove the CIG (which was previously caused by the lack of the check in unbind). 