### PR TITLE
fs: fat_fs: Fix fs_statvfs when using variable sector sizes

### DIFF
--- a/subsys/fs/fat_fs.c
+++ b/subsys/fs/fat_fs.c
@@ -393,10 +393,15 @@ static int fatfs_statvfs(struct fs_mount_t *mountp,
 	stat->f_bfree = f_bfree;
 
 	/*
-	 * FF_MIN_SS holds the sector size. It is one of the configuration
-	 * constants used by the FS module
+	 * If FF_MIN_SS and FF_MAX_SS differ, variable sector size support is
+	 * enabled and the file system object structure contains the actual sector
+	 * size, otherwise it is configured to a fixed value give by FF_MIN_SS.
 	 */
+#if FF_MAX_SS != FF_MIN_SS
+	stat->f_bsize = fs->ssize;
+#else
 	stat->f_bsize = FF_MIN_SS;
+#endif
 	stat->f_frsize = fs->csize * stat->f_bsize;
 	stat->f_blocks = (fs->n_fatent - 2);
 


### PR DESCRIPTION
The fs_statvfs function assumes FatFs is configured for a fixed sector
size and therefore may return wrong sector sizes when it is configured
for variable sector sizes instead. Fix that by returning the ssize
variable given in the file system object structure.

Signed-off-by: Markus Fuchs <markus.fuchs@ch.sauter-bc.com>