### PR TITLE
arch: riscv: enable RISC-V GP-relative addressing

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -20,6 +20,18 @@ config FLOAT_HARD
 	help
 	  This option enables the hard-float calling convention.
 
+config RISCV_GP
+	bool "Enable RISC-V global pointer relative addressing"
+	default n
+	help
+	  Use global pointer relative addressing for small globals declared
+	  anywhere in the executable. It can benefit performance and reduce
+	  the code size.
+
+	  Note: To support this feature, RISC-V SoC needs to initialize
+	  global pointer at program start or earlier than any instruction
+	  using GP relative addressing.
+
 menu "RISCV Processor Options"
 
 config CORE_E31

--- a/include/arch/riscv/common/linker.ld
+++ b/include/arch/riscv/common/linker.ld
@@ -240,6 +240,22 @@ SECTIONS
 		 *(.data)
 		 *(".data.*")
 
+#ifdef CONFIG_RISCV_GP
+		/*
+		 * RISC-V architecture has 12-bit signed immediate offsets in the
+		 * instructions. If we can put the most commonly accessed globals
+		 * in a special 4K span of memory addressed by the GP register, then
+		 * we can access those values in a single instruction, saving both
+		 * codespace and runtime.
+		 *
+		 * Since these immediate offsets are signed, place gp 0x800 past the
+		 * beginning of .sdata so that we can use both positive and negative
+		 * offsets.
+		 */
+		 . = ALIGN(8);
+		 PROVIDE (__global_pointer$ = . + 0x800);
+#endif
+
 		 *(.sdata .sdata.* .gnu.linkonce.s.*)
 
 /* Located in generated directory. This file is populated by the

--- a/soc/riscv/esp32c3/Kconfig.soc
+++ b/soc/riscv/esp32c3/Kconfig.soc
@@ -4,6 +4,7 @@
 config SOC_ESP32C3
 	bool "ESP32C3"
 	select RISCV
+	select RISCV_GP
 	select DYNAMIC_INTERRUPTS
 
 config IDF_TARGET_ESP32C3

--- a/soc/riscv/esp32c3/linker.ld
+++ b/soc/riscv/esp32c3/linker.ld
@@ -154,7 +154,9 @@ SECTIONS
     *(.data.*)
     *(.gnu.linkonce.d.*)
     *(.data1)
+#ifdef CONFIG_RISCV_GP
     __global_pointer$ = . + 0x800;
+#endif /* CONFIG_RISCV_GP */
     *(.sdata)
     *(.sdata.*)
     *(.gnu.linkonce.s.*)

--- a/soc/riscv/esp32c3/soc.c
+++ b/soc/riscv/esp32c3/soc.c
@@ -36,6 +36,7 @@ void __attribute__((section(".iram1"))) __start(void)
 	volatile uint32_t *wdt_rtc_protect = (uint32_t *)RTC_CNTL_WDTWPROTECT_REG;
 	volatile uint32_t *wdt_rtc_reg = (uint32_t *)RTC_CNTL_WDTCONFIG0_REG;
 
+#ifdef CONFIG_RISCV_GP
 	/* Configure the global pointer register
 	 * (This should be the first thing startup does, as any other piece of code could be
 	 * relaxed by the linker to access something relative to __global_pointer$)
@@ -44,6 +45,7 @@ void __attribute__((section(".iram1"))) __start(void)
 						".option norelax\n"
 						"la gp, __global_pointer$\n"
 						".option pop");
+#endif /* CONFIG_RISCV_GP */
 
 	__asm__ __volatile__("la t0, _esp32c3_vector_table\n"
 						"csrw mtvec, t0\n");

--- a/soc/riscv/riscv-privilege/common/vector.S
+++ b/soc/riscv/riscv-privilege/common/vector.S
@@ -15,6 +15,14 @@ GTEXT(__initialize)
 GTEXT(__irq_wrapper)
 
 SECTION_FUNC(vectors, __start)
+#if defined(CONFIG_RISCV_GP)
+	/* Initialize global pointer */
+	.option push
+	.option norelax
+	la gp, __global_pointer$
+	.option pop
+#endif
+
 	.option norvc;
 
 	/*

--- a/soc/riscv/riscv-privilege/miv/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-privilege/miv/Kconfig.defconfig.series
@@ -17,6 +17,9 @@ config RISCV_HAS_CPU_IDLE
 config RISCV_HAS_PLIC
 	default y
 
+config RISCV_GP
+	default y
+
 config 2ND_LVL_ISR_TBL_OFFSET
 	default 12
 

--- a/soc/riscv/riscv-privilege/sifive-freedom/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-privilege/sifive-freedom/Kconfig.defconfig.series
@@ -17,6 +17,9 @@ config RISCV_HAS_CPU_IDLE
 config RISCV_HAS_PLIC
 	default y
 
+config RISCV_GP
+	default y
+
 config 2ND_LVL_ISR_TBL_OFFSET
 	default 12
 

--- a/soc/riscv/riscv-privilege/starfive_jh71xx/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-privilege/starfive_jh71xx/Kconfig.defconfig.series
@@ -18,6 +18,9 @@ config RISCV_HAS_CPU_IDLE
 config RISCV_HAS_PLIC
 	default y
 
+config RISCV_GP
+	default y
+
 config 2ND_LVL_ISR_TBL_OFFSET
 	default 12
 

--- a/soc/riscv/riscv-privilege/telink_b91/CMakeLists.txt
+++ b/soc/riscv/riscv-privilege/telink_b91/CMakeLists.txt
@@ -12,4 +12,4 @@ zephyr_ld_options(-fuse-ld=bfd)
 
 # Set compile options
 zephyr_compile_options_ifdef(CONFIG_TELINK_B91_HWDSP -mext-dsp)
-zephyr_compile_options(-mno-relax)
+zephyr_compile_options_ifndef(CONFIG_RISCV_GP -mno-relax)

--- a/soc/riscv/riscv-privilege/telink_b91/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-privilege/telink_b91/Kconfig.defconfig.series
@@ -23,6 +23,10 @@ config RISCV_HAS_PLIC
 	bool
 	default y
 
+config RISCV_GP
+	bool
+	default y
+
 config NUM_IRQS
 	int
 	default 64

--- a/soc/riscv/riscv-privilege/telink_b91/linker.ld
+++ b/soc/riscv/riscv-privilege/telink_b91/linker.ld
@@ -31,12 +31,6 @@ SECTIONS
 
 SECTIONS
 {
-	SECTION_DATA_PROLOGUE(_DATA_SECTION_NAME,,)
-	{
-		. = ALIGN(8);
-		PROVIDE (__global_pointer$ = __data_ram_start + 0x800);
-	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
-
 	SECTION_DATA_PROLOGUE(retention_data,,)
 	{
 		. = ALIGN(8);

--- a/soc/riscv/riscv-privilege/telink_b91/start.S
+++ b/soc/riscv/riscv-privilege/telink_b91/start.S
@@ -27,7 +27,6 @@ entry:
 	.org 0x26
 	.short (0x173B)
 
-	.option pop
 	.align 2
 
 start:
@@ -69,3 +68,5 @@ _RAMCODE_INIT_BEGIN:
 
 _START:
 	j __start
+
+	.option pop

--- a/soc/riscv/riscv-privilege/virt/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-privilege/virt/Kconfig.defconfig.series
@@ -18,6 +18,9 @@ config RISCV_HAS_CPU_IDLE
 config RISCV_HAS_PLIC
 	default y
 
+config RISCV_GP
+	default y
+
 config 2ND_LVL_ISR_TBL_OFFSET
 	default 12
 


### PR DESCRIPTION
This PR introduce RISC-V global pointer relative addressing to improve performance and reduce code size with the option `CONFIG_RISCV_GP`. If adding `__global_pointer$` symbol into linker script, RISC-V linker is capable of relaxing accesses to global variable that live within a 12-bit signed offset from GP register. And we use it to optimize small globals access (`.sdata` section).
(https://www.sifive.com/blog/all-aboard-part-3-linker-relaxation-in-riscv-toolchain)

Because GP should be initialized at program start, each RISC-V SoC needs to initialize GP by itself.
To support RISC-V SoCs, we can split them into 3 kinds.
1. riscv-privilege SoC with common entry point.
2. riscv-privilege SoC with customized entry point.
3. Not riscv-privilege SoCs.

And their supporting (**Updated** from discussion below):
1. Kind 1 RISC-V SoCs are all enabled in this PR because they have common entry point: `_start`
2. Kind 2 RISC-V SoCs also run `_start` to initialize GP, but they also need to disable linker relaxation before `_start` 
This PR enables `telink_b91` as the example.
3. Kind 3 RISC-V SoCs need to init GP itself.
`esp32c3` as the example has already supported it.

Other RISC-V SoCs can refer to them to support GP.

**Testing**

This PR has been verified on `qemu_riscv32` & `qemu_riscv32_xip` platform. (virt & sifive-freedom soc)
Thanks @yurvyn for helping verify it on `telink_b91` soc. I don't have Telink board.

p.s. Upcoming Andes SoC in PR #37321 doesn't contain GP support because I'm not sure either PR will be merged first. I will update GP support of it if either PR gets merged.