### PR TITLE
manifest: update to remove CONFIG_USB in MCUboot sample

### DIFF
--- a/boards/arm/bl654_usb/Kconfig.defconfig
+++ b/boards/arm/bl654_usb/Kconfig.defconfig
@@ -23,18 +23,9 @@ config FLASH_LOAD_OFFSET
 	default 0x1000
 	depends on BOARD_HAS_NRF5_BOOTLOADER && !USE_DT_CODE_PARTITION
 
-if USB
-
-config USB_NRFX
-	default y
-
-config USB_DEVICE_STACK
-	default y
+if USB_DEVICE_STACK
 
 config USB_UART_CONSOLE
-	default y
-
-config UART_INTERRUPT_DRIVEN
 	default y
 
 config UART_LINE_CTRL
@@ -46,7 +37,7 @@ config UART_CONSOLE_ON_DEV_NAME
 config UART_SHELL_ON_DEV_NAME
 	default "CDC_ACM_0"
 
-endif # USB
+endif # USB_DEVICE_STACK
 
 if IEEE802154
 

--- a/boards/arm/bl654_usb/bl654_usb_defconfig
+++ b/boards/arm/bl654_usb/bl654_usb_defconfig
@@ -12,13 +12,12 @@ CONFIG_SERIAL=y
 
 # Enable console
 CONFIG_CONSOLE=y
-CONFIG_USB_UART_CONSOLE=y
 
 # Enable GPIO
 CONFIG_GPIO=y
 
 # Enable USB
-CONFIG_USB=y
+CONFIG_USB_DEVICE_STACK=y
 
 # Additional board options
 CONFIG_GPIO_AS_PINRESET=y

--- a/subsys/usb/Kconfig
+++ b/subsys/usb/Kconfig
@@ -3,12 +3,6 @@
 # Copyright (c) 2016 Wind River Systems, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-config USB
-	bool "Enable USB device stack (DEPRECATED)"
-	select USB_DEVICE_STACK
-	help
-	  Compatibility option for the external modules.
-
 menuconfig USB_DEVICE_STACK
 	bool "USB Device Support"
 	select USB_DEVICE_DRIVER

--- a/west.yml
+++ b/west.yml
@@ -158,7 +158,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 62b78ff2a2148490f91ee9a4b4d7a7ab8bbc4fd4
+      revision: 35576c623f3b64b2c496889f1959f6beb64e64bc
       path: bootloader/mcuboot
     - name: mcumgr
       revision: a15a953e35b0d3100893fd86a127c3e8b7e3257c


### PR DESCRIPTION
MCUboot version update to remove Kconfig option CONFIG_USB.

After the modules are adapted for the revised
USB device stack configuration, and it seems that
it was only necessary for MCUboot, we can finally
remove Kconfig option CONFIG_USB.