### PR TITLE
drivers: clock_control: stm32h7: fix comment mistake 'bansk'

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -327,7 +327,7 @@ static inline int stm32_clock_control_on(const struct device *dev,
 
 	ARG_UNUSED(dev);
 
-	/* Both cores can access bansk by following LL API */
+	/* Both cores can access banks by following LL API */
 	/* Using "_Cn_" LL API would restrict access to one or the other */
 	z_stm32_hsem_lock(CFG_HW_RCC_SEMID, HSEM_LOCK_DEFAULT_RETRY);
 	switch (pclken->bus) {
@@ -376,7 +376,7 @@ static inline int stm32_clock_control_off(const struct device *dev,
 
 	ARG_UNUSED(dev);
 
-	/* Both cores can access bansk by following LL API */
+	/* Both cores can access banks by following LL API */
 	/* Using "_Cn_" LL API would restrict access to one or the other */
 	z_stm32_hsem_lock(CFG_HW_RCC_SEMID, HSEM_LOCK_DEFAULT_RETRY);
 	switch (pclken->bus) {


### PR DESCRIPTION
Signed-off-by: Oliver Yang <cameledyang@pm.me>