### PR TITLE
doc: net: Remove obsolete note about sockets thread-safety status

### DIFF
--- a/doc/reference/networking/sockets.rst
+++ b/doc/reference/networking/sockets.rst
@@ -146,11 +146,6 @@ Secure sockets offer the following options for socket management:
 API Reference
 *************
 
-Note that current socket API implementation is not thread safe and caller
-should not do socket operations to same socket from multiple threads unless
-protected by a mutex, semaphore or similar.
-
-
 BSD Sockets
 ===========
 


### PR DESCRIPTION
The socket API was updated with mutex protection, however this
was not reflected in the documentation. Remove the obsolete note on the
thread-safety status of the socket API, to prevent confusion.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>