### PR TITLE
drivers: i2c: rcar: Fix possible compiler warning

### DIFF
--- a/drivers/i2c/i2c_rcar.c
+++ b/drivers/i2c/i2c_rcar.c
@@ -165,7 +165,7 @@ static int i2c_rcar_transfer_msg(const struct device *dev, struct i2c_msg *msg)
 {
 	const struct i2c_rcar_cfg *config = DEV_I2C_CFG(dev);
 	uint32_t i, reg;
-	int ret;
+	int ret = 0;
 
 	if ((msg->flags & I2C_MSG_RW_MASK) == I2C_MSG_READ) {
 		/* Reading as master */


### PR DESCRIPTION
In certain build cases we get the following compiler warning:

i2c_rcar.c: In function 'i2c_rcar_transfer_msg':
i2c_rcar.c:168:6: warning: 'ret' may be used uninitialized in
                  this function [-Wmaybe-uninitialized]

Fix this by initializing ret to 0 at start of function.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>