### PR TITLE
dts: esp32s2: fix counter dt information

### DIFF
--- a/dts/xtensa/espressif/esp32s2.dtsi
+++ b/dts/xtensa/espressif/esp32s2.dtsi
@@ -87,7 +87,7 @@
 
 		timer1: counter@3f41f024 {
 			compatible = "espressif,esp32-timer";
-			reg = <0x3ff5f024 DT_SIZE_K(4)>;
+			reg = <0x3f41f024 DT_SIZE_K(4)>;
 			interrupts = <TG0_T1_LEVEL_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
 			label = "TIMG0_T1";
@@ -97,7 +97,7 @@
 		timer2: counter@3f420000 {
 			compatible = "espressif,esp32-timer";
 			reg = <0x3f420000 DT_SIZE_K(4)>;
-			interrupts = <TG0_T1_LEVEL_INTR_SOURCE>;
+			interrupts = <TG1_T0_LEVEL_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
 			label = "TIMG1_T0";
 			status = "disabled";


### PR DESCRIPTION
Provide correct timer1 node base address and timer2 interrupt source information.
