### PR TITLE
Bluetooth: controller: df: Fixes truncated transmission of CTE

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_df.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_df.c
@@ -345,20 +345,17 @@ uint8_t ll_df_set_cl_cte_tx_enable(uint8_t adv_handle, uint8_t cte_enable)
 		hdr_data.field_data = (uint8_t *)&cte_info;
 		hdr_data.extra_data = df_cfg;
 
-		err = ull_adv_sync_pdu_alloc(adv, 0,
-					     ULL_ADV_PDU_HDR_FIELD_CTE_INFO,
-					     NULL, &pdu_prev, &pdu,
-					     &extra_data_prev, &extra_data,
+		err = ull_adv_sync_pdu_alloc(adv, ULL_ADV_PDU_HDR_FIELD_CTE_INFO, 0, NULL,
+					     &pdu_prev, &pdu, &extra_data_prev, &extra_data,
 					     &ter_idx);
 		if (err) {
 			return err;
 		}
 
 		if (extra_data) {
-			ull_adv_sync_extra_data_set_clear(extra_data_prev,
-							  extra_data,
-							  ULL_ADV_PDU_HDR_FIELD_CTE_INFO,
-							  0, &hdr_data);
+			ull_adv_sync_extra_data_set_clear(extra_data_prev, extra_data,
+							  ULL_ADV_PDU_HDR_FIELD_CTE_INFO, 0,
+							  &df_cfg);
 		}
 
 		err = ull_adv_sync_pdu_set_clear(lll_sync, pdu_prev, pdu,


### PR DESCRIPTION
Fixes #36959

There was an issue with wrong length of CTE send in connectionless
mode, with periodic advertising PDUs. Radio peripheral was not
configured to send CTE with correct length while PDU had CTEInfo
field informing receiver that CTE is attached to the PDU.

Source of the problem was in ll_df_set_cl_cte_tx_enable function.

Order of parameters in ull_adv_sync_pdu_alloc was wrong.
ULL_ADV_PDU_HDR_FIELD_CTE_INFO was speficed as hdr_rem_fields.
Because of that extra_data, memory used to provide CTE configuration
to LLL, was not allocated. PDU content is prepared in ULL, so CTEInfo
field included correct information, while Radio was never configured
by LLL to send CTE.

ull_adv_sync_extra_data_set_clear received a pointer to hdr_data,
instead of a direct pointer to df_cfg structure. When extra_data
was allocated correclty, wrong CTE configuration was provided
copied there and LLL received invalid CTE length. It was different
than the length in PDUs CTEInfo field.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>

