### PR TITLE
Stm spi clocks

### DIFF
--- a/dts/arm/st/f4/stm32f410.dtsi
+++ b/dts/arm/st/f4/stm32f410.dtsi
@@ -24,6 +24,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40015000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00100000>;
 			interrupts = <85 5>;
 			status = "disabled";
 			label = "SPI_5";

--- a/dts/arm/st/f4/stm32f411.dtsi
+++ b/dts/arm/st/f4/stm32f411.dtsi
@@ -23,6 +23,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40015000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00100000>;
 			interrupts = <85 5>;
 			status = "disabled";
 			label = "SPI_5";

--- a/dts/arm/st/f4/stm32f411.dtsi
+++ b/dts/arm/st/f4/stm32f411.dtsi
@@ -8,16 +8,6 @@
 
 / {
 	soc {
-		spi4: spi@40013400 {
-			compatible = "st,stm32-spi";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40013400 0x400>;
-			interrupts = <84 5>;
-			status = "disabled";
-			label = "SPI_4";
-		};
-
 		spi5: spi@40015000 {
 			compatible = "st,stm32-spi";
 			#address-cells = <1>;


### PR DESCRIPTION
It seems like SPI5 has never been used on stm32f411/412.
The clock was missing. Took a while to realize the problem was a missing clock, because SPI5 was configured like SPI4 in stm32f411.dtsi.
The reason though why spi4 might work (haven't used it my self) is that it is already fully defined in stm32f401.dtsi.

With this PR the duplicate spi4 attributes are removed and spi5 clock attribute is added
