### PR TITLE
Bluetooth: host: initialise mps_reduced to false in ecred reconf req

### DIFF
--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -1235,7 +1235,7 @@ static void le_ecred_reconf_req(struct bt_l2cap *l2cap, uint8_t ident,
 	uint16_t mtu, mps;
 	uint16_t scid, result = BT_L2CAP_RECONF_SUCCESS;
 	int chan_count = 0;
-	bool mps_reduced;
+	bool mps_reduced = false;
 
 	if (buf->len < sizeof(*req)) {
 		BT_ERR("Too small ecred reconf req packet size");


### PR DESCRIPTION
No initialisation will lead to undefined behaviour in check for
BT_L2CAP_RECONF_INVALID_MPS.

This is affecting L2CAP/ECFC/BV-23-C

Signed-off-by: Krzysztof Kopyściński <krzysztof.kopyscinski@codecoup.pl>