### PR TITLE
ci: bump to docker image 0.18.3

### DIFF
--- a/.buildkite/daily.yml
+++ b/.buildkite/daily.yml
@@ -10,7 +10,7 @@ steps:
       manual: true
     plugins:
       - docker#v3.5.0:
-          image: "zephyrprojectrtos/ci:v0.18.2"
+          image: "zephyrprojectrtos/ci:v0.18.3"
           propagate-environment: true
           volumes:
             - "/var/lib/buildkite-agent/git-mirrors:/var/lib/buildkite-agent/git-mirrors"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,7 +10,7 @@ steps:
       manual: true
     plugins:
       - docker#v3.5.0:
-          image: "zephyrprojectrtos/ci:v0.18.2"
+          image: "zephyrprojectrtos/ci:v0.18.3"
           propagate-environment: true
           volumes:
             - "/var/lib/buildkite-agent/git-mirrors:/var/lib/buildkite-agent/git-mirrors"

--- a/.github/workflows/bsim.yaml
+++ b/.github/workflows/bsim.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: bsim-build-cancel
     container:
-      image: zephyrprojectrtos/ci:v0.18.2
+      image: zephyrprojectrtos/ci:v0.18.3
       options: '--entrypoint /bin/bash'
     env:
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: clang-build-cancel
     container:
-      image: zephyrprojectrtos/ci:v0.18.2
+      image: zephyrprojectrtos/ci:v0.18.3
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false

--- a/.github/workflows/errno.yml
+++ b/.github/workflows/errno.yml
@@ -8,7 +8,7 @@ jobs:
   check-errno:
     runs-on: ubuntu-latest
     container:
-      image: zephyrprojectrtos/ci:v0.18.2
+      image: zephyrprojectrtos/ci:v0.18.3
 
     steps:
       - name: checkout

--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -27,7 +27,7 @@ jobs:
     if: github.repository == 'zephyrproject-rtos/zephyr'
     needs: footprint-tracking-cancel
     container:
-      image: zephyrprojectrtos/ci:v0.18.2
+      image: zephyrprojectrtos/ci:v0.18.3
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false

--- a/.github/workflows/footprint.yml
+++ b/.github/workflows/footprint.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.repository == 'zephyrproject-rtos/zephyr'
     needs: footprint-cancel
     container:
-      image: zephyrprojectrtos/ci:v0.18.2
+      image: zephyrprojectrtos/ci:v0.18.3
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false


### PR DESCRIPTION
Update to 0.18.3 to hopefully get fix for uefi-run needed by
qemu_x86_64.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>