### PR TITLE
espi: npcx: Add missing includes to header

### DIFF
--- a/soc/arm/nuvoton_npcx/common/soc_espi.h
+++ b/soc/arm/nuvoton_npcx/common/soc_espi.h
@@ -7,6 +7,9 @@
 #ifndef _NUVOTON_NPCX_SOC_ESPI_H_
 #define _NUVOTON_NPCX_SOC_ESPI_H_
 
+#include <device.h>
+#include <sys/util.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Add the missing includes to make the header more portable. It currently
requires other headers to be included before it.

Signed-off-by: Yuval Peress <peress@chromium.org>