### PR TITLE
tests: kernel: timer api with real time slot in test_sleep_abs

### DIFF
--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -802,11 +802,11 @@ void test_sleep_abs(void)
 	/* Systems with very high tick rates and/or slow idle resume
 	 * (I've seen this on intel_adsp) can occasionally take more
 	 * than a tick to return from k_sleep().  Set a 100us real
-	 * time slop.
+	 *  time slop or more depending on the time to resume
 	 */
 	k_ticks_t late = end - (start + sleep_ticks);
 
-	zassert_true(late >= 0 && late < k_us_to_ticks_ceil32(100),
+	zassert_true(late >= 0 && late < k_us_to_ticks_ceil32(250),
 		     "expected wakeup at %lld, got %lld (late %lld)",
 		     start + sleep_ticks, end, late);
 }


### PR DESCRIPTION
This patch is testing the test_sleep_abs with a real time slot value
that depends on the TICKS_PER_SEC. The reason is that for platforms
like stm32wb55rg with PM, the real time slot must be adjusted because
of the LPTIM ticker.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/35720

Signed-off-by: Francois Ramu <francois.ramu@st.com>