### PR TITLE
Bluetooth: controller: Fix wrong CTE type in per adv report

### DIFF
--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -1503,6 +1503,7 @@ struct bt_hci_cp_le_set_privacy_mode {
 #define BT_HCI_LE_AOA_CTE                      0x0
 #define BT_HCI_LE_AOD_CTE_1US                  0x1
 #define BT_HCI_LE_AOD_CTE_2US                  0x2
+#define BT_HCI_LE_NO_CTE                       0xFF
 
 #define BT_HCI_LE_CTE_COUNT_MIN                0x1
 #define BT_HCI_LE_CTE_COUNT_MAX                0x10

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -5344,11 +5344,11 @@ static void le_per_adv_sync_report(struct pdu_data *pdu_data,
 	struct bt_hci_evt_le_per_advertising_report *sep;
 	int8_t tx_pwr = BT_HCI_LE_ADV_TX_POWER_NO_PREF;
 	struct pdu_adv *adv = (void *)pdu_data;
+	uint8_t cte_type = BT_HCI_LE_NO_CTE;
 	struct node_rx_pdu *node_rx_curr;
 	struct node_rx_pdu *node_rx_next;
 	uint8_t total_data_len = 0U;
 	uint8_t data_status = 0U;
-	uint8_t cte_type = 0U;
 	uint8_t data_len = 0U;
 	uint8_t *data = NULL;
 	uint8_t data_max_len;


### PR DESCRIPTION
The Bluetooth Core spec 5.2 requires to provide CTE type in
periodic advertising report.
The implementation of le_per_adv_sync_report assigned
value zero to be default CTE type. The assigned value
in Bluetooth Core spec 5.2 means "AoA Constant Tone
Extension". In case there is no CTE attached to periodic
advertising PDU, CTE type should contain value 0xFF.

This commit fixes the issue.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>