### PR TITLE
doc: mcumgr: Mention udp in the transport overview

### DIFF
--- a/doc/guides/device_mgmt/mcumgr.rst
+++ b/doc/guides/device_mgmt/mcumgr.rst
@@ -19,6 +19,7 @@ over the following transports:
 
 * BLE (Bluetooth Low Energy)
 * Serial (UART)
+* UDP over IP
 
 The management subsystem is based on the Simple Management Protocol (SMP)
 provided by `MCUmgr`_, an open source project that provides a


### PR DESCRIPTION
The overview at the top of the page only listed ble and serial as
available transports. This commit adds udp to this list.

Signed-off-by: Christian Taedcke <christian.taedcke@lemonbeat.com>