### PR TITLE
Bluetooth: ISO: Move bt_iso_accept and make static

### DIFF
--- a/subsys/bluetooth/host/iso_internal.h
+++ b/subsys/bluetooth/host/iso_internal.h
@@ -95,9 +95,6 @@ void hci_le_big_sync_established(struct net_buf *buf);
 void hci_le_big_sync_lost(struct net_buf *buf);
 
 /* Notify ISO channels of a new connection */
-int bt_iso_accept(struct bt_conn *acl, struct bt_conn *iso);
-
-/* Notify ISO channels of a new connection */
 void bt_iso_connected(struct bt_conn *iso);
 
 /* Notify ISO channels of a disconnect event */


### PR DESCRIPTION
Move the function and make it static as it is only
used in iso.c and for unicast only.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>