### PR TITLE
Bluetooth: Controller: Only remove duplicate resume events

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -949,7 +949,7 @@ static void preempt(void *param)
 				 *       the prepare pipeline hence re-iterate
 				 *       through the prepare pipeline.
 				 */
-				idx = UINT8_MAX;
+				iter_idx = UINT8_MAX;
 #endif /* CONFIG_BT_CTLR_LOW_LAT_ULL_DONE */
 			}
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -939,7 +939,8 @@ static void preempt(void *param)
 		iter = ull_prepare_dequeue_iter(&iter_idx);
 		while (iter) {
 			if (!iter->is_aborted &&
-			    event.curr.param == iter->prepare_param.param) {
+			    (event.curr.param == iter->prepare_param.param) &&
+			    iter->is_resume) {
 				iter->is_aborted = 1;
 				iter->abort_cb(&iter->prepare_param,
 					       iter->prepare_param.param);


### PR DESCRIPTION
When events are placed back into pipeline as resume events,
only remove duplicate resume events and not new prepare
events that may have been enqueue between the start of the
pre-empt ticker and its timeout.

Due to new prepare events that was removed, extra done
events generated cause the number of enqueued done events
to overflow and assert.

Fixes #36381.
Fixes #37597.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>


Controller debug pin toggle detecting a late advertising event caused by a race condition where new scan prepare is enqueued between adv prepare and its pre-empt timeout. 

![image](https://user-images.githubusercontent.com/6350656/129479106-cd66e122-e7f9-4b0f-907c-0c6df944926e.png)

After the fix:

![image](https://user-images.githubusercontent.com/6350656/129479133-3490f3bc-5ba2-41c8-8615-36b525c761ec.png)
