### PR TITLE
boards: arm: stm32f303 disco DTS supports uart4

### DIFF
--- a/boards/arm/stm32f3_disco/doc/index.rst
+++ b/boards/arm/stm32f3_disco/doc/index.rst
@@ -134,6 +134,8 @@ Default Zephyr Peripheral Mapping:
 - UART_1_RX : PC5
 - UART_2_TX : PA2
 - UART_2_RX : PA3
+- UART_4_TX : PC10
+- UART_4_RX : PC11
 - I2C1_SCL : PB6
 - I2C1_SDA : PB7
 - I2C2_SCL : PA9

--- a/boards/arm/stm32f3_disco/stm32f3_disco.dts
+++ b/boards/arm/stm32f3_disco/stm32f3_disco.dts
@@ -104,6 +104,12 @@
 	status = "okay";
 };
 
+&uart4 {
+	pinctrl-0 = <&uart4_tx_pc10 &uart4_rx_pc11>;
+	current-speed = <115200>;
+	status = "okay";
+};
+
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	status = "okay";

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -198,6 +198,15 @@
 			label = "UART_3";
 		};
 
+		uart4: serial@40004c00 {
+			compatible = "st,stm32-uart";
+			reg = <0x40004c00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00080000>;
+			interrupts = <52 0>;
+			status = "disabled";
+			label = "UART_4";
+		};
+
 		i2c1: i2c@40005400 {
 			compatible = "st,stm32-i2c-v2";
 			clock-frequency = <I2C_BITRATE_STANDARD>;


### PR DESCRIPTION
This adds the uart4 device to the stm32f3_disco board
based on the stm32f303 device from STMicroelectronics

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/38273

Signed-off-by: Francois Ramu <francois.ramu@st.com>