### PR TITLE
CODEOWNERS: add owners for ARC MWDT libC layer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -537,6 +537,7 @@
 /lib/posix/                               @pfalcon
 /subsys/portability/                      @nashif
 /lib/libc/                                @nashif
+/lib/libc/arcmwdt/                        @abrodkin @ruuddw @evgeniy-paltsev
 /modules/                                 @nashif
 /modules/trusted-firmware-m/              @ioannisg @microbuilder
 /kernel/device.c                          @andyross @nashif


### PR DESCRIPTION
Add condeowner for ARC MWDT libC layer files.