### PR TITLE
DF: Fix error in remove CTE from periodic advertising chain

### DIFF
--- a/tests/bluetooth/df/connectionless_cte_chains/src/common.c
+++ b/tests/bluetooth/df/connectionless_cte_chains/src/common.c
@@ -141,8 +141,8 @@ void common_create_per_adv_chain(struct ll_adv_set *adv_set, uint8_t pdu_count)
 	pdu = lll_adv_sync_data_peek(lll_sync, NULL);
 	ull_adv_sync_pdu_init(pdu, 0);
 
-	err = ull_adv_sync_pdu_alloc(adv_set, 0, 0, NULL, &pdu_prev, &pdu, &extra_data_prev,
-				     &extra_data, &pdu_idx);
+	err = ull_adv_sync_pdu_alloc(adv_set, ULL_ADV_PDU_EXTRA_DATA_ALLOC_IF_EXIST, &pdu_prev,
+				     &pdu, &extra_data_prev, &extra_data, &pdu_idx);
 	zassert_equal(err, 0, "Unexpected error while PDU allocation, err: %d", err);
 
 	if (extra_data) {


### PR DESCRIPTION
cte_info_clear function is responsible for remove of CTE from
periodic advertising PDUs, including remove from optional chained
PDUs. The function uses subortinate function rem_cte_info_from_per_-
adv_chain to remove CTE from chained PDUs.

The rem_cte_info_from_per_adv_chain had pdu_prev and pdu as arguments.
After return from the function the pdu_prev should point to last
PDU from previously used periodic advertising data and pdu should
point to last new periodic advertising data.

The rem_cte_info_from_per_adv_chain function removes CTEInfo from
all but last one PDU. Last PDU must have removed AuxPtr field also.
Remove of CTEInfo and AuxPtr from last PDU is done explicitly in
the cte_info_clear function.

Unfortunately rem_cte_info_from_per_adv_chain had wrong type of
parameters for pdu_prev and pdu. These parameters were pointers
instead od double pointers.
That caused cte_info_clear function to remove CTEInfo and AuxPtr
from first PDU in a chain, which is AUX_SYNC_IND.

Changed parameters pdu_prev and pdu in the rem_cte_info_from_per_adv_-
chain to be double pointers.

Besides that:
- Fixes compilation in unit tests for DF and periodic advertising chains.
- Adds small corrections in comments.