### PR TITLE
Bluetooth: Mesh: Fix missing call to adv send end callback in legacy

### DIFF
--- a/subsys/bluetooth/mesh/adv_legacy.c
+++ b/subsys/bluetooth/mesh/adv_legacy.c
@@ -119,6 +119,8 @@ static inline void adv_send(struct net_buf *buf)
 		return;
 	}
 
+	bt_mesh_adv_send_end(err, BT_MESH_ADV(buf));
+
 	BT_DBG("Advertising stopped (%u ms)", (uint32_t) k_uptime_delta(&time));
 }
 


### PR DESCRIPTION
Friend feature relies on start/end callbacks in advertising and
adv_legacy backend was missing a call to bt_mesh_adv_send_end().

Signed-off-by: Michał Narajowski <michal.narajowski@codecoup.pl>