### PR TITLE
drivers: clock control stm32wb has MSI clock range to set

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -636,13 +636,11 @@ int stm32_clock_control_init(const struct device *dev)
 		LL_SetFlashLatency(new_flash_freq);
 	}
 
-#if !defined(CONFIG_SOC_SERIES_STM32WBX)
 	/* Set MSI Range */
 #if !defined(CONFIG_SOC_SERIES_STM32WBX)
 	LL_RCC_MSI_EnableRangeSelection();
 #endif
 	LL_RCC_MSI_SetRange(STM32_MSI_RANGE << RCC_CR_MSIRANGE_Pos);
-#endif
 
 #if STM32_MSI_PLL_MODE
 	/* Enable MSI hardware auto calibration */


### PR DESCRIPTION
When the MSI clock is selected as source on the stm32wbx device,
the MSI has a range to choose the MSI input frequency.

Whith the STM32_SYSCLK_SRC_MSI, the range of the MSI must be selected, even if the DTS has default value (<6>)  --> LL_RCC_MSI_SetRange()

Despite the stm32l4xx, stm32l5xx, stm32wlxx which also has a MSI, the stm32wbx has now range selection bit to enable.

Signed-off-by: Francois Ramu <francois.ramu@st.com>