### PR TITLE
drivers: serial: gecko: add hw flow control support for EFR32 Series 2

### DIFF
--- a/drivers/serial/uart_gecko.c
+++ b/drivers/serial/uart_gecko.c
@@ -52,7 +52,8 @@ but not supported by this SOC"
 #endif
 
 #if defined(UART_GECKO_HW_FLOW_CONTROL) && \
-	(!defined(CONFIG_SOC_GECKO_HAS_INDIVIDUAL_PIN_LOCATION))
+	(!defined(CONFIG_SOC_GECKO_HAS_INDIVIDUAL_PIN_LOCATION) && \
+	 !defined(GPIO_USART_ROUTEEN_RTSPEN))
 #error "Driver not supporting hardware flow control for this SOC"
 #endif
 


### PR DESCRIPTION
Add hardware flow control support for the EFR32MG21 and other modules
using `GPIO_USART_ROUTEEN_RTSPEN` (and `GPIO_USART_ROUTEEN_CTSEN`) instead
of the Kconfig `SOC_GECKO_HAS_INDIVIDUAL_PIN_LOCATION`.

The driver already contained the section settings the RTS and CTS pins
for modules using the `GPIO_USART_ROUTEEN_(RTS|CTS)PEN` define, but it was
not compiling because of an #ifdef checking only for
`CONFIG_SOC_GECKO_HAS_INDIVIDUAL_PIN_LOCATION` and not both.

Tested with samples/hello_world on efr32_radio_brd4180a

Related issue: #21292

Signed-off-by: Steven Lemaire <steven.lemaire@zii.aero>