### PR TITLE
pm: device: add action based APIs

### DIFF
--- a/doc/reference/power_management/index.rst
+++ b/doc/reference/power_management/index.rst
@@ -310,15 +310,17 @@ identify the devices on which to execute power management operations.
    Ensure that the SOC interface does not alter the original list. Since the kernel
    uses the original list, it must remain unchanged.
 
-Device Set Power State
-----------------------
+Device Actions
+--------------
 
 .. code-block:: c
 
-   int pm_device_state_set(const struct device *dev, enum pm_device_state state);
+   int pm_device_resume(const struct device *dev);
+   int pm_device_suspend(const struct device *dev);
+   int pm_device_turn_off(const struct device *dev);
 
-Calls the :c:func:`pm_control()` handler function implemented by the
-device driver with the provided state.
+All the functions listed above call the :c:func:`pm_control()` handler function
+implemented by the device driver with the appropriate action.
 
 Device Get Power State
 ----------------------
@@ -431,8 +433,9 @@ Management mechanism which reduces the overall system Power consumtion
 by suspending the devices which are idle or not being used while the
 System is active or running.
 
-The framework uses :c:func:`pm_device_state_set()` API set the
-device power state accordingly based on the usage count.
+The framework uses :c:func:`pm_device_resume()` and
+:c:func:`pm_device_suspend()` APIs set the device power state accordingly based
+on the usage count.
 
 The interfaces and APIs provided by the Device Runtime PM are
 designed to be generic and architecture independent.

--- a/drivers/led/led_pwm.c
+++ b/drivers/led/led_pwm.c
@@ -130,16 +130,15 @@ static int led_pwm_pm_control(const struct device *dev,
 		/* NOTE: temporary solution, deserves proper fix */
 		switch (action) {
 		case PM_DEVICE_ACTION_RESUME:
-			state = PM_DEVICE_STATE_ACTIVE;
+			err = pm_device_resume(dev);
 			break;
 		case PM_DEVICE_ACTION_SUSPEND:
-			state = PM_DEVICE_STATE_SUSPENDED;
+			err = pm_device_suspend(dev);
 			break;
 		default:
 			return -ENOTSUP;
 		}
 
-		err = pm_device_state_set(led_pwm->dev, state);
 		if (err) {
 			LOG_ERR("Cannot switch PWM %p power state", led_pwm->dev);
 		}

--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -4286,8 +4286,7 @@ static void shutdown_uart(void)
 	if (ictx.uart_on) {
 		HL7800_IO_DBG_LOG("Power OFF the UART");
 		uart_irq_rx_disable(ictx.mdm_ctx.uart_dev);
-		rc = pm_device_state_set(ictx.mdm_ctx.uart_dev,
-					 PM_DEVICE_STATE_SUSPENDED);
+		rc = pm_device_suspend(ictx.mdm_ctx.uart_dev);
 		if (rc) {
 			LOG_ERR("Error disabling UART peripheral (%d)", rc);
 		}
@@ -4303,8 +4302,7 @@ static void power_on_uart(void)
 
 	if (!ictx.uart_on) {
 		HL7800_IO_DBG_LOG("Power ON the UART");
-		rc = pm_device_state_set(ictx.mdm_ctx.uart_dev,
-					 PM_DEVICE_STATE_ACTIVE);
+		rc = pm_device_resume(ictx.mdm_ctx.uart_dev);
 		if (rc) {
 			LOG_ERR("Error enabling UART peripheral (%d)", rc);
 		}

--- a/drivers/modem/modem_receiver.c
+++ b/drivers/modem/modem_receiver.c
@@ -199,7 +199,7 @@ int mdm_receiver_sleep(struct mdm_receiver_context *ctx)
 {
 	uart_irq_rx_disable(ctx->uart_dev);
 #ifdef CONFIG_PM_DEVICE
-	pm_device_state_set(ctx->uart_dev, PM_DEVICE_STATE_SUSPENDED);
+	pm_device_suspend(ctx->uart_dev);
 #endif
 	return 0;
 }
@@ -207,7 +207,7 @@ int mdm_receiver_sleep(struct mdm_receiver_context *ctx)
 int mdm_receiver_wake(struct mdm_receiver_context *ctx)
 {
 #ifdef CONFIG_PM_DEVICE
-	pm_device_state_set(ctx->uart_dev, PM_DEVICE_STATE_ACTIVE);
+	pm_device_resume(ctx->uart_dev);
 #endif
 	uart_irq_rx_enable(ctx->uart_dev);
 

--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -213,27 +213,6 @@ int pm_device_turn_off(const struct device *dev);
 int pm_device_low_power(const struct device *dev);
 
 /**
- * @brief Set the power state of a device.
- *
- * This function calls the device PM control callback so that the device does
- * the necessary operations to put the device into the given state.
- *
- * @note Some devices may not support all device power states.
- *
- * @param dev Device instance.
- * @param state Device power state to be set.
- *
- * @retval 0 If successful.
- * @retval -ENOTSUP If operation is not supported given current device state.
- * @retval -EALREADY If device is already at the requested state.
- * @retval -EBUSY If device is changing its state.
-
- * @retval Errno Other negative errno on failure.
- */
-int pm_device_state_set(const struct device *dev,
-			enum pm_device_state state);
-
-/**
  * @brief Obtain the power state of a device.
  *
  * @param dev Device instance.

--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -147,6 +147,72 @@ typedef int (*pm_device_control_callback_t)(const struct device *dev,
 const char *pm_device_state_str(enum pm_device_state state);
 
 /**
+ * @brief Resume a device.
+ *
+ * A device can be resumed from #PM_DEVICE_STATE_SUSPENDED or
+ * #PM_DEVICE_STATE_OFF states.
+ *
+ * @param dev Device instance.
+ *
+ * @retval 0 If successful.
+ * @retval -ENOSYS If the device does not implement support for power management.
+ * @retval -EALREADY If the device is already active.
+ * @retval -EBUSY If the device is busy transitioning to a new state.
+ * @retval -errno Other negative errno on failure.
+ */
+int pm_device_resume(const struct device *dev);
+
+/**
+ * @brief Suspend a device.
+ *
+ * A device can only be suspended if its state is #PM_DEVICE_STATE_ACTIVE.
+ *
+ * @param dev Device instance.
+ *
+ * @retval 0 If successful.
+ * @retval -ENOSYS If the device does not implement support for power management.
+ * @retval -ENOTSUP If the operation is not supported given the current device state.
+ * @retval -EALREADY If the device is already active.
+ * @retval -EBUSY If the device is busy transitioning to a new state.
+ * @retval -errno Other negative errno on failure.
+ */
+int pm_device_suspend(const struct device *dev);
+
+/**
+ * @brief Turn off a device.
+ *
+ * A device can be turned off from #PM_DEVICE_STATE_ACTIVE or
+ * #PM_DEVICE_STATE_SUSPENDED states. A device may not implement support for
+ * turn off.
+ *
+ * @param dev Device instance.
+ *
+ * @retval 0 If successful.
+ * @retval -ENOSYS If the device does not implement support for power management.
+ * @retval -ENOTSUP If the operation is not supported.
+ * @retval -EALREADY If the device is already active.
+ * @retval -EBUSY If the device is busy transitioning to a new state.
+ * @retval -errno Other negative errno on failure.
+ */
+int pm_device_turn_off(const struct device *dev);
+
+/**
+ * @brief Put a device into low power state.
+ *
+ * @warning Provided for compatibility, use pm_device_suspend() instead.
+ *
+ * @param dev Device instance.
+ *
+ * @retval 0 If successful.
+ * @retval -ENOSYS If the device does not implement support for power management.
+ * @retval -ENOTSUP If the operation is not supported.
+ * @retval -EALREADY If the device is already active.
+ * @retval -EBUSY If the device is busy transitioning to a new state.
+ * @retval -errno Other negative errno on failure.
+ */
+int pm_device_low_power(const struct device *dev);
+
+/**
  * @brief Set the power state of a device.
  *
  * This function calls the device PM control callback so that the device does
@@ -158,7 +224,7 @@ const char *pm_device_state_str(enum pm_device_state state);
  * @param state Device power state to be set.
  *
  * @retval 0 If successful.
- * @retval -ENOTSUP If requested state is not supported.
+ * @retval -ENOTSUP If operation is not supported given current device state.
  * @retval -EALREADY If device is already at the requested state.
  * @retval -EBUSY If device is changing its state.
 

--- a/samples/boards/nrf/system_off/src/main.c
+++ b/samples/boards/nrf/system_off/src/main.c
@@ -66,17 +66,17 @@ void main(void)
 	k_busy_wait(BUSY_WAIT_S * USEC_PER_SEC);
 
 	printk("Busy-wait %u s with UART off\n", BUSY_WAIT_S);
-	rc = pm_device_state_set(cons, PM_DEVICE_STATE_SUSPENDED);
+	rc = pm_device_suspend(cons);
 	k_busy_wait(BUSY_WAIT_S * USEC_PER_SEC);
-	rc = pm_device_state_set(cons, PM_DEVICE_STATE_ACTIVE);
+	rc = pm_device_resume(cons);
 
 	printk("Sleep %u s\n", SLEEP_S);
 	k_sleep(K_SECONDS(SLEEP_S));
 
 	printk("Sleep %u s with UART off\n", SLEEP_S);
-	rc = pm_device_state_set(cons, PM_DEVICE_STATE_SUSPENDED);
+	rc = pm_device_suspend(cons);
 	k_sleep(K_SECONDS(SLEEP_S));
-	rc = pm_device_state_set(cons, PM_DEVICE_STATE_ACTIVE);
+	rc = pm_device_resume(cons);
 
 	printk("Entering system off; press BUTTON1 to restart\n");
 

--- a/samples/drivers/spi_flash_at45/src/main.c
+++ b/samples/drivers/spi_flash_at45/src/main.c
@@ -150,8 +150,8 @@ void main(void)
 	printk("OK\n");
 
 #if IS_ENABLED(CONFIG_PM_DEVICE)
-	printk("Putting the flash device into suspended state... ");
-	err = pm_device_state_set(flash_dev, PM_DEVICE_STATE_SUSPENDED);
+	printk("Suspending the flash device...");
+	err = pm_device_suspend(flash_dev);
 	if (err != 0) {
 		printk("FAILED\n");
 		return;

--- a/samples/sensor/apds9960/src/main.c
+++ b/samples/sensor/apds9960/src/main.c
@@ -77,14 +77,10 @@ void main(void)
 		       intensity.val1, pdata.val1);
 
 #ifdef CONFIG_PM_DEVICE
-		enum pm_device_state p_state;
-
-		p_state = PM_DEVICE_STATE_SUSPENDED;
-		pm_device_state_set(dev, p_state);
+		pm_device_suspend(dev);
 		printk("set low power state for 2s\n");
 		k_sleep(K_MSEC(2000));
-		p_state = PM_DEVICE_STATE_ACTIVE;
-		pm_device_state_set(dev, p_state);
+		pm_device_resume(dev);
 #endif
 	}
 }

--- a/samples/sensor/fdc2x1x/src/main.c
+++ b/samples/sensor/fdc2x1x/src/main.c
@@ -34,20 +34,20 @@ static void trigger_handler(const struct device *dev,
 #endif
 
 #ifdef CONFIG_PM_DEVICE
-static void pm_info(enum pm_device_state state, int status)
+static void pm_info(enum pm_device_action action, int status)
 {
 	ARG_UNUSED(dev);
 	ARG_UNUSED(arg);
 
-	switch (state) {
-	case PM_DEVICE_STATE_ACTIVE:
-		printk("Enter ACTIVE_STATE ");
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
+		printk("Resume: ");
 		break;
-	case PM_DEVICE_STATE_SUSPENDED:
-		printk("Enter SUSPEND_STATE ");
+	case PM_DEVICE_ACTION_SUSPEND:
+		printk("Suspend: ");
 		break;
-	case PM_DEVICE_STATE_OFF:
-		printk("Enter OFF_STATE ");
+	case PM_DEVICE_ACTION_TURN_OFF:
+		printk("Turn off: ");
 		break;
 	}
 
@@ -92,20 +92,16 @@ void main(void)
 
 #ifdef CONFIG_PM_DEVICE
 	/* Testing the power modes */
-	enum pm_device_state p_state;
 	int ret;
 
-	p_state = PM_DEVICE_STATE_SUSPENDED;
-	ret = pm_device_state_set(dev, p_state);
-	pm_info(p_state, ret);
+	ret = pm_device_suspend(dev);
+	pm_info(PM_DEVICE_ACTION_SUSPEND, ret);
 
-	p_state = PM_DEVICE_STATE_OFF;
-	ret = pm_device_state_set(dev, p_state);
-	pm_info(p_state, ret);
+	ret = pm_device_turn_off(dev);
+	pm_info(PM_DEVICE_ACTION_TURN_OFF, ret);
 
-	p_state = PM_DEVICE_STATE_ACTIVE;
-	ret = pm_device_state_set(dev, p_state);
-	pm_info(p_state, ret);
+	ret = pm_device_resume(dev);
+	pm_info(PM_DEVICE_ACTION_RESUME, ret);
 #endif
 
 	while (1) {
@@ -133,13 +129,11 @@ void main(void)
 
 
 #ifdef CONFIG_PM_DEVICE
-		p_state = PM_DEVICE_STATE_OFF;
-		ret = pm_device_state_set(dev, p_state);
-		pm_info(p_state, ret);
+		ret = pm_device_turn_off(dev);
+		pm_info(PM_DEVICE_ACTION_TURN_OFF, ret);
 		k_sleep(K_MSEC(2000));
-		p_state = PM_DEVICE_STATE_ACTIVE;
-		ret = pm_device_state_set(dev, p_state);
-		pm_info(p_state, ret);
+		ret = pm_device_resume(dev);
+		pm_info(PM_DEVICE_ACTION_RESUME, ret);
 #elif CONFIG_FDC2X1X_TRIGGER_NONE
 		k_sleep(K_MSEC(100));
 #endif

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -5532,7 +5532,7 @@ static int cmd_net_suspend(const struct shell *shell, size_t argc,
 
 		dev = net_if_get_device(iface);
 
-		ret = pm_device_state_set(dev, PM_DEVICE_STATE_SUSPENDED);
+		ret = pm_device_suspend(dev);
 		if (ret != 0) {
 			PR_INFO("Iface could not be suspended: ");
 
@@ -5576,7 +5576,7 @@ static int cmd_net_resume(const struct shell *shell, size_t argc,
 
 		dev = net_if_get_device(iface);
 
-		ret = pm_device_state_set(dev, PM_DEVICE_STATE_ACTIVE);
+		ret = pm_device_resume(dev);
 		if (ret != 0) {
 			PR_INFO("Iface could not be resumed\n");
 		}

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -211,65 +211,6 @@ int pm_device_low_power(const struct device *dev)
 	return 0;
 }
 
-int pm_device_state_set(const struct device *dev,
-			enum pm_device_state state)
-{
-	int ret;
-	enum pm_device_action action;
-
-	if (dev->pm_control == NULL) {
-		return -ENOSYS;
-	}
-
-	if (atomic_test_bit(&dev->pm->flags, PM_DEVICE_FLAG_TRANSITIONING)) {
-		return -EBUSY;
-	}
-
-	switch (state) {
-	case PM_DEVICE_STATE_SUSPENDED:
-		if (dev->pm->state == PM_DEVICE_STATE_SUSPENDED) {
-			return -EALREADY;
-		} else if (dev->pm->state == PM_DEVICE_STATE_OFF) {
-			return -ENOTSUP;
-		}
-
-		action = PM_DEVICE_ACTION_SUSPEND;
-		break;
-	case PM_DEVICE_STATE_ACTIVE:
-		if (dev->pm->state == PM_DEVICE_STATE_ACTIVE) {
-			return -EALREADY;
-		}
-
-		action = PM_DEVICE_ACTION_RESUME;
-		break;
-	case PM_DEVICE_STATE_LOW_POWER:
-		if (dev->pm->state == state) {
-			return -EALREADY;
-		}
-
-		action = PM_DEVICE_ACTION_LOW_POWER;
-		break;
-	case PM_DEVICE_STATE_OFF:
-		if (dev->pm->state == state) {
-			return -EALREADY;
-		}
-
-		action = PM_DEVICE_ACTION_TURN_OFF;
-		break;
-	default:
-		return -ENOTSUP;
-	}
-
-	ret = dev->pm_control(dev, action);
-	if (ret < 0) {
-		return ret;
-	}
-
-	dev->pm->state = state;
-
-	return 0;
-}
-
 int pm_device_state_get(const struct device *dev,
 			enum pm_device_state *state)
 {

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -30,12 +30,12 @@ static void pm_device_runtime_state_set(struct pm_device *pm)
 	switch (dev->pm->state) {
 	case PM_DEVICE_STATE_ACTIVE:
 		if ((dev->pm->usage == 0) && dev->pm->enable) {
-			ret = pm_device_state_set(dev, PM_DEVICE_STATE_SUSPENDED);
+			ret = pm_device_suspend(dev);
 		}
 		break;
 	case PM_DEVICE_STATE_SUSPENDED:
 		if ((dev->pm->usage > 0) || !dev->pm->enable) {
-			ret = pm_device_state_set(dev, PM_DEVICE_STATE_ACTIVE);
+			ret = pm_device_resume(dev);
 		}
 		break;
 	default:
@@ -91,9 +91,9 @@ static int pm_device_request(const struct device *dev,
 		 * the gpio. Lets just power on/off the device.
 		 */
 		if (dev->pm->usage == 1) {
-			(void)pm_device_state_set(dev, PM_DEVICE_STATE_ACTIVE);
+			(void)pm_device_resume(dev);
 		} else if (dev->pm->usage == 0) {
-			(void)pm_device_state_set(dev, PM_DEVICE_STATE_SUSPENDED);
+			(void)pm_device_suspend(dev);
 		}
 		goto out;
 	}

--- a/tests/kernel/device/src/main.c
+++ b/tests/kernel/device/src/main.c
@@ -286,8 +286,8 @@ static void test_enable_and_disable_automatic_runtime_pm(void)
  * sets/clears busy status and validates status again.
  *
  * @see device_get_binding(), pm_device_busy_set(), pm_device_busy_clear(),
- * pm_device_is_busy(), pm_device_is_any_busy(),
- * pm_device_state_set()
+ * pm_device_is_busy(), pm_device_is_any_busy(), pm_device_resume(),
+ * pm_device_suspend()
  */
 void test_dummy_device_pm(void)
 {
@@ -318,16 +318,15 @@ void test_dummy_device_pm(void)
 
 	test_build_suspend_device_list();
 
-	/* Set device state to PM_DEVICE_STATE_ACTIVE */
-	ret = pm_device_state_set(dev, PM_DEVICE_STATE_ACTIVE);
+	/* Resume device */
+	ret = pm_device_resume(dev);
 	if (ret == -ENOSYS) {
 		TC_PRINT("Power management not supported on device");
 		ztest_test_skip();
 		return;
 	}
 
-	zassert_true((ret == 0),
-			"Unable to set active state to device");
+	zassert_true((ret == 0), "Unable to resume the device");
 
 	ret = pm_device_state_get(dev, &device_power_state);
 	zassert_true((ret == 0),
@@ -335,15 +334,15 @@ void test_dummy_device_pm(void)
 	zassert_true((device_power_state == PM_DEVICE_STATE_ACTIVE),
 			"Error power status");
 
-	/* Set device state to PM_DEVICE_STATE_SUSPENDED */
-	ret = pm_device_state_set(dev, PM_DEVICE_STATE_SUSPENDED);
+	/* Suspend device */
+	ret = pm_device_suspend(dev);
 
-	zassert_true((ret == 0), "Unable to force suspend device");
+	zassert_true((ret == 0), "Unable to suspend the device");
 
 	ret = pm_device_state_get(dev, &device_power_state);
 	zassert_true((ret == 0),
 			"Unable to get suspend state to device");
-	zassert_true((device_power_state == PM_DEVICE_STATE_ACTIVE),
+	zassert_true((device_power_state == PM_DEVICE_STATE_SUSPENDED),
 			"Error power status");
 }
 #else

--- a/tests/net/pm/src/main.c
+++ b/tests/net/pm/src/main.c
@@ -148,14 +148,14 @@ void test_pm(void)
 	 */
 	k_yield();
 
-	ret = pm_device_state_set(dev, PM_DEVICE_STATE_SUSPENDED);
-	zassert_true(ret == 0, "Could not set state");
+	ret = pm_device_suspend(dev);
+	zassert_true(ret == 0, "Could not suspend");
 
 	zassert_true(net_if_is_suspended(iface), "net iface is not suspended");
 
 	/* Let's try to suspend it again, it should fail relevantly */
-	ret = pm_device_state_set(dev, PM_DEVICE_STATE_SUSPENDED);
-	zassert_true(ret == -EALREADY, "Could change state");
+	ret = pm_device_suspend(dev);
+	zassert_true(ret == -EALREADY, "Could suspend");
 
 	zassert_true(net_if_is_suspended(iface), "net iface is not suspended");
 
@@ -164,13 +164,13 @@ void test_pm(void)
 		     (struct sockaddr *)&addr4, sizeof(struct sockaddr_in));
 	zassert_true(ret < 0, "Could send data");
 
-	ret = pm_device_state_set(dev, PM_DEVICE_STATE_ACTIVE);
-	zassert_true(ret == 0, "Could not set state");
+	ret = pm_device_resume(dev);
+	zassert_true(ret == 0, "Could not resume");
 
 	zassert_false(net_if_is_suspended(iface), "net iface is suspended");
 
-	ret = pm_device_state_set(dev, PM_DEVICE_STATE_ACTIVE);
-	zassert_true(ret == -EALREADY, "Could change state");
+	ret = pm_device_resume(dev);
+	zassert_true(ret == -EALREADY, "Could resume");
 
 	/* Let's send some data, it should go through */
 	ret = sendto(sock, data, ARRAY_SIZE(data), 0,

--- a/tests/subsys/pm/power_mgmt/src/main.c
+++ b/tests/subsys/pm/power_mgmt/src/main.c
@@ -167,8 +167,8 @@ void test_power_state_trans(void)
  *  - system inform device system power state change through device interface
  *    pm_control
  *
- * @see pm_device_get_async(), pm_device_put_async(), pm_device_state_set(),
- *      pm_device_state_get()
+ * @see pm_device_get_async(), pm_device_put_async(), pm_device_resume(),
+ *      pm_device_suspend(), pm_device_turn_off(), pm_device_state_get()
  *
  * @ingroup power_tests
  */


### PR DESCRIPTION
This patch adds some new APIs to trigger a device action:

- `pm_device_resume()`
- `pm_device_suspend()`
- `pm_device_turn_off()`
- `pm_device_low_power()`

These APIs are a replacement to the `pm_device_state_set()` API, which
will be removed in subsequent patches. The reason for this removal is
that devices no longer receive a target state but an action to execute,
for example, a device will be told to _suspend_ instead of entering the
_suspended_ state. The current implementation on `pm_device_state_set()`
was selecting the right action to be run based on the given state. This
was done mainly for legacy reasons: `pm_device_state_set` was the only
call available before the transition to actions.

This change allows providing more accurate documentation for each
action, since some of them have subtle requirements that were not clear
enough (e.g. a turned off device can not be suspended).

Note that `pm_device_low_power()` is provided for compatibility, but it
should eventually be replaced by just `pm_device_suspend()`.