### PR TITLE
tests: i2s: Fix i2s_states_test

### DIFF
--- a/tests/drivers/i2s/i2s_api/src/test_i2s_states.c
+++ b/tests/drivers/i2s/i2s_api/src/test_i2s_states.c
@@ -123,7 +123,7 @@ void test_i2s_state_ready_neg(void)
 	zassert_equal(ret, -EIO, NULL);
 
 	/* Configure TX stream changing its state to READY */
-	ret = configure_stream(dev_i2s_rx, I2S_DIR_TX);
+	ret = configure_stream(dev_i2s_tx, I2S_DIR_TX);
 	zassert_equal(ret, TC_PASS, NULL);
 
 	/* Send TX stream triggers */


### PR DESCRIPTION
The device used for TX stream in the test_i2s_state_ready_neg() function is incorrect.

