### PR TITLE
LE Audio broadcast source API use chan array

### DIFF
--- a/include/bluetooth/audio.h
+++ b/include/bluetooth/audio.h
@@ -985,14 +985,18 @@ int bt_audio_chan_send(struct bt_audio_chan *chan, struct net_buf *buf);
  *  called and no audio information (BIGInfo) will be visible to scanners
  *  (see bt_le_per_adv_sync_cb).
  *
- *  @param[in]  chan        Channel object being used for the broadcaster.
+ *  @param[in]  chans       Array of channel objects being used for the
+ *                          broadcaster. This array shall remain valid for the
+ *                          duration of the broadcast source.
+ *  @param[in]  num_chan    Number of channels in @p chans.
  *  @param[in]  codec       Codec configuration.
  *  @param[in]  qos         Quality of Service configuration
  *  @param[out] source      Pointer to the broadcast source created
  *
  *  @return Zero on success or (negative) error code otherwise.
  */
-int bt_audio_broadcast_source_create(struct bt_audio_chan *chan,
+int bt_audio_broadcast_source_create(struct bt_audio_chan *chans,
+				     uint8_t num_chan,
 				     struct bt_codec *codec,
 				     struct bt_codec_qos *qos,
 				     struct bt_audio_broadcast_source **source);

--- a/subsys/bluetooth/host/audio/endpoint.h
+++ b/subsys/bluetooth/host/audio/endpoint.h
@@ -43,8 +43,8 @@ struct bt_audio_broadcast_source {
 	struct bt_iso_big *big;
 	struct bt_iso_chan *bis[BROADCAST_STREAM_CNT];
 	struct bt_codec_qos *qos;
-	/* The "main" channel used to create the broadcast source */
-	struct bt_audio_chan *chan;
+	/* The channels used to create the broadcast source */
+	struct bt_audio_chan *chans;
 };
 
 struct bt_audio_broadcast_sink {

--- a/subsys/bluetooth/host/audio/endpoint.h
+++ b/subsys/bluetooth/host/audio/endpoint.h
@@ -34,7 +34,7 @@ struct bt_audio_ep_cb {
 #define BT_AUDIO_EP_REMOTE	0x01
 
 struct bt_audio_broadcast_source {
-	uint8_t bis_count;
+	uint8_t chan_count;
 	uint8_t subgroup_count;
 	uint32_t pd; /** QoS Presentation Delay */
 	uint32_t broadcast_id; /* 24 bit */

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/broadcast_source_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/broadcast_source_test.c
@@ -50,17 +50,11 @@ static void test_main(void)
 
 	printk("Bluetooth initialized\n");
 
-	/* Link all channels */
-	memset(broadcast_source_chans, 0, sizeof(broadcast_source_chans));
-	for (int i = 0; i < ARRAY_SIZE(broadcast_source_chans); i++) {
-		for (int j = i + 1; j < ARRAY_SIZE(broadcast_source_chans); j++) {
-			bt_audio_chan_link(&broadcast_source_chans[i],
-					   &broadcast_source_chans[j]);
-		}
+	(void)memset(broadcast_source_chans, 0, sizeof(broadcast_source_chans));
 
-	}
-
-	err = bt_audio_broadcast_source_create(&broadcast_source_chans[0],
+	printk("Creating broadcast source\n");
+	err = bt_audio_broadcast_source_create(broadcast_source_chans,
+					       ARRAY_SIZE(broadcast_source_chans),
 					       &preset_48_1_2.codec,
 					       &preset_48_1_2.qos,
 					       &source);
@@ -69,9 +63,9 @@ static void test_main(void)
 		return;
 	}
 
-	err = bt_audio_broadcast_source_reconfig(source,
-						    &preset_48_2_2.codec,
-						    &preset_48_2_2.qos);
+	printk("Reconfiguring broadcast source\n");
+	err = bt_audio_broadcast_source_reconfig(source, &preset_48_2_2.codec,
+						 &preset_48_2_2.qos);
 	if (err != 0) {
 		FAIL("Unable to reconfigure broadcast source: %d", err);
 		return;
@@ -79,6 +73,7 @@ static void test_main(void)
 
 	k_sleep(K_SECONDS(10));
 
+	printk("Deleting broadcast source\n");
 	err = bt_audio_broadcast_source_delete(source);
 	if (err != 0) {
 		FAIL("Unable to delete broadcast source: %d", err);
@@ -87,7 +82,9 @@ static void test_main(void)
 	source = NULL;
 
 	/* Recreate broadcast source to verify that it's possible */
-	err = bt_audio_broadcast_source_create(&broadcast_source_chans[0],
+	printk("Recreating broadcast source\n");
+	err = bt_audio_broadcast_source_create(broadcast_source_chans,
+					       ARRAY_SIZE(broadcast_source_chans),
 					       &preset_48_1_2.codec,
 					       &preset_48_1_2.qos,
 					       &source);
@@ -96,6 +93,7 @@ static void test_main(void)
 		return;
 	}
 
+	printk("Deleting broadcast source\n");
 	err = bt_audio_broadcast_source_delete(source);
 	if (err != 0) {
 		FAIL("Unable to delete broadcast source: %d", err);


### PR DESCRIPTION
Modify the bt_audio_broadcast_source_create function to take  array of channels instead of a list of channels. This  better matches the broadcast ISO API as well as making it more clear that the list/array is immutable.