### PR TITLE
samples/mgmt/smp_svr: Increase main stack size

### DIFF
--- a/samples/subsys/mgmt/mcumgr/smp_svr/prj.conf
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/prj.conf
@@ -3,6 +3,7 @@ CONFIG_MCUMGR=y
 
 # Some command handlers require a large stack.
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2304
+CONFIG_MAIN_STACK_SIZE=2048
 
 # Ensure an MCUboot-compatible binary is generated.
 CONFIG_BOOTLOADER_MCUBOOT=y


### PR DESCRIPTION
Some build variants will fail runtime for certain boards (e.g. nRF52832)
due to stack overflow. Avoid this by increasing the stack size.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>