### PR TITLE
drivers/sensor: lis2mdl: Fix errors when CONFIG_PM_DEVICE=y

### DIFF
--- a/drivers/sensor/lis2mdl/lis2mdl.c
+++ b/drivers/sensor/lis2mdl/lis2mdl.c
@@ -450,8 +450,7 @@ static int lis2mdl_set_power_state(struct lis2mdl_data *lis2mdl,
 		const struct lis2mdl_config *const config,
 		enum pm_device_state new_state)
 {
-	const struct lis2mdl_config *cfg = dev->config;
-	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
+	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&config->ctx;
 	int status = 0;
 
 	if (new_state == PM_DEVICE_STATE_ACTIVE) {
@@ -523,7 +522,7 @@ static int lis2mdl_pm_control(const struct device *dev, uint32_t ctrl_command,
 #define LIS2MDL_DEVICE_INIT(inst)					\
 	DEVICE_DT_INST_DEFINE(inst,					\
 			    lis2mdl_init,				\
-			    NULL,					\
+			    lis2mdl_pm_control,				\
 			    &lis2mdl_data_##inst,			\
 			    &lis2mdl_config_##inst,			\
 			    POST_KERNEL,				\


### PR DESCRIPTION
Fix a couple of issues related to Power Management:

    1. A build error because 'dev' was used even if not declared
       in the caller routine scope
    2. The lis2mdl power management init specific routine was
       not declared in in the device instance definition
