### PR TITLE
Bluetooth: Controller: Fix incorrect common header length calc

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -5216,12 +5216,6 @@ static void le_ext_adv_report(struct pdu_data *pdu_data,
 		}
 
 		hdr_len = ptr - (uint8_t *)p;
-		if (hdr_len <= (PDU_AC_EXT_HEADER_SIZE_MIN +
-				sizeof(struct pdu_adv_ext_hdr))) {
-			hdr_len = PDU_AC_EXT_HEADER_SIZE_MIN;
-			ptr = (uint8_t *)h;
-		}
-
 		hdr_buf_len = PDU_AC_EXT_HEADER_SIZE_MIN + p->ext_hdr_len;
 		if (hdr_len > hdr_buf_len) {
 			BT_WARN("    Header length %u/%u, INVALID.", hdr_len,
@@ -5624,12 +5618,6 @@ static void le_per_adv_sync_report(struct pdu_data *pdu_data,
 	}
 
 	hdr_len = ptr - (uint8_t *)p;
-		if (hdr_len <= (PDU_AC_EXT_HEADER_SIZE_MIN +
-				sizeof(struct pdu_adv_ext_hdr))) {
-			hdr_len = PDU_AC_EXT_HEADER_SIZE_MIN;
-			ptr = (uint8_t *)h;
-		}
-
 	hdr_buf_len = PDU_AC_EXT_HEADER_SIZE_MIN + p->ext_hdr_len;
 	if (hdr_len > hdr_buf_len) {
 		BT_WARN("    Header length %u/%u, INVALID.", hdr_len,


### PR DESCRIPTION
Fix incorrect calculation of received common extended header
length. Due to this a zero length advertising data is
reported in Extended Advertising and Periodic Advertising
report as one byte AD data.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>