### PR TITLE
Bluetooth: Audio: Add initial server values in bt_vcs_register_param

### DIFF
--- a/include/bluetooth/audio/vcs.h
+++ b/include/bluetooth/audio/vcs.h
@@ -39,11 +39,24 @@ extern "C" {
 #define BT_VCS_ERR_INVALID_COUNTER             0x80
 #define BT_VCS_ERR_OP_NOT_SUPPORTED            0x81
 
+/** Volume Control Service Mute Values */
+#define BT_VCS_STATE_UNMUTED                   0x00
+#define BT_VCS_STATE_MUTED                     0x01
+
 /** @brief Opaque Volume Control Service instance. */
 struct bt_vcs;
 
 /** Register structure for Volume Control Service */
 struct bt_vcs_register_param {
+	/** Initial step size (1-255) */
+	uint8_t step;
+
+	/** Initial mute state (0-1) */
+	uint8_t mute;
+
+	/** Initial volume level (0-255) */
+	uint8_t volume;
+
 	/** Register parameters for Volume Offset Control Services */
 	struct bt_vocs_register_param vocs_param[BT_VCS_VOCS_CNT];
 

--- a/subsys/bluetooth/shell/vcs.c
+++ b/subsys/bluetooth/shell/vcs.c
@@ -193,6 +193,10 @@ static int cmd_vcs_init(const struct shell *sh, size_t argc, char **argv)
 		vcs_param.aics_param[i].cb = &aics_cbs;
 	}
 
+	vcs_param.step = 1;
+	vcs_param.mute = BT_VCS_STATE_UNMUTED;
+	vcs_param.volume = 100;
+
 	vcs_param.cb = &vcs_cbs;
 
 	result = bt_vcs_register(&vcs_param, &vcs);

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_test.c
@@ -474,6 +474,9 @@ static void test_standalone(void)
 		vcs_param.aics_param[i].cb = &aics_cb;
 	}
 
+	vcs_param.step = 1;
+	vcs_param.mute = BT_VCS_STATE_UNMUTED;
+	vcs_param.volume = 100;
 	vcs_param.cb = &vcs_cb;
 
 	err = bt_vcs_register(&vcs_param, &vcs);
@@ -667,6 +670,9 @@ static void test_main(void)
 		vcs_param.aics_param[i].cb = &aics_cb;
 	}
 
+	vcs_param.step = 1;
+	vcs_param.mute = BT_VCS_STATE_UNMUTED;
+	vcs_param.volume = 100;
 	vcs_param.cb = &vcs_cb;
 
 	err = bt_vcs_register(&vcs_param, &vcs);


### PR DESCRIPTION
Add support for setting initial values in bt_vcs_register_param
when registering a VCS service.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

fixes https://github.com/zephyrproject-rtos/zephyr/issues/37386