### PR TITLE
drivers: stm32 spi supports TI or Motorola standard protocols

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -559,7 +559,11 @@ static int spi_stm32_configure(const struct device *dev,
 
 #if !defined(CONFIG_SOC_SERIES_STM32F1X) \
 	&& (!defined(CONFIG_SOC_SERIES_STM32L1X) || defined(SPI_CR2_FRF))
-	LL_SPI_SetStandard(spi, LL_SPI_PROTOCOL_MOTOROLA);
+	if (cfg->ti_mode) {
+		LL_SPI_SetStandard(spi, LL_SPI_PROTOCOL_TI);
+	} else {
+		LL_SPI_SetStandard(spi, LL_SPI_PROTOCOL_MOTOROLA);
+	}
 #endif
 
 	/* At this point, it's mandatory to set this on the context! */
@@ -922,6 +926,14 @@ static void spi_stm32_irq_config_func_##id(const struct device *dev)		\
 #define SPI_DMA_STATUS_SEM(id)
 #endif
 
+#if !defined(CONFIG_SOC_SERIES_STM32F1X) \
+	&& (!defined(CONFIG_SOC_SERIES_STM32L1X) || defined(SPI_CR2_FRF))
+#define STM32_SPI_TI_MODE_CONFIG(id)				\
+	.ti_mode = DT_INST_PROP(id, frame_format),
+#else
+#define STM32_SPI_TI_MODE_CONFIG(id)
+#endif
+
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_subghz)
 #define STM32_SPI_USE_SUBGHZSPI_NSS_CONFIG(id)				\
 	.use_subghzspi_nss = DT_INST_PROP_OR(				\
@@ -946,6 +958,7 @@ static const struct spi_stm32_config spi_stm32_cfg_##id = {		\
 	.pinctrl_list_size = ARRAY_SIZE(spi_pins_##id),			\
 	STM32_SPI_IRQ_HANDLER_FUNC(id)					\
 	STM32_SPI_USE_SUBGHZSPI_NSS_CONFIG(id)				\
+	STM32_SPI_TI_MODE_CONFIG(id)					\
 };									\
 									\
 static struct spi_stm32_data spi_stm32_dev_data_##id = {		\

--- a/drivers/spi/spi_ll_stm32.h
+++ b/drivers/spi/spi_ll_stm32.h
@@ -19,6 +19,16 @@ struct spi_stm32_config {
 #ifdef CONFIG_SPI_STM32_INTERRUPT
 	irq_config_func_t irq_config;
 #endif
+
+#if !defined(CONFIG_SOC_SERIES_STM32F1X) \
+	&& (!defined(CONFIG_SOC_SERIES_STM32L1X) || defined(SPI_CR2_FRF))
+	/*
+	 * if supported by the instance, this bit will configure the frame-format
+	 * of the SPI to be compliant with the TI protocol.
+	 */
+	bool ti_mode;
+#endif
+
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_subghz)
 	bool use_subghzspi_nss;
 #endif

--- a/dts/bindings/spi/st,stm32-spi-common.yaml
+++ b/dts/bindings/spi/st,stm32-spi-common.yaml
@@ -12,6 +12,16 @@ properties:
     interrupts:
       required: true
 
+    frame-format:
+      type: boolean
+      required: false
+      description: |
+        Use Frame Format to support TI or motorola SPI mode when the SPI
+        interface is compatible with the TI protocol. The FRF bit of the
+        SPIx_CR2 configures the SPI to be compliant with this protocol.
+        false: SPI Motorola mode (default)
+        true: SPI TI mode
+
     pinctrl-0:
       type: phandles
       required: false


### PR DESCRIPTION
This changes introduces a new property to the DTS of the stm32 spi to configure the Frame Format. 
Some STM32 devices, have a SPI interface which is compatible with the TI protocol. The FRF bit of the SPIx_CR2 register can be used to configure the SPI to be compliant with this protocol.
By default the frame format is motorola Mode.

To configure the TI mode, the dts should include the property as follows:
```
&spi1 {
	frame-format;
};

```

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/38683

Signed-off-by: Francois Ramu <francois.ramu@st.com>