### PR TITLE
interrupt_controller: intc_esp32c3: added intc driver

### DIFF
--- a/drivers/interrupt_controller/CMakeLists.txt
+++ b/drivers/interrupt_controller/CMakeLists.txt
@@ -21,5 +21,6 @@ zephyr_library_sources_ifdef(CONFIG_RV32M1_INTMUX           intc_rv32m1_intmux.c
 zephyr_library_sources_ifdef(CONFIG_SAM0_EIC                intc_sam0_eic.c)
 zephyr_library_sources_ifdef(CONFIG_SHARED_IRQ              intc_shared_irq.c)
 zephyr_library_sources_ifdef(CONFIG_INTC_ESP32              intc_esp32.c)
+zephyr_library_sources_ifdef(CONFIG_INTC_ESP32C3            intc_esp32c3.c)
 zephyr_library_sources_ifdef(CONFIG_SWERV_PIC               intc_swerv_pic.c)
 zephyr_library_sources_ifdef(CONFIG_VEXRISCV_LITEX_IRQ      intc_vexriscv_litex.c)

--- a/drivers/interrupt_controller/Kconfig
+++ b/drivers/interrupt_controller/Kconfig
@@ -69,6 +69,8 @@ source "drivers/interrupt_controller/Kconfig.intel_vtd"
 
 source "drivers/interrupt_controller/Kconfig.esp32"
 
+source "drivers/interrupt_controller/Kconfig.esp32c3"
+
 source "drivers/interrupt_controller/Kconfig.xec"
 
 endmenu

--- a/drivers/interrupt_controller/Kconfig.esp32c3
+++ b/drivers/interrupt_controller/Kconfig.esp32c3
@@ -1,0 +1,10 @@
+# Copyright (c) 2021 Espressif Systems (Shanghai) Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+config INTC_ESP32C3
+	bool "Enables ESP32C3 interrupt controller driver"
+	depends on SOC_ESP32C3
+	default y
+	help
+	  Enables the esp32c3 interrupt controller driver to handle ISR
+	  management at SoC level.

--- a/drivers/interrupt_controller/Kconfig.esp32c3
+++ b/drivers/interrupt_controller/Kconfig.esp32c3
@@ -8,3 +8,13 @@ config INTC_ESP32C3
 	help
 	  Enables the esp32c3 interrupt controller driver to handle ISR
 	  management at SoC level.
+
+config INTC_ESP32C3_DECISIONS_LOG
+	bool "Enables Espressif's interrupt allocator logging"
+	depends on INTC_ESP32C3
+	select LOG
+	help
+	  Enable this option to visualize information on decisions made by the
+	  interrupt allocator. This has no impact on the interrupt allocator usage
+	  but may be valuable for debugging purposes. When enabled, messages are
+	  print to the serial console.

--- a/drivers/interrupt_controller/intc_esp32c3.c
+++ b/drivers/interrupt_controller/intc_esp32c3.c
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2021 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include <soc/periph_defs.h>
+#include <limits.h>
+#include <assert.h>
+#include "soc/soc.h"
+#include <soc.h>
+#include <zephyr.h>
+#include <drivers/interrupt_controller/intc_esp32c3.h>
+#include <sw_isr_table.h>
+
+#include <logging/log.h>
+LOG_MODULE_REGISTER(intc_esp32c3, CONFIG_LOG_DEFAULT_LEVEL);
+
+#define ESP32C3_INTC_DEFAULT_PRIORITY   15
+#define ESP32C3_INTC_DEFAULT_THRESHOLD  1
+#define ESP32C3_INTC_DISABLED_SLOT      31
+#define ESP32C3_INTC_SRCS_PER_IRQ       2
+#define ESP32C3_INTC_AVAILABLE_IRQS     30
+
+static uint32_t esp_intr_enabled_mask[2] = {0, 0};
+
+static void esp_intr_default_isr(const void *arg)
+{
+	ARG_UNUSED(arg);
+	ulong_t mcause;
+
+	__asm__ volatile("csrr %0, mcause" : "=r" (mcause));
+	mcause &= SOC_MCAUSE_EXP_MASK;
+
+	LOG_DBG("Spurious interrupt, mcause: %ld, source %d", mcause, soc_intr_get_next_source());
+}
+
+static uint32_t esp_intr_find_irq_for_source(uint32_t source)
+{
+	/* in general case, each 2 sources goes routed to
+	 * 1 IRQ line.
+	 */
+	uint32_t irq = (source / ESP32C3_INTC_SRCS_PER_IRQ);
+
+	if (irq > ESP32C3_INTC_AVAILABLE_IRQS) {
+		LOG_DBG("Clamping the source: %d no more IRQs available", source);
+		irq = ESP32C3_INTC_AVAILABLE_IRQS;
+	} else if (irq == 0) {
+		irq = 1;
+	}
+
+	LOG_DBG("Found IRQ: %d for source: %d", irq, source);
+
+	return irq;
+}
+
+void esp_intr_initialize(void)
+{
+	/* IRQ 31 is reserved for disabled interrupts,
+	 * so route all sources to it
+	 */
+	for (int i = 0 ; i < ESP32C3_INTC_AVAILABLE_IRQS + 2; i++) {
+		irq_disable(i);
+	}
+
+	for (int i = 0; i < ETS_MAX_INTR_SOURCE; i++) {
+		esp_rom_intr_matrix_set(0,
+			i,
+			ESP32C3_INTC_DISABLED_SLOT);
+
+		irq_connect_dynamic(i,
+			ESP32C3_INTC_DEFAULT_PRIORITY,
+			esp_intr_default_isr,
+			NULL,
+			0);
+	}
+
+	/* set global esp32c3's INTC masking level */
+	esprv_intc_int_set_threshold(ESP32C3_INTC_DEFAULT_THRESHOLD);
+}
+
+int esp_intr_alloc(int source,
+		int flags,
+		isr_handler_t handler,
+		void *arg,
+		void **ret_handle)
+{
+	ARG_UNUSED(flags);
+	ARG_UNUSED(ret_handle);
+
+	if (handler == NULL) {
+		return -EINVAL;
+	}
+
+	if (source < 0 || source >= ETS_MAX_INTR_SOURCE) {
+		return -EINVAL;
+	}
+
+	uint32_t key = irq_lock();
+	uint32_t irq = esp_intr_find_irq_for_source(source);
+
+	esp_rom_intr_matrix_set(0, source, irq);
+
+	irq_connect_dynamic(source,
+		ESP32C3_INTC_DEFAULT_PRIORITY,
+		handler,
+		arg,
+		0);
+
+	if (source < 32) {
+		esp_intr_enabled_mask[0] |= (1 << source);
+	} else {
+		esp_intr_enabled_mask[1] |= (1 << (source - 32));
+	}
+
+	LOG_DBG("Enabled isrs -- 0: 0x%X -- 1: 0x%X",
+		esp_intr_enabled_mask[0], esp_intr_enabled_mask[1]);
+
+	irq_unlock(key);
+	irq_enable(irq);
+
+	return 0;
+}
+
+int esp_intr_disable(int source)
+{
+	if (source < 0 || source >= ETS_MAX_INTR_SOURCE) {
+		return -EINVAL;
+	}
+
+	uint32_t key = irq_lock();
+
+	esp_rom_intr_matrix_set(source,
+		source,
+		ESP32C3_INTC_DISABLED_SLOT);
+
+	if (source < 32) {
+		esp_intr_enabled_mask[0] &= ~(1 << source);
+	} else {
+		esp_intr_enabled_mask[1] &= ~(1 << (source - 32));
+	}
+
+	LOG_DBG("Enabled isrs -- 0: 0x%X -- 1: 0x%X",
+		esp_intr_enabled_mask[0], esp_intr_enabled_mask[1]);
+
+	irq_unlock(key);
+
+	return 0;
+}
+
+int esp_intr_enable(int source)
+{
+	if (source < 0 || source >= ETS_MAX_INTR_SOURCE) {
+		return -EINVAL;
+	}
+
+	uint32_t key = irq_lock();
+	uint32_t irq = esp_intr_find_irq_for_source(source);
+
+	irq_disable(irq);
+	esp_rom_intr_matrix_set(0, source, irq);
+
+	if (source < 32) {
+		esp_intr_enabled_mask[0] |= (1 << source);
+	} else {
+		esp_intr_enabled_mask[1] |= (1 << (source - 32));
+	}
+
+	LOG_DBG("Enabled isrs -- 0: 0x%X -- 1: 0x%X",
+		esp_intr_enabled_mask[0], esp_intr_enabled_mask[1]);
+
+	irq_enable(irq);
+	irq_unlock(key);
+
+	return 0;
+}
+
+uint32_t esp_intr_get_enabled_intmask(int status_mask_number)
+{
+	LOG_DBG("Enabled isrs -- 0: 0x%X -- 1: 0x%X",
+		esp_intr_enabled_mask[0], esp_intr_enabled_mask[1]);
+
+	if (status_mask_number == 0) {
+		return esp_intr_enabled_mask[0];
+	} else {
+		return esp_intr_enabled_mask[1];
+	}
+}

--- a/drivers/interrupt_controller/intc_esp32c3.c
+++ b/drivers/interrupt_controller/intc_esp32c3.c
@@ -21,6 +21,17 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(intc_esp32c3, CONFIG_LOG_DEFAULT_LEVEL);
 
+/*
+ * Define this to debug the choices made when allocating the interrupt. This leads to much debugging
+ * output within a critical region, which can lead to weird effects like e.g. the interrupt watchdog
+ * being triggered, that is why it is separate from the normal LOG* scheme.
+ */
+#ifdef CONFIG_INTC_ESP32C3_DECISIONS_LOG
+# define INTC_LOG(...) LOG_INF(__VA_ARGS__)
+#else
+# define INTC_LOG(...) do {} while (0)
+#endif
+
 #define ESP32C3_INTC_DEFAULT_PRIORITY   15
 #define ESP32C3_INTC_DEFAULT_THRESHOLD  1
 #define ESP32C3_INTC_DISABLED_SLOT      31
@@ -37,7 +48,7 @@ static void esp_intr_default_isr(const void *arg)
 	__asm__ volatile("csrr %0, mcause" : "=r" (mcause));
 	mcause &= SOC_MCAUSE_EXP_MASK;
 
-	LOG_DBG("Spurious interrupt, mcause: %ld, source %d", mcause, soc_intr_get_next_source());
+	INTC_LOG("Spurious interrupt, mcause: %ld, source %d", mcause, soc_intr_get_next_source());
 }
 
 static uint32_t esp_intr_find_irq_for_source(uint32_t source)
@@ -48,13 +59,13 @@ static uint32_t esp_intr_find_irq_for_source(uint32_t source)
 	uint32_t irq = (source / ESP32C3_INTC_SRCS_PER_IRQ);
 
 	if (irq > ESP32C3_INTC_AVAILABLE_IRQS) {
-		LOG_DBG("Clamping the source: %d no more IRQs available", source);
+		INTC_LOG("Clamping the source: %d no more IRQs available", source);
 		irq = ESP32C3_INTC_AVAILABLE_IRQS;
 	} else if (irq == 0) {
 		irq = 1;
 	}
 
-	LOG_DBG("Found IRQ: %d for source: %d", irq, source);
+	INTC_LOG("Found IRQ: %d for source: %d", irq, source);
 
 	return irq;
 }
@@ -118,7 +129,7 @@ int esp_intr_alloc(int source,
 		esp_intr_enabled_mask[1] |= (1 << (source - 32));
 	}
 
-	LOG_DBG("Enabled isrs -- 0: 0x%X -- 1: 0x%X",
+	INTC_LOG("Enabled isrs -- 0: 0x%X -- 1: 0x%X",
 		esp_intr_enabled_mask[0], esp_intr_enabled_mask[1]);
 
 	irq_unlock(key);
@@ -145,7 +156,7 @@ int esp_intr_disable(int source)
 		esp_intr_enabled_mask[1] &= ~(1 << (source - 32));
 	}
 
-	LOG_DBG("Enabled isrs -- 0: 0x%X -- 1: 0x%X",
+	INTC_LOG("Enabled isrs -- 0: 0x%X -- 1: 0x%X",
 		esp_intr_enabled_mask[0], esp_intr_enabled_mask[1]);
 
 	irq_unlock(key);
@@ -171,7 +182,7 @@ int esp_intr_enable(int source)
 		esp_intr_enabled_mask[1] |= (1 << (source - 32));
 	}
 
-	LOG_DBG("Enabled isrs -- 0: 0x%X -- 1: 0x%X",
+	INTC_LOG("Enabled isrs -- 0: 0x%X -- 1: 0x%X",
 		esp_intr_enabled_mask[0], esp_intr_enabled_mask[1]);
 
 	irq_enable(irq);
@@ -182,7 +193,7 @@ int esp_intr_enable(int source)
 
 uint32_t esp_intr_get_enabled_intmask(int status_mask_number)
 {
-	LOG_DBG("Enabled isrs -- 0: 0x%X -- 1: 0x%X",
+	INTC_LOG("Enabled isrs -- 0: 0x%X -- 1: 0x%X",
 		esp_intr_enabled_mask[0], esp_intr_enabled_mask[1]);
 
 	if (status_mask_number == 0) {

--- a/drivers/timer/esp32c3_sys_timer.c
+++ b/drivers/timer/esp32c3_sys_timer.c
@@ -17,6 +17,7 @@
 #include <drivers/timer/system_timer.h>
 #include <sys_clock.h>
 #include <soc.h>
+#include <device.h>
 
 #define CYC_PER_TICK ((uint32_t)((uint64_t)sys_clock_hw_cycles_per_sec()	\
 			      / (uint64_t)CONFIG_SYS_CLOCK_TICKS_PER_SEC))
@@ -70,7 +71,7 @@ int sys_clock_driver_init(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 
-	esp_intr_alloc(ETS_SYSTIMER_TARGET0_EDGE_INTR_SOURCE,
+	esp_intr_alloc(DT_IRQN(DT_NODELABEL(systimer0)),
 		0,
 		sys_timer_isr,
 		NULL,

--- a/dts/bindings/timer/espressif,esp32-systimer
+++ b/dts/bindings/timer/espressif,esp32-systimer
@@ -1,0 +1,18 @@
+# Copyright (c) 2021 Espressif Systems (Shanghai) Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Espressif ESP32 Systimer peripheral
+
+compatible: "espressif,esp32-systimer"
+
+include: base.yaml
+
+properties:
+    reg:
+      required: true
+
+    interrupts:
+      required: true
+
+    label:
+      required: true

--- a/dts/riscv/espressif/esp32c3.dtsi
+++ b/dts/riscv/espressif/esp32c3.dtsi
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <mem.h>
+#include <dt-bindings/interrupt-controller/esp-esp32c3-intmux.h>
 
 / {
 	#address-cells = <1>;
@@ -29,6 +30,24 @@
 		sram0: memory@3fc7c000 {
 			compatible = "mmio-sram";
 			reg = <0x3fc7c000 0x50000>;
+		};
+
+		intc: interrupt-controller@600c2000 {
+			#interrupt-cells = <1>;
+			compatible = "espressif,esp32-intc";
+			interrupt-controller;
+			reg = <0x600c2000 0x198>;
+			label = "INTC_0";
+			status = "okay";
+		};
+
+		systimer0: systimer@60023000 {
+			compatible = "espressif,esp32-systimer";
+			reg = <0x60023000 0x80>;
+			interrupts = <SYSTIMER_TARGET0_EDGE_INTR_SOURCE>;
+			interrupt-parent = <&intc>;
+			label = "SYSTIMER_0";
+			status = "okay";
 		};
 
 		uart0: uart@60000000 {

--- a/include/drivers/interrupt_controller/intc_esp32c3.h
+++ b/include/drivers/interrupt_controller/intc_esp32c3.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2021 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_ESP_INTR_ALLOC_H__
+#define ZEPHYR_INCLUDE_DRIVERS_ESP_INTR_ALLOC_H__
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <soc.h>
+/*
+ * Interrupt allocation flags - These flags can be used to specify
+ * which interrupt qualities the code calling esp_intr_alloc* needs.
+ *
+ */
+
+/* Keep the LEVELx values as they are here; they match up with (1<<level) */
+#define ESP_INTR_FLAG_LEVEL1		(1<<1)	/* Accept a Level 1 int vector, lowest priority */
+#define ESP_INTR_FLAG_EDGE		    (1<<9)	/* Edge-triggered interrupt */
+
+/* Function prototype for interrupt handler function */
+typedef void (*isr_handler_t)(const void *arg);
+
+/**
+ * @brief Initializes interrupt table to its defaults
+ */
+void esp_intr_initialize(void);
+
+/**
+ * @brief Allocate an interrupt with the given parameters.
+ *
+ * This finds an interrupt that matches the restrictions as given in the flags
+ * parameter, maps the given interrupt source to it and hooks up the given
+ * interrupt handler (with optional argument) as well. If needed, it can return
+ * a handle for the interrupt as well.
+ *
+ * @param source The interrupt source.
+ * @param flags An ORred mask of the ESP_INTR_FLAG_* defines. These restrict the
+ *               choice of interrupts that this routine can choose from. If this value
+ *               is 0, it will default to allocating a non-shared interrupt of level
+ *               1, 2 or 3. If this is ESP_INTR_FLAG_SHARED, it will allocate a shared
+ *               interrupt of level 1. Setting ESP_INTR_FLAG_INTRDISABLED will return
+ *               from this function with the interrupt disabled.
+ * @param handler The interrupt handler.
+ * @param arg    Optional argument for passed to the interrupt handler
+ * @param ret_handle Pointer to a struct intr_handle_data_t pointer to store a handle that can
+ *               later be used to request details or free the interrupt. Can be NULL if no handle
+ *               is required.
+ *
+ * @return -EINVAL if the combination of arguments is invalid.
+ *         -ENODEV No free interrupt found with the specified flags
+ *         0 otherwise
+ */
+int esp_intr_alloc(int source,
+		int flags,
+		isr_handler_t handler,
+		void *arg,
+		void **ret_handle);
+
+/**
+ * @brief Disable the interrupt associated with the source
+ *
+ * @param source The interrupt source
+ *
+ * @return -EINVAL if the combination of arguments is invalid.
+ *         0 otherwise
+ */
+int esp_intr_disable(int source);
+
+/**
+ * @brief Enable the interrupt associated with the source
+ *
+ * @param source The interrupt source
+ * @return -EINVAL if the combination of arguments is invalid.
+ *         0 otherwise
+ */
+int esp_intr_enable(int source);
+
+/**
+ * @brief Gets the current enabled interrupts
+ *
+ * @param status_mask_number the status mask can be 0 or 1
+ * @return bitmask of enabled interrupt sources
+ */
+uint32_t esp_intr_get_enabled_intmask(int status_mask_number);
+
+#endif

--- a/include/dt-bindings/interrupt-controller/esp-esp32c3-intmux.h
+++ b/include/dt-bindings/interrupt-controller/esp-esp32c3-intmux.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2021 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_INTERRUPT_CONTROLLER_ESP32C3_INTMUX_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_INTERRUPT_CONTROLLER_ESP32C3_INTMUX_H_
+
+#define WIFI_MAC_INTR_SOURCE				0	/**< interrupt of WiFi MAC, level*/
+#define WIFI_MAC_NMI_SOURCE					1	/**< interrupt of WiFi MAC, NMI, use if MAC have bug to fix in NMI*/
+#define WIFI_PWR_INTR_SOURCE				2	/**< */
+#define WIFI_BB_INTR_SOURCE					3	/**< interrupt of WiFi BB, level, we can do some calibartion*/
+#define BT_MAC_INTR_SOURCE					4	/**< will be cancelled*/
+#define BT_BB_INTR_SOURCE					5	/**< interrupt of BT BB, level*/
+#define BT_BB_NMI_SOURCE					6	/**< interrupt of BT BB, NMI, use if BB have bug to fix in NMI*/
+#define RWBT_INTR_SOURCE					7	/**< interrupt of RWBT, level*/
+#define RWBLE_INTR_SOURCE					8	/**< interrupt of RWBLE, level*/
+#define RWBT_NMI_SOURCE						9	/**< interrupt of RWBT, NMI, use if RWBT have bug to fix in NMI*/
+#define RWBLE_NMI_SOURCE					10	/**< interrupt of RWBLE, NMI, use if RWBT have bug to fix in NMI*/
+#define I2C_MASTER_SOURCE					11	/**< interrupt of I2C Master, level*/
+#define SLC0_INTR_SOURCE					12	/**< interrupt of SLC0, level*/
+#define SLC1_INTR_SOURCE					13	/**< interrupt of SLC1, level*/
+#define APB_CTRL_INTR_SOURCE				14	/**< interrupt of APB ctrl, ?*/
+#define UHCI0_INTR_SOURCE					15	/**< interrupt of UHCI0, level*/
+#define GPIO_INTR_SOURCE					16	/**< interrupt of GPIO, level*/
+#define GPIO_NMI_SOURCE						17	/**< interrupt of GPIO, NMI*/
+#define SPI1_INTR_SOURCE					18	/**< interrupt of SPI1, level, SPI1 is for flash read/write, do not use this*/
+#define SPI2_INTR_SOURCE					19	/**< interrupt of SPI2, level*/
+#define I2S1_INTR_SOURCE					20	/**< interrupt of I2S1, level*/
+#define UART0_INTR_SOURCE					21	/**< interrupt of UART0, level*/
+#define UART1_INTR_SOURCE					22	/**< interrupt of UART1, level*/
+#define LEDC_INTR_SOURCE					23	/**< interrupt of LED PWM, level*/
+#define EFUSE_INTR_SOURCE					24	/**< interrupt of efuse, level, not likely to use*/
+#define TWAI_INTR_SOURCE					25	/**< interrupt of can, level*/
+#define USB_INTR_SOURCE						26	/**< interrupt of USB, level*/
+#define RTC_CORE_INTR_SOURCE				27	/**< interrupt of rtc core, level, include rtc watchdog*/
+#define RMT_INTR_SOURCE						28	/**< interrupt of remote controller, level*/
+#define I2C_EXT0_INTR_SOURCE				29	/**< interrupt of I2C controller1, level*/
+#define TIMER1_INTR_SOURCE					30
+#define TIMER2_INTR_SOURCE					31
+#define TG0_T0_LEVEL_INTR_SOURCE			32	/**< interrupt of TIMER_GROUP0, TIMER0, level*/
+#define TG0_WDT_LEVEL_INTR_SOURCE			33	/**< interrupt of TIMER_GROUP0, WATCH DOG, level*/
+#define TG1_T0_LEVEL_INTR_SOURCE			34	/**< interrupt of TIMER_GROUP1, TIMER0, level*/
+#define TG1_WDT_LEVEL_INTR_SOURCE			35	/**< interrupt of TIMER_GROUP1, WATCHDOG, level*/
+#define CACHE_IA_INTR_SOURCE				36	/**< interrupt of Cache Invalied Access, LEVEL*/
+#define SYSTIMER_TARGET0_EDGE_INTR_SOURCE	37	/**< interrupt of system timer 0, EDGE*/
+#define SYSTIMER_TARGET1_EDGE_INTR_SOURCE	38	/**< interrupt of system timer 1, EDGE*/
+#define SYSTIMER_TARGET2_EDGE_INTR_SOURCE	39	/**< interrupt of system timer 2, EDGE*/
+#define SPI_MEM_REJECT_CACHE_INTR_SOURCE	40	/**< interrupt of SPI0 Cache access and SPI1 access rejected, LEVEL*/
+#define ICACHE_PRELOAD0_INTR_SOURCE			41	/**< interrupt of ICache perload operation, LEVEL*/
+#define ICACHE_SYNC0_INTR_SOURCE			42	/**< interrupt of instruction cache sync done, LEVEL*/
+#define APB_ADC_INTR_SOURCE					43	/**< interrupt of APB ADC, LEVEL*/
+#define DMA_CH0_INTR_SOURCE					44	/**< interrupt of general DMA channel 0, LEVEL*/
+#define DMA_CH1_INTR_SOURCE					45	/**< interrupt of general DMA channel 1, LEVEL*/
+#define DMA_CH2_INTR_SOURCE					46	/**< interrupt of general DMA channel 2, LEVEL*/
+#define RSA_INTR_SOURCE						47	/**< interrupt of RSA accelerator, level*/
+#define AES_INTR_SOURCE						48	/**< interrupt of AES accelerator, level*/
+#define SHA_INTR_SOURCE						49	/**< interrupt of SHA accelerator, level*/
+#define FROM_CPU_INTR0_SOURCE				50	/**< interrupt0 generated from a CPU, level*/ /* Used for FreeRTOS */
+#define FROM_CPU_INTR1_SOURCE				51	/**< interrupt1 generated from a CPU, level*/ /* Used for FreeRTOS */
+#define FROM_CPU_INTR2_SOURCE				52	/**< interrupt2 generated from a CPU, level*/ /* Used for DPORT Access */
+#define FROM_CPU_INTR3_SOURCE				53	/**< interrupt3 generated from a CPU, level*/ /* Used for DPORT Access */
+#define ASSIST_DEBUG_INTR_SOURCE			54	/**< interrupt of Assist debug module, LEVEL*/
+#define DMA_APBPERI_PMS_INTR_SOURCE			55
+#define CORE0_IRAM0_PMS_INTR_SOURCE			56
+#define CORE0_DRAM0_PMS_INTR_SOURCE			57
+#define CORE0_PIF_PMS_INTR_SOURCE			58
+#define CORE0_PIF_PMS_SIZE_INTR_SOURCE		59
+#define BAK_PMS_VIOLATE_INTR_SOURCE			60
+#define CACHE_CORE0_ACS_INTR_SOURCE			61
+
+#endif

--- a/include/dt-bindings/interrupt-controller/esp-esp32c3-intmux.h
+++ b/include/dt-bindings/interrupt-controller/esp-esp32c3-intmux.h
@@ -7,67 +7,67 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_INTERRUPT_CONTROLLER_ESP32C3_INTMUX_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_INTERRUPT_CONTROLLER_ESP32C3_INTMUX_H_
 
-#define WIFI_MAC_INTR_SOURCE				0	/**< interrupt of WiFi MAC, level*/
-#define WIFI_MAC_NMI_SOURCE					1	/**< interrupt of WiFi MAC, NMI, use if MAC have bug to fix in NMI*/
-#define WIFI_PWR_INTR_SOURCE				2	/**< */
-#define WIFI_BB_INTR_SOURCE					3	/**< interrupt of WiFi BB, level, we can do some calibartion*/
-#define BT_MAC_INTR_SOURCE					4	/**< will be cancelled*/
-#define BT_BB_INTR_SOURCE					5	/**< interrupt of BT BB, level*/
-#define BT_BB_NMI_SOURCE					6	/**< interrupt of BT BB, NMI, use if BB have bug to fix in NMI*/
-#define RWBT_INTR_SOURCE					7	/**< interrupt of RWBT, level*/
-#define RWBLE_INTR_SOURCE					8	/**< interrupt of RWBLE, level*/
-#define RWBT_NMI_SOURCE						9	/**< interrupt of RWBT, NMI, use if RWBT have bug to fix in NMI*/
-#define RWBLE_NMI_SOURCE					10	/**< interrupt of RWBLE, NMI, use if RWBT have bug to fix in NMI*/
-#define I2C_MASTER_SOURCE					11	/**< interrupt of I2C Master, level*/
-#define SLC0_INTR_SOURCE					12	/**< interrupt of SLC0, level*/
-#define SLC1_INTR_SOURCE					13	/**< interrupt of SLC1, level*/
-#define APB_CTRL_INTR_SOURCE				14	/**< interrupt of APB ctrl, ?*/
-#define UHCI0_INTR_SOURCE					15	/**< interrupt of UHCI0, level*/
-#define GPIO_INTR_SOURCE					16	/**< interrupt of GPIO, level*/
-#define GPIO_NMI_SOURCE						17	/**< interrupt of GPIO, NMI*/
-#define SPI1_INTR_SOURCE					18	/**< interrupt of SPI1, level, SPI1 is for flash read/write, do not use this*/
-#define SPI2_INTR_SOURCE					19	/**< interrupt of SPI2, level*/
-#define I2S1_INTR_SOURCE					20	/**< interrupt of I2S1, level*/
-#define UART0_INTR_SOURCE					21	/**< interrupt of UART0, level*/
-#define UART1_INTR_SOURCE					22	/**< interrupt of UART1, level*/
-#define LEDC_INTR_SOURCE					23	/**< interrupt of LED PWM, level*/
-#define EFUSE_INTR_SOURCE					24	/**< interrupt of efuse, level, not likely to use*/
-#define TWAI_INTR_SOURCE					25	/**< interrupt of can, level*/
-#define USB_INTR_SOURCE						26	/**< interrupt of USB, level*/
-#define RTC_CORE_INTR_SOURCE				27	/**< interrupt of rtc core, level, include rtc watchdog*/
-#define RMT_INTR_SOURCE						28	/**< interrupt of remote controller, level*/
-#define I2C_EXT0_INTR_SOURCE				29	/**< interrupt of I2C controller1, level*/
-#define TIMER1_INTR_SOURCE					30
-#define TIMER2_INTR_SOURCE					31
-#define TG0_T0_LEVEL_INTR_SOURCE			32	/**< interrupt of TIMER_GROUP0, TIMER0, level*/
-#define TG0_WDT_LEVEL_INTR_SOURCE			33	/**< interrupt of TIMER_GROUP0, WATCH DOG, level*/
-#define TG1_T0_LEVEL_INTR_SOURCE			34	/**< interrupt of TIMER_GROUP1, TIMER0, level*/
-#define TG1_WDT_LEVEL_INTR_SOURCE			35	/**< interrupt of TIMER_GROUP1, WATCHDOG, level*/
-#define CACHE_IA_INTR_SOURCE				36	/**< interrupt of Cache Invalied Access, LEVEL*/
-#define SYSTIMER_TARGET0_EDGE_INTR_SOURCE	37	/**< interrupt of system timer 0, EDGE*/
-#define SYSTIMER_TARGET1_EDGE_INTR_SOURCE	38	/**< interrupt of system timer 1, EDGE*/
-#define SYSTIMER_TARGET2_EDGE_INTR_SOURCE	39	/**< interrupt of system timer 2, EDGE*/
-#define SPI_MEM_REJECT_CACHE_INTR_SOURCE	40	/**< interrupt of SPI0 Cache access and SPI1 access rejected, LEVEL*/
-#define ICACHE_PRELOAD0_INTR_SOURCE			41	/**< interrupt of ICache perload operation, LEVEL*/
-#define ICACHE_SYNC0_INTR_SOURCE			42	/**< interrupt of instruction cache sync done, LEVEL*/
-#define APB_ADC_INTR_SOURCE					43	/**< interrupt of APB ADC, LEVEL*/
-#define DMA_CH0_INTR_SOURCE					44	/**< interrupt of general DMA channel 0, LEVEL*/
-#define DMA_CH1_INTR_SOURCE					45	/**< interrupt of general DMA channel 1, LEVEL*/
-#define DMA_CH2_INTR_SOURCE					46	/**< interrupt of general DMA channel 2, LEVEL*/
-#define RSA_INTR_SOURCE						47	/**< interrupt of RSA accelerator, level*/
-#define AES_INTR_SOURCE						48	/**< interrupt of AES accelerator, level*/
-#define SHA_INTR_SOURCE						49	/**< interrupt of SHA accelerator, level*/
-#define FROM_CPU_INTR0_SOURCE				50	/**< interrupt0 generated from a CPU, level*/ /* Used for FreeRTOS */
-#define FROM_CPU_INTR1_SOURCE				51	/**< interrupt1 generated from a CPU, level*/ /* Used for FreeRTOS */
-#define FROM_CPU_INTR2_SOURCE				52	/**< interrupt2 generated from a CPU, level*/ /* Used for DPORT Access */
-#define FROM_CPU_INTR3_SOURCE				53	/**< interrupt3 generated from a CPU, level*/ /* Used for DPORT Access */
-#define ASSIST_DEBUG_INTR_SOURCE			54	/**< interrupt of Assist debug module, LEVEL*/
-#define DMA_APBPERI_PMS_INTR_SOURCE			55
-#define CORE0_IRAM0_PMS_INTR_SOURCE			56
-#define CORE0_DRAM0_PMS_INTR_SOURCE			57
-#define CORE0_PIF_PMS_INTR_SOURCE			58
-#define CORE0_PIF_PMS_SIZE_INTR_SOURCE		59
-#define BAK_PMS_VIOLATE_INTR_SOURCE			60
-#define CACHE_CORE0_ACS_INTR_SOURCE			61
+#define WIFI_MAC_INTR_SOURCE                0
+#define WIFI_MAC_NMI_SOURCE                 1
+#define WIFI_PWR_INTR_SOURCE                2
+#define WIFI_BB_INTR_SOURCE                 3
+#define BT_MAC_INTR_SOURCE                  4
+#define BT_BB_INTR_SOURCE                   5
+#define BT_BB_NMI_SOURCE                    6
+#define RWBT_INTR_SOURCE                    7
+#define RWBLE_INTR_SOURCE                   8
+#define RWBT_NMI_SOURCE                     9
+#define RWBLE_NMI_SOURCE                    10
+#define I2C_MASTER_SOURCE                   11
+#define SLC0_INTR_SOURCE                    12
+#define SLC1_INTR_SOURCE                    13
+#define APB_CTRL_INTR_SOURCE                14
+#define UHCI0_INTR_SOURCE                   15
+#define GPIO_INTR_SOURCE                    16
+#define GPIO_NMI_SOURCE                     17
+#define SPI1_INTR_SOURCE                    18
+#define SPI2_INTR_SOURCE                    19
+#define I2S1_INTR_SOURCE                    20
+#define UART0_INTR_SOURCE                   21
+#define UART1_INTR_SOURCE                   22
+#define LEDC_INTR_SOURCE                    23
+#define EFUSE_INTR_SOURCE                   24
+#define TWAI_INTR_SOURCE                    25
+#define USB_INTR_SOURCE                     26
+#define RTC_CORE_INTR_SOURCE                27
+#define RMT_INTR_SOURCE                     28
+#define I2C_EXT0_INTR_SOURCE                29
+#define TIMER1_INTR_SOURCE                  30
+#define TIMER2_INTR_SOURCE                  31
+#define TG0_T0_LEVEL_INTR_SOURCE            32
+#define TG0_WDT_LEVEL_INTR_SOURCE           33
+#define TG1_T0_LEVEL_INTR_SOURCE            34
+#define TG1_WDT_LEVEL_INTR_SOURCE           35
+#define CACHE_IA_INTR_SOURCE                36
+#define SYSTIMER_TARGET0_EDGE_INTR_SOURCE   37
+#define SYSTIMER_TARGET1_EDGE_INTR_SOURCE   38
+#define SYSTIMER_TARGET2_EDGE_INTR_SOURCE   39
+#define SPI_MEM_REJECT_CACHE_INTR_SOURCE    40
+#define ICACHE_PRELOAD0_INTR_SOURCE         41
+#define ICACHE_SYNC0_INTR_SOURCE            42
+#define APB_ADC_INTR_SOURCE                 43
+#define DMA_CH0_INTR_SOURCE                 44
+#define DMA_CH1_INTR_SOURCE                 45
+#define DMA_CH2_INTR_SOURCE                 46
+#define RSA_INTR_SOURCE                     47
+#define AES_INTR_SOURCE                     48
+#define SHA_INTR_SOURCE                     49
+#define FROM_CPU_INTR0_SOURCE               50
+#define FROM_CPU_INTR1_SOURCE               51
+#define FROM_CPU_INTR2_SOURCE               52
+#define FROM_CPU_INTR3_SOURCE               53
+#define ASSIST_DEBUG_INTR_SOURCE            54
+#define DMA_APBPERI_PMS_INTR_SOURCE         55
+#define CORE0_IRAM0_PMS_INTR_SOURCE         56
+#define CORE0_DRAM0_PMS_INTR_SOURCE         57
+#define CORE0_PIF_PMS_INTR_SOURCE           58
+#define CORE0_PIF_PMS_SIZE_INTR_SOURCE      59
+#define BAK_PMS_VIOLATE_INTR_SOURCE         60
+#define CACHE_CORE0_ACS_INTR_SOURCE         61
 
 #endif

--- a/soc/riscv/esp32c3/CMakeLists.txt
+++ b/soc/riscv/esp32c3/CMakeLists.txt
@@ -4,5 +4,6 @@ zephyr_sources(
   idle.c
   vectors.S
   soc_irq.S
+  soc_irq.c
   soc.c
   )

--- a/soc/riscv/esp32c3/Kconfig.defconfig
+++ b/soc/riscv/esp32c3/Kconfig.defconfig
@@ -9,7 +9,7 @@ config SOC
 	default "esp32c3"
 
 config NUM_IRQS
-	default 32
+	default 62
 
 config GEN_ISR_TABLES
 	default y

--- a/soc/riscv/esp32c3/soc.h
+++ b/soc/riscv/esp32c3/soc.h
@@ -40,6 +40,8 @@ extern void esp_rom_uart_tx_wait_idle(uint8_t uart_no);
 extern STATUS esp_rom_uart_tx_one_char(uint8_t chr);
 extern STATUS esp_rom_uart_rx_one_char(uint8_t *chr);
 extern void esp_rom_ets_set_user_start(uint32_t start);
+extern void esprv_intc_int_set_threshold(int priority_threshold);
+uint32_t soc_intr_get_next_source(void);
 
 #endif /* _ASMLANGUAGE */
 

--- a/soc/riscv/esp32c3/soc_irq.S
+++ b/soc/riscv/esp32c3/soc_irq.S
@@ -9,6 +9,7 @@
 /* Exports */
 GTEXT(__soc_is_irq)
 GTEXT(__soc_handle_irq)
+GTEXT(soc_intr_get_next_source)
 
 SECTION_FUNC(exception.other, __soc_is_irq)
 	csrr a0, mcause
@@ -16,4 +17,10 @@ SECTION_FUNC(exception.other, __soc_is_irq)
 	ret
 
 SECTION_FUNC(exception.other, __soc_handle_irq)
+	addi sp, sp,-4
+	sw  ra, 0x00(sp)
+	la t1, soc_intr_get_next_source
+	jalr ra, t1
+	lw  ra, 0x00(sp)
+	addi sp, sp, 4
 	ret

--- a/soc/riscv/esp32c3/soc_irq.c
+++ b/soc/riscv/esp32c3/soc_irq.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <soc/rtc_cntl_reg.h>
+#include <soc/timer_group_reg.h>
+#include <soc/gpio_reg.h>
+#include <soc/syscon_reg.h>
+#include <soc/system_reg.h>
+#include <soc/cache_memory.h>
+#include "hal/soc_ll.h"
+#include <riscv/interrupt.h>
+#include <soc/interrupt_reg.h>
+#include <soc/periph_defs.h>
+#include <drivers/interrupt_controller/intc_esp32c3.h>
+
+#include <kernel_structs.h>
+#include <string.h>
+#include <toolchain/gcc.h>
+#include <soc.h>
+
+#define ESP32C3_INTC_DEFAULT_PRIO			15
+#define ESP32C3_INTSTATUS_SLOT1_THRESHOLD	32
+
+void arch_irq_enable(unsigned int irq)
+{
+	uint32_t key = irq_lock();
+
+	esprv_intc_int_set_priority(irq, ESP32C3_INTC_DEFAULT_PRIO);
+	esprv_intc_int_set_type(irq, INTR_TYPE_LEVEL);
+	esprv_intc_int_enable(1 << irq);
+	irq_unlock(key);
+}
+
+void arch_irq_disable(unsigned int irq)
+{
+	esprv_intc_int_disable(1 << irq);
+}
+
+int arch_irq_is_enabled(unsigned int irq)
+{
+	return (REG_READ(INTERRUPT_CORE0_CPU_INT_ENABLE_REG) & (1 << irq));
+}
+
+uint32_t soc_intr_get_next_source(void)
+{
+	uint32_t status;
+	uint32_t source;
+
+	status = REG_READ(INTERRUPT_CORE0_INTR_STATUS_0_REG) &
+		esp_intr_get_enabled_intmask(0);
+
+	if (status) {
+		source = __builtin_ffs(status) - 1;
+	} else {
+		status = REG_READ(INTERRUPT_CORE0_INTR_STATUS_1_REG) &
+			esp_intr_get_enabled_intmask(1);
+		source = (__builtin_ffs(status) - 1 + ESP32C3_INTSTATUS_SLOT1_THRESHOLD);
+	}
+
+	return source;
+}


### PR DESCRIPTION
For esp32c3 and replaces the hardcoded interrupt
attaching procedures with this new driver.

The allocation strategy reuses the common riscv software isr table infrastructure provided
by zephyr:

* It multiplexes each IRQ with 2 interrupt sources, special cases may have more or less IRQ lines
attached to different sources;

* After an IRQ is selected, it is routed to the interrupt matrix as usual and the IRQ is enabled if it was not previously;

* The ISR + argument is installed directly into zephyr´s software ISR table entry, the peripheral source number is used directly as table index;

* When an ISR occurs, the zephyr platform specific __soc_handle_irq was modified and it is called, and instead of returning the mcause in a0, it returns the source of the peripheral in a0, and this value is used to fetch the proper ISR entry from sw ISR table;

* If further interrupts are pending the irq wrapper calls __soc_handle_irq, and from lowest to highest source number, one by one gets checked and placed in a0 for next ISR handle until all pending interrupts get addressed;

* When a peripheral source is not needed to interrupt anymore, it is just routed to an inactive IRQ line which is kept permanently disabled preventing it to fire, IRQ line 31 is used by this purpose.