### PR TITLE
Bluetooth: ISO: Remove use of conn->channels for ISO

### DIFF
--- a/include/bluetooth/iso.h
+++ b/include/bluetooth/iso.h
@@ -64,7 +64,6 @@ struct bt_iso_chan {
 	struct bt_iso_chan_ops		*ops;
 	/** Channel QoS reference */
 	struct bt_iso_chan_qos		*qos;
-	sys_snode_t			node;
 	uint8_t				state;
 	bt_security_t			required_sec_level;
 };

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -99,6 +99,10 @@ struct bt_conn_sco {
 struct bt_conn_iso {
 	/* Reference to ACL Connection */
 	struct bt_conn          *acl;
+
+	/* Reference to the struct bt_iso_chan */
+	struct bt_iso_chan      *chan;
+
 	union {
 		/* CIG ID */
 		uint8_t			cig_id;
@@ -179,7 +183,7 @@ struct bt_conn {
 	/* Queue for outgoing ACL data */
 	struct k_fifo		tx_queue;
 
-	/* Active L2CAP/ISO channels */
+	/* Active L2CAP channels */
 	sys_slist_t		channels;
 
 	/* Delayed work deferred tasks:


### PR DESCRIPTION
The channels list were originally meant to be used
for multiple bt_iso_chan per iso connect (bt_conn), but
that is not the case for the current API, and won't be
going forward, so the use of the list has been removed.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>