### PR TITLE
doc: Document the switch from Slack to Discord

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ and the documentation's `Getting Started Guide`_ to start developing.
 Community Support
 *****************
 
-Community support is provided via mailing lists and Slack; see the Resources
+Community support is provided via mailing lists and Discord; see the Resources
 below for details.
 
 .. _project-resources:
@@ -64,8 +64,8 @@ Here's a quick summary of resources to help you find your way around:
 * **Nightly CI Build Status**: https://lists.zephyrproject.org/g/builds
   The builds@lists.zephyrproject.org mailing list archives the CI
   (buildkite) nightly build results.
-* **Chat**: Zephyr's Slack workspace is https://zephyrproject.slack.com.  Use
-  this `Slack Invite`_ to register.
+* **Chat**: Real-time chat happens in Zephyr's Discord Server. Use
+  this `Discord Invite`_ to register.
 * **Contributing**: see the `Contribution Guide`_
 * **Wiki**: `Zephyr GitHub wiki`_
 * **Issues**: https://github.com/zephyrproject-rtos/zephyr/issues
@@ -74,7 +74,7 @@ Here's a quick summary of resources to help you find your way around:
   tracked separately at https://zephyrprojectsec.atlassian.net.
 * **Zephyr Project Website**: https://zephyrproject.org
 
-.. _Slack Invite: https://tinyurl.com/2vue8666
+.. _Discord Invite: https://chat.zephyrproject.org
 .. _supported boards: http://docs.zephyrproject.org/latest/boards/index.html
 .. _Zephyr Documentation: http://docs.zephyrproject.org
 .. _Introduction to Zephyr: http://docs.zephyrproject.org/latest/introduction/index.html

--- a/doc/contribute/index.rst
+++ b/doc/contribute/index.rst
@@ -205,15 +205,16 @@ Pull Requests and Issues
 
 .. _Zephyr devel mailing list: https://lists.zephyrproject.org/g/devel
 
-.. _Zephyr Slack channel: https://zephyrproject.slack.com
+.. _Zephyr Discord Server: https://chat.zephyrproject.org
 
 Before starting on a patch, first check in our issues `Zephyr Project Issues`_
 system to see what's been reported on the issue you'd like to address.  Have a
-conversation on the `Zephyr devel mailing list`_ (or the the `Zephyr Slack channel`_)
-to see what others think of your issue (and proposed solution).  You may find
-others that have encountered the issue you're finding, or that have similar
-ideas for changes or additions.  Send a message to the `Zephyr devel mailing list`_
-to introduce and discuss your idea with the development community.
+conversation on the `Zephyr devel mailing list`_ (or the the `Zephyr Discord
+Server`_) to see what others think of your issue (and proposed solution).  You
+may find others that have encountered the issue you're finding, or that have
+similar ideas for changes or additions.  Send a message to the `Zephyr devel
+mailing list`_ to introduce and discuss your idea with the development
+community.
 
 It's always a good practice to search for existing or related issues before
 submitting your own. When you submit an issue (bug or feature request), the

--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -623,13 +623,12 @@ Here are some next steps for exploring Zephyr:
 Asking for Help
 ***************
 
-You can ask for help on a mailing list or on Slack. Please send bug reports and
+You can ask for help on a mailing list or on Discord. Please send bug reports and
 feature requests to GitHub.
 
 * **Mailing Lists**: users@lists.zephyrproject.org is usually the right list to
   ask for help. `Search archives and sign up here`_.
-* **Slack**: Zephyr's workspace is https://zephyrproject.slack.com; you can
-  register with this `Slack invite`_.
+* **Discord**: You can join with this `Discord invite`_.
 * **GitHub**: Use `GitHub issues`_ for bugs and feature requests.
 
 How to Ask
@@ -656,9 +655,9 @@ Text includes source code, terminal commands, and their output.
 Doing this makes it easier for people to help you, and also helps other users
 search the archives.
 
-When copy/pasting more than 5 lines of text into Slack, create a `snippet`_.
+When copy/pasting more than 5 lines of text into Discord, create a snippet using
+three backticks to delimit the snippet.
 
 .. _Search archives and sign up here: https://lists.zephyrproject.org/g/users
-.. _Slack invite: https://tinyurl.com/2vue8666
+.. _Discord invite: https://chat.zephyrproject.org
 .. _GitHub issues: https://github.com/zephyrproject-rtos/zephyr/issues
-.. _snippet: https://get.slack.help/hc/en-us/articles/204145658-Create-a-snippet


### PR DESCRIPTION
After the Technical Steering Committee decided to approve the transition
from Slack to Discord, it is necessary to update all the documentation
to reflect this change.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>