### PR TITLE
drivers: pinmux: stm32: fix remap equality check

### DIFF
--- a/drivers/pinmux/pinmux_stm32.c
+++ b/drivers/pinmux/pinmux_stm32.c
@@ -169,16 +169,12 @@ int stm32_dt_pinctrl_configure(const struct soc_gpio_pinctrl *pinctrl,
 int stm32_dt_pinctrl_remap(const struct soc_gpio_pinctrl *pinctrl,
 			   size_t list_size, uint32_t base)
 {
-	int remap;
-	uint32_t mux;
+	uint8_t remap;
 
-	remap = STM32_DT_PINMUX_REMAP(pinctrl[0].pinmux);
+	remap = (uint8_t)STM32_DT_PINMUX_REMAP(pinctrl[0].pinmux);
 
-	for (int i = 1; i < list_size; i++) {
-		mux = pinctrl[i].pinmux;
-		remap = STM32_DT_PINMUX_REMAP(mux);
-
-		if (STM32_DT_PINMUX_REMAP(mux) != remap) {
+	for (size_t i = 1U; i < list_size; i++) {
+		if (STM32_DT_PINMUX_REMAP(pinctrl[i].pinmux) != remap) {
 			return -EINVAL;
 		}
 	}

--- a/drivers/pinmux/pinmux_stm32.h
+++ b/drivers/pinmux/pinmux_stm32.h
@@ -70,7 +70,7 @@ struct soc_gpio_pinctrl {
  * value
  */
 #define STM32_DT_PINMUX_REMAP(__pin) \
-	((__pin) & 0x1f)
+	((__pin) & 0x1fU)
 #endif
 
 /* pretend that array will cover pin functions */


### PR DESCRIPTION
The equality check for remap was not being performed since the local
variable remap was assigned to the value being checked just before the
check. Some minor simplifications have been performed (fixed variable
types).

This PR is part of some improvements while doing an initial port of the pinmux STM32 driver to the #37572 API