### PR TITLE
drivers/flash/flash_shell: Check for read error before verification

### DIFF
--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -124,7 +124,10 @@ static int cmd_write(const struct shell *shell, size_t argc, char *argv[])
 
 	shell_print(shell, "Write OK.");
 
-	flash_read(flash_dev, w_addr, check_array, sizeof(buf_array[0]) * j);
+	if (flash_read(flash_dev, w_addr, check_array, sizeof(buf_array[0]) * j) != 0) {
+		shell_print(shell, "Verification read ERROR!");
+		return -EIO;
+	}
 
 	if (memcmp(buf_array, check_array, sizeof(buf_array[0]) * j) == 0) {
 		shell_print(shell, "Verified.");


### PR DESCRIPTION
The cmd_write contains write verification that compares what has
been written with what it can read; the flash read operation
status was not checked which means that the bus or communication
problem was reported the same way as malformed write.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>