### PR TITLE
modbus: Add file record support

### DIFF
--- a/include/modbus/modbus.h
+++ b/include/modbus/modbus.h
@@ -61,6 +61,21 @@ struct modbus_adu {
 	uint16_t crc;
 };
 
+struct modbus_write_file_record {
+	uint16_t file_number;
+	uint16_t record_number;
+	uint16_t record_length;
+	uint16_t * const record_data;
+};
+
+struct modbus_read_file_record {
+	uint16_t file_number;
+	uint16_t record_number;
+	uint16_t record_length;
+	uint8_t file_response_length;
+	uint16_t *record_data;
+};
+
 /**
  * @brief Coil read (FC01)
  *
@@ -330,6 +345,16 @@ int modbus_write_holding_regs_fp(const int iface,
 				 float *const reg_buf,
 				 const uint16_t num_regs);
 
+int modbus_read_file_record(const int iface,
+			    const uint8_t unit_id,
+			    struct modbus_read_file_record records[],
+			    const int num_file_records);
+
+int modbus_write_file_record(const int iface,
+			     const uint8_t unit_id,
+			     const struct modbus_write_file_record records[],
+			     const int num_file_records);
+
 /** Modbus Server User Callback structure */
 struct modbus_user_callbacks {
 	/** Coil read callback */
@@ -358,6 +383,19 @@ struct modbus_user_callbacks {
 
 	/** Floating Point Holding Register write callback */
 	int (*holding_reg_wr_fp)(uint16_t addr, float reg);
+
+	/** File Record read callback */
+	int (*file_record_rd)(uint16_t file_number,
+			      uint16_t record_number,
+			      uint16_t record_length,
+			      uint16_t record_data[],
+			      uint8_t *response_length);
+
+	/** File Record write callback */
+	int (*file_record_wr)(uint16_t file_number,
+			      uint16_t record_number,
+			      uint16_t *record_length,
+			      uint16_t record_data[]);
 };
 
 /**

--- a/subsys/modbus/modbus_internal.h
+++ b/subsys/modbus/modbus_internal.h
@@ -45,6 +45,8 @@
 #define	MODBUS_FC08_DIAGNOSTICS			8
 #define	MODBUS_FC15_COILS_WR			15
 #define	MODBUS_FC16_HOLDING_REGS_WR		16
+#define	MODBUS_FC20_FILE_RECORD_RD		20
+#define	MODBUS_FC21_FILE_RECORD_WR		21
 
 /* Diagnostic sub-function codes */
 #define MODBUS_FC08_SUBF_QUERY			0

--- a/tests/subsys/modbus/src/main.c
+++ b/tests/subsys/modbus/src/main.c
@@ -51,6 +51,7 @@ void test_main(void)
 			 ztest_unit_test(test_di_rd),
 			 ztest_unit_test(test_input_reg),
 			 ztest_unit_test(test_holding_reg),
+			 ztest_unit_test(test_file_record),
 			 ztest_unit_test(test_diagnostic),
 			 ztest_unit_test(test_client_disable),
 			 ztest_unit_test(test_server_disable)

--- a/tests/subsys/modbus/src/test_modbus.h
+++ b/tests/subsys/modbus/src/test_modbus.h
@@ -44,6 +44,7 @@ void test_coil_wr_rd(void);
 void test_di_rd(void);
 void test_input_reg(void);
 void test_holding_reg(void);
+void test_file_record(void);
 void test_diagnostic(void);
 void test_client_disable(void);
 

--- a/tests/subsys/modbus/src/test_modbus_client.c
+++ b/tests/subsys/modbus/src/test_modbus_client.c
@@ -188,6 +188,45 @@ void test_holding_reg(void)
 		      "FC16FP verify failed");
 }
 
+void test_file_record(void)
+{
+	uint16_t file_rec_wr[8] = {0, 2, 1, 3, 5, 4, 7, 6};
+	uint16_t file_rec_rd[8] = {0};
+	struct modbus_write_file_record write_records[1] = {
+		{
+			.file_number = 1,
+			.record_number = 1,
+			.record_length = ARRAY_SIZE(file_rec_wr),
+			.record_data = file_rec_wr,
+		}
+	};
+	int err;
+
+	err = modbus_write_file_record(client_iface,
+				       node,
+				       write_records,
+				       ARRAY_SIZE(write_records));
+	zassert_not_equal(err, 0, "FC21 write request failed");
+
+	struct modbus_read_file_record read_records[1] = {
+		{
+			.file_number = 1,
+			.record_number = 1,
+			.record_length = ARRAY_SIZE(file_rec_rd),
+			.record_data = file_rec_rd,
+		}
+	};
+	err = modbus_read_file_record(client_iface,
+				      node,
+				      read_records,
+				      ARRAY_SIZE(read_records));
+	zassert_equal(err, 0, "FC20 read request failed");
+
+	LOG_HEXDUMP_DBG(file_rec_rd, sizeof(file_rec_rd), "FC20, file_rec_rd");
+	zassert_equal(memcmp(file_rec_wr, file_rec_rd, sizeof(file_rec_wr)), 0,
+		      "FC21 verify failed");
+}
+
 void test_diagnostic(void)
 {
 	uint16_t data = 0xcafe;
@@ -331,6 +370,11 @@ void test_input_reg(void)
 }
 
 void test_holding_reg(void)
+{
+	ztest_test_skip();
+}
+
+void test_file_record(void)
 {
 	ztest_test_skip();
 }


### PR DESCRIPTION
This commit adds support for function codes 20 (Read File Record)
and 21 (Write File Record) to the server. Write File Record allows the
application to modify the record data in the response. This is typically
the case when responding with the same data adds unnecessary overhead.
Tested with Pymodbus.

Signed-off-by: Christian Sandberg <christian.sandberg@xylem.com>