### PR TITLE
 samples: subsys: mgmt: smp_svr: Define Image Version in the example

### DIFF
--- a/samples/subsys/mgmt/mcumgr/smp_svr/prj.conf
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/prj.conf
@@ -1,6 +1,9 @@
 # Enable mcumgr.
 CONFIG_MCUMGR=y
 
+# Define Image Version
+CONFIG_MCUBOOT_IMAGE_VERSION="0.0.1"
+
 # Some command handlers require a large stack.
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 


### PR DESCRIPTION
Define CONFIG_MCUBOOT_IMAGE_VERSION as default in the example, as this
is crucial for versioning using mcumgr/smp_svr

Signed-off-by: João Dullius <joaodullius@bpmrep.com.br>