### PR TITLE
ARC: 64BIT: increase LOG_PROCESS_THREAD stack size to fix failing test

### DIFF
--- a/subsys/logging/Kconfig.processing
+++ b/subsys/logging/Kconfig.processing
@@ -78,6 +78,7 @@ config LOG_PROCESS_THREAD_STACK_SIZE
 	int "Stack size for the internal log processing thread"
 	default 4096 if (X86 && X86_64)
 	default 4096 if ARM64
+	default 4096 if (ARC && 64BIT)
 	default 4096 if SPARC
 	default 2048 if COVERAGE_GCOV
 	default 2048 if (RISCV && 64BIT)


### PR DESCRIPTION
Increase LOG_PROCESS_THREAD_STACK_SIZE for ARCv3 64 bit to fix failing test `tests/subsys/logging/log_core_additional/logging.add.async` due to stack overflow.