### PR TITLE
drivers: serial: ns16550: fix uart initialization

### DIFF
--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -339,7 +339,6 @@ static int uart_ns16550_configure(const struct device *dev,
 {
 	struct uart_ns16550_dev_data * const dev_data = DEV_DATA(dev);
 	const struct uart_ns16550_device_config * const dev_cfg = DEV_CFG(dev);
-	uint8_t lcr_cache;
 	uint8_t mdc = 0U;
 
 	/* temp for return value if error occurs in this locked region */
@@ -466,10 +465,7 @@ static int uart_ns16550_configure(const struct device *dev,
 		);
 
 	/* clear the port */
-	lcr_cache = INBYTE(LCR(dev));
-	OUTBYTE(LCR(dev), LCR_DLAB | lcr_cache);
 	INBYTE(RDR(dev));
-	OUTBYTE(LCR(dev), lcr_cache);
 
 	/* disable interrupts  */
 	OUTBYTE(IER(dev), 0x00);


### PR DESCRIPTION
Do not set DLAB bit in Line Control Register when the access to
the baud rate divisor registers is not needed.

Signed-off-by: Dawid Niedzwiecki <dn@semihalf.com>