### PR TITLE
Bluetooth: Mesh: Check if app key is bound in Model Publication Set

### DIFF
--- a/subsys/bluetooth/mesh/access.c
+++ b/subsys/bluetooth/mesh/access.c
@@ -553,7 +553,7 @@ uint8_t bt_mesh_elem_count(void)
 	return dev_comp->elem_count;
 }
 
-static bool model_has_key(struct bt_mesh_model *mod, uint16_t key)
+bool bt_mesh_model_has_key(struct bt_mesh_model *mod, uint16_t key)
 {
 	int i;
 
@@ -694,7 +694,7 @@ void bt_mesh_model_recv(struct bt_mesh_net_rx *rx, struct net_buf_simple *buf)
 			continue;
 		}
 
-		if (!model_has_key(model, rx->ctx.app_idx)) {
+		if (!bt_mesh_model_has_key(model, rx->ctx.app_idx)) {
 			continue;
 		}
 
@@ -729,7 +729,7 @@ int bt_mesh_model_send(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *msg,
 		       const struct bt_mesh_send_cb *cb, void *cb_data)
 {
-	if (!model_has_key(model, ctx->app_idx)) {
+	if (!bt_mesh_model_has_key(model, ctx->app_idx)) {
 		BT_ERR("Model not bound to AppKey 0x%04x", ctx->app_idx);
 		return -EINVAL;
 	}

--- a/subsys/bluetooth/mesh/access.h
+++ b/subsys/bluetooth/mesh/access.h
@@ -18,6 +18,7 @@ uint8_t bt_mesh_elem_count(void);
 struct bt_mesh_elem *bt_mesh_elem_find(uint16_t addr);
 
 bool bt_mesh_has_addr(uint16_t addr);
+bool bt_mesh_model_has_key(struct bt_mesh_model *mod, uint16_t key);
 
 void bt_mesh_model_extensions_walk(struct bt_mesh_model *root,
 				   enum bt_mesh_walk (*cb)(struct bt_mesh_model *mod,

--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -216,7 +216,7 @@ static uint8_t _mod_pub_set(struct bt_mesh_model *model, uint16_t pub_addr,
 		return STATUS_SUCCESS;
 	}
 
-	if (!bt_mesh_app_key_exists(app_idx)) {
+	if (!bt_mesh_app_key_exists(app_idx) || !bt_mesh_model_has_key(model, app_idx)) {
 		return STATUS_INVALID_APPKEY;
 	}
 


### PR DESCRIPTION
Th Configuration Server should respond with and Invalid AppKey Index
status code when the AppKey identified by AppKeyIndex is not known to
the node or is not bound to the model identified by the ModelIdentifier.

Signed-off-by: Michał Narajowski <michal.narajowski@codecoup.pl>