### PR TITLE
logging: Add choice name in template

### DIFF
--- a/subsys/logging/Kconfig.template.log_config
+++ b/subsys/logging/Kconfig.template.log_config
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-choice
+choice "$(module)_LOG_LEVEL_CHOICE"
 	prompt "Max compiled-in log level for $(module-str)"
 	default $(module)_LOG_LEVEL_INF
 	depends on LOG


### PR DESCRIPTION
This PR adds choice name in a logging subsystem
Kconfig template file. It adds possibility to include Kconfig files which uses logging template in different places