### PR TITLE
net: buf: Fix net_buf struct issue due to frags and node elem union

### DIFF
--- a/include/net/buf.h
+++ b/include/net/buf.h
@@ -917,13 +917,11 @@ static inline void net_buf_simple_restore(struct net_buf_simple *buf,
  * using the net_buf_alloc() API.
  */
 struct net_buf {
-	union {
-		/** Allow placing the buffer into sys_slist_t */
-		sys_snode_t node;
+	/** Allow placing the buffer into sys_slist_t */
+	sys_snode_t node;
 
-		/** Fragments associated with this buffer. */
-		struct net_buf *frags;
-	};
+	/** Fragments associated with this buffer. */
+	struct net_buf *frags;
 
 	/** Reference count. */
 	uint8_t ref;

--- a/subsys/net/buf.c
+++ b/subsys/net/buf.c
@@ -265,6 +265,7 @@ struct net_buf *net_buf_alloc_len(struct net_buf_pool *pool, size_t size,
 		irq_unlock(key);
 
 		buf = pool_get_uninit(pool, uninit_count);
+		memset(&buf->node, 0, sizeof(buf->node));
 		goto success;
 	}
 


### PR DESCRIPTION
net_buf elements are used in net_pool which are based on lifo
implementation. Yet, net_buf structure doesn't respect lifo requierement
that the first word must be reserved for the lifo kernel implementation.

In most cases, this is fine as this word is mostly accessed when the
element is not allocated, however, this is not always true.
In such situation, node element is written, ehnce frags element value is
not NULL anymore and anything might happen...

This fixes #38829 issue.

Signed-off-by: Xavier Chapron <xavier.chapron@stimio.fr>