### PR TITLE
Bluetooth: Audio: Fix return value of bt_audio_cig_terminate if not found

### DIFF
--- a/subsys/bluetooth/host/audio/chan.c
+++ b/subsys/bluetooth/host/audio/chan.c
@@ -1035,7 +1035,7 @@ int bt_audio_cig_terminate(struct bt_audio_chan *chan)
 	}
 
 	BT_DBG("CIG not found for chan %p", chan);
-	return -EINVAL;
+	return 0; /* Return 0 as it would already be terminated */
 }
 
 int bt_audio_chan_connect(struct bt_audio_chan *chan)


### PR DESCRIPTION
If no CIG is found for the channel, it should return 0, as that
implies that the CIG was not created for that channel.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>