### PR TITLE
samples: led_ws2812: fix dma property in nucleo_f070rb.overlay

### DIFF
--- a/samples/drivers/led_ws2812/boards/nucleo_f070rb.overlay
+++ b/samples/drivers/led_ws2812/boards/nucleo_f070rb.overlay
@@ -9,7 +9,7 @@
 #include "../f070rb-bindings.h"
 
 &spi1 { /* MOSI on PA7 */
-	dmas = <&dma1 3 0 0x20440 0x03>, <&dma1 2 0 0x20480 0x03>;
+	dmas = <&dma1 3 0x20440>, <&dma1 2 0x20480>;
 	dma-names = "tx", "rx";
 
 	led_strip: b1414@0 {


### PR DESCRIPTION
Since commit 718c77a4cdc4 ("dts: arm: stm32f0 soc serie has dma of type
V2bis"), the DMA DT cell of STM32F0 MCU has been fixed. It now has three
elements instead of five previously.

This patch fixes the dma property used in nucleo_f070rb.overlay
accordingly.

Signed-off-by: Simon Guinot <simon.guinot@seagate.com>