### PR TITLE
drivers: adc: stm32h7 has a different oversampling config API

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -441,42 +441,74 @@ static int start_read(const struct device *dev,
 		break;
 	case 1:
 		LL_ADC_SetOverSamplingScope(adc, LL_ADC_OVS_GRP_REGULAR_CONTINUED);
+#if defined(CONFIG_SOC_SERIES_STM32H7X)
+		LL_ADC_ConfigOverSamplingRatioShift(adc, sequence->oversampling,
+#else /* CONFIG_SOC_SERIES_STM32H7X */
 		LL_ADC_ConfigOverSamplingRatioShift(adc, LL_ADC_OVS_RATIO_2,
+#endif /* CONFIG_SOC_SERIES_STM32H7X */
 						    LL_ADC_OVS_SHIFT_RIGHT_1);
 		break;
 	case 2:
 		LL_ADC_SetOverSamplingScope(adc, LL_ADC_OVS_GRP_REGULAR_CONTINUED);
+#if defined(CONFIG_SOC_SERIES_STM32H7X)
+		LL_ADC_ConfigOverSamplingRatioShift(adc, sequence->oversampling,
+#else /* CONFIG_SOC_SERIES_STM32H7X */
 		LL_ADC_ConfigOverSamplingRatioShift(adc, LL_ADC_OVS_RATIO_4,
+#endif /* CONFIG_SOC_SERIES_STM32H7X */
 						    LL_ADC_OVS_SHIFT_RIGHT_2);
 		break;
 	case 3:
 		LL_ADC_SetOverSamplingScope(adc, LL_ADC_OVS_GRP_REGULAR_CONTINUED);
+#if defined(CONFIG_SOC_SERIES_STM32H7X)
+		LL_ADC_ConfigOverSamplingRatioShift(adc, sequence->oversampling,
+#else /* CONFIG_SOC_SERIES_STM32H7X */
 		LL_ADC_ConfigOverSamplingRatioShift(adc, LL_ADC_OVS_RATIO_8,
+#endif /* CONFIG_SOC_SERIES_STM32H7X */
 						    LL_ADC_OVS_SHIFT_RIGHT_3);
 		break;
 	case 4:
 		LL_ADC_SetOverSamplingScope(adc, LL_ADC_OVS_GRP_REGULAR_CONTINUED);
+#if defined(CONFIG_SOC_SERIES_STM32H7X)
+		LL_ADC_ConfigOverSamplingRatioShift(adc, sequence->oversampling,
+#else /* CONFIG_SOC_SERIES_STM32H7X */
 		LL_ADC_ConfigOverSamplingRatioShift(adc, LL_ADC_OVS_RATIO_16,
+#endif /* CONFIG_SOC_SERIES_STM32H7X */
 						    LL_ADC_OVS_SHIFT_RIGHT_4);
 		break;
 	case 5:
 		LL_ADC_SetOverSamplingScope(adc, LL_ADC_OVS_GRP_REGULAR_CONTINUED);
+#if defined(CONFIG_SOC_SERIES_STM32H7X)
+		LL_ADC_ConfigOverSamplingRatioShift(adc, sequence->oversampling,
+#else /* CONFIG_SOC_SERIES_STM32H7X */
 		LL_ADC_ConfigOverSamplingRatioShift(adc, LL_ADC_OVS_RATIO_32,
+#endif /* CONFIG_SOC_SERIES_STM32H7X */
 						    LL_ADC_OVS_SHIFT_RIGHT_5);
 		break;
 	case 6:
 		LL_ADC_SetOverSamplingScope(adc, LL_ADC_OVS_GRP_REGULAR_CONTINUED);
+#if defined(CONFIG_SOC_SERIES_STM32H7X)
+		LL_ADC_ConfigOverSamplingRatioShift(adc, sequence->oversampling,
+#else /* CONFIG_SOC_SERIES_STM32H7X */
 		LL_ADC_ConfigOverSamplingRatioShift(adc, LL_ADC_OVS_RATIO_64,
+#endif /* CONFIG_SOC_SERIES_STM32H7X */
 						    LL_ADC_OVS_SHIFT_RIGHT_6);
 		break;
 	case 7:
 		LL_ADC_SetOverSamplingScope(adc, LL_ADC_OVS_GRP_REGULAR_CONTINUED);
+#if defined(CONFIG_SOC_SERIES_STM32H7X)
+		LL_ADC_ConfigOverSamplingRatioShift(adc, sequence->oversampling,
+#else
 		LL_ADC_ConfigOverSamplingRatioShift(adc, LL_ADC_OVS_RATIO_128,
+#endif /* CONFIG_SOC_SERIES_STM32H7X */
 						    LL_ADC_OVS_SHIFT_RIGHT_7);
 		break;
 	case 8:
 		LL_ADC_SetOverSamplingScope(adc, LL_ADC_OVS_GRP_REGULAR_CONTINUED);
+#if defined(CONFIG_SOC_SERIES_STM32H7X)
+		LL_ADC_ConfigOverSamplingRatioShift(adc, sequence->oversampling,
+#else
 		LL_ADC_ConfigOverSamplingRatioShift(adc, LL_ADC_OVS_RATIO_256,
+#endif
 						    LL_ADC_OVS_SHIFT_RIGHT_8);
 		break;
 	default:


### PR DESCRIPTION
The LL_ADC_ConfigOverSamplingRatioShift function for
the stm32H7xx soc serie differs from other for the 'ratio':
"This parameter can be in the range from 1 to 1024"
Note that in the stm32h7xx_ll_adc.c the LL_ADC_OVS_RATIO_xxx value is
defined for ADC of type ADC_VER_V5_V90.

Fixes #37375, #37379  

Signed-off-by: Francois Ramu <francois.ramu@st.com>