### PR TITLE
toolchain: cmake: doc: Resolve include of other.h for off-tree toolchains

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,11 @@ zephyr_compile_definitions(
   __ZEPHYR__=1
 )
 
+# Ensure that include/toolchain.h includes toolchain/other.h for all off-tree toolchains
+if(TOOLCHAIN_USE_CUSTOM)
+  zephyr_compile_definitions(__TOOLCHAIN_CUSTOM__)
+endif()
+
 # @Intent: Set compiler flags to enable buffer overflow checks in libc functions
 # @config in CONFIG_NO_OPTIMIZATIONS optional : Optimizations may affect security
 zephyr_compile_definitions($<TARGET_PROPERTY:compiler,security_fortify> )

--- a/doc/getting_started/toolchain_custom_cmake.rst
+++ b/doc/getting_started/toolchain_custom_cmake.rst
@@ -13,12 +13,16 @@ environment variables <env_vars>`:
 Zephyr will then include the toolchain cmake files located in the
 :file:`TOOLCHAIN_ROOT` directory:
 
-- :file:`cmake/toolchain/generic.cmake`: configures the toolchain for "generic"
-  use, which mostly means running the C preprocessor on :ref:`devicetree
-  input files <dt-input-files>`.
-- :file:`cmake/toolchain/target.cmake`: configures the toolchain for "target"
-  use, i.e. building Zephyr and your application's source code.
+- :file:`cmake/toolchain/<toolchain name>/generic.cmake`: configures the
+  toolchain for "generic" use, which mostly means running the C preprocessor
+  on the generated
+  :ref:`devicetree` file.
+- :file:`cmake/toolchain/<toolchain name>/target.cmake`: configures the
+  toolchain for "target" use, i.e. building Zephyr and your application's
+  source code.
 
+Here <toolchain name> is the same as the name provided in
+:envvar:`ZEPHYR_TOOLCHAIN_VARIANT`
 See the zephyr files :zephyr_file:`cmake/generic_toolchain.cmake` and
 :zephyr_file:`cmake/target_toolchain.cmake` for more details on what your
 :file:`generic.cmake` and :file:`target.cmake` files should contain.
@@ -38,6 +42,31 @@ If you do this, ``-C <initial-cache>`` `cmake option`_ may useful. If you save
 your :makevar:`ZEPHYR_TOOLCHAIN_VARIANT`, :makevar:`TOOLCHAIN_ROOT`, and other
 settings in a file named :file:`my-toolchain.cmake`, you can then invoke cmake
 as ``cmake -C my-toolchain.cmake ...`` to save typing.
+
+Zephyr includes :file:`include/toolchain.h` which again includes a toolchain
+specific header based on the compiler identifier, such as ``__llvm__`` or
+``__GNUC__``.
+Some custom compilers identify themselves as the compiler on which they are
+based, for example ``llvm`` which then gets the :file:`toolchain/llvm.h` included.
+This included file may though not be right for the custom toolchain. In order
+to solve this, and thus to get the :file:`include/other.h` included instead,
+add the set(TOOLCHAIN_USE_CUSTOM 1) cmake line to the generic.cmake and/or
+target.cmake files located under
+:file:`<TOOLCHAIN_ROOT>/cmake/toolchain/<toolchain name>/`.
+
+When :makevar:`TOOLCHAIN_USE_CUSTOM` is set, the :file:`other.h` must be
+available out-of-tree and it must include the correct header for the custom
+toolchain.
+A good location for the :file:`other.h` header file, would be a
+directory under the directory specified in :envvar:`TOOLCHAIN_ROOT` as
+:file:`include/toolchain`.
+To get the toolchain header included in zephyr's build, the
+:makevar:`USERINCLUDE` can be set to point to the include directory, as shown
+here:
+
+.. code-block:: console
+
+   west build -- -DZEPHYR_TOOLCHAIN_VARIANT=... -DTOOLCHAIN_ROOT=... -DUSERINCLUDE=...
 
 .. _cmake option:
    https://cmake.org/cmake/help/latest/manual/cmake.1.html#options

--- a/include/toolchain.h
+++ b/include/toolchain.h
@@ -33,7 +33,12 @@
 #define HAS_BUILTIN(x) HAS_BUILTIN_##x
 #endif
 
-#if defined(__XCC__)
+#if defined(__TOOLCHAIN_CUSTOM__)
+/* This include line exists for off-tree definitions of compilers,
+ * and therefore this header is not meant to exist in-tree
+ */
+#include <toolchain/other.h>
+#elif defined(__XCC__)
 #include <toolchain/xcc.h>
 #elif defined(__CCAC__)
 #include <toolchain/mwdt.h>
@@ -42,10 +47,7 @@
 #elif defined(__GNUC__) || (defined(_LINKER) && defined(__GCC_LINKER_CMD__))
 #include <toolchain/gcc.h>
 #else
-/* This include line exists for off-tree definitions of compilers,
- * and therefore this header is not meant to exist in-tree
- */
-#include <toolchain/other.h>
+#error "Invalid/unknown toolchain configuration"
 #endif
 
 /*


### PR DESCRIPTION
To ensure that an off-tree toolchain always gets the toolchain/other.h
header included, such that it can include the correct header for the
toolchain via the other.h, the define __TOOLCHAIN_CUSTOM__ will be set
when ever TOOLCHAIN_ROOT is specified. As TOOLCHAIN_ROOT is only
specified externally for off-tree toolchains, this has no impact on
in-tree toolchains and their functionality.

Custom toolchain documentation updated to describe the required 
toolchain/other.h, suggested placement and how to get it included.
Also updated documentation with missing toolchain name in path to 
generic.cmake and target.cmake.

Fixes #36117

Signed-off-by: Danny Oerndrup <daor@demant.com>