### PR TITLE
stm32: Add FMAC support to Kconfig

### DIFF
--- a/modules/Kconfig.stm32
+++ b/modules/Kconfig.stm32
@@ -169,6 +169,11 @@ config USE_STM32_HAL_FLASH_RAMFUNC
 	  Enable STM32Cube Embedded Flash Memory RAM functions (FLASH_RAMFUNC)
 	  HAL module driver
 
+config USE_STM32_HAL_FMAC
+	bool
+	help
+	  Enable STM32Cube Filter Math Accelerator (FMAC) HAL module driver
+
 config USE_STM32_HAL_FMPI2C
 	bool
 	help
@@ -566,6 +571,11 @@ config USE_STM32_LL_EXTI
 	help
 	  Enable STM32Cube Extended interrupt and event controller (EXTI) LL
 	  module driver
+
+config USE_STM32_LL_FMAC
+	bool
+	help
+	  Enable STM32Cube Filter Math Accelerator (FMAC) LL module driver
 
 config USE_STM32_LL_FMC
 	bool


### PR DESCRIPTION
This commit adds FMAC HAL and LL drivers to the build system
Required to enable Filter Math Accelerator (FMAC) on STM32G4/H7 devices
Signed-off-by: Tom Owen <tom.owen@zepler.net>