### PR TITLE
drivers: ieee802154: reverse ack data ext addr string

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -842,11 +842,16 @@ static int nrf5_configure(const struct device *dev,
 		uint8_t ext_addr_le[EXTENDED_ADDRESS_SIZE];
 
 		sys_put_le16(config->ack_ie.short_addr, short_addr_le);
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-		memcpy(ext_addr_le, config->ack_ie.ext_addr, EXTENDED_ADDRESS_SIZE);
-#else
+		/**
+		 * The extended address field passed to this function starts
+		 * with the leftmost octet and ends with the rightmost octet.
+		 * The IEEE 802.15.4 transmission order mandates this order to be
+		 * reversed in a transmitted frame.
+		 *
+		 * The nrf_802154_ack_data_set expects extended address in transmission
+		 * order.
+		 */
 		sys_memcpy_swap(ext_addr_le, config->ack_ie.ext_addr, EXTENDED_ADDRESS_SIZE);
-#endif
 
 		if (config->ack_ie.data_len > 0) {
 			nrf_802154_ack_data_set(short_addr_le, false, config->ack_ie.data,

--- a/include/net/ieee802154_radio.h
+++ b/include/net/ieee802154_radio.h
@@ -281,6 +281,13 @@ struct ieee802154_config {
 			const uint8_t *data;
 			uint16_t data_len;
 			uint16_t short_addr;
+			/**
+			 * The extended address is expected to be passed starting
+			 * with the leftmost octet and ending with the rightmost octet.
+			 * A device with an extended address 01:23:45:67:89:ab:cd:ef
+			 * should provide a pointer to array containing values in the
+			 * same exact order.
+			 */
 			const uint8_t *ext_addr;
 		} ack_ie;
 	};


### PR DESCRIPTION
When ack data for extended address is set with the
nrf_802154_ack_data_set function, the extended address
must be reversed to the IEEE 802.15.4 address transmit
order in order to be properly matched.

Signed-off-by: Rafał Kuźnia <rafal.kuznia@nordicsemi.no>