### PR TITLE
board/arm stm32: SDMMC support for stm32h747i_disco

### DIFF
--- a/boards/arm/stm32h747i_disco/Kconfig.defconfig
+++ b/boards/arm/stm32h747i_disco/Kconfig.defconfig
@@ -19,4 +19,7 @@ config NET_L2_ETHERNET
 
 endif # NETWORKING
 
+config DISK_DRIVER_SDMMC
+	default y if DISK_DRIVERS
+
 endif # BOARD_STM32H747I_DISCO_M7

--- a/boards/arm/stm32h747i_disco/doc/index.rst
+++ b/boards/arm/stm32h747i_disco/doc/index.rst
@@ -73,6 +73,8 @@ The current Zephyr stm32h747i_disco board configuration supports the following h
 +-----------+------------+-------------------------------------+
 | SPI       | on-chip    | spi                                 |
 +-----------+------------+-------------------------------------+
+| SDMMC     | on-chip    | disk access                         |
++-----------+------------+-------------------------------------+
 
 (*) From UM2411 Rev 4:
    With the default setting, the Ethernet feature is not working because of
@@ -99,6 +101,7 @@ Default Zephyr Peripheral Mapping:
 - UART_1 TX/RX : PA9/PA10 (ST-Link Virtual Port Com)
 - UART_8 TX/RX : PJ8/PJ9 (Arduino Serial)
 - SPI_5 NSS/SCK/MISO/MOSI : PK1/PK0/PJ11/PJ10 (Arduino SPI)
+- SDMMC_1 D0/D1/D2/D3/CK/CMD: PC8/PC9/PC10/PC11/PC12/PD2
 - LD1 : PI12
 - LD2 : PI13
 - LD3 : PI14

--- a/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.dts
+++ b/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.dts
@@ -161,4 +161,12 @@
 	};
 };
 
+&sdmmc1 {
+	status = "okay";
+	pinctrl-0 = <&sdmmc1_d0_pc8 &sdmmc1_d1_pc9
+			&sdmmc1_d2_pc10 &sdmmc1_d3_pc11
+			&sdmmc1_ck_pc12 &sdmmc1_cmd_pd2>;
+	cd-gpios = <&gpioi 8 GPIO_ACTIVE_LOW>;
+};
+
 arduino_spi: &spi5 {};


### PR DESCRIPTION
This commit adds support for SDMMC in stm32h747i_disco. This commit is tested with fat fs list file example in samples/subsys/fs/fatfs.

Signed-off-by: Affrin Pinhero <affrin.pinhero@hcl.com>