### PR TITLE
Bluetooth: shell: Add bluetooth tag to shell tests

### DIFF
--- a/tests/bluetooth/shell/testcase.yaml
+++ b/tests/bluetooth/shell/testcase.yaml
@@ -36,6 +36,7 @@ tests:
       - native_posix
     extra_configs:
       - CONFIG_BT_VCS=n
+    tags: bluetooth
   bluetooth.shell.no_vocs:
     build_only: true
     integration_platforms:
@@ -43,6 +44,7 @@ tests:
     extra_configs:
       - CONFIG_BT_VOCS_MAX_INSTANCE_COUNT=0
       - CONFIG_BT_VCS_VOCS_INSTANCE_COUNT=0
+    tags: bluetooth
   bluetooth.shell.no_aics:
     build_only: true
     integration_platforms:
@@ -51,6 +53,7 @@ tests:
       - CONFIG_BT_AICS_MAX_INSTANCE_COUNT=0
       - CONFIG_BT_VCS_AICS_INSTANCE_COUNT=0
       - CONFIG_BT_MICS_AICS_INSTANCE_COUNT=0
+    tags: bluetooth
   bluetooth.shell.no_aics_vocs:
     build_only: true
     integration_platforms:
@@ -61,12 +64,14 @@ tests:
       - CONFIG_BT_AICS_MAX_INSTANCE_COUNT=0
       - CONFIG_BT_VCS_AICS_INSTANCE_COUNT=0
       - CONFIG_BT_MICS_AICS_INSTANCE_COUNT=0
+    tags: bluetooth
   bluetooth.shell.no_vcs_client:
     build_only: true
     integration_platforms:
       - native_posix
     extra_configs:
       - CONFIG_BT_VCS_CLIENT=n
+    tags: bluetooth
   bluetooth.shell.no_vcs_vcs_client:
     build_only: true
     integration_platforms:
@@ -74,30 +79,35 @@ tests:
     extra_configs:
       - CONFIG_BT_VCS=n
       - CONFIG_BT_VCS_CLIENT=n
+    tags: bluetooth
   bluetooth.shell.vcs_client_no_aics_client:
     build_only: true
     integration_platforms:
       - native_posix
     extra_configs:
       - CONFIG_BT_VCS_CLIENT_MAX_AICS_INST=0
+    tags: bluetooth
   bluetooth.shell.vcs_client_no_vocs_client:
     build_only: true
     integration_platforms:
       - native_posix
     extra_configs:
       - CONFIG_BT_VCS_CLIENT_MAX_VOCS_INST=0
+    tags: bluetooth
   bluetooth.shell.no_mics:
     build_only: true
     integration_platforms:
       - native_posix
     extra_configs:
       - CONFIG_BT_MICS=n
+    tags: bluetooth
   bluetooth.shell.no_mics_client:
     build_only: true
     integration_platforms:
       - native_posix
     extra_configs:
       - CONFIG_BT_MICS_CLIENT=n
+    tags: bluetooth
   bluetooth.shell.no_mics_mics_client:
     build_only: true
     integration_platforms:
@@ -105,9 +115,11 @@ tests:
     extra_configs:
       - CONFIG_BT_MICS=n
       - CONFIG_BT_MICS_CLIENT=n
+    tags: bluetooth
   bluetooth.shell.mics_client_no_aics_client:
     build_only: true
     integration_platforms:
       - native_posix
     extra_configs:
       - CONFIG_BT_MICS_CLIENT_MAX_AICS_INST=0
+    tags: bluetooth


### PR DESCRIPTION
Add missing bluetooth tag for recently added tests in
the testcase.yaml file.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>