### PR TITLE
drivers: modem: gsm_ppp: Fix ppp_dev

### DIFF
--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -525,7 +525,7 @@ static struct net_if *ppp_net_if(void)
 static void set_ppp_carrier_on(struct gsm_modem *gsm)
 {
 	static const struct ppp_api *api;
-	const struct device *ppp_dev = DEVICE_DT_GET(DT_INST(0, zephyr_gsm_ppp));
+	const struct device *ppp_dev = device_get_binding(CONFIG_NET_PPP_DRV_NAME);
 	struct net_if *iface = gsm->iface;
 	int ret;
 


### PR DESCRIPTION
ppp_dev should be pointing to the net/ppp driver.

Signed-off-by: Yong Cong Sin <yongcong.sin@gmail.com>