### PR TITLE
scripts: runners: add connect_srst support for blackmagicprobe

### DIFF
--- a/boards/arm/lora_e5_dev_board/board.cmake
+++ b/boards/arm/lora_e5_dev_board/board.cmake
@@ -5,6 +5,7 @@ board_runner_args(pyocd "--flash-opt=-O reset_type=hw")
 board_runner_args(pyocd "--flash-opt=-O connect_mode=under-reset")
 board_runner_args(jlink "--device=STM32WLE5JC" "--speed=4000" "--reset-after-load")
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset=hw")
+board_runner_args(blackmagicprobe "--gdb-serial=/dev/ttyBmpGdb" "--connect-srst")
 
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/arm/lora_e5_dev_board/lora_e5_dev_board.dts
+++ b/boards/arm/lora_e5_dev_board/lora_e5_dev_board.dts
@@ -75,6 +75,35 @@
 		regulator-boot-on;
 		status = "okay";
 	};
+
+	power-states {
+		stop0: state0 {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-idle";
+			substate-id = <1>;
+			min-residency-us = <100>;
+		};
+		stop1: state1 {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-idle";
+			substate-id = <2>;
+			min-residency-us = <500>;
+		};
+		stop2: state2 {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-idle";
+			substate-id = <3>;
+			min-residency-us = <900>;
+		};
+	};
+};
+
+&cpu0 {
+	cpu-power-states = <&stop0 &stop1 &stop2>;
+};
+
+&lptim1 {
+	status = "okay";
 };
 
 &clk_msi {

--- a/scripts/west_commands/runners/blackmagicprobe.py
+++ b/scripts/west_commands/runners/blackmagicprobe.py
@@ -12,11 +12,19 @@ from runners.core import ZephyrBinaryRunner, RunnerCaps
 class BlackMagicProbeRunner(ZephyrBinaryRunner):
     '''Runner front-end for Black Magic probe.'''
 
-    def __init__(self, cfg, gdb_serial):
+    def __init__(self, cfg, gdb_serial, connect_srst=False):
         super().__init__(cfg)
         self.gdb = [cfg.gdb] if cfg.gdb else None
         self.elf_file = cfg.elf_file
         self.gdb_serial = gdb_serial
+        if connect_srst:
+            self.connect_srst_enable_arg = [
+                    '-ex', "monitor connect_srst enable"]
+            self.connect_srst_disable_arg = [
+                    '-ex', "monitor connect_srst disable"]
+        else:
+            self.connect_srst_enable_arg = []
+            self.connect_srst_disable_arg = []
 
     @classmethod
     def name(cls):
@@ -28,20 +36,24 @@ class BlackMagicProbeRunner(ZephyrBinaryRunner):
 
     @classmethod
     def do_create(cls, cfg, args):
-        return BlackMagicProbeRunner(cfg, args.gdb_serial)
+        return BlackMagicProbeRunner(cfg, args.gdb_serial, args.connect_srst)
 
     @classmethod
     def do_add_parser(cls, parser):
         parser.add_argument('--gdb-serial', default='/dev/ttyACM0',
                             help='GDB serial port')
+        parser.add_argument('--connect-srst', action='store_true',
+                            help='Assert SRST during connect? (default: no)')
 
     def bmp_flash(self, command, **kwargs):
         if self.elf_file is None:
             raise ValueError('Cannot debug; elf file is missing')
         command = (self.gdb +
                    ['-ex', "set confirm off",
-                    '-ex', "target extended-remote {}".format(self.gdb_serial),
-                    '-ex', "monitor swdp_scan",
+                    '-ex', "target extended-remote {}".format(
+                        self.gdb_serial)] +
+                    self.connect_srst_enable_arg +
+                   ['-ex', "monitor swdp_scan",
                     '-ex', "attach 1",
                     '-ex', "load {}".format(self.elf_file),
                     '-ex', "kill",
@@ -61,15 +73,17 @@ class BlackMagicProbeRunner(ZephyrBinaryRunner):
             command = (self.gdb +
                        ['-ex', "set confirm off",
                         '-ex', "target extended-remote {}".format(
-                            self.gdb_serial),
-                        '-ex', "monitor swdp_scan",
+                            self.gdb_serial)] +
+                        self.connect_srst_disable_arg +
+                       ['-ex', "monitor swdp_scan",
                         '-ex', "attach 1"])
         else:
             command = (self.gdb +
                        ['-ex', "set confirm off",
                         '-ex', "target extended-remote {}".format(
-                            self.gdb_serial),
-                        '-ex', "monitor swdp_scan",
+                            self.gdb_serial)] +
+                        self.connect_srst_disable_arg +
+                       ['-ex', "monitor swdp_scan",
                         '-ex', "attach 1",
                         '-ex', "file {}".format(self.elf_file)])
         self.check_call_ignore_sigint(command)
@@ -79,8 +93,10 @@ class BlackMagicProbeRunner(ZephyrBinaryRunner):
             raise ValueError('Cannot debug; elf file is missing')
         command = (self.gdb +
                    ['-ex', "set confirm off",
-                    '-ex', "target extended-remote {}".format(self.gdb_serial),
-                    '-ex', "monitor swdp_scan",
+                    '-ex', "target extended-remote {}".format(
+                        self.gdb_serial)] +
+                    self.connect_srst_enable_arg +
+                   ['-ex', "monitor swdp_scan",
                     '-ex', "attach 1",
                     '-ex', "file {}".format(self.elf_file),
                     '-ex', "load {}".format(self.elf_file)])


### PR DESCRIPTION
Add runner support for using the connect_srst feature on blackmagicprobe on a per-board basis. Set that for `lora_e5_dev_board` as an example.