### PR TITLE
doc: extensions: doxyrunner: fix HTML output handling

### DIFF
--- a/doc/_extensions/zephyr/doxyrunner.py
+++ b/doc/_extensions/zephyr/doxyrunner.py
@@ -293,7 +293,7 @@ def sync_doxygen(doxyfile: str, new: Path, prev: Path) -> None:
     """
 
     generate_html = get_doxygen_option(doxyfile, "GENERATE_HTML")
-    if generate_html == "YES":
+    if generate_html[0] == "YES":
         html_output = get_doxygen_option(doxyfile, "HTML_OUTPUT")
         if not html_output:
             raise ValueError("No HTML_OUTPUT set in Doxyfile")


### PR DESCRIPTION
The extension was not evaluating the GENERATE_HTML option correctly. The
get_doxygen_option returns a `List[str]`, not a `str`.

This effectively means that the Zephyr apidoc has not been updated for a
while as the extension was not moving the output to the final
destination folder.