### PR TITLE
ITE: dts/riscv it8xxx2: add pinmux control of SHI

### DIFF
--- a/dts/riscv/it8xxx2-alts-map.dtsi
+++ b/dts/riscv/it8xxx2-alts-map.dtsi
@@ -99,5 +99,19 @@
 		pinctrl_i2c_data5: i2c_data5 {
 			pinctrls = <&pinmuxa 5 IT8XXX2_PINMUX_FUNC_3>;
 		};
+
+		/* SHI alternate function */
+		pinctrl_shi_mosi: shi_mosi {
+			pinctrls = <&pinmuxm 0 IT8XXX2_PINMUX_FUNC_1>;
+		};
+		pinctrl_shi_miso: shi_miso {
+			pinctrls = <&pinmuxm 1 IT8XXX2_PINMUX_FUNC_1>;
+		};
+		pinctrl_shi_clk: shi_clk {
+			pinctrls = <&pinmuxm 4 IT8XXX2_PINMUX_FUNC_1>;
+		};
+		pinctrl_shi_cs: shi_cs {
+			pinctrls = <&pinmuxm 5 IT8XXX2_PINMUX_FUNC_1>;
+		};
 	};
 };


### PR DESCRIPTION
Add pinmux control for SHI alternate function.

Signed-off-by: Tim Lin <tim2.lin@ite.corp-partner.google.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zephyrproject-rtos/zephyr/37199)
<!-- Reviewable:end -->
