### PR TITLE
ci: Update daily to use docker image 0.18.2

### DIFF
--- a/.buildkite/daily.yml
+++ b/.buildkite/daily.yml
@@ -10,7 +10,7 @@ steps:
       manual: true
     plugins:
       - docker#v3.5.0:
-          image: "zephyrprojectrtos/ci:v0.18.0"
+          image: "zephyrprojectrtos/ci:v0.18.2"
           propagate-environment: true
           volumes:
             - "/var/lib/buildkite-agent/git-mirrors:/var/lib/buildkite-agent/git-mirrors"


### PR DESCRIPTION
Keep daily docker image in sync with PR based CI image.  Need
this for both fix for uefi-run and cmake.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>