### PR TITLE
toolchain: linker: Add kconfig header to link script generation

### DIFF
--- a/cmake/linker/arcmwdt/target.cmake
+++ b/cmake/linker/arcmwdt/target.cmake
@@ -35,6 +35,7 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
     OUTPUT ${linker_script_gen}
     DEPENDS
     ${LINKER_SCRIPT}
+    ${AUTOCONF_H}
     ${extra_dependencies}
     # NB: 'linker_script_dep' will use a keyword that ends 'DEPENDS'
     ${linker_script_dep}
@@ -45,6 +46,7 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
     -MD -MF ${linker_script_gen}.dep -MT ${base_name}/${linker_script_gen}
     -D_LINKER
     -D_ASMLANGUAGE
+    -imacros ${AUTOCONF_H}
     ${current_includes}
     ${current_defines}
     ${linker_pass_define}

--- a/cmake/linker/ld/target.cmake
+++ b/cmake/linker/ld/target.cmake
@@ -54,6 +54,7 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
     OUTPUT ${linker_script_gen}
     DEPENDS
     ${LINKER_SCRIPT}
+    ${AUTOCONF_H}
     ${extra_dependencies}
     # NB: 'linker_script_dep' will use a keyword that ends 'DEPENDS'
     ${linker_script_dep}
@@ -63,6 +64,7 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
     -MD -MF ${linker_script_gen}.dep -MT ${base_name}/${linker_script_gen}
     -D_LINKER
     -D_ASMLANGUAGE
+    -imacros ${AUTOCONF_H}
     ${current_includes}
     ${current_defines}
     ${linker_pass_define}


### PR DESCRIPTION
Add auto-generated kconfig header to linker script pre-processing
via -imacros flag. This permits link scripts supplied via
zephyr_linker_sources() to use CONFIG_* variables.

Signed-off-by: David Palchak <palchak@google.com>