### PR TITLE
west.yml: Update CMSIS-Core components to 5.8.0 release

### DIFF
--- a/doc/releases/release-notes-2.7.rst
+++ b/doc/releases/release-notes-2.7.rst
@@ -82,6 +82,7 @@ Architectures
 
   * AARCH32
 
+     * Updated CMSIS version to 5.8.0
      * Added support for FPU in QEMU for Cortex-M, allowing to build and execute
        tests in CI with FPU and FPU_SHARING options enabled.
 

--- a/west.yml
+++ b/west.yml
@@ -32,7 +32,7 @@ manifest:
       revision: 094aeb41bb93e9199d24d665ee43e9e05d6d7b1c
       path: modules/lib/civetweb
     - name: cmsis
-      revision: c3bd2094f92d574377f7af2aec147ae181aa5f8e
+      revision: 2c143ffc1fcc044c7f45f2d8ba259228ad5ffa06
       path: modules/hal/cmsis
       groups:
         - hal


### PR DESCRIPTION
```
Update the CMSIS-Core components to the CMSIS 5.8.0 release:

* CMSIS-Core(M) 5.5.0
* CMSIS-Core(A) 1.2.1

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>
```

CMSIS PR: https://github.com/zephyrproject-rtos/cmsis/pull/11
~~STM32 PR: https://github.com/zephyrproject-rtos/hal_stm32/pull/113~~ (see https://github.com/zephyrproject-rtos/zephyr/pull/37697#issuecomment-904726253)

Closes #37693.

Depends on #37880.