### PR TITLE
Upmerge openthread

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -61,7 +61,12 @@ static struct nrf5_802154_data nrf5_data;
 
 #define DRX_SLOT_PH 0 /* Placeholder delayed reception window ID */
 #define DRX_SLOT_RX 1 /* Actual delayed reception window ID */
-#define PH_DURATION 10 /* Duration of the placeholder window, in microseconds  */
+#define PH_DURATION 10 /* Duration of the placeholder window, in microseconds */
+/* When scheduling the actual delayed reception window an adjustment of
+ * 800 us is required to match the CSL tranmission timing for unknown
+ * reasons. This is a temporary workaround until the root cause is found.
+ */
+#define DRX_ADJUST 800
 
 #if defined(CONFIG_IEEE802154_NRF5_UICR_EUI64_ENABLE)
 #if defined(CONFIG_SOC_NRF5340_CPUAPP)
@@ -755,7 +760,7 @@ static void nrf5_config_csl_period(uint16_t period)
 
 static void nrf5_schedule_rx(uint8_t channel, uint32_t start, uint32_t duration)
 {
-	nrf5_receive_at(start, duration, channel, DRX_SLOT_RX);
+	nrf5_receive_at(start - DRX_ADJUST, duration, channel, DRX_SLOT_RX);
 
 	/* The placeholder reception window is rescheduled for the next period */
 	nrf_802154_receive_at_cancel(DRX_SLOT_PH);
@@ -888,8 +893,7 @@ static int nrf5_configure(const struct device *dev,
 
 /* nRF5 radio driver callbacks */
 
-void nrf_802154_received_timestamp_raw(uint8_t *data, int8_t power, uint8_t lqi,
-				       uint32_t time)
+void nrf_802154_received_timestamp_raw(uint8_t *data, int8_t power, uint8_t lqi, uint32_t time)
 {
 	for (uint32_t i = 0; i < ARRAY_SIZE(nrf5_data.rx_frames); i++) {
 		if (nrf5_data.rx_frames[i].psdu != NULL) {
@@ -897,13 +901,15 @@ void nrf_802154_received_timestamp_raw(uint8_t *data, int8_t power, uint8_t lqi,
 		}
 
 		nrf5_data.rx_frames[i].psdu = data;
-		nrf5_data.rx_frames[i].time = time;
 		nrf5_data.rx_frames[i].rssi = power;
 		nrf5_data.rx_frames[i].lqi = lqi;
 
+#if !defined(CONFIG_NRF_802154_SER_HOST) && defined(CONFIG_NET_PKT_TIMESTAMP)
+		nrf5_data.rx_frames[i].time = nrf_802154_first_symbol_timestamp_get(time, data[0]);
+#endif
+
 		if (data[ACK_REQUEST_BYTE] & ACK_REQUEST_BIT) {
-			nrf5_data.rx_frames[i].ack_fpb =
-						nrf5_data.last_frame_ack_fpb;
+			nrf5_data.rx_frames[i].ack_fpb = nrf5_data.last_frame_ack_fpb;
 		} else {
 			nrf5_data.rx_frames[i].ack_fpb = false;
 		}

--- a/lib/libc/minimal/include/ctype.h
+++ b/lib/libc/minimal/include/ctype.h
@@ -69,6 +69,11 @@ static inline int isalnum(int chr)
 	return (int)(isalpha(chr) || isdigit(chr));
 }
 
+static inline int iscntrl(int c)
+{
+	return (int)((((unsigned int)c) <= 31U) || (((unsigned int)c) == 127U));
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/net/lib/openthread/platform/radio.c
+++ b/subsys/net/lib/openthread/platform/radio.c
@@ -1005,13 +1005,13 @@ uint64_t otPlatRadioGetNow(otInstance *aInstance)
 #endif
 
 #if defined(CONFIG_IEEE802154_2015)
-void otPlatRadioSetMacKey(otInstance *aInstance, uint8_t aKeyIdMode,
-			  uint8_t aKeyId, const otMacKey *aPrevKey,
-			  const otMacKey *aCurrKey, const otMacKey *aNextKey)
+void otPlatRadioSetMacKey(otInstance *aInstance, uint8_t aKeyIdMode, uint8_t aKeyId,
+			  const otMacKeyMaterial *aPrevKey, const otMacKeyMaterial *aCurrKey,
+			  const otMacKeyMaterial *aNextKey, otRadioKeyType aKeyType)
 {
 	ARG_UNUSED(aInstance);
-	__ASSERT_NO_MSG(aPrevKey != NULL && aCurrKey != NULL &&
-			aNextKey != NULL);
+	__ASSERT_NO_MSG(aKeyType == OT_KEY_TYPE_LITERAL_KEY);
+	__ASSERT_NO_MSG(aPrevKey != NULL && aCurrKey != NULL && aNextKey != NULL);
 
 	uint8_t key_id_mode = aKeyIdMode >> 3;
 
@@ -1019,19 +1019,19 @@ void otPlatRadioSetMacKey(otInstance *aInstance, uint8_t aKeyIdMode,
 		{
 			.key_id_mode = key_id_mode,
 			.key_index = aKeyId == 1 ? 0x80 : aKeyId - 1,
-			.key_value = (uint8_t *)aPrevKey->m8,
+			.key_value = (uint8_t *)aPrevKey->mKeyMaterial.mKey.m8,
 			.frame_counter_per_key = false,
 		},
 		{
 			.key_id_mode = key_id_mode,
 			.key_index = aKeyId,
-			.key_value = (uint8_t *)aCurrKey->m8,
+			.key_value = (uint8_t *)aCurrKey->mKeyMaterial.mKey.m8,
 			.frame_counter_per_key = false,
 		},
 		{
 			.key_id_mode = key_id_mode,
 			.key_index = aKeyId == 0x80 ? 1 : aKeyId + 1,
-			.key_value = (uint8_t *)aNextKey->m8,
+			.key_value = (uint8_t *)aNextKey->mKeyMaterial.mKey.m8,
 			.frame_counter_per_key = false,
 		},
 		{

--- a/west.yml
+++ b/west.yml
@@ -183,7 +183,7 @@ manifest:
       revision: 6010f0523cbc75f551d9256cf782f173177acdef
       path: modules/lib/open-amp
     - name: openthread
-      revision: 5d706547ebcb0a85e11412bcd88e80e2af98c74d
+      revision: fd1ab161f7d5cfd5d0120cd5d1797811e78ff918
       path: modules/lib/openthread
     - name: segger
       revision: 3a52ab222133193802d3c3b4d21730b9b1f1d2f6


### PR DESCRIPTION
Update OpenThread to the latest changes.

OpenThread is now compatible with mbedtls 2 and 3.

This PR uses commits from and deprecates https://github.com/zephyrproject-rtos/zephyr/pull/38497