### PR TITLE
linker: add an initialized DATA_SECTIONS linker location option

### DIFF
--- a/include/arch/arc/v2/linker.ld
+++ b/include/arch/arc/v2/linker.ld
@@ -196,6 +196,11 @@ SECTIONS {
 #include <linker/cplusplus-ram.ld>
 #endif /* __MWDT_LINKER_CMD__ */
 
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-data-sections.ld>
+
 	__data_ram_end = .;
 	MPU_MIN_SIZE_ALIGN
 	/* Define linker symbols */

--- a/include/arch/arm/aarch32/cortex_a_r/scripts/linker.ld
+++ b/include/arch/arm/aarch32/cortex_a_r/scripts/linker.ld
@@ -298,6 +298,11 @@ SECTIONS
 #include <linker/kobject-data.ld>
 #include <linker/cplusplus-ram.ld>
 
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-data-sections.ld>
+
     __data_ram_end = .;
 
 

--- a/include/arch/arm/aarch32/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/aarch32/cortex_m/scripts/linker.ld
@@ -323,6 +323,11 @@ SECTIONS
 
 #include <linker/cplusplus-ram.ld>
 
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-data-sections.ld>
+
     __data_ram_end = .;
 
 #ifndef CONFIG_USERSPACE

--- a/include/arch/arm64/scripts/linker.ld
+++ b/include/arch/arm64/scripts/linker.ld
@@ -274,6 +274,11 @@ SECTIONS
 #include <linker/kobject-data.ld>
 #include <linker/cplusplus-ram.ld>
 
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-data-sections.ld>
+
     __data_ram_end = .;
 
 

--- a/include/arch/nios2/linker.ld
+++ b/include/arch/nios2/linker.ld
@@ -228,6 +228,11 @@ SECTIONS
 
 #include <linker/cplusplus-ram.ld>
 
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-data-sections.ld>
+
     __data_ram_end = .;
 
 	SECTION_DATA_PROLOGUE(_BSS_SECTION_NAME,(NOLOAD),)

--- a/include/arch/posix/linker.ld
+++ b/include/arch/posix/linker.ld
@@ -48,6 +48,11 @@ SECTIONS
 
 #include <arch/posix/native_tasks.ld>
 
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-data-sections.ld>
+
  __data_ram_end = .;
 
 /* Located in generated directory. This file is populated by the

--- a/include/arch/riscv/common/linker.ld
+++ b/include/arch/riscv/common/linker.ld
@@ -247,6 +247,12 @@ SECTIONS
  * zephyr_linker_sources() Cmake function.
  */
 #include <snippets-ram-sections.ld>
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-data-sections.ld>
+
     __data_ram_end = .;
 
     MPU_MIN_SIZE_ALIGN

--- a/include/arch/sparc/linker.ld
+++ b/include/arch/sparc/linker.ld
@@ -104,6 +104,12 @@ SECTIONS
  * zephyr_linker_sources() Cmake function.
  */
 #include <snippets-ram-sections.ld>
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-data-sections.ld>
+
     __data_ram_end = .;
 
     SECTION_DATA_PROLOGUE(_BSS_SECTION_NAME,(NOLOAD),)

--- a/include/arch/x86/ia32/linker.ld
+++ b/include/arch/x86/ia32/linker.ld
@@ -476,6 +476,11 @@ SECTIONS
 #include <linker/kobject-data.ld>
 #endif /* !CONFIG_LINKER_USE_PINNED_SECTION */
 
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-data-sections.ld>
+
 	MMU_PAGE_ALIGN
 	__data_ram_end = .;
 

--- a/include/arch/x86/intel64/linker.ld
+++ b/include/arch/x86/intel64/linker.ld
@@ -184,6 +184,11 @@ SECTIONS
 #include <linker/cplusplus-ram.ld>
 #include <arch/x86/pagetables.ld>
 
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-data-sections.ld>
+
 /* Must be last in RAM */
 #include <linker/kobject-data.ld>
 	MMU_PAGE_ALIGN

--- a/soc/riscv/openisa_rv32m1/linker.ld
+++ b/soc/riscv/openisa_rv32m1/linker.ld
@@ -183,6 +183,11 @@ SECTIONS
 #include <linker/common-ram.ld>
 #include <linker/cplusplus-ram.ld>
 
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-data-sections.ld>
+
     __data_ram_end = .;
     __data_rom_start = LOADADDR(_DATA_SECTION_NAME);
 


### PR DESCRIPTION
Hi, hit this issue while using the `ITERABLE_SECTION_RAM` macro on a linker file included with `zephyr_linker_sources`, looks like there's currently no way of specifying initialized RAM sections (`RWDATA` does not work in that case), so for example `RAM_SECTIONS` leaves those sections uninitialized, example:

```
(gdb) info files
...
        0x1009a43c - 0x100a5988 is rodata
        0x200c0000 - 0x200c0720 is zephyr_shim_hook_list_area
        0x200c0720 - 0x200c28a0 is datas
...
(gdb) p &__data_ram_start
$1 = (char (*)[]) 0x200c0720 <prl_debug_level.lto_priv>
(gdb) p &__data_ram_end
$2 = (char (*)[]) 0x200c30a4
```

(where `zephyr_shim_hook_list_area` is declared with `ITERABLE_SECTION_RAM` in `RAM_SECTIONS`).

Adding a `DATA_SECTIONS` option to cover this case, only relevant for architectures using XIP, tried to keep the include last for all architecture linker files.