### PR TITLE
thread: set mxcsr bit 6 DAZ to zero to disable denormals-are-zeros

### DIFF
--- a/include/arch/x86/intel64/thread.h
+++ b/include/arch/x86/intel64/thread.h
@@ -36,7 +36,12 @@
 
 #define X86_FXSAVE_SIZE		512	/* size and alignment of buffer ... */
 #define X86_FXSAVE_ALIGN	16	/* ... for FXSAVE/FXRSTOR ops */
-#define X86_MXCSR_SANE		0x1dc0	/* enable division-by-zero exception */
+
+/* MXCSR Control and Status Register for SIMD floating-point operations.
+ * Set default value 1F80H according to the Intel(R) 64 and IA-32 Manual.
+ * Disable denormals-are-zeros mode.
+ */
+#define X86_MXCSR_SANE		0x1f80
 
 #ifndef _ASMLANGUAGE
 


### PR DESCRIPTION
Currently we are using mxcsr register with the bit 6 DAZ enabled.
When the denormals-are-zeros flag is set, the processor
converts all denormal source operands to a zero with the sign
of the original operand before performing any computations on them.
It causes bugs in the SIMD XMM registers computation like #38646
I suggest to disable Denormals-Are-Zeros flag and mask division-by-zero
exception.
Set value to the default 1F80H according to the Intel(R) 64 and IA-32
Architectures Software Developer's Manual.
Fix will let all x86 boards perform SIMD computation using XMM
registers in the correct way.
Fixes #38646

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>