### PR TITLE
scripts: add exception handler when parsing input for syscalls fails

### DIFF
--- a/scripts/parse_syscalls.py
+++ b/scripts/parse_syscalls.py
@@ -76,8 +76,12 @@ def analyze_headers(multiple_directories):
                                                    'common.h'))):
                     continue
 
-                with open(path, "r", encoding="utf-8") as fp:
-                    contents = fp.read()
+                try:
+                    with open(path, "r", encoding="utf-8") as fp:
+                        contents = fp.read()
+                except Exception:
+                    sys.stderr.write("Failed while parsing %s\n" % path)
+                    raise
 
                 try:
                     syscall_result = [(mo.groups(), fn)


### PR DESCRIPTION
If an input file fails to decode due to a unicode parsing error this will dump the offending file as part of the error message