### PR TITLE
drivers: flash: Kconfig.sam: Fix depends on

### DIFF
--- a/drivers/flash/Kconfig.sam
+++ b/drivers/flash/Kconfig.sam
@@ -9,8 +9,8 @@ config SOC_FLASH_SAM
 	select FLASH_HAS_PAGE_LAYOUT
 	select FLASH_HAS_DRIVER_ENABLED
 	select MPU_ALLOW_FLASH_WRITE if ARM_MPU
-	depends on SOC_FAMILY_SAM
-	depends on SOC_SERIES_SAME70 || \
+	depends on SOC_FAMILY_SAM || \
+		   SOC_SERIES_SAME70 || \
 		   SOC_SERIES_SAMV71
 	help
 	  Enable the Atmel SAM series internal flash driver.


### PR DESCRIPTION
The Kconfig refactor that replaces some single-symbol 'if's with 'depends on' added a second entry.  That entry allows flash driver
be selected for SoC's without support.  This fixes the 'depends on' entry to allows only SAME/V SoCs.

Signed-off-by: Gerson Fernando Budke <nandojve@gmail.com>