### PR TITLE
samples: net: lwm2m_client: Minor typo in lwm2m sample log message

### DIFF
--- a/samples/net/lwm2m_client/src/lwm2m-client.c
+++ b/samples/net/lwm2m_client/src/lwm2m-client.c
@@ -444,7 +444,7 @@ static void rd_client_event(struct lwm2m_ctx *client,
 		break;
 
 	case LWM2M_RD_CLIENT_EVENT_NETWORK_ERROR:
-		LOG_ERR("LwM2M engine reported a network erorr.");
+		LOG_ERR("LwM2M engine reported a network error.");
 		lwm2m_rd_client_stop(client, rd_client_event);
 		break;
 	}


### PR DESCRIPTION
Just a minor typo in the log output. Was a bit jarring when I saw it.