### PR TITLE
Bluetooth: Controller: Update AD data race implementation

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -273,9 +273,13 @@ struct pdu_adv *lll_adv_pdu_alloc(struct lll_adv_pdu *pdu, uint8_t *idx)
 	uint8_t first, last;
 	void *p;
 
+	/* TODO: Make this unique mechanism to update last element in double
+	 *       buffer a re-usable utility function.
+	 */
 	first = pdu->first;
 	last = pdu->last;
 	if (first == last) {
+		/* Return the index of next free PDU in the double buffer */
 		last++;
 		if (last == DOUBLE_BUFFER_SIZE) {
 			last = 0U;
@@ -283,10 +287,23 @@ struct pdu_adv *lll_adv_pdu_alloc(struct lll_adv_pdu *pdu, uint8_t *idx)
 	} else {
 		uint8_t first_latest;
 
+		/* LLL has not consumed the first PDU. Revert back the `last` so
+		 * that LLL still consumes the first PDU while the caller of
+		 * this function updates/modifies the latest PDU.
+		 *
+		 * Under race condition:
+		 * 1. LLL runs before `pdu->last` is reverted, then `pdu->first`
+		 *    has changed, hence restore `pdu->last` and return index of
+		 *    next free PDU in the double buffer.
+		 * 2. LLL runs after `pdu->last` is reverted, then `pdu->first`
+		 *    will not change, return the saved `last` as the index of
+		 *    the next free PDU in the double buffer.
+		 */
 		pdu->last = first;
 		cpu_dmb();
 		first_latest = pdu->first;
 		if (first_latest != first) {
+			pdu->last = last;
 			last++;
 			if (last == DOUBLE_BUFFER_SIZE) {
 				last = 0U;


### PR DESCRIPTION
Update the AD data race condition handling with explicit
revert of `pdu->last` value after detecting the race.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>