### PR TITLE
dts: stm32f103Xd: added missing dts file

### DIFF
--- a/dts/arm/st/f1/stm32f103Xd.dtsi
+++ b/dts/arm/st/f1/stm32f103Xd.dtsi
@@ -1,20 +1,24 @@
 /*
- * Copyright (c) 2017 I-SENSE group of ICCS
+ * Copyright (c) 2021 Teltonika
  *
- * SoC device tree include for STM32F103xE SoCs
+ * SoC device tree include for STM32F103xD SoCs
  * where 'x' is replaced for specific SoCs like {R,V,Z}
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <mem.h>
-#include <st/f1/stm32f103Xd.dtsi>
+#include <st/f1/stm32f103Xc.dtsi>
 
 / {
+	sram0: memory@20000000 {
+		reg = <0x20000000 DT_SIZE_K(64)>;
+	};
+
 	soc {
 		flash-controller@40022000 {
 			flash0: flash@8000000 {
-				reg = <0x08000000 DT_SIZE_K(512)>;
+				reg = <0x08000000 DT_SIZE_K(384)>;
 				erase-block-size = <DT_SIZE_K(2)>;
 			};
 		};


### PR DESCRIPTION
1. Added stm32f103xd series dts file that was missing.
2. Changed stm32f103xe file's import dts <st/f1/stm32f103Xc.dtsi> to
   <st/f1/stm32f103Xd.dtsi>. This change will show only the difference
   between stm32f103xd and stm32f103xd series.