### PR TITLE
subsys/mgmt/mcumgr: Add direct upload image list

### DIFF
--- a/include/mgmt/mcumgr/zephyr_groups.h
+++ b/include/mgmt/mcumgr/zephyr_groups.h
@@ -19,6 +19,9 @@ extern "C" {
 /* Basic group */
 #define ZEPHYR_MGMT_GRP_BASIC		ZEPHYR_MGMT_GRP_BASE
 #define ZEPHYR_MGMT_GRP_BASIC_CMD_ERASE_STORAGE	0	/* Command to erase storage partition */
+#define ZEPHYR_MGMT_GRP_BASIC_CMD_IMAGE_LIST	1	/* Command lists "image-?" partitions with
+							 * parameters.
+							 */
 
 #ifdef __cplusplus
 }

--- a/subsys/mgmt/mcumgr/Kconfig
+++ b/subsys/mgmt/mcumgr/Kconfig
@@ -234,6 +234,12 @@ config MCUMGR_GRP_BASIC_CMD_STORAGE_ERASE
 	help
 	  Enables command that allows to erase storage partition.
 
+config MCUMGR_GRP_BASIC_CMD_IMAGE_LIST
+	bool "Enable Zephyr specific image list"
+	help
+	  The option enables special image list that presents statuses of images by the direct
+	  upload numbers.
+
 module=MGMT_SETTINGS
 module-dep=LOG
 module-str=SETTINGS

--- a/subsys/mgmt/mcumgr/zephyr_grp/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/zephyr_grp/CMakeLists.txt
@@ -5,5 +5,11 @@
 #
 
 zephyr_library()
-zephyr_library_sources_ifdef(CONFIG_MCUMGR_GRP_BASIC_CMD_STORAGE_ERASE basic_mgmt.c)
+if (CONFIG_MCUMGR_GRP_BASIC_CMD_STORAGE_ERASE OR CONFIG_MCUMGR_GRP_BASIC_CMD_IMAGE_LIST)
+	zephyr_library_sources(basic_mgmt.c)
+endif()
 zephyr_library_link_libraries(MCUMGR)
+
+if(CONFIG_MCUMGR_GRP_BASIC_CMD_IMAGE_LIST)
+	zephyr_library_link_libraries(MCUBOOT_BOOTUTIL)
+endif()

--- a/subsys/mgmt/mcumgr/zephyr_grp/basic_mgmt.c
+++ b/subsys/mgmt/mcumgr/zephyr_grp/basic_mgmt.c
@@ -10,6 +10,9 @@
 #include <mgmt/mgmt.h>
 #include <mgmt/mcumgr/zephyr_groups.h>
 #include <storage/flash_map.h>
+#include <sys/util_macro.h>
+#include "bootutil/image.h"
+#include "bootutil/bootutil_public.h"
 
 LOG_MODULE_REGISTER(mgmt_zephyr_basic, CONFIG_MGMT_SETTINGS_LOG_LEVEL);
 
@@ -33,6 +36,89 @@ int storage_erase(void)
 	return rc;
 }
 
+
+#if defined(CONFIG_MCUMGR_GRP_BASIC_CMD_IMAGE_LIST)
+static int image_status(int id, char *buffer, ssize_t len)
+{
+	const struct flash_area *fa;
+	struct image_header hdr;
+	struct boot_swap_state bss;
+	int rc = flash_area_open(id, &fa);
+
+	if (rc < 0) {
+		LOG_ERR("Flash area %d open failed", id);
+		return -1;
+	}
+
+	rc = flash_area_read(fa, 0, &hdr, sizeof(hdr));
+	if (rc < 0) {
+		flash_area_close(fa);
+		LOG_ERR("Flash area %d read failed", id);
+		return -1;
+	}
+
+	rc = boot_read_swap_state(fa, &bss);
+	flash_area_close(fa);
+	if (rc < 0) {
+		LOG_ERR("Boot swap state %d read failed", id);
+		return -1;
+	}
+	if (hdr.ih_magic == IMAGE_MAGIC) {
+		snprintf(buffer, len, "ver=%d.%d.%d.%d%s", hdr.ih_ver.iv_major,
+			 hdr.ih_ver.iv_minor, hdr.ih_ver.iv_revision,
+			 hdr.ih_ver.iv_build_num,
+			 bss.copy_done == BOOT_FLAG_SET ? ",copy_done" : "");
+		return 1;
+	}
+	/* Not an application, not an error */
+	return 0;
+}
+
+/* Only defined images are probed */
+#define IMAGE_LIST_ITEM(n, node_label)					\
+	COND_CODE_1(DT_HAS_FIXED_PARTITION_LABEL(node_label),		\
+		({							\
+			.num = n,					\
+			.fa_id = FLASH_AREA_ID(node_label),		\
+		},), ())
+
+static int image_list(struct mgmt_ctxt *ctxt)
+{
+	static const struct {
+		int num; int fa_id;
+	} images[] = {
+		IMAGE_LIST_ITEM(1, image_0)
+		IMAGE_LIST_ITEM(2, image_1)
+		IMAGE_LIST_ITEM(3, image_2)
+		IMAGE_LIST_ITEM(4, image_3)
+	};
+	CborError cbor_err = 0;
+	char buffer[64];	/* Buffer should fit version and flags */
+
+	for (int i = 0; cbor_err == 0 && i < ARRAY_SIZE(images); i++) {
+		if (image_status(images[i].num, buffer, sizeof(buffer)) > 0) {
+			cbor_err |= cbor_encode_int(&ctxt->encoder, images[i].num);
+			cbor_err |= cbor_encode_text_stringz(&ctxt->encoder, buffer);
+		}
+	}
+
+	return cbor_err;
+}
+static int image_list_handler(struct mgmt_ctxt *ctxt)
+{
+	CborError cbor_err = 0;
+	int rc = image_list(ctxt);
+
+	cbor_err |= cbor_encode_text_stringz(&ctxt->encoder, "rc");
+	cbor_err |= cbor_encode_int(&ctxt->encoder, rc);
+	if (cbor_err != 0) {
+		return MGMT_ERR_ENOMEM;
+	}
+
+	return MGMT_ERR_EOK;
+}
+#endif
+
 static int storage_erase_handler(struct mgmt_ctxt *ctxt)
 {
 	CborError cbor_err = 0;
@@ -52,6 +138,12 @@ static const struct mgmt_handler zephyr_mgmt_basic_handlers[] = {
 		.mh_read  = NULL,
 		.mh_write = storage_erase_handler,
 	},
+#if defined(CONFIG_MCUMGR_GRP_BASIC_CMD_IMAGE_LIST)
+	[ZEPHYR_MGMT_GRP_BASIC_CMD_IMAGE_LIST] = {
+		.mh_read = image_list_handler,
+		.mh_write = NULL,
+	},
+#endif
 };
 
 static struct mgmt_group zephyr_basic_mgmt_group = {


### PR DESCRIPTION
The commit adds support for Zephyr specific command to list
"image-?" partitions, with direct image upload numbering,
and information in application versions and statuses.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>