### PR TITLE
cmake: extensions: fix copy/paste issues in DT error messages

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -2734,12 +2734,12 @@ function(dt_reg_size var)
   cmake_parse_arguments(DT_REG "" "${req_single_args};${single_args}" "" ${ARGN})
 
   if(${ARGV0} IN_LIST req_single_args)
-    message(FATAL_ERROR "dt_reg_addr(${ARGV0} ...) missing return parameter.")
+    message(FATAL_ERROR "dt_reg_size(${ARGV0} ...) missing return parameter.")
   endif()
 
   foreach(arg ${req_single_args})
     if(NOT DEFINED DT_REG_${arg})
-      message(FATAL_ERROR "dt_reg_addr(${ARGV0} ...) "
+      message(FATAL_ERROR "dt_reg_size(${ARGV0} ...) "
                           "missing required argument: ${arg}"
       )
     endif()


### PR DESCRIPTION
These were copied from dt_reg_addr and not changed.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>