### PR TITLE
boards: mps3_an547: Fix typo in the board documentation

### DIFF
--- a/boards/arm/mps3_an547/doc/index.rst
+++ b/boards/arm/mps3_an547/doc/index.rst
@@ -209,8 +209,8 @@ at build time via:
    $ west build -b mps3_an547 samples/hello°world -DEMU_PLATFORM=qemu -t run
 
 
-Note, however, that the Ethos-U55 FPU is not available in QEMU. If you require
-the use of the FPU, please use the default FVP for device emulation.
+Note, however, that the Ethos-U55 NPU is not available in QEMU. If you require
+the use of the NPU, please use the default FVP for device emulation.
 
 .. _Corstone-300 FVP:
    https://developer.arm.com/tools-and-software/open-source-software/arm-platforms-software/arm-ecosystem-fvps


### PR DESCRIPTION
The mps3_an547 board documentation incorrectly referred to the
Ethos-U55 coprocessor as an FPU (floating point unit) when it is really
an NPU (neural processing unit).

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>