### PR TITLE
ipc: Call ipm_set_enabled() also for dual IPM support

### DIFF
--- a/subsys/ipc/rpmsg_multi_instance/rpmsg_multi_instance.c
+++ b/subsys/ipc/rpmsg_multi_instance/rpmsg_multi_instance.c
@@ -267,6 +267,12 @@ int rpmsg_mi_ctx_init(struct rpmsg_mi_ctx *ctx, const struct rpmsg_mi_ctx_cfg *c
 	/* Register IPM callback. This cb executes when msg has come. */
 	ipm_register_callback(ctx->ipm_rx_handle, ipm_callback, ctx);
 
+	err = ipm_set_enabled(ctx->ipm_rx_handle, 1);
+	if (err != 0) {
+		LOG_ERR("Could not enable IPM interrupts and callbacks for RX");
+		return err;
+	}
+
 	ctx->vq[RPMSG_VQ_0] = virtqueue_allocate(vring_size);
 	if (!ctx->vq[RPMSG_VQ_0]) {
 		LOG_ERR("virtqueue_allocate failed to alloc vq[RPMSG_VQ_0]");

--- a/subsys/ipc/rpmsg_service/rpmsg_backend.c
+++ b/subsys/ipc/rpmsg_service/rpmsg_backend.c
@@ -229,6 +229,13 @@ int rpmsg_backend_init(struct metal_io_region **io, struct virtio_device *vdev)
 	}
 
 	ipm_register_callback(ipm_rx_handle, ipm_callback, NULL);
+
+	err = ipm_set_enabled(ipm_rx_handle, 1);
+	if (err != 0) {
+		LOG_ERR("Could not enable IPM interrupts and callbacks for RX");
+		return err;
+	}
+
 #elif defined(CONFIG_RPMSG_SERVICE_SINGLE_IPM_SUPPORT)
 	ipm_handle = device_get_binding(CONFIG_RPMSG_SERVICE_IPM_NAME);
 


### PR DESCRIPTION
The IPC drivers rpmsg_service and rpmsg_multi_instance are not
explicitly enabling the IPM channels when two different devices are used
for TX and RX. While this could be redundant for some IPM drivers, in
some cases the hardware needs to be enabled before using it.

Add the missing calls to ipm_set_enabled() for both the devices.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>