### PR TITLE
drivers/entropy: stm32 add seed error recovery

### DIFF
--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -180,6 +180,14 @@ static int random_byte_get(void)
 		}
 
 		retval = LL_RNG_ReadRandData32(rng);
+		if (retval == 0) {
+			/* A seed error could have occurred between RNG_SR
+			 * polling and RND_DR output reading.
+			 */
+			retval = -EAGAIN;
+			goto out;
+		}
+
 		retval &= 0xFF;
 	}
 


### PR DESCRIPTION
After this changes are applied the driver tries to recover when a seed error is detected.
Series which support the "Conditioning soft reset" perform a soft-reset.
Other series clear the flag and flush the pipeline.

Additionally, in case a zero value is read the value is not used and an error returned instead. 

