### PR TITLE
tests: thread: Add an initialization to the global variable

### DIFF
--- a/tests/kernel/threads/thread_apis/src/test_threads_cancel_abort.c
+++ b/tests/kernel/threads/thread_apis/src/test_threads_cancel_abort.c
@@ -125,6 +125,7 @@ void test_delayed_thread_abort(void)
 {
 	int current_prio = k_thread_priority_get(k_current_get());
 
+	execute_flag = 0;
 	/* Make current thread preemptive */
 	k_thread_priority_set(k_current_get(), K_PRIO_PREEMPT(2));
 


### PR DESCRIPTION
Add an initialization to the global variable to make sure testcases
can be ran correctly.

Signed-off-by: NingX Zhao <ningx.zhao@intel.com>