### PR TITLE
Bluetooth: ISO: Pointer check in bt_iso_connected was incorrect

### DIFF
--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -311,7 +311,7 @@ void bt_iso_connected(struct bt_conn *iso)
 {
 	struct bt_iso_chan *chan;
 
-	if (iso || iso->type != BT_CONN_TYPE_ISO) {
+	if (iso == NULL || iso->type != BT_CONN_TYPE_ISO) {
 		BT_DBG("Invalid parameters: iso %p iso->type %u", iso,
 		       iso ? iso->type : 0);
 		return;


### PR DESCRIPTION
Instead of checking `if (iso == NULL)` it simply checked
`if (iso)` which is the opposite of what it should have done.

This completely blocks iso from connecting channels.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

fixes #38197