### PR TITLE
boards: arm: nxp: mimxrt1024_evk: enable dma driver

### DIFF
--- a/boards/arm/mimxrt1024_evk/doc/index.rst
+++ b/boards/arm/mimxrt1024_evk/doc/index.rst
@@ -93,6 +93,8 @@ features:
 +-----------+------------+-------------------------------------+
 | HWINFO    | on-chip    | reset cause                         |
 +-----------+------------+-------------------------------------+
+| DMA       | on-chip    | dma                                 |
++-----------+------------+-------------------------------------+
 
 The default configuration can be found in the defconfig file:
 ``boards/arm/mimxrt1024_evk/mimxrt1024_evk_defconfig``

--- a/boards/arm/mimxrt1024_evk/mimxrt1024_evk.dts
+++ b/boards/arm/mimxrt1024_evk/mimxrt1024_evk.dts
@@ -112,3 +112,7 @@
 		label = "FXOS8700";
 	};
 };
+
+&edma0 {
+	status = "okay";
+};

--- a/boards/arm/mimxrt1024_evk/mimxrt1024_evk.yaml
+++ b/boards/arm/mimxrt1024_evk/mimxrt1024_evk.yaml
@@ -16,6 +16,7 @@ ram: 32768
 flash: 4096
 supported:
   - can
+  - dma
   - hwinfo
   - netif:eth
   - watchdog


### PR DESCRIPTION
Enable the dma driver on the mimxrt1024_evk board.

Tested with:
 - tests/drivers/dma/chan_blen_transfer
 - tests/drivers/dma/chan_link_transfer
 - tests/drivers/dma/loop_transfer

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>