### PR TITLE
doc: Improve drivers documentation

### DIFF
--- a/doc/reference/drivers/index.rst
+++ b/doc/reference/drivers/index.rst
@@ -147,7 +147,7 @@ A subsystem API definition typically looks like this:
         struct subsystem_api *api;
 
         api = (struct subsystem_api *)dev->api;
-        api->do_that(dev, foo, bar);
+        api->do_that(dev, baz);
   }
 
 A driver implementing a particular subsystem will define the real implementation
@@ -474,7 +474,7 @@ is made within the init function:
    {
       ...
       /* Write some data to the MMIO region */
-      sys_write32(DEVICE_MMIO_GET(dev), 0xDEADBEEF);
+      sys_write32(0xDEADBEEF, DEVICE_MMIO_GET(dev));
       ...
    }
 
@@ -536,8 +536,8 @@ For example:
    {
       ...
       /* Write some data to the MMIO regions */
-      sys_write32(DEVICE_MMIO_GET(dev, grault), 0xDEADBEEF);
-      sys_write32(DEVICE_MMIO_GET(dev, courge), 0xF0CCAC1A);
+      sys_write32(0xDEADBEEF, DEVICE_MMIO_GET(dev, grault));
+      sys_write32(0xF0CCAC1A, DEVICE_MMIO_GET(dev, courge));
       ...
    }
 

--- a/doc/reference/drivers/index.rst
+++ b/doc/reference/drivers/index.rst
@@ -499,14 +499,14 @@ For example:
 
    struct my_driver_config {
       ...
-    	DEVICE_MMIO_NAMED_ROM(courge);
+    	DEVICE_MMIO_NAMED_ROM(corge);
    	DEVICE_MMIO_NAMED_ROM(grault);
       ...
    }
 
    struct my_driver_dev_data {
   	   ...
-   	DEVICE_MMIO_NAMED_RAM(courge);
+   	DEVICE_MMIO_NAMED_RAM(corge);
    	DEVICE_MMIO_NAMED_RAM(grault);
    	...
    }
@@ -519,7 +519,7 @@ For example:
 
    const static struct my_driver_config my_driver_config_0 = {
       ...
-      DEVICE_MMIO_NAMED_ROM_INIT(courge, DT_DRV_INST(...)),
+      DEVICE_MMIO_NAMED_ROM_INIT(corge, DT_DRV_INST(...)),
       DEVICE_MMIO_NAMED_ROM_INIT(grault, DT_DRV_INST(...)),
       ...
    }
@@ -527,7 +527,7 @@ For example:
    int my_driver_init(const struct device *dev)
    {
       ...
-      DEVICE_MMIO_NAMED_MAP(dev, courge, K_MEM_CACHE_NONE);
+      DEVICE_MMIO_NAMED_MAP(dev, corge, K_MEM_CACHE_NONE);
       DEVICE_MMIO_NAMED_MAP(dev, grault, K_MEM_CACHE_NONE);
       ...
    }
@@ -537,7 +537,7 @@ For example:
       ...
       /* Write some data to the MMIO regions */
       sys_write32(0xDEADBEEF, DEVICE_MMIO_GET(dev, grault));
-      sys_write32(0xF0CCAC1A, DEVICE_MMIO_GET(dev, courge));
+      sys_write32(0xF0CCAC1A, DEVICE_MMIO_GET(dev, corge));
       ...
    }
 

--- a/include/sys/device_mmio.h
+++ b/include/sys/device_mmio.h
@@ -323,7 +323,7 @@ struct z_device_mmio_rom {
  *
  * struct foo_driver_data {
  *      int blarg;
- *      DEVICE_MMIO_NAMED_RAM(courge);
+ *      DEVICE_MMIO_NAMED_RAM(corge);
  *      DEVICE_MMIO_NAMED_RAM(grault);
  *      int wibble;
  *      ...
@@ -380,7 +380,7 @@ struct z_device_mmio_rom {
  *
  * struct foo_config {
  *      int bar;
- *      DEVICE_MMIO_NAMED_ROM(courge);
+ *      DEVICE_MMIO_NAMED_ROM(corge);
  *      DEVICE_MMIO_NAMED_ROM(grault);
  *      int baz;
  *      ...
@@ -417,11 +417,11 @@ struct z_device_mmio_rom {
  * a device config struct, using information from DTS.
  *
  * Example for an instance of a driver belonging to the "foo" subsystem
- * that will have two regions named 'courge' and 'grault':
+ * that will have two regions named 'corge' and 'grault':
  *
  * struct foo_config my_config = {
  *	bar = 7;
- *	DEVICE_MMIO_NAMED_ROM_INIT(courge, DT_DRV_INST(...));
+ *	DEVICE_MMIO_NAMED_ROM_INIT(corge, DT_DRV_INST(...));
  *	DEVICE_MMIO_NAMED_ROM_INIT(grault, DT_DRV_INST(...));
  *	baz = 2;
  *	...

--- a/tests/kernel/device/src/mmio.c
+++ b/tests/kernel/device/src/mmio.c
@@ -103,19 +103,19 @@ void test_mmio_single(void)
 struct foo_mult_dev_data {
 	int baz;
 
-	DEVICE_MMIO_NAMED_RAM(courge);
+	DEVICE_MMIO_NAMED_RAM(corge);
 	DEVICE_MMIO_NAMED_RAM(grault);
 };
 
 struct foo_mult_dev_data foo12_data;
 
 struct foo_mult_config_info {
-	DEVICE_MMIO_NAMED_ROM(courge);
+	DEVICE_MMIO_NAMED_ROM(corge);
 	DEVICE_MMIO_NAMED_ROM(grault);
 };
 
 const struct foo_mult_config_info foo12_config = {
-	DEVICE_MMIO_NAMED_ROM_INIT(courge, DT_DRV_INST(1)),
+	DEVICE_MMIO_NAMED_ROM_INIT(corge, DT_DRV_INST(1)),
 	DEVICE_MMIO_NAMED_ROM_INIT(grault, DT_DRV_INST(2))
 };
 
@@ -124,7 +124,7 @@ const struct foo_mult_config_info foo12_config = {
 
 int foo_mult_init(const struct device *dev)
 {
-	DEVICE_MMIO_NAMED_MAP(dev, courge, K_MEM_CACHE_NONE);
+	DEVICE_MMIO_NAMED_MAP(dev, corge, K_MEM_CACHE_NONE);
 	DEVICE_MMIO_NAMED_MAP(dev, grault, K_MEM_CACHE_NONE);
 
 	return 0;
@@ -143,7 +143,7 @@ DEVICE_DEFINE(foo12, "foo12", foo_mult_init, NULL,
  * stuff somewhere.
  *
  * We show that this works for a device instance that has two named regions,
- * 'courge' and 'grault' that respectively come from DTS instances 1 and 2.
+ * 'corge' and 'grault' that respectively come from DTS instances 1 and 2.
  *
  * We also perform some checks depending on configuration:
  * - If MMIO addresses are maintained in RAM, check that the ROM struct
@@ -159,32 +159,32 @@ void test_mmio_multiple(void)
 {
 	/* See comments for test_mmio_single */
 	const struct device *dev = device_get_binding("foo12");
-	mm_reg_t regs_courge, regs_grault;
-	const struct z_device_mmio_rom *rom_courge, *rom_grault;
+	mm_reg_t regs_corge, regs_grault;
+	const struct z_device_mmio_rom *rom_corge, *rom_grault;
 
 	zassert_not_null(dev, "null foo12");
 
-	regs_courge = DEVICE_MMIO_NAMED_GET(dev, courge);
+	regs_corge = DEVICE_MMIO_NAMED_GET(dev, corge);
 	regs_grault = DEVICE_MMIO_NAMED_GET(dev, grault);
-	rom_courge = DEVICE_MMIO_NAMED_ROM_PTR(dev, courge);
+	rom_corge = DEVICE_MMIO_NAMED_ROM_PTR(dev, corge);
 	rom_grault = DEVICE_MMIO_NAMED_ROM_PTR(dev, grault);
 
-	zassert_not_equal(regs_courge, 0, "bad regs_courge");
+	zassert_not_equal(regs_corge, 0, "bad regs_corge");
 	zassert_not_equal(regs_grault, 0, "bad regs_grault");
 
 #ifdef DEVICE_MMIO_IS_IN_RAM
-	zassert_equal(rom_courge->phys_addr, DT_INST_REG_ADDR(1),
-		      "bad phys_addr (courge)");
-	zassert_equal(rom_courge->size, DT_INST_REG_SIZE(1),
-		      "bad size (courge)");
+	zassert_equal(rom_corge->phys_addr, DT_INST_REG_ADDR(1),
+		      "bad phys_addr (corge)");
+	zassert_equal(rom_corge->size, DT_INST_REG_SIZE(1),
+		      "bad size (corge)");
 	zassert_equal(rom_grault->phys_addr, DT_INST_REG_ADDR(2),
 		      "bad phys_addr (grault)");
 	zassert_equal(rom_grault->size, DT_INST_REG_SIZE(2),
 		      "bad size (grault)");
 #else
-	zassert_equal(rom_courge->addr, DT_INST_REG_ADDR(1),
-		      "bad addr (courge)");
-	zassert_equal(regs_courge, rom_courge->addr, "bad regs (courge)");
+	zassert_equal(rom_corge->addr, DT_INST_REG_ADDR(1),
+		      "bad addr (corge)");
+	zassert_equal(regs_corge, rom_corge->addr, "bad regs (corge)");
 	zassert_equal(rom_grault->addr, DT_INST_REG_ADDR(2),
 		      "bad addr (grault)");
 	zassert_equal(regs_grault, rom_grault->addr, "bad regs (grault)");
@@ -231,7 +231,7 @@ void test_mmio_toplevel(void)
 	rom_foo3 = DEVICE_MMIO_TOPLEVEL_ROM_PTR(foo3);
 	rom_foo4 = DEVICE_MMIO_TOPLEVEL_ROM_PTR(foo4);
 
-	zassert_not_equal(regs_foo3, 0, "bad regs_courge");
+	zassert_not_equal(regs_foo3, 0, "bad regs_corge");
 	zassert_not_equal(regs_foo4, 0, "bad regs_grault");
 
 #ifdef DEVICE_MMIO_IS_IN_RAM


### PR DESCRIPTION
Drivers documentation was updated to match the functions signatures.
Also "courge" looked like a misspelling of "corge" so it was changed.