### PR TITLE
Bluetooth: Mesh: Fix adv send end callback

### DIFF
--- a/subsys/bluetooth/mesh/adv.c
+++ b/subsys/bluetooth/mesh/adv.c
@@ -42,11 +42,7 @@ K_FIFO_DEFINE(bt_mesh_adv_queue);
 
 static void adv_buf_destroy(struct net_buf *buf)
 {
-	struct bt_mesh_adv adv = *BT_MESH_ADV(buf);
-
 	net_buf_destroy(buf);
-
-	bt_mesh_adv_send_end(0, &adv);
 }
 
 NET_BUF_POOL_DEFINE(adv_buf_pool, CONFIG_BT_MESH_ADV_BUF_COUNT,

--- a/subsys/bluetooth/mesh/adv.h
+++ b/subsys/bluetooth/mesh/adv.h
@@ -91,9 +91,10 @@ static inline void bt_mesh_adv_send_start(uint16_t duration, int err,
 }
 
 static inline void bt_mesh_adv_send_end(
-	int err, struct bt_mesh_adv const *adv)
+	int err, struct bt_mesh_adv *adv)
 {
 	if (adv->started && adv->cb && adv->cb->end) {
+		adv->started = 0;
 		adv->cb->end(err, adv->cb_data);
 	}
 }

--- a/subsys/bluetooth/mesh/adv_legacy.c
+++ b/subsys/bluetooth/mesh/adv_legacy.c
@@ -119,6 +119,8 @@ static inline void adv_send(struct net_buf *buf)
 		return;
 	}
 
+	bt_mesh_adv_send_end(err, BT_MESH_ADV(buf));
+
 	BT_DBG("Advertising stopped (%u ms)", (uint32_t) k_uptime_delta(&time));
 }
 


### PR DESCRIPTION
Friend feature relies on start/end callbacks in advertising and
adv_legacy backend was missing a call to bt_mesh_adv_send_end().

adv->started flag was not cleared in bt_mesh_adv_send_end().

Signed-off-by: Michał Narajowski michal.narajowski@codecoup.pl