### PR TITLE
samples: bluetooth: Fix scan filter

### DIFF
--- a/samples/bluetooth/central_ht/src/main.c
+++ b/samples/bluetooth/central_ht/src/main.c
@@ -228,7 +228,7 @@ static int scan_start(void)
 	 */
 	struct bt_le_scan_param scan_param = {
 		.type       = BT_LE_SCAN_TYPE_ACTIVE,
-		.options    = BT_LE_SCAN_OPT_FILTER_DUPLICATE,
+		.options    = BT_LE_SCAN_OPT_NONE,
 		.interval   = BT_GAP_SCAN_FAST_INTERVAL,
 		.window     = BT_GAP_SCAN_FAST_WINDOW,
 	};


### PR DESCRIPTION
We should use no filter filter to process adv data
according to code comment above.

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>