### PR TITLE
pm; device: Remove force and transitional states

### DIFF
--- a/doc/reference/power_management/index.rst
+++ b/doc/reference/power_management/index.rst
@@ -253,16 +253,6 @@ The four device power states:
    Most device context is lost by the hardware. Device drivers must save and
    restore or reinitialize any context lost by the hardware.
 
-:code:`PM_DEVICE_STATE_SUSPENDING`
-
-   Device is currently transitioning from :c:macro:`PM_DEVICE_STATE_ACTIVE` to
-   :c:macro:`PM_DEVICE_STATE_SUSPENDED`.
-
-:code:`PM_DEVICE_STATE_RESUMING`
-
-   Device is currently transitioning from :c:macro:`PM_DEVICE_STATE_SUSPENDED`
-   to :c:macro:`PM_DEVICE_STATE_ACTIVE`.
-
 :code:`PM_DEVICE_STATE_OFF`
 
    Power has been fully removed from the device. The device context is lost

--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -43,13 +43,6 @@ enum pm_device_state {
 	 */
 	PM_DEVICE_STATE_SUSPENDED,
 	/**
-	 * Device is suspended (forced).
-	 *
-	 * @note
-	 *     Device context may be lost.
-	 */
-	PM_DEVICE_STATE_FORCE_SUSPEND,
-	/**
 	 * Device is turned off (power removed).
 	 *
 	 * @note

--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -48,11 +48,7 @@ enum pm_device_state {
 	 * @note
 	 *     Device context is lost.
 	 */
-	PM_DEVICE_STATE_OFF,
-	/** Device is being resumed. */
-	PM_DEVICE_STATE_RESUMING,
-	/** Device is being suspended. */
-	PM_DEVICE_STATE_SUSPENDING,
+	PM_DEVICE_STATE_OFF
 };
 
 /** @brief Device PM flags. */
@@ -66,6 +62,8 @@ enum pm_device_flag {
 	PM_DEVICE_FLAGS_WS_CAPABLE,
 	/** Indicates if the device is being used as wakeup source. */
 	PM_DEVICE_FLAGS_WS_ENABLED,
+	/** Indicates that the device is changing its state */
+	PM_DEVICE_FLAG_TRANSITIONING,
 	/** Number of flags (internal use only). */
 	PM_DEVICE_FLAG_COUNT
 };
@@ -140,8 +138,9 @@ const char *pm_device_state_str(enum pm_device_state state);
  *
  * @retval 0 If successful.
  * @retval -ENOTSUP If requested state is not supported.
- * @retval -EALREADY If device is already at (or transitioning to) the requested
- *         state.
+ * @retval -EALREADY If device is already at the requested state.
+ * @retval -EBUSY If device is changing its state.
+
  * @retval Errno Other negative errno on failure.
  */
 int pm_device_state_set(const struct device *dev,

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -64,11 +64,6 @@ int pm_low_power_devices(void)
 	return _pm_devices(PM_DEVICE_STATE_LOW_POWER);
 }
 
-int pm_force_suspend_devices(void)
-{
-	return _pm_devices(PM_DEVICE_STATE_FORCE_SUSPEND);
-}
-
 void pm_resume_devices(void)
 {
 	size_t i;
@@ -91,8 +86,6 @@ const char *pm_device_state_str(enum pm_device_state state)
 		return "low power";
 	case PM_DEVICE_STATE_SUSPENDED:
 		return "suspended";
-	case PM_DEVICE_STATE_FORCE_SUSPEND:
-		return "force suspend";
 	case PM_DEVICE_STATE_OFF:
 		return "off";
 	default:
@@ -128,13 +121,6 @@ int pm_device_state_set(const struct device *dev,
 		}
 
 		action = PM_DEVICE_ACTION_RESUME;
-		break;
-	case PM_DEVICE_STATE_FORCE_SUSPEND:
-		if (dev->pm->state == state) {
-			return -EALREADY;
-		}
-
-		action = PM_DEVICE_ACTION_FORCE_SUSPEND;
 		break;
 	case PM_DEVICE_STATE_LOW_POWER:
 		if (dev->pm->state == state) {

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -103,10 +103,13 @@ int pm_device_state_set(const struct device *dev,
 		return -ENOSYS;
 	}
 
+	if (atomic_test_bit(&dev->pm->flags, PM_DEVICE_FLAG_TRANSITIONING)) {
+		return -EBUSY;
+	}
+
 	switch (state) {
 	case PM_DEVICE_STATE_SUSPENDED:
-		if ((dev->pm->state == PM_DEVICE_STATE_SUSPENDED) ||
-		    (dev->pm->state == PM_DEVICE_STATE_SUSPENDING)) {
+		if (dev->pm->state == PM_DEVICE_STATE_SUSPENDED) {
 			return -EALREADY;
 		} else if (dev->pm->state == PM_DEVICE_STATE_OFF) {
 			return -ENOTSUP;
@@ -115,8 +118,7 @@ int pm_device_state_set(const struct device *dev,
 		action = PM_DEVICE_ACTION_SUSPEND;
 		break;
 	case PM_DEVICE_STATE_ACTIVE:
-		if ((dev->pm->state == PM_DEVICE_STATE_ACTIVE) ||
-		    (dev->pm->state == PM_DEVICE_STATE_RESUMING)) {
+		if (dev->pm->state == PM_DEVICE_STATE_ACTIVE) {
 			return -EALREADY;
 		}
 

--- a/tests/kernel/device/src/main.c
+++ b/tests/kernel/device/src/main.c
@@ -335,8 +335,8 @@ void test_dummy_device_pm(void)
 	zassert_true((device_power_state == PM_DEVICE_STATE_ACTIVE),
 			"Error power status");
 
-	/* Set device state to PM_DEVICE_STATE_FORCE_SUSPEND */
-	ret = pm_device_state_set(dev, PM_DEVICE_STATE_FORCE_SUSPEND);
+	/* Set device state to PM_DEVICE_STATE_SUSPENDED */
+	ret = pm_device_state_set(dev, PM_DEVICE_STATE_SUSPENDED);
 
 	zassert_true((ret == 0), "Unable to force suspend device");
 


### PR DESCRIPTION
- Remove `PM_DEVICE_STATE_FORCE_SUSPEND`. This is not properly a state but an action.
- Remove transitional states. Keep information about transition using device pm flags.