### PR TITLE
cmake: allow users to give runner args at cmake time

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -815,8 +815,11 @@ function(board_finalize_runner_args runner)
     # Default arguments from the common runner file come first.
     ${ARGN}
     # Arguments explicitly given with board_runner_args() come
-    # last, so they take precedence.
+    # next, so they take precedence over the common runner file.
     ${explicit}
+    # Arguments given via the CMake cache come last of all. Users
+    # can provide variables in this way from the CMake command line.
+    ${BOARD_RUNNER_ARGS_${runner_id}}
     )
 
   # Add the finalized runner to the global property list.


### PR DESCRIPTION
If the BOARD_RUNNER_ARGS_${runner_id} variable contains anything, add
it to the global property of the same name with all the final runner
args from board_runner_args() and friends.

This allows use cases like this:

  west build ... -- -DBOARD_RUNNER_ARGS_jlink="--some-jlink-arg"

The ${runner_id} part is the runner's name converted to a C
identifier, i.e. with special characters changed to underscores.

So e.g. the 'dfu-util' runner would use BOARD_RUNNER_ARGS_dfu_util.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>