### PR TITLE
Bluetooth: host: Force hci reponse opcode match cmd

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2007,6 +2007,7 @@ static void hci_cmd_done(uint16_t opcode, uint8_t status, struct net_buf *buf)
 	if (cmd(buf)->opcode != opcode) {
 		BT_WARN("OpCode 0x%04x completed instead of expected 0x%04x",
 			opcode, cmd(buf)->opcode);
+		return;
 	}
 
 	if (cmd(buf)->state && !status) {


### PR DESCRIPTION
We should force match opcode ins of ignore it.

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>