### PR TITLE
hal_nordic: Adjust temperature sensor stack size.

### DIFF
--- a/modules/hal_nordic/Kconfig
+++ b/modules/hal_nordic/Kconfig
@@ -122,7 +122,7 @@ config NRF_802154_TEMPERATURE_UPDATE_PRIO
 
 config NRF_802154_TEMPERATURE_UPDATE_STACK_SIZE
 	int "nRF 802.15.4 temperature update stack size"
-	default 128
+	default 256
 	help
 	  Stack size of a thread updating current temperature for nRF 802.15.4 driver.
 


### PR DESCRIPTION
This commit extends size of stack used by IEEE 802.15.4 radio
temperature sensor. This commit fixes stack overflow issue in
echo_server sample for OpenThread.

Signed-off-by: Przemyslaw Bida <przemyslaw.bida@nordicsemi.no>