### PR TITLE
subsys/mgmt/mcumgr: Add missing static to function storage_erase

### DIFF
--- a/subsys/mgmt/mcumgr/zephyr_grp/basic_mgmt.c
+++ b/subsys/mgmt/mcumgr/zephyr_grp/basic_mgmt.c
@@ -13,9 +13,7 @@
 
 LOG_MODULE_REGISTER(mgmt_zephyr_basic, CONFIG_MGMT_SETTINGS_LOG_LEVEL);
 
-#define STORAGE_MGMT_ID_ERASE 6
-
-int storage_erase(void)
+static int storage_erase(void)
 {
 	const struct flash_area *fa;
 	int rc = flash_area_open(FLASH_AREA_ID(storage), &fa);


### PR DESCRIPTION
The local function has been missing static specifier.
The commit also removes unused STORAGE_MGMT_ID_ERASE define.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>