### PR TITLE
kernel: mark z_current_get() as const

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -494,6 +494,7 @@ __syscall void k_wakeup(k_tid_t thread);
  *
  * @return ID of current thread.
  */
+__attribute_const__
 __syscall k_tid_t z_current_get(void);
 
 #ifdef CONFIG_THREAD_LOCAL_STORAGE


### PR DESCRIPTION
In commit 00f95032938e1387126f453b64f8c479987ca16e to make
k_current_get() work without syscall, a new z_current_get()
was introduced since there are times when thread local
storage has not been initialized. However, this was not
marked with const attribute the same as k_current_get().
This may result in slower compiled code as each call to
z_current_get() may actually need to go through the whole
function call process instead of reusing the result from
previous call in the same scope. So add const attribute
to z_current_get() to restore the old behavior.

Fixes #37460

Signed-off-by: Daniel Leung <daniel.leung@intel.com>