### PR TITLE
[Backport v2.5-branch] tests: schedule_api: lengthen interval for slicing reset test

### DIFF
--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
@@ -71,13 +71,13 @@ static void thread_time_slice(void *p1, void *p2, void *p3)
 		 * also expecting task switch below the switching tolerance.
 		 */
 		expected_slice_min =
-			(k_ms_to_ticks_ceil32(SLICE_SIZE)
+			(k_ms_to_ticks_floor32(SLICE_SIZE)
 			 - switch_tolerance_ticks)
 			* k_ticks_to_cyc_floor32(1);
 		expected_slice_max =
 			(k_ms_to_ticks_ceil32(SLICE_SIZE)
 			 + switch_tolerance_ticks)
-			* k_ticks_to_cyc_floor32(1);
+			* k_ticks_to_cyc_ceil32(1);
 	}
 
 #ifdef CONFIG_DEBUG


### PR DESCRIPTION
When calculating the expected interval for threads other than
the first one, the test uses ms->ticks->cycles conversion to
figure out the bound of cycles permitted. Both lower and upper
bound conversions are using the k_*_to_*_floor32(). When
numbers involved are not wholly divisible, decimal points are
being truncated, resulting in incorrect intervals, and thus
failing tests. So change the calculation to appropriate
floor() or ceil() based on the boundary.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>

Backport 803eb1e from #32551