### PR TITLE
hwinfo: stm32: Enable PIN_RESET only if there were no other causes

### DIFF
--- a/drivers/hwinfo/hwinfo_stm32.c
+++ b/drivers/hwinfo/hwinfo_stm32.c
@@ -41,11 +41,6 @@ int z_impl_hwinfo_get_reset_cause(uint32_t *cause)
 		flags |= RESET_SOFTWARE;
 	}
 #endif
-#if defined(RCC_FLAG_PINRST)
-	if (LL_RCC_IsActiveFlag_PINRST()) {
-		flags |= RESET_PIN;
-	}
-#endif
 #if defined(RCC_FLAG_IWDGRST)
 	if (LL_RCC_IsActiveFlag_IWDGRST()) {
 		flags |= RESET_WATCHDOG;
@@ -79,6 +74,13 @@ int z_impl_hwinfo_get_reset_cause(uint32_t *cause)
 #if defined(RCC_FLAG_LPWRRST)
 	if (LL_RCC_IsActiveFlag_LPWRRST()) {
 		flags |= RESET_LOW_POWER_WAKE;
+	}
+#endif
+#if defined(RCC_FLAG_PINRST)
+	if (!flags) {
+		if (LL_RCC_IsActiveFlag_PINRST()) {
+			flags |= RESET_PIN;
+		}
 	}
 #endif
 


### PR DESCRIPTION
STM32 SoCs implement various reset types by pulling the reset
pin low. Therefore, these reset types set the PINRST flag, even
if the reset was not caused by an actual pin reset event.
To fix this, the driver should check the PINRST flag last,
and set PIN_RESET only if the other flags are unset.

Signed-off-by: Yonatan Schachter <yonatan.schachter@gmail.com>