### PR TITLE
shell: improve shell_execute_cmd function

### DIFF
--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1608,6 +1608,8 @@ int shell_execute_cmd(const struct shell *shell, const char *cmd)
 	ret_val = execute(shell);
 	k_mutex_unlock(&shell->ctx->wr_mtx);
 
+	cmd_buffer_clear(shell);
+
 	return ret_val;
 }
 


### PR DESCRIPTION
The function to execute shell commands: shell_execute_cmd will now
behave similarly to invoking command line commands.
I.e. after the command is executed the command buffer is cleared,
while the cursor is set to the initial position.

Signed-off-by: Jakub Rzeszutko <jakub.rzeszutko@nordicsemi.no>