### PR TITLE
 Bluetooth: host: Cancel limited adv timeout when advertising stopped

### DIFF
--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -1413,12 +1413,15 @@ static void adv_timeout(struct k_work *work)
 	dwork = k_work_delayable_from_work(work);
 	adv = CONTAINER_OF(dwork, struct bt_le_ext_adv, timeout_work);
 
-	err = bt_le_ext_adv_stop(adv);
+	if (adv == bt_dev.adv) {
+		err = bt_le_adv_stop();
+	} else {
+		err = bt_le_ext_adv_stop(adv);
+	}
 #else
 	err = bt_le_adv_stop();
 #endif
-	__ASSERT(err == 0, "Limited Advertising timeout reached, "
-			   "failed to stop advertising");
+	BT_WARN("Failed to stop advertising: %d", err);
 }
 
 #if defined(CONFIG_BT_PER_ADV)

--- a/subsys/bluetooth/host/adv.h
+++ b/subsys/bluetooth/host/adv.h
@@ -19,3 +19,4 @@ int bt_le_adv_set_enable_ext(struct bt_le_ext_adv *adv,
 			 bool enable,
 			 const struct bt_le_ext_adv_start_param *param);
 int bt_le_adv_set_enable_legacy(struct bt_le_ext_adv *adv, bool enable);
+int bt_le_lim_adv_cancel_timeout(struct bt_le_ext_adv *adv);

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1322,6 +1322,12 @@ static void le_legacy_conn_complete(struct net_buf *buf)
 	struct bt_hci_evt_le_conn_complete *evt = (void *)buf->data;
 	struct bt_hci_evt_le_enh_conn_complete enh;
 
+#if defined(CONFIG_BT_BROADCASTER)
+	struct bt_le_ext_adv *adv = bt_le_adv_lookup_legacy();
+
+	(void)bt_le_lim_adv_cancel_timeout(adv);
+#endif
+
 	BT_DBG("status 0x%02x role %u %s", evt->status, evt->role,
 	       bt_addr_le_str(&evt->peer_addr));
 

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -149,7 +149,7 @@ struct bt_le_ext_adv {
 	int8_t                    tx_power;
 #endif /* defined(CONFIG_BT_EXT_ADV) */
 
-	struct k_work_delayable	timeout_work;
+	struct k_work_delayable	lim_adv_timeout_work;
 };
 
 enum {


### PR DESCRIPTION
Advertising might stop when:
- it was stopped by an application
- device connected to a peer
- extended advertising reached stop condition
  defined in BT_LE_EXT_ADV_START_PARAM - this is handled in ll

Signed-off-by: Michał Narajowski <michal.narajowski@codecoup.pl>