### PR TITLE
ci: github: bump SDK usage to 0.13.0

### DIFF
--- a/.github/workflows/bsim.yaml
+++ b/.github/workflows/bsim.yaml
@@ -22,11 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: bsim-build-cancel
     container:
-      image: zephyrprojectrtos/ci:v0.17.1
+      image: zephyrprojectrtos/ci:v0.18.0
       options: '--entrypoint /bin/bash'
     env:
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.12.4
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.13.0
       CLANG_ROOT_DIR: /usr/lib/llvm-12
       BSIM_OUT_PATH: /opt/bsim/
       BSIM_COMPONENTS_PATH: /opt/bsim/components

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -14,14 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: clang-build-cancel
     container:
-      image: zephyrprojectrtos/ci:v0.17.1
+      image: zephyrprojectrtos/ci:v0.18.0
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false
       matrix:
         subset: [1, 2, 3, 4, 5]
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.12.4
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.13.0
       CLANG_ROOT_DIR: /usr/lib/llvm-12
       MATRIX_SIZE: 5
     steps:

--- a/.github/workflows/errno.yml
+++ b/.github/workflows/errno.yml
@@ -8,7 +8,7 @@ jobs:
   check-errno:
     runs-on: ubuntu-latest
     container:
-      image: zephyrprojectrtos/ci:v0.17.1
+      image: zephyrprojectrtos/ci:v0.18.0
 
     steps:
       - name: checkout

--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -25,12 +25,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: footprint-tracking-cancel
     container:
-      image: zephyrprojectrtos/ci:v0.17.1
+      image: zephyrprojectrtos/ci:v0.18.0
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.12.4
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.13.0
       CLANG_ROOT_DIR: /usr/lib/llvm-12
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr
     steps:

--- a/.github/workflows/footprint.yml
+++ b/.github/workflows/footprint.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: footprint-cancel
     container:
-      image: zephyrprojectrtos/ci:v0.17.1
+      image: zephyrprojectrtos/ci:v0.18.0
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.12.4
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.13.0
       CLANG_ROOT_DIR: /usr/lib/llvm-12
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr
     steps:


### PR DESCRIPTION
Now that SDK 0.13.0 is out, bump all github workflows to utilize it.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>