### PR TITLE
hpet: make it support EHL/PSE CPU

### DIFF
--- a/drivers/timer/Kconfig
+++ b/drivers/timer/Kconfig
@@ -80,7 +80,6 @@ config APIC_TIMER_IRQ_PRIORITY
 
 config HPET_TIMER
 	bool "HPET timer"
-	depends on X86
 	select IOAPIC if X86
 	select LOAPIC if X86
 	imply TIMER_READS_ITS_FREQUENCY_AT_RUNTIME


### PR DESCRIPTION
- Change to 64-bit mode for better usages.
- Add Kconfig option to change min_delay and clock period.
- Add Kconfig option to set interrupt as level triggered for ARM CPUs
with NVIC, whose DTS interrupts setting has no "sense" cell.
- Make the change of HPET comparator register as a weak function, which
could be overwritten by EHL/PSE CPU to implement its special operations.

Signed-off-by: Dong Wang <dong.d.wang@intel.com>