### PR TITLE
usb: class: cdc_acm: Add check for irq_ena in cdc_acm_irq_tx_ready function

### DIFF
--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -588,7 +588,7 @@ static int cdc_acm_irq_tx_ready(const struct device *dev)
 {
 	struct cdc_acm_dev_data_t * const dev_data = DEV_DATA(dev);
 
-	if (dev_data->tx_ready) {
+	if (dev_data->tx_irq_ena && dev_data->tx_ready) {
 		return 1;
 	}
 


### PR DESCRIPTION
`cdc_acm_irq_tx_ready` and `cdc_acm_irq_rx_ready` were not checking if their respective interrupt was enabled. Adding checks for the respective interrupts also matches the logic in `cdc_acm_irq_is_pending`.

Signed-off-by: Eric Johnson <eric@liveathos.com>