### PR TITLE
scripts: check_compliance should not generate soc/shield Kconfig files

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -268,36 +268,6 @@ class KconfigCheck(ComplianceTest):
                 ))
             fp_module_file.write(content)
 
-    def write_kconfig_soc(self):
-        """
-        Write KConfig soc files to be sourced during Kconfig parsing
-
-        """
-
-        soc_defconfig_file = os.path.join(tempfile.gettempdir(), "Kconfig.soc.defconfig")
-        soc_file = os.path.join(tempfile.gettempdir(), "Kconfig.soc")
-        soc_arch_file = os.path.join(tempfile.gettempdir(), "Kconfig.soc.arch")
-        shield_defconfig_file = os.path.join(tempfile.gettempdir(), "Kconfig.shield.defconfig")
-        shield_file = os.path.join(tempfile.gettempdir(), "Kconfig.shield")
-        try:
-            with open(soc_defconfig_file, 'w', encoding="utf-8") as fp:
-                fp.write(f'osource "{ZEPHYR_BASE}/soc/$(ARCH)/*/Kconfig.defconfig"\n')
-
-            with open(soc_file, 'w', encoding="utf-8") as fp:
-                fp.write(f'osource "{ZEPHYR_BASE}/soc/$(ARCH)/*/Kconfig.soc"\n')
-
-            with open(soc_arch_file, 'w', encoding="utf-8") as fp:
-                fp.write(f'osource "{ZEPHYR_BASE}/soc/$(ARCH)/Kconfig"\n\
-osource "{ZEPHYR_BASE}/soc/$(ARCH)/*/Kconfig"\n')
-
-            with open(shield_defconfig_file, 'w', encoding="utf-8") as fp:
-                fp.write(f'osource "{ZEPHYR_BASE}/boards/shields/*/Kconfig.defconfig"\n')
-
-            with open(shield_file, 'w', encoding="utf-8") as fp:
-                fp.write(f'osource "{ZEPHYR_BASE}/boards/shields/*/Kconfig.shield"\n')
-        except IOError as ex:
-            self.error(ex.output)
-
     def parse_kconfig(self):
         """
         Returns a kconfiglib.Kconfig object for the Kconfig files. We reuse
@@ -336,9 +306,6 @@ osource "{ZEPHYR_BASE}/soc/$(ARCH)/*/Kconfig"\n')
 
         # For multi repo support
         self.get_modules(os.path.join(tempfile.gettempdir(), "Kconfig.modules"))
-
-        # For list of SOC_ROOT support
-        self.write_kconfig_soc()
 
         # Tells Kconfiglib to generate warnings for all references to undefined
         # symbols within Kconfig files


### PR DESCRIPTION
Fixes: #38463

With 6be1b2af9b1e00a5b28f3341454aea65af8f8d77 then Zephyr shields and
soc Kconfig are always sourced from Kconfig directly.

However, check_compliance.py generates Kconfig files for sourcing the
same files thus sourcing the same files twice.
The end result is a lot of Kconfig warnings as described in #38463.

Removing the generated Kconfig files as this is no longer needed after
6be1b2af9b1e00a5b28f3341454aea65af8f8d77 has been introduced.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>