### PR TITLE
drivers: flash: Kconfig.sam: -depends on and +dfu sample exclude

### DIFF
--- a/drivers/flash/Kconfig.sam
+++ b/drivers/flash/Kconfig.sam
@@ -9,8 +9,7 @@ config SOC_FLASH_SAM
 	select FLASH_HAS_PAGE_LAYOUT
 	select FLASH_HAS_DRIVER_ENABLED
 	select MPU_ALLOW_FLASH_WRITE if ARM_MPU
-	depends on SOC_FAMILY_SAM || \
-		   SOC_SERIES_SAME70 || \
+	depends on SOC_SERIES_SAME70 || \
 		   SOC_SERIES_SAMV71
 	help
 	  Enable the Atmel SAM series internal flash driver.

--- a/samples/subsys/usb/dfu/sample.yaml
+++ b/samples/subsys/usb/dfu/sample.yaml
@@ -4,7 +4,7 @@ tests:
   sample.usb.dfu:
     build_only: True
     platform_exclude: native_posix native_posix_64 mimxrt1010_evk
-      mimxrt1050_evk_qspi mimxrt1020_evk mimxrt1015_evk mimxrt1060_evk
+      mimxrt1050_evk_qspi mimxrt1020_evk mimxrt1015_evk mimxrt1060_evk sam4l_ek
       mimxrt1050_evk mimxrt1060_evk_hyperflash nucleo_f207zg teensy40 teensy41
     depends_on: usb_device
     filter: dt_label_with_parent_compat_enabled("slot0_partition", "fixed-partitions") and


### PR DESCRIPTION
This reverts commit 626b1b79df62bcdc4142cb671693ea9f31f10909.

Additional platforms with SAM SoC's are experiencing the same problem.
Would prefer a common fix.
