### PR TITLE
bluetooth: host: Fix legacy SMP pairing

### DIFF
--- a/subsys/bluetooth/host/smp.h
+++ b/subsys/bluetooth/host/smp.h
@@ -86,7 +86,7 @@ struct bt_smp_encrypt_info {
 	uint8_t  ltk[16];
 } __packed;
 
-#define BT_SMP_CMD_CENTRAL_IDENT		0x0
+#define BT_SMP_CMD_CENTRAL_IDENT		0x07
 struct bt_smp_central_ident {
 	uint8_t ediv[2];
 	uint8_t rand[8];


### PR DESCRIPTION
This is a regression introduced in b8770acc28f157ee when
aligning with BT Core Spec 5.3 naming convention.

Signed-off-by: Szymon Janc <szymon.janc@codecoup.pl>