### PR TITLE
shell: Fix builds for platforms without uart

### DIFF
--- a/subsys/shell/Kconfig.backends
+++ b/subsys/shell/Kconfig.backends
@@ -11,9 +11,13 @@ menuconfig SHELL_BACKENDS
 
 if SHELL_BACKENDS
 
+# Workaround for not being able to have commas in macro arguments
+DT_CHOSEN_Z_SHELL_UART := zephyr,shell-uart
+
 config SHELL_BACKEND_SERIAL
 	bool "Enable serial backend"
-	default y
+	default "$(dt_chosen_enabled,$(DT_CHOSEN_Z_SHELL_UART))" if HAS_DTS
+	default y if !HAS_DTS
 	select SERIAL
 	select RING_BUFFER
 	help


### PR DESCRIPTION
We get build issues due to the removal of the Kconfig symbol
CONFIG_UART_SHELL_ON_DEV_NAME on platforms that didn't have a uart
set as we'd get a default value for those platforms.  Update the
Kconfig logic to only enable SHELL_BACKEND_SERIAL if we have
zephyr,shell-uart specified in the devicetree to address the issue.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>