### PR TITLE
MAINTAINERS: remove mengxianglinx from USB collaborators

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1524,8 +1524,6 @@ USB:
     status: maintained
     maintainers:
         - jfischer-no
-    collaborators:
-        - mengxianglinx
     files:
         - drivers/usb/
         - dts/bindings/usb/


### PR DESCRIPTION
mengxianglinx is not an USB collaborator.