### PR TITLE
soc: arm: nxp_imx: rt: Configure settings for TRNG IP

### DIFF
--- a/drivers/entropy/Kconfig.mcux
+++ b/drivers/entropy/Kconfig.mcux
@@ -26,3 +26,19 @@ config ENTROPY_MCUX_RNG
 	help
 	  This option enables the true random number generator (TRNG)
 	  driver based on the MCUX RNG driver on LPC Family.
+
+#
+# Don't use use the MCUX TRNG as a random source as it is not designed
+# to supply a continuous random stream. Instead, it is used to provide
+# a seed to RNG generator.
+#
+# Use the software implemented xoroshiro RNG.
+# Use CSPRNG for cryptographically secure RNG source.
+#
+choice RNG_GENERATOR_CHOICE
+	default XOSHIRO_RANDOM_GENERATOR if ENTROPY_MCUX_TRNG
+endchoice
+
+choice CSPRNG_GENERATOR_CHOICE
+	default CTR_DRBG_CSPRNG_GENERATOR if ENTROPY_MCUX_TRNG
+endchoice

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
@@ -152,6 +152,24 @@ choice SEGGER_SYSVIEW_SECTION
 	depends on SEGGER_SYSTEMVIEW
 endchoice
 
+#
+# MBEDTLS is larger but much faster than TinyCrypt so choose wisely
+#
+config MBEDTLS
+#config TINYCRYPT
+	default y if CSPRING_ENABLED
+	depends on ENTROPY_GENERATOR
+
+if MBEDTLS
+#
+# MBEDTLS CTR_DRBG code path needs extra stack space for initialization than
+# what the ztest_thread_stack defaults to.
+#
+config TEST_EXTRA_STACKSIZE
+	int
+	default 1024
+endif # MBEDTLS
+
 source "soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt*"
 
 endif # SOC_SERIES_IMX_RT

--- a/soc/arm/nxp_imx/rt6xx/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt6xx/Kconfig.defconfig.series
@@ -27,6 +27,24 @@ config ENTROPY_MCUX_TRNG
 	default y if HAS_MCUX_TRNG
 	depends on ENTROPY_GENERATOR
 
+#
+# MBEDTLS is larger but much faster than TinyCrypt so choose wisely
+#
+config MBEDTLS
+#config TINYCRYPT
+	default y if CSPRING_ENABLED
+	depends on ENTROPY_GENERATOR
+
+if MBEDTLS
+#
+# MBEDTLS CTR_DRBG code path needs extra stack space for initialization than
+# what the ztest_thread_stack defaults to.
+#
+config TEST_EXTRA_STACKSIZE
+	int
+	default 1024
+endif # MBEDTLS
+
 source "soc/arm/nxp_imx/rt6xx/Kconfig.defconfig.mimxrt6*"
 
 endif # SOC_SERIES_MIMXRT6XX


### PR DESCRIPTION
RT platforms that support TRNG IP (rt10xx and rt6xx) need to set
RNG and CSRNG to Xoroshiro and CTR_DRBG respectively instead of
using TRNG as random source.

Fixes: #37307

Signed-off-by: David Leach <david.leach@nxp.com>