### PR TITLE
drivers: spi: improve initialization of multiple cs gpios

### DIFF
--- a/drivers/spi/spi_b91.c
+++ b/drivers/spi/spi_b91.c
@@ -349,18 +349,19 @@ static int spi_b91_config(const struct device *dev,
 	/* save context config */
 	b91_data->ctx.config = config;
 
-	/* config software CS control if enabled */
-	if (config->cs != NULL) {
-		spi_context_cs_configure(&b91_data->ctx);
-	}
-
 	return 0;
 }
 
 /* API implementation: init */
 static int spi_b91_init(const struct device *dev)
 {
+	int err;
 	struct spi_b91_data *data = SPI_DATA(dev);
+
+	err = spi_context_cs_configure_all(&data->ctx);
+	if (err < 0) {
+		return err;
+	}
 
 	spi_context_unlock_unconditionally(&data->ctx);
 
@@ -458,6 +459,7 @@ static struct spi_driver_api spi_b91_api = {
 	static struct spi_b91_data spi_b91_data_##inst = {			\
 		SPI_CONTEXT_INIT_LOCK(spi_b91_data_##inst, ctx),		\
 		SPI_CONTEXT_INIT_SYNC(spi_b91_data_##inst, ctx),		\
+		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(inst), ctx)		\
 	};									\
 										\
 	static struct spi_b91_cfg spi_b91_cfg_##inst = {			\

--- a/drivers/spi/spi_b91.c
+++ b/drivers/spi/spi_b91.c
@@ -474,7 +474,7 @@ static struct spi_driver_api spi_b91_api = {
 			      &spi_b91_data_##inst,				\
 			      &spi_b91_cfg_##inst,				\
 			      POST_KERNEL,					\
-			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+			      CONFIG_SPI_INIT_PRIORITY,				\
 			      &spi_b91_api);
 
 DT_INST_FOREACH_STATUS_OKAY(SPI_B91_INIT)

--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -114,8 +114,6 @@ static int spi_cc13xx_cc26xx_configure(const struct device *dev,
 			    cfg->cs_pin, cfg->sck_pin);
 
 	ctx->config = config;
-	/* This will reconfigure the CS pin as GPIO if same as cfg->cs_pin. */
-	spi_context_cs_configure(ctx);
 
 	/* Disable SSI before making configuration changes */
 	SSIDisable(cfg->base);
@@ -297,14 +295,20 @@ static const struct spi_driver_api spi_cc13xx_cc26xx_driver_api = {
 		POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,			    \
 		&spi_cc13xx_cc26xx_driver_api)
 
-#define SPI_CC13XX_CC26XX_INIT_FUNC(n)					    \
-	static int spi_cc13xx_cc26xx_init_##n(const struct device *dev)	    \
-	{								    \
-		SPI_CC13XX_CC26XX_POWER_SPI(n);				    \
-									    \
-		spi_context_unlock_unconditionally(&get_dev_data(dev)->ctx);\
-									    \
-		return 0;						    \
+#define SPI_CC13XX_CC26XX_INIT_FUNC(n)						\
+	static int spi_cc13xx_cc26xx_init_##n(const struct device *dev)		\
+	{									\
+		int err;							\
+		SPI_CC13XX_CC26XX_POWER_SPI(n);					\
+										\
+		err = spi_context_cs_configure_all(&get_dev_data(dev)->ctx);	\
+		if (err < 0) {							\
+			return err;						\
+		}								\
+										\
+		spi_context_unlock_unconditionally(&get_dev_data(dev)->ctx);	\
+										\
+		return 0;							\
 	}
 
 #define SPI_CC13XX_CC26XX_INIT(n)					\
@@ -322,10 +326,11 @@ static const struct spi_driver_api spi_cc13xx_cc26xx_driver_api = {
 									\
 	static struct spi_cc13xx_cc26xx_data				\
 		spi_cc13xx_cc26xx_data_##n = {				\
-		SPI_CONTEXT_INIT_LOCK(spi_cc13xx_cc26xx_data_##n, ctx),	  \
-		SPI_CONTEXT_INIT_SYNC(spi_cc13xx_cc26xx_data_##n, ctx),	  \
-	};								  \
-									  \
+		SPI_CONTEXT_INIT_LOCK(spi_cc13xx_cc26xx_data_##n, ctx),	\
+		SPI_CONTEXT_INIT_SYNC(spi_cc13xx_cc26xx_data_##n, ctx),	\
+		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx)	\
+	};								\
+									\
 	SPI_CC13XX_CC26XX_DEVICE_INIT(n);
 
 DT_INST_FOREACH_STATUS_OKAY(SPI_CC13XX_CC26XX_INIT)

--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -27,6 +27,8 @@ enum spi_ctx_runtime_op_mode {
 struct spi_context {
 	const struct spi_config *config;
 	const struct spi_config *owner;
+	const struct gpio_dt_spec *cs_gpios;
+	size_t num_cs_gpios;
 
 	struct k_sem lock;
 	struct k_sem sync;
@@ -56,6 +58,20 @@ struct spi_context {
 
 #define SPI_CONTEXT_INIT_SYNC(_data, _ctx_name)				\
 	._ctx_name.sync = Z_SEM_INITIALIZER(_data._ctx_name.sync, 0, 1)
+
+#define SPI_CONTEXT_CS_GPIO_SPEC_ELEM(_node_id, _prop, _idx)		\
+	GPIO_DT_SPEC_GET_BY_IDX(_node_id, _prop, _idx),
+
+#define SPI_CONTEXT_CS_GPIOS_FOREACH_ELEM(_node_id)				\
+	DT_FOREACH_PROP_ELEM(_node_id, cs_gpios,				\
+				SPI_CONTEXT_CS_GPIO_SPEC_ELEM)
+
+#define SPI_CONTEXT_CS_GPIOS_INITIALIZE(_node_id, _ctx_name)				\
+	._ctx_name.cs_gpios = (const struct gpio_dt_spec []) {				\
+		COND_CODE_1(DT_SPI_HAS_CS_GPIOS(_node_id),				\
+			    (SPI_CONTEXT_CS_GPIOS_FOREACH_ELEM(_node_id)), ({0}))	\
+	},										\
+	._ctx_name.num_cs_gpios = DT_PROP_LEN_OR(_node_id, cs_gpios, 0),
 
 static inline bool spi_context_configured(struct spi_context *ctx,
 					  const struct spi_config *config)
@@ -181,6 +197,32 @@ gpio_dt_flags_t spi_context_cs_active_level(struct spi_context *ctx)
 	}
 
 	return GPIO_ACTIVE_LOW;
+}
+
+static inline int spi_context_cs_configure_all(struct spi_context *ctx)
+{
+	int ret;
+	const struct gpio_dt_spec *cs_gpio;
+
+	for (cs_gpio = ctx->cs_gpios; cs_gpio < &ctx->cs_gpios[ctx->num_cs_gpios]; cs_gpio++) {
+		if (!device_is_ready(cs_gpio->port)) {
+			LOG_ERR("CS GPIO port %s pin %d is not ready",
+				cs_gpio->port->name, cs_gpio->pin);
+			return -ENODEV;
+		}
+
+		/* Validate CS active levels are equivalent */
+		__ASSERT(spi_context_cs_active_level(ctx) ==
+			 (cs_gpio->dt_flags & GPIO_ACTIVE_LOW),
+			 "Devicetree and spi_context CS levels are not equal");
+
+		ret = gpio_pin_configure_dt(cs_gpio, GPIO_OUTPUT_INACTIVE);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	return 0;
 }
 
 static inline int spi_context_cs_configure(struct spi_context *ctx)

--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -225,28 +225,6 @@ static inline int spi_context_cs_configure_all(struct spi_context *ctx)
 	return 0;
 }
 
-static inline int spi_context_cs_configure(struct spi_context *ctx)
-{
-	int ret;
-
-	if (ctx->config->cs && ctx->config->cs->gpio.port) {
-		/* Validate CS active levels are equivalent */
-		__ASSERT(spi_context_cs_active_level(ctx) ==
-			 (ctx->config->cs->gpio.dt_flags & GPIO_ACTIVE_LOW),
-			 "Devicetree and spi_context CS levels are not equal");
-		ret = gpio_pin_configure_dt(&ctx->config->cs->gpio,
-				      GPIO_OUTPUT_INACTIVE);
-		if (ret < 0) {
-			LOG_ERR("Failed to configure 'cs' gpio: %d", ret);
-			return ret;
-		}
-	} else {
-		LOG_INF("CS control inhibited (no GPIO device)");
-	}
-
-	return 0;
-}
-
 static inline void _spi_context_cs_control(struct spi_context *ctx,
 					   bool on, bool force_off)
 {

--- a/drivers/spi/spi_dw.c
+++ b/drivers/spi/spi_dw.c
@@ -258,8 +258,6 @@ static int spi_dw_configure(const struct spi_dw_config *info,
 		write_ser(1 << config->slave, info->regs);
 	}
 
-	spi_context_cs_configure(&spi->ctx);
-
 	if (spi_dw_is_slave(spi)) {
 		LOG_DBG("Installed slave config %p:"
 			    " ws/dfs %u/%u, mode %u/%u/%u",
@@ -517,6 +515,7 @@ static const struct spi_driver_api dw_spi_api = {
 
 int spi_dw_init(const struct device *dev)
 {
+	int err;
 	const struct spi_dw_config *info = dev->config;
 	struct spi_dw_data *spi = dev->data;
 
@@ -527,6 +526,11 @@ int spi_dw_init(const struct device *dev)
 	clear_bit_ssienr(info->regs);
 
 	LOG_DBG("Designware SPI driver initialized on device: %p", dev);
+
+	err = spi_context_cs_configure_all(&spi->ctx);
+	if (err < 0) {
+		return err;
+	}
 
 	spi_context_unlock_unconditionally(&spi->ctx);
 
@@ -540,6 +544,7 @@ void spi_config_0_irq(void);
 struct spi_dw_data spi_dw_data_port_0 = {
 	SPI_CONTEXT_INIT_LOCK(spi_dw_data_port_0, ctx),
 	SPI_CONTEXT_INIT_SYNC(spi_dw_data_port_0, ctx),
+	SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(0), ctx)
 };
 
 #if DT_NODE_HAS_PROP(DT_INST_PHANDLE(0, clocks), clock_frequency)
@@ -603,6 +608,7 @@ void spi_config_1_irq(void);
 struct spi_dw_data spi_dw_data_port_1 = {
 	SPI_CONTEXT_INIT_LOCK(spi_dw_data_port_1, ctx),
 	SPI_CONTEXT_INIT_SYNC(spi_dw_data_port_1, ctx),
+	SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(1), ctx)
 };
 
 #if DT_NODE_HAS_PROP(DT_INST_PHANDLE(1, clocks), clock_frequency)
@@ -666,6 +672,7 @@ void spi_config_2_irq(void);
 struct spi_dw_data spi_dw_data_port_2 = {
 	SPI_CONTEXT_INIT_LOCK(spi_dw_data_port_2, ctx),
 	SPI_CONTEXT_INIT_SYNC(spi_dw_data_port_2, ctx),
+	SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(2), ctx)
 };
 
 #if DT_NODE_HAS_PROP(DT_INST_PHANDLE(2, clocks), clock_frequency)
@@ -729,6 +736,7 @@ void spi_config_3_irq(void);
 struct spi_dw_data spi_dw_data_port_3 = {
 	SPI_CONTEXT_INIT_LOCK(spi_dw_data_port_3, ctx),
 	SPI_CONTEXT_INIT_SYNC(spi_dw_data_port_3, ctx),
+	SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(3), ctx)
 };
 
 #if DT_NODE_HAS_PROP(DT_INST_PHANDLE(3, clocks), clock_frequency)

--- a/drivers/spi/spi_esp32_spim.c
+++ b/drivers/spi/spi_esp32_spim.c
@@ -414,7 +414,7 @@ static const struct spi_driver_api spi_api = {
 	DEVICE_DT_DEFINE(DT_NODELABEL(spi##idx), &spi_esp32_init,	\
 			      device_pm_control_no, &spi_data_##idx,	\
 			      &spi_config_##idx, POST_KERNEL,	\
-			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &spi_api);
+			      CONFIG_SPI_INIT_PRIORITY, &spi_api);
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(spi2), okay)
 ESP32_SPI_INIT(2);

--- a/drivers/spi/spi_gecko.c
+++ b/drivers/spi/spi_gecko.c
@@ -107,8 +107,6 @@ static int spi_config(const struct device *dev,
 	/* At this point, it's mandatory to set this on the context! */
 	data->ctx.config = config;
 
-	spi_context_cs_configure(&data->ctx);
-
 	return 0;
 }
 
@@ -209,7 +207,9 @@ static void spi_gecko_init_pins(const struct device *dev)
 
 static int spi_gecko_init(const struct device *dev)
 {
+	int err;
 	const struct spi_gecko_config *config = dev->config;
+	struct spi_gecko_data *data = dev->data;
 	USART_InitSync_TypeDef usartInit = USART_INITSYNC_DEFAULT;
 
 	/* The peripheral and gpio clock are already enabled from soc and gpio
@@ -236,6 +236,11 @@ static int spi_gecko_init(const struct device *dev)
 
 	/* Initialize USART pins */
 	spi_gecko_init_pins(dev);
+
+	err = spi_context_cs_configure_all(&data->ctx);
+	if (err < 0) {
+		return err;
+	}
 
 	/* Enable the peripheral */
 	config->base->CMD = (uint32_t) usartEnable;
@@ -291,6 +296,7 @@ static struct spi_driver_api spi_gecko_api = {
 	static struct spi_gecko_data spi_gecko_data_##n = { \
 		SPI_CONTEXT_INIT_LOCK(spi_gecko_data_##n, ctx), \
 		SPI_CONTEXT_INIT_SYNC(spi_gecko_data_##n, ctx), \
+		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx)	\
 	}; \
 	static struct spi_gecko_config spi_gecko_cfg_##n = { \
 	    .base = (USART_TypeDef *) \

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -569,8 +569,6 @@ static int spi_stm32_configure(const struct device *dev,
 	/* At this point, it's mandatory to set this on the context! */
 	data->ctx.config = config;
 
-	spi_context_cs_configure(&data->ctx);
-
 	LOG_DBG("Installed config %p: freq %uHz (div = %u),"
 		    " mode %u/%u/%u, slave %u",
 		    config, clock >> br, 1 << br,
@@ -863,6 +861,12 @@ static int spi_stm32_init(const struct device *dev)
 		return -ENODEV;
 	}
 #endif /* CONFIG_SPI_STM32_DMA */
+
+	err = spi_context_cs_configure_all(&data->ctx);
+	if (err < 0) {
+		return err;
+	}
+
 	spi_context_unlock_unconditionally(&data->ctx);
 
 	return 0;
@@ -960,6 +964,7 @@ static struct spi_stm32_data spi_stm32_dev_data_##id = {		\
 	SPI_DMA_CHANNEL(id, rx, RX, PERIPHERAL, MEMORY)			\
 	SPI_DMA_CHANNEL(id, tx, TX, MEMORY, PERIPHERAL)			\
 	SPI_DMA_STATUS_SEM(id)						\
+	SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(id), ctx)		\
 };									\
 									\
 DEVICE_DT_INST_DEFINE(id, &spi_stm32_init, NULL,			\

--- a/drivers/spi/spi_mcux_dspi.c
+++ b/drivers/spi/spi_mcux_dspi.c
@@ -654,7 +654,6 @@ static int spi_mcux_configure(const struct device *dev,
 #endif
 
 	data->ctx.config = spi_cfg;
-	spi_context_cs_configure(&data->ctx);
 
 	return 0;
 }
@@ -746,6 +745,7 @@ static int spi_mcux_release(const struct device *dev,
 
 static int spi_mcux_init(const struct device *dev)
 {
+	int err;
 	struct spi_mcux_data *data = dev->data;
 #ifdef CONFIG_DSPI_MCUX_EDMA
 	enum dma_channel_filter spi_filter = DMA_CHANNEL_NORMAL;
@@ -763,6 +763,12 @@ static int spi_mcux_init(const struct device *dev)
 	config->irq_config_func(dev);
 #endif
 	data->dev = dev;
+
+	err = spi_context_cs_configure_all(&data->ctx);
+	if (err < 0) {
+		return err;
+	}
+
 	spi_context_unlock_unconditionally(&data->ctx);
 
 	return 0;
@@ -856,6 +862,7 @@ static const struct spi_driver_api spi_mcux_driver_api = {
 	static struct spi_mcux_data spi_mcux_data_##id = {		\
 		SPI_CONTEXT_INIT_LOCK(spi_mcux_data_##id, ctx),		\
 		SPI_CONTEXT_INIT_SYNC(spi_mcux_data_##id, ctx),		\
+		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(id), ctx)	\
 		TX_DMA_CONFIG(id) RX_DMA_CONFIG(id)			\
 	};								\
 	static const struct spi_mcux_config spi_mcux_config_##id = {	\

--- a/drivers/spi/spi_mcux_flexcomm.c
+++ b/drivers/spi/spi_mcux_flexcomm.c
@@ -770,7 +770,7 @@ static void spi_mcux_config_func_##id(const struct device *dev) \
 			    &spi_mcux_data_##id,			\
 			    &spi_mcux_config_##id,			\
 			    POST_KERNEL,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+			    CONFIG_SPI_INIT_PRIORITY,			\
 			    &spi_mcux_driver_api);			\
 	\
 	SPI_MCUX_FLEXCOMM_IRQ_HANDLER(id)

--- a/drivers/spi/spi_mcux_flexcomm.c
+++ b/drivers/spi/spi_mcux_flexcomm.c
@@ -213,7 +213,6 @@ static int spi_mcux_configure(const struct device *dev,
 		SPI_SetDummyData(base, 0);
 
 		data->ctx.config = spi_cfg;
-		spi_context_cs_configure(&data->ctx);
 	} else {
 		spi_slave_config_t slave_config;
 
@@ -674,6 +673,7 @@ static int spi_mcux_release(const struct device *dev,
 
 static int spi_mcux_init(const struct device *dev)
 {
+	int err;
 	const struct spi_mcux_config *config = dev->config;
 	struct spi_mcux_data *data = dev->data;
 
@@ -692,6 +692,12 @@ static int spi_mcux_init(const struct device *dev)
 		return -ENODEV;
 	}
 #endif /* CONFIG_SPI_MCUX_FLEXCOMM_DMA */
+
+
+	err = spi_context_cs_configure_all(&data->ctx);
+	if (err < 0) {
+		return err;
+	}
 
 	spi_context_unlock_unconditionally(&data->ctx);
 
@@ -762,6 +768,7 @@ static void spi_mcux_config_func_##id(const struct device *dev) \
 	static struct spi_mcux_data spi_mcux_data_##id = {		\
 		SPI_CONTEXT_INIT_LOCK(spi_mcux_data_##id, ctx),		\
 		SPI_CONTEXT_INIT_SYNC(spi_mcux_data_##id, ctx),		\
+		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(id), ctx)	\
 		SPI_DMA_CHANNELS(id)		\
 	};								\
 	DEVICE_DT_INST_DEFINE(id,					\

--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -306,7 +306,7 @@ static const struct spi_driver_api spi_mcux_driver_api = {
 	DEVICE_DT_INST_DEFINE(n, &spi_mcux_init, NULL,			\
 			    &spi_mcux_data_##n,				\
 			    &spi_mcux_config_##n, POST_KERNEL,		\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+			    CONFIG_SPI_INIT_PRIORITY,			\
 			    &spi_mcux_driver_api);			\
 									\
 	static void spi_mcux_config_func_##n(const struct device *dev)	\

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -146,7 +146,6 @@ static int configure(const struct device *dev,
 	dev_data->initialized = true;
 
 	ctx->config = spi_cfg;
-	spi_context_cs_configure(ctx);
 
 	return 0;
 }
@@ -327,14 +326,20 @@ static int spi_nrfx_pm_control(const struct device *dev,
 		": cannot enable both pull-up and pull-down on MISO line");    \
 	static int spi_##idx##_init(const struct device *dev)		       \
 	{								       \
+		int err;                                                       \
 		IRQ_CONNECT(DT_IRQN(SPI(idx)), DT_IRQ(SPI(idx), priority),     \
 			    nrfx_isr, nrfx_spi_##idx##_irq_handler, 0);	       \
+		err = spi_context_cs_configure_all(&get_dev_data(dev)->ctx);   \
+		if (err < 0) {                                                 \
+			return err;                                            \
+		}                                                              \
 		spi_context_unlock_unconditionally(&get_dev_data(dev)->ctx);   \
 		return 0;						       \
 	}								       \
 	static struct spi_nrfx_data spi_##idx##_data = {		       \
 		SPI_CONTEXT_INIT_LOCK(spi_##idx##_data, ctx),		       \
 		SPI_CONTEXT_INIT_SYNC(spi_##idx##_data, ctx),		       \
+		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(idx), ctx)	       \
 		.dev  = DEVICE_DT_GET(SPI(idx)),			       \
 		.busy = false,						       \
 	};								       \

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -179,7 +179,6 @@ static int configure(const struct device *dev,
 	dev_data->initialized = true;
 
 	ctx->config = spi_cfg;
-	spi_context_cs_configure(ctx);
 
 	return 0;
 }
@@ -392,15 +391,21 @@ static int spim_nrfx_pm_control(const struct device *dev,
 		": cannot enable both pull-up and pull-down on MISO line");    \
 	static int spi_##idx##_init(const struct device *dev)		       \
 	{								       \
+		int err;                                                       \
 		IRQ_CONNECT(NRFX_IRQ_NUMBER_GET(NRF_SPIM##idx),		       \
 			    DT_IRQ(SPIM(idx), priority),		       \
 			    nrfx_isr, nrfx_spim_##idx##_irq_handler, 0);       \
+		err = spi_context_cs_configure_all(&get_dev_data(dev)->ctx);   \
+		if (err < 0) {                                                 \
+			return err;                                            \
+		}                                                              \
 		spi_context_unlock_unconditionally(&get_dev_data(dev)->ctx);   \
 		return 0;						       \
 	}								       \
 	static struct spi_nrfx_data spi_##idx##_data = {		       \
 		SPI_CONTEXT_INIT_LOCK(spi_##idx##_data, ctx),		       \
 		SPI_CONTEXT_INIT_SYNC(spi_##idx##_data, ctx),		       \
+		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(idx), ctx)         \
 		.dev  = DEVICE_DT_GET(SPIM(idx)),			       \
 		.busy = false,						       \
 	};								       \

--- a/drivers/spi/spi_rv32m1_lpspi.c
+++ b/drivers/spi/spi_rv32m1_lpspi.c
@@ -189,7 +189,6 @@ static int spi_mcux_configure(const struct device *dev,
 	LPSPI_SetDummyData(base, 0);
 
 	data->ctx.config = spi_cfg;
-	spi_context_cs_configure(&data->ctx);
 
 	return 0;
 }
@@ -255,6 +254,7 @@ static int spi_mcux_release(const struct device *dev,
 
 static int spi_mcux_init(const struct device *dev)
 {
+	int err;
 	const struct spi_mcux_config *config = dev->config;
 	struct spi_mcux_data *data = dev->data;
 
@@ -263,6 +263,11 @@ static int spi_mcux_init(const struct device *dev)
 	config->irq_config_func(dev);
 
 	data->dev = dev;
+
+	err = spi_context_cs_configure_all(&data->ctx);
+	if (err < 0) {
+		return err;
+	}
 
 	spi_context_unlock_unconditionally(&data->ctx);
 
@@ -293,6 +298,7 @@ static const struct spi_driver_api spi_mcux_driver_api = {
 	static struct spi_mcux_data spi_mcux_data_##n = {		\
 		SPI_CONTEXT_INIT_LOCK(spi_mcux_data_##n, ctx),		\
 		SPI_CONTEXT_INIT_SYNC(spi_mcux_data_##n, ctx),		\
+		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx)	\
 	};								\
 									\
 	DEVICE_DT_INST_DEFINE(n, &spi_mcux_init, NULL,			\

--- a/drivers/spi/spi_rv32m1_lpspi.c
+++ b/drivers/spi/spi_rv32m1_lpspi.c
@@ -299,7 +299,7 @@ static const struct spi_driver_api spi_mcux_driver_api = {
 			    &spi_mcux_data_##n,				\
 			    &spi_mcux_config_##n,			\
 			    POST_KERNEL,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+			    CONFIG_SPI_INIT_PRIORITY,			\
 			    &spi_mcux_driver_api);			\
 									\
 	static void spi_mcux_config_func_##n(const struct device *dev)	\

--- a/drivers/spi/spi_sam0.c
+++ b/drivers/spi/spi_sam0.c
@@ -135,7 +135,6 @@ static int spi_sam0_configure(const struct device *dev,
 	}
 
 	data->ctx.config = config;
-	spi_context_cs_configure(&data->ctx);
 
 	return 0;
 }
@@ -675,6 +674,7 @@ static int spi_sam0_release(const struct device *dev,
 
 static int spi_sam0_init(const struct device *dev)
 {
+	int err;
 	const struct spi_sam0_config *cfg = dev->config;
 	struct spi_sam0_data *data = dev->data;
 	SercomSpi *regs = cfg->regs;
@@ -705,6 +705,11 @@ static int spi_sam0_init(const struct device *dev)
 	}
 	data->dev = dev;
 #endif
+
+	err = spi_context_cs_configure_all(&data->ctx);
+	if (err < 0) {
+		return err;
+	}
 
 	spi_context_unlock_unconditionally(&data->ctx);
 
@@ -763,6 +768,7 @@ static const struct spi_sam0_config spi_sam0_config_##n = {		\
 	static struct spi_sam0_data spi_sam0_dev_data_##n = {		\
 		SPI_CONTEXT_INIT_LOCK(spi_sam0_dev_data_##n, ctx),	\
 		SPI_CONTEXT_INIT_SYNC(spi_sam0_dev_data_##n, ctx),	\
+		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx)	\
 	};								\
 	DEVICE_DT_INST_DEFINE(n, &spi_sam0_init, NULL,			\
 			    &spi_sam0_dev_data_##n,			\

--- a/drivers/spi/spi_sifive.c
+++ b/drivers/spi/spi_sifive.c
@@ -153,8 +153,14 @@ void spi_sifive_xfer(const struct device *dev, const bool hw_cs_control)
 
 int spi_sifive_init(const struct device *dev)
 {
+	int err;
 	/* Disable SPI Flash mode */
 	sys_clear_bit(SPI_REG(dev, REG_FCTRL), SF_FCTRL_EN);
+
+	err = spi_context_cs_configure_all(&SPI_DATA(dev)->ctx);
+	if (err < 0) {
+		return err;
+	}
 
 	/* Make sure the context is unlocked */
 	spi_context_unlock_unconditionally(&SPI_DATA(dev)->ctx);
@@ -188,7 +194,6 @@ int spi_sifive_transceive(const struct device *dev,
 		 * If the user has requested manual GPIO control, ask the
 		 * context for control and disable HW control
 		 */
-		spi_context_cs_configure(&SPI_DATA(dev)->ctx);
 		sys_write32(SF_CSMODE_OFF, SPI_REG(dev, REG_CSMODE));
 	} else {
 		/*
@@ -245,6 +250,7 @@ static struct spi_driver_api spi_sifive_api = {
 	static struct spi_sifive_data spi_sifive_data_##n = { \
 		SPI_CONTEXT_INIT_LOCK(spi_sifive_data_##n, ctx), \
 		SPI_CONTEXT_INIT_SYNC(spi_sifive_data_##n, ctx), \
+		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx)	\
 	}; \
 	static struct spi_sifive_cfg spi_sifive_cfg_##n = { \
 		.base = DT_INST_REG_ADDR_BY_NAME(n, control), \

--- a/drivers/spi/spi_xec_qmspi.c
+++ b/drivers/spi/spi_xec_qmspi.c
@@ -221,9 +221,6 @@ static int qmspi_configure(const struct device *dev,
 
 	data->ctx.config = config;
 
-	/* Add driver specific data to SPI context structure */
-	spi_context_cs_configure(&data->ctx);
-
 	regs->MODE |= MCHP_QMSPI_M_ACTIVATE;
 
 	return 0;
@@ -616,6 +613,7 @@ static int qmspi_release(const struct device *dev,
  */
 static int qmspi_init(const struct device *dev)
 {
+	int err;
 	const struct spi_qmspi_config *cfg = dev->config;
 	struct spi_qmspi_data *data = dev->data;
 	QMSPI_Type *regs = cfg->regs;
@@ -629,6 +627,11 @@ static int qmspi_init(const struct device *dev)
 
 	MCHP_GIRQ_BLK_CLREN(cfg->girq);
 	NVIC_ClearPendingIRQ(cfg->girq_nvic_direct);
+
+	err = spi_context_cs_configure_all(&data->ctx);
+	if (err < 0) {
+		return err;
+	}
 
 	spi_context_unlock_unconditionally(&data->ctx);
 
@@ -671,7 +674,8 @@ static const struct spi_qmspi_config spi_qmspi_0_config = {
 
 static struct spi_qmspi_data spi_qmspi_0_dev_data = {
 	SPI_CONTEXT_INIT_LOCK(spi_qmspi_0_dev_data, ctx),
-	SPI_CONTEXT_INIT_SYNC(spi_qmspi_0_dev_data, ctx)
+	SPI_CONTEXT_INIT_SYNC(spi_qmspi_0_dev_data, ctx),
+	SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(0), ctx)
 };
 
 DEVICE_DT_INST_DEFINE(0,

--- a/drivers/spi/spi_xlnx_axi_quadspi.c
+++ b/drivers/spi/spi_xlnx_axi_quadspi.c
@@ -481,7 +481,7 @@ static const struct spi_driver_api xlnx_quadspi_driver_api = {
 			    NULL,					\
 			    &xlnx_quadspi_data_##n,			\
 			    &xlnx_quadspi_config_##n, POST_KERNEL,	\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+			    CONFIG_SPI_INIT_PRIORITY,			\
 			    &xlnx_quadspi_driver_api);			\
 									\
 	static void xlnx_quadspi_config_func_##n(const struct device *dev)	\

--- a/drivers/spi/spi_xlnx_axi_quadspi.c
+++ b/drivers/spi/spi_xlnx_axi_quadspi.c
@@ -214,10 +214,6 @@ static int xlnx_quadspi_configure(const struct device *dev,
 
 	ctx->config = spi_cfg;
 
-	if (!IS_ENABLED(CONFIG_SPI_SLAVE) || !spi_context_is_slave(ctx)) {
-		spi_context_cs_configure(ctx);
-	}
-
 	return 0;
 }
 
@@ -436,6 +432,7 @@ static void xlnx_quadspi_isr(const struct device *dev)
 
 static int xlnx_quadspi_init(const struct device *dev)
 {
+	int err;
 	const struct xlnx_quadspi_config *config = dev->config;
 	struct xlnx_quadspi_data *data = dev->data;
 
@@ -447,6 +444,11 @@ static int xlnx_quadspi_init(const struct device *dev)
 	/* Enable DTR Empty interrupt */
 	xlnx_quadspi_write32(dev, IPIXR_DTR_EMPTY, IPIER_OFFSET);
 	xlnx_quadspi_write32(dev, DGIER_GIE, DGIER_OFFSET);
+
+	err = spi_context_cs_configure_all(&data->ctx);
+	if (err < 0) {
+		return err;
+	}
 
 	spi_context_unlock_unconditionally(&data->ctx);
 
@@ -475,6 +477,7 @@ static const struct spi_driver_api xlnx_quadspi_driver_api = {
 	static struct xlnx_quadspi_data xlnx_quadspi_data_##n = {	\
 		SPI_CONTEXT_INIT_LOCK(xlnx_quadspi_data_##n, ctx),	\
 		SPI_CONTEXT_INIT_SYNC(xlnx_quadspi_data_##n, ctx),	\
+		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx)	\
 	};								\
 									\
 	DEVICE_DT_INST_DEFINE(n, &xlnx_quadspi_init,			\


### PR DESCRIPTION
Initialize all defined cs gpios and set them as inactive during driver initialization to be sure that before first communication over SPI the cs gpio is in the valid state. It also fixes the case when we have multiple devices connected to the one SPI interface and the initial state of cs gpios after MCU reset is floating and might be low, so that prevents us from communicating between particular devices. 

PR has been tested on STM32F4 with 15 TMC5160 stepper motor controllers connected via SPI.

That's an updated version of https://github.com/zephyrproject-rtos/zephyr/pull/36982