### PR TITLE
Simplify arguments list of ull_adv_sync_pdu_alloc

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
@@ -75,17 +75,6 @@ enum ull_adv_pdu_extra_data_flag {
 #define ULL_ADV_PDU_HDR_FIELD_ACAD      BIT(8)
 #define ULL_ADV_PDU_HDR_FIELD_AD_DATA   BIT(9)
 
-/* Helper type to store data for extended advertising
- * header fields and extra data.
- */
-struct ull_adv_ext_hdr_data {
-	void *field_data;
-
-#if defined(CONFIG_BT_CTLR_ADV_EXT_PDU_EXTRA_DATA_MEMORY)
-	void *extra_data;
-#endif /* CONFIG_BT_CTLR_ADV_EXT_PDU_EXTRA_DATA_MEMORY */
-};
-
 /* helper function to handle adv done events */
 void ull_adv_done(struct node_rx_event_done *done);
 
@@ -189,12 +178,9 @@ uint8_t ull_adv_sync_pdu_alloc(struct ll_adv_set *adv,
 /* helper function to set/clear common extended header format fields
  * for AUX_SYNC_IND PDU.
  */
-uint8_t ull_adv_sync_pdu_set_clear(struct lll_adv_sync *lll_sync,
-				   struct pdu_adv *ter_pdu_prev,
-				   struct pdu_adv *ter_pdu,
-				   uint16_t hdr_add_fields,
-				   uint16_t hdr_rem_fields,
-				   struct ull_adv_ext_hdr_data *hdr_data);
+uint8_t ull_adv_sync_pdu_set_clear(struct lll_adv_sync *lll_sync, struct pdu_adv *ter_pdu_prev,
+				   struct pdu_adv *ter_pdu, uint16_t hdr_add_fields,
+				   uint16_t hdr_rem_fields, void *hdr_data);
 
 /* helper function to update extra_data field */
 void ull_adv_sync_extra_data_set_clear(void *extra_data_prev,

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
@@ -50,6 +50,18 @@ uint8_t ull_adv_time_update(struct ll_adv_set *adv, struct pdu_adv *pdu,
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 
+/* Enumeration provides flags for management of memory for extra_data
+ * related with advertising PDUs.
+ */
+enum ull_adv_pdu_extra_data_flag {
+	/* Allocate extra_data memory if it was available in former PDU */
+	ULL_ADV_PDU_EXTRA_DATA_ALLOC_IF_EXIST,
+	/* Allocate extra_data memory no matter if it was available */
+	ULL_ADV_PDU_EXTRA_DATA_ALLOC_ALWAYS,
+	/* Never allocate new memory for extra_data */
+	ULL_ADV_PDU_EXTRA_DATA_ALLOC_NEVER
+};
+
 /* Below are BT Spec v5.2, Vol 6, Part B Section 2.3.4 Table 2.12 defined */
 #define ULL_ADV_PDU_HDR_FIELD_ADVA      BIT(0)
 #define ULL_ADV_PDU_HDR_FIELD_TARGETA   BIT(1)
@@ -170,14 +182,9 @@ void ull_adv_sync_info_fill(struct ll_adv_sync_set *sync,
  * previous and new PDU for further processing.
  */
 uint8_t ull_adv_sync_pdu_alloc(struct ll_adv_set *adv,
-			       uint16_t hdr_add_fields,
-			       uint16_t hdr_rem_fields,
-			       struct ull_adv_ext_hdr_data *hdr_data,
-			       struct pdu_adv **ter_pdu_prev,
-			       struct pdu_adv **ter_pdu_new,
-			       void **extra_data_prev,
-			       void **extra_data_new,
-			       uint8_t *ter_idx);
+			       enum ull_adv_pdu_extra_data_flag extra_data_flags,
+			       struct pdu_adv **ter_pdu_prev, struct pdu_adv **ter_pdu_new,
+			       void **extra_data_prev, void **extra_data_new, uint8_t *ter_idx);
 
 /* helper function to set/clear common extended header format fields
  * for AUX_SYNC_IND PDU.

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -60,7 +60,6 @@ uint8_t ll_big_create(uint8_t big_handle, uint8_t adv_handle, uint8_t num_bis,
 {
 	uint8_t field_data[1 + sizeof(uint8_t *)];
 	struct ull_adv_ext_hdr_data hdr_data;
-	void *extra_data_prev, *extra_data;
 	struct lll_adv_sync *lll_adv_sync;
 	struct lll_adv_iso *lll_adv_iso;
 	struct pdu_adv *pdu_prev, *pdu;
@@ -140,7 +139,7 @@ uint8_t ll_big_create(uint8_t big_handle, uint8_t adv_handle, uint8_t num_bis,
 
 	/* Allocate next PDU */
 	err = ull_adv_sync_pdu_alloc(adv, ULL_ADV_PDU_EXTRA_DATA_ALLOC_IF_EXIST, &pdu_prev, &pdu,
-				     &extra_data_prev, &extra_data, &ter_idx);
+				     NULL, NULL, &ter_idx);
 	if (err) {
 		return err;
 	}
@@ -227,7 +226,6 @@ uint8_t ll_big_test_create(uint8_t big_handle, uint8_t adv_handle,
 
 uint8_t ll_big_terminate(uint8_t big_handle, uint8_t reason)
 {
-	void *extra_data_prev, *extra_data;
 	struct lll_adv_sync *lll_adv_sync;
 	struct lll_adv_iso *lll_adv_iso;
 	struct pdu_adv *pdu_prev, *pdu;
@@ -255,7 +253,7 @@ uint8_t ll_big_terminate(uint8_t big_handle, uint8_t reason)
 
 	/* Allocate next PDU */
 	err = ull_adv_sync_pdu_alloc(adv, ULL_ADV_PDU_EXTRA_DATA_ALLOC_IF_EXIST, &pdu_prev, &pdu,
-				     &extra_data_prev, &extra_data, &ter_idx);
+				     NULL, NULL, &ter_idx);
 	if (err) {
 		return err;
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -58,8 +58,7 @@ uint8_t ll_big_create(uint8_t big_handle, uint8_t adv_handle, uint8_t num_bis,
 		      uint8_t packing, uint8_t framing, uint8_t encryption,
 		      uint8_t *bcode)
 {
-	uint8_t field_data[1 + sizeof(uint8_t *)];
-	struct ull_adv_ext_hdr_data hdr_data;
+	uint8_t hdr_data[1 + sizeof(uint8_t *)];
 	struct lll_adv_sync *lll_adv_sync;
 	struct lll_adv_iso *lll_adv_iso;
 	struct pdu_adv *pdu_prev, *pdu;
@@ -145,16 +144,14 @@ uint8_t ll_big_create(uint8_t big_handle, uint8_t adv_handle, uint8_t num_bis,
 	}
 
 	/* Add ACAD to AUX_SYNC_IND */
-	hdr_data.field_data = field_data;
-	field_data[0] = sizeof(struct pdu_big_info) + 2;
-	err = ull_adv_sync_pdu_set_clear(lll_adv_sync, pdu_prev, pdu,
-					 ULL_ADV_PDU_HDR_FIELD_ACAD, 0U,
-					 &hdr_data);
+	hdr_data[0] = sizeof(struct pdu_big_info) + 2;
+	err = ull_adv_sync_pdu_set_clear(lll_adv_sync, pdu_prev, pdu, ULL_ADV_PDU_HDR_FIELD_ACAD,
+					 0U, hdr_data);
 	if (err) {
 		return err;
 	}
 
-	memcpy(&acad, &field_data[1], sizeof(acad));
+	memcpy(&acad, &hdr_data[1], sizeof(acad));
 	acad[0] = sizeof(struct pdu_big_info) + 1;
 	acad[1] = BT_DATA_BIG_INFO;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -139,7 +139,7 @@ uint8_t ll_big_create(uint8_t big_handle, uint8_t adv_handle, uint8_t num_bis,
 	}
 
 	/* Allocate next PDU */
-	err = ull_adv_sync_pdu_alloc(adv, 0, 0, NULL, &pdu_prev, &pdu,
+	err = ull_adv_sync_pdu_alloc(adv, ULL_ADV_PDU_EXTRA_DATA_ALLOC_IF_EXIST, &pdu_prev, &pdu,
 				     &extra_data_prev, &extra_data, &ter_idx);
 	if (err) {
 		return err;
@@ -254,7 +254,7 @@ uint8_t ll_big_terminate(uint8_t big_handle, uint8_t reason)
 	adv = HDR_LLL2ULL(lll_adv);
 
 	/* Allocate next PDU */
-	err = ull_adv_sync_pdu_alloc(adv, 0, 0, NULL, &pdu_prev, &pdu,
+	err = ull_adv_sync_pdu_alloc(adv, ULL_ADV_PDU_EXTRA_DATA_ALLOC_IF_EXIST, &pdu_prev, &pdu,
 				     &extra_data_prev, &extra_data, &ter_idx);
 	if (err) {
 		return err;

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -382,7 +382,7 @@ uint8_t ll_adv_sync_param_set(uint8_t handle, uint16_t interval, uint16_t flags)
 
 	sync->interval = interval;
 
-	err = ull_adv_sync_pdu_alloc(adv, 0, 0, NULL, &pdu_prev, &pdu,
+	err = ull_adv_sync_pdu_alloc(adv, ULL_ADV_PDU_EXTRA_DATA_ALLOC_IF_EXIST, &pdu_prev, &pdu,
 				     &extra_data_prev, &extra_data, &ter_idx);
 	if (err) {
 		return err;
@@ -439,8 +439,7 @@ uint8_t ll_adv_sync_ad_data_set(uint8_t handle, uint8_t op, uint8_t len,
 	field_data[0] = len;
 	memcpy(&field_data[1], &data, sizeof(data));
 
-	err = ull_adv_sync_pdu_alloc(adv, ULL_ADV_PDU_HDR_FIELD_AD_DATA, 0,
-				     &hdr_data, &pdu_prev, &pdu,
+	err = ull_adv_sync_pdu_alloc(adv, ULL_ADV_PDU_EXTRA_DATA_ALLOC_IF_EXIST, &pdu_prev, &pdu,
 				     &extra_data_prev, &extra_data, &ter_idx);
 	if (err) {
 		return err;
@@ -798,14 +797,9 @@ void ull_adv_sync_offset_get(struct ll_adv_set *adv)
 }
 
 uint8_t ull_adv_sync_pdu_alloc(struct ll_adv_set *adv,
-			       uint16_t hdr_add_fields,
-			       uint16_t hdr_rem_fields,
-			       struct ull_adv_ext_hdr_data *hdr_data,
-			       struct pdu_adv **ter_pdu_prev,
-			       struct pdu_adv **ter_pdu_new,
-			       void **extra_data_prev,
-			       void **extra_data_new,
-			       uint8_t *ter_idx)
+			       enum ull_adv_pdu_extra_data_flag extra_data_flag,
+			       struct pdu_adv **ter_pdu_prev, struct pdu_adv **ter_pdu_new,
+			       void **extra_data_prev, void **extra_data_new, uint8_t *ter_idx)
 {
 	struct pdu_adv *pdu_prev, *pdu_new;
 	struct lll_adv_sync *lll_sync;
@@ -824,9 +818,8 @@ uint8_t ull_adv_sync_pdu_alloc(struct ll_adv_set *adv,
 
 #if defined(CONFIG_BT_CTLR_DF_ADV_CTE_TX)
 	/* Get reference to new periodic advertising PDU data buffer */
-	if ((hdr_add_fields & ULL_ADV_PDU_HDR_FIELD_CTE_INFO) ||
-	    (!(hdr_rem_fields & ULL_ADV_PDU_HDR_FIELD_CTE_INFO) &&
-	     ed_prev)) {
+	if (extra_data_flag == ULL_ADV_PDU_EXTRA_DATA_ALLOC_ALWAYS ||
+	    (extra_data_flag == ULL_ADV_PDU_EXTRA_DATA_ALLOC_IF_EXIST && ed_prev)) {
 		/* If there was an extra data in past PDU data or it is required
 		 * by the hdr_add_fields then allocate memmory for it.
 		 */

--- a/subsys/bluetooth/controller/ll_sw/ull_df.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_df.c
@@ -297,11 +297,8 @@ uint8_t ll_df_set_cl_cte_tx_enable(uint8_t adv_handle, uint8_t cte_enable)
 			return BT_HCI_ERR_CMD_DISALLOWED;
 		}
 
-		err = ull_adv_sync_pdu_alloc(adv, 0,
-					     ULL_ADV_PDU_HDR_FIELD_CTE_INFO,
-					     NULL, &pdu_prev, &pdu,
-					     &extra_data_prev, &extra_data,
-					     &ter_idx);
+		err = ull_adv_sync_pdu_alloc(adv, ULL_ADV_PDU_EXTRA_DATA_ALLOC_NEVER, &pdu_prev,
+					     &pdu, &extra_data_prev, &extra_data, &ter_idx);
 		if (err) {
 			return err;
 		}
@@ -334,9 +331,8 @@ uint8_t ll_df_set_cl_cte_tx_enable(uint8_t adv_handle, uint8_t cte_enable)
 		hdr_data.field_data = (uint8_t *)&cte_info;
 		hdr_data.extra_data = df_cfg;
 
-		err = ull_adv_sync_pdu_alloc(adv, ULL_ADV_PDU_HDR_FIELD_CTE_INFO, 0, NULL,
-					     &pdu_prev, &pdu, &extra_data_prev, &extra_data,
-					     &ter_idx);
+		err = ull_adv_sync_pdu_alloc(adv, ULL_ADV_PDU_EXTRA_DATA_ALLOC_ALWAYS, &pdu_prev,
+					     &pdu, &extra_data_prev, &extra_data, &ter_idx);
 		if (err) {
 			return err;
 		}

--- a/subsys/bluetooth/controller/ll_sw/ull_df.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_df.c
@@ -320,7 +320,7 @@ uint8_t ll_df_set_cl_cte_tx_enable(uint8_t adv_handle, uint8_t cte_enable)
 		df_cfg->is_enabled = 0U;
 	} else {
 		struct pdu_cte_info cte_info;
-		struct ull_adv_ext_hdr_data hdr_data;
+		void *hdr_data;
 
 		if (df_cfg->is_enabled) {
 			return BT_HCI_ERR_CMD_DISALLOWED;
@@ -328,8 +328,7 @@ uint8_t ll_df_set_cl_cte_tx_enable(uint8_t adv_handle, uint8_t cte_enable)
 
 		cte_info.type = df_cfg->cte_type;
 		cte_info.time = df_cfg->cte_length;
-		hdr_data.field_data = (uint8_t *)&cte_info;
-		hdr_data.extra_data = df_cfg;
+		hdr_data = (uint8_t *)&cte_info;
 
 		err = ull_adv_sync_pdu_alloc(adv, ULL_ADV_PDU_EXTRA_DATA_ALLOC_ALWAYS, &pdu_prev,
 					     &pdu, &extra_data_prev, &extra_data, &ter_idx);
@@ -340,12 +339,11 @@ uint8_t ll_df_set_cl_cte_tx_enable(uint8_t adv_handle, uint8_t cte_enable)
 		if (extra_data) {
 			ull_adv_sync_extra_data_set_clear(extra_data_prev, extra_data,
 							  ULL_ADV_PDU_HDR_FIELD_CTE_INFO, 0,
-							  &df_cfg);
+							  df_cfg);
 		}
 
 		err = ull_adv_sync_pdu_set_clear(lll_sync, pdu_prev, pdu,
-						 ULL_ADV_PDU_HDR_FIELD_CTE_INFO,
-						 0, &hdr_data);
+						 ULL_ADV_PDU_HDR_FIELD_CTE_INFO, 0, hdr_data);
 		if (err) {
 			return err;
 		}


### PR DESCRIPTION
The PR provides enhancement to use of ull_adv_sync_pdu_alloc.

The function had:
- Arguments that were related with updating of extended advertising PDU header. The arguments were actually used to manage allocation of `extra_data` memory.
- Unused argument `hdr_data`.