### PR TITLE
samples/audio/sof: remove zephyr_interface_library_named(sof_lib)

### DIFF
--- a/samples/subsys/audio/sof/CMakeLists.txt
+++ b/samples/subsys/audio/sof/CMakeLists.txt
@@ -9,8 +9,6 @@ target_sources(app PRIVATE
     src/main.c
   )
 
-zephyr_interface_library_named(sof_lib)
-
 zephyr_library_include_directories(app PUBLIC
     ${sof_module}/src/arch/xtensa/include
     ${sof_module}/src/include

--- a/samples/subsys/audio/sof/prj.conf
+++ b/samples/subsys/audio/sof/prj.conf
@@ -1,4 +1,6 @@
+# See https://docs.zephyrproject.org/latest/guides/modules.html
 CONFIG_SOF=y
+
 CONFIG_LOG=y
 CONFIG_BUILD_OUTPUT_BIN=n
 


### PR DESCRIPTION
As this makes no difference, it's misleading so let's remove it to stop
being misled. I don't know why initial commit efa794dbc5fe2 added it but
the build directory is strictly identical with or without this line.

The SOF code is included in the build thanks to CONFIG_SOF in prj.conf,
not this. Also add a comment there highlighting which particular CONFIG_
triggers the inclusion of the module.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>