### PR TITLE
modules: hal_microchip: Update Microchip HAL to version 1.2.1

### DIFF
--- a/drivers/espi/espi_mchp_xec.c
+++ b/drivers/espi/espi_mchp_xec.c
@@ -22,8 +22,6 @@
 #define ESPI_XEC_VWIRE_SEND_TIMEOUT 100ul
 
 #define VW_MAX_GIRQS                2ul
-/* Missing HAL value */
-#define MEC_ESPI_MSVW08_SRC1_VAL    BIT(5)
 
 /* 200ms */
 #define MAX_OOB_TIMEOUT             200ul

--- a/west.yml
+++ b/west.yml
@@ -77,7 +77,7 @@ manifest:
       groups:
         - hal
     - name: hal_microchip
-      revision: b280eec5d3b1296b231117c1999bcd0269b6ecc4
+      revision: 870d05e6a64ea9548da6b907058b03c8c9420826
       path: modules/hal/microchip
       groups:
         - hal


### PR DESCRIPTION
Microchip HAL update used by MEC152x projects with eSPI
definition changes.
Update west manifest point to latest HAL.
Signed-off-by: Scott Worley <scott.worley@microchip.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zephyrproject-rtos/zephyr/37214)
<!-- Reviewable:end -->
