### PR TITLE
posix: fix pthread for SMP platforms

### DIFF
--- a/lib/posix/pthread_barrier.c
+++ b/lib/posix/pthread_barrier.c
@@ -9,9 +9,11 @@
 #include <ksched.h>
 #include <wait_q.h>
 
+extern struct k_spinlock z_pthread_spinlock;
+
 int pthread_barrier_wait(pthread_barrier_t *b)
 {
-	unsigned int key = irq_lock();
+	k_spinlock_key_t key = k_spin_lock(&z_pthread_spinlock);
 	int ret = 0;
 
 	b->count++;
@@ -22,10 +24,10 @@ int pthread_barrier_wait(pthread_barrier_t *b)
 		while (z_waitq_head(&b->wait_q)) {
 			_ready_one_thread(&b->wait_q);
 		}
-		z_reschedule_irqlock(key);
+		z_reschedule(&z_pthread_spinlock, key);
 		ret = PTHREAD_BARRIER_SERIAL_THREAD;
 	} else {
-		(void) z_pend_curr_irqlock(key, &b->wait_q, K_FOREVER);
+		(void) z_pend_curr(&z_pthread_spinlock, key, &b->wait_q, K_FOREVER);
 	}
 
 	return ret;


### PR DESCRIPTION
We shouldn't use swapping with an interrupt lock held as it works incorrectly on SMP platforms (see #36736 for details)

Fix that by replacing irq_lock (which is defined to SMP global lock on SMP systems) with spinlock for pthread subsystem.

NOTE: we fix that in a simple way with single spinlock for mutex / cond_var / barrier. That could be improved later (i.e. split it for several spinlocks).

Fixes: #36736
Fixes: #37109