### PR TITLE
tests: enable supported tests for h3ulcb

### DIFF
--- a/boards/arm/rcar_h3ulcb/rcar_h3ulcb_cr7.yaml
+++ b/boards/arm/rcar_h3ulcb/rcar_h3ulcb_cr7.yaml
@@ -5,4 +5,12 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
-ram: 768
+supported:
+  - i2c
+  - can
+  - gpio
+  - clock_control
+  - uart
+testing:
+  ignore_tags:
+    - isotp


### PR DESCRIPTION
Adding test for features that are now available on h3ulcb.
We are ignoring isotp tests because of the internal loopback
implementation of the R-Car CAN controller which is sending
Rx isr before sending the Tx isr, totally confusing the Zephyr
ISOTP state machine and causing false positive.

See https://github.com/zephyrproject-rtos/zephyr/pull/34892#issuecomment-845211219 for more information about the hardware issue.

Signed-off-by: Aymeric Aillet <aymeric.aillet@iot.bzh>