### PR TITLE
manifest: openthread upmerge up to commit `2e625bfe`

### DIFF
--- a/subsys/net/l2/openthread/Kconfig.features
+++ b/subsys/net/l2/openthread/Kconfig.features
@@ -140,6 +140,9 @@ config OPENTHREAD_MULTIPLE_INSTANCE
 config OPENTHREAD_NEIGHBOR_DISCOVERY_AGENT
 	bool "Enable neighbor discovery agent support"
 
+config OPENTHREAD_NETDATA_PUBLISHER
+	bool "Enable Thread Network Data publisher"
+
 config OPENTHREAD_PING_SENDER
 	bool "Enable ping sender support"
 

--- a/subsys/net/lib/openthread/platform/radio.c
+++ b/subsys/net/lib/openthread/platform/radio.c
@@ -272,6 +272,10 @@ void transmit_message(struct k_work *tx_job)
 	radio_api->set_channel(radio_dev, sTransmitFrame.mChannel);
 	radio_api->set_txpower(radio_dev, tx_power);
 
+	net_pkt_set_ieee802154_frame_secured(tx_pkt,
+					     sTransmitFrame.mInfo.mTxInfo.mIsSecurityProcessed);
+	net_pkt_set_ieee802154_mac_hdr_rdy(tx_pkt, sTransmitFrame.mInfo.mTxInfo.mIsHeaderUpdated);
+
 	if ((radio_api->get_capabilities(radio_dev) & IEEE802154_HW_TXTIME) &&
 	    (sTransmitFrame.mInfo.mTxInfo.mTxDelay != 0)) {
 		uint64_t tx_at = sTransmitFrame.mInfo.mTxInfo.mTxDelayBaseTime +
@@ -325,6 +329,10 @@ void transmit_message(struct k_work *tx_job)
 
 static inline void handle_tx_done(otInstance *aInstance)
 {
+	sTransmitFrame.mInfo.mTxInfo.mIsSecurityProcessed =
+		net_pkt_ieee802154_frame_secured(tx_pkt);
+	sTransmitFrame.mInfo.mTxInfo.mIsHeaderUpdated = net_pkt_ieee802154_mac_hdr_rdy(tx_pkt);
+
 	if (IS_ENABLED(CONFIG_OPENTHREAD_DIAG) && otPlatDiagModeGet()) {
 		otPlatDiagRadioTransmitDone(aInstance, &sTransmitFrame, tx_result);
 	} else {

--- a/west.yml
+++ b/west.yml
@@ -183,7 +183,7 @@ manifest:
       revision: 6010f0523cbc75f551d9256cf782f173177acdef
       path: modules/lib/open-amp
     - name: openthread
-      revision: 542b14a5bc5b38f29e2cab892c66da670a524b05
+      revision: 6e88d170bb7567d5e9638168e597f602ff3b6046
       path: modules/lib/openthread
     - name: segger
       revision: 3a52ab222133193802d3c3b4d21730b9b1f1d2f6


### PR DESCRIPTION
Update manifest with OpenThread up to commit `2e625bfe` and make use of new `mIsHeaderUpdated` flag in TX frame metadata.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>