### PR TITLE
dts: arm: stm32f0 soc serie has dma of type V2bis

### DIFF
--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -388,8 +388,8 @@
 		};
 
 		dma1: dma@40020000 {
-			compatible = "st,stm32-dma-v2";
-			#dma-cells = <3>;
+			compatible = "st,stm32-dma-v2bis";
+			#dma-cells = <2>;
 			reg = <0x40020000 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x1>;
 			interrupts = <9 0 10 0 10 0 11 0 11 0>;

--- a/dts/arm/st/f0/stm32f091.dtsi
+++ b/dts/arm/st/f0/stm32f091.dtsi
@@ -69,8 +69,8 @@
 		};
 
 		dma2: dma@40020400 {
-			compatible = "st,stm32-dma-v2";
-			#dma-cells = <3>;
+			compatible = "st,stm32-dma-v2bis";
+			#dma-cells = <2>;
 			reg = <0x40020400 0x400>;
 			interrupts = <9 0 10 0 10 0 11 0 11 0 11 0
 				      11 0 10 0 10 0 11 0 11 0 11 0>;

--- a/dts/bindings/dma/st,stm32-dma-v2bis.yaml
+++ b/dts/bindings/dma/st,stm32-dma-v2bis.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  STM32 DMA controller (V2bis) for the stm32F1 and stm32L1 soc families
+  STM32 DMA controller (V2bis) for the stm32F0, stm32F1 and stm32L1 soc families
 
   This DMA controller includes several channels with different requests.
   All the requests ar ORed before entering the DMA, so that only one request


### PR DESCRIPTION
The type of DMA for the stm32f0 devices was wrong
Its DMA is of type V2bis where the peripheral request is fixed.
The corresponding DMA cell has 2 elements.
The stm32f091 has two DMA instances.

This is modified for the stm32f030/070 and the stm32f0x1/f0x2/f0x8 families according to the RefMan.

Signed-off-by: Francois Ramu <francois.ramu@st.com>