### PR TITLE
drivers: edac: Fix PCIe Kconfig dependency

### DIFF
--- a/drivers/edac/Kconfig
+++ b/drivers/edac/Kconfig
@@ -25,7 +25,7 @@ config EDAC_SHELL
 
 config EDAC_IBECC
 	bool "In-Band ECC (IBECC)"
-	depends on X86
+	depends on X86 && PCIE
 	help
 	  This option selects In-Band ECC (IBECC) IP support.
 


### PR DESCRIPTION
It's not possible to build the IBECC driver without PCIe support.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>