### PR TITLE
dts: bindings: add XIP node for nordic devices

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -2771,24 +2771,26 @@ function(dt_num_regs var)
 endfunction()
 
 # Usage:
-#   dt_reg_addr(<var> PATH <path> [INDEX <idx>])
+#   dt_reg_addr(<var> PATH <path> [INDEX <idx>] [NAME <name>])
 #
-# Get the base address of the register block at index <idx>.
-# If <idx> is omitted, then the value at index 0 will be returned.
+# Get the base address of the register block at index <idx>, or with
+# name <name>. If <idx> and <name> are both omitted, the value at
+# index 0 will be returned. Do not give both <idx> and <name>.
 #
 # The value will be returned in the <var> parameter.
 #
 # Results can be:
 # - The base address of the register block
 # - <var> will be undefined if node does not exists or does not have a register
-#   block at the requested index.
+#   block at the requested index or with the requested name
 #
 # <var>          : Return variable where the address value will be stored
 # PATH <path>    : Node path
-# INDEX <idx>    : Index number
+# INDEX <idx>    : Register block index number
+# NAME <name>    : Register block name
 function(dt_reg_addr var)
   set(req_single_args "PATH")
-  set(single_args "INDEX")
+  set(single_args "INDEX;NAME")
   cmake_parse_arguments(DT_REG "" "${req_single_args};${single_args}" "" ${ARGN})
 
   if(${ARGV0} IN_LIST req_single_args)
@@ -2803,8 +2805,16 @@ function(dt_reg_addr var)
     endif()
   endforeach()
 
-  if(NOT DEFINED DT_REG_INDEX)
+  if(DEFINED DT_REG_INDEX AND DEFINED DT_REG_NAME)
+    message(FATAL_ERROR "dt_reg_addr(${ARGV0} ...) given both INDEX and NAME")
+  elseif(NOT DEFINED DT_REG_INDEX AND NOT DEFINED DT_REG_NAME)
     set(DT_REG_INDEX 0)
+  elseif(DEFINED DT_REG_NAME)
+    dt_reg_index_private(DT_REG_INDEX "${DT_REG_PATH}" "${DT_REG_NAME}")
+    if(DT_REG_INDEX EQUAL "-1")
+      set(${var} PARENT_SCOPE)
+      return()
+    endif()
   endif()
 
   get_target_property(${var}_list devicetree_target "DT_REG|${DT_REG_PATH}|ADDR")
@@ -2819,19 +2829,21 @@ function(dt_reg_addr var)
 endfunction()
 
 # Usage:
-#   dt_reg_size(<var> PATH <path> [INDEX <idx>])
+#   dt_reg_size(<var> PATH <path> [INDEX <idx>] [NAME <name>])
 #
-# Get the size of the register block at index <idx>.
-# If INDEX is omitted, then the value at index 0 will be returned.
+# Get the size of the register block at index <idx>, or with
+# name <name>. If <idx> and <name> are both omitted, the value at
+# index 0 will be returned. Do not give both <idx> and <name>.
 #
 # The value will be returned in the <value> parameter.
 #
 # <var>          : Return variable where the size value will be stored
 # PATH <path>    : Node path
-# INDEX <idx>    : Index number
+# INDEX <idx>    : Register block index number
+# NAME <name>    : Register block name
 function(dt_reg_size var)
   set(req_single_args "PATH")
-  set(single_args "INDEX")
+  set(single_args "INDEX;NAME")
   cmake_parse_arguments(DT_REG "" "${req_single_args};${single_args}" "" ${ARGN})
 
   if(${ARGV0} IN_LIST req_single_args)
@@ -2846,8 +2858,16 @@ function(dt_reg_size var)
     endif()
   endforeach()
 
-  if(NOT DEFINED DT_REG_INDEX)
+  if(DEFINED DT_REG_INDEX AND DEFINED DT_REG_NAME)
+    message(FATAL_ERROR "dt_reg_size(${ARGV0} ...) given both INDEX and NAME")
+  elseif(NOT DEFINED DT_REG_INDEX AND NOT DEFINED DT_REG_NAME)
     set(DT_REG_INDEX 0)
+  elseif(DEFINED DT_REG_NAME)
+    dt_reg_index_private(DT_REG_INDEX "${DT_REG_PATH}" "${DT_REG_NAME}")
+    if(DT_REG_INDEX EQUAL "-1")
+      set(${var} PARENT_SCOPE)
+      return()
+    endif()
   endif()
 
   get_target_property(${var}_list devicetree_target "DT_REG|${DT_REG_PATH}|SIZE")
@@ -2859,6 +2879,17 @@ function(dt_reg_size var)
   endif()
 
   set(${var} ${${var}} PARENT_SCOPE)
+endfunction()
+
+# Internal helper for dt_reg_addr/dt_reg_size; not meant to be used directly
+function(dt_reg_index_private var path name)
+  dt_prop(reg_names PATH "${path}" PROPERTY "reg-names")
+  if(NOT DEFINED reg_names)
+    set(index "-1")
+  else()
+    list(FIND reg_names "${name}" index)
+  endif()
+  set(${var} "${index}" PARENT_SCOPE)
 endfunction()
 
 # Usage:

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -413,7 +413,8 @@
 			compatible = "nordic,nrf-qspi";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x40029000 0x1000>;
+			reg = <0x40029000 0x1000>, <0x12000000 0x8000000>;
+			reg-names = "qspi", "qspi_mm";
 			interrupts = <41 NRF_DEFAULT_IRQ_PRIORITY>;
 			status = "disabled";
 			label = "QSPI";

--- a/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
@@ -382,7 +382,8 @@ qspi: qspi@2b000 {
 	compatible = "nordic,nrf-qspi";
 	#address-cells = <1>;
 	#size-cells = <0>;
-	reg = <0x2b000 0x1000>;
+	reg = <0x2b000 0x1000>, <0x10000000 0x10000000>;
+	reg-names = "qspi", "qspi_mm";
 	interrupts = <43 NRF_DEFAULT_IRQ_PRIORITY>;
 	status = "disabled";
 	label = "QSPI";

--- a/dts/bindings/flash_controller/nordic,nrf-qspi.yaml
+++ b/dts/bindings/flash_controller/nordic,nrf-qspi.yaml
@@ -4,6 +4,21 @@
 description: |
     Properties defining the interface for the Nordic QSPI peripheral.
 
+    The reg property describes two register blocks: one for the memory
+    corresponding to the QSPI peripheral registers, and another for
+    the memory mapped XIP area:
+
+        qspi: qspi@2b000 {
+                compatible = "nordic,nrf-qspi";
+                reg = <0x2b000 0x1000>, <0x10000000 0x10000000>;
+                reg-names = "qspi", "qspi_mm";
+                ...
+        };
+
+    Above, the register block with base address 0x2b000 and name
+    "qspi" are the QSPI peripheral registers. The register block with
+    base address 0x10000000 and name "qspi_mm" is the XIP area.
+
 compatible: "nordic,nrf-qspi"
 
 include: flash-controller.yaml


### PR DESCRIPTION
There is currently no information available about the XIP
addresses for the nRF52840 and nRF5340.

Add a new node type and add the nodes to the qspi bus.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>