### PR TITLE
cmake: remove deprecated `set_conf_file()` support

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -464,10 +464,6 @@ elseif(CACHED_CONF_FILE)
 elseif(DEFINED ENV{CONF_FILE})
   set(CONF_FILE $ENV{CONF_FILE})
 
-elseif(COMMAND set_conf_file)
-  message(WARNING "'set_conf_file' is deprecated, it will be removed in a future release.")
-  set_conf_file()
-
 elseif(EXISTS   ${APPLICATION_SOURCE_DIR}/prj_${BOARD}.conf)
   set(CONF_FILE ${APPLICATION_SOURCE_DIR}/prj_${BOARD}.conf)
 


### PR DESCRIPTION
The `set_conf_file()` was deprecated in
6d4ba3490fee518da9136ce54d45d82200e800c6

which is before Zephyr v1.14 LTS.
Let's remove the support now, before releasing a new LTS.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>