### PR TITLE
dts: bindings: vendor-prefixes: Add Bouffalo Lab prefix

### DIFF
--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -89,6 +89,7 @@ beacon	Compass Electronics Group, LLC
 beagle	BeagleBoard.org Foundation
 bhf	Beckhoff Automation GmbH & Co. KG
 bitmain	Bitmain Technologies
+bl	Bouffalo Lab
 blutek	BluTek Power
 boe	BOE Technology Group Co., Ltd.
 bosch	Bosch Sensortec GmbH


### PR DESCRIPTION
Add bl as manufacturer binding prefix for Bouffalo Lab.

Signed-off-by: Gerson Fernando Budke <nandojve@gmail.com>