### PR TITLE
twister: Fix wrong error counter in report

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -2059,6 +2059,7 @@ class CMake():
         else:
             self.instance.status = "error"
             self.instance.reason = "Cmake build failure"
+            self.instance.fill_results_by_status()
             logger.error("Cmake build failure: %s for %s" % (self.source_dir, self.platform.name))
             results = {"returncode": p.returncode}
 


### PR DESCRIPTION
If "Cmake build failure" is detected test instance get status "error".
Despite this in final report this error is counted as failure. It can
be fix, by set proper results of each testcase in instance from None
to "BLOCK" after found Cmake error. After this fix, error is counted
properly in final report.

Fixes #37140

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>