### PR TITLE
manifest: update SOF module

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -191,7 +191,7 @@ manifest:
       groups:
         - debug
     - name: sof
-      revision: 23c7e4739c301cc0dbc625aaf3f8e86042891565
+      revision: pull/12/head
       path: modules/audio/sof
     - name: tflite-micro
       revision: 9156d050927012da87079064db59d07f03b8baf6


### PR DESCRIPTION
Update SOF module to latest main to fix
SOF with Zephyr on i.MX.

Signed-off-by: Iuliana Prodan <iuliana.prodan@nxp.com>