### PR TITLE
ITE: drivers/i2c: remove redundant printk

### DIFF
--- a/drivers/i2c/i2c_ite_it8xxx2.c
+++ b/drivers/i2c/i2c_ite_it8xxx2.c
@@ -804,6 +804,13 @@ static int i2c_it8xxx2_transfer(const struct device *dev, struct i2c_msg *msgs,
 		/* TODO: the timeout should be adjustable */
 		res = k_sem_take(&data->device_sync_sem, K_MSEC(100));
 		/*
+		 * The irq will be enabled at the condition of start or
+		 * repeat start of I2C. If timeout occurs without being
+		 * wake up during suspend(ex: interrupt is not fired),
+		 * the irq should be disabled immediately.
+		 */
+		irq_disable(config->i2c_irq_base);
+		/*
 		 * The transaction is dropped on any error(timeout, NACK, fail,
 		 * bus error, device error).
 		 */

--- a/drivers/i2c/i2c_ite_it8xxx2.c
+++ b/drivers/i2c/i2c_ite_it8xxx2.c
@@ -771,8 +771,6 @@ static int i2c_it8xxx2_transfer(const struct device *dev, struct i2c_msg *msgs,
 		if (i2c_bus_not_available(dev)) {
 			/* Recovery I2C bus */
 			i2c_recover_bus(dev);
-			printk("I2C ch%d reset cause %d\n", config->port,
-			       I2C_RC_NO_IDLE_FOR_START);
 			/*
 			 * After resetting I2C bus, if I2C bus is not available
 			 * (No external pull-up), drop the transaction.


### PR DESCRIPTION
ITE: drivers/i2c: remove redundant printk
This printk has been printed in i2c_recovery_bus routine,
so here is redundant.

ITE: drivers/i2c: disable the interrupt
The irq will be enabled at the condition of start or repeat
start of I2C. If timeout occurs without being wake up during
suspend(ex: interrupt is not fired), the irq should be
disabled immediately.

Signed-off-by: Tim Lin <tim2.lin@ite.corp-partner.google.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zephyrproject-rtos/zephyr/37099)
<!-- Reviewable:end -->
