### PR TITLE
bugfix: samples: display: Set ft800 sample to be build only

### DIFF
--- a/samples/drivers/misc/ft800/sample.yaml
+++ b/samples/drivers/misc/ft800/sample.yaml
@@ -6,3 +6,6 @@ tests:
     depends_on: spi
     platform_allow: nrf52840dk_nrf52840
     extra_args: SHIELD=ftdi_vm800c
+    harness: display
+    harness_config:
+      fixture: spi_display_ft800


### PR DESCRIPTION
The sample from samples/drivers/misc/ft800/ causes twister to
timeout as it has no pass conditions defined nor produces any
output that can be verified. What is more, it requires a shield fixture
which is not reflected in the sample.yaml. This fix sets test harness
to display and adds an entry for the required fixture.

Fixes: #38536

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>