### PR TITLE
eth-w5500 fixes, command read-back / reset pin toggle

### DIFF
--- a/drivers/ethernet/eth_w5500.c
+++ b/drivers/ethernet/eth_w5500.c
@@ -509,6 +509,7 @@ static int w5500_init(const struct device *dev)
 		}
 		gpio_pin_set_dt(&config->reset, 0);
 		k_usleep(500);
+		gpio_pin_set_dt(&config->reset, 1);
 	}
 
 	err = w5500_hw_reset(dev);

--- a/drivers/ethernet/eth_w5500.c
+++ b/drivers/ethernet/eth_w5500.c
@@ -160,18 +160,18 @@ static int w5500_command(const struct device *dev, uint8_t cmd)
 	uint64_t end = sys_clock_timeout_end_calc(K_MSEC(100));
 
 	w5500_spi_write(dev, W5500_S0_CR, &cmd, 1);
-  while(1) {
-    w5500_spi_read(dev, W5500_S0_CR, &reg, 1);
-    if (!reg) {
-      break;
-    }
-    int64_t remaining = end - sys_clock_tick_get();
-		if (remaining <= 0) {
-      return -EIO;
+	while(1) {
+		w5500_spi_read(dev, W5500_S0_CR, &reg, 1);
+		if (!reg) {
+			break;
 		}
-    k_busy_wait(W5500_PHY_ACCESS_DELAY);
+		int64_t remaining = end - sys_clock_tick_get();
+		if (remaining <= 0) {
+			return -EIO;
+		}
+		k_busy_wait(W5500_PHY_ACCESS_DELAY);
 	}
-  return 0;
+	return 0;
 }
 
 static int w5500_tx(const struct device *dev, struct net_pkt *pkt)

--- a/drivers/ethernet/eth_w5500.c
+++ b/drivers/ethernet/eth_w5500.c
@@ -160,19 +160,18 @@ static int w5500_command(const struct device *dev, uint8_t cmd)
 	uint64_t end = sys_clock_timeout_end_calc(K_MSEC(100));
 
 	w5500_spi_write(dev, W5500_S0_CR, &cmd, 1);
-	do {
-		int64_t remaining = end - sys_clock_tick_get();
-
+  while(1) {
+    w5500_spi_read(dev, W5500_S0_CR, &reg, 1);
+    if (!reg) {
+      break;
+    }
+    int64_t remaining = end - sys_clock_tick_get();
 		if (remaining <= 0) {
-			return -EIO;
+      return -EIO;
 		}
-
-		w5500_spi_read(dev, W5500_S0_CR, &reg, 1);
-
-		k_msleep(1);
-	} while (reg != 0);
-
-	return 0;
+    k_busy_wait(W5500_PHY_ACCESS_DELAY);
+	}
+  return 0;
 }
 
 static int w5500_tx(const struct device *dev, struct net_pkt *pkt)

--- a/drivers/ethernet/eth_w5500_priv.h
+++ b/drivers/ethernet/eth_w5500_priv.h
@@ -76,6 +76,9 @@
 #define W5500_Sn_RX_MEM_START	0x30000
 #define W5500_RX_MEM_SIZE	0x04000
 
+/* Delay for PHY write/read operations (25.6 us) */
+#define W5500_PHY_ACCESS_DELAY		26U
+
 struct w5500_config {
 	struct spi_dt_spec spi;
 	struct gpio_dt_spec interrupt;


### PR DESCRIPTION
I had bus faults in kernel scheduler during w5500_command(dev, S0_CR_RECV)
changed from k_sleep, which will allow other threads to wakeup to k_busy_wait (when necessary)