### PR TITLE
doc: west release 0.11.1 follow-ups

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -26,7 +26,7 @@ on:
 
 env:
   # NOTE: west docstrings will be extracted from the version listed here
-  WEST_VERSION: 0.11.1a1
+  WEST_VERSION: 0.11.1
   # The latest CMake available directly with apt is 3.18, but we need >=3.20
   # so we fetch that through pip.
   CMAKE_VERSION: 3.20.5

--- a/doc/guides/west/release-notes.rst
+++ b/doc/guides/west/release-notes.rst
@@ -14,7 +14,7 @@ New features:
 Bug fixes:
 
 - The manifest file parser was incorrectly allowing project names which contain
-  the path separator characters ``/`` and ``\\``. These invalid characters are
+  the path separator characters ``/`` and ``\``. These invalid characters are
   now rejected.
 
   Note: if you need to place a project within a subdirectory of the workspace
@@ -30,7 +30,7 @@ Bug fixes:
 - The :envvar:`WEST_CONFIG_LOCAL` environment variable now correctly
   overrides the default location, :file:`<workspace topdir>/.west/config`.
 
-- ``west update --fetch=smart`` (``smart`` is the default) now correclty skips
+- ``west update --fetch=smart`` (``smart`` is the default) now correctly skips
   fetches for project revisions which are `lightweight tags`_ (it already
   worked correctly for annotated tags; only lightweight tags were unnecessarily
   fetched).


### PR DESCRIPTION
Use 0.11.1 to build the docs. The docstrings are the same as 0.11.1a1,
so it doesn't make a difference in the output, but let's keep things
clean now that the final release is up.

Fix typos in the release notes.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>