### PR TITLE
Bluetooth: ISO: Add ISO tx callback struct array

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -87,6 +87,20 @@ static struct bt_conn sco_conns[CONFIG_BT_MAX_SCO_CONN];
 #endif /* CONFIG_BT_BREDR */
 #endif /* CONFIG_BT_CONN */
 
+#if defined(CONFIG_BT_ISO)
+/* Callback TX buffers for ISO */
+static struct bt_conn_tx iso_tx[CONFIG_BT_ISO_TX_BUF_COUNT];
+
+int bt_conn_iso_init(void)
+{
+	for (size_t i = 0; i < ARRAY_SIZE(iso_tx); i++) {
+		k_fifo_put(&free_tx, &iso_tx[i]);
+	}
+
+	return 0;
+}
+#endif /* CONFIG_BT_ISO */
+
 struct k_sem *bt_conn_get_pkts(struct bt_conn *conn)
 {
 #if defined(CONFIG_BT_BREDR)

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -251,6 +251,8 @@ struct bt_iso_create_param {
 	struct bt_iso_chan	**chans;
 };
 
+int bt_conn_iso_init(void);
+
 /* Add a new ISO connection */
 struct bt_conn *bt_conn_add_iso(struct bt_conn *acl);
 

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3465,6 +3465,13 @@ static int bt_init(void)
 		}
 	}
 
+	if (IS_ENABLED(CONFIG_BT_ISO)) {
+		err = bt_conn_iso_init();
+		if (err) {
+			return err;
+		}
+	}
+
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
 		if (!bt_dev.id_count) {
 			BT_INFO("No ID address. App must call settings_load()");


### PR DESCRIPTION
Add an array similar to the bt_conn (ACL/L2CAP)
tx sent callback, and initialize it.

This increases the number of bt_conn_tx available
such that ISO does not take any of "L2CAP's" buffers,
but also ensures that the sent callback is called
for a broadcast iso only build.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

fixes #38563