### PR TITLE
ci: doc: fix some publish issues and enable debug mode

### DIFF
--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -39,6 +39,8 @@ jobs:
         aws-region: us-east-1
 
     - name: Upload to AWS S3
+      env:
+        HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
       run: |
         if [ "${HEAD_BRANCH:0:1}" == "v" ]; then
           VERSION=${HEAD_BRANCH:1}

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -50,4 +50,4 @@ jobs:
 
         aws s3 sync --quiet html-output/html s3://docs.zephyrproject.org/${VERSION} --delete
         aws s3 sync --quiet html-output/html/doxygen/html s3://docs.zephyrproject.org/apidoc/${VERSION} --delete
-        aws s3 sync --quiet pdf-output/zephyr.pdf s3://docs.zephyrproject.org/${VERSION}/zephyr.pdf
+        aws s3 cp --quiet pdf-output/zephyr.pdf s3://docs.zephyrproject.org/${VERSION}/zephyr.pdf

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -48,6 +48,11 @@ jobs:
           VERSION="latest"
         fi
 
-        aws s3 sync --quiet html-output/html s3://docs.zephyrproject.org/${VERSION} --delete
-        aws s3 sync --quiet html-output/html/doxygen/html s3://docs.zephyrproject.org/apidoc/${VERSION} --delete
-        aws s3 cp --quiet pdf-output/zephyr.pdf s3://docs.zephyrproject.org/${VERSION}/zephyr.pdf
+        echo "Publish version: ${VERSION}"
+        ls -l html-output/html
+        ls -l html-output/html/doxygen/html
+        ls -l pdf-output/
+
+        aws s3 sync --debug html-output/html s3://docs.zephyrproject.org/${VERSION} --delete
+        aws s3 sync --debug html-output/html/doxygen/html s3://docs.zephyrproject.org/apidoc/${VERSION} --delete
+        aws s3 cp --debug pdf-output/zephyr.pdf s3://docs.zephyrproject.org/${VERSION}/zephyr.pdf


### PR DESCRIPTION
- `github.event.workflow_run.head_branch` contains the actual release tag
on releases, so it is required. It does not affect the publication of
"latest".
- Use `cp` instead of `sync` for PDF
- Enable debug facilities to diagnose AWS S3 issues