### PR TITLE
dts: st: h7: fix wwdg1 reg size

### DIFF
--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -235,7 +235,7 @@
 
 		wwdg1: watchdog@50003000 {
 			compatible = "st,stm32-window-watchdog";
-			reg = <0x50003000 0x400>;
+			reg = <0x50003000 0x1000>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB3 0x00000800>;
 			interrupts = <0 7>;
 			status = "disabled";


### PR DESCRIPTION
nice to have real accurate sizing,
WWDG size happens to be 0x1000, reference manual for your perusal 

![image](https://user-images.githubusercontent.com/17961318/134756328-77e93bdf-7dda-41d5-9d1d-87aae795f452.png)

Signed-off-by: Manojkumar Subramaniam <manoj@electrolance.com>