### PR TITLE
drivers: usb_dc_mcux_ehci: use K_NO_WAIT in k_heap_alloc()

### DIFF
--- a/drivers/usb/device/usb_dc_mcux_ehci.c
+++ b/drivers/usb/device/usb_dc_mcux_ehci.c
@@ -78,8 +78,8 @@ static usb_device_struct_t dev_data;
 #if ((defined(USB_DEVICE_CONFIG_EHCI)) && (USB_DEVICE_CONFIG_EHCI > 0U))
 /* EHCI device driver interface */
 static const usb_device_controller_interface_struct_t ehci_iface = {
-								    USB_DeviceEhciInit, USB_DeviceEhciDeinit, USB_DeviceEhciSend,
-								    USB_DeviceEhciRecv, USB_DeviceEhciCancel, USB_DeviceEhciControl
+	USB_DeviceEhciInit, USB_DeviceEhciDeinit, USB_DeviceEhciSend,
+	USB_DeviceEhciRecv, USB_DeviceEhciCancel, USB_DeviceEhciControl
 };
 #endif
 

--- a/drivers/usb/device/usb_dc_mcux_ehci.c
+++ b/drivers/usb/device/usb_dc_mcux_ehci.c
@@ -211,9 +211,9 @@ int usb_dc_ep_configure(const struct usb_dc_ep_cfg_data *const cfg)
 		block->data = NULL;
 	}
 
-	block->data = k_heap_alloc(&ep_buf_pool, cfg->ep_mps, K_MSEC(10));
+	block->data = k_heap_alloc(&ep_buf_pool, cfg->ep_mps, K_NO_WAIT);
 	if (block->data == NULL) {
-		LOG_ERR("Memory allocation time-out");
+		LOG_ERR("Failed to allocate memory");
 		return -ENOMEM;
 	}
 


### PR DESCRIPTION
drivers: usb_dc_mcux_ehci: use K_NO_WAIT in k_heap_alloc()
