### PR TITLE
Bluetooth: Controller: Fixes for aux scanner

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -5545,6 +5545,21 @@ static void le_per_adv_sync_report(struct pdu_data *pdu_data,
 		return;
 	}
 
+	if (node_rx->hdr.rx_ftr.aux_failed) {
+		sep = meta_evt(buf,
+			       BT_HCI_EVT_LE_PER_ADVERTISING_REPORT,
+			       sizeof(*sep));
+
+		sep->handle = sys_cpu_to_le16(node_rx->hdr.handle);
+		sep->tx_power = BT_HCI_LE_ADV_TX_POWER_NO_PREF;
+		sep->rssi = BT_HCI_LE_RSSI_NOT_AVAILABLE;
+		sep->cte_type = BT_HCI_LE_NO_CTE;
+		sep->data_status = BT_HCI_LE_ADV_EVT_TYPE_DATA_STATUS_INCOMPLETE;
+		sep->length = 0;
+
+		return;
+	}
+
 	/* The Link Layer currently returns RSSI as an absolute value */
 	rssi = -(node_rx->hdr.rx_ftr.rssi);
 

--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -283,6 +283,7 @@ struct node_rx_ftr {
 #if defined(CONFIG_BT_CTLR_ADV_EXT) && defined(CONFIG_BT_OBSERVER)
 	uint8_t  aux_lll_sched:1;
 	uint8_t  aux_w4next:1;
+	uint8_t  aux_failed:1;
 
 	uint8_t  phy_flags:1;
 	uint8_t  scan_req:1;

--- a/subsys/bluetooth/controller/ll_sw/lll_scan.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_scan.h
@@ -31,6 +31,7 @@ struct lll_scan {
 	uint16_t duration_expire;
 	uint8_t  phy:3;
 	uint8_t  is_adv_ind:1;
+	uint8_t  is_aux_prep:1;
 	uint8_t  is_aux_sched:1;
 
 	/* temporary storage when aux scan was scheduled from LLL */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -353,6 +353,7 @@ static int common_prepare_cb(struct lll_prepare_param *p, bool is_resume)
 	radio_pkt_configure(8, PDU_AC_LEG_PAYLOAD_SIZE_MAX, (lll->phy << 1));
 
 	lll->is_adv_ind = 0U;
+	lll->is_aux_prep = 0U;
 	lll->is_aux_sched = 0U;
 #else /* !CONFIG_BT_CTLR_ADV_EXT */
 	radio_phy_set(0, 0);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -488,6 +488,7 @@ static int isr_rx(struct lll_sync *lll, uint8_t node_type, uint8_t *trx_cnt,
 
 			ftr = &(node_rx->hdr.rx_ftr);
 			ftr->param = lll;
+			ftr->aux_failed = 0U;
 			ftr->rssi = (rssi_ready) ? radio_rssi_get() :
 						   BT_HCI_LE_RSSI_NOT_AVAILABLE;
 			ftr->ticks_anchor = radio_tmr_start_get();
@@ -582,6 +583,21 @@ static void isr_rx_aux_chain(void *param)
 
 	if (err == -EBUSY) {
 		return;
+	}
+
+	if (!trx_cnt || !crc_ok) {
+		struct node_rx_pdu *node_rx;
+
+		node_rx = ull_pdu_rx_alloc();
+		LL_ASSERT(node_rx);
+
+		node_rx->hdr.type = NODE_RX_TYPE_EXT_AUX_RELEASE;
+
+		node_rx->hdr.rx_ftr.param = lll;
+		node_rx->hdr.rx_ftr.aux_failed = 1U;
+
+		ull_rx_put(node_rx->hdr.link, node_rx);
+		ull_rx_sched();
 	}
 
 	lll_isr_cleanup(param);

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -633,6 +633,9 @@ void ull_scan_aux_release(memq_link_t *link, struct node_rx_hdr *rx)
 
 	param_ull = HDR_LLL2ULL(rx->rx_ftr.param);
 
+	/* Mark for buffer for release */
+	rx->type = NODE_RX_TYPE_RELEASE;
+
 	if (ull_scan_is_valid_get(param_ull)) {
 		struct lll_scan *lll;
 
@@ -646,6 +649,12 @@ void ull_scan_aux_release(memq_link_t *link, struct node_rx_hdr *rx)
 
 		lll = rx->rx_ftr.param;
 		lll_aux = lll->lll_aux;
+
+		/* Change node type so HCI can dispatch report for truncated
+		 * data properly.
+		 */
+		rx->type = NODE_RX_TYPE_SYNC_REPORT;
+		rx->handle = ull_sync_handle_get(HDR_LLL2ULL(lll));
 #endif /* CONFIG_BT_CTLR_SYNC_PERIODIC */
 	} else {
 		LL_ASSERT(0);
@@ -654,13 +663,22 @@ void ull_scan_aux_release(memq_link_t *link, struct node_rx_hdr *rx)
 
 	if (lll_aux) {
 		struct ll_scan_aux_set *aux;
+		struct ull_hdr *hdr;
 
 		aux = HDR_LLL2ULL(lll_aux);
-		flush(aux);
-	}
+		hdr = &aux->ull;
 
-	/* Mark for buffer for release */
-	rx->type = NODE_RX_TYPE_RELEASE;
+		LL_ASSERT(ull_ref_get(hdr) < 2);
+		/* Flush from here of from done event, if one is pending */
+		if (ull_ref_get(hdr) == 0) {
+			flush(aux);
+		} else {
+			LL_ASSERT(!hdr->disabled_cb);
+
+			hdr->disabled_param = aux;
+			hdr->disabled_cb = last_disabled_cb;
+		}
+	}
 
 	ll_rx_put(link, rx);
 	ll_rx_sched();


### PR DESCRIPTION
This fixes issues in aux scanner:
- proper termination of HCI reports for failed periodic advertisement train scan
- crash when scanning on aux context release