### PR TITLE
soc: stm32g0: pm_power_ functions should be __weak

### DIFF
--- a/soc/arm/st_stm32/stm32g0/power.c
+++ b/soc/arm/st_stm32/stm32g0/power.c
@@ -20,7 +20,7 @@
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
 /* Invoke Low Power/System Off specific Tasks */
-void pm_power_state_set(struct pm_state_info info)
+__weak void pm_power_state_set(struct pm_state_info info)
 {
 	if (info.state != PM_STATE_SUSPEND_TO_IDLE) {
 		LOG_DBG("Unsupported power state %u", info.state);
@@ -50,7 +50,7 @@ void pm_power_state_set(struct pm_state_info info)
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-void pm_power_state_exit_post_ops(struct pm_state_info info)
+__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
 {
 	if (info.state != PM_STATE_SUSPEND_TO_IDLE) {
 		LOG_DBG("Unsupported power substate %u", info.state);


### PR DESCRIPTION
In commit "pm: Fix weak linkage symbols" (PR #35274),
PM SoC hooks were converted to __weak to avoid clash with
new definition of these symbols in subsys/pm/power.c.

G0 power implementation was implemented in parallel
with this change and missed the update.

Fixes #38332

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>