### PR TITLE
x86: x86-64: add arch_float_en-/dis-able() functions

### DIFF
--- a/arch/x86/core/intel64/thread.c
+++ b/arch/x86/core/intel64/thread.c
@@ -61,3 +61,15 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	thread->arch.flags = X86_THREAD_FLAG_ALL;
 	thread->switch_handle = thread;
 }
+
+int arch_float_disable(struct k_thread *thread)
+{
+	/* x86-64 always has FP/SSE enabled so cannot be disabled */
+	return -ENOTSUP;
+}
+
+int arch_float_enable(struct k_thread *thread, unsigned int options)
+{
+	/* x86-64 always has FP/SSE enabled so nothing to do here */
+	return 0;
+}

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -214,7 +214,15 @@ extern void k_thread_foreach_unlocked(
 /* x86 Bitmask definitions for threads user options */
 
 #if defined(CONFIG_FPU_SHARING) && defined(CONFIG_X86_SSE)
-/* thread uses SSEx (and also FP) registers */
+/**
+ * @brief FP and SSE registers are managed by context switch on x86
+ *
+ * @details
+ * This option indicates that the thread uses the x86 CPU's floating point
+ * and SSE registers. This instructs the kernel to take additional steps to
+ * save and restore the contents of these registers when scheduling
+ * the thread. No effect if @kconfig{CONFIG_X86_SSE} is not enabled.
+ */
 #define K_SSE_REGS (BIT(7))
 #endif
 #endif

--- a/kernel/include/kernel_arch_interface.h
+++ b/kernel/include/kernel_arch_interface.h
@@ -181,8 +181,9 @@ void arch_switch_to_main_thread(struct k_thread *main_thread, char *stack_ptr,
  * @note For ARM architecture, disabling floating point preservation may only
  * be requested for the current thread and cannot be requested in ISRs.
  *
- * @retval 0       On success.
- * @retval -EINVAL If the floating point disabling could not be performed.
+ * @retval 0        On success.
+ * @retval -EINVAL  If the floating point disabling could not be performed.
+ * @retval -ENOTSUP If the operation is not supported
  */
 int arch_float_disable(struct k_thread *thread);
 
@@ -192,7 +193,7 @@ int arch_float_disable(struct k_thread *thread);
  * The function is used to enable the preservation of floating
  * point context information for a particular thread.
  * This API depends on each architecture implimentation. If the architecture
- * does not support enableing, this API will always be failed.
+ * does not support enabling, this API will always be failed.
  *
  * The @a options parameter indicates which floating point register sets will
  * be used by the specified thread. Currently it is used by x86 only.
@@ -200,8 +201,9 @@ int arch_float_disable(struct k_thread *thread);
  * @param thread  ID of thread.
  * @param options architecture dependent options
  *
- * @retval 0       On success.
- * @retval -EINVAL If the floating point enabling could not be performed.
+ * @retval 0        On success.
+ * @retval -EINVAL  If the floating point enabling could not be performed.
+ * @retval -ENOTSUP If the operation is not supported
  */
 int arch_float_enable(struct k_thread *thread, unsigned int options);
 #endif /* CONFIG_FPU && CONFIG_FPU_SHARING */


### PR DESCRIPTION
This adds arch_float_enable() and arch_float_disable() to x86-64.
As x86-64 always has FP/SSE enabled, these operations are basically
no-ops. These are added just for the completeness of arch interface.

Fixes #38022

Also add doc to `K_SSE_REGS` thread option, and document `-ENOTSUP` for `arch_float_enable()` and `arch_float_disable()` APIs.