### PR TITLE
boards: stm32h747i_disco: add openOCD cortex M4 debug support

### DIFF
--- a/boards/arm/stm32h747i_disco/doc/index.rst
+++ b/boards/arm/stm32h747i_disco/doc/index.rst
@@ -186,8 +186,8 @@ See :ref:`build_an_application` for more information about application builds.
    official release does not support H7 dualcore yet.
    Also, with OpenOCD, sometimes, flashing is not working. It is necessary to
    erase the flash (with STM32CubeProgrammer for example) to make it work again.
-   Debugging with OpenOCD is currently working for this board only with Cortex M7,
-   not Cortex M4.
+   Debugging with OpenOCD is currently working for this board on both Cortex M7,
+   and Cortex M4.
 
 
 Flashing

--- a/boards/arm/stm32h747i_disco/support/openocd_stm32h747i_disco_m4.cfg
+++ b/boards/arm/stm32h747i_disco/support/openocd_stm32h747i_disco_m4.cfg
@@ -1,7 +1,5 @@
 
-source [find interface/stlink.cfg]
-
-transport select hla_swd
+source [find interface/stlink-dap.cfg]
 
 set DUAL_BANK 1
 
@@ -9,4 +7,4 @@ set DUAL_CORE 1
 
 source [find target/stm32h7x.cfg]
 
-reset_config srst_only srst_nogate connect_assert_srst
+reset_config srst_only srst_gates_jtag connect_assert_srst


### PR DESCRIPTION
boards: stm32h747i_disco: add openOCD cortex M4 debug support

Dualcore is not supported by hla transport, switch to dap.
Also, reset_config srst_only srst_nogate connect_assert_srst
doesn't work. I needed to replace srst_nogate by srst_gates_jtag
(alternative could be to remove connect_assert_srst)
