### PR TITLE
Bluetooth: Audio: Fix vcs_client_test duplicate conn_callbacks

### DIFF
--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_client_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_client_test.c
@@ -15,7 +15,6 @@
 #define VOCS_DESC_SIZE 64
 #define AICS_DESC_SIZE 64
 
-static struct bt_conn_cb conn_callbacks;
 extern enum bst_result_t bst_result;
 
 static struct bt_vcs *vcs;


### PR DESCRIPTION
The conn_callbacks was duplicated in the file, due to a missing
delete when BT_CONN_CB_DEFINE was introduced.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>