### PR TITLE
Bluetooth: Controller: Fix multiple peripheral connection deadlock

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -5903,7 +5903,9 @@ static inline void ctrl_tx_ack(struct ll_conn *conn, struct node_tx **tx,
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 	case PDU_DATA_LLCTRL_TYPE_LENGTH_REQ:
 		/* wait for response */
-		conn->llcp_length.state = LLCP_LENGTH_STATE_RSP_WAIT;
+		if (conn->llcp_length.state == LLCP_LENGTH_STATE_REQ_ACK_WAIT) {
+			conn->llcp_length.state = LLCP_LENGTH_STATE_RSP_WAIT;
+		}
 		break;
 
 	case PDU_DATA_LLCTRL_TYPE_LENGTH_RSP:


### PR DESCRIPTION
Fix deadlock in multiple peripheral connection in a device
due to redundant double reservation of node rx buffer during
crossover scenario in Data Length Update procedure.

Data Length Update resize state was reset back to response
wait state when peripheral received an acknowledgment to
local initiated Data Length Request PDU after having already
transitioned to resize state.

Implementation is designed to transition to resize state
under both Data Length Response reception and crossover
scenario of Data Length Request reception when procedure is
local initiated.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>