### PR TITLE
Revert "lib: newlib: Add workaround for #38258"

### DIFF
--- a/cmake/verify-toolchain.cmake
+++ b/cmake/verify-toolchain.cmake
@@ -16,7 +16,7 @@
 # FORMAT=json: Print the output as a json formatted string, useful for Python
 
 # This is the minimum required Zephyr-SDK version which supports CMake package
-set(TOOLCHAIN_ZEPHYR_MINIMUM_REQUIRED_VERSION 0.13)
+set(TOOLCHAIN_ZEPHYR_MINIMUM_REQUIRED_VERSION 0.13.1)
 
 # Set internal variables if set in environment.
 if(NOT DEFINED ZEPHYR_TOOLCHAIN_VARIANT)

--- a/lib/libc/newlib/libc-hooks.c
+++ b/lib/libc/newlib/libc-hooks.c
@@ -130,20 +130,6 @@ static int malloc_prepare(const struct device *unused)
 		 "minimum required size specified by "
 		 "CONFIG_NEWLIB_LIBC_MIN_REQUIRED_HEAP_SIZE");
 
-#ifdef CONFIG_XTENSA
-	/*
-	 * FIXME: For Xtensa, the first `malloc` call may fail if the HEAP_BASE
-	 *        is such that the first `sbrk` call returns a 4096-byte
-	 *        aligned address.
-	 *
-	 *        This is a very ugly workaround for the issue #38258 and must
-	 *        be removed once it is fixed.
-	 */
-	void *ptr = malloc(16);
-
-	free(ptr);
-#endif /* CONFIG_XTENSA */
-
 	return 0;
 }
 


### PR DESCRIPTION
```
Revert "lib: newlib: Add workaround for #38258"

The commit 9bd1483afeb18f4225ec7b0340b0d4e20efb7d01 was added as a
workaround for the Xtensa initial malloc failure bug.

This bug has been fixed in the Zephyr SDK 0.13.1 release and therefore
this workaround is no longer needed.
```

Fixes #38258 

NOTE: This PR also contains a commit to update the minimum required Zephyr SDK version to 0.13.1, which is required to support this.