### PR TITLE
soc: riscv: ite: it8xxx2: guard SoC Kconfig options

### DIFF
--- a/soc/riscv/riscv-ite/it8xxx2/Kconfig.soc
+++ b/soc/riscv/riscv-ite/it8xxx2/Kconfig.soc
@@ -12,6 +12,8 @@ config SOC_IT8XXX2
 
 endchoice
 
+if SOC_IT8XXX2
+
 config SOC_IT8XXX2_PLL_FLASH_48M
 	bool "Flash frequency is 48MHz"
 	default y
@@ -31,3 +33,5 @@ config SOC_IT8XXX2_EXT_32K
 	bool "Use external 32.768 kHz clock source"
 
 endchoice
+
+endif # SOC_IT8XXX2


### PR DESCRIPTION
Guard the IT8XXX2 SoC specific Kconfig options with 'if ... endif'.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zephyrproject-rtos/zephyr/38549)
<!-- Reviewable:end -->
