### PR TITLE
twister: ignore ROM region overflows

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -1986,7 +1986,7 @@ class CMake():
                     log.write(log_msg)
 
             if log_msg:
-                res = re.findall("region `(FLASH|RAM|ICCM|DCCM|SRAM)' overflowed by", log_msg)
+                res = re.findall("region `(FLASH|ROM|RAM|ICCM|DCCM|SRAM)' overflowed by", log_msg)
                 if res and not self.overflow_as_errors:
                     logger.debug("Test skipped due to {} Overflow".format(res[0]))
                     self.instance.status = "skipped"


### PR DESCRIPTION
Add ROM region to list of regions to optionally ignore overflows on.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>