### PR TITLE
tests: threads: fix kernel/thread_stack test

### DIFF
--- a/tests/kernel/threads/thread_stack/src/main.c
+++ b/tests/kernel/threads/thread_stack/src/main.c
@@ -160,8 +160,8 @@ void stack_buffer_scenarios(void)
 	 *
 	 * First test does direct read & write starting at the estimated
 	 * stack pointer up to the highest addresses in the buffer
+	 * Starting from &val which is close enough to stack pointer
 	 */
-	val = *stack_start;
 	stack_ptr = &val;
 	for (pos = stack_ptr; pos < stack_end; pos++) {
 		/* pos is volatile so this doesn't get optimized out */


### PR DESCRIPTION
Fix the broken logic in the kernel/thread_stack test.
The modified test should do direct read & write from estimated stack pointer to highest address in the stack buffer.
Previously this test was start from lowest address in the stack which would trigger exception of hardware stack checking scheme violation on ARC boards and other targets with hardware stack overflow detection.

Fixes #38804