### PR TITLE
docs: Improve documentation of bootloader usage

### DIFF
--- a/doc/guides/device_mgmt/dfu.rst
+++ b/doc/guides/device_mgmt/dfu.rst
@@ -36,11 +36,21 @@ In order to use MCUboot with Zephyr you need to take the following into account:
 
 1. You will need to define the flash partitions required by MCUboot; see
    :ref:`flash_map_api` for details.
-2. Your application's :file:`.conf` file needs to enable the
+2. You will have to specify your flash parition as the chosen code partition
+
+.. code-block:: devicetree
+
+   / {
+      chosen {
+         zephyr,code-partition = &slot0_partition;
+      };
+   };
+
+3. Your application's :file:`.conf` file needs to enable the
    :kconfig:`CONFIG_BOOTLOADER_MCUBOOT` Kconfig option in order for Zephyr to
    be built in an MCUboot-compatible manner
-3. You need to build and flash MCUboot itself on your device
-4. You might need to take precautions to avoid mass erasing the flash and also
+4. You need to build and flash MCUboot itself on your device
+5. You might need to take precautions to avoid mass erasing the flash and also
    to flash the Zephyr application image at the correct offset (right after the
    bootloader)
 


### PR DESCRIPTION
Describes the necessity to specify the code partition as the chosen one.

Signed-off-by: Benedikt Schmidt <benedikt.schmidt@embedded-solutions.at>