### PR TITLE
net: shell: Fix assertion in net nbr command

### DIFF
--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -3806,7 +3806,8 @@ static void nbr_cb(struct net_nbr *nbr, void *user_data)
 	   net_sprint_ll_addr(
 		   net_nbr_get_lladdr(nbr->idx)->addr,
 		   net_nbr_get_lladdr(nbr->idx)->len),
-	   net_nbr_get_lladdr(nbr->idx)->len == 8U ? "" : padding,
+	   nbr->idx == NET_NBR_LLADDR_UNKNOWN ? "" :
+		(net_nbr_get_lladdr(nbr->idx)->len == 8U ? "" : padding),
 	   net_sprint_ipv6_addr(&net_ipv6_nbr_data(nbr)->addr));
 }
 #endif


### PR DESCRIPTION
Listing a neighbour table with "net nbr" command, when a  neighbour w/o
assigned link address was present, resulted in an assert condition. Add
additional check to prevent this.

Fixes #38196

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>