### PR TITLE
Bluetooth: Controller: Fix corrupt AD data after directed advertising

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -125,6 +125,17 @@ config BT_CTLR_HCI_VS_BUILD_INFO
 	  character is required at the beginning to separate it from the
 	  already included information.
 
+config BT_CTLR_AD_DATA_BACKUP
+	bool "Enable Legacy AD Data backup"
+	depends on BT_PERIPHERAL || BT_CTLR_ADV_EXT
+	default y
+	help
+	  Backup Legacy Advertising Data when switching to Legacy Directed or
+	  to Extended Advertising mode, and restore it when switching back to
+	  Legacy Non-Directed Advertising mode.
+	  Application can disable this feature if not using Directed
+	  Advertising or switch between Legacy and Extended Advertising.
+
 config BT_CTLR_HCI_ADV_HANDLE_MAPPING
 	bool "Enable advertising set handle mapping between HCI and LL"
 	depends on BT_CTLR_ADV_EXT

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_types.h
@@ -12,6 +12,16 @@ struct ll_adv_set {
 	struct ull_hdr ull;
 	struct lll_adv lll;
 
+#if defined(CONFIG_BT_CTLR_AD_DATA_BACKUP)
+	/* Legacy AD Data backup when switching to legacy directed advertising
+	 * or to Extended Advertising.
+	 */
+	struct {
+		uint8_t len;
+		uint8_t data[PDU_AC_DATA_SIZE_MAX];
+	} ad_data_backup;
+#endif /* CONFIG_BT_CTLR_AD_DATA_BACKUP */
+
 #if defined(CONFIG_BT_PERIPHERAL)
 	memq_link_t        *link_cc_free;
 	struct node_rx_pdu *node_rx_cc_free;


### PR DESCRIPTION
Fix corrupt AD data used after directed advertising by
storing a backup of the AD data before switching to directed
advertising. Restore back the AD data with switching to non-
directed advertising.

Fixes #18850.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>