### PR TITLE
Fix native_posix build on Debian

### DIFF
--- a/cmake/linker/ld/target_baremetal.cmake
+++ b/cmake/linker/ld/target_baremetal.cmake
@@ -8,7 +8,6 @@ macro(toolchain_ld_baremetal)
   zephyr_ld_options(
     -nostdlib
     -static
-    -no-pie
     ${LINKERFLAGPREFIX},-X
     ${LINKERFLAGPREFIX},-N
   )

--- a/cmake/linker/ld/target_base.cmake
+++ b/cmake/linker/ld/target_base.cmake
@@ -11,6 +11,7 @@ macro(toolchain_ld_base)
   # TOOLCHAIN_LD_FLAGS comes from compiler/gcc/target.cmake
   # LINKERFLAGPREFIX comes from linker/ld/target.cmake
   zephyr_ld_options(
+    -no-pie
     ${TOOLCHAIN_LD_FLAGS}
   )
 


### PR DESCRIPTION
Debian (by default) enables PIE/PIC and the flag to override it doesn't
use the 'f' prefix. This is fixed by also adding -no-pie and -no-pic
to the zephyr_cc_options.

Issue #35244

Signed-off-by: Yuval Peress <peress@google.com>