### PR TITLE
manifest: MCUboot update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -158,7 +158,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: ca01db4216c63678768ea78fe04f27cd80b83246
+      revision: pull/56/head
       path: bootloader/mcuboot
     - name: mcumgr
       revision: a15a953e35b0d3100893fd86a127c3e8b7e3257c


### PR DESCRIPTION
MCUboot was synchronized up to:
https://github.com/mcu-tools/mcuboot/commit/994816d

- introduce MCUBOOT_CPU_IDLE() for support low power single thread
- Allow not working secondary image device and boot form primary device if image available
- Add processing of PERUSER mgmt commands group for serial recovery,
  see `CONFIG_ENABLE_MGMT_PERUSER`
- Added the support of MBEDTLS version 3.0.0
- serial recovery: Allow upload to image-slot selected directly,
  see `CONFIG_MCUBOOT_SERIAL_DIRECT_IMAGE_UPLOAD`
- replaced direct access to flash_area/flash_sector fields with MCUboot's specific getter functions
- fixed cbor encoder issue which was causing that serial recovery upload of an image bigger than 64KB would fail.

- many fixes to functionalities not used by zephyr-project port so fare:
  DIRECT_XIP and RAM_LOAD modes, simulator and others

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>

Depends on: https://github.com/zephyrproject-rtos/trusted-firmware-m/pull/60