### PR TITLE
dts: arm: stm32f4: Add quadspi node

### DIFF
--- a/boards/arm/stm32f412g_disco/doc/index.rst
+++ b/boards/arm/stm32f412g_disco/doc/index.rst
@@ -95,6 +95,12 @@ The Zephyr stm32f412g_disco board configuration supports the following hardware 
 +-----------+------------+-------------------------------------+
 | GPIO      | on-chip    | gpio                                |
 +-----------+------------+-------------------------------------+
+| I2C       | on-chip    | i2c                                 |
++-----------+------------+-------------------------------------+
+| SPI       | on-chip    | spi                                 |
++-----------+------------+-------------------------------------+
+| QSPI NOR  | on-chip    | off-chip flash                      |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on Zephyr porting.
 

--- a/boards/arm/stm32f412g_disco/stm32f412g_disco.dts
+++ b/boards/arm/stm32f412g_disco/stm32f412g_disco.dts
@@ -123,3 +123,20 @@
 &rtc {
 	status = "okay";
 };
+
+&quadspi {
+	pinctrl-0 = <&quadspi_clk_pb2 &quadspi_bk1_ncs_pg6
+		     &quadspi_bk1_io0_pf8 &quadspi_bk1_io1_pf9
+		     &quadspi_bk1_io2_pf7 &quadspi_bk1_io3_pf6>;
+
+	status = "okay";
+
+	n25q128a1: qspi-nor-flash@0 {
+		compatible = "st,stm32-qspi-nor";
+		label = "N25Q128A1";
+		reg = <0>;
+		qspi-max-frequency = <72000000>;
+		size = <DT_SIZE_M(16*8)>;
+		status = "okay";
+	};
+};

--- a/dts/arm/st/f4/stm32f412.dtsi
+++ b/dts/arm/st/f4/stm32f412.dtsi
@@ -163,5 +163,16 @@
 		usbotg_fs: usb@50000000 {
 			num-bidir-endpoints = <6>;
 		};
+
+		quadspi: quadspi@a0001000 {
+			compatible = "st,stm32-qspi";
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			reg = <0xa0001000 0x400>;
+			interrupts = <92 0>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x00000002>;
+			status = "disabled";
+			label = "QUADSPI";
+		};
 	};
 };


### PR DESCRIPTION
By some reason qspi support has never been added to stm32f4xx

Think this is what is needed
