### PR TITLE
wifi: esp_at: configurable scanning changes

### DIFF
--- a/drivers/wifi/esp_at/Kconfig.esp_at
+++ b/drivers/wifi/esp_at/Kconfig.esp_at
@@ -16,6 +16,21 @@ menuconfig WIFI_ESP_AT
 
 if WIFI_ESP_AT
 
+config WIFI_ESP_AT_SCAN_PASSIVE
+	bool "Passive scan"
+	help
+	  Use passive scanning.
+
+config WIFI_ESP_AT_SCAN_MAC_ADDRESS
+	bool "MAC address in scan response"
+	help
+	  Get mac address in scan response.
+
+config WIFI_ESP_AT_SCAN_RESULT_RSSI_ORDERED
+	bool "Scan result ordering based on RSSI"
+	help
+	  Order based on RSSI.
+
 config WIFI_ESP_AT_RX_STACK_SIZE
 	int "Stack size for the Espressif esp wifi driver RX thread"
 	default 1024

--- a/drivers/wifi/esp_at/esp.c
+++ b/drivers/wifi/esp_at/esp.c
@@ -253,6 +253,7 @@ MODEM_CMD_DEFINE(on_cmd_cipstamac)
 }
 
 /* +CWLAP:(sec,ssid,rssi,channel) */
+/* with: CONFIG_WIFI_ESP_AT_SCAN_MAC_ADDRESS: +CWLAP:<ecn>,<ssid>,<rssi>,<mac>,<ch>*/
 MODEM_CMD_DEFINE(on_cmd_cwlap)
 {
 	struct esp_data *dev = CONTAINER_OF(data, struct esp_data,
@@ -276,7 +277,18 @@ MODEM_CMD_DEFINE(on_cmd_cwlap)
 	memcpy(res.ssid, argv[1], i);
 	res.ssid_length = i;
 	res.rssi = strtol(argv[2], NULL, 10);
-	res.channel = strtol(argv[3], NULL, 10);
+
+	if (IS_ENABLED(CONFIG_WIFI_ESP_AT_SCAN_MAC_ADDRESS)) {
+		argv[3] = str_unquote(argv[3]);
+		res.mac_length = WIFI_MAC_ADDR_LEN;
+		if (net_bytes_from_str(res.mac, sizeof(res.mac), argv[3]) < 0) {
+			LOG_ERR("Invalid MAC address");
+			res.mac_length = 0;
+		}
+		res.channel = (argc > 4) ? strtol(argv[4], NULL, 10) : -1;
+	} else {
+		res.channel = strtol(argv[3], NULL, 10);
+	}
 
 	if (dev->scan_cb) {
 		dev->scan_cb(dev->net_iface, 0, &res);
@@ -717,7 +729,11 @@ static void esp_mgmt_scan_work(struct k_work *work)
 	struct esp_data *dev;
 	int ret;
 	static const struct modem_cmd cmds[] = {
+#if defined(CONFIG_WIFI_ESP_AT_SCAN_MAC_ADDRESS)
+		MODEM_CMD("+CWLAP:", on_cmd_cwlap, 5U, ","),
+#else
 		MODEM_CMD("+CWLAP:", on_cmd_cwlap, 4U, ","),
+#endif
 	};
 
 	dev = CONTAINER_OF(work, struct esp_data, scan_work);
@@ -726,9 +742,13 @@ static void esp_mgmt_scan_work(struct k_work *work)
 	if (ret < 0) {
 		goto out;
 	}
-	ret = esp_cmd_send(dev, cmds, ARRAY_SIZE(cmds), "AT+CWLAP",
+	ret = esp_cmd_send(dev,
+			   cmds, ARRAY_SIZE(cmds),
+			   ESP_CMD_CWLAP,
 			   ESP_SCAN_TIMEOUT);
 	esp_mode_flags_clear(dev, EDF_STA_LOCK);
+	LOG_DBG("ESP Wi-Fi scan: cmd = %s", ESP_CMD_CWLAP);
+
 	if (ret < 0) {
 		LOG_ERR("Failed to scan: ret %d", ret);
 	}
@@ -925,8 +945,11 @@ static void esp_init_work(struct k_work *work)
 #endif
 		/* enable multiple socket support */
 		SETUP_CMD_NOHANDLE("AT+CIPMUX=1"),
-		/* only need ecn,ssid,rssi,channel */
-		SETUP_CMD_NOHANDLE("AT+CWLAPOPT=0,23"),
+
+		SETUP_CMD_NOHANDLE(
+			ESP_CMD_CWLAPOPT(ESP_CMD_CWLAPOPT_ORDERED, ESP_CMD_CWLAPOPT_MASK)),
+		SETUP_CMD_NOHANDLE(ESP_CMD_CWLAP),
+
 #if defined(CONFIG_WIFI_ESP_AT_VERSION_2_0)
 		SETUP_CMD_NOHANDLE(ESP_CMD_CWMODE(STA)),
 		SETUP_CMD_NOHANDLE("AT+CWAUTOCONN=0"),

--- a/drivers/wifi/esp_at/esp.h
+++ b/drivers/wifi/esp_at/esp.h
@@ -131,6 +131,28 @@ extern "C" {
 #define ESP_CMD_SET_IP(ip, gateway, mask) "AT+"_CIPSTA"=\"" \
 			  ip "\",\""  gateway  "\",\""  mask "\""
 
+#if defined(CONFIG_WIFI_ESP_AT_SCAN_PASSIVE)
+#define ESP_CMD_CWLAP "AT+CWLAP=,,,1,,"
+#else
+#define ESP_CMD_CWLAP "AT+CWLAP"
+#endif
+
+#if defined(CONFIG_WIFI_ESP_AT_SCAN_RESULT_RSSI_ORDERED)
+#define ESP_CMD_CWLAPOPT_ORDERED "1"
+#else
+#define ESP_CMD_CWLAPOPT_ORDERED "0"
+#endif
+
+#if defined(CONFIG_WIFI_ESP_AT_SCAN_MAC_ADDRESS)
+/* We need ecn,ssid,rssi,mac,channel */
+#define ESP_CMD_CWLAPOPT_MASK "31"
+#else
+/* no mac: only need ecn,ssid,rssi,channel */
+#define ESP_CMD_CWLAPOPT_MASK "23"
+#endif
+
+#define ESP_CMD_CWLAPOPT(sort, mask) "AT+CWLAPOPT=" sort "," mask
+
 extern struct esp_data esp_driver_data;
 
 enum esp_socket_flags {

--- a/include/net/wifi.h
+++ b/include/net/wifi.h
@@ -19,6 +19,7 @@ enum wifi_security_type {
 
 #define WIFI_SSID_MAX_LEN 32
 #define WIFI_PSK_MAX_LEN 64
+#define WIFI_MAC_ADDR_LEN 6
 
 #define WIFI_CHANNEL_MAX 14
 #define WIFI_CHANNEL_ANY 255

--- a/include/net/wifi_mgmt.h
+++ b/include/net/wifi_mgmt.h
@@ -91,6 +91,9 @@ struct wifi_scan_result {
 	uint8_t channel;
 	enum wifi_security_type security;
 	int8_t rssi;
+
+	uint8_t mac[WIFI_MAC_ADDR_LEN];
+	uint8_t mac_length;
 };
 
 struct wifi_connect_req_params {

--- a/subsys/net/l2/wifi/CMakeLists.txt
+++ b/subsys/net/l2/wifi/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library()
+zephyr_library_include_directories(${ZEPHYR_BASE}/subsys/net/ip)
 zephyr_library_compile_definitions_ifdef(
   CONFIG_NEWLIB_LIBC __LINUX_ERRNO_EXTENSIONS__
   )

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -22,6 +22,8 @@ LOG_MODULE_REGISTER(net_wifi_shell, LOG_LEVEL_INF);
 #include <net/wifi_mgmt.h>
 #include <net/net_event.h>
 
+#include "net_private.h"
+
 #define WIFI_SHELL_MODULE "wifi"
 
 #define WIFI_SHELL_MGMT_EVENTS (NET_EVENT_WIFI_SCAN_RESULT |		\
@@ -60,21 +62,22 @@ static void handle_wifi_scan_result(struct net_mgmt_event_callback *cb)
 {
 	const struct wifi_scan_result *entry =
 		(const struct wifi_scan_result *)cb->info;
+	uint8_t mac_string_buf[sizeof("xx:xx:xx:xx:xx:xx")];
 
 	scan_result++;
 
 	if (scan_result == 1U) {
 		print(context.shell, SHELL_NORMAL,
-		      "%-4s | %-32s %-5s | %-4s | %-4s | %-5s\n",
-		      "Num", "SSID", "(len)", "Chan", "RSSI", "Sec");
+		      "\n%-4s | %-32s %-5s | %-4s | %-4s | %-5s    | %s\n",
+		      "Num", "SSID", "(len)", "Chan", "RSSI", "Sec", "MAC");
 	}
 
-	print(context.shell, SHELL_NORMAL,
-	      "%-4d | %-32s %-5u | %-4u | %-4d | %-5s\n",
-	      scan_result, entry->ssid, entry->ssid_length,
-	      entry->channel, entry->rssi,
-	      (entry->security == WIFI_SECURITY_TYPE_PSK ?
-	       "WPA/WPA2" : "Open"));
+	print(context.shell, SHELL_NORMAL, "%-4d | %-32s %-5u | %-4u | %-4d | %-5s | %s\n",
+	      scan_result, entry->ssid, entry->ssid_length, entry->channel, entry->rssi,
+	      (entry->security == WIFI_SECURITY_TYPE_PSK ? "WPA/WPA2" : "Open    "),
+	      ((entry->mac_length) ?
+		      net_sprint_ll_addr_buf(entry->mac, WIFI_MAC_ADDR_LEN, mac_string_buf,
+					     sizeof(mac_string_buf)) : ""));
 }
 
 static void handle_wifi_scan_done(struct net_mgmt_event_callback *cb)


### PR DESCRIPTION
This PR adds:
- drivers: esp_at: options to have more information in scanning result and possibility to have passive scanning.
Default scanning still as now but can be configured:
If CONFIG_WIFI_ESP_AT_SCAN_MAC_ADDRESS: mac addresses included in scanning results.
If CONFIG_WIFI_ESP_AT_SCAN_PASSIVE: passive scanning is used instead of default active scanning.
If CONFIG_WIFI_ESP_AT_SCAN_RESULT_RSSI_ORDERED: scanning response ordered by RSSI.
- wifi shell: printing MAC address if available.