### PR TITLE
Bluetooth: Audio: Add missing media proxy write callbacks

### DIFF
--- a/subsys/bluetooth/host/audio/media_proxy.c
+++ b/subsys/bluetooth/host/audio/media_proxy.c
@@ -239,8 +239,8 @@ static void mcc_player_name_read_cb(struct bt_conn *conn, int err, const char *n
 		BT_ERR("Player name failed");
 	}
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->player_name) {
-		mprx.ctrlr.cbs->player_name(&mprx.remote_player, err, name);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->player_name_recv) {
+		mprx.ctrlr.cbs->player_name_recv(&mprx.remote_player, err, name);
 	} else {
 		BT_DBG("No callback");
 	}
@@ -255,8 +255,8 @@ static void mcc_icon_obj_id_read_cb(struct bt_conn *conn, int err, uint64_t id)
 		BT_ERR("Icon Object ID read failed (%d)", err);
 	}
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->icon_id) {
-		mprx.ctrlr.cbs->icon_id(&mprx.remote_player, err, id);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->icon_id_recv) {
+		mprx.ctrlr.cbs->icon_id_recv(&mprx.remote_player, err, id);
 	} else {
 		BT_DBG("No callback");
 	}
@@ -269,8 +269,8 @@ static void mcc_icon_url_read_cb(struct bt_conn *conn, int err, const char *url)
 		BT_ERR("Icon URL read failed (%d)", err);
 	}
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->icon_url) {
-		mprx.ctrlr.cbs->icon_url(&mprx.remote_player, err, url);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->icon_url_recv) {
+		mprx.ctrlr.cbs->icon_url_recv(&mprx.remote_player, err, url);
 	} else {
 		BT_DBG("No callback");
 	}
@@ -283,8 +283,8 @@ static void mcc_track_changed_ntf_cb(struct bt_conn *conn, int err)
 		return;
 	}
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_changed) {
-		mprx.ctrlr.cbs->track_changed(&mprx.remote_player, err);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_changed_recv) {
+		mprx.ctrlr.cbs->track_changed_recv(&mprx.remote_player, err);
 	} else {
 		BT_DBG("No callback");
 	}
@@ -296,8 +296,8 @@ static void mcc_track_title_read_cb(struct bt_conn *conn, int err, const char *t
 		BT_ERR("Track title read failed (%d)", err);
 	}
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_title) {
-		mprx.ctrlr.cbs->track_title(&mprx.remote_player, err, title);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_title_recv) {
+		mprx.ctrlr.cbs->track_title_recv(&mprx.remote_player, err, title);
 	} else {
 		BT_DBG("No callback");
 	}
@@ -309,8 +309,8 @@ static void mcc_track_dur_read_cb(struct bt_conn *conn, int err, int32_t dur)
 		BT_ERR("Track duration read failed (%d)", err);
 	}
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_duration) {
-		mprx.ctrlr.cbs->track_duration(&mprx.remote_player, err, dur);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_duration_recv) {
+		mprx.ctrlr.cbs->track_duration_recv(&mprx.remote_player, err, dur);
 	} else {
 		BT_DBG("No callback");
 	}
@@ -322,8 +322,8 @@ static void mcc_track_position_read_cb(struct bt_conn *conn, int err, int32_t po
 		BT_ERR("Track position read failed (%d)", err);
 	}
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_position) {
-		mprx.ctrlr.cbs->track_position(&mprx.remote_player, err, pos);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_position_recv) {
+		mprx.ctrlr.cbs->track_position_recv(&mprx.remote_player, err, pos);
 	} else {
 		BT_DBG("No callback");
 	}
@@ -336,8 +336,8 @@ static void mcc_track_position_set_cb(struct bt_conn *conn, int err, int32_t pos
 	}
 
 	/* MCC has separate callbacks for read and set - media_proxy has a common one */
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_position) {
-		mprx.ctrlr.cbs->track_position(&mprx.remote_player, err, pos);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_position_recv) {
+		mprx.ctrlr.cbs->track_position_recv(&mprx.remote_player, err, pos);
 	} else {
 		BT_DBG("No callback");
 	}
@@ -349,8 +349,8 @@ static void mcc_playback_speed_read_cb(struct bt_conn *conn, int err, int8_t spe
 		BT_ERR("Playback speed read failed (%d)", err);
 	}
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->playback_speed) {
-		mprx.ctrlr.cbs->playback_speed(&mprx.remote_player, err, speed);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->playback_speed_recv) {
+		mprx.ctrlr.cbs->playback_speed_recv(&mprx.remote_player, err, speed);
 	} else {
 		BT_DBG("No callback");
 	}
@@ -362,8 +362,8 @@ static void mcc_playback_speed_set_cb(struct bt_conn *conn, int err, int8_t spee
 		BT_ERR("Playback speed set failed (%d)", err);
 	}
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->playback_speed) {
-		mprx.ctrlr.cbs->playback_speed(&mprx.remote_player, err, speed);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->playback_speed_recv) {
+		mprx.ctrlr.cbs->playback_speed_recv(&mprx.remote_player, err, speed);
 	} else {
 		BT_DBG("No callback");
 	}
@@ -375,8 +375,8 @@ static void mcc_seeking_speed_read_cb(struct bt_conn *conn, int err, int8_t spee
 		BT_ERR("Seeking speed read failed (%d)", err);
 	}
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->seeking_speed) {
-		mprx.ctrlr.cbs->seeking_speed(&mprx.remote_player, err, speed);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->seeking_speed_recv) {
+		mprx.ctrlr.cbs->seeking_speed_recv(&mprx.remote_player, err, speed);
 	} else {
 		BT_DBG("No callback");
 	}
@@ -389,8 +389,8 @@ static void mcc_segments_obj_id_read_cb(struct bt_conn *conn, int err, uint64_t 
 		BT_ERR("Track Segments Object ID read failed (%d)", err);
 	}
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_segments_id) {
-		mprx.ctrlr.cbs->track_segments_id(&mprx.remote_player, err, id);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_segments_id_recv) {
+		mprx.ctrlr.cbs->track_segments_id_recv(&mprx.remote_player, err, id);
 	} else {
 		BT_DBG("No callback");
 	}
@@ -402,8 +402,8 @@ static void mcc_current_track_obj_id_read_cb(struct bt_conn *conn, int err, uint
 		BT_ERR("Current Track Object ID read failed (%d)", err);
 	}
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->current_track_id) {
-		mprx.ctrlr.cbs->current_track_id(&mprx.remote_player, err, id);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->current_track_id_recv) {
+		mprx.ctrlr.cbs->current_track_id_recv(&mprx.remote_player, err, id);
 	} else {
 		BT_DBG("No callback");
 	}
@@ -415,8 +415,8 @@ static void mcc_next_track_obj_id_read_cb(struct bt_conn *conn, int err, uint64_
 		BT_ERR("Next Track Object ID read failed (%d)", err);
 	}
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->next_track_id) {
-		mprx.ctrlr.cbs->next_track_id(&mprx.remote_player, err, id);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->next_track_id_recv) {
+		mprx.ctrlr.cbs->next_track_id_recv(&mprx.remote_player, err, id);
 	} else {
 		BT_DBG("No callback");
 	}
@@ -428,8 +428,8 @@ static void mcc_current_group_obj_id_read_cb(struct bt_conn *conn, int err, uint
 		BT_ERR("Current Group Object ID read failed (%d)", err);
 	}
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->current_group_id) {
-		mprx.ctrlr.cbs->current_group_id(&mprx.remote_player, err, id);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->current_group_id_recv) {
+		mprx.ctrlr.cbs->current_group_id_recv(&mprx.remote_player, err, id);
 	} else {
 		BT_DBG("No callback");
 	}
@@ -441,8 +441,8 @@ static void mcc_parent_group_obj_id_read_cb(struct bt_conn *conn, int err, uint6
 		BT_ERR("Parent Group Object ID read failed (%d)", err);
 	}
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->parent_group_id) {
-		mprx.ctrlr.cbs->parent_group_id(&mprx.remote_player, err, id);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->parent_group_id_recv) {
+		mprx.ctrlr.cbs->parent_group_id_recv(&mprx.remote_player, err, id);
 	} else {
 		BT_DBG("No callback");
 	}
@@ -456,8 +456,8 @@ static void mcc_playing_order_read_cb(struct bt_conn *conn, int err, uint8_t ord
 		BT_ERR("Playing order read failed (%d)", err);
 	}
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->playing_order) {
-		mprx.ctrlr.cbs->playing_order(&mprx.remote_player, err, order);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->playing_order_recv) {
+		mprx.ctrlr.cbs->playing_order_recv(&mprx.remote_player, err, order);
 	} else {
 		BT_DBG("No callback");
 	}
@@ -469,8 +469,8 @@ static void mcc_playing_order_set_cb(struct bt_conn *conn, int err, uint8_t orde
 		BT_ERR("Playing order set failed (%d)", err);
 	}
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->playing_order) {
-		mprx.ctrlr.cbs->playing_order(&mprx.remote_player, err, order);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->playing_order_recv) {
+		mprx.ctrlr.cbs->playing_order_recv(&mprx.remote_player, err, order);
 	} else {
 		BT_DBG("No callback");
 	}
@@ -482,8 +482,8 @@ static void mcc_playing_orders_supported_read_cb(struct bt_conn *conn, int err, 
 		BT_ERR("Playing orders supported read failed (%d)", err);
 	}
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->playing_orders_supported) {
-		mprx.ctrlr.cbs->playing_orders_supported(&mprx.remote_player, err, orders);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->playing_orders_supported_recv) {
+		mprx.ctrlr.cbs->playing_orders_supported_recv(&mprx.remote_player, err, orders);
 	} else {
 		BT_DBG("No callback");
 	}
@@ -495,8 +495,8 @@ static void mcc_media_state_read_cb(struct bt_conn *conn, int err, uint8_t state
 		BT_ERR("Media State read failed (%d)", err);
 	}
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->media_state) {
-		mprx.ctrlr.cbs->media_state(&mprx.remote_player, err, state);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->media_state_recv) {
+		mprx.ctrlr.cbs->media_state_recv(&mprx.remote_player, err, state);
 	} else {
 		BT_DBG("No callback");
 	}
@@ -548,8 +548,8 @@ static void mcc_opcodes_supported_read_cb(struct bt_conn *conn, int err, uint32_
 		BT_ERR("Opcodes supported read failed (%d)", err);
 	}
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->commands_supported) {
-		mprx.ctrlr.cbs->commands_supported(&mprx.remote_player, err, opcodes);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->commands_supported_recv) {
+		mprx.ctrlr.cbs->commands_supported_recv(&mprx.remote_player, err, opcodes);
 	} else {
 		BT_DBG("No callback");
 	}
@@ -601,8 +601,8 @@ static void mcc_search_results_obj_id_read_cb(struct bt_conn *conn, int err, uin
 		BT_ERR("Search Results Object ID read failed (%d)", err);
 	}
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->search_results_id) {
-		mprx.ctrlr.cbs->search_results_id(&mprx.remote_player, err, id);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->search_results_id_recv) {
+		mprx.ctrlr.cbs->search_results_id_recv(&mprx.remote_player, err, id);
 	} else {
 		BT_DBG("No callback");
 	}
@@ -615,8 +615,8 @@ static void mcc_content_control_id_read_cb(struct bt_conn *conn, int err, uint8_
 		BT_ERR("Content Control ID read failed (%d)", err);
 	}
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->content_ctrl_id) {
-		mprx.ctrlr.cbs->content_ctrl_id(&mprx.remote_player, err, ccid);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->content_ctrl_id_recv) {
+		mprx.ctrlr.cbs->content_ctrl_id_recv(&mprx.remote_player, err, ccid);
 	} else {
 		BT_DBG("No callback");
 	}
@@ -714,8 +714,8 @@ int media_proxy_ctrl_player_name_get(struct media_player *player)
 		if (mprx.local_player.calls->player_name_get) {
 			const char *name = mprx.local_player.calls->player_name_get();
 
-			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->player_name) {
-				mprx.ctrlr.cbs->player_name(&mprx.local_player, 0, name);
+			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->player_name_recv) {
+				mprx.ctrlr.cbs->player_name_recv(&mprx.local_player, 0, name);
 			} else {
 				BT_DBG("No callback");
 			}
@@ -747,8 +747,8 @@ int media_proxy_ctrl_icon_id_get(struct media_player *player)
 		if (mprx.local_player.calls->icon_id_get) {
 			uint64_t id = mprx.local_player.calls->icon_id_get();
 
-			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->icon_id) {
-				mprx.ctrlr.cbs->icon_id(&mprx.local_player, 0, id);
+			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->icon_id_recv) {
+				mprx.ctrlr.cbs->icon_id_recv(&mprx.local_player, 0, id);
 			} else {
 				BT_DBG("No callback");
 			}
@@ -779,8 +779,8 @@ int media_proxy_ctrl_icon_url_get(struct media_player *player)
 		if (mprx.local_player.calls->icon_url_get) {
 			const char *url = mprx.local_player.calls->icon_url_get();
 
-			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->icon_url) {
-				mprx.ctrlr.cbs->icon_url(player, 0, url);
+			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->icon_url_recv) {
+				mprx.ctrlr.cbs->icon_url_recv(player, 0, url);
 			} else {
 				BT_DBG("No callback");
 			}
@@ -811,8 +811,8 @@ int media_proxy_ctrl_track_title_get(struct media_player *player)
 		if (mprx.local_player.calls->track_title_get) {
 			const char *title = mprx.local_player.calls->track_title_get();
 
-			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_title) {
-				mprx.ctrlr.cbs->track_title(player, 0, title);
+			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_title_recv) {
+				mprx.ctrlr.cbs->track_title_recv(player, 0, title);
 			} else {
 				BT_DBG("No callback");
 			}
@@ -843,8 +843,8 @@ int media_proxy_ctrl_track_duration_get(struct media_player *player)
 		if (mprx.local_player.calls->track_duration_get) {
 			int32_t duration = mprx.local_player.calls->track_duration_get();
 
-			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_duration) {
-				mprx.ctrlr.cbs->track_duration(player, 0, duration);
+			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_duration_recv) {
+				mprx.ctrlr.cbs->track_duration_recv(player, 0, duration);
 			} else {
 				BT_DBG("No callback");
 			}
@@ -874,8 +874,8 @@ int media_proxy_ctrl_track_position_get(struct media_player *player)
 		if (mprx.local_player.calls->track_position_get) {
 			int32_t position = mprx.local_player.calls->track_position_get();
 
-			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_position) {
-				mprx.ctrlr.cbs->track_position(player, 0, position);
+			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_position_recv) {
+				mprx.ctrlr.cbs->track_position_recv(player, 0, position);
 			} else {
 				BT_DBG("No callback");
 			}
@@ -932,8 +932,8 @@ int media_proxy_ctrl_playback_speed_get(struct media_player *player)
 		if (mprx.local_player.calls->playback_speed_get) {
 			int8_t speed = mprx.local_player.calls->playback_speed_get();
 
-			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->playback_speed) {
-				mprx.ctrlr.cbs->playback_speed(player, 0, speed);
+			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->playback_speed_recv) {
+				mprx.ctrlr.cbs->playback_speed_recv(player, 0, speed);
 			} else {
 				BT_DBG("No callback");
 			}
@@ -990,8 +990,8 @@ int media_proxy_ctrl_seeking_speed_get(struct media_player *player)
 		if (mprx.local_player.calls->seeking_speed_get) {
 			int8_t speed = mprx.local_player.calls->seeking_speed_get();
 
-			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->seeking_speed) {
-				mprx.ctrlr.cbs->seeking_speed(player, 0, speed);
+			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->seeking_speed_recv) {
+				mprx.ctrlr.cbs->seeking_speed_recv(player, 0, speed);
 			} else {
 				BT_DBG("No callback");
 			}
@@ -1022,8 +1022,8 @@ int media_proxy_ctrl_track_segments_id_get(struct media_player *player)
 		if (mprx.local_player.calls->track_segments_id_get) {
 			uint64_t id = mprx.local_player.calls->track_segments_id_get();
 
-			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_segments_id) {
-				mprx.ctrlr.cbs->track_segments_id(player, 0, id);
+			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_segments_id_recv) {
+				mprx.ctrlr.cbs->track_segments_id_recv(player, 0, id);
 			} else {
 				BT_DBG("No callback");
 			}
@@ -1054,8 +1054,8 @@ int media_proxy_ctrl_current_track_id_get(struct media_player *player)
 		if (mprx.local_player.calls->current_track_id_get) {
 			uint64_t id = mprx.local_player.calls->current_track_id_get();
 
-			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->current_track_id) {
-				mprx.ctrlr.cbs->current_track_id(player, 0, id);
+			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->current_track_id_recv) {
+				mprx.ctrlr.cbs->current_track_id_recv(player, 0, id);
 			} else {
 				BT_DBG("No callback");
 			}
@@ -1113,8 +1113,8 @@ int media_proxy_ctrl_next_track_id_get(struct media_player *player)
 		if (mprx.local_player.calls->next_track_id_get) {
 			uint64_t id = mprx.local_player.calls->next_track_id_get();
 
-			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->next_track_id) {
-				mprx.ctrlr.cbs->next_track_id(player, 0, id);
+			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->next_track_id_recv) {
+				mprx.ctrlr.cbs->next_track_id_recv(player, 0, id);
 			} else {
 				BT_DBG("No callback");
 			}
@@ -1172,8 +1172,8 @@ int media_proxy_ctrl_current_group_id_get(struct media_player *player)
 		if (mprx.local_player.calls->current_group_id_get) {
 			uint64_t id = mprx.local_player.calls->current_group_id_get();
 
-			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->current_group_id) {
-				mprx.ctrlr.cbs->current_group_id(player, 0, id);
+			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->current_group_id_recv) {
+				mprx.ctrlr.cbs->current_group_id_recv(player, 0, id);
 			} else {
 				BT_DBG("No callback");
 			}
@@ -1231,8 +1231,8 @@ int media_proxy_ctrl_parent_group_id_get(struct media_player *player)
 		if (mprx.local_player.calls->parent_group_id_get) {
 			uint64_t id = mprx.local_player.calls->parent_group_id_get();
 
-			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->parent_group_id) {
-				mprx.ctrlr.cbs->parent_group_id(player, 0, id);
+			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->parent_group_id_recv) {
+				mprx.ctrlr.cbs->parent_group_id_recv(player, 0, id);
 			} else {
 				BT_DBG("No callback");
 			}
@@ -1263,8 +1263,8 @@ int media_proxy_ctrl_playing_order_get(struct media_player *player)
 		if (mprx.local_player.calls->playing_order_get) {
 			uint8_t order = mprx.local_player.calls->playing_order_get();
 
-			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->playing_order) {
-				mprx.ctrlr.cbs->playing_order(player, 0, order);
+			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->playing_order_recv) {
+				mprx.ctrlr.cbs->playing_order_recv(player, 0, order);
 			} else {
 				BT_DBG("No callback");
 			}
@@ -1322,8 +1322,8 @@ int media_proxy_ctrl_playing_orders_supported_get(struct media_player *player)
 		if (mprx.local_player.calls->playing_orders_supported_get) {
 			uint16_t orders = mprx.local_player.calls->playing_orders_supported_get();
 
-			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->playing_orders_supported) {
-				mprx.ctrlr.cbs->playing_orders_supported(player, 0, orders);
+			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->playing_orders_supported_recv) {
+				mprx.ctrlr.cbs->playing_orders_supported_recv(player, 0, orders);
 			} else {
 				BT_DBG("No callback");
 			}
@@ -1354,8 +1354,8 @@ int media_proxy_ctrl_media_state_get(struct media_player *player)
 		if (mprx.local_player.calls->media_state_get) {
 			uint8_t state = mprx.local_player.calls->media_state_get();
 
-			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->media_state) {
-				mprx.ctrlr.cbs->media_state(player, 0, state);
+			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->media_state_recv) {
+				mprx.ctrlr.cbs->media_state_recv(player, 0, state);
 			} else {
 				BT_DBG("No callback");
 			}
@@ -1412,8 +1412,8 @@ int media_proxy_ctrl_commands_supported_get(struct media_player *player)
 		if (mprx.local_player.calls->commands_supported_get) {
 			uint32_t opcodes = mprx.local_player.calls->commands_supported_get();
 
-			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->commands_supported) {
-				mprx.ctrlr.cbs->commands_supported(player, 0, opcodes);
+			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->commands_supported_recv) {
+				mprx.ctrlr.cbs->commands_supported_recv(player, 0, opcodes);
 			} else {
 				BT_DBG("No callback");
 			}
@@ -1470,8 +1470,8 @@ int media_proxy_ctrl_search_results_id_get(struct media_player *player)
 		if (mprx.local_player.calls->search_results_id_get) {
 			uint64_t id = mprx.local_player.calls->search_results_id_get();
 
-			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->search_results_id) {
-				mprx.ctrlr.cbs->search_results_id(player, 0, id);
+			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->search_results_id_recv) {
+				mprx.ctrlr.cbs->search_results_id_recv(player, 0, id);
 			} else {
 				BT_DBG("No callback");
 			}
@@ -1502,8 +1502,8 @@ uint8_t media_proxy_ctrl_content_ctrl_id_get(struct media_player *player)
 		if (mprx.local_player.calls->content_ctrl_id_get) {
 			uint8_t ccid = mprx.local_player.calls->content_ctrl_id_get();
 
-			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->content_ctrl_id) {
-				mprx.ctrlr.cbs->content_ctrl_id(player, 0, ccid);
+			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->content_ctrl_id_recv) {
+				mprx.ctrlr.cbs->content_ctrl_id_recv(player, 0, ccid);
 			} else {
 				BT_DBG("No callback");
 			}
@@ -1555,8 +1555,8 @@ void media_proxy_pl_track_changed_cb(void)
 {
 	mprx.sctrlr.cbs->track_changed();
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_changed) {
-		mprx.ctrlr.cbs->track_changed(&mprx.local_player, 0);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_changed_recv) {
+		mprx.ctrlr.cbs->track_changed_recv(&mprx.local_player, 0);
 	} else {
 		BT_DBG("No ctrlr track changed callback");
 	}
@@ -1566,8 +1566,8 @@ void media_proxy_pl_track_title_cb(char *title)
 {
 	mprx.sctrlr.cbs->track_title(title);
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_title) {
-		mprx.ctrlr.cbs->track_title(&mprx.local_player, 0, title);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_title_recv) {
+		mprx.ctrlr.cbs->track_title_recv(&mprx.local_player, 0, title);
 	} else {
 		BT_DBG("No ctrlr track title callback");
 	}
@@ -1577,8 +1577,8 @@ void media_proxy_pl_track_duration_cb(int32_t duration)
 {
 	mprx.sctrlr.cbs->track_duration(duration);
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_duration) {
-		mprx.ctrlr.cbs->track_duration(&mprx.local_player, 0, duration);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_duration_recv) {
+		mprx.ctrlr.cbs->track_duration_recv(&mprx.local_player, 0, duration);
 	} else {
 		BT_DBG("No ctrlr track duration callback");
 	}
@@ -1588,8 +1588,8 @@ void media_proxy_pl_track_position_cb(int32_t position)
 {
 	mprx.sctrlr.cbs->track_position(position);
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_position) {
-		mprx.ctrlr.cbs->track_position(&mprx.local_player, 0, position);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_position_recv) {
+		mprx.ctrlr.cbs->track_position_recv(&mprx.local_player, 0, position);
 	} else {
 		BT_DBG("No ctrlr track position callback");
 	}
@@ -1599,8 +1599,8 @@ void media_proxy_pl_playback_speed_cb(int8_t speed)
 {
 	mprx.sctrlr.cbs->playback_speed(speed);
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->playback_speed) {
-		mprx.ctrlr.cbs->playback_speed(&mprx.local_player, 0, speed);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->playback_speed_recv) {
+		mprx.ctrlr.cbs->playback_speed_recv(&mprx.local_player, 0, speed);
 	} else {
 		BT_DBG("No ctrlr playback speed callback");
 	}
@@ -1610,8 +1610,8 @@ void media_proxy_pl_seeking_speed_cb(int8_t speed)
 {
 	mprx.sctrlr.cbs->seeking_speed(speed);
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->seeking_speed) {
-		mprx.ctrlr.cbs->seeking_speed(&mprx.local_player, 0, speed);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->seeking_speed_recv) {
+		mprx.ctrlr.cbs->seeking_speed_recv(&mprx.local_player, 0, speed);
 	} else {
 		BT_DBG("No ctrlr seeking speed callback");
 	}
@@ -1622,8 +1622,8 @@ void media_proxy_pl_current_track_id_cb(uint64_t id)
 {
 	mprx.sctrlr.cbs->current_track_id(id);
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->current_track_id) {
-		mprx.ctrlr.cbs->current_track_id(&mprx.local_player, 0, id);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->current_track_id_recv) {
+		mprx.ctrlr.cbs->current_track_id_recv(&mprx.local_player, 0, id);
 	} else {
 		BT_DBG("No ctrlr current track id callback");
 	}
@@ -1633,8 +1633,8 @@ void media_proxy_pl_next_track_id_cb(uint64_t id)
 {
 	mprx.sctrlr.cbs->next_track_id(id);
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->next_track_id) {
-		mprx.ctrlr.cbs->next_track_id(&mprx.local_player, 0, id);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->next_track_id_recv) {
+		mprx.ctrlr.cbs->next_track_id_recv(&mprx.local_player, 0, id);
 	} else {
 		BT_DBG("No ctrlr next track id callback");
 	}
@@ -1644,8 +1644,8 @@ void media_proxy_pl_current_group_id_cb(uint64_t id)
 {
 	mprx.sctrlr.cbs->current_group_id(id);
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->current_group_id) {
-		mprx.ctrlr.cbs->current_group_id(&mprx.local_player, 0, id);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->current_group_id_recv) {
+		mprx.ctrlr.cbs->current_group_id_recv(&mprx.local_player, 0, id);
 	} else {
 		BT_DBG("No ctrlr current group id callback");
 	}
@@ -1655,8 +1655,8 @@ void media_proxy_pl_parent_group_id_cb(uint64_t id)
 {
 	mprx.sctrlr.cbs->parent_group_id(id);
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->parent_group_id) {
-		mprx.ctrlr.cbs->parent_group_id(&mprx.local_player, 0, id);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->parent_group_id_recv) {
+		mprx.ctrlr.cbs->parent_group_id_recv(&mprx.local_player, 0, id);
 	} else {
 		BT_DBG("No ctrlr parent group id callback");
 	}
@@ -1667,8 +1667,8 @@ void media_proxy_pl_playing_order_cb(uint8_t order)
 {
 	mprx.sctrlr.cbs->playing_order(order);
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->playing_order) {
-		mprx.ctrlr.cbs->playing_order(&mprx.local_player, 0, order);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->playing_order_recv) {
+		mprx.ctrlr.cbs->playing_order_recv(&mprx.local_player, 0, order);
 	} else {
 		BT_DBG("No ctrlr playing order callback");
 	}
@@ -1678,8 +1678,8 @@ void media_proxy_pl_media_state_cb(uint8_t state)
 {
 	mprx.sctrlr.cbs->media_state(state);
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->media_state) {
-		mprx.ctrlr.cbs->media_state(&mprx.local_player, 0, state);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->media_state_recv) {
+		mprx.ctrlr.cbs->media_state_recv(&mprx.local_player, 0, state);
 	} else {
 		BT_DBG("No ctrlr media state callback");
 	}
@@ -1700,8 +1700,8 @@ void media_proxy_pl_commands_supported_cb(uint32_t opcodes)
 {
 	mprx.sctrlr.cbs->commands_supported(opcodes);
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->commands_supported) {
-		mprx.ctrlr.cbs->commands_supported(&mprx.local_player, 0, opcodes);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->commands_supported_recv) {
+		mprx.ctrlr.cbs->commands_supported_recv(&mprx.local_player, 0, opcodes);
 	} else {
 		BT_DBG("No ctrlr commands supported callback");
 	}
@@ -1723,8 +1723,8 @@ void media_proxy_pl_search_results_id_cb(uint64_t id)
 {
 	mprx.sctrlr.cbs->search_results_id(id);
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->search_results_id) {
-		mprx.ctrlr.cbs->search_results_id(&mprx.local_player, 0, id);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->search_results_id_recv) {
+		mprx.ctrlr.cbs->search_results_id_recv(&mprx.local_player, 0, id);
 	} else {
 		BT_DBG("No ctrlr search results id callback");
 	}

--- a/subsys/bluetooth/host/audio/media_proxy.c
+++ b/subsys/bluetooth/host/audio/media_proxy.c
@@ -335,9 +335,8 @@ static void mcc_track_position_set_cb(struct bt_conn *conn, int err, int32_t pos
 		BT_ERR("Track Position set failed (%d)", err);
 	}
 
-	/* MCC has separate callbacks for read and set - media_proxy has a common one */
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_position_recv) {
-		mprx.ctrlr.cbs->track_position_recv(&mprx.remote_player, err, pos);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_position_write) {
+		mprx.ctrlr.cbs->track_position_write(&mprx.remote_player, err, pos);
 	} else {
 		BT_DBG("No callback");
 	}
@@ -362,8 +361,8 @@ static void mcc_playback_speed_set_cb(struct bt_conn *conn, int err, int8_t spee
 		BT_ERR("Playback speed set failed (%d)", err);
 	}
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->playback_speed_recv) {
-		mprx.ctrlr.cbs->playback_speed_recv(&mprx.remote_player, err, speed);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->playback_speed_write) {
+		mprx.ctrlr.cbs->playback_speed_write(&mprx.remote_player, err, speed);
 	} else {
 		BT_DBG("No callback");
 	}
@@ -409,6 +408,8 @@ static void mcc_current_track_obj_id_read_cb(struct bt_conn *conn, int err, uint
 	}
 }
 
+/* TODO: current track set callback - must be added to MCC first */
+
 static void mcc_next_track_obj_id_read_cb(struct bt_conn *conn, int err, uint64_t id)
 {
 	if (err) {
@@ -422,6 +423,8 @@ static void mcc_next_track_obj_id_read_cb(struct bt_conn *conn, int err, uint64_
 	}
 }
 
+/* TODO: next track set callback - must be added to MCC first */
+
 static void mcc_current_group_obj_id_read_cb(struct bt_conn *conn, int err, uint64_t id)
 {
 	if (err) {
@@ -434,6 +437,8 @@ static void mcc_current_group_obj_id_read_cb(struct bt_conn *conn, int err, uint
 		BT_DBG("No callback");
 	}
 }
+
+/* TODO: current group set callback - must be added to MCC first */
 
 static void mcc_parent_group_obj_id_read_cb(struct bt_conn *conn, int err, uint64_t id)
 {
@@ -469,8 +474,8 @@ static void mcc_playing_order_set_cb(struct bt_conn *conn, int err, uint8_t orde
 		BT_ERR("Playing order set failed (%d)", err);
 	}
 
-	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->playing_order_recv) {
-		mprx.ctrlr.cbs->playing_order_recv(&mprx.remote_player, err, order);
+	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->playing_order_write) {
+		mprx.ctrlr.cbs->playing_order_write(&mprx.remote_player, err, order);
 	} else {
 		BT_DBG("No callback");
 	}
@@ -906,6 +911,12 @@ int media_proxy_ctrl_track_position_set(struct media_player *player, int32_t pos
 		if (mprx.local_player.calls->track_position_set) {
 			mprx.local_player.calls->track_position_set(position);
 
+			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_position_write) {
+				mprx.ctrlr.cbs->track_position_write(player, 0, position);
+			} else {
+				BT_DBG("No callback");
+			}
+
 			return 0;
 		}
 
@@ -963,6 +974,12 @@ int media_proxy_ctrl_playback_speed_set(struct media_player *player, int8_t spee
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		if (mprx.local_player.calls->playback_speed_set) {
 			mprx.local_player.calls->playback_speed_set(speed);
+
+			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->playback_speed_write) {
+				mprx.ctrlr.cbs->playback_speed_write(player, 0, speed);
+			} else {
+				BT_DBG("No callback");
+			}
 
 			return 0;
 		}
@@ -1086,6 +1103,12 @@ int media_proxy_ctrl_current_track_id_set(struct media_player *player, uint64_t 
 		if (mprx.local_player.calls->current_track_id_set) {
 			mprx.local_player.calls->current_track_id_set(id);
 
+			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->current_track_id_write) {
+				mprx.ctrlr.cbs->current_track_id_write(player, 0, id);
+			} else {
+				BT_DBG("No callback");
+			}
+
 			return 0;
 		}
 
@@ -1145,6 +1168,12 @@ int media_proxy_ctrl_next_track_id_set(struct media_player *player, uint64_t id)
 		if (mprx.local_player.calls->next_track_id_set) {
 			mprx.local_player.calls->next_track_id_set(id);
 
+			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->next_track_id_write) {
+				mprx.ctrlr.cbs->next_track_id_write(player, 0, id);
+			} else {
+				BT_DBG("No callback");
+			}
+
 			return 0;
 		}
 
@@ -1203,6 +1232,12 @@ int media_proxy_ctrl_current_group_id_set(struct media_player *player, uint64_t 
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		if (mprx.local_player.calls->current_group_id_set) {
 			mprx.local_player.calls->current_group_id_set(id);
+
+			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->current_group_id_write) {
+				mprx.ctrlr.cbs->current_group_id_write(player, 0, id);
+			} else {
+				BT_DBG("No callback");
+			}
 
 			return 0;
 		}
@@ -1295,6 +1330,12 @@ int media_proxy_ctrl_playing_order_set(struct media_player *player, uint8_t orde
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		if (mprx.local_player.calls->playing_order_set) {
 			mprx.local_player.calls->playing_order_set(order);
+
+			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->playing_order_write) {
+				mprx.ctrlr.cbs->playing_order_write(player, 0, order);
+			} else {
+				BT_DBG("No callback");
+			}
 
 			return 0;
 		}

--- a/subsys/bluetooth/host/audio/media_proxy.h
+++ b/subsys/bluetooth/host/audio/media_proxy.h
@@ -576,18 +576,30 @@ struct media_proxy_ctrl_cbs {
 	void (*media_state_recv)(struct media_player *player, int err, uint8_t state);
 
 	/**
-	 * @brief Command receive callback
+	 * @brief Command send callback
 	 *
-	 * Called when a command has been sent, to give the result of the
-	 * command
+	 * Called when a command has been sent
 	 * See also media_proxy_ctrl_command_send()
 	 *
 	 * @param player   Media player instance pointer
 	 * @param err      Error value. 0 on success, GATT error on positive value
 	 *                 or errno on negative value.
-	 * @param cmd_ntf  The result of the command
+	 * @param cmd      The command sent
 	 */
-	void (*command)(struct media_player *player, int err, struct mpl_cmd_ntf cmd_ntf);
+	void (*command_send)(struct media_player *player, int err, struct mpl_cmd cmd);
+
+	/**
+	 * @brief Command result receive callback
+	 *
+	 * Called when a command result has been received
+	 * See also media_proxy_ctrl_command_send()
+	 *
+	 * @param player   Media player instance pointer
+	 * @param err      Error value. 0 on success, GATT error on positive value
+	 *                 or errno on negative value.
+	 * @param result   The result received
+	 */
+	void (*command_recv)(struct media_player *player, int err, struct mpl_cmd_ntf result);
 
 	/**
 	 * @brief Commands supported receive callback
@@ -991,6 +1003,8 @@ int media_proxy_ctrl_media_state_get(struct media_player *player);
  *
  * Send a command to the media player.
  * Commands may cause the media player to change its state
+ * May result in two callbacks - one for the actual sending of the command to the
+ * player, one for the result of the command from the player.
  *
  * @param player      Media player instance pointer
  * @param command     The command to send

--- a/subsys/bluetooth/host/audio/media_proxy.h
+++ b/subsys/bluetooth/host/audio/media_proxy.h
@@ -74,7 +74,7 @@ struct mpl_sci {
 struct mpl_search {
 	uint8_t len;
 	char    search[SEARCH_LEN_MAX]; /* Concatenated search control items */
-};	                                /* - (type, length, param) */
+};                                      /* - (type, length, param) */
 
 
 /* PUBLIC API FOR CONTROLLERS */
@@ -279,7 +279,7 @@ struct media_proxy_ctrl_cbs {
 	 * @param player   Media player instance pointer
 	 * @param err      Error value. 0 on success, GATT error on positive value
 	 *                 or errno on negative value.
-	 * @param name	   The name of the media player
+	 * @param name     The name of the media player
 	 */
 	void (*player_name_recv)(struct media_player *player, int err, const char *name);
 
@@ -292,7 +292,7 @@ struct media_proxy_ctrl_cbs {
 	 * @param player   Media player instance pointer
 	 * @param err      Error value. 0 on success, GATT error on positive value
 	 *                 or errno on negative value.
-	 * @param id	   The ID of the Icon object in the Object Transfer Service (48 bits)
+	 * @param id       The ID of the Icon object in the Object Transfer Service (48 bits)
 	 */
 	void (*icon_id_recv)(struct media_player *player, int err, uint64_t id);
 
@@ -305,7 +305,7 @@ struct media_proxy_ctrl_cbs {
 	 * @param player   Media player instance pointer
 	 * @param err      Error value. 0 on success, GATT error on positive value
 	 *                 or errno on negative value.
-	 * @param url	   The URL of the icon
+	 * @param url      The URL of the icon
 	 */
 	void (*icon_url_recv)(struct media_player *player, int err, const char *url);
 
@@ -329,7 +329,7 @@ struct media_proxy_ctrl_cbs {
 	 * @param player   Media player instance pointer
 	 * @param err      Error value. 0 on success, GATT error on positive value
 	 *                 or errno on negative value.
-	 * @param title	   The title of the current track
+	 * @param title    The title of the current track
 	 */
 	void (*track_title_recv)(struct media_player *player, int err, const char *title);
 
@@ -422,7 +422,7 @@ struct media_proxy_ctrl_cbs {
 	 * @param player   Media player instance pointer
 	 * @param err      Error value. 0 on success, GATT error on positive value
 	 *                 or errno on negative value.
-	 * @param id	   The ID of the track segments object in Object Transfer Service (48 bits)
+	 * @param id       The ID of the track segments object in Object Transfer Service (48 bits)
 	 */
 	void (*track_segments_id_recv)(struct media_player *player, int err, uint64_t id);
 
@@ -436,7 +436,7 @@ struct media_proxy_ctrl_cbs {
 	 * @param player   Media player instance pointer
 	 * @param err      Error value. 0 on success, GATT error on positive value
 	 *                 or errno on negative value.
-	 * @param id	   The ID of the current track object in Object Transfer Service (48 bits)
+	 * @param id       The ID of the current track object in Object Transfer Service (48 bits)
 	 */
 	void (*current_track_id_recv)(struct media_player *player, int err, uint64_t id);
 
@@ -449,7 +449,7 @@ struct media_proxy_ctrl_cbs {
 	 * @param player   Media player instance pointer
 	 * @param err      Error value. 0 on success, GATT error on positive value
 	 *                 or errno on negative value.
-	 * @param id	   The ID (48 bits) attempted to write
+	 * @param id       The ID (48 bits) attempted to write
 	 */
 	void (*current_track_id_write)(struct media_player *player, int err, uint64_t id);
 
@@ -463,7 +463,7 @@ struct media_proxy_ctrl_cbs {
 	 * @param player   Media player instance pointer
 	 * @param err      Error value. 0 on success, GATT error on positive value
 	 *                 or errno on negative value.
-	 * @param id	   The ID of the next track object in Object Transfer Service (48 bits)
+	 * @param id       The ID of the next track object in Object Transfer Service (48 bits)
 	 */
 	void (*next_track_id_recv)(struct media_player *player, int err, uint64_t id);
 
@@ -476,7 +476,7 @@ struct media_proxy_ctrl_cbs {
 	 * @param player   Media player instance pointer
 	 * @param err      Error value. 0 on success, GATT error on positive value
 	 *                 or errno on negative value.
-	 * @param id	   The ID (48 bits) attempted to write
+	 * @param id       The ID (48 bits) attempted to write
 	 */
 	void (*next_track_id_write)(struct media_player *player, int err, uint64_t id);
 
@@ -490,7 +490,7 @@ struct media_proxy_ctrl_cbs {
 	 * @param player   Media player instance pointer
 	 * @param err      Error value. 0 on success, GATT error on positive value
 	 *                 or errno on negative value.
-	 * @param id	   The ID of the current group object in Object Transfer Service (48 bits)
+	 * @param id       The ID of the current group object in Object Transfer Service (48 bits)
 	 */
 	void (*current_group_id_recv)(struct media_player *player, int err, uint64_t id);
 
@@ -503,7 +503,7 @@ struct media_proxy_ctrl_cbs {
 	 * @param player   Media player instance pointer
 	 * @param err      Error value. 0 on success, GATT error on positive value
 	 *                 or errno on negative value.
-	 * @param id	   The ID (48 bits) attempted to write
+	 * @param id       The ID (48 bits) attempted to write
 	 */
 	void (*current_group_id_write)(struct media_player *player, int err, uint64_t id);
 
@@ -516,7 +516,7 @@ struct media_proxy_ctrl_cbs {
 	 * @param player   Media player instance pointer
 	 * @param err      Error value. 0 on success, GATT error on positive value
 	 *                 or errno on negative value.
-	 * @param id	   The ID of the parent group object in Object Transfer Service (48 bits)
+	 * @param id       The ID of the parent group object in Object Transfer Service (48 bits)
 	 */
 	void (*parent_group_id_recv)(struct media_player *player, int err, uint64_t id);
 
@@ -654,7 +654,7 @@ struct media_proxy_ctrl_cbs {
 	 * @param player   Media player instance pointer
 	 * @param err      Error value. 0 on success, GATT error on positive value
 	 *                 or errno on negative value.
-	 * @param id	   The ID of the search results object in Object Transfer Service (48 bits)
+	 * @param id       The ID of the search results object in Object Transfer Service (48 bits)
 	 */
 	void (*search_results_id_recv)(struct media_player *player, int err, uint64_t id);
 
@@ -886,7 +886,7 @@ int media_proxy_ctrl_current_track_id_get(struct media_player *player);
  * Requires Object Transfer Service
  *
  * @param player   Media player instance pointer
- * @param id	   The ID of a track object
+ * @param id       The ID of a track object
  *
  * @return 0 if success, errno on failure.
  */
@@ -946,7 +946,7 @@ int media_proxy_ctrl_current_group_id_get(struct media_player *player);
  * Requires Object Transfer Service
  *
  * @param player   Media player instance pointer
- * @param id	   The ID of a group object
+ * @param id       The ID of a group object
  *
  * @return 0 if success, errno on failure.
  */
@@ -986,7 +986,7 @@ int media_proxy_ctrl_playing_order_get(struct media_player *player);
  * Set the media player's playing order
  *
  * @param player   Media player instance pointer
- * @param order	   The playing order to set
+ * @param order    The playing order to set
  *
  * @return 0 if success, errno on failure.
  */
@@ -1169,7 +1169,7 @@ struct media_proxy_pl_calls {
 	 * values, and (backwards) from the end of the track for
 	 * negative values.
 	 *
-	 * @param position	The player position to set
+	 * @param position    The player position to set
 	 */
 	void (*track_position_set)(int32_t position);
 
@@ -1256,7 +1256,7 @@ struct media_proxy_pl_calls {
 	 * Change the player's current track to the track given by the ID.
 	 * (Behaves similarly to the goto track command.)
 	 *
-	 * @param id	The ID of a track object
+	 * @param id    The ID of a track object
 	 */
 	void (*current_track_id_set)(uint64_t id);
 
@@ -1275,7 +1275,7 @@ struct media_proxy_pl_calls {
 	 *
 	 * Change the player's next track to the track given by the ID.
 	 *
-	 * @param id	The ID of a track object
+	 * @param id    The ID of a track object
 	 */
 	void (*next_track_id_set)(uint64_t id);
 
@@ -1298,7 +1298,7 @@ struct media_proxy_pl_calls {
 	 * Change the player's current group to the group given by the
 	 * ID, and the current track to the first track in that group.
 	 *
-	 * @param id	The ID of a group object
+	 * @param id    The ID of a group object
 	 */
 	void (*current_group_id_set)(uint64_t id);
 
@@ -1603,7 +1603,7 @@ void media_proxy_pl_search_cb(uint8_t result_code);
  * To be called when the ID of the search results is changed
  * (typically as the result of a new successful search).
  *
- * @param id	The ID of the search results object in the OTS
+ * @param id    The ID of the search results object in the OTS
  */
 void media_proxy_pl_search_results_id_cb(uint64_t id);
 

--- a/subsys/bluetooth/host/audio/media_proxy.h
+++ b/subsys/bluetooth/host/audio/media_proxy.h
@@ -615,18 +615,35 @@ struct media_proxy_ctrl_cbs {
 	void (*commands_supported_recv)(struct media_player *player, int err, uint32_t opcodes);
 
 	/**
-	 * @brief Search receive callback
+	 * @brief Search send callback
 	 *
-	 * Called when a search operation has been set, to give the result
-	 * of the operation
+	 * Called when a search has been sent
 	 * See also media_proxy_ctrl_search_send()
 	 *
 	 * @param player        Media player instance pointer
 	 * @param err           Error value. 0 on success, GATT error on positive value
 	 *                      or errno on negative value.
-	 * @param result_code   The result of the operation
+	 * @param search        The search sent
 	 */
-	void (*search)(struct media_player *player, int err, uint8_t result_code);
+	void (*search_send)(struct media_player *player, int err, struct mpl_search search);
+
+	/**
+	 * @brief Search result code receive callback
+	 *
+	 * Called when a search result code has been received
+	 * See also media_proxy_ctrl_search_send()
+	 *
+	 * The search result code tells whether the search was successful or not.
+	 * For a successful search, the actual results of the search (i.e. what was found
+	 * as a result of the search)can be accessed using the Search Results Object ID.
+	 * The Search Results Object ID has a separate callback - search_results_id_recv().
+	 *
+	 * @param player        Media player instance pointer
+	 * @param err           Error value. 0 on success, GATT error on positive value
+	 *                      or errno on negative value.
+	 * @param result_code   Search result code
+	 */
+	void (*search_recv)(struct media_player *player, int err, uint8_t result_code);
 
 	/**
 	 * @brief Search Results Object ID receive callback
@@ -1029,8 +1046,13 @@ int media_proxy_ctrl_commands_supported_get(struct media_player *player);
  * @brief Set Search
  *
  * Write a search to the media player.
- * If the search is successful, the search result will be available as an object
- * in the Object Transfer Service.
+ * If the search is successful, the search results will be available as a group object
+ * in the Object Transfer Service (OTS).
+ *
+ * May result in up to three callbacks
+ * - one for the actual sending of the search to the player
+ * - one for the result code for the search from the player
+ * - if the search is successful, one for the the search results object ID in the OTs
  *
  * Requires Object Transfer Service
  *

--- a/subsys/bluetooth/host/audio/media_proxy.h
+++ b/subsys/bluetooth/host/audio/media_proxy.h
@@ -361,6 +361,19 @@ struct media_proxy_ctrl_cbs {
 	void (*track_position_recv)(struct media_player *player, int err, int32_t position);
 
 	/**
+	 * @brief Track Position write callback
+	 *
+	 * Called when the Track Position is written
+	 * See also media_proxy_ctrl_track_position_set().
+	 *
+	 * @param player     Media player instance pointer
+	 * @param err        Error value. 0 on success, GATT error on positive value
+	 *                   or errno on negative value.
+	 * @param position   The position given attempted to write
+	 */
+	void (*track_position_write)(struct media_player *player, int err, int32_t position);
+
+	/**
 	 * @brief Playback Speed receive callback
 	 *
 	 * Called when the Playback Speed is read or changed
@@ -373,6 +386,19 @@ struct media_proxy_ctrl_cbs {
 	 * @param speed    The playback speed parameter
 	 */
 	void (*playback_speed_recv)(struct media_player *player, int err, int8_t speed);
+
+	/**
+	 * @brief Playback Speed write callback
+	 *
+	 * Called when the Playback Speed is written
+	 * See also media_proxy_ctrl_playback_speed_set()
+	 *
+	 * @param player   Media player instance pointer
+	 * @param err      Error value. 0 on success, GATT error on positive value
+	 *                 or errno on negative value.
+	 * @param speed    The playback speed parameter attempted to write
+	 */
+	void (*playback_speed_write)(struct media_player *player, int err, int8_t speed);
 
 	/**
 	 * @brief Seeking Speed receive callback
@@ -415,6 +441,19 @@ struct media_proxy_ctrl_cbs {
 	void (*current_track_id_recv)(struct media_player *player, int err, uint64_t id);
 
 	/**
+	 * @brief Current Track Object ID write callback
+	 *
+	 * Called when the Current Track Object ID is written
+	 * See also media_proxy_ctrl_current_track_id_set()
+	 *
+	 * @param player   Media player instance pointer
+	 * @param err      Error value. 0 on success, GATT error on positive value
+	 *                 or errno on negative value.
+	 * @param id	   The ID (48 bits) attempted to write
+	 */
+	void (*current_track_id_write)(struct media_player *player, int err, uint64_t id);
+
+	/**
 	 * @brief Next Track Object ID receive callback
 	 *
 	 * Called when the Next Track Object ID is read or changed
@@ -429,6 +468,19 @@ struct media_proxy_ctrl_cbs {
 	void (*next_track_id_recv)(struct media_player *player, int err, uint64_t id);
 
 	/**
+	 * @brief Next Track Object ID write callback
+	 *
+	 * Called when the Next Track Object ID is written
+	 * See also media_proxy_ctrl_next_track_id_set()
+	 *
+	 * @param player   Media player instance pointer
+	 * @param err      Error value. 0 on success, GATT error on positive value
+	 *                 or errno on negative value.
+	 * @param id	   The ID (48 bits) attempted to write
+	 */
+	void (*next_track_id_write)(struct media_player *player, int err, uint64_t id);
+
+	/**
 	 * @brief Current Group Object ID receive callback
 	 *
 	 * Called when the Current Group Object ID is read or changed
@@ -441,6 +493,19 @@ struct media_proxy_ctrl_cbs {
 	 * @param id	   The ID of the current group object in Object Transfer Service (48 bits)
 	 */
 	void (*current_group_id_recv)(struct media_player *player, int err, uint64_t id);
+
+	/**
+	 * @brief Current Group Object ID write callback
+	 *
+	 * Called when the Current Group Object ID is written
+	 * See also media_proxy_ctrl_current_group_id_set()
+	 *
+	 * @param player   Media player instance pointer
+	 * @param err      Error value. 0 on success, GATT error on positive value
+	 *                 or errno on negative value.
+	 * @param id	   The ID (48 bits) attempted to write
+	 */
+	void (*current_group_id_write)(struct media_player *player, int err, uint64_t id);
 
 	/**
 	 * @brief Parent Group Object ID receive callback
@@ -468,6 +533,19 @@ struct media_proxy_ctrl_cbs {
 	 * @param order    The playing order
 	 */
 	void (*playing_order_recv)(struct media_player *player, int err, uint8_t order);
+
+	/**
+	 * @brief Playing Order write callback
+	 *
+	 * Called when the Playing Order is written
+	 * See also media_proxy_ctrl_playing_order_set()
+	 *
+	 * @param player   Media player instance pointer
+	 * @param err      Error value. 0 on success, GATT error on positive value
+	 *                 or errno on negative value.
+	 * @param order    The playing order attempted to write
+	 */
+	void (*playing_order_write)(struct media_player *player, int err, uint8_t order);
 
 	/**
 	 * @brief Playing Orders Supported receive callback

--- a/subsys/bluetooth/host/audio/media_proxy.h
+++ b/subsys/bluetooth/host/audio/media_proxy.h
@@ -271,7 +271,7 @@ struct media_proxy_ctrl_cbs {
 	void (*discover_player)(struct media_player *player, int err);
 
 	/**
-	 * @brief Media Player Name callback
+	 * @brief Media Player Name receive callback
 	 *
 	 * Called when the Media Player Name is read or changed
 	 * See also media_proxy_ctrl_name_get()
@@ -281,10 +281,10 @@ struct media_proxy_ctrl_cbs {
 	 *                 or errno on negative value.
 	 * @param name	   The name of the media player
 	 */
-	void (*player_name)(struct media_player *player, int err, const char *name);
+	void (*player_name_recv)(struct media_player *player, int err, const char *name);
 
 	/**
-	 * @brief Media Player Icon Object ID callback
+	 * @brief Media Player Icon Object ID receive callback
 	 *
 	 * Called when the Media Player Icon Object ID is read
 	 * See also media_proxy_ctrl_icon_id_get()
@@ -294,10 +294,10 @@ struct media_proxy_ctrl_cbs {
 	 *                 or errno on negative value.
 	 * @param id	   The ID of the Icon object in the Object Transfer Service (48 bits)
 	 */
-	void (*icon_id)(struct media_player *player, int err, uint64_t id);
+	void (*icon_id_recv)(struct media_player *player, int err, uint64_t id);
 
 	/**
-	 * @brief Media Player Icon URL callback
+	 * @brief Media Player Icon URL receive callback
 	 *
 	 * Called when the Media Player Icon URL is read
 	 * See also media_proxy_ctrl_icon_url_get()
@@ -307,10 +307,10 @@ struct media_proxy_ctrl_cbs {
 	 *                 or errno on negative value.
 	 * @param url	   The URL of the icon
 	 */
-	void (*icon_url)(struct media_player *player, int err, const char *url);
+	void (*icon_url_recv)(struct media_player *player, int err, const char *url);
 
 	/**
-	 * @brief Track changed callback
+	 * @brief Track changed receive callback
 	 *
 	 * Called when the Current Track is changed
 	 *
@@ -318,10 +318,10 @@ struct media_proxy_ctrl_cbs {
 	 * @param err      Error value. 0 on success, GATT error on positive value
 	 *                 or errno on negative value.
 	 */
-	void (*track_changed)(struct media_player *player, int err);
+	void (*track_changed_recv)(struct media_player *player, int err);
 
 	/**
-	 * @brief Track Title callback
+	 * @brief Track Title receive callback
 	 *
 	 * Called when the Track Title is read or changed
 	 * See also media_proxy_ctrl_track_title_get()
@@ -331,10 +331,10 @@ struct media_proxy_ctrl_cbs {
 	 *                 or errno on negative value.
 	 * @param title	   The title of the current track
 	 */
-	void (*track_title)(struct media_player *player, int err, const char *title);
+	void (*track_title_recv)(struct media_player *player, int err, const char *title);
 
 	/**
-	 * @brief Track Duration callback
+	 * @brief Track Duration receive callback
 	 *
 	 * Called when the Track Duration is read or changed
 	 * Seel also media_proxy_ctrl_track_duration_get()
@@ -344,10 +344,10 @@ struct media_proxy_ctrl_cbs {
 	 *                   or errno on negative value.
 	 * @param duration   The duration of the current track
 	 */
-	void (*track_duration)(struct media_player *player, int err, int32_t duration);
+	void (*track_duration_recv)(struct media_player *player, int err, int32_t duration);
 
 	/**
-	 * @brief Track Position callback
+	 * @brief Track Position receive callback
 	 *
 	 * Called when the Track Position is read or changed
 	 * See also media_proxy_ctrl_track_position_get() and
@@ -358,10 +358,10 @@ struct media_proxy_ctrl_cbs {
 	 *                   or errno on negative value.
 	 * @param position   The player's position in the track
 	 */
-	void (*track_position)(struct media_player *player, int err, int32_t position);
+	void (*track_position_recv)(struct media_player *player, int err, int32_t position);
 
 	/**
-	 * @brief Playback Speed callback
+	 * @brief Playback Speed receive callback
 	 *
 	 * Called when the Playback Speed is read or changed
 	 * See also media_proxy_ctrl_playback_speed_get() and
@@ -372,10 +372,10 @@ struct media_proxy_ctrl_cbs {
 	 *                 or errno on negative value.
 	 * @param speed    The playback speed parameter
 	 */
-	void (*playback_speed)(struct media_player *player, int err, int8_t speed);
+	void (*playback_speed_recv)(struct media_player *player, int err, int8_t speed);
 
 	/**
-	 * @brief Seeking Speed callback
+	 * @brief Seeking Speed receive callback
 	 *
 	 * Called when the Seeking Speed is read or changed
 	 * See also media_proxy_ctrl_seeking_speed_get()
@@ -385,10 +385,10 @@ struct media_proxy_ctrl_cbs {
 	 *                 or errno on negative value.
 	 * @param speed    The seeking speed factor
 	 */
-	void (*seeking_speed)(struct media_player *player, int err, int8_t speed);
+	void (*seeking_speed_recv)(struct media_player *player, int err, int8_t speed);
 
 	/**
-	 * @brief Track Segments Object ID callback
+	 * @brief Track Segments Object ID receive callback
 	 *
 	 * Called when the Track Segments Object ID is read
 	 * See also media_proxy_ctrl_track_segments_id_get()
@@ -398,10 +398,10 @@ struct media_proxy_ctrl_cbs {
 	 *                 or errno on negative value.
 	 * @param id	   The ID of the track segments object in Object Transfer Service (48 bits)
 	 */
-	void (*track_segments_id)(struct media_player *player, int err, uint64_t id);
+	void (*track_segments_id_recv)(struct media_player *player, int err, uint64_t id);
 
 	/**
-	 * @brief Current Track Object ID callback
+	 * @brief Current Track Object ID receive callback
 	 *
 	 * Called when the Current Track Object ID is read or changed
 	 * See also media_proxy_ctrl_current_track_id_get() and
@@ -412,10 +412,10 @@ struct media_proxy_ctrl_cbs {
 	 *                 or errno on negative value.
 	 * @param id	   The ID of the current track object in Object Transfer Service (48 bits)
 	 */
-	void (*current_track_id)(struct media_player *player, int err, uint64_t id);
+	void (*current_track_id_recv)(struct media_player *player, int err, uint64_t id);
 
 	/**
-	 * @brief Next Track Object ID callback
+	 * @brief Next Track Object ID receive callback
 	 *
 	 * Called when the Next Track Object ID is read or changed
 	 * See also media_proxy_ctrl_next_track_id_get() and
@@ -426,10 +426,10 @@ struct media_proxy_ctrl_cbs {
 	 *                 or errno on negative value.
 	 * @param id	   The ID of the next track object in Object Transfer Service (48 bits)
 	 */
-	void (*next_track_id)(struct media_player *player, int err, uint64_t id);
+	void (*next_track_id_recv)(struct media_player *player, int err, uint64_t id);
 
 	/**
-	 * @brief Current Group Object ID callback
+	 * @brief Current Group Object ID receive callback
 	 *
 	 * Called when the Current Group Object ID is read or changed
 	 * See also media_proxy_ctrl_current_group_id_get() and
@@ -440,10 +440,10 @@ struct media_proxy_ctrl_cbs {
 	 *                 or errno on negative value.
 	 * @param id	   The ID of the current group object in Object Transfer Service (48 bits)
 	 */
-	void (*current_group_id)(struct media_player *player, int err, uint64_t id);
+	void (*current_group_id_recv)(struct media_player *player, int err, uint64_t id);
 
 	/**
-	 * @brief Parent Group Object ID callback
+	 * @brief Parent Group Object ID receive callback
 	 *
 	 * Called when the Parent Group Object ID is read or changed
 	 * See also media_proxy_ctrl_parent_group_id_get()
@@ -453,10 +453,10 @@ struct media_proxy_ctrl_cbs {
 	 *                 or errno on negative value.
 	 * @param id	   The ID of the parent group object in Object Transfer Service (48 bits)
 	 */
-	void (*parent_group_id)(struct media_player *player, int err, uint64_t id);
+	void (*parent_group_id_recv)(struct media_player *player, int err, uint64_t id);
 
 	/**
-	 * @brief Playing Order callback
+	 * @brief Playing Order receive callback
 	 *
 	 * Called when the Playing Order is read or changed
 	 * See also media_proxy_ctrl_playing_order_get() and
@@ -467,10 +467,10 @@ struct media_proxy_ctrl_cbs {
 	 *                 or errno on negative value.
 	 * @param order    The playing order
 	 */
-	void (*playing_order)(struct media_player *player, int err, uint8_t order);
+	void (*playing_order_recv)(struct media_player *player, int err, uint8_t order);
 
 	/**
-	 * @brief Playing Orders Supported callback
+	 * @brief Playing Orders Supported receive callback
 	 *
 	 * Called when the Playing Orders Supported is read
 	 * See also media_proxy_ctrl_playing_orders_supported_get()
@@ -480,10 +480,11 @@ struct media_proxy_ctrl_cbs {
 	 *                 or errno on negative value.
 	 * @param orders   The playing orders supported
 	 */
-	void (*playing_orders_supported)(struct media_player *player, int err, uint16_t orders);
+	void (*playing_orders_supported_recv)(struct media_player *player, int err,
+					      uint16_t orders);
 
 	/**
-	 * @brief Media State callback
+	 * @brief Media State receive callback
 	 *
 	 * Called when the Media State is read or changed
 	 * See also media_proxy_ctrl_media_state_get() and
@@ -494,10 +495,10 @@ struct media_proxy_ctrl_cbs {
 	 *                 or errno on negative value.
 	 * @param state    The media player state
 	 */
-	void (*media_state)(struct media_player *player, int err, uint8_t state);
+	void (*media_state_recv)(struct media_player *player, int err, uint8_t state);
 
 	/**
-	 * @brief Command callback
+	 * @brief Command receive callback
 	 *
 	 * Called when a command has been sent, to give the result of the
 	 * command
@@ -511,7 +512,7 @@ struct media_proxy_ctrl_cbs {
 	void (*command)(struct media_player *player, int err, struct mpl_cmd_ntf cmd_ntf);
 
 	/**
-	 * @brief Commands supported callback
+	 * @brief Commands supported receive callback
 	 *
 	 * Called when the Commands Supported is read or changed
 	 * See also media_proxy_ctrl_commands_supported_get()
@@ -521,10 +522,10 @@ struct media_proxy_ctrl_cbs {
 	 *                     or errno on negative value.
 	 * @param opcodes      The supported command opcodes (bitmap)
 	 */
-	void (*commands_supported)(struct media_player *player, int err, uint32_t opcodes);
+	void (*commands_supported_recv)(struct media_player *player, int err, uint32_t opcodes);
 
 	/**
-	 * @brief Search callback
+	 * @brief Search receive callback
 	 *
 	 * Called when a search operation has been set, to give the result
 	 * of the operation
@@ -538,7 +539,7 @@ struct media_proxy_ctrl_cbs {
 	void (*search)(struct media_player *player, int err, uint8_t result_code);
 
 	/**
-	 * @brief Search Results Object ID callback
+	 * @brief Search Results Object ID receive callback
 	 * See also media_proxy_ctrl_search_results_id_get()
 	 *
 	 * Called when the Search Results Object ID is read or changed
@@ -548,10 +549,10 @@ struct media_proxy_ctrl_cbs {
 	 *                 or errno on negative value.
 	 * @param id	   The ID of the search results object in Object Transfer Service (48 bits)
 	 */
-	void (*search_results_id)(struct media_player *player, int err, uint64_t id);
+	void (*search_results_id_recv)(struct media_player *player, int err, uint64_t id);
 
 	/**
-	 * @brief Content Control ID callback
+	 * @brief Content Control ID receive callback
 	 *
 	 * Called when the Content Control ID is read
 	 * See also media_proxy_ctrl_content_ctrl_id_get()
@@ -561,7 +562,7 @@ struct media_proxy_ctrl_cbs {
 	 *                 or errno on negative value.
 	 * @param ccid     The content control ID
 	 */
-	void (*content_ctrl_id)(struct media_player *player, int err, uint8_t ccid);
+	void (*content_ctrl_id_recv)(struct media_player *player, int err, uint8_t ccid);
 };
 
 /**

--- a/subsys/bluetooth/shell/media_controller.c
+++ b/subsys/bluetooth/shell/media_controller.c
@@ -324,7 +324,17 @@ static void commands_supported_cb(struct media_player *plr, int err, uint32_t op
 }
 
 #ifdef CONFIG_BT_OTS
-static void search_cb(struct media_player *plr, int err, uint8_t result_code)
+static void search_send_cb(struct media_player *plr, int err, struct mpl_search search)
+{
+	if (err) {
+		shell_error(ctx_shell, "Player: %p, Search send failed (%d)", plr, err);
+		return;
+	}
+
+	shell_print(ctx_shell, "Player: %p, Search sent with len %u", plr, search.len);
+}
+
+static void search_recv_cb(struct media_player *plr, int err, uint8_t result_code)
 {
 	if (err) {
 		shell_error(ctx_shell, "Player: %p, Search failed (%d)", plr, err);
@@ -404,7 +414,8 @@ int cmd_media_init(const struct shell *sh, size_t argc, char *argv[])
 	cbs.command_recv                  = command_recv_cb;
 	cbs.commands_supported_recv       = commands_supported_cb;
 #ifdef CONFIG_BT_OTS
-	cbs.search                        = search_cb;
+	cbs.search_send                   = search_send_cb;
+	cbs.search_recv                   = search_recv_cb;
 	cbs.search_results_id_recv        = search_results_id_cb;
 #endif /* CONFIG_BT_OTS */
 	cbs.content_ctrl_id_recv          = content_ctrl_id_cb;

--- a/subsys/bluetooth/shell/media_controller.c
+++ b/subsys/bluetooth/shell/media_controller.c
@@ -291,7 +291,17 @@ static void media_state_cb(struct media_player *plr, int err, uint8_t state)
 	/* TODO: Parse state and output state name (e.g. "Playing") */
 }
 
-static void command_cb(struct media_player *plr, int err, struct mpl_cmd_ntf cmd_ntf)
+static void command_send_cb(struct media_player *plr, int err, struct mpl_cmd cmd)
+{
+	if (err) {
+		shell_error(ctx_shell, "Player: %p, Command send failed (%d)", plr, err);
+		return;
+	}
+
+	shell_print(ctx_shell, "Player: %p, Command opcode sent: %u", plr, cmd.opcode);
+}
+
+static void command_recv_cb(struct media_player *plr, int err, struct mpl_cmd_ntf cmd_ntf)
 {
 	if (err) {
 		shell_error(ctx_shell, "Player: %p, Command failed (%d)", plr, err);
@@ -390,7 +400,8 @@ int cmd_media_init(const struct shell *sh, size_t argc, char *argv[])
 	cbs.playing_order_write           = playing_order_write_cb;
 	cbs.playing_orders_supported_recv = playing_orders_supported_cb;
 	cbs.media_state_recv              = media_state_cb;
-	cbs.command                       = command_cb;
+	cbs.command_send                  = command_send_cb;
+	cbs.command_recv                  = command_recv_cb;
 	cbs.commands_supported_recv       = commands_supported_cb;
 #ifdef CONFIG_BT_OTS
 	cbs.search                        = search_cb;

--- a/subsys/bluetooth/shell/media_controller.c
+++ b/subsys/bluetooth/shell/media_controller.c
@@ -336,34 +336,34 @@ int cmd_media_init(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	/* Set up the callback structure */
-	cbs.discover_player          = discover_player_cb;
-	cbs.local_player_instance    = local_player_instance_cb;
-	cbs.player_name              = player_name_cb;
-	cbs.icon_id                  = icon_id_cb;
-	cbs.icon_url                 = icon_url_cb;
-	cbs.track_changed            = track_changed_cb;
-	cbs.track_title              = track_title_cb;
-	cbs.track_duration           = track_duration_cb;
-	cbs.track_position           = track_position_cb;
-	cbs.playback_speed           = playback_speed_cb;
-	cbs.seeking_speed            = seeking_speed_cb;
+	cbs.discover_player               = discover_player_cb;
+	cbs.local_player_instance         = local_player_instance_cb;
+	cbs.player_name_recv              = player_name_cb;
+	cbs.icon_id_recv                  = icon_id_cb;
+	cbs.icon_url_recv                 = icon_url_cb;
+	cbs.track_changed_recv            = track_changed_cb;
+	cbs.track_title_recv              = track_title_cb;
+	cbs.track_duration_recv           = track_duration_cb;
+	cbs.track_position_recv           = track_position_cb;
+	cbs.playback_speed_recv           = playback_speed_cb;
+	cbs.seeking_speed_recv            = seeking_speed_cb;
 #ifdef CONFIG_BT_OTS
-	cbs.track_segments_id        = track_segments_id_cb;
-	cbs.current_track_id         = current_track_id_cb;
-	cbs.next_track_id            = next_track_id_cb;
-	cbs.current_group_id         = current_group_id_cb;
-	cbs.parent_group_id          = parent_group_id_cb;
+	cbs.track_segments_id_recv        = track_segments_id_cb;
+	cbs.current_track_id_recv         = current_track_id_cb;
+	cbs.next_track_id_recv            = next_track_id_cb;
+	cbs.current_group_id_recv         = current_group_id_cb;
+	cbs.parent_group_id_recv          = parent_group_id_cb;
 #endif /* CONFIG_BT_OTS */
-	cbs.playing_order            = playing_order_cb;
-	cbs.playing_orders_supported = playing_orders_supported_cb;
-	cbs.media_state              = media_state_cb;
-	cbs.command                  = command_cb;
-	cbs.commands_supported       = commands_supported_cb;
+	cbs.playing_order_recv            = playing_order_cb;
+	cbs.playing_orders_supported_recv = playing_orders_supported_cb;
+	cbs.media_state_recv              = media_state_cb;
+	cbs.command                       = command_cb;
+	cbs.commands_supported_recv       = commands_supported_cb;
 #ifdef CONFIG_BT_OTS
-	cbs.search                   = search_cb;
-	cbs.search_results_id        = search_results_id_cb;
+	cbs.search                        = search_cb;
+	cbs.search_results_id_recv        = search_results_id_cb;
 #endif /* CONFIG_BT_OTS */
-	cbs.content_ctrl_id          = content_ctrl_id_cb;
+	cbs.content_ctrl_id_recv          = content_ctrl_id_cb;
 
 	err = media_proxy_ctrl_register(&cbs);
 	if (err) {

--- a/subsys/bluetooth/shell/media_controller.c
+++ b/subsys/bluetooth/shell/media_controller.c
@@ -127,24 +127,44 @@ static void track_duration_cb(struct media_player *plr, int err, int32_t duratio
 	shell_print(ctx_shell, "Player: %p, Track duration: %d", plr, duration);
 }
 
-static void track_position_cb(struct media_player *plr, int err, int32_t position)
+static void track_position_recv_cb(struct media_player *plr, int err, int32_t position)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Track position failed (%d)", plr, err);
+		shell_error(ctx_shell, "Player: %p, Track position receive failed (%d)", plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Track Position: %d", plr, position);
+	shell_print(ctx_shell, "Player: %p, Track Position received: %d", plr, position);
 }
 
-static void playback_speed_cb(struct media_player *plr, int err, int8_t speed)
+static void track_position_write_cb(struct media_player *plr, int err, int32_t position)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Playback speed failed (%d)", plr, err);
+		shell_error(ctx_shell, "Player: %p, Track position write failed (%d)", plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Playback speed: %d", plr, speed);
+	shell_print(ctx_shell, "Player: %p, Track Position write: %d", plr, position);
+}
+
+static void playback_speed_recv_cb(struct media_player *plr, int err, int8_t speed)
+{
+	if (err) {
+		shell_error(ctx_shell, "Player: %p, Playback speed receive failed (%d)", plr, err);
+		return;
+	}
+
+	shell_print(ctx_shell, "Player: %p, Playback speed received: %d", plr, speed);
+}
+
+static void playback_speed_write_cb(struct media_player *plr, int err, int8_t speed)
+{
+	if (err) {
+		shell_error(ctx_shell, "Player: %p, Playback speed write failed (%d)", plr, err);
+		return;
+	}
+
+	shell_print(ctx_shell, "Player: %p, Playback speed write: %d", plr, speed);
 }
 
 static void seeking_speed_cb(struct media_player *plr, int err, int8_t speed)
@@ -228,14 +248,24 @@ static void parent_group_id_cb(struct media_player *plr, int err, uint64_t id)
 }
 #endif /* CONFIG_BT_OTS */
 
-static void playing_order_cb(struct media_player *plr, int err, uint8_t order)
+static void playing_order_recv_cb(struct media_player *plr, int err, uint8_t order)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Playing order failed (%d)", plr, err);
+		shell_error(ctx_shell, "Player: %p, Playing order receive_failed (%d)", plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Playing order: %u", plr, order);
+	shell_print(ctx_shell, "Player: %p, Playing received: %u", plr, order);
+}
+
+static void playing_order_write_cb(struct media_player *plr, int err, uint8_t order)
+{
+	if (err) {
+		shell_error(ctx_shell, "Player: %p, Playing order write_failed (%d)", plr, err);
+		return;
+	}
+
+	shell_print(ctx_shell, "Player: %p, Playing written: %u", plr, order);
 }
 
 static void playing_orders_supported_cb(struct media_player *plr, int err, uint16_t orders)
@@ -344,8 +374,10 @@ int cmd_media_init(const struct shell *sh, size_t argc, char *argv[])
 	cbs.track_changed_recv            = track_changed_cb;
 	cbs.track_title_recv              = track_title_cb;
 	cbs.track_duration_recv           = track_duration_cb;
-	cbs.track_position_recv           = track_position_cb;
-	cbs.playback_speed_recv           = playback_speed_cb;
+	cbs.track_position_recv           = track_position_recv_cb;
+	cbs.track_position_write          = track_position_write_cb;
+	cbs.playback_speed_recv           = playback_speed_recv_cb;
+	cbs.playback_speed_write          = playback_speed_write_cb;
 	cbs.seeking_speed_recv            = seeking_speed_cb;
 #ifdef CONFIG_BT_OTS
 	cbs.track_segments_id_recv        = track_segments_id_cb;
@@ -354,7 +386,8 @@ int cmd_media_init(const struct shell *sh, size_t argc, char *argv[])
 	cbs.current_group_id_recv         = current_group_id_cb;
 	cbs.parent_group_id_recv          = parent_group_id_cb;
 #endif /* CONFIG_BT_OTS */
-	cbs.playing_order_recv            = playing_order_cb;
+	cbs.playing_order_recv            = playing_order_recv_cb;
+	cbs.playing_order_write           = playing_order_write_cb;
 	cbs.playing_orders_supported_recv = playing_orders_supported_cb;
 	cbs.media_state_recv              = media_state_cb;
 	cbs.command                       = command_cb;

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/media_controller_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/media_controller_test.c
@@ -440,33 +440,33 @@ void initialize_media(void)
 	}
 
 	/* Set up the callback structure */
-	cbs.local_player_instance    = local_player_instance_cb;
-	cbs.discover_player          = discover_player_cb;
-	cbs.player_name              = player_name_cb;
-	cbs.icon_id                  = icon_id_cb;
-	cbs.icon_url                 = icon_url_cb;
-	cbs.track_title              = track_title_cb;
-	cbs.track_duration           = track_duration_cb;
-	cbs.track_position           = track_position_cb;
-	cbs.playback_speed           = playback_speed_cb;
-	cbs.seeking_speed            = seeking_speed_cb;
+	cbs.local_player_instance         = local_player_instance_cb;
+	cbs.discover_player               = discover_player_cb;
+	cbs.player_name_recv              = player_name_cb;
+	cbs.icon_id_recv                  = icon_id_cb;
+	cbs.icon_url_recv                 = icon_url_cb;
+	cbs.track_title_recv              = track_title_cb;
+	cbs.track_duration_recv           = track_duration_cb;
+	cbs.track_position_recv           = track_position_cb;
+	cbs.playback_speed_recv           = playback_speed_cb;
+	cbs.seeking_speed_recv            = seeking_speed_cb;
 #ifdef CONFIG_BT_OTS
-	cbs.track_segments_id        = track_segments_id_cb;
-	cbs.current_track_id         = current_track_id_cb;
-	cbs.next_track_id            = next_track_id_cb;
-	cbs.current_group_id         = current_group_id_cb;
-	cbs.parent_group_id          = parent_group_id_cb;
+	cbs.track_segments_id_recv        = track_segments_id_cb;
+	cbs.current_track_id_recv         = current_track_id_cb;
+	cbs.next_track_id_recv            = next_track_id_cb;
+	cbs.current_group_id_recv         = current_group_id_cb;
+	cbs.parent_group_id_recv          = parent_group_id_cb;
 #endif /* CONFIG_BT_OTS */
-	cbs.playing_order            = playing_order_cb;
-	cbs.playing_orders_supported = playing_orders_supported_cb;
-	cbs.media_state              = media_state_cb;
-	cbs.command                  = command_cb;
-	cbs.commands_supported       = commands_supported_cb;
+	cbs.playing_order_recv            = playing_order_cb;
+	cbs.playing_orders_supported_recv = playing_orders_supported_cb;
+	cbs.media_state_recv              = media_state_cb;
+	cbs.command                       = command_cb;
+	cbs.commands_supported_recv       = commands_supported_cb;
 #ifdef CONFIG_BT_OTS
-	cbs.search                   = search_cb;
-	cbs.search_results_id        = search_results_id_cb;
+	cbs.search                        = search_cb;
+	cbs.search_results_id_recv        = search_results_id_cb;
 #endif /* CONFIG_BT_OTS */
-	cbs.content_ctrl_id          = content_ctrl_id_cb;
+	cbs.content_ctrl_id_recv          = content_ctrl_id_cb;
 
 	UNSET_FLAG(local_player_instance);
 


### PR DESCRIPTION
This PR adds missing write callbacks to the media proxy (they were forgotten when the media proxy was done).
Writes no longer have to use the read/notify callbacks.
