### PR TITLE
Bluetooth: controller: fixing error re. conn param req ack/req

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -3537,8 +3537,10 @@ static inline void event_conn_param_rsp(struct ll_conn *conn)
 
 	ctrl_tx_enqueue(conn, tx);
 
-	/* procedure request acked */
-	conn->llcp_conn_param.ack = conn->llcp_conn_param.req;
+	/* Wait for connection update to be initiated by
+	 * peer central device
+	 */
+	conn->llcp_conn_param.state = LLCP_CPR_STATE_UPD_WAIT;
 }
 
 static inline void event_conn_param_app_req(struct ll_conn *conn)
@@ -3608,6 +3610,7 @@ static inline void event_conn_param_prep(struct ll_conn *conn,
 
 	case LLCP_CPR_STATE_APP_WAIT:
 	case LLCP_CPR_STATE_RSP_WAIT:
+	case LLCP_CPR_STATE_UPD_WAIT:
 	case LLCP_CPR_STATE_UPD:
 		/* Do nothing */
 		break;
@@ -4335,7 +4338,8 @@ static uint8_t conn_upd_recv(struct ll_conn *conn, memq_link_t *link,
 
 #if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
 	if ((conn->llcp_conn_param.req != conn->llcp_conn_param.ack) &&
-	    (conn->llcp_conn_param.state == LLCP_CPR_STATE_RSP_WAIT)) {
+	    ((conn->llcp_conn_param.state == LLCP_CPR_STATE_RSP_WAIT) ||
+	     (conn->llcp_conn_param.state == LLCP_CPR_STATE_UPD_WAIT))) {
 		conn->llcp_conn_param.ack = conn->llcp_conn_param.req;
 	}
 #endif /* CONFIG_BT_CTLR_CONN_PARAM_REQ */

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
@@ -229,10 +229,11 @@ struct ll_conn {
 			LLCP_CPR_STATE_APP_REQ,
 			LLCP_CPR_STATE_APP_WAIT,
 			LLCP_CPR_STATE_RSP_WAIT,
+			LLCP_CPR_STATE_UPD_WAIT,
 			LLCP_CPR_STATE_UPD,
 			LLCP_CPR_STATE_OFFS_REQ,
 			LLCP_CPR_STATE_OFFS_RDY,
-		} state:3 __packed;
+		} state:4 __packed;
 		uint8_t  cmd:1;
 		uint8_t  disabled:1;
 		uint8_t  status;


### PR DESCRIPTION
During testing towards Samsung S9, we have seen instances where we as peripheral would send a PHY request during an ongoing conn param req, and it was found that this was due to a bug in handling of conn param req on our part.

llcp.conn_param.ack was reset on tx of conn param rsp, however this
should only be done once the expected conn update ind is received
and sets the cu.ack flag to indicate cu procedure 'takes over'
