### PR TITLE
dts: psoc6: Use valid IRQ prio levels for CM4

### DIFF
--- a/dts/arm/cypress/psoc6.dtsi
+++ b/dts/arm/cypress/psoc6.dtsi
@@ -251,7 +251,7 @@
 		spi0: spi@40610000 {
 			compatible = "cypress,psoc6-spi";
 			reg = <0x40610000 0x10000>;
-			interrupts = <41 7>;
+			interrupts = <41 6>;
 			peripheral-id = <0>;
 			status = "disabled";
 			label = "spi_0";
@@ -261,7 +261,7 @@
 		spi1: spi@40620000 {
 			compatible = "cypress,psoc6-spi";
 			reg = <0x40620000 0x10000>;
-			interrupts = <42 7>;
+			interrupts = <42 6>;
 			peripheral-id = <1>;
 			status = "disabled";
 			label = "spi_1";
@@ -271,7 +271,7 @@
 		spi2: spi@40630000 {
 			compatible = "cypress,psoc6-spi";
 			reg = <0x40630000 0x10000>;
-			interrupts = <43 7>;
+			interrupts = <43 6>;
 			peripheral-id = <2>;
 			status = "disabled";
 			label = "spi_2";
@@ -281,7 +281,7 @@
 		spi3: spi@40640000 {
 			compatible = "cypress,psoc6-spi";
 			reg = <0x40640000 0x10000>;
-			interrupts = <44 7>;
+			interrupts = <44 6>;
 			peripheral-id = <3>;
 			status = "disabled";
 			label = "spi_3";
@@ -291,7 +291,7 @@
 		spi4: spi@40650000 {
 			compatible = "cypress,psoc6-spi";
 			reg = <0x40650000 0x10000>;
-			interrupts = <45 7>;
+			interrupts = <45 6>;
 			peripheral-id = <4>;
 			status = "disabled";
 			label = "spi_4";
@@ -301,7 +301,7 @@
 		spi5: spi@40660000 {
 			compatible = "cypress,psoc6-spi";
 			reg = <0x40660000 0x10000>;
-			interrupts = <46 7>;
+			interrupts = <46 6>;
 			peripheral-id = <5>;
 			status = "disabled";
 			label = "spi_5";
@@ -311,7 +311,7 @@
 		spi6: spi@40670000 {
 			compatible = "cypress,psoc6-spi";
 			reg = <0x40670000 0x10000>;
-			interrupts = <47 7>;
+			interrupts = <47 6>;
 			peripheral-id = <6>;
 			status = "disabled";
 			label = "spi_6";
@@ -321,7 +321,7 @@
 		spi7: spi@40680000 {
 			compatible = "cypress,psoc6-spi";
 			reg = <0x40680000 0x10000>;
-			interrupts = <48 7>;
+			interrupts = <48 6>;
 			peripheral-id = <7>;
 			status = "disabled";
 			label = "spi_7";
@@ -331,7 +331,7 @@
 		spi8: spi@40690000 {
 			compatible = "cypress,psoc6-spi";
 			reg = <0x40690000 0x10000>;
-			interrupts = <18 7>;
+			interrupts = <18 6>;
 			peripheral-id = <8>;
 			status = "disabled";
 			label = "spi_8";
@@ -342,7 +342,7 @@
 		uart0: uart@40610000 {
 			compatible = "cypress,psoc6-uart";
 			reg = <0x40610000 0x10000>;
-			interrupts = <41 7>;
+			interrupts = <41 6>;
 			peripheral-id = <0>;
 			status = "disabled";
 			label = "uart_0";
@@ -350,7 +350,7 @@
 		uart1: uart@40620000 {
 			compatible = "cypress,psoc6-uart";
 			reg = <0x40620000 0x10000>;
-			interrupts = <42 7>;
+			interrupts = <42 6>;
 			peripheral-id = <1>;
 			status = "disabled";
 			label = "uart_1";
@@ -358,7 +358,7 @@
 		uart2: uart@40630000 {
 			compatible = "cypress,psoc6-uart";
 			reg = <0x40630000 0x10000>;
-			interrupts = <43 7>;
+			interrupts = <43 6>;
 			peripheral-id = <2>;
 			status = "disabled";
 			label = "uart_2";
@@ -366,7 +366,7 @@
 		uart3: uart@40640000 {
 			compatible = "cypress,psoc6-uart";
 			reg = <0x40640000 0x10000>;
-			interrupts = <44 7>;
+			interrupts = <44 6>;
 			peripheral-id = <3>;
 			status = "disabled";
 			label = "uart_3";
@@ -374,7 +374,7 @@
 		uart4: uart@40650000 {
 			compatible = "cypress,psoc6-uart";
 			reg = <0x40650000 0x10000>;
-			interrupts = <45 7>;
+			interrupts = <45 6>;
 			peripheral-id = <4>;
 			status = "disabled";
 			label = "uart_4";
@@ -382,7 +382,7 @@
 		uart5: uart@40660000 {
 			compatible = "cypress,psoc6-uart";
 			reg = <0x40660000 0x10000>;
-			interrupts = <46 7>;
+			interrupts = <46 6>;
 			peripheral-id = <5>;
 			status = "disabled";
 			label = "uart_5";
@@ -390,7 +390,7 @@
 		uart6: uart@40670000 {
 			compatible = "cypress,psoc6-uart";
 			reg = <0x40670000 0x10000>;
-			interrupts = <47 7>;
+			interrupts = <47 6>;
 			peripheral-id = <6>;
 			status = "disabled";
 			label = "uart_6";
@@ -398,7 +398,7 @@
 		uart7: uart@40680000 {
 			compatible = "cypress,psoc6-uart";
 			reg = <0x40680000 0x10000>;
-			interrupts = <48 7>;
+			interrupts = <48 6>;
 			peripheral-id = <7>;
 			status = "disabled";
 			label = "uart_7";
@@ -406,7 +406,7 @@
 		uart8: uart@40690000 {
 			compatible = "cypress,psoc6-uart";
 			reg = <0x40690000 0x10000>;
-			interrupts = <18 7>;
+			interrupts = <18 6>;
 			peripheral-id = <8>;
 			status = "disabled";
 			label = "uart_8";


### PR DESCRIPTION


    The psoc6 SoC has 2 cores, each with different allowed priority ranges:

    CM0: 0-3 (2 bits of NVIC prio, no prio reserved by the kernel)
    CM4: 0-6 (3 bits of NVIC prio, one level reserved by the kernel)

    Since some of the peripherals are only available to the CM4, those
    should be set to a priority that is actually valid for it. In this case
    the lowest possible one is 6, so transition from 7 to 6.

    Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>
