### PR TITLE
subsys: logging: log_core: add extra space in missed strdup err msg

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -182,7 +182,7 @@ static bool is_rodata(const void *addr)
  */
 static void detect_missed_strdup(struct log_msg *msg)
 {
-#define ERR_MSG	"argument %d in source %s log message \"%s\" missing" \
+#define ERR_MSG	"argument %d in source %s log message \"%s\" missing " \
 		"log_strdup()."
 	uint32_t idx;
 	const char *str;


### PR DESCRIPTION
It improves readability in an error message:

before: <err> log: argument 0 in source storage log message "val %s"
missinglog_strdup().

after: <err> log: argument 0 in source storage log message "val %s"
missing log_strdup().

Signed-off-by: Bartosz Bilas <b.bilas@grinn-global.com>