### PR TITLE
Bluetooth: controller: Fix ASSERT caused by ULL releasing chain PDUs

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -1542,3 +1542,15 @@ static inline bool isr_rx_ci_adva_check(uint8_t tx_addr, uint8_t *addr,
 	return (tx_addr == ci->rx_addr) &&
 		!memcmp(addr, ci->connect_ind.adv_addr, BDADDR_SIZE);
 }
+
+#if defined(CONFIG_ZTEST)
+uint32_t lll_adv_free_pdu_fifo_count_get(void)
+{
+	return MFIFO_AVAIL_COUNT_GET(pdu_free);
+}
+
+uint32_t lll_adv_pdu_mem_free_count_get(void)
+{
+	return mem_free_count_get(mem_pdu.free);
+}
+#endif /* CONFIG_ZTEST */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_internal.h
@@ -78,3 +78,8 @@ bool lll_adv_connect_ind_check(struct lll_adv *lll, struct pdu_adv *ci,
 			       uint8_t tx_addr, uint8_t *addr,
 			       uint8_t rx_addr, uint8_t *tgt_addr,
 			       uint8_t devmatch_ok, uint8_t *rl_idx);
+
+#if defined(CONFIG_ZTEST)
+uint32_t lll_adv_free_pdu_fifo_count_get(void);
+uint32_t lll_adv_pdu_mem_free_count_get(void);
+#endif /* CONFIG_ZTEST */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_pdu.h
@@ -178,6 +178,11 @@ static inline void *lll_adv_sync_extra_data_peek(struct lll_adv_sync *lll)
 {
 	return lll->data.extra_data[lll->data.last];
 }
+
+static inline void *lll_adv_sync_extra_data_curr_get(struct lll_adv_sync *lll)
+{
+	return lll->data.extra_data[lll->data.first];
+}
 #endif /* CONFIG_BT_CTLR_ADV_EXT_PDU_EXTRA_DATA_MEMORY */
 #endif /* CONFIG_BT_CTLR_ADV_PERIODIC */
 #endif /* CONFIG_BT_CTLR_ADV_EXT */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df.c
@@ -92,7 +92,7 @@ void lll_df_cte_tx_enable(struct lll_adv_sync *lll_sync, const struct pdu_adv *p
 		if (ext_hdr->cte_info) {
 			const struct lll_df_adv_cfg *df_cfg;
 
-			df_cfg = lll_adv_sync_extra_data_peek(lll_sync);
+			df_cfg = lll_adv_sync_extra_data_curr_get(lll_sync);
 			LL_ASSERT(df_cfg);
 
 			df_cte_tx_configure(df_cfg);

--- a/subsys/bluetooth/controller/ll_sw/ull_df.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_df.c
@@ -835,14 +835,18 @@ static uint8_t rem_cte_info_from_per_adv_chain(struct lll_adv_sync *lll_sync,
 	while (pdu_chained) {
 		if (pdu_ext_adv_is_empty_without_cte(pdu_chained)) {
 			/* If there is an empty PDU then all remaining PDUs shoudl be released. */
-			lll_adv_pdu_linked_release_all(pdu_chained);
+			if (!new_chain) {
+				lll_adv_pdu_linked_release_all(pdu_chained);
+
+				/* Set new end of chain in PDUs linked list. If pdu differs from
+				 * prev_pdu then it is already end of a chain. If it doesn't differ,
+				 * then chain end is changed in right place by use of pdu_prev.
+				 * That makes sure there is no PDU released twice (here and when LLL
+				 * swaps PDU buffers).
+				 */
+				lll_adv_pdu_linked_append(NULL, *pdu_prev);
+			}
 			pdu_chained = NULL;
-			/* Set new end of chain in PDUs linked list. If pdu differs from prev_pdu
-			 * then it is alread end of a chain. If it doesn't differ, then chain end
-			 * is changed in rigth place by use of pdu_prev. That makes sure there
-			 * is no PDU released twice (here and when LLL swaps PDU buffers).
-			 */
-			lll_adv_pdu_linked_append(NULL, *pdu_prev);
 		} else {
 			/* Update one before pdu_chained */
 			err = ull_adv_sync_pdu_set_clear(lll_sync, *pdu_prev, *pdu, 0,

--- a/tests/bluetooth/df/connectionless_cte_chains/src/common.c
+++ b/tests/bluetooth/df/connectionless_cte_chains/src/common.c
@@ -108,6 +108,8 @@ void common_release_adv_set(struct ll_adv_set *adv_set)
 		if (sync) {
 			sync->is_started = 0U;
 		}
+
+		lll_adv_data_reset(&sync->lll.data);
 	}
 	adv_set->lll.sync = NULL;
 	if (adv_set->df_cfg->is_enabled) {
@@ -196,8 +198,14 @@ void common_release_per_adv_chain(struct ll_adv_set *adv_set)
 
 	lll_sync = adv_set->lll.sync;
 	pdu = lll_adv_sync_data_peek(lll_sync, NULL);
+	if (pdu != NULL) {
+		lll_adv_pdu_linked_release_all(pdu);
+	}
 
-	lll_adv_pdu_linked_release_all(pdu);
+	pdu = (void *)lll_sync->data.pdu[lll_sync->data.first];
+	if (pdu != NULL) {
+		lll_adv_pdu_linked_release_all(pdu);
+	}
 }
 
 /*
@@ -443,6 +451,17 @@ void common_validate_chain_with_cte(struct ll_adv_set *adv, uint8_t cte_count,
 	}
 }
 
+/*
+ * @brief Helper function to cleanup after test case end.
+ *
+ * @param adv               Pointer to advertising set
+ */
+void common_teardown(struct ll_adv_set *adv)
+{
+	common_release_per_adv_chain(adv);
+	common_release_adv_set(adv);
+	lll_adv_init();
+}
 /*
  * @brief Helper function to add payload data to extended advertising PDU.
  *

--- a/tests/bluetooth/df/connectionless_cte_chains/src/common.h
+++ b/tests/bluetooth/df/connectionless_cte_chains/src/common.h
@@ -19,3 +19,4 @@ void common_prepare_df_cfg(struct ll_adv_set *adv, uint8_t cte_count);
 void common_validate_per_adv_chain(struct ll_adv_set *adv, uint8_t pdu_count);
 void common_validate_chain_with_cte(struct ll_adv_set *adv, uint8_t cte_count,
 				    uint8_t ad_data_pdu_count);
+void common_teardown(struct ll_adv_set *adv);

--- a/tests/bluetooth/df/connectionless_cte_chains/src/test_remove_cte_from_chain.c
+++ b/tests/bluetooth/df/connectionless_cte_chains/src/test_remove_cte_from_chain.c
@@ -23,6 +23,7 @@
 #include "lll/lll_adv_types.h"
 #include "lll_adv.h"
 #include "lll/lll_adv_pdu.h"
+#include "lll/lll_adv_internal.h"
 #include "lll_adv_sync.h"
 #include "lll/lll_df_types.h"
 
@@ -33,9 +34,11 @@
 #include "common.h"
 
 #define TEST_ADV_SET_HANDLE 0
-#define TEST_PER_ADV_CHAIN_LENGTH 5
-#define TEST_PER_ADV_SINGLE_PDU 1
 #define TEST_CTE_COUNT 3
+#define TEST_PER_ADV_CHAIN_LENGTH 5
+#define TEST_PER_ADV_CHAIN_INCREASED_LENGTH 7
+#define TEST_PER_ADV_CHAIN_DECREASED_LENGTH (TEST_CTE_COUNT - 1)
+#define TEST_PER_ADV_SINGLE_PDU 1
 #define TEST_CTE_SINGLE 1
 /* It does not matter for purpose of this tests what is the type or length of CTE used. */
 #define TEST_CTE_TYPE BT_HCI_LE_AOD_CTE_2US
@@ -62,9 +65,7 @@ void test_remove_cte_from_chain_extended_to_tx_all_cte(void)
 	/* Validate result */
 	common_validate_per_adv_chain(adv, TEST_PER_ADV_SINGLE_PDU);
 
-	/* Teardown */
-	common_release_per_adv_chain(adv);
-	common_release_adv_set(adv);
+	common_teardown(adv);
 }
 
 void test_remove_cte_from_chain_where_each_pdu_includes_cte(void)
@@ -93,9 +94,7 @@ void test_remove_cte_from_chain_where_each_pdu_includes_cte(void)
 	/* Validate result */
 	common_validate_per_adv_chain(adv, TEST_CTE_COUNT);
 
-	/* Teardown */
-	common_release_per_adv_chain(adv);
-	common_release_adv_set(adv);
+	common_teardown(adv);
 }
 
 void test_remove_cte_from_chain_with_more_pdu_than_cte(void)
@@ -121,9 +120,7 @@ void test_remove_cte_from_chain_with_more_pdu_than_cte(void)
 	/* Validate result */
 	common_validate_per_adv_chain(adv, TEST_PER_ADV_CHAIN_LENGTH);
 
-	/* Teardown */
-	common_release_per_adv_chain(adv);
-	common_release_adv_set(adv);
+	common_teardown(adv);
 }
 
 void test_remove_cte_from_single_pdu_chain(void)
@@ -149,17 +146,199 @@ void test_remove_cte_from_single_pdu_chain(void)
 	/* Validate result */
 	common_validate_per_adv_chain(adv, TEST_PER_ADV_SINGLE_PDU);
 
-	/* Teardown */
-	common_release_per_adv_chain(adv);
-	common_release_adv_set(adv);
+	common_teardown(adv);
+}
+
+void remove_cte_from_chain_after_enqueue_to_lll(uint8_t cte_count, uint8_t init_chain_length,
+						uint8_t expected_mem_pdu_used_count_for_enable,
+						uint8_t expected_mem_pdu_used_count_for_disable,
+						uint8_t expected_pdu_in_chain_after_cte_disable,
+						uint8_t updated_chain_length,
+						uint8_t expected_end_fifo_free_pdu_count,
+						bool new_chain_before_cte_disable)
+{
+	uint32_t pdu_mem_cnt_expected, pdu_mem_cnt;
+	struct pdu_adv *pdu_prev, *pdu_new;
+	struct ll_adv_set *adv;
+	uint32_t pdu_fifo_cnt;
+	uint8_t handle;
+	uint8_t upd;
+	int err;
+
+	pdu_mem_cnt_expected = lll_adv_pdu_mem_free_count_get();
+
+	/* Setup for test */
+	adv = common_create_adv_set(TEST_ADV_SET_HANDLE);
+	/* Use smaller number of CTE for request than number of PDUs in an initial chain.
+	 * In such situation chain should not be extended and PDUs pool should be not affected.
+	 */
+	common_prepare_df_cfg(adv, cte_count);
+	common_create_per_adv_chain(adv, init_chain_length);
+
+	handle = ull_adv_handle_get(adv);
+
+	err = ll_df_set_cl_cte_tx_enable(handle, true);
+	zassert_equal(err, 0,
+		      "Unexpected error while enabling CTE for periodic avertising chain, err: %d",
+		      err);
+
+	/* Swap PDU double buffer and get new latest PDU data */
+	pdu_new = lll_adv_sync_data_latest_get(adv->lll.sync, NULL, &upd);
+	zassert_not_equal(pdu_new, NULL,
+			  "Unexpected value of new PDU pointer after PDU double buffer swap");
+
+	pdu_prev = lll_adv_sync_data_peek(adv->lll.sync, NULL);
+	zassert_equal(pdu_prev, pdu_new,
+		      "Unexpected value of previous PDU pointer after PDU double buffer swap");
+
+	/* Free PDUs fifo should hold single PDU released during double buffer swap. The PDU
+	 * was allocated during advertising set creation.
+	 */
+	pdu_fifo_cnt = lll_adv_free_pdu_fifo_count_get();
+	zassert_equal(pdu_fifo_cnt, TEST_PER_ADV_SINGLE_PDU,
+		      "Unexpected number of free PDUs in a fifo: %d", pdu_fifo_cnt);
+
+	/* Expected free PDUs count is decreased by:
+	 * - single PDU allocated during advertising set creation,
+	 * - number of PDUs allocated for per. adv. chain to Tx CTE
+	 */
+	pdu_mem_cnt_expected -= expected_mem_pdu_used_count_for_enable;
+	pdu_mem_cnt = lll_adv_pdu_mem_free_count_get();
+	zassert_equal(pdu_mem_cnt, pdu_mem_cnt_expected,
+		      "Unexpected amount of free PDUs memory: %d, expected %d", pdu_mem_cnt,
+		      pdu_mem_cnt_expected);
+
+	if (new_chain_before_cte_disable) {
+		common_create_per_adv_chain(adv, updated_chain_length);
+	}
+
+	err = ll_df_set_cl_cte_tx_enable(handle, false);
+	zassert_equal(err, 0,
+		      "Unexpected error while disabling CTE for periodic avertising chain, err: %d",
+		      err);
+	/* Validate result */
+	common_validate_per_adv_chain(adv, expected_pdu_in_chain_after_cte_disable);
+
+	/* Swap PDU double buffer to check correctness of release former PDUs */
+	pdu_new = lll_adv_sync_data_latest_get(adv->lll.sync, NULL, &upd);
+	zassert_not_equal(pdu_new, NULL,
+			  "Unexpected value of PDU pointer after PDU double buffer swap");
+
+	/* Validate number of released PDUs */
+
+	/* Number of free PDUs in a fifo is a number of released PDUs from former periodic
+	 * advertising chain. One free PDU that had been in a fifo was used for allocation of
+	 * the new PDU without CTE.
+	 */
+	pdu_fifo_cnt = lll_adv_free_pdu_fifo_count_get();
+	zassert_equal(pdu_fifo_cnt, expected_end_fifo_free_pdu_count,
+		      "Unexpected number of free PDUs in a fifo: %d", pdu_fifo_cnt);
+
+	/* Number of free PDUs in memory pool may decreased. Single PDU for AUX_SYNC_IND was
+	 * acquired from free PDUs fifo. The memory pool will decrease by number of non empty PDUs
+	 * in a chain subtracted by 1 (PDU taken from free PDUs fifo).
+	 */
+	pdu_mem_cnt_expected -= expected_mem_pdu_used_count_for_disable;
+
+	pdu_mem_cnt = lll_adv_pdu_mem_free_count_get();
+	zassert_equal(pdu_mem_cnt, pdu_mem_cnt_expected,
+		      "Unexpected amount of free PDUs memory: %d, expected %d", pdu_mem_cnt,
+		      pdu_mem_cnt_expected);
+
+	common_teardown(adv);
+}
+
+void test_remove_cte_from_chain_extended_to_tx_all_cte_after_enqueue_to_lll(void)
+{
+	uint8_t cte_count = TEST_CTE_COUNT;
+	uint8_t init_chain_length = TEST_PER_ADV_SINGLE_PDU;
+	uint8_t expected_mem_pdu_used_count_for_enable = TEST_CTE_COUNT + TEST_PER_ADV_SINGLE_PDU;
+	uint8_t expected_mem_pdu_used_count_for_disable = 0;
+	uint8_t expected_pdu_in_chain_after_cte_disable = TEST_PER_ADV_SINGLE_PDU;
+	uint8_t updated_chain_length = 0;
+	uint8_t expected_end_fifo_free_pdu_count = TEST_CTE_COUNT;
+	bool new_chain_before_cte_disable = false;
+
+	remove_cte_from_chain_after_enqueue_to_lll(
+		cte_count, init_chain_length, expected_mem_pdu_used_count_for_enable,
+		expected_mem_pdu_used_count_for_disable, expected_pdu_in_chain_after_cte_disable,
+		updated_chain_length, expected_end_fifo_free_pdu_count,
+		new_chain_before_cte_disable);
+}
+
+void test_remove_cte_from_chain_with_more_pdu_than_cte_after_enqueue_to_lll(void)
+{
+	uint8_t cte_count = TEST_CTE_COUNT;
+	uint8_t init_chain_length = TEST_PER_ADV_CHAIN_LENGTH;
+	uint8_t expected_mem_pdu_used_count_for_enable =
+		TEST_PER_ADV_CHAIN_LENGTH + TEST_PER_ADV_SINGLE_PDU;
+	uint8_t expected_mem_pdu_used_count_for_disable =
+		TEST_PER_ADV_CHAIN_LENGTH - TEST_PER_ADV_SINGLE_PDU;
+	uint8_t expected_pdu_in_chain_after_cte_disable = TEST_PER_ADV_CHAIN_LENGTH;
+	uint8_t updated_chain_length = 0;
+	uint8_t expected_end_fifo_free_pdu_count = TEST_PER_ADV_CHAIN_LENGTH;
+	bool new_chain_before_cte_disable = false;
+
+	remove_cte_from_chain_after_enqueue_to_lll(
+		cte_count, init_chain_length, expected_mem_pdu_used_count_for_enable,
+		expected_mem_pdu_used_count_for_disable, expected_pdu_in_chain_after_cte_disable,
+		updated_chain_length, expected_end_fifo_free_pdu_count,
+		new_chain_before_cte_disable);
+}
+
+void test_remove_cte_from_chain_length_increased_after_enqueue_to_lll(void)
+{
+	uint8_t cte_count = TEST_CTE_COUNT;
+	uint8_t init_chain_length = TEST_PER_ADV_CHAIN_LENGTH;
+	uint8_t expected_mem_pdu_used_count_for_enable =
+		TEST_PER_ADV_CHAIN_LENGTH + TEST_PER_ADV_SINGLE_PDU;
+	uint8_t expected_mem_pdu_used_count_for_disable =
+		TEST_PER_ADV_CHAIN_INCREASED_LENGTH - TEST_PER_ADV_SINGLE_PDU;
+	uint8_t expected_pdu_in_chain_after_cte_disable = TEST_PER_ADV_CHAIN_INCREASED_LENGTH;
+	uint8_t updated_chain_length = TEST_PER_ADV_CHAIN_INCREASED_LENGTH;
+	uint8_t expected_end_fifo_free_pdu_count = TEST_PER_ADV_CHAIN_LENGTH;
+	bool new_chain_before_cte_disable = true;
+
+	remove_cte_from_chain_after_enqueue_to_lll(
+		cte_count, init_chain_length, expected_mem_pdu_used_count_for_enable,
+		expected_mem_pdu_used_count_for_disable, expected_pdu_in_chain_after_cte_disable,
+		updated_chain_length, expected_end_fifo_free_pdu_count,
+		new_chain_before_cte_disable);
+}
+
+void test_remove_cte_from_chain_length_decreased_after_enqueue_to_lll(void)
+{
+	uint8_t cte_count = TEST_CTE_COUNT;
+	uint8_t init_chain_length = TEST_PER_ADV_CHAIN_LENGTH;
+	uint8_t expected_mem_pdu_used_count_for_enable =
+		TEST_PER_ADV_CHAIN_LENGTH + TEST_PER_ADV_SINGLE_PDU;
+	uint8_t expected_mem_pdu_used_count_for_disable =
+		TEST_PER_ADV_CHAIN_DECREASED_LENGTH - TEST_PER_ADV_SINGLE_PDU;
+	uint8_t expected_pdu_in_chain_after_cte_disable = TEST_PER_ADV_CHAIN_DECREASED_LENGTH;
+	uint8_t updated_chain_length = TEST_PER_ADV_CHAIN_DECREASED_LENGTH;
+	uint8_t expected_end_fifo_free_pdu_count = TEST_PER_ADV_CHAIN_LENGTH;
+	bool new_chain_before_cte_disable = true;
+
+	remove_cte_from_chain_after_enqueue_to_lll(
+		cte_count, init_chain_length, expected_mem_pdu_used_count_for_enable,
+		expected_mem_pdu_used_count_for_disable, expected_pdu_in_chain_after_cte_disable,
+		updated_chain_length, expected_end_fifo_free_pdu_count,
+		new_chain_before_cte_disable);
 }
 
 void run_remove_cte_to_per_adv_chain_tests(void)
 {
-	ztest_test_suite(test_add_cte_to_per_adv_chain,
-			 ztest_unit_test(test_remove_cte_from_chain_extended_to_tx_all_cte),
-			 ztest_unit_test(test_remove_cte_from_chain_where_each_pdu_includes_cte),
-			 ztest_unit_test(test_remove_cte_from_chain_with_more_pdu_than_cte),
-			 ztest_unit_test(test_remove_cte_from_single_pdu_chain));
+	ztest_test_suite(
+		test_add_cte_to_per_adv_chain,
+		ztest_unit_test(test_remove_cte_from_chain_extended_to_tx_all_cte),
+		ztest_unit_test(test_remove_cte_from_chain_where_each_pdu_includes_cte),
+		ztest_unit_test(test_remove_cte_from_chain_with_more_pdu_than_cte),
+		ztest_unit_test(test_remove_cte_from_single_pdu_chain),
+		ztest_unit_test(
+			test_remove_cte_from_chain_extended_to_tx_all_cte_after_enqueue_to_lll),
+		ztest_unit_test(
+			test_remove_cte_from_chain_with_more_pdu_than_cte_after_enqueue_to_lll),
+		ztest_unit_test(test_remove_cte_from_chain_length_increased_after_enqueue_to_lll),
+		ztest_unit_test(test_remove_cte_from_chain_length_decreased_after_enqueue_to_lll));
 	ztest_run_test_suite(test_add_cte_to_per_adv_chain);
 }


### PR DESCRIPTION
When CTE is enabled for periodic advertising and number of CTE is
greater than number of PDUs in a chain, that are needed to transport
advertising data, there are additional empty PDUs used for transport
CTE.

CTE transmission may be disabled when periodic advertising event is
pending in LLL. rem_cte_info_from_per_adv_chain removed CTEInfo field
from extended advertising header in chained PDUs. When there were found
empty PDUs (created to transport CTE only), they were released from
the chain that was currently used by LLL. That caused an assert in
isr_tx handler due to broken advertising chain.

The rem_cte_info_from_per_adv_chain may not relese PDUs that are in
use by LLL. The PDUs may be released by LLL in prepare step when
advertising pdu double buffer is swapped by lll_adv_sync_data_latest-
_get.

This PR fixes that issue.