### PR TITLE
Bluetooth: fix C++ linker errors

### DIFF
--- a/include/bluetooth/buf.h
+++ b/include/bluetooth/buf.h
@@ -23,6 +23,10 @@
 #include <bluetooth/hci.h>
 #include <sys/util.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** Possible types of buffers passed around the Bluetooth stack */
 enum bt_buf_type {
 	/** HCI command */
@@ -154,5 +158,9 @@ static inline enum bt_buf_type bt_buf_get_type(struct net_buf *buf)
 /**
  * @}
  */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZEPHYR_INCLUDE_BLUETOOTH_BUF_H_ */


### PR DESCRIPTION
Add missing header guards.