### PR TITLE
tests: Bluetooth Mesh: Use unique names for all simulations

### DIFF
--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/tests_scripts/friendship/msg_mesh_low_lat.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/tests_scripts/friendship/msg_mesh_low_lat.sh
@@ -6,7 +6,7 @@ source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
 
 # Test communication between the LPN and a third mesh device
 conf=prj_low_lat_conf
-RunTest mesh_friendship_msg_mesh \
+RunTest mesh_friendship_msg_mesh_low_lat \
 	friendship_lpn_msg_mesh \
 	friendship_other_msg \
 	friendship_friend_est

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/tests_scripts/transport/loopback_group_low_lat.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/tests_scripts/transport/loopback_group_low_lat.sh
@@ -5,4 +5,4 @@
 source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
 
 conf=prj_low_lat_conf
-RunTest mesh_transport_loopback_group transport_tx_loopback_group transport_rx_group
+RunTest mesh_transport_loopback_group_low_lat transport_tx_loopback_group transport_rx_group

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/tests_scripts/transport/unicast_low_lat.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/tests_scripts/transport/unicast_low_lat.sh
@@ -5,4 +5,4 @@
 source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
 
 conf=prj_low_lat_conf
-RunTest mesh_transport_unicast transport_tx_unicast transport_rx_unicast
+RunTest mesh_transport_unicast_low_lat transport_tx_unicast transport_rx_unicast


### PR DESCRIPTION
Adds a low_lat name to the duplicated low_lat babblesim tests to allow
them to run in parallel with their counter parts.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>