### PR TITLE
twister: fix json reporting of build only tests

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -3675,7 +3675,6 @@ class TestSuite(DisablePyTestCollectionMixin):
                 handler_time = instance.metrics.get('handler_time', 0)
                 ram_size = instance.metrics.get ("ram_size", 0)
                 rom_size  = instance.metrics.get("rom_size",0)
-
                 for k in instance.results.keys():
                     testcases = list(filter(lambda d: not (d.get('testcase') == k and d.get('platform') == p), testcases ))
                     testcase = {"testcase": k,
@@ -3687,12 +3686,12 @@ class TestSuite(DisablePyTestCollectionMixin):
                     if rom_size:
                         testcase["rom_size"] = rom_size
 
-                    if instance.results[k] in ["PASS"]:
+                    if instance.results[k] in ["PASS"] or instance.status == 'passed':
                         testcase["status"] = "passed"
                         if instance.handler:
                             testcase["execution_time"] =  handler_time
 
-                    elif instance.results[k] in ['FAIL', 'BLOCK'] or instance.status in ["error", "failed", "timeout"]:
+                    elif instance.results[k] in ['FAIL', 'BLOCK'] or instance.status in ["error", "failed", "timeout", "flash_error"]:
                         testcase["status"] = "failed"
                         testcase["reason"] = instance.reason
                         testcase["execution_time"] =  handler_time
@@ -3702,7 +3701,7 @@ class TestSuite(DisablePyTestCollectionMixin):
                             testcase["device_log"] = self.process_log(device_log)
                         else:
                             testcase["build_log"] = self.process_log(build_log)
-                    else:
+                    elif instance.status == 'skipped':
                         testcase["status"] = "skipped"
                         testcase["reason"] = instance.reason
                     testcases.append(testcase)


### PR DESCRIPTION
Tests are reported as skipped if they are only being built. Fix this by
checking for the correct status.

Fixes #37475

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
