### PR TITLE
ITE: gpio: it8xxx2: disable irq before configuring pin interrupt

### DIFF
--- a/drivers/gpio/gpio_ite_it8xxx2.c
+++ b/drivers/gpio/gpio_ite_it8xxx2.c
@@ -522,6 +522,9 @@ static int gpio_ite_pin_interrupt_configure(const struct device *dev,
 		return -ENOTSUP;
 	}
 
+	/* Disable irq before configuring it */
+	irq_disable(gpio_irq);
+
 	if (trig & GPIO_INT_TRIG_BOTH) {
 		uint8_t wuc_group = gpio_irqs[gpio_irq].wuc_group;
 		uint8_t wuc_mask = gpio_irqs[gpio_irq].wuc_mask;


### PR DESCRIPTION
Fixed the following assertion causing by high level functions
enable gpio interrupt at the same pin at least two times:

ASSERTION FAIL [!arch_irq_is_enabled(irq)]
@ ZEPHYR_BASE/arch/common/sw_isr_common.c:84 IRQ xxx is enabled

Signed-off-by: Dino Li <Dino.Li@ite.com.tw>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zephyrproject-rtos/zephyr/37235)
<!-- Reviewable:end -->
