### PR TITLE
testsuite ends properly when testing  stm32wb55 with PM

### DIFF
--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -427,6 +427,9 @@ void end_report(void)
 	} else {
 		TC_END_REPORT(TC_PASS);
 	}
+#ifdef CONFIG_STM32_LPTIM_TIMER
+	k_busy_wait(100);
+#endif /* CONFIG_STM32_LPTIM_TIMER */
 }
 
 #ifdef CONFIG_USERSPACE


### PR DESCRIPTION
On the stm32, when the PM is enabled, the Kernel is ticked by the LPTIMER.
When the PM is enabled, then the stm32 UART  has its own PM_DEVICE. Entering/Exiting the PM is controlled by the `uart_stm32_pm_control()` function. The the PM_DEVICE Action is to enter low power mode, with PM_DEVICE_ACTION_LOW_POWER or PM_DEVICE_ACTION_SUSPEND

If not delayed, the end_report() the twister is not really ended, the  `PROJECT EXECUTION SUCCESSFUL` is missing.
With this short delay, the twister ends with the expected  `PROJECT EXECUTION SUCCESSFUL`

Signed-off-by: Francois Ramu <francois.ramu@st.com>