### PR TITLE
include: driver: sensor: add tank level channel in units of percent

### DIFF
--- a/drivers/sensor/sensor_shell.c
+++ b/drivers/sensor/sensor_shell.c
@@ -55,6 +55,7 @@ const char *sensor_channel_name[SENSOR_CHAN_ALL] = {
 	[SENSOR_CHAN_POS_DY] =		"pos_dy",
 	[SENSOR_CHAN_POS_DZ] =		"pos_dz",
 	[SENSOR_CHAN_RPM] = 		"rpm",
+	[SENSOR_CHAN_TANK_LEVEL] =	"tank_level",
 	[SENSOR_CHAN_GAUGE_VOLTAGE] =	"gauge_voltage",
 	[SENSOR_CHAN_GAUGE_AVG_CURRENT] = "gauge_avg_current",
 	[SENSOR_CHAN_GAUGE_STDBY_CURRENT] = "gauge_stdby_current",

--- a/include/drivers/sensor.h
+++ b/include/drivers/sensor.h
@@ -140,6 +140,9 @@ enum sensor_channel {
 	/** Revolutions per minute, in RPM. */
 	SENSOR_CHAN_RPM,
 
+	/** Tank level, in percent. */
+	SENSOR_CHAN_TANK_LEVEL,
+
 	/** Voltage, in volts **/
 	SENSOR_CHAN_GAUGE_VOLTAGE,
 	/** Average current, in amps **/


### PR DESCRIPTION
Provides an enum for tank level sensor drivers.

Signed-off-by: Nick Ward <nick.ward@setec.com.au>