### PR TITLE
subsys/shell: Expose echo as a config per backend instance

### DIFF
--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -793,6 +793,7 @@ extern void z_shell_print_stream(const void *user_ctx, const char *data,
  * @param[in] shell		Pointer to shell instance.
  * @param[in] transport_config	Transport configuration during initialization.
  * @param[in] use_colors	Enables colored prints.
+ * @param[in] echo		Enables echo.
  * @param[in] log_backend	If true, the console will be used as logger
  *				backend.
  * @param[in] init_log_level	Default severity level for the logger.
@@ -800,7 +801,7 @@ extern void z_shell_print_stream(const void *user_ctx, const char *data,
  * @return Standard error code.
  */
 int shell_init(const struct shell *shell, const void *transport_config,
-	       bool use_colors, bool log_backend, uint32_t init_log_level);
+	       bool use_colors, bool echo, bool log_backend, uint32_t init_log_level);
 
 /**
  * @brief Uninitializes the transport layer and the internal shell state.

--- a/samples/subsys/shell/shell_module/src/uart_reinit.c
+++ b/samples/subsys/shell/shell_module/src/uart_reinit.c
@@ -16,7 +16,7 @@ void shell_init_from_work(struct k_work *work)
 		(CONFIG_SHELL_BACKEND_SERIAL_LOG_LEVEL > LOG_LEVEL_DBG) ?
 		CONFIG_LOG_MAX_LEVEL : CONFIG_SHELL_BACKEND_SERIAL_LOG_LEVEL;
 
-	shell_init(shell_backend_uart_get_ptr(), dev, true, log_backend, level);
+	shell_init(shell_backend_uart_get_ptr(), dev, true, true, log_backend, level);
 }
 
 static void shell_reinit_trigger(void)

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1177,7 +1177,7 @@ static void shell_log_process(const struct shell *shell)
 }
 
 static int instance_init(const struct shell *shell, const void *p_config,
-			 bool use_colors)
+			 bool use_colors, bool echo)
 {
 	__ASSERT_NO_MSG((shell->shell_flag == SHELL_FLAG_CRLF_DEFAULT) ||
 			(shell->shell_flag == SHELL_FLAG_OLF_CRLF));
@@ -1205,7 +1205,7 @@ static int instance_init(const struct shell *shell, const void *p_config,
 	}
 
 	z_flag_tx_rdy_set(shell, true);
-	z_flag_echo_set(shell, IS_ENABLED(CONFIG_SHELL_ECHO_STATUS));
+	z_flag_echo_set(shell, IS_ENABLED(CONFIG_SHELL_ECHO_STATUS) && echo);
 	z_flag_obscure_set(shell, IS_ENABLED(CONFIG_SHELL_START_OBSCURED));
 	z_flag_mode_delete_set(shell,
 			     IS_ENABLED(CONFIG_SHELL_BACKSPACE_MODE_DELETE));
@@ -1339,7 +1339,7 @@ void shell_thread(void *shell_handle, void *arg_log_backend,
 }
 
 int shell_init(const struct shell *shell, const void *transport_config,
-	       bool use_colors, bool log_backend, uint32_t init_log_level)
+	       bool use_colors, bool echo, bool log_backend, uint32_t init_log_level)
 {
 	__ASSERT_NO_MSG(shell);
 	__ASSERT_NO_MSG(shell->ctx && shell->iface && shell->default_prompt);
@@ -1348,7 +1348,7 @@ int shell_init(const struct shell *shell, const void *transport_config,
 		return -EALREADY;
 	}
 
-	int err = instance_init(shell, transport_config, use_colors);
+	int err = instance_init(shell, transport_config, use_colors, echo);
 
 	if (err != 0) {
 		return err;

--- a/subsys/shell/shell_dummy.c
+++ b/subsys/shell/shell_dummy.c
@@ -101,7 +101,7 @@ const struct shell_transport_api shell_dummy_transport_api = {
 static int enable_shell_dummy(const struct device *arg)
 {
 	ARG_UNUSED(arg);
-	shell_init(&shell_dummy, NULL, true, true, LOG_LEVEL_INF);
+	shell_init(&shell_dummy, NULL, true, true, true, LOG_LEVEL_INF);
 	return 0;
 }
 SYS_INIT(enable_shell_dummy, POST_KERNEL, 0);

--- a/subsys/shell/shell_rtt.c
+++ b/subsys/shell/shell_rtt.c
@@ -114,7 +114,7 @@ static int enable_shell_rtt(const struct device *arg)
 	uint32_t level = (CONFIG_SHELL_RTT_INIT_LOG_LEVEL > LOG_LEVEL_DBG) ?
 		      CONFIG_LOG_MAX_LEVEL : CONFIG_SHELL_RTT_INIT_LOG_LEVEL;
 
-	shell_init(&shell_rtt, NULL, true, log_backend, level);
+	shell_init(&shell_rtt, NULL, true, true, log_backend, level);
 
 	return 0;
 }

--- a/subsys/shell/shell_telnet.c
+++ b/subsys/shell/shell_telnet.c
@@ -496,7 +496,7 @@ static int enable_shell_telnet(const struct device *arg)
 	uint32_t level = (CONFIG_SHELL_TELNET_INIT_LOG_LEVEL > LOG_LEVEL_DBG) ?
 		      CONFIG_LOG_MAX_LEVEL : CONFIG_SHELL_TELNET_INIT_LOG_LEVEL;
 
-	return shell_init(&shell_telnet, NULL, true, log_backend, level);
+	return shell_init(&shell_telnet, NULL, true, true, log_backend, level);
 }
 
 SYS_INIT(enable_shell_telnet, APPLICATION, 0);

--- a/subsys/shell/shell_uart.c
+++ b/subsys/shell/shell_uart.c
@@ -307,7 +307,7 @@ static int enable_shell_uart(const struct device *arg)
 		smp_shell_init();
 	}
 
-	shell_init(&shell_uart, dev, true, log_backend, level);
+	shell_init(&shell_uart, dev, true, true, log_backend, level);
 
 	return 0;
 }


### PR DESCRIPTION
Expose echo flag so that it can be configured according to the characteristics of the shell backend.

Required for non-terminal shell backend (such as #38107) to work alongside other backends.