### PR TITLE
device: add DEVICE_DT_GET_OR_NULL utility macro

### DIFF
--- a/drivers/pinmux/pinmux_stm32.c
+++ b/drivers/pinmux/pinmux_stm32.c
@@ -24,23 +24,18 @@
 #include <pinmux/pinmux_stm32.h>
 #include <pm/device_runtime.h>
 
-#define GPIO_DEVICE(gpio_port)						\
-	COND_CODE_1(DT_NODE_HAS_STATUS(DT_NODELABEL(gpio_port), okay),	\
-		    (DEVICE_DT_GET(DT_NODELABEL(gpio_port))),		\
-		    ((const struct device *)NULL))
-
 const struct device * const gpio_ports[STM32_PORTS_MAX] = {
-	GPIO_DEVICE(gpioa),
-	GPIO_DEVICE(gpiob),
-	GPIO_DEVICE(gpioc),
-	GPIO_DEVICE(gpiod),
-	GPIO_DEVICE(gpioe),
-	GPIO_DEVICE(gpiof),
-	GPIO_DEVICE(gpiog),
-	GPIO_DEVICE(gpioh),
-	GPIO_DEVICE(gpioi),
-	GPIO_DEVICE(gpioj),
-	GPIO_DEVICE(gpiok),
+	DEVICE_DT_GET_OR_NULL(DT_NODELABEL(gpioa)),
+	DEVICE_DT_GET_OR_NULL(DT_NODELABEL(gpiob)),
+	DEVICE_DT_GET_OR_NULL(DT_NODELABEL(gpioc)),
+	DEVICE_DT_GET_OR_NULL(DT_NODELABEL(gpiod)),
+	DEVICE_DT_GET_OR_NULL(DT_NODELABEL(gpioe)),
+	DEVICE_DT_GET_OR_NULL(DT_NODELABEL(gpiof)),
+	DEVICE_DT_GET_OR_NULL(DT_NODELABEL(gpiog)),
+	DEVICE_DT_GET_OR_NULL(DT_NODELABEL(gpioh)),
+	DEVICE_DT_GET_OR_NULL(DT_NODELABEL(gpioi)),
+	DEVICE_DT_GET_OR_NULL(DT_NODELABEL(gpioj)),
+	DEVICE_DT_GET_OR_NULL(DT_NODELABEL(gpiok)),
 };
 
 static int stm32_pin_configure(uint32_t pin, uint32_t func, uint32_t altf)

--- a/include/device.h
+++ b/include/device.h
@@ -302,6 +302,19 @@ typedef int16_t device_handle_t;
 		    (ZERO_OR_COMPILE_ERROR(0)))
 
 /**
+ * @def DEVICE_DT_GET_OR_NULL
+ *
+ * @brief Utility macro to obtain an optional reference to a device.
+ *
+ * @param node_id Node identifier.
+ *
+ * @return Pointer to a device if it exists, NULL otherwise.
+ */
+#define DEVICE_DT_GET_OR_NULL(node_id)					\
+	COND_CODE_1(DT_NODE_HAS_STATUS(node_id, okay),			\
+		    (DEVICE_DT_GET(node_id)), (NULL))
+
+/**
  * @def DEVICE_GET
  *
  * @brief Obtain a pointer to a device object by name

--- a/tests/lib/devicetree/devices/src/main.c
+++ b/tests/lib/devicetree/devices/src/main.c
@@ -211,6 +211,17 @@ static void test_supports(void)
 	zassert_true(check_handle(DEV_HDL(TEST_DEVB), hdls, nhdls), NULL);
 }
 
+static void test_get_or_null(void)
+{
+	const struct device *dev;
+
+	dev = DEVICE_DT_GET_OR_NULL(TEST_DEVA);
+	zassert_not_equal(dev, NULL, NULL);
+
+	dev = DEVICE_DT_GET_OR_NULL(non_existing_node);
+	zassert_equal(dev, NULL, NULL);
+}
+
 void test_main(void)
 {
 	size_t ndevs;
@@ -221,7 +232,8 @@ void test_main(void)
 	ztest_test_suite(devicetree_driver,
 			 ztest_unit_test(test_init_order),
 			 ztest_unit_test(test_requires),
-			 ztest_unit_test(test_supports)
+			 ztest_unit_test(test_supports),
+			 ztest_unit_test(test_get_or_null)
 			 );
 	ztest_run_test_suite(devicetree_driver);
 }


### PR DESCRIPTION
Add a new utility macro to obtain an optional reference to a device. If
the provided node_id is not enabled, the macro falls back to NULL.