### PR TITLE
STM32 devices support AHB prescaler value in range 1-512

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -64,17 +64,6 @@
 #define STM32WL_DUAL_CORE
 #endif
 
-#if STM32_AHB_PRESCALER > 1
-/*
- * AHB prescaler allows to set a HCLK frequency (feeding cortex systick)
- * lower than SYSCLK frequency (actual core frequency).
- * Though, zephyr doesn't make a difference today between these two clocks.
- * So, changing this prescaler is not allowed until it is made possible to
- * use them independently in zephyr clock subsystem.
- */
-#error "AHB prescaler can't be higher than 1"
-#endif
-
 /**
  * @brief fill in AHB/APB buses configuration structure
  */

--- a/drivers/clock_control/clock_stm32_ll_u5.c
+++ b/drivers/clock_control/clock_stm32_ll_u5.c
@@ -30,18 +30,6 @@
 #define z_apb3_prescaler(v) LL_RCC_APB3_DIV_ ## v
 #define apb3_prescaler(v) z_apb3_prescaler(v)
 
-
-#if STM32_AHB_PRESCALER > 1
-/*
- * AHB prescaler allows to set a HCLK frequency (feeding cortex systick)
- * lower than SYSCLK frequency (actual core frequency).
- * Though, zephyr doesn't make a difference today between these two clocks.
- * So, changing this prescaler is not allowed until it is made possible to
- * use them independently in zephyr clock subsystem.
- */
-#error "AHB prescaler can't be higher than 1"
-#endif
-
 #if STM32_SYSCLK_SRC_PLL
 
 /**

--- a/dts/bindings/clock/st,stm32-rcc.yaml
+++ b/dts/bindings/clock/st,stm32-rcc.yaml
@@ -58,12 +58,18 @@ properties:
       required: false
       enum:
         - 1
+        - 2
+        - 4
+        - 8
+        - 16
+        - 64
+        - 128
+        - 256
+        - 512
       description: |
           AHB prescaler. Sets a HCLK frequency (feeding Cortex-M Systick)
           lower than SYSCLK frequency (actual core frequency).
-          Zephyr doesn't make a difference today between these two clocks.
-          Changing this prescaler is not allowed until it is made possible to
-          use them independently in Zephyr clock subsystem.
+          The HCLK clocks CPU, AHB, memories and DMA.
 
     apb1-prescaler:
       type: int

--- a/dts/bindings/clock/st,stm32wb-rcc.yaml
+++ b/dts/bindings/clock/st,stm32wb-rcc.yaml
@@ -18,13 +18,23 @@ properties:
       required: false
       enum:
         - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 8
+        - 10
+        - 16
+        - 32
+        - 64
+        - 128
+        - 256
+        - 512
       description: |
           CPU1 prescaler. Sets a HCLK1 frequency (feeding Cortex-M Systick)
           lower than SYSCLK frequency (actual core frequency).
-          Zephyr doesn't make a difference today between these two clocks.
-          Changing this prescaler is not allowed until it is made possible to
-          use them independently in Zephyr clock subsystem.
-          HCLK1 clocks CPU1, AHB1, AHB2, AHB3 and SRAM1.
+          The HCLK1 clocks CPU1, AHB1, AHB2, AHB3 and SRAM1.
 
     cpu2-prescaler:
       type: int


### PR DESCRIPTION
The DTS can accept a ahb-prescaler  >1 and <512 to reduce the SYSCLOCK to the HCLK.


FIxes https://github.com/zephyrproject-rtos/zephyr/issues/37173

Signed-off-by: Francois Ramu <francois.ramu@st.com>
