### PR TITLE
Bluetooth: Controller: Fix null pointer dereferencing in Extended Scanning and Periodic Synchronization

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -1341,7 +1341,7 @@ isr_rx_do_close:
 
 		node_rx->hdr.type = NODE_RX_TYPE_EXT_AUX_RELEASE;
 
-		node_rx->hdr.rx_ftr.param = lll;
+		node_rx->hdr.rx_ftr.param = lll->lll_aux;
 
 		ull_rx_put(node_rx->hdr.link, node_rx);
 		ull_rx_sched();

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -695,7 +695,16 @@ isr_rx_do_close:
 
 			node_rx->hdr.type = NODE_RX_TYPE_EXT_AUX_RELEASE;
 
-			node_rx->hdr.rx_ftr.param = lll->lll_aux;
+			/* Use LLL scan context pointer which will be resolved
+			 * to LLL aux context in the `ull_scan_aux_release`
+			 * function in ULL execution context.
+			 * As ULL execution context is the one assigning the
+			 * `lll->lll_aux`, if it has not been assigned then
+			 * `ull_scan_aux_release` will not dereference it, but
+			 * under race, if ULL execution did assign one, it will
+			 * free it.
+			 */
+			node_rx->hdr.rx_ftr.param = lll;
 
 			ull_rx_put(node_rx->hdr.link, node_rx);
 			ull_rx_sched();

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -566,6 +566,15 @@ static void isr_rx_aux_chain(void *param)
 
 	lll = param;
 	aux_lll = lll->lll_aux;
+	if (!aux_lll) {
+		/* auxiliary context not assigned (yet) in ULL execution
+		 * context, drop current reception and abort further chain PDU
+		 * receptions, if any.
+		 */
+		lll_isr_status_reset();
+
+		goto isr_rx_aux_chain_done;
+	}
 
 	err = isr_rx(lll, NODE_RX_TYPE_EXT_AUX_REPORT, &crc_ok);
 
@@ -573,6 +582,7 @@ static void isr_rx_aux_chain(void *param)
 		return;
 	}
 
+isr_rx_aux_chain_done:
 	isr_rx_done_cleanup(lll, 1U);
 }
 


### PR DESCRIPTION
Fix null pointer dereferencing in Extended Scanning when
there are more peer devices than the allocated auxiliary
contexts.

When LLL scheduling does not get an auxiliary context
assigned in the ULL execution context, then further chain
reception is aborted, access to `lll->lll_aux` which is
NULL causes null pointer dereferencing in
`ull_scan_aux_release`.

Fix null pointer deferencing in Periodic Synchronization
when ULL execution context could not assign an auxiliary
context when in LLL scheduling to receive chain PDUs.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>

This PR is rebased over #38165 