### PR TITLE
arch: give the choice "Cache type" a name

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -923,7 +923,7 @@ config ICACHE_LINE_SIZE
 
 	  Detect automatically at runtime by selecting ICACHE_LINE_SIZE_DETECT.
 
-choice
+choice CACHE_TYPE
 	prompt "Cache type"
 	depends on CACHE_MANAGEMENT
 	default HAS_ARCH_CACHE


### PR DESCRIPTION
Give the choice a name so that the soc/board developers can change the
default selection in their Kconfig.*.

For example:
choice CACHE_TYPE
	default HAS_EXTERNAL_CACHE
endchoice

There was a similar issue had beed discussed:
https://github.com/zephyrproject-rtos/zephyr/issues/6948

Signed-off-by: Dylan Hung <dylan_hung@aspeedtech.com>
Change-Id: I07c3e78a5243b30912f8e44fa3181fa163016318