### PR TITLE
soc: stm32: SEGGER RTT requires some extra configuration

### DIFF
--- a/soc/arm/st_stm32/common/soc_config.c
+++ b/soc/arm/st_stm32/common/soc_config.c
@@ -12,6 +12,8 @@
 #include <init.h>
 #include <soc.h>
 #include <arch/cpu.h>
+#include <stm32_ll_system.h>
+#include <stm32_ll_bus.h>
 
 /**
  * @brief Perform SoC configuration at boot.
@@ -29,6 +31,37 @@ static int st_stm32_common_config(const struct device *dev)
 	/* Enable the SWO pin */
 	DBGMCU->CR |= DBGMCU_CR_TRACE_IOEN;
 #endif
+
+#if defined(CONFIG_USE_SEGGER_RTT)
+	/* On some STM32 boards, for unclear reason,
+	 * RTT feature is working with realtime update only when
+	 *   - one of the DMA is clocked.
+	 * See https://github.com/zephyrproject-rtos/zephyr/issues/34324
+	 */
+#if defined(__HAL_RCC_DMA1_CLK_ENABLE)
+	__HAL_RCC_DMA1_CLK_ENABLE();
+#endif /* __HAL_RCC_DMA1_CLK_ENABLE */
+
+	/* On some STM32 boards, for unclear reason,
+	 * RTT feature is working with realtime update only when
+	 *   - one of the DBGMCU bit STOP/STANDBY/SLEEP is set
+	 * See https://github.com/zephyrproject-rtos/zephyr/issues/34324
+	 */
+#if defined(LL_APB1_GRP1_PERIPH_DBGMCU)
+	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_DBGMCU);
+#elif defined(LL_APB1_GRP2_PERIPH_DBGMCU)
+	LL_APB1_GRP2_EnableClock(LL_APB1_GRP2_PERIPH_DBGMCU);
+#elif defined(LL_APB2_GRP1_PERIPH_DBGMCU)
+	LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_DBGMCU);
+#endif /* LL_APB1_GRP1_PERIPH_DBGMCU */
+
+#if defined(CONFIG_SOC_SERIES_STM32H7X) || defined(CONFIG_SOC_SERIES_STM32MP1X)
+	HAL_EnableDBGSleepMode();
+#else
+	LL_DBGMCU_EnableDBGStopMode();
+#endif /* CONFIG_SOC_SERIES_STM32H7X || CONFIG_SOC_SERIES_STM32MP1X */
+
+#endif /* CONFIG_USE_SEGGER_RTT */
 
 	return 0;
 }


### PR DESCRIPTION
soc: stm32: SEGGER RTT requires some extra configuration

On some STM32 boards, for unclear reason,
RTT feature is working with realtime update only when
  * one of the DMA is clocked
and sometimes also
  * one of the DBGMCU bit STOP/STANDBY/SLEEP is set
 
Fixes #34324
