### PR TITLE
cmake: Do not include `zephyr_stdint.h` for native POSIX archs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,7 +237,12 @@ zephyr_compile_options($<$<COMPILE_LANGUAGE:ASM>:$<TARGET_PROPERTY:asm,required>
 
 # @Intent: Enforce standard integer type correspondance to match Zephyr usage.
 # (must be after compiler specific flags)
-zephyr_compile_options("SHELL: $<TARGET_PROPERTY:compiler,imacros> ${ZEPHYR_BASE}/include/toolchain/zephyr_stdint.h")
+if(NOT CONFIG_ARCH_POSIX)
+  # `zephyr_stdint.h` is not included for the POSIX (native) arch because it
+  # compiles with the host toolchain/headers and there can be conflicts if we
+  # arbitrarily redefine our own type system (see #37718).
+  zephyr_compile_options("SHELL: $<TARGET_PROPERTY:compiler,imacros> ${ZEPHYR_BASE}/include/toolchain/zephyr_stdint.h")
+endif()
 
 # Common toolchain-agnostic assembly flags
 zephyr_compile_options(


### PR DESCRIPTION
This commit updates the Zephyr build system such that it does not
include the `zephyr_stdint.h`, which tries to define Zephyr's own type
system, when compiling for the native POSIX architecture.

The native POSIX architecture compiles with the host toolchain and
headers, and there can be conflicts if we arbitrarily define our own
type system (e.g. mismatch between the types and the specifiers defined
in `inttypes.h`).

Note that this is not meant to be a permanent fix; instead, it is meant
to serve as a temporary workaround until we no longer need to define
our own type system.

For more details, refer to the issue #37718.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Fixes #37718.