### PR TITLE
tests: kernel: sched: schedule_api: enlarge timeslice criterion

### DIFF
--- a/tests/kernel/sched/schedule_api/src/test_slice_scheduling.c
+++ b/tests/kernel/sched/schedule_api/src/test_slice_scheduling.c
@@ -41,8 +41,8 @@ static void thread_tslice(void *p1, void *p2, void *p3)
 	int thread_parameter = (idx == (NUM_THREAD - 1)) ? '\n' :
 			       (idx + 'A');
 
-	int64_t expected_slice_min = k_ticks_to_ms_floor64(k_ms_to_ticks_ceil32(SLICE_SIZE));
-	int64_t expected_slice_max = k_ticks_to_ms_floor64(k_ms_to_ticks_ceil32(SLICE_SIZE) + 1);
+	int64_t expected_slice_min = k_ticks_to_ms_floor64(k_ms_to_ticks_ceil32(SLICE_SIZE) - 1);
+	int64_t expected_slice_max = k_ticks_to_ms_ceil64(k_ms_to_ticks_ceil32(SLICE_SIZE) + 1);
 
 	/* Clumsy, but need to handle the precision loss with
 	 * submillisecond ticks.  It's always possible to alias and


### PR DESCRIPTION
tests: kernel: sched: schedule_api: enlarge timeslice  #criterion

From time to time, measured slice time is one less/more than requested.
Fixes #35793
