### PR TITLE
shell: remove Kconfig option CONFIG_UART_SHELL_ON_DEV_NAME

### DIFF
--- a/doc/reference/devicetree/api.rst
+++ b/doc/reference/devicetree/api.rst
@@ -342,7 +342,7 @@ device.
    * - zephyr,ot-uart
      - Used by the OpenThread to specify UART device for Spinel protocol
    * - zephyr,shell-uart
-     - Sets default :kconfig:`CONFIG_UART_SHELL_ON_DEV_NAME`
+     - Sets UART device used by serial shell backend
    * - zephyr,sram
      - A node whose ``reg`` sets the base address and size of SRAM memory
        available to the Zephyr image, used during linking

--- a/doc/releases/release-notes-2.7.rst
+++ b/doc/releases/release-notes-2.7.rst
@@ -54,6 +54,8 @@ Removed APIs in this release
   in favor of direct use of chosen node ``zephyr,uart-mcumgr``.
 * Removed ``CONFIG_UART_CONSOLE_ON_DEV_NAME`` Kconfig option
   in favor of direct use of chosen node ``zephyr,console``.
+* Removed ``CONFIG_UART_SHELL_ON_DEV_NAME`` Kconfig option
+  in favor of direct use of chosen node ``zephyr,shell-uart``.
 
 ============================
 

--- a/samples/subsys/shell/shell_module/sample.yaml
+++ b/samples/subsys/shell/shell_module/sample.yaml
@@ -5,7 +5,7 @@ common:
     - native_posix
 tests:
   sample.shell.shell_module:
-    filter: ( CONFIG_SERIAL and CONFIG_UART_SHELL_ON_DEV_NAME )
+    filter: CONFIG_SERIAL and dt_chosen_enabled("zephyr,shell-uart")
     tags: shell
     harness: keyboard
     min_ram: 40
@@ -17,12 +17,12 @@ tests:
     extra_args: OVERLAY_CONFIG="overlay-usb.conf"
                 DTC_OVERLAY_FILE="usb.overlay"
   sample.shell.shell_module.minimal:
-    filter: ( CONFIG_SERIAL and CONFIG_UART_SHELL_ON_DEV_NAME )
+    filter: CONFIG_SERIAL and dt_chosen_enabled("zephyr,shell-uart")
     tags: shell
     harness: keyboard
     extra_args: CONF_FILE="prj_minimal.conf"
   sample.shell.shell_module.getopt:
-    filter: ( CONFIG_SERIAL and CONFIG_UART_SHELL_ON_DEV_NAME )
+    filter: CONFIG_SERIAL and dt_chosen_enabled("zephyr,shell-uart")
     tags: shell
     harness: keyboard
     min_ram: 40
@@ -33,7 +33,7 @@ tests:
     harness: keyboard
     extra_args: CONF_FILE="prj_minimal_rtt.conf"
   sample.shell.shell_module.login:
-    filter: ( CONFIG_SERIAL and CONFIG_UART_SHELL_ON_DEV_NAME )
+    filter: CONFIG_SERIAL and dt_chosen_enabled("zephyr,shell-uart")
     tags: shell
     harness: keyboard
     min_ram: 40

--- a/samples/subsys/shell/shell_module/src/uart_reinit.c
+++ b/samples/subsys/shell/shell_module/src/uart_reinit.c
@@ -10,8 +10,7 @@
 
 void shell_init_from_work(struct k_work *work)
 {
-	const struct device *dev =
-			device_get_binding(CONFIG_UART_SHELL_ON_DEV_NAME);
+	const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_shell_uart));
 	bool log_backend = CONFIG_SHELL_BACKEND_SERIAL_LOG_LEVEL > 0;
 	uint32_t level =
 		(CONFIG_SHELL_BACKEND_SERIAL_LOG_LEVEL > LOG_LEVEL_DBG) ?
@@ -86,8 +85,7 @@ K_TIMER_DEFINE(uart_poll_timer, uart_poll_timeout, uart_poll_timer_stopped);
 static void shell_uninit_cb(const struct shell *shell, int res)
 {
 	__ASSERT_NO_MSG(res >= 0);
-	const struct device *dev =
-			device_get_binding(CONFIG_UART_SHELL_ON_DEV_NAME);
+	const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_shell_uart));
 
 	if (IS_ENABLED(CONFIG_SHELL_BACKEND_SERIAL_INTERRUPT_DRIVEN)) {
 		/* connect uart to my handler */

--- a/subsys/shell/Kconfig.backends
+++ b/subsys/shell/Kconfig.backends
@@ -35,20 +35,6 @@ config SHELL_PROMPT_UART
 	help
 	  Displayed prompt name for UART backend.
 
-# Workaround for not being able to have commas in macro arguments
-DT_CHOSEN_Z_SHELL_UART := zephyr,shell-uart
-
-config UART_SHELL_ON_DEV_NAME
-	string "Device Name of UART Device for SHELL_BACKEND_SERIAL"
-	default "$(dt_chosen_label,$(DT_CHOSEN_Z_SHELL_UART))" if HAS_DTS
-	default "UART_0"
-	help
-	  This option specifies the name of UART device to be used for the
-	  SHELL UART backend.
-	  In case when DTS is enabled (HAS_DTS), the default value is
-	  set from DTS chosen node 'zephyr,shell-uart' but can be overridden
-	  here.
-
 # Internal config to enable UART interrupts if supported.
 config SHELL_BACKEND_SERIAL_INTERRUPT_DRIVEN
 	bool "Interrupt driven"

--- a/subsys/shell/shell_uart.c
+++ b/subsys/shell/shell_uart.c
@@ -293,14 +293,13 @@ const struct shell_transport_api shell_uart_transport_api = {
 static int enable_shell_uart(const struct device *arg)
 {
 	ARG_UNUSED(arg);
-	const struct device *dev =
-			device_get_binding(CONFIG_UART_SHELL_ON_DEV_NAME);
+	const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_shell_uart));
 	bool log_backend = CONFIG_SHELL_BACKEND_SERIAL_LOG_LEVEL > 0;
 	uint32_t level =
 		(CONFIG_SHELL_BACKEND_SERIAL_LOG_LEVEL > LOG_LEVEL_DBG) ?
 		CONFIG_LOG_MAX_LEVEL : CONFIG_SHELL_BACKEND_SERIAL_LOG_LEVEL;
 
-	if (dev == NULL) {
+	if (!device_is_ready(dev)) {
 		return -ENODEV;
 	}
 


### PR DESCRIPTION
Follow up on commit bfd45e5b8cab
("drivers: remove Kconfig option CONFIG_UART_CONSOLE_ON_DEV_NAME")
Now we can also remove Kconfig option CONFIG_UART_CONSOLE_ON_DEV_NAME
since all UART drivers are converted to devicetree and we can just use
DEVICE_DT_GET(DT_CHOSEN(zephyr_shell_uart)).