### PR TITLE
soc: esp32: update clock configuration calls

### DIFF
--- a/drivers/clock_control/clock_control_esp32.c
+++ b/drivers/clock_control/clock_control_esp32.c
@@ -84,15 +84,6 @@ static void esp_clk_bbpll_enable(void)
 	REGI2C_WRITE(I2C_BBPLL, I2C_BBPLL_BBADC_CAL_7_0, BBPLL_BBADC_CAL_7_0_VAL);
 }
 
-void IRAM_ATTR ets_update_cpu_frequency(uint32_t ticks_per_us)
-{
-	/* Update scale factors used by ets_delay_us */
-	esp_rom_g_ticks_per_us_pro = ticks_per_us;
-#if defined(CONFIG_SMP)
-	esp_rom_g_ticks_per_us_app = ticks_per_us;
-#endif
-}
-
 static void esp_clk_wait_for_slow_cycle(void)
 {
 	REG_CLR_BIT(TIMG_RTCCALICFG_REG(0), TIMG_RTC_CALI_START_CYCLING | TIMG_RTC_CALI_START);

--- a/drivers/clock_control/clock_control_esp32s2.c
+++ b/drivers/clock_control/clock_control_esp32s2.c
@@ -60,12 +60,6 @@ static void esp_clk_bbpll_enable(void)
 				RTC_CNTL_BBPLL_FORCE_PD | RTC_CNTL_BBPLL_I2C_FORCE_PD);
 }
 
-void IRAM_ATTR ets_update_cpu_frequency(uint32_t ticks_per_us)
-{
-	/* Update scale factors used by ets_delay_us */
-	esp_rom_g_ticks_per_us_pro = ticks_per_us;
-}
-
 static int esp_clk_cpu_freq_to_pll_mhz(int cpu_freq_mhz)
 {
 	int dbias = DIG_DBIAS_80M_160M;

--- a/drivers/entropy/entropy_esp32.c
+++ b/drivers/entropy/entropy_esp32.c
@@ -7,20 +7,14 @@
 #define DT_DRV_COMPAT espressif_esp32_trng
 
 #include <string.h>
-#include <hal/cpu_hal.h>
-#include <esp_clk.h>
 #include <soc/rtc.h>
 #include <soc/wdev_reg.h>
 #include <soc/rtc_cntl_reg.h>
 #include <soc/apb_ctrl_reg.h>
 #include <esp_system.h>
 #include <soc.h>
+#include <hal/cpu_hal.h>
 #include <drivers/entropy.h>
-
-#ifdef CONFIG_SOC_ESP32
-#include <xtensa/core-macros.h>
-#include <soc/dport_reg.h>
-#endif
 
 static inline uint32_t entropy_esp32_get_u32(void)
 {

--- a/soc/riscv/esp32c3/soc.h
+++ b/soc/riscv/esp32c3/soc.h
@@ -12,6 +12,7 @@
 #include <rom/spi_flash.h>
 #include <zephyr/types.h>
 #include <stdbool.h>
+#include <esp_clk.h>
 #endif
 
 #include <arch/riscv/arch.h>

--- a/soc/xtensa/esp32/soc.h
+++ b/soc/xtensa/esp32/soc.h
@@ -16,6 +16,9 @@
 #include <stdbool.h>
 #include <arch/xtensa/arch.h>
 
+#include <xtensa/core-macros.h>
+#include <esp32/clk.h>
+
 static inline void esp32_set_mask32(uint32_t v, uint32_t mem_addr)
 {
 	sys_write32(sys_read32(mem_addr) | v, mem_addr);

--- a/soc/xtensa/esp32s2/soc.h
+++ b/soc/xtensa/esp32s2/soc.h
@@ -14,6 +14,7 @@
 #include <esp32s2/rom/ets_sys.h>
 #include <esp32s2/rom/spi_flash.h>
 #include <esp32s2/rom/cache.h>
+#include <esp_clk.h>
 
 #include <zephyr/types.h>
 #include <stdbool.h>


### PR DESCRIPTION
Removed duplicated calls in clock subsystems.
Move proper includes to soc specific.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>