### PR TITLE
drivers: eth: mcux: Fix PTP clock init priority dependency

### DIFF
--- a/drivers/ethernet/Kconfig.mcux
+++ b/drivers/ethernet/Kconfig.mcux
@@ -84,6 +84,14 @@ config ETH_MCUX_PTP_CLOCK_SRC_HZ
 	  Set the frequency in Hz sourced to the PTP timer.
 	  If the value is set properly, the timer will be accurate.
 
+config ETH_MCUX_PTP_CLOCK_INIT_PRIO
+	int
+	default 85
+	help
+	  MCUX PTP Clock initialization priority level. There is
+	  a dependency from the network stack that this device
+	  initializes before network stack (NET_INIT_PRIO).
+
 endif # PTP_CLOCK_MCUX
 
 endif # ETH_MCUX

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -1541,6 +1541,6 @@ static int ptp_mcux_init(const struct device *port)
 
 DEVICE_DEFINE(mcux_ptp_clock_0, PTP_CLOCK_NAME, ptp_mcux_init,
 		NULL, &ptp_mcux_0_context, NULL, POST_KERNEL,
-		CONFIG_APPLICATION_INIT_PRIORITY, &api);
+		CONFIG_ETH_MCUX_PTP_CLOCK_INIT_PRIO, &api);
 
 #endif /* CONFIG_PTP_CLOCK_MCUX */


### PR DESCRIPTION
The net_core device initialization has a subtle dependency
on the PTP clock initialization. Adding a Kconfig and set
it to a priority level less than net_core. This will ensure
the initialization sequence.

Fixes #38571

Signed-off-by: David Leach <david.leach@nxp.com>