### PR TITLE
Bluetooth: mesh: Fail provisioning when RFU values are used

### DIFF
--- a/subsys/bluetooth/mesh/prov_device.c
+++ b/subsys/bluetooth/mesh/prov_device.c
@@ -137,9 +137,9 @@ static void prov_start(const uint8_t *data)
 		return;
 	}
 
-	if (data[1] == PUB_KEY_OOB &&
-	    !(IS_ENABLED(CONFIG_BT_MESH_PROV_OOB_PUBLIC_KEY) &&
-	      bt_mesh_prov->public_key_be)) {
+	if (data[1] > PUB_KEY_OOB ||
+	    (data[1] == PUB_KEY_OOB &&
+	     (!IS_ENABLED(CONFIG_BT_MESH_PROV_OOB_PUBLIC_KEY) || !bt_mesh_prov->public_key_be))) {
 		BT_ERR("Invalid public key type: 0x%02x", data[1]);
 		prov_fail(PROV_ERR_NVAL_FMT);
 		return;


### PR DESCRIPTION
When Public Key field is set to RFU value then we should send
Provisioning Fail with Invalid Format error.

Signed-off-by: Michał Narajowski <michal.narajowski@codecoup.pl>