### PR TITLE
Stm32 pwm use common pins (Nucleo G0B1, G474, L476, WB55)

### DIFF
--- a/boards/arm/nucleo_g0b1re/nucleo_g0b1re.dts
+++ b/boards/arm/nucleo_g0b1re/nucleo_g0b1re.dts
@@ -90,7 +90,16 @@
 	pwm3: pwm {
 		status = "okay";
 		st,prescaler = <10000>;
-		pinctrl-0 = <&tim3_ch1_pa6>;
+		pinctrl-0 = <&tim3_ch1_pb4>;
+	};
+};
+
+&timers15 {
+	status = "okay";
+	pwm15: pwm {
+		status = "okay";
+		st,prescaler = <10000>;
+		pinctrl-0 = <&tim15_ch1_pb14>;
 	};
 };
 
@@ -113,8 +122,8 @@
 };
 
 &spi2 {
-	pinctrl-0 = <&spi2_nss_pb12 &spi2_sck_pb13
-		     &spi2_miso_pb14 &spi2_mosi_pb15>;
+	pinctrl-0 = <&spi2_nss_pd0 &spi2_sck_pd1
+		     &spi2_miso_pd3 &spi2_mosi_pd4>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_g474re/nucleo_g474re.dts
+++ b/boards/arm/nucleo_g474re/nucleo_g474re.dts
@@ -116,7 +116,16 @@
 
 	pwm2: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim2_ch1_pa5>;
+		pinctrl-0 = <&tim2_ch3_pb10>;
+	};
+};
+
+&timers3 {
+	status = "okay";
+	pwm3: pwm {
+		status = "okay";
+		st,prescaler = <10000>;
+		pinctrl-0 = <&tim3_ch1_pb4>;
 	};
 };
 

--- a/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
+++ b/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
@@ -140,7 +140,17 @@
 
 	pwm2: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim2_ch1_pa0>;
+		pinctrl-0 = <&tim2_ch3_pb10>;
+	};
+};
+
+&timers3 {
+	status = "okay";
+
+	pwm3: pwm {
+		status = "okay";
+		st,prescaler = <10000>;
+		pinctrl-0 = <&tim3_ch1_pb4>;
 	};
 };
 

--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -133,11 +133,21 @@
 	status = "okay";
 };
 
+&timers1 {
+	status = "okay";
+
+	pwm1: pwm {
+		status = "okay";
+		st,prescaler = <10000>;
+		pinctrl-0 = <&tim1_ch1_pa8>;
+	};
+};
+
 &timers2 {
 	status = "okay";
 	pwm2: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim2_ch1_pa0>;
+		pinctrl-0 = <&tim2_ch1_pa15>;
 	};
 };
 


### PR DESCRIPTION
In order to ease testing this PR moves timer pwm pins of several nucleo boards to common arduino PINs.