### PR TITLE
Telink b91 OpenThread twister support

### DIFF
--- a/boards/riscv/tlsr9518adk80d/tlsr9518adk80d.yaml
+++ b/boards/riscv/tlsr9518adk80d/tlsr9518adk80d.yaml
@@ -9,3 +9,8 @@ ram: 128
 flash: 1024
 supported:
   - gpio
+  - i2c
+  - ieee802154
+  - pwm
+  - spi
+  - netif:openthread

--- a/samples/net/openthread/coprocessor/boards/tlsr9518adk80d.overlay
+++ b/samples/net/openthread/coprocessor/boards/tlsr9518adk80d.overlay
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2021 Telink Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,ot-uart = &uart0;
+		zephyr,console = &uart1;
+	};
+};
+
+&uart0 {
+	status = "okay";
+	current-speed = <57600>;
+	pinctrl-0 = <&uart0_tx_pb2 &uart0_rx_pb3>;
+};
+
+&uart1 {
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&uart1_tx_pc6 &uart1_rx_pc7>;
+};

--- a/samples/net/openthread/coprocessor/sample.yaml
+++ b/samples/net/openthread/coprocessor/sample.yaml
@@ -9,7 +9,7 @@ sample:
 tests:
   sample.net.openthread.coprocessor:
     build_only: true
-    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833
+    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 tlsr9518adk80d
     tags: ci_build
   sample.net.openthread.coprocessor.usb:
     build_only: true
@@ -19,6 +19,6 @@ tests:
                 DTC_OVERLAY_FILE="usb.overlay"
   samples.openthread.coprocessor.rcp:
     build_only: true
-    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833
+    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 tlsr9518adk80d
     tags: ci_build
     extra_args: OVERLAY_CONFIG=overlay-rcp.conf

--- a/samples/net/sockets/echo_client/sample.yaml
+++ b/samples/net/sockets/echo_client/sample.yaml
@@ -48,6 +48,15 @@ tests:
     tags: net openthread
     platform_allow: nrf52840dk_nrf52840
     filter: TOOLCHAIN_HAS_NEWLIB == 1
+  sample.net.sockets.echo_client.b91_802154:
+    extra_args: OVERLAY_CONFIG="overlay-802154.conf"
+    platform_allow: tlsr9518adk80d
+  sample.net.sockets.echo_client.b91_openthread:
+    extra_args: OVERLAY_CONFIG="overlay-ot.conf"
+    slow: true
+    tags: net openthread
+    platform_allow: tlsr9518adk80d
+    filter: TOOLCHAIN_HAS_NEWLIB == 1
   sample.net.sockets.echo_client.kw41z_openthread:
     extra_args: OVERLAY_CONFIG="overlay-ot.conf"
     slow: true

--- a/samples/net/sockets/echo_server/sample.yaml
+++ b/samples/net/sockets/echo_server/sample.yaml
@@ -42,6 +42,9 @@ tests:
   sample.net.sockets.echo_server.nrf_802154:
     extra_args: OVERLAY_CONFIG="overlay-802154.conf"
     platform_allow: nrf52840dk_nrf52840
+  sample.net.sockets.echo_server.b91_802154:
+    extra_args: OVERLAY_CONFIG="overlay-802154.conf"
+    platform_allow: tlsr9518adk80d
   sample.net.sockets.echo_server.usbnet:
     depends_on: usb_device
     harness: net
@@ -59,6 +62,12 @@ tests:
     slow: true
     tags: net openthread
     platform_allow: nrf52840dk_nrf52840
+    filter: TOOLCHAIN_HAS_NEWLIB == 1
+  sample.net.sockets.echo_server.b91_openthread:
+    extra_args: OVERLAY_CONFIG="overlay-ot.conf"
+    slow: true
+    tags: net openthread
+    platform_allow: tlsr9518adk80d
     filter: TOOLCHAIN_HAS_NEWLIB == 1
   sample.net.sockets.echo_server.kw41z_openthread:
     extra_args: OVERLAY_CONFIG="overlay-ot.conf"


### PR DESCRIPTION
- Fixed build fail of OpenThread Coprocessor samples for tlsr9518adk80d board.
- Included tlsr9518adk80d board to CI checking. 