### PR TITLE
Bluetooth: host: Remove reset of conn handle on disconnect

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -739,7 +739,6 @@ static void hci_disconn_complete(struct net_buf *buf)
 	conn->err = evt->reason;
 
 	bt_conn_set_state(conn, BT_CONN_DISCONNECTED);
-	conn->handle = 0U;
 
 	if (conn->type != BT_CONN_TYPE_LE) {
 #if defined(CONFIG_BT_BREDR)


### PR DESCRIPTION
(Re)setting the connection handle in hci_disconn_complete
should not be done as the handle are used for
logging/debugging purposes after this, and makes it
impossible to lookup the handle of disconnected
connections.

The connection handle is set to 0 during bt_conn_new
in any case.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>