### PR TITLE
net: sockets: add shutdown() support in vtable and implement it for native and tls sockets

### DIFF
--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -460,7 +460,7 @@ static void http_timeout(struct k_work *work)
 	struct http_client_internal_data *data =
 		CONTAINER_OF(work, struct http_client_internal_data, work);
 
-	(void)zsock_close(data->sock);
+	(void)zsock_shutdown(data->sock, SHUT_RD);
 }
 
 int http_client_req(int sock, struct http_request *req,

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -405,6 +405,30 @@ unlock:
 	(void)k_condvar_signal(&ctx->cond.recv);
 }
 
+int zsock_shutdown_ctx(struct net_context *ctx, int how)
+{
+	if (how == SHUT_RD) {
+		if (net_context_get_state(ctx) == NET_CONTEXT_LISTENING) {
+			SET_ERRNO(net_context_accept(ctx, NULL, K_NO_WAIT, NULL));
+		} else {
+			SET_ERRNO(net_context_recv(ctx, NULL, K_NO_WAIT, NULL));
+		}
+
+		sock_set_eof(ctx);
+
+		zsock_flush_queue(ctx);
+
+		/* Let reader to wake if it was sleeping */
+		(void)k_condvar_signal(&ctx->cond.recv);
+	} else if (how == SHUT_WR || how == SHUT_RDWR) {
+		SET_ERRNO(-ENOTSUP);
+	} else {
+		SET_ERRNO(-EINVAL);
+	}
+
+	return 0;
+}
+
 int zsock_bind_ctx(struct net_context *ctx, const struct sockaddr *addr,
 		   socklen_t addrlen)
 {
@@ -2138,6 +2162,11 @@ static int sock_ioctl_vmeth(void *obj, unsigned int request, va_list args)
 	}
 }
 
+static int sock_shutdown_vmeth(void *obj, int how)
+{
+	return zsock_shutdown_ctx(obj, how);
+}
+
 static int sock_bind_vmeth(void *obj, const struct sockaddr *addr,
 			   socklen_t addrlen)
 {
@@ -2212,6 +2241,7 @@ const struct socket_op_vtable sock_fd_op_vtable = {
 		.close = sock_close_vmeth,
 		.ioctl = sock_ioctl_vmeth,
 	},
+	.shutdown = sock_shutdown_vmeth,
 	.bind = sock_bind_vmeth,
 	.connect = sock_connect_vmeth,
 	.listen = sock_listen_vmeth,

--- a/subsys/net/lib/sockets/sockets_internal.h
+++ b/subsys/net/lib/sockets/sockets_internal.h
@@ -49,6 +49,7 @@ static inline bool net_socket_is_tls(void *obj)
 
 struct socket_op_vtable {
 	struct fd_op_vtable fd_vtable;
+	int (*shutdown)(void *obj, int how);
 	int (*bind)(void *obj, const struct sockaddr *addr, socklen_t addrlen);
 	int (*connect)(void *obj, const struct sockaddr *addr,
 		       socklen_t addrlen);

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -2509,6 +2509,13 @@ static int tls_sock_ioctl_vmeth(void *obj, unsigned int request, va_list args)
 	}
 }
 
+static int tls_sock_shutdown_vmeth(void *obj, int how)
+{
+	struct tls_context *ctx = obj;
+
+	return zsock_shutdown(ctx->sock, how);
+}
+
 static int tls_sock_bind_vmeth(void *obj, const struct sockaddr *addr,
 			       socklen_t addrlen)
 {
@@ -2592,6 +2599,7 @@ static const struct socket_op_vtable tls_sock_fd_op_vtable = {
 		.close = tls_sock_close_vmeth,
 		.ioctl = tls_sock_ioctl_vmeth,
 	},
+	.shutdown = tls_sock_shutdown_vmeth,
 	.bind = tls_sock_bind_vmeth,
 	.connect = tls_sock_connect_vmeth,
 	.listen = tls_sock_listen_vmeth,

--- a/tests/net/socket/tcp/src/main.c
+++ b/tests/net/socket/tcp/src/main.c
@@ -124,6 +124,13 @@ static void test_recvfrom(int sock,
 		      "unexpected data");
 }
 
+static void test_shutdown(int sock, int how)
+{
+	zassert_equal(shutdown(sock, how),
+		      0,
+		      "shutdown failed");
+}
+
 static void test_close(int sock)
 {
 	zassert_equal(close(sock),
@@ -433,6 +440,102 @@ void test_v6_recv_enotconn(void)
 	test_bind(s_sock, (struct sockaddr *)&s_saddr, sizeof(s_saddr));
 
 	_test_recv_enotconn(c_sock, s_sock);
+}
+
+void test_shutdown_rd_synchronous(void)
+{
+	/* recv() after shutdown(..., SHUT_RD) should return 0 (EOF).
+	 */
+	int c_sock;
+	int s_sock;
+	int new_sock;
+	struct sockaddr_in6 c_saddr, s_saddr;
+	struct sockaddr addr;
+	socklen_t addrlen = sizeof(addr);
+
+	prepare_sock_tcp_v6(CONFIG_NET_CONFIG_MY_IPV6_ADDR, ANY_PORT,
+			    &c_sock, &c_saddr);
+	prepare_sock_tcp_v6(CONFIG_NET_CONFIG_MY_IPV6_ADDR, SERVER_PORT,
+			    &s_sock, &s_saddr);
+
+	test_bind(s_sock, (struct sockaddr *)&s_saddr, sizeof(s_saddr));
+	test_listen(s_sock);
+
+	/* Connect and accept that connection */
+	test_connect(c_sock, (struct sockaddr *)&s_saddr, sizeof(s_saddr));
+
+	test_accept(s_sock, &new_sock, &addr, &addrlen);
+
+	/* Shutdown reception */
+	test_shutdown(c_sock, SHUT_RD);
+
+	/* EOF should be notified by recv() */
+	test_eof(c_sock);
+
+	test_close(new_sock);
+	test_close(s_sock);
+	test_close(c_sock);
+
+	k_sleep(TCP_TEARDOWN_TIMEOUT);
+}
+
+struct shutdown_data {
+	struct k_work_delayable work;
+	int fd;
+	int how;
+};
+
+static void shutdown_work(struct k_work *work)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct shutdown_data *data = CONTAINER_OF(dwork, struct shutdown_data,
+						  work);
+
+	shutdown(data->fd, data->how);
+}
+
+void test_shutdown_rd_while_recv(void)
+{
+	/* Blocking recv() should return EOF after shutdown(..., SHUT_RD) is
+	 * called from another thread.
+	 */
+	int c_sock;
+	int s_sock;
+	int new_sock;
+	struct sockaddr_in6 c_saddr, s_saddr;
+	struct sockaddr addr;
+	socklen_t addrlen = sizeof(addr);
+	struct shutdown_data shutdown_work_data;
+
+	prepare_sock_tcp_v6(CONFIG_NET_CONFIG_MY_IPV6_ADDR, ANY_PORT,
+			    &c_sock, &c_saddr);
+	prepare_sock_tcp_v6(CONFIG_NET_CONFIG_MY_IPV6_ADDR, SERVER_PORT,
+			    &s_sock, &s_saddr);
+
+	test_bind(s_sock, (struct sockaddr *)&s_saddr, sizeof(s_saddr));
+	test_listen(s_sock);
+
+	/* Connect and accept that connection */
+	test_connect(c_sock, (struct sockaddr *)&s_saddr, sizeof(s_saddr));
+
+	test_accept(s_sock, &new_sock, &addr, &addrlen);
+
+	/* Schedule reception shutdown from workqueue */
+	k_work_init_delayable(&shutdown_work_data.work, shutdown_work);
+	shutdown_work_data.fd = c_sock;
+	shutdown_work_data.how = SHUT_RD;
+	k_work_schedule(&shutdown_work_data.work, K_MSEC(10));
+
+	/* Start blocking recv(), which should be unblocked by shutdown() from
+	 * another thread and return EOF (0).
+	 */
+	test_eof(c_sock);
+
+	test_close(new_sock);
+	test_close(s_sock);
+	test_close(c_sock);
+
+	k_sleep(TCP_TEARDOWN_TIMEOUT);
 }
 
 static void calc_net_context(struct net_context *context, void *user_data)
@@ -961,6 +1064,8 @@ void test_main(void)
 		ztest_user_unit_test(test_v6_sendto_recvfrom_null_dest),
 		ztest_user_unit_test(test_v4_recv_enotconn),
 		ztest_user_unit_test(test_v6_recv_enotconn),
+		ztest_user_unit_test(test_shutdown_rd_synchronous),
+		ztest_unit_test(test_shutdown_rd_while_recv),
 		ztest_unit_test(test_open_close_immediately),
 		ztest_user_unit_test(test_v4_accept_timeout),
 		ztest_unit_test(test_so_type),


### PR DESCRIPTION
So far shutdown() implementation was a noop and just resulted in warning
logs. Add shutdown() method into socket vtable. Call it if provided and
fallback into returning -ENOTSUP if not.

Add basic shutdown() implementation for net_context sockets, which
handles only SHUT_RD as 'how' parameter and returns -ENOTSUP for SHUT_WR
and SHUT_RDWR. The main use case to cover is to allow race-free wakeup
of threads calling recv() on the same socket.

Add basic shutdown() implementation of TLS sockets, which basically
calls shutdown() on underlying wrapped sockets.

Fix internal http_client timeout implementation by using shutdown(..., SHUT_RD)
instead of close().

Fixes: #37730