### PR TITLE
soc/arm: power: Leftover from pm hooks conversion to __weak

### DIFF
--- a/soc/arm/nxp_kinetis/ke1xf/power.c
+++ b/soc/arm/nxp_kinetis/ke1xf/power.c
@@ -25,7 +25,7 @@ __ramfunc static void wait_for_flash_prefetch_and_idle(void)
 }
 #endif /* CONFIG_XIP */
 
-void pm_power_state_set(struct pm_state_info info)
+__weak void pm_power_state_set(struct pm_state_info info)
 {
 	switch (info.state) {
 	case PM_STATE_RUNTIME_IDLE:
@@ -51,7 +51,7 @@ void pm_power_state_set(struct pm_state_info info)
 	}
 }
 
-void pm_power_state_exit_post_ops(struct pm_state_info info)
+__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
 {
 	ARG_UNUSED(info);
 

--- a/soc/arm/st_stm32/stm32l0/power.c
+++ b/soc/arm/st_stm32/stm32l0/power.c
@@ -27,7 +27,7 @@ LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 #endif
 
 /* Invoke Low Power/System Off specific Tasks */
-void pm_power_state_set(struct pm_state_info info)
+__weak void pm_power_state_set(struct pm_state_info info)
 {
 	switch (info.state) {
 	case PM_STATE_SUSPEND_TO_IDLE:
@@ -51,7 +51,7 @@ void pm_power_state_set(struct pm_state_info info)
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-void pm_power_state_exit_post_ops(struct pm_state_info info)
+__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
 {
 	switch (info.state) {
 	case PM_STATE_SUSPEND_TO_IDLE:

--- a/soc/arm/st_stm32/stm32wl/power.c
+++ b/soc/arm/st_stm32/stm32wl/power.c
@@ -20,7 +20,7 @@
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
 /* Invoke Low Power/System Off specific Tasks */
-void pm_power_state_set(struct pm_state_info info)
+__weak void pm_power_state_set(struct pm_state_info info)
 {
 	switch (info.state) {
 	case PM_STATE_SUSPEND_TO_IDLE:
@@ -66,7 +66,7 @@ void pm_power_state_set(struct pm_state_info info)
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-void pm_power_state_exit_post_ops(struct pm_state_info info)
+__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
 {
 	switch (info.state) {
 	case PM_STATE_SUSPEND_TO_IDLE:


### PR DESCRIPTION
In commit "pm: Fix weak linkage symbols" (PR #35274),
PM SoC hooks were converted to __weak to avoid clash with
new definition of these symbols in subsys/pm/power.c.

In this process, few SoCs were missed.
Fix this.

#37226

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>