### PR TITLE
Tests: bluetooth: tester: accomodate L2CAP connect commant to BTP change

### DIFF
--- a/tests/bluetooth/tester/src/bttester.h
+++ b/tests/bluetooth/tester/src/bttester.h
@@ -746,6 +746,7 @@ struct l2cap_connect_cmd {
 	uint16_t psm;
 	uint16_t mtu;
 	uint8_t num;
+	uint8_t ecfc;
 } __packed;
 struct l2cap_connect_rp {
 	uint8_t num;

--- a/tests/bluetooth/tester/src/l2cap.c
+++ b/tests/bluetooth/tester/src/l2cap.c
@@ -182,12 +182,12 @@ static void connect(uint8_t *data, uint16_t len)
 		allocated_channels[i] = &chan->le.chan;
 	}
 
-	if (cmd->num == 1) {
+	if (cmd->num == 1 && cmd->ecfc == 0) {
 		err = bt_l2cap_chan_connect(conn, &chan->le.chan, cmd->psm);
 		if (err < 0) {
 			goto fail;
 		}
-	} else if (cmd->num > 1) {
+	} else if (cmd->ecfc == 1) {
 #if defined(CONFIG_BT_L2CAP_ECRED)
 		err = bt_l2cap_ecred_chan_connect(conn, allocated_channels,
 							cmd->psm);


### PR DESCRIPTION
BTP change extended L2CAP_CONNECT command by ECFC flag, which determines
which connection procedure is used (non-enhanced or ecred). Now, only
this flag determines the procedure used, not number of requested
channels.

This was affecting L2CAP/ECFC/BV-25-C

Signed-off-by: Krzysztof Kopyściński <krzysztof.kopyscinski@codecoup.pl>