### PR TITLE
tests: common: add test for ffs function

### DIFF
--- a/tests/kernel/common/src/bitarray.c
+++ b/tests/kernel/common/src/bitarray.c
@@ -616,5 +616,56 @@ void test_bitarray_region_set_clear(void)
 }
 
 /**
+ * @brief Test find MSB and LSB operations
+ *
+ * @details Verify the functions that find out the most significiant
+ * bit and least significiant bit work as expected.
+ *
+ * @see find_msb_set(), find_lsb_set()
+ */
+void test_ffs(void)
+{
+	uint32_t value;
+	unsigned int bit;
+
+	/* boundary test, input is min */
+	value = 0x0;
+	zassert_equal(find_msb_set(value), 0, "MSB is not matched");
+	zassert_equal(find_lsb_set(value), 0, "LSB is not matched");
+
+	/* boundary test, input is min + 1 */
+	value = 0x00000001;
+	zassert_equal(find_msb_set(value), 1, "MSB is not matched");
+	zassert_equal(find_lsb_set(value), 1, "LSB is not matched");
+
+	/* average value test */
+	value = 0x80000000;
+	zassert_equal(find_msb_set(value), 32, "MSB is not matched");
+	zassert_equal(find_lsb_set(value), 32, "LSB is not matched");
+
+	/* mediate value test */
+	value = 0x000FF000;
+	zassert_equal(find_msb_set(value), 20, "MSB is not matched");
+	zassert_equal(find_lsb_set(value), 13, "LSB is not matched");
+
+	/* boundary test, input is max */
+	value = 0xffffffff;
+	zassert_equal(find_msb_set(value), 32, "MSB is not matched");
+	zassert_equal(find_lsb_set(value), 1, "LSB is not matched");
+
+	/* boundary test, input is max - 1 */
+	value = 0xfffffffe;
+	zassert_equal(find_msb_set(value), 32, "MSB is not matched");
+	zassert_equal(find_lsb_set(value), 2, "LSB is not matched");
+
+	/* equivalent class testing, each bit means a class */
+	for (bit = 0; bit < 32 ; bit++) {
+		value = 1UL << bit;
+		zassert_equal(find_msb_set(value), bit + 1, "MSB is not matched");
+		zassert_equal(find_lsb_set(value), bit + 1, "LSB is not matched");
+	}
+}
+
+/**
  * @}
  */

--- a/tests/kernel/common/src/main.c
+++ b/tests/kernel/common/src/main.c
@@ -49,6 +49,7 @@ extern void test_bitarray_set_clear(void);
 extern void test_bitarray_alloc_free(void);
 extern void test_bitarray_region_set_clear(void);
 extern void test_nop(void);
+extern void test_ffs(void);
 
 /**
  * @defgroup kernel_common_tests Common Tests
@@ -162,7 +163,8 @@ void test_main(void)
 			 ztest_user_unit_test(test_errno),
 			 ztest_unit_test(test_ms_time_duration),
 			 ztest_unit_test(test_bounds_check_mitigation),
-			 ztest_unit_test(test_nop)
+			 ztest_unit_test(test_nop),
+			 ztest_unit_test(test_ffs)
 			 );
 
 	ztest_run_test_suite(common);


### PR DESCRIPTION
Add a testcase for find_msb_set() and find_lsb_set() functions.

We have no dedicating test for these two functions, so we simply add this to test it.

Signed-off-by: Enjia Mai <enjiax.mai@intel.com>