### PR TITLE
riscv: linker: provide symbol of _flash_used

### DIFF
--- a/include/arch/riscv/common/linker.ld
+++ b/include/arch/riscv/common/linker.ld
@@ -264,6 +264,13 @@ SECTIONS
 
      GROUP_END(RAMABLE_REGION)
 
+#ifdef CONFIG_XIP
+	/* Firmware binary size is text + rodata + data in rom. */
+	_flash_used = _image_rom_size + (__data_ram_end - __data_ram_start);
+#else
+	_flash_used = _image_rom_size;
+#endif
+
 #include <linker/debug-sections.ld>
 
     /DISCARD/ : { *(.note.GNU-stack) }


### PR DESCRIPTION
The symbol provides the image size.

Signed-off-by: Dino Li <Dino.Li@ite.com.tw>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zephyrproject-rtos/zephyr/37388)
<!-- Reviewable:end -->
