### PR TITLE
Bluetooth: uuid: Use BT_UUID_SIZE_ macros for bt_uuid_create

### DIFF
--- a/subsys/bluetooth/host/uuid.c
+++ b/subsys/bluetooth/host/uuid.c
@@ -80,15 +80,15 @@ bool bt_uuid_create(struct bt_uuid *uuid, const uint8_t *data, uint8_t data_len)
 {
 	/* Copy UUID from packet data/internal variable to internal bt_uuid */
 	switch (data_len) {
-	case 2:
+	case BT_UUID_SIZE_16:
 		uuid->type = BT_UUID_TYPE_16;
 		BT_UUID_16(uuid)->val = sys_get_le16(data);
 		break;
-	case 4:
+	case BT_UUID_SIZE_32:
 		uuid->type = BT_UUID_TYPE_32;
 		BT_UUID_32(uuid)->val = sys_get_le32(data);
 		break;
-	case 16:
+	case BT_UUID_SIZE_128:
 		uuid->type = BT_UUID_TYPE_128;
 		memcpy(&BT_UUID_128(uuid)->val, data, 16);
 		break;


### PR DESCRIPTION
Use the UUID size macros instead of literal values in
bt_uuid_create.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>