### PR TITLE
logging: use green color for info log level

### DIFF
--- a/subsys/logging/Kconfig.formatting
+++ b/subsys/logging/Kconfig.formatting
@@ -58,6 +58,13 @@ config LOG_BACKEND_SHOW_COLOR
 	help
 	  When enabled selected backend prints errors in red and warning in yellow.
 
+if LOG_BACKEND_SHOW_COLOR
+
+config LOG_INFO_COLOR_GREEN
+	bool "Use green color for info level logs"
+
+endif
+
 config LOG_BACKEND_FORMAT_TIMESTAMP
 	bool "Enable timestamp formatting in the backend"
 	depends on LOG_BACKEND_UART || LOG_BACKEND_NATIVE_POSIX || LOG_BACKEND_RTT \

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -16,6 +16,7 @@
 
 #define LOG_COLOR_CODE_DEFAULT "\x1B[0m"
 #define LOG_COLOR_CODE_RED     "\x1B[1;31m"
+#define LOG_COLOR_CODE_GREEN   "\x1B[1;32m"
 #define LOG_COLOR_CODE_YELLOW  "\x1B[1;33m"
 
 #define HEXDUMP_BYTES_IN_LINE 16
@@ -38,7 +39,7 @@ static const char *const colors[] = {
 	NULL,
 	LOG_COLOR_CODE_RED,     /* err */
 	LOG_COLOR_CODE_YELLOW,  /* warn */
-	NULL,                   /* info */
+	IS_ENABLED(CONFIG_LOG_INFO_COLOR_GREEN) ? LOG_COLOR_CODE_GREEN : NULL,   /* info */
 	NULL                    /* dbg */
 };
 


### PR DESCRIPTION
Info log messages don't have dedicated color which
makes them harder to separate from debug logs.

Introduce green color in log output for info level
so it stands out like error and warning messages do.

Signed-off-by: Marin Jurjević <marin.jurjevic@hotmail.com>