### PR TITLE
pm: improve data initialization

### DIFF
--- a/include/device.h
+++ b/include/device.h
@@ -839,6 +839,12 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 	static struct device_state Z_DEVICE_STATE_NAME(dev_name)	\
 	__attribute__((__section__(".z_devstate"))) = {			\
 		.pm = {						        \
+			.usage = ATOMIC_INIT(0),			\
+			.lock = Z_MUTEX_INITIALIZER(			\
+				Z_DEVICE_STATE_NAME(dev_name).pm.lock),	\
+			.condvar = Z_CONDVAR_INITIALIZER(		\
+				Z_DEVICE_STATE_NAME(dev_name).pm.condvar),\
+			.state = PM_DEVICE_STATE_ACTIVE,		\
 			.flags = ATOMIC_INIT(COND_CODE_1(		\
 					DT_NODE_EXISTS(node_id),	\
 					(DT_PROP_OR(			\

--- a/include/device.h
+++ b/include/device.h
@@ -839,7 +839,7 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 	static struct device_state Z_DEVICE_STATE_NAME(dev_name)	\
 	__attribute__((__section__(".z_devstate"))) = {			\
 		.pm = {						        \
-			.usage = ATOMIC_INIT(0),			\
+			.usage = 0U,					\
 			.lock = Z_MUTEX_INITIALIZER(			\
 				Z_DEVICE_STATE_NAME(dev_name).pm.lock),	\
 			.condvar = Z_CONDVAR_INITIALIZER(		\

--- a/include/device.h
+++ b/include/device.h
@@ -831,27 +831,10 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 		(&DEVICE_NAME_GET(dev_name)), level, prio)
 
 #ifdef CONFIG_PM_DEVICE
-/* Use of DT_PROP_OR here is because we cant assume that 'wakeup-source`
- * will be a defined property for the binding of the devicetree node that
- * is associated with the device
- */
 #define Z_DEVICE_STATE_DEFINE(node_id, dev_name)			\
 	static struct device_state Z_DEVICE_STATE_NAME(dev_name)	\
 	__attribute__((__section__(".z_devstate"))) = {			\
-		.pm = {						        \
-			.usage = 0U,					\
-			.lock = Z_MUTEX_INITIALIZER(			\
-				Z_DEVICE_STATE_NAME(dev_name).pm.lock),	\
-			.condvar = Z_CONDVAR_INITIALIZER(		\
-				Z_DEVICE_STATE_NAME(dev_name).pm.condvar),\
-			.state = PM_DEVICE_STATE_ACTIVE,		\
-			.flags = ATOMIC_INIT(COND_CODE_1(		\
-					DT_NODE_EXISTS(node_id),	\
-					(DT_PROP_OR(			\
-					node_id, wakeup_source, 0)),	\
-					(0)) <<			        \
-				PM_DEVICE_FLAGS_WS_CAPABLE),		\
-		},                                                      \
+		.pm = Z_PM_DEVICE_INIT(Z_DEVICE_STATE_NAME(dev_name), node_id) \
 	};
 
 #define Z_DEVICE_DEFINE_PM_INIT(dev_name, pm_control_fn)	\

--- a/include/device.h
+++ b/include/device.h
@@ -831,21 +831,21 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 		(&DEVICE_NAME_GET(dev_name)), level, prio)
 
 #ifdef CONFIG_PM_DEVICE
+#define Z_DEVICE_STATE_PM_INIT(node_id, dev_name)			\
+	.pm = Z_PM_DEVICE_INIT(Z_DEVICE_STATE_NAME(dev_name).pm, node_id),
+#define Z_DEVICE_DEFINE_PM_INIT(dev_name, pm_control_fn)		\
+	.pm_control = (pm_control_fn),					\
+	.pm = &Z_DEVICE_STATE_NAME(dev_name).pm,
+#else
+#define Z_DEVICE_STATE_PM_INIT(node_id, dev_name)
+#define Z_DEVICE_DEFINE_PM_INIT(dev_name, pm_control_fn)
+#endif
+
 #define Z_DEVICE_STATE_DEFINE(node_id, dev_name)			\
 	static struct device_state Z_DEVICE_STATE_NAME(dev_name)	\
 	__attribute__((__section__(".z_devstate"))) = {			\
-		.pm = Z_PM_DEVICE_INIT(Z_DEVICE_STATE_NAME(dev_name), node_id) \
+		Z_DEVICE_STATE_PM_INIT(node_id, dev_name)		\
 	};
-
-#define Z_DEVICE_DEFINE_PM_INIT(dev_name, pm_control_fn)	\
-	.pm_control = (pm_control_fn),				\
-	.pm = &Z_DEVICE_STATE_NAME(dev_name).pm,
-#else
-#define Z_DEVICE_STATE_DEFINE(node_id, dev_name) \
-	__pinned_bss \
-	static struct device_state Z_DEVICE_STATE_NAME(dev_name);
-#define Z_DEVICE_DEFINE_PM_INIT(dev_name, pm_control_fn)
-#endif
 
 #ifdef __cplusplus
 }

--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -126,8 +126,8 @@ struct pm_device {
 #define Z_PM_DEVICE_INIT(obj, node_id)					\
 	{								\
 		.usage = 0U,						\
-		.lock = Z_MUTEX_INITIALIZER(obj.pm.lock),		\
-		.condvar = Z_CONDVAR_INITIALIZER(obj.pm.condvar),	\
+		.lock = Z_MUTEX_INITIALIZER(obj.lock),			\
+		.condvar = Z_CONDVAR_INITIALIZER(obj.condvar),		\
 		.state = PM_DEVICE_STATE_ACTIVE,			\
 		.flags = ATOMIC_INIT(COND_CODE_1(			\
 				DT_NODE_EXISTS(node_id),		\

--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -115,6 +115,27 @@ struct pm_device {
 };
 
 /**
+ * @brief Utility macro to initialize #pm_device.
+ *
+ * @note DT_PROP_OR is used to retrieve the wakeup_source property because
+ * it may not be defined on all devices.
+ *
+ * @param obj Name of the #pm_device structure being initialized.
+ * @param node_id Devicetree node for the initialized device (can be invalid).
+ */
+#define Z_PM_DEVICE_INIT(obj, node_id)					\
+	{								\
+		.usage = 0U,						\
+		.lock = Z_MUTEX_INITIALIZER(obj.pm.lock),		\
+		.condvar = Z_CONDVAR_INITIALIZER(obj.pm.condvar),	\
+		.state = PM_DEVICE_STATE_ACTIVE,			\
+		.flags = ATOMIC_INIT(COND_CODE_1(			\
+				DT_NODE_EXISTS(node_id),		\
+				(DT_PROP_OR(node_id, wakeup_source, 0)),\
+				(0)) << PM_DEVICE_FLAGS_WS_CAPABLE),	\
+	}
+
+/**
  * @brief Device power management control function callback.
  *
  * @param dev Device instance.

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -25,19 +25,6 @@ extern const struct device __device_end[];
 
 extern uint32_t __device_init_status_start[];
 
-static inline void device_pm_state_init(const struct device *dev)
-{
-#ifdef CONFIG_PM_DEVICE
-	*dev->pm = (struct pm_device){
-		.usage = ATOMIC_INIT(0),
-		.lock = Z_MUTEX_INITIALIZER(dev->pm->lock),
-		.condvar = Z_CONDVAR_INITIALIZER(dev->pm->condvar),
-		.state = PM_DEVICE_STATE_ACTIVE,
-		.flags = ATOMIC_INIT(dev->pm->flags),
-	};
-#endif /* CONFIG_PM_DEVICE */
-}
-
 /**
  * @brief Initialize state for all static devices.
  *
@@ -49,7 +36,6 @@ void z_device_state_init(void)
 	const struct device *dev = __device_start;
 
 	while (dev < __device_end) {
-		device_pm_state_init(dev);
 		z_object_init(dev);
 		++dev;
 	}


### PR DESCRIPTION
This PR improves the code used to initialize PM related data structures.

Summary of changes:

```
pm: fully initialize pm_device on Z_DEVICE_STATE_DEFINE

The initialization of the struct pm_device pm field found in the device
state can be statically initialized without the need of doing it at
runtime.
```
```
pm: fix usage initialization

The usage field was being initialized using the ATOMIC_INIT macro,
however, it is just a uint32_t variable.
```
```
pm: device: create struct pm_device initializer

Create a utility macro to initialize struct pm_device. The initializer
is kept in the pm/device.h header.
```
```
device: improve device data initialization

The Z_DEVICE_STATE_DEFINE macro was conditioned by CONFIG_PM_DEVICE.
This is a problem if one day we have other conditional fields in the
device state field that need to be initialized. The approach has been
changed to have an always existing initializer for the PM field, that is
a no-op if device PM is not enabled.
```
```
device: organize state and device initializers

Organize in a more logical flow the device state initializer and
the device initializer parts.
```