### PR TITLE
lib: timeutil: fix implicit conversions from float to double

### DIFF
--- a/lib/os/timeutil.c
+++ b/lib/os/timeutil.c
@@ -82,7 +82,7 @@ int timeutil_sync_state_update(struct timeutil_sync_state *tsp,
 		if (tsp->base.ref == 0) {
 			tsp->base = *inst;
 			tsp->latest = (struct timeutil_sync_instant){};
-			tsp->skew = 1.0;
+			tsp->skew = 1.0f;
 			rv = 0;
 		} else {
 			tsp->latest = *inst;
@@ -137,7 +137,7 @@ int timeutil_sync_ref_from_local(const struct timeutil_sync_state *tsp,
 		/* (x * 1.0) != x for large values of x.
 		 * Therefore only apply the multiplication if the skew is not one.
 		 */
-		if (tsp->skew != 1.0) {
+		if (tsp->skew != 1.0f) {
 			local_delta *= (double)tsp->skew;
 		}
 		int64_t ref_delta = local_delta * cfg->ref_Hz / cfg->local_Hz;
@@ -147,7 +147,7 @@ int timeutil_sync_ref_from_local(const struct timeutil_sync_state *tsp,
 			rv = -ERANGE;
 		} else {
 			*refp = ref_abs;
-			rv = (int)(tsp->skew != 1.0);
+			rv = (int)(tsp->skew != 1.0f);
 		}
 	}
 
@@ -167,14 +167,14 @@ int timeutil_sync_local_from_ref(const struct timeutil_sync_state *tsp,
 		 */
 		int64_t local_delta = (ref_delta * cfg->local_Hz) / cfg->ref_Hz;
 
-		if (tsp->skew != 1.0) {
+		if (tsp->skew != 1.0f) {
 			local_delta /= (double)tsp->skew;
 		}
 		int64_t local_abs = (int64_t)tsp->base.local
 				    + (int64_t)local_delta;
 
 		*localp = local_abs;
-		rv = (int)(tsp->skew != 1.0);
+		rv = (int)(tsp->skew != 1.0f);
 	}
 
 	return rv;
@@ -182,7 +182,7 @@ int timeutil_sync_local_from_ref(const struct timeutil_sync_state *tsp,
 
 int32_t timeutil_sync_skew_to_ppb(float skew)
 {
-	int64_t ppb64 = (int64_t)((1.0 - skew) * 1E9);
+	int64_t ppb64 = (int64_t)((1.0 - (double)skew) * 1E9);
 	int32_t ppb32 = (int32_t)ppb64;
 
 	return (ppb64 == ppb32) ? ppb32 : INT32_MIN;


### PR DESCRIPTION
C implicit promotion rules will want to make floats into doubles very easily. Zephyr build will generate warnings when this flag, -Wdouble-promotion, is enabled with GCC.

```
third-party/zephyr/zephyr_rtos/v2.6.0/zephyr/lib/os/timeutil.c: In function 'timeutil_sync_ref_from_local':
third-party/zephyr/zephyr_rtos/v2.6.0/zephyr/lib/os/timeutil.c:145:25: error: implicit conversion from 'float' to 'double' to match other operand of binary expression [-Werror=double-promotion]
    rv = (int)(tsp->skew != 1.0);
                         ^~
third-party/zephyr/zephyr_rtos/v2.6.0/zephyr/lib/os/timeutil.c: In function 'timeutil_sync_local_from_ref':
third-party/zephyr/zephyr_rtos/v2.6.0/zephyr/lib/os/timeutil.c:166:24: error: implicit conversion from 'float' to 'double' to match other operand of binary expression [-Werror=double-promotion]
   rv = (int)(tsp->skew != 1.0);
                        ^~
third-party/zephyr/zephyr_rtos/v2.6.0/zephyr/lib/os/timeutil.c: In function 'timeutil_sync_skew_to_ppb':
third-party/zephyr/zephyr_rtos/v2.6.0/zephyr/lib/os/timeutil.c:174:33: error: implicit conversion from 'float' to 'double' to match other operand of binary expression [-Werror=double-promotion]
  int64_t ppb64 = (int64_t)((1.0 - skew) * 1E9);
                                 ^
cc1: all warnings being treated as errors
```

These compiler flags were added by simply adding the following to my `CMakeLists.txt`
```
add_compile_options(-Werror=double-promotion)
add_compile_options(-Wdouble-promotion)
```
