### PR TITLE
Bluetooth: samples: Update periodic advertising data update rate

### DIFF
--- a/samples/bluetooth/periodic_adv/src/main.c
+++ b/samples/bluetooth/periodic_adv/src/main.c
@@ -56,7 +56,7 @@ void main(void)
 	}
 
 	while (true) {
-		k_sleep(K_SECONDS(1));
+		k_sleep(K_SECONDS(10));
 
 		mfg_data[2]++;
 


### PR DESCRIPTION
Update periodic advertising data update rate. The periodic advertiser
is configured with a periodic advertising interval of 2.4 seconds but
updating the data every second. This leads to many of the advertising
data values not being sent at all.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>