### PR TITLE
dts: arm: stm32f373x soc has 2 dma instances of same type.

### DIFF
--- a/dts/arm/st/f3/stm32f373Xc.dtsi
+++ b/dts/arm/st/f3/stm32f373Xc.dtsi
@@ -20,7 +20,7 @@
 		};
 
 		dma2: dma@40020400 {
-			compatible = "st,stm32-dma-v2";
+			compatible = "st,stm32-dma-v2bis";
 			reg = <0x40020400 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x2>;
 			interrupts = <56 0 57 0 58 0 59 0 60 0>;


### PR DESCRIPTION
Like the first instance of the dma in the stm32l3xx soc,
the second DMA instance of the stm32f373 is of the same type
V2bis : dma  request is fixed (no dma-slot).

It was wrongly defined has type V2 instead of V2bis (only STM32373C_EVAL Evaluation Board might be impacted ).

Signed-off-by: Francois Ramu <francois.ramu@st.com>