### PR TITLE
CODEOWNERS: add code owners to dts/arm/nuvoton/

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -370,8 +370,7 @@
 /dts/arm/ti/cc26?2*                       @bwitherspoon
 /dts/arm/ti/cc3235*                       @vanti
 /dts/arm/nordic/                          @ioannisg @carlescufi
-/dts/arm/nuvoton/                         @ssekar15
-/dts/arm/nuvoton/npcx/                    @MulinChao @WealianLiao @ChiHuaL
+/dts/arm/nuvoton/                         @ssekar15 @MulinChao @WealianLiao @ChiHuaL
 /dts/arm/nxp/                             @MaureenHelm @mmahadevan108 @dleach02
 /dts/arm/microchip/                       @franciscomunoz @albertofloyd @scottwcpg
 /dts/arm/silabs/efm32_pg_1b.dtsi          @rdmeneze


### PR DESCRIPTION
Move @MulinChao, @WealianLiao, and myself from code owners entry
dts/arm/nuvoton/npcx to dts/arm/nuvoton.
So we will be chosen as reviewers automatically when dtsi files under
dts/arm/nuvoton are touched.

Signed-off-by: Jun Lin <CHLin56@nuvoton.com>