### PR TITLE
drivers: ethernet: eth_stm32_hal.c: add wait time for buffer allocation

### DIFF
--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -389,7 +389,7 @@ static struct net_pkt *eth_rx(const struct device *dev, uint16_t *vlan_tag)
 #endif /* CONFIG_SOC_SERIES_STM32H7X */
 
 	pkt = net_pkt_rx_alloc_with_buffer(get_iface(dev_data, *vlan_tag),
-					   total_len, AF_UNSPEC, 0, K_NO_WAIT);
+					   total_len, AF_UNSPEC, 0, K_MSEC(100));
 	if (!pkt) {
 		LOG_ERR("Failed to obtain RX buffer");
 		goto release_desc;


### PR DESCRIPTION
Driver's RX thread can wait some time before a free buffer is available.
When resources are limited we can easily run out of them.

Fixes #36891.

Signed-off-by: Jan Pohanka <xhpohanka@gmail.com>