### PR TITLE
Microchip: MEC172x: Mask out tests of feature not yet implemented

### DIFF
--- a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.yaml
+++ b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.yaml
@@ -16,3 +16,8 @@ flash: 352
 supported:
   - gpio
   - pinmux
+testing:
+  ignore_tags:
+    - device
+    - pm
+    - power


### PR DESCRIPTION
Fixes #37676
Microchip MEC172x is a new SoC and not all drivers and features
are implemented. Update board settings to ignore device, pm,
power, and subsys tests.

Signed-off-by: Scott Worley <scott.worley@microchip.com>