### PR TITLE
shell: fix assert in panic mode

### DIFF
--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -618,11 +618,11 @@ struct shell_stats {
  * @internal @brief Flags for shell backend configuration.
  */
 struct shell_backend_config_flags {
-	uint32_t insert_mode :1; /*!< Controls insert mode for text introduction.*/
-	uint32_t echo        :1; /*!< Controls shell echo.*/
+	uint32_t insert_mode :1; /*!< Controls insert mode for text introduction */
+	uint32_t echo        :1; /*!< Controls shell echo */
 	uint32_t obscure     :1; /*!< If echo on, print asterisk instead */
 	uint32_t mode_delete :1; /*!< Operation mode of backspace key */
-	uint32_t use_colors  :1; /*!< Controls colored syntax.*/
+	uint32_t use_colors  :1; /*!< Controls colored syntax */
 	uint32_t use_vt100   :1; /*!< Controls VT100 commands usage in shell */
 };
 
@@ -643,12 +643,13 @@ BUILD_ASSERT((sizeof(struct shell_backend_config_flags) == sizeof(uint32_t)),
 };
 
 struct shell_backend_ctx_flags {
-	uint32_t processing   :1; /*!< Shell is executing process function.*/
+	uint32_t processing   :1; /*!< Shell is executing process function */
 	uint32_t tx_rdy       :1;
 	uint32_t history_exit :1; /*!< Request to exit history mode */
 	uint32_t last_nl      :8; /*!< Last received new line character */
 	uint32_t cmd_ctx      :1; /*!< Shell is executing command */
-	uint32_t print_noinit :1; /*!< Print request from not initialized shell*/
+	uint32_t print_noinit :1; /*!< Print request from not initialized shell */
+	uint32_t panic_mode   :1; /*!< Shell in panic mode */
 };
 
 BUILD_ASSERT((sizeof(struct shell_backend_ctx_flags) == sizeof(uint32_t)),

--- a/subsys/shell/shell_log_backend.c
+++ b/subsys/shell/shell_log_backend.c
@@ -289,6 +289,7 @@ static void panic(const struct log_backend *const backend)
 	if (err == 0) {
 		shell->log_backend->control_block->state =
 						SHELL_LOG_BACKEND_PANIC;
+		z_flag_panic_mode_set(shell, true);
 
 		/* Move to the start of next line. */
 		z_shell_multiline_data_calc(&shell->ctx->vt100_ctx.cons,

--- a/subsys/shell/shell_ops.c
+++ b/subsys/shell/shell_ops.c
@@ -502,19 +502,20 @@ void z_shell_vfprintf(const struct shell *shell, enum shell_vt100_color color,
 	}
 }
 
-void z_shell_fprintf(const struct shell *shell,
-			    enum shell_vt100_color color,
-			    const char *fmt, ...)
+void z_shell_fprintf(const struct shell *sh,
+		     enum shell_vt100_color color,
+		     const char *fmt, ...)
 {
-	__ASSERT_NO_MSG(shell);
-	__ASSERT(!k_is_in_isr(), "Thread context required.");
-	__ASSERT_NO_MSG(shell->ctx);
-	__ASSERT_NO_MSG(shell->fprintf_ctx);
+	__ASSERT_NO_MSG(sh);
+	__ASSERT_NO_MSG(sh->ctx);
+	__ASSERT_NO_MSG(sh->fprintf_ctx);
 	__ASSERT_NO_MSG(fmt);
+	__ASSERT(z_flag_panic_mode_get(sh) || !k_is_in_isr(),
+		 "Thread context required.");
 
 	va_list args;
 
 	va_start(args, fmt);
-	z_shell_vfprintf(shell, color, fmt, args);
+	z_shell_vfprintf(sh, color, fmt, args);
 	va_end(args);
 }

--- a/subsys/shell/shell_ops.h
+++ b/subsys/shell/shell_ops.h
@@ -203,6 +203,19 @@ static inline bool z_flag_print_noinit_set(const struct shell *sh, bool val)
 	return ret;
 }
 
+static inline bool z_flag_panic_mode_get(const struct shell *sh)
+{
+	return sh->ctx->ctx.flags.panic_mode == 1;
+}
+
+static inline bool z_flag_panic_mode_set(const struct shell *sh, bool val)
+{
+	bool ret;
+
+	Z_SHELL_SET_FLAG_ATOMIC(sh, ctx, panic_mode, val, ret);
+	return ret;
+}
+
 /* Function sends VT100 command to clear the screen from cursor position to
  * end of the screen.
  */


### PR DESCRIPTION
In panic mode, the function: z_shell_fprintf is expected to be called from an interrupt context. Therefore, the dedicated assert
cannot be checked in this case.

Fixes #38612
