### PR TITLE
boards: nucleo_wb55rg: Give more flash space to M0 binary

### DIFF
--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -189,9 +189,9 @@ zephyr_udc0: &usb {
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		/* Set all partitions with first 812K of flash */
-		/* last 212K are reseved for M0 usage */
-		/* Configure partitions to make use of the whole 812K */
+		/* Set all partitions with first 808K of flash */
+		/* last 216K are reseved for M0 usage */
+		/* Configure partitions to make use of the whole 808K */
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
@@ -211,7 +211,7 @@ zephyr_udc0: &usb {
 		};
 		storage_partition: partition@c8000 {
 			label = "storage";
-			reg = <0x000c8000 0x3000>;
+			reg = <0x000c8000 0x2000>;
 		};
 
 	};

--- a/dts/arm/st/wb/stm32wb55Xg.dtsi
+++ b/dts/arm/st/wb/stm32wb55Xg.dtsi
@@ -14,7 +14,7 @@
 	soc {
 		flash-controller@58004000 {
 			flash0: flash@8000000 {
-				reg = <0x08000000 DT_SIZE_K(812)>;
+				reg = <0x08000000 DT_SIZE_K(808)>;
 			};
 		};
 	};


### PR DESCRIPTION
Since version 1.11.0, Full stack M0 binary requires 216K of flash
being available, while previously 212K were required.

Review flash partitioning to take it into account.
Additionally:
- update value in board yaml file.
- align value in package .dtsi file

Fixes #38735

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>