### PR TITLE
Bluetooth: ISO: Add iso accept info struct

### DIFF
--- a/include/bluetooth/iso.h
+++ b/include/bluetooth/iso.h
@@ -446,6 +446,23 @@ struct bt_iso_chan_ops {
 	void (*sent)(struct bt_iso_chan *chan);
 };
 
+struct bt_iso_accept_info {
+	/** The ACL connection that is requesting authorization */
+	struct bt_conn *acl;
+
+	/** @brief The ID of the connected isochronous group (CIG) on the central
+	 *
+	 * The ID is unique per ACL
+	 */
+	uint8_t cig_id;
+
+	/** @brief The ID of the connected isochronous stream (CIS) on the central
+	 *
+	 * This ID is unique within a CIG
+	 */
+	uint8_t cis_id;
+};
+
 /** @brief ISO Server structure. */
 struct bt_iso_server {
 	/** Required minimim security level */
@@ -456,12 +473,13 @@ struct bt_iso_server {
 	 *  This callback is called whenever a new incoming connection requires
 	 *  authorization.
 	 *
-	 *  @param acl The ACL connection that is requesting authorization
+	 *  @param info The ISO accept information structure
 	 *  @param chan Pointer to receive the allocated channel
 	 *
 	 *  @return 0 in case of success or negative value in case of error.
 	 */
-	int (*accept)(struct bt_conn *acl, struct bt_iso_chan **chan);
+	int (*accept)(const struct bt_iso_accept_info *info,
+		      struct bt_iso_chan **chan);
 };
 
 /** @brief Register ISO server.

--- a/samples/bluetooth/iso_connected_benchmark/src/main.c
+++ b/samples/bluetooth/iso_connected_benchmark/src/main.c
@@ -272,9 +272,10 @@ static struct bt_iso_chan_ops iso_ops = {
 	.disconnected	= iso_disconnected,
 };
 
-static int iso_accept(struct bt_conn *acl, struct bt_iso_chan **chan)
+static int iso_accept(const struct bt_iso_accept_info *info,
+		      struct bt_iso_chan **chan)
 {
-	LOG_INF("Incoming ISO request from %p", (void *)acl);
+	LOG_INF("Incoming ISO request from %p", (void *)info->acl);
 
 	for (int i = 0; i < ARRAY_SIZE(iso_chans); i++) {
 		if (iso_chans[i].state == BT_ISO_DISCONNECTED) {

--- a/samples/bluetooth/peripheral_iso/src/main.c
+++ b/samples/bluetooth/peripheral_iso/src/main.c
@@ -125,9 +125,10 @@ static struct bt_iso_chan iso_chan = {
 	.qos = &iso_qos,
 };
 
-static int iso_accept(struct bt_conn *acl, struct bt_iso_chan **chan)
+static int iso_accept(const struct bt_iso_accept_info *info,
+		      struct bt_iso_chan **chan)
 {
-	printk("Incoming request from %p\n", (void *)acl);
+	printk("Incoming request from %p\n", (void *)info->acl);
 
 	if (iso_chan.iso) {
 		printk("No channels available\n");

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -1226,6 +1226,7 @@ static int hci_le_create_cis(const struct bt_iso_connect_param *param,
 
 int bt_iso_accept(struct bt_conn *acl, struct bt_conn *iso)
 {
+	struct bt_iso_accept_info accept_info;
 	struct bt_iso_chan *chan;
 	int err;
 
@@ -1241,7 +1242,11 @@ int bt_iso_accept(struct bt_conn *acl, struct bt_conn *iso)
 		return -ENOMEM;
 	}
 
-	err = iso_server->accept(acl, &chan);
+	accept_info.acl = acl;
+	accept_info.cig_id = iso->iso.cig_id;
+	accept_info.cis_id = iso->iso.cis_id;
+
+	err = iso_server->accept(&accept_info, &chan);
 	if (err < 0) {
 		BT_ERR("Server failed to accept: %d", err);
 		return err;

--- a/subsys/bluetooth/shell/iso.c
+++ b/subsys/bluetooth/shell/iso.c
@@ -77,9 +77,11 @@ static struct bt_iso_cig *cig;
 
 NET_BUF_POOL_FIXED_DEFINE(tx_pool, 1, DATA_MTU, NULL);
 
-static int iso_accept(struct bt_conn *acl, struct bt_iso_chan **chan)
+static int iso_accept(const struct bt_iso_accept_info *info,
+		      struct bt_iso_chan **chan)
 {
-	shell_print(ctx_shell, "Incoming request from %p", acl);
+	shell_print(ctx_shell, "Incoming request from %p with CIG ID 0x%02X and CIS ID 0x%02X",
+		    info->acl, info->cig_id, info->cis_id);
 
 	if (iso_chan.iso) {
 		shell_print(ctx_shell, "No channels available");


### PR DESCRIPTION
Add a new struct that provides information to the upper
layer when accepting an connected isochronous stream.

The CIG ID and CIS ID makes it possible for the upper layer
to determine which ISO channels are "together" in a group.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>