### PR TITLE
Improve timer-based PRNG and run tests on m2gl025_miv board by default 

### DIFF
--- a/boards/riscv/m2gl025_miv/m2gl025_miv.yaml
+++ b/boards/riscv/m2gl025_miv/m2gl025_miv.yaml
@@ -7,6 +7,7 @@ toolchain:
 ram: 64
 simulation: renode
 testing:
+  default: true
   ignore_tags:
     - net
     - bluetooth

--- a/subsys/random/rand32_timer.c
+++ b/subsys/random/rand32_timer.c
@@ -28,7 +28,7 @@
  */
 static atomic_val_t _rand32_counter;
 
-#define _RAND32_INC 1000000013U
+#define _RAND32_INC 1000000003U
 
 /**
  *

--- a/tests/kernel/mem_protect/stack_random/testcase.yaml
+++ b/tests/kernel/mem_protect/stack_random/testcase.yaml
@@ -1,5 +1,4 @@
 tests:
   kernel.memory_protection.stack_random:
     arch_exclude: posix
-    platform_exclude: qemu_riscv32
     tags: kernel memory_protection


### PR DESCRIPTION
This PR introduced two changes.

PR #36996 disabled running `mem_protect/stack_random` test on `qemu_riscv32` platform because of this test consistently failing on said platform. This test starts new threads in equal time intervals, and because of that we get similar results while performing the modulus operation when calculating stack pointer address.

This can be solved either by adding a delay, changing the number of iterations or improving the timer-based PRNG by adding multiplier, increment and modulus parameters. The first commit adds multiplier, increment and modulus parameters to the timer-based PRNG to address this issue. This addresses issue #37006.

The second commit enables running tests in Renode on emulated 32-bit RISC-V `m2gl025_miv` platform as a double-check for situations like this in the future.
