### PR TITLE
stm32 LPTIMER interrupt  priority set to 1

### DIFF
--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -207,7 +207,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40007c00 0x400>;
-			interrupts = <17 0>;
+			interrupts = <17 1>;
 			interrupt-names = "wakeup";
 			status = "disabled";
 			label = "LPTIM_1";

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -269,7 +269,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40007c00 0x400>;
-			interrupts = <13 0>;
+			interrupts = <13 1>;
 			interrupt-names = "wakeup";
 			status = "disabled";
 			label = "LPTIM_1";

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -394,7 +394,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40007c00 0x400>;
-			interrupts = <65 0>;
+			interrupts = <65 1>;
 			interrupt-names = "wakeup";
 			status = "disabled";
 			label = "LPTIM_1";

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -277,7 +277,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40007c00 0x400>;
-			interrupts = <67 0>;
+			interrupts = <67 1>;
 			interrupt-names = "wakeup";
 			status = "disabled";
 			label = "LPTIM_1";

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -369,7 +369,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40007c00 0x400>;
-			interrupts = <47 0>;
+			interrupts = <47 1>;
 			interrupt-names = "wakeup";
 			status = "disabled";
 			label = "LPTIM_1";

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -161,7 +161,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40007c00 0x400>;
-			interrupts = <39 0>;
+			interrupts = <39 1>;
 			interrupt-names = "wakeup";
 			status = "disabled";
 			label = "LPTIM_1";


### PR DESCRIPTION
The priority  of the LPTIM irq is set to the same level as the systick irq priority
in the DTS of each stm32 devices that enables the LPTIMer for LowPower management

The priority of the kernel systick interrupt is read as 1 in the system Handler priority reg (SHPR3)
when the PM is not configured. For those stm32 devices, when the CONFIG_PM is on, the kernel
is ticked by the LPTIMer, which priority level is also set to 1.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/38031

Signed-off-by: Francois Ramu <francois.ramu@st.com>