### PR TITLE
drivers/timer/cavs_timer: Don't suppress smp_timer_init()

### DIFF
--- a/drivers/timer/cavs_timer.c
+++ b/drivers/timer/cavs_timer.c
@@ -182,7 +182,6 @@ uint32_t sys_clock_cycle_get_32(void)
 	return count32();
 }
 
-#if defined(CONFIG_SMP) && CONFIG_MP_NUM_CPUS > 1 && !defined(CONFIG_SMP_BOOT_DELAY)
 /* Runs on secondary cores */
 void smp_timer_init(void)
 {
@@ -197,4 +196,3 @@ void smp_timer_init(void)
 		    22 + TIMER);
 	irq_enable(TIMER_IRQ);
 }
-#endif


### PR DESCRIPTION
This function wasn't being defined when SMP_BOOT_DELAY was set or when
SMP wasn't enabled.  There's no reason for either, then function
doesn't depend on any kconfig-dependent build-time state, and (given
that we use -ffunction-sections) it won't appear in output binaries
unless called.

And there are use cases (e.g. z_smp_start_cpu()) where we need that
function even when BOOT_DELAY is enabled.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>