### PR TITLE
Fix mdns dst address on dual stack hosts

### DIFF
--- a/subsys/net/lib/dns/dns_sd.c
+++ b/subsys/net/lib/dns/dns_sd.c
@@ -935,7 +935,7 @@ int dns_sd_extract_service_proto_domain(const uint8_t *query,
 	label_size = query[offs];
 	if (label_size == 0 || label_size > proto_size - 1
 	    || offs + label_size > query_size) {
-		NET_DBG("could not get proto for '%s...'", service);
+		NET_DBG("could not get proto for '%s...'", log_strdup(service));
 		return -EINVAL;
 	} else {
 		strncpy(proto, &query[offs + 1], label_size);
@@ -947,8 +947,8 @@ int dns_sd_extract_service_proto_domain(const uint8_t *query,
 	label_size = query[offs];
 	if (label_size == 0 || label_size > domain_size - 1
 	    || offs + label_size > query_size) {
-		NET_DBG("could not get domain for '%s.%s...'", service,
-			proto);
+		NET_DBG("could not get domain for '%s.%s...'",
+			log_strdup(service), log_strdup(proto));
 		return -EINVAL;
 	} else {
 		strncpy(domain, &query[offs + 1], label_size);
@@ -959,7 +959,9 @@ int dns_sd_extract_service_proto_domain(const uint8_t *query,
 	/* Check that we have reached the DNS terminator */
 	if (query[offs] != 0) {
 		NET_DBG("ignoring request for '%s.%s.%s...'",
-			service, proto, domain);
+			log_strdup(service),
+			log_strdup(proto),
+			log_strdup(domain));
 		return -EINVAL;
 	}
 

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -51,6 +51,11 @@ static struct net_context *ipv6;
 #define DNS_RESOLVER_BUF_CTR	(DNS_RESOLVER_MIN_BUF + \
 				 CONFIG_MDNS_RESOLVER_ADDITIONAL_BUF_CTR)
 
+#ifndef CONFIG_NET_TEST
+static int setup_dst_addr(struct net_context *ctx, struct net_pkt *pkt,
+			  struct sockaddr *dst, socklen_t *dst_len);
+#endif /* CONFIG_NET_TEST */
+
 NET_BUF_POOL_DEFINE(mdns_msg_pool, DNS_RESOLVER_BUF_CTR,
 		    DNS_RESOLVER_MAX_BUF_SIZE, 0, NULL);
 
@@ -73,10 +78,8 @@ static void create_ipv4_addr(struct sockaddr_in *addr)
 	addr->sin_addr.s_addr = htonl(0xE00000FB);
 }
 
-static int setup_dst_addr(struct net_context *ctx,
-			  struct net_pkt *pkt,
-			  struct sockaddr *dst,
-			  socklen_t *dst_len)
+int setup_dst_addr(struct net_context *ctx, struct net_pkt *pkt,
+		   struct sockaddr *dst, socklen_t *dst_len)
 {
 	if (IS_ENABLED(CONFIG_NET_IPV4) &&
 	    net_pkt_family(pkt) == AF_INET) {

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -440,7 +440,7 @@ static int dns_read(struct net_context *ctx,
 		    (result->len - 1) >= hostname_len &&
 		    &(result->data + 1)[hostname_len] == lquery) {
 			NET_DBG("mDNS query to our hostname %s.local",
-				hostname);
+				log_strdup(hostname));
 			send_response(ctx, pkt, ip_hdr, result, qtype);
 		} else if (IS_ENABLED(CONFIG_MDNS_RESPONDER_DNS_SD)
 			&& qtype == DNS_RR_TYPE_PTR) {

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -73,6 +73,28 @@ static void create_ipv4_addr(struct sockaddr_in *addr)
 	addr->sin_addr.s_addr = htonl(0xE00000FB);
 }
 
+static int setup_dst_addr(struct net_context *ctx,
+			  struct net_pkt *pkt,
+			  struct sockaddr *dst,
+			  socklen_t *dst_len)
+{
+	if (IS_ENABLED(CONFIG_NET_IPV4) &&
+	    net_pkt_family(pkt) == AF_INET) {
+		create_ipv4_addr(net_sin(dst));
+		*dst_len = sizeof(struct sockaddr_in);
+		net_context_set_ipv4_ttl(ctx, 255);
+	} else if (IS_ENABLED(CONFIG_NET_IPV6) &&
+		   net_pkt_family(pkt) == AF_INET6) {
+		create_ipv6_addr(net_sin6(dst));
+		*dst_len = sizeof(struct sockaddr_in6);
+		net_context_set_ipv6_hop_limit(ctx, 255);
+	} else {
+		return -EPFNOSUPPORT;
+	}
+
+	return 0;
+}
+
 static struct net_context *get_ctx(sa_family_t family)
 {
 	struct net_context *ctx;
@@ -217,48 +239,34 @@ static int send_response(struct net_context *ctx,
 	socklen_t dst_len;
 	int ret;
 
-	if (qtype == DNS_RR_TYPE_A) {
-#if defined(CONFIG_NET_IPV4)
+	ret = setup_dst_addr(ctx, pkt, &dst, &dst_len);
+	if (ret < 0) {
+		NET_DBG("unable to set up the response address");
+		return ret;
+	}
+
+	if (IS_ENABLED(CONFIG_NET_IPV4) && qtype == DNS_RR_TYPE_A) {
 		const struct in_addr *addr;
 
 		addr = net_if_ipv4_select_src_addr(net_pkt_iface(pkt),
 						   &ip_hdr->ipv4->src);
-
-		create_ipv4_addr(net_sin(&dst));
-		dst_len = sizeof(struct sockaddr_in);
 
 		ret = create_answer(ctx, query, qtype,
 				      sizeof(struct in_addr), (uint8_t *)addr);
 		if (ret != 0) {
 			return ret;
 		}
-
-		net_context_set_ipv4_ttl(ctx, 255);
-#else /* CONFIG_NET_IPV4 */
-		return -EPFNOSUPPORT;
-#endif /* CONFIG_NET_IPV4 */
-
-	} else if (qtype == DNS_RR_TYPE_AAAA) {
-#if defined(CONFIG_NET_IPV6)
+	} else if (IS_ENABLED(CONFIG_NET_IPV6) && qtype == DNS_RR_TYPE_AAAA) {
 		const struct in6_addr *addr;
 
 		addr = net_if_ipv6_select_src_addr(net_pkt_iface(pkt),
 						   &ip_hdr->ipv6->src);
-
-		create_ipv6_addr(net_sin6(&dst));
-		dst_len = sizeof(struct sockaddr_in6);
 
 		ret = create_answer(ctx, query, qtype,
 				      sizeof(struct in6_addr), (uint8_t *)addr);
 		if (ret != 0) {
 			return -ENOMEM;
 		}
-
-		net_context_set_ipv6_hop_limit(ctx, 255);
-#else /* CONFIG_NET_IPV6 */
-		return -EPFNOSUPPORT;
-#endif /* CONFIG_NET_IPV6 */
-
 	} else {
 		/* TODO: support also service PTRs */
 		return -EINVAL;
@@ -294,6 +302,7 @@ static void send_sd_response(struct net_context *ctx,
 	const struct dns_sd_rec *record;
 	struct dns_sd_rec filter;
 	struct sockaddr dst;
+	socklen_t dst_len;
 	const struct in6_addr *addr6 = NULL;
 	const struct in_addr *addr4 = NULL;
 	char service_buf[DNS_SD_SERVICE_MAX_SIZE + 1];
@@ -303,20 +312,22 @@ static void send_sd_response(struct net_context *ctx,
 	/* This actually is used but the compiler doesn't see that */
 	ARG_UNUSED(record);
 
+	ret = setup_dst_addr(ctx, pkt, &dst, &dst_len);
+	if (ret < 0) {
+		NET_DBG("unable to set up the response address");
+		return;
+	}
+
 	if (IS_ENABLED(CONFIG_NET_IPV4)) {
 		/* Look up the local IPv4 address */
 		addr4 = net_if_ipv4_select_src_addr(net_pkt_iface(pkt),
 					   &ip_hdr->ipv4->src);
-		create_ipv4_addr(net_sin(&dst));
-		net_context_set_ipv4_ttl(ctx, 255);
 	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV6)) {
 		/* Look up the local IPv6 address */
 		addr6 = net_if_ipv6_select_src_addr(net_pkt_iface(pkt),
 					   &ip_hdr->ipv6->src);
-		create_ipv6_addr(net_sin6(&dst));
-		net_context_set_ipv6_hop_limit(ctx, 255);
 	}
 
 	ret = dns_sd_extract_service_proto_domain(dns_msg->msg,
@@ -349,7 +360,7 @@ static void send_sd_response(struct net_context *ctx,
 
 			/* Send the response */
 			ret = net_context_sendto(ctx, result->data,
-				result->len, &dst, sizeof(dst), NULL,
+				result->len, &dst, dst_len, NULL,
 				K_NO_WAIT, NULL);
 			if (ret < 0) {
 				NET_DBG("Cannot send mDNS reply (%d)", ret);


### PR DESCRIPTION
Hi, hit this bug when testing the mdns client on a dual stack setup, turns out the code is setting the wrong type of address in two different conditions, resulting the response being sent to invalid address. Checking the source packet family to handle this correctly.

Also fixing few missing strdup found while debugging this.