### PR TITLE
device: supported devices API

### DIFF
--- a/include/device.h
+++ b/include/device.h
@@ -679,6 +679,8 @@ static inline bool device_is_ready(const struct device *dev)
  *     List of devicetree dependency ordinals (if any),
  *     DEVICE_HANDLE_SEP,
  *     List of injected dependency ordinals (if any),
+ *     DEVICE_HANDLE_SEP,
+ *     List of devicetree supporting ordinals (if any),
  * }
  *
  * After processing in gen_handles.py, the format is updated to:
@@ -686,6 +688,8 @@ static inline bool device_is_ready(const struct device *dev)
  *     List of existing devicetree dependency handles (if any),
  *     DEVICE_HANDLE_SEP,
  *     List of injected dependency ordinals (if any),
+ *     DEVICE_HANDLE_SEP,
+ *     List of existing devicetree support handles (if any),
  *     DEVICE_HANDLE_NULL padding to original length (at least one)
  * }
  *
@@ -717,6 +721,9 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 		))							\
 			DEVICE_HANDLE_SEP,				\
 			Z_DEVICE_EXTRA_HANDLES(__VA_ARGS__)		\
+			DEVICE_HANDLE_SEP,				\
+	COND_CODE_1(DT_NODE_EXISTS(node_id),				\
+			(DT_SUPPORTS_DEP_ORDS(node_id)), ())		\
 		};
 
 #define Z_DEVICE_DEFINE_INIT(node_id, dev_name, pm_control_fn)		\

--- a/include/device.h
+++ b/include/device.h
@@ -478,8 +478,7 @@ device_required_handles_get(const struct device *dev,
 	if (rv != NULL) {
 		size_t i = 0;
 
-		while ((rv[i] != DEVICE_HANDLE_ENDS)
-		       && (rv[i] != DEVICE_HANDLE_SEP)) {
+		while (rv[i] != DEVICE_HANDLE_SEP) {
 			++i;
 		}
 		*count = i;
@@ -673,6 +672,22 @@ static inline bool device_is_ready(const struct device *dev)
  * from being captured when the original object file is compiled), and
  * in a distinct pass1 section (which will be replaced by
  * postprocessing).
+ *
+ * Before processing in gen_handles.py, the array format is:
+ * {
+ *     DEVICE_ORDINAL (or DEVICE_HANDLE_NULL if not a devicetree node),
+ *     List of devicetree dependency ordinals (if any),
+ *     DEVICE_HANDLE_SEP,
+ *     List of injected dependency ordinals (if any),
+ * }
+ *
+ * After processing in gen_handles.py, the format is updated to:
+ * {
+ *     List of existing devicetree dependency handles (if any),
+ *     DEVICE_HANDLE_SEP,
+ *     List of injected dependency ordinals (if any),
+ *     DEVICE_HANDLE_NULL padding to original length (at least one)
+ * }
  *
  * It is also (experimentally) necessary to provide explicit alignment
  * on each object. Otherwise x86-64 builds will introduce padding

--- a/include/device.h
+++ b/include/device.h
@@ -37,7 +37,7 @@ extern "C" {
 
 /** @brief Type used to represent devices and functions.
  *
- * The extreme values and zero have special significance.  Negative
+ * The extreme values and zero have special significance. Negative
  * values identify functionality that does not correspond to a Zephyr
  * device, such as the system clock or a SYS_INIT() function.
  */
@@ -124,7 +124,7 @@ typedef int16_t device_handle_t;
  * @param cfg_ptr The address to the structure containing the
  * configuration information for this instance of the driver.
  *
- * @param level The initialization level.  See SYS_INIT() for
+ * @param level The initialization level. See SYS_INIT() for
  * details.
  *
  * @param prio Priority within the selected initialization level. See
@@ -160,14 +160,14 @@ typedef int16_t device_handle_t;
  * @brief Like DEVICE_DEFINE but taking metadata from a devicetree node.
  *
  * @details This macro defines a device object that is automatically
- * configured by the kernel during system initialization.  The device
+ * configured by the kernel during system initialization. The device
  * object name is derived from the node identifier (encoding the
  * devicetree path to the node), and the driver name is from the @p
  * label property of the devicetree node.
  *
  * The device is declared with extern visibility, so device objects
  * defined through this API can be obtained directly through
- * DEVICE_DT_GET() using @p node_id.  Before using the pointer the
+ * DEVICE_DT_GET() using @p node_id. Before using the pointer the
  * referenced object should be checked using device_is_ready().
  *
  * @param node_id The devicetree node identifier.
@@ -182,7 +182,7 @@ typedef int16_t device_handle_t;
  * @param cfg_ptr The address to the structure containing the
  * configuration information for this instance of the driver.
  *
- * @param level The initialization level.  See SYS_INIT() for
+ * @param level The initialization level. See SYS_INIT() for
  * details.
  *
  * @param prio Priority within the selected initialization level. See
@@ -205,7 +205,7 @@ typedef int16_t device_handle_t;
  *
  * @brief Like DEVICE_DT_DEFINE for an instance of a DT_DRV_COMPAT compatible
  *
- * @param inst instance number.  This is replaced by
+ * @param inst instance number. This is replaced by
  * <tt>DT_DRV_COMPAT(inst)</tt> in the call to DEVICE_DT_DEFINE.
  *
  * @param ... other parameters as expected by DEVICE_DT_DEFINE.
@@ -334,7 +334,7 @@ typedef int16_t device_handle_t;
 /**
  * @brief Runtime device dynamic structure (in RAM) per driver instance
  *
- * Fields in this are expected to be default-initialized to zero.  The
+ * Fields in this are expected to be default-initialized to zero. The
  * kernel driver infrastructure and driver access functions are
  * responsible for ensuring that any non-zero initialization is done
  * before they are accessed.
@@ -344,7 +344,7 @@ struct device_state {
 	 *
 	 * The absolute value returned when the device initialization
 	 * function was invoked, or `UINT8_MAX` if the value exceeds
-	 * an 8-bit integer.  If initialized is also set, a zero value
+	 * an 8-bit integer. If initialized is also set, a zero value
 	 * indicates initialization succeeded.
 	 */
 	unsigned int init_res : 8;
@@ -377,7 +377,7 @@ struct device {
 	/** optional pointer to handles associated with the device.
 	 *
 	 * This encodes a sequence of sets of device handles that have
-	 * some relationship to this node.  The individual sets are
+	 * some relationship to this node. The individual sets are
 	 * extracted with dedicated API, such as
 	 * device_required_handles_get().
 	 */
@@ -463,8 +463,8 @@ typedef int (*device_visitor_callback_t)(const struct device *dev, void *context
  * @param dev the device for which dependencies are desired.
  *
  * @param count pointer to a place to store the number of devices provided at
- * the returned pointer.  The value is not set if the call returns a null
- * pointer.  The value may be set to zero.
+ * the returned pointer. The value is not set if the call returns a null
+ * pointer. The value may be set to zero.
  *
  * @return a pointer to a sequence of @p *count device handles, or a null
  * pointer if @p dh does not provide dependency information.
@@ -493,11 +493,11 @@ device_required_handles_get(const struct device *dev,
  *
  * Zephyr maintains information about which devices are directly required by
  * another device; for example an I2C-based sensor driver will require an I2C
- * controller for communication.  Required devices can derive from
+ * controller for communication. Required devices can derive from
  * statically-defined devicetree relationships or dependencies registered
  * at runtime.
  *
- * This API supports operating on the set of required devices.  Example uses
+ * This API supports operating on the set of required devices. Example uses
  * include making sure required devices are ready before the requiring device
  * is used, and releasing them when the requiring device is no longer needed.
  *
@@ -508,14 +508,14 @@ device_required_handles_get(const struct device *dev,
  *
  * @note This API is not available to unprivileged threads.
  *
- * @param dev a device of interest.  The devices that this device depends on
- * will be used as the set of devices to visit.  This parameter must not be
+ * @param dev a device of interest. The devices that this device depends on
+ * will be used as the set of devices to visit. This parameter must not be
  * null.
  *
  * @param visitor_cb the function that should be invoked on each device in the
- * dependency set.  This parameter must not be null.
+ * dependency set. This parameter must not be null.
  *
- * @param context state that is passed through to the visitor function.  This
+ * @param context state that is passed through to the visitor function. This
  * parameter may be null if @p visitor tolerates a null @p context.
  *
  * @return The number of devices that were visited if all visits succeed, or
@@ -533,7 +533,7 @@ int device_required_foreach(const struct device *dev,
  * it can use this function to retrieve the device structure of the lower level
  * driver by the name the driver exposes to the system.
  *
- * @param name device name to search for.  A null pointer, or a pointer to an
+ * @param name device name to search for. A null pointer, or a pointer to an
  * empty string, will cause NULL to be returned.
  *
  * @return pointer to device structure; NULL if not found or cannot be used.
@@ -543,7 +543,7 @@ __syscall const struct device *device_get_binding(const char *name);
 /** @brief Get access to the static array of static devices.
  *
  * @param devices where to store the pointer to the array of
- * statically allocated devices.  The array must not be mutated
+ * statically allocated devices. The array must not be mutated
  * through this pointer.
  *
  * @return the number of statically allocated devices.
@@ -596,7 +596,7 @@ static inline int z_impl_device_usable_check(const struct device *dev)
  * in a state where it can be used with its standard API.
  *
  * This can be used with device pointers captured from DEVICE_DT_GET(), which
- * does not include the readiness checks of device_get_binding().  At minimum
+ * does not include the readiness checks of device_get_binding(). At minimum
  * this means that the device has been successfully initialized, but it may
  * take on further conditions (e.g. is not powered down).
  *
@@ -619,7 +619,7 @@ static inline bool device_is_ready(const struct device *dev)
  * so synthesize a unique dev_name from the devicetree node.
  *
  * The ordinal used in this name can be mapped to the path by
- * examining zephyr/include/generated/device_extern.h header.  If the
+ * examining zephyr/include/generated/device_extern.h header. If the
  * format of this conversion changes, gen_defines should be updated to
  * match it.
  */
@@ -631,7 +631,7 @@ static inline bool device_is_ready(const struct device *dev)
 #define Z_DEVICE_STATE_NAME(dev_name) _CONCAT(__devstate_, dev_name)
 
 /** Synthesize the name of the object that holds device ordinal and
- * dependency data.  If the object doesn't come from a devicetree
+ * dependency data. If the object doesn't come from a devicetree
  * node, use dev_name.
  */
 #define Z_DEVICE_HANDLE_NAME(node_id, dev_name)				\
@@ -658,7 +658,7 @@ static inline bool device_is_ready(const struct device *dev)
 #define Z_DEVICE_DEFINE_PM_SLOT(dev_name)
 #endif
 
-/* Construct objects that are referenced from struct device.  These
+/* Construct objects that are referenced from struct device. These
  * include power management and dependency handles.
  */
 #define Z_DEVICE_DEFINE_PRE(node_id, dev_name, ...)			\
@@ -675,7 +675,7 @@ static inline bool device_is_ready(const struct device *dev)
  * postprocessing).
  *
  * It is also (experimentally) necessary to provide explicit alignment
- * on each object.  Otherwise x86-64 builds will introduce padding
+ * on each object. Otherwise x86-64 builds will introduce padding
  * between objects in the same input section in individual object
  * files, which will be retained in subsequent links both wasting
  * space and resulting in aggregate size changes relative to pass2

--- a/include/device.h
+++ b/include/device.h
@@ -488,6 +488,47 @@ device_required_handles_get(const struct device *dev,
 }
 
 /**
+ * @brief Get the set of handles that this device supports.
+ *
+ * The set of supported devices is inferred from devicetree, and does not
+ * include any software constructs that may depend on the device.
+ *
+ * @param dev the device for which supports are desired.
+ *
+ * @param count pointer to a place to store the number of devices provided at
+ * the returned pointer. The value is not set if the call returns a null
+ * pointer. The value may be set to zero.
+ *
+ * @return a pointer to a sequence of @p *count device handles, or a null
+ * pointer if @p dh does not provide dependency information.
+ */
+static inline const device_handle_t *
+device_supported_handles_get(const struct device *dev,
+			     size_t *count)
+{
+	const device_handle_t *rv = dev->handles;
+	size_t region = 0;
+	size_t i = 0;
+
+	if (rv != NULL) {
+		/* Fast forward to supporting devices */
+		while (region != 2) {
+			if (*rv == DEVICE_HANDLE_SEP) {
+				region++;
+			}
+			rv++;
+		}
+		/* Count supporting devices */
+		while (rv[i] != DEVICE_HANDLE_ENDS) {
+			++i;
+		}
+		*count = i;
+	}
+
+	return rv;
+}
+
+/**
  * @brief Visit every device that @p dev directly requires.
  *
  * Zephyr maintains information about which devices are directly required by
@@ -523,6 +564,42 @@ device_required_handles_get(const struct device *dev,
 int device_required_foreach(const struct device *dev,
 			  device_visitor_callback_t visitor_cb,
 			  void *context);
+
+/**
+ * @brief Visit every device that @p dev directly supports.
+ *
+ * Zephyr maintains information about which devices are directly supported by
+ * another device; for example an I2C controller will support an I2C-based
+ * sensor driver. Supported devices can derive from statically-defined
+ * devicetree relationships.
+ *
+ * This API supports operating on the set of supported devices. Example uses
+ * include iterating over the devices connected to a regulator when it is
+ * powered on.
+ *
+ * There is no guarantee on the order in which required devices are visited.
+ *
+ * If the @p visitor function returns a negative value iteration is halted,
+ * and the returned value from the visitor is returned from this function.
+ *
+ * @note This API is not available to unprivileged threads.
+ *
+ * @param dev a device of interest. The devices that this device supports
+ * will be used as the set of devices to visit. This parameter must not be
+ * null.
+ *
+ * @param visitor_cb the function that should be invoked on each device in the
+ * support set. This parameter must not be null.
+ *
+ * @param context state that is passed through to the visitor function. This
+ * parameter may be null if @p visitor tolerates a null @p context.
+ *
+ * @return The number of devices that were visited if all visits succeed, or
+ * the negative value returned from the first visit that did not succeed.
+ */
+int device_supported_foreach(const struct device *dev,
+			     device_visitor_callback_t visitor_cb,
+			     void *context);
 
 /**
  * @brief Retrieve the device structure for a driver by name

--- a/include/device.h
+++ b/include/device.h
@@ -702,7 +702,6 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 		))							\
 			DEVICE_HANDLE_SEP,				\
 			Z_DEVICE_EXTRA_HANDLES(__VA_ARGS__)		\
-			DEVICE_HANDLE_ENDS,				\
 		};
 
 #define Z_DEVICE_DEFINE_INIT(node_id, dev_name, pm_control_fn)		\

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -176,14 +176,11 @@ bool z_device_ready(const struct device *dev)
 	return dev->state->initialized && (dev->state->init_res == 0U);
 }
 
-int device_required_foreach(const struct device *dev,
-			  device_visitor_callback_t visitor_cb,
-			  void *context)
+static int device_visitor(const device_handle_t *handles,
+			   size_t handle_count,
+			   device_visitor_callback_t visitor_cb,
+			   void *context)
 {
-	size_t handle_count = 0;
-	const device_handle_t *handles =
-		device_required_handles_get(dev, &handle_count);
-
 	/* Iterate over fixed devices */
 	for (size_t i = 0; i < handle_count; ++i) {
 		device_handle_t dh = handles[i];
@@ -196,4 +193,26 @@ int device_required_foreach(const struct device *dev,
 	}
 
 	return handle_count;
+}
+
+int device_required_foreach(const struct device *dev,
+			    device_visitor_callback_t visitor_cb,
+			    void *context)
+{
+	size_t handle_count = 0;
+	const device_handle_t *handles =
+		device_required_handles_get(dev, &handle_count);
+
+	return device_visitor(handles, handle_count, visitor_cb, context);
+}
+
+int device_supported_foreach(const struct device *dev,
+			     device_visitor_callback_t visitor_cb,
+			     void *context)
+{
+	size_t handle_count = 0;
+	const device_handle_t *handles =
+		device_supported_handles_get(dev, &handle_count);
+
+	return device_visitor(handles, handle_count, visitor_cb, context);
 }

--- a/scripts/gen_handles.py
+++ b/scripts/gen_handles.py
@@ -241,7 +241,7 @@ def main():
         handle.dev_deps = []
         handle.ext_deps = []
         deps = handle.dev_deps
-        while True:
+        while hvi < len(hv):
             h = hv[hvi]
             if h == DEVICE_HANDLE_ENDS:
                 break
@@ -302,8 +302,10 @@ def main():
 
             # When CONFIG_USERSPACE is enabled the pre-built elf is
             # also used to get hashes that identify kernel objects by
-            # address.  We can't allow the size of any object in the
-            # final elf to change.
+            # address. We can't allow the size of any object in the
+            # final elf to change. We also must make sure at least one
+            # DEVICE_HANDLE_ENDS is inserted.
+            assert len(hdls) < len(hs.handles), "%s no DEVICE_HANDLE_ENDS inserted" % (dev.sym.name,)
             while len(hdls) < len(hs.handles):
                 hdls.append(DEVICE_HANDLE_ENDS)
             assert len(hdls) == len(hs.handles), "%s handle overflow" % (dev.sym.name,)

--- a/scripts/gen_handles.py
+++ b/scripts/gen_handles.py
@@ -240,15 +240,19 @@ def main():
         hvi = 1
         handle.dev_deps = []
         handle.ext_deps = []
-        deps = handle.dev_deps
+        handle.dev_sups = []
+        hdls = handle.dev_deps
         while hvi < len(hv):
             h = hv[hvi]
             if h == DEVICE_HANDLE_ENDS:
                 break
             if h == DEVICE_HANDLE_SEP:
-                deps = handle.ext_deps
+                if hdls == handle.dev_deps:
+                    hdls = handle.ext_deps
+                else:
+                    hdls = handle.dev_sups
             else:
-                deps.append(h)
+                hdls.append(h)
                 n = edt
             hvi += 1
 
@@ -261,6 +265,7 @@ def main():
     for sn in used_nodes:
         # Where we're storing the final set of nodes: these are all used
         sn.__depends = set()
+        sn.__supports = set()
 
         deps = set(sn.depends_on)
         debug("\nNode: %s\nOrig deps:\n\t%s" % (sn.path, "\n\t".join([dn.path for dn in deps])))
@@ -273,7 +278,16 @@ def main():
                 # forward the dependency up one level
                 for ddn in dn.depends_on:
                     deps.add(ddn)
-        debug("final deps:\n\t%s\n" % ("\n\t".join([ _dn.path for _dn in sn.__depends])))
+        debug("Final deps:\n\t%s\n" % ("\n\t".join([ _dn.path for _dn in sn.__depends])))
+
+        sups = set(sn.required_by)
+        debug("\nOrig sups:\n\t%s" % ("\n\t".join([dn.path for dn in sups])))
+        while len(sups) > 0:
+            dn = sups.pop()
+            if dn in used_nodes:
+                # this is used
+                sn.__supports.add(dn)
+        debug("\nFinal sups:\n\t%s" % ("\n\t".join([dn.path for dn in sn.__supports])))
 
     with open(args.output_source, "w") as fp:
         fp.write('#include <device.h>\n')
@@ -284,6 +298,7 @@ def main():
             assert hs, "no hs for %s" % (dev.sym.name,)
             dep_paths = []
             ext_paths = []
+            sup_paths = []
             hdls = []
 
             sn = hs.node
@@ -294,12 +309,23 @@ def main():
                         dep_paths.append(dn.path)
                     else:
                         dep_paths.append('(%s)' % dn.path)
+
             # Force separator to signal start of injected dependencies
             hdls.append(DEVICE_HANDLE_SEP)
             if len(hs.ext_deps) > 0:
                 # TODO: map these to something smaller?
                 ext_paths.extend(map(str, hs.ext_deps))
                 hdls.extend(hs.ext_deps)
+
+            # Force separator to signal start of supported devices
+            hdls.append(DEVICE_HANDLE_SEP)
+            if len(hs.dev_sups) > 0:
+                for dn in sn.required_by:
+                    if dn in sn.__supports:
+                        sup_paths.append(dn.path)
+                    else:
+                        sup_paths.append('(%s)' % dn.path)
+                hdls.extend(dn.__device.dev_handle for dn in sn.__supports)
 
             # When CONFIG_USERSPACE is enabled the pre-built elf is
             # also used to get hashes that identify kernel objects by
@@ -317,9 +343,14 @@ def main():
             ]
 
             if len(dep_paths) > 0:
-                lines.append(' * - %s' % ('\n * - '.join(dep_paths)))
+                lines.append(' * Direct Dependencies:')
+                lines.append(' *   - %s' % ('\n *   - '.join(dep_paths)))
             if len(ext_paths) > 0:
-                lines.append(' * + %s' % ('\n * + '.join(ext_paths)))
+                lines.append(' * Injected Dependencies:')
+                lines.append(' *   - %s' % ('\n *   - '.join(ext_paths)))
+            if len(sup_paths) > 0:
+                lines.append(' * Supported:')
+                lines.append(' *   - %s' % ('\n *   - '.join(sup_paths)))
 
             lines.extend([
                 ' */',

--- a/scripts/gen_handles.py
+++ b/scripts/gen_handles.py
@@ -294,10 +294,11 @@ def main():
                         dep_paths.append(dn.path)
                     else:
                         dep_paths.append('(%s)' % dn.path)
+            # Force separator to signal start of injected dependencies
+            hdls.append(DEVICE_HANDLE_SEP)
             if len(hs.ext_deps) > 0:
                 # TODO: map these to something smaller?
                 ext_paths.extend(map(str, hs.ext_deps))
-                hdls.append(DEVICE_HANDLE_SEP)
                 hdls.extend(hs.ext_deps)
 
             # When CONFIG_USERSPACE is enabled the pre-built elf is

--- a/tests/lib/devicetree/devices/src/main.c
+++ b/tests/lib/devicetree/devices/src/main.c
@@ -74,15 +74,15 @@ static bool check_handle(device_handle_t hdl,
 	return false;
 }
 
-struct requires_context {
+struct visitor_context {
 	uint8_t ndevs;
 	const struct device *rdevs[2];
 };
 
-static int requires_visitor(const struct device *dev,
-			    void *context)
+static int device_visitor(const struct device *dev,
+			  void *context)
 {
-	struct requires_context *ctx = context;
+	struct visitor_context *ctx = context;
 	const struct device **rdp = ctx->rdevs;
 
 	while (rdp < (ctx->rdevs + ctx->ndevs)) {
@@ -102,14 +102,14 @@ static void test_requires(void)
 	size_t nhdls = 0;
 	const device_handle_t *hdls;
 	const struct device *dev;
-	struct requires_context ctx = { 0 };
+	struct visitor_context ctx = { 0 };
 
 	/* TEST_GPIO: no req */
 	dev = device_get_binding(DT_LABEL(TEST_GPIO));
 	zassert_equal(dev, DEVICE_DT_GET(TEST_GPIO), NULL);
 	hdls = device_required_handles_get(dev, &nhdls);
 	zassert_equal(nhdls, 0, NULL);
-	zassert_equal(0, device_required_foreach(dev, requires_visitor, &ctx),
+	zassert_equal(0, device_required_foreach(dev, device_visitor, &ctx),
 		      NULL);
 
 	/* TEST_I2C: no req */
@@ -117,7 +117,7 @@ static void test_requires(void)
 	zassert_equal(dev, DEVICE_DT_GET(TEST_I2C), NULL);
 	hdls = device_required_handles_get(dev, &nhdls);
 	zassert_equal(nhdls, 0, NULL);
-	zassert_equal(0, device_required_foreach(dev, requires_visitor, &ctx),
+	zassert_equal(0, device_required_foreach(dev, device_visitor, &ctx),
 		      NULL);
 
 	/* TEST_DEVA: TEST_I2C GPIO */
@@ -129,23 +129,23 @@ static void test_requires(void)
 	zassert_true(check_handle(DEV_HDL(TEST_GPIO), hdls, nhdls), NULL);
 
 	/* Visit fails if not enough space */
-	ctx = (struct requires_context){
+	ctx = (struct visitor_context){
 		.ndevs = 1,
 	};
-	zassert_equal(-ENOSPC, device_required_foreach(dev, requires_visitor, &ctx),
+	zassert_equal(-ENOSPC, device_required_foreach(dev, device_visitor, &ctx),
 		      NULL);
 
 	/* Visit succeeds if enough space. */
-	ctx = (struct requires_context){
+	ctx = (struct visitor_context){
 		.ndevs = 2,
 	};
-	zassert_equal(2, device_required_foreach(dev, requires_visitor, &ctx),
+	zassert_equal(2, device_required_foreach(dev, device_visitor, &ctx),
 		      NULL);
 	zassert_true((ctx.rdevs[0] == device_from_handle(DEV_HDL(TEST_I2C)))
-		      || (ctx.rdevs[1] == device_from_handle(DEV_HDL(TEST_I2C))),
+		     || (ctx.rdevs[1] == device_from_handle(DEV_HDL(TEST_I2C))),
 		     NULL);
 	zassert_true((ctx.rdevs[0] == device_from_handle(DEV_HDL(TEST_GPIO)))
-		      || (ctx.rdevs[1] == device_from_handle(DEV_HDL(TEST_GPIO))),
+		     || (ctx.rdevs[1] == device_from_handle(DEV_HDL(TEST_GPIO))),
 		     NULL);
 
 	/* TEST_GPIOX: TEST_I2C */
@@ -154,10 +154,10 @@ static void test_requires(void)
 	hdls = device_required_handles_get(dev, &nhdls);
 	zassert_equal(nhdls, 1, NULL);
 	zassert_true(check_handle(DEV_HDL(TEST_I2C), hdls, nhdls), NULL);
-	ctx = (struct requires_context){
+	ctx = (struct visitor_context){
 		.ndevs = 3,
 	};
-	zassert_equal(1, device_required_foreach(dev, requires_visitor, &ctx),
+	zassert_equal(1, device_required_foreach(dev, device_visitor, &ctx),
 		      NULL);
 	zassert_true(ctx.rdevs[0] == device_from_handle(DEV_HDL(TEST_I2C)),
 		     NULL);
@@ -171,6 +171,46 @@ static void test_requires(void)
 	zassert_true(check_handle(DEV_HDL(TEST_GPIOX), hdls, nhdls), NULL);
 }
 
+static void test_supports(void)
+{
+	size_t nhdls = 0;
+	const device_handle_t *hdls;
+	const struct device *dev;
+	struct visitor_context ctx = { 0 };
+
+	/* TEST_DEVB: None */
+	dev = DEVICE_DT_GET(TEST_DEVB);
+	hdls = device_supported_handles_get(dev, &nhdls);
+	zassert_equal(nhdls, 0, NULL);
+
+	/* TEST_GPIO: TEST_DEVA */
+	dev = DEVICE_DT_GET(TEST_GPIO);
+	hdls = device_supported_handles_get(dev, &nhdls);
+	zassert_equal(nhdls, 1, NULL);
+	zassert_true(check_handle(DEV_HDL(TEST_DEVA), hdls, nhdls), NULL);
+
+	/* Visit fails if not enough space */
+	ctx = (struct visitor_context){
+		.ndevs = 0,
+	};
+	zassert_equal(-ENOSPC, device_supported_foreach(dev, device_visitor, &ctx), NULL);
+
+	/* Visit succeeds if enough space. */
+	ctx = (struct visitor_context){
+		.ndevs = 1,
+	};
+	zassert_equal(1, device_supported_foreach(dev, device_visitor, &ctx), NULL);
+	zassert_true(ctx.rdevs[0] == device_from_handle(DEV_HDL(TEST_DEVA)), NULL);
+
+	/* TEST_I2C: TEST_DEVA TEST_GPIOX TEST_DEVB */
+	dev = DEVICE_DT_GET(TEST_I2C);
+	hdls = device_supported_handles_get(dev, &nhdls);
+	zassert_equal(nhdls, 3, NULL);
+	zassert_true(check_handle(DEV_HDL(TEST_DEVA), hdls, nhdls), NULL);
+	zassert_true(check_handle(DEV_HDL(TEST_GPIOX), hdls, nhdls), NULL);
+	zassert_true(check_handle(DEV_HDL(TEST_DEVB), hdls, nhdls), NULL);
+}
+
 void test_main(void)
 {
 	size_t ndevs;
@@ -180,7 +220,8 @@ void test_main(void)
 
 	ztest_test_suite(devicetree_driver,
 			 ztest_unit_test(test_init_order),
-			 ztest_unit_test(test_requires)
-		);
+			 ztest_unit_test(test_requires),
+			 ztest_unit_test(test_supports)
+			 );
 	ztest_run_test_suite(devicetree_driver);
 }


### PR DESCRIPTION
Implements an API to iterate over devicetree devices that an arbitrary device supports.
Follows the conventions setup by the dependent devices API.

Includes a minor optimization to the handles array (saves one handle per array), which offsets the cost of the additional `DEVICE_HANDLE_SEP`. Therefore the ROM increase is purely a function of the number of supported devices per device (2 bytes per).

Implements #37793.