### PR TITLE
drivers/sensor: lps22hh: Fix int32 overflow in the val2 part

### DIFF
--- a/drivers/sensor/lps22hh/lps22hh.c
+++ b/drivers/sensor/lps22hh/lps22hh.c
@@ -62,7 +62,11 @@ static inline void lps22hh_press_convert(struct sensor_value *val,
 	/* Also convert hPa into kPa */
 
 	val->val1 = press_tmp / 40960;
-	val->val2 = (press_tmp % 40960) * 1000000 / 40960;
+
+	/* For the decimal part use (3125 / 128) as a factor instead of
+	 * (1000000 / 40960) to avoid int32 overflow
+	 */
+	val->val2 = (press_tmp % 40960) * 3125 / 128;
 }
 
 static inline void lps22hh_temp_convert(struct sensor_value *val,


### PR DESCRIPTION
The val2 calculation was done using (1000000 / 40960) as
multiplying factor, which was sometimes leading to a
int32 overflow. So, let's use the equivalent (but smaller)
(3125 / 128).

Fixes #38090
