### PR TITLE
 cmake: create zephyr_build_string 

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -1309,6 +1309,66 @@ function(pow2round n)
   set(${n} ${${n}} PARENT_SCOPE)
 endfunction()
 
+# Function to create a build string based on BOARD, BOARD_REVISION, and BUILD
+# type.
+#
+# This is a common function to ensure that build strings are always created
+# in a uniform way.
+#
+# Usage:
+#   zephyr_build_string(<out-variable>
+#                       BOARD <board>
+#                       [BOARD_REVISION <revision>]
+#                       [BUILD <type>]
+#   )
+#
+# <out-variable>:            Output variable where the build string will be returned.
+# BOARD <board>:             Board name to use when creating the build string.
+# BOARD_REVISION <revision>: Board revision to use when creating the build string.
+# BUILD <type>:              Build type to use when creating the build string.
+#
+# Examples
+# calling
+#   zephyr_build_string(build_string BOARD alpha BUILD debug)
+# will return the string `alpha_debug` in `build_string` parameter.
+#
+# calling
+#   zephyr_build_string(build_string BOARD alpha BOARD_REVISION 1.0.0 BUILD debug)
+# will return the string `alpha_1_0_0_debug` in `build_string` parameter.
+#
+function(zephyr_build_string outvar)
+  set(single_args BOARD BOARD_REVISION BUILD)
+
+  cmake_parse_arguments(BUILD_STR "" "${single_args}" "" ${ARGN})
+  if(BUILD_STR_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR
+      "zephyr_build_string(${ARGV0} <val> ...) given unknown arguments:"
+      " ${BUILD_STR_UNPARSED_ARGUMENTS}"
+    )
+  endif()
+
+  if(DEFINED BUILD_STR_BOARD_REVISION AND NOT BUILD_STR_BOARD)
+    message(FATAL_ERROR
+      "zephyr_build_string(${ARGV0} <list> BOARD_REVISION ${BUILD_STR_BOARD_REVISION} ...)"
+      " given without BOARD argument, please specify BOARD"
+    )
+  endif()
+
+  set(${outvar} ${BUILD_STR_BOARD})
+
+  if(DEFINED BUILD_STR_BOARD_REVISION)
+    string(REPLACE "." "_" revision_string ${BUILD_STR_BOARD_REVISION})
+    set(${outvar} "${${outvar}}_${revision_string}")
+  endif()
+
+  if(BUILD_STR_BUILD)
+    set(${outvar} "${${outvar}}_${BUILD_STR_BUILD}")
+  endif()
+
+  # This updates the provided outvar in parent scope (callers scope)
+  set(${outvar} ${${outvar}} PARENT_SCOPE)
+endfunction()
+
 ########################################################
 # 2. Kconfig-aware extensions
 ########################################################
@@ -2075,6 +2135,8 @@ endfunction()
 #                          Issue an error for any relative path not specified
 #                          by user with `-D<path>`
 #
+# returns an updated list of absolute paths
+#
 # CONF_FILES <path>: Find all configuration files in path and return them in a
 #                    list. Configuration files will be:
 #                    - DTS:       Overlay files (.overlay)
@@ -2096,7 +2158,6 @@ endfunction()
 #                                  BUILD debug, will look for <board>_debug.conf
 #                                  and <board>_debug.overlay, instead of <board>.conf
 #
-# returns an updated list of absolute paths
 function(zephyr_file)
   set(file_options APPLICATION_ROOT CONF_FILES)
   if((ARGC EQUAL 0) OR (NOT (ARGV0 IN_LIST file_options)))
@@ -2112,7 +2173,7 @@ Please provide one of following: APPLICATION_ROOT, CONF_FILES")
 
   cmake_parse_arguments(FILE "" "${single_args}" "" ${ARGN})
   if(FILE_UNPARSED_ARGUMENTS)
-      message(FATAL_ERROR "zephyr_file(${ARGV0} <path> ...) given unknown arguments: ${FILE_UNPARSED_ARGUMENTS}")
+      message(FATAL_ERROR "zephyr_file(${ARGV0} <val> ...) given unknown arguments: ${FILE_UNPARSED_ARGUMENTS}")
   endif()
 
 
@@ -2167,15 +2228,22 @@ Relative paths are only allowed with `-D${ARGV1}=<path>`")
       endif()
     endif()
 
-    set(FILENAMES ${FILE_BOARD})
+    zephyr_build_string(filename
+                        BOARD ${FILE_BOARD}
+                        BUILD ${FILE_BUILD}
+    )
+    set(filename_list ${filename})
 
-    if(DEFINED FILE_BOARD_REVISION)
-      string(REPLACE "." "_" revision_string ${FILE_BOARD_REVISION})
-      list(APPEND FILENAMES "${FILE_BOARD}_${revision_string}")
-    endif()
+    zephyr_build_string(filename
+                        BOARD ${FILE_BOARD}
+                        BOARD_REVISION ${FILE_BOARD_REVISION}
+                        BUILD ${FILE_BUILD}
+    )
+    list(APPEND filename_list ${filename})
+    list(REMOVE_DUPLICATES filename_list)
 
     if(FILE_DTS)
-      foreach(filename ${FILENAMES})
+      foreach(filename ${filename_list})
         if(EXISTS ${FILE_CONF_FILES}/${filename}.overlay)
           list(APPEND ${FILE_DTS} ${FILE_CONF_FILES}/${filename}.overlay)
         endif()
@@ -2186,11 +2254,7 @@ Relative paths are only allowed with `-D${ARGV1}=<path>`")
     endif()
 
     if(FILE_KCONF)
-      foreach(filename ${FILENAMES})
-        if(FILE_BUILD)
-          set(filename "${filename}_${FILE_BUILD}")
-        endif()
-
+      foreach(filename ${filename_list})
         if(EXISTS ${FILE_CONF_FILES}/${filename}.conf)
           list(APPEND ${FILE_KCONF} ${FILE_CONF_FILES}/${filename}.conf)
         endif()


### PR DESCRIPTION
This commit creates a new `zephyr_build_string()` function.

`zephyr_build_string()` provides a common way of constructing a build
string based on board name, board revision, and build type.

Having this as a function facilitate creation of names in a common way
and thus helps to ensure naming consistency, especially if newer info
is later embedded into the build string.

Initially the build string will be used to lookup configuration
fragments and devicetree overlay files.

This function is used by `zephyr_file(CONF_FILES ...)`.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>