### PR TITLE
Bluetooth: Controller: Fix return value for unassigned aux context

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -724,7 +724,14 @@ static int isr_rx_pdu(struct lll_scan *lll, struct lll_scan_aux *lll_aux,
 		}
 
 		if (!lll_aux_to_use) {
-			return -ENOBUFS;
+			/* Return -ECHILD, as ULL execution has not yet assigned
+			 * an aux context. This can happen only under LLL
+			 * scheduling where in LLL auxiliary channel PDU
+			 * reception is spawn from LLL primary channel scanning
+			 * and on completion will join back to resume primary
+			 * channel PDU scanning.
+			 */
+			return -ECHILD;
 		}
 
 		/* Always use CSA#2 on secondary channel, we need 2 nodes for conn
@@ -1014,7 +1021,14 @@ static int isr_rx_pdu(struct lll_scan *lll, struct lll_scan_aux *lll_aux,
 			ftr->param = lll;
 			ftr->scan_rsp = lll->lll_aux->state;
 		} else {
-			return -ECANCELED;
+			/* Return -ECHILD, as ULL execution has not yet assigned
+			 * an aux context. This can happen only under LLL
+			 * scheduling where in LLL auxiliary channel PDU
+			 * reception is spawn from LLL primary channel scanning
+			 * and on completion will join back to resume primary
+			 * channel PDU scanning.
+			 */
+			return -ECHILD;
 		}
 
 		/* Allocate before `lll_scan_aux_setup` call, so that a new


### PR DESCRIPTION
Fix the return value use to indicate unassigned auxiliary
context when scanning is using LLL scheduling. This can
happen only under LLL scheduling where in LLL auxiliary
channel PDU reception has been spawn from LLL primary
channel scanning and on completion will join back to resume
primary channel PDU scanning.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>