### PR TITLE
ITE: soc: it8xxx2: correct extensions

### DIFF
--- a/soc/riscv/riscv-ite/CMakeLists.txt
+++ b/soc/riscv/riscv-ite/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_subdirectory(common)
 add_subdirectory(${SOC_SERIES})
-zephyr_compile_options(-march=rv32i)
+zephyr_compile_options(-march=rv32imac)

--- a/soc/riscv/riscv-ite/it8xxx2/Kconfig.soc
+++ b/soc/riscv/riscv-ite/it8xxx2/Kconfig.soc
@@ -8,7 +8,7 @@ depends on SOC_SERIES_RISCV32_IT8XXX2
 config SOC_IT8XXX2
 	bool "ITE IT8XXX2 system implementation"
 	select RISCV
-	select ATOMIC_OPERATIONS_C
+	select ATOMIC_OPERATIONS_BUILTIN
 
 endchoice
 


### PR DESCRIPTION
it8xxx2 supports 'm', 'a', and 'c' extensions.
Enable them to save flash space and also improve
latency of fetching code from flash.

Signed-off-by: Dino Li <Dino.Li@ite.com.tw>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zephyrproject-rtos/zephyr/37161)
<!-- Reviewable:end -->
