### PR TITLE
drivers: ieee802154: remove dummy implementation of ieee802154_radio_handle_ack() from ieee802154_radio.h

### DIFF
--- a/include/net/ieee802154_radio.h
+++ b/include/net/ieee802154_radio.h
@@ -394,17 +394,8 @@ static inline bool ieee802154_is_ar_flag_set(struct net_buf *frag)
  *
  * @return NET_OK if it was handled, NET_CONTINUE otherwise
  */
-#ifndef CONFIG_IEEE802154_RAW_MODE
 extern enum net_verdict ieee802154_radio_handle_ack(struct net_if *iface,
 						    struct net_pkt *pkt);
-#else /* CONFIG_IEEE802154_RAW_MODE */
-
-static inline enum net_verdict ieee802154_radio_handle_ack(struct net_if *iface,
-							   struct net_pkt *pkt)
-{
-	return NET_CONTINUE;
-}
-#endif /* CONFIG_IEEE802154_RAW_MODE */
 
 /**
  * @brief Initialize L2 stack for a given interface

--- a/samples/net/wpan_serial/src/main.c
+++ b/samples/net/wpan_serial/src/main.c
@@ -520,6 +520,11 @@ int net_recv_data(struct net_if *iface, struct net_pkt *pkt)
 	return 0;
 }
 
+enum net_verdict ieee802154_radio_handle_ack(struct net_if *iface, struct net_pkt *pkt)
+{
+	return NET_CONTINUE;
+}
+
 void main(void)
 {
 	const struct device *dev;

--- a/samples/net/wpanusb/src/wpanusb.c
+++ b/samples/net/wpanusb/src/wpanusb.c
@@ -409,6 +409,11 @@ out:
 	return ret;
 }
 
+enum net_verdict ieee802154_radio_handle_ack(struct net_if *iface, struct net_pkt *pkt)
+{
+	return NET_CONTINUE;
+}
+
 void main(void)
 {
 	int ret;


### PR DESCRIPTION
When using the IEEE802154 radio interface in `CONFIG_IEEE802154_RAW_MODE`, there is no way to handle ack frames because of the dummy implementation of `ieee802154_radio_handle_ack()` in the ieee802154_radio header file.

Removed the dummy implementation from the header so you can/need to implement it in the application. Added the dummy implementation to the wpan_serial and wpanusb sample as they use `CONFIG_IEEE802154_RAW_MODE`.