### PR TITLE
Enable entropy stm32f2

### DIFF
--- a/boards/arm/nucleo_f207zg/doc/index.rst
+++ b/boards/arm/nucleo_f207zg/doc/index.rst
@@ -102,6 +102,8 @@ The Zephyr nucleo_207zg board configuration supports the following hardware feat
 +-------------+------------+-------------------------------------+
 | PWM         | on-chip    | PWM                                 |
 +-------------+------------+-------------------------------------+
+| RNG         | on-chip    | Random Number Generator             |
++-------------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr port.
 

--- a/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
+++ b/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
@@ -112,6 +112,10 @@
 	status = "okay";
 };
 
+&rng {
+	status = "okay";
+};
+
 &adc1 {
 	pinctrl-0 = <&adc1_in0_pa0>;
 	status = "okay";

--- a/boards/arm/nucleo_f207zg/nucleo_f207zg.yaml
+++ b/boards/arm/nucleo_f207zg/nucleo_f207zg.yaml
@@ -22,3 +22,4 @@ supported:
   - dac
   - backup_sram
   - pwm
+  - rng

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -14,6 +14,7 @@
 
 / {
 	chosen {
+		zephyr,entropy = &rng;
 		zephyr,flash-controller = &flash;
 	};
 
@@ -536,6 +537,15 @@
 				label = "PWM_12";
 				#pwm-cells = <3>;
 			};
+		};
+
+		rng: rng@50060800 {
+			compatible = "st,stm32-rng";
+			reg = <0x50060800 0x400>;
+			interrupts = <80 0>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00000040>;
+			status = "disabled";
+			label = "RNG";
 		};
 
 		backup_sram: memory@40024000 {


### PR DESCRIPTION
These commits enable entropy in nucleo_f207zg platform.
This has been tested with tests/drivers/entropy/api/ and is working as expected.

```
Running test suite entropy_api
===================================================================
START - test_entropy_get_entropy
random device is 0x8004d68, name is RNG
  0x60
  0xc5
  0xc5
  0x8a
  0xa2
  0x58
  0xbd
  0x79
  0x16
 PASS - test_entropy_get_entropy in 0.10 seconds
===================================================================
Test suite entropy_api succeeded
===================================================================
PROJECT EXECUTION SUCCESSFUL
 


    *** Booting Zephyr OS build zephyr-v2.6.0-760-g0ef77d4ea41f  ***
Running test suite entropy_api
===================================================================
START - test_entropy_get_entropy
random device is 0x8004d68, name is RNG
  0xcd
  0xf7
  0x31
  0x68
  0xac
  0x8d
  0x43
  0x5b
  0xc0
 PASS - test_entropy_get_entropy in 0.10 seconds
===================================================================
Test suite entropy_api succeeded
===================================================================
PROJECT EXECUTION SUCCESSFUL
```