### PR TITLE
Bluetooth: Fix minor conditional compile related comment

### DIFF
--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -922,7 +922,7 @@ struct bt_conn_cb {
 	 */
 	void (*le_data_len_updated)(struct bt_conn *conn,
 				    struct bt_conn_le_data_len_info *info);
-#endif /* defined(CONFIG_BT_USER_PHY_UPDATE) */
+#endif /* defined(CONFIG_BT_USER_DATA_LEN_UPDATE) */
 
 	struct bt_conn_cb *_next;
 };


### PR DESCRIPTION
Fix minor conditional compile related comment.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>