### PR TITLE
soc: esp32: Fix placement for system heap

### DIFF
--- a/soc/xtensa/esp32/linker.ld
+++ b/soc/xtensa/esp32/linker.ld
@@ -460,6 +460,9 @@ __shell_root_cmds_end = __esp_shell_root_cmds_end;
     . = ALIGN (4);
     _btdm_bss_end = ABSOLUTE(.);
 
+    /* Buffer for system heap should be placed in dram0_0_seg */
+    *libkernel.a:mempool.*(.noinit.kheap_buf__system_heap .noinit.*.kheap_buf__system_heap)
+
     *(.dynsbss)
     *(.sbss)
     *(.sbss.*)


### PR DESCRIPTION
System heap buffer was moved from dram0_0_seg to dram0_1_seg after https://github.com/zephyrproject-rtos/zephyr/commit/d92d1f162af3ba24963f1026fc0a304f1a44d1f3.
This PR fixes system heap buffer placement.