### PR TITLE
bluetooth: Add defines for ECC key lengths

### DIFF
--- a/subsys/bluetooth/host/ecc.c
+++ b/subsys/bluetooth/host/ecc.c
@@ -16,11 +16,11 @@
 #define LOG_MODULE_NAME bt_ecc
 #include "common/log.h"
 
-static uint8_t pub_key[64];
+static uint8_t pub_key[BT_PUB_KEY_LEN];
 static sys_slist_t pub_key_cb_slist;
 static bt_dh_key_cb_t dh_key_cb;
 
-static const uint8_t debug_public_key[64] = {
+static const uint8_t debug_public_key[BT_PUB_KEY_LEN] = {
 	/* X */
 	0xe6, 0x9d, 0x35, 0x0e, 0x48, 0x01, 0x03, 0xcc,
 	0xdb, 0xfd, 0xf4, 0xac, 0x11, 0x91, 0xf4, 0xef,
@@ -35,7 +35,7 @@ static const uint8_t debug_public_key[64] = {
 
 bool bt_pub_key_is_debug(uint8_t *pub_key)
 {
-	return memcmp(pub_key, debug_public_key, 64) == 0;
+	return memcmp(pub_key, debug_public_key, BT_PUB_KEY_LEN) == 0;
 }
 
 int bt_pub_key_gen(struct bt_pub_key_cb *new_cb)
@@ -150,7 +150,7 @@ static int hci_generate_dhkey_v2(const uint8_t *remote_pk, uint8_t key_type)
 	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_GENERATE_DHKEY_V2, buf, NULL);
 }
 
-int bt_dh_key_gen(const uint8_t remote_pk[64], bt_dh_key_cb_t cb)
+int bt_dh_key_gen(const uint8_t remote_pk[BT_PUB_KEY_LEN], bt_dh_key_cb_t cb)
 {
 	int err;
 
@@ -195,7 +195,7 @@ void bt_hci_evt_le_pkey_complete(struct net_buf *buf)
 	atomic_clear_bit(bt_dev.flags, BT_DEV_PUB_KEY_BUSY);
 
 	if (!evt->status) {
-		memcpy(pub_key, evt->key, 64);
+		memcpy(pub_key, evt->key, BT_PUB_KEY_LEN);
 		atomic_set_bit(bt_dev.flags, BT_DEV_HAS_PUB_KEY);
 	}
 

--- a/subsys/bluetooth/host/ecc.h
+++ b/subsys/bluetooth/host/ecc.h
@@ -6,6 +6,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/** Key size used in Bluetooth's ECC domain. */
+#define BT_ECC_KEY_SIZE            32
+/** Length of a Bluetooth ECC public key coordinate. */
+#define BT_PUB_KEY_COORD_LEN       (BT_ECC_KEY_SIZE)
+/** Length of a Bluetooth ECC public key. */
+#define BT_PUB_KEY_LEN             (2 * (BT_PUB_KEY_COORD_LEN))
+/** Length of a Bluetooth ECC private key. */
+#define BT_PRIV_KEY_LEN            (BT_ECC_KEY_SIZE)
+/** Length of a Bluetooth Diffie-Hellman key. */
+#define BT_DH_KEY_LEN              (BT_ECC_KEY_SIZE)
+
 /*  @brief Container for public key callback */
 struct bt_pub_key_cb {
 	/** @brief Callback type for Public Key generation.
@@ -16,7 +27,7 @@ struct bt_pub_key_cb {
 	 *
 	 *  @param key The local public key, or NULL in case of no key.
 	 */
-	void (*func)(const uint8_t key[64]);
+	void (*func)(const uint8_t key[BT_PUB_KEY_LEN]);
 
 	/* Internal */
 	sys_snode_t node;
@@ -63,7 +74,7 @@ const uint8_t *bt_pub_key_get(void);
  *
  *  @param key The DH Key, or NULL in case of failure.
  */
-typedef void (*bt_dh_key_cb_t)(const uint8_t key[32]);
+typedef void (*bt_dh_key_cb_t)(const uint8_t key[BT_DH_KEY_LEN]);
 
 /*  @brief Calculate a DH Key from a remote Public Key.
  *
@@ -74,4 +85,4 @@ typedef void (*bt_dh_key_cb_t)(const uint8_t key[32]);
  *
  *  @return Zero on success or negative error code otherwise
  */
-int bt_dh_key_gen(const uint8_t remote_pk[64], bt_dh_key_cb_t cb);
+int bt_dh_key_gen(const uint8_t remote_pk[BT_PUB_KEY_LEN], bt_dh_key_cb_t cb);

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -167,10 +167,10 @@ struct bt_smp {
 	uint8_t				tk[16];
 
 	/* Remote Public Key for LE SC */
-	uint8_t				pkey[64];
+	uint8_t				pkey[BT_PUB_KEY_LEN];
 
 	/* DHKey */
-	uint8_t				dhkey[32];
+	uint8_t				dhkey[BT_DH_KEY_LEN];
 
 	/* Remote DHKey check */
 	uint8_t				e[16];
@@ -3520,7 +3520,7 @@ static uint8_t smp_dhkey_ready(struct bt_smp *smp, const uint8_t *dhkey)
 	}
 
 	atomic_clear_bit(smp->flags, SMP_FLAG_DHKEY_PENDING);
-	memcpy(smp->dhkey, dhkey, 32);
+	memcpy(smp->dhkey, dhkey, BT_DH_KEY_LEN);
 
 	/* wait for user passkey confirmation */
 	if (atomic_test_bit(smp->flags, SMP_FLAG_USER)) {
@@ -4159,7 +4159,7 @@ static uint8_t smp_public_key_slave(struct bt_smp *smp)
 	uint8_t err;
 
 	if (!atomic_test_bit(smp->flags, SMP_FLAG_SC_DEBUG_KEY) &&
-	    memcmp(smp->pkey, sc_public_key, 32) == 0) {
+	    memcmp(smp->pkey, sc_public_key, BT_PUB_KEY_COORD_LEN) == 0) {
 		/* Deny public key with identitcal X coordinate unless it is the
 		 * debug public key.
 		 */
@@ -4216,8 +4216,8 @@ static uint8_t smp_public_key(struct bt_smp *smp, struct net_buf *buf)
 
 	BT_DBG("");
 
-	memcpy(smp->pkey, req->x, 32);
-	memcpy(&smp->pkey[32], req->y, 32);
+	memcpy(smp->pkey, req->x, BT_PUB_KEY_COORD_LEN);
+	memcpy(&smp->pkey[BT_PUB_KEY_COORD_LEN], req->y, BT_PUB_KEY_COORD_LEN);
 
 	/* mark key as debug if remote is using it */
 	if (bt_pub_key_is_debug(smp->pkey)) {
@@ -4235,7 +4235,7 @@ static uint8_t smp_public_key(struct bt_smp *smp, struct net_buf *buf)
 	if (IS_ENABLED(CONFIG_BT_CENTRAL) &&
 	    smp->chan.chan.conn->role == BT_HCI_ROLE_MASTER) {
 		if (!atomic_test_bit(smp->flags, SMP_FLAG_SC_DEBUG_KEY) &&
-		    memcmp(smp->pkey, sc_public_key, 32) == 0) {
+		    memcmp(smp->pkey, sc_public_key, BT_PUB_KEY_COORD_LEN) == 0) {
 			/* Deny public key with identitcal X coordinate unless
 			 * it is the debug public key.
 			 */

--- a/subsys/bluetooth/mesh/adv.c
+++ b/subsys/bluetooth/mesh/adv.c
@@ -23,6 +23,7 @@
 #include "net.h"
 #include "foundation.h"
 #include "beacon.h"
+#include "host/ecc.h"
 #include "prov.h"
 #include "proxy.h"
 

--- a/subsys/bluetooth/mesh/adv_legacy.c
+++ b/subsys/bluetooth/mesh/adv_legacy.c
@@ -25,6 +25,7 @@
 #include "net.h"
 #include "foundation.h"
 #include "beacon.h"
+#include "host/ecc.h"
 #include "prov.h"
 #include "proxy.h"
 

--- a/subsys/bluetooth/mesh/beacon.c
+++ b/subsys/bluetooth/mesh/beacon.c
@@ -20,6 +20,7 @@
 #include "adv.h"
 #include "mesh.h"
 #include "net.h"
+#include "host/ecc.h"
 #include "prov.h"
 #include "crypto.h"
 #include "beacon.h"

--- a/subsys/bluetooth/mesh/gatt_services.c
+++ b/subsys/bluetooth/mesh/gatt_services.c
@@ -23,6 +23,7 @@
 #include "net.h"
 #include "rpl.h"
 #include "transport.h"
+#include "host/ecc.h"
 #include "prov.h"
 #include "beacon.h"
 #include "foundation.h"

--- a/subsys/bluetooth/mesh/main.c
+++ b/subsys/bluetooth/mesh/main.c
@@ -20,6 +20,7 @@
 
 #include "test.h"
 #include "adv.h"
+#include "host/ecc.h"
 #include "prov.h"
 #include "provisioner.h"
 #include "net.h"

--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -34,6 +34,7 @@
 #include "foundation.h"
 #include "beacon.h"
 #include "settings.h"
+#include "host/ecc.h"
 #include "prov.h"
 #include "cfg.h"
 

--- a/subsys/bluetooth/mesh/pb_adv.c
+++ b/subsys/bluetooth/mesh/pb_adv.c
@@ -14,6 +14,7 @@
 #include "adv.h"
 #include "crypto.h"
 #include "beacon.h"
+#include "host/ecc.h"
 #include "prov.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_MESH_DEBUG_PROV)

--- a/subsys/bluetooth/mesh/pb_gatt.c
+++ b/subsys/bluetooth/mesh/pb_gatt.c
@@ -9,6 +9,7 @@
 #include "net.h"
 #include "proxy.h"
 #include "adv.h"
+#include "host/ecc.h"
 #include "prov.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_MESH_DEBUG_PROV)

--- a/subsys/bluetooth/mesh/prov.c
+++ b/subsys/bluetooth/mesh/prov.c
@@ -48,7 +48,7 @@ static void pub_key_ready(const uint8_t *pkey)
 	BT_DBG("Local public key ready");
 }
 
-int bt_mesh_prov_reset_state(void (*func)(const uint8_t key[64]))
+int bt_mesh_prov_reset_state(void (*func)(const uint8_t key[BT_PUB_KEY_LEN]))
 {
 	int err;
 	static struct bt_pub_key_cb pub_key_cb;

--- a/subsys/bluetooth/mesh/prov.h
+++ b/subsys/bluetooth/mesh/prov.h
@@ -113,7 +113,7 @@ struct bt_mesh_prov_link {
 	uint8_t oob_size;               /* Authen size */
 	uint8_t auth[16];               /* Authen value */
 
-	uint8_t dhkey[32];              /* Calculated DHKey */
+	uint8_t dhkey[BT_DH_KEY_LEN];   /* Calculated DHKey */
 	uint8_t expect;                 /* Next expected PDU */
 
 	uint8_t conf[16];               /* Remote Confirmation */
@@ -147,7 +147,7 @@ static inline void bt_mesh_prov_buf_init(struct net_buf_simple *buf, uint8_t typ
 	net_buf_simple_add_u8(buf, type);
 }
 
-int bt_mesh_prov_reset_state(void (*func)(const uint8_t key[64]));
+int bt_mesh_prov_reset_state(void (*func)(const uint8_t key[BT_PUB_KEY_LEN]));
 
 bool bt_mesh_prov_active(void);
 

--- a/subsys/bluetooth/mesh/proxy_msg.c
+++ b/subsys/bluetooth/mesh/proxy_msg.c
@@ -25,6 +25,7 @@
 #include "net.h"
 #include "rpl.h"
 #include "transport.h"
+#include "host/ecc.h"
 #include "prov.h"
 #include "beacon.h"
 #include "foundation.h"

--- a/subsys/bluetooth/mesh/subnet.c
+++ b/subsys/bluetooth/mesh/subnet.c
@@ -36,6 +36,7 @@
 #include "beacon.h"
 #include "rpl.h"
 #include "settings.h"
+#include "host/ecc.h"
 #include "prov.h"
 
 /* Tracking of what storage changes are pending for Net Keys. We track this in


### PR DESCRIPTION
Adds defines for ECC public keys, private keys, DH keys and key
coordinates. Replaces raw numbers throughout.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>

Hex files for the mesh, central_hr and peripheral_hids samples in this branch are identical to builds on main.