### PR TITLE
Update sign.py output to use CONFIG_KERNEL_BIN_NAME

### DIFF
--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -262,7 +262,7 @@ class ImgtoolSigner(Signer):
         if not args.quiet:
             log.banner('signing binaries')
         if in_bin:
-            out_bin = args.sbin or str(b / 'zephyr' / 'zephyr.signed.bin')
+            out_bin = args.sbin or str(b / 'zephyr' / f'{kernel}.signed.bin')
             sign_bin = sign_base + [in_bin, out_bin]
             if not args.quiet:
                 log.inf(f'unsigned bin: {in_bin}')
@@ -270,7 +270,7 @@ class ImgtoolSigner(Signer):
                 log.dbg(quote_sh_list(sign_bin))
             subprocess.check_call(sign_bin)
         if in_hex:
-            out_hex = args.shex or str(b / 'zephyr' / 'zephyr.signed.hex')
+            out_hex = args.shex or str(b / 'zephyr' / f'{kernel}.signed.hex')
             sign_hex = sign_base + [in_hex, out_hex]
             if not args.quiet:
                 log.inf(f'unsigned hex: {in_hex}')


### PR DESCRIPTION
The command west sign will output zephyr.signed.bin and zephyr.signed.hex regardless of the name of the unsigned binaries. This change updates west sign so that the signed binaries take the name of the unsigned binaries by default.

Old behavior:
CONFIG_KERNEL_BIN_NAME="helloworld"
west build produces helloworld.bin and helloworld.hex
west sign produces zephyr.signed.bin and zephyr.signed.hex

New behavior:
CONFIG_KERNEL_BIN_NAME="helloworld"
west build produces helloworld.bin and helloworld.hex
west sign produces helloworld.signed.bin and helloworld.signed.hex