### PR TITLE
soc: intel_adsp: Add app API for page-level memory management

### DIFF
--- a/soc/xtensa/intel_adsp/common/CMakeLists.txt
+++ b/soc/xtensa/intel_adsp/common/CMakeLists.txt
@@ -16,6 +16,8 @@ zephyr_library_sources(main_entry.S)
 zephyr_library_sources(soc.c)
 zephyr_library_sources(soc_mp.c)
 zephyr_library_sources(trace_out.c)
+zephyr_library_sources(mem_map.c)
+zephyr_library_sources(adsp_mem.c)
 
 zephyr_library_link_libraries(INTEL_ADSP_COMMON)
 

--- a/soc/xtensa/intel_adsp/common/adsp_mem.c
+++ b/soc/xtensa/intel_adsp/common/adsp_mem.c
@@ -1,0 +1,224 @@
+/* Copyright (c) 2021 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <adsp_mem.h>
+#include <sys/util_macro.h>
+#include <spinlock.h>
+#include <soc/memory.h>
+
+/* Start of the region protection option memory region dedicated to
+ * RAM on these devices (this is the uncached mapping, there is
+ * another at 0xa0000000, but this one is normative)
+ */
+#define ADSP_MEM_RPO_BASE 0x80000000
+
+#define PAGEID_FLAG BIT(18)
+#define PAGEID_MASK (PAGEID_FLAG - 1)
+
+/* Header on each block in a page free list, stored at the first
+ * address of the block of pages
+ */
+struct pagerec {
+	size_t num_pages;
+	struct pagerec *next;
+};
+
+struct pagepool {
+	struct pagerec *head;
+	uint32_t idx_start;
+	uint32_t idx_end;
+};
+
+static struct pagepool pools[SOC_ADSP_MEM_NUM_TYPES];
+
+static struct k_spinlock pagelock;
+
+void *soc_adsp_page_addr(soc_adsp_page_id_t pid)
+{
+	/* The page ID is the index of the page within the 512MB
+	 * Xtensa RPO region, with BIT(18) masked in above it to make
+	 * it positive-definite.  (One bit larger than space to allow
+	 * an index "just past the end" to be legal for comparison).
+	 * That allows us to reserve the "negative" region for error
+	 * codes and have a zero available as a null.
+	 */
+	return (void *)(ADSP_MEM_RPO_BASE + (pid & PAGEID_MASK) * SOC_ADSP_PAGE_SZ);
+}
+
+soc_adsp_page_id_t soc_adsp_page_id(void *addr)
+{
+	uintptr_t idx = (((uintptr_t)addr) - ADSP_MEM_RPO_BASE) / SOC_ADSP_PAGE_SZ;
+
+	return (idx & PAGEID_MASK) | PAGEID_FLAG;
+}
+
+static void *page_alloc(struct pagepool *pool)
+{
+	void *ret = NULL;
+
+	if (pool->head != NULL) {
+		if (pool->head->num_pages == 1) {
+			/* Single page record */
+			ret = pool->head;
+			pool->head = pool->head->next;
+		} else {
+			/* Multipage block, use the last one */
+			pool->head->num_pages--;
+			ret = (void *)((size_t)pool->head
+				       + (pool->head->num_pages * SOC_ADSP_PAGE_SZ));
+		}
+	}
+	return ret;
+}
+
+static void page_free(struct pagepool *pool, void *page)
+{
+	struct pagerec *pr = page;
+
+	pr->num_pages = 1;
+	pr->next = pool->head;
+	pool->head = pr;
+}
+
+soc_adsp_page_id_t soc_adsp_page_alloc(enum soc_adsp_mem_t type)
+{
+	k_spinlock_key_t k = k_spin_lock(&pagelock);
+	void *page = page_alloc(&pools[type]);
+
+	k_spin_unlock(&pagelock, k);
+	return page == NULL ? -ENOMEM : soc_adsp_page_id(page);
+}
+
+int32_t soc_adsp_page_free(soc_adsp_page_id_t page)
+{
+	k_spinlock_key_t k = k_spin_lock(&pagelock);
+
+	for (int i = 0; i < ARRAY_SIZE(pools); i++) {
+		if (page >= pools[i].idx_start && page < pools[i].idx_end) {
+			page_free(&pools[i], soc_adsp_page_addr(page));
+		}
+	}
+	k_spin_unlock(&pagelock, k);
+	return -EINVAL;
+}
+
+int32_t soc_adsp_pages_alloc(enum soc_adsp_mem_t type, size_t count,
+			     soc_adsp_page_id_t *pages_out)
+{
+	int i;
+
+	for (i = 0; i < count; i++) {
+		pages_out[i] = soc_adsp_page_alloc(type);
+		if (pages_out[i] < 0) {
+			break;
+		}
+	}
+
+	/* Clean up on failure */
+	if (i < count) {
+		(void)soc_adsp_pages_free(pages_out, i);
+		return -ENOMEM;
+	}
+
+	return 0;
+}
+
+int32_t soc_adsp_pages_free(soc_adsp_page_id_t *pages, size_t count)
+{
+	for (int i = 0; i < count; i++) {
+		soc_adsp_page_free(pages[i]);
+	}
+	return 0;
+}
+
+int32_t soc_adsp_pages_map(size_t count, soc_adsp_page_id_t *pages, void *vaddr)
+{
+	k_spinlock_key_t k = k_spin_lock(&pagelock);
+	int32_t ret = 0;
+
+	for (int i = 0; i < count; i++) {
+		void *va = (char *)vaddr + (i * SOC_ADSP_PAGE_SZ);
+		void *pa = soc_adsp_page_addr(pages[i]);
+
+		/* Only HPSRAM can be mapped */
+		if (pages[i] < pools[SOC_ADSP_MEM_HP_SRAM].idx_start ||
+		    pages[i] >= pools[SOC_ADSP_MEM_HP_SRAM].idx_end) {
+			ret = -EINVAL;
+		}
+
+		z_soc_mem_map(z_soc_cached_ptr(va),
+			      (uintptr_t) z_soc_cached_ptr(pa),
+			      SOC_ADSP_PAGE_SZ, 0);
+	}
+
+	k_spin_unlock(&pagelock, k);
+	return ret;
+}
+
+int32_t soc_adsp_pages_unmap(size_t count, void *vaddr)
+{
+	k_spinlock_key_t k = k_spin_lock(&pagelock);
+
+	for (int i = 0; i < count; i++) {
+		void *va = (char *)vaddr + (i * SOC_ADSP_PAGE_SZ);
+
+		z_soc_mem_unmap(z_soc_cached_ptr(va), SOC_ADSP_PAGE_SZ);
+	}
+
+	k_spin_unlock(&pagelock, k);
+	return 0;
+}
+
+#endif /* ZEPHYR_SOC_ADSP_MEM_H_ */
+
+static void pool_init(struct pagepool *pool, uintptr_t start, uintptr_t end)
+{
+	/* Force the input addresses to the lower (uncached) of the
+	 * two mapped RPO regions.
+	 */
+	start &= ~BIT(29);
+	end &= ~BIT(29);
+
+	start = ROUND_UP(start, SOC_ADSP_PAGE_SZ);
+	end = ROUND_DOWN(end, SOC_ADSP_PAGE_SZ);
+
+	struct pagerec *pr = (void *)start;
+
+	pr->num_pages = (end - start) / SOC_ADSP_PAGE_SZ;
+	pr->next = NULL;
+	pool->head = pr;
+	pool->idx_start = soc_adsp_page_id((void *)start);
+	pool->idx_end = soc_adsp_page_id((void *)end);
+}
+
+void soc_adsp_mem_init(void)
+{
+	/* Usable HP SRAM ("normal" memory) starts with a
+	 * linker-maintained symbol marking the end of the linked area
+	 */
+	extern char _end;
+
+	pool_init(&pools[SOC_ADSP_MEM_HP_SRAM], (uintptr_t)&_end,
+		  HP_SRAM_BASE + HP_SRAM_SIZE);
+
+	uintptr_t lpbase = LP_SRAM_BASE;
+
+	/* cAVS 2.5 hardware uses the bottom of LPSRAM as its boot
+	 * vector, so we can't touch that page
+	 */
+	if (IS_ENABLED(CONFIG_SOC_SERIES_INTEL_CAVS_V25)) {
+		lpbase += SOC_ADSP_PAGE_SZ;
+	}
+
+	pool_init(&pools[SOC_ADSP_MEM_LP_SRAM], lpbase,
+		  LP_SRAM_BASE + LP_SRAM_SIZE);
+
+	/* IMR memory is poorly exposed by Zephyr's integration right
+	 * now.  The base doesn't appear in dts or SOF-derived
+	 * headers, the size is actually requested at runtime via the
+	 * bootloader ROM.  This works for now, needs a framework.
+	 */
+	if (IS_ENABLED(CONFIG_SOC_SERIES_INTEL_CAVS_V25)) {
+		pool_init(&pools[SOC_ADSP_MEM_IMR], 0x90000000, 0x90400000);
+	}
+}

--- a/soc/xtensa/intel_adsp/common/include/adsp_mem.h
+++ b/soc/xtensa/intel_adsp/common/include/adsp_mem.h
@@ -1,0 +1,252 @@
+/* Copyright (c) 2021 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_SOC_ADSP_MEM_H_
+#define ZEPHYR_SOC_ADSP_MEM_H_
+
+#include <zephyr/types.h>
+
+/**
+ * SOC-specific paged memory management API for cAVS hardware
+ *
+ * These devices implement a global PMMU allowing for limited virtual
+ * address translation of physical (4k) pages across several hardware
+ * types, but with different semantics than the virtual memory
+ * hardware available via per-CPU MMUs.  Mappings are universal,
+ * shared between all CPUs, threads and interrupt/exception contexts
+ * on the system.
+ *
+ * The APIs here provide an allocation manager for pages within
+ * physical memory regions, and a mapping utility allowing them to be
+ * placed and moved within the global virtual address space.
+ *
+ * Note that while the hardware capabilities are insufficient for
+ * implementing Zephyr userspace, the expectation is that this
+ * facility will be used in concert with a MPU-based userspace
+ * implementation.  So where needed, the implementation is expected to
+ * integrate with the userspace internals, for example to detect
+ * attempts to remap pages already mapped in runnable threads.
+ *
+ * @note The mapping APIs here is specificed symmetrically with
+ * respect to hardware memory types.  In practice, different hardware
+ * can be instantiated with different capabilities, and it may not be
+ * generically possible to remap all memory identically (e.g. IMR
+ * memory in particular may only be "mappable" at its physical
+ * hardware address).  The specification here is agnostic as to
+ * capabilities, and it is left to the application layer to understand
+ * the specifics of the mapping architecture chosen and to present
+ * only valid combinations to the driver layer.
+ *
+ * @note A note on error handling: many of these APIs are specified to
+ * detect and return errors based on current mapping or userspace
+ * state.  Because there are performance concerns with such checking,
+ * and because these are inherently priviledged APIs, it is expected
+ * that the error handling will be disableable at compile time.  This
+ * allows it to be a routine part of development code but elided for
+ * production binaries where needed.
+ */
+
+/**
+ * @brief Audio DSP memory types
+ *
+ * Enumeration of hardware memory regions managed by this layer.
+ */
+enum soc_adsp_mem_t {
+	SOC_ADSP_MEM_IMR,
+	SOC_ADSP_MEM_LP_SRAM,
+	SOC_ADSP_MEM_HP_SRAM,
+	SOC_ADSP_MEM_NUM_TYPES
+};
+
+/**
+ * @brief Hardware page ID
+ *
+ * Opaque identifier representing a hardware page.  The negative space
+ * is reserved for error results presented via intermediate APIs
+ * (e.g. -ENOMEM).  Zero is likewise reserved for use as a null value
+ * within the application (but otherwise unused by the API).  All real
+ * pages will have a positive definite value.  All valid RAM page
+ * addresses can be represented with page IDs.
+ */
+typedef int32_t soc_adsp_page_id_t;
+
+/* Hardware page size, in bytes */
+#define SOC_ADSP_PAGE_SZ 4096
+
+/**
+ * @brief Hardware address of page ID
+ *
+ * Returns the hardware address of a given page ID
+ *
+ * @param pid A valid soc_adsp_page_id_t
+ * @return A pointer representing the first hardware address of the page
+ */
+void *soc_adsp_page_addr(soc_adsp_page_id_t pid);
+
+/**
+ * @brief Page ID of physical address
+ *
+ * Returns the page ID containing a given physical hardware address
+ *
+ * @param addr A physical hardware address
+ * @return The soc_adsp_page_id_t containing the specified address
+ */
+soc_adsp_page_id_t soc_adsp_page_id(void *addr);
+
+/**
+ * @brief Allocate hardware page
+ *
+ * Allocates a single hardware page of the specified type from the
+ * free pool.  Returns the page ID, or -ENOMEM on error.
+ *
+ * @param type The memory type from which to allocate
+ * @return A hardware page ID, or an error
+ */
+soc_adsp_page_id_t soc_adsp_page_alloc(enum soc_adsp_mem_t type);
+
+/**
+ * @brief Free hardware page
+ *
+ * Returns a previously allocated hardware page to its relevant pool
+ * for use by other application code.  Returns zero on success, or an
+ * error for an invalid page, or if the page is currently mapped by a
+ * runnable thread.
+ *
+ * @note In most cases, pages will be freed automatically when they
+ * are unmapped from the global virtual memory space.  This API exists
+ * only for managing unmapped pages.
+ *
+ * @param page Hardware page ID to free
+ * @return Zero on success, or error
+ */
+int32_t soc_adsp_page_free(soc_adsp_page_id_t page);
+
+/**
+ * @brief Allocate multiple hardware pages
+ *
+ * As for soc_adsp_page_alloc(), but allocates multiple pages at a
+ * time, plaing them into the output array.
+ *
+ * @param type The memory type from which to allocate
+ * @param count Number of pages to allocate
+ * @param pages_out Output array to be populated with allocated pages
+ * @return Zero on success, or -ENOMEM
+ */
+int32_t soc_adsp_pages_alloc(enum soc_adsp_mem_t type, size_t count,
+			     soc_adsp_page_id_t *pages_out);
+
+/**
+ * @brief Free multiple pages
+ *
+ * As for soc_adsp_page_free(), but frees multiple pages at a time.
+ *
+ * @param pages Pointer to an array of pages to free
+ * @param count Number of pages to free
+ * @return Zero on success, or an error
+ */
+int32_t soc_adsp_pages_free(soc_adsp_page_id_t *pages, size_t count);
+
+/**
+ * @brief Map pages into virtual address space
+ *
+ * Maps pages into the global virtual address.  The virtual space
+ * specified must be page aligned, currently unmapped and unused, and
+ * the pages must not be in use by an existing mapping.
+ *
+ * @note This API is specified to fail on duplicate mappings (where
+ * the same physical memory is present at multiple addresses), even
+ * though the hardware is capable.  A separate "dup" API can be added
+ * for such cases, but in general such a condition represents an error
+ * that should be detected.
+ *
+ * @param count Number of pages to map
+ * @param pages Array of page IDs to map
+ * @param vaddr Virtual address pointer
+ * @return Zero, or an error
+ */
+int32_t soc_adsp_pages_map(size_t count, soc_adsp_page_id_t *pages, void *vaddr);
+
+/**
+ * @brief Unmap pages from virtual address space
+ *
+ * Unmaps pages from the global virtual address space, and frees them
+ * to their respective pools for use by other application code (as for
+ * soc_adsp_page_free()).  The pages at the specified address must be
+ * unmapped in the memory domain of any runnable Zephyr thread.  The
+ * virtual address specified must be page aligned and valid.
+ *
+ * @param count Number of pages to unmap
+ * @param vaddr Virtual address of pages to unmap
+ * @return Zero, or an error
+ */
+int32_t soc_adsp_pages_unmap(size_t count, void *vaddr);
+
+/**
+ * @brief Unmap/remap virtual pages
+ *
+ * Acts as an atomic combination of
+ * soc_adsp_pages_map()/soc_adsp_pages_unmap().  Physical memory at
+ * vaddr_old is remapped to appear at vaddr_new.  Both addresses must
+ * be page aligned and valid.  The virtual memory at both the old and
+ * new addresses must be unmapped in the memory domains of any
+ * runnable Zephyr thread.  The space at the new address must be
+ * currently unmapped (i.e. overlapping remaps are not supported)
+ *
+ * @param count Number of pages to remap
+ * @param vaddr_old Virtual address of existing memory
+ * @param vaddr_old Virtual address to which to remap the memory
+ * @return Zero, or an error
+ */
+int32_t soc_adsp_pages_remap(size_t count, void *vaddr_old, void *vaddr_new);
+
+/**
+ * @brief Physically move memory, with copy
+ *
+ * Atomically copies memory from existing physical pages to new
+ * physical pages, optionally remapping to a different virtual
+ * address.  All validity requirements are as for other APIs: the
+ * virtual address must be aligned and valid, the new pages must be
+ * currently unmapped, the old pages must be mapped virtually, but
+ * unmapped in the memory domains of any runnable thread.
+ *
+ * The intent behind this API is the ability to move virtual memory
+ * between different physical hardware without interfering with
+ * logical application state, for example to move thread memory to
+ * memory preserved across a DSP idle state.
+ *
+ * @note The remapping process happens logically after the copy, so
+ * unlike soc_adsp_pages_remap(), the virtual addresses here are
+ * allowed to overlap.
+ *
+ * @param count Number of pages to remap
+ * @param vaddr_old Virtual address of existing memory
+ * @param vaddr_old Virtual address to which to remap the memory
+ * @param pages_new Array of physical pages to contain the moved memory
+ * @return Zero, or an error
+ */
+int32_t soc_adsp_pages_copy(size_t count, void *vaddr_old, void *vaddr_new,
+			    soc_adsp_page_id_t *pages_new);
+
+/**
+ * Map physical memory into the virtual address space
+ *
+ * This maps physical L2 HP-SRAM memory into virtual address space.
+ *
+ * @param vaddr Page-aligned Destination virtual address to map
+ * @param paddr Page-aligned Source physical address to map
+ * @param size  Page-aligned size of the mapped memory region in bytes
+ * @param flags Access and control flags, see K_MEM_PERM_* macros
+ */
+void z_soc_mem_map(void *vaddr, uintptr_t paddr, size_t size, uint32_t flags);
+
+/**
+ * Remove mappings for a provided virtual address range
+ *
+ * @param vaddr Page-aligned base virtual address to un-map
+ * @param size  Page-aligned region size
+ */
+void z_soc_mem_unmap(void *vaddr, size_t size);
+
+void soc_adsp_mem_init(void);
+
+#endif /* ZEPHYR_SOC_ADSP_MEM_H_ */

--- a/soc/xtensa/intel_adsp/common/include/adsp_mem.h
+++ b/soc/xtensa/intel_adsp/common/include/adsp_mem.h
@@ -247,6 +247,15 @@ void z_soc_mem_map(void *vaddr, uintptr_t paddr, size_t size, uint32_t flags);
  */
 void z_soc_mem_unmap(void *vaddr, size_t size);
 
+/**
+ * Returns the physical address associated with the (page-aligned)
+ * virtual address argument
+ *
+ * @param vaddr Virtual page address to translate
+ * @return Physical address of memory backing the page, or NULL if not mapped
+ */
+void *z_soc_mem_phys_addr(void *vaddr);
+
 void soc_adsp_mem_init(void);
 
 #endif /* ZEPHYR_SOC_ADSP_MEM_H_ */

--- a/soc/xtensa/intel_adsp/common/mem_map.c
+++ b/soc/xtensa/intel_adsp/common/mem_map.c
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2021 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <kernel.h>
+#include <spinlock.h>
+#include <sys/__assert.h>
+#include <sys/mem_manage.h>
+#include <sys/util.h>
+
+#include <soc.h>
+#include <soc/memory.h>
+
+#define TLB_BASE 0x3000
+
+/* Number of significant bits in the page index (defines the size of
+ * the table)
+ */
+#ifdef SOC_SERIES_INTEL_CAVS_V15
+# define TLB_PADDR_SIZE 9
+#else
+# define TLB_PADDR_SIZE 11
+#endif
+
+#define PAGE_SIZE      4096
+#define TLB_PADDR_MASK ((1 << TLB_PADDR_SIZE) - 1)
+#define TLB_ENABLE_BIT BIT(TLB_PADDR_SIZE)
+
+static struct k_spinlock soc_mem_map_lock;
+
+/**
+ * Calculate the index to the TLB table.
+ *
+ * @param vaddr Page-aligned virutal address.
+ * @return Index to the TLB table.
+ */
+static uint32_t get_tlb_entry_idx(uintptr_t vaddr)
+{
+	return ((POINTER_TO_UINT(vaddr) - HP_SRAM_BASE) / PAGE_SIZE);
+}
+
+void z_soc_mem_map(void *vaddr, uintptr_t paddr, size_t size, uint32_t flags)
+{
+	k_spinlock_key_t key;
+	uint16_t *tlb_entries = UINT_TO_POINTER(TLB_BASE);
+	uint32_t entry_idx;
+	uint16_t entry;
+	size_t offset;
+
+	ARG_UNUSED(flags);
+
+	/* TODO: add assertions on bounds of virtual address space */
+	__ASSERT_NO_MSG(paddr >= HP_SRAM_BASE);
+	__ASSERT_NO_MSG((paddr + size) <= (HP_SRAM_BASE + HP_SRAM_SIZE));
+
+	/* Make sure inputs are page-aligned */
+	__ASSERT_NO_MSG((paddr % PAGE_SIZE) == 0U);
+	__ASSERT_NO_MSG((POINTER_TO_UINT(vaddr) % PAGE_SIZE) == 0U);
+	__ASSERT_NO_MSG((size % PAGE_SIZE) == 0U);
+
+	key = k_spin_lock(&soc_mem_map_lock);
+
+	for (offset = 0; offset < size; offset += PAGE_SIZE) {
+		entry_idx = get_tlb_entry_idx(POINTER_TO_UINT(vaddr) + offset);
+
+		/* The address part of the TLB entry takes the lowest
+		 * TLB_PADDR_SIZE bits of the physical page number,
+		 * and discards the highest bits.  This is due to the
+		 * architecture design where the same physical page
+		 * can be accessed via two addresses. One address goes
+		 * through the cache, and the other one accesses
+		 * memory directly (without cache). The difference
+		 * between these two addresses are in the higher bits,
+		 * and the lower bits are the same.  And this is why
+		 * TLB only cares about the lower part of the physical
+		 * address.
+		 */
+		entry = ((((paddr + offset) / PAGE_SIZE) & TLB_PADDR_MASK)
+			 | TLB_ENABLE_BIT);
+
+		tlb_entries[entry_idx] = entry;
+	}
+
+	k_spin_unlock(&soc_mem_map_lock, key);
+}
+
+void z_soc_mem_unmap(void *vaddr, size_t size)
+{
+	k_spinlock_key_t key;
+	uint32_t entry_idx;
+	uint16_t *tlb_entries = UINT_TO_POINTER(TLB_BASE);
+	size_t offset;
+
+	/* TODO: add assertions on bounds of virtual address space */
+
+	/* Make sure inputs are page-aligned */
+	__ASSERT_NO_MSG((POINTER_TO_UINT(vaddr) % PAGE_SIZE) == 0U);
+	__ASSERT_NO_MSG((size % PAGE_SIZE) == 0U);
+
+	key = k_spin_lock(&soc_mem_map_lock);
+
+	for (offset = 0; offset < size; offset += PAGE_SIZE) {
+		entry_idx = get_tlb_entry_idx(POINTER_TO_UINT(vaddr) + offset);
+
+		/* Simply clear the enable bit */
+		tlb_entries[entry_idx] &= ~TLB_ENABLE_BIT;
+	}
+
+	k_spin_unlock(&soc_mem_map_lock, key);
+}

--- a/soc/xtensa/intel_adsp/common/mem_map.c
+++ b/soc/xtensa/intel_adsp/common/mem_map.c
@@ -110,3 +110,11 @@ void z_soc_mem_unmap(void *vaddr, size_t size)
 
 	k_spin_unlock(&soc_mem_map_lock, key);
 }
+
+void *z_soc_mem_phys_addr(void *vaddr)
+{
+	uint16_t *tlb_entries = UINT_TO_POINTER(TLB_BASE);
+	uint16_t ent = tlb_entries[get_tlb_entry_idx(POINTER_TO_UINT(vaddr))];
+
+	return (void *)((ent & TLB_PADDR_MASK) * PAGE_SIZE + HP_SRAM_BASE);
+}

--- a/soc/xtensa/intel_adsp/common/soc.c
+++ b/soc/xtensa/intel_adsp/common/soc.c
@@ -12,6 +12,7 @@
 
 #include <soc/shim.h>
 #include <cavs-idc.h>
+#include <adsp_mem.h>
 #include "soc.h"
 
 #ifdef CONFIG_DYNAMIC_INTERRUPTS
@@ -287,6 +288,8 @@ static int soc_init(const struct device *dev)
 #if CONFIG_MP_NUM_CPUS > 1
 	soc_idc_init();
 #endif
+
+	soc_adsp_mem_init();
 
 	return 0;
 }

--- a/tests/boards/intel_adsp/mem/CMakeLists.txt
+++ b/tests/boards/intel_adsp/mem/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(adsp_mem)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/boards/intel_adsp/mem/prj.conf
+++ b/tests/boards/intel_adsp/mem/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/boards/intel_adsp/mem/src/main.c
+++ b/tests/boards/intel_adsp/mem/src/main.c
@@ -1,0 +1,123 @@
+/* Copyright (c) 2021 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <ztest.h>
+#include <zephyr.h>
+#include <sys/printk.h>
+#include <soc/memory.h>
+#include <adsp_mem.h>
+
+extern char _heap_sentry;
+
+#define N_PAGES 3
+
+struct pagemem {
+	uint32_t mem[1024];
+};
+
+void test_adsp_mem(void)
+{
+	soc_adsp_page_id_t p[N_PAGES];
+	void *pa[N_PAGES];
+
+	for (int i = 0; i < N_PAGES; i++) {
+		p[i] = soc_adsp_page_alloc(SOC_ADSP_MEM_HP_SRAM);
+		zassert_true(p[i] > 0, "page alloc failed");
+		pa[i] = soc_adsp_page_addr(p[i]);
+		zassert_not_null(pa[i], "no addr for page");
+	}
+
+	/* Whitebox, make sure a page we just freed is the first one
+	 * returned.  Easy way of ensuring that the free added it
+	 * correctly, even though we don't specify this ordering.
+	 */
+	soc_adsp_page_free(p[2]);
+	zassert_equal(p[2], soc_adsp_page_alloc(SOC_ADSP_MEM_HP_SRAM),
+		      "just-freed page not reused");
+
+	/* Find a virtual address beyond physical memory */
+	void *va = (void *)ROUND_UP(HP_SRAM_BASE + HP_SRAM_SIZE, 4096);
+
+	va = z_soc_uncached_ptr(va);
+
+	/* Map our physical pages to the new location */
+	int32_t ret = soc_adsp_pages_map(N_PAGES, p, va); /* assert == 0 */
+
+	zassert_true(ret == 0, "soc_adsp_pages_map() failed");
+
+	/* Mark the new pages */
+	struct pagemem *vps = va;
+	const uint32_t markers[] = { 0x11111111, 0x22222222, 0x33333333 };
+
+	for (int i = 0; i < N_PAGES; i++) {
+		vps[i].mem[0] = markers[i];
+	}
+
+	/* Verify the originals reflect the change */
+	for (int i = 0; i < N_PAGES; i++) {
+		zassert_equal(vps[i].mem[0], *(uint32_t *)pa[i],
+			      "mapping and original don't match");
+	}
+
+	/* Remap to another region (this will unmap the first virtual pages) */
+	struct pagemem *vps2 = &vps[N_PAGES];
+
+	ret = soc_adsp_pages_remap(N_PAGES, vps, vps2);
+	zassert_true(ret == 0, "soc_adsp_pages_remap() failed");
+
+	for (int i = 0; i < N_PAGES; i++) {
+		zassert_equal(vps2[i].mem[0], *(uint32_t *)pa[i],
+			      "remapping and original don't match");
+	}
+
+	/* Now copy the remapped pages to a third virtual region */
+	struct pagemem *vps3 = &vps2[N_PAGES];
+	soc_adsp_page_id_t new_pages[N_PAGES];
+
+	ret = soc_adsp_pages_alloc(SOC_ADSP_MEM_HP_SRAM, N_PAGES, new_pages);
+	zassert_true(ret == 0, "soc_adsp_pages_alloc failed");
+
+	ret = soc_adsp_pages_copy(N_PAGES, vps2, vps3, new_pages);
+	zassert_true(ret == 0, "soc_adsp_pages_copy failed");
+
+	/* Make sure they match the originals */
+	for (int i = 0; i < N_PAGES; i++) {
+		zassert_equal(*(int *)pa[i], vps3[i].mem[0],
+			      "page copy failed to match data");
+	}
+
+	/* Modify the copy and make sure the originals are unmodified */
+	const int poison = 0x5a5a5a5a;
+
+	for (int i = 0; i < N_PAGES; i++) {
+		vps3[i].mem[0] = poison;
+		zassert_equal(*(int *)pa[i], markers[i],
+			      "page copy modified original");
+	}
+
+	/* Unmap */
+	ret = soc_adsp_pages_unmap(N_PAGES, vps2);
+	zassert_true(ret == 0, "soc_adsp_pages_unmap() failed");
+
+	/* Verify the copied region was not unmapped */
+	for (int i = 0; i < N_PAGES; i++) {
+		zassert_equal(vps3[i].mem[0], poison,
+			      "original page data changed after unmap");
+	}
+
+	/* Verify the originals are still unmodified */
+	for (int i = 0; i < N_PAGES; i++) {
+		zassert_equal(*(int *)pa[i], markers[i],
+			      "original page data changed after unmap");
+	}
+}
+
+
+void test_main(void)
+{
+	ztest_test_suite(adsp_mem,
+			 ztest_unit_test(test_adsp_mem));
+
+	ztest_run_test_suite(adsp_mem);
+}

--- a/tests/boards/intel_adsp/mem/testcase.yaml
+++ b/tests/boards/intel_adsp/mem/testcase.yaml
@@ -1,0 +1,3 @@
+tests:
+  boards.intel_adsp.mem:
+    platform_allow: intel_adsp_cavs25


### PR DESCRIPTION
This adds an API above the just-added TLB driver that does page-level allocation management of memory in the various cAVS memory spaces, with mapping/remapping support in HP-SRAM where the hardware permits. Memory bounds are automatically detected via a pre-existing linker symbol. 