### PR TITLE
demand_paging: eviction/nru: fix incorrect dirty bit return val

### DIFF
--- a/subsys/demand_paging/eviction/nru.c
+++ b/subsys/demand_paging/eviction/nru.c
@@ -45,6 +45,7 @@ struct z_page_frame *k_mem_paging_eviction_select(bool *dirty_ptr)
 	unsigned int last_prec = 4U;
 	struct z_page_frame *last_pf = NULL, *pf;
 	bool accessed;
+	bool last_dirty = false;
 	bool dirty = false;
 	uintptr_t flags, phys;
 
@@ -71,18 +72,20 @@ struct z_page_frame *k_mem_paging_eviction_select(bool *dirty_ptr)
 		if (prec == 0) {
 			/* If we find a not accessed, clean page we're done */
 			last_pf = pf;
+			last_dirty = dirty;
 			break;
 		}
 
 		if (prec < last_prec) {
 			last_prec = prec;
 			last_pf = pf;
+			last_dirty = dirty;
 		}
 	}
 	/* Shouldn't ever happen unless every page is pinned */
 	__ASSERT(last_pf != NULL, "no page to evict");
 
-	*dirty_ptr = dirty;
+	*dirty_ptr = last_dirty;
 
 	return last_pf;
 }


### PR DESCRIPTION
In k_mem_paging_eviction_select(), the returned dirty bit value
may not be actually associated with the page selected, but
rather the last page examined. So fix this.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>