### PR TITLE
cmsis_rots_v1: fix for clearing signal flags in osSignalWait.

### DIFF
--- a/subsys/portability/cmsis_rtos_v1/cmsis_signal.c
+++ b/subsys/portability/cmsis_rtos_v1/cmsis_signal.c
@@ -157,7 +157,7 @@ osEvent osSignalWait(int32_t signals, uint32_t millisec)
 
 	/* Clear signal flags as the thread is ready now */
 	key = irq_lock();
-	thread_def->signal_results &= ~(signals);
+	thread_def->signal_results &= signals ? ~(signals) : 0;
 	irq_unlock(key);
 
 	return evt;


### PR DESCRIPTION
we use flag 0 in osSignalWait function to wait for
any single signal flag, but with this 0 flag,
it won't clear thread signal results as expected in "thread_def->signal_results &= signals".
we need to check whether signal flag is 0 firstly.

fix: #37182 

Signed-off-by: Chen Peng1 <peng1.chen@intel.com>