### PR TITLE
Bluetooth: Controller: Fix legacy advertising PDU length initialization

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -297,8 +297,12 @@ uint8_t ll_adv_params_set(uint16_t interval, uint8_t adv_type,
 	pdu = lll_adv_data_peek(&adv->lll);
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 	if (is_new_set) {
-		pdu->type = pdu_adv_type[adv_type];
 		is_pdu_type_changed = 1;
+
+		pdu->type = pdu_adv_type[adv_type];
+		if (pdu->type != PDU_ADV_TYPE_EXT_IND) {
+			pdu->len = 0U;
+		}
 	/* check if new PDU type is different that past one */
 	} else if (pdu->type != pdu_adv_type[adv_type]) {
 		is_pdu_type_changed = 1;


### PR DESCRIPTION
Fix missing initialization of legacy advertising PDU length
when advertising sets are reused between extended and legacy
advertising modes.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>