### PR TITLE
sys: ring_buffer: ring_buf_peek() and ring_buf_size_get()

### DIFF
--- a/include/sys/ring_buffer.h
+++ b/include/sys/ring_buffer.h
@@ -216,6 +216,18 @@ static inline uint32_t ring_buf_capacity_get(struct ring_buf *buf)
 }
 
 /**
+ * @brief Determine used space in a ring buffer.
+ *
+ * @param buf Address of ring buffer.
+ *
+ * @return Ring buffer space used (in 32-bit words or bytes).
+ */
+static inline uint32_t ring_buf_size_get(struct ring_buf *buf)
+{
+	return buf->tail - buf->head;
+}
+
+/**
  * @brief Write a data item to a ring buffer.
  *
  * This routine writes a data item to ring buffer @a buf. The data item
@@ -405,6 +417,34 @@ int ring_buf_get_finish(struct ring_buf *buf, uint32_t size);
  * @retval Number of bytes written to the output buffer.
  */
 uint32_t ring_buf_get(struct ring_buf *buf, uint8_t *data, uint32_t size);
+
+/**
+ * @brief Peek at data from a ring buffer.
+ *
+ * This routine reads data from a ring buffer @a buf without removal.
+ *
+ * @warning
+ * Use cases involving multiple reads of the ring buffer must prevent
+ * concurrent read operations, either by preventing all readers from
+ * being preempted or by using a mutex to govern reads to the ring buffer.
+ *
+ * @warning
+ * Ring buffer instance should not mix byte access and  item mode
+ * (calls prefixed with ring_buf_item_).
+ *
+ * @warning
+ * Multiple calls to peek will result in the same data being 'peeked'
+ * multiple times. To remove data, use either @ref ring_buf_get or
+ * @ref ring_buf_get_claim followed by @ref ring_buf_get_finish with a
+ * non-zero `size`.
+ *
+ * @param buf  Address of ring buffer.
+ * @param data Address of the output buffer. Cannot be NULL.
+ * @param size Data size (in bytes).
+ *
+ * @retval Number of bytes written to the output buffer.
+ */
+uint32_t ring_buf_peek(struct ring_buf *buf, uint8_t *data, uint32_t size);
 
 /**
  * @}

--- a/lib/os/ring_buffer.c
+++ b/lib/os/ring_buffer.c
@@ -284,3 +284,28 @@ uint32_t ring_buf_get(struct ring_buf *buf, uint8_t *data, uint32_t size)
 
 	return total_size;
 }
+
+uint32_t ring_buf_peek(struct ring_buf *buf, uint8_t *data, uint32_t size)
+{
+	uint8_t *src;
+	uint32_t partial_size;
+	uint32_t total_size = 0U;
+	int err;
+
+	size = MIN(size, ring_buf_size_get(buf));
+
+	do {
+		partial_size = ring_buf_get_claim(buf, &src, size);
+		__ASSERT_NO_MSG(data != NULL);
+		memcpy(data, src, partial_size);
+		data += partial_size;
+		total_size += partial_size;
+		size -= partial_size;
+	} while (size && partial_size);
+
+	/* effectively unclaim total_size bytes */
+	err = ring_buf_get_finish(buf, 0);
+	__ASSERT_NO_MSG(err == 0);
+
+	return total_size;
+}

--- a/tests/lib/ringbuffer/src/main.c
+++ b/tests/lib/ringbuffer/src/main.c
@@ -676,6 +676,81 @@ void test_capacity(void)
 			"Unexpected capacity");
 }
 
+void test_size(void)
+{
+	uint32_t size;
+	static uint8_t buf[RINGBUFFER_SIZE];
+
+	ring_buf_init(&ringbuf_raw, sizeof(buf), ringbuf_raw.buf.buf8);
+
+	/* Test 0 */
+	size = ring_buf_size_get(&ringbuf_raw);
+	zassert_equal(0, size, "wrong size: exp: %u act: %u", 0, size);
+
+	/* Test 1 */
+	ring_buf_put(&ringbuf_raw, "x", 1);
+	size = ring_buf_size_get(&ringbuf_raw);
+	zassert_equal(1, size, "wrong size: exp: %u act: %u", 1, size);
+
+	/* Test N */
+	ring_buf_reset(&ringbuf_raw);
+	ring_buf_put(&ringbuf_raw, buf, sizeof(buf));
+	size = ring_buf_size_get(&ringbuf_raw);
+	zassert_equal(sizeof(buf), size, "wrong size: exp: %u: actual: %u", sizeof(buf), size);
+
+	/* Test N - 2 with wrap-around */
+	ring_buf_put(&ringbuf_raw, buf, sizeof(buf));
+	ring_buf_get(&ringbuf_raw, NULL, 3);
+	ring_buf_put(&ringbuf_raw, "x", 1);
+
+	size = ring_buf_size_get(&ringbuf_raw);
+	zassert_equal(sizeof(buf) - 2, size, "wrong size: exp: %u: actual: %u", sizeof(buf) - 2,
+		      size);
+}
+
+void test_peek(void)
+{
+	uint32_t size;
+	uint8_t byte = 0x42;
+	static uint8_t buf[RINGBUFFER_SIZE];
+
+	ring_buf_init(&ringbuf_raw, sizeof(buf), ringbuf_raw.buf.buf8);
+
+	/* Test 0 */
+	size = ring_buf_peek(&ringbuf_raw, (uint8_t *)0x1, 42424242);
+	zassert_equal(0, size, "wrong peek size: exp: %u: actual: %u", 0, size);
+
+	/* Test 1 */
+	ring_buf_put(&ringbuf_raw, "*", 1);
+	size = ring_buf_peek(&ringbuf_raw, &byte, 1);
+	zassert_equal(1, size, "wrong peek size: exp: %u: actual: %u", 1, size);
+	zassert_equal('*', byte, "wrong buffer contents: exp: %u: actual: %u", '*', byte);
+	size = ring_buf_size_get(&ringbuf_raw);
+	zassert_equal(1, size, "wrong buffer size: exp: %u: actual: %u", 1, size);
+
+	/* Test N */
+	ring_buf_reset(&ringbuf_raw);
+	for (size = 0; size < sizeof(buf); ++size) {
+		buf[size] = 'A' + (size % ('Z' - 'A' + 1));
+	}
+
+	ring_buf_put(&ringbuf_raw, buf, sizeof(buf));
+	memset(buf, '*', sizeof(buf)); /* fill with pattern */
+
+	size = ring_buf_peek(&ringbuf_raw, buf, sizeof(buf));
+	zassert_equal(sizeof(buf), size, "wrong peek size: exp: %u: actual: %u", sizeof(buf), size);
+	size = ring_buf_size_get(&ringbuf_raw);
+	zassert_equal(sizeof(buf), size, "wrong buffer size: exp: %u: actual: %u", sizeof(buf),
+		      size);
+
+	for (size = 0; size < sizeof(buf); ++size) {
+		ringbuf_raw.buf.buf8[size] = 'A' + (size % ('Z' - 'A' + 1));
+	}
+
+	zassert_equal(0, memcmp(buf, ringbuf_raw.buf.buf8, sizeof(buf)),
+		      "content validation failed");
+}
+
 void test_reset(void)
 {
 	uint8_t indata[] = {1, 2, 3, 4, 5};
@@ -969,6 +1044,8 @@ void test_main(void)
 		       ztest_unit_test(test_byte_put_free),
 		       ztest_unit_test(test_ringbuffer_equal_bufs),
 		       ztest_unit_test(test_capacity),
+		       ztest_unit_test(test_size),
+		       ztest_unit_test(test_peek),
 		       ztest_unit_test(test_reset),
 		       ztest_unit_test(test_ringbuffer_performance),
 		       ztest_unit_test(test_ringbuffer_concurrent)


### PR DESCRIPTION
Add `ring_buf_size_get()` to get the number of bytes currently available in the ring buffer.

Add `ring_buf_peek()` to read data from the head of a ring buffer without removal.

Fixes #37145
