### PR TITLE
logging: log_backend_xtensa_sim: Add support for logging v2

### DIFF
--- a/subsys/logging/Kconfig.backends
+++ b/subsys/logging/Kconfig.backends
@@ -216,7 +216,6 @@ config LOG_BACKEND_NATIVE_POSIX
 config LOG_BACKEND_XTENSA_SIM
 	bool "Enable xtensa simulator backend"
 	depends on SOC_XTENSA_SAMPLE_CONTROLLER || SOC_FAMILY_INTEL_ADSP
-	depends on !LOG2
 	help
 	  Enable backend in xtensa simulator
 

--- a/subsys/logging/log_backend_xtensa_sim.c
+++ b/subsys/logging/log_backend_xtensa_sim.c
@@ -44,6 +44,14 @@ static void put(const struct log_backend *const backend,
 
 }
 
+static void process(const struct log_backend *const backend,
+		    union log_msg2_generic *msg)
+{
+	uint32_t flags = log_backend_std_get_flags();
+
+	log_output_msg2_process(&log_output_xsim, &msg->log, flags);
+}
+
 static void panic(struct log_backend const *const backend)
 {
 	log_backend_std_panic(&log_output_xsim);
@@ -73,10 +81,11 @@ static void sync_hexdump(const struct log_backend *const backend,
 }
 
 const struct log_backend_api log_backend_xtensa_sim_api = {
-	.put = IS_ENABLED(CONFIG_LOG_IMMEDIATE) ? NULL : put,
-	.put_sync_string = IS_ENABLED(CONFIG_LOG_IMMEDIATE) ?
+	.process = IS_ENABLED(CONFIG_LOG2) ? process : NULL,
+	.put = IS_ENABLED(CONFIG_LOG_MODE_DEFERRED) ? put : NULL,
+	.put_sync_string = IS_ENABLED(CONFIG_LOG_MODE_IMMEDIATE) ?
 			sync_string : NULL,
-	.put_sync_hexdump = IS_ENABLED(CONFIG_LOG_IMMEDIATE) ?
+	.put_sync_hexdump = IS_ENABLED(CONFIG_LOG_MODE_IMMEDIATE) ?
 			sync_hexdump : NULL,
 	.panic = panic,
 	.dropped = IS_ENABLED(CONFIG_LOG_IMMEDIATE) ? NULL : dropped,


### PR DESCRIPTION
Added support for logging v2 backend API in xtensa_sim.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>