### PR TITLE
Tests: Bluetooth: tester: change of L2CAP listen() API

### DIFF
--- a/tests/bluetooth/tester/src/bttester.h
+++ b/tests/bluetooth/tester/src/bttester.h
@@ -772,6 +772,8 @@ struct l2cap_listen_cmd {
 	uint16_t psm;
 	uint8_t transport;
 	uint16_t mtu;
+	uint8_t security;
+	uint8_t key_size;
 	uint16_t response;
 } __packed;
 

--- a/tests/bluetooth/tester/src/l2cap.c
+++ b/tests/bluetooth/tester/src/l2cap.c
@@ -351,16 +351,20 @@ static void listen(uint8_t *data, uint16_t len)
 
 	server->accept = accept;
 	server->psm = cmd->psm;
-
-	if (server->psm == 0x00F4) {
-		/* TSPX_psm_encryption_key_size_required */
-		req_keysize = 16;
-	} else if (server->psm == 0x00F3) {
-		/* TSPX_psm_authentication_required */
-		authorize_flag = true;
-	} else if (server->psm == 0x00F2) {
+	LOG_DBG("sec lvl: %d, keysize: %d", cmd->security, cmd->key_size);
+	if (server->psm == 0x00F2 || cmd->security == 2) {
 		/* TSPX_psm_authentication_required */
 		server->sec_level = BT_SECURITY_L3;
+	}
+	if (server->psm == 0x00F3 || cmd->security == 3) {
+		/* TSPX_psm_authorization_required */
+		authorize_flag = true;
+	}
+	if (server->psm == 0x00F4) {
+		req_keysize = 16;
+	} else if (cmd->key_size > 0) {
+		/* TSPX_psm_encryption_key_size_required */
+		req_keysize = cmd->key_size;
 	}
 
 	if (bt_l2cap_server_register(server) < 0) {


### PR DESCRIPTION
L2CAP listen() command was extended by adding `security` and `key_size`
fields. It can be used to configure security requirements for L2CAP
connection to be accepted. This is required for tests
L2CAP/ECFC/BV-{11, 13, 15}-C - normally (in corrsponding L2CAP/LE/CFC/BV
tests) requirements are defined by PSMs, but in ECFC EATT PSM is always
used.

Signed-off-by: Krzysztof Kopyściński <krzysztof.kopyscinski@codecoup.pl>