### PR TITLE
cmake: oneApi: add oneApi support on windows

### DIFF
--- a/arch/x86/core/ia32.cmake
+++ b/arch/x86/core/ia32.cmake
@@ -1,7 +1,8 @@
 # Copyright (c) 2019 Intel Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-if (CMAKE_C_COMPILER_ID STREQUAL "Clang")
+if (CMAKE_C_COMPILER_ID STREQUAL "Clang"
+  OR CMAKE_C_COMPILER_ID STREQUAL "IntelLLVM")
   # We rely on GAS for assembling, so don't use the integrated assembler
   zephyr_compile_options($<$<COMPILE_LANGUAGE:ASM>:-no-integrated-as>)
 elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU")

--- a/arch/x86/ia32.cmake
+++ b/arch/x86/ia32.cmake
@@ -12,7 +12,8 @@ endif()
 set_property(GLOBAL PROPERTY PROPERTY_OUTPUT_ARCH "i386")
 set_property(GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT "elf32-i386")
 
-if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
+if(CMAKE_C_COMPILER_ID STREQUAL "Clang"
+  OR CMAKE_C_COMPILER_ID STREQUAL "IntelLLVM")
   zephyr_compile_options(-Qunused-arguments)
 
   zephyr_cc_option(

--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -609,6 +609,11 @@ endif()
 include(${ZEPHYR_BASE}/cmake/target_toolchain.cmake)
 
 project(Zephyr-Kernel VERSION ${PROJECT_VERSION})
+
+# Add .S file extension suffix into CMAKE_ASM_SOURCE_FILE_EXTENSIONS,
+# because clang from OneApi can't recongnize them as asm files on
+# windows now.
+list(APPEND CMAKE_ASM_SOURCE_FILE_EXTENSIONS "S")
 enable_language(C CXX ASM)
 # The setup / configuration of the toolchain itself and the configuration of
 # supported compilation flags are now split, as this allows to use the toolchain

--- a/cmake/bintools/oneApi/target.cmake
+++ b/cmake/bintools/oneApi/target.cmake
@@ -7,7 +7,10 @@ endif()
 
 find_program(CMAKE_AR      llvm-ar      ${find_program_clang_args}   )
 find_program(CMAKE_NM      llvm-nm      ${find_program_clang_args}   )
-find_program(CMAKE_OBJDUMP llvm-objdump ${find_program_clang_args}   )
+# In OneApi installation directory on Windows, there is no llvm-objdump
+# binary, so would better use objdump from system environment both
+# on Linux and Windows.
+find_program(CMAKE_OBJDUMP objdump      ${find_program_binutils_args})
 find_program(CMAKE_RANLIB  llvm-ranlib  ${find_program_clang_args}   )
 find_program(CMAKE_OBJCOPY llvm-objcopy ${find_program_binutils_args})
 find_program(CMAKE_READELF readelf      ${find_program_binutils_args})

--- a/cmake/compiler/clang/target.cmake
+++ b/cmake/compiler/clang/target.cmake
@@ -69,7 +69,7 @@ if(NOT "${ARCH}" STREQUAL "posix")
     list(APPEND TOOLCHAIN_LIBS gcc)
   endif()
 
-  set(CMAKE_REQUIRED_FLAGS -nostartfiles -nostdlib ${isystem_include_flags})
+  list(APPEND CMAKE_REQUIRED_FLAGS -nostartfiles -nostdlib ${isystem_include_flags})
   string(REPLACE ";" " " CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
 
 endif()

--- a/cmake/toolchain/oneApi/generic.cmake
+++ b/cmake/toolchain/oneApi/generic.cmake
@@ -6,14 +6,15 @@ else()
   set_ifndef(ONEAPI_TOOLCHAIN_PATH "$ENV{ONEAPI_TOOLCHAIN_PATH}")
 endif()
 
+# the default oneApi installation path is related to os
+string(TOLOWER ${CMAKE_HOST_SYSTEM_NAME} system)
 if(ONEAPI_TOOLCHAIN_PATH)
-  set(TOOLCHAIN_HOME ${ONEAPI_TOOLCHAIN_PATH}/compiler/latest/linux/bin/)
+  set(TOOLCHAIN_HOME ${ONEAPI_TOOLCHAIN_PATH}/compiler/latest/${system}/bin/)
   set(ONEAPI_PYTHON_PATH ${ONEAPI_TOOLCHAIN_PATH}/intelpython/latest/bin)
 endif()
 
 set(ONEAPI_TOOLCHAIN_PATH ${ONEAPI_TOOLCHAIN_PATH} CACHE PATH "oneApi install directory")
 
-set(COMPILER icx)
 set(LINKER lld)
 set(BINTOOLS oneApi)
 
@@ -23,8 +24,23 @@ else()
   set(triple i686-pc-none-elf)
 endif()
 
-set(CMAKE_C_COMPILER_TARGET   ${triple})
-set(CMAKE_ASM_COMPILER_TARGET ${triple})
-set(CMAKE_CXX_COMPILER_TARGET ${triple})
+if(system STREQUAL "linux")
+  set(COMPILER icx)
+  set(CMAKE_C_COMPILER_TARGET   ${triple})
+  set(CMAKE_ASM_COMPILER_TARGET ${triple})
+  set(CMAKE_CXX_COMPILER_TARGET ${triple})
+
+# icx compiler of oneApi will invoke clang-cl on windows,
+# this is not supported in zephyr now, so change to use
+# clang directly.
+# and the clang from oneApi can't recognize those cross
+# compiling target variables of cmake, so used other
+# cmake functions to pass them to clang.
+elseif(system STREQUAL "windows")
+  set(COMPILER clang)
+  list(APPEND CMAKE_REQUIRED_FLAGS --target=${triple})
+  add_compile_options(--target=${triple})
+  add_link_options(--target=${triple})
+endif()
 
 message(STATUS "Found toolchain: host (clang/ld)")


### PR DESCRIPTION
The icx compiler of oneApi will invoke clang-cl on windows,
this is not supported in zephyr now, so change to use
clang directly.
And the clang from oneApi can't recognize those cross
compiling target variables of cmake, such as
CMAKE_C_COMPILER_TARGET, so used other cmake functions
to pass them to clang.

Signed-off-by: Chen Peng1 <peng1.chen@intel.com>