### PR TITLE
subsys/mgmt/hawkbit: Add missing CONFIG_HAWKBIT_LOG_LEVEL

### DIFF
--- a/subsys/mgmt/hawkbit/hawkbit.c
+++ b/subsys/mgmt/hawkbit/hawkbit.c
@@ -9,7 +9,7 @@
 
 #include <logging/log.h>
 
-LOG_MODULE_REGISTER(hawkbit);
+LOG_MODULE_REGISTER(hawkbit, CONFIG_HAWKBIT_LOG_LEVEL);
 
 #include <stdio.h>
 #include <zephyr.h>


### PR DESCRIPTION
Add missing CONFIG_HAWKBIT_LOG_LEVEL so that its verbosity can be
configured.

Signed-off-by: Yong Cong Sin <yongcong.sin@gmail.com>