### PR TITLE
Bluetooth: Modify kconfig to use related path

### DIFF
--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -172,7 +172,7 @@ config BT_OBSERVER
 
 endmenu
 
-source "subsys/bluetooth/services/Kconfig"
+rsource "services/Kconfig"
 
 config BT_CONN
 	bool
@@ -309,10 +309,10 @@ config BT_ISO_MAX_BIG
 endif # BT_ISO_BROADCAST
 endif # BT_ISO
 
-source "subsys/bluetooth/common/Kconfig"
-source "subsys/bluetooth/host/Kconfig"
-source "subsys/bluetooth/controller/Kconfig"
-source "subsys/bluetooth/shell/Kconfig"
+rsource "common/Kconfig"
+rsource "host/Kconfig"
+rsource "controller/Kconfig"
+rsource "shell/Kconfig"
 
 endif # BT_HCI
 
@@ -329,7 +329,7 @@ config BT_COMPANY_ID
 	  Company Identifiers can be found here:
 	  https://www.bluetooth.com/specifications/assigned-numbers/company-identifiers
 
-source "subsys/bluetooth/mesh/Kconfig"
-source "subsys/bluetooth/audio/Kconfig"
+rsource "mesh/Kconfig"
+rsource "audio/Kconfig"
 
 endif # BT

--- a/subsys/bluetooth/audio/Kconfig
+++ b/subsys/bluetooth/audio/Kconfig
@@ -49,9 +49,9 @@ config BT_AUDIO_DEBUG
 	  Use this option to enable debug logs for the Bluetooth
 	  Audio functionality.
 
-source "subsys/bluetooth/audio/Kconfig.vocs"
-source "subsys/bluetooth/audio/Kconfig.aics"
-source "subsys/bluetooth/audio/Kconfig.vcs"
-source "subsys/bluetooth/audio/Kconfig.mics"
+rsource "Kconfig.vocs"
+rsource "Kconfig.aics"
+rsource "Kconfig.vcs"
+rsource "Kconfig.mics"
 
 endif # BT_AUDIO

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -629,8 +629,8 @@ config BT_CTLR_HCI_CODEC_AND_DELAY_INFO
 	  Enable HCI commands to read information about supported
 	  codecs, codec capabilities, and controller delay.
 
-source "subsys/bluetooth/controller/Kconfig.df"
-source "subsys/bluetooth/controller/Kconfig.ll_sw_split"
+rsource "Kconfig.df"
+rsource "Kconfig.ll_sw_split"
 
 config BT_CTLR_ASSERT_HANDLER
 	bool "Application Defined Assertion Handler"

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -446,8 +446,8 @@ config BT_SMP_MIN_ENC_KEY_SIZE
 
 endif # BT_SMP
 
-source "subsys/bluetooth/host/Kconfig.l2cap"
-source "subsys/bluetooth/host/Kconfig.gatt"
+rsource "Kconfig.l2cap"
+rsource "Kconfig.gatt"
 
 config BT_MAX_PAIRED
 	int "Maximum number of paired devices"

--- a/subsys/bluetooth/services/Kconfig
+++ b/subsys/bluetooth/services/Kconfig
@@ -6,14 +6,14 @@
 menu "GATT Services"
 	depends on BT_CONN
 
-source "subsys/bluetooth/services/Kconfig.dis"
+rsource "Kconfig.dis"
 
-source "subsys/bluetooth/services/Kconfig.bas"
+rsource "Kconfig.bas"
 
-source "subsys/bluetooth/services/Kconfig.hrs"
+rsource "Kconfig.hrs"
 
-source "subsys/bluetooth/services/Kconfig.tps"
+rsource "Kconfig.tps"
 
-source "subsys/bluetooth/services/ots/Kconfig"
+rsource "ots/Kconfig"
 
 endmenu


### PR DESCRIPTION
Because we use the extended kconfig, we have already
supported relative paths, and it is clearer to use
relative paths in the bluetooth submodules.

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>