### PR TITLE
xtensa: fix implicit declaration of _xtensa_handle_one_int*

### DIFF
--- a/arch/xtensa/core/xtensa-asm2.c
+++ b/arch/xtensa/core/xtensa-asm2.c
@@ -157,12 +157,29 @@ __unused void *xtensa_int##l##_c(void *interrupted_stack)	\
 	return z_get_next_switch_handle(interrupted_stack);		\
 }
 
+#if XCHAL_NMILEVEL >= 2
 DEF_INT_C_HANDLER(2)
+#endif
+
+#if XCHAL_NMILEVEL >= 3
 DEF_INT_C_HANDLER(3)
+#endif
+
+#if XCHAL_NMILEVEL >= 4
 DEF_INT_C_HANDLER(4)
+#endif
+
+#if XCHAL_NMILEVEL >= 5
 DEF_INT_C_HANDLER(5)
+#endif
+
+#if XCHAL_NMILEVEL >= 6
 DEF_INT_C_HANDLER(6)
+#endif
+
+#if XCHAL_NMILEVEL >= 7
 DEF_INT_C_HANDLER(7)
+#endif
 
 static inline DEF_INT_C_HANDLER(1)
 


### PR DESCRIPTION
Some Xtensa SoCs may not have that many levels of interrupts.
So limit the call to DEF_INT_C_HANDLER() to only supported
levels to avoid calling non-existent functions.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>