### PR TITLE
Bluetooth: Add BT_GAP_ADV_PROPs for report data status

### DIFF
--- a/include/bluetooth/gap.h
+++ b/include/bluetooth/gap.h
@@ -118,6 +118,23 @@ enum {
 	BT_GAP_ADV_PROP_SCAN_RESPONSE         = BIT(3),
 	/** Extended advertising. */
 	BT_GAP_ADV_PROP_EXT_ADV               = BIT(4),
+	/** The received data is the last part of an advertisement.
+	 *
+	 * This bit is set when all the data is reported at once
+	 * or when the data was received in chucks and the received
+	 * data is the last part of an advertisement.
+	 */
+	BT_GAP_ADV_PROP_REPORT_LAST           = BIT(5),
+	/** The reported data is a chuck of the total advertisement data.
+	 *
+	 * The reported data may be the first, intermediate, or the last part
+	 * of the total advertisement.
+	 *
+	 * If this bit is set in conjunction with
+	 * @ref BT_GAP_ADV_PROP_REPORT_LAST, that indicates the
+	 * device was unable to receive the remaining data.
+	 */
+	BT_GAP_ADV_PROP_REPORT_INCOMPLETE     = BIT(6),
 };
 
 /** Maximum advertising data length. */

--- a/tests/bluetooth/bsim_bt/bsim_test_advx/src/main.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_advx/src/main.c
@@ -820,6 +820,10 @@ static void scan_recv(const struct bt_le_scan_recv_info *info,
 	       phy2str(info->primary_phy), phy2str(info->secondary_phy),
 	       info->interval, info->interval * 5 / 4, info->sid);
 
+	if (!(info->adv_props & BT_GAP_ADV_PROP_REPORT_LAST)) {
+		FAIL("Didn't expect a report where REPORT_LAST is not set.");
+	}
+
 	if (info->interval) {
 		if (!is_periodic) {
 			is_periodic = true;


### PR DESCRIPTION
When the controller reports advertising data, the advertisement data
may be split into multiple reports. In order to decode the data, the
application must know if the report is complete and if it is the first,
intermediate, or last fragment.

Another approach would have been to accumulating the data in the host
until the data is complete. That would require additional memory
management.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/37368

Extended an existing tests to validate that the
BT_GAP_ADV_PROP_REPORT_LAST is correctly set.

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>