### PR TITLE
Revert "tests: drivers: build_all: add fake serial device for modem tests"

### DIFF
--- a/tests/drivers/build_all/modem/src/main.c
+++ b/tests/drivers/build_all/modem/src/main.c
@@ -27,11 +27,3 @@ void main(void)
 DEVICE_DT_DEFINE(DT_INST(0, vnd_gpio), NULL, NULL, NULL, NULL,
 		 POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
 #endif
-
-#if DT_NODE_EXISTS(DT_INST(0, vnd_serial))
-/* Fake serial device, needed for building drivers that use DEVICE_DT_GET()
- * to access serial bus.
- */
-DEVICE_DT_DEFINE(DT_INST(0, vnd_serial), NULL, NULL, NULL, NULL,
-		 POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
-#endif


### PR DESCRIPTION
This reverts commit 9e58a1e475473fcea1c3b0d05ac9c738141c821a.

This change is in conflict with commit 94f7ed356f0c ("drivers: serial:
add a dummy driver for vnd,serial"). As a result two equal serial
devices are defines, resulting in link error.