### PR TITLE
flash: spi_nor: fix building on XCC

### DIFF
--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -674,6 +674,17 @@ static int spi_nor_erase(const struct device *dev, off_t addr, size_t size)
 				ret = -EINVAL;
 			}
 		}
+
+#ifdef __XCC__
+		/*
+		 * FIXME: remove this hack once XCC is fixed.
+		 *
+		 * Without this volatile return value, XCC would segfault
+		 * compiling this file complaining about failure in CGPREP
+		 * phase.
+		 */
+		volatile int xcc_ret =
+#endif
 		spi_nor_wait_until_ready(dev);
 	}
 


### PR DESCRIPTION
For some reason, XCC fails to build complaining segfault
during CGPREP phase. Adding an assignment to a volatile
return value seems to fix this. This provides an easily
revertable commit to workaround the issue.

Fixes #37734

Signed-off-by: Daniel Leung <daniel.leung@intel.com>