### PR TITLE
boards: arm: Enable watchdog driver on mimxrt1064_evk

### DIFF
--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -17,6 +17,7 @@
 		pwm-led0 = &green_pwm_led;
 		sw0 = &user_button;
 		kscan0 = &touch_controller;
+		watchdog0 = &wdog0;
 	};
 
 	chosen {
@@ -236,4 +237,8 @@ zephyr_udc0: &usb1 {
 &flexcan2 {
 	status = "okay";
 	bus-speed = <125000>;
+};
+
+&wdog0 {
+	status = "okay";
 };

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.yaml
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.yaml
@@ -28,3 +28,4 @@ supported:
   - video
   - kscan:touch
   - can
+  - watchdog


### PR DESCRIPTION
Enables the watchdog driver on the mimxrt1064_evk board. The board
documentation is not updated because it already mentions watchdog driver
support.

Tested with tests/drivers/watchdog/wdt_basic_api

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>