### PR TITLE
edtlib enhancements for non-ZEPHYR_BASE DTS_ROOTs

### DIFF
--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -23,8 +23,9 @@ set(EDT_PICKLE                  ${PROJECT_BINARY_DIR}/edt.pickle)
 set(DEVICETREE_UNFIXED_H        ${PROJECT_BINARY_DIR}/include/generated/devicetree_unfixed.h)
 set(DEVICE_EXTERN_H             ${PROJECT_BINARY_DIR}/include/generated/device_extern.h)
 set(DTS_POST_CPP                ${PROJECT_BINARY_DIR}/${BOARD}.dts.pre.tmp)
-# A list of generally accepted vendor prefixes.
-set_ifndef(VENDOR_PREFIXES      ${ZEPHYR_BASE}/dts/bindings/vendor-prefixes.txt)
+# The location of a list of known vendor prefixes.
+# This is relative to each element of DTS_ROOT.
+set(VENDOR_PREFIXES             dts/bindings/vendor-prefixes.txt)
 
 set_ifndef(DTS_SOURCE ${BOARD_DIR}/${BOARD}.dts)
 
@@ -113,6 +114,11 @@ if(SUPPORTS_DTS)
         DTS_ROOT_BINDINGS
         ${bindings_path}
         )
+    endif()
+
+    set(vendor_prefixes ${dts_root}/${VENDOR_PREFIXES})
+    if(EXISTS ${vendor_prefixes})
+      list(APPEND EXTRA_GEN_DEFINES_ARGS --vendor-prefixes ${vendor_prefixes})
     endif()
   endforeach()
 
@@ -228,7 +234,6 @@ if(SUPPORTS_DTS)
   --device-header-out ${DEVICE_EXTERN_H}
   --dts-out ${ZEPHYR_DTS} # As a debugging aid
   --edt-pickle-out ${EDT_PICKLE}
-  --vendor-prefixes ${VENDOR_PREFIXES}
   ${EXTRA_GEN_DEFINES_ARGS}
   )
 

--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -90,6 +90,7 @@ if(SUPPORTS_DTS)
   endforeach()
 
   unset(DTS_ROOT_SYSTEM_INCLUDE_DIRS)
+  unset(DTS_ROOT_BINDINGS)
   foreach(dts_root ${DTS_ROOT})
     foreach(dts_root_path
         include
@@ -105,15 +106,12 @@ if(SUPPORTS_DTS)
           )
       endif()
     endforeach()
-  endforeach()
 
-  unset(DTS_ROOT_BINDINGS)
-  foreach(dts_root ${DTS_ROOT})
-    set(full_path ${dts_root}/dts/bindings)
-    if(EXISTS ${full_path})
+    set(bindings_path ${dts_root}/dts/bindings)
+    if(EXISTS ${bindings_path})
       list(APPEND
         DTS_ROOT_BINDINGS
-        ${full_path}
+        ${bindings_path}
         )
     endif()
   endforeach()

--- a/doc/guides/dts/bindings.rst
+++ b/doc/guides/dts/bindings.rst
@@ -142,8 +142,9 @@ subdirectories of the following places:
 - any :ref:`module <modules>` that defines a ``dts_root`` in its
   :ref:`modules_build_settings`
 
-The build system will consider any YAML file in any of these, including
-in any subdirectories, when matching nodes to bindings.
+The build system will consider any YAML file in any of these, including in any
+subdirectories, when matching nodes to bindings. A file is considered YAML if
+its name ends with ``.yaml`` or ``.yml``.
 
 .. warning::
 

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -57,10 +57,9 @@ def main():
 
     setup_edtlib_logging()
 
-    if args.vendor_prefixes:
-        vendor_prefixes = edtlib.load_vendor_prefixes_txt(args.vendor_prefixes)
-    else:
-        vendor_prefixes = None
+    vendor_prefixes = {}
+    for prefixes_file in args.vendor_prefixes:
+        vendor_prefixes.update(edtlib.load_vendor_prefixes_txt(prefixes_file))
 
     try:
         edt = edtlib.EDT(args.dts, args.bindings_dirs,
@@ -214,8 +213,9 @@ def parse_args():
                         help="path to write device struct extern header to")
     parser.add_argument("--edt-pickle-out",
                         help="path to write pickled edtlib.EDT object to")
-    parser.add_argument("--vendor-prefixes",
-                        help="vendor-prefixes.txt path; used for validation")
+    parser.add_argument("--vendor-prefixes", action='append', default=[],
+                        help="vendor-prefixes.txt path; used for validation; "
+                             "may be given multiple times")
     parser.add_argument("--edtlib-Werror", action="store_true",
                         help="if set, edtlib-specific warnings become errors. "
                              "(this does not apply to warnings shared "

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -196,7 +196,7 @@ class EDT:
         self._fixed_partitions_no_bus = support_fixed_partitions_on_any_bus
         self._infer_binding_for_paths = set(infer_binding_for_paths or [])
         self._werror = bool(werror)
-        self._vendor_prefixes = vendor_prefixes
+        self._vendor_prefixes = vendor_prefixes or {}
 
         self.dts_path = dts
         self.bindings_dirs = bindings_dirs
@@ -516,7 +516,7 @@ class EDT:
                  'must match this regular expression: '
                  f"'{compat_re}'")
 
-        if ',' in compat and self._vendor_prefixes is not None:
+        if ',' in compat and self._vendor_prefixes:
             vendor = compat.split(',', 1)[0]
             # As an exception, the root node can have whatever
             # compatibles it wants. Other nodes get checked.

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -2049,7 +2049,7 @@ def _binding_paths(bindings_dirs):
     for bindings_dir in bindings_dirs:
         for root, _, filenames in os.walk(bindings_dir):
             for filename in filenames:
-                if filename.endswith(".yaml"):
+                if filename.endswith(".yaml") or filename.endswith(".yml"):
                     binding_paths.append(os.path.join(root, filename))
 
     return binding_paths


### PR DESCRIPTION
- Allow each DTS_ROOT to have its own dts/bindings/vendor-prefixes.txt. Fixes #37797
- Allow .yml files to be considered bindings. This is meant to allow downstream DTS_ROOTs some flexibility