### PR TITLE
i2c: introduce `struct i2c_dt_spec`

### DIFF
--- a/drivers/sensor/bme680/bme680.h
+++ b/drivers/sensor/bme680/bme680.h
@@ -8,8 +8,7 @@
 #define __SENSOR_BME680_H__
 
 #include <device.h>
-#include <zephyr/types.h>
-
+#include <drivers/i2c.h>
 
 #define BME680_CHIP_ID                  0x61
 
@@ -120,9 +119,6 @@
 #define BME680_CONCAT_BYTES(msb, lsb) (((uint16_t)msb << 8) | (uint16_t)lsb)
 
 struct bme680_data {
-	const struct device *i2c_master;
-	uint16_t i2c_slave_addr;
-
 	/* Compensation parameters. */
 	uint16_t par_h1;
 	uint16_t par_h2;
@@ -165,6 +161,10 @@ struct bme680_data {
 	int32_t t_fine;
 
 	uint8_t chip_id;
+};
+
+struct bme680_config {
+	struct i2c_dt_spec bus;
 };
 
 #endif /* __SENSOR_BME680_H__ */

--- a/drivers/sensor/sht3xd/sht3xd.c
+++ b/drivers/sensor/sht3xd/sht3xd.c
@@ -52,31 +52,30 @@ static uint8_t sht3xd_compute_crc(uint16_t value)
 
 int sht3xd_write_command(const struct device *dev, uint16_t cmd)
 {
+	const struct sht3xd_config *config = dev->config;
 	uint8_t tx_buf[2];
 
 	sys_put_be16(cmd, tx_buf);
-	return i2c_write(sht3xd_i2c_device(dev), tx_buf, sizeof(tx_buf),
-			 sht3xd_i2c_address(dev));
+	return i2c_write_dt(&config->bus, tx_buf, sizeof(tx_buf));
 }
 
 int sht3xd_write_reg(const struct device *dev, uint16_t cmd, uint16_t val)
 {
+	const struct sht3xd_config *config = dev->config;
 	uint8_t tx_buf[5];
 
 	sys_put_be16(cmd, &tx_buf[0]);
 	sys_put_be16(val, &tx_buf[2]);
 	tx_buf[4] = sht3xd_compute_crc(val);
 
-	return i2c_write(sht3xd_i2c_device(dev), tx_buf, sizeof(tx_buf),
-			 sht3xd_i2c_address(dev));
+	return i2c_write_dt(&config->bus, tx_buf, sizeof(tx_buf));
 }
 
 static int sht3xd_sample_fetch(const struct device *dev,
 			       enum sensor_channel chan)
 {
+	const struct sht3xd_config *config = dev->config;
 	struct sht3xd_data *data = dev->data;
-	const struct device *i2c = sht3xd_i2c_device(dev);
-	uint8_t address = sht3xd_i2c_address(dev);
 	uint8_t rx_buf[6];
 	uint16_t t_sample, rh_sample;
 
@@ -92,7 +91,7 @@ static int sht3xd_sample_fetch(const struct device *dev,
 	}
 	k_sleep(K_MSEC(measure_wait[SHT3XD_REPEATABILITY_IDX] / USEC_PER_MSEC));
 
-	if (i2c_read(i2c, rx_buf, sizeof(rx_buf), address) < 0) {
+	if (i2c_read_dt(&config->bus, rx_buf, sizeof(rx_buf)) < 0) {
 		LOG_DBG("Failed to read data sample!");
 		return -EIO;
 	}
@@ -102,8 +101,8 @@ static int sht3xd_sample_fetch(const struct device *dev,
 
 	sys_put_be16(SHT3XD_CMD_FETCH, tx_buf);
 
-	if (i2c_write_read(i2c, address, tx_buf, sizeof(tx_buf),
-			   rx_buf, sizeof(rx_buf)) < 0) {
+	if (i2c_write_read_dt(&config->bus, tx_buf, sizeof(tx_buf),
+			      rx_buf, sizeof(rx_buf)) < 0) {
 		LOG_DBG("Failed to read data sample!");
 		return -EIO;
 	}
@@ -167,22 +166,12 @@ static const struct sensor_driver_api sht3xd_driver_api = {
 
 static int sht3xd_init(const struct device *dev)
 {
-	struct sht3xd_data *data = dev->data;
 	const struct sht3xd_config *cfg = dev->config;
-	const struct device *i2c = device_get_binding(cfg->bus_name);
 
-	if (i2c == NULL) {
-		LOG_DBG("Failed to get pointer to %s device!",
-			cfg->bus_name);
+	if (!device_is_ready(cfg->bus.bus)) {
+		LOG_ERR("I2C bus %s is not ready!", cfg->bus.bus->name);
 		return -EINVAL;
 	}
-	data->bus = i2c;
-
-	if (!cfg->base_address) {
-		LOG_DBG("No I2C address");
-		return -EINVAL;
-	}
-	data->dev = dev;
 
 	/* clear status register */
 	if (sht3xd_write_command(dev, SHT3XD_CMD_CLEAR_STATUS) < 0) {
@@ -204,6 +193,9 @@ static int sht3xd_init(const struct device *dev)
 	k_busy_wait(measure_wait[SHT3XD_REPEATABILITY_IDX]);
 #endif
 #ifdef CONFIG_SHT3XD_TRIGGER
+	struct sht3xd_data *data = dev->data;
+
+	data->dev = dev;
 	if (sht3xd_init_interrupt(dev) < 0) {
 		LOG_DBG("Failed to initialize interrupt");
 		return -EIO;
@@ -215,11 +207,10 @@ static int sht3xd_init(const struct device *dev)
 
 struct sht3xd_data sht3xd0_driver;
 static const struct sht3xd_config sht3xd0_cfg = {
-	.bus_name = DT_INST_BUS_LABEL(0),
+	.bus = I2C_DT_SPEC_INST_GET(0),
 #ifdef CONFIG_SHT3XD_TRIGGER
 	.alert_gpio_name = DT_INST_GPIO_LABEL(0, alert_gpios),
 #endif
-	.base_address = DT_INST_REG_ADDR(0),
 #ifdef CONFIG_SHT3XD_TRIGGER
 	.alert_pin = DT_INST_GPIO_PIN(0, alert_gpios),
 	.alert_flags = DT_INST_GPIO_FLAGS(0, alert_gpios),
@@ -227,6 +218,6 @@ static const struct sht3xd_config sht3xd0_cfg = {
 };
 
 DEVICE_DT_INST_DEFINE(0, sht3xd_init, NULL,
-		    &sht3xd0_driver, &sht3xd0_cfg,
-		    POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
-		    &sht3xd_driver_api);
+		      &sht3xd0_driver, &sht3xd0_cfg,
+		      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
+		      &sht3xd_driver_api);

--- a/drivers/sensor/sht3xd/sht3xd.h
+++ b/drivers/sensor/sht3xd/sht3xd.h
@@ -10,6 +10,7 @@
 #include <device.h>
 #include <kernel.h>
 #include <drivers/gpio.h>
+#include <drivers/i2c.h>
 
 #define SHT3XD_CMD_FETCH                0xE000
 #define SHT3XD_CMD_ART                  0x2B32
@@ -44,12 +45,12 @@
 #define SHT3XD_CLEAR_STATUS_WAIT_USEC   1000
 
 struct sht3xd_config {
-	char *bus_name;
+	struct i2c_dt_spec bus;
+
 #ifdef CONFIG_SHT3XD_TRIGGER
 	char *alert_gpio_name;
 #endif /* CONFIG_SHT3XD_TRIGGER */
 
-	uint8_t base_address;
 #ifdef CONFIG_SHT3XD_TRIGGER
 	uint8_t alert_pin;
 	uint8_t alert_flags;
@@ -57,13 +58,11 @@ struct sht3xd_config {
 };
 
 struct sht3xd_data {
-	const struct device *dev;
-	const struct device *bus;
-
 	uint16_t t_sample;
 	uint16_t rh_sample;
 
 #ifdef CONFIG_SHT3XD_TRIGGER
+	const struct device *dev;
 	const struct device *alert_gpio;
 	struct gpio_callback alert_cb;
 
@@ -85,20 +84,6 @@ struct sht3xd_data {
 
 #endif /* CONFIG_SHT3XD_TRIGGER */
 };
-
-static inline uint8_t sht3xd_i2c_address(const struct device *dev)
-{
-	const struct sht3xd_config *dcp = dev->config;
-
-	return dcp->base_address;
-}
-
-static inline const struct device *sht3xd_i2c_device(const struct device *dev)
-{
-	const struct sht3xd_data *ddp = dev->data;
-
-	return ddp->bus;
-}
 
 #ifdef CONFIG_SHT3XD_TRIGGER
 int sht3xd_write_command(const struct device *dev, uint16_t cmd);

--- a/include/drivers/i2c.h
+++ b/include/drivers/i2c.h
@@ -58,6 +58,45 @@ extern "C" {
 /** Controller to act as Master. */
 #define I2C_MODE_MASTER			BIT(4)
 
+/**
+ * @brief Complete I2C DT information
+ *
+ * @param bus is the I2C bus
+ * @param addr is the slave address
+ */
+struct i2c_dt_spec {
+	const struct device *bus;
+	uint16_t addr;
+};
+
+/**
+ * @brief Structure initializer for i2c_dt_spec from devicetree
+ *
+ * This helper macro expands to a static initializer for a <tt>struct
+ * i2c_dt_spec</tt> by reading the relevant bus and address data from
+ * the devicetree.
+ *
+ * @param node_id Devicetree node identifier for the I2C device whose
+ *                struct i2c_dt_spec to create an initializer for
+ */
+#define I2C_DT_SPEC_GET(node_id)		     \
+	{							     \
+		.bus = DEVICE_DT_GET(DT_BUS(node_id)),		     \
+		.addr = DT_REG_ADDR(node_id) \
+	}
+
+/**
+ * @brief Structure initializer for i2c_dt_spec from devicetree instance
+ *
+ * This is equivalent to
+ * <tt>I2C_DT_SPEC_GET(DT_DRV_INST(inst))</tt>.
+ *
+ * @param inst Devicetree instance number
+ */
+#define I2C_DT_SPEC_INST_GET(inst) \
+	I2C_DT_SPEC_GET(DT_DRV_INST(inst))
+
+
 /*
  * I2C_MSG_* are I2C Message flags.
  */

--- a/include/drivers/i2c.h
+++ b/include/drivers/i2c.h
@@ -397,6 +397,25 @@ static inline int z_impl_i2c_transfer(const struct device *dev,
 }
 
 /**
+ * @brief Perform data transfer to another I2C device in master mode.
+ *
+ * This is equivalent to:
+ *
+ *     i2c_transfer(spec->bus, msgs, num_msgs, spec->addr);
+ *
+ * @param spec I2C specification from devicetree.
+ * @param msgs Array of messages to transfer.
+ * @param num_msgs Number of messages to transfer.
+ *
+ * @return a value from i2c_transfer()
+ */
+static inline int i2c_transfer_dt(const struct i2c_dt_spec *spec,
+				  struct i2c_msg *msgs, uint8_t num_msgs)
+{
+	return i2c_transfer(spec->bus, msgs, num_msgs, spec->addr);
+}
+
+/**
  * @brief Recover the I2C bus
  *
  * Attempt to recover the I2C bus.
@@ -565,6 +584,25 @@ static inline int i2c_write(const struct device *dev, const uint8_t *buf,
 }
 
 /**
+ * @brief Write a set amount of data to an I2C device.
+ *
+ * This is equivalent to:
+ *
+ *     i2c_write(spec->bus, buf, num_bytes, spec->addr);
+ *
+ * @param spec I2C specification from devicetree.
+ * @param buf Memory pool from which the data is transferred.
+ * @param num_bytes Number of bytes to write.
+ *
+ * @return a value from i2c_write()
+ */
+static inline int i2c_write_dt(const struct i2c_dt_spec *spec,
+			       const uint8_t *buf, uint32_t num_bytes)
+{
+	return i2c_write(spec->bus, buf, num_bytes, spec->addr);
+}
+
+/**
  * @brief Read a set amount of data from an I2C device.
  *
  * This routine reads a set amount of data synchronously.
@@ -588,6 +626,25 @@ static inline int i2c_read(const struct device *dev, uint8_t *buf,
 	msg.flags = I2C_MSG_READ | I2C_MSG_STOP;
 
 	return i2c_transfer(dev, &msg, 1, addr);
+}
+
+/**
+ * @brief Read a set amount of data from an I2C device.
+ *
+ * This is equivalent to:
+ *
+ *     i2c_read(spec->bus, buf, num_bytes, spec->addr);
+ *
+ * @param spec I2C specification from devicetree.
+ * @param buf Memory pool that stores the retrieved data.
+ * @param num_bytes Number of bytes to read.
+ *
+ * @return a value from i2c_read()
+ */
+static inline int i2c_read_dt(const struct i2c_dt_spec *spec,
+			      uint8_t *buf, uint32_t num_bytes)
+{
+	return i2c_read(spec->bus, buf, num_bytes, spec->addr);
 }
 
 /**
@@ -626,6 +683,32 @@ static inline int i2c_write_read(const struct device *dev, uint16_t addr,
 }
 
 /**
+ * @brief Write then read data from an I2C device.
+ *
+ * This is equivalent to:
+ *
+ *     i2c_write_read(spec->bus, spec->addr,
+ *                    write_buf, num_write,
+ *                    read_buf, num_read);
+ *
+ * @param spec I2C specification from devicetree.
+ * @param write_buf Pointer to the data to be written
+ * @param num_write Number of bytes to write
+ * @param read_buf Pointer to storage for read data
+ * @param num_read Number of bytes to read
+ *
+ * @return a value from i2c_write_read()
+ */
+static inline int i2c_write_read_dt(const struct i2c_dt_spec *spec,
+				    const void *write_buf, size_t num_write,
+				    void *read_buf, size_t num_read)
+{
+	return i2c_write_read(spec->bus, spec->addr,
+			      write_buf, num_write,
+			      read_buf, num_read);
+}
+
+/**
  * @brief Read multiple bytes from an internal address of an I2C device.
  *
  * This routine reads multiple bytes from an internal address of an
@@ -652,6 +735,29 @@ static inline int i2c_burst_read(const struct device *dev,
 	return i2c_write_read(dev, dev_addr,
 			      &start_addr, sizeof(start_addr),
 			      buf, num_bytes);
+}
+
+/**
+ * @brief Read multiple bytes from an internal address of an I2C device.
+ *
+ * This is equivalent to:
+ *
+ *     i2c_burst_read(spec->bus, spec->addr, start_addr, buf, num_bytes);
+ *
+ * @param spec I2C specification from devicetree.
+ * @param start_addr Internal address from which the data is being read.
+ * @param buf Memory pool that stores the retrieved data.
+ * @param num_bytes Number of bytes to read.
+ *
+ * @return a value from i2c_burst_read()
+ */
+static inline int i2c_burst_read_dt(const struct i2c_dt_spec *spec,
+				    uint8_t start_addr,
+				    uint8_t *buf,
+				    uint32_t num_bytes)
+{
+	return i2c_burst_read(spec->bus, spec->addr,
+			      start_addr, buf, num_bytes);
 }
 
 /**
@@ -695,6 +801,29 @@ static inline int i2c_burst_write(const struct device *dev,
 }
 
 /**
+ * @brief Write multiple bytes to an internal address of an I2C device.
+ *
+ * This is equivalent to:
+ *
+ *     i2c_burst_write(spec->bus, spec->addr, start_addr, buf, num_bytes);
+ *
+ * @param spec I2C specification from devicetree.
+ * @param start_addr Internal address to which the data is being written.
+ * @param buf Memory pool from which the data is transferred.
+ * @param num_bytes Number of bytes being written.
+ *
+ * @return a value from i2c_burst_write()
+ */
+static inline int i2c_burst_write_dt(const struct i2c_dt_spec *spec,
+				     uint8_t start_addr,
+				     const uint8_t *buf,
+				     uint32_t num_bytes)
+{
+	return i2c_burst_write(spec->bus, spec->addr,
+			       start_addr, buf, num_bytes);
+}
+
+/**
  * @brief Read internal register of an I2C device.
  *
  * This routine reads the value of an 8-bit internal register of an I2C
@@ -716,6 +845,25 @@ static inline int i2c_reg_read_byte(const struct device *dev,
 	return i2c_write_read(dev, dev_addr,
 			      &reg_addr, sizeof(reg_addr),
 			      value, sizeof(*value));
+}
+
+/**
+ * @brief Read internal register of an I2C device.
+ *
+ * This is equivalent to:
+ *
+ *     i2c_reg_read_byte(spec->bus, spec->addr, reg_addr, value);
+ *
+ * @param spec I2C specification from devicetree.
+ * @param reg_addr Address of the internal register being read.
+ * @param value Memory pool that stores the retrieved register value.
+ *
+ * @return a value from i2c_reg_read_byte()
+ */
+static inline int i2c_reg_read_byte_dt(const struct i2c_dt_spec *spec,
+				       uint8_t reg_addr, uint8_t *value)
+{
+	return i2c_reg_read_byte(spec->bus, spec->addr, reg_addr, value);
 }
 
 /**
@@ -743,6 +891,25 @@ static inline int i2c_reg_write_byte(const struct device *dev,
 	uint8_t tx_buf[2] = {reg_addr, value};
 
 	return i2c_write(dev, tx_buf, 2, dev_addr);
+}
+
+/**
+ * @brief Write internal register of an I2C device.
+ *
+ * This is equivalent to:
+ *
+ *     i2c_reg_write_byte(spec->bus, spec->addr, reg_addr, value);
+ *
+ * @param spec I2C specification from devicetree.
+ * @param reg_addr Address of the internal register being written.
+ * @param value Value to be written to internal register.
+ *
+ * @return a value from i2c_reg_write_byte()
+ */
+static inline int i2c_reg_write_byte_dt(const struct i2c_dt_spec *spec,
+					uint8_t reg_addr, uint8_t value)
+{
+	return i2c_reg_write_byte(spec->bus, spec->addr, reg_addr, value);
 }
 
 /**
@@ -783,6 +950,28 @@ static inline int i2c_reg_update_byte(const struct device *dev,
 	}
 
 	return i2c_reg_write_byte(dev, dev_addr, reg_addr, new_value);
+}
+
+/**
+ * @brief Update internal register of an I2C device.
+ *
+ * This is equivalent to:
+ *
+ *     i2c_reg_update_byte(spec->bus, spec->addr, reg_addr, mask, value);
+ *
+ * @param spec I2C specification from devicetree.
+ * @param reg_addr Address of the internal register being updated.
+ * @param mask Bitmask for updating internal register.
+ * @param value Value for updating internal register.
+ *
+ * @return a value from i2c_reg_update_byte()
+ */
+static inline int i2c_reg_update_byte_dt(const struct i2c_dt_spec *spec,
+					 uint8_t reg_addr, uint8_t mask,
+					 uint8_t value)
+{
+	return i2c_reg_update_byte(spec->bus, spec->addr,
+				   reg_addr, mask, value);
 }
 
 /**


### PR DESCRIPTION
Introduces the struct i2c_dt_spec type, which contains the complete I2C bus information derived from devicetree. It serves the same purpose as `struct spi_dt_spec` in that it can be constructed automatically in DEVICE_DT_INST_DEFINE macros and provided as a single handle to I2C API calls.

It encapsulates less information than `struct spi_dt_spec`, but it still reduces boilerplate and chances for error in device drivers.
It also allows the following pattern to be used for drivers that support both SPI and I2C buses.
```
struct device_config {
    union {
        struct spi_dt_spec spi;
        struct i2c_dt_spec i2c;
    };
};
```