### PR TITLE
libc/minimal: Add islower() to ctype.h

### DIFF
--- a/doc/guides/portability/posix.rst
+++ b/doc/guides/portability/posix.rst
@@ -255,7 +255,7 @@ This is implemented as part of the minimal C library available in Zephyr.
     iscntrl(),
     isdigit(),+
     isgraph(),+
-    islower(),
+    islower(),+
     isprint(),+
     ispunct(),
     isspace(),+

--- a/lib/libc/minimal/include/ctype.h
+++ b/lib/libc/minimal/include/ctype.h
@@ -13,6 +13,11 @@
 extern "C" {
 #endif
 
+static inline int islower(int a)
+{
+	return (int)(((unsigned)(a)-(unsigned)'a') < 26U);
+}
+
 static inline int isupper(int a)
 {
 	return (int)(((unsigned)(a)-(unsigned)'A') < 26U);


### PR DESCRIPTION
ctype.h in minimal libc was lacking implementation of
islower(int a).

Signed-off-by: Jan Pohanka <xhpohanka@gmail.com>