### PR TITLE
net: mqtt: Fix large payload sending

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1257,9 +1257,16 @@ static int context_write_data(struct net_pkt *pkt, const void *buf,
 		int i;
 
 		for (i = 0; i < msghdr->msg_iovlen; i++) {
+			int len = MIN(msghdr->msg_iov[i].iov_len, buf_len);
+
 			ret = net_pkt_write(pkt, msghdr->msg_iov[i].iov_base,
-					    msghdr->msg_iov[i].iov_len);
+					    len);
 			if (ret < 0) {
+				break;
+			}
+
+			buf_len -= len;
+			if (buf_len == 0) {
 				break;
 			}
 		}

--- a/subsys/net/lib/mqtt/mqtt_transport_socket_tls.c
+++ b/subsys/net/lib/mqtt/mqtt_transport_socket_tls.c
@@ -120,11 +120,37 @@ int mqtt_client_tls_write(struct mqtt_client *client, const uint8_t *data,
 int mqtt_client_tls_write_msg(struct mqtt_client *client,
 			      const struct msghdr *message)
 {
-	int ret;
+	int ret, i;
+	size_t offset = 0;
+	size_t total_len = 0;
 
-	ret = zsock_sendmsg(client->transport.tls.sock, message, 0);
-	if (ret < 0) {
-		return -errno;
+	for (i = 0; i < message->msg_iovlen; i++) {
+		total_len += message->msg_iov[i].iov_len;
+	}
+
+	while (offset < total_len) {
+		ret = zsock_sendmsg(client->transport.tls.sock, message, 0);
+		if (ret < 0) {
+			return -errno;
+		}
+
+		offset += ret;
+		if (offset >= total_len) {
+			break;
+		}
+
+		/* Update msghdr for the next iteration. */
+		for (i = 0; i < message->msg_iovlen; i++) {
+			if (ret < message->msg_iov[i].iov_len) {
+				message->msg_iov[i].iov_len -= ret;
+				message->msg_iov[i].iov_base =
+					(uint8_t *)message->msg_iov[i].iov_base + ret;
+				break;
+			}
+
+			ret -= message->msg_iov[i].iov_len;
+			message->msg_iov[i].iov_len = 0;
+		}
 	}
 
 	return 0;

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -1673,6 +1673,10 @@ ssize_t ztls_sendmsg_ctx(struct tls_context *ctx, const struct msghdr *msg,
 			struct iovec *vec = msg->msg_iov + i;
 			size_t sent = 0;
 
+			if (vec->iov_len == 0) {
+				continue;
+			}
+
 			while (sent < vec->iov_len) {
 				uint8_t *ptr = (uint8_t *)vec->iov_base + sent;
 


### PR DESCRIPTION
There was a problem with the `sendmsg()` implementation at the `net_context` level - it would ignore the avalable buffer length in net_pkt, which could result in an overflow and error being returned for larger payloads. In result, it was not possible to transfer large data over MQTT, which uses `sendmsg()` underneath.

Fix this at the `net_context` level (by respecting the buffer size, and sending less data if too much was requested at once, it's acceptable according to the man pages), and then verifying the actual length of the data sent in the MQTT transport handlers. 

Fixes #38769