### PR TITLE
subsys/mgmt/hawkbit: Fix typo

### DIFF
--- a/subsys/mgmt/hawkbit/hawkbit.c
+++ b/subsys/mgmt/hawkbit/hawkbit.c
@@ -627,7 +627,7 @@ int hawkbit_init(void)
 	LOG_DBG("Action id: current %d", action_id);
 
 	image_ok = boot_is_img_confirmed();
-	LOG_INF("Image is %s confirmed OK", image_ok ? "" : " not");
+	LOG_INF("Image is %s confirmed OK", image_ok ? "" : "not");
 	if (!image_ok) {
 		ret = boot_write_img_confirmed();
 		if (ret < 0) {


### PR DESCRIPTION
Removes the extra space before "not".

Signed-off-by: Yong Cong Sin <yongcong.sin@gmail.com>