### PR TITLE
Bluetooth: ISO: Fix disconnect issues

### DIFF
--- a/include/bluetooth/iso.h
+++ b/include/bluetooth/iso.h
@@ -83,8 +83,6 @@ struct bt_iso_chan;
 enum {
 	/** Channel disconnected */
 	BT_ISO_DISCONNECTED,
-	/** Channel bound to a connection */
-	BT_ISO_BOUND,
 	/** Channel in connecting state */
 	BT_ISO_CONNECT,
 	/** Channel ready for upper layer traffic on it */

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1066,15 +1066,6 @@ void bt_conn_unref(struct bt_conn *conn)
 {
 	atomic_val_t old;
 
-	/* Cleanup ISO before releasing the last reference to prevent other
-	 * threads reallocating the same connection while cleanup is ongoing.
-	 */
-	if (IS_ENABLED(CONFIG_BT_ISO_UNICAST) &&
-	    conn->type == BT_CONN_TYPE_ISO &&
-	    atomic_get(&conn->ref) == 1) {
-		bt_iso_cleanup(conn);
-	}
-
 	old = atomic_dec(&conn->ref);
 
 	BT_DBG("handle %u ref %d -> %d", conn->handle, old,

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -255,7 +255,7 @@ struct bt_iso_create_param {
 struct bt_conn *bt_conn_add_iso(struct bt_conn *acl);
 
 /* Cleanup ISO references */
-void bt_iso_cleanup(struct bt_conn *iso_conn);
+void bt_iso_cleanup_acl(struct bt_conn *iso_conn);
 
 /* Add a new BR/EDR connection */
 struct bt_conn *bt_conn_add_br(const bt_addr_t *peer);


### PR DESCRIPTION
The disconnect handling of ACL connects in the sample was done
incorrect, and caused a call to bt_conn_unref with a NULL
pointer.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

fixes #38240