### PR TITLE
manifest: update hal_nxp to fix FlexCAN on MKE1xF

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -88,7 +88,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: c7bb88ec3240f1f44b1aafd2831b1472ca99b1d8
+      revision: 78efc4ba7c1057c1cf2bf06e3e27ed7cc33e1da7
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Update the NXP HAL to bring in fix for the FlexCAN driver on the NXP Kinetis MKE1xF.

Fixes: #38442

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>