### PR TITLE
display: introduce CONFIG_DISPLAY_INIT_PRIORITY

### DIFF
--- a/drivers/display/Kconfig
+++ b/drivers/display/Kconfig
@@ -10,6 +10,12 @@ menuconfig DISPLAY
 
 if DISPLAY
 
+config DISPLAY_INIT_PRIORITY
+	int "Display devices init priority"
+	default 90
+	help
+	  Display devices initialization priority.
+
 module = DISPLAY
 module-str = display
 source "subsys/logging/Kconfig.template.log_config"

--- a/drivers/display/display_dummy.c
+++ b/drivers/display/display_dummy.c
@@ -126,5 +126,5 @@ static const struct display_driver_api dummy_display_api = {
 DEVICE_DEFINE(dummy_display, CONFIG_DUMMY_DISPLAY_DEV_NAME,
 		    &dummy_display_init, NULL,
 		    &dummy_display_data, NULL,
-		    APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY,
+		    APPLICATION, CONFIG_DISPLAY_INIT_PRIORITY,
 		    &dummy_display_api);

--- a/drivers/display/display_ili9xxx.c
+++ b/drivers/display/display_ili9xxx.c
@@ -447,7 +447,7 @@ static const struct display_driver_api ili9xxx_api = {
 	DEVICE_DT_DEFINE(INST_DT_ILI9XXX(n, t), ili9xxx_init,                  \
 			    NULL, &ili9xxx_data_##n,                           \
 			    &ili9xxx_config_##n, POST_KERNEL,                  \
-			    CONFIG_APPLICATION_INIT_PRIORITY, &ili9xxx_api);
+			    CONFIG_DISPLAY_INIT_PRIORITY, &ili9xxx_api);
 
 #define DT_INST_FOREACH_ILI9XXX_STATUS_OKAY(t)                                 \
 	UTIL_LISTIFY(DT_NUM_INST_STATUS_OKAY(ilitek_ili##t), ILI9XXX_INIT, t)

--- a/drivers/display/display_sdl.c
+++ b/drivers/display/display_sdl.c
@@ -417,7 +417,7 @@ static const struct display_driver_api sdl_display_api = {
 
 DEVICE_DEFINE(sdl_display, CONFIG_SDL_DISPLAY_DEV_NAME, &sdl_display_init,
 		NULL, &sdl_display_data, NULL, APPLICATION,
-		CONFIG_APPLICATION_INIT_PRIORITY, &sdl_display_api);
+		CONFIG_DISPLAY_INIT_PRIORITY, &sdl_display_api);
 
 
 NATIVE_TASK(sdl_display_cleanup, ON_EXIT, 1);

--- a/drivers/display/display_st7735r.c
+++ b/drivers/display/display_st7735r.c
@@ -575,7 +575,7 @@ static const struct display_driver_api st7735r_api = {
 	};									\
 	DEVICE_DT_INST_DEFINE(inst, st7735r_init, st7735r_pm_control,		\
 			      &st7735r_data_ ## inst, &st7735r_config_ ## inst,	\
-			      APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY,	\
+			      APPLICATION, CONFIG_DISPLAY_INIT_PRIORITY,	\
 			      &st7735r_api);
 
 DT_INST_FOREACH_STATUS_OKAY(ST7735R_INIT)

--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -440,4 +440,4 @@ static struct st7789v_data st7789v_data = {
 
 DEVICE_DT_INST_DEFINE(0, &st7789v_init,
 	      st7789v_pm_control, &st7789v_data, NULL, APPLICATION,
-	      CONFIG_APPLICATION_INIT_PRIORITY, &st7789v_api);
+	      CONFIG_DISPLAY_INIT_PRIORITY, &st7789v_api);

--- a/drivers/display/gd7965.c
+++ b/drivers/display/gd7965.c
@@ -450,5 +450,5 @@ static struct display_driver_api gd7965_driver_api = {
 
 DEVICE_DT_INST_DEFINE(0, gd7965_init, NULL,
 		      &gd7965_driver, &gd7965_config,
-		      POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY,
+		      POST_KERNEL, CONFIG_DISPLAY_INIT_PRIORITY,
 		      &gd7965_driver_api);

--- a/drivers/display/grove_lcd_rgb.c
+++ b/drivers/display/grove_lcd_rgb.c
@@ -344,5 +344,5 @@ static struct glcd_data grove_lcd_driver = {
 	 */
 DEVICE_DEFINE(grove_lcd, GROVE_LCD_NAME, glcd_initialize,
 		NULL, &grove_lcd_driver, &grove_lcd_config,
-		POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY,
+		POST_KERNEL, CONFIG_DISPLAY_INIT_PRIORITY,
 		(void *)&grove_lcd_driver);

--- a/drivers/display/ls0xx.c
+++ b/drivers/display/ls0xx.c
@@ -340,5 +340,5 @@ static struct display_driver_api ls0xx_driver_api = {
 
 DEVICE_DT_INST_DEFINE(0, ls0xx_init, NULL,
 		      &ls0xx_driver, &ls0xx_config,
-		      POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY,
+		      POST_KERNEL, CONFIG_DISPLAY_INIT_PRIORITY,
 		      &ls0xx_driver_api);

--- a/drivers/display/ssd1306.c
+++ b/drivers/display/ssd1306.c
@@ -448,5 +448,5 @@ static struct display_driver_api ssd1306_driver_api = {
 
 DEVICE_DT_INST_DEFINE(0, ssd1306_init, NULL,
 		      &ssd1306_driver, &ssd1306_config,
-		      POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY,
+		      POST_KERNEL, CONFIG_DISPLAY_INIT_PRIORITY,
 		      &ssd1306_driver_api);

--- a/drivers/display/ssd16xx.c
+++ b/drivers/display/ssd16xx.c
@@ -701,5 +701,5 @@ static struct display_driver_api ssd16xx_driver_api = {
 
 DEVICE_DT_INST_DEFINE(0, ssd16xx_init, NULL,
 		    &ssd16xx_driver, NULL,
-		    POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY,
+		    POST_KERNEL, CONFIG_DISPLAY_INIT_PRIORITY,
 		    &ssd16xx_driver_api);


### PR DESCRIPTION
This introduces a new kconfig CONFIG_DISPLAY_INIT_PRIORITY
to specify the initialization priority for display devices.
Most of the display devices are using APPLICATION and
CONFIG_APPLICATION_INIT_PRIORITY which is not entirely
appropriate for devices. Due to linking order, the display
device may be initialized after application code at same
init level and priority. This results in the display device
not ready to be used for application code. So this kconfig
option allows the display devices to be initialized earlier
if needed.

For the drivers using CONFIG_APPLICATION_INIT_PRIORITY,
they have been changed to use CONFIG_DISPLAY_INIT_PRIORITY
instead.

Note that the default value for CONFIG_DISPLAY_INIT_PRIORITY
is the same as CONFIG_APPLICATION_INIT_PRIORITY at 90 to
avoid any functional changes.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>