### PR TITLE
boards: arm: mimxrt1024_evk: enable watchdog

### DIFF
--- a/boards/arm/mimxrt1024_evk/doc/index.rst
+++ b/boards/arm/mimxrt1024_evk/doc/index.rst
@@ -89,6 +89,8 @@ features:
 +-----------+------------+-------------------------------------+
 | CAN       | on-chip    | can                                 |
 +-----------+------------+-------------------------------------+
+| WATCHDOG  | on-chip    | watchdog                            |
++-----------+------------+-------------------------------------+
 
 The default configuration can be found in the defconfig file:
 ``boards/arm/mimxrt1024_evk/mimxrt1024_evk_defconfig``

--- a/boards/arm/mimxrt1024_evk/mimxrt1024_evk.dts
+++ b/boards/arm/mimxrt1024_evk/mimxrt1024_evk.dts
@@ -15,6 +15,7 @@
 	aliases {
 		led0 = &green_led;
 		sw0 = &user_button;
+		watchdog0 = &wdog0;
 	};
 
 	chosen {
@@ -96,6 +97,10 @@
 &flexcan1 {
 	status = "okay";
 	bus-speed = <125000>;
+};
+
+&wdog0 {
+	status = "okay";
 };
 
 &lpi2c4 {

--- a/boards/arm/mimxrt1024_evk/mimxrt1024_evk.yaml
+++ b/boards/arm/mimxrt1024_evk/mimxrt1024_evk.yaml
@@ -17,3 +17,4 @@ flash: 4096
 supported:
   - netif:eth
   - can
+  - watchdog


### PR DESCRIPTION
Enable the on-chip watchdog of the NXP i.MX RT1024 Evaluation Kit.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>