### PR TITLE
dts: arm: st: rename g0 tim1 interrupt to align with f0 series

### DIFF
--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -218,7 +218,7 @@
 			reg = <0x40012C00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000800>;
 			interrupts = <13 0>, <14 0>;
-			interrupt-names = "brk", "cc";
+			interrupt-names = "brk_up_trg_com", "cc";
 			status = "disabled";
 			label = "TIMERS_1";
 


### PR DESCRIPTION
Renames stm32g0 tim1 brk interrupt to brk_up_trg_com, such that the
naming aligns with stm32f0 series and drivers can find the interrupt
with a common name.