### PR TITLE
shell: uart: Add waiting on DTR signal before sending data

### DIFF
--- a/subsys/shell/Kconfig.backends
+++ b/subsys/shell/Kconfig.backends
@@ -71,6 +71,13 @@ config SHELL_BACKEND_SERIAL_RX_POLL_PERIOD
 	help
 	  Determines how often UART is polled for RX byte.
 
+config SHELL_BACKEND_SERIAL_CHECK_DTR
+	bool "Check DTR signal before TX"
+	default y if USB_UART_CONSOLE
+	depends on UART_LINE_CTRL
+	help
+	  Check DTR signal before TX.
+
 module = SHELL_BACKEND_SERIAL
 default-timeout = 100
 source "subsys/shell/Kconfig.template.shell_log_queue_timeout"


### PR DESCRIPTION
Problem:
In some cases, as described in: https://github.com/zephyrproject-rtos/zephyr/issues/36948
shell backend sends characters to output before serial device
is ready for it. It results in observing additional characters
inserted on the shell input after device boot.

Solution:
Added waiting on DTR signal before sending anything to the output.

Fixes: #36948

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>