### PR TITLE
boards: arm: Reset Ethernet PHY after system timer on mimxrt1xxx_evk's

### DIFF
--- a/boards/arm/mimxrt1020_evk/pinmux.c
+++ b/boards/arm/mimxrt1020_evk/pinmux.c
@@ -244,5 +244,5 @@ static int mimxrt1020_evk_phy_reset(const struct device *dev)
 
 SYS_INIT(mimxrt1020_evk_init, PRE_KERNEL_1, 0);
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(enet), okay) && CONFIG_NET_L2_ETHERNET
-SYS_INIT(mimxrt1020_evk_phy_reset, PRE_KERNEL_2, 0);
+SYS_INIT(mimxrt1020_evk_phy_reset, POST_KERNEL, CONFIG_PHY_INIT_PRIORITY);
 #endif

--- a/boards/arm/mimxrt1024_evk/pinmux.c
+++ b/boards/arm/mimxrt1024_evk/pinmux.c
@@ -104,5 +104,5 @@ static int mimxrt1024_evk_phy_reset(const struct device *dev)
 
 SYS_INIT(mimxrt1024_evk_init, PRE_KERNEL_1, 0);
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(enet), okay) && CONFIG_NET_L2_ETHERNET
-SYS_INIT(mimxrt1024_evk_phy_reset, PRE_KERNEL_2, 1);
+SYS_INIT(mimxrt1024_evk_phy_reset, POST_KERNEL, CONFIG_PHY_INIT_PRIORITY);
 #endif

--- a/boards/arm/mimxrt1050_evk/pinmux.c
+++ b/boards/arm/mimxrt1050_evk/pinmux.c
@@ -331,5 +331,5 @@ static int mimxrt1050_evk_phy_reset(const struct device *dev)
 
 SYS_INIT(mimxrt1050_evk_init, PRE_KERNEL_1, 0);
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(enet), okay) && CONFIG_NET_L2_ETHERNET
-SYS_INIT(mimxrt1050_evk_phy_reset, PRE_KERNEL_2, 0);
+SYS_INIT(mimxrt1050_evk_phy_reset, POST_KERNEL, CONFIG_PHY_INIT_PRIORITY);
 #endif

--- a/boards/arm/mimxrt1060_evk/pinmux.c
+++ b/boards/arm/mimxrt1060_evk/pinmux.c
@@ -328,5 +328,5 @@ static int mimxrt1060_evk_phy_reset(const struct device *dev)
 
 SYS_INIT(mimxrt1060_evk_init, PRE_KERNEL_1, 0);
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(enet), okay) && CONFIG_NET_L2_ETHERNET
-SYS_INIT(mimxrt1060_evk_phy_reset, PRE_KERNEL_2, 0);
+SYS_INIT(mimxrt1060_evk_phy_reset, POST_KERNEL, CONFIG_PHY_INIT_PRIORITY);
 #endif

--- a/boards/arm/mimxrt1064_evk/pinmux.c
+++ b/boards/arm/mimxrt1064_evk/pinmux.c
@@ -351,5 +351,5 @@ static int mimxrt1064_evk_phy_reset(const struct device *dev)
 
 SYS_INIT(mimxrt1064_evk_init, PRE_KERNEL_1, 0);
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(enet), okay) && CONFIG_NET_L2_ETHERNET
-SYS_INIT(mimxrt1064_evk_phy_reset, PRE_KERNEL_2, 0);
+SYS_INIT(mimxrt1064_evk_phy_reset, POST_KERNEL, CONFIG_PHY_INIT_PRIORITY);
 #endif

--- a/boards/arm/mimxrt1170_evk/pinmux.c
+++ b/boards/arm/mimxrt1170_evk/pinmux.c
@@ -214,5 +214,5 @@ static int mimxrt1170_evk_phy_reset(const struct device *dev)
 
 SYS_INIT(mimxrt1170_evk_init, PRE_KERNEL_1, 0);
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(enet), okay) && CONFIG_NET_L2_ETHERNET
-SYS_INIT(mimxrt1170_evk_phy_reset, PRE_KERNEL_2, 0);
+SYS_INIT(mimxrt1170_evk_phy_reset, POST_KERNEL, CONFIG_PHY_INIT_PRIORITY);
 #endif


### PR DESCRIPTION
Moves the Ethernet PHY reset routine on mimxrt1xxx_evk boards to execute
in the POST_KERNEL initialization level rather than the PRE_KERNEL_2
level because it relies on a kernel service, k_busy_wait(). Leverages
the existing CONFIG_PHY_INIT_PRIORITY to allow users to configure when
within the POST_KERNEL level this routine occurs, which by default is
set correctly to the following order:

```
Init Function			Init Level	Priority
--------------------------------------------------------------------------------------
sys_clock_driver_init		PRE_KERNEL_2	CONFIG_SYSTEM_CLOCK_INIT_PRIORITY=0
mcux_igpio_##n##_init		POST_KERNEL	CONFIG_KERNEL_INIT_PRIORITY_DEFAULT=40
mimxrt1064_evk_phy_reset	POST_KERNEL	CONFIG_PHY_INIT_PRIORITY=70
eth_init			POST_KERNEL	CONFIG_ETH_INIT_PRIORITY=80
net_init			POST_KERNEL	CONFIG_NET_INIT_PRIO=90
```

This fixes an issue that was introduced in commit
f0b3146ff5538e5381318a309fec292d3fbb1f3f, which caused the system timer
to be initialized after the Ethernet PHY reset. As a result, the
k_busy_wait() never returned and the kernel never finished booting. The
serial driver never initialized and there was no output on the console,
not even a boot banner.

Tested on the mimxrt1064_evk board with samples/net/dhcpv4_client.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Fixes #38186 

cc: @ainguraXmarquiegui