### PR TITLE
logging: fs: fix leak of opened directories in check_log_file_exist()

### DIFF
--- a/subsys/logging/log_backend_fs.c
+++ b/subsys/logging/log_backend_fs.c
@@ -120,8 +120,8 @@ static int check_log_file_exist(int num)
 	while (true) {
 		rc = fs_readdir(&dir, &ent);
 		if (rc < 0) {
-			(void) fs_closedir(&dir);
-			return -EIO;
+			rc = -EIO;
+			goto close_dir;
 		}
 		if (ent.name[0] == 0) {
 			break;
@@ -130,13 +130,17 @@ static int check_log_file_exist(int num)
 		rc = get_log_file_id(&ent);
 
 		if (rc == num) {
-			return 1;
+			rc = 1;
+			goto close_dir;
 		}
 	}
 
+	rc = 0;
+
+close_dir:
 	(void) fs_closedir(&dir);
 
-	return 0;
+	return rc;
 }
 
 int write_log_to_file(uint8_t *data, size_t length, void *ctx)


### PR DESCRIPTION
Opened directory descriptor is leaked when returning 1. Fix that by
utilizing goto in function return path.

Fixes: 6b18e6992d0f ("subsys/loggin/log_backend_fs: added recovery after file lost")