### PR TITLE
ARC: qemu_arc_hs6x: enable upstream verification

### DIFF
--- a/boards/arc/qemu_arc/qemu_arc_hs6x.yaml
+++ b/boards/arc/qemu_arc/qemu_arc_hs6x.yaml
@@ -7,6 +7,7 @@ toolchain:
   - cross-compile
   - zephyr
 testing:
+  default: true
   ignore_tags:
     - net
     - bluetooth

--- a/tests/lib/cbprintf_package/testcase.yaml
+++ b/tests/lib/cbprintf_package/testcase.yaml
@@ -1,6 +1,8 @@
 common:
   filter: CONFIG_QEMU_TARGET or CONFIG_BOARD_NATIVE_POSIX
   tags: cbprintf
+  # FIXME: qemu_arc_hs6x excluded, see #38041
+  platform_exclude: qemu_arc_hs6x
   integration_platforms:
     - native_posix
 tests:

--- a/tests/lib/ringbuffer/testcase.yaml
+++ b/tests/lib/ringbuffer/testcase.yaml
@@ -1,5 +1,7 @@
 tests:
   libraries.data_structures:
     tags: ring_buffer circular_buffer
+    # FIXME: qemu_arc_hs6x excluded, see #37861
+    platform_exclude: qemu_arc_hs6x
     integration_platforms:
       - qemu_x86

--- a/tests/subsys/logging/log_api/testcase.yaml
+++ b/tests/subsys/logging/log_api/testcase.yaml
@@ -45,52 +45,72 @@ tests:
       - CONFIG_SAMPLE_MODULE_LOG_LEVEL_DBG=y
 
   logging.log2_api_deferred_overflow_rt_filter:
+    # FIXME: qemu_arc_hs6x excluded, see #38041
+    platform_exclude: qemu_arc_hs6x
     extra_configs:
       - CONFIG_LOG2_MODE_DEFERRED=y
       - CONFIG_LOG_MODE_OVERFLOW=y
       - CONFIG_LOG_RUNTIME_FILTERING=y
 
   logging.log2_api_deferred_overflow:
+    # FIXME: qemu_arc_hs6x excluded, see #38041
+    platform_exclude: qemu_arc_hs6x
     extra_configs:
       - CONFIG_LOG2_MODE_DEFERRED=y
       - CONFIG_LOG_MODE_OVERFLOW=y
 
   logging.log2_api_deferred_no_overflow:
+    # FIXME: qemu_arc_hs6x excluded, see #38041
+    platform_exclude: qemu_arc_hs6x
     extra_configs:
       - CONFIG_LOG2_MODE_DEFERRED=y
       - CONFIG_LOG_MODE_OVERFLOW=n
 
   logging.log2_api_deferred_static_filter:
+    # FIXME: qemu_arc_hs6x excluded, see #38041
+    platform_exclude: qemu_arc_hs6x
     extra_configs:
       - CONFIG_LOG2_MODE_DEFERRED=y
       - CONFIG_SAMPLE_MODULE_LOG_LEVEL_DBG=y
 
   logging.log2_api_deferred_func_prefix:
+    # FIXME: qemu_arc_hs6x excluded, see #38041
+    platform_exclude: qemu_arc_hs6x
     extra_configs:
       - CONFIG_LOG2_MODE_DEFERRED=y
       - CONFIG_SAMPLE_MODULE_LOG_LEVEL_DBG=y
       - CONFIG_LOG_FUNC_NAME_PREFIX_DBG=y
 
   logging.log2_api_deferred_64b_timestamp:
+    # FIXME: qemu_arc_hs6x excluded, see #38041
+    platform_exclude: qemu_arc_hs6x
     extra_configs:
       - CONFIG_LOG2_MODE_DEFERRED=y
       - CONFIG_LOG_TIMESTAMP_64BIT=y
 
   logging.log2_api_immediate:
+    # FIXME: qemu_arc_hs6x excluded, see #38041
+    platform_exclude: qemu_arc_hs6x
     extra_configs:
       - CONFIG_LOG2_MODE_IMMEDIATE=y
 
   logging.log2_api_immediate_rt_filter:
+    # FIXME: qemu_arc_hs6x excluded, see #38041
+    platform_exclude: qemu_arc_hs6x
     extra_configs:
       - CONFIG_LOG2_MODE_IMMEDIATE=y
       - CONFIG_LOG_RUNTIME_FILTERING=y
 
   logging.log2_api_immediate_static_filter:
+    # FIXME: qemu_arc_hs6x excluded, see #38041
+    platform_exclude: qemu_arc_hs6x
     extra_configs:
       - CONFIG_LOG2_MODE_IMMEDIATE=y
       - CONFIG_SAMPLE_MODULE_LOG_LEVEL_DBG=y
 
   logging.log2_api_immediate_64b_timestamp:
+    # FIXME: qemu_arc_hs6x excluded, see #38041
+    platform_exclude: qemu_arc_hs6x
     extra_configs:
       - CONFIG_LOG2_MODE_IMMEDIATE=y
       - CONFIG_LOG_TIMESTAMP_64BIT=y

--- a/tests/subsys/logging/log_msg2/testcase.yaml
+++ b/tests/subsys/logging/log_msg2/testcase.yaml
@@ -1,6 +1,8 @@
 common:
   filter: CONFIG_QEMU_TARGET or CONFIG_BOARD_NATIVE_POSIX
   tags: log_api logging
+  # FIXME: qemu_arc_hs6x excluded, see #38041
+  platform_exclude: qemu_arc_hs6x
   integration_platforms:
     - native_posix
 tests:


### PR DESCRIPTION
`qemu_arc_hs6x` board represents the ARCv3 64bit architecture, so let's enable upstream verification for it.

We temporarily disable a few failing tests for `qemu_arc_hs6x`, see #37861 #38041

We didn't enable upstream verification earlier because we didn't have corresponding toolchain/qemu in older Zephyr SDK. We Have them in 0.13.0 SDK.