### PR TITLE
logging: fs: Remove littlefs dependency

### DIFF
--- a/subsys/logging/CMakeLists.txt
+++ b/subsys/logging/CMakeLists.txt
@@ -26,8 +26,6 @@ if(NOT CONFIG_LOG_MINIMAL)
     log_backend_fs.c
   )
 
-  zephyr_link_libraries_ifdef(CONFIG_LOG_BACKEND_FS LITTLEFS)
-
   zephyr_sources_ifdef(
     CONFIG_LOG_CMDS
     log_cmds.c

--- a/subsys/logging/Kconfig.backends
+++ b/subsys/logging/Kconfig.backends
@@ -298,10 +298,13 @@ config LOG_BACKEND_ADSP
 	  family of audio processors
 
 config LOG_BACKEND_FS
-	bool "Enable LittleFS backend"
+	bool "Enable file system backend"
 	depends on FILE_SYSTEM
 	help
-	  When enabled backend is using LittleFS to output logs.
+	  When enabled, backend is using the configured file system to output logs.
+	  As the file system must be mounted for the logging to work, it must be
+	  either configured for auto-mount or manually mounted by the application.
+	  Log messages are discarded as long as the file system is not mounted.
 
 if LOG_BACKEND_FS
 


### PR DESCRIPTION
Remove littlefs dependency as FS backend works with any file system as long as
it is (manually or automatically) mounted.

Fixes #36851

Signed-off-by: Markus Fuchs <markus.fuchs@ch.sauter-bc.com>