### PR TITLE
drivers: esp32: fix data range check

### DIFF
--- a/drivers/flash/flash_esp32.c
+++ b/drivers/flash/flash_esp32.c
@@ -445,7 +445,7 @@ static int program_page(const struct device *dev, uint32_t spi_addr,
 	}
 
 	/* check if write in one page */
-	if (page_size < (spi_addr % (page_size + byte_length))) {
+	if (page_size < ((spi_addr % page_size) + byte_length)) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Fix typo in range check regarding
single page writing.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>