### PR TITLE
Documentation: Kconfig - move links to official doc to separate page

### DIFF
--- a/doc/guides/build/index.rst
+++ b/doc/guides/build/index.rst
@@ -365,6 +365,7 @@ tips and best practices for writing :file:`Kconfig` files.
 .. toctree::
    :maxdepth: 1
 
+   kconfig/official_doc.rst
    kconfig/menuconfig.rst
    kconfig/setting.rst
    kconfig/tips.rst

--- a/doc/guides/build/kconfig/official_doc.rst
+++ b/doc/guides/build/kconfig/official_doc.rst
@@ -1,0 +1,11 @@
+.. _kconfig_official_doc:
+
+Kconfig - Official Documentation
+################################
+
+.. note::
+
+   The official Kconfig documentation is `kconfig-language.rst
+   <https://www.kernel.org/doc/html/latest/kbuild/kconfig-language.html>`__
+   and `kconfig-macro-language.rst
+   <https://www.kernel.org/doc/html/latest/kbuild/kconfig-macro-language.html>`__.

--- a/doc/guides/build/kconfig/tips.rst
+++ b/doc/guides/build/kconfig/tips.rst
@@ -6,13 +6,6 @@ Kconfig - Tips and Best Practices
 This page covers some Kconfig best practices and explains some Kconfig
 behaviors and features that might be cryptic or that are easily overlooked.
 
-.. note::
-
-   The official Kconfig documentation is `kconfig-language.rst
-   <https://www.kernel.org/doc/html/latest/kbuild/kconfig-language.html>`__
-   and `kconfig-macro-language.rst
-   <https://www.kernel.org/doc/html/latest/kbuild/kconfig-macro-language.html>`__.
-
 .. contents::
    :local:
    :depth: 2


### PR DESCRIPTION
Move note with links to official Kconfig documentation to separate
page, to make it visible in the table of contents, so that it is
easier to find.

Signed-off-by: Asbjørn Sæbø <asbjorn.sabo@nordicsemi.no>