### PR TITLE
board/arm stm32: Sdmmc init error solved.

### DIFF
--- a/boards/arm/stm32f746g_disco/Kconfig.defconfig
+++ b/boards/arm/stm32f746g_disco/Kconfig.defconfig
@@ -25,4 +25,7 @@ config KSCAN_FT5336
 
 endif # KSCAN
 
+config DISK_DRIVER_SDMMC
+	default y if DISK_DRIVERS
+
 endif # BOARD_STM32F746G_DISCO

--- a/boards/arm/stm32l496g_disco/Kconfig.defconfig
+++ b/boards/arm/stm32l496g_disco/Kconfig.defconfig
@@ -13,4 +13,7 @@ config SPI_STM32_INTERRUPT
 	default y
 	depends on SPI
 
+config DISK_DRIVER_SDMMC
+	default y if DISK_DRIVERS
+
 endif # BOARD_STM32L496G_DISCO


### PR DESCRIPTION
This commit solves SDMMC init error. In this commit, SDMMC missing configuration for stm32l496g_disco & stm32f746g_disco were added. This commit is tested with the fat fs list file example in samples/subsys/fs/fatfs. 
Signed-off-by: Affrin Pinhero <affrin.pinhero@hcl.com>