### PR TITLE
samples: bluetooth: hci_uart: Fix command len calculation

### DIFF
--- a/samples/bluetooth/hci_uart/src/main.c
+++ b/samples/bluetooth/hci_uart/src/main.c
@@ -78,7 +78,7 @@ static bool valid_type(uint8_t type)
 static uint32_t get_len(const uint8_t *hdr_buf, uint8_t type)
 {
 	switch (type) {
-	case BT_BUF_CMD:
+	case H4_CMD:
 		return ((const struct bt_hci_cmd_hdr *)hdr_buf)->param_len;
 	case H4_ISO:
 		return sys_le16_to_cpu(((const struct bt_hci_iso_data_hdr *)hdr_buf)->slen);


### PR DESCRIPTION
Due to a historical error introduced during an hci_uart refactor, the
get_len() function was using the wrong HCI H4 packet identifier for
commands. Instead of using H4_CMD (0x01) it was trying to match
BT_BUF_CMD (0x00).

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>