### PR TITLE
subsys/mgmt/hawkbit: Flash device to follow dts

### DIFF
--- a/subsys/mgmt/hawkbit/hawkbit.c
+++ b/subsys/mgmt/hawkbit/hawkbit.c
@@ -52,6 +52,9 @@ LOG_MODULE_REGISTER(hawkbit);
 #define SLOT1_SIZE FLASH_AREA_SIZE(image_1)
 #define HTTP_HEADER_CONTENT_TYPE_JSON "application/json;charset=UTF-8"
 
+#define STORAGE_NODE DT_NODE_BY_FIXED_PARTITION_LABEL(storage)
+#define FLASH_NODE DT_MTD_FROM_FIXED_PARTITION(STORAGE_NODE)
+
 #if ((CONFIG_HAWKBIT_POLL_INTERVAL > 1)	\
 	&& (CONFIG_HAWKBIT_POLL_INTERVAL < 43200))
 static uint32_t poll_sleep = (CONFIG_HAWKBIT_POLL_INTERVAL * 60 * MSEC_PER_SEC);
@@ -604,11 +607,12 @@ int hawkbit_init(void)
 	int ret = 0, rc = 0;
 	struct flash_pages_info info;
 	int32_t action_id;
+	const struct device *flash_dev;
+
+	flash_dev = DEVICE_DT_GET(FLASH_NODE);
 
 	fs.offset = FLASH_AREA_OFFSET(storage);
-	rc = flash_get_page_info_by_offs(
-		device_get_binding(DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL),
-		fs.offset, &info);
+	rc = flash_get_page_info_by_offs(flash_dev, fs.offset, &info);
 	if (rc) {
 		LOG_ERR("Unable to get storage page info");
 		return -EIO;
@@ -617,7 +621,7 @@ int hawkbit_init(void)
 	fs.sector_size = info.size;
 	fs.sector_count = 3U;
 
-	rc = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
+	rc = nvs_init(&fs, flash_dev->name);
 	if (rc) {
 		LOG_ERR("Storage flash Init failed");
 		return -ENODEV;


### PR DESCRIPTION
The flash device of "partition" should follow the devicetree.

Signed-off-by: Yong Cong Sin <yongcong.sin@gmail.com>