### PR TITLE
Fix reference to a released stack variable in modem_context_sprint_ip…

### DIFF
--- a/drivers/modem/modem_context.h
+++ b/drivers/modem/modem_context.h
@@ -91,10 +91,12 @@ struct modem_context {
  * @brief  IP address to string
  *
  * @param  addr: sockaddr to be converted
+ * @param  buf:  Buffer to store IP in string form
+ * @param  buf_size:  buffer size
  *
- * @retval Buffer with IP in string form
+ * @retval 0 if ok, < 0 if error.
  */
-char *modem_context_sprint_ip_addr(const struct sockaddr *addr);
+int modem_context_sprint_ip_addr(const struct sockaddr *addr, char *buf, size_t buf_size);
 
 /**
  * @brief  Get port from IP address


### PR DESCRIPTION
Suggested fix for issue #38172. How can I test it?

Fixes #38172.