### PR TITLE
drivers/pcie: Improve and fix MBAR retrieval depending on use cases

### DIFF
--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -244,7 +244,7 @@ int e1000_probe(const struct device *ddev)
 		return -ENODEV;
 	}
 
-	pcie_get_mbar(bdf, 0, &mbar);
+	pcie_probe_mbar(bdf, 0, &mbar);
 	pcie_set_cmd(bdf, PCIE_CONF_CMDSTAT_MEM |
 		     PCIE_CONF_CMDSTAT_MASTER, true);
 

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -623,7 +623,7 @@ static int i2c_dw_initialize(const struct device *dev)
 			return -EINVAL;
 		}
 
-		pcie_get_mbar(rom->pcie_bdf, 0, &mbar);
+		pcie_probe_mbar(rom->pcie_bdf, 0, &mbar);
 		pcie_set_cmd(rom->pcie_bdf, PCIE_CONF_CMDSTAT_MEM, true);
 
 		device_map(DEVICE_MMIO_RAM_PTR(dev), mbar.phys_addr,

--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -360,7 +360,7 @@ static int uart_ns16550_configure(const struct device *dev,
 			goto out;
 		}
 
-		pcie_get_mbar(dev_cfg->pcie_bdf, 0, &mbar);
+		pcie_probe_mbar(dev_cfg->pcie_bdf, 0, &mbar);
 		pcie_set_cmd(dev_cfg->pcie_bdf, PCIE_CONF_CMDSTAT_MEM, true);
 
 		device_map(DEVICE_MMIO_RAM_PTR(dev), mbar.phys_addr, mbar.size,

--- a/include/drivers/pcie/pcie.h
+++ b/include/drivers/pcie/pcie.h
@@ -88,7 +88,18 @@ extern void pcie_conf_write(pcie_bdf_t bdf, unsigned int reg, uint32_t data);
 extern bool pcie_probe(pcie_bdf_t bdf, pcie_id_t id);
 
 /**
- * @brief Get the nth MMIO address assigned to an endpoint.
+ * @brief Get the MBAR at a specific BAR index
+ * @param bdf the PCI(e) endpoint
+ * @param bar_index 0-based BAR index
+ * @param mbar Pointer to struct pcie_mbar
+ * @return true if the mbar was found and is valid, false otherwise
+ */
+extern bool pcie_get_mbar(pcie_bdf_t bdf,
+			  unsigned int bar_index,
+			  struct pcie_mbar *mbar);
+
+/**
+ * @brief Probe the nth MMIO address assigned to an endpoint.
  * @param bdf the PCI(e) endpoint
  * @param index (0-based) index
  * @param mbar Pointer to struct pcie_mbar
@@ -100,9 +111,9 @@ extern bool pcie_probe(pcie_bdf_t bdf, pcie_id_t id);
  * are order-preserving with respect to the endpoint BARs: e.g., index 0
  * will return the lowest-numbered memory BAR on the endpoint.
  */
-extern bool pcie_get_mbar(pcie_bdf_t bdf,
-			  unsigned int index,
-			  struct pcie_mbar *mbar);
+extern bool pcie_probe_mbar(pcie_bdf_t bdf,
+			    unsigned int index,
+			    struct pcie_mbar *mbar);
 
 /**
  * @brief Set or reset bits in the endpoint command/status register.


### PR DESCRIPTION
So far pcie_get_mbar() has been the only way to retrieve a MBAR. But
it's logic does not fit all uses cases as we will see further.
The meaning of its parameter "index" is not about BAR index but about
a valid Base Address count instead. It's an arbitrary way to index
MBARs unrelated to the actual BAR index.

While this has proven to be just the function we needed so far, this has
not been the case for MSI-X, which one (through BIR info) needs to
access the BAR by their actual index. Same as ivshmem in fact, though
that one did not generate any bug since it never has IO BARs nor 64bits
BARs (so far?).

So:

- renaming existing pcie_get_mbar() to pcie_probe_mbar(), which is a
  more relevant name as it indeed probes the BARs to find the nth valid
  one.
- Introducing a new pcie_get_mbar() which this time really asks for the
  BAR index.
- Applying the change where relevant. So all use pcie_probe_mbar() now
  but MSI-X and ivshmem.

Fixes #37444

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>