### PR TITLE
samples: i2c: fram: use node label instead of alias

### DIFF
--- a/samples/drivers/i2c_fujitsu_fram/sample.yaml
+++ b/samples/drivers/i2c_fujitsu_fram/sample.yaml
@@ -4,7 +4,7 @@ tests:
   sample.drivers.i2c.fujitsu_fram:
     tags: drivers
     depends_on: i2c
-    filter: dt_alias_exists("i2c-0")
+    filter: dt_nodelabel_enabled("i2c0")
     harness: console
     harness_config:
         type: one_line

--- a/samples/drivers/i2c_fujitsu_fram/src/main.c
+++ b/samples/drivers/i2c_fujitsu_fram/src/main.c
@@ -10,10 +10,8 @@
 #include <device.h>
 #include <drivers/i2c.h>
 
-#define I2C_NODE DT_ALIAS(i2c_0)
-
 /**
- * @file Sample app using the Fujitsu MB85RC256V FRAM through ARC I2C.
+ * @file Sample app using the Fujitsu MB85RC256V FRAM through I2C.
  */
 
 #define FRAM_I2C_ADDR	0x50
@@ -72,7 +70,7 @@ static int read_bytes(const struct device *i2c_dev, uint16_t addr,
 
 void main(void)
 {
-	const struct device *i2c_dev = DEVICE_DT_GET(I2C_NODE);
+	const struct device *i2c_dev = DEVICE_DT_GET(DT_NODELABEL(i2c0));
 	uint8_t cmp_data[16];
 	uint8_t data[16];
 	int i, ret;


### PR DESCRIPTION
Add more coverage by not using aliases and directly use node label.

Fixes #38154

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
