### PR TITLE
Bluetooth: Host: direction: Fixing the bug to support 1us slot

### DIFF
--- a/subsys/bluetooth/host/direction.c
+++ b/subsys/bluetooth/host/direction.c
@@ -40,14 +40,10 @@ static struct bt_le_df_ant_info df_ant_info;
 const static uint8_t df_dummy_switch_pattern[BT_HCI_LE_SWITCH_PATTERN_LEN_MIN] = { 0, 0 };
 #endif /* CONFIG_BT_DF_CONNECTIONLESS_CTE_RX */
 
-#define DF_SUPP_TEST(feat, n)                   ((feat) & BIT((n)))
+#define DF_AOD_TX_1US_SUPPORT(supp)             (supp & BT_HCI_LE_1US_AOD_TX)
+#define DF_AOD_RX_1US_SUPPORT(supp)             (supp & BT_HCI_LE_1US_AOD_RX)
+#define DF_AOA_RX_1US_SUPPORT(supp)             (supp & BT_HCI_LE_1US_AOA_RX)
 
-#define DF_AOD_TX_1US_SUPPORT(supp)             (DF_SUPP_TEST(supp, \
-						BT_HCI_LE_1US_AOD_TX))
-#define DF_AOD_RX_1US_SUPPORT(supp)             (DF_SUPP_TEST(supp, \
-						BT_HCI_LE_1US_AOD_RX))
-#define DF_AOA_RX_1US_SUPPORT(supp)             (DF_SUPP_TEST(supp, \
-						BT_HCI_LE_1US_AOA_RX))
 #define DF_SAMPLING_ANTENNA_NUMBER_MIN 0x2
 
 #if defined(CONFIG_BT_DF_CONNECTIONLESS_CTE_RX)


### PR DESCRIPTION
There was an issue with receiving CTE packets when the time
slot has changed from 2us to 1us. After receiving the packets
when it tries to enable receiving of CTE, the validator
returns EINVAL error.

Source of the problem is "validate_cte_rx_params" function,
it calls DF_AOA_RX_1US_SUPPORT(df_ant_info.switch_sample_rates)
which is expanded to:
((df_ant_info.switch_sample_rates) & BIT((BT_HCI_LE_1US_AOA_RX)))

And due to definition of BT_HCI_LE_1US_AOA_RX in hci.h it will be:
((df_ant_info.switch_sample_rates) & BIT(BIT(2)))

So the BIT operation has executed two times.

Signed-off-by: Saleh Mehdikhani <saleh.mehdikhani@unikie.com>