### PR TITLE
Bluetooth: Mesh: Coverity fixes for 2021 08 26

### DIFF
--- a/subsys/bluetooth/mesh/cfg_cli.c
+++ b/subsys/bluetooth/mesh/cfg_cli.c
@@ -864,7 +864,7 @@ static int lpn_timeout_status(struct bt_mesh_model *model, struct bt_mesh_msg_ct
 		return -ENOENT;
 	}
 
-	if (param && param->polltimeout) {
+	if (param->polltimeout) {
 		*param->polltimeout = polltimeout;
 	}
 

--- a/subsys/bluetooth/mesh/cfg_cli.c
+++ b/subsys/bluetooth/mesh/cfg_cli.c
@@ -140,8 +140,7 @@ static int krp_status(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	       ctx->net_idx, ctx->app_idx, ctx->addr, buf->len,
 	       bt_hex(buf->data, buf->len));
 
-	if (!bt_mesh_msg_ack_ctx_match(&cli->ack_ctx, OP_KRP_STATUS, ctx->addr,
-				       (void **)&param)) {
+	if (!bt_mesh_msg_ack_ctx_match(&cli->ack_ctx, OP_KRP_STATUS, ctx->addr, (void **)&param)) {
 		return -ENOENT;
 	}
 
@@ -153,11 +152,11 @@ static int krp_status(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		return -ENOENT;
 	}
 
-	if (param && param->status) {
+	if (param->status) {
 		*param->status = status;
 	}
 
-	if (param && param->phase) {
+	if (param->phase) {
 		*param->phase = phase;
 	}
 

--- a/subsys/bluetooth/mesh/shell.c
+++ b/subsys/bluetooth/mesh/shell.c
@@ -1638,6 +1638,7 @@ static int mod_pub_set(const struct shell *shell, uint16_t addr, uint16_t mod_id
 	int err;
 
 	pub.addr = strtoul(argv[0], NULL, 0);
+	pub.uuid = NULL;
 	pub.app_idx = strtoul(argv[1], NULL, 0);
 	pub.cred_flag = str2bool(argv[2]);
 	pub.ttl = strtoul(argv[3], NULL, 0);

--- a/tests/bluetooth/tester/src/mesh.c
+++ b/tests/bluetooth/tester/src/mesh.c
@@ -862,8 +862,7 @@ static void composition_data_get(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_COMP_DATA_GET, CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_COMP_DATA_GET, CONTROLLER_INDEX, BTP_STATUS_FAILED);
 }
 
 static void config_krp_get(uint8_t *data, uint16_t len)
@@ -891,8 +890,7 @@ static void config_krp_get(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_KRP_GET, CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_KRP_GET, CONTROLLER_INDEX, BTP_STATUS_FAILED);
 }
 
 static void config_krp_set(uint8_t *data, uint16_t len)
@@ -920,8 +918,7 @@ static void config_krp_set(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_KRP_SET, CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_KRP_SET, CONTROLLER_INDEX, BTP_STATUS_FAILED);
 }
 
 static void config_beacon_get(uint8_t *data, uint16_t len)
@@ -943,8 +940,7 @@ static void config_beacon_get(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_BEACON_GET, CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_BEACON_GET, CONTROLLER_INDEX, BTP_STATUS_FAILED);
 }
 
 static void config_beacon_set(uint8_t *data, uint16_t len)
@@ -967,8 +963,7 @@ static void config_beacon_set(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_BEACON_SET, CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_BEACON_SET, CONTROLLER_INDEX, BTP_STATUS_FAILED);
 }
 
 static void config_default_ttl_get(uint8_t *data, uint16_t len)
@@ -990,9 +985,8 @@ static void config_default_ttl_get(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_DEFAULT_TTL_GET,
-		   CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_DEFAULT_TTL_GET, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
 }
 
 static void config_default_ttl_set(uint8_t *data, uint16_t len)
@@ -1015,9 +1009,8 @@ static void config_default_ttl_set(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_DEFAULT_TTL_SET,
-		   CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_DEFAULT_TTL_SET, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
 }
 
 static void config_gatt_proxy_get(uint8_t *data, uint16_t len)
@@ -1039,9 +1032,8 @@ static void config_gatt_proxy_get(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_GATT_PROXY_GET,
-		   CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_GATT_PROXY_GET, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
 }
 
 static void config_gatt_proxy_set(uint8_t *data, uint16_t len)
@@ -1064,9 +1056,8 @@ static void config_gatt_proxy_set(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_GATT_PROXY_SET,
-		   CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_GATT_PROXY_SET, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
 }
 
 static void config_friend_get(uint8_t *data, uint16_t len)
@@ -1088,8 +1079,7 @@ static void config_friend_get(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_FRIEND_GET, CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_FRIEND_GET, CONTROLLER_INDEX, BTP_STATUS_FAILED);
 }
 
 static void config_friend_set(uint8_t *data, uint16_t len)
@@ -1112,8 +1102,7 @@ static void config_friend_set(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_FRIEND_SET, CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_FRIEND_SET, CONTROLLER_INDEX, BTP_STATUS_FAILED);
 }
 
 static void config_relay_get(uint8_t *data, uint16_t len)
@@ -1137,8 +1126,7 @@ static void config_relay_get(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_RELAY_GET, CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_RELAY_GET, CONTROLLER_INDEX, BTP_STATUS_FAILED);
 }
 
 static void config_relay_set(uint8_t *data, uint16_t len)
@@ -1162,8 +1150,7 @@ static void config_relay_set(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_RELAY_SET, CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_RELAY_SET, CONTROLLER_INDEX, BTP_STATUS_FAILED);
 }
 
 static void config_mod_pub_get(uint8_t *data, uint16_t len)
@@ -1188,9 +1175,8 @@ static void config_mod_pub_get(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_MODEL_PUB_GET,
-		   CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_MODEL_PUB_GET, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
 }
 
 static void config_mod_pub_set(uint8_t *data, uint16_t len)
@@ -1224,9 +1210,8 @@ static void config_mod_pub_set(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_MODEL_PUB_SET,
-		   CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_MODEL_PUB_SET, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
 }
 
 static void config_mod_pub_va_set(uint8_t *data, uint16_t len)
@@ -1259,9 +1244,8 @@ static void config_mod_pub_va_set(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_MODEL_PUB_VA_SET,
-		   CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_MODEL_PUB_VA_SET, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
 }
 
 static void config_mod_sub_add(uint8_t *data, uint16_t len)
@@ -1286,9 +1270,8 @@ static void config_mod_sub_add(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_MODEL_SUB_ADD,
-		   CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_MODEL_SUB_ADD, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
 }
 
 static void config_mod_sub_ovw(uint8_t *data, uint16_t len)
@@ -1313,9 +1296,8 @@ static void config_mod_sub_ovw(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_MODEL_SUB_OVW,
-		   CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_MODEL_SUB_OVW, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
 }
 
 static void config_mod_sub_del(uint8_t *data, uint16_t len)
@@ -1340,9 +1322,8 @@ static void config_mod_sub_del(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_MODEL_SUB_DEL,
-		   CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_MODEL_SUB_DEL, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
 }
 
 static void config_mod_sub_del_all(uint8_t *data, uint16_t len)
@@ -1367,9 +1348,8 @@ static void config_mod_sub_del_all(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_MODEL_SUB_DEL_ALL,
-		   CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_MODEL_SUB_DEL_ALL, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
 }
 
 static void config_mod_sub_get(uint8_t *data, uint16_t len)
@@ -1396,9 +1376,8 @@ static void config_mod_sub_get(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_MODEL_SUB_GET,
-		   CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_MODEL_SUB_GET, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
 }
 
 static void config_mod_sub_get_vnd(uint8_t *data, uint16_t len)
@@ -1425,9 +1404,8 @@ static void config_mod_sub_get_vnd(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_MODEL_SUB_GET_VND,
-		   CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_MODEL_SUB_GET_VND, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
 }
 
 static void config_mod_sub_va_add(uint8_t *data, uint16_t len)
@@ -1454,9 +1432,8 @@ static void config_mod_sub_va_add(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_MODEL_SUB_VA_ADD,
-		   CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_MODEL_SUB_VA_ADD, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
 }
 
 static void config_mod_sub_va_del(uint8_t *data, uint16_t len)
@@ -1483,9 +1460,8 @@ static void config_mod_sub_va_del(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_MODEL_SUB_VA_DEL,
-		   CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_MODEL_SUB_VA_DEL, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
 }
 
 static void config_mod_sub_va_ovw(uint8_t *data, uint16_t len)
@@ -1512,9 +1488,8 @@ static void config_mod_sub_va_ovw(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_MODEL_SUB_VA_OVW,
-		   CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_MODEL_SUB_VA_OVW, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
 }
 
 static void config_netkey_add(uint8_t *data, uint16_t len)
@@ -1538,8 +1513,7 @@ static void config_netkey_add(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_NETKEY_ADD, CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_NETKEY_ADD, CONTROLLER_INDEX, BTP_STATUS_FAILED);
 }
 
 static void config_netkey_update(uint8_t *data, uint16_t len)
@@ -1564,9 +1538,8 @@ static void config_netkey_update(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_NETKEY_UPDATE,
-		   CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_NETKEY_UPDATE, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
 }
 
 static void config_netkey_get(uint8_t *data, uint16_t len)
@@ -1591,8 +1564,7 @@ static void config_netkey_get(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_NETKEY_GET, CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_NETKEY_GET, CONTROLLER_INDEX, BTP_STATUS_FAILED);
 }
 
 static void config_netkey_del(uint8_t *data, uint16_t len)
@@ -1616,8 +1588,7 @@ static void config_netkey_del(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_NETKEY_DEL, CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_NETKEY_DEL, CONTROLLER_INDEX, BTP_STATUS_FAILED);
 }
 
 static void config_appkey_add(uint8_t *data, uint16_t len)
@@ -1642,8 +1613,7 @@ static void config_appkey_add(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_APPKEY_ADD, CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_APPKEY_ADD, CONTROLLER_INDEX, BTP_STATUS_FAILED);
 }
 
 static void config_appkey_update(uint8_t *data, uint16_t len)
@@ -1668,9 +1638,8 @@ static void config_appkey_update(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_APPKEY_UPDATE,
-		   CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_APPKEY_UPDATE, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
 }
 
 static void config_appkey_del(uint8_t *data, uint16_t len)
@@ -1695,8 +1664,7 @@ static void config_appkey_del(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_APPKEY_DEL, CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_APPKEY_DEL, CONTROLLER_INDEX, BTP_STATUS_FAILED);
 }
 
 static void config_appkey_get(uint8_t *data, uint16_t len)
@@ -1723,8 +1691,7 @@ static void config_appkey_get(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_APPKEY_GET, CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_APPKEY_GET, CONTROLLER_INDEX, BTP_STATUS_FAILED);
 }
 
 static void config_model_app_bind(uint8_t *data, uint16_t len)
@@ -1749,9 +1716,8 @@ static void config_model_app_bind(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_MODEL_APP_BIND,
-		   CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_MODEL_APP_BIND, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
 }
 
 static void config_model_app_bind_vnd(uint8_t *data, uint16_t len)
@@ -1776,9 +1742,8 @@ static void config_model_app_bind_vnd(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_MODEL_APP_BIND_VND,
-		   CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_MODEL_APP_BIND_VND, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
 }
 
 static void config_model_app_unbind(uint8_t *data, uint16_t len)
@@ -1803,9 +1768,8 @@ static void config_model_app_unbind(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_MODEL_APP_UNBIND,
-		   CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_MODEL_APP_UNBIND, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
 }
 
 static void config_model_app_get(uint8_t *data, uint16_t len)
@@ -1832,9 +1796,8 @@ static void config_model_app_get(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_MODEL_APP_GET,
-		   CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_MODEL_APP_GET, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
 }
 
 static void config_model_app_vnd_get(uint8_t *data, uint16_t len)
@@ -1861,9 +1824,8 @@ static void config_model_app_vnd_get(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_MODEL_APP_VND_GET,
-		   CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_MODEL_APP_VND_GET, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
 }
 
 static void config_hb_pub_set(uint8_t *data, uint16_t len)
@@ -1894,9 +1856,8 @@ static void config_hb_pub_set(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_HEARTBEAT_PUB_SET,
-		   CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_HEARTBEAT_PUB_SET, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
 }
 
 static void config_hb_pub_get(uint8_t *data, uint16_t len)
@@ -1920,9 +1881,8 @@ static void config_hb_pub_get(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_HEARTBEAT_PUB_GET,
-		   CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_HEARTBEAT_PUB_GET, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
 }
 
 static void config_hb_sub_set(uint8_t *data, uint16_t len)
@@ -1950,9 +1910,8 @@ static void config_hb_sub_set(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_HEARTBEAT_SUB_SET,
-		   CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_HEARTBEAT_SUB_SET, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
 }
 
 static void config_hb_sub_get(uint8_t *data, uint16_t len)
@@ -1976,9 +1935,8 @@ static void config_hb_sub_get(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_HEARTBEAT_SUB_GET,
-		   CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_HEARTBEAT_SUB_GET, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
 }
 
 static void config_net_trans_get(uint8_t *data, uint16_t len)
@@ -2002,9 +1960,8 @@ static void config_net_trans_get(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_NET_TRANS_GET,
-		   CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_NET_TRANS_GET, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
 }
 
 static void config_net_trans_set(uint8_t *data, uint16_t len)
@@ -2028,9 +1985,8 @@ static void config_net_trans_set(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_NET_TRANS_SET,
-		   CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_NET_TRANS_SET, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
 }
 
 static void config_node_identity_set(uint8_t *data, uint16_t len)
@@ -2061,8 +2017,7 @@ static void config_node_identity_set(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_NODE_IDT_SET, CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_NODE_IDT_SET, CONTROLLER_INDEX, BTP_STATUS_FAILED);
 }
 
 static void config_node_identity_get(uint8_t *data, uint16_t len)
@@ -2093,8 +2048,7 @@ static void config_node_identity_get(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_NODE_IDT_GET, CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_NODE_IDT_GET, CONTROLLER_INDEX, BTP_STATUS_FAILED);
 }
 
 static void config_node_reset(uint8_t *data, uint16_t len)
@@ -2117,8 +2071,7 @@ static void config_node_reset(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_NODE_RESET, CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_NODE_RESET, CONTROLLER_INDEX, BTP_STATUS_FAILED);
 }
 
 static void config_lpn_timeout_get(uint8_t *data, uint16_t len)
@@ -2143,9 +2096,8 @@ static void config_lpn_timeout_get(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_LPN_TIMEOUT_GET,
-		   CONTROLLER_INDEX,
-		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CFG_LPN_TIMEOUT_GET, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
 }
 
 static void health_fault_get(uint8_t *data, uint16_t len)


### PR DESCRIPTION
Fixes all Coverity errors reported on the Bluetooth Mesh subsystem on 2021/08/26.

Fixes zephyrproject-rtos#37948
Fixes zephyrproject-rtos#37949
Fixes zephyrproject-rtos#38016.
Fixes zephyrproject-rtos#37983.
