### PR TITLE
doc: Add missing description for deadline scheduling

### DIFF
--- a/doc/reference/kernel/scheduling/index.rst
+++ b/doc/reference/kernel/scheduling/index.rst
@@ -39,6 +39,15 @@ The kernel's scheduler selects the highest priority ready thread
 to be the current thread. When multiple ready threads of the same priority
 exist, the scheduler chooses the one that has been waiting longest.
 
+A thread's relative priority is primarily determined by its static priority.
+However, when both earliest-deadline-first scheduling is enabled
+(:kconfig:`CONFIG_SCHED_DEADLINE`) and a choice of threads have equal
+static priority, then the thread with the earlier deadline is considered
+to have the higher priority. Thus, when earliest-deadline-first scheduling is
+enabled, two threads are only considered to have the same priority when both
+their static priorities and deadlines are equal. The routine
+:c:func:`k_thread_deadline_set` is used to set a thread's deadline.
+
 .. note::
     Execution of ISRs takes precedence over thread execution,
     so the execution of the current thread may be replaced by an ISR

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -743,7 +743,7 @@ __syscall void k_thread_priority_set(k_tid_t thread, int prio);
  * integers.  The number of cycles between the "first" deadline in the
  * scheduler queue and the "last" deadline must be less than 2^31 (i.e
  * a signed non-negative quantity).  Failure to adhere to this rule
- * may result in scheduled threads running in an incorrect dealine
+ * may result in scheduled threads running in an incorrect deadline
  * order.
  *
  * @note Despite the API naming, the scheduler makes no guarantees the


### PR DESCRIPTION
doc: Add deadline scheduling information

Adds information to the kernel scheduling documentation explaining
how a thread's deadline is used to determine the thread's relative
priority.


Fixes #36770