### PR TITLE
Change Led driver PCA9633 to enable the device at init

### DIFF
--- a/drivers/led/pca9633.c
+++ b/drivers/led/pca9633.c
@@ -36,6 +36,8 @@ LOG_MODULE_REGISTER(pca9633);
 #define PCA9633_GRPFREQ         0x07
 #define PCA9633_LEDOUT          0x08
 
+/* PCA9633 mode register 1 */
+#define PCA9633_MODE1_SLEEP     0x10    /* Sleep Mode */
 /* PCA9633 mode register 2 */
 #define PCA9633_MODE2_DMBLNK    0x20    /* Enable blinking */
 
@@ -185,6 +187,14 @@ static int pca9633_led_init(const struct device *dev)
 		return -EINVAL;
 	}
 
+	/* Take the LED driver out from Sleep mode. */
+	if (i2c_reg_update_byte(data->i2c, DT_INST_REG_ADDR(0),
+				PCA9633_MODE1,
+				PCA9633_MODE1_SLEEP,
+				~PCA9633_MODE1_SLEEP)) {
+		LOG_ERR("LED reg update failed");
+		return -EIO;
+	}
 	/* Hardware specific limits */
 	dev_data->min_period = 41U;
 	dev_data->max_period = 10667U;


### PR DESCRIPTION
Update of LED Driver for PCA9633 to take the IC out from sleep at driver initialization.
Fixes #37180