### PR TITLE
soc: riscv: priv: call __reset during boot

### DIFF
--- a/soc/riscv/litex-vexriscv/Kconfig.soc
+++ b/soc/riscv/litex-vexriscv/Kconfig.soc
@@ -5,3 +5,4 @@ config SOC_RISCV32_LITEX_VEXRISCV
 	bool "LiteX VexRiscv system implementation"
 	select RISCV
 	select ATOMIC_OPERATIONS_C
+	select INCLUDE_RESET_VECTOR

--- a/soc/riscv/riscv-privilege/andes_v5/Kconfig.soc
+++ b/soc/riscv/riscv-privilege/andes_v5/Kconfig.soc
@@ -8,6 +8,7 @@ depends on SOC_SERIES_RISCV_ANDES_V5
 config SOC_RISCV_ANDES_AE350
 	bool "Andes AE350 SoC implementation"
 	select ATOMIC_OPERATIONS_BUILTIN
+	select INCLUDE_RESET_VECTOR
 
 endchoice
 

--- a/soc/riscv/riscv-privilege/common/vector.S
+++ b/soc/riscv/riscv-privilege/common/vector.S
@@ -32,5 +32,5 @@ SECTION_FUNC(vectors, __start)
 	la t0, __irq_wrapper
 	csrw mtvec, t0
 
-	/* Jump to __initialize */
-	tail __initialize
+	/* Jump to __reset */
+	tail __reset

--- a/soc/riscv/riscv-privilege/miv/Kconfig.soc
+++ b/soc/riscv/riscv-privilege/miv/Kconfig.soc
@@ -10,5 +10,6 @@ choice
 config SOC_RISCV32_MIV
 	bool "Microsemi Mi-V system implementation"
 	select ATOMIC_OPERATIONS_C
+	select INCLUDE_RESET_VECTOR
 
 endchoice

--- a/soc/riscv/riscv-privilege/sifive-freedom/Kconfig.soc
+++ b/soc/riscv/riscv-privilege/sifive-freedom/Kconfig.soc
@@ -10,15 +10,18 @@ choice
 config SOC_RISCV_SIFIVE_FREEDOM
 	bool "SiFive Freedom SOC implementation"
 	select ATOMIC_OPERATIONS_C
+	select INCLUDE_RESET_VECTOR
 
 config SOC_RISCV_SIFIVE_FU540
 	bool "SiFive Freedom U540 SOC implementation"
 	select ATOMIC_OPERATIONS_C
+	select INCLUDE_RESET_VECTOR
 	select 64BIT
 
 config SOC_RISCV_SIFIVE_FU740
 	bool "SiFive Freedom U740 SOC implementation"
 	select ATOMIC_OPERATIONS_C
+	select INCLUDE_RESET_VECTOR
 	select 64BIT
 
 endchoice

--- a/soc/riscv/riscv-privilege/starfive_jh71xx/Kconfig.soc
+++ b/soc/riscv/riscv-privilege/starfive_jh71xx/Kconfig.soc
@@ -8,5 +8,6 @@ choice
 config SOC_JH7100
 	bool "Starfive JH7100"
 	select ATOMIC_OPERATIONS_BUILTIN
+	select INCLUDE_RESET_VECTOR
 
 endchoice

--- a/soc/riscv/riscv-privilege/telink_b91/Kconfig.soc
+++ b/soc/riscv/riscv-privilege/telink_b91/Kconfig.soc
@@ -29,5 +29,6 @@ config SOC_RISCV_TELINK_B91
 	bool "Telink B91 SoC implementation"
 	select ATOMIC_OPERATIONS_BUILTIN
 	select CPU_HAS_FPU
+	select INCLUDE_RESET_VECTOR
 
 endchoice

--- a/soc/riscv/riscv-privilege/virt/Kconfig.soc
+++ b/soc/riscv/riscv-privilege/virt/Kconfig.soc
@@ -8,5 +8,6 @@ choice
 config SOC_RISCV_VIRT
 	bool "QEMU RISC-V VirtIO Board"
 	select ATOMIC_OPERATIONS_BUILTIN
+	select INCLUDE_RESET_VECTOR
 
 endchoice


### PR DESCRIPTION
Call `__reset` instead of directly calling `__initialize` from the common RISC-V privileged SoC vectors `__start`. This allows injection of SoC specific reset code just after setting up the machine trap vector.

RISC-V privilege SoCs without the need for custom reset code can set `CONFIG_INCLUDE_RESET_VECTOR=y` to include a `__reset` stub which simply calls `__initialize`.

Fixes: #38396

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>