### PR TITLE
include: net: remove __packed from network structs

### DIFF
--- a/include/net/dhcpv4.h
+++ b/include/net/dhcpv4.h
@@ -40,7 +40,7 @@ enum net_dhcpv4_state {
 	NET_DHCPV4_RENEWING,
 	NET_DHCPV4_REBINDING,
 	NET_DHCPV4_BOUND,
-} __packed;
+};
 
 /** @endcond */
 

--- a/include/net/ethernet.h
+++ b/include/net/ethernet.h
@@ -294,7 +294,7 @@ enum ethernet_qbu_param_type {
 enum ethernet_qbu_preempt_status {
 	ETHERNET_QBU_STATUS_EXPRESS,
 	ETHERNET_QBU_STATUS_PREEMPTABLE
-} __packed;
+};
 
 /** @endcond */
 
@@ -455,7 +455,7 @@ struct net_eth_hdr {
 	struct net_eth_addr dst;
 	struct net_eth_addr src;
 	uint16_t type;
-} __packed;
+};
 
 struct ethernet_vlan {
 	/** Network interface that has VLAN enabled */
@@ -610,7 +610,7 @@ struct net_eth_vlan_hdr {
 		uint16_t tci;  /* tag control info */
 	} vlan;
 	uint16_t type;
-} __packed;
+};
 
 
 static inline bool net_eth_is_addr_broadcast(struct net_eth_addr *addr)

--- a/include/net/gptp.h
+++ b/include/net/gptp.h
@@ -52,7 +52,7 @@ struct gptp_scaled_ns {
 
 	/** Low half. */
 	int64_t low;
-} __packed;
+};
 
 /**
  * @brief UScaled Nanoseconds.
@@ -63,7 +63,7 @@ struct gptp_uscaled_ns {
 
 	/** Low half. */
 	uint64_t low;
-} __packed;
+};
 
 /** @cond INTERNAL_HIDDEN */
 
@@ -128,7 +128,7 @@ struct gptp_port_identity {
 
 	/** Number of the port. */
 	uint16_t port_number;
-} __packed;
+};
 
 struct gptp_flags {
 	union {
@@ -138,7 +138,7 @@ struct gptp_flags {
 		/** Whole field access. */
 		uint16_t all;
 	};
-} __packed;
+};
 
 struct gptp_hdr {
 	/** Type of the message. */
@@ -182,7 +182,7 @@ struct gptp_hdr {
 
 	/** Message Interval in Log2 for Sync and Announce messages. */
 	int8_t log_msg_interval;
-} __packed;
+};
 
 /** @cond INTERNAL_HIDDEN */
 

--- a/include/net/lldp.h
+++ b/include/net/lldp.h
@@ -140,7 +140,7 @@ struct net_lldp_chassis_tlv {
 	uint8_t subtype;
 	/** Chassis ID value */
 	uint8_t value[NET_LLDP_CHASSIS_ID_VALUE_LEN];
-} __packed;
+};
 
 /** Port ID TLV, see chapter 8.5.3 in IEEE 802.1AB */
 struct net_lldp_port_tlv {
@@ -150,7 +150,7 @@ struct net_lldp_port_tlv {
 	uint8_t subtype;
 	/** Port ID value */
 	uint8_t value[NET_LLDP_PORT_ID_VALUE_LEN];
-} __packed;
+};
 
 /** Time To Live TLV, see chapter 8.5.4 in IEEE 802.1AB */
 struct net_lldp_time_to_live_tlv {
@@ -158,7 +158,7 @@ struct net_lldp_time_to_live_tlv {
 	uint16_t type_length;
 	/** Time To Live (TTL) value */
 	uint16_t ttl;
-} __packed;
+};
 
 /**
  * LLDP Data Unit (LLDPDU) shall contain the following ordered TLVs
@@ -168,7 +168,7 @@ struct net_lldpdu {
 	struct net_lldp_chassis_tlv chassis_id;	/**< Mandatory Chassis TLV */
 	struct net_lldp_port_tlv port_id;	/**< Mandatory Port TLV */
 	struct net_lldp_time_to_live_tlv ttl;	/**< Mandatory TTL TLV */
-} __packed;
+};
 
 /**
  * @brief Set the LLDP data unit for a network interface.

--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -414,7 +414,7 @@ enum net_priority {
 	NET_PRIORITY_VO = 5, /**< Voice, < 10 ms latency and jitter  */
 	NET_PRIORITY_IC = 6, /**< Internetwork control               */
 	NET_PRIORITY_NC = 7  /**< Network control                    */
-} __packed;
+};
 
 #define NET_MAX_PRIORITIES 8 /* How many priority values there are */
 
@@ -433,7 +433,7 @@ enum net_addr_state {
 	NET_ADDR_TENTATIVE = 0,  /**< Tentative address              */
 	NET_ADDR_PREFERRED,      /**< Preferred address              */
 	NET_ADDR_DEPRECATED,     /**< Deprecated address             */
-} __packed;
+};
 
 /** How the network address is assigned to network interface */
 enum net_addr_type {
@@ -447,7 +447,7 @@ enum net_addr_type {
 	NET_ADDR_MANUAL,
 	/** Manually set address which is overridable by DHCP */
 	NET_ADDR_OVERRIDABLE,
-} __packed;
+};
 
 /** @cond INTERNAL_HIDDEN */
 
@@ -460,14 +460,14 @@ struct net_ipv6_hdr {
 	uint8_t hop_limit;
 	struct in6_addr src;
 	struct in6_addr dst;
-} __packed;
+};
 
 struct net_ipv6_frag_hdr {
 	uint8_t nexthdr;
 	uint8_t reserved;
 	uint16_t offset;
 	uint32_t id;
-} __packed;
+};
 
 struct net_ipv4_hdr {
 	uint8_t vhl;
@@ -480,20 +480,20 @@ struct net_ipv4_hdr {
 	uint16_t chksum;
 	struct in_addr src;
 	struct in_addr dst;
-} __packed;
+};
 
 struct net_icmp_hdr {
 	uint8_t type;
 	uint8_t code;
 	uint16_t chksum;
-} __packed;
+};
 
 struct net_udp_hdr {
 	uint16_t src_port;
 	uint16_t dst_port;
 	uint16_t len;
 	uint16_t chksum;
-} __packed;
+};
 
 struct net_tcp_hdr {
 	uint16_t src_port;
@@ -506,7 +506,7 @@ struct net_tcp_hdr {
 	uint16_t chksum;
 	uint8_t urg[2];
 	uint8_t optdata[0];
-} __packed;
+};
 
 static inline const char *net_addr_type2str(enum net_addr_type type)
 {

--- a/include/net/net_l2.h
+++ b/include/net/net_l2.h
@@ -44,7 +44,7 @@ enum net_l2_flags {
 	 * IP address etc to network interface.
 	 */
 	NET_L2_POINT_TO_POINT			= BIT(3),
-} __packed;
+};
 
 /**
  * @brief Network L2 structure

--- a/include/net/net_linkaddr.h
+++ b/include/net/net_linkaddr.h
@@ -59,7 +59,7 @@ enum net_link_type {
 	NET_LINK_CANBUS_RAW,
 	/** 6loCAN link address. */
 	NET_LINK_CANBUS,
-} __packed;
+};
 
 /**
  *  @brief Hardware link address structure

--- a/include/net/ppp.h
+++ b/include/net/ppp.h
@@ -162,7 +162,7 @@ enum lcp_option_type {
 
 	/** Address-and-Control-Field-Compression */
 	LCP_OPTION_ADDR_CTRL_COMPRESS = 8
-} __packed;
+};
 
 /**
  * IPCP option types from RFC 1332
@@ -192,7 +192,7 @@ enum ipcp_option_type {
 
 	/** Secondary NBNS Server Address */
 	IPCP_OPTION_NBNS2 = 132,
-} __packed;
+};
 
 /**
  * IPV6CP option types from RFC 5072
@@ -202,7 +202,7 @@ enum ipv6cp_option_type {
 
 	/** Interface identifier */
 	IPV6CP_OPTION_INTERFACE_IDENTIFIER = 1,
-} __packed;
+};
 
 /**
  * @typedef net_ppp_lcp_echo_reply_cb_t

--- a/include/net/ptp_time.h
+++ b/include/net/ptp_time.h
@@ -109,7 +109,7 @@ struct net_ptp_extended_time {
 		} _fns;
 		uint64_t fract_nsecond;
 	};
-} __packed;
+};
 
 /**
  * @}


### PR DESCRIPTION
GCC 9 produces a warning about taking the address of a member
of a packed structure. Since the networking headers should all
use unaligned accesses and are manually packed then we can
remove the attribute.

Fixes #16587
