### PR TITLE
devicetree: delete deprecated header

### DIFF
--- a/include/generated_dts_board.h
+++ b/include/generated_dts_board.h
@@ -1,6 +1,0 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
-
-#warning "generated_dts_board.h has been renamed to devicetree.h. Please include that instead."
-#include <devicetree.h>


### PR DESCRIPTION
Delete the "generated_dts_board.h" file, which was renamed to
devicetree.h a long time ago and was kept for compatibility.