### PR TITLE
device: insert padding to ordinal array

### DIFF
--- a/include/device.h
+++ b/include/device.h
@@ -813,6 +813,7 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 	COND_CODE_1(DT_NODE_EXISTS(node_id), (				\
 			DT_DEP_ORD(node_id),				\
 			DT_REQUIRES_DEP_ORDS(node_id)			\
+			DT_REQUIRES_DEP_ORDS_PADDING(node_id)		\
 		), (							\
 			DEVICE_HANDLE_NULL,				\
 		))							\

--- a/include/devicetree/ordinals.h
+++ b/include/devicetree/ordinals.h
@@ -44,6 +44,19 @@
 #define DT_REQUIRES_DEP_ORDS(node_id) DT_CAT(node_id, _REQUIRES_ORDS)
 
 /**
+ * @brief Get the list of padding indicies for the dependencies array
+ *
+ * Based on the presence or absence of parent devices in the final binary,
+ * padding may need to be inserted into the ordinal array to ensure array sizes
+ * don't increase in the post processing steps.
+ *
+ * @param node_id Node identifier
+ * @return a list of padding indicies to insert
+ */
+#define DT_REQUIRES_DEP_ORDS_PADDING(node_id) \
+	DT_CAT(node_id, _REQUIRES_ORDS_PADDING)
+
+/**
  * @brief Get a list of dependency ordinals of what depends directly on a node
  *
  * There is a comma after each ordinal in the expansion, **including**

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -642,17 +642,25 @@ def write_dep_info(node):
         else:
             return "/* nothing */"
 
+    def fmt_padding(num):
+        if num > 0:
+            return "\\\n\t" + \
+                " \\\n\t".join("DEVICE_HANDLE_NULL," for _ in range(num))
+        else:
+            return "/* nothing */"
+
     out_comment("Node's dependency ordinal:")
     out_dt_define(f"{node.z_path_id}_ORD", node.dep_ordinal)
 
+    reqs = node.depends_on
+    reqs_padding = node.depends_on_fan_out - len(reqs)
     out_comment("Ordinals for what this node depends on directly:")
-    out_dt_define(f"{node.z_path_id}_REQUIRES_ORDS",
-                  fmt_dep_list(node.depends_on))
+    out_dt_define(f"{node.z_path_id}_REQUIRES_ORDS", fmt_dep_list(reqs))
+    out_dt_define(f"{node.z_path_id}_REQUIRES_ORDS_PADDING", fmt_padding(reqs_padding))
 
+    sups = node.required_by
     out_comment("Ordinals for what depends directly on this node:")
-    out_dt_define(f"{node.z_path_id}_SUPPORTS_ORDS",
-                  fmt_dep_list(node.required_by))
-
+    out_dt_define(f"{node.z_path_id}_SUPPORTS_ORDS", fmt_dep_list(sups))
 
 def prop2value(prop):
     # Gets the macro value for property 'prop', if there is

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -593,6 +593,12 @@ class Node:
     depends_on:
       A list with the nodes that the node directly depends on
 
+    required_by_fan_out:
+      An estimate of the maximum fan-out of nodes that depend on the node
+
+    depends_on_fan_out:
+      An estimate of the maximum fan-out of nodes that the node depends on
+
     status:
       The node's status property value, as a string, or "okay" if the node
       has no status property set. If the node's status property is "ok",
@@ -725,6 +731,16 @@ class Node:
     def depends_on(self):
         "See the class docstring"
         return self.edt._graph.depends_on(self)
+
+    @property
+    def required_by_fan_out(self):
+        "See the class docstring"
+        return self.edt._graph.required_by_fan_out(self)
+
+    @property
+    def depends_on_fan_out(self):
+        "See the class docstring"
+        return self.edt._graph.depends_on_fan_out(self)
 
     @property
     def status(self):

--- a/scripts/dts/python-devicetree/tests/test-bindings/device-on-any-bus.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings/device-on-any-bus.yaml
@@ -3,3 +3,7 @@
 description: Device on any bus
 
 compatible: "on-any-bus"
+
+properties:
+    test-gpios:
+        type: phandle-array

--- a/scripts/dts/python-devicetree/tests/test.dts
+++ b/scripts/dts/python-devicetree/tests/test.dts
@@ -341,6 +341,10 @@
 			node2 {
 				compatible = "on-any-bus", "on-bus";
 			};
+			gpio-dependent-node {
+				compatible = "on-any-bus";
+				test-gpios = <&{/gpio-map/destination} 0>;
+			};
 		};
 		bar-bus {
 			compatible = "bar-bus";

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -441,6 +441,22 @@ def test_dependencies():
     assert edt.get_node("/") in edt.get_node("/in-dir-1").depends_on
     assert edt.get_node("/in-dir-1") in edt.get_node("/").required_by
 
+def test_graph_queries():
+    with from_here():
+        edt = edtlib.EDT("test.dts", ["test-bindings"])
+
+    assert edt.get_node("/").depends_on_fan_out == 0
+    assert edt.get_node("/buses").depends_on_fan_out == 1
+    assert edt.get_node("/buses/foo-bus").depends_on_fan_out == 1
+    assert edt.get_node("/buses/foo-bus/node1").depends_on_fan_out == 1
+    assert edt.get_node("/buses/foo-bus/gpio-dependent-node").depends_on_fan_out == 2
+
+    assert edt.get_node("/buses").required_by_fan_out == 5
+    assert edt.get_node("/buses/foo-bus").required_by_fan_out == 3
+    assert edt.get_node("/buses/foo-bus/node1").required_by_fan_out == 1
+    assert edt.get_node("/buses/foo-bus/node1/nested").required_by_fan_out == 0
+    assert edt.get_node("/buses/foo-bus/node2").required_by_fan_out == 0
+
 def test_slice_errs(tmp_path):
     '''Test error messages from the internal _slice() helper'''
 


### PR DESCRIPTION
Insert padding into the handles array in devices to account for the fact that dependencies can "fan-out" to more devices than are included in the direct `_REQUIRES_ORDS` property, if nodes in that array do not exist in the final binary.

While working on this I attempted to forward down supported devices as well, but this results in paddings of many hundreds of handles for high level nodes like interrupt and clock controllers on heavily interconnected platforms like `frdm_k64f`. The ROM increase for that can't be justified, and I don't think an algorithm exists to calculate the actual fan-out value, so supporting this information must wait for multiple link stages.

Resolves #38181