### PR TITLE
Bluetooth: Controller: HCI: Fixing the bug to store 12 bit IQ samples

### DIFF
--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -2442,8 +2442,8 @@ struct bt_hci_evt_le_chan_sel_algo {
 
 #define BT_HCI_EVT_LE_CONNECTIONLESS_IQ_REPORT  0x15
 struct bt_hci_le_iq_sample {
-	int8_t i;
-	int8_t q;
+	int16_t i;
+	int16_t q;
 };
 
 struct bt_hci_evt_le_connectionless_iq_report {

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -2619,7 +2619,6 @@ static void le_df_connectionless_iq_report(struct pdu_data *pdu_rx,
 
 	struct lll_sync *lll;
 	uint8_t samples_cnt;
-	int16_t iq_tmp;
 	int16_t rssi;
 	uint8_t idx;
 
@@ -2678,10 +2677,8 @@ static void le_df_connectionless_iq_report(struct pdu_data *pdu_rx,
 		sep->sample_count = 0;
 	} else {
 		for (idx = 0; idx < samples_cnt; ++idx) {
-			iq_tmp = IQ_SHIFT_12_TO_8_BIT(iq_report->sample[idx].i);
-			sep->sample[idx].i = (int8_t)iq_tmp;
-			iq_tmp = IQ_SHIFT_12_TO_8_BIT(iq_report->sample[idx].q);
-			sep->sample[idx].q = (int8_t)iq_tmp;
+			sep->sample[idx].i = iq_report->sample[idx].i;
+			sep->sample[idx].q = iq_report->sample[idx].q;
 		}
 		sep->sample_count = samples_cnt;
 	}

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df_types.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df_types.h
@@ -54,7 +54,6 @@ struct lll_df_adv_cfg {
 #define IQ_SAMPLE_CNT  (PDU_DC_LL_HEADER_SIZE + LL_LENGTH_OCTETS_RX_MAX)
 
 #define RSSI_DBM_TO_DECI_DBM(x) (-(x) * 10)
-#define IQ_SHIFT_12_TO_8_BIT(x) ((x) >> 4)
 
 /* Structure to store an single IQ sample */
 struct iq_sample {


### PR DESCRIPTION
While IQ samples are captured in 12 bit resolution as described in
the documents of nRF chipsets, 4 bits of the data was omitted by
the software when it was reported to other components by HCI layer.

Now it stores the IQ samples as they are captured at the origin in
a 16 bit signed integer.

Signed-off-by: Saleh Mehdikhani <saleh.mehdikhani@unikie.com>