### PR TITLE
display: st77xx: Move initialization to POST_KERNEL

### DIFF
--- a/drivers/display/display_st7735r.c
+++ b/drivers/display/display_st7735r.c
@@ -575,7 +575,7 @@ static const struct display_driver_api st7735r_api = {
 	};									\
 	DEVICE_DT_INST_DEFINE(inst, st7735r_init, st7735r_pm_control,		\
 			      &st7735r_data_ ## inst, &st7735r_config_ ## inst,	\
-			      APPLICATION, CONFIG_DISPLAY_INIT_PRIORITY,	\
+			      POST_KERNEL, CONFIG_DISPLAY_INIT_PRIORITY,	\
 			      &st7735r_api);
 
 DT_INST_FOREACH_STATUS_OKAY(ST7735R_INIT)

--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -439,5 +439,5 @@ static struct st7789v_data st7789v_data = {
 };
 
 DEVICE_DT_INST_DEFINE(0, &st7789v_init,
-	      st7789v_pm_control, &st7789v_data, NULL, APPLICATION,
+	      st7789v_pm_control, &st7789v_data, NULL, POST_KERNEL,
 	      CONFIG_DISPLAY_INIT_PRIORITY, &st7789v_api);


### PR DESCRIPTION
These are the only two display drivers initializing in APPLICATION.
Dependency exposed with LVGL with initialization at same level and
priority.

Fixes #38690

Signed-off-by: David Leach <david.leach@nxp.com>