### PR TITLE
runners: openocd: always search the board support directory if found

### DIFF
--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -34,16 +34,22 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
                  gdb_port=DEFAULT_OPENOCD_GDB_PORT):
         super().__init__(cfg)
 
+        support = path.join(cfg.board_dir, 'support')
+
         if not config:
-            default = path.join(cfg.board_dir, 'support', 'openocd.cfg')
+            default = path.join(support, 'openocd.cfg')
             if path.exists(default):
                 config = [default]
         self.openocd_config = config
 
         search_args = []
+        if path.exists(support):
+            search_args.append('-s')
+            search_args.append(support)
+
         if self.openocd_config is not None:
             for i in self.openocd_config:
-                if path.exists(i):
+                if path.exists(i) and not path.samefile(path.dirname(i), support):
                     search_args.append('-s')
                     search_args.append(path.dirname(i))
 


### PR DESCRIPTION
Always add the `boards/<arch>/<board>/support` directory to the OpenOCD runner search path if the directory exists.

This simplifies using custom `--config <partial-board.cfg>` runner arguments without having to use the full path to the cfg file.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>