### PR TITLE
bluetooth: mesh: Fix IVU duration counter update

### DIFF
--- a/subsys/bluetooth/mesh/main.c
+++ b/subsys/bluetooth/mesh/main.c
@@ -163,6 +163,7 @@ void bt_mesh_reset(void)
 	}
 
 	bt_mesh.iv_index = 0U;
+	bt_mesh.ivu_duration = 0;
 	bt_mesh.seq = 0U;
 
 	memset(bt_mesh.flags, 0, sizeof(bt_mesh.flags));

--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -184,11 +184,13 @@ int bt_mesh_net_create(uint16_t idx, uint8_t flags, const uint8_t key[16],
 	atomic_set_bit_to(bt_mesh.flags, BT_MESH_IVU_IN_PROGRESS,
 			  BT_MESH_IV_UPDATE(flags));
 
-	/* Set minimum required hours, since the 96-hour minimum requirement
-	 * doesn't apply straight after provisioning (since we can't know how
-	 * long has actually passed since the network changed its state).
+	/* If IV Update is already in progress, set minimum required hours,
+	 * since the 96-hour minimum requirement doesn't apply in this case straight
+	 * after provisioning.
 	 */
-	bt_mesh.ivu_duration = BT_MESH_IVU_MIN_HOURS;
+	if (BT_MESH_IV_UPDATE(flags)) {
+		bt_mesh.ivu_duration = BT_MESH_IVU_MIN_HOURS;
+	}
 
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
 		BT_DBG("Storing network information persistently");

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_persistence.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_persistence.c
@@ -120,7 +120,7 @@ static void test_provisioning_data_load(void)
 
 	/* verify IV index state */
 	if (bt_mesh.iv_index != test_ividx ||
-	    bt_mesh.ivu_duration != 96 ||
+	    bt_mesh.ivu_duration != 0 ||
 	    atomic_test_bit(bt_mesh.flags, BT_MESH_IVU_IN_PROGRESS)) {
 		FAIL("IV loading verification failed");
 	}

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/tests_scripts/provision/iv_update_flag.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/tests_scripts/provision/iv_update_flag.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Copyright 2021 Lingao Meng
+# SPDX-License-Identifier: Apache-2.0
+
+source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
+
+RunTest mesh_provision_iv_update_zero_duration prov_provisioner_iv_update_flag_zero
+
+RunTest mesh_provision_iv_update_one_duration prov_provisioner_iv_update_flag_one


### PR DESCRIPTION
When device is first provisioned with IV Update
flag is set to 0, it should wait for minimum of
96 hours before going into IV Update In Progress
state. Such limit does not apply, if device is
provisioned with IV Update flag is set to 1.

Signed-off-by: Omkar Kulkarni <omkar.kulkarni@nordicsemi.no>