### PR TITLE
arch: riscv: Increase default CONFIG_TEST_EXTRA_STACKSIZE for 32-bit

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -136,7 +136,7 @@ config MAIN_STACK_SIZE
 	default 4096 if 64BIT
 
 config TEST_EXTRA_STACKSIZE
-	default 1024 if 64BIT
+	default 1024
 
 config CMSIS_THREAD_MAX_STACK_SIZE
 	default 1024 if 64BIT


### PR DESCRIPTION
Increases the default CONFIG_TEST_EXTRA_STACKSIZE for the 32-bit RISC-V
architecture. This fixes the portability.posix.fs test on the
qemu_riscv32 platform.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Fixes failure introduced in #36302