### PR TITLE
drivers: adc: stm32h7: Oversampling Ratio set incorrectly

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -527,6 +527,15 @@ static int start_read(const struct device *dev,
 	case 8:
 		adc_stm32_oversampling(adc, 8, LL_ADC_OVS_SHIFT_RIGHT_8);
 		break;
+#if defined(CONFIG_SOC_SERIES_STM32H7X)
+	/* stm32 H7 ADC1 & 2 have oversampling ratio from 1..1024 */
+	case 9:
+		adc_stm32_oversampling(adc, 9, LL_ADC_OVS_SHIFT_RIGHT_9);
+		break;
+	case 10:
+		adc_stm32_oversampling(adc, 10, LL_ADC_OVS_SHIFT_RIGHT_10);
+		break;
+#endif /* CONFIG_SOC_SERIES_STM32H7X */
 	default:
 		LOG_ERR("Invalid oversampling");
 		LL_ADC_Enable(adc);

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -384,9 +384,8 @@ static int start_read(const struct device *dev,
 	/*
 	 * Each channel in the sequence must be previously enabled in PCSEL.
 	 * This register controls the analog switch integrated in the IO level.
-	 * NOTE: There is no LL API to control this register yet.
 	 */
-	adc->PCSEL |= channels & ADC_PCSEL_PCSEL_Msk;
+	LL_ADC_SetChannelPreSelection(adc, channel);
 #endif
 
 #if defined(CONFIG_SOC_SERIES_STM32F0X) || \


### PR DESCRIPTION
Configure the with Oversampling ratio for the stm32H7 soc devices, with the LL_ADC_ConfigOverSamplingRatioShift
The LL API function dffers from other stm32 soc : 
ratio is directly the value to set from 1..1024
Depending on the ADC instance ratio is directly the value to set from 1..1024   --> ADC of the stm32H74x for example
or is directly a 3-bit   --> **ADC3** of the stm32H723 for example

requires https://github.com/zephyrproject-rtos/hal_stm32/pull/117

fixes https://github.com/zephyrproject-rtos/zephyr/issues/38606

Signed-off-by: Francois Ramu francois.ramu@st.com