### PR TITLE
west.yml: allow users to easily add more modules

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -62,6 +62,7 @@
 /soc/arm64/xenvm/                         @lorc
 /soc/arm64/arm/                           @povergoing
 /soc/arm64/arm/fvp_aemv8a/                @carlocaione
+/submanifests/*                           @mbolivar-nordic
 /arch/x86/                                @jhedberg @nashif @jenmwms @aasthagr
 /arch/nios2/                              @nashif
 /arch/posix/                              @aescolar @daor-oti

--- a/doc/guides/modules.rst
+++ b/doc/guides/modules.rst
@@ -400,6 +400,11 @@ your own.
    use other Zephyr modules provided by :ref:`west <west>`.
    This can for example be useful for special test purposes.
 
+If you want to permanently add modules to the zephyr workspace and you are
+using zephyr as your manifest repository, you can also add a west manifest file
+into the :zephyr_file:`submanifests` directory. See
+:zephyr_file:`submanifests/README.txt` for more details.
+
 See :ref:`west-basics` for more on west workspaces.
 
 Finally, you can also specify the list of modules yourself in various ways, or

--- a/submanifests/README.txt
+++ b/submanifests/README.txt
@@ -1,0 +1,10 @@
+This directory can contain additional west manifest files. Any files
+in this directory will be included in the main west.yml file sorted by
+filename.
+
+See example.yaml.sample for an example.
+
+For more details about how this works, see this part of the west
+documentation:
+
+https://docs.zephyrproject.org/latest/guides/west/manifest.html#example-2-2-downstream-with-directory-of-manifest-files

--- a/submanifests/example.yaml.sample
+++ b/submanifests/example.yaml.sample
@@ -1,0 +1,18 @@
+# Example manifest file you can include into the main west.yml file.
+#
+# To make this work, copy this file's contents to a new file,
+# 'example.yaml', in the same directory.
+#
+# Then change the 'name' and 'url' below and run 'west update'.
+#
+# Your module will be added to the local workspace and kept in sync
+# every time you run 'west update'.
+#
+# If you want to fetch a particular commit rather than the main
+# branch, change the 'revision' line accordingly.
+
+manifest:
+  projects:
+    - name: my-module
+      url: https://github.com/my-username/my-module
+      revision: main

--- a/west.yml
+++ b/west.yml
@@ -219,3 +219,4 @@ manifest:
   self:
     path: zephyr
     west-commands: scripts/west-commands.yml
+    import: submanifests


### PR DESCRIPTION
Import any manifest files in a new 'submanifests' directory into
west.yml.

This lets users define custom zephyr modules or easily override
built-in modules by dropping their own manifest files into
submanifests/some-user-file.yaml.

Provide an example and a README with links to the relevant
documentation in 'submanifests' to get users started.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>