### PR TITLE
drivers: dma: stm32 source_periph incorrectly set in dma_stm32

### DIFF
--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -415,7 +415,7 @@ DMA_STM32_EXPORT_API int dma_stm32_configure(const struct device *dev,
 		DMA_InitStruct.Mode = LL_DMA_MODE_NORMAL;
 	}
 
-	stream->source_periph = stream->direction == MEMORY_TO_PERIPHERAL;
+	stream->source_periph = (stream->direction == PERIPHERAL_TO_MEMORY);
 
 	/* set the data width, when source_data_size equals dest_data_size */
 	int index = find_lsb_set(config->source_data_size) - 1;


### PR DESCRIPTION
The flag source_periph seems to be incorrectly set in dma_stm32.
In case the transfer direction is from periph to mem, then the
stream->source_periph is 1 (true) else it is false.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/36781

Signed-off-by: Francois Ramu <francois.ramu@st.com>