### PR TITLE
Bluetooth: Mesh: Refactor Mesh Model Extensions

### DIFF
--- a/include/bluetooth/mesh/access.h
+++ b/include/bluetooth/mesh/access.h
@@ -509,11 +509,10 @@ struct bt_mesh_model {
 	const struct bt_mesh_model_cb * const cb;
 
 #ifdef CONFIG_BT_MESH_MODEL_EXTENSIONS
-	/* Pointer to the next model in a model extension tree. */
+	/* Pointer to the next model in a model extension list. */
 	struct bt_mesh_model *next;
-	/* Pointer to the first model this model extends. */
-	struct bt_mesh_model *extends;
 #endif
+
 	/** Model-specific user data */
 	void *user_data;
 };
@@ -634,24 +633,30 @@ int bt_mesh_model_data_store(struct bt_mesh_model *mod, bool vnd,
  *  Mesh models may be extended to reuse their functionality, forming a more
  *  complex model. A Mesh model may extend any number of models, in any element.
  *  The extensions may also be nested, ie a model that extends another may
- *  itself be extended. Extensions may not be cyclical, and a model can only be
- *  extended by one other model.
+ *  itself be extended.
  *
- *  A set of models that extend each other form a model extension tree.
+ *  A set of models that extend each other form a model extension list.
  *
- *  All models in an extension tree share one subscription list per element. The
+ *  All models in an extension list share one subscription list per element. The
  *  access layer will utilize the combined subscription list of all models in an
- *  extension tree and element, giving the models extended subscription list
+ *  extension list and element, giving the models extended subscription list
  *  capacity.
  *
- *  @param mod      Mesh model.
- *  @param base_mod The model being extended.
+ *  @param extending_mod      Mesh model that is extending the base model.
+ *  @param base_mod           The model being extended.
  *
  *  @retval 0 Successfully extended the base_mod model.
- *  @retval -EALREADY The base_mod model is already extended.
  */
-int bt_mesh_model_extend(struct bt_mesh_model *mod,
+int bt_mesh_model_extend(struct bt_mesh_model *extending_mod,
 			 struct bt_mesh_model *base_mod);
+
+/** @brief Check if model is extended by another model.
+ *
+ *  @param model The model to check.
+ *
+ *  @retval true If model is extended by another model, otherwise false
+ */
+bool bt_mesh_model_is_extended(struct bt_mesh_model *model);
 
 /** Node Composition */
 struct bt_mesh_comp {

--- a/subsys/bluetooth/mesh/access.h
+++ b/subsys/bluetooth/mesh/access.h
@@ -19,12 +19,10 @@ struct bt_mesh_elem *bt_mesh_elem_find(uint16_t addr);
 
 bool bt_mesh_has_addr(uint16_t addr);
 
-struct bt_mesh_model *bt_mesh_model_root(struct bt_mesh_model *mod);
-void bt_mesh_model_tree_walk(struct bt_mesh_model *root,
-			     enum bt_mesh_walk (*cb)(struct bt_mesh_model *mod,
-						     uint32_t depth,
-						     void *user_data),
-			     void *user_data);
+void bt_mesh_model_extensions_walk(struct bt_mesh_model *root,
+				   enum bt_mesh_walk (*cb)(struct bt_mesh_model *mod,
+							   void *user_data),
+				   void *user_data);
 
 uint16_t *bt_mesh_model_find_group(struct bt_mesh_model **mod, uint16_t addr);
 

--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -1145,8 +1145,7 @@ send_status:
 				   mod_id, vnd);
 }
 
-static enum bt_mesh_walk mod_sub_clear_visitor(struct bt_mesh_model *mod,
-					       uint32_t depth, void *user_data)
+static enum bt_mesh_walk mod_sub_clear_visitor(struct bt_mesh_model *mod, void *user_data)
 {
 	if (IS_ENABLED(CONFIG_BT_MESH_LOW_POWER)) {
 		bt_mesh_lpn_group_del(mod->groups, ARRAY_SIZE(mod->groups));
@@ -1206,8 +1205,7 @@ static int mod_sub_overwrite(struct bt_mesh_model *model,
 
 
 	if (ARRAY_SIZE(mod->groups) > 0) {
-		bt_mesh_model_tree_walk(bt_mesh_model_root(mod),
-					mod_sub_clear_visitor, NULL);
+		bt_mesh_model_extensions_walk(mod, mod_sub_clear_visitor, NULL);
 
 		mod->groups[0] = sub_addr;
 		status = STATUS_SUCCESS;
@@ -1269,8 +1267,7 @@ static int mod_sub_del_all(struct bt_mesh_model *model,
 		goto send_status;
 	}
 
-	bt_mesh_model_tree_walk(bt_mesh_model_root(mod), mod_sub_clear_visitor,
-				NULL);
+	bt_mesh_model_extensions_walk(mod, mod_sub_clear_visitor, NULL);
 
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
 		bt_mesh_model_sub_store(mod);
@@ -1288,8 +1285,7 @@ struct mod_sub_list_ctx {
 	struct net_buf_simple *msg;
 };
 
-static enum bt_mesh_walk mod_sub_list_visitor(struct bt_mesh_model *mod,
-					      uint32_t depth, void *ctx)
+static enum bt_mesh_walk mod_sub_list_visitor(struct bt_mesh_model *mod, void *ctx)
 {
 	struct mod_sub_list_ctx *visit = ctx;
 	int count = 0;
@@ -1365,8 +1361,7 @@ static int mod_sub_get(struct bt_mesh_model *model,
 
 	visit_ctx.msg = &msg;
 	visit_ctx.elem_idx = mod->elem_idx;
-	bt_mesh_model_tree_walk(bt_mesh_model_root(mod), mod_sub_list_visitor,
-				&visit_ctx);
+	bt_mesh_model_extensions_walk(mod, mod_sub_list_visitor, &visit_ctx);
 
 send_list:
 	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
@@ -1425,8 +1420,7 @@ static int mod_sub_get_vnd(struct bt_mesh_model *model,
 
 	visit_ctx.msg = &msg;
 	visit_ctx.elem_idx = mod->elem_idx;
-	bt_mesh_model_tree_walk(bt_mesh_model_root(mod), mod_sub_list_visitor,
-				&visit_ctx);
+	bt_mesh_model_extensions_walk(mod, mod_sub_list_visitor, &visit_ctx);
 
 send_list:
 	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
@@ -1639,8 +1633,7 @@ static int mod_sub_va_overwrite(struct bt_mesh_model *model,
 
 		status = bt_mesh_va_add(label_uuid, &sub_addr);
 		if (status == STATUS_SUCCESS) {
-			bt_mesh_model_tree_walk(bt_mesh_model_root(mod),
-						mod_sub_clear_visitor, NULL);
+			bt_mesh_model_extensions_walk(mod, mod_sub_clear_visitor, NULL);
 			mod->groups[0] = sub_addr;
 
 			if (IS_ENABLED(CONFIG_BT_SETTINGS)) {


### PR DESCRIPTION
The existing extension tree does not support all the features that are
defined by the specification (e.g. multiple parents).

To enable full support for Model Extensions this patch introduces graph
representation in a form of edge list. This representation allows for
fine-grained control over memory usage. The downside is that traversing
the graph is sub-optimal computationally.

Signed-off-by: Michał Narajowski <michal.narajowski@codecoup.pl>