### PR TITLE
scripts: edtlib: fix werror for unknown vendor

### DIFF
--- a/boards/arm/hexiwear_k64/hexiwear_k64.dts
+++ b/boards/arm/hexiwear_k64/hexiwear_k64.dts
@@ -89,7 +89,7 @@
 
 	max30101@57 {
 		status = "disabled";
-		compatible = "max,max30101";
+		compatible = "maxim,max30101";
 		reg = <0x57>;
 		label = "MAX30101";
 	};

--- a/boards/arm/particle_boron/particle_boron.dts
+++ b/boards/arm/particle_boron/particle_boron.dts
@@ -43,7 +43,7 @@
 	hw-flow-control;
 
 	sara_r4 {
-		compatible = "ublox,sara-r4";
+		compatible = "u-blox,sara-r4";
 		label = "ublox-sara-r4";
 		status = "okay";
 

--- a/boards/arm/pinetime_devkit0/pinetime_devkit0.dts
+++ b/boards/arm/pinetime_devkit0/pinetime_devkit0.dts
@@ -100,14 +100,14 @@
 
 	/* TianYiHeXin HRS3300 PPG Hear Rate Sensor (800KHz) */
 	hrs3300: hrs3300@44 {
-		compatible = "tian-yi-he-xin,hrs3300";
+		compatible = "tian-yi-he-xin-hrs3300";
 		reg = <0x44>;
 		label = "HRS3300";
 	};
 
 	/* Hynitron CST816S Capacitive Touch Controller (400KHz) */
 	cst816s: cst816s@15 {
-		compatible = "hynitron,cst816s";
+		compatible = "hynitron-cst816s";
 		reg = <0x15>;
 		label = "CST816S";
 		irq-gpios = <&gpio0 28 GPIO_ACTIVE_LOW>;

--- a/boards/arm/pinetime_devkit0/pinetime_devkit0.dts
+++ b/boards/arm/pinetime_devkit0/pinetime_devkit0.dts
@@ -126,7 +126,7 @@
 
 	/* Macronix MX25L CMOS Flash Memory */
 	mx25l: mx25l@0 {
-		compatible = "macronix,cmos-mx25l";
+		compatible = "mxicy,cmos-mx25l";
 		reg = <0>;
 		spi-max-frequency = <8000000>; /* 8MHz */
 		label = "CMOS MX25L";

--- a/boards/shields/sparkfun_sara_r4/sparkfun_sara_r4.overlay
+++ b/boards/shields/sparkfun_sara_r4/sparkfun_sara_r4.overlay
@@ -9,7 +9,7 @@
 	status = "okay";
 
 	sara_r4 {
-		compatible = "ublox,sara-r4";
+		compatible = "u-blox,sara-r4";
 		label = "ublox-sara-r4";
 		mdm-power-gpios = <&arduino_header 11 0>; /* D5 */
 		mdm-reset-gpios = <&arduino_header 12 0>; /* D6 */

--- a/boards/xtensa/qemu_xtensa/qemu_xtensa.dts
+++ b/boards/xtensa/qemu_xtensa/qemu_xtensa.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "qemu_xtensa";
-	compatible = "xtensa,sample-controller";
+	compatible = "cdns,xtensa-sample-controller";
 
 	chosen {
 		zephyr,sram = &sram0;

--- a/boards/xtensa/xt-sim/xt-sim.dts
+++ b/boards/xtensa/xt-sim/xt-sim.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "xt-sim";
-	compatible = "xtensa,sample-controller";
+	compatible = "cdns,xtensa-sample-controller";
 
 	chosen {
 		zephyr,sram = &sram0;

--- a/doc/releases/release-notes-2.7.rst
+++ b/doc/releases/release-notes-2.7.rst
@@ -281,6 +281,30 @@ Build and Infrastructure
 
 * Devicetree
 
+  * Various compatibles had incorrect vendor prefixes in their :ref:`compatible
+    <dt-important-props>` properties; the following changes were made to fix
+    these.
+
+    * ``nios,i2c`` is now ``altr,nios2-i2c``
+    * ``colorway,lpd8803`` is now ``greeled,lpd8803``
+    * ``colorway,lpd8806`` is now ``greeled,lpd8806``
+    * ``grove,light`` is now ``seeed,grove-light``
+    * ``grove,temperature`` is now ``seeed,grove-temperature``
+    * ``max,max30101`` is now ``maxim,max30101``
+    * ``ublox,sara-r4`` is now ``u-blox,sara-r4``
+    * ``xtensa,core-intc`` is now ``cdns,xtensa-core-intc``
+
+    Out of tree users of these compatibles will need to update their
+    devicetrees.
+
+    You can support multiple versions of Zephyr with one devicetree by
+    including both the old and new values in your nodes' compatible properties,
+    like this example for the LPD8803::
+
+        my-led-strip@0 {
+                compatible = "colorway,lpd8803", "greeled,lpd8803";
+                ...
+        };
 
 * West (extensions)
 

--- a/drivers/i2c/i2c_nios2.c
+++ b/drivers/i2c/i2c_nios2.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT nios2_i2c
+#define DT_DRV_COMPAT altr_nios2_i2c
 
 #include <errno.h>
 #include <drivers/i2c.h>

--- a/drivers/led_strip/lpd880x.c
+++ b/drivers/led_strip/lpd880x.c
@@ -9,10 +9,10 @@
 #include <errno.h>
 #include <string.h>
 
-#if DT_NODE_HAS_STATUS(DT_INST(0, colorway_lpd8806), okay)
-#define DT_DRV_COMPAT colorway_lpd8806
+#if DT_NODE_HAS_STATUS(DT_INST(0, greeled_lpd8806), okay)
+#define DT_DRV_COMPAT greeled_lpd8806
 #else
-#define DT_DRV_COMPAT colorway_lpd8803
+#define DT_DRV_COMPAT greeled_lpd8803
 #endif
 
 #define LOG_LEVEL CONFIG_LED_STRIP_LOG_LEVEL

--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT ublox_sara_r4
+#define DT_DRV_COMPAT u_blox_sara_r4
 
 #include <logging/log.h>
 LOG_MODULE_REGISTER(modem_ublox_sara_r4, CONFIG_MODEM_LOG_LEVEL);

--- a/drivers/sensor/grove/light_sensor.c
+++ b/drivers/sensor/grove/light_sensor.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT grove_light
+#define DT_DRV_COMPAT seeed_grove_light
 
 #include <drivers/adc.h>
 #include <device.h>

--- a/drivers/sensor/grove/temperature_sensor.c
+++ b/drivers/sensor/grove/temperature_sensor.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT grove_temperature
+#define DT_DRV_COMPAT seeed_grove_temperature
 
 #include <drivers/adc.h>
 #include <device.h>

--- a/drivers/sensor/max30101/max30101.c
+++ b/drivers/sensor/max30101/max30101.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT max_max30101
+#define DT_DRV_COMPAT maxim_max30101
 
 #include <logging/log.h>
 

--- a/dts/bindings/cpu/cadence,tensilica-xtensa-lx4.yaml
+++ b/dts/bindings/cpu/cadence,tensilica-xtensa-lx4.yaml
@@ -3,6 +3,6 @@
 
 description: Cadence Tensilica Xtensa LX4 CPU
 
-compatible: "cadence,tensilica-xtensa-lx4"
+compatible: "cdns,tensilica-xtensa-lx4"
 
 include: cpu.yaml

--- a/dts/bindings/cpu/cadence,tensilica-xtensa-lx6.yaml
+++ b/dts/bindings/cpu/cadence,tensilica-xtensa-lx6.yaml
@@ -3,7 +3,7 @@
 
 description: Cadence Tensilica Xtensa LX6 CPU
 
-compatible: "cadence,tensilica-xtensa-lx6"
+compatible: "cdns,tensilica-xtensa-lx6"
 
 include: cpu.yaml
 

--- a/dts/bindings/i2c/altr,nios2-i2c.yaml
+++ b/dts/bindings/i2c/altr,nios2-i2c.yaml
@@ -1,9 +1,9 @@
 # Copyright (c) 2018 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-description: NIOS2 I2C
+description: Altera NIOS2 I2C
 
-compatible: "nios2,i2c"
+compatible: "altr,nios2-i2c"
 
 include: i2c-controller.yaml
 

--- a/dts/bindings/interrupt-controller/cdns,xtensa-core-intc.yaml
+++ b/dts/bindings/interrupt-controller/cdns,xtensa-core-intc.yaml
@@ -1,6 +1,6 @@
 description: Xtensa Core interrupt controller
 
-compatible: "xtensa,core-intc"
+compatible: "cdns,xtensa-core-intc"
 
 include: [interrupt-controller.yaml, base.yaml]
 

--- a/dts/bindings/interrupt-controller/vexriscv-intc0.yaml
+++ b/dts/bindings/interrupt-controller/vexriscv-intc0.yaml
@@ -3,7 +3,7 @@
 
 description: LiteX VexRiscV interrupt controller
 
-compatible: "vexriscv,intc0"
+compatible: "vexriscv-intc0"
 
 include: [interrupt-controller.yaml, base.yaml]
 

--- a/dts/bindings/led_strip/greeled,lpd8803.yaml
+++ b/dts/bindings/led_strip/greeled,lpd8803.yaml
@@ -1,8 +1,8 @@
 # Copyright (c) 2019, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-description: Colorway LPD8806 SPI LED strip
+description: GreeLed LPD8803 SPI LED strip
 
-compatible: "colorway,lpd8806"
+compatible: "greeled,lpd8803"
 
 include: spi-device.yaml

--- a/dts/bindings/led_strip/greeled,lpd8806.yaml
+++ b/dts/bindings/led_strip/greeled,lpd8806.yaml
@@ -1,8 +1,8 @@
 # Copyright (c) 2019, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-description: Colorway LPD8803 SPI LED strip
+description: GreeLed LPD8806 SPI LED strip
 
-compatible: "colorway,lpd8803"
+compatible: "greeled,lpd8806"
 
 include: spi-device.yaml

--- a/dts/bindings/modem/u-blox,sara-r4.yaml
+++ b/dts/bindings/modem/u-blox,sara-r4.yaml
@@ -3,7 +3,7 @@
 
 description: u-blox SARA-R4 modem
 
-compatible: "ublox,sara-r4"
+compatible: "u-blox,sara-r4"
 
 include: uart-device.yaml
 

--- a/dts/bindings/sensor/maxim,max30101.yaml
+++ b/dts/bindings/sensor/maxim,max30101.yaml
@@ -3,6 +3,6 @@
 
 description: MAX30101 heart rate sensor
 
-compatible: "max,max30101"
+compatible: "maxim,max30101"
 
 include: i2c-device.yaml

--- a/dts/bindings/sensor/seeed,grove-light.yaml
+++ b/dts/bindings/sensor/seeed,grove-light.yaml
@@ -3,7 +3,7 @@
 
 description: Grove Photo-Resistor Light Sensor
 
-compatible: "grove,light"
+compatible: "seeed,grove-light"
 
 include: base.yaml
 

--- a/dts/bindings/sensor/seeed,grove-temperature.yaml
+++ b/dts/bindings/sensor/seeed,grove-temperature.yaml
@@ -3,7 +3,7 @@
 
 description: Grove NTC Temperature Sensor
 
-compatible: "grove,temperature"
+compatible: "seeed,grove-temperature"
 
 include: base.yaml
 

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -265,6 +265,7 @@ incircuit	In-Circuit GmbH
 inet-tek	Shenzhen iNet Mobile Internet Technology Co., Ltd
 infineon	Infineon Technologies
 inforce	Inforce Computing
+inventek	Inventek Systems
 ivo	InfoVision Optoelectronics Kunshan Co. Ltd.
 ingenic	Ingenic Semiconductor
 innolux	Innolux Corporation

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -652,6 +652,7 @@ wlf	Wolfson Microelectronics
 wm	Wondermedia Technologies, Inc.
 wnc	Wistron NeWeb Corporation
 wobo	Wobo
+wolfson	Cirrus Logic, Inc. (formerly Wolfson Microelectronics plc)
 worldsemi	Worldsemi Co., Limited
 x-powers	X-Powers
 xes	Extreme Engineering Solutions (X-ES)

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -358,6 +358,7 @@ mentor	Mentor Graphics
 meraki	Cisco Meraki, LLC
 merrii	Merrii Technology Co., Ltd.
 micrel	Micrel Inc.
+microbit	Micro:bit Educational Foundation
 microchip	Microchip Technology Inc.
 microcrystal	Micro Crystal AG
 micron	Micron Technology Inc.

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -225,6 +225,7 @@ giantplus	Giantplus Technology Co., Ltd.
 globalscale	Globalscale Technologies, Inc.
 globaltop	GlobalTop Technology, Inc.
 gmt	Global Mixed-mode Technology, Inc.
+gooddisplay	Dalian Good Display Co., Ltd.
 goodix	Shenzhen Huiding Technology Co., Ltd.
 google	Google, Inc.
 grinn	Grinn

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -544,6 +544,7 @@ skyworks	Skyworks Solutions, Inc.
 smartlabs	SmartLabs LLC
 smsc	Standard Microsystems Corporation
 snps	Synopsys, Inc.
+starfive	StarFive Technology Co. Ltd.
 sochip	Shenzhen SoChip Technology Co., Ltd.
 socionext	Socionext Inc.
 solidrun	SolidRun

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -579,6 +579,7 @@ tcs	Shenzhen City Tang Cheng Technology Co., Ltd.
 tdo	Shangai Top Display Optoelectronics Co., Ltd
 technexion	TechNexion
 technologic	Technologic Systems
+telink	Telink Semiconductor
 tempo	Tempo Semiconductor
 techstar	Shenzhen Techstar Electronics Co., Ltd.
 terasic	Terasic Inc.

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -56,6 +56,7 @@ apple	Apple Inc.
 aptina	Aptina Imaging
 arasan	Arasan Chip Systems
 archermind	ArcherMind Technology (Nanjing) Co., Ltd.
+arc	Synopsys, Inc. (formerly ARC International PLC)
 arctic	Arctic Sand
 arcx	arcx Inc. / Archronix Inc.
 arduino	Arduino

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -645,6 +645,7 @@ wlf	Wolfson Microelectronics
 wm	Wondermedia Technologies, Inc.
 wnc	Wistron NeWeb Corporation
 wobo	Wobo
+worldsemi	Worldsemi Co., Limited
 x-powers	X-Powers
 xes	Extreme Engineering Solutions (X-ES)
 xiaomi	Xiaomi Technology Co., Ltd.

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -636,6 +636,7 @@ wi2wi	Wi2Wi, Inc.
 winbond	Winbond Electronics corp.
 winstar	Winstar Display Corp.
 wits	Shenzhen Merrii Technology Co., Ltd. (WITS)
+wiznet	WIZnet Co., Ltd.
 wlf	Wolfson Microelectronics
 wm	Wondermedia Technologies, Inc.
 wnc	Wistron NeWeb Corporation

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -241,6 +241,7 @@ hitex	Hitex Development Tools
 holt	Holt Integrated Circuits, Inc.
 honestar	Honestar Technologies Co., Ltd.
 honeywell	Honeywell
+hoperf	HOPERF Microelectronics Co. Ltd
 hoperun	Jiangsu HopeRun Software Co., Ltd.
 hp	Hewlett Packard
 hsg	HannStar Display Co.

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -49,6 +49,7 @@ amstaos	AMS-Taos Inc.
 analogix	Analogix Semiconductor, Inc.
 andestech	Andes Technology Corporation
 anvo	Anvo-Systems Dresden GmbH
+aosong	Guangzhou Aosong Electronic Co., Ltd.
 apa	Apa Electronic Co., Ltd
 apm	Applied Micro Circuits Corporation (APM)
 apple	Apple Inc.

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -212,6 +212,7 @@ focaltech	FocalTech Systems Co.,Ltd
 frida	Shenzhen Frida LCD Co., Ltd.
 friendlyarm	Guangzhou FriendlyARM Computer Tech Co., Ltd
 fsl	Freescale Semiconductor
+ftdi	Future Technology Devices International Ltd.
 fujitsu	Fujitsu Ltd.
 gaisler	Gaisler
 gardena	GARDENA GmbH

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -142,6 +142,7 @@ cznic	CZ.NIC, z.s.p.o.
 dallas	Maxim Integrated Products (formerly Dallas Semiconductor)
 dataimage	DataImage, Inc.
 davicom	DAVICOM Semiconductor, Inc.
+decawave	Qorvo, Inc (formerly Decawave)
 dell	Dell Inc.
 delta	Delta Electronics, Inc.
 denx	Denx Software Engineering

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -49,6 +49,7 @@ amstaos	AMS-Taos Inc.
 analogix	Analogix Semiconductor, Inc.
 andestech	Andes Technology Corporation
 anvo	Anvo-Systems Dresden GmbH
+apa	Apa Electronic Co., Ltd
 apm	Applied Micro Circuits Corporation (APM)
 apple	Apple Inc.
 aptina	Aptina Imaging

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -638,6 +638,7 @@ winstar	Winstar Display Corp.
 wits	Shenzhen Merrii Technology Co., Ltd. (WITS)
 wlf	Wolfson Microelectronics
 wm	Wondermedia Technologies, Inc.
+wnc	Wistron NeWeb Corporation
 wobo	Wobo
 x-powers	X-Powers
 xes	Extreme Engineering Solutions (X-ES)

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -232,6 +232,7 @@ gmt	Global Mixed-mode Technology, Inc.
 gooddisplay	Dalian Good Display Co., Ltd.
 goodix	Shenzhen Huiding Technology Co., Ltd.
 google	Google, Inc.
+greeled	GreeLed Electronic Ltd.
 grinn	Grinn
 grmn	Garmin Limited
 gumstix	Gumstix, Inc.

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -363,6 +363,7 @@ microbit	Micro:bit Educational Foundation
 microchip	Microchip Technology Inc.
 microcrystal	Micro Crystal AG
 micron	Micron Technology Inc.
+microsemi	Microchip Technology Inc. (formerly Microsemi Corporation)
 microsoft	Microsoft Corporation
 microsys	MicroSys Electronics GmbH
 mikroe	MikroElektronika d.o.o.

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -468,6 +468,7 @@ qi	Qi Hardware
 qihua	Chengdu Kaixuan Information Technology Co., Ltd.
 qiaodian	QiaoDian XianShi Corporation
 qnap	QNAP Systems, Inc.
+quectel	Quectel Wireless Solutions Co., Ltd.
 quicklogic	QuickLogic Corp.
 radxa	Radxa
 raidsonic	RaidSonic Technology GmbH

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -98,7 +98,6 @@ brcm	Broadcom Corporation
 buffalo	Buffalo, Inc.
 bur	B&R Industrial Automation GmbH
 bticino	Bticino International
-cadence	Cadence Design Systems, Inc.
 calaosystems	CALAO Systems SAS
 calxeda	Calxeda
 canaan	Canaan, Inc.

--- a/dts/nios2/nios2f.dtsi
+++ b/dts/nios2/nios2f.dtsi
@@ -45,7 +45,7 @@
 		};
 
 		i2c0: i2c@100200 {
-			compatible = "nios2,i2c";
+			compatible = "altr,nios2-i2c";
 			clock-frequency = <I2C_BITRATE_ULTRA>;
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/riscv/riscv32-fe310.dtsi
+++ b/dts/riscv/riscv32-fe310.dtsi
@@ -5,7 +5,7 @@
 / {
 	#address-cells = <1>;
 	#size-cells = <1>;
-	compatible = "SiFive,FE310G-0002-Z0-dev", "fe310-dev", "sifive-dev";
+	compatible = "sifive,FE310G-0002-Z0-dev", "fe310-dev", "sifive-dev";
 	model = "SiFive,FE310G-0002-Z0";
 	cpus {
 		#address-cells = <1>;
@@ -34,7 +34,7 @@
 	soc {
 		#address-cells = <1>;
 		#size-cells = <1>;
-		compatible = "SiFive,FE310G-0002-Z0-soc", "fe310-soc",
+		compatible = "sifive,FE310G-0002-Z0-soc", "fe310-soc",
 			"sifive-soc", "simple-bus";
 		ranges;
 		wdog0: wdog@10000000 {

--- a/dts/riscv/riscv32-litex-vexriscv.dtsi
+++ b/dts/riscv/riscv32-litex-vexriscv.dtsi
@@ -35,7 +35,7 @@
 		ranges;
 		intc0: interrupt-controller@bc0 {
 			#interrupt-cells = <2>;
-			compatible = "vexriscv,intc0";
+			compatible = "vexriscv-intc0";
 			interrupt-controller;
 			reg = <0xbc0 0x4 0xfc0 0x4>;
 			reg-names = "irq_mask", "irq_pending";

--- a/dts/riscv/riscv32-litex-vexriscv.dtsi
+++ b/dts/riscv/riscv32-litex-vexriscv.dtsi
@@ -20,7 +20,7 @@
 		#size-cells = <0>;
 		cpu@0 {
 			clock-frequency = <100000000>;
-			compatible = "spinalhdl,vexriscv", "riscv";
+			compatible = "riscv";
 			device_type = "cpu";
 			reg = <0>;
 			riscv,isa = "rv32imac";

--- a/dts/xtensa/espressif/esp32.dtsi
+++ b/dts/xtensa/espressif/esp32.dtsi
@@ -22,14 +22,14 @@
 
 		cpu0: cpu@0 {
 			device_type = "cpu";
-			compatible = "cadence,tensilica-xtensa-lx6";
+			compatible = "cdns,tensilica-xtensa-lx6";
 			reg = <0>;
 			clock-source = <ESP32_CLK_SRC_PLL>;
 		};
 
 		cpu1: cpu@1 {
 			device_type = "cpu";
-			compatible = "cadence,tensilica-xtensa-lx6";
+			compatible = "cdns,tensilica-xtensa-lx6";
 			reg = <1>;
 			clock-source = <ESP32_CLK_SRC_PLL>;
 		};

--- a/dts/xtensa/espressif/esp32s2.dtsi
+++ b/dts/xtensa/espressif/esp32s2.dtsi
@@ -15,7 +15,7 @@
 
 		cpu0: cpu@0 {
 			device_type = "cpu";
-			compatible = "cadence,tensilica-xtensa-lx7";
+			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <0>;
 		};
 	};

--- a/dts/xtensa/intel/intel_byt_adsp.dtsi
+++ b/dts/xtensa/intel/intel_byt_adsp.dtsi
@@ -34,7 +34,7 @@
 
 	soc {
 		core_intc: core_intc@0 {
-			compatible = "xtensa,core-intc";
+			compatible = "cdns,xtensa-core-intc";
 			reg = <0x00 0x400>;
 			interrupt-controller;
 			#interrupt-cells = <3>;

--- a/dts/xtensa/intel/intel_byt_adsp.dtsi
+++ b/dts/xtensa/intel/intel_byt_adsp.dtsi
@@ -15,7 +15,7 @@
 
 		cpu0: cpu@0 {
 			device_type = "cpu";
-			compatible = "cadence,tensilica-xtensa-lx4";
+			compatible = "cdns,tensilica-xtensa-lx4";
 			reg = <0>;
 		};
 	};

--- a/dts/xtensa/intel/intel_cavs15.dtsi
+++ b/dts/xtensa/intel/intel_cavs15.dtsi
@@ -15,13 +15,13 @@
 
 		cpu0: cpu@0 {
 			device_type = "cpu";
-			compatible = "cadence,tensilica-xtensa-lx4";
+			compatible = "cdns,tensilica-xtensa-lx4";
 			reg = <0>;
 		};
 
 		cpu1: cpu@1 {
 			device_type = "cpu";
-			compatible = "cadence,tensilica-xtensa-lx4";
+			compatible = "cdns,tensilica-xtensa-lx4";
 			reg = <1>;
 		};
 	};

--- a/dts/xtensa/intel/intel_cavs15.dtsi
+++ b/dts/xtensa/intel/intel_cavs15.dtsi
@@ -38,7 +38,7 @@
 
 	soc {
 		core_intc: core_intc@0 {
-			compatible = "xtensa,core-intc";
+			compatible = "cdns,xtensa-core-intc";
 			reg = <0x00 0x400>;
 			interrupt-controller;
 			#interrupt-cells = <3>;

--- a/dts/xtensa/intel/intel_cavs18.dtsi
+++ b/dts/xtensa/intel/intel_cavs18.dtsi
@@ -52,7 +52,7 @@
 
 	soc {
 		core_intc: core_intc@0 {
-			compatible = "xtensa,core-intc";
+			compatible = "cdns,xtensa-core-intc";
 			reg = <0x00 0x400>;
 			interrupt-controller;
 			#interrupt-cells = <3>;

--- a/dts/xtensa/intel/intel_cavs18.dtsi
+++ b/dts/xtensa/intel/intel_cavs18.dtsi
@@ -15,25 +15,25 @@
 
 		cpu0: cpu@0 {
 			device_type = "cpu";
-			compatible = "cadence,tensilica-xtensa-lx4";
+			compatible = "cdns,tensilica-xtensa-lx4";
 			reg = <0>;
 		};
 
 		cpu1: cpu@1 {
 			device_type = "cpu";
-			compatible = "cadence,tensilica-xtensa-lx4";
+			compatible = "cdns,tensilica-xtensa-lx4";
 			reg = <1>;
 		};
 
 		cpu2: cpu@2 {
 			device_type = "cpu";
-			compatible = "cadence,tensilica-xtensa-lx4";
+			compatible = "cdns,tensilica-xtensa-lx4";
 			reg = <2>;
 		};
 
 		cpu3: cpu@3 {
 			device_type = "cpu";
-			compatible = "cadence,tensilica-xtensa-lx4";
+			compatible = "cdns,tensilica-xtensa-lx4";
 			reg = <3>;
 		};
 	};

--- a/dts/xtensa/intel/intel_cavs20.dtsi
+++ b/dts/xtensa/intel/intel_cavs20.dtsi
@@ -52,7 +52,7 @@
 
 	soc {
 		core_intc: core_intc@0 {
-			compatible = "xtensa,core-intc";
+			compatible = "cdns,xtensa-core-intc";
 			reg = <0x00 0x400>;
 			interrupt-controller;
 			#interrupt-cells = <3>;

--- a/dts/xtensa/intel/intel_cavs20.dtsi
+++ b/dts/xtensa/intel/intel_cavs20.dtsi
@@ -15,25 +15,25 @@
 
 		cpu0: cpu@0 {
 			device_type = "cpu";
-			compatible = "cadence,tensilica-xtensa-lx4";
+			compatible = "cdns,tensilica-xtensa-lx4";
 			reg = <0>;
 		};
 
 		cpu1: cpu@1 {
 			device_type = "cpu";
-			compatible = "cadence,tensilica-xtensa-lx4";
+			compatible = "cdns,tensilica-xtensa-lx4";
 			reg = <1>;
 		};
 
 		cpu2: cpu@2 {
 			device_type = "cpu";
-			compatible = "cadence,tensilica-xtensa-lx4";
+			compatible = "cdns,tensilica-xtensa-lx4";
 			reg = <2>;
 		};
 
 		cpu3: cpu@3 {
 			device_type = "cpu";
-			compatible = "cadence,tensilica-xtensa-lx4";
+			compatible = "cdns,tensilica-xtensa-lx4";
 			reg = <3>;
 		};
 	};

--- a/dts/xtensa/intel/intel_cavs25.dtsi
+++ b/dts/xtensa/intel/intel_cavs25.dtsi
@@ -52,7 +52,7 @@
 
 	soc {
 		core_intc: core_intc@0 {
-			compatible = "xtensa,core-intc";
+			compatible = "cdns,xtensa-core-intc";
 			reg = <0x00 0x400>;
 			interrupt-controller;
 			#interrupt-cells = <3>;

--- a/dts/xtensa/intel/intel_cavs25.dtsi
+++ b/dts/xtensa/intel/intel_cavs25.dtsi
@@ -15,25 +15,25 @@
 
 		cpu0: cpu@0 {
 			device_type = "cpu";
-			compatible = "cadence,tensilica-xtensa-lx4";
+			compatible = "cdns,tensilica-xtensa-lx4";
 			reg = <0>;
 		};
 
 		cpu1: cpu@1 {
 			device_type = "cpu";
-			compatible = "cadence,tensilica-xtensa-lx4";
+			compatible = "cdns,tensilica-xtensa-lx4";
 			reg = <1>;
 		};
 
 		cpu2: cpu@2 {
 			device_type = "cpu";
-			compatible = "cadence,tensilica-xtensa-lx4";
+			compatible = "cdns,tensilica-xtensa-lx4";
 			reg = <2>;
 		};
 
 		cpu3: cpu@3 {
 			device_type = "cpu";
-			compatible = "cadence,tensilica-xtensa-lx4";
+			compatible = "cdns,tensilica-xtensa-lx4";
 			reg = <3>;
 		};
 	};

--- a/dts/xtensa/intel/intel_s1000.dtsi
+++ b/dts/xtensa/intel/intel_s1000.dtsi
@@ -14,13 +14,13 @@
 
 		cpu0: cpu@0 {
 			device_type = "cpu";
-			compatible = "cadence,tensilica-xtensa-lx6";
+			compatible = "cdns,tensilica-xtensa-lx6";
 			reg = <0>;
 		};
 
 		cpu1: cpu@1 {
 			device_type = "cpu";
-			compatible = "cadence,tensilica-xtensa-lx6";
+			compatible = "cdns,tensilica-xtensa-lx6";
 			reg = <1>;
 		};
 	};

--- a/dts/xtensa/intel/intel_s1000.dtsi
+++ b/dts/xtensa/intel/intel_s1000.dtsi
@@ -43,7 +43,7 @@
 
 	soc {
 		core_intc: core_intc@0 {
-			compatible = "xtensa,core-intc";
+			compatible = "cdns,xtensa-core-intc";
 			reg = <0x00 0x400>;
 			interrupt-controller;
 			#interrupt-cells = <3>;

--- a/samples/drivers/led_lpd8806/boards/96b_carbon.overlay
+++ b/samples/drivers/led_lpd8806/boards/96b_carbon.overlay
@@ -7,7 +7,7 @@
 &spi2 {
 
 	led_strip@0 {
-		compatible = "colorway,lpd8806";
+		compatible = "greeled,lpd8806";
 		reg = <0>;
 		spi-max-frequency = <2000000>;
 		label = "LPD8806";

--- a/samples/drivers/led_lpd8806/src/main.c
+++ b/samples/drivers/led_lpd8806/src/main.c
@@ -38,7 +38,7 @@ static const struct led_rgb black = {
 
 struct led_rgb strip_colors[STRIP_NUM_LEDS];
 
-static const struct device *strip = DEVICE_DT_GET_ANY(colorway_lpd8806);
+static const struct device *strip = DEVICE_DT_GET_ANY(greeled_lpd8806);
 
 const struct led_rgb *color_at(size_t time, size_t i)
 {

--- a/samples/sensor/grove_light/boards/nrf52dk_nrf52832.overlay
+++ b/samples/sensor/grove_light/boards/nrf52dk_nrf52832.overlay
@@ -7,7 +7,7 @@
 / {
 	ntc {
 		label = "GLS";
-		compatible = "grove,light";
+		compatible = "seeed,grove-light";
 		io-channels = <&arduino_adc 0>;
 	};
 };

--- a/samples/sensor/grove_light/src/main.c
+++ b/samples/sensor/grove_light/src/main.c
@@ -13,7 +13,8 @@
 
 void main(void)
 {
-	const struct device *dev = device_get_binding(DT_LABEL(DT_INST(0, grove_light)));
+	const struct device *dev =
+		device_get_binding(DT_LABEL(DT_INST(0, seeed_grove_light)));
 
 	if (dev == NULL) {
 		printf("device not found.  aborting test.\n");

--- a/samples/sensor/grove_temperature/boards/nrf52dk_nrf52832.overlay
+++ b/samples/sensor/grove_temperature/boards/nrf52dk_nrf52832.overlay
@@ -7,7 +7,7 @@
 / {
 	ntc {
 		label = "GTS";
-		compatible = "grove,temperature";
+		compatible = "seeed,grove-temperature";
 		io-channels = <&arduino_adc 0>;
 	};
 };

--- a/samples/sensor/grove_temperature/src/main.c
+++ b/samples/sensor/grove_temperature/src/main.c
@@ -19,7 +19,9 @@
 
 void main(void)
 {
-	const struct device *dev = device_get_binding(DT_LABEL(DT_INST(0, grove_temperature)));
+	const struct device *dev =
+		device_get_binding(DT_LABEL(DT_INST(0,
+						    seeed_grove_temperature)));
 	struct sensor_value temp;
 	int read;
 

--- a/samples/sensor/max30101/src/main.c
+++ b/samples/sensor/max30101/src/main.c
@@ -11,7 +11,7 @@
 void main(void)
 {
 	struct sensor_value green;
-	const struct device *dev = DEVICE_DT_GET_ANY(max_max30101);
+	const struct device *dev = DEVICE_DT_GET_ANY(maxim_max30101);
 
 	if (dev == NULL) {
 		printf("Could not get max30101 device\n");

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -518,7 +518,10 @@ class EDT:
 
         if ',' in compat and self._vendor_prefixes is not None:
             vendor = compat.split(',', 1)[0]
-            if vendor not in self._vendor_prefixes and \
+            # As an exception, the root node can have whatever
+            # compatibles it wants. Other nodes get checked.
+            if node.path != '/' and \
+                   vendor not in self._vendor_prefixes and \
                    vendor not in _VENDOR_PREFIX_ALLOWED:
                 if self._werror:
                     log_fn = _LOG.error

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -524,10 +524,10 @@ class EDT:
                    vendor not in self._vendor_prefixes and \
                    vendor not in _VENDOR_PREFIX_ALLOWED:
                 if self._werror:
-                    log_fn = _LOG.error
+                    handler_fn = _err
                 else:
-                    log_fn = _LOG.warning
-                log_fn(
+                    handler_fn = _LOG.warning
+                handler_fn(
                     f"node '{node.path}' compatible '{compat}' "
                     f"has unknown vendor prefix '{vendor}'")
 

--- a/tests/boards/altera_max10/i2c_master/src/i2c_master.c
+++ b/tests/boards/altera_max10/i2c_master/src/i2c_master.c
@@ -65,7 +65,8 @@ static int powerup_adv7513(const struct device *i2c_dev)
 
 static int test_i2c_adv7513(void)
 {
-	const struct device *i2c_dev = device_get_binding(DT_LABEL(DT_INST(0, nios2_i2c)));
+	const struct device *i2c_dev =
+		device_get_binding(DT_LABEL(DT_INST(0, altr_nios2_i2c)));
 	uint32_t i2c_cfg = I2C_SPEED_SET(I2C_SPEED_STANDARD) | I2C_MODE_MASTER;
 	uint8_t data;
 

--- a/tests/drivers/build_all/modem/uart.dtsi
+++ b/tests/drivers/build_all/modem/uart.dtsi
@@ -31,17 +31,17 @@ test_wnc_m14a2a: wncm14a2a {
 };
 
 test_sara_r4: sara_r4 {
-      compatible = "ublox,sara-r4";
-      label = "ublox-sara-r4";
+	compatible = "u-blox,sara-r4";
+	label = "ublox-sara-r4";
 
-      mdm-power-gpios = <&test_gpio 0 0>;
-      mdm-reset-gpios = <&test_gpio 0 0>;
+	mdm-power-gpios = <&test_gpio 0 0>;
+	mdm-reset-gpios = <&test_gpio 0 0>;
 };
 
 test_quectel_bg9x: quectel_bg9x {
-      compatible = "quectel,bg9x";
-      label = "quectel,bg9x";
+	compatible = "quectel,bg9x";
+	label = "quectel,bg9x";
 
-      mdm-power-gpios = <&test_gpio 0 0>;
-      mdm-reset-gpios = <&test_gpio 0 0>;
+	mdm-power-gpios = <&test_gpio 0 0>;
+	mdm-reset-gpios = <&test_gpio 0 0>;
 };

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -162,7 +162,7 @@ test_i2c_isl29035: isl29035@17 {
 };
 
 test_i2c_max30101: max30101@18 {
-	compatible = "max,max30101";
+	compatible = "maxim,max30101";
 	label = "MAX30101";
 	reg = <0x18>;
 };

--- a/tests/drivers/build_all/sensor/spi.dtsi
+++ b/tests/drivers/build_all/sensor/spi.dtsi
@@ -67,14 +67,14 @@ test_spi_bmi160: bmi160@7 {
 };
 
 test_spi_lpd8803: lpd8803@8 {
-	compatible = "colorway,lpd8803";
+	compatible = "greeled,lpd8803";
 	label = "LPD8803";
 	reg = <0x8>;
 	spi-max-frequency = <0>;
 };
 
 test_spi_lpd8806: lpd8806@9 {
-	compatible = "colorway,lpd8806";
+	compatible = "greeled,lpd8806";
 	label = "LPD8806";
 	reg = <0x9>;
 	spi-max-frequency = <0>;


### PR DESCRIPTION
Commit c4079e4be29afd57f6cae431c4b849970eb91dd5
("scripts: rework edtlib warnings-turned-errors") was trying to abort
on unknown vendor prefix, but the error log is not fatal.

Fix it by using the same error handling function we use when aborting
due to deprecated property usage.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>