### PR TITLE
Bluetooth: host: Ignore return value of change-aware when reading DBhash

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -783,7 +783,7 @@ static ssize_t db_hash_read(struct bt_conn *conn,
 	 * The client reads the Database Hash characteristic and then the server
 	 * receives another ATT request from the client.
 	 */
-	bt_gatt_change_aware(conn, true);
+	(void)bt_gatt_change_aware(conn, true);
 
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, db_hash.hash,
 				 sizeof(db_hash.hash));


### PR DESCRIPTION
Ignore the return value of the bt_gatt_change_aware function when the client
is reading the database hash characteristic value. This is the point where the
client becomes change-aware, so nothing else should be done if the client
is change-unaware.

Fixes: #38012

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>