### PR TITLE
tests: power_mgmt: Add nucleo_l476rg to integrations platforms

### DIFF
--- a/tests/subsys/pm/power_mgmt/testcase.yaml
+++ b/tests/subsys/pm/power_mgmt/testcase.yaml
@@ -7,4 +7,5 @@ tests:
     integration_platforms:
       - qemu_x86
       - mps2_an385
+      - nucleo_l476rg
     tags: power


### PR DESCRIPTION
Add a real board/SoC that supports power mgmt on the STM32 side to
get some additional coverage and hopefully catch any build issues
in the future.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>