### PR TITLE
kernel/mem_slab: reorder Z_MEM_SLAB_INITIALIZER() initializers

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -4772,8 +4772,8 @@ struct k_mem_slab {
 #define Z_MEM_SLAB_INITIALIZER(obj, slab_buffer, slab_block_size, \
 			       slab_num_blocks) \
 	{ \
-	.lock = {}, \
 	.wait_q = Z_WAIT_Q_INIT(&obj.wait_q), \
+	.lock = {}, \
 	.num_blocks = slab_num_blocks, \
 	.block_size = slab_block_size, \
 	.buffer = slab_buffer, \


### PR DESCRIPTION
Trivial changes for C++ that make the macro Z_MEM_SLAB_INITIALIZER initializing the members in the same order they were defined.

Fixes : https://github.com/zephyrproject-rtos/zephyr/issues/38219

Signed-off-by: Lucas Dietrich <ld.adecy@gmail.com>