### PR TITLE
Bluetooth: host: Fix Limited Advertising timeout cancel

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1160,6 +1160,7 @@ void bt_hci_le_enh_conn_complete(struct bt_hci_evt_le_enh_conn_complete *evt)
 		 * object to keep host in sync with controller state.
 		 */
 		atomic_clear_bit(adv->flags, BT_ADV_ENABLED);
+		(void)bt_le_lim_adv_cancel_timeout(adv);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_CENTRAL) &&
@@ -1323,12 +1324,6 @@ static void le_legacy_conn_complete(struct net_buf *buf)
 {
 	struct bt_hci_evt_le_conn_complete *evt = (void *)buf->data;
 	struct bt_hci_evt_le_enh_conn_complete enh;
-
-#if defined(CONFIG_BT_BROADCASTER)
-	struct bt_le_ext_adv *adv = bt_le_adv_lookup_legacy();
-
-	(void)bt_le_lim_adv_cancel_timeout(adv);
-#endif
 
 	BT_DBG("status 0x%02x role %u %s", evt->status, evt->role,
 	       bt_addr_le_str(&evt->peer_addr));


### PR DESCRIPTION
Timeout cancel should only be done for connections established in
peripheral role.

Enhanced connection complete event could still be delivered without
extended advertising support (i.e no advertising set terminated event)
so this handling should be moved to the common conn complete function.

Fixes #37467

Signed-off-by: Michał Narajowski <michal.narajowski@codecoup.pl>