### PR TITLE
Bluetooth: Controller: Fix uninitialized pointer read of SR ADI

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -265,6 +265,11 @@ uint8_t ll_adv_aux_sr_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref, ui
 
 	/* If no length is provided, discard data */
 	if (!len) {
+		/* No scan response data, primary channel PDU's ADI update
+		 * should not copy into scan response ADI.
+		 */
+		sr_adi = NULL;
+
 		goto sr_data_set_did_update;
 	}
 


### PR DESCRIPTION
When Extended Scan Response data of length zero is set, the
Scan Response do not have the Common Extended Payload Format
and hence no ADI field. Fix uninitialized pointer to Scan
Response Data's ADI to avoid copy of ADI from primary
channel PDU.

Fixes #38015.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>