### PR TITLE
bluetooth: monitor: Add support for logging v2

### DIFF
--- a/subsys/bluetooth/host/monitor.c
+++ b/subsys/bluetooth/host/monitor.c
@@ -325,6 +325,43 @@ static void monitor_log_put(const struct log_backend *const backend,
 	atomic_clear_bit(&flags, BT_LOG_BUSY);
 }
 
+static void monitor_log_process(const struct log_backend *const backend,
+				union log_msg2_generic *msg)
+{
+	struct bt_monitor_user_logging user_log;
+	struct monitor_log_ctx ctx;
+	struct bt_monitor_hdr hdr;
+	static const char id[] = "bt";
+
+	log_output_ctx_set(&monitor_log_output, &ctx);
+
+	ctx.total_len = 0;
+	log_output_msg2_process(&monitor_log_output, &msg->log,
+			       LOG_OUTPUT_FLAG_CRLF_NONE);
+
+	if (atomic_test_and_set_bit(&flags, BT_LOG_BUSY)) {
+		drop_add(BT_MONITOR_USER_LOGGING);
+		return;
+	}
+
+	encode_hdr(&hdr, (uint32_t)log_msg2_get_timestamp(&msg->log),
+		   BT_MONITOR_USER_LOGGING,
+		   sizeof(user_log) + sizeof(id) + ctx.total_len + 1);
+
+	user_log.priority = monitor_priority_get(log_msg2_get_level(&msg->log));
+	user_log.ident_len = sizeof(id);
+
+	monitor_send(&hdr, BT_MONITOR_BASE_HDR_LEN + hdr.hdr_len);
+	monitor_send(&user_log, sizeof(user_log));
+	monitor_send(id, sizeof(id));
+	monitor_send(ctx.msg, ctx.total_len);
+
+	/* Terminate the string with null */
+	uart_poll_out(monitor_dev, '\0');
+
+	atomic_clear_bit(&flags, BT_LOG_BUSY);
+}
+
 static void monitor_log_panic(const struct log_backend *const backend)
 {
 }
@@ -335,7 +372,8 @@ static void monitor_log_init(const struct log_backend *const backend)
 }
 
 static const struct log_backend_api monitor_log_api = {
-	.put = monitor_log_put,
+	.process = IS_ENABLED(CONFIG_LOG2_MODE_DEFERRED) ? monitor_log_process : NULL,
+	.put = IS_ENABLED(CONFIG_LOG_MODE_DEFERRED) ? monitor_log_put : NULL,
 	.panic = monitor_log_panic,
 	.init = monitor_log_init,
 };


### PR DESCRIPTION
Added support for logging v2 backend API in bluetooth monitor backend.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>