### PR TITLE
riscv: linker: add support for FLASH_LOAD_OFFSET

### DIFF
--- a/include/arch/riscv/common/linker.ld
+++ b/include/arch/riscv/common/linker.ld
@@ -33,7 +33,12 @@
 
 #ifdef CONFIG_XIP
 #if DT_NODE_HAS_COMPAT_STATUS(DT_CHOSEN(zephyr_flash), soc_nv_flash, okay)
+#ifdef CONFIG_FLASH_LOAD_OFFSET
+#define ROM_BASE (DT_REG_ADDR(DT_CHOSEN(zephyr_flash)) + \
+				CONFIG_FLASH_LOAD_OFFSET)
+#else /* !CONFIG_FLASH_LOAD_OFFSET */
 #define ROM_BASE DT_REG_ADDR(DT_CHOSEN(zephyr_flash))
+#endif /* CONFIG_FLASH_LOAD_OFFSET */
 #define ROM_SIZE DT_REG_SIZE(DT_CHOSEN(zephyr_flash))
 #elif DT_NODE_HAS_COMPAT_STATUS(DT_CHOSEN(zephyr_flash), jedec_spi_nor, okay)
 /* For jedec,spi-nor we expect the spi controller to memory map the flash


### PR DESCRIPTION
This allows board to re-configure ROM_BASE address while building
firmware image.

For example, a board need to build two firmware images. And the images
are put into one flash and required to work independent:

config FLASH_LOAD_OFFSET
    default 0 if FIRST_IMAGE
    default 0x80000 if SECOND_IMAGE

Signed-off-by: Dino Li <Dino.Li@ite.com.tw>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zephyrproject-rtos/zephyr/37364)
<!-- Reviewable:end -->
