### PR TITLE
Prevent re-initialising rssi_work_handle on ppp restart

### DIFF
--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -990,7 +990,10 @@ void gsm_ppp_start(const struct device *dev)
 	(void)k_work_reschedule(&gsm->gsm_configure_work, K_NO_WAIT);
 
 #if defined(CONFIG_GSM_MUX)
-	k_work_init_delayable(&rssi_work_handle, rssi_handler);
+	// Don't initialize rssi_work_handle if it's already pending!
+	if (k_work_delayable_is_pending(&rssi_work_handle) == false){
+		k_work_init_delayable(&rssi_work_handle, rssi_handler);
+	}
 #endif
 }
 


### PR DESCRIPTION
Signed-off-by: lachlan@intellitrac.com.au <lachlan@intellitrac.com.au>

Issue is as follows:
Using a generic GSM modem with GSM MUXing enabled:
- Initialise GSM modem on startup as normal (i.e. CONFIG_GSM_PPP_AUTOSTART=y). As part of this process, gsm_ppp_start() will run.
- After some time, run gsm_ppp_stop() (i.e. when device needs to go to sleep).
- Run gsm_ppp_start() again.

The line `k_work_init_delayable(&rssi_work_handle, rssi_handler);` will run again, re-initialising the work item, but the work item is still in the queue from the first time that gsm_ppp_start() was run, so when that work item comes due, the sys_workq thread will attempt to run an empty work item and dereference a null pointer. The fix is just to check that rssi_work_handle hasn't already been initialized.