### PR TITLE
boards: add deprecations for various 'ns' TF-M boards

### DIFF
--- a/boards/deprecated.cmake
+++ b/boards/deprecated.cmake
@@ -7,3 +7,10 @@
 #
 # To add a board rename, add a line in following format:
 # set(<old_board_name>_DEPRECATED <new_board_name>)
+
+set(bl5340_dvk_cpuappns_DEPRECATED bl5340_dvk_cpuapp_ns)
+set(mps2_an521_nonsecure_DEPRECATED mps2_an521_ns)
+set(musca_b1_nonsecure_DEPRECATED musca_b1_ns)
+set(musca_s1_nonsecure_DEPRECATED musca_s1_ns)
+set(nrf5340dk_nrf5340_cpuappns_DEPRECATED nrf5340dk_nrf5340_cpuapp_ns)
+set(nrf9160dk_nrf9160ns_DEPRECATED nrf9160dk_nrf9160_ns)


### PR DESCRIPTION
Various non-secure variants of boards with SoCs that have Trusted
Firmware M support were recently renamed without any deprecations
added for the old names. This unnecessarily breaks the build for out
of tree users.

Fix that by adding the following deprecations (deprecated name ->
replacement name):

  bl5340_dvk_cpuappns        -> bl5340_dvk_cpuapp_ns
  mps2_an521_nonsecure       -> mps2_an521_ns
  musca_b1_nonsecure         -> musca_b1_ns
  musca_s1_nonsecure         -> musca_s1_ns
  nrf5340dk_nrf5340_cpuappns -> nrf5340dk_nrf5340_cpuapp_ns
  nrf9160dk_nrf9160ns        -> nrf9160dk_nrf9160_ns

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>