### PR TITLE
dts/arm: stm32l5: Fix flash controller compatible

### DIFF
--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -95,7 +95,7 @@
 			#size-cells = <1>;
 
 			flash0: flash@8000000 {
-				compatible = "st,stm32-nv-flash";
+				compatible = "st,stm32-nv-flash", "soc-nv-flash";
 				label = "FLASH_STM32";
 				write-block-size = <8>;
 				erase-block-size = <2048>;


### PR DESCRIPTION
Compatible "soc-nv-flash" was removed as part as #38077,
while it should have been kept, similarly to what was done
on other SoCs.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>