### PR TITLE
tests: bluetooth: Fix qemu or native l2cap conn params update

### DIFF
--- a/tests/bluetooth/tester/src/bttester.h
+++ b/tests/bluetooth/tester/src/bttester.h
@@ -781,6 +781,16 @@ struct l2cap_accept_connection_cmd {
 	uint16_t result;
 } __packed;
 
+#define L2CAP_CONN_PARAM_UPDATE		0x08
+struct l2cap_conn_param_update_cmd {
+	uint8_t address_type;
+	uint8_t address[6];
+	uint16_t interval_min;
+	uint16_t interval_max;
+	uint16_t latency;
+	uint16_t timeout;
+} __packed;
+
 /* events */
 #define L2CAP_EV_CONNECTION_REQ		0x80
 struct l2cap_connection_req_ev {


### PR DESCRIPTION
Test case L2CAP/LE/CPU/BV-01-C require IUT send L2CAP Connection Parameter.
Although we use CONFIG_BT_CTLR_CONN_PARAM_REQ to turn off
the controller function, but it is not feasible for native posix or qemu.

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>