### PR TITLE
Bluetooth: Fix missing rewrite `attr`

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -2293,6 +2293,8 @@ int bt_gatt_notify_cb(struct bt_conn *conn,
 		if (!gatt_find_by_uuid(&data, params->uuid)) {
 			return -ENOENT;
 		}
+
+		params->attr = data.attr;
 	} else {
 		if (!data.handle) {
 			return -ENOENT;

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -2371,6 +2371,8 @@ int bt_gatt_indicate(struct bt_conn *conn,
 		if (!gatt_find_by_uuid(&data, params->uuid)) {
 			return -ENOENT;
 		}
+
+		params->attr = data.attr;
 	} else {
 		if (!data.handle) {
 			return -ENOENT;


### PR DESCRIPTION
When call `bt_gatt_notify_cb` with param->attr set to null.
and attr->uuid set to given uuid, the internal notify will
search uuid, but not assigned to param->attr, which cauce
null point reference when:
   notify --> gatt_notify  --> bt_gatt_check_perm

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>