### PR TITLE
Bluetooth: ISO: Remove duplicate struct bt_iso_chan declaration

### DIFF
--- a/include/bluetooth/iso.h
+++ b/include/bluetooth/iso.h
@@ -74,8 +74,6 @@ extern "C" {
 /** Broadcast code size */
 #define BT_ISO_BROADCAST_CODE_SIZE  16
 
-struct bt_iso_chan;
-
 /** @brief Life-span states of ISO channel. Used only by internal APIs
  *  dealing with setting channel to proper state depending on operational
  *  context.


### PR DESCRIPTION
The struct was declared twice (once as an opaque type) in
iso.h, but was unneeded. Removed to avoid confusion about
whether it is an opaque type.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>