### PR TITLE
boards: creating a pinmux library for pinmux source files

### DIFF
--- a/boards/arc/hsdk/CMakeLists.txt
+++ b/boards/arc/hsdk/CMakeLists.txt
@@ -3,5 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-
-zephyr_sources_ifdef(CONFIG_PINMUX_HSDK pinmux.c)
+if(CONFIG_PINMUX_HSDK)
+  zephyr_library_named(pinmux)
+  zephyr_library_sources(pinmux.c)
+endif()

--- a/boards/arm/adafruit_feather_m0_basic_proto/CMakeLists.txt
+++ b/boards/arm/adafruit_feather_m0_basic_proto/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_PINMUX_SAM0)
-  zephyr_library()
+  zephyr_library_named(pinmux)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/adafruit_itsybitsy_m4_express/CMakeLists.txt
+++ b/boards/arm/adafruit_itsybitsy_m4_express/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_PINMUX_SAM0)
-  zephyr_library()
+  zephyr_library_named(pinmux)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/adafruit_trinket_m0/CMakeLists.txt
+++ b/boards/arm/adafruit_trinket_m0/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_PINMUX_SAM0)
-  zephyr_library()
+  zephyr_library_named(pinmux)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/arduino_nano_33_iot/CMakeLists.txt
+++ b/boards/arm/arduino_nano_33_iot/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_PINMUX_SAM0)
-  zephyr_library()
+  zephyr_library_named(pinmux)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/arduino_zero/CMakeLists.txt
+++ b/boards/arm/arduino_zero/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_PINMUX_SAM0)
-  zephyr_library()
+  zephyr_library_named(pinmux)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/atsamd20_xpro/CMakeLists.txt
+++ b/boards/arm/atsamd20_xpro/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_PINMUX_SAM0)
-  zephyr_library()
+  zephyr_library_named(pinmux)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/atsamd21_xpro/CMakeLists.txt
+++ b/boards/arm/atsamd21_xpro/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright (c) 2018 Bryan O'Donoghue
 # SPDX-License-Identifier: Apache-2.0
 if(CONFIG_PINMUX_SAM0)
-  zephyr_library()
+  zephyr_library_named(pinmux)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/atsame54_xpro/CMakeLists.txt
+++ b/boards/arm/atsame54_xpro/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright (c) 2018 Bryan O'Donoghue
 # SPDX-License-Identifier: Apache-2.0
 if(CONFIG_PINMUX_SAM0)
-  zephyr_library()
+  zephyr_library_named(pinmux)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/atsamr21_xpro/CMakeLists.txt
+++ b/boards/arm/atsamr21_xpro/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright (c) 2019 Benjamin Valentin
 # SPDX-License-Identifier: Apache-2.0
 if(CONFIG_PINMUX_SAM0)
-  zephyr_library()
+  zephyr_library_named(pinmux)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/cc3220sf_launchxl/CMakeLists.txt
+++ b/boards/arm/cc3220sf_launchxl/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+zephyr_library_named(pinmux)
+zephyr_library_sources(pinmux.c)
+
 zephyr_library()
-zephyr_library_sources(
-    pinmux.c
-    dbghdr.c
-    )
+zephyr_library_sources(dbghdr.c)

--- a/boards/arm/cc3235sf_launchxl/CMakeLists.txt
+++ b/boards/arm/cc3235sf_launchxl/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+zephyr_library_named(pinmux)
+zephyr_library_sources(pinmux.c)
+
 zephyr_library()
-zephyr_library_sources(
-    pinmux.c
-    dbghdr.c
-    )
+zephyr_library_sources(dbghdr.c)

--- a/boards/arm/colibri_imx7d_m4/CMakeLists.txt
+++ b/boards/arm/colibri_imx7d_m4/CMakeLists.txt
@@ -4,5 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-zephyr_library()
+zephyr_library_named(pinmux)
 zephyr_library_sources(pinmux.c)

--- a/boards/arm/frdm_k22f/CMakeLists.txt
+++ b/boards/arm/frdm_k22f/CMakeLists.txt
@@ -5,6 +5,6 @@
 #
 
 if(CONFIG_PINMUX_MCUX)
-  zephyr_library()
+  zephyr_library_named(pinmux)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/frdm_k64f/CMakeLists.txt
+++ b/boards/arm/frdm_k64f/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_PINMUX_MCUX)
-  zephyr_library()
+  zephyr_library_named(pinmux)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/frdm_k82f/CMakeLists.txt
+++ b/boards/arm/frdm_k82f/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_PINMUX_MCUX)
-  zephyr_library()
+  zephyr_library_named(pinmux)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/frdm_kl25z/CMakeLists.txt
+++ b/boards/arm/frdm_kl25z/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_PINMUX_MCUX)
-  zephyr_library()
+  zephyr_library_named(pinmux)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/frdm_kw41z/CMakeLists.txt
+++ b/boards/arm/frdm_kw41z/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
+zephyr_library_named(pinmux)
 zephyr_library_sources(pinmux.c)

--- a/boards/arm/hexiwear_k64/CMakeLists.txt
+++ b/boards/arm/hexiwear_k64/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
+zephyr_library_named(pinmux)
 zephyr_library_sources(pinmux.c)

--- a/boards/arm/hexiwear_kw40z/CMakeLists.txt
+++ b/boards/arm/hexiwear_kw40z/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
+zephyr_library_named(pinmux)
 zephyr_library_sources(pinmux.c)

--- a/boards/arm/ip_k66f/CMakeLists.txt
+++ b/boards/arm/ip_k66f/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_PINMUX_MCUX)
-  zephyr_library()
+  zephyr_library_named(pinmux)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/lpcxpresso54114/CMakeLists.txt
+++ b/boards/arm/lpcxpresso54114/CMakeLists.txt
@@ -5,6 +5,6 @@
 #
 
 if(CONFIG_PINMUX_MCUX_LPC)
-  zephyr_library()
+  zephyr_library_named(pinmux)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/lpcxpresso55s16/CMakeLists.txt
+++ b/boards/arm/lpcxpresso55s16/CMakeLists.txt
@@ -5,6 +5,6 @@
 #
 
 if(CONFIG_PINMUX_MCUX_LPC)
-  zephyr_library()
+  zephyr_library_named(pinmux)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/lpcxpresso55s28/CMakeLists.txt
+++ b/boards/arm/lpcxpresso55s28/CMakeLists.txt
@@ -5,6 +5,6 @@
 #
 
 if(CONFIG_PINMUX_MCUX_LPC)
-  zephyr_library()
+  zephyr_library_named(pinmux)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/lpcxpresso55s69/CMakeLists.txt
+++ b/boards/arm/lpcxpresso55s69/CMakeLists.txt
@@ -6,7 +6,7 @@
 #
 
 if(CONFIG_PINMUX_MCUX_LPC)
-  zephyr_library()
+  zephyr_library_named(pinmux)
   zephyr_library_sources(pinmux.c)
 endif()
 

--- a/boards/arm/mec1501modular_assy6885/CMakeLists.txt
+++ b/boards/arm/mec1501modular_assy6885/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-zephyr_library()
+zephyr_library_named(pinmux)
 zephyr_library_sources(pinmux.c)
 
 if(DEFINED ENV{EVERGLADES_SPI_GEN})

--- a/boards/arm/mec15xxevb_assy6853/CMakeLists.txt
+++ b/boards/arm/mec15xxevb_assy6853/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-zephyr_library()
+zephyr_library_named(pinmux)
 zephyr_library_sources(pinmux.c)
 
 if(DEFINED ENV{EVERGLADES_SPI_GEN})

--- a/boards/arm/mec172xevb_assy6906/CMakeLists.txt
+++ b/boards/arm/mec172xevb_assy6906/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-zephyr_library()
+zephyr_library_named(pinmux)
 zephyr_library_sources(pinmux.c)
 
 if(DEFINED ENV{MEC172X_SPI_GEN})

--- a/boards/arm/mec2016evb_assy6797/CMakeLists.txt
+++ b/boards/arm/mec2016evb_assy6797/CMakeLists.txt
@@ -4,5 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-zephyr_library()
+zephyr_library_named(pinmux)
 zephyr_library_sources(pinmux.c)

--- a/boards/arm/mimx8mm_evk/CMakeLists.txt
+++ b/boards/arm/mimx8mm_evk/CMakeLists.txt
@@ -4,5 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-zephyr_library()
+zephyr_library_named(pinmux)
 zephyr_library_sources(pinmux.c)

--- a/boards/arm/mimxrt1010_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1010_evk/CMakeLists.txt
@@ -4,5 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-zephyr_library()
+zephyr_library_named(pinmux)
 zephyr_library_sources(pinmux.c)

--- a/boards/arm/mimxrt1015_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1015_evk/CMakeLists.txt
@@ -4,5 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-zephyr_library()
+zephyr_library_named(pinmux)
 zephyr_library_sources(pinmux.c)

--- a/boards/arm/mimxrt1020_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1020_evk/CMakeLists.txt
@@ -4,5 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-zephyr_library()
+zephyr_library_named(pinmux)
 zephyr_library_sources(pinmux.c)

--- a/boards/arm/mimxrt1024_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1024_evk/CMakeLists.txt
@@ -4,5 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-zephyr_library()
+zephyr_library_named(pinmux)
 zephyr_library_sources(pinmux.c)

--- a/boards/arm/mimxrt1050_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1050_evk/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-zephyr_library()
+zephyr_library_named(pinmux)
 zephyr_library_sources(pinmux.c)
 
 if (CONFIG_DISPLAY)

--- a/boards/arm/mimxrt1060_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1060_evk/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-zephyr_library()
+zephyr_library_named(pinmux)
 zephyr_library_sources(pinmux.c)
 
 if (CONFIG_DISPLAY)

--- a/boards/arm/mimxrt1064_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1064_evk/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-zephyr_library()
+zephyr_library_named(pinmux)
 zephyr_library_sources(pinmux.c)
 
 if (CONFIG_DISPLAY)

--- a/boards/arm/mimxrt1170_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1170_evk/CMakeLists.txt
@@ -4,5 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-zephyr_library()
+zephyr_library_named(pinmux)
 zephyr_library_sources(pinmux.c)

--- a/boards/arm/mimxrt685_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt685_evk/CMakeLists.txt
@@ -4,5 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-zephyr_library()
+zephyr_library_named(pinmux)
 zephyr_library_sources(pinmux.c)

--- a/boards/arm/mm_feather/CMakeLists.txt
+++ b/boards/arm/mm_feather/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-zephyr_library()
+zephyr_library_named(pinmux)
 zephyr_library_sources(pinmux.c)
 zephyr_sources_ifdef(CONFIG_BOOT_FLEXSPI_NOR flexspi_nor_config.c)
 zephyr_sources_ifdef(CONFIG_DEVICE_CONFIGURATION_DATA mmfeather_sdram_ini_dcd.c)

--- a/boards/arm/mm_swiftio/CMakeLists.txt
+++ b/boards/arm/mm_swiftio/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-zephyr_library()
+zephyr_library_named(pinmux)
 zephyr_library_sources(pinmux.c)
 zephyr_sources_ifdef(CONFIG_BOOT_FLEXSPI_NOR flexspi_nor_config.c)
 zephyr_sources_ifdef(CONFIG_DEVICE_CONFIGURATION_DATA mmswiftio_sdram_ini_dcd.c)

--- a/boards/arm/mps2_an385/CMakeLists.txt
+++ b/boards/arm/mps2_an385/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
+zephyr_library_named(pinmux)
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/mps2_an521/CMakeLists.txt
+++ b/boards/arm/mps2_an521/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-zephyr_library()
+zephyr_library_named(pinmux)
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 

--- a/boards/arm/pico_pi_m4/CMakeLists.txt
+++ b/boards/arm/pico_pi_m4/CMakeLists.txt
@@ -3,5 +3,5 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-zephyr_library()
+zephyr_library_named(pinmux)
 zephyr_library_sources(pinmux.c)

--- a/boards/arm/sam4e_xpro/CMakeLists.txt
+++ b/boards/arm/sam4e_xpro/CMakeLists.txt
@@ -4,5 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-zephyr_library()
+zephyr_library_named(pinmux)
 zephyr_library_sources(pinmux.c)

--- a/boards/arm/sam_e70_xplained/CMakeLists.txt
+++ b/boards/arm/sam_e70_xplained/CMakeLists.txt
@@ -4,5 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-zephyr_library()
+zephyr_library_named(pinmux)
 zephyr_library_sources(pinmux.c)

--- a/boards/arm/sam_v71_xult/CMakeLists.txt
+++ b/boards/arm/sam_v71_xult/CMakeLists.txt
@@ -4,5 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-zephyr_library()
+zephyr_library_named(pinmux)
 zephyr_library_sources(pinmux.c)

--- a/boards/arm/seeeduino_xiao/CMakeLists.txt
+++ b/boards/arm/seeeduino_xiao/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_PINMUX_SAM0)
-  zephyr_library()
+  zephyr_library_named(pinmux)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/serpente/CMakeLists.txt
+++ b/boards/arm/serpente/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_PINMUX_SAM0)
-  zephyr_library()
+  zephyr_library_named(pinmux)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/stm32g0316_disco/CMakeLists.txt
+++ b/boards/arm/stm32g0316_disco/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_PINMUX)
-zephyr_library()
+zephyr_library_named(pinmux)
 zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/teensy4/CMakeLists.txt
+++ b/boards/arm/teensy4/CMakeLists.txt
@@ -5,10 +5,11 @@
 #
 
 if(CONFIG_PINMUX)
-    zephyr_library()
+    zephyr_library_named(pinmux)
     zephyr_library_sources(pinmux.c)
     zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 endif()
 
+zephyr_library()
 zephyr_library_sources(flexspi_nor_config.c)
 zephyr_library_sources_ifdef(CONFIG_DEVICE_CONFIGURATION_DATA teensy4_sdram_ini_dcd.c)

--- a/boards/arm/twr_ke18f/CMakeLists.txt
+++ b/boards/arm/twr_ke18f/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_PINMUX_MCUX)
-  zephyr_library()
+  zephyr_library_named(pinmux)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/twr_kv58f220m/CMakeLists.txt
+++ b/boards/arm/twr_kv58f220m/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_PINMUX_MCUX)
-  zephyr_library()
+  zephyr_library_named(pinmux)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/udoo_neo_full_m4/CMakeLists.txt
+++ b/boards/arm/udoo_neo_full_m4/CMakeLists.txt
@@ -4,5 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-zephyr_library()
+zephyr_library_named(pinmux)
 zephyr_library_sources(pinmux.c)

--- a/boards/arm/usb_kw24d512/CMakeLists.txt
+++ b/boards/arm/usb_kw24d512/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_PINMUX_MCUX)
-  zephyr_library()
+  zephyr_library_named(pinmux)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/v2m_beetle/CMakeLists.txt
+++ b/boards/arm/v2m_beetle/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_PINMUX_BEETLE)
-  zephyr_library()
+  zephyr_library_named(pinmux)
   zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/v2m_musca_b1/CMakeLists.txt
+++ b/boards/arm/v2m_musca_b1/CMakeLists.txt
@@ -4,5 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-zephyr_library()
+zephyr_library_named(pinmux)
 zephyr_library_sources(pinmux.c)

--- a/boards/arm/v2m_musca_s1/CMakeLists.txt
+++ b/boards/arm/v2m_musca_s1/CMakeLists.txt
@@ -4,5 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-zephyr_library()
+zephyr_library_named(pinmux)
 zephyr_library_sources(pinmux.c)

--- a/boards/arm/warp7_m4/CMakeLists.txt
+++ b/boards/arm/warp7_m4/CMakeLists.txt
@@ -4,5 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-zephyr_library()
+zephyr_library_named(pinmux)
 zephyr_library_sources(pinmux.c)

--- a/boards/riscv/hifive1/CMakeLists.txt
+++ b/boards/riscv/hifive1/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
+zephyr_library_named(pinmux)
 zephyr_library_sources(pinmux.c)

--- a/boards/riscv/hifive1_revb/CMakeLists.txt
+++ b/boards/riscv/hifive1_revb/CMakeLists.txt
@@ -1,4 +1,4 @@
 # Copyright (c) 2019 SiFive Inc.
 # SPDX-License-Identifier: Apache-2.0
-zephyr_library()
+zephyr_library_named(pinmux)
 zephyr_library_sources(pinmux.c)

--- a/boards/riscv/it8xxx2_evb/CMakeLists.txt
+++ b/boards/riscv/it8xxx2_evb/CMakeLists.txt
@@ -2,5 +2,5 @@
 # Copyright (c) 2020 ITE Corporation. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
-zephyr_library()
+zephyr_library_named(pinmux)
 zephyr_library_sources(pinmux.c)

--- a/boards/riscv/rv32m1_vega/CMakeLists.txt
+++ b/boards/riscv/rv32m1_vega/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
+zephyr_library_named(pinmux)
 zephyr_library_sources(pinmux.c)

--- a/boards/xtensa/intel_s1000_crb/CMakeLists.txt
+++ b/boards/xtensa/intel_s1000_crb/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_PINMUX_INTEL_S1000)
-  zephyr_library()
+  zephyr_library_named(pinmux)
   zephyr_library_sources(pinmux.c)
 endif()
 

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -426,6 +426,17 @@ endmacro()
 
 # Provides amend functionality to a Zephyr library for out-of-tree usage.
 #
+# Usage:
+#   zephyr_library_amend([<name>])
+#
+# When called with a library name, then the library must already have been
+# defined in the build system.
+# Afterwards, additional source may be amended to the existing library.
+#
+# Example:
+#   zephyr_library_amend(foo)
+#   zephyr_library_sources(bar.c)
+#
 # When called from a Zephyr module, the corresponding zephyr library defined
 # within Zephyr will be looked up.
 #
@@ -452,16 +463,20 @@ endmacro()
 # expressions.
 #
 macro(zephyr_library_amend)
-  # This is a macro because we need to ensure the ZEPHYR_CURRENT_LIBRARY and
-  # following zephyr_library_* calls are executed within the scope of the
-  # caller.
-  if(NOT ZEPHYR_CURRENT_MODULE_DIR)
-    message(FATAL_ERROR "Function only available for Zephyr modules.")
+  if(${ARGC} GREATER 0)
+    set(ZEPHYR_CURRENT_LIBRARY ${ARGV1})
+  else()
+    # This is a macro because we need to ensure the ZEPHYR_CURRENT_LIBRARY and
+    # following zephyr_library_* calls are executed within the scope of the
+    # caller.
+    if(NOT ZEPHYR_CURRENT_MODULE_DIR)
+      message(FATAL_ERROR "Function only available for Zephyr modules.")
+    endif()
+
+    zephyr_library_get_current_dir_lib_name(${ZEPHYR_CURRENT_MODULE_DIR} lib_name)
+
+    set(ZEPHYR_CURRENT_LIBRARY ${lib_name})
   endif()
-
-  zephyr_library_get_current_dir_lib_name(${ZEPHYR_CURRENT_MODULE_DIR} lib_name)
-
-  set(ZEPHYR_CURRENT_LIBRARY ${lib_name})
 endmacro()
 
 function(zephyr_link_interface interface)

--- a/drivers/pinmux/CMakeLists.txt
+++ b/drivers/pinmux/CMakeLists.txt
@@ -1,6 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
+if(TARGET pinmux)
+  zephyr_library_amend(pinmux)
+else()
+  zephyr_library_named(pinmux)
+endif()
+
 
 # Board initialization
 zephyr_library_sources_ifdef(CONFIG_PINMUX_CC13XX_CC26XX   pinmux_cc13xx_cc26xx.c)


### PR DESCRIPTION
With the driver library cleanup in #37512 all drivers are now placed in
dedicated zephyr libraries and not directly in libzephyr.a.

This commit follows up on this by placing all pinmux.c files in a
dedicated pinmux zephyr library.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>