### PR TITLE
footprint: Add Bluetooth samples to footprint tracking

### DIFF
--- a/scripts/footprint/plan.txt
+++ b/scripts/footprint/plan.txt
@@ -14,3 +14,7 @@ footprints,power-management,it8xxx2_evb,tests/benchmarks/footprints,-DCONF_FILE=
 footprints,power-management,iotdk,tests/benchmarks/footprints,-DCONF_FILE=prj_pm.conf
 echo_client,default,frdm_k64f,samples/net/sockets/echo_client,
 echo_server,default,frdm_k64f,samples/net/sockets/echo_server,
+bt_beacon, default, nrf52840dk_nrf52840, samples/bluetooth/beacon
+bt_peripheral, default, nrf52840dk_nrf52840, samples/bluetooth/peripheral
+bt_central_hr, default, nrf52840dk_nrf52840, samples/bluetooth/central_hr
+bt_mesh_demo, default, bbc_microbit, samples/bluetooth/mesh_demo


### PR DESCRIPTION
Add a few Bluetooth samples to track their footprint as part of the
effort to contain firmware bloat.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>