### PR TITLE
Mec172x v2 headers 006

### DIFF
--- a/soc/arm/microchip_mec/mec172x/reg/mec172x_espi_iom.h
+++ b/soc/arm/microchip_mec/mec172x/reg/mec172x_espi_iom.h
@@ -1,0 +1,942 @@
+/*
+ * Copyright (c) 2021 Microchip Technology Inc. and its subsidiaries.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _MEC172X_ESPI_IO_H
+#define _MEC172X_ESPI_IO_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+/* Offsets from base for various register groups */
+#define MCHP_ESPI_IO_PC_OFS		0x0100u
+#define MCHP_ESPI_IO_HOST_BAR_OFS	0x0120u
+#define MCHP_ESPI_IO_LTR_OFS		0x0220u
+#define MCHP_ESPI_IO_OOB_OFS		0x0240u
+#define MCHP_ESPI_IO_FC_OFS		0x0280u
+#define MCHP_ESPI_IO_CAP_OFS		0x02b0u
+#define MCHP_ESPI_IO_SIRQ_OFS		0x03a0u
+
+/* eSPI Global Capabilities 0 */
+#define MCHP_ESPI_GBL_CAP0_MASK		0x0fu
+#define MCHP_ESPI_GBL_CAP0_PC_SUPP	BIT(0)
+#define MCHP_ESPI_GBL_CAP0_VW_SUPP	BIT(1)
+#define MCHP_ESPI_GBL_CAP0_OOB_SUPP	BIT(2)
+#define MCHP_ESPI_GBL_CAP0_FC_SUPP	BIT(3)
+
+/* eSPI Global Capabilities 1 */
+#define MCHP_ESPI_GBL_CAP1_MASK			0xffu
+#define MCHP_ESPI_GBL_CAP1_MAX_FREQ_POS		0u
+#define MCHP_ESPI_GBL_CAP1_MAX_FREQ_MASK	0x07u
+#define MCHP_ESPI_GBL_CAP1_MAX_FREQ_20M		0x00u
+#define MCHP_ESPI_GBL_CAP1_MAX_FREQ_25M		0x01u
+#define MCHP_ESPI_GBL_CAP1_MAX_FREQ_33M		0x02u
+#define MCHP_ESPI_GBL_CAP1_MAX_FREQ_50M		0x03u
+#define MCHP_ESPI_GBL_CAP1_MAX_FREQ_66M		0x04u
+#define MCHP_ESPI_GBL_CAP1_ALERT_POS		3u /* Read-Only */
+#define MCHP_ESPI_GBL_CAP1_ALERT_DED_PIN	\
+	BIT(MCHP_ESPI_GBL_CAP1_ALERT_POS)
+#define MCHP_ESPI_GBL_CAP1_ALERT_ON_IO1		0u
+#define MCHP_ESPI_GBL_CAP1_IO_MODE_POS		4u
+#define MCHP_ESPI_GBL_CAP1_IO_MODE_MASK0	0x03u
+#define MCHP_ESPI_GBL_CAP1_IO_MODE_MASK		SHLU32(0x03u, 4)
+#define MCHP_ESPI_GBL_CAP1_IO_MODE0_1		0u
+#define MCHP_ESPI_GBL_CAP1_IO_MODE0_12		1u
+#define MCHP_ESPI_GBL_CAP1_IO_MODE0_14		2u
+#define MCHP_ESPI_GBL_CAP1_IO_MODE0_124		3u
+#define MCHP_ESPI_GBL_CAP1_IO_MODE_1		\
+	SHLU32(MCHP_ESPI_GBL_CAP1_IO_MODE0_1, MCHP_ESPI_GBL_CAP1_IO_MODE_POS)
+
+#define MCHP_ESPI_GBL_CAP1_IO_MODE_12		\
+	SHLU32(MCHP_ESPI_GBL_CAP1_IO_MODE0_12, MCHP_ESPI_GBL_CAP1_IO_MODE_POS)
+
+#define MCHP_ESPI_GBL_CAP1_IO_MODE_14		\
+	SHLU32(MCHP_ESPI_GBL_CAP1_IO_MODE0_14, MCHP_ESPI_GBL_CAP1_IO_MODE_POS)
+
+#define MCHP_ESPI_GBL_CAP1_IO_MODE_124		\
+	SHLU32(MCHP_ESPI_GBL_CAP1_IO_MODE0_124, MCHP_ESPI_GBL_CAP1_IO_MODE_POS)
+
+/*
+ * Support Open Drain ALERT pin configuration
+ * EC sets this bit if it can support open-drain ESPI_ALERT#
+ */
+#define MCHP_ESPI_GBL_CAP1_ALERT_ODS_POS	6u
+#define MCHP_ESPI_GBL_CAP1_ALERT_ODS BIT(MCHP_ESPI_GBL_CAP1_ALERT_ODS_POS)
+
+/*
+ * Read-Only ALERT Open Drain select.
+ * If EC has indicated it can support open-drain ESPI_ALERT# then
+ * the Host can enable open-drain ESPI_ALERT# by sending a configuraiton
+ * message. This read-only bit relects the configuration selection.
+ */
+#define MCHP_ESPI_GBL_CAP1_ALERT_ODS_SEL_POS	7u
+#define MCHP_ESPI_GBL_CAP1_ALERT_SEL_ODS \
+	BIT(MCHP_ESPI_GBL_CAP1_ALERT_ODS_SEL_POS)
+
+/* Peripheral Channel(PC) Capabilities */
+#define MCHP_ESPI_PC_CAP_MASK			0x07u
+#define MCHP_ESPI_PC_CAP_MAX_PLD_SZ_MASK	0x07u
+#define MCHP_ESPI_PC_CAP_MAX_PLD_SZ_64		0x01u
+#define MCHP_ESPI_PC_CAP_MAX_PLD_SZ_128		0x02u
+#define MCHP_ESPI_PC_CAP_MAX_PLD_SZ_256		0x03u
+
+/* Virtual Wire(VW) Capabilities */
+#define MCHP_ESPI_VW_CAP_MASK			0x3fu
+#define MCHP_ESPI_VW_CAP_MAX_VW_CNT_MASK	0x3fu
+
+/* Out-of-Band(OOB) Capabilities */
+#define MCHP_ESPI_OOB_CAP_MASK			0x07u
+#define MCHP_ESPI_OOB_CAP_MAX_PLD_SZ_MASK	0x07u
+#define MCHP_ESPI_OOB_CAP_MAX_PLD_SZ_73		0x01u
+#define MCHP_ESPI_OOB_CAP_MAX_PLD_SZ_137	0x02u
+#define MCHP_ESPI_OOB_CAP_MAX_PLD_SZ_265	0x03u
+
+/* Flash Channel(FC) Capabilities */
+#define MCHP_ESPI_FC_CAP_MASK			0xffu
+#define MCHP_ESPI_FC_CAP_MAX_PLD_SZ_MASK	0x07u
+#define MCHP_ESPI_FC_CAP_MAX_PLD_SZ_64		0x01u
+#define MCHP_ESPI_FC_CAP_SHARE_POS		3u
+#define MCHP_ESPI_FC_CAP_SHARE_MASK0		0x03u
+#define MCHP_ESPI_FC_CAP_SHARE_MASK		\
+	SHLU32(MCHP_ESPI_FC_CAP_SHARE_MASK0, MCHP_ESPI_FC_CAP_SHARE_POS)
+
+#define MCHP_ESPI_FC_CAP_SHARE_MAF_ONLY		0u
+#define MCHP_ESPI_FC_CAP_SHARE_MAF2_ONLY	\
+	SHLU32(1U, MCHP_ESPI_FC_CAP_SHARE_POS)
+
+#define MCHP_ESPI_FC_CAP_SHARE_SAF_ONLY		\
+	SHLU32(2U, MCHP_ESPI_FC_CAP_SHARE_POS)
+
+#define MCHP_ESPI_FC_CAP_SHARE_MAF_SAF		\
+	SHLU32(3U, MCHP_ESPI_FC_CAP_SHARE_POS)
+
+#define MCHP_ESPI_FC_CAP_MAX_RD_SZ_POS		5u
+#define MCHP_ESPI_FC_CAP_MAX_RD_SZ_MASK0	0x07u
+#define MCHP_ESPI_FC_CAP_MAX_RD_SZ_MASK		\
+	SHLU32(MCHP_ESPI_FC_CAP_MAX_RD_SZ_MASK0, \
+	       MCHP_ESPI_FC_CAP_MAX_RD_SZ_POS)
+
+#define MCHP_ESPI_FC_CAP_MAX_RD_SZ_64		\
+	BIT(MCHP_ESPI_FC_CAP_MAX_RD_SZ_POS)
+
+/* PC Ready */
+#define MCHP_ESPI_PC_READY_MASK		0x01u;
+#define MCHP_ESPI_PC_READY		0x01u;
+
+/* OOB Ready */
+#define MCHP_ESPI_OOB_READY_MASK	0x01u;
+#define MCHP_ESPI_OOB_READY		0x01u;
+
+/* FC Ready */
+#define MCHP_ESPI_FC_READY_MASK		0x01u;
+#define MCHP_ESPI_FC_READY		0x01u;
+
+/* ESPI_RESET# Interrupt Status */
+#define MCHP_ESPI_RST_ISTS_MASK		0x03u;
+#define MCHP_ESPI_RST_ISTS_POS		0u
+#define MCHP_ESPI_RST_ISTS		BIT(MCHP_ESPI_RST_ISTS_POS)
+#define MCHP_ESPI_RST_ISTS_PIN_RO_POS	1u
+#define MCHP_ESPI_RST_ISTS_PIN_RO_HI	BIT(MCHP_ESPI_RST_ISTS_PIN_RO_POS)
+
+/* ESPI_RESET# Interrupt Enable */
+#define MCHP_ESPI_RST_IEN_MASK		0x01u
+#define MCHP_ESPI_RST_IEN		0x01u
+
+/* eSPI Platform Reset Source */
+#define MCHP_ESPI_PLTRST_SRC_MASK	0x01u
+#define MCHP_ESPI_PLTRST_SRC_POS	0u
+#define MCHP_ESPI_PLTRST_SRC_IS_PIN	0x01u
+#define MCHP_ESPI_PLTRST_SRC_IS_VW	0x00u
+
+/* VW Ready */
+#define MCHP_ESPI_VW_READY_MASK		0x01u
+#define MCHP_ESPI_VW_READY		0x01u
+
+/* SAF Erase Block size */
+#define MCHP_ESPI_SERASE_SZ_1K_BITPOS	0
+#define MCHP_ESPI_SERASE_SZ_2K_BITPOS	1
+#define MCHP_ESPI_SERASE_SZ_4K_BITPOS	2
+#define MCHP_ESPI_SERASE_SZ_8K_BITPOS	3
+#define MCHP_ESPI_SERASE_SZ_16K_BITPOS	4
+#define MCHP_ESPI_SERASE_SZ_32K_BITPOS	5
+#define MCHP_ESPI_SERASE_SZ_64K_BITPOS	6
+#define MCHP_ESPI_SERASE_SZ_128K_BITPOS 7
+#define MCHP_ESPI_SERASE_SZ_1K		BIT(0)
+#define MCHP_ESPI_SERASE_SZ_2K		BIT(1)
+#define MCHP_ESPI_SERASE_SZ_4K		BIT(2)
+#define MCHP_ESPI_SERASE_SZ_8K		BIT(3)
+#define MCHP_ESPI_SERASE_SZ_16K		BIT(4)
+#define MCHP_ESPI_SERASE_SZ_32K		BIT(5)
+#define MCHP_ESPI_SERASE_SZ_64K		BIT(6)
+#define MCHP_ESPI_SERASE_SZ_128K	BIT(7)
+#define MCHP_ESPI_SERASE_SZ(bitpos) BIT((bitpos) + 10u)
+
+/* VW Error Status */
+#define MCHP_ESPI_VW_ERR_STS_MASK		0x33u
+#define MCHP_ESPI_VW_ERR_STS_FATAL_POS		0u
+#define MCHP_ESPI_VW_ERR_STS_FATAL_RO		\
+	BIT(MCHP_ESPI_VW_ERR_STS_FATAL_POS)
+
+#define MCHP_ESPI_VW_ERR_STS_FATAL_CLR_POS	1u
+#define MCHP_ESPI_VW_ERR_STS_FATAL_CLR_WO	\
+	BIT(MCHP_ESPI_VW_ERR_STS_FATAL_CLR_POS)
+
+#define MCHP_ESPI_VW_ERR_STS_NON_FATAL_POS	4u
+#define MCHP_ESPI_VW_ERR_STS_NON_FATAL_RO	\
+	BIT(MCHP_ESPI_VW_ERR_STS_NON_FATAL_POS)
+
+#define MCHP_ESPI_VW_ERR_STS_NON_FATAL_CLR_POS	5u
+#define MCHP_ESPI_VW_ERR_STS_NON_FATAL_CLR_WO	\
+	BIT(MCHP_ESPI_VW_ERR_STS_NON_FATAL_CLR_POS)
+
+/* VW Channel Enable Status */
+#define MCHP_ESPI_VW_EN_STS_MASK	0x01u
+#define MCHP_ESPI_VW_EN_STS_RO		0x01u
+
+/*
+ * MCHP_ESPI_IO_PC - eSPI IO Peripheral Channel registers @ 0x400F3500
+ */
+
+/* Peripheral Channel Last Cycle length, type, and tag. */
+#define MCHP_ESPI_PC_LC_LEN_POS		0u
+#define MCHP_ESPI_PC_LC_LEN_MASK0	0x0fffu
+#define MCHP_ESPI_PC_LC_LEN_MASK	0x0fffu
+#define MCHP_ESPI_PC_LC_TYPE_POS	12u
+#define MCHP_ESPI_PC_LC_TYPE_MASK0	0xffu
+#define MCHP_ESPI_PC_LC_TYPE_MASK	(0xffu << 12)
+#define MCHP_ESPI_PC_LC_TAG_POS		20u
+#define MCHP_ESPI_PC_LC_TAG_MASK0	0x0fu
+#define MCHP_ESPI_PC_LC_TAG_MASK	(0x0fu << 20)
+
+/*
+ * Peripheral Channel Status
+ * Bus error, Channel enable change, and Bus master enable change.
+ */
+#define MCHP_ESPI_PC_STS_BUS_ERR_POS	16u /* RW1C */
+#define MCHP_ESPI_PC_STS_BUS_ERR	BIT(MCHP_ESPI_PC_STS_BUS_ERR_POS)
+#define MCHP_ESPI_PC_STS_EN_POS		24u /* RO */
+#define MCHP_ESPI_PC_STS_EN		BIT(MCHP_ESPI_PC_STS_EN_POS)
+#define MCHP_ESPI_PC_STS_EN_CHG_POS	25u /* RW1C */
+#define MCHP_ESPI_PC_STS_EN_CHG		BIT(MCHP_ESPI_PC_STS_EN_CHG_POS)
+#define MCHP_ESPI_PC_STS_BM_EN_POS	27u /* RO */
+#define MCHP_ESPI_PC_STS_BM_EN		BIT(MCHP_ESPI_PC_STS_BM_EN_POS)
+#define MCHP_ESPI_PC_STS_BM_EN_CHG_POS	28u /* RW1C */
+#define MCHP_ESPI_PC_STS_BM_EN_CHG	BIT(MCHP_ESPI_PC_STS_BM_EN_CHG_POS)
+
+/*
+ * Peripheral Channel Interrupt Enables for
+ * Bus error, Channel enable change, and Bus master enable change.
+ * PC_LC_ADDR_LSW (@ 0x0000) Periph Chan Last Cycle address LSW
+ * PC_LC_ADDR_MSW (@ 0x0004) Periph Chan Last Cycle address MSW
+ * PC_LC_LEN_TYPE_TAG (@ 0x0008) Periph Chan Last Cycle length/type/tag
+ * PC_ERR_ADDR_LSW (@ 0x000C) Periph Chan Error Address LSW
+ * PC_ERR_ADDR_MSW (@ 0x0010) Periph Chan Error Address MSW
+ * PC_STATUS (@ 0x0014) Periph Chan Status
+ * PC_IEN (@ 0x0018) Periph Chan IEN
+ */
+#define MCHP_ESPI_PC_IEN_BUS_ERR_POS	16u
+#define MCHP_ESPI_PC_IEN_BUS_ERR	BIT(MCHP_ESPI_PC_IEN_BUS_ERR_POS)
+#define MCHP_ESPI_PC_IEN_EN_CHG_POS	25u
+#define MCHP_ESPI_PC_IEN_EN_CHG		BIT(MCHP_ESPI_PC_IEN_BUS_ERR_POS)
+#define MCHP_ESPI_PC_IEN_BM_EN_CHG_POS	28u
+#define MCHP_ESPI_PC_IEN_BM_EN_CHG	BIT(MCHP_ESPI_PC_IEN_BUS_ERR_POS)
+
+/*---- ESPI_IO_LTR - eSPI IO LTR registers ----*/
+#define MCHP_ESPI_LTR_STS_TX_DONE_POS	0u /* RW1C */
+#define MCHP_ESPI_LTR_STS_TX_DONE	BIT(MCHP_ESPI_LTR_STS_TX_DONE_POS)
+#define MCHP_ESPI_LTR_STS_OVRUN_POS	3u /* RW1C */
+#define MCHP_ESPI_LTR_STS_OVRUN		BIT(MCHP_ESPI_LTR_STS_OVRUN_POS)
+#define MCHP_ESPI_LTR_STS_HDIS_POS	4u /* RW1C */
+#define MCHP_ESPI_LTR_STS_HDIS		BIT(MCHP_ESPI_LTR_STS_HDIS_POS)
+#define MCHP_ESPI_LTR_STS_TX_BUSY_POS	8u /* RO */
+#define MCHP_ESPI_LTR_STS_TX_BUSY	BIT(MCHP_ESPI_LTR_STS_TX_BUSY_POS)
+
+#define MCHP_ESPI_LTR_IEN_TX_DONE_POS	0u
+#define MCHP_ESPI_LTR_IEN_TX_DONE	BIT(MCHP_ESPI_LTR_IEN_TX_DONE_POS)
+
+#define MCHP_ESPI_LTR_CTRL_START_POS	0u
+#define MCHP_ESPI_LTR_CTRL_START	BIT(MCHP_ESPI_LTR_CTRL_START_POS)
+#define MCHP_ESPI_LTR_CTRL_TAG_POS	8u
+#define MCHP_ESPI_LTR_CTRL_TAG_MASK0	0x0fu
+#define MCHP_ESPI_LTR_CTRL_TAG_MASK	\
+	SHLU32(MCHP_ESPI_LTR_CTRL_TAG_MASK0, MCHP_ESPI_LTR_CTRL_TAG_POS)
+
+#define MCHP_ESPI_LTR_MSG_VAL_POS	0u
+#define MCHP_ESPI_LTR_MSG_VAL_MASK0	0x3ffu
+#define MCHP_ESPI_LTR_MSG_VAL_MASK	\
+	SHLU32(MCHP_ESPI_LTR_MSG_VAL_MASK0, MCHP_ESPI_LTR_MSG_VAL_POS)
+#define MCHP_ESPI_LTR_MSG_SC_POS	10u
+#define MCHP_ESPI_LTR_MSG_SC_MASK0	0x07u
+#define MCHP_ESPI_LTR_MSG_SC_MASK	\
+	SHLU32(MCHP_ESPI_LTR_MSG_SC_MASK0, MCHP_ESPI_LTR_MSG_SC_POS)
+#define MCHP_ESPI_LTR_MSG_RT_POS	13u
+#define MCHP_ESPI_LTR_MSG_RT_MASK0	0x03u
+#define MCHP_ESPI_LTR_MSG_RT_MASK	\
+	SHLU32(MCHP_ESPI_LTR_MSG_RT_MASK0, MCHP_ESPI_LTR_MSG_RT_POS)
+/* eSPI specification indicates RT field must be 00b */
+#define MCHP_ESPI_LTR_MSG_RT_VAL	0u
+#define MCHP_ESPI_LTR_MSG_REQ_POS	15u
+/* inifinite latency(default) */
+#define MCHP_ESPI_LTR_MSG_REQ_INF	0u
+/* latency computed from VAL and SC(scale) fields */
+#define MCHP_ESPI_LTR_MSG_REQ_VAL	 BIT(MCHP_ESPI_LTR_MSG_REQ_POS)
+
+/*---- ESPI_IO_OOB - eSPI IO OOB registers ----*/
+#define MCHP_ESPI_OOB_RX_ADDR_LSW_MASK	0xfffffffcu
+#define MCHP_ESPI_OOB_TX_ADDR_LSW_MASK	0xfffffffcu
+
+/* OOB RX_LEN register */
+/* Number of bytes received (RO) */
+#define MCHP_ESPI_OOB_RX_LEN_POS	0u
+#define MCHP_ESPI_OOB_RX_LEN_MASK	0x1fffu
+/* Receive buffer length field (RW) */
+#define MCHP_ESPI_OOB_RX_BUF_LEN_POS	16u
+#define MCHP_ESPI_OOB_RX_BUF_LEN_MASK0	0x1fffu
+#define MCHP_ESPI_OOB_RX_BUF_LEN_MASK	\
+	SHLU32(MCHP_ESPI_OOB_RX_BUF_LEN_MASK0, MCHP_ESPI_OOB_RX_BUF_LEN_POS)
+
+/* OOB TX_LEN register */
+#define MCHP_ESPI_OOB_TX_MSG_LEN_POS	0u
+#define MCHP_ESPI_OOB_TX_MSG_LEN_MASK	0x1fffu
+
+/* OOB RX_CTRL */
+/* Set AVAIL bit to indicate SRAM Buffer and size has been configured */
+#define MCHP_ESPI_OOB_RX_CTRL_AVAIL_POS	0u /* WO */
+#define MCHP_ESPI_OOB_RX_CTRL_AVAIL	BIT(MCHP_ESPI_OOB_RX_CTRL_AVAIL_POS)
+#define MCHP_ESPI_OOB_RX_CTRL_CHEN_POS	9u /* RO */
+#define MCHP_ESPI_OOB_RX_CTRL_CHEN	BIT(MCHP_ESPI_OOB_RX_CTRL_CHEN_POS)
+/* Copy of eSPI OOB Capabilities max. payload size */
+#define MCHP_ESPI_OOB_RX_CTRL_MAX_SZ_POS	16u /* RO */
+#define MCHP_ESPI_OOB_RX_CTRL_MAX_SZ_MASK0	0x07u
+#define MCHP_ESPI_OOB_RX_CTRL_MAX_SZ_MASK	\
+	SHLU32(MCHP_ESPI_OOB_RX_CTRL_MAX_SZ_MASK0, \
+	       MCHP_ESPI_OOB_RX_CTRL_MAX_SZ_POS)
+
+/* OOB RX_IEN */
+#define MCHP_ESPI_OOB_RX_IEN_POS	0u
+#define MCHP_ESPI_OOB_RX_IEN		BIT(MCHP_ESPI_OOB_RX_IEN_POS)
+
+/* OOB RX_STS */
+#define MCHP_ESPI_OOB_RX_STS_DONE_POS	0u /* RW1C */
+#define MCHP_ESPI_OOB_RX_STS_DONE	BIT(MCHP_ESPI_OOB_RX_STS_DONE_POS)
+#define MCHP_ESPI_OOB_RX_STS_IBERR_POS	1u  /* RW1C */
+#define MCHP_ESPI_OOB_RX_STS_IBERR	BIT(MCHP_ESPI_OOB_RX_STS_IBERR_POS)
+#define MCHP_ESPI_OOB_RX_STS_OVRUN_POS	2u  /* RW1C */
+#define MCHP_ESPI_OOB_RX_STS_OVRUN	BIT(MCHP_ESPI_OOB_RX_STS_OVRUN_POS)
+#define MCHP_ESPI_OOB_RX_STS_RXEN_POS	3u  /* RO */
+#define MCHP_ESPI_OOB_RX_STS_RXEN	BIT(MCHP_ESPI_OOB_RX_STS_RXEN_POS)
+#define MCHP_ESPI_OOB_RX_STS_TAG_POS	8u  /* RO */
+#define MCHP_ESPI_OOB_RX_STS_TAG_MASK0	0x0fu
+#define MCHP_ESPI_OOB_RX_STS_TAG_MASK	\
+	SHLU32(MCHP_ESPI_OOB_RX_STS_TAG_MASK0, MCHP_ESPI_OOB_RX_STS_TAG_POS)
+
+#define MCHP_ESPI_OOB_RX_STS_ALL_RW1C	0x07u
+#define MCHP_ESPI_OOB_RX_STS_ALL	0x0fu
+
+/* OOB TX_CTRL */
+#define MCHP_ESPI_OOB_TX_CTRL_START_POS 0u /* WO */
+#define MCHP_ESPI_OOB_TX_CTRL_START	BIT(MCHP_ESPI_OOB_TX_CTRL_START_POS)
+#define MCHP_ESPI_OOB_TX_CTRL_TAG_POS	8u  /* RW */
+#define MCHP_ESPI_OOB_TX_CTRL_TAG_MASK0 0x0fu
+#define MCHP_ESPI_OOB_TX_CTRL_TAG_MASK	\
+	SHLU32(MCHP_ESPI_OOB_TX_CTRL_TAG_MASK0, MCHP_ESPI_OOB_TX_CTRL_TAG_POS)
+
+/* OOB TX_IEN */
+#define MCHP_ESPI_OOB_TX_IEN_DONE_POS	0u
+#define MCHP_ESPI_OOB_TX_IEN_DONE	BIT(MCHP_ESPI_OOB_TX_IEN_DONE_POS)
+#define MCHP_ESPI_OOB_TX_IEN_CHG_EN_POS 1u
+#define MCHP_ESPI_OOB_TX_IEN_CHG_EN	BIT(MCHP_ESPI_OOB_TX_IEN_CHG_EN_POS)
+#define MCHP_ESPI_OOB_TX_IEN_ALL	0x03u
+
+/* OOB TX_STS */
+#define MCHP_ESPI_OOB_TX_STS_DONE_POS	0u /* RW1C */
+#define MCHP_ESPI_OOB_TX_STS_DONE	BIT(MCHP_ESPI_OOB_TX_STS_DONE_POS)
+#define MCHP_ESPI_OOB_TX_STS_CHG_EN_POS 1u /* RW1C */
+#define MCHP_ESPI_OOB_TX_STS_CHG_EN	BIT(MCHP_ESPI_OOB_TX_STS_CHG_EN_POS)
+#define MCHP_ESPI_OOB_TX_STS_IBERR_POS	2u /* RW1C */
+#define MCHP_ESPI_OOB_TX_STS_IBERR	BIT(MCHP_ESPI_OOB_TX_STS_IBERR_POS)
+#define MCHP_ESPI_OOB_TX_STS_OVRUN_POS	3u /* RW1C */
+#define MCHP_ESPI_OOB_TX_STS_OVRUN	BIT(MCHP_ESPI_OOB_TX_STS_OVRUN_POS)
+#define MCHP_ESPI_OOB_TX_STS_BADREQ_POS 5u /* RW1C */
+#define MCHP_ESPI_OOB_TX_STS_BADREQ	BIT(MCHP_ESPI_OOB_TX_STS_BADREQ_POS)
+#define MCHP_ESPI_OOB_TX_STS_BUSY_POS	8u /* RO */
+#define MCHP_ESPI_OOB_TX_STS_BUSY	BIT(MCHP_ESPI_OOB_TX_STS_BUSY_POS)
+/* Read-only copy of OOB Channel Enabled bit */
+#define MCHP_ESPI_OOB_TX_STS_CHEN_POS	9u /* RO */
+#define MCHP_ESPI_OOB_TX_STS_CHEN	BIT(MCHP_ESPI_OOB_TX_STS_CHEN_POS)
+
+#define MCHP_ESPI_OOB_TX_STS_ALL_RW1C	0x2fu
+
+/*---- MCHP_ESPI_IO_FC - eSPI IO Flash channel registers ----*/
+/* FC MEM_ADDR_LSW */
+#define MCHP_ESPI_FC_MEM_ADDR_LSW_MASK	0xfffffffcu
+
+/* FC CTRL */
+#define MCHP_ESPI_FC_CTRL_START_POS	0u /* WO */
+#define MCHP_ESPI_FC_CTRL_START		BIT(MCHP_ESPI_FC_CTRL_START_POS)
+#define MCHP_ESPI_FC_CTRL_FUNC_POS	2u  /* RW */
+#define MCHP_ESPI_FC_CTRL_FUNC_MASK0	0x03u
+#define MCHP_ESPI_FC_CTRL_FUNC_MASK	\
+	SHLU32(MCHP_ESPI_FC_CTRL_FUNC_MASK0, MCHP_ESPI_FC_CTRL_FUNC_POS)
+#define MCHP_ESPI_FC_CTRL_RD0		0x00u
+#define MCHP_ESPI_FC_CTRL_WR0		0x01u
+#define MCHP_ESPI_FC_CTRL_ERS0		0x02u
+#define MCHP_ESPI_FC_CTRL_ERL0		0x03u
+#define MCHP_ESPI_FC_CTRL_FUNC(f)	\
+	((uint32_t)(f) & MCHP_ESPI_FC_CTRL_FUNC_MASK)
+
+#define MCHP_ESPI_FC_CTRL_TAG_POS	4u
+#define MCHP_ESPI_FC_CTRL_TAG_MASK0	0x0fu
+#define MCHP_ESPI_FC_CTRL_TAG_MASK	\
+	SHLU32(MCHP_ESPI_FC_CTRL_TAG_MASK0, MCHP_ESPI_FC_CTRL_TAG_POS)
+
+#define MCHP_ESPI_FC_CTRL_TAG(t)	\
+	((uint32_t)(t) & MCHP_ESPI_FC_CTRL_TAG_MASK)
+
+#define MCHP_ESPI_FC_CTRL_ABORT_POS	16u /* WO */
+#define MCHP_ESPI_FC_CTRL_ABORT		BIT(MCHP_ESPI_FC_CTRL_ABORT_POS)
+
+/* FC IEN */
+#define MCHP_ESPI_FC_IEN_DONE_POS	0u
+#define MCHP_ESPI_FC_IEN_DONE		BIT(MCHP_ESPI_FC_IEN_DONE_POS)
+#define MCHP_ESPI_FC_IEN_CHG_EN_POS	1u
+#define MCHP_ESPI_FC_IEN_CHG_EN		BIT(MCHP_ESPI_FC_IEN_CHG_EN_POS)
+
+/* FC CFG */
+#define MCHP_ESPI_FC_CFG_BUSY_POS	0u /* RO */
+#define MCHP_ESPI_FC_CFG_BUSY		BIT(MCHP_ESPI_FC_CFG_BUSY_POS)
+#define MCHP_ESPI_FC_CFG_ERBSZ_POS	2u  /* RO */
+#define MCHP_ESPI_FC_CFG_ERBSZ_MASK0	0x07u
+#define MCHP_ESPI_FC_CFG_ERBSZ_MASK	\
+	SHLU32(MCHP_ESPI_FC_CFG_ERBSZ_MASK0, MCHP_ESPI_FC_CFG_ERBSZ_POS)
+#define MCHP_ESPI_FC_CFG_ERBSZ_4K	\
+	SHLU32(0x01u, MCHP_ESPI_FC_CFG_ERBSZ_POS)
+#define MCHP_ESPI_FC_CFG_ERBSZ_64K	\
+	SHLU32(0x02u, MCHP_ESPI_FC_CFG_ERBSZ_POS)
+#define MCHP_ESPI_FC_CFG_ERBSZ_4K_64K	\
+	SHLU32(0x03u, MCHP_ESPI_FC_CFG_ERBSZ_POS)
+#define MCHP_ESPI_FC_CFG_ERBSZ_128K	\
+	SHLU32(0x04u, MCHP_ESPI_FC_CFG_ERBSZ_POS)
+#define MCHP_ESPI_FC_CFG_ERBSZ_256K	\
+	SHLU32(0x05u, MCHP_ESPI_FC_CFG_ERBSZ_POS)
+#define MCHP_ESPI_FC_CFG_MAXPLD_POS	8u /* RO */
+#define MCHP_ESPI_FC_CFG_MAXPLD_MASK0	0x07u
+#define MCHP_ESPI_FC_CFG_MAXPLD_MASK	\
+	SHLU32(MCHP_ESPI_FC_CFG_MAXPLD_MASK0, MCHP_ESPI_FC_CFG_MAXPLD_POS)
+#define MCHP_ESPI_FC_CFG_MAXPLD_64B	\
+	SHLU32(0x01u, MCHP_ESPI_FC_CFG_MAXPLD_POS)
+#define MCHP_ESPI_FC_CFG_MAXPLD_128B	\
+	SHLU32(0x02u, MCHP_ESPI_FC_CFG_MAXPLD_POS)
+#define MCHP_ESPI_FC_CFG_MAXPLD_256B	\
+	SHLU32(0x03u, MCHP_ESPI_FC_CFG_MAXPLD_POS)
+#define MCHP_ESPI_FC_CFG_SAFS_SEL_POS	11u
+#define MCHP_ESPI_FC_CFG_SAFS_SEL	BIT(MCHP_ESPI_FC_CFG_SAFS_SEL_POS)
+#define MCHP_ESPI_FC_CFG_MAXRD_POS	12u /* RO */
+#define MCHP_ESPI_FC_CFG_MAXRD_MASK0	0x07u
+#define MCHP_ESPI_FC_CFG_MAXRD_MASK	\
+	SHLU32(MCHP_ESPI_FC_CFG_MAXRD_MASK0, MCHP_ESPI_FC_CFG_MAXRD_POS)
+#define MCHP_ESPI_FC_CFG_MAXRD_64B	\
+	SHLU32(0x01u, MCHP_ESPI_FC_CFG_MAXRD_POS)
+#define MCHP_ESPI_FC_CFG_MAXRD_128B	\
+	SHLU32(0x02u, MCHP_ESPI_FC_CFG_MAXRD_POS)
+#define MCHP_ESPI_FC_CFG_MAXRD_256B	\
+	SHLU32(0x03u, MCHP_ESPI_FC_CFG_MAXRD_POS)
+#define MCHP_ESPI_FC_CFG_MAXRD_512B	\
+	SHLU32(0x04u, MCHP_ESPI_FC_CFG_MAXRD_POS)
+#define MCHP_ESPI_FC_CFG_MAXRD_1K	\
+	SHLU32(0x05u, MCHP_ESPI_FC_CFG_MAXRD_POS)
+#define MCHP_ESPI_FC_CFG_MAXRD_2K	\
+	SHLU32(0x06u, MCHP_ESPI_FC_CFG_MAXRD_POS)
+#define MCHP_ESPI_FC_CFG_MAXRD_4K	\
+	SHLU32(0x07u, MCHP_ESPI_FC_CFG_MAXRD_POS)
+#define MCHP_ESPI_FC_CFG_FORCE_MS_POS	28u /* RW */
+#define MCHP_ESPI_FC_CFG_FORCE_MS_MASK0 0x03u
+#define MCHP_ESPI_FC_CFG_FORCE_MS_MASK	\
+	SHLU32(MCHP_ESPI_FC_CFG_FORCE_MS_MASK0, MCHP_ESPI_FC_CFG_FORCE_MS_POS)
+/* Host (eSPI Master) can select MAFS or SAFS */
+#define MCHP_ESPI_FC_CFG_FORCE_NONE	0u
+/* EC forces eSPI slave HW to only allow MAFS */
+#define MCHP_ESPI_FC_CFG_FORCE_MAFS	\
+	SHLU32(0x02u, MCHP_ESPI_FC_CFG_FORCE_MS_POS)
+/* EC forces eSPI slave HW to only allow SAFS */
+#define MCHP_ESPI_FC_CFG_FORCE_SAFS	\
+	SHLU32(0x03u, MCHP_ESPI_FC_CFG_FORCE_MS_POS)
+
+/* FC STS */
+#define MCHP_ESPI_FC_STS_CHAN_EN_POS	0u /* RO */
+#define MCHP_ESPI_FC_STS_CHAN_EN	BIT(MCHP_ESPI_FC_STS_CHAN_EN_POS)
+
+#define MCHP_ESPI_FC_STS_CHAN_EN_CHG_POS	1u /* RW1C */
+#define MCHP_ESPI_FC_STS_CHAN_EN_CHG	BIT(MCHP_ESPI_FC_STS_CHAN_EN_CHG_POS)
+
+#define MCHP_ESPI_FC_STS_DONE_POS	2u /* RW1C */
+#define MCHP_ESPI_FC_STS_DONE		BIT(MCHP_ESPI_FC_STS_DONE_POS)
+#define MCHP_ESPI_FC_STS_MDIS_POS	3u /* RW1C */
+#define MCHP_ESPI_FC_STS_MDIS		BIT(MCHP_ESPI_FC_STS_MDIS_POS)
+#define MCHP_ESPI_FC_STS_IBERR_POS	4u /* RW1C */
+#define MCHP_ESPI_FC_STS_IBERR		BIT(MCHP_ESPI_FC_STS_IBERR_POS)
+#define MCHP_ESPI_FC_STS_ABS_POS	5u /* RW1C */
+#define MCHP_ESPI_FC_STS_ABS		BIT(MCHP_ESPI_FC_STS_ABS_POS)
+#define MCHP_ESPI_FC_STS_OVRUN_POS	6u /* RW1C */
+#define MCHP_ESPI_FC_STS_OVRUN		BIT(MCHP_ESPI_FC_STS_OVRUN_POS)
+#define MCHP_ESPI_FC_STS_INC_POS	7u /* RW1C */
+#define MCHP_ESPI_FC_STS_INC		BIT(MCHP_ESPI_FC_STS_INC_POS)
+#define MCHP_ESPI_FC_STS_FAIL_POS	8u /* RW1C */
+#define MCHP_ESPI_FC_STS_FAIL		BIT(MCHP_ESPI_FC_STS_FAIL_POS)
+#define MCHP_ESPI_FC_STS_OVFL_POS	9u /* RW1C */
+#define MCHP_ESPI_FC_STS_OVFL		BIT(MCHP_ESPI_FC_STS_OVFL_POS)
+#define MCHP_ESPI_FC_STS_BADREQ_POS	11u /* RW1C */
+#define MCHP_ESPI_FC_STS_BADREQ		BIT(MCHP_ESPI_FC_STS_BADREQ_POS)
+
+#define MCHP_ESPI_FC_STS_ALL_RW1C	0x0bfeu
+
+/*---- MCHP_ESPI_IO_BAR_HOST - eSPI IO Host visible BAR registers ----*/
+
+/*
+ * IOBAR_INH_LSW/MSW 64-bit register: each bit = 1 inhibits an I/O BAR
+ * independent of the BAR's Valid bit.
+ * Logical Device Number = bit position.
+ */
+#define MCHP_ESPI_IOBAR_LDN_MBOX	0u
+#define MCHP_ESPI_IOBAR_LDN_KBC		1u
+#define MCHP_ESPI_IOBAR_LDN_ACPI_EC_0	2u
+#define MCHP_ESPI_IOBAR_LDN_ACPI_EC_1	3u
+#define MCHP_ESPI_IOBAR_LDN_ACPI_EC_2	4u
+#define MCHP_ESPI_IOBAR_LDN_ACPI_EC_3	5u
+#define MCHP_ESPI_IOBAR_LDN_ACPI_EC_4	6u
+#define MCHP_ESPI_IOBAR_LDN_ACPI_PM1	7u
+#define MCHP_ESPI_IOBAR_LDN_PORT92	8u
+#define MCHP_ESPI_IOBAR_LDN_UART_0	9u
+#define MCHP_ESPI_IOBAR_LDN_UART_1	10u
+#define MCHP_ESPI_IOBAR_LDN_IOC		13u
+#define MCHP_ESPI_IOBAR_LDN_MEM		14u
+#define MCHP_ESPI_IOBAR_LDN_GLUE_LOG	15u
+#define MCHP_ESPI_IOBAR_LDN_EMI_0	16u
+#define MCHP_ESPI_IOBAR_LDN_EMI_1	17u
+#define MCHP_ESPI_IOBAR_LDN_EMI_2	18u
+#define MCHP_ESPI_IOBAR_LDN_RTC		20u
+#define MCHP_ESPI_IOBAR_LDN_P80CAP_0	32u	/* BDP Port80 Capture */
+#define MCHP_ESPI_IOBAR_LDN_P80CAP_1	31u	/* BDP Alias Capture */
+#define MCHP_ESPI_IOBAR_LDN_T32B	47u
+#define MCHP_ESPI_IOBAR_LDN_LASIC	48u
+
+/*
+ * IOBAR_INIT: Default address of I/O Plug and Play Super-IO index/data
+ * configuration registers. (Defaults to 0x2E/0x2F)
+ */
+#define MCHP_ESPI_IOBAR_INIT_DFLT	0x2eu
+
+/*
+ * EC_IRQ: A write to bit[0] triggers EC SERIRQ. The actual
+ * SERIRQ slot is configured in MCHP_ESPI_IO_SIRQ.EC_SIRQ
+ */
+#define MCHP_ESPI_EC_IRQ_GEN (1u << 0)
+
+/* 32-bit Host IO BAR */
+#define MCHP_ESPI_IO_BAR_HOST_VALID_POS		0u
+#define MCHP_ESPI_IO_BAR_HOST_VALID		\
+	BIT(MCHP_ESPI_IO_BAR_HOST_VALID_POS)
+#define MCHP_ESPI_IO_BAR_HOST_ADDR_POS		16u
+#define MCHP_ESPI_IO_BAR_HOST_ADDR_MASK0	0xffffu
+#define MCHP_ESPI_IO_BAR_HOST_ADDR_MASK		0xffff0000u
+
+/* Offsets from first SIRQ */
+#define MCHP_ESPI_SIRQ_MBOX_SIRQ	0u
+#define MCHP_ESPI_SIRQ_MBOX_SMI		1u
+#define MCHP_ESPI_SIRQ_KBC_KIRQ		2u
+#define MCHP_ESPI_SIRQ_KBC_MIRQ		3u
+#define MCHP_ESPI_SIRQ_ACPI_EC0		4u
+#define MCHP_ESPI_SIRQ_ACPI_EC1		5u
+#define MCHP_ESPI_SIRQ_ACPI_EC2		6u
+#define MCHP_ESPI_SIRQ_ACPI_EC3		7u
+#define MCHP_ESPI_SIRQ_ACPI_EC4		8u
+#define MCHP_ESPI_SIRQ_UART0		9u
+#define MCHP_ESPI_SIRQ_UART1		10u
+#define MCHP_ESPI_SIRQ_EMI0_HOST	11u
+#define MCHP_ESPI_SIRQ_EMI0_E2H		12u
+#define MCHP_ESPI_SIRQ_EMI1_HOST	13u
+#define MCHP_ESPI_SIRQ_EMI1_E2H		14u
+#define MCHP_ESPI_SIRQ_EMI2_HOST	15u
+#define MCHP_ESPI_SIRQ_EMI2_E2H		16u
+#define MCHP_ESPI_SIRQ_RTC		17u
+#define MCHP_ESPI_SIRQ_EC		18u
+#define MCHP_ESPI_SIRQ_RSVD19		19u
+#define MCHP_ESPI_SIRQ_MAX		20u
+
+/*
+ * Values for Logical Device SIRQ registers.
+ * Unless disabled each logical device must have a unique value
+ * programmed to its SIRQ register.
+ * Values 0x00u through 0x7Fu are sent using VWire host index 0x00
+ * Values 0x80h through 0xFEh are sent using VWire host index 0x01
+ * All registers reset default is 0xFFu (disabled).
+ */
+#define MCHP_ESPI_IO_SIRQ_DIS	0xFFu
+
+/* eSPI Memory component registers */
+/* BM_STS */
+#define MCHP_ESPI_BM_STS_DONE_1_POS	0u /* RW1C */
+#define MCHP_ESPI_BM_STS_DONE_1		BIT(MCHP_ESPI_BM_STS_DONE_1_POS)
+#define MCHP_ESPI_BM_STS_BUSY_1_POS	1u /* RO */
+#define MCHP_ESPI_BM_STS_BUSY_1		BIT(MCHP_ESPI_BM_STS_BUSY_1_POS)
+#define MCHP_ESPI_BM_STS_AB_EC_1_POS	2u /* RW1C */
+#define MCHP_ESPI_BM_STS_AB_EC_1	BIT(MCHP_ESPI_BM_STS_AB_EC_1_POS)
+#define MCHP_ESPI_BM_STS_AB_HOST_1_POS	3u /* RW1C */
+#define MCHP_ESPI_BM_STS_AB_HOST_1	BIT(MCHP_ESPI_BM_STS_AB_HOST_1_POS)
+#define MCHP_ESPI_BM_STS_AB_CH2_1_POS	4u /* RW1C */
+#define MCHP_ESPI_BM_STS_CH2_AB_1	BIT(MCHP_ESPI_BM_STS_AB_CH2_1_POS)
+#define MCHP_ESPI_BM_STS_OVFL_1_POS	5u /* RW1C */
+#define MCHP_ESPI_BM_STS_OVFL_1_CH2	BIT(MCHP_ESPI_BM_STS_OVFL_1_POS)
+#define MCHP_ESPI_BM_STS_OVRUN_1_POS	6u /* RW1C */
+#define MCHP_ESPI_BM_STS_OVRUN_1_CH2	BIT(MCHP_ESPI_BM_STS_OVRUN_1_POS)
+#define MCHP_ESPI_BM_STS_INC_1_POS	7u /* RW1C */
+#define MCHP_ESPI_BM_STS_INC_1		BIT(MCHP_ESPI_BM_STS_INC_1_POS)
+#define MCHP_ESPI_BM_STS_FAIL_1_POS	8u /* RW1C */
+#define MCHP_ESPI_BM_STS_FAIL_1		BIT(MCHP_ESPI_BM_STS_FAIL_1_POS)
+#define MCHP_ESPI_BM_STS_IBERR_1_POS	9u /* RW1C */
+#define MCHP_ESPI_BM_STS_IBERR_1	BIT(MCHP_ESPI_BM_STS_IBERR_1_POS)
+#define MCHP_ESPI_BM_STS_BADREQ_1_POS	11u /* RW1C */
+#define MCHP_ESPI_BM_STS_BADREQ_1	BIT(MCHP_ESPI_BM_STS_BADREQ_1_POS)
+#define MCHP_ESPI_BM_STS_DONE_2_POS	16u /* RW1C */
+#define MCHP_ESPI_BM_STS_DONE_2		BIT(MCHP_ESPI_BM_STS_DONE_2_POS)
+#define MCHP_ESPI_BM_STS_BUSY_2_POS	17u /* RO */
+#define MCHP_ESPI_BM_STS_BUSY_2		BIT(MCHP_ESPI_BM_STS_BUSY_2_POS)
+#define MCHP_ESPI_BM_STS_AB_EC_2_POS	18u /* RW1C */
+#define MCHP_ESPI_BM_STS_AB_EC_2	BIT(MCHP_ESPI_BM_STS_AB_EC_2_POS)
+#define MCHP_ESPI_BM_STS_AB_HOST_2_POS	19u /* RW1C */
+#define MCHP_ESPI_BM_STS_AB_HOST_2	BIT(MCHP_ESPI_BM_STS_AB_HOST_2_POS)
+#define MCHP_ESPI_BM_STS_AB_CH1_2_POS	20u /* RW1C */
+#define MCHP_ESPI_BM_STS_AB_CH1_2	BIT(MCHP_ESPI_BM_STS_AB_CH1_2_POS)
+#define MCHP_ESPI_BM_STS_OVFL_2_POS	21u /* RW1C */
+#define MCHP_ESPI_BM_STS_OVFL_2_CH2	BIT(MCHP_ESPI_BM_STS_OVFL_2_POS)
+#define MCHP_ESPI_BM_STS_OVRUN_2_POS	22u /* RW1C */
+#define MCHP_ESPI_BM_STS_OVRUN_CH2_2	BIT(MCHP_ESPI_BM_STS_OVRUN_2_POS)
+#define MCHP_ESPI_BM_STS_INC_2_POS	23u /* RW1C */
+#define MCHP_ESPI_BM_STS_INC_2		BIT(MCHP_ESPI_BM_STS_INC_2_POS)
+#define MCHP_ESPI_BM_STS_FAIL_2_POS	24u /* RW1C */
+#define MCHP_ESPI_BM_STS_FAIL_2		BIT(MCHP_ESPI_BM_STS_FAIL_2_POS)
+#define MCHP_ESPI_BM_STS_IBERR_2_POS	25u /* RW1C */
+#define MCHP_ESPI_BM_STS_IBERR_2	BIT(MCHP_ESPI_BM_STS_IBERR_2_POS)
+#define MCHP_ESPI_BM_STS_BADREQ_2_POS	27u /* RW1C */
+#define MCHP_ESPI_BM_STS_BADREQ_2	BIT(MCHP_ESPI_BM_STS_BADREQ_2_POS)
+
+#define MCHP_ESPI_BM_STS_ALL_RW1C_1	0x0bfdu
+#define MCHP_ESPI_BM_STS_ALL_RW1C_2	0x0bfd0000u
+
+/* BM_IEN */
+#define MCHP_ESPI_BM1_IEN_DONE_POS	0u
+#define MCHP_ESPI_BM1_IEN_DONE		BIT(MCHP_ESPI_BM1_IEN_DONE_POS)
+#define MCHP_ESPI_BM2_IEN_DONE_POS	16u
+#define MCHP_ESPI_BM2_IEN_DONE		BIT(MCHP_ESPI_BM2_IEN_DONE_POS)
+
+/* BM_CFG */
+#define MCHP_ESPI_BM1_CFG_TAG_POS	0u
+#define MCHP_ESPI_BM1_CFG_TAG_MASK0	0x0fu
+#define MCHP_ESPI_BM1_CFG_TAG_MASK	0x0fu
+#define MCHP_ESPI_BM2_CFG_TAG_POS	16u
+#define MCHP_ESPI_BM2_CFG_TAG_MASK0	0x0fu
+#define MCHP_ESPI_BM2_CFG_TAG_MASK	0x0f0000u
+
+/* BM1_CTRL */
+#define MCHP_ESPI_BM1_CTRL_START_POS	0u /* WO */
+#define MCHP_ESPI_BM1_CTRL_START	BIT(MCHP_ESPI_BM1_CTRL_START_POS)
+#define MCHP_ESPI_BM1_CTRL_ABORT_POS	1u /* WO */
+#define MCHP_ESPI_BM1_CTRL_ABORT	BIT(MCHP_ESPI_BM1_CTRL_ABORT_POS)
+#define MCHP_ESPI_BM1_CTRL_EN_INC_POS	2u /* RW */
+#define MCHP_ESPI_BM1_CTRL_EN_INC	BIT(MCHP_ESPI_BM1_CTRL_EN_INC_POS)
+#define MCHP_ESPI_BM1_CTRL_WAIT_NB2_POS 3u  /* RW */
+#define MCHP_ESPI_BM1_CTRL_WAIT_NB2	BIT(MCHP_ESPI_BM1_CTRL_WAIT_NB2_POS)
+#define MCHP_ESPI_BM1_CTRL_CTYPE_POS	8u
+#define MCHP_ESPI_BM1_CTRL_CTYPE_MASK0	0x03u
+#define MCHP_ESPI_BM1_CTRL_CTYPE_MASK	\
+	SHLU32(MCHP_ESPI_BM1_CTRL_CTYPE_MASK0, MCHP_ESPI_BM1_CTRL_CTYPE_POS)
+#define MCHP_ESPI_BM1_CTRL_CTYPE_RD_ADDR32	0x00u
+#define MCHP_ESPI_BM1_CTRL_CTYPE_WR_ADDR32	\
+	SHLU32(0x01u, MCHP_ESPI_BM1_CTRL_CTYPE_POS)
+#define MCHP_ESPI_BM1_CTRL_CTYPE_RD_ADDR64	\
+	SHLU32(0x02u, MCHP_ESPI_BM1_CTRL_CTYPE_POS)
+#define MCHP_ESPI_BM1_CTRL_CTYPE_WR_ADDR64	\
+	SHLU32(0x03u, MCHP_ESPI_BM1_CTRL_CTYPE_POS)
+#define MCHP_ESPI_BM1_CTRL_LEN_POS	16u
+#define MCHP_ESPI_BM1_CTRL_LEN_MASK0	0x1fffu
+#define MCHP_ESPI_BM1_CTRL_LEN_MASK	0x1fff0000u
+
+/* BM1_EC_ADDR_LSW */
+#define MCHP_ESPI_BM1_EC_ADDR_LSW_MASK	0xfffffffcu
+
+/* BM2_CTRL */
+#define MCHP_ESPI_BM2_CTRL_START_POS	0u /* WO */
+#define MCHP_ESPI_BM2_CTRL_START	BIT(MCHP_ESPI_BM2_CTRL_START_POS)
+#define MCHP_ESPI_BM2_CTRL_ABORT_POS	1u /* WO */
+#define MCHP_ESPI_BM2_CTRL_ABORT	BIT(MCHP_ESPI_BM2_CTRL_ABORT_POS)
+#define MCHP_ESPI_BM2_CTRL_EN_INC_POS	2u /* RW */
+#define MCHP_ESPI_BM2_CTRL_EN_INC	BIT(MCHP_ESPI_BM2_CTRL_EN_INC_POS)
+#define MCHP_ESPI_BM2_CTRL_WAIT_NB2_POS 3u /* RW */
+#define MCHP_ESPI_BM2_CTRL_WAIT_NB2	BIT(MCHP_ESPI_BM2_CTRL_WAIT_NB2_POS)
+#define MCHP_ESPI_BM2_CTRL_CTYPE_POS		8u
+#define MCHP_ESPI_BM2_CTRL_CTYPE_MASK0		0x03u
+#define MCHP_ESPI_BM2_CTRL_CTYPE_MASK		0x0300u
+#define MCHP_ESPI_BM2_CTRL_CTYPE_RD_ADDR32	0x00u
+#define MCHP_ESPI_BM2_CTRL_CTYPE_WR_ADDR32	0x0100u
+#define MCHP_ESPI_BM2_CTRL_CTYPE_RD_ADDR64	0x0200u
+#define MCHP_ESPI_BM2_CTRL_CTYPE_WR_ADDR64	0x0300u
+#define MCHP_ESPI_BM2_CTRL_LEN_POS		16u
+#define MCHP_ESPI_BM2_CTRL_LEN_MASK0		0x1fffu
+#define MCHP_ESPI_BM2_CTRL_LEN_MASK		0x1fff0000u
+
+/* BM2_EC_ADDR_LSW */
+#define MCHP_ESPI_BM2_EC_ADDR_LSW_MASK	0xfffffffcu
+
+/*
+ * MCHP_ESPI_MEM_BAR_EC @ 0x400F3930
+ * Half-word H0 of each EC Memory BAR contains
+ * Memory BAR memory address mask bits in bits[7:0]
+ * Logical Device Number in bits[13:8]
+ */
+#define MCHP_ESPI_EBAR_H0_MEM_MASK_POS	0u
+#define MCHP_ESPI_EBAR_H0_MEM_MASK_MASK 0xffu
+#define MCHP_ESPI_EBAR_H0_LDN_POS	8u
+#define MCHP_ESPI_EBAR_H0_LDN_MASK0	0x3fu
+#define MCHP_ESPI_EBAR_H0_LDN_MASK	0x3f00u
+
+/*
+ * MCHP_ESPI_MEM_BAR_HOST @ 0x400F3B30
+ * Each Host BAR contains:
+ * bit[0] (RW) = Valid bit
+ * bits[15:1] = Reserved, read-only 0
+ * bits[47:16] (RW) = bits[31:0] of the Host Memory address.
+ */
+
+/* Memory BAR Host address valid */
+#define MCHP_ESPI_HBAR_VALID_POS	0u
+#define MCHP_ESPI_HBAR_VALID_MASK	0x01u
+/*
+ * Host address is in bits[47:16] of the HBAR
+ * HBAR's are spaced every 10 bytes (80 bits) but
+ * only implement bits[47:0]
+ */
+#define MCHP_ESPI_HBAR_VALID_OFS	0x00u	/* byte 0 */
+/* 32-bit Host Address */
+#define MCHP_ESPI_HBAR_ADDR_B0_OFS	0x02u	/* byte 2 */
+#define MCHP_ESPI_HBAR_ADDR_B1_OFS	0x03u	/* byte 3 */
+#define MCHP_ESPI_HBAR_ADDR_B2_OFS	0x04u	/* byte 4 */
+#define MCHP_ESPI_HBAR_ADDR_B3_OFS	0x05u	/* byte 5 */
+
+#define MCHP_EC_SRAM_BAR_H0_VALID_POS		0u
+#define MCHP_EC_SRAM_BAR_H0_VALID_MASK0		0x01u
+#define MCHP_EC_SRAM_BAR_H0_VALID_MASK		0x01u
+#define MCHP_EC_SRAM_BAR_H0_VALID		0x01u
+#define MCHP_EC_SRAM_BAR_H0_ACCESS_POS		1u
+#define MCHP_EC_SRAM_BAR_H0_ACCESS_MASK0	0x03u
+#define MCHP_EC_SRAM_BAR_H0_ACCESS_MASK		0x06u
+#define MCHP_EC_SRAM_BAR_H0_ACCESS_NONE		0x00u
+#define MCHP_EC_SRAM_BAR_H0_ACCESS_RO		0x02u
+#define MCHP_EC_SRAM_BAR_H0_ACCESS_WO		0x04u
+#define MCHP_EC_SRAM_BAR_H0_ACCESS_RW		0x06u
+#define MCHP_EC_SRAM_BAR_H0_SIZE_POS		4u
+#define MCHP_EC_SRAM_BAR_H0_SIZE_MASK0		0x0fu
+#define MCHP_EC_SRAM_BAR_H0_SIZE_MASK		0xf0u
+#define MCHP_EC_SRAM_BAR_H0_SIZE_1B		0x00u
+#define MCHP_EC_SRAM_BAR_H0_SIZE_2B		0x10u
+#define MCHP_EC_SRAM_BAR_H0_SIZE_4B		0x20u
+#define MCHP_EC_SRAM_BAR_H0_SIZE_8B		0x30u
+#define MCHP_EC_SRAM_BAR_H0_SIZE_16B		0x40u
+#define MCHP_EC_SRAM_BAR_H0_SIZE_32B		0x50u
+#define MCHP_EC_SRAM_BAR_H0_SIZE_64B		0x60u
+#define MCHP_EC_SRAM_BAR_H0_SIZE_128B		0x70u
+#define MCHP_EC_SRAM_BAR_H0_SIZE_256B		0x80u
+#define MCHP_EC_SRAM_BAR_H0_SIZE_512B		0x90u
+#define MCHP_EC_SRAM_BAR_H0_SIZE_1KB		0xa0u
+#define MCHP_EC_SRAM_BAR_H0_SIZE_2KB		0xb0u
+#define MCHP_EC_SRAM_BAR_H0_SIZE_4KB		0xc0u
+#define MCHP_EC_SRAM_BAR_H0_SIZE_8KB		0xd0u
+#define MCHP_EC_SRAM_BAR_H0_SIZE_16KB		0xe0u
+#define MCHP_EC_SRAM_BAR_H0_SIZE_32KB		0xf0u
+/* EC and Host SRAM BAR start offset of EC or Host memory address */
+#define MCHP_EC_SRAM_BAR_MADDR_OFS1		2u
+#define MCHP_EC_SRAM_BAR_MADDR_OFS2		4u
+
+/* Interfaces to any C modules */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Array indices for eSPI IO BAR Host and EC-only register structures */
+enum espi_io_bar_idx {
+	IOB_IOC = 0,
+	IOB_MEM,
+	IOB_MBOX,
+	IOB_KBC,
+	IOB_ACPI_EC0,
+	IOB_ACPI_EC1,
+	IOB_ACPI_EC2,
+	IOB_ACPI_EC3,
+	IOB_ACPI_EC4,
+	IOB_ACPI_PM1,
+	IOB_PORT92,
+	IOB_UART0,
+	IOB_UART1,
+	IOB_EMI0,
+	IOB_EMI1,
+	IOB_EMI2,
+	IOB_P80BD,		/* MEC152x IOB_P80_CAP0 */
+	IOB_P80BD_ALIAS,	/* MEC152x IOB_P80_CAP1 */
+	IOB_RTC,
+	IOB_RSVD19,
+	IOB_T32B,
+	IOB_RSVD21,
+	IOB_GLUE,
+	IOB_MAX
+};
+
+/** @brief Serial IRQ byte register indices */
+enum espi_io_sirq_idx {
+	SIRQ_MBOX = 0,	   SIRQ_MBOX_SMI,     SIRQ_KBC_KIRQ,
+	SIRQ_KBC_MIRQ,	   SIRQ_ACPI_EC0_OBF, SIRQ_ACPI_EC1_OBF,
+	SIRQ_ACPI_EC2_OBF, SIRQ_ACPI_EC3_OBF, SIRQ_ACPI_EC4_OBF,
+	SIRQ_UART0,	   SIRQ_UART1,	      SIRQ_EMI0_HEV,
+	SIRQ_EMI0_E2H,	   SIRQ_EMI1_HEV,     SIRQ_EMI1_E2H,
+	SIRQ_EMI2_HEV,	   SIRQ_EMI2_E2H,     SIRQ_RTC,
+	SIRQ_EC,	   SIRQ_MAX
+};
+
+enum espi_mem_bar_idx {
+	MEMB_MBOX = 0,
+	MEMB_ACPI_EC0,
+	MEMB_ACPI_EC1,
+	MEMB_ACPI_EC2,
+	MEMB_ACPI_EC3,
+	MEMB_ACPI_EC4,
+	MEMB_EMI0,
+	MEMB_EMI1,
+	MEMB_EMI2,
+	MEMB_T32B,
+	MEMB_MAX
+};
+
+/* eSPI */
+struct espi_io_mbar { /* 80-bit register */
+	volatile uint16_t  LDN_MASK;
+	volatile uint16_t  RESERVED[4];
+}; /* Size = 10 (0xa) */
+
+struct espi_mbar_host {
+	volatile uint16_t  VALID;
+	volatile uint16_t  HADDR_LSH;
+	volatile uint16_t  HADDR_MSH;
+	volatile uint16_t  RESERVED[2];
+}; /* Size = 10 (0xa) */
+
+struct espi_sram_bar {
+	volatile uint16_t  VACCSZ;
+	volatile uint16_t  EC_SRAM_BASE_LSH;
+	volatile uint16_t  EC_SRAM_BASE_MSH;
+	volatile uint16_t  RESERVED[2];
+}; /* Size = 10 (0xa) */
+
+struct espi_sram_host_bar {
+	volatile uint16_t  ACCSZ;
+	volatile uint16_t  HBASE_LSH;
+	volatile uint16_t  HBASE_MSH;
+	volatile uint16_t  RESERVED[2];
+}; /* Size = 10 (0xa) */
+
+/** @brief eSPI Capabilities, I/O and Memory components in one structure */
+struct espi_iom_regs { /* @ 0x400F3400 */
+	volatile uint8_t   RTIDX;		/* @ 0x0000 */
+	volatile uint8_t   RTDAT;		/* @ 0x0001 */
+	volatile uint16_t  RESERVED;
+	volatile uint32_t  RESERVED1[63];
+	volatile uint32_t  PCLC[3];		/* @ 0x0100 */
+	volatile uint32_t  PCERR[2];		/* @ 0x010C */
+	volatile uint32_t  PCSTS;		/* @ 0x0114 */
+	volatile uint32_t  PCIEN;		/* @ 0x0118 */
+	volatile uint32_t  RESERVED2;
+	volatile uint32_t  PCBINH[2];		/* @ 0x0120 */
+	volatile uint32_t  PCBINIT;		/* @ 0x0128 */
+	volatile uint32_t  PCECIRQ;		/* @ 0x012C */
+	volatile uint32_t  PCCKNP;		/* @ 0x0130 */
+	volatile uint32_t  PCBARI[29];		/* @ 0x0134 */
+	volatile uint32_t  RESERVED3[30];
+	volatile uint32_t  PCLTRSTS;		/* @ 0x0220 */
+	volatile uint32_t  PCLTREN;		/* @ 0x0224 */
+	volatile uint32_t  PCLTRCTL;		/* @ 0x0228 */
+	volatile uint32_t  PCLTRM;		/* @ 0x022C */
+	volatile uint32_t  RESERVED4[4];
+	volatile uint32_t  OOBRXA[2];		/* @ 0x0240 */
+	volatile uint32_t  OOBTXA[2];		/* @ 0x0248 */
+	volatile uint32_t  OOBRXL;		/* @ 0x0250 */
+	volatile uint32_t  OOBTXL;		/* @ 0x0254 */
+	volatile uint32_t  OOBRXC;		/* @ 0x0258 */
+	volatile uint32_t  OOBRXIEN;		/* @ 0x025C */
+	volatile uint32_t  OOBRXSTS;		/* @ 0x0260 */
+	volatile uint32_t  OOBTXC;		/* @ 0x0264 */
+	volatile uint32_t  OOBTXIEN;		/* @ 0x0268 */
+	volatile uint32_t  OOBTXSTS;		/* @ 0x026C */
+	volatile uint32_t  RESERVED5[4];
+	volatile uint32_t  FCFA[2];		/* @ 0x0280 */
+	volatile uint32_t  FCBA[2];		/* @ 0x0288 */
+	volatile uint32_t  FCLEN;		/* @ 0x0290 */
+	volatile uint32_t  FCCTL;		/* @ 0x0294 */
+	volatile uint32_t  FCIEN;		/* @ 0x0298 */
+	volatile uint32_t  FCCFG;		/* @ 0x029C */
+	volatile uint32_t  FCSTS;		/* @ 0x02A0 */
+	volatile uint32_t  RESERVED6[3];
+	volatile uint32_t  VWSTS;		/* @ 0x02B0 */
+	volatile uint32_t  RESERVED7[11];
+	volatile uint8_t   CAPID;		/* @ 0x02E0 */
+	volatile uint8_t   CAP0;		/* @ 0x02E1 */
+	volatile uint8_t   CAP1;		/* @ 0x02E2 */
+	volatile uint8_t   CAPPC;		/* @ 0x02E3 */
+	volatile uint8_t   CAPVW;		/* @ 0x02E4 */
+	volatile uint8_t   CAPOOB;		/* @ 0x02E5 */
+	volatile uint8_t   CAPFC;		/* @ 0x02E6 */
+	volatile uint8_t   PCRDY;		/* @ 0x02E7 */
+	volatile uint8_t   OOBRDY;		/* @ 0x02E8 */
+	volatile uint8_t   FCRDY;		/* @ 0x02E9 */
+	volatile uint8_t   ERIS;		/* @ 0x02EA */
+	volatile uint8_t   ERIE;		/* @ 0x02EB */
+	volatile uint8_t   PLTSRC;		/* @ 0x02EC */
+	volatile uint8_t   VWRDY;		/* @ 0x02ED */
+	volatile uint8_t   SAFEBS;		/* @ 0x02EE */
+	volatile uint8_t   RESERVED8;
+	volatile uint32_t  RESERVED9[16];
+	volatile uint32_t  ACTV;		/* @ 0x0330 */
+	volatile uint32_t  IOHBAR[29];		/* @ 0x0334 */
+	volatile uint32_t  RESERVED10;
+	volatile uint8_t   SIRQ[19];		/* @ 0x03ac */
+	volatile uint8_t   RESERVED11;
+	volatile uint32_t  RESERVED12[12];
+	volatile uint32_t  VWERREN;		/* @ 0x03f0 */
+	volatile uint32_t  RESERVED13[79];
+	struct espi_io_mbar MBAR[10];		/* @ 0x0530 */
+	volatile uint32_t  RESERVED14[6];
+	struct espi_sram_bar SRAMBAR[2];	/* @ 0x05AC */
+	volatile uint32_t  RESERVED15[16];
+	volatile uint32_t  BM_STATUS;		/* @ 0x0600 */
+	volatile uint32_t  BM_IEN;		/* @ 0x0604 */
+	volatile uint32_t  BM_CONFIG;		/* @ 0x0608 */
+	volatile uint32_t  RESERVED16;
+	volatile uint32_t  BM_CTRL1;		/* @ 0x0610 */
+	volatile uint32_t  BM_HADDR1_LSW;	/* @ 0x0614 */
+	volatile uint32_t  BM_HADDR1_MSW;	/* @ 0x0618 */
+	volatile uint32_t  BM_EC_ADDR1_LSW;	/* @ 0x061C */
+	volatile uint32_t  BM_EC_ADDR1_MSW;	/* @ 0x0620 */
+	volatile uint32_t  BM_CTRL2;		/* @ 0x0624 */
+	volatile uint32_t  BM_HADDR2_LSW;	/* @ 0x0628 */
+	volatile uint32_t  BM_HADDR2_MSW;	/* @ 0x062C */
+	volatile uint32_t  BM_EC_ADDR2_LSW;	/* @ 0x0630 */
+	volatile uint32_t  BM_EC_ADDR2_MSW;	/* @ 0x0634 */
+	volatile uint32_t  RESERVED17[62];
+	struct espi_mbar_host HMBAR[10];	/* @ 0x0730 */
+	volatile uint32_t  RESERVED18[6];
+	struct espi_sram_host_bar HSRAMBAR[2];	/* @ 0x07AC */
+}; /* Size = 1984 (0x7c0) */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* #ifndef _MEC172X_ESPI_IO_H */

--- a/soc/arm/microchip_mec/mec172x/reg/mec172x_espi_saf.h
+++ b/soc/arm/microchip_mec/mec172x/reg/mec172x_espi_saf.h
@@ -1,0 +1,544 @@
+/*
+ * Copyright (c) 2021 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _MEC172X_ESPI_SAF_H_
+#define _MEC172X_ESPI_SAF_H_
+
+#include <stdint.h>
+#include <stddef.h>
+
+#define MCHP_ESPI_SAF_BASE_ADDR		0x40008000u
+#define MCHP_ESPI_SAF_COMM_BASE_ADDR	0x40071000u
+
+/* SAF hardware supports up to 2 external SPI flash devices */
+#define MCHP_ESPI_SAF_CS_MAX		2
+
+/* Three TAG Map registers */
+#define MCHP_ESPI_SAF_TAGMAP_MAX	3
+/* 17 protection regions */
+#define MCHP_ESPI_SAF_PR_MAX		17
+
+#define MCHP_SAF_FL_CM_PRF_CS0_OFS	0x1b0u
+#define MCHP_SAF_FL_CM_PRF_CS1_OFS	0x1b2u
+
+#define MCHP_ESPI_SAF_BASE		0x40008000u
+#define MCHP_ESPI_SAF_COMM_BASE		0x40071000u
+#define MCHP_ESPI_SAF_COMM_MODE_OFS	0x2b8u
+#define MCHP_ESPI_SAF_COMM_MODE_ADDR	(MCHP_ESPI_SAF_COMM_BASE_ADDR +	\
+					 MCHP_ESPI_SAF_COMM_MODE_OFS)
+
+/* SAF Protection region described by 4 32-bit registers. 17 regions */
+#define MCHP_ESPI_SAF_PROT_MAX		17u
+
+/* Register bit definitions */
+
+/* SAF EC Portal Command register */
+#define MCHP_SAF_ECP_CMD_OFS		0x18u
+#define MCHP_SAF_ECP_CMD_MASK		0xff00ffffu
+#define MCHP_SAF_ECP_CMD_PUT_POS	0
+#define MCHP_SAF_ECP_CMD_PUT_MASK	0xffu
+#define MCHP_SAF_ECP_CMD_PUT_FLASH_NP	0x0au
+#define MCHP_SAF_ECP_CMD_CTYPE_POS	8
+#define MCHP_SAF_ECP_CMD_CTYPE_READ0	0x00u
+#define MCHP_SAF_ECP_CMD_CTYPE_WRITE0	0x01u
+#define MCHP_SAF_ECP_CMD_CTYPE_ERASE0	0x02u
+#define MCHP_SAF_ECP_CMD_CTYPE_MAX0	0x03u
+#define MCHP_SAF_ECP_CMD_CTYPE_MASK	0xff00ul
+#define MCHP_SAF_ECP_CMD_CTYPE_READ	0x0000ul
+#define MCHP_SAF_ECP_CMD_CTYPE_WRITE	0x0100ul
+#define MCHP_SAF_ECP_CMD_CTYPE_ERASE	0x0200ul
+#define MCHP_SAF_ECP_CMD_LEN_POS	24
+#define MCHP_SAF_ECP_CMD_LEN_MASK0	0xffu
+#define MCHP_SAF_ECP_CMD_LEN_MASK	0xff000000ul
+/* Read/Write request size (1 <= reqlen <= 64) bytes */
+#define MCHP_SAF_ECP_CMD_RW_LEN_MIN	1u
+#define MCHP_SAF_ECP_CMD_RW_LEN_MAX	64u
+/* Only three erase sizes are supported encoded as */
+#define MCHP_SAF_ECP_CMD_ERASE_4K	0u
+#define MCHP_SAF_ECP_CMD_ERASE_32K	BIT(24)
+#define MCHP_SAF_ECP_CMD_ERASE_64K	BIT(25)
+
+/* SAF EC Portal Flash Address register */
+#define MCHP_SAF_ECP_FLAR_OFS		0x1cu
+#define MCHP_SAF_ECP_FLAR_MASK		0xffffffffu
+
+/* SAF EC Portal Start register */
+#define MCHP_SAF_ECP_START_OFS		0x20u
+#define MCHP_SAF_ECP_START_MASK		0x01u
+#define MCHP_SAF_ECP_START		BIT(0)
+
+/* SAF EC Portal Buffer Address register */
+#define MCHP_SAF_ECP_BFAR_OFS		0x24u
+#define MCHP_SAF_ECP_BFAR_MASK		0xfffffffcu
+
+/* SAF EC Portal Status register */
+#define MCHP_SAF_ECP_STS_OFS		0x28u
+#define MCHP_SAF_ECP_STS_MASK		0x1ffu
+#define MCHP_SAF_ECP_STS_ERR_MASK	0x1fcu
+#define MCHP_SAF_ECP_STS_DONE		BIT(0)
+#define MCHP_SAF_ECP_STS_DONE_TST	BIT(1)
+#define MCHP_SAF_ECP_STS_TMOUT		BIT(2)
+#define MCHP_SAF_ECP_STS_OOR		BIT(3)
+#define MCHP_SAF_ECP_STS_AV		BIT(4)
+#define MCHP_SAF_ECP_STS_BND_4K		BIT(5)
+#define MCHP_SAF_ECP_STS_ERSZ		BIT(6)
+#define MCHP_SAF_ECP_STS_ST_OVFL	BIT(7)
+#define MCHP_SAF_ECP_STS_BAD_REQ	BIT(8)
+
+/* SAF EC Portal Interrupt Enable register */
+#define MCHP_SAF_ECP_INTEN_OFS		0x2cu
+#define MCHP_SAF_ECP_INTEN_MASK		0x01u
+#define MCHP_SAF_ECP_INTEN_DONE		BIT(0)
+
+/* SAF Flash Configuratin Size Limit register */
+#define MCHP_SAF_FL_CFG_SIZE_LIM_OFS	0x30u
+#define MCHP_SAF_FL_CFG_SIZE_LIM_MASK	0xffffffffu
+
+/* SAF Flash Configuration Threshold register */
+#define MCHP_SAF_FL_CFG_THRH_OFS	0x34u
+#define MCHP_SAF_FL_CFG_THRH_MASK	0xffffffffu
+
+/* SAF Flash Configuration Miscellaneous register */
+#define MCHP_SAF_FL_CFG_MISC_OFS	0x38u
+#define MCHP_SAF_FL_CFG_MISC_MASK	0x000030f3u
+#define MCHP_SAF_FL_CFG_MISC_PFOE_MASK	0x03u
+#define MCHP_SAF_FL_CFG_MISC_PFOE_DFLT	0x00u
+#define MCHP_SAF_FL_CFG_MISC_PFOE_EXP	0x03u
+#define MCHP_SAF_FL_CFG_MISC_CS0_4BM	BIT(4)
+#define MCHP_SAF_FL_CFG_MISC_CS1_4BM	BIT(5)
+#define MCHP_SAF_FL_CFG_MISC_CS0_CPE	BIT(6)
+#define MCHP_SAF_FL_CFG_MISC_CS1_CPE	BIT(7)
+#define MCHP_SAF_FL_CFG_MISC_SAF_EN	BIT(12)
+#define MCHP_SAF_FL_CFG_MISC_SAF_LOCK	BIT(13)
+
+/* SAF eSPI Monitor Status register */
+#define MCHP_SAF_ESPI_MON_STATUS_OFS	0x3cu
+#define MCHP_SAF_ESPI_MON_STATUS_MASK	0x1fu
+#define MCHP_SAF_ESPI_MON_STS_TMOUT	BIT(0)
+#define MCHP_SAF_ESPI_MON_STS_OOR	BIT(1)
+#define MCHP_SAF_ESPI_MON_STS_AV	BIT(2)
+#define MCHP_SAF_ESPI_MON_STS_BND_4K	BIT(3)
+#define MCHP_SAF_ESPI_MON_STS_ERSZ	BIT(4)
+
+/* SAF eSPI Monitor Interrupt Enable register */
+#define MCHP_SAF_ESPI_MON_INTEN_OFS	0x40u
+#define MCHP_SAF_ESPI_MON_INTEN_MASK	0x1fu
+#define MCHP_SAF_ESPI_MON_INTEN_TMOUT	BIT(0)
+#define MCHP_SAF_ESPI_MON_INTEN_OOR	BIT(1)
+#define MCHP_SAF_ESPI_MON_INTEN_AV	BIT(2)
+#define MCHP_SAF_ESPI_MON_INTEN_BND_4K	BIT(3)
+#define MCHP_SAF_ESPI_MON_INTEN_ERSZ	BIT(4)
+
+/* SAF EC Portal Busy register */
+#define MCHP_SAF_ECP_BUSY_OFS		0x44u
+#define MCHP_SAF_ECP_BUSY_MASK		0x01u
+#define MCHP_SAF_ECP_BUSY		BIT(0)
+
+/* SAF CS0/CS1 Opcode A registers */
+#define MCHP_SAF_CS0_OPA_OFS		0x4cu
+#define MCHP_SAF_CS1_OPA_OFS		0x5cu
+#define MCHP_SAF_CS_OPA_MASK		0xffffffffu
+#define MCHP_SAF_CS_OPA_WE_POS		0
+#define MCHP_SAF_CS_OPA_WE_MASK		0xfful
+#define MCHP_SAF_CS_OPA_SUS_POS		8
+#define MCHP_SAF_CS_OPA_SUS_MASK	0xff00ul
+#define MCHP_SAF_CS_OPA_RSM_POS		16
+#define MCHP_SAF_CS_OPA_RSM_MASK	0xff0000ul
+#define MCHP_SAF_CS_OPA_POLL1_POS	24
+#define MCHP_SAF_CS_OPA_POLL1_MASK	0xff000000ul
+
+/* SAF CS0/CS1 Opcode B registers */
+#define MCHP_SAF_CS0_OPB_OFS		0x50u
+#define MCHP_SAF_CS1_OPB_OFS		0x60u
+#define MCHP_SAF_CS_OPB_OFS		0xffffffffu
+#define MCHP_SAF_CS_OPB_ER0_POS		0
+#define MCHP_SAF_CS_OPB_ER0_MASK	0xffu
+#define MCHP_SAF_CS_OPB_ER1_POS		8
+#define MCHP_SAF_CS_OPB_ER1_MASK	0xff00ul
+#define MCHP_SAF_CS_OPB_ER2_POS		16
+#define MCHP_SAF_CS_OPB_ER2_MASK	0xff0000ul
+#define MCHP_SAF_CS_OPB_PGM_POS		24
+#define MCHP_SAF_CS_OPB_PGM_MASK	0xff000000ul
+
+/* SAF CS0/CS1 Opcode C registers */
+#define MCHP_SAF_CS0_OPC_OFS		0x54u
+#define MCHP_SAF_CS1_OPC_OFS		0x64u
+#define MCHP_SAF_CS_OPC_MASK		0xffffffffu
+#define MCHP_SAF_CS_OPC_RD_POS		0
+#define MCHP_SAF_CS_OPC_RD_MASK		0xffu
+#define MCHP_SAF_CS_OPC_MNC_POS		8
+#define MCHP_SAF_CS_OPC_MNC_MASK	0xff00ul
+#define MCHP_SAF_CS_OPC_MC_POS		16
+#define MCHP_SAF_CS_OPC_MC_MASK		0xff0000ul
+#define MCHP_SAF_CS_OPC_POLL2_POS	24
+#define MCHP_SAF_CS_OPC_POLL2_MASK	0xff000000ul
+
+/* SAF CS0/CS1 registers */
+#define MCHP_SAF_CS0_DESCR_OFS		0x58u
+#define MCHP_SAF_CS1_DESCR_OFS		0x68u
+#define MCHP_SAF_CS_DESCR_MASK		0x0000ff0fu
+#define MCHP_SAF_CS_DESCR_ENTC_POS	0
+#define MCHP_SAF_CS_DESCR_ENTC_MASK	0x0fu
+#define MCHP_SAF_CS_DESCR_RDC_POS	8
+#define MCHP_SAF_CS_DESCR_RDC_MASK	0x0f00ul
+#define MCHP_SAF_CS_DESCR_SZC_POS	12
+#define MCHP_SAF_CS_DESCR_SZC_MASK	0xf000ul
+
+/* SAF Flash Configuration General Descriptors register */
+#define MCHP_SAF_FL_CFG_GEN_DESCR_OFS		0x6cu
+#define MCHP_SAF_FL_CFG_GEN_DESCR_MASK		0x0000ff0fu
+/* value for standard 16 descriptor programming */
+#define MCHP_SAF_FL_CFG_GEN_DESCR_STD		0x0000ee0cu
+#define MCHP_SAF_FL_CFG_GEN_DESCR_EXC_POS	0
+#define MCHP_SAF_FL_CFG_GEN_DESCR_EXC_MASK	0x0fu
+#define MCHP_SAF_FL_CFG_GEN_DESCR_POLL1_POS	8
+#define MCHP_SAF_FL_CFG_GEN_DESCR_POLL1_MASK	\
+	SHLU32(0x0Fu, MCHP_SAF_FL_CFG_GEN_DESCR_POLL1_POS)
+
+#define MCHP_SAF_FL_CFG_GEN_DESCR_POLL2_POS	12
+#define MCHP_SAF_FL_CFG_GEN_DESCR_POLL2_MASK	\
+	SHLU32(0x0Fu, MCHP_SAF_FL_CFG_GEN_DESCR_POLL2_POS)
+
+/* SAF Protection Lock register */
+#define MCHP_SAF_PROT_LOCK_OFS		0x70u
+#define MCHP_SAF_PROT_LOCK_MASK		0x1ffffu
+#define MCHP_SAF_PROT_LOCK0		BIT(0)
+#define MCHP_SAF_PROT_LOCK1		BIT(1)
+#define MCHP_SAF_PROT_LOCK2		BIT(2)
+#define MCHP_SAF_PROT_LOCK3		BIT(3)
+#define MCHP_SAF_PROT_LOCK4		BIT(4)
+#define MCHP_SAF_PROT_LOCK5		BIT(5)
+#define MCHP_SAF_PROT_LOCK6		BIT(6)
+#define MCHP_SAF_PROT_LOCK7		BIT(7)
+#define MCHP_SAF_PROT_LOCK8		BIT(8)
+#define MCHP_SAF_PROT_LOCK9		BIT(9)
+#define MCHP_SAF_PROT_LOCK10		BIT(10)
+#define MCHP_SAF_PROT_LOCK11		BIT(11)
+#define MCHP_SAF_PROT_LOCK12		BIT(12)
+#define MCHP_SAF_PROT_LOCK13		BIT(13)
+#define MCHP_SAF_PROT_LOCK14		BIT(14)
+#define MCHP_SAF_PROT_LOCK15		BIT(15)
+#define MCHP_SAF_PROT_LOCK16		BIT(16)
+
+/* SAF Protection Dirty register */
+#define MCHP_SAF_PROT_DIRTY_OFS		0x74u
+#define MCHP_SAF_PROT_DIRTY_MASK	0xfffu
+#define MCHP_SAF_PROT_DIRTY0		BIT(0)
+#define MCHP_SAF_PROT_DIRTY1		BIT(1)
+#define MCHP_SAF_PROT_DIRTY2		BIT(2)
+#define MCHP_SAF_PROT_DIRTY3		BIT(3)
+#define MCHP_SAF_PROT_DIRTY4		BIT(4)
+#define MCHP_SAF_PROT_DIRTY5		BIT(5)
+#define MCHP_SAF_PROT_DIRTY6		BIT(6)
+#define MCHP_SAF_PROT_DIRTY7		BIT(7)
+#define MCHP_SAF_PROT_DIRTY8		BIT(8)
+#define MCHP_SAF_PROT_DIRTY9		BIT(9)
+#define MCHP_SAF_PROT_DIRTY10		BIT(10)
+#define MCHP_SAF_PROT_DIRTY11		BIT(11)
+
+/* SAF Tag Map 0 register */
+#define MCHP_SAF_TAG_MAP0_OFS		0x78u
+#define MCHP_SAF_TAG_MAP0_MASK		0x77777777u
+#define MCHP_SAF_TAG_MAP0_DFLT_VAL	0x23221100u
+#define MCHP_SAF_TAG_MAP0_STM0_POS	0
+#define MCHP_SAF_TAG_MAP0_STM0_MASK	0x07u
+#define MCHP_SAF_TAG_MAP0_STM1_POS	4
+#define MCHP_SAF_TAG_MAP0_STM1_MASK	\
+	SHLU32(MCHP_SAF_TAG_MAP0_STM0_MASK, MCHP_SAF_TAG_MAP0_STM1_POS)
+#define MCHP_SAF_TAG_MAP0_STM2_POS	8
+#define MCHP_SAF_TAG_MAP0_STM2_MASK	\
+	SHLU32(MCHP_SAF_TAG_MAP0_STM0_MASK, MCHP_SAF_TAG_MAP1_STM2_POS)
+#define MCHP_SAF_TAG_MAP0_STM3_POS	12
+#define MCHP_SAF_TAG_MAP0_STM3_MASK	\
+	SHLU32(MCHP_SAF_TAG_MAP0_STM0_MASK, MCHP_SAF_TAG_MAP1_STM3_POS)
+#define MCHP_SAF_TAG_MAP0_STM4_POS	16
+#define MCHP_SAF_TAG_MAP0_STM4_MASK	\
+	SHLU32(MCHP_SAF_TAG_MAP0_STM0_MASK, MCHP_SAF_TAG_MAP1_STM4_POS)
+#define MCHP_SAF_TAG_MAP0_STM5_POS	20
+#define MCHP_SAF_TAG_MAP0_STM5_MASK	\
+	SHLU32(MCHP_SAF_TAG_MAP0_STM0_MASK, MCHP_SAF_TAG_MAP1_STM5_POS)
+#define MCHP_SAF_TAG_MAP0_STM6_POS	24
+#define MCHP_SAF_TAG_MAP0_STM6_MASK	\
+	SHLU32(MCHP_SAF_TAG_MAP0_STM0_MASK, MCHP_SAF_TAG_MAP1_STM6_POS)
+#define MCHP_SAF_TAG_MAP0_STM7_POS	28
+#define MCHP_SAF_TAG_MAP0_STM7_MASK	\
+	SHLU32(MCHP_SAF_TAG_MAP0_STM0_MASK, MCHP_SAF_TAG_MAP1_STM7_POS)
+
+/* SAF Tag Map 1 register */
+#define MCHP_SAF_TAG_MAP1_OFS		0x7Cu
+#define MCHP_SAF_TAG_MAP1_MASK		0x77777777u
+#define MCHP_SAF_TAG_MAP1_DFLT_VAL	0x77677767u
+#define MCHP_SAF_TAG_MAP1_STM8_POS	0
+#define MCHP_SAF_TAG_MAP1_STM8_MASK	0x07u
+#define MCHP_SAF_TAG_MAP1_STM9_POS	4
+#define MCHP_SAF_TAG_MAP1_STM9_MASK	\
+	SHLU32(MCHP_SAF_TAG_MAP1_STM8_MASK, MCHP_SAF_TAG_MAP1_STM9_POS)
+#define MCHP_SAF_TAG_MAP1_STMA_POS	8
+#define MCHP_SAF_TAG_MAP1_STMA_MASK	\
+	SHLU32(MCHP_SAF_TAG_MAP1_STM8_MASK, MCHP_SAF_TAG_MAP1_STMA_POS)
+#define MCHP_SAF_TAG_MAP1_STMB_POS	12
+#define MCHP_SAF_TAG_MAP1_STMB_MASK	\
+	SHLU32(MCHP_SAF_TAG_MAP1_STM8_MASK, MCHP_SAF_TAG_MAP1_STMB_POS)
+#define MCHP_SAF_TAG_MAP1_STMC_POS	16
+#define MCHP_SAF_TAG_MAP1_STMC_MASK	\
+	SHLU32(MCHP_SAF_TAG_MAP1_STM8_MASK, MCHP_SAF_TAG_MAP1_STMC_POS)
+#define MCHP_SAF_TAG_MAP1_STMD_POS	20
+#define MCHP_SAF_TAG_MAP1_STMD_MASK	\
+	SHLU32(MCHP_SAF_TAG_MAP1_STM8_MASK, MCHP_SAF_TAG_MAP1_STMD_POS)
+#define MCHP_SAF_TAG_MAP1_STME_POS	24
+#define MCHP_SAF_TAG_MAP1_STME_MASK	\
+	SHLU32(MCHP_SAF_TAG_MAP1_STM8_MASK, MCHP_SAF_TAG_MAP1_STME_POS)
+#define MCHP_SAF_TAG_MAP1_STMF_POS	28
+#define MCHP_SAF_TAG_MAP1_STMF_MASK	\
+	SHLU32(MCHP_SAF_TAG_MAP1_STM8_MASK, MCHP_SAF_TAG_MAP1_STMF_POS)
+
+/* SAF Tag Map 2 register */
+#define MCHP_SAF_TAG_MAP2_OFS		0x80u
+#define MCHP_SAF_TAG_MAP2_MASK		0x80000007u
+#define MCHP_SAF_TAG_MAP2_DFLT_VAL	0x00000005u
+#define MCHP_SAF_TAG_MAP2_SM_EC_POS	0
+#define MCHP_SAF_TAG_MAP2_SM_EC_MASK	0x07u
+#define MCHP_SAF_TAG_MAP2_LOCK_POS	31
+#define MCHP_SAF_TAG_MAP2_LOCK		BIT(MCHP_SAF_TAG_MAP2_LOCK_POS)
+
+/* SAF Protection Region Start registers */
+#define MCHP_SAF_PROT_RG0_START_OFS	0x84u
+#define MCHP_SAF_PROT_RG1_START_OFS	0x94u
+#define MCHP_SAF_PROT_RG2_START_OFS	0xA4u
+#define MCHP_SAF_PROT_RG3_START_OFS	0xB4u
+#define MCHP_SAF_PROT_RG4_START_OFS	0xC4u
+#define MCHP_SAF_PROT_RG5_START_OFS	0xD4u
+#define MCHP_SAF_PROT_RG6_START_OFS	0xE4u
+#define MCHP_SAF_PROT_RG7_START_OFS	0xF4u
+#define MCHP_SAF_PROT_RG8_START_OFS	0x104u
+#define MCHP_SAF_PROT_RG9_START_OFS	0x114u
+#define MCHP_SAF_PROT_RG10_START_OFS	0x124u
+#define MCHP_SAF_PROT_RG11_START_OFS	0x134u
+#define MCHP_SAF_PROT_RG12_START_OFS	0x144u
+#define MCHP_SAF_PROT_RG13_START_OFS	0x154u
+#define MCHP_SAF_PROT_RG14_START_OFS	0x164u
+#define MCHP_SAF_PROT_RG15_START_OFS	0x174u
+#define MCHP_SAF_PROT_RG16_START_OFS	0x184u
+#define MCHP_SAF_PROT_RG_START_MASK	0xfffffu
+#define MCHP_SAF_PROT_RG_START_DFLT	0x07fffu
+
+/* SAF Protection Region Limit registers */
+#define MCHP_SAF_PROT_RG0_LIMIT_OFS	0x88u
+#define MCHP_SAF_PROT_RG1_LIMIT_OFS	0x98u
+#define MCHP_SAF_PROT_RG2_LIMIT_OFS	0xa8u
+#define MCHP_SAF_PROT_RG3_LIMIT_OFS	0xb8u
+#define MCHP_SAF_PROT_RG4_LIMIT_OFS	0xc8u
+#define MCHP_SAF_PROT_RG5_LIMIT_OFS	0xd8u
+#define MCHP_SAF_PROT_RG6_LIMIT_OFS	0xe8u
+#define MCHP_SAF_PROT_RG7_LIMIT_OFS	0xf8u
+#define MCHP_SAF_PROT_RG8_LIMIT_OFS	0x108u
+#define MCHP_SAF_PROT_RG9_LIMIT_OFS	0x118u
+#define MCHP_SAF_PROT_RG10_LIMIT_OFS	0x128u
+#define MCHP_SAF_PROT_RG11_LIMIT_OFS	0x138u
+#define MCHP_SAF_PROT_RG12_LIMIT_OFS	0x148u
+#define MCHP_SAF_PROT_RG13_LIMIT_OFS	0x158u
+#define MCHP_SAF_PROT_RG14_LIMIT_OFS	0x168u
+#define MCHP_SAF_PROT_RG15_LIMIT_OFS	0x178u
+#define MCHP_SAF_PROT_RG16_LIMIT_OFS	0x188u
+#define MCHP_SAF_PROT_RG_LIMIT_MASK	0xfffffu
+#define MCHP_SAF_PROT_RG_LIMIT_DFLT	0
+
+/* SAF Protection Region Write Bitmap registers */
+#define MCHP_SAF_PROT_RG0_WBM_OFS	0x8cu
+#define MCHP_SAF_PROT_RG1_WBM_OFS	0x9cu
+#define MCHP_SAF_PROT_RG2_WBM_OFS	0xacu
+#define MCHP_SAF_PROT_RG3_WBM_OFS	0xbcu
+#define MCHP_SAF_PROT_RG4_WBM_OFS	0xccu
+#define MCHP_SAF_PROT_RG5_WBM_OFS	0xdcu
+#define MCHP_SAF_PROT_RG6_WBM_OFS	0xefu
+#define MCHP_SAF_PROT_RG7_WBM_OFS	0xfcu
+#define MCHP_SAF_PROT_RG8_WBM_OFS	0x10cu
+#define MCHP_SAF_PROT_RG9_WBM_OFS	0x11cu
+#define MCHP_SAF_PROT_RG10_WBM_OFS	0x12cu
+#define MCHP_SAF_PROT_RG11_WBM_OFS	0x13cu
+#define MCHP_SAF_PROT_RG12_WBM_OFS	0x14cu
+#define MCHP_SAF_PROT_RG13_WBM_OFS	0x15cu
+#define MCHP_SAF_PROT_RG14_WBM_OFS	0x16cu
+#define MCHP_SAF_PROT_RG15_WBM_OFS	0x17cu
+#define MCHP_SAF_PROT_RG16_WBM_OFS	0x18cu
+#define MCHP_SAF_PROT_RG_WBM_MASK	0xffu
+#define MCHP_SAF_PROT_RG_WBM0		BIT(0)
+#define MCHP_SAF_PROT_RG_WBM1		BIT(1)
+#define MCHP_SAF_PROT_RG_WBM2		BIT(2)
+#define MCHP_SAF_PROT_RG_WBM3		BIT(3)
+#define MCHP_SAF_PROT_RG_WBM4		BIT(4)
+#define MCHP_SAF_PROT_RG_WBM5		BIT(5)
+#define MCHP_SAF_PROT_RG_WBM6		BIT(6)
+#define MCHP_SAF_PROT_RG_WBM7		BIT(7)
+
+/* SAF Protection Region Read Bitmap registers */
+#define MCHP_SAF_PROT_RG0_RBM_OFS	0x90u
+#define MCHP_SAF_PROT_RG1_RBM_OFS	0xa0u
+#define MCHP_SAF_PROT_RG2_RBM_OFS	0xb0u
+#define MCHP_SAF_PROT_RG3_RBM_OFS	0xc0u
+#define MCHP_SAF_PROT_RG4_RBM_OFS	0xd0u
+#define MCHP_SAF_PROT_RG5_RBM_OFS	0xe0u
+#define MCHP_SAF_PROT_RG6_RBM_OFS	0xf0u
+#define MCHP_SAF_PROT_RG7_RBM_OFS	0x100u
+#define MCHP_SAF_PROT_RG8_RBM_OFS	0x110u
+#define MCHP_SAF_PROT_RG9_RBM_OFS	0x120u
+#define MCHP_SAF_PROT_RG10_RBM_OFS	0x130u
+#define MCHP_SAF_PROT_RG11_RBM_OFS	0x140u
+#define MCHP_SAF_PROT_RG12_RBM_OFS	0x150u
+#define MCHP_SAF_PROT_RG13_RBM_OFS	0x160u
+#define MCHP_SAF_PROT_RG14_RBM_OFS	0x170u
+#define MCHP_SAF_PROT_RG15_RBM_OFS	0x180u
+#define MCHP_SAF_PROT_RG16_RBM_OFS	0x190u
+#define MCHP_SAF_PROT_RG_RBM_MASK	0xffu
+#define MCHP_SAF_PROT_RG_RBM0		BIT(0)
+#define MCHP_SAF_PROT_RG_RBM1		BIT(1)
+#define MCHP_SAF_PROT_RG_RBM2		BIT(2)
+#define MCHP_SAF_PROT_RG_RBM3		BIT(3)
+#define MCHP_SAF_PROT_RG_RBM4		BIT(4)
+#define MCHP_SAF_PROT_RG_RBM5		BIT(5)
+#define MCHP_SAF_PROT_RG_RBM6		BIT(6)
+#define MCHP_SAF_PROT_RG_RBM7		BIT(7)
+
+/* SAF Poll Timeout register */
+#define MCHP_SAF_POLL_TMOUT_OFS		0x194u
+#define MCHP_SAF_POLL_TMOUT_MASK	0x3ffffu
+#define MCHP_SAF_POLL_TMOUT_5S		0x28000u
+
+/* SAF Poll Interval register */
+#define MCHP_SAF_POLL_INTRVL_OFS	0x198u
+#define MCHP_SAF_POLL_INTRVL_MASK	0xffffu
+
+/* SAF Suspend Resume Interval register */
+#define MCHP_SAF_SUS_RSM_INTRVL_OFS	0x19Cu
+#define MCHP_SAF_SUS_RSM_INTRVL_MASK	0xffffu
+
+/* SAF Consecutive Read Timeout register */
+#define MCHP_SAF_CRD_TMOUT_OFS		0x1a0u
+#define MCHP_SAF_CRD_TMOUT_MASK		0xfffffu
+
+/* SAF Flash CS0/CS1 Configuration Poll2 Mask registers */
+#define MCHP_SAF_FL0_CFG_P2M_OFS	0x1a4u
+#define MCHP_SAF_FL1_CFG_P2M_OFS	0x1a6u
+#define MCHP_SAF_FL_CFG_P2M_MASK	0xffffu
+
+/* SAF Flash Configuration Special Mode register */
+#define MCHP_SAF_FL_CFG_SPM_OFS		0x1a8u
+#define MCHP_SAF_FL_CFG_SPM_MASK	0x01u
+#define MCHP_SAF_FL_CFG_SPM_DIS_SUSP	BIT(0)
+
+/* SAF Suspend Check Delay register */
+#define MCHP_SAF_SUS_CHK_DLY_OFS	0x1acu
+#define MCHP_SAF_SUS_CHK_DLY_MASK	0xfffffu
+
+/* SAF Flash 0/1 Continuous Mode Prefix registers */
+#define MCHP_SAF_FL_CM_PRF_OFS		0x1b0u
+#define MCHP_SAF_FL_CM_PRF_MASK		0xffffu
+#define MCHP_SAF_FL_CM_PRF_CS_OP_POS	0
+#define MCHP_SAF_FL_CM_PRF_CS_OP_MASK	0xffu
+#define MCHP_SAF_FL_CM_PRF_CS_DAT_POS	8
+#define MCHP_SAF_FL_CM_PRF_CS_DAT_MASK \
+	SHLU32(MCHP_SAF_FL_CM_PRF_CS_OP_MASK, MCHP_SAF_FL_CM_PRF_CS_DAT_POS)
+
+/* SAF DnX Protection Bypass register */
+#define MCHP_SAF_DNX_PROT_BYP_OFS	0x1b4u
+#define MCHP_SAF_DNX_PROT_BYP_MASK	0xffffffffu
+
+/* SAF Communication Mode */
+#define MCHP_SAF_COMM_MODE_MASK		0x01u
+/* Allow pre-fetch from flash devices */
+#define MCHP_SAF_COMM_MODE_PF_EN	BIT(0)
+
+/* SAF TAG numbers[0:0xF] */
+#define MCHP_SAF_TAG_M0T0	0u
+#define MCHP_SAF_TAG_M0T1	1u
+#define MCHP_SAF_TAG_M1T0	2u
+#define MCHP_SAF_TAG_M1T1	3u
+#define MCHP_SAF_TAG_M2T0	4u
+#define MCHP_SAF_TAG_M2T1	5u
+#define MCHP_SAF_TAG_M3T0	6u
+#define MCHP_SAF_TAG_M2T2	7u
+#define MCHP_SAF_TAG_M6T0	9u
+#define MCHP_SAF_TAG_M6T1	0x0du
+#define MCHP_SAF_TAG_MAX	0x10u
+
+/* SAF Master numbers */
+#define MCHP_SAF_MSTR_CS_INIT	0u
+#define MCHP_SAF_MSTR_CPU	1u
+#define MCHP_SAF_MSTR_CS_ME	2u
+#define MCHP_SAF_MSTR_CS_LAN	3u
+#define MCHP_SAF_MSTR_UNUSED4	4u
+#define MCHP_SAF_MSTR_EC_FW	5u
+#define MCHP_SAF_MSTR_CS_IE	6u
+#define MCHP_SAF_MSTR_UNUSED7	7u
+#define MCHP_SAF_MSTR_MAX	8u
+#define MCHP_SAF_MSTR_ALL	0xffu
+
+/* eSPI SAF */
+/** @brief SAF SPI Opcodes and descriptor indices */
+struct mchp_espi_saf_op {
+	volatile uint32_t OPA;
+	volatile uint32_t OPB;
+	volatile uint32_t OPC;
+	volatile uint32_t OP_DESCR;
+};
+
+/** @brief SAF protection regions contain 4 32-bit registers. */
+struct mchp_espi_saf_pr {
+	volatile uint32_t START;
+	volatile uint32_t LIMIT;
+	volatile uint32_t WEBM;
+	volatile uint32_t RDBM;
+};
+
+/** @brief eSPI SAF configuration and control registers at 0x40008000 */
+struct mchp_espi_saf {
+	uint32_t RSVD1[6];
+	volatile uint32_t SAF_ECP_CMD;
+	volatile uint32_t SAF_ECP_FLAR;
+	volatile uint32_t SAF_ECP_START;
+	volatile uint32_t SAF_ECP_BFAR;
+	volatile uint32_t SAF_ECP_STATUS;
+	volatile uint32_t SAF_ECP_INTEN;
+	volatile uint32_t SAF_FL_CFG_SIZE_LIM;
+	volatile uint32_t SAF_FL_CFG_THRH;
+	volatile uint32_t SAF_FL_CFG_MISC;
+	volatile uint32_t SAF_ESPI_MON_STATUS;
+	volatile uint32_t SAF_ESPI_MON_INTEN;
+	volatile uint32_t SAF_ECP_BUSY;
+	uint32_t RSVD2[1];
+	struct mchp_espi_saf_op SAF_CS_OP[2];
+	volatile uint32_t SAF_FL_CFG_GEN_DESCR;
+	volatile uint32_t SAF_PROT_LOCK;
+	volatile uint32_t SAF_PROT_DIRTY;
+	volatile uint32_t SAF_TAG_MAP[3];
+	struct mchp_espi_saf_pr SAF_PROT_RG[17];
+	volatile uint32_t SAF_POLL_TMOUT;
+	volatile uint32_t SAF_POLL_INTRVL;
+	volatile uint32_t SAF_SUS_RSM_INTRVL;
+	volatile uint32_t SAF_CONSEC_RD_TMOUT;
+	volatile uint16_t SAF_CS0_CFG_P2M;
+	volatile uint16_t SAF_CS1_CFG_P2M;
+	volatile uint32_t SAF_FL_CFG_SPM;
+	volatile uint32_t SAF_SUS_CHK_DLY;
+	volatile uint16_t SAF_CS0_CM_PRF;
+	volatile uint16_t SAF_CS1_CM_PRF;
+	volatile uint32_t SAF_DNX_PROT_BYP;
+};
+
+struct mchp_espi_saf_comm { /* @ 0x40071000 */
+	uint32_t TEST0;
+	uint32_t TEST1;
+	uint32_t TEST2;
+	uint32_t TEST3;
+	uint32_t TEST4;
+	uint32_t TEST5;
+	uint32_t TEST6;
+	uint32_t RSVD1[(0x2b8 - 0x01c) / 4];
+	uint32_t SAF_COMM_MODE; /* @ 0x400712b8 */
+	uint32_t TEST7;
+};
+
+#endif /* _MEC172X_ESPI_SAF_H_ */

--- a/soc/arm/microchip_mec/mec172x/reg/mec172x_espi_vw.h
+++ b/soc/arm/microchip_mec/mec172x/reg/mec172x_espi_vw.h
@@ -1,0 +1,365 @@
+/*
+ * Copyright (c) 2021 Microchip Technology Inc. and its subsidiaries.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _MEC172X_ESPI_VW_H
+#define _MEC172X_ESPI_VW_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+/* Master to Slave VW register: 96-bit (3 32 bit registers) */
+/* 32-bit word 0 (bits[31:0]) */
+#define ESPI_M2SW0_OFS			0u
+#define ESPI_M2SW0_IDX_POS		0
+#define ESPI_M2SW0_IDX_MASK		0xffu
+#define ESPI_M2SW0_MTOS_SRC_POS		8u
+#define ESPI_M2SW0_MTOS_SRC_MASK0	0x03u
+#define ESPI_M2SW0_MTOS_SRC_MASK	0x300u
+#define ESPI_M2SW0_MTOS_SRC_ESPI_RST	0u
+#define ESPI_M2SW0_MTOS_SRC_SYS_RST	0x100u
+#define ESPI_M2SW0_MTOS_SRC_SIO_RST	0x200u
+#define ESPI_M2SW0_MTOS_SRC_PLTRST	0x300u
+#define ESPI_M2SW0_MTOS_STATE_POS	12u
+#define ESPI_M2SW0_MTOS_STATE_MASK0	0x0fu
+#define ESPI_M2SW0_MTOS_STATE_MASK	0xf000u
+/* 32-bit word 1 (bits[63:32]) */
+#define ESPI_M2SW1_OFS			4u
+#define ESPI_M2SW1_SRC0_SEL_POS		0
+#define ESPI_M2SW1_SRC_SEL_MASK0	0x0fu
+#define ESPI_M2SW1_SRC0_SEL_MASK	0x0fu
+#define ESPI_M2SW1_SRC1_SEL_POS		8
+#define ESPI_M2SW1_SRC1_SEL_MASK	0x0f00u
+#define ESPI_M2SW1_SRC2_SEL_POS		16
+#define ESPI_M2SW1_SRC2_SEL_MASK	0x0f0000u
+#define ESPI_M2SW1_SRC3_SEL_POS		24
+#define ESPI_M2SW1_SRC3_SEL_MASK	0x0f000000u
+/* 0 <= n < 4 */
+#define ESPI_M2SW1_SRC_SEL_POS(n)	((n) * 8u)
+#define ESPI_M2SW1_SRC_SEL_MASK(n)	SHLU32(0xfu, ((n) * 8u))
+#define ESPI_M2SW1_SRC_SEL_VAL(n, v)	SHLU32(((v) & 0xfu), ((n) * 8u))
+/* 32-bit word 2 (bits[95:64]) */
+#define ESPI_M2SW2_OFS			8u
+#define ESPI_M2SW2_SRC_MASK0		0x0fu
+#define ESPI_M2SW2_SRC0_POS		0
+#define ESPI_M2SW2_SRC0_MASK		0x0fu
+#define ESPI_M2SW2_SRC1_POS		8u
+#define ESPI_M2SW2_SRC1_MASK		0x0f00u
+#define ESPI_M2SW2_SRC2_POS		16u
+#define ESPI_M2SW2_SRC2_MASK		0x0f0000u
+#define ESPI_M2SW2_SRC3_POS		24u
+#define ESPI_M2SW2_SRC3_MASK		0x0f000000u
+/* 0 <= n < 4 */
+#define ESPI_M2SW2_SRC_POS(n)		((n) * 8u)
+#define ESPI_M2SW2_SRC_MASK(n)		SHLU32(0xfu, ((n) * 8u))
+#define ESPI_M2SW2_SRC_VAL(n, v)	SHLU32(((v) & 0xfu), ((n) * 8u))
+
+/*
+ * Zero based values used for above SRC_SEL fields.
+ * These values select the interrupt sensitivity for the VWire.
+ * Example: Set SRC1 to Level High
+ *
+ * r = read MSVW1 register
+ * r &= ESPI_M2SW1_SRC_SEL_MASK(1)
+ * r |= ESPI_MSVW1_SRC_SEL_VAL(1, ESPI_IRQ_SEL_LVL_HI)
+ * write r to MSVW1 register
+ */
+#define ESPI_IRQ_SEL_LVL_LO	0
+#define ESPI_IRQ_SEL_LVL_HI	1
+#define ESPI_IRQ_SEL_DIS	4
+/* NOTE: Edge trigger modes allow VWires to wake from deep sleep */
+#define ESPI_IRQ_SEL_REDGE	0x0du
+#define ESPI_IRQ_SEL_FEDGE	0x0eu
+#define ESPI_IRQ_SEL_BEDGE	0x0fu
+
+/* Slave to Master VW register: 64-bit (2 32 bit registers) */
+/* 32-bit word 0 (bits[31:0]) */
+#define ESPI_S2MW0_OFS			0
+#define ESPI_S2MW0_IDX_POS		0
+#define ESPI_S2MW0_IDX_MASK		0xffu
+#define ESPI_S2MW0_STOM_POS		8u
+#define ESPI_S2MW0_STOM_SRC_POS		8u
+#define ESPI_S2MW0_STOM_MASK0		0xf3u
+#define ESPI_S2MW0_STOM_MASK		0xf300u
+#define ESPI_S2MW0_STOM_SRC_MASK0	0x03u
+#define ESPI_S2MW0_STOM_SRC_MASK	0x0300u
+#define ESPI_S2MW0_STOM_SRC_ESPI_RST	0u
+#define ESPI_S2MW0_STOM_SRC_SYS_RST	0x0100u
+#define ESPI_S2MW0_STOM_SRC_SIO_RST	0x0200u
+#define ESPI_S2MW0_STOM_SRC_PLTRST	0x0300u
+#define ESPI_S2MW0_STOM_STATE_POS	12u
+#define ESPI_S2MW0_STOM_STATE_MASK0	0x0fu
+#define ESPI_S2MW0_STOM_STATE_MASK	0x0f000u
+#define ESPI_S2MW0_CHG0_POS		16u
+#define ESPI_S2MW0_CHG0			BIT(ESPI_S2MW0_CHG0_POS)
+#define ESPI_S2MW0_CHG1_POS		17u
+#define ESPI_S2MW0_CHG1			BIT(ESPI_S2MW0_CHG1_POS)
+#define ESPI_S2MW0_CHG2_POS		18u
+#define ESPI_S2MW0_CHG2			BIT(ESPI_S2MW0_CHG2_POS)
+#define ESPI_S2MW0_CHG3_POS		19u
+#define ESPI_S2MW0_CHG3			BIT(ESPI_S2MW0_CHG3_POS)
+#define ESPI_S2MW0_CHG_ALL_POS		16u
+#define ESPI_S2MW0_CHG_ALL_MASK0	0x0fu
+#define ESPI_S2MW0_CHG_ALL_MASK		0x0f0000u
+/* 0 <= n < 4 */
+#define ESPI_S2MW1_CHG_POS(n)		((n) + 16u)
+#define ESPI_S2MW1_CHG(v, n)		\
+	(((uint32_t)(v) >> ESPI_S2MW1_CHG_POS(n)) & 0x01)
+
+/* 32-bit word 1 (bits[63:32]) */
+#define ESPI_S2MW1_OFS			4u
+#define ESPI_S2MW1_SRC0_POS		0u
+#define ESPI_S2MW1_SRC0			BIT(ESPI_S2MW1_SRC0_POS)
+#define ESPI_S2MW1_SRC1_POS		8u
+#define ESPI_S2MW1_SRC1			BIT(ESPI_S2MW1_SRC1_POS)
+#define ESPI_S2MW1_SRC2_POS		16u
+#define ESPI_S2MW1_SRC2			BIT(ESPI_S2MW1_SRC2_POS)
+#define ESPI_S2MW1_SRC3_POS		24u
+#define ESPI_S2MW1_SRC3			BIT(ESPI_S2MW1_SRC3_POS)
+/* 0 <= n < 4 */
+#define ESPI_S2MW1_SRC_POS(n)		SHLU32((n), 3)
+#define ESPI_S2MW1_SRC(v, n)		\
+	SHLU32(((uint32_t)(v) & 0x01), (ESPI_S2MW1_SRC_POS(n)))
+
+/**
+ * @brief eSPI Virtual Wires (ESPI_VW)
+ */
+
+#define ESPI_MSVW_IDX_MAX	10u
+#define ESPI_SMVW_IDX_MAX	10u
+
+#define ESPI_NUM_MSVW		11u
+#define ESPI_NUM_SMVW		11u
+
+/*
+ * ESPI MSVW interrupts
+ * GIRQ24 contains MSVW 0 - 6
+ * GIRQ25 contains MSVW 7 - 10
+ */
+#define MEC_ESPI_MSVW_NUM_GIRQS     2u
+
+/* Master-to-Slave VW byte indices(offsets) */
+#define MSVW_INDEX_OFS		0u
+#define MSVW_MTOS_OFS		1u
+#define MSVW_SRC0_ISEL_OFS	4u
+#define MSVW_SRC1_ISEL_OFS	5u
+#define MSVW_SRC2_ISEL_OFS	6u
+#define MSVW_SRC3_ISEL_OFS	7u
+#define MSVW_SRC0_OFS		8u
+#define MSVW_SRC1_OFS		9u
+#define MSVW_SRC2_OFS		10u
+#define MSVW_SRC3_OFS		11u
+
+/* Slave-to-Master VW byte indices(offsets) */
+#define SMVW_INDEX_OFS		0u
+#define SMVW_STOM_OFS		1u
+#define SMVW_CHANGED_OFS	2u
+#define SMVW_SRC0_OFS		4u
+#define SMVW_SRC1_OFS		5u
+#define SMVW_SRC2_OFS		6u
+#define SMVW_SRC3_OFS		7u
+
+
+/* Master-to-Slave Virtual Wire 96-bit register */
+#define MEC_MSVW_SRC0_IRQ_SEL_POS	0u
+#define MEC_MSVW_SRC1_IRQ_SEL_POS	8u
+#define MEC_MSVW_SRC2_IRQ_SEL_POS	16u
+#define MEC_MSVW_SRC3_IRQ_SEL_POS	24u
+
+#define MEC_MSVW_SRC_IRQ_SEL_MASK0	0x0fu
+#define MEC_MSVW_SRC0_IRQ_SEL_MASK	\
+	SHLU32(MEC_MSVW_SRC_IRQ_SEL_MASK0, MEC_MSVW_SRC0_IRQ_SEL_POS)
+#define MEC_MSVW_SRC1_IRQ_SEL_MASK	\
+	SHLU32(MEC_MSVW_SRC_IRQ_SEL_MASK0, MEC_MSVW_SRC1_IRQ_SEL_POS)
+#define MEC_MSVW_SRC2_IRQ_SEL_MASK	\
+	SHLU32(MEC_MSVW_SRC_IRQ_SEL_MASK0, MEC_MSVW_SRC2_IRQ_SEL_POS)
+#define MEC_MSVW_SRC3_IRQ_SEL_MASK	\
+	SHLU32(MEC_MSVW_SRC_IRQ_SEL_MASK0, MEC_MSVW_SRC3_IRQ_SEL_POS)
+
+#define MEC_MSVW_SRC_IRQ_SEL_LVL_LO	0x00u
+#define MEC_MSVW_SRC_IRQ_SEL_LVL_HI	0x01u
+#define MEC_MSVW_SRC_IRQ_SEL_DIS	0x04u
+#define MEC_MSVW_SRC_IRQ_SEL_EDGE_FALL	0x0du
+#define MEC_MSVW_SRC_IRQ_SEL_EDGE_RISE	0x0eu
+#define MEC_MSVW_SRC_IRQ_SEL_EDGE_BOTH	0x0fu
+
+/*
+ * 0 <= src <= 3
+ * isel = MEC_MSVW_SRC_IRQ_SEL_LVL_LO, ...
+ */
+#define MEC_MSVW_SRC_IRQ_SEL_VAL(src, isel)	\
+	((uint32_t)(isel) << ((src) * 8u))
+
+#define MEC_MSVW_SRC0_POS	0u
+#define MEC_MSVW_SRC1_POS	8u
+#define MEC_MSVW_SRC2_POS	16u
+#define MEC_MSVW_SRC3_POS	24u
+
+#define MEC_MSVW_SRC_MASK0	0x01u
+
+#define MEC_MSVW_SRC0_MASK	BIT(0)
+#define MEC_MSVW_SRC1_MASK	BIT(8)
+#define MEC_MSVW_SRC2_MASK	BIT(16)
+#define MEC_MSVW_SRC3_MASK	BIT(24)
+
+/*
+ * 0 <= src <= 3
+ * val = 0 or 1
+ */
+#define MEC_MSVW_SRC_VAL(src, val)	\
+	((uint32_t)(val & 0x01u) << ((src) * 8u))
+
+/* Slave-to-Master Virtual Wire 64-bit register */
+
+/* MSVW helper inline functions */
+
+/* Interfaces to any C modules */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum espi_msvw_src {
+	MSVW_SRC0 = 0u,
+	MSVW_SRC1,
+	MSVW_SRC2,
+	MSVW_SRC3
+};
+
+enum espi_smvw_src {
+	SMVW_SRC0 = 0u,
+	SMVW_SRC1,
+	SMVW_SRC2,
+	SMVW_SRC3
+};
+
+enum espi_msvw_irq_sel {
+	MSVW_IRQ_SEL_LVL_LO	= 0x00u,
+	MSVW_IRQ_SEL_LVL_HI	= 0x01u,
+	MSVW_IRQ_SEL_DIS	= 0x04u,
+	MSVW_IRQ_SEL_EDGE_FALL	= 0x0du,
+	MSVW_IRQ_SEL_EDGE_RISE	= 0x0eu,
+	MSVW_IRQ_SEL_EDGE_BOTH	= 0x0fu
+};
+
+/* Used for both MSVW MTOS and SMVW STOM fields */
+enum espi_vw_rst_src {
+	VW_RST_SRC_ESPI_RESET = 0u,
+	VW_RST_SRC_SYS_RESET,
+	VW_RST_SRC_SIO_RESET,
+	VW_RST_SRC_PLTRST,
+};
+
+enum espi_msvw_byte_idx {
+	MSVW_BI_INDEX = 0,
+	MSVW_BI_MTOS,
+	MSVW_BI_RSVD2,
+	MSVW_BI_RSVD3,
+	MSVW_BI_IRQ_SEL0,
+	MSVW_BI_IRQ_SEL1,
+	MSVW_BI_IRQ_SEL2,
+	MSVW_BI_IRQ_SEL3,
+	MSVW_BI_SRC0,
+	MSVW_BI_SRC1,
+	MSVW_BI_SRC2,
+	MSVW_BI_SRC3,
+	MSVW_IDX_MAX
+};
+
+enum espi_smvw_byte_idx {
+	SMVW_BI_INDEX = 0,
+	SMVW_BI_STOM,
+	SMVW_BI_SRC_CHG,
+	SMVW_BI_RSVD3,
+	SMVW_BI_SRC0,
+	SMVW_BI_SRC1,
+	SMVW_BI_SRC2,
+	SMVW_BI_SRC3,
+	SMVW_IDX_MAX
+};
+
+/** @brief eSPI 96-bit Host-to-Target Virtual Wire register */
+struct espi_msvw_reg {
+	volatile uint8_t INDEX;
+	volatile uint8_t MTOS;
+	uint8_t RSVD1[2];
+	volatile uint32_t SRC_IRQ_SEL;
+	volatile uint32_t SRC;
+};
+
+/** @brief eSPI 96-bit Host-to-Target Virtual Wire register as bytes */
+struct espi_msvwb_reg {
+	volatile uint8_t HTVWB[12];
+};
+
+/** @brief HW implements 11 Host-to-Target VW registers as an array */
+struct espi_msvw_ar_regs {
+	struct espi_msvw_reg MSVW[11];
+};
+
+/** @brief HW implements 11 Host-to-Target VW registers as named registers */
+struct espi_msvw_named_regs {
+	struct espi_msvw_reg MSVW00;
+	struct espi_msvw_reg MSVW01;
+	struct espi_msvw_reg MSVW02;
+	struct espi_msvw_reg MSVW03;
+	struct espi_msvw_reg MSVW04;
+	struct espi_msvw_reg MSVW05;
+	struct espi_msvw_reg MSVW06;
+	struct espi_msvw_reg MSVW07;
+	struct espi_msvw_reg MSVW08;
+	struct espi_msvw_reg MSVW09;
+	struct espi_msvw_reg MSVW10;
+};
+
+/** @brief eSPI M2S VW registers as an array of words at 0x400F9C00 */
+struct espi_msvw32_regs {
+	volatile uint32_t MSVW32[11 * 3];
+};
+
+/** @brief eSPI 64-bit Target-to-Host Virtual Wire register */
+struct espi_smvw_reg {
+	volatile uint8_t INDEX;
+	volatile uint8_t STOM;
+	volatile uint8_t SRC_CHG;
+	uint8_t RSVD1[1];
+	volatile uint32_t SRC;
+};
+
+/** @brief eSPI 64-bit Target-to-Host Virtual Wire register as bytes */
+struct espi_smvwb_reg {
+	volatile uint8_t THVWB[8];
+};
+
+
+/** @brief HW implements 11 Target-to-Host VW registers as an array */
+struct espi_smvw_ar_regs {
+	struct espi_smvw_reg SMVW[11];
+};
+
+/** @brief HW implements 11 Target-to-Host VW registers as named registers */
+struct espi_smvw_named_regs {
+	struct espi_smvw_reg SMVW00;
+	struct espi_smvw_reg SMVW01;
+	struct espi_smvw_reg SMVW02;
+	struct espi_smvw_reg SMVW03;
+	struct espi_smvw_reg SMVW04;
+	struct espi_smvw_reg SMVW05;
+	struct espi_smvw_reg SMVW06;
+	struct espi_smvw_reg SMVW07;
+	struct espi_smvw_reg SMVW08;
+	struct espi_smvw_reg SMVW09;
+	struct espi_smvw_reg SMVW10;
+};
+
+/** @brief eSPI S2M VW registers as an array of words at 0x400F9E00 */
+struct espi_smvw32_regs {
+	volatile uint32_t SMVW[11 * 2];
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* #ifndef _MEC172X_ESPI_VW_H */

--- a/soc/arm/microchip_mec/mec172x/soc.h
+++ b/soc/arm/microchip_mec/mec172x/soc.h
@@ -30,6 +30,9 @@
 #include "reg/mec172x_defs.h"
 #include "reg/mec172x_ecia.h"
 #include "reg/mec172x_ecs.h"
+#include "reg/mec172x_espi_iom.h"
+#include "reg/mec172x_espi_saf.h"
+#include "reg/mec172x_espi_vw.h"
 #include "reg/mec172x_pcr.h"
 
 /* common peripheral register defines */


### PR DESCRIPTION
Depends on 37013
Add MEC172x eSPI chip specific headers.