### PR TITLE
bluetooth: host: conn: Fix conn param during l2cap fallback

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1464,6 +1464,8 @@ static int send_conn_le_param_update(struct bt_conn *conn,
 
 		/* store those in case of fallback to L2CAP */
 		if (rc == 0) {
+			conn->le.interval_min = param->interval_min;
+			conn->le.interval_max = param->interval_max;
 			conn->le.pending_latency = param->latency;
 			conn->le.pending_timeout = param->timeout;
 		}


### PR DESCRIPTION
When falling back to L2CAP for connection parameter updates, the
interval min and maxes should also be saved.

Fixes #38613.

Signed-off-by: Eric Johnson <eric@liveathos.com>