### PR TITLE
drivers: i2c: sam0 Fix i2c NACK on receive

### DIFF
--- a/drivers/i2c/i2c_sam0.c
+++ b/drivers/i2c/i2c_sam0.c
@@ -162,7 +162,7 @@ static void i2c_sam0_isr(const struct device *dev)
 		data->msg.buffer++;
 		data->msg.size--;
 	} else if (status & SERCOM_I2CM_INTFLAG_SB) {
-		if (!continue_next) {
+		if (!continue_next && (data->msg.size == 1)) {
 			/*
 			 * If this is the last byte, then prepare for an auto
 			 * NACK before doing the actual read.  This does not
@@ -175,7 +175,7 @@ static void i2c_sam0_isr(const struct device *dev)
 		data->msg.buffer++;
 		data->msg.size--;
 
-		if (!continue_next) {
+		if (!continue_next && !data->msg.size) {
 			i2c->INTENCLR.reg = SERCOM_I2CM_INTENCLR_MASK;
 			k_sem_give(&data->sem);
 			return;


### PR DESCRIPTION
PR #38482 made the sam0 i2c send NACK when receiving a single message

Fixes #38878
Fixes #41016

Signed-off-by: Christoffer Zakrisson <rustypig91@gmail.com>