### PR TITLE
drivers: modem: hl7800: Add runtime control of log level

### DIFF
--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -7,6 +7,7 @@
 #define DT_DRV_COMPAT swir_hl7800
 
 #include <zephyr/logging/log.h>
+#include <zephyr/logging/log_ctrl.h>
 LOG_MODULE_REGISTER(modem_hl7800, CONFIG_MODEM_LOG_LEVEL);
 
 #include <zephyr/types.h>
@@ -1381,6 +1382,20 @@ void mdm_hl7800_generate_status_events(void)
 	event_handler(HL7800_EVENT_ACTIVE_BANDS, ictx.mdm_active_bands_string);
 	event_handler(HL7800_EVENT_REVISION, ictx.mdm_revision);
 	hl7800_unlock();
+}
+
+uint32_t mdm_hl7800_log_filter_set(uint32_t level)
+{
+	uint32_t new_log_level = 0;
+
+#ifdef CONFIG_LOG
+	new_log_level =
+		log_filter_set(NULL, CONFIG_LOG_DOMAIN_ID,
+			       log_source_id_get(STRINGIFY(LOG_MODULE_NAME)),
+			       level);
+#endif
+
+	return new_log_level;
 }
 
 static int send_data(struct hl7800_socket *sock, struct net_pkt *pkt)

--- a/include/zephyr/drivers/modem/hl7800.h
+++ b/include/zephyr/drivers/modem/hl7800.h
@@ -523,6 +523,18 @@ void mdm_hl7800_register_cts_callback(void (*func)(int state));
  */
 int32_t mdm_hl7800_set_bands(const char *bands);
 
+/**
+ * @brief Set the log level for the modem.
+ *
+ * @note It cannot be set higher than CONFIG_MODEM_LOG_LEVEL.
+ * If debug level is desired, then it must be compiled with that level.
+ *
+ * @param level 0 (None) - 4 (Debug)
+ *
+ * @retval new log level
+ */
+uint32_t mdm_hl7800_log_filter_set(uint32_t level);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/logging/log_ctrl.h
+++ b/include/zephyr/logging/log_ctrl.h
@@ -121,6 +121,15 @@ const char *log_source_name_get(uint32_t domain_id, uint32_t source_id);
 const char *log_domain_name_get(uint32_t domain_id);
 
 /**
+ * @brief Function for finding source ID based on source name.
+ *
+ * @param name Source name
+ *
+ * @return Source ID or negative number when source ID is not found.
+ */
+int log_source_id_get(const char *name);
+
+/**
  * @brief Get source filter for the provided backend.
  *
  * @param backend	Backend instance.

--- a/samples/subsys/logging/logger/src/main.c
+++ b/samples/subsys/logging/logger/src/main.c
@@ -63,26 +63,6 @@ static uint32_t timestamp_freq(void)
 }
 
 /**
- * @brief Function for finding source ID based on source name.
- *
- * @param name Source name
- *
- * @return Source ID.
- */
-static int16_t log_source_id_get(const char *name)
-{
-
-	for (int16_t i = 0; i < log_src_cnt_get(CONFIG_LOG_DOMAIN_ID); i++) {
-		if (strcmp(log_source_name_get(CONFIG_LOG_DOMAIN_ID, i), name)
-		    == 0) {
-			return i;
-		}
-	}
-
-	return -1;
-}
-
-/**
  * @brief Function demonstrates module level filtering.
  *
  * Sample module API is called then logging for this module is disabled and

--- a/subsys/logging/log_mgmt.c
+++ b/subsys/logging/log_mgmt.c
@@ -64,6 +64,17 @@ const char *log_source_name_get(uint32_t domain_id, uint32_t src_id)
 	return src_id < z_log_sources_count() ? log_name_get(src_id) : NULL;
 }
 
+int log_source_id_get(const char *name)
+{
+	for (int i = 0; i < log_src_cnt_get(CONFIG_LOG_DOMAIN_ID); i++) {
+		if (strcmp(log_source_name_get(CONFIG_LOG_DOMAIN_ID, i),
+			   name) == 0) {
+			return i;
+		}
+	}
+	return -1;
+}
+
 static uint32_t max_filter_get(uint32_t filters)
 {
 	uint32_t max_filter = LOG_LEVEL_NONE;

--- a/tests/subsys/logging/log_api/src/main.c
+++ b/tests/subsys/logging/log_api/src/main.c
@@ -59,26 +59,6 @@ static log_timestamp_t timestamp_get(void)
 }
 
 /**
- * @brief Function for finding source ID based on source name.
- *
- * @param name Source name
- *
- * @return Source ID.
- */
-static int16_t log_source_id_get(const char *name)
-{
-	int16_t count = (int16_t)log_src_cnt_get(CONFIG_LOG_DOMAIN_ID);
-
-	for (int16_t i = 0; i < count; i++) {
-		if (strcmp(log_source_name_get(CONFIG_LOG_DOMAIN_ID, i), name)
-		    == 0) {
-			return i;
-		}
-	}
-	return -1;
-}
-
-/**
  * @brief Flush logs.
  *
  * If processing thread is enabled keep sleeping until there are no pending messages


### PR DESCRIPTION
Default mode must be debug or it can't ever be enabled.
Allow debug log messages to be printed when using
mdm_hl7800_send_at_cmd API.
Add logging to active bands and network coverage commands.