### PR TITLE
Bluetooth: host: Fix shell adv data and device name misconfiguration

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3542,7 +3542,10 @@ int bt_enable(bt_ready_cb_t cb)
 			return err;
 		}
 	} else {
-		bt_set_name(CONFIG_BT_DEVICE_NAME);
+		err = bt_set_name(CONFIG_BT_DEVICE_NAME);
+		if (err) {
+			BT_WARN("Failed to set device name (%d)", err);
+		}
 	}
 
 	ready_cb = cb;
@@ -3584,6 +3587,13 @@ int bt_enable(bt_ready_cb_t cb)
 	k_work_submit(&bt_dev.init);
 	return 0;
 }
+
+#define DEVICE_NAME_LEN (sizeof(CONFIG_BT_DEVICE_NAME) - 1)
+#if defined(CONFIG_BT_DEVICE_NAME_DYNAMIC)
+BUILD_ASSERT(DEVICE_NAME_LEN < CONFIG_BT_DEVICE_NAME_MAX);
+#else
+BUILD_ASSERT(DEVICE_NAME_LEN < 248);
+#endif
 
 int bt_set_name(const char *name)
 {

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -36,9 +36,6 @@
 #include "ll.h"
 #include "hci.h"
 
-#define DEVICE_NAME		CONFIG_BT_DEVICE_NAME
-#define DEVICE_NAME_LEN		(sizeof(DEVICE_NAME) - 1)
-
 /* Multiply bt 1.25 to get MS */
 #define BT_INTERVAL_TO_MS(interval) ((interval) * 5 / 4)
 

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -1241,6 +1241,9 @@ static int cmd_adv_data(const struct shell *shell, size_t argc, char *argv[])
 		if (strcmp(arg, "scan-response") &&
 		    *data_len == ARRAY_SIZE(ad)) {
 			/* Maximum entries limit reached. */
+			shell_print(shell, "Failed to set advertising data: "
+					   "Maximum entries limit reached");
+
 			return -ENOEXEC;
 		}
 
@@ -1258,6 +1261,8 @@ static int cmd_adv_data(const struct shell *shell, size_t argc, char *argv[])
 			(*data_len)++;
 		} else if (!strcmp(arg, "scan-response")) {
 			if (data == sd) {
+				shell_print(shell, "Failed to set advertising data: "
+						   "duplicate scan-response option");
 				return -ENOEXEC;
 			}
 
@@ -1270,11 +1275,13 @@ static int cmd_adv_data(const struct shell *shell, size_t argc, char *argv[])
 				      sizeof(hex_data) - hex_data_len);
 
 			if (!len || (len - 1) != (hex_data[hex_data_len])) {
+				shell_print(shell, "Failed to set advertising data: "
+						   "malformed hex data");
 				return -ENOEXEC;
 			}
 
 			data[*data_len].type = hex_data[hex_data_len + 1];
-			data[*data_len].data_len = hex_data[hex_data_len];
+			data[*data_len].data_len = len - 2;
 			data[*data_len].data = &hex_data[hex_data_len + 2];
 			(*data_len)++;
 			hex_data_len += len;


### PR DESCRIPTION
Fix adv-data command when given arbitrary advertising data in
hexadecimal format. The data_len field should contain the length of the
data which does not include the data type. Instead the AD len field in
the data was given. This caused the AD len field to be increased by 1
in the advertising dat.

Add a build assert if the device name has been misconfigured. The device
name has a max length of 248. When configured as dynamic make sure that
the initial device length can fit in the dynamic max length.
This prevents us from having to handle length overflow when setting
device name in advertising data which has an 8-bit length field.

Log a warning if failing to set the device name in bt_enable.
Remove unused defines in the shell.