### PR TITLE
tests: fix typo in the comments

### DIFF
--- a/tests/kernel/common/src/irq_offload.c
+++ b/tests/kernel/common/src/irq_offload.c
@@ -160,7 +160,7 @@ __no_optimization void test_nop(void)
 	 * ,leave it unchanged, or even reduce it. Therefore, NOP
 	 * instructions are not suitable for timing loops.
 	 *
-	 * So we skip the this test, it will get a negative cycles.
+	 * So we skip this test, it will get a negative cycles.
 	 *
 	 * And on physical EHL_CRB, up squared and INTEL ADSP boards,
 	 * we also got a similar situation, we skip the check as well.

--- a/tests/kernel/interrupt/src/dynamic_isr.c
+++ b/tests/kernel/interrupt/src/dynamic_isr.c
@@ -108,11 +108,11 @@ extern const void *x86_irq_args[];
 			"irq connect dynamic failed");
 
 	/*
-	 * The reason we need to hard code the the trigger vector here
+	 * The reason we need to hard code the trigger vector here
 	 * is that the x86 only support immediate number for INT
 	 * instruction. So trigger an interrupt of x86 under gcov code
 	 * coverage report enabled, which means GCC optimization will
-	 * be -O0. In this case, an build error happends and shows:
+	 * be -O0. In this case, an build error happens and shows:
 	 * "error: 'asm' operand 0 probably does not match constraints"
 	 * and "error: impossible constraint in 'asm'"
 	 *


### PR DESCRIPTION
Whiling reading the code, find some typos in the code comments.
In file tests: kernel: common:src: irq_offload.c, and tests: kernel: interrupt: src:  dynamic_isr.c.

Signed-off-by: Naiyuan Tian <naiyuan.tian@intel.com>