### PR TITLE
net: socket: fix significant buffer tls send

### DIFF
--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -1650,13 +1650,21 @@ ssize_t ztls_sendmsg_ctx(struct tls_context *ctx, const struct msghdr *msg,
 	len = 0;
 	if (msg) {
 		for (i = 0; i < msg->msg_iovlen; i++) {
-			ret = ztls_sendto_ctx(ctx, msg->msg_iov[i].iov_base,
-					      msg->msg_iov[i].iov_len, flags,
-					      msg->msg_name, msg->msg_namelen);
-			if (ret < 0) {
-				return ret;
+			struct iovec *vec = msg->msg_iov + i;
+			size_t sent = 0;
+
+			while (sent < vec->iov_len) {
+				uint8_t *ptr = (uint8_t *)vec->iov_base + sent;
+
+				ret = ztls_sendto_ctx(ctx, ptr,
+					    vec->iov_len - sent, flags,
+					    msg->msg_name, msg->msg_namelen);
+				if (ret < 0) {
+					return ret;
+				}
+				sent += ret;
 			}
-			len += ret;
+			len += sent;
 		}
 	}
 


### PR DESCRIPTION
Sending of > 2k buffers leads to split socket writes.
Current implementation is not checking for full buffer size.
ztls_sendmsg_ctx proceeds to next iov on sucessful write.

Solution: Add loop into ztls_sendmsg_ctx to process whole buffer
before proceeding to next iov.
