### PR TITLE
scripts: runner: Introduce blflash runner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -619,6 +619,7 @@
 /scripts/twister                          @nashif
 /scripts/series-push-hook.sh              @erwango
 /scripts/west_commands/                   @mbolivar-nordic
+/scripts/west_commands/runners/blflash.py @mbolivar-nordic @nandojve
 /scripts/west-commands.yml                @mbolivar-nordic
 /scripts/zephyr_module.py                 @tejlmand
 /scripts/uf2conv.py                       @petejohanson

--- a/boards/common/blflash.board.cmake
+++ b/boards/common/blflash.board.cmake
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+
+board_set_flasher_ifnset(blflash)
+board_finalize_runner_args(blflash)

--- a/scripts/west_commands/runners/__init__.py
+++ b/scripts/west_commands/runners/__init__.py
@@ -26,6 +26,7 @@ def _import_runner_module(runner_name):
 
 _names = [
     'blackmagicprobe',
+    'blflash',
     'bossac',
     'canopen_program',
     'dediprog',

--- a/scripts/west_commands/runners/blflash.py
+++ b/scripts/west_commands/runners/blflash.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2021 Gerson Fernando Budke <nandojve@gmail.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+'''Bouffalo Lab flash tool (blflash) runner for serial boot ROM'''
+
+from runners.core import ZephyrBinaryRunner, RunnerCaps
+
+DEFAULT_BLFLASH_PORT = '/dev/ttyUSB0'
+DEFAULT_BLFLASH_SPEED = '2000000'
+
+class BlFlashBinaryRunner(ZephyrBinaryRunner):
+    '''Runner front-end for blflash.'''
+
+    def __init__(self, cfg, blflash='blflash',
+                 port=DEFAULT_BLFLASH_PORT,
+                 speed=DEFAULT_BLFLASH_SPEED):
+        super().__init__(cfg)
+        self.blflash = blflash
+        self.port = port
+        self.speed = speed
+
+    @classmethod
+    def name(cls):
+        return 'blflash'
+
+    @classmethod
+    def capabilities(cls):
+        return RunnerCaps(commands={'flash'})
+
+    @classmethod
+    def do_add_parser(cls, parser):
+        parser.add_argument('--blflash', default='blflash',
+                            help='path to blflash, default is blflash')
+        parser.add_argument('--port', default=DEFAULT_BLFLASH_PORT,
+                            help='serial port to use, default is ' +
+                            str(DEFAULT_BLFLASH_PORT))
+        parser.add_argument('--speed', default=DEFAULT_BLFLASH_SPEED,
+                            help='serial port speed to use, default is ' +
+                            DEFAULT_BLFLASH_SPEED)
+
+    @classmethod
+    def do_create(cls, cfg, args):
+        return BlFlashBinaryRunner(cfg,
+                                   blflash=args.blflash,
+                                   port=args.port,
+                                   speed=args.speed)
+
+    def do_run(self, command, **kwargs):
+        self.require(self.blflash)
+        self.ensure_output('bin')
+
+        cmd_flash = [self.blflash,
+                     'flash',
+                     '-s', self.speed,
+                     self.cfg.bin_file,
+                     '-p', self.port]
+
+        self.check_call(cmd_flash)

--- a/scripts/west_commands/tests/test_imports.py
+++ b/scripts/west_commands/tests/test_imports.py
@@ -16,6 +16,7 @@ def test_runner_imports():
     # Please keep this sorted alphabetically.
     expected = set(('arc-nsim',
                     'blackmagicprobe',
+                    'blflash',
                     'bossac',
                     'canopen',
                     'dediprog',


### PR DESCRIPTION
Add Bouffalo Lab ISP console flash runner.  This tool enable bootloader to flash devices using serial port.

The blflash Rust tool can be found at
  https://github.com/spacemeowx2/blflash

Signed-off-by: Gerson Fernando Budke <nandojve@gmail.com>