### PR TITLE
net: Fix missing __ASSERT_ON macro

### DIFF
--- a/subsys/net/buf.c
+++ b/subsys/net/buf.c
@@ -330,7 +330,9 @@ success:
 			return NULL;
 		}
 
+#if __ASSERT_ON
 		NET_BUF_ASSERT(req_size <= size);
+#endif
 	} else {
 		buf->__buf = NULL;
 	}


### PR DESCRIPTION
Fix missing `__ASSERT_ON` cause build error
when not defined.

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>