### PR TITLE
Revert "ci: doc: enable debug for aws s3 step"

### DIFF
--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -48,11 +48,6 @@ jobs:
           VERSION="latest"
         fi
 
-        echo "Publish version: ${VERSION}"
-        ls -l html-output/html
-        ls -l html-output/html/doxygen/html
-        ls -l pdf-output/
-
-        aws s3 sync --debug html-output/html s3://docs.zephyrproject.org/${VERSION} --delete
-        aws s3 sync --debug html-output/html/doxygen/html s3://docs.zephyrproject.org/apidoc/${VERSION} --delete
-        aws s3 cp --debug pdf-output/zephyr.pdf s3://docs.zephyrproject.org/${VERSION}/zephyr.pdf
+        aws s3 sync --quiet html-output/html s3://docs.zephyrproject.org/${VERSION} --delete
+        aws s3 sync --quiet html-output/html/doxygen/html s3://docs.zephyrproject.org/apidoc/${VERSION} --delete
+        aws s3 cp --quiet pdf-output/zephyr.pdf s3://docs.zephyrproject.org/${VERSION}/zephyr.pdf


### PR DESCRIPTION
This reverts commit 40a5cf6016d2af61e67223e3314bba85133c93a1. Debug
information is no longer necessary as doc-publish workflow is now
working correctly.