### PR TITLE
ARC: MWDT: get rid of MWDT startup libs

### DIFF
--- a/arch/arc/CMakeLists.txt
+++ b/arch/arc/CMakeLists.txt
@@ -20,3 +20,7 @@ if(CONFIG_ISA_ARCV2)
 endif()
 
 add_subdirectory(core)
+
+if(COMPILER STREQUAL arcmwdt)
+  add_subdirectory(arcmwdt)
+endif()

--- a/arch/arc/arcmwdt/CMakeLists.txt
+++ b/arch/arc/arcmwdt/CMakeLists.txt
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_ARCMWDT_LIBC OR CONFIG_CPLUSPLUS)
+  zephyr_sources(arcmwdt-dtr-stubs.c)
+endif()

--- a/arch/arc/arcmwdt/arcmwdt-dtr-stubs.c
+++ b/arch/arc/arcmwdt/arcmwdt-dtr-stubs.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2021 Synopsys.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <toolchain.h>
+
+__weak void *__dso_handle;
+
+int __cxa_atexit(void (*destructor)(void *), void *objptr, void *dso)
+{
+	ARG_UNUSED(destructor);
+	ARG_UNUSED(objptr);
+	ARG_UNUSED(dso);
+	return 0;
+}
+
+int atexit(void (*function)(void))
+{
+	return 0;
+}

--- a/cmake/linker/arcmwdt/target.cmake
+++ b/cmake/linker/arcmwdt/target.cmake
@@ -119,12 +119,8 @@ macro(toolchain_ld_baremetal)
     -Hhostlib=
     -Hheap=0
     -Hnoivt
+    -Hnocrt
   )
-
-  # We only use CPP initialization code from crt
-  if(NOT CONFIG_CPLUSPLUS)
-    zephyr_ld_options(-Hnocrt)
-  endif()
 
   # There are two options:
   # - We have full MWDT libc support and we link MWDT libc - this is default

--- a/include/arch/arc/v2/linker.ld
+++ b/include/arch/arc/v2/linker.ld
@@ -88,13 +88,6 @@ SECTIONS {
 #include <linker/kobject-text.ld>
 	} GROUP_LINK_IN(ROMABLE_REGION)
 
-#if defined(CONFIG_CPLUSPLUS) && !defined(CONFIG_CPP_STATIC_INIT_GNU) && defined(__MWDT_LINKER_CMD__)
-	/* .init section with code iterating over static objects constructors */
-	SECTION_PROLOGUE(.init,,ALIGN(4)) {
-		KEEP(*(.init*))
-	} GROUP_LINK_IN(ROMABLE_REGION)
-#endif /* CONFIG_CPLUSPLUS && !CONFIG_CPP_STATIC_INIT_GNU && __MWDT_LINKER_CMD__ */
-
 	__text_region_end = .;
 	__rodata_region_start = .;
 

--- a/lib/libc/arcmwdt/libc-hooks.c
+++ b/lib/libc/arcmwdt/libc-hooks.c
@@ -76,3 +76,9 @@ int *___errno(void)
 {
 	return z_errno();
 }
+
+__weak void _exit(int status)
+{
+	while (1) {
+	}
+}

--- a/subsys/cpp/cpp_init.c
+++ b/subsys/cpp/cpp_init.c
@@ -20,11 +20,11 @@ void z_cpp_init_static(void)
 #else
 
 #ifdef __CCAC__
-void _init(void);
+void __do_global_ctors_aux(void);
 
 void z_cpp_init_static(void)
 {
-	_init();
+	__do_global_ctors_aux();
 }
 #endif /* __CCAC__ */
 


### PR DESCRIPTION
`__cxa_atexit` implementation provided by MWDT startup code do memory allocations with `malloc` which is an issue as we don't support it right now.

As we don't support calling static object destructors in Zephyr let's implement our own  __cxa_atexit as a stub and get rid of MWDT startup libs entirely.