### PR TITLE
Bluetooth: ISO: Add missing negation for valid_chan_io_qos

### DIFF
--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -1451,7 +1451,7 @@ static int big_init_bis(struct bt_iso_big *big, bool broadcaster)
 
 		if (broadcaster) {
 			CHECKIF(bis->qos->tx == NULL ||
-				valid_chan_io_qos(bis->qos->tx, true)) {
+				!valid_chan_io_qos(bis->qos->tx, true)) {
 				BT_DBG("Invalid BIS QOS");
 				return -EINVAL;
 			}


### PR DESCRIPTION
A check for valid_chan_io_qos in big_init_bis was missing
a negation when checking for invalid parameters.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>