### PR TITLE
include: usb: fix hid feature item typo

### DIFF
--- a/include/usb/class/hid.h
+++ b/include/usb/class/hid.h
@@ -199,7 +199,7 @@ extern "C" {
  * @return  HID Feature item
  */
 #define HID_FEATURE(a)			\
-	HID_ITEM(HID_ITEM_TAG_OUTPUT, HID_ITEM_TYPE_MAIN, 1), a
+	HID_ITEM(HID_ITEM_TAG_FEATURE, HID_ITEM_TYPE_MAIN, 1), a
 
 /**
  * @brief Define HID Collection item with the data length of one byte.


### PR DESCRIPTION
Fix typo setting HID feature item to output item.

Signed-off-by: Sven Åkersten <sven.akersten@gmail.com>