### PR TITLE
Split LE Audio broadcast source API from connected

### DIFF
--- a/include/bluetooth/audio.h
+++ b/include/bluetooth/audio.h
@@ -905,8 +905,9 @@ int bt_audio_chan_start(struct bt_audio_chan *chan);
  *
  *  This procedure is used by a client to make a channel stop streaming.
  *
- *  This shall only be called for unicast and broadcast source channels, as
- *  broadcast sinks will always be started once synchronized.
+ *  This shall only be called for unicast channels.
+ *  Broadcast sinks cannot be stopped.
+ *  Broadcast sources shall be stopped with bt_audio_broadcast_source_stop().
  *
  *  @param chan Channel object
  *
@@ -1005,6 +1006,18 @@ int bt_audio_broadcast_source_create(struct bt_audio_chan *chan,
  *  @return Zero on success or (negative) error code otherwise.
  */
 int bt_audio_broadcast_source_start(struct bt_audio_broadcast_source *source);
+
+/** @brief Stop audio broadcast source.
+ *
+ *  Stop an audio broadcast source.
+ *  The broadcast source will stop advertising BIGInfo, and audio data can no
+ *  longer be streamed.
+ *
+ *  @param source      Pointer to the broadcast source
+ *
+ *  @return Zero on success or (negative) error code otherwise.
+ */
+int bt_audio_broadcast_source_stop(struct bt_audio_broadcast_source *source);
 
 /** @brief Start scan for broadcast sources.
  *

--- a/include/bluetooth/audio.h
+++ b/include/bluetooth/audio.h
@@ -983,15 +983,17 @@ int bt_audio_chan_send(struct bt_audio_chan *chan, struct net_buf *buf);
  *  Starting any one channel for a broadcaster will start all the others
  *  supplied to this function.
  *
- *  @param chan        Channel object being used for the broadcaster.
- *  @param codec       Codec configuration.
- *  @param qos         Quality of Service configuration
+ *  @param[in]  chan        Channel object being used for the broadcaster.
+ *  @param[in]  codec       Codec configuration.
+ *  @param[in]  qos         Quality of Service configuration
+ *  @param[out] source      Pointer to the broadcast source created
  *
  *  @return Zero on success or (negative) error code otherwise.
  */
 int bt_audio_broadcast_source_create(struct bt_audio_chan *chan,
 				     struct bt_codec *codec,
-				     struct bt_codec_qos *qos);
+				     struct bt_codec_qos *qos,
+				     struct bt_audio_broadcast_source **source);
 
 /** @brief Start scan for broadcast sources.
  *

--- a/include/bluetooth/audio.h
+++ b/include/bluetooth/audio.h
@@ -891,8 +891,9 @@ int bt_audio_chan_disable(struct bt_audio_chan *chan);
  *
  *  This procedure is used by a client to make a channel start streaming.
  *
- *  This shall only be called for unicast and broadcast source channels, as
- *  broadcast sinks will always be started once synchronized.
+ *  This shall only be called for unicast channels.
+ *  Broadcast sinks will always be started once synchronized, and broadcast
+ *  source channels shall be started with bt_audio_broadcast_source_start().
  *
  *  @param chan Channel object
  *
@@ -968,20 +969,18 @@ int bt_audio_chan_unlink(struct bt_audio_chan *chan1,
  */
 int bt_audio_chan_send(struct bt_audio_chan *chan, struct net_buf *buf);
 
-/** @brief Create audio broadcaster.
+/** @brief Create audio broadcast source.
  *
- *  Create a new audio broadcaster with one or more audio channels. To create a
- *  broadcaster with multiple channels, the channels must be linked with
- *  bt_audio_chan_link.
+ *  Create a new audio broadcast source with one or more audio channels.
+ *  To create a broadcast source with multiple channels, the channels must be
+ *  linked with bt_audio_chan_link().
  *
- *  The broadcaster will be visible for scanners once this has been called, and
- *  the device will advertise audio announcements.
+ *  The broadcast source will be visible for scanners once this has been called,
+ *  and the device will advertise audio announcements.
  *
- *  No audio data can be sent until bt_audio_chan_start has been called.
- *  No audio information (BIGInfo) will be visible to scanners
- *  (see bt_le_per_adv_sync_cb) until bt_audio_chan_start has been called.
- *  Starting any one channel for a broadcaster will start all the others
- *  supplied to this function.
+ *  No audio data can be sent until bt_audio_broadcast_source_start() has been
+ *  called and no audio information (BIGInfo) will be visible to scanners
+ *  (see bt_le_per_adv_sync_cb).
  *
  *  @param[in]  chan        Channel object being used for the broadcaster.
  *  @param[in]  codec       Codec configuration.
@@ -994,6 +993,18 @@ int bt_audio_broadcast_source_create(struct bt_audio_chan *chan,
 				     struct bt_codec *codec,
 				     struct bt_codec_qos *qos,
 				     struct bt_audio_broadcast_source **source);
+
+/** @brief Start audio broadcast source.
+ *
+ *  Start an audio broadcast source with one or more audio channels.
+ *  The broadcast source will start advertising BIGInfo, and audio data can
+ *  be streamed.
+ *
+ *  @param source      Pointer to the broadcast source
+ *
+ *  @return Zero on success or (negative) error code otherwise.
+ */
+int bt_audio_broadcast_source_start(struct bt_audio_broadcast_source *source);
 
 /** @brief Start scan for broadcast sources.
  *

--- a/include/bluetooth/audio.h
+++ b/include/bluetooth/audio.h
@@ -922,6 +922,8 @@ int bt_audio_chan_stop(struct bt_audio_chan *chan);
  *
  *  Broadcast sink channels shall be released using
  *  bt_audio_broadcast_sink_release.
+ *  Broadcast source channels cannot be released, but can be deleted by
+ *  bt_audio_broadcast_source_delete().
  *
  *  @param chan Channel object
  *  @param cache True to cache the codec configuration or false to forget it
@@ -1018,6 +1020,18 @@ int bt_audio_broadcast_source_start(struct bt_audio_broadcast_source *source);
  *  @return Zero on success or (negative) error code otherwise.
  */
 int bt_audio_broadcast_source_stop(struct bt_audio_broadcast_source *source);
+
+/** @brief Delete audio broadcast source.
+ *
+ *  Delete an audio broadcast source.
+ *  The broadcast source will stop advertising entirely, and the source can
+ *  no longer be used.
+ *
+ *  @param source      Pointer to the broadcast source
+ *
+ *  @return Zero on success or (negative) error code otherwise.
+ */
+int bt_audio_broadcast_source_delete(struct bt_audio_broadcast_source *source);
 
 /** @brief Start scan for broadcast sources.
  *

--- a/include/bluetooth/audio.h
+++ b/include/bluetooth/audio.h
@@ -821,7 +821,7 @@ struct bt_audio_chan *bt_audio_chan_config(struct bt_conn *conn,
  *  This procedure is used by a client to reconfigure a channel using the
  *  a different local capability and/or codec configuration.
  *
- *  This can only be done for unicast and broadcast source channels.
+ *  This can only be done for unicast channels.
  *
  *  @param chan Channel object being reconfigured
  *  @param cap Local Audio Capability being reconfigured
@@ -996,6 +996,21 @@ int bt_audio_broadcast_source_create(struct bt_audio_chan *chan,
 				     struct bt_codec *codec,
 				     struct bt_codec_qos *qos,
 				     struct bt_audio_broadcast_source **source);
+
+/** @brief Reconfigure audio broadcast source.
+ *
+ *  Reconfigure an audio broadcast source with a new codec and codec quality of
+ *  service parameters.
+ *
+ *  @param source      Pointer to the broadcast source
+ *  @param codec       Codec configuration.
+ *  @param qos         Quality of Service configuration
+ *
+ *  @return Zero on success or (negative) error code otherwise.
+ */
+int bt_audio_broadcast_source_reconfig(struct bt_audio_broadcast_source *source,
+				       struct bt_codec *codec,
+				       struct bt_codec_qos *qos);
 
 /** @brief Start audio broadcast source.
  *

--- a/subsys/bluetooth/host/audio/chan.c
+++ b/subsys/bluetooth/host/audio/chan.c
@@ -73,12 +73,14 @@ struct bt_audio_base_ad {
 
 static struct bt_iso_cig *cigs[CONNECTED_AUDIO_GROUP_COUNT];
 static struct bt_audio_chan *enabling[CONFIG_BT_ISO_MAX_CHAN];
+#if defined(CONFIG_BT_AUDIO_BROADCAST)
 static struct bt_audio_broadcast_source broadcast_sources[BROADCAST_SRC_CNT];
 static struct bt_audio_broadcast_sink broadcast_sinks[BROADCAST_SNK_CNT];
 static struct bt_le_scan_cb broadcast_scan_cb;
 
 static int bt_audio_set_base(const struct bt_audio_broadcast_source *source,
 			     struct bt_codec *codec);
+#endif /* CONFIG_BT_AUDIO_BROADCAST */
 
 static void chan_attach(struct bt_conn *conn, struct bt_audio_chan *chan,
 			struct bt_audio_ep *ep, struct bt_audio_capability *cap,
@@ -1145,6 +1147,7 @@ void bt_audio_chan_cb_register(struct bt_audio_chan *chan, struct bt_audio_chan_
 	chan->ops = ops;
 }
 
+#if defined(CONFIG_BT_AUDIO_BROADCAST)
 static int bt_audio_broadcast_source_setup_chan(uint8_t index,
 						struct bt_audio_chan *chan,
 						struct bt_codec *codec,
@@ -2501,5 +2504,5 @@ int bt_audio_broadcast_sink_release(struct bt_audio_broadcast_sink *sink)
 
 	return 0;
 }
-
+#endif /* CONFIG_BT_AUDIO_BROADCAST */
 #endif /* CONFIG_BT_BAP */

--- a/subsys/bluetooth/host/audio/chan.c
+++ b/subsys/bluetooth/host/audio/chan.c
@@ -1384,7 +1384,8 @@ static int bt_audio_set_base(const struct bt_audio_broadcast_source *source,
 
 int bt_audio_broadcast_source_create(struct bt_audio_chan *chan,
 				     struct bt_codec *codec,
-				     struct bt_codec_qos *qos)
+				     struct bt_codec_qos *qos,
+				     struct bt_audio_broadcast_source **out_source)
 {
 	struct bt_audio_broadcast_source *source;
 	struct bt_audio_chan *tmp;
@@ -1408,6 +1409,13 @@ int bt_audio_broadcast_source_create(struct bt_audio_chan *chan,
 	 * terms of BAP compliance), or even stop the advertiser without
 	 * stopping the BIG (which also goes against the BAP specification).
 	 */
+
+	CHECKIF(out_source == NULL) {
+		BT_DBG("out_source is NULL");
+		return -EINVAL;
+	}
+	/* Set out_source to NULL until the source has actually been created */
+	*out_source = NULL;
 
 	CHECKIF(chan == NULL) {
 		BT_DBG("chan is NULL");
@@ -1530,6 +1538,8 @@ int bt_audio_broadcast_source_create(struct bt_audio_chan *chan,
 	}
 
 	BT_DBG("Broadcasting with ID 0x%6X", source->broadcast_id);
+
+	*out_source = source;
 
 	return 0;
 }

--- a/subsys/bluetooth/host/audio/endpoint.c
+++ b/subsys/bluetooth/host/audio/endpoint.c
@@ -26,8 +26,12 @@
 
 static struct bt_audio_ep snks[CONFIG_BT_MAX_CONN][SNK_SIZE];
 static struct bt_audio_ep srcs[CONFIG_BT_MAX_CONN][SRC_SIZE];
+#if BROADCAST_SRC_CNT > 0
 static struct bt_audio_ep broadcast_srcs[BROADCAST_SRC_CNT][BROADCAST_STREAM_CNT];
+#endif /* BROADCAST_SRC_CNT > 0 */
+#if BROADCAST_SNK_CNT > 0
 static struct bt_audio_ep broadcast_snks[BROADCAST_SNK_CNT][BROADCAST_SNK_STREAM_CNT];
+#endif /* BROADCAST_SNK_CNT > 0 */
 
 #if defined(CONFIG_BT_BAP)
 static struct bt_gatt_subscribe_params cp_subscribe[CONFIG_BT_MAX_CONN];
@@ -240,20 +244,25 @@ struct bt_audio_ep *bt_audio_ep_new(struct bt_conn *conn, uint8_t dir,
 	return NULL;
 }
 
+#if defined(CONFIG_BT_AUDIO_BROADCAST)
 struct bt_audio_ep *bt_audio_ep_broadcaster_new(uint8_t index, uint8_t dir)
 {
 	int i, size;
 	struct bt_audio_ep *cache = NULL;
 
 	switch (dir) {
+#if BROADCAST_SNK_CNT > 0
 	case BT_AUDIO_SINK:
 		cache = broadcast_snks[index];
 		size = ARRAY_SIZE(broadcast_snks[index]);
 		break;
+#endif /* BROADCAST_SNK_CNT > 0 */
+#if BROADCAST_SRC_CNT > 0
 	case BT_AUDIO_SOURCE:
 		cache = broadcast_srcs[index];
 		size = ARRAY_SIZE(broadcast_srcs[index]);
 		break;
+#endif /* BROADCAST_SRC_CNT > 0 */
 	default:
 		return NULL;
 	}
@@ -276,6 +285,7 @@ struct bt_audio_ep *bt_audio_ep_broadcaster_new(uint8_t index, uint8_t dir)
 
 	return NULL;
 }
+#endif /* CONFIG_BT_AUDIO_BROADCAST */
 
 struct bt_audio_ep *bt_audio_ep_get(struct bt_conn *conn, uint8_t dir,
 				    uint16_t handle)
@@ -1433,7 +1443,7 @@ bool bt_audio_ep_is_broadcast_snk(const struct bt_audio_ep *ep)
 			return true;
 		}
 	}
-#endif /* BROADCAST_SRC_CNT > 0 */
+#endif /* BROADCAST_SNK_CNT > 0 */
 	return false;
 }
 

--- a/subsys/bluetooth/host/audio/endpoint.h
+++ b/subsys/bluetooth/host/audio/endpoint.h
@@ -38,6 +38,7 @@ struct bt_audio_broadcast_source {
 	uint8_t subgroup_count;
 	uint32_t pd; /** QoS Presentation Delay */
 	uint32_t broadcast_id; /* 24 bit */
+
 	struct bt_le_ext_adv *adv;
 	struct bt_iso_big *big;
 	struct bt_iso_chan *bis[BROADCAST_STREAM_CNT];

--- a/subsys/bluetooth/host/audio/endpoint.h
+++ b/subsys/bluetooth/host/audio/endpoint.h
@@ -41,6 +41,9 @@ struct bt_audio_broadcast_source {
 	struct bt_le_ext_adv *adv;
 	struct bt_iso_big *big;
 	struct bt_iso_chan *bis[BROADCAST_STREAM_CNT];
+	struct bt_codec_qos *qos;
+	/* The "main" channel used to create the broadcast source */
+	struct bt_audio_chan *chan;
 };
 
 struct bt_audio_broadcast_sink {

--- a/subsys/bluetooth/shell/bap.c
+++ b/subsys/bluetooth/shell/bap.c
@@ -1152,16 +1152,36 @@ static int cmd_create_broadcast(const struct shell *sh, size_t argc,
 	err = bt_audio_broadcast_source_create(free_chan, &preset->codec,
 					       &preset->qos, &default_source);
 	if (err != 0) {
-		shell_error(sh, "Unable to create broadcaster: %d", err);
+		shell_error(sh, "Unable to create broadcast source: %d", err);
 		return err;
 	}
 
 	broadcast_chan_index_bits |= BIT(i);
 
-	shell_print(sh, "Broadcaster created: preset %s", preset->name);
+	shell_print(sh, "Broadcast source created: preset %s", preset->name);
 
 	if (default_chan == NULL) {
 		default_chan = free_chan;
+	}
+
+	return 0;
+}
+
+
+static int cmd_start_broadcast(const struct shell *sh, size_t argc,
+			       char *argv[])
+{
+	int err;
+
+	if (default_source == NULL) {
+		shell_info(sh, "Broadcast source not created");
+		return -ENOEXEC;
+	}
+
+	err = bt_audio_broadcast_source_start(default_source);
+	if (err != 0) {
+		shell_error(sh, "Unable to start broadcast source: %d", err);
+		return err;
 	}
 
 	return 0;
@@ -1359,6 +1379,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bap_cmds,
 		      cmd_config, 3, 2),
 	SHELL_CMD_ARG(create_broadcast, NULL, "[codec] [preset]",
 		      cmd_create_broadcast, 1, 2),
+	SHELL_CMD_ARG(start_broadcast, NULL, "", cmd_start_broadcast, 1, 0),
 	SHELL_CMD_ARG(broadcast_scan, NULL, "<on, off>",
 		      cmd_broadcast_scan, 2, 0),
 	SHELL_CMD_ARG(accept_broadcast, NULL, "0x<broadcast_id>",

--- a/subsys/bluetooth/shell/bap.c
+++ b/subsys/bluetooth/shell/bap.c
@@ -1167,7 +1167,6 @@ static int cmd_create_broadcast(const struct shell *sh, size_t argc,
 	return 0;
 }
 
-
 static int cmd_start_broadcast(const struct shell *sh, size_t argc,
 			       char *argv[])
 {
@@ -1181,6 +1180,24 @@ static int cmd_start_broadcast(const struct shell *sh, size_t argc,
 	err = bt_audio_broadcast_source_start(default_source);
 	if (err != 0) {
 		shell_error(sh, "Unable to start broadcast source: %d", err);
+		return err;
+	}
+
+	return 0;
+}
+
+static int cmd_stop_broadcast(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err;
+
+	if (default_source == NULL) {
+		shell_info(sh, "Broadcast source not created");
+		return -ENOEXEC;
+	}
+
+	err = bt_audio_broadcast_source_stop(default_source);
+	if (err != 0) {
+		shell_error(sh, "Unable to stop broadcast source: %d", err);
 		return err;
 	}
 
@@ -1380,6 +1397,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bap_cmds,
 	SHELL_CMD_ARG(create_broadcast, NULL, "[codec] [preset]",
 		      cmd_create_broadcast, 1, 2),
 	SHELL_CMD_ARG(start_broadcast, NULL, "", cmd_start_broadcast, 1, 0),
+	SHELL_CMD_ARG(stop_broadcast, NULL, "", cmd_stop_broadcast, 1, 0),
 	SHELL_CMD_ARG(broadcast_scan, NULL, "<on, off>",
 		      cmd_broadcast_scan, 2, 0),
 	SHELL_CMD_ARG(accept_broadcast, NULL, "0x<broadcast_id>",

--- a/subsys/bluetooth/shell/bap.c
+++ b/subsys/bluetooth/shell/bap.c
@@ -477,10 +477,6 @@ static int cmd_release(const struct shell *sh, size_t argc, char *argv[])
 	if (err) {
 		shell_error(sh, "Unable to release Channel");
 		return -ENOEXEC;
-	} else {
-		if (PART_OF_ARRAY(broadcast_source_chans, default_chan)) {
-			default_source = NULL;
-		}
 	}
 
 	return 0;
@@ -1204,6 +1200,26 @@ static int cmd_stop_broadcast(const struct shell *sh, size_t argc, char *argv[])
 	return 0;
 }
 
+static int cmd_delete_broadcast(const struct shell *sh, size_t argc,
+				char *argv[])
+{
+	int err;
+
+	if (default_source == NULL) {
+		shell_info(sh, "Broadcast source not created");
+		return -ENOEXEC;
+	}
+
+	err = bt_audio_broadcast_source_delete(default_source);
+	if (err != 0) {
+		shell_error(sh, "Unable to delete broadcast source: %d", err);
+		return err;
+	}
+	default_source = NULL;
+
+	return 0;
+}
+
 static int cmd_broadcast_scan(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err;
@@ -1398,6 +1414,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bap_cmds,
 		      cmd_create_broadcast, 1, 2),
 	SHELL_CMD_ARG(start_broadcast, NULL, "", cmd_start_broadcast, 1, 0),
 	SHELL_CMD_ARG(stop_broadcast, NULL, "", cmd_stop_broadcast, 1, 0),
+	SHELL_CMD_ARG(delete_broadcast, NULL, "", cmd_delete_broadcast, 1, 0),
 	SHELL_CMD_ARG(broadcast_scan, NULL, "<on, off>",
 		      cmd_broadcast_scan, 2, 0),
 	SHELL_CMD_ARG(accept_broadcast, NULL, "0x<broadcast_id>",

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/broadcast_sink_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/broadcast_sink_test.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifdef CONFIG_BT_BAP
+#if defined(CONFIG_BT_BAP) && defined(CONFIG_BT_AUDIO_BROADCAST)
 
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/audio.h>
@@ -142,11 +142,11 @@ struct bst_test_list *test_broadcast_sink_install(struct bst_test_list *tests)
 	return bst_add_tests(tests, test_broadcast_sink);
 }
 
-#else /* !CONFIG_BT_BAP */
+#else /* !(CONFIG_BT_BAP && CONFIG_BT_AUDIO_BROADCAST) */
 
 struct bst_test_list *test_broadcast_sink_install(struct bst_test_list *tests)
 {
 	return tests;
 }
 
-#endif /* CONFIG_BT_BAP */
+#endif /* CONFIG_BT_BAP && CONFIG_BT_AUDIO_BROADCAST */

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/broadcast_source_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/broadcast_source_test.c
@@ -68,8 +68,9 @@ static void test_main(void)
 		return;
 	}
 
-	err = bt_audio_chan_reconfig(&broadcast_source_chans[0], NULL,
-				     &preset_48_2_2.codec);
+	err = bt_audio_broadcast_source_reconfig(source,
+						    &preset_48_2_2.codec,
+						    &preset_48_2_2.qos);
 	if (err != 0) {
 		FAIL("Unable to reconfigure broadcast source: %d", err);
 		return;

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/broadcast_source_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/broadcast_source_test.c
@@ -57,6 +57,7 @@ static void test_main(void)
 			bt_audio_chan_link(&broadcast_source_chans[i],
 					   &broadcast_source_chans[j]);
 		}
+
 	}
 
 	err = bt_audio_broadcast_source_create(&broadcast_source_chans[0],
@@ -77,6 +78,23 @@ static void test_main(void)
 	}
 
 	k_sleep(K_SECONDS(10));
+
+	err = bt_audio_broadcast_source_delete(source);
+	if (err != 0) {
+		FAIL("Unable to delete broadcast source: %d", err);
+		return;
+	}
+	source = NULL;
+
+	/* Recreate broadcast source to verify that it's possible */
+	err = bt_audio_broadcast_source_create(&broadcast_source_chans[0],
+					       &preset_48_1_2.codec,
+					       &preset_48_1_2.qos,
+					       &source);
+	if (err != 0) {
+		FAIL("Unable to create broadcast source: %d", err);
+		return;
+	}
 
 	err = bt_audio_broadcast_source_delete(source);
 	if (err != 0) {

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/broadcast_source_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/broadcast_source_test.c
@@ -77,9 +77,9 @@ static void test_main(void)
 
 	k_sleep(K_SECONDS(10));
 
-	err = bt_audio_chan_release(&broadcast_source_chans[0], false);
+	err = bt_audio_broadcast_source_delete(source);
 	if (err != 0) {
-		FAIL("Unable to release broadcast channels: %d", err);
+		FAIL("Unable to delete broadcast source: %d", err);
 		return;
 	}
 	source = NULL;

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/broadcast_source_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/broadcast_source_test.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifdef CONFIG_BT_BAP
+#if defined(CONFIG_BT_BAP) && defined(CONFIG_BT_AUDIO_BROADCAST)
 
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/audio.h>
@@ -103,11 +103,11 @@ struct bst_test_list *test_broadcast_source_install(struct bst_test_list *tests)
 	return bst_add_tests(tests, test_broadcast_source);
 }
 
-#else /* !CONFIG_BT_BAP */
+#else /* !(CONFIG_BT_BAP && CONFIG_BT_AUDIO_BROADCAST) */
 
 struct bst_test_list *test_broadcast_source_install(struct bst_test_list *tests)
 {
 	return tests;
 }
 
-#endif /* CONFIG_BT_BAP */
+#endif /* CONFIG_BT_BAP && CONFIG_BT_AUDIO_BROADCAST */

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/broadcast_source_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/broadcast_source_test.c
@@ -40,6 +40,7 @@ static void test_main(void)
 			   BT_CODEC_LC3_QOS_10_OUT_UNFRAMED(100u, 23u, 60u,
 							    40000u));
 	struct bt_audio_chan broadcast_source_chans[BROADCAST_STREAM_CNT];
+	struct bt_audio_broadcast_source *source;
 
 	err = bt_enable(NULL);
 	if (err) {
@@ -60,7 +61,8 @@ static void test_main(void)
 
 	err = bt_audio_broadcast_source_create(&broadcast_source_chans[0],
 					       &preset_48_1_2.codec,
-					       &preset_48_1_2.qos);
+					       &preset_48_1_2.qos,
+					       &source);
 	if (err != 0) {
 		FAIL("Unable to create broadcast source: %d", err);
 		return;
@@ -80,6 +82,7 @@ static void test_main(void)
 		FAIL("Unable to release broadcast channels: %d", err);
 		return;
 	}
+	source = NULL;
 
 	PASS("Broadcast source passed\n");
 }


### PR DESCRIPTION
Rather than using the LE Audio API for unicast/connected channels, we introduce a new API for the broadcast source. This significantly simplifies the API for both sides, as well a logical split.  