### PR TITLE
cmake: CMake compile features support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,21 +168,29 @@ if(CONFIG_CPLUSPLUS)
   # Kconfig choice ensures only one of these CONFIG_STD_CPP* is set.
   if(CONFIG_STD_CPP98)
     set(STD_CPP_DIALECT_FLAGS $<TARGET_PROPERTY:compiler-cpp,dialect_cpp98>)
+    list(APPEND CMAKE_CXX_COMPILE_FEATURES ${compile_features_cpp98})
   elseif(CONFIG_STD_CPP11)
     set(STD_CPP_DIALECT_FLAGS $<TARGET_PROPERTY:compiler-cpp,dialect_cpp11>) # Default in kconfig
+    list(APPEND CMAKE_CXX_COMPILE_FEATURES ${compile_features_cpp11})
   elseif(CONFIG_STD_CPP14)
     set(STD_CPP_DIALECT_FLAGS $<TARGET_PROPERTY:compiler-cpp,dialect_cpp14>)
+    list(APPEND CMAKE_CXX_COMPILE_FEATURES ${compile_features_cpp14})
   elseif(CONFIG_STD_CPP17)
     set(STD_CPP_DIALECT_FLAGS $<TARGET_PROPERTY:compiler-cpp,dialect_cpp17>)
+    list(APPEND CMAKE_CXX_COMPILE_FEATURES ${compile_features_cpp17})
   elseif(CONFIG_STD_CPP2A)
     set(STD_CPP_DIALECT_FLAGS $<TARGET_PROPERTY:compiler-cpp,dialect_cpp2a>)
+    list(APPEND CMAKE_CXX_COMPILE_FEATURES ${compile_features_cpp20})
   elseif(CONFIG_STD_CPP20)
     set(STD_CPP_DIALECT_FLAGS $<TARGET_PROPERTY:compiler-cpp,dialect_cpp20>)
+    list(APPEND CMAKE_CXX_COMPILE_FEATURES ${compile_features_cpp20})
   elseif(CONFIG_STD_CPP2B)
     set(STD_CPP_DIALECT_FLAGS $<TARGET_PROPERTY:compiler-cpp,dialect_cpp2b>)
+    list(APPEND CMAKE_CXX_COMPILE_FEATURES ${compile_features_cpp20})
   else()
     assert(0 "Unreachable code. Expected C++ standard to have been chosen. See Kconfig.zephyr.")
   endif()
+  set(CMAKE_CXX_COMPILE_FEATURES ${CMAKE_CXX_COMPILE_FEATURES} PARENT_SCOPE)
 
   zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:${STD_CPP_DIALECT_FLAGS}>)
 endif()
@@ -979,6 +987,7 @@ set_ifndef(CSTD c99)
 zephyr_compile_options(
   $<$<COMPILE_LANGUAGE:C>:$<TARGET_PROPERTY:compiler,cstd>${CSTD}>
 )
+set(CMAKE_C_COMPILE_FEATURES ${compile_features_${CSTD}} PARENT_SCOPE)
 
 # @Intent: Configure linker scripts, i.e. generate linker scripts with variables substituted
 toolchain_ld_configure_files()

--- a/cmake/compiler/compiler_features.cmake
+++ b/cmake/compiler/compiler_features.cmake
@@ -1,0 +1,26 @@
+set(c23id c2x gnu2x)
+set(c17id c17 c18 gnu17 gnu18 "iso9899:2017" "iso9899:2018")
+set(c11id c11 gnu11 "iso9899:2011")
+set(c99id c99 gnu99 "iso9899:1999")
+set(c90id c89 c90 gnu89 gnu90 "iso9899:1990" "iso9899:199409")
+
+set(compile_features_list)
+
+# For each id value above a compile_features_${idval} with a list of supported
+# `c_std_XX` values are created for easy lookup.
+# For example, the settings
+# - `compile_feature_c99` will contain `c_std_90;c_std_99`
+# - `compile_feature_iso9899:2011` will contain `c_std_90;c_std_99;c_std_11`
+# that can then be used to set CMAKE_C_COMPILE_FEATURES accordingly.
+foreach(standard 90 99 11 17 23)
+  list(APPEND compile_features_list c_std_${standard})
+  foreach(id ${c${standard}id})
+    set(compile_features_${id} ${compile_features_list})
+  endforeach()
+endforeach()
+
+set(compile_features_cpp98 cxx_std_98)
+set(compile_features_cpp11 cxx_std_11 ${compile_features_cpp98})
+set(compile_features_cpp14 cxx_std_14 ${compile_features_cpp11})
+set(compile_features_cpp17 cxx_std_17 ${compile_features_cpp14})
+set(compile_features_cpp20 cxx_std_20 ${compile_features_cpp17})

--- a/cmake/target_toolchain_flags.cmake
+++ b/cmake/target_toolchain_flags.cmake
@@ -24,6 +24,11 @@ set(TOOLCHAIN_SIGNATURE ${CMAKE_C_COMPILER_MD5_SUM})
 string(MD5 COMPILER_SIGNATURE ${CMAKE_C_COMPILER}_${CMAKE_C_COMPILER_ID}_${CMAKE_C_COMPILER_VERSION})
 set(TOOLCHAIN_SIGNATURE ${TOOLCHAIN_SIGNATURE}_${COMPILER_SIGNATURE})
 
+# Load the compile features file which will provide compile features lists for
+# various C / CXX language dialects that can then be exported based on current
+# Zephyr Kconfig settings or the CSTD global property.
+include(${CMAKE_CURRENT_LIST_DIR}/compiler/compiler_features.cmake)
+
 # Loading of templates are strictly not needed as they does not set any
 # properties.
 # They purely provides an overview as well as a starting point for supporting


### PR DESCRIPTION
Fixes: #36558 #32577

This commit introduces CMAKE_C_COMPILE_FEATURES and
CMAKE_CXX_COMPILE_FEATURES.

This allows users to use the `target_compile_features()` in their own
code.

In Zephyr, the CMAKE_C/CXX_COMPILE_FEATURES are defined based on the
compiler and the Kconfig / CSTD setting.
Doing so ensures that a user compiling Zephyr with c99 and specifies
`target_compile_features(<target> ... c_std_11)` will get an error.
And similar if building Zephyr with C++ support and c++11, but testing
for `target_compile_features(<target> ... cxx_std_17)`.

For example in the C++ case, the user must ensure that Zephyr is
compiled with C++17, that is: CPLUSPLUS=y and STD_CPP17=y, in which case
the CMAKE_CXX_COMPILE_FEATURES will contain support for C++17 and thus
the `target_compile_features(<target> ... cxx_std_17)` will succeed.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>