### PR TITLE
drivers: sx126x_standalone: use the correct dev_data for dio1 callback

### DIFF
--- a/drivers/lora/sx126x_standalone.c
+++ b/drivers/lora/sx126x_standalone.c
@@ -53,7 +53,8 @@ void sx126x_dio1_irq_disable(struct sx126x_data *dev_data)
 static void sx126x_dio1_irq_callback(const struct device *dev,
 				     struct gpio_callback *cb, uint32_t pins)
 {
-	struct sx126x_data *dev_data = dev->data;
+	struct sx126x_data *dev_data = CONTAINER_OF(cb, struct sx126x_data,
+						    dio1_irq_callback);
 
 	if (pins & BIT(sx126x_gpio_dio1.pin)) {
 		k_work_submit(&dev_data->dio1_irq_work);


### PR DESCRIPTION
Hey hi! Short bugfix, introduced this one when splitting the driver out, did not realize that the "struct device" there was the GPIO device, not the LORA one (of course!). I don't have a sx1262 board to test this fully, but I ran the problematic code by setting the line to a pushbutton and triggering the callback manually, should be working alright now.

@JordanYates reported the problem in https://github.com/zephyrproject-rtos/zephyr/pull/36573#issuecomment-898863831