### PR TITLE
drivers: flash: add specific api for access flash_simulator RAM

### DIFF
--- a/drivers/flash/flash_simulator.c
+++ b/drivers/flash/flash_simulator.c
@@ -454,3 +454,29 @@ NATIVE_TASK(flash_native_posix_options, PRE_BOOT_1, 1);
 NATIVE_TASK(flash_native_posix_cleanup, ON_EXIT, 1);
 
 #endif /* CONFIG_ARCH_POSIX */
+
+/* Extension to generic flash driver API */
+void *z_impl_flash_simulator_get_memory(const struct device *dev,
+					size_t *mock_size)
+{
+	ARG_UNUSED(dev);
+
+	*mock_size = FLASH_SIMULATOR_FLASH_SIZE;
+	return mock_flash;
+}
+
+#ifdef CONFIG_USERSPACE
+
+#include <syscall_handler.h>
+
+void *z_vrfy_flash_simulator_get_memory(const struct device *dev,
+				      size_t *mock_size)
+{
+	Z_OOPS(Z_SYSCALL_SPECIFIC_DRIVER(dev, K_OBJ_DRIVER_FLASH, &flash_sim_api));
+
+	return z_impl_flash_simulator_get_memory(dev, mock_size);
+}
+
+#include <syscalls/flash_simulator_get_memory_mrsh.c>
+
+#endif /* CONFIG_USERSPACE */

--- a/include/drivers/flash/flash_simulator.h
+++ b/include/drivers/flash/flash_simulator.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021 Noric Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef __ZEPHYR_INCLUDE_DRIVERS__FLASH_SIMULATOR_H__
+#define __ZEPHYR_INCLUDE_DRIVERS__FLASH_SIMULATOR_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @file
+ * @brief Flash simulator specific API.
+ *
+ * Extension for flash simulator.
+ */
+
+/**
+ * @brief Obtain a pointer to the RAM buffer used but by the simulator
+ *
+ * This function allows the caller to get the address and size of the RAM buffer
+ * in which the flash simulator emulates its flash memory content.
+ *
+ * @param[in]  dev flash simulator device pointer.
+ * @param[out] mock_size size of the ram buffer.
+ *
+ * @retval pointer to the ram buffer
+ */
+__syscall void *flash_simulator_get_memory(const struct device *dev,
+					   size_t *mock_size);
+#ifdef __cplusplus
+}
+#endif
+
+#include <syscalls/flash_simulator.h>
+
+#endif /* __ZEPHYR_INCLUDE_DRIVERS__FLASH_SIMULATOR_H__ */

--- a/tests/drivers/flash_simulator/src/main.c
+++ b/tests/drivers/flash_simulator/src/main.c
@@ -279,6 +279,26 @@ static void test_get_erase_value(void)
 		      FLASH_SIMULATOR_ERASE_VALUE);
 }
 
+#include <drivers/flash/flash_simulator.h>
+
+static void test_get_mock(void)
+{
+#ifdef CONFIG_ARCH_POSIX
+	ztest_test_skip();
+#else
+	size_t mock_size;
+	void *mock_ptr;
+
+	mock_ptr = flash_simulator_get_memory(flash_dev, &mock_size);
+
+	zassert_true(mock_ptr != NULL,
+		     "Expected mock_flash address, got NULL.");
+	zassert_equal(mock_size, FLASH_SIMULATOR_FLASH_SIZE,
+		     "Expected mock_flash size %d, got %d",
+		      FLASH_SIMULATOR_FLASH_SIZE, mock_size);
+#endif
+}
+
 void test_main(void)
 {
 	ztest_test_suite(flash_sim_api,
@@ -289,7 +309,8 @@ void test_main(void)
 			 ztest_unit_test(test_out_of_bounds),
 			 ztest_unit_test(test_align),
 			 ztest_unit_test(test_get_erase_value),
-			 ztest_unit_test(test_double_write));
+			 ztest_unit_test(test_double_write),
+			 ztest_unit_test(test_get_mock));
 
 	ztest_run_test_suite(flash_sim_api);
 }


### PR DESCRIPTION
I have a use-case where I use this flash-sim as a mock flash interface for RAM where I need the flash_area API to be responsible for writing/reading RAM like it was accessing a flash area.

These changes are purposed to remove unused code and make the `mock_flash` available outside the module. 