### PR TITLE
test: lib/cbprintf_fp: fix test filtering

### DIFF
--- a/tests/lib/cbprintf_fp/testcase.yaml
+++ b/tests/lib/cbprintf_fp/testcase.yaml
@@ -5,7 +5,7 @@ common:
   integration_platforms:
     - qemu_x86
     - qemu_x86_64
-  filter: CONSOLE_HAS_DRIVER
+  filter: CONFIG_CONSOLE_HAS_DRIVER
 tests:
   lib.cbprintf_fp.printk:
     extra_configs:


### PR DESCRIPTION
The commit 6fe9e408ab (tests/cbprintf_fp: Filter on CONSOLE_HAS_DRIVER) added filtering on Kconfig symbol incorrectly - it checked `CONSOLE_HAS_DRIVER` instead of `CONFIG_CONSOLE_HAS_DRIVER` so this test was filtered out (and therefore skipped) on all platforms.

Fix that.

Fixes: 6fe9e408ab
