### PR TITLE
net: introduce net_pkt_remove_tail() and fix CRC16 removal from PPP frames

### DIFF
--- a/drivers/net/ppp.c
+++ b/drivers/net/ppp.c
@@ -416,8 +416,8 @@ static void ppp_process_msg(struct ppp_driver_context *ppp)
 #endif
 			net_pkt_unref(ppp->pkt);
 		} else {
-			/* Skip FCS bytes (2) */
-			net_buf_frag_last(ppp->pkt->buffer)->len -= 2;
+			/* Remove FCS bytes (2) */
+			net_pkt_remove_tail(ppp->pkt, 2);
 
 			/* Make sure we now start reading from PPP header in
 			 * PPP L2 recv()

--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -1706,6 +1706,22 @@ size_t net_pkt_available_payload_buffer(struct net_pkt *pkt,
 void net_pkt_trim_buffer(struct net_pkt *pkt);
 
 /**
+ * @brief Remove @a length bytes from tail of packet
+ *
+ * @details This function does not take packet cursor into account. It is a
+ *          helper to remove unneeded bytes from tail of packet (like appended
+ *          CRC). It takes care of buffer deallocation if removed bytes span
+ *          whole buffer(s).
+ *
+ * @param pkt    Network packet
+ * @param length Number of bytes to be removed
+ *
+ * @retval 0       On success.
+ * @retval -EINVAL If packet length is shorter than @a length.
+ */
+int net_pkt_remove_tail(struct net_pkt *pkt, size_t length);
+
+/**
  * @brief Initialize net_pkt cursor
  *
  * @details This will initialize the net_pkt cursor from its buffer.


### PR DESCRIPTION
Introduce a helper function for being able to remove any arbitrary
length from tail of packet. This is handy in cases when removing
unneeded data, like CRC once it was verified.

CRC16 was removed by simply decreasing length of the last fragment by 2.
This worked as long as last fragment was longer than 1 byte. If not,
then last fragment was corrupted (its length ended up being 65535),
leading to undefined behavior.

Fix CRC16 removal by utilizing recently introduced
net_pkt_remove_tail(), that properly handles multiple fragments.

This is alternative solution to #33255, that came up during review.