### PR TITLE
 tests: kernel: mem_protect: stack_random: disable qemu_riscv32

### DIFF
--- a/tests/kernel/mem_protect/stack_random/testcase.yaml
+++ b/tests/kernel/mem_protect/stack_random/testcase.yaml
@@ -1,4 +1,5 @@
 tests:
   kernel.memory_protection.stack_random:
     arch_exclude: posix
+    platform_exclude: qemu_riscv32
     tags: kernel memory_protection


### PR DESCRIPTION
Test fails consistently in CI but local builds succeed. Puzzling. This happened somewhere between 84c5a469ab and de13034502.

In order  to keep main green, disabling this test only for qemu_riscv32 until a solution is found.
    
```
% west build -p always -b qemu_riscv32 -t run tests/kernel/mem_protect/stack_random
...
*** Booting Zephyr OS build zephyr-v2.6.0-1039-g523764b3fd75  ***
Running test suite stack_pointer_randomness
===================================================================
START - test_stack_pt_randomization
Test Stack pointer randomization
stack pointer changed 13 times out of 64 tests
PASS - test_stack_pt_randomization in 0.5 seconds
===================================================================
Test suite stack_pointer_randomness succeeded
===================================================================
PROJECT EXECUTION SUCCESSFUL
```
    
```
ERROR   - *** Booting Zephyr OS build zephyr-v2.6.0-1063-g0106d8f2a391  ***
--
  | Running test suite stack_pointer_randomness
  | ===================================================================
  | START - test_stack_pt_randomization
  | Test Stack pointer randomization
  | stack pointer changed 0 times out of 64 tests
  |
  | Assertion failed at WEST_TOPDIR/zephyr/tests/kernel/mem_protect/stack_random/src/main.c:68: test_stack_pt_randomization: (sp_changed equal to 0)
  | Stack pointer is not randomized
  | FAIL - test_stack_pt_randomization in 0.6 seconds
  | ===================================================================
  | Test suite stack_pointer_randomness failed.
  | ===================================================================
  | PROJECT EXECUTION FAILED
```
