### PR TITLE
ci: Bump to use SDK 0.13.0

### DIFF
--- a/.buildkite/daily.yml
+++ b/.buildkite/daily.yml
@@ -3,14 +3,14 @@ steps:
     - .buildkite/run.sh
     env:
       ZEPHYR_TOOLCHAIN_VARIANT: "zephyr"
-      ZEPHYR_SDK_INSTALL_DIR: "/opt/toolchains/zephyr-sdk-0.13.0-rc4"
+      ZEPHYR_SDK_INSTALL_DIR: "/opt/toolchains/zephyr-sdk-0.13.0"
     parallelism: 400
     timeout_in_minutes: 210
     retry:
       manual: true
     plugins:
       - docker#v3.5.0:
-          image: "zephyrprojectrtos/ci:v0.17.6"
+          image: "zephyrprojectrtos/ci:v0.18.0"
           propagate-environment: true
           volumes:
             - "/var/lib/buildkite-agent/git-mirrors:/var/lib/buildkite-agent/git-mirrors"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,14 +3,14 @@ steps:
     - .buildkite/run.sh
     env:
       ZEPHYR_TOOLCHAIN_VARIANT: "zephyr"
-      ZEPHYR_SDK_INSTALL_DIR: "/opt/toolchains/zephyr-sdk-0.12.4"
+      ZEPHYR_SDK_INSTALL_DIR: "/opt/toolchains/zephyr-sdk-0.13.0"
     parallelism: 20
     timeout_in_minutes: 180
     retry:
       manual: true
     plugins:
       - docker#v3.5.0:
-          image: "zephyrprojectrtos/ci:v0.17.1"
+          image: "zephyrprojectrtos/ci:v0.18.0"
           propagate-environment: true
           volumes:
             - "/var/lib/buildkite-agent/git-mirrors:/var/lib/buildkite-agent/git-mirrors"


### PR DESCRIPTION
Now that SDK 0.13.0 is released bump buildkite based CI to utilize it

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>