### PR TITLE
ci: increase number of builds for daily CI

### DIFF
--- a/.buildkite/daily.yml
+++ b/.buildkite/daily.yml
@@ -4,7 +4,7 @@ steps:
     env:
       ZEPHYR_TOOLCHAIN_VARIANT: "zephyr"
       ZEPHYR_SDK_INSTALL_DIR: "/opt/toolchains/zephyr-sdk-0.13.0"
-    parallelism: 400
+    parallelism: 500
     timeout_in_minutes: 210
     retry:
       manual: true


### PR DESCRIPTION
Bump to 500 builds since we have some builds that are timing out
after 3hr of building.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>