### PR TITLE
Bluetooth: adv: Fix wrong assert

### DIFF
--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -1373,7 +1373,7 @@ static void adv_timeout(struct k_work *work)
 #else
 	err = bt_le_adv_stop();
 #endif
-	__ASSERT(err != 0, "Limited Advertising timeout reached, "
+	__ASSERT(err == 0, "Limited Advertising timeout reached, "
 			   "failed to stop advertising");
 }
 


### PR DESCRIPTION
Fixes wrong ASSERT usage cause abnormal failed.

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>