### PR TITLE
 west.yml: Update mcumgr revision and assisting commits

### DIFF
--- a/subsys/mgmt/mcumgr/Kconfig
+++ b/subsys/mgmt/mcumgr/Kconfig
@@ -156,6 +156,17 @@ config IMG_MGMT_UL_CHUNK_SIZE
 	  this size gets allocated on the stack during handling of a image upload
 	  command.
 
+config IMG_MGMT_UPDATABLE_IMAGE_NUMBER
+	int "Number of supported images"
+	default UPDATEABLE_IMAGE_NUMBER
+	range 1 2
+	help
+	  Sets how many application images are supported (pairs of secondary and primary slots).
+	  Setting this to 2 requires MCUMGR_BUF_SIZE to be at least 512b.
+	  NOTE: The UPDATEABLE_IMAGE_NUMBER of MCUBOOT configuration, even for Zephyr build,
+	  needs to be set to the same value; this is due to the fact that the mcumgr uses
+	  boot_util and the UPDATEABLE_IMAGE_NUMBER controls number of images supported
+	  by that library.
 
 config IMG_MGMT_VERBOSE_ERR
 	bool "Verbose logging when uploading a new image"

--- a/west.yml
+++ b/west.yml
@@ -161,7 +161,7 @@ manifest:
       revision: 70bfbd21cdf5f6d1402bc8d0031e197222ed2ec0
       path: bootloader/mcuboot
     - name: mcumgr
-      revision: 31a2aa9cea58d3ceecbf0d5b91361bff7c94aeca
+      revision: df9be737619956efbdeb65d4d6935ee0432a580f
       path: modules/lib/mcumgr
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
The PR contains commit that updates mcumgr revision and Zephyr commit that provides Kconfig option to control
additions of multi-image support, that is included with the revision update.

Commits affecting Zephyr that are included with the new revision:
- edb485c samples/smp_svr/zephyr: Increase main stack size
- c0cb989 zephyr: Do not use CONFIG_IMG_MGMT_UPDATABLE_IMAGE_NUMBER directly
- 10cda4e zephyr: Fix assert when image number out of range
- 347a418 zephyr: Fix erase command failing for multi-image configuration
- e06e772 zephyr: Fix possible memory leak in  img_mgmt_impl_write_image_data
- 345caab img_mgmt: fix callback parameter values

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>