### PR TITLE
 cmake: Zephyr ALLOW_EMPTY library property

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -712,9 +712,12 @@ foreach(zephyr_lib ${ZEPHYR_LIBS_PROPERTY})
     if(NOT source_list
        AND NOT ${lib_imported}
     )
-      message(WARNING
-        "No SOURCES given to Zephyr library: ${zephyr_lib}\nExcluding target from build."
-      )
+      get_property(allow_empty TARGET ${zephyr_lib} PROPERTY ALLOW_EMPTY)
+      if(NOT "${allow_empty}")
+        message(WARNING
+          "No SOURCES given to Zephyr library: ${zephyr_lib}\nExcluding target from build."
+        )
+      endif()
       target_sources(${zephyr_lib} PRIVATE ${ZEPHYR_BASE}/misc/empty_file.c)
       set_property(TARGET ${zephyr_lib} PROPERTY EXCLUDE_FROM_ALL TRUE)
       list(REMOVE_ITEM ZEPHYR_LIBS_PROPERTY ${zephyr_lib})

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -565,6 +565,31 @@ function(zephyr_library_app_memory partition)
                "-l" $<TARGET_FILE_NAME:${ZEPHYR_CURRENT_LIBRARY}> "${partition}")
 endfunction()
 
+# Configure a Zephyr library specific property.
+#
+# Usage:
+#   zephyr_library_property(<property> <value>)
+#
+# Current Zephyr library specific properties that are supported:
+# ALLOW_EMPTY <TRUE:FALSE>: Allow a Zephyr library to be empty.
+#                           An empty Zephyr library will generate a CMake
+#                           configure time warning unless `ALLOW_EMPTY` is TRUE.
+function(zephyr_library_property)
+  set(single_args "ALLOW_EMPTY")
+  cmake_parse_arguments(LIB_PROP "" "${single_args}" "" ${ARGN})
+  target_compile_definitions(${ZEPHYR_CURRENT_LIBRARY} PRIVATE ${item} ${ARGN})
+
+  if(LIB_PROP_UNPARSED_ARGUMENTS)
+      message(FATAL_ERROR "zephyr_library_property(${ARGV0} ...) given unknown arguments: ${FILE_UNPARSED_ARGUMENTS}")
+  endif()
+
+  foreach(arg ${single_args})
+    if(DEFINED LIB_PROP_${arg})
+      set_property(TARGET ${ZEPHYR_CURRENT_LIBRARY} PROPERTY ${arg} ${LIB_PROP_${arg}})
+    endif()
+  endforeach()
+endfunction()
+
 # 1.2.1 zephyr_interface_library_*
 #
 # A Zephyr interface library is a thin wrapper over a CMake INTERFACE

--- a/drivers/interrupt_controller/CMakeLists.txt
+++ b/drivers/interrupt_controller/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library()
+zephyr_library_property(ALLOW_EMPTY TRUE)
 zephyr_library_sources_ifdef(CONFIG_ARCV2_INTERRUPT_UNIT    intc_arcv2_irq_unit.c)
 zephyr_library_sources_ifdef(CONFIG_CAVS_ICTL               intc_cavs.c)
 zephyr_library_sources_ifdef(CONFIG_DW_ICTL                 intc_dw.c)


### PR DESCRIPTION
This commit is an alternative to #37910



 drives: cmake: zephyr_library_property(ALLOW_EMPTY TRUE) on drivers lib

This commit now sets the Zephyr library property `ALLOW_EMPTY` to
silence the warning:
`No SOURCES given to Zephyr library: drivers__interrupt_controller`

-----

 cmake: Zephyr ALLOW_EMPTY library property

This introduces a dedicated zephyr_library_property() function which
provides a common way to set Zephyr build system known properties on
Zephyr libraries.

As a first common property is the `ALLOW_EMPTY` property which allows
to create a `zephyr_library()` without putting any content inside of it.

In general libraries should not be created unless there are files to
places inside of it, however in some cases there are so many
`zephyr_library_sources_ifdef(<setting> <file.c>)`
where testing each setting before creating the library may not be
desired.

This commit allows the following construct in those cases:
```
zephyr_library()
zephyr_library_property(ALLOW_EMPTY TRUE)
zephyr_library_sources_ifdef(CONFIG_SETTING_1 file_1.c)
zephyr_library_sources_ifdef(CONFIG_SETTING_2 file_2.c)
...
zephyr_library_sources_ifdef(CONFIG_SETTING_n file_n.c)

```
