### PR TITLE
Bluetooth: Controller: Fix extended header data be zero-length array

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -279,7 +279,7 @@ struct pdu_adv_com_ext_adv {
 #endif
 	union {
 		struct pdu_adv_ext_hdr ext_hdr;
-		uint8_t ext_hdr_adv_data[254];
+		uint8_t ext_hdr_adv_data[0];
 	};
 } __packed;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -303,8 +303,8 @@ uint8_t ll_adv_aux_sr_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref, ui
 	/* Check if data will fit in remaining space */
 	/* TODO: need aux_chain_ind support */
 	ext_hdr_len = sr_dptr - &sr_com_hdr->ext_hdr_adv_data[0];
-	if (sizeof(sr_com_hdr->ext_hdr_adv_data) -
-	    sr_com_hdr->ext_hdr_len < len) {
+	if ((PDU_AC_EXT_HEADER_SIZE_MIN + ext_hdr_len + len) >
+	    PDU_AC_PAYLOAD_SIZE_MAX) {
 		return BT_HCI_ERR_PACKET_TOO_LONG;
 	}
 
@@ -748,6 +748,7 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 	sec_len += ad_len;
 
 	/* Check AdvData overflow */
+	/* TODO: need aux_chain_ind support */
 	if (sec_len > PDU_AC_PAYLOAD_SIZE_MAX) {
 		/* FIXME: release allocations */
 		return BT_HCI_ERR_PACKET_TOO_LONG;


### PR DESCRIPTION
Fix the definiion of Common Extended Payload Format data
field in the PDU definitions to be zero-length array,
because PDU size are configurable and to avoid allocations
being made using these PDU structs.

Corrected the extended scan response length check code to
use the correct define instead.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>