### PR TITLE
drivers: convert to `spi_dt_spec`

### DIFF
--- a/drivers/can/can_mcp2515.h
+++ b/drivers/can/can_mcp2515.h
@@ -25,13 +25,6 @@ struct mcp2515_tx_cb {
 };
 
 struct mcp2515_data {
-	/* spi device data */
-	const struct device *spi;
-	struct spi_config spi_cfg;
-#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
-	struct spi_cs_control spi_cs_ctrl;
-#endif /* DT_INST_SPI_DEV_HAS_CS_GPIOS(0) */
-
 	/* interrupt data */
 	const struct device *int_gpio;
 	struct gpio_callback int_gpio_cb;
@@ -59,12 +52,7 @@ struct mcp2515_data {
 
 struct mcp2515_config {
 	/* spi configuration */
-	const char *spi_port;
-	uint8_t spi_cs_pin;
-	uint8_t spi_cs_flags;
-	const char *spi_cs_port;
-	uint32_t spi_freq;
-	uint8_t spi_slave;
+	struct spi_dt_spec bus;
 
 	/* interrupt configuration */
 	uint8_t int_pin;

--- a/drivers/dac/dac_dacx0508.c
+++ b/drivers/dac/dac_dacx0508.c
@@ -31,27 +31,20 @@ LOG_MODULE_REGISTER(dac_dacx0508, CONFIG_DAC_LOG_LEVEL);
 #define DACX0508_MAX_CHANNEL    8
 
 struct dacx0508_config {
-	const char *spi_dev_name;
-	const char *spi_cs_dev_name;
-	gpio_pin_t spi_cs_pin;
-	gpio_dt_flags_t spi_cs_dt_flags;
-	struct spi_config spi_cfg;
+	struct spi_dt_spec bus;
 	uint8_t resolution;
 	uint8_t reference;
 	uint8_t gain[8];
 };
 
 struct dacx0508_data {
-	const struct device *spi_dev;
-	struct spi_cs_control spi_cs;
-	struct spi_config spi_cfg;
 	uint8_t configured;
 };
 
 static int dacx0508_reg_read(const struct device *dev, uint8_t addr,
 			     uint8_t *data)
 {
-	struct dacx0508_data *dev_data = dev->data;
+	const struct dacx0508_config *config = dev->config;
 	const struct spi_buf buf[2] = {
 		{
 			.buf = &addr,
@@ -80,12 +73,12 @@ static int dacx0508_reg_read(const struct device *dev, uint8_t addr,
 
 	tmp = addr |= DACX0508_READ_CMD;
 
-	ret = spi_write(dev_data->spi_dev, &dev_data->spi_cfg, &tx);
+	ret = spi_write_dt(&config->bus, &tx);
 	if (ret) {
 		return ret;
 	}
 
-	ret = spi_read(dev_data->spi_dev, &dev_data->spi_cfg, &rx);
+	ret = spi_read_dt(&config->bus, &rx);
 	if (ret) {
 		return ret;
 	}
@@ -100,7 +93,7 @@ static int dacx0508_reg_read(const struct device *dev, uint8_t addr,
 static int dacx0508_reg_write(const struct device *dev, uint8_t addr,
 			      	uint8_t *data)
 {
-	struct dacx0508_data *dev_data = dev->data;
+	const struct dacx0508_config *config = dev->config;
 	const struct spi_buf buf[2] = {
 		{
 			.buf = &addr,
@@ -121,7 +114,7 @@ static int dacx0508_reg_write(const struct device *dev, uint8_t addr,
 		return -EWOULDBLOCK;
 	}
 
-	return spi_write(dev_data->spi_dev, &dev_data->spi_cfg, &tx);
+	return spi_write_dt(&config->bus, &tx);
 }
 
 int dacx0508_reg_update(const struct device *dev, uint8_t addr,
@@ -337,25 +330,9 @@ static int dacx0508_init(const struct device *dev)
 	struct dacx0508_data *data = dev->data;
 	int ret;
 
-	data->spi_dev = device_get_binding(config->spi_dev_name);
-	if (!data->spi_dev) {
-		LOG_ERR("Cannot get pointer to %s device",
-			config->spi_dev_name);
-		return -EINVAL;
-	}
-
-	if (config->spi_cs_dev_name) {
-		data->spi_cs.gpio_dev =
-				device_get_binding(config->spi_cs_dev_name);
-		if (!data->spi_cs.gpio_dev) {
-			LOG_ERR("Cannot get pointer to %s device",
-				config->spi_cs_dev_name);
-			return -EINVAL;
-		}
-		data->spi_cs.gpio_pin = config->spi_cs_pin;
-		data->spi_cs.gpio_dt_flags = config->spi_cs_dt_flags;
-		data->spi_cfg = config->spi_cfg;
-		data->spi_cfg.cs = &data->spi_cs;
+	if (!spi_is_ready(&config->bus)) {
+		LOG_ERR("SPI bus %s not ready", config->bus.bus->name);
+		return -ENODEV;
 	}
 
 	ret = dacx0508_soft_reset(dev);
@@ -389,29 +366,9 @@ static const struct dac_driver_api dacx0508_driver_api = {
 #define DACX0508_DEVICE(t, n, res) \
 	static struct dacx0508_data dac##t##_data_##n; \
 	static const struct dacx0508_config dac##t##_config_##n = { \
-		.spi_dev_name = DT_BUS_LABEL(INST_DT_DACX0508(n, t)), \
-		.spi_cs_dev_name = \
-			UTIL_AND( \
-			DT_SPI_DEV_HAS_CS_GPIOS(INST_DT_DACX0508(n, t)), \
-			DT_SPI_DEV_CS_GPIOS_LABEL(INST_DT_DACX0508(n, t)) \
-			), \
-		.spi_cs_pin = \
-			UTIL_AND( \
-			DT_SPI_DEV_HAS_CS_GPIOS(INST_DT_DACX0508(n, t)), \
-			DT_SPI_DEV_CS_GPIOS_PIN(INST_DT_DACX0508(n, t)) \
-			), \
-		.spi_cs_dt_flags = UTIL_AND( \
-			DT_SPI_DEV_HAS_CS_GPIOS(INST_DT_DACX0508(n, t)), \
-			DT_SPI_DEV_CS_GPIOS_FLAGS(INST_DT_DACX0508(n, t)) \
-			), \
-		.spi_cfg = { \
-			.operation = (SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB | \
-				     SPI_WORD_SET(8) | SPI_MODE_CPHA), \
-			.frequency = DT_PROP(INST_DT_DACX0508(n, t), \
-					     spi_max_frequency), \
-			.slave = DT_REG_ADDR(INST_DT_DACX0508(n, t)), \
-			.cs = &dac##t##_data_##n.spi_cs, \
-		}, \
+		.bus = SPI_DT_SPEC_GET(INST_DT_DACX0508(n, t), \
+			SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB | \
+			SPI_WORD_SET(8) | SPI_MODE_CPHA, 0), \
 		.resolution = res, \
 		.reference = DT_PROP(INST_DT_DACX0508(n, t), \
 					     voltage_reference), \

--- a/drivers/display/display_st7735r.c
+++ b/drivers/display/display_st7735r.c
@@ -34,9 +34,7 @@ struct st7735r_gpio_data {
 };
 
 struct st7735r_config {
-	const char *spi_name;
-	const char *cs_name;
-	struct spi_config spi_config;
+	struct spi_dt_spec bus;
 	struct st7735r_gpio_data cmd_data;
 	struct st7735r_gpio_data reset;
 	uint16_t height;
@@ -61,8 +59,6 @@ struct st7735r_config {
 
 struct st7735r_data {
 	const struct st7735r_config *config;
-	const struct device *spi_dev;
-	struct spi_cs_control cs_ctrl;
 	const struct device *cmd_data_dev;
 	const struct device *reset_dev;
 	uint16_t x_offset;
@@ -92,7 +88,7 @@ static int st7735r_transmit(struct st7735r_data *data, uint8_t cmd,
 	int ret;
 
 	st7735r_set_cmd(data, 1);
-	ret = spi_write(data->spi_dev, &data->config->spi_config, &tx_bufs);
+	ret = spi_write_dt(&data->config->bus, &tx_bufs);
 	if (ret < 0) {
 		return ret;
 	}
@@ -101,7 +97,7 @@ static int st7735r_transmit(struct st7735r_data *data, uint8_t cmd,
 		tx_buf.buf = (void *)tx_data;
 		tx_buf.len = tx_count;
 		st7735r_set_cmd(data, 0);
-		ret = spi_write(data->spi_dev, &data->config->spi_config, &tx_bufs);
+		ret = spi_write_dt(&data->config->bus, &tx_bufs);
 		if (ret < 0) {
 			return ret;
 		}
@@ -244,7 +240,7 @@ static int st7735r_write(const struct device *dev,
 	for (write_cnt = 1U; write_cnt < nbr_of_writes; ++write_cnt) {
 		tx_buf.buf = (void *)write_data_start;
 		tx_buf.len = desc->width * ST7735R_PIXEL_SIZE * write_h;
-		ret = spi_write(data->spi_dev, &data->config->spi_config, &tx_bufs);
+		ret = spi_write_dt(&data->config->bus, &tx_bufs);
 		if (ret < 0) {
 			return ret;
 		}
@@ -446,18 +442,9 @@ static int st7735r_init(const struct device *dev)
 	struct st7735r_config *config = (struct st7735r_config *)dev->config;
 	int ret;
 
-	data->spi_dev = device_get_binding(config->spi_name);
-	if (data->spi_dev == NULL) {
-		LOG_ERR("Could not get SPI device for LCD");
+	if (!spi_is_ready(&config->bus)) {
+		LOG_ERR("SPI bus %s not ready", config->bus.bus->name);
 		return -ENODEV;
-	}
-
-	if (config->cs_name) {
-		data->cs_ctrl.gpio_dev = device_get_binding(config->cs_name);
-		if (data->cs_ctrl.gpio_dev == NULL) {
-			LOG_ERR("Could not get device for SPI CS");
-			return -ENODEV;
-		}
 	}
 
 	if (config->reset.name) {
@@ -574,18 +561,8 @@ static const struct display_driver_api st7735r_api = {
 	static struct st7735r_data st7735r_data_ ## inst;			\
 										\
 	const static struct st7735r_config st7735r_config_ ## inst = {		\
-		.spi_name = DT_INST_BUS_LABEL(inst),				\
-		.cs_name = UTIL_AND(						\
-			DT_INST_SPI_DEV_HAS_CS_GPIOS(inst),			\
-			DT_INST_SPI_DEV_CS_GPIOS_LABEL(inst)),			\
-		.spi_config.slave = DT_INST_REG_ADDR(inst),			\
-		.spi_config.frequency = UTIL_AND(				\
-			DT_HAS_PROP(inst, spi_max_frequency),			\
-			DT_INST_PROP(inst, spi_max_frequency)),			\
-		.spi_config.operation = SPI_OP_MODE_MASTER | SPI_WORD_SET(8),	\
-		.spi_config.cs = UTIL_AND(					\
-			DT_INST_SPI_DEV_HAS_CS_GPIOS(inst),			\
-			&(st7735r_data_ ## inst.cs_ctrl)),			\
+		.bus = SPI_DT_SPEC_INST_GET(					\
+			inst, SPI_OP_MODE_MASTER | SPI_WORD_SET(8), 0),		\
 		.cmd_data.name = DT_INST_GPIO_LABEL(inst, cmd_data_gpios),	\
 		.cmd_data.pin = DT_INST_GPIO_PIN(inst, cmd_data_gpios),		\
 		.cmd_data.flags = DT_INST_GPIO_FLAGS(inst, cmd_data_gpios),	\
@@ -620,13 +597,6 @@ static const struct display_driver_api st7735r_api = {
 										\
 	static struct st7735r_data st7735r_data_ ## inst = {			\
 		.config = &st7735r_config_ ## inst,				\
-		.cs_ctrl.gpio_pin = UTIL_AND(					\
-			DT_INST_SPI_DEV_HAS_CS_GPIOS(inst),			\
-			DT_INST_SPI_DEV_CS_GPIOS_PIN(inst)),			\
-		.cs_ctrl.gpio_dt_flags = UTIL_AND(				\
-			DT_INST_SPI_DEV_HAS_CS_GPIOS(inst),			\
-			DT_INST_SPI_DEV_CS_GPIOS_FLAGS(inst)),			\
-		.cs_ctrl.delay = 0U,						\
 		.x_offset = DT_INST_PROP(inst, x_offset),			\
 		.y_offset = DT_INST_PROP(inst, y_offset),			\
 	};									\

--- a/drivers/display/gd7965.c
+++ b/drivers/display/gd7965.c
@@ -26,16 +26,9 @@ LOG_MODULE_REGISTER(gd7965, CONFIG_DISPLAY_LOG_LEVEL);
  * also first gate/source should be 0.
  */
 
-#define GD7965_SPI_FREQ DT_INST_PROP(0, spi_max_frequency)
-#define GD7965_BUS_NAME DT_INST_BUS_LABEL(0)
 #define GD7965_DC_PIN DT_INST_GPIO_PIN(0, dc_gpios)
 #define GD7965_DC_FLAGS DT_INST_GPIO_FLAGS(0, dc_gpios)
 #define GD7965_DC_CNTRL DT_INST_GPIO_LABEL(0, dc_gpios)
-#define GD7965_CS_PIN DT_INST_SPI_DEV_CS_GPIOS_PIN(0)
-#define GD7965_CS_FLAGS DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0)
-#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
-#define GD7965_CS_CNTRL DT_INST_SPI_DEV_CS_GPIOS_LABEL(0)
-#endif
 #define GD7965_BUSY_PIN DT_INST_GPIO_PIN(0, busy_gpios)
 #define GD7965_BUSY_CNTRL DT_INST_GPIO_LABEL(0, busy_gpios)
 #define GD7965_BUSY_FLAGS DT_INST_GPIO_FLAGS(0, busy_gpios)
@@ -57,14 +50,14 @@ LOG_MODULE_REGISTER(gd7965, CONFIG_DISPLAY_LOG_LEVEL);
 
 
 struct gd7965_data {
+	const struct gd7965_config *config;
 	const struct device *reset;
 	const struct device *dc;
 	const struct device *busy;
-	const struct device *spi_dev;
-	struct spi_config spi_config;
-#if defined(GD7965_CS_CNTRL)
-	struct spi_cs_control cs_ctrl;
-#endif
+};
+
+struct gd7965_config {
+	struct spi_dt_spec bus;
 };
 
 static uint8_t gd7965_softstart[] = DT_INST_PROP(0, softstart);
@@ -82,7 +75,7 @@ static inline int gd7965_write_cmd(struct gd7965_data *driver,
 	struct spi_buf_set buf_set = {.buffers = &buf, .count = 1};
 
 	gpio_pin_set(driver->dc, GD7965_DC_PIN, 1);
-	if (spi_write(driver->spi_dev, &driver->spi_config, &buf_set)) {
+	if (spi_write_dt(&driver->config->bus, &buf_set)) {
 		return -EIO;
 	}
 
@@ -90,7 +83,7 @@ static inline int gd7965_write_cmd(struct gd7965_data *driver,
 		buf.buf = data;
 		buf.len = len;
 		gpio_pin_set(driver->dc, GD7965_DC_PIN, 0);
-		if (spi_write(driver->spi_dev, &driver->spi_config, &buf_set)) {
+		if (spi_write_dt(&driver->config->bus, &buf_set)) {
 			return -EIO;
 		}
 	}
@@ -392,20 +385,15 @@ static int gd7965_controller_init(const struct device *dev)
 
 static int gd7965_init(const struct device *dev)
 {
+	const struct gd7965_config *config = dev->config;
 	struct gd7965_data *driver = dev->data;
 
 	LOG_DBG("");
 
-	driver->spi_dev = device_get_binding(GD7965_BUS_NAME);
-	if (driver->spi_dev == NULL) {
-		LOG_ERR("Could not get SPI device for GD7965");
-		return -EIO;
+	if (!spi_is_ready(&config->bus)) {
+		LOG_ERR("SPI bus %s not ready", config->bus.bus->name);
+		return -ENODEV;
 	}
-
-	driver->spi_config.frequency = GD7965_SPI_FREQ;
-	driver->spi_config.operation = SPI_OP_MODE_MASTER | SPI_WORD_SET(8);
-	driver->spi_config.slave = DT_INST_REG_ADDR(0);
-	driver->spi_config.cs = NULL;
 
 	driver->reset = device_get_binding(GD7965_RESET_CNTRL);
 	if (driver->reset == NULL) {
@@ -434,23 +422,17 @@ static int gd7965_init(const struct device *dev)
 	gpio_pin_configure(driver->busy, GD7965_BUSY_PIN,
 			   GPIO_INPUT | GD7965_BUSY_FLAGS);
 
-#if defined(GD7965_CS_CNTRL)
-	driver->cs_ctrl.gpio_dev = device_get_binding(GD7965_CS_CNTRL);
-	if (!driver->cs_ctrl.gpio_dev) {
-		LOG_ERR("Unable to get SPI GPIO CS device");
-		return -EIO;
-	}
-
-	driver->cs_ctrl.gpio_pin = GD7965_CS_PIN;
-	driver->cs_ctrl.gpio_dt_flags = GD7965_CS_FLAGS;
-	driver->cs_ctrl.delay = 0U;
-	driver->spi_config.cs = &driver->cs_ctrl;
-#endif
-
 	return gd7965_controller_init(dev);
 }
 
-static struct gd7965_data gd7965_driver;
+static struct gd7965_data gd7965_driver = {
+	.config = &gd7965_config
+};
+
+static const struct gd7965_config gd7965_config {
+	.bus = SPI_DT_SPEC_INST_GET(
+		0, SPI_OP_MODE_MASTER | SPI_WORD_SET(8), 0)
+};
 
 static struct display_driver_api gd7965_driver_api = {
 	.blanking_on = gd7965_blanking_on,
@@ -467,6 +449,6 @@ static struct display_driver_api gd7965_driver_api = {
 
 
 DEVICE_DT_INST_DEFINE(0, gd7965_init, NULL,
-		    &gd7965_driver, NULL,
-		    POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY,
-		    &gd7965_driver_api);
+		      &gd7965_driver, &gd7965_config,
+		      POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY,
+		      &gd7965_driver_api);

--- a/drivers/display/ls0xx.c
+++ b/drivers/display/ls0xx.c
@@ -49,11 +49,11 @@ struct ls0xx_data {
 #if DT_INST_NODE_HAS_PROP(0, extcomin_gpios)
 	const struct device *extcomin_dev;
 #endif
-	const struct device *spi_dev;
-	struct spi_cs_control cs_ctrl;
-	struct spi_config spi_config;
 };
 
+struct ls0xx_config {
+	struct spi_dt_spec bus;
+};
 
 #if DT_INST_NODE_HAS_PROP(0, extcomin_gpios)
 /* Driver will handle VCOM toggling */
@@ -103,21 +103,21 @@ static int ls0xx_blanking_on(const struct device *dev)
 
 static int ls0xx_cmd(const struct device *dev, uint8_t *buf, uint8_t len)
 {
-	struct ls0xx_data *driver = dev->data;
+	const struct ls0xx_config *config = dev->config;
 	struct spi_buf cmd_buf = { .buf = buf, .len = len };
 	struct spi_buf_set buf_set = { .buffers = &cmd_buf, .count = 1 };
 
-	return spi_write(driver->spi_dev, &driver->spi_config, &buf_set);
+	return spi_write_dt(&config->bus, &buf_set);
 }
 
 static int ls0xx_clear(const struct device *dev)
 {
-	struct ls0xx_data *driver = dev->data;
+	const struct ls0xx_config *config = dev->config;
 	uint8_t clear_cmd[2] = { LS0XX_BIT_CLEAR, 0 };
 	int err;
 
 	err = ls0xx_cmd(dev, clear_cmd, sizeof(clear_cmd));
-	spi_release(driver->spi_dev, &driver->spi_config);
+	spi_release_dt(&config->bus);
 
 	return err;
 }
@@ -127,7 +127,7 @@ static int ls0xx_update_display(const struct device *dev,
 				uint16_t num_lines,
 				const uint8_t *data)
 {
-	struct ls0xx_data *driver = dev->data;
+	const struct ls0xx_config *config = dev->config;
 	uint8_t write_cmd[1] = { LS0XX_BIT_WRITECMD };
 	uint8_t ln = start_line;
 	uint8_t dummy = 27;
@@ -158,8 +158,7 @@ static int ls0xx_update_display(const struct device *dev,
 	 */
 	for (; ln <= start_line + num_lines - 1; ln++) {
 		line_buf[1].buf = (uint8_t *)data;
-		err |= spi_write(driver->spi_dev, &driver->spi_config,
-				 &line_set);
+		err |= spi_write_dt(&config->bus, &line_set);
 		data += LS0XX_PANEL_WIDTH / LS0XX_PIXELS_PER_BYTE;
 	}
 
@@ -169,7 +168,7 @@ static int ls0xx_update_display(const struct device *dev,
 	 */
 	err |= ls0xx_cmd(dev, write_cmd, sizeof(write_cmd));
 
-	spi_release(driver->spi_dev, &driver->spi_config);
+	spi_release_dt(&config->bus);
 
 	return err;
 }
@@ -270,35 +269,13 @@ static int ls0xx_set_pixel_format(const struct device *dev,
 
 static int ls0xx_init(const struct device *dev)
 {
+	const struct ls0xx_config *config = dev->config;
 	struct ls0xx_data *driver = dev->data;
 
-	driver->spi_dev = device_get_binding(DT_INST_BUS_LABEL(0));
-	if (driver->spi_dev == NULL) {
-		LOG_ERR("Could not get SPI device for LS0XX");
-		return -EIO;
+	if (!spi_is_ready(&config->bus)) {
+		LOG_ERR("SPI bus %s not ready", config->bus.bus->name);
+		return -ENODEV;
 	}
-
-	driver->spi_config.frequency = DT_INST_PROP(0, spi_max_frequency);
-	driver->spi_config.operation = SPI_OP_MODE_MASTER |
-				       SPI_WORD_SET(8) |
-				       SPI_TRANSFER_LSB |
-				       SPI_CS_ACTIVE_HIGH |
-				       SPI_HOLD_ON_CS |
-				       SPI_LOCK_ON;
-	driver->spi_config.slave = 0;
-
-#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
-	driver->cs_ctrl.gpio_dev = device_get_binding(
-		DT_INST_SPI_DEV_CS_GPIOS_LABEL(0));
-	if (driver->cs_ctrl.gpio_dev == NULL) {
-		LOG_ERR("Could not get SPI device for LS0XX");
-		return -EIO;
-	}
-	driver->cs_ctrl.gpio_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0);
-	driver->cs_ctrl.gpio_dt_flags = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0);
-	driver->cs_ctrl.delay = 0U;
-	driver->spi_config.cs = &driver->cs_ctrl;
-#endif
 
 #if DT_INST_NODE_HAS_PROP(0, disp_en_gpios)
 	driver->disp_dev = device_get_binding(
@@ -341,6 +318,13 @@ static int ls0xx_init(const struct device *dev)
 
 static struct ls0xx_data ls0xx_driver;
 
+static const struct ls0xx_config ls0xx_config = {
+	.bus = SPI_DT_SPEC_INST_GET(
+		0, SPI_OP_MODE_MASTER | SPI_WORD_SET(8) |
+		SPI_TRANSFER_LSB | SPI_CS_ACTIVE_HIGH |
+		SPI_HOLD_ON_CS | SPI_LOCK_ON, 0)
+};
+
 static struct display_driver_api ls0xx_driver_api = {
 	.blanking_on = ls0xx_blanking_on,
 	.blanking_off = ls0xx_blanking_off,
@@ -355,6 +339,6 @@ static struct display_driver_api ls0xx_driver_api = {
 };
 
 DEVICE_DT_INST_DEFINE(0, ls0xx_init, NULL,
-		      &ls0xx_driver, NULL,
+		      &ls0xx_driver, &ls0xx_config,
 		      POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY,
 		      &ls0xx_driver_api);

--- a/drivers/display/ssd16xx.c
+++ b/drivers/display/ssd16xx.c
@@ -25,16 +25,9 @@ LOG_MODULE_REGISTER(ssd16xx);
  * SSD1673, SSD1608, SSD1681, ILI3897 compatible EPD controller driver.
  */
 
-#define SSD16XX_SPI_FREQ DT_INST_PROP(0, spi_max_frequency)
-#define SSD16XX_BUS_NAME DT_INST_BUS_LABEL(0)
 #define SSD16XX_DC_PIN DT_INST_GPIO_PIN(0, dc_gpios)
 #define SSD16XX_DC_FLAGS DT_INST_GPIO_FLAGS(0, dc_gpios)
 #define SSD16XX_DC_CNTRL DT_INST_GPIO_LABEL(0, dc_gpios)
-#define SSD16XX_CS_PIN DT_INST_SPI_DEV_CS_GPIOS_PIN(0)
-#define SSD16XX_CS_FLAGS DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0)
-#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
-#define SSD16XX_CS_CNTRL DT_INST_SPI_DEV_CS_GPIOS_LABEL(0)
-#endif
 #define SSD16XX_BUSY_PIN DT_INST_GPIO_PIN(0, busy_gpios)
 #define SSD16XX_BUSY_CNTRL DT_INST_GPIO_LABEL(0, busy_gpios)
 #define SSD16XX_BUSY_FLAGS DT_INST_GPIO_FLAGS(0, busy_gpios)
@@ -62,13 +55,13 @@ struct ssd16xx_data {
 	const struct device *reset;
 	const struct device *dc;
 	const struct device *busy;
-	const struct device *spi_dev;
-	struct spi_config spi_config;
-#if defined(SSD16XX_CS_CNTRL)
-	struct spi_cs_control cs_ctrl;
-#endif
+	const struct ssd16xx_config *config;
 	uint8_t scan_mode;
 	uint8_t update_cmd;
+};
+
+struct ssd16xx_config {
+	struct spi_dt_spec bus;
 };
 
 #if DT_INST_NODE_HAS_PROP(0, lut_initial)
@@ -91,7 +84,7 @@ static inline int ssd16xx_write_cmd(struct ssd16xx_data *driver,
 	struct spi_buf_set buf_set = {.buffers = &buf, .count = 1};
 
 	gpio_pin_set(driver->dc, SSD16XX_DC_PIN, 1);
-	err = spi_write(driver->spi_dev, &driver->spi_config, &buf_set);
+	err = spi_write_dt(&driver->config->bus, &buf_set);
 	if (err < 0) {
 		return err;
 	}
@@ -100,7 +93,7 @@ static inline int ssd16xx_write_cmd(struct ssd16xx_data *driver,
 		buf.buf = data;
 		buf.len = len;
 		gpio_pin_set(driver->dc, SSD16XX_DC_PIN, 0);
-		err = spi_write(driver->spi_dev, &driver->spi_config, &buf_set);
+		err = spi_write_dt(&driver->config->bus, &buf_set);
 		if (err < 0) {
 			return err;
 		}
@@ -643,20 +636,15 @@ static int ssd16xx_controller_init(const struct device *dev)
 
 static int ssd16xx_init(const struct device *dev)
 {
+	const struct ssd16xx_config *config = dev->config;
 	struct ssd16xx_data *driver = dev->data;
 
 	LOG_DBG("");
 
-	driver->spi_dev = device_get_binding(SSD16XX_BUS_NAME);
-	if (driver->spi_dev == NULL) {
-		LOG_ERR("Could not get SPI device for SSD16XX");
-		return -EIO;
+	if (!spi_is_ready(&config->bus)) {
+		LOG_ERR("SPI bus %s not ready", config->bus.bus->name);
+		return -ENODEV;
 	}
-
-	driver->spi_config.frequency = SSD16XX_SPI_FREQ;
-	driver->spi_config.operation = SPI_OP_MODE_MASTER | SPI_WORD_SET(8);
-	driver->spi_config.slave = DT_INST_REG_ADDR(0);
-	driver->spi_config.cs = NULL;
 
 	driver->reset = device_get_binding(SSD16XX_RESET_CNTRL);
 	if (driver->reset == NULL) {
@@ -685,23 +673,17 @@ static int ssd16xx_init(const struct device *dev)
 	gpio_pin_configure(driver->busy, SSD16XX_BUSY_PIN,
 			   GPIO_INPUT | SSD16XX_BUSY_FLAGS);
 
-#if defined(SSD16XX_CS_CNTRL)
-	driver->cs_ctrl.gpio_dev = device_get_binding(SSD16XX_CS_CNTRL);
-	if (!driver->cs_ctrl.gpio_dev) {
-		LOG_ERR("Unable to get SPI GPIO CS device");
-		return -EIO;
-	}
-
-	driver->cs_ctrl.gpio_pin = SSD16XX_CS_PIN;
-	driver->cs_ctrl.gpio_dt_flags = SSD16XX_CS_FLAGS;
-	driver->cs_ctrl.delay = 0U;
-	driver->spi_config.cs = &driver->cs_ctrl;
-#endif
-
 	return ssd16xx_controller_init(dev);
 }
 
-static struct ssd16xx_data ssd16xx_driver;
+static const struct ssd16xx_config ssd16xx_config = {
+	.bus = SPI_DT_SPEC_INST_GET(
+		0, SPI_OP_MODE_MASTER | SPI_WORD_SET(8), 0)
+};
+
+static struct ssd16xx_data ssd16xx_driver = {
+	.config = &ssd16xx_config
+};
 
 static struct display_driver_api ssd16xx_driver_api = {
 	.blanking_on = ssd16xx_blanking_on,


### PR DESCRIPTION
Convert a range of drivers (mostly display) to use `struct spi_dt_spec`.
Depends on #37357