### PR TITLE
samples: i2s: echo: fix building on litex_vexriscv

### DIFF
--- a/samples/drivers/i2s/echo/src/main.c
+++ b/samples/drivers/i2s/echo/src/main.c
@@ -10,7 +10,6 @@
 #include <drivers/i2s.h>
 #include <drivers/gpio.h>
 #include <string.h>
-#include <drivers/clock_control/nrf_clock_control.h>
 
 
 #if DT_NODE_EXISTS(DT_NODELABEL(i2s_rxtx))


### PR DESCRIPTION
There is no need to include nrf_clock_control.h so remove it as
this fixes a build issue when trying to compile this sample on
litex_vexriscv.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>