### PR TITLE
PM:  Stubs for when CONFIG_PM is not enabled

### DIFF
--- a/include/pm/pm.h
+++ b/include/pm/pm.h
@@ -199,9 +199,6 @@ void pm_power_state_exit_post_ops(struct pm_state_info info);
  * @}
  */
 
-
-void z_pm_save_idle_exit(int32_t ticks);
-
 #else  /* CONFIG_PM */
 
 #define pm_notifier_register(notifier)
@@ -215,6 +212,8 @@ void z_pm_save_idle_exit(int32_t ticks);
 #define pm_power_state_exit_post_ops(info)
 
 #endif /* CONFIG_PM */
+
+void z_pm_save_idle_exit(int32_t ticks);
 
 #ifdef __cplusplus
 }

--- a/include/pm/pm.h
+++ b/include/pm/pm.h
@@ -23,8 +23,6 @@ extern "C" {
  * @}
  */
 
-#ifdef CONFIG_PM
-
 /**
  * @brief System Power Management API
  *
@@ -65,6 +63,7 @@ struct pm_notifier {
 	void (*state_exit)(enum pm_state state);
 };
 
+#ifdef CONFIG_PM
 /**
  * @brief Force usage of given power state.
  *
@@ -202,6 +201,19 @@ void pm_power_state_exit_post_ops(struct pm_state_info info);
 
 
 void z_pm_save_idle_exit(int32_t ticks);
+
+#else  /* CONFIG_PM */
+
+#define pm_notifier_register(notifier)
+#define pm_notifier_unregister(notifier) (-ENOSYS)
+
+#define pm_constraint_set(pm_state)
+#define pm_constraint_release(pm_state)
+#define pm_constraint_get(pm_state) (true)
+
+#define pm_power_state_set(info)
+#define pm_power_state_exit_post_ops(info)
+
 #endif /* CONFIG_PM */
 
 #ifdef __cplusplus


### PR DESCRIPTION
Create stubs for when the subsystem is not compiled. Some drivers need
to use constraints when are in the middle of a transaction to avoid
the system to sleep. As the same driver may be used in a target that
does not support power management, they have to conditionally (#if
CONFIG_PM) call these functions, these stubs avoid this regular problem.
