### PR TITLE
soc: riscv: andes_v5: Fix up linker script

### DIFF
--- a/soc/riscv/riscv-privilege/andes_v5/ae350/linker.ld
+++ b/soc/riscv/riscv-privilege/andes_v5/ae350/linker.ld
@@ -117,7 +117,7 @@ SECTIONS
 	}
 
     GROUP_START(ROMABLE_REGION)
-    _image_rom_start = ROM_BASE;
+    __rom_region_start = ROM_BASE;
 
     SECTION_PROLOGUE(_VECTOR_SECTION_NAME,,)
     {
@@ -172,7 +172,7 @@ SECTIONS
 
     _image_text_end = .;
 
-	_image_rodata_start = .;
+	__rodata_region_start = .;
 #include <linker/common-rom.ld>
 #include <linker/thread-local-storage.ld>
 
@@ -195,8 +195,8 @@ SECTIONS
 	} GROUP_LINK_IN(ROMABLE_REGION)
 
 #include <linker/cplusplus-rom.ld>
-	_image_rodata_end = .;
-	MPU_ALIGN(_image_rodata_end - _image_rom_start);
+	__rodata_region_end = .;
+	MPU_ALIGN(__rodata_region_end - __rom_region_start);
     GROUP_END(ROMABLE_REGION)
 
     GROUP_START(RAMABLE_REGION)
@@ -373,7 +373,7 @@ SECTION_PROLOGUE(.last_section,(NOLOAD),)
 
 /* To provide the image size as a const expression,
  * calculate this value here. */
-_image_rom_end = LOADADDR(.last_section);
-_image_rom_size = _image_rom_end - _image_rom_start;
+__rom_region_end = LOADADDR(.last_section);
+__rom_region_size = __rom_region_end - __rom_region_start;
 
 }


### PR DESCRIPTION
Update andes_v5 linker script to match the changes from this commit:

commit c6aded2dcbeda8911139a0e23ff1fe72cedb217a
Author: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>
Date:   Mon Aug 9 18:16:51 2021 +0200

    linker: align _image_rodata and _image_rom start/end/size linker ...

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>