### PR TITLE
Bluetooth: ISO: Add sent callback

### DIFF
--- a/include/bluetooth/iso.h
+++ b/include/bluetooth/iso.h
@@ -432,6 +432,15 @@ struct bt_iso_chan_ops {
 	 */
 	void (*recv)(struct bt_iso_chan *chan, const struct bt_iso_recv_info *info,
 			struct net_buf *buf);
+
+	/** @brief Channel sent callback
+	 *
+	 *  If this callback is provided it will be called whenever a SDU has
+	 *  been completely sent.
+	 *
+	 *  @param chan The channel which has sent data.
+	 */
+	void (*sent)(struct bt_iso_chan *chan);
 };
 
 /** @brief ISO Server structure. */


### PR DESCRIPTION
Add a sent callback to bt_iso_chan_ops so that the application
can be notified when an SDU has been sent. This can help the
application decide whether to queue up multiple, or only
have a single ISO PDU enqueue for reduced latency.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>