### PR TITLE
.github: update action-manifest SHA

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
 
       - name: Manifest
-        uses: zephyrproject-rtos/action-manifest@v1.1.0
+        uses: zephyrproject-rtos/action-manifest@2f1ad2908599d4fe747f886f9d733dd7eebae4ef
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           manifest-path: 'west.yml'


### PR DESCRIPTION
Use the latest.

I'm attempting to work around a failure in https://github.com/zephyrproject-rtos/zephyr/pull/37155 by merging the action update first, so that PR can be retested against the latest action code.