### PR TITLE
ipc: rpmsg_multi_instance: Some fixes and init cleanup

### DIFF
--- a/include/ipc/rpmsg_multi_instance.h
+++ b/include/ipc/rpmsg_multi_instance.h
@@ -98,7 +98,7 @@ struct rpmsg_mi_ctx {
 
 	unsigned int ipm_tx_id;
 
-	uint32_t shm_status_reg_addr;
+	uintptr_t shm_status_reg_addr;
 	struct metal_io_region *shm_io;
 	struct metal_device shm_device;
 	metal_phys_addr_t shm_physmap[1];
@@ -111,8 +111,8 @@ struct rpmsg_mi_ctx {
 	struct virtio_vring_info rvrings[2];
 	struct virtio_device vdev;
 
-	uint32_t vring_tx_addr;
-	uint32_t vring_rx_addr;
+	uintptr_t vring_tx_addr;
+	uintptr_t vring_rx_addr;
 
 	sys_slist_t endpoints;
 };

--- a/subsys/ipc/rpmsg_multi_instance/rpmsg_multi_instance.c
+++ b/subsys/ipc/rpmsg_multi_instance/rpmsg_multi_instance.c
@@ -201,69 +201,47 @@ static bool rpmsg_mi_config_verify(const struct rpmsg_mi_ctx_cfg *cfg)
 	return true;
 }
 
-int rpmsg_mi_ctx_init(struct rpmsg_mi_ctx *ctx, const struct rpmsg_mi_ctx_cfg *cfg)
+static int libmetal_setup(struct rpmsg_mi_ctx *ctx)
 {
 	struct metal_init_params metal_params = METAL_INIT_DEFAULTS;
-	size_t vring_size = VRING_SIZE_GET(cfg->shm->size);
 	struct metal_device *device;
-	int err = 0;
+	int err;
 
-	if (!ctx || !cfg) {
-		return -EINVAL;
-	}
-
-	if (!rpmsg_mi_config_verify(cfg)) {
-		return -EIO;
-	}
-
-	LOG_DBG("RPMsg multiple instance initialization");
-
-	k_mutex_lock(&shm_mutex, K_FOREVER);
-
-	/* Start IPM workqueue */
-	k_work_queue_start(&ctx->ipm_work_q, cfg->ipm_stack_area,
-			   cfg->ipm_stack_size, cfg->ipm_work_q_prio, NULL);
-	k_thread_name_set(&ctx->ipm_work_q.thread, cfg->ipm_thread_name);
-	k_work_init(&ctx->ipm_work, ipm_callback_process);
-
-	ctx->name = cfg->name;
-	sys_slist_init(&ctx->endpoints);
-
-	/* Configure share memory */
-	rpmsg_mi_configure_shm(ctx, cfg);
-
-	/* Libmetal setup */
 	err = metal_init(&metal_params);
 	if (err) {
 		LOG_ERR("metal_init: failed - error code %d", err);
-		goto out;
+		return err;
 	}
 
 	err = metal_register_generic_device(&ctx->shm_device);
 	if (err) {
 		LOG_ERR("Could not register shared memory device: %d", err);
-		goto out;
+		return err;
 	}
 
 	err = metal_device_open("generic", SHM_DEVICE_NAME, &device);
 	if (err) {
 		LOG_ERR("metal_device_open failed: %d", err);
-		goto out;
+		return err;
 	}
 
 	ctx->shm_io = metal_device_io_region(device, 0);
 	if (!ctx->shm_io) {
 		LOG_ERR("metal_device_io_region failed to get region");
-		err = -ENODEV;
-		goto out;
+		return -ENODEV;
 	}
 
-	 /* IPM setup. */
+	return 0;
+}
+
+static int ipm_setup(struct rpmsg_mi_ctx *ctx, const struct rpmsg_mi_ctx_cfg *cfg)
+{
+	int err;
+
 	ctx->ipm_tx_handle = device_get_binding(cfg->ipm_tx_name);
 	if (!ctx->ipm_tx_handle) {
 		LOG_ERR("Could not get TX IPM device handle");
-		err = -ENODEV;
-		goto out;
+		return -ENODEV;
 	}
 
 	ctx->ipm_tx_id = cfg->ipm_tx_id;
@@ -271,11 +249,15 @@ int rpmsg_mi_ctx_init(struct rpmsg_mi_ctx *ctx, const struct rpmsg_mi_ctx_cfg *c
 	ctx->ipm_rx_handle = device_get_binding(cfg->ipm_rx_name);
 	if (!ctx->ipm_rx_handle) {
 		LOG_ERR("Could not get RX IPM device handle");
-		err = -ENODEV;
-		goto out;
+		return -ENODEV;
 	}
 
-	/* Register IPM callback. This cb executes when msg has come. */
+	k_work_queue_start(&ctx->ipm_work_q, cfg->ipm_stack_area,
+			   cfg->ipm_stack_size, cfg->ipm_work_q_prio, NULL);
+	k_thread_name_set(&ctx->ipm_work_q.thread, cfg->ipm_thread_name);
+
+	k_work_init(&ctx->ipm_work, ipm_callback_process);
+
 	ipm_register_callback(ctx->ipm_rx_handle, ipm_callback, ctx);
 
 	err = ipm_set_enabled(ctx->ipm_rx_handle, 1);
@@ -284,18 +266,21 @@ int rpmsg_mi_ctx_init(struct rpmsg_mi_ctx *ctx, const struct rpmsg_mi_ctx_cfg *c
 		return err;
 	}
 
+	return 0;
+}
+
+static int vq_setup(struct rpmsg_mi_ctx *ctx, size_t vring_size)
+{
 	ctx->vq[RPMSG_VQ_0] = virtqueue_allocate(vring_size);
 	if (!ctx->vq[RPMSG_VQ_0]) {
 		LOG_ERR("virtqueue_allocate failed to alloc vq[RPMSG_VQ_0]");
-		err = -ENOMEM;
-		goto out;
+		return -ENOMEM;
 	}
 
 	ctx->vq[RPMSG_VQ_1] = virtqueue_allocate(vring_size);
 	if (!ctx->vq[RPMSG_VQ_1]) {
 		LOG_ERR("virtqueue_allocate failed to alloc vq[RPMSG_VQ_1]");
-		err = -ENOMEM;
-		goto out;
+		return -ENOMEM;
 	}
 
 	ctx->rvrings[RPMSG_VQ_0].io = ctx->shm_io;
@@ -317,6 +302,52 @@ int rpmsg_mi_ctx_init(struct rpmsg_mi_ctx *ctx, const struct rpmsg_mi_ctx_cfg *c
 	ctx->vdev.func = &dispatch;
 	ctx->vdev.vrings_info = &ctx->rvrings[0];
 
+	return 0;
+}
+
+int rpmsg_mi_ctx_init(struct rpmsg_mi_ctx *ctx, const struct rpmsg_mi_ctx_cfg *cfg)
+{
+	int err = 0;
+
+	if (!ctx || !cfg) {
+		return -EINVAL;
+	}
+
+	LOG_DBG("RPMsg multiple instance initialization");
+
+	if (!rpmsg_mi_config_verify(cfg)) {
+		return -EIO;
+	}
+
+	k_mutex_lock(&shm_mutex, K_FOREVER);
+
+	/* Configure shared memory */
+	rpmsg_mi_configure_shm(ctx, cfg);
+
+	/* Setup libmetal */
+	err = libmetal_setup(ctx);
+	if (err) {
+		LOG_ERR("Failed to setup libmetal");
+		goto out;
+	}
+
+	/* Setup IPM */
+	err = ipm_setup(ctx, cfg);
+	if (err) {
+		LOG_ERR("Failed to setup IPM");
+		goto out;
+	}
+
+	/* Setup VQs / VRINGs */
+	err = vq_setup(ctx, VRING_SIZE_GET(cfg->shm->size));
+	if (err) {
+		LOG_ERR("Failed to setup VQs / VRINGs");
+		goto out;
+	}
+
+	ctx->name = cfg->name;
+	sys_slist_init(&ctx->endpoints);
+
 	if (IS_ENABLED(CONFIG_RPMSG_MULTI_INSTANCE_MASTER)) {
 		/* This step is only required if you are VirtIO device master.
 		 * Initialize the shared buffers pool.
@@ -329,7 +360,6 @@ int rpmsg_mi_ctx_init(struct rpmsg_mi_ctx *ctx, const struct rpmsg_mi_ctx_cfg *c
 	} else {
 		err = rpmsg_init_vdev(&ctx->rvdev, &ctx->vdev, NULL, ctx->shm_io, NULL);
 	}
-
 
 	if (err) {
 		LOG_ERR("RPMSG vdev initialization failed %d", err);

--- a/subsys/ipc/rpmsg_multi_instance/rpmsg_multi_instance.c
+++ b/subsys/ipc/rpmsg_multi_instance/rpmsg_multi_instance.c
@@ -99,7 +99,7 @@ static void ipm_callback(const struct device *dev, void *context, uint32_t id, v
 	k_work_submit_to_queue(&ctx->ipm_work_q, &ctx->ipm_work);
 }
 
-int rpmsg_mi_configure_shm(struct rpmsg_mi_ctx *ctx, const struct rpmsg_mi_ctx_cfg *cfg)
+static void rpmsg_mi_configure_shm(struct rpmsg_mi_ctx *ctx, const struct rpmsg_mi_ctx_cfg *cfg)
 {
 	size_t vring_size = VRING_SIZE_GET(cfg->shm->size);
 	uintptr_t shm_addr = SHMEM_INST_ADDR_AUTOALLOC_GET(cfg->shm->addr,
@@ -133,8 +133,6 @@ int rpmsg_mi_configure_shm(struct rpmsg_mi_ctx *ctx, const struct rpmsg_mi_ctx_c
 
 	ctx->vring_rx_addr = shm_local_start_addr + rpmsg_reg_size;
 	ctx->vring_tx_addr = ctx->vring_rx_addr + vring_region_size;
-
-	return 0;
 }
 
 static int ept_cb(struct rpmsg_endpoint *ept, void *data, size_t len, uint32_t src, void *priv)
@@ -233,11 +231,7 @@ int rpmsg_mi_ctx_init(struct rpmsg_mi_ctx *ctx, const struct rpmsg_mi_ctx_cfg *c
 	sys_slist_init(&ctx->endpoints);
 
 	/* Configure share memory */
-	err = rpmsg_mi_configure_shm(ctx, cfg);
-	if (err) {
-		LOG_ERR("shmem configuration: failed - error code %d", err);
-		goto out;
-	}
+	rpmsg_mi_configure_shm(ctx, cfg);
 
 	/* Libmetal setup */
 	err = metal_init(&metal_params);

--- a/subsys/ipc/rpmsg_multi_instance/rpmsg_multi_instance.c
+++ b/subsys/ipc/rpmsg_multi_instance/rpmsg_multi_instance.c
@@ -146,7 +146,6 @@ static int ept_cb(struct rpmsg_endpoint *ept, void *data, size_t len, uint32_t s
 			mi_ep->bound = true;
 			if (mi_ep->cb->bound) {
 				mi_ep->cb->bound(mi_ep->priv);
-				return 0;
 			}
 		}
 		return 0;

--- a/subsys/ipc/rpmsg_multi_instance/rpmsg_multi_instance.c
+++ b/subsys/ipc/rpmsg_multi_instance/rpmsg_multi_instance.c
@@ -27,7 +27,7 @@ static void rpmsg_service_unbind(struct rpmsg_endpoint *p_ep)
 static unsigned char virtio_get_status(struct virtio_device *p_vdev)
 {
 	struct  rpmsg_mi_ctx *ctx = metal_container_of(p_vdev, struct rpmsg_mi_ctx, vdev);
-	unsigned char ret = VIRTIO_CONFIG_STATUS_DRIVER_OK;
+	uint8_t ret = VIRTIO_CONFIG_STATUS_DRIVER_OK;
 
 	if (!IS_ENABLED(CONFIG_RPMSG_MULTI_INSTANCE_MASTER)) {
 		sys_cache_data_range(&ctx->shm_status_reg_addr,
@@ -101,17 +101,17 @@ static void ipm_callback(const struct device *dev, void *context, uint32_t id, v
 
 int rpmsg_mi_configure_shm(struct rpmsg_mi_ctx *ctx, const struct rpmsg_mi_ctx_cfg *cfg)
 {
-	uint8_t vring_size = VRING_SIZE_GET(cfg->shm->size);
-	uint32_t shm_addr = SHMEM_INST_ADDR_AUTOALLOC_GET(cfg->shm->addr,
+	size_t vring_size = VRING_SIZE_GET(cfg->shm->size);
+	uintptr_t shm_addr = SHMEM_INST_ADDR_AUTOALLOC_GET(cfg->shm->addr,
 							  cfg->shm->size,
 							  cfg->shm->instance);
-	uint32_t shm_size = SHMEM_INST_SIZE_AUTOALLOC_GET(cfg->shm->size);
+	size_t shm_size = SHMEM_INST_SIZE_AUTOALLOC_GET(cfg->shm->size);
 
-	uint32_t shm_local_start_addr = shm_addr + VDEV_STATUS_SIZE;
-	uint32_t shm_local_size = shm_size - VDEV_STATUS_SIZE;
+	uintptr_t shm_local_start_addr = shm_addr + VDEV_STATUS_SIZE;
+	size_t shm_local_size = shm_size - VDEV_STATUS_SIZE;
 
-	uint32_t rpmsg_reg_size = VRING_COUNT * VIRTQUEUE_SIZE_GET(vring_size);
-	uint32_t vring_region_size = VRING_SIZE_COMPUTE(vring_size, VRING_ALIGNMENT);
+	size_t rpmsg_reg_size = VRING_COUNT * VIRTQUEUE_SIZE_GET(vring_size);
+	size_t vring_region_size = VRING_SIZE_COMPUTE(vring_size, VRING_ALIGNMENT);
 
 	ctx->shm_status_reg_addr = shm_addr;
 	ctx->shm_physmap[0] = shm_local_start_addr;
@@ -207,7 +207,7 @@ static bool rpmsg_mi_config_verify(const struct rpmsg_mi_ctx_cfg *cfg)
 int rpmsg_mi_ctx_init(struct rpmsg_mi_ctx *ctx, const struct rpmsg_mi_ctx_cfg *cfg)
 {
 	struct metal_init_params metal_params = METAL_INIT_DEFAULTS;
-	uint8_t vring_size = VRING_SIZE_GET(cfg->shm->size);
+	size_t vring_size = VRING_SIZE_GET(cfg->shm->size);
 	struct metal_device *device;
 	int err = 0;
 


### PR DESCRIPTION
A less controversial cleanup of the `rpmsg_multi_instance` driver and some fixes.