### PR TITLE
Bluetooth: Controller: Refactor same peer connection check and add check in Initiator

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -307,6 +307,9 @@ struct node_rx_iso_meta {
 /* Define invalid/unassigned Controller state/role instance handle */
 #define NODE_RX_HANDLE_INVALID 0xFFFF
 
+/* Define invalid/unassigned Controller LLL context handle */
+#define LLL_HANDLE_INVALID     0xFFFF
+
 /* Header of node_rx_pdu */
 struct node_rx_hdr {
 	union {

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1005,10 +1005,12 @@ uint8_t ll_adv_enable(uint8_t enable)
 #endif
 
 #if defined(CONFIG_BT_CTLR_CHECK_SAME_PEER_CONN)
-		conn->own_addr_type = BT_ADDR_LE_NONE->type;
-		memcpy(conn->own_addr, BT_ADDR_LE_NONE->a.val, sizeof(conn->own_addr));
-		conn->peer_addr_type = BT_ADDR_LE_NONE->type;
-		memcpy(conn->peer_addr, BT_ADDR_LE_NONE->a.val, sizeof(conn->peer_addr));
+		conn->own_id_addr_type = BT_ADDR_LE_NONE->type;
+		(void)memcpy(conn->own_id_addr, BT_ADDR_LE_NONE->a.val,
+			     sizeof(conn->own_id_addr));
+		conn->peer_id_addr_type = BT_ADDR_LE_NONE->type;
+		(void)memcpy(conn->peer_id_addr, BT_ADDR_LE_NONE->a.val,
+			     sizeof(conn->peer_id_addr));
 #endif /* CONFIG_BT_CTLR_CHECK_SAME_PEER_CONN */
 
 		conn->common.fex_valid = 0;
@@ -2682,7 +2684,7 @@ static const uint8_t *adva_update(struct ll_adv_set *adv, struct pdu_adv *pdu)
 #else
 	const uint8_t *rpa = NULL;
 #endif
-	const uint8_t *own_addr;
+	const uint8_t *own_id_addr;
 	const uint8_t *tx_addr;
 	uint8_t *adv_addr;
 
@@ -2690,22 +2692,22 @@ static const uint8_t *adva_update(struct ll_adv_set *adv, struct pdu_adv *pdu)
 		if (0) {
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 		} else if (ll_adv_cmds_is_ext() && pdu->tx_addr) {
-			own_addr = ll_adv_aux_random_addr_get(adv, NULL);
+			own_id_addr = ll_adv_aux_random_addr_get(adv, NULL);
 #endif
 		} else {
-			own_addr = ll_addr_get(pdu->tx_addr, NULL);
+			own_id_addr = ll_addr_get(pdu->tx_addr, NULL);
 		}
 	}
 
 #if defined(CONFIG_BT_CTLR_CHECK_SAME_PEER_CONN)
-	memcpy(adv->own_addr, own_addr, BDADDR_SIZE);
+	(void)memcpy(adv->own_id_addr, own_id_addr, BDADDR_SIZE);
 #endif /* CONFIG_BT_CTLR_CHECK_SAME_PEER_CONN */
 
 	if (rpa) {
 		pdu->tx_addr = 1;
 		tx_addr = rpa;
 	} else {
-		tx_addr = own_addr;
+		tx_addr = own_id_addr;
 	}
 
 	adv_addr = adv_pdu_adva_get(pdu);

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_types.h
@@ -51,7 +51,7 @@ struct ll_adv_set {
 #endif /* CONFIG_BT_CTLR_PRIVACY */
 
 #if defined(CONFIG_BT_CTLR_CHECK_SAME_PEER_CONN)
-	uint8_t  own_addr[BDADDR_SIZE];
+	uint8_t  own_id_addr[BDADDR_SIZE];
 #endif /* CONFIG_BT_CTLR_CHECK_SAME_PEER_CONN */
 
 #if defined(CONFIG_BT_CTLR_DF_ADV_CTE_TX)

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -808,8 +808,10 @@ uint8_t ull_conn_default_phy_rx_get(void)
 #endif /* CONFIG_BT_CTLR_PHY */
 
 #if defined(CONFIG_BT_CTLR_CHECK_SAME_PEER_CONN)
-bool ull_conn_peer_connected(uint8_t own_addr_type, uint8_t *own_addr,
-			     uint8_t peer_addr_type, uint8_t *peer_addr)
+bool ull_conn_peer_connected(uint8_t const own_id_addr_type,
+			     uint8_t const *const own_id_addr,
+			     uint8_t const peer_id_addr_type,
+			     uint8_t const *const peer_id_addr)
 {
 	uint16_t handle;
 
@@ -817,10 +819,10 @@ bool ull_conn_peer_connected(uint8_t own_addr_type, uint8_t *own_addr,
 		struct ll_conn *conn = ll_connected_get(handle);
 
 		if (conn &&
-		    conn->peer_addr_type == peer_addr_type &&
-		    !memcmp(conn->peer_addr, peer_addr, BDADDR_SIZE) &&
-		    conn->own_addr_type == own_addr_type &&
-		    !memcmp(conn->own_addr, own_addr, BDADDR_SIZE)) {
+		    conn->peer_id_addr_type == peer_id_addr_type &&
+		    !memcmp(conn->peer_id_addr, peer_id_addr, BDADDR_SIZE) &&
+		    conn->own_id_addr_type == own_id_addr_type &&
+		    !memcmp(conn->own_id_addr, own_id_addr, BDADDR_SIZE)) {
 			return true;
 		}
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1198,7 +1198,7 @@ void ull_conn_done(struct node_rx_event_done *done)
 	lll = &conn->lll;
 
 	/* Skip if connection terminated by local host */
-	if (unlikely(lll->handle == 0xFFFF)) {
+	if (unlikely(lll->handle == LLL_HANDLE_INVALID)) {
 		return;
 	}
 
@@ -1540,7 +1540,7 @@ void ull_conn_tx_demux(uint8_t count)
 			struct pdu_data *p = (void *)tx->pdu;
 
 			p->ll_id = PDU_DATA_LLID_RESV;
-			ll_tx_ack_put(0xFFFF, tx);
+			ll_tx_ack_put(LLL_HANDLE_INVALID, tx);
 		}
 
 #if defined(CONFIG_BT_CTLR_LLID_DATA_START_EMPTY)
@@ -1656,7 +1656,7 @@ void ull_conn_tx_ack(uint16_t handle, memq_link_t *link, struct node_tx *tx)
 	LL_ASSERT(pdu_tx->len);
 
 	if (pdu_tx->ll_id == PDU_DATA_LLID_CTRL) {
-		if (handle != 0xFFFF) {
+		if (handle != LLL_HANDLE_INVALID) {
 			struct ll_conn *conn = ll_conn_get(handle);
 
 			ctrl_tx_ack(conn, &tx, pdu_tx);
@@ -1674,10 +1674,10 @@ void ull_conn_tx_ack(uint16_t handle, memq_link_t *link, struct node_tx *tx)
 		} else {
 			LL_ASSERT(!link->next);
 		}
-	} else if (handle == 0xFFFF) {
+	} else if (handle == LLL_HANDLE_INVALID) {
 		pdu_tx->ll_id = PDU_DATA_LLID_RESV;
 	} else {
-		LL_ASSERT(handle != 0xFFFF);
+		LL_ASSERT(handle != LLL_HANDLE_INVALID);
 	}
 
 	ll_tx_ack_put(handle, tx);
@@ -1981,7 +1981,7 @@ static void conn_cleanup_finalize(struct ll_conn *conn)
 		  (ticker_status == TICKER_STATUS_BUSY));
 
 	/* Invalidate the connection context */
-	lll->handle = 0xFFFF;
+	lll->handle = LLL_HANDLE_INVALID;
 
 	/* Demux and flush Tx PDUs that remain enqueued in thread context */
 	ull_conn_tx_demux(UINT8_MAX);
@@ -2114,7 +2114,7 @@ static void tx_lll_flush(void *param)
 		idx = MFIFO_ENQUEUE_GET(conn_ack, (void **)&lll_tx);
 		LL_ASSERT(lll_tx);
 
-		lll_tx->handle = 0xFFFF;
+		lll_tx->handle = LLL_HANDLE_INVALID;
 		lll_tx->node = tx;
 
 		/* TX node UPSTREAM, i.e. Tx node ack path */

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1928,6 +1928,7 @@ static inline void disable(uint16_t handle)
 					conn, &conn->lll);
 	LL_ASSERT(err == 0 || err == -EALREADY);
 
+	conn->lll.handle = LLL_HANDLE_INVALID;
 	conn->lll.link_tx_free = NULL;
 }
 

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_internal.h
@@ -18,8 +18,10 @@ uint16_t ull_conn_default_tx_octets_get(void);
 uint16_t ull_conn_default_tx_time_get(void);
 uint8_t ull_conn_default_phy_tx_get(void);
 uint8_t ull_conn_default_phy_rx_get(void);
-bool ull_conn_peer_connected(uint8_t own_addr_type, uint8_t *own_addr,
-			     uint8_t peer_addr_type, uint8_t *peer_addr);
+bool ull_conn_peer_connected(uint8_t const own_id_addr_type,
+			     uint8_t const *const own_id_addr,
+			     uint8_t const peer_id_addr_type,
+			     uint8_t const *const peer_id_addr);
 void ull_conn_setup(memq_link_t *rx_link, struct node_rx_hdr *rx);
 int ull_conn_rx(memq_link_t *link, struct node_rx_pdu **rx);
 int ull_conn_llcp(struct ll_conn *conn, uint32_t ticks_at_expire, uint16_t lazy);

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
@@ -56,10 +56,10 @@ struct ll_conn {
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 
 #if defined(CONFIG_BT_CTLR_CHECK_SAME_PEER_CONN)
-	uint8_t own_addr_type:1;
-	uint8_t peer_addr_type:2;
-	uint8_t own_addr[BDADDR_SIZE];
-	uint8_t peer_addr[BDADDR_SIZE];
+	uint8_t own_id_addr_type:1;
+	uint8_t peer_id_addr_type:1;
+	uint8_t own_id_addr[BDADDR_SIZE];
+	uint8_t peer_id_addr[BDADDR_SIZE];
 #endif /* CONFIG_BT_CTLR_CHECK_SAME_PEER_CONN */
 
 	union {

--- a/subsys/bluetooth/controller/ll_sw/ull_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_filter.c
@@ -1103,12 +1103,13 @@ static void conn_rpa_update(uint8_t rl_idx)
 	for (handle = 0U; handle < CONFIG_BT_MAX_CONN; handle++) {
 		struct ll_conn *conn = ll_connected_get(handle);
 
-		/* The RPA of the connection matches the RPA that was just resolved */
-		if (conn &&
-		    conn->peer_addr_type < 2U &&
-		    !memcmp(conn->peer_addr, rl[rl_idx].curr_rpa.val, BDADDR_SIZE)) {
-			memcpy(conn->peer_addr, rl[rl_idx].id_addr.val, BDADDR_SIZE);
-			conn->peer_addr_type += 2U;
+		/* The RPA of the connection matches the RPA that was just
+		 * resolved
+		 */
+		if (conn && !memcmp(conn->peer_id_addr, rl[rl_idx].curr_rpa.val,
+				    BDADDR_SIZE)) {
+			(void)memcpy(conn->peer_id_addr, rl[rl_idx].id_addr.val,
+				     BDADDR_SIZE);
 			break;
 		}
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -112,22 +112,25 @@ void ull_slave_setup(struct node_rx_hdr *rx, struct node_rx_ftr *ftr,
 	link = rx->link;
 
 #if defined(CONFIG_BT_CTLR_CHECK_SAME_PEER_CONN)
-	uint8_t own_addr_type = pdu_adv->rx_addr;
-	uint8_t *own_addr = adv->own_addr;
+	const uint8_t peer_id_addr_type = (peer_addr_type & 0x01);
+	const uint8_t own_id_addr_type = pdu_adv->rx_addr;
+	const uint8_t *own_id_addr = adv->own_id_addr;
 
 	/* Do not connect twice to the same peer */
-	if (ull_conn_peer_connected(own_addr_type, own_addr,
-				    peer_addr_type, peer_id_addr)) {
+	if (ull_conn_peer_connected(own_id_addr_type, own_id_addr,
+				    peer_id_addr_type, peer_id_addr)) {
 		invalid_release(&adv->ull, lll, link, rx);
 
 		return;
 	}
 
-	/* Remember peer and own identity */
-	conn->peer_addr_type = peer_addr_type;
-	memcpy(conn->peer_addr, peer_id_addr, sizeof(conn->peer_addr));
-	conn->own_addr_type = own_addr_type;
-	memcpy(conn->own_addr, own_addr, sizeof(conn->own_addr));
+	/* Remember peer and own identity address */
+	conn->peer_id_addr_type = peer_id_addr_type;
+	(void)memcpy(conn->peer_id_addr, peer_id_addr,
+		     sizeof(conn->peer_id_addr));
+	conn->own_id_addr_type = own_id_addr_type;
+	(void)memcpy(conn->own_id_addr, own_id_addr,
+		     sizeof(conn->own_id_addr));
 #endif /* CONFIG_BT_CTLR_CHECK_SAME_PEER_CONN */
 
 	memcpy(&lll->crc_init[0], &pdu_adv->connect_ind.crc_init[0], 3);


### PR DESCRIPTION
Store and check device identity addr type of public or
random.

Add implementation to initiator to check and reject
connection requests to already connected peer.

These changes continue to pass the related 1 peripheral conformance test cases,
and now pass 3 initiator conformance tests.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>