### PR TITLE
Bluetooth: ots: Fix output formatting

### DIFF
--- a/subsys/bluetooth/services/ots/ots_oacp.c
+++ b/subsys/bluetooth/services/ots/ots_oacp.c
@@ -318,7 +318,7 @@ static void oacp_read_proc_cb(struct bt_gatt_ots_l2cap *l2cap_ctx,
 	}
 
 	if (len < 0) {
-		LOG_ERR("OCAP Read Op failed with error: %d", len);
+		LOG_ERR("OCAP Read Op failed with error: %zd", len);
 
 		bt_gatt_ots_l2cap_disconnect(&ots->l2cap);
 		ots->cur_obj->state.type = BT_GATT_OTS_OBJECT_IDLE_STATE;


### PR DESCRIPTION
Fix output formatting after changes in
https://github.com/zephyrproject-rtos/zephyr/pull/36653/
causes Twister build fails in pending le-audio code.

Signed-off-by: Asbjørn Sæbø <asbjorn.sabo@nordicsemi.no>