### PR TITLE
net: openthread: handle NONE level logs

### DIFF
--- a/subsys/net/lib/openthread/platform/logging.c
+++ b/subsys/net/lib/openthread/platform/logging.c
@@ -22,6 +22,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 static inline int log_translate(otLogLevel aLogLevel)
 {
 	switch (aLogLevel) {
+	case OT_LOG_LEVEL_NONE:
 	case OT_LOG_LEVEL_CRIT:
 		return LOG_LEVEL_ERR;
 	case OT_LOG_LEVEL_WARN:


### PR DESCRIPTION
`OT_LOG_LEVEL_NONE` has some uses within OpenThread but it is not
hanled in the Zephyr's platform implementation. This commit makes
use of those logs as `LOG_LEVEL_ERR` level.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>