### PR TITLE
Bluetooth: Controller: Fix missing reset of Periodic Sync Create

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -695,42 +695,6 @@ void ll_reset(void)
 #endif /* CONFIG_BT_CTLR_ADV_ISO */
 
 #if defined(CONFIG_BT_CONN)
-#if defined(CONFIG_BT_CENTRAL)
-	/* Reset initiator */
-	{
-		void *rx;
-
-		err = ll_connect_disable(&rx);
-		if (!err) {
-			struct ll_scan_set *scan;
-
-			scan = ull_scan_is_enabled_get(SCAN_HANDLE_1M);
-
-			if (IS_ENABLED(CONFIG_BT_CTLR_ADV_EXT) &&
-			    IS_ENABLED(CONFIG_BT_CTLR_PHY_CODED)) {
-				struct ll_scan_set *scan_other;
-
-				scan_other = ull_scan_is_enabled_get(SCAN_HANDLE_PHY_CODED);
-				if (scan_other) {
-					if (scan) {
-						scan->is_enabled = 0U;
-						scan->lll.conn = NULL;
-					}
-
-					scan = scan_other;
-				}
-			}
-
-			LL_ASSERT(scan);
-
-			scan->is_enabled = 0U;
-			scan->lll.conn = NULL;
-		}
-
-		ARG_UNUSED(rx);
-	}
-#endif /* CONFIG_BT_CENTRAL */
-
 	/* Reset conn role */
 	err = ull_conn_reset();
 	LL_ASSERT(!err);

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -759,6 +759,11 @@ int ull_conn_reset(void)
 	uint16_t handle;
 	int err;
 
+#if defined(CONFIG_BT_CENTRAL)
+	/* Reset initiator */
+	(void)ull_master_reset();
+#endif /* CONFIG_BT_CENTRAL */
+
 	for (handle = 0U; handle < CONFIG_BT_MAX_CONN; handle++) {
 		disable(handle);
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -641,6 +641,44 @@ uint8_t ll_enc_req_send(uint16_t handle, uint8_t const *const rand,
 }
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 
+int ull_master_reset(void)
+{
+	int err;
+	void *rx;
+
+	err = ll_connect_disable(&rx);
+	if (!err) {
+		struct ll_scan_set *scan;
+
+		scan = ull_scan_is_enabled_get(SCAN_HANDLE_1M);
+
+		if (IS_ENABLED(CONFIG_BT_CTLR_ADV_EXT) &&
+		    IS_ENABLED(CONFIG_BT_CTLR_PHY_CODED)) {
+			struct ll_scan_set *scan_other;
+
+			scan_other =
+				ull_scan_is_enabled_get(SCAN_HANDLE_PHY_CODED);
+			if (scan_other) {
+				if (scan) {
+					scan->is_enabled = 0U;
+					scan->lll.conn = NULL;
+				}
+
+				scan = scan_other;
+			}
+		}
+
+		LL_ASSERT(scan);
+
+		scan->is_enabled = 0U;
+		scan->lll.conn = NULL;
+	}
+
+	ARG_UNUSED(rx);
+
+	return err;
+}
+
 void ull_master_cleanup(struct node_rx_hdr *rx_free)
 {
 	struct lll_conn *conn_lll;

--- a/subsys/bluetooth/controller/ll_sw/ull_master_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_master_internal.h
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+int ull_master_reset(void);
 void ull_master_cleanup(struct node_rx_hdr *rx_free);
 void ull_master_setup(struct node_rx_hdr *rx, struct node_rx_ftr *ftr,
 		      struct lll_conn *lll);

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2020 Nordic Semiconductor ASA
+ * Copyright (c) 2020-2021 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr.h>
+#include <soc.h>
 #include <sys/byteorder.h>
 #include <bluetooth/hci.h>
 
@@ -13,6 +14,7 @@
 #include "util/memq.h"
 #include "util/mayfly.h"
 
+#include "hal/cpu.h"
 #include "hal/ccm.h"
 #include "hal/radio.h"
 #include "hal/ticker.h"
@@ -216,15 +218,20 @@ uint8_t ll_sync_create_cancel(void **rx)
 
 	/* Check for race condition where in sync is established when sync
 	 * context was set to NULL.
+	 *
+	 * Setting `scan->per_scan.sync` to NULL represents cancellation
+	 * requested in the thread context. Checking `sync->timeout_reload`
+	 * confirms if synchronization was established before
+	 * `scan->per_scan.sync` was set to NULL.
 	 */
 	sync = scan->per_scan.sync;
-	if (!sync || sync->timeout_reload) {
-		return BT_HCI_ERR_CMD_DISALLOWED;
-	}
-
 	scan->per_scan.sync = NULL;
 	if (IS_ENABLED(CONFIG_BT_CTLR_PHY_CODED)) {
 		scan_coded->per_scan.sync = NULL;
+	}
+	cpu_dmb();
+	if (!sync || sync->timeout_reload) {
+		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
 
 	node_rx = (void *)scan->per_scan.node_rx_estab;
@@ -301,7 +308,15 @@ int ull_sync_init(void)
 
 int ull_sync_reset(void)
 {
+	uint16_t handle;
+	void *rx;
 	int err;
+
+	(void)ll_sync_create_cancel(&rx);
+
+	for (handle = 0U; handle < CONFIG_BT_PER_ADV_SYNC_MAX; handle++) {
+		(void)ll_sync_terminate(handle);
+	}
 
 	err = init_reset();
 	if (err) {


### PR DESCRIPTION
Fix missing reset of Periodic Sync Create when HCI Reset is
performed.

Refactor out the initiator reset implementation into a
function.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>