### PR TITLE
clock: esp32: fix dt node path

### DIFF
--- a/drivers/clock_control/clock_control_esp32.c
+++ b/drivers/clock_control/clock_control_esp32.c
@@ -357,8 +357,8 @@ static const struct clock_control_driver_api clock_control_esp32_api = {
 };
 
 static const struct esp32_clock_config esp32_clock_config0 = {
-	.clk_src_sel = DT_PROP(DT_INST(0, cadence_tensilica_xtensa_lx6), clock_source),
-	.cpu_freq = DT_PROP(DT_INST(0, cadence_tensilica_xtensa_lx6), clock_frequency),
+	.clk_src_sel = DT_PROP(DT_INST(0, cdns_tensilica_xtensa_lx6), clock_source),
+	.cpu_freq = DT_PROP(DT_INST(0, cdns_tensilica_xtensa_lx6), clock_frequency),
 	.xtal_freq_sel = DT_INST_PROP(0, xtal_freq),
 	.xtal_div =  DT_INST_PROP(0, xtal_div),
 };
@@ -370,8 +370,9 @@ DEVICE_DT_INST_DEFINE(0,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_OBJECTS,
 		    &clock_control_esp32_api);
 
-BUILD_ASSERT((CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC) == MHZ(DT_PROP(DT_INST(0, cadence_tensilica_xtensa_lx6), clock_frequency)),
-		"SYS_CLOCK_HW_CYCLES_PER_SEC Value must be equal to CPU_Freq");
+BUILD_ASSERT((CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC) ==
+		    MHZ(DT_PROP(DT_INST(0, cdns_tensilica_xtensa_lx6), clock_frequency)),
+		    "SYS_CLOCK_HW_CYCLES_PER_SEC Value must be equal to CPU_Freq");
 
-BUILD_ASSERT(DT_NODE_HAS_PROP(DT_INST(0, cadence_tensilica_xtensa_lx6), clock_source),
+BUILD_ASSERT(DT_NODE_HAS_PROP(DT_INST(0, cdns_tensilica_xtensa_lx6), clock_source),
 		"CPU clock-source property must be set to ESP32_CLK_SRC_XTAL or ESP32_CLK_SRC_PLL");


### PR DESCRIPTION
Latest node linux prefix update commit
missed esp32 clock entry.

ref: 7cf99aa2f2ae032a9643e12403066426abcf08ad

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>