### PR TITLE
soc: riscv: privilege: define __soc_handle_irq and soc_interrupt_init() as weak symbols

### DIFF
--- a/soc/riscv/riscv-privilege/common/soc_common_irq.c
+++ b/soc/riscv/riscv-privilege/common/soc_common_irq.c
@@ -90,7 +90,7 @@ int arch_irq_is_enabled(unsigned int irq)
 }
 
 #if defined(CONFIG_RISCV_SOC_INTERRUPT_INIT)
-void soc_interrupt_init(void)
+__weak void soc_interrupt_init(void)
 {
 	/* ensure that all interrupts are disabled */
 	(void)irq_lock();

--- a/soc/riscv/riscv-privilege/common/soc_irq.S
+++ b/soc/riscv/riscv-privilege/common/soc_irq.S
@@ -14,8 +14,11 @@
 #include <linker/sections.h>
 #include <soc.h>
 
-/* exports */
-GTEXT(__soc_handle_irq)
+/*
+ * __soc_handle_irq is defined as .weak to allow re-implementation by
+ * SOCs that do not truly follow the riscv privilege specification.
+ */
+WTEXT(__soc_handle_irq)
 
 /*
  * SOC-specific function to handle pending IRQ number generating the interrupt.
@@ -32,7 +35,7 @@ SECTION_FUNC(exception.other, __soc_handle_irq)
 
 /*
  * __soc_is_irq is defined as .weak to allow re-implementation by
- * SOCs that does not truly follow the riscv privilege specification.
+ * SOCs that do not truly follow the riscv privilege specification.
  */
 WTEXT(__soc_is_irq)
 


### PR DESCRIPTION
Define __soc_handle_irq and soc_interrupt_init() as a weak symbols in the common RISC-V privileged instruction set SoC support.

This allows overriding for SoCs which are not fully compliant with the RISC-V privileged specification.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>