### PR TITLE
subsys: modbus: Add transaction_id & proto_id to response

### DIFF
--- a/subsys/modbus/modbus_server.c
+++ b/subsys/modbus/modbus_server.c
@@ -950,6 +950,8 @@ bool modbus_server_handler(struct modbus_context *ctx)
 	}
 
 	/* Prepare response header */
+	ctx->tx_adu.trans_id = ctx->rx_adu.trans_id;
+	ctx->tx_adu.proto_id = ctx->rx_adu.proto_id;
 	ctx->tx_adu.unit_id = addr;
 	ctx->tx_adu.fc = fc;
 


### PR DESCRIPTION
This copy transaction_id and proto_id from the request header to the MBAP response header as
described in the Modbus_Messaging_Implementation_Guide_V1_0b

Signed-off-by: Luc Viala <luc.viala19@gmail.com>