### PR TITLE
Bluetooth: Audio: Rename broadcaster and make opaque type

### DIFF
--- a/include/bluetooth/audio.h
+++ b/include/bluetooth/audio.h
@@ -50,6 +50,9 @@ struct bt_audio_endpoint;
 /** @brief Abstract Audio Broadcast Sink structure. */
 struct bt_audio_broadcast_sink;
 
+/** @brief Abstract Audio Broadcast Source structure. */
+struct bt_audio_broadcast_source;
+
 /** @brief Codec configuration structure */
 struct bt_codec_data {
 	struct bt_data data;
@@ -590,8 +593,8 @@ struct bt_audio_capability_ops {
 	/** @brief Scan terminated callback
 	 *
 	 *  Scan terminated callback is called whenever a scan started by
-	 *  bt_audio_broadcaster_scan_start is terminated before
-	 *  bt_audio_broadcaster_scan_stop.
+	 *  bt_audio_broadcast_scan_start() is terminated before
+	 *  bt_audio_broadcast_scan_stop().
 	 *
 	 *  Typical reasons for this are that the periodic advertising has
 	 *  synchronized (success criteria) or the scan timed out.
@@ -607,7 +610,7 @@ struct bt_audio_capability_ops {
 	 *  The periodic advertising synchronization lost callback is called if
 	 *  the periodic advertising sync is lost. If this happens, the sink
 	 *  object is released. To synchronize to the broadcaster again,
-	 *  bt_audio_broadcaster_scan_start  must be called.
+	 *  bt_audio_broadcast_scan_start() must be called.
 	 *
 	 *  @param sink          Pointer to the sink structure.
 	 */
@@ -986,9 +989,9 @@ int bt_audio_chan_send(struct bt_audio_chan *chan, struct net_buf *buf);
  *
  *  @return Zero on success or (negative) error code otherwise.
  */
-int bt_audio_broadcaster_create(struct bt_audio_chan *chan,
-				struct bt_codec *codec,
-				struct bt_codec_qos *qos);
+int bt_audio_broadcast_source_create(struct bt_audio_chan *chan,
+				     struct bt_codec *codec,
+				     struct bt_codec_qos *qos);
 
 /** @brief Start scan for broadcast sources.
  *
@@ -1002,7 +1005,7 @@ int bt_audio_broadcaster_create(struct bt_audio_chan *chan,
  *
  *  @return Zero on success or (negative) error code otherwise.
  */
-int bt_audio_broadcaster_scan_start(const struct bt_le_scan_param *param);
+int bt_audio_broadcast_scan_start(const struct bt_le_scan_param *param);
 
 /**
  * @brief Stop scan for broadcast sources.
@@ -1011,7 +1014,7 @@ int bt_audio_broadcaster_scan_start(const struct bt_le_scan_param *param);
  *
  *  @return Zero on success or (negative) error code otherwise.
  */
-int bt_audio_broadcaster_scan_stop(void);
+int bt_audio_broadcast_scan_stop(void);
 
 /** @brief Sync to a broadcaster's audio
  *

--- a/subsys/bluetooth/host/audio/bass_client.c
+++ b/subsys/bluetooth/host/audio/bass_client.c
@@ -480,7 +480,7 @@ static int bt_bass_client_common_cp(struct bt_conn *conn, const struct net_buf_s
 }
 
 
-static bool broadcaster_found(struct bt_data *data, void *user_data)
+static bool broadcast_source_found(struct bt_data *data, void *user_data)
 {
 	const struct bt_le_scan_recv_info *info = user_data;
 	struct bt_uuid_16 adv_uuid;
@@ -521,7 +521,7 @@ void scan_recv(const struct bt_le_scan_recv_info *info, struct net_buf_simple *a
 		return;
 	}
 
-	bt_data_parse(ad, broadcaster_found, (void *)info);
+	bt_data_parse(ad, broadcast_source_found, (void *)info);
 }
 
 static struct bt_le_scan_cb scan_cb = {

--- a/subsys/bluetooth/host/audio/endpoint.h
+++ b/subsys/bluetooth/host/audio/endpoint.h
@@ -33,7 +33,7 @@ struct bt_audio_ep_cb {
 #define BT_AUDIO_EP_LOCAL	0x00
 #define BT_AUDIO_EP_REMOTE	0x01
 
-struct bt_audio_broadcaster {
+struct bt_audio_broadcast_source {
 	uint8_t bis_count;
 	uint8_t subgroup_count;
 	uint32_t pd; /** QoS Presentation Delay */
@@ -81,7 +81,7 @@ struct bt_audio_ep {
 
 	/* Broadcast fields */
 	/* TODO: Create a union to reduce memory usage */
-	struct bt_audio_broadcaster *broadcaster;
+	struct bt_audio_broadcast_source *broadcast_source;
 	struct bt_audio_broadcast_sink *broadcast_sink;
 };
 

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/broadcast_sink_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/broadcast_sink_test.c
@@ -36,7 +36,7 @@ static void pa_synced_cb(struct bt_audio_broadcast_sink *sink,
 			 struct bt_le_per_adv_sync *sync,
 			 uint32_t broadcast_id)
 {
-	printk("PA synced to broadcaster %p with broadcast ID 0x%06X\n",
+	printk("PA synced for broadcast sink %p with broadcast ID 0x%06X\n",
 	       sink, broadcast_id);
 
 	SET_FLAG(pa_synced);
@@ -49,7 +49,7 @@ static void base_recv_cb(struct bt_audio_broadcast_sink *sink,
 		return;
 	}
 
-	printk("Received BASE with %u subgroups from broadcaster %p\n",
+	printk("Received BASE with %u subgroups from broadcast sink %p\n",
 	       base->subgroup_count, sink);
 
 	SET_FLAG(base_received);
@@ -109,7 +109,7 @@ static void test_main(void)
 	UNSET_FLAG(base_received);
 	UNSET_FLAG(pa_synced);
 	printk("Scanning for broadcast sources\n");
-	err = bt_audio_broadcaster_scan_start(BT_LE_SCAN_ACTIVE);
+	err = bt_audio_broadcast_scan_start(BT_LE_SCAN_ACTIVE);
 	if (err != 0) {
 		FAIL("Unable to start scan for broadcast sources: %d", err);
 		return;

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/broadcast_source_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/broadcast_source_test.c
@@ -39,7 +39,7 @@ static void test_main(void)
 			   BT_CODEC_LC3_CONFIG_48_2,
 			   BT_CODEC_LC3_QOS_10_OUT_UNFRAMED(100u, 23u, 60u,
 							    40000u));
-	struct bt_audio_chan broadcast_chans[BROADCAST_STREAM_CNT];
+	struct bt_audio_chan broadcast_source_chans[BROADCAST_STREAM_CNT];
 
 	err = bt_enable(NULL);
 	if (err) {
@@ -50,23 +50,23 @@ static void test_main(void)
 	printk("Bluetooth initialized\n");
 
 	/* Link all channels */
-	memset(broadcast_chans, 0, sizeof(broadcast_chans));
-	for (int i = 0; i < ARRAY_SIZE(broadcast_chans); i++) {
-		for (int j = i + 1; j < ARRAY_SIZE(broadcast_chans); j++) {
-			bt_audio_chan_link(&broadcast_chans[i],
-					   &broadcast_chans[j]);
+	memset(broadcast_source_chans, 0, sizeof(broadcast_source_chans));
+	for (int i = 0; i < ARRAY_SIZE(broadcast_source_chans); i++) {
+		for (int j = i + 1; j < ARRAY_SIZE(broadcast_source_chans); j++) {
+			bt_audio_chan_link(&broadcast_source_chans[i],
+					   &broadcast_source_chans[j]);
 		}
 	}
 
-	err = bt_audio_broadcaster_create(&broadcast_chans[0],
-					  &preset_48_1_2.codec,
-					  &preset_48_1_2.qos);
+	err = bt_audio_broadcast_source_create(&broadcast_source_chans[0],
+					       &preset_48_1_2.codec,
+					       &preset_48_1_2.qos);
 	if (err != 0) {
-		FAIL("Unable to create broadcaster: %d", err);
+		FAIL("Unable to create broadcast source: %d", err);
 		return;
 	}
 
-	err = bt_audio_chan_reconfig(&broadcast_chans[0], NULL,
+	err = bt_audio_chan_reconfig(&broadcast_source_chans[0], NULL,
 				     &preset_48_2_2.codec);
 	if (err != 0) {
 		FAIL("Unable to reconfigure broadcast source: %d", err);
@@ -75,13 +75,13 @@ static void test_main(void)
 
 	k_sleep(K_SECONDS(10));
 
-	err = bt_audio_chan_release(&broadcast_chans[0], false);
+	err = bt_audio_chan_release(&broadcast_source_chans[0], false);
 	if (err != 0) {
 		FAIL("Unable to release broadcast channels: %d", err);
 		return;
 	}
 
-	PASS("Broadcaster passed\n");
+	PASS("Broadcast source passed\n");
 }
 
 static const struct bst_test_instance test_broadcast_source[] = {


### PR DESCRIPTION
Rename `broadcaster` to `broadcast_source` to be more
similar to broadcast sink.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>