### PR TITLE
samples: drivers: adc initialize the adc_sequence calibration

### DIFF
--- a/samples/drivers/adc/src/main.c
+++ b/samples/drivers/adc/src/main.c
@@ -59,6 +59,7 @@ struct adc_sequence sequence = {
 	/* buffer size in bytes, not number of samples */
 	.buffer_size = sizeof(sample_buffer),
 	.resolution  = ADC_RESOLUTION,
+	.calibrate = false,
 };
 
 void main(void)


### PR DESCRIPTION
The struct adc_sequence member calibrate must be set to 'false',
this avoids a second calibration in start_read()
which must not be triggered when ADC is enabled.

Fixes: #38578

Signed-off-by: Francois Ramu <francois.ramu@st.com>