### PR TITLE
Microchip: MEC172x: Device tree constant property cleanup

### DIFF
--- a/dts/arm/microchip/mec172xnsz.dtsi
+++ b/dts/arm/microchip/mec172xnsz.dtsi
@@ -328,8 +328,6 @@
 			girqs = <21 2>;
 			pcrs = <1 9>;
 			label = "WDT_0";
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 		};
 		rtimer: timer@40007400 {
 			compatible = "microchip,xec-rtos-timer";
@@ -348,8 +346,6 @@
 			label = "TIMER_0";
 			max-value = <0xFFFF>;
 			prescaler = <0>;
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		timer1: timer@40000c20 {
@@ -362,8 +358,6 @@
 			label = "TIMER_1";
 			max-value = <0xFFFF>;
 			prescaler = <0>;
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		timer2: timer@40000c40 {
@@ -376,8 +370,6 @@
 			label = "TIMER_2";
 			max-value = <0xFFFF>;
 			prescaler = <0>;
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		timer3: timer@40000c60 {
@@ -390,8 +382,6 @@
 			label = "TIMER_3";
 			max-value = <0xFFFF>;
 			prescaler = <0>;
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		/*
@@ -409,8 +399,6 @@
 			label = "TIMER_4";
 			max-value = <0xFFFFFFFF>;
 			prescaler = <0>;
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		timer5: timer@40000ca0 {
@@ -423,8 +411,6 @@
 			label = "TIMER_5";
 			max-value = <0xFFFFFFFF>;
 			prescaler = <0>;
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		cntr0: timer@40000d00 {
@@ -433,8 +419,6 @@
 			girqs = <23 6>;
 			pcrs = <4 2>;
 			label = "EVTMR_0";
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		cntr1: timer@40000d20 {
@@ -443,8 +427,6 @@
 			girqs = <23 7>;
 			pcrs = <4 3>;
 			label = "EVTMR_1";
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		cntr2: timer@40000d40 {
@@ -453,8 +435,6 @@
 			girqs = <23 8>;
 			pcrs = <4 3>;
 			label = "EVTMR_2";
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		cntr3: timer@40000d60 {
@@ -463,8 +443,6 @@
 			girqs = <23 9>;
 			pcrs = <4 4>;
 			label = "EVTMR_3";
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		cctmr0: timer@40001000 {
@@ -476,8 +454,6 @@
 				<18 25>, <18 26>, <18 27>, <18 28>;
 			pcrs = <3 30>;
 			label = "CCTMR_0";
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		hibtimer0: timer@40009800 {
@@ -510,7 +486,6 @@
 				     <124 0>, <125 0>;
 			girqs = <21 10>, <21 11>, <21 12>, <21 13>, <21 14>;
 			label = "VCI_0";
-			#girqs-cells = <2>;
 			status = "disabled";
 		};
 		dmac: dmac@40002400 {
@@ -526,8 +501,6 @@
 			pcrs = <1 6>;
 			label = "DMA_0";
 			#dma-cells = <2>;
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		i2c_smb_0: i2c@40004000 {
@@ -539,8 +512,6 @@
 			label = "I2C_SMB_0";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		i2c_smb_1: i2c@40004400 {
@@ -552,8 +523,6 @@
 			label = "I2C_SMB_1";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		i2c_smb_2: i2c@40004800 {
@@ -565,8 +534,6 @@
 			label = "I2C_SMB_2";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		i2c_smb_3: i2c@40004c00 {
@@ -578,8 +545,6 @@
 			label = "I2C_SMB_3";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		i2c_smb_4: i2c@40005000 {
@@ -591,8 +556,6 @@
 			label = "I2C_SMB_4";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		uart0: uart@400f2400 {
@@ -623,8 +586,6 @@
 			label = "PS2_0";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		pwm0: pwm@40005800 {
@@ -633,7 +594,6 @@
 			label = "PWM_0";
 			status = "disabled";
 			#pwm-cells = <1>;
-			#pcrs-cells = <2>;
 		};
 		pwm1: pwm@40005810 {
 			reg = <0x40005810 0x20>;
@@ -641,7 +601,6 @@
 			label = "PWM_1";
 			status = "disabled";
 			#pwm-cells = <1>;
-			#pcrs-cells = <2>;
 		};
 		pwm2: pwm@40005820 {
 			reg = <0x40005820 0x20>;
@@ -649,7 +608,6 @@
 			label = "PWM_2";
 			status = "disabled";
 			#pwm-cells = <1>;
-			#pcrs-cells = <2>;
 		};
 		pwm3: pwm@40005830 {
 			reg = <0x40005830 0x20>;
@@ -657,7 +615,6 @@
 			label = "PWM_3";
 			status = "disabled";
 			#pwm-cells = <1>;
-			#pcrs-cells = <2>;
 		};
 		pwm4: pwm@40005840 {
 			reg = <0x40005840 0x20>;
@@ -665,7 +622,6 @@
 			label = "PWM_4";
 			status = "disabled";
 			#pwm-cells = <1>;
-			#pcrs-cells = <2>;
 		};
 		pwm5: pwm@40005850 {
 			reg = <0x40005850 0x20>;
@@ -673,7 +629,6 @@
 			label = "PWM_5";
 			status = "disabled";
 			#pwm-cells = <1>;
-			#pcrs-cells = <2>;
 		};
 		pwm6: pwm@40005860 {
 			reg = <0x40005860 0x20>;
@@ -681,7 +636,6 @@
 			label = "PWM_6";
 			status = "disabled";
 			#pwm-cells = <1>;
-			#pcrs-cells = <2>;
 		};
 		pwm7: pwm@40005870 {
 			reg = <0x40005870 0x20>;
@@ -689,7 +643,6 @@
 			label = "PWM_7";
 			status = "disabled";
 			#pwm-cells = <1>;
-			#pcrs-cells = <2>;
 		};
 		pwm8: pwm@40005880 {
 			reg = <0x40005880 0x20>;
@@ -697,7 +650,6 @@
 			label = "PWM_8";
 			status = "disabled";
 			#pwm-cells = <1>;
-			#pcrs-cells = <2>;
 		};
 		tach0: tach@40006000 {
 			reg = <0x40006000 0x10>;
@@ -707,8 +659,6 @@
 			label = "TACH_0";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		tach1: tach@40006010 {
@@ -719,8 +669,6 @@
 			label = "TACH_1";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		tach2: tach@40006020 {
@@ -731,8 +679,6 @@
 			label = "TACH_2";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		tach3: tach@40006030 {
@@ -743,8 +689,6 @@
 			label = "TACH_3";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		rpmfan0: rpmfan@4000a000 {
@@ -753,8 +697,6 @@
 			girqs = <17 20>, <17 21>;
 			pcrs = <3 12>;
 			label = "RPMFAN_0";
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		rpmfan1: rpmfan@4000a080 {
@@ -763,8 +705,6 @@
 			girqs = <17 22>, <17 23>;
 			pcrs = <4 7>;
 			label = "RPMFAN_1";
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		adc0: adc@40007c00 {
@@ -775,8 +715,6 @@
 			label = "ADC_0";
 			status = "disabled";
 			#io-channel-cells = <1>;
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 		};
 		kscan0: kscan@40009c00 {
 			reg = <0x40009c00 0x18>;
@@ -787,8 +725,6 @@
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 		};
 		peci0: peci@40006400 {
 			reg = <0x40006400 0x80>;
@@ -798,8 +734,6 @@
 			label = "PECI_0";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 		};
 		spi0: spi@40070000 {
 			reg = <0x40070000 0x400>;
@@ -817,10 +751,8 @@
 			dcsda = <6>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			#girqs-cells = <2>;
 			#ldma-cells = <2>;
 			#legdma-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		spi1: spi@40009400 {
@@ -829,8 +761,6 @@
 			girqs = <18 2>, <18 3>;
 			pcrs = <3 9>;
 			label = "SPI_1";
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		spi2: spi@40009480 {
@@ -839,8 +769,6 @@
 			girqs = <18 4>, <18 5>;
 			pcrs = <4 22>;
 			label = "SPI_2";
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		prochot0: prochot@40003400 {
@@ -849,8 +777,6 @@
 			girqs = <17 17>;
 			pcrs = <4 13>;
 			label = "PROCHOT_0";
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		rcid0: rcid@40001400 {
@@ -859,8 +785,6 @@
 			girqs = <17 10>;
 			pcrs = <4 10>;
 			label = "RCID_0";
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		rcid1: rcid@40001480 {
@@ -869,8 +793,6 @@
 			girqs = <17 11>;
 			pcrs = <4 11>;
 			label = "RCID_1";
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		rcid2: rcid@40001500 {
@@ -879,8 +801,6 @@
 			girqs = <17 12>;
 			pcrs = <4 12>;
 			label = "RCID_2";
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		spip0: spip@40007000 {
@@ -889,8 +809,6 @@
 			girqs = <18 0>;
 			pcrs = <4 16>;
 			label = "SPIP_0";
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		bbled0: bbled@4000b800 {
@@ -899,8 +817,6 @@
 			girqs = <17 13>;
 			pcrs = <3 16>;
 			label = "BBLED_0";
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		bbled1: bbled@4000b900 {
@@ -909,8 +825,6 @@
 			girqs = <17 14>;
 			pcrs = <3 17>;
 			label = "BBLED_1";
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		bbled2: bbled@4000ba00 {
@@ -919,8 +833,6 @@
 			girqs = <17 15>;
 			pcrs = <3 18>;
 			label = "BBLED_2";
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		bbled3: bbled@4000bb00 {
@@ -929,8 +841,6 @@
 			girqs = <17 16>;
 			pcrs = <3 25>;
 			label = "BBLED_3";
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		bclink0: bclink@4000cd00 {
@@ -939,8 +849,6 @@
 			girqs = <18 7>, <18 6>;
 			pcrs = <3 19>;
 			label = "BCLINK_0";
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		mbox0: mbox@400f0000 {
@@ -949,8 +857,6 @@
 			girqs = <15 20>;
 			pcrs = <2 17>;
 			label = "MBOX_0";
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		emi0: emi@400f4000 {
@@ -958,7 +864,6 @@
 			interrupts = <42 0>;
 			girqs = <15 2>;
 			label = "EMI_0";
-			#girqs-cells = <2>;
 			status = "disabled";
 		};
 		emi1: emi@400f4400 {
@@ -966,7 +871,6 @@
 			interrupts = <43 0>;
 			girqs = <15 3>;
 			label = "EMI_1";
-			#girqs-cells = <2>;
 			status = "disabled";
 		};
 		emi2: emi@400f4800 {
@@ -974,7 +878,6 @@
 			interrupts = <44 0>;
 			girqs = <15 4>;
 			label = "EMI_2";
-			#girqs-cells = <2>;
 			status = "disabled";
 		};
 		rtc0: rtc@400f5000 {
@@ -983,8 +886,6 @@
 			girqs = <21 8>, <21 9>;
 			pcrs = <2 18>;
 			label = "RTC_0";
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		p80bd0: p80bd@400f8000 {
@@ -993,22 +894,18 @@
 			girqs = <15 22>;
 			pcrs = <2 25>;
 			label = "P80BD_0";
-			#girqs-cells = <2>;
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		tfdp0: tfdp@40008c00 {
 			reg = <0x40008c00 0x10>;
 			pcrs = <1 7>;
 			label = "TFDP_0";
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 		glblcfg0: glblcfg@400fff00 {
 			reg = <0x400fff00 0x40>;
 			pcrs = <2 12>;
 			label = "GLBLCFG_0";
-			#pcrs-cells = <2>;
 			status = "disabled";
 		};
 	};

--- a/dts/bindings/rtc/microchip,xec-timer.yaml
+++ b/dts/bindings/rtc/microchip,xec-timer.yaml
@@ -37,18 +37,18 @@ properties:
       required: true
       description: PCR sleep enable register index and bit position.
 
-    "girqs-cells":
+    "girq-cells":
       type: int
       const: 2
 
-    "#pcrs-cells":
+    "#pcr-cells":
       type: int
       const: 2
 
-girqs-cells:
+girq-cells:
     - girq_num
     - bitpos
 
-pcrs-cells:
+pcr-cells:
     - reg_index
     - bitpos

--- a/dts/bindings/timer/microchip,xec-rtos-timer.yaml
+++ b/dts/bindings/timer/microchip,xec-rtos-timer.yaml
@@ -22,10 +22,10 @@ properties:
       required: true
       description: Array of GIRQ numbers [8:26] and bit positions [0:31].
 
-    "girqs-cells":
+    "girq-cells":
       type: int
       const: 2
 
-girqs-cells:
+girq-cells:
     - girq_num
     - bitpos


### PR DESCRIPTION
Microchip XEC two custom DT properies girqs and pcrs cell sizes
are defined as constants. There is no need to replicate these
is the chip DTSI since the value cannot be changes. Fix the syntax
of the cell size constant to match the naming convention used
thoughout DT.

Signed-off-by: Scott Worley <scott.worley@microchip.com>