### PR TITLE
sys: util: fix compilation with XCC

### DIFF
--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -234,7 +234,9 @@ static inline int64_t arithmetic_shift_right(int64_t value, uint8_t shift)
  */
 static inline void bytecpy(void *dst, const void *src, size_t size)
 {
-	for (size_t i = 0; i < size; ++i) {
+	size_t i;
+
+	for (i = 0; i < size; ++i) {
 		((uint8_t *)dst)[i] = ((uint8_t *)src)[i];
 	}
 }


### PR DESCRIPTION
Xtensa XCC does not like C99 style declarations in for
loops.

Fixes: 268f9bf16339 ("nuvoton: battery-backed ram")
Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>