### PR TITLE
drivers: gicv3: set SPI's affinity when it is enabled

### DIFF
--- a/drivers/interrupt_controller/intc_gicv3.c
+++ b/drivers/interrupt_controller/intc_gicv3.c
@@ -84,6 +84,17 @@ void arm_gic_irq_enable(unsigned int intid)
 	uint32_t idx = intid / GIC_NUM_INTR_PER_REG;
 
 	sys_write32(mask, ISENABLER(GET_DIST_BASE(intid), idx));
+
+#ifdef CONFIG_ARMV8_A_NS
+	/*
+	 * Affinity routing is enabled for Non-secure state (GICD_CTLR.ARE_NS
+	 * is set to '1' when GIC distributor is initialized) ,so need to set
+	 * SPI's affinity, now set it to be the PE on which it is enabled.
+	 */
+	if (GIC_IS_SPI(intid))
+		sys_write64(MPIDR_TO_CORE(GET_MPIDR()),
+				IROUTER(GET_DIST_BASE(intid), intid));
+#endif
 }
 
 void arm_gic_irq_disable(unsigned int intid)

--- a/drivers/interrupt_controller/intc_gicv3_priv.h
+++ b/drivers/interrupt_controller/intc_gicv3_priv.h
@@ -47,4 +47,8 @@
 #define GICR_WAKER_PS			1
 #define GICR_WAKER_CA			2
 
+/* GITCD_IROUTER */
+#define GIC_DIST_IROUTER		0x6000
+#define IROUTER(base, n)		(base + GIC_DIST_IROUTER + (n) * 8)
+
 #endif /* ZEPHYR_INCLUDE_DRIVERS_INTC_GICV3_PRIV_H_ */

--- a/include/arch/arm64/sys_io.h
+++ b/include/arch/arm64/sys_io.h
@@ -81,6 +81,22 @@ static ALWAYS_INLINE void sys_write32(uint32_t data, mem_addr_t addr)
 	__asm__ volatile("str %w0, [%1]" : : "r" (data), "r" (addr));
 }
 
+static ALWAYS_INLINE uint64_t sys_read64(mem_addr_t addr)
+{
+	uint64_t val;
+
+	__asm__ volatile("ldr %x0, [%1]" : "=r" (val) : "r" (addr));
+
+	__DMB();
+	return val;
+}
+
+static ALWAYS_INLINE void sys_write64(uint64_t data, mem_addr_t addr)
+{
+	__DMB();
+	__asm__ volatile("str %x0, [%1]" : : "r" (data), "r" (addr));
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/drivers/interrupt_controller/gic.h
+++ b/include/drivers/interrupt_controller/gic.h
@@ -228,6 +228,11 @@
 
 #define GIC_SPI_INT_BASE		32
 
+#define GIC_SPI_MAX_INTID		1019
+
+#define GIC_IS_SPI(intid)		(((intid) >= GIC_SPI_INT_BASE) && \
+					((intid) <= GIC_SPI_MAX_INTID))
+
 #define GIC_NUM_INTR_PER_REG		32
 
 #define GIC_NUM_CFG_PER_REG		16


### PR DESCRIPTION
When affinity routing is enabled for Non-secure state
( GICD_CTLR.ARE_NS is '1'), need to set routing information
for the SPI interrupt.

Signed-off-by: Jiafei Pan <Jiafei.Pan@nxp.com>