### PR TITLE
boards: arm: sam0: Fix pinmux init prio

### DIFF
--- a/boards/arm/adafruit_feather_m0_basic_proto/pinmux.c
+++ b/boards/arm/adafruit_feather_m0_basic_proto/pinmux.c
@@ -11,16 +11,16 @@
 static int board_pinmux_init(const struct device *dev)
 {
 	const struct device *muxa = DEVICE_DT_GET(DT_NODELABEL(pinmux_a));
-
-	__ASSERT_NO_MSG(device_is_ready(muxa));
-
-#if (ATMEL_SAM0_DT_SERCOM_CHECK(4, atmel_sam0_spi) && CONFIG_SPI_SAM0)
 	const struct device *muxb = DEVICE_DT_GET(DT_NODELABEL(pinmux_b));
 
-	__ASSERT_NO_MSG(device_is_ready(muxb));
-#endif
 	ARG_UNUSED(dev);
-	ARG_UNUSED(muxa);
+
+	if (!device_is_ready(muxa)) {
+		return -ENXIO;
+	}
+	if (!device_is_ready(muxb)) {
+		return -ENXIO;
+	}
 
 #if (ATMEL_SAM0_DT_SERCOM_CHECK(4, atmel_sam0_spi) && CONFIG_SPI_SAM0)
 	/* SPI SERCOM4 on MISO=PA12/pad 0, MOSI=PB10/pad 2, SCK=PB11/pad 3 */
@@ -75,4 +75,4 @@ static int board_pinmux_init(const struct device *dev)
 	return 0;
 }
 
-SYS_INIT(board_pinmux_init, PRE_KERNEL_1, CONFIG_PINMUX_INIT_PRIORITY);
+SYS_INIT(board_pinmux_init, PRE_KERNEL_2, CONFIG_PINMUX_INIT_PRIORITY);

--- a/boards/arm/adafruit_itsybitsy_m4_express/pinmux.c
+++ b/boards/arm/adafruit_itsybitsy_m4_express/pinmux.c
@@ -10,15 +10,17 @@
 
 static int board_pinmux_init(const struct device *dev)
 {
-	__unused const struct device *muxa = DEVICE_DT_GET(DT_NODELABEL(pinmux_a));
-	__unused const struct device *muxb = DEVICE_DT_GET(DT_NODELABEL(pinmux_b));
-
-	__ASSERT_NO_MSG(device_is_ready(muxa));
-	__ASSERT_NO_MSG(device_is_ready(muxb));
+	const struct device *muxa = DEVICE_DT_GET(DT_NODELABEL(pinmux_a));
+	const struct device *muxb = DEVICE_DT_GET(DT_NODELABEL(pinmux_b));
 
 	ARG_UNUSED(dev);
-	ARG_UNUSED(muxa);
-	ARG_UNUSED(muxb);
+
+	if (!device_is_ready(muxa)) {
+		return -ENXIO;
+	}
+	if (!device_is_ready(muxb)) {
+		return -ENXIO;
+	}
 
 #if ATMEL_SAM0_DT_SERCOM_CHECK(1, atmel_sam0_spi) && defined(CONFIG_SPI_SAM0)
 	/* SPI SERCOM1 on MISO=PB23/pad 3, MOSI=PA0/pad 0, SCK=PA1/pad 1 */
@@ -62,4 +64,4 @@ static int board_pinmux_init(const struct device *dev)
 	return 0;
 }
 
-SYS_INIT(board_pinmux_init, PRE_KERNEL_1, CONFIG_PINMUX_INIT_PRIORITY);
+SYS_INIT(board_pinmux_init, PRE_KERNEL_2, CONFIG_PINMUX_INIT_PRIORITY);

--- a/boards/arm/adafruit_trinket_m0/pinmux.c
+++ b/boards/arm/adafruit_trinket_m0/pinmux.c
@@ -12,10 +12,11 @@ static int board_pinmux_init(const struct device *dev)
 {
 	const struct device *muxa = DEVICE_DT_GET(DT_NODELABEL(pinmux_a));
 
-	__ASSERT_NO_MSG(device_is_ready(muxa));
-
 	ARG_UNUSED(dev);
-	ARG_UNUSED(muxa);
+
+	if (!device_is_ready(muxa)) {
+		return -ENXIO;
+	}
 
 #if (ATMEL_SAM0_DT_SERCOM_CHECK(0, atmel_sam0_spi) && CONFIG_SPI_SAM0)
 	/* SPI SERCOM0 on MISO=PA9/pad 1, MOSI=PA6/pad 2, SCK=PA7/pad 3 */
@@ -58,4 +59,4 @@ static int board_pinmux_init(const struct device *dev)
 	return 0;
 }
 
-SYS_INIT(board_pinmux_init, PRE_KERNEL_1, CONFIG_PINMUX_INIT_PRIORITY);
+SYS_INIT(board_pinmux_init, PRE_KERNEL_2, CONFIG_PINMUX_INIT_PRIORITY);

--- a/boards/arm/arduino_nano_33_iot/pinmux.c
+++ b/boards/arm/arduino_nano_33_iot/pinmux.c
@@ -13,12 +13,14 @@ static int board_pinmux_init(const struct device *dev)
 	const struct device *muxa = DEVICE_DT_GET(DT_NODELABEL(pinmux_a));
 	const struct device *muxb = DEVICE_DT_GET(DT_NODELABEL(pinmux_b));
 
-	__ASSERT_NO_MSG(device_is_ready(muxa));
-	__ASSERT_NO_MSG(device_is_ready(muxb));
-
 	ARG_UNUSED(dev);
-	ARG_UNUSED(muxa);
-	ARG_UNUSED(muxb);
+
+	if (!device_is_ready(muxa)) {
+		return -ENXIO;
+	}
+	if (!device_is_ready(muxb)) {
+		return -ENXIO;
+	}
 
 #if defined(CONFIG_SPI_SAM0)
 #if ATMEL_SAM0_DT_SERCOM_CHECK(1, atmel_sam0_spi)
@@ -86,4 +88,4 @@ static int board_pinmux_init(const struct device *dev)
 	return 0;
 }
 
-SYS_INIT(board_pinmux_init, PRE_KERNEL_1, CONFIG_PINMUX_INIT_PRIORITY);
+SYS_INIT(board_pinmux_init, PRE_KERNEL_2, CONFIG_PINMUX_INIT_PRIORITY);

--- a/boards/arm/arduino_zero/pinmux.c
+++ b/boards/arm/arduino_zero/pinmux.c
@@ -13,12 +13,14 @@ static int board_pinmux_init(const struct device *dev)
 	const struct device *muxa = DEVICE_DT_GET(DT_NODELABEL(pinmux_a));
 	const struct device *muxb = DEVICE_DT_GET(DT_NODELABEL(pinmux_b));
 
-	__ASSERT_NO_MSG(device_is_ready(muxa));
-	__ASSERT_NO_MSG(device_is_ready(muxb));
-
 	ARG_UNUSED(dev);
-	ARG_UNUSED(muxa);
-	ARG_UNUSED(muxb);
+
+	if (!device_is_ready(muxa)) {
+		return -ENXIO;
+	}
+	if (!device_is_ready(muxb)) {
+		return -ENXIO;
+	}
 
 #if (ATMEL_SAM0_DT_SERCOM_CHECK(4, atmel_sam0_spi) && CONFIG_SPI_SAM0)
 	/* SPI SERCOM4 on MISO=PA12/pad 0, MOSI=PB10/pad 2, SCK=PB11/pad 3 */
@@ -62,4 +64,4 @@ static int board_pinmux_init(const struct device *dev)
 	return 0;
 }
 
-SYS_INIT(board_pinmux_init, PRE_KERNEL_1, CONFIG_PINMUX_INIT_PRIORITY);
+SYS_INIT(board_pinmux_init, PRE_KERNEL_2, CONFIG_PINMUX_INIT_PRIORITY);

--- a/boards/arm/atsamd20_xpro/pinmux.c
+++ b/boards/arm/atsamd20_xpro/pinmux.c
@@ -13,12 +13,14 @@ static int board_pinmux_init(const struct device *dev)
 	const struct device *muxa = DEVICE_DT_GET(DT_NODELABEL(pinmux_a));
 	const struct device *muxb = DEVICE_DT_GET(DT_NODELABEL(pinmux_b));
 
-	__ASSERT_NO_MSG(device_is_ready(muxa));
-	__ASSERT_NO_MSG(device_is_ready(muxb));
-
 	ARG_UNUSED(dev);
-	ARG_UNUSED(muxa);
-	ARG_UNUSED(muxb);
+
+	if (!device_is_ready(muxa)) {
+		return -ENXIO;
+	}
+	if (!device_is_ready(muxb)) {
+		return -ENXIO;
+	}
 
 #if (ATMEL_SAM0_DT_SERCOM_CHECK(0, atmel_sam0_spi) && CONFIG_SPI_SAM0)
 	/* SPI SERCOM0 on MISO=PA04, MOSI=PA06, SCK=PA07 */
@@ -66,4 +68,4 @@ static int board_pinmux_init(const struct device *dev)
 	return 0;
 }
 
-SYS_INIT(board_pinmux_init, PRE_KERNEL_1, CONFIG_PINMUX_INIT_PRIORITY);
+SYS_INIT(board_pinmux_init, PRE_KERNEL_2, CONFIG_PINMUX_INIT_PRIORITY);

--- a/boards/arm/atsamd21_xpro/pinmux.c
+++ b/boards/arm/atsamd21_xpro/pinmux.c
@@ -13,12 +13,14 @@ static int board_pinmux_init(const struct device *dev)
 	const struct device *muxa = DEVICE_DT_GET(DT_NODELABEL(pinmux_a));
 	const struct device *muxb = DEVICE_DT_GET(DT_NODELABEL(pinmux_b));
 
-	__ASSERT_NO_MSG(device_is_ready(muxa));
-	__ASSERT_NO_MSG(device_is_ready(muxb));
-
 	ARG_UNUSED(dev);
-	ARG_UNUSED(muxa);
-	ARG_UNUSED(muxb);
+
+	if (!device_is_ready(muxa)) {
+		return -ENXIO;
+	}
+	if (!device_is_ready(muxb)) {
+		return -ENXIO;
+	}
 
 #if (ATMEL_SAM0_DT_SERCOM_CHECK(0, atmel_sam0_spi) && CONFIG_SPI_SAM0)
 #warning Pin mapping may not be configured
@@ -76,4 +78,4 @@ static int board_pinmux_init(const struct device *dev)
 	return 0;
 }
 
-SYS_INIT(board_pinmux_init, PRE_KERNEL_1, CONFIG_PINMUX_INIT_PRIORITY);
+SYS_INIT(board_pinmux_init, PRE_KERNEL_2, CONFIG_PINMUX_INIT_PRIORITY);

--- a/boards/arm/atsame54_xpro/pinmux.c
+++ b/boards/arm/atsame54_xpro/pinmux.c
@@ -15,16 +15,20 @@ static int board_pinmux_init(const struct device *dev)
 	const struct device *muxc = DEVICE_DT_GET(DT_NODELABEL(pinmux_c));
 	const struct device *muxd = DEVICE_DT_GET(DT_NODELABEL(pinmux_d));
 
-	__ASSERT_NO_MSG(device_is_ready(muxa));
-	__ASSERT_NO_MSG(device_is_ready(muxb));
-	__ASSERT_NO_MSG(device_is_ready(muxc));
-	__ASSERT_NO_MSG(device_is_ready(muxd));
-
 	ARG_UNUSED(dev);
-	ARG_UNUSED(muxa);
-	ARG_UNUSED(muxb);
-	ARG_UNUSED(muxc);
-	ARG_UNUSED(muxd);
+
+	if (!device_is_ready(muxa)) {
+		return -ENXIO;
+	}
+	if (!device_is_ready(muxb)) {
+		return -ENXIO;
+	}
+	if (!device_is_ready(muxc)) {
+		return -ENXIO;
+	}
+	if (!device_is_ready(muxd)) {
+		return -ENXIO;
+	}
 
 #if (ATMEL_SAM0_DT_SERCOM_CHECK(0, atmel_sam0_spi) && CONFIG_SPI_SAM0)
 #warning Pin mapping may not be configured
@@ -107,4 +111,4 @@ static int board_pinmux_init(const struct device *dev)
 	return 0;
 }
 
-SYS_INIT(board_pinmux_init, PRE_KERNEL_1, CONFIG_PINMUX_INIT_PRIORITY);
+SYS_INIT(board_pinmux_init, PRE_KERNEL_2, CONFIG_PINMUX_INIT_PRIORITY);

--- a/boards/arm/atsamr21_xpro/pinmux.c
+++ b/boards/arm/atsamr21_xpro/pinmux.c
@@ -15,14 +15,17 @@ static int board_pinmux_init(const struct device *dev)
 	const struct device *muxb = DEVICE_DT_GET(DT_NODELABEL(pinmux_b));
 	const struct device *muxc = DEVICE_DT_GET(DT_NODELABEL(pinmux_c));
 
-	__ASSERT_NO_MSG(device_is_ready(muxa));
-	__ASSERT_NO_MSG(device_is_ready(muxb));
-	__ASSERT_NO_MSG(device_is_ready(muxc));
-
 	ARG_UNUSED(dev);
-	ARG_UNUSED(muxa);
-	ARG_UNUSED(muxb);
-	ARG_UNUSED(muxc);
+
+	if (!device_is_ready(muxa)) {
+		return -ENXIO;
+	}
+	if (!device_is_ready(muxb)) {
+		return -ENXIO;
+	}
+	if (!device_is_ready(muxc)) {
+		return -ENXIO;
+	}
 
 #if (ATMEL_SAM0_DT_SERCOM_CHECK(0, atmel_sam0_spi) && CONFIG_SPI_SAM0)
 #warning Pin mapping may not be configured
@@ -91,4 +94,4 @@ static int board_pinmux_init(const struct device *dev)
 	return 0;
 }
 
-SYS_INIT(board_pinmux_init, PRE_KERNEL_1, CONFIG_PINMUX_INIT_PRIORITY);
+SYS_INIT(board_pinmux_init, PRE_KERNEL_2, CONFIG_PINMUX_INIT_PRIORITY);

--- a/boards/arm/seeeduino_xiao/pinmux.c
+++ b/boards/arm/seeeduino_xiao/pinmux.c
@@ -10,15 +10,17 @@
 
 static int board_pinmux_init(const struct device *dev)
 {
-	__unused const struct device *muxa = DEVICE_DT_GET(DT_NODELABEL(pinmux_a));
-	__unused const struct device *muxb = DEVICE_DT_GET(DT_NODELABEL(pinmux_b));
-
-	__ASSERT_NO_MSG(device_is_ready(muxa));
-	__ASSERT_NO_MSG(device_is_ready(muxb));
+	const struct device *muxa = DEVICE_DT_GET(DT_NODELABEL(pinmux_a));
+	const struct device *muxb = DEVICE_DT_GET(DT_NODELABEL(pinmux_b));
 
 	ARG_UNUSED(dev);
-	ARG_UNUSED(muxa);
-	ARG_UNUSED(muxb);
+
+	if (!device_is_ready(muxa)) {
+		return -ENXIO;
+	}
+	if (!device_is_ready(muxb)) {
+		return -ENXIO;
+	}
 
 #if ATMEL_SAM0_DT_SERCOM_CHECK(2, atmel_sam0_i2c) && defined(CONFIG_I2C_SAM0)
 	/* SERCOM2 on SDA=PA08, SCL=PA09 */
@@ -74,4 +76,4 @@ static int board_pinmux_init(const struct device *dev)
 	return 0;
 }
 
-SYS_INIT(board_pinmux_init, PRE_KERNEL_1, CONFIG_PINMUX_INIT_PRIORITY);
+SYS_INIT(board_pinmux_init, PRE_KERNEL_2, CONFIG_PINMUX_INIT_PRIORITY);

--- a/boards/arm/serpente/pinmux.c
+++ b/boards/arm/serpente/pinmux.c
@@ -12,10 +12,11 @@ static int board_pinmux_init(const struct device *dev)
 {
 	const struct device *muxa = DEVICE_DT_GET(DT_NODELABEL(pinmux_a));
 
-	__ASSERT_NO_MSG(device_is_ready(muxa));
-
 	ARG_UNUSED(dev);
-	ARG_UNUSED(muxa);
+
+	if (!device_is_ready(muxa)) {
+		return -ENXIO;
+	}
 
 	/* sercom 3 is always spi - it is the onboard flash */
 	/* SPI SERCOM3 on MISO=PA18, MOSI=PA16, SCK=PA17, CS=PA15*/
@@ -52,4 +53,4 @@ static int board_pinmux_init(const struct device *dev)
 	return 0;
 }
 
-SYS_INIT(board_pinmux_init, PRE_KERNEL_1, CONFIG_PINMUX_INIT_PRIORITY);
+SYS_INIT(board_pinmux_init, PRE_KERNEL_2, CONFIG_PINMUX_INIT_PRIORITY);


### PR DESCRIPTION
After pinmux being converted to build a separate static library ( #37512 ) console not show anymore and there is a hard fault.  The hard fault happen because pinmux drivers are not ready yet and board emits an assert.  This change board pinmux initialization to PRE_KERNEL_2 and let system take care error handling.

Discovered at #38085.

Signed-off-by: Gerson Fernando Budke <nandojve@gmail.com>