### PR TITLE
ITE: drivers/i2c: it8xxx2: move pinctrls macro to soc_dt.h

### DIFF
--- a/dts/bindings/i2c/ite,it8xxx2-i2c.yaml
+++ b/dts/bindings/i2c/ite,it8xxx2-i2c.yaml
@@ -28,11 +28,8 @@ properties:
         description: Get the handle of the GPIO device
 
     pinctrl-0:
-      type: phandle
+      type: phandles
       required: true
-      description: Configuration of I2C clock pinmux controller
-
-    pinctrl-1:
-      type: phandle
-      required: true
-      description: Configuration of I2C data pinmux controller
+      description: Configuration of I2C SCL and SDA pinmux controller.
+                   The SCL pin must be specified first and the SDA pin
+                   second in the pinctrl-0 array.

--- a/dts/riscv/it8xxx2.dtsi
+++ b/dts/riscv/it8xxx2.dtsi
@@ -602,8 +602,8 @@
 			label = "I2C_0";
 			port-num = <0>;
 			gpio-dev = <&gpiob>;
-			pinctrl-0 = <&pinctrl_i2c_clk0>;  /* GPB3 */
-			pinctrl-1 = <&pinctrl_i2c_data0>; /* GPB4 */
+			pinctrl-0 = <&pinctrl_i2c_clk0    /* GPB3 */
+				     &pinctrl_i2c_data0>; /* GPB4 */
 		};
 		i2c1: i2c@f01c80 {
 			compatible = "ite,it8xxx2-i2c";
@@ -616,8 +616,8 @@
 			label = "I2C_1";
 			port-num = <1>;
 			gpio-dev = <&gpioc>;
-			pinctrl-0 = <&pinctrl_i2c_clk1>;  /* GPC1 */
-			pinctrl-1 = <&pinctrl_i2c_data1>; /* GPC2 */
+			pinctrl-0 = <&pinctrl_i2c_clk1    /* GPC1 */
+				     &pinctrl_i2c_data1>; /* GPC2 */
 		};
 		i2c2: i2c@f01cc0 {
 			compatible = "ite,it8xxx2-i2c";
@@ -630,8 +630,8 @@
 			label = "I2C_2";
 			port-num = <2>;
 			gpio-dev = <&gpiof>;
-			pinctrl-0 = <&pinctrl_i2c_clk2>;  /* GPF6 */
-			pinctrl-1 = <&pinctrl_i2c_data2>; /* GPF7 */
+			pinctrl-0 = <&pinctrl_i2c_clk2    /* GPF6 */
+				     &pinctrl_i2c_data2>; /* GPF7 */
 		};
 		i2c3: i2c@f03680 {
 			compatible = "ite,it8xxx2-i2c";
@@ -644,8 +644,8 @@
 			label = "I2C_3";
 			port-num = <3>;
 			gpio-dev = <&gpioh>;
-			pinctrl-0 = <&pinctrl_i2c_clk3>;  /* GPH1 */
-			pinctrl-1 = <&pinctrl_i2c_data3>; /* GPH2 */
+			pinctrl-0 = <&pinctrl_i2c_clk3    /* GPH1 */
+				     &pinctrl_i2c_data3>; /* GPH2 */
 		};
 		i2c4: i2c@f03500 {
 			compatible = "ite,it8xxx2-i2c";
@@ -658,8 +658,8 @@
 			label = "I2C_4";
 			port-num = <4>;
 			gpio-dev = <&gpioe>;
-			pinctrl-0 = <&pinctrl_i2c_clk4>;  /* GPE0 */
-			pinctrl-1 = <&pinctrl_i2c_data4>; /* GPE7 */
+			pinctrl-0 = <&pinctrl_i2c_clk4    /* GPE0 */
+				     &pinctrl_i2c_data4>; /* GPE7 */
 		};
 		i2c5: i2c@f03580 {
 			compatible = "ite,it8xxx2-i2c";
@@ -672,8 +672,8 @@
 			label = "I2C_5";
 			port-num = <5>;
 			gpio-dev = <&gpioa>;
-			pinctrl-0 = <&pinctrl_i2c_clk5>;  /* GPA4 */
-			pinctrl-1 = <&pinctrl_i2c_data5>; /* GPA5 */
+			pinctrl-0 = <&pinctrl_i2c_clk5    /* GPA4 */
+				     &pinctrl_i2c_data5>; /* GPA5 */
 		};
 
 		ecpm: clock-controller@f01e00 {


### PR DESCRIPTION
This PR will change accessing the related pinctrl macro from soc_dt.h
And the pinctrl of SCL and SDA were got from pinctrl-0 and pinctrl-1,
respectively. Change it to get from pinctrl-0 only.

Signed-off-by: Tim Lin <tim2.lin@ite.corp-partner.google.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zephyrproject-rtos/zephyr/37633)
<!-- Reviewable:end -->
