### PR TITLE
Bluetooth: Controller: Resolve AdvA in AUX_CONNECT_RSP PDU

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_internal.h
@@ -4,9 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+bool lll_scan_adva_check(struct lll_scan *lll, uint8_t addr_type, uint8_t *addr,
+			 uint8_t rl_idx);
+bool lll_scan_ext_tgta_check(struct lll_scan *lll, bool pri, bool is_init,
+			     struct pdu_adv *pdu, uint8_t rl_idx);
 void lll_scan_prepare_connect_req(struct lll_scan *lll, struct pdu_adv *pdu_tx,
 				  uint8_t phy, uint8_t adv_tx_addr,
 				  uint8_t *adv_addr, uint8_t init_tx_addr,
 				  uint8_t *init_addr, uint32_t *conn_space_us);
-bool lll_scan_ext_tgta_check(struct lll_scan *lll, bool pri, bool is_init,
-			     struct pdu_adv *pdu, uint8_t rl_idx);


### PR DESCRIPTION
Add implementation to resolve AdvA in the received
AUX_CONNECT_RSP PDU before generating the connection
complete.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>