### PR TITLE
doc: modules guide updated with Zephyr CMake lists description

### DIFF
--- a/doc/guides/modules.rst
+++ b/doc/guides/modules.rst
@@ -530,6 +530,20 @@ variables. For example:
 
   include(${ZEPHYR_CURRENT_MODULE_DIR}/cmake/code.cmake)
 
+It is possible to append values to a Zephyr CMake list variable from the module's first
+CMakeLists.txt file.
+To do so, append the value to the list and then set the list in the PARENT_SCOPE
+of the CMakeLists.txt file. For example, to append ``bar`` to the ``FOO_LIST`` variable in the
+Zephyr CMakeLists.txt scope:
+
+.. code-block:: cmake
+
+  list(APPEND FOO_LIST bar)
+  set(FOO_LIST ${FOO_LIST} PARENT_SCOPE)
+
+An example of a Zephyr list where this is useful is when adding additional
+directories to the ``SYSCALL_INCLUDE_DIRS`` list.
+
 Zephyr module dependencies
 ==========================
 


### PR DESCRIPTION
This commit extends the `Build system integration` section in the Zephyr
modules guide with a description on how a module may append additional
values to Zephyr CMake lists.

This is useful for modules that might need to append values to the
`SYSCALL_INCLUDE_DIRS` list.

This commit is followup to the discussion found in:
https://github.com/zephyrproject-rtos/zephyr/pull/33756#issuecomment-895896774

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>