### PR TITLE
soc: arm: st_stm32: do not enable PM_DEVICE by default

### DIFF
--- a/soc/arm/st_stm32/stm32g0/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32g0/Kconfig.defconfig.series
@@ -12,12 +12,7 @@ source "soc/arm/st_stm32/stm32g0/Kconfig.defconfig.stm32g0*"
 config SOC_SERIES
 	default "stm32g0"
 
-if PM
-config PM_DEVICE
-	default y
-
 config STM32_LPTIM_TIMER
-	default y
-endif # PM
+	default y if PM
 
 endif # SOC_SERIES_STM32G0X

--- a/soc/arm/st_stm32/stm32l0/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32l0/Kconfig.defconfig.series
@@ -12,12 +12,7 @@ source "soc/arm/st_stm32/stm32l0/Kconfig.defconfig.stm32l0*"
 config SOC_SERIES
 	default "stm32l0"
 
-if PM
-config PM_DEVICE
-	default y
-
 config STM32_LPTIM_TIMER
-	default y
-endif # PM
+	default y if PM
 
 endif # SOC_SERIES_STM32L0X

--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.series
@@ -13,12 +13,7 @@ source "soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l4*"
 config SOC_SERIES
 	default "stm32l4"
 
-if PM
-config PM_DEVICE
-	default y
-
 config STM32_LPTIM_TIMER
-	default y
-endif # PM
+	default y if PM
 
 endif # SOC_SERIES_STM32L4X

--- a/soc/arm/st_stm32/stm32l5/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32l5/Kconfig.defconfig.series
@@ -10,13 +10,8 @@ source "soc/arm/st_stm32/stm32l5/Kconfig.defconfig.stm32l5*"
 config SOC_SERIES
 	default "stm32l5"
 
-if PM
-config PM_DEVICE
-	default y
-
 config STM32_LPTIM_TIMER
-	default y
-endif # PM
+	default y if PM
 
 if ENTROPY_GENERATOR
 

--- a/soc/arm/st_stm32/stm32wb/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32wb/Kconfig.defconfig.series
@@ -10,12 +10,7 @@ source "soc/arm/st_stm32/stm32wb/Kconfig.defconfig.stm32wb*"
 config SOC_SERIES
 	default "stm32wb"
 
-if PM
-config PM_DEVICE
-	default y
-
 config STM32_LPTIM_TIMER
-	default y
-endif # PM
+	default y if PM
 
 endif # SOC_SERIES_STM32WBX

--- a/soc/arm/st_stm32/stm32wl/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32wl/Kconfig.defconfig.series
@@ -10,12 +10,7 @@ source "soc/arm/st_stm32/stm32wl/Kconfig.defconfig.stm32wl*"
 config SOC_SERIES
 	default "stm32wl"
 
-if PM
-config PM_DEVICE
-	default y
-
 config STM32_LPTIM_TIMER
-	default y
-endif # PM
+	default y if PM
 
 endif # SOC_SERIES_STM32WLX


### PR DESCRIPTION
CONFIG_PM_DEVICE was a de-facto requirement when enabling CONFIG_PM=y
since some devices, i.e. UART, used the PM device hooks to block
suspension process while the device was busy finishing transmission.
This has now been fixed using constraints, so CONFIG_PM=y can be enabled
without further requirements.

Fixes #38452 

`samples/hello_world`, with `CONFIG_PM=y`, `nucleo_wb55rg`:

Before this patch:
```
Memory region         Used Size  Region Size  %age Used
           FLASH:       16856 B       812 KB      2.03%
            SRAM:        5376 B        96 KB      5.47%
           SRAM1:          0 GB        10 KB      0.00%
           SRAM2:          0 GB        20 KB      0.00%
        IDT_LIST:          0 GB         2 KB      0.00%

```
After this patch:
```
Memory region         Used Size  Region Size  %age Used
           FLASH:       15184 B       812 KB      1.83%
            SRAM:        4224 B        96 KB      4.30%
           SRAM1:          0 GB        10 KB      0.00%
           SRAM2:          0 GB        20 KB      0.00%
        IDT_LIST:          0 GB         2 KB      0.00%
```