### PR TITLE
kernel: allow linking a prebuilt library instead of compiling

### DIFF
--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -3,6 +3,20 @@
 # kernel is a normal CMake library and not a zephyr_library because it
 # should not be --whole-archive'd
 
+# If a pre-built static library containing kernel code exists in
+# this directory, libkernel.a, link it with the application code
+# instead of building from source.
+zephyr_library_get_current_dir_lib_name(${ZEPHYR_BASE} libkernel_stem)
+set(libkernel ${CMAKE_CURRENT_SOURCE_DIR}/lib${libkernel_stem}${CMAKE_STATIC_LIBRARY_SUFFIX})
+unset(libkernel_stem)
+
+if(EXISTS ${libkernel})
+
+add_library(kernel INTERFACE)
+target_link_libraries(kernel INTERFACE ${libkernel})
+
+else()
+
 list(APPEND kernel_files
   banner.c
   device.c
@@ -92,6 +106,10 @@ target_include_directories(kernel PRIVATE
   ${ARCH_DIR}/${ARCH}/include
   )
 
+target_link_libraries(kernel zephyr_interface)
+
+endif()
+
 add_dependencies(kernel zephyr_generated_headers)
 
-target_link_libraries(kernel zephyr_interface)
+unset(libkernel)


### PR DESCRIPTION
This adds a very primitive logic to allow linking a prebuilt
static library of kernel code instead of building the kernel
from source. Note that the library is built with a specific
set of kconfigs, and they must match when building applications,
or else there would be mysterious crashes.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>