### PR TITLE
kwork_q: Fix an undefined behavior in k_work_queue_start

### DIFF
--- a/doc/reference/kernel/threads/workqueue.rst
+++ b/doc/reference/kernel/threads/workqueue.rst
@@ -222,9 +222,11 @@ Defining and Controlling a Workqueue
 ====================================
 
 A workqueue is defined using a variable of type :c:struct:`k_work_q`.
-The workqueue is initialized by defining the stack area used by its thread
-and then calling :c:func:`k_work_queue_start`. The stack area must be defined
-using :c:macro:`K_THREAD_STACK_DEFINE` to ensure it is properly set up in
+The workqueue is initialized by defining the stack area used by its
+thread, initializing the :c:struct:`k_work_q`, either zeroing its
+memory or calling :c:func:`k_work_queue_init`, and then calling
+:c:func:`k_work_queue_start`. The stack area must be defined using
+:c:macro:`K_THREAD_STACK_DEFINE` to ensure it is properly set up in
 memory.
 
 The following code defines and initializes a workqueue:
@@ -237,6 +239,8 @@ The following code defines and initializes a workqueue:
     K_THREAD_STACK_DEFINE(my_stack_area, MY_STACK_SIZE);
 
     struct k_work_q my_work_q;
+
+    k_work_queue_init(&my_work_q);
 
     k_work_queue_start(&my_work_q, my_stack_area,
                        K_THREAD_STACK_SIZEOF(my_stack_area), MY_PRIORITY,

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -3061,7 +3061,9 @@ void k_work_queue_init(struct k_work_q *queue);
  * This configures the work queue thread and starts it running.  The function
  * should not be re-invoked on a queue.
  *
- * @param queue pointer to the queue structure.
+ * @param queue pointer to the queue structure. It must be initialized
+ *        in zeroed/bss memory or with @ref k_work_queue_init before
+ *        use.
  *
  * @param stack pointer to the work thread stack area.
  *

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -3045,6 +3045,17 @@ int k_work_cancel(struct k_work *work);
  */
 bool k_work_cancel_sync(struct k_work *work, struct k_work_sync *sync);
 
+/** @brief Initialize a work queue structure.
+ *
+ * This must be invoked before starting a work queue structure for the first time.
+ * It need not be invoked again on the same work queue structure.
+ *
+ * @funcprops \isr_ok
+ *
+ * @param queue the queue structure to be initialized.
+ */
+void k_work_queue_init(struct k_work_q *queue);
+
 /** @brief Initialize a work queue.
  *
  * This configures the work queue thread and starts it running.  The function

--- a/include/tracing/tracing.h
+++ b/include/tracing/tracing.h
@@ -393,6 +393,12 @@
  */
 
 /**
+ * @brief Trace initialisation of a Work Queue structure
+ * @param queue Work Queue structure
+ */
+#define sys_port_trace_k_work_queue_init(queue)
+
+/**
  * @brief Trace start of a Work Queue call entry
  * @param queue Work Queue structure
  */

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -676,6 +676,17 @@ static void work_queue_main(void *workq_ptr, void *p2, void *p3)
 	}
 }
 
+void k_work_queue_init(struct k_work_q *queue)
+{
+	__ASSERT_NO_MSG(queue != NULL);
+
+	*queue = (struct k_work_q) {
+		.flags = 0,
+	};
+
+	SYS_PORT_TRACING_OBJ_INIT(k_work_queue, queue);
+}
+
 void k_work_queue_start(struct k_work_q *queue,
 			k_thread_stack_t *stack,
 			size_t stack_size,

--- a/subsys/tracing/ctf/tracing_ctf.h
+++ b/subsys/tracing/ctf/tracing_ctf.h
@@ -87,6 +87,7 @@ extern "C" {
 #define sys_port_trace_k_work_cancel_sync_blocking(work, sync)
 #define sys_port_trace_k_work_cancel_sync_exit(work, sync, ret)
 
+#define sys_port_trace_k_work_queue_init(queue)
 #define sys_port_trace_k_work_queue_start_enter(queue)
 #define sys_port_trace_k_work_queue_start_exit(queue)
 #define sys_port_trace_k_work_queue_drain_enter(queue)

--- a/subsys/tracing/sysview/tracing_sysview.h
+++ b/subsys/tracing/sysview/tracing_sysview.h
@@ -133,6 +133,7 @@ extern "C" {
 #define TID_WORK_SUBMIT (99u + TID_OFFSET)
 #define TID_WORK_SUBMIT_TO_QUEUE (100u + TID_OFFSET)
 #define TID_WORK_QUEUE_UNPLUG (101u + TID_OFFSET)
+#define TID_WORK_QUEUE_INIT (102u + TID_OFFSET)
 
 #define TID_FIFO_INIT (110u + TID_OFFSET)
 #define TID_FIFO_CANCEL_WAIT (111u + TID_OFFSET)
@@ -303,6 +304,10 @@ void sys_trace_thread_info(struct k_thread *thread);
 
 #define sys_port_trace_k_work_cancel_sync_exit(work, sync, ret)                                    \
 	SEGGER_SYSVIEW_RecordEndCallU32(TID_WORK_CANCEL_SYNC, (uint32_t)ret)
+
+#define sys_port_trace_k_work_queue_init(queue)             \
+	SEGGER_SYSVIEW_RecordU32(TID_WORK_QUEUE_INIT,       \
+				 (uint32_t)(uintptr_t)queue)
 
 #define sys_port_trace_k_work_queue_start_enter(queue)                                             \
 	SEGGER_SYSVIEW_RecordU32(TID_WORK_QUEUE_START, (uint32_t)(uintptr_t)queue)

--- a/subsys/tracing/test/tracing_test.h
+++ b/subsys/tracing/test/tracing_test.h
@@ -78,6 +78,7 @@
 #define sys_port_trace_k_work_cancel_sync_blocking(work, sync)
 #define sys_port_trace_k_work_cancel_sync_exit(work, sync, ret)
 
+#define sys_port_trace_k_work_queue_init(queue)
 #define sys_port_trace_k_work_queue_start_enter(queue)
 #define sys_port_trace_k_work_queue_start_exit(queue)
 #define sys_port_trace_k_work_queue_drain_enter(queue)


### PR DESCRIPTION
 - The function expects the queue to be zeroed initialized but was not documenting it.