### PR TITLE
cmake: Emit boilerplate status to stdout

### DIFF
--- a/share/zephyr-package/cmake/ZephyrConfig.cmake
+++ b/share/zephyr-package/cmake/ZephyrConfig.cmake
@@ -20,7 +20,7 @@ macro(include_boilerplate location)
   endif()
 
   if(NOT NO_BOILERPLATE)
-    message("Including boilerplate (${location}): ${BOILERPLATE_FILE}")
+    message(STATUS "Including boilerplate (${location}): ${BOILERPLATE_FILE}")
     include(${BOILERPLATE_FILE} NO_POLICY_SCOPE)
   endif()
 endmacro()


### PR DESCRIPTION
Tags the "Including boilerplate" cmake line with the STATUS mode to put
it in stdout instead of stderr. This also adds the CMake "--" prefix to
the message, making it fit in with the other status messages.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>