### PR TITLE
pm: device_runtime: Fix return values

### DIFF
--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -109,8 +109,14 @@ static int pm_device_request(const struct device *dev,
 
 	if (state == PM_DEVICE_STATE_ACTIVE) {
 		dev->pm->usage++;
+		if (dev->pm->usage > 1) {
+			goto out_unlock;
+		}
 	} else {
 		dev->pm->usage--;
+		if (dev->pm->usage > 0) {
+			goto out_unlock;
+		}
 	}
 
 

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -113,6 +113,11 @@ static int pm_device_request(const struct device *dev,
 			goto out_unlock;
 		}
 	} else {
+		/* Check if it is already 0 to avoid an underflow */
+		if (dev->pm->usage == 0) {
+			goto out_unlock;
+		}
+
 		dev->pm->usage--;
 		if (dev->pm->usage > 0) {
 			goto out_unlock;


### PR DESCRIPTION
Return -EBUSY in cases where the request failed because the reference
count does not reach the right value.

Fixes #37821

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>