### PR TITLE
boards: 96b_wistrio: use GPIO API to configure pull-up

### DIFF
--- a/boards/arm/96b_wistrio/CMakeLists.txt
+++ b/boards/arm/96b_wistrio/CMakeLists.txt
@@ -1,4 +1,2 @@
-if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-endif()

--- a/boards/arm/96b_wistrio/CMakeLists.txt
+++ b/boards/arm/96b_wistrio/CMakeLists.txt
@@ -1,2 +1,2 @@
 zephyr_library()
-zephyr_library_sources(pinmux.c)
+zephyr_library_sources(pins.c)

--- a/boards/arm/96b_wistrio/pinmux.c
+++ b/boards/arm/96b_wistrio/pinmux.c
@@ -8,26 +8,12 @@
 #include <drivers/gpio.h>
 #include <init.h>
 #include <kernel.h>
-#include <drivers/pinmux.h>
 #include <sys/sys_io.h>
-
-#include <pinmux/pinmux_stm32.h>
-
-static const struct pin_config pinconf[] = {
-	/* RF_CTX_PA */
-	{STM32_PIN_PA4, STM32_PUSHPULL_PULLUP},
-	/* RF_CRX_RX */
-	{STM32_PIN_PB6, STM32_PUSHPULL_PULLUP},
-	/* RF_CBT_HF */
-	{STM32_PIN_PB7, STM32_PUSHPULL_PULLUP},
-};
 
 static int pinmux_stm32_init(const struct device *port)
 {
 	ARG_UNUSED(port);
 	const struct device *gpioa, *gpiob, *gpioh;
-
-	stm32_setup_pins(pinconf, ARRAY_SIZE(pinconf));
 
 	gpioa = device_get_binding(DT_LABEL(DT_NODELABEL(gpioa)));
 	if (!gpioa) {
@@ -44,13 +30,16 @@ static int pinmux_stm32_init(const struct device *port)
 		return -ENODEV;
 	}
 
-	gpio_pin_configure(gpioa, 4, GPIO_OUTPUT);
+	/* RF_CTX_PA */
+	gpio_pin_configure(gpioa, 4, GPIO_OUTPUT | GPIO_PULL_UP);
 	gpio_pin_set(gpioa, 4, 1);
 
-	gpio_pin_configure(gpiob, 6, GPIO_OUTPUT);
+	/* RF_CRX_RX */
+	gpio_pin_configure(gpiob, 6, GPIO_OUTPUT | GPIO_PULL_UP);
 	gpio_pin_set(gpiob, 6, 1);
 
-	gpio_pin_configure(gpiob, 7, GPIO_OUTPUT);
+	/* RF_CBT_HF */
+	gpio_pin_configure(gpiob, 7, GPIO_OUTPUT | GPIO_PULL_UP);
 	gpio_pin_set(gpiob, 7, 0);
 
 	gpio_pin_configure(gpioh, 1, GPIO_OUTPUT);

--- a/boards/arm/96b_wistrio/pins.c
+++ b/boards/arm/96b_wistrio/pins.c
@@ -10,7 +10,7 @@
 #include <kernel.h>
 #include <sys/sys_io.h>
 
-static int pinmux_stm32_init(const struct device *port)
+static int pins_stm32_init(const struct device *port)
 {
 	ARG_UNUSED(port);
 	const struct device *gpioa, *gpiob, *gpioh;
@@ -49,4 +49,4 @@ static int pinmux_stm32_init(const struct device *port)
 }
 
 /* Need to be initialised after GPIO driver */
-SYS_INIT(pinmux_stm32_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+SYS_INIT(pins_stm32_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);


### PR DESCRIPTION
Some minor cleanups found while doing an initial port of the STM32 pinmux driver to the #37572 API.

```
boards: 96b_wistrio: use GPIO API to configure pull-up

The internal pinmux API was being used to setup GPIO pull-ups, however,
this can be done using the standard GPIO API.
```
```
boards: 96b_wistrio: rename pinmux board file

The name pinmux is misleading, since no actual pinmuxing is done (just
pull-up setup).
```