### PR TITLE
RFC: native_posix fails to compile on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -366,9 +366,12 @@ if(CONFIG_USERSPACE)
   set(KOBJECT_LINKER_DEP kobject_linker)
 endif()
 
+# TODO: macOS linker has an -order_file argument that may be similar
+if (NOT (${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Darwin" AND CONFIG_ARCH_POSIX))
 get_property(TOPT GLOBAL PROPERTY TOPT)
 set_ifndef(  TOPT -Wl,-T) # clang doesn't pick -T for some reason and complains,
                           # while -Wl,-T works for both, gcc and clang
+endif()
 
 if(CONFIG_HAVE_CUSTOM_LINKER_SCRIPT)
   set(LINKER_SCRIPT ${APPLICATION_SOURCE_DIR}/${CONFIG_CUSTOM_LINKER_SCRIPT})
@@ -1492,6 +1495,8 @@ if(CONFIG_OUTPUT_DISASSEMBLE_ALL)
 endif()
 
 if(CONFIG_OUTPUT_STAT)
+# probably some equivalent command exists to read stats from a Mach-O binary
+if (NOT (${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Darwin" AND CONFIG_ARCH_POSIX))
 #  zephyr_post_build(TOOLS bintools COMMAND readelf FLAGS headers INFILE file OUTFILE outfile)
   list(APPEND
     post_build_commands
@@ -1506,6 +1511,7 @@ if(CONFIG_OUTPUT_STAT)
     post_build_byproducts
     ${KERNEL_STAT_NAME}
     )
+endif()
 endif()
 
 if(CONFIG_BUILD_OUTPUT_STRIPPED)

--- a/boards/posix/native_posix/CMakeLists.txt
+++ b/boards/posix/native_posix/CMakeLists.txt
@@ -18,6 +18,13 @@ zephyr_library_sources(
 	hw_counter.c
 	)
 
+if (${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Darwin")
+	set(STD_CPP_DIALECT_FLAGS $<TARGET_PROPERTY:compiler-cpp,dialect_cpp11>)
+	zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:${STD_CPP_DIALECT_FLAGS}>)
+	toolchain_ld_cpp()
+	zephyr_library_sources(PRIVATE macho_init.cpp)
+endif()
+
 zephyr_library_include_directories(
   ${ZEPHYR_BASE}/kernel/include
   ${ZEPHYR_BASE}/arch/posix/include

--- a/boards/posix/native_posix/macho_init.cpp
+++ b/boards/posix/native_posix/macho_init.cpp
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2021, Facebook
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <algorithm>
+#include <climits>
+#include <iostream>
+#include <list>
+#include <vector>
+#include <zephyr.h>
+#include <device.h>
+#include <soc.h>
+
+using namespace std;
+
+extern "C" {
+int __bss_start;
+int __bss_end;
+const struct device __device_start[] = {};
+const struct device __device_end[] = {};
+int __init_APPLICATION_start;
+int __init_POST_KERNEL_start;
+int __init_PRE_KERNEL_1_start;
+int __init_PRE_KERNEL_2_start;
+int __init_end;
+int __native_FIRST_SLEEP_tasks_start;
+int __native_ON_EXIT_tasks_start;
+int __native_PRE_BOOT_1_tasks_start;
+int __native_PRE_BOOT_2_tasks_start;
+int __native_PRE_BOOT_3_tasks_start;
+int __native_tasks_end;
+const struct _static_thread_data __static_thread_data_list_start[] __attribute__((used)) = {};
+const struct _static_thread_data __static_thread_data_list_end[] __attribute__((used)) = {};
+int _k_heap_list_start;
+int _k_heap_list_end;
+int _k_mem_slab_list_start;
+int _k_mem_slab_list_end;
+
+void __z_native_posix_init_add(const char *name, const void *fn, const struct device *dev, const char *levelstr, int prio);
+void __z_native_posix_init_run(int level);
+void __z_native_posix_task_add(const char *name, const void *fn, const char *levelstr, int prio);
+void __z_native_posix_task_run(int level);
+void __z_native_posix_static_thread_add(const char *name, size_t stack_size, void *entry, void *p1, void *p2, void *p3, int prio, int delay);
+};
+
+typedef int (*init_fun_t)(const struct device *);
+struct init_fun_dev {
+	//init_fun_dev() : init_fun_dev(nullptr, nullptr, nullptr, INT_MAX) {}
+	init_fun_dev(const char *name, init_fun_t fun, const struct device *dev, int prio) : name(name), fun(fun), dev(dev), prio(prio) {}
+
+	const char *name;
+	init_fun_t fun;
+	const struct device *dev;
+	unsigned prio;
+};
+
+static vector<init_fun_dev> *PRE_KERNEL_1_init_objs;
+static vector<init_fun_dev> *PRE_KERNEL_2_init_objs;
+static vector<init_fun_dev> *POST_KERNEL_init_objs;
+static vector<init_fun_dev> *APPLICATION_init_objs;
+
+void __z_native_posix_init_add(const char *name, const void *fn, const struct device *dev, const char *levelstr, int prio)
+{
+	//cout << "INIT: name: " << name << " fn: " << fn << " device: " << dev << " level: " << levelstr << " prio: " << prio << endl;
+
+	vector<init_fun_dev> *vifd = nullptr;
+	string level(levelstr);
+
+	if (PRE_KERNEL_1_init_objs == nullptr) {
+		// oddly, these get clobbered before main unless they are dynamically allocated
+		PRE_KERNEL_1_init_objs = new vector<init_fun_dev>();
+		PRE_KERNEL_2_init_objs = new vector<init_fun_dev>();
+		POST_KERNEL_init_objs = new vector<init_fun_dev>();
+		APPLICATION_init_objs = new vector<init_fun_dev>();
+		__ASSERT_NO_MSG(PRE_KERNEL_1_init_objs);
+		__ASSERT_NO_MSG(PRE_KERNEL_2_init_objs);
+		__ASSERT_NO_MSG(POST_KERNEL_init_objs);
+		__ASSERT_NO_MSG(APPLICATION_init_objs);
+	}
+
+	if (level == "PRE_KERNEL_1") {
+		vifd = PRE_KERNEL_1_init_objs;
+	} else if (level == "PRE_KERNEL_2") {
+		vifd = PRE_KERNEL_2_init_objs;
+	} else if (level == "POST_KERNEL") {
+		vifd = POST_KERNEL_init_objs;
+	} else if (level == "APPLICATION") {
+		vifd = APPLICATION_init_objs;
+	} else {
+		__ASSERT(false, "unsupported level");
+	}
+
+	vifd->push_back(init_fun_dev(name, (init_fun_t)fn, dev, prio));
+}
+
+void __z_native_posix_init_run(int level) {
+	(void) level;
+
+	vector<init_fun_dev> *vifd = nullptr;
+
+	switch(level) {
+	case _SYS_INIT_LEVEL_PRE_KERNEL_1:
+		vifd = PRE_KERNEL_1_init_objs;
+		break;
+	case _SYS_INIT_LEVEL_PRE_KERNEL_2:
+		vifd = PRE_KERNEL_2_init_objs;
+		break;
+	case _SYS_INIT_LEVEL_POST_KERNEL:
+		vifd = POST_KERNEL_init_objs;
+		break;
+	case _SYS_INIT_LEVEL_APPLICATION:
+		vifd = APPLICATION_init_objs;
+		break;
+	default:
+		__ASSERT(false, "unsupported level");
+	}
+
+	if (vifd == nullptr || vifd->size() == 0) {
+		//cout << "no init functions to execute at init level " << level << endl;
+		return;
+	}
+
+	// sort initializers by increasing priority
+	sort((*vifd).begin(), (*vifd).end(),
+		[](const init_fun_dev & a, const init_fun_dev & b) -> bool {
+			return b.prio > a.prio;
+		});
+
+	for(auto& i: *vifd) {
+		//cout << "running " << i.name << "()" << endl;
+		int rc = i.fun(i.dev);
+		if (i.dev != NULL) {
+			i.dev->state->init_res = rc;
+			if (i.dev->state->init_res == 0) {
+				i.dev->state->initialized = true;
+			}
+		}
+	}
+}
+
+typedef void (*task_fun_t)(void);
+struct task_fun {
+	task_fun(const char *name, task_fun_t fun, int prio) : name(name), fun(fun), prio(prio) {}
+
+	const char *name;
+	task_fun_t fun;
+	unsigned prio;
+};
+
+static vector<task_fun> *PRE_BOOT_1_tasks;
+static vector<task_fun> *PRE_BOOT_2_tasks;
+static vector<task_fun> *PRE_BOOT_3_tasks;
+static vector<task_fun> *FIRST_SLEEP_tasks;
+static vector<task_fun> *ON_EXIT_tasks;
+
+void __z_native_posix_task_add(const char *name, const void *fn, const char *levelstr, int prio)
+{
+	//cout << "TASK: name: " << name << " fn: " << fn << " level: " << levelstr << " prio: " << prio << endl;
+	string level(levelstr);
+	vector<task_fun> *vtf = nullptr;
+
+	if (PRE_BOOT_1_tasks == nullptr) {
+		// oddly, these get clobbered before main unless they are dynamically allocated
+		PRE_BOOT_1_tasks = new vector<task_fun>();
+		PRE_BOOT_2_tasks = new vector<task_fun>();
+		PRE_BOOT_3_tasks = new vector<task_fun>();
+		FIRST_SLEEP_tasks = new vector<task_fun>();
+		ON_EXIT_tasks = new vector<task_fun>();
+		__ASSERT_NO_MSG(PRE_BOOT_1_tasks);
+		__ASSERT_NO_MSG(PRE_BOOT_2_tasks);
+		__ASSERT_NO_MSG(PRE_BOOT_3_tasks);
+		__ASSERT_NO_MSG(FIRST_SLEEP_tasks);
+		__ASSERT_NO_MSG(ON_EXIT_tasks);
+	}
+
+	if (level == "PRE_BOOT_1") {
+		vtf = PRE_BOOT_1_tasks;
+	} else if (level == "PRE_BOOT_2") {
+		vtf = PRE_BOOT_2_tasks;
+	} else if (level == "PRE_BOOT_3") {
+		vtf = PRE_BOOT_3_tasks;
+	} else if (level == "FIRST_SLEEP") {
+		vtf = FIRST_SLEEP_tasks;
+	} else if (level == "ON_EXIT") {
+		vtf = ON_EXIT_tasks;
+	} else {
+		__ASSERT(false, "unsupported level");
+	}
+
+	vtf->push_back(task_fun(name, (task_fun_t)fn, prio));
+}
+
+void __z_native_posix_task_run(int level)
+{
+	vector<task_fun> *vtf = nullptr;
+
+	switch(level) {
+	case _NATIVE_PRE_BOOT_1_LEVEL:
+		vtf = PRE_BOOT_1_tasks;
+		break;
+	case _NATIVE_PRE_BOOT_2_LEVEL:
+		vtf = PRE_BOOT_2_tasks;
+		break;
+	case _NATIVE_PRE_BOOT_3_LEVEL:
+		vtf = PRE_BOOT_3_tasks;
+		break;
+	case _NATIVE_FIRST_SLEEP_LEVEL:
+		vtf = FIRST_SLEEP_tasks;
+		break;
+	case _NATIVE_ON_EXIT_LEVEL:
+		vtf = ON_EXIT_tasks;
+		break;
+	default:
+		__ASSERT(false, "unsupported level");
+	}
+
+	if (vtf == nullptr || vtf->size() == 0) {
+		//cout << "no tasks to execute at native task level " << level << endl;
+		return;
+	}
+
+	// sort initializers by increasing priority
+	sort(vtf->begin(), vtf->end(),
+		[](const task_fun & a, const task_fun & b) -> bool {
+			return b.prio > a.prio;
+		});
+
+	for(auto& t: *vtf) {
+		//cout << "running " << t.name << "()" << endl;
+		t.fun();
+	}
+}
+
+void __z_native_posix_static_thread_add(const char *name, size_t stack_size, void *entry, void *p1, void *p2, void *p3, int prio, int delay)
+{
+	//cout << "THREAD: " << name << " stack_size: " << stack_size << " entry: " << entry << " p1: " << p1 << " p2: " << p2 << " p3: " << p3 << " prio: " << prio << " delay: " << delay << endl;
+}

--- a/drivers/timer/sys_clock_init.c
+++ b/drivers/timer/sys_clock_init.c
@@ -18,6 +18,18 @@
 
 /* Weak-linked noop defaults for optional driver interfaces*/
 
+#if defined(__APPLE__) && defined(__MACH__)
+extern void sys_clock_isr(void *arg);
+extern int sys_clock_driver_init(const struct device *dev);
+int sys_clock_device_ctrl(const struct device *dev,
+				 uint32_t ctrl_command,
+				 enum pm_device_state *state);
+void sys_clock_set_timeout(int32_t ticks, bool idle);
+void sys_clock_idle_exit(void)
+{
+}
+void sys_clock_disable(void);
+#else /* defined(__APPLE__) && defined(__MACH__) */
 void __weak sys_clock_isr(void *arg)
 {
 	__ASSERT_NO_MSG(false);
@@ -47,6 +59,7 @@ void __weak sys_clock_idle_exit(void)
 void __weak sys_clock_disable(void)
 {
 }
+#endif /* defined(__APPLE__) && defined(__MACH__) */
 
 SYS_DEVICE_DEFINE("sys_clock", sys_clock_driver_init, sys_clock_device_ctrl,
 		PRE_KERNEL_2, CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -148,10 +148,17 @@ do {                                                                    \
 	__attribute__((section("." STRINGIFY(segment))))
 #define Z_GENERIC_DOT_SECTION(segment) __GENERIC_DOT_SECTION(segment)
 
+#if defined(__APPLE__) && defined(__MACH__)
+#define __z_section(x) __attribute__((section("__common,z_mac_sad")))
+#define ___in_section(a, b, c) __attribute__((section("__common,z_sad_mac")))
+#else
 #define ___in_section(a, b, c) \
 	__attribute__((section("." Z_STRINGIFY(a)			\
 				"." Z_STRINGIFY(b)			\
 				"." Z_STRINGIFY(c))))
+#define __z_section(x) __attribute__((__section__(x)))
+#endif
+
 #define __in_section(a, b, c) ___in_section(a, b, c)
 
 #define __in_section_unique(seg) ___in_section(seg, __FILE__, __COUNTER__)
@@ -486,13 +493,11 @@ do {                                                                    \
 #elif defined(CONFIG_ARCH_POSIX)
 #define GEN_ABSOLUTE_SYM(name, value)               \
 	__asm__(".globl\t" #name "\n\t.equ\t" #name \
-		",%c0"                              \
-		"\n\t.type\t" #name ",@object" :  : "n"(value))
+		",%c0" :  : "n"(value))
 
 #define GEN_ABSOLUTE_SYM_KCONFIG(name, value)       \
 	__asm__(".globl\t" #name                    \
-		"\n\t.equ\t" #name "," #value       \
-		"\n\t.type\t" #name ",@object")
+		"\n\t.equ\t" #name "," #value)
 
 #elif defined(CONFIG_SPARC)
 #define GEN_ABSOLUTE_SYM(name, value)			\
@@ -570,6 +575,11 @@ do {                                                                    \
 #define Z_POW2_CEIL(x) ((1UL << (31U - __builtin_clzl(x))) < x ?  \
 		1UL << (31U - __builtin_clzl(x) + 1U) : \
 		1UL << (31U - __builtin_clzl(x)))
+#endif
+
+#if defined(__APPLE__) && defined(__MACH__)
+#define __ssize_t_defined 1
+#define __off_t_defined 1
 #endif
 
 #endif /* !_LINKER */

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -18,7 +18,6 @@ target_link_libraries(kernel INTERFACE ${libkernel})
 else()
 
 list(APPEND kernel_files
-  main_weak.c
   banner.c
   device.c
   errno.c
@@ -29,6 +28,13 @@ list(APPEND kernel_files
   thread.c
   version.c
   )
+
+if (NOT (${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Darwin" AND CONFIG_ARCH_POSIX))
+list(APPEND kernel_files
+  main_weak.c
+  )
+endif()
+
 
 if(CONFIG_MULTITHREADING)
 list(APPEND kernel_files

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -54,6 +54,10 @@ void z_device_state_init(void)
  */
 void z_sys_init_run_level(int32_t level)
 {
+#if defined(__APPLE__) && defined(__MACH__)
+	extern void __z_native_posix_init_run(int level);
+	__z_native_posix_init_run(level);
+#else /* defined(__APPLE__) && defined(__MACH__) */
 	static const struct init_entry *levels[] = {
 		__init_PRE_KERNEL_1_start,
 		__init_PRE_KERNEL_2_start,
@@ -87,6 +91,7 @@ void z_sys_init_run_level(int32_t level)
 			dev->state->initialized = true;
 		}
 	}
+#endif /* defined(__APPLE__) && defined(__MACH__) */
 }
 
 const struct device *z_impl_device_get_binding(const char *name)

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -722,6 +722,7 @@ static void grant_static_access(void)
 
 void z_init_static_threads(void)
 {
+#if !(defined(__APPLE__) && defined(__MACH__))
 	_FOREACH_STATIC_THREAD(thread_data) {
 		z_setup_new_thread(
 			thread_data->init_thread,
@@ -760,6 +761,7 @@ void z_init_static_threads(void)
 		}
 	}
 	k_sched_unlock();
+#endif /* !(defined(__APPLE__) && defined(__MACH__)) */
 }
 #endif
 

--- a/lib/os/cbprintf_packaged.c
+++ b/lib/os/cbprintf_packaged.c
@@ -69,8 +69,10 @@ struct __va_list {
 	int	__vr_offs;
 };
 
+#if !(defined(__APPLE__) && defined(__MACH__))
 BUILD_ASSERT(sizeof(va_list) == sizeof(struct __va_list),
 	     "architecture specific support is wrong");
+#endif /* !(defined(__APPLE__) && defined(__MACH__)) */
 
 static int cbprintf_via_va_list(cbprintf_cb out, void *ctx,
 				const char *fmt, void *buf)

--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -38,6 +38,13 @@ static struct k_spinlock lock;
  * @return 0
  */
 /* LCOV_EXCL_START */
+#if defined(__APPLE__) && defined(__MACH__)
+int arch_printk_char_out(int c)
+{
+	extern int putchar(int c);
+	return putchar(c);
+}
+#else /* defined(__APPLE__) && defined(__MACH__) */
 __attribute__((weak)) int arch_printk_char_out(int c)
 {
 	ARG_UNUSED(c);
@@ -45,6 +52,7 @@ __attribute__((weak)) int arch_printk_char_out(int c)
 	/* do nothing */
 	return 0;
 }
+#endif /* defined(__APPLE__) && defined(__MACH__) */
 /* LCOV_EXCL_STOP */
 
 int (*_char_out)(int) = arch_printk_char_out;

--- a/scripts/gen_handles.py
+++ b/scripts/gen_handles.py
@@ -32,6 +32,7 @@ import os
 import struct
 import pickle
 from distutils.version import LooseVersion
+import magic
 
 import elftools
 from elftools.elf.elffile import ELFFile
@@ -168,11 +169,6 @@ def main():
     parse_args()
 
     assert args.kernel, "--kernel ELF required to extract data"
-    elf = ELFFile(open(args.kernel, "rb"))
-
-    edtser = os.path.join(os.path.split(args.kernel)[0], "edt.pickle")
-    with open(edtser, 'rb') as f:
-        edt = pickle.load(f)
 
     devices = []
     handles = []
@@ -182,6 +178,19 @@ def main():
                           "_DEVICE_STRUCT_SIZEOF",
                           "_DEVICE_STRUCT_HANDLES_OFFSET"])
     ld_constants = dict()
+
+    filetype = magic.from_file(args.kernel)
+    if filetype.startswith('Mach-O'):
+        with open(args.output_source, "w") as fp:
+            # not sure if anything needs to be written here
+            pass
+        return
+
+    elf = ELFFile(open(args.kernel, "rb"))
+
+    edtser = os.path.join(os.path.split(args.kernel)[0], "edt.pickle")
+    with open(edtser, 'rb') as f:
+        edt = pickle.load(f)
 
     for section in elf.iter_sections():
         if isinstance(section, SymbolTableSection):

--- a/scripts/gen_offset_header.py
+++ b/scripts/gen_offset_header.py
@@ -14,7 +14,9 @@ intended for use in assembly code.
 
 from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import SymbolTableSection
+import magic
 import argparse
+import subprocess
 import sys
 
 
@@ -38,21 +40,46 @@ def gen_offset_header(input_name, input_file, output_file):
 #ifndef %s
 #define %s\n\n""" % (include_guard, include_guard))
 
-    obj = ELFFile(input_file)
-    for sym in get_symbol_table(obj).iter_symbols():
-        if isinstance(sym.name, bytes):
-            sym.name = str(sym.name, 'ascii')
+    filetype = magic.from_file(input_name)
 
-        if not sym.name.endswith(('_OFFSET', '_SIZEOF')):
-            continue
-        if sym.entry['st_shndx'] != 'SHN_ABS':
-            continue
-        if sym.entry['st_info']['bind'] != 'STB_GLOBAL':
-            continue
+    if filetype.startswith('ELF'):
+        obj = ELFFile(input_file)
+        for sym in get_symbol_table(obj).iter_symbols():
+            if isinstance(sym.name, bytes):
+                sym.name = str(sym.name, 'ascii')
 
-        output_file.write(
-            "#define %s 0x%x\n" %
-            (sym.name, sym.entry['st_value']))
+            if not sym.name.endswith(('_OFFSET', '_SIZEOF')):
+                continue
+            if sym.entry['st_shndx'] != 'SHN_ABS':
+                continue
+            if sym.entry['st_info']['bind'] != 'STB_GLOBAL':
+                continue
+
+            output_file.write(
+                "#define %s 0x%x\n" %
+                (sym.name, sym.entry['st_value']))
+
+    elif filetype.startswith('Mach-O'):
+        process = subprocess.run('nm -g {}'.format(input_name), shell=True,
+                                 check=True, stdout=subprocess.PIPE, universal_newlines=True)
+        output = process.stdout
+
+        for line in output.splitlines():
+            word = line.split()
+            if len(word) != 3:
+                continue
+
+            sym = type('', (), {})()
+            sym.entry = word[0]
+            sym.type = word[1]
+            sym.name = word[2]
+
+            if not sym.name.endswith(('_OFFSET', '_SIZEOF')):
+                continue
+            if sym.type != 'A':
+                continue
+
+            output_file.write('#define {} 0x{}\n'.format(sym.name, sym.entry))
 
     output_file.write("\n#endif /* %s */\n" % include_guard)
 

--- a/soc/posix/inf_clock/soc.c
+++ b/soc/posix/inf_clock/soc.c
@@ -226,6 +226,10 @@ void posix_boot_cpu(void)
  */
 void run_native_tasks(int level)
 {
+#if defined(__APPLE__) && defined(__MACH__)
+	extern void __z_native_posix_task_run(int level);
+	__z_native_posix_task_run(level);
+#else /* defined(__APPLE__) && defined(__MACH__) */
 	extern void (*__native_PRE_BOOT_1_tasks_start[])(void);
 	extern void (*__native_PRE_BOOT_2_tasks_start[])(void);
 	extern void (*__native_PRE_BOOT_3_tasks_start[])(void);
@@ -250,6 +254,7 @@ void run_native_tasks(int level)
 			(*fptr)();
 		}
 	}
+#endif /* defined(__APPLE__) && defined(__MACH__) */
 }
 
 /**

--- a/soc/posix/inf_clock/soc.h
+++ b/soc/posix/inf_clock/soc.h
@@ -42,10 +42,21 @@ void posix_soc_clean_up(void);
  * Note that for the PRE and ON_EXIT levels neither the Zephyr kernel or
  * any Zephyr thread are running.
  */
+#if defined(__APPLE__) && defined(__MACH__)
+#define NATIVE_TASK(fn, level, prio)	\
+	__attribute__((constructor)) \
+	static void _CONCAT(__ctor_, fn)(void) { \
+		extern void __z_native_posix_task_add(const char *n, \
+			const void *f, const char *l, int p); \
+		__z_native_posix_task_add(STRINGIFY(fn), fn, STRINGIFY(level), \
+			prio); \
+	}
+#else
 #define NATIVE_TASK(fn, level, prio)	\
 	static void (*_CONCAT(__native_task_, fn)) __used	\
-	__attribute__((__section__(".native_" #level STRINGIFY(prio) "_task")))\
+	__z_section(".native_" #level STRINGIFY(prio) "_task")\
 	= fn
+#endif /* defined(__APPLE__) && defined(__MACH__) */
 
 
 #define _NATIVE_PRE_BOOT_1_LEVEL	0


### PR DESCRIPTION
This was a bit of a hack, but it really highlights some of the things that we take for granted with Linux and otherwise with ELF-based targets.

Specifically, on macOS:

* the Mach-O binary file format lacks:
  * weak symbol support
  * support for section names > 16 characters
* The assembler (llvm) does not support the `.type` directive
* The `--whole-archive` option is not supported by the macOS linker
* `va_list` size is [inconsistent](https://github.com/zephyrproject-rtos/zephyr/blob/main/lib/os/cbprintf_packaged.c#L72) for cbprintf:
  * on macOS (64-bit) `sizeof(va_list)`: 8 `sizeof(struct __va_list)`: 32

The Mach-O binary format limitations definitely present the greatest challenges currently to targetting macOS for native_posix_64 in the long run.

# Weak Symbol Support

The `__attribute__((weak_import))` is supposedly supported on macOS, but at the time this commit was made, it did absolutely nothing. Perhaps there is some other special applesauce that was missing 🤷.

Often, weak symbols are used in place of explicit infrastructure for overriding function implementations or symbol values. Weak symbols are actually not a standard feature of C and are mainly an ELF convenience. As a result, Zephyr will not be fully portable to different toolchains until weak symbols are removed entirely.

# Section Name Limitations

In addition to a section name, macOS also relies on a segment name. The combination of the two looks like this:

`__attribute__((section("segment_name,section_name")))`

Both the `segment_name` and `section_name` are limited to 1 <= n <= 16 ascii characters in length. ELF solves that problem by placing section names into the string table. Perhaps that could be a long- term solution if the proper patches could be supplied to LLVM and Apple, but the adoption of that is unlikely. It's quite likely that the same proposal has already been made a number of times.

Currently, we rely a great deal on `Z_ITERABLE_SECTION()` and `Z_STRUCT_SECTION_FOREACH()`. It does not seem like a realistic expectation to rely on the C preprocessor and linker to perform all of the heavy lifting necessary for processing sections on macOS.

In addition to section names that are defined *dynamically* via macro-pasting (set at compile time), we also have *statically* defined sections that are just defined in source code without any macro-pasting (set prior to compile time). There is some work currently being done on CMake generated linker scripts #36140 where the section naming is brought out of C and placed in the build system, which would help for the *statically* defined sections.

For *dynamic* section names that are set at compile-time, currently there are 2 possible solutions.

## Possible Solution No. 1

It may be possible to solve this problem by creating a new macro that behaves slightly differently for ELF vs Mach-O targets; on ELF, it could create the section name as usual, but with  Mach-O,  it could use the `__attribute__((constructor))` to copy the relevant details to an unordered map for later processing. A slight modification of this approach could be used to sort each item into an ordered map.

If we then transition `Z_STRUCT_SECTION_FOREACH()` to a runtime function call with a callback, then the ELF implementation could operate more or less as usual, but the Mach-O implementation could be adjusted to simply process the previously updated data structures.

```
void __z_struct_section_foreach(const char *section, void (*cb)(void *));
```

There is a proof of concept working for that in this PR.

## Possible Solution No. 2

Another possible solution for *dynamic* sections is to add symbol metadata in the form of strings and then perform some post-processing of those symbols and sections, similarly to what we do now with the various ELF hack scripts.

For this approach, my thoughts are:
1. Place all such symbols into `__attribute__((section("__DATA,z_macho_tmp")))`
1. Encode `"symbol_name,intended_elf_section"` tuple as a const string in `__attribute__((section("__DATA,z_macho_tuple")))`
  a. possibly some other construct that guarantees uniqueness
1. In postprocessing, use the hash of the intended ELF section as a new section name
  a. so e.g. `__z_foo_init_PRIORITY_BOOT_1_foo` => `a57c313908dbe` or something
1. Copy the symbol to the new section
1. Repeat for each tuple
1. Discard `z_macho_tmp` section
1. Discard `z_macho_tuple` section

## Useful Links

Details about the Mach-O binary format and linker-generated sections can
be found at the links below:
https://opensource.apple.com/source/xnu/xnu-4903.221.2/EXTERNAL_HEADERS/mach-o/loader.h.auto.html
https://github.com/aidansteele/osx-abi-macho-file-format-reference
https://stackoverflow.com/questions/17669593/how-to-get-a-pointer-to-a-binary-section-in-mac-os-x

Fixes #10945