### PR TITLE
Bluetooth: Mesh: Fix mesh mod_pub shell command

### DIFF
--- a/subsys/bluetooth/mesh/shell.c
+++ b/subsys/bluetooth/mesh/shell.c
@@ -1632,7 +1632,7 @@ static int mod_pub_get(const struct shell *shell, uint16_t addr, uint16_t mod_id
 static int mod_pub_set(const struct shell *shell, uint16_t addr, uint16_t mod_id,
 		       uint16_t cid, char *argv[])
 {
-	struct bt_mesh_cfg_mod_pub pub;
+	struct bt_mesh_cfg_mod_pub pub = {0};
 	uint8_t status, count;
 	uint16_t interval;
 	int err;


### PR DESCRIPTION
Model publication configuration structure has uuid field,
which is used to configure publication to a virtual address.

This commit sets it to zero so that it is not used, when configuring
models publication via shell.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>