### PR TITLE
logging: count file with index 0 as log file too

### DIFF
--- a/subsys/logging/log_backend_fs.c
+++ b/subsys/logging/log_backend_fs.c
@@ -239,7 +239,7 @@ static int get_log_file_id(struct fs_dirent *ent)
 
 	num = atoi(ent->name + LOG_PREFIX_LEN);
 
-	if (num <= MAX_FILE_NUMERAL && num > 0) {
+	if (num <= MAX_FILE_NUMERAL && num >= 0) {
 		return num;
 	}
 
@@ -277,7 +277,7 @@ static int allocate_new_file(struct fs_file_t *file)
 			}
 
 			file_num = get_log_file_id(&ent);
-			if (file_num > 0) {
+			if (file_num >= 0) {
 
 				if (file_num > max) {
 					max = file_num;


### PR DESCRIPTION
Fixes #36667

If you had a single log file with index 0 created and you reboot
the log backend wasn't counting it and was overwiting it.
If you filled that file up before rebooting then it worked as
expected, creating a new file at the next index on each boot.

Signed-off-by: Elliot Revell-Nash <elliot.revell-nash@wdtl.com>