### PR TITLE
samples: basic: blinky_pwm: Add details in README to support nucleo w…

### DIFF
--- a/samples/basic/blinky_pwm/README.rst
+++ b/samples/basic/blinky_pwm/README.rst
@@ -58,6 +58,8 @@ In these other cases, however, manual wiring is necessary:
      - connect PWM2 (PA0) to an LED
    * - :ref:`nucleo_f103rb_board`
      - connect PWM1 (PA8) to an LED
+   * - :ref:`nucleo_wb55rg_board`
+     - connect PWM1 (PA8) to an LED
 
 Building and Running
 ********************

--- a/samples/basic/blinky_pwm/boards/nucleo_wb55rg.overlay
+++ b/samples/basic/blinky_pwm/boards/nucleo_wb55rg.overlay
@@ -1,0 +1,18 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2021 Planet Innovation
+ */
+
+/ {
+	pwmleds {
+		compatible = "pwm-leds";
+		external_pwm_led: external_pwm_led {
+			pwms = <&pwm1 1 0 PWM_POLARITY_NORMAL>;
+		};
+	};
+
+	aliases {
+		pwm-led0 = &external_pwm_led;
+	};
+};


### PR DESCRIPTION
samples: basic: blinky_pwm: Add support for nucleo_wb55rg platform

 Create a board overlay file in the application directory to add
 pwm-led0 entry over default device tree. Also, include instruction
 in the README file that connection of external LED at pin PA8 is
 required for the demo to work.

Signed-off-by: Waqas Mazhar <waqas.mazhar@planetinnovation.com.au>