### PR TITLE
samples/basic/threads: Enable thread awareness

### DIFF
--- a/samples/basic/threads/prj.conf
+++ b/samples/basic/threads/prj.conf
@@ -2,3 +2,6 @@ CONFIG_PRINTK=y
 CONFIG_HEAP_MEM_POOL_SIZE=256
 CONFIG_ASSERT=y
 CONFIG_GPIO=y
+
+#Enable thread awareness for debugging tools supporting it
+CONFIG_DEBUG_THREAD_INFO=y


### PR DESCRIPTION
Enable thread awareness by default on this sample as a
demonstrator for this feature.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>