### PR TITLE
bugfix: sample: test: Add pass conditions to audio/dmic sample

### DIFF
--- a/samples/drivers/audio/dmic/sample.yaml
+++ b/samples/drivers/audio/dmic/sample.yaml
@@ -7,3 +7,10 @@ tests:
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
+    harness: console
+    harness_config:
+      type: multi_line
+      ordered: true
+      regex:
+        - "DMIC sample"
+        - "Exiting"


### PR DESCRIPTION
Twister was failing for samples/drivers/audio/dmic with timeout
because there were no pass conditions defined. This patch sets
harness to console and adds regex entries to be checked.

Fixes: #38532

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>