### PR TITLE
DT tooling and DT API for RANGES property

### DIFF
--- a/doc/guides/dts/macros.bnf
+++ b/doc/guides/dts/macros.bnf
@@ -41,6 +41,15 @@ node-macro =/ %s"DT_N" path-id %s"_IRQ_IDX_" DIGIT
               %s"_VAL_" dt-name [ %s"_EXISTS" ]
 node-macro =/ %s"DT_N" path-id %s"_IRQ_NAME_" dt-name
               %s"_VAL_" dt-name [ %s"_EXISTS" ]
+; The ranges property is also special.
+node-macro =/ %s"DT_N" path-id %s"_RANGES_NUM"
+node-macro =/ %s"DT_N" path-id %s"_RANGES_IDX_" DIGIT "_EXISTS"
+node-macro =/ %s"DT_N" path-id %s"_RANGES_IDX_" DIGIT
+              %s"_VAL_" ( %s"CHILD_BUS_FLAGS" / %s"CHILD_BUS_ADDRESS" /
+                          %s"PARENT_BUS_ADDRESS" / %s"LENGTH")
+node-macro =/ %s"DT_N" path-id %s"_RANGES_IDX_" DIGIT
+              %s"_VAL_CHILD_BUS_FLAGS_EXISTS"
+node-macro =/ %s"DT_N" path-id %s"_FOREACH_RANGE"
 ; Subnodes of the fixed-partitions compatible get macros which contain
 ; a unique ordinal value for each partition
 node-macro =/ %s"DT_N" path-id %s"_PARTITION_ID" DIGIT

--- a/doc/reference/devicetree/api.rst
+++ b/doc/reference/devicetree/api.rst
@@ -46,13 +46,30 @@ Property access
 ===============
 
 The following general-purpose macros can be used to access node properties.
-There are special-purpose APIs for accessing the :ref:`devicetree-reg-property`
-and :ref:`devicetree-interrupts-property`.
+There are special-purpose APIs for accessing the :ref:`devicetree-ranges-property`,
+:ref:`devicetree-reg-property` and :ref:`devicetree-interrupts-property`.
 
 Property values can be read using these macros even if the node is disabled,
 as long as it has a matching binding.
 
 .. doxygengroup:: devicetree-generic-prop
+
+.. _devicetree-ranges-property:
+
+``ranges`` property
+===================
+
+Use these APIs instead of :ref:`devicetree-property-access` to access the
+``ranges`` property. Because this property's semantics are defined by the
+devicetree specification, these macros can be used even for nodes without
+matching bindings. However, they take on special semantics when the node's
+binding indicates it is a PCIe bus node, as defined in the
+`PCI Bus Binding to: IEEE Std 1275-1994 Standard for Boot (Initialization Configuration) Firmware`_
+
+.. _PCI Bus Binding to\: IEEE Std 1275-1994 Standard for Boot (Initialization Configuration) Firmware:
+    https://www.openfirmware.info/data/docs/bus.pci.pdf
+
+.. doxygengroup:: devicetree-ranges-prop
 
 .. _devicetree-reg-property:
 

--- a/doc/releases/release-notes-3.0.rst
+++ b/doc/releases/release-notes-3.0.rst
@@ -38,6 +38,9 @@ Changes in this release
 
 * Added function for getting status of USB device remote wakeup feature.
 
+* Added ``ranges`` and ``dma-ranges`` as invalid property to be used with DT_PROP_LEN()
+  along ``reg`` and ``interrupts``.
+
 ==========================
 
 Removed APIs in this release

--- a/dts/bindings/test/vnd,pcie.yaml
+++ b/dts/bindings/test/vnd,pcie.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: Test PCIe bus controller
+
+compatible: vnd,pcie
+
+include: base.yaml
+
+bus: pcie

--- a/include/devicetree.h
+++ b/include/devicetree.h
@@ -549,7 +549,8 @@
  * - reg property: use DT_NUM_REGS(node_id) instead
  * - interrupts property: use DT_NUM_IRQS(node_id) instead
  *
- * It is an error to use this macro with the reg or interrupts properties.
+ * It is an error to use this macro with the ranges, dma-ranges, reg
+ * or interrupts properties.
  *
  * For other properties, behavior is undefined.
  *

--- a/include/devicetree.h
+++ b/include/devicetree.h
@@ -1295,6 +1295,360 @@
  */
 
 /**
+ * @defgroup devicetree-ranges-prop ranges property
+ * @ingroup devicetree
+ * @{
+ */
+
+/**
+ * @brief Get the number of range blocks in the ranges property
+ *
+ * Use this instead of DT_PROP_LEN(node_id, ranges).
+ *
+ * Example devicetree fragment:
+ *
+ *     pcie0: pcie@0 {
+ *             compatible = "intel,pcie";
+ *             reg = <0 1>;
+ *             #address-cells = <3>;
+ *             #size-cells = <2>;
+ *
+ *             ranges = <0x1000000 0 0 0 0x3eff0000 0 0x10000>,
+ *                      <0x2000000 0 0x10000000 0 0x10000000 0 0x2eff0000>,
+ *                      <0x3000000 0x80 0 0x80 0 0x80 0>;
+ *     };
+ *
+ *     other: other@1 {
+ *             reg = <1 1>;
+ *
+ *             ranges = <0x0 0x0 0x0 0x3eff0000 0x10000>,
+ *                      <0x0 0x10000000 0x0 0x10000000 0x2eff0000>;
+ *     };
+ *
+ * Example usage:
+ *
+ *     DT_NUM_RANGES(DT_NODELABEL(pcie0)) // 3
+ *     DT_NUM_RANGES(DT_NODELABEL(other)) // 2
+ *
+ * @param node_id node identifier
+ */
+#define DT_NUM_RANGES(node_id) DT_CAT(node_id, _RANGES_NUM)
+
+/**
+ * @brief Is "idx" a valid range block index?
+ *
+ * If this returns 1, then DT_RANGES_CHILD_BUS_ADDRESS_BY_IDX(node_id, idx),
+ * DT_RANGES_PARENT_BUS_ADDRESS_BY_IDX(node_id, idx) or
+ * DT_RANGES_LENGTH_BY_IDX(node_id, idx) are valid.
+ * For DT_RANGES_CHILD_BUS_FLAGS_BY_IDX(node_id, idx) the return value
+ * of DT_RANGES_HAS_CHILD_BUS_FLAGS_AT_IDX(node_id, idx) will indicate
+ * validity.
+ * If it returns 0, it is an error to use those macros with index "idx",
+ * including DT_RANGES_CHILD_BUS_FLAGS_BY_IDX(node_id, idx).
+ *
+ * Example devicetree fragment:
+ *
+ *
+ *     pcie0: pcie@0 {
+ *             compatible = "intel,pcie";
+ *             reg = <0 1>;
+ *             #address-cells = <3>;
+ *             #size-cells = <2>;
+ *
+ *             ranges = <0x1000000 0 0 0 0x3eff0000 0 0x10000>,
+ *                      <0x2000000 0 0x10000000 0 0x10000000 0 0x2eff0000>,
+ *                      <0x3000000 0x80 0 0x80 0 0x80 0>;
+ *     };
+ *
+ *     other: other@1 {
+ *             reg = <1 1>;
+ *
+ *             ranges = <0x0 0x0 0x0 0x3eff0000 0x10000>,
+ *                      <0x0 0x10000000 0x0 0x10000000 0x2eff0000>;
+ *     };
+ *
+ * Example usage:
+ *
+ *     DT_RANGES_HAS_IDX(DT_NODELABEL(pcie0), 0) // 1
+ *     DT_RANGES_HAS_IDX(DT_NODELABEL(pcie0), 1) // 1
+ *     DT_RANGES_HAS_IDX(DT_NODELABEL(pcie0), 2) // 1
+ *     DT_RANGES_HAS_IDX(DT_NODELABEL(pcie0), 3) // 0
+ *     DT_RANGES_HAS_IDX(DT_NODELABEL(other), 0) // 1
+ *     DT_RANGES_HAS_IDX(DT_NODELABEL(other), 1) // 1
+ *     DT_RANGES_HAS_IDX(DT_NODELABEL(other), 2) // 0
+ *     DT_RANGES_HAS_IDX(DT_NODELABEL(other), 3) // 0
+ *
+ * @param node_id node identifier
+ * @param idx index to check
+ * @return 1 if "idx" is a valid register block index,
+ *         0 otherwise.
+ */
+#define DT_RANGES_HAS_IDX(node_id, idx) \
+	IS_ENABLED(DT_CAT4(node_id, _RANGES_IDX_, idx, _EXISTS))
+
+/**
+ * @brief Does a ranges property have child bus flags at index?
+ *
+ * If this returns 1, then DT_RANGES_CHILD_BUS_FLAGS_BY_IDX(node_id, idx) is valid.
+ * If it returns 0, it is an error to use this macro with index "idx".
+ * This macro only returns 1 for PCIe buses (i.e. nodes whose bindings specify they
+ * are "pcie" bus nodes.)
+ *
+ * Example devicetree fragment:
+ *
+ *     parent {
+ *             #address-cells = <2>;
+ *
+ *             pcie0: pcie@0 {
+ *                     compatible = "intel,pcie";
+ *                     reg = <0 0 1>;
+ *                     #address-cells = <3>;
+ *                     #size-cells = <2>;
+ *
+ *                     ranges = <0x1000000 0 0 0 0x3eff0000 0 0x10000>,
+ *                              <0x2000000 0 0x10000000 0 0x10000000 0 0x2eff0000>,
+ *                              <0x3000000 0x80 0 0x80 0 0x80 0>;
+ *             };
+ *
+ *             other: other@1 {
+ *                     reg = <0 1 1>;
+ *
+ *                     ranges = <0x0 0x0 0x0 0x3eff0000 0x10000>,
+ *                              <0x0 0x10000000 0x0 0x10000000 0x2eff0000>;
+ *             };
+ *     };
+ *
+ * Example usage:
+ *
+ *     DT_RANGES_HAS_CHILD_BUS_FLAGS_AT_IDX(DT_NODELABEL(pcie0), 0) // 1
+ *     DT_RANGES_HAS_CHILD_BUS_FLAGS_AT_IDX(DT_NODELABEL(pcie0), 1) // 1
+ *     DT_RANGES_HAS_CHILD_BUS_FLAGS_AT_IDX(DT_NODELABEL(pcie0), 2) // 1
+ *     DT_RANGES_HAS_CHILD_BUS_FLAGS_AT_IDX(DT_NODELABEL(pcie0), 3) // 0
+ *     DT_RANGES_HAS_CHILD_BUS_FLAGS_AT_IDX(DT_NODELABEL(other), 0) // 0
+ *     DT_RANGES_HAS_CHILD_BUS_FLAGS_AT_IDX(DT_NODELABEL(other), 1) // 0
+ *     DT_RANGES_HAS_CHILD_BUS_FLAGS_AT_IDX(DT_NODELABEL(other), 2) // 0
+ *     DT_RANGES_HAS_CHILD_BUS_FLAGS_AT_IDX(DT_NODELABEL(other), 3) // 0
+ *
+ * @param node_id node identifier
+ * @param idx logical index into the ranges array
+ * @return 1 if "idx" is a valid child bus flags index,
+ *         0 otherwise.
+ */
+#define DT_RANGES_HAS_CHILD_BUS_FLAGS_AT_IDX(node_id, idx) \
+	IS_ENABLED(DT_CAT4(node_id, _RANGES_IDX_, idx, _VAL_CHILD_BUS_FLAGS_EXISTS))
+
+/**
+ * @brief Get the ranges property child bus flags at index
+ *
+ * When the node is a PCIe bus, the Child Bus Address has an extra cell used to store some
+ * flags, thus this cell is extracted from the Child Bus Address as Child Bus Flags field.
+ *
+ * Example devicetree fragments:
+ *
+ *     parent {
+ *             #address-cells = <2>;
+ *
+ *             pcie0: pcie@0 {
+ *                     compatible = "intel,pcie";
+ *                     reg = <0 0 1>;
+ *                     #address-cells = <3>;
+ *                     #size-cells = <2>;
+ *
+ *                     ranges = <0x1000000 0 0 0 0x3eff0000 0 0x10000>,
+ *                              <0x2000000 0 0x10000000 0 0x10000000 0 0x2eff0000>,
+ *                              <0x3000000 0x80 0 0x80 0 0x80 0>;
+ *             };
+ *     };
+ *
+ * Example usage:
+ *
+ *     DT_RANGES_CHILD_BUS_FLAGS_BY_IDX(DT_NODELABEL(pcie0), 0) // 0x1000000
+ *     DT_RANGES_CHILD_BUS_FLAGS_BY_IDX(DT_NODELABEL(pcie0), 1) // 0x2000000
+ *     DT_RANGES_CHILD_BUS_FLAGS_BY_IDX(DT_NODELABEL(pcie0), 2) // 0x3000000
+ *
+ * @param node_id node identifier
+ * @param idx logical index into the ranges array
+ * @returns range child bus flags field at idx
+ */
+#define DT_RANGES_CHILD_BUS_FLAGS_BY_IDX(node_id, idx) \
+	DT_CAT4(node_id, _RANGES_IDX_, idx, _VAL_CHILD_BUS_FLAGS)
+
+/**
+ * @brief Get the ranges property child bus address at index
+ *
+ * When the node is a PCIe bus, the Child Bus Address has an extra cell used to store some
+ * flags, thus this cell is removed from the Child Bus Address.
+ *
+ * Example devicetree fragments:
+ *
+ *     parent {
+ *             #address-cells = <2>;
+ *
+ *             pcie0: pcie@0 {
+ *                     compatible = "intel,pcie";
+ *                     reg = <0 0 1>;
+ *                     #address-cells = <3>;
+ *                     #size-cells = <2>;
+ *
+ *                     ranges = <0x1000000 0 0 0 0x3eff0000 0 0x10000>,
+ *                              <0x2000000 0 0x10000000 0 0x10000000 0 0x2eff0000>,
+ *                              <0x3000000 0x80 0 0x80 0 0x80 0>;
+ *             };
+ *
+ *             other: other@1 {
+ *                     reg = <0 1 1>;
+ *
+ *                     ranges = <0x0 0x0 0x0 0x3eff0000 0x10000>,
+ *                              <0x0 0x10000000 0x0 0x10000000 0x2eff0000>;
+ *             };
+ *     };
+ *
+ * Example usage:
+ *
+ *     DT_RANGES_CHILD_BUS_ADDRESS_BY_IDX(DT_NODELABEL(pcie0), 0) // 0
+ *     DT_RANGES_CHILD_BUS_ADDRESS_BY_IDX(DT_NODELABEL(pcie0), 1) // 0x10000000
+ *     DT_RANGES_CHILD_BUS_ADDRESS_BY_IDX(DT_NODELABEL(pcie0), 2) // 0x8000000000
+ *     DT_RANGES_CHILD_BUS_ADDRESS_BY_IDX(DT_NODELABEL(other), 0) // 0
+ *     DT_RANGES_CHILD_BUS_ADDRESS_BY_IDX(DT_NODELABEL(other), 1) // 0x10000000
+ *
+ * @param node_id node identifier
+ * @param idx logical index into the ranges array
+ * @returns range child bus address field at idx
+ */
+#define DT_RANGES_CHILD_BUS_ADDRESS_BY_IDX(node_id, idx) \
+	DT_CAT4(node_id, _RANGES_IDX_, idx, _VAL_CHILD_BUS_ADDRESS)
+
+/**
+ * @brief Get the ranges property parent bus address at index
+ *
+ * Similarly to DT_RANGES_CHILD_BUS_ADDRESS_BY_IDX(), this properly accounts
+ * for child bus flags cells when the node is a PCIe bus.
+ *
+ * Example devicetree fragment:
+ *
+ *     parent {
+ *             #address-cells = <2>;
+ *
+ *             pcie0: pcie@0 {
+ *                     compatible = "intel,pcie";
+ *                     reg = <0 0 1>;
+ *                     #address-cells = <3>;
+ *                     #size-cells = <2>;
+ *
+ *                     ranges = <0x1000000 0 0 0 0x3eff0000 0 0x10000>,
+ *                              <0x2000000 0 0x10000000 0 0x10000000 0 0x2eff0000>,
+ *                              <0x3000000 0x80 0 0x80 0 0x80 0>;
+ *             };
+ *
+ *             other: other@1 {
+ *                     reg = <0 1 1>;
+ *
+ *                     ranges = <0x0 0x0 0x0 0x3eff0000 0x10000>,
+ *                              <0x0 0x10000000 0x0 0x10000000 0x2eff0000>;
+ *             };
+ *     };
+ *
+ * Example usage:
+ *
+ *     DT_RANGES_PARENT_BUS_ADDRESS_BY_IDX(DT_NODELABEL(pcie0), 0) // 0x3eff0000
+ *     DT_RANGES_PARENT_BUS_ADDRESS_BY_IDX(DT_NODELABEL(pcie0), 1) // 0x10000000
+ *     DT_RANGES_PARENT_BUS_ADDRESS_BY_IDX(DT_NODELABEL(pcie0), 2) // 0x8000000000
+ *     DT_RANGES_PARENT_BUS_ADDRESS_BY_IDX(DT_NODELABEL(other), 0) // 0x3eff0000
+ *     DT_RANGES_PARENT_BUS_ADDRESS_BY_IDX(DT_NODELABEL(other), 1) // 0x10000000
+ *
+ * @param node_id node identifier
+ * @param idx logical index into the ranges array
+ * @returns range parent bus address field at idx
+ */
+#define DT_RANGES_PARENT_BUS_ADDRESS_BY_IDX(node_id, idx) \
+	DT_CAT4(node_id, _RANGES_IDX_, idx, _VAL_PARENT_BUS_ADDRESS)
+
+/**
+ * @brief Get the ranges property length at index
+ *
+ * Similarly to DT_RANGES_CHILD_BUS_ADDRESS_BY_IDX(), this properly accounts
+ * for child bus flags cells when the node is a PCIe bus.
+ *
+ * Example devicetree fragment:
+ *
+ *     parent {
+ *             #address-cells = <2>;
+ *
+ *             pcie0: pcie@0 {
+ *                     compatible = "intel,pcie";
+ *                     reg = <0 0 1>;
+ *                     #address-cells = <3>;
+ *                     #size-cells = <2>;
+ *
+ *                     ranges = <0x1000000 0 0 0 0x3eff0000 0 0x10000>,
+ *                              <0x2000000 0 0x10000000 0 0x10000000 0 0x2eff0000>,
+ *                              <0x3000000 0x80 0 0x80 0 0x80 0>;
+ *             };
+ *
+ *             other: other@1 {
+ *                     reg = <0 1 1>;
+ *
+ *                     ranges = <0x0 0x0 0x0 0x3eff0000 0x10000>,
+ *                              <0x0 0x10000000 0x0 0x10000000 0x2eff0000>;
+ *             };
+ *     };
+ *
+ * Example usage:
+ *
+ *     DT_RANGES_LENGTH_BY_IDX(DT_NODELABEL(pcie0), 0) // 0x10000
+ *     DT_RANGES_LENGTH_BY_IDX(DT_NODELABEL(pcie0), 1) // 0x2eff0000
+ *     DT_RANGES_LENGTH_BY_IDX(DT_NODELABEL(pcie0), 2) // 0x8000000000
+ *     DT_RANGES_LENGTH_BY_IDX(DT_NODELABEL(other), 0) // 0x10000
+ *     DT_RANGES_LENGTH_BY_IDX(DT_NODELABEL(other), 1) // 0x2eff0000
+ *
+ * @param node_id node identifier
+ * @param idx logical index into the ranges array
+ * @returns range length field at idx
+ */
+#define DT_RANGES_LENGTH_BY_IDX(node_id, idx) \
+	DT_CAT4(node_id, _RANGES_IDX_, idx, _VAL_LENGTH)
+
+/**
+ * @brief Invokes "fn" for each entry of "node_id" ranges property
+ *
+ * The macro "fn" must take two parameters, "node_id" which will be the node
+ * identifier of the node with the ranges property and "idx" the index of
+ * the ranges block.
+ *
+ * Example devicetree fragment:
+ *
+ *     n: node@0 {
+ *             reg = <0 0 1>;
+ *
+ *             ranges = <0x0 0x0 0x0 0x3eff0000 0x10000>,
+ *                      <0x0 0x10000000 0x0 0x10000000 0x2eff0000>;
+ *     };
+ *
+ * Example usage:
+ *
+ *     #define RANGE_LENGTH(node_id, idx) DT_RANGES_LENGTH_BY_IDX(node_id, idx),
+ *
+ *     const uint64_t *ranges_length[] = {
+ *             DT_FOREACH_RANGE(DT_NODELABEL(n), RANGE_LENGTH)
+ *     };
+ *
+ * This expands to:
+ *
+ *     const char *ranges_length[] = {
+ *         0x10000, 0x2eff0000,
+ *     };
+ *
+ * @param node_id node identifier
+ * @param fn macro to invoke
+ */
+#define DT_FOREACH_RANGE(node_id, fn) \
+	DT_CAT(node_id, _FOREACH_RANGE)(fn)
+
+/**
+ * @}
+ */
+
+/**
  * @defgroup devicetree-reg-prop reg property
  * @ingroup devicetree
  * @{

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -355,6 +355,7 @@ def write_special_props(node):
     # Macros that are special to the devicetree specification
     out_comment("Macros for properties that are special in the specification:")
     write_regs(node)
+    write_ranges(node)
     write_interrupts(node)
     write_compatibles(node)
     write_status(node)
@@ -363,6 +364,49 @@ def write_special_props(node):
     # we can't capture with the current bindings language.
     write_pinctrls(node)
     write_fixed_partitions(node)
+
+def write_ranges(node):
+    # ranges property: edtlib knows the right #address-cells and
+    # #size-cells of parent and child, and can therefore pack the
+    # child & parent addresses and sizes correctly
+
+    idx_vals = []
+    path_id = node.z_path_id
+
+    if node.ranges is not None:
+        idx_vals.append((f"{path_id}_RANGES_NUM", len(node.ranges)))
+
+    for i,range in enumerate(node.ranges):
+        idx_vals.append((f"{path_id}_RANGES_IDX_{i}_EXISTS", 1))
+
+        if node.bus == "pcie":
+            idx_vals.append((f"{path_id}_RANGES_IDX_{i}_VAL_CHILD_BUS_FLAGS_EXISTS", 1))
+            idx_macro = f"{path_id}_RANGES_IDX_{i}_VAL_CHILD_BUS_FLAGS"
+            idx_value = range.child_bus_addr >> ((range.child_bus_cells - 1) * 32)
+            idx_vals.append((idx_macro,
+                             f"{idx_value} /* {hex(idx_value)} */"))
+        if range.child_bus_addr is not None:
+            idx_macro = f"{path_id}_RANGES_IDX_{i}_VAL_CHILD_BUS_ADDRESS"
+            if node.bus == "pcie":
+                idx_value = range.child_bus_addr & ((1 << (range.child_bus_cells - 1) * 32) - 1)
+            else:
+                idx_value = range.child_bus_addr
+            idx_vals.append((idx_macro,
+                             f"{idx_value} /* {hex(idx_value)} */"))
+        if range.parent_bus_addr is not None:
+            idx_macro = f"{path_id}_RANGES_IDX_{i}_VAL_PARENT_BUS_ADDRESS"
+            idx_vals.append((idx_macro,
+                             f"{range.parent_bus_addr} /* {hex(range.parent_bus_addr)} */"))
+        if range.length is not None:
+            idx_macro = f"{path_id}_RANGES_IDX_{i}_VAL_LENGTH"
+            idx_vals.append((idx_macro,
+                             f"{range.length} /* {hex(range.length)} */"))
+
+    for macro, val in idx_vals:
+        out_dt_define(macro, val)
+
+    out_dt_define(f"{path_id}_FOREACH_RANGE(fn)",
+            " ".join(f"fn(DT_{path_id}, {i})" for i,range in enumerate(node.ranges)))
 
 def write_regs(node):
     # reg property: edtlib knows the right #address-cells and
@@ -682,10 +726,12 @@ def prop_len(prop):
     # Returns the property's length if and only if we should generate
     # a _LEN macro for the property. Otherwise, returns None.
     #
-    # This deliberately excludes reg and interrupts.
+    # This deliberately excludes ranges, dma-ranges, reg and interrupts.
     # While they have array type, their lengths as arrays are
     # basically nonsense semantically due to #address-cells and
-    # #size-cells for "reg" and #interrupt-cells for "interrupts".
+    # #size-cells for "reg", #interrupt-cells for "interrupts"
+    # and #address-cells, #size-cells and the #address-cells from the
+    # parent node for "ranges" and "dma-ranges".
     #
     # We have special purpose macros for the number of register blocks
     # / interrupt specifiers. Excluding them from this list means
@@ -698,7 +744,7 @@ def prop_len(prop):
 
     if (prop.type in ["array", "uint8-array", "string-array",
                       "phandles", "phandle-array"] and
-                prop.name not in ["reg", "interrupts"]):
+                prop.name not in ["ranges", "dma-ranges", "reg", "interrupts"]):
         return len(prop.val)
 
     return None

--- a/scripts/dts/python-devicetree/tests/test.dts
+++ b/scripts/dts/python-devicetree/tests/test.dts
@@ -124,6 +124,110 @@
 	};
 
 	//
+	// 'ranges'
+	//
+
+	ranges-zero-cells {
+		#address-cells = <0>;
+
+		node {
+			#address-cells = <0>;
+			#size-cells = <0>;
+
+			ranges;
+		};
+	};
+
+	ranges-zero-parent-cells {
+		#address-cells = <0>;
+
+		node {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			ranges = <0xA>,
+				 <0x1A>,
+				 <0x2A>;
+		};
+	};
+
+	ranges-one-address-cells {
+		#address-cells = <0>;
+
+		node {
+			reg = <1>;
+			#address-cells = <1>;
+
+			ranges = <0xA 0xB>,
+				 <0x1A 0x1B>,
+				 <0x2A 0x2B>;
+		};
+	};
+
+	ranges-one-address-two-size-cells {
+		#address-cells = <0>;
+
+		node {
+			reg = <1>;
+			#address-cells = <1>;
+			#size-cells = <2>;
+
+			ranges = <0xA 0xB 0xC>,
+				 <0x1A 0x1B 0x1C>,
+				 <0x2A 0x2B 0x2C>;
+		};
+	};
+
+	ranges-two-address-cells {
+		#address-cells = <1>;
+
+		node@1 {
+			reg = <1 2>;
+
+			ranges = <0xA 0xB 0xC 0xD>,
+				 <0x1A 0x1B 0x1C 0x1D>,
+				 <0x2A 0x2B 0x2C 0x2D>;
+		};
+	};
+
+	ranges-two-address-two-size-cells {
+		#address-cells = <1>;
+
+		node@1 {
+			reg = <1 2>;
+			#size-cells = <2>;
+
+			ranges = <0xA 0xB 0xC 0xD 0xE>,
+				 <0x1A 0x1B 0x1C 0x1D 0x1E>,
+				 <0x2A 0x2B 0x2C 0x2D 0x1D>;
+		};
+	};
+
+	ranges-three-address-cells {
+		node@1 {
+			reg = <0 1 2>;
+			#address-cells = <3>;
+
+			ranges = <0xA 0xB 0xC 0xD 0xE 0xF>,
+				 <0x1A 0x1B 0x1C 0x1D 0x1E 0x1F>,
+				 <0x2A 0x2B 0x2C 0x2D 0x2E 0x2F>;
+		};
+	};
+
+	ranges-three-address-two-size-cells {
+		node@1 {
+			reg = <0 1 2>;
+			#address-cells = <3>;
+			#size-cells = <2>;
+
+			ranges = <0xA 0xB 0xC 0xD 0xE 0xF 0x10>,
+				 <0x1A 0x1B 0x1C 0x1D 0x1E 0x1F 0x110>,
+				 <0x2A 0x2B 0x2C 0x2D 0x2E 0x2F 0x210>;
+		};
+	};
+
+
+	//
 	// 'reg'
 	//
 

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -78,6 +78,43 @@ def test_interrupts():
     assert str(edt.get_node("/interrupt-map-bitops-test/node@70000000E").interrupts) == \
         f"[<ControllerAndData, controller: <Node /interrupt-map-bitops-test/controller in 'test.dts', binding {filenames[2]}>, data: OrderedDict([('one', 3), ('two', 2)])>]"
 
+def test_ranges():
+    '''Tests for the ranges property'''
+    with from_here():
+        edt = edtlib.EDT("test.dts", ["test-bindings"])
+
+    assert str(edt.get_node("/reg-ranges/parent").ranges) == \
+        "[<Range, child-bus-cells: 0x1, child-bus-addr: 0x1, parent-bus-cells: 0x2, parent-bus-addr: 0xa0000000b, length-cells 0x1, length 0x1>, <Range, child-bus-cells: 0x1, child-bus-addr: 0x2, parent-bus-cells: 0x2, parent-bus-addr: 0xc0000000d, length-cells 0x1, length 0x2>, <Range, child-bus-cells: 0x1, child-bus-addr: 0x4, parent-bus-cells: 0x2, parent-bus-addr: 0xe0000000f, length-cells 0x1, length 0x1>]"
+
+    assert str(edt.get_node("/reg-nested-ranges/grandparent").ranges) == \
+        "[<Range, child-bus-cells: 0x2, child-bus-addr: 0x0, parent-bus-cells: 0x3, parent-bus-addr: 0x30000000000000000, length-cells 0x2, length 0x200000002>]"
+
+    assert str(edt.get_node("/reg-nested-ranges/grandparent/parent").ranges) == \
+        "[<Range, child-bus-cells: 0x1, child-bus-addr: 0x0, parent-bus-cells: 0x2, parent-bus-addr: 0x200000000, length-cells 0x1, length 0x2>]"
+
+    assert str(edt.get_node("/ranges-zero-cells/node").ranges) == "[]"
+
+    assert str(edt.get_node("/ranges-zero-parent-cells/node").ranges) == \
+        "[<Range, child-bus-cells: 0x1, child-bus-addr: 0xa, parent-bus-cells: 0x0, length-cells 0x0>, <Range, child-bus-cells: 0x1, child-bus-addr: 0x1a, parent-bus-cells: 0x0, length-cells 0x0>, <Range, child-bus-cells: 0x1, child-bus-addr: 0x2a, parent-bus-cells: 0x0, length-cells 0x0>]"
+
+    assert str(edt.get_node("/ranges-one-address-cells/node").ranges) == \
+        "[<Range, child-bus-cells: 0x1, child-bus-addr: 0xa, parent-bus-cells: 0x0, length-cells 0x1, length 0xb>, <Range, child-bus-cells: 0x1, child-bus-addr: 0x1a, parent-bus-cells: 0x0, length-cells 0x1, length 0x1b>, <Range, child-bus-cells: 0x1, child-bus-addr: 0x2a, parent-bus-cells: 0x0, length-cells 0x1, length 0x2b>]"
+
+    assert str(edt.get_node("/ranges-one-address-two-size-cells/node").ranges) == \
+        "[<Range, child-bus-cells: 0x1, child-bus-addr: 0xa, parent-bus-cells: 0x0, length-cells 0x2, length 0xb0000000c>, <Range, child-bus-cells: 0x1, child-bus-addr: 0x1a, parent-bus-cells: 0x0, length-cells 0x2, length 0x1b0000001c>, <Range, child-bus-cells: 0x1, child-bus-addr: 0x2a, parent-bus-cells: 0x0, length-cells 0x2, length 0x2b0000002c>]"
+
+    assert str(edt.get_node("/ranges-two-address-cells/node@1").ranges) == \
+        "[<Range, child-bus-cells: 0x2, child-bus-addr: 0xa0000000b, parent-bus-cells: 0x1, parent-bus-addr: 0xc, length-cells 0x1, length 0xd>, <Range, child-bus-cells: 0x2, child-bus-addr: 0x1a0000001b, parent-bus-cells: 0x1, parent-bus-addr: 0x1c, length-cells 0x1, length 0x1d>, <Range, child-bus-cells: 0x2, child-bus-addr: 0x2a0000002b, parent-bus-cells: 0x1, parent-bus-addr: 0x2c, length-cells 0x1, length 0x2d>]"
+
+    assert str(edt.get_node("/ranges-two-address-two-size-cells/node@1").ranges) == \
+        "[<Range, child-bus-cells: 0x2, child-bus-addr: 0xa0000000b, parent-bus-cells: 0x1, parent-bus-addr: 0xc, length-cells 0x2, length 0xd0000000e>, <Range, child-bus-cells: 0x2, child-bus-addr: 0x1a0000001b, parent-bus-cells: 0x1, parent-bus-addr: 0x1c, length-cells 0x2, length 0x1d0000001e>, <Range, child-bus-cells: 0x2, child-bus-addr: 0x2a0000002b, parent-bus-cells: 0x1, parent-bus-addr: 0x2c, length-cells 0x2, length 0x2d0000001d>]"
+
+    assert str(edt.get_node("/ranges-three-address-cells/node@1").ranges) == \
+        "[<Range, child-bus-cells: 0x3, child-bus-addr: 0xa0000000b0000000c, parent-bus-cells: 0x2, parent-bus-addr: 0xd0000000e, length-cells 0x1, length 0xf>, <Range, child-bus-cells: 0x3, child-bus-addr: 0x1a0000001b0000001c, parent-bus-cells: 0x2, parent-bus-addr: 0x1d0000001e, length-cells 0x1, length 0x1f>, <Range, child-bus-cells: 0x3, child-bus-addr: 0x2a0000002b0000002c, parent-bus-cells: 0x2, parent-bus-addr: 0x2d0000002e, length-cells 0x1, length 0x2f>]"
+
+    assert str(edt.get_node("/ranges-three-address-two-size-cells/node@1").ranges) == \
+        "[<Range, child-bus-cells: 0x3, child-bus-addr: 0xa0000000b0000000c, parent-bus-cells: 0x2, parent-bus-addr: 0xd0000000e, length-cells 0x2, length 0xf00000010>, <Range, child-bus-cells: 0x3, child-bus-addr: 0x1a0000001b0000001c, parent-bus-cells: 0x2, parent-bus-addr: 0x1d0000001e, length-cells 0x2, length 0x1f00000110>, <Range, child-bus-cells: 0x3, child-bus-addr: 0x2a0000002b0000002c, parent-bus-cells: 0x2, parent-bus-addr: 0x2d0000002e, length-cells 0x2, length 0x2f00000210>]"
+
 def test_reg():
     '''Tests for the regs property'''
     with from_here():

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -441,5 +441,30 @@
 				};
 			};
 		};
+
+		test-ranges {
+			#address-cells = <2>;
+			#size-cells = <1>;
+
+			test_ranges_pcie: pcie@0 {
+				compatible = "vnd,pcie";
+				reg = <0 0 1>;
+				#address-cells = <3>;
+				#size-cells = <2>;
+
+				ranges = <0x1000000 0 0 0 0x3eff0000 0 0x10000>,
+					 <0x2000000 0 0x10000000 0 0x10000000 0 0x2eff0000>,
+					 <0x3000000 0x80 0 0x80 0 0x80 0>;
+			};
+
+			test_ranges_other: other@1 {
+				reg = <0 1 1>;
+				#address-cells = <2>;
+				#size-cells = <1>;
+
+				ranges = <0x0 0x0 0x0 0x3eff0000 0x10000>,
+				         <0x0 0x10000000 0x0 0x10000000 0x2eff0000>;
+			};
+		};
 	};
 };

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -81,6 +81,9 @@
 #define TEST_IO_CHANNEL_CTLR_1 DT_NODELABEL(test_adc_1)
 #define TEST_IO_CHANNEL_CTLR_2 DT_NODELABEL(test_adc_2)
 
+#define TEST_RANGES_PCIE  DT_NODELABEL(test_ranges_pcie)
+#define TEST_RANGES_OTHER DT_NODELABEL(test_ranges_other)
+
 #define TA_HAS_COMPAT(compat) DT_NODE_HAS_COMPAT(TEST_ARRAYS, compat)
 
 #define TO_STRING(x) TO_STRING_(x)
@@ -1723,6 +1726,123 @@ static void test_great_grandchild(void)
 	zassert_equal(DT_PROP(DT_NODELABEL(test_ggc), ggc_prop), 42, "");
 }
 
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT vnd_test_ranges_pcie
+static void test_ranges_pcie(void)
+{
+#define FLAGS(node_id, idx)				\
+	DT_RANGES_CHILD_BUS_FLAGS_BY_IDX(node_id, idx),
+#define CHILD_BUS_ADDR(node_id, idx)				\
+	DT_RANGES_CHILD_BUS_ADDRESS_BY_IDX(node_id, idx),
+#define PARENT_BUS_ADDR(node_id, idx)				\
+	DT_RANGES_PARENT_BUS_ADDRESS_BY_IDX(node_id, idx),
+#define LENGTH(node_id, idx) DT_RANGES_LENGTH_BY_IDX(node_id, idx),
+
+	unsigned int count = DT_NUM_RANGES(TEST_RANGES_PCIE);
+
+	const uint64_t ranges_pcie_flags[] = {
+		DT_FOREACH_RANGE(TEST_RANGES_PCIE, FLAGS)
+	};
+
+	const uint64_t ranges_child_bus_addr[] = {
+		DT_FOREACH_RANGE(TEST_RANGES_PCIE, CHILD_BUS_ADDR)
+	};
+
+	const uint64_t ranges_parent_bus_addr[] = {
+		DT_FOREACH_RANGE(TEST_RANGES_PCIE, PARENT_BUS_ADDR)
+	};
+
+	const uint64_t ranges_length[] = {
+		DT_FOREACH_RANGE(TEST_RANGES_PCIE, LENGTH)
+	};
+
+	zassert_equal(count, 3, "");
+
+	zassert_equal(DT_RANGES_HAS_IDX(TEST_RANGES_PCIE, 0), 1, "");
+	zassert_equal(DT_RANGES_HAS_IDX(TEST_RANGES_PCIE, 1), 1, "");
+	zassert_equal(DT_RANGES_HAS_IDX(TEST_RANGES_PCIE, 2), 1, "");
+	zassert_equal(DT_RANGES_HAS_IDX(TEST_RANGES_PCIE, 3), 0, "");
+
+	zassert_equal(DT_RANGES_HAS_CHILD_BUS_FLAGS_AT_IDX(TEST_RANGES_PCIE, 0),
+		      1, "");
+	zassert_equal(DT_RANGES_HAS_CHILD_BUS_FLAGS_AT_IDX(TEST_RANGES_PCIE, 1),
+		      1, "");
+	zassert_equal(DT_RANGES_HAS_CHILD_BUS_FLAGS_AT_IDX(TEST_RANGES_PCIE, 2),
+		      1, "");
+	zassert_equal(DT_RANGES_HAS_CHILD_BUS_FLAGS_AT_IDX(TEST_RANGES_PCIE, 3),
+		      0, "");
+
+	zassert_equal(ranges_pcie_flags[0], 0x1000000, "");
+	zassert_equal(ranges_pcie_flags[1], 0x2000000, "");
+	zassert_equal(ranges_pcie_flags[2], 0x3000000, "");
+	zassert_equal(ranges_child_bus_addr[0], 0, "");
+	zassert_equal(ranges_child_bus_addr[1], 0x10000000, "");
+	zassert_equal(ranges_child_bus_addr[2], 0x8000000000, "");
+	zassert_equal(ranges_parent_bus_addr[0], 0x3eff0000, "");
+	zassert_equal(ranges_parent_bus_addr[1], 0x10000000, "");
+	zassert_equal(ranges_parent_bus_addr[2], 0x8000000000, "");
+	zassert_equal(ranges_length[0], 0x10000, "");
+	zassert_equal(ranges_length[1], 0x2eff0000, "");
+	zassert_equal(ranges_length[2], 0x8000000000, "");
+
+#undef FLAGS
+#undef CHILD_BUS_ADDR
+#undef PARENT_BUS_ADDR
+#undef LENGTH
+}
+
+static void test_ranges_other(void)
+{
+#define HAS_FLAGS(node_id, idx) \
+	DT_RANGES_HAS_CHILD_BUS_FLAGS_AT_IDX(node_id, idx)
+#define FLAGS(node_id, idx) \
+	DT_RANGES_CHILD_BUS_FLAGS_BY_IDX(node_id, idx),
+#define CHILD_BUS_ADDR(node_id, idx) \
+	DT_RANGES_CHILD_BUS_ADDRESS_BY_IDX(node_id, idx),
+#define PARENT_BUS_ADDR(node_id, idx) \
+	DT_RANGES_PARENT_BUS_ADDRESS_BY_IDX(node_id, idx),
+#define LENGTH(node_id, idx) DT_RANGES_LENGTH_BY_IDX(node_id, idx),
+
+	unsigned int count = DT_NUM_RANGES(TEST_RANGES_OTHER);
+
+	const uint32_t ranges_child_bus_addr[] = {
+		DT_FOREACH_RANGE(TEST_RANGES_OTHER, CHILD_BUS_ADDR)
+	};
+
+	const uint32_t ranges_parent_bus_addr[] = {
+		DT_FOREACH_RANGE(TEST_RANGES_OTHER, PARENT_BUS_ADDR)
+	};
+
+	const uint32_t ranges_length[] = {
+		DT_FOREACH_RANGE(TEST_RANGES_OTHER, LENGTH)
+	};
+
+	zassert_equal(count, 2, "");
+
+	zassert_equal(DT_RANGES_HAS_IDX(TEST_RANGES_OTHER, 0), 1, "");
+	zassert_equal(DT_RANGES_HAS_IDX(TEST_RANGES_OTHER, 1), 1, "");
+	zassert_equal(DT_RANGES_HAS_IDX(TEST_RANGES_OTHER, 2), 0, "");
+	zassert_equal(DT_RANGES_HAS_IDX(TEST_RANGES_OTHER, 3), 0, "");
+
+	zassert_equal(HAS_FLAGS(TEST_RANGES_OTHER, 0), 0, "");
+	zassert_equal(HAS_FLAGS(TEST_RANGES_OTHER, 1), 0, "");
+	zassert_equal(HAS_FLAGS(TEST_RANGES_OTHER, 2), 0, "");
+	zassert_equal(HAS_FLAGS(TEST_RANGES_OTHER, 3), 0, "");
+
+	zassert_equal(ranges_child_bus_addr[0], 0, "");
+	zassert_equal(ranges_child_bus_addr[1], 0x10000000, "");
+	zassert_equal(ranges_parent_bus_addr[0], 0x3eff0000, "");
+	zassert_equal(ranges_parent_bus_addr[1], 0x10000000, "");
+	zassert_equal(ranges_length[0], 0x10000, "");
+	zassert_equal(ranges_length[1], 0x2eff0000, "");
+
+#undef HAS_FLAGS
+#undef FLAGS
+#undef CHILD_BUS_ADDR
+#undef PARENT_BUS_ADDR
+#undef LENGTH
+}
+
 static void test_compat_get_any_status_okay(void)
 {
 	zassert_true(
@@ -2148,6 +2268,8 @@ void test_main(void)
 			 ztest_unit_test(test_child_nodes_list),
 			 ztest_unit_test(test_child_nodes_list_varg),
 			 ztest_unit_test(test_great_grandchild),
+			 ztest_unit_test(test_ranges_pcie),
+			 ztest_unit_test(test_ranges_other),
 			 ztest_unit_test(test_compat_get_any_status_okay),
 			 ztest_unit_test(test_dep_ord),
 			 ztest_unit_test(test_path),


### PR DESCRIPTION
As requested in https://github.com/zephyrproject-rtos/zephyr/pull/37668#pullrequestreview-729799792, this adds support for parsing and extracting the DT RANGES property with the associated macros.

The ranges property is used standalone in PCIe DT bindings, As described in IEEE Std 1275-1994, to describe the PCI I/O and memory regions.