### PR TITLE
drivers: lora: sx12xx: fix atomic include

### DIFF
--- a/drivers/lora/sx12xx_common.c
+++ b/drivers/lora/sx12xx_common.c
@@ -8,7 +8,7 @@
 #include <drivers/gpio.h>
 #include <drivers/lora.h>
 #include <logging/log.h>
-#include <sys/atomic_builtin.h>
+#include <sys/atomic.h>
 #include <zephyr.h>
 
 /* LoRaMac-node specific includes */


### PR DESCRIPTION
Include sys/atomic.h instead of sys/atomic_builtin.h, so that build for
platforms with non-default atomic implementation will still succeed.

Fixes: #37839