### PR TITLE
Bluetooth: Audio: Media - code reordering, no functional changes

### DIFF
--- a/include/bluetooth/mcc.h
+++ b/include/bluetooth/mcc.h
@@ -182,6 +182,15 @@ typedef void (*bt_mcc_next_track_obj_id_read_cb)(struct bt_conn *conn,
 typedef void (*bt_mcc_next_track_obj_id_set_cb)(struct bt_conn *conn, int err,
 						uint64_t id);
 
+/** @brief Callback function for bt_mcc_read_parent_group_obj_id()
+ *
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
+ * @param id            The Parent Group Object ID (UINT48)
+ */
+typedef void (*bt_mcc_parent_group_obj_id_read_cb)(struct bt_conn *conn,
+						   int err, uint64_t id);
+
 /** @brief Callback function for bt_mcc_read_current_group_obj_id()
  *
  * @param conn          The connection that was used to initialise the media control client
@@ -200,14 +209,6 @@ typedef void (*bt_mcc_current_group_obj_id_read_cb)(struct bt_conn *conn,
 typedef void (*bt_mcc_current_group_obj_id_set_cb)(struct bt_conn *conn, int err,
 						   uint64_t obj_id);
 
-/** @brief Callback function for bt_mcc_read_parent_group_obj_id()
- *
- * @param conn          The connection that was used to initialise the media control client
- * @param err           Error value. 0 on success, GATT error or errno on fail
- * @param id            The Parent Group Object ID (UINT48)
- */
-typedef void (*bt_mcc_parent_group_obj_id_read_cb)(struct bt_conn *conn,
-						   int err, uint64_t id);
 #endif /* CONFIG_BT_OTC */
 
 /** @brief Callback function for bt_mcc_read_playing_order()
@@ -381,17 +382,6 @@ typedef void (*bt_mcc_otc_read_current_track_object_cb)(struct bt_conn *conn, in
 typedef void (*bt_mcc_otc_read_next_track_object_cb)(struct bt_conn *conn, int err,
 						     struct net_buf_simple *buf);
 
-/** @brief Callback function for bt_mcc_otc_read_current_group_object()
- *
- * @param conn          The connection that was used to initialise the media control client
- * @param err           Error value. 0 on success, GATT error or errno on fail
- * @param buf           Buffer containing the object contents
- *
- * If err is EMSGSIZE, the object contents have been truncated.
- */
-typedef void (*bt_mcc_otc_read_current_group_object_cb)(struct bt_conn *conn, int err,
-							struct net_buf_simple *buf);
-
 /** @brief Callback function for bt_mcc_otc_read_parent_group_object()
  *
  * @param conn          The connection that was used to initialise the media control client
@@ -402,6 +392,17 @@ typedef void (*bt_mcc_otc_read_current_group_object_cb)(struct bt_conn *conn, in
  */
 typedef void (*bt_mcc_otc_read_parent_group_object_cb)(struct bt_conn *conn, int err,
 						       struct net_buf_simple *buf);
+
+/** @brief Callback function for bt_mcc_otc_read_current_group_object()
+ *
+ * @param conn          The connection that was used to initialise the media control client
+ * @param err           Error value. 0 on success, GATT error or errno on fail
+ * @param buf           Buffer containing the object contents
+ *
+ * If err is EMSGSIZE, the object contents have been truncated.
+ */
+typedef void (*bt_mcc_otc_read_current_group_object_cb)(struct bt_conn *conn, int err,
+							struct net_buf_simple *buf);
 
 #endif /* CONFIG_BT_OTC */
 

--- a/subsys/bluetooth/host/audio/media_proxy.h
+++ b/subsys/bluetooth/host/audio/media_proxy.h
@@ -481,6 +481,19 @@ struct media_proxy_ctrl_cbs {
 	void (*next_track_id_write)(struct media_player *player, int err, uint64_t id);
 
 	/**
+	 * @brief Parent Group Object ID receive callback
+	 *
+	 * Called when the Parent Group Object ID is read or changed
+	 * See also media_proxy_ctrl_parent_group_id_get()
+	 *
+	 * @param player   Media player instance pointer
+	 * @param err      Error value. 0 on success, GATT error on positive value
+	 *                 or errno on negative value.
+	 * @param id       The ID of the parent group object in Object Transfer Service (48 bits)
+	 */
+	void (*parent_group_id_recv)(struct media_player *player, int err, uint64_t id);
+
+	/**
 	 * @brief Current Group Object ID receive callback
 	 *
 	 * Called when the Current Group Object ID is read or changed
@@ -506,19 +519,6 @@ struct media_proxy_ctrl_cbs {
 	 * @param id       The ID (48 bits) attempted to write
 	 */
 	void (*current_group_id_write)(struct media_player *player, int err, uint64_t id);
-
-	/**
-	 * @brief Parent Group Object ID receive callback
-	 *
-	 * Called when the Parent Group Object ID is read or changed
-	 * See also media_proxy_ctrl_parent_group_id_get()
-	 *
-	 * @param player   Media player instance pointer
-	 * @param err      Error value. 0 on success, GATT error on positive value
-	 *                 or errno on negative value.
-	 * @param id       The ID of the parent group object in Object Transfer Service (48 bits)
-	 */
-	void (*parent_group_id_recv)(struct media_player *player, int err, uint64_t id);
 
 	/**
 	 * @brief Playing Order receive callback
@@ -921,6 +921,25 @@ int media_proxy_ctrl_next_track_id_get(struct media_player *player);
 int media_proxy_ctrl_next_track_id_set(struct media_player *player, uint64_t id);
 
 /**
+ * @brief Read Parent Group Object ID
+ *
+ * Get an ID (48 bit) that can be used to retrieve the Parent
+ * Track Object from an Object Transfer Service
+ *
+ * The parent group is the parent of the current group.
+ *
+ * See the Media Control Service spec v1.0 sections 3.14 and
+ * 4.4 for a description of the Current Track Object.
+ *
+ * Requires Object Transfer Service
+ *
+ * @param player   Media player instance pointer
+ *
+ * @return 0 if success, errno on failure.
+ */
+int media_proxy_ctrl_parent_group_id_get(struct media_player *player);
+
+/**
  * @brief Read Current Group Object ID
  *
  * Get an ID (48 bit) that can be used to retrieve the Current
@@ -951,25 +970,6 @@ int media_proxy_ctrl_current_group_id_get(struct media_player *player);
  * @return 0 if success, errno on failure.
  */
 int media_proxy_ctrl_current_group_id_set(struct media_player *player, uint64_t id);
-
-/**
- * @brief Read Parent Group Object ID
- *
- * Get an ID (48 bit) that can be used to retrieve the Parent
- * Track Object from an Object Transfer Service
- *
- * The parent group is the parent of the current group.
- *
- * See the Media Control Service spec v1.0 sections 3.14 and
- * 4.4 for a description of the Current Track Object.
- *
- * Requires Object Transfer Service
- *
- * @param player   Media player instance pointer
- *
- * @return 0 if success, errno on failure.
- */
-int media_proxy_ctrl_parent_group_id_get(struct media_player *player);
 
 /**
  * @brief Read Playing Order
@@ -1280,6 +1280,21 @@ struct media_proxy_pl_calls {
 	void (*next_track_id_set)(uint64_t id);
 
 	/**
+	 * @brief Read Parent Group Object ID
+	 *
+	 * Get an ID (48 bit) that can be used to retrieve the Parent
+	 * Track Object from an Object Transfer Service
+	 *
+	 * The parent group is the parent of the current group.
+	 *
+	 * See the Media Control Service spec v1.0 sections 3.14 and
+	 * 4.4 for a description of the Current Track Object.
+	 *
+	 * @return The Current Group Object ID
+	 */
+	uint64_t (*parent_group_id_get)(void);
+
+	/**
 	 * @brief Read Current Group Object ID
 	 *
 	 * Get an ID (48 bit) that can be used to retrieve the Current
@@ -1301,21 +1316,6 @@ struct media_proxy_pl_calls {
 	 * @param id    The ID of a group object
 	 */
 	void (*current_group_id_set)(uint64_t id);
-
-	/**
-	 * @brief Read Parent Group Object ID
-	 *
-	 * Get an ID (48 bit) that can be used to retrieve the Parent
-	 * Track Object from an Object Transfer Service
-	 *
-	 * The parent group is the parent of the current group.
-	 *
-	 * See the Media Control Service spec v1.0 sections 3.14 and
-	 * 4.4 for a description of the Current Track Object.
-	 *
-	 * @return The Current Group Object ID
-	 */
-	uint64_t (*parent_group_id_get)(void);
 
 	/**
 	 * @brief Read Playing Order
@@ -1526,15 +1526,6 @@ void media_proxy_pl_current_track_id_cb(uint64_t id);
 void media_proxy_pl_next_track_id_cb(uint64_t id);
 
 /**
- * @brief Current group object ID callback
- *
- * To be called when the ID of the current group is changed
- *
- * @param speed	The ID of the current group object in the OTS
- */
-void media_proxy_pl_current_group_id_cb(uint64_t id);
-
-/**
  * @brief Parent group object ID callback
  *
  * To be called when the ID of the parent group is changed
@@ -1542,6 +1533,15 @@ void media_proxy_pl_current_group_id_cb(uint64_t id);
  * @param speed	The ID of the parent group object in the OTS
  */
 void media_proxy_pl_parent_group_id_cb(uint64_t id);
+
+/**
+ * @brief Current group object ID callback
+ *
+ * To be called when the ID of the current group is changed
+ *
+ * @param speed	The ID of the current group object in the OTS
+ */
+void media_proxy_pl_current_group_id_cb(uint64_t id);
 
 /**
  * @brief Playing order callback

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/media_controller_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/media_controller_test.c
@@ -31,8 +31,8 @@ static uint64_t g_icon_object_id;
 static uint64_t g_track_segments_object_id;
 static uint64_t g_current_track_object_id;
 static uint64_t g_next_track_object_id;
-static uint64_t g_current_group_object_id;
 static uint64_t g_parent_group_object_id;
+static uint64_t g_current_group_object_id;
 static uint64_t g_search_results_object_id;
 
 static int32_t  g_pos;
@@ -58,8 +58,8 @@ CREATE_FLAG(seeking_speed_read);
 CREATE_FLAG(track_segments_object_id_read);
 CREATE_FLAG(current_track_object_id_read);
 CREATE_FLAG(next_track_object_id_read);
-CREATE_FLAG(current_group_object_id_read);
 CREATE_FLAG(parent_group_object_id_read);
+CREATE_FLAG(current_group_object_id_read);
 CREATE_FLAG(search_results_object_id_read);
 CREATE_FLAG(playing_order_flag);
 CREATE_FLAG(playing_orders_supported_read);
@@ -303,22 +303,6 @@ static void next_track_id_cb(struct media_player *plr, int err, uint64_t id)
 	SET_FLAG(next_track_object_id_read);
 }
 
-static void current_group_id_cb(struct media_player *plr, int err, uint64_t id)
-{
-	if (err) {
-		FAIL("Current Group Object ID read failed (%d)\n", err);
-		return;
-	}
-
-	if (plr != current_player) {
-		FAIL("Wrong player\n");
-		return;
-	}
-
-	g_current_group_object_id = id;
-	SET_FLAG(current_group_object_id_read);
-}
-
 static void parent_group_id_cb(struct media_player *plr, int err, uint64_t id)
 {
 	if (err) {
@@ -333,6 +317,22 @@ static void parent_group_id_cb(struct media_player *plr, int err, uint64_t id)
 
 	g_parent_group_object_id = id;
 	SET_FLAG(parent_group_object_id_read);
+}
+
+static void current_group_id_cb(struct media_player *plr, int err, uint64_t id)
+{
+	if (err) {
+		FAIL("Current Group Object ID read failed (%d)\n", err);
+		return;
+	}
+
+	if (plr != current_player) {
+		FAIL("Wrong player\n");
+		return;
+	}
+
+	g_current_group_object_id = id;
+	SET_FLAG(current_group_object_id_read);
 }
 
 static void playing_order_recv_cb(struct media_player *plr, int err, uint8_t order)
@@ -535,8 +535,8 @@ void initialize_media(void)
 	cbs.track_segments_id_recv        = track_segments_id_cb;
 	cbs.current_track_id_recv         = current_track_id_cb;
 	cbs.next_track_id_recv            = next_track_id_cb;
-	cbs.current_group_id_recv         = current_group_id_cb;
 	cbs.parent_group_id_recv          = parent_group_id_cb;
+	cbs.current_group_id_recv         = current_group_id_cb;
 #endif /* CONFIG_BT_OTS */
 	cbs.playing_order_recv            = playing_order_recv_cb;
 	cbs.playing_order_write           = playing_order_write_cb;
@@ -1461,17 +1461,6 @@ void test_media_controller_player(struct media_player *player)
 	WAIT_FOR_FLAG(next_track_object_id_read);
 	printk("Next Track Object ID read succeeded\n");
 
-	/* Read current group object ******************************************/
-	UNSET_FLAG(current_group_object_id_read);
-	err = media_proxy_ctrl_current_group_id_get(current_player);
-	if (err) {
-		FAIL("Failed to read current group object ID: %d", err);
-		return;
-	}
-
-	WAIT_FOR_FLAG(current_group_object_id_read);
-	printk("Current Group Object ID read succeeded\n");
-
 	/* Read parent group object ******************************************/
 	UNSET_FLAG(parent_group_object_id_read);
 	err = media_proxy_ctrl_parent_group_id_get(current_player);
@@ -1482,6 +1471,17 @@ void test_media_controller_player(struct media_player *player)
 
 	WAIT_FOR_FLAG(parent_group_object_id_read);
 	printk("Parent Group Object ID read succeeded\n");
+
+	/* Read current group object ******************************************/
+	UNSET_FLAG(current_group_object_id_read);
+	err = media_proxy_ctrl_current_group_id_get(current_player);
+	if (err) {
+		FAIL("Failed to read current group object ID: %d", err);
+		return;
+	}
+
+	WAIT_FOR_FLAG(current_group_object_id_read);
+	printk("Current Group Object ID read succeeded\n");
 
 	/* Read and set playing order *************************************/
 	UNSET_FLAG(playing_order_flag);


### PR DESCRIPTION
For consistency and easier navigation, the media control code is
structured according to the order of the characteristics in the Media
Control Service specification.  This commit updates this according to
a change in a late spec errata, where the position of the parent group
characteristic was clarified.

There are no functional changes here, it is all just moving parent
group functions and variables unchanged to other places in the same
file.

Signed-off-by: Asbjørn Sæbø <asbjorn.sabo@nordicsemi.no>