### PR TITLE
Bluetooth: Audio: Fix pass output from BabbleSim tests

### DIFF
--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/ccp_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/ccp_test.c
@@ -202,7 +202,7 @@ static void test_main(void)
 	}
 
 	WAIT_FOR(read_complete);
-	PASS("CCP Passed");
+	PASS("CCP Passed\n");
 }
 
 static const struct bst_test_instance test_ccp[] = {

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/common.h
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/common.h
@@ -47,10 +47,10 @@
 		bs_trace_error_time_line(__VA_ARGS__); \
 	} while (0)
 
-#define PASS(...) \
+#define PASS(__str) \
 	do { \
 		bst_result = Passed; \
-		bs_trace_info_time(1, __VA_ARGS__); \
+		bs_trace_info_time(1, "PASSED: %s", __str); \
 	} while (0)
 
 #define SET_STEP(s)							\


### PR DESCRIPTION
Update the pass output from the Babblesim tests to alway be prefixed with "PASSED"
Add a missing newline