### PR TITLE
drivers: can: mcux_flexcan: fix irq connect

### DIFF
--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -768,7 +768,7 @@ static const struct can_driver_api mcux_flexcan_driver_api = {
 		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(id, name, irq),		\
 		DT_INST_IRQ_BY_NAME(id, name, priority),		\
 		mcux_flexcan_isr,					\
-		DEVICE_DT_INST_GET(id), id);				\
+		DEVICE_DT_INST_GET(id), 0);				\
 		irq_enable(DT_INST_IRQ_BY_NAME(id, name, irq));		\
 	} while (0)
 


### PR DESCRIPTION
`IRQ_CONNECT` macro last argument is architecture-specific flag, but now there is instance id at this place.
So i have error, when use two CAN (i.MX RT1021). Assert in `zephyr\include\arch\arm\aarch32\irq.h:116`, 
because id == 1 equal `IRQ_ZERO_LATENCY`.

This PR set architecture-specific flag to 0.