### PR TITLE
boards: bl654_usb: add zephyr,bt-c2h-uart property

### DIFF
--- a/boards/arm/bl654_usb/bl654_usb.dts
+++ b/boards/arm/bl654_usb/bl654_usb.dts
@@ -16,6 +16,7 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &bl654_cdc_acm_uart;
 		zephyr,shell-uart = &bl654_cdc_acm_uart;
+		zephyr,bt-c2h-uart = &bl654_cdc_acm_uart;
 		zephyr,code-partition = &slot0_partition;
 	};
 


### PR DESCRIPTION
This would allow hci_uart sample to be used
with bl654_usb board.

Resolves #38026