### PR TITLE
drivers/ivshmem: MSI API change was not applied in this drivers

### DIFF
--- a/drivers/virtualization/virt_ivshmem.c
+++ b/drivers/virtualization/virt_ivshmem.c
@@ -70,7 +70,7 @@ static bool ivshmem_configure_interrupts(const struct device *dev)
 
 	LOG_DBG("%u MSI-X Vectors connected", n_vectors);
 
-	if (!pcie_msi_enable(data->bdf, data->vectors, n_vectors)) {
+	if (!pcie_msi_enable(data->bdf, data->vectors, n_vectors, 0)) {
 		LOG_ERR("Could not enable MSI-X");
 		goto out;
 	}


### PR DESCRIPTION
commit id ec2b9d42afbffa27076bf42b4953eacfb8a3c709 missed that ivshmem
uses pcie_msi_enable as well, thus fixing it now.

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>