### PR TITLE
boards: doc: Improve readability of debug sections for frdm-k64f and mimxrt685-evk

### DIFF
--- a/boards/arm/frdm_k64f/doc/index.rst
+++ b/boards/arm/frdm_k64f/doc/index.rst
@@ -223,40 +223,40 @@ Early versions of this board have an outdated version of the OpenSDA bootloader
 and require an update. Please see the `DAPLink Bootloader Update`_ page for
 instructions to update from the CMSIS-DAP bootloader to the DAPLink bootloader.
 
-Option 1: :ref:`opensda-daplink-onboard-debug-probe` (Recommended)
-------------------------------------------------------------------
+.. tabs::
 
-Install the :ref:`pyocd-debug-host-tools` and make sure they are in your search
-path.
+   .. group-tab:: OpenSDA DAPLink Onboard (Recommended)
 
-Follow the instructions in :ref:`opensda-daplink-onboard-debug-probe` to program
-the `OpenSDA DAPLink FRDM-K64F Firmware`_.
+        Install the :ref:`pyocd-debug-host-tools` and make sure they are in your search
+        path.
 
-Option 2: :ref:`opensda-jlink-onboard-debug-probe`
---------------------------------------------------
+        Follow the instructions in :ref:`opensda-daplink-onboard-debug-probe` to program
+        the `OpenSDA DAPLink FRDM-K64F Firmware`_.
 
-Install the :ref:`jlink-debug-host-tools` and make sure they are in your search
-path.
+   .. group-tab:: OpenSDA JLink Onboard
 
-The version of J-Link firmware to program to the board depends on the version
-of the DAPLink bootloader. Refer to `OpenSDA Serial and Debug Adapter`_ for
-more details. On this page, change the pull-down menu for "Choose your board to
-start" to FRDM-K64F, and review the section "To update your board with OpenSDA
-applications". Note that Segger does provide an OpenSDA J-Link Board-Specific
-Firmware for this board, however it is not compatible with the DAPLink
-bootloader. After downloading the appropriate J-Link firmware, follow the
-instructions in :ref:`opensda-jlink-onboard-debug-probe` to program to the
-board.
+        Install the :ref:`jlink-debug-host-tools` and make sure they are in your search
+        path.
 
-Add the arguments ``-DBOARD_FLASH_RUNNER=jlink`` and
-``-DBOARD_DEBUG_RUNNER=jlink`` when you invoke ``west build`` to override the
-default runner from pyOCD to J-Link:
+        The version of J-Link firmware to program to the board depends on the version
+        of the DAPLink bootloader. Refer to `OpenSDA Serial and Debug Adapter`_ for
+        more details. On this page, change the pull-down menu for "Choose your board to
+        start" to FRDM-K64F, and review the section "To update your board with OpenSDA
+        applications". Note that Segger does provide an OpenSDA J-Link Board-Specific
+        Firmware for this board, however it is not compatible with the DAPLink
+        bootloader. After downloading the appropriate J-Link firmware, follow the
+        instructions in :ref:`opensda-jlink-onboard-debug-probe` to program to the
+        board.
 
-.. zephyr-app-commands::
-   :zephyr-app: samples/hello_world
-   :board: frdm_k64f
-   :gen-args: -DBOARD_FLASH_RUNNER=jlink -DBOARD_DEBUG_RUNNER=jlink
-   :goals: build
+        Add the arguments ``-DBOARD_FLASH_RUNNER=jlink`` and
+        ``-DBOARD_DEBUG_RUNNER=jlink`` when you invoke ``west build`` to override the
+        default runner from pyOCD to J-Link:
+
+        .. zephyr-app-commands::
+           :zephyr-app: samples/hello_world
+           :board: frdm_k64f
+           :gen-args: -DBOARD_FLASH_RUNNER=jlink -DBOARD_DEBUG_RUNNER=jlink
+           :goals: build
 
 Configuring a Console
 =====================

--- a/boards/arm/mimxrt685_evk/doc/index.rst
+++ b/boards/arm/mimxrt685_evk/doc/index.rst
@@ -180,24 +180,28 @@ Configuring a Debug Probe
 A debug probe is used for both flashing and debugging the board. This board is
 configured by default to use the LPC-Link2.
 
-:ref:`lpclink2-jlink-onboard-debug-probe`
------------------------------------------
+.. tabs::
 
-Install the :ref:`jlink-debug-host-tools` and make sure they are in your search
-path. Install jumpers JP17, JP18 and JP19, to connect the SWD signals from onboard
-debug circuit.  These jumpers are installed by default.
+    .. group-tab:: LPCLink2 JLink Onboard
 
-Follow the instructions in :ref:`lpclink2-jlink-onboard-debug-probe` to program
-the J-Link firmware. Please make sure you have the latest firmware for this
-board.
 
-:ref:`jlink-external-debug-probe`
------------------------------------------
+        1. Install the :ref:`jlink-debug-host-tools` and make sure they are in your search path.
+        2. To connect the SWD signals to onboard debug circuit, install jumpers JP17, JP18 and JP19,
+           if not already done (these jumpers are installed by default).
+        3. Follow the instructions in :ref:`lpclink2-jlink-onboard-debug-probe` to program the
+           J-Link firmware. Please make sure you have the latest firmware for this board.
 
-Install the :ref:`jlink-debug-host-tools` and make sure they are in your search
-path. Remove jumpers JP17, JP18 and JP19, to disconnect the SWD signals from onboard
-debug circuit.  These jumpers are installed by default. Connect the J-Link probe
-to J2 10-pin header.
+    .. group-tab:: JLink External
+
+
+        1. Install the :ref:`jlink-debug-host-tools` and make sure they are in your search path.
+
+        2. To disconnect the SWD signals from onboard debug circuit, **remove** jumpers J17, J18,
+           and J19 (these are installed by default).
+
+        3. Connect the J-Link probe to J2 10-pin header.
+
+        See :ref:`jlink-external-debug-probe` for more information.
 
 Configuring a Console
 =====================


### PR DESCRIPTION
Reformats debug probe configuration sections for a couple NXP boards,
adding tabs to clarify options.

Signed-off-by: Julia Hathaway <julia.hathaway@nxp.com>