### PR TITLE
tests: threads: fix uninitialized scalar variable

### DIFF
--- a/tests/kernel/threads/thread_stack/src/main.c
+++ b/tests/kernel/threads/thread_stack/src/main.c
@@ -92,7 +92,7 @@ void stack_buffer_scenarios(void)
 	k_thread_stack_t *stack_obj = scenario_data.stack;
 	size_t obj_size = scenario_data.object_size;
 	size_t stack_size, unused, carveout, reserved, alignment, adjusted;
-	uint8_t val;
+	uint8_t val = 0;
 	char *stack_start, *stack_ptr, *stack_end, *obj_start, *obj_end;
 	char *stack_buf;
 	volatile char *pos;
@@ -161,6 +161,7 @@ void stack_buffer_scenarios(void)
 	 * First test does direct read & write starting at the estimated
 	 * stack pointer up to the highest addresses in the buffer
 	 */
+	val = *stack_start;
 	stack_ptr = &val;
 	for (pos = stack_ptr; pos < stack_end; pos++) {
 		/* pos is volatile so this doesn't get optimized out */


### PR DESCRIPTION
In the file variable val is not initialized,
causing the variable stack_ptr, pos, points to uninitialized data.
Initialize the variable val according to the code and commits.

Fixes #37916

Signed-off-by: Naiyuan Tian <naiyuan.tian@intel.com>