### PR TITLE
device handle hotfixes for 2.7

### DIFF
--- a/include/device.h
+++ b/include/device.h
@@ -712,8 +712,6 @@ static inline bool device_is_ready(const struct device *dev)
  *     List of devicetree dependency ordinals (if any),
  *     DEVICE_HANDLE_SEP,
  *     List of injected dependency ordinals (if any),
- *     DEVICE_HANDLE_SEP,
- *     List of devicetree supporting ordinals (if any),
  * }
  *
  * After processing in gen_handles.py, the format is updated to:
@@ -721,8 +719,6 @@ static inline bool device_is_ready(const struct device *dev)
  *     List of existing devicetree dependency handles (if any),
  *     DEVICE_HANDLE_SEP,
  *     List of injected dependency ordinals (if any),
- *     DEVICE_HANDLE_SEP,
- *     List of existing devicetree support handles (if any),
  *     DEVICE_HANDLE_NULL padding to original length (at least one)
  * }
  *
@@ -754,9 +750,6 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 		))							\
 			DEVICE_HANDLE_SEP,				\
 			Z_DEVICE_EXTRA_HANDLES(__VA_ARGS__)		\
-			DEVICE_HANDLE_SEP,				\
-	COND_CODE_1(DT_NODE_EXISTS(node_id),				\
-			(DT_SUPPORTS_DEP_ORDS(node_id)), ())		\
 		};
 
 #ifdef CONFIG_PM_DEVICE

--- a/include/device.h
+++ b/include/device.h
@@ -699,6 +699,50 @@ static inline bool device_is_ready(const struct device *dev)
 	Z_DEVICE_STATE_DEFINE(node_id, dev_name)			\
 	Z_DEVICE_DEFINE_PM_SLOT(dev_name)
 
+/* Helper macros needed for CONFIG_DEVICE_HANDLE_PADDING. These should
+ * be deleted when that option is removed.
+ *
+ * This is implemented "by hand" -- rather than using a helper macro
+ * like UTIL_LISTIFY() -- because we need to allow users to wrap
+ * DEVICE_DT_DEFINE with UTIL_LISTIFY, like this:
+ *
+ *     #define DEFINE_FOO_DEVICE(...) DEVICE_DT_DEFINE(...)
+ *     UTIL_LISTIFY(N, DEFINE_FOO_DEVICE)
+ *
+ * If Z_DEVICE_HANDLE_PADDING uses UTIL_LISTIFY, this type of code
+ * would fail, because the UTIL_LISTIFY token within the
+ * Z_DEVICE_DEFINE_HANDLES expansion would not be expanded again,
+ * since it appears in a context where UTIL_LISTIFY is already being
+ * expanded. Standard C does not reexpand macros appearing in their
+ * own expansion; this would lead to infinite recursions in general.
+ */
+#define Z_DEVICE_HANDLE_PADDING \
+	Z_DEVICE_HANDLE_PADDING_(CONFIG_DEVICE_HANDLE_PADDING)
+#define Z_DEVICE_HANDLE_PADDING_(count) \
+	Z_DEVICE_HANDLE_PADDING__(count)
+#define Z_DEVICE_HANDLE_PADDING__(count) \
+	Z_DEVICE_HANDLE_PADDING_ ## count
+#define Z_DEVICE_HANDLE_PADDING_10 \
+	DEVICE_HANDLE_ENDS, Z_DEVICE_HANDLE_PADDING_9
+#define Z_DEVICE_HANDLE_PADDING_9 \
+	DEVICE_HANDLE_ENDS, Z_DEVICE_HANDLE_PADDING_8
+#define Z_DEVICE_HANDLE_PADDING_8 \
+	DEVICE_HANDLE_ENDS, Z_DEVICE_HANDLE_PADDING_7
+#define Z_DEVICE_HANDLE_PADDING_7 \
+	DEVICE_HANDLE_ENDS, Z_DEVICE_HANDLE_PADDING_6
+#define Z_DEVICE_HANDLE_PADDING_6 \
+	DEVICE_HANDLE_ENDS, Z_DEVICE_HANDLE_PADDING_5
+#define Z_DEVICE_HANDLE_PADDING_5 \
+	DEVICE_HANDLE_ENDS, Z_DEVICE_HANDLE_PADDING_4
+#define Z_DEVICE_HANDLE_PADDING_4 \
+	DEVICE_HANDLE_ENDS, Z_DEVICE_HANDLE_PADDING_3
+#define Z_DEVICE_HANDLE_PADDING_3 \
+	DEVICE_HANDLE_ENDS, Z_DEVICE_HANDLE_PADDING_2
+#define Z_DEVICE_HANDLE_PADDING_2 \
+	DEVICE_HANDLE_ENDS, Z_DEVICE_HANDLE_PADDING_1
+#define Z_DEVICE_HANDLE_PADDING_1 \
+	DEVICE_HANDLE_ENDS, Z_DEVICE_HANDLE_PADDING_0
+#define Z_DEVICE_HANDLE_PADDING_0 EMPTY
 
 /* Initial build provides a record that associates the device object
  * with its devicetree ordinal, and provides the dependency ordinals.
@@ -735,6 +779,7 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 		))							\
 			DEVICE_HANDLE_SEP,				\
 			Z_DEVICE_EXTRA_HANDLES(__VA_ARGS__)		\
+			Z_DEVICE_HANDLE_PADDING				\
 		};
 
 #ifdef CONFIG_PM_DEVICE

--- a/include/device.h
+++ b/include/device.h
@@ -502,47 +502,6 @@ device_required_handles_get(const struct device *dev,
 }
 
 /**
- * @brief Get the set of handles that this device supports.
- *
- * The set of supported devices is inferred from devicetree, and does not
- * include any software constructs that may depend on the device.
- *
- * @param dev the device for which supports are desired.
- *
- * @param count pointer to a place to store the number of devices provided at
- * the returned pointer. The value is not set if the call returns a null
- * pointer. The value may be set to zero.
- *
- * @return a pointer to a sequence of @p *count device handles, or a null
- * pointer if @p dh does not provide dependency information.
- */
-static inline const device_handle_t *
-device_supported_handles_get(const struct device *dev,
-			     size_t *count)
-{
-	const device_handle_t *rv = dev->handles;
-	size_t region = 0;
-	size_t i = 0;
-
-	if (rv != NULL) {
-		/* Fast forward to supporting devices */
-		while (region != 2) {
-			if (*rv == DEVICE_HANDLE_SEP) {
-				region++;
-			}
-			rv++;
-		}
-		/* Count supporting devices */
-		while (rv[i] != DEVICE_HANDLE_ENDS) {
-			++i;
-		}
-		*count = i;
-	}
-
-	return rv;
-}
-
-/**
  * @brief Visit every device that @p dev directly requires.
  *
  * Zephyr maintains information about which devices are directly required by
@@ -578,42 +537,6 @@ device_supported_handles_get(const struct device *dev,
 int device_required_foreach(const struct device *dev,
 			  device_visitor_callback_t visitor_cb,
 			  void *context);
-
-/**
- * @brief Visit every device that @p dev directly supports.
- *
- * Zephyr maintains information about which devices are directly supported by
- * another device; for example an I2C controller will support an I2C-based
- * sensor driver. Supported devices can derive from statically-defined
- * devicetree relationships.
- *
- * This API supports operating on the set of supported devices. Example uses
- * include iterating over the devices connected to a regulator when it is
- * powered on.
- *
- * There is no guarantee on the order in which required devices are visited.
- *
- * If the @p visitor function returns a negative value iteration is halted,
- * and the returned value from the visitor is returned from this function.
- *
- * @note This API is not available to unprivileged threads.
- *
- * @param dev a device of interest. The devices that this device supports
- * will be used as the set of devices to visit. This parameter must not be
- * null.
- *
- * @param visitor_cb the function that should be invoked on each device in the
- * support set. This parameter must not be null.
- *
- * @param context state that is passed through to the visitor function. This
- * parameter may be null if @p visitor tolerates a null @p context.
- *
- * @return The number of devices that were visited if all visits succeed, or
- * the negative value returned from the first visit that did not succeed.
- */
-int device_supported_foreach(const struct device *dev,
-			     device_visitor_callback_t visitor_cb,
-			     void *context);
 
 /**
  * @brief Retrieve the device structure for a driver by name

--- a/include/device.h
+++ b/include/device.h
@@ -492,7 +492,8 @@ device_required_handles_get(const struct device *dev,
 	if (rv != NULL) {
 		size_t i = 0;
 
-		while (rv[i] != DEVICE_HANDLE_SEP) {
+		while ((rv[i] != DEVICE_HANDLE_ENDS)
+		       && (rv[i] != DEVICE_HANDLE_SEP)) {
 			++i;
 		}
 		*count = i;
@@ -705,22 +706,6 @@ static inline bool device_is_ready(const struct device *dev)
  * from being captured when the original object file is compiled), and
  * in a distinct pass1 section (which will be replaced by
  * postprocessing).
- *
- * Before processing in gen_handles.py, the array format is:
- * {
- *     DEVICE_ORDINAL (or DEVICE_HANDLE_NULL if not a devicetree node),
- *     List of devicetree dependency ordinals (if any),
- *     DEVICE_HANDLE_SEP,
- *     List of injected dependency ordinals (if any),
- * }
- *
- * After processing in gen_handles.py, the format is updated to:
- * {
- *     List of existing devicetree dependency handles (if any),
- *     DEVICE_HANDLE_SEP,
- *     List of injected dependency ordinals (if any),
- *     DEVICE_HANDLE_NULL padding to original length (at least one)
- * }
  *
  * It is also (experimentally) necessary to provide explicit alignment
  * on each object. Otherwise x86-64 builds will introduce padding

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -303,6 +303,22 @@ config WAITQ_DUMB
 
 endchoice # WAITQ_ALGORITHM
 
+config DEVICE_HANDLE_PADDING
+	int "Number of additional device handles to use for padding"
+	default 0
+	range 0 10
+	help
+	  This is a "fudge factor" which works around build system
+	  limitations. It is safe to ignore unless you get a specific
+	  build system error about it.
+
+	  The option's value is the number of superfluous device handle
+	  values which are introduced into the array pointed to by each
+	  device's 'handles' member during the first linker pass.
+
+	  Each handle uses 2 bytes, so a value of 3 would use an extra
+	  6 bytes of ROM for every device.
+
 menu "Kernel Debugging and Metrics"
 
 config INIT_STACKS

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -162,11 +162,14 @@ bool z_device_ready(const struct device *dev)
 	return dev->state->initialized && (dev->state->init_res == 0U);
 }
 
-static int device_visitor(const device_handle_t *handles,
-			   size_t handle_count,
-			   device_visitor_callback_t visitor_cb,
-			   void *context)
+int device_required_foreach(const struct device *dev,
+			  device_visitor_callback_t visitor_cb,
+			  void *context)
 {
+	size_t handle_count = 0;
+	const device_handle_t *handles =
+		device_required_handles_get(dev, &handle_count);
+
 	/* Iterate over fixed devices */
 	for (size_t i = 0; i < handle_count; ++i) {
 		device_handle_t dh = handles[i];
@@ -179,26 +182,4 @@ static int device_visitor(const device_handle_t *handles,
 	}
 
 	return handle_count;
-}
-
-int device_required_foreach(const struct device *dev,
-			    device_visitor_callback_t visitor_cb,
-			    void *context)
-{
-	size_t handle_count = 0;
-	const device_handle_t *handles =
-		device_required_handles_get(dev, &handle_count);
-
-	return device_visitor(handles, handle_count, visitor_cb, context);
-}
-
-int device_supported_foreach(const struct device *dev,
-			     device_visitor_callback_t visitor_cb,
-			     void *context)
-{
-	size_t handle_count = 0;
-	const device_handle_t *handles =
-		device_supported_handles_get(dev, &handle_count);
-
-	return device_visitor(handles, handle_count, visitor_cb, context);
 }

--- a/scripts/gen_handles.py
+++ b/scripts/gen_handles.py
@@ -300,11 +300,10 @@ def main():
                         dep_paths.append(dn.path)
                     else:
                         dep_paths.append('(%s)' % dn.path)
-            # Force separator to signal start of injected dependencies
-            hdls.append(DEVICE_HANDLE_SEP)
             if len(hs.ext_deps) > 0:
                 # TODO: map these to something smaller?
                 ext_paths.extend(map(str, hs.ext_deps))
+                hdls.append(DEVICE_HANDLE_SEP)
                 hdls.extend(hs.ext_deps)
 
             # When CONFIG_USERSPACE is enabled the pre-built elf is

--- a/scripts/gen_handles.py
+++ b/scripts/gen_handles.py
@@ -246,19 +246,15 @@ def main():
         hvi = 1
         handle.dev_deps = []
         handle.ext_deps = []
-        handle.dev_sups = []
-        hdls = handle.dev_deps
+        deps = handle.dev_deps
         while hvi < len(hv):
             h = hv[hvi]
             if h == DEVICE_HANDLE_ENDS:
                 break
             if h == DEVICE_HANDLE_SEP:
-                if hdls == handle.dev_deps:
-                    hdls = handle.ext_deps
-                else:
-                    hdls = handle.dev_sups
+                deps = handle.ext_deps
             else:
-                hdls.append(h)
+                deps.append(h)
                 n = edt
             hvi += 1
 
@@ -271,7 +267,6 @@ def main():
     for sn in used_nodes:
         # Where we're storing the final set of nodes: these are all used
         sn.__depends = set()
-        sn.__supports = set()
 
         deps = set(sn.depends_on)
         debug("\nNode: %s\nOrig deps:\n\t%s" % (sn.path, "\n\t".join([dn.path for dn in deps])))
@@ -284,16 +279,7 @@ def main():
                 # forward the dependency up one level
                 for ddn in dn.depends_on:
                     deps.add(ddn)
-        debug("Final deps:\n\t%s\n" % ("\n\t".join([ _dn.path for _dn in sn.__depends])))
-
-        sups = set(sn.required_by)
-        debug("\nOrig sups:\n\t%s" % ("\n\t".join([dn.path for dn in sups])))
-        while len(sups) > 0:
-            dn = sups.pop()
-            if dn in used_nodes:
-                # this is used
-                sn.__supports.add(dn)
-        debug("\nFinal sups:\n\t%s" % ("\n\t".join([dn.path for dn in sn.__supports])))
+        debug("final deps:\n\t%s\n" % ("\n\t".join([ _dn.path for _dn in sn.__depends])))
 
     with open(args.output_source, "w") as fp:
         fp.write('#include <device.h>\n')
@@ -304,7 +290,6 @@ def main():
             assert hs, "no hs for %s" % (dev.sym.name,)
             dep_paths = []
             ext_paths = []
-            sup_paths = []
             hdls = []
 
             sn = hs.node
@@ -315,23 +300,12 @@ def main():
                         dep_paths.append(dn.path)
                     else:
                         dep_paths.append('(%s)' % dn.path)
-
             # Force separator to signal start of injected dependencies
             hdls.append(DEVICE_HANDLE_SEP)
             if len(hs.ext_deps) > 0:
                 # TODO: map these to something smaller?
                 ext_paths.extend(map(str, hs.ext_deps))
                 hdls.extend(hs.ext_deps)
-
-            # Force separator to signal start of supported devices
-            hdls.append(DEVICE_HANDLE_SEP)
-            if len(hs.dev_sups) > 0:
-                for dn in sn.required_by:
-                    if dn in sn.__supports:
-                        sup_paths.append(dn.path)
-                    else:
-                        sup_paths.append('(%s)' % dn.path)
-                hdls.extend(dn.__device.dev_handle for dn in sn.__supports)
 
             # When CONFIG_USERSPACE is enabled the pre-built elf is
             # also used to get hashes that identify kernel objects by
@@ -349,14 +323,9 @@ def main():
             ]
 
             if len(dep_paths) > 0:
-                lines.append(' * Direct Dependencies:')
-                lines.append(' *   - %s' % ('\n *   - '.join(dep_paths)))
+                lines.append(' * - %s' % ('\n * - '.join(dep_paths)))
             if len(ext_paths) > 0:
-                lines.append(' * Injected Dependencies:')
-                lines.append(' *   - %s' % ('\n *   - '.join(ext_paths)))
-            if len(sup_paths) > 0:
-                lines.append(' * Supported:')
-                lines.append(' *   - %s' % ('\n *   - '.join(sup_paths)))
+                lines.append(' * + %s' % ('\n * + '.join(ext_paths)))
 
             lines.extend([
                 ' */',

--- a/scripts/gen_handles.py
+++ b/scripts/gen_handles.py
@@ -311,9 +311,15 @@ def main():
             # address. We can't allow the size of any object in the
             # final elf to change. We also must make sure at least one
             # DEVICE_HANDLE_ENDS is inserted.
-            assert len(hdls) < len(hs.handles), "%s no DEVICE_HANDLE_ENDS inserted" % (dev.sym.name,)
-            while len(hdls) < len(hs.handles):
+            padding = len(hs.handles) - len(hdls)
+            assert padding > 0, \
+                (f"device {dev.sym.name}: "
+                 "linker pass 1 left no room to insert DEVICE_HANDLE_ENDS. "
+                 "To work around, increase CONFIG_DEVICE_HANDLE_PADDING by " +
+                 str(1 + (-padding)))
+            while padding > 0:
                 hdls.append(DEVICE_HANDLE_ENDS)
+                padding -= 1
             assert len(hdls) == len(hs.handles), "%s handle overflow" % (dev.sym.name,)
 
             lines = [

--- a/tests/lib/devicetree/devices/src/main.c
+++ b/tests/lib/devicetree/devices/src/main.c
@@ -74,15 +74,15 @@ static bool check_handle(device_handle_t hdl,
 	return false;
 }
 
-struct visitor_context {
+struct requires_context {
 	uint8_t ndevs;
 	const struct device *rdevs[2];
 };
 
-static int device_visitor(const struct device *dev,
-			  void *context)
+static int requires_visitor(const struct device *dev,
+			    void *context)
 {
-	struct visitor_context *ctx = context;
+	struct requires_context *ctx = context;
 	const struct device **rdp = ctx->rdevs;
 
 	while (rdp < (ctx->rdevs + ctx->ndevs)) {
@@ -102,14 +102,14 @@ static void test_requires(void)
 	size_t nhdls = 0;
 	const device_handle_t *hdls;
 	const struct device *dev;
-	struct visitor_context ctx = { 0 };
+	struct requires_context ctx = { 0 };
 
 	/* TEST_GPIO: no req */
 	dev = device_get_binding(DT_LABEL(TEST_GPIO));
 	zassert_equal(dev, DEVICE_DT_GET(TEST_GPIO), NULL);
 	hdls = device_required_handles_get(dev, &nhdls);
 	zassert_equal(nhdls, 0, NULL);
-	zassert_equal(0, device_required_foreach(dev, device_visitor, &ctx),
+	zassert_equal(0, device_required_foreach(dev, requires_visitor, &ctx),
 		      NULL);
 
 	/* TEST_I2C: no req */
@@ -117,7 +117,7 @@ static void test_requires(void)
 	zassert_equal(dev, DEVICE_DT_GET(TEST_I2C), NULL);
 	hdls = device_required_handles_get(dev, &nhdls);
 	zassert_equal(nhdls, 0, NULL);
-	zassert_equal(0, device_required_foreach(dev, device_visitor, &ctx),
+	zassert_equal(0, device_required_foreach(dev, requires_visitor, &ctx),
 		      NULL);
 
 	/* TEST_DEVA: TEST_I2C GPIO */
@@ -129,23 +129,23 @@ static void test_requires(void)
 	zassert_true(check_handle(DEV_HDL(TEST_GPIO), hdls, nhdls), NULL);
 
 	/* Visit fails if not enough space */
-	ctx = (struct visitor_context){
+	ctx = (struct requires_context){
 		.ndevs = 1,
 	};
-	zassert_equal(-ENOSPC, device_required_foreach(dev, device_visitor, &ctx),
+	zassert_equal(-ENOSPC, device_required_foreach(dev, requires_visitor, &ctx),
 		      NULL);
 
 	/* Visit succeeds if enough space. */
-	ctx = (struct visitor_context){
+	ctx = (struct requires_context){
 		.ndevs = 2,
 	};
-	zassert_equal(2, device_required_foreach(dev, device_visitor, &ctx),
+	zassert_equal(2, device_required_foreach(dev, requires_visitor, &ctx),
 		      NULL);
 	zassert_true((ctx.rdevs[0] == device_from_handle(DEV_HDL(TEST_I2C)))
-		     || (ctx.rdevs[1] == device_from_handle(DEV_HDL(TEST_I2C))),
+		      || (ctx.rdevs[1] == device_from_handle(DEV_HDL(TEST_I2C))),
 		     NULL);
 	zassert_true((ctx.rdevs[0] == device_from_handle(DEV_HDL(TEST_GPIO)))
-		     || (ctx.rdevs[1] == device_from_handle(DEV_HDL(TEST_GPIO))),
+		      || (ctx.rdevs[1] == device_from_handle(DEV_HDL(TEST_GPIO))),
 		     NULL);
 
 	/* TEST_GPIOX: TEST_I2C */
@@ -154,10 +154,10 @@ static void test_requires(void)
 	hdls = device_required_handles_get(dev, &nhdls);
 	zassert_equal(nhdls, 1, NULL);
 	zassert_true(check_handle(DEV_HDL(TEST_I2C), hdls, nhdls), NULL);
-	ctx = (struct visitor_context){
+	ctx = (struct requires_context){
 		.ndevs = 3,
 	};
-	zassert_equal(1, device_required_foreach(dev, device_visitor, &ctx),
+	zassert_equal(1, device_required_foreach(dev, requires_visitor, &ctx),
 		      NULL);
 	zassert_true(ctx.rdevs[0] == device_from_handle(DEV_HDL(TEST_I2C)),
 		     NULL);
@@ -171,45 +171,6 @@ static void test_requires(void)
 	zassert_true(check_handle(DEV_HDL(TEST_GPIOX), hdls, nhdls), NULL);
 }
 
-static void test_supports(void)
-{
-	size_t nhdls = 0;
-	const device_handle_t *hdls;
-	const struct device *dev;
-	struct visitor_context ctx = { 0 };
-
-	/* TEST_DEVB: None */
-	dev = DEVICE_DT_GET(TEST_DEVB);
-	hdls = device_supported_handles_get(dev, &nhdls);
-	zassert_equal(nhdls, 0, NULL);
-
-	/* TEST_GPIO: TEST_DEVA */
-	dev = DEVICE_DT_GET(TEST_GPIO);
-	hdls = device_supported_handles_get(dev, &nhdls);
-	zassert_equal(nhdls, 1, NULL);
-	zassert_true(check_handle(DEV_HDL(TEST_DEVA), hdls, nhdls), NULL);
-
-	/* Visit fails if not enough space */
-	ctx = (struct visitor_context){
-		.ndevs = 0,
-	};
-	zassert_equal(-ENOSPC, device_supported_foreach(dev, device_visitor, &ctx), NULL);
-
-	/* Visit succeeds if enough space. */
-	ctx = (struct visitor_context){
-		.ndevs = 1,
-	};
-	zassert_equal(1, device_supported_foreach(dev, device_visitor, &ctx), NULL);
-	zassert_true(ctx.rdevs[0] == device_from_handle(DEV_HDL(TEST_DEVA)), NULL);
-
-	/* TEST_I2C: TEST_DEVA TEST_GPIOX TEST_DEVB */
-	dev = DEVICE_DT_GET(TEST_I2C);
-	hdls = device_supported_handles_get(dev, &nhdls);
-	zassert_equal(nhdls, 3, NULL);
-	zassert_true(check_handle(DEV_HDL(TEST_DEVA), hdls, nhdls), NULL);
-	zassert_true(check_handle(DEV_HDL(TEST_GPIOX), hdls, nhdls), NULL);
-	zassert_true(check_handle(DEV_HDL(TEST_DEVB), hdls, nhdls), NULL);
-}
 
 static void test_get_or_null(void)
 {
@@ -232,7 +193,6 @@ void test_main(void)
 	ztest_test_suite(devicetree_driver,
 			 ztest_unit_test(test_init_order),
 			 ztest_unit_test(test_requires),
-			 ztest_unit_test(test_supports),
 			 ztest_unit_test(test_get_or_null)
 			 );
 	ztest_run_test_suite(devicetree_driver);


### PR DESCRIPTION
Fixes: #38181

When CONFIG_USERSPACE is enabled, the ELF file from linker pass 1 is
used to create a hash table that identifies kernel objects by address.
We therefore can't allow the size of any object in the pass 2 ELF to
change in a way that would change those addresses, or we would create
a garbage hash table.

Simultaneously (and regardless of CONFIG_USERSPACE's value),
gen_handles.py must transform arrays of handles from their pass 1
values to their pass 2 values; see the file's docstring for more
details on that transformation.

However, it is possible that a device has more direct dependencies in
the pass 2 handles array than its corresponding devicetree node had in
the pass 1 array. When this happens and gen_handles.py has no room to fill
the end of the array with a final DEVICE_HANDLE_ENDS,
the build fails and leaves users with no recourse to fix it. That's a
formerly theoretical showstopper, which became a real life showstopper when
the "supported" devices patchset landed in #37836.

To work around this for now:

- revert the 'supports' patches; which seem to have other problems anyway (see item 4. in https://github.com/zephyrproject-rtos/zephyr/pull/38487#pullrequestreview-762592997)
- although the reverts make the problem go away for current tests, add a new config option, CONFIG_DEVICE_HANDLE_PADDING, that users can use to hack around this limitation in case they run into the problem elsewhere

We'll chase a more invasive but better fix after 2.7 is released and try to backport it if we can.