### PR TITLE
Bluetooth: Audio: Revert codec check

### DIFF
--- a/subsys/bluetooth/host/audio/ascs.c
+++ b/subsys/bluetooth/host/audio/ascs.c
@@ -620,7 +620,7 @@ static int ase_config(struct bt_ascs *ascs, struct bt_ascs_ase *ase,
 		struct bt_codec codec;
 
 		/* Skip if capabilities don't match */
-		if (memcmp(&cfg->codec, &cap->codec, sizeof(cap->codec))) {
+		if (cfg->codec.id != cap->codec->id) {
 			continue;
 		}
 

--- a/subsys/bluetooth/host/audio/bap.c
+++ b/subsys/bluetooth/host/audio/bap.c
@@ -71,7 +71,7 @@ static struct bt_audio_chan *bap_config(struct bt_conn *conn,
 	}
 
 	SYS_SLIST_FOR_EACH_CONTAINER(lst, lcap, node) {
-		if (memcmp(&lcap->codec, &cap->codec, sizeof(cap->codec))) {
+		if (lcap->codec->id != cap->codec->id) {
 			continue;
 		}
 

--- a/subsys/bluetooth/host/audio/chan.c
+++ b/subsys/bluetooth/host/audio/chan.c
@@ -128,7 +128,7 @@ struct bt_audio_chan *bt_audio_chan_config(struct bt_conn *conn,
 	}
 
 	/* Check that codec and frequency are supported */
-	if (memcmp(&codec, &cap->codec, sizeof(cap->codec))) {
+	if (cap->codec->id != codec->id) {
 		BT_ERR("Invalid codec id");
 		return NULL;
 	}
@@ -198,7 +198,7 @@ int bt_audio_chan_reconfig(struct bt_audio_chan *chan,
 	}
 
 	/* Check that codec is supported */
-	if (memcmp(&codec, &cap->codec, sizeof(cap->codec))) {
+	if (cap->codec->id != codec->id) {
 		return -ENOTSUP;
 	}
 


### PR DESCRIPTION
Reverts the commit as it breaks BAP for working. 

Whatever was the intention of this change, wasn't properly implemented. 