### PR TITLE
tracing: Fix ISR number for Segger System View

### DIFF
--- a/subsys/tracing/sysview/sysview.c
+++ b/subsys/tracing/sysview/sysview.c
@@ -21,8 +21,12 @@ uint32_t sysview_get_timestamp(void)
 uint32_t sysview_get_interrupt(void)
 {
 #ifdef CONFIG_CPU_CORTEX_M
+	/* As per Cortex-M3 Devices Generic User Guide, we need to subtract 16 from
+	   the VECTACTIVE field of the ICSR regiester in order to obtain the CMSIS
+	   IRQ number.
+	*/
 	interrupt = ((SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) >>
-		     SCB_ICSR_VECTACTIVE_Pos);
+		     SCB_ICSR_VECTACTIVE_Pos) - 16;
 #endif
 	return interrupt;
 }


### PR DESCRIPTION
This fixes the issue where Segger System View GUI was incorrectly
made to report high ISR numbers.

Signed-off-by: Balaji Srinivasan <balaji.srinivasan@nordicsemi.no>