### PR TITLE
Bluetooth: common: Add build asserts for address struct sizes

### DIFF
--- a/include/bluetooth/addr.h
+++ b/include/bluetooth/addr.h
@@ -30,10 +30,17 @@ extern "C" {
 #define BT_ADDR_LE_PUBLIC_ID    0x02
 #define BT_ADDR_LE_RANDOM_ID    0x03
 
+/** Length in bytes of a standard Bluetooth address */
+#define BT_ADDR_SIZE 6
+
 /** Bluetooth Device Address */
 typedef struct {
-	uint8_t  val[6];
+	uint8_t  val[BT_ADDR_SIZE];
 } bt_addr_t;
+/**/
+
+/** Length in bytes of an LE Bluetooth address. Not packed, so no sizeof() */
+#define BT_ADDR_LE_SIZE 7
 
 /** Bluetooth LE Device Address */
 typedef struct {

--- a/subsys/bluetooth/common/dummy.c
+++ b/subsys/bluetooth/common/dummy.c
@@ -10,6 +10,17 @@
  */
 
 #include <zephyr.h>
+#include <bluetooth/bluetooth.h>
+
+/*
+ * The unpacked structs below are used inside __packed structures that reflect
+ * what goes on the wire. While alignment is not a problem for those, since all
+ * their members are bytes or byte arrays, the size is. They must not be padded
+ * by the compiler, otherwise the on-wire packet will not map the packed
+ * structure correctly.
+ */
+BUILD_ASSERT(sizeof(bt_addr_t) == BT_ADDR_SIZE);
+BUILD_ASSERT(sizeof(bt_addr_le_t) == BT_ADDR_LE_SIZE);
 
 #if defined(CONFIG_BT_HCI_HOST)
 /* The Bluetooth subsystem requires the Tx thread to execute at higher priority


### PR DESCRIPTION
In some HCI packed structures we place non-packed structs inside.
Alignment is not an issue for those, but size is. If the compiler ever
packs those it would become a real problem, and so detect this at build
time.
See the link below for more info:
https://stackoverflow.com/a/66389167

Also see this comment here:
https://github.com/zephyrproject-rtos/zephyr/issues/16587#issuecomment-930116330
