### PR TITLE
boards: efr32mg_sltb004a: Add minimal pwm support

### DIFF
--- a/boards/arm/efr32mg_sltb004a/efr32mg_sltb004a.dts
+++ b/boards/arm/efr32mg_sltb004a/efr32mg_sltb004a.dts
@@ -15,6 +15,7 @@
 	aliases {
 		led0 = &led0;
 		led1 = &led1;
+		pwm-led0 = &pwm_led0;
 		sw0 = &button0;
 		sw1 = &button1;
 		watchdog0 = &wdog0;
@@ -51,6 +52,14 @@
 			/* gpio flags need validation */
 			gpios = <&gpiod 15 GPIO_ACTIVE_LOW>;
 			label = "User Push Button 1";
+		};
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+		status = "okay";
+		pwm_led0: pwm_led0 {
+			pwms = <&pwm0 0 PWM_POLARITY_NORMAL>;
 		};
 	};
 };
@@ -139,6 +148,16 @@
 &rtcc0 {
 	prescaler = <1>;
 	status = "okay";
+};
+
+&timer0 {
+	status = "okay";
+
+	pwm0: pwm {
+		status = "okay";
+		pin-location = <GECKO_LOCATION(17) GECKO_PORT_D GECKO_PIN(9)>;
+		prescaler = <1024>;
+	};
 };
 
 &gpio {

--- a/dts/arm/silabs/efr32mg.dtsi
+++ b/dts/arm/silabs/efr32mg.dtsi
@@ -4,6 +4,7 @@
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/i2c/i2c.h>
 #include "gpio_gecko.h"
+#include <dt-bindings/pwm/pwm.h>
 
 / {
 	chosen {
@@ -232,6 +233,20 @@
 			label = "WDOG1";
 			interrupts = <3 0>;
 			status = "disabled";
+		};
+
+		timer0: timer@40018000 {
+			compatible = "silabs,gecko-timers";
+			reg = <0x40018000 0x400>;
+			status = "disabled";
+			label = "TIMER_0";
+
+			pwm {
+				compatible = "silabs,gecko-pwm";
+				status = "disabled";
+				label = "PWM_0";
+				#pwm-cells = <2>;
+			};
 		};
 
 		trng0: trng@4001d000 {

--- a/soc/arm/silabs_exx32/efr32mg12p/Kconfig.defconfig.efr32mg12p
+++ b/soc/arm/silabs_exx32/efr32mg12p/Kconfig.defconfig.efr32mg12p
@@ -28,3 +28,7 @@ config SOC_FLASH_GECKO
 config SPI_GECKO
 	default y
 	depends on SPI
+
+config PWM_GECKO
+	default y
+	depends on PWM


### PR DESCRIPTION
Add minimal pwm support to the efr32mg12p soc and the Thunderboard Sense 2 board.

Signed-off-by: Christian Taedcke <christian.taedcke@lemonbeat.com>