### PR TITLE
net: sockets: tls: Fix TLS/DTLS client POLLHUP notification

### DIFF
--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -1812,7 +1812,13 @@ static ssize_t recvfrom_dtls_client(struct tls_context *ctx, void *buf,
 	switch (ret) {
 	case MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY:
 		/* Peer notified that it's closing the connection. */
-		return 0;
+		ret = tls_mbedtls_reset(ctx);
+		if (ret == 0) {
+			ret = -ENOTCONN;
+		} else {
+			ret = -ENOMEM;
+		}
+		break;
 
 	case MBEDTLS_ERR_SSL_TIMEOUT:
 		(void)mbedtls_ssl_close_notify(&ctx->ssl);

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -1876,7 +1876,7 @@ static ssize_t recvfrom_dtls_server(struct tls_context *ctx, void *buf,
 				if (ret == 0) {
 					repeat = true;
 				} else {
-					ret = -ECONNABORTED;
+					ret = -ENOMEM;
 				}
 
 				continue;
@@ -1901,7 +1901,7 @@ static ssize_t recvfrom_dtls_server(struct tls_context *ctx, void *buf,
 			if (ret == 0) {
 				repeat = true;
 			} else {
-				ret = -ECONNABORTED;
+				ret = -ENOMEM;
 			}
 			break;
 


### PR DESCRIPTION
The `poll()` function did not report POLLHUP if the peer ended the DTLS
session, making it impossible to detect such event on the application
side.

On the other hand, TLS erroneously reported POLLHUP along with each
POLLIN event, as the 0 returned by the `recv()` socket call was
wrongly interpreted (it was expected to get 0 in return as 0 bytes were
requested).

Fix this by introducing a helper function to process the mbedtls context
and verify if new application data is pending. Use this new function in
the poll handler, instead of a socket `recv()` call, to remove any
ambiguity in the usage, for both TLS and DTLS.

Fixes #37720

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>