### PR TITLE
Bluetooth: Controller: Fix Periodic Sync memory corruptions and bus faults

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_sync.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_sync.h
@@ -10,6 +10,10 @@ struct lll_sync {
 	uint8_t access_addr[4];
 	uint8_t crc_init[3];
 
+	uint8_t phy:3;
+	uint8_t is_rx_enabled:1;
+	uint8_t is_aux_sched:1;
+
 	uint16_t skip_prepare;
 	uint16_t skip_event;
 	uint16_t event_counter;
@@ -31,9 +35,6 @@ struct lll_sync {
 
 	/* used to store lll_aux when chain is being scanned */
 	struct lll_scan_aux *lll_aux;
-
-	uint8_t phy:3;
-	uint8_t is_rx_enabled:1;
 
 #if defined(CONFIG_BT_CTLR_DF_SCAN_CTE_RX)
 	struct lll_df_sync df_cfg;

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -658,6 +658,11 @@ void ull_scan_aux_release(memq_link_t *link, struct node_rx_hdr *rx)
 		 */
 		rx->type = NODE_RX_TYPE_SYNC_REPORT;
 		rx->handle = ull_sync_handle_get(param_ull);
+
+		/* Dequeue will try releasing list of node rx, set the extra
+		 * pointer to NULL.
+		 */
+		rx->rx_ftr.extra = NULL;
 #endif /* CONFIG_BT_CTLR_SYNC_PERIODIC */
 	} else {
 		LL_ASSERT(0);

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -522,8 +522,6 @@ ull_scan_aux_rx_flush:
 	if (aux) {
 		struct ull_hdr *hdr;
 
-		hdr = &aux->ull;
-
 		/* Enqueue last rx in aux context if possible, otherwise send
 		 * immediately since we are in sync context.
 		 */
@@ -544,6 +542,7 @@ ull_scan_aux_rx_flush:
 		 * callback. Flushing here would release aux context and thus
 		 * ull_hdr before done event was processed.
 		 */
+		hdr = &aux->ull;
 		LL_ASSERT(ull_ref_get(hdr) < 2);
 		if (ull_ref_get(hdr) == 0) {
 			flush(aux);
@@ -658,7 +657,7 @@ void ull_scan_aux_release(memq_link_t *link, struct node_rx_hdr *rx)
 		 * data properly.
 		 */
 		rx->type = NODE_RX_TYPE_SYNC_REPORT;
-		rx->handle = ull_sync_handle_get(HDR_LLL2ULL(lll));
+		rx->handle = ull_sync_handle_get(param_ull);
 #endif /* CONFIG_BT_CTLR_SYNC_PERIODIC */
 	} else {
 		LL_ASSERT(0);
@@ -673,6 +672,7 @@ void ull_scan_aux_release(memq_link_t *link, struct node_rx_hdr *rx)
 		hdr = &aux->ull;
 
 		LL_ASSERT(ull_ref_get(hdr) < 2);
+
 		/* Flush from here of from done event, if one is pending */
 		if (ull_ref_get(hdr) == 0) {
 			flush(aux);


### PR DESCRIPTION
Fix repeated periodic sync drift compensation invoked when
receiving chain PDUs which caused memory corruptions and
bus faults.

Use `is_aux_sched` flag in Periodic Sync's LLL context to
differentiate between the first AUX_SYNC_IND PDU followed by
use of LLL scheduling to receive following AUX_CHAIN_IND PDU
versus ULL scheduling being used to receive AUX_CHAIN_IND
PDUs.

Drift compensation to be done only using the AUX_SYNC_IND
PDU and not on reception of AUX_CHAIN_IND PDU using ULL
scheduling.

Fix imprecise data bus error when receiving Periodic
Advertising Report caused due to uninitialized `extra` field
member in the node rx struct passed from ULL to LL thread
context.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>
