### PR TITLE
soc: arm: stm32lx: fix using MSI as wake-up clock source

### DIFF
--- a/soc/arm/st_stm32/stm32l0/power.c
+++ b/soc/arm/st_stm32/stm32l0/power.c
@@ -15,6 +15,7 @@
 #include <stm32l0xx_ll_rcc.h>
 #include <stm32l0xx_ll_system.h>
 #include <clock_control/clock_stm32_ll_common.h>
+#include <drivers/clock_control/stm32_clock_control.h>
 
 #include <logging/log.h>
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);

--- a/soc/arm/st_stm32/stm32l4/power.c
+++ b/soc/arm/st_stm32/stm32l4/power.c
@@ -15,6 +15,7 @@
 #include <stm32l4xx_ll_rcc.h>
 #include <stm32l4xx_ll_system.h>
 #include <clock_control/clock_stm32_ll_common.h>
+#include <drivers/clock_control/stm32_clock_control.h>
 
 #include <logging/log.h>
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);

--- a/soc/arm/st_stm32/stm32l5/power.c
+++ b/soc/arm/st_stm32/stm32l5/power.c
@@ -15,6 +15,7 @@
 #include <stm32l5xx_ll_rcc.h>
 #include <stm32l5xx_ll_system.h>
 #include <clock_control/clock_stm32_ll_common.h>
+#include <drivers/clock_control/stm32_clock_control.h>
 
 #include <logging/log.h>
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);


### PR DESCRIPTION
Following the migration of the clock source configuration in DTS (commit
2691541ad22), HSI is always used as wake-up source on STM32LX. It is
reconfigured as MSI just after, but it slightly increase the wake-up
time and power consumption.
    
It happens as the file defining STM32_SYSCLK_SRC_MSI is not included.
Fix that.
    
Fixes #38807
    
Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>