### PR TITLE
drivers: sensor: add const qualifier to conversion

### DIFF
--- a/include/drivers/sensor.h
+++ b/include/drivers/sensor.h
@@ -643,7 +643,7 @@ static inline void sensor_degrees_to_rad(int32_t d, struct sensor_value *rad)
  * @param val A pointer to a sensor_value struct.
  * @return The converted value.
  */
-static inline double sensor_value_to_double(struct sensor_value *val)
+static inline double sensor_value_to_double(const struct sensor_value *val)
 {
 	return (double)val->val1 + (double)val->val2 / 1000000;
 }


### PR DESCRIPTION
`sensor_value_to_double(struct sensor_value *val)` should never alter the given value of val.
Therefore adding a const qualifier makes sense. Fixes #37029
