### PR TITLE
net: ethernet: Refactor IPv4 to MAC multicast address conversion

### DIFF
--- a/include/net/ethernet.h
+++ b/include/net/ethernet.h
@@ -682,6 +682,15 @@ const struct net_eth_addr *net_eth_broadcast_addr(void);
 /** @endcond */
 
 /**
+ * @brief Convert IPv4 multicast address to Ethernet address.
+ *
+ * @param ipv4_addr IPv4 multicast address
+ * @param mac_addr Output buffer for Ethernet address
+ */
+void net_eth_ipv4_mcast_to_mac_addr(const struct in_addr *ipv4_addr,
+				    struct net_eth_addr *mac_addr);
+
+/**
  * @brief Convert IPv6 multicast address to Ethernet address.
  *
  * @param ipv6_addr IPv6 multicast address

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -45,6 +45,25 @@ const struct net_eth_addr *net_eth_broadcast_addr(void)
 	return &broadcast_eth_addr;
 }
 
+void net_eth_ipv4_mcast_to_mac_addr(const struct in_addr *ipv4_addr,
+				    struct net_eth_addr *mac_addr)
+{
+	/* RFC 1112 6.4. Extensions to an Ethernet Local Network Module
+	 * "An IP host group address is mapped to an Ethernet multicast
+	 * address by placing the low-order 23-bits of the IP address into
+	 * the low-order 23 bits of the Ethernet multicast address
+	 * 01-00-5E-00-00-00 (hex)."
+	 */
+	mac_addr->addr[0] = 0x01;
+	mac_addr->addr[1] = 0x00;
+	mac_addr->addr[2] = 0x5e;
+	mac_addr->addr[3] = ipv4_addr->s4_addr[1];
+	mac_addr->addr[4] = ipv4_addr->s4_addr[2];
+	mac_addr->addr[5] = ipv4_addr->s4_addr[3];
+
+	mac_addr->addr[3] &= 0x7f;
+}
+
 void net_eth_ipv6_mcast_to_mac_addr(const struct in6_addr *ipv6_addr,
 				    struct net_eth_addr *mac_addr)
 {
@@ -348,14 +367,7 @@ static bool ethernet_fill_in_dst_on_ipv4_mcast(struct net_pkt *pkt,
 	if (net_pkt_family(pkt) == AF_INET &&
 	    net_ipv4_is_addr_mcast(&NET_IPV4_HDR(pkt)->dst)) {
 		/* Multicast address */
-		dst->addr[0] = 0x01;
-		dst->addr[1] = 0x00;
-		dst->addr[2] = 0x5e;
-		dst->addr[3] = NET_IPV4_HDR(pkt)->dst.s4_addr[1];
-		dst->addr[4] = NET_IPV4_HDR(pkt)->dst.s4_addr[2];
-		dst->addr[5] = NET_IPV4_HDR(pkt)->dst.s4_addr[3];
-
-		dst->addr[3] &= 0x7f;
+		net_eth_ipv4_mcast_to_mac_addr(&NET_IPV4_HDR(pkt)->dst, dst);
 
 		return true;
 	}


### PR DESCRIPTION
Refactor IPv4 multicast address to MAC multicast address conversion
into its own function, so it can be reused by drivers as it is already
possible for IPv6 multicast addresses.

Signed-off-by: Markus Fuchs <markus.fuchs@ch.sauter-bc.com>