### PR TITLE
usb: usb_dc_mcux: fix building with CONFIG_NOCACHE_MEMORY

### DIFF
--- a/drivers/usb/device/usb_dc_mcux.c
+++ b/drivers/usb/device/usb_dc_mcux.c
@@ -68,7 +68,7 @@ static void usb_isr_handler(void);
 /* The max MPS is 1023 for FS, 1024 for HS. */
 #if defined(CONFIG_NOCACHE_MEMORY)
 #define EP_BUF_NONCACHED
-__nocache K_HEAP_DEFINE(ep_buf_pool, 1024 * EP_BUF_NUMOF_BLOCKS);
+K_HEAP_DEFINE_NOCACHE(ep_buf_pool, 1024 * EP_BUF_NUMOF_BLOCKS);
 #else
 K_HEAP_DEFINE(ep_buf_pool, 1024 * EP_BUF_NUMOF_BLOCKS);
 #endif


### PR DESCRIPTION
This fixes a build error as K_HEAP_DEFINE() is specifying its own linker section so that it is no longer possible to specify another linker section. A new macro `K_HEAP_DEFINE_NOCACHE()` has been introduced for this defining a kheap in uncached memory.
    