### PR TITLE
doc: ci: workflow improvements and PDF support

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -50,7 +50,7 @@ jobs:
 
     - name: west setup
       run: |
-        west init -l . || true
+        west init -l .
 
     - name: build-docs
       run: |

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -55,14 +55,17 @@ jobs:
     - name: build-docs
       run: |
         SPHINXOPTS="-q -W -j auto" make -C doc html
-        tar cvf htmldocs.tar --directory=./doc/_build html
+
+    - name: compress-docs
+      run: |
+        tar cfJ html-output.tar.xz --directory=doc/_build html
 
     - name: upload-build
       uses: actions/upload-artifact@master
       continue-on-error: True
       with:
-        name: htmldocs.tar
-        path: htmldocs.tar
+        name: html-output
+        path: html-output.tar.xz
 
   doc-build-pdf:
     name: "Documentation Build (PDF)"

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -59,7 +59,13 @@ jobs:
 
     - name: build-docs
       run: |
-        SPHINXOPTS="-q -W -j auto" make -C doc html
+        if [[ "$GITHUB_REF" =~ "refs/tags/v" ]]; then
+          DOC_TAG="release"
+        else
+          DOC_TAG="development"
+        fi
+
+        DOC_TAG=${DOC_TAG} SPHINXOPTS="-q -W -j auto" make -C doc html
 
     - name: compress-docs
       run: |
@@ -103,7 +109,13 @@ jobs:
 
     - name: build-docs
       run: |
-        SPHINXOPTS="-q -j auto" LATEXMKOPTS="-quiet -halt-on-error" make -C doc pdf
+        if [[ "$GITHUB_REF" =~ "refs/tags/v" ]]; then
+          DOC_TAG="release"
+        else
+          DOC_TAG="development"
+        fi
+
+        DOC_TAG=${DOC_TAG} SPHINXOPTS="-q -j auto" LATEXMKOPTS="-quiet -halt-on-error" make -C doc pdf
 
     - name: upload-build
       uses: actions/upload-artifact@master

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -20,8 +20,8 @@ on:
     - 'scripts/requirements-doc.txt'
 
 jobs:
-  doc-build:
-    name: "Documentation Build"
+  doc-build-html:
+    name: "Documentation Build (HTML)"
     runs-on: ubuntu-latest
 
     steps:
@@ -63,3 +63,43 @@ jobs:
       with:
         name: htmldocs.tar
         path: htmldocs.tar
+
+  doc-build-pdf:
+    name: "Documentation Build (PDF)"
+    runs-on: ubuntu-latest
+    container: texlive/texlive:latest
+
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+
+    - name: install-pkgs
+      run: |
+        apt-get update
+        apt-get install -y python3-pip cmake ninja-build doxygen graphviz librsvg2-bin
+
+    - name: cache-pip
+      uses: actions/cache@v1
+      with:
+        path: ~/.cache/pip
+        key: pip-${{ hashFiles('scripts/requirements-doc.txt') }}
+
+    - name: install-pip
+      run: |
+        pip3 install -U setuptools wheel pip
+        pip3 install -r scripts/requirements-doc.txt
+        pip3 install west==0.11.0
+
+    - name: west setup
+      run: |
+        west init -l .
+
+    - name: build-docs
+      run: |
+        SPHINXOPTS="-q -j auto" LATEXMKOPTS="-quiet -halt-on-error" make -C doc pdf
+
+    - name: upload-build
+      uses: actions/upload-artifact@master
+      with:
+        name: pdf-output
+        path: doc/_build/latex/zephyr.pdf

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -25,10 +25,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Update PATH for west
-      run: |
-        echo "$HOME/.local/bin" >> $GITHUB_PATH
-
     - name: checkout
       uses: actions/checkout@v2
 

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -24,6 +24,10 @@ on:
     - 'scripts/dts/**'
     - 'scripts/requirements-doc.txt'
 
+env:
+  # NOTE: west docstrings will be extracted from the version listed here
+  WEST_VERSION: 0.11.0
+
 jobs:
   doc-build-html:
     name: "Documentation Build (HTML)"
@@ -47,7 +51,7 @@ jobs:
       run: |
         sudo pip3 install -U setuptools wheel pip
         pip3 install -r scripts/requirements-doc.txt
-        pip3 install west==0.11.0
+        pip3 install west==${WEST_VERSION}
 
     - name: west setup
       run: |
@@ -92,7 +96,7 @@ jobs:
       run: |
         pip3 install -U setuptools wheel pip
         pip3 install -r scripts/requirements-doc.txt
-        pip3 install west==0.11.0
+        pip3 install west==${WEST_VERSION}
 
     - name: west setup
       run: |

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -4,6 +4,11 @@
 name: Documentation GitHub Workflow
 
 on:
+  schedule:
+    - cron: '0 */3 * * *'
+  push:
+    tags:
+      - v*
   pull_request:
     paths:
     - 'doc/**'

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -40,7 +40,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-doc-pip
+        key: pip-${{ hashFiles('scripts/requirements-doc.txt') }}
 
     - name: install-pip
       run: |

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -67,7 +67,6 @@ jobs:
 
     - name: upload-build
       uses: actions/upload-artifact@master
-      continue-on-error: True
       with:
         name: html-output
         path: html-output.tar.xz

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 Linaro Limited.
 # SPDX-License-Identifier: Apache-2.0
 
-name: Documentation GitHub Workflow
+name: Documentation Build
 
 on:
   schedule:

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -1,48 +1,35 @@
 # Copyright (c) 2020 Linaro Limited.
+# Copyright (c) 2021 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-name: Doc build for Release or Daily
+name: Publish Documentation
 
-# Either a daily based on schedule/cron or only on tag push
 on:
-  schedule:
-    - cron:  '50 1/3 * * *'
-  push:
-    paths:
-      - 'VERSION'
+  workflow_run:
+    workflows: ["Documentation GitHub Workflow"]
+    branches:
+      - main
+      - v*
     tags:
-      # only publish v* tags, do not care about zephyr-v* which point to the
-      # same commit
-      - 'v*'
+      - v*
+    types:
+      - completed
 
 jobs:
   doc-publish:
     name: Publish Documentation
     runs-on: ubuntu-latest
-    if: github.repository == 'zephyrproject-rtos/zephyr'
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
-    - name: Update PATH for west
-      run: |
-        echo "$HOME/.local/bin" >> $GITHUB_PATH
+    - name: Download artifacts
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        workflow: doc-build.yml
 
-    - name: Determine tag
-      id: tag
+    - name: Uncompress HTML docs
       run: |
-        # We expect to get here either due to a schedule event in which
-        # case we are doing a daily build of the docs, or because a new
-        # tag was pushed, in which case we are building docs for a release
-        if [ ${GITHUB_EVENT_NAME} == "schedule" ]; then
-           echo ::set-output name=TYPE::daily;
-           echo ::set-output name=RELEASE::latest;
-        elif [ ${GITHUB_EVENT_NAME} == "push" ]; then
-           # If push due to a tag GITHUB_REF will look like refs/tags/TAG-FOO
-           # chop of 'refs/tags' so RELEASE=TAG-FOO
-           echo ::set-output name=TYPE::release;
-           echo ::set-output name=RELEASE::${GITHUB_REF/refs\/tags\//};
-        else
-           exit 1
-        fi
+        tar xf html-output/html-output.tar.xz -C html-output
 
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
@@ -51,59 +38,14 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: us-east-1
 
-    - name: checkout
-      uses: actions/checkout@v2
-
-    - name: install-pkgs
-      run: |
-        sudo apt-get install -y ninja-build doxygen graphviz
-
-    - name: cache-pip
-      uses: actions/cache@v1
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-doc-pip
-
-    - name: install-pip
-      run: |
-        sudo pip3 install -U setuptools wheel pip
-        pip3 install -r scripts/requirements-base.txt
-        pip3 install -r scripts/requirements-doc.txt
-
-    - name: west setup
-      run: |
-        west init -l . || true
-
-    - name: build-docs
-      env:
-        DOC_TAG: ${{ steps.tag.outputs.TYPE }}
-      run: |
-        source zephyr-env.sh
-        make DOC_TAG=${DOC_TAG} -C doc html
-
     - name: Upload to AWS S3
-      env:
-        RELEASE: ${{ steps.tag.outputs.RELEASE }}
       run: |
-        echo "DOC_RELEASE=[$RELEASE]"
-        if [ "$RELEASE" == "latest" ]; then
-           echo "publish latest docs"
-           aws s3 sync  --quiet doc/_build/html s3://docs.zephyrproject.org/latest --delete
-           echo "success sync of latest docs"
+        if [ "${HEAD_BRANCH:0:1}" == "v" ]; then
+          VERSION=${HEAD_BRANCH:1}
         else
-           # we want just the version, without the leading 'v'
-           DOC_RELEASE=${RELEASE:1}
-           echo "publish release docs: ${DOC_RELEASE}"
-           aws s3 sync  --quiet doc/_build/html s3://docs.zephyrproject.org/${DOC_RELEASE}
-           echo "success sync of rel docs"
+          VERSION="latest"
         fi
-        if [ -d doc/_build/doxygen/html ]; then
-           if [ "$RELEASE" == "latest" ]; then
-              API_RELEASE=latest
-           else
-              API_RELEASE=${RELEASE:1}
-           fi
-           echo "publish doxygen to apidoc/${API_RELEASE}"
-           aws s3 sync  --quiet doc/_build/doxygen/html s3://docs.zephyrproject.org/apidoc/${API_RELEASE} --delete
-           echo "success publish of doxygen"
-        fi
+
+        aws s3 sync --quiet html-output/html s3://docs.zephyrproject.org/${VERSION} --delete
+        aws s3 sync --quiet html-output/html/doxygen/html s3://docs.zephyrproject.org/apidoc/${VERSION} --delete
+        aws s3 sync --quiet pdf-output/zephyr.pdf s3://docs.zephyrproject.org/${VERSION}/zephyr.pdf

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -6,7 +6,7 @@ name: Publish Documentation
 
 on:
   workflow_run:
-    workflows: ["Documentation GitHub Workflow"]
+    workflows: ["Documentation Build"]
     branches:
       - main
       - v*

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -5,6 +5,7 @@
 BUILDDIR ?= _build
 DOC_TAG ?= development
 SPHINXOPTS ?= -j auto
+LATEXMKOPTS ?= -halt-on-error -no-shell-escape
 KCONFIG_TURBO_MODE ?= 0
 
 # ------------------------------------------------------------------------------
@@ -25,6 +26,7 @@ configure:
 		-S. \
 		-DDOC_TAG=${DOC_TAG} \
 		-DSPHINXOPTS="${SPHINXOPTS}" \
+		-DLATEXMKOPTS="${LATEXMKOPTS}" \
 		-DKCONFIG_TURBO_MODE=${KCONFIG_TURBO_MODE}
 
 clean:

--- a/doc/_templates/zversions.html
+++ b/doc/_templates/zversions.html
@@ -13,6 +13,11 @@
         {% endfor %}
       </dl>
       <dl>
+        <dt>{{ _('Downloads') }}</dt>
+        {% set prefix = current_version if is_release else "latest" %}
+        <dd><a href="/{{ prefix }}/zephyr.pdf">PDF</a></dd>
+      </dl>
+      <dl>
         <dt>{{ _('zephyrproject.org Links') }}</dt>
           <dd>
             <a href="https://www.zephyrproject.org/">Project Home</a>


### PR DESCRIPTION
This PR brings some improvements to the documentation workflow:

- A single "Documentation Build" workflow is used to build the documentation, regardless if it's for a PR, a release or a scheduled event.
- The "Documentation Publish" workflow will run on `main` or releases after documentation build succeeds. It re-uses artifacts from the build stage.
- PDF support has been added (build and publish)

NOTE: I'm not entirely familiar with how AWS S3 is configured for Zephyr, so that part may require more attention as I may have missed something.