### PR TITLE
drivers: modem: hl7800: Add query carrier config

### DIFF
--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -514,6 +514,7 @@ struct hl7800_iface_ctx {
 	bool mdm_startup_reporting_on;
 	int device_services_ind;
 	bool new_rat_cmd_support;
+	uint8_t operator_index;
 
 	/* modem state */
 	bool allow_sleep;
@@ -1050,6 +1051,24 @@ int32_t mdm_hl7800_get_local_time(struct tm *tm, int32_t *offset)
 	return ret;
 }
 #endif
+
+int32_t mdm_hl7800_get_operator_index(void)
+{
+	int ret;
+
+	hl7800_lock();
+	wakeup_hl7800();
+	ictx.last_socket_id = 0;
+	ret = send_at_cmd(NULL, "AT+KCARRIERCFG?", MDM_CMD_SEND_TIMEOUT, 0,
+			  false);
+	allow_sleep(true);
+	hl7800_unlock();
+	if (ret < 0) {
+		return ret;
+	} else {
+		return ictx.operator_index;
+	}
+}
 
 void mdm_hl7800_generate_status_events(void)
 {
@@ -2371,6 +2390,32 @@ static bool on_cmd_network_report_query(struct net_buf **buf, uint16_t len)
 	return true;
 }
 
+static bool on_cmd_operator_index_query(struct net_buf **buf, uint16_t len)
+{
+	struct net_buf *frag = NULL;
+	char carrier[MDM_HL7800_OPERATOR_INDEX_SIZE];
+	size_t out_len;
+
+	wait_for_modem_data_and_newline(buf, net_buf_frags_len(*buf),
+					MDM_HL7800_OPERATOR_INDEX_SIZE);
+
+	frag = NULL;
+	len = net_buf_findcrlf(*buf, &frag);
+	if (!frag) {
+		LOG_ERR("Unable to find end of operator index response");
+		goto done;
+	}
+
+	out_len = net_buf_linearize(carrier, MDM_HL7800_OPERATOR_INDEX_STRLEN,
+				    *buf, 0, len);
+	carrier[out_len] = 0;
+	ictx.operator_index = (uint8_t)strtol(carrier, NULL, 10);
+
+	LOG_INF("Operator Index: %u", ictx.operator_index);
+done:
+	return true;
+}
+
 #ifdef CONFIG_NEWLIB_LIBC
 /* Handler: +CCLK: "yy/MM/dd,hh:mm:ss±zz" */
 static bool on_cmd_rtc_query(struct net_buf **buf, uint16_t len)
@@ -3335,6 +3380,7 @@ static void hl7800_rx(void)
 		CMD_HANDLER("+WPPP: 1,1,", atcmdinfo_pdp_authentication_cfg),
 		CMD_HANDLER("+CGDCONT: 1", atcmdinfo_pdp_context),
 		CMD_HANDLER("AT+CEREG?", network_report_query),
+		CMD_HANDLER("+KCARRIERCFG: ", operator_index_query),
 #ifdef CONFIG_NEWLIB_LIBC
 		CMD_HANDLER("+CCLK: ", rtc_query),
 #endif

--- a/include/drivers/modem/hl7800.h
+++ b/include/drivers/modem/hl7800.h
@@ -57,6 +57,9 @@ struct mdm_hl7800_apn {
 #define MDM_HL7800_LTE_BAND_STR_SIZE 21
 #define MDM_HL7800_LTE_BAND_STRLEN (MDM_HL7800_LTE_BAND_STR_SIZE - 1)
 
+#define MDM_HL7800_OPERATOR_INDEX_SIZE 3
+#define MDM_HL7800_OPERATOR_INDEX_STRLEN (MDM_HL7800_OPERATOR_INDEX_SIZE - 1)
+
 enum mdm_hl7800_radio_mode { MDM_RAT_CAT_M1 = 0, MDM_RAT_CAT_NB1 };
 
 enum mdm_hl7800_event {
@@ -262,6 +265,13 @@ int32_t mdm_hl7800_get_local_time(struct tm *tm, int32_t *offset);
  */
 int32_t mdm_hl7800_update_fw(char *file_path);
 #endif
+
+/**
+ * @brief Read the operator index from the modem.
+ *
+ * @retval negative error code, 0 on success
+ */
+int32_t mdm_hl7800_get_operator_index(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Add API to query the carrier config of the HL7800.

