### PR TITLE
logging: fs: allow maximum file size to be 1GB

### DIFF
--- a/subsys/logging/Kconfig.backends
+++ b/subsys/logging/Kconfig.backends
@@ -354,7 +354,7 @@ config LOG_BACKEND_FS_DIR
 config LOG_BACKEND_FS_FILE_SIZE
 	int "User defined log file size"
 	default 4096
-	range 128 16384
+	range 128 1073741824
 	help
 	  Max log file size (in bytes).
 


### PR DESCRIPTION
So far the maximum configurable file size was limited to 16KB (2^14).
This might be enough for small partitions on internal flash. For
external QSPI memories however, this is certainly too restrictive.

Change maximum configurable file size to be 1GB, which is 2^30. Such
value will prevent signed integers overflow on 32-bit platforms, while
giving user full flexibility on how big log files should be.