### PR TITLE
Support running CMSIS-DSP tests with FPU

### DIFF
--- a/boards/arm/frdm_k64f/frdm_k64f.yaml
+++ b/boards/arm/frdm_k64f/frdm_k64f.yaml
@@ -2,6 +2,8 @@ identifier: frdm_k64f
 name: NXP FRDM-K64F
 type: mcu
 arch: arm
+ram: 256
+flash: 1024
 toolchain:
   - zephyr
   - gnuarmemb

--- a/boards/arm/mps2_an521/mps2_an521.yaml
+++ b/boards/arm/mps2_an521/mps2_an521.yaml
@@ -2,6 +2,8 @@ identifier: mps2_an521
 name: ARM V2M MPS2-AN521
 type: mcu
 arch: arm
+ram: 4096
+flash: 4096
 simulation: qemu
 toolchain:
   - gnuarmemb

--- a/boards/arm/mps2_an521/mps2_an521_ns.yaml
+++ b/boards/arm/mps2_an521/mps2_an521_ns.yaml
@@ -2,6 +2,8 @@ identifier: mps2_an521_ns
 name: ARM V2M MPS2-AN521_ns
 type: mcu
 arch: arm
+ram: 4096
+flash: 4096
 simulation: qemu
 toolchain:
   - gnuarmemb

--- a/boards/arm/mps2_an521/mps2_an521_remote.yaml
+++ b/boards/arm/mps2_an521/mps2_an521_remote.yaml
@@ -2,6 +2,7 @@ identifier: mps2_an521_remote
 name: ARM V2M MPS2-AN521_remote
 type: mcu
 arch: arm
+simulation: qemu
 toolchain:
   - gnuarmemb
   - zephyr

--- a/boards/arm/mps2_an521/mps2_an521_remote.yaml
+++ b/boards/arm/mps2_an521/mps2_an521_remote.yaml
@@ -2,6 +2,8 @@ identifier: mps2_an521_remote
 name: ARM V2M MPS2-AN521_remote
 type: mcu
 arch: arm
+ram: 4096
+flash: 4096
 simulation: qemu
 toolchain:
   - gnuarmemb

--- a/boards/arm/sam_e70_xplained/sam_e70_xplained.yaml
+++ b/boards/arm/sam_e70_xplained/sam_e70_xplained.yaml
@@ -2,6 +2,8 @@ identifier: sam_e70_xplained
 name: SAM E70 Xplained
 type: mcu
 arch: arm
+ram: 384
+flash: 2048
 toolchain:
   - zephyr
   - gnuarmemb

--- a/boards/arm/sam_e70_xplained/sam_e70b_xplained.yaml
+++ b/boards/arm/sam_e70_xplained/sam_e70b_xplained.yaml
@@ -2,6 +2,8 @@ identifier: sam_e70b_xplained
 name: SAM E70 Xplained (Revision B)
 type: mcu
 arch: arm
+ram: 384
+flash: 2048
 toolchain:
   - zephyr
   - gnuarmemb

--- a/boards/posix/native_posix/native_posix.yaml
+++ b/boards/posix/native_posix/native_posix.yaml
@@ -2,6 +2,8 @@ identifier: native_posix
 name: Native 32-bit POSIX port
 type: native
 arch: posix
+ram: 65536
+flash: 65536
 toolchain:
   - zephyr
   - llvm

--- a/boards/posix/native_posix/native_posix_64.yaml
+++ b/boards/posix/native_posix/native_posix_64.yaml
@@ -2,6 +2,8 @@ identifier: native_posix_64
 name: Native 64-bit POSIX port
 type: native
 arch: posix
+ram: 65536
+flash: 65536
 toolchain:
   - zephyr
   - llvm

--- a/soc/arm/arm/mps2/Kconfig.soc
+++ b/soc/arm/arm/mps2/Kconfig.soc
@@ -24,5 +24,6 @@ config SOC_MPS2_AN521_CPU1
 	bool "ARM Cortex-M33 SMM-SSE-200 on V2M-MPS2+ (AN521) CPU1"
 	select SOC_MPS2_AN521
 	select CPU_HAS_FPU
+	select ARMV8_M_DSP
 
 endchoice

--- a/tests/benchmarks/cmsis_dsp/basicmath/testcase.yaml
+++ b/tests/benchmarks/cmsis_dsp/basicmath/testcase.yaml
@@ -8,3 +8,12 @@ tests:
     tags: benchmark cmsis_dsp
     min_flash: 128
     min_ram: 64
+  benchmark.cmsis_dsp.basicmath.fpu:
+    filter: (CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1
+    integration_platforms:
+      - mps2_an521_remote
+    tags: benchmark cmsis_dsp fpu
+    extra_configs:
+      - CONFIG_FPU=y
+    min_flash: 128
+    min_ram: 64

--- a/tests/lib/cmsis_dsp/basicmath/testcase.yaml
+++ b/tests/lib/cmsis_dsp/basicmath/testcase.yaml
@@ -9,3 +9,12 @@ tests:
     tags: cmsis_dsp
     min_flash: 128
     min_ram: 64
+  libraries.cmsis_dsp.basicmath.fpu:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - mps2_an521_remote
+    tags: cmsis_dsp fpu
+    extra_configs:
+      - CONFIG_FPU=y
+    min_flash: 128
+    min_ram: 64

--- a/tests/lib/cmsis_dsp/bayes/testcase.yaml
+++ b/tests/lib/cmsis_dsp/bayes/testcase.yaml
@@ -9,3 +9,12 @@ tests:
     tags: cmsis_dsp
     min_flash: 64
     min_ram: 32
+  libraries.cmsis_dsp.bayes.fpu:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - mps2_an521_remote
+    tags: cmsis_dsp fpu
+    extra_configs:
+      - CONFIG_FPU=y
+    min_flash: 64
+    min_ram: 32

--- a/tests/lib/cmsis_dsp/complexmath/testcase.yaml
+++ b/tests/lib/cmsis_dsp/complexmath/testcase.yaml
@@ -9,3 +9,12 @@ tests:
     tags: cmsis_dsp
     min_flash: 128
     min_ram: 64
+  libraries.cmsis_dsp.complexmath.fpu:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - mps2_an521_remote
+    tags: cmsis_dsp fpu
+    extra_configs:
+      - CONFIG_FPU=y
+    min_flash: 128
+    min_ram: 64

--- a/tests/lib/cmsis_dsp/distance/testcase.yaml
+++ b/tests/lib/cmsis_dsp/distance/testcase.yaml
@@ -9,3 +9,12 @@ tests:
     tags: cmsis_dsp
     min_flash: 64
     min_ram: 32
+  libraries.cmsis_dsp.distance.fpu:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - mps2_an521_remote
+    tags: cmsis_dsp fpu
+    extra_configs:
+      - CONFIG_FPU=y
+    min_flash: 64
+    min_ram: 32

--- a/tests/lib/cmsis_dsp/fastmath/testcase.yaml
+++ b/tests/lib/cmsis_dsp/fastmath/testcase.yaml
@@ -9,3 +9,12 @@ tests:
     tags: cmsis_dsp
     min_flash: 128
     min_ram: 64
+  libraries.cmsis_dsp.fastmath.fpu:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - mps2_an521_remote
+    tags: cmsis_dsp fpu
+    extra_configs:
+      - CONFIG_FPU=y
+    min_flash: 128
+    min_ram: 64

--- a/tests/lib/cmsis_dsp/filtering/testcase.yaml
+++ b/tests/lib/cmsis_dsp/filtering/testcase.yaml
@@ -1,31 +1,80 @@
 common:
-  filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
-  integration_platforms:
-    - frdm_k64f
-    - sam_e70_xplained
-    - mps2_an521
-    - native_posix
-  tags: cmsis_dsp
   toolchain_exclude: llvm
 
 tests:
   libraries.cmsis_dsp.filtering:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    tags: cmsis_dsp
     skip: true
   libraries.cmsis_dsp.filtering.biquad:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - frdm_k64f
+      - sam_e70_xplained
+      - mps2_an521
+      - native_posix
+    tags: cmsis_dsp
     min_flash: 128
     min_ram: 64
     extra_args: CONF_FILE=prj_base.conf
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_FILTERING_BIQUAD=y
+  libraries.cmsis_dsp.filtering.biquad.fpu:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - mps2_an521_remote
+    tags: cmsis_dsp fpu
+    min_flash: 128
+    min_ram: 64
+    extra_args: CONF_FILE=prj_base.conf
+    extra_configs:
+      - CONFIG_CMSIS_DSP_TEST_FILTERING_BIQUAD=y
+      - CONFIG_FPU=y
   libraries.cmsis_dsp.filtering.fir:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - frdm_k64f
+      - sam_e70_xplained
+      - mps2_an521
+      - native_posix
+    tags: cmsis_dsp
     min_flash: 128
     min_ram: 64
     extra_args: CONF_FILE=prj_base.conf
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_FILTERING_FIR=y
+  libraries.cmsis_dsp.filtering.fir.fpu:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - mps2_an521_remote
+    tags: cmsis_dsp fpu
+    min_flash: 128
+    min_ram: 64
+    extra_args: CONF_FILE=prj_base.conf
+    extra_configs:
+      - CONFIG_CMSIS_DSP_TEST_FILTERING_FIR=y
+      - CONFIG_FPU=y
   libraries.cmsis_dsp.filtering.misc:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - frdm_k64f
+      - sam_e70_xplained
+      - mps2_an521
+      - native_posix
+    tags: cmsis_dsp
     min_flash: 256
     min_ram: 64
     extra_args: CONF_FILE=prj_base.conf
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_FILTERING_MISC=y
+  libraries.cmsis_dsp.filtering.misc.fpu:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - mps2_an521_remote
+    tags: cmsis_dsp fpu
+    min_flash: 256
+    min_ram: 64
+    extra_args: CONF_FILE=prj_base.conf
+    extra_configs:
+      - CONFIG_CMSIS_DSP_TEST_FILTERING_MISC=y
+      - CONFIG_FPU=y

--- a/tests/lib/cmsis_dsp/matrix/testcase.yaml
+++ b/tests/lib/cmsis_dsp/matrix/testcase.yaml
@@ -1,57 +1,179 @@
-common:
-  filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
-  integration_platforms:
-    - frdm_k64f
-    - sam_e70_xplained
-    - mps2_an521
-    - native_posix
-  tags: cmsis_dsp
-
 tests:
   libraries.cmsis_dsp.matrix:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    tags: cmsis_dsp
     skip: true
   libraries.cmsis_dsp.matrix.unary_q15:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - frdm_k64f
+      - sam_e70_xplained
+      - mps2_an521
+      - native_posix
+    tags: cmsis_dsp
     min_flash: 128
     min_ram: 64
     extra_args: CONF_FILE=prj_base.conf
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_MATRIX_UNARY_Q15=y
+  libraries.cmsis_dsp.matrix.unary_q15.fpu:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - mps2_an521_remote
+    tags: cmsis_dsp fpu
+    min_flash: 128
+    min_ram: 64
+    extra_args: CONF_FILE=prj_base.conf
+    extra_configs:
+      - CONFIG_CMSIS_DSP_TEST_MATRIX_UNARY_Q15=y
+      - CONFIG_FPU=y
   libraries.cmsis_dsp.matrix.unary_q31:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - frdm_k64f
+      - sam_e70_xplained
+      - mps2_an521
+      - native_posix
+    tags: cmsis_dsp
     min_flash: 128
     min_ram: 64
     extra_args: CONF_FILE=prj_base.conf
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_MATRIX_UNARY_Q31=y
+  libraries.cmsis_dsp.matrix.unary_q31.fpu:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - mps2_an521_remote
+    tags: cmsis_dsp fpu
+    min_flash: 128
+    min_ram: 64
+    extra_args: CONF_FILE=prj_base.conf
+    extra_configs:
+      - CONFIG_CMSIS_DSP_TEST_MATRIX_UNARY_Q31=y
+      - CONFIG_FPU=y
   libraries.cmsis_dsp.matrix.unary_f32:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - frdm_k64f
+      - sam_e70_xplained
+      - mps2_an521
+      - native_posix
+    tags: cmsis_dsp
     min_flash: 128
     min_ram: 64
     extra_args: CONF_FILE=prj_base.conf
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_MATRIX_UNARY_F32=y
+  libraries.cmsis_dsp.matrix.unary_f32.fpu:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - mps2_an521_remote
+    tags: cmsis_dsp fpu
+    min_flash: 128
+    min_ram: 64
+    extra_args: CONF_FILE=prj_base.conf
+    extra_configs:
+      - CONFIG_CMSIS_DSP_TEST_MATRIX_UNARY_F32=y
+      - CONFIG_FPU=y
   libraries.cmsis_dsp.matrix.unary_f64:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - frdm_k64f
+      - sam_e70_xplained
+      - mps2_an521
+      - native_posix
+    tags: cmsis_dsp
     min_flash: 128
     min_ram: 64
     extra_args: CONF_FILE=prj_base.conf
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_MATRIX_UNARY_F64=y
+  libraries.cmsis_dsp.matrix.unary_f64.fpu:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - mps2_an521_remote
+    tags: cmsis_dsp fpu
+    min_flash: 128
+    min_ram: 64
+    extra_args: CONF_FILE=prj_base.conf
+    extra_configs:
+      - CONFIG_CMSIS_DSP_TEST_MATRIX_UNARY_F64=y
+      - CONFIG_FPU=y
   libraries.cmsis_dsp.matrix.binary_q15:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - frdm_k64f
+      - sam_e70_xplained
+      - mps2_an521
+      - native_posix
+    tags: cmsis_dsp
     platform_exclude: mps2_an521 frdm_kw41z
     min_flash: 128
     min_ram: 128
     extra_args: CONF_FILE=prj_base.conf
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_MATRIX_BINARY_Q15=y
+  libraries.cmsis_dsp.matrix.binary_q15.fpu:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - mps2_an521_remote
+    tags: cmsis_dsp fpu
+    platform_exclude: mps2_an521 frdm_kw41z
+    min_flash: 128
+    min_ram: 128
+    extra_args: CONF_FILE=prj_base.conf
+    extra_configs:
+      - CONFIG_CMSIS_DSP_TEST_MATRIX_BINARY_Q15=y
+      - CONFIG_FPU=y
   libraries.cmsis_dsp.matrix.binary_q31:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - frdm_k64f
+      - sam_e70_xplained
+      - mps2_an521
+      - native_posix
+    tags: cmsis_dsp
     platform_exclude: frdm_kw41z
     min_flash: 128
     min_ram: 128
     extra_args: CONF_FILE=prj_base.conf
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_MATRIX_BINARY_Q31=y
+  libraries.cmsis_dsp.matrix.binary_q31.fpu:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - mps2_an521_remote
+    tags: cmsis_dsp fpu
+    platform_exclude: frdm_kw41z
+    min_flash: 128
+    min_ram: 128
+    extra_args: CONF_FILE=prj_base.conf
+    extra_configs:
+      - CONFIG_CMSIS_DSP_TEST_MATRIX_BINARY_Q31=y
+      - CONFIG_FPU=y
   libraries.cmsis_dsp.matrix.binary_f32:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - frdm_k64f
+      - sam_e70_xplained
+      - mps2_an521
+      - native_posix
+    tags: cmsis_dsp
     platform_exclude: frdm_kw41z
     min_flash: 128
     min_ram: 128
     extra_args: CONF_FILE=prj_base.conf
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_MATRIX_BINARY_F32=y
+  libraries.cmsis_dsp.matrix.binary_f32.fpu:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - mps2_an521_remote
+    tags: cmsis_dsp fpu
+    platform_exclude: frdm_kw41z
+    min_flash: 128
+    min_ram: 128
+    extra_args: CONF_FILE=prj_base.conf
+    extra_configs:
+      - CONFIG_CMSIS_DSP_TEST_MATRIX_BINARY_F32=y
+      - CONFIG_FPU=y

--- a/tests/lib/cmsis_dsp/matrix/testcase.yaml
+++ b/tests/lib/cmsis_dsp/matrix/testcase.yaml
@@ -107,7 +107,7 @@ tests:
       - mps2_an521
       - native_posix
     tags: cmsis_dsp
-    platform_exclude: mps2_an521 frdm_kw41z
+    platform_exclude: frdm_kw41z
     min_flash: 128
     min_ram: 128
     extra_args: CONF_FILE=prj_base.conf
@@ -118,7 +118,7 @@ tests:
     integration_platforms:
       - mps2_an521_remote
     tags: cmsis_dsp fpu
-    platform_exclude: mps2_an521 frdm_kw41z
+    platform_exclude: frdm_kw41z
     min_flash: 128
     min_ram: 128
     extra_args: CONF_FILE=prj_base.conf

--- a/tests/lib/cmsis_dsp/statistics/testcase.yaml
+++ b/tests/lib/cmsis_dsp/statistics/testcase.yaml
@@ -9,3 +9,12 @@ tests:
     tags: cmsis_dsp
     min_flash: 128
     min_ram: 64
+  libraries.cmsis_dsp.statistics.fpu:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - mps2_an521_remote
+    tags: cmsis_dsp fpu
+    min_flash: 128
+    min_ram: 64
+    extra_configs:
+      - CONFIG_FPU=y

--- a/tests/lib/cmsis_dsp/support/testcase.yaml
+++ b/tests/lib/cmsis_dsp/support/testcase.yaml
@@ -9,3 +9,12 @@ tests:
     tags: cmsis_dsp
     min_flash: 128
     min_ram: 64
+  libraries.cmsis_dsp.support.fpu:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - mps2_an521_remote
+    tags: cmsis_dsp fpu
+    min_flash: 128
+    min_ram: 64
+    extra_configs:
+      - CONFIG_FPU=y

--- a/tests/lib/cmsis_dsp/svm/testcase.yaml
+++ b/tests/lib/cmsis_dsp/svm/testcase.yaml
@@ -9,3 +9,12 @@ tests:
     tags: cmsis_dsp
     min_flash: 128
     min_ram: 64
+  libraries.cmsis_dsp.svm.fpu:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - mps2_an521_remote
+    tags: cmsis_dsp fpu
+    min_flash: 128
+    min_ram: 64
+    extra_configs:
+      - CONFIG_FPU=y

--- a/tests/lib/cmsis_dsp/transform/testcase.yaml
+++ b/tests/lib/cmsis_dsp/transform/testcase.yaml
@@ -1,60 +1,197 @@
-common:
-  filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
-  integration_platforms:
-    - frdm_k64f
-    - sam_e70_xplained
-    - mps2_an521
-    - native_posix
-  tags: cmsis_dsp
-
 tests:
   libraries.cmsis_dsp.transform:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    tags: cmsis_dsp
     skip: true
   libraries.cmsis_dsp.transform.cq15:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - frdm_k64f
+      - sam_e70_xplained
+      - mps2_an521
+      - native_posix
+    tags: cmsis_dsp
     min_flash: 512
     min_ram: 64
     extra_args: CONF_FILE=prj_base.conf
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_CQ15=y
+  libraries.cmsis_dsp.transform.cq15.fpu:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - mps2_an521_remote
+    tags: cmsis_dsp fpu
+    min_flash: 512
+    min_ram: 64
+    extra_args: CONF_FILE=prj_base.conf
+    extra_configs:
+      - CONFIG_CMSIS_DSP_TEST_TRANSFORM_CQ15=y
+      - CONFIG_FPU=y
   libraries.cmsis_dsp.transform.rq15:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - frdm_k64f
+      - sam_e70_xplained
+      - mps2_an521
+      - native_posix
+    tags: cmsis_dsp
     min_flash: 512
     min_ram: 64
     extra_args: CONF_FILE=prj_base.conf
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_RQ15=y
+  libraries.cmsis_dsp.transform.rq15.fpu:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - mps2_an521_remote
+    tags: cmsis_dsp fpu
+    min_flash: 512
+    min_ram: 64
+    extra_args: CONF_FILE=prj_base.conf
+    extra_configs:
+      - CONFIG_CMSIS_DSP_TEST_TRANSFORM_RQ15=y
+      - CONFIG_FPU=y
   libraries.cmsis_dsp.transform.cq31:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - frdm_k64f
+      - sam_e70_xplained
+      - mps2_an521
+      - native_posix
+    tags: cmsis_dsp
     min_flash: 1024
     min_ram: 64
     extra_args: CONF_FILE=prj_base.conf
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_CQ31=y
+  libraries.cmsis_dsp.transform.cq31.fpu:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - mps2_an521_remote
+    tags: cmsis_dsp fpu
+    min_flash: 1024
+    min_ram: 64
+    extra_args: CONF_FILE=prj_base.conf
+    extra_configs:
+      - CONFIG_CMSIS_DSP_TEST_TRANSFORM_CQ31=y
+      - CONFIG_FPU=y
   libraries.cmsis_dsp.transform.rq31:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - frdm_k64f
+      - sam_e70_xplained
+      - mps2_an521
+      - native_posix
+    tags: cmsis_dsp
     min_flash: 1024
     min_ram: 64
     extra_args: CONF_FILE=prj_base.conf
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_RQ31=y
+  libraries.cmsis_dsp.transform.rq31.fpu:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - mps2_an521_remote
+    tags: cmsis_dsp fpu
+    min_flash: 1024
+    min_ram: 64
+    extra_args: CONF_FILE=prj_base.conf
+    extra_configs:
+      - CONFIG_CMSIS_DSP_TEST_TRANSFORM_RQ31=y
+      - CONFIG_FPU=y
   libraries.cmsis_dsp.transform.cf32:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - frdm_k64f
+      - sam_e70_xplained
+      - mps2_an521
+      - native_posix
+    tags: cmsis_dsp
     min_flash: 1024
     min_ram: 64
     extra_args: CONF_FILE=prj_base.conf
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_CF32=y
+  libraries.cmsis_dsp.transform.cf32.fpu:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - mps2_an521_remote
+    tags: cmsis_dsp fpu
+    min_flash: 1024
+    min_ram: 64
+    extra_args: CONF_FILE=prj_base.conf
+    extra_configs:
+      - CONFIG_CMSIS_DSP_TEST_TRANSFORM_CF32=y
+      - CONFIG_FPU=y
   libraries.cmsis_dsp.transform.rf32:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - frdm_k64f
+      - sam_e70_xplained
+      - mps2_an521
+      - native_posix
+    tags: cmsis_dsp
     min_flash: 512
     min_ram: 64
     extra_args: CONF_FILE=prj_base.conf
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_RF32=y
+  libraries.cmsis_dsp.transform.rf32.fpu:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - mps2_an521_remote
+    tags: cmsis_dsp fpu
+    min_flash: 512
+    min_ram: 64
+    extra_args: CONF_FILE=prj_base.conf
+    extra_configs:
+      - CONFIG_CMSIS_DSP_TEST_TRANSFORM_RF32=y
+      - CONFIG_FPU=y
   libraries.cmsis_dsp.transform.cf64:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - frdm_k64f
+      - sam_e70_xplained
+      - mps2_an521
+      - native_posix
+    tags: cmsis_dsp
     min_flash: 1024
     min_ram: 96
     extra_args: CONF_FILE=prj_base.conf
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_CF64=y
+  libraries.cmsis_dsp.transform.cf64.fpu:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - mps2_an521_remote
+    tags: cmsis_dsp fpu
+    min_flash: 1024
+    min_ram: 96
+    extra_args: CONF_FILE=prj_base.conf
+    extra_configs:
+      - CONFIG_CMSIS_DSP_TEST_TRANSFORM_CF64=y
+      - CONFIG_FPU=y
   libraries.cmsis_dsp.transform.rf64:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - frdm_k64f
+      - sam_e70_xplained
+      - mps2_an521
+      - native_posix
+    tags: cmsis_dsp
     min_flash: 1024
     min_ram: 64
     extra_args: CONF_FILE=prj_base.conf
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_RF64=y
+  libraries.cmsis_dsp.transform.rf64.fpu:
+    filter: ((CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    integration_platforms:
+      - mps2_an521_remote
+    tags: cmsis_dsp fpu
+    min_flash: 1024
+    min_ram: 64
+    extra_args: CONF_FILE=prj_base.conf
+    extra_configs:
+      - CONFIG_CMSIS_DSP_TEST_TRANSFORM_RF64=y
+      - CONFIG_FPU=y


### PR DESCRIPTION
This series adds new testcases to run the CMSIS-DSP benchmarks and tests with hardware FPU in the CI as well as in hardware.

Also, some boards that were being used as "integration platforms" were missing the `ram` and `flash` properties in the board yaml file and defaulting to 128KB RAM and 512KB flash which are not enough to run the CMSIS-DSP tests. This caused twister to not run these tests, so here we add these properties with the correct values as well.

Note that simulating ARM FPU has been made possible in #35381 through `mps2_an521_remote`.

Closes #36013.