### PR TITLE
Bluetooth: ISO: Remove bt_conn_unref for ISO deferred work

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1524,8 +1524,11 @@ static void deferred_work(struct k_work *work)
 		struct bt_conn *iso;
 
 		if (conn->type == BT_CONN_TYPE_ISO) {
+			/* bt_iso_disconnected is responsible for unref'ing the
+			 * connection pointer, as it is conditional on whether
+			 * the connection is a central or peripheral.
+			 */
 			bt_iso_disconnected(conn);
-			bt_conn_unref(conn);
 			return;
 		}
 


### PR DESCRIPTION
Removed the bt_conn_unref from the deferred_work function.
For ISO, the conn unref for the peripheral will happen in
the bt_iso_disconnected function. For the central, the
unref shall only happen when the CIG is terminated.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>