### PR TITLE
usb: Fix building error in usb_descriptor with misra test

### DIFF
--- a/subsys/usb/usb_descriptor.c
+++ b/subsys/usb/usb_descriptor.c
@@ -310,7 +310,7 @@ __weak uint8_t *usb_update_sn_string_descriptor(void)
 	 * unless the user requested a longer serial number.
 	 */
 	const int usblen = sizeof(CONFIG_USB_DEVICE_SN) / 2;
-	uint8_t hwid[MAX(16, usblen)];
+	uint8_t hwid[MAX(16, sizeof(CONFIG_USB_DEVICE_SN) / 2)];
 	static uint8_t sn[sizeof(CONFIG_USB_DEVICE_SN) + 1];
 	const char hex[] = "0123456789ABCDEF";
 	int hwlen, skip;


### PR DESCRIPTION
When we build tests/kernel/common/kernel.common.misra on
bl654_usb we get the following error:

subsys/usb/usb_descriptor.c:313:2: error: ISO C90 forbids array
'hwid' whose size cannot be evaluated [-Werror=vla]

Fix by removing use of usblen variable in array.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>