### PR TITLE
mgmt: mcumgr: make smp_shell work with shell logs

### DIFF
--- a/include/shell/shell_log_backend.h
+++ b/include/shell/shell_log_backend.h
@@ -118,6 +118,20 @@ void z_shell_log_backend_enable(const struct shell_log_backend *backend,
  */
 void z_shell_log_backend_disable(const struct shell_log_backend *backend);
 
+/** @brief Suspend shell log backend.
+ *
+ * @param backend Shell log backend instance.
+ */
+void z_shell_log_backend_suspend(const struct shell_log_backend *backend);
+
+/** @brief Resume shell log backend.
+ *	   This function can be used after calling z_shell_log_backend_suspend
+ *	   function, to resume shell log backend operations.
+ *
+ * @param backend		Shell log backend instance.
+ */
+void z_shell_log_backend_resume(const struct shell_log_backend *backend);
+
 /** @brief Trigger processing of one log entry.
  *
  * @param backend Shell log backend instance.

--- a/subsys/mgmt/mcumgr/smp_shell.c
+++ b/subsys/mgmt/mcumgr/smp_shell.c
@@ -85,6 +85,13 @@ static int read_mcumgr_byte(struct smp_shell_data *data, uint8_t byte)
 		}
 	}
 
+	if (IS_ENABLED(CONFIG_SHELL_LOG_BACKEND)) {
+		const struct shell *const sh = shell_backend_uart_get_ptr();
+
+		/* Reactivating the shell_log_backend */
+		z_shell_log_backend_resume(sh->log_backend);
+	}
+
 	/* Non-mcumgr byte received. */
 	return SMP_SHELL_MCUMGR_STATE_NONE;
 }
@@ -179,7 +186,11 @@ static int smp_shell_tx_pkt(struct zephyr_smp_transport *zst,
 			    struct net_buf *nb)
 {
 	int rc;
+	if (IS_ENABLED(CONFIG_SHELL_LOG_BACKEND)) {
+		const struct shell *const sh = shell_backend_uart_get_ptr();
 
+		z_shell_log_backend_suspend(sh->log_backend);
+	}
 	rc = mcumgr_serial_tx_pkt(nb->data, nb->len, smp_shell_tx_raw, NULL);
 	mcumgr_buf_free(nb);
 

--- a/subsys/shell/shell_log_backend.c
+++ b/subsys/shell/shell_log_backend.c
@@ -136,6 +136,16 @@ void z_shell_log_backend_disable(const struct shell_log_backend *backend)
 	backend->control_block->state = SHELL_LOG_BACKEND_DISABLED;
 }
 
+void shell_log_backend_suspend(const struct shell_log_backend *backend)
+{
+	backend->control_block->state = SHELL_LOG_BACKEND_DISABLED;
+}
+
+void z_shell_log_backend_resume(const struct shell_log_backend *backend)
+{
+	backend->control_block->state = SHELL_LOG_BACKEND_ENABLED;
+}
+
 static void msg_process(const struct log_output *log_output,
 			struct log_msg *msg, bool colors)
 {


### PR DESCRIPTION
This fix is for disabling shell_log_backend temporarily when MCUMGR
data exchange is ongoing. and reactivate when it finish.

This should fix #36882

Signed-off-by: Mohamed ElShahawi <ExtremeGTX@hotmail.com>