### PR TITLE
west.yml: update modules/hal/stm32/hal_stm32 for stm32h7

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -114,7 +114,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 5c8275071ec1cf160bfe8c18bbd9330a7d714dc8
+      revision: pull/117/head
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Update the stm32h7xx/drivers/include/stm32h7xx_ll_adc.h
to include the ADC3 of version ADC_VER_V5_V90
in the LL_ADC_ConfigOverSamplingRatioShift function.

completes the https://github.com/zephyrproject-rtos/zephyr/pull/38627
required to fix #38606

Signed-off-by: Francois Ramu <francois.ramu@st.com>