### PR TITLE
Bluetooth: Controller: Fix HCI reset assert initiating on coded PHY

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -700,7 +700,23 @@ void ll_reset(void)
 		if (!err) {
 			struct ll_scan_set *scan;
 
-			scan = ull_scan_is_enabled_get(0);
+			scan = ull_scan_is_enabled_get(SCAN_HANDLE_1M);
+
+			if (IS_ENABLED(CONFIG_BT_CTLR_ADV_EXT) &&
+			    IS_ENABLED(CONFIG_BT_CTLR_PHY_CODED)) {
+				struct ll_scan_set *scan_other;
+
+				scan_other = ull_scan_is_enabled_get(SCAN_HANDLE_PHY_CODED);
+				if (scan_other) {
+					if (scan) {
+						scan->is_enabled = 0U;
+						scan->lll.conn = NULL;
+					}
+
+					scan = scan_other;
+				}
+			}
+
 			LL_ASSERT(scan);
 
 			scan->is_enabled = 0U;


### PR DESCRIPTION
Fix HCI Reset Command from asserting when there is pending
connection creation requested on coded PHY.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>