### PR TITLE
soc: nordic_nrf: Add Kconfig options for APPROTECT handling

### DIFF
--- a/modules/hal_nordic/nrfx/CMakeLists.txt
+++ b/modules/hal_nordic/nrfx/CMakeLists.txt
@@ -27,6 +27,15 @@ zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF5340_CPUAPP      NRF5340_XXAA_APP
 zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF5340_CPUNET      NRF5340_XXAA_NETWORK)
 zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF9160             NRF9160_XXAA)
 
+zephyr_compile_definitions_ifdef(CONFIG_NRF_APPROTECT_LOCK
+                                 ENABLE_APPROTECT)
+zephyr_compile_definitions_ifdef(CONFIG_NRF_APPROTECT_USER_HANDLING
+                                 ENABLE_APPROTECT_USER_HANDLING)
+zephyr_compile_definitions_ifdef(CONFIG_NRF_SECURE_APPROTECT_LOCK
+                                 ENABLE_SECURE_APPROTECT)
+zephyr_compile_definitions_ifdef(CONFIG_NRF_SECURE_APPROTECT_USER_HANDLING
+                                 ENABLE_SECURE_APPROTECT_USER_HANDLING)
+
 # Connect Kconfig compilation option for Non-Secure software with option required by MDK/nrfx
 zephyr_compile_definitions_ifdef(CONFIG_ARM_NONSECURE_FIRMWARE NRF_TRUSTZONE_NONSECURE)
 zephyr_compile_definitions_ifdef(CONFIG_LOG_BACKEND_SWO ENABLE_SWO)

--- a/soc/arm/nordic_nrf/Kconfig
+++ b/soc/arm/nordic_nrf/Kconfig
@@ -52,4 +52,71 @@ config NFCT_PINS_AS_GPIOS
 	  NFC pins in nRF52 series: P0.09 and P0.10
 	  NFC pins in nRF5340: P0.02 and P0.03
 
+choice NRF_APPROTECT_HANDLING
+	bool "APPROTECT handling"
+	depends on SOC_SERIES_NRF52X || SOC_NRF5340_CPUNET || \
+		   (SOC_NRF5340_CPUAPP && !TRUSTED_EXECUTION_NONSECURE)
+	default NRF_APPROTECT_USE_UICR
+	help
+	  Specifies how the SystemInit() function should handle the APPROTECT
+	  mechanism.
+
+config NRF_APPROTECT_USE_UICR
+	bool "Use UICR"
+	help
+	  When this option is selected, the SystemInit() function loads the
+	  firmware branch state of the APPROTECT mechanism from UICR, so if
+	  UICR->APPROTECT is disabled, CTRLAP->APPROTECT will be disabled.
+
+config NRF_APPROTECT_LOCK
+	bool "Lock"
+	help
+	  When this option is selected, the SystemInit() function locks
+	  the firmware branch of the APPROTECT mechanism, preventing it
+	  from being opened.
+
+config NRF_APPROTECT_USER_HANDLING
+	bool "Allow user handling"
+	depends on !SOC_SERIES_NRF52X
+	help
+	  When this option is selected, the SystemInit() function does not
+	  touch the APPROTECT mechanism, allowing the user code to handle it
+	  at later stages, for example, to implement authenticated debug.
+
+endchoice
+
+choice NRF_SECURE_APPROTECT_HANDLING
+	bool "Secure APPROTECT handling"
+	depends on (SOC_NRF5340_CPUAPP && !TRUSTED_EXECUTION_NONSECURE)
+	default NRF_SECURE_APPROTECT_USE_UICR
+	help
+	  Specifies how the SystemInit() function should handle the secure
+	  APPROTECT mechanism.
+
+config NRF_SECURE_APPROTECT_USE_UICR
+	bool "Use UICR"
+	help
+	  When this option is selected, the SystemInit() function loads the
+	  firmware branch state of the secure APPROTECT mechanism from UICR,
+	  so if UICR->SECUREAPPROTECT is disabled, CTRLAP->SECUREAPPROTECT
+	  will be disabled.
+
+config NRF_SECURE_APPROTECT_LOCK
+	bool "Lock"
+	help
+	  When this option is selected, the SystemInit() function locks the
+	  firmware branch of the secure APPROTECT mechanism, preventing it
+	  from being opened.
+
+config NRF_SECURE_APPROTECT_USER_HANDLING
+	bool "Allow user handling"
+	depends on !SOC_SERIES_NRF52X
+	help
+	  When this option is selected, the SystemInit() function does not
+	  touch the secure APPROTECT mechanism, allowing the user code to
+	  handle it at later stages, for example, to implement authenticated
+	  debug.
+
+endchoice
+
 endif # SOC_FAMILY_NRF

--- a/west.yml
+++ b/west.yml
@@ -82,7 +82,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 00fd2aa97a22ea1052d9dabe1b18ab396daab93a
+      revision: a6e5299041f152da5ae0ab17b2e44e088bb96d6d
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Add Kconfig options that allow users to select the way the APPROTECT
mechanism is handled in the SystemInit() function.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>
