### PR TITLE
devicetree: Add mailbox bindings

### DIFF
--- a/dts/bindings/base/base.yaml
+++ b/dts/bindings/base/base.yaml
@@ -97,3 +97,14 @@ properties:
       required: false
       type: string-array
       description: Provided names of IO channel specifiers
+
+    mboxes:
+      required: false
+      type: phandle-array
+      description: mailbox / IPM channels specifiers
+      specifier-space: mbox
+
+    mbox-names:
+      required: false
+      type: string-array
+      description: Provided names of mailbox / IPM channel specifiers

--- a/dts/bindings/mailbox/mailbox-controller.yaml
+++ b/dts/bindings/mailbox/mailbox-controller.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2021, Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+# Common fields for mailbox / IPM controllers
+
+properties:
+    "#mbox-cells":
+      type: int
+      required: true
+      description: Number of items to expect in a Mailbox specifier


### PR DESCRIPTION
Add general mboxes, mbox-names to base.yaml to be utilized by any
clients that use mailboxes.

Additionally add mailbox-controller.yaml for common properties shared
by all mailbox controller devices.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>