### PR TITLE
Fix missing ISO Disconnect callback

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -842,10 +842,6 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 
 		break;
 	case BT_CONN_DISCONNECTED:
-		if (conn->type == BT_CONN_TYPE_ISO) {
-			break;
-		}
-
 #if defined(CONFIG_BT_CONN)
 		if (conn->type == BT_CONN_TYPE_SCO) {
 			/* TODO: Notify sco disconnected */
@@ -922,7 +918,6 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 			break;
 		}
 		break;
-#endif /* CONFIG_BT_CONN */
 	case BT_CONN_CONNECT_AUTO:
 		break;
 	case BT_CONN_CONNECT_ADV:
@@ -948,6 +943,7 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 		break;
 	case BT_CONN_DISCONNECT:
 		break;
+#endif /* CONFIG_BT_CONN */
 	case BT_CONN_DISCONNECT_COMPLETE:
 		process_unack_tx(conn);
 		break;

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -1135,7 +1135,7 @@ int bt_iso_accept(struct bt_conn *conn)
 
 	err = iso_server->accept(conn, &chan);
 	if (err < 0) {
-		BT_ERR("err %d", err);
+		BT_ERR("Server failed to accept: %d", err);
 		return err;
 	}
 

--- a/subsys/bluetooth/shell/iso.c
+++ b/subsys/bluetooth/shell/iso.c
@@ -13,7 +13,6 @@
 #include <ctype.h>
 #include <zephyr.h>
 #include <shell/shell.h>
-#include <sys/printk.h>
 #include <sys/byteorder.h>
 #include <sys/util.h>
 
@@ -29,18 +28,19 @@
 static void iso_recv(struct bt_iso_chan *chan, const struct bt_iso_recv_info *info,
 		struct net_buf *buf)
 {
-	printk("Incoming data channel %p len %u, seq: %d, ts: %d\n", chan, buf->len,
-			info->sn, info->ts);
+	shell_print(ctx_shell, "Incoming data channel %p len %u, seq: %d, ts: %d",
+		    chan, buf->len, info->sn, info->ts);
 }
 
 static void iso_connected(struct bt_iso_chan *chan)
 {
-	printk("ISO Channel %p connected\n", chan);
+	shell_print(ctx_shell, "ISO Channel %p connected", chan);
 }
 
 static void iso_disconnected(struct bt_iso_chan *chan, uint8_t reason)
 {
-	printk("ISO Channel %p disconnected with reason 0x%02x\n", chan, reason);
+	shell_print(ctx_shell, "ISO Channel %p disconnected with reason 0x%02x",
+		    chan, reason);
 }
 
 static struct bt_iso_chan_ops iso_ops = {
@@ -77,10 +77,10 @@ NET_BUF_POOL_FIXED_DEFINE(tx_pool, 1, DATA_MTU, NULL);
 
 static int iso_accept(struct bt_conn *conn, struct bt_iso_chan **chan)
 {
-	printk("Incoming conn %p\n", conn);
+	shell_print(ctx_shell, "Incoming conn %p", conn);
 
 	if (iso_chan.conn) {
-		printk("No channels available\n");
+		shell_print(ctx_shell, "No channels available");
 		return -ENOMEM;
 	}
 


### PR DESCRIPTION
Fixes an issue where the ISO disconnect callback was not called. This also changes a few other string messages to better debug such issues in the future. 

Fixes #37406