### PR TITLE
Fix net/socket_select.h includes

### DIFF
--- a/include/net/socket_select.h
+++ b/include/net/socket_select.h
@@ -14,6 +14,7 @@
  * @{
  */
 
+#include <toolchain.h>
 #include <net/socket_types.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
Macros such as __syscall must be defined before use.