### PR TITLE
twister: No error when skipping quarantined tests in integration mode

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -3270,8 +3270,8 @@ class TestSuite(DisablePyTestCollectionMixin):
         for instance in self.discards:
             instance.reason = self.discards[instance]
             # If integration mode is on all skips on integration_platforms are treated as errors.
-            # TODO: add quarantine relief here when PR with quarantine feature gets merged
-            if self.integration and instance.platform.name in instance.testcase.integration_platforms:
+            if self.integration and instance.platform.name in instance.testcase.integration_platforms \
+                and "Quarantine" not in instance.reason:
                 instance.status = "error"
                 instance.reason += " but is one of the integration platforms"
                 instance.fill_results_by_status()


### PR DESCRIPTION
When integration mode is on, any skips on integration_platforms are
treated as errors. This patch adds an exemption for quarantined tests.
They will stay as skipped.

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>