### PR TITLE
drivers/uart: stm32: Fix TC flag handling in IRQ driven mode

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -456,7 +456,7 @@ static void uart_stm32_poll_out(const struct device *dev,
 	while (!LL_USART_IsActiveFlag_TXE(UartInstance)) {
 	}
 
-	/* do not allow system to suspend until transmission has completed */
+	/* Do not allow system to suspend until transmission has completed */
 	pm_constraint_set(PM_STATE_SUSPEND_TO_IDLE);
 
 	LL_USART_TransmitData8(UartInstance, (uint8_t)c);
@@ -519,6 +519,8 @@ static int uart_stm32_fifo_fill(const struct device *dev,
 {
 	USART_TypeDef *UartInstance = UART_STRUCT(dev);
 	uint8_t num_tx = 0U;
+
+	LL_USART_ClearFlag_TC(UartInstance);
 
 	if ((size > 0) && LL_USART_IsActiveFlag_TXE(UartInstance)) {
 		/* do not allow system to suspend until transmission has completed */
@@ -803,8 +805,6 @@ static void uart_stm32_isr(const struct device *dev)
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	if (LL_USART_IsActiveFlag_TC(UartInstance)) {
-		LL_USART_ClearFlag_TC(UartInstance);
-
 		/* allow system to suspend, UART has now finished */
 		pm_constraint_release(PM_STATE_SUSPEND_TO_IDLE);
 	}
@@ -1453,7 +1453,6 @@ static int uart_stm32_init(const struct device *dev)
 	/* Enable TC interrupt so we can release suspend constraint when done */
 	LL_USART_EnableIT_TC(UartInstance);
 #endif /* defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_PM) */
-
 #ifdef CONFIG_UART_ASYNC_API
 	return uart_stm32_async_init(dev);
 #else

--- a/drivers/serial/uart_stm32.h
+++ b/drivers/serial/uart_stm32.h
@@ -72,6 +72,9 @@ struct uart_stm32_data {
 	uint8_t *rx_next_buffer;
 	size_t rx_next_buffer_len;
 #endif
+#ifdef CONFIG_PM
+	bool tx_stream_on;
+#endif
 };
 
 #endif	/* ZEPHYR_DRIVERS_SERIAL_UART_STM32_H_ */


### PR DESCRIPTION
When modifying driver to use PM constraints to handle PM requests,
some change of behavior was introduced in IRQ driven mode,
to accommodate with the new usage of _TC flag.

This had impact in some scenarios, like shell for instance.
Likely, TC flag was cleared too soon, having consequences on
behavior on functions were it is checked (irq_is_pending,
irq_tx_complete).

Fix this by clearing the flag on fifo_fill.

EDIT:
~~Additionally, remove code enabling IT on driver init,
as this doesn't work well with some platforms (F4).~~ > Fixed by the following:

EDIT: Additionally, in polling mode take into account byte streams (Fixes #38620)

Tested on:
- nucleo_wb55rg (shell, uart_basic_api, pm, shell + pm)
- nucleo_f429zi (shell, uart_basic_api, uart_async_api)

Fixes #38519

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>

EDIT: Also fixes:
- tests/drivers/uart/uart_async_api/drivers.uart.uart_async_api disco_l475_iot1