### PR TITLE
subsys/mgmt/hawkbit: Update sample, cleanup logs, implement client-side auth, fix multipacket response handling, improve error handling

### DIFF
--- a/samples/subsys/mgmt/hawkbit/README.rst
+++ b/samples/subsys/mgmt/hawkbit/README.rst
@@ -85,58 +85,62 @@ Step 4: Build Hawkbit
 
 .. _hawkbit_sample_sign:
 
-Step 5: Sign the first image
-============================
+Step 5: Sign and confirm the first image
+========================================
 
 From this section onwards you use a binary (``.bin``) image format.
 
 .. code-block:: console
 
    west sign -t imgtool -- --key \
-   ~/zephyrproject/bootloader/mcuboot/root-rsa-2048.pem
+   ~/zephyrproject/bootloader/mcuboot/root-rsa-2048.pem --confirm \
+   --version 1.0.0
 
-The command above creates an image file called :file:`zephyr.signed.bin` in the
-build directory.
+The command above creates a signed and confirmed image file called
+:file:`zephyr.signed.confirmed.bin` in the build directory. It's important for
+the first image to be confirmed as MCUboot isn't able to confirm an image that
+is flashed using a hardware tool, and Hawkbit will reboot to trigger a firmware
+swap if it isn't able to confirm the running image on init.
 
 Step 6: Flash the first image
 =============================
 
-Upload the :file:`signed.bin` file from Step 5 to image slot-0 of your board.
+Upload the :file:`zephyr.signed.confirmed.bin` file from Step 5 to image slot-0
+of your board.
 
 .. code-block:: console
 
-   west flash --bin-file build/zephyr/zephyr.signed.bin
+   west flash --bin-file build/zephyr/zephyr.signed.confirmed.bin
 
-Once the image is flashed.In hawkbit server UI, you should see the the
-frdm_k64f show up in the Targets pane. It's time to upload a firmware binary
-to the server, and update it using this UI.
+Once the image is flashed and booted, the sample will print the image build
+time to the console. After it connects to the internet, in hawkbit server UI,
+you should see the the frdm_k64f show up in the Targets pane. It's time to
+upload a firmware binary to the server, and update it using this UI.
 
 Step 7: Building and signing the test image
 ===========================================
 
-Perhaps the easiest sample to test with is the :zephyr_file:`samples/hello_world`
-sample provided by Zephyr, documented in the :ref:`hello_world` section.
-
-Edit :zephyr_file:`sample/hello_world/prj.conf` and enable the required MCUboot
-Kconfig option as described in :ref:`mcuboot` by adding the following line to
-it:
+The easiest way to test the functionality of Hawkbit is to repeat step 4 to
+build the sample again, so that the build time will be different. Then, similar
+to step 5, sign the image and assign it a different version number but without
+confirming it like so:
 
 .. code-block:: console
 
-   CONFIG_BOOTLOADER_MCUBOOT=y
+   west sign -t imgtool -- --key \
+   ~/zephyrproject/bootloader/mcuboot/root-rsa-2048.pem \
+   --version 1.0.1
 
-Then build the sample as usual (see :ref:`hello_world`).
-
-Follow the Step 5 generate an image file called :file:`zephyr.signed.bin` in the
-build directory.
+The command above creates a signed image file called
+:file:`zephyr.signed.bin` in the build directory.
 
 Upload the signed image to the server. Click Upload icon in left pane of UI and
-create a new Software Module with type Apps (``name:hello_world,version:1.0``).
+create a new Software Module with type Apps (``name:hawkbit,version:1.0.1``).
 Then upload the signed image to the server with Upload file Icon.
 
 Click on distribution icon in the left pane of UI and create a new Distribution
-with type Apps only (``name:frdm_k64f_update,version:1.0``). Assign the
-``hello_world`` software module to the created distribution. Click on Deployment
+with type Apps only (``name:frdm_k64f_update,version:1.0.1``). Assign the
+``hawkbit`` software module to the created distribution. Click on Deployment
 icon in the left pane of UI and assign the ``frdm_k64f_update`` distribution to
 the target ``frdm_k64f``.
 
@@ -165,8 +169,8 @@ In the terminal you used for debugging the board, type the following command:
    kernel reboot cold
 
 Your board will reboot and then start with the new image. After rebooting, the
-board will automatically ping the server again and the message ``No update
-available`` will be printed on the terminal.
+board will print a different image build time then automatically ping the server
+again and the message ``No update available`` will be printed on the terminal.
 
 Step 10: Clone and build hawkbit with https
 ===========================================

--- a/samples/subsys/mgmt/hawkbit/src/main.c
+++ b/samples/subsys/mgmt/hawkbit/src/main.c
@@ -52,7 +52,9 @@ void main(void)
 	case HAWKBIT_UNCONFIRMED_IMAGE:
 		LOG_ERR("Image is unconfirmed");
 		LOG_ERR("Rebooting to previous confirmed image");
-
+		LOG_ERR("If this image is flashed using a hardware tool");
+		LOG_ERR("Make sure that it is a confirmed image");
+		k_sleep(K_SECONDS(1));
 		sys_reboot(SYS_REBOOT_WARM);
 		break;
 

--- a/samples/subsys/mgmt/hawkbit/src/main.c
+++ b/samples/subsys/mgmt/hawkbit/src/main.c
@@ -25,6 +25,7 @@ void main(void)
 	int ret = -1;
 
 	LOG_INF("Hawkbit sample app started");
+	LOG_INF("Image build time: " __DATE__ " " __TIME__);
 
 	app_dhcpv4_startup();
 

--- a/subsys/mgmt/hawkbit/Kconfig
+++ b/subsys/mgmt/hawkbit/Kconfig
@@ -52,6 +52,35 @@ config HAWKBIT_PORT
 	help
 	  Configure the hawkbit port number.
 
+choice
+	prompt "Hawkbit DDI API authentication modes"
+	default HAWKBIT_DDI_NO_SECURITY
+
+config HAWKBIT_DDI_NO_SECURITY
+	bool "No authentication security"
+	help
+	  No authentication security for the Hawkbit DDI API.
+
+config HAWKBIT_DDI_TARGET_SECURITY
+	bool "Use target security token authentication"
+	help
+	  Use target security token authentication for the Hawkbit DDI API.
+
+config HAWKBIT_DDI_GATEWAY_SECURITY
+	bool "Use gateway security token authentication"
+	help
+	  Use gateway security token authentication for the Hawkbit DDI API.
+
+endchoice
+
+config HAWKBIT_DDI_SECURITY_TOKEN
+	string "Authentication security token"
+	depends on HAWKBIT_DDI_TARGET_SECURITY || HAWKBIT_DDI_GATEWAY_SECURITY
+	default ""
+	help
+	  Authentication security token for the configured Hawkbit DDI
+	  authentication mode.
+
 module = HAWKBIT
 module-str = Log Level for hawkbit
 module-help = Enables logging for Hawkbit code.

--- a/subsys/mgmt/hawkbit/hawkbit.c
+++ b/subsys/mgmt/hawkbit/hawkbit.c
@@ -847,11 +847,17 @@ static void response_cb(struct http_response *rsp,
 		}
 
 		if (body_data != NULL) {
+			ret = mbedtls_md_update(&hb_context.dl.hash_ctx, body_data,
+					  body_len);
+			if (ret != 0) {
+				LOG_ERR("mbedTLS md update error: %d", ret);
+				hb_context.code_status = HAWKBIT_DOWNLOAD_ERROR;
+				break;
+			}
+
 			ret = flash_img_buffered_write(
 				&hb_context.flash_ctx, body_data, body_len,
 				final_data == HTTP_DATA_FINAL);
-			mbedtls_md_update(&hb_context.dl.hash_ctx, body_data,
-					  body_len);
 			if (ret < 0) {
 				LOG_ERR("Flash write error: %d", ret);
 				hb_context.code_status = HAWKBIT_DOWNLOAD_ERROR;

--- a/subsys/mgmt/hawkbit/hawkbit.c
+++ b/subsys/mgmt/hawkbit/hawkbit.c
@@ -735,6 +735,7 @@ static void response_cb(struct http_response *rsp,
 					hb_context.dl.http_content_size,
 					hb_context.dl.downloaded_size);
 				hb_context.code_status = HAWKBIT_METADATA_ERROR;
+				break;
 			}
 
 			hb_context.response_data[hb_context.dl.downloaded_size] = '\0';
@@ -807,6 +808,7 @@ static void response_cb(struct http_response *rsp,
 			if (hb_context.dl.http_content_size != hb_context.dl.downloaded_size) {
 				LOG_ERR("HTTP response len mismatch");
 				hb_context.code_status = HAWKBIT_METADATA_ERROR;
+				break;
 			}
 
 			hb_context.response_data[hb_context.dl.downloaded_size] = '\0';
@@ -855,6 +857,7 @@ static void response_cb(struct http_response *rsp,
 			if (ret < 0) {
 				LOG_ERR("Flash write error: %d", ret);
 				hb_context.code_status = HAWKBIT_DOWNLOAD_ERROR;
+				break;
 			}
 		}
 

--- a/subsys/mgmt/hawkbit/hawkbit.c
+++ b/subsys/mgmt/hawkbit/hawkbit.c
@@ -718,7 +718,6 @@ static void response_cb(struct http_response *rsp,
 					LOG_ERR("Failed to realloc memory");
 					hb_context.code_status =
 						HAWKBIT_METADATA_ERROR;
-					cleanup_connection();
 					break;
 				}
 
@@ -793,7 +792,6 @@ static void response_cb(struct http_response *rsp,
 					LOG_ERR("Failed to realloc memory");
 					hb_context.code_status =
 						HAWKBIT_METADATA_ERROR;
-					cleanup_connection();
 					break;
 				}
 
@@ -1133,7 +1131,7 @@ enum hawkbit_response hawkbit_probe(void)
 	}
 
 	if (hb_context.code_status == HAWKBIT_METADATA_ERROR) {
-		goto error;
+		goto cleanup;
 	}
 
 	if (hawkbit_results.base.config.polling.sleep) {
@@ -1216,7 +1214,7 @@ enum hawkbit_response hawkbit_probe(void)
 	}
 
 	if (hb_context.code_status == HAWKBIT_METADATA_ERROR) {
-		goto error;
+		goto cleanup;
 	}
 
 	hawkbit_dump_deployment(&hawkbit_results.dep);

--- a/subsys/mgmt/hawkbit/hawkbit.c
+++ b/subsys/mgmt/hawkbit/hawkbit.c
@@ -1334,6 +1334,9 @@ static void autohandler(struct k_work *work)
 	case HAWKBIT_UNCONFIRMED_IMAGE:
 		LOG_ERR("Image is unconfirmed");
 		LOG_ERR("Rebooting to previous confirmed image");
+		LOG_ERR("If this image is flashed using a hardware tool");
+		LOG_ERR("Make sure that it is a confirmed image");
+		k_sleep(K_SECONDS(1));
 		sys_reboot(SYS_REBOOT_WARM);
 		break;
 

--- a/subsys/mgmt/hawkbit/hawkbit.c
+++ b/subsys/mgmt/hawkbit/hawkbit.c
@@ -868,6 +868,16 @@ static bool send_request(enum http_method method,
 	const char *fini = hawkbit_status_finished(finished);
 	const char *exec = hawkbit_status_execution(execution);
 	char device_id[DEVICE_ID_HEX_MAX_SIZE] = { 0 };
+#ifndef CONFIG_HAWKBIT_DDI_NO_SECURITY
+	static const char * const headers[] = {
+#ifdef CONFIG_HAWKBIT_DDI_GATEWAY_SECURITY
+		"Authorization: GatewayToken "CONFIG_HAWKBIT_DDI_SECURITY_TOKEN"\r\n",
+#else
+		"Authorization: TargetToken "CONFIG_HAWKBIT_DDI_SECURITY_TOKEN"\r\n",
+#endif /* CONFIG_HAWKBIT_DDI_GATEWAY_SECURITY */
+		NULL
+	};
+#endif /* CONFIG_HAWKBIT_DDI_NO_SECURITY */
 
 	if (!hawkbit_get_device_identity(device_id, DEVICE_ID_HEX_MAX_SIZE)) {
 		hb_context.code_status = HAWKBIT_METADATA_ERROR;
@@ -883,6 +893,9 @@ static bool send_request(enum http_method method,
 	hb_context.http_req.response = response_cb;
 	hb_context.http_req.recv_buf = hb_context.recv_buf_tcp;
 	hb_context.http_req.recv_buf_len = sizeof(hb_context.recv_buf_tcp);
+#ifndef CONFIG_HAWKBIT_DDI_NO_SECURITY
+	hb_context.http_req.header_fields = (const char **)headers;
+#endif
 	hb_context.final_data_received = false;
 
 	switch (type) {

--- a/subsys/mgmt/hawkbit/hawkbit.c
+++ b/subsys/mgmt/hawkbit/hawkbit.c
@@ -385,7 +385,7 @@ static void hawkbit_update_sleep(struct hawkbit_ctl_res *hawkbit_res)
 	const char *sleep = hawkbit_res->config.polling.sleep;
 
 	if (strlen(sleep) != HAWKBIT_SLEEP_LENGTH) {
-		LOG_ERR("Invalid poll sleep: %s", sleep);
+		LOG_ERR("Invalid poll sleep: %s", log_strdup(sleep));
 	} else {
 		sleep_time = hawkbit_time2sec(sleep);
 		if (sleep_time > 0 &&
@@ -415,14 +415,14 @@ static int hawkbit_find_cancelAction_base(struct hawkbit_ctl_res *res,
 	helper = strstr(href, "cancelAction/");
 	if (!helper) {
 		/* A badly formatted cancel base is a server error */
-		LOG_ERR("Missing cancelBase/ in href %s", href);
+		LOG_ERR("Missing cancelBase/ in href %s", log_strdup(href));
 		return -EINVAL;
 	}
 
 	len = strlen(helper);
 	if (len > CANCEL_BASE_SIZE - 1) {
 		/* Lack of memory is an application error */
-		LOG_ERR("cancelBase %s is too big (len %zu, max %zu)", helper,
+		LOG_ERR("cancelBase %s is too big (len %zu, max %zu)", log_strdup(helper),
 			len, CANCEL_BASE_SIZE - 1);
 		return -ENOMEM;
 	}
@@ -468,7 +468,7 @@ static int hawkbit_find_deployment_base(struct hawkbit_ctl_res *res,
 	helper = strstr(href, "deploymentBase/");
 	if (!helper) {
 		/* A badly formatted deployment base is a server error */
-		LOG_ERR("Missing deploymentBase/ in href %s", href);
+		LOG_ERR("Missing deploymentBase/ in href %s", log_strdup(href));
 		return -EINVAL;
 	}
 
@@ -476,7 +476,7 @@ static int hawkbit_find_deployment_base(struct hawkbit_ctl_res *res,
 	if (len > DEPLOYMENT_BASE_SIZE - 1) {
 		/* Lack of memory is an application error */
 		LOG_ERR("deploymentBase %s is too big (len %zu, max %zu)",
-			helper, len, DEPLOYMENT_BASE_SIZE - 1);
+			log_strdup(helper), len, DEPLOYMENT_BASE_SIZE - 1);
 		return -ENOMEM;
 	}
 
@@ -516,7 +516,7 @@ static int hawkbit_parse_deployment(struct hawkbit_dep_res *res,
 
 	chunk = &res->deployment.chunks[0];
 	if (strcmp("bApp", chunk->part)) {
-		LOG_ERR("Only part 'bApp' is supported; got %s", chunk->part);
+		LOG_ERR("Only part 'bApp' is supported; got %s", log_strdup(chunk->part));
 		return -EINVAL;
 	}
 
@@ -553,7 +553,7 @@ static int hawkbit_parse_deployment(struct hawkbit_dep_res *res,
 
 	helper = strstr(href, "/DEFAULT/controller/v1");
 	if (!helper) {
-		LOG_ERR("Unexpected download-http href format: %s", helper);
+		LOG_ERR("Unexpected download-http href format: %s", log_strdup(helper));
 		return -EINVAL;
 	}
 
@@ -563,7 +563,7 @@ static int hawkbit_parse_deployment(struct hawkbit_dep_res *res,
 		return -EINVAL;
 	} else if (len > DOWNLOAD_HTTP_SIZE - 1) {
 		LOG_ERR("download-http %s is too big (len: %zu, max: %zu)",
-			helper, len, DOWNLOAD_HTTP_SIZE - 1);
+			log_strdup(helper), len, DOWNLOAD_HTTP_SIZE - 1);
 		return -ENOMEM;
 	}
 


### PR DESCRIPTION
This PR addresses the following issues:

- First and second commits address a few issues in the current Hawkbit sample which can confuse a new user:
   - Current sample doesn't mentioned that the image flashed using a hardware tool should be a confirmed image. Following the instructions in the current sample will result in the board rebooting indefinitely. See point 6 of #37225 
   - Current sample tests the upgrade functionality of Hawkbit using a `hello-world` which doesn't have the hawkbit subsys. So after the `hello_world` image booted up, the new image won't actually confirm itself and ping the Hawkbit server.
- Third commit is aimed to improve the consistency of the log messages and make it easier for user to identify the origin and type of error.
- Forth commit added `log_strdup` to strings from a pointer to the http response. See point 8 of #37225 
- Fifth commit is production focused and implemented Hawkbit client side DDI API authentication using `Target` or `Gateway` token.
- Sixth commit addresses http response parsing issue when the Hawkbit server sends it in multiple packets. See #37610. This implementation is basically copied from #37243
- Seventh commit workaround point 5 of #37225, so that the user is aware of what happened. Previously the Hawkbit/sample would just reboot immediately, leaving no time for the log subsys to actually print the messages.
- Eighth commit breaks the execution of code when there's an error in `response_cb` so that it can be handled properly in `hawkbit_probe`. Previously the program continues to run even if there's an error.
- Ninth commit improved the consistency of error handling past http_request in `hawkbit_probe`, and fixes a potential issue where the connection isn't cleaned up when error occured.
- Tenth commit addresses [[Coverity CID: 239555] Unchecked return value in subsys/mgmt/hawkbit/hawkbit.c](https://github.com/zephyrproject-rtos/zephyr/issues/38137)

Fixes #37610
Fixes #37225
Fixes #38137