### PR TITLE
soc: stm32l0: force DBGMCU Sleep/Stop/Standby bits to 0

### DIFF
--- a/soc/arm/st_stm32/stm32l0/power.c
+++ b/soc/arm/st_stm32/stm32l0/power.c
@@ -85,6 +85,8 @@ static int stm32_power_init(const struct device *dev)
 	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
 
 #ifdef CONFIG_DEBUG
+#error "Enabling DBGMCU Sleep/Stop/Standby on STM32L0 causes Hardfault.\
+		See #37119"
 	/* Enable the Debug Module during STOP mode */
 	LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_DBGMCU);
 	LL_DBGMCU_EnableDBGStopMode();

--- a/soc/arm/st_stm32/stm32l0/soc.c
+++ b/soc/arm/st_stm32/stm32l0/soc.c
@@ -52,6 +52,15 @@ static int stm32l0_init(const struct device *arg)
 	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
 	LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE1);
 
+	/* Enabling DBGMCU bits Sleep/Stop/Standby on STM32L0 causes Hardfault.
+	 * See #37119
+	 * As a workaround, force those bits to 0
+	 */
+	LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_DBGMCU);
+	MODIFY_REG(DBGMCU->CR, DBGMCU_CR_DBG_SLEEP |
+						   DBGMCU_CR_DBG_STOP |
+						   DBGMCU_CR_DBG_STANDBY, 0U);
+
 	return 0;
 }
 


### PR DESCRIPTION
soc: stm32l0: force DBGMCU Sleep/Stop/Standby bits to 0

Enabling DBGMCU bits Sleep/Stop/Standby on STM32L0
causes Hardfault. See #37119
As a workaround, force those bits to 0
