### PR TITLE
drivers: uart_ns16550: Fix dts hw_flow_control mapping to config

### DIFF
--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -1066,7 +1066,7 @@ static const struct uart_driver_api uart_ns16550_driver_api = {
 #define DEV_DATA_FLOW_CTRL0 UART_CFG_FLOW_CTRL_NONE
 #define DEV_DATA_FLOW_CTRL1 UART_CFG_FLOW_CTRL_RTS_CTS
 #define DEV_DATA_FLOW_CTRL(n) \
-	_CONCAT(DEV_DATA_FLOW_CTRL, DT_INST_NODE_HAS_PROP(n, hw_flow_control))
+	_CONCAT(DEV_DATA_FLOW_CTRL, DT_INST_PROP_OR(n, hw_flow_control, 0))
 
 #define DEV_DATA_DLF0(n)
 #define DEV_DATA_DLF1(n) \


### PR DESCRIPTION
DT_INST_NODE_HAS_PROP() returns true always since the boolean
tag is valid. Use DT_INST_PROP_OR() to get the real value.

Fixes: baecd7e55a6 "drivers: uart_ns16550: Remove CMake-based templating"
Signed-off-by: Timo Teräs <timo.teras@iki.fi>