### PR TITLE
manifest: update hal_nordic

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -78,7 +78,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 00fd2aa97a22ea1052d9dabe1b18ab396daab93a
+      revision: pull/102/head
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
The new hal_nordic revision updates the nrfx component
to contain DPPI_CH_NUM symbol fix for nRF5340.

Signed-off-by: Nikodem Kastelik <nikodem.kastelik@nordicsemi.no>