### PR TITLE
tests/lib/cmsis_dsp: matrix: Limit f16 tc execution on ram => 144

### DIFF
--- a/tests/lib/cmsis_dsp/matrix/testcase.yaml
+++ b/tests/lib/cmsis_dsp/matrix/testcase.yaml
@@ -237,9 +237,8 @@ tests:
       - mps2_an521
       - native_posix
     tags: cmsis_dsp
-    platform_exclude: frdm_kw41z
     min_flash: 128
-    min_ram: 128
+    min_ram: 144
     extra_args: CONF_FILE=prj_base.conf
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_MATRIX_BINARY_F16=y
@@ -248,9 +247,8 @@ tests:
     integration_platforms:
       - mps2_an521_remote
     tags: cmsis_dsp fpu
-    platform_exclude: frdm_kw41z
     min_flash: 128
-    min_ram: 128
+    min_ram: 144
     extra_args: CONF_FILE=prj_base.conf
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_MATRIX_BINARY_F16=y


### PR DESCRIPTION
binary_f16 and binary_f16.fpu test cases fail when target
SRAM size is below 140k.
Update test case requirements to set min_ram to 144.

Additionally, remove the platform_exclude hich is now useless
(frdm_kw41z ram is 128k).

Fixes #38826

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>