### PR TITLE
Bluetooth: hci_uart: Add workaround for no command buffer available

### DIFF
--- a/samples/bluetooth/hci_uart/prj.conf
+++ b/samples/bluetooth/hci_uart/prj.conf
@@ -17,3 +17,7 @@ CONFIG_BT_TINYCRYPT_ECC=n
 CONFIG_BT_CTLR_DTM_HCI=y
 
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=512
+
+# Workaround: Unable to allocate command buffer when using K_NO_WAIT since
+# Host number of completed commands does not follow normal flow control.
+CONFIG_BT_BUF_CMD_TX_COUNT=10

--- a/samples/bluetooth/hci_uart/src/main.c
+++ b/samples/bluetooth/hci_uart/src/main.c
@@ -132,6 +132,7 @@ static void rx_isr(void)
 				buf = bt_buf_get_tx(BT_BUF_H4, K_NO_WAIT,
 						    &type, sizeof(type));
 				if (!buf) {
+					LOG_ERR("No available command buffers!");
 					state = ST_IDLE;
 					return;
 				}


### PR DESCRIPTION
Add workaround for no command buffer available when the host is
transmitting Host Number of Completed Packet Commands.
This command does not follow normal flow control of HCI commands and
the controller side HCI drivers that allocates HCI command buffers with
K_NO_WAIT can end up running out of command buffers.

Increase the command buffer count from 2 to 10 for the HCI uart driver
until the issue has a proper fix

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>