### PR TITLE
soc/arm: stm32wb: Default C2 power mode to SHUTDOWN

### DIFF
--- a/soc/arm/st_stm32/stm32wb/soc.c
+++ b/soc/arm/st_stm32/stm32wb/soc.c
@@ -45,6 +45,10 @@ static int stm32wb_init(const struct device *arg)
 	/* At reset, system core clock is set to 4 MHz from MSI */
 	SystemCoreClock = 4000000;
 
+	/* Set C2 Power Mode to shutdown */
+	/* It will be udated by C2 when required */
+	LL_C2_PWR_SetPowerMode(LL_PWR_MODE_SHUTDOWN);
+
 	return 0;
 }
 


### PR DESCRIPTION
Low power modes entry on stm32wb depends on requests coming from both
cores, with no consideration of the fact that C2 is booted  or not.

By default, set C2 power mode to shutdown at C1 start up.
If required, it will be updated by C2.
In case C2 is not started, this will allow C1 to enter any power mode
with no dependency on C2.

Fixes #38173

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>