### PR TITLE
runners: jlink: manually check command output

### DIFF
--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -6,11 +6,9 @@
 
 import argparse
 from functools import partial
-import logging
 import os
 from pathlib import Path
 import shlex
-import subprocess
 import sys
 import tempfile
 
@@ -311,7 +309,8 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                    self.tool_opt)
 
             self.logger.info('Flashing file: {}'.format(flash_file))
-            kwargs = {}
-            if not self.logger.isEnabledFor(logging.DEBUG):
-                kwargs['stdout'] = subprocess.DEVNULL
-            self.check_call(cmd, **kwargs)
+            # JLink.exe does not currently (v7.54b) return an error code when flashing fails.
+            # Manually check the output string for failures if the call appears to work.
+            output = self.check_output(cmd, encoding='utf-8')
+            if "Writing failed." in output:
+                raise RuntimeError(output)


### PR DESCRIPTION
Manually check the output of the JLink tool when flashing, as failures
do not result in error codes being returned that `check_call` can
validate. The string "Writing failed." appears at the end of the output
if running the script fails:

```
Connecting to target via SWD
InitTarget() start
InitTarget() end
InitTarget() start
InitTarget() end
InitTarget() start
InitTarget() end
InitTarget() start
InitTarget() end
Cannot connect to target.

Target connection not established yet but required for command.
Device "NRF52" selected.

Connecting to target via SWD
InitTarget() start
InitTarget() end
InitTarget() start
InitTarget() end
InitTarget() start
InitTarget() end
InitTarget() start
InitTarget() end
Cannot connect to target.

Writing failed.

Reading failed.

Script processing completed.
```

Fixes #38592.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>