### PR TITLE
modules: Hooks Kconfig for MCUboot's bootutil

### DIFF
--- a/modules/Kconfig.mcuboot_bootutil
+++ b/modules/Kconfig.mcuboot_bootutil
@@ -21,4 +21,12 @@ module-str = MCUboot bootutil
 source "subsys/logging/Kconfig.template.log_config"
 endif
 
+config BOOT_IMAGE_ACCESS_HOOKS
+	bool "Enable hooks for overriding MCUboot's bootutil native routines"
+	help
+	  Allow to provide procedures for override or extend native
+	  MCUboot's routines required for access the image data.
+	  It is up to the application project to add source file which
+	  implements hooks to the build.
+
 endif # MCUBOOT_BOOTUTIL_LIB


### PR DESCRIPTION
Mcuboot's bootutil libraries has option to use hooks which
allows to customize its behavior while proceeding on images
date. This patch introduces configuration options required for that.

related to https://github.com/mcu-tools/mcuboot/pull/1137

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>