### PR TITLE
Bluetooth: host: Fix non-connectable advertiser configured as scannable

### DIFF
--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -973,6 +973,10 @@ int bt_le_ext_adv_set_data(struct bt_le_ext_adv *adv,
  * advertiser set is currently advertising. Stop the advertising set before
  * calling this function.
  *
+ * @note When changing the option @ref BT_LE_ADV_OPT_USE_NAME then
+ *       @ref bt_le_ext_adv_set_data needs to be called in order to update the
+ *       advertising data and scan response data.
+ *
  * @param adv   Advertising set object.
  * @param param Advertising parameters.
  *

--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -228,6 +228,15 @@ static bool valid_adv_ext_param(const struct bt_le_adv_param *param)
 			/* Extended options require extended advertising. */
 			return false;
 		}
+
+		if ((param->options & BT_LE_ADV_OPT_EXT_ADV) &&
+		    (param->options & BT_LE_ADV_OPT_SCANNABLE) &&
+		    (param->options & BT_LE_ADV_OPT_FORCE_NAME_IN_AD)) {
+			/* Advertising data is not permitted for an extended
+			 * scannable advertiser.
+			 */
+			return false;
+		}
 	}
 
 	if (IS_ENABLED(CONFIG_BT_PRIVACY) &&
@@ -472,7 +481,7 @@ static int le_adv_update(struct bt_le_ext_adv *adv,
 			name, strlen(name));
 	}
 
-	if (!(ext_adv && scannable) || force_name_in_ad) {
+	if (!(ext_adv && scannable)) {
 		d_len = 1;
 		d[0].data = ad;
 		d[0].len = ad_len;

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -92,7 +92,9 @@ enum {
 	/* Advertiser set is currently advertising in the controller. */
 	BT_ADV_ENABLED,
 	/* Advertiser should include name in advertising data */
-	BT_ADV_INCLUDE_NAME,
+	BT_ADV_INCLUDE_NAME_AD,
+	/* Advertiser should include name in scan response data */
+	BT_ADV_INCLUDE_NAME_SD,
 	/* Advertiser set is connectable */
 	BT_ADV_CONNECTABLE,
 	/* Advertiser set is scannable */
@@ -121,10 +123,6 @@ enum {
 	 * in the controller.
 	 */
 	BT_PER_ADV_CTE_ENABLED,
-	/* The device name has been forced to appear in the advertising data
-	 * instead of in the scan response data
-	 */
-	BT_ADV_FORCE_NAME_IN_AD,
 
 	BT_ADV_NUM_FLAGS,
 };

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -1001,6 +1001,9 @@ static int cmd_advertise(const struct shell *shell, size_t argc, char *argv[])
 			param.options |= BT_LE_ADV_OPT_USE_IDENTITY;
 		} else if (!strcmp(arg, "no-name")) {
 			param.options &= ~BT_LE_ADV_OPT_USE_NAME;
+		} else if (!strcmp(arg, "name-ad")) {
+			param.options |= BT_LE_ADV_OPT_USE_NAME;
+			param.options |= BT_LE_ADV_OPT_FORCE_NAME_IN_AD;
 		} else if (!strcmp(arg, "one-time")) {
 			param.options |= BT_LE_ADV_OPT_ONE_TIME;
 		} else if (!strcmp(arg, "disable-37")) {
@@ -1126,6 +1129,9 @@ static bool adv_param_parse(size_t argc, char *argv[],
 			param->options |= BT_LE_ADV_OPT_USE_IDENTITY;
 		} else if (!strcmp(arg, "name")) {
 			param->options |= BT_LE_ADV_OPT_USE_NAME;
+		} else if (!strcmp(arg, "name-ad")) {
+			param->options |= BT_LE_ADV_OPT_USE_NAME;
+			param->options |= BT_LE_ADV_OPT_FORCE_NAME_IN_AD;
 		} else if (!strcmp(arg, "low")) {
 			param->options |= BT_LE_ADV_OPT_DIR_MODE_LOW_DUTY;
 		} else if (!strcmp(arg, "disable-37")) {
@@ -3070,7 +3076,7 @@ static int cmd_auth_oob_tk(const struct shell *shell, size_t argc, char *argv[])
 #define EXT_ADV_PARAM "<type: conn-scan conn-nscan, nconn-scan nconn-nscan> " \
 		      "[ext-adv] [no-2m] [coded] "                            \
 		      "[whitelist: wl, wl-scan, wl-conn] [identity] [name] "  \
-		      "[directed "HELP_ADDR_LE"] [mode: low]"                 \
+		      "[name-ad] [directed "HELP_ADDR_LE"] [mode: low]"       \
 		      "[disable-37] [disable-38] [disable-39]"
 #else
 #define EXT_ADV_SCAN_OPT ""
@@ -3101,7 +3107,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
 	SHELL_CMD_ARG(advertise, NULL,
 		      "<type: off, on, scan, nconn> [mode: discov, non_discov] "
 		      "[whitelist: wl, wl-scan, wl-conn] [identity] [no-name] "
-		      "[one-time] [disable-37] [disable-38] [disable-39]",
+		      "[one-time] [name-ad]"
+		      "[disable-37] [disable-38] [disable-39]",
 		      cmd_advertise, 2, 8),
 #if defined(CONFIG_BT_PERIPHERAL)
 	SHELL_CMD_ARG(directed-adv, NULL, HELP_ADDR_LE " [mode: low] "


### PR DESCRIPTION
Fix non-connectable advertiser configured as ADV_SCAN_IND when configured
by application to have the device name appear in the advertising data
instead of the scan response data.

Disallow creating an extended scannable advertiser with the device name
configured to appear in the advertising data.
This would fail in either the call to bt_le_ext_adv_start or
bt_le_ext_adv_set_data when the host would try to set advertising data in the
controller.
Instead this now fails in the bt_le_ext_adv_create call.

Document the behavior of the include name option when this is changed by
updating the advertising parameters of the advertising set.
In this case we cannot update the advertising data since the host does not have
a copy to modify. The application will have to do update with its current
advertising data.

Allow the application to configure the advertiser as scannable when it does not
provide scan data in the call to bt_le_adv_start. This makes it possible for the
application to later add scan response data in the bt_le_adv_update_data call.
This aligns the legacy code path with the extended code path which already had
this behavior.

This also stops a directed connectable advertiser from being marked internally
in the host as scannable. This appears to not have been causing any issues.

Fixes: #37462