### PR TITLE
Bluetooth: ASCS: Fix bad #if defined(BT_AUDIO_UNICAST_SERVER)

### DIFF
--- a/subsys/bluetooth/host/audio/ascs.c
+++ b/subsys/bluetooth/host/audio/ascs.c
@@ -30,7 +30,7 @@
 #include "capabilities.h"
 #include "pacs_internal.h"
 
-#if defined(BT_AUDIO_UNICAST_SERVER)
+#if defined(CONFIG_BT_AUDIO_UNICAST_SERVER)
 
 #define ASE_ID(_ase) ase->ep.status.id
 #define ASE_DIR(_id) \


### PR DESCRIPTION
The #if defined was missing CONFIG and never compiled the
filed properly.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>