### PR TITLE
json: Changes enum name of square brackets from list to array

### DIFF
--- a/include/data/json.h
+++ b/include/data/json.h
@@ -37,8 +37,12 @@ enum json_tokens {
 	JSON_TOK_NONE = '_',
 	JSON_TOK_OBJECT_START = '{',
 	JSON_TOK_OBJECT_END = '}',
-	JSON_TOK_LIST_START = '[',
-	JSON_TOK_LIST_END = ']',
+	/* JSON_TOK_LIST_START will be removed use JSON_TOK_ARRAY_START */
+	JSON_TOK_LIST_START __deprecated = '[',
+	JSON_TOK_ARRAY_START = '[',
+	/* JSON_TOK_LIST_END will be removed use JSON_TOK_ARRAY_END */
+	JSON_TOK_LIST_END __deprecated = ']',
+	JSON_TOK_ARRAY_END = ']',
 	JSON_TOK_STRING = '"',
 	JSON_TOK_COLON = ':',
 	JSON_TOK_COMMA = ',',
@@ -65,7 +69,7 @@ struct json_obj_descr {
 
 	/* Valid values here (enum json_tokens): JSON_TOK_STRING,
 	 * JSON_TOK_NUMBER, JSON_TOK_TRUE, JSON_TOK_FALSE,
-	 * JSON_TOK_OBJECT_START, JSON_TOK_LIST_START.  (All others
+	 * JSON_TOK_OBJECT_START, JSON_TOK_ARRAY_START.  (All others
 	 * ignored.) Maximum value is '}' (125), so this has to be 7 bits
 	 * long.
 	 */
@@ -201,7 +205,7 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.field_name = (#field_name_), \
 		.align_shift = Z_ALIGN_SHIFT(struct_), \
 		.field_name_len = sizeof(#field_name_) - 1, \
-		.type = JSON_TOK_LIST_START, \
+		.type = JSON_TOK_ARRAY_START, \
 		.offset = offsetof(struct_, field_name_), \
 		{ \
 			.array = { \
@@ -258,7 +262,7 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.field_name = (#field_name_), \
 		.align_shift = Z_ALIGN_SHIFT(struct_), \
 		.field_name_len = sizeof(#field_name_) - 1, \
-		.type = JSON_TOK_LIST_START, \
+		.type = JSON_TOK_ARRAY_START, \
 		.offset = offsetof(struct_, field_name_), \
 		{ \
 			.array = { \
@@ -331,14 +335,14 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.field_name = (#field_name_), \
 		.align_shift = Z_ALIGN_SHIFT(struct_), \
 		.field_name_len = sizeof(#field_name_) - 1, \
-		.type = JSON_TOK_LIST_START, \
+		.type = JSON_TOK_ARRAY_START, \
 		.offset = offsetof(struct_, field_name_), \
 		{ \
 			.array = { \
 				.element_descr = (struct json_obj_descr[]) { { \
 					.align_shift = \
 						Z_ALIGN_SHIFT(struct_), \
-					.type = JSON_TOK_LIST_START, \
+					.type = JSON_TOK_ARRAY_START, \
 					.offset = offsetof(struct_, \
 							   len_field_), \
 					{ \
@@ -434,7 +438,7 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.field_name = (json_field_name_), \
 		.align_shift = Z_ALIGN_SHIFT(struct_), \
 		.field_name_len = sizeof(json_field_name_) - 1, \
-		.type = JSON_TOK_LIST_START, \
+		.type = JSON_TOK_ARRAY_START, \
 		.offset = offsetof(struct_, struct_field_name_), \
 		{ \
 			.array = { \
@@ -498,7 +502,7 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.field_name = json_field_name_, \
 		.align_shift = Z_ALIGN_SHIFT(struct_), \
 		.field_name_len = sizeof(json_field_name_) - 1, \
-		.type = JSON_TOK_LIST_START, \
+		.type = JSON_TOK_ARRAY_START, \
 		.offset = offsetof(struct_, struct_field_name_), \
 		{ \
 			.array = { \

--- a/lib/os/json.c
+++ b/lib/os/json.c
@@ -306,7 +306,7 @@ static int element_token(enum json_tokens token)
 {
 	switch (token) {
 	case JSON_TOK_OBJECT_START:
-	case JSON_TOK_LIST_START:
+	case JSON_TOK_ARRAY_START:
 	case JSON_TOK_STRING:
 	case JSON_TOK_NUMBER:
 	case JSON_TOK_TRUE:
@@ -375,7 +375,7 @@ static int arr_next(struct json_obj *json, struct token *value)
 		return -EINVAL;
 	}
 
-	if (value->type == JSON_TOK_LIST_END) {
+	if (value->type == JSON_TOK_ARRAY_END) {
 		return 0;
 	}
 
@@ -445,7 +445,7 @@ static int decode_value(struct json_obj *obj,
 		return obj_parse(obj, descr->object.sub_descr,
 				 descr->object.sub_descr_len,
 				 field);
-	case JSON_TOK_LIST_START:
+	case JSON_TOK_ARRAY_START:
 		return arr_parse(obj, descr->array.element_descr,
 				 descr->array.n_elements, field, val);
 	case JSON_TOK_FALSE:
@@ -484,7 +484,7 @@ static ptrdiff_t get_elem_size(const struct json_obj_descr *descr)
 	case JSON_TOK_TRUE:
 	case JSON_TOK_FALSE:
 		return sizeof(bool);
-	case JSON_TOK_LIST_START:
+	case JSON_TOK_ARRAY_START:
 		return descr->array.n_elements * get_elem_size(descr->array.element_descr);
 	case JSON_TOK_OBJECT_START: {
 		ptrdiff_t total = 0;
@@ -523,7 +523,7 @@ static int arr_parse(struct json_obj *obj,
 	}
 
 	while (!arr_next(obj, &value)) {
-		if (value.type == JSON_TOK_LIST_END) {
+		if (value.type == JSON_TOK_ARRAY_END) {
 			return 0;
 		}
 
@@ -819,7 +819,7 @@ static int encode(const struct json_obj_descr *descr, const void *val,
 		return bool_encode(ptr, append_bytes, data);
 	case JSON_TOK_STRING:
 		return str_encode(ptr, append_bytes, data);
-	case JSON_TOK_LIST_START:
+	case JSON_TOK_ARRAY_START:
 		return arr_encode(descr->array.element_descr, ptr,
 				  val, append_bytes, data);
 	case JSON_TOK_OBJECT_START:


### PR DESCRIPTION
Pretty straight forward, changed name of enums token from JSON_TOK_LIST_ to JSON_TOK_ARRAY_

