### PR TITLE
Coding guideline fixes - Fix function prototypes re-definitions

### DIFF
--- a/drivers/console/uart_console.c
+++ b/drivers/console/uart_console.c
@@ -564,9 +564,6 @@ void uart_register_input(struct k_fifo *avail, struct k_fifo *lines,
 }
 
 #else
-#define console_input_init(x) \
-	do {    /* nothing */ \
-	} while ((0))
 #define uart_register_input(x) \
 	do {    /* nothing */  \
 	} while ((0))

--- a/drivers/console/uart_console.c
+++ b/drivers/console/uart_console.c
@@ -97,18 +97,10 @@ static int console_out(int c)
 
 #if defined(CONFIG_STDOUT_CONSOLE)
 extern void __stdout_hook_install(int (*hook)(int));
-#else
-#define __stdout_hook_install(x) \
-	do {    /* nothing */	 \
-	} while ((0))
 #endif
 
 #if defined(CONFIG_PRINTK)
 extern void __printk_hook_install(int (*fn)(int));
-#else
-#define __printk_hook_install(x) \
-	do {    /* nothing */	 \
-	} while ((0))
 #endif
 
 #if defined(CONFIG_CONSOLE_HANDLER)
@@ -564,9 +556,13 @@ void uart_register_input(struct k_fifo *avail, struct k_fifo *lines,
 }
 
 #else
-#define uart_register_input(x) \
-	do {    /* nothing */  \
-	} while ((0))
+void uart_register_input(struct k_fifo *avail, struct k_fifo *lines,
+			 uint8_t (*completion)(char *str, uint8_t len))
+{
+	ARG_UNUSED(avail);
+	ARG_UNUSED(lines);
+	ARG_UNUSED(completion);
+}
 #endif
 
 /**
@@ -578,8 +574,12 @@ void uart_register_input(struct k_fifo *avail, struct k_fifo *lines,
 
 static void uart_console_hook_install(void)
 {
+#if defined(CONFIG_STDOUT_CONSOLE)
 	__stdout_hook_install(console_out);
+#endif
+#if defined(CONFIG_PRINTK)
 	__printk_hook_install(console_out);
+#endif
 }
 
 /**

--- a/include/sys/kobject.h
+++ b/include/sys/kobject.h
@@ -134,52 +134,6 @@ struct z_object_assignment {
  * @param obj Address of the kernel object
  */
 void z_object_init(const void *obj);
-#else
-/* LCOV_EXCL_START */
-#define K_THREAD_ACCESS_GRANT(thread, ...)
-
-/**
- * @internal
- */
-static inline void z_object_init(const void *obj)
-{
-	ARG_UNUSED(obj);
-}
-
-/**
- * @internal
- */
-static inline void z_impl_k_object_access_grant(const void *object,
-						struct k_thread *thread)
-{
-	ARG_UNUSED(object);
-	ARG_UNUSED(thread);
-}
-
-/**
- * @internal
- */
-static inline void k_object_access_revoke(const void *object,
-					  struct k_thread *thread)
-{
-	ARG_UNUSED(object);
-	ARG_UNUSED(thread);
-}
-
-/**
- * @internal
- */
-static inline void z_impl_k_object_release(const void *object)
-{
-	ARG_UNUSED(object);
-}
-
-static inline void k_object_access_all_grant(const void *object)
-{
-	ARG_UNUSED(object);
-}
-/* LCOV_EXCL_STOP */
-#endif /* !CONFIG_USERSPACE */
 
 /**
  * Grant a thread access to a kernel object
@@ -236,6 +190,54 @@ __syscall void k_object_release(const void *object);
  */
 void k_object_access_all_grant(const void *object);
 
+#else
+/* LCOV_EXCL_START */
+#define K_THREAD_ACCESS_GRANT(thread, ...)
+
+/**
+ * @internal
+ */
+static inline void z_object_init(const void *obj)
+{
+	ARG_UNUSED(obj);
+}
+
+/**
+ * @internal
+ */
+static inline void z_impl_k_object_access_grant(const void *object,
+						struct k_thread *thread)
+{
+	ARG_UNUSED(object);
+	ARG_UNUSED(thread);
+}
+
+/**
+ * @internal
+ */
+static inline void k_object_access_revoke(const void *object,
+					  struct k_thread *thread)
+{
+	ARG_UNUSED(object);
+	ARG_UNUSED(thread);
+}
+
+/**
+ * @internal
+ */
+static inline void z_impl_k_object_release(const void *object)
+{
+	ARG_UNUSED(object);
+}
+
+static inline void k_object_access_all_grant(const void *object)
+{
+	ARG_UNUSED(object);
+}
+/* LCOV_EXCL_STOP */
+#endif /* !CONFIG_USERSPACE */
+
+#ifdef CONFIG_DYNAMIC_OBJECTS
 /**
  * Allocate a kernel object of a designated type
  *
@@ -252,7 +254,6 @@ void k_object_access_all_grant(const void *object);
  */
 __syscall void *k_object_alloc(enum k_objects otype);
 
-#ifdef CONFIG_DYNAMIC_OBJECTS
 /**
  * Allocate memory and install as a generic kernel object
  *
@@ -310,6 +311,7 @@ static inline struct z_object *z_dynamic_object_create(size_t size)
  */
 void k_object_free(void *obj);
 #else
+
 /* LCOV_EXCL_START */
 static inline void *z_impl_k_object_alloc(enum k_objects otype)
 {


### PR DESCRIPTION
Fix issues with functions being re-defined as macros.

Thanks for BUGSENG to spot these problems.