### PR TITLE
 [TOPIC-BLE-LLCP] Tests: unittest: remove extra call to teardown

### DIFF
--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -370,10 +370,6 @@ static int run_test(struct unit_test *test)
 		run_test_functions(test);
 	}
 
-	phase = TEST_PHASE_TEARDOWN;
-	test->teardown();
-	phase = TEST_PHASE_FRAMEWORK;
-
 	if (test_result == -1) {
 		ret = TC_FAIL;
 	}


### PR DESCRIPTION
The missing call to teardown was added in the main branch, this call is
superfluous, resulting in the teardown function being called twice


Signed-off-by: Andries Kruithof <Andries.Kruithof@nordicsemi.no>