### PR TITLE
west.yml: hal_stm32: Update STM32 HCI lib to v1.9.0

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -118,7 +118,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 2016f613f8138b8abe42013ab983a0d2fe0459b9
+      revision: 7e5f46d25a292f4a140af6da7afc0efc67d56e45
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Update STM32WB HCI lib based on STM32Cube package V1.9.0.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>