### PR TITLE
bmm150 sensor: bug fix for reading z axis

### DIFF
--- a/drivers/sensor/bmm150/bmm150.c
+++ b/drivers/sensor/bmm150/bmm150.c
@@ -353,7 +353,7 @@ static int bmm150_channel_get(const struct device *dev,
 		bmm150_convert(val, drv_data->sample_y);
 		break;
 	case SENSOR_CHAN_MAGN_Z:
-		bmm150_convert(val, drv_data->sample_x);
+		bmm150_convert(val, drv_data->sample_z);
 		break;
 	case SENSOR_CHAN_MAGN_XYZ:
 		bmm150_convert(val, drv_data->sample_x);


### PR DESCRIPTION
**Describe the bug**
The issue was when reading the Z-axis on the BMM150 sensor it returned the same value as X-axis. 

**To Reproduce**
Steps to reproduce the behavior:
1. build the sample for zephyr/samples/sensor/bmm150
2. see the output

**Expected behavior**
when calling `sensor_channel_get(mag_dev, SENSOR_CHAN_MAGN_Z, &magz) ` it needs to return Z axis value

**Impact**
the wrong value provided by the driver to the application

**Logs and console output**
can be observed in the serial console with the sample for bmm150

**Environment (please complete the following information):**
 - OS: Linux
 - Toolchain gcc-none-eabi
 - NCS1.6.0
