### PR TITLE
github: Update security page

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -12,8 +12,8 @@ At this time, with the latest release of v2.5.0, the supported
 versions are:
 
   - 1.14.2: Current LTS
-  - v2.4.0: Prior release
-  - v2.5.0: Current release
+  - v2.5.0: Prior release
+  - v2.6.0: Current release
 
 ## Reporting process
 


### PR DESCRIPTION
Update security page with the current maintained versions.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>