### PR TITLE
bluetooth: hci: esp32: Fix DBG logging

### DIFF
--- a/drivers/bluetooth/hci/hci_esp32.c
+++ b/drivers/bluetooth/hci/hci_esp32.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_hci_driver_esp32
 #include "common/log.h"
 


### PR DESCRIPTION
The log level was always set to debug. Defining BT_DBG_ENABLED same
as for other bluetooth files allows to switch off debug log messages.
