### PR TITLE
dts: arm: stm32h7 introducing the stm32h723xE device

### DIFF
--- a/dts/arm/st/h7/stm32h723Xe.dtsi
+++ b/dts/arm/st/h7/stm32h723Xe.dtsi
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2021 STMicroelectronics
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <st/h7/stm32h723.dtsi>
+
+/ {
+	soc {
+		flash-controller@52002000 {
+			flash0: flash@8000000 {
+				compatible = "soc-nv-flash";
+				label = "FLASH_STM32";
+				reg = <0x08000000 DT_SIZE_K(512)>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
This stm32h723xE is similar to the existing stm32h723xG
with only **512K** of flash memory.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/38235

Based on the [stm32h723xE/G datasheet ](https://www.st.com/resource/en/datasheet/stm32h723ve.pdf) from STMicroelectronics

Signed-off-by: Francois Ramu <francois.ramu@st.com>