### PR TITLE
drivers: flash_sam: fix flash_sam_write_page

### DIFF
--- a/drivers/flash/flash_sam.c
+++ b/drivers/flash/flash_sam.c
@@ -144,8 +144,9 @@ static int flash_sam_write_page(const struct device *dev, off_t offset,
 	/* We need to copy the data using 32-bit accesses */
 	for (; len > 0; len -= sizeof(*src)) {
 		*dst++ = *src++;
+		/* Assure data are written to the latch buffer consecutively */
+		__DSB();
 	}
-	__DSB();
 
 	/* Trigger the flash write */
 	efc->EEFC_FCR = EEFC_FCR_FKEY_PASSWD |


### PR DESCRIPTION
According to Atmel SAM datasheet when writing data to the latch buffer
"32-bit words must be written continuously, in either ascending or
descending order. Writing the latch buffer in a random order is not
permitted." To enforce the requirement we need to call a memory barrier
instruction after copying every word of data to the latch buffer. In
the absensce of __DSB() call the ARM processor is free to change order
of AHB transfers. This has caused the driver to occasionally corrupt
data programmed in the flash.

Fixes #37515