### PR TITLE
arch: arc: cpu_idle: add workaround for iotdk board

### DIFF
--- a/arch/arc/core/cpu_idle.S
+++ b/arch/arc/core/cpu_idle.S
@@ -42,12 +42,22 @@ SECTION_FUNC(TEXT, arch_cpu_idle)
 	POPR blink
 #endif
 
+/*
+ * Workaround for iotdk board. When iotdk board enter sleep mode,
+ * some peripherals (eg: uart) will power off and and board can't
+ * wake up through peripherals interrupt.
+ */
+#ifdef CONFIG_BOARD_IOTDK
+	j_s.d [blink]
+	seti 0
+#else
 	/* z_arc_cpu_sleep_mode is 32 bit despite of platform bittnes */
 	ld r1, [z_arc_cpu_sleep_mode]
 	or r1, r1, (1 << 4) /* set IRQ-enabled bit */
 	sleep r1
 	j_s [blink]
 	nop
+#endif
 
 /*
  * @brief Put the CPU in low-power mode, entered with IRQs locked
@@ -64,9 +74,19 @@ SECTION_FUNC(TEXT, arch_cpu_atomic_idle)
 	POPR blink
 #endif
 
+/*
+ * Workaround for iotdk board. When iotdk board enter sleep mode,
+ * some peripherals (eg: uart) will power off and and board can't
+ * wake up through peripherals interrupt.
+ */
+#ifdef CONFIG_BOARD_IOTDK
+	j_s.d [blink]
+	seti r0
+#else
 	/* z_arc_cpu_sleep_mode is 32 bit despite of platform bittnes */
 	ld r1, [z_arc_cpu_sleep_mode]
 	or r1, r1, (1 << 4) /* set IRQ-enabled bit */
 	sleep r1
 	j_s.d [blink]
 	seti r0
+#endif


### PR DESCRIPTION
When iotdk board enter sleep mode, some peripherals (eg: uart) will
power off and and board can't wake up through peripherals interrupt. So
add workaround for itodk board and not enter sleep mode in idle thread.

Signed-off-by: Watson Zeng <zhiwei@synopsys.com>

fix: #36254 