### PR TITLE
samples: boards: nrfx: Fix setting up of (D)PPI channel endpoints

### DIFF
--- a/samples/boards/nrf/nrfx/README.rst
+++ b/samples/boards/nrf/nrfx/README.rst
@@ -20,6 +20,11 @@ for the GPIOTE interrupt. Button 1 is configured to create an event when pushed.
 This calls the ``button_handler()`` callback and triggers the LED 1 pin OUT task.
 LED is then toggled.
 
+Please note that no debouncing mechanism is used for the button, so it may
+happen that one press results in multiple events. And because the event-task
+connection is handled in hardware, for very fast coming events, toggling of
+the LED may sometimes be even unnoticeable.
+
 Requirements
 ************
 

--- a/samples/boards/nrf/nrfx/src/main.c
+++ b/samples/boards/nrf/nrfx/src/main.c
@@ -100,10 +100,8 @@ void main(void)
 	 * the button is pressed, the LED pin will be toggled.
 	 */
 	nrfx_gppi_channel_endpoints_setup(channel,
-		nrf_gpiote_event_address_get(NRF_GPIOTE,
-			nrfx_gpiote_in_event_get(INPUT_PIN)),
-		nrf_gpiote_task_address_get(NRF_GPIOTE,
-			nrfx_gpiote_in_event_get(OUTPUT_PIN)));
+		nrfx_gpiote_in_event_addr_get(INPUT_PIN),
+		nrfx_gpiote_out_task_addr_get(OUTPUT_PIN));
 
 	/* Enable (D)PPI channel. */
 #if defined(DPPI_PRESENT)


### PR DESCRIPTION
There is a copy-paste error in this sample code that results
in a function for input events being called for an output pin.
By chance, this has no influence on the behavior of the sample,
as the function returns a register offset that for events and
tasks is the same for a given channel, but obviously the code
is confusing.
This is fixed by replacing the relevant part with more suitable
function calls, to also simplify the code a little.

On the occasion, also a remark is added about no button debouncing
used in the sample, to prevent users from being surprised by its
possible behavior.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>