### PR TITLE
Bluetooth: Controller: Allow resolving list update during passive scan

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_filter.c
@@ -1019,7 +1019,7 @@ static int rl_access_check(bool check_ar)
 	 */
 	return ((IS_ENABLED(CONFIG_BT_BROADCASTER) && ull_adv_is_enabled(0)) ||
 		(IS_ENABLED(CONFIG_BT_OBSERVER) &&
-		 (ull_scan_is_enabled(0) & ~BIT(0))))
+		 (ull_scan_is_enabled(0) & ~ULL_SCAN_IS_PASSIVE)))
 		? 0 : 1;
 }
 

--- a/subsys/bluetooth/controller/ll_sw/ull_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_filter.c
@@ -1014,8 +1014,12 @@ static int rl_access_check(bool check_ar)
 		}
 	}
 
+	/* NOTE: Allowed when passive scanning, otherwise deny if advertising,
+	 *       active scanning, initiating or periodic sync create is active.
+	 */
 	return ((IS_ENABLED(CONFIG_BT_BROADCASTER) && ull_adv_is_enabled(0)) ||
-		(IS_ENABLED(CONFIG_BT_OBSERVER) && ull_scan_is_enabled(0)))
+		(IS_ENABLED(CONFIG_BT_OBSERVER) &&
+		 (ull_scan_is_enabled(0) & ~BIT(0))))
 		? 0 : 1;
 }
 

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -618,31 +618,25 @@ uint32_t ull_scan_is_enabled(uint8_t handle)
 {
 	struct ll_scan_set *scan;
 
-	/* NOTE: BIT(0) - passive scanning enabled
-	 *       BIT(1) - active scanning enabled
-	 *       BIT(2) - initiator enabled
-	 *       BIT(3) - periodic sync create active
-	 */
-
 	scan = ull_scan_is_enabled_get(handle);
 	if (!scan) {
 #if defined(CONFIG_BT_CTLR_SYNC_PERIODIC)
 		scan = ull_scan_set_get(handle);
 
-		return scan->per_scan.sync ? BIT(3) : 0;
+		return scan->per_scan.sync ? ULL_SCAN_IS_SYNC : 0U;
 #else
-		return 0;
+		return 0U;
 #endif
 	}
 
 	return (((uint32_t)scan->is_enabled << scan->lll.type) |
 #if defined(CONFIG_BT_CENTRAL)
-		(scan->lll.conn ? BIT(2) : 0) |
+		(scan->lll.conn ? ULL_SCAN_IS_INITIATOR : 0U) |
 #endif
 #if defined(CONFIG_BT_CTLR_SYNC_PERIODIC)
-		(scan->per_scan.sync ? BIT(3) : 0) |
+		(scan->per_scan.sync ? ULL_SCAN_IS_SYNC : 0U) |
 #endif
-		0);
+		0U);
 }
 
 uint32_t ull_scan_filter_pol_get(uint8_t handle)

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -618,18 +618,29 @@ uint32_t ull_scan_is_enabled(uint8_t handle)
 {
 	struct ll_scan_set *scan;
 
-	scan = ull_scan_is_enabled_get(handle);
-	if (!scan) {
-		return 0;
-	}
-
 	/* NOTE: BIT(0) - passive scanning enabled
 	 *       BIT(1) - active scanning enabled
 	 *       BIT(2) - initiator enabled
+	 *       BIT(3) - periodic sync create active
 	 */
+
+	scan = ull_scan_is_enabled_get(handle);
+	if (!scan) {
+#if defined(CONFIG_BT_CTLR_SYNC_PERIODIC)
+		scan = ull_scan_set_get(handle);
+
+		return scan->per_scan.sync ? BIT(3) : 0;
+#else
+		return 0;
+#endif
+	}
+
 	return (((uint32_t)scan->is_enabled << scan->lll.type) |
 #if defined(CONFIG_BT_CENTRAL)
 		(scan->lll.conn ? BIT(2) : 0) |
+#endif
+#if defined(CONFIG_BT_CTLR_SYNC_PERIODIC)
+		(scan->per_scan.sync ? BIT(3) : 0) |
 #endif
 		0);
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_internal.h
@@ -62,6 +62,10 @@ struct ll_scan_set *ull_scan_is_enabled_get(uint8_t handle);
 struct ll_scan_set *ull_scan_is_disabled_get(uint8_t handle);
 
 /* Return flags if enabled */
+#define ULL_SCAN_IS_PASSIVE   BIT(0)
+#define ULL_SCAN_IS_ACTIVE    BIT(1)
+#define ULL_SCAN_IS_INITIATOR BIT(2)
+#define ULL_SCAN_IS_SYNC      BIT(3)
 uint32_t ull_scan_is_enabled(uint8_t handle);
 
 /* Return filter policy used */


### PR DESCRIPTION
Allow resolving list update  when passive scanning,
otherwise deny if advertising, active scanning, initiating
or periodic sync create is active.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>