### PR TITLE
x86/cache: fix issues in arch dcache flush function

### DIFF
--- a/arch/x86/core/Kconfig.ia32
+++ b/arch/x86/core/Kconfig.ia32
@@ -170,4 +170,12 @@ config X86_USE_THREAD_LOCAL_STORAGE
 	help
 	  Internal config to enable thread local storage.
 
+config X86_MFENCE_INSTRUCTION_SUPPORTED
+	bool "X86 MFENCE instruction supported"
+	default y
+	depends on CACHE_MANAGEMENT
+	help
+	  Set n to disable the use of MFENCE instruction in arch_dcache_flush()
+	  for X86 CPUs have CLFLUSH instruction but no MFENCE
+
 endif # !X86_64


### PR DESCRIPTION
Correct the wrong operand of clflush instruction. The old operand
points to a location inside stack and doesn't work. The new one
works well by taking linux kernel code as reference.

End address instead of size should get round up

Add Kconfig option to disable the usage of mfence intruction for
SoC that has clfulsh but no mfence supported.

Signed-off-by: Dong Wang <dong.d.wang@intel.com>