### PR TITLE
soc: stl32l0: Enable DMA clock instead of DBGMCU clock

### DIFF
--- a/soc/arm/st_stm32/stm32l0/soc.c
+++ b/soc/arm/st_stm32/stm32l0/soc.c
@@ -60,7 +60,7 @@ static int stm32l0_init(const struct device *arg)
 	 * (similarly than it fixes
 	 * https://github.com/zephyrproject-rtos/zephyr/issues/#34324 )
 	 */
-	LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_DBGMCU);
+	LL_AHB1_GRP1_EnableClock(LL_AHB1_GRP1_PERIPH_DMA1);
 
 	return 0;
 }


### PR DESCRIPTION
soc: stl32l0: Enable DMA clock instead of DBGMCU clock

During review of #38681, switching from HAL to LL,
involuntarily enable DBGMCU clock instead of DMA clock.

Fixes #37119
