### PR TITLE
subsys: task_wdt: fix silent init failures

### DIFF
--- a/include/task_wdt/task_wdt.h
+++ b/include/task_wdt/task_wdt.h
@@ -47,6 +47,9 @@ typedef void (*task_wdt_callback_t)(int channel_id, void *user_data);
  *
  * @retval 0 If successful.
  * @retval -ENOTSUP If assigning a hardware watchdog is not supported.
+ * @retval -Errno Negative errno if the fallback hw_wdt is used and the
+ *                install timeout API fails.  See wdt_install_timeout()
+ *                API for possible return values.
  */
 int task_wdt_init(const struct device *hw_wdt);
 

--- a/samples/subsys/task_wdt/src/main.c
+++ b/samples/subsys/task_wdt/src/main.c
@@ -58,6 +58,7 @@ static void task_wdt_callback(int channel_id, void *user_data)
 
 void main(void)
 {
+	int ret;
 #ifdef WDT_NODE
 	const struct device *hw_wdt_dev = DEVICE_DT_GET(WDT_NODE);
 #else
@@ -72,7 +73,12 @@ void main(void)
 		hw_wdt_dev = NULL;
 	}
 
-	task_wdt_init(hw_wdt_dev);
+	ret = task_wdt_init(hw_wdt_dev);
+	if (ret != 0) {
+		printk("task wdt init failure: %d\n", ret);
+		return;
+	}
+
 
 	/* passing NULL instead of callback to trigger system reset */
 	int task_wdt_id = task_wdt_add(1100U, NULL, NULL);

--- a/subsys/task_wdt/task_wdt.c
+++ b/subsys/task_wdt/task_wdt.c
@@ -136,6 +136,10 @@ int task_wdt_init(const struct device *hw_wdt)
 
 		hw_wdt_dev = hw_wdt;
 		hw_wdt_channel = wdt_install_timeout(hw_wdt_dev, &wdt_config);
+		if (hw_wdt_channel < 0) {
+			LOG_ERR("hw_wdt install timeout failed: %d", hw_wdt_channel);
+			return hw_wdt_channel;
+		}
 #else
 		return -ENOTSUP;
 #endif


### PR DESCRIPTION
The task_wdt_init() API can fail to install a timeout for the fallback
hardware WDT (hw_wdt) without returning an error code.  This patch enables
task_wdt_init() to return the hw_wdt install timeout error code if the hw_wdt
install timeout fails.

This issue was noticed when I had trouble using the stm32 wdt as the fallback
hw_wdt with the task_wdt sample.  The sample wasn't functioning as it should
because the hw_wdt install timeout API was silently failing with an invalid timeout.

Signed-off-by: Nick Ward <nick.ward@setec.com.au>