### PR TITLE
disk: Add support for MCUs with SDIO drivers.

### DIFF
--- a/drivers/disk/sdmmc_stm32.c
+++ b/drivers/disk/sdmmc_stm32.c
@@ -18,6 +18,10 @@
 
 LOG_MODULE_REGISTER(stm32_sdmmc, CONFIG_SDMMC_LOG_LEVEL);
 
+#ifndef MMC_TypeDef
+#define MMC_TypeDef SDMMC_TypeDef
+#endif
+
 struct stm32_sdmmc_priv {
 	SD_HandleTypeDef hsd;
 	int status;
@@ -402,7 +406,7 @@ static const struct soc_gpio_pinctrl sdmmc_pins_1[] =
 
 static struct stm32_sdmmc_priv stm32_sdmmc_priv_1 = {
 	.hsd = {
-		.Instance = (SDMMC_TypeDef *)DT_INST_REG_ADDR(0),
+		.Instance = (MMC_TypeDef *)DT_INST_REG_ADDR(0),
 	},
 #if DT_INST_NODE_HAS_PROP(0, cd_gpios)
 	.cd = {


### PR DESCRIPTION
The STM32F4 for example have a peripheral identical with the STMF7 for SD-card, but it is named SDIO instead of SDMMC . The STM32Cube have defines for all MCUs with SDIO/SDMMC that abstracts away this difference, and thus the same driver can be used on all MCUs with SD cards support.

The exception is the "stm32mp1xx" that then needs to have an explicit define in the driver.