### PR TITLE
lvgl: specify ram requirement in sample.yaml

### DIFF
--- a/doc/guides/test/twister.rst
+++ b/doc/guides/test/twister.rst
@@ -287,11 +287,11 @@ depends_on: <list of features>
     will enable the test only those platforms that provide this feature.
 
 min_ram: <integer>
-    minimum amount of RAM needed for this test to build and run. This is
+    minimum amount of RAM in KB needed for this test to build and run. This is
     compared with information provided by the board metadata.
 
 min_flash: <integer>
-    minimum amount of ROM needed for this test to build and run. This is
+    minimum amount of ROM in KB needed for this test to build and run. This is
     compared with information provided by the board metadata.
 
 timeout: <number of seconds>

--- a/samples/subsys/display/lvgl/sample.yaml
+++ b/samples/subsys/display/lvgl/sample.yaml
@@ -8,6 +8,9 @@ tests:
     tags: samples display gui
   sample.display.adafruit_2_8_tft_touch_v2:
     depends_on: arduino_gpio arduino_i2c arduino_spi
+    # Default settings end up allocating an ~150KB sized buffer in lvgl.
+    # This adds a bit of buffer to that for other data.
+    min_ram: 175
     platform_exclude: reel_board reel_board_v2 ubx_evkannab1_nrf52832
     extra_args: SHIELD=adafruit_2_8_tft_touch_v2
     tags: shield


### PR DESCRIPTION
Commit c79b1a38aabe26fc0fbc6bd6af0a5453e8aba95a ("samples: display:
Convert driver and lvgl sample.yaml to use depends_on") started using
depends_on in the sample YAML for a lvgl application instead of
platform_allow.

This breaks build testing with twister and overflow checking enabled
on more resource constrained platforms. The test case's .config
ends up with:

```
    CONFIG_LVGL_HOR_RES_MAX=320
    CONFIG_LVGL_VER_RES_MAX=240
    CONFIG_LVGL_VDB_SIZE=64
    CONFIG_LVGL_BITS_PER_PIXEL=24
```

And lib/gui/lvgl/lvgl.c, where we allocate a buffer of size:

```
    (CONFIG_LVGL_BITS_PER_PIXEL *
     ((CONFIG_LVGL_VDB_SIZE * CONFIG_LVGL_HOR_RES_MAX *
       CONFIG_LVGL_VER_RES_MAX) / 100)
     / 8)
```

Require 147456 bytes to build the sample, ultimately overflowing RAM
if you run something along the lines of:

```
    twister -T samples/.... -p <constrained_platform> --overflow-as-errors
```

This is a reasonable test to be doing to make sure that sample RAM
requirements do not get too big for a subset of platforms that are of
interest, and it no longer works.

To fix it, add a min_ram line for this case so that we can still run
overflow tests on a large set of samples without fine-grained special
casing or creating an ever-growing list of platform excludes for this
test.

I also added a docs patch to make the min_ram (and min_rom) units explicit.