### PR TITLE
Remove device get binding from more sensor samples

### DIFF
--- a/samples/sensor/ams_iAQcore/CMakeLists.txt
+++ b/samples/sensor/ams_iAQcore/CMakeLists.txt
@@ -2,8 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-set(DTC_OVERLAY_FILE "${CMAKE_CURRENT_SOURCE_DIR}/iaq_core.overlay")
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(iAQcore)
 

--- a/samples/sensor/ams_iAQcore/README.rst
+++ b/samples/sensor/ams_iAQcore/README.rst
@@ -13,11 +13,17 @@ VOC. The values are fetched and printed every second.
 Building and Running
 ********************
 
-This sample application uses the sensor connected to the i2c stated in the
-iaq_core.overlay file.
-Flash the binary to a board of choice with a sensor connected.
-This sample can run on every board with i2c.
-For example build for a nucleo_f446re board:
+This sample can be built as-is for any board with an Arduino-style I2C header
+configured in its :ref:`devicetree <dt-guide>`, as configured in the
+:zephyr_file:`samples/sensor/ams_iAQcore/app.overlay` devicetree overlay file.
+
+(To build the sample on other platforms, use another devicetree overlay file.
+See :ref:`set-devicetree-overlays`.)
+
+Flash the binary to your board with a sensor connected to the I2C bus
+configured via devicetree.
+
+For example, to build and flash for the ``nucleo_f446re`` board:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/sensor/ams_iAQcore

--- a/samples/sensor/ams_iAQcore/app.overlay
+++ b/samples/sensor/ams_iAQcore/app.overlay
@@ -7,7 +7,7 @@
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 
-	iaqcore: iaqcore@5a {
+	iaqcore@5a {
 		compatible = "ams,iaqcore";
 		reg = <0x5a>;
 		label = "IAQ_CORE";

--- a/samples/sensor/ams_iAQcore/src/main.c
+++ b/samples/sensor/ams_iAQcore/src/main.c
@@ -11,12 +11,13 @@
 
 void main(void)
 {
-	const struct device *dev;
+	const struct device *dev = DEVICE_DT_GET_ONE(ams_iaqcore);
 	struct sensor_value co2, voc;
 
-	dev = device_get_binding(DT_LABEL(DT_INST(0, ams_iaqcore)));
-	if (!dev) {
-		printk("Failed to get device binding");
+	if (!device_is_ready(dev)) {
+		printf("Device %s is not ready; "
+		       "check its initialization function return value\n",
+		       dev->name);
 		return;
 	}
 

--- a/samples/sensor/ccs811/README.rst
+++ b/samples/sensor/ccs811/README.rst
@@ -17,6 +17,15 @@ human presence.
 Building and Running
 ********************
 
+This project outputs sensor data to the console. It requires a CCS811 sensor,
+which is present on the ``thingy52_nrf52832`` board.
+
+On other platforms, ensure the :ref:`devicetree <dt-guide>` has an enabled
+:dtcompatible:`ams,ccs811` node.
+
+If you get an error on the line of code using :c:macro:`DEVICE_DT_GET_ONE`,
+your devicetree is likely to be missing this node.
+
 Building and Running on thingy52_nrf52832
 =========================================
 
@@ -37,7 +46,7 @@ After a soft reset, there is a 5-second startup period
 where readings are unstable, and then we can see steady
 reported measurements of about 400 ppm eC02 and 0 ppb eTVOC.
 
-.. code-block::console
+.. code-block:: console
 
    *** Booting Zephyr OS build zephyr-v2.1.0-310-g32a3e9907bab  ***
    device is 0x20001088, name is CCS811

--- a/samples/sensor/ccs811/src/main.c
+++ b/samples/sensor/ccs811/src/main.c
@@ -113,12 +113,14 @@ static void do_main(const struct device *dev)
 
 void main(void)
 {
-	const struct device *dev = device_get_binding(DT_LABEL(DT_INST(0, ams_ccs811)));
+	const struct device *dev = DEVICE_DT_GET_ONE(ams_ccs811);
 	struct ccs811_configver_type cfgver;
 	int rc;
 
-	if (!dev) {
-		printk("Failed to get device binding");
+	if (!device_is_ready(dev)) {
+		printf("Device %s is not ready; "
+		       "check its initialization function return value\n",
+		       dev->name);
 		return;
 	}
 

--- a/samples/sensor/hts221/README.rst
+++ b/samples/sensor/hts221/README.rst
@@ -22,14 +22,20 @@ References
 Building and Running
 ********************
 
- This project outputs sensor data to the console. It requires an HTS221
- sensor, which is present on the disco_l475_iot1 board.
+This project outputs sensor data to the console. It requires an HTS221 sensor,
+which is present on the ``disco_l475_iot1`` board. To build for that platform:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/sensor/hts221
    :board: disco_l475_iot1
    :goals: build
    :compact:
+
+On other platforms, ensure the :ref:`devicetree <dt-guide>` has an enabled
+:dtcompatible:`st,hts221` node.
+
+If you get an error on the line of code using :c:macro:`DEVICE_DT_GET_ONE`,
+your devicetree is likely to be missing this node.
 
 Sample Output
 =============

--- a/samples/sensor/hts221/src/main.c
+++ b/samples/sensor/hts221/src/main.c
@@ -48,10 +48,12 @@ static void hts221_handler(const struct device *dev,
 
 void main(void)
 {
-	const struct device *dev = device_get_binding("HTS221");
+	const struct device *dev = DEVICE_DT_GET_ONE(st_hts221);
 
-	if (dev == NULL) {
-		printf("Could not get HTS221 device\n");
+	if (!device_is_ready(dev)) {
+		printf("Device %s is not ready; "
+		       "check its initialization function return value\n",
+		       dev->name);
 		return;
 	}
 

--- a/samples/sensor/lps22hb/README.rst
+++ b/samples/sensor/lps22hb/README.rst
@@ -22,14 +22,20 @@ References
 Building and Running
 ********************
 
-This project outputs sensor data to the console. It requires an LPS22HB
-sensor, which is present on the disco_l475_iot1 board.
+This project outputs sensor data to the console. It requires an LPS22HB sensor,
+which is present on the ``disco_l475_iot1`` board. To build for that platform:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/sensor/lps22hb
    :board: disco_l475_iot1
    :goals: build
    :compact:
+
+On other platforms, ensure the :ref:`devicetree <dt-guide>` has an enabled
+:dtcompatible:`st,lps22hb-press` node.
+
+If you get an error on the line of code using :c:macro:`DEVICE_DT_GET_ONE`,
+your devicetree is likely to be missing this node.
 
 Sample Output
 =============

--- a/samples/sensor/lps22hb/src/main.c
+++ b/samples/sensor/lps22hb/src/main.c
@@ -43,10 +43,12 @@ static void process_sample(const struct device *dev)
 
 void main(void)
 {
-	const struct device *dev = device_get_binding(DT_LABEL(DT_INST(0, st_lps22hb_press)));
+	const struct device *dev = DEVICE_DT_GET_ONE(st_lps22hb_press);
 
-	if (dev == NULL) {
-		printf("Could not get LPS22HB device\n");
+	if (!device_is_ready(dev)) {
+		printf("Device %s is not ready; "
+		       "check its initialization function return value\n",
+		       dev->name);
 		return;
 	}
 

--- a/samples/sensor/mpu6050/README.rst
+++ b/samples/sensor/mpu6050/README.rst
@@ -23,8 +23,17 @@ control the sensor.
 Building and Running
 ********************
 
-After providing a devicetree overlay that specifies the sensor location,
-build this sample app using:
+This sample can be built as-is for any board with an Arduino-style I2C header
+configured in its :ref:`devicetree <dt-guide>`, as configured in the
+:zephyr_file:`samples/sensor/mpu6050/app.overlay` devicetree overlay file.
+
+(To build the sample on other platforms, use another devicetree overlay file.
+See :ref:`set-devicetree-overlays`.)
+
+Flash the binary to your board with a sensor connected to the I2C bus
+configured via devicetree.
+
+For example, to build and flash for the ``nrf52dk_nrf52832`` board:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/sensor/mpu6050

--- a/samples/sensor/mpu6050/app.overlay
+++ b/samples/sensor/mpu6050/app.overlay
@@ -1,10 +1,13 @@
 /*
- * Copyright (c) 2019 Nordic Semiconductor ASA
+ * Copyright (c) 2019, 2021 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&i2c0 {
+&arduino_i2c {
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+
 	mpu6050@68 {
 		compatible = "invensense,mpu6050";
 		reg = <0x68>;

--- a/samples/sensor/mpu6050/sample.yaml
+++ b/samples/sensor/mpu6050/sample.yaml
@@ -9,7 +9,7 @@ sample:
 tests:
   sample.sensor.mpu6050:
     build_only: true
-    platform_allow: nrf52dk_nrf52832
     tags: sensors
+    depends_on: i2c arduino_i2c
     integration_platforms:
       - nrf52dk_nrf52832

--- a/samples/sensor/mpu6050/src/main.c
+++ b/samples/sensor/mpu6050/src/main.c
@@ -86,11 +86,12 @@ static void handle_mpu6050_drdy(const struct device *dev,
 
 void main(void)
 {
-	const char *const label = DT_LABEL(DT_INST(0, invensense_mpu6050));
-	const struct device *mpu6050 = device_get_binding(label);
+	const struct device *mpu6050 = DEVICE_DT_GET_ONE(invensense_mpu6050);
 
-	if (!mpu6050) {
-		printf("Failed to find sensor %s\n", label);
+	if (!device_is_ready(mpu6050)) {
+		printf("Device %s is not ready; "
+		       "check its initialization function return value\n",
+		       mpu6050->name);
 		return;
 	}
 


### PR DESCRIPTION
Continued incremental progress to using DT-aware device getters throughout the samples.