### PR TITLE
drivers: gpio: cy8c95xx: use LOG_DBG instead of LOG_INF

### DIFF
--- a/drivers/gpio/gpio_cy8c95xx.c
+++ b/drivers/gpio/gpio_cy8c95xx.c
@@ -279,7 +279,7 @@ out:
 	if (rc != 0) {
 		LOG_ERR("%s init failed: %d", dev->name, rc);
 	} else {
-		LOG_INF("%s init ok", dev->name);
+		LOG_DBG("%s init ok", dev->name);
 	}
 	k_sem_give(drv_data->lock);
 	return rc;


### PR DESCRIPTION
LOG_INF: It's meant to write generic user oriented messages.
LOG_DBG: It's meant to write developer oriented information.

Use LOG_DBG instead of LOG_INF to hide debug message.

The unexpected debug message may bother some test which test logging subsystem.

Fix: #36255 