### PR TITLE
Fix: document: Fix there is no API Reference in clock

### DIFF
--- a/doc/reference/kernel/timing/clocks.rst
+++ b/doc/reference/kernel/timing/clocks.rst
@@ -347,3 +347,9 @@ the time they passed the timeout to you.  Care must be taken to call
 this function just once, as synchronously as possible to the timeout
 creation in user code.  It should not be used on a "stored" timeout
 value, and should never be called iteratively in a loop.
+
+
+API Reference
+*************
+
+.. doxygengroup:: clock_apis

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1515,6 +1515,7 @@ static inline void *z_impl_k_timer_user_data_get(const struct k_timer *timer)
 
 /**
  * @addtogroup clock_apis
+ * @ingroup kernel_apis
  * @{
  */
 


### PR DESCRIPTION
Add the Doxygen group in the clock rst file to generate the API Reference
chapter.
Fixes #37032

Signed-off-by: Jian Kang <jianx.kang@intel.com>