### PR TITLE
 drivers: entropy: gecko: add driver using Secure Element module of EFR32

### DIFF
--- a/boards/arm/efr32_radio/efr32_radio_brd4180a.dts
+++ b/boards/arm/efr32_radio/efr32_radio_brd4180a.dts
@@ -62,8 +62,8 @@
 
 &usart0 {
 	current-speed = <115200>;
-	location-rx = <GECKO_LOCATION(0) GECKO_PORT_C GECKO_PIN(1)>;
-	location-tx = <GECKO_LOCATION(0) GECKO_PORT_C GECKO_PIN(0)>;
+	location-rx = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(6)>;
+	location-tx = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(5)>;
 	status = "okay";
 };
 

--- a/drivers/entropy/CMakeLists.txt
+++ b/drivers/entropy/CMakeLists.txt
@@ -18,3 +18,4 @@ zephyr_library_sources_ifdef(CONFIG_ENTROPY_RV32M1_TRNG        entropy_rv32m1_tr
 zephyr_library_sources_ifdef(CONFIG_ENTROPY_GECKO_TRNG         entropy_gecko_trng.c)
 zephyr_library_sources_ifdef(CONFIG_ENTROPY_NEORV32_TRNG       entropy_neorv32_trng.c)
 zephyr_library_sources_ifdef(CONFIG_ENTROPY_BT_HCI             entropy_bt_hci.c)
+zephyr_library_sources_ifdef(CONFIG_ENTROPY_GECKO_SE           entropy_gecko_se.c)

--- a/drivers/entropy/Kconfig.gecko
+++ b/drivers/entropy/Kconfig.gecko
@@ -1,6 +1,7 @@
 # gecko entropy generator driver configuration
 
 # Copyright (c) 2020 Lemonbeat GmbH
+# Copyright (c) 2021 Safran Passenger Innovations Germany GmbH
 # SPDX-License-Identifier: Apache-2.0
 
 config ENTROPY_GECKO_TRNG
@@ -11,3 +12,12 @@ config ENTROPY_GECKO_TRNG
 	help
 	  This option enables the true random number generator
 	  driver based on the TRNG.
+
+config ENTROPY_GECKO_SE
+	bool "GECKO SE driver"
+	depends on SOC_GECKO_SE
+	select ENTROPY_HAS_DRIVER
+	default y
+	help
+	  This option enables the true random number generator
+	  driver based on the Secure Element (SE) module.

--- a/drivers/entropy/entropy_gecko_se.c
+++ b/drivers/entropy/entropy_gecko_se.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2021 Safran Passenger Innovations Germany GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT silabs_gecko_semailbox
+
+ #include <drivers/entropy.h>
+ #include <soc.h>
+ #include "em_cmu.h"
+ #include "sl_se_manager.h"
+ #include "sl_se_manager_entropy.h"
+
+
+static int entropy_gecko_se_get_entropy(const struct device *dev,
+					uint8_t *buffer,
+					uint16_t length)
+{
+	ARG_UNUSED(dev);
+
+	int err = 0;
+	sl_status_t status;
+	sl_se_command_context_t cmd_ctx;
+
+	status = sl_se_init_command_context(&cmd_ctx);
+
+	if (status == SL_STATUS_OK) {
+		status = sl_se_get_random(&cmd_ctx, buffer, length);
+
+		if (status != SL_STATUS_OK) {
+			err = -EIO;
+		}
+
+		sl_se_deinit_command_context(&cmd_ctx);
+	} else {
+		err = -EIO;
+	}
+
+	return err;
+}
+
+static int entropy_gecko_se_get_entropy_isr(const struct device *dev,
+					    uint8_t *buf,
+					    uint16_t len, uint32_t flags)
+{
+	return -ENOTSUP;
+}
+
+static int entropy_gecko_se_init(const struct device *dev)
+{
+	if (sl_se_init()) {
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static const struct entropy_driver_api entropy_gecko_se_api_funcs = {
+	.get_entropy = entropy_gecko_se_get_entropy,
+	.get_entropy_isr = entropy_gecko_se_get_entropy_isr
+};
+
+#define GECKO_SE_INIT(n) \
+	DEVICE_DT_INST_DEFINE(n, \
+			      entropy_gecko_se_init, NULL, \
+			      NULL, NULL, \
+			      PRE_KERNEL_1, CONFIG_ENTROPY_INIT_PRIORITY, \
+			      &entropy_gecko_se_api_funcs); \
+
+DT_INST_FOREACH_STATUS_OKAY(GECKO_SE_INIT)

--- a/dts/arm/silabs/efr32mg21.dtsi
+++ b/dts/arm/silabs/efr32mg21.dtsi
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 TriaGnoSys GmbH
+ * Copyright (c) 2021 Safran Passenger Innovations Germany GmbH
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,6 +12,7 @@
 
 / {
 	chosen {
+		zephyr,entropy = &se;
 		zephyr,flash-controller = &msc;
 	};
 
@@ -168,6 +170,15 @@
 				#gpio-cells = <2>;
 				status = "disabled";
 			};
+		};
+
+		se: semailbox@4c000000 {
+			compatible = "silabs,gecko-semailbox";
+			reg = <0x4c000000 0x80>;
+			interrupts = <0 3>, <1 3>, <2 3>;
+			interrupt-names = "SETAMPERHOST", "SEMBRX", "SEMBTX";
+			label = "SEMAILBOX";
+			status = "okay";
 		};
 
 		wdog0: wdog@4a018000 {

--- a/dts/bindings/crypto/silabs,gecko-semailbox.yaml
+++ b/dts/bindings/crypto/silabs,gecko-semailbox.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2021 Safran Passenger Innovations Germany GmbH
+# SPDX-License-Identifier: Apache-2.0
+
+description: Silicon Labs Secure Element mailbox node
+
+compatible: "silabs,gecko-semailbox"
+
+include: base.yaml
+
+properties:
+    reg:
+      required: true
+
+    label:
+      required: true
+
+    interrupts:
+      required: true

--- a/west.yml
+++ b/west.yml
@@ -117,7 +117,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: be39d4eebeddac6e18e9c0c3ba1b31ad1e82eaed
+      revision: 08dd39f1a20a2aaec596b909c31e9b23d7fef09d
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
Some EFR32 SoCs use a secure element subsystem to manage
security features (i.e., TRNG, secure bootloader or cryptographic
functions).

This driver relies on the SE Manager high-level API provided by Silicon
Labs. The API interacts with the SE subsystem, provides helper functions
to achieve cryptographic operations and ensures that only one operation
is running at a time by using mutexes and semaphores.

Instead of relying on the SE Manager from Silicon Labs, one could
recreate the behaviour of the Manager and put the code in the crypto
driver folder and create a dependency for other drivers using the crypto
manager (e.g., keys, entropy).

I went for the SE Manager API as it is already there and supported by
Silicon Labs.

Tested using the random subsystem.

There is a PR for the SE Manager API at [#7](https://github.com/zephyrproject-rtos/hal_silabs/pull/16)

Signed-off-by: Steven Lemaire <steven.lemaire@zii.aero>