### PR TITLE
sensors: tmp112, tmp116: use compile time defined i2c device and allow multiple tmp112

### DIFF
--- a/drivers/sensor/tmp116/tmp116.c
+++ b/drivers/sensor/tmp116/tmp116.c
@@ -22,10 +22,9 @@ LOG_MODULE_REGISTER(TMP116, CONFIG_SENSOR_LOG_LEVEL);
 static int tmp116_reg_read(const struct device *dev, uint8_t reg,
 			   uint16_t *val)
 {
-	struct tmp116_data *drv_data = dev->data;
 	const struct tmp116_dev_config *cfg = dev->config;
 
-	if (i2c_burst_read(drv_data->i2c, cfg->i2c_addr, reg, (uint8_t *)val, 2)
+	if (i2c_burst_read_dt(&cfg->bus, reg, (uint8_t *)val, 2)
 	    < 0) {
 		return -EIO;
 	}
@@ -38,12 +37,10 @@ static int tmp116_reg_read(const struct device *dev, uint8_t reg,
 static int tmp116_reg_write(const struct device *dev, uint8_t reg,
 			    uint16_t val)
 {
-	struct tmp116_data *drv_data = dev->data;
 	const struct tmp116_dev_config *cfg = dev->config;
 	uint8_t tx_buf[3] = {reg, val >> 8, val & 0xFF};
 
-	return i2c_write(drv_data->i2c, tx_buf, sizeof(tx_buf),
-			cfg->i2c_addr);
+	return i2c_write_dt(&cfg->bus, tx_buf, sizeof(tx_buf));
 }
 
 /**
@@ -180,11 +177,8 @@ static int tmp116_init(const struct device *dev)
 	int rc;
 	uint16_t id;
 
-	/* Bind to the I2C bus that the sensor is connected */
-	drv_data->i2c = device_get_binding(cfg->i2c_bus_label);
-	if (!drv_data->i2c) {
-		LOG_ERR("Cannot bind to %s device!",
-			cfg->i2c_bus_label);
+	if (!device_is_ready(cfg->bus.bus)) {
+		LOG_ERR("I2C dev %s not ready", cfg->bus.bus->name);
 		return -EINVAL;
 	}
 
@@ -202,8 +196,7 @@ static int tmp116_init(const struct device *dev)
 #define DEFINE_TMP116(_num) \
 	static struct tmp116_data tmp116_data_##_num; \
 	static const struct tmp116_dev_config tmp116_config_##_num = { \
-		.i2c_addr = DT_INST_REG_ADDR(_num), \
-		.i2c_bus_label = DT_INST_BUS_LABEL(_num) \
+		.bus = I2C_DT_SPEC_INST_GET(_num) \
 	}; \
 	DEVICE_DT_INST_DEFINE(_num, tmp116_init, NULL,			\
 		&tmp116_data_##_num, &tmp116_config_##_num, POST_KERNEL, \

--- a/drivers/sensor/tmp116/tmp116.h
+++ b/drivers/sensor/tmp116/tmp116.h
@@ -28,14 +28,12 @@
 #define TMP116_CFGR_DATA_READY BIT(13)
 
 struct tmp116_data {
-	const struct device *i2c;
 	uint16_t sample;
 	uint16_t id;
 };
 
 struct tmp116_dev_config {
-	uint16_t i2c_addr;
-	char *i2c_bus_label;
+	struct i2c_dt_spec bus;
 };
 
 #endif /*  ZEPHYR_DRIVERS_SENSOR_TMP116_TMP116_H_ */


### PR DESCRIPTION
This PR allows the creation of multiple tmp112 instances and makes use of the device-tree-based compile-time device gathering.