### PR TITLE
scripts: Track memory footprint for networking samples on frdm_k64f

### DIFF
--- a/scripts/footprint/plan.txt
+++ b/scripts/footprint/plan.txt
@@ -8,3 +8,5 @@ footprints,default,altera_max10,tests/benchmarks/footprints,
 footprints,default,hifive1_revb,tests/benchmarks/footprints,
 footprints,default,ehl_crb,tests/benchmarks/footprints,
 footprints,userspace,ehl_crb,tests/benchmarks/footprints,-DCONF_FILE=prj_userspace.conf
+echo_client,default,frdm_k64f,samples/net/sockets/echo_client,
+echo_server,default,frdm_k64f,samples/net/sockets/echo_server,


### PR DESCRIPTION
Extends memory footprint tracking to include echo_client and echo_server
networking samples on the frdm_k64f board.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>