### PR TITLE
tests: benchmarks: latency_measure: fix potential div by zero

### DIFF
--- a/tests/benchmarks/latency_measure/src/heap_malloc_free.c
+++ b/tests/benchmarks/latency_measure/src/heap_malloc_free.c
@@ -47,8 +47,18 @@ void heap_malloc_free(void)
 		count++;
 	}
 
-	PRINT_STATS_AVG("Average time for heap malloc", sum_malloc, count);
-	PRINT_STATS_AVG("Average time for heap free", sum_free, count);
+	/* if count is 0, it means that there is not enough memory heap
+	 * to do k_malloc at least once, then it's meaningless to
+	 * calculate average time of memory allocation and free.
+	 */
+	if (count == 0) {
+		printk("Error: there isn't enough memory heap to do "
+				"k_malloc at least once, please "
+				"increase heap size\n");
+	} else {
+		PRINT_STATS_AVG("Average time for heap malloc", sum_malloc, count);
+		PRINT_STATS_AVG("Average time for heap free", sum_free, count);
+	}
 
 	timing_stop();
 }


### PR DESCRIPTION
If the count is zero in the heap_malloc_free test, a div by zero
would happen, so add a condition to handle this potential error.

fix: #37950 

Signed-off-by: Chen Peng1 <peng1.chen@intel.com>