### PR TITLE
Bluetooth: Host: Fix MPU fault due to incorrect EV_COUNT

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2391,7 +2391,7 @@ static void process_events(struct k_poll_event *ev, int count)
 
 #if defined(CONFIG_BT_CONN)
 #if defined(CONFIG_BT_ISO)
-/* command FIFO + conn_change signal + MAX_CONN + MAX_ISO_CONN */
+/* command FIFO + conn_change signal + MAX_CONN + ISO_MAX_CHAN */
 #define EV_COUNT (2 + CONFIG_BT_MAX_CONN + CONFIG_BT_ISO_MAX_CHAN)
 #else
 /* command FIFO + conn_change signal + MAX_CONN */
@@ -2399,8 +2399,8 @@ static void process_events(struct k_poll_event *ev, int count)
 #endif /* CONFIG_BT_ISO */
 #else
 #if defined(CONFIG_BT_ISO)
-/* command FIFO + MAX_ISO_CONN */
-#define EV_COUNT (1 + CONFIG_BT_ISO_MAX_CHAN)
+/* command FIFO + conn_change signal + ISO_MAX_CHAN */
+#define EV_COUNT (2 + CONFIG_BT_ISO_MAX_CHAN)
 #else
 /* command FIFO */
 #define EV_COUNT 1


### PR DESCRIPTION
Fix MPU fault due to incorrect EV_COUNT, `conn_change`
signal was not accounted for in the array used by k_poll.

Relates to commit 78540881166a ("Bluetooth: ISO: Fixes
missing handling of broadcast ISO TX").

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>