### PR TITLE
Coverity fixes in logging and cbprintf

### DIFF
--- a/subsys/logging/log_msg2.c
+++ b/subsys/logging/log_msg2.c
@@ -83,7 +83,7 @@ void z_impl_z_log_msg2_runtime_vcreate(uint8_t domain_id, const void *source,
 	}
 
 	if (msg && fmt) {
-		plen = cbvprintf_package(msg->data, plen, 0, fmt, ap);
+		plen = cbvprintf_package(msg->data, (size_t)plen, 0, fmt, ap);
 		__ASSERT_NO_MSG(plen >= 0);
 	}
 

--- a/tests/lib/cbprintf_package/src/test.inc
+++ b/tests/lib/cbprintf_package/src/test.inc
@@ -148,11 +148,15 @@ void test_cbprintf_rw_str_indexes(void)
 		ztest_test_skip();
 	}
 
+	zassert_true(len0 > 0, NULL);
 	len1 = cbprintf_package(NULL, 0, CBPRINTF_PACKAGE_ADD_STRING_IDXS,
 				test_str, 100, test_str1);
+	zassert_true(len1 > 0, NULL);
+
 	CBPRINTF_STATIC_PACKAGE(NULL, 0, len2, 0,
 				CBPRINTF_PACKAGE_ADD_STRING_IDXS,
 				test_str, 100, test_str1);
+	zassert_true(len2 > 0, NULL);
 
 	/* package with string indexes will contain two more bytes holding indexes
 	 * of string parameter locations.


### PR DESCRIPTION
Coverity fixes for issues reported in logging and cbprintf.

Fixes #38123.
Fixes #38001.
Fixes #38000.