### PR TITLE
[TOPIC-BLE-LLCP] Bluetooth: controller: added codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -591,7 +591,7 @@
 /share/zephyrunittest-package/            @tejlmand
 /subsys/bluetooth/                        @joerchan @jhedberg @Vudentz
 /subsys/bluetooth/audio/                  @joerchan @jhedberg @Vudentz @Thalley @asbjornsabo
-/subsys/bluetooth/controller/             @carlescufi @cvinayak @thoh-ot @kruithofa @erbr-ot @sjanc
+/subsys/bluetooth/controller/             @carlescufi @cvinayak @thoh-ot @kruithofa @erbr-ot @sjanc @tosk-ot @ppryga
 /subsys/bluetooth/mesh/                   @jhedberg @trond-snekvik @joerchan @Vudentz
 /subsys/canbus/                           @alexanderwachter
 /subsys/cpp/                              @vanwinkeljan
@@ -651,7 +651,7 @@
 /tests/benchmarks/cmsis_dsp/              @stephanosio
 /tests/boards/native_posix/               @aescolar @daor-oti
 /tests/boards/intel_s1000_crb/            @dcpleung @sathishkuttan
-/tests/bluetooth/                         @carlescufi @cvinayak @thoh-ot @kruithofa @erbr-ot @sjanc
+/tests/bluetooth/                         @carlescufi @cvinayak @thoh-ot @kruithofa @erbr-ot @sjanc @tosk-ot @ppryga
 /tests/bluetooth/bsim_bt/                 @joerchan @jhedberg @Vudentz @aescolar @wopu-ot
 /tests/bluetooth/bsim_bt/bsim_test_audio/ @joerchan @jhedberg @Vudentz @aescolar @wopu-ot @Thalley @asbjornsabo
 /tests/posix/                             @pfalcon


### PR DESCRIPTION
Added Piotr and Tommy as code owners, so that they automatically get assigned to PRs

Signed-off-by: Andries Kruithof <Andries.Kruithof@nordicsemi.no>