### PR TITLE
bluetooth: remove Kconfig options CONFIG_BT_*_ON_DEV_NAME

### DIFF
--- a/doc/reference/devicetree/api.rst
+++ b/doc/reference/devicetree/api.rst
@@ -308,9 +308,9 @@ device.
      - Selects the UART used for host communication in the
        :ref:`bluetooth-hci-uart-sample`
    * - zephyr,bt-mon-uart
-     - Sets default :kconfig:`CONFIG_BT_MONITOR_ON_DEV_NAME`
+     - Sets UART device used for the Bluetooth monitor logging
    * - zephyr,bt-uart
-     - Sets default :kconfig:`CONFIG_BT_UART_ON_DEV_NAME`
+     - Sets UART device used by Bluetooth
    * - zephyr,can-primary
      - Sets the primary CAN controller
    * - zephyr,ccm

--- a/doc/releases/release-notes-2.7.rst
+++ b/doc/releases/release-notes-2.7.rst
@@ -50,6 +50,10 @@ Removed APIs in this release
 * Removed ``CONFIG_OPENTHREAD_COPROCESSOR_SPINEL_ON_UART_ACM`` and
   ``CONFIG_OPENTHREAD_COPROCESSOR_SPINEL_ON_UART_DEV_NAME`` Kconfig options
   in favor of chosen node ``zephyr,ot-uart``.
+* Removed ``CONFIG_BT_UART_ON_DEV_NAME`` Kconfig option
+  in favor of direct use of chosen node ``zephyr,bt-uart``.
+* Removed ``CONFIG_BT_MONITOR_ON_DEV_NAME`` Kconfig option
+  in favor of direct use of chosen node ``zephyr,bt-mon-uart``.
 * Removed ``CONFIG_UART_MCUMGR_ON_DEV_NAME`` Kconfig option
   in favor of direct use of chosen node ``zephyr,uart-mcumgr``.
 * Removed ``CONFIG_UART_CONSOLE_ON_DEV_NAME`` Kconfig option

--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -76,18 +76,6 @@ config BT_NO_DRIVER
 
 endchoice
 
-# Workaround for not being able to have commas in macro arguments
-DT_CHOSEN_Z_BT_UART := zephyr,bt-uart
-
-config BT_UART_ON_DEV_NAME
-	string "Device Name of UART Device for Bluetooth"
-	default "$(dt_chosen_label,$(DT_CHOSEN_Z_BT_UART))" if HAS_DTS
-	default "UART_0"
-	depends on BT_UART
-	help
-	  This option specifies the name of UART device to be used
-	  for Bluetooth.
-
 if BT_SPI
 
 config BT_SPI_INIT_PRIORITY

--- a/drivers/bluetooth/hci/h4.c
+++ b/drivers/bluetooth/hci/h4.c
@@ -510,8 +510,8 @@ static int bt_uart_init(const struct device *unused)
 {
 	ARG_UNUSED(unused);
 
-	h4_dev = device_get_binding(CONFIG_BT_UART_ON_DEV_NAME);
-	if (!h4_dev) {
+	h4_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_bt_uart));
+	if (!device_is_ready(h4_dev)) {
 		return -EINVAL;
 	}
 

--- a/drivers/bluetooth/hci/h5.c
+++ b/drivers/bluetooth/hci/h5.c
@@ -769,9 +769,8 @@ static int bt_uart_init(const struct device *unused)
 {
 	ARG_UNUSED(unused);
 
-	h5_dev = device_get_binding(CONFIG_BT_UART_ON_DEV_NAME);
-
-	if (h5_dev == NULL) {
+	h5_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_bt_uart));
+	if (!device_is_ready(h5_dev)) {
 		return -EINVAL;
 	}
 

--- a/soc/x86/atom/Kconfig.defconfig
+++ b/soc/x86/atom/Kconfig.defconfig
@@ -17,9 +17,6 @@ config UART_PIPE_ON_DEV_NAME
 	default "UART_1"
 	depends on UART_PIPE
 
-config BT_MONITOR_ON_DEV_NAME
-	default "UART_1" if BT_DEBUG_MONITOR_UART
-
 endif
 
 endif

--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -348,18 +348,6 @@ endchoice # Bluetooth debug type
 
 if BT_DEBUG
 
-# Workaround for not being able to have commas in macro arguments
-DT_CHOSEN_Z_BT_MON_UART := zephyr,bt-mon-uart
-
-config BT_MONITOR_ON_DEV_NAME
-	string "Device Name of Bluetooth monitor logging UART"
-	depends on BT_DEBUG_MONITOR_UART
-	default "$(dt_chosen_label,$(DT_CHOSEN_Z_BT_MON_UART))" if HAS_DTS
-	default "UART_0"
-	help
-	  This option specifies the name of UART device to be used
-	  for the Bluetooth monitor logging.
-
 config BT_DEBUG_HCI_DRIVER
 	bool "Bluetooth HCI driver debug"
 	help

--- a/subsys/bluetooth/host/monitor.c
+++ b/subsys/bluetooth/host/monitor.c
@@ -233,10 +233,6 @@ extern void __printk_hook_install(int (*fn)(int));
 extern void __stdout_hook_install(int (*fn)(int));
 #endif /* !CONFIG_UART_CONSOLE */
 
-#if defined(CONFIG_HAS_DTS) && !defined(CONFIG_BT_MONITOR_ON_DEV_NAME)
-#define CONFIG_BT_MONITOR_ON_DEV_NAME DT_LABEL(DT_CHOSEN(zephyr_console))
-#endif
-
 #ifndef CONFIG_LOG_MINIMAL
 struct monitor_log_ctx {
 	size_t total_len;
@@ -347,9 +343,9 @@ static int bt_monitor_init(const struct device *d)
 {
 	ARG_UNUSED(d);
 
-	monitor_dev = device_get_binding(CONFIG_BT_MONITOR_ON_DEV_NAME);
+	monitor_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_bt_mon_uart));
 
-	__ASSERT_NO_MSG(monitor_dev);
+	__ASSERT_NO_MSG(device_is_ready(monitor_dev));
 
 #if defined(CONFIG_UART_INTERRUPT_DRIVEN)
 	uart_irq_rx_disable(monitor_dev);


### PR DESCRIPTION
Follow up on commit bfd45e5b8cab
("drivers: remove Kconfig option CONFIG_UART_CONSOLE_ON_DEV_NAME")
Remove Kconfig options
CONFIG_BT_UART_ON_DEV_NAME and CONFIG_BT_MONITOR_ON_DEV_NAME
since all UART drivers are converted to devicetree and we can just use
DEVICE_DT_GET(DT_CHOSEN(zephyr_bt_uart)) and
DEVICE_DT_GET(DT_CHOSEN(zephyr_bt_mon_uart)).