### PR TITLE
boards: stm32l5: add usb_fs definition to devicetree

### DIFF
--- a/boards/arm/stm32l562e_dk/doc/index.rst
+++ b/boards/arm/stm32l562e_dk/doc/index.rst
@@ -185,6 +185,8 @@ hardware features:
 +-----------+------------+-------------------------------------+
 | WATCHDOG  | on-chip    | independent watchdog                |
 +-----------+------------+-------------------------------------+
+| USB       | on-chip    | usb                                 |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr port.
 

--- a/boards/arm/stm32l562e_dk/stm32l562e_dk.yaml
+++ b/boards/arm/stm32l562e_dk/stm32l562e_dk.yaml
@@ -18,5 +18,6 @@ supported:
   - dma
   - usart
   - arduino_spi
+  - usb
 ram: 192
 flash: 512

--- a/boards/arm/stm32l562e_dk/stm32l562e_dk_common.dtsi
+++ b/boards/arm/stm32l562e_dk/stm32l562e_dk_common.dtsi
@@ -146,3 +146,8 @@
 	cs-gpios = <&gpioe 0 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 	status = "okay";
 };
+
+zephyr_udc0: &usb {
+	pinctrl-0 = <&usb_dp_pa12 &usb_dm_pa11>;
+	status = "okay";
+};

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -201,7 +201,8 @@ static int usb_dc_stm32_clock_enable(void)
 	 */
 #if defined(RCC_HSI48_SUPPORT) || \
 	defined(CONFIG_SOC_SERIES_STM32WBX) || \
-	defined(CONFIG_SOC_SERIES_STM32H7X)
+	defined(CONFIG_SOC_SERIES_STM32H7X) || \
+	defined(CONFIG_SOC_SERIES_STM32L5X)
 
 	/*
 	 * In STM32L0 series, HSI48 requires VREFINT and its buffer

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -564,6 +564,26 @@
 			label = "ADC_2";
 			#io-channel-cells = <1>;
 		};
+
+		usb: usb@4000d400 {
+			compatible = "st,stm32-usb";
+			reg = <0x4000d400 0x400>;
+			interrupts = <73 0>;
+			interrupt-names = "usb";
+			num-bidir-endpoints = <8>;
+			ram-size = <1024>;
+			status = "disabled";
+			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00200000>;
+			phys = <&usb_fs_phy>;
+			label = "USB";
+		};
+
+	};
+
+	usb_fs_phy: usbphy {
+		compatible = "usb-nop-xceiv";
+		#phy-cells = <0>;
+		label = "USB_FS_PHY";
 	};
 };
 


### PR DESCRIPTION
Add USB_FS device definition to devicetree of all STM32L5 SoC family

Signed-off-by: Luc Viala <luc.viala19@gmail.com>