### PR TITLE
MAINTAINERS: add espressif soc and colaborators

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1425,12 +1425,18 @@ Espressif Platforms:
     status: maintained
     maintainers:
         - sylvioalves
+        - glaubermaroto
+        - ulipe
     files:
         - drivers/*/*esp32*
-        - boards/xtensa/esp32/
-        - soc/xtensa/esp32/
+        - boards/xtensa/esp32*/
+        - soc/xtensa/esp32*/
+        - boards/riscv/esp32*/
+        - soc/riscv/esp32*/
         - dts/xtensa/espressif/
+        - dts/riscv/espressif/
         - dts/bindings/*/*esp32*
+        - samples/boards/esp32*
     labels:
         - "platform: ESP32"
 


### PR DESCRIPTION
Include riscv and xtensa boards

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>