### PR TITLE
drivers: display: st7789v: remove incorrect error check

### DIFF
--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -407,7 +407,7 @@ static int st7789v_pm_control(const struct device *dev,
 		st7789v_exit_sleep(data);
 		break;
 	case PM_DEVICE_ACTION_SUSPEND:
-		ret = st7789v_transmit(data, ST7789V_CMD_SLEEP_IN, NULL, 0);
+		st7789v_transmit(data, ST7789V_CMD_SLEEP_IN, NULL, 0);
 		break;
 	default:
 		ret = -ENOTSUP;


### PR DESCRIPTION
The st7789v_transmit function does not return any error code (void), so
ret = st7789v_transmit(...) is wrong.

Fixes #38818 