### PR TITLE
drivers: regulator: Fix k_work_schedule return code handling

### DIFF
--- a/drivers/regulator/regulator_fixed.c
+++ b/drivers/regulator/regulator_fixed.c
@@ -115,7 +115,7 @@ static void finalize_transition(struct driver_data_onoff *data,
 			data->task = WORK_TASK_DELAY;
 			data->notify = notify;
 			rc = k_work_schedule(&data->dwork, K_USEC(delay_us));
-			if (rc == 0) {
+			if (rc >= 0) {
 				return;
 			}
 #endif /* CONFIG_MULTITHREADING */


### PR DESCRIPTION
k_work_schedule may return other non-negative value than 0.
When driver was adapted to the new k_work API that was not
taken into account.

Fixes #38655.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>