### PR TITLE
Bluetooth: Controller: Properly terminate per adv HCI on failed rx

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -5545,6 +5545,21 @@ static void le_per_adv_sync_report(struct pdu_data *pdu_data,
 		return;
 	}
 
+	if (node_rx->hdr.rx_ftr.aux_failed) {
+		sep = meta_evt(buf,
+			       BT_HCI_EVT_LE_PER_ADVERTISING_REPORT,
+			       sizeof(*sep));
+
+		sep->handle = sys_cpu_to_le16(node_rx->hdr.handle);
+		sep->tx_power = BT_HCI_LE_ADV_TX_POWER_NO_PREF;
+		sep->rssi = BT_HCI_LE_RSSI_NOT_AVAILABLE;
+		sep->cte_type = BT_HCI_LE_NO_CTE;
+		sep->data_status = BT_HCI_LE_ADV_EVT_TYPE_DATA_STATUS_INCOMPLETE;
+		sep->length = 0;
+
+		return;
+	}
+
 	/* The Link Layer currently returns RSSI as an absolute value */
 	rssi = -(node_rx->hdr.rx_ftr.rssi);
 

--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -283,6 +283,7 @@ struct node_rx_ftr {
 #if defined(CONFIG_BT_CTLR_ADV_EXT) && defined(CONFIG_BT_OBSERVER)
 	uint8_t  aux_lll_sched:1;
 	uint8_t  aux_w4next:1;
+	uint8_t  aux_failed:1;
 
 	uint8_t  phy_flags:1;
 	uint8_t  scan_req:1;


### PR DESCRIPTION
If one of AUX_CHAIN_IND is not received properly we need to send an
extra report over HCI to indicate that data are incomplete.

Signed-off-by: Andrzej Kaczmarek <andrzej.kaczmarek@codecoup.pl>