### PR TITLE
pm: cc13x2_cc26x2: Implement their own constraint

### DIFF
--- a/soc/arm/ti_simplelink/cc13x2_cc26x2/power.c
+++ b/soc/arm/ti_simplelink/cc13x2_cc26x2/power.c
@@ -182,5 +182,55 @@ void PowerCC26XX_schedulerRestore(void)
 	 */
 }
 
+/* Constraint API hooks */
+
+void pm_constraint_set(enum pm_state state)
+{
+	switch (state) {
+	case PM_STATE_RUNTIME_IDLE:
+		Power_setConstraint(PowerCC26XX_DISALLOW_IDLE);
+		break;
+	case PM_STATE_STANDBY:
+		Power_setConstraint(PowerCC26XX_DISALLOW_STANDBY);
+		break;
+	default:
+		break;
+	}
+}
+
+void pm_constraint_release(enum pm_state state)
+{
+	switch (state) {
+	case PM_STATE_RUNTIME_IDLE:
+		Power_releaseConstraint(PowerCC26XX_DISALLOW_IDLE);
+		break;
+	case PM_STATE_STANDBY:
+		Power_releaseConstraint(PowerCC26XX_DISALLOW_STANDBY);
+		break;
+	default:
+		break;
+	}
+}
+
+bool pm_constraint_get(enum pm_state state)
+{
+	bool ret = true;
+	uint32_t constraints;
+
+	constraints = Power_getConstraintMask();
+	switch (state) {
+	case PM_STATE_RUNTIME_IDLE:
+		ret = (constraints & (1 << PowerCC26XX_DISALLOW_IDLE)) == 0;
+		break;
+	case PM_STATE_STANDBY:
+		ret = (constraints & (1 << PowerCC26XX_DISALLOW_STANDBY)) == 0;
+		break;
+	default:
+		break;
+	}
+
+	return ret;
+}
+
 SYS_INIT(power_initialize, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 SYS_INIT(unlatch_pins, POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY);

--- a/subsys/pm/pm_ctrl.c
+++ b/subsys/pm/pm_ctrl.c
@@ -18,7 +18,7 @@ LOG_MODULE_DECLARE(power);
 
 static atomic_t power_state_disable_count[PM_STATES_LEN];
 
-void pm_constraint_set(enum pm_state state)
+__weak void pm_constraint_set(enum pm_state state)
 {
 	atomic_val_t v;
 
@@ -30,7 +30,7 @@ void pm_constraint_set(enum pm_state state)
 	(void)(v);
 }
 
-void pm_constraint_release(enum pm_state state)
+__weak void pm_constraint_release(enum pm_state state)
 {
 	atomic_val_t v;
 
@@ -42,7 +42,7 @@ void pm_constraint_release(enum pm_state state)
 	(void)(v);
 }
 
-bool pm_constraint_get(enum pm_state state)
+__weak bool pm_constraint_get(enum pm_state state)
 {
 	__ASSERT(state < PM_STATES_LEN, "Invalid power state!");
 


### PR DESCRIPTION
TI Hal has its own constraint API that is used by its drivers. These
constraints need to be correlated with Zephyr constraints to be
constraints set in the HAL be visible on Zephyr and vice-versa.

Fixes #38362

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>