### PR TITLE
doc: update coding guidelines compliance stages

### DIFF
--- a/doc/contribute/coding_guidelines/index.rst
+++ b/doc/contribute/coding_guidelines/index.rst
@@ -14,16 +14,14 @@ Stage I
   blocked by reviewers/approvers due to violations.
 
 Stage II
-  Begin enforcement on a limited scope of the code base. Initially this would be
+  Begin enforcement on a limited scope of the code base. Initially, this would be
   the safety certification scope. For rules easily applied across codebase, we
   should not limit compliance to initial scope. This step requires tooling and
-  CI setup.
-  This stage will begin during the 2.4 development cycle and end with the Zephyr
-  LTS2 (2.6) to achieve and LTS2 that is ready for certification.
+  CI setup and will start sometime after LTS2.
 
 Stage III
   Revisit the coding guideline rules and based on experience from previous
-  stages, refine/iterate on selected rules. This stage is to start after LTS2.
+  stages, refine/iterate on selected rules.
 
 Stage IV
    Expand enforcement to the wider codebase. Exceptions may be granted on some


### PR DESCRIPTION
Updates wording in Coding Guidelines page to remove outdated timelines and correct the criteria for each stage. Changes reflect that we are in stage 1 and will not reach stage 2 until the CI for enforcing coding guidelines has been established.

Signed-off-by: Lauren Murphy <lauren.murphy@intel.com>