### PR TITLE
Bluetooth: Mesh: add packet header checksum in H5

### DIFF
--- a/drivers/bluetooth/hci/h5.c
+++ b/drivers/bluetooth/hci/h5.c
@@ -415,6 +415,7 @@ static void bt_uart_isr(const struct device *unused, void *user_data)
 	uint8_t byte;
 	int ret;
 	static uint8_t hdr[4];
+	uint8_t header_checksum;
 
 	ARG_UNUSED(unused);
 	ARG_UNUSED(user_data);
@@ -463,6 +464,15 @@ static void bt_uart_isr(const struct device *unused, void *user_data)
 
 			if (remaining) {
 				break;
+			}
+
+			header_checksum = ~((hdr[0] + hdr[1] + hdr[2]) & 0xff);
+
+			if (hdr[3] != header_checksum) {
+				BT_ERR("Wrong packet header %02x %02x %02x %02x",
+				       hdr[0], hdr[1], hdr[2], hdr[3]);
+				h5_reset_rx();
+				continue;
 			}
 
 			remaining = H5_HDR_LEN(hdr);


### PR DESCRIPTION
Signed-off-by: Guofeng Wan <wanguofeng@xiaomi.com>