### PR TITLE
driver: eSPI: unify the bit fields of ACPI/KBC event data

### DIFF
--- a/include/drivers/espi.h
+++ b/include/drivers/espi.h
@@ -253,6 +253,29 @@ enum lpc_peripheral_opcode {
 #endif /* CONFIG_ESPI_PERIPHERAL_CUSTOM_OPCODE */
 };
 
+/* KBC 8042 event: Input Buffer Full */
+#define HOST_KBC_EVT_IBF BIT(0)
+/* KBC 8042 event: Output Buffer Empty */
+#define HOST_KBC_EVT_OBE BIT(1)
+/**
+ * @brief Bit field definition of evt_data in struct espi_event for KBC.
+ */
+struct espi_evt_data_kbc {
+	uint32_t type:8;
+	uint32_t data:8;
+	uint32_t evt:8;
+	uint32_t reserved:8;
+};
+
+/**
+ * @brief Bit field definition of evt_data in struct espi_event for ACPI.
+ */
+struct espi_evt_data_acpi {
+	uint32_t type:8;
+	uint32_t data:8;
+	uint32_t reserved:16;
+};
+
 /**
  * @brief eSPI event
  */

--- a/soc/arm/nuvoton_npcx/common/soc_espi.h
+++ b/soc/arm/nuvoton_npcx/common/soc_espi.h
@@ -14,28 +14,6 @@
 extern "C" {
 #endif
 
-/* 8042 event data format */
-#define NPCX_8042_EVT_POS 16U
-#define NPCX_8042_DATA_POS 8U
-#define NPCX_8042_TYPE_POS 0U
-
-/* 8042 event type format */
-#define NPCX_8042_EVT_IBF BIT(0)
-#define NPCX_8042_EVT_OBE BIT(1)
-
-/*
- * The format of event data for KBC 8042 protocol:
- * [23:16] - 8042 event type: 1: Input buffer full, 2: Output buffer empty.
- * [15:8]  - 8042 data: 8-bit 8042 data.
- * [0:7]   - 8042 protocol type: 0: data type, 1: command type.
- */
-#define NPCX_8042_EVT_DATA(event, data, type) (((event) << NPCX_8042_EVT_POS) \
-	| ((data) << NPCX_8042_DATA_POS) | ((type) << NPCX_8042_TYPE_POS));
-
-/* ACPI event data format */
-#define NPCX_ACPI_DATA_POS 8U
-#define NPCX_ACPI_TYPE_POS 0U
-
 /**
  * @brief Turn on all interrupts of eSPI host interface module.
  *


### PR DESCRIPTION
The KBC/ACPI event data is 4-byte in width and composed of
event/data/type fields. However, the field position is defined by each
chip vendor via macro and not unified in the current implementation.
The commit uses the structure bit field to define and unify the field
position. It helps the application access it with a common approach.

Signed-off-by: Jun Lin <CHLin56@nuvoton.com>