### PR TITLE
net: socket: fix regression causing corrupted poll timeout

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -1457,8 +1457,7 @@ int zsock_poll_internal(struct zsock_pollfd *fds, int nfds, k_timeout_t timeout)
 		if (K_TIMEOUT_EQ(timeout, K_FOREVER)) {
 			poll_timeout = SYS_FOREVER_MS;
 		} else {
-			poll_timeout = k_ticks_to_ms_floor32(
-				sys_clock_timeout_end_calc(timeout));
+			poll_timeout = k_ticks_to_ms_floor32(timeout.ticks);
 		}
 
 		return z_fdtable_call_ioctl(offl_vtable, offl_ctx,


### PR DESCRIPTION
k_timeout_t was converted to ticks using a nonsense function
causing poll timeout corruption for offloaded sockets; this
commit uses ticks directly from the struct instead.

Fixes #37472