### PR TITLE
kernel: fix kobj table if having .sdata section.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -929,6 +929,7 @@ if(CONFIG_USERSPACE)
     COMMAND $<TARGET_PROPERTY:bintools,elfconvert_command>
             $<TARGET_PROPERTY:bintools,elfconvert_flag>
             $<TARGET_PROPERTY:bintools,elfconvert_flag_section_rename>.data=.kobject_data.data
+            $<TARGET_PROPERTY:bintools,elfconvert_flag_section_rename>.sdata=.kobject_data.sdata
             $<TARGET_PROPERTY:bintools,elfconvert_flag_section_rename>.text=.kobject_data.text
             $<TARGET_PROPERTY:bintools,elfconvert_flag_section_rename>.rodata=.kobject_data.rodata
             $<TARGET_PROPERTY:bintools,elfconvert_flag_infile>${KOBJECT_HASH_OUTPUT_OBJ_PATH}

--- a/include/linker/kobject-data.ld
+++ b/include/linker/kobject-data.ld
@@ -53,6 +53,7 @@
 #endif
 
 	*(".kobject_data.data*")
+	*(".kobject_data.sdata*")
 
 #ifdef KOBJECT_DATA_ALIGN
 	_kobject_data_area_end = .;


### PR DESCRIPTION
The gperf generated data needs to be placed at the end of memory
to avoid pushing symbols around in memory, but data in .sdata section
aren't placed currently. Also renaming .sdata section to kobject_data.*
section and add it to kobject_data output section to fix issue.

Fixes #37023.

Signed-off-by: Jim Shu <cwshu@andestech.com>