### PR TITLE
linker: esp32: update linker with recent BT iterable

### DIFF
--- a/soc/xtensa/esp32/linker.ld
+++ b/soc/xtensa/esp32/linker.ld
@@ -281,6 +281,10 @@ _net_buf_pool_list = _esp_net_buf_pool_list;
     Z_LINK_ITERABLE_ALIGNED(bt_l2cap_br_fixed_chan, 4);
 #endif
 
+#if defined(CONFIG_BT_CONN)
+    Z_LINK_ITERABLE_ALIGNED(bt_conn_cb, 4)
+#endif
+
     Z_LINK_ITERABLE_ALIGNED(bt_gatt_service_static, 4);
 
 #if defined(CONFIG_BT_MESH)


### PR DESCRIPTION
bt_conn_cb section was added into common-rom.ld and
as current ESP has limited segment section number, it
needs to be moved out from there.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>