### PR TITLE
twister: when simulation is mdb-nsim, call make run

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -2280,8 +2280,7 @@ class ProjectBuilder(FilterBuilder):
         elif instance.platform.simulation == "mdb-nsim":
             if find_executable("mdb"):
                 instance.handler = BinaryHandler(instance, "nsim")
-                instance.handler.pid_fn = os.path.join(instance.build_dir, "mdb.pid")
-                instance.handler.call_west_flash = True
+                instance.handler.call_make_run = True
         elif instance.platform.simulation == "armfvp":
             instance.handler = BinaryHandler(instance, "armfvp")
             instance.handler.call_make_run = True


### PR DESCRIPTION
For twister, when simulation is mdb-nsim, the platform is
nsim_hs_smp.  Twister will call `west flash` to download elf file, but after https://github.com/zephyrproject-rtos/zephyr/pull/36619 was merged, the  `nsim_hs_smp` supports  `make run` and `ninja run`


In addition, this commit can avoids issue https://github.com/zephyrproject-rtos/zephyr/issues/36655

Signed-off-by: Jingru Wang <jingru@synopsys.com>