### PR TITLE
actions: run footprint action in zephyr repo only

### DIFF
--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   footprint-tracking-cancel:
     runs-on: ubuntu-latest
+    if: github.repository == 'zephyrproject-rtos/zephyr'
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.6.0
@@ -23,6 +24,7 @@ jobs:
           access_token: ${{ github.token }}
   footprint-tracking:
     runs-on: ubuntu-latest
+    if: github.repository == 'zephyrproject-rtos/zephyr'
     needs: footprint-tracking-cancel
     container:
       image: zephyrprojectrtos/ci:v0.18.2

--- a/.github/workflows/footprint.yml
+++ b/.github/workflows/footprint.yml
@@ -5,6 +5,7 @@ on: pull_request
 jobs:
   footprint-cancel:
     runs-on: ubuntu-latest
+    if: github.repository == 'zephyrproject-rtos/zephyr'
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.6.0
@@ -12,6 +13,7 @@ jobs:
           access_token: ${{ github.token }}
   footprint-delta:
     runs-on: ubuntu-latest
+    if: github.repository == 'zephyrproject-rtos/zephyr'
     needs: footprint-cancel
     container:
       image: zephyrprojectrtos/ci:v0.18.2


### PR DESCRIPTION
Run footprint actions only on the zephyr repo.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
