### PR TITLE
boards: riscv: tlsr9518adk80d: fix wrong board's link name

### DIFF
--- a/boards/riscv/tlsr9518adk80d/doc/index.rst
+++ b/boards/riscv/tlsr9518adk80d/doc/index.rst
@@ -1,4 +1,4 @@
-.. _tlst9518adk80d:
+.. _tlsr9518adk80d:
 
 Telink TLSR9518ADK80D
 #####################


### PR DESCRIPTION
Fixed wrong board link name in documentation:
  _tlst9518adk80d -> _tlsr9518adk80d

Signed-off-by: Yuriy Vynnychek <yura.vynnychek@telink-semi.com>