### PR TITLE
Bluetooth: Controller: Fix directed advertising report

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -5184,7 +5184,7 @@ no_ext_hdr:
 	adv_info = (void *)(((uint8_t *)sep) + sizeof(*sep));
 
 	/* Set directed advertising bit */
-	if ((evt_type == BT_HCI_LE_ADV_EVT_TYPE_CONN) && direct_addr) {
+	if (direct_addr) {
 		evt_type |= BT_HCI_LE_ADV_EVT_TYPE_DIRECT;
 	}
 


### PR DESCRIPTION
Fix extended advertising report to set the directed bit in
the event type when receiving directed non-connectable
advertising.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>