### PR TITLE
drivers: serial: stm32 uart defines dma slot with macro

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1462,7 +1462,7 @@ static int uart_stm32_pm_control(const struct device *dev,
 	.dma_dev = DEVICE_DT_GET(STM32_DMA_CTLR(index, dir)),			\
 	.dma_channel = DT_INST_DMAS_CELL_BY_NAME(index, dir, channel),	\
 	.dma_cfg = {							\
-		.dma_slot = DT_INST_DMAS_CELL_BY_NAME(index, dir, slot),\
+		.dma_slot = STM32_DMA_SLOT(index, dir, slot),\
 		.channel_direction = STM32_DMA_CONFIG_DIRECTION(	\
 					STM32_DMA_CHANNEL_CONFIG(index, dir)),\
 		.channel_priority = STM32_DMA_CONFIG_PRIORITY(		\


### PR DESCRIPTION
The STM32_DMA_SLOT macro from include/drivers/dma/dma_stm32.h
must be used here, especially for dma of type v2bis.
In this case, the dma-cell is not defined and slot is null.

This will fix compilation error when building tests/drivers/uart/uart_async_api for nucleo_l152re or stm32f3_disco
or any device with DMA of type V2bis.

Signed-off-by: Francois Ramu <francois.ramu@st.com>