### PR TITLE
debug: analyzer: fix incorrect cpu cycle counts

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -5710,6 +5710,20 @@ int k_thread_runtime_stats_get(k_tid_t thread,
  */
 int k_thread_runtime_stats_all_get(k_thread_runtime_stats_t *stats);
 
+/**
+ * @brief Clear runtime statistics for a specific thread
+ *
+ * @param stats Pointer to struct to copy statistics into.
+ * @return -EINVAL if null pointers, otherwise 0
+ */
+int k_thread_runtime_stats_clear(k_tid_t thread);
+
+
+/**
+ * @brief Clear runtime statistics for all threads
+ */
+void k_thread_runtime_stats_all_clear(void);
+
 #endif
 
 #ifdef __cplusplus

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -1050,7 +1050,9 @@ void z_thread_mark_switched_out(void)
 	diff = timing_cycles_get(&thread->rt_stats.last_switched_in, &now);
 #else
 	now = k_cycle_get_32();
-	diff = (uint64_t)(now - thread->rt_stats.last_switched_in);
+	diff = now < thread->rt_stats.last_switched_in ?
+		(uint64_t) UINT32_MAX - thread->rt_stats.last_switched_in + now :
+		now - thread->rt_stats.last_switched_in;
 	thread->rt_stats.last_switched_in = 0;
 #endif /* CONFIG_THREAD_RUNTIME_STATS_USE_TIMING_FUNCTIONS */
 
@@ -1088,6 +1090,22 @@ int k_thread_runtime_stats_all_get(k_thread_runtime_stats_t *stats)
 		     sizeof(threads_runtime_stats));
 
 	return 0;
+}
+
+int k_thread_runtime_stats_clear(k_tid_t thread)
+{
+	if (thread == NULL) {
+		return -EINVAL;
+	}
+
+	thread->rt_stats.stats.execution_cycles = 0;
+
+	return 0;
+}
+
+void k_thread_runtime_stats_all_clear(void)
+{
+	threads_runtime_stats.execution_cycles = 0;
 }
 #endif /* CONFIG_THREAD_RUNTIME_STATS */
 

--- a/subsys/debug/thread_analyzer.c
+++ b/subsys/debug/thread_analyzer.c
@@ -110,6 +110,11 @@ static void thread_analyze_cb(const struct k_thread *cthread, void *user_data)
 	}
 #endif
 	cb(&info);
+
+#ifdef CONFIG_THREAD_RUNTIME_STATS
+	k_thread_runtime_stats_clear(thread);
+#endif
+
 }
 
 void thread_analyzer_run(thread_analyzer_cb cb)
@@ -133,6 +138,7 @@ void thread_analyzer_auto(void)
 {
 	for (;;) {
 		thread_analyzer_print();
+		k_thread_runtime_stats_all_clear();
 		k_sleep(K_SECONDS(CONFIG_THREAD_ANALYZER_AUTO_INTERVAL));
 	}
 }


### PR DESCRIPTION
The existing CPU cycle counts do not handle unsigned integer rollover
when taking the diff from previous cycles.

The existing cycles do not reset for the next analyzer interval.
This causes excessive accumulation of execution cycles and does not
provide an accurate run-time usage statistic.

This patch addresses these bugs by implementing runtime_stats_clear
functions for use by the thread analyser, and calculates the difference
from last_switched_cycles with the rollover case.

Fixes #37521 

Signed-off-by: Arien Judge <arienjudge@outlook.com>