### PR TITLE
Bluetooth: Mesh: fix ble mesh bsim tests compile warnings

### DIFF
--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/mesh_test.h
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/mesh_test.h
@@ -52,7 +52,7 @@
 
 #define ASSERT_TRUE(cond, ...)                                                 \
 	do {                                                                   \
-		if (!cond) {                                                   \
+		if (!(cond)) {                                                   \
 			bst_result = Failed;                                   \
 			bs_trace_error_time_line(                              \
 				#cond "is false.", ##__VA_ARGS__);             \


### PR DESCRIPTION
If bsim tests are built without errors then warnings are hidden.
A couple of them has sneaked in recent PRs.

Signed-off-by: Aleksandr Khromykh <aleksandr.khromykh@nordicsemi.no>