### PR TITLE
samples: boards: nrf: battery: fix usage without voltage divider

### DIFF
--- a/samples/boards/nrf/battery/README.rst
+++ b/samples/boards/nrf/battery/README.rst
@@ -73,7 +73,7 @@ The code can be found in :zephyr_file:`samples/boards/nrf/battery`.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/boards/nrf/battery
-   :board: nrf52_pca20020
+   :board: thingy52_nrf52832
    :goals: build flash
    :compact:
 

--- a/samples/boards/nrf/battery/README.rst
+++ b/samples/boards/nrf/battery/README.rst
@@ -11,29 +11,40 @@ infrastructure to measure the voltage of the device power supply.  Two
 power supply configurations are supported:
 
 * If the board devicetree has a ``/vbatt`` node with compatible
-  ``voltage-divider`` then the voltage is measured using that divider.
-* Otherwise the power source is assumed to be directly connected to the
-  digital voltage signal, and the internal source for ``Vdd`` is
-  selected.
+  ``voltage-divider`` then the voltage is measured using that divider. An
+  example of a devicetree node describing a voltage divider for battery
+  monitoring is:
 
-An example of a devicetree node describing a voltage divider for battery
-monitoring is:
+   .. code-block:: devicetree
 
-.. code-block:: none
+      / {
+         vbatt {
+            compatible = "voltage-divider";
+            io-channels = <&adc 4>;
+            output-ohms = <180000>;
+            full-ohms = <(1500000 + 180000)>;
+            power-gpios = <&sx1509b 4 0>;
+         };
+      };
 
-   / {
-   	vbatt {
-   		compatible = "voltage-divider";
-   		io-channels = <&adc 4>;
-   		output-ohms = <180000>;
-   		full-ohms = <(1500000 + 180000)>;
-   		power-gpios = <&sx1509b 4 0>;
-   	};
-   };
+* If the board does not have a voltage divider and so no ``/vbatt`` node
+  present, the ADC configuration (device and channel) needs to be provided via
+  the ``zephyr,user`` node. In this case the power source is assumed to be
+  directly connected to the digital voltage signal, and the internal source for
+  ``Vdd`` is selected. An example of a Devicetree configuration for this case is
+  shown below:
+
+   .. code-block :: devicetree
+
+      / {
+         zephyr,user {
+            io-channels = <&adc 4>;
+         };
+      };
 
 Note that in many cases where there is no voltage divider the digital
 voltage will be fed from a regulator that provides a fixed voltage
-regardless of source voltage, rather than by the source directly.  In
+regardless of source voltage, rather than by the source directly. In
 configuration involving a regulator the measured voltage will be
 constant.
 

--- a/samples/boards/nrf/battery/src/battery.c
+++ b/samples/boards/nrf/battery/src/battery.c
@@ -21,6 +21,7 @@
 LOG_MODULE_REGISTER(BATTERY, CONFIG_ADC_LOG_LEVEL);
 
 #define VBATT DT_PATH(vbatt)
+#define ZEPHYR_USER DT_PATH(zephyr_user)
 
 #ifdef CONFIG_BOARD_THINGY52_NRF52832
 /* This board uses a divider that reduces max voltage to
@@ -71,7 +72,7 @@ static const struct divider_config divider_config = {
 	.full_ohm = DT_PROP(VBATT, full_ohms),
 #else /* /vbatt exists */
 	.io_channel = {
-		DT_LABEL(DT_NODELABEL(adc)),
+		DT_IO_CHANNELS_INPUT(ZEPHYR_USER),
 	},
 #endif /* /vbatt exists */
 };
@@ -84,7 +85,11 @@ struct divider_data {
 	int16_t raw;
 };
 static struct divider_data divider_data = {
+#if DT_NODE_HAS_STATUS(VBATT, okay)
 	.adc = DEVICE_DT_GET(DT_IO_CHANNELS_CTLR(VBATT)),
+#else
+	.adc = DEVICE_DT_GET(DT_IO_CHANNELS_CTLR(ZEPHYR_USER)),
+#endif
 };
 
 static int divider_setup(void)


### PR DESCRIPTION
The nRF battery sample claims that it works without the need of a vbatt
node (voltage divider). However, this was currently not possible because
the sample code did have no means to extract the necessary ADC details
(instance and channel) from Devicetree unless vbatt was present. Similar
to other ADC samples, the zephyr,user node is used to define io-channels
property in this case. The sample README has been updated with an
example of how measurement without a voltage divider can be achieved.

Fixes #37865 