### PR TITLE
usb: audio: prevent unaligned memory access

### DIFF
--- a/subsys/usb/class/audio/audio.c
+++ b/subsys/usb/class/audio/audio.c
@@ -181,7 +181,7 @@ static uint8_t get_num_of_channels(const struct feature_unit_descriptor *fu)
  */
 static uint16_t get_controls(const struct feature_unit_descriptor *fu)
 {
-	return *(uint16_t *)((uint8_t *)fu + BMA_CONTROLS_OFFSET);
+	return sys_get_le16((uint8_t *)&fu->bmaControls[0]);
 }
 
 /**
@@ -221,7 +221,9 @@ static void fix_fu_descriptors(struct usb_if_descriptor *iface)
 
 	/* start from 1 as elem 0 is filled when descriptor is declared */
 	for (int i = 1; i < get_num_of_channels(fu); i++) {
-		*(fu->bmaControls + i) = fu->bmaControls[0];
+		(void)memcpy(&fu->bmaControls[i],
+			     &fu->bmaControls[0],
+			     sizeof(uint16_t));
 	}
 
 	if (header->bInCollection == 2) {
@@ -230,7 +232,9 @@ static void fix_fu_descriptors(struct usb_if_descriptor *iface)
 			INPUT_TERMINAL_DESC_SIZE +
 			OUTPUT_TERMINAL_DESC_SIZE);
 		for (int i = 1; i < get_num_of_channels(fu); i++) {
-			*(fu->bmaControls + i) = fu->bmaControls[0];
+			(void)memcpy(&fu->bmaControls[i],
+				     &fu->bmaControls[0],
+				     sizeof(uint16_t));
 		}
 	}
 }


### PR DESCRIPTION
Prevent unaligned memory access.

Fixes #36873