### PR TITLE
fs: allow to configure per-alloaction heap overhead

### DIFF
--- a/subsys/fs/Kconfig.littlefs
+++ b/subsys/fs/Kconfig.littlefs
@@ -89,4 +89,19 @@ config FS_LITTLEFS_FC_HEAP_SIZE
 	  support up to FS_LITTLE_FS_NUM_FILES blocks of
 	  FS_LITTLEFS_CACHE_SIZE bytes.
 
+if FS_LITTLEFS_FC_HEAP_SIZE <= 0
+
+config FS_LITTLEFS_HEAP_PER_ALLOC_OVERHEAD_SIZE
+	int "Size of per-allocation overhead for littleFS heap in bytes"
+	default 32
+	help
+	  In case when total size of littleFS heap is automatically calculated
+	  we need to take into account overhead caused per block allocation.
+	  For the purpose of heap size calculation the size of each cache block
+	  will be increased by this value.
+	  NOTE: when your app fails to open pre-defined number of files, as set
+	  by FS_LITTLEFS_NUM_FILES, try to increase the value.
+
+endif # FS_LITTLEFS_FC_HEAP_SIZE <= 0
+
 endif # FILE_SYSTEM_LITTLEFS

--- a/subsys/fs/littlefs_fs.c
+++ b/subsys/fs/littlefs_fs.c
@@ -41,10 +41,13 @@ static K_MEM_SLAB_DEFINE(lfs_dir_pool, sizeof(struct lfs_dir),
  * the filecache heap.  This relates to the CHUNK_UNIT parameter in
  * the heap implementation, but that value is not visible outside the
  * kernel.
+ * FIXME: value for this macro should be rather taken from the Kernel
+ * internals than set by user, but we do not have a way to do so now.
  */
-#define FC_HEAP_PER_ALLOC_OVERHEAD 24U
+#define FC_HEAP_PER_ALLOC_OVERHEAD CONFIG_FS_LITTLEFS_HEAP_PER_ALLOC_OVERHEAD_SIZE
 
 #if (CONFIG_FS_LITTLEFS_FC_HEAP_SIZE - 0) <= 0
+BUILD_ASSERT((CONFIG_FS_LITTLEFS_HEAP_PER_ALLOC_OVERHEAD_SIZE % 8) == 0);
 /* Auto-generate heap size from cache size and number of files */
 #undef CONFIG_FS_LITTLEFS_FC_HEAP_SIZE
 #define CONFIG_FS_LITTLEFS_FC_HEAP_SIZE						\


### PR DESCRIPTION
The size of overhead for each heap allocation can change after
heap implementation change and such change impacts automatic
calculation of heap size for littleFS.
This patch allows per-alloaction overhead to be configurable and then
This is a temporary fix (work around) until per-alloaction overhead value
will be available from kernel internals.

Fixes #36962

Signed-off-by: Artur Lipowski <Artur.Lipowski@hidglobal.com>