### PR TITLE
bluetooth: smp: Fix duplicate pairing_failed callback

### DIFF
--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -1864,7 +1864,11 @@ static void smp_pairing_complete(struct bt_smp *smp, uint8_t status)
 						 security_err);
 		}
 
-		if (bt_auth && bt_auth->pairing_failed) {
+		/* Check SMP_FLAG_PAIRING as bt_conn_security_changed may
+		 * have called the pairing_failed callback already.
+		 */
+		if (atomic_test_bit(smp->flags, SMP_FLAG_PAIRING) &&
+		    bt_auth && bt_auth->pairing_failed) {
 			bt_auth->pairing_failed(conn, security_err);
 		}
 	}


### PR DESCRIPTION
In the case where keys are distributed on an unencrypted link,
we got the following call trace:
  - bt_smp_recv()
    - smp_error()
    - smp_pairing_complete()
      - bt_conn_security_changed()
      - smp_pairing_complete()
        - bt_auth->pairing_failed()
        - smp_reset()
      - bt_auth->pairing_failed()
      - smp_reset()

To avoid the second call to bt_auth->pairing_failed()
we validate the that smp flags before calling the callback.