### PR TITLE
LE Audio broadcast sink API change to channel array

### DIFF
--- a/subsys/bluetooth/host/audio/endpoint.h
+++ b/subsys/bluetooth/host/audio/endpoint.h
@@ -49,7 +49,7 @@ struct bt_audio_broadcast_source {
 
 struct bt_audio_broadcast_sink {
 	uint8_t index; /* index of broadcast_snks array */
-	uint8_t bis_count;
+	uint8_t chan_count;
 	uint8_t subgroup_count;
 	uint16_t pa_interval;
 	uint16_t iso_interval;
@@ -62,8 +62,8 @@ struct bt_audio_broadcast_sink {
 	struct bt_audio_capability *cap; /* Capability that accepted the PA sync */
 	struct bt_iso_big *big;
 	struct bt_iso_chan *bis[BROADCAST_SNK_STREAM_CNT];
-	/* The "main" channel used to create the broadcast sink */
-	struct bt_audio_chan *chan;
+	/* The channels used to create the broadcast sink */
+	struct bt_audio_chan *chans;
 };
 
 struct bt_audio_ep {

--- a/subsys/bluetooth/shell/bap.c
+++ b/subsys/bluetooth/shell/bap.c
@@ -1255,7 +1255,6 @@ static int cmd_accept_broadcast(const struct shell *sh, size_t argc,
 
 static int cmd_sync_broadcast(const struct shell *sh, size_t argc, char *argv[])
 {
-	static bool chans_linked;
 	uint32_t bis_bitfield;
 	int err;
 
@@ -1274,24 +1273,8 @@ static int cmd_sync_broadcast(const struct shell *sh, size_t argc, char *argv[])
 		return -ENOEXEC;
 	}
 
-	if (!chans_linked) {
-		/* We can just link all broadcast sink channels once, as it
-		 * doesn't matter if we provide too many channels to the API,
-		 * as long as we provide enough.
-		 */
-
-		/* Link all channels */
-		for (int i = 0; i < ARRAY_SIZE(broadcast_sink_chans); i++) {
-			for (int j = i + 1; j < ARRAY_SIZE(broadcast_sink_chans); j++) {
-				bt_audio_chan_link(&broadcast_sink_chans[i],
-						   &broadcast_sink_chans[j]);
-			}
-		}
-		chans_linked = true;
-	}
-
 	err = bt_audio_broadcast_sink_sync(default_sink, bis_bitfield,
-				      broadcast_sink_chans, NULL);
+					   broadcast_sink_chans, NULL);
 	if (err != 0) {
 		shell_error(sh, "Failed to sync to broadcast: %d", err);
 		return err;


### PR DESCRIPTION
Update the broadcast sink API to use array of channels instead of a list. 