### PR TITLE
west.yml: add project groups

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -34,72 +34,118 @@ manifest:
     - name: cmsis
       revision: c3bd2094f92d574377f7af2aec147ae181aa5f8e
       path: modules/hal/cmsis
+      groups:
+        - hal
     - name: edtt
       revision: 7dd56fc100d79cc45c33d43e7401d1803e26f6e7
       path: tools/edtt
+      groups:
+        - tools
     - name: fatfs
       revision: 1d1fcc725aa1cb3c32f366e0c53d7490d0fe1109
       path: modules/fs/fatfs
+      groups:
+        - fs
     - name: hal_altera
       revision: 23c1c1dd7a0c1cc9a399509d1819375847c95b97
       path: modules/hal/altera
+      groups:
+        - hal
     - name: hal_atmel
       revision: d17b7dd92d209b20bc1e15431d068edc29bf438d
       path: modules/hal/atmel
+      groups:
+        - hal
     - name: hal_cypress
       revision: 81a059f21435bc7e315bccd720da5a9b615bbb50
       path: modules/hal/cypress
+      groups:
+        - hal
     - name: hal_espressif
       revision: f525ee6f468c2c68119731e1453ad72d189a1277
       path: modules/hal/espressif
+      groups:
+        - hal
       west-commands: west/west-commands.yml
       revision: c21d252a2188fcb60d52dceb6b018a9f4a371817
       path: modules/hal/espressif
+      groups:
+        - hal
     - name: hal_infineon
       revision: f1fa8241f8786198ba41155413243de36ed878a5
       path: modules/hal/infineon
+      groups:
+        - hal
     - name: hal_microchip
       revision: b280eec5d3b1296b231117c1999bcd0269b6ecc4
       path: modules/hal/microchip
+      groups:
+        - hal
     - name: hal_nordic
       revision: d979c8dc313e4dc3e52d5606c28622e5278be50c
       path: modules/hal/nordic
+      groups:
+        - hal
     - name: hal_nuvoton
       revision: b4d31f33238713a568e23618845702fadd67386f
       path: modules/hal/nuvoton
+      groups:
+        - hal
     - name: hal_nxp
       revision: 4b493d4346e841e786a8daa2eb2ee03cbe5cfd37
       path: modules/hal/nxp
+      groups:
+        - hal
     - name: hal_openisa
       revision: 40d049f69c50b58ea20473bee14cf93f518bf262
       path: modules/hal/openisa
+      groups:
+        - hal
     - name: hal_quicklogic
       revision: b3a66fe6d04d87fd1533a5c8de51d0599fcd08d0
       path: modules/hal/quicklogic
       repo-path: hal_quicklogic
+      groups:
+        - hal
     - name: hal_silabs
       revision: be39d4eebeddac6e18e9c0c3ba1b31ad1e82eaed
       path: modules/hal/silabs
+      groups:
+        - hal
     - name: hal_st
       revision: 575de9d461aa6f430cf62c58a053675377e700f3
       path: modules/hal/st
+      groups:
+        - hal
     - name: hal_stm32
       revision: 2016f613f8138b8abe42013ab983a0d2fe0459b9
       path: modules/hal/stm32
+      groups:
+        - hal
     - name: hal_telink
       revision: ffcfd6282aa213f1dc0848dbca6279b098f6b143
       path: modules/hal/telink
+      groups:
+        - hal
     - name: hal_ti
       revision: 3da6fae25fc44ec830fac4a92787b585ff55435e
       path: modules/hal/ti
+      groups:
+        - hal
     - name: hal_xtensa
       revision: 2f04b615cd5ad3a1b8abef33f9bdd10cc1990ed6
       path: modules/hal/xtensa
+      groups:
+        - hal
     - name: libmetal
       revision: 39d049d4ae68e6f6d595fce7de1dcfc1024fb4eb
       path: modules/hal/libmetal
+      groups:
+        - hal
     - name: littlefs
       path: modules/fs/littlefs
+      groups:
+        - fs
       revision: 9e4498d1c73009acd84bb36036ee5e2869112a6c
     - name: loramac-node
       revision: 12019623bbad9eb54fe51066847a7cbd4b4eac57
@@ -113,6 +159,8 @@ manifest:
     - name: mbedtls
       revision: 5765cb7f75a9973ae9232d438e361a9d7bbc49e7
       path: modules/crypto/mbedtls
+      groups:
+        - crypto
     - name: mcuboot
       revision: 7a5196820ba48a6ad7e7d573c9048c021960677c
       path: bootloader/mcuboot
@@ -121,6 +169,8 @@ manifest:
       path: modules/lib/mcumgr
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t
+      groups:
+        - debug
       revision: 75e671550ac1acb502f315fe4952514dc73f7bfb
     - name: nanopb
       revision: d148bd26718e4c10414f07a7eb1bd24c62e56c5d
@@ -128,6 +178,8 @@ manifest:
     - name: net-tools
       revision: f49bd1354616fae4093bf36e5eaee43c51a55127
       path: tools/net-tools
+      groups:
+        - tools
     - name: nrf_hw_models
       revision: a47e326ca772ddd14cc3b9d4ca30a9ab44ecca16
       path: modules/bsim_hw_models/nrf_hw_models
@@ -140,6 +192,8 @@ manifest:
     - name: segger
       revision: 3a52ab222133193802d3c3b4d21730b9b1f1d2f6
       path: modules/debug/segger
+      groups:
+        - debug
     - name: sof
       revision: 779f28ed465c03899c8a7d4aaf399856f4e51158
       path: modules/audio/sof
@@ -150,6 +204,8 @@ manifest:
     - name: tfm-mcuboot # This is used by the trusted-firmware-m module.
       revision: v1.7.2
       path: modules/tee/tfm-mcuboot
+      groups:
+        - tee
       repo-path: mcuboot
     - name: tinycbor
       revision: 40daca97b478989884bffb5226e9ab73ca54b8c4
@@ -157,12 +213,18 @@ manifest:
     - name: tinycrypt
       revision: 3e9a49d2672ec01435ffbf0d788db6d95ef28de0
       path: modules/crypto/tinycrypt
+      groups:
+        - crypto
     - name: TraceRecorderSource
       revision: 5b5f8d7adbf0e93a09087e8f5708f0eebb8b25bf
       path: modules/debug/TraceRecorder
+      groups:
+        - debug
     - name: trusted-firmware-m
       path: modules/tee/tfm
       revision: e18b7a9b040b5b5324520388047c9e7d678447e6
+      groups:
+        - tee
 
   self:
     path: zephyr


### PR DESCRIPTION
Add project groups for enabling/disabling projects with group-filter.

Example usage:
west init -m https://github.com/zephyrproject-rtos/zephyr.git --mr main
west update --group-filter=-hal -o=--depth=1 -n

Fixes issue #36324.

Signed-off-by: Artem Panfilov <artemp@synopsys.com>