### PR TITLE
drivers: interrupt_controller: plic is independent of risc-v privileged

### DIFF
--- a/drivers/interrupt_controller/Kconfig
+++ b/drivers/interrupt_controller/Kconfig
@@ -19,8 +19,7 @@ config ARCV2_INTERRUPT_UNIT
 config PLIC
 	bool "Platform Level Interrupt Controller (PLIC)"
 	default y
-	depends on SOC_FAMILY_RISCV_PRIVILEGE
-	select RISCV_HAS_PLIC
+	depends on RISCV_HAS_PLIC
 	select MULTI_LEVEL_INTERRUPTS
 	select 2ND_LEVEL_INTERRUPTS
 	help


### PR DESCRIPTION
The RISC-V Platform-Level Interrupt Controller (PLIC) was moved from the RISC-V Privileged Specification v1.11 to a separate specification (see https://github.com/riscv/riscv-plic-spec).

Reflect this by not automatically enabling the PLIC interrupt controller driver for all RISC-V privileged SoCs, but only for SoCs with the CONFIG_RISCV_HAS_PLIC Kconfig option enabled.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>