### PR TITLE
dts: don't use 'test' vendor prefix

### DIFF
--- a/tests/drivers/gpio/gpio_api_1pin/boards/particle_xenon.overlay
+++ b/tests/drivers/gpio/gpio_api_1pin/boards/particle_xenon.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&sx1509b 0 0>; /* EXT0 */
 		in-gpios = <&sx1509b 1 0>;  /* EXT1 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/atsamd21_xpro.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/atsamd21_xpro.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&portb 6 0>; /* EXT1.5 */
 		in-gpios = <&portb 7 0>;  /* EXT1.6 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/bl5340_dvk_cpuapp.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/bl5340_dvk_cpuapp.overlay
@@ -7,7 +7,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&gpio_exp0 0 0>;
 		in-gpios = <&gpio_exp0 4 0>;
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/cc1352r1_launchxl.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/cc1352r1_launchxl.overlay
@@ -8,7 +8,7 @@
 
 / {
         resources {
-                compatible = "test,gpio_basic_api";
+                compatible = "test-gpio-basic-api";
                 out-gpios = <&gpio0 22 0>;
                 in-gpios = <&gpio0 21 0>;
         };

--- a/tests/drivers/gpio/gpio_basic_api/boards/cc3220sf_launchxl.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/cc3220sf_launchxl.overlay
@@ -8,7 +8,7 @@
 
 / {
         resources {
-                compatible = "test,gpio_basic_api";
+                compatible = "test-gpio-basic-api";
                 out-gpios = <&gpioa2 1 0>;
                 in-gpios = <&gpioa2 0 0>;
         };

--- a/tests/drivers/gpio/gpio_basic_api/boards/cc3235sf_launchxl.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/cc3235sf_launchxl.overlay
@@ -8,7 +8,7 @@
 
 / {
         resources {
-                compatible = "test,gpio_basic_api";
+                compatible = "test-gpio-basic-api";
                 out-gpios = <&gpioa2 1 0>;
                 in-gpios = <&gpioa2 0 0>;
         };

--- a/tests/drivers/gpio/gpio_basic_api/boards/disco_l475_iot1.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/disco_l475_iot1.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&arduino_header 6 0>; /* Arduino D0 */
 		in-gpios = <&arduino_header 7 0>;  /* Arduino D1 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/efr32mg_sltb004a.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/efr32mg_sltb004a.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&gpiof 6 0>; /* Arduino D0 */
 		in-gpios = <&gpiof 5 0>;  /* Arduino D1 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/em_starterkit.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/em_starterkit.overlay
@@ -7,7 +7,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&gpio0 18 0>; /* Pmod3 pin 9  */
 		in-gpios = <&gpio0 19 0>;  /* Pmod3 pin 10 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/esp32.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/esp32.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&gpio0 16 0>;
 		in-gpios = <&gpio0 17 0>;
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/frdm_k64f.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/frdm_k64f.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&gpioc 16 0>; /* Arduino D0 */
 		in-gpios = <&gpioc 17 0>;  /* Arduino D1 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/hifive1_revb.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/hifive1_revb.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&gpio0 12 0>; /* Arduino A4 */
 		in-gpios = <&gpio0 13 0>;  /* Arduino A5 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/lpcxpresso54114_m4.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/lpcxpresso54114_m4.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&gpio0 8 0>; /* Arduino D0 */
 		in-gpios = <&gpio0 9 0>;  /* Arduino D1 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/lpcxpresso55s69_cpu0.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/lpcxpresso55s69_cpu0.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&gpio0 16 0>; /* Arduino A0 */
 		in-gpios  = <&gpio0 23 0>; /* Arduino A1 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/mec15xxevb_assy6853.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/mec15xxevb_assy6853.overlay
@@ -7,7 +7,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 
 		/*
 		 * Remove jumpers on JP31 to disconnect pull-up resistor.

--- a/tests/drivers/gpio/gpio_basic_api/boards/mimxrt1050_evk.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/mimxrt1050_evk.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&gpio1 23 0>; /* Arduino D0 */
 		in-gpios = <&gpio1 22 0>;  /* Arduino D1 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/mimxrt1060_evk.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/mimxrt1060_evk.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&gpio1 23 0>; /* Arduino D0 */
 		in-gpios = <&gpio1 22 0>;  /* Arduino D1 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/mimxrt685_evk_cm33.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/mimxrt685_evk_cm33.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&gpio0 5 0>; /* Arduino A0 */
 		in-gpios  = <&gpio0 6 0>; /* Arduino A1 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/native_posix.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/native_posix.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&gpio0 0 0>; /* Pin 0 */
 		in-gpios = <&gpio0 1 0>; /* Pin 1 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/npcx7m6fb_evb.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/npcx7m6fb_evb.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&gpioc 5 0>; /* GPIO header 2 */
 		in-gpios = <&gpioc 6 0>;  /* GPIO header 3 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/npcx9m6f_evb.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/npcx9m6f_evb.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&gpioc 5 0>; /* GPIO header 2 */
 		in-gpios = <&gpioc 6 0>;  /* GPIO header 3 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nrf52840dk_nrf52840.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&gpio1 1 0>; /* Arduino D0 */
 		in-gpios = <&gpio1 2 0>;  /* Arduino D1 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/nucleo_f030r8.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nucleo_f030r8.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&arduino_header 0 0>; /* Arduino A0 */
 		in-gpios = <&arduino_header 1 0>;  /* Arduino A1 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/nucleo_f091rc.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nucleo_f091rc.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&arduino_header 0 0>; /* Arduino A0 */
 		in-gpios = <&arduino_header 1 0>;  /* Arduino A1 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/nucleo_f103rb.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nucleo_f103rb.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&arduino_header 0 0>; /* Arduino A0 */
 		in-gpios = <&arduino_header 1 0>;  /* Arduino A1 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/nucleo_f207zg.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nucleo_f207zg.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&arduino_header 11 0>; /* Arduino D5 */
 		in-gpios = <&arduino_header 12 0>;  /* Arduino D6 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/nucleo_f334r8.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nucleo_f334r8.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&arduino_header 0 0>; /* Arduino A0 */
 		in-gpios = <&arduino_header 1 0>;  /* Arduino A1 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/nucleo_f401re.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nucleo_f401re.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&arduino_header 0 0>; /* Arduino A0 */
 		in-gpios = <&arduino_header 1 0>;  /* Arduino A1 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/nucleo_f429zi.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nucleo_f429zi.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&arduino_header 6 0>; /* Arduino D0 */
 		in-gpios = <&arduino_header 7 0>;  /* Arduino D1 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/nucleo_f746zg.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nucleo_f746zg.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&arduino_header 6 0>; /* Arduino D0 */
 		in-gpios = <&arduino_header 7 0>;  /* Arduino D1 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/nucleo_g071rb.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nucleo_g071rb.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&arduino_header 0 0>; /* Arduino A0 */
 		in-gpios = <&arduino_header 1 0>;  /* Arduino A1 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/nucleo_g474re.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nucleo_g474re.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&arduino_header 0 0>; /* Arduino A0 */
 		in-gpios = <&arduino_header 1 0>;  /* Arduino A1 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/nucleo_l053r8.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nucleo_l053r8.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&arduino_header 0 0>; /* Arduino A0 */
 		in-gpios = <&arduino_header 1 0>;  /* Arduino A1 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/nucleo_l073rz.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nucleo_l073rz.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&arduino_header 0 0>; /* Arduino A0 */
 		in-gpios = <&arduino_header 1 0>;  /* Arduino A1 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/nucleo_l152re.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nucleo_l152re.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&arduino_header 4 0>; /* Arduino A4 */
 		in-gpios = <&arduino_header 5 0>;  /* Arduino A5 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/nucleo_l476rg.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nucleo_l476rg.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&arduino_header 0 0>; /* Arduino A0 */
 		in-gpios = <&arduino_header 1 0>;  /* Arduino A1 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/nucleo_l4r5zi.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nucleo_l4r5zi.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&arduino_header 6 0>; /* Arduino D0 */
 		in-gpios = <&arduino_header 7 0>;  /* Arduino D1 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/nucleo_wb55rg.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nucleo_wb55rg.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&arduino_header 0 0>; /* Arduino A0 */
 		in-gpios = <&arduino_header 1 0>;  /* Arduino A1 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/particle_xenon.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/particle_xenon.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&sx1509b 0 0>; /* EXT0 */
 		in-gpios = <&sx1509b 1 0>;  /* EXT1 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/quick_feather.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/quick_feather.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&gpio 2 0>; /* Header J8 - pin 6 */
 		in-gpios = <&gpio 0 0>;  /* Header J8 - pin 10 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/rv32m1_vega_ri5cy.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/rv32m1_vega_ri5cy.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&arduino_header 6 0>; /* Arduino D0 */
 		in-gpios = <&arduino_header 7 0>;  /* Arduino D1 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/sam_e70_xplained.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/sam_e70_xplained.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&piod 21 0>;
 		in-gpios = <&piod 20 0>;
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/stm32f3_disco.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/stm32f3_disco.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&gpioc 6 0>;
 		in-gpios = <&gpioc 7 0>;
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/stm32h747i_disco_m7.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/stm32h747i_disco_m7.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&arduino_header 20 0>; /* Arduino D14 */
 		in-gpios = <&arduino_header 21 0>;  /* Arduino D15 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/stm32l562e_dk.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/stm32l562e_dk.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&arduino_header 0 0>; /* Arduino A0 */
 		in-gpios = <&arduino_header 1 0>;  /* Arduino A1 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/stm32mp157c_dk2.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/stm32mp157c_dk2.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&arduino_header 0 0>; /* Arduino A0 */
 		in-gpios = <&arduino_header 1 0>;  /* Arduino A1 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/thingy52_nrf52832.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/thingy52_nrf52832.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&sx1509b 0 0>; /* EXT0 */
 		in-gpios = <&sx1509b 1 0>;  /* EXT1 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/tlsr9518adk80d.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/tlsr9518adk80d.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&gpioc 6 0>; /* Port C 6 */
 		in-gpios = <&gpioc 7 0>;  /* Port C 7 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/udoo_neo_full_m4.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/udoo_neo_full_m4.overlay
@@ -6,7 +6,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 		out-gpios = <&gpio5 14 0>; /* J4 pin 4 */
 		in-gpios = <&gpio5 15 0>;  /* J4 pin 3 */
 	};

--- a/tests/drivers/gpio/gpio_basic_api/boards/up_squared.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/up_squared.overlay
@@ -18,7 +18,7 @@
 
 / {
 	resources {
-		compatible = "test,gpio_basic_api";
+		compatible = "test-gpio-basic-api";
 
 		out-gpios = <&gpio_w 19 0>; /* HAT Pin 40 */
 		in-gpios  = <&gpio_w 18 0>; /* HAT Pin 38 */

--- a/tests/drivers/gpio/gpio_basic_api/dts/bindings/test-gpio-basic-api.yaml
+++ b/tests/drivers/gpio/gpio_basic_api/dts/bindings/test-gpio-basic-api.yaml
@@ -8,7 +8,7 @@ description: |
     This binding provides resources required to build and run the
     tests/drivers/gpio/gpio_basic_api test in Zephyr.
 
-compatible: "test,gpio_basic_api"
+compatible: "test-gpio-basic-api"
 
 properties:
     out-gpios:

--- a/tests/drivers/gpio/gpio_basic_api/testcase.yaml
+++ b/tests/drivers/gpio/gpio_basic_api/testcase.yaml
@@ -3,7 +3,7 @@ tests:
     tags: drivers gpio
     depends_on: gpio
     min_flash: 34
-    filter: dt_compat_enabled("test,gpio_basic_api")
+    filter: dt_compat_enabled("test-gpio-basic-api")
     harness: ztest
     harness_config:
       fixture: gpio_loopback

--- a/tests/drivers/pwm/pwm_loopback/boards/frdm_k64f.overlay
+++ b/tests/drivers/pwm/pwm_loopback/boards/frdm_k64f.overlay
@@ -8,7 +8,7 @@
 
 / {
 	pwm_loopback_0 {
-		compatible = "test,pwm_loopback";
+		compatible = "test-pwm-loopback";
 		pwms = <&ftm0 0 0 PWM_POLARITY_NORMAL>, /* PTC1, J1 pin 5 */
 		       <&ftm3 4 0 PWM_POLARITY_NORMAL>; /* PTC8, J1 pin 7 */
 	};

--- a/tests/drivers/pwm/pwm_loopback/boards/twr_ke18f.overlay
+++ b/tests/drivers/pwm/pwm_loopback/boards/twr_ke18f.overlay
@@ -8,7 +8,7 @@
 
 / {
 	pwm_loopback_0 {
-		compatible = "test,pwm_loopback";
+		compatible = "test-pwm-loopback";
 		pwms = <&ftm2 6 0 PWM_POLARITY_NORMAL>, /* PTE15, J20 pin 5 */
 		       <&pwt 1 0 PWM_POLARITY_NORMAL>;  /* PTE11, J20 pin 8 */
 	};

--- a/tests/drivers/pwm/pwm_loopback/dts/bindings/test-pwm-loopback.yaml
+++ b/tests/drivers/pwm/pwm_loopback/dts/bindings/test-pwm-loopback.yaml
@@ -8,7 +8,7 @@ description: |
     This binding provides resources required to build and run the
     tests/drivers/pwm/pwm_loopback test in Zephyr.
 
-compatible: "test,pwm_loopback"
+compatible: "test-pwm-loopback"
 
 properties:
     pwms:

--- a/tests/drivers/pwm/pwm_loopback/testcase.yaml
+++ b/tests/drivers/pwm/pwm_loopback/testcase.yaml
@@ -2,7 +2,7 @@ tests:
   drivers.pwm.loopback:
     tags: pwm drivers userspace
     depends_on: pwm
-    filter: dt_compat_enabled("test,pwm_loopback")
+    filter: dt_compat_enabled("test-pwm-loopback")
     harness: ztest
     harness_config:
       fixture: pwm_loopback

--- a/tests/drivers/regulator/fixed/dts/bindings/test-regulator-fixed.yaml
+++ b/tests/drivers/regulator/fixed/dts/bindings/test-regulator-fixed.yaml
@@ -5,7 +5,7 @@ description: |
     This binding provides resources required to build and run the
     tests/drivers/regulator/fixed test in Zephyr.
 
-compatible: "test,regulator-fixed"
+compatible: "test-regulator-fixed"
 
 properties:
     check-gpios:

--- a/tests/drivers/regulator/fixed/dts/test_common.dtsi
+++ b/tests/drivers/regulator/fixed/dts/test_common.dtsi
@@ -26,6 +26,6 @@
 #endif /* APP_DTS_REGULATOR_OFF_DELAYED */
 	};
 	resources {
-		compatible = "test,regulator-fixed";
+		compatible = "test-regulator-fixed";
 	};
 };

--- a/tests/drivers/regulator/fixed/testcase.yaml
+++ b/tests/drivers/regulator/fixed/testcase.yaml
@@ -1,7 +1,7 @@
 common:
   tags: drivers gpio
   depends_on: gpio
-  filter: dt_compat_enabled("test,regulator-fixed")
+  filter: dt_compat_enabled("test-regulator-fixed")
   harness: ztest
   harness_config:
     fixture: regulator_loopback

--- a/tests/subsys/pm/power_states_api/boards/native_posix.overlay
+++ b/tests/subsys/pm/power_states_api/boards/native_posix.overlay
@@ -6,7 +6,7 @@
 
 / {
 	power_states: power_states {
-		compatible = "test,power_states_api";
+		compatible = "test-power-states-api";
 		cpu-power-states = <&state0 &state1 &state2>;
 	};
 

--- a/tests/subsys/pm/power_states_api/dts/bindings/test-power-states-api.yaml
+++ b/tests/subsys/pm/power_states_api/dts/bindings/test-power-states-api.yaml
@@ -5,7 +5,7 @@ description: |
     This binding provides resources required to build and run the
     tests/subsys/power/power_states_api test in Zephyr.
 
-compatible: "test,power_states_api"
+compatible: "test-power-states-api"
 
 properties:
     cpu-power-states:


### PR DESCRIPTION
This is now failing an edtlib check for unknown vendor prefixes.

I can't find a reason to use a vendor prefix in application-local
bindings like this, so just remove it wherever it appears by
normalizing to test-foo-compat instead of test,foo_compat or
test,foo-compat.
