### PR TITLE
Bluetooth: Mesh: Fix missing destructor function

### DIFF
--- a/subsys/bluetooth/mesh/adv.c
+++ b/subsys/bluetooth/mesh/adv.c
@@ -40,7 +40,7 @@ const uint8_t bt_mesh_adv_type[BT_MESH_ADV_TYPES] = {
 
 K_FIFO_DEFINE(bt_mesh_adv_queue);
 
-static void adv_buf_destroy(struct net_buf *buf)
+void bt_mesh_adv_buf_destroy(struct net_buf *buf)
 {
 	struct bt_mesh_adv adv = *BT_MESH_ADV(buf);
 
@@ -50,7 +50,8 @@ static void adv_buf_destroy(struct net_buf *buf)
 }
 
 NET_BUF_POOL_DEFINE(adv_buf_pool, CONFIG_BT_MESH_ADV_BUF_COUNT,
-		    BT_MESH_ADV_DATA_SIZE, BT_MESH_ADV_USER_DATA_SIZE, adv_buf_destroy);
+		    BT_MESH_ADV_DATA_SIZE, BT_MESH_ADV_USER_DATA_SIZE,
+		    bt_mesh_adv_buf_destroy);
 
 static struct bt_mesh_adv adv_pool[CONFIG_BT_MESH_ADV_BUF_COUNT];
 

--- a/subsys/bluetooth/mesh/adv.h
+++ b/subsys/bluetooth/mesh/adv.h
@@ -46,6 +46,8 @@ extern struct k_fifo bt_mesh_adv_queue;
 /* Lookup table for Advertising data types for bt_mesh_adv_type: */
 extern const uint8_t bt_mesh_adv_type[BT_MESH_ADV_TYPES];
 
+void bt_mesh_adv_buf_destroy(struct net_buf *buf);
+
 /* xmit_count: Number of retransmissions, i.e. 0 == 1 transmission */
 struct net_buf *bt_mesh_adv_create(enum bt_mesh_adv_type type, uint8_t xmit,
 				   k_timeout_t timeout);

--- a/subsys/bluetooth/mesh/friend.c
+++ b/subsys/bluetooth/mesh/friend.c
@@ -52,7 +52,7 @@ struct friend_pdu_info {
 };
 
 NET_BUF_POOL_FIXED_DEFINE(friend_buf_pool, FRIEND_BUF_COUNT,
-			  BT_MESH_ADV_DATA_SIZE, NULL);
+			  BT_MESH_ADV_DATA_SIZE, bt_mesh_adv_buf_destroy);
 
 static struct friend_adv {
 	struct bt_mesh_adv adv;


### PR DESCRIPTION
Zephyr Bluetooth Mesh move adv send cb to buf destructor
callback in PR(https://github.com/zephyrproject-rtos/zephyr/pull/35702), There are two net_buf_pool define, one to adv.c
and one to friend.c, we are missing define destructor in friend.c.

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>