### PR TITLE
[backport v1.14-branch] Bluetooth: controller: Check length field of adv and scan response data

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_adv.c
@@ -296,6 +296,10 @@ u8_t ll_adv_data_set(u8_t len, u8_t const *const data)
 	struct pdu_adv *pdu;
 	u8_t last;
 
+	if (len > PDU_AC_SIZE_MAX) {
+		return BT_HCI_ERR_INVALID_PARAM;
+	}
+
 	/* Dont update data if directed or extended advertising. */
 	radio_adv_data = radio_adv_data_get();
 	prev = (struct pdu_adv *)&radio_adv_data->data[radio_adv_data->last][0];
@@ -351,6 +355,10 @@ u8_t ll_adv_scan_rsp_set(u8_t len, u8_t const *const data)
 	struct pdu_adv *prev;
 	struct pdu_adv *pdu;
 	u8_t last;
+
+	if (len > PDU_AC_SIZE_MAX) {
+		return BT_HCI_ERR_INVALID_PARAM;
+	}
 
 	/* use the last index in double buffer, */
 	radio_scan_data = radio_scan_data_get();

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -331,6 +331,10 @@ u8_t ll_adv_data_set(u8_t len, u8_t const *const data)
 	struct pdu_adv *pdu;
 	u8_t idx;
 
+	if (len > PDU_AC_SIZE_MAX) {
+		return BT_HCI_ERR_INVALID_PARAM;
+	}
+
 	adv = ull_adv_set_get(handle);
 	if (!adv) {
 		return BT_HCI_ERR_CMD_DISALLOWED;
@@ -381,6 +385,10 @@ u8_t ll_adv_scan_rsp_set(u8_t len, u8_t const *const data)
 	struct pdu_adv *prev;
 	struct pdu_adv *pdu;
 	u8_t idx;
+
+	if (len > PDU_AC_SIZE_MAX) {
+		return BT_HCI_ERR_INVALID_PARAM;
+	}
 
 	adv = ull_adv_set_get(handle);
 	if (!adv) {


### PR DESCRIPTION
Check the length field of the advertising and scan response data.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>

backport of #35935

Fixes: #35983