### PR TITLE
soc/intel_adsp: Correct linker syntax for ancient binutils

### DIFF
--- a/cmake/compiler/xcc/compiler_flags.cmake
+++ b/cmake/compiler/xcc/compiler_flags.cmake
@@ -4,4 +4,10 @@ if(CC STREQUAL "clang")
   include(${ZEPHYR_BASE}/cmake/compiler/clang/compiler_flags.cmake)
 else()
   include(${ZEPHYR_BASE}/cmake/compiler/gcc/compiler_flags.cmake)
+
+  # XCC is based on GCC 4.2 which has a somewhat pedantic take on the
+  # fact that linkage semantics differed between C99 and GNU at the
+  # time.  Suppress the warning, it's the best we can do given that
+  # it's a legacy compiler.
+  set_compiler_property(APPEND PROPERTY warning_base "-fgnu89-inline")
 endif()

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -170,6 +170,23 @@ static ALWAYS_INLINE struct k_thread *_priq_dumb_mask_best(sys_dlist_t *pq)
 }
 #endif
 
+ALWAYS_INLINE void z_priq_dumb_add(sys_dlist_t *pq, struct k_thread *thread)
+{
+	struct k_thread *t;
+
+	__ASSERT_NO_MSG(!z_is_idle_thread_object(thread));
+
+	SYS_DLIST_FOR_EACH_CONTAINER(pq, t, base.qnode_dlist) {
+		if (z_sched_prio_cmp(thread, t) > 0) {
+			sys_dlist_insert(&t->base.qnode_dlist,
+					 &thread->base.qnode_dlist);
+			return;
+		}
+	}
+
+	sys_dlist_append(pq, &thread->base.qnode_dlist);
+}
+
 /* _current is never in the run queue until context switch on
  * SMP configurations, see z_requeue_current()
  */
@@ -926,23 +943,6 @@ void *z_get_next_switch_handle(void *interrupted)
 #endif
 }
 #endif
-
-ALWAYS_INLINE void z_priq_dumb_add(sys_dlist_t *pq, struct k_thread *thread)
-{
-	struct k_thread *t;
-
-	__ASSERT_NO_MSG(!z_is_idle_thread_object(thread));
-
-	SYS_DLIST_FOR_EACH_CONTAINER(pq, t, base.qnode_dlist) {
-		if (z_sched_prio_cmp(thread, t) > 0) {
-			sys_dlist_insert(&t->base.qnode_dlist,
-					 &thread->base.qnode_dlist);
-			return;
-		}
-	}
-
-	sys_dlist_append(pq, &thread->base.qnode_dlist);
-}
 
 void z_priq_dumb_remove(sys_dlist_t *pq, struct k_thread *thread)
 {

--- a/soc/xtensa/intel_adsp/cavs_v15/linker.ld
+++ b/soc/xtensa/intel_adsp/cavs_v15/linker.ld
@@ -42,9 +42,11 @@ PROVIDE(_MemErrorHandler = 0x00000000);
  * the output tooling ignores it, but it will cause the linker to emit
  * 512MB of unused data into the output file!)
  *
+ * (Note clumsy syntax because XCC doesn't understand the "~" operator)
+ *
  */
 #define SEGSTART_CACHED   (ALIGN(64) | 0x20000000)
-#define SEGSTART_UNCACHED (ALIGN(64) & ~0x20000000)
+#define SEGSTART_UNCACHED (ALIGN(64) & 0xdfffffff) /* == ~0x20000000 */
 
 MEMORY
 {

--- a/soc/xtensa/intel_adsp/cavs_v18/linker.ld
+++ b/soc/xtensa/intel_adsp/cavs_v18/linker.ld
@@ -42,9 +42,11 @@ PROVIDE(_MemErrorHandler = 0x00000000);
  * the output tooling ignores it, but it will cause the linker to emit
  * 512MB of unused data into the output file!)
  *
+ * (Note clumsy syntax because XCC doesn't understand the "~" operator)
+ *
  */
 #define SEGSTART_CACHED   (ALIGN(64) | 0x20000000)
-#define SEGSTART_UNCACHED (ALIGN(64) & ~0x20000000)
+#define SEGSTART_UNCACHED (ALIGN(64) & 0xdfffffff) /* == ~0x20000000 */
 
 MEMORY
 {

--- a/soc/xtensa/intel_adsp/cavs_v25/linker.ld
+++ b/soc/xtensa/intel_adsp/cavs_v25/linker.ld
@@ -42,10 +42,11 @@ PROVIDE(_MemErrorHandler = 0x00000000);
  * the output tooling ignores it, but it will cause the linker to emit
  * 512MB of unused data into the output file!)
  *
+ * (Note clumsy syntax because XCC doesn't understand the "~" operator)
  */
 #ifdef CONFIG_KERNEL_COHERENCE
 #define SEGSTART_CACHED   (ALIGN(64) | 0x20000000)
-#define SEGSTART_UNCACHED (ALIGN(64) & ~0x20000000)
+#define SEGSTART_UNCACHED (ALIGN(64) & 0xdfffffff) /* == ~0x20000000 */
 #else
 #define SEGSTART_CACHED   /**/
 #define SEGSTART_UNCACHED /**/


### PR DESCRIPTION
Older binutils, like the (nine-year-old!) 2.23 version that powers
many Cadence XCC toolchains, happen not to support the "~" operator to
perform bitwise negation.  And they generate an absolutely hilarious
series of inscrutable error messages when they try to tell you this
fairly simple fact.

Just fold it into the constant.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>