### PR TITLE
drivers: dma: stm32 initialize a dma_stm32_data structure

### DIFF
--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -610,6 +610,10 @@ static int dma_stm32_init(const struct device *dev)
 #endif /* CONFIG_DMAMUX_STM32 */
 	}
 
+	((struct dma_stm32_data *)dev->data)->dma_ctx.magic = 0;
+	((struct dma_stm32_data *)dev->data)->dma_ctx.dma_channels = 0;
+	((struct dma_stm32_data *)dev->data)->dma_ctx.atomic = 0;
+
 	return 0;
 }
 

--- a/drivers/dma/dma_stm32.h
+++ b/drivers/dma/dma_stm32.h
@@ -30,6 +30,7 @@ struct dma_stm32_stream {
 };
 
 struct dma_stm32_data {
+		struct dma_context dma_ctx;
 };
 
 struct dma_stm32_config {

--- a/include/drivers/dma.h
+++ b/include/drivers/dma.h
@@ -210,7 +210,7 @@ struct dma_status {
  *
  */
 struct dma_context {
-	int magic;
+	int32_t magic;
 	int dma_channels;
 	atomic_t *atomic;
 };


### PR DESCRIPTION
In the dma.h there is a dma_ctx structure using a magic code
to be identify. This structure must be prepared as a new element of the dma_stm32_data.

Without this init, the `tests/drivers/dma/loop_transfer/` on the  test _nucleo_f091rc_ board fails in the `dma_request_channel()
` function call.

```
*** Booting Zephyr OS build zephyr-v2.6.0-1722-g8566bfec2609  *
Running test suite dma_m2m_loop_test                           
===============================================================
START - test_dma_m2m_loop                                      
DMA memory to memory transfer started on DMA_1                 
Preparing DMA Controller                                       
E: ***** HARD FAULT *****                                      
E: r0/a1:  0x080059d4  r1/a2:  0xfffffc7f  r2/a3:  0x20000488  
E: r3/a4:  0x200006b1 r12/ip:  0x00000000 r14/lr:  0x08002d6f  
E:  xpsr:  0x21000000                                          
E: Faulting instruction address (r15/pc): 0x08000550           
E: >>> ZEPHYR FATAL ERROR 0: CPU exception on CPU 0            
E: Current thread: 0x20000290 (test_dma_m2m_loop)              
E: Halting system      
```


Signed-off-by: Francois Ramu <francois.ramu@st.com>