### PR TITLE
Bluetooth: Audio: Media - writes to writeable object IDs

### DIFF
--- a/include/bluetooth/mcc.h
+++ b/include/bluetooth/mcc.h
@@ -1,5 +1,5 @@
 /** @file
- *  @brief Bluetooth Media Control Client interface
+ *  @brief Bluetooth Media Control Client (MCC) interface
  *
  *  Updated to the Media Control Profile specification version d09r01
  */
@@ -26,282 +26,282 @@ extern "C" {
 
 /**** Callback functions ******************************************************/
 
-/** @brief Callback function for mcc_discover_mcs
+/** @brief Callback function for bt_mcc_discover_mcs()
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  */
 typedef void (*bt_mcc_discover_mcs_cb)(struct bt_conn *conn, int err);
 
-/** @brief Callback function for mcc_read_player_name
+/** @brief Callback function for bt_mcc_read_player_name()
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param name          Player name, max length is PLAYER_NAME_MAX (mpl.h)
  */
 typedef void (*bt_mcc_player_name_read_cb)(struct bt_conn *conn, int err,
-					     const char *name);
+					   const char *name);
 
 #ifdef CONFIG_BT_OTC
-/** @brief Callback function for mcc_read_icon_obj_id
+/** @brief Callback function for bt_mcc_read_icon_obj_id()
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param icon_id       The ID of the Icon Object. This is a UINT48 in a uint64_t
  */
 typedef void (*bt_mcc_icon_obj_id_read_cb)(struct bt_conn *conn, int err,
-					     uint64_t id);
+					   uint64_t id);
 #endif /* CONFIG_BT_OTC */
 
-/** @brief Callback function for mcc_read_icon_url
+/** @brief Callback function for bt_mcc_read_icon_url()
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param icon_url      The URL of the Icon
  */
 typedef void (*bt_mcc_icon_url_read_cb)(struct bt_conn *conn, int err,
-					  const char *icon_url);
+					const char *icon_url);
 
-/** @brief Callback function for track_changed
+/** @brief Callback function for track changed notifications
  *
  * The track changed characteristic is a special case.  It can not be
  * read or written, it can only be notified.
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  */
 typedef void (*bt_mcc_track_changed_ntf_cb)(struct bt_conn *conn, int err);
 
 
-/** @brief Callback function for mcc_read_track_title
+/** @brief Callback function for bt_mcc_read_track_title()
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param title         The title of the track
  */
 typedef void (*bt_mcc_track_title_read_cb)(struct bt_conn *conn, int err,
-					     const char *title);
+					   const char *title);
 
-/** @brief Callback function for mcc_read_track_dur
+/** @brief Callback function for bt_mcc_read_track_dur()
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param dur           The duration of the track
  */
 typedef void (*bt_mcc_track_dur_read_cb)(struct bt_conn *conn, int err,
-					   int32_t dur);
+					 int32_t dur);
 
-/** @brief Callback function for mcc_read_track_position
+/** @brief Callback function for bt_mcc_read_track_position()
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param pos           The Track Position
  */
 typedef void (*bt_mcc_track_position_read_cb)(struct bt_conn *conn, int err,
-						int32_t pos);
+					      int32_t pos);
 
-/** @brief Callback function for mcc_set_track_position
+/** @brief Callback function for bt_mcc_set_track_position()
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param pos           The Track Position written (or attempted to write)
  */
 typedef void (*bt_mcc_track_position_set_cb)(struct bt_conn *conn, int err,
-					       int32_t pos);
+					     int32_t pos);
 
-/** @brief Callback function for mcc_read_playback_speed
+/** @brief Callback function for bt_mcc_read_playback_speed()
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param speed         The Playback Speed
  */
 typedef void (*bt_mcc_playback_speed_read_cb)(struct bt_conn *conn, int err,
-						int8_t speed);
+					      int8_t speed);
 
-/** @brief Callback function for mcc_set_playback_speed
+/** @brief Callback function for bt_mcc_set_playback_speed()
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param speed         The Playback Speed written (or attempted to write)
  */
 typedef void (*bt_mcc_playback_speed_set_cb)(struct bt_conn *conn, int err,
-					       int8_t speed);
+					     int8_t speed);
 
-/** @brief Callback function for mcc_read_seeking_speed
+/** @brief Callback function for bt_mcc_read_seeking_speed()
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param speed         The Seeking Speed
  */
 typedef void (*bt_mcc_seeking_speed_read_cb)(struct bt_conn *conn, int err,
-					       int8_t speed);
+					     int8_t speed);
 
 #ifdef CONFIG_BT_OTC
-/** @brief Callback function for mcc_segments_obj_read
+/** @brief Callback function for bt_mcc_read_segments_obj_id()
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param id            The Track Segments Object ID (UINT48)
  */
 typedef void (*bt_mcc_segments_obj_id_read_cb)(struct bt_conn *conn,
-						 int err, uint64_t id);
+					       int err, uint64_t id);
 
-/** @brief Callback function for mcc_current_track_obj_id_read
+/** @brief Callback function for bt_mcc_read_current_track_obj_id()
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param id            The Current Track Object ID (UINT48)
  */
 typedef void (*bt_mcc_current_track_obj_id_read_cb)(struct bt_conn *conn,
-						      int err, uint64_t id);
+						    int err, uint64_t id);
 
-/** @brief Callback function for mcc_set_current_track_obj_id
+/** @brief Callback function for bt_mcc_set_current_track_obj_id()
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param id            The Object ID (UINT48) written (or attempted to write)
  */
 typedef void (*bt_mcc_current_track_obj_id_set_cb)(struct bt_conn *conn, int err,
 						   uint64_t id);
 
-/** @brief Callback function for mcc_next_track_obj_id_obj_read
+/** @brief Callback function for bt_mcc_read_next_track_obj_id_obj()
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param id            The Next Track Object ID (UINT48)
  */
 typedef void (*bt_mcc_next_track_obj_id_read_cb)(struct bt_conn *conn,
-						   int err, uint64_t id);
+						 int err, uint64_t id);
 
-/** @brief Callback function for mcc_set_next_track_obj_id
+/** @brief Callback function for bt_mcc_set_next_track_obj_id()
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param id            The Object ID (UINT48) written (or attempted to write)
  */
 typedef void (*bt_mcc_next_track_obj_id_set_cb)(struct bt_conn *conn, int err,
 						uint64_t id);
 
-/** @brief Callback function for mcc_current_group_obj_id_read
+/** @brief Callback function for bt_mcc_read_current_group_obj_id()
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param id            The Current Group Object ID (UINT48)
  */
 typedef void (*bt_mcc_current_group_obj_id_read_cb)(struct bt_conn *conn,
-						      int err, uint64_t id);
+						    int err, uint64_t id);
 
-/** @brief Callback function for mcc_set_current_group_obj_id
+/** @brief Callback function for bt_mcc_set_current_group_obj_id()
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param id            The Object ID (UINT48) written (or attempted to write)
  */
 typedef void (*bt_mcc_current_group_obj_id_set_cb)(struct bt_conn *conn, int err,
 						   uint64_t obj_id);
 
-/** @brief Callback function for mcc_parent_group_obj_id_read
+/** @brief Callback function for bt_mcc_read_parent_group_obj_id()
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param id            The Parent Group Object ID (UINT48)
  */
 typedef void (*bt_mcc_parent_group_obj_id_read_cb)(struct bt_conn *conn,
-						     int err, uint64_t id);
+						   int err, uint64_t id);
 #endif /* CONFIG_BT_OTC */
 
-/** @brief Callback function for playing_order_read
+/** @brief Callback function for bt_mcc_read_playing_order()
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param order         The playback order
  */
 typedef void (*bt_mcc_playing_order_read_cb)(struct bt_conn *conn, int err,
-					       uint8_t order);
+					     uint8_t order);
 
-/** @brief Callback function for mcc_set_playing_order
+/** @brief Callback function for bt_mcc_set_playing_order()
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param order         The Playing Order written (or attempted to write)
  */
 typedef void (*bt_mcc_playing_order_set_cb)(struct bt_conn *conn, int err,
-					      uint8_t order);
+					    uint8_t order);
 
-/** @brief Callback function for playing_orders_supported_read
+/** @brief Callback function for bt_mcc_read_playing_orders_supported()
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param orders        The playback orders supported (bitmap)
  */
 typedef void (*bt_mcc_playing_orders_supported_read_cb)(struct bt_conn *conn,
-						     int err, uint16_t orders);
+							int err, uint16_t orders);
 
-/** @brief Callback function for media_state_read
+/** @brief Callback function for bt_mcc_read_media_state()
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param state         The Media State
  */
 typedef void (*bt_mcc_media_state_read_cb)(struct bt_conn *conn, int err,
-					     uint8_t state);
+					   uint8_t state);
 
-/** @brief Callback function for mcc_send_cmd
+/** @brief Callback function for bt_mcc_send_cmd()
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param cmd           The command sent
  */
 typedef void (*bt_mcc_cmd_send_cb)(struct bt_conn *conn, int err,
-				     struct mpl_cmd cmd);
+				   struct mpl_cmd cmd);
 
 /** @brief Callback function for command notifications
  *
  * Notifications for commands use a different parameter structure
  * than what is used for sending commands
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param ntf           The command notification
  */
 typedef void (*bt_mcc_cmd_ntf_cb)(struct bt_conn *conn, int err,
-				    struct mpl_cmd_ntf ntf);
+				  struct mpl_cmd_ntf ntf);
 
-/** @brief Callback function for mcc_read_opcodes_supported
+/** @brief Callback function for bt_mcc_read_opcodes_supported()
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param opcodes       The supported opcodes
  */
 typedef void (*bt_mcc_opcodes_supported_read_cb)(struct bt_conn *conn,
-						   int err, uint32_t opcodes);
+						 int err, uint32_t opcodes);
 
 #ifdef CONFIG_BT_OTC
-/** @brief Callback function for mcc_send_search
+/** @brief Callback function for bt_mcc_send_search()
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param search        The search written (or attempted to write)
  */
 typedef void (*bt_mcc_search_send_cb)(struct bt_conn *conn, int err,
-					struct mpl_search search);
+				      struct mpl_search search);
 
 /** @brief Callback function for search notifications
  *
  * Notifications for the search control points have a different parameter
  * structure than callbacks for search sends
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param ntf           The search notification
  */
 typedef void (*bt_mcc_search_ntf_cb)(struct bt_conn *conn, int err,
-				       uint8_t result_code);
+				     uint8_t result_code);
 
-/** @brief Callback function for mcc_search_results_obj_id_read
+/** @brief Callback function for bt_mcc_read_search_results_obj_id()
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param id            The Search Results Object ID (UINT48)
  *
  * Note that the Search Results Object ID value may be zero, in case the
@@ -309,13 +309,13 @@ typedef void (*bt_mcc_search_ntf_cb)(struct bt_conn *conn, int err,
  * there has not been a successful search.)
  */
 typedef void (*bt_mcc_search_results_obj_id_read_cb)(struct bt_conn *conn,
-						       int err, uint64_t id);
+						     int err, uint64_t id);
 #endif /* CONFIG_BT_OTC */
 
-/** @brief Callback function for mcc_read_content_control_id
+/** @brief Callback function for bt_mcc_read_content_control_id()
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param ccid          The Content Control ID
  */
 typedef void (*bt_mcc_content_control_id_read_cb)(struct bt_conn *conn,
@@ -325,83 +325,83 @@ typedef void (*bt_mcc_content_control_id_read_cb)(struct bt_conn *conn,
 
 /** @brief Callback function for object selected
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  */
 typedef void (*bt_mcc_otc_obj_selected_cb)(struct bt_conn *conn, int err);
 
 /** @brief Callback function for object metadata
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, errno on fail
  */
 typedef void (*bt_mcc_otc_obj_metadata_cb)(struct bt_conn *conn, int err);
 
-/** @brief Callback function for bt_mcc_otc_read_icon_object
+/** @brief Callback function for bt_mcc_otc_read_icon_object()
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param buf           Buffer containing the object contents
  *
  * If err is EMSGSIZE, the object contents have been truncated.
  */
 typedef void (*bt_mcc_otc_read_icon_object_cb)(struct bt_conn *conn, int err,
-						 struct net_buf_simple *buf);
+					       struct net_buf_simple *buf);
 
-/** @brief Callback function for bt_mcc_otc_read_track_segments_object
+/** @brief Callback function for bt_mcc_otc_read_track_segments_object()
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param buf           Buffer containing the object contents
  *
  * If err is EMSGSIZE, the object contents have been truncated.
  */
 typedef void (*bt_mcc_otc_read_track_segments_object_cb)(struct bt_conn *conn, int err,
-							   struct net_buf_simple *buf);
+							 struct net_buf_simple *buf);
 
-/** @brief Callback function for bt_mcc_otc_read_current_track_object
+/** @brief Callback function for bt_mcc_otc_read_current_track_object()
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param buf           Buffer containing the object contents
  *
  * If err is EMSGSIZE, the object contents have been truncated.
  */
 typedef void (*bt_mcc_otc_read_current_track_object_cb)(struct bt_conn *conn, int err,
-							  struct net_buf_simple *buf);
+							struct net_buf_simple *buf);
 
-/** @brief Callback function for bt_mcc_otc_read_next_track_object
+/** @brief Callback function for bt_mcc_otc_read_next_track_object()
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param buf           Buffer containing the object contents
  *
  * If err is EMSGSIZE, the object contents have been truncated.
  */
 typedef void (*bt_mcc_otc_read_next_track_object_cb)(struct bt_conn *conn, int err,
-						       struct net_buf_simple *buf);
+						     struct net_buf_simple *buf);
 
-/** @brief Callback function for bt_mcc_otc_read_current_group_object
+/** @brief Callback function for bt_mcc_otc_read_current_group_object()
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param buf           Buffer containing the object contents
  *
  * If err is EMSGSIZE, the object contents have been truncated.
  */
 typedef void (*bt_mcc_otc_read_current_group_object_cb)(struct bt_conn *conn, int err,
-							  struct net_buf_simple *buf);
+							struct net_buf_simple *buf);
 
-/** @brief Callback function for bt_mcc_otc_read_parent_group_object
+/** @brief Callback function for bt_mcc_otc_read_parent_group_object()
  *
- * @param conn          The connection that was used to initialise MCC
- * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param buf           Buffer containing the object contents
  *
  * If err is EMSGSIZE, the object contents have been truncated.
  */
 typedef void (*bt_mcc_otc_read_parent_group_object_cb)(struct bt_conn *conn, int err,
-							  struct net_buf_simple *buf);
+						       struct net_buf_simple *buf);
 
 #endif /* CONFIG_BT_OTC */
 
@@ -471,8 +471,8 @@ int bt_mcc_init(struct bt_mcc_cb *cb);
  * Discover Media Control Service on the server given by the connection
  * Optionally subscribe to notifications.
  *
- * Shall be called once after initialization and before using other MCC
- * functionality.
+ * Shall be called once after initialization and before using other
+ * media control client functionality.
  *
  * @param conn        The connection on which to do MCS discovery
  * @param subscribe   Whether to subscribe to notifications

--- a/include/bluetooth/mcc.h
+++ b/include/bluetooth/mcc.h
@@ -155,6 +155,15 @@ typedef void (*bt_mcc_segments_obj_id_read_cb)(struct bt_conn *conn,
 typedef void (*bt_mcc_current_track_obj_id_read_cb)(struct bt_conn *conn,
 						      int err, uint64_t id);
 
+/** @brief Callback function for mcc_set_current_track_obj_id
+ *
+ * @param conn          The connection that was used to initialise MCC
+ * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param id            The Object ID (UINT48) written (or attempted to write)
+ */
+typedef void (*bt_mcc_current_track_obj_id_set_cb)(struct bt_conn *conn, int err,
+						   uint64_t id);
+
 /** @brief Callback function for mcc_next_track_obj_id_obj_read
  *
  * @param conn          The connection that was used to initialise MCC
@@ -164,6 +173,15 @@ typedef void (*bt_mcc_current_track_obj_id_read_cb)(struct bt_conn *conn,
 typedef void (*bt_mcc_next_track_obj_id_read_cb)(struct bt_conn *conn,
 						   int err, uint64_t id);
 
+/** @brief Callback function for mcc_set_next_track_obj_id
+ *
+ * @param conn          The connection that was used to initialise MCC
+ * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param id            The Object ID (UINT48) written (or attempted to write)
+ */
+typedef void (*bt_mcc_next_track_obj_id_set_cb)(struct bt_conn *conn, int err,
+						uint64_t id);
+
 /** @brief Callback function for mcc_current_group_obj_id_read
  *
  * @param conn          The connection that was used to initialise MCC
@@ -172,6 +190,15 @@ typedef void (*bt_mcc_next_track_obj_id_read_cb)(struct bt_conn *conn,
  */
 typedef void (*bt_mcc_current_group_obj_id_read_cb)(struct bt_conn *conn,
 						      int err, uint64_t id);
+
+/** @brief Callback function for mcc_set_current_group_obj_id
+ *
+ * @param conn          The connection that was used to initialise MCC
+ * @param err           Error value. 0 on success, GATT error or ERRNO on fail
+ * @param id            The Object ID (UINT48) written (or attempted to write)
+ */
+typedef void (*bt_mcc_current_group_obj_id_set_cb)(struct bt_conn *conn, int err,
+						   uint64_t obj_id);
 
 /** @brief Callback function for mcc_parent_group_obj_id_read
  *
@@ -398,8 +425,11 @@ struct bt_mcc_cb {
 #ifdef CONFIG_BT_OTC
 	bt_mcc_segments_obj_id_read_cb           segments_obj_id_read;
 	bt_mcc_current_track_obj_id_read_cb      current_track_obj_id_read;
+	bt_mcc_current_track_obj_id_set_cb       current_track_obj_id_set;
 	bt_mcc_next_track_obj_id_read_cb         next_track_obj_id_read;
+	bt_mcc_next_track_obj_id_set_cb          next_track_obj_id_set;
 	bt_mcc_current_group_obj_id_read_cb      current_group_obj_id_read;
+	bt_mcc_current_group_obj_id_set_cb       current_group_obj_id_set;
 	bt_mcc_parent_group_obj_id_read_cb       parent_group_obj_id_read;
 #endif /* CONFIG_BT_OTC */
 	bt_mcc_playing_order_read_cb	         playing_order_read;
@@ -500,11 +530,35 @@ int bt_mcc_read_segments_obj_id(struct bt_conn *conn);
 /** @brief Read Current Track Object ID */
 int bt_mcc_read_current_track_obj_id(struct bt_conn *conn);
 
+/** @brief Set Current Track Object ID
+ *
+ * Set the Current Track to the the track given by the @p id parameter
+ *
+ * @param id   Object Transfer Service ID (UINT48) of the track to set as the current track
+ */
+int bt_mcc_set_current_track_obj_id(struct bt_conn *conn, uint64_t id);
+
 /** @brief Read Next Track Object ID */
 int bt_mcc_read_next_track_obj_id(struct bt_conn *conn);
 
+/** @brief Set Next Track Object ID
+ *
+ * Set the Next Track to the the track given by the @p id parameter
+ *
+ * @param id   Object Transfer Service ID (UINT48) of the track to set as the next track
+ */
+int bt_mcc_set_next_track_obj_id(struct bt_conn *conn, uint64_t id);
+
 /** @brief Read Current Group Object ID */
 int bt_mcc_read_current_group_obj_id(struct bt_conn *conn);
+
+/** @brief Set Current Group Object ID
+ *
+ * Set the Current Group to the the group given by the @p id parameter
+ *
+ * @param id   Object Transfer Service ID (UINT48) of the group to set as the current group
+ */
+int bt_mcc_set_current_group_obj_id(struct bt_conn *conn, uint64_t id);
 
 /** @brief Read Parent Group Object ID */
 int bt_mcc_read_parent_group_obj_id(struct bt_conn *conn);

--- a/subsys/bluetooth/host/audio/mcc.c
+++ b/subsys/bluetooth/host/audio/mcc.c
@@ -1463,7 +1463,7 @@ int bt_mcc_init(struct bt_mcc_cb *cb)
 int bt_mcc_discover_mcs(struct bt_conn *conn, bool subscribe)
 {
 	if (!conn) {
-		return -ENOTCONN;
+		return -EINVAL;
 	} else if (cur_mcs_inst) {
 		return -EBUSY;
 	}
@@ -1489,7 +1489,7 @@ int bt_mcc_read_player_name(struct bt_conn *conn)
 	int err;
 
 	if (!conn) {
-		return -ENOTCONN;
+		return -EINVAL;
 	}
 
 	if (!cur_mcs_inst->player_name_handle) {
@@ -1518,7 +1518,7 @@ int bt_mcc_read_icon_obj_id(struct bt_conn *conn)
 	int err;
 
 	if (!conn) {
-		return -ENOTCONN;
+		return -EINVAL;
 	}
 
 	if (!cur_mcs_inst->icon_obj_id_handle) {
@@ -1546,7 +1546,7 @@ int bt_mcc_read_icon_url(struct bt_conn *conn)
 	int err;
 
 	if (!conn) {
-		return -ENOTCONN;
+		return -EINVAL;
 	}
 
 	if (!cur_mcs_inst->icon_url_handle) {
@@ -1573,7 +1573,7 @@ int bt_mcc_read_track_title(struct bt_conn *conn)
 	int err;
 
 	if (!conn) {
-		return -ENOTCONN;
+		return -EINVAL;
 	}
 
 	if (!cur_mcs_inst->track_title_handle) {
@@ -1600,7 +1600,7 @@ int bt_mcc_read_track_dur(struct bt_conn *conn)
 	int err;
 
 	if (!conn) {
-		return -ENOTCONN;
+		return -EINVAL;
 	}
 
 	if (!cur_mcs_inst->track_dur_handle) {
@@ -1627,7 +1627,7 @@ int bt_mcc_read_track_position(struct bt_conn *conn)
 	int err;
 
 	if (!conn) {
-		return -ENOTCONN;
+		return -EINVAL;
 	}
 
 	if (!cur_mcs_inst->track_pos_handle) {
@@ -1654,7 +1654,7 @@ int bt_mcc_set_track_position(struct bt_conn *conn, int32_t pos)
 	int err;
 
 	if (!conn) {
-		return -ENOTCONN;
+		return -EINVAL;
 	}
 
 	if (!cur_mcs_inst->track_pos_handle) {
@@ -1687,7 +1687,7 @@ int bt_mcc_read_playback_speed(struct bt_conn *conn)
 	int err;
 
 	if (!conn) {
-		return -ENOTCONN;
+		return -EINVAL;
 	}
 
 	if (!cur_mcs_inst->playback_speed_handle) {
@@ -1714,7 +1714,7 @@ int bt_mcc_set_playback_speed(struct bt_conn *conn, int8_t speed)
 	int err;
 
 	if (!conn) {
-		return -ENOTCONN;
+		return -EINVAL;
 	}
 
 	if (!cur_mcs_inst->playback_speed_handle) {
@@ -1747,7 +1747,7 @@ int bt_mcc_read_seeking_speed(struct bt_conn *conn)
 	int err;
 
 	if (!conn) {
-		return -ENOTCONN;
+		return -EINVAL;
 	}
 
 	if (!cur_mcs_inst->seeking_speed_handle) {
@@ -1775,7 +1775,7 @@ int bt_mcc_read_segments_obj_id(struct bt_conn *conn)
 	int err;
 
 	if (!conn) {
-		return -ENOTCONN;
+		return -EINVAL;
 	}
 
 	if (!cur_mcs_inst->segments_obj_id_handle) {
@@ -1802,7 +1802,7 @@ int bt_mcc_read_current_track_obj_id(struct bt_conn *conn)
 	int err;
 
 	if (!conn) {
-		return -ENOTCONN;
+		return -EINVAL;
 	}
 
 	if (!cur_mcs_inst->current_track_obj_id_handle) {
@@ -1829,7 +1829,7 @@ int bt_mcc_set_current_track_obj_id(struct bt_conn *conn, uint64_t obj_id)
 	int err;
 
 	if (!conn) {
-		return -ENOTCONN;
+		return -EINVAL;
 	}
 
 	if (obj_id < 0x100) { /* TODO: Add limit define to ots.h, replace magic constant here */
@@ -1865,7 +1865,7 @@ int bt_mcc_read_next_track_obj_id(struct bt_conn *conn)
 	int err;
 
 	if (!conn) {
-		return -ENOTCONN;
+		return -EINVAL;
 	}
 
 	if (!cur_mcs_inst->next_track_obj_id_handle) {
@@ -1892,7 +1892,7 @@ int bt_mcc_set_next_track_obj_id(struct bt_conn *conn, uint64_t obj_id)
 	int err;
 
 	if (!conn) {
-		return -ENOTCONN;
+		return -EINVAL;
 	}
 
 	if (obj_id < 0x100) { /* TODO: Add limit define to ots.h, replace magic constant here */
@@ -1928,7 +1928,7 @@ int bt_mcc_read_current_group_obj_id(struct bt_conn *conn)
 	int err;
 
 	if (!conn) {
-		return -ENOTCONN;
+		return -EINVAL;
 	}
 
 	if (!cur_mcs_inst->current_group_obj_id_handle) {
@@ -1955,7 +1955,7 @@ int bt_mcc_set_current_group_obj_id(struct bt_conn *conn, uint64_t obj_id)
 	int err;
 
 	if (!conn) {
-		return -ENOTCONN;
+		return -EINVAL;
 	}
 
 	if (obj_id < 0x100) { /* TODO: Add limit define to ots.h, replace magic constant here */
@@ -1991,7 +1991,7 @@ int bt_mcc_read_parent_group_obj_id(struct bt_conn *conn)
 	int err;
 
 	if (!conn) {
-		return -ENOTCONN;
+		return -EINVAL;
 	}
 
 	if (!cur_mcs_inst->parent_group_obj_id_handle) {
@@ -2019,7 +2019,7 @@ int bt_mcc_read_playing_order(struct bt_conn *conn)
 	int err;
 
 	if (!conn) {
-		return -ENOTCONN;
+		return -EINVAL;
 	}
 
 	if (!cur_mcs_inst->playing_order_handle) {
@@ -2046,7 +2046,7 @@ int bt_mcc_set_playing_order(struct bt_conn *conn, uint8_t order)
 	int err;
 
 	if (!conn) {
-		return -ENOTCONN;
+		return -EINVAL;
 	}
 
 	if (!cur_mcs_inst->playing_order_handle) {
@@ -2079,7 +2079,7 @@ int bt_mcc_read_playing_orders_supported(struct bt_conn *conn)
 	int err;
 
 	if (!conn) {
-		return -ENOTCONN;
+		return -EINVAL;
 	}
 
 	if (!cur_mcs_inst->playing_orders_supported_handle) {
@@ -2106,7 +2106,7 @@ int bt_mcc_read_media_state(struct bt_conn *conn)
 	int err;
 
 	if (!conn) {
-		return -ENOTCONN;
+		return -EINVAL;
 	}
 
 	if (!cur_mcs_inst->media_state_handle) {
@@ -2134,7 +2134,7 @@ int bt_mcc_send_cmd(struct bt_conn *conn, struct mpl_cmd cmd)
 	int length = sizeof(cmd.opcode);
 
 	if (!conn) {
-		return -ENOTCONN;
+		return -EINVAL;
 	}
 
 	if (!cur_mcs_inst->cp_handle) {
@@ -2172,7 +2172,7 @@ int bt_mcc_read_opcodes_supported(struct bt_conn *conn)
 	int err;
 
 	if (!conn) {
-		return -ENOTCONN;
+		return -EINVAL;
 	}
 
 	if (!cur_mcs_inst->opcodes_supported_handle) {
@@ -2200,7 +2200,7 @@ int bt_mcc_send_search(struct bt_conn *conn, struct mpl_search search)
 	int err;
 
 	if (!conn) {
-		return -ENOTCONN;
+		return -EINVAL;
 	}
 
 	if (!cur_mcs_inst->scp_handle) {
@@ -2233,7 +2233,7 @@ int bt_mcc_read_search_results_obj_id(struct bt_conn *conn)
 	int err;
 
 	if (!conn) {
-		return -ENOTCONN;
+		return -EINVAL;
 	}
 
 	if (!cur_mcs_inst->search_results_obj_id_handle) {
@@ -2261,7 +2261,7 @@ int bt_mcc_read_content_control_id(struct bt_conn *conn)
 	int err;
 
 	if (!conn) {
-		return -ENOTCONN;
+		return -EINVAL;
 	}
 
 	if (!cur_mcs_inst->content_control_id_handle) {

--- a/subsys/bluetooth/host/audio/mpl_internal.h
+++ b/subsys/bluetooth/host/audio/mpl_internal.h
@@ -84,6 +84,12 @@ struct mpl_mediaplayer_t {
 #endif /* CONFIG_BT_OTS || CONFIG_BT_OTC */
 	uint8_t              content_ctrl_id;
 	struct media_proxy_pl_calls calls;
+
+	bool                        next_track_set; /* If next track explicitly set */
+	struct {
+		struct mpl_track_t  *track; /* The track explicitly set as next track */
+		struct mpl_group_t  *group; /* The group of the set track */
+	} next;
 };
 
 


### PR DESCRIPTION
Implement missing functions to do, and handle, writes to writable object IDs in the media control service.

Client functions to do the writes.
Shell functions corresponding to this
Proper handling of writes in the mediaplayer
BabbleSim tests