### PR TITLE
pm: device: simplify some logic, cleanups

### DIFF
--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -23,62 +23,31 @@ extern const struct device *__pm_device_slots_start[];
 /* Number of devices successfully suspended. */
 static size_t num_susp;
 
-static bool should_suspend(const struct device *dev, enum pm_device_state state)
-{
-	int rc;
-	enum pm_device_state current_state;
-
-	if (pm_device_is_busy(dev) != 0) {
-		return false;
-	}
-
-	rc = pm_device_state_get(dev, &current_state);
-	if ((rc == -ENOSYS) || (rc != 0)) {
-		LOG_DBG("Was not possible to get device %s state: %d",
-			dev->name, rc);
-		return false;
-	}
-
-	/*
-	 * If the device is currently powered off or the request was
-	 * to go to the same state, just ignore it.
-	 */
-	if ((current_state == PM_DEVICE_STATE_OFF) ||
-			(current_state == state)) {
-		return false;
-	}
-
-	return true;
-}
-
-static int _pm_devices(uint32_t state)
+static int _pm_devices(enum pm_device_state state)
 {
 	const struct device *dev;
 	num_susp = 0;
 
 	for (dev = (__device_end - 1); dev > __device_start; dev--) {
-		bool suspend;
-		int rc;
+		int ret;
 
-		suspend = should_suspend(dev, state);
-		if (suspend) {
-			/*
-			 * Don't bother the device if it is currently
-			 * in the right state.
-			 */
-			rc = pm_device_state_set(dev, state);
-			if (rc == -ENOTSUP) {
-				continue;
-			} else if ((rc != -ENOSYS) && (rc != 0)) {
-				LOG_DBG("%s did not enter %s state: %d",
-					dev->name, pm_device_state_str(state),
-					rc);
-				return rc;
-			}
-
-			__pm_device_slots_start[num_susp] = dev;
-			num_susp++;
+		/* ignore busy devices */
+		if (pm_device_is_busy(dev)) {
+			continue;
 		}
+
+		ret = pm_device_state_set(dev, state);
+		/* ignore devices not supporting or already at the given state */
+		if ((ret == -ENOSYS) || (ret == -ENOTSUP) || (ret == -EALREADY)) {
+			continue;
+		} else if (ret < 0) {
+			LOG_ERR("Device %s did not enter %s state (%d)",
+				dev->name, pm_device_state_str(state), ret);
+			return ret;
+		}
+
+		__pm_device_slots_start[num_susp] = dev;
+		num_susp++;
 	}
 
 	return 0;

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -145,6 +145,8 @@ int pm_device_state_set(const struct device *dev,
 		if ((dev->pm->state == PM_DEVICE_STATE_SUSPENDED) ||
 		    (dev->pm->state == PM_DEVICE_STATE_SUSPENDING)) {
 			return -EALREADY;
+		} else if (dev->pm->state == PM_DEVICE_STATE_OFF) {
+			return -ENOTSUP;
 		}
 
 		action = PM_DEVICE_ACTION_SUSPEND;


### PR DESCRIPTION
```
pm: device: do not allow suspending a turned off device

A device that is turned off should not be suspended. A device that has
been turned off can only be resumed. This action is currently forbidden
by the "should_suspend" function in the device PM code.
```
```
pm: device: simplify suspend checks

The shared _pm_devices function used should_suspend check function to
see if a device had to be suspended or not. Some of the logic inside
that function was redundant since the pm_device_state_set function
already performs similar checks, e.g. if the device is already at the
given state or the state transition is not supported it will return
error codes appropriately.
```
```
pm: device: use z_device_get_all_static

Use the internal function z_device_get_all_static helper function
instead of using __device_start and __device_end directly. Some other
minor adjustments have been done (e.g. reduce *dev scope to the for
loop). An issue on the range of the for loop in _pm_devices has also
been fixed.
```