### PR TITLE
Bluetooth: host: Fix bug in adv timeout for limited advertiser

### DIFF
--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -1367,9 +1367,7 @@ static void adv_timeout(struct k_work *work)
 	dwork = k_work_delayable_from_work(work);
 	adv = CONTAINER_OF(dwork, struct bt_le_ext_adv, timeout_work);
 
-	if (atomic_test_bit(adv->flags, BT_ADV_EXT_ADV)) {
-		err = bt_le_ext_adv_stop(adv);
-	}
+	err = bt_le_ext_adv_stop(adv);
 #else
 	err = bt_le_adv_stop();
 #endif


### PR DESCRIPTION
Fix bug in adv timeout for limited advertiser when extended advertising
features has been enabled. The advertiser was only stopped when
configured as an extended advertiser. It should be stopped when
configured as a legacy advertiser also.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>