### PR TITLE
scripts: runners: bossac: Allow Bossac run on Windows (native)

### DIFF
--- a/boards/arm/arduino_nano_33_ble/doc/index.rst
+++ b/boards/arm/arduino_nano_33_ble/doc/index.rst
@@ -103,7 +103,7 @@ Once you have a path to bossac, you can pass it as an argument to west:
 
 .. code-block:: bash
 
-   west flash --bossac="<path to the arduino version of bossac>"
+   west flash --bossac="<path to the arduino version of bossac>" --bossac-port="<com port>"
 
 Flashing
 ========

--- a/scripts/west_commands/runners/bossac.py
+++ b/scripts/west_commands/runners/bossac.py
@@ -5,6 +5,7 @@
 
 '''bossac-specific runner (flash only) for Atmel SAM microcontrollers.'''
 
+import os
 import pathlib
 import pickle
 import platform
@@ -251,8 +252,10 @@ class BossacBinaryRunner(ZephyrBinaryRunner):
                 'could not import edtlib; something may be wrong with the '
                 'python environment')
 
-        if platform.system() == 'Windows':
-            msg = 'CAUTION: BOSSAC runner not support on Windows!'
+        if 'microsoft' in platform.uname().release.lower() or \
+                os.getenv('WSL_DISTRO_NAME') != None or \
+                    os.getenv('WSL_INTEROP') != None:
+            msg = 'CAUTION: BOSSAC runner not supported on WSL!'
             raise RuntimeError(msg)
         elif platform.system() == 'Darwin' and self.port is None:
             self.port = self.get_darwin_user_port_choice()


### PR DESCRIPTION
Fixes #37538 by correctly detecting WSL and blocking bossac from running
on that platform, but allowing it to run on Windows native.

Explicited --bossac-port on the documentation.

Signed-off-by: João Dullius <joaodullius@bpmrep.com.br>