### PR TITLE
net: if: Make sure to update the prefix when it already exists

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -2152,7 +2152,7 @@ static struct net_if_ipv6_prefix *ipv6_prefix_find(struct net_if *iface,
 	}
 
 	for (i = 0; i < NET_IF_MAX_IPV6_PREFIX; i++) {
-		if (!ipv6->unicast[i].is_used) {
+		if (!ipv6->prefix[i].is_used) {
 			continue;
 		}
 


### PR DESCRIPTION
This is an issue that I found while using the TAHI test suite for RFC2640. Running test case _v6LC.1.3.2: Part A (Time Elapsed Between Fragments less than Sixty Seconds)_ would succeed the first time, but fail on follow-up runs. Zephyr uses the wrong destination address due to an expired prefix not being re-enabled in these follow-up runs.

It can happen that the prefix exists but has expired. In that case, `net_if_ipv6_prefix_add()` will not work as intended, because it will bail out without re-enabling the existing prefix. Call `net_if_ipv6_prefix_init()` when the prefix already exists, so that it is also updated with the latest data (length, lifetime, etc.).