### PR TITLE
[RFC] drivers: spi_ll_stm32: initialize all cs gpios during init

### DIFF
--- a/drivers/spi/spi_ll_stm32.h
+++ b/drivers/spi/spi_ll_stm32.h
@@ -19,6 +19,8 @@ struct spi_stm32_config {
 #ifdef CONFIG_SPI_STM32_INTERRUPT
 	irq_config_func_t irq_config;
 #endif
+	const struct gpio_dt_spec *cs_gpios;
+	size_t num_cs_gpios;
 };
 
 #ifdef CONFIG_SPI_STM32_DMA


### PR DESCRIPTION
In case when we have multiple devices connected to the one SPI interface the initial state of CS gpios after MCU reset is floating and it might be low that prevents us from communicating between particular devices. Fix that by initializing all provided cs gpios and setting them as inactive.