### PR TITLE
boards: nucleo_g0b1re: Missing zephyr_udc0 alternate node label

### DIFF
--- a/boards/arm/nucleo_g0b1re/nucleo_g0b1re.dts
+++ b/boards/arm/nucleo_g0b1re/nucleo_g0b1re.dts
@@ -65,7 +65,7 @@
 	apb1-prescaler = <1>;
 };
 
-&usb {
+zephyr_udc0: &usb {
 	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
 	status = "okay";
 };


### PR DESCRIPTION
This board is missing new usb device controller alternate node label.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>