### PR TITLE
Bluetooth: Mesh: Return ETIMEDOUT if k_sem_take call times out

### DIFF
--- a/subsys/bluetooth/mesh/msg.c
+++ b/subsys/bluetooth/mesh/msg.c
@@ -64,6 +64,10 @@ int bt_mesh_msg_ack_ctx_wait(struct bt_mesh_msg_ack_ctx *ack, k_timeout_t timeou
 	err = k_sem_take(&ack->sem, timeout);
 	bt_mesh_msg_ack_ctx_clear(ack);
 
+	if (err == -EAGAIN) {
+		return -ETIMEDOUT;
+	}
+
 	return err;
 }
 


### PR DESCRIPTION
EAGAIN is used in some other places in the code, e.g. if node is not
provisioned when a model tries to send a message. This change helps to
differentiated if the acknowledged message timed out from other failers.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>