### PR TITLE
drivers: timer: Fix RISC-V machine timer count drift due integer math

### DIFF
--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -64,7 +64,7 @@ static void timer_isr(const void *arg)
 	uint64_t now = mtime();
 	uint32_t dticks = (uint32_t)((now - last_count) / CYC_PER_TICK);
 
-	last_count += dticks * CYC_PER_TICK;
+	last_count = now;
 
 	if (!TICKLESS) {
 		uint64_t next = last_count + CYC_PER_TICK;


### PR DESCRIPTION
In the RISC-V machine timer ISR handler there are a series of lines which gets the current time and also adjust the "last" time to the current time: https://github.com/zephyrproject-rtos/zephyr/blob/2e045a0ed6b1fa32688d1d163c74652dbed19bd8/drivers/timer/riscv_machine_timer.c#L64-L67
Specifically, the `last_count` update arithmetically simplifies to:
```
last_count += dticks * CYC_PER_TICK
        ▼
last_count = last_count + ((now - last_count) / CYC_PER_TICK) * CYC_PER_TICK
        ▼
last_count = last_count + (now - last_count)
        ▼
last_count = now
```
However, the original `last_count += dticks * CYC_PER_TICK;` expression is susceptible to integer division errors if `CYC_PER_TICK` does not divide the `now - last_count` quantity exactly and when that is multiplied again `CYC_PER_TICK`, an accumulated error can be introduced which affects further timer scheduling.

This PR eliminates the redundant division-followed-by-multiplication, and fixes #37852 @henrikbrixandersen @LeiW000 and @naiyuantian.