### PR TITLE
dts: bindings: cpu: Add riscv cpu bindings

### DIFF
--- a/dts/bindings/riscv/riscv,cpus.yaml
+++ b/dts/bindings/riscv/riscv,cpus.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) 2021 Gerson Fernando Budke <nandojve@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+include: cpu.yaml
+
+properties:
+  mmu-type:
+    description: Memory Management Unit (MMU)
+    required: false
+    type: string
+    enum:
+      - riscv,sv32
+      - riscv,sv39
+      - riscv,sv48
+      - riscv,none
+
+  riscv,isa:
+    description: RISC-V instruction set architecture
+    required: true
+    type: string
+    enum:
+      - rv32imac
+      - rv32imafc
+      - rv32imafcb
+      - rv64imac
+      - rv64imafdc
+
+  riscv,pmpregions:
+    description: Physical Memory Protection (PMP)
+    required: true
+    type: int

--- a/dts/bindings/riscv/riscv,sifive-e24.yaml
+++ b/dts/bindings/riscv/riscv,sifive-e24.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2021 Gerson Fernando Budke <nandojve@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+description: SiFive E24 Standard Core CPU
+
+compatible: "riscv,sifive-e24"
+
+include: riscv,sifive.yaml

--- a/dts/bindings/riscv/riscv,sifive.yaml
+++ b/dts/bindings/riscv/riscv,sifive.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2021 Gerson Fernando Budke <nandojve@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+# Common fields for SiFive RISC-V CPUs
+
+include: riscv,cpus.yaml
+
+properties:
+    hardware-exec-breakpoint-count:
+      type: int
+      required: false
+      description: Number of hardware break points


### PR DESCRIPTION
~This add missing `timebase-frequency` property on `cpu.yaml` and it fix indentation.~
~The second part add~ Add `riscv,cpu.yaml` binding to be used as riscv cpu base. It introduces `riscv,sifive.yaml`, which open space to define specific properties for this vendor. The goal is have `sifive-e24` cpu binding available.
