### PR TITLE
doc: west v0.11.1 notes

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -26,7 +26,7 @@ on:
 
 env:
   # NOTE: west docstrings will be extracted from the version listed here
-  WEST_VERSION: 0.11.0
+  WEST_VERSION: 0.11.1a1
 
 jobs:
   doc-build-html:

--- a/doc/_extensions/zephyr/link-roles.py
+++ b/doc/_extensions/zephyr/link-roles.py
@@ -31,15 +31,27 @@ def get_github_rev():
 def setup(app):
     rev = get_github_rev()
 
-    # try to get url from West; this adds compatibility with repos
-    # located elsewhere
+    # Try to get the zephyr repository's GitHub URL from the manifest.
+    #
+    # This allows building the docs in downstream Zephyr-based
+    # software with forks of the zephyr repository, and getting
+    # :zephyr_file: / :zephyr_raw: output that links to the fork,
+    # instead of mainline zephyr.
+    baseurl = None
     if west_manifest is not None:
-        baseurl = west_manifest.get_projects(['zephyr'])[0].url
-    else:
-        baseurl = None
+        try:
+            # This search tries to look up a project named 'zephyr'.
+            # If zephyr is the manifest repository, this raises
+            # ValueError, since there isn't any such project.
+            baseurl = west_manifest.get_projects(['zephyr'],
+                                                 allow_paths=False)[0].url
+            # Spot check that we have a non-empty URL.
+            assert baseurl
+        except ValueError:
+            pass
 
-    # or fallback to default
-    if baseurl is None or baseurl == '':
+    # If the search failed, fall back on the mainline URL.
+    if baseurl is None:
         baseurl = 'https://github.com/zephyrproject-rtos/zephyr'
 
     app.add_role('zephyr_file', autolink('{}/blob/{}/%s'.format(baseurl, rev)))

--- a/doc/guides/west/manifest.rst
+++ b/doc/guides/west/manifest.rst
@@ -151,6 +151,8 @@ bases are respectively ``https://git.example.com/base1`` and
 example, you might use ``git@example.com:base1`` if ``remote1`` supported Git
 over SSH as well. Anything acceptable to Git will work.
 
+.. _west-manifests-projects:
+
 Projects
 ========
 

--- a/doc/guides/west/release-notes.rst
+++ b/doc/guides/west/release-notes.rst
@@ -3,6 +3,59 @@
 West Release Notes
 ##################
 
+v0.11.1
+*******
+
+New features:
+
+- ``west status`` now only prints output for projects which have a nonempty
+  status.
+
+Bug fixes:
+
+- The manifest file parser was incorrectly allowing project names which contain
+  the path separator characters ``/`` and ``\\``. These invalid characters are
+  now rejected.
+
+  Note: if you need to place a project within a subdirectory of the workspace
+  topdir, use the ``path:`` key. If you need to customize a project's fetch URL
+  relative to its remote ``url-base:``, use ``repo-path:``. See
+  :ref:`west-manifests-projects` for examples.
+
+- The changes made in west v0.10.1 to the ``west init --manifest-rev`` option
+  which selected the default branch name were leaving the manifest repository
+  in a detached HEAD state. This has been fixed by using ``git clone`` internally
+  instead of ``git init`` and ``git fetch``. See `issue #522`_ for details.
+
+- The :envvar:`WEST_CONFIG_LOCAL` environment variable now correctly
+  overrides the default location, :file:`<workspace topdir>/.west/config`.
+
+- ``west update --fetch=smart`` (``smart`` is the default) now correclty skips
+  fetches for project revisions which are `lightweight tags`_ (it already
+  worked correctly for annotated tags; only lightweight tags were unnecessarily
+  fetched).
+
+Other changes:
+
+- The fix for issue #522 mentioned above introduces a new restriction. The
+  ``west init --manifest-rev`` option value, if given, must now be either a
+  branch or a tag. In particular, "pseudo-branches" like GitHub's
+  ``pull/1234/head`` references which could previously be used to fetch a pull
+  request can no longer be passed to ``--manifest-rev``. Users must now fetch
+  and check out such revisions manually after running ``west init``.
+
+:ref:`API <west-apis>` changes:
+
+- ``west.manifest.Manifest.get_projects()`` avoids incorrect results in
+  some edge cases described in `issue #523`_.
+
+- ``west.manifest.Project.sha()`` now works correctly for tag revisions.
+  (This applies to both lightweight and annotated tags.)
+
+.. _lightweight tags: https://git-scm.com/book/en/v2/Git-Basics-Tagging
+.. _issue #522: https://github.com/zephyrproject-rtos/west/issues/522
+.. _issue #523: https://github.com/zephyrproject-rtos/west/issues/523
+
 v0.11.0
 *******
 


### PR DESCRIPTION
This is a stopgap release meant to backport bug fixes and new features while v0.12.0 is blocked.
