### PR TITLE
stm32: Set openocd as default runner for 2 targets

### DIFF
--- a/boards/arm/nucleo_g071rb/board.cmake
+++ b/boards/arm/nucleo_g071rb/board.cmake
@@ -5,7 +5,7 @@ board_runner_args(pyocd "--flash-opt=-O connect_mode=under-reset")
 board_runner_args(jlink "--device=STM32G071RB" "--speed=4000")
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset=hw")
 
-include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)

--- a/boards/arm/nucleo_g071rb/doc/index.rst
+++ b/boards/arm/nucleo_g071rb/doc/index.rst
@@ -154,27 +154,7 @@ flashed in the usual way (see :ref:`build_an_application` and
 Flashing
 ========
 
-Nucleo G071RB board includes an ST-LINK/V2-1 embedded debug tool interface.
-
-This interface is not yet supported by the openocd version included in the Zephyr SDK.
-
-Instead, support can be enabled on pyocd by adding "pack" support with
-the following pyocd command:
-
-.. code-block:: console
-
-   $ pyocd pack --update
-   $ pyocd pack --install stm32g071rb
-
-Note:
-To manually enable the openocd interface, You can still update, compile and install
-a 'local' openocd from the official openocd repo http://openocd.zylin.com .
-Then run the following openocd command where the '/usr/local/bin/openocd'is your path
-for the freshly installed openocd, given by "$ which openocd" :
-
-.. code-block:: console
-
-   $ west flash --openocd /usr/local/bin/openocd
+Nucleo G071RB board includes an ST-LINK/V3 embedded debug tool interface.
 
 Flashing an application to Nucleo G071RB
 ----------------------------------------

--- a/boards/arm/nucleo_g474re/board.cmake
+++ b/boards/arm/nucleo_g474re/board.cmake
@@ -4,5 +4,5 @@
 # to allow board re-flashing (see PR #23230)
 board_runner_args(pyocd "--target=stm32g474rbtx")
 
-include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/nucleo_g474re/doc/index.rst
+++ b/boards/arm/nucleo_g474re/doc/index.rst
@@ -197,26 +197,6 @@ Flashing
 
 Nucleo G474RE board includes an ST-LINK/V3E embedded debug tool interface.
 
-This interface is not yet supported by the openocd version included in the Zephyr SDK.
-
-Instead, support can be enabled on pyocd by adding "pack" support with
-the following pyocd command:
-
-.. code-block:: console
-
-   $ pyocd pack --update
-   $ pyocd pack --install stm32g474re
-
-Note:
-To manually enable the openocd interface, You can still update, compile and install
-a 'local' openocd from the official openocd repo http://openocd.zylin.com .
-Then run the following openocd command where the '/usr/local/bin/openocd'is your path
-for the freshly installed openocd, given by "$ which openocd" :
-
-.. code-block:: console
-
-   $ west flash --openocd /usr/local/bin/openocd
-
 Flashing an application to Nucleo G474RE
 ----------------------------------------
 


### PR DESCRIPTION
Zephyr SDK now features an openocd version compatible with stm32g4/g0 targets.
Set openocd as the default zephyr runner for 2 of these targets