### PR TITLE
Bluetooth: sample: central_iso fix bad printk statement

### DIFF
--- a/samples/bluetooth/central_iso/src/main.c
+++ b/samples/bluetooth/central_iso/src/main.c
@@ -195,7 +195,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 	iso_err = bt_iso_cig_create(&param, &cig);
 
 	if (iso_err) {
-		printk("Failed to bind iso to connection (%d)\n", iso_err);
+		printk("Failed to create CIG (%d)\n", iso_err);
 		return;
 	}
 


### PR DESCRIPTION
The prinkt statement did not match the action that was taken.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>