### PR TITLE
clock_control: add API to allow setting clock rate

### DIFF
--- a/drivers/clock_control/Kconfig
+++ b/drivers/clock_control/Kconfig
@@ -16,6 +16,15 @@ menuconfig CLOCK_CONTROL
 
 if CLOCK_CONTROL
 
+config CLOCK_CONTROL_ENABLE_SET_RATE
+	bool "Enable setting clock rate at runtime"
+	help
+	  This enables the APIs and supported drivers to set the clock
+	  rate at runtime.
+
+	  Say N if unsure, or if your application does not need this (which
+	  will save a few bytes).
+
 module = CLOCK_CONTROL
 module-str = clock control
 source "subsys/logging/Kconfig.template.log_config"


### PR DESCRIPTION
This adds to the clock control API so that clock rate can be
set at runtime. This is useful for setting rate on clocks
other than the one used for scheduling and timeouts. With this,
clocks can also be stopped to save on power if needed.
A new kconfig is used to enable this option. So for applications
that do not need this, they can save a few bytes in the API
struct.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>