### PR TITLE
boards: Revert "boards: acrn_ehl_crb: Add ibecc DTS node"

### DIFF
--- a/boards/x86/acrn/acrn_ehl_crb.dts
+++ b/boards/x86/acrn/acrn_ehl_crb.dts
@@ -5,11 +5,3 @@
  */
 
 #include "acrn.dts"
-
-/ {
-	ibecc: ibecc {
-	       compatible = "intel,ibecc";
-	       label = "ibecc";
-	       status = "okay";
-	};
-};


### PR DESCRIPTION
This reverts commit 445a23a167c027bef3468d9e77556a363ed2dd07.

This change was made with the incorrect assumption that using IBECC in
an ACRN VM is a valid use case. Turns out that ACRN will always manage
the IBECC access itself and the Zephyr driver is only useful for running
natively on the hardware.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>