### PR TITLE
soc: arm: stm32wl: wakeup from stop clock selection based on sysclk

### DIFF
--- a/soc/arm/st_stm32/stm32wl/power.c
+++ b/soc/arm/st_stm32/stm32wl/power.c
@@ -15,16 +15,24 @@
 #include <stm32wlxx_ll_rcc.h>
 #include <stm32wlxx_ll_system.h>
 #include <clock_control/clock_stm32_ll_common.h>
+#include <drivers/clock_control/stm32_clock_control.h>
 
 #include <logging/log.h>
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
+
+/* select MSI as wake-up system clock if configured, HSI otherwise */
+#if STM32_SYSCLK_SRC_MSI
+#define RCC_STOP_WAKEUPCLOCK_SELECTED LL_RCC_STOP_WAKEUPCLOCK_MSI
+#else
+#define RCC_STOP_WAKEUPCLOCK_SELECTED LL_RCC_STOP_WAKEUPCLOCK_HSI
+#endif
 
 /* Invoke Low Power/System Off specific Tasks */
 __weak void pm_power_state_set(struct pm_state_info info)
 {
 	switch (info.state) {
 	case PM_STATE_SUSPEND_TO_IDLE:
-		LL_RCC_SetClkAfterWakeFromStop(LL_RCC_STOP_WAKEUPCLOCK_HSI);
+		LL_RCC_SetClkAfterWakeFromStop(RCC_STOP_WAKEUPCLOCK_SELECTED);
 		LL_PWR_ClearFlag_WU();
 		switch (info.substate_id) {
 		case 1:


### PR DESCRIPTION
When exiting Stop mode, if system clock is MSI, MSI oscillator is
selected as wakeup from stop clock; otherwise HSI16 oscillator is
selected.

It is otherwise reconfigured as MSI just after, but it slightly
increases the wake-up time and power consumption.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>