### PR TITLE
Add Broadcast ISO NULL checks

### DIFF
--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -1325,7 +1325,7 @@ static void cleanup_big(struct bt_iso_big *big)
 	for (int i = 0; i < big->num_bis; i++) {
 		struct bt_iso_chan *bis = big->bis[i];
 
-		if (bis->conn) {
+		if (bis != NULL && bis->conn != NULL) {
 			bt_conn_unref(bis->conn);
 			bis->conn = NULL;
 		}

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -1786,6 +1786,13 @@ int bt_iso_big_sync(struct bt_le_per_adv_sync *sync, struct bt_iso_big_sync_para
 		return -EINVAL;
 	}
 
+	for (int i = 0; i < param->num_bis; i++) {
+		if (param->bis_channels[i] == NULL) {
+			BT_DBG("NULL channel in bis_channels[%d]", i);
+			return -EINVAL;
+		}
+	}
+
 	big = get_free_big();
 
 	if (!big) {

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -1451,6 +1451,13 @@ int bt_iso_big_create(struct bt_le_ext_adv *padv, struct bt_iso_big_create_param
 		return -EINVAL;
 	}
 
+	for (int i = 0; i < param->num_bis; i++) {
+		if (param->bis_channels[i] == NULL) {
+			BT_DBG("NULL channel in bis_channels[%d]", i);
+			return -EINVAL;
+		}
+	}
+
 	big = get_free_big();
 
 	if (!big) {


### PR DESCRIPTION
Adds a few NULL checks on ISO connections supplied from the caller. 