### PR TITLE
ci: Bump to use CMake 3.20.5

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,7 +10,7 @@ steps:
       manual: true
     plugins:
       - docker#v3.5.0:
-          image: "zephyrprojectrtos/ci:v0.18.0"
+          image: "zephyrprojectrtos/ci:v0.18.2"
           propagate-environment: true
           volumes:
             - "/var/lib/buildkite-agent/git-mirrors:/var/lib/buildkite-agent/git-mirrors"

--- a/.github/workflows/bsim.yaml
+++ b/.github/workflows/bsim.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: bsim-build-cancel
     container:
-      image: zephyrprojectrtos/ci:v0.18.0
+      image: zephyrprojectrtos/ci:v0.18.2
       options: '--entrypoint /bin/bash'
     env:
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: clang-build-cancel
     container:
-      image: zephyrprojectrtos/ci:v0.18.0
+      image: zephyrprojectrtos/ci:v0.18.2
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -27,6 +27,9 @@ on:
 env:
   # NOTE: west docstrings will be extracted from the version listed here
   WEST_VERSION: 0.11.1a1
+  # The latest CMake available directly with apt is 3.18, but we need >=3.20
+  # so we fetch that through pip.
+  CMAKE_VERSION: 3.20.5
 
 jobs:
   doc-build-html:
@@ -52,6 +55,7 @@ jobs:
         sudo pip3 install -U setuptools wheel pip
         pip3 install -r scripts/requirements-doc.txt
         pip3 install west==${WEST_VERSION}
+        pip3 install cmake==${CMAKE_VERSION}
 
     - name: west setup
       run: |
@@ -89,7 +93,7 @@ jobs:
     - name: install-pkgs
       run: |
         apt-get update
-        apt-get install -y python3-pip cmake ninja-build doxygen graphviz librsvg2-bin
+        apt-get install -y python3-pip ninja-build doxygen graphviz librsvg2-bin
 
     - name: cache-pip
       uses: actions/cache@v1
@@ -102,6 +106,7 @@ jobs:
         pip3 install -U setuptools wheel pip
         pip3 install -r scripts/requirements-doc.txt
         pip3 install west==${WEST_VERSION}
+        pip3 install cmake==${CMAKE_VERSION}
 
     - name: west setup
       run: |

--- a/.github/workflows/errno.yml
+++ b/.github/workflows/errno.yml
@@ -8,7 +8,7 @@ jobs:
   check-errno:
     runs-on: ubuntu-latest
     container:
-      image: zephyrprojectrtos/ci:v0.18.0
+      image: zephyrprojectrtos/ci:v0.18.2
 
     steps:
       - name: checkout

--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: footprint-tracking-cancel
     container:
-      image: zephyrprojectrtos/ci:v0.18.0
+      image: zephyrprojectrtos/ci:v0.18.2
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false

--- a/.github/workflows/footprint.yml
+++ b/.github/workflows/footprint.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: footprint-cancel
     container:
-      image: zephyrprojectrtos/ci:v0.18.0
+      image: zephyrprojectrtos/ci:v0.18.2
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false


### PR DESCRIPTION
With CMake minimum required as 3.20.0 we update CI to use docker image
v0.18.2, which contains CMake 3.20.5.

For doc builds we fetch the same CMake v3.20.5 but using pip as the doc
build doesn't use the docker image.

The main reason for increasing CMake version is better toolchain
support.
The decision to bump the CMake version was taken by the Toolchain WG.

Better toolchain support is added in the following CMake versions:
- armclang, CMake 3.15
- Intel oneAPI, CMake 3.20
- IAR, CMake 3.15 and 3.20

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>