### PR TITLE
drivers: uart_ns16550: add interrupt workaround for it8xxx2 series

### DIFF
--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -859,6 +859,13 @@ static void uart_ns16550_isr(const struct device *dev)
 		dev_data->cb(dev, dev_data->cb_data);
 	}
 
+	if (IS_ENABLED(CONFIG_SOC_IT8XXX2_UART_INT_WORKAROUND)) {
+		uint8_t ier = INBYTE(IER(dev));
+
+		/* re-enables IER */
+		OUTBYTE(IER(dev), 0);
+		OUTBYTE(IER(dev), ier);
+	}
 }
 
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */

--- a/soc/riscv/riscv-ite/it8xxx2/Kconfig.soc
+++ b/soc/riscv/riscv-ite/it8xxx2/Kconfig.soc
@@ -23,6 +23,15 @@ config SOC_IT8XXX2_PLL_FLASH_48M
 	  Set n to use the default settings.
 	  (PLL and CPU run at 48MHz, flash frequency is 16MHz)
 
+config SOC_IT8XXX2_UART_INT_WORKAROUND
+	bool "Enable uart workaround to prevent uart interrupt get stuck"
+	default y
+	depends on UART_NS16550
+	help
+	   IT8XXX2 uart interrupt polarity is rising-edge-triggered.
+	   This configuration re-enables IER at the end of ISR to ensure a pending
+	   uart interrupt can be fired again after interrupt return.
+
 choice
 	prompt "Clock source for PLL reference clock"
 


### PR DESCRIPTION
INTC uart interrupt polarity on IT8XXX2 is rising-edge-triggered.
If IIR (interrupt identification register) is set after calling
callback function and before interrupt return. The INTC will miss the
interrupt due to it can't sense low to high change from uart.
This fix the issue.

Signed-off-by: Dino Li <Dino.Li@ite.com.tw>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zephyrproject-rtos/zephyr/38767)
<!-- Reviewable:end -->
