### PR TITLE
modem: HL7800: fix PSM

### DIFF
--- a/boards/arm/pinnacle_100_dvk/pinnacle_100_dvk.dts
+++ b/boards/arm/pinnacle_100_dvk/pinnacle_100_dvk.dts
@@ -116,7 +116,6 @@
 		mdm-wake-gpios = <&gpio1 13 0>;
 		mdm-pwr-on-gpios = <&gpio1 2 0>;
 		mdm-fast-shutd-gpios = <&gpio1 14 0>;
-		mdm-uart-dtr-gpios = <&gpio0 24 0>;
 		mdm-vgpio-gpios = <&gpio1 11 0>;
 		mdm-uart-dsr-gpios = <&gpio0 25 0>;
 		mdm-uart-cts-gpios = <&gpio0 15 0>;

--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -4767,7 +4767,7 @@ reboot:
 	SEND_AT_CMD_EXPECT_OK("AT+KHWIOCFG=3,1,6");
 
 	/* Turn on sleep mode */
-	SEND_AT_CMD_EXPECT_OK("AT+KSLEEP=0,2,10");
+	SEND_AT_CMD_EXPECT_OK("AT+KSLEEP=1,2,10");
 
 #if CONFIG_MODEM_HL7800_PSM
 	/* Turn off eDRX */

--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -147,7 +147,6 @@ enum mdm_control_pins {
 	MDM_WAKE,
 	MDM_PWR_ON,
 	MDM_FAST_SHUTD,
-	MDM_UART_DTR,
 	MDM_VGPIO,
 	MDM_UART_DSR,
 	MDM_UART_CTS,
@@ -207,10 +206,6 @@ static const struct mdm_control_pinconfig pinconfig[] = {
 		  DT_INST_GPIO_PIN(0, mdm_fast_shutd_gpios),
 		  (GPIO_OUTPUT | GPIO_OPEN_DRAIN)),
 
-	/* MDM_UART_DTR */
-	PINCONFIG(DT_INST_GPIO_LABEL(0, mdm_uart_dtr_gpios),
-		  DT_INST_GPIO_PIN(0, mdm_uart_dtr_gpios), GPIO_OUTPUT),
-
 	/* MDM_VGPIO */
 	PINCONFIG(DT_INST_GPIO_LABEL(0, mdm_vgpio_gpios),
 		  DT_INST_GPIO_PIN(0, mdm_vgpio_gpios),
@@ -242,8 +237,6 @@ static const struct mdm_control_pinconfig pinconfig[] = {
 #define MDM_PWR_ON_NOT_ASSERTED 1
 #define MDM_FAST_SHUTD_ASSERTED 0
 #define MDM_FAST_SHUTD_NOT_ASSERTED 1
-#define MDM_UART_DTR_ASSERTED 0 /* Asserted keeps the module awake */
-#define MDM_UART_DTR_NOT_ASSERTED 1
 
 #define MDM_SEND_OK_ENABLED 0
 #define MDM_SEND_OK_DISABLED 1
@@ -812,28 +805,12 @@ static void modem_assert_fast_shutd(bool assert)
 	}
 }
 
-static void modem_assert_uart_dtr(bool assert)
-{
-	if (assert) {
-		HL7800_IO_DBG_LOG("MDM_UART_DTR -> ASSERTED");
-		gpio_pin_set(ictx.gpio_port_dev[MDM_UART_DTR],
-			     pinconfig[MDM_UART_DTR].pin,
-			     MDM_UART_DTR_ASSERTED);
-	} else {
-		HL7800_IO_DBG_LOG("MDM_UART_DTR -> NOT_ASSERTED");
-		gpio_pin_set(ictx.gpio_port_dev[MDM_UART_DTR],
-			     pinconfig[MDM_UART_DTR].pin,
-			     MDM_UART_DTR_NOT_ASSERTED);
-	}
-}
-
 static void allow_sleep_work_callback(struct k_work *item)
 {
 	ARG_UNUSED(item);
 	LOG_DBG("Allow sleep");
 	ictx.allow_sleep = true;
 	modem_assert_wake(false);
-	modem_assert_uart_dtr(false);
 }
 
 static void allow_sleep(bool allow)
@@ -848,7 +825,6 @@ static void allow_sleep(bool allow)
 		k_work_cancel_delayable(&ictx.allow_sleep_work);
 		ictx.allow_sleep = false;
 		modem_assert_wake(true);
-		modem_assert_uart_dtr(true);
 	}
 #endif
 }
@@ -4319,7 +4295,6 @@ static void prepare_io_for_reset(void)
 {
 	HL7800_IO_DBG_LOG("Preparing IO for reset/sleep");
 	shutdown_uart();
-	modem_assert_uart_dtr(true);
 	modem_assert_wake(false);
 	modem_assert_pwr_on(false);
 	modem_assert_fast_shutd(false);
@@ -5647,7 +5622,6 @@ static int hl7800_init(const struct device *dev)
 	ictx.uart_on = true;
 
 	modem_assert_wake(false);
-	modem_assert_uart_dtr(false);
 	modem_assert_pwr_on(false);
 	modem_assert_fast_shutd(false);
 

--- a/dts/bindings/modem/swir,hl7800.yaml
+++ b/dts/bindings/modem/swir,hl7800.yaml
@@ -30,10 +30,6 @@ properties:
         type: phandle-array
         required: true
 
-    mdm-uart-dtr-gpios:
-        type: phandle-array
-        required: true
-
     mdm-vgpio-gpios:
         type: phandle-array
         required: true

--- a/tests/drivers/build_all/modem/uart.dtsi
+++ b/tests/drivers/build_all/modem/uart.dtsi
@@ -13,7 +13,6 @@ test_hl7800: hl7800 {
 	mdm-wake-gpios = <&test_gpio 0 0>;
 	mdm-pwr-on-gpios = <&test_gpio 0 0>;
 	mdm-fast-shutd-gpios = <&test_gpio 0 0>;
-	mdm-uart-dtr-gpios = <&test_gpio 0 0>;
 	mdm-uart-dsr-gpios = <&test_gpio 0 0>;
 	mdm-uart-cts-gpios = <&test_gpio 0 0>;
 	mdm-gpio6-gpios = <&test_gpio 0 0>;


### PR DESCRIPTION
Fix power-save-mode (PSM) operation.
When in PSM, do not bring the networking interface down
when an out-of-coverage event occurs.
When PSM goes into hibernate, this will cause an
out-of-coverage event to occur, even though the device
still has access to service.
Keeping the networking interface in the up state
allows an app to send data whenever it needs to.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/38617