### PR TITLE
net: lwm2m: Add default firmware update port

### DIFF
--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -162,7 +162,19 @@ config LWM2M_PEER_PORT
 	depends on LWM2M_RD_CLIENT_SUPPORT
 	default 5683
 	help
-	  This is the default server port to connect to for LWM2M communication
+	  This is the default server port to connect to for LWM2M communication.
+
+config LWM2M_FIRMWARE_PORT_NONSECURE
+	int "LWM2M firmware server port non-secure"
+	default 5683
+	help
+	  This is the default server port to connect to for LwM2M firmware downloads over coap.
+
+config LWM2M_FIRMWARE_PORT_SECURE
+	int "LWM2M firmware server port secure"
+	default 5684
+	help
+	  This is the default server port to connect to for LwM2M firmware downloads over coaps.
 
 config LWM2M_SECURITY_INSTANCE_COUNT
 	int "Maximum # of LWM2M Security object instances"

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -4724,7 +4724,7 @@ int lwm2m_socket_start(struct lwm2m_ctx *client_ctx)
 	return lwm2m_socket_add(client_ctx);
 }
 
-int lwm2m_parse_peerinfo(char *url, struct sockaddr *addr, bool *use_dtls)
+int lwm2m_parse_peerinfo(char *url, struct sockaddr *addr, bool *use_dtls, bool is_firmware_uri)
 {
 	struct http_parser_url parser;
 #if defined(CONFIG_LWM2M_DNS_SUPPORT)
@@ -4762,8 +4762,16 @@ int lwm2m_parse_peerinfo(char *url, struct sockaddr *addr, bool *use_dtls)
 	}
 
 	if (!(parser.field_set & (1 << UF_PORT))) {
-		/* Set to default port of CoAP */
-		parser.port = CONFIG_LWM2M_PEER_PORT;
+		if (is_firmware_uri && *use_dtls) {
+			/* Set to default coaps firmware update port */
+			parser.port = CONFIG_LWM2M_FIRMWARE_PORT_SECURE;
+		} else if (is_firmware_uri) {
+			/* Set to default coap firmware update port */
+			parser.port = CONFIG_LWM2M_FIRMWARE_PORT_NONSECURE;
+		} else {
+			/* Set to default LwM2M server port */
+			parser.port = CONFIG_LWM2M_PEER_PORT;
+		}
 	}
 
 	off = parser.field_data[UF_HOST].off;
@@ -4848,7 +4856,7 @@ int lwm2m_engine_start(struct lwm2m_ctx *client_ctx)
 
 	url[url_len] = '\0';
 	ret = lwm2m_parse_peerinfo(url, &client_ctx->remote_addr,
-				   &client_ctx->use_dtls);
+				   &client_ctx->use_dtls, false);
 	if (ret < 0) {
 		return ret;
 	}

--- a/subsys/net/lib/lwm2m/lwm2m_engine.h
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.h
@@ -144,6 +144,6 @@ const char *lwm2m_engine_get_attr_name(const struct lwm2m_attr *attr);
 int  lwm2m_socket_add(struct lwm2m_ctx *ctx);
 void lwm2m_socket_del(struct lwm2m_ctx *ctx);
 int  lwm2m_socket_start(struct lwm2m_ctx *client_ctx);
-int  lwm2m_parse_peerinfo(char *url, struct sockaddr *addr, bool *use_dtls);
+int  lwm2m_parse_peerinfo(char *url, struct sockaddr *addr, bool *use_dtls, bool is_firmware_uri);
 
 #endif /* LWM2M_ENGINE_H */

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
@@ -387,7 +387,7 @@ static void firmware_transfer(void)
 #endif
 
 	ret = lwm2m_parse_peerinfo(server_addr, &firmware_ctx.remote_addr,
-				   &firmware_ctx.use_dtls);
+				   &firmware_ctx.use_dtls, true);
 	if (ret < 0) {
 		LOG_ERR("Failed to parse server URI.");
 		goto error;


### PR DESCRIPTION
If a firmware update is fetched from a server, and no port number is set
in the URI (e.g. coap://example.com/fw_update), the client will try
to connect on the port specified by CONFIG_LWM2M_PEER_PORT.
If a port different from the peer port is to be used for firmware
update, this has to be set explicitly in the URI:
coap://example.com:5683/fw_update.

This fix adds CONFIG_LWM2M_FIRMWARE_PORT, which will be used when
fetching a firmware update without specifying the port number in the
URI.

Signed-off-by: Tjerand Bjornsen <tjerand.bjornsen@nordicsemi.no>