### PR TITLE
doc: fix gen_devicetree_rest.py bindings search

### DIFF
--- a/doc/_scripts/gen_devicetree_rest.py
+++ b/doc/_scripts/gen_devicetree_rest.py
@@ -217,7 +217,8 @@ def load_bindings(dts_roots):
 
     binding_files = []
     for dts_root in dts_roots:
-        binding_files.extend(glob.glob(f'{dts_root}/dts/bindings/**/*.yaml'))
+        binding_files.extend(glob.glob(f'{dts_root}/dts/bindings/**/*.yaml',
+                                       recursive=True))
 
     bindings = edtlib.bindings_from_paths(binding_files, ignore_errors=True)
 


### PR DESCRIPTION
The gen_devicetree_rest.py script is responsible for generating .rst
files that comprise the devicetree bindings index. As a first step, it
finds all the YAML files that might be bindings.

However, it's doing that incorrectly and ignoring files in nested
subdirectories. This affects bindings in places like
dts/bindings/net/wireless, which are not found.

Fix it by using recursive=True in the glob.glob() call.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>