### PR TITLE
drivers/clock_control: stm32: Fixes around LSE clock

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -457,6 +457,10 @@ int stm32_clock_control_init(const struct device *dev)
 	LL_RCC_MSI_SetCalibTrimming(0);
 
 #if STM32_MSI_PLL_MODE
+
+#ifndef STM32_LSE_CLOCK
+#error "MSI Hardware auto calibration requires LSE clock activation"
+#endif
 	/* Enable MSI hardware auto calibration */
 	LL_RCC_MSI_EnablePLLMode();
 #endif

--- a/drivers/clock_control/clock_stm32g4.c
+++ b/drivers/clock_control/clock_stm32g4.c
@@ -49,7 +49,7 @@ void config_enable_default_clocks(void)
 	/* Enable the power interface clock */
 	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
 
-#ifdef STM32_LSE
+#ifdef STM32_LSE_CLOCK
 	/* LSE belongs to the back-up domain, enable access.*/
 
 	/* Set the DBP bit in the Power control register 1 (PWR_CR1) */


### PR DESCRIPTION
Fix macro used in g4 file to enable LSE clock.
Then, to avoid no-op configurations, generate an error
when MSI Hardware auto calibration is selected but LSE
clock is not enabled.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>