### PR TITLE
drivers: gpio: nrf: Remove CONFIG_GPIO_NRF_P0 and CONFIG_GPIO_NRF_P1

### DIFF
--- a/boards/shields/sparkfun_sara_r4/Kconfig.defconfig
+++ b/boards/shields/sparkfun_sara_r4/Kconfig.defconfig
@@ -35,8 +35,6 @@ config NET_IPV6
 config NET_CONFIG_NEED_IPV6
 	default n
 
-rsource "boards/*.defconfig"
-
 endif # NETWORKING
 
 endif # SHIELD_SPARKFUN_SARA_R4

--- a/boards/shields/sparkfun_sara_r4/boards/nrf52840dk_nrf52840.defconfig
+++ b/boards/shields/sparkfun_sara_r4/boards/nrf52840dk_nrf52840.defconfig
@@ -1,9 +1,0 @@
-# Copyright (c) 2019 Linaro Limited
-# SPDX-License-Identifier: Apache-2.0
-
-if BOARD_NRF52840DK_NRF52840
-
-config GPIO_NRF_P1
-	default y
-
-endif # BOARD_NRF52840DK_NRF52840

--- a/boards/shields/wnc_m14a2a/Kconfig.defconfig
+++ b/boards/shields/wnc_m14a2a/Kconfig.defconfig
@@ -28,8 +28,6 @@ config NET_IPV6
 config NET_CONFIG_NEED_IPV6
 	default n
 
-rsource "boards/*.defconfig"
-
 endif # NETWORKING
 
 endif # SHIELD_WNC_M14A2A

--- a/boards/shields/wnc_m14a2a/boards/nrf52840dk_nrf52840.defconfig
+++ b/boards/shields/wnc_m14a2a/boards/nrf52840dk_nrf52840.defconfig
@@ -1,9 +1,0 @@
-# Copyright (c) 2019 Linaro Limited
-# SPDX-License-Identifier: Apache-2.0
-
-if BOARD_NRF52840DK_NRF52840
-
-config GPIO_NRF_P1
-	default y
-
-endif # BOARD_NRF52840DK_NRF52840

--- a/drivers/gpio/Kconfig.nrfx
+++ b/drivers/gpio/Kconfig.nrfx
@@ -17,20 +17,6 @@ config GPIO_NRF_INIT_PRIORITY
 	help
 	  Initialization priority for nRF GPIO.
 
-config GPIO_NRF_P0
-	bool "nRF GPIO Port P0"
-	depends on HAS_HW_NRF_GPIO0
-	default y
-	help
-	  Enable nRF GPIO port P0 config options.
-
-config GPIO_NRF_P1
-	bool "nRF GPIO Port P1"
-	depends on HAS_HW_NRF_GPIO1
-	default y
-	help
-	  Enable nRF GPIO port P1 config options.
-
 choice
 	prompt "nRF GPIO edge interrupts mechanism"
 	default GPIO_NRF_INT_EDGE_USING_GPIOTE

--- a/drivers/gpio/gpio_nrfx.c
+++ b/drivers/gpio/gpio_nrfx.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT nordic_nrf_gpio
+
 #include <drivers/gpio.h>
 #include <hal/nrf_gpio.h>
 #include <hal/nrf_gpiote.h>
@@ -16,8 +18,6 @@
 #error "GPIO LATCH is required by edge interrupts using GPIO SENSE," \
 	"but it is not supported by the platform."
 #endif
-
-#define GPIO(id) DT_NODELABEL(gpio##id)
 
 struct gpio_nrfx_data {
 	/* gpio_driver_data needs to be first */
@@ -492,16 +492,13 @@ static void gpiote_event_handler(void)
 						 NRF_GPIOTE_EVENT_PORT);
 
 	if (port_event) {
-#ifdef CONFIG_GPIO_NRF_P0
-		fired_triggers[0] =
-			check_level_trigger_pins(DEVICE_DT_GET(GPIO(0)),
-						 &sense_levels[0]);
-#endif
-#ifdef CONFIG_GPIO_NRF_P1
-		fired_triggers[1] =
-			check_level_trigger_pins(DEVICE_DT_GET(GPIO(1)),
-						 &sense_levels[1]);
-#endif
+		#define GPIO_NRF_GET_TRIGGERS(i) \
+			fired_triggers[DT_INST_PROP(i, port)] = \
+				check_level_trigger_pins(DEVICE_DT_INST_GET(i), \
+							 &sense_levels[DT_INST_PROP(i, port)]);
+
+		DT_INST_FOREACH_STATUS_OKAY(GPIO_NRF_GET_TRIGGERS)
+		#undef GPIO_NRF_GET_TRIGGERS
 
 		/* Sense detect was disabled while checking pins so
 		 * DETECT should be deasserted.
@@ -530,37 +527,34 @@ static void gpiote_event_handler(void)
 		 * This may cause DETECT to be re-asserted if pin state has
 		 * already changed to the newly configured sense level.
 		 */
-#ifdef CONFIG_GPIO_NRF_P0
-		cfg_edge_sense_pins(DEVICE_DT_GET(GPIO(0)), sense_levels[0]);
-#endif
-#ifdef CONFIG_GPIO_NRF_P1
-		cfg_edge_sense_pins(DEVICE_DT_GET(GPIO(1)), sense_levels[1]);
-#endif
+		#define GPIO_NRF_CFG_EDGE_SENSE_PINS(i) \
+		   cfg_edge_sense_pins(DEVICE_DT_INST_GET(i), \
+				       sense_levels[DT_INST_PROP(i, port)]);
+
+		DT_INST_FOREACH_STATUS_OKAY(GPIO_NRF_CFG_EDGE_SENSE_PINS)
+		#undef GPIO_NRF_CFG_EDGE_SENSE_PINS
 	}
 
-#ifdef CONFIG_GPIO_NRF_P0
-	if (fired_triggers[0]) {
-		fire_callbacks(DEVICE_DT_GET(GPIO(0)), fired_triggers[0]);
-	}
-#endif
-#ifdef CONFIG_GPIO_NRF_P1
-	if (fired_triggers[1]) {
-		fire_callbacks(DEVICE_DT_GET(GPIO(1)), fired_triggers[1]);
-	}
-#endif
+	#define GPIO_NRF_FIRE_CALLBACKS(i) \
+		if (fired_triggers[DT_INST_PROP(i, port)]) { \
+			fire_callbacks(DEVICE_DT_INST_GET(i), \
+				       fired_triggers[DT_INST_PROP(i, port)]); \
+		}
+
+	DT_INST_FOREACH_STATUS_OKAY(GPIO_NRF_FIRE_CALLBACKS)
+	#undef GPIO_NRF_FIRE_CALLBACKS
 
 	if (port_event) {
 		/* Reprogram sense to match current configuration.
 		 * This may cause DETECT to be re-asserted.
 		 */
-#ifdef CONFIG_GPIO_NRF_P0
-		cfg_level_pins(DEVICE_DT_GET(GPIO(0)));
-#endif
-#ifdef CONFIG_GPIO_NRF_P1
-		cfg_level_pins(DEVICE_DT_GET(GPIO(1)));
-#endif
+		#define GPIO_NRF_CFG_LEVEL_PINS(i) cfg_level_pins(DEVICE_DT_INST_GET(i));
+
+		DT_INST_FOREACH_STATUS_OKAY(GPIO_NRF_CFG_LEVEL_PINS)
+		#undef GPIO_NRF_CFG_LEVEL_PINS
 	}
 }
+
 
 #define GPIOTE_NODE DT_INST(0, nordic_nrf_gpiote)
 
@@ -590,26 +584,20 @@ static int gpio_nrfx_init(const struct device *port)
 	static const struct gpio_nrfx_cfg gpio_nrfx_p##id##_cfg = {	\
 		.common = {						\
 			.port_pin_mask =				\
-			GPIO_PORT_PIN_MASK_FROM_DT_NODE(GPIO(id)),	\
+			GPIO_PORT_PIN_MASK_FROM_DT_INST(id),		\
 		},							\
-		.port = NRF_P##id,					\
-		.port_num = id						\
+		.port = (NRF_GPIO_Type *)DT_INST_REG_ADDR(id),		\
+		.port_num = DT_INST_PROP(id, port)			\
 	};								\
 									\
 	static struct gpio_nrfx_data gpio_nrfx_p##id##_data;		\
 									\
-	DEVICE_DT_DEFINE(GPIO(id), gpio_nrfx_init,			\
+	DEVICE_DT_INST_DEFINE(id, gpio_nrfx_init,			\
 			 NULL,						\
 			 &gpio_nrfx_p##id##_data,			\
 			 &gpio_nrfx_p##id##_cfg,			\
 			 POST_KERNEL,					\
-			 CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,		\
-			 &gpio_nrfx_drv_api_funcs)
+			 CONFIG_GPIO_NRF_INIT_PRIORITY,			\
+			 &gpio_nrfx_drv_api_funcs);
 
-#ifdef CONFIG_GPIO_NRF_P0
-GPIO_NRF_DEVICE(0);
-#endif
-
-#ifdef CONFIG_GPIO_NRF_P1
-GPIO_NRF_DEVICE(1);
-#endif
+DT_INST_FOREACH_STATUS_OKAY(GPIO_NRF_DEVICE)


### PR DESCRIPTION
Remove Kconfig options for enabling device instances in favor of
taking that information only from device tree. Prior to that
change there was a mix of devicetree and Kconfig.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>