### PR TITLE
kernel: Remove unused timeout_q from z_kernel

### DIFF
--- a/include/kernel_structs.h
+++ b/include/kernel_structs.h
@@ -135,11 +135,6 @@ typedef struct _cpu _cpu_t;
 struct z_kernel {
 	struct _cpu cpus[CONFIG_MP_NUM_CPUS];
 
-#ifdef CONFIG_SYS_CLOCK_EXISTS
-	/* queue of timeouts */
-	sys_dlist_t timeout_q;
-#endif
-
 #ifdef CONFIG_PM
 	int32_t idle; /* Number of ticks for kernel idling */
 #endif
@@ -188,8 +183,6 @@ bool z_smp_cpu_mobile(void);
 #define _current_cpu (&_kernel.cpus[0])
 #define _current _kernel.cpus[0].current
 #endif
-
-#define _timeout_q _kernel.timeout_q
 
 /* kernel wait queue record */
 

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -65,14 +65,6 @@ K_KERNEL_PINNED_STACK_ARRAY_DEFINE(z_interrupt_stacks,
 				   CONFIG_MP_NUM_CPUS,
 				   CONFIG_ISR_STACK_SIZE);
 
-#ifdef CONFIG_SYS_CLOCK_EXISTS
-	#define initialize_timeouts() do { \
-		sys_dlist_init(&_timeout_q); \
-	} while (false)
-#else
-	#define initialize_timeouts() do { } while ((0))
-#endif
-
 extern void idle(void *unused1, void *unused2, void *unused3);
 
 
@@ -313,8 +305,6 @@ static char *prepare_multithreading(void)
 			(Z_KERNEL_STACK_BUFFER(z_interrupt_stacks[i]) +
 			 K_KERNEL_STACK_SIZEOF(z_interrupt_stacks[i]));
 	}
-
-	initialize_timeouts();
 
 	return stack_ptr;
 }


### PR DESCRIPTION
This commit removes the `timeout_q` from the `struct z_kernel` since it
is no longer used.

Note that the new kernel timeout implementation introduced in the
commit 987c0e5fc1fa665ce629796c97529f219380e0a7 uses `timeout_list`
global variable in place of it.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>