### PR TITLE
Bluetooth: Controller: Remove memcpy of SCAN_REQ and CONN_REQ PDUs

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -303,6 +303,9 @@ struct node_rx_iso_meta {
 	uint8_t  status;              /* Status of reception (OK/not OK) */
 };
 
+/* Define invalid/unassigned Controller state/role instance handle */
+#define NODE_RX_HANDLE_INVALID 0xFFFF
+
 /* Header of node_rx_pdu */
 struct node_rx_hdr {
 	union {

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -624,8 +624,6 @@ int lll_adv_scan_req_report(struct lll_adv *lll, struct pdu_adv *pdu_adv_rx,
 			    uint8_t rl_idx, uint8_t rssi_ready)
 {
 	struct node_rx_pdu *node_rx;
-	struct pdu_adv *pdu_adv;
-	uint8_t pdu_len;
 
 	node_rx = ull_pdu_rx_alloc_peek(3);
 	if (!node_rx) {
@@ -636,13 +634,6 @@ int lll_adv_scan_req_report(struct lll_adv *lll, struct pdu_adv *pdu_adv_rx,
 	/* Prepare the report (scan req) */
 	node_rx->hdr.type = NODE_RX_TYPE_SCAN_REQ;
 	node_rx->hdr.handle = ull_adv_lll_handle_get(lll);
-
-	/* Make a copy of PDU into Rx node (as the received PDU is in the
-	 * scratch buffer), and save the RSSI value.
-	 */
-	pdu_adv = (void *)node_rx->pdu;
-	pdu_len = offsetof(struct pdu_adv, payload) + pdu_adv_rx->len;
-	memcpy(pdu_adv, pdu_adv_rx, pdu_len);
 
 	node_rx->hdr.rx_ftr.rssi = (rssi_ready) ? radio_rssi_get() :
 						  BT_HCI_LE_RSSI_NOT_AVAILABLE;
@@ -999,14 +990,15 @@ static void abort_cb(struct lll_prepare_param *prepare_param, void *param)
 
 static void isr_tx(void *param)
 {
-	uint32_t hcto;
 	struct node_rx_pdu *node_rx_prof;
+	struct node_rx_pdu *node_rx;
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 	struct lll_adv *lll = param;
 	uint8_t phy_p = lll->phy_p;
 #else
 	uint8_t phy_p = 0;
 #endif
+	uint32_t hcto;
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
 		lll_prof_latency_capture();
@@ -1020,7 +1012,11 @@ static void isr_tx(void *param)
 	radio_tmr_tifs_set(EVENT_IFS_US);
 	radio_switch_complete_and_tx(phy_p, 0, phy_p, 0);
 
-	radio_pkt_rx_set(radio_pkt_scratch_get());
+	/* setup Rx buffer */
+	node_rx = ull_pdu_rx_alloc_peek(1);
+	LL_ASSERT(node_rx);
+	radio_pkt_rx_set(node_rx->pdu);
+
 	/* assert if radio packet ptr is not set and radio started rx */
 	LL_ASSERT(!radio_is_ready());
 
@@ -1310,6 +1306,7 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 			     uint8_t irkmatch_ok, uint8_t irkmatch_id,
 			     uint8_t rssi_ready)
 {
+	struct node_rx_pdu *node_rx;
 	struct pdu_adv *pdu_adv;
 	struct pdu_adv *pdu_rx;
 	uint8_t tx_addr;
@@ -1325,7 +1322,10 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 	uint8_t rl_idx = FILTER_IDX_NONE;
 #endif /* CONFIG_BT_CTLR_PRIVACY */
 
-	pdu_rx = (void *)radio_pkt_scratch_get();
+	node_rx = ull_pdu_rx_alloc_peek(1);
+	LL_ASSERT(node_rx);
+
+	pdu_rx = (void *)node_rx->pdu;
 	pdu_adv = lll_adv_data_curr_get(lll);
 
 	addr = pdu_adv->adv_ind.addr;
@@ -1438,9 +1438,6 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 
 		rx->hdr.type = NODE_RX_TYPE_CONNECTION;
 		rx->hdr.handle = 0xffff;
-
-		memcpy(rx->pdu, pdu_rx, (offsetof(struct pdu_adv, connect_ind) +
-					 sizeof(struct pdu_adv_connect_ind)));
 
 		ftr = &(rx->hdr.rx_ftr);
 		ftr->param = lll;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -1000,6 +1000,7 @@ static void abort_cb(struct lll_prepare_param *prepare_param, void *param)
 static void isr_tx(void *param)
 {
 	uint32_t hcto;
+	struct node_rx_pdu *node_rx_prof;
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 	struct lll_adv *lll = param;
 	uint8_t phy_p = lll->phy_p;
@@ -1009,6 +1010,7 @@ static void isr_tx(void *param)
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
 		lll_prof_latency_capture();
+		node_rx_prof = lll_prof_reserve();
 	}
 
 	/* Clear radio tx status and events */
@@ -1071,7 +1073,7 @@ static void isr_tx(void *param)
 		/* NOTE: as scratch packet is used to receive, it is safe to
 		 * generate profile event using rx nodes.
 		 */
-		lll_prof_send();
+		lll_prof_reserve_send(node_rx_prof);
 	}
 }
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -362,12 +362,14 @@ static void isr_done(void *param)
 
 static void isr_tx(void *param)
 {
+	struct node_rx_pdu *node_rx_prof;
 	struct lll_adv_aux *lll_aux;
 	struct lll_adv *lll;
 	uint32_t hcto;
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
 		lll_prof_latency_capture();
+		node_rx_prof = lll_prof_reserve();
 	}
 
 	/* Clear radio tx status and events */
@@ -430,10 +432,7 @@ static void isr_tx(void *param)
 #endif /* CONFIG_BT_CTLR_GPIO_LNA_PIN */
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
-		/* NOTE: as scratch packet is used to receive, it is safe to
-		 * generate profile event using rx nodes.
-		 */
-		lll_prof_send();
+		lll_prof_reserve_send(node_rx_prof);
 	}
 }
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -43,13 +43,6 @@
 #include "common/log.h"
 #include "hal/debug.h"
 
-static uint8_t lll_adv_connect_rsp_pdu[PDU_AC_LL_HEADER_SIZE +
-				       offsetof(struct pdu_adv_com_ext_adv,
-						ext_hdr_adv_data) +
-				       offsetof(struct pdu_adv_ext_hdr,
-						data) +
-				       ADVA_SIZE + TARGETA_SIZE];
-
 static int init_reset(void);
 static int prepare_cb(struct lll_prepare_param *p);
 static void isr_done(void *param);
@@ -60,86 +53,13 @@ static inline int isr_rx_pdu(struct lll_adv_aux *lll_aux,
 			     uint8_t irkmatch_ok, uint8_t irkmatch_id,
 			     uint8_t rssi_ready);
 #if defined(CONFIG_BT_PERIPHERAL)
+static struct pdu_adv *init_connect_rsp_pdu(struct pdu_adv *pdu_ci);
 static void isr_tx_connect_rsp(void *param);
-#endif /* CONFIG_BT_PERIPHERAL */
-
-static struct pdu_adv *init_connect_rsp_pdu(void)
-{
-	struct pdu_adv_com_ext_adv *com_hdr;
-	struct pdu_adv_ext_hdr *hdr;
-	struct pdu_adv *pdu;
-	uint8_t ext_hdr_len;
-	uint8_t *dptr;
-
-	pdu = (void *)lll_adv_connect_rsp_pdu;
-	pdu->type = PDU_ADV_TYPE_AUX_CONNECT_RSP;
-	pdu->rfu = 0;
-	pdu->chan_sel = 0;
-	pdu->tx_addr = 0;
-	pdu->rx_addr = 0;
-	pdu->len = 0;
-
-	com_hdr = &pdu->adv_ext_ind;
-	hdr = &com_hdr->ext_hdr;
-	dptr = (void *)hdr;
-
-	/* Flags */
-	*dptr = 0;
-	hdr->adv_addr = 1;
-	hdr->tgt_addr = 1;
-	dptr++;
-
-	/* Note: AdvA and InitA are updated before transmitting PDU */
-
-	/* AdvA */
-	dptr += BDADDR_SIZE;
-	/* InitA */
-	dptr += BDADDR_SIZE;
-
-	ext_hdr_len = dptr - (uint8_t *)&com_hdr->ext_hdr;
-
-	/* Finish Common ExtAdv Payload header */
-	com_hdr->adv_mode = 0;
-	com_hdr->ext_hdr_len = ext_hdr_len;
-
-	/* Finish PDU */
-	pdu->len = dptr - &pdu->payload[0];
-
-	return pdu;
-}
-
-#if defined(CONFIG_BT_PERIPHERAL)
-static struct pdu_adv *update_connect_rsp_pdu(struct pdu_adv *pdu_ci)
-{
-	struct pdu_adv_com_ext_adv *cr_com_hdr;
-	struct pdu_adv_ext_hdr *cr_hdr;
-	struct pdu_adv *pdu_cr;
-	uint8_t *cr_dptr;
-
-	pdu_cr = (void *)lll_adv_connect_rsp_pdu;
-	pdu_cr->tx_addr = pdu_ci->rx_addr;
-	pdu_cr->rx_addr = pdu_ci->tx_addr;
-
-	cr_com_hdr = &pdu_cr->adv_ext_ind;
-	cr_hdr = &cr_com_hdr->ext_hdr;
-	/* Skip flags */
-	cr_dptr = cr_hdr->data;
-
-	/* AdvA */
-	memcpy(cr_dptr, &pdu_ci->connect_ind.adv_addr, BDADDR_SIZE);
-	cr_dptr += BDADDR_SIZE;
-	/* InitA */
-	memcpy(cr_dptr, &pdu_ci->connect_ind.init_addr, BDADDR_SIZE);
-
-	return pdu_cr;
-}
 #endif /* CONFIG_BT_PERIPHERAL */
 
 int lll_adv_aux_init(void)
 {
 	int err;
-
-	init_connect_rsp_pdu();
 
 	err = init_reset();
 	if (err) {
@@ -363,6 +283,7 @@ static void isr_done(void *param)
 static void isr_tx(void *param)
 {
 	struct node_rx_pdu *node_rx_prof;
+	struct node_rx_pdu *node_rx;
 	struct lll_adv_aux *lll_aux;
 	struct lll_adv *lll;
 	uint32_t hcto;
@@ -382,7 +303,11 @@ static void isr_tx(void *param)
 	radio_tmr_tifs_set(EVENT_IFS_US);
 	radio_switch_complete_and_tx(lll->phy_s, 0, lll->phy_s, 1);
 
-	radio_pkt_rx_set(radio_pkt_scratch_get());
+	/* setup Rx buffer */
+	node_rx = ull_pdu_rx_alloc_peek(1);
+	LL_ASSERT(node_rx);
+	radio_pkt_rx_set(node_rx->pdu);
+
 	/* assert if radio packet ptr is not set and radio started rx */
 	LL_ASSERT(!radio_is_ready());
 
@@ -496,6 +421,7 @@ static inline int isr_rx_pdu(struct lll_adv_aux *lll_aux,
 			     uint8_t irkmatch_ok, uint8_t irkmatch_id,
 			     uint8_t rssi_ready)
 {
+	struct node_rx_pdu *node_rx;
 	struct pdu_adv_ext_hdr *hdr;
 	struct pdu_adv *pdu_adv;
 	struct pdu_adv *pdu_aux;
@@ -517,7 +443,10 @@ static inline int isr_rx_pdu(struct lll_adv_aux *lll_aux,
 
 	lll = lll_aux->adv;
 
-	pdu_rx = (void *)radio_pkt_scratch_get();
+	node_rx = ull_pdu_rx_alloc_peek(1);
+	LL_ASSERT(node_rx);
+
+	pdu_rx = (void *)node_rx->pdu;
 	pdu_adv = lll_adv_data_curr_get(lll);
 	pdu_aux = lll_adv_aux_data_latest_get(lll_aux, &upd);
 	LL_ASSERT(pdu_aux);
@@ -605,7 +534,7 @@ static inline int isr_rx_pdu(struct lll_adv_aux *lll_aux,
 		 * are done */
 		radio_isr_set(isr_tx_connect_rsp, rx);
 		radio_switch_complete_and_disable();
-		pdu_tx = update_connect_rsp_pdu(pdu_rx);
+		pdu_tx = init_connect_rsp_pdu(pdu_rx);
 		radio_pkt_tx_set(pdu_tx);
 
 		/* assert if radio packet ptr is not set and radio started tx */
@@ -637,8 +566,6 @@ static inline int isr_rx_pdu(struct lll_adv_aux *lll_aux,
 		rx->hdr.type = NODE_RX_TYPE_CONNECTION;
 		rx->hdr.handle = 0xffff;
 
-		memcpy(rx->pdu, pdu_rx, (offsetof(struct pdu_adv, connect_ind) +
-					 sizeof(struct pdu_adv_connect_ind)));
 		ftr = &(rx->hdr.rx_ftr);
 		ftr->param = lll;
 		ftr->ticks_anchor = radio_tmr_start_get();
@@ -661,6 +588,49 @@ static inline int isr_rx_pdu(struct lll_adv_aux *lll_aux,
 }
 
 #if defined(CONFIG_BT_PERIPHERAL)
+static struct pdu_adv *init_connect_rsp_pdu(struct pdu_adv *pdu_ci)
+{
+	struct pdu_adv_com_ext_adv *cr_com_hdr;
+	struct pdu_adv_ext_hdr *cr_hdr;
+	struct pdu_adv *pdu_cr;
+	uint8_t *cr_dptr;
+
+	pdu_cr = radio_pkt_scratch_get();
+	pdu_cr->type = PDU_ADV_TYPE_AUX_CONNECT_RSP;
+	pdu_cr->rfu = 0;
+	pdu_cr->chan_sel = 0;
+	pdu_cr->tx_addr = pdu_ci->rx_addr;
+	pdu_cr->rx_addr = pdu_ci->tx_addr;
+
+	/* Common Extended Header Format Advertising Mode */
+	cr_com_hdr = &pdu_cr->adv_ext_ind;
+	cr_com_hdr->adv_mode = 0;
+
+	/* Clear Flags */
+	cr_hdr = &cr_com_hdr->ext_hdr;
+	cr_dptr = (void *)cr_hdr;
+	*cr_dptr = 0;
+	cr_dptr = cr_hdr->data;
+
+	/* AdvA */
+	cr_hdr->adv_addr = 1;
+	memcpy(cr_dptr, &pdu_ci->connect_ind.adv_addr, BDADDR_SIZE);
+	cr_dptr += BDADDR_SIZE;
+
+	/* InitA */
+	cr_hdr->tgt_addr = 1;
+	memcpy(cr_dptr, &pdu_ci->connect_ind.init_addr, BDADDR_SIZE);
+	cr_dptr += BDADDR_SIZE;
+
+	/* Common Extended Header Length */
+	cr_com_hdr->ext_hdr_len = cr_dptr - (uint8_t *)&cr_com_hdr->ext_hdr;
+
+	/* PDU length */
+	pdu_cr->len = cr_dptr - &pdu_cr->payload[0];
+
+	return pdu_cr;
+}
+
 static void isr_tx_connect_rsp(void *param)
 {
 	struct node_rx_ftr *ftr;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_prof_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_prof_internal.h
@@ -28,3 +28,5 @@ void lll_prof_latency_capture(void);
 void lll_prof_radio_end_backup(void);
 void lll_prof_cputime_capture(void);
 void lll_prof_send(void);
+struct node_rx_pdu *lll_prof_reserve(void);
+void lll_prof_reserve_send(struct node_rx_pdu *rx);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -41,11 +41,6 @@
 #include <ull_scan_types.h>
 #include "hal/debug.h"
 
-#if defined(CONFIG_BT_CENTRAL)
-static uint8_t lll_scan_connect_req_pdu[PDU_AC_LL_HEADER_SIZE +
-					sizeof(struct pdu_adv_connect_ind)];
-#endif /* CONFIG_BT_CENTRAL */
-
 static int init_reset(void);
 static int prepare_cb(struct lll_prepare_param *p);
 static void abort_cb(struct lll_prepare_param *prepare_param, void *param);
@@ -779,7 +774,7 @@ static int isr_rx_pdu(struct lll_scan *lll, struct lll_scan_aux *lll_aux,
 			init_addr = lll->init_addr;
 		}
 
-		pdu_tx = (void *)lll_scan_connect_req_pdu;
+		pdu_tx = radio_pkt_scratch_get();
 
 		lll_scan_prepare_connect_req(lll, pdu_tx, phy_aux,
 					     pdu->tx_addr,
@@ -1144,10 +1139,12 @@ static void isr_tx_scan_req_lll_schedule(void *param)
 #if defined(CONFIG_BT_CENTRAL)
 static void isr_tx_connect_req(void *param)
 {
-	void *pdu_rx;
+	struct node_rx_pdu *node_rx;
 
-	pdu_rx = radio_pkt_scratch_get();
-	isr_tx(param, pdu_rx, isr_rx_connect_rsp, param);
+	node_rx = ull_pdu_rx_alloc_peek(1);
+	LL_ASSERT(node_rx);
+
+	isr_tx(param, (void *)node_rx->pdu, isr_rx_connect_rsp, param);
 }
 
 static void isr_rx_connect_rsp(void *param)
@@ -1204,10 +1201,17 @@ static void isr_rx_connect_rsp(void *param)
 
 	/* Check for PDU reception */
 	if (trx_done && crc_ok) {
-		pdu_rx = radio_pkt_scratch_get();
-		trx_done = isr_rx_connect_rsp_check(lll,
-				(void *)lll_scan_connect_req_pdu, pdu_rx,
-				rl_idx);
+		struct node_rx_pdu *node_rx;
+		struct pdu_adv *pdu_tx;
+
+		pdu_tx = radio_pkt_scratch_get();
+
+		node_rx = ull_pdu_rx_alloc_peek(1);
+		LL_ASSERT(node_rx);
+		pdu_rx = (void *)node_rx->pdu;
+
+		trx_done = isr_rx_connect_rsp_check(lll, pdu_tx, pdu_rx,
+						    rl_idx);
 	} else {
 		trx_done = 0U;
 	}


### PR DESCRIPTION
Add the lll_prof_reserve and lll_prof_reserve_send profiling
functions to use when profiling active scanning and
initiator.

Removed implementation that used memcpy of received PDUs and
instead using the free Rx buffers; use the scratch PDU for
transmitting scan requests and connection requests.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>