### PR TITLE
Bluetooth: Mesh: Fixes Same appkey add to multi netkey

### DIFF
--- a/subsys/bluetooth/mesh/app_keys.c
+++ b/subsys/bluetooth/mesh/app_keys.c
@@ -249,7 +249,7 @@ uint8_t bt_mesh_app_key_add(uint16_t app_idx, uint16_t net_idx,
 
 	if (app->app_idx == app_idx) {
 		if (app->net_idx != net_idx) {
-			return STATUS_INVALID_BINDING;
+			return STATUS_INVALID_NETKEY;
 		}
 
 		if (memcmp(key, app->keys[0].val, 16)) {


### PR DESCRIPTION
The latest MESH.TS 1.0.1.2 4.15.10 Appkey List Procedures
MESH/NODE/CFG/AKL/BI-04-C

Verify that the IUT can respond to an Config AppKey Add
message with NetKeyIndex and AppKeyIndex already stored.

6. Repeat step 1 with the same AppKey, the same
AppKeyIndex, but NetKeyIndex field set to 0x001.

7. The Lower Tester expects the IUT to respond
with an Config AppKey Status message with the
Status field set to 0x04 (Invalid NetKey) and
the NetKeyIndex and AppKeyIndex values equal to
those sent in step 5.

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>