### PR TITLE
doc: cmake package: remove stale cmake version lines

### DIFF
--- a/doc/guides/zephyr_cmake_package.rst
+++ b/doc/guides/zephyr_cmake_package.rst
@@ -248,7 +248,6 @@ For example:
 
   .. code-block:: cmake
 
-     cmake_minimum_required(VERSION 3.13.1)
      find_package(Zephyr 2.2.0)
      project(app)
 
@@ -283,7 +282,6 @@ syntax may be used:
 
 .. code-block:: cmake
 
-   cmake_minimum_required(VERSION 3.13.1)
    find_package(Zephyr 2.a)
    project(app)
 
@@ -295,7 +293,6 @@ In this case, the application CMakeLists.txt could be written as:
 
 .. code-block:: cmake
 
-   cmake_minimum_required(VERSION 3.13.1)
    find_package(Zephyr 2.a EXACT)
    project(app)
 
@@ -303,7 +300,6 @@ In case no Zephyr is found which satisfies the version required, as example, the
 
 .. code-block:: cmake
 
-   cmake_minimum_required(VERSION 3.13.1)
    find_package(Zephyr 2.z)
    project(app)
 
@@ -363,8 +359,6 @@ A Zephyr preference list can be specified as:
 
 .. code-block:: cmake
 
-   cmake_minimum_required(VERSION 3.13.1)
-
    set(ZEPHYR_PREFER "zephyr-custom" "zephyr-vendor")
    find_package(Zephyr)
 
@@ -381,8 +375,6 @@ Zephyr. When testing is done, the ``zephyr-test`` folder can simply be removed.
 Such a CMakeLists.txt could look as:
 
 .. code-block:: cmake
-
-   cmake_minimum_required(VERSION 3.13.1)
 
    set(ZEPHYR_PREFER "zephyr-test")
    find_package(Zephyr)


### PR DESCRIPTION
This page is meant to document the behavior of the Zephyr cmake
package. However, its example CMake snippets contain some stale
references to a minimum version (3.13.1, now 3.20).

These lines are a bit of a distraction anyway, so just remove them.
They matter in general, but they don't matter where the Zephyr cmake
package is concerned.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>