### PR TITLE
drivers/clock_control: stm32wl: Changes around use of  HSE as input clock

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -486,18 +486,24 @@ int stm32_clock_control_init(const struct device *dev)
 	LL_RCC_MSI_Disable();
 
 #elif STM32_PLL_SRC_HSE
-	int hse_bypass;
 
+#ifndef CONFIG_SOC_SERIES_STM32WLX
+	int hse_bypass;
 	if (IS_ENABLED(STM32_HSE_BYPASS)) {
 		hse_bypass = LL_UTILS_HSEBYPASS_ON;
 	} else {
 		hse_bypass = LL_UTILS_HSEBYPASS_OFF;
 	}
+#else
+	if (IS_ENABLED(STM32_HSE_TCXO)) {
+		LL_RCC_HSE_EnableTcxo();
+	}
+	if (IS_ENABLED(STM32_HSE_DIV2)) {
+		LL_RCC_HSE_EnableDiv2();
+	}
+#endif
 
 	/* Switch to PLL with HSE as clock source */
-#ifdef CONFIG_SOC_SERIES_STM32WLX
-	LL_RCC_HSE_EnableTcxo();
-#endif
 	LL_PLL_ConfigSystemClock_HSE(
 #if !defined(CONFIG_SOC_SERIES_STM32WBX) && !defined(CONFIG_SOC_SERIES_STM32WLX)
 		CONFIG_CLOCK_STM32_HSE_CLOCK,
@@ -520,8 +526,14 @@ int stm32_clock_control_init(const struct device *dev)
 					       GET_CURRENT_FLASH_PRESCALER());
 
 	/* Calculate new SystemCoreClock variable based on HSE freq */
-	new_hclk_freq = __LL_RCC_CALC_HCLK_FREQ(CONFIG_CLOCK_STM32_HSE_CLOCK,
-						hclk_prescaler);
+	uint32_t hse_freq;
+	if (IS_ENABLED(STM32_HSE_DIV2)) {
+		hse_freq = CONFIG_CLOCK_STM32_HSE_CLOCK / 2;
+	} else {
+		hse_freq = CONFIG_CLOCK_STM32_HSE_CLOCK;
+	}
+	new_hclk_freq = __LL_RCC_CALC_HCLK_FREQ(hse_freq, hclk_prescaler);
+
 #if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_SOC_SERIES_STM32WLX)
 	new_flash_freq = RCC_CALC_FLASH_FREQ(CONFIG_CLOCK_STM32_HSE_CLOCK,
 					       flash_prescaler);
@@ -542,18 +554,18 @@ int stm32_clock_control_init(const struct device *dev)
 
 	/* Enable HSE if not enabled */
 	if (LL_RCC_HSE_IsReady() != 1) {
+#ifdef CONFIG_SOC_SERIES_STM32WLX
+		if (IS_ENABLED(STM32_HSE_TCXO)) {
+			LL_RCC_HSE_EnableTcxo();
+		}
+#else
 		/* Check if need to enable HSE bypass feature or not */
 		if (IS_ENABLED(STM32_HSE_BYPASS)) {
-#ifdef CONFIG_SOC_SERIES_STM32WLX
-			LL_RCC_HSE_EnableTcxo();
-		} else {
-			LL_RCC_HSE_DisableTcxo();
-#else
 			LL_RCC_HSE_EnableBypass();
 		} else {
 			LL_RCC_HSE_DisableBypass();
-#endif
 		}
+#endif
 
 		/* Enable HSE */
 		LL_RCC_HSE_Enable();

--- a/dts/arm/seeed/lora-e5.dtsi
+++ b/dts/arm/seeed/lora-e5.dtsi
@@ -9,7 +9,7 @@
 
 &clk_hse {
 	clock-frequency = <DT_FREQ_M(32)>;
-	hse-bypass;
+	hse-tcxo;
 };
 
 &clk_lse {

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -36,7 +36,7 @@
 	clocks {
 		clk_hse: clk-hse {
 			#clock-cells = <0>;
-			compatible = "st,stm32-hse-clock";
+			compatible = "st,stm32wl-hse-clock";
 			/* Expected clock-frequency on the whole series 32MHz */
 			clock-frequency = <DT_FREQ_M(32)>;
 			status = "disabled";

--- a/dts/bindings/clock/st,stm32wl-hse-clock.yaml
+++ b/dts/bindings/clock/st,stm32wl-hse-clock.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2021, Linaro ltd
+# SPDX-License-Identifier: Apache-2.0
+
+description: STM32WL HSE Clock
+
+compatible: "st,stm32wl-hse-clock"
+
+include: [fixed-clock.yaml]
+
+properties:
+    hse-tcxo:
+      type: boolean
+      required: false
+      description: |
+        When set, TCXO is selected as external source clock for HSE.
+        Otherwise, external cyrstal is selected as HSE source clock.
+
+    hse-div2:
+      type: boolean
+      required: false
+      description: |
+        When set HSE output clock is divided by 2.
+        Otherwise, no prescaler is used.

--- a/include/drivers/clock_control/stm32_clock_control.h
+++ b/include/drivers/clock_control/stm32_clock_control.h
@@ -309,8 +309,13 @@
 
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(clk_hse), st_stm32_hse_clock, okay)
 #define STM32_HSE_BYPASS	DT_PROP(DT_NODELABEL(clk_hse), hse_bypass)
-#else
+#elif !DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(clk_hse), st_stm32wl_hse_clock, okay)
 #define STM32_HSE_BYPASS	CONFIG_CLOCK_STM32_HSE_BYPASS
+#endif
+
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(clk_hse), st_stm32wl_hse_clock, okay)
+#define STM32_HSE_TCXO	DT_PROP(DT_NODELABEL(clk_hse), hse_tcxo)
+#define STM32_HSE_DIV2	DT_PROP(DT_NODELABEL(clk_hse), hse_div2)
 #endif
 
 struct stm32_pclken {

--- a/west.yml
+++ b/west.yml
@@ -118,7 +118,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 4200321ef1cd27cacc37b0439389424156bb1267
+      revision: 3caeeaa83d7467027f49651199c8bf3ec25456cd
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
This change around use of HSE on STM32WL is two fold:
- Make use of https://github.com/zephyrproject-rtos/hal_stm32/pull/111 which fixes a bug in STM32Cube LL API. (This is a temporary patch as official bug has been filled internally. Reference provided)
- Add a dedicated binding for STM32WL HSE clock and implement related changes

Fixes #37260