### PR TITLE
samples/posix: eventfd: Prevent run in twister when SRAM below 32K

### DIFF
--- a/samples/posix/eventfd/sample.yaml
+++ b/samples/posix/eventfd/sample.yaml
@@ -9,6 +9,7 @@ common:
     - mps2_an385
 tests:
   sample.posix.eventfd:
+    min_ram: 32
     tags: posix
     harness: console
     harness_config:


### PR DESCRIPTION
This test makes use of dynamic RAM allocation done on the leftover
SRAM. Similarly to test/posix/eventfd, limit this test execution on
platforms with at least 32K of RAM available.

Fixes #38601

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>