### PR TITLE
soc: stm32l0: enable DMA clock to fix Hardfault linked to DBGMCU bits

### DIFF
--- a/soc/arm/st_stm32/stm32l0/soc.c
+++ b/soc/arm/st_stm32/stm32l0/soc.c
@@ -17,6 +17,7 @@
 #include <string.h>
 #include <stm32_ll_bus.h>
 #include <stm32_ll_pwr.h>
+#include <stm32_ll_bus.h>
 
 /**
  * @brief Perform basic hardware initialization at boot.
@@ -51,6 +52,15 @@ static int stm32l0_init(const struct device *arg)
 	 */
 	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
 	LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE1);
+
+	/* On STM32L0, there are some hardfault when enabling DBGMCU bit:
+	 * Sleep, Stop or Standby.
+	 * See https://github.com/zephyrproject-rtos/zephyr/issues/#37119
+	 * For unclear reason, enabling DMA clock fixes this issue
+	 * (similarly than it fixes
+	 * https://github.com/zephyrproject-rtos/zephyr/issues/#34324 )
+	 */
+	LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_DBGMCU);
 
 	return 0;
 }


### PR DESCRIPTION
soc: stm32l0: enable DMA clock to fix Hardfault linked to DBGMCU bits

On STM32L0, there are some hardfault when DBGMCU bit Sleep, Stop
or Standby are enabled. See #37119
For unclear reason, enabling DMA clock fixes this issue.
(similarly than #38561, DMA clock comes with DBGMCU bits)

Fixes #37119