### PR TITLE
soc: nordic_nrf: Add Kconfig option for enabling trace port

### DIFF
--- a/modules/hal_nordic/nrfx/CMakeLists.txt
+++ b/modules/hal_nordic/nrfx/CMakeLists.txt
@@ -38,6 +38,8 @@ zephyr_compile_definitions_ifdef(CONFIG_NRF_SECURE_APPROTECT_LOCK
                                  ENABLE_SECURE_APPROTECT)
 zephyr_compile_definitions_ifdef(CONFIG_NRF_SECURE_APPROTECT_USER_HANDLING
                                  ENABLE_SECURE_APPROTECT_USER_HANDLING)
+zephyr_library_compile_definitions_ifdef(CONFIG_NRF_TRACE_PORT
+                                 ENABLE_TRACE)
 
 # Connect Kconfig compilation option for Non-Secure software with option required by MDK/nrfx
 zephyr_compile_definitions_ifdef(CONFIG_ARM_NONSECURE_FIRMWARE NRF_TRUSTZONE_NONSECURE)

--- a/soc/arm/nordic_nrf/Kconfig
+++ b/soc/arm/nordic_nrf/Kconfig
@@ -119,4 +119,12 @@ config NRF_SECURE_APPROTECT_USER_HANDLING
 
 endchoice
 
+config NRF_TRACE_PORT
+	bool "Enable nRF TPIU"
+	depends on !SOC_SERIES_NRF51X
+	help
+	  Enable this option to initialize the TPIU (Trace Port Interface
+	  Unit) for tracing using a hardware probe. If disabled, the trace
+	  pins will be used as GPIO.
+
 endif # SOC_FAMILY_NRF


### PR DESCRIPTION
Add Kconfig option to enable the hardware trace port in the SystemInit() function in the Nordic MDK.