### PR TITLE
sample: usb: hid-cdc: add a sleep for cpu to response

### DIFF
--- a/samples/subsys/usb/hid-cdc/src/main.c
+++ b/samples/subsys/usb/hid-cdc/src/main.c
@@ -637,6 +637,9 @@ void main(void)
 					   &dtr);
 			if (dtr) {
 				break;
+			} else {
+				/* Give CPU resources to low priority threads. */
+				k_sleep(K_MSEC(100));
 			}
 		}
 


### PR DESCRIPTION
add a sleep while the uart init is fail.
so cpu will have chance to output error message

Signed-off-by: Hake Huang <hake.huang@oss.nxp.com>