### PR TITLE
usb: cdc: invoke callback, if tx_irq_ena and tx_ready go to true

### DIFF
--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -358,9 +358,15 @@ static void cdc_acm_do_cb(struct cdc_acm_dev_data_t *dev_data,
 		if (!dev_data->configured) {
 			cdc_acm_read_cb(cfg->endpoint[ACM_OUT_EP_IDX].ep_addr, 0,
 					dev_data);
+			dev_data->configured = true;
 		}
-		dev_data->configured = true;
-		dev_data->tx_ready = true;
+		if (!dev_data->tx_ready) {
+			dev_data->tx_ready = true;
+			/* if wait tx irq, invoke callback */
+			if (dev_data->cb && dev_data->tx_irq_ena) {
+				k_work_submit_to_queue(&USB_WORK_Q, &dev_data->cb_work);
+			}
+		}
 		break;
 	case USB_DC_DISCONNECTED:
 		LOG_INF("Device disconnected");


### PR DESCRIPTION
Invoking interrupt callback, when `tx_ready` go to `true` and `tx_irq` is enable.

Before 4f2682bd79c0b13ca5271af44d6ea93fba717520 spurious rx-interrupt provided start to read shell tx ring buffer by CDC_ACM. Now shell log backend not transmit data, until CDC_ACM received data from host.
This PR added invoking interrupt callback if tx interrupt is enable, when CDC_ACM go to configured state, and flag `tx_ready` go to `true`.