### PR TITLE
drivers: can: mcux_flexcan: Update to support rt1170

### DIFF
--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -506,7 +506,7 @@ static void mcux_flexcan_detach(const struct device *dev, int filter_id)
 }
 
 static inline void mcux_flexcan_transfer_error_status(const struct device *dev,
-						      uint32_t error)
+						      uint64_t error)
 {
 	const struct mcux_flexcan_config *config = dev->config;
 	struct mcux_flexcan_data *data = dev->data;
@@ -518,23 +518,23 @@ static inline void mcux_flexcan_transfer_error_status(const struct device *dev,
 	struct can_bus_err_cnt err_cnt;
 
 	if (error & CAN_ESR1_FLTCONF(2)) {
-		LOG_DBG("Tx bus off (error 0x%08x)", error);
+		LOG_DBG("Tx bus off (error 0x%08llx)", error);
 		status = CAN_TX_BUS_OFF;
 	} else if ((error & kFLEXCAN_Bit0Error) ||
 		   (error & kFLEXCAN_Bit1Error)) {
-		LOG_DBG("TX arbitration lost (error 0x%08x)", error);
+		LOG_DBG("TX arbitration lost (error 0x%08llx)", error);
 		status = CAN_TX_ARB_LOST;
 	} else if (error & kFLEXCAN_AckError) {
-		LOG_DBG("TX no ACK received (error 0x%08x)", error);
+		LOG_DBG("TX no ACK received (error 0x%08llx)", error);
 		status = CAN_TX_ERR;
 	} else if (error & kFLEXCAN_StuffingError) {
-		LOG_DBG("RX stuffing error (error 0x%08x)", error);
+		LOG_DBG("RX stuffing error (error 0x%08llx)", error);
 	} else if (error & kFLEXCAN_FormError) {
-		LOG_DBG("RX form error (error 0x%08x)", error);
+		LOG_DBG("RX form error (error 0x%08llx)", error);
 	} else if (error & kFLEXCAN_CrcError) {
-		LOG_DBG("RX CRC error (error 0x%08x)", error);
+		LOG_DBG("RX CRC error (error 0x%08llx)", error);
 	} else {
-		LOG_DBG("Unhandled error (error 0x%08x)", error);
+		LOG_DBG("Unhandled error (error 0x%08llx)", error);
 	}
 
 	state = mcux_flexcan_get_state(dev, &err_cnt);
@@ -643,10 +643,7 @@ static inline void mcux_flexcan_transfer_rx_idle(const struct device *dev,
 	}
 }
 
-static void mcux_flexcan_transfer_callback(CAN_Type *base,
-					   flexcan_handle_t *handle,
-					   status_t status, uint32_t result,
-					   void *userData)
+static FLEXCAN_CALLBACK(mcux_flexcan_transfer_callback)
 {
 	struct mcux_flexcan_data *data = (struct mcux_flexcan_data *)userData;
 
@@ -654,21 +651,23 @@ static void mcux_flexcan_transfer_callback(CAN_Type *base,
 	case kStatus_FLEXCAN_UnHandled:
 		__fallthrough;
 	case kStatus_FLEXCAN_ErrorStatus:
-		mcux_flexcan_transfer_error_status(data->dev, result);
+		mcux_flexcan_transfer_error_status(data->dev, (uint64_t)result);
 		break;
 	case kStatus_FLEXCAN_TxSwitchToRx:
 		__fallthrough;
 	case kStatus_FLEXCAN_TxIdle:
-		mcux_flexcan_transfer_tx_idle(data->dev, result);
+		/* The result field is a MB value which is limited to 32bit value */
+		mcux_flexcan_transfer_tx_idle(data->dev, (uint32_t)result);
 		break;
 	case kStatus_FLEXCAN_RxOverflow:
 		__fallthrough;
 	case kStatus_FLEXCAN_RxIdle:
-		mcux_flexcan_transfer_rx_idle(data->dev, result);
+		/* The result field is a MB value which is limited to 32bit value */
+		mcux_flexcan_transfer_rx_idle(data->dev, (uint32_t)result);
 		break;
 	default:
 		LOG_WRN("Unhandled error/status (status 0x%08x, "
-			 "result = 0x%08x", status, result);
+			 "result = 0x%08llx", status, (uint64_t)result);
 	}
 }
 


### PR DESCRIPTION
The RT1170 platform adjusted the result parameter in the callback
function to be a uint64_t. The adjustment is to conditionally change
the callback definition and then cast the result value to a size that
fits the reported values across the various SOCs.

With error results, cast result to uint64_t and modified the called
function to print a uint64_t value.

With the RX/TX status, result is a MB value that doesn't exceed 64
so the result value is cast down to a uint32_t.

Fixes #37691

Signed-off-by: David Leach <david.leach@nxp.com>