### PR TITLE
Bluetooth: controller: Add reset of per adv for HCI_Reset command

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -33,6 +33,7 @@
 #include "lll_adv.h"
 #include "lll_adv_pdu.h"
 #include "lll_adv_aux.h"
+#include "lll_adv_sync.h"
 #include "lll_conn.h"
 #include "lll_chan.h"
 #include "lll_filter.h"
@@ -159,6 +160,12 @@ int lll_adv_init(void)
 		return err;
 	}
 #endif /* BT_CTLR_ADV_AUX_SET > 0 */
+#if defined(CONFIG_BT_CTLR_ADV_PERIODIC)
+	err = lll_adv_sync_init();
+	if (err) {
+		return err;
+	}
+#endif /* CONFIG_BT_CTLR_ADV_PERIODIC */
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
 
 	err = init_reset();
@@ -180,6 +187,12 @@ int lll_adv_reset(void)
 		return err;
 	}
 #endif /* BT_CTLR_ADV_AUX_SET > 0 */
+#if defined(CONFIG_BT_CTLR_ADV_PERIODIC)
+	err = lll_adv_sync_reset();
+	if (err) {
+		return err;
+	}
+#endif /* CONFIG_BT_CTLR_ADV_PERIODIC */
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
 
 	err = init_reset();

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -434,7 +434,7 @@ int ull_adv_aux_init(void)
 	return 0;
 }
 
-int ull_adv_aux_reset(void)
+int ull_adv_aux_reset_finalize(void)
 {
 	int err;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
@@ -80,7 +80,7 @@ void ull_adv_done(struct node_rx_event_done *done);
 
 /* Helper functions to initialise and reset ull_adv_aux module */
 int ull_adv_aux_init(void);
-int ull_adv_aux_reset(void);
+int ull_adv_aux_reset_finalize(void);
 
 /* Return the aux set handle given the aux set instance */
 uint8_t ull_adv_aux_handle_get(struct ll_adv_aux_set *aux);
@@ -150,6 +150,7 @@ void ull_adv_aux_ptr_fill(uint8_t **dptr, uint8_t phy_s);
 
 int ull_adv_sync_init(void);
 int ull_adv_sync_reset(void);
+int ull_adv_sync_reset_finalize(void);
 
 /* helper function to release periodic advertising instance */
 void ull_adv_sync_release(struct ll_adv_sync_set *sync);

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -635,6 +635,42 @@ int ull_adv_sync_init(void)
 
 int ull_adv_sync_reset(void)
 {
+	struct lll_adv_sync *lll_sync;
+	struct ll_adv_sync_set *sync;
+	struct ll_adv_set *adv;
+	uint8_t handle;
+	int err;
+
+	for (handle = 0U; handle < BT_CTLR_ADV_SET; handle++) {
+		adv = ull_adv_is_created_get(handle);
+		if (!adv) {
+			continue;
+		}
+
+		lll_sync = adv->lll.sync;
+		if (!lll_sync) {
+			continue;
+		}
+
+		sync = HDR_LLL2ULL(lll_sync);
+
+		if (!sync->is_started) {
+			sync->is_enabled = 0U;
+
+			continue;
+		}
+
+		err = sync_remove(sync, adv, 0U);
+		if (err) {
+			return err;
+		}
+	}
+
+	return 0;
+}
+
+int ull_adv_sync_reset_finalize(void)
+{
 	int err;
 
 	err = init_reset();

--- a/subsys/bluetooth/controller/ll_sw/ull_df.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_df.c
@@ -124,6 +124,21 @@ int ull_df_reset(void)
 {
 	int err;
 
+#if defined(CONFIG_BT_CTLR_DF_ADV_CTE_TX)
+	struct ll_adv_set *adv;
+	uint8_t handle;
+
+	/* Get the advertising set instance */
+	for (handle = 0U; handle < BT_CTLR_ADV_SET; handle++) {
+		adv = ull_adv_is_created_get(handle);
+		if (!adv) {
+			continue;
+		}
+
+		adv->df_cfg = NULL;
+	}
+#endif /* CONFIG_BT_CTLR_DF_ADV_CTE_TX */
+
 	err = init_reset();
 	if (err) {
 		return err;


### PR DESCRIPTION
There is missing handling of periodic advertising reset for
HCI_Reset command. That makes impossible to execute e.g.
qualification tests without rebooting of the DUT
for periodic advertising and direction finding.

This commit adds missing implementation.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>