### PR TITLE
devicetree: Fix DT_PROP/DT_PROP_BY_IDX for phandle(s)

### DIFF
--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -682,10 +682,13 @@ def phandle_macros(prop, macro):
 
     if prop.type == "phandle":
         # A phandle is treated as a phandles with fixed length 1.
+        ret[f"{macro}"] = f"DT_{prop.val.z_path_id}"
+        ret[f"{macro}_IDX_0"] = f"DT_{prop.val.z_path_id}"
         ret[f"{macro}_IDX_0_PH"] = f"DT_{prop.val.z_path_id}"
         ret[f"{macro}_IDX_0_EXISTS"] = 1
     elif prop.type == "phandles":
         for i, node in enumerate(prop.val):
+            ret[f"{macro}_IDX_{i}"] = f"DT_{node.z_path_id}"
             ret[f"{macro}_IDX_{i}_PH"] = f"DT_{node.z_path_id}"
             ret[f"{macro}_IDX_{i}_EXISTS"] = 1
     elif prop.type == "phandle-array":

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -616,6 +616,10 @@ static void test_phandles(void)
 
 	/* phandle */
 	zassert_true(DT_NODE_HAS_PROP(TEST_PH, ph), "");
+	zassert_true(DT_SAME_NODE(DT_PROP(TEST_PH, ph),
+				  DT_NODELABEL(test_gpio_1)), "");
+	zassert_true(DT_SAME_NODE(DT_PROP_BY_IDX(TEST_PH, ph, 0),
+				  DT_NODELABEL(test_gpio_1)), "");
 	/* DT_PROP_BY_PHANDLE */
 	zassert_true(!strcmp(ph_label, "TEST_GPIO_1"), "");
 
@@ -623,6 +627,8 @@ static void test_phandles(void)
 	zassert_true(DT_NODE_HAS_PROP(TEST_PH, phs), "");
 	zassert_equal(ARRAY_SIZE(phs_labels), 3, "");
 	zassert_equal(DT_PROP_LEN(TEST_PH, phs), 3, "");
+	zassert_true(DT_SAME_NODE(DT_PROP_BY_IDX(TEST_PH, phs, 1),
+				  DT_NODELABEL(test_gpio_2)), "");
 
 	/* DT_PROP_BY_PHANDLE_IDX */
 	zassert_true(!strcmp(DT_PROP_BY_PHANDLE_IDX(TEST_PH, phs, 0, label),


### PR DESCRIPTION
DT_PROP for a phandle property should return the node that phandle
points to (similar for DT_PROP_BY_IDX for phandles)  and this wasn't
working as the define generator didn't create the proper defines for
phandle(s).

Fix the generator and add some tests to make sure this continues to
work correctly.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>