### PR TITLE
samples: philosophers: fix Xtensa and pointer type mismatch warnings

### DIFF
--- a/samples/philosophers/src/phil_obj_abstract.h
+++ b/samples/philosophers/src/phil_obj_abstract.h
@@ -81,12 +81,12 @@
 			uint32_t stack_mem[1];
 		} fork_obj_t;
 		#define fork_init(x) do { \
-			k_stack_init(x, (uint32_t *)((x) + 1), 1); \
+			k_stack_init(x, (void *)((x) + 1), 1); \
 			k_stack_push(x, MAGIC); \
 		} while ((0))
 	#endif
 	#define take(x) do { \
-		uint32_t data; k_stack_pop(x, &data, K_FOREVER); \
+		uint32_t data; k_stack_pop(x, (void *)&data, K_FOREVER); \
 		__ASSERT(data == MAGIC, "data was %x\n", data); \
 	} while ((0))
 	#define drop(x) k_stack_push(x, MAGIC)

--- a/subsys/debug/thread_info.c
+++ b/subsys/debug/thread_info.c
@@ -80,6 +80,13 @@ size_t _kernel_thread_info_offsets[] = {
 #elif defined(CONFIG_ARCH_POSIX)
 	[THREAD_INFO_OFFSET_T_STACK_PTR] = offsetof(struct k_thread,
 						callee_saved.thread_status),
+#elif defined(CONFIG_XTENSA)
+	/* Xtensa does not store stack pointers inside thread objects.
+	 * The registers are saved in thread stack where there is
+	 * no fixed location for this to work. So mark this as
+	 * unimplemented to avoid the #warning below.
+	 */
+	[THREAD_INFO_OFFSET_T_STACK_PTR] = THREAD_INFO_UNIMPLEMENTED,
 #else
 	/* Use a special value so that OpenOCD knows that obtaining the stack
 	 * pointer is not possible on this particular architecture.


### PR DESCRIPTION
Xtensa does not store the stack pointers in thread objects but pushing the registers into the stack. There is no fixed location to retrieve the stack pointer so mark stack pointer in the debug thread info as unimplemented to avoid the #warning.

Also fix the compiler warnings about pointer type mis-match when using the stack fork.