### PR TITLE
west: runners: Add new -i/--dev-id device identifier common runner option

### DIFF
--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -207,6 +207,11 @@ class RunnerCaps:
     - commands: set of supported commands; default is {'flash',
       'debug', 'debugserver', 'attach'}.
 
+    - dev_id: whether the runner supports device identifiers, in the form of an
+      -i, --dev-id option. This is useful when the user has multiple debuggers
+      connected to a single computer, in order to select which one will be used
+      with the command provided.
+
     - flash_addr: whether the runner supports flashing to an
       arbitrary address. Default is False. If true, the runner
       must honor the --dt-flash option.
@@ -225,14 +230,17 @@ class RunnerCaps:
     def __init__(self,
                  commands: Set[str] = {'flash', 'debug',
                                        'debugserver', 'attach'},
+                 dev_id: bool = False,
                  flash_addr: bool = False,
                  erase: bool = False):
         self.commands = commands
+        self.dev_id = dev_id
         self.flash_addr = bool(flash_addr)
         self.erase = bool(erase)
 
     def __str__(self):
         return (f'RunnerCaps(commands={self.commands}, '
+                f'dev_id={self.dev_id}, '
                 f'flash_addr={self.flash_addr}, '
                 f'erase={self.erase}'
                 ')')
@@ -423,6 +431,13 @@ class ZephyrBinaryRunner(abc.ABC):
         # using them to mean something else.
         caps = cls.capabilities()
 
+        if caps.dev_id:
+            parser.add_argument('-i', '--dev-id',
+                                dest='dev_id',
+                                help=cls.dev_id_help())
+        else:
+            parser.add_argument('-i', '--dev-id', help=argparse.SUPPRESS)
+
         if caps.flash_addr:
             parser.add_argument('--dt-flash', default='n', choices=_YN_CHOICES,
                                 action=_DTFlashAction,
@@ -454,6 +469,8 @@ class ZephyrBinaryRunner(abc.ABC):
         - ``args``: arguments parsed from execution environment, as
           specified by ``add_parser()``.'''
         caps = cls.capabilities()
+        if args.dev_id and not caps.dev_id:
+            _missing_cap(cls, '--dev-id')
         if args.dt_flash and not caps.flash_addr:
             _missing_cap(cls, '--dt-flash')
         if args.erase and not caps.erase:
@@ -529,6 +546,14 @@ class ZephyrBinaryRunner(abc.ABC):
         '''
         return (self.build_conf.getboolean('CONFIG_DEBUG_THREAD_INFO') or
                 self.build_conf.getboolean('CONFIG_OPENOCD_SUPPORT'))
+
+    @classmethod
+    def dev_id_help(cls) -> str:
+        ''' Get the ArgParse help text for the --dev-id option.'''
+        return '''Device identifier. Use it to select
+                  which debugger, device, node or instance to
+                  target when multiple ones are available or
+                  connected.'''
 
     @staticmethod
     def require(program: str) -> str:

--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -288,6 +288,17 @@ class _ToggleAction(argparse.Action):
     def __call__(self, parser, args, ignored, option):
         setattr(args, self.dest, not option.startswith('--no-'))
 
+class DeprecatedAction(argparse.Action):
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        _logger.warning(f'Argument {self.option_strings[0]} is deprecated, '
+                        f'use {self._replacement} instead.')
+        setattr(namespace, self.dest, values)
+
+def depr_action(*args, replacement=None, **kwargs):
+    action = DeprecatedAction(*args, **kwargs)
+    setattr(action, '_replacement', replacement)
+    return action
 
 class ZephyrBinaryRunner(abc.ABC):
     '''Abstract superclass for binary runners (flashers, debuggers).

--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -5,6 +5,7 @@
 '''Runner for debugging with J-Link.'''
 
 import argparse
+from functools import partial
 import logging
 import os
 from pathlib import Path
@@ -13,7 +14,7 @@ import subprocess
 import sys
 import tempfile
 
-from runners.core import ZephyrBinaryRunner, RunnerCaps
+from runners.core import ZephyrBinaryRunner, RunnerCaps, depr_action
 
 try:
     from pylink.library import Library
@@ -83,6 +84,8 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
 
         # Optional:
         parser.add_argument('--id', required=False, dest='dev_id',
+                            action=partial(depr_action,
+                                           replacement='-i/--dev-id'),
                             help='Deprecated: use -i/--dev-id instead')
         parser.add_argument('--iface', default='swd',
                             help='interface to use, default is swd')

--- a/scripts/west_commands/runners/nrfjprog.py
+++ b/scripts/west_commands/runners/nrfjprog.py
@@ -5,6 +5,7 @@
 
 '''Runner for flashing with nrfjprog.'''
 
+from functools import partial
 import os
 from pathlib import Path
 import shlex
@@ -12,7 +13,7 @@ import subprocess
 import sys
 from re import fullmatch, escape
 
-from runners.core import ZephyrBinaryRunner, RunnerCaps
+from runners.core import ZephyrBinaryRunner, RunnerCaps, depr_action
 
 try:
     from intelhex import IntelHex
@@ -80,6 +81,8 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
                             action='store_true',
                             help='use reset instead of pinreset')
         parser.add_argument('--snr', required=False, dest='dev_id',
+                            action=partial(depr_action,
+                                           replacement='-i/--dev-id'),
                             help='Deprecated: use -i/--dev-id instead')
         parser.add_argument('--tool-opt', default=[], action='append',
                             help='''Additional options for nrfjprog,

--- a/scripts/west_commands/runners/pyocd.py
+++ b/scripts/west_commands/runners/pyocd.py
@@ -4,11 +4,12 @@
 
 '''Runner for pyOCD .'''
 
+from functools import partial
 import os
 from os import path
 
 from runners.core import ZephyrBinaryRunner, RunnerCaps, \
-    BuildConfiguration
+    BuildConfiguration, depr_action
 
 DEFAULT_PYOCD_GDB_PORT = 3333
 DEFAULT_PYOCD_TELNET_PORT = 4444
@@ -111,6 +112,8 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
         parser.add_argument('--tui', default=False, action='store_true',
                             help='if given, GDB uses -tui')
         parser.add_argument('--board-id', dest='dev_id',
+                            action=partial(depr_action,
+                                           replacement='-i/--dev-id'),
                             help='Deprecated: use -i/--dev-id instead')
         parser.add_argument('--tool-opt',
                             help='''Additional options for pyocd Commander,

--- a/scripts/west_commands/runners/pyocd.py
+++ b/scripts/west_commands/runners/pyocd.py
@@ -19,11 +19,11 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
 
     def __init__(self, cfg, target,
                  pyocd='pyocd',
-                 flash_addr=0x0, erase=False, flash_opts=None,
+                 dev_id=None, flash_addr=0x0, erase=False, flash_opts=None,
                  gdb_port=DEFAULT_PYOCD_GDB_PORT,
                  telnet_port=DEFAULT_PYOCD_TELNET_PORT, tui=False,
                  pyocd_config=None,
-                 board_id=None, daparg=None, frequency=None, tool_opt=None):
+                 daparg=None, frequency=None, tool_opt=None):
         super().__init__(cfg)
 
         default = path.join(cfg.board_dir, 'support', 'pyocd.yaml')
@@ -53,8 +53,8 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
         self.pyocd_config_args = pyocd_config_args
 
         board_args = []
-        if board_id is not None:
-            board_args = ['-u', board_id]
+        if dev_id is not None:
+            board_args = ['-u', dev_id]
         self.board_args = board_args
 
         daparg_args = []
@@ -81,7 +81,12 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
     @classmethod
     def capabilities(cls):
         return RunnerCaps(commands={'flash', 'debug', 'debugserver', 'attach'},
-                          flash_addr=True, erase=True)
+                          dev_id=True, flash_addr=True, erase=True)
+
+    @classmethod
+    def dev_id_help(cls) -> str:
+        return '''Device identifier. Use it to select the probe's unique ID
+                  or substring thereof.'''
 
     @classmethod
     def do_add_parser(cls, parser):
@@ -105,8 +110,8 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
                                 DEFAULT_PYOCD_TELNET_PORT))
         parser.add_argument('--tui', default=False, action='store_true',
                             help='if given, GDB uses -tui')
-        parser.add_argument('--board-id',
-                            help='ID of board to flash, default is to prompt')
+        parser.add_argument('--board-id', dest='dev_id',
+                            help='Deprecated: use -i/--dev-id instead')
         parser.add_argument('--tool-opt',
                             help='''Additional options for pyocd Commander,
                             e.g. \'--script=user.py\' ''')
@@ -121,7 +126,7 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
             pyocd=args.pyocd,
             flash_addr=flash_addr, erase=args.erase, flash_opts=args.flash_opt,
             gdb_port=args.gdb_port, telnet_port=args.telnet_port, tui=args.tui,
-            board_id=args.board_id, daparg=args.daparg,
+            dev_id=args.dev_id, daparg=args.daparg,
             frequency=args.frequency,
             tool_opt=args.tool_opt)
 

--- a/scripts/west_commands/tests/test_pyocd.py
+++ b/scripts/west_commands/tests/test_pyocd.py
@@ -18,7 +18,7 @@ from conftest import RC_BUILD_DIR, RC_GDB, RC_KERNEL_HEX, RC_KERNEL_ELF
 
 TEST_PYOCD = 'test-pyocd'
 TEST_ADDR = 0xadd
-TEST_BOARD_ID = 'test-board-id'
+TEST_DEV_ID = 'test-dev-id'
 TEST_FREQUENCY = 'test-frequency'
 TEST_DAPARG = 'test-daparg'
 TEST_TARGET = 'test-target'
@@ -34,7 +34,7 @@ TEST_ALL_KWARGS = {
     'gdb_port': TEST_GDB_PORT,
     'telnet_port': TEST_TELNET_PORT,
     'tui': False,
-    'board_id': TEST_BOARD_ID,
+    'dev_id': TEST_DEV_ID,
     'frequency': TEST_FREQUENCY,
     'daparg': TEST_DAPARG,
     'tool_opt': TEST_TOOL_OPT,
@@ -49,7 +49,7 @@ TEST_ALL_PARAMS = (['--target', TEST_TARGET,
                     TEST_FLASH_OPTS] +
                    ['--gdb-port', str(TEST_GDB_PORT),
                     '--telnet-port', str(TEST_TELNET_PORT),
-                    '--board-id', TEST_BOARD_ID,
+                    '--dev-id', TEST_DEV_ID,
                     '--frequency', str(TEST_FREQUENCY),
                     '--tool-opt', TEST_TOOL_OPT])
 
@@ -71,7 +71,7 @@ FLASH_ALL_EXPECTED_CALL = ([TEST_PYOCD,
                             'flash',
                             '-e', 'sector',
                             '-a', hex(TEST_ADDR), '-da', TEST_DAPARG,
-                            '-t', TEST_TARGET, '-u', TEST_BOARD_ID,
+                            '-t', TEST_TARGET, '-u', TEST_DEV_ID,
                             '-f', TEST_FREQUENCY,
                             TEST_TOOL_OPT] +
                            TEST_FLASH_OPTS +
@@ -86,7 +86,7 @@ DEBUG_ALL_EXPECTED_SERVER = [TEST_PYOCD,
                              '-p', str(TEST_GDB_PORT),
                              '-T', str(TEST_TELNET_PORT),
                              '-t', TEST_TARGET,
-                             '-u', TEST_BOARD_ID,
+                             '-u', TEST_DEV_ID,
                              '-f', TEST_FREQUENCY,
                              TEST_TOOL_OPT]
 DEBUG_ALL_EXPECTED_CLIENT = [RC_GDB, RC_KERNEL_ELF,
@@ -112,7 +112,7 @@ DEBUGSERVER_ALL_EXPECTED_CALL = [TEST_PYOCD,
                                  '-p', str(TEST_GDB_PORT),
                                  '-T', str(TEST_TELNET_PORT),
                                  '-t', TEST_TARGET,
-                                 '-u', TEST_BOARD_ID,
+                                 '-u', TEST_DEV_ID,
                                  '-f', TEST_FREQUENCY,
                                  TEST_TOOL_OPT]
 DEBUGSERVER_DEF_EXPECTED_CALL = ['pyocd',


### PR DESCRIPTION
In order to avoid different runners implementing device identification each in their own way, introduce a new `-i/--dev-id` command-line switch that allows the user to specify which board/debugger/node is to be targeted by the flash or debug operation.