### PR TITLE
Disable support for 1.8V USDHC negotiation on RT685 EVK

### DIFF
--- a/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.dts
+++ b/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.dts
@@ -300,6 +300,8 @@ i2s1: &flexcomm3 {
 
 &usdhc1 {
 	status = "okay";
+	/* Quick fix for 1.8V SD cards on RT600- disable 1.8V negotiation */
+	no-1-8-v;
 	pwr-gpios = <&gpio2 10 GPIO_ACTIVE_HIGH>;
 };
 


### PR DESCRIPTION
The MIMXRT685 evaluation board uses a PMIC to reduce the signalling
voltage for a connected SD card to 1.8V, which Zephyr does not currently
support. This results in Zephyr failing to interface with any SD card
that supports 1.8V signalling when run on the RT685 eval board.

This PR disables 1.8V SD card signalling support for the RT685 eval board,
which enables it to properly interface with low voltage SD cards since they are
backwards compatible with 3.3V signalling.

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>