### PR TITLE
drivers: serial: stm32: use PM constraints to prevent suspension

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -459,8 +459,6 @@ static void uart_stm32_poll_out(const struct device *dev,
 	/* do not allow system to suspend until transmission has completed */
 	pm_constraint_set(PM_STATE_SUSPEND_TO_IDLE);
 
-	LL_USART_ClearFlag_TC(UartInstance);
-
 	LL_USART_TransmitData8(UartInstance, (uint8_t)c);
 }
 

--- a/drivers/serial/uart_stm32.h
+++ b/drivers/serial/uart_stm32.h
@@ -25,6 +25,11 @@ struct uart_stm32_config {
 	int  parity;
 	const struct soc_gpio_pinctrl *pinctrl_list;
 	size_t pinctrl_list_size;
+#if defined(CONFIG_PM) \
+	&& !defined(CONFIG_UART_INTERRUPT_DRIVEN) \
+	&& !defined(CONFIG_UART_ASYNC_API)
+	uart_irq_config_func_t irq_config_func;
+#endif
 };
 
 #ifdef CONFIG_UART_ASYNC_API


### PR DESCRIPTION
In the current implementation, the STM32 UART driver required to enable
`CONFIG_PM_DEVICE` when `CONFIG_PM=y` to function properly. The main
reason is that in some situations, like in polling mode, transmissions
are not fully synchronous. That is, a byte is pushed to the _queue_ if
it is empty, and then the function returns without waiting for it to be
transmitted to the wire. This makes sense to make things like per-byte
transmission efficient. However, this introduces a problem: the system
may reach idle state, and so enter low power modes before the UART has
actually finished processing the last data in the queue. If this happens,
communications can be interrupted, or garbage data may be put into the
UART line.

The proposed solution in this patch uses PM constraints to solve this
problem. For the IRQ/DMA case it is easy since we can set the constraint
before transmission start, and when the completion (TC) interrupt is
received we can clear it. However, the polling mode did not have the
capability to signal the completion. For this case, a simpler IRQ
routine is provided to just release the constraint. As a result, the PM
hooks are not required, and so the system can operate with just `CONFIG_PM`.

Fixes #38382 
Fixes #38437

@erwango @FRASTM seems to fix the issue on my side, but I may have missed things. `CONFIG_PM_DEVICE=y` default for STM32 should likely be reviewed.