### PR TITLE
drivers: modem: hl7800: Add retries to get IP address info

### DIFF
--- a/drivers/modem/Kconfig.hl7800
+++ b/drivers/modem/Kconfig.hl7800
@@ -265,4 +265,8 @@ config MODEM_HL7800_INIT_PRIORITY
 	  Note that the priority needs to be lower than the net stack
 	  so that it can start before the networking sub-system.
 
+config MODEM_HL7800_GET_IP_ADDR_INFO_ATTEMPTS
+	int "Number of attempts to get IP address info during init"
+	default 4
+
 endif # MODEM_HL7800

--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -2301,7 +2301,8 @@ static void iface_status_work_cb(struct k_work *work)
 	} else if (ictx.iface && net_if_is_up(ictx.iface)) {
 		hl7800_start_rssi_work();
 		/* get IP address info */
-		SEND_AT_CMD_IGNORE_ERROR("AT+CGCONTRDP=1");
+		(void)send_at_cmd(NULL, "AT+CGCONTRDP=1", MDM_CMD_SEND_TIMEOUT,
+				  CONFIG_MODEM_HL7800_GET_IP_ADDR_INFO_ATTEMPTS, false);
 		/* get active bands */
 		SEND_AT_CMD_IGNORE_ERROR("AT+KBND?");
 	}


### PR DESCRIPTION
Allow command retries when querying IP address info.
