### PR TITLE
gpio: shell: Replace gpio listen with blink

### DIFF
--- a/drivers/gpio/gpio_shell.c
+++ b/drivers/gpio/gpio_shell.c
@@ -35,7 +35,7 @@ static const struct args_index args_indx = {
 	.value = 3,
 };
 
-static int cmd_gpio_conf(const struct shell *shell, size_t argc, char **argv)
+static int cmd_gpio_conf(const struct shell *sh, size_t argc, char **argv)
 {
 	uint8_t index = 0U;
 	int type = GPIO_OUTPUT;
@@ -52,7 +52,7 @@ static int cmd_gpio_conf(const struct shell *shell, size_t argc, char **argv)
 			return 0;
 		}
 	} else {
-		shell_error(shell, "Wrong parameters for conf");
+		shell_error(sh, "Wrong parameters for conf");
 		return -ENOTSUP;
 	}
 
@@ -60,7 +60,7 @@ static int cmd_gpio_conf(const struct shell *shell, size_t argc, char **argv)
 
 	if (dev != NULL) {
 		index = (uint8_t)atoi(argv[args_indx.index]);
-		shell_print(shell, "Configuring %s pin %d",
+		shell_print(sh, "Configuring %s pin %d",
 			    argv[args_indx.port], index);
 		gpio_pin_configure(dev, index, type);
 	}
@@ -68,7 +68,7 @@ static int cmd_gpio_conf(const struct shell *shell, size_t argc, char **argv)
 	return 0;
 }
 
-static int cmd_gpio_get(const struct shell *shell,
+static int cmd_gpio_get(const struct shell *sh,
 			size_t argc, char **argv)
 {
 	const struct device *dev;
@@ -78,7 +78,7 @@ static int cmd_gpio_get(const struct shell *shell,
 	if (isdigit((unsigned char)argv[args_indx.index][0])) {
 		index = (uint8_t)atoi(argv[args_indx.index]);
 	} else {
-		shell_error(shell, "Wrong parameters for get");
+		shell_error(sh, "Wrong parameters for get");
 		return -EINVAL;
 	}
 
@@ -86,13 +86,13 @@ static int cmd_gpio_get(const struct shell *shell,
 
 	if (dev != NULL) {
 		index = (uint8_t)atoi(argv[2]);
-		shell_print(shell, "Reading %s pin %d",
+		shell_print(sh, "Reading %s pin %d",
 			    argv[args_indx.port], index);
 		rc = gpio_pin_get(dev, index);
 		if (rc >= 0) {
-			shell_print(shell, "Value %d", rc);
+			shell_print(sh, "Value %d", rc);
 		} else {
-			shell_error(shell, "Error %d reading value", rc);
+			shell_error(sh, "Error %d reading value", rc);
 			return -EIO;
 		}
 	}
@@ -100,7 +100,7 @@ static int cmd_gpio_get(const struct shell *shell,
 	return 0;
 }
 
-static int cmd_gpio_set(const struct shell *shell,
+static int cmd_gpio_set(const struct shell *sh,
 			size_t argc, char **argv)
 {
 	const struct device *dev;
@@ -112,14 +112,14 @@ static int cmd_gpio_set(const struct shell *shell,
 		index = (uint8_t)atoi(argv[args_indx.index]);
 		value = (uint8_t)atoi(argv[args_indx.value]);
 	} else {
-		shell_print(shell, "Wrong parameters for set");
+		shell_print(sh, "Wrong parameters for set");
 		return -EINVAL;
 	}
 	dev = device_get_binding(argv[args_indx.port]);
 
 	if (dev != NULL) {
 		index = (uint8_t)atoi(argv[2]);
-		shell_print(shell, "Writing to %s pin %d",
+		shell_print(sh, "Writing to %s pin %d",
 			    argv[args_indx.port], index);
 		gpio_pin_set(dev, index, value);
 	}
@@ -131,7 +131,7 @@ static int cmd_gpio_set(const struct shell *shell,
 /* 500 msec = 1/2 sec */
 #define SLEEP_TIME_MS   500
 
-static int cmd_gpio_blink(const struct shell *shell,
+static int cmd_gpio_blink(const struct shell *sh,
 			  size_t argc, char **argv)
 {
 	const struct device *dev;
@@ -143,18 +143,18 @@ static int cmd_gpio_blink(const struct shell *shell,
 	if (isdigit((unsigned char)argv[args_indx.index][0])) {
 		index = (uint8_t)atoi(argv[args_indx.index]);
 	} else {
-		shell_error(shell, "Wrong parameters for blink");
+		shell_error(sh, "Wrong parameters for blink");
 		return -EINVAL;
 	}
 	dev = device_get_binding(argv[args_indx.port]);
 
 	if (dev != NULL) {
 		index = (uint8_t)atoi(argv[2]);
-		shell_fprintf(shell, SHELL_NORMAL, "Blinking port %s index %d.", argv[1], index);
-		shell_fprintf(shell, SHELL_NORMAL, " Hit any key to exit");
+		shell_fprintf(sh, SHELL_NORMAL, "Blinking port %s index %d.", argv[1], index);
+		shell_fprintf(sh, SHELL_NORMAL, " Hit any key to exit");
 
 		while (true) {
-			(void)shell->iface->api->read(shell->iface, &data, sizeof(data), &count);
+			(void)sh->iface->api->read(sh->iface, &data, sizeof(data), &count);
 			if (count != 0) {
 				break;
 			}
@@ -163,7 +163,7 @@ static int cmd_gpio_blink(const struct shell *shell,
 			k_msleep(SLEEP_TIME_MS);
 		}
 
-		shell_fprintf(shell, SHELL_NORMAL, "\n");
+		shell_fprintf(sh, SHELL_NORMAL, "\n");
 	}
 
 	return 0;

--- a/drivers/gpio/gpio_shell.c
+++ b/drivers/gpio/gpio_shell.c
@@ -28,25 +28,11 @@ struct args_index {
 	uint8_t value;
 };
 
-struct args_number {
-	uint8_t conf;
-	uint8_t set;
-	uint8_t get;
-	uint8_t blink;
-};
-
 static const struct args_index args_indx = {
 	.port = 1,
 	.index = 2,
 	.mode = 3,
 	.value = 3,
-};
-
-static const struct args_number args_no = {
-	.conf = 4,
-	.set = 4,
-	.get = 3,
-	.blink = 3
 };
 
 static int cmd_gpio_conf(const struct shell *shell, size_t argc, char **argv)
@@ -55,8 +41,7 @@ static int cmd_gpio_conf(const struct shell *shell, size_t argc, char **argv)
 	int type = GPIO_OUTPUT;
 	const struct device *dev;
 
-	if (argc == args_no.conf &&
-	    isdigit((unsigned char)argv[args_indx.index][0]) &&
+	if (isdigit((unsigned char)argv[args_indx.index][0]) &&
 	    isalpha((unsigned char)argv[args_indx.mode][0])) {
 		index = (uint8_t)atoi(argv[args_indx.index]);
 		if (!strcmp(argv[args_indx.mode], "in")) {
@@ -90,7 +75,7 @@ static int cmd_gpio_get(const struct shell *shell,
 	uint8_t index = 0U;
 	int rc;
 
-	if (argc == args_no.get && isdigit((unsigned char)argv[args_indx.index][0])) {
+	if (isdigit((unsigned char)argv[args_indx.index][0])) {
 		index = (uint8_t)atoi(argv[args_indx.index]);
 	} else {
 		shell_error(shell, "Wrong parameters for get");
@@ -122,8 +107,7 @@ static int cmd_gpio_set(const struct shell *shell,
 	uint8_t index = 0U;
 	uint8_t value = 0U;
 
-	if (argc == args_no.set &&
-	    isdigit((unsigned char)argv[args_indx.index][0]) &&
+	if (isdigit((unsigned char)argv[args_indx.index][0]) &&
 	    isdigit((unsigned char)argv[args_indx.value][0])) {
 		index = (uint8_t)atoi(argv[args_indx.index]);
 		value = (uint8_t)atoi(argv[args_indx.value]);
@@ -156,10 +140,10 @@ static int cmd_gpio_blink(const struct shell *shell,
 	size_t count = 0;
 	char data;
 
-	if (argc == args_no.blink && isdigit((unsigned char)argv[args_indx.index][0])) {
+	if (isdigit((unsigned char)argv[args_indx.index][0])) {
 		index = (uint8_t)atoi(argv[args_indx.index]);
 	} else {
-		shell_error(shell, "Wrong parameters for get");
+		shell_error(shell, "Wrong parameters for blink");
 		return -EINVAL;
 	}
 	dev = device_get_binding(argv[args_indx.port]);
@@ -186,10 +170,10 @@ static int cmd_gpio_blink(const struct shell *shell,
 }
 
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_gpio,
-			       SHELL_CMD(conf, NULL, "Configure GPIO", cmd_gpio_conf),
-			       SHELL_CMD(get, NULL, "Get GPIO value", cmd_gpio_get),
-			       SHELL_CMD(set, NULL, "Set GPIO", cmd_gpio_set),
-			       SHELL_CMD(blink, NULL, "Blink GPIO", cmd_gpio_blink),
+			       SHELL_CMD_ARG(conf, NULL, "Configure GPIO", cmd_gpio_conf, 4, 0),
+			       SHELL_CMD_ARG(get, NULL, "Get GPIO value", cmd_gpio_get, 3, 0),
+			       SHELL_CMD_ARG(set, NULL, "Set GPIO", cmd_gpio_set, 4, 0),
+			       SHELL_CMD_ARG(blink, NULL, "Blink GPIO", cmd_gpio_blink, 3, 0),
 			       SHELL_SUBCMD_SET_END /* Array terminated. */
 			       );
 


### PR DESCRIPTION
This is a frequently used command during hardware bringup
The listen command was not actually implemented
Also uncrustified and check_compliance.py

Signed-off-by: Dennis Ruffer <daruffer@gmail.com>