### PR TITLE
PCIe extended configuration space API

### DIFF
--- a/arch/x86/core/pcie.c
+++ b/arch/x86/core/pcie.c
@@ -142,6 +142,19 @@ static inline void pcie_conf(pcie_bdf_t bdf, unsigned int reg,
 
 /* these functions are explained in include/drivers/pcie/pcie.h */
 
+bool pcie_ecam_access(void)
+{
+#ifdef CONFIG_PCIE_MMIO_CFG
+	if (bus_segs[0].mmio == NULL) {
+		pcie_mm_init();
+	}
+
+	return do_pcie_mmio_cfg;
+#else
+	return false;
+#endif
+}
+
 uint32_t pcie_conf_read(pcie_bdf_t bdf, unsigned int reg)
 {
 	uint32_t data = 0U;

--- a/drivers/pcie/host/pcie.c
+++ b/drivers/pcie/host/pcie.c
@@ -71,6 +71,36 @@ uint32_t pcie_get_cap(pcie_bdf_t bdf, uint32_t cap_id)
 	return reg;
 }
 
+uint32_t pcie_get_ext_cap(pcie_bdf_t bdf, uint32_t ext_cap_id)
+{
+	uint32_t reg = PCIE_CONF_SPACE_SIZE;
+	uint32_t data;
+
+	if (!pcie_ecam_access()) {
+		return 0;
+	}
+
+	while (reg != 0) {
+		data = pcie_conf_read(bdf, reg);
+		if (data == 0) {
+			return 0;
+		}
+
+		if (PCIE_EXT_CONF_CAP_ID(data) == ext_cap_id) {
+			break;
+		}
+
+		reg = PCIE_EXT_CONF_CAP_NEXT(data);
+		if ((reg < PCIE_CONF_SPACE_SIZE) ||
+		    (reg > (PCIE_EXT_CONF_SPACE_SIZE -
+			     PCIE_EXT_CONF_CAP_MIN_SIZE))) {
+			return 0;
+		}
+	}
+
+	return reg;
+}
+
 bool pcie_get_mbar(pcie_bdf_t bdf, unsigned int index, struct pcie_mbar *mbar)
 {
 	uintptr_t phys_addr;

--- a/drivers/pcie/host/shell.c
+++ b/drivers/pcie/host/shell.c
@@ -93,6 +93,16 @@ static void show(const struct shell *shell, pcie_bdf_t bdf)
 				      "    wired interrupt on IRQ %d\n", irq);
 		}
 	}
+
+	if (pcie_ecam_access()) {
+		data = pcie_conf_read(bdf, PCIE_CONF_SPACE_SIZE);
+	} else {
+		data = 0;
+	}
+
+	shell_fprintf(shell, SHELL_NORMAL,
+		      "    %sExtended Capabilities available\n",
+		      data == 0 ? "No " : "");
 }
 
 static int cmd_pcie_ls(const struct shell *shell, size_t argc, char **argv)

--- a/drivers/pcie/host/shell.c
+++ b/drivers/pcie/host/shell.c
@@ -18,7 +18,6 @@ static void show_msi(const struct shell *shell, pcie_bdf_t bdf)
 	uint32_t data;
 
 	msi = pcie_get_cap(bdf, PCIE_MSI_CAP_ID);
-
 	if (msi) {
 		data = pcie_conf_read(bdf, msi + PCIE_MSI_MCR);
 		shell_fprintf(shell, SHELL_NORMAL, "    MSI support%s%s\n",
@@ -27,7 +26,6 @@ static void show_msi(const struct shell *shell, pcie_bdf_t bdf)
 	}
 
 	msi = pcie_get_cap(bdf, PCIE_MSIX_CAP_ID);
-
 	if (msi) {
 		shell_fprintf(shell, SHELL_NORMAL, "    MSI-X support\n");
 	}
@@ -63,7 +61,6 @@ static void show(const struct shell *shell, pcie_bdf_t bdf)
 	unsigned int irq;
 
 	data = pcie_conf_read(bdf, PCIE_CONF_ID);
-
 	if (data == PCIE_ID_NONE) {
 		return;
 	}
@@ -84,7 +81,6 @@ static void show(const struct shell *shell, pcie_bdf_t bdf)
 		     PCIE_CONF_CLASSREV_REV(data));
 
 	data = pcie_conf_read(bdf, PCIE_CONF_TYPE);
-
 	if (PCIE_CONF_TYPE_BRIDGE(data)) {
 		shell_fprintf(shell, SHELL_NORMAL, " [bridge]\n");
 	} else {

--- a/include/drivers/pcie/pcie.h
+++ b/include/drivers/pcie/pcie.h
@@ -156,6 +156,44 @@ extern void pcie_irq_enable(pcie_bdf_t bdf, unsigned int irq);
  */
 extern uint32_t pcie_get_cap(pcie_bdf_t bdf, uint32_t cap_id);
 
+/**
+ * @brief Check if PCIe is access through ECAM
+ *
+ * Note: Enhanced Configuration Access Mechanism is mandatory for extended
+ *       configuration space access.
+ *
+ * This function is exported by the arch/SoC/board code.
+ *
+ * @return True if ECAM is enabled, False otherwise
+ */
+extern bool pcie_ecam_access(void);
+
+/**
+ * @brief Find a PCIe extended capability in a device's extended configuration
+ *        space.
+ *
+ * @param bdf the PCI device to examine
+ * @param ext_cap_id The extended capability ID of interest
+ * @return the index of the configuration word, or 0 if no capability.
+ */
+extern uint32_t pcie_get_ext_cap(pcie_bdf_t bdf, uint32_t ext_cap_id);
+
+/*
+ * Extended Configuration space size
+ * (Note: this includes the legacy configuration space as well)
+ */
+#define PCIE_EXT_CONF_SPACE_SIZE	4096U
+
+#define PCIE_EXT_CONF_CAP_ID(w)		((w) & 0xFFFFU)
+#define PCIE_EXT_CONF_CAP_NEXT(w)	(((w) >> 20) & 0xFFCU)
+
+#define PCIE_EXT_CONF_CAP_MIN_SIZE	8
+
+/*
+ * Legacy Configuration space size
+ */
+#define PCIE_CONF_SPACE_SIZE	256U
+
 /*
  * Configuration word 13 contains the head of the capabilities list.
  */


### PR DESCRIPTION
This is a proposal for reading getting extended capabilities in PCIe

I put it as DNM since it looks like pcie_conf_read() on x86 (the MMIO verion, or "ECAM") seems to be buggy. 
PCIe specs says that if extended caps are not there we should read 0s for the very first header. And that's not what is happening: it sometimes reads "0xFFFFFFFF" which is against the specs. And it reminds me a case where reading inaccessible memory in fact returns a register full of 1s. 

I'll investigate that. I could see that we always assume the space to be 4096 bytes, but is that always the case? 