### PR TITLE
ARC: boards: allow Zephyr toolchain for ARCv3 64bit boards

### DIFF
--- a/boards/arc/nsim/nsim_hs6x.yaml
+++ b/boards/arc/nsim/nsim_hs6x.yaml
@@ -5,6 +5,7 @@ simulation: nsim
 arch: arc
 toolchain:
   - cross-compile
+  - zephyr
 testing:
   ignore_tags:
     - net

--- a/boards/arc/nsim/nsim_hs6x_smp.yaml
+++ b/boards/arc/nsim/nsim_hs6x_smp.yaml
@@ -5,6 +5,7 @@ simulation: mdb-nsim
 arch: arc
 toolchain:
   - cross-compile
+  - zephyr
 testing:
   ignore_tags:
     - net

--- a/boards/arc/qemu_arc/qemu_arc_hs6x.yaml
+++ b/boards/arc/qemu_arc/qemu_arc_hs6x.yaml
@@ -5,6 +5,7 @@ simulation: qemu
 arch: arc
 toolchain:
   - cross-compile
+  - zephyr
 testing:
   ignore_tags:
     - net


### PR DESCRIPTION
As 0.13 SDK is available and used in upstream verification by default we can allow Zephyr toolchain for ARCv3 64bit boards.

NOTE: currently we only allow to build ARCv3 64bit boards with Zephyr toolchain, we also need to enable testing on qemu in upstream verification after we fix / filter failing logging tests (`tests/subsys/logging/log_msg2` and `tests/subsys/logging/log_api`)