### PR TITLE
logging: rtt: Add overwrite mode

### DIFF
--- a/subsys/logging/Kconfig.backends
+++ b/subsys/logging/Kconfig.backends
@@ -121,6 +121,12 @@ config LOG_BACKEND_RTT_SYST_ENABLE
 	help
 	  When enabled backend is using RTT to output syst format logs.
 
+config LOG_BACKEND_RTT_MODE_OVERWRITE
+	bool "Overwrite messages if up-buffer full"
+	help
+	  If there is not enough space in up-buffer for a message overwrite
+	  oldest one.
+
 endchoice
 
 config LOG_BACKEND_RTT_MESSAGE_SIZE


### PR DESCRIPTION
In this mode the oldest data is overwritten
when the buffer is full

Closes #36282

Signed-off-by: Guillaume Lager <g.lager@innoseis.com>