### PR TITLE
Add support for BME680 SPI Interface

### DIFF
--- a/drivers/sensor/bme680/CMakeLists.txt
+++ b/drivers/sensor/bme680/CMakeLists.txt
@@ -1,9 +1,9 @@
-#
 # Copyright (c) 2018 Bosch Sensortec GmbH
+# Copyright (c) 2022, Leonard Pollak
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 
 zephyr_library()
 
-zephyr_library_sources(bme680.c)
+zephyr_library_sources(bme680.c bme680_i2c.c bme680_spi.c)

--- a/drivers/sensor/bme680/Kconfig
+++ b/drivers/sensor/bme680/Kconfig
@@ -1,13 +1,15 @@
 # BME680 temperature, pressure, humidity and gas sensor configuration options
 
 # Copyright (c) 2018 Bosch Sensortec GmbH
+# Copyright (c) 2022, Leonard Pollak
+#
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig BME680
 	bool "BME680 sensor"
-	depends on I2C
+	depends on I2C || SPI
 	help
-	  Enable driver for BME680 I2C-based based temperature, pressure, humidity and gas sensor.
+	  Enable driver for BME680 I2C- or SPI- based temperature, pressure, humidity and gas sensor.
 
 if BME680
 

--- a/drivers/sensor/bme680/bme680.c
+++ b/drivers/sensor/bme680/bme680.c
@@ -11,33 +11,49 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT bosch_bme680
-
-#include "bme680.h"
 #include <drivers/gpio.h>
-#include <drivers/i2c.h>
 #include <init.h>
 #include <kernel.h>
 #include <sys/byteorder.h>
 #include <sys/__assert.h>
 #include <drivers/sensor.h>
-
 #include <logging/log.h>
+
+#include "bme680.h"
+
 LOG_MODULE_REGISTER(bme680, CONFIG_SENSOR_LOG_LEVEL);
 
-static int bme680_reg_read(const struct device *dev, uint8_t start,
-			   uint8_t *buf, int size)
+
+#if BME680_BUS_SPI
+static inline bool bme680_is_on_spi(const struct device *dev)
 {
 	const struct bme680_config *config = dev->config;
 
-	return i2c_burst_read_dt(&config->bus, start, buf, size);
+	return config->bus_io == &bme680_bus_io_spi;
+}
+#endif
+
+static inline int bme680_bus_check(const struct device *dev)
+{
+	const struct bme680_config *config = dev->config;
+
+	return config->bus_io->check(&config->bus);
 }
 
-static int bme680_reg_write(const struct device *dev, uint8_t reg, uint8_t val)
+static inline int bme680_reg_read(const struct device *dev,
+				  uint8_t start, uint8_t *buf, int size)
 {
 	const struct bme680_config *config = dev->config;
 
-	return i2c_reg_write_byte_dt(&config->bus, reg, val);
+	return config->bus_io->read(dev, start, buf, size);
+}
+
+static inline int bme680_reg_write(const struct device *dev, uint8_t reg,
+				   uint8_t val)
+{
+	const struct bme680_config *config = dev->config;
+
+	return config->bus_io->write(dev, reg, val);
 }
 
 static void bme680_calc_temp(struct bme680_data *data, uint32_t adc_temp)
@@ -346,13 +362,22 @@ static int bme680_read_compensation(const struct device *dev)
 static int bme680_init(const struct device *dev)
 {
 	struct bme680_data *data = dev->data;
-	const struct bme680_config *config = dev->config;
 	int err;
 
-	if (!device_is_ready(config->bus.bus)) {
-		LOG_ERR("I2C master %s not ready", config->bus.bus->name);
-		return -EINVAL;
+	err = bme680_bus_check(dev);
+	if (err < 0) {
+		LOG_ERR("Bus not ready for '%s'", dev->name);
+		return err;
 	}
+
+#if BME680_BUS_SPI
+	if (bme680_is_on_spi(dev)) {
+		err = bme680_reg_read(dev, BME680_REG_MEM_PAGE, &data->mem_page, 1);
+		if (err < 0) {
+			return err;
+		}
+	}
+#endif
 
 	err = bme680_reg_read(dev, BME680_REG_CHIP_ID, &data->chip_id, 1);
 	if (err < 0) {
@@ -410,12 +435,39 @@ static const struct sensor_driver_api bme680_api_funcs = {
 	.channel_get = bme680_channel_get,
 };
 
-static struct bme680_data bme680_data;
+/* Initializes a struct bme680_config for an instance on a SPI bus. */
+#define BME680_CONFIG_SPI(inst)				\
+	{						\
+		.bus.spi = SPI_DT_SPEC_INST_GET(	\
+			inst, BME680_SPI_OPERATION, 0),	\
+		.bus_io = &bme680_bus_io_spi,		\
+	}
 
-static const struct bme680_config bme680_config = {
-	.bus = I2C_DT_SPEC_INST_GET(0)
-};
+/* Initializes a struct bme680_config for an instance on an I2C bus. */
+#define BME680_CONFIG_I2C(inst)			       \
+	{					       \
+		.bus.i2c = I2C_DT_SPEC_INST_GET(inst), \
+		.bus_io = &bme680_bus_io_i2c,	       \
+	}
 
-DEVICE_DT_INST_DEFINE(0, bme680_init, NULL, &bme680_data,
-		      &bme680_config, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
-		      &bme680_api_funcs);
+/*
+ * Main instantiation macro, which selects the correct bus-specific
+ * instantiation macros for the instance.
+ */
+#define BME680_DEFINE(inst)						\
+	static struct bme680_data bme680_data_##inst;			\
+	static const struct bme680_config bme680_config_##inst =	\
+		COND_CODE_1(DT_INST_ON_BUS(inst, spi),			\
+			    (BME680_CONFIG_SPI(inst)),			\
+			    (BME680_CONFIG_I2C(inst)));			\
+	DEVICE_DT_INST_DEFINE(inst,					\
+			 bme680_init,					\
+			 NULL,						\
+			 &bme680_data_##inst,				\
+			 &bme680_config_##inst,				\
+			 POST_KERNEL,					\
+			 CONFIG_SENSOR_INIT_PRIORITY,			\
+			 &bme680_api_funcs);
+
+/* Create the struct device for every status "okay" node in the devicetree. */
+DT_INST_FOREACH_STATUS_OKAY(BME680_DEFINE)

--- a/drivers/sensor/bme680/bme680.c
+++ b/drivers/sensor/bme680/bme680.c
@@ -292,7 +292,7 @@ static int bme680_read_compensation(const struct device *dev)
 	}
 
 	err = bme680_reg_read(dev, BME680_REG_COEFF2, &buff[BME680_LEN_COEFF1],
-			      16);
+			      BME680_LEN_COEFF2);
 	if (err < 0) {
 		return err;
 	}

--- a/drivers/sensor/bme680/bme680.h
+++ b/drivers/sensor/bme680/bme680.h
@@ -29,7 +29,7 @@
 #define BME680_REG_CTRL_HUM             0x72
 #define BME680_REG_CTRL_MEAS            0x74
 #define BME680_REG_CONFIG               0x75
-#define BME680_REG_MEM_PAGE             0xf3
+#define BME680_REG_MEM_PAGE             0x73
 #define BME680_REG_UNIQUE_ID            0x83
 #define BME680_REG_COEFF1               0x8a
 #define BME680_REG_CHIP_ID              0xd0

--- a/drivers/sensor/bme680/bme680.h
+++ b/drivers/sensor/bme680/bme680.h
@@ -1,12 +1,14 @@
 /*
  * Copyright (c) 2018 Bosch Sensortec GmbH
+ * Copyright (c) 2022, Leonard Pollak
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __SENSOR_BME680_H__
-#define __SENSOR_BME680_H__
+#ifndef __ZEPHYR_DRIVERS_SENSOR_BME680_H__
+#define __ZEPHYR_DRIVERS_SENSOR_BME680_H__
 
+#include <zephyr/types.h>
 #include <device.h>
 #include <drivers/i2c.h>
 
@@ -32,9 +34,9 @@
 #define BME680_REG_MEM_PAGE             0x73
 #define BME680_REG_UNIQUE_ID            0x83
 #define BME680_REG_COEFF1               0x8a
-#define BME680_REG_CHIP_ID              0xd0
-#define BME680_REG_SOFT_RESET           0xe0
 #define BME680_REG_COEFF2               0xe1
+#define BME680_REG_CHIP_ID		0xd0
+#define BME680_REG_SOFT_RESET           0xe0
 
 #define BME680_MSK_NEW_DATA             0x80
 #define BME680_MSK_GAS_RANGE            0x0f
@@ -167,4 +169,4 @@ struct bme680_config {
 	struct i2c_dt_spec bus;
 };
 
-#endif /* __SENSOR_BME680_H__ */
+#endif /* __ZEPHYR_DRIVERS_SENSOR_BME680_H__ */

--- a/drivers/sensor/bme680/bme680_i2c.c
+++ b/drivers/sensor/bme680/bme680_i2c.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2016, 2017 Intel Corporation
+ * Copyright (c) 2017 IpTronix S.r.l.
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ * Copyright (c) 2022, Leonard Pollak
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Bus-specific functionality for BME680s accessed via I2C.
+ */
+
+#include "bme680.h"
+
+#if BME680_BUS_I2C
+static int bme680_bus_check_i2c(const union bme680_bus *bus)
+{
+	return device_is_ready(bus->i2c.bus) ? 0 : -ENODEV;
+}
+
+static int bme680_reg_read_i2c(const struct device *dev,
+			       uint8_t start, uint8_t *buf, int size)
+{
+	const struct bme680_config *config = dev->config;
+
+	return i2c_burst_read_dt(&config->bus.i2c, start, buf, size);
+}
+
+static int bme680_reg_write_i2c(const struct device *dev,
+				uint8_t reg, uint8_t val)
+{
+	const struct bme680_config *config = dev->config;
+
+	return i2c_reg_write_byte_dt(&config->bus.i2c, reg, val);
+}
+
+const struct bme680_bus_io bme680_bus_io_i2c = {
+	.check = bme680_bus_check_i2c,
+	.read = bme680_reg_read_i2c,
+	.write = bme680_reg_write_i2c,
+};
+#endif /* BME680_BUS_I2C */

--- a/drivers/sensor/bme680/bme680_spi.c
+++ b/drivers/sensor/bme680/bme680_spi.c
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2016, 2017 Intel Corporation
+ * Copyright (c) 2017 IpTronix S.r.l.
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ * Copyright (c) 2022, Leonard Pollak
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Bus-specific functionality for BME680s accessed via SPI.
+ */
+
+#include <logging/log.h>
+#include "bme680.h"
+
+#if BME680_BUS_SPI
+
+LOG_MODULE_DECLARE(bme680, CONFIG_SENSOR_LOG_LEVEL);
+
+static int bme680_bus_check_spi(const union bme680_bus *bus)
+{
+	return spi_is_ready(&bus->spi) ? 0 : -ENODEV;
+}
+
+static inline int bme680_set_mem_page(const struct device *dev, uint8_t addr)
+{
+	const struct bme680_config *config = dev->config;
+	struct bme680_data *data = dev->data;
+	uint8_t page;
+	int err = 0;
+
+	if (addr > 0x7f) {
+		page = BME680_MEM_PAGE1;
+	} else {
+		page = BME680_MEM_PAGE0;
+	}
+
+	if (data->mem_page != page) {
+
+		data->mem_page = page;
+		uint8_t cmd[] = { BME680_REG_MEM_PAGE & BME680_SPI_WRITE_MSK, data->mem_page };
+		const struct spi_buf tx_buf = {
+			.buf = cmd,
+			.len = sizeof(cmd)
+		};
+		const struct spi_buf_set tx = {
+			.buffers = &tx_buf,
+			.count = 1
+		};
+
+		err = spi_write_dt(&config->bus.spi, &tx);
+	}
+	return err;
+}
+
+static int bme680_reg_write_spi(const struct device *dev,
+				uint8_t reg, uint8_t val)
+{
+	const struct bme680_config *config = dev->config;
+	int err;
+	uint8_t cmd[] = { reg & BME680_SPI_WRITE_MSK, val };
+	const struct spi_buf tx_buf = {
+		.buf = cmd,
+		.len = sizeof(cmd)
+	};
+	const struct spi_buf_set tx = {
+		.buffers = &tx_buf,
+		.count = 1
+	};
+
+	err = bme680_set_mem_page(dev, reg);
+	if (err) {
+		return err;
+	}
+
+	err = spi_write_dt(&config->bus.spi, &tx);
+
+	return err;
+}
+
+static int bme680_reg_read_spi(const struct device *dev,
+			       uint8_t start, uint8_t *buf, int size)
+{
+	const struct bme680_config *config = dev->config;
+	int err;
+	uint8_t addr;
+	const struct spi_buf tx_buf = {
+		.buf = &addr,
+		.len = 1
+	};
+	const struct spi_buf_set tx = {
+		.buffers = &tx_buf,
+		.count = 1
+	};
+	struct spi_buf rx_buf[2];
+	const struct spi_buf_set rx = {
+		.buffers = rx_buf,
+		.count = ARRAY_SIZE(rx_buf)
+	};
+
+	rx_buf[0].buf = NULL;
+	rx_buf[0].len = 1;
+
+	addr = start | BME680_SPI_READ_BIT;
+	rx_buf[1].buf = buf;
+	rx_buf[1].len = size;
+
+	err = bme680_set_mem_page(dev, start);
+	if (err) {
+		return err;
+	}
+
+	err = spi_transceive_dt(&config->bus.spi, &tx, &rx);
+
+	return err;
+}
+
+const struct bme680_bus_io bme680_bus_io_spi = {
+	.check = bme680_bus_check_spi,
+	.read = bme680_reg_read_spi,
+	.write = bme680_reg_write_spi,
+};
+#endif /* BME680_BUS_SPI */

--- a/dts/bindings/sensor/bosch,bme680-spi.yaml
+++ b/dts/bindings/sensor/bosch,bme680-spi.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2022, Leonard Pollak
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    The BME680 is an integrated environmental sensor that measures
+    temperature, pressure, humidity and air quality
+
+compatible: "bosch,bme680"
+
+include: spi-device.yaml

--- a/tests/drivers/build_all/sensor/spi.dtsi
+++ b/tests/drivers/build_all/sensor/spi.dtsi
@@ -337,3 +337,10 @@ test_spi_icm42670: icm42670@3c {
 	gyro-hz = <800>;
 	gyro-fs = <2000>;
 };
+
+test_spi_bme680: bme680@3c {
+	compatible = "bosch,bme680";
+	label = "BME680";
+	reg = <0x3c>;
+	spi-max-frequency = <0>;
+};


### PR DESCRIPTION
This Pull request adds support for the BME680 SPI Interface.
It is mostly analogous to the BME280.

Signed-off-by: Leonard Pollak leonardp@tr-host.de