### PR TITLE
tests: arch: arm_thread_swap: Fix FPSCR validation for ARMv8.1-M

### DIFF
--- a/tests/arch/arm/arm_no_multithreading/src/main.c
+++ b/tests/arch/arm/arm_no_multithreading/src/main.c
@@ -13,6 +13,16 @@
   #error test can only run on Cortex-M MCUs
 #endif
 
+#if defined(CONFIG_ARMV8_1_M_MAINLINE)
+/*
+ * For ARMv8.1-M, the FPSCR[18:16] LTPSIZE field may always read 0b010 if MVE
+ * is not implemented, so mask it when validating the value of the FPSCR.
+ */
+#define FPSCR_MASK		(~FPU_FPDSCR_LTPSIZE_Msk)
+#else
+#define FPSCR_MASK		(0xffffffffU)
+#endif
+
 extern K_THREAD_STACK_DEFINE(z_main_stack, CONFIG_MAIN_STACK_SIZE);
 
 static volatile int test_flag;
@@ -58,7 +68,7 @@ void test_main(void)
 			psp, main_stack_base, main_stack_top);
 
 #if defined(CONFIG_FPU)
-	__ASSERT(__get_FPSCR() == 0,
+	__ASSERT((__get_FPSCR() & FPSCR_MASK) == 0,
 		"FPSCR not zero (0x%x)", __get_FPSCR());
 #endif
 

--- a/tests/arch/arm/arm_no_multithreading/testcase.yaml
+++ b/tests/arch/arm/arm_no_multithreading/testcase.yaml
@@ -6,4 +6,4 @@ tests:
   arch.arm.no_multithreading:
     filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE
     platform_allow: qemu_cortex_m0 qemu_cortex_m3 mps2_an385 mps2_an521
-      nrf52840dk_nrf52840 nrf9160dk_nrf9160 nrf51dk_nrf51422
+      mps3_an547 nrf52840dk_nrf52840 nrf9160dk_nrf9160 nrf51dk_nrf51422


### PR DESCRIPTION
```
This commit fixes the FPSCR register initialisation validation test
for the ARMv8.1-M architecture.

For ARMv8.1-M, the newly added LTPSIZE field in the FPSCR may always
read the value of 4 when the M-Profile Vector Extension (MVE) is not
implemented or FP context is not active, so we must ignore its value
when validating the FPSCR register initialisation.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>
```

Fixes #37856