### PR TITLE
twister: native_posix: Ignor filtering by toolchain for native_posix

### DIFF
--- a/boards/posix/native_posix/native_posix.yaml
+++ b/boards/posix/native_posix/native_posix.yaml
@@ -5,7 +5,7 @@ arch: posix
 ram: 65536
 flash: 65536
 toolchain:
-  - zephyr
+  - host
   - llvm
 supported:
   - eeprom

--- a/boards/posix/native_posix/native_posix_64.yaml
+++ b/boards/posix/native_posix/native_posix_64.yaml
@@ -5,7 +5,7 @@ arch: posix
 ram: 65536
 flash: 65536
 toolchain:
-  - zephyr
+  - host
   - llvm
 supported:
   - eeprom

--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -3202,6 +3202,7 @@ class TestSuite(DisablePyTestCollectionMixin):
 
                 if not force_toolchain \
                         and toolchain and (toolchain not in plat.supported_toolchains) \
+                        and "host" not in plat.supported_toolchains \
                         and tc.type != 'unit':
                     discards[instance] = discards.get(instance, "Not supported by the toolchain")
 


### PR DESCRIPTION
In the case of native_posix (and other "host" toolchain based
platforms) Twister shouldn't filter tests by ZEPHYR_TOOLCHAIN_VARIANT.
The PR replaces `- zephyr` with `- host` in native_posix(_64).yaml
and modify the filter in twisterlib.py to not block building
if "host" is under the platform supported toolchains.

Fixes: #38418

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>