### PR TITLE
dtlib: minor fixes

### DIFF
--- a/scripts/dts/python-devicetree/src/devicetree/dtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/dtlib.py
@@ -1939,11 +1939,6 @@ _byte_re = re.compile(r"[0-9a-fA-F]{2}")
 # '\c', where c might be a single character or an octal/hex escape.
 _unescape_re = re.compile(br'\\([0-7]{1,3}|x[0-9A-Fa-f]{1,2}|.)')
 
-# #line directive (this is the regex the C tools use)
-_line_re = re.compile(
-    r'^#(?:line)?[ \t]+([0-9]+)[ \t]+"((?:[^\\"]|\\.)*)"(?:[ \t]+[0-9]+)?',
-    re.MULTILINE)
-
 def _init_tokens():
     # Builds a (<token 1>)|(<token 2>)|... regex and returns it. The
     # way this is constructed makes the token's value as an int appear

--- a/scripts/dts/python-devicetree/tests/test_dtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_dtlib.py
@@ -100,6 +100,16 @@ def temporary_chdir(dirname):
     finally:
         os.chdir(here)
 
+def test_invalid_nodenames():
+    # Regression test that verifies node names are not matched against
+    # the more permissive set of rules used for property names.
+
+    verify_error_endswith("""
+/dts-v1/;
+/ { node? {}; };
+""",
+                          "/node?: bad character '?' in node name")
+
 def test_cell_parsing():
     '''Miscellaneous properties containing zero or more cells'''
 
@@ -2107,15 +2117,12 @@ def test_reprs():
 def test_names():
     '''Tests for node/property names.'''
 
-    # The C tools disallow '@' in property names, but otherwise accept the same
-    # characters in node and property names. Emulate that instead of the DT spec
-    # (v0.2), which gives different characters for nodes and properties.
     verify_parse(r"""
 /dts-v1/;
 
 / {
 	// A leading \ is accepted but ignored in node/propert names
-	\aA0,._+*#?- = &_, &{/aA0,._+*#?@-};
+	\aA0,._+*#?- = &_, &{/aA0,._+@-};
 
 	// Names that overlap with operators and integer literals
 
@@ -2126,7 +2133,8 @@ def test_names():
 	0 = [ 04 ];
 	0x123 = [ 05 ];
 
-	_: \aA0,._+*#?@- {
+	// Node names are more restrictive than property names.
+	_: \aA0,._+@- {
 	};
 
 	0 {
@@ -2137,14 +2145,14 @@ def test_names():
 /dts-v1/;
 
 / {
-	aA0,._+*#?- = &_, &{/aA0,._+*#?@-};
+	aA0,._+*#?- = &_, &{/aA0,._+@-};
 	+ = [ 00 ];
 	* = [ 02 ];
 	- = [ 01 ];
 	? = [ 03 ];
 	0 = [ 04 ];
 	0x123 = [ 05 ];
-	_: aA0,._+*#?@- {
+	_: aA0,._+@- {
 	};
 	0 {
 	};


### PR DESCRIPTION
- remove an unused variable
- stop allowing invalid characters in node names