### PR TITLE
drivers: disk: Fix USDHC driver to return 0 on success

### DIFF
--- a/drivers/disk/usdhc.c
+++ b/drivers/disk/usdhc.c
@@ -2641,7 +2641,7 @@ static int usdhc_board_access_init(struct usdhc_priv *priv)
 			priv->inserted = true;
 		} else {
 			priv->inserted = false;
-			ret = -ENODEV;
+			return -ENODEV;
 		}
 	} else {
 		ret = usdhc_cd_gpio_init(priv->detect_gpio,
@@ -2668,7 +2668,7 @@ static int usdhc_board_access_init(struct usdhc_priv *priv)
 		priv->inserted = true;
 		LOG_INF("SD inserted!");
 	}
-	return ret;
+	return 0;
 }
 
 static int usdhc_access_init(const struct device *dev)


### PR DESCRIPTION
The function usdhc_board_access_init was returning a non-zero value as the variable "ret" is also used to store the GPIO level for card-detect.

This was causing failures when running the `samples/subsys/fs/fat_fs` application on MXRT1060 and MXRT1050 boards.