### PR TITLE
soc: xtensa: esp32s2: linker script cleanup

### DIFF
--- a/soc/xtensa/esp32s2/linker.ld
+++ b/soc/xtensa/esp32s2/linker.ld
@@ -197,8 +197,6 @@ _net_buf_pool_list = _esp_net_buf_pool_list;
 #pragma pop_macro("ITERABLE_SECTION_RAM_GC_ALLOWED")
 #pragma pop_macro("ITERABLE_SECTION_RAM")
 
-#include <linker/common-ram.ld>
-
   .dram0.data :
   {
     _data_start = ABSOLUTE(.);


### PR DESCRIPTION
Removal of duplicate inclusion of common-ram linker file from esp32s2 soc bring-up.