### PR TITLE
Fix bme280 faulty measurement

### DIFF
--- a/drivers/sensor/bme280/bme280.c
+++ b/drivers/sensor/bme280/bme280.c
@@ -353,6 +353,12 @@ static int bme280_chip_init(const struct device *dev)
 		return -ENOTSUP;
 	}
 
+	err = bme280_reg_write(dev, BME280_REG_RESET, BME280_CMD_SOFT_RESET);
+	if (err < 0) {
+		LOG_DBG("Soft-reset failed: %d", err);
+		return err;
+	}
+
 	err = bme280_read_compensation(dev);
 	if (err < 0) {
 		return err;
@@ -380,6 +386,8 @@ static int bme280_chip_init(const struct device *dev)
 		LOG_DBG("CONFIG write failed: %d", err);
 		return err;
 	}
+	/* Wait for the sensor to be ready */
+	k_sleep(K_MSEC(1));
 
 #ifdef CONFIG_PM_DEVICE
 	/* Set power state to ACTIVE */

--- a/drivers/sensor/bme280/bme280.c
+++ b/drivers/sensor/bme280/bme280.c
@@ -408,7 +408,7 @@ int bme280_pm_ctrl(const struct device *dev, uint32_t ctrl_command,
 				ret = bme280_chip_init(dev);
 			}
 			/* Switching to OFF from any */
-			else if (new_pm_state == PM_DEVICE_STATE_OFF) {
+			else if (*state == PM_DEVICE_STATE_OFF) {
 
 				/* Put the chip into sleep mode */
 				ret = bme280_reg_write(dev,
@@ -422,7 +422,7 @@ int bme280_pm_ctrl(const struct device *dev, uint32_t ctrl_command,
 
 			/* Store the new state */
 			if (!ret)
-				data->pm_state = new_pm_state;
+				data->pm_state = *state;
 		}
 	}
 	/* Get power state */

--- a/drivers/sensor/bme280/bme280.h
+++ b/drivers/sensor/bme280/bme280.h
@@ -74,6 +74,8 @@ extern const struct bme280_bus_io bme280_bus_io_i2c;
 #define BME280_MODE_NORMAL              0x03
 #define BME280_SPI_3W_DISABLE           0x00
 #define BME280_CMD_SOFT_RESET           0xB6
+#define BME280_STATUS_MEASURING         0x08
+#define BME280_STATUS_IM_UPDATE         0x01
 
 #if defined CONFIG_BME280_MODE_NORMAL
 #define BME280_MODE BME280_MODE_NORMAL
@@ -155,7 +157,7 @@ extern const struct bme280_bus_io bme280_bus_io_i2c;
 					 BME280_SPI_3W_DISABLE)
 
 
-#define BME280_CTRL_MEAS_OFF_VAL		(BME280_PRESS_OVER | \
+#define BME280_CTRL_MEAS_OFF_VAL	(BME280_PRESS_OVER | \
 					 BME280_TEMP_OVER |  \
 					 BME280_MODE_SLEEP)
 

--- a/drivers/sensor/bme280/bme280.h
+++ b/drivers/sensor/bme280/bme280.h
@@ -63,6 +63,7 @@ extern const struct bme280_bus_io bme280_bus_io_i2c;
 #define BME280_REG_CTRL_MEAS            0xF4
 #define BME280_REG_CTRL_HUM             0xF2
 #define BME280_REG_STATUS               0xF3
+#define BME280_REG_RESET                0xE0
 
 #define BMP280_CHIP_ID_SAMPLE_1         0x56
 #define BMP280_CHIP_ID_SAMPLE_2         0x57
@@ -72,6 +73,7 @@ extern const struct bme280_bus_io bme280_bus_io_i2c;
 #define BME280_MODE_FORCED              0x01
 #define BME280_MODE_NORMAL              0x03
 #define BME280_SPI_3W_DISABLE           0x00
+#define BME280_CMD_SOFT_RESET           0xB6
 
 #if defined CONFIG_BME280_MODE_NORMAL
 #define BME280_MODE BME280_MODE_NORMAL


### PR DESCRIPTION
Fixes #37231

**Cause**

The data was being fetched before the sensor was ready. After boot, the sensor loads the NVM, which are are used to do the calculations. (See sections 4.2.2 and 5.4.4)

The NVM is loaded after power-on, and before any measurement according to the datasheet, but it takes much longer after power on than after a reset.

**Fix**
~Add a delay to  the driver initialization the ensure correct measurements after a power cycle.~

~Empirically I found that adding a 1ms delay is enough to fix the problem.~
Do a soft reset in the initialization. (Note: this makes the issue visible after every reset).

Fetch the data after the measurement has been completed and the NVM has been copied.


This has been testes in this environment:

 - OS: linux
 - Toolchain: Zephyr SDK
 - Version 2.6.0
 - Board: custom 
 - SoC: nrf52840 

**Tests**

`west build -p always -b board samples/sensor/bme280 && west flash`

The driver was tested in this modes
 * Normal mode and PM off
 * Normal mode and PM on
 * Forced mode and PM off
 * Forced mode and PM on
 
** Doc:
https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bme280-ds002.pdf
https://github.com/BoschSensortec/BME280_driver/blob/master/



 
