### PR TITLE
Bluetooth: Controller: Remove ULL header include in LLL

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -45,8 +45,6 @@
 #include "lll_prof_internal.h"
 #include "lll_df_internal.h"
 
-#include "ull_internal.h"
-
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_lll_adv
 #include "common/log.h"


### PR DESCRIPTION
Do not include ULL header in LLL, instead values and fields
required in LLL shall be declared in LLL contexts.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>