### PR TITLE
samples: i2s_litex: add filter i2s

### DIFF
--- a/samples/drivers/i2s/litex/sample.yaml
+++ b/samples/drivers/i2s/litex/sample.yaml
@@ -4,6 +4,7 @@ sample:
   name: i2s example
 common:
     tags: introduction
+    depends_on: i2s
     harness: console
     harness_config:
       type: one_line


### PR DESCRIPTION
add i2s depends_on to filter out non-supported platform

Signed-off-by: Hake Huang <hake.huang@oss.nxp.com>