### PR TITLE
logging: Cleaning references to tracing in logging

### DIFF
--- a/include/logging/log_msg2.h
+++ b/include/logging/log_msg2.h
@@ -42,7 +42,6 @@ typedef uint32_t log_timestamp_t;
  */
 
 #define Z_LOG_MSG2_LOG 0
-#define Z_LOG_MSG2_TRACE 1
 
 #define LOG_MSG2_GENERIC_HDR \
 	MPSC_PBUF_HDR;\
@@ -55,16 +54,6 @@ struct log_msg2_desc {
 	uint32_t package_len:10;
 	uint32_t data_len:12;
 	uint32_t reserved:1;
-};
-
-struct log_msg2_trace_hdr {
-	LOG_MSG2_GENERIC_HDR;
-	uint32_t evt_id:5;
-#if CONFIG_LOG_TRACE_SHORT_TIMESTAMP
-	uint32_t timestamp:24;
-#else
-	log_timestamp_t timestamp;
-#endif
 };
 
 union log_msg2_source {
@@ -93,15 +82,6 @@ struct log_msg2_hdr {
 #endif
 };
 
-struct log_msg2_trace {
-	struct log_msg2_trace_hdr hdr;
-};
-
-struct log_msg2_trace_ptr {
-	struct log_msg2_trace_hdr hdr;
-	void *ptr;
-};
-
 struct log_msg2 {
 	struct log_msg2_hdr hdr;
 	uint8_t data[];
@@ -114,8 +94,6 @@ struct log_msg2_generic_hdr {
 union log_msg2_generic {
 	union mpsc_pbuf_generic buf;
 	struct log_msg2_generic_hdr generic;
-	struct log_msg2_trace trace;
-	struct log_msg2_trace_ptr trace_ptr;
 	struct log_msg2 log;
 };
 
@@ -424,16 +402,6 @@ do { \
 			   _domain_id, _source, _level, _data, _dlen, \
 			   Z_LOG_STR(_level, __VA_ARGS__))
 
-#define Z_TRACING_LOG_HDR_INIT(name, id) \
-	struct log_msg2_trace name = { \
-		.hdr = { \
-			.type = Z_LOG_MSG2_TRACE, \
-			.valid = 1, \
-			.busy = 0, \
-			.evt_id = id, \
-		} \
-	}
-
 /** @brief Allocate log message.
  *
  * @param wlen Length in 32 bit words.
@@ -560,7 +528,6 @@ static inline uint32_t log_msg2_generic_get_wlen(const union mpsc_pbuf_generic *
 		return log_msg2_get_total_wlen(msg->hdr.desc);
 	}
 
-	/* trace TODO */
 	return 0;
 }
 

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -1174,35 +1174,6 @@ void z_log_msg2_init(void)
 	mpsc_pbuf_init(&log_buffer, &mpsc_config);
 }
 
-static uint32_t log_diff_timestamp(void)
-{
-	extern log_timestamp_get_t timestamp_func;
-
-	return timestamp_func();
-}
-
-void z_log_msg2_put_trace(struct log_msg2_trace trace)
-{
-	union log_msg2_generic generic = {
-		.trace = trace
-	};
-
-	trace.hdr.timestamp = IS_ENABLED(CONFIG_LOG_TRACE_SHORT_TIMESTAMP) ?
-				log_diff_timestamp() : timestamp_func();
-	mpsc_pbuf_put_word(&log_buffer, generic.buf);
-}
-
-void z_log_msg2_put_trace_ptr(struct log_msg2_trace trace, void *data)
-{
-	union log_msg2_generic generic = {
-		.trace = trace
-	};
-
-	trace.hdr.timestamp = IS_ENABLED(CONFIG_LOG_TRACE_SHORT_TIMESTAMP) ?
-				log_diff_timestamp() : timestamp_func();
-	mpsc_pbuf_put_word_ext(&log_buffer, generic.buf, data);
-}
-
 struct log_msg2 *z_log_msg2_alloc(uint32_t wlen)
 {
 	return (struct log_msg2 *)mpsc_pbuf_alloc(&log_buffer, wlen,

--- a/tests/subsys/logging/log_msg2/src/main.c
+++ b/tests/subsys/logging/log_msg2/src/main.c
@@ -568,40 +568,6 @@ void test_saturate(void)
 	zassert_equal(msg, NULL, "Expected no pending messages");
 }
 
-#define TRACE_ID1 (1)
-#define TRACE_ID2 (31)
-void test_log_msg2_put_trace(void)
-{
-	union log_msg2_generic *msg;
-
-	Z_TRACING_LOG_HDR_INIT(trace, TRACE_ID1);
-
-	test_init();
-	z_log_msg2_put_trace(trace);
-	msg = z_log_msg2_claim();
-	zassert_true(msg, "Unexpected null message");
-	zassert_equal(msg->generic.type, Z_LOG_MSG2_TRACE, "Unexpected type");
-	zassert_equal(msg->trace.hdr.evt_id, TRACE_ID1, "Unexpected ID");
-	z_log_msg2_free(msg);
-}
-
-#define SIZE_OF_TRACE_DATA (10)
-void test_log_msg2_put_trace_ptr(void)
-{
-	uint32_t trace_data = 0x1234;
-	union log_msg2_generic *msg;
-
-	Z_TRACING_LOG_HDR_INIT(trace, TRACE_ID2);
-
-	test_init();
-	z_log_msg2_put_trace_ptr(trace, (void *)&trace_data);
-	msg = z_log_msg2_claim();
-	zassert_true(msg, "Unexpected null message");
-	zassert_equal(msg->generic.type, Z_LOG_MSG2_TRACE, "Unexpected type");
-	zassert_equal(msg->trace.hdr.evt_id, TRACE_ID2, "Unexpected ID");
-	z_log_msg2_free(msg);
-}
-
 /*test case main entry*/
 void test_main(void)
 {
@@ -615,9 +581,7 @@ void test_main(void)
 		ztest_unit_test(test_mode_size_data_only),
 		ztest_unit_test(test_mode_size_plain_str_data),
 		ztest_unit_test(test_mode_size_str_with_2strings),
-		ztest_unit_test(test_saturate),
-		ztest_unit_test(test_log_msg2_put_trace),
-		ztest_unit_test(test_log_msg2_put_trace_ptr)
+		ztest_unit_test(test_saturate)
 		);
 	ztest_run_test_suite(test_log_msg2);
 }


### PR DESCRIPTION
There were some leftovers in logging after attempt to use
logging as tracing backend. Removing all references since it
lead to test compilation failures.

It fixes currently broken CI.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>