### PR TITLE
lib: newlib: Add workaround for #38258

### DIFF
--- a/lib/libc/newlib/libc-hooks.c
+++ b/lib/libc/newlib/libc-hooks.c
@@ -130,6 +130,20 @@ static int malloc_prepare(const struct device *unused)
 		 "minimum required size specified by "
 		 "CONFIG_NEWLIB_LIBC_MIN_REQUIRED_HEAP_SIZE");
 
+#ifdef CONFIG_XTENSA
+	/*
+	 * FIXME: For Xtensa, the first `malloc` call may fail if the HEAP_BASE
+	 *        is such that the first `sbrk` call returns a 4096-byte
+	 *        aligned address.
+	 *
+	 *        This is a very ugly workaround for the issue #38258 and must
+	 *        be removed once it is fixed.
+	 */
+	void *ptr = malloc(16);
+
+	free(ptr);
+#endif /* CONFIG_XTENSA */
+
 	return 0;
 }
 


### PR DESCRIPTION
```
For the Xtensa platforms (e.g. qemu_xtensa), the first `malloc` call
may fail if the newlib heap base address is such that the first `sbrk`
call returns a 4096-byte aligned address.

Here we add a workaround for Xtensa that allocates and immediately
frees a 16-byte memory block during initialisation so that all
subsequent `malloc` calls succeed.

This commit needs to be reverted once the issue #38258 is fixed.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>
```

Fixes #38234.

Workaround for #38258.