### PR TITLE
bsim: test: fix missing of warnings in bsim test build system

### DIFF
--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_scanner.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_scanner.c
@@ -67,7 +67,7 @@ static void test_tx_device_setup(void)
 /** Bypassing setting up transmission, and will try to send the raw data that is
  *  provided to the function.
  */
-static void test_tx_send_ad_type_msg(uint8_t type, uint8_t *data, uint8_t len)
+static void test_tx_send_ad_type_msg(uint8_t type, const uint8_t *data, uint8_t len)
 {
 	struct bt_le_adv_param param = {};
 	uint16_t duration, adv_int;

--- a/tests/bluetooth/bsim_bt/compile.sh
+++ b/tests/bluetooth/bsim_bt/compile.sh
@@ -23,6 +23,7 @@ function compile(){
   local conf_file="${conf_file:-prj.conf}"
   local cmake_args="${cmake_args:-"-DCONFIG_COVERAGE=y"}"
   local ninja_args="${ninja_args:-""}"
+  local cc_flags="${cc_flags:-"-Werror"}"
 
   local exe_name="${exe_name:-bs_${BOARD}_${app}_${conf_file}}"
   local exe_name=${exe_name//\//_}
@@ -39,8 +40,9 @@ function compile(){
       [ -d "${this_dir}" ] && rm ${this_dir} -rf
       mkdir -p ${this_dir} && cd ${this_dir}
       cmake -GNinja -DBOARD_ROOT=${BOARD_ROOT} -DBOARD=${BOARD} \
-            -DCONF_FILE=${conf_file} ${cmake_args} ${app_root}/${app} \
-            &> cmake.out || { cat cmake.out && return 0; }
+        -DCONF_FILE=${conf_file} ${cmake_args} \
+        -DCMAKE_C_FLAGS="${cc_flags}" ${app_root}/${app} \
+        &> cmake.out || { cat cmake.out && return 0; }
   else
       cd ${this_dir}
   fi


### PR DESCRIPTION
bsim test build system hides compile warnings.
This commit adds extra cc flags to prevent this.

Signed-off-by: Aleksandr Khromykh <aleksandr.khromykh@nordicsemi.no>