### PR TITLE
npcx: Disable I2C controllers by default

### DIFF
--- a/boards/arm/npcx7m6fb_evb/npcx7m6fb_evb.dts
+++ b/boards/arm/npcx7m6fb_evb/npcx7m6fb_evb.dts
@@ -90,6 +90,10 @@
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
+&i2c_ctrl0 {
+	status = "okay";
+};
+
 &tach1 {
 	status = "okay";
 	pinctrl-0 = <&alt3_ta1_sl1>; /* Use TA1_SL1 (PIN40) as input pin */

--- a/boards/arm/npcx9m6f_evb/npcx9m6f_evb.dts
+++ b/boards/arm/npcx9m6f_evb/npcx9m6f_evb.dts
@@ -103,6 +103,10 @@
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
+&i2c_ctrl0 {
+	status = "okay";
+};
+
 &tach1 {
 	status = "okay";
 	pinctrl-0 = <&alt3_ta1_sl1>; /* Use TA1_SL1 (PIN40) as input pin */

--- a/dts/arm/nuvoton/npcx.dtsi
+++ b/dts/arm/nuvoton/npcx.dtsi
@@ -425,6 +425,7 @@
 			interrupts = <13 3>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL3 0>;
 			label = "I2CCTRL_0";
+			status = "disabled";
 		};
 
 		i2c_ctrl1: i2c@4000b000 {
@@ -433,6 +434,7 @@
 			interrupts = <14 3>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL3 1>;
 			label = "I2CCTRL_1";
+			status = "disabled";
 		};
 
 		i2c_ctrl2: i2c@400c0000 {
@@ -441,6 +443,7 @@
 			interrupts = <36 3>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL3 2>;
 			label = "I2CCTRL_2";
+			status = "disabled";
 		};
 
 		i2c_ctrl3: i2c@400c2000 {
@@ -449,6 +452,7 @@
 			interrupts = <37 3>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL3 3>;
 			label = "I2CCTRL_3";
+			status = "disabled";
 		};
 
 		i2c_ctrl4: i2c@40008000 {
@@ -457,6 +461,7 @@
 			interrupts = <19 3>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL3 4>;
 			label = "I2CCTRL_4";
+			status = "disabled";
 		};
 
 		i2c_ctrl5: i2c@40017000 {
@@ -465,6 +470,7 @@
 			interrupts = <20 3>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL7 0>;
 			label = "I2CCTRL_5";
+			status = "disabled";
 		};
 
 		i2c_ctrl6: i2c@40018000 {
@@ -473,6 +479,7 @@
 			interrupts = <16 3>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL7 1>;
 			label = "I2CCTRL_6";
+			status = "disabled";
 		};
 
 		i2c_ctrl7: i2c@40019000 {
@@ -481,6 +488,7 @@
 			interrupts = <8 3>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL7 2>;
 			label = "I2CCTRL_7";
+			status = "disabled";
 		};
 
 		tach1: tach@400e1000 {


### PR DESCRIPTION
The NPCX I2C implementation contains two modules, an I2C port and an
I2C controller.  Disable the I2C controller nodes by default and require
the user to enable both the I2C port and controller in the devicetree.

Signed-off-by: Keith Short <keithshort@chromium.org>