### PR TITLE
device: Fix device from handle function

### DIFF
--- a/include/device.h
+++ b/include/device.h
@@ -431,7 +431,7 @@ device_from_handle(device_handle_t dev_handle)
 	const struct device *dev = NULL;
 	size_t numdev = __device_end - __device_start;
 
-	if ((dev_handle > 0) && ((size_t)dev_handle < numdev)) {
+	if ((dev_handle > 0) && ((size_t)dev_handle <= numdev)) {
 		dev = &__device_start[dev_handle - 1];
 	}
 


### PR DESCRIPTION
This function was returning NULL for the last handle because of a
wrong comparison.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>