### PR TITLE
drivers: timer: implementation cleanups

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -357,20 +357,26 @@
 /drivers/spi/*b91*                        @yurvyn
 /drivers/spi/spi_rv32m1_lpspi*            @karstenkoenig
 /drivers/spi/*esp32*                      @glaubermaroto
-/drivers/timer/apic_timer.c               @dcpleung @nashif
+/drivers/timer/*apic*                     @dcpleung @nashif
 /drivers/timer/apic_tsc.c                 @andyross
-/drivers/timer/arm_arch_timer.c           @carlocaione
-/drivers/timer/cortex_m_systick.c         @anangl
-/drivers/timer/altera_avalon_timer_hal.c  @nashif
-/drivers/timer/riscv_machine_timer.c      @kgugala @pgielda
-/drivers/timer/ite_it8xxx2_timer.c        @ite
-/drivers/timer/xlnx_psttc_timer*          @wjliang @stephanosio
-/drivers/timer/cc13x2_cc26x2_rtc_timer.c  @vanti
-/drivers/timer/cavs_timer.c               @dcpleung
-/drivers/timer/stm32_lptim_timer.c        @FRASTM
-/drivers/timer/leon_gptimer.c             @martin-aberg
-/drivers/timer/rcar_cmt_timer.c           @julien-massot
-/drivers/timer/esp32c3_sys_timer.c        @uLipe
+/drivers/timer/*arm_arch*                 @carlocaione
+/drivers/timer/*cortex_m_systick*         @anangl
+/drivers/timer/*altera_avalon*            @nashif
+/drivers/timer/*riscv_machine*            @kgugala @pgielda
+/drivers/timer/*ite_it8xxx2*              @ite
+/drivers/timer/*xlnx_psttc*               @wjliang @stephanosio
+/drivers/timer/*cc13x2_cc26x2_rtc*        @vanti
+/drivers/timer/*cavs*                     @dcpleung
+/drivers/timer/*stm32_lptim*              @FRASTM
+/drivers/timer/*leon_gptimer*             @martin-aberg
+/drivers/timer/*rcar_cmt*                 @julien-massot
+/drivers/timer/*esp32c3_sys*              @uLipe
+/drivers/timer/*sam0_rtc*                 @bendiscz
+/drivers/timer/*arcv2*                    @ruuddw
+/drivers/timer/*xtensa*                   @dcpleung
+/drivers/timer/*rv32m1_lptmr*             @mbolivar
+/drivers/timer/*nrf_rtc*                  @anangl
+/drivers/timer/*hpet*                     @dcpleung
 /drivers/usb/                             @jfischer-no
 /drivers/usb/device/usb_dc_stm32.c        @ydamigos @loicpoulain
 /drivers/video/                           @loicpoulain

--- a/arch/arm/core/aarch32/cortex_m/vector_table.S
+++ b/arch/arm/core/aarch32/cortex_m/vector_table.S
@@ -80,14 +80,12 @@ SECTION_SUBSEC_FUNC(exc_vector_table,_vector_table_section,_vector_table)
     .word z_arm_exc_spurious
 #endif
 #if defined(CONFIG_CPU_CORTEX_M_HAS_SYSTICK)
-#if defined(CONFIG_SYS_CLOCK_EXISTS)
-    /* Install sys_clock_isr even if CORTEX_M_SYSTICK is not set
-     * (e.g. to support out-of-tree SysTick-based timer drivers).
-     */
+#if defined(CONFIG_SYS_CLOCK_EXISTS) && \
+    defined(CONFIG_CORTEX_M_SYSTICK_INSTALL_ISR)
     .word sys_clock_isr
 #else
     .word z_arm_exc_spurious
-#endif /* CONFIG_SYS_CLOCK_EXISTS */
+#endif /* CONFIG_SYS_CLOCK_EXISTS && CONFIG_CORTEX_M_SYSTICK_INSTALL_ISR */
 #else
     .word 0
 #endif /* CONFIG_CPU_CORTEX_M_HAS_SYSTICK */

--- a/drivers/timer/Kconfig
+++ b/drivers/timer/Kconfig
@@ -7,385 +7,18 @@
 
 menu "Timer Drivers"
 
-config TIMER_HAS_64BIT_CYCLE_COUNTER
-	bool
-	help
-	  When this option is true, the k_cycle_get_64() call is
-	  available to provide values from a 64-bit cycle counter.
-
-menuconfig APIC_TIMER
-	bool "New local APIC timer"
-	depends on X86
-	depends on LOAPIC
-	select TICKLESS_CAPABLE
-	help
-	  Use the x86 local APIC in one-shot mode as the system time
-	  source.  NOTE: this probably isn't what you want except on
-	  older or idiosyncratic hardware (or environments like qemu
-	  without complete APIC emulation).  Modern hardware will work
-	  better with CONFIG_APIC_TSC_DEADLINE_TIMER.
-
-if APIC_TIMER
-
-config APIC_TIMER_IRQ
-	int "Local APIC timer IRQ"
-	default 24
-	help
-	  This option specifies the IRQ used by the local APIC timer.
-	  Note: this MUST be set to the index immediately after the
-	  last IO-APIC IRQ (the timer is the first entry in the APIC
-	  local vector table).  This footgun is not intended to be
-	  user-configurable and almost certainly should be managed via
-	  a different mechanism.
-
-config APIC_TIMER_TSC
-	bool "Use invariant TSC for sys_clock_cycle_get_32()"
-	select TIMER_HAS_64BIT_CYCLE_COUNTER
-	help
-	  If your CPU supports invariant TSC, and you know the ratio of the
-	  TSC frequency to CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC (the local APIC
-	  timer frequency), then enable this for a much faster and more
-	  accurate sys_clock_cycle_get_32().
-
-if APIC_TIMER_TSC
-
-config APIC_TIMER_TSC_N
-	int "TSC to local APIC timer frequency multiplier (N)"
-	default 1
-
-config APIC_TIMER_TSC_M
-	int "TSC to local APIC timer frequency divisor (M)"
-	default 1
-
-endif # APIC_TIMER_TSC
-
-endif # APIC_TIMER
-
-config APIC_TSC_DEADLINE_TIMER
-	bool "Even newer APIC timer using TSC deadline mode"
-	depends on X86
-	select LOAPIC
-	select TICKLESS_CAPABLE
-	help
-	  Extremely simple timer driver based the local APIC TSC
-	  deadline capability.  The use of a free-running 64 bit
-	  counter with comparator eliminates almost all edge cases
-	  from the handling, and the near-instruction-cycle resolution
-	  permits effectively unlimited precision where needed (the
-	  limit becomes the CPU time taken to execute the timing
-	  logic). SMP-safe and very fast, this should be the obvious
-	  choice for any x86 device with invariant TSC and TSC
-	  deadline capability.
-
-config APIC_TIMER_IRQ_PRIORITY
-	int "Local APIC timer interrupt priority"
-	depends on APIC_TIMER || APIC_TSC_DEADLINE_TIMER
-	default 4
-	help
-	  This option specifies the interrupt priority used by the
-	  local APIC timer.
-
-config HPET_TIMER
-	bool "HPET timer"
-	select IOAPIC if X86
-	select LOAPIC if X86
-	imply TIMER_READS_ITS_FREQUENCY_AT_RUNTIME
-	select TICKLESS_CAPABLE
-	select TIMER_HAS_64BIT_CYCLE_COUNTER
-	help
-	  This option selects High Precision Event Timer (HPET) as a
-	  system timer.
-
-menuconfig ARCV2_TIMER
-	bool "ARC Timer"
-	default y
-	depends on ARC
-	select TICKLESS_CAPABLE
-	help
-	  This module implements a kernel device driver for the ARCv2 processor timer 0
-	  and provides the standard "system clock driver" interfaces.
-
-config ARCV2_TIMER_IRQ_PRIORITY
-	int "ARC timer interrupt priority"
-	default 0
-	depends on ARCV2_TIMER
-	help
-	  This option specifies the IRQ priority used by the ARC timer. Lower
-	  values have higher priority.
-
-config ARM_ARCH_TIMER
-	bool "ARM architected timer"
-	depends on GIC
-	select ARCH_HAS_CUSTOM_BUSY_WAIT
-	select TICKLESS_CAPABLE
-	select TIMER_HAS_64BIT_CYCLE_COUNTER
-	help
-	  This module implements a kernel device driver for the ARM architected
-	  timer which provides per-cpu timers attached to a GIC to deliver its
-	  per-processor interrupts via PPIs.
-
-DT_COMPAT_ARM_V6M_SYSTICK := arm,armv6m-systick
-DT_COMPAT_ARM_V7M_SYSTICK := arm,armv7m-systick
-DT_COMPAT_ARM_V8M_SYSTICK := arm,armv8m-systick
-DT_COMPAT_ARM_V8_1M_SYSTICK := arm,armv8.1m-systick
-
-config ARM_ARCH_TIMER_ERRATUM_740657
-	bool "ARM architected timer is affected by ARM erratum 740657"
-	depends on ARM_ARCH_TIMER
-	help
-	  This option indicates that the ARM architected timer as implemented
-	  in the target hardware is affected by the ARM erratum 740657 (comp.
-	  ARM Cortex-A9 processors Software Developers Errata Notice, ARM
-	  document ID032315) which leads to an additional, spurious interrupt
-	  indication upon every actual timer interrupt. This option activates
-	  the workaround for the erratum within the timer driver.
-
-config CORTEX_M_SYSTICK
-	bool "Cortex-M SYSTICK timer"
-	depends on CPU_CORTEX_M_HAS_SYSTICK
-	default $(dt_compat_enabled,$(DT_COMPAT_ARM_V6M_SYSTICK)) || \
-		$(dt_compat_enabled,$(DT_COMPAT_ARM_V7M_SYSTICK)) || \
-		$(dt_compat_enabled,$(DT_COMPAT_ARM_V8M_SYSTICK)) || \
-		$(dt_compat_enabled,$(DT_COMPAT_ARM_V8_1M_SYSTICK))
-	select TICKLESS_CAPABLE
-	help
-	  This module implements a kernel device driver for the Cortex-M processor
-	  SYSTICK timer and provides the standard "system clock driver" interfaces.
-
-config ALTERA_AVALON_TIMER
-	bool "Altera Avalon Interval Timer"
-	default y
-	depends on NIOS2
-	help
-	  This module implements a kernel device driver for the Altera Avalon
-	  Interval Timer as described in the Embedded IP documentation, for use
-	  with Nios II and possibly other Altera soft CPUs. It provides the
-	  standard "system clock driver" interfaces.
-
-config ITE_IT8XXX2_TIMER
-	bool "ITE it8xxx2 timer driver"
-	depends on SOC_IT8XXX2
-	select TICKLESS_CAPABLE
-	help
-	  This module implements a kernel device driver for the ITE it8xxx2
-	  HW timer model
-
-config NRF_RTC_TIMER
-	bool "nRF Real Time Counter (NRF_RTC1) Timer"
-	depends on CLOCK_CONTROL
-	depends on SOC_COMPATIBLE_NRF
-	select TICKLESS_CAPABLE
-	select NRF_HW_RTC1_RESERVED
-	help
-	  This module implements a kernel device driver for the nRF Real Time
-	  Counter NRF_RTC1 and provides the standard "system clock driver"
-	  interfaces.
-
-if NRF_RTC_TIMER
-
-config NRF_RTC_TIMER_USER_CHAN_COUNT
-	int "Additional channels that can be used"
-	default 0
-	help
-	  Use nrf_rtc_timer.h API. Driver is not managing allocation of channels.
-
-choice
-	prompt "Clock startup policy"
-	default SYSTEM_CLOCK_WAIT_FOR_STABILITY
-
-config SYSTEM_CLOCK_NO_WAIT
-	bool "No wait"
-	help
-	  System clock source is initiated but does not wait for clock readiness.
-	  When this option is picked, system clock may not be ready when code relying
-	  on kernel API is executed. Requested timeouts will be prolonged by the
-	  remaining startup time.
-
-config SYSTEM_CLOCK_WAIT_FOR_AVAILABILITY
-	bool "Wait for availability"
-	help
-	  System clock source initialization waits until clock is available. In some
-	  systems, clock initially runs from less accurate source which has faster
-	  startup time and then seamlessly switches to the target clock source when
-	  it is ready. When this option is picked, system clock is available after
-	  system clock driver initialization but it may be less accurate. Option is
-	  equivalent to waiting for stability if clock source does not have
-	  intermediate state.
-
-config SYSTEM_CLOCK_WAIT_FOR_STABILITY
-	bool "Wait for stability"
-	help
-	  System clock source initialization waits until clock is stable. When this
-	  option is picked, system clock is available and stable after system clock
-	  driver initialization.
-
-endchoice
-
-endif # NRF_RTC_TIMER
-
-source "drivers/timer/Kconfig.stm32_lptim"
-
-config RISCV_MACHINE_TIMER
-	bool "RISCV Machine Timer"
-	depends on SOC_FAMILY_RISCV_PRIVILEGE
-	select TICKLESS_CAPABLE
-	select TIMER_HAS_64BIT_CYCLE_COUNTER
-	help
-	  This module implements a kernel device driver for the generic RISCV machine
-	  timer driver. It provides the standard "system clock driver" interfaces.
-
-config RV32M1_LPTMR_TIMER
-	bool "RV32M1 LPTMR system timer driver"
-	default y
-	depends on SOC_OPENISA_RV32M1_RISCV32
-	depends on RV32M1_INTMUX
-	help
-	  This module implements a kernel device driver for using the LPTMR
-	  peripheral as the system clock. It provides the standard "system clock
-	  driver" interfaces.
-
-config LITEX_TIMER
-	bool "LiteX Timer"
-	default y
-	depends on SOC_RISCV32_LITEX_VEXRISCV
-	select TIMER_HAS_64BIT_CYCLE_COUNTER
-	help
-	  This module implements a kernel device driver for LiteX Timer.
-
-config NATIVE_POSIX_TIMER
-	bool "(POSIX) native_posix timer driver"
-	default y
-	depends on BOARD_NATIVE_POSIX
-	select TICKLESS_CAPABLE
-	select TIMER_HAS_64BIT_CYCLE_COUNTER
-	help
-	  This module implements a kernel device driver for the native_posix HW timer
-	  model
-
-config XTENSA_TIMER
-	bool "Xtensa timer support"
-	depends on XTENSA
-	default y
-	select TICKLESS_CAPABLE
-	help
-	  Enables a system timer driver for Xtensa based on the CCOUNT
-	  and CCOMPARE special registers.
-
-config ESP32C3_SYS_TIMER
-	bool "ESP32C3 sys-timer support"
-	depends on SOC_ESP32C3
-	default y
-	select TICKLESS_CAPABLE
-	select TIMER_HAS_64BIT_CYCLE_COUNTER
-	help
-	  This option enables the system timer driver for the Espressif ESP32C3
-	  and provides the standard "system clock driver" interface.
-
-config XTENSA_TIMER_ID
-	int "System timer CCOMPAREn register index"
-	default 1
-	depends on XTENSA_TIMER
-	help
-	  Index of the CCOMPARE register (and associated interrupt)
-	  used for the system timer.  Xtensa CPUs have hard-configured
-	  interrupt priorities associated with each timer, and some of
-	  them can be unmaskable (and thus not usable by OS code that
-	  need synchronization, like the timer subsystem!).  Choose
-	  carefully.  Generally you want the timer with the highest
-	  priority maskable interrupt.
-
-config SAM0_RTC_TIMER
-	bool "Atmel SAM0 series RTC timer"
-	depends on SOC_FAMILY_SAM0
-	select TICKLESS_CAPABLE
-	help
-	  This module implements a kernel device driver for the Atmel SAM0
-	  series Real Time Counter and provides the standard "system clock
-	  driver" interfaces.
-
-config MCHP_XEC_RTOS_TIMER
-	bool "Microchip XEC series RTOS timer"
-	depends on SOC_FAMILY_MEC
-	select TICKLESS_CAPABLE
-	help
-	  This module implements a kernel device driver for the Microchip
-	  XEC series RTOS timer and provides the standard "system clock
-	  driver" interfaces.
-
-config CC13X2_CC26X2_RTC_TIMER
-	bool "TI SimpleLink CC13x2/CC26x2 RTC timer"
-	depends on SOC_SERIES_CC13X2_CC26X2
-	select TICKLESS_CAPABLE
-	select TIMER_HAS_64BIT_CYCLE_COUNTER
-	help
-	  This module implements a kernel device driver for the TI SimpleLink
-	  CC13X2_CC26X2 series Real Time Counter and provides the standard
-	  "system clock driver" interfaces.
-
-config RCAR_CMT_TIMER
-	bool "Renesas RCar cmt timer"
-	default y
-	depends on SOC_SERIES_RCAR_GEN3
-	help
-	  This module implements a kernel device driver for the Renesas RCAR
-	  platform provides the standard "system clock driver" interfaces.
-	  If unchecked, no timer will be used.
-
-config XLNX_PSTTC_TIMER
-	bool "Xilinx PS ttc timer support"
-	default y
-	depends on SOC_XILINX_ZYNQMP
-	select TICKLESS_CAPABLE
-	help
-	  This module implements a kernel device driver for the Xilinx ZynqMP
-	  platform provides the standard "system clock driver" interfaces.
-	  If unchecked, no timer will be used.
-
-config XLNX_PSTTC_TIMER_INDEX
-	int "Xilinx PS ttc timer index"
-	range 0 3
-	default 0
-	depends on XLNX_PSTTC_TIMER
-	help
-	  This is the index of TTC timer picked to provide system clock.
-
-config CAVS_TIMER
-	bool "CAVS DSP Wall Clock Timer on Intel SoC"
-	depends on CAVS_ICTL
-	select TICKLESS_CAPABLE
-	select TIMER_HAS_64BIT_CYCLE_COUNTER
-	help
-	  The DSP wall clock timer is a timer driven directly by
-	  external oscillator and is external to the CPU core(s).
-	  It is not as fast as the internal core clock, but provides
-	  a common and synchronized counter for all CPU cores (which
-	  is useful for SMP).
-
-config LEON_GPTIMER
-	bool "LEON timer"
-	depends on SOC_SPARC_LEON
-	select DYNAMIC_INTERRUPTS
-	help
-	  This module implements a kernel device driver for the GRLIB
-	  GPTIMER which is common in LEON systems.
-
-config NPCX_ITIM_TIMER
-	bool "Nuvoton NPCX series internal 64/32-bit timers"
-	default y
-	depends on SOC_FAMILY_NPCX
-	select TICKLESS_CAPABLE
-	select TIMER_HAS_64BIT_CYCLE_COUNTER
-	help
-	  This module implements a kernel device driver for the Nuvoton NPCX
-	  series internal 64/32-bit timers and provides the standard "system
-	  clock driver" interfaces.
-
 config SYSTEM_CLOCK_DISABLE
 	bool "API to disable system clock"
 	help
 	  This option enables the sys_clock_disable() API in the kernel. It is
 	  needed by some subsystems (which will automatically select it), but is
 	  rarely needed by applications.
+
+config TIMER_HAS_64BIT_CYCLE_COUNTER
+	bool
+	help
+	  When this option is true, the k_cycle_get_64() call is
+	  available to provide values from a 64-bit cycle counter.
 
 config TIMER_READS_ITS_FREQUENCY_AT_RUNTIME
 	bool "Timer queries its hardware to find its frequency at runtime"
@@ -422,24 +55,30 @@ config TICKLESS_CAPABLE
 	  sys_clock_announce() (really, not to produce an interrupt at
 	  all) until the specified expiration.
 
-DT_COMPAT_NXP_OS_TIMER := nxp,os-timer
-
-config MCUX_OS_TIMER
-	bool "MCUX OS Event timer"
-	depends on HAS_MCUX_OS_TIMER
-	default $(dt_compat_enabled,$(DT_COMPAT_NXP_OS_TIMER))
-	select TICKLESS_CAPABLE
-	select TIMER_HAS_64BIT_CYCLE_COUNTER
-	help
-	  This module implements a kernel device driver for the NXP OS
-	  event timer and provides the standard "system clock driver" interfaces.
-
-config MCUX_LPTMR_TIMER
-	bool "MCUX LPTMR timer"
-	depends on HAS_MCUX_LPTMR && !COUNTER_MCUX_LPTMR
-	help
-	  This module implements a kernel device driver for the NXP MCUX Low
-	  Power Timer (LPTMR) and provides the standard "system clock driver"
-	  interfaces.
+source "drivers/timer/Kconfig.altera_avalon"
+source "drivers/timer/Kconfig.apic"
+source "drivers/timer/Kconfig.arcv2"
+source "drivers/timer/Kconfig.arm_arch"
+source "drivers/timer/Kconfig.cavs"
+source "drivers/timer/Kconfig.cc13x2_cc26x2_rtc"
+source "drivers/timer/Kconfig.cortex_m_systick"
+source "drivers/timer/Kconfig.esp32c3_sys"
+source "drivers/timer/Kconfig.hpet"
+source "drivers/timer/Kconfig.ite_it8xxx2"
+source "drivers/timer/Kconfig.leon_gptimer"
+source "drivers/timer/Kconfig.litex"
+source "drivers/timer/Kconfig.mchp_xec_rtos"
+source "drivers/timer/Kconfig.mcux_lptmr"
+source "drivers/timer/Kconfig.mcux_os"
+source "drivers/timer/Kconfig.native_posix"
+source "drivers/timer/Kconfig.npcx_itim"
+source "drivers/timer/Kconfig.nrf_rtc"
+source "drivers/timer/Kconfig.rcar_cmt"
+source "drivers/timer/Kconfig.riscv_machine"
+source "drivers/timer/Kconfig.rv32m1_lptmr"
+source "drivers/timer/Kconfig.sam0_rtc"
+source "drivers/timer/Kconfig.stm32_lptim"
+source "drivers/timer/Kconfig.xlnx_psttc"
+source "drivers/timer/Kconfig.xtensa"
 
 endmenu

--- a/drivers/timer/Kconfig
+++ b/drivers/timer/Kconfig
@@ -7,13 +7,6 @@
 
 menu "Timer Drivers"
 
-config SYSTEM_CLOCK_DISABLE
-	bool "API to disable system clock"
-	help
-	  This option enables the sys_clock_disable() API in the kernel. It is
-	  needed by some subsystems (which will automatically select it), but is
-	  rarely needed by applications.
-
 config TIMER_HAS_64BIT_CYCLE_COUNTER
 	bool
 	help
@@ -54,6 +47,12 @@ config TICKLESS_CAPABLE
 	  one should be expected not to produce a call to
 	  sys_clock_announce() (really, not to produce an interrupt at
 	  all) until the specified expiration.
+
+config SYSTEM_TIMER_HAS_DISABLE_SUPPORT
+	bool
+	help
+	  This option should be selected by drivers implementing support for
+	  sys_clock_disable() API.
 
 source "drivers/timer/Kconfig.altera_avalon"
 source "drivers/timer/Kconfig.apic"

--- a/drivers/timer/Kconfig.altera_avalon
+++ b/drivers/timer/Kconfig.altera_avalon
@@ -1,0 +1,14 @@
+# Copyright (c) 2014-2015 Wind River Systems, Inc.
+# Copyright (c) 2016 Cadence Design Systems, Inc.
+# Copyright (c) 2019 Intel Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+config ALTERA_AVALON_TIMER
+	bool "Altera Avalon Interval Timer"
+	default y
+	depends on NIOS2
+	help
+	  This module implements a kernel device driver for the Altera Avalon
+	  Interval Timer as described in the Embedded IP documentation, for use
+	  with Nios II and possibly other Altera soft CPUs. It provides the
+	  standard "system clock driver" interfaces.

--- a/drivers/timer/Kconfig.apic
+++ b/drivers/timer/Kconfig.apic
@@ -1,0 +1,76 @@
+# Copyright (c) 2014-2015 Wind River Systems, Inc.
+# Copyright (c) 2016 Cadence Design Systems, Inc.
+# Copyright (c) 2019 Intel Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+menuconfig APIC_TIMER
+	bool "New local APIC timer"
+	depends on X86
+	depends on LOAPIC
+	select TICKLESS_CAPABLE
+	help
+	  Use the x86 local APIC in one-shot mode as the system time
+	  source.  NOTE: this probably isn't what you want except on
+	  older or idiosyncratic hardware (or environments like qemu
+	  without complete APIC emulation).  Modern hardware will work
+	  better with CONFIG_APIC_TSC_DEADLINE_TIMER.
+
+if APIC_TIMER
+
+config APIC_TIMER_IRQ
+	int "Local APIC timer IRQ"
+	default 24
+	help
+	  This option specifies the IRQ used by the local APIC timer.
+	  Note: this MUST be set to the index immediately after the
+	  last IO-APIC IRQ (the timer is the first entry in the APIC
+	  local vector table).  This footgun is not intended to be
+	  user-configurable and almost certainly should be managed via
+	  a different mechanism.
+
+config APIC_TIMER_TSC
+	bool "Use invariant TSC for sys_clock_cycle_get_32()"
+	select TIMER_HAS_64BIT_CYCLE_COUNTER
+	help
+	  If your CPU supports invariant TSC, and you know the ratio of the
+	  TSC frequency to CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC (the local APIC
+	  timer frequency), then enable this for a much faster and more
+	  accurate sys_clock_cycle_get_32().
+
+if APIC_TIMER_TSC
+
+config APIC_TIMER_TSC_N
+	int "TSC to local APIC timer frequency multiplier (N)"
+	default 1
+
+config APIC_TIMER_TSC_M
+	int "TSC to local APIC timer frequency divisor (M)"
+	default 1
+
+endif # APIC_TIMER_TSC
+
+endif # APIC_TIMER
+
+config APIC_TSC_DEADLINE_TIMER
+	bool "Even newer APIC timer using TSC deadline mode"
+	depends on X86
+	select LOAPIC
+	select TICKLESS_CAPABLE
+	help
+	  Extremely simple timer driver based the local APIC TSC
+	  deadline capability.  The use of a free-running 64 bit
+	  counter with comparator eliminates almost all edge cases
+	  from the handling, and the near-instruction-cycle resolution
+	  permits effectively unlimited precision where needed (the
+	  limit becomes the CPU time taken to execute the timing
+	  logic). SMP-safe and very fast, this should be the obvious
+	  choice for any x86 device with invariant TSC and TSC
+	  deadline capability.
+
+config APIC_TIMER_IRQ_PRIORITY
+	int "Local APIC timer interrupt priority"
+	depends on APIC_TIMER || APIC_TSC_DEADLINE_TIMER
+	default 4
+	help
+	  This option specifies the interrupt priority used by the
+	  local APIC timer.

--- a/drivers/timer/Kconfig.arcv2
+++ b/drivers/timer/Kconfig.arcv2
@@ -1,0 +1,21 @@
+# Copyright (c) 2014-2015 Wind River Systems, Inc.
+# Copyright (c) 2016 Cadence Design Systems, Inc.
+# Copyright (c) 2019 Intel Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+menuconfig ARCV2_TIMER
+	bool "ARC Timer"
+	default y
+	depends on ARC
+	select TICKLESS_CAPABLE
+	help
+	  This module implements a kernel device driver for the ARCv2 processor timer 0
+	  and provides the standard "system clock driver" interfaces.
+
+config ARCV2_TIMER_IRQ_PRIORITY
+	int "ARC timer interrupt priority"
+	default 0
+	depends on ARCV2_TIMER
+	help
+	  This option specifies the IRQ priority used by the ARC timer. Lower
+	  values have higher priority.

--- a/drivers/timer/Kconfig.arm_arch
+++ b/drivers/timer/Kconfig.arm_arch
@@ -1,0 +1,26 @@
+# Copyright (c) 2014-2015 Wind River Systems, Inc.
+# Copyright (c) 2016 Cadence Design Systems, Inc.
+# Copyright (c) 2019 Intel Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+config ARM_ARCH_TIMER
+	bool "ARM architected timer"
+	depends on GIC
+	select ARCH_HAS_CUSTOM_BUSY_WAIT
+	select TICKLESS_CAPABLE
+	select TIMER_HAS_64BIT_CYCLE_COUNTER
+	help
+	  This module implements a kernel device driver for the ARM architected
+	  timer which provides per-cpu timers attached to a GIC to deliver its
+	  per-processor interrupts via PPIs.
+
+config ARM_ARCH_TIMER_ERRATUM_740657
+	bool "ARM architected timer is affected by ARM erratum 740657"
+	depends on ARM_ARCH_TIMER
+	help
+	  This option indicates that the ARM architected timer as implemented
+	  in the target hardware is affected by the ARM erratum 740657 (comp.
+	  ARM Cortex-A9 processors Software Developers Errata Notice, ARM
+	  document ID032315) which leads to an additional, spurious interrupt
+	  indication upon every actual timer interrupt. This option activates
+	  the workaround for the erratum within the timer driver.

--- a/drivers/timer/Kconfig.cavs
+++ b/drivers/timer/Kconfig.cavs
@@ -1,0 +1,16 @@
+# Copyright (c) 2014-2015 Wind River Systems, Inc.
+# Copyright (c) 2016 Cadence Design Systems, Inc.
+# Copyright (c) 2019 Intel Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+config CAVS_TIMER
+	bool "CAVS DSP Wall Clock Timer on Intel SoC"
+	depends on CAVS_ICTL
+	select TICKLESS_CAPABLE
+	select TIMER_HAS_64BIT_CYCLE_COUNTER
+	help
+	  The DSP wall clock timer is a timer driven directly by
+	  external oscillator and is external to the CPU core(s).
+	  It is not as fast as the internal core clock, but provides
+	  a common and synchronized counter for all CPU cores (which
+	  is useful for SMP).

--- a/drivers/timer/Kconfig.cc13x2_cc26x2_rtc
+++ b/drivers/timer/Kconfig.cc13x2_cc26x2_rtc
@@ -1,0 +1,14 @@
+# Copyright (c) 2014-2015 Wind River Systems, Inc.
+# Copyright (c) 2016 Cadence Design Systems, Inc.
+# Copyright (c) 2019 Intel Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+config CC13X2_CC26X2_RTC_TIMER
+	bool "TI SimpleLink CC13x2/CC26x2 RTC timer"
+	depends on SOC_SERIES_CC13X2_CC26X2
+	select TICKLESS_CAPABLE
+	select TIMER_HAS_64BIT_CYCLE_COUNTER
+	help
+	  This module implements a kernel device driver for the TI SimpleLink
+	  CC13X2_CC26X2 series Real Time Counter and provides the standard
+	  "system clock driver" interfaces.

--- a/drivers/timer/Kconfig.cortex_m_systick
+++ b/drivers/timer/Kconfig.cortex_m_systick
@@ -17,6 +17,14 @@ config CORTEX_M_SYSTICK
 		$(dt_compat_enabled,$(DT_COMPAT_ARM_V8_1M_SYSTICK))
 	select TICKLESS_CAPABLE
 	select SYSTEM_TIMER_HAS_DISABLE_SUPPORT
+	select CORTEX_M_SYSTICK_INSTALL_ISR
 	help
 	  This module implements a kernel device driver for the Cortex-M processor
 	  SYSTICK timer and provides the standard "system clock driver" interfaces.
+
+config CORTEX_M_SYSTICK_INSTALL_ISR
+	bool
+	depends on CPU_CORTEX_M_HAS_SYSTICK
+	help
+	  This option should be selected by SysTick-based drivers so that the
+	  sys_clock_isr() function is installed.

--- a/drivers/timer/Kconfig.cortex_m_systick
+++ b/drivers/timer/Kconfig.cortex_m_systick
@@ -1,0 +1,21 @@
+# Copyright (c) 2014-2015 Wind River Systems, Inc.
+# Copyright (c) 2016 Cadence Design Systems, Inc.
+# Copyright (c) 2019 Intel Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+DT_COMPAT_ARM_V6M_SYSTICK := arm,armv6m-systick
+DT_COMPAT_ARM_V7M_SYSTICK := arm,armv7m-systick
+DT_COMPAT_ARM_V8M_SYSTICK := arm,armv8m-systick
+DT_COMPAT_ARM_V8_1M_SYSTICK := arm,armv8.1m-systick
+
+config CORTEX_M_SYSTICK
+	bool "Cortex-M SYSTICK timer"
+	depends on CPU_CORTEX_M_HAS_SYSTICK
+	default $(dt_compat_enabled,$(DT_COMPAT_ARM_V6M_SYSTICK)) || \
+		$(dt_compat_enabled,$(DT_COMPAT_ARM_V7M_SYSTICK)) || \
+		$(dt_compat_enabled,$(DT_COMPAT_ARM_V8M_SYSTICK)) || \
+		$(dt_compat_enabled,$(DT_COMPAT_ARM_V8_1M_SYSTICK))
+	select TICKLESS_CAPABLE
+	help
+	  This module implements a kernel device driver for the Cortex-M processor
+	  SYSTICK timer and provides the standard "system clock driver" interfaces.

--- a/drivers/timer/Kconfig.cortex_m_systick
+++ b/drivers/timer/Kconfig.cortex_m_systick
@@ -16,6 +16,7 @@ config CORTEX_M_SYSTICK
 		$(dt_compat_enabled,$(DT_COMPAT_ARM_V8M_SYSTICK)) || \
 		$(dt_compat_enabled,$(DT_COMPAT_ARM_V8_1M_SYSTICK))
 	select TICKLESS_CAPABLE
+	select SYSTEM_TIMER_HAS_DISABLE_SUPPORT
 	help
 	  This module implements a kernel device driver for the Cortex-M processor
 	  SYSTICK timer and provides the standard "system clock driver" interfaces.

--- a/drivers/timer/Kconfig.esp32c3_sys
+++ b/drivers/timer/Kconfig.esp32c3_sys
@@ -1,0 +1,14 @@
+# Copyright (c) 2014-2015 Wind River Systems, Inc.
+# Copyright (c) 2016 Cadence Design Systems, Inc.
+# Copyright (c) 2019 Intel Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+config ESP32C3_SYS_TIMER
+	bool "ESP32C3 sys-timer support"
+	depends on SOC_ESP32C3
+	default y
+	select TICKLESS_CAPABLE
+	select TIMER_HAS_64BIT_CYCLE_COUNTER
+	help
+	  This option enables the system timer driver for the Espressif ESP32C3
+	  and provides the standard "system clock driver" interface.

--- a/drivers/timer/Kconfig.hpet
+++ b/drivers/timer/Kconfig.hpet
@@ -1,0 +1,15 @@
+# Copyright (c) 2014-2015 Wind River Systems, Inc.
+# Copyright (c) 2016 Cadence Design Systems, Inc.
+# Copyright (c) 2019 Intel Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+config HPET_TIMER
+	bool "HPET timer"
+	select IOAPIC if X86
+	select LOAPIC if X86
+	imply TIMER_READS_ITS_FREQUENCY_AT_RUNTIME
+	select TICKLESS_CAPABLE
+	select TIMER_HAS_64BIT_CYCLE_COUNTER
+	help
+	  This option selects High Precision Event Timer (HPET) as a
+	  system timer.

--- a/drivers/timer/Kconfig.ite_it8xxx2
+++ b/drivers/timer/Kconfig.ite_it8xxx2
@@ -1,0 +1,12 @@
+# Copyright (c) 2014-2015 Wind River Systems, Inc.
+# Copyright (c) 2016 Cadence Design Systems, Inc.
+# Copyright (c) 2019 Intel Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+config ITE_IT8XXX2_TIMER
+	bool "ITE it8xxx2 timer driver"
+	depends on SOC_IT8XXX2
+	select TICKLESS_CAPABLE
+	help
+	  This module implements a kernel device driver for the ITE it8xxx2
+	  HW timer model

--- a/drivers/timer/Kconfig.leon_gptimer
+++ b/drivers/timer/Kconfig.leon_gptimer
@@ -1,0 +1,12 @@
+# Copyright (c) 2014-2015 Wind River Systems, Inc.
+# Copyright (c) 2016 Cadence Design Systems, Inc.
+# Copyright (c) 2019 Intel Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+config LEON_GPTIMER
+	bool "LEON timer"
+	depends on SOC_SPARC_LEON
+	select DYNAMIC_INTERRUPTS
+	help
+	  This module implements a kernel device driver for the GRLIB
+	  GPTIMER which is common in LEON systems.

--- a/drivers/timer/Kconfig.litex
+++ b/drivers/timer/Kconfig.litex
@@ -1,0 +1,12 @@
+# Copyright (c) 2014-2015 Wind River Systems, Inc.
+# Copyright (c) 2016 Cadence Design Systems, Inc.
+# Copyright (c) 2019 Intel Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+config LITEX_TIMER
+	bool "LiteX Timer"
+	default y
+	depends on SOC_RISCV32_LITEX_VEXRISCV
+	select TIMER_HAS_64BIT_CYCLE_COUNTER
+	help
+	  This module implements a kernel device driver for LiteX Timer.

--- a/drivers/timer/Kconfig.mchp_xec_rtos
+++ b/drivers/timer/Kconfig.mchp_xec_rtos
@@ -7,6 +7,7 @@ config MCHP_XEC_RTOS_TIMER
 	bool "Microchip XEC series RTOS timer"
 	depends on SOC_FAMILY_MEC
 	select TICKLESS_CAPABLE
+	select SYSTEM_TIMER_HAS_DISABLE_SUPPORT
 	help
 	  This module implements a kernel device driver for the Microchip
 	  XEC series RTOS timer and provides the standard "system clock

--- a/drivers/timer/Kconfig.mchp_xec_rtos
+++ b/drivers/timer/Kconfig.mchp_xec_rtos
@@ -1,0 +1,13 @@
+# Copyright (c) 2014-2015 Wind River Systems, Inc.
+# Copyright (c) 2016 Cadence Design Systems, Inc.
+# Copyright (c) 2019 Intel Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+config MCHP_XEC_RTOS_TIMER
+	bool "Microchip XEC series RTOS timer"
+	depends on SOC_FAMILY_MEC
+	select TICKLESS_CAPABLE
+	help
+	  This module implements a kernel device driver for the Microchip
+	  XEC series RTOS timer and provides the standard "system clock
+	  driver" interfaces.

--- a/drivers/timer/Kconfig.mcux_lptmr
+++ b/drivers/timer/Kconfig.mcux_lptmr
@@ -6,6 +6,7 @@
 config MCUX_LPTMR_TIMER
 	bool "MCUX LPTMR timer"
 	depends on HAS_MCUX_LPTMR && !COUNTER_MCUX_LPTMR
+	select SYSTEM_TIMER_HAS_DISABLE_SUPPORT
 	help
 	  This module implements a kernel device driver for the NXP MCUX Low
 	  Power Timer (LPTMR) and provides the standard "system clock driver"

--- a/drivers/timer/Kconfig.mcux_lptmr
+++ b/drivers/timer/Kconfig.mcux_lptmr
@@ -1,0 +1,12 @@
+# Copyright (c) 2014-2015 Wind River Systems, Inc.
+# Copyright (c) 2016 Cadence Design Systems, Inc.
+# Copyright (c) 2019 Intel Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+config MCUX_LPTMR_TIMER
+	bool "MCUX LPTMR timer"
+	depends on HAS_MCUX_LPTMR && !COUNTER_MCUX_LPTMR
+	help
+	  This module implements a kernel device driver for the NXP MCUX Low
+	  Power Timer (LPTMR) and provides the standard "system clock driver"
+	  interfaces.

--- a/drivers/timer/Kconfig.mcux_os
+++ b/drivers/timer/Kconfig.mcux_os
@@ -1,0 +1,15 @@
+# Copyright (c) 2014-2015 Wind River Systems, Inc.
+# Copyright (c) 2016 Cadence Design Systems, Inc.
+# Copyright (c) 2019 Intel Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+DT_COMPAT_NXP_OS_TIMER := nxp,os-timer
+
+config MCUX_OS_TIMER
+	bool "MCUX OS Event timer"
+	depends on HAS_MCUX_OS_TIMER
+	default $(dt_compat_enabled,$(DT_COMPAT_NXP_OS_TIMER))
+	select TICKLESS_CAPABLE
+	help
+	  This module implements a kernel device driver for the NXP OS
+	  event timer and provides the standard "system clock driver" interfaces.

--- a/drivers/timer/Kconfig.native_posix
+++ b/drivers/timer/Kconfig.native_posix
@@ -9,6 +9,7 @@ config NATIVE_POSIX_TIMER
 	depends on BOARD_NATIVE_POSIX
 	select TICKLESS_CAPABLE
 	select TIMER_HAS_64BIT_CYCLE_COUNTER
+	select SYSTEM_TIMER_HAS_DISABLE_SUPPORT
 	help
 	  This module implements a kernel device driver for the native_posix HW timer
 	  model

--- a/drivers/timer/Kconfig.native_posix
+++ b/drivers/timer/Kconfig.native_posix
@@ -1,0 +1,14 @@
+# Copyright (c) 2014-2015 Wind River Systems, Inc.
+# Copyright (c) 2016 Cadence Design Systems, Inc.
+# Copyright (c) 2019 Intel Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+config NATIVE_POSIX_TIMER
+	bool "(POSIX) native_posix timer driver"
+	default y
+	depends on BOARD_NATIVE_POSIX
+	select TICKLESS_CAPABLE
+	select TIMER_HAS_64BIT_CYCLE_COUNTER
+	help
+	  This module implements a kernel device driver for the native_posix HW timer
+	  model

--- a/drivers/timer/Kconfig.npcx_itim
+++ b/drivers/timer/Kconfig.npcx_itim
@@ -1,0 +1,15 @@
+# Copyright (c) 2014-2015 Wind River Systems, Inc.
+# Copyright (c) 2016 Cadence Design Systems, Inc.
+# Copyright (c) 2019 Intel Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+config NPCX_ITIM_TIMER
+	bool "Nuvoton NPCX series internal 64/32-bit timers"
+	default y
+	depends on SOC_FAMILY_NPCX
+	select TICKLESS_CAPABLE
+	select TIMER_HAS_64BIT_CYCLE_COUNTER
+	help
+	  This module implements a kernel device driver for the Nuvoton NPCX
+	  series internal 64/32-bit timers and provides the standard "system
+	  clock driver" interfaces.

--- a/drivers/timer/Kconfig.nrf_rtc
+++ b/drivers/timer/Kconfig.nrf_rtc
@@ -1,0 +1,57 @@
+# Copyright (c) 2014-2015 Wind River Systems, Inc.
+# Copyright (c) 2016 Cadence Design Systems, Inc.
+# Copyright (c) 2019 Intel Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+config NRF_RTC_TIMER
+	bool "nRF Real Time Counter (NRF_RTC1) Timer"
+	depends on CLOCK_CONTROL
+	depends on SOC_COMPATIBLE_NRF
+	select TICKLESS_CAPABLE
+	select NRF_HW_RTC1_RESERVED
+	help
+	  This module implements a kernel device driver for the nRF Real Time
+	  Counter NRF_RTC1 and provides the standard "system clock driver"
+	  interfaces.
+
+if NRF_RTC_TIMER
+
+config NRF_RTC_TIMER_USER_CHAN_COUNT
+	int "Additional channels that can be used"
+	default 0
+	help
+	  Use nrf_rtc_timer.h API. Driver is not managing allocation of channels.
+
+choice
+	prompt "Clock startup policy"
+	default SYSTEM_CLOCK_WAIT_FOR_STABILITY
+
+config SYSTEM_CLOCK_NO_WAIT
+	bool "No wait"
+	help
+	  System clock source is initiated but does not wait for clock readiness.
+	  When this option is picked, system clock may not be ready when code relying
+	  on kernel API is executed. Requested timeouts will be prolonged by the
+	  remaining startup time.
+
+config SYSTEM_CLOCK_WAIT_FOR_AVAILABILITY
+	bool "Wait for availability"
+	help
+	  System clock source initialization waits until clock is available. In some
+	  systems, clock initially runs from less accurate source which has faster
+	  startup time and then seamlessly switches to the target clock source when
+	  it is ready. When this option is picked, system clock is available after
+	  system clock driver initialization but it may be less accurate. Option is
+	  equivalent to waiting for stability if clock source does not have
+	  intermediate state.
+
+config SYSTEM_CLOCK_WAIT_FOR_STABILITY
+	bool "Wait for stability"
+	help
+	  System clock source initialization waits until clock is stable. When this
+	  option is picked, system clock is available and stable after system clock
+	  driver initialization.
+
+endchoice
+
+endif # NRF_RTC_TIMER

--- a/drivers/timer/Kconfig.rcar_cmt
+++ b/drivers/timer/Kconfig.rcar_cmt
@@ -1,0 +1,13 @@
+# Copyright (c) 2014-2015 Wind River Systems, Inc.
+# Copyright (c) 2016 Cadence Design Systems, Inc.
+# Copyright (c) 2019 Intel Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+config RCAR_CMT_TIMER
+	bool "Renesas RCar cmt timer"
+	default y
+	depends on SOC_SERIES_RCAR_GEN3
+	help
+	  This module implements a kernel device driver for the Renesas RCAR
+	  platform provides the standard "system clock driver" interfaces.
+	  If unchecked, no timer will be used.

--- a/drivers/timer/Kconfig.riscv_machine
+++ b/drivers/timer/Kconfig.riscv_machine
@@ -1,0 +1,13 @@
+# Copyright (c) 2014-2015 Wind River Systems, Inc.
+# Copyright (c) 2016 Cadence Design Systems, Inc.
+# Copyright (c) 2019 Intel Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+config RISCV_MACHINE_TIMER
+	bool "RISCV Machine Timer"
+	depends on SOC_FAMILY_RISCV_PRIVILEGE
+	select TICKLESS_CAPABLE
+	select TIMER_HAS_64BIT_CYCLE_COUNTER
+	help
+	  This module implements a kernel device driver for the generic RISCV machine
+	  timer driver. It provides the standard "system clock driver" interfaces.

--- a/drivers/timer/Kconfig.rv32m1_lptmr
+++ b/drivers/timer/Kconfig.rv32m1_lptmr
@@ -1,0 +1,14 @@
+# Copyright (c) 2014-2015 Wind River Systems, Inc.
+# Copyright (c) 2016 Cadence Design Systems, Inc.
+# Copyright (c) 2019 Intel Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+config RV32M1_LPTMR_TIMER
+	bool "RV32M1 LPTMR system timer driver"
+	default y
+	depends on SOC_OPENISA_RV32M1_RISCV32
+	depends on RV32M1_INTMUX
+	help
+	  This module implements a kernel device driver for using the LPTMR
+	  peripheral as the system clock. It provides the standard "system clock
+	  driver" interfaces.

--- a/drivers/timer/Kconfig.sam0_rtc
+++ b/drivers/timer/Kconfig.sam0_rtc
@@ -1,0 +1,13 @@
+# Copyright (c) 2014-2015 Wind River Systems, Inc.
+# Copyright (c) 2016 Cadence Design Systems, Inc.
+# Copyright (c) 2019 Intel Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+config SAM0_RTC_TIMER
+	bool "Atmel SAM0 series RTC timer"
+	depends on SOC_FAMILY_SAM0
+	select TICKLESS_CAPABLE
+	help
+	  This module implements a kernel device driver for the Atmel SAM0
+	  series Real Time Counter and provides the standard "system clock
+	  driver" interfaces.

--- a/drivers/timer/Kconfig.xlnx_psttc
+++ b/drivers/timer/Kconfig.xlnx_psttc
@@ -1,0 +1,22 @@
+# Copyright (c) 2014-2015 Wind River Systems, Inc.
+# Copyright (c) 2016 Cadence Design Systems, Inc.
+# Copyright (c) 2019 Intel Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+config XLNX_PSTTC_TIMER
+	bool "Xilinx PS ttc timer support"
+	default y
+	depends on SOC_XILINX_ZYNQMP
+	select TICKLESS_CAPABLE
+	help
+	  This module implements a kernel device driver for the Xilinx ZynqMP
+	  platform provides the standard "system clock driver" interfaces.
+	  If unchecked, no timer will be used.
+
+config XLNX_PSTTC_TIMER_INDEX
+	int "Xilinx PS ttc timer index"
+	range 0 3
+	default 0
+	depends on XLNX_PSTTC_TIMER
+	help
+	  This is the index of TTC timer picked to provide system clock.

--- a/drivers/timer/Kconfig.xtensa
+++ b/drivers/timer/Kconfig.xtensa
@@ -1,0 +1,26 @@
+# Copyright (c) 2014-2015 Wind River Systems, Inc.
+# Copyright (c) 2016 Cadence Design Systems, Inc.
+# Copyright (c) 2019 Intel Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+config XTENSA_TIMER
+	bool "Xtensa timer support"
+	depends on XTENSA
+	default y
+	select TICKLESS_CAPABLE
+	help
+	  Enables a system timer driver for Xtensa based on the CCOUNT
+	  and CCOMPARE special registers.
+
+config XTENSA_TIMER_ID
+	int "System timer CCOMPAREn register index"
+	default 1
+	depends on XTENSA_TIMER
+	help
+	  Index of the CCOMPARE register (and associated interrupt)
+	  used for the system timer.  Xtensa CPUs have hard-configured
+	  interrupt priorities associated with each timer, and some of
+	  them can be unmaskable (and thus not usable by OS code that
+	  need synchronization, like the timer subsystem!).  Choose
+	  carefully.  Generally you want the timer with the highest
+	  priority maskable interrupt.

--- a/drivers/timer/altera_avalon_timer_hal.c
+++ b/drivers/timer/altera_avalon_timer_hal.c
@@ -42,24 +42,6 @@ static void timer_irq_handler(const void *unused)
 	wrapped_announce(_sys_idle_elapsed_ticks);
 }
 
-int sys_clock_driver_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	IOWR_ALTERA_AVALON_TIMER_PERIODL(TIMER_0_BASE,
-			k_ticks_to_cyc_floor32(1) & 0xFFFF);
-	IOWR_ALTERA_AVALON_TIMER_PERIODH(TIMER_0_BASE,
-			(k_ticks_to_cyc_floor32(1) >> 16) & 0xFFFF);
-
-	IRQ_CONNECT(TIMER_0_IRQ, 0, timer_irq_handler, NULL, 0);
-	irq_enable(TIMER_0_IRQ);
-
-	alt_avalon_timer_sc_init((void *)TIMER_0_BASE, 0,
-			TIMER_0_IRQ, k_ticks_to_cyc_floor32(1));
-
-	return 0;
-}
-
 uint32_t sys_clock_cycle_get_32(void)
 {
 	/* Per the Altera Embedded IP Peripherals guide, you cannot
@@ -85,3 +67,24 @@ uint32_t sys_clock_elapsed(void)
 {
 	return 0;
 }
+
+static int sys_clock_driver_init(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	IOWR_ALTERA_AVALON_TIMER_PERIODL(TIMER_0_BASE,
+			k_ticks_to_cyc_floor32(1) & 0xFFFF);
+	IOWR_ALTERA_AVALON_TIMER_PERIODH(TIMER_0_BASE,
+			(k_ticks_to_cyc_floor32(1) >> 16) & 0xFFFF);
+
+	IRQ_CONNECT(TIMER_0_IRQ, 0, timer_irq_handler, NULL, 0);
+	irq_enable(TIMER_0_IRQ);
+
+	alt_avalon_timer_sc_init((void *)TIMER_0_BASE, 0,
+			TIMER_0_IRQ, k_ticks_to_cyc_floor32(1));
+
+	return 0;
+}
+
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/apic_timer.c
+++ b/drivers/timer/apic_timer.c
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <device.h>
 #include <drivers/timer/system_timer.h>
 #include <sys_clock.h>
 #include <spinlock.h>
@@ -213,7 +214,7 @@ uint32_t sys_clock_cycle_get_32(void)
 
 #endif
 
-int sys_clock_driver_init(const struct device *dev)
+static int sys_clock_driver_init(const struct device *dev)
 {
 	uint32_t val;
 
@@ -240,3 +241,6 @@ int sys_clock_driver_init(const struct device *dev)
 
 	return 0;
 }
+
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/apic_tsc.c
+++ b/drivers/timer/apic_tsc.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2021 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <device.h>
 #include <drivers/timer/system_timer.h>
 #include <sys_clock.h>
 #include <spinlock.h>
@@ -154,7 +155,7 @@ static inline void cpuid(uint32_t *eax, uint32_t *ebx, uint32_t *ecx, uint32_t *
 			 : "a"(*eax), "c"(*ecx));
 }
 
-int sys_clock_driver_init(const struct device *dev)
+static int sys_clock_driver_init(const struct device *dev)
 {
 #ifdef CONFIG_ASSERT
 	uint32_t eax, ebx, ecx, edx;
@@ -200,3 +201,6 @@ int sys_clock_driver_init(const struct device *dev)
 
 	return 0;
 }
+
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/arm_arch_timer.c
+++ b/drivers/timer/arm_arch_timer.c
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
+#include <device.h>
 #include <drivers/timer/arm_arch_timer.h>
 #include <drivers/timer/system_timer.h>
 #include <sys_clock.h>
@@ -83,21 +83,6 @@ static void arm_arch_timer_compare_isr(const void *arg)
 	k_spin_unlock(&lock, key);
 
 	sys_clock_announce(delta_ticks);
-}
-
-int sys_clock_driver_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	IRQ_CONNECT(ARM_ARCH_TIMER_IRQ, ARM_ARCH_TIMER_PRIO,
-		    arm_arch_timer_compare_isr, NULL, ARM_ARCH_TIMER_FLAGS);
-	arm_arch_timer_init();
-	arm_arch_timer_set_compare(arm_arch_timer_count() + CYC_PER_TICK);
-	arm_arch_timer_enable(true);
-	irq_enable(ARM_ARCH_TIMER_IRQ);
-	arm_arch_timer_set_irq_mask(false);
-
-	return 0;
 }
 
 void sys_clock_set_timeout(int32_t ticks, bool idle)
@@ -192,3 +177,21 @@ void smp_timer_init(void)
 	arm_arch_timer_set_irq_mask(false);
 }
 #endif
+
+static int sys_clock_driver_init(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	IRQ_CONNECT(ARM_ARCH_TIMER_IRQ, ARM_ARCH_TIMER_PRIO,
+		    arm_arch_timer_compare_isr, NULL, ARM_ARCH_TIMER_FLAGS);
+	arm_arch_timer_init();
+	arm_arch_timer_set_compare(arm_arch_timer_count() + CYC_PER_TICK);
+	arm_arch_timer_enable(true);
+	irq_enable(ARM_ARCH_TIMER_IRQ);
+	arm_arch_timer_set_irq_mask(false);
+
+	return 0;
+}
+
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/cc13x2_cc26x2_rtc_timer.c
+++ b/drivers/timer/cc13x2_cc26x2_rtc_timer.c
@@ -15,6 +15,7 @@
  * the comparator value set is reached.
  */
 
+#include <device.h>
 #include <soc.h>
 #include <drivers/clock_control.h>
 #include <drivers/timer/system_timer.h>
@@ -183,24 +184,6 @@ static void startDevice(void)
 	irq_unlock(key);
 }
 
-int sys_clock_driver_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	rtc_last = 0U;
-
-	initDevice();
-	startDevice();
-
-	/* Enable RTC interrupt. */
-	IRQ_CONNECT(DT_INST_IRQN(0),
-		DT_INST_IRQ(0, priority),
-		rtc_isr, 0, 0);
-	irq_enable(DT_INST_IRQN(0));
-
-	return 0;
-}
-
 void sys_clock_set_timeout(int32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
@@ -247,3 +230,24 @@ uint64_t sys_clock_cycle_get_64(void)
 {
 	return AONRTCCurrent64BitValueGet() / RTC_COUNTS_PER_CYCLE;
 }
+
+static int sys_clock_driver_init(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	rtc_last = 0U;
+
+	initDevice();
+	startDevice();
+
+	/* Enable RTC interrupt. */
+	IRQ_CONNECT(DT_INST_IRQN(0),
+		DT_INST_IRQ(0, priority),
+		rtc_isr, 0, 0);
+	irq_enable(DT_INST_IRQN(0));
+
+	return 0;
+}
+
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <device.h>
 #include <drivers/timer/system_timer.h>
 #include <sys_clock.h>
 #include <spinlock.h>
@@ -149,21 +150,6 @@ void sys_clock_isr(void *arg)
 	z_arm_int_exit();
 }
 
-int sys_clock_driver_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	NVIC_SetPriority(SysTick_IRQn, _IRQ_PRIO_OFFSET);
-	last_load = CYC_PER_TICK - 1;
-	overflow_cyc = 0U;
-	SysTick->LOAD = last_load;
-	SysTick->VAL = 0; /* resets timer to last_load */
-	SysTick->CTRL |= (SysTick_CTRL_ENABLE_Msk |
-			  SysTick_CTRL_TICKINT_Msk |
-			  SysTick_CTRL_CLKSOURCE_Msk);
-	return 0;
-}
-
 void sys_clock_set_timeout(int32_t ticks, bool idle)
 {
 	/* Fast CPUs and a 24 bit counter mean that even idle systems
@@ -279,3 +265,21 @@ void sys_clock_disable(void)
 {
 	SysTick->CTRL &= ~SysTick_CTRL_ENABLE_Msk;
 }
+
+static int sys_clock_driver_init(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	NVIC_SetPriority(SysTick_IRQn, _IRQ_PRIO_OFFSET);
+	last_load = CYC_PER_TICK - 1;
+	overflow_cyc = 0U;
+	SysTick->LOAD = last_load;
+	SysTick->VAL = 0; /* resets timer to last_load */
+	SysTick->CTRL |= (SysTick_CTRL_ENABLE_Msk |
+			  SysTick_CTRL_TICKINT_Msk |
+			  SysTick_CTRL_CLKSOURCE_Msk);
+	return 0;
+}
+
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -5,6 +5,7 @@
  */
 
 #define DT_DRV_COMPAT intel_hpet
+#include <device.h>
 #include <drivers/timer/system_timer.h>
 #include <sys_clock.h>
 #include <spinlock.h>
@@ -317,56 +318,6 @@ static void config_timer0(unsigned int irq)
 }
 
 __boot_func
-int sys_clock_driver_init(const struct device *dev)
-{
-	extern int z_clock_hw_cycles_per_sec;
-	uint32_t hz, reg;
-
-	ARG_UNUSED(dev);
-	ARG_UNUSED(hz);
-	ARG_UNUSED(z_clock_hw_cycles_per_sec);
-
-	DEVICE_MMIO_TOPLEVEL_MAP(hpet_regs, K_MEM_CACHE_NONE);
-
-#if DT_INST_IRQ_HAS_CELL(0, sense)
-	IRQ_CONNECT(DT_INST_IRQN(0),
-		    DT_INST_IRQ(0, priority),
-		    hpet_isr, 0, DT_INST_IRQ(0, sense));
-#else
-	IRQ_CONNECT(DT_INST_IRQN(0),
-		    DT_INST_IRQ(0, priority),
-		    hpet_isr, 0, 0);
-#endif
-	config_timer0(DT_INST_IRQN(0));
-	irq_enable(DT_INST_IRQN(0));
-
-#ifdef CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME
-	hz = (uint32_t)(HPET_COUNTER_CLK_PERIOD / hpet_counter_clk_period_get());
-	z_clock_hw_cycles_per_sec = hz;
-	cyc_per_tick = hz / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
-#endif
-
-	/* Note: we set the legacy routing bit, because otherwise
-	 * nothing in Zephyr disables the PIT which then fires
-	 * interrupts into the same IRQ.  But that means we're then
-	 * forced to use IRQ2 contra the way the kconfig IRQ selection
-	 * is supposed to work.  Should fix this.
-	 */
-	reg = hpet_gconf_get();
-	reg |= GCONF_LR | GCONF_ENABLE;
-	hpet_gconf_set(reg);
-
-	last_count = hpet_counter_get();
-	if (cyc_per_tick >= HPET_CMP_MIN_DELAY) {
-		hpet_timer_comparator_set(last_count + cyc_per_tick);
-	} else {
-		hpet_timer_comparator_set(last_count + HPET_CMP_MIN_DELAY);
-	}
-
-	return 0;
-}
-
-__boot_func
 void smp_timer_init(void)
 {
 	/* Noop, the HPET is a single system-wide device and it's
@@ -453,3 +404,56 @@ void sys_clock_idle_exit(void)
 	reg |= GCONF_ENABLE;
 	hpet_gconf_set(reg);
 }
+
+__boot_func
+static int sys_clock_driver_init(const struct device *dev)
+{
+	extern int z_clock_hw_cycles_per_sec;
+	uint32_t hz, reg;
+
+	ARG_UNUSED(dev);
+	ARG_UNUSED(hz);
+	ARG_UNUSED(z_clock_hw_cycles_per_sec);
+
+	DEVICE_MMIO_TOPLEVEL_MAP(hpet_regs, K_MEM_CACHE_NONE);
+
+#if DT_INST_IRQ_HAS_CELL(0, sense)
+	IRQ_CONNECT(DT_INST_IRQN(0),
+		    DT_INST_IRQ(0, priority),
+		    hpet_isr, 0, DT_INST_IRQ(0, sense));
+#else
+	IRQ_CONNECT(DT_INST_IRQN(0),
+		    DT_INST_IRQ(0, priority),
+		    hpet_isr, 0, 0);
+#endif
+	config_timer0(DT_INST_IRQN(0));
+	irq_enable(DT_INST_IRQN(0));
+
+#ifdef CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME
+	hz = (uint32_t)(HPET_COUNTER_CLK_PERIOD / hpet_counter_clk_period_get());
+	z_clock_hw_cycles_per_sec = hz;
+	cyc_per_tick = hz / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
+#endif
+
+	/* Note: we set the legacy routing bit, because otherwise
+	 * nothing in Zephyr disables the PIT which then fires
+	 * interrupts into the same IRQ.  But that means we're then
+	 * forced to use IRQ2 contra the way the kconfig IRQ selection
+	 * is supposed to work.  Should fix this.
+	 */
+	reg = hpet_gconf_get();
+	reg |= GCONF_LR | GCONF_ENABLE;
+	hpet_gconf_set(reg);
+
+	last_count = hpet_counter_get();
+	if (cyc_per_tick >= HPET_CMP_MIN_DELAY) {
+		hpet_timer_comparator_set(last_count + cyc_per_tick);
+	} else {
+		hpet_timer_comparator_set(last_count + HPET_CMP_MIN_DELAY);
+	}
+
+	return 0;
+}
+
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/ite_it8xxx2_timer.c
+++ b/drivers/timer/ite_it8xxx2_timer.c
@@ -5,6 +5,7 @@
 
 #define DT_DRV_COMPAT ite_it8xxx2_timer
 
+#include <device.h>
 #include <drivers/timer/system_timer.h>
 #include <dt-bindings/interrupt-controller/ite-intc.h>
 #include <soc.h>
@@ -331,7 +332,7 @@ static int timer_init(enum ext_timer_idx ext_timer,
 	return 0;
 }
 
-int sys_clock_driver_init(const struct device *dev)
+static int sys_clock_driver_init(const struct device *dev)
 {
 	int ret;
 
@@ -372,3 +373,6 @@ int sys_clock_driver_init(const struct device *dev)
 
 	return 0;
 }
+
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/leon_gptimer.c
+++ b/drivers/timer/leon_gptimer.c
@@ -12,6 +12,7 @@
 
 #define DT_DRV_COMPAT gaisler_gptimer
 
+#include <device.h>
 #include <drivers/timer/system_timer.h>
 #include <sys_clock.h>
 
@@ -101,7 +102,7 @@ static void init_downcounter(volatile struct gptimer_timer_regs *tmr)
 	tmr->ctrl = GPTIMER_CTRL_LD | GPTIMER_CTRL_RS | GPTIMER_CTRL_EN;
 }
 
-int sys_clock_driver_init(const struct device *dev)
+static int sys_clock_driver_init(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 	const int timer_interrupt = get_timer_irq();
@@ -127,3 +128,6 @@ int sys_clock_driver_init(const struct device *dev)
 	irq_enable(timer_interrupt);
 	return 0;
 }
+
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/litex_timer.c
+++ b/drivers/timer/litex_timer.c
@@ -72,7 +72,7 @@ uint32_t sys_clock_elapsed(void)
 	return 0;
 }
 
-int sys_clock_driver_init(const struct device *dev)
+static int sys_clock_driver_init(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 	IRQ_CONNECT(TIMER_IRQ, DT_INST_IRQ(0, priority),
@@ -94,3 +94,6 @@ int sys_clock_driver_init(const struct device *dev)
 
 	return 0;
 }
+
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/mcux_lptmr_timer.c
+++ b/drivers/timer/mcux_lptmr_timer.c
@@ -6,6 +6,7 @@
 
 #define DT_DRV_COMPAT nxp_kinetis_lptmr
 
+#include <device.h>
 #include <drivers/timer/system_timer.h>
 #include <fsl_lptmr.h>
 
@@ -91,7 +92,7 @@ static void mcux_lptmr_timer_isr(void *arg)
 	LPTMR_ClearStatusFlags(LPTMR_BASE, kLPTMR_TimerCompareFlag);
 }
 
-int sys_clock_driver_init(const struct device *dev)
+static int sys_clock_driver_init(const struct device *dev)
 {
 	lptmr_config_t config;
 
@@ -120,3 +121,6 @@ int sys_clock_driver_init(const struct device *dev)
 
 	return 0;
 }
+
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/mcux_os_timer.c
+++ b/drivers/timer/mcux_os_timer.c
@@ -110,9 +110,9 @@ uint64_t sys_clock_cycle_get_64(void)
 	return OSTIMER_GetCurrentTimerValue(base);
 }
 
-static int sys_clock_driver_init(const struct device *device)
+static int sys_clock_driver_init(const struct device *dev)
 {
-	ARG_UNUSED(device);
+	ARG_UNUSED(dev);
 
 	/* Configure event timer's ISR */
 	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority),

--- a/drivers/timer/mcux_os_timer.c
+++ b/drivers/timer/mcux_os_timer.c
@@ -6,6 +6,7 @@
 
 #define DT_DRV_COMPAT nxp_os_timer
 
+#include <device.h>
 #include <drivers/timer/system_timer.h>
 #include <sys_clock.h>
 #include <spinlock.h>
@@ -48,30 +49,6 @@ void mcux_lpc_ostick_isr(void *arg)
 
 	k_spin_unlock(&lock, key);
 	sys_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? dticks : 1);
-}
-
-int sys_clock_driver_init(const struct device *device)
-{
-	ARG_UNUSED(device);
-
-	/* Configure event timer's ISR */
-	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority),
-					mcux_lpc_ostick_isr, NULL, 0);
-
-	base = (OSTIMER_Type *)DT_INST_REG_ADDR(0);
-
-	EnableDeepSleepIRQ(DT_INST_IRQN(0));
-
-	/* Initialize the OS timer, setting clock configuration. */
-	OSTIMER_Init(base);
-
-	last_count = OSTIMER_GetCurrentTimerValue(base);
-	OSTIMER_SetMatchValue(base, last_count + CYC_PER_TICK, NULL);
-
-	/* Enable event timer interrupt */
-	irq_enable(DT_INST_IRQN(0));
-
-	return 0;
 }
 
 void sys_clock_set_timeout(int32_t ticks, bool idle)
@@ -132,3 +109,30 @@ uint64_t sys_clock_cycle_get_64(void)
 {
 	return OSTIMER_GetCurrentTimerValue(base);
 }
+
+static int sys_clock_driver_init(const struct device *device)
+{
+	ARG_UNUSED(device);
+
+	/* Configure event timer's ISR */
+	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority),
+					mcux_lpc_ostick_isr, NULL, 0);
+
+	base = (OSTIMER_Type *)DT_INST_REG_ADDR(0);
+
+	EnableDeepSleepIRQ(DT_INST_IRQN(0));
+
+	/* Initialize the OS timer, setting clock configuration. */
+	OSTIMER_Init(base);
+
+	last_count = OSTIMER_GetCurrentTimerValue(base);
+	OSTIMER_SetMatchValue(base, last_count + CYC_PER_TICK, NULL);
+
+	/* Enable event timer interrupt */
+	irq_enable(DT_INST_IRQN(0));
+
+	return 0;
+}
+
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/native_posix_timer.c
+++ b/drivers/timer/native_posix_timer.c
@@ -107,8 +107,6 @@ uint32_t sys_clock_elapsed(void)
 	return (hwm_get_time() - last_tick_time)/tick_period;
 }
 
-
-#if defined(CONFIG_SYSTEM_CLOCK_DISABLE)
 /**
  *
  * @brief Stop announcing sys ticks into the kernel
@@ -122,7 +120,6 @@ void sys_clock_disable(void)
 	irq_disable(TIMER_TICK_IRQ);
 	hwtimer_set_silent_ticks(INT64_MAX);
 }
-#endif /* CONFIG_SYSTEM_CLOCK_DISABLE */
 
 /*
  * @brief Initialize system timer driver

--- a/drivers/timer/native_posix_timer.c
+++ b/drivers/timer/native_posix_timer.c
@@ -60,26 +60,6 @@ void np_timer_isr_test_hook(const void *arg)
 	np_timer_isr(NULL);
 }
 
-/*
- * @brief Initialize system timer driver
- *
- * Enable the hw timer, setting its tick period, and setup its interrupt
- */
-int sys_clock_driver_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	tick_period = 1000000ul / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
-
-	last_tick_time = hwm_get_time();
-	hwtimer_enable(tick_period);
-
-	IRQ_CONNECT(TIMER_TICK_IRQ, 1, np_timer_isr, 0, 0);
-	irq_enable(TIMER_TICK_IRQ);
-
-	return 0;
-}
-
 /**
  * @brief Set system clock timeout
  *
@@ -143,3 +123,26 @@ void sys_clock_disable(void)
 	hwtimer_set_silent_ticks(INT64_MAX);
 }
 #endif /* CONFIG_SYSTEM_CLOCK_DISABLE */
+
+/*
+ * @brief Initialize system timer driver
+ *
+ * Enable the hw timer, setting its tick period, and setup its interrupt
+ */
+static int sys_clock_driver_init(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	tick_period = 1000000ul / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
+
+	last_tick_time = hwm_get_time();
+	hwtimer_enable(tick_period);
+
+	IRQ_CONNECT(TIMER_TICK_IRQ, 1, np_timer_isr, 0, 0);
+	irq_enable(TIMER_TICK_IRQ);
+
+	return 0;
+}
+
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/npcx_itim_timer.c
+++ b/drivers/timer/npcx_itim_timer.c
@@ -34,6 +34,7 @@
  *   "sleep/deep sleep" power state if CONFIG_PM is enabled.
  */
 
+#include <device.h>
 #include <drivers/clock_control.h>
 #include <drivers/timer/system_timer.h>
 #include <sys_clock.h>

--- a/drivers/timer/rcar_cmt_timer.c
+++ b/drivers/timer/rcar_cmt_timer.c
@@ -84,13 +84,13 @@ uint32_t sys_clock_cycle_get_32(void)
  * The second one is used for cycles count, the match value is set
  * at max uint32_t.
  */
-static int sys_clock_driver_init(const struct device *device)
+static int sys_clock_driver_init(const struct device *dev)
 {
 	const struct device *clk;
 	uint32_t reg_val;
 	int i, ret;
 
-	ARG_UNUSED(device);
+	ARG_UNUSED(dev);
 	clk = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(0));
 	if (clk == NULL) {
 		return -ENODEV;

--- a/drivers/timer/rcar_cmt_timer.c
+++ b/drivers/timer/rcar_cmt_timer.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <device.h>
 #include <soc.h>
 #include <drivers/timer/system_timer.h>
 #include <drivers/clock_control.h>
@@ -66,13 +67,24 @@ static void cmt_isr(void *arg)
 	sys_clock_announce(1);
 }
 
+uint32_t sys_clock_elapsed(void)
+{
+	/* Always return 0 for tickful operation */
+	return 0;
+}
+
+uint32_t sys_clock_cycle_get_32(void)
+{
+	return sys_read32(TIMER_BASE_ADDR + CMCNT1_OFFSET);
+}
+
 /*
  * Initialize both channels at same frequency,
  * Set the first one to generates interrupt at CYCLES_PER_TICK.
  * The second one is used for cycles count, the match value is set
  * at max uint32_t.
  */
-int sys_clock_driver_init(const struct device *device)
+static int sys_clock_driver_init(const struct device *device)
 {
 	const struct device *clk;
 	uint32_t reg_val;
@@ -140,13 +152,5 @@ int sys_clock_driver_init(const struct device *device)
 	return 0;
 }
 
-uint32_t sys_clock_elapsed(void)
-{
-	/* Always return 0 for tickful operation */
-	return 0;
-}
-
-uint32_t sys_clock_cycle_get_32(void)
-{
-	return sys_read32(TIMER_BASE_ADDR + CMCNT1_OFFSET);
-}
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <device.h>
 #include <drivers/timer/system_timer.h>
 #include <sys_clock.h>
 #include <spinlock.h>
@@ -79,17 +80,6 @@ static void timer_isr(const void *arg)
 	sys_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? dticks : 1);
 }
 
-int sys_clock_driver_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	IRQ_CONNECT(RISCV_MACHINE_TIMER_IRQ, 0, timer_isr, NULL, 0);
-	last_count = mtime();
-	set_mtimecmp(last_count + CYC_PER_TICK);
-	irq_enable(RISCV_MACHINE_TIMER_IRQ);
-	return 0;
-}
-
 void sys_clock_set_timeout(int32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
@@ -152,3 +142,17 @@ uint64_t sys_clock_cycle_get_64(void)
 {
 	return mtime();
 }
+
+static int sys_clock_driver_init(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	IRQ_CONNECT(RISCV_MACHINE_TIMER_IRQ, 0, timer_isr, NULL, 0);
+	last_count = mtime();
+	set_mtimecmp(last_count + CYC_PER_TICK);
+	irq_enable(RISCV_MACHINE_TIMER_IRQ);
+	return 0;
+}
+
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/rv32m1_lptmr_timer.c
+++ b/drivers/timer/rv32m1_lptmr_timer.c
@@ -6,6 +6,7 @@
 
 #define DT_DRV_COMPAT openisa_rv32m1_lptmr
 
+#include <device.h>
 #include <zephyr.h>
 #include <sys/util.h>
 #include <drivers/timer/system_timer.h>
@@ -53,7 +54,20 @@ static void lptmr_irq_handler(const struct device *unused)
 	sys_clock_announce(1);                     /* Poke the scheduler. */
 }
 
-int sys_clock_driver_init(const struct device *unused)
+uint32_t sys_clock_cycle_get_32(void)
+{
+	return cycle_count + SYSTEM_TIMER_INSTANCE->CNR;
+}
+
+/*
+ * Since we're not tickless, this is identically zero.
+ */
+uint32_t sys_clock_elapsed(void)
+{
+	return 0;
+}
+
+static int sys_clock_driver_init(const struct device *unused)
 {
 	uint32_t csr, psr, sircdiv; /* LPTMR registers */
 
@@ -131,15 +145,5 @@ int sys_clock_driver_init(const struct device *unused)
 	return 0;
 }
 
-uint32_t sys_clock_cycle_get_32(void)
-{
-	return cycle_count + SYSTEM_TIMER_INSTANCE->CNR;
-}
-
-/*
- * Since we're not tickless, this is identically zero.
- */
-uint32_t sys_clock_elapsed(void)
-{
-	return 0;
-}
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/sys_clock_init.c
+++ b/drivers/timer/sys_clock_init.c
@@ -18,11 +18,6 @@
 
 /* Weak-linked noop defaults for optional driver interfaces*/
 
-void __weak sys_clock_isr(void *arg)
-{
-	__ASSERT_NO_MSG(false);
-}
-
 void __weak sys_clock_set_timeout(int32_t ticks, bool idle)
 {
 }

--- a/drivers/timer/sys_clock_init.c
+++ b/drivers/timer/sys_clock_init.c
@@ -30,7 +30,3 @@ void __weak sys_clock_set_timeout(int32_t ticks, bool idle)
 void __weak sys_clock_idle_exit(void)
 {
 }
-
-void __weak sys_clock_disable(void)
-{
-}

--- a/drivers/timer/sys_clock_init.c
+++ b/drivers/timer/sys_clock_init.c
@@ -23,13 +23,6 @@ void __weak sys_clock_isr(void *arg)
 	__ASSERT_NO_MSG(false);
 }
 
-int __weak sys_clock_driver_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 0;
-}
-
 void __weak sys_clock_set_timeout(int32_t ticks, bool idle)
 {
 }
@@ -41,6 +34,3 @@ void __weak sys_clock_idle_exit(void)
 void __weak sys_clock_disable(void)
 {
 }
-
-SYS_DEVICE_DEFINE("sys_clock", sys_clock_driver_init,
-		PRE_KERNEL_2, CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/xlnx_psttc_timer.c
+++ b/drivers/timer/xlnx_psttc_timer.c
@@ -7,6 +7,7 @@
 
 #define DT_DRV_COMPAT xlnx_ttcps
 
+#include <device.h>
 #include <soc.h>
 #include <drivers/timer/system_timer.h>
 #include "xlnx_psttc_timer_priv.h"
@@ -96,7 +97,50 @@ static void ttc_isr(const void *arg)
 	sys_clock_announce(ticks);
 }
 
-int sys_clock_driver_init(const struct device *dev)
+void sys_clock_set_timeout(int32_t ticks, bool idle)
+{
+#ifdef CONFIG_TICKLESS_KERNEL
+	uint32_t cycles;
+	uint32_t next_cycles;
+
+	/* Read counter value */
+	cycles = read_count();
+
+	/* Calculate timeout counter value */
+	if (ticks == K_TICKS_FOREVER) {
+		next_cycles = cycles + CYCLES_NEXT_MAX;
+	} else {
+		next_cycles = cycles + ((uint32_t)ticks * CYCLES_PER_TICK);
+	}
+
+	/* Set match value for the next interrupt */
+	update_match(cycles, next_cycles);
+#endif
+}
+
+uint32_t sys_clock_elapsed(void)
+{
+#ifdef CONFIG_TICKLESS_KERNEL
+	uint32_t cycles;
+
+	/* Read counter value */
+	cycles = read_count();
+
+	/* Return the number of ticks since last announcement */
+	return (cycles - last_cycles) / CYCLES_PER_TICK;
+#else
+	/* Always return 0 for tickful operation */
+	return 0;
+#endif
+}
+
+uint32_t sys_clock_cycle_get_32(void)
+{
+	/* Return the current counter value */
+	return read_count();
+}
+
+static int sys_clock_driver_init(const struct device *dev)
 {
 	uint32_t reg_val;
 	ARG_UNUSED(dev);
@@ -153,45 +197,5 @@ int sys_clock_driver_init(const struct device *dev)
 	return 0;
 }
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
-{
-#ifdef CONFIG_TICKLESS_KERNEL
-	uint32_t cycles;
-	uint32_t next_cycles;
-
-	/* Read counter value */
-	cycles = read_count();
-
-	/* Calculate timeout counter value */
-	if (ticks == K_TICKS_FOREVER) {
-		next_cycles = cycles + CYCLES_NEXT_MAX;
-	} else {
-		next_cycles = cycles + ((uint32_t)ticks * CYCLES_PER_TICK);
-	}
-
-	/* Set match value for the next interrupt */
-	update_match(cycles, next_cycles);
-#endif
-}
-
-uint32_t sys_clock_elapsed(void)
-{
-#ifdef CONFIG_TICKLESS_KERNEL
-	uint32_t cycles;
-
-	/* Read counter value */
-	cycles = read_count();
-
-	/* Return the number of ticks since last announcement */
-	return (cycles - last_cycles) / CYCLES_PER_TICK;
-#else
-	/* Always return 0 for tickful operation */
-	return 0;
-#endif
-}
-
-uint32_t sys_clock_cycle_get_32(void)
-{
-	/* Return the current counter value */
-	return read_count();
-}
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/xtensa_sys_timer.c
+++ b/drivers/timer/xtensa_sys_timer.c
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <device.h>
 #include <drivers/timer/system_timer.h>
 #include <sys_clock.h>
 #include <spinlock.h>
@@ -54,16 +55,6 @@ static void ccompare_isr(const void *arg)
 
 	k_spin_unlock(&lock, key);
 	sys_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? dticks : 1);
-}
-
-int sys_clock_driver_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	IRQ_CONNECT(TIMER_IRQ, 0, ccompare_isr, 0, 0);
-	set_ccompare(ccount() + CYC_PER_TICK);
-	irq_enable(TIMER_IRQ);
-	return 0;
 }
 
 void sys_clock_set_timeout(int32_t ticks, bool idle)
@@ -122,3 +113,16 @@ void smp_timer_init(void)
 	irq_enable(TIMER_IRQ);
 }
 #endif
+
+static int sys_clock_driver_init(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	IRQ_CONNECT(TIMER_IRQ, 0, ccompare_isr, 0, 0);
+	set_ccompare(ccount() + CYC_PER_TICK);
+	irq_enable(TIMER_IRQ);
+	return 0;
+}
+
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/include/drivers/timer/system_timer.h
+++ b/include/drivers/timer/system_timer.h
@@ -16,8 +16,7 @@
 #define ZEPHYR_INCLUDE_DRIVERS_SYSTEM_TIMER_H_
 
 #include <stdbool.h>
-#include <device.h>
-#include <stdbool.h>
+#include <zephyr/types.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -28,15 +27,6 @@ extern "C" {
  * @defgroup clock_apis Clock APIs
  * @{
  */
-
-/**
- * @brief Initialize system clock driver
- *
- * The system clock is a Zephyr device created globally.  This is its
- * initialization callback.  It is a weak symbol that will be
- * implemented as a noop if undefined in the clock driver.
- */
-extern int sys_clock_driver_init(const struct device *dev);
 
 /**
  * @brief Set system clock timeout

--- a/include/drivers/timer/system_timer.h
+++ b/include/drivers/timer/system_timer.h
@@ -108,6 +108,21 @@ extern void sys_clock_announce(int32_t ticks);
  * instantaneous answer.
  */
 extern uint32_t sys_clock_elapsed(void);
+
+#if defined(CONFIG_SYS_CLOCK_EXISTS) && \
+	defined(CONFIG_SYSTEM_TIMER_HAS_DISABLE_SUPPORT) || \
+	defined(__DOXYGEN__)
+/**
+ * @brief Disable system timer.
+ *
+ * This function is a no-op if the system timer does not have the capability
+ * of being disabled.
+ */
+extern void sys_clock_disable(void);
+#else
+static inline void sys_clock_disable(void) {}
+#endif /* CONFIG_SYSTEM_TIMER_HAS_DISABLE_SUPPORT */
+
 /**
  * @}
  */

--- a/lib/os/Kconfig
+++ b/lib/os/Kconfig
@@ -132,11 +132,10 @@ endif
 
 config REBOOT
 	bool "Reboot functionality"
-	select SYSTEM_CLOCK_DISABLE
 	help
 	  Enable the sys_reboot() API. Enabling this can drag in other subsystems
-	  needed to perform a "safe" reboot (e.g. SYSTEM_CLOCK_DISABLE, to stop the
-	  system clock before issuing a reset).
+	  needed to perform a "safe" reboot (e.g. to stop the system clock before
+	  issuing a reset).
 
 rsource "Kconfig.cbprintf"
 

--- a/lib/os/reboot.c
+++ b/lib/os/reboot.c
@@ -4,19 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <drivers/timer/system_timer.h>
 #include <sys/reboot.h>
 #include <kernel.h>
 #include <sys/printk.h>
 
 extern void sys_arch_reboot(int type);
-extern void sys_clock_disable(void);
 
 FUNC_NORETURN void sys_reboot(int type)
 {
 	(void)irq_lock();
-#ifdef CONFIG_SYS_CLOCK_EXISTS
 	sys_clock_disable();
-#endif
 
 	sys_arch_reboot(type);
 

--- a/soc/arm/nxp_imx/rt6xx/soc.c
+++ b/soc/arm/nxp_imx/rt6xx/soc.c
@@ -105,7 +105,8 @@ __imx_boot_ivt_section void (* const image_vector_table[])(void)  = {
 	z_arm_debug_monitor,	/* 0x30 */
 	(void (*)())image_vector_table,		/* 0x34, imageLoadAddress. */
 	z_arm_pendsv,						/* 0x38 */
-#if defined(CONFIG_SYS_CLOCK_EXISTS)
+#if defined(CONFIG_SYS_CLOCK_EXISTS) && \
+	defined(CONFIG_CORTEX_M_SYSTICK_INSTALL_ISR)
 	sys_clock_isr,						/* 0x3C */
 #else
 	z_arm_exc_spurious,


### PR DESCRIPTION
This PR started as a discussion to remove sys_clock* weak implementations, but I've also taken the opportunity to clean up a bit of other areas, in particular:

- Kconfig split
- Move init to every driver (no need for weak init/PM functions)
- Improve usage of sys_clock_disable() API
- Improve usage of SysTick sys_clock_isr() install

A couple of weak functions remain `sys_clock_elapsed` and `sys_clock_set_timeout`. By looking at the implementations and docs, I think we can also do better in that area, but I may be missing things:

- Simplify `sys_clock_elapsed()` (provide a default that returns 0 if non-tickless?)
- Simplify `sys_clock_set_timeout()` (no-op if non-tickless?)