### PR TITLE
drivers: sensor: clean up zephyr_library calls, again

### DIFF
--- a/drivers/sensor/lsm303dlhc_magn/CMakeLists.txt
+++ b/drivers/sensor/lsm303dlhc_magn/CMakeLists.txt
@@ -5,4 +5,4 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_LSM303DLHC_MAGN lsm303dlhc_magn.c)
+zephyr_library_sources(lsm303dlhc_magn.c)

--- a/drivers/sensor/ms5607/CMakeLists.txt
+++ b/drivers/sensor/ms5607/CMakeLists.txt
@@ -1,6 +1,5 @@
 # Copyright (c) 2019 Thomas Schmid <tom@lfence.de>
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library_sources(ms5607.c)
-zephyr_library_sources(ms5607_i2c.c)
-zephyr_library_sources_ifdef(CONFIG_MS5607            ms5607_spi.c)
+zephyr_library()
+zephyr_library_sources(ms5607.c ms5607_i2c.c ms5607_spi.c)

--- a/drivers/sensor/shtcx/CMakeLists.txt
+++ b/drivers/sensor/shtcx/CMakeLists.txt
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library()
-
-zephyr_library_sources_ifdef(CONFIG_SHTCX shtcx.c)
+zephyr_library_sources(shtcx.c)


### PR DESCRIPTION
Apply the same fix in bd8afe9365e19d579417a514dd3bc87ee1667b9f
(" drivers: sensor: clean up zephyr_library calls") to remove
redundant code in the sensor driver build system files. Additional
instances of the antipattern have crept in.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>