### PR TITLE
drivers: GPIO: Microchip: Fix GPIO interrupt enable spurious interrupt

### DIFF
--- a/drivers/gpio/gpio_mchp_xec.c
+++ b/drivers/gpio/gpio_mchp_xec.c
@@ -13,6 +13,10 @@
 
 #include "gpio_utils.h"
 
+#define XEC_GPIO_EDGE_DLY_COUNT		8
+/* read only register in same AHB segmment for dummy writes */
+#define XEC_GPIO_DLY_ADDR		0x40080150u
+
 #define GPIO_IN_BASE(config) \
 	((__IO uint32_t *)(GPIO_PARIN_BASE + (config->port_num << 2)))
 
@@ -211,6 +215,7 @@ static int gpio_xec_pin_interrupt_configure(const struct device *dev,
 	 */
 	current_pcr1 = config->pcr1_base + pin;
 	*current_pcr1 = (*current_pcr1 & ~mask) | pcr1;
+	__DMB(); /* insure write completes */
 
 	if (mode != GPIO_INT_MODE_DISABLED) {
 		/* We enable the interrupts in the EC aggregator so that the


### PR DESCRIPTION
Microchip MEC GPIO hardware can trigger a spurious interrupt when
interrupt detection is set to edge mode especially falling edge mode.
Clearing the status immediately after enabling interrupt detection does
not work because the hardware takes a small number of AHB clocks to
set the status. After interrupt detection enable we spin for a small
number of cycles reading a hardware register to generate delay. By this
time the spurious status is present and cleared before enabling the
interrupt in the GIRQ.

Fixes #34879.

Signed-off-by: Scott Worley <scott.worley@microchip.com>