### PR TITLE
pm: remove a conditional compilation directive in pm.h

### DIFF
--- a/include/pm/pm.h
+++ b/include/pm/pm.h
@@ -85,6 +85,8 @@ void pm_power_state_force(struct pm_state_info info);
  * Dump Low Power states debug info like LPS entry count and residencies.
  */
 void pm_dump_debug_info(void);
+#else
+static inline void pm_dump_debug_info(void) { }
 
 #endif /* CONFIG_PM_DEBUG */
 

--- a/subsys/pm/power.c
+++ b/subsys/pm/power.c
@@ -68,7 +68,6 @@ void pm_dump_debug_info(void)
 static inline void pm_debug_start_timer(void) { }
 static inline void pm_debug_stop_timer(void) { }
 static void pm_log_debug_info(enum pm_state state) { }
-void pm_dump_debug_info(void) { }
 #endif
 
 static inline void exit_pos_ops(struct pm_state_info info)


### PR DESCRIPTION
pm_dump_debug_info() is defined in power.c for both CONFIG_PM_DEBUG
is defined and not defined, its declaration in pm.h should be consistent
with its defination.

Signed-off-by: Meng xianglin <xianglinx.meng@intel.com>