### PR TITLE
drivers: serial: uart low power device control

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1429,6 +1429,7 @@ static int uart_stm32_pm_control(const struct device *dev,
 
 	/* setting a low power mode */
 	switch (action) {
+	case PM_DEVICE_ACTION_LOW_POWER:
 	case PM_DEVICE_ACTION_SUSPEND:
 #ifdef USART_ISR_BUSY
 		/* Make sure that no USART transfer is on-going */
@@ -1445,6 +1446,9 @@ static int uart_stm32_pm_control(const struct device *dev,
 		/* Clear OVERRUN flag */
 		LL_USART_ClearFlag_ORE(UartInstance);
 		/* Leave UartInstance unchanged */
+		break;
+	case PM_DEVICE_ACTION_RESUME:
+		/* Leave UartInstance ready to Tx/Rx */
 		break;
 	default:
 		return -ENOTSUP;


### PR DESCRIPTION
All the PM_Device states of the stm32 UART are handled in a coherent way,. When the Device is going to suspend or Low Power, the uart must have finished its Transmission. 
- 	 PM_DEVICE_ACTION_LOW_POWER:
- 	 PM_DEVICE_ACTION_SUSPEND:
In any other PM Device state, nothing special to do, but the PM_DEVICE_ACTION action should not be handled as an error.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/38382

Signed-off-by: Francois Ramu <francois.ramu@st.com>