### PR TITLE
boards: arm: mimxrt1024_evk: enable flexcan1

### DIFF
--- a/boards/arm/mimxrt1024_evk/doc/index.rst
+++ b/boards/arm/mimxrt1024_evk/doc/index.rst
@@ -81,6 +81,8 @@ features:
 +-----------+------------+-------------------------------------+
 | ENET      | on-chip    | ethernet                            |
 +-----------+------------+-------------------------------------+
+| CAN       | on-chip    | can                                 |
++-----------+------------+-------------------------------------+
 
 The default configuration can be found in the defconfig file:
 ``boards/arm/mimxrt1024_evk/mimxrt1024_evk_defconfig``
@@ -126,6 +128,10 @@ The MIMXRT1024 SoC has five pairs of pinmux/gpio controllers.
 | GPIO_EMC_41   | ENET_MDC        | Ethernet                  |
 +---------------+-----------------+---------------------------+
 | GPIO_EMC_40   | ENET_MDIO       | Ethernet                  |
++---------------+-----------------+---------------------------+
+| GPIO_SD_B1_00 | FLEXCAN1_TX     | CAN TX                    |
++---------------+-----------------+---------------------------+
+| GPIO_SD_B1_01 | FLEXCAN1_RX     | CAN RX                    |
 +---------------+-----------------+---------------------------+
 
 System Clock

--- a/boards/arm/mimxrt1024_evk/mimxrt1024_evk.dts
+++ b/boards/arm/mimxrt1024_evk/mimxrt1024_evk.dts
@@ -26,6 +26,7 @@
 		zephyr,dtcm = &dtcm;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
+		zephyr,can-primary = &flexcan1;
 	};
 
 	sdram0: memory@80000000 {
@@ -90,4 +91,9 @@
 &lpuart1 {
 	status = "okay";
 	current-speed = <115200>;
+};
+
+&flexcan1 {
+	status = "okay";
+	bus-speed = <125000>;
 };

--- a/boards/arm/mimxrt1024_evk/mimxrt1024_evk.yaml
+++ b/boards/arm/mimxrt1024_evk/mimxrt1024_evk.yaml
@@ -16,3 +16,4 @@ ram: 32768
 flash: 4096
 supported:
   - netif:eth
+  - can

--- a/boards/arm/mimxrt1024_evk/pinmux.c
+++ b/boards/arm/mimxrt1024_evk/pinmux.c
@@ -88,6 +88,15 @@ static int mimxrt1024_evk_init(const struct device *dev)
 	GPIO_WritePinOutput(GPIO1, 4, 0);
 #endif
 
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(flexcan1), okay) && CONFIG_CAN
+	/* FlexCAN1 TX, RX */
+	IOMUXC_SetPinMux(IOMUXC_GPIO_SD_B1_00_FLEXCAN1_TX, 1);
+	IOMUXC_SetPinMux(IOMUXC_GPIO_SD_B1_01_FLEXCAN1_RX, 1);
+
+	IOMUXC_SetPinConfig(IOMUXC_GPIO_SD_B1_00_FLEXCAN1_TX, 0x10B0u);
+	IOMUXC_SetPinConfig(IOMUXC_GPIO_SD_B1_01_FLEXCAN1_RX, 0x10B0u);
+#endif
+
 	return 0;
 }
 


### PR DESCRIPTION
Enable FlexCAN1 on the NXP i.MX RT1024 Evaluation Kit.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>