### PR TITLE
modules: mbedtls: Provide 3rd option for MBEDTLS configuration

### DIFF
--- a/modules/mbedtls/CMakeLists.txt
+++ b/modules/mbedtls/CMakeLists.txt
@@ -35,8 +35,7 @@ if(CONFIG_ARCH_POSIX AND CONFIG_ASAN AND NOT CONFIG_64BIT)
 endif ()
 
   zephyr_library_link_libraries(mbedTLS)
-else()
-  assert(CONFIG_MBEDTLS_LIBRARY "MBEDTLS was enabled, but neither BUILTIN or LIBRARY was selected.")
+elseif (CONFIG_MBEDTLS_LIBRARY)
 
   # NB: CONFIG_MBEDTLS_LIBRARY is not regression tested and is
   # therefore susceptible to bit rot
@@ -53,6 +52,11 @@ else()
   # Lib mbedtls_external depends on libgcc (I assume?) so to allow
   # mbedtls_external to link with gcc we need to ensure it is placed
   # after mbedtls_external on the linkers command line.
+else()
+  # If none of either CONFIG_MBEDTLS_BUILTIN or CONFIG_MBEDTLS_LIBRARY
+  # are defined the users need add a custom Kconfig choice to the
+  # MBEDTLS_IMPLEMENTATION and manually add the mbedtls library and
+  # included the required directories for mbedtls in their projects.
 endif()
 
 endif()


### PR DESCRIPTION
-The current scheme in zephyr has the two choices MBEDTLS_BUILTIN
 and MBEDTLS_LIBRARY, but the choice of MBEDTLS_LIBRARY requires
 setting CONFIG_MBEDTLS_INSTALL_PATH for includes and library linking.
 This is not neccesary so the 3rd option (none of these two) is provided
 in an external project.
-Made else an elseif(CONFIG_MBEDTLS_LIBRARY.
-Removed reduntant assertion between the two choices.

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>