### PR TITLE
STM32: Fix runtime device PM

### DIFF
--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -79,11 +79,6 @@
 	status = "okay";
 };
 
-&usart2 {
-	current-speed = <115200>;
-	status = "okay";
-};
-
 &uart4 {
 	pinctrl-0 = <&uart4_tx_pa0 &uart4_rx_pa1>;
 	current-speed = <115200>;

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -683,7 +683,7 @@ static int gpio_stm32_init(const struct device *dev)
 			    gpio_stm32_pm_device_ctrl,			       \
 			    &gpio_stm32_data_## __suffix,		       \
 			    &gpio_stm32_cfg_## __suffix,		       \
-			    POST_KERNEL,				       \
+			    PRE_KERNEL_1,				       \
 			    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	       \
 			    &gpio_stm32_driver)
 

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -114,7 +114,7 @@ static inline uint32_t stm32_pinval_get(int pin)
 /**
  * @brief Configure the hardware.
  */
-int gpio_stm32_configure(const struct device *dev, int pin, int conf, int altf)
+void gpio_stm32_configure(const struct device *dev, int pin, int conf, int altf)
 {
 	const struct gpio_stm32_config *cfg = dev->config;
 	GPIO_TypeDef *gpio = (GPIO_TypeDef *)cfg->base;
@@ -221,7 +221,6 @@ int gpio_stm32_configure(const struct device *dev, int pin, int conf, int altf)
 	z_stm32_hsem_unlock(CFG_HW_GPIO_SEMID);
 #endif  /* CONFIG_SOC_SERIES_STM32F1X */
 
-	return 0;
 }
 
 /**

--- a/drivers/gpio/gpio_stm32.h
+++ b/drivers/gpio/gpio_stm32.h
@@ -243,7 +243,7 @@ struct gpio_stm32_data {
  * @param conf GPIO mode
  * @param altf Alternate function
  */
-int gpio_stm32_configure(const struct device *dev, int pin, int conf, int altf);
+void gpio_stm32_configure(const struct device *dev, int pin, int conf, int altf);
 
 /**
  * @brief Enable / disable GPIO port clock.


### PR DESCRIPTION
Runtime device PM was broken on STM32 following merge of https://github.com/zephyrproject-rtos/zephyr/commit/cc2f0e9c08dcad59a4cc0117028a5fcf9d73f433 that unveiled a flaw in current
STM32 PM implementation around gpio/pinmux.

Fix this issue by changing initialization step of gpio devices and reworking calls to gpio in pinmux
pseudo driver.

Fixes #36917 
