### PR TITLE
boards: sam/sam0: Add debuggers thread awareness

### DIFF
--- a/boards/arm/atsamd20_xpro/support/openocd.cfg
+++ b/boards/arm/atsamd20_xpro/support/openocd.cfg
@@ -20,3 +20,5 @@ $_TARGETNAME configure -event gdb-detach {
 	echo "Debugger detaching: resuming execution"
 	resume
 }
+
+$_TARGETNAME configure -rtos Zephyr

--- a/boards/arm/atsamd21_xpro/support/openocd.cfg
+++ b/boards/arm/atsamd21_xpro/support/openocd.cfg
@@ -22,3 +22,5 @@ $_TARGETNAME configure -event gdb-detach {
 	echo "Debugger detaching: resuming execution"
 	resume
 }
+
+$_TARGETNAME configure -rtos Zephyr

--- a/boards/arm/atsame54_xpro/support/openocd.cfg
+++ b/boards/arm/atsame54_xpro/support/openocd.cfg
@@ -23,3 +23,5 @@ $_TARGETNAME configure -event gdb-detach {
 	echo "Debugger detaching: resuming execution"
 	resume
 }
+
+$_TARGETNAME configure -rtos Zephyr

--- a/boards/arm/atsamr21_xpro/support/openocd.cfg
+++ b/boards/arm/atsamr21_xpro/support/openocd.cfg
@@ -22,3 +22,5 @@ $_TARGETNAME configure -event gdb-detach {
 	echo "Debugger detaching: resuming execution"
 	resume
 }
+
+$_TARGETNAME configure -rtos Zephyr

--- a/boards/arm/sam4e_xpro/support/openocd.cfg
+++ b/boards/arm/sam4e_xpro/support/openocd.cfg
@@ -25,3 +25,5 @@ $_TARGETNAME configure -event gdb-detach {
 	echo "Debugger detaching: resuming execution"
 	resume
 }
+
+$_TARGETNAME configure -rtos Zephyr

--- a/boards/arm/sam4l_ek/board.cmake
+++ b/boards/arm/sam4l_ek/board.cmake
@@ -4,4 +4,5 @@
 board_runner_args(jlink "--device=atsam4lc4c")
 board_runner_args(jlink "--speed=4000")
 board_runner_args(jlink "--reset-after-load")
+board_runner_args(jlink "-rtos GDBServer/RTOSPlugin_Zephyr")
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/sam4s_xplained/board.cmake
+++ b/boards/arm/sam4s_xplained/board.cmake
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(jlink "--device=atsam4s16c" "--speed=4000")
+board_runner_args(jlink "-rtos GDBServer/RTOSPlugin_Zephyr")
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 
 include(${ZEPHYR_BASE}/boards/common/bossac.board.cmake)

--- a/boards/arm/sam_e70_xplained/support/openocd.cfg
+++ b/boards/arm/sam_e70_xplained/support/openocd.cfg
@@ -25,3 +25,5 @@ $_TARGETNAME configure -event gdb-detach {
 	echo "Debugger detaching: resuming execution"
 	resume
 }
+
+$_TARGETNAME configure -rtos Zephyr

--- a/boards/arm/sam_v71_xult/support/openocd.cfg
+++ b/boards/arm/sam_v71_xult/support/openocd.cfg
@@ -25,3 +25,5 @@ $_TARGETNAME configure -event gdb-detach {
 	echo "Debugger detaching: resuming execution"
 	resume
 }
+
+$_TARGETNAME configure -rtos Zephyr


### PR DESCRIPTION
Zephyr thread awareness is available but Atmel SAM/SAM0 boards don't have debuggers configuration.  Add thread awareness option to enable feature when user selects CONFIG_DEBUG_THREAD_INFO=y.

Enhancement #37205

Signed-off-by: Gerson Fernando Budke <nandojve@gmail.com>