### PR TITLE
boards: circuitdojo_feather_nrf9160: small DT improvements

### DIFF
--- a/boards/arm/circuitdojo_feather_nrf9160/circuitdojo_feather_nrf9160_common.dts
+++ b/boards/arm/circuitdojo_feather_nrf9160/circuitdojo_feather_nrf9160_common.dts
@@ -122,7 +122,7 @@
 		compatible = "st,lis2dh";
 		label = "LIS2DH";
 		reg = <0x18>;
-		irq-gpios = <&gpio0 29 0>;
+		irq-gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
 	};
 
 };
@@ -227,7 +227,7 @@
 		io-channels = <&adc 7>;
 		output-ohms = <100000>;
 		full-ohms = <(100000 + 100000)>;
-		power-gpios = <&gpio0 25 0>;
+		power-gpios = <&gpio0 25 GPIO_ACTIVE_HIGH>;
 	};
 };
 

--- a/boards/arm/circuitdojo_feather_nrf9160/circuitdojo_feather_nrf9160_common.dts
+++ b/boards/arm/circuitdojo_feather_nrf9160/circuitdojo_feather_nrf9160_common.dts
@@ -123,6 +123,7 @@
 		label = "LIS2DH";
 		reg = <0x18>;
 		irq-gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
+		disconnect-sdo-sa0-pull-up;
 	};
 
 };


### PR DESCRIPTION
Using GPIO_ACTIVE_HIGH explicitly says what is the active level of GPIO,
so prefer that instead of using 0.

LIS2DH12TR has an internal pull-up connected to SDA0 pin, while this pin
is connected directly to GND on PCB. This results in constant power
consumption, which can be prevented by disconnecting internal SDA0
pull-up. Do so by adding 'disconnect-sdo-sa0-pull-up' DT property, so
that accelerometer driver will send a proper command during boot.