### PR TITLE
kernel: drop unused priority related definitions

### DIFF
--- a/include/kernel_structs.h
+++ b/include/kernel_structs.h
@@ -34,11 +34,6 @@
 extern "C" {
 #endif
 
-#define K_NUM_PRIORITIES \
-	(CONFIG_NUM_COOP_PRIORITIES + CONFIG_NUM_PREEMPT_PRIORITIES + 1)
-
-#define K_NUM_PRIO_BITMAPS ((K_NUM_PRIORITIES + 31) >> 5)
-
 /*
  * Bitmask definitions for the struct k_thread.thread_state field.
  *

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -41,10 +41,6 @@ config NUM_COOP_PRIORITIES
 	  This can be set to zero to disable cooperative scheduling. Cooperative
 	  threads always preempt preemptible threads.
 
-	  Each priority requires an extra 8 bytes of RAM. Each set of 32 extra
-	  total priorities require an extra 4 bytes and add one possible
-	  iteration to loops that search for the next thread to run.
-
 	  The total number of priorities is
 
 	   NUM_COOP_PRIORITIES + NUM_PREEMPT_PRIORITIES + 1
@@ -62,10 +58,6 @@ config NUM_PREEMPT_PRIORITIES
 	  to priorities 0 to CONFIG_NUM_PREEMPT_PRIORITIES - 1.
 
 	  This can be set to 0 to disable preemptible scheduling.
-
-	  Each priority requires an extra 8 bytes of RAM. Each set of 32 extra
-	  total priorities require an extra 4 bytes and add one possible
-	  iteration to loops that search for the next thread to run.
 
 	  The total number of priorities is
 


### PR DESCRIPTION
Hi, this drops a couple of seemingly obsolete and unused defines, and two Kconfig comments that do not seem to apply anymore since https://github.com/zephyrproject-rtos/zephyr/commit/1acd8c2996c3a1ae0691247deff8c32519307f17.