### PR TITLE
modem: hl7800: fix IPv6 operation

### DIFF
--- a/drivers/modem/Kconfig.hl7800
+++ b/drivers/modem/Kconfig.hl7800
@@ -303,4 +303,21 @@ config MODEM_HL7800_USE_GLONASS
 config MODEM_HL7800_POLTE
 	bool "Enable PoLTE commands and handlers"
 
+choice
+	prompt "IP Address family"
+	default MODEM_HL7800_ADDRESS_FAMILY_IPV4V6
+	help
+	  The address family for IP connections.
+
+config MODEM_HL7800_ADDRESS_FAMILY_IPV4
+	bool "IPv4"
+
+config MODEM_HL7800_ADDRESS_FAMILY_IPV6
+	bool "IPv6"
+
+config MODEM_HL7800_ADDRESS_FAMILY_IPV4V6
+	bool "IPv4v6"
+
+endchoice
+
 endif # MODEM_HL7800

--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -1709,14 +1709,16 @@ static void dns_work_cb(struct k_work *work)
 	struct dns_resolve_context *dnsCtx;
 	static const char * const dns_servers_str[] = { ictx.dns_string, NULL };
 
-	/* set new DNS addr in DNS resolver */
-	LOG_DBG("Refresh DNS resolver");
-	dnsCtx = dns_resolve_get_default();
+	if (ictx.iface && net_if_is_up(ictx.iface)) {
+		/* set new DNS addr in DNS resolver */
+		LOG_DBG("Refresh DNS resolver");
+		dnsCtx = dns_resolve_get_default();
 
-	ret = dns_resolve_reconfigure(dnsCtx, dns_servers_str, NULL);
-	if (ret < 0) {
-		LOG_ERR("dns_resolve_init fail (%d)", ret);
-		return;
+		ret = dns_resolve_reconfigure(dnsCtx, dns_servers_str, NULL);
+		if (ret < 0) {
+			LOG_ERR("dns_resolve_init fail (%d)", ret);
+			return;
+		}
 	}
 #endif
 }

--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -311,7 +311,18 @@ static const struct mdm_control_pinconfig pinconfig[] = {
 #define PROFILE_LINE_2                                                         \
 	"S00:255 S01:255 S03:255 S04:255 S05:255 S07:255 S08:255 S10:255\r\n"
 
-#define SETUP_GPRS_CONNECTION_CMD "AT+KCNXCFG=1,\"GPRS\",\"\",,,\"IPV4V6\""
+#define ADDRESS_FAMILY_IPV4 "IPV4"
+#if defined(CONFIG_MODEM_HL7800_ADDRESS_FAMILY_IPV4V6)
+#define MODEM_HL7800_ADDRESS_FAMILY "IPV4V6"
+#elif defined(CONFIG_MODEM_HL7800_ADDRESS_FAMILY_IPV4)
+#define MODEM_HL7800_ADDRESS_FAMILY ADDRESS_FAMILY_IPV4
+#else
+#define MODEM_HL7800_ADDRESS_FAMILY "IPV6"
+#endif
+
+#define SETUP_GPRS_CONNECTION_CMD                                                                  \
+	"AT+KCNXCFG=1,\"GPRS\",\"\",,,"                                                            \
+	"\"" MODEM_HL7800_ADDRESS_FAMILY "\""
 #define SET_RAT_M1_CMD_LEGACY "AT+KSRAT=0"
 #define SET_RAT_NB1_CMD_LEGACY "AT+KSRAT=1"
 #define SET_RAT_M1_CMD "AT+KSRAT=0,1"
@@ -4963,8 +4974,12 @@ static int write_apn(char *access_point_name)
 
 	/* PDP Context */
 	memset(cmd_string, 0, MDM_HL7800_APN_CMD_MAX_SIZE);
-	strncat(cmd_string, "AT+CGDCONT=1,\"IPV4V6\",\"",
-		MDM_HL7800_APN_CMD_MAX_STRLEN);
+	if (strcmp(MODEM_HL7800_ADDRESS_FAMILY, ADDRESS_FAMILY_IPV4)) {
+		strncat(cmd_string, "AT+CGDCONT=1,\"" MODEM_HL7800_ADDRESS_FAMILY "\",\"",
+			MDM_HL7800_APN_CMD_MAX_STRLEN);
+	} else {
+		strncat(cmd_string, "AT+CGDCONT=1,\"IP\",\"", MDM_HL7800_APN_CMD_MAX_STRLEN);
+	}
 	strncat(cmd_string, access_point_name, MDM_HL7800_APN_CMD_MAX_STRLEN);
 	strncat(cmd_string, "\"", MDM_HL7800_APN_CMD_MAX_STRLEN);
 	return send_at_cmd(NULL, cmd_string, MDM_CMD_SEND_TIMEOUT, 0, false);


### PR DESCRIPTION
Assign the IPv6 address from the LTE network to the
network iface.
Configure DNS resolver with IPv6 DNS address from the
LTE network.
Fix socket AT commands to account for IPv6 addresses.

fixes #38716
