### PR TITLE
boards: mimxrt1024_evk: mcuboot support

### DIFF
--- a/boards/arm/mimxrt1024_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1024_evk/Kconfig.defconfig
@@ -12,4 +12,10 @@ choice CODE_LOCATION
 	default CODE_FLEXSPI
 endchoice
 
+config FLASH_MCUX_FLEXSPI_NOR
+	default y if FLASH
+
+config FLASH_MCUX_FLEXSPI_XIP
+	default y if FLASH
+
 endif # BOARD_MIMXRT1024_EVK

--- a/boards/arm/mimxrt1024_evk/mimxrt1024_evk.dts
+++ b/boards/arm/mimxrt1024_evk/mimxrt1024_evk.dts
@@ -18,7 +18,11 @@
 	};
 
 	chosen {
+		zephyr,flash-controller = &flexspi;
+		zephyr,flash = &is25wp032;
+		zephyr,code-partition = &slot0_partition;
 		zephyr,sram = &sdram0;
+		zephyr,itcm = &itcm;
 		zephyr,dtcm = &dtcm;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
@@ -43,6 +47,35 @@
 		user_button: button-1 {
 			label = "User SW4";
 			gpios = <&gpio5 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&is25wp032 {
+	status = "okay";
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(64)>;
+		};
+
+		slot0_partition: partition@10000 {
+			label = "image-0";
+			reg = <0x00010000 DT_SIZE_K(1984)>;
+		};
+
+		slot1_partition: partition@200000 {
+			label = "image-1";
+			reg = <0x00200000 DT_SIZE_K(1984)>;
+		};
+
+		scratch_partition: partition@3f0000 {
+			label = "image-scratch";
+			reg = <0x003f0000 DT_SIZE_K(64)>;
 		};
 	};
 };

--- a/dts/arm/nxp/nxp_rt1024.dtsi
+++ b/dts/arm/nxp/nxp_rt1024.dtsi
@@ -28,14 +28,17 @@
 };
 
 &flexspi {
+	status = "okay";
 	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(4)>;
-	is25wp064: is25wp064@0 {
-		compatible = "issi,is25wp064", "jedec,spi-nor";
-		size = <67108864>;
-		label = "IS25WP064";
+	is25wp032: is25wp032@0 {
+		compatible = "nxp,imx-flexspi-nor";
+		size = <DT_SIZE_M(32)>;
+		label = "IS25WP032";
 		reg = <0>;
 		spi-max-frequency = <133000000>;
 		status = "okay";
 		jedec-id = [9d 70 17];
+		erase-block-size = <DT_SIZE_K(4)>;
+		write-block-size = <1>;
 	};
 };

--- a/soc/arm/nxp_imx/rt/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt/Kconfig.soc
@@ -85,6 +85,7 @@ config SOC_MIMXRT1024
 	select HAS_MCUX_CACHE
 	select HAS_MCUX_CCM
 	select HAS_MCUX_ENET
+	select HAS_MCUX_FLEXSPI
 	select HAS_MCUX_IGPIO
 	select HAS_MCUX_LPI2C
 	select HAS_MCUX_LPSPI


### PR DESCRIPTION
Adds missing Flexspi kconfig support to the board as well as a flash partition table compatible with mcuboot layout.

The flash device in the SoC dts file was missing the correct compatible binding and erase/write-block-size necessary for mcuboot. Futhermore, the device size and label is corrected to reflect the actual onboard chip.

Tested [Device Firmware Upgrade](https://docs.zephyrproject.org/latest/samples/subsys/mgmt/mcumgr/smp_svr/README.html#device-firmware-upgrade-dfu) over the UDP transport (see #37863 for ethernet support).