### PR TITLE
manifest: mcuboot update for bringing upstream bugfixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -158,7 +158,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: ca01db4216c63678768ea78fe04f27cd80b83246
+      revision: 70bfbd21cdf5f6d1402bc8d0031e197222ed2ec0
       path: bootloader/mcuboot
     - name: mcumgr
       revision: 31a2aa9cea58d3ceecbf0d5b91361bff7c94aeca


### PR DESCRIPTION
Synchronization to latest MCUboot is impossible now due the lack of compatibility with TFM module.
This PR is for bringing as much fixes as possible from the upsteram project.

MCUboot fork was updated in order to bring bugfixes from its
upstream:
- introduce MCUBOOT_CPU_IDLE() for support low power single thread
(fixes single thread power consumption)
- Allow not working secondary image device and boot form primary
device if image available
- fixes memory alignment of the RAM buffer that is used to temporarily
store data during swap.
- update devicetree py package lib files include path in assembly
- serial recovery: cbor_encoder: fix str encoding macros
- zephyr: Kconfig: fix board references
- do not set defaults for LOG_IMMEDIATE Kconfig
- boot: Do not use `irq_lock()` if using arm cleanup
- Kconfig: fix deadlock on cryptolib selectors

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>

fixes https://github.com/zephyrproject-rtos/zephyr/issues/38402