### PR TITLE
boards: fvp_base_revc_2xaemv8a: permit running Zephyr at EL1NS

### DIFF
--- a/boards/arm64/fvp_base_revc_2xaemv8a/doc/index.rst
+++ b/boards/arm64/fvp_base_revc_2xaemv8a/doc/index.rst
@@ -71,6 +71,29 @@ To run with FVP, ARMFVP_BIN_PATH must be set before running:
 
 e.g. export ARMFVP_BIN_PATH=<path/to/fvp/dir>
 
+Running Zephyr at EL1NS
+***********************
+
+In order to run Zephyr as EL1NS with ``CONFIG_ARMV8_A_NS``, you'll need a proper
+Trusted Firmware loaded in the FVP model.
+
+The ARM TF-A for FVP can be used to run Zephyr as preloaded BL33 payload.
+
+Checkout and Build the TF-A:
+
+.. code-block:: console
+
+   git clone https://git.trustedfirmware.org/TF-A/trusted-firmware-a.git --depth 1
+   cd trusted-firmware-a/
+   make PLAT=fvp PRELOADED_BL33_BASE="0x88000000" all fip
+
+then export the ``ARMFVP_BL1_FILE` and ``ARMFVP_FIP_FILE`` environment variables:
+
+.. code-block:: console
+
+   export ARMFVP_BL1_FILE=<path/to/tfa-a/build/fvp/release/bl1.bin>
+   export ARMFVP_FIP_FILE=<path/to/tfa-a/build/fvp/release/fip.bin>
+
 Debugging
 =========
 

--- a/cmake/emu/armfvp.cmake
+++ b/cmake/emu/armfvp.cmake
@@ -10,11 +10,36 @@ find_program(
   NAMES ${ARMFVP_BIN_NAME}
   )
 
+if(CONFIG_ARMV8_A_NS)
+  foreach(filetype BL1 FIP)
+    if ((NOT DEFINED ARMFVP_${filetype}_FILE) AND (EXISTS "$ENV{ARMFVP_${filetype}_FILE}"))
+      set(ARMFVP_${filetype}_FILE "$ENV{ARMFVP_${filetype}_FILE}" CACHE FILEPATH
+        "ARM FVP ${filetype} File specified in environment"
+	)
+    endif()
+
+    if(NOT EXISTS "${ARMFVP_${filetype}_FILE}")
+      string(TOLOWER ${filetype} filename)
+      message(FATAL_ERROR "Please specify ARMFVP_${filetype}_FILE in environment "
+        "or with -DARMFVP_${filetype}_FILE=</path/to/${filename}.bin>")
+    endif()
+  endforeach()
+
+  set(ARMFVP_FLAGS ${ARMFVP_FLAGS}
+    -C bp.secureflashloader.fname=${ARMFVP_BL1_FILE}
+    -C bp.flashloader0.fname=${ARMFVP_FIP_FILE}
+    --data cluster0.cpu0="${APPLICATION_BINARY_DIR}/zephyr/${KERNEL_BIN_NAME}"@0x88000000
+    )
+else()
+  set(ARMFVP_FLAGS ${ARMFVP_FLAGS}
+    -a ${APPLICATION_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME}
+    )
+endif()
+
 add_custom_target(run
   COMMAND
   ${ARMFVP}
   ${ARMFVP_FLAGS}
-  -a ${APPLICATION_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME}
   DEPENDS ${ARMFVP} ${logical_target_for_zephyr_elf}
   WORKING_DIRECTORY ${APPLICATION_BINARY_DIR}
   COMMENT "FVP: ${ARMFVP}"


### PR DESCRIPTION
It may be needed to run Zephyr at EL1NS level with `CONFIG_ARMV8_A_NS`
In order to run at EL1NS, you'll need a proper Firmware loaded in the FVP model
to run Zephyr at non-secure EL3.

The ARM TF-A for FVP can used to run Zephyr as preloaded BL33.

This adds the necessary cmake scripts to load the TF-A binaries and
load Zephyr as preloaded BL33 payload.

Signed-off-by: Neil Armstrong <narmstrong@baylibre.com>