### PR TITLE
logging: allow timestamp formatting for FS backend

### DIFF
--- a/subsys/logging/Kconfig.formatting
+++ b/subsys/logging/Kconfig.formatting
@@ -61,7 +61,7 @@ config LOG_BACKEND_SHOW_COLOR
 config LOG_BACKEND_FORMAT_TIMESTAMP
 	bool "Enable timestamp formatting in the backend"
 	depends on LOG_BACKEND_UART || LOG_BACKEND_NATIVE_POSIX || LOG_BACKEND_RTT \
-	           || LOG_BACKEND_SWO || LOG_BACKEND_XTENSA_SIM
+	           || LOG_BACKEND_SWO || LOG_BACKEND_XTENSA_SIM || LOG_BACKEND_FS
 	default y
 	help
 	  When enabled timestamp is formatted to hh:mm:ss:ms,us.


### PR DESCRIPTION
FS backend is no different when it comes to producing human readable
timestamp. Allow to select it when FS is the only enabled logging
backend.