### PR TITLE
uart: ns16550: add parity support

### DIFF
--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -431,8 +431,11 @@ static int uart_ns16550_configure(const struct device *dev,
 	case UART_CFG_PARITY_NONE:
 		uart_cfg.parity = LCR_PDIS;
 		break;
+	case UART_CFG_PARITY_ODD:
+		uart_cfg.parity = LCR_PEN;
+		break;
 	case UART_CFG_PARITY_EVEN:
-		uart_cfg.parity = LCR_EPS;
+		uart_cfg.parity = LCR_PEN | LCR_EPS;
 		break;
 	default:
 		ret = -ENOTSUP;


### PR DESCRIPTION
In the driver for the National Semiconductor uart chip number 16550, the LCR_PEN bit meant to enable parity is never being set.  Furthermore, the odd parity setting (UART_CFG_PARITY_ODD) was not listed, which would result in any attempts at using that setting return error unsupported.
Both even and odd parity are supported by the device.  The driver just needs to properly set the enable bit so that the full functionality of the uart chip can be taken advantage of.
The fix to the currently nonfunctional even parity requires setting the enable bit along with the even parity bit.  Enabling odd parity requires setting the enable bit while not setting the even parity bit (which leaves it on odd parity).