### PR TITLE
west.yml: Add hal gigadevice

### DIFF
--- a/modules/Kconfig
+++ b/modules/Kconfig
@@ -46,6 +46,9 @@ comment "Unavailable modules, please install those via the project manifest."
 # config ZEPHYR_<MODULE_NAME_UPPER>_MODULE
 # 	bool
 
+comment "hal_gigadevice module not available."
+	depends on !ZEPHYR_HAL_GIGADEVICE_MODULE
+
 comment "hal_nordic module not available."
 	depends on !ZEPHYR_HAL_NORDIC_MODULE
 

--- a/modules/hal_gigadevice/CMakeLists.txt
+++ b/modules/hal_gigadevice/CMakeLists.txt
@@ -1,0 +1,51 @@
+# Copyright (c) 2021 ATL-Electronics
+# SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_HAS_GD32_HAL)
+
+zephyr_library_named(hal_gigadevice)
+
+if(NOT gd32_soc_uc)
+  message(WARNING "'gd32_soc' not defined. The gd32_soc variables\
+ are necessary to identify firmware directory. Make sure that\
+ CONFIG_SOC_SERIES_GD32* is well defined at modules/hal_gigadevice")
+endif()
+
+zephyr_library_compile_definitions(${gd32_soc_uc})
+
+set(gd32_soc_dir     ${ZEPHYR_HAL_GIGADEVICE_MODULE_DIR}/${gd32_soc_uc})
+set(gd32_cmsis_dir   ${gd32_soc_dir}/CMSIS/GD/${gd32_soc_uc})
+set(gd32_std_dir     ${gd32_soc_dir}/standard_peripheral)
+set(gd32_std_src_dir ${gd32_std_dir}/Source)
+
+# Global includes to be used outside hal_gigadevice
+zephyr_include_directories(${gd32_cmsis_dir}/Include)
+zephyr_include_directories(${gd32_std_dir}/Include)
+
+zephyr_library_sources(${gd32_cmsis_dir}/Source/system_${gd32_soc_lc}.c)
+
+zephyr_library_sources_ifdef(CONFIG_USE_GD32_ADC   ${gd32_std_src_dir}/${gd32_soc_lc}_adc.c)
+zephyr_library_sources_ifdef(CONFIG_USE_GD32_BKP   ${gd32_std_src_dir}/${gd32_soc_lc}_bkp.c)
+zephyr_library_sources_ifdef(CONFIG_USE_GD32_CAN   ${gd32_std_src_dir}/${gd32_soc_lc}_can.c)
+zephyr_library_sources_ifdef(CONFIG_USE_GD32_CRC   ${gd32_std_src_dir}/${gd32_soc_lc}_crc.c)
+zephyr_library_sources_ifdef(CONFIG_USE_GD32_CTC   ${gd32_std_src_dir}/${gd32_soc_lc}_ctc.c)
+zephyr_library_sources_ifdef(CONFIG_USE_GD32_DAC   ${gd32_std_src_dir}/${gd32_soc_lc}_dac.c)
+zephyr_library_sources_ifdef(CONFIG_USE_GD32_DBG   ${gd32_std_src_dir}/${gd32_soc_lc}_dbg.c)
+zephyr_library_sources_ifdef(CONFIG_USE_GD32_DMA   ${gd32_std_src_dir}/${gd32_soc_lc}_dma.c)
+zephyr_library_sources_ifdef(CONFIG_USE_GD32_EXMC  ${gd32_std_src_dir}/${gd32_soc_lc}_exmc.c)
+zephyr_library_sources_ifdef(CONFIG_USE_GD32_EXTI  ${gd32_std_src_dir}/${gd32_soc_lc}_exti.c)
+zephyr_library_sources_ifdef(CONFIG_USE_GD32_FMC   ${gd32_std_src_dir}/${gd32_soc_lc}_fmc.c)
+zephyr_library_sources_ifdef(CONFIG_USE_GD32_FWDGT ${gd32_std_src_dir}/${gd32_soc_lc}_fwdgt.c)
+zephyr_library_sources_ifdef(CONFIG_USE_GD32_GPIO  ${gd32_std_src_dir}/${gd32_soc_lc}_gpio.c)
+zephyr_library_sources_ifdef(CONFIG_USE_GD32_I2C   ${gd32_std_src_dir}/${gd32_soc_lc}_i2c.c)
+zephyr_library_sources_ifdef(CONFIG_USE_GD32_MISC  ${gd32_std_src_dir}/${gd32_soc_lc}_misc.c)
+zephyr_library_sources_ifdef(CONFIG_USE_GD32_PMU   ${gd32_std_src_dir}/${gd32_soc_lc}_pmu.c)
+zephyr_library_sources_ifdef(CONFIG_USE_GD32_RCU   ${gd32_std_src_dir}/${gd32_soc_lc}_rcu.c)
+zephyr_library_sources_ifdef(CONFIG_USE_GD32_RTC   ${gd32_std_src_dir}/${gd32_soc_lc}_rtc.c)
+zephyr_library_sources_ifdef(CONFIG_USE_GD32_SDIO  ${gd32_std_src_dir}/${gd32_soc_lc}_sdio.c)
+zephyr_library_sources_ifdef(CONFIG_USE_GD32_SPI   ${gd32_std_src_dir}/${gd32_soc_lc}_spi.c)
+zephyr_library_sources_ifdef(CONFIG_USE_GD32_TIMER ${gd32_std_src_dir}/${gd32_soc_lc}_timer.c)
+zephyr_library_sources_ifdef(CONFIG_USE_GD32_USART ${gd32_std_src_dir}/${gd32_soc_lc}_usart.c)
+zephyr_library_sources_ifdef(CONFIG_USE_GD32_WWDGT ${gd32_std_src_dir}/${gd32_soc_lc}_wwdgt.c)
+
+endif()

--- a/modules/hal_gigadevice/Kconfig
+++ b/modules/hal_gigadevice/Kconfig
@@ -1,0 +1,192 @@
+# Copyright (c) 2021 ATL-Electronics
+# SPDX-License-Identifier: Apache-2.0
+
+config ZEPHYR_HAL_GIGADEVICE_MODULE
+	bool
+
+config SOC_FAMILY_GD32
+	bool
+	select HAS_GD32_HAL
+	select BUILD_OUTPUT_HEX
+
+config SOC_FAMILY
+	string
+	default "gigadevice"
+	depends on SOC_FAMILY_GD32
+
+config HAS_GD32_HAL
+	bool
+
+if HAS_GD32_HAL
+
+config USE_GD32_ADC
+	bool
+	help
+	  Enable GD32 Analog-to-Digital Converter (ADC) HAL module driver
+
+config USE_GD32_BKP
+	bool
+	help
+	  Enable GD32 Backup Registers (BKP) HAL module driver
+
+config USE_GD32_CAN
+	bool
+	help
+	  Enable GD32 Controller Area Network (CAN) HAL module driver
+
+config USE_GD32_CMP
+	bool
+	help
+	  Enable GD32 Comparator (CMP) HAL module driver
+
+config USE_GD32_CRC
+	bool
+	help
+	  Enable GD32 Cyclic redundancy check calculation unit (CRC) HAL
+	  module driver
+
+config USE_GD32_CTC
+	bool
+	help
+	  Enable GD32 Clock Trim Controller (CTC) HAL module driver
+
+config USE_GD32_DAC
+	bool
+	help
+	  Enable GD32 Digital-to-Analog Converter (DAC) HAL module driver
+
+config USE_GD32_DBG
+	bool
+	help
+	  Enable GD32 Debug (DBG) HAL module driver
+
+config USE_GD32_DMA
+	bool
+	help
+	  Enable GD32 Direct Memory Access controller (DMA) HAL module driver
+
+config USE_GD32_ECLIC
+	bool
+	help
+	  Enable GD32 Enhancement Core-Local Interrupt Controller (ECLIC) HAL
+	  module driver
+
+config USE_GD32_ENET
+	bool
+	help
+	  Enable GD32 Ethernet (ENET) HAL module driver
+
+config USE_GD32_EXMC
+	bool
+	help
+	  Enable GD32 External Memory Controller (EXMC) HAL module driver
+
+config USE_GD32_EXTI
+	bool
+	help
+	  Enable GD32 Interrupt/Event controller (EXTI) HAL module driver
+
+config USE_GD32_FMC
+	bool
+	help
+	  Enable GD32 Flash Memory Controller (FMC) HAL module driver
+
+config USE_GD32_FWDGT
+	bool
+	help
+	  Enable GD32 Free Watchdog Timer (FWDGT) HAL module driver
+
+config USE_GD32_GPIO
+	bool
+	default y
+	help
+	  Enable GD32 General-purpose and Alternate-Function I/Os
+	  (GPIO and AFIO) HAL module driver
+
+config USE_GD32_I2C
+	bool
+	help
+	  Enable GD32 Inter-Integrated Circuit Interface (I2C) HAL module driver
+
+config USE_GD32_MISC
+	bool
+	help
+	  Enable GD32 System Utilities (MISC) HAL module driver
+
+config USE_GD32_PMU
+	bool
+	help
+	  Enable GD32 Power Management Unit (PMU) HAL module driver
+
+config USE_GD32_RCU
+	bool
+	default y
+	help
+	  Enable GD32 Reset and Clock Unit (RCU) HAL module driver
+
+config USE_GD32_RTC
+	bool
+	help
+	  Enable GD32 Real-Time Clock (RTC) HAL module driver
+
+config USE_GD32_SDIO
+	bool
+	help
+	  Enable GD32 Secure Digital Input/Output interface (SDIO) HAL module
+	  driver
+
+config USE_GD32_SPI
+	bool
+	help
+	  Enable GD32 Serial Peripheral Interface(SPI) HAL module driver
+
+config USE_GD32_SQPI
+	bool
+	help
+	  Enable GD32 Serial/Quad Parallel Interface (SQPI) HAL module driver
+
+config USE_GD32_SHRTIMER
+	bool
+	help
+	  Enable GD32 Super High-Resolution Timer (SHRTIMER) HAL module driver
+
+config USE_GD32_TIMER
+	bool
+	help
+	  Enable GD32 Timer (TIMER) HAL module driver
+
+config USE_GD32_TMU
+	bool
+	help
+	  Enable GD32 Trigonometric Math Unit (TMU) HAL module driver
+
+config USE_GD32_USART
+	bool
+	help
+	  Enable GD32 Universal Synchronous/Asynchronous Receiver/Transmitter
+	  (USART) HAL module driver
+
+config USE_GD32_USBD
+	bool
+	help
+	  Enable GD32 Universal Serial Bus full-speed Device interface (USBD)
+	  HAL module driver
+
+config USE_GD32_USBFS
+	bool
+	help
+	  Enable GD32 Universal Serial Bus on-the-go Full-Speed (USBFS) HAL
+	  module driver
+
+config USE_GD32_USBHS
+	bool
+	help
+	  Enable GD32 Universal Serial Bus High-Speed interface (USBHS) HAL
+	  module driver
+
+config USE_GD32_WWDGT
+	bool
+	help
+	  Enable GD32 Window Watchdog Timer (WWDGT) HAL module driver
+
+endif # HAS_GD32_HAL

--- a/west.yml
+++ b/west.yml
@@ -67,6 +67,11 @@ manifest:
       west-commands: west/west-commands.yml
       groups:
         - hal
+    - name: hal_gigadevice
+      revision: ce323de9655972a545cbdddda813c1576d85d5d1
+      path: modules/hal/gigadevice
+      groups:
+        - hal
     - name: hal_infineon
       revision: f1fa8241f8786198ba41155413243de36ed878a5
       path: modules/hal/infineon


### PR DESCRIPTION
This add modules/hal/gigadevice with three firmware libraries:

 - GD32E103 ARM (Cortex-M4F)
 - GD32F403 ARM (Cortex-M4F)
 - GD32VF103 RISC-V (Nucleisys Bumblebee core)

Signed-off-by: Gerson Fernando Budke <gerson.budke@atl-electronics.com>