### PR TITLE
shell: fix polling TXDONE signal by multiple threads

### DIFF
--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -698,6 +698,10 @@ struct shell_ctx {
 	volatile union shell_internal internal; /*!< Internal shell data.*/
 
 	struct k_poll_signal signals[SHELL_SIGNALS];
+
+	/*!< Events that should be used only internally by shell thread.
+	 * Event for SHELL_SIGNAL_TXDONE is initialized but unused.
+	 */
 	struct k_poll_event events[SHELL_SIGNALS];
 
 	struct k_mutex wr_mtx;

--- a/subsys/shell/shell_ops.c
+++ b/subsys/shell/shell_ops.c
@@ -369,7 +369,13 @@ static void shell_pend_on_txdone(const struct shell *shell)
 {
 	if (IS_ENABLED(CONFIG_MULTITHREADING) &&
 	    (shell->ctx->state < SHELL_STATE_PANIC_MODE_ACTIVE)) {
-		k_poll(&shell->ctx->events[SHELL_SIGNAL_TXDONE], 1, K_FOREVER);
+		struct k_poll_event event;
+
+		k_poll_event_init(&event,
+				  K_POLL_TYPE_SIGNAL,
+				  K_POLL_MODE_NOTIFY_ONLY,
+				  &shell->ctx->signals[SHELL_SIGNAL_TXDONE]);
+		k_poll(&event, 1, K_FOREVER);
 		k_poll_signal_reset(&shell->ctx->signals[SHELL_SIGNAL_TXDONE]);
 	} else {
 		/* Blocking wait in case of bare metal. */


### PR DESCRIPTION
This patch fixes the issue that can cause a deadlock in shell.
When two threads simultaneously poll the TXDONE signal, only one
of them will receive it, leaving second one stalled.
The problem was that shell's context contains k_poll_event objects that
were polled by multiple threads. Polling it overwrites the poller field
that was set by previous thread.
Instead, the k_poll_event object must be created on the stack by every
thread that wants to poll the TXDONE signal.
This makes sure that no thread will be left waiting for this signal forever.

Signed-off-by: Michał Barnaś <mb@semihalf.com>