### PR TITLE
kernel/sched: Add "thread_usage" API for thread runtime cycle monitoring

### DIFF
--- a/arch/arc/core/isr_wrapper.S
+++ b/arch/arc/core/isr_wrapper.S
@@ -277,6 +277,10 @@ SECTION_FUNC(TEXT, _isr_demux)
 	PUSHR r59
 #endif
 
+#ifdef CONFIG_SCHED_THREAD_USAGE
+	bl z_sched_usage_stop
+#endif
+
 #ifdef CONFIG_TRACING_ISR
 	bl sys_trace_isr_enter
 #endif

--- a/arch/arm64/core/isr_wrapper.S
+++ b/arch/arm64/core/isr_wrapper.S
@@ -35,6 +35,10 @@ SECTION_FUNC(TEXT, _isr_wrapper)
 	/* ++(_kernel->nested) to be checked by arch_is_in_isr() */
 	inc_nest_counter x0, x1
 
+#ifdef CONFIG_SCHED_THREAD_USAGE
+	bl	z_sched_usage_stop
+#endif
+
 #ifdef CONFIG_TRACING
 	bl	sys_trace_isr_enter
 #endif

--- a/arch/sparc/core/interrupt_trap.S
+++ b/arch/sparc/core/interrupt_trap.S
@@ -145,6 +145,11 @@ __sparc_trap_interrupt:
 	nop
 	nop
 
+#ifdef CONFIG_SCHED_THREAD_USAGE
+	call	z_sched_usage_stop
+	nop
+#endif
+
 #ifdef CONFIG_TRACING_ISR
 	call	sys_trace_isr_enter
 	 nop

--- a/arch/x86/core/intel64/locore.S
+++ b/arch/x86/core/intel64/locore.S
@@ -778,6 +778,11 @@ irq_enter_unnested: /* Not nested: dump state to thread struct for __resume */
 #endif
 
 irq_dispatch:
+#ifdef CONFIG_SCHED_THREAD_USAGE
+	pushq %rcx
+	call z_sched_usage_stop
+	popq %rcx
+#endif
 	movq x86_irq_funcs(,%rcx,8), %rax
 	movq x86_irq_args(,%rcx,8), %rdi
 	call *%rax

--- a/arch/xtensa/core/xtensa-asm2.c
+++ b/arch/xtensa/core/xtensa-asm2.c
@@ -136,6 +136,13 @@ static inline unsigned int get_bits(int offset, int num_bits, unsigned int val)
 	return val & mask;
 }
 
+static ALWAYS_INLINE void usage_stop(void)
+{
+#ifdef CONFIG_SCHED_THREAD_USAGE
+	z_sched_usage_stop();
+#endif
+}
+
 /* The wrapper code lives here instead of in the python script that
  * generates _xtensa_handle_one_int*().  Seems cleaner, still kind of
  * ugly.
@@ -147,6 +154,7 @@ static inline unsigned int get_bits(int offset, int num_bits, unsigned int val)
 __unused void *xtensa_int##l##_c(void *interrupted_stack)	\
 {							   \
 	uint32_t irqs, intenable, m;			   \
+	usage_stop();					   \
 	__asm__ volatile("rsr.interrupt %0" : "=r"(irqs)); \
 	__asm__ volatile("rsr.intenable %0" : "=r"(intenable)); \
 	irqs &= intenable;					\

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -21,10 +21,6 @@
 #include <toolchain.h>
 #include <tracing/tracing_macros.h>
 
-#ifdef CONFIG_THREAD_RUNTIME_STATS_USE_TIMING_FUNCTIONS
-#include <timing/timing.h>
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -5874,8 +5870,6 @@ __syscall int k_float_disable(struct k_thread *thread);
  */
 __syscall int k_float_enable(struct k_thread *thread, unsigned int options);
 
-#ifdef CONFIG_THREAD_RUNTIME_STATS
-
 /**
  * @brief Get the runtime statistics of a thread
  *
@@ -5893,8 +5887,6 @@ int k_thread_runtime_stats_get(k_tid_t thread,
  * @return -EINVAL if null pointers, otherwise 0
  */
 int k_thread_runtime_stats_all_get(k_thread_runtime_stats_t *stats);
-
-#endif
 
 #ifdef __cplusplus
 }

--- a/include/kernel/thread.h
+++ b/include/kernel/thread.h
@@ -169,29 +169,11 @@ struct _thread_userspace_local_data {
 };
 #endif
 
-#ifdef CONFIG_THREAD_RUNTIME_STATS
-struct k_thread_runtime_stats {
-	/* Thread execution cycles */
-#ifdef CONFIG_THREAD_RUNTIME_STATS_USE_TIMING_FUNCTIONS
-	timing_t execution_cycles;
-#else
+typedef struct k_thread_runtime_stats {
+#ifdef CONFIG_SCHED_THREAD_USAGE
 	uint64_t execution_cycles;
 #endif
-};
-
-typedef struct k_thread_runtime_stats k_thread_runtime_stats_t;
-
-struct _thread_runtime_stats {
-	/* Timestamp when last switched in */
-#ifdef CONFIG_THREAD_RUNTIME_STATS_USE_TIMING_FUNCTIONS
-	timing_t last_switched_in;
-#else
-	uint32_t last_switched_in;
-#endif
-
-	k_thread_runtime_stats_t stats;
-};
-#endif
+}  k_thread_runtime_stats_t;
 
 struct z_poller {
 	bool is_polling;
@@ -288,11 +270,6 @@ struct k_thread {
 	/* Pointer to arch-specific TLS area */
 	uintptr_t tls;
 #endif /* CONFIG_THREAD_LOCAL_STORAGE */
-
-#ifdef CONFIG_THREAD_RUNTIME_STATS
-	/** Runtime statistics */
-	struct _thread_runtime_stats rt_stats;
-#endif
 
 #ifdef CONFIG_DEMAND_PAGING_THREAD_STATS
 	/** Paging statistics */

--- a/include/kernel/thread.h
+++ b/include/kernel/thread.h
@@ -116,6 +116,10 @@ struct _thread_base {
 	/* this thread's entry in a timeout queue */
 	struct _timeout timeout;
 #endif
+
+#ifdef CONFIG_SCHED_THREAD_USAGE
+	uint64_t usage;
+#endif
 };
 
 typedef struct _thread_base _thread_base_t;

--- a/include/kernel_structs.h
+++ b/include/kernel_structs.h
@@ -175,6 +175,7 @@ struct z_kernel {
 
 #ifdef CONFIG_SCHED_THREAD_USAGE_ALL
 	uint64_t all_thread_usage;
+	uint64_t idle_thread_usage;
 #endif
 };
 

--- a/include/kernel_structs.h
+++ b/include/kernel_structs.h
@@ -130,6 +130,10 @@ struct _cpu {
 	uint8_t swap_ok;
 #endif
 
+#ifdef CONFIG_SCHED_THREAD_USAGE
+	uint32_t usage0;
+#endif
+
 	/* Per CPU architecture specifics */
 	struct _cpu_arch arch;
 };

--- a/include/kernel_structs.h
+++ b/include/kernel_structs.h
@@ -172,6 +172,10 @@ struct z_kernel {
 #if defined(CONFIG_THREAD_MONITOR)
 	struct k_thread *threads; /* singly linked list of ALL threads */
 #endif
+
+#ifdef CONFIG_SCHED_THREAD_USAGE_ALL
+	uint64_t all_thread_usage;
+#endif
 };
 
 typedef struct z_kernel _kernel_t;

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -379,7 +379,7 @@ config INSTRUMENT_THREAD_SWITCHING
 
 config SCHED_THREAD_USAGE
 	bool "Collect thread runtime usage"
-	depends on USE_SWITCH
+	select INSTRUMENT_THREAD_SWITCHING if !USE_SWITCH
 	help
 	  Alternate implementation of thread runtime cycle usage
 

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -377,26 +377,14 @@ config THREAD_MAX_NAME_LEN
 config INSTRUMENT_THREAD_SWITCHING
 	bool
 
-config SCHED_THREAD_USAGE
-	bool "Collect thread runtime usage"
-	select INSTRUMENT_THREAD_SWITCHING if !USE_SWITCH
-	help
-	  Alternate implementation of thread runtime cycle usage
-
-config SCHED_THREAD_USAGE_ALL
-	bool "Collect total system runtime usage"
-	default y if SCHED_THREAD_USAGE
-	help
-	  Maintain a sum of all non-idle thread cycle usage.
-
 menuconfig THREAD_RUNTIME_STATS
 	bool "Thread runtime statistics"
-	select INSTRUMENT_THREAD_SWITCHING
 	help
 	  Gather thread runtime statistics.
 
 	  For example:
 	    - Thread total execution cycles
+	    - System total execution cycles
 
 if THREAD_RUNTIME_STATS
 
@@ -408,6 +396,20 @@ config THREAD_RUNTIME_STATS_USE_TIMING_FUNCTIONS
 
 	  Note that timing functions may use a different timer than
 	  the default timer for OS timekeeping.
+
+config SCHED_THREAD_USAGE
+	bool "Collect thread runtime usage"
+	default y
+	select INSTRUMENT_THREAD_SWITCHING if !USE_SWITCH
+	help
+	  Collect thread runtime info at context switch time
+
+config SCHED_THREAD_USAGE_ALL
+	bool "Collect total system runtime usage"
+	default y if SCHED_THREAD_USAGE
+	depends on SCHED_THREAD_USAGE
+	help
+	  Maintain a sum of all non-idle thread cycle usage.
 
 endif # THREAD_RUNTIME_STATS
 

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -377,6 +377,12 @@ config THREAD_MAX_NAME_LEN
 config INSTRUMENT_THREAD_SWITCHING
 	bool
 
+config SCHED_THREAD_USAGE
+	bool "Collect thread runtime usage"
+	depends on USE_SWITCH
+	help
+	  Alternate implementation of thread runtime cycle usage
+
 menuconfig THREAD_RUNTIME_STATS
 	bool "Thread runtime statistics"
 	select INSTRUMENT_THREAD_SWITCHING

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -383,6 +383,12 @@ config SCHED_THREAD_USAGE
 	help
 	  Alternate implementation of thread runtime cycle usage
 
+config SCHED_THREAD_USAGE_ALL
+	bool "Collect total system runtime usage"
+	default y if SCHED_THREAD_USAGE
+	help
+	  Maintain a sum of all non-idle thread cycle usage.
+
 menuconfig THREAD_RUNTIME_STATS
 	bool "Thread runtime statistics"
 	select INSTRUMENT_THREAD_SWITCHING

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -363,4 +363,35 @@ static inline bool z_sched_wake_all(_wait_q_t *wait_q, int swap_retval,
 int z_sched_wait(struct k_spinlock *lock, k_spinlock_key_t key,
 		 _wait_q_t *wait_q, k_timeout_t timeout, void **data);
 
+
+/** @brief Halt thread cycle usage accounting.
+ *
+ * Halts the accumulation of thread cycle usage and adds the current
+ * total to the thread's counter.  Called on context switch.
+ *
+ * Note that this function is idempotent.  The core kernel code calls
+ * it at the end of interrupt handlers (because that is where we have
+ * a portable hook) where we are context switching, which will include
+ * any cycles spent in the ISR in the per-thread accounting.  But
+ * architecture code can also call it earlier out of interrupt entry
+ * to improve measurement fidelity.
+ *
+ * This function assumes local interrupts are masked (so that the
+ * current CPU pointer and current thread are safe to modify), but
+ * requires no other synchronizaton.  Architecture layers don't need
+ * to do anything more.
+ */
+void z_sched_usage_stop(void);
+
+void z_sched_usage_start(struct k_thread *thread);
+
+static inline void z_sched_usage_switch(struct k_thread *thread)
+{
+	ARG_UNUSED(thread);
+#ifdef CONFIG_SCHED_THREAD_USAGE
+	z_sched_usage_stop();
+	z_sched_usage_start(thread);
+#endif
+}
+
 #endif /* ZEPHYR_KERNEL_INCLUDE_KSCHED_H_ */

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -385,6 +385,8 @@ void z_sched_usage_stop(void);
 
 void z_sched_usage_start(struct k_thread *thread);
 
+uint64_t z_sched_thread_usage(struct k_thread *thread);
+
 static inline void z_sched_usage_switch(struct k_thread *thread)
 {
 	ARG_UNUSED(thread);

--- a/kernel/include/kswap.h
+++ b/kernel/include/kswap.h
@@ -109,6 +109,7 @@ static ALWAYS_INLINE unsigned int do_swap(unsigned int key,
 #ifdef CONFIG_TIMESLICING
 		z_reset_time_slice();
 #endif
+		z_sched_usage_switch(new_thread);
 
 #ifdef CONFIG_SMP
 		_current_cpu->swap_ok = 0;

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1778,7 +1778,9 @@ void z_sched_usage_stop(void)
 		uint32_t dt = usage_now() - u0;
 
 #ifdef CONFIG_SCHED_THREAD_USAGE_ALL
-		if (!z_is_idle_thread_object(_current)) {
+		if (z_is_idle_thread_object(_current)) {
+			_kernel.idle_thread_usage += dt;
+		} else {
 			_kernel.all_thread_usage += dt;
 		}
 #endif
@@ -1799,7 +1801,9 @@ uint64_t z_sched_thread_usage(struct k_thread *thread)
 		uint32_t dt = now - u0;
 
 #ifdef CONFIG_SCHED_THREAD_USAGE_ALL
-		if (!z_is_idle_thread_object(thread)) {
+		if (z_is_idle_thread_object(thread)) {
+			_kernel.idle_thread_usage += dt;
+		} else {
 			_kernel.all_thread_usage += dt;
 		}
 #endif

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1767,7 +1767,14 @@ void z_sched_usage_stop(void)
 	uint32_t u0 = _current_cpu->usage0;
 
 	if (u0 != 0) {
-		_current->base.usage += usage_now() - u0;
+		uint32_t dt = usage_now() - u0;
+
+#ifdef CONFIG_SCHED_THREAD_USAGE_ALL
+		if (!z_is_idle_thread_object(_current)) {
+			_kernel.all_thread_usage += dt;
+		}
+#endif
+		_current->base.usage += dt;
 	}
 
 	_current_cpu->usage0 = 0;
@@ -1781,7 +1788,15 @@ uint64_t z_sched_thread_usage(struct k_thread *thread)
 	uint64_t ret = thread->base.usage;
 
 	if (u0 != 0) {
-		ret += now - u0;
+		uint32_t dt = now - u0;
+
+#ifdef CONFIG_SCHED_THREAD_USAGE_ALL
+		if (!z_is_idle_thread_object(thread)) {
+			_kernel.all_thread_usage += dt;
+		}
+#endif
+
+		ret += dt;
 		thread->base.usage = ret;
 		_current_cpu->usage0 = now;
 	}

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -17,6 +17,8 @@
 #include <logging/log.h>
 #include <sys/atomic.h>
 #include <sys/math_extras.h>
+#include <timing/timing.h>
+
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 #if defined(CONFIG_SCHED_DUMB)
@@ -1746,7 +1748,13 @@ static struct k_spinlock usage_lock;
 
 static uint32_t usage_now(void)
 {
-	uint32_t now = k_cycle_get_32();
+	uint32_t now;
+
+#ifdef CONFIG_THREAD_RUNTIME_STATS_USE_TIMING_FUNCTIONS
+	now = (uint32_t)timing_counter_get();
+#else
+	now = k_cycle_get_32();
+#endif
 
 	/* Edge case: we use a zero as a null ("stop() already called") */
 	return (now == 0) ? 1 : now;

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1737,6 +1737,11 @@ int z_sched_wait(struct k_spinlock *lock, k_spinlock_key_t key,
 
 #ifdef CONFIG_SCHED_THREAD_USAGE
 
+/* Need one of these for this to work */
+#if !defined(CONFIG_USE_SWITCH) && !defined(CONFIG_INSTRUMENT_THREAD_SWITCHING)
+#error "No data backend configured for CONFIG_SCHED_THREAD_USAGE"
+#endif
+
 static struct k_spinlock usage_lock;
 
 static uint32_t usage_now(void)

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -31,10 +31,6 @@
 #include <logging/log.h>
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
-#ifdef CONFIG_THREAD_RUNTIME_STATS
-k_thread_runtime_stats_t threads_runtime_stats;
-#endif
-
 #ifdef CONFIG_THREAD_MONITOR
 /* This lock protects the linked list of active threads; i.e. the
  * initial _kernel.threads pointer and the linked list made up of
@@ -607,10 +603,6 @@ char *z_setup_new_thread(struct k_thread *new_thread,
 
 	SYS_PORT_TRACING_OBJ_FUNC(k_thread, create, new_thread);
 
-#ifdef CONFIG_THREAD_RUNTIME_STATS
-	memset(&new_thread->rt_stats, 0, sizeof(new_thread->rt_stats));
-#endif
-
 	return stack_ptr;
 }
 
@@ -1013,18 +1005,6 @@ void z_thread_mark_switched_in(void)
 #ifdef CONFIG_TRACING
 	SYS_PORT_TRACING_FUNC(k_thread, switched_in);
 #endif
-
-#ifdef CONFIG_THREAD_RUNTIME_STATS
-	struct k_thread *thread;
-
-	thread = k_current_get();
-#ifdef CONFIG_THREAD_RUNTIME_STATS_USE_TIMING_FUNCTIONS
-	thread->rt_stats.last_switched_in = timing_counter_get();
-#else
-	thread->rt_stats.last_switched_in = k_cycle_get_32();
-#endif /* CONFIG_THREAD_RUNTIME_STATS_USE_TIMING_FUNCTIONS */
-
-#endif /* CONFIG_THREAD_RUNTIME_STATS */
 }
 
 void z_thread_mark_switched_out(void)
@@ -1033,48 +1013,12 @@ void z_thread_mark_switched_out(void)
 	z_sched_usage_stop();
 #endif
 
-#ifdef CONFIG_THREAD_RUNTIME_STATS
-#ifdef CONFIG_THREAD_RUNTIME_STATS_USE_TIMING_FUNCTIONS
-	timing_t now;
-#else
-	uint32_t now;
-#endif /* CONFIG_THREAD_RUNTIME_STATS_USE_TIMING_FUNCTIONS */
-
-	uint64_t diff;
-	struct k_thread *thread;
-
-	thread = k_current_get();
-
-	if (unlikely(thread->rt_stats.last_switched_in == 0)) {
-		/* Has not run before */
-		return;
-	}
-
-	if (unlikely(thread->base.thread_state == _THREAD_DUMMY)) {
-		/* dummy thread has no stat struct */
-		return;
-	}
-
-#ifdef CONFIG_THREAD_RUNTIME_STATS_USE_TIMING_FUNCTIONS
-	now = timing_counter_get();
-	diff = timing_cycles_get(&thread->rt_stats.last_switched_in, &now);
-#else
-	now = k_cycle_get_32();
-	diff = (uint64_t)(now - thread->rt_stats.last_switched_in);
-	thread->rt_stats.last_switched_in = 0;
-#endif /* CONFIG_THREAD_RUNTIME_STATS_USE_TIMING_FUNCTIONS */
-
-	thread->rt_stats.stats.execution_cycles += diff;
-
-	threads_runtime_stats.execution_cycles += diff;
-#endif /* CONFIG_THREAD_RUNTIME_STATS */
-
 #ifdef CONFIG_TRACING
 	SYS_PORT_TRACING_FUNC(k_thread, switched_out);
 #endif
 }
+#endif /* CONFIG_INSTRUMENT_THREAD_SWITCHING */
 
-#ifdef CONFIG_THREAD_RUNTIME_STATS
 int k_thread_runtime_stats_get(k_tid_t thread,
 			       k_thread_runtime_stats_t *stats)
 {
@@ -1082,8 +1026,11 @@ int k_thread_runtime_stats_get(k_tid_t thread,
 		return -EINVAL;
 	}
 
-	(void)memcpy(stats, &thread->rt_stats.stats,
-		     sizeof(thread->rt_stats.stats));
+	*stats = (k_thread_runtime_stats_t) {};
+
+#ifdef CONFIG_SCHED_THREAD_USAGE
+	stats->execution_cycles = z_sched_thread_usage(thread);
+#endif
 
 	return 0;
 }
@@ -1094,11 +1041,11 @@ int k_thread_runtime_stats_all_get(k_thread_runtime_stats_t *stats)
 		return -EINVAL;
 	}
 
-	(void)memcpy(stats, &threads_runtime_stats,
-		     sizeof(threads_runtime_stats));
+	*stats = (k_thread_runtime_stats_t) {};
+
+#ifdef CONFIG_SCHED_THREAD_USAGE_ALL
+	stats->execution_cycles = _kernel.all_thread_usage;
+#endif
 
 	return 0;
 }
-#endif /* CONFIG_THREAD_RUNTIME_STATS */
-
-#endif /* CONFIG_INSTRUMENT_THREAD_SWITCHING */

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -1006,6 +1006,10 @@ static inline k_ticks_t z_vrfy_k_thread_timeout_expires_ticks(
 #ifdef CONFIG_INSTRUMENT_THREAD_SWITCHING
 void z_thread_mark_switched_in(void)
 {
+#if defined(CONFIG_SCHED_THREAD_USAGE) && !defined(CONFIG_USE_SWITCH)
+	z_sched_usage_start(_current);
+#endif
+
 #ifdef CONFIG_TRACING
 	SYS_PORT_TRACING_FUNC(k_thread, switched_in);
 #endif
@@ -1025,6 +1029,10 @@ void z_thread_mark_switched_in(void)
 
 void z_thread_mark_switched_out(void)
 {
+#if defined(CONFIG_SCHED_THREAD_USAGE) && !defined(CONFIG_USE_SWITCH)
+	z_sched_usage_stop();
+#endif
+
 #ifdef CONFIG_THREAD_RUNTIME_STATS
 #ifdef CONFIG_THREAD_RUNTIME_STATS_USE_TIMING_FUNCTIONS
 	timing_t now;

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -1044,7 +1044,8 @@ int k_thread_runtime_stats_all_get(k_thread_runtime_stats_t *stats)
 	*stats = (k_thread_runtime_stats_t) {};
 
 #ifdef CONFIG_SCHED_THREAD_USAGE_ALL
-	stats->execution_cycles = _kernel.all_thread_usage;
+	stats->execution_cycles = (_kernel.all_thread_usage
+				   + _kernel.idle_thread_usage);
 #endif
 
 	return 0;

--- a/tests/kernel/threads/thread_apis/src/main.c
+++ b/tests/kernel/threads/thread_apis/src/main.c
@@ -18,6 +18,7 @@
 #include <kernel.h>
 #include <kernel_internal.h>
 #include <string.h>
+#include <ksched.h>
 
 extern void test_threads_spawn_params(void);
 extern void test_threads_spawn_priority(void);
@@ -531,6 +532,10 @@ static void foreach_callback(const struct k_thread *thread, void *user_data)
 	k_thread_runtime_stats_t stats;
 	int ret;
 
+	if (z_is_idle_thread_object((k_tid_t)thread)) {
+		return;
+	}
+
 	/* Check NULL parameters */
 	ret = k_thread_runtime_stats_get(NULL, &stats);
 	zassert_true(ret == -EINVAL, NULL);
@@ -541,10 +546,10 @@ static void foreach_callback(const struct k_thread *thread, void *user_data)
 	((k_thread_runtime_stats_t *)user_data)->execution_cycles +=
 		stats.execution_cycles;
 }
-/* This case accumulates every threath's execution_cycles first, then get
- * the total execution_cycles from a global k_thread_runtime_stats_t, the
- * two values should be equal. So this case must run before any thread
- * destroyed
+/* This case accumulates every threath's execution_cycles first, then
+ * get the total execution_cycles from a global
+ * k_thread_runtime_stats_t to see that all time is reflected in the
+ * total.
  */
 void test_thread_runtime_stats_get(void)
 {
@@ -559,27 +564,34 @@ void test_thread_runtime_stats_get(void)
 	zassert_true(ret == -EINVAL, NULL);
 
 	k_thread_runtime_stats_all_get(&stats_all);
-	zassert_equal(stats.execution_cycles, stats_all.execution_cycles, NULL);
+	zassert_true(stats.execution_cycles <= stats_all.execution_cycles, NULL);
 }
 
 void test_k_busy_wait(void)
 {
-	uint64_t cycles;
+	uint64_t cycles, dt;
 	k_thread_runtime_stats_t test_stats;
 
 	k_thread_runtime_stats_get(k_current_get(), &test_stats);
 	cycles = test_stats.execution_cycles;
 	k_busy_wait(0);
 	k_thread_runtime_stats_get(k_current_get(), &test_stats);
-	/* execution_cycles doesn't increase after 0 usec */
-	zassert_equal(test_stats.execution_cycles, cycles, NULL);
-	cycles = test_stats.execution_cycles;
 
+	/* execution_cycles doesn't increase significantly after 0
+	 * usec (10ms slop experimentally determined,
+	 * non-deterministic software emulators are VERY slow wrt
+	 * their cycle rate)
+	 */
+	dt = test_stats.execution_cycles - cycles;
+	zassert_true(dt < k_ms_to_cyc_ceil64(10), NULL);
+
+	cycles = test_stats.execution_cycles;
 	k_busy_wait(100);
 	k_thread_runtime_stats_get(k_current_get(), &test_stats);
-	/* in busy wait, this thread never been scheduled */
-	zassert_equal(test_stats.execution_cycles, cycles, NULL);
-	cycles = test_stats.execution_cycles;
+
+	/* execution_cycles increases correctly */
+	dt = test_stats.execution_cycles - cycles;
+	zassert_true(dt >= k_cyc_to_us_floor64(100), NULL);
 }
 
 static void tp_entry(void *p1, void *p2, void *p3)


### PR DESCRIPTION
This is an alternate backend that does what THREAD_RUNTIME_STATS is doing currently, but with a few advantages:

* Correctly synchronized: you can't race against a running thread (potentially on another CPU!) while querying its usage.

* Realtime results: you get the right answer always, up to timer precision, even if a thread has been running for a while uninterrupted and hasn't updated its total.

* Portable, no need for per-architecture code at all for the simple case. (It leverages the USE_SWITCH layer to do this, so won't work on older architectures)

* Faster/smaller: minimizes use of 64 bit math; lower overhead in thread struct (keeps the scratch "started" time in the CPU struct instead).  One 64 bit counter per thread and a 32 bit scratch register in the CPU struct.

* Standalone.  It's a core (but optional) scheduler feature, no dependence on para-kernel configuration like the tracing infrastructure.

* More precise: allows architectures to optionally call a trivial zero-argument/no-result cdecl function out of interrupt entry to avoid accounting for ISR runtime in thread totals.  No configuration needed here, if it's called then you get proper ISR accounting, and if not you don't.

For right now, pending unification, it's added side-by-side with the older API and left as a z_*() internal symbol. 