### PR TITLE
cmake: compiler: Add framework for disabling C++ standard includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1675,12 +1675,16 @@ if((CMAKE_BUILD_TYPE IN_LIST build_types) AND (NOT NO_BUILD_TYPE_WARNING))
   endif()
 endif()
 
-# @Intent: Set compiler specific flags for standard C includes
+# @Intent: Set compiler specific flags for standard C/C++ includes
 # Done at the very end, so any other system includes which may
 # be added by Zephyr components were first in list.
 # Note, the compile flags are moved, but the system include is still present here.
 zephyr_compile_options($<TARGET_PROPERTY:compiler,nostdinc>)
 target_include_directories(zephyr_interface SYSTEM INTERFACE $<TARGET_PROPERTY:compiler,nostdinc_include>)
+
+if(NOT CONFIG_LIB_CPLUSPLUS)
+  zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:$<TARGET_PROPERTY:compiler-cpp,nostdincxx>>)
+endif()
 
 # Finally export all build flags from Zephyr
 add_subdirectory_ifdef(

--- a/cmake/compiler/compiler_flags_template.cmake
+++ b/cmake/compiler/compiler_flags_template.cmake
@@ -50,6 +50,9 @@ set_compiler_property(PROPERTY cstd)
 set_compiler_property(PROPERTY nostdinc)
 set_compiler_property(PROPERTY nostdinc_include)
 
+# Compiler flags for disabling C++ standard include.
+set_compiler_property(TARGET compiler-cpp PROPERTY nostdincxx)
+
 # Required C++ flags when compiling C++ code
 set_property(TARGET compiler-cpp PROPERTY required)
 

--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -120,6 +120,8 @@ if (NOT CONFIG_NEWLIB_LIBC AND
   set_compiler_property(APPEND PROPERTY nostdinc_include ${NOSTDINC})
 endif()
 
+set_compiler_property(TARGET compiler-cpp PROPERTY nostdincxx "-nostdinc++")
+
 # Required C++ flags when using gcc
 set_property(TARGET compiler-cpp PROPERTY required "-fcheck-new")
 

--- a/samples/modules/tflite-micro/hello_world/prj.conf
+++ b/samples/modules/tflite-micro/hello_world/prj.conf
@@ -13,5 +13,6 @@
 # limitations under the License.
 # ==============================================================================s
 CONFIG_CPLUSPLUS=y
+CONFIG_LIB_CPLUSPLUS=y
 CONFIG_NEWLIB_LIBC=y
 CONFIG_TENSORFLOW_LITE_MICRO=y


### PR DESCRIPTION
```
This commit adds a new C++ compiler property `nostdincxx` which
specifies the C++ compiler flag for excluding the C++ standard library
include directory from the include paths.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>
```

Fixes #36644.