### PR TITLE
scripts: runners: openocd: Fix empty search path

### DIFF
--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -47,8 +47,9 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
                     search_args.append('-s')
                     search_args.append(path.dirname(i))
 
-        for p in cfg.openocd_search:
-            search_args.extend(['-s', p])
+        if cfg.openocd_search is not None:
+            for p in cfg.openocd_search:
+                search_args.extend(['-s', p])
         self.openocd_cmd = [cfg.openocd] + search_args
         # openocd doesn't cope with Windows path names, so convert
         # them to POSIX style just to be sure.


### PR DESCRIPTION
When enable thread awareness feature for OpenOCD the search path was converted to a list.  In some environments OPENOCD_DEFAULT_PATH may not be defined.  That create an empty search path list system fails. This add a test to skips fill search_args with openocd_search values when list is empty.

Fixes #38272.

Signed-off-by: Gerson Fernando Budke <nandojve@gmail.com>