### PR TITLE
scripts: check_compliance: fix filter_py edge case

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -887,15 +887,20 @@ class PyLint(ComplianceTest):
 
 def filter_py(root, fnames):
     # PyLint check helper. Returns all Python script filenames among the
-    # filenames in 'fnames', relative to directory 'root'. Uses the
-    # python-magic library, so that we can detect Python files that
-    # don't end in .py as well. python-magic is a frontend to libmagic,
-    # which is also used by 'file'.
+    # filenames in 'fnames', relative to directory 'root'.
+    #
+    # Uses the python-magic library, so that we can detect Python
+    # files that don't end in .py as well. python-magic is a frontend
+    # to libmagic, which is also used by 'file'.
+    #
+    # The extra os.path.isfile() is necessary because git includes
+    # submodule directories in its output.
 
     return [fname for fname in fnames
-            if fname.endswith(".py") or
-               magic.from_file(os.path.join(root, fname),
-                               mime=True) == "text/x-python"]
+            if os.path.isfile(os.path.join(root, fname)) and
+            (fname.endswith(".py") or
+             magic.from_file(os.path.join(root, fname),
+                             mime=True) == "text/x-python")]
 
 
 class Identity(ComplianceTest):


### PR DESCRIPTION
The filter_py() function is handed a bunch of file names and is
expected to give back just the python files.

Its input is the output from a 'git diff' command which normally when
used in the vanilla zephyr repository just prints regular files.

In situations where we're checking compliance on a repository with
submodules, however, filter_py() can be given directories in the
'fnames' list from the git output.

In the interests of being defensive and sharing infrastructure, just
handle this case in filter_py().

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>