### PR TITLE
doc: release: 2.7: add release notes for PCI/PCIe

### DIFF
--- a/doc/releases/release-notes-2.7.rst
+++ b/doc/releases/release-notes-2.7.rst
@@ -333,6 +333,11 @@ Drivers and Sensors
 
   * Added gsm_ppp devicetree support
 
+* PCI/PCIe
+
+  * Fixed an issue that MSI-X was used even though it is not available.
+  * Improved MBAR retrieval for MSI-X.
+  * Added ability to retrieve extended PCI/PCIe capabilities.
 
 * Pinmux
 


### PR DESCRIPTION
Add release notes for PCI/PCIe based on commit history.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>