### PR TITLE
twister: Fix execution of twister in makefile environment

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -2094,6 +2094,13 @@ class CMake():
         p = subprocess.Popen(cmd, **kwargs)
         out, _ = p.communicate()
 
+        # It might happen that the environment adds ANSI escape codes like \x1b[0m,
+        # for instance if twister is executed from inside a makefile. In such a
+        # scenario it is then necessary to remove them, as otherwise the JSON decoding
+        # will fail.
+        ansi_escape = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
+        out = ansi_escape.sub('', out.decode())
+
         if p.returncode == 0:
             msg = "Finished running  %s" % (args[0])
             logger.debug(msg)


### PR DESCRIPTION
When run by a makefile twister might fail to decode the text results of
commands, based upon the environment settings of the system. With this
change escape characters are removed before the string is passed to the
json decoder.

Signed-off-by: Benedikt Schmidt <benedikt.schmidt@embedded-solutions.at>