### PR TITLE
Bluetooth: controller: Update supported commands for ISO

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -81,6 +81,12 @@ config BT_CTLR_CONN_RSSI_SUPPORT
 config BT_CTLR_ECDH_SUPPORT
 	bool
 
+config BT_CTLR_READ_ISO_LINK_QUALITY_SUPPORT
+	depends on BT_CTLR_SYNC_ISO_SUPPORT || \
+		   BT_CTLR_CENTRAL_ISO_SUPPORT || \
+		   BT_CTLR_PERIPHERAL_ISO_SUPPORT
+	bool
+
 config BT_CTLR
 	bool "Bluetooth Controller"
 	help
@@ -610,6 +616,13 @@ config BT_CTLR_CONN_ISO_STREAMS_PER_GROUP
 config BT_CTLR_ISO
 	bool
 	default BT_CTLR_BROADCAST_ISO || BT_CTLR_CONN_ISO
+
+config BT_CTLR_READ_ISO_LINK_QUALITY
+	bool "LE Read ISO Link Quality"
+	depends on BT_CTLR_READ_ISO_LINK_QUALITY_SUPPORT
+	depends on BT_CTLR_SYNC_ISO || BT_CTLR_CONN_ISO
+	help
+	  Enable support for LE Read ISO Link Quality command.
 
 config BT_CTLR_DTM
 	bool

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -839,8 +839,11 @@ static void read_supported_commands(struct net_buf *buf, struct net_buf **evt)
 #if defined(CONFIG_BT_CTLR_SYNC_ISO) || defined(CONFIG_BT_CTLR_CONN_ISO)
 	/* LE ISO Receive Test, LE ISO Read Test Counters */
 	rp->commands[43] |= BIT(6) | BIT(7);
+
+#if defined(CONFIG_BT_CTLR_READ_ISO_LINK_QUALITY)
 	/* LE Read ISO Link Quality */
 	rp->commands[44] |= BIT(2);
+#endif /* CONFIG_BT_CTLR_READ_ISO_LINK_QUALITY */
 #endif /* CONFIG_BT_CTLR_ADV_ISO || CONFIG_BT_CTLR_CONN_ISO */
 
 #if defined(CONFIG_BT_CTLR_ISO)
@@ -2051,6 +2054,7 @@ static void le_iso_read_test_counters(struct net_buf *buf, struct net_buf **evt)
 	rp->failed_cnt   = sys_cpu_to_le32(failed_cnt);
 }
 
+#if defined(CONFIG_BT_CTLR_READ_ISO_LINK_QUALITY)
 static void le_read_iso_link_quality(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_read_iso_link_quality *cmd = (void *)buf->data;
@@ -2088,6 +2092,8 @@ static void le_read_iso_link_quality(struct net_buf *buf, struct net_buf **evt)
 	rp->rx_unreceived_packets = sys_cpu_to_le32(rx_unreceived_packets);
 	rp->duplicate_packets     = sys_cpu_to_le32(duplicate_packets);
 }
+#endif /* CONFIG_BT_CTLR_READ_ISO_LINK_QUALITY */
+
 #endif /* CONFIG_BT_CTLR_SYNC_ISO || CONFIG_BT_CTLR_CONN_ISO */
 
 #if defined(CONFIG_BT_CTLR_ISO)
@@ -3760,9 +3766,11 @@ static int controller_cmd_handle(uint16_t  ocf, struct net_buf *cmd,
 	case BT_OCF(BT_HCI_OP_LE_ISO_READ_TEST_COUNTERS):
 		le_iso_read_test_counters(cmd, evt);
 		break;
+#if defined(CONFIG_BT_CTLR_READ_ISO_LINK_QUALITY)
 	case BT_OCF(BT_HCI_OP_LE_READ_ISO_LINK_QUALITY):
 		le_read_iso_link_quality(cmd, evt);
 		break;
+#endif /* CONFIG_BT_CTLR_READ_ISO_LINK_QUALITY */
 #endif /* CONFIG_BT_CTLR_SYNC_ISO || CONFIG_BT_CTLR_CONN_ISO */
 
 #if defined(CONFIG_BT_CTLR_SET_HOST_FEATURE)

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -1501,12 +1501,12 @@ static void le_set_adv_enable(struct net_buf *buf, struct net_buf **evt)
 static void le_create_big(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_create_big *cmd = (void *)buf->data;
-	uint8_t status;
 	uint32_t sdu_interval;
-	uint16_t max_sdu;
 	uint16_t max_latency;
 	uint8_t big_handle;
 	uint8_t adv_handle;
+	uint16_t max_sdu;
+	uint8_t status;
 
 	status = ll_adv_iso_by_hci_handle_new(cmd->big_handle, &big_handle);
 	if (status) {
@@ -1535,11 +1535,11 @@ static void le_create_big(struct net_buf *buf, struct net_buf **evt)
 static void le_create_big_test(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_create_big_test *cmd = (void *)buf->data;
-	uint8_t status;
 	uint32_t sdu_interval;
 	uint16_t iso_interval;
 	uint16_t max_sdu;
 	uint16_t max_pdu;
+	uint8_t status;
 
 	sdu_interval = sys_get_le24(cmd->sdu_interval);
 	iso_interval = sys_le16_to_cpu(cmd->iso_interval);
@@ -1975,8 +1975,8 @@ static void le_iso_transmit_test(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_iso_transmit_test *cmd = (void *)buf->data;
 	struct bt_hci_rp_le_iso_transmit_test *rp;
-	uint8_t status;
 	uint16_t handle;
+	uint8_t status;
 
 	handle = sys_le16_to_cpu(cmd->handle);
 
@@ -1991,12 +1991,12 @@ static void le_read_iso_tx_sync(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_read_iso_tx_sync *cmd = (void *)buf->data;
 	struct bt_hci_rp_le_read_iso_tx_sync *rp;
-	uint8_t status;
-	uint16_t handle, handle_le16;
-
-	uint16_t seq;
+	uint16_t handle_le16;
 	uint32_t timestamp;
 	uint32_t offset;
+	uint16_t handle;
+	uint8_t status;
+	uint16_t seq;
 
 	handle_le16 = cmd->handle;
 	handle = sys_le16_to_cpu(handle_le16);
@@ -2017,8 +2017,8 @@ static void le_iso_receive_test(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_iso_receive_test *cmd = (void *)buf->data;
 	struct bt_hci_rp_le_iso_receive_test *rp;
-	uint8_t status;
 	uint16_t handle;
+	uint8_t status;
 
 	handle = sys_le16_to_cpu(cmd->handle);
 
@@ -2033,11 +2033,11 @@ static void le_iso_read_test_counters(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_read_test_counters *cmd = (void *)buf->data;
 	struct bt_hci_rp_le_read_test_counters *rp;
-	uint8_t status;
-	uint16_t handle;
 	uint32_t received_cnt;
 	uint32_t missed_cnt;
 	uint32_t failed_cnt;
+	uint16_t handle;
+	uint8_t status;
 
 	handle = sys_le16_to_cpu(cmd->handle);
 	status = ll_iso_read_test_counters(handle, &received_cnt,
@@ -2055,16 +2055,16 @@ static void le_read_iso_link_quality(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_read_iso_link_quality *cmd = (void *)buf->data;
 	struct bt_hci_rp_le_read_iso_link_quality *rp;
-	uint8_t status;
-	uint16_t handle, handle_le16;
-
-	uint32_t tx_unacked_packets;
-	uint32_t tx_flushed_packets;
 	uint32_t tx_last_subevent_packets;
 	uint32_t retransmitted_packets;
-	uint32_t crc_error_packets;
 	uint32_t rx_unreceived_packets;
+	uint32_t tx_unacked_packets;
+	uint32_t tx_flushed_packets;
+	uint32_t crc_error_packets;
 	uint32_t duplicate_packets;
+	uint16_t handle_le16;
+	uint16_t handle;
+	uint8_t status;
 
 	handle_le16 = cmd->handle;
 	handle = sys_le16_to_cpu(handle_le16);
@@ -2124,8 +2124,8 @@ static void le_remove_iso_path(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_remove_iso_path *cmd = (void *)buf->data;
 	struct bt_hci_rp_le_remove_iso_path *rp;
-	uint8_t status;
 	uint16_t handle;
+	uint8_t status;
 
 	handle = sys_le16_to_cpu(cmd->handle);
 
@@ -2140,11 +2140,11 @@ static void le_iso_test_end(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_iso_test_end *cmd = (void *)buf->data;
 	struct bt_hci_rp_le_iso_test_end *rp;
-	uint8_t status;
-	uint16_t handle;
 	uint32_t received_cnt;
 	uint32_t missed_cnt;
 	uint32_t failed_cnt;
+	uint16_t handle;
+	uint8_t status;
 
 	handle = sys_le16_to_cpu(cmd->handle);
 	status = ll_iso_test_end(handle, &received_cnt, &missed_cnt,

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -1984,7 +1984,7 @@ static void le_iso_transmit_test(struct net_buf *buf, struct net_buf **evt)
 
 	rp = hci_cmd_complete(evt, sizeof(*rp));
 	rp->status = status;
-	rp->handle = cmd->handle;
+	rp->handle = sys_cpu_to_le16(handle);
 }
 
 static void le_read_iso_tx_sync(struct net_buf *buf, struct net_buf **evt)
@@ -2026,7 +2026,7 @@ static void le_iso_receive_test(struct net_buf *buf, struct net_buf **evt)
 
 	rp = hci_cmd_complete(evt, sizeof(*rp));
 	rp->status = status;
-	rp->handle = cmd->handle;
+	rp->handle = sys_cpu_to_le16(handle);
 }
 
 static void le_iso_read_test_counters(struct net_buf *buf, struct net_buf **evt)
@@ -2045,7 +2045,7 @@ static void le_iso_read_test_counters(struct net_buf *buf, struct net_buf **evt)
 
 	rp = hci_cmd_complete(evt, sizeof(*rp));
 	rp->status = status;
-	rp->handle = cmd->handle;
+	rp->handle = sys_cpu_to_le16(handle);
 	rp->received_cnt = sys_cpu_to_le32(received_cnt);
 	rp->missed_cnt   = sys_cpu_to_le32(missed_cnt);
 	rp->failed_cnt   = sys_cpu_to_le32(failed_cnt);
@@ -2152,7 +2152,7 @@ static void le_iso_test_end(struct net_buf *buf, struct net_buf **evt)
 
 	rp = hci_cmd_complete(evt, sizeof(*rp));
 	rp->status = status;
-	rp->handle = cmd->handle;
+	rp->handle = sys_cpu_to_le16(handle);
 	rp->received_cnt = sys_cpu_to_le32(received_cnt);
 	rp->missed_cnt   = sys_cpu_to_le32(missed_cnt);
 	rp->failed_cnt   = sys_cpu_to_le32(failed_cnt);

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -730,6 +730,13 @@ static void read_supported_commands(struct net_buf *buf, struct net_buf **evt)
 	/* LE Start Encryption */
 	rp->commands[28] |= BIT(0);
 #endif /* CONFIG_BT_CTLR_LE_ENC */
+
+#if defined(CONFIG_BT_CTLR_CENTRAL_ISO)
+	/* LE Set CIG Parameters */
+	rp->commands[41] |= BIT(7);
+	/* LE Set CIG Parameters Test, LE Create CIS, LE Remove CIS */
+	rp->commands[42] |= BIT(0) | BIT(1) | BIT(2);
+#endif /* CONFIG_BT_CTLR_CENTRAL_ISO */
 #endif /* CONFIG_BT_CENTRAL */
 
 #if defined(CONFIG_BT_PERIPHERAL)
@@ -737,6 +744,10 @@ static void read_supported_commands(struct net_buf *buf, struct net_buf **evt)
 	/* LE LTK Request Reply, LE LTK Request Negative Reply */
 	rp->commands[28] |= BIT(1) | BIT(2);
 #endif /* CONFIG_BT_CTLR_LE_ENC */
+#if defined(CONFIG_BT_CTLR_PERIPHERAL_ISO)
+	/* LE Accept CIS Request, LE Reject CIS Request */
+	rp->commands[42] |= BIT(3) | BIT(4);
+#endif /* CONFIG_BT_CTLR_PERIPHERAL_ISO */
 #endif /* CONFIG_BT_PERIPHERAL */
 
 	/* Disconnect. */
@@ -819,10 +830,30 @@ static void read_supported_commands(struct net_buf *buf, struct net_buf **evt)
 	rp->commands[38] |= BIT(7);
 
 #if defined(CONFIG_BT_CTLR_ADV_ISO) || defined(CONFIG_BT_CTLR_CONN_ISO)
-	/* LE Read Buffer Size v2 */
-	rp->commands[41] |= BIT(5);
+	/* LE Read Buffer Size v2, LE Read ISO TX Sync */
+	rp->commands[41] |= BIT(5) | BIT(6);
+	/* LE ISO Transmit Test */
+	rp->commands[43] |= BIT(5);
+#endif /* CONFIG_BT_CTLR_ADV_ISO || CONFIG_BT_CTLR_CONN_ISO */
 
-#endif /* CONFIG_BT_CTLR_ISO || CONFIG_BT_CTLR_CONN_ISO */
+#if defined(CONFIG_BT_CTLR_SYNC_ISO) || defined(CONFIG_BT_CTLR_CONN_ISO)
+	/* LE ISO Receive Test, LE ISO Read Test Counters */
+	rp->commands[43] |= BIT(6) | BIT(7);
+	/* LE Read ISO Link Quality */
+	rp->commands[44] |= BIT(2);
+#endif /* CONFIG_BT_CTLR_ADV_ISO || CONFIG_BT_CTLR_CONN_ISO */
+
+#if defined(CONFIG_BT_CTLR_ISO)
+	/* LE Setup ISO Data Path, LE Remove ISO Data Path */
+	rp->commands[43] |= BIT(3) | BIT(4);
+	/* LE ISO Test End */
+	rp->commands[44] |= BIT(0);
+#endif /* CONFIG_BT_CTLR_ISO */
+
+#if defined(CONFIG_BT_CTLR_SET_HOST_FEATURE)
+	/* LE Set Host Feature */
+	rp->commands[44] |= BIT(1);
+#endif /* CONFIG_BT_CTLR_SET_HOST_FEATURE */
 
 #if defined(CONFIG_BT_CTLR_HCI_CODEC_AND_DELAY_INFO)
 	/* Read Supported Codecs */
@@ -1939,7 +1970,23 @@ static void le_remove_cig(struct net_buf *buf, struct net_buf **evt)
 
 #endif /* CONFIG_BT_CENTRAL */
 
-#if defined(CONFIG_BT_CTLR_CONN_ISO)
+#if defined(CONFIG_BT_CTLR_ADV_ISO) || defined(CONFIG_BT_CTLR_CONN_ISO)
+static void le_iso_transmit_test(struct net_buf *buf, struct net_buf **evt)
+{
+	struct bt_hci_cp_le_iso_transmit_test *cmd = (void *)buf->data;
+	struct bt_hci_rp_le_iso_transmit_test *rp;
+	uint8_t status;
+	uint16_t handle;
+
+	handle = sys_le16_to_cpu(cmd->handle);
+
+	status = ll_iso_transmit_test(handle, cmd->payload_type);
+
+	rp = hci_cmd_complete(evt, sizeof(*rp));
+	rp->status = status;
+	rp->handle = cmd->handle;
+}
+
 static void le_read_iso_tx_sync(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_read_iso_tx_sync *cmd = (void *)buf->data;
@@ -1962,6 +2009,46 @@ static void le_read_iso_tx_sync(struct net_buf *buf, struct net_buf **evt)
 	rp->seq       = sys_cpu_to_le16(seq);
 	rp->timestamp = sys_cpu_to_le32(timestamp);
 	sys_put_le24(offset, rp->offset);
+}
+#endif /* CONFIG_BT_CTLR_ADV_ISO || CONFIG_BT_CTLR_CONN_ISO */
+
+#if defined(CONFIG_BT_CTLR_SYNC_ISO) || defined(CONFIG_BT_CTLR_CONN_ISO)
+static void le_iso_receive_test(struct net_buf *buf, struct net_buf **evt)
+{
+	struct bt_hci_cp_le_iso_receive_test *cmd = (void *)buf->data;
+	struct bt_hci_rp_le_iso_receive_test *rp;
+	uint8_t status;
+	uint16_t handle;
+
+	handle = sys_le16_to_cpu(cmd->handle);
+
+	status = ll_iso_receive_test(handle, cmd->payload_type);
+
+	rp = hci_cmd_complete(evt, sizeof(*rp));
+	rp->status = status;
+	rp->handle = cmd->handle;
+}
+
+static void le_iso_read_test_counters(struct net_buf *buf, struct net_buf **evt)
+{
+	struct bt_hci_cp_le_read_test_counters *cmd = (void *)buf->data;
+	struct bt_hci_rp_le_read_test_counters *rp;
+	uint8_t status;
+	uint16_t handle;
+	uint32_t received_cnt;
+	uint32_t missed_cnt;
+	uint32_t failed_cnt;
+
+	handle = sys_le16_to_cpu(cmd->handle);
+	status = ll_iso_read_test_counters(handle, &received_cnt,
+					   &missed_cnt, &failed_cnt);
+
+	rp = hci_cmd_complete(evt, sizeof(*rp));
+	rp->status = status;
+	rp->handle = cmd->handle;
+	rp->received_cnt = sys_cpu_to_le32(received_cnt);
+	rp->missed_cnt   = sys_cpu_to_le32(missed_cnt);
+	rp->failed_cnt   = sys_cpu_to_le32(failed_cnt);
 }
 
 static void le_read_iso_link_quality(struct net_buf *buf, struct net_buf **evt)
@@ -2001,7 +2088,9 @@ static void le_read_iso_link_quality(struct net_buf *buf, struct net_buf **evt)
 	rp->rx_unreceived_packets = sys_cpu_to_le32(rx_unreceived_packets);
 	rp->duplicate_packets     = sys_cpu_to_le32(duplicate_packets);
 }
+#endif /* CONFIG_BT_CTLR_SYNC_ISO || CONFIG_BT_CTLR_CONN_ISO */
 
+#if defined(CONFIG_BT_CTLR_ISO)
 static void le_setup_iso_path(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_setup_iso_path *cmd = (void *)buf->data;
@@ -2047,38 +2136,6 @@ static void le_remove_iso_path(struct net_buf *buf, struct net_buf **evt)
 	rp->handle = sys_cpu_to_le16(handle);
 }
 
-static void le_iso_receive_test(struct net_buf *buf, struct net_buf **evt)
-{
-	struct bt_hci_cp_le_iso_receive_test *cmd = (void *)buf->data;
-	struct bt_hci_rp_le_iso_receive_test *rp;
-	uint8_t status;
-	uint16_t handle;
-
-	handle = sys_le16_to_cpu(cmd->handle);
-
-	status = ll_iso_receive_test(handle, cmd->payload_type);
-
-	rp = hci_cmd_complete(evt, sizeof(*rp));
-	rp->status = status;
-	rp->handle = cmd->handle;
-}
-
-static void le_iso_transmit_test(struct net_buf *buf, struct net_buf **evt)
-{
-	struct bt_hci_cp_le_iso_transmit_test *cmd = (void *)buf->data;
-	struct bt_hci_rp_le_iso_transmit_test *rp;
-	uint8_t status;
-	uint16_t handle;
-
-	handle = sys_le16_to_cpu(cmd->handle);
-
-	status = ll_iso_transmit_test(handle, cmd->payload_type);
-
-	rp = hci_cmd_complete(evt, sizeof(*rp));
-	rp->status = status;
-	rp->handle = cmd->handle;
-}
-
 static void le_iso_test_end(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_iso_test_end *cmd = (void *)buf->data;
@@ -2100,29 +2157,7 @@ static void le_iso_test_end(struct net_buf *buf, struct net_buf **evt)
 	rp->missed_cnt   = sys_cpu_to_le32(missed_cnt);
 	rp->failed_cnt   = sys_cpu_to_le32(failed_cnt);
 }
-
-static void le_iso_read_test_counters(struct net_buf *buf, struct net_buf **evt)
-{
-	struct bt_hci_cp_le_read_test_counters *cmd = (void *)buf->data;
-	struct bt_hci_rp_le_read_test_counters *rp;
-	uint8_t status;
-	uint16_t handle;
-	uint32_t received_cnt;
-	uint32_t missed_cnt;
-	uint32_t failed_cnt;
-
-	handle = sys_le16_to_cpu(cmd->handle);
-	status = ll_iso_read_test_counters(handle, &received_cnt,
-					   &missed_cnt, &failed_cnt);
-
-	rp = hci_cmd_complete(evt, sizeof(*rp));
-	rp->status = status;
-	rp->handle = cmd->handle;
-	rp->received_cnt = sys_cpu_to_le32(received_cnt);
-	rp->missed_cnt   = sys_cpu_to_le32(missed_cnt);
-	rp->failed_cnt   = sys_cpu_to_le32(failed_cnt);
-}
-#endif /* CONFIG_BT_CTLR_CONN_ISO */
+#endif /* CONFIG_BT_CTLR_ISO */
 
 #if defined(CONFIG_BT_CTLR_SET_HOST_FEATURE)
 static void le_set_host_feature(struct net_buf *buf, struct net_buf **evt)
@@ -3697,39 +3732,38 @@ static int controller_cmd_handle(uint16_t  ocf, struct net_buf *cmd,
 #endif /* CONFIG_BT_CTLR_PERIPHERAL_ISO */
 #endif /* CONFIG_BT_PERIPHERAL */
 
-#if defined(CONFIG_BT_CTLR_CONN_ISO)
-	case BT_OCF(BT_HCI_OP_LE_READ_ISO_TX_SYNC):
-		le_read_iso_tx_sync(cmd, evt);
-		break;
-
+#if defined(CONFIG_BT_CTLR_ISO)
 	case BT_OCF(BT_HCI_OP_LE_SETUP_ISO_PATH):
 		le_setup_iso_path(cmd, evt);
 		break;
-
 	case BT_OCF(BT_HCI_OP_LE_REMOVE_ISO_PATH):
 		le_remove_iso_path(cmd, evt);
 		break;
-
-	case BT_OCF(BT_HCI_OP_LE_ISO_RECEIVE_TEST):
-		le_iso_receive_test(cmd, evt);
-		break;
-
-	case BT_OCF(BT_HCI_OP_LE_ISO_TRANSMIT_TEST):
-		le_iso_transmit_test(cmd, evt);
-		break;
-
 	case BT_OCF(BT_HCI_OP_LE_ISO_TEST_END):
 		le_iso_test_end(cmd, evt);
 		break;
+#endif /* CONFIG_BT_CTLR_ISO */
 
+#if defined(CONFIG_BT_CTLR_ADV_ISO) || defined(CONFIG_BT_CTLR_CONN_ISO)
+	case BT_OCF(BT_HCI_OP_LE_ISO_TRANSMIT_TEST):
+		le_iso_transmit_test(cmd, evt);
+		break;
+	case BT_OCF(BT_HCI_OP_LE_READ_ISO_TX_SYNC):
+		le_read_iso_tx_sync(cmd, evt);
+		break;
+#endif /* CONFIG_BT_CTLR_ADV_ISO || CONFIG_BT_CTLR_CONN_ISO */
+
+#if defined(CONFIG_BT_CTLR_SYNC_ISO) || defined(CONFIG_BT_CTLR_CONN_ISO)
+	case BT_OCF(BT_HCI_OP_LE_ISO_RECEIVE_TEST):
+		le_iso_receive_test(cmd, evt);
+		break;
 	case BT_OCF(BT_HCI_OP_LE_ISO_READ_TEST_COUNTERS):
 		le_iso_read_test_counters(cmd, evt);
 		break;
-
 	case BT_OCF(BT_HCI_OP_LE_READ_ISO_LINK_QUALITY):
 		le_read_iso_link_quality(cmd, evt);
 		break;
-#endif /* CONFIG_BT_CTLR_CONN_ISO */
+#endif /* CONFIG_BT_CTLR_SYNC_ISO || CONFIG_BT_CTLR_CONN_ISO */
 
 #if defined(CONFIG_BT_CTLR_SET_HOST_FEATURE)
 	case BT_OCF(BT_HCI_OP_LE_SET_HOST_FEATURE):

--- a/subsys/bluetooth/controller/ll_sw/ull_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso.c
@@ -258,6 +258,7 @@ uint8_t ll_iso_read_test_counters(uint16_t handle, uint32_t *received_cnt,
 	return BT_HCI_ERR_CMD_DISALLOWED;
 }
 
+#if defined(CONFIG_BT_CTLR_READ_ISO_LINK_QUALITY)
 uint8_t ll_read_iso_link_quality(uint16_t  handle,
 				 uint32_t *tx_unacked_packets,
 				 uint32_t *tx_flushed_packets,
@@ -278,6 +279,8 @@ uint8_t ll_read_iso_link_quality(uint16_t  handle,
 
 	return BT_HCI_ERR_CMD_DISALLOWED;
 }
+#endif /* CONFIG_BT_CTLR_READ_ISO_LINK_QUALITY */
+
 #endif /* CONFIG_BT_CTLR_SYNC_ISO || CONFIG_BT_CTLR_CONN_ISO */
 
 #if defined(CONFIG_BT_CTLR_ADV_ISO) || defined(CONFIG_BT_CTLR_CONN_ISO)

--- a/subsys/bluetooth/controller/ll_sw/ull_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso.c
@@ -201,12 +201,14 @@ uint8_t ll_setup_iso_path(uint16_t handle, uint8_t path_dir, uint8_t path_id,
 
 uint8_t ll_remove_iso_path(uint16_t handle, uint8_t path_dir)
 {
-	struct ll_conn_iso_stream *cis = ll_conn_iso_stream_get(handle);
 	/* TBD: If the Host issues this command with a Connection_Handle that does not exist
 	 * or is not for a CIS or a BIS, the Controller shall return the error code Unknown
 	 * Connection Identifier (0x02).
 	 */
-	struct ll_iso_datapath *dp;
+	struct ll_iso_datapath *dp = NULL;
+
+#if defined(CONFIG_BT_CTLR_CONN_ISO)
+	struct ll_conn_iso_stream *cis = ll_conn_iso_stream_get(handle);
 
 	if (path_dir == BT_HCI_DATAPATH_DIR_HOST_TO_CTLR) {
 		dp = cis->datapath_in;
@@ -224,6 +226,7 @@ uint8_t ll_remove_iso_path(uint16_t handle, uint8_t path_dir)
 		/* Reserved for future use */
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
+#endif /* CONFIG_BT_CTLR_CONN_ISO */
 
 	if (!dp) {
 		/* Datapath was not previously set up */
@@ -234,29 +237,11 @@ uint8_t ll_remove_iso_path(uint16_t handle, uint8_t path_dir)
 	return 0;
 }
 
+#if defined(CONFIG_BT_CTLR_SYNC_ISO) || defined(CONFIG_BT_CTLR_CONN_ISO)
 uint8_t ll_iso_receive_test(uint16_t handle, uint8_t payload_type)
 {
 	ARG_UNUSED(handle);
 	ARG_UNUSED(payload_type);
-
-	return BT_HCI_ERR_CMD_DISALLOWED;
-}
-
-uint8_t ll_iso_transmit_test(uint16_t handle, uint8_t payload_type)
-{
-	ARG_UNUSED(handle);
-	ARG_UNUSED(payload_type);
-
-	return BT_HCI_ERR_CMD_DISALLOWED;
-}
-
-uint8_t ll_iso_test_end(uint16_t handle, uint32_t *received_cnt,
-			uint32_t *missed_cnt, uint32_t *failed_cnt)
-{
-	ARG_UNUSED(handle);
-	ARG_UNUSED(received_cnt);
-	ARG_UNUSED(missed_cnt);
-	ARG_UNUSED(failed_cnt);
 
 	return BT_HCI_ERR_CMD_DISALLOWED;
 }
@@ -290,6 +275,28 @@ uint8_t ll_read_iso_link_quality(uint16_t  handle,
 	ARG_UNUSED(crc_error_packets);
 	ARG_UNUSED(rx_unreceived_packets);
 	ARG_UNUSED(duplicate_packets);
+
+	return BT_HCI_ERR_CMD_DISALLOWED;
+}
+#endif /* CONFIG_BT_CTLR_SYNC_ISO || CONFIG_BT_CTLR_CONN_ISO */
+
+#if defined(CONFIG_BT_CTLR_ADV_ISO) || defined(CONFIG_BT_CTLR_CONN_ISO)
+uint8_t ll_iso_transmit_test(uint16_t handle, uint8_t payload_type)
+{
+	ARG_UNUSED(handle);
+	ARG_UNUSED(payload_type);
+
+	return BT_HCI_ERR_CMD_DISALLOWED;
+}
+#endif /* CONFIG_BT_CTLR_ADV_ISO || CONFIG_BT_CTLR_CONN_ISO */
+
+uint8_t ll_iso_test_end(uint16_t handle, uint32_t *received_cnt,
+			uint32_t *missed_cnt, uint32_t *failed_cnt)
+{
+	ARG_UNUSED(handle);
+	ARG_UNUSED(received_cnt);
+	ARG_UNUSED(missed_cnt);
+	ARG_UNUSED(failed_cnt);
 
 	return BT_HCI_ERR_CMD_DISALLOWED;
 }


### PR DESCRIPTION
Set bits for ISO-related supported commands depending on selected
features and adjust compilation guards for the respective handler
functions.

Signed-off-by: Wolfgang Puffitsch <wopu@demant.com>