### PR TITLE
kernel/sched: Add CONFIG_CPU_MASK_PIN_ONLY

### DIFF
--- a/include/kernel_structs.h
+++ b/include/kernel_structs.h
@@ -109,6 +109,10 @@ struct _cpu {
 	/* one assigned idle thread per CPU */
 	struct k_thread *idle_thread;
 
+#ifdef CONFIG_SCHED_CPU_MASK_PIN_ONLY
+	struct _ready_q ready_q;
+#endif
+
 #if (CONFIG_NUM_METAIRQ_PRIORITIES > 0) && (CONFIG_NUM_COOP_PRIORITIES > 0)
 	/* Coop thread preempted by current metairq, or NULL */
 	struct k_thread *metairq_preempted;
@@ -143,7 +147,9 @@ struct z_kernel {
 	 * ready queue: can be big, keep after small fields, since some
 	 * assembly (e.g. ARC) are limited in the encoding of the offset
 	 */
+#ifndef CONFIG_SCHED_CPU_MASK_PIN_ONLY
 	struct _ready_q ready_q;
+#endif
 
 #ifdef CONFIG_FPU_SHARING
 	/*

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -136,6 +136,21 @@ config SCHED_CPU_MASK
 	  CPU.  With one CPU, it's just a higher overhead version of
 	  k_thread_start/stop().
 
+config SCHED_CPU_MASK_PIN_ONLY
+	bool "CPU mask variant with single-CPU pinning only"
+	depends on SMP && SCHED_CPU_MASK
+	help
+	  When true, enables a variant of SCHED_CPU_MASK where only
+	  one CPU may be specified for every thread.  Effectively, all
+	  threads have a single "assigned" CPU and they will never be
+	  scheduled symmetrically.  In general this is not helpful,
+	  but some applications have a carefully designed threading
+	  architecture and want to make their own decisions about how
+	  to assign work to CPUs.  In that circumstance, some moderate
+	  optimizations can be made (e.g. having a separate run queue
+	  per CPU, keeping the list length shorter).  Most
+	  applications don't want this.
+
 config MAIN_STACK_SIZE
 	int "Size of stack for initialization and main thread"
 	default 2048 if COVERAGE_GCOV

--- a/kernel/include/kernel_offsets.h
+++ b/kernel/include/kernel_offsets.h
@@ -40,7 +40,9 @@ GEN_OFFSET_SYM(_kernel_t, threads);
 GEN_OFFSET_SYM(_kernel_t, idle);
 #endif
 
+#ifndef CONFIG_SCHED_CPU_MASK_PIN_ONLY
 GEN_OFFSET_SYM(_kernel_t, ready_q);
+#endif
 
 #ifndef CONFIG_SMP
 GEN_OFFSET_SYM(_ready_q_t, cache);

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -582,7 +582,11 @@ char *z_setup_new_thread(struct k_thread *new_thread,
 	}
 #endif
 #ifdef CONFIG_SCHED_CPU_MASK
-	new_thread->base.cpu_mask = -1;
+	if (IS_ENABLED(CONFIG_SCHED_CPU_MASK_PIN_ONLY)) {
+		new_thread->base.cpu_mask = 1; /* must specify only one cpu */
+	} else {
+		new_thread->base.cpu_mask = -1; /* allow all cpus */
+	}
 #endif
 #ifdef CONFIG_ARCH_HAS_CUSTOM_SWAP_TO_MAIN
 	/* _current may be null if the dummy thread is not used */

--- a/tests/kernel/threads/thread_apis/src/test_threads_cpu_mask.c
+++ b/tests/kernel/threads/thread_apis/src/test_threads_cpu_mask.c
@@ -42,6 +42,13 @@ void test_threads_cpu_mask(void)
 	zassert_true(ret == -EINVAL, "");
 
 	for (pass = 0; pass < 4; pass++) {
+		if (IS_ENABLED(CONFIG_SCHED_CPU_MASK_PIN_ONLY) && pass == 1) {
+			/* Pass 1 enables more than one CPU in the
+			 * mask, which is illegal when PIN_ONLY
+			 */
+			continue;
+		}
+
 		child_has_run = false;
 
 		/* Create a thread at a higher priority, don't start

--- a/tests/kernel/threads/thread_apis/testcase.yaml
+++ b/tests/kernel/threads/thread_apis/testcase.yaml
@@ -2,3 +2,9 @@ tests:
   kernel.threads.apis:
     tags: kernel threads userspace ignore_faults
     min_flash: 34
+  kernel.threads.apis.pinonly:
+    tags: kernel threads userspace ignore_faults
+    min_flash: 34
+    filter: CONFIG_SMP
+    extra_configs:
+      - CONFIG_SCHED_CPU_MASK_PIN_ONLY=y


### PR DESCRIPTION
Some SMP applications have threading designs where every thread created is always assigned to a specific CPU, and never want to schedule them symmetrically across CPUs under any circumstance.

In this situation, it's possible to optimize the run queue design a bit to put a separate queue in each CPU struct instead of having a single global one.  This is probably good for a few cycles per scheduling event (maybe a bit more on architectures where cache locality can be exploited) in circumstances where there is more than one runnable thread.  It's a mild optimization, but a basically simple one. 

(Structured as a bunch of refactorings plus a single functional patch to make clear how simple a change this is)