### PR TITLE
drivers: modem: Fix compiler warning

### DIFF
--- a/drivers/modem/modem_cmd_handler.c
+++ b/drivers/modem/modem_cmd_handler.c
@@ -474,7 +474,7 @@ int modem_cmd_send_ext(struct modem_iface *iface,
 		       struct k_sem *sem, k_timeout_t timeout, int flags)
 {
 	struct modem_cmd_handler_data *data;
-	int ret;
+	int ret = 0;
 
 	if (!iface || !handler || !handler->cmd_handler_data || !buf) {
 		return -EINVAL;


### PR DESCRIPTION
When building tests/drivers/build_all/modem on native_posix_64 we get:

	modem_cmd_handler.c:545:9: error: ret may be used
	uninitialized in this function
	[-Werror=maybe-uninitialized]

Fix by adding simple initialization of ret = 0 at start of function.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>