### PR TITLE
tests: lib: json: Negate assert messages

### DIFF
--- a/tests/lib/json/src/main.c
+++ b/tests/lib/json/src/main.c
@@ -147,10 +147,10 @@ static void test_json_encoding(void)
 
 	ret = json_obj_encode_buf(test_descr, ARRAY_SIZE(test_descr),
 				  &ts, buffer, sizeof(buffer));
-	zassert_equal(ret, 0, "Encoding function returned no errors");
+	zassert_equal(ret, 0, "Encoding function failed");
 
 	ret = strncmp(buffer, encoded, sizeof(encoded) - 1);
-	zassert_equal(ret, 0, "Encoded contents consistent");
+	zassert_equal(ret, 0, "Encoded contents not consistent");
 }
 
 static void test_json_decoding(void)
@@ -181,39 +181,40 @@ static void test_json_decoding(void)
 			     ARRAY_SIZE(test_descr), &ts);
 
 	zassert_equal(ret, (1 << ARRAY_SIZE(test_descr)) - 1,
-		     "All fields decoded correctly");
+		      "Not all fields decoded correctly");
 
 	zassert_true(!strcmp(ts.some_string, "zephyr 123\\uABCD456"),
-		    "String decoded correctly");
-	zassert_equal(ts.some_int, 42, "Positive integer decoded correctly");
-	zassert_equal(ts.some_bool, true, "Boolean decoded correctly");
+		     "String not decoded correctly");
+	zassert_equal(ts.some_int, 42, "Positive integer not decoded correctly");
+	zassert_equal(ts.some_bool, true, "Boolean not decoded correctly");
 	zassert_equal(ts.some_nested_struct.nested_int, -1234,
-		     "Nested negative integer decoded correctly");
+		      "Nested negative integer not decoded correctly");
 	zassert_equal(ts.some_nested_struct.nested_bool, false,
-		     "Nested boolean value decoded correctly");
+		      "Nested boolean value not decoded correctly");
 	zassert_true(!strcmp(ts.some_nested_struct.nested_string,
 			    "this should be escaped: \\t"),
-		    "Nested string decoded correctly");
-	zassert_equal(ts.some_array_len, 5, "Array has correct number of items");
+		     "Nested string not decoded correctly");
+	zassert_equal(ts.some_array_len, 5,
+		      "Array doesn't have correct number of items");
 	zassert_true(!memcmp(ts.some_array, expected_array,
 		    sizeof(expected_array)),
-		    "Array decoded with expected values");
+		    "Array not decoded with expected values");
 	zassert_true(ts.another_bxxl,
-		     "Named boolean (special chars) decoded correctly");
+		     "Named boolean (special chars) not decoded correctly");
 	zassert_false(ts.if_,
-		      "Named boolean (reserved word) decoded correctly");
+		      "Named boolean (reserved word) not decoded correctly");
 	zassert_equal(ts.another_array_len, 4,
-		      "Named array has correct number of items");
+		      "Named array does not have correct number of items");
 	zassert_true(!memcmp(ts.another_array, expected_other_array,
 			     sizeof(expected_other_array)),
-		     "Decoded named array with expected values");
+		     "Decoded named array not with expected values");
 	zassert_equal(ts.xnother_nexx.nested_int, 1234,
-		      "Named nested integer decoded correctly");
+		      "Named nested integer not decoded correctly");
 	zassert_equal(ts.xnother_nexx.nested_bool, true,
-		      "Named nested boolean decoded correctly");
+		      "Named nested boolean not decoded correctly");
 	zassert_true(!strcmp(ts.xnother_nexx.nested_string,
 			     "no escape necessary"),
-		     "Named nested string decoded correctly");
+		     "Named nested string not decoded correctly");
 }
 
 static void test_json_decoding_array_array(void)
@@ -231,23 +232,24 @@ static void test_json_decoding_array_array(void)
 			     ARRAY_SIZE(array_array_descr),
 			     &obj_array_array_ts);
 
-	zassert_equal(ret, 1, "Encoding array of object returned no errors");
-	zassert_equal(obj_array_array_ts.objects_array_len, 3, "Array has correct number of items");
+	zassert_equal(ret, 1, "Encoding array of objects returned error");
+	zassert_equal(obj_array_array_ts.objects_array_len, 3,
+		      "Array doesn't have correct number of items");
 
 	zassert_true(!strcmp(obj_array_array_ts.objects_array[0].objects.name,
-			 "Simón Bolívar"), "String decoded correctly");
+			 "Simón Bolívar"), "String not decoded correctly");
 	zassert_equal(obj_array_array_ts.objects_array[0].objects.height, 168,
-		      "Simón Bolívar height decoded correctly");
+		      "Simón Bolívar height not decoded correctly");
 
 	zassert_true(!strcmp(obj_array_array_ts.objects_array[1].objects.name,
-			 "Pelé"), "String decoded correctly");
+			 "Pelé"), "String not decoded correctly");
 	zassert_equal(obj_array_array_ts.objects_array[1].objects.height, 173,
-		      "Pelé height decoded correctly");
+		      "Pelé height not decoded correctly");
 
 	zassert_true(!strcmp(obj_array_array_ts.objects_array[2].objects.name,
-			 "Usain Bolt"), "String decoded correctly");
+			 "Usain Bolt"), "String not decoded correctly");
 	zassert_equal(obj_array_array_ts.objects_array[2].objects.height, 195,
-		      "Usain Bolt height decoded correctly");
+		      "Usain Bolt height not decoded correctly");
 }
 
 static void test_json_obj_arr_encoding(void)
@@ -284,9 +286,9 @@ static void test_json_obj_arr_encoding(void)
 
 	ret = json_obj_encode_buf(obj_array_descr, ARRAY_SIZE(obj_array_descr),
 				  &oa, buffer, sizeof(buffer));
-	zassert_equal(ret, 0, "Encoding array of object returned no errors");
+	zassert_equal(ret, 0, "Encoding array of object returned error");
 	zassert_true(!strcmp(buffer, encoded),
-		     "Encoded array of objects is consistent");
+		     "Encoded array of objects is not consistent");
 }
 
 static void test_json_obj_arr_decoding(void)
@@ -325,17 +327,17 @@ static void test_json_obj_arr_decoding(void)
 			     ARRAY_SIZE(obj_array_descr), &oa);
 
 	zassert_equal(ret, (1 << ARRAY_SIZE(obj_array_descr)) - 1,
-		      "Array of object fields decoded correctly");
+		      "Array of object fields not decoded correctly");
 	zassert_equal(oa.num_elements, 10,
-		      "Number of object fields decoded correctly");
+		      "Number of object fields not decoded correctly");
 
 	for (int i = 0; i < expected.num_elements; i++) {
 		zassert_true(!strcmp(oa.elements[i].name,
 				     expected.elements[i].name),
-			     "Element %d name decoded correctly", i);
+			     "Element %d name not decoded correctly", i);
 		zassert_equal(oa.elements[i].height,
 			      expected.elements[i].height,
-			      "Element %d height decoded correctly", i);
+			      "Element %d height not decoded correctly", i);
 	}
 }
 
@@ -470,11 +472,11 @@ static void test_json_escape(void)
 	len = strlen(buf);
 
 	ret = json_escape(buf, &len, sizeof(buf));
-	zassert_equal(ret, 0, "Escape succeeded");
+	zassert_equal(ret, 0, "Escape did not succeed");
 	zassert_equal(len, sizeof(buf) - 1,
-		      "Escaped length computed correctly");
+		      "Escaped length not computed correctly");
 	zassert_true(!strcmp(buf, expected),
-		     "Escaped value is correct");
+		     "Escaped value is not correct");
 }
 
 /* Edge case: only one character, which must be escaped. */
@@ -487,11 +489,11 @@ static void test_json_escape_one(void)
 
 	ret = json_escape(buf, &len, sizeof(buf));
 	zassert_equal(ret, 0,
-		      "Escaping one character succeeded");
+		      "Escaping one character did not succeed");
 	zassert_equal(len, sizeof(buf) - 1,
-		      "Escaping one character length is correct");
+		      "Escaping one character length is not correct");
 	zassert_true(!strcmp(buf, expected),
-		     "Escaped value is correct");
+		     "Escaped value is not correct");
 }
 
 static void test_json_escape_empty(void)
@@ -501,9 +503,9 @@ static void test_json_escape_empty(void)
 	ssize_t ret;
 
 	ret = json_escape(empty, &len, sizeof(empty));
-	zassert_equal(ret, 0, "Escaped empty string");
-	zassert_equal(len, 0, "Length of empty escaped string is zero");
-	zassert_equal(empty[0], '\0', "Empty string remains empty");
+	zassert_equal(ret, 0, "Escaping empty string not successful");
+	zassert_equal(len, 0, "Length of empty escaped string is not zero");
+	zassert_equal(empty[0], '\0', "Empty string does not remain empty");
 }
 
 static void test_json_escape_no_op(void)
@@ -514,11 +516,11 @@ static void test_json_escape_no_op(void)
 	ssize_t ret;
 
 	ret = json_escape(nothing_to_escape, &len, sizeof(nothing_to_escape));
-	zassert_equal(ret, 0, "Nothing to escape handled correctly");
+	zassert_equal(ret, 0, "Escape no-op not handled correctly");
 	zassert_equal(len, sizeof(nothing_to_escape) - 1,
-		      "Didn't change length of already escaped string");
+		      "Changed length of already escaped string");
 	zassert_true(!strcmp(nothing_to_escape, expected),
-		     "Didn't alter string with nothing to escape");
+		     "Altered string with nothing to escape");
 }
 
 static void test_json_escape_bounds_check(void)
@@ -528,7 +530,7 @@ static void test_json_escape_bounds_check(void)
 	ssize_t ret;
 
 	ret = json_escape(not_enough_memory, &len, sizeof(not_enough_memory));
-	zassert_equal(ret, -ENOMEM, "Bounds check OK");
+	zassert_equal(ret, -ENOMEM, "Bounds check failed");
 }
 
 static void test_json_encode_bounds_check(void)
@@ -543,12 +545,12 @@ static void test_json_encode_bounds_check(void)
 	uint8_t buf[10];
 	ssize_t ret = json_obj_encode_buf(descr, ARRAY_SIZE(descr),
 					  &str, buf, 10);
-	zassert_equal(ret, 0, "Bounds check passed");
-	zassert_equal(strlen(buf), 9, "encoded value length");
+	zassert_equal(ret, 0, "Encoding failed despite large enough buffer");
+	zassert_equal(strlen(buf), 9, "Encoded string length mismatch");
 
 	ret = json_obj_encode_buf(descr, ARRAY_SIZE(descr),
 				     &str, buf, 9);
-	zassert_equal(ret, -ENOMEM, "Bounds check rejected");
+	zassert_equal(ret, -ENOMEM, "Bounds check failed");
 }
 
 void test_main(void)


### PR DESCRIPTION
Assert messages are printed if the assertion fails, so they should
state what went wrong instead of the expected behaviour.