### PR TITLE
Bluetooth: host: Define recommended per adv constants

### DIFF
--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -807,8 +807,8 @@ struct bt_le_per_adv_param {
 		BT_LE_PER_ADV_PARAM_INIT(_int_min, _int_max, _options) \
 	})
 
-#define BT_LE_PER_ADV_DEFAULT BT_LE_PER_ADV_PARAM(BT_GAP_ADV_SLOW_INT_MIN, \
-						  BT_GAP_ADV_SLOW_INT_MAX, \
+#define BT_LE_PER_ADV_DEFAULT BT_LE_PER_ADV_PARAM(BT_GAP_PER_ADV_SLOW_INT_MIN, \
+						  BT_GAP_PER_ADV_SLOW_INT_MAX, \
 						  BT_LE_PER_ADV_OPT_NONE)
 
 /**

--- a/include/bluetooth/gap.h
+++ b/include/bluetooth/gap.h
@@ -75,6 +75,12 @@ extern "C" {
 #define BT_GAP_ADV_FAST_INT_MAX_2               0x00f0  /* 150 ms   */
 #define BT_GAP_ADV_SLOW_INT_MIN                 0x0640  /* 1 s      */
 #define BT_GAP_ADV_SLOW_INT_MAX                 0x0780  /* 1.2 s    */
+#define BT_GAP_PER_ADV_FAST_INT_MIN_1           0x0018  /* 30 ms    */
+#define BT_GAP_PER_ADV_FAST_INT_MAX_1           0x0030  /* 60 ms    */
+#define BT_GAP_PER_ADV_FAST_INT_MIN_2           0x0050  /* 100 ms   */
+#define BT_GAP_PER_ADV_FAST_INT_MAX_2           0x0078  /* 150 ms   */
+#define BT_GAP_PER_ADV_SLOW_INT_MIN             0x0320  /* 1 s      */
+#define BT_GAP_PER_ADV_SLOW_INT_MAX             0x03C0  /* 1.2 s    */
 #define BT_GAP_INIT_CONN_INT_MIN                0x0018  /* 30 ms    */
 #define BT_GAP_INIT_CONN_INT_MAX                0x0028  /* 50 ms    */
 


### PR DESCRIPTION
These constants are based on (i.e. exactly as) the
recommended values for regular (i.e. non-periodic)
advertising.

The GAP spec does not actually specifiy these numbers (or any
numbers for periodic advertising), but they are sane
numbers to use for periodic advertisement.

The issue with using the non-periodic advertising
whereas the peridic advertising unit is 1.25ms.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

fixes https://github.com/zephyrproject-rtos/zephyr/issues/37790