### PR TITLE
cmake: remove target_compile_definitions() in zephyr_library_property

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -577,7 +577,6 @@ endfunction()
 function(zephyr_library_property)
   set(single_args "ALLOW_EMPTY")
   cmake_parse_arguments(LIB_PROP "" "${single_args}" "" ${ARGN})
-  target_compile_definitions(${ZEPHYR_CURRENT_LIBRARY} PRIVATE ${item} ${ARGN})
 
   if(LIB_PROP_UNPARSED_ARGUMENTS)
       message(FATAL_ERROR "zephyr_library_property(${ARGV0} ...) given unknown arguments: ${FILE_UNPARSED_ARGUMENTS}")


### PR DESCRIPTION
Fixes: #38761

The introduction of zephyr_library_property in #38347 contained a
stray function call `target_compile_definitions()` resulting in the
library property name and value to also be added compile definitions to
the Zephyr library.

The Zephyr library property is an internal property and is not supposed
to be added as compile definitions, and thus this call is removed with
this commit.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>