### PR TITLE
Bluetooth: Host: Doc fixup for rename of BT_SECURITY_L*

### DIFF
--- a/doc/guides/bluetooth/bluetooth-arch.rst
+++ b/doc/guides/bluetooth/bluetooth-arch.rst
@@ -332,17 +332,17 @@ capable of displaying a passkey to the user.
 Depending on the local and remote security requirements & capabilities,
 there are four possible security levels that can be reached:
 
-    :c:enumerator:`BT_SECURITY_LOW`
+    :c:enumerator:`BT_SECURITY_L1`
         No encryption and no authentication.
 
-    :c:enumerator:`BT_SECURITY_MEDIUM`
+    :c:enumerator:`BT_SECURITY_L2`
         Encryption but no authentication (no MITM protection).
 
-    :c:enumerator:`BT_SECURITY_HIGH`
+    :c:enumerator:`BT_SECURITY_L3`
         Encryption and authentication using the legacy pairing method
         from Bluetooth 4.0 and 4.1.
 
-    :c:enumerator:`BT_SECURITY_FIPS`
+    :c:enumerator:`BT_SECURITY_L4`
         Encryption and authentication using the LE Secure Connections
         feature available since Bluetooth 4.2.
 

--- a/subsys/net/l2/Kconfig
+++ b/subsys/net/l2/Kconfig
@@ -40,10 +40,10 @@ config NET_L2_BT_SEC_LEVEL
 	range 1 4
 	help
 	  Security level of Bluetooth Link:
-	  Level 1 (BT_SECURITY_LOW) = No encryption or authentication required
-	  Level 2 (BT_SECURITY_MEDIUM) = Only encryption required
-	  Level 3 (BT_SECURITY_HIGH) = Encryption and authentication required
-	  Level 4 (BT_SECURITY_FIPS) = Secure connection required
+	  Level 1 (BT_SECURITY_L1) = No encryption or authentication required
+	  Level 2 (BT_SECURITY_L2) = Only encryption required
+	  Level 3 (BT_SECURITY_L3) = Encryption and authentication required
+	  Level 4 (BT_SECURITY_L4) = LE Secure Connection required
 
 module = NET_L2_BT
 module-dep = NET_LOG


### PR DESCRIPTION
BT_SECURITY_LOW and etc. were previously renamed and are no longer
valid.

The original rename is in the following commits:
1c48757d9489e59ef77c8f1e565e2164716abfdd (New names, deprecate old)
5f2a9ba8e40ecbb1a97d2f1fbf164f168eb27c55 (Remove deprecated names)

Signed-off-by: Aleksander Wasaznik <aleksander.wasaznik@nordicsemiconductor.no>