### PR TITLE
cmake: gnu: Fix debugging when GDB fails to load because of Python

### DIFF
--- a/cmake/bintools/gnu/target.cmake
+++ b/cmake/bintools/gnu/target.cmake
@@ -12,6 +12,23 @@ find_program(CMAKE_NM      ${CROSS_COMPILE}nm      PATHS ${TOOLCHAIN_HOME} NO_DE
 find_program(CMAKE_STRIP   ${CROSS_COMPILE}strip   PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
 
 find_program(CMAKE_GDB     ${CROSS_COMPILE}gdb     PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+
+if(CMAKE_GDB)
+  execute_process(
+    COMMAND ${CMAKE_GDB} --configuration
+    OUTPUT_VARIABLE GDB_PY_NO_PY
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    RESULTS_VARIABLE GDB_CFG_ERR
+    )
+  if (${GDB_CFG_ERR})
+    # Failed to execute GDB, likely because of Python deps
+    find_program(CMAKE_GDB_NO_PY  ${CROSS_COMPILE}gdb-no-py  PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+    if (CMAKE_GDB_NO_PY)
+      set(CMAKE_GDB ${CMAKE_GDB_NO_PY} CACHE FILEPATH "Path to a program." FORCE)
+    endif()
+  endif()
+endif()
+
 find_program(CMAKE_GDB     gdb-multiarch           PATHS ${TOOLCHAIN_HOME}                )
 
 # Include bin tool properties


### PR DESCRIPTION
GDB can be built with or without Python support. When built with Python
support this can cause a particular problem: The gdb executable relies
on shared libraries that are bound to a specific Python version. But
since most Linux distributions typically ship with a single version, it
is very difficult to choose which one to target when building GDB.
When GDB executes, if it fails to load the shared libraries it will exit
immediately with an error code of 127 and output resembling this:

/home/carles/bin/zephyr-sdk/arm-zephyr-eabi/bin/arm-zephyr-eabi-gdb:
error while loading shared libraries: libpython3.8.so.1.0: cannot open
shared object file: No such file or directory

There are two known approaches to shipping multiple gdb executables:

- The Zephyr SDK ships a default `gdb` with Python **enabled**, and then a
  separate `gdb-no-py` executable with Python **disabled**
- GNU Arm Embedded ships with a default `gdb` with Python **disabled**, and an
  additional `gdb-py` with Python **enabled**

To mitigate the problem of not being able to debug, fall back to a
'gdb-no-py' if it exists whenever the standard gdb executable fails to
even run.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>