### PR TITLE
drivers: clock_control: stm32: enable PWR clock unconditionally

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_u5.c
+++ b/drivers/clock_control/clock_stm32_ll_u5.c
@@ -60,9 +60,10 @@ static void config_pll_init(LL_UTILS_PLLInitTypeDef *pllinit)
  */
 void config_enable_default_clocks(void)
 {
-#if STM32_LSE_CLOCK
+	/* Enable the power interface clock */
 	LL_AHB3_GRP1_EnableClock(LL_AHB3_GRP1_PERIPH_PWR);
 
+#if STM32_LSE_CLOCK
 	if (!LL_PWR_IsEnabledBkUpAccess()) {
 		/* Enable write access to Backup domain */
 		LL_PWR_EnableBkUpAccess();

--- a/drivers/clock_control/clock_stm32l4_l5_wb_wl.c
+++ b/drivers/clock_control/clock_stm32l4_l5_wb_wl.c
@@ -48,6 +48,11 @@ void config_pll_init(LL_UTILS_PLLInitTypeDef *pllinit)
  */
 void config_enable_default_clocks(void)
 {
+#ifdef LL_APB1_GRP1_PERIPH_PWR
+	/* Enable the power interface clock */
+	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
+#endif
+
 #if STM32_LSE_CLOCK
 	/* LSE belongs to the back-up domain, enable access.*/
 
@@ -56,11 +61,6 @@ void config_enable_default_clocks(void)
 	LL_AHB3_GRP1_EnableClock(LL_AHB3_GRP1_PERIPH_HSEM);
 #endif
 	z_stm32_hsem_lock(CFG_HW_RCC_SEMID, HSEM_LOCK_DEFAULT_RETRY);
-
-#ifdef LL_APB1_GRP1_PERIPH_PWR
-	/* Enable the power interface clock */
-	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
-#endif
 
 	/* Set the DBP bit in the Power control register 1 (PWR_CR1) */
 	LL_PWR_EnableBkUpAccess();


### PR DESCRIPTION
Enable PWR clock unconditionally for L4, L5 and U5
like it is done on other stm32 series

This is a regression introduced by #32390

Fixes #37781 
