### PR TITLE
emul: Implement emul_get_binding

### DIFF
--- a/include/drivers/emul.h
+++ b/include/drivers/emul.h
@@ -98,6 +98,20 @@ extern const struct emul __emul_list_end[];
 int emul_init_for_bus_from_list(const struct device *dev,
 				const struct emul_list_for_bus *list);
 
+/**
+ * @brief Retrieve the emul structure for an emulator by name
+ *
+ * @details Emulator objects are created via the EMUL_DEFINE() macro and placed in memory by the
+ * linker. If the emulator structure is needed for custom API calls, it can be retrieved by the name
+ * that the emulator exposes to the system (this is the devicetree node's label by default).
+ *
+ * @param name Emulator name to search for.  A null pointer, or a pointer to an
+ * empty string, will cause NULL to be returned.
+ *
+ * @return pointer to emulator structure; NULL if not found or cannot be used.
+ */
+const struct emul *emul_get_binding(const char *name);
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/subsys/emul/emul.c
+++ b/subsys/emul/emul.c
@@ -13,20 +13,13 @@ LOG_MODULE_REGISTER(emul);
 #include <drivers/emul.h>
 #include <string.h>
 
-/**
- * Find a an emulator using its link information
- *
- * @param emul Emulator info to find
- * @return pointer to emulator, or NULL if not found
- */
-static const struct emul *
-emul_find_by_link(const struct emul_link_for_bus *emul)
+const struct emul *emul_get_binding(const char *name)
 {
-	const struct emul *erp;
+	const struct emul *emul_it;
 
-	for (erp = __emul_list_start; erp < __emul_list_end; erp++) {
-		if (strcmp(erp->dev_label, emul->label) == 0) {
-			return erp;
+	for (emul_it = __emul_list_start; emul_it < __emul_list_end; emul_it++) {
+		if (strcmp(emul_it->dev_label, name) == 0) {
+			return emul_it;
 		}
 	}
 
@@ -49,7 +42,7 @@ int emul_init_for_bus_from_list(const struct device *dev,
 	LOG_INF("Registering %d emulator(s) for %s", cfg->num_children,
 		dev->name);
 	for (elp = cfg->children; elp < end; elp++) {
-		const struct emul *emul = emul_find_by_link(elp);
+		const struct emul *emul = emul_get_binding(elp->label);
 
 		__ASSERT(emul, "Cannot find emulator for '%s'", elp->label);
 


### PR DESCRIPTION
Issue #38271

Implement a getter for emulators similar to device_get_binding. This
function can be used to get the emulator instance during tests to call
emulator specific functions.

Example: The current BMI160 emulator pre-defines a finite set of data
samples that will be returned. If a test was to be written for logic
that uses that data, then the emulator would become completely useless
without the ability for the test to define what data should be returned.

This will also help in exercising error conditions in tests.

Signed-off-by: Yuval Peress <peress@chromium.org>