### PR TITLE
net: openthread: add Kconfig options for periodic parent search

### DIFF
--- a/subsys/net/l2/openthread/Kconfig.thread
+++ b/subsys/net/l2/openthread/Kconfig.thread
@@ -99,3 +99,33 @@ config OPENTHREAD_CSL_MIN_RECEIVE_ON
 config OPENTHREAD_MAC_SOFTWARE_TX_SECURITY_ENABLE
 	bool "Enable software transmission security logic"
 	default y if OPENTHREAD_THREAD_VERSION_1_2
+
+config OPENTHREAD_MLE_INFORM_PREVIOUS_PARENT_ON_REATTACH
+	bool "Inform previous parent on reattach"
+	default y if OPENTHREAD_PARENT_SEARCH
+	help
+	  To allow end devices (EDs) in a Thread network to inform their
+	  previous parent router that they have attached to a new parent
+	  router, enable the Inform Previous Parent on Reattach feature.
+
+config OPENTHREAD_PARENT_SEARCH
+	bool "Enable periodic parent search support"
+	help
+	  To allow end devices (EDs) in a Thread network to switch to a
+	  better parent router than their current one—while still attached
+	  to the network—enable the Periodic Parent Search feature.
+
+config OPENTHREAD_PARENT_SEARCH_CHECK_INTERVAL
+	int "Interval to trigger parent search in seconds"
+	default 540
+	depends on OPENTHREAD_PARENT_SEARCH
+
+config OPENTHREAD_PARENT_SEARCH_BACKOFF_INTERVAL
+	int "Backoff interval to prevent parent search retry in seconds"
+	default 36000
+	depends on OPENTHREAD_PARENT_SEARCH
+
+config OPENTHREAD_PARENT_SEARCH_RSS_THRESHOLD
+	int "RSSI threshold to trigger parent search"
+	default -65
+	depends on OPENTHREAD_PARENT_SEARCH

--- a/subsys/net/lib/openthread/platform/openthread-core-zephyr-config.h
+++ b/subsys/net/lib/openthread/platform/openthread-core-zephyr-config.h
@@ -102,6 +102,55 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_MLE_INFORM_PREVIOUS_PARENT_ON_REATTACH
+ *
+ * Define as 1 for a child to inform its previous parent when it attaches to a new parent.
+ *
+ */
+#ifdef CONFIG_OPENTHREAD_MLE_INFORM_PREVIOUS_PARENT_ON_REATTACH
+#define OPENTHREAD_CONFIG_MLE_INFORM_PREVIOUS_PARENT_ON_REATTACH 1
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_PARENT_SEARCH_ENABLE
+ *
+ * Define as 1 to enable periodic parent search feature.
+ *
+ */
+#ifdef CONFIG_OPENTHREAD_PARENT_SEARCH
+#define OPENTHREAD_CONFIG_PARENT_SEARCH_ENABLE 1
+
+/**
+ * @def OPENTHREAD_CONFIG_PARENT_SEARCH_CHECK_INTERVAL
+ *
+ * Specifies the interval in seconds for a child to check the trigger condition
+ * to perform a parent search.
+ *
+ */
+#define OPENTHREAD_CONFIG_PARENT_SEARCH_CHECK_INTERVAL                         \
+	CONFIG_OPENTHREAD_PARENT_SEARCH_CHECK_INTERVAL
+
+/**
+ * @def OPENTHREAD_CONFIG_PARENT_SEARCH_BACKOFF_INTERVAL
+ *
+ * Specifies the backoff interval in seconds for a child to not perform a parent
+ * search after triggering one.
+ *
+ */
+#define OPENTHREAD_CONFIG_PARENT_SEARCH_BACKOFF_INTERVAL                       \
+	CONFIG_OPENTHREAD_PARENT_SEARCH_BACKOFF_INTERVAL
+
+/**
+ * @def OPENTHREAD_CONFIG_PARENT_SEARCH_RSS_THRESHOLD
+ *
+ * Specifies the RSS threshold used to trigger a parent search.
+ *
+ */
+#define OPENTHREAD_CONFIG_PARENT_SEARCH_RSS_THRESHOLD                          \
+	CONFIG_OPENTHREAD_PARENT_SEARCH_RSS_THRESHOLD
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_MAC_SOFTWARE_TX_TIMING_ENABLE
  *
  * Define to 1 to enable software transmission target time logic.


### PR DESCRIPTION
The openthread has enhanced features for periodic parent search, this commit adds kconfig options to enable and configure these.