### PR TITLE
drivers: entropy: mcux_trng: fix error after reset

### DIFF
--- a/drivers/entropy/entropy_mcux_trng.c
+++ b/drivers/entropy/entropy_mcux_trng.c
@@ -27,6 +27,16 @@ static int entropy_mcux_trng_get_entropy(const struct device *dev,
 	ARG_UNUSED(dev);
 
 	status = TRNG_GetRandomData(config->base, buffer, length);
+	if (unlikely(status)) {
+		/*
+		 * There can be a situation after certain types of resets
+		 * where the underlying TRNG IP reports an error. The
+		 * TRNG_GetRandomData() function will clear the error but
+		 * doesn't try to retrieve random data so make the request
+		 * again.
+		 */
+		status = TRNG_GetRandomData(config->base, buffer, length);
+	}
 	__ASSERT_NO_MSG(!status);
 
 	return 0;


### PR DESCRIPTION
There are situations after certain types of resets of the
board, that the underlying TRNG IP reports an error when
making a request for TRNG_GetRandomData(). The function
will clear the error bit but doesn't try to retrieve the
entropy data so this change will retry once on the error.

The observation is that the error only occurs once and
since this function is likely only called a couple of
times to provide a seed to RNG functions there is little
impact.

Fixes #37619

Signed-off-by: David Leach <david.leach@nxp.com>