### PR TITLE
Bluetooth: controller: Fix compilation error due to missing includes

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_df.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_df.c
@@ -6,6 +6,7 @@
 
 #include <stdint.h>
 #include <errno.h>
+#include <soc.h>
 #include <devicetree.h>
 #include <sys/util_macro.h>
 #include <hal/nrf_radio.h>

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df.c
@@ -5,6 +5,7 @@
  */
 
 #include <stdint.h>
+#include <soc.h>
 #include <bluetooth/hci.h>
 
 #include "util/util.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_df.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_df.c
@@ -5,8 +5,8 @@
  */
 
 #include <stdint.h>
-
 #include <zephyr.h>
+#include <soc.h>
 #include <sys/util.h>
 #include <bluetooth/hci.h>
 


### PR DESCRIPTION
When CONFIG_ARM_MPU is explicitly unset in application prj.conf there
were build warnings related with implicit declarations of following
symbols: NRF_DT_GPIOS_TO_PSEL, __WFE, __SEV.
Lack of NRF_DT_GPIOS_TO_PSEL lead to build error due to undeclared
dfegpio0_gpios symbol.

The cause for the warnings and error were missing soc.h includes in
few source files. The missing includes were added in this commit.

This PR fixes issue https://github.com/zephyrproject-rtos/zephyr/issues/38340.