### PR TITLE
Revert "boards: up_squared_adsp: Add IPM console to device tree"

### DIFF
--- a/boards/xtensa/intel_adsp_cavs15/intel_adsp_cavs15.dts
+++ b/boards/xtensa/intel_adsp_cavs15/intel_adsp_cavs15.dts
@@ -14,6 +14,5 @@
 
 	chosen {
 		zephyr,sram = &sram0;
-		zephyr,console = &ipm_console;
 	};
 };

--- a/dts/xtensa/intel/intel_cavs15.dtsi
+++ b/dts/xtensa/intel/intel_cavs15.dtsi
@@ -100,11 +100,6 @@
 			label = "IPM_0";
 		};
 
-		ipm_console: ipm_console {
-			compatible = "zephyr,ipm-console";
-			label="IPM_0";
-		};
-
 		mailbox: mailbox@1180 {
 			compatible = "intel,intel-adsp-mailbox";
 			reg = <0x1180 0x20>;


### PR DESCRIPTION
This reverts commit 3dfcfcd3c9d80da967d1cb68760a2492b49da1a3.

Fixes build warning:
```
-- Found BOARD.dts: boards/xtensa/intel_adsp_cavs15/intel_adsp_cavs15.dts
intel_adsp_cavs15.dts.pre.tmp:96.28-99.5: Warning (simple_bus_reg):
               /soc/ipm_console: missing or empty reg/ranges property
```
According to @andyross  the ipm_console is not relevant to this hardware
and Device Tree is not the place for software configuration anyway.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>