### PR TITLE
kconfig: add names to some choices

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -272,7 +272,7 @@ config NATIVE_APPLICATION
 	  Build as a native application that can run on the host and using
 	  resources and libraries provided by the host.
 
-choice
+choice COMPILER_OPTIMIZATIONS
 	prompt "Optimization level"
 	default NO_OPTIMIZATIONS    if COVERAGE
 	default DEBUG_OPTIMIZATIONS if DEBUG

--- a/subsys/fs/Kconfig.fatfs
+++ b/subsys/fs/Kconfig.fatfs
@@ -65,7 +65,7 @@ config FS_FATFS_LFN
 
 if FS_FATFS_LFN
 
-choice
+choice FS_FATFS_LFN_MODE
 	prompt "LFN memory mode"
 	default FS_FATFS_LFN_MODE_BSS
 

--- a/subsys/logging/Kconfig.backends
+++ b/subsys/logging/Kconfig.backends
@@ -19,7 +19,7 @@ config LOG_BACKEND_UART_OUTPUT_DICTIONARY
 	help
 	  UART backend is in dictionary-based logging output mode.
 
-choice
+choice LOG_BACKEND_UART_OUTPUT
 	prompt "UART Backend Output Mode"
 	default LOG_BACKEND_UART_OUTPUT_TEXT
 
@@ -99,7 +99,7 @@ config LOG_BACKEND_RTT
 
 if LOG_BACKEND_RTT
 
-choice
+choice LOG_BACKEND_RTT_MODE
 	prompt "Logger behavior"
 	default LOG_BACKEND_RTT_MODE_BLOCK
 
@@ -315,7 +315,7 @@ config LOG_BACKEND_FS_OUTPUT_DICTIONARY
 	help
 	  FS backend is in dictionary-based logging output mode.
 
-choice
+choice LOG_BACKEND_FS_OUTPUT
 	prompt "FS Backend Output Mode"
 	default LOG_BACKEND_FS_OUTPUT_TEXT
 

--- a/subsys/pm/policy/Kconfig
+++ b/subsys/pm/policy/Kconfig
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-choice
+choice PM_POLICY
 	prompt "Idle State Power Management Policy"
 	help
 	  Select the idle state power management policy.


### PR DESCRIPTION
So the issue I've been having is that I am unable to make choices from other Kconfig files via select or making a Kconfig.defconfig ish file with the same choice name. I guess you're supposed to make choices in the prj.conf file, however I'm having many different builds and some choices depends on my application's Kconfig symbols, making the staticness of prj.conf files unfeasible. With named choices, you can influence choices in a Kconfig.defconfig ish file.

I guess I'm stirring the pot here because [this](https://github.com/zephyrproject-rtos/zephyr/issues/31824) issue is suggesting to add names to all choices, however no activity in over 6 month.

This is literally the only pain I'm having (at the moment) with Kconfig, DTS & CMake, which is pretty cool in itself because these three tools solve a very complex problem which is hardware independence, and application modularity and dependencies.