### PR TITLE
usb: cdc_acm: rework descriptors, config, and data definitions macros 

### DIFF
--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -891,18 +891,12 @@ static int cdc_acm_line_ctrl_get(const struct device *dev,
 
 /*
  * @brief Poll the device for input.
- *
- * @return -ENOTSUP Since underlying USB device controller always uses
- * interrupts, polled mode UART APIs are not implemented for the UART interface
- * exported by CDC ACM driver. Apps should use fifo_read API instead.
  */
-
 static int cdc_acm_poll_in(const struct device *dev, unsigned char *c)
 {
-	ARG_UNUSED(dev);
-	ARG_UNUSED(c);
+	int ret = cdc_acm_fifo_read(dev, c, 1);
 
-	return -ENOTSUP;
+	return ret == 1 ? 0 : -1;
 }
 
 /*

--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -428,7 +428,7 @@ static void cdc_interface_config(struct usb_desc_header *head,
 	desc->if0_union.bControlInterface = bInterfaceNumber;
 	desc->if1.bInterfaceNumber = bInterfaceNumber + 1;
 	desc->if0_union.bSubordinateInterface0 = bInterfaceNumber + 1;
-#ifdef CONFIG_USB_COMPOSITE_DEVICE
+#if (CONFIG_USB_COMPOSITE_DEVICE || CONFIG_CDC_ACM_IAD)
 	desc->iad_cdc.bFirstInterface = bInterfaceNumber;
 #endif
 }


### PR DESCRIPTION
Rework descriptors, config, and data definitions macros.
Use cdc_acm_fifo_read() to support poll in.

These are a few patches split off from #37085, which has become a little cluttered.