### PR TITLE
drivers: modem: gsm_ppp: Add support for Quectel modems w/ CMUX

### DIFF
--- a/drivers/console/Kconfig.gsm_mux
+++ b/drivers/console/Kconfig.gsm_mux
@@ -60,6 +60,7 @@ config GSM_MUX_PENDING_CMD_MAX
 config GSM_MUX_MRU_DEFAULT_LEN
 	int "Default size of received user data (MRU)"
 	default 127 if MODEM_GSM_SIMCOM
+	default 127 if MODEM_GSM_QUECTEL
 	default 31
 	range 1 1509
 	depends on GSM_MUX

--- a/drivers/modem/Kconfig.gsm
+++ b/drivers/modem/Kconfig.gsm
@@ -27,6 +27,11 @@ config MODEM_GSM_SIMCOM
 	help
 	  Use this if you have SIMCOM based modem like SIM800 etc.
 
+config MODEM_GSM_QUECTEL
+	bool "Quectel modem"
+	help
+	  Use this if you have Quectel based modem like EC2X etc.
+
 endchoice
 
 config MODEM_GSM_RX_STACK_SIZE

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -769,6 +769,20 @@ static int mux_enable(struct gsm_modem *gsm)
 			STRINGIFY(CONFIG_GSM_MUX_MRU_DEFAULT_LEN),
 			&gsm->sem_response,
 			GSM_CMD_AT_TIMEOUT);
+	} else if (IS_ENABLED(CONFIG_MODEM_GSM_QUECTEL)) {
+		ret = modem_cmd_send_nolock(&gsm->context.iface,
+				    &gsm->context.cmd_handler,
+				    &response_cmds[0],
+				    ARRAY_SIZE(response_cmds),
+				    "AT+CMUX=0,0,5,"
+				    STRINGIFY(CONFIG_GSM_MUX_MRU_DEFAULT_LEN),
+				    &gsm->sem_response,
+				    GSM_CMD_AT_TIMEOUT);
+
+		/* Arbitrary delay for Quectel modems to initialize the CMUX,
+		 * without this the AT cmd will fail.
+		 */
+		k_sleep(K_SECONDS(1));
 	} else {
 		/* Generic GSM modem */
 		ret = modem_cmd_send_nolock(&gsm->context.iface,


### PR DESCRIPTION
Add support for Quectel modem in `gsm_ppp` modem driver.

The CMUX cmd is based on MUX application notes v1.0(2020-09-22) for BG95, BG77 and BG600L. Tested and working on EC21e (EC21EFAR06A01M4G or newer).

As the `gsm_ppp` doesn't do power control, it is required to power on the modem manually in the application.

The [CMUX document](https://forums.quectel.com/uploads/short-url/uoB16C44M5IzrdgmZ87PPJ9axSc.pdf) is available [publicly on the internet](https://www.google.com/search?q=quectel+at%2Bcmux+site%3Aforums.quectel.com&rlz=1C1SQJL_enMY906MY907&oq=quectel+at%2Bcmux+site%3Aforums.quectel.com).

fixes #38653