### PR TITLE
drivers: watchdog: fix missing stm32 LOG_LEVEL macro

### DIFF
--- a/drivers/watchdog/wdt_wwdg_stm32.c
+++ b/drivers/watchdog/wdt_wwdg_stm32.c
@@ -18,6 +18,7 @@
 
 #include "wdt_wwdg_stm32.h"
 
+#define LOG_LEVEL CONFIG_WDT_LOG_LEVEL
 #include <logging/log.h>
 LOG_MODULE_REGISTER(wdt_wwdg_stm32);
 


### PR DESCRIPTION
Without this a user can't enable logging for the STM32 wdt driver.

Signed-off-by: Nick Ward <nick.ward@setec.com.au>