### PR TITLE
stm32f1: Fix gpio interrupt configuration

### DIFF
--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -692,7 +692,8 @@ GPIO_DEVICE_INIT_STM32(k, K);
 #endif /* DT_NODE_HAS_STATUS(DT_NODELABEL(gpiok), okay) */
 
 
-#if defined(CONFIG_SOC_SERIES_STM32F1X)
+#if defined(CONFIG_SOC_SERIES_STM32F1X) && \
+	!defined(CONFIG_GPIO_STM32_SWJ_ENABLE)
 
 static int gpio_stm32_afio_init(const struct device *dev)
 {
@@ -716,6 +717,6 @@ static int gpio_stm32_afio_init(const struct device *dev)
 	return 0;
 }
 
-SYS_DEVICE_DEFINE("gpio_stm32_afio", gpio_stm32_afio_init, NULL, PRE_KERNEL_2, 0);
+SYS_DEVICE_DEFINE("gpio_stm32_afio", gpio_stm32_afio_init, NULL, PRE_KERNEL_1, 0);
 
-#endif /* CONFIG_SOC_SERIES_STM32F1X */
+#endif /* CONFIG_SOC_SERIES_STM32F1X && !CONFIG_GPIO_STM32_SWJ_ENABLE */

--- a/tests/drivers/gpio/gpio_basic_api/boards/nucleo_f103rb.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nucleo_f103rb.overlay
@@ -7,7 +7,7 @@
 / {
 	resources {
 		compatible = "test-gpio-basic-api";
-		out-gpios = <&arduino_header 0 0>; /* Arduino A0 */
-		in-gpios = <&arduino_header 1 0>;  /* Arduino A1 */
+		out-gpios = <&arduino_header 4 0>; /* Arduino A4 */
+		in-gpios = <&arduino_header 5 0>;  /* Arduino A5 */
 	};
 };


### PR DESCRIPTION
```
    tests/drivers: gpio_basic_api: Upudate nucleo_f103rb configuration
    
    For some reason, provided pin configuration for nucleo_f103rb
    is not able to detect gpio callback issues.
    Move to other pin combination which detect pin callback issues.

```
```

    drivers/gpio: stm32f1: AFIO init should happen before GPIO inits
    
    GPIO initialization was moved to PRE_KERNEL_1 with commit
    590162a5cc06c72b70dee93f410b878bc0935f1f.
    This had the consequence of having AFIO init done after GPIO init
    as a consequence, this sequence ends up with AFIO clock disabled,
    and hence negative impact on AFIO expected services.
```

Fixes #38870
