### PR TITLE
net: http: switch to zsock_ for http_client

### DIFF
--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -32,7 +32,7 @@ LOG_MODULE_REGISTER(net_http, CONFIG_NET_HTTP_LOG_LEVEL);
 static ssize_t sendall(int sock, const void *buf, size_t len)
 {
 	while (len) {
-		ssize_t out_len = send(sock, buf, len, 0);
+		ssize_t out_len = zsock_send(sock, buf, len, 0);
 
 		if (out_len < 0) {
 			return -errno;
@@ -415,7 +415,7 @@ static int http_wait_data(int sock, struct http_request *req)
 	int received, ret;
 
 	do {
-		received = recv(sock, req->internal.response.recv_buf + offset,
+		received = zsock_recv(sock, req->internal.response.recv_buf + offset,
 				req->internal.response.recv_buf_len - offset,
 				0);
 		if (received == 0) {
@@ -460,7 +460,7 @@ static void http_timeout(struct k_work *work)
 	struct http_client_internal_data *data =
 		CONTAINER_OF(work, struct http_client_internal_data, work);
 
-	(void)close(data->sock);
+	(void)zsock_close(data->sock);
 }
 
 int http_client_req(int sock, struct http_request *req,


### PR DESCRIPTION
Using zsock_ in http_client instead of the POSIX API versions of the
functions allows the usage of http_client in combination with
CONFIG_POSIX_API.

Signed-off-by: Benedikt Schmidt <benedikt.schmidt@embedded-solutions.at>