### PR TITLE
ci: doc: fix build target for doc publish

### DIFF
--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -79,7 +79,7 @@ jobs:
         DOC_TAG: ${{ steps.tag.outputs.TYPE }}
       run: |
         source zephyr-env.sh
-        make DOC_TAG=${DOC_TAG} -C doc htmldocs
+        make DOC_TAG=${DOC_TAG} -C doc html
 
     - name: Upload to AWS S3
       env:


### PR DESCRIPTION
The build target was not updated on the doc publish workflow (htmldocs -> html).