### PR TITLE
dt-bindings: gic: Fix conflicting flags

### DIFF
--- a/include/dt-bindings/interrupt-controller/arm-gic.h
+++ b/include/dt-bindings/interrupt-controller/arm-gic.h
@@ -6,6 +6,8 @@
 #ifndef __DT_BINDING_ARM_GIC_H
 #define __DT_BINDING_ARM_GIC_H
 
+#include <sys/util_macro.h>
+
 /* CPU Interrupt numbers */
 #define	GIC_INT_VIRT_MAINT		25
 #define	GIC_INT_HYP_TIMER		26
@@ -15,8 +17,9 @@
 #define	GIC_INT_NS_PHYS_TIMER	30
 #define	GIC_INT_LEGACY_IRQ		31
 
-#define	IRQ_TYPE_LEVEL		0x0
-#define	IRQ_TYPE_EDGE		0x1
+/* BIT(0) reserved for IRQ_ZERO_LATENCY */
+#define	IRQ_TYPE_LEVEL		BIT(1)
+#define	IRQ_TYPE_EDGE		BIT(2)
 
 #define	GIC_SPI			0x0
 #define	GIC_PPI			0x1


### PR DESCRIPTION
Fix conflicting flags between IRQ_TYPE_EDGE and IRQ_ZERO_LATENCY.

Closes: #38168 