### PR TITLE
net: sockets: Allow to create both native and offloaded sockets

### DIFF
--- a/drivers/modem/quectel-bg9x.c
+++ b/drivers/modem/quectel-bg9x.c
@@ -1203,4 +1203,5 @@ NET_DEVICE_DT_INST_OFFLOAD_DEFINE(0, modem_init, NULL,
 				  &api_funcs, MDM_MAX_DATA_LENGTH);
 
 /* Register NET sockets. */
-NET_SOCKET_REGISTER(quectel_bg9x, AF_UNSPEC, offload_is_supported, offload_socket);
+NET_SOCKET_OFFLOADED_REGISTER(quectel_bg9x, AF_UNSPEC, offload_is_supported,
+			      offload_socket);

--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -1956,8 +1956,8 @@ static bool offload_is_supported(int family, int type, int proto)
 	return true;
 }
 
-NET_SOCKET_REGISTER(ublox_sara_r4, AF_UNSPEC, offload_is_supported,
-		    offload_socket);
+NET_SOCKET_OFFLOADED_REGISTER(ublox_sara_r4, AF_UNSPEC, offload_is_supported,
+			      offload_socket);
 
 #if defined(CONFIG_DNS_RESOLVER)
 /* TODO: This is a bare-bones implementation of DNS handling

--- a/drivers/wifi/eswifi/eswifi_socket_offload.c
+++ b/drivers/wifi/eswifi/eswifi_socket_offload.c
@@ -571,8 +571,8 @@ static const struct socket_op_vtable eswifi_socket_fd_op_vtable = {
 };
 
 #ifdef CONFIG_NET_SOCKETS_OFFLOAD
-NET_SOCKET_REGISTER(eswifi, AF_UNSPEC, eswifi_socket_is_supported,
-		    eswifi_socket_create);
+NET_SOCKET_OFFLOADED_REGISTER(eswifi, AF_UNSPEC, eswifi_socket_is_supported,
+			      eswifi_socket_create);
 #endif
 
 static int eswifi_off_getaddrinfo(const char *node, const char *service,

--- a/drivers/wifi/simplelink/simplelink_sockets.c
+++ b/drivers/wifi/simplelink/simplelink_sockets.c
@@ -1264,8 +1264,8 @@ static int simplelink_socket_accept(void *obj, struct sockaddr *addr,
 }
 
 #ifdef CONFIG_NET_SOCKETS_OFFLOAD
-NET_SOCKET_REGISTER(simplelink, AF_UNSPEC, simplelink_is_supported,
-		    simplelink_socket_create);
+NET_SOCKET_OFFLOADED_REGISTER(simplelink, AF_UNSPEC, simplelink_is_supported,
+			      simplelink_socket_create);
 #endif
 
 void simplelink_sockets_init(void)

--- a/include/net/socket.h
+++ b/include/net/socket.h
@@ -876,6 +876,7 @@ struct ifreq {
  */
 struct net_socket_register {
 	int family;
+	bool is_offloaded;
 	bool (*is_supported)(int family, int type, int proto);
 	int (*handler)(int family, int type, int proto);
 };
@@ -887,6 +888,16 @@ struct net_socket_register {
 	static const STRUCT_SECTION_ITERABLE(net_socket_register,	\
 			NET_SOCKET_GET_NAME(socket_name)) = {		\
 		.family = _family,					\
+		.is_offloaded = false,					\
+		.is_supported = _is_supported,				\
+		.handler = _handler,					\
+	}
+
+#define NET_SOCKET_OFFLOADED_REGISTER(socket_name, _family, _is_supported, _handler) \
+	static const STRUCT_SECTION_ITERABLE(net_socket_register,	\
+			NET_SOCKET_GET_NAME(socket_name)) = {		\
+		.family = _family,					\
+		.is_offloaded = true,					\
 		.is_supported = _is_supported,				\
 		.handler = _handler,					\
 	}

--- a/include/net/socket_offload.h
+++ b/include/net/socket_offload.h
@@ -45,6 +45,13 @@ int socket_offload_getaddrinfo(const char *node, const char *service,
 
 void socket_offload_freeaddrinfo(struct zsock_addrinfo *res);
 
+/* When CONFIG_NET_SOCKETS_OFFLOAD is enabled, offloaded sockets take precedence
+ * when creating a new socket. Combine this flag with a socket type when
+ * creating a socket, to enforce native socket creation
+ * (e. g. SOCK_STREAM | SOCK_NATIVE).
+ */
+#define SOCK_NATIVE 0x80000000
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -152,8 +152,9 @@ config NET_SOCKETS_OFFLOAD_TLS
 	default y
 	help
 	  If enabled, the offloading engine is expected to handle TLS/DTLS
-	  socket calls. Othwerwise, Zephyrs native TLS socket implementation
-	  will be used, and only TCP/UDP socket calls will be offloaded.
+	  socket calls exclusively. Otherwise, Zephyrs native TLS socket
+	  implementation will also be enabled, allowing to create native
+	  TLS/DTLS sockets as well.
 
 config NET_SOCKETS_PACKET
 	bool "Enable packet socket support"


### PR DESCRIPTION
So far it was impossible to create both native and offloaded sockets (in
case mutliple interfaces are avaialble) as the decission regarding
socket implementation is made solely on the addres family, socket type
and socket protocol. This makes it impossible to differentiate between
offloaded and native sockets based only on this information.

Fix this, by introducing NET_SOCKET_OFFLOADED_REGISTER macro, allowing
to explictly mark the socket implementation as offloaded. Additionally,
add SOCK_NATIVE flag that can be or'ed with the targeted socket type
(for instance SOCK_STREAM | SOCK_NATIVE), which makes it explicit that
native socket should be created instead of an offloaded one.

With this approach, offloaded sockets takes preference, being the
default choice when creating socket (provided that the offloaded
impelmentatinon matches the family/type/protocol as indicated by
is_suported() function. However, if the socket type is or'ed with
SOCK_NATIVE flag, the offloaded implementations are skipped and a native
socket is created instead.
