### PR TITLE
Allow multiple entries in EMU_PLATFORM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1622,8 +1622,17 @@ if(HEX_FILES_TO_MERGE)
   message(VERBOSE "Merging hex files: ${HEX_FILES_TO_MERGE}")
 endif()
 
-if(EMU_PLATFORM)
-  include(${ZEPHYR_BASE}/cmake/emu/${EMU_PLATFORM}.cmake)
+if(SUPPORTED_EMU_PLATFORMS)
+  list(GET SUPPORTED_EMU_PLATFORMS 0 default_emu)
+  add_custom_target(run DEPENDS run_${default_emu})
+
+  foreach(EMU_PLATFORM ${SUPPORTED_EMU_PLATFORMS})
+    include(${ZEPHYR_BASE}/cmake/emu/${EMU_PLATFORM}.cmake)
+  endforeach()
+
+  if(TARGET debugserver_${default_emu})
+    add_custom_target(debugserver DEPENDS debugserver_${default_emu})
+  endif()
 else()
   add_custom_target(run
     COMMAND

--- a/boards/arc/nsim/board.cmake
+++ b/boards/arc/nsim/board.cmake
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-set(EMU_PLATFORM nsim)
+set(SUPPORTED_EMU_PLATFORMS nsim)
 
 if(NOT (CONFIG_SOC_NSIM_HS_SMP OR CONFIG_SOC_NSIM_HS6X_SMP))
   board_set_flasher_ifnset(arc-nsim)

--- a/boards/arc/qemu_arc/board.cmake
+++ b/boards/arc/qemu_arc/board.cmake
@@ -1,4 +1,4 @@
-set(EMU_PLATFORM qemu)
+set(SUPPORTED_EMU_PLATFORMS qemu)
 
 set(QEMU_CPU_TYPE_${ARCH} arc)
 

--- a/boards/arm/mps2_an385/board.cmake
+++ b/boards/arm/mps2_an385/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set(EMU_PLATFORM qemu)
+set(SUPPORTED_EMU_PLATFORMS qemu)
 
 set(QEMU_CPU_TYPE_${ARCH} cortex-m3)
 set(QEMU_FLAGS_${ARCH}

--- a/boards/arm/mps2_an521/board.cmake
+++ b/boards/arm/mps2_an521/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set(EMU_PLATFORM qemu)
+set(SUPPORTED_EMU_PLATFORMS qemu)
 
 set(QEMU_CPU_TYPE_${ARCH} cortex-m33)
 set(QEMU_FLAGS_${ARCH}

--- a/boards/arm/mps3_an547/board.cmake
+++ b/boards/arm/mps3_an547/board.cmake
@@ -9,35 +9,31 @@
 #
 # $ west build -b mps3_an547 samples/hello°world -DEMU_PLATFORM=qemu -t run
 
-if(NOT DEFINED EMU_PLATFORM)
-  set(EMU_PLATFORM qemu)
-endif()
+set(SUPPORTED_EMU_PLATFORMS qemu armfvp)
 
-if (EMU_PLATFORM STREQUAL "qemu")
-  # QEMU settings
-  set(QEMU_CPU_TYPE_${ARCH} cortex-m55)
-  set(QEMU_FLAGS_${ARCH}
-    -cpu ${QEMU_CPU_TYPE_${ARCH}}
-    -machine mps3-an547
-    -nographic
-    -vga none
-    )
-  board_set_debugger_ifnset(qemu)
-else()
-  # FVP settings
-  set(ARMFVP_BIN_NAME FVP_Corstone_SSE-300_Ethos-U55)
+# QEMU settings
+set(QEMU_CPU_TYPE_${ARCH} cortex-m55)
+set(QEMU_FLAGS_${ARCH}
+  -cpu ${QEMU_CPU_TYPE_${ARCH}}
+  -machine mps3-an547
+  -nographic
+  -vga none
+  )
+board_set_debugger_ifnset(qemu)
 
-  # FVP Parameters
-  # -C indicate a config option in the form of:
-  #   instance.parameter=value
-  # Run the FVP with --list-params to list all options
-  set(ARMFVP_FLAGS
-    -C mps3_board.uart0.out_file=-
-    -C mps3_board.uart0.unbuffered_output=1
-    -C mps3_board.uart1.out_file=-
-    -C mps3_board.uart1.unbuffered_output=1
-    -C mps3_board.uart2.out_file=-
-    -C mps3_board.uart2.unbuffered_output=1
-    -C mps3_board.visualisation.disable-visualisation=1
-    )
-endif()
+# FVP settings
+set(ARMFVP_BIN_NAME FVP_Corstone_SSE-300_Ethos-U55)
+
+# FVP Parameters
+# -C indicate a config option in the form of:
+#   instance.parameter=value
+# Run the FVP with --list-params to list all options
+set(ARMFVP_FLAGS
+  -C mps3_board.uart0.out_file=-
+  -C mps3_board.uart0.unbuffered_output=1
+  -C mps3_board.uart1.out_file=-
+  -C mps3_board.uart1.unbuffered_output=1
+  -C mps3_board.uart2.out_file=-
+  -C mps3_board.uart2.unbuffered_output=1
+  -C mps3_board.visualisation.disable-visualisation=1
+  )

--- a/boards/arm/qemu_cortex_m0/board.cmake
+++ b/boards/arm/qemu_cortex_m0/board.cmake
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-set(EMU_PLATFORM qemu)
+set(SUPPORTED_EMU_PLATFORMS qemu)
 
 set(QEMU_CPU_TYPE_${ARCH} cortex-m0)
 set(QEMU_FLAGS_${ARCH}

--- a/boards/arm/qemu_cortex_m3/board.cmake
+++ b/boards/arm/qemu_cortex_m3/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set(EMU_PLATFORM qemu)
+set(SUPPORTED_EMU_PLATFORMS qemu)
 
 set(QEMU_CPU_TYPE_${ARCH} cortex-m3)
 set(QEMU_FLAGS_${ARCH}

--- a/boards/arm/qemu_cortex_r5/board.cmake
+++ b/boards/arm/qemu_cortex_r5/board.cmake
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-set(EMU_PLATFORM qemu)
+set(SUPPORTED_EMU_PLATFORMS qemu)
 set(QEMU_ARCH xilinx-aarch64)
 
 set(QEMU_CPU_TYPE_${ARCH} cortex-r5)

--- a/boards/arm64/fvp_base_revc_2xaemv8a/board.cmake
+++ b/boards/arm64/fvp_base_revc_2xaemv8a/board.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Carlo Caione <ccaione@baylibre.com>
 # SPDX-License-Identifier: Apache-2.0
 
-set(EMU_PLATFORM armfvp)
+set(SUPPORTED_EMU_PLATFORMS armfvp)
 set(ARMFVP_BIN_NAME FVP_Base_RevC-2xAEMvA)
 
 set(ARMFVP_FLAGS

--- a/boards/arm64/fvp_baser_aemv8r/board.cmake
+++ b/boards/arm64/fvp_baser_aemv8r/board.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Arm Limited (or its affiliates). All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-set(EMU_PLATFORM armfvp)
+set(SUPPORTED_EMU_PLATFORMS armfvp)
 set(ARMFVP_BIN_NAME FVP_BaseR_AEMv8R)
 
 set(ARMFVP_FLAGS

--- a/boards/arm64/qemu_cortex_a53/board.cmake
+++ b/boards/arm64/qemu_cortex_a53/board.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2019 Carlo Caione <ccaione@baylibre.com>
 # SPDX-License-Identifier: Apache-2.0
 
-set(EMU_PLATFORM qemu)
+set(SUPPORTED_EMU_PLATFORMS qemu)
 set(QEMU_ARCH aarch64)
 
 set(QEMU_CPU_TYPE_${ARCH} cortex-a53)

--- a/boards/nios2/qemu_nios2/board.cmake
+++ b/boards/nios2/qemu_nios2/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set(EMU_PLATFORM qemu)
+set(SUPPORTED_EMU_PLATFORMS qemu)
 
 set(QEMU_CPU_TYPE_${ARCH} nios2)
 

--- a/boards/posix/native_posix/board.cmake
+++ b/boards/posix/native_posix/board.cmake
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set(EMU_PLATFORM native)
+set(SUPPORTED_EMU_PLATFORMS native)

--- a/boards/posix/nrf52_bsim/board.cmake
+++ b/boards/posix/nrf52_bsim/board.cmake
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set(EMU_PLATFORM native)
+set(SUPPORTED_EMU_PLATFORMS native)

--- a/boards/riscv/hifive1/board.cmake
+++ b/boards/riscv/hifive1/board.cmake
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set(SUPPORTED_EMU_PLATFORMS qemu)
+set(SUPPORTED_EMU_PLATFORMS renode qemu)
+set(RENODE_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/support/hifive1.resc)
 
+set(QEMU_binary_suffix riscv32)
 set(QEMU_CPU_TYPE_${ARCH} riscv32)
 
 set(QEMU_FLAGS_${ARCH}

--- a/boards/riscv/hifive1/board.cmake
+++ b/boards/riscv/hifive1/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set(EMU_PLATFORM qemu)
+set(SUPPORTED_EMU_PLATFORMS qemu)
 
 set(QEMU_CPU_TYPE_${ARCH} riscv32)
 

--- a/boards/riscv/hifive1/hifive1.yaml
+++ b/boards/riscv/hifive1/hifive1.yaml
@@ -5,6 +5,7 @@ arch: riscv32
 toolchain:
   - zephyr
 ram: 16
+simulation: renode
 supported:
   - pwm
   - gpio
@@ -13,3 +14,5 @@ testing:
   ignore_tags:
     - net
     - bluetooth
+    - flash
+    - newlib

--- a/boards/riscv/hifive1/support/hifive1.resc
+++ b/boards/riscv/hifive1/support/hifive1.resc
@@ -1,0 +1,20 @@
+:description: This script is prepared to run Zephyr on SiFive-FE310 board.
+:name: SiFive-FE310
+
+$name?="SiFive-FE310"
+
+using sysbus
+mach create $name
+machine LoadPlatformDescription @platforms/cpus/sifive-fe310.repl
+
+sysbus Tag <0x10008000 4> "PRCI_HFROSCCFG" 0xFFFFFFFF
+sysbus Tag <0x10008008 4> "PRCI_PLLCFG" 0xFFFFFFFF
+cpu PerformanceInMips 320
+
+showAnalyzer uart0
+
+macro reset
+"""
+    sysbus LoadELF $bin
+"""
+runMacro $reset

--- a/boards/riscv/it8xxx2_evb/board.cmake
+++ b/boards/riscv/it8xxx2_evb/board.cmake
@@ -1,2 +1,2 @@
-set(EMU_PLATFORM renode)
+set(SUPPORTED_EMU_PLATFORMS renode)
 set(RENODE_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/support/it8xxx2_evb.resc)

--- a/boards/riscv/m2gl025_miv/board.cmake
+++ b/boards/riscv/m2gl025_miv/board.cmake
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set(EMU_PLATFORM renode)
+set(SUPPORTED_EMU_PLATFORMS renode)
 set(RENODE_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/support/m2gl025_miv.resc)

--- a/boards/riscv/qemu_riscv32/board.cmake
+++ b/boards/riscv/qemu_riscv32/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set(EMU_PLATFORM qemu)
+set(SUPPORTED_EMU_PLATFORMS qemu)
 
 set(QEMU_binary_suffix riscv32)
 set(QEMU_CPU_TYPE_${ARCH} riscv32)

--- a/boards/riscv/qemu_riscv64/board.cmake
+++ b/boards/riscv/qemu_riscv64/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set(EMU_PLATFORM qemu)
+set(SUPPORTED_EMU_PLATFORMS qemu)
 
 set(QEMU_binary_suffix riscv64)
 set(QEMU_CPU_TYPE_${ARCH} riscv64)

--- a/boards/sparc/generic_leon3/board.cmake
+++ b/boards/sparc/generic_leon3/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set(EMU_PLATFORM tsim)
+set(SUPPORTED_EMU_PLATFORMS tsim)
 
 find_program(TSIM tsim-leon3)
 

--- a/boards/sparc/gr716a_mini/board.cmake
+++ b/boards/sparc/gr716a_mini/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set(EMU_PLATFORM tsim)
+set(SUPPORTED_EMU_PLATFORMS tsim)
 
 find_program(TSIM tsim-leon3)
 

--- a/boards/sparc/qemu_leon3/board.cmake
+++ b/boards/sparc/qemu_leon3/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set(EMU_PLATFORM qemu)
+set(SUPPORTED_EMU_PLATFORMS qemu)
 
 set(QEMU_binary_suffix sparc)
 set(QEMU_CPU_TYPE_${ARCH} leon3)

--- a/boards/x86/qemu_x86/board.cmake
+++ b/boards/x86/qemu_x86/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set(EMU_PLATFORM qemu)
+set(SUPPORTED_EMU_PLATFORMS qemu)
 
 if(NOT CONFIG_REBOOT)
   set(REBOOT_FLAG -no-reboot)

--- a/boards/xtensa/qemu_xtensa/board.cmake
+++ b/boards/xtensa/qemu_xtensa/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set(EMU_PLATFORM qemu)
+set(SUPPORTED_EMU_PLATFORMS qemu)
 
 set(QEMU_CPU_TYPE_${ARCH} sample_controller)
 

--- a/cmake/emu/armfvp.cmake
+++ b/cmake/emu/armfvp.cmake
@@ -36,7 +36,7 @@ else()
     )
 endif()
 
-add_custom_target(run
+add_custom_target(run_armfvp
   COMMAND
   ${ARMFVP}
   ${ARMFVP_FLAGS}

--- a/cmake/emu/native.cmake
+++ b/cmake/emu/native.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-add_custom_target(run
+add_custom_target(run_native
   COMMAND
   ${APPLICATION_BINARY_DIR}/zephyr/${KERNEL_EXE_NAME}
   DEPENDS ${logical_target_for_zephyr_elf}

--- a/cmake/emu/nsim.cmake
+++ b/cmake/emu/nsim.cmake
@@ -34,7 +34,7 @@ else()
 endif()
 
 string(REPLACE ";" " " MDB_COMMAND "${MDB_OPTIONS}")
-add_custom_target(run
+add_custom_target(run_nsim
   COMMAND
   ${MDB_OPTIONS}
   ${APPLICATION_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME}
@@ -49,7 +49,7 @@ find_program(
   nsimdrv
   )
 
-add_custom_target(run
+add_custom_target(run_nsim
   COMMAND
   ${NSIM}
   -propsfile
@@ -61,7 +61,7 @@ add_custom_target(run
   USES_TERMINAL
   )
 
-add_custom_target(debugserver
+add_custom_target(debugserver_nsim
   COMMAND
   ${NSIM}
   -propsfile

--- a/cmake/emu/qemu.cmake
+++ b/cmake/emu/qemu.cmake
@@ -37,8 +37,8 @@ if(CONFIG_QEMU_UEFI_BOOT)
 endif()
 
 set(qemu_targets
-  run
-  debugserver
+  run_qemu
+  debugserver_qemu
   )
 
 set(QEMU_FLAGS -pidfile)
@@ -334,7 +334,7 @@ set(env_qemu $ENV{QEMU_EXTRA_FLAGS})
 separate_arguments(env_qemu)
 list(APPEND QEMU_EXTRA_FLAGS ${env_qemu})
 
-list(APPEND MORE_FLAGS_FOR_debugserver -s -S)
+list(APPEND MORE_FLAGS_FOR_debugserver_qemu -s -S)
 
 # Architectures can define QEMU_KERNEL_FILE to use a specific output
 # file to pass to qemu (and a "qemu_kernel_target" target to generate

--- a/cmake/emu/renode.cmake
+++ b/cmake/emu/renode.cmake
@@ -11,7 +11,7 @@ set(RENODE_FLAGS
   --pid-file renode.pid
   )
 
-add_custom_target(run
+add_custom_target(run_renode
   COMMAND
   ${RENODE}
   ${RENODE_FLAGS}

--- a/cmake/emu/tsim.cmake
+++ b/cmake/emu/tsim.cmake
@@ -2,7 +2,7 @@
 
 set(TSIM_FLAGS -e run -e exit)
 
-add_custom_target(run
+add_custom_target(run_tsim
   COMMAND
   ${TSIM}
   ${TSIM_SYS}

--- a/cmake/flash/CMakeLists.txt
+++ b/cmake/flash/CMakeLists.txt
@@ -141,7 +141,7 @@ foreach(target flash debug debugserver attach)
     set(comment "Debugging ${BOARD}")
   elseif(target STREQUAL debugserver)
     set(comment "Debugging ${BOARD}")
-    if(EMU_PLATFORM)
+    if(SUPPORTED_EMU_PLATFORMS)
       # cmake/qemu/CMakeLists.txt will add a debugserver target for
       # emulation platforms, so we don't add one here
       continue()

--- a/doc/application/index.rst
+++ b/doc/application/index.rst
@@ -990,6 +990,12 @@ again.
    QEMU, :ref:`set the environment variable <env_vars>` :envvar:`QEMU_BIN_PATH`
    to the path of the QEMU binary you want to use instead.
 
+.. note::
+
+   You can choose a specific emulator by appending ``_<emulator>`` to your
+   target name, for example ``west build -t run_qemu`` or ``ninja run_qemu``
+   for QEMU.
+
 .. _application_debugging:
 
 Application Debugging


### PR DESCRIPTION
This PR introduces a way to define the `EMU_PLATFORM` variable as a list, and to choose which emulation platform the simulation will be run on by either setting the `EMU_PLATFORM_DEFAULT` variable in the per-board cmake file, or by using the added command line argument, e.g.:

```
west build -p always -b hifive1 -e renode -t run samples/hello_world
```

If `EMU_PLATFORM_DEFAULT` and command line argument have not been set, then it defaults to running the simulation on the first emulation platform from `EMU_PLATFORM` list.