### PR TITLE
dts: bindings: Add missing binding for SI7055 sensor

### DIFF
--- a/dts/bindings/sensor/silabs,si7055.yaml
+++ b/dts/bindings/sensor/silabs,si7055.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2021, Linaro ltd
+# SPDX-License-Identifier: Apache-2.0
+
+description: Si7055 temperature sensor
+
+compatible: "silabs,si7055"
+
+include: i2c-device.yaml


### PR DESCRIPTION
Add missing dts binding for sensor, this was causing build errors with
CONFIG_PM set on bt510/bt6x0 boards.

Fixes #37675

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>