### PR TITLE
MAINTAINERS: add myself as riscv collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1205,6 +1205,7 @@ RISCV arch:
     collaborators:
         - mgielda
         - katsuster
+        - henrikbrixandersen
     files:
         - arch/riscv/
         - boards/riscv/


### PR DESCRIPTION
Add myself as collaborator for RISC-V architecture related code.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>