### PR TITLE
doc: ci: publish: install graphviz

### DIFF
--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -56,7 +56,7 @@ jobs:
 
     - name: install-pkgs
       run: |
-        sudo apt-get install -y ninja-build doxygen
+        sudo apt-get install -y ninja-build doxygen graphviz
 
     - name: cache-pip
       uses: actions/cache@v1


### PR DESCRIPTION
Graphviz was missing on the doc publish workflow.