### PR TITLE
net: ipv6: fix NBR lock initialization

### DIFF
--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -2489,11 +2489,11 @@ void net_ipv6_nbr_init(void)
 	net_icmpv6_register_handler(&ns_input_handler);
 	net_icmpv6_register_handler(&na_input_handler);
 	k_work_init_delayable(&ipv6_ns_reply_timer, ipv6_ns_reply_timeout);
+	k_sem_init(&nbr_lock, 1, K_SEM_MAX_LIMIT);
 #endif
 #if defined(CONFIG_NET_IPV6_ND)
 	net_icmpv6_register_handler(&ra_input_handler);
 	k_work_init_delayable(&ipv6_nd_reachable_timer,
 			      ipv6_nd_reachable_timeout);
-	k_sem_init(&nbr_lock, 1, K_SEM_MAX_LIMIT);
 #endif
 }


### PR DESCRIPTION
The nbr_lock var actually depends on CONFIG_NET_IPV6_NBR_CACHE (not CONFIG_NET_IPV6_ND), so move its initialization call.

Fixes #38498.

Signed-off-by: Stancu Florin <niflostancu@gmail.com>