### PR TITLE
stm32 ADC oversampler and resolution when no conversion is ongoing

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -409,10 +409,18 @@ static int start_read(const struct device *dev,
 		return err;
 	}
 
-#if defined(CONFIG_SOC_SERIES_STM32G0X)
+#if defined(CONFIG_SOC_SERIES_STM32G0X) || \
+	defined(CONFIG_SOC_SERIES_STM32G4X) || \
+	defined(CONFIG_SOC_SERIES_STM32H7X) || \
+	defined(CONFIG_SOC_SERIES_STM32L0X) || \
+	defined(CONFIG_SOC_SERIES_STM32L4X) || \
+	defined(CONFIG_SOC_SERIES_STM32L5X) || \
+	defined(CONFIG_SOC_SERIES_STM32WBX) || \
+	defined(CONFIG_SOC_SERIES_STM32WLX)
 	/*
 	 * Errata: Writing ADC_CFGR1 register while ADEN bit is set
 	 * resets RES[1:0] bitfield. We need to disable and enable adc.
+	 * On all those stm32 devices it is allowed to write these bits only when ADEN = 0.
 	 */
 	if (LL_ADC_IsEnabled(adc) == 1UL) {
 		LL_ADC_Disable(adc);


### PR DESCRIPTION
According to the RM of the STM32G0X, STM32G4X, STM32H7X, STM32L0X, STM32L4X, STM32WBX, STM32WLX,
and also STM32L5X, the ADC must be disabled before writing the ADC Resolution and the Oversampler.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/38578

Signed-off-by: Francois Ramu <francois.ramu@st.com>