### PR TITLE
Bluetooth: Controller: Check for invalid PHY in Aux Ptr

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -5089,19 +5089,28 @@ static void le_ext_adv_report(struct pdu_data *pdu_data,
 		}
 
 		if (h->aux_ptr) {
-			struct pdu_adv_aux_ptr *aux;
+			struct pdu_adv_aux_ptr *aux_ptr;
 			uint8_t aux_phy;
 
-			aux = (void *)ptr;
-			ptr += sizeof(*aux);
+			aux_ptr = (void *)ptr;
+			if (aux_ptr->phy > EXT_ADV_AUX_PHY_LE_CODED) {
+				struct node_rx_ftr *ftr;
 
-			sec_phy_curr = aux->phy + 1;
+				ftr = &node_rx->hdr.rx_ftr;
+				node_rx_extra_list_release(ftr->extra);
+				return;
+			}
 
-			aux_phy = BIT(aux->phy);
+			ptr += sizeof(*aux_ptr);
+
+			sec_phy_curr = aux_ptr->phy + 1;
+
+			aux_phy = BIT(aux_ptr->phy);
 
 			BT_DBG("    AuxPtr chan_idx = %u, ca = %u, offs_units "
-			       "= %u offs = 0x%x, phy = 0x%x", aux->chan_idx,
-			       aux->ca, aux->offs_units, aux->offs, aux_phy);
+			       "= %u offs = 0x%x, phy = 0x%x",
+			       aux_ptr->chan_idx, aux_ptr->ca,
+			       aux_ptr->offs_units, aux_ptr->offs, aux_phy);
 		}
 
 		if (h->sync_info) {
@@ -5514,19 +5523,28 @@ static void le_per_adv_sync_report(struct pdu_data *pdu_data,
 
 		/* AuxPtr */
 		if (h->aux_ptr) {
-			struct pdu_adv_aux_ptr *aux;
+			struct pdu_adv_aux_ptr *aux_ptr;
 			uint8_t aux_phy;
 
-			aux = (void *)ptr;
-			ptr += sizeof(*aux);
+			aux_ptr = (void *)ptr;
+			if (aux_ptr->phy > EXT_ADV_AUX_PHY_LE_CODED) {
+				struct node_rx_ftr *ftr;
 
-			sec_phy_curr = aux->phy + 1;
+				ftr = &node_rx->hdr.rx_ftr;
+				node_rx_extra_list_release(ftr->extra);
+				return;
+			}
 
-			aux_phy = BIT(aux->phy);
+			ptr += sizeof(*aux_ptr);
+
+			sec_phy_curr = aux_ptr->phy + 1;
+
+			aux_phy = BIT(aux_ptr->phy);
 
 			BT_DBG("    AuxPtr chan_idx = %u, ca = %u, offs_units "
-			       "= %u offs = 0x%x, phy = 0x%x", aux->chan_idx,
-			       aux->ca, aux->offs_units, aux->offs, aux_phy);
+			       "= %u offs = 0x%x, phy = 0x%x",
+			       aux_ptr->chan_idx, aux_ptr->ca,
+			       aux_ptr->offs_units, aux_ptr->offs, aux_phy);
 		}
 
 		/* No SyncInfo */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -152,7 +152,8 @@ uint8_t lll_scan_aux_setup(struct lll_scan *lll, struct pdu_adv *pdu,
 
 	/* No need to scan further if no aux_ptr filled */
 	aux_ptr = (void *)pri_dptr;
-	if (unlikely(!pri_hdr->aux_ptr || !aux_ptr->offs)) {
+	if (unlikely(!pri_hdr->aux_ptr || !aux_ptr->offs ||
+		     (aux_ptr->phy > EXT_ADV_AUX_PHY_LE_CODED))) {
 		return 0;
 	}
 

--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -330,9 +330,9 @@ enum pdu_adv_offs_units {
 };
 
 enum pdu_adv_aux_phy {
-	EXT_ADV_AUX_PHY_LE_1M  = 0x00,
-	EXT_ADV_AUX_PHY_LE_2M  = 0x01,
-	EXT_ADV_AUX_PHY_LE_COD = 0x02,
+	EXT_ADV_AUX_PHY_LE_1M    = 0x00,
+	EXT_ADV_AUX_PHY_LE_2M    = 0x01,
+	EXT_ADV_AUX_PHY_LE_CODED = 0x02,
 };
 
 struct pdu_cte_info {

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -299,7 +299,8 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 #endif /* CONFIG_BT_CTLR_SYNC_PERIODIC */
 	}
 
-	if (!aux_ptr || !aux_ptr->offs) {
+	if (!aux_ptr || !aux_ptr->offs ||
+	    (aux_ptr->phy > EXT_ADV_AUX_PHY_LE_CODED)) {
 		goto ull_scan_aux_rx_flush;
 	}
 


### PR DESCRIPTION
Add check to validate PHY value in the Auxiliary Pointer
structure in the common extended header format.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>