### PR TITLE
host: l2cap: assign mtu and mps when chan is found

### DIFF
--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -1295,9 +1295,11 @@ static void le_ecred_reconf_req(struct bt_l2cap *l2cap, uint8_t ident,
 		goto response;
 	}
 
-	while (chan_count-- >= 0) {
+	while (chan_count >= 1) {
+		chan_count -= 1;
 		BT_L2CAP_LE_CHAN(chans[chan_count])->tx.mtu = mtu;
 		BT_L2CAP_LE_CHAN(chans[chan_count])->tx.mps = mps;
+
 	}
 
 	BT_DBG("mtu %u mps %u", mtu, mps);


### PR DESCRIPTION
In while loop there is a series of checks for valid request, starting
with finding matchin CID. If chan was not found assignment still took
place, leading to crash with MPU FAULT. Now new mtu and mps values
will be assigned only for valid channels.

Signed-off-by: Krzysztof Kopyściński <krzysztof.kopyscinski@codecoup.pl>