### PR TITLE
samples: hci_rpmsg: Introduce Thingy:53 configuration

### DIFF
--- a/samples/bluetooth/hci_rpmsg/boards/thingy53_nrf5340_cpunet.conf
+++ b/samples/bluetooth/hci_rpmsg/boards/thingy53_nrf5340_cpunet.conf
@@ -1,0 +1,11 @@
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Reduce RAM usage to let the firmware fit on network core
+CONFIG_BT_MAX_CONN=10
+
+# Increase maximum data length of PDU supported in the Controller
+CONFIG_BT_CTLR_DATA_LENGTH_MAX=251
+CONFIG_BT_BUF_ACL_TX_SIZE=251
+CONFIG_BT_BUF_ACL_RX_SIZE=251


### PR DESCRIPTION
Change introduces default configuration overlay for Thingy:53. The configuration overlay is needed to speed up DFU over BLE.