### PR TITLE
samples: boards: stm32: fix backup sram memory displays wrong info

### DIFF
--- a/boards/arm/nucleo_h723zg/doc/index.rst
+++ b/boards/arm/nucleo_h723zg/doc/index.rst
@@ -92,27 +92,29 @@ Supported Features
 The Zephyr nucleo_h723zg board configuration supports the following hardware
 features:
 
-+-----------+------------+-------------------------------------+
-| Interface | Controller | Driver/Component                    |
-+===========+============+=====================================+
-| NVIC      | on-chip    | nested vector interrupt controller  |
-+-----------+------------+-------------------------------------+
-| UART      | on-chip    | serial port                         |
-+-----------+------------+-------------------------------------+
-| PINMUX    | on-chip    | pinmux                              |
-+-----------+------------+-------------------------------------+
-| GPIO      | on-chip    | gpio                                |
-+-----------+------------+-------------------------------------+
-| RTC       | on-chip    | counter                             |
-+-----------+------------+-------------------------------------+
-| I2C       | on-chip    | i2c                                 |
-+-----------+------------+-------------------------------------+
-| PWM       | on-chip    | pwm                                 |
-+-----------+------------+-------------------------------------+
-| ETHERNET  | on-chip    | ethernet                            |
-+-----------+------------+-------------------------------------+
-| RNG       | on-chip    | True Random number generator        |
-+-----------+------------+-------------------------------------+
++-------------+------------+-------------------------------------+
+| Interface   | Controller | Driver/Component                    |
++=============+============+=====================================+
+| NVIC        | on-chip    | nested vector interrupt controller  |
++-------------+------------+-------------------------------------+
+| UART        | on-chip    | serial port                         |
++-------------+------------+-------------------------------------+
+| PINMUX      | on-chip    | pinmux                              |
++-------------+------------+-------------------------------------+
+| GPIO        | on-chip    | gpio                                |
++-------------+------------+-------------------------------------+
+| RTC         | on-chip    | counter                             |
++-------------+------------+-------------------------------------+
+| I2C         | on-chip    | i2c                                 |
++-------------+------------+-------------------------------------+
+| PWM         | on-chip    | pwm                                 |
++-------------+------------+-------------------------------------+
+| ETHERNET    | on-chip    | ethernet                            |
++-------------+------------+-------------------------------------+
+| RNG         | on-chip    | True Random number generator        |
++-------------+------------+-------------------------------------+
+| Backup SRAM | on-chip    | Backup SRAM                         |
++-------------+------------+-------------------------------------+  
 
 Other hardware features are not yet supported on this Zephyr port.
 
@@ -146,6 +148,12 @@ Serial Port
 
 Nucleo H723ZG board has 4 UARTs and 4 USARTs. The Zephyr console output is
 assigned to UART3. Default settings are 115200 8N1.
+
+Backup SRAM
+-----------
+
+In order to test backup SRAM you may want to disconnect VBAT from VDD. You can
+do it by removing ``SB52`` jumper on the back side of the board.
 
 Programming and Debugging
 *************************

--- a/boards/arm/nucleo_h723zg/nucleo_h723zg.dts
+++ b/boards/arm/nucleo_h723zg/nucleo_h723zg.dts
@@ -105,6 +105,10 @@
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
+&backup_sram {
+ 	status = "okay"; 
+};
+
 &timers12 {
 	status = "okay";
 

--- a/boards/arm/nucleo_h723zg/nucleo_h723zg.yaml
+++ b/boards/arm/nucleo_h723zg/nucleo_h723zg.yaml
@@ -17,3 +17,4 @@ supported:
   - i2c
   - pwm
   - netif:eth
+  - backup_sram


### PR DESCRIPTION
Closes #37658 
have a generic board overlay
Signed-off-by: Manojkumar Subramaniam <manoj@electrolance.com>