### PR TITLE
Generic Host PCIe Controller Support

### DIFF
--- a/boards/arm64/qemu_cortex_a53/qemu_cortex_a53.dts
+++ b/boards/arm64/qemu_cortex_a53/qemu_cortex_a53.dts
@@ -28,7 +28,7 @@
 	soc {
 		sram0: memory@40000000 {
 			compatible = "mmio-sram";
-			reg = <0x40000000 DT_SIZE_M(128)>;
+			reg = <0x0 0x40000000 0x0 DT_SIZE_M(128)>;
 		};
 
 	};

--- a/doc/reference/devicetree/api.rst
+++ b/doc/reference/devicetree/api.rst
@@ -388,6 +388,8 @@ device.
      - Instruction Tightly Coupled Memory node on some Arm SoCs
    * - zephyr,ot-uart
      - Used by the OpenThread to specify UART device for Spinel protocol
+   * - zephyr,pcie-controller
+     - The node corresponding to the PCIe Controller
    * - zephyr,shell-uart
      - Sets UART device used by serial shell backend
    * - zephyr,sram

--- a/drivers/pcie/host/CMakeLists.txt
+++ b/drivers/pcie/host/CMakeLists.txt
@@ -1,6 +1,8 @@
 zephyr_library()
 
 zephyr_library_sources(pcie.c)
+zephyr_library_sources_ifdef(CONFIG_PCIE_CONTROLLER controller.c)
+zephyr_library_sources_ifdef(CONFIG_PCIE_ECAM pcie_ecam.c)
 zephyr_library_sources_ifdef(CONFIG_PCIE_MSI msi.c)
 zephyr_library_sources_ifdef(CONFIG_PCIE_SHELL shell.c)
 zephyr_library_sources_ifdef(CONFIG_PCIE_PTM ptm.c)

--- a/drivers/pcie/host/Kconfig
+++ b/drivers/pcie/host/Kconfig
@@ -14,6 +14,23 @@ module = PCIE
 module-str = pcie
 source "subsys/logging/Kconfig.template.log_config"
 
+config PCIE_CONTROLLER
+	bool "Enable PCIe Controller management"
+	help
+	  Add support for PCIe Controller management when not handled by a
+	  system firmware like on x86 platforms.
+
+if PCIE_CONTROLLER
+
+config PCIE_ECAM
+	bool "Enable support for PCIe ECAM Controllers"
+	help
+	  Add support for Enhanced Configuration Address Mapping configured
+	  PCIe Controllers allowing all outgoing I/O and MEM TLPs to be mapped
+	  from memory space into any 256 MB region of the PCIe configuration space.
+
+endif # PCIE_CONTROLLER
+
 config PCIE_MSI
 	bool "Enable support for PCI(e) MSI"
 	help

--- a/drivers/pcie/host/controller.c
+++ b/drivers/pcie/host/controller.c
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2021 BayLibre, SAS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <logging/log.h>
+LOG_MODULE_REGISTER(pcie_core, LOG_LEVEL_INF);
+
+#include <kernel.h>
+#include <drivers/pcie/pcie.h>
+#include <drivers/pcie/controller.h>
+
+#if CONFIG_PCIE_MSI
+#include <drivers/pcie/msi.h>
+#endif
+
+/* arch agnostic PCIe API implementation */
+
+uint32_t pcie_conf_read(pcie_bdf_t bdf, unsigned int reg)
+{
+	const struct device *dev;
+
+	dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_pcie_controller));
+	if (!dev) {
+		LOG_ERR("Failed to get PCIe root complex");
+		return 0xffffffff;
+	}
+
+	return pcie_ctrl_conf_read(dev, bdf, reg);
+}
+
+void pcie_conf_write(pcie_bdf_t bdf, unsigned int reg, uint32_t data)
+{
+	const struct device *dev;
+
+	dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_pcie_controller));
+	if (!dev) {
+		LOG_ERR("Failed to get PCIe root complex");
+		return;
+	}
+
+	pcie_ctrl_conf_write(dev, bdf, reg, data);
+}
+
+uint32_t generic_pcie_ctrl_conf_read(mm_reg_t cfg_addr, pcie_bdf_t bdf, unsigned int reg)
+{
+	volatile uint32_t *bdf_cfg_mem = (volatile uint32_t *)((uintptr_t)cfg_addr + (bdf << 4));
+
+	if (!cfg_addr) {
+		return 0xffffffff;
+	}
+
+	return bdf_cfg_mem[reg];
+}
+
+void generic_pcie_ctrl_conf_write(mm_reg_t cfg_addr, pcie_bdf_t bdf,
+				 unsigned int reg, uint32_t data)
+{
+	volatile uint32_t *bdf_cfg_mem = (volatile uint32_t *)((uintptr_t)cfg_addr + (bdf << 4));
+
+	if (!cfg_addr) {
+		return;
+	}
+
+	bdf_cfg_mem[reg] = data;
+}
+
+static void generic_pcie_ctrl_enumerate_type1(const struct device *ctrl_dev, pcie_bdf_t bdf)
+{
+	/* Not yet supported */
+}
+
+static void generic_pcie_ctrl_type0_enumerate_bars(const struct device *ctrl_dev, pcie_bdf_t bdf)
+{
+	unsigned int bar, reg, data;
+	uintptr_t scratch, bar_bus_addr;
+	size_t size, bar_size;
+
+	for (bar = 0, reg = PCIE_CONF_BAR0; reg <= PCIE_CONF_BAR5; reg ++, bar++) {
+		bool found_mem64 = false;
+		bool found_mem = false;
+
+		data = scratch = pcie_conf_read(bdf, reg);
+
+		if (PCIE_CONF_BAR_INVAL_FLAGS(data)) {
+			continue;
+		}
+
+		if (PCIE_CONF_BAR_MEM(data)) {
+			found_mem = true;
+			if (PCIE_CONF_BAR_64(data)) {
+				found_mem64 = true;
+				scratch |= ((uint64_t)pcie_conf_read(bdf, reg + 1)) << 32;
+				if (PCIE_CONF_BAR_ADDR(scratch) == PCIE_CONF_BAR_INVAL64) {
+					continue;
+				}
+			} else {
+				if (PCIE_CONF_BAR_ADDR(scratch) == PCIE_CONF_BAR_INVAL) {
+					continue;
+				}
+			}
+		}
+
+		pcie_conf_write(bdf, reg, 0xFFFFFFFF);
+		size = pcie_conf_read(bdf, reg);
+		pcie_conf_write(bdf, reg, scratch & 0xFFFFFFFF);
+
+		if (found_mem64) {
+			pcie_conf_write(bdf, reg + 1, 0xFFFFFFFF);
+			size |= ((uint64_t)pcie_conf_read(bdf, reg + 1)) << 32;
+			pcie_conf_write(bdf, reg + 1, scratch >> 32);
+		}
+
+		if (!PCIE_CONF_BAR_ADDR(size)) {
+			if (found_mem64) {
+				reg++;
+			}
+			continue;
+		}
+
+		if (found_mem) {
+			if (found_mem64) {
+				bar_size = (uint64_t)~PCIE_CONF_BAR_ADDR(size) + 1;
+			} else {
+				bar_size = (uint32_t)~PCIE_CONF_BAR_ADDR(size) + 1;
+			}
+		} else {
+			bar_size = (uint32_t)~PCIE_CONF_BAR_IO_ADDR(size) + 1;
+		}
+
+		if (pcie_ctrl_region_allocate(ctrl_dev, bdf, found_mem,
+					      found_mem64, bar_size, &bar_bus_addr)) {
+			uintptr_t bar_phys_addr;
+
+			pcie_ctrl_region_xlate(ctrl_dev, bdf, found_mem,
+					      found_mem64, bar_bus_addr, &bar_phys_addr);
+
+			LOG_INF("[%02x:%02x.%x] BAR%d size 0x%lx "
+				"assigned [%s 0x%lx-0x%lx -> 0x%lx-0x%lx]",
+				PCIE_BDF_TO_BUS(bdf), PCIE_BDF_TO_DEV(bdf), PCIE_BDF_TO_FUNC(bdf),
+				bar, bar_size,
+				found_mem ? (found_mem64 ? "mem64" : "mem") : "io",
+				bar_bus_addr, bar_bus_addr + bar_size - 1,
+				bar_phys_addr, bar_phys_addr + bar_size - 1);
+
+			pcie_conf_write(bdf, reg, bar_bus_addr & 0xFFFFFFFF);
+			if (found_mem64) {
+				pcie_conf_write(bdf, reg + 1, bar_bus_addr >> 32);
+			}
+		} else {
+			LOG_INF("[%02x:%02x.%x] BAR%d size 0x%lx Failed memory allocation.",
+				PCIE_BDF_TO_BUS(bdf), PCIE_BDF_TO_DEV(bdf), PCIE_BDF_TO_FUNC(bdf),
+				bar, bar_size);
+		}
+
+		if (found_mem64) {
+			reg++;
+		}
+	}
+}
+
+static void generic_pcie_ctrl_enumerate_type0(const struct device *ctrl_dev, pcie_bdf_t bdf)
+{
+	/* Setup Type0 BARs */
+	generic_pcie_ctrl_type0_enumerate_bars(ctrl_dev, bdf);
+}
+
+void generic_pcie_ctrl_enumerate(const struct device *ctrl_dev, pcie_bdf_t bdf_start)
+{
+	uint32_t data, class, id;
+	unsigned int dev = PCIE_BDF_TO_DEV(bdf_start),
+		     func = 0,
+		     bus = PCIE_BDF_TO_BUS(bdf_start);
+
+	for (; dev <= PCIE_MAX_DEV; dev++) {
+		func = 0;
+		for (; func <= PCIE_MAX_FUNC; func++) {
+			pcie_bdf_t bdf = PCIE_BDF(bus, dev, func);
+			bool multifunction_device = false;
+			bool layout_type_1 = false;
+
+			id = pcie_conf_read(bdf, PCIE_CONF_ID);
+			if (id == PCIE_ID_NONE) {
+				continue;
+			}
+
+			class = pcie_conf_read(bdf, PCIE_CONF_CLASSREV);
+			data = pcie_conf_read(bdf, PCIE_CONF_TYPE);
+
+			multifunction_device = PCIE_CONF_MULTIFUNCTION(data);
+			layout_type_1 = PCIE_CONF_TYPE_BRIDGE(data);
+
+			LOG_INF("[%02x:%02x.%x] %04x:%04x class %x subclass %x progif %x "
+				"rev %x Type%x multifunction %s",
+				PCIE_BDF_TO_BUS(bdf), PCIE_BDF_TO_DEV(bdf), PCIE_BDF_TO_FUNC(bdf),
+				id & 0xffff, id >> 16,
+				PCIE_CONF_CLASSREV_CLASS(class),
+				PCIE_CONF_CLASSREV_SUBCLASS(class),
+				PCIE_CONF_CLASSREV_PROGIF(class),
+				PCIE_CONF_CLASSREV_REV(class),
+				layout_type_1 ? 1 : 0,
+				multifunction_device ? "true" : "false");
+
+			if (layout_type_1) {
+				generic_pcie_ctrl_enumerate_type1(ctrl_dev, bdf);
+			} else {
+				generic_pcie_ctrl_enumerate_type0(ctrl_dev, bdf);
+			}
+
+			/* Do not enumerate sub-functions if not a multifunction device */
+			if (PCIE_BDF_TO_FUNC(bdf) == 0 && !multifunction_device) {
+				break;
+			}
+		}
+	}
+}

--- a/drivers/pcie/host/pcie_ecam.c
+++ b/drivers/pcie/host/pcie_ecam.c
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) 2021 BayLibre, SAS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <logging/log.h>
+LOG_MODULE_REGISTER(pcie_ecam, LOG_LEVEL_ERR);
+
+#include <kernel.h>
+#include <device.h>
+#include <drivers/pcie/pcie.h>
+#include <drivers/pcie/controller.h>
+
+#define DT_DRV_COMPAT pci_host_ecam_generic
+
+/*
+ * PCIe Controllers Regions
+ *
+ * TOFIX:
+ * - handle prefetchable regions
+ */
+enum pcie_region_type {
+	PCIE_REGION_IO = 0,
+	PCIE_REGION_MEM,
+	PCIE_REGION_MEM64,
+	PCIE_REGION_MAX,
+};
+
+struct pcie_ecam_data {
+	uintptr_t cfg_phys_addr;
+	mm_reg_t cfg_addr;
+	size_t cfg_size;
+	struct {
+		uintptr_t phys_start;
+		uintptr_t bus_start;
+		size_t size;
+		size_t allocation_offset;
+	} regions[PCIE_REGION_MAX];
+};
+
+static int pcie_ecam_init(const struct device *dev)
+{
+	const struct pcie_ctrl_config *cfg = (const struct pcie_ctrl_config *)dev->config;
+	struct pcie_ecam_data *data = (struct pcie_ecam_data *)dev->data;
+	int i;
+
+	/*
+	 * Flags defined in the PCI Bus Binding to IEEE Std 1275-1994 :
+	 *           Bit# 33222222 22221111 11111100 00000000
+	 *                10987654 32109876 54321098 76543210
+	 *
+	 * phys.hi cell:  npt000ss bbbbbbbb dddddfff rrrrrrrr
+	 * phys.mid cell: hhhhhhhh hhhhhhhh hhhhhhhh hhhhhhhh
+	 * phys.lo cell:  llllllll llllllll llllllll llllllll
+	 *
+	 * where:
+	 *
+	 * n	is 0 if the address is relocatable, 1 otherwise
+	 * p	is 1 if the addressable region is "prefetchable", 0 otherwise
+	 * t	is 1 if the address is aliased (for non-relocatable I/O), below 1 MB (for Memory),
+	 *	or below 64 KB (for relocatable I/O).
+	 * ss	is the space code, denoting the address space
+	 *	00 denotes Configuration Space
+	 *	01 denotes I/O Space
+	 *	10 denotes 32-bit-address Memory Space
+	 *	11 denotes 64-bit-address Memory Space
+	 * bbbbbbbb	is the 8-bit Bus Number
+	 * ddddd	is the 5-bit Device Number
+	 * fff	is the 3-bit Function Number
+	 * rrrrrrrr	is the 8-bit Register Number
+	 * hh...hh	is a 32-bit unsigned number
+	 * ll...ll	is a 32-bit unsigned number
+	 *	for I/O Space is the 32-bit offset from the start of the region
+	 *	for 32-bit-address Memory Space is the 32-bit offset from the start of the region
+	 *	for 64-bit-address Memory Space is the 64-bit offset from the start of the region
+	 *
+	 * Here we only handle the p, ss, hh and ll fields.
+	 *
+	 * TOFIX:
+	 * - handle prefetchable bit
+	 */
+	for (i = 0 ; i < cfg->ranges_count ; ++i) {
+		switch ((cfg->ranges[i].flags >> 24) & 0x03) {
+		case 0x01:
+			data->regions[PCIE_REGION_IO].bus_start = cfg->ranges[i].pcie_bus_addr;
+			data->regions[PCIE_REGION_IO].phys_start = cfg->ranges[i].host_map_addr;
+			data->regions[PCIE_REGION_IO].size = cfg->ranges[i].map_length;
+			/* Linux & U-Boot avoids allocating PCI resources from address 0 */
+			if (data->regions[PCIE_REGION_IO].bus_start < 0x1000)
+				data->regions[PCIE_REGION_IO].allocation_offset = 0x1000;
+			break;
+		case 0x02:
+			data->regions[PCIE_REGION_MEM].bus_start = cfg->ranges[i].pcie_bus_addr;
+			data->regions[PCIE_REGION_MEM].phys_start = cfg->ranges[i].host_map_addr;
+			data->regions[PCIE_REGION_MEM].size = cfg->ranges[i].map_length;
+			/* Linux & U-Boot avoids allocating PCI resources from address 0 */
+			if (data->regions[PCIE_REGION_MEM].bus_start < 0x1000)
+				data->regions[PCIE_REGION_MEM].allocation_offset = 0x1000;
+			break;
+		case 0x03:
+			data->regions[PCIE_REGION_MEM64].bus_start = cfg->ranges[i].pcie_bus_addr;
+			data->regions[PCIE_REGION_MEM64].phys_start = cfg->ranges[i].host_map_addr;
+			data->regions[PCIE_REGION_MEM64].size = cfg->ranges[i].map_length;
+			/* Linux & U-Boot avoids allocating PCI resources from address 0 */
+			if (data->regions[PCIE_REGION_MEM64].bus_start < 0x1000)
+				data->regions[PCIE_REGION_MEM64].allocation_offset = 0x1000;
+			break;
+		}
+	}
+
+	if (!data->regions[PCIE_REGION_IO].size &&
+	    !data->regions[PCIE_REGION_MEM].size &&
+	    !data->regions[PCIE_REGION_MEM64].size) {
+		LOG_ERR("No regions defined");
+		return -EINVAL;
+	}
+
+	/* Get Config address space physical address & size */
+	data->cfg_phys_addr = cfg->cfg_addr;
+	data->cfg_size = cfg->cfg_size;
+
+	if (data->regions[PCIE_REGION_IO].size) {
+		LOG_DBG("IO bus [0x%lx - 0x%lx, size 0x%lx]",
+			data->regions[PCIE_REGION_IO].bus_start,
+			(data->regions[PCIE_REGION_IO].bus_start +
+			 data->regions[PCIE_REGION_IO].size - 1),
+			data->regions[PCIE_REGION_IO].size);
+		LOG_DBG("IO space [0x%lx - 0x%lx, size 0x%lx]",
+			data->regions[PCIE_REGION_IO].phys_start,
+			(data->regions[PCIE_REGION_IO].phys_start +
+			 data->regions[PCIE_REGION_IO].size - 1),
+			data->regions[PCIE_REGION_IO].size);
+	}
+	if (data->regions[PCIE_REGION_MEM].size) {
+		LOG_DBG("MEM bus [0x%lx - 0x%lx, size 0x%lx]",
+			data->regions[PCIE_REGION_MEM].bus_start,
+			(data->regions[PCIE_REGION_MEM].bus_start +
+			 data->regions[PCIE_REGION_MEM].size - 1),
+			data->regions[PCIE_REGION_MEM].size);
+		LOG_DBG("MEM space [0x%lx - 0x%lx, size 0x%lx]",
+			data->regions[PCIE_REGION_MEM].phys_start,
+			(data->regions[PCIE_REGION_MEM].phys_start +
+			 data->regions[PCIE_REGION_MEM].size - 1),
+			data->regions[PCIE_REGION_MEM].size);
+	}
+	if (data->regions[PCIE_REGION_MEM64].size) {
+		LOG_DBG("MEM64 bus [0x%lx - 0x%lx, size 0x%lx]",
+			data->regions[PCIE_REGION_MEM64].bus_start,
+			(data->regions[PCIE_REGION_MEM64].bus_start +
+			 data->regions[PCIE_REGION_MEM64].size - 1),
+			data->regions[PCIE_REGION_MEM64].size);
+		LOG_DBG("MEM64 space [0x%lx - 0x%lx, size 0x%lx]",
+			data->regions[PCIE_REGION_MEM64].phys_start,
+			(data->regions[PCIE_REGION_MEM64].phys_start +
+			 data->regions[PCIE_REGION_MEM64].size - 1),
+			data->regions[PCIE_REGION_MEM64].size);
+	}
+
+	/* Map config space to be used by the generic_pcie_ctrl_conf_read/write callbacks */
+	device_map(&data->cfg_addr, data->cfg_phys_addr, data->cfg_size, K_MEM_CACHE_NONE);
+
+	LOG_DBG("Config space [0x%lx - 0x%lx, size 0x%lx]",
+		data->cfg_phys_addr, (data->cfg_phys_addr + data->cfg_size - 1), data->cfg_size);
+	LOG_DBG("Config mapped [0x%lx - 0x%lx, size 0x%lx]",
+		data->cfg_addr, (data->cfg_addr + data->cfg_size - 1), data->cfg_size);
+
+	generic_pcie_ctrl_enumerate(dev, PCIE_BDF(0, 0, 0));
+
+	return 0;
+}
+
+static uint32_t pcie_ecam_ctrl_conf_read(const struct device *dev, pcie_bdf_t bdf, unsigned int reg)
+{
+	struct pcie_ecam_data *data = (struct pcie_ecam_data *)dev->data;
+
+	return generic_pcie_ctrl_conf_read(data->cfg_addr, bdf, reg);
+}
+
+static void pcie_ecam_ctrl_conf_write(const struct device *dev, pcie_bdf_t bdf, unsigned int reg,
+				      uint32_t reg_data)
+{
+	struct pcie_ecam_data *data = (struct pcie_ecam_data *)dev->data;
+
+	generic_pcie_ctrl_conf_write(data->cfg_addr, bdf, reg, reg_data);
+}
+
+static bool pcie_ecam_region_allocate_type(struct pcie_ecam_data *data, pcie_bdf_t bdf,
+					   size_t bar_size, uintptr_t *bar_bus_addr,
+					   enum pcie_region_type type)
+{
+	uintptr_t addr;
+
+	addr = (((data->regions[type].bus_start + data->regions[type].allocation_offset) - 1) |
+		((bar_size) - 1)) + 1;
+
+	if (addr - data->regions[type].bus_start + bar_size > data->regions[type].size)
+		return false;
+
+	*bar_bus_addr = addr;
+	data->regions[type].allocation_offset = addr - data->regions[type].bus_start + bar_size;
+
+	return true;
+}
+
+static bool pcie_ecam_region_allocate(const struct device *dev, pcie_bdf_t bdf,
+				      bool mem, bool mem64, size_t bar_size,
+				      uintptr_t *bar_bus_addr)
+{
+	struct pcie_ecam_data *data = (struct pcie_ecam_data *)dev->data;
+	enum pcie_region_type type;
+
+	if (mem && !data->regions[PCIE_REGION_MEM64].size &&
+	    !data->regions[PCIE_REGION_MEM].size) {
+		LOG_DBG("bdf %x no mem region defined for allocation", bdf);
+		return false;
+	}
+
+	if (!mem && !data->regions[PCIE_REGION_IO].size) {
+		LOG_DBG("bdf %x no io region defined for allocation", bdf);
+		return false;
+	}
+
+	/*
+	 * Allocate into mem64 region if available or is the only available
+	 *
+	 * TOFIX:
+	 * - handle allocation from/to mem/mem64 when a region is full
+	 */
+	if (mem && ((mem64 && data->regions[PCIE_REGION_MEM64].size) ||
+		    (data->regions[PCIE_REGION_MEM64].size &&
+		     !data->regions[PCIE_REGION_MEM].size))) {
+		type = PCIE_REGION_MEM64;
+	} else if (mem) {
+		type = PCIE_REGION_MEM;
+	} else {
+		type = PCIE_REGION_IO;
+	}
+
+	return pcie_ecam_region_allocate_type(data, bdf, bar_size, bar_bus_addr, type);
+}
+
+static bool pcie_ecam_region_xlate(const struct device *dev, pcie_bdf_t bdf,
+				   bool mem, bool mem64, uintptr_t bar_bus_addr,
+				   uintptr_t *bar_addr)
+{
+	struct pcie_ecam_data *data = (struct pcie_ecam_data *)dev->data;
+	enum pcie_region_type type;
+
+	/* Means it hasn't been allocated */
+	if (!bar_bus_addr)
+		return false;
+
+	if (mem && ((mem64 && data->regions[PCIE_REGION_MEM64].size) ||
+		    (data->regions[PCIE_REGION_MEM64].size &&
+		     !data->regions[PCIE_REGION_MEM].size))) {
+		type = PCIE_REGION_MEM64;
+	} else if (mem) {
+		type = PCIE_REGION_MEM;
+	} else {
+		type = PCIE_REGION_IO;
+	}
+
+	*bar_addr = data->regions[type].phys_start + (bar_bus_addr - data->regions[type].bus_start);
+
+	return true;
+}
+
+static const struct pcie_ctrl_driver_api pcie_ecam_api = {
+	.conf_read = pcie_ecam_ctrl_conf_read,
+	.conf_write = pcie_ecam_ctrl_conf_write,
+	.region_allocate = pcie_ecam_region_allocate,
+	.region_xlate = pcie_ecam_region_xlate,
+};
+
+#define PCIE_ECAM_INIT(n)							\
+	static struct pcie_ecam_data pcie_ecam_data##n;				\
+	static const struct pcie_ctrl_config pcie_ecam_config##n = {		\
+		.cfg_addr = DT_INST_REG_ADDR(n),				\
+		.cfg_size = DT_INST_REG_SIZE(n),				\
+		.ranges_count = DT_NUM_RANGES(DT_DRV_INST(n)),		\
+		.ranges = {							\
+			DT_FOREACH_RANGE(DT_DRV_INST(n), PCIE_RANGE_FORMAT)	\
+		},								\
+	};									\
+	DEVICE_DT_INST_DEFINE(n, &pcie_ecam_init, NULL,				\
+			      &pcie_ecam_data##n,				\
+			      &pcie_ecam_config##n,				\
+			      PRE_KERNEL_1,					\
+			      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,		\
+			      &pcie_ecam_api);
+
+DT_INST_FOREACH_STATUS_OKAY(PCIE_ECAM_INIT)

--- a/dts/arm64/qemu-virt/qemu-virt-a53.dtsi
+++ b/dts/arm64/qemu-virt/qemu-virt-a53.dtsi
@@ -18,6 +18,9 @@
 #include <dt-bindings/interrupt-controller/arm-gic.h>
 
 / {
+	#address-cells = <2>;
+	#size-cells = <2>;
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -56,12 +59,16 @@
 	};
 
 	soc {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
 		interrupt-parent = <&gic>;
 
 		gic: interrupt-controller@8000000 {
 			compatible = "arm,gic";
-			reg = <0x8000000 0x010000>,
-			      <0x80a0000 0xf60000>;
+			reg = <0x00 0x8000000 0x00 0x010000>,
+			      <0x00 0x80a0000 0x00 0xf60000>;
 			interrupt-controller;
 			#interrupt-cells = <4>;
 			label = "GIC";
@@ -70,7 +77,7 @@
 
 		uart0: uart@9000000 {
 			compatible = "arm,pl011";
-			reg = <0x9000000 0x1000>;
+			reg = <0x00 0x9000000 0x00 0x1000>;
 			status = "disabled";
 			interrupts = <GIC_SPI 1 IRQ_TYPE_LEVEL 0>;
 			interrupt-names = "irq_0";
@@ -85,7 +92,7 @@
 			 * one value in the reg property, so we comment out the
 			 * second flash bank for now
 			 */
-			reg = <0x0 DT_SIZE_M(64) /* 0x4000000 DT_SIZE_M(64) */>;
+			reg = <0x0 0x0 0x0 DT_SIZE_M(64) /* 0x4000000 DT_SIZE_M(64) */>;
 		};
 	};
 };

--- a/dts/bindings/pcie/host/pci-host-ecam-generic.yaml
+++ b/dts/bindings/pcie/host/pci-host-ecam-generic.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2020 BayLibre, SAS
+# SPDX-License-Identifier: Apache-2.0
+
+description: PCIe Controller in ECAM mode
+
+compatible: "pci-host-ecam-generic"
+
+include: pcie-controller.yaml
+
+properties:
+    reg:
+      required: true
+
+    msi-parent:
+      type: phandle
+
+    ranges:
+      type: array
+      required: true
+      description: |
+        As described in IEEE Std 1275-1994, but must provide at least a
+        definition of non-prefetchable memory. One or both of prefetchable Memory
+        and IO Space may also be provided.

--- a/include/drivers/pcie/controller.h
+++ b/include/drivers/pcie/controller.h
@@ -1,0 +1,294 @@
+/**
+ * @file
+ *
+ * @brief Public APIs for the PCIe Controllers drivers.
+ */
+
+/*
+ * Copyright (c) 2021 BayLibre, SAS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_DRIVERS_PCIE_CONTROLLERS_H_
+#define ZEPHYR_INCLUDE_DRIVERS_PCIE_CONTROLLERS_H_
+
+#include <zephyr/types.h>
+#include <device.h>
+
+/**
+ * @brief PCI Express Controller Interface
+ * @defgroup pcie_controller_interface PCI Express Controller Interface
+ * @ingroup io_interfaces
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Function called to read a 32-bit word from an endpoint's configuration space.
+ *
+ * Read a 32-bit word from an endpoint's configuration space with the PCI Express Controller
+ * configuration space access method (I/O port, memory mapped or custom method)
+ *
+ * @param dev PCI Express Controller device pointer
+ * @param bdf PCI(e) endpoint
+ * @param reg the configuration word index (not address)
+ * @return the word read (0xFFFFFFFFU if nonexistent endpoint or word)
+ */
+typedef uint32_t (*pcie_ctrl_conf_read_t)(const struct device *dev, pcie_bdf_t bdf,
+					  unsigned int reg);
+
+/**
+ * @brief Function called to write a 32-bit word to an endpoint's configuration space.
+ *
+ * Write a 32-bit word to an endpoint's configuration space with the PCI Express Controller
+ * configuration space access method (I/O port, memory mapped or custom method)
+ *
+ * @param dev PCI Express Controller device pointer
+ * @param bdf PCI(e) endpoint
+ * @param reg the configuration word index (not address)
+ * @param data the value to write
+ */
+typedef void (*pcie_ctrl_conf_write_t)(const struct device *dev, pcie_bdf_t bdf,
+					  unsigned int reg, uint32_t data);
+
+/**
+ * @brief Function called to allocate a memory region subset for an endpoint Base Address Register.
+ *
+ * When enumerating PCIe Endpoints, Type0 endpoints can require up to 6 memory zones
+ * via the Base Address Registers from I/O or Memory types.
+ *
+ * This call allocates such zone in the PCI Express Controller memory regions if
+ * such region is available and space is still available.
+ *
+ * @param dev PCI Express Controller device pointer
+ * @param bdf PCI(e) endpoint
+ * @param mem True if the BAR is of memory type
+ * @param mem64 True if the BAR is of 64bit memory type
+ * @param bar_size Size in bytes of the Base Address Register as returned by HW
+ * @param bar_bus_addr bus-centric address allocated to be written in the BAR register
+ * @return True if allocation was possible, False if allocation failed
+ */
+typedef bool (*pcie_ctrl_region_allocate_t)(const struct device *dev, pcie_bdf_t bdf,
+					    bool mem, bool mem64, size_t bar_size,
+					    uintptr_t *bar_bus_addr);
+
+/**
+ * @brief Function called to translate an endpoint Base Address Register bus-centric address
+ * into Physical address.
+ *
+ * When enumerating PCIe Endpoints, Type0 endpoints can require up to 6 memory zones
+ * via the Base Address Registers from I/O or Memory types.
+ *
+ * The bus-centric address set in this BAR register is not necessarely accessible from the CPU,
+ * thus must be translated by using the PCI Express Controller memory regions translation
+ * ranges to permit mapping from the CPU.
+ *
+ * @param dev PCI Express Controller device pointer
+ * @param bdf PCI(e) endpoint
+ * @param mem True if the BAR is of memory type
+ * @param mem64 True if the BAR is of 64bit memory type
+ * @param bar_bus_addr bus-centric address written in the BAR register
+ * @param bar_addr CPU-centric address translated from the bus-centric address
+ * @return True if translation was possible, False if translation failed
+ */
+typedef bool (*pcie_ctrl_region_xlate_t)(const struct device *dev, pcie_bdf_t bdf,
+					 bool mem, bool mem64, uintptr_t bar_bus_addr,
+					 uintptr_t *bar_addr);
+
+/**
+ * @brief Read a 32-bit word from a Memory-Mapped endpoint's configuration space.
+ *
+ * Read a 32-bit word from an endpoint's configuration space from a Memory-Mapped
+ * configuration space access method, known as PCI Control Access Method (CAM) or
+ * PCIe Extended Control Access Method (ECAM).
+ *
+ * @param cfg_addr Logical address of Memory-Mapped configuration space
+ * @param bdf PCI(e) endpoint
+ * @param reg the configuration word index (not address)
+ * @return the word read (0xFFFFFFFFU if nonexistent endpoint or word)
+ */
+uint32_t generic_pcie_ctrl_conf_read(mm_reg_t cfg_addr, pcie_bdf_t bdf, unsigned int reg);
+
+
+/**
+ * @brief Write a 32-bit word to a Memory-Mapped endpoint's configuration space.
+ *
+ * Write a 32-bit word to an endpoint's configuration space from a Memory-Mapped
+ * configuration space access method, known as PCI Control Access Method (CAM) or
+ * PCIe Extended Control Access Method (ECAM).
+ *
+ * @param cfg_addr Logical address of Memory-Mapped configuration space
+ * @param bdf PCI(e) endpoint
+ * @param reg the configuration word index (not address)
+ * @param data the value to write
+ */
+void generic_pcie_ctrl_conf_write(mm_reg_t cfg_addr, pcie_bdf_t bdf,
+				  unsigned int reg, uint32_t data);
+
+/**
+ * @brief Start PCIe Endpoints enumeration.
+ *
+ * Start a PCIe Endpoints enumeration from a Bus number.
+ * When on non-x86 architecture or when firmware didn't setup the PCIe Bus hierarchy,
+ * the PCIe bus complex must be enumerated to setup the Endpoints Base Address Registers.
+ *
+ * @param dev PCI Express Controller device pointer
+ * @param bdf_start PCI(e) start endpoint (only bus & dev are used to start enumeration)
+ */
+void generic_pcie_ctrl_enumerate(const struct device *dev, pcie_bdf_t bdf_start);
+
+/** @brief Structure providing callbacks to be implemented for devices
+ * that supports the PCI Express Controller API
+ */
+__subsystem struct pcie_ctrl_driver_api {
+	pcie_ctrl_conf_read_t conf_read;
+	pcie_ctrl_conf_write_t conf_write;
+	pcie_ctrl_region_allocate_t region_allocate;
+	pcie_ctrl_region_xlate_t region_xlate;
+};
+
+/**
+ * @brief Read a 32-bit word from an endpoint's configuration space.
+ *
+ * Read a 32-bit word from an endpoint's configuration space with the PCI Express Controller
+ * configuration space access method (I/O port, memory mapped or custom method)
+ *
+ * @param dev PCI Express Controller device pointer
+ * @param bdf PCI(e) endpoint
+ * @param reg the configuration word index (not address)
+ * @return the word read (0xFFFFFFFFU if nonexistent endpoint or word)
+ */
+static inline uint32_t pcie_ctrl_conf_read(const struct device *dev, pcie_bdf_t bdf,
+					   unsigned int reg)
+{
+	const struct pcie_ctrl_driver_api *api =
+		(const struct pcie_ctrl_driver_api *)dev->api;
+
+	return api->conf_read(dev, bdf, reg);
+}
+
+/**
+ * @brief Write a 32-bit word to an endpoint's configuration space.
+ *
+ * Write a 32-bit word to an endpoint's configuration space with the PCI Express Controller
+ * configuration space access method (I/O port, memory mapped or custom method)
+ *
+ * @param dev PCI Express Controller device pointer
+ * @param bdf PCI(e) endpoint
+ * @param reg the configuration word index (not address)
+ * @param data the value to write
+ */
+static inline void pcie_ctrl_conf_write(const struct device *dev, pcie_bdf_t bdf,
+					unsigned int reg, uint32_t data)
+{
+	const struct pcie_ctrl_driver_api *api =
+		(const struct pcie_ctrl_driver_api *)dev->api;
+
+	api->conf_write(dev, bdf, reg, data);
+}
+
+/**
+ * @brief Allocate a memory region subset for an endpoint Base Address Register.
+ *
+ * When enumerating PCIe Endpoints, Type0 endpoints can require up to 6 memory zones
+ * via the Base Address Registers from I/O or Memory types.
+ *
+ * This call allocates such zone in the PCI Express Controller memory regions if
+ * such region is available and space is still available.
+ *
+ * @param dev PCI Express Controller device pointer
+ * @param bdf PCI(e) endpoint
+ * @param mem True if the BAR is of memory type
+ * @param mem64 True if the BAR is of 64bit memory type
+ * @param bar_size Size in bytes of the Base Address Register as returned by HW
+ * @param bar_bus_addr bus-centric address allocated to be written in the BAR register
+ * @return True if allocation was possible, False if allocation failed
+ */
+static inline bool pcie_ctrl_region_allocate(const struct device *dev, pcie_bdf_t bdf,
+					     bool mem, bool mem64, size_t bar_size,
+					     uintptr_t *bar_bus_addr)
+{
+	const struct pcie_ctrl_driver_api *api =
+		(const struct pcie_ctrl_driver_api *)dev->api;
+
+	return api->region_allocate(dev, bdf, mem, mem64, bar_size, bar_bus_addr);
+}
+
+/**
+ * @brief Translate an endpoint Base Address Register bus-centric address into Physical address.
+ *
+ * When enumerating PCIe Endpoints, Type0 endpoints can require up to 6 memory zones
+ * via the Base Address Registers from I/O or Memory types.
+ *
+ * The bus-centric address set in this BAR register is not necessarely accessible from the CPU,
+ * thus must be translated by using the PCI Express Controller memory regions translation
+ * ranges to permit mapping from the CPU.
+ *
+ * @param dev PCI Express Controller device pointer
+ * @param bdf PCI(e) endpoint
+ * @param mem True if the BAR is of memory type
+ * @param mem64 True if the BAR is of 64bit memory type
+ * @param bar_bus_addr bus-centric address written in the BAR register
+ * @param bar_addr CPU-centric address translated from the bus-centric address
+ * @return True if translation was possible, False if translation failed
+ */
+static inline bool pcie_ctrl_region_xlate(const struct device *dev, pcie_bdf_t bdf,
+					  bool mem, bool mem64, uintptr_t bar_bus_addr,
+					  uintptr_t *bar_addr)
+{
+	const struct pcie_ctrl_driver_api *api =
+		(const struct pcie_ctrl_driver_api *)dev->api;
+
+	if (!api->region_xlate) {
+		*bar_addr = bar_bus_addr;
+		return true;
+	} else {
+		return api->region_xlate(dev, bdf, mem, mem64, bar_bus_addr, bar_addr);
+	}
+}
+
+/** @brief Structure describing a device that supports the PCI Express Controller API
+ */
+struct pcie_ctrl_config {
+	/* Configuration space physical address */
+	uintptr_t cfg_addr;
+	/* Configuration space physical size */
+	size_t cfg_size;
+	/* BAR regions translation ranges count */
+	size_t ranges_count;
+	/* BAR regions translation ranges table */
+	struct {
+		/* Flags as defined in the PCI Bus Binding to IEEE Std 1275-1994 */
+		uint32_t flags;
+		/* bus-centric offset from the start of the region */
+		uintptr_t pcie_bus_addr;
+		/* CPU-centric offset from the start of the region */
+		uintptr_t host_map_addr;
+		/* region size */
+		size_t map_length;
+	} ranges[];
+};
+
+/*
+ * Fills the pcie_ctrl_config.ranges table from DT
+ */
+#define PCIE_RANGE_FORMAT(node_id, idx)							\
+{											\
+	.flags = DT_RANGES_CHILD_BUS_FLAGS_BY_IDX(node_id, idx),			\
+	.pcie_bus_addr = DT_RANGES_CHILD_BUS_ADDRESS_BY_IDX(node_id, idx),		\
+	.host_map_addr = DT_RANGES_PARENT_BUS_ADDRESS_BY_IDX(node_id, idx),		\
+	.map_length = DT_RANGES_LENGTH_BY_IDX(node_id, idx),				\
+},
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_PCIE_CONTROLLERS_H_ */

--- a/include/drivers/pcie/pcie.h
+++ b/include/drivers/pcie/pcie.h
@@ -243,6 +243,7 @@ extern uint32_t pcie_get_ext_cap(pcie_bdf_t bdf, uint32_t cap_id);
 
 #define PCIE_CONF_TYPE		3U
 
+#define PCIE_CONF_MULTIFUNCTION(w)	(((w) & 0x00800000U) != 0U)
 #define PCIE_CONF_TYPE_BRIDGE(w)	(((w) & 0x007F0000U) != 0U)
 
 /*
@@ -262,6 +263,7 @@ extern uint32_t pcie_get_ext_cap(pcie_bdf_t bdf, uint32_t cap_id);
 #define PCIE_CONF_BAR_MEM(w)		(((w) & 0x00000001U) != 0x00000001U)
 #define PCIE_CONF_BAR_64(w)		(((w) & 0x00000006U) == 0x00000004U)
 #define PCIE_CONF_BAR_ADDR(w)		((w) & ~0xfUL)
+#define PCIE_CONF_BAR_IO_ADDR(w)	((w) & ~0x3UL)
 #define PCIE_CONF_BAR_FLAGS(w)		((w) & 0xfUL)
 #define PCIE_CONF_BAR_NONE		0U
 

--- a/tests/drivers/syscon/boards/qemu_cortex_a53.overlay
+++ b/tests/drivers/syscon/boards/qemu_cortex_a53.overlay
@@ -18,7 +18,7 @@
 	syscon: syscon@42000000 {
 		compatible = "syscon";
 		status = "okay";
-		reg = <0x42000000 0x8>;
+		reg = <0 0x42000000 0 0x8>;
 		reg-io-width = <1>;
 	};
 };


### PR DESCRIPTION
This PR is the first step into PCIe Host Controller support on non-x86 platforms (aka Generic or platform-agnostic)

This adds :
- edtlib/gen_defines: changes to handle the ranges DT attribute
- pci-host-ecam-generic bindings
- PCIe Controller API
- Generic PCIe Controller layer implementing the current PCIe API
- Generic PCIe Controller in ECAM mode driver

The Generic PCIe Controller layer provides:
- Configuration space read/write
- single bus endpoint enumerations
- Endpoint I/O, MEM & MEM64 BARs allocation
- Endpoint I/O, MEM & MEM64 BARs get & translation for drivers

The Generic PCIe Controller in ECAM mode driver provides:
- Raw DT RANGES properties into usable PCIe regions
- Configuration space read/write into ECAM config space
- PCIe regions allocation & translation

The limitations are:
- No support for PCIe prefetchable regions
- No support for PCIe bus configuration (only bus0 is supported)
- No support for multiple controllers (no domain-id in BDF)

Support has been designed to initially support Root Complexes with Root Complex Integrated Endpoint, which was designed for Embedded Systems with internal-only PCIe Endpoints on bus 0.

Testing has been done with QEMU with endpoints only on bus0, this can be achieved with:
```
-device <device>,bus=pcie.0
```

MSI/MSI-X support depends on #37506 completion

DT RANGES tooling and macros are pushed to #38106 and this serie is rebased on it, will need to be merged before this one.

Extended PCI(e) capability offset & defines changes were moved to #38256
