### PR TITLE
 Bluetooth: Mesh: Redefine callback registration

### DIFF
--- a/include/bluetooth/mesh/main.h
+++ b/include/bluetooth/mesh/main.h
@@ -598,9 +598,9 @@ struct bt_mesh_lpn_cb {
  *
  *  @param _name Name of callback structure.
  */
-#define BT_MESH_LPN_CB_DEFINE(_name)                                 \
-	static const STRUCT_SECTION_ITERABLE(bt_mesh_lpn_cb,         \
-					     _CONCAT(bt_mesh_lpn_cb, \
+#define BT_MESH_LPN_CB_DEFINE(_name)                                  \
+	static const STRUCT_SECTION_ITERABLE(bt_mesh_lpn_cb,          \
+					     _CONCAT(bt_mesh_lpn_cb_, \
 						     _name))
 
 /** Friend Node callback functions. */
@@ -651,9 +651,9 @@ struct bt_mesh_friend_cb {
  *
  *  @param _name Name of callback structure.
  */
-#define BT_MESH_FRIEND_CB_DEFINE(_name)                                 \
-	static const STRUCT_SECTION_ITERABLE(bt_mesh_friend_cb,         \
-					     _CONCAT(bt_mesh_friend_cb, \
+#define BT_MESH_FRIEND_CB_DEFINE(_name)                                  \
+	static const STRUCT_SECTION_ITERABLE(bt_mesh_friend_cb,          \
+					     _CONCAT(bt_mesh_friend_cb_, \
 						     _name))
 
 /** @brief Terminate Friendship.

--- a/include/bluetooth/mesh/proxy.h
+++ b/include/bluetooth/mesh/proxy.h
@@ -51,7 +51,7 @@ struct bt_mesh_proxy_cb {
  */
 #define BT_MESH_PROXY_CB_DEFINE(_name)                                         \
 	static const STRUCT_SECTION_ITERABLE(                                  \
-		bt_mesh_proxy_cb, _CONCAT(bt_mesh_proxy_cb, _name))
+		bt_mesh_proxy_cb, _CONCAT(bt_mesh_proxy_cb_, _name))
 
 /** @brief Enable advertising with Node Identity.
  *

--- a/subsys/bluetooth/mesh/app_keys.c
+++ b/subsys/bluetooth/mesh/app_keys.c
@@ -602,7 +602,9 @@ static void subnet_evt(struct bt_mesh_subnet *sub, enum bt_mesh_key_evt evt)
 	}
 }
 
-BT_MESH_SUBNET_CB_DEFINE(subnet_evt);
+BT_MESH_SUBNET_CB_DEFINE(app_keys) = {
+	.evt_handler = subnet_evt,
+};
 
 void bt_mesh_app_keys_reset(void)
 {

--- a/subsys/bluetooth/mesh/beacon.c
+++ b/subsys/bluetooth/mesh/beacon.c
@@ -423,7 +423,9 @@ static void subnet_evt(struct bt_mesh_subnet *sub, enum bt_mesh_key_evt evt)
 	}
 }
 
-BT_MESH_SUBNET_CB_DEFINE(subnet_evt);
+BT_MESH_SUBNET_CB_DEFINE(beacon) = {
+	.evt_handler = subnet_evt,
+};
 
 void bt_mesh_beacon_init(void)
 {

--- a/subsys/bluetooth/mesh/friend.c
+++ b/subsys/bluetooth/mesh/friend.c
@@ -1305,7 +1305,9 @@ static void subnet_evt(struct bt_mesh_subnet *sub, enum bt_mesh_key_evt evt)
 	}
 }
 
-BT_MESH_SUBNET_CB_DEFINE(subnet_evt);
+BT_MESH_SUBNET_CB_DEFINE(friend) = {
+	.evt_handler = subnet_evt,
+};
 
 int bt_mesh_friend_init(void)
 {

--- a/subsys/bluetooth/mesh/gatt_services.c
+++ b/subsys/bluetooth/mesh/gatt_services.c
@@ -640,7 +640,9 @@ static void subnet_evt(struct bt_mesh_subnet *sub, enum bt_mesh_key_evt evt)
 	}
 }
 
-BT_MESH_SUBNET_CB_DEFINE(subnet_evt);
+BT_MESH_SUBNET_CB_DEFINE(gatt_services) = {
+	.evt_handler = subnet_evt,
+};
 
 static void proxy_ccc_changed(const struct bt_gatt_attr *attr, uint16_t value)
 {

--- a/subsys/bluetooth/mesh/lpn.c
+++ b/subsys/bluetooth/mesh/lpn.c
@@ -1075,7 +1075,9 @@ static void subnet_evt(struct bt_mesh_subnet *sub, enum bt_mesh_key_evt evt)
 	}
 }
 
-BT_MESH_SUBNET_CB_DEFINE(subnet_evt);
+BT_MESH_SUBNET_CB_DEFINE(lpn) = {
+	.evt_handler = subnet_evt,
+};
 
 int bt_mesh_lpn_init(void)
 {

--- a/subsys/bluetooth/mesh/subnet.h
+++ b/subsys/bluetooth/mesh/subnet.h
@@ -76,13 +76,11 @@ struct bt_mesh_subnet_cb {
  *
  *  @brief Register a subnet event callback.
  *
- *  @param _handler Handler function, see @ref bt_mesh_subnet_cb::evt_handler.
+ *  @param _name Handler name.
  */
-#define BT_MESH_SUBNET_CB_DEFINE(_handler)                                     \
-	static const STRUCT_SECTION_ITERABLE(                                  \
-		bt_mesh_subnet_cb, _CONCAT(bt_mesh_subnet_cb_, _handler)) = {  \
-		.evt_handler = (_handler),                                     \
-	}
+#define BT_MESH_SUBNET_CB_DEFINE(_name)                                    \
+	static const STRUCT_SECTION_ITERABLE(                               \
+		bt_mesh_subnet_cb, _CONCAT(bt_mesh_subnet_cb_, _name))
 
 /** @brief Reset all Network keys. */
 void bt_mesh_net_keys_reset(void);


### PR DESCRIPTION
There is a problem with the previous method, that is,
we use the same label(bt_mesh_subnet_cb_subnet_evt) and
put it in the same section, which is not friendly for debugging.