### PR TITLE
npcx: fit the booter's behavior in different NPCX series 

### DIFF
--- a/drivers/espi/espi_npcx.c
+++ b/drivers/espi/espi_npcx.c
@@ -856,6 +856,11 @@ static int espi_npcx_init(const struct device *dev)
 	const struct device *const clk_dev = DEVICE_DT_GET(NPCX_CLK_CTRL_NODE);
 	int i, ret;
 
+	/* If booter doesn't set the host interface type */
+	if (!NPCX_BOOTER_IS_HIF_TYPE_SET()) {
+		npcx_host_interface_sel(NPCX_HIF_TYPE_ESPI_SHI);
+	}
+
 	/* Turn on eSPI device clock first */
 	ret = clock_control_on(clk_dev, (clock_control_subsys_t *)
 							&config->clk_cfg);

--- a/dts/arm/nuvoton/npcx.dtsi
+++ b/dts/arm/nuvoton/npcx.dtsi
@@ -671,6 +671,10 @@
 		compatible = "nuvoton,npcx-soc-id";
 		family-id = <0x20>;
 	};
+
+	booter-variant {
+		compatible = "nuvoton,npcx-booter-variant";
+	};
 };
 
 &nvic {

--- a/dts/arm/nuvoton/npcx7.dtsi
+++ b/dts/arm/nuvoton/npcx7.dtsi
@@ -202,4 +202,8 @@
 		chip-id = <0x07>;
 		revision-reg = <0x00007FFC 1>;
 	};
+
+	booter-variant {
+		hif-type-auto;
+	};
 };

--- a/dts/bindings/misc/nuvoton,npcx-booter-variant.yaml
+++ b/dts/bindings/misc/nuvoton,npcx-booter-variant.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2021 Nuvoton Technology Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Nuvoton, NPCX booter variant options
+
+compatible: "nuvoton,npcx-booter-variant"
+
+properties:
+    hif-type-auto:
+        type: boolean
+        required: false
+        description: |
+            The host interface type (LPC/eSPI/SHI) is configured by booter
+            if true; otherwise, it should be configured by the firmware.

--- a/soc/arm/nuvoton_npcx/common/reg/reg_def.h
+++ b/soc/arm/nuvoton_npcx/common/reg/reg_def.h
@@ -226,6 +226,13 @@ static inline uint32_t npcx_lv_gpio_ctl_offset(uint32_t ctl_no)
 #define NPCX_DEVPU0_I2C3_0_PUE                6
 #define NPCX_DEVPU1_F_SPI_PUD_EN              7
 
+/* Supported host interface type for HIF_TYP_SEL FILED in DEVCNT register. */
+enum npcx_hif_type {
+	NPCX_HIF_TYPE_NONE,
+	NPCX_HIF_TYPE_LPC,
+	NPCX_HIF_TYPE_ESPI_SHI,
+};
+
 /*
  * System Glue (GLUE) device registers
  */

--- a/soc/arm/nuvoton_npcx/common/scfg.c
+++ b/soc/arm/nuvoton_npcx/common/scfg.c
@@ -209,6 +209,13 @@ void npcx_pinctrl_psl_input_configure(void)
 	}
 }
 
+void npcx_host_interface_sel(enum npcx_hif_type hif_type)
+{
+	struct scfg_reg *inst_scfg = HAL_SFCG_INST();
+
+	SET_FIELD(inst_scfg->DEVCNT, NPCX_DEVCNT_HIF_TYP_SEL_FIELD, hif_type);
+}
+
 /* Pin-control driver registration */
 static int npcx_scfg_init(const struct device *dev)
 {

--- a/soc/arm/nuvoton_npcx/common/soc_dt.h
+++ b/soc/arm/nuvoton_npcx/common/soc_dt.h
@@ -705,4 +705,14 @@
 #define NPCX_DT_PSL_OUT_PIN(inst) DT_PROP(DT_INST(inst, nuvoton_npcx_psl_out), \
 							pin)
 
+/**
+ * @brief Check if the host interface type is automatically configured by
+ * booter.
+ *
+ * @return TRUE - if the host interface is configured by booter,
+ *         FALSE - otherwise.
+ */
+#define NPCX_BOOTER_IS_HIF_TYPE_SET() \
+	DT_PROP(DT_PATH(booter_variant), hif_type_auto)
+
 #endif /* _NUVOTON_NPCX_SOC_DT_H_ */

--- a/soc/arm/nuvoton_npcx/common/soc_pins.h
+++ b/soc/arm/nuvoton_npcx/common/soc_pins.h
@@ -168,6 +168,13 @@ void npcx_lvol_suspend_io_pads(void);
  */
 bool npcx_lvol_is_enabled(int port, int pin);
 
+/**
+ * @brief Select the host interface type
+ *
+ * @param hif_type host interface type
+ */
+void npcx_host_interface_sel(enum npcx_hif_type hif_type);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
The booter (bootloader) behavior may be different in different NPCX chip series. One example is that the booter sets the host interface type in NPCX7 series but leaves the firmware to set it in NPCX9 series.  
This PR do the following:
1. adds a new DT node to record variants in its properties.
2. add an API function to select the host interface type.
3. set the host interface type in eSPI driver explicitly if it is not set by the booter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zephyrproject-rtos/zephyr/37330)
<!-- Reviewable:end -->
