### PR TITLE
sensor: convert sgp40 and sht4x to `struct i2c_dt_spec`

### DIFF
--- a/drivers/sensor/sgp40/sgp40.c
+++ b/drivers/sensor/sgp40/sgp40.c
@@ -36,8 +36,7 @@ static int sgp40_write_command(const struct device *dev, uint16_t cmd)
 
 	sys_put_be16(cmd, tx_buf);
 
-	return i2c_write(cfg->bus, tx_buf, sizeof(tx_buf),
-			 cfg->i2c_addr);
+	return i2c_write_dt(&cfg->bus, tx_buf, sizeof(tx_buf));
 }
 
 static int sgp40_start_measurement(const struct device *dev)
@@ -50,8 +49,7 @@ static int sgp40_start_measurement(const struct device *dev)
 	sys_put_be24(sys_get_be24(data->rh_param), &tx_buf[2]);
 	sys_put_be24(sys_get_be24(data->t_param), &tx_buf[5]);
 
-	return i2c_write(cfg->bus, tx_buf, sizeof(tx_buf),
-			 cfg->i2c_addr);
+	return i2c_write_dt(&cfg->bus, tx_buf, sizeof(tx_buf));
 }
 
 static int sgp40_attr_set(const struct device *dev,
@@ -110,7 +108,7 @@ static int sgp40_selftest(const struct device *dev)
 
 	k_sleep(K_MSEC(SGP40_TEST_WAIT_MS));
 
-	rc = i2c_read(cfg->bus, rx_buf, sizeof(rx_buf), cfg->i2c_addr);
+	rc = i2c_read_dt(&cfg->bus, rx_buf, sizeof(rx_buf));
 	if (rc < 0) {
 		LOG_ERR("Failed to read data sample.");
 		return rc;
@@ -151,7 +149,7 @@ static int sgp40_sample_fetch(const struct device *dev,
 
 	k_sleep(K_MSEC(SGP40_MEASURE_WAIT_MS));
 
-	rc = i2c_read(cfg->bus, rx_buf, sizeof(rx_buf), cfg->i2c_addr);
+	rc = i2c_read_dt(&cfg->bus, rx_buf, sizeof(rx_buf));
 	if (rc < 0) {
 		LOG_ERR("Failed to read data sample.");
 		return rc;
@@ -211,7 +209,7 @@ static int sgp40_init(const struct device *dev)
 	const struct sgp40_config *cfg = dev->config;
 	struct sensor_value comp_data;
 
-	if (!device_is_ready(cfg->bus)) {
+	if (!device_is_ready(cfg->bus.bus)) {
 		LOG_ERR("Device not ready.");
 		return -ENODEV;
 	}
@@ -250,8 +248,7 @@ static const struct sensor_driver_api sgp40_api = {
 	static struct sgp40_data sgp40_data_##n;		\
 								\
 	static const struct sgp40_config sgp40_config_##n = {	\
-		.bus = DEVICE_DT_GET(DT_INST_BUS(n)),		\
-		.i2c_addr = DT_INST_REG_ADDR(n),		\
+		.bus = I2C_DT_SPEC_INST_GET(n),			\
 		.selftest = DT_INST_PROP(n, enable_selftest),	\
 	};							\
 								\

--- a/drivers/sensor/sgp40/sgp40.h
+++ b/drivers/sensor/sgp40/sgp40.h
@@ -38,8 +38,7 @@
 #define SGP40_COMP_DEFAULT_RH	50
 
 struct sgp40_config {
-	const struct device *bus;
-	uint8_t i2c_addr;
+	struct i2c_dt_spec bus;
 	bool selftest;
 };
 

--- a/drivers/sensor/sht4x/sht4x.c
+++ b/drivers/sensor/sht4x/sht4x.c
@@ -34,7 +34,7 @@ static int sht4x_write_command(const struct device *dev, uint8_t cmd)
 	const struct sht4x_config *cfg = dev->config;
 	uint8_t tx_buf[1] = { cmd };
 
-	return i2c_write(cfg->bus, tx_buf, sizeof(tx_buf), cfg->i2c_addr);
+	return i2c_write_dt(&cfg->bus, tx_buf, sizeof(tx_buf));
 }
 
 static int sht4x_read_sample(const struct device *dev,
@@ -45,7 +45,7 @@ static int sht4x_read_sample(const struct device *dev,
 	uint8_t rx_buf[6];
 	int rc;
 
-	rc = i2c_read(cfg->bus, rx_buf, sizeof(rx_buf), cfg->i2c_addr);
+	rc = i2c_read_dt(&cfg->bus, rx_buf, sizeof(rx_buf));
 	if (rc < 0) {
 		LOG_ERR("Failed to read data from device.");
 		return rc;
@@ -185,7 +185,7 @@ static int sht4x_init(const struct device *dev)
 	const struct sht4x_config *cfg = dev->config;
 	int rc = 0;
 
-	if (!device_is_ready(cfg->bus)) {
+	if (!device_is_ready(cfg->bus.bus)) {
 		LOG_ERR("Device not ready.");
 		return -ENODEV;
 	}
@@ -212,8 +212,7 @@ static const struct sensor_driver_api sht4x_api = {
 	static struct sht4x_data sht4x_data_##n;		\
 								\
 	static const struct sht4x_config sht4x_config_##n = {	\
-		.bus = DEVICE_DT_GET(DT_INST_BUS(n)),		\
-		.i2c_addr = DT_INST_REG_ADDR(n),		\
+		.bus = I2C_DT_SPEC_INST_GET(n),			\
 		.repeatability = DT_INST_PROP(n, repeatability)	\
 	};							\
 								\

--- a/drivers/sensor/sht4x/sht4x.h
+++ b/drivers/sensor/sht4x/sht4x.h
@@ -25,8 +25,7 @@
 #define SHT4X_CRC_INIT		0xFF
 
 struct sht4x_config {
-	const struct device *bus;
-	uint8_t i2c_addr;
+	struct i2c_dt_spec bus;
 	uint8_t repeatability;
 };
 


### PR DESCRIPTION
FWIW this converts the sgp40 and sht4x driver to the newly introduced  `struct i2c_dt_spec`

Signed-off-by: Leonard Pollak <leonardp@tr-host.de>