### PR TITLE
scripts: twister: print message from CMake verify toolchain on failures

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -2108,7 +2108,7 @@ class CMake():
 
         else:
             logger.error("Cmake script failure: %s" % (args[0]))
-            results = {"returncode": p.returncode}
+            results = {"returncode": p.returncode, "returnmsg": out}
 
         return results
 
@@ -2898,7 +2898,7 @@ class TestSuite(DisablePyTestCollectionMixin):
 
         try:
             if result['returncode']:
-                raise TwisterRuntimeError("E: Variable ZEPHYR_TOOLCHAIN_VARIANT is not defined")
+                raise TwisterRuntimeError(f"E: {result['returnmsg']}")
         except Exception as e:
             print(str(e))
             sys.exit(2)


### PR DESCRIPTION
Fixes: #38924

When the `verify-toolchain.cmake` script fails, then twister will print
a standard message to the user regardless of the reason.
> E: Variable ZEPHYR_TOOLCHAIN_VARIANT is not defined

The `verify-toolchain.cmake` already prints detailed information
regarding the cause of the failure, so twister should just pass that
message as-is.

For example, the message that is provided by verify-toolchain.cmake
when Zephyr SDK 0.13.0 is installed but 0.13.1 is required looks like:
> CMake Error at cmake/verify-toolchain.cmake:75 (find_package):
>  Could not find a configuration file for package "Zephyr-sdk" that is
>  compatible with requested version "0.13.1".
>
>  The following configuration files were considered but not accepted:
>
> /opt/zephyr-sdk-0.13.0/cmake/Zephyr-sdkConfig.cmake, version: 0.13.0

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>