### PR TITLE
modules: hal_nxp: tweak integration to utilize cmake-ext/kconfig-ext

### DIFF
--- a/modules/hal_nxp/CMakeLists.txt
+++ b/modules/hal_nxp/CMakeLists.txt
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2021 Linaro, Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+add_subdirectory(${ZEPHYR_CURRENT_MODULE_DIR} hal_nxp)

--- a/modules/hal_nxp/Kconfig
+++ b/modules/hal_nxp/Kconfig
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2021 Linaro, Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# file is empty and kept as a place holder if/when Kconfig is needed

--- a/west.yml
+++ b/west.yml
@@ -88,7 +88,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: bb97ba1cb3820d5799f53c7af765830d766b56a2
+      revision: 1d823ea49bf7f6229a1097fbff33e27ba0dd389b
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Update zephyr side to handle hal_nxp using cmake-ext/kconfig-ext.  This
allows for having zephyr specific integration code live with the zephyr
source tree.

For now on the cmake side we just use add_subdirectory() of the hal_nxp
repo so the integration is effectively transparent.

For Kconfig we add a place holder Kconfig file since the hal_nxp repo
doesn't have any Kconfig files in it currently.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>