### PR TITLE
usb: rework cdc_acm_poll_out to non-blocking 

### DIFF
--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -281,7 +281,6 @@ static void cdc_acm_read_cb(uint8_t ep, int size, void *priv)
 		LOG_ERR("Ring buffer full, drop %zd bytes", size - wrote);
 	}
 
-done:
 	dev_data->rx_ready = true;
 
 	/* Call callback only if rx irq ena */
@@ -289,6 +288,7 @@ done:
 		k_work_submit_to_queue(&USB_WORK_Q, &dev_data->cb_work);
 	}
 
+done:
 	usb_transfer(ep, dev_data->rx_buf, sizeof(dev_data->rx_buf),
 		     USB_TRANS_READ, cdc_acm_read_cb, dev_data);
 


### PR DESCRIPTION
Change cdc_acm_poll_out to do the best to mimic behavior
of a hardware UART controller without flow control.

With this patch, if the USB subsystem is not ready,
no data is transferred to the buffer, that is, new character
is dropped. If the USB subsystem is ready and the buffer is full,
the first character from the tx_ringbuf is removed to
make room for the new character.

Second patch is to avoid spurious interrupt on configured or resume events.