### PR TITLE
Changes to Modbus and sam0 in order to fix issue 38264. 

### DIFF
--- a/drivers/serial/uart_sam0.c
+++ b/drivers/serial/uart_sam0.c
@@ -757,6 +757,36 @@ static int uart_sam0_irq_tx_ready(const struct device *dev)
 	return regs->INTFLAG.bit.DRE != 0;
 }
 
+#ifdef CONFIG_MODBUS_SERIAL_USE_TXC
+static void uart_sam0_irq_txc_enable(const struct device *dev)
+{
+	SercomUsart * const regs = DEV_CFG(dev)->regs;
+
+	regs->INTENSET.reg = SERCOM_USART_INTENSET_TXC;
+}
+
+static void uart_sam0_irq_txc_disable(const struct device *dev)
+{
+	SercomUsart * const regs = DEV_CFG(dev)->regs;
+
+	regs->INTENCLR.reg = SERCOM_USART_INTENCLR_TXC;
+}
+
+static void uart_sam0_irq_txc_clear(const struct device *dev)
+{
+	SercomUsart * const regs = DEV_CFG(dev)->regs;
+
+	regs->INTFLAG.bit.TXC = 1;
+}
+
+static int uart_sam0_irq_txc_ready(const struct device *dev)
+{
+	SercomUsart * const regs = DEV_CFG(dev)->regs;
+
+	return (regs->INTFLAG.bit.TXC & regs->INTENSET.bit.TXC) != 0;
+}
+#endif
+
 static void uart_sam0_irq_rx_enable(const struct device *dev)
 {
 	SercomUsart * const regs = DEV_CFG(dev)->regs;
@@ -1133,6 +1163,12 @@ static const struct uart_driver_api uart_sam0_driver_api = {
 	.irq_tx_enable = uart_sam0_irq_tx_enable,
 	.irq_tx_disable = uart_sam0_irq_tx_disable,
 	.irq_tx_ready = uart_sam0_irq_tx_ready,
+#if CONFIG_MODBUS_SERIAL_USE_TXC	
+	.irq_txc_enable = uart_sam0_irq_txc_enable,
+	.irq_txc_disable = uart_sam0_irq_txc_disable,
+	.irq_txc_ready = uart_sam0_irq_txc_ready,
+	.irq_txc_clear = uart_sam0_irq_txc_clear,
+#endif	
 	.irq_rx_enable = uart_sam0_irq_rx_enable,
 	.irq_rx_disable = uart_sam0_irq_rx_disable,
 	.irq_rx_ready = uart_sam0_irq_rx_ready,

--- a/include/drivers/uart.h
+++ b/include/drivers/uart.h
@@ -399,6 +399,20 @@ __subsystem struct uart_driver_api {
 	/** Interrupt driven transfer ready function */
 	int (*irq_tx_ready)(const struct device *dev);
 
+	#ifdef CONFIG_MODBUS_SERIAL_USE_TXC
+	/** Interrupt driven transfer complete enabling function */
+	void (*irq_txc_enable)(const struct device *dev);
+
+	/** Interrupt driven transfer complete disabling function */
+	void (*irq_txc_disable)(const struct device *dev);
+
+	/** Interrupt driven transfer complete ready function */
+	int (*irq_txc_ready)(const struct device *dev);
+
+	/** Interrupt driven transfer complete clearing function */
+	void (*irq_txc_clear)(const struct device *dev);
+#endif
+
 	/** Interrupt driven receiver enabling function */
 	void (*irq_rx_enable)(const struct device *dev);
 
@@ -897,6 +911,97 @@ static inline int uart_irq_tx_ready(const struct device *dev)
 
 	return 0;
 }
+
+#ifdef CONFIG_MODBUS_SERIAL_USE_TXC
+/**
+ * @brief Enable TXC interrupt in IER.
+ *
+ * @param dev UART device structure.
+ *
+ * @return N/A
+ */
+__syscall void uart_irq_txc_enable(const struct device *dev);
+
+static inline void z_impl_uart_irq_txc_enable(const struct device *dev)
+{
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	const struct uart_driver_api *api =
+		(const struct uart_driver_api *)dev->api;
+
+	if (api->irq_txc_enable != NULL) {
+		api->irq_txc_enable(dev);
+	}
+#endif
+}
+/**
+ * @brief Disable TXC interrupt in IER.
+ *
+ * @param dev UART device structure.
+ *
+ * @return N/A
+ */
+__syscall void uart_irq_txc_disable(const struct device *dev);
+
+static inline void z_impl_uart_irq_txc_disable(const struct device *dev)
+{
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	const struct uart_driver_api *api =
+		(const struct uart_driver_api *)dev->api;
+
+	if (api->irq_txc_disable != NULL) {
+		api->irq_txc_disable(dev);
+	}
+#endif
+}
+/**
+ * @brief Clear TXC interrupt in IER.
+ *
+ * @param dev UART device structure.
+ *
+ * @return N/A
+ */
+__syscall void uart_irq_txc_clear(const struct device *dev);
+
+static inline void z_impl_uart_irq_txc_clear(const struct device *dev)
+{
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	const struct uart_driver_api *api =
+		(const struct uart_driver_api *)dev->api;
+
+	if (api->irq_txc_clear != NULL) {
+		api->irq_txc_clear(dev);
+	}
+#endif
+}
+
+/**
+ * @brief Check if UART TX has completed
+ *
+ * @details Check if UART TX has completed, buffer is empty i.e. all data has 
+ * been transmitted. This function must be called in a UART interrupt
+ * handler, or its result is undefined. Before calling this function
+ * in the interrupt handler, uart_irq_update() must be called once per
+ * the handler invocation.
+ *
+ * @param dev UART device structure.
+ *
+ * @retval 1 If the transmission is complete.
+ * @retval 0 Otherwise.
+ */
+static inline int uart_irq_txc_ready(const struct device *dev)
+{
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	const struct uart_driver_api *api =
+		(const struct uart_driver_api *)dev->api;
+
+	if (api->irq_txc_ready != NULL) {
+		return api->irq_txc_ready(dev);
+	}
+#endif
+
+	return 0;
+}
+#endif 
 
 /**
  * @brief Enable RX interrupt.

--- a/subsys/modbus/Kconfig
+++ b/subsys/modbus/Kconfig
@@ -32,6 +32,9 @@ config MODBUS_ROLE_CLIENT_SERVER
 
 endchoice
 
+config MODBUS_SERIAL_USE_TXC
+	bool "RS485 transmissionion completion support"
+
 config MODBUS_SERVER
 	bool
 	default y if MODBUS_ROLE_SERVER || MODBUS_ROLE_CLIENT_SERVER


### PR DESCRIPTION
…ow the de/re pin to be toggled correctly after all data has been transmitted. Bug was that the toggle was happening after the buffer was empty this lead to early toggle of the pin(s)

Signed-off-by: Gustav Karlsson <gkarlsson@karlssonrobotics.com>