### PR TITLE
doc: gsg: re-add missing dtc-msys2

### DIFF
--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -163,7 +163,7 @@ The current minimum required version for the main dependencies are:
          .. code-block:: console
 
             choco install cmake --installargs 'ADD_CMAKE_TO_PATH=System'
-            choco install ninja gperf python git
+            choco install ninja gperf python git dtc-msys2
 
       #. Close the window and open a new ``cmd.exe`` window **as a regular user** to continue.
 


### PR DESCRIPTION
It was lost in d5533765ff44b04d5f8b85ce4374ca30fae00aa5

Signed-off-by: Manuel Argüelles <manuel.arguelles@coredumplabs.com>