### PR TITLE
tests: bluetooth: shell: Filter tests on dts "storage_partition"

### DIFF
--- a/tests/bluetooth/shell/testcase.yaml
+++ b/tests/bluetooth/shell/testcase.yaml
@@ -32,6 +32,7 @@ tests:
 # Bluetooth Audio Compile validation tests
   bluetooth.shell.no_vcs:
     build_only: true
+    filter: dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
     integration_platforms:
       - native_posix
     extra_configs:
@@ -39,6 +40,7 @@ tests:
     tags: bluetooth
   bluetooth.shell.no_vocs:
     build_only: true
+    filter: dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
     integration_platforms:
       - native_posix
     extra_configs:
@@ -47,6 +49,7 @@ tests:
     tags: bluetooth
   bluetooth.shell.no_aics:
     build_only: true
+    filter: dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
     integration_platforms:
       - native_posix
     extra_configs:
@@ -56,6 +59,7 @@ tests:
     tags: bluetooth
   bluetooth.shell.no_aics_vocs:
     build_only: true
+    filter: dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
     integration_platforms:
       - native_posix
     extra_configs:
@@ -67,6 +71,7 @@ tests:
     tags: bluetooth
   bluetooth.shell.no_vcs_client:
     build_only: true
+    filter: dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
     integration_platforms:
       - native_posix
     extra_configs:
@@ -74,6 +79,7 @@ tests:
     tags: bluetooth
   bluetooth.shell.no_vcs_vcs_client:
     build_only: true
+    filter: dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
     integration_platforms:
       - native_posix
     extra_configs:
@@ -82,6 +88,7 @@ tests:
     tags: bluetooth
   bluetooth.shell.vcs_client_no_aics_client:
     build_only: true
+    filter: dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
     integration_platforms:
       - native_posix
     extra_configs:
@@ -89,6 +96,7 @@ tests:
     tags: bluetooth
   bluetooth.shell.vcs_client_no_vocs_client:
     build_only: true
+    filter: dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
     integration_platforms:
       - native_posix
     extra_configs:
@@ -96,6 +104,7 @@ tests:
     tags: bluetooth
   bluetooth.shell.no_mics:
     build_only: true
+    filter: dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
     integration_platforms:
       - native_posix
     extra_configs:
@@ -103,12 +112,14 @@ tests:
     tags: bluetooth
   bluetooth.shell.no_mics_client:
     build_only: true
+    filter: dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
     integration_platforms:
       - native_posix
     extra_configs:
       - CONFIG_BT_MICS_CLIENT=n
     tags: bluetooth
   bluetooth.shell.no_mics_mics_client:
+    filter: dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
     build_only: true
     integration_platforms:
       - native_posix
@@ -117,6 +128,7 @@ tests:
       - CONFIG_BT_MICS_CLIENT=n
     tags: bluetooth
   bluetooth.shell.mics_client_no_aics_client:
+    filter: dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
     build_only: true
     integration_platforms:
       - native_posix


### PR DESCRIPTION
Some of the shell tests need a devicetree "fixed-partition" and
"storage_partition" for the settings partition support.  Not all
boards support this, so filter the tests on the devicetree having
this.

Fixes #37115

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>