### PR TITLE
drivers: spi: set max chunk len for esp32

### DIFF
--- a/drivers/spi/spi_esp32_spim.c
+++ b/drivers/spi/spi_esp32_spim.c
@@ -63,6 +63,7 @@ static int IRAM_ATTR spi_esp32_transfer(const struct device *dev)
 	spi_hal_dev_config_t *hal_dev = &data->dev_config;
 	spi_hal_trans_config_t *hal_trans = &data->trans_config;
 	size_t chunk_len = spi_context_max_continuous_chunk(&data->ctx);
+	chunk_len = MIN(chunk_len, SOC_SPI_MAXIMUM_BUFFER_SIZE);
 
 	/* clean up and prepare SPI hal */
 	memset((uint32_t *) hal->hw->data_buf, 0, sizeof(hal->hw->data_buf));

--- a/soc/xtensa/esp32/soc.h
+++ b/soc/xtensa/esp32/soc.h
@@ -8,6 +8,7 @@
 #define __SOC_H__
 #include <soc/dport_reg.h>
 #include <soc/rtc_cntl_reg.h>
+#include <soc/soc_caps.h>
 #include <esp32/rom/ets_sys.h>
 #include <esp32/rom/spi_flash.h>
 


### PR DESCRIPTION
Max SPI chunk len was missing from the
implementation, causing SPI to hang up in some
conditions.

Fixes #35978
Fixes #37213

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>