### PR TITLE
boards: add usbd0 aliases node to all boards with USB support

### DIFF
--- a/boards/arm/96b_aerocore2/96b_aerocore2.dts
+++ b/boards/arm/96b_aerocore2/96b_aerocore2.dts
@@ -36,6 +36,7 @@
 	aliases {
 		led0 = &yellow_led_1;
 		led1 = &blue_led_2;
+		usbd0 = &usbotg_fs;
 	};
 
 };

--- a/boards/arm/96b_carbon/96b_carbon.dts
+++ b/boards/arm/96b_carbon/96b_carbon.dts
@@ -50,6 +50,7 @@
 		led1 = &green_led_2;
 		led2 = &bt_blue_led;
 		sw0 = &user_button;
+		usbd0 = &usbotg_fs;
 	};
 };
 

--- a/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.dts
+++ b/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.dts
@@ -48,6 +48,7 @@
 		led0 = &led0;
 		led1 = &led1;
 		sw0 = &button0;
+		usbd0 = &usbd;
 	};
 };
 

--- a/boards/arm/adafruit_itsybitsy_m4_express/adafruit_itsybitsy_m4_express.dts
+++ b/boards/arm/adafruit_itsybitsy_m4_express/adafruit_itsybitsy_m4_express.dts
@@ -24,6 +24,7 @@
 		led0 = &led0;
 		pwm-led0 = &pwm_led0;
 		pwm-0 = &tcc0;
+		usbd0 = &usb0;
 	};
 
 	leds {

--- a/boards/arm/adafruit_trinket_m0/adafruit_trinket_m0.dts
+++ b/boards/arm/adafruit_trinket_m0/adafruit_trinket_m0.dts
@@ -23,6 +23,7 @@
 	aliases {
 		led0 = &led0;
 		pwm-led0 = &pwm_led0;
+		usbd0 = &usb0;
 	};
 
 	leds {

--- a/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble.dts
+++ b/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble.dts
@@ -33,6 +33,7 @@
 	aliases {
 		led0 = &led0;
 		spi = &spi2;
+		usbd0 = &usbd;
 	};
 };
 

--- a/boards/arm/arduino_nano_33_iot/arduino_nano_33_iot.dts
+++ b/boards/arm/arduino_nano_33_iot/arduino_nano_33_iot.dts
@@ -38,6 +38,7 @@
 	aliases {
 		led0 = &led0;
 		pwm-led0 = &pwm_led0;
+		usbd0 = &usb0;
 	};
 };
 

--- a/boards/arm/arduino_zero/arduino_zero.dts
+++ b/boards/arm/arduino_zero/arduino_zero.dts
@@ -24,6 +24,7 @@
 		led1 = &led1;
 		led2 = &led2;
 		pwm-led0 = &pwm_led0;
+		usbd0 = &usb0;
 	};
 
 	leds {

--- a/boards/arm/atsamd21_xpro/atsamd21_xpro.dts
+++ b/boards/arm/atsamd21_xpro/atsamd21_xpro.dts
@@ -24,6 +24,7 @@
 		pwm-led0 = &pwm_led0;
 		sw0 = &user_button;
 		i2c-0 = &sercom2;
+		usbd0 = &usb0;
 	};
 
 	leds {

--- a/boards/arm/atsame54_xpro/atsame54_xpro.dts
+++ b/boards/arm/atsame54_xpro/atsame54_xpro.dts
@@ -24,6 +24,7 @@
 		pwm-led0 = &pwm_led0;
 		sw0 = &button0;
 		i2c-0 = &sercom7;
+		usbd0 = &usb0;
 	};
 
 	leds {

--- a/boards/arm/atsamr21_xpro/atsamr21_xpro.dts
+++ b/boards/arm/atsamr21_xpro/atsamr21_xpro.dts
@@ -24,6 +24,7 @@
 		pwm-led0 = &pwm_led0;
 		sw0 = &user_button;
 		i2c-0 = &sercom1;
+		usbd0 = &usb0;
 	};
 
 	leds {

--- a/boards/arm/bbc_microbit_v2/bbc_microbit_v2.dts
+++ b/boards/arm/bbc_microbit_v2/bbc_microbit_v2.dts
@@ -15,6 +15,7 @@
 	aliases {
 		sw0 = &buttonA;
 		sw1 = &buttonB;
+		usbd0 = &usbd;
 	};
 
 	chosen {

--- a/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp.dts
+++ b/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp.dts
@@ -19,6 +19,10 @@
 		zephyr,sram-secure-partition = &sram0_s;
 		zephyr,sram-non-secure-partition = &sram0_ns;
 	};
+
+	aliases {
+		usbd0 = &usbd;
+	};
 };
 
 &usbd {

--- a/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp_ns.dts
+++ b/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp_ns.dts
@@ -17,6 +17,10 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_ns_partition;
 	};
+
+	aliases {
+		usbd0 = &usbd;
+	};
 };
 
 &usbd {

--- a/boards/arm/bl653_dvk/bl653_dvk.dts
+++ b/boards/arm/bl653_dvk/bl653_dvk.dts
@@ -72,6 +72,7 @@
 		sw1 = &button2;
 		sw2 = &button3;
 		sw3 = &button4;
+		usbd0 = &usbd;
 	};
 };
 

--- a/boards/arm/bl654_dvk/bl654_dvk.dts
+++ b/boards/arm/bl654_dvk/bl654_dvk.dts
@@ -72,6 +72,7 @@
 		sw1 = &button2;
 		sw2 = &button3;
 		sw3 = &button4;
+		usbd0 = &usbd;
 	};
 };
 

--- a/boards/arm/degu_evk/degu_evk.dts
+++ b/boards/arm/degu_evk/degu_evk.dts
@@ -62,6 +62,7 @@
 		sw0 = &button0;
 		sw1 = &button1;
 		sw2 = &button2;
+		usbd0 = &usbd;
 	};
 };
 

--- a/boards/arm/frdm_k22f/frdm_k22f.dts
+++ b/boards/arm/frdm_k22f/frdm_k22f.dts
@@ -23,6 +23,7 @@
 		green-pwm-led = &green_pwm_led;
 		blue-pwm-led = &blue_pwm_led;
 		red-pwm-led = &red_pwm_led;
+		usbd0 = &usbotg;
 	};
 
 	chosen {

--- a/boards/arm/frdm_k64f/frdm_k64f.dts
+++ b/boards/arm/frdm_k64f/frdm_k64f.dts
@@ -14,6 +14,7 @@
 		led2 = &red_led;
 		sw0 = &user_button_3;
 		sw1 = &user_button_2;
+		usbd0 = &usbotg;
 	};
 
 	chosen {

--- a/boards/arm/frdm_k82f/frdm_k82f.dts
+++ b/boards/arm/frdm_k82f/frdm_k82f.dts
@@ -23,6 +23,7 @@
 		pwm-led2 = &blue_pwm_led;
 		sw0 = &user_button_0;
 		sw1 = &user_button_1;
+		usbd0 = &usbotg;
 	};
 
 	chosen {

--- a/boards/arm/frdm_kl25z/frdm_kl25z.dts
+++ b/boards/arm/frdm_kl25z/frdm_kl25z.dts
@@ -14,6 +14,7 @@
 		led2 = &red_led;
 		sw0 = &user_button_0;
 		sw1 = &user_button_1;
+		usbd0 = &usbotg;
 	};
 
 	chosen {

--- a/boards/arm/nrf52840_blip/nrf52840_blip.dts
+++ b/boards/arm/nrf52840_blip/nrf52840_blip.dts
@@ -54,6 +54,7 @@
 		led1 = &led1;
 		led2 = &led2;
 		sw0 = &button0;
+		usbd0 = &usbd;
 	};
 };
 

--- a/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
+++ b/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
@@ -77,6 +77,7 @@
 		green-pwm-led = &pwm_led0_green;
 		red-pwm-led = &pwm_led1_red;
 		blue-pwm-led = &pwm_led2_blue;
+		usbd0 = &usbd;
 	};
 };
 

--- a/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
+++ b/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
@@ -73,6 +73,7 @@
 		blue-pwm-led = &pwm_led1;
 		red-pwm-led = &pwm_led2;
 		sw0 = &button0;
+		usbd0 = &usbd;
 	};
 };
 

--- a/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
+++ b/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
@@ -49,6 +49,7 @@
 		led1 = &blue_led_1;
 		led2 = &red_led_1;
 		sw0 = &user_button;
+		usbd0 = &usbotg_fs;
 	};
 };
 

--- a/boards/arm/nucleo_f412zg/nucleo_f412zg.dts
+++ b/boards/arm/nucleo_f412zg/nucleo_f412zg.dts
@@ -49,6 +49,7 @@
 		led1 = &blue_led_1;
 		led2 = &red_led_1;
 		sw0 = &user_button;
+		usbd0 = &usbotg_fs;
 	};
 };
 

--- a/boards/arm/nucleo_f413zh/nucleo_f413zh.dts
+++ b/boards/arm/nucleo_f413zh/nucleo_f413zh.dts
@@ -49,6 +49,7 @@
 		led1 = &blue_led_1;
 		led2 = &red_led_1;
 		sw0 = &user_button;
+		usbd0 = &usbotg_fs;
 	};
 };
 

--- a/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
+++ b/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
@@ -51,6 +51,7 @@
 		led1 = &blue_led_1;
 		led2 = &red_led_1;
 		sw0 = &user_button;
+		usbd0 = &usbotg_fs;
 	};
 };
 

--- a/boards/arm/nucleo_f746zg/nucleo_f746zg.dts
+++ b/boards/arm/nucleo_f746zg/nucleo_f746zg.dts
@@ -58,6 +58,7 @@
 		led1 = &blue_led;
 		led2 = &red_led;
 		sw0 = &user_button;
+		usbd0 = &usbotg_fs;
 	};
 };
 

--- a/boards/arm/nucleo_f756zg/nucleo_f756zg.dts
+++ b/boards/arm/nucleo_f756zg/nucleo_f756zg.dts
@@ -57,6 +57,7 @@
 		led1 = &blue_led;
 		led2 = &red_led;
 		sw0 = &user_button;
+		usbd0 = &usbotg_fs;
 	};
 };
 

--- a/boards/arm/nucleo_f767zi/nucleo_f767zi.dts
+++ b/boards/arm/nucleo_f767zi/nucleo_f767zi.dts
@@ -59,6 +59,7 @@
 		led1 = &blue_led;
 		led2 = &red_led;
 		sw0 = &user_button;
+		usbd0 = &usbotg_fs;
 	};
 };
 

--- a/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
+++ b/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
@@ -55,6 +55,7 @@
 		led1 = &yellow_led;
 		pwm-led0 = &red_pwm_led;
 		sw0 = &user_button;
+		usbd0 = &usbotg_fs;
 	};
 };
 

--- a/boards/arm/nucleo_h753zi/nucleo_h753zi.dts
+++ b/boards/arm/nucleo_h753zi/nucleo_h753zi.dts
@@ -55,6 +55,7 @@
 		led1 = &yellow_led;
 		pwm-led0 = &red_pwm_led;
 		sw0 = &user_button;
+		usbd0 = &usbotg_fs;
 	};
 };
 

--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -80,6 +80,7 @@
 		sw0 = &user_button_1;
 		sw1 = &user_button_2;
 		sw2 = &user_button_3;
+		usbd0 = &usb;
 	};
 };
 

--- a/boards/arm/olimex_stm32_e407/olimex_stm32_e407.dts
+++ b/boards/arm/olimex_stm32_e407/olimex_stm32_e407.dts
@@ -39,6 +39,7 @@
 	aliases {
 		led0 = &green_led_1;
 		sw0 = &user_button;
+		usbd0 = &usbotg_hs;
 	};
 };
 

--- a/boards/arm/olimexino_stm32/olimexino_stm32.dts
+++ b/boards/arm/olimexino_stm32/olimexino_stm32.dts
@@ -44,6 +44,7 @@
 		led0 = &green_led_1;
 		led1 = &yellow_led_2;
 		sw0 = &user_button;
+		usbd0 = &usb;
 	};
 };
 

--- a/boards/arm/particle_argon/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_argon/dts/mesh_feather.dtsi
@@ -18,6 +18,7 @@
 		led3 = &status_blue;
 		sw0 = &mode_button;
 		sw1 = &reset_button;
+		usbd0 = &usbd;
 	};
 
 	chosen {

--- a/boards/arm/particle_boron/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_boron/dts/mesh_feather.dtsi
@@ -18,6 +18,7 @@
 		led3 = &status_blue;
 		sw0 = &mode_button;
 		sw1 = &reset_button;
+		usbd0 = &usbd;
 	};
 
 	chosen {

--- a/boards/arm/particle_xenon/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_xenon/dts/mesh_feather.dtsi
@@ -18,6 +18,7 @@
 		led3 = &status_blue;
 		sw0 = &mode_button;
 		sw1 = &reset_button;
+		usbd0 = &usbd;
 	};
 
 	chosen {

--- a/boards/arm/pinnacle_100_dvk/pinnacle_100_dvk.dts
+++ b/boards/arm/pinnacle_100_dvk/pinnacle_100_dvk.dts
@@ -71,6 +71,7 @@
 		sw1 = &button2;
 		sw2 = &button3;
 		sw3 = &button4;
+		usbd0 = &usbd;
 	};
 };
 

--- a/boards/arm/rak4631_nrf52840/rak4631_nrf52840.dts
+++ b/boards/arm/rak4631_nrf52840/rak4631_nrf52840.dts
@@ -39,6 +39,7 @@
 	aliases {
 		led0 = &blue_led;
 		lora0 = &lora;
+		usbd0 = &usbd;
 	};
 };
 

--- a/boards/arm/rak5010_nrf52840/rak5010_nrf52840.dts
+++ b/boards/arm/rak5010_nrf52840/rak5010_nrf52840.dts
@@ -33,6 +33,7 @@
 	/* Declaration of aliases */
 	aliases {
 		led0 = &led0;
+		usbd0 = &usbd;
 	};
 };
 

--- a/boards/arm/reel_board/dts/reel_board.dtsi
+++ b/boards/arm/reel_board/dts/reel_board.dtsi
@@ -83,6 +83,7 @@
 		green-pwm-led = &green_pwm_led;
 		blue-pwm-led = &blue_pwm_led;
 		sw0 = &user_button;
+		usbd0 = &usbd;
 	};
 };
 

--- a/boards/arm/sam_e70_xplained/sam_e70_xplained-common.dtsi
+++ b/boards/arm/sam_e70_xplained/sam_e70_xplained-common.dtsi
@@ -14,6 +14,7 @@
 		i2c-2 = &twihs2;
 		led0 = &green_led;
 		sw0 = &sw0_user_button;
+		usbd0 = &usbhs;
 	};
 
 	chosen {

--- a/boards/arm/sam_v71_xult/sam_v71_xult-common.dtsi
+++ b/boards/arm/sam_v71_xult/sam_v71_xult-common.dtsi
@@ -17,6 +17,7 @@
 		pwm-0 = &pwm0;
 		sw0 = &sw0_user_button;
 		sw1 = &sw1_user_button;
+		usbd0 = &usbhs;
 	};
 
 	chosen {

--- a/boards/arm/seeeduino_xiao/seeeduino_xiao.dts
+++ b/boards/arm/seeeduino_xiao/seeeduino_xiao.dts
@@ -40,6 +40,7 @@
 		led0 = &led;
 		led1 = &rx_led;
 		led2 = &tx_led;
+		usbd0 = &usb0;
 	};
 };
 

--- a/boards/arm/serpente/serpente.dts
+++ b/boards/arm/serpente/serpente.dts
@@ -33,6 +33,7 @@
 		red-pwm-led = &red_pwm_led;
 		green-pwm-led = &green_pwm_led;
 		blue-pwm-led = &blue_pwm_led;
+		usbd0 = &usb0;
 	};
 
 	leds {

--- a/boards/arm/stm32f3_disco/stm32f3_disco.dts
+++ b/boards/arm/stm32f3_disco/stm32f3_disco.dts
@@ -68,6 +68,7 @@
 		led0 = &green_led_6;
 		led1 = &green_led_7;
 		sw0 = &user_button;
+		usbd0 = &usb;
 	};
 };
 

--- a/boards/arm/stm32f469i_disco/stm32f469i_disco.dts
+++ b/boards/arm/stm32f469i_disco/stm32f469i_disco.dts
@@ -55,6 +55,7 @@
 		led2 = &red_led_3;
 		led3 = &blue_led_4;
 		sw0 = &user_button;
+		usbd0 = &usbotg_fs;
 	};
 };
 

--- a/boards/arm/stm32f723e_disco/stm32f723e_disco.dts
+++ b/boards/arm/stm32f723e_disco/stm32f723e_disco.dts
@@ -49,6 +49,7 @@
 		led1 = &red_led;
 		led2 = &green_led;
 		sw0 = &user_button;
+		usbd0 = &usbotg_fs;
 	};
 };
 

--- a/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
+++ b/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
@@ -42,6 +42,7 @@
 		led0 = &green_led_1;
 		sw0 = &user_button;
 		kscan0 = &touch_controller;
+		usbd0 = &usbotg_fs;
 	};
 };
 

--- a/boards/arm/teensy4/teensy40.dts
+++ b/boards/arm/teensy4/teensy40.dts
@@ -14,6 +14,7 @@
 
 	aliases {
 		led0 = &board_led;
+		usbd0 = &usb1;
 	};
 
 	chosen {

--- a/boards/arm/ubx_bmd340eval_nrf52840/ubx_bmd340eval_nrf52840.dts
+++ b/boards/arm/ubx_bmd340eval_nrf52840/ubx_bmd340eval_nrf52840.dts
@@ -125,6 +125,7 @@
 		sw1 = &button1;
 		sw2 = &button2;
 		sw3 = &button3;
+		usbd0 = &usbd;
 	};
 };
 

--- a/boards/arm/ubx_bmd345eval_nrf52840/ubx_bmd345eval_nrf52840.dts
+++ b/boards/arm/ubx_bmd345eval_nrf52840/ubx_bmd345eval_nrf52840.dts
@@ -127,6 +127,7 @@
 		sw2 = &button2;
 		sw3 = &button3;
 		bootloader-led0 = &led0;
+		usbd0 = &usbd;
 	};
 };
 

--- a/boards/arm/ubx_bmd380eval_nrf52840/ubx_bmd380eval_nrf52840.dts
+++ b/boards/arm/ubx_bmd380eval_nrf52840/ubx_bmd380eval_nrf52840.dts
@@ -86,6 +86,7 @@
 		sw1 = &button1;
 		sw2 = &button2;
 		sw3 = &button3;
+		usbd0 = &usbd;
 	};
 };
 

--- a/boards/arm/ubx_evkninab3_nrf52840/ubx_evkninab3_nrf52840.dts
+++ b/boards/arm/ubx_evkninab3_nrf52840/ubx_evkninab3_nrf52840.dts
@@ -118,6 +118,7 @@
 		blue-pwm-led = &blue_pwm_led;
 		sw0 = &button0;
 		sw1 = &button1;
+		usbd0 = &usbd;
 	};
 };
 

--- a/boards/arm/ubx_evkninab4_nrf52833/ubx_evkninab4_nrf52833.dts
+++ b/boards/arm/ubx_evkninab4_nrf52833/ubx_evkninab4_nrf52833.dts
@@ -121,6 +121,7 @@
 		blue-pwm-led = &blue_pwm_led;
 		sw0 = &button0;
 		sw1 = &button1;
+		usbd0 = &usbd;
 	};
 };
 

--- a/boards/arm/usb_kw24d512/usb_kw24d512.dts
+++ b/boards/arm/usb_kw24d512/usb_kw24d512.dts
@@ -12,6 +12,7 @@
 		led0 = &led_0;
 		led1 = &led_1;
 		sw0 = &user_button_1;
+		usbd0 = &usbd;
 	};
 
 	chosen {

--- a/boards/arm/waveshare_open103z/waveshare_open103z.dts
+++ b/boards/arm/waveshare_open103z/waveshare_open103z.dts
@@ -74,6 +74,7 @@
 		led2 = &led_3;
 		led3 = &led_4;
 		sw0 = &button;
+		usbd0 = &usb;
 	};
 };
 

--- a/boards/xtensa/intel_s1000_crb/intel_s1000_crb.dts
+++ b/boards/xtensa/intel_s1000_crb/intel_s1000_crb.dts
@@ -10,6 +10,7 @@
 
 	aliases {
 		uart-0 = &uart0;
+		usbd0 = &usb;
 	};
 
 	chosen {


### PR DESCRIPTION
USB devicetree nodes in Zephyr have different names,
mostly derived from the designations in data sheets.
Add usbd0 alias to specific USB node to allow generic
USB sample to be build.
Follow up on commit b4242a8dabd8 ("boards: add USB node aliases")

For more background information, see merged PR #35465

Split off from #37085, which has become a little cluttered.