### PR TITLE
Bluetooth: Mesh: Add kconfig for thread priority

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -296,6 +296,16 @@ config BT_MESH_ADV_STACK_SIZE
 	  NOTE: This is an advanced setting and should not be changed unless
 	  absolutely necessary
 
+config BT_MESH_ADV_PRIO
+	int "Mesh advertiser thread priority"
+	depends on BT_MESH_ADV_LEGACY
+	default 7
+	help
+	  Priority of bt mesh adv thread.
+
+	  NOTE: This is an advanced setting and should not be changed unless
+	  absolutely necessary
+
 config BT_MESH_IV_UPDATE_SEQ_LIMIT
 	hex "Sequence number limit to start iv update"
 	default 0x800000

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -293,6 +293,8 @@ config BT_MESH_ADV_STACK_SIZE
 	default 1024 if BT_HOST_CRYPTO
 	default 768
 	help
+	  Size of bt mesh adv thread stack.
+
 	  NOTE: This is an advanced setting and should not be changed unless
 	  absolutely necessary
 

--- a/subsys/bluetooth/mesh/adv_legacy.c
+++ b/subsys/bluetooth/mesh/adv_legacy.c
@@ -178,7 +178,8 @@ void bt_mesh_adv_init(void)
 {
 	k_thread_create(&adv_thread_data, adv_thread_stack,
 			K_KERNEL_STACK_SIZEOF(adv_thread_stack), adv_thread,
-			NULL, NULL, NULL, K_PRIO_COOP(7), 0, K_FOREVER);
+			NULL, NULL, NULL, K_PRIO_COOP(CONFIG_BT_MESH_ADV_PRIO),
+			0, K_FOREVER);
 	k_thread_name_set(&adv_thread_data, "BT Mesh adv");
 }
 


### PR DESCRIPTION
Add Kconfig `CONFIG_BT_MESH_ADV_PRIO`.

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>