### PR TITLE
Bluetooth: ISO: Fixes missing handling of broadcast ISO TX

### DIFF
--- a/include/drivers/bluetooth/hci_driver.h
+++ b/include/drivers/bluetooth/hci_driver.h
@@ -63,11 +63,13 @@ static inline uint8_t bt_hci_evt_get_flags(uint8_t evt)
 	case BT_HCI_EVT_DISCONN_COMPLETE:
 		return BT_HCI_EVT_FLAG_RECV | BT_HCI_EVT_FLAG_RECV_PRIO;
 		/* fallthrough */
-#if defined(CONFIG_BT_CONN)
+#if defined(CONFIG_BT_CONN) || defined(CONFIG_BT_ISO)
 	case BT_HCI_EVT_NUM_COMPLETED_PACKETS:
+#if defined(CONFIG_BT_CONN)
 	case BT_HCI_EVT_DATA_BUF_OVERFLOW:
 		__fallthrough;
 #endif /* defined(CONFIG_BT_CONN) */
+#endif /* CONFIG_BT_CONN ||  CONFIG_BT_ISO */
 	case BT_HCI_EVT_CMD_COMPLETE:
 	case BT_HCI_EVT_CMD_STATUS:
 		return BT_HCI_EVT_FLAG_RECV_PRIO;

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -620,7 +620,7 @@ config BT_DEBUG_HCI_CORE
 
 config BT_DEBUG_CONN
 	bool "Bluetooth connection debug"
-	depends on BT_CONN
+	depends on BT_CONN || BT_ISO
 	help
 	  This option enables debug support for Bluetooth
 	  connection handling.


### PR DESCRIPTION
Fixes issues when sending data with a broadcast ISO only build. This includes moving a few additional functions from being ACL-only to also work with BT_ISO builds, as well as some updates handling of number_completed_packets events and reading buffer sizes from the controller. 