### PR TITLE
libc: minimal: Add <endian.h> for htobe32 et al

### DIFF
--- a/lib/libc/minimal/include/endian.h
+++ b/lib/libc/minimal/include/endian.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021 Space Cubics, LLC.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_ENDIAN_H_
+#define ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_ENDIAN_H_
+
+#include <stdint.h>
+#include <sys/byteorder.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline uint16_t htobe16(uint16_t val) { sys_cpu_to_be16(val); }
+static inline uint16_t htole16(uint16_t val) { sys_cpu_to_le16(val); }
+static inline uint16_t be16toh(uint16_t val) { sys_be16_to_cpu(val); }
+static inline uint16_t le16toh(uint16_t val) { sys_le16_to_cpu(val); }
+
+static inline uint32_t htobe32(uint32_t val) { sys_cpu_to_be32(val); }
+static inline uint32_t htole32(uint32_t val) { sys_cpu_to_le32(val); }
+static inline uint32_t be32toh(uint32_t val) { sys_be32_to_cpu(val); }
+static inline uint32_t le32toh(uint32_t val) { sys_le32_to_cpu(val); }
+
+static inline uint64_t htobe64(uint64_t val) { sys_cpu_to_be64(val); }
+static inline uint64_t htole64(uint64_t val) { sys_cpu_to_le64(val); }
+static inline uint64_t be64toh(uint64_t val) { sys_be64_to_cpu(val); }
+static inline uint64_t le64toh(uint64_t val) { sys_le64_to_cpu(val); }
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_ENDIAN_H_ */

--- a/lib/libc/minimal/include/sys/types.h
+++ b/lib/libc/minimal/include/sys/types.h
@@ -10,6 +10,7 @@
 
 #include <stdint.h>
 #include <sys/_types.h>
+#include <endian.h>
 
 typedef unsigned int mode_t;
 


### PR DESCRIPTION
Add <endian.h> with the following functions to the minimal libc

htobe16(), htole16(), be16toh(), le16toh(),
htobe32(), htole32(), be32toh(), le32toh(),
htobe64(), htole64(), be64toh(), le64toh(),

These functions are originally from OpenBSD but many other OSes,
including GNU Libc[1] and picolibc adopted[2].  There seems to be a
talk[3] for inclusion in The Open Group Standard.

Unfortunately some BSD, such as MacOS, uses <machine/endian.h> and
expect <sys/types.h> to pull this in, both GNU libc and picolibc does
the same.  Thus, this commit also modify <sys/types.h> to include
<endian.h>.

[1]: https://sourceware.org/git/?p=glibc.git;a=blob;f=include/endian.h
[2]: https://github.com/picolibc/picolibc/pull/169
[3]: https://austingroupbugs.net/view.php?id=162

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>