### PR TITLE
Bluetooth: host: compile out check for multiple identities

### DIFF
--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -1613,6 +1613,7 @@ int bt_le_oob_get_local(uint8_t id, struct bt_le_oob *oob)
 		}
 
 		if (IS_ENABLED(CONFIG_BT_OBSERVER) &&
+		    CONFIG_BT_ID_MAX > 1 &&
 		    id != BT_ID_DEFAULT &&
 		    (atomic_test_bit(bt_dev.flags, BT_DEV_SCANNING) ||
 		     atomic_test_bit(bt_dev.flags, BT_DEV_INITIATING))) {


### PR DESCRIPTION
Compile out check that is only needed when multiple identities have
been enabled.

Fixes: #38134

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>