### PR TITLE
Bluetooth: Object transfer service object ID mask define

### DIFF
--- a/include/bluetooth/services/ots.h
+++ b/include/bluetooth/services/ots.h
@@ -31,6 +31,15 @@ extern "C" {
 /** @brief Size of OTS object ID (in bytes). */
 #define BT_OTS_OBJ_ID_SIZE 6
 
+/** @brief Minimum allowed value for object ID (except ID for directory listing) */
+#define BT_OTS_OBJ_ID_MIN 0x000000000100
+
+/** @brief Maximum allowed value for object ID (except ID for directory listing) */
+#define BT_OTS_OBJ_ID_MAX 0xFFFFFFFFFFFF
+
+/** @brief ID of the Directory Listing Object */
+#define OTS_OBJ_ID_DIR_LIST     0x000000000000
+
 /** @brief Mask for OTS object IDs, preserving the 48 bits */
 #define BT_OTS_OBJ_ID_MASK BIT64_MASK(48)
 

--- a/include/bluetooth/services/ots.h
+++ b/include/bluetooth/services/ots.h
@@ -31,6 +31,9 @@ extern "C" {
 /** @brief Size of OTS object ID (in bytes). */
 #define BT_OTS_OBJ_ID_SIZE 6
 
+/** @brief Mask for OTS object IDs, preserving the 48 bits */
+#define BT_OTS_OBJ_ID_MASK BIT64_MASK(48)
+
 /** @brief Length of OTS object ID string (in bytes). */
 #define BT_OTS_OBJ_ID_STR_LEN 15
 

--- a/subsys/bluetooth/services/ots/ots_internal.h
+++ b/subsys/bluetooth/services/ots/ots_internal.h
@@ -21,9 +21,6 @@ extern "C" {
 #define DIR_LIST_OBJ_RECORD_MAX_SIZE       172
 #define DIR_LIST_MAX_SIZE (DIR_LIST_OBJ_RECORD_MAX_SIZE * CONFIG_BT_OTS_MAX_OBJ_CNT)
 
-/** @brief ID of the Directory Listing Object */
-#define OTS_OBJ_ID_DIR_LIST     0x000000000000
-
 /**@brief OTS Attribute Protocol Application Error codes. */
 enum bt_gatt_ots_att_err_codes {
 	/** An attempt was made to write a value that is invalid or

--- a/subsys/bluetooth/services/ots/ots_obj_manager.c
+++ b/subsys/bluetooth/services/ots/ots_obj_manager.c
@@ -18,8 +18,6 @@
 
 LOG_MODULE_DECLARE(bt_ots, CONFIG_BT_OTS_LOG_LEVEL);
 
-/**Start of the usable range of Object IDs (values 0 to 0x100 are reserved)*/
-#define OTS_OBJ_ID_START_RANGE  0x000000000100
 
 struct bt_gatt_ots_pool_item {
 	sys_dnode_t dnode;
@@ -39,10 +37,10 @@ static uint64_t obj_id_to_index(uint64_t id)
 		if (id == OTS_OBJ_ID_DIR_LIST) {
 			return id;
 		} else {
-			return id - OTS_OBJ_ID_START_RANGE + 1;
+			return id - BT_OTS_OBJ_ID_MIN + 1;
 		}
 	} else {
-		return id - OTS_OBJ_ID_START_RANGE;
+		return id - BT_OTS_OBJ_ID_MIN;
 	}
 }
 
@@ -52,10 +50,10 @@ static uint64_t obj_index_to_id(uint64_t index)
 		if (index == 0) {
 			return OTS_OBJ_ID_DIR_LIST;
 		} else {
-			return OTS_OBJ_ID_START_RANGE + index - 1;
+			return BT_OTS_OBJ_ID_MIN + index - 1;
 		}
 	} else {
-		return OTS_OBJ_ID_START_RANGE + index;
+		return BT_OTS_OBJ_ID_MIN + index;
 	}
 }
 
@@ -161,7 +159,7 @@ int bt_gatt_ots_obj_manager_obj_get(
 		return -ENOENT;
 	}
 
-	if (id < OTS_OBJ_ID_START_RANGE &&
+	if (id < BT_OTS_OBJ_ID_MIN &&
 	    (IS_ENABLED(CONFIG_BT_OTS_DIR_LIST_OBJ) &&
 		id != OTS_OBJ_ID_DIR_LIST)) {
 		return -EINVAL;


### PR DESCRIPTION
Object IDs are 48 bits, but are often carried in uint64_t variables.
This PR defines a mask value that retains the least significant 48 bits.

The PR also adds defines for the maximum and minimum allowed values for object IDs, and moves the define for the directory listing object ID to the public header file.  This will allow users of the module to check that object ID values are valid.

Signed-off-by: Asbjørn Sæbø <asbjorn.sabo@nordicsemi.no>