### PR TITLE
RFC: drivers: modem: gsm_ppp: Optimizations and implement on/off

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -282,6 +282,7 @@
 /drivers/misc/ft8xx/                      @hubertmis
 /drivers/modem/hl7800.c                   @LairdCP/zephyr
 /drivers/modem/Kconfig.hl7800             @LairdCP/zephyr
+/drivers/modem/gsm_ppp.h                  @ycsin
 /drivers/pcie/                            @dcpleung @nashif @jhedberg
 /drivers/peci/                            @albertofloyd @franciscomunoz @scottwcpg
 /drivers/pinmux/*b91*                     @yurvyn

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -39,7 +39,7 @@ LOG_MODULE_REGISTER(modem_gsm, CONFIG_MODEM_LOG_LEVEL);
 #define GSM_RSSI_RETRIES                10
 #define GSM_RSSI_INVALID                -1000
 
-#if defined(CONFIG_MODEM_GSM_ENABLE_CESQ_RSSI)
+#if IS_ENABLED(CONFIG_MODEM_GSM_ENABLE_CESQ_RSSI)
 	#define GSM_RSSI_MAXVAL          0
 #else
 	#define GSM_RSSI_MAXVAL         -51
@@ -91,7 +91,7 @@ K_KERNEL_STACK_DEFINE(gsm_rx_stack, GSM_RX_STACK_SIZE);
 struct k_thread gsm_rx_thread;
 static struct k_work_delayable rssi_work_handle;
 
-#if defined(CONFIG_MODEM_GSM_ENABLE_CESQ_RSSI)
+#if IS_ENABLED(CONFIG_MODEM_GSM_ENABLE_CESQ_RSSI)
 	/* helper macro to keep readability */
 #define ATOI(s_, value_, desc_) modem_atoi(s_, value_, desc_, __func__)
 
@@ -120,7 +120,7 @@ static int modem_atoi(const char *s, const int err_value,
 
 	return ret;
 }
-#endif
+#endif /* IS_ENABLED(CONFIG_MODEM_GSM_ENABLE_CESQ_RSSI) */
 
 static void gsm_rx(struct gsm_modem *gsm)
 {
@@ -172,7 +172,7 @@ static int unquoted_atoi(const char *s, int base)
 MODEM_CMD_DEFINE(on_cmd_atcmdinfo_cops)
 {
 	if (argc >= 3) {
-#if defined(CONFIG_MODEM_CELL_INFO)
+#if IS_ENABLED(CONFIG_MODEM_CELL_INFO)
 		gsm.context.data_operator = unquoted_atoi(argv[2], 10);
 		LOG_INF("operator: %u",
 			gsm.context.data_operator);
@@ -187,7 +187,7 @@ MODEM_CMD_DEFINE(on_cmd_atcmdinfo_cops)
 	return 0;
 }
 
-#if defined(CONFIG_MODEM_SHELL)
+#if IS_ENABLED(CONFIG_MODEM_SHELL)
 #define MDM_MANUFACTURER_LENGTH  10
 #define MDM_MODEL_LENGTH         16
 #define MDM_REVISION_LENGTH      64
@@ -200,7 +200,7 @@ struct modem_info {
 	char mdm_model[MDM_MODEL_LENGTH];
 	char mdm_revision[MDM_REVISION_LENGTH];
 	char mdm_imei[MDM_IMEI_LENGTH];
-#if defined(CONFIG_MODEM_SIM_NUMBERS)
+#if IS_ENABLED(CONFIG_MODEM_SIM_NUMBERS)
 	char mdm_imsi[MDM_IMSI_LENGTH];
 	char mdm_iccid[MDM_ICCID_LENGTH];
 #endif
@@ -268,7 +268,7 @@ MODEM_CMD_DEFINE(on_cmd_atcmdinfo_imei)
 	return 0;
 }
 
-#if defined(CONFIG_MODEM_SIM_NUMBERS)
+#if IS_ENABLED(CONFIG_MODEM_SIM_NUMBERS)
 /* Handler: <IMSI> */
 MODEM_CMD_DEFINE(on_cmd_atcmdinfo_imsi)
 {
@@ -308,8 +308,7 @@ MODEM_CMD_DEFINE(on_cmd_atcmdinfo_iccid)
 }
 #endif /* CONFIG_MODEM_SIM_NUMBERS */
 
-#if defined(CONFIG_MODEM_CELL_INFO)
-
+#if IS_ENABLED(CONFIG_MODEM_CELL_INFO)
 /*
  * Handler: +CEREG: <n>[0],<stat>[1],<tac>[2],<ci>[3],<AcT>[4]
  */
@@ -352,7 +351,7 @@ static int gsm_query_cellinfo(struct gsm_modem *gsm)
 #endif /* CONFIG_MODEM_CELL_INFO */
 #endif /* CONFIG_MODEM_SHELL */
 
-#if defined(CONFIG_MODEM_GSM_ENABLE_CESQ_RSSI)
+#if IS_ENABLED(CONFIG_MODEM_GSM_ENABLE_CESQ_RSSI)
 /*
  * Handler: +CESQ: <rxlev>[0],<ber>[1],<rscp>[2],<ecn0>[3],<rsrq>[4],<rsrp>[5]
  */
@@ -402,15 +401,15 @@ MODEM_CMD_DEFINE(on_cmd_atcmdinfo_rssi_csq)
 
 	return 0;
 }
-#endif
+#endif /* CONFIG_MODEM_GSM_ENABLE_CESQ_RSSI */
 
-#if defined(CONFIG_MODEM_GSM_ENABLE_CESQ_RSSI)
+#if IS_ENABLED(CONFIG_MODEM_GSM_ENABLE_CESQ_RSSI)
 static const struct modem_cmd read_rssi_cmd =
 	MODEM_CMD("+CESQ:", on_cmd_atcmdinfo_rssi_cesq, 6U, ",");
 #else
 static const struct modem_cmd read_rssi_cmd =
 	MODEM_CMD("+CSQ:", on_cmd_atcmdinfo_rssi_csq, 2U, ",");
-#endif
+#endif /* CONFIG_MODEM_GSM_ENABLE_CESQ_RSSI */
 
 static const struct setup_cmd setup_cmds[] = {
 	/* no echo */
@@ -420,17 +419,17 @@ static const struct setup_cmd setup_cmds[] = {
 	/* extender errors in numeric form */
 	SETUP_CMD_NOHANDLE("AT+CMEE=1"),
 
-#if defined(CONFIG_MODEM_SHELL)
+#if IS_ENABLED(CONFIG_MODEM_SHELL)
 	/* query modem info */
 	SETUP_CMD("AT+CGMI", "", on_cmd_atcmdinfo_manufacturer, 0U, ""),
 	SETUP_CMD("AT+CGMM", "", on_cmd_atcmdinfo_model, 0U, ""),
 	SETUP_CMD("AT+CGMR", "", on_cmd_atcmdinfo_revision, 0U, ""),
-# if defined(CONFIG_MODEM_SIM_NUMBERS)
+# if IS_ENABLED(CONFIG_MODEM_SIM_NUMBERS)
 	SETUP_CMD("AT+CIMI", "", on_cmd_atcmdinfo_imsi, 0U, ""),
 	SETUP_CMD("AT+CCID", "", on_cmd_atcmdinfo_iccid, 0U, ""),
 # endif
 	SETUP_CMD("AT+CGSN", "", on_cmd_atcmdinfo_imei, 0U, ""),
-#endif
+#endif /* CONFIG_MODEM_SHELL */
 
 	/* disable unsolicited network registration codes */
 	SETUP_CMD_NOHANDLE("AT+CREG=0"),
@@ -552,24 +551,24 @@ static void set_ppp_carrier_on(struct gsm_modem *gsm)
 static void rssi_handler(struct k_work *work)
 {
 	int ret;
-#if defined(CONFIG_MODEM_GSM_ENABLE_CESQ_RSSI)
+#if IS_ENABLED(CONFIG_MODEM_GSM_ENABLE_CESQ_RSSI)
 	ret = modem_cmd_send_nolock(&gsm.context.iface, &gsm.context.cmd_handler,
 		&read_rssi_cmd, 1, "AT+CESQ", &gsm.sem_response, GSM_CMD_SETUP_TIMEOUT);
 #else
 	ret = modem_cmd_send_nolock(&gsm.context.iface, &gsm.context.cmd_handler,
 		&read_rssi_cmd, 1, "AT+CSQ", &gsm.sem_response, GSM_CMD_SETUP_TIMEOUT);
-#endif
+#endif /* CONFIG_MODEM_GSM_ENABLE_CESQ_RSSI */
 
 	if (ret < 0) {
 		LOG_DBG("No answer to RSSI readout, %s", "ignoring...");
 	}
 
-#if defined(CONFIG_GSM_MUX)
-#if defined(CONFIG_MODEM_CELL_INFO)
+#if IS_ENABLED(CONFIG_GSM_MUX)
+#if IS_ENABLED(CONFIG_MODEM_CELL_INFO)
 	(void) gsm_query_cellinfo(&gsm);
 #endif
 	k_work_reschedule(&rssi_work_handle, K_SECONDS(CONFIG_MODEM_GSM_RSSI_POLLING_PERIOD));
-#endif
+#endif /* CONFIG_GSM_MUX */
 
 }
 
@@ -587,7 +586,8 @@ static void gsm_finalize_connection(struct gsm_modem *gsm)
 		goto attaching;
 	}
 
-	if (IS_ENABLED(CONFIG_GSM_MUX) && gsm->mux_enabled) {
+#if IS_ENABLED(CONFIG_GSM_MUX)
+	if (gsm->mux_enabled) {
 		ret = modem_cmd_send_nolock(&gsm->context.iface,
 					    &gsm->context.cmd_handler,
 					    &response_cmds[0],
@@ -602,16 +602,17 @@ static void gsm_finalize_connection(struct gsm_modem *gsm)
 			return;
 		}
 	}
+#endif
 
-	if (IS_ENABLED(CONFIG_MODEM_GSM_FACTORY_RESET_AT_BOOT)) {
-		(void)modem_cmd_send_nolock(&gsm->context.iface,
-					    &gsm->context.cmd_handler,
-					    &response_cmds[0],
-					    ARRAY_SIZE(response_cmds),
-					    "AT&F", &gsm->sem_response,
-					    GSM_CMD_AT_TIMEOUT);
-		k_sleep(K_SECONDS(1));
-	}
+#if IS_ENABLED(CONFIG_MODEM_GSM_FACTORY_RESET_AT_BOOT)
+	(void)modem_cmd_send_nolock(&gsm->context.iface,
+				    &gsm->context.cmd_handler,
+				    &response_cmds[0],
+				    ARRAY_SIZE(response_cmds),
+				    "AT&F", &gsm->sem_response,
+				    GSM_CMD_AT_TIMEOUT);
+	k_sleep(K_SECONDS(1));
+#endif
 
 	ret = gsm_setup_mccmno(gsm);
 
@@ -674,24 +675,24 @@ attaching:
 
  attached:
 
-	if (!IS_ENABLED(CONFIG_GSM_MUX)) {
-		/* Read connection quality (RSSI) before PPP carrier is ON */
-		rssi_handler(NULL);
+#if !IS_ENABLED(CONFIG_GSM_MUX)
+	/* Read connection quality (RSSI) before PPP carrier is ON */
+	rssi_handler(NULL);
 
-		if (!(gsm->context.data_rssi && gsm->context.data_rssi != GSM_RSSI_INVALID &&
-			gsm->context.data_rssi < GSM_RSSI_MAXVAL)) {
+	if (!(gsm->context.data_rssi && gsm->context.data_rssi != GSM_RSSI_INVALID &&
+		gsm->context.data_rssi < GSM_RSSI_MAXVAL)) {
 
-			LOG_DBG("Not valid RSSI, %s", "retrying...");
-			if (gsm->rssi_retries-- > 0) {
-				(void)k_work_reschedule(&gsm->gsm_configure_work,
-							K_MSEC(GSM_RSSI_RETRY_DELAY_MSEC));
-				return;
-			}
+		LOG_DBG("Not valid RSSI, %s", "retrying...");
+		if (gsm->rssi_retries-- > 0) {
+			(void)k_work_reschedule(&gsm->gsm_configure_work,
+						K_MSEC(GSM_RSSI_RETRY_DELAY_MSEC));
+			return;
 		}
-#if defined(CONFIG_MODEM_CELL_INFO)
-		(void) gsm_query_cellinfo(gsm);
-#endif
 	}
+#if IS_ENABLED(CONFIG_MODEM_CELL_INFO)
+	(void) gsm_query_cellinfo(gsm);
+#endif
+#endif /* !IS_ENABLED(CONFIG_GSM_MUX) */
 
 	LOG_DBG("modem setup returned %d, %s", ret, "enable PPP");
 
@@ -710,7 +711,8 @@ attaching:
 
 	set_ppp_carrier_on(gsm);
 
-	if (IS_ENABLED(CONFIG_GSM_MUX) && gsm->mux_enabled) {
+#if IS_ENABLED(CONFIG_GSM_MUX)
+	if (gsm->mux_enabled) {
 		/* Re-use the original iface for AT channel */
 		ret = modem_iface_uart_init_dev(&gsm->context.iface,
 						gsm->at_dev);
@@ -736,6 +738,7 @@ attaching:
 		modem_cmd_handler_tx_unlock(&gsm->context.cmd_handler);
 		k_work_schedule(&rssi_work_handle, K_SECONDS(CONFIG_MODEM_GSM_RSSI_POLLING_PERIOD));
 	}
+#endif /* CONFIG_GSM_MUX */
 }
 
 static int mux_enable(struct gsm_modem *gsm)
@@ -760,7 +763,7 @@ static int mux_enable(struct gsm_modem *gsm)
 			"+CMUXSRVPORT=" STRINGIFY(DLCI_AT) ",1;"
 #else
 			"AT"
-#endif
+#endif /* SIMCOM_LTE */
 			"+CMUX=0,0,5,"
 			STRINGIFY(CONFIG_GSM_MUX_MRU_DEFAULT_LEN),
 			&gsm->sem_response,
@@ -940,8 +943,8 @@ static void gsm_configure(struct k_work *work)
 		return;
 	}
 
-	if (IS_ENABLED(CONFIG_GSM_MUX) && ret == 0 &&
-	    gsm->mux_enabled == false) {
+#if IS_ENABLED(CONFIG_GSM_MUX)
+	if (ret == 0 && gsm->mux_enabled == false) {
 
 		ret = mux_enable(gsm);
 		if (ret == 0) {
@@ -964,11 +967,11 @@ static void gsm_configure(struct k_work *work)
 
 			(void)k_work_reschedule(&gsm->gsm_configure_work,
 						K_NO_WAIT);
-			return;
 		}
 	}
-
+#else
 	gsm_finalize_connection(gsm);
+#endif /* CONFIG_GSM_MUX */
 }
 
 void gsm_ppp_start(const struct device *dev)
@@ -986,7 +989,7 @@ void gsm_ppp_start(const struct device *dev)
 	k_work_init_delayable(&gsm->gsm_configure_work, gsm_configure);
 	(void)k_work_reschedule(&gsm->gsm_configure_work, K_NO_WAIT);
 
-#if defined(CONFIG_GSM_MUX)
+#if IS_ENABLED(CONFIG_GSM_MUX)
 	k_work_init_delayable(&rssi_work_handle, rssi_handler);
 #endif
 }
@@ -998,14 +1001,14 @@ void gsm_ppp_stop(const struct device *dev)
 
 	net_if_l2(iface)->enable(iface, false);
 
-	if (IS_ENABLED(CONFIG_GSM_MUX)) {
-		/* Lower mux_enabled flag to trigger re-sending AT+CMUX etc */
-		gsm->mux_enabled = false;
+#if IS_ENABLED(CONFIG_GSM_MUX)
+	/* Lower mux_enabled flag to trigger re-sending AT+CMUX etc */
+	gsm->mux_enabled = false;
 
-		if (gsm->ppp_dev) {
-			uart_mux_disable(gsm->ppp_dev);
-		}
+	if (gsm->ppp_dev) {
+		uart_mux_disable(gsm->ppp_dev);
 	}
+#endif
 
 	if (modem_cmd_handler_tx_lock(&gsm->context.cmd_handler,
 				      K_SECONDS(10))) {
@@ -1037,13 +1040,13 @@ static int gsm_init(const struct device *dev)
 		return r;
 	}
 
-#if defined(CONFIG_MODEM_SHELL)
+#if IS_ENABLED(CONFIG_MODEM_SHELL)
 	/* modem information storage */
 	gsm->context.data_manufacturer = minfo.mdm_manufacturer;
 	gsm->context.data_model = minfo.mdm_model;
 	gsm->context.data_revision = minfo.mdm_revision;
 	gsm->context.data_imei = minfo.mdm_imei;
-#if defined(CONFIG_MODEM_SIM_NUMBERS)
+#if IS_ENABLED(CONFIG_MODEM_SIM_NUMBERS)
 	gsm->context.data_imsi = minfo.mdm_imsi;
 	gsm->context.data_iccid = minfo.mdm_iccid;
 #endif	/* CONFIG_MODEM_SIM_NUMBERS */

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -953,16 +953,15 @@ static void gsm_configure(struct k_work *work)
 
 		ret = mux_enable(gsm);
 		if (ret == 0) {
+			LOG_DBG("GSM muxing enabled");
 			gsm->mux_enabled = true;
 		} else {
+			LOG_DBG("GSM muxing disabled");
 			gsm->mux_enabled = false;
 			(void)k_work_reschedule(&gsm->gsm_configure_work,
 						K_NO_WAIT);
 			return;
 		}
-
-		LOG_DBG("GSM muxing %s", gsm->mux_enabled ? "enabled" :
-							    "disabled");
 
 		if (gsm->mux_enabled) {
 			gsm->state = STATE_INIT;

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -17,12 +17,15 @@ LOG_MODULE_REGISTER(modem_gsm, CONFIG_MODEM_LOG_LEVEL);
 #include <net/ppp.h>
 #include <drivers/gsm_ppp.h>
 #include <drivers/uart.h>
-#include <drivers/console/uart_mux.h>
 
 #include "modem_context.h"
 #include "modem_iface_uart.h"
 #include "modem_cmd_handler.h"
+
+#if IS_ENABLED(CONFIG_GSM_MUX)
+#include <drivers/console/uart_mux.h>
 #include "../console/gsm_mux.h"
+#endif
 
 #include <stdio.h>
 
@@ -80,7 +83,9 @@ static struct gsm_modem {
 
 	int rssi_retries;
 	int attach_retries;
+#if IS_ENABLED(CONFIG_GSM_MUX)
 	bool mux_enabled : 1;
+#endif
 	bool attached : 1;
 } gsm;
 
@@ -741,42 +746,42 @@ attaching:
 #endif /* CONFIG_GSM_MUX */
 }
 
+#if IS_ENABLED(CONFIG_GSM_MUX)
 static int mux_enable(struct gsm_modem *gsm)
 {
-	int ret;
+	int ret = 0;
 
 	/* Turn on muxing */
-	if (IS_ENABLED(CONFIG_MODEM_GSM_SIMCOM)) {
-		ret = modem_cmd_send_nolock(
-			&gsm->context.iface,
-			&gsm->context.cmd_handler,
-			&response_cmds[0],
-			ARRAY_SIZE(response_cmds),
+#if IS_ENABLED(CONFIG_MODEM_GSM_SIMCOM)
+	ret = modem_cmd_send_nolock(&gsm->context.iface,
+				    &gsm->context.cmd_handler,
+				    &response_cmds[0],
+				    ARRAY_SIZE(response_cmds),
 #if defined(SIMCOM_LTE)
-			/* FIXME */
-			/* Some SIMCOM modems can set the channels */
-			/* Control channel always at DLCI 0 */
-			"AT+CMUXSRVPORT=0,0;"
-			/* PPP should be at DLCI 1 */
-			"+CMUXSRVPORT=" STRINGIFY(DLCI_PPP) ",1;"
-			/* AT should be at DLCI 2 */
-			"+CMUXSRVPORT=" STRINGIFY(DLCI_AT) ",1;"
+				    /* FIXME */
+				    /* Some SIMCOM modems can set the channels */
+				    /* Control channel always at DLCI 0 */
+				    "AT+CMUXSRVPORT=0,0;"
+				    /* PPP should be at DLCI 1 */
+				    "+CMUXSRVPORT=" STRINGIFY(DLCI_PPP) ",1;"
+				    /* AT should be at DLCI 2 */
+				    "+CMUXSRVPORT=" STRINGIFY(DLCI_AT) ",1;"
 #else
-			"AT"
+				    "AT"
 #endif /* SIMCOM_LTE */
-			"+CMUX=0,0,5,"
-			STRINGIFY(CONFIG_GSM_MUX_MRU_DEFAULT_LEN),
-			&gsm->sem_response,
-			GSM_CMD_AT_TIMEOUT);
-	} else {
-		/* Generic GSM modem */
-		ret = modem_cmd_send_nolock(&gsm->context.iface,
-				     &gsm->context.cmd_handler,
-				     &response_cmds[0],
-				     ARRAY_SIZE(response_cmds),
-				     "AT+CMUX=0", &gsm->sem_response,
-				     GSM_CMD_AT_TIMEOUT);
-	}
+				    "+CMUX=0,0,5,"
+				    STRINGIFY(CONFIG_GSM_MUX_MRU_DEFAULT_LEN),
+				    &gsm->sem_response,
+				    GSM_CMD_AT_TIMEOUT);
+#else /* Generic modem */
+	/* Generic GSM modem */
+	ret = modem_cmd_send_nolock(&gsm->context.iface,
+				    &gsm->context.cmd_handler,
+				    &response_cmds[0],
+				    ARRAY_SIZE(response_cmds),
+				    "AT+CMUX=0", &gsm->sem_response,
+				    GSM_CMD_AT_TIMEOUT);
+#endif /* CONFIG_MODEM_GSM_SIMCOM */
 
 	if (ret < 0) {
 		LOG_ERR("AT+CMUX ret:%d", ret);
@@ -828,8 +833,7 @@ static void mux_setup(struct k_work *work)
 	/* We need to call this to reactivate mux ISR. Note: This is only called
 	 * after re-initing gsm_ppp.
 	 */
-	if (IS_ENABLED(CONFIG_GSM_MUX) &&
-	    gsm->ppp_dev && gsm->state == STATE_CONTROL_CHANNEL) {
+	if (gsm->ppp_dev && gsm->state == STATE_CONTROL_CHANNEL) {
 		uart_mux_enable(gsm->ppp_dev);
 	}
 
@@ -920,6 +924,7 @@ fail:
 	gsm->state = STATE_INIT;
 	gsm->mux_enabled = false;
 }
+#endif /* CONFIG_GSM_MUX */
 
 static void gsm_configure(struct k_work *work)
 {
@@ -1084,9 +1089,9 @@ static int gsm_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	if (IS_ENABLED(CONFIG_GSM_PPP_AUTOSTART)) {
-		gsm_ppp_start(dev);
-	}
+#if CONFIG_GSM_PPP_AUTOSTART
+	gsm_ppp_start(dev);
+#endif
 
 	return 0;
 }

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -81,8 +81,6 @@ static struct gsm_modem {
 	int rssi_retries;
 	int attach_retries;
 	bool mux_enabled : 1;
-	bool mux_setup_done : 1;
-	bool setup_done : 1;
 	bool attached : 1;
 } gsm;
 
@@ -710,8 +708,6 @@ attaching:
 		return;
 	}
 
-	gsm->setup_done = true;
-
 	set_ppp_carrier_on(gsm);
 
 	if (IS_ENABLED(CONFIG_GSM_MUX) && gsm->mux_enabled) {
@@ -946,7 +942,6 @@ static void gsm_configure(struct k_work *work)
 
 	if (IS_ENABLED(CONFIG_GSM_MUX) && ret == 0 &&
 	    gsm->mux_enabled == false) {
-		gsm->mux_setup_done = false;
 
 		ret = mux_enable(gsm);
 		if (ret == 0) {

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -601,7 +601,7 @@ static void gsm_finalize_connection(struct gsm_modem *gsm)
 				    "AT", &gsm->sem_response,
 				    GSM_CMD_AT_TIMEOUT);
 	if (ret < 0) {
-		LOG_ERR("modem setup returned %d, %s",
+		LOG_ERR("AT returned %d, %s",
 			ret, "retrying...");
 		(void)k_work_reschedule(&gsm->gsm_configure_work,
 					K_SECONDS(1));
@@ -622,7 +622,7 @@ static void gsm_finalize_connection(struct gsm_modem *gsm)
 	ret = gsm_setup_mccmno(gsm);
 
 	if (ret < 0) {
-		LOG_ERR("modem setup returned %d, %s",
+		LOG_ERR("gsm_setup_mccmno returned %d, %s",
 				ret, "retrying...");
 
 		(void)k_work_reschedule(&gsm->gsm_configure_work,
@@ -637,7 +637,7 @@ static void gsm_finalize_connection(struct gsm_modem *gsm)
 						  &gsm->sem_response,
 						  GSM_CMD_SETUP_TIMEOUT);
 	if (ret < 0) {
-		LOG_DBG("modem setup returned %d, %s",
+		LOG_DBG("setup_cmds returned %d, %s",
 			ret, "retrying...");
 		(void)k_work_reschedule(&gsm->gsm_configure_work, K_SECONDS(1));
 		return;
@@ -699,7 +699,7 @@ attaching:
 #endif
 #endif /* !IS_ENABLED(CONFIG_GSM_MUX) */
 
-	LOG_DBG("modem setup returned %d, %s", ret, "enable PPP");
+	LOG_DBG("modem RSSI: %d, %s", gsm->context.data_rssi, "enable PPP");
 
 	ret = modem_cmd_handler_setup_cmds_nolock(&gsm->context.iface,
 						  &gsm->context.cmd_handler,
@@ -708,7 +708,7 @@ attaching:
 						  &gsm->sem_response,
 						  GSM_CMD_SETUP_TIMEOUT);
 	if (ret < 0) {
-		LOG_DBG("modem setup returned %d, %s",
+		LOG_DBG("connect_cmds returned %d, %s",
 			ret, "retrying...");
 		(void)k_work_reschedule(&gsm->gsm_configure_work, K_SECONDS(1));
 		return;

--- a/drivers/modem/gsm_ppp.h
+++ b/drivers/modem/gsm_ppp.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2021 G-Technologies Sdn. Bhd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef GSM_PPP_H
+#define GSM_PPP_H
+
+#include <device.h>
+#include "modem_context.h"
+
+#define GSM_PPP_HAS_PWR_SRC DT_INST_NODE_HAS_PROP(0, power_src_gpios)
+#define GSM_PPP_HAS_PWR_KEY DT_INST_NODE_HAS_PROP(0, power_key_gpios)
+
+#if GSM_PPP_HAS_PWR_SRC || GSM_PPP_HAS_PWR_KEY
+/* pin settings */
+enum mdm_control_pins {
+#if GSM_PPP_HAS_PWR_SRC
+	GSM_PPP_MDM_PWR_SRC,
+#endif
+#if GSM_PPP_HAS_PWR_KEY
+	GSM_PPP_MDM_PWR_KEY,
+#endif
+};
+
+/* Modem pins - Power, Reset & others. */
+static struct modem_pin modem_pins[] = {
+#if GSM_PPP_HAS_PWR_SRC
+	/* MDM_POWER SUPPLY */
+	MODEM_PIN(DT_INST_GPIO_LABEL(0, power_src_gpios), DT_INST_GPIO_PIN(0, power_src_gpios),
+		  DT_INST_GPIO_FLAGS(0, power_src_gpios) | GPIO_OUTPUT_LOW),
+#endif
+
+#if GSM_PPP_HAS_PWR_KEY
+	/* MDM_POWER_KEY */
+	MODEM_PIN(DT_INST_GPIO_LABEL(0, power_key_gpios), DT_INST_GPIO_PIN(0, power_key_gpios),
+		  DT_INST_GPIO_FLAGS(0, power_key_gpios) | GPIO_OUTPUT_LOW),
+#endif
+};
+#endif
+
+/**
+ * @brief  Disable power source of the modem.
+ *
+ * @param  ctx: modem_context struct
+ *
+ * @retval None.
+ */
+static inline void gsm_ppp_disable_power_source(struct modem_context *ctx)
+{
+#if GSM_PPP_HAS_PWR_SRC
+	modem_pin_write(ctx, GSM_PPP_MDM_PWR_SRC, 0);
+#endif
+}
+
+/**
+ * @brief  Enable power source of the modem.
+ *
+ * @param  ctx: modem_context struct
+ *
+ * @retval None.
+ */
+static inline void gsm_ppp_enable_power_source(struct modem_context *ctx)
+{
+#if GSM_PPP_HAS_PWR_SRC
+	modem_pin_write(ctx, GSM_PPP_MDM_PWR_SRC, 1);
+#endif
+}
+
+#if GSM_PPP_HAS_PWR_KEY
+static inline void gsm_ppp_press_power_key(struct modem_context *ctx, const k_timeout_t dur)
+{
+	modem_pin_write(ctx, GSM_PPP_MDM_PWR_KEY, 1);
+	k_sleep(dur);
+	modem_pin_write(ctx, GSM_PPP_MDM_PWR_KEY, 0);
+}
+#endif
+
+/**
+ * @brief  Operations required to turn the modem on.
+ *
+ * @param  ctx: modem_context struct
+ *
+ * @retval None.
+ */
+static inline void gsm_ppp_power_on_ops(struct modem_context *ctx)
+{
+#if DT_INST_NODE_HAS_PROP(0, power_key_on_ms)
+	gsm_ppp_press_power_key(ctx, K_MSEC(DT_INST_PROP(0, power_key_on_ms)));
+#endif
+}
+
+/**
+ * @brief  Operations required to turn the modem off.
+ *
+ * @param  ctx: modem_context struct
+ *
+ * @retval None.
+ */
+static inline void gsm_ppp_power_off_ops(struct modem_context *ctx)
+{
+#if DT_INST_NODE_HAS_PROP(0, power_key_off_ms)
+	gsm_ppp_press_power_key(ctx, K_MSEC(DT_INST_PROP(0, power_key_off_ms)));
+#endif
+}
+
+#endif /* GSM_PPP_H */

--- a/drivers/modem/modem_cmd_handler.h
+++ b/drivers/modem/modem_cmd_handler.h
@@ -164,6 +164,8 @@ int modem_cmd_handler_update_cmds(struct modem_cmd_handler_data *data,
  *
  * @param  *iface: interface to use
  * @param  *handler: command handler to use
+ * @param  *handler_cmds: commands to attach
+ * @param  handler_cmds_len: size of commands array
  * @param  *buf: NULL terminated send buffer
  * @param  *sem: wait for response semaphore
  * @param  timeout: timeout of command
@@ -182,6 +184,8 @@ int modem_cmd_send_ext(struct modem_iface *iface,
  *
  * @param  *iface: interface to use
  * @param  *handler: command handler to use
+ * @param  *handler_cmds: commands to attach
+ * @param  handler_cmds_len: size of commands array
  * @param  *buf: NULL terminated send buffer
  * @param  *sem: wait for response semaphore
  * @param  timeout: timeout of command
@@ -205,6 +209,8 @@ static inline int modem_cmd_send_nolock(struct modem_iface *iface,
  *
  * @param  *iface: interface to use
  * @param  *handler: command handler to use
+ * @param  *handler_cmds: commands to attach
+ * @param  handler_cmds_len: size of commands array
  * @param  *buf: NULL terminated send buffer
  * @param  *sem: wait for response semaphore
  * @param  timeout: timeout of command
@@ -271,18 +277,25 @@ int modem_cmd_handler_init(struct modem_cmd_handler *handler,
  * @brief  Lock the modem for sending cmds
  *
  * This is semaphore-based rather than mutex based, which means there's no
- * requirements of thread ownership for the user. These functions are useful
+ * requirements of thread ownership for the user. This function is useful
  * when one needs to prevent threads from sending UART data to the modem for an
  * extended period of time (for example during modem reset).
  *
  * @param  *handler: command handler to lock
- * @param  lock: set true to lock, false to unlock
  * @param  timeout: give up after timeout
  *
  * @retval 0 if ok, < 0 if error.
  */
 int modem_cmd_handler_tx_lock(struct modem_cmd_handler *handler,
 			      k_timeout_t timeout);
+
+/**
+ * @brief  Unlock the modem for sending cmds
+ *
+ * @param  *handler: command handler to unlock
+ *
+ * @retval None.
+ */
 void modem_cmd_handler_tx_unlock(struct modem_cmd_handler *handler);
 
 

--- a/dts/bindings/modem/zephyr,gsm-ppp.yaml
+++ b/dts/bindings/modem/zephyr,gsm-ppp.yaml
@@ -6,3 +6,25 @@ description: GSM PPP modem
 compatible: "zephyr,gsm-ppp"
 
 include: uart-device.yaml
+
+properties:
+  power-src-gpios:
+    type: phandle-array
+    required: false
+    description: |
+      Pin to enable the power supply to the modem.
+  power-key-gpios:
+    type: phandle-array
+    required: false
+    description: |
+      Power key pin of the modem.
+  power-key-on-ms:
+    type: int
+    required: false
+    description: |
+      Duration required to hold the power key for the modem to turn on.
+  power-key-off-ms:
+    type: int
+    required: false
+    description: |
+      Duration required to hold the power key for the modem to turn off.

--- a/include/drivers/gsm_ppp.h
+++ b/include/drivers/gsm_ppp.h
@@ -9,8 +9,23 @@
 
 /** @cond INTERNAL_HIDDEN */
 struct device;
-void gsm_ppp_start(const struct device *dev);
-void gsm_ppp_stop(const struct device *dev);
+/**
+ * @brief  Start the GSM PPP modem.
+ *
+ * @param  dev: Modem device struct
+ *
+ * @retval 0 if success, errno.h values otherwise.
+ */
+int gsm_ppp_start(const struct device *dev);
+
+/**
+ * @brief  Stop the GSM PPP modem.
+ *
+ * @param  dev: Modem device struct
+ *
+ * @retval 0 if success, errno.h values otherwise.
+ */
+int gsm_ppp_stop(const struct device *dev);
 /** @endcond */
 
 #endif /* GSM_PPP_H_ */


### PR DESCRIPTION
`gsm_ppp_start` and `gsm_ppp_stop` were introduced in #28475 that allows the modem to be turned on and off in the software level. After the merge of #34548, it is now possible to control the on and off of the modem in hardware level for the `gsm_ppp` modem.

This PR aims to:
1. cleanup some unused code,
2. changed how the driver is being compiled based on the Kconfig,
3. use a FSM for the setup, instead of the previous enum + boolean combo
4. further implement the `gsm_ppp_start` and `gsm_ppp_stop` so that it now turn off the hardware when the modem isn't in use to achieve power saving for battery operated devices.

fixes #33998