### PR TITLE
boards: nucleo_l073rz: Set LSI as LPTIM clock source

### DIFF
--- a/boards/arm/nucleo_l073rz/Kconfig.defconfig
+++ b/boards/arm/nucleo_l073rz/Kconfig.defconfig
@@ -12,4 +12,10 @@ config SPI_STM32_INTERRUPT
 	default y
 	depends on SPI
 
+# FIXME: LSE not working as LPTIM clock source. Use LSI instead.
+choice STM32_LPTIM_CLOCK
+	default STM32_LPTIM_CLOCK_LSI
+	depends on STM32_LPTIM_TIMER
+endchoice
+
 endif # BOARD_NUCLEO_L073RZ


### PR DESCRIPTION
For some reason, LSE can't be used as LPTIM clock source
on nucleo_l073rz.
As a consequence, low power operations are not functional on
this platform.
Waiting for the original issue to be fixed, set LSI as LPTIM
clock source.

EDIT:
Additional advantage of this change is that it will enable compilation of this option, which is not used otherwise.

Partially fixes #38930

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>