### PR TITLE
Fix a few typos in docs/messages

### DIFF
--- a/doc/guides/dts/intro.rst
+++ b/doc/guides/dts/intro.rst
@@ -442,7 +442,7 @@ Additional notes on the above:
   values as *node identifiers*. Node identifiers are covered in more detail in
   :ref:`dt-from-c`.
 
-- Array and similar type property values can be split several ``<>``
+- Array and similar type property values can be split into several ``<>``
   blocks, like this:
 
   .. code-block:: none

--- a/include/console/console.h
+++ b/include/console/console.h
@@ -57,7 +57,7 @@ ssize_t console_write(void *dummy, const void *buf, size_t size);
  *  Return next input character from console. If no characters available,
  *  this function will block. This function is similar to ANSI C
  *  getchar() function and is intended to ease porting of existing
- *  software. Before this function can be used, console_getchar_init()
+ *  software. Before this function can be used, console_init()
  *  should be called once. This function is incompatible with native
  *  Zephyr callback-based console input processing, shell subsystem,
  *  or console_getline().

--- a/samples/bluetooth/peripheral_hids/prj.conf
+++ b/samples/bluetooth/peripheral_hids/prj.conf
@@ -1,4 +1,4 @@
-# Incresed stack due to settings API usage
+# Increased stack due to settings API usage
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 
 CONFIG_BT=y

--- a/samples/subsys/settings/src/main.c
+++ b/samples/subsys/settings/src/main.c
@@ -439,7 +439,7 @@ static void example_initialization(void)
 		if ((rc != 0) && (rc != -ENOENT)) {
 			printk("can't delete config file%d\n", rc);
 		} else {
-			printk("FS initiqalized: OK\n");
+			printk("FS initialized: OK\n");
 		}
 	}
 #endif


### PR DESCRIPTION
Fix two typos in documentation and one in a sample's console message
found while learning Zephyr and exploring the source code.

Feel free to close if it's too much hassle to have this merged :)