### PR TITLE
Bluetooth: ISO: Fix build on native_posix_64 with debug

### DIFF
--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -672,7 +672,7 @@ static bool valid_chan_io_qos(const struct bt_iso_chan_io_qos *io_qos,
 	const size_t max_sdu = MIN(max_mtu, BT_ISO_MAX_SDU);
 
 	if (io_qos->sdu > max_sdu) {
-		BT_DBG("sdu (%u) shall be smaller than %u",
+		BT_DBG("sdu (%u) shall be smaller than %zu",
 		       io_qos->sdu, max_sdu);
 		return false;
 	}


### PR DESCRIPTION
On native_posix_64 we get the following compile error in CI:

error: format %u expects argument of type unsigned int

Fix by using %zu instead of %u as type is of size_t.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>