### PR TITLE
pm: device: Use the right build conditional

### DIFF
--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -14,7 +14,7 @@
 #include <logging/log.h>
 LOG_MODULE_DECLARE(power);
 
-#if defined(CONFIG_PM)
+#if defined(CONFIG_PM_DEVICE)
 extern const struct device *__pm_device_slots_start[];
 
 /* Number of devices successfully suspended. */
@@ -80,7 +80,7 @@ void pm_resume_devices(void)
 
 	num_susp = 0;
 }
-#endif /* defined(CONFIG_PM) */
+#endif /* defined(CONFIG_PM_DEVICE) */
 
 const char *pm_device_state_str(enum pm_device_state state)
 {


### PR DESCRIPTION
_pm_devices, pm_suspend_devices, pm_low_power_devices and
pm_resume_devices are only used if CONFIG_PM_DEVICE is defined and not
CONFIG_PM.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>