### PR TITLE
Bluetooth: Host: Reassemble extended advertising reports

### DIFF
--- a/drivers/bluetooth/hci/h4.c
+++ b/drivers/bluetooth/hci/h4.c
@@ -154,8 +154,7 @@ static inline void get_evt_hdr(void)
 
 	if (!rx.remaining) {
 		if (rx.evt.evt == BT_HCI_EVT_LE_META_EVENT &&
-		    (rx.hdr[sizeof(*hdr)] == BT_HCI_EVT_LE_ADVERTISING_REPORT ||
-		     rx.hdr[sizeof(*hdr)] == BT_HCI_EVT_LE_EXT_ADVERTISING_REPORT)) {
+		    (rx.hdr[sizeof(*hdr)] == BT_HCI_EVT_LE_ADVERTISING_REPORT)) {
 			BT_DBG("Marking adv report as discardable");
 			rx.discardable = true;
 		}

--- a/drivers/bluetooth/hci/hci_esp32.c
+++ b/drivers/bluetooth/hci/hci_esp32.c
@@ -40,8 +40,6 @@ static bool is_hci_event_discardable(const uint8_t *evt_data)
 		switch (subevt_type) {
 		case BT_HCI_EVT_LE_ADVERTISING_REPORT:
 			return true;
-		case BT_HCI_EVT_LE_EXT_ADVERTISING_REPORT:
-			return true;
 		default:
 			return false;
 		}

--- a/drivers/bluetooth/hci/ipm_stm32wb.c
+++ b/drivers/bluetooth/hci/ipm_stm32wb.c
@@ -179,8 +179,7 @@ static void bt_ipm_rx_thread(void)
 			default:
 				mev = (void *)&hcievt->evtserial.evt.payload;
 				if (hcievt->evtserial.evt.evtcode == BT_HCI_EVT_LE_META_EVENT &&
-				    (mev->subevent == BT_HCI_EVT_LE_ADVERTISING_REPORT ||
-				     mev->subevent == BT_HCI_EVT_LE_EXT_ADVERTISING_REPORT)) {
+				    (mev->subevent == BT_HCI_EVT_LE_ADVERTISING_REPORT)) {
 					discardable = true;
 					timeout = K_NO_WAIT;
 				}

--- a/drivers/bluetooth/hci/rpmsg.c
+++ b/drivers/bluetooth/hci/rpmsg.c
@@ -41,8 +41,6 @@ static bool is_hci_event_discardable(const uint8_t *evt_data)
 		switch (subevt_type) {
 		case BT_HCI_EVT_LE_ADVERTISING_REPORT:
 			return true;
-		case BT_HCI_EVT_LE_EXT_ADVERTISING_REPORT:
-			return true;
 		default:
 			return false;
 		}

--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -370,8 +370,7 @@ static void bt_spi_rx_thread(void)
 					continue;
 				default:
 					if (rxmsg[1] == BT_HCI_EVT_LE_META_EVENT &&
-					    (rxmsg[3] == BT_HCI_EVT_LE_ADVERTISING_REPORT ||
-					     rxmsg[3] == BT_HCI_EVT_LE_EXT_ADVERTISING_REPORT)) {
+					    (rxmsg[3] == BT_HCI_EVT_LE_ADVERTISING_REPORT)) {
 						discardable = true;
 						timeout = K_NO_WAIT;
 					}

--- a/drivers/bluetooth/hci/userchan.c
+++ b/drivers/bluetooth/hci/userchan.c
@@ -64,8 +64,7 @@ static struct net_buf *get_rx(const uint8_t *buf)
 	switch (buf[0]) {
 	case H4_EVT:
 		if (buf[1] == BT_HCI_EVT_LE_META_EVENT &&
-		    (buf[3] == BT_HCI_EVT_LE_ADVERTISING_REPORT ||
-		     buf[3] == BT_HCI_EVT_LE_EXT_ADVERTISING_REPORT)) {
+		    (buf[3] == BT_HCI_EVT_LE_ADVERTISING_REPORT)) {
 			discardable = true;
 			timeout = K_NO_WAIT;
 		}

--- a/include/bluetooth/gap.h
+++ b/include/bluetooth/gap.h
@@ -118,6 +118,13 @@ enum {
 	BT_GAP_ADV_PROP_SCAN_RESPONSE         = BIT(3),
 	/** Extended advertising. */
 	BT_GAP_ADV_PROP_EXT_ADV               = BIT(4),
+	/** The reported data is a truncated.
+	 *
+	 * Either the controller or the host
+	 * was not able to receive or store
+	 * the complete advertisement.
+	 */
+	BT_GAP_ADV_PROP_REPORT_TRUNCATED      = BIT(5),
 };
 
 /** Maximum advertising data length. */

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -492,6 +492,18 @@ config BT_BACKGROUND_SCAN_WINDOW
 	int "Scan window used for background scanning in 0.625 ms units"
 	default 18
 	range 4 16384
+
+if BT_EXT_ADV
+config BT_EXT_SCAN_BUF_SIZE
+	int "Maximum advertisement report size"
+	range 1 1650
+	default 255
+	help
+	  Maximum size of an advertisement report. If the advertisement
+	  provided by the controller is larger than this buffer size,
+	  the remaining data will be discarded.
+endif # BT_EXT_ADV
+
 endif # BT_OBSERVER
 
 config BT_SCAN_WITH_IDENTITY


### PR DESCRIPTION
The host reassmbles incomplete extended advertising reports
before presenting them to the application. Hereby we avoid
giving unparsable, partial reports to the application.

Important: The controller shall not discard these events in
HCI layer. If events with data status set to "No more to come"
are dropped, unrelated events will be concatinated.

The incoming HCI LE Extended Advertising Reports are stored
in a temporary buffer of size CONFIG_BT_EXT_SCAN_BUF_SIZE.

If either the controller or host is unable to receive the complete
advertisement, the property BT_GAP_ADV_PROP_REPORT_TRUNCATED
will be set.

If the host is truncating the data, and the controller indicates
it will provide more, the host will discard those events.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/37368

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>