### PR TITLE
drivers: eth: e1000: only enable e1000 clock on e1000 configured

### DIFF
--- a/drivers/ethernet/Kconfig.e1000
+++ b/drivers/ethernet/Kconfig.e1000
@@ -9,10 +9,11 @@ menuconfig ETH_E1000
 	help
 	  Enable Intel(R) PRO/1000 Gigabit Ethernet driver.
 
+if ETH_E1000
+
 config ETH_NIC_MODEL
 	string
 	default "e1000"
-	depends on ETH_E1000
 	help
 	  Tells what Qemu network model to use. This value is given as
 	  a parameter to -nic qemu command line option.
@@ -38,3 +39,5 @@ config ETH_E1000_PTP_CLOCK_SRC_HZ
 	help
 	  Set the frequency in Hz sourced to the PTP timer.
 	  If the value is set properly, the timer will be accurate.
+
+endif # ETH_E1000


### PR DESCRIPTION
e1000 clock should only be enabled by default if e1000 driver is
configured

Signed-off-by: Xabier Marquiegui <xmarquiegui@ainguraiiot.com>