### PR TITLE
mgmt: mcumgr: Make SMP service notification function public

### DIFF
--- a/include/mgmt/mcumgr/smp_bt.h
+++ b/include/mgmt/mcumgr/smp_bt.h
@@ -32,6 +32,18 @@ int smp_bt_register(void);
  */
 int smp_bt_unregister(void);
 
+/**
+ * Transmits an SMP command/response over the specified Bluetooth connection
+ * as a notification.
+ *
+ * @param conn Connection object.
+ * @param data Pointer to SMP message.
+ * @param len data length.
+ *
+ * @return 0 in case of success or negative value in case of error.
+ */
+int smp_bt_notify(struct bt_conn *conn, const void *data, uint16_t len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/mgmt/mcumgr/smp_bt.c
+++ b/subsys/mgmt/mcumgr/smp_bt.c
@@ -94,10 +94,7 @@ static struct bt_gatt_attr smp_bt_attrs[] = {
 
 static struct bt_gatt_service smp_bt_svc = BT_GATT_SERVICE(smp_bt_attrs);
 
-/**
- * Transmits an SMP response over the specified Bluetooth connection.
- */
-static int smp_bt_tx_rsp(struct bt_conn *conn, const void *data, uint16_t len)
+int smp_bt_notify(struct bt_conn *conn, const void *data, uint16_t len)
 {
 	return bt_gatt_notify(conn, smp_bt_attrs + 2, data, len);
 }
@@ -171,7 +168,7 @@ static int smp_bt_tx_pkt(struct zephyr_smp_transport *zst, struct net_buf *nb)
 	if (conn == NULL) {
 		rc = -1;
 	} else {
-		rc = smp_bt_tx_rsp(conn, nb->data, nb->len);
+		rc = smp_bt_notify(conn, nb->data, nb->len);
 		bt_conn_unref(conn);
 	}
 


### PR DESCRIPTION
Allow SMP messages to be sent from user space. 
For example, a user defined command can be sent when a value changes 
so that the client doesn't have to poll.

Signed-off-by: Andrew Hedin <andrew.hedin@lairdconnect.com>