### PR TITLE
lib: os: mpsc_pbuf: Add const qualifier to API calls

### DIFF
--- a/include/logging/log_msg2.h
+++ b/include/logging/log_msg2.h
@@ -542,7 +542,7 @@ static inline uint32_t log_msg2_get_total_wlen(const struct log_msg2_desc desc)
  *
  * @return Length in 32 bit words.
  */
-static inline uint32_t log_msg2_generic_get_wlen(union mpsc_pbuf_generic *item)
+static inline uint32_t log_msg2_generic_get_wlen(const union mpsc_pbuf_generic *item)
 {
 	union log_msg2_generic *generic_msg = (union log_msg2_generic *)item;
 

--- a/include/sys/mpsc_pbuf.h
+++ b/include/sys/mpsc_pbuf.h
@@ -69,7 +69,7 @@ struct mpsc_pbuf_buffer;
  *
  * @return Size of the packet in 32 bit words.
  */
-typedef uint32_t (*mpsc_pbuf_get_wlen)(union mpsc_pbuf_generic *packet);
+typedef uint32_t (*mpsc_pbuf_get_wlen)(const union mpsc_pbuf_generic *packet);
 
 /** @brief Callback called when packet is dropped.
  *
@@ -77,8 +77,8 @@ typedef uint32_t (*mpsc_pbuf_get_wlen)(union mpsc_pbuf_generic *packet);
  *
  * @param packet Packet that is being dropped.
  */
-typedef void (*mpsc_pbuf_notify_drop)(struct mpsc_pbuf_buffer *buffer,
-					union mpsc_pbuf_generic *packet);
+typedef void (*mpsc_pbuf_notify_drop)(const struct mpsc_pbuf_buffer *buffer,
+				      const union mpsc_pbuf_generic *packet);
 
 /** @brief MPSC packet buffer structure. */
 struct mpsc_pbuf_buffer {
@@ -179,7 +179,7 @@ void mpsc_pbuf_commit(struct mpsc_pbuf_buffer *buffer,
  * and data on remaining bits.
  */
 void mpsc_pbuf_put_word(struct mpsc_pbuf_buffer *buffer,
-			union mpsc_pbuf_generic word);
+			const union mpsc_pbuf_generic word);
 
 /** @brief Put a packet consisting of a word and a pointer.
  *  *
@@ -194,7 +194,8 @@ void mpsc_pbuf_put_word(struct mpsc_pbuf_buffer *buffer,
  * @param data User data.
  */
 void mpsc_pbuf_put_word_ext(struct mpsc_pbuf_buffer *buffer,
-			union mpsc_pbuf_generic word, void *data);
+			    const union mpsc_pbuf_generic word,
+			    const void *data);
 
 /** @brief Put a packet into a buffer.
  *
@@ -203,18 +204,20 @@ void mpsc_pbuf_put_word_ext(struct mpsc_pbuf_buffer *buffer,
  *
  * @param buffer Buffer.
  *
- * @param data First word of data must contain MPSC_PBUF_HDR with valid set.
+ * @param data First word of data must contain MPSC_PBUF_HDR with valid bit set.
  *
  * @param wlen Packet size in words.
  */
 void mpsc_pbuf_put_data(struct mpsc_pbuf_buffer *buffer,
-			uint32_t *data, size_t wlen);
+			const uint32_t *data, size_t wlen);
 
 /** @brief Claim the first pending packet.
  *
  * @param buffer Buffer.
+ *
+ * @return Pointer to the claimed packet or null if none available.
  */
-union mpsc_pbuf_generic *mpsc_pbuf_claim(struct mpsc_pbuf_buffer *buffer);
+const union mpsc_pbuf_generic *mpsc_pbuf_claim(struct mpsc_pbuf_buffer *buffer);
 
 /** @brief Free a packet.
  *

--- a/lib/os/mpsc_pbuf.c
+++ b/lib/os/mpsc_pbuf.c
@@ -185,7 +185,7 @@ static union mpsc_pbuf_generic *drop_item_locked(struct mpsc_pbuf_buffer *buffer
 }
 
 void mpsc_pbuf_put_word(struct mpsc_pbuf_buffer *buffer,
-			union mpsc_pbuf_generic item)
+			const union mpsc_pbuf_generic item)
 {
 	bool cont;
 	uint32_t free_wlen;
@@ -305,7 +305,8 @@ void mpsc_pbuf_commit(struct mpsc_pbuf_buffer *buffer,
 }
 
 void mpsc_pbuf_put_word_ext(struct mpsc_pbuf_buffer *buffer,
-			union mpsc_pbuf_generic item, void *data)
+			    const union mpsc_pbuf_generic item,
+			    const void *data)
 {
 	static const size_t l =
 		(sizeof(item) + sizeof(data)) / sizeof(uint32_t);
@@ -327,7 +328,7 @@ void mpsc_pbuf_put_word_ext(struct mpsc_pbuf_buffer *buffer,
 			void **p =
 				(void **)&buffer->buf[buffer->tmp_wr_idx + 1];
 
-			*p = data;
+			*p = (void *)data;
 			buffer->tmp_wr_idx =
 				idx_inc(buffer, buffer->tmp_wr_idx, l);
 			buffer->wr_idx = idx_inc(buffer, buffer->wr_idx, l);
@@ -352,7 +353,7 @@ void mpsc_pbuf_put_word_ext(struct mpsc_pbuf_buffer *buffer,
 	} while (cont);
 }
 
-void mpsc_pbuf_put_data(struct mpsc_pbuf_buffer *buffer, uint32_t *data,
+void mpsc_pbuf_put_data(struct mpsc_pbuf_buffer *buffer, const uint32_t *data,
 			size_t wlen)
 {
 	bool cont;
@@ -395,7 +396,7 @@ void mpsc_pbuf_put_data(struct mpsc_pbuf_buffer *buffer, uint32_t *data,
 	} while (cont);
 }
 
-union mpsc_pbuf_generic *mpsc_pbuf_claim(struct mpsc_pbuf_buffer *buffer)
+const union mpsc_pbuf_generic *mpsc_pbuf_claim(struct mpsc_pbuf_buffer *buffer)
 {
 	union mpsc_pbuf_generic *item;
 	bool cont;

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -98,8 +98,8 @@ struct mpsc_pbuf_buffer log_buffer;
 static uint32_t __aligned(Z_LOG_MSG2_ALIGNMENT)
 	buf32[CONFIG_LOG_BUFFER_SIZE / sizeof(int)];
 
-static void notify_drop(struct mpsc_pbuf_buffer *buffer,
-			union mpsc_pbuf_generic *item);
+static void notify_drop(const struct mpsc_pbuf_buffer *buffer,
+			const union mpsc_pbuf_generic *item);
 
 static const struct mpsc_pbuf_buffer_config mpsc_config = {
 	.buf = (uint32_t *)buf32,
@@ -859,9 +859,12 @@ bool z_log_dropped_pending(void)
 	return dropped_cnt > 0;
 }
 
-static void notify_drop(struct mpsc_pbuf_buffer *buffer,
-			union mpsc_pbuf_generic *item)
+static void notify_drop(const struct mpsc_pbuf_buffer *buffer,
+			const union mpsc_pbuf_generic *item)
 {
+	ARG_UNUSED(buffer);
+	ARG_UNUSED(item);
+
 	z_log_dropped();
 }
 

--- a/tests/lib/mpsc_pbuf/src/main.c
+++ b/tests/lib/mpsc_pbuf/src/main.c
@@ -44,7 +44,7 @@ union test_item {
 	union mpsc_pbuf_generic item;
 };
 
-static uint32_t get_wlen(union mpsc_pbuf_generic *item)
+static uint32_t get_wlen(const union mpsc_pbuf_generic *item)
 {
 	union test_item *t_item = (union test_item *)item;
 
@@ -55,7 +55,7 @@ static uint32_t drop_cnt;
 static uintptr_t exp_dropped_data[10];
 static uint32_t exp_dropped_len[10];
 
-static void drop(struct mpsc_pbuf_buffer *buffer, union mpsc_pbuf_generic *item)
+static void drop(const struct mpsc_pbuf_buffer *buffer, const union mpsc_pbuf_generic *item)
 {
 	struct test_data_var *packet = (struct test_data_var *)item;
 
@@ -891,8 +891,8 @@ static void validate_packet(struct test_data_var *packet)
 	current_rd_idx++;
 }
 
-static void consistent_drop(struct mpsc_pbuf_buffer *buffer,
-			    union mpsc_pbuf_generic *item)
+static void consistent_drop(const struct mpsc_pbuf_buffer *buffer,
+			    const union mpsc_pbuf_generic *item)
 {
 	validate_packet((struct test_data_var *)item);
 }


### PR DESCRIPTION
Add const qualifier where it was missing. Updating
relevant code.

As indicated in ##38268.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>