### PR TITLE
doc: application specific devicetree overlay file described, app.overlay

### DIFF
--- a/doc/guides/dts/howtos.rst
+++ b/doc/guides/dts/howtos.rst
@@ -219,6 +219,7 @@ Here are some ways to set it:
 #. create a ``boards/<BOARD>.overlay`` file in the application
    folder, for the current board
 #. create a ``<BOARD>.overlay`` file in the application folder
+#. create an ``app.overlay`` file in the application folder
 
 Here is an example :ref:`using west build <west-building-dtc-overlay-file>`.
 However you set the value, it is saved in the CMake cache between builds.


### PR DESCRIPTION
Follow-up: #16817, commit af968c26942feef3628fc05293c1cb3584e719a4

The referred commit introduced app.overlay as a general application
devicetree overlay if no specific board overlay is found.

This commit document this behavior in the devicetree howto.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>