### PR TITLE
west.yml: Build imxrt6xx drivers in the nxp hal library

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -68,7 +68,7 @@ manifest:
       revision: b4d31f33238713a568e23618845702fadd67386f
       path: modules/hal/nuvoton
     - name: hal_nxp
-      revision: ac1ad8d44a407f8f1fe813e983bda085e9ef342a
+      revision: 9a52c50338dcec8ab938f91f62e829898e298d14
       path: modules/hal/nxp
     - name: hal_openisa
       revision: 40d049f69c50b58ea20473bee14cf93f518bf262


### PR DESCRIPTION
Make the imxrt6xx drivers consistent with the other SoC family drivers
by building them in the nxp hal library. Similar to commit
cf0587c3ec6f967568c3788208e35af29e2dd266, this stops leaking long source
paths in build directories and makes them deterministic.

When building samples/hello_world for mimxrt685_evk_cm33, this changes
the build directories from:
```
build/
└── zephyr
└── CMakeFiles
    └── zephyr.dir
	└── home
	    └── maureen
		└── zephyrproject
		    └── modules
			└── hal
			    └── nxp
				└── mcux
				    └── drivers
					└── imxrt6xx
					    ├── fsl_cache.c.obj
					    ├── fsl_common.c.obj
					    ├── fsl_flexcomm.c.obj
					    ├── fsl_gpio.c.obj
					    ├── fsl_inputmux.c.obj
					    ├── fsl_ostimer.c.obj
					    ├── fsl_pint.c.obj
					    └── fsl_usart.c.obj

to:

build/
└── modules
└── nxp
    └── lib..__modules__hal__nxp.a
```
Signed-off-by: Maureen Helm <maureen.helm@nxp.com>