### PR TITLE
Bluetooth: host: df: Fix compilation warning in direction.c

### DIFF
--- a/subsys/bluetooth/host/direction.c
+++ b/subsys/bluetooth/host/direction.c
@@ -52,8 +52,7 @@ const static uint8_t df_dummy_switch_pattern[BT_HCI_LE_SWITCH_PATTERN_LEN_MIN] =
 
 #if defined(CONFIG_BT_DF_CONNECTIONLESS_CTE_RX)
 static int validate_cte_rx_params(const struct bt_df_per_adv_sync_cte_rx_param *params);
-static void prepare_cte_rx_enable_cmd_params(struct bt_hci_cp_le_set_cl_cte_sampling_enable *cp,
-					     struct net_buf *buf, struct bt_le_per_adv_sync *sync,
+static void prepare_cte_rx_enable_cmd_params(struct net_buf *buf, struct bt_le_per_adv_sync *sync,
 					     const struct bt_df_per_adv_sync_cte_rx_param *params,
 					     bool enable);
 static int hci_df_set_cl_cte_rx_enable(struct bt_le_per_adv_sync *sync, bool enable,
@@ -234,11 +233,11 @@ static int validate_cte_rx_params(const struct bt_df_per_adv_sync_cte_rx_param *
 	return 0;
 }
 
-static void prepare_cte_rx_enable_cmd_params(struct bt_hci_cp_le_set_cl_cte_sampling_enable *cp,
-					     struct net_buf *buf, struct bt_le_per_adv_sync *sync,
+static void prepare_cte_rx_enable_cmd_params(struct net_buf *buf, struct bt_le_per_adv_sync *sync,
 					     const struct bt_df_per_adv_sync_cte_rx_param *params,
 					     bool enable)
 {
+	struct bt_hci_cp_le_set_cl_cte_sampling_enable *cp;
 	const uint8_t *ant_ids;
 
 	cp = net_buf_add(buf, sizeof(*cp));
@@ -275,7 +274,6 @@ static void prepare_cte_rx_enable_cmd_params(struct bt_hci_cp_le_set_cl_cte_samp
 static int hci_df_set_cl_cte_rx_enable(struct bt_le_per_adv_sync *sync, bool enable,
 				       const struct bt_df_per_adv_sync_cte_rx_param *params)
 {
-	struct bt_hci_cp_le_set_cl_cte_sampling_enable *cp;
 	struct bt_hci_rp_le_set_cl_cte_sampling_enable *rp;
 	struct bt_hci_cmd_state_set state;
 	struct net_buf *buf, *rsp;
@@ -292,12 +290,13 @@ static int hci_df_set_cl_cte_rx_enable(struct bt_le_per_adv_sync *sync, bool ena
 	 * antenna ids, so command size if extended by num_and_ids.
 	 */
 	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_CL_CTE_SAMPLING_ENABLE,
-				sizeof(*cp) + (enable ? params->num_ant_ids : 0));
+				(sizeof(struct bt_hci_cp_le_set_cl_cte_sampling_enable) +
+				 (enable ? params->num_ant_ids : 0)));
 	if (!buf) {
 		return -ENOBUFS;
 	}
 
-	prepare_cte_rx_enable_cmd_params(cp, buf, sync, params, enable);
+	prepare_cte_rx_enable_cmd_params(buf, sync, params, enable);
 
 	bt_hci_cmd_state_set_init(buf, &state, sync->flags, BT_PER_ADV_SYNC_CTE_ENABLED, enable);
 


### PR DESCRIPTION
Fix compilation warning in hci_df_set_cl_cte_rx_enable function.
The struct bt_hci_cp_le_set_cl_cte_sampling_enable *cp variable
was used just to evaluate size in bt_hci_cmd_create call.

The variable is moved to prepare_cte_rx_enable_cmd_params
function and size of the buf is evaluated directly from type.

Code is simpler and prepare_cte_rx_enable_cmd_params does not
require passing additional argument.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>