### PR TITLE
drivers: clock_control: clock_stm32g4: Fix ifdef STM32_LSE_CLOCK

### DIFF
--- a/drivers/clock_control/clock_stm32g4.c
+++ b/drivers/clock_control/clock_stm32g4.c
@@ -49,7 +49,7 @@ void config_enable_default_clocks(void)
 	/* Enable the power interface clock */
 	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
 
-#ifdef STM32_LSE_CLOCK
+#if STM32_LSE_CLOCK
 	/* LSE belongs to the back-up domain, enable access.*/
 
 	/* Set the DBP bit in the Power control register 1 (PWR_CR1) */


### PR DESCRIPTION
the macro STM32_LSE_CLOCK is always defined and therefore systems
without lse crystals hang on startup.
Use `#if` instead of `#ifdef`
