### PR TITLE
dts/arm/st: wl: increase Sub-GHz SPI frequency to 12MHz

### DIFF
--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -296,7 +296,7 @@
 				compatible = "st,stm32wl-subghz-radio";
 				reg = <0>;
 				interrupts = <50 0>;
-				spi-max-frequency = <1000000>;
+				spi-max-frequency = <12000000>;
 				status = "disabled";
 				label = "subghz-radio";
 			};


### PR DESCRIPTION
The maximum supported speed according to the SX126x datasheet (I have
not found that information in the STM32WL datasheet or reference
manual). Increase the Sub-GHz SPI frequency from 1 Mhz to to 12 MHz,
which corresponds to a baud rate prescaler of 4 with a 48 MHz clock. It
also matches what is done the the STM32CubeWL package.
    
This reduces the time the MCU is kept running, thus reducing the global
power consumption.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>