### PR TITLE
drivers: ipm: set IPM_STM32_HSEM default from the device tree

### DIFF
--- a/boards/arm/stm32h747i_disco/Kconfig.defconfig
+++ b/boards/arm/stm32h747i_disco/Kconfig.defconfig
@@ -12,14 +12,6 @@ config BOARD
 config STM32H7_DUAL_CORE
 	default y
 
-if IPM_STM32_HSEM
-
-config IPM_STM32_HSEM_CPU
-	default 1 if BOARD_STM32H747I_DISCO_M7
-	default 2 if BOARD_STM32H747I_DISCO_M4
-
-endif # IPM_STM32_HSEM
-
 if NETWORKING
 
 config NET_L2_ETHERNET

--- a/drivers/ipm/Kconfig
+++ b/drivers/ipm/Kconfig
@@ -120,7 +120,8 @@ config IPM_STM32_HSEM
 
 config IPM_STM32_HSEM_CPU
 	int "HSEM CPU ID"
-	default 1
+	default 1 if "$(dt_nodelabel_enabled,cpu0)"
+	default 2 if "$(dt_nodelabel_enabled,cpu1)"
 	range 1 2
 	depends on IPM_STM32_HSEM
 	help

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -24,7 +24,7 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		cpu@0 {
+		cpu0: cpu@0 {
 			device_type = "cpu";
 			compatible = "arm,cortex-m7";
 			reg = <0>;

--- a/dts/arm/st/h7/stm32h7_dualcore.dtsi
+++ b/dts/arm/st/h7/stm32h7_dualcore.dtsi
@@ -8,7 +8,7 @@
 
 / {
 	cpus {
-		cpu@1 {
+		cpu1: cpu@1 {
 			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <1>;


### PR DESCRIPTION
Hi, was trying out the recently introduced stm32 hsem driver (thanks @cameled!) on a Nucleo H755 and realized that it needs a board specific override to pick a valid config. How would you feel about having the original Kconfig entry default selected from the device tree instead? Would help avoiding having to copy that board Kconfig.defaults all over.