### PR TITLE
cmake: dts: import devicetree symbols into CMake

### DIFF
--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -27,6 +27,10 @@ set(DTS_POST_CPP                ${PROJECT_BINARY_DIR}/${BOARD}.dts.pre.tmp)
 # This is relative to each element of DTS_ROOT.
 set(VENDOR_PREFIXES             dts/bindings/vendor-prefixes.txt)
 
+# Devicetree in CMake.
+set(DTS_CMAKE_SCRIPT            ${ZEPHYR_BASE}/scripts/dts/gen_dts_cmake.py)
+set(DTS_CMAKE                   ${PROJECT_BINARY_DIR}/dts.cmake)
+
 set_ifndef(DTS_SOURCE ${BOARD_DIR}/${BOARD}.dts)
 
 zephyr_file(APPLICATION_ROOT DTS_ROOT)
@@ -175,6 +179,7 @@ if(SUPPORTS_DTS)
     CMAKE_CONFIGURE_DEPENDS
     ${include_files}
     ${GEN_DEFINES_SCRIPT}
+    ${DTS_CMAKE_SCRIPT}
     )
 
   #
@@ -248,6 +253,20 @@ if(SUPPORTS_DTS)
     message(STATUS "Generated zephyr.dts: ${ZEPHYR_DTS}")
     message(STATUS "Generated devicetree_unfixed.h: ${DEVICETREE_UNFIXED_H}")
     message(STATUS "Generated device_extern.h: ${DEVICE_EXTERN_H}")
+  endif()
+
+  execute_process(
+    COMMAND ${PYTHON_EXECUTABLE} ${DTS_CMAKE_SCRIPT}
+    --edt-pickle ${EDT_PICKLE}
+    --cmake-out ${DTS_CMAKE}
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+    RESULT_VARIABLE ret
+    )
+  if(NOT "${ret}" STREQUAL "0")
+    message(FATAL_ERROR "gen_dts_cmake.py failed with return code: ${ret}")
+  else()
+    message(STATUS "Including generated dts.cmake file: ${DTS_CMAKE}")
+    include(${DTS_CMAKE})
   endif()
 
 else()

--- a/scripts/dts/gen_dts_cmake.py
+++ b/scripts/dts/gen_dts_cmake.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+'''
+This script uses edtlib and the devicetree data in the build directory
+to generate a CMake file which contains devicetree data.
+
+That data can then be used in the rest of the build system.
+
+The generated CMake file looks like this:
+
+  add_custom_target(devicetree_target)
+  set_target_properties(devicetree_target PROPERTIES
+                        "DT_PROP|/soc|compatible" "vnd,soc;")
+  ...
+
+It defines a special CMake target, and saves various values in the
+devicetree as CMake target properties.
+
+Be careful:
+
+  "Property" here can refer to a CMake target property or a
+  DTS property. DTS property values are stored inside
+  CMake target properties, along with other devicetree data.
+
+The build system includes this generated file early on, so
+devicetree values can be used at CMake processing time.
+
+Accss is not done directly, but with Zephyr CMake extension APIs,
+like this:
+
+  # sets 'compat' to "vnd,soc" in CMake
+  dt_prop(compat PATH "/soc" PROPERTY compatible INDEX 0)
+
+This is analogous to how DTS values are encoded as C macros,
+which can be read in source code using C APIs like
+DT_PROP(node_id, foo) from devicetree.h.
+'''
+
+import argparse
+import os
+import pickle
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), 'python-devicetree',
+                             'src'))
+
+
+def parse_args():
+    # Returns parsed command-line arguments
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cmake-out", required=True,
+                        help="path to write the CMake property file")
+    parser.add_argument("--edt-pickle", required=True,
+                        help="path to read the pickled edtlib.EDT object from")
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    with open(args.edt_pickle, 'rb') as f:
+        edt = pickle.load(f)
+
+    # In what looks like an undocumented implementation detail, CMake
+    # target properties are stored in a C++ standard library map whose
+    # keys and values are each arbitrary strings, so we can use
+    # whatever we want as target property names.
+    #
+    # We therefore use '|' as a field separator character below within
+    # because it's not a valid character in DTS node paths or property
+    # names. This lets us store the "real" paths and property names
+    # without conversion to lowercase-and-underscores like we have to
+    # do in C.
+    #
+    # If CMake adds restrictions on target property names later, we
+    # can just tweak the generated file to use a more restrictive
+    # property encoding, perhaps reusing the same style documented in
+    # macros.bnf for C macros.
+
+    cmake_props = []
+    for node in edt.chosen_nodes:
+        path = edt.chosen_nodes[node].path
+        cmake_props.append(f'"DT_CHOSEN|{node}" "{path}"')
+
+    for node in edt.nodes:
+        cmake_props.append(f'"DT_NODE|{node.path}" TRUE')
+
+        for label in node.labels:
+            cmake_props.append(f'"DT_NODELABEL|{label}" "{node.path}"')
+
+        for item in node.props:
+            # We currently do not support phandles for edt -> cmake conversion.
+            if "phandle" not in node.props[item].type:
+                if "array" in node.props[item].type:
+                    # Convert array to CMake list
+                    cmake_value = ''
+                    for val in node.props[item].val:
+                        cmake_value = f'{cmake_value}{val};'
+                else:
+                    cmake_value = node.props[item].val
+
+                # Encode node's property 'item' as a CMake target property
+                # with a name like 'DT_PROP|<path>|<property>'.
+                cmake_prop = f'DT_PROP|{node.path}|{item}'
+                cmake_props.append(f'"{cmake_prop}" "{cmake_value}"')
+
+        if node.regs is not None:
+            cmake_props.append(f'"DT_REG|{node.path}|NUM" "{len(node.regs)}"')
+            cmake_addr = ''
+            cmake_size = ''
+
+            for reg in node.regs:
+                if reg.addr is None:
+                    cmake_addr = f'{cmake_addr}NONE;'
+                else:
+                    cmake_addr = f'{cmake_addr}{hex(reg.addr)};'
+
+                if reg.size is None:
+                    cmake_size = f'{cmake_size}NONE;'
+                else:
+                    cmake_size = f'{cmake_size}{hex(reg.size)};'
+
+            cmake_props.append(f'"DT_REG|{node.path}|ADDR" "{cmake_addr}"')
+            cmake_props.append(f'"DT_REG|{node.path}|SIZE" "{cmake_size}"')
+
+    with open(args.cmake_out, "w", encoding="utf-8") as cmake_file:
+        print('add_custom_target(devicetree_target)', file=cmake_file)
+        print(file=cmake_file)
+
+        for prop in cmake_props:
+            print(
+                f'set_target_properties(devicetree_target PROPERTIES {prop})',
+                file=cmake_file
+            )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This commit introduces devicetree API in CMake so that devicetree
properties and register block can be used in the CMake build system.

The script scripts/dts/dts_cmake.py processes the edt.pickle and
generates a corresponding devicetree property map in a devicetree_target
that is then used in CMake.

The following devicetree API has been made available in Zephyr CMake:
```
- dt_nodelabel(<var> LABEL <label>)
- dt_node_exists(<var> NODE <node>)
- dt_node_has_status(<var> NODE <node> STATUS <status>)
- dt_prop(<var> NODE <node> PROPERTY <prop>)
- dt_prop(<var> NODE <node> INDEX <idx> PROPERTY <prop>)
- dt_num_regs(<var> NODE <node>)
- dt_reg_addr(<var> NODE <node> [INDEX <idx>])
- dt_reg_size(<var> NODE <node> [INDEX <idx>])
- dt_has_chosen(<var> PROPERTY <prop>)
- dt_chosen(<var> PROPERTY <prop>)
```

Signed-off-by: Marti Bolivar <marti.bolivar@nordicsemi.no>
Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>

-------

This is needed by:  #36140 