### PR TITLE
drivers: spi: stm32: Fix forever lock when configure failed

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -613,7 +613,7 @@ static int transceive(const struct device *dev,
 
 	ret = spi_stm32_configure(dev, config);
 	if (ret) {
-		return ret;
+		goto end;
 	}
 
 	/* Set buffers info */
@@ -656,6 +656,7 @@ static int transceive(const struct device *dev,
 
 #endif
 
+end:
 	spi_context_release(&data->ctx, ret);
 
 	return ret;
@@ -710,8 +711,8 @@ static int transceive_dma(const struct device *dev,
 	k_sem_reset(&data->status_sem);
 
 	ret = spi_stm32_configure(dev, config);
-	if (ret != 0) {
-		return ret;
+	if (ret) {
+		goto end;
 	}
 
 	/* Set buffers info */
@@ -777,6 +778,7 @@ static int transceive_dma(const struct device *dev,
 
 	spi_stm32_complete(dev, ret);
 
+end:
 	spi_context_release(&data->ctx, ret);
 
 	return ret;


### PR DESCRIPTION
On transceive, if the SPI configure failed, the SPI wasn't release.

Fixes #38621