### PR TITLE
net: mqtt: check mqtt_abort() function parameters before locking

### DIFF
--- a/subsys/net/lib/mqtt/mqtt.c
+++ b/subsys/net/lib/mqtt/mqtt.c
@@ -578,9 +578,9 @@ error:
 
 int mqtt_abort(struct mqtt_client *client)
 {
-	mqtt_mutex_lock(client);
-
 	NULL_PARAM_CHECK(client);
+
+	mqtt_mutex_lock(client);
 
 	if (client->internal.state != MQTT_STATE_IDLE) {
 		client_disconnect(client, -ECONNABORTED, true);


### PR DESCRIPTION
Function parameters can be checked without MQTT instance lock being
held. Additionally if NULL parameter would be passed (which this check
tries to handle), then function would return without releasing lock.
