### PR TITLE
Bluetooth: Controller: Update Bluetooth version to 5.3

### DIFF
--- a/subsys/bluetooth/controller/include/ll_feat.h
+++ b/subsys/bluetooth/controller/include/ll_feat.h
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define LL_VERSION_NUMBER BT_HCI_VERSION_5_2
+#define LL_VERSION_NUMBER BT_HCI_VERSION_5_3
 
 #if defined(CONFIG_BT_CTLR_LE_ENC)
 #define LL_FEAT_BIT_ENC BIT64(BT_LE_FEAT_BIT_ENC)


### PR DESCRIPTION
Update the Bluetooth HCI Version to 5.3.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>