### PR TITLE
Bluetooth: Missing `_` when concat with name field

### DIFF
--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -940,7 +940,7 @@ void bt_conn_cb_register(struct bt_conn_cb *cb);
  */
 #define BT_CONN_CB_DEFINE(_name)					\
 	static const STRUCT_SECTION_ITERABLE(bt_conn_cb,		\
-						_CONCAT(bt_conn_cb,	\
+						_CONCAT(bt_conn_cb_,	\
 							_name))
 
 /** @brief Enable/disable bonding.


### PR DESCRIPTION
Add missing `_` between struct type with _name.

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>