### PR TITLE
Revert "dts: bindings: vendor-prefixes: Add gigadevice prefix"

### DIFF
--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -226,7 +226,6 @@ gemei	Gemei Digital Technology Co., Ltd.
 geniatech	Geniatech, Inc.
 giantec	Giantec Semiconductor, Inc.
 giantplus	Giantplus Technology Co., Ltd.
-gigadevice	GigaDevice Semiconductor
 globalscale	Globalscale Technologies, Inc.
 globaltop	GlobalTop Technology, Inc.
 gmt	Global Mixed-mode Technology, Inc.


### PR DESCRIPTION
This reverts commit d3a558591f9aed96ed5324cd0dc973ecdee46f75.

We shouldn't be adding vendor prefixes for things we don't have
upstream bindings for unless we've inherited them from Linux.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>