### PR TITLE
linker: __data_region_start equal to __data_start

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -3083,8 +3083,8 @@ function(zephyr_linker_dts_memory)
 endfunction()
 
 # Usage:
-#   zephyr_linker_group(NAME <name> [VMA <region|group>] [LMA <region|group>])
-#   zephyr_linker_group(NAME <name> GROUP <group>)
+#   zephyr_linker_group(NAME <name> [VMA <region|group>] [LMA <region|group>] [SYMBOL <SECTION>])
+#   zephyr_linker_group(NAME <name> GROUP <group> [SYMBOL <SECTION>])
 #
 # Zephyr linker group.
 # This function specifies a group inside a memory region or another group.
@@ -3108,6 +3108,8 @@ endfunction()
 #                       If a group is used then the VMA region of that group will be used.
 # LMA <region|group>  : Memory region or group to be used for this group.
 # GROUP <group>       : Place the new group inside the existing group <group>
+# SYMBOL <SECTION>    : Specify that start symbol of the region should be identical
+#                       to the start address of the first section in the group.
 #
 # Note: VMA and LMA are mutual exclusive with GROUP
 #
@@ -3153,7 +3155,8 @@ endfunction()
 # |                     |
 # +---------------------+
 function(zephyr_linker_group)
-  set(single_args "NAME;GROUP;LMA;VMA")
+  set(single_args "NAME;GROUP;LMA;SYMBOL;VMA")
+  set(symbol_values SECTION)
   cmake_parse_arguments(GROUP "" "${single_args}" "" ${ARGN})
 
   if(GROUP_UNPARSED_ARGUMENTS)
@@ -3166,6 +3169,12 @@ function(zephyr_linker_group)
     message(FATAL_ERROR "zephyr_linker_group(GROUP ...) cannot be used with "
                         "VMA or LMA"
     )
+  endif()
+
+  if(DEFINED GROUP_SYMBOL)
+    if(NOT ${GROUP_SYMBOL} IN_LIST symbol_values)
+      message(FATAL_ERROR "zephyr_linker_group(SYMBOL ...) given unknown value")
+    endif()
   endif()
 
   set(GROUP)

--- a/cmake/linker/linker_script_common.cmake
+++ b/cmake/linker/linker_script_common.cmake
@@ -58,11 +58,12 @@ function(get_parent)
 endfunction()
 
 function(create_group)
-  cmake_parse_arguments(OBJECT "" "GROUP;LMA;NAME;OBJECT;VMA" "" ${ARGN})
+  cmake_parse_arguments(OBJECT "" "GROUP;LMA;NAME;OBJECT;SYMBOL;VMA" "" ${ARGN})
 
   set_property(GLOBAL PROPERTY GROUP_${OBJECT_NAME}          TRUE)
   set_property(GLOBAL PROPERTY GROUP_${OBJECT_NAME}_OBJ_TYPE GROUP)
   set_property(GLOBAL PROPERTY GROUP_${OBJECT_NAME}_NAME     ${OBJECT_NAME})
+  set_property(GLOBAL PROPERTY GROUP_${OBJECT_NAME}_SYMBOL   ${OBJECT_SYMBOL})
 
   if(DEFINED OBJECT_GROUP)
     find_object(OBJECT parent NAME ${OBJECT_GROUP})

--- a/cmake/linker_script/arm/linker.cmake
+++ b/cmake/linker_script/arm/linker.cmake
@@ -59,9 +59,9 @@ else()
 endif()
 
 zephyr_linker_group(NAME RAM_REGION VMA RAM LMA ROM_REGION)
-zephyr_linker_group(NAME TEXT_REGION GROUP ROM_REGION)
+zephyr_linker_group(NAME TEXT_REGION GROUP ROM_REGION SYMBOL SECTION)
 zephyr_linker_group(NAME RODATA_REGION GROUP ROM_REGION)
-zephyr_linker_group(NAME DATA_REGION GROUP RAM_REGION)
+zephyr_linker_group(NAME DATA_REGION GROUP RAM_REGION SYMBOL SECTION)
 
 # should go to a relocation.cmake - from include/linker/rel-sections.ld - start
 zephyr_linker_section(NAME  .rel.plt  HIDDEN)

--- a/include/arch/arc/v2/linker.ld
+++ b/include/arch/arc/v2/linker.ld
@@ -173,11 +173,10 @@ SECTIONS {
 
 	GROUP_START(DATA_REGION)
 
-	__data_region_start = .;
-
 	SECTION_DATA_PROLOGUE(_DATA_SECTION_NAME,,) {
 
 /* when XIP, .text is in ROM, but vector table must be at start of .data */
+		__data_region_start = .;
 		__data_start = .;
 		*(".data")
 		*(".data.*")

--- a/include/arch/arm/aarch32/cortex_a_r/scripts/linker.ld
+++ b/include/arch/arm/aarch32/cortex_a_r/scripts/linker.ld
@@ -278,10 +278,9 @@ SECTIONS
 
 #include <linker/common-noinit.ld>
 
-    __data_region_start = .;
-
     SECTION_DATA_PROLOGUE(_DATA_SECTION_NAME,,)
     {
+        __data_region_start = .;
         __data_start = .;
         *(.data)
         *(".data.*")

--- a/include/arch/arm/aarch32/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/aarch32/cortex_m/scripts/linker.ld
@@ -294,10 +294,9 @@ SECTIONS
 
     GROUP_START(DATA_REGION)
 
-    __data_region_start = .;
-
     SECTION_DATA_PROLOGUE(_DATA_SECTION_NAME,,)
 	{
+	__data_region_start = .;
 	__data_start = .;
 	*(.data)
 	*(".data.*")

--- a/include/arch/arm64/scripts/linker.ld
+++ b/include/arch/arm64/scripts/linker.ld
@@ -248,10 +248,9 @@ SECTIONS
 
 #include <linker/common-noinit.ld>
 
-    __data_region_start = .;
-
     SECTION_DATA_PROLOGUE(_DATA_SECTION_NAME,,)
     {
+	__data_region_start = .;
 	__data_start = .;
         *(.data)
         *(".data.*")

--- a/include/arch/riscv/common/linker.ld
+++ b/include/arch/riscv/common/linker.ld
@@ -229,12 +229,11 @@ SECTIONS
 #include <linker/common-noinit.ld>
 #include <linker/cplusplus-ram.ld>
 
-    __data_region_start = .;
-
     SECTION_DATA_PROLOGUE(_DATA_SECTION_NAME,,)
 	{
 		 . = ALIGN(4);
 		/* _image_ram_start = .; */
+		 __data_region_start = .;
 		 __data_start = .;
 
 		 *(.data)

--- a/include/arch/sparc/linker.ld
+++ b/include/arch/sparc/linker.ld
@@ -68,7 +68,6 @@ SECTIONS
     __rom_region_end = .;
 
     __data_region_load_start = .;
-    __data_region_start = .;
 
 
     SECTION_PROLOGUE(.plt,,)
@@ -85,6 +84,7 @@ SECTIONS
 	{
 		 . = ALIGN(8);
 		 _image_ram_start = .;
+		 __data_region_start = .;
 		 __data_start = .;
 
 		 *(.data)

--- a/soc/riscv/openisa_rv32m1/linker.ld
+++ b/soc/riscv/openisa_rv32m1/linker.ld
@@ -159,12 +159,11 @@ SECTIONS
 
     GROUP_START(RAM)
 
-    __data_region_start = .;
-
     SECTION_DATA_PROLOGUE(_DATA_SECTION_NAME,,)
 	{
 	. = ALIGN(4);
 	_image_ram_start = .;
+	__data_region_start = .;
 	__data_start = .;
 
 	*(.data)


### PR DESCRIPTION
Fixes: #38591, #38207, #37861

The commit 65a2de84a9d5c535167951bf1cf610c4f7967ea5 aligned the data
linker symbol for sections and regions.

The data region symbol start has been placed outside the sections thus
being defined as the address of the region before alignment of the first
section in the data region, usually the `datas` section.

The symbol defining the start address of the data section is after
section alignment.
In most cases the address of the data region start and datas section
start will be identical, but not always.
The data region symbol is a new linker symbol and existing code has
been depending on the old data section start symbol.
Thus, the update to the use of the data region start symbol instead of
data ram start symbol thus results in a different address when the
section is aligned to a different address.

To ensure the original behavior in all cases, the data region start
address is now moved inside the data section.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>

------
~DNM to allow time to examine the ld linker script generator for possible related fixup.~