### PR TITLE
kernel: native_posix: Don't run global C++ constructors

### DIFF
--- a/kernel/init.c
+++ b/kernel/init.c
@@ -197,7 +197,7 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 #endif
 	boot_banner();
 
-#ifdef CONFIG_CPLUSPLUS
+#if defined(CONFIG_CPLUSPLUS) && !defined(CONFIG_ARCH_POSIX)
 	/* Process the .ctors and .init_array sections */
 	extern void __do_global_ctors_aux(void);
 	extern void __do_init_array_aux(void);


### PR DESCRIPTION
On the native_posix board global object constructors
are run by the underlying OS runtime init prior to
Zephyr kernel init. Thus Zephyr should not run global
object constructors a second time. Doing so breaks
application behavior that relies on global
constructors doing work that must be done only once.
See [bug #36858](https://github.com/zephyrproject-rtos/zephyr/issues/36858) for more information.

Fixes #36858.