### PR TITLE
Microchip: MEC172x: Add all peripherals to device tree

### DIFF
--- a/dts/arm/microchip/mec172xnsz.dtsi
+++ b/dts/arm/microchip/mec172xnsz.dtsi
@@ -256,6 +256,201 @@
 				status = "disabled";
 			};
 		};
+		gpio_000_036: gpio@40081000 {
+			reg = < 0x40081000 0x80 0x40081300 0x04
+				0x40081380 0x04 0x400813fc 0x04>;
+			interrupts = <3 2>;
+			gpio-controller;
+			label="GPIO000_036";
+			#gpio-cells=<2>;
+		};
+		gpio_040_076: gpio@40081080 {
+			reg = < 0x40081080 0x80 0x40081304 0x04
+				0x40081384 0x04 0x400813f8 0x4>;
+			interrupts = <2 2>;
+			gpio-controller;
+			label="GPIO040_076";
+			#gpio-cells=<2>;
+		};
+		gpio_100_136: gpio@40081100 {
+			reg = < 0x40081100 0x80 0x40081308 0x04
+				0x40081388 0x04 0x400813f4 0x04>;
+			gpio-controller;
+			interrupts = <1 2>;
+			label="GPIO100_136";
+			#gpio-cells=<2>;
+		};
+		gpio_140_176: gpio@40081180 {
+			reg = < 0x40081180 0x80 0x4008130c 0x04
+				0x4008138c 0x04 0x400813f0 0x04>;
+			gpio-controller;
+			interrupts = <0 2>;
+			label="GPIO140_176";
+			#gpio-cells=<2>;
+		};
+		gpio_200_236: gpio@40081200 {
+			reg = < 0x40081200 0x80 0x40081310 0x04
+				0x40081390 0x04 0x400813ec 0x04>;
+			gpio-controller;
+			interrupts = <4 2>;
+			label="GPIO200_236";
+			#gpio-cells=<2>;
+		};
+		gpio_240_276: gpio@40081280 {
+			reg = < 0x40081280 0x80 0x40081314 0x04
+				0x40081394 0x04 0x400813e8 0x04>;
+			gpio-controller;
+			interrupts = <17 2>;
+			label="GPIO240_276";
+			#gpio-cells=<2>;
+		};
+		wdog: watchdog@40000400 {
+			reg = <0x40000400 0x400>;
+			interrupts = <171 0>;
+			girqs = <21 2>;
+			pcrs = <1 9>;
+			label = "WDT_0";
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+		};
+		rtimer: timer@40007400 {
+			reg = <0x40007400 0x10>;
+			interrupts = <111 0>;
+			label = "RTIMER";
+			girqs = <23 10>;
+		};
+		timer0: timer@40000c00 {
+			clock-frequency = <48000000>;
+			reg = <0x40000C00 0x20>;
+			interrupts = <136 0>;
+			girqs = <23 0>;
+			pcrs = <1 30>;
+			label = "TIMER_0";
+			max-value = <0xFFFF>;
+			prescaler = <0>;
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		timer1: timer@40000c20 {
+			clock-frequency = <48000000>;
+			reg = <0x40000C20 0x20>;
+			interrupts = <137 0>;
+			girqs = <23 1>;
+			pcrs = <1 31>;
+			label = "TIMER_1";
+			max-value = <0xFFFF>;
+			prescaler = <0>;
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		timer2: timer@40000c40 {
+			clock-frequency = <48000000>;
+			reg = <0x40000C40 0x20>;
+			interrupts = <138 0>;
+			girqs = <23 2>;
+			pcrs = <3 21>;
+			label = "TIMER_2";
+			max-value = <0xFFFF>;
+			prescaler = <0>;
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		timer3: timer@40000c60 {
+			clock-frequency = <48000000>;
+			reg = <0x40000C60 0x20>;
+			interrupts = <139 0>;
+			girqs = <23 3>;
+			pcrs = <3 22>;
+			label = "TIMER_3";
+			max-value = <0xFFFF>;
+			prescaler = <0>;
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		timer4: timer@40000c80 {
+			clock-frequency = <48000000>;
+			reg = <0x40000C80 0x20>;
+			interrupts = <140 0>;
+			girqs = <23 4>;
+			pcrs = <3 23>;
+			label = "TIMER_4";
+			max-value = <0xFFFFFFFF>;
+			prescaler = <0>;
+			exclude;
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		timer5: timer@40000ca0 {
+			clock-frequency = <48000000>;
+			reg = <0x40000CA0 0x20>;
+			interrupts = <141 0>;
+			girqs = <23 5>;
+			pcrs = <3 24>;
+			label = "TIMER_5";
+			max-value = <0xFFFFFFFF>;
+			prescaler = <0>;
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		cntr0: timer@40000d00 {
+			reg = <0x40000d00 0x20>;
+			interrupts = <142 0>;
+			girqs = <23 6>;
+			pcrs = <4 2>;
+			label = "EVTMR_0";
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		cntr1: timer@40000d20 {
+			reg = <0x40000d20 0x20>;
+			interrupts = <143 0>;
+			girqs = <23 7>;
+			pcrs = <4 3>;
+			label = "EVTMR_1";
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		cntr2: timer@40000d40 {
+			reg = <0x40000d40 0x20>;
+			interrupts = <144 0>;
+			girqs = <23 8>;
+			pcrs = <4 3>;
+			label = "EVTMR_2";
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		cntr3: timer@40000d60 {
+			reg = <0x40000d60 0x20>;
+			interrupts = <145 0>;
+			girqs = <23 9>;
+			pcrs = <4 4>;
+			label = "EVTMR_3";
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		cctmr0: timer@40001000 {
+			reg = <0x40001000 0x40>;
+			interrupts = <146 0>, <147 0>, <148 0>, <149 0>,
+				     <150 0>, <151 0>, <152 0>, <153 0>,
+				     <154 0>;
+			girqs = <18 20>, <18 21>, <18 22>, <18 23>, <18 24>,
+				<18 25>, <18 26>, <18 27>, <18 28>;
+			pcrs = <3 30>;
+			label = "CCTMR_0";
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
 		hibtimer0: timer@40009800 {
 			reg = <0x40009800 0x20>;
 			interrupts = <112 0>;
@@ -267,6 +462,109 @@
 			interrupts = <113 0>;
 			girqs = <23 17>;
 			label = "HIBTIMER_1";
+		};
+		weektmr0: timer@4000ac80 {
+			reg = <0x4000ac80 0x80>;
+			interrupts = <114 0>, <115 0>, <116 0>,
+				     <117 0>, <118 0>;
+			girqs = <21 3>, <21 4>, <21 5>, <21 6>, <21 7>;
+			label = "WEEKTMR_0";
+			status = "disabled";
+		};
+		vbm0: vbm@4000a800 {
+			reg = <0x4000a800 0x100>;
+			label = "VBM_0";
+		};
+		vci0: vci@4000ae00 {
+			reg = <0x4000ae00 0x40>;
+			interrupts = <121 0>, <122 0>, <123 0>,
+				     <124 0>, <125 0>;
+			girqs = <21 10>, <21 11>, <21 12>, <21 13>, <21 14>;
+			label = "VCI_0";
+			#girqs-cells = <2>;
+			status = "disabled";
+		};
+		dmac: dmac@40002400 {
+			reg = <0x40002400 0xc00>;
+			interrupts = <24 0>, <25 0>, <26 0>, <27 0>,
+				     <28 0>, <29 0>, <30 0>, <31 0>,
+				     <32 0>, <33 0>, <34 0>, <35 0>,
+				     <36 0>, <37 0>, <38 0>, <39 0>;
+			girqs = <14 0>, <14 1>, <14 2>, <14 3>,
+				<14 4>, <14 5>, <14 6>, <14 7>,
+				<14 8>, <14 9>, <14 10>, <14 11>,
+				<14 12>, <14 13>, <14 14>, <14 15>;
+			pcrs = <1 6>;
+			label = "DMA_0";
+			#dma-cells = <2>;
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		i2c_smb_0: i2c@40004000 {
+			reg = <0x40004000 0x80>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			interrupts = <20 1>;
+			girqs = <13 0>;
+			pcrs = <1 10>;
+			label = "I2C_SMB_0";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		i2c_smb_1: i2c@40004400 {
+			reg = <0x40004400 0x80>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			interrupts = <21 1>;
+			girqs = <13 1>;
+			pcrs = <3 13>;
+			label = "I2C_SMB_1";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		i2c_smb_2: i2c@40004800 {
+			reg = <0x40004800 0x80>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			interrupts = <22 1>;
+			girqs = <13 2>;
+			pcrs = <3 14>;
+			label = "I2C_SMB_2";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		i2c_smb_3: i2c@40004c00 {
+			reg = <0x40004C00 0x80>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			interrupts = <23 1>;
+			girqs = <13 3>;
+			pcrs = <3 15>;
+			label = "I2C_SMB_3";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		i2c_smb_4: i2c@40005000 {
+			reg = <0x40005000 0x80>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			interrupts = <158 1>;
+			girqs = <13 4>;
+			pcrs = <3 20>;
+			label = "I2C_SMB_4";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
 		};
 		uart0: uart@400f2400 {
 			compatible = "ns16550";
@@ -286,6 +584,395 @@
 			current-speed = <38400>;
 			label = "UART_1";
 			reg-shift = <0>;
+			status = "disabled";
+		};
+		ps2_0: ps2@40009000 {
+			reg = <0x40009000 0x40>;
+			interrupts = <100 1>;
+			girqs = <18 10>;
+			pcrs = <3 5>;
+			label = "PS2_0";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		pwm0: pwm@40005800 {
+			reg = <0x40005800 0x20>;
+			pcrs = <1 4>;
+			label = "PWM_0";
+			status = "disabled";
+			#pwm-cells = <1>;
+			#pcrs-cells = <2>;
+		};
+		pwm1: pwm@40005810 {
+			reg = <0x40005810 0x20>;
+			pcrs = <1 20>;
+			label = "PWM_1";
+			status = "disabled";
+			#pwm-cells = <1>;
+			#pcrs-cells = <2>;
+		};
+		pwm2: pwm@40005820 {
+			reg = <0x40005820 0x20>;
+			pcrs = <1 21>;
+			label = "PWM_2";
+			status = "disabled";
+			#pwm-cells = <1>;
+			#pcrs-cells = <2>;
+		};
+		pwm3: pwm@40005830 {
+			reg = <0x40005830 0x20>;
+			pcrs = <1 22>;
+			label = "PWM_3";
+			status = "disabled";
+			#pwm-cells = <1>;
+			#pcrs-cells = <2>;
+		};
+		pwm4: pwm@40005840 {
+			reg = <0x40005840 0x20>;
+			pcrs = <1 23>;
+			label = "PWM_4";
+			status = "disabled";
+			#pwm-cells = <1>;
+			#pcrs-cells = <2>;
+		};
+		pwm5: pwm@40005850 {
+			reg = <0x40005850 0x20>;
+			pcrs = <1 24>;
+			label = "PWM_5";
+			status = "disabled";
+			#pwm-cells = <1>;
+			#pcrs-cells = <2>;
+		};
+		pwm6: pwm@40005860 {
+			reg = <0x40005860 0x20>;
+			pcrs = <1 25>;
+			label = "PWM_6";
+			status = "disabled";
+			#pwm-cells = <1>;
+			#pcrs-cells = <2>;
+		};
+		pwm7: pwm@40005870 {
+			reg = <0x40005870 0x20>;
+			pcrs = <1 26>;
+			label = "PWM_7";
+			status = "disabled";
+			#pwm-cells = <1>;
+			#pcrs-cells = <2>;
+		};
+		pwm8: pwm@40005880 {
+			reg = <0x40005880 0x20>;
+			pcrs = <1 27>;
+			label = "PWM_8";
+			status = "disabled";
+			#pwm-cells = <1>;
+			#pcrs-cells = <2>;
+		};
+		tach0: tach@40006000 {
+			reg = <0x40006000 0x10>;
+			interrupts = <71 4>;
+			girqs = <17 1>;
+			pcrs = <1 2>;
+			label = "TACH_0";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		tach1: tach@40006010 {
+			reg = <0x40006010 0x10>;
+			interrupts = <72 4>;
+			girqs = <17 2>;
+			pcrs = <1 11>;
+			label = "TACH_1";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		tach2: tach@40006020 {
+			reg = <0x40006020 0x10>;
+			interrupts = <73 4>;
+			girqs = <17 3>;
+			pcrs = <1 12>;
+			label = "TACH_2";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		tach3: tach@40006030 {
+			reg = <0x40006030 0x10>;
+			interrupts = <159 4>;
+			girqs = <17 4>;
+			pcrs = <1 13>;
+			label = "TACH_3";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		rpmfan0: rpmfan@4000a000 {
+			reg = <0x4000a000 0x80>;
+			interrrupts = <74 1>, <75 1>;
+			girqs = <17 20>, <17 21>;
+			pcrs = <3 12>;
+			label = "RPMFAN_0";
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		rpmfan1: rpmfan@4000a080 {
+			reg = <0x4000a080 0x80>;
+			interrrupts = <76 1>, <77 1>;
+			girqs = <17 22>, <17 23>;
+			pcrs = <4 7>;
+			label = "RPMFAN_1";
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		adc0: adc@40007c00 {
+			reg = <0x40007c00 0x90>;
+			interrupts = <78 0>, <79 0>;
+			girqs = <17 8>, <17 9>;
+			pcrs = <3 3>;
+			label = "ADC_0";
+			status = "disabled";
+			#io-channel-cells = <1>;
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+		};
+		kscan0: kscan@40009c00 {
+			reg = <0x40009c00 0x18>;
+			interrupts = <135 0>;
+			girqs = <21 25>;
+			pcrs = <3 11>;
+			label = "KSCAN";
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+		};
+		peci0: peci@40006400 {
+			reg = <0x40006400 0x80>;
+			interrupts = <70 4>;
+			girqs = <17 0>;
+			pcrs = <1 1>;
+			label = "PECI_0";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+		};
+		spi0: spi@40070000 {
+			reg = <0x40070000 0x400>;
+			interrupts = <91 2>;
+			girqs = <18 1>;
+			pcrs = <4 8>;
+			clock-frequency = <12000000>;
+			label = "SPI_0";
+			ldmas = <3 3>;
+			lines = <1>;
+			chip_select = <0>;
+			dcsckon = <6>;
+			dckcsoff = <4>;
+			dldh = <6>;
+			dcsda = <6>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			#girqs-cells = <2>;
+			#ldma-cells = <2>;
+			#legdma-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		spi1: spi@40009400 {
+			reg = <0x40009400 0x80>;
+			interrupts = <92 2>, <93 2>;
+			girqs = <18 2>, <18 3>;
+			pcrs = <3 9>;
+			label = "SPI_1";
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		spi2: spi@40009480 {
+			reg = <0x40009480 0x80>;
+			interrupts = <94 2>, <95 2>;
+			girqs = <18 4>, <18 5>;
+			pcrs = <4 22>;
+			label = "SPI_2";
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		prochot0: prochot@40003400 {
+			reg = <0x40003400 0x20>;
+			interrupts = <87 0>;
+			girqs = <17 17>;
+			pcrs = <4 13>;
+			label = "PROCHOT_0";
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		rcid0: rcid@40001400 {
+			reg = <0x40001400 0x80>;
+			interrupts = <80 0>;
+			girqs = <17 10>;
+			pcrs = <4 10>;
+			label = "RCID_0";
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		rcid1: rcid@40001480 {
+			reg = <0x40001480 0x80>;
+			interrupts = <81 0>;
+			girqs = <17 11>;
+			pcrs = <4 11>;
+			label = "RCID_1";
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		rcid2: rcid@40001500 {
+			reg = <0x40001500 0x80>;
+			interrupts = <82 0>;
+			girqs = <17 12>;
+			pcrs = <4 12>;
+			label = "RCID_2";
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		spip0: spip@40007000 {
+			reg = <0x40007000 0x100>;
+			interrupts = <90 0>;
+			girqs = <18 0>;
+			pcrs = <4 16>;
+			label = "SPIP_0";
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		bbled0: bbled@4000b800 {
+			reg = <0x4000b800 0x100>;
+			interrupts = <83 0>;
+			girqs = <17 13>;
+			pcrs = <3 16>;
+			label = "BBLED_0";
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		bbled1: bbled@4000b900 {
+			reg = <0x4000b900 0x100>;
+			interrupts = <84 0>;
+			girqs = <17 14>;
+			pcrs = <3 17>;
+			label = "BBLED_1";
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		bbled2: bbled@4000ba00 {
+			reg = <0x4000ba00 0x100>;
+			interrupts = <85 0>;
+			girqs = <17 15>;
+			pcrs = <3 18>;
+			label = "BBLED_2";
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		bbled3: bbled@4000bb00 {
+			reg = <0x4000bb00 0x100>;
+			interrupts = <86 0>;
+			girqs = <17 16>;
+			pcrs = <3 25>;
+			label = "BBLED_3";
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		bclink0: bclink@4000cd00 {
+			reg = <0x4000cd00 0x20>;
+			interrupts = <96 0>, <97 0>;
+			girqs = <18 7>, <18 6>;
+			pcrs = <3 19>;
+			label = "BCLINK_0";
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		mbox0: mbox@400f0000 {
+			reg = <0x400f0000 0x200>;
+			interrupts = <60 0>;
+			girqs = <15 20>;
+			pcrs = <2 17>;
+			label = "MBOX_0";
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		emi0: emi@400f4000 {
+			reg = <0x400f4000 0x400>;
+			interrupts = <42 0>;
+			girqs = <15 2>;
+			label = "EMI_0";
+			#girqs-cells = <2>;
+			status = "disabled";
+		};
+		emi1: emi@400f4400 {
+			reg = <0x400f4400 0x400>;
+			interrupts = <43 0>;
+			girqs = <15 3>;
+			label = "EMI_1";
+			#girqs-cells = <2>;
+			status = "disabled";
+		};
+		emi2: emi@400f4800 {
+			reg = <0x400f4800 0x400>;
+			interrupts = <44 0>;
+			girqs = <15 4>;
+			label = "EMI_2";
+			#girqs-cells = <2>;
+			status = "disabled";
+		};
+		rtc0: rtc@400f5000 {
+			reg = <0x400f5000 0x100>;
+			interrupts = <119 0>, <120 0>;
+			girqs = <21 8>, <21 9>;
+			pcrs = <2 18>;
+			label = "RTC_0";
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		p80bd0: p80bd@400f8000 {
+			reg = <0x400f8000 0x800>;
+			interrupts = <62 0>;
+			girqs = <15 22>;
+			pcrs = <2 25>;
+			label = "P80BD_0";
+			#girqs-cells = <2>;
+			#pcrs-cells = <2>;
+			status = "disabled";
+		};
+		tfdp0: tfdp@40008c00 {
+			reg = <0x40008c00 0x10>;
+			pcrs = <1 7>;
+			label = "TFDP_0";
+			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		glblcfg0: glblcfg@400fff00 {


### PR DESCRIPTION
Add nearly all the MEC172x peripherals to chip device tree.
MEC172x drivers will use parameters from their device node(s).
No drivers loaded at this time.

Signed-off-by: Scott Worley <scott.worley@microchip.com>