### PR TITLE
boards: arm: Enable dma driver on mimxrt1064_evk

### DIFF
--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -233,6 +233,10 @@ zephyr_udc0: &usb1 {
 	cd-gpios = <&gpio2 28 GPIO_ACTIVE_LOW>;
 };
 
+&edma0 {
+	status = "okay";
+};
+
 &flexcan2 {
 	status = "okay";
 	bus-speed = <125000>;

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.yaml
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.yaml
@@ -19,6 +19,7 @@ supported:
   - arduino_serial
   - counter
   - display
+  - dma
   - gpio
   - i2c
   - netif:eth

--- a/tests/drivers/dma/chan_link_transfer/testcase.yaml
+++ b/tests/drivers/dma/chan_link_transfer/testcase.yaml
@@ -3,11 +3,11 @@ tests:
     min_ram: 16
     depends_on: dma
     tags: drivers dma
-    platform_allow: frdm_k64f mimxrt1060_evk
+    platform_allow: frdm_k64f mimxrt1060_evk mimxrt1064_evk
   drivers.dma.interactive:
     depends_on: dma
     extra_args: CONF_FILE=prj_shell.conf
     min_ram: 16
     tags: drivers dma
     harness: keyboard
-    platform_allow: frdm_k64f mimxrt1060_evk
+    platform_allow: frdm_k64f mimxrt1060_evk mimxrt1064_evk


### PR DESCRIPTION
Enables the dma driver on the mimxrt1064_evk board. The board
documentation is not updated because it already mentions dma driver
support.

Tested with:
  - tests/drivers/dma/chan_blen_transfer
  - tests/drivers/dma/chan_link_transfer
  - tests/drivers/dma/loop_transfer

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>