### PR TITLE
lib: timeutil: fix linearity when no skew present

### DIFF
--- a/lib/os/timeutil.c
+++ b/lib/os/timeutil.c
@@ -28,8 +28,8 @@
  * @see http://howardhinnant.github.io/date_algorithms.html#days_from_civil
  */
 static int64_t time_days_from_civil(int64_t y,
-				  unsigned int m,
-				  unsigned int d)
+				    unsigned int m,
+				    unsigned int d)
 {
 	y -= m <= 2;
 
@@ -134,8 +134,13 @@ int timeutil_sync_ref_from_local(const struct timeutil_sync_state *tsp,
 	if ((tsp->skew > 0) && (tsp->base.ref > 0) && (refp != NULL)) {
 		const struct timeutil_sync_config *cfg = tsp->cfg;
 		int64_t local_delta = local - tsp->base.local;
-		int64_t ref_delta = (int64_t)(tsp->skew * local_delta) *
-			cfg->ref_Hz / cfg->local_Hz;
+		/* (x * 1.0) != x for large values of x.
+		 * Therefore only apply the multiplication if the skew is not one.
+		 */
+		if (tsp->skew != 1.0) {
+			local_delta *= (double)tsp->skew;
+		}
+		int64_t ref_delta = local_delta * cfg->ref_Hz / cfg->local_Hz;
 		int64_t ref_abs = (int64_t)tsp->base.ref + ref_delta;
 
 		if (ref_abs < 0) {
@@ -157,10 +162,16 @@ int timeutil_sync_local_from_ref(const struct timeutil_sync_state *tsp,
 	if ((tsp->skew > 0) && (tsp->base.ref > 0) && (localp != NULL)) {
 		const struct timeutil_sync_config *cfg = tsp->cfg;
 		int64_t ref_delta = (int64_t)(ref - tsp->base.ref);
-		double local_delta = (ref_delta * cfg->local_Hz) / cfg->ref_Hz
-			/ tsp->skew;
+		/* (x / 1.0) != x for large values of x.
+		 * Therefore only apply the division if the skew is not one.
+		 */
+		int64_t local_delta = (ref_delta * cfg->local_Hz) / cfg->ref_Hz;
+
+		if (tsp->skew != 1.0) {
+			local_delta /= (double)tsp->skew;
+		}
 		int64_t local_abs = (int64_t)tsp->base.local
-			+ (int64_t)local_delta;
+				    + (int64_t)local_delta;
 
 		*localp = local_abs;
 		rv = (int)(tsp->skew != 1.0);


### PR DESCRIPTION
Fix the linearity of the timeutil library at large deltas between base and time instants.
The core problem was that the conversion of large deltas to floats was not lossless.
Moving the floating point calculation to a conditional both stops the lossy conversion and provides a modest performance boost when skew is not used.