### PR TITLE
Kernel: Fix missing unlock when waiting memory

### DIFF
--- a/kernel/mem_slab.c
+++ b/kernel/mem_slab.c
@@ -126,6 +126,8 @@ int k_mem_slab_alloc(struct k_mem_slab *slab, void **mem, k_timeout_t timeout)
 	} else {
 		SYS_PORT_TRACING_OBJ_FUNC_BLOCKING(k_mem_slab, alloc, slab, timeout);
 
+		k_spin_unlock(&slab->lock, key);
+
 		/* wait for a free block or timeout */
 		result = z_pend_curr(&slab->lock, key, &slab->wait_q, timeout);
 		if (result == 0) {


### PR DESCRIPTION
Signed-off-by: Lingao Meng <menglingao@xiaomi.com>