### PR TITLE
PCI Express Extended Capabilities support

### DIFF
--- a/drivers/pcie/host/msi.c
+++ b/drivers/pcie/host/msi.c
@@ -6,6 +6,7 @@
 
 #include <kernel.h>
 #include <drivers/pcie/msi.h>
+#include <drivers/pcie/cap.h>
 
 /* functions documented in include/drivers/pcie/msi.h */
 
@@ -118,12 +119,12 @@ uint8_t pcie_msi_vectors_allocate(pcie_bdf_t bdf,
 	uint32_t base;
 	uint32_t req_vectors;
 
-	base = pcie_get_cap(bdf, PCIE_MSI_CAP_ID);
+	base = pcie_get_cap(bdf, PCI_CAP_ID_MSI);
 
 	if (IS_ENABLED(CONFIG_PCIE_MSI_X)) {
 		uint32_t base_msix;
 
-		base_msix = pcie_get_cap(bdf, PCIE_MSIX_CAP_ID);
+		base_msix = pcie_get_cap(bdf, PCI_CAP_ID_MSIX);
 		if (base_msix != 0U) {
 			msi = false;
 			base = base_msix;
@@ -161,12 +162,12 @@ bool pcie_msi_vector_connect(pcie_bdf_t bdf,
 {
 	uint32_t base;
 
-	base = pcie_get_cap(bdf, PCIE_MSI_CAP_ID);
+	base = pcie_get_cap(bdf, PCI_CAP_ID_MSI);
 
 	if (IS_ENABLED(CONFIG_PCIE_MSI_X)) {
 		uint32_t base_msix;
 
-		base_msix = pcie_get_cap(bdf, PCIE_MSIX_CAP_ID);
+		base_msix = pcie_get_cap(bdf, PCI_CAP_ID_MSIX);
 		if (base_msix != 0U) {
 			base = base_msix;
 		}
@@ -268,12 +269,12 @@ bool pcie_msi_enable(pcie_bdf_t bdf,
 	bool msi = true;
 	uint32_t base;
 
-	base = pcie_get_cap(bdf, PCIE_MSI_CAP_ID);
+	base = pcie_get_cap(bdf, PCI_CAP_ID_MSI);
 
 	if (IS_ENABLED(CONFIG_PCIE_MSI_X)) {
 		uint32_t base_msix;
 
-		base_msix = pcie_get_cap(bdf, PCIE_MSIX_CAP_ID);
+		base_msix = pcie_get_cap(bdf, PCI_CAP_ID_MSIX);
 		if ((base_msix != 0U) && (base != 0U)) {
 			disable_msi(bdf, base);
 		}

--- a/drivers/pcie/host/pcie.c
+++ b/drivers/pcie/host/pcie.c
@@ -71,6 +71,31 @@ uint32_t pcie_get_cap(pcie_bdf_t bdf, uint32_t cap_id)
 	return reg;
 }
 
+uint32_t pcie_get_ext_cap(pcie_bdf_t bdf, uint32_t cap_id)
+{
+	unsigned int reg = PCIE_CONF_EXT_CAPPTR; /* Start at end of the PCI configuration space */
+	uint32_t data;
+
+	while (reg) {
+		data = pcie_conf_read(bdf, reg);
+		if (!data || data == 0xffffffff) {
+			return 0;
+		}
+
+		if (PCIE_CONF_EXT_CAP_ID(data) == cap_id) {
+			break;
+		}
+
+		reg = PCIE_CONF_EXT_CAP_NEXT(data) >> 2;
+
+		if (reg < PCIE_CONF_EXT_CAPPTR) {
+			return 0;
+		}
+	}
+
+	return reg;
+}
+
 bool pcie_get_mbar(pcie_bdf_t bdf,
 		   unsigned int bar_index,
 		   struct pcie_mbar *mbar)

--- a/drivers/pcie/host/shell.c
+++ b/drivers/pcie/host/shell.c
@@ -9,6 +9,7 @@
 
 #ifdef CONFIG_PCIE_MSI
 #include <drivers/pcie/msi.h>
+#include <drivers/pcie/cap.h>
 #endif
 
 static void show_msi(const struct shell *shell, pcie_bdf_t bdf)
@@ -17,7 +18,7 @@ static void show_msi(const struct shell *shell, pcie_bdf_t bdf)
 	uint32_t msi;
 	uint32_t data;
 
-	msi = pcie_get_cap(bdf, PCIE_MSI_CAP_ID);
+	msi = pcie_get_cap(bdf, PCI_CAP_ID_MSI);
 
 	if (msi) {
 		data = pcie_conf_read(bdf, msi + PCIE_MSI_MCR);
@@ -26,7 +27,7 @@ static void show_msi(const struct shell *shell, pcie_bdf_t bdf)
 			      (data & PCIE_MSI_MCR_EN) ? ", enabled" : "");
 	}
 
-	msi = pcie_get_cap(bdf, PCIE_MSIX_CAP_ID);
+	msi = pcie_get_cap(bdf, PCI_CAP_ID_MSIX);
 
 	if (msi) {
 		shell_fprintf(shell, SHELL_NORMAL, "    MSI-X support\n");

--- a/include/drivers/pcie/cap.h
+++ b/include/drivers/pcie/cap.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2021 BayLibre, SAS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_DRIVERS_PCIE_CAP_H_
+#define ZEPHYR_INCLUDE_DRIVERS_PCIE_CAP_H_
+
+/*
+ * PCI & PCI Express Capabilities
+ * from PCI Code and ID Assignment Specification Revision 1.11
+ */
+
+#define PCI_CAP_ID_NULL		0x00U	/* Null Capability */
+#define PCI_CAP_ID_PM		0x01U	/* Power Management */
+#define PCI_CAP_ID_AGP		0x02U	/* Accelerated Graphics Port */
+#define PCI_CAP_ID_VPD		0x03U	/* Vital Product Data */
+#define PCI_CAP_ID_SLOTID	0x04U	/* Slot Identification */
+#define PCI_CAP_ID_MSI		0x05U	/* Message Signalled Interrupts */
+#define PCI_CAP_ID_CHSWP	0x06U	/* CompactPCI HotSwap */
+#define PCI_CAP_ID_PCIX		0x07U	/* PCI-X */
+#define PCI_CAP_ID_HT		0x08U	/* HyperTransport */
+#define PCI_CAP_ID_VNDR		0x09U	/* Vendor-Specific */
+#define PCI_CAP_ID_DBG		0x0AU	/* Debug port */
+#define PCI_CAP_ID_CCRC		0x0BU	/* CompactPCI Central Resource Control */
+#define PCI_CAP_ID_SHPC		0x0CU	/* PCI Standard Hot-Plug Controller */
+#define PCI_CAP_ID_SSVID	0x0DU	/* Bridge subsystem vendor/device ID */
+#define PCI_CAP_ID_AGP3		0x0EU	/* AGP 8x */
+#define PCI_CAP_ID_SECDEV	0x0FU	/* Secure Device */
+#define PCI_CAP_ID_EXP		0x10U	/* PCI Express */
+#define PCI_CAP_ID_MSIX		0x11U	/* MSI-X */
+#define PCI_CAP_ID_SATA		0x12U	/* Serial ATA Data/Index Configuration */
+#define PCI_CAP_ID_AF		0x13U	/* PCI Advanced Features */
+#define PCI_CAP_ID_EA		0x14U	/* PCI Enhanced Allocation */
+#define PCI_CAP_ID_FPB		0x14U	/* Flattening Portal Bridge */
+
+/*
+ * PCI Express Extended Capabilities
+ */
+
+#define PCI_EXT_CAP_ID_NULL	0x0000U	/* Null Capability */
+#define PCI_EXT_CAP_ID_ERR	0x0001U	/* Advanced Error Reporting */
+#define PCI_EXT_CAP_ID_VC	0x0002U	/* Virtual Channel when no MFVC */
+#define PCI_EXT_CAP_ID_DSN	0x0003U	/* Device Serial Number */
+#define PCI_EXT_CAP_ID_PWR	0x0004U	/* Power Budgeting */
+#define PCI_EXT_CAP_ID_RCLD	0x0005U	/* Root Complex Link Declaration */
+#define PCI_EXT_CAP_ID_RCILC	0x0006U	/* Root Complex Internal Link Control */
+#define PCI_EXT_CAP_ID_RCEC	0x0007U	/* Root Complex Event Collector Endpoint Association */
+#define PCI_EXT_CAP_ID_MFVC	0x0008U	/* Multi-Function VC Capability */
+#define PCI_EXT_CAP_ID_MFVC_VC	0x0009U	/* Virtual Channel used with MFVC */
+#define PCI_EXT_CAP_ID_RCRB	0x000AU	/* Root Complex Register Block */
+#define PCI_EXT_CAP_ID_VNDR	0x000BU	/* Vendor-Specific Extended Capability */
+#define PCI_EXT_CAP_ID_CAC	0x000CU	/* Config Access Correlation - obsolete */
+#define PCI_EXT_CAP_ID_ACS	0x000DU	/* Access Control Services */
+#define PCI_EXT_CAP_ID_ARI	0x000EU	/* Alternate Routing-ID Interpretation */
+#define PCI_EXT_CAP_ID_ATS	0x000FU	/* Address Translation Services */
+#define PCI_EXT_CAP_ID_SRIOV	0x0010U	/* Single Root I/O Virtualization */
+#define PCI_EXT_CAP_ID_MRIOV	0x0011U	/* Multi Root I/O Virtualization */
+#define PCI_EXT_CAP_ID_MCAST	0x0012U	/* Multicast */
+#define PCI_EXT_CAP_ID_PRI	0x0013U	/* Page Request Interface */
+#define PCI_EXT_CAP_ID_AMD_XXX	0x0014U	/* Reserved for AMD */
+#define PCI_EXT_CAP_ID_REBAR	0x0015U	/* Resizable BAR */
+#define PCI_EXT_CAP_ID_DPA	0x0016U	/* Dynamic Power Allocation */
+#define PCI_EXT_CAP_ID_TPH	0x0017U	/* TPH Requester */
+#define PCI_EXT_CAP_ID_LTR	0x0018U	/* Latency Tolerance Reporting */
+#define PCI_EXT_CAP_ID_SECPCI	0x0019U	/* Secondary PCIe Capability */
+#define PCI_EXT_CAP_ID_PMUX	0x001AU	/* Protocol Multiplexing */
+#define PCI_EXT_CAP_ID_PASID	0x001BU	/* Process Address Space ID */
+#define PCI_EXT_CAP_ID_DPC	0x001DU	/* DPC: Downstream Port Containment */
+#define PCI_EXT_CAP_ID_L1SS	0x001EU	/* L1 PM Substates */
+#define PCI_EXT_CAP_ID_PTM	0x001FU	/* Precision Time Measurement */
+#define PCI_EXT_CAP_ID_DVSEC	0x0023U	/* Designated Vendor-Specific Extended Capability */
+#define PCI_EXT_CAP_ID_DLF	0x0025U	/* Data Link Feature */
+#define PCI_EXT_CAP_ID_PL_16GT	0x0026U	/* Physical Layer 16.0 GT/s */
+#define PCI_EXT_CAP_ID_LMR	0x0027U	/* Lane Margining at the Receiver */
+#define PCI_EXT_CAP_ID_HID	0x0028U	/* Hierarchy ID  */
+#define PCI_EXT_CAP_ID_NPEM	0x0029U	/* Native PCIe Enclosure Management */
+#define PCI_EXT_CAP_ID_PL_32GT	0x002AU	/* Physical Layer 32.0 GT/s */
+#define PCI_EXT_CAP_ID_AP	0x002BU	/* Alternate Protocol */
+#define PCI_EXT_CAP_ID_SFI	0x002CU	/* System Firmware Intermediary  */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_PCIE_CAP_H_ */

--- a/include/drivers/pcie/msi.h
+++ b/include/drivers/pcie/msi.h
@@ -108,13 +108,6 @@ extern bool pcie_msi_enable(pcie_bdf_t bdf,
 			    uint8_t n_vector);
 
 /*
- * MSI capability IDs in the PCI configuration capability list.
- */
-
-#define PCIE_MSI_CAP_ID		0x05U
-#define PCIE_MSIX_CAP_ID	0x11U
-
-/*
  * The first word of the MSI capability is shared with the
  * capability ID and list link.  The high 16 bits are the MCR.
  */

--- a/include/drivers/pcie/pcie.h
+++ b/include/drivers/pcie/pcie.h
@@ -167,6 +167,15 @@ extern void pcie_irq_enable(pcie_bdf_t bdf, unsigned int irq);
  */
 extern uint32_t pcie_get_cap(pcie_bdf_t bdf, uint32_t cap_id);
 
+/**
+ * @brief Find an Extended PCI(e) capability in an endpoint's configuration space.
+ *
+ * @param bdf the PCI endpoint to examine
+ * @param cap_id the capability ID of interest
+ * @return the index of the configuration word, or 0 if no capability.
+ */
+extern uint32_t pcie_get_ext_cap(pcie_bdf_t bdf, uint32_t cap_id);
+
 /*
  * Configuration word 13 contains the head of the capabilities list.
  */
@@ -181,6 +190,21 @@ extern uint32_t pcie_get_cap(pcie_bdf_t bdf, uint32_t cap_id);
 
 #define PCIE_CONF_CAP_ID(w)		((w) & 0xFFU)
 #define PCIE_CONF_CAP_NEXT(w)		(((w) >> 10) & 0x3FU)
+
+/*
+ * The extended PCI Express capabilies lies at the end of the PCI configuration space
+ */
+
+#define PCIE_CONF_EXT_CAPPTR	64U
+
+/*
+ * The first word of every capability contains an extended capability identifier,
+ * and a link to the next capability (or 0) in the extended configuration space.
+ */
+
+#define PCIE_CONF_EXT_CAP_ID(w)		((w) & 0xFFFFU)
+#define PCIE_CONF_EXT_CAP_VER(w)	(((w) >> 16) & 0xFU)
+#define PCIE_CONF_EXT_CAP_NEXT(w)	(((w) >> 20) & 0xFFFU)
 
 /*
  * Configuration word 0 aligns directly with pcie_id_t.


### PR DESCRIPTION
This adds Extended PCI(e) capability offset get function & new Capabilites defines header.

These patches were split from #37668 