### PR TITLE
tests: driver: build-test: add mini_ram limit to build cases

### DIFF
--- a/tests/drivers/build_all/modem/testcase.yaml
+++ b/tests/drivers/build_all/modem/testcase.yaml
@@ -5,6 +5,7 @@ tests:
   drivers.modem.build:
     extra_args: CONF_FILE=modem.conf
     platform_exclude: serpente particle_boron rak5010_nrf52840 litex_vexriscv ip_k66f
+    min_ram: 36
   drivers.modem.ublox_sara.build:
     extra_args: CONF_FILE=modem_ublox_sara.conf
     platform_exclude: serpente pinnacle_100_dvk litex_vexriscv ip_k66f
@@ -14,3 +15,4 @@ tests:
   drivers.modem.quectel_bg9x.build:
     extra_args: CONF_FILE=modem_quectel_bg9x.conf
     platform_exclude: serpente pinnacle_100_dvk litex_vexriscv ip_k66f
+    min_ram: 36


### PR DESCRIPTION
below two build test can not fit in SRAM size

drivers.modem.build
drivers.modem.quectel_bg9x.build

build error report:

region `SRAM' overflowed by 20688 bytes
collect2: error: ld returned 1 exit status

Signed-off-by: Hake Huang <hake.huang@oss.nxp.com>