### PR TITLE
drivers: cc13xx_cc26xx: update HAL TI SimpleLink SDK 4.40

### DIFF
--- a/drivers/entropy/entropy_cc13xx_cc26xx.c
+++ b/drivers/entropy/entropy_cc13xx_cc26xx.c
@@ -16,6 +16,7 @@
 #include <sys/ring_buffer.h>
 #include <sys/sys_io.h>
 
+#include <driverlib/rom.h>
 #include <driverlib/prcm.h>
 #include <driverlib/trng.h>
 
@@ -322,7 +323,7 @@ static int entropy_cc13xx_cc26xx_init(const struct device *dev)
 	}
 
 	/* Peripherals should not be accessed until power domain is on. */
-	while (PRCMPowerDomainStatus(PRCM_DOMAIN_PERIPH) !=
+	while (PRCMPowerDomainsAllOn(PRCM_DOMAIN_PERIPH) !=
 	       PRCM_DOMAIN_POWER_ON) {
 		continue;
 	}

--- a/drivers/gpio/gpio_cc13xx_cc26xx.c
+++ b/drivers/gpio/gpio_cc13xx_cc26xx.c
@@ -15,6 +15,7 @@
 #include <driverlib/gpio.h>
 #include <driverlib/interrupt.h>
 #include <driverlib/ioc.h>
+#include <driverlib/rom.h>
 #include <driverlib/prcm.h>
 
 #include <inc/hw_aon_event.h>
@@ -260,7 +261,7 @@ static int gpio_cc13xx_cc26xx_init(const struct device *dev)
 	irq_enable(DT_INST_IRQN(0));
 
 	/* Peripheral should not be accessed until power domain is on. */
-	while (PRCMPowerDomainStatus(PRCM_DOMAIN_PERIPH) !=
+	while (PRCMPowerDomainsAllOn(PRCM_DOMAIN_PERIPH) !=
 	       PRCM_DOMAIN_POWER_ON) {
 		continue;
 	}

--- a/drivers/i2c/i2c_cc13xx_cc26xx.c
+++ b/drivers/i2c/i2c_cc13xx_cc26xx.c
@@ -17,6 +17,7 @@ LOG_MODULE_REGISTER(i2c_cc13xx_cc26xx);
 
 #include <driverlib/i2c.h>
 #include <driverlib/ioc.h>
+#include <driverlib/rom.h>
 #include <driverlib/prcm.h>
 
 #include <ti/drivers/Power.h>
@@ -391,7 +392,7 @@ static int i2c_cc13xx_cc26xx_init(const struct device *dev)
 	}
 
 	/* I2C should not be accessed until power domain is on. */
-	while (PRCMPowerDomainStatus(PRCM_DOMAIN_SERIAL) !=
+	while (PRCMPowerDomainsAllOn(PRCM_DOMAIN_SERIAL) !=
 	       PRCM_DOMAIN_POWER_ON) {
 		continue;
 	}

--- a/drivers/serial/uart_cc13xx_cc26xx.c
+++ b/drivers/serial/uart_cc13xx_cc26xx.c
@@ -14,6 +14,7 @@
 #include <drivers/uart.h>
 
 #include <driverlib/ioc.h>
+#include <driverlib/rom.h>
 #include <driverlib/prcm.h>
 #include <driverlib/uart.h>
 
@@ -504,7 +505,7 @@ static const struct uart_driver_api uart_cc13xx_cc26xx_driver_api = {
 		}							\
 									     \
 		/* UART should not be accessed until power domain is on. */  \
-		while (PRCMPowerDomainStatus(domain) !=			     \
+		while (PRCMPowerDomainsAllOn(domain) !=			     \
 			PRCM_DOMAIN_POWER_ON) {				     \
 			continue;					     \
 		}							     \

--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -14,6 +14,7 @@ LOG_MODULE_REGISTER(spi_cc13xx_cc26xx);
 #include <pm/device.h>
 #include <pm/pm.h>
 
+#include <driverlib/rom.h>
 #include <driverlib/prcm.h>
 #include <driverlib/ssi.h>
 #include <driverlib/ioc.h>
@@ -286,7 +287,7 @@ static const struct spi_driver_api spi_cc13xx_cc26xx_driver_api = {
 		}							  \
 									  \
 		/* SSI should not be accessed until power domain is on. */\
-		while (PRCMPowerDomainStatus(domain) !=			  \
+		while (PRCMPowerDomainsAllOn(domain) !=			  \
 			PRCM_DOMAIN_POWER_ON) {				  \
 			continue;					  \
 		}							  \

--- a/west.yml
+++ b/west.yml
@@ -134,7 +134,7 @@ manifest:
       groups:
         - hal
     - name: hal_ti
-      revision: 1992a4c536554c4f409c36896eda6abdc414d277
+      revision: pull/27/head
       path: modules/hal/ti
       groups:
         - hal


### PR DESCRIPTION
Hi, I thought it would be nice to have an more up-to-date SDK (although version 5 is the latest, still WIP when I get to it).
Minor upgrades should be safe for now.
Tested on both CC1352P LaunchXL and several custom-made CC1352R boards (using GPIO, timers and Sub-GHz radio).

Note: SDK renamed PRCMPowerDomainStatus to PRCMPowerDomainsAllOn, so drivers were changed too.

Linked hal_ti pull req: https://github.com/zephyrproject-rtos/hal_ti/pull/27 .
Should I make an issue referencing this, too ?

Thanks.