### PR TITLE
PM: Fixes: Some general fixes in pm device and pm device_runtime

### DIFF
--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -142,6 +142,7 @@ const char *pm_device_state_str(enum pm_device_state state);
  * @retval -ENOTSUP If requested state is not supported.
  * @retval -EALREADY If device is already at (or transitioning to) the requested
  *         state.
+ * @retval Errno Other negative errno on failure.
  */
 int pm_device_state_set(const struct device *dev,
 			enum pm_device_state state);

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -64,18 +64,18 @@ static void pm_work_handler(struct k_work *work)
 }
 
 static int pm_device_request(const struct device *dev,
-			enum pm_device_state target_state, uint32_t pm_flags)
+			enum pm_device_state state, uint32_t pm_flags)
 {
 	int ret = 0;
 
-	SYS_PORT_TRACING_FUNC_ENTER(pm, device_request, dev, target_state);
+	SYS_PORT_TRACING_FUNC_ENTER(pm, device_request, dev, state);
 
-	__ASSERT((target_state == PM_DEVICE_STATE_ACTIVE) ||
-			(target_state == PM_DEVICE_STATE_SUSPENDED),
+	__ASSERT((state == PM_DEVICE_STATE_ACTIVE) ||
+			(state == PM_DEVICE_STATE_SUSPENDED),
 			"Invalid device PM state requested");
 
 	if (k_is_pre_kernel()) {
-		if (target_state == PM_DEVICE_STATE_ACTIVE) {
+		if (state == PM_DEVICE_STATE_ACTIVE) {
 			dev->pm->usage++;
 		} else {
 			dev->pm->usage--;
@@ -107,7 +107,7 @@ static int pm_device_request(const struct device *dev,
 		goto out_unlock;
 	}
 
-	if (target_state == PM_DEVICE_STATE_ACTIVE) {
+	if (state == PM_DEVICE_STATE_ACTIVE) {
 		dev->pm->usage++;
 	} else {
 		dev->pm->usage--;
@@ -134,10 +134,10 @@ static int pm_device_request(const struct device *dev,
 
 	/*
 	 * dev->pm->state was set in pm_device_runtime_state_set(). As the
-	 * device may not have been properly changed to the target_state or
+	 * device may not have been properly changed to the state or
 	 * another thread we check it here before returning.
 	 */
-	ret = target_state == dev->pm->state ? 0 : -EIO;
+	ret = state == dev->pm->state ? 0 : -EIO;
 
 out_unlock:
 	(void)k_mutex_unlock(&dev->pm->lock);

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -70,7 +70,7 @@ static void pm_work_handler(struct k_work *work)
 }
 
 static int pm_device_request(const struct device *dev,
-			     uint32_t target_state, uint32_t pm_flags)
+			enum pm_device_state target_state, uint32_t pm_flags)
 {
 	int ret = 0;
 

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -28,17 +28,11 @@ static void pm_device_runtime_state_set(struct pm_device *pm)
 	case PM_DEVICE_STATE_ACTIVE:
 		if ((dev->pm->usage == 0) && dev->pm->enable) {
 			ret = pm_device_state_set(dev, PM_DEVICE_STATE_SUSPENDED);
-			if (ret == 0) {
-				dev->pm->state = PM_DEVICE_STATE_SUSPENDED;
-			}
 		}
 		break;
 	case PM_DEVICE_STATE_SUSPENDED:
 		if ((dev->pm->usage > 0) || !dev->pm->enable) {
 			ret = pm_device_state_set(dev, PM_DEVICE_STATE_ACTIVE);
-			if (ret == 0) {
-				dev->pm->state = PM_DEVICE_STATE_ACTIVE;
-			}
 		}
 		break;
 	case PM_DEVICE_STATE_SUSPENDING:


### PR DESCRIPTION
- Fix variable type and name
- Fix not necessary (wrong) state set
- Add a possible return value in an API documentation