### PR TITLE
drivers: sx126x_stm32wl: clear the radio IRQ before reenabling it

### DIFF
--- a/drivers/lora/sx126x_stm32wl.c
+++ b/drivers/lora/sx126x_stm32wl.c
@@ -35,6 +35,7 @@ uint32_t sx126x_get_dio1_pin_state(struct sx126x_data *dev_data)
 
 void sx126x_dio1_irq_enable(struct sx126x_data *dev_data)
 {
+	NVIC_ClearPendingIRQ(DT_INST_IRQN(0));
 	irq_enable(DT_INST_IRQN(0));
 }
 


### PR DESCRIPTION
Hi, quick fix for the WL variant of the sx126x radio driver. Troubleshooted this with @aurel32 in Discord, chasing down some suspiciously high power consumption in idle state. See the patch comment for the details.