### PR TITLE
arch: arm: core: aarch32: fix regression introduced with Cortex-R

### DIFF
--- a/arch/arm/core/aarch32/userspace.S
+++ b/arch/arm/core/aarch32/userspace.S
@@ -548,9 +548,6 @@ dispatch_syscall:
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE) \
     /* set stack back to unprivileged stack */
     ldr ip, [sp,#12]
-#endif
-
-#if !defined(CONFIG_CPU_CORTEX_R)
     msr PSP, ip
 #endif
 


### PR DESCRIPTION
arch: arm: core: aarch32: fix regression introduced with Cortex-R

Regression introduced on ARMV6_M_ARMV8_M_BASELINE by Cortex-R PR #28231
Fixes #38421
