### PR TITLE
boards: stm32u5: Fix instructions to use openocd

### DIFF
--- a/boards/arm/b_u585i_iot02a/doc/index.rst
+++ b/boards/arm/b_u585i_iot02a/doc/index.rst
@@ -255,9 +255,9 @@ Debugging
 STM32U5 support is not currently supported in openocd. As a temporary workaround,
 user can use `STMicroelectronics customized version of OpenOCD`_ to debug the
 the B_U585I_IOT02A Discovery kit.
-For this you need to fetch this repo and build openocd following the instructions
-provided in the README of the project. Then, build zephyr project indicating the
-openocd location in west build command.
+For this you need to fetch this repo, checkout branch "openocd-cubeide-r3" and
+build openocd following the instructions provided in the README of the project.
+Then, build zephyr project indicating the openocd location in west build command.
 
 Here is an example for the :ref:`blinky-sample` application.
 
@@ -269,17 +269,11 @@ Here is an example for the :ref:`blinky-sample` application.
 
 Then, indicate openocd as the chosen runner in flash and debug commands:
 
-.. zephyr-app-commands::
-   :zephyr-app: samples/basic/blinky
-   :board: b_u585i_iot02a
-   :gen-args: -r openocd
-   :goals: flash
 
-.. zephyr-app-commands::
-   :zephyr-app: samples/basic/blinky
-   :board: nucleo_u575zi_q
-   :gen-args: -r openocd
-   :goals: debug
+   .. code-block:: console
+
+      $ west flash -r openocd
+      $ west debug -r openocd
 
 
 .. _B U585I IOT02A Discovery kit website:

--- a/boards/arm/nucleo_u575zi_q/doc/nucleou575zi_q.rst
+++ b/boards/arm/nucleo_u575zi_q/doc/nucleou575zi_q.rst
@@ -240,9 +240,9 @@ Debugging
 STM32U5 support is not currently supported in openocd. As a temporary workaround,
 user can use `STMicroelectronics customized version of OpenOCD`_ to debug the
 the Nucleo U575ZI Q.
-For this you need to fetch this repo and build openocd following the instructions
-provided in the README of the project. Then, build zephyr project indicating the
-openocd location in west build command.
+For this you need to fetch this repo, checkout branch "openocd-cubeide-r3" and
+build openocd following the instructions provided in the README of the project.
+Then, build zephyr project indicating the openocd location in west build command.
 
 Here is an example for the :ref:`blinky-sample` application.
 
@@ -254,17 +254,11 @@ Here is an example for the :ref:`blinky-sample` application.
 
 Then, indicate openocd as the chosen runner in flash and debug commands:
 
-.. zephyr-app-commands::
-   :zephyr-app: samples/basic/blinky
-   :board: nucleo_u575zi_q
-   :gen-args: -r openocd
-   :goals: flash
 
-.. zephyr-app-commands::
-   :zephyr-app: samples/basic/blinky
-   :board: nucleo_u575zi_q
-   :gen-args: -r openocd
-   :goals: debug
+   .. code-block:: console
+
+      $ west flash -r openocd
+      $ west debug -r openocd
 
 
 .. _STM32 Nucleo-144 board User Manual:


### PR DESCRIPTION
Instructions to use openocd on stm32u5 based platforms were missing
an instruction on the branch to use.
Also, the console excerpt were not rendering correctly, so fix
them.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>