### PR TITLE
Bluetooth: ISO: Add ISO limits as #defines and use them

### DIFF
--- a/include/bluetooth/iso.h
+++ b/include/bluetooth/iso.h
@@ -35,7 +35,44 @@ extern "C" {
 				  BT_HCI_ISO_DATA_HDR_SIZE)
 
 /** Value to set the ISO data path over HCi. */
-#define BT_ISO_DATA_PATH_HCI     0x00
+#define BT_ISO_DATA_PATH_HCI        0x00
+
+/** Minimum interval value in microseconds */
+#define BT_ISO_INTERVAL_MIN         0x0000FF
+/** Maximum interval value in microseconds */
+#define BT_ISO_INTERVAL_MAX         0x0FFFFF
+/** Minimum latency value in milliseconds */
+#define BT_ISO_LATENCY_MIN          0x0005
+/** Maximum latency value in milliseconds */
+#define BT_ISO_LATENCY_MAX          0x0FA0
+/** Packets will be sent sequentially between the channels in the group */
+#define BT_ISO_PACKING_SEQUENTIAL   0x00
+/** Packets will be sent interleaved between the channels in the group */
+#define BT_ISO_PACKING_INTERLEAVED  0x01
+/** Packets may be framed or unframed */
+#define BT_ISO_FRAMING_UNFRAMED     0x00
+/** Packets are always framed */
+#define BT_ISO_FRAMING_FRAMED       0x01
+/** Maximum number of isochronous channels in a single group */
+#define BT_ISO_MAX_GROUP_ISO_COUNT  0x1F
+/** Maximum SDU size */
+#define BT_ISO_MAX_SDU              0x0FFF
+/** Minimum BIG sync timeout value (N * 10 ms) */
+#define BT_ISO_SYNC_TIMEOUT_MIN     0x000A
+/** Maximum BIG sync timeout value (N * 10 ms) */
+#define BT_ISO_SYNC_TIMEOUT_MAX     0x4000
+/** Controller controlled maximum subevent count value */
+#define BT_ISO_SYNC_MSE_ANY         0x00
+/** Minimum BIG sync maximum subevent count value */
+#define BT_ISO_SYNC_MSE_MIN         0x01
+/** Maximum BIG sync maximum subevent count value */
+#define BT_ISO_SYNC_MSE_MAX         0x1F
+/** Maximum connected ISO retransmission value */
+#define BT_ISO_CONNECTED_RTN_MAX    0xFF
+/** Maximum broadcast ISO retransmission value */
+#define BT_ISO_BROADCAST_RTN_MAX    0x1E
+/** Broadcast code size */
+#define BT_ISO_BROADCAST_CODE_SIZE  16
 
 struct bt_iso_chan;
 
@@ -70,13 +107,13 @@ struct bt_iso_chan {
 
 /** @brief ISO Channel IO QoS structure. */
 struct bt_iso_chan_io_qos {
-	/** Channel SDU. Value range 0x0000 - 0x0FFF. */
+	/** Channel SDU. Maximum value is BT_ISO_MAX_SDU */
 	uint16_t			sdu;
 	/** Channel PHY - See BT_GAP_LE_PHY for values.
 	 *  Setting BT_GAP_LE_PHY_NONE is invalid.
 	 */
 	uint8_t				phy;
-	/** Channel Retransmission Number. Value range 0x00 - 0x0F. */
+	/** Channel Retransmission Number. */
 	uint8_t				rtn;
 	/** @brief Channel data path reference
 	 *
@@ -156,19 +193,29 @@ struct bt_iso_recv_info {
 struct bt_iso_cig;
 
 struct bt_iso_cig_create_param {
-	/** Array of pointers to CIS channels
+	/** @brief Array of pointers to CIS channels
 	 *
 	 * This array shall remain valid for the duration of the CIG.
 	 */
 	struct bt_iso_chan **cis_channels;
 
-	/** Number channels in @p cis_channels */
+	/** @brief Number channels in @p cis_channels
+	 *
+	 *  Maximum number of channels in a single group is
+	 *  BT_ISO_MAX_GROUP_ISO_COUNT
+	 */
 	uint8_t num_cis;
 
-	/** Channel interval in us. Value range 0x0000FF - 0xFFFFFF. */
+	/** @brief Channel interval in us.
+	 *
+	 *  Value range BT_ISO_INTERVAL_MIN - BT_ISO_INTERVAL_MAX.
+	 */
 	uint32_t interval;
 
-	/** Channel Latency in ms. Value range 0x0005 - 0x0FA0. */
+	/** @brief Channel Latency in ms.
+	 *
+	 *  Value range BT_ISO_LATENCY_MIN - BT_ISO_LATENCY_MAX.
+	 */
 	uint16_t latency;
 
 	/** @brief Channel peripherals sleep clock accuracy Only for CIS
@@ -180,10 +227,17 @@ struct bt_iso_cig_create_param {
 	 */
 	uint8_t sca;
 
-	/** Channel packing mode. 0 for unpacked, 1 for packed. */
+	/** @brief Channel packing mode.
+	 *
+	 *  BT_ISO_PACKING_SEQUENTIAL or BT_ISO_PACKING_INTERLEAVED
+	 */
 	uint8_t packing;
 
-	/** Channel framing mode. 0 for unframed, 1 for framed. */
+	/** @brief Channel framing mode.
+	 *
+	 * BT_ISO_FRAMING_UNFRAMED for unframed and
+	 * BT_ISO_FRAMING_FRAMED for framed.
+	 */
 	uint8_t framing;
 };
 
@@ -205,37 +259,58 @@ struct bt_iso_big_create_param {
 	 */
 	struct bt_iso_chan **bis_channels;
 
-	/** Number channels in @p bis_channels */
+	/** @brief Number channels in @p bis_channels
+	 *
+	 *  Maximum number of channels in a single group is
+	 *  BT_ISO_MAX_GROUP_ISO_COUNT
+	 */
 	uint8_t num_bis;
 
-	/** Channel interval in us. Value range 0x0000FF - 0xFFFFFF. */
+	/** @brief Channel interval in us.
+	 *
+	 *  Value range BT_ISO_INTERVAL_MIN - BT_ISO_INTERVAL_MAX.
+	 */
 	uint32_t interval;
 
-	/** Channel Latency in ms. Value range 0x0005 - 0x0FA0. */
+	/** @brief Channel Latency in ms.
+	 *
+	 *  Value range BT_ISO_LATENCY_MIN - BT_ISO_LATENCY_MAX.
+	 */
 	uint16_t latency;
 
-	/** Channel packing mode. 0 for unpacked, 1 for packed. */
+	/** @brief Channel packing mode.
+	 *
+	 *  BT_ISO_PACKING_SEQUENTIAL or BT_ISO_PACKING_INTERLEAVED
+	 */
 	uint8_t packing;
 
-	/** Channel framing mode. 0 for unframed, 1 for framed. */
+	/** @brief Channel framing mode.
+	 *
+	 * BT_ISO_FRAMING_UNFRAMED for unframed and
+	 * BT_ISO_FRAMING_FRAMED for framed.
+	 */
 	uint8_t framing;
 
 	/** Whether or not to encrypt the streams. */
-	bool  encryption;
+	bool encryption;
 
 	/** @brief Broadcast code
 	 *
 	 *  The code used to derive the session key that is used to encrypt and
 	 *  decrypt BIS payloads.
 	 */
-	uint8_t  bcode[16];
+	uint8_t bcode[BT_ISO_BROADCAST_CODE_SIZE];
 };
 
 struct bt_iso_big_sync_param {
 	/** Array of pointers to BIS channels */
 	struct bt_iso_chan **bis_channels;
 
-	/** Number channels in @p bis_channels */
+	/** @brief Number channels in @p bis_channels
+	 *
+	 *  Maximum number of channels in a single group is
+	 *  BT_ISO_MAX_GROUP_ISO_COUNT
+	 */
 	uint8_t num_bis;
 
 	/** Bitfield of the BISes to sync to */
@@ -243,12 +318,19 @@ struct bt_iso_big_sync_param {
 
 	/** @brief Maximum subevents
 	 *
-	 *  The MSE (Maximum Subevents) parameter is the maximum number of subevents that a
-	 *  Controller should use to receive data payloads in each interval for a BIS
+	 *  The MSE (Maximum Subevents) parameter is the maximum number of
+	 *  subevents that a  Controller should use to receive data payloads
+	 *  in each interval for a BIS.
+	 *
+	 *  Value range is BT_ISO_SYNC_MSE_MIN to BT_ISO_SYNC_MSE_MAX, or
+	 *  BT_ISO_SYNC_MSE_ANY to let the controller choose.
 	 */
 	uint32_t mse;
 
-	/** Synchronization timeout for the BIG (N * 10 MS) */
+	/** @brief Synchronization timeout for the BIG (N * 10 MS)
+	 *
+	 * Value range is BT_ISO_SYNC_TIMEOUT_MIN to BT_ISO_SYNC_TIMEOUT_MAX.
+	 */
 	uint16_t sync_timeout;
 
 	/** Whether or not the streams of the BIG are encrypted */
@@ -259,7 +341,7 @@ struct bt_iso_big_sync_param {
 	 *  The code used to derive the session key that is used to encrypt and
 	 *  decrypt BIS payloads.
 	 */
-	uint8_t  bcode[16];
+	uint8_t bcode[BT_ISO_BROADCAST_CODE_SIZE];
 };
 
 struct bt_iso_biginfo {

--- a/samples/bluetooth/iso_broadcast_benchmark/src/broadcaster.c
+++ b/samples/bluetooth/iso_broadcast_benchmark/src/broadcaster.c
@@ -114,8 +114,7 @@ static int parse_rtn_arg(void)
 	}
 
 	rtn = strtoul(buffer, NULL, 0);
-	/* TODO: Replace literal int with a #define once it has been created */
-	if (rtn > 16) {
+	if (rtn > BT_ISO_BROADCAST_RTN_MAX) {
 		printk("Invalid RTN %llu", rtn);
 		return -EINVAL;
 	}
@@ -138,8 +137,7 @@ static int parse_interval_arg(void)
 	}
 
 	interval = strtoul(buffer, NULL, 0);
-	/* TODO: Replace literal int with a #define once it has been created */
-	if (interval < 0x100 || interval > 0xFFFFF) {
+	if (interval < BT_ISO_INTERVAL_MIN || interval > BT_ISO_INTERVAL_MAX) {
 		printk("Invalid interval %llu", interval);
 		return -EINVAL;
 	}
@@ -162,8 +160,7 @@ static int parse_latency_arg(void)
 	}
 
 	latency = strtoul(buffer, NULL, 0);
-	/* TODO: Replace literal int with a #define once it has been created */
-	if (latency > 0xFA0) {
+	if (latency < BT_ISO_LATENCY_MIN || latency > BT_ISO_LATENCY_MAX) {
 		printk("Invalid latency %llu", latency);
 		return -EINVAL;
 	}
@@ -212,8 +209,7 @@ static int parse_sdu_arg(void)
 	}
 
 	sdu = strtoul(buffer, NULL, 0);
-	/* TODO: Replace literal int with a #define once it has been created */
-	if (sdu > 0xFFF) {
+	if (sdu > MIN(BT_ISO_MAX_SDU, sizeof(iso_data))) {
 		printk("Invalid SDU %llu", sdu);
 		return -EINVAL;
 	}
@@ -236,8 +232,8 @@ static int parse_packing_arg(void)
 	}
 
 	packing = strtoul(buffer, NULL, 0);
-	/* TODO: Replace literal int with a #define once it has been created */
-	if (packing > 1) {
+	if (packing != BT_ISO_PACKING_SEQUENTIAL &&
+	    packing != BT_ISO_PACKING_INTERLEAVED) {
 		printk("Invalid packing %llu", packing);
 		return -EINVAL;
 	}
@@ -260,8 +256,8 @@ static int parse_framing_arg(void)
 	}
 
 	framing = strtoul(buffer, NULL, 0);
-	/* TODO: Replace literal int with a #define once it has been created */
-	if (framing > 1) {
+	if (framing != BT_ISO_FRAMING_UNFRAMED &&
+	    framing != BT_ISO_FRAMING_FRAMED) {
 		printk("Invalid framing %llu", framing);
 		return -EINVAL;
 	}
@@ -284,7 +280,7 @@ static int parse_bis_count_arg(void)
 	}
 
 	bis_count = strtoul(buffer, NULL, 0);
-	if (bis_count > CONFIG_BT_ISO_MAX_CHAN) {
+	if (bis_count > MAX(BT_ISO_MAX_GROUP_ISO_COUNT, CONFIG_BT_ISO_MAX_CHAN)) {
 		printk("Invalid BIS count %llu", bis_count);
 		return -EINVAL;
 	}

--- a/samples/bluetooth/iso_connected_benchmark/src/main.c
+++ b/samples/bluetooth/iso_connected_benchmark/src/main.c
@@ -453,8 +453,7 @@ static int parse_rtn_arg(struct bt_iso_chan_io_qos *qos)
 	}
 
 	rtn = strtoul(buffer, NULL, 0);
-	/* TODO: Replace literal int with a #define once it has been created */
-	if (rtn > 16) {
+	if (rtn > BT_ISO_CONNECTED_RTN_MAX) {
 		printk("Invalid RTN %llu", rtn);
 		return -EINVAL;
 	}
@@ -478,7 +477,7 @@ static int parse_interval_arg(void)
 
 	interval = strtoul(buffer, NULL, 0);
 	/* TODO: Replace literal ints with a #define once it has been created */
-	if (interval < 0x100 || interval > 0xFFFFF) {
+	if (interval < BT_ISO_INTERVAL_MIN || interval > BT_ISO_INTERVAL_MAX) {
 		printk("Invalid interval %llu", interval);
 		return -EINVAL;
 	}
@@ -501,8 +500,7 @@ static int parse_latency_arg(void)
 	}
 
 	latency = strtoul(buffer, NULL, 0);
-	/* TODO: Replace literal int with a #define once it has been created */
-	if (latency > 0xFA0) {
+	if (latency < BT_ISO_LATENCY_MIN || latency > BT_ISO_LATENCY_MAX) {
 		printk("Invalid latency %llu", latency);
 		return -EINVAL;
 	}
@@ -551,8 +549,8 @@ static int parse_sdu_arg(struct bt_iso_chan_io_qos *qos)
 	}
 
 	sdu = strtoul(buffer, NULL, 0);
-	/* TODO: Replace literal int with a #define once it has been created */
-	if (sdu > 0xFFF || sdu < sizeof(uint32_t) /* room for the counter */) {
+	if (sdu > MIN(BT_ISO_MAX_SDU, sizeof(iso_data)) ||
+	    sdu < sizeof(uint32_t) /* room for the counter */) {
 		printk("Invalid SDU %llu", sdu);
 		return -EINVAL;
 	}
@@ -575,7 +573,7 @@ static int parse_cis_count_arg(void)
 	}
 
 	cis_count = strtoul(buffer, NULL, 0);
-	if (cis_count > CONFIG_BT_ISO_MAX_CHAN) {
+	if (cis_count > MAX(BT_ISO_MAX_GROUP_ISO_COUNT, CONFIG_BT_ISO_MAX_CHAN)) {
 		printk("Invalid CIS count %llu", cis_count);
 		return -EINVAL;
 	}

--- a/tests/bluetooth/bsim_bt/bsim_test_iso/src/main.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_iso/src/main.c
@@ -14,6 +14,7 @@
 
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/hci.h>
+#include <bluetooth/iso.h>
 
 #include "bs_types.h"
 #include "bs_tracing.h"
@@ -116,7 +117,7 @@ static void test_iso_main(void)
 	uint8_t packing = 0;
 	uint8_t framing = 0;
 	uint8_t encryption = 0;
-	uint8_t bcode[16] = { 0 };
+	uint8_t bcode[BT_ISO_BROADCAST_CODE_SIZE] = { 0 };
 
 	/* Assume that index == handle */
 	adv_handle = bt_le_ext_adv_get_index(adv);
@@ -344,7 +345,7 @@ static void test_iso_recv_main(void)
 	uint8_t big_handle = 0;
 	uint8_t mse = 0;
 	uint8_t encryption = 0;
-	uint8_t bcode[16] = { 0 };
+	uint8_t bcode[BT_ISO_BROADCAST_CODE_SIZE] = { 0 };
 	uint16_t sync_timeout = 0;
 	struct node_rx_hdr *node_rx;
 


### PR DESCRIPTION
Add #define's for ISO HCI limits and use them to validate
input parameters.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>