### PR TITLE
Bluetooth: Controller: Fix uninit update flag given to PDU _latest_get

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -202,6 +202,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 	lll = p->param;
 
 	/* FIXME: get latest only when primary PDU without Aux PDUs */
+	upd = 0U;
 	sec_pdu = lll_adv_aux_data_latest_get(lll, &upd);
 	LL_ASSERT(sec_pdu);
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
@@ -158,6 +158,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 			     ((uint32_t)lll->crc_init[0])));
 	lll_chan_set(data_chan_use);
 
+	upd = 0U;
 	pdu = lll_adv_sync_data_latest_get(lll, NULL, &upd);
 	LL_ASSERT(pdu);
 


### PR DESCRIPTION
Fix uninitialized update flag given to PDU _latest_get()
functions.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>