### PR TITLE
Bluetooth: Add workaround for no command buffer available

### DIFF
--- a/samples/bluetooth/hci_rpmsg/prj.conf
+++ b/samples/bluetooth/hci_rpmsg/prj.conf
@@ -11,3 +11,7 @@ CONFIG_BT_MAX_CONN=16
 CONFIG_BT_CTLR_ASSERT_HANDLER=y
 CONFIG_BT_HCI_RAW_RESERVE=1
 CONFIG_BT_BUF_CMD_TX_COUNT=4
+
+# Workaround: Unable to allocate command buffer when using K_NO_WAIT since
+# Host number of completed commands does not follow normal flow control.
+CONFIG_BT_BUF_CMD_TX_COUNT=10

--- a/samples/bluetooth/hci_spi/prj.conf
+++ b/samples/bluetooth/hci_spi/prj.conf
@@ -9,3 +9,7 @@ CONFIG_BT_TINYCRYPT_ECC=n
 CONFIG_BT_BUF_ACL_RX_COUNT=10
 CONFIG_BT_BUF_ACL_RX_SIZE=251
 CONFIG_BT_HCI_RAW_RESERVE=1
+
+# Workaround: Unable to allocate command buffer when using K_NO_WAIT since
+# Host number of completed commands does not follow normal flow control.
+CONFIG_BT_BUF_CMD_TX_COUNT=10

--- a/samples/bluetooth/hci_usb/prj.conf
+++ b/samples/bluetooth/hci_usb/prj.conf
@@ -9,3 +9,7 @@ CONFIG_BT_HCI_RAW=y
 CONFIG_USB_DEVICE_STACK=y
 CONFIG_USB_DEVICE_BLUETOOTH=y
 CONFIG_USB_DEVICE_BLUETOOTH_VS_H4=n
+
+# Workaround: Unable to allocate command buffer when using K_NO_WAIT since
+# Host number of completed commands does not follow normal flow control.
+CONFIG_BT_BUF_CMD_TX_COUNT=10

--- a/samples/bluetooth/hci_usb_h4/prj.conf
+++ b/samples/bluetooth/hci_usb_h4/prj.conf
@@ -5,3 +5,7 @@ CONFIG_UART_INTERRUPT_DRIVEN=y
 
 CONFIG_USB_DEVICE_STACK=y
 CONFIG_USB_DEVICE_BT_H4=y
+
+# Workaround: Unable to allocate command buffer when using K_NO_WAIT since
+# Host number of completed commands does not follow normal flow control.
+CONFIG_BT_BUF_CMD_TX_COUNT=10


### PR DESCRIPTION
Add workaround for no command buffer available when the host is
transmitting Host Number of Completed Packet Commands.
This command does not follow normal flow control of HCI commands and
the controller side HCI drivers that allocates HCI command buffers with
K_NO_WAIT can end up running out of command buffers.

Increase the command buffer count from 2 to 10 for the affected drivers
until the issue has a proper fix.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>