### PR TITLE
drivers: modem: HL7800: Allow operation without a SIM card

### DIFF
--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -501,7 +501,7 @@ struct hl7800_iface_ctx {
 	char mdm_sn[MDM_HL7800_SERIAL_NUMBER_SIZE];
 	char mdm_network_status[MDM_NETWORK_STATUS_LENGTH];
 	char mdm_iccid[MDM_HL7800_ICCID_SIZE];
-	uint8_t mdm_startup_state;
+	enum mdm_hl7800_startup_state mdm_startup_state;
 	enum mdm_hl7800_radio_mode mdm_rat;
 	char mdm_active_bands_string[MDM_HL7800_LTE_BAND_STR_SIZE];
 	char mdm_bands_string[MDM_HL7800_LTE_BAND_STR_SIZE];
@@ -3693,8 +3693,6 @@ static int modem_boot_handler(char *reason)
 		LOG_ERR("Err waiting for boot: %d, DSR: %u", ret,
 			ictx.dsr_state);
 		return -1;
-	} else if (ictx.mdm_startup_state != HL7800_STARTUP_STATE_READY) {
-		return -1;
 	} else {
 		LOG_INF("Modem booted!");
 	}
@@ -4028,7 +4026,7 @@ reboot:
 	SEND_COMPLEX_AT_CMD("AT+KGSN=3");
 
 	/* query SIM ICCID */
-	SEND_AT_CMD_EXPECT_OK("AT+CCID?");
+	SEND_AT_CMD_IGNORE_ERROR("AT+CCID?");
 
 	/* An empty string is used here so that it doesn't conflict
 	 * with the APN used in the +CGDCONT command.
@@ -4079,7 +4077,6 @@ error:
 	LOG_ERR("Unable to configure modem");
 	ictx.configured = false;
 	set_network_state(HL7800_UNABLE_TO_CONFIGURE);
-	modem_reset();
 	/* Kernel will fault with non-zero return value.
 	 * Allow other parts of application to run when modem cannot be configured.
 	 */


### PR DESCRIPTION
Allow the driver to run if a SIM card is not present.
This allows public HL7800 APIs like firmware updates
to be used even if no network is available.
Remove duplicate query ICCID command.