### PR TITLE
Bluetooth: Controller: Use one bit for Extended Scan Filter Directed

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -284,13 +284,13 @@ struct node_rx_ftr {
 	uint8_t  scan_req:1;
 	uint8_t  scan_rsp:1;
 #endif /* CONFIG_BT_CTLR_ADV_EXT && CONFIG_BT_OBSERVER */
+#if defined(CONFIG_BT_CTLR_EXT_SCAN_FP)
+	uint8_t  direct:1;
+#endif /* CONFIG_BT_CTLR_EXT_SCAN_FP */
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 	uint8_t  lrpa_used:1;
 	uint8_t  rl_idx;
 #endif /* CONFIG_BT_CTLR_PRIVACY */
-#if defined(CONFIG_BT_CTLR_EXT_SCAN_FP)
-	uint8_t  direct;
-#endif /* CONFIG_BT_CTLR_EXT_SCAN_FP */
 #if defined(CONFIG_BT_HCI_MESH_EXT)
 	uint8_t  chan_idx;
 #endif /* CONFIG_BT_HCI_MESH_EXT */


### PR DESCRIPTION
Use one bit to represent the Extended Scan Filter Directed
Advertising Report.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>