### PR TITLE
drivers: serial: stm32: renable IT RXNE as part of graceful disable

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -977,6 +977,9 @@ static int uart_stm32_async_rx_disable(const struct device *dev)
 	data->rx_next_buffer = NULL;
 	data->rx_next_buffer_len = 0;
 
+	/*when async rx is disabled, enable interruptable instance of uart to function normally*/
+	LL_USART_EnableIT_RXNE(UartInstance);
+
 	LOG_DBG("rx: disabled");
 
 	async_user_callback(data, &disabled_event);


### PR DESCRIPTION
async_rx_disable does not re-enable RXNE interrupt, it was disabled
during enable

Signed-off-by: Manojkumar Subramaniam <manoj@electrolance.com>