### PR TITLE
modules: hal_nordic: Add nrf51 MDK defines needed to apply nrf51 erratas

### DIFF
--- a/modules/hal_nordic/nrfx/CMakeLists.txt
+++ b/modules/hal_nordic/nrfx/CMakeLists.txt
@@ -15,6 +15,9 @@ zephyr_include_directories(.)
 
 # Define MDK defines globally
 zephyr_compile_definitions_ifdef(CONFIG_SOC_SERIES_NRF51X       NRF51)
+zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF51822_QFAA       NRF51422_XXAA)
+zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF51822_QFAB       NRF51422_XXAB)
+zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF51822_QFAC       NRF51422_XXAC)
 zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF52805            NRF52805_XXAA)
 zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF52810            NRF52810_XXAA)
 zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF52811            NRF52811_XXAA)


### PR DESCRIPTION
Add nrf51 MDK defines needed to correctly select the nrf51 erratas needed on
the specific SoCs. The nrf51_erratas.h header file only uses these
defines to check which erratas should be applied.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>