### PR TITLE
[Backport v2.6-branch] Microchip: XEC GPIO driver interrupt enable fix part 2

### DIFF
--- a/drivers/gpio/gpio_mchp_xec.c
+++ b/drivers/gpio/gpio_mchp_xec.c
@@ -9,9 +9,12 @@
 #include <errno.h>
 #include <device.h>
 #include <drivers/gpio.h>
+#include <sys/sys_io.h>
 #include <soc.h>
 
 #include "gpio_utils.h"
+
+#define XEC_GPIO_EDGE_DLY_COUNT		4
 
 #define GPIO_IN_BASE(config) \
 	((__IO uint32_t *)(GPIO_PARIN_BASE + (config->port_num << 2)))
@@ -211,6 +214,10 @@ static int gpio_xec_pin_interrupt_configure(const struct device *dev,
 	 */
 	current_pcr1 = config->pcr1_base + pin;
 	*current_pcr1 = (*current_pcr1 & ~mask) | pcr1;
+	/* delay for HW to synchronize after it ungates its clock */
+	for (int i = 0; i < XEC_GPIO_EDGE_DLY_COUNT; i++) {
+		(void)*current_pcr1;
+	}
 
 	if (mode != GPIO_INT_MODE_DISABLED) {
 		/* We enable the interrupts in the EC aggregator so that the


### PR DESCRIPTION
Fixes issue #34879
This PR updates previous PR's 37138 and 37139.
Refer to issue 34879 for information from MCHP HW
designers. A delay after enabling interrupts is a
more appropriate work-around than depending upon
behavior of ARM DMB instruction.

Comparing to the original PR #37479 left changes only related to the
drivers/gpio/gpio_mchp_xec.c file
Tested  mec15xxevb_assy6853 board, no bugs GPIO detected

Signed-off-by: Scott Worley <scott.worley@microchip.com>
Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>