### PR TITLE
Clear up ACL/ISO bt_conn naming for ISO 

### DIFF
--- a/include/bluetooth/iso.h
+++ b/include/bluetooth/iso.h
@@ -96,7 +96,7 @@ enum {
 /** @brief ISO Channel structure. */
 struct bt_iso_chan {
 	/** Channel connection reference */
-	struct bt_conn			*conn;
+	struct bt_conn			*iso;
 	/** Channel operations reference */
 	struct bt_iso_chan_ops		*ops;
 	/** Channel QoS reference */
@@ -243,10 +243,10 @@ struct bt_iso_cig_create_param {
 
 struct bt_iso_connect_param {
 	/* The ISO channel to connect */
-	struct bt_iso_chan *iso;
+	struct bt_iso_chan *iso_chan;
 
 	/* The ACL connection */
-	struct bt_conn *conn;
+	struct bt_conn *acl;
 };
 
 /** Opaque type representing an Broadcast Isochronous Group (BIG). */
@@ -444,12 +444,12 @@ struct bt_iso_server {
 	 *  This callback is called whenever a new incoming connection requires
 	 *  authorization.
 	 *
-	 *  @param conn The connection that is requesting authorization
+	 *  @param acl The ACL connection that is requesting authorization
 	 *  @param chan Pointer to receive the allocated channel
 	 *
 	 *  @return 0 in case of success or negative value in case of error.
 	 */
-	int (*accept)(struct bt_conn *conn, struct bt_iso_chan **chan);
+	int (*accept)(struct bt_conn *acl, struct bt_iso_chan **chan);
 };
 
 /** @brief Register ISO server.

--- a/samples/bluetooth/central_iso/src/main.c
+++ b/samples/bluetooth/central_iso/src/main.c
@@ -199,8 +199,8 @@ static void connected(struct bt_conn *conn, uint8_t err)
 		return;
 	}
 
-	connect_param.conn = conn;
-	connect_param.iso = &iso_chan;
+	connect_param.acl = conn;
+	connect_param.iso_chan = &iso_chan;
 
 	iso_err = bt_iso_chan_connect(&connect_param, ARRAY_SIZE(channels));
 

--- a/samples/bluetooth/iso_connected_benchmark/src/main.c
+++ b/samples/bluetooth/iso_connected_benchmark/src/main.c
@@ -272,9 +272,9 @@ static struct bt_iso_chan_ops iso_ops = {
 	.disconnected	= iso_disconnected,
 };
 
-static int iso_accept(struct bt_conn *conn, struct bt_iso_chan **chan)
+static int iso_accept(struct bt_conn *acl, struct bt_iso_chan **chan)
 {
-	LOG_INF("Incoming ISO request");
+	LOG_INF("Incoming ISO request from %p", (void *)acl);
 
 	for (int i = 0; i < ARRAY_SIZE(iso_chans); i++) {
 		if (iso_chans[i].state == BT_ISO_DISCONNECTED) {
@@ -788,8 +788,8 @@ static int central_create_cig(void)
 	LOG_INF("Connecting ISO channels");
 
 	for (int i = 0; i < cig_create_param.num_cis; i++) {
-		connect_param[i].conn = default_conn;
-		connect_param[i].iso = &iso_chans[i];
+		connect_param[i].acl = default_conn;
+		connect_param[i].iso_chan = &iso_chans[i];
 	}
 
 	err = bt_iso_chan_connect(connect_param, cig_create_param.num_cis);

--- a/samples/bluetooth/peripheral_iso/src/main.c
+++ b/samples/bluetooth/peripheral_iso/src/main.c
@@ -125,11 +125,11 @@ static struct bt_iso_chan iso_chan = {
 	.qos = &iso_qos,
 };
 
-static int iso_accept(struct bt_conn *conn, struct bt_iso_chan **chan)
+static int iso_accept(struct bt_conn *acl, struct bt_iso_chan **chan)
 {
-	printk("Incoming conn %p\n", conn);
+	printk("Incoming request from %p\n", (void *)acl);
 
-	if (iso_chan.conn) {
+	if (iso_chan.iso) {
 		printk("No channels available\n");
 		return -ENOMEM;
 	}

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1488,21 +1488,21 @@ static struct bt_conn *conn_lookup_iso(struct bt_conn *conn)
 	int i;
 
 	for (i = 0; i < ARRAY_SIZE(iso_conns); i++) {
-		struct bt_conn *iso_conn = bt_conn_ref(&iso_conns[i]);
+		struct bt_conn *iso = bt_conn_ref(&iso_conns[i]);
 
-		if (!iso_conn) {
+		if (iso == NULL) {
 			continue;
 		}
 
-		if (iso_conn == conn) {
-			return iso_conn;
+		if (iso == conn) {
+			return iso;
 		}
 
-		if (bt_conn_iso(iso_conn)->acl == conn) {
-			return iso_conn;
+		if (iso->iso.acl == conn) {
+			return iso;
 		}
 
-		bt_conn_unref(iso_conn);
+		bt_conn_unref(iso);
 	}
 #endif /* CONFIG_BT_ISO */
 	return NULL;

--- a/subsys/bluetooth/host/iso_internal.h
+++ b/subsys/bluetooth/host/iso_internal.h
@@ -95,13 +95,13 @@ void hci_le_big_sync_established(struct net_buf *buf);
 void hci_le_big_sync_lost(struct net_buf *buf);
 
 /* Notify ISO channels of a new connection */
-int bt_iso_accept(struct bt_conn *conn);
+int bt_iso_accept(struct bt_conn *iso);
 
 /* Notify ISO channels of a new connection */
-void bt_iso_connected(struct bt_conn *conn);
+void bt_iso_connected(struct bt_conn *iso);
 
 /* Notify ISO channels of a disconnect event */
-void bt_iso_disconnected(struct bt_conn *conn);
+void bt_iso_disconnected(struct bt_conn *iso);
 
 /* Allocate ISO PDU */
 #if defined(CONFIG_NET_BUF_LOG)
@@ -154,8 +154,6 @@ void bt_iso_chan_set_state(struct bt_iso_chan *chan, uint8_t state);
 #endif /* CONFIG_BT_DEBUG_ISO */
 
 /* Process incoming data for a connection */
-void bt_iso_recv(struct bt_conn *conn, struct net_buf *buf, uint8_t flags);
+void bt_iso_recv(struct bt_conn *iso, struct net_buf *buf, uint8_t flags);
 
-struct bt_conn_iso *bt_conn_iso(struct bt_conn *conn);
-
-void bt_iso_remove_data_path(struct bt_conn *conn);
+void bt_iso_remove_data_path(struct bt_conn *iso);

--- a/subsys/bluetooth/host/iso_internal.h
+++ b/subsys/bluetooth/host/iso_internal.h
@@ -95,7 +95,7 @@ void hci_le_big_sync_established(struct net_buf *buf);
 void hci_le_big_sync_lost(struct net_buf *buf);
 
 /* Notify ISO channels of a new connection */
-int bt_iso_accept(struct bt_conn *iso);
+int bt_iso_accept(struct bt_conn *acl, struct bt_conn *iso);
 
 /* Notify ISO channels of a new connection */
 void bt_iso_connected(struct bt_conn *iso);

--- a/subsys/bluetooth/shell/iso.c
+++ b/subsys/bluetooth/shell/iso.c
@@ -77,11 +77,11 @@ static struct bt_iso_cig *cig;
 
 NET_BUF_POOL_FIXED_DEFINE(tx_pool, 1, DATA_MTU, NULL);
 
-static int iso_accept(struct bt_conn *conn, struct bt_iso_chan **chan)
+static int iso_accept(struct bt_conn *acl, struct bt_iso_chan **chan)
 {
-	shell_print(ctx_shell, "Incoming conn %p", conn);
+	shell_print(ctx_shell, "Incoming request from %p", acl);
 
-	if (iso_chan.conn) {
+	if (iso_chan.iso) {
 		shell_print(ctx_shell, "No channels available");
 		return -ENOMEM;
 	}
@@ -251,12 +251,12 @@ static int cmd_cig_term(const struct shell *sh, size_t argc, char *argv[])
 static int cmd_connect(const struct shell *sh, size_t argc, char *argv[])
 {
 	struct bt_iso_connect_param connect_param = {
-		.conn = default_conn,
-		.iso = &iso_chan
+		.acl = default_conn,
+		.iso_chan = &iso_chan
 	};
 	int err;
 
-	if (iso_chan.conn == NULL) {
+	if (iso_chan.iso == NULL) {
 		shell_error(sh, "ISO channel not initialized in a CIG");
 		return 0;
 	}
@@ -283,7 +283,7 @@ static int cmd_send(const struct shell *shell, size_t argc, char *argv[])
 		count = strtoul(argv[1], NULL, 10);
 	}
 
-	if (!iso_chan.conn) {
+	if (!iso_chan.iso) {
 		shell_error(shell, "Not bound");
 		return 0;
 	}
@@ -357,7 +357,7 @@ static int cmd_broadcast(const struct shell *shell, size_t argc, char *argv[])
 		count = strtoul(argv[1], NULL, 10);
 	}
 
-	if (!bis_iso_chan.conn) {
+	if (!bis_iso_chan.iso) {
 		shell_error(shell, "BIG not created");
 		return -ENOEXEC;
 	}


### PR DESCRIPTION
The generic name `struct bt_conn *conn` was used too many places, which made it hard to determine if the pointer was an ISO or ACL pointer. 

This PR cleans this up with explicit naming for both the internal or public use. 