### PR TITLE
Add configuration option to suppress destination unreachable errors

### DIFF
--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -842,6 +842,12 @@ module-help = Enables promiscuous mode to output debug messages.
 source "subsys/net/Kconfig.template.log_config.net"
 endif # NET_PROMISCUOUS_MODE
 
+config NET_DISABLE_ICMP_DESTINATION_UNREACHABLE
+	bool "Disable destination unreachable ICMP errors"
+	help
+	  Suppress the generation of ICMP destination unreachable errors
+	  when ports that are not in a listening state receive packets.
+
 source "subsys/net/ip/Kconfig.stack"
 
 source "subsys/net/ip/Kconfig.mgmt"

--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -461,6 +461,10 @@ static bool conn_addr_cmp(struct net_pkt *pkt,
 
 static inline void conn_send_icmp_error(struct net_pkt *pkt)
 {
+	if (IS_ENABLED(CONFIG_NET_DISABLE_ICMP_DESTINATION_UNREACHABLE)) {
+		return;
+	}
+
 	if (IS_ENABLED(CONFIG_NET_IPV6) && net_pkt_family(pkt) == AF_INET6) {
 		net_icmpv6_send_error(pkt, NET_ICMPV6_DST_UNREACH,
 				      NET_ICMPV6_DST_UNREACH_NO_PORT, 0);


### PR DESCRIPTION
This PR introduces a configuration option for the networking stack to go into stealth mode and suppress the generation ICMP destination unreachable errors.