### PR TITLE
Revert "linker: xtensa: move IDT_LIST region"

### DIFF
--- a/soc/xtensa/intel_adsp/cavs_v15/include/soc/memory.h
+++ b/soc/xtensa/intel_adsp/cavs_v15/include/soc/memory.h
@@ -87,7 +87,7 @@
  * Interrupt Descriptor Table (IDT). This is a bogus address as this
  * section will be stripped off in the final image.
  */
-#define IDT_BASE				0xFFFFDFFF
+#define IDT_BASE				(RAM_BASE + RAM_SIZE)
 
 /* size of the Interrupt Descriptor Table (IDT) */
 #define IDT_SIZE				0x2000

--- a/soc/xtensa/intel_adsp/cavs_v18/include/soc/memory.h
+++ b/soc/xtensa/intel_adsp/cavs_v18/include/soc/memory.h
@@ -84,7 +84,7 @@
  * Interrupt Descriptor Table (IDT). This is a bogus address as this
  * section will be stripped off in the final image.
  */
-#define IDT_BASE				0xFFFFDFFF
+#define IDT_BASE				(RAM_BASE + RAM_SIZE)
 
 /* size of the Interrupt Descriptor Table (IDT) */
 #define IDT_SIZE				0x2000

--- a/soc/xtensa/intel_adsp/cavs_v20/include/soc/memory.h
+++ b/soc/xtensa/intel_adsp/cavs_v20/include/soc/memory.h
@@ -84,7 +84,7 @@
  * Interrupt Descriptor Table (IDT). This is a bogus address as this
  * section will be stripped off in the final image.
  */
-#define IDT_BASE				0xFFFFDFFF
+#define IDT_BASE				(RAM_BASE + RAM_SIZE)
 
 /* size of the Interrupt Descriptor Table (IDT) */
 #define IDT_SIZE				0x2000

--- a/soc/xtensa/intel_adsp/cavs_v25/include/soc/memory.h
+++ b/soc/xtensa/intel_adsp/cavs_v25/include/soc/memory.h
@@ -84,7 +84,7 @@
  * Interrupt Descriptor Table (IDT). This is a bogus address as this
  * section will be stripped off in the final image.
  */
-#define IDT_BASE				0xFFFFDFFF
+#define IDT_BASE				(RAM_BASE + RAM_SIZE)
 
 /* size of the Interrupt Descriptor Table (IDT) */
 #define IDT_SIZE				0x2000

--- a/soc/xtensa/intel_s1000/memory.h
+++ b/soc/xtensa/intel_s1000/memory.h
@@ -63,7 +63,7 @@
  * Interrupt Descriptor Table (IDT). This is a bogus address as this
  * section will be stripped off in the final image.
  */
-#define IDT_BASE				0xFFFFDFFF
+#define IDT_BASE				(RAM_BASE + RAM_SIZE)
 
 /* size of the Interrupt Descriptor Table (IDT) */
 #define IDT_SIZE				0x2000


### PR DESCRIPTION
This reverts commit 9505ee89a3401af93ffddc68e7b04fc948e2f89a.

Fixes #38214
