### PR TITLE
cmake: add a comment header to zephyr_settings.txt

### DIFF
--- a/cmake/zephyr_module.cmake
+++ b/cmake/zephyr_module.cmake
@@ -62,7 +62,7 @@ if(WEST OR ZEPHYR_MODULES)
   endif()
 
   if(EXISTS ${ZEPHYR_SETTINGS_FILE})
-    file(STRINGS ${ZEPHYR_SETTINGS_FILE} ZEPHYR_SETTINGS_TXT ENCODING UTF-8)
+    file(STRINGS ${ZEPHYR_SETTINGS_FILE} ZEPHYR_SETTINGS_TXT ENCODING UTF-8 REGEX "^[^#]")
     foreach(setting ${ZEPHYR_SETTINGS_TXT})
       # Match <key>:<value> for each line of file, each corresponding to
       # a setting.  The use of quotes is required due to CMake not supporting

--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -375,6 +375,16 @@ def main():
 
     if args.settings_out:
         with open(args.settings_out, 'w', encoding="utf-8") as fp:
+            fp.write('''\
+# WARNING. THIS FILE IS AUTO-GENERATED. DO NOT MODIFY!
+#
+# This file contains build system settings derived from your modules.
+#
+# Modules may be set via ZEPHYR_MODULES, ZEPHYR_EXTRA_MODULES,
+# and/or the west manifest file.
+#
+# See the Modules guide for more information.
+''')
             fp.write(settings)
 
     if args.twister_out:


### PR DESCRIPTION
I saw a user wondering what this is for and and where it comes from.
Provide a comment header with some explanation and a pointer to where
to find out more.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>