### PR TITLE
ITE: soc: it8xxx2: add initialization setting for hibernate mode

### DIFF
--- a/soc/riscv/riscv-ite/it8xxx2/soc.c
+++ b/soc/riscv/riscv-ite/it8xxx2/soc.c
@@ -136,6 +136,12 @@ static int ite_it8xxx2_init(const struct device *arg)
 {
 	ARG_UNUSED(arg);
 
+	/*
+	 * bit7: wake up CPU if it is in low power mode and
+	 * an interrupt is pending.
+	 */
+	IT83XX_GCTRL_WMCR |= BIT(7);
+
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(uart1), okay)
 	/* UART1 board init */
 	/* bit2: clocks to UART1 modules are not gated. */


### PR DESCRIPTION
Setting this bit will wake up CPU if it is in low power mode
and an interrupt is pending.

Signed-off-by: Tim Lin <tim2.lin@ite.corp-partner.google.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zephyrproject-rtos/zephyr/38249)
<!-- Reviewable:end -->
