### PR TITLE
net_buf_slist_{put|get}: make SMP safe

### DIFF
--- a/include/net/buf.h
+++ b/include/net/buf.h
@@ -1376,8 +1376,7 @@ void net_buf_slist_put(sys_slist_t *list, struct net_buf *buf);
  * @brief Get a buffer from a list.
  *
  * If the buffer had any fragments, these will automatically be recovered from
- * the list as well and be placed to the buffer's fragment list. This function
- * is NOT thread-safe when recovering fragments.
+ * the list as well and be placed to the buffer's fragment list.
  *
  * @param list Which list to take the buffer from.
  *


### PR DESCRIPTION
Replace irq_lock() with a spin lock, and rework the `get` version
to be entirely SMP safe.
