### PR TITLE
Bluetooth: host: cancel limited adv timeout when advertising stopped

### DIFF
--- a/subsys/bluetooth/host/adv.h
+++ b/subsys/bluetooth/host/adv.h
@@ -19,3 +19,4 @@ int bt_le_adv_set_enable_ext(struct bt_le_ext_adv *adv,
 			 bool enable,
 			 const struct bt_le_ext_adv_start_param *param);
 int bt_le_adv_set_enable_legacy(struct bt_le_ext_adv *adv, bool enable);
+void bt_le_lim_adv_cancel_timeout(struct bt_le_ext_adv *adv);

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1323,6 +1323,13 @@ static void le_legacy_conn_complete(struct net_buf *buf)
 	struct bt_hci_evt_le_conn_complete *evt = (void *)buf->data;
 	struct bt_hci_evt_le_enh_conn_complete enh;
 
+#if defined(CONFIG_BT_BROADCASTER)
+	struct bt_le_ext_adv *adv = bt_le_adv_lookup_legacy();
+
+	/* Cancel limited advertising timeout */
+	bt_le_lim_adv_cancel_timeout(adv);
+#endif
+
 	BT_DBG("status 0x%02x role %u %s", evt->status, evt->role,
 	       bt_addr_le_str(&evt->peer_addr));
 

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -152,6 +152,8 @@ struct bt_le_ext_adv {
 #endif /* defined(CONFIG_BT_EXT_ADV) */
 
 	struct k_work_delayable	timeout_work;
+
+	bool timeout_work_active;
 };
 
 enum {


### PR DESCRIPTION
Advertising might stop when:
- it was stopped by application
- device connected to a peer
- extended advertising reached stop condition
  defined in BT_LE_EXT_ADV_START_PARAM - this is handled in ll

Signed-off-by: Krzysztof Kopyściński <krzysztof.kopyscinski@codecoup.pl>

Fixes #37467