### PR TITLE
dts: bindings: vendor-prefixes: Add gigadevice prefix

### DIFF
--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -226,6 +226,7 @@ gemei	Gemei Digital Technology Co., Ltd.
 geniatech	Geniatech, Inc.
 giantec	Giantec Semiconductor, Inc.
 giantplus	Giantplus Technology Co., Ltd.
+gigadevice	GigaDevice Semiconductor
 globalscale	Globalscale Technologies, Inc.
 globaltop	GlobalTop Technology, Inc.
 gmt	Global Mixed-mode Technology, Inc.


### PR DESCRIPTION
Add gigadevice manufacturer binding prefix.

Signed-off-by: Gerson Fernando Budke <gerson.budke@atl-electronics.com>