### PR TITLE
cmake: remove policy CMP0079 old behavior

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -31,11 +31,6 @@ cmake_minimum_required(VERSION 3.20.0)
 # CMP0002: "Logical target names must be globally unique"
 cmake_policy(SET CMP0002 NEW)
 
-# Use the old CMake behaviour until the build scripts have been ported
-# to the new behaviour.
-# CMP0079: "target_link_libraries() allows use with targets in other directories"
-cmake_policy(SET CMP0079 OLD)
-
 # Use the old CMake behaviour until we are updating the CMake 3.20 as minimum
 # required. This ensure that CMake >=3.20 will be consistent with older CMakes.
 # CMP0116: Ninja generators transform DEPFILE s from add_custom_command().


### PR DESCRIPTION
Fixes: #38558

This commit removes: `cmake_policy(SET CMP0079 OLD)`

This means Zephyr will now allow the new CMP0079 behavior introduced
with CMake version 3.13.

Code has now been examined and no occurences has been found where the
INTERFACE keyword was used with `target_link_libraries()` outside the
CMakeLists.txt scope where the original libraries were created.

As an additional safeguard `./scripts/twister -c -N --cmake-only`
has been executed before and after this change and all `build.ninja`
files for each test / sample have been diffed.
Removing the CMP0079 policy creates identical build files, hence removal
of the old policy will not impact the build.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>