### PR TITLE
ipm: Add support for multi-channel IPM

### DIFF
--- a/drivers/console/ipm_console.c
+++ b/drivers/console/ipm_console.c
@@ -30,7 +30,7 @@ static int console_out(int c)
 	msg.size = len;
 	msg.id = len;
 
-	ret = ipm_send(ipm_dev, 1, &msg);
+	ret = ipm_send(ipm_dev, 1, 0, &msg);
 	if (ret) {
 		LOG_ERR("Error sending character %c over IPM, ret %d", c, ret);
 	}

--- a/drivers/console/ipm_console.c
+++ b/drivers/console/ipm_console.c
@@ -16,6 +16,7 @@ const struct device *ipm_dev;
 
 static int console_out(int c)
 {
+	struct ipm_msg msg;
 	static char buf[CONFIG_IPM_CONSOLE_LINE_BUF_LEN];
 	static size_t len;
 	int ret;
@@ -25,7 +26,11 @@ static int console_out(int c)
 		return c;
 	}
 
-	ret = ipm_send(ipm_dev, 1, len, buf, len);
+	msg.data = buf;
+	msg.size = len;
+	msg.id = len;
+
+	ret = ipm_send(ipm_dev, 1, &msg);
 	if (ret) {
 		LOG_ERR("Error sending character %c over IPM, ret %d", c, ret);
 	}

--- a/drivers/console/ipm_console_receiver.c
+++ b/drivers/console/ipm_console_receiver.c
@@ -138,7 +138,7 @@ int ipm_console_receiver_init(const struct device *d)
 	ring_buf_init(&driver_data->rb, config_info->rb_size32,
 		      config_info->ring_buf_data);
 
-	ipm_register_callback(ipm, ipm_console_receive_callback, driver_data);
+	ipm_register_callback(ipm, ipm_console_receive_callback, 0, driver_data);
 
 	k_thread_create(&driver_data->rx_thread, config_info->thread_stack,
 			CONFIG_IPM_CONSOLE_STACK_SIZE, ipm_console_thread,

--- a/drivers/console/ipm_console_sender.c
+++ b/drivers/console/ipm_console_sender.c
@@ -17,15 +17,21 @@ static const struct device *ipm_console_device;
 
 static int consoleOut(int character)
 {
+	struct ipm_msg msg;
+
 	if (character == '\r') {
 		return character;
 	}
+
+	msg.data = NULL;
+	msg.size = 0;
+	msg.id = character;
 
 	/*
 	 * We just stash the character into the id field and don't supply
 	 * any extra data
 	 */
-	ipm_send(ipm_console_device, 1, character, NULL, 0);
+	ipm_send(ipm_console_device, 1, &msg);
 
 	return character;
 }

--- a/drivers/console/ipm_console_sender.c
+++ b/drivers/console/ipm_console_sender.c
@@ -31,7 +31,7 @@ static int consoleOut(int character)
 	 * We just stash the character into the id field and don't supply
 	 * any extra data
 	 */
-	ipm_send(ipm_console_device, 1, &msg);
+	ipm_send(ipm_console_device, 1, 0, &msg);
 
 	return character;
 }

--- a/drivers/ipm/ipm_cavs_idc.c
+++ b/drivers/ipm/ipm_cavs_idc.c
@@ -86,13 +86,16 @@ static void cavs_idc_isr(const struct device *dev)
 #endif
 }
 
-static int cavs_idc_send(const struct device *dev, int wait, struct ipm_msg *msg)
+static int cavs_idc_send(const struct device *dev, int wait, uint32_t channel,
+			 struct ipm_msg *msg)
 {
 	uint32_t curr_cpu_id = arch_curr_cpu()->id;
 	uint32_t ext = POINTER_TO_UINT(msg->data);
 	uint32_t reg;
 	bool busy;
 	int i;
+
+	ARG_UNUSED(channel);
 
 	if ((wait != 0) || (msg->size != 0)) {
 		return -ENOTSUP;
@@ -159,9 +162,12 @@ static uint32_t cavs_idc_max_id_val_get(const struct device *dev)
 
 static void cavs_idc_register_callback(const struct device *dev,
 				       ipm_callback_t cb,
+				       uint32_t channel,
 				       void *user_data)
 {
 	struct cavs_idc_data *drv_data = dev->data;
+
+	ARG_UNUSED(channel);
 
 	drv_data->cb = cb;
 	drv_data->user_data = user_data;

--- a/drivers/ipm/ipm_cavs_idc.c
+++ b/drivers/ipm/ipm_cavs_idc.c
@@ -86,16 +86,15 @@ static void cavs_idc_isr(const struct device *dev)
 #endif
 }
 
-static int cavs_idc_send(const struct device *dev, int wait, uint32_t id,
-			 const void *data, int size)
+static int cavs_idc_send(const struct device *dev, int wait, struct ipm_msg *msg)
 {
 	uint32_t curr_cpu_id = arch_curr_cpu()->id;
-	uint32_t ext = POINTER_TO_UINT(data);
+	uint32_t ext = POINTER_TO_UINT(msg->data);
 	uint32_t reg;
 	bool busy;
 	int i;
 
-	if ((wait != 0) || (size != 0)) {
+	if ((wait != 0) || (msg->size != 0)) {
 		return -ENOTSUP;
 	}
 
@@ -119,7 +118,7 @@ static int cavs_idc_send(const struct device *dev, int wait, uint32_t id,
 		return -EBUSY;
 	}
 
-	id &= IPC_IDCITC_MSG_MASK;
+	msg->id &= IPC_IDCITC_MSG_MASK;
 	ext &= IPC_IDCIETC_MSG_MASK;
 	ext |= IPC_IDCIETC_DONE; /* always clear DONE bit */
 
@@ -130,7 +129,7 @@ static int cavs_idc_send(const struct device *dev, int wait, uint32_t id,
 		}
 
 		idc_write(IPC_IDCIETC(i), curr_cpu_id, ext);
-		idc_write(IPC_IDCITC(i), curr_cpu_id, id | IPC_IDCITC_BUSY);
+		idc_write(IPC_IDCITC(i), curr_cpu_id, msg->id | IPC_IDCITC_BUSY);
 	}
 
 	return 0;

--- a/drivers/ipm/ipm_handlers.c
+++ b/drivers/ipm/ipm_handlers.c
@@ -8,13 +8,12 @@
 #include <drivers/ipm.h>
 
 static inline int z_vrfy_ipm_send(const struct device *dev, int wait,
-				  uint32_t id,
-				  const void *data, int size)
+				  struct ipm_msg *msg)
 {
 	Z_OOPS(Z_SYSCALL_DRIVER_IPM(dev, send));
-	Z_OOPS(Z_SYSCALL_MEMORY_READ(data, size));
-	return z_impl_ipm_send((const struct device *)dev, wait, id,
-			       (const void *)data, size);
+	Z_OOPS(Z_SYSCALL_MEMORY_READ(msg, sizeof(struct ipm_msg)));
+	Z_OOPS(Z_SYSCALL_MEMORY_READ(msg->data, msg->size));
+	return z_impl_ipm_send((const struct device *)dev, wait, msg);
 }
 #include <syscalls/ipm_send_mrsh.c>
 

--- a/drivers/ipm/ipm_handlers.c
+++ b/drivers/ipm/ipm_handlers.c
@@ -8,7 +8,7 @@
 #include <drivers/ipm.h>
 
 static inline int z_vrfy_ipm_send(const struct device *dev, int wait,
-				  struct ipm_msg *msg)
+				  uint32_t channel, struct ipm_msg *msg)
 {
 	Z_OOPS(Z_SYSCALL_DRIVER_IPM(dev, send));
 	Z_OOPS(Z_SYSCALL_MEMORY_READ(msg, sizeof(struct ipm_msg)));
@@ -31,9 +31,25 @@ static inline uint32_t z_vrfy_ipm_max_id_val_get(const struct device *dev)
 }
 #include <syscalls/ipm_max_id_val_get_mrsh.c>
 
+static inline uint32_t z_vrfy_ipm_max_channels_get(const struct device *dev)
+{
+	Z_OOPS(Z_SYSCALL_DRIVER_IPM(dev, max_channels_get));
+	return z_impl_ipm_max_channels_get((const struct device *)dev);
+}
+#include <syscalls/ipm_max_channels_get_mrsh.c>
+
 static inline int z_vrfy_ipm_set_enabled(const struct device *dev, int enable)
 {
 	Z_OOPS(Z_SYSCALL_DRIVER_IPM(dev, set_enabled));
 	return z_impl_ipm_set_enabled((const struct device *)dev, enable);
 }
 #include <syscalls/ipm_set_enabled_mrsh.c>
+
+static inline int z_vrfy_ipm_configure_channel(const struct device *dev,
+					       uint32_t channel,
+					       void *conf)
+{
+	Z_OOPS(Z_SYSCALL_DRIVER_IPM(dev, configure_channel));
+	return z_impl_ipm_configure_channel((const struct device *)dev, channel, conf);
+}
+#include <syscalls/ipm_configure_channel_mrsh.c>

--- a/drivers/ipm/ipm_imx.c
+++ b/drivers/ipm/ipm_imx.c
@@ -86,13 +86,16 @@ static void imx_mu_isr(const struct device *dev)
 #endif
 }
 
-static int imx_mu_ipm_send(const struct device *dev, int wait, struct ipm_msg *msg)
+static int imx_mu_ipm_send(const struct device *dev, int wait, uint32_t channel,
+			   struct ipm_msg *msg)
 {
 	const struct imx_mu_config *config = dev->config;
 	MU_Type *base = MU(config);
 	uint32_t data32[IMX_IPM_DATA_REGS];
 	mu_status_t status;
 	int i;
+
+	ARG_UNUSED(channel);
 
 	if (msg->id > CONFIG_IPM_IMX_MAX_ID_VAL) {
 		return -EINVAL;
@@ -138,9 +141,12 @@ static uint32_t imx_mu_ipm_max_id_val_get(const struct device *dev)
 
 static void imx_mu_ipm_register_callback(const struct device *dev,
 					 ipm_callback_t cb,
+					 uint32_t channel,
 					 void *user_data)
 {
 	struct imx_mu_data *driver_data = dev->data;
+
+	ARG_UNUSED(channel);
 
 	driver_data->callback = cb;
 	driver_data->user_data = user_data;

--- a/drivers/ipm/ipm_intel_adsp.c
+++ b/drivers/ipm/ipm_intel_adsp.c
@@ -107,17 +107,16 @@ static void ipm_adsp_isr(const struct device *dev)
 	}
 }
 
-static int ipm_adsp_send(const struct device *dev, int wait, uint32_t id,
-			 const void *data, int size)
+static int ipm_adsp_send(const struct device *dev, int wait, struct ipm_msg *msg)
 {
-	LOG_DBG("Send: id %d data %p size %d", id, data, size);
-	LOG_HEXDUMP_DBG(data, size, "send");
+	LOG_DBG("Send: id %d data %p size %d", msg->id, msg->data, msg->size);
+	LOG_HEXDUMP_DBG(msg->data, msg->size, "send");
 
-	if (id > IPM_INTEL_ADSP_MAX_ID_VAL) {
+	if (msg->id > IPM_INTEL_ADSP_MAX_ID_VAL) {
 		return -EINVAL;
 	}
 
-	if (size > IPM_INTEL_ADSP_MAX_DATA_SIZE) {
+	if (msg->size > IPM_INTEL_ADSP_MAX_DATA_SIZE) {
 		return -EMSGSIZE;
 	}
 
@@ -131,11 +130,11 @@ static int ipm_adsp_send(const struct device *dev, int wait, uint32_t id,
 		}
 	}
 
-	memcpy((void *)IPM_INTEL_ADSP_MAILBOX_OUT, data, size);
-	SOC_DCACHE_FLUSH((void *)IPM_INTEL_ADSP_MAILBOX_OUT, size);
+	memcpy((void *)IPM_INTEL_ADSP_MAILBOX_OUT, msg->data, msg->size);
+	SOC_DCACHE_FLUSH((void *)IPM_INTEL_ADSP_MAILBOX_OUT, msg->size);
 
 	ipc_write(IPC_DIPCIE, 0);
-	ipc_write(IPC_DIPCI, IPC_DIPCI_BUSY | id);
+	ipc_write(IPC_DIPCI, IPC_DIPCI_BUSY | msg->id);
 
 	return 0;
 }

--- a/drivers/ipm/ipm_intel_adsp.c
+++ b/drivers/ipm/ipm_intel_adsp.c
@@ -107,10 +107,13 @@ static void ipm_adsp_isr(const struct device *dev)
 	}
 }
 
-static int ipm_adsp_send(const struct device *dev, int wait, struct ipm_msg *msg)
+static int ipm_adsp_send(const struct device *dev, int wait, uint32_t channel,
+			 struct ipm_msg *msg)
 {
 	LOG_DBG("Send: id %d data %p size %d", msg->id, msg->data, msg->size);
 	LOG_HEXDUMP_DBG(msg->data, msg->size, "send");
+
+	ARG_UNUSED(channel);
 
 	if (msg->id > IPM_INTEL_ADSP_MAX_ID_VAL) {
 		return -EINVAL;
@@ -141,9 +144,12 @@ static int ipm_adsp_send(const struct device *dev, int wait, struct ipm_msg *msg
 
 static void ipm_adsp_register_callback(const struct device *dev,
 				       ipm_callback_t cb,
+				       uint32_t channel,
 				       void *user_data)
 {
 	struct ipm_adsp_data *data = dev->data;
+
+	ARG_UNUSED(channel);
 
 	data->callback = cb;
 	data->user_data = user_data;

--- a/drivers/ipm/ipm_mcux.c
+++ b/drivers/ipm/ipm_mcux.c
@@ -73,9 +73,7 @@ static void mcux_mailbox_isr(const struct device *dev)
 }
 
 
-static int mcux_mailbox_ipm_send(const struct device *d, int wait,
-				 uint32_t id,
-				 const void *data, int size)
+static int mcux_mailbox_ipm_send(const struct device *d, int wait, struct ipm_msg *msg)
 {
 	const struct mcux_mailbox_config *config = d->config;
 	MAILBOX_Type *base = config->base;
@@ -87,18 +85,18 @@ static int mcux_mailbox_ipm_send(const struct device *d, int wait,
 
 	ARG_UNUSED(wait);
 
-	if (id > MCUX_IPM_MAX_ID_VAL) {
+	if (msg->id > MCUX_IPM_MAX_ID_VAL) {
 		return -EINVAL;
 	}
 
-	if (size > MCUX_IPM_DATA_REGS * sizeof(uint32_t)) {
+	if (msg->size > MCUX_IPM_DATA_REGS * sizeof(uint32_t)) {
 		return -EMSGSIZE;
 	}
 
 	flags = irq_lock();
 
 	/* Actual message is passing using 32 bits registers */
-	memcpy(data32, data, size);
+	memcpy(data32, msg->data, msg->size);
 
 	for (i = 0; i < ARRAY_SIZE(data32); ++i) {
 		MAILBOX_SetValueBits(base, MAILBOX_ID_OTHER_CPU, data32[i]);

--- a/drivers/ipm/ipm_mcux.c
+++ b/drivers/ipm/ipm_mcux.c
@@ -73,7 +73,8 @@ static void mcux_mailbox_isr(const struct device *dev)
 }
 
 
-static int mcux_mailbox_ipm_send(const struct device *d, int wait, struct ipm_msg *msg)
+static int mcux_mailbox_ipm_send(const struct device *d, int wait, uint32_t channel,
+				 struct ipm_msg *msg)
 {
 	const struct mcux_mailbox_config *config = d->config;
 	MAILBOX_Type *base = config->base;
@@ -84,6 +85,7 @@ static int mcux_mailbox_ipm_send(const struct device *d, int wait, struct ipm_ms
 	int i;
 
 	ARG_UNUSED(wait);
+	ARG_UNUSED(channel);
 
 	if (msg->id > MCUX_IPM_MAX_ID_VAL) {
 		return -EINVAL;
@@ -125,9 +127,12 @@ static uint32_t mcux_mailbox_ipm_max_id_val_get(const struct device *d)
 
 static void mcux_mailbox_ipm_register_callback(const struct device *d,
 					       ipm_callback_t cb,
+					       uint32_t channel,
 					       void *context)
 {
 	struct mcux_mailbox_data *driver_data = d->data;
+
+	ARG_UNUSED(channel);
 
 	driver_data->callback = cb;
 	driver_data->callback_ctx = context;

--- a/drivers/ipm/ipm_mhu.c
+++ b/drivers/ipm/ipm_mhu.c
@@ -57,9 +57,11 @@ static uint32_t ipm_mhu_get_status(const struct device *d,
 	return IPM_MHU_ERR_NONE;
 }
 
-static int ipm_mhu_send(const struct device *d, int wait, struct ipm_msg *msg)
+static int ipm_mhu_send(const struct device *d, int wait, uint32_t channel,
+			struct ipm_msg *msg)
 {
 	ARG_UNUSED(wait);
+	ARG_UNUSED(channel);
 
 	const uint32_t set_val = 0x01;
 
@@ -156,9 +158,12 @@ static int ipm_mhu_max_data_size_get(const struct device *d)
 
 static void ipm_mhu_register_cb(const struct device *d,
 				ipm_callback_t cb,
+				uint32_t channel,
 				void *user_data)
 {
 	struct ipm_mhu_data *driver_data = DEV_DATA(d);
+
+	ARG_UNUSED(channel);
 
 	driver_data->callback = cb;
 	driver_data->user_data = user_data;

--- a/drivers/ipm/ipm_mhu.c
+++ b/drivers/ipm/ipm_mhu.c
@@ -57,26 +57,25 @@ static uint32_t ipm_mhu_get_status(const struct device *d,
 	return IPM_MHU_ERR_NONE;
 }
 
-static int ipm_mhu_send(const struct device *d, int wait, uint32_t cpu_id,
-			  const void *data, int size)
+static int ipm_mhu_send(const struct device *d, int wait, struct ipm_msg *msg)
 {
 	ARG_UNUSED(wait);
-	ARG_UNUSED(data);
+
 	const uint32_t set_val = 0x01;
 
 	struct ipm_mhu_reg_map_t *p_mhu_dev;
 
-	if (cpu_id >= IPM_MHU_CPU_MAX) {
+	if (msg->id >= IPM_MHU_CPU_MAX) {
 		return -EINVAL;
 	}
 
-	if (size > IPM_MHU_MAX_DATA_SIZE) {
+	if (msg->size > IPM_MHU_MAX_DATA_SIZE) {
 		return -EMSGSIZE;
 	}
 
 	p_mhu_dev = (struct ipm_mhu_reg_map_t *)IPM_MHU_REGS(d);
 
-	switch (cpu_id) {
+	switch (msg->id) {
 	case IPM_MHU_CPU1:
 		p_mhu_dev->cpu1intr_set = set_val;
 		break;

--- a/drivers/ipm/ipm_nrfx_ipc.c
+++ b/drivers/ipm/ipm_nrfx_ipc.c
@@ -44,8 +44,11 @@ static void nrfx_ipc_handler(uint32_t event_mask, void *p_context)
 	}
 }
 
-static int ipm_nrf_send(const struct device *dev, int wait, struct ipm_msg *msg)
+static int ipm_nrf_send(const struct device *dev, int wait, uint32_t channel,
+			struct ipm_msg *msg)
 {
+	ARG_UNUSED(channel);
+
 	if (msg->id > NRFX_IPC_ID_MAX_VALUE) {
 		return -EINVAL;
 	}
@@ -74,8 +77,11 @@ static uint32_t ipm_nrf_max_id_val_get(const struct device *dev)
 
 static void ipm_nrf_register_callback(const struct device *dev,
 				      ipm_callback_t cb,
+				      uint32_t channel,
 				      void *user_data)
 {
+	ARG_UNUSED(channel);
+
 	nrfx_ipm_data.callback = cb;
 	nrfx_ipm_data.user_data = user_data;
 }
@@ -163,8 +169,11 @@ static int vipm_nrf_init(const struct device *dev)
 
 #define VIPM_DEVICE_1(_idx)						\
 static int vipm_nrf_##_idx##_send(const struct device *dev, int wait,	\
+				  uint32_t channel,			\
 				  struct ipm_msg *msg)			\
 {									\
+	ARG_UNUSED(channel);						\
+									\
 	if (!IS_ENABLED(CONFIG_IPM_MSG_CH_##_idx##_TX)) {		\
 		LOG_ERR("IPM_" #_idx " is RX message channel");		\
 		return -EINVAL;						\
@@ -190,8 +199,11 @@ static int vipm_nrf_##_idx##_send(const struct device *dev, int wait,	\
 									\
 static void vipm_nrf_##_idx##_register_callback(const struct device *dev, \
 						ipm_callback_t cb,	\
+						uint32_t channel,	\
 						void *user_data)	\
 {									\
+	ARG_UNUSED(channel);						\
+									\
 	if (IS_ENABLED(CONFIG_IPM_MSG_CH_##_idx##_RX)) {		\
 		nrfx_vipm_data.callback[_idx] = cb;			\
 		nrfx_vipm_data.user_data[_idx] = user_data;		\

--- a/drivers/ipm/ipm_nrfx_ipc.c
+++ b/drivers/ipm/ipm_nrfx_ipc.c
@@ -44,18 +44,17 @@ static void nrfx_ipc_handler(uint32_t event_mask, void *p_context)
 	}
 }
 
-static int ipm_nrf_send(const struct device *dev, int wait, uint32_t id,
-			const void *data, int size)
+static int ipm_nrf_send(const struct device *dev, int wait, struct ipm_msg *msg)
 {
-	if (id > NRFX_IPC_ID_MAX_VALUE) {
+	if (msg->id > NRFX_IPC_ID_MAX_VALUE) {
 		return -EINVAL;
 	}
 
-	if (size > 0) {
+	if (msg->size > 0) {
 		LOG_WRN("nRF driver does not support sending data over IPM");
 	}
 
-	gipm_send(id);
+	gipm_send(msg->id);
 	return 0;
 }
 
@@ -164,23 +163,23 @@ static int vipm_nrf_init(const struct device *dev)
 
 #define VIPM_DEVICE_1(_idx)						\
 static int vipm_nrf_##_idx##_send(const struct device *dev, int wait,	\
-				  uint32_t id, const void *data, int size)	\
+				  struct ipm_msg *msg)			\
 {									\
 	if (!IS_ENABLED(CONFIG_IPM_MSG_CH_##_idx##_TX)) {		\
 		LOG_ERR("IPM_" #_idx " is RX message channel");		\
 		return -EINVAL;						\
 	}								\
 									\
-	if (id > NRFX_IPC_ID_MAX_VALUE) {				\
+	if (msg->id > NRFX_IPC_ID_MAX_VALUE) {				\
 		return -EINVAL;						\
 	}								\
 									\
-	if (id != 0) {							\
+	if (msg->id != 0) {							\
 		LOG_WRN("Passing message ID to IPM with"		\
 			"predefined message ID");			\
 	}								\
 									\
-	if (size > 0) {							\
+	if (msg->size > 0) {							\
 		LOG_WRN("nRF driver does not support"			\
 			"sending data over IPM");			\
 	}								\

--- a/drivers/ipm/ipm_stm32_hsem.c
+++ b/drivers/ipm/ipm_stm32_hsem.c
@@ -74,20 +74,18 @@ static void stm32_hsem_mailbox_irq_config_func(const struct device *dev)
 	irq_enable(DT_INST_IRQN(0));
 }
 
-int stm32_hsem_mailbox_ipm_send(const struct device *dev, int wait, uint32_t id,
-			  const void *buff, int size)
+int stm32_hsem_mailbox_ipm_send(const struct device *dev, int wait, struct ipm_msg *msg)
 {
 	struct stm32_hsem_mailbox_data *data = dev->data;
 
 	ARG_UNUSED(wait);
-	ARG_UNUSED(buff);
 
-	if (size) {
+	if (msg->size) {
 		LOG_WRN("stm32 HSEM not support data transfer");
 		return -EMSGSIZE;
 	}
 
-	if (id) {
+	if (msg->id) {
 		LOG_WRN("stm32 HSEM only support a single instance of mailbox");
 		return -EINVAL;
 	}

--- a/drivers/ipm/ipm_stm32_hsem.c
+++ b/drivers/ipm/ipm_stm32_hsem.c
@@ -74,11 +74,13 @@ static void stm32_hsem_mailbox_irq_config_func(const struct device *dev)
 	irq_enable(DT_INST_IRQN(0));
 }
 
-int stm32_hsem_mailbox_ipm_send(const struct device *dev, int wait, struct ipm_msg *msg)
+int stm32_hsem_mailbox_ipm_send(const struct device *dev, int wait, uint32_t channel,
+				struct ipm_msg *msg)
 {
 	struct stm32_hsem_mailbox_data *data = dev->data;
 
 	ARG_UNUSED(wait);
+	ARG_UNUSED(channel);
 
 	if (msg->size) {
 		LOG_WRN("stm32 HSEM not support data transfer");
@@ -104,9 +106,12 @@ int stm32_hsem_mailbox_ipm_send(const struct device *dev, int wait, struct ipm_m
 
 void stm32_hsem_mailbox_ipm_register_callback(const struct device *dev,
 					ipm_callback_t cb,
+					uint32_t channel,
 					void *user_data)
 {
 	struct stm32_hsem_mailbox_data *data = dev->data;
+
+	ARG_UNUSED(channel);
 
 	data->callback = cb;
 	data->user_data = user_data;

--- a/drivers/ipm/ipm_stm32_ipcc.c
+++ b/drivers/ipm/ipm_stm32_ipcc.c
@@ -152,12 +152,14 @@ static void stm32_ipcc_mailbox_tx_isr(const struct device *dev)
 }
 
 static int stm32_ipcc_mailbox_ipm_send(const struct device *dev, int wait,
+				       uint32_t channel,
 				       struct ipm_msg *msg)
 {
 	struct stm32_ipcc_mbx_data *data = dev->data;
 	const struct stm32_ipcc_mailbox_config *cfg = DEV_CFG(dev);
 
 	ARG_UNUSED(wait);
+	ARG_UNUSED(channel);
 
 	/* No data transmition, only doorbell */
 	if (msg->size) {
@@ -201,9 +203,12 @@ static uint32_t stm32_ipcc_mailbox_ipm_max_id_val_get(const struct device *d)
 
 static void stm32_ipcc_mailbox_ipm_register_callback(const struct device *d,
 						     ipm_callback_t cb,
+						     uint32_t channel,
 						     void *user_data)
 {
 	struct stm32_ipcc_mbx_data *data = DEV_DATA(d);
+
+	ARG_UNUSED(channel);
 
 	data->callback = cb;
 	data->user_data = user_data;

--- a/dts/bindings/base/base.yaml
+++ b/dts/bindings/base/base.yaml
@@ -97,3 +97,13 @@ properties:
       required: false
       type: string-array
       description: Provided names of IO channel specifiers
+
+    mboxes:
+      required: false
+      type: phandle-array
+      description: mailbox / IPM channels specifiers
+
+    mbox-names:
+      required: false
+      type: string-array
+      description: Provided names of mailbox / IPM channel specifiers

--- a/dts/bindings/mailbox/mailbox-controller.yaml
+++ b/dts/bindings/mailbox/mailbox-controller.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2021, Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+# Common fields for mailbox / IPM controllers
+
+properties:
+    "#mbox-cells":
+      type: int
+      required: true
+      description: Number of items to expect in a Mailbox specifier

--- a/dts/bindings/test/vnd,ipm-zero-cell.yaml
+++ b/dts/bindings/test/vnd,ipm-zero-cell.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) 2021, Carlo Caione <ccaione@baylibre.com>
+# SPDX-License-Identifier: Apache-2.0
+
+description: VND IPM controller (0 cell)
+
+compatible: "vnd,ipm-zero-cell"
+
+properties:
+  label:
+    type: string
+    required: true

--- a/dts/bindings/test/vnd,ipm.yaml
+++ b/dts/bindings/test/vnd,ipm.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2021, Carlo Caione <ccaione@baylibre.com>
+# SPDX-License-Identifier: Apache-2.0
+
+description: VND IPM controller
+
+compatible: "vnd,ipm"
+
+include: mailbox-controller.yaml
+
+properties:
+  label:
+    type: string
+    required: true
+
+mbox-cells:
+  - channel

--- a/include/drivers/ipm.h
+++ b/include/drivers/ipm.h
@@ -18,6 +18,42 @@
  * @defgroup ipm_interface IPM Interface
  * @ingroup io_interfaces
  * @{
+ *
+ *                      CPU #1        |
+ * +----------+                       |        +----------+
+ * |          +---TX9----+   +--------+--RX8---+          |
+ * |  dev A   |          |   |        |        |  CPU #2  |
+ * |          <---RX8--+ |   | +------+--TX9--->          |
+ * +----------+        | |   | |      |        +----------+
+ *                  +--+-v---v-+--+   |
+ *                  |             |   |
+ *                  |   IPM dev   |   |
+ *                  |             |   |
+ *                  +--+-^---^--+-+   |
+ * +----------+        | |   |  |     |        +----------+
+ * |          <---RX2--+ |   |  +-----+--TX3--->          |
+ * |  dev B   |          |   |        |        |  CPU #3  |
+ * |          +---TX3----+   +--------+--RX2---+          |
+ * +----------+                       |        +----------+
+ *                                    |
+ *
+ * An IPM device is a peripheral capable of passing signals (and data depending
+ * on the peripheral) between CPUs and clusters in the system. Each IPM
+ * instance is providing one or more channels, each one targeting one other CPU
+ * cluster (multiple channels can target the same cluster).
+ *
+ * For example in the plot the device 'dev A' is using the TX channel 9 to
+ * signal (or exchange data with) the CPU #2 and it's expecting data or signals
+ * on the RX channel 8. Thus it can send the message through the channel 9, and
+ * it can register a callback on the channel 8 of the IPM device.
+ *
+ * While a message is sent through a selected channel it might be accompanied
+ * with optional ID number, if given hardware supports such accompanying
+ * number. Allowed range of allowed ID values for given IPM instance is
+ * hardware dependent.
+ *
+ * IPM driver users can determine number of supported channels and max value of
+ * ID using functions available in the driver API.
  */
 
 #include <kernel.h>
@@ -69,7 +105,8 @@ typedef void (*ipm_callback_t)(const struct device *ipmdev, void *user_data,
  *
  * See @a ipm_send() for argument definitions.
  */
-typedef int (*ipm_send_t)(const struct device *ipmdev, int wait, struct ipm_msg *msg);
+typedef int (*ipm_send_t)(const struct device *ipmdev, int wait, uint32_t channel,
+			  struct ipm_msg *msg);
 
 /**
  * @typedef ipm_max_data_size_get_t
@@ -93,8 +130,9 @@ typedef uint32_t (*ipm_max_id_val_get_t)(const struct device *ipmdev);
  *
  * See @a ipm_register_callback() for argument definitions.
  */
-typedef void (*ipm_register_callback_t)(const struct device *port,
+typedef void (*ipm_register_callback_t)(const struct device *dev,
 					ipm_callback_t cb,
+					uint32_t channel,
 					void *user_data);
 
 /**
@@ -105,12 +143,31 @@ typedef void (*ipm_register_callback_t)(const struct device *port,
  */
 typedef int (*ipm_set_enabled_t)(const struct device *ipmdev, int enable);
 
+/**
+ * @typedef ipm_max_channels_get_t
+ * @brief Callback API to get maximum number of channels
+ *
+ * See @a ipm_max_channels_get() for argument definitions.
+ */
+typedef uint32_t (*ipm_max_channels_get_t)(const struct device *ipmdev);
+
+/**
+ * @typedef ipm_configure_channel_t
+ * @brief Configure the channel in the IPM device
+ *
+ * See @a ipm_configure_channel() for argument definitions.
+ */
+typedef int (*ipm_configure_channel_t)(const struct device *ipmdev, uint32_t channel,
+				       void *conf);
+
 __subsystem struct ipm_driver_api {
 	ipm_send_t send;
 	ipm_register_callback_t register_callback;
 	ipm_max_data_size_get_t max_data_size_get;
 	ipm_max_id_val_get_t max_id_val_get;
+	ipm_max_channels_get_t max_channels_get;
 	ipm_set_enabled_t set_enabled;
+	ipm_configure_channel_t configure_channel;
 };
 
 /**
@@ -136,7 +193,8 @@ __subsystem struct ipm_driver_api {
  *	       finishes. If there is deferred processing on the remote side,
  *	       or you would like to queue outgoing messages and wait on an
  *	       event/semaphore, you can implement that in a high-level driver
- * @param msg Message struct
+ * @param channel Channel to use
+ * @param msg Pointer to the message struct
  *
  * @retval -EBUSY    If the remote hasn't yet read the last data sent.
  * @retval -EMSGSIZE If the supplied data size is unsupported by the driver.
@@ -144,14 +202,16 @@ __subsystem struct ipm_driver_api {
  *                   or the device isn't an outbound IPM channel.
  * @retval 0         On success.
  */
-__syscall int ipm_send(const struct device *ipmdev, int wait, struct ipm_msg *msg);
+__syscall int ipm_send(const struct device *ipmdev, int wait, uint32_t channel,
+		       struct ipm_msg *msg);
 
-static inline int z_impl_ipm_send(const struct device *ipmdev, int wait, struct ipm_msg *msg)
+static inline int z_impl_ipm_send(const struct device *ipmdev, int wait, uint32_t channel,
+				  struct ipm_msg *msg)
 {
 	const struct ipm_driver_api *api =
 		(const struct ipm_driver_api *)ipmdev->api;
 
-	return api->send(ipmdev, wait, msg);
+	return api->send(ipmdev, wait, channel, msg);
 }
 
 /**
@@ -159,16 +219,18 @@ static inline int z_impl_ipm_send(const struct device *ipmdev, int wait, struct 
  *
  * @param ipmdev Driver instance pointer.
  * @param cb Callback function to execute on incoming message interrupts.
+ * @param channel Channel to register the callback on.
  * @param user_data Application-specific data pointer which will be passed
  *        to the callback function when executed.
  */
 static inline void ipm_register_callback(const struct device *ipmdev,
-					 ipm_callback_t cb, void *user_data)
+					 ipm_callback_t cb, uint32_t channel,
+					 void *user_data)
 {
 	const struct ipm_driver_api *api =
 		(const struct ipm_driver_api *)ipmdev->api;
 
-	api->register_callback(ipmdev, cb, user_data);
+	api->register_callback(ipmdev, cb, channel, user_data);
 }
 
 /**
@@ -230,6 +292,243 @@ static inline int z_impl_ipm_set_enabled(const struct device *ipmdev,
 		(const struct ipm_driver_api *)ipmdev->api;
 
 	return api->set_enabled(ipmdev, enable);
+}
+
+/**
+ * @brief Return the maximum number of channels.
+ *
+ * Return the maximum number of channels supported by the hardware.
+ *
+ * @param ipmdev Driver instance pointer.
+ *
+ * @return Maximum possible number of supported channels.
+ */
+__syscall uint32_t ipm_max_channels_get(const struct device *ipmdev);
+
+static inline uint32_t z_impl_ipm_max_channels_get(const struct device *ipmdev)
+{
+	const struct ipm_driver_api *api =
+		(const struct ipm_driver_api *)ipmdev->api;
+
+	if (api->max_channels_get == NULL) {
+		/* At least 1 channel */
+		return 1;
+	}
+
+	return api->max_channels_get(ipmdev);
+}
+
+/**
+ * @brief Configure channels.
+ *
+ * Configure the device for the specified channels.
+ *
+ * @param ipmdev Driver instance pointer.
+ * @param channel IPM device channel
+ * @param conf Pointer to user-defined configuration parameter.
+ *
+ * @retval 0       On success.
+ * @retval -EINVAL If it isn't a valid channel.
+ */
+__syscall int ipm_configure_channel(const struct device *ipmdev, uint32_t channel,
+				    void *conf);
+
+static inline int z_impl_ipm_configure_channel(const struct device *ipmdev,
+					       uint32_t channel, void *conf)
+{
+	const struct ipm_driver_api *api =
+		(const struct ipm_driver_api *)ipmdev->api;
+
+	if (api->configure_channel == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->configure_channel(ipmdev, channel, conf);
+}
+
+/**
+ * @brief Provides a type to hold IPM information specified in devicetree
+ *
+ * This type is sufficient to hold an IPM device pointer and the channel ID
+ * to control IPM configuration which may be given in devicetree.
+ */
+struct ipm_dt_spec {
+	const struct device *dev;
+	uint32_t channel;
+};
+
+/**
+ * @brief Structure initializer for ipm_dt_spec from devicetree
+ *
+ * This helper macro expands to a static initializer for a @p ipm_dt_spec by
+ * reading the relevant device controller and channel number from the
+ * devicetree.
+ *
+ * Example devicetree fragment:
+ *
+ *     ipm1: ipm-controller@... { ... };
+ *
+ *     n: node {
+ *             mboxes = <&ipm1 8>,
+ *                      <&ipm1 9>;
+ *             mbox-names = "tx", "rx";
+ *     };
+ *
+ * Example usage:
+ *
+ *     const struct ipm_dt_spec spec = IPM_DT_SPEC_GET(DT_NODELABEL(n), tx);
+ *
+ * @param node_id Devicetree node identifier for the IPM device whose
+ *                struct ipm_dt_spec to create an initializer for
+ * @param name lowercase-and-underscores name for the mboxes element
+ */
+#define IPM_DT_SPEC_GET(node_id, name)						\
+	{									\
+		.dev = DEVICE_DT_GET(IPM_DT_CTLR_BY_NAME(node_id, name)),	\
+		.channel = IPM_DT_CHANNEL_BY_NAME(node_id, name),		\
+	}
+
+/**
+ * @brief Get the node identifier for the IPM controller from a
+ *        mboxes property by name
+ *
+ * Example devicetree fragment:
+ *
+ *     ipm1: ipm-controller@... { ... };
+ *
+ *     n: node {
+ *             mboxes = <&ipm1 8>,
+ *                      <&ipm1 9>;
+ *             mbox-names = "tx", "rx";
+ *     };
+ *
+ * Example usage:
+ *
+ *     IPM_DT_CTLR_BY_NAME(DT_NODELABEL(n), tx) // DT_NODELABEL(ipm1)
+ *     IPM_DT_CTLR_BY_NAME(DT_NODELABEL(n), rx) // DT_NODELABEL(ipm1)
+ *
+ * @param node_id node identifier for a node with a mboxes property
+ * @param name lowercase-and-underscores name of a mboxes element
+ *             as defined by the node's mbox-names property
+ *
+ * @return the node identifier for the IPM controller in the named element
+ *
+ * @see DT_PHANDLE_BY_NAME()
+ */
+#define IPM_DT_CTLR_BY_NAME(node_id, name) \
+	DT_PHANDLE_BY_NAME(node_id, mboxes, name)
+
+/**
+ * @brief Get a IPM channel value by name
+ *
+ * Example devicetree fragment:
+ *
+ *     ipm1: ipm@... {
+ *             #mbox-cells = <1>;
+ *     };
+ *
+ *     n: node {
+ *		mboxes = <&ipm1 1>,
+ *		         <&ipm1 6>;
+ *		mbox-names = "tx", "rx";
+ *     };
+ *
+ * Bindings fragment for the ipm compatible:
+ *
+ *     mbox-cells:
+ *       - channel
+ *
+ * Example usage:
+ *
+ *     IPM_DT_CHANNEL_BY_NAME(DT_NODELABEL(n), tx) // 1
+ *     IPM_DT_CHANNEL_BY_NAME(DT_NODELABEL(n), rx) // 6
+ *
+ * @param node_id node identifier for a node with a mboxes property
+ * @param name lowercase-and-underscores name of a mboxes element
+ *             as defined by the node's mbox-names property
+ *
+ * @return the channel value in the specifier at the named element or 0 if no
+ *         channels are supported
+ *
+ * @see DT_PHA_BY_NAME()
+ */
+#define IPM_DT_CHANNEL_BY_NAME(node_id, name) \
+	DT_PHA_BY_NAME_OR(node_id, mboxes, name, channel, 0)
+
+/**
+ * @brief Try to send a message over the IPM device.
+ *
+ * This is equivalent to:
+ *
+ *     ipm_send(spec->dev, wait, spec->channel, msg);
+ *
+ * @param spec IPM specification from devicetree.
+ * @param wait If nonzero, busy-wait for remote to consume the message. The
+ *	       message is considered consumed once the remote interrupt handler
+ *	       finishes. If there is deferred processing on the remote side,
+ *	       or you would like to queue outgoing messages and wait on an
+ *	       event/semaphore, you can implement that in a high-level driver
+ * @param msg Pointer to the message struct
+ *
+ * @return a value from ipm_send()
+ */
+static inline int ipm_send_dt(const struct ipm_dt_spec *spec, int wait, struct ipm_msg *msg)
+{
+	return ipm_send(spec->dev, wait, spec->channel, msg);
+}
+
+/**
+ * @brief Register a callback function for incoming messages.
+ *
+ * This is equivalent to:
+ *
+ *     ipm_register_callback(spec->dev, cb, spec->channel, user_data);
+ *
+ * @param spec IPM specification from devicetree.
+ * @param cb Callback function to execute on incoming message interrupts.
+ * @param user_data Application-specific data pointer which will be passed
+ *        to the callback function when executed.
+ */
+static inline void ipm_register_callback_dt(const struct ipm_dt_spec *spec,
+					    ipm_callback_t cb, void *user_data)
+{
+	ipm_register_callback(spec->dev, cb, spec->channel, user_data);
+}
+
+/**
+ * @brief Enable interrupts and callbacks for inbound channels.
+ *
+ * This is equivalent to:
+ *
+ *     ipm_set_enabled(spec->dev, enable);
+ *
+ * @param spec IPM specification from devicetree.
+ * @param enable Set to 0 to disable and to nonzero to enable.
+ *
+ * @return a value from ipm_set_enable()
+ */
+static inline int ipm_set_enabled_dt(const struct ipm_dt_spec *spec, int enable)
+{
+	return ipm_set_enabled(spec->dev, enable);
+}
+
+/**
+ * @brief Configure channel.
+ *
+ * Configure the device for the specified channel.
+ *
+ * This is equivalent to:
+ *
+ *     ipm_configure_channel(spec->dev, spec->channel, conf);
+ *
+ * @param spec IPM specification from devicetree.
+ * @param conf Pointer to user-defined configuration parameter for the channel.
+ *
+ * @retval a value from ipm_configure_channel()
+ */
+static inline int ipm_configure_channel_dt(const struct ipm_dt_spec *spec, void *conf)
+{
+	return ipm_configure_channel(spec->dev, spec->channel, conf);
 }
 
 #ifdef __cplusplus

--- a/samples/boards/stm32/h7_dual_core/src/main.c
+++ b/samples/boards/stm32/h7_dual_core/src/main.c
@@ -57,7 +57,7 @@ void main(void)
 	data.led = &led0;
 	data.led_is_on = false;
 
-	ipm_register_callback(ipm, new_message_callback, &data);
+	ipm_register_callback(ipm, new_message_callback, 0, &data);
 
 	ipm_set_enabled(ipm, 1);
 
@@ -66,7 +66,7 @@ void main(void)
 	msg.id = 0;
 
 	while (1) {
-		ipm_send(ipm, 0, &msg);
+		ipm_send(ipm, 0, 0, &msg);
 		k_msleep(SLEEP_TIME_MS);
 	}
 }

--- a/samples/boards/stm32/h7_dual_core/src/main.c
+++ b/samples/boards/stm32/h7_dual_core/src/main.c
@@ -37,6 +37,7 @@ void new_message_callback(const struct device *dev, void *user_data,
 void main(void)
 {
 	const struct device *ipm;
+	struct ipm_msg msg;
 
 	printk("STM32 h7_dual_core application\n");
 
@@ -60,8 +61,12 @@ void main(void)
 
 	ipm_set_enabled(ipm, 1);
 
+	msg.data = NULL;
+	msg.size = 0;
+	msg.id = 0;
+
 	while (1) {
-		ipm_send(ipm, 0, 0, NULL, 0);
+		ipm_send(ipm, 0, &msg);
 		k_msleep(SLEEP_TIME_MS);
 	}
 }

--- a/samples/subsys/ipc/ipm_imx/src/main.c
+++ b/samples/subsys/ipc/ipm_imx/src/main.c
@@ -14,6 +14,7 @@ static void ipm_callback(const struct device *dev, void *context,
 {
 	int i;
 	int status;
+	struct ipm_msg msg;
 	uint32_t *data32 = (uint32_t *)data;
 
 	printk("%s: id = %u, data = 0x", __func__, id);
@@ -22,8 +23,11 @@ static void ipm_callback(const struct device *dev, void *context,
 	}
 	printk("\n");
 
-	status = ipm_send(dev, 1, id, (const void *)data,
-			  CONFIG_IPM_IMX_MAX_DATA_SIZE);
+	msg.data = (const void *) data;
+	msg.size = CONFIG_IPM_IMX_MAX_DATA_SIZE;
+	msg.id = id;
+
+	status = ipm_send(dev, 1, &msg);
 	if (status) {
 		printk("ipm_send() failed: %d\n", status);
 	}

--- a/samples/subsys/ipc/ipm_imx/src/main.c
+++ b/samples/subsys/ipc/ipm_imx/src/main.c
@@ -27,7 +27,7 @@ static void ipm_callback(const struct device *dev, void *context,
 	msg.size = CONFIG_IPM_IMX_MAX_DATA_SIZE;
 	msg.id = id;
 
-	status = ipm_send(dev, 1, &msg);
+	status = ipm_send(dev, 1, 0, &msg);
 	if (status) {
 		printk("ipm_send() failed: %d\n", status);
 	}
@@ -42,7 +42,7 @@ void main(void)
 		while (1) {
 		}
 	}
-	ipm_register_callback(ipm, ipm_callback, NULL);
+	ipm_register_callback(ipm, ipm_callback, 0, NULL);
 	ipm_set_enabled(ipm, 1);
 	printk("IPM initialized, data size = %d\n",
 		CONFIG_IPM_IMX_MAX_DATA_SIZE);

--- a/samples/subsys/ipc/ipm_mcux/remote/src/main_remote.c
+++ b/samples/subsys/ipc/ipm_mcux/remote/src/main_remote.c
@@ -18,7 +18,7 @@ void ping_ipm_callback(const struct device *dev, void *context,
 	msg.size = 4;
 	msg.id = 0;
 
-	ipm_send(dev, 1, &msg);
+	ipm_send(dev, 1, 0, &msg);
 }
 
 
@@ -32,7 +32,7 @@ void main(void)
 		while (1) {
 		}
 	}
-	ipm_register_callback(ipm, ping_ipm_callback, NULL);
+	ipm_register_callback(ipm, ping_ipm_callback, 0, NULL);
 	ipm_set_enabled(ipm, 1);
 	while (1) {
 	}

--- a/samples/subsys/ipc/ipm_mcux/remote/src/main_remote.c
+++ b/samples/subsys/ipc/ipm_mcux/remote/src/main_remote.c
@@ -12,7 +12,13 @@
 void ping_ipm_callback(const struct device *dev, void *context,
 		       uint32_t id, volatile void *data)
 {
-	ipm_send(dev, 1, 0, (const void *)data, 4);
+	struct ipm_msg msg;
+
+	msg.data = data;
+	msg.size = 4;
+	msg.id = 0;
+
+	ipm_send(dev, 1, &msg);
 }
 
 

--- a/samples/subsys/ipc/ipm_mcux/src/main_master.c
+++ b/samples/subsys/ipc/ipm_mcux/src/main_master.c
@@ -14,14 +14,20 @@ int gcounter;
 void ping_ipm_callback(const struct device *dev, void *context,
 		       uint32_t id, volatile void *data)
 {
+	struct ipm_msg msg;
+
 	gcounter = *(int *)data;
 	/* Show current ping-pong counter value */
 	printk("Received: %d\n", gcounter);
 	/* Increment on our side */
 	gcounter++;
 	if (gcounter < 100) {
+		msg.data = &gcounter;
+		msg.size = 4;
+		msg.id = 0;
+
 		/* Send back to the other core */
-		ipm_send(dev, 1, 0, &gcounter, 4);
+		ipm_send(dev, 1, &msg);
 	}
 }
 
@@ -31,6 +37,7 @@ void main(void)
 				* zero value can't be sent via mailbox register
 				*/
 	const struct device *ipm;
+	struct ipm_msg msg;
 
 	printk("Hello World from MASTER! %s\n", CONFIG_ARCH);
 
@@ -47,8 +54,12 @@ void main(void)
 	/* Enable the IPM device */
 	ipm_set_enabled(ipm, 1);
 
+	msg.data = &first_message;
+	msg.size = 4;
+	msg.id = 0;
+
 	/* Send initial message with 4 bytes length*/
-	ipm_send(ipm, 1, 0, &first_message, 4);
+	ipm_send(ipm, 1, &msg);
 	while (1) {
 	}
 }

--- a/samples/subsys/ipc/ipm_mcux/src/main_master.c
+++ b/samples/subsys/ipc/ipm_mcux/src/main_master.c
@@ -27,7 +27,7 @@ void ping_ipm_callback(const struct device *dev, void *context,
 		msg.id = 0;
 
 		/* Send back to the other core */
-		ipm_send(dev, 1, &msg);
+		ipm_send(dev, 1, 0, &msg);
 	}
 }
 
@@ -50,7 +50,7 @@ void main(void)
 	}
 
 	/* Register application callback with no context */
-	ipm_register_callback(ipm, ping_ipm_callback, NULL);
+	ipm_register_callback(ipm, ping_ipm_callback, 0, NULL);
 	/* Enable the IPM device */
 	ipm_set_enabled(ipm, 1);
 
@@ -59,7 +59,7 @@ void main(void)
 	msg.id = 0;
 
 	/* Send initial message with 4 bytes length*/
-	ipm_send(ipm, 1, &msg);
+	ipm_send(ipm, 1, 0, &msg);
 	while (1) {
 	}
 }

--- a/samples/subsys/ipc/ipm_mhu_dual_core/src/main.c
+++ b/samples/subsys/ipc/ipm_mhu_dual_core/src/main.c
@@ -31,7 +31,7 @@ static void main_cpu_1(void)
 	msg.size = 1;
 	msg.id = MHU_CPU0;
 
-	ipm_send(mhu0, 0, &msg);
+	ipm_send(mhu0, 0, 0, &msg);
 
 	while (1) {
 	}
@@ -49,7 +49,7 @@ static void mhu_isr_callback(const struct device *dev, void *context,
 		msg.size = 1;
 		msg.id = MHU_CPU1;
 
-		ipm_send(dev, 0, &msg);
+		ipm_send(dev, 0, 0, &msg);
 	} else if (cpu_id == MHU_CPU1) {
 		printk("MHU Test Done.\n");
 	}
@@ -68,7 +68,7 @@ void main(void)
 	} else {
 		printk("CPU %d, get MHU0 success!\n",
 				sse_200_platform_get_cpu_id());
-		ipm_register_callback(mhu0, mhu_isr_callback, NULL);
+		ipm_register_callback(mhu0, mhu_isr_callback, 0, NULL);
 	}
 
 	if (sse_200_platform_get_cpu_id() == MHU_CPU0) {

--- a/samples/subsys/ipc/ipm_mhu_dual_core/src/main.c
+++ b/samples/subsys/ipc/ipm_mhu_dual_core/src/main.c
@@ -24,9 +24,14 @@ static void main_cpu_0(void)
 
 static void main_cpu_1(void)
 {
+	struct ipm_msg msg;
 	const uint32_t set_mhu = 1;
 
-	ipm_send(mhu0, 0, MHU_CPU0, &set_mhu, 1);
+	msg.data = &set_mhu;
+	msg.size = 1;
+	msg.id = MHU_CPU0;
+
+	ipm_send(mhu0, 0, &msg);
 
 	while (1) {
 	}
@@ -36,10 +41,15 @@ static void mhu_isr_callback(const struct device *dev, void *context,
 			     uint32_t cpu_id, volatile void *data)
 {
 	const uint32_t set_mhu = 1;
+	struct ipm_msg msg;
 
 	printk("MHU ISR on CPU %d\n", cpu_id);
 	if (cpu_id == MHU_CPU0) {
-		ipm_send(dev, 0, MHU_CPU1, &set_mhu, 1);
+		msg.data = &set_mhu;
+		msg.size = 1;
+		msg.id = MHU_CPU1;
+
+		ipm_send(dev, 0, &msg);
 	} else if (cpu_id == MHU_CPU1) {
 		printk("MHU Test Done.\n");
 	}

--- a/samples/subsys/ipc/openamp/remote/src/main.c
+++ b/samples/subsys/ipc/openamp/remote/src/main.c
@@ -73,15 +73,25 @@ static uint32_t virtio_get_features(struct virtio_device *vdev)
 
 static void virtio_notify(struct virtqueue *vq)
 {
+	struct ipm_msg msg;
+
 #if defined(CONFIG_SOC_MPS2_AN521) || \
 	defined(CONFIG_SOC_V2M_MUSCA_B1)
 	uint32_t current_core = sse_200_platform_get_cpu_id();
 
-	ipm_send(ipm_handle, 0, current_core ? 0 : 1, 0, 1);
+	msg.data = (const void *) 0;
+	msg.size = 1;
+	msg.id = current_core ? 0 : 1;
+
+	ipm_send(ipm_handle, 0, &msg);
 #else
 	uint32_t dummy_data = 0x00110011; /* Some data must be provided */
 
-	ipm_send(ipm_handle, 0, 0, &dummy_data, sizeof(dummy_data));
+	msg.data = &dummy_data;
+	msg.size = sizeof(dummy_data);
+	msg.id = 0;
+
+	ipm_send(ipm_handle, 0, &msg);
 #endif /* #if defined(CONFIG_SOC_MPS2_AN521) */
 }
 

--- a/samples/subsys/ipc/openamp/remote/src/main.c
+++ b/samples/subsys/ipc/openamp/remote/src/main.c
@@ -83,7 +83,7 @@ static void virtio_notify(struct virtqueue *vq)
 	msg.size = 1;
 	msg.id = current_core ? 0 : 1;
 
-	ipm_send(ipm_handle, 0, &msg);
+	ipm_send(ipm_handle, 0, 0, &msg);
 #else
 	uint32_t dummy_data = 0x00110011; /* Some data must be provided */
 
@@ -91,7 +91,7 @@ static void virtio_notify(struct virtqueue *vq)
 	msg.size = sizeof(dummy_data);
 	msg.id = 0;
 
-	ipm_send(ipm_handle, 0, &msg);
+	ipm_send(ipm_handle, 0, 0, &msg);
 #endif /* #if defined(CONFIG_SOC_MPS2_AN521) */
 }
 
@@ -192,7 +192,7 @@ void app_task(void *arg1, void *arg2, void *arg3)
 		return;
 	}
 
-	ipm_register_callback(ipm_handle, platform_ipm_callback, NULL);
+	ipm_register_callback(ipm_handle, platform_ipm_callback, 0, NULL);
 
 	status = ipm_set_enabled(ipm_handle, 1);
 	if (status != 0) {

--- a/samples/subsys/ipc/openamp/src/main.c
+++ b/samples/subsys/ipc/openamp/src/main.c
@@ -87,12 +87,22 @@ static void virtio_notify(struct virtqueue *vq)
 #if defined(CONFIG_SOC_MPS2_AN521) || \
 	defined(CONFIG_SOC_V2M_MUSCA_B1)
 	uint32_t current_core = sse_200_platform_get_cpu_id();
+	struct ipm_msg msg;
 
-	ipm_send(ipm_handle, 0, current_core ? 0 : 1, 0, 1);
+	msg.data = (const void *) 0;
+	msg.size = 1;
+	msg.id = current_core ? 0 : 1;
+
+	ipm_send(ipm_handle, 0, &msg);
 #else
 	uint32_t dummy_data = 0x55005500; /* Some data must be provided */
+	struct ipm_msg msg;
 
-	ipm_send(ipm_handle, 0, 0, &dummy_data, sizeof(dummy_data));
+	msg.data = &dummy_data;
+	msg.size = sizeof(dummy_data);
+	msg.id = 0;
+
+	ipm_send(ipm_handle, 0, &msg);
 #endif /* #if defined(CONFIG_SOC_MPS2_AN521) */
 }
 

--- a/samples/subsys/ipc/openamp/src/main.c
+++ b/samples/subsys/ipc/openamp/src/main.c
@@ -93,7 +93,7 @@ static void virtio_notify(struct virtqueue *vq)
 	msg.size = 1;
 	msg.id = current_core ? 0 : 1;
 
-	ipm_send(ipm_handle, 0, &msg);
+	ipm_send(ipm_handle, 0, 0, &msg);
 #else
 	uint32_t dummy_data = 0x55005500; /* Some data must be provided */
 	struct ipm_msg msg;
@@ -102,7 +102,7 @@ static void virtio_notify(struct virtqueue *vq)
 	msg.size = sizeof(dummy_data);
 	msg.id = 0;
 
-	ipm_send(ipm_handle, 0, &msg);
+	ipm_send(ipm_handle, 0, 0, &msg);
 #endif /* #if defined(CONFIG_SOC_MPS2_AN521) */
 }
 
@@ -216,7 +216,7 @@ void app_task(void *arg1, void *arg2, void *arg3)
 		return;
 	}
 
-	ipm_register_callback(ipm_handle, platform_ipm_callback, NULL);
+	ipm_register_callback(ipm_handle, platform_ipm_callback, 0, NULL);
 
 	status = ipm_set_enabled(ipm_handle, 1);
 	if (status != 0) {

--- a/samples/subsys/ipc/openamp_rsc_table/src/main_remote.c
+++ b/samples/subsys/ipc/openamp_rsc_table/src/main_remote.c
@@ -114,7 +114,7 @@ int mailbox_notify(void *priv, uint32_t id)
 	msg.id = 0;
 
 	LOG_DBG("%s: msg received\n", __func__);
-	ipm_send(ipm_handle, 0, &msg);
+	ipm_send(ipm_handle, 0, 0, &msg);
 
 	return 0;
 }
@@ -175,7 +175,7 @@ int platform_init(void)
 		return -1;
 	}
 
-	ipm_register_callback(ipm_handle, platform_ipm_callback, NULL);
+	ipm_register_callback(ipm_handle, platform_ipm_callback, 0, NULL);
 
 	status = ipm_set_enabled(ipm_handle, 1);
 	if (status) {

--- a/samples/subsys/ipc/openamp_rsc_table/src/main_remote.c
+++ b/samples/subsys/ipc/openamp_rsc_table/src/main_remote.c
@@ -105,10 +105,16 @@ static void new_service_cb(struct rpmsg_device *rdev, const char *name,
 
 int mailbox_notify(void *priv, uint32_t id)
 {
+	struct ipm_msg msg;
+
 	ARG_UNUSED(priv);
 
+	msg.data = NULL;
+	msg.size = 0;
+	msg.id = 0;
+
 	LOG_DBG("%s: msg received\n", __func__);
-	ipm_send(ipm_handle, 0, id, NULL, 0);
+	ipm_send(ipm_handle, 0, &msg);
 
 	return 0;
 }

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -1239,6 +1239,9 @@ class Node:
             # e.g. foo-gpios still maps to #gpio-cells rather than
             # #foo-gpio-cells
             basename = "gpio"
+        elif prop.name == "mboxes":
+            # "mboxes" property will be associated to "#mbox-cells" and "mbox-names"
+            basename = "mbox"
         else:
             # Strip -s. We've already checked that the property names end in -s
             # in _check_prop_type_and_default().

--- a/soc/xtensa/intel_adsp/common/soc_mp.c
+++ b/soc/xtensa/intel_adsp/common/soc_mp.c
@@ -398,9 +398,13 @@ void arch_sched_ipi(void)
 	 */
 	const struct device *idcdev =
 		device_get_binding(DT_LABEL(DT_INST(0, intel_cavs_idc)));
+	struct ipm_msg msg;
 
-	ipm_send(idcdev, 0, IPM_CAVS_IDC_MSG_SCHED_IPI_ID,
-		 IPM_CAVS_IDC_MSG_SCHED_IPI_DATA, 0);
+	msg.data = IPM_CAVS_IDC_MSG_SCHED_IPI_DATA;
+	msg.size = 0;
+	msg.id = IPM_CAVS_IDC_MSG_SCHED_IPI_ID;
+
+	ipm_send(idcdev, 0, &msg);
 #endif
 }
 

--- a/soc/xtensa/intel_adsp/common/soc_mp.c
+++ b/soc/xtensa/intel_adsp/common/soc_mp.c
@@ -404,7 +404,7 @@ void arch_sched_ipi(void)
 	msg.size = 0;
 	msg.id = IPM_CAVS_IDC_MSG_SCHED_IPI_ID;
 
-	ipm_send(idcdev, 0, &msg);
+	ipm_send(idcdev, 0, 0, &msg);
 #endif
 }
 

--- a/soc/xtensa/intel_s1000/soc_mp.c
+++ b/soc/xtensa/intel_s1000/soc_mp.c
@@ -197,9 +197,14 @@ void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
 FUNC_ALIAS(soc_sched_ipi, arch_sched_ipi, void);
 void soc_sched_ipi(void)
 {
+	struct ipm_msg msg;
+
+	msg.data = IPM_CAVS_IDC_MSG_SCHED_IPI_DATA;
+	msg.size = 0;
+	msg.id = IPM_CAVS_IDC_MSG_SCHED_IPI_ID;
+
 	if (likely(idc != NULL)) {
-		ipm_send(idc, 0, IPM_CAVS_IDC_MSG_SCHED_IPI_ID,
-			 IPM_CAVS_IDC_MSG_SCHED_IPI_DATA, 0);
+		ipm_send(idc, 0, &msg);
 	}
 }
 #endif

--- a/soc/xtensa/intel_s1000/soc_mp.c
+++ b/soc/xtensa/intel_s1000/soc_mp.c
@@ -204,7 +204,7 @@ void soc_sched_ipi(void)
 	msg.id = IPM_CAVS_IDC_MSG_SCHED_IPI_ID;
 
 	if (likely(idc != NULL)) {
-		ipm_send(idc, 0, &msg);
+		ipm_send(idc, 0, 0, &msg);
 	}
 }
 #endif

--- a/subsys/ipc/rpmsg_service/rpmsg_backend.c
+++ b/subsys/ipc/rpmsg_service/rpmsg_backend.c
@@ -128,7 +128,7 @@ static void virtio_notify(struct virtqueue *vq)
 	msg.size = 0;
 	msg.id = 0;
 
-	status = ipm_send(ipm_tx_handle, 0, &msg);
+	status = ipm_send(ipm_tx_handle, 0, 0, &msg);
 #elif defined(CONFIG_RPMSG_SERVICE_SINGLE_IPM_SUPPORT)
 
 #if defined(CONFIG_SOC_MPS2_AN521) || \
@@ -139,7 +139,7 @@ static void virtio_notify(struct virtqueue *vq)
 	msg.size = 1;
 	msg.id = current_core ? 0 : 1;
 
-	status = ipm_send(ipm_handle, 0, &msg);
+	status = ipm_send(ipm_handle, 0, 0, &msg);
 #else
 	uint32_t dummy_data = 0x55005500; /* Some data must be provided */
 
@@ -147,7 +147,7 @@ static void virtio_notify(struct virtqueue *vq)
 	msg.size = sizeof(dummy_data);
 	msg.id = 0;
 
-	status = ipm_send(ipm_handle, 0, &msg);
+	status = ipm_send(ipm_handle, 0, 0, &msg);
 #endif /* #if defined(CONFIG_SOC_MPS2_AN521) */
 
 #endif
@@ -241,7 +241,7 @@ int rpmsg_backend_init(struct metal_io_region **io, struct virtio_device *vdev)
 		return -ENODEV;
 	}
 
-	ipm_register_callback(ipm_rx_handle, ipm_callback, NULL);
+	ipm_register_callback(ipm_rx_handle, ipm_callback, 0, NULL);
 
 	err = ipm_set_enabled(ipm_rx_handle, 1);
 	if (err != 0) {
@@ -257,7 +257,7 @@ int rpmsg_backend_init(struct metal_io_region **io, struct virtio_device *vdev)
 		return -ENODEV;
 	}
 
-	ipm_register_callback(ipm_handle, ipm_callback, NULL);
+	ipm_register_callback(ipm_handle, ipm_callback, 0, NULL);
 
 	err = ipm_set_enabled(ipm_handle, 1);
 	if (err != 0) {

--- a/subsys/ipc/rpmsg_service/rpmsg_backend.c
+++ b/subsys/ipc/rpmsg_service/rpmsg_backend.c
@@ -121,20 +121,33 @@ static void virtio_set_features(struct virtio_device *vdev,
 static void virtio_notify(struct virtqueue *vq)
 {
 	int status;
+	struct ipm_msg msg;
 
 #if defined(CONFIG_RPMSG_SERVICE_DUAL_IPM_SUPPORT)
-	status = ipm_send(ipm_tx_handle, 0, 0, NULL, 0);
+	msg.data = NULL;
+	msg.size = 0;
+	msg.id = 0;
+
+	status = ipm_send(ipm_tx_handle, 0, &msg);
 #elif defined(CONFIG_RPMSG_SERVICE_SINGLE_IPM_SUPPORT)
 
 #if defined(CONFIG_SOC_MPS2_AN521) || \
 	defined(CONFIG_SOC_V2M_MUSCA_B1)
 	uint32_t current_core = sse_200_platform_get_cpu_id();
 
-	status = ipm_send(ipm_handle, 0, current_core ? 0 : 1, 0, 1);
+	msg.data = (const void *) 0;
+	msg.size = 1;
+	msg.id = current_core ? 0 : 1;
+
+	status = ipm_send(ipm_handle, 0, &msg);
 #else
 	uint32_t dummy_data = 0x55005500; /* Some data must be provided */
 
-	status = ipm_send(ipm_handle, 0, 0, &dummy_data, sizeof(dummy_data));
+	msg.data = &dummy_data;
+	msg.size = sizeof(dummy_data);
+	msg.id = 0;
+
+	status = ipm_send(ipm_handle, 0, &msg);
 #endif /* #if defined(CONFIG_SOC_MPS2_AN521) */
 
 #endif

--- a/tests/drivers/ipm/src/ipm_dummy.c
+++ b/tests/drivers/ipm/src/ipm_dummy.c
@@ -44,8 +44,7 @@ static void ipm_dummy_isr(const void *data)
 
 /* IPM API functions for the dummy driver */
 
-static int ipm_dummy_send(const struct device *d, int wait, uint32_t id,
-			  const void *data, int size)
+static int ipm_dummy_send(const struct device *d, int wait, struct ipm_msg *msg)
 {
 	struct ipm_dummy_driver_data *driver_data;
 	volatile uint8_t *datareg;
@@ -53,7 +52,7 @@ static int ipm_dummy_send(const struct device *d, int wait, uint32_t id,
 	int i;
 
 	driver_data = d->data;
-	if (size > ipm_max_data_size_get(d)) {
+	if (msg->size > ipm_max_data_size_get(d)) {
 		return -EMSGSIZE;
 	}
 
@@ -61,13 +60,13 @@ static int ipm_dummy_send(const struct device *d, int wait, uint32_t id,
 		return -EBUSY;
 	}
 
-	data8 = (const uint8_t *)data;
+	data8 = (const uint8_t *)msg->data;
 	datareg = (volatile uint8_t *)driver_data->regs.data;
 
-	for (i = 0; i < size; ++i) {
+	for (i = 0; i < msg->size; ++i) {
 		datareg[i] = data8[i];
 	}
-	driver_data->regs.id = id;
+	driver_data->regs.id = msg->id;
 	driver_data->regs.busy = 1U;
 
 	irq_offload(ipm_dummy_isr, (const void *)d);

--- a/tests/drivers/ipm/src/ipm_dummy.h
+++ b/tests/drivers/ipm/src/ipm_dummy.h
@@ -12,6 +12,8 @@
 #include <device.h>
 #include <drivers/ipm.h>
 
+#define NUM_CHANNELS 2
+
 /* Arbitrary */
 #define DUMMY_IPM_DATA_WORDS    4
 
@@ -23,9 +25,10 @@ struct ipm_dummy_regs {
 };
 
 struct ipm_dummy_driver_data {
-	ipm_callback_t cb;
+	ipm_callback_t cb[NUM_CHANNELS];
 	void *cb_context;
 	volatile struct ipm_dummy_regs regs;
+	uint32_t channel;
 };
 
 int ipm_dummy_init(const struct device *d);

--- a/tests/drivers/ipm/src/main.c
+++ b/tests/drivers/ipm/src/main.c
@@ -78,6 +78,7 @@ void main(void)
 {
 	int rv, i;
 	const struct device *ipm;
+	struct ipm_msg msg;
 
 	TC_SUITE_START("test_ipm");
 	TC_START(__func__);
@@ -86,8 +87,13 @@ void main(void)
 	/* Try sending a raw string to the IPM device to show that the
 	 * receiver works
 	 */
+	msg.data = NULL;
+	msg.size = 0;
+
 	for (i = 0; i < strlen(thestr); i++) {
-		ipm_send(ipm, 1, thestr[i], NULL, 0);
+		msg.id = thestr[i];
+
+		ipm_send(ipm, 1, &msg);
 	}
 
 	/* Now do this through printf() to exercise the sender */

--- a/tests/drivers/ipm/src/main.c
+++ b/tests/drivers/ipm/src/main.c
@@ -74,6 +74,13 @@ DEVICE_DEFINE(ipm_console_recv0, "ipm_recv0", ipm_console_receiver_init,
 
 static const char thestr[] = "everything is awesome\n";
 
+static void ipm_callback_channel1(const struct device *ipmdev, void *user_data,
+				  uint32_t id, volatile void *data)
+{
+	/* poor's man toupper() */
+	printk("%c", id - 32);
+}
+
 void main(void)
 {
 	int rv, i;
@@ -93,7 +100,7 @@ void main(void)
 	for (i = 0; i < strlen(thestr); i++) {
 		msg.id = thestr[i];
 
-		ipm_send(ipm, 1, &msg);
+		ipm_send(ipm, 1, 0, &msg);
 	}
 
 	/* Now do this through printf() to exercise the sender */
@@ -109,6 +116,16 @@ void main(void)
 	/* XXX how to tell if something was actually printed out for
 	 * automation purposes?
 	 */
+
+	ipm_register_callback(ipm, ipm_callback_channel1, 1, NULL);
+
+	for (i = 0; i < strlen(thestr) - 1; i++) {
+		msg.id = thestr[i];
+
+		/* EVERYTHING IS AWESOME */
+		ipm_send(ipm, 1, 1, &msg);
+	}
+	printk("\n");
 
 	rv = TC_PASS;
 	TC_END_RESULT(rv);

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -217,6 +217,20 @@
 			};
 		};
 
+		test_ipm: ipm {
+			label = "TEST_IPM";
+			compatible = "vnd,ipm";
+			#mbox-cells = <1>;
+			status = "okay";
+		};
+
+		test_ipm_zero_cell: ipm_zero_cell {
+			label = "TEST_IPM_ZERO_CELL";
+			compatible = "vnd,ipm-zero-cell";
+			#mbox-cells = <0>;
+			status = "okay";
+		};
+
 		test_spi: spi@33334444 {
 			#address-cells = < 1 >;
 			#size-cells = < 0 >;
@@ -320,6 +334,8 @@
 			pinctrl-1 = <&test_pincfg_c &test_pincfg_d>;
 			pinctrl-2 = <&test_pincfg_d>;
 			pinctrl-names = "default", "sleep", "f.o.o2";
+			mboxes = <&test_ipm 1>, <&test_ipm 2>, <&test_ipm_zero_cell>;
+			mbox-names = "tx", "rx", "x";
 		};
 
 		/* there should only be one of these */

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -37,6 +37,7 @@
 #include <devicetree.h>
 #include <device.h>
 #include <drivers/gpio.h>
+#include <drivers/ipm.h>
 
 #define TEST_CHILDREN	DT_PATH(test, test_children)
 #define TEST_DEADBEEF	DT_PATH(test, gpio_deadbeef)
@@ -2078,6 +2079,39 @@ static void test_pinctrl(void)
 	zassert_equal(DT_INST_PINCTRL_HAS_NAME(0, f_o_o2), 0, "");
 }
 
+static void test_ipm(void)
+{
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT vnd_adc_temp_sensor
+
+	const struct ipm_dt_spec spec_tx = IPM_DT_SPEC_GET(TEST_TEMP, tx);
+	const struct ipm_dt_spec spec_rx = IPM_DT_SPEC_GET(TEST_TEMP, rx);
+
+	zassert_equal(spec_tx.channel, 1, "");
+	zassert_equal(spec_rx.channel, 2, "");
+
+	zassert_equal(IPM_DT_CHANNEL_BY_NAME(TEST_TEMP, tx), 1, "");
+	zassert_equal(IPM_DT_CHANNEL_BY_NAME(TEST_TEMP, rx), 2, "");
+
+	zassert_true(DT_SAME_NODE(IPM_DT_CTLR_BY_NAME(TEST_TEMP, tx),
+				  DT_NODELABEL(test_ipm)), "");
+	zassert_true(DT_SAME_NODE(IPM_DT_CTLR_BY_NAME(TEST_TEMP, rx),
+				  DT_NODELABEL(test_ipm)), "");
+
+	zassert_equal(IPM_DT_CHANNEL_BY_NAME(TEST_TEMP, tx), 1, "");
+	zassert_equal(IPM_DT_CHANNEL_BY_NAME(TEST_TEMP, rx), 2, "");
+
+	const struct ipm_dt_spec spec_zero_cell = IPM_DT_SPEC_GET(TEST_TEMP, x);
+
+	zassert_equal(spec_zero_cell.channel, 0, "");
+
+	zassert_equal(IPM_DT_CHANNEL_BY_NAME(TEST_TEMP, x), 0, "");
+
+	zassert_true(DT_SAME_NODE(IPM_DT_CTLR_BY_NAME(TEST_TEMP, x),
+				  DT_NODELABEL(test_ipm_zero_cell)), "");
+
+}
+
 void test_main(void)
 {
 	ztest_test_suite(devicetree_api,
@@ -2120,7 +2154,8 @@ void test_main(void)
 			 ztest_unit_test(test_path),
 			 ztest_unit_test(test_node_name),
 			 ztest_unit_test(test_same_node),
-			 ztest_unit_test(test_pinctrl)
+			 ztest_unit_test(test_pinctrl),
+			 ztest_unit_test(test_ipm)
 		);
 	ztest_run_test_suite(devicetree_api);
 }


### PR DESCRIPTION
DNM before #38616 and #39035 are in.

One limitation of the current IPM API is that it is assuming that the hardware is only exporting one single channel through which the data can be sent or signalling can happen.
    
If the hardware supports multiple channels, the device must be instantiated (possibly in the DT) several times, one for each channel to be able to send data through multiple channels using the same hw peripheral. Also in the current API only one callback can be registered, that means that only one driver is controlling all the signalling happening on all the channels.
 
With this patch we introduce the possibility to send data through multiple channels and register a callback on different channels also when the IPM device has a single instance in the DT. The goal is giving the possibility to several drivers to send data through different channels and register a callback on a specific channel.
    
For sending data a new `channel` parameter has been added to the `ipm_send()` function, and the same parameter has been added to the `ipm_register_callback()` function.
    
Using this new parameter the driver can use `ipm_send()` to send data through a specific channel, and they can use `ipm_register_callback()` to register a callback on that channel, the callback will be called when new data will be received on that channel.
    
Two more functions are also added to the API: `ipm_max_channels_get()` to get the maximum number of channels and `ipm_configure_channel()` to configure the channel at the hardware level.
    
Three new DT helpers are also added:
- `DT_IPMS_CTLR_BY_NAME`
- `DT_IPMS_CHANNEL_BY_NAME`
- `IPM_DT_SPEC_GET`
    
to be able to easily retrieve device and TX / RX channels from DT.
    
So for example in the DT we can have:
 ``` 
        ipm: ipm@2a000 {
                compatible = "vnd,ipm";
                #mbox-cells = <1>;
                ...
        };

        ipm_zero: ipm@3a000 {
                compatible = "vnd,ipm";
                #mbox-cells = <0>;
                ...
        };
    
        ipm-user@0 {
                compatible = "some,ipm-user";
                mboxes = <&ipm 9>, <&ipm 8>;
                mbox-names =  "tx", "rx";
                ...
        };
        ipm-user@1 {
                compatible = "other,ipm-user";
                mboxes = <&ipm 10>, <&ipm 11>, <&ipm_zero>;
                mbox-names =  "tx", "rx", "single";
                ...
        };
 ```

`ipm-user@0` is using the channel `9` for TX and channel `8` for RX. It can register a callback that will be called when new data is received by the IPM device on channel `8`. At the same time `ipm-user@1` driver is sending data through channel `10`, and it is interested in all the messages received on the channel `11`, for this reason it will be registering a callback on this channel.
    
In the code we use the DT helpers to retrieve all the parameters, for example:
```   
        struct device *tx = DEVICE_DT_GET(DT_IPMS_CTLR_BY_NAME(..., tx));
        struct device *rx = DEVICE_DT_GET(DT_IPMS_CTLR_BY_NAME(..., rx));
    
        uint32_t tx_channel = DT_IPMS_CHANNEL_BY_NAME(..., tx));
        uint32_t tx_channel = DT_IPMS_CHANNEL_BY_NAME(..., rx));
``` 
or we can use:
```
        struct ipm_dt_spec ipm = IPM_DT_SPEC_GET(..., tx, rx);

        ipm_send_dt(ipm, 0, msg);
        ...
```
Tests are modified to test all the newly introduced features.