### PR TITLE
stm32u5: Add openocd support

### DIFF
--- a/boards/arm/nucleo_u575zi_q/board.cmake
+++ b/boards/arm/nucleo_u575zi_q/board.cmake
@@ -1,4 +1,11 @@
 board_runner_args(stm32cubeprogrammer "--erase" "--port=swd" "--reset=hw")
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset=hw")
 
+board_runner_args(openocd "--tcl-port=6666")
+board_runner_args(openocd --cmd-pre-init "gdb_report_data_abort enable")
+board_runner_args(openocd "--no-halt")
+
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
+# FIXME: openocd runner requires use of STMicro openocd fork.
+# Check board documentation for more details.
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/arm/nucleo_u575zi_q/doc/nucleou575zi_q.rst
+++ b/boards/arm/nucleo_u575zi_q/doc/nucleou575zi_q.rst
@@ -234,6 +234,38 @@ You should see the following message on the console:
 
    Hello World! arm
 
+Debugging
+=========
+
+STM32U5 support is not currently supported in openocd. As a temporary workaround,
+user can use `STMicroelectronics customized version of OpenOCD`_ to debug the
+the Nucleo U575ZI Q.
+For this you need to fetch this repo and build openocd following the instructions
+provided in the README of the project. Then, build zephyr project indicating the
+openocd location in west build command.
+
+Here is an example for the :ref:`blinky-sample` application.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: nucleo_u575zi_q
+   :gen-args: -DOPENOCD="<path_to_openocd>/openocd/src/openocd" -DOPENOCD_DEFAULT_PATH="<path_to_openocd>/openocd/tcl/"
+   :goals: build
+
+Then, indicate openocd as the chosen runner in flash and debug commands:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: nucleo_u575zi_q
+   :gen-args: -r openocd
+   :goals: flash
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: nucleo_u575zi_q
+   :gen-args: -r openocd
+   :goals: debug
+
 
 .. _STM32 Nucleo-144 board User Manual:
    http://www.st.com/resource/en/user_manual/dm00615305.pdf
@@ -246,3 +278,6 @@ You should see the following message on the console:
 
 .. _STM32CubeProgrammer:
    https://www.st.com/en/development-tools/stm32cubeprog.html
+
+.. _STMicroelectronics customized version of OpenOCD:
+   https://github.com/STMicroelectronics/OpenOCD

--- a/boards/arm/nucleo_u575zi_q/support/openocd.cfg
+++ b/boards/arm/nucleo_u575zi_q/support/openocd.cfg
@@ -1,0 +1,44 @@
+source [find interface/stlink-dap.cfg]
+
+set WORKAREASIZE 0x8000
+
+transport select "dapdirect_swd"
+
+set CHIPNAME STM32U575ZITxQ
+set BOARDNAME NUCLEO-U575ZI-Q
+
+# Enable debug when in low power modes
+set ENABLE_LOW_POWER 1
+
+# Stop Watchdog counters when halt
+set STOP_WATCHDOG 1
+
+# STlink Debug clock frequency
+set CLOCK_FREQ 8000
+
+# Reset configuration
+# use hardware reset, connect under reset
+# connect_assert_srst needed if low power mode application running (WFI...)
+reset_config srst_only srst_nogate connect_assert_srst
+set CONNECT_UNDER_RESET 1
+set CORE_RESET 0
+
+# ACCESS PORT NUMBER
+set AP_NUM 0
+# GDB PORT
+set GDB_PORT 3333
+
+# BCTM CPU variables
+
+source [find target/stm32u5x.cfg]
+
+$_TARGETNAME configure -event gdb-attach {
+	echo "Debugger attaching: halting execution"
+	reset halt
+	gdb_breakpoint_override hard
+}
+
+$_TARGETNAME configure -event gdb-detach {
+	echo "Debugger detaching: resuming execution"
+	resume
+}


### PR DESCRIPTION
Required changes to enable openocd support on stm32u5 targets.

This is made in 2 steps:
- Update west openocd runner to support a gdb server command issued without "halt" command
- As stm32u5 support is not yet available in upstream openocd, as a temporay workaround, provide instructions to use an openocd fork with its support.

~~@mbolivar-nordic, @galak I'm setting this as draft PR, as I know this may raise some concerns.~~
~~Otherwise, please let me know if I can trun this into an official PR.~~