### PR TITLE
doc: relnotes: Add a comment to the Bluetooth 2.6 release notes

### DIFF
--- a/doc/releases/release-notes-2.6.rst
+++ b/doc/releases/release-notes-2.6.rst
@@ -259,6 +259,10 @@ Bluetooth
   * Added the ability to send HCI monitor traces over RTT.
   * Refactored the Bluetooth buffer configuration for simplicity. See the
     commit message of 6483e12a8ac4f495b28279a6b84014f633b0d374 for more info.
+    Note however that the aformentioned commit message has two typos;
+
+    * ``BT_CTLR_TX_BUFFER`` should be ``BT_CTLR_TX_BUFFERS``
+    * ``BT_CTLR_TX_BUFFERS_SIZE`` should be ``BT_CTLR_TX_BUFFER_SIZE``
   * Added support for concurrent advertising with multiple identities.
   * Changed the logic to disable scanning before setting the random address.
   * Fixed a crash where an ATT timeout occurred on a disconnected ATT channel.


### PR DESCRIPTION
The Zephyr 2.6 release notes, in the Bluetooth section, refers the user
to a commit message which had a couple of typos in it. Clarify this in
the very release notes.

Fixes #36692.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>