### PR TITLE
[TOPIC-BLE-LLCP] Bluetooth: controller: fix some checkpatch warnings/errors

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ll_addr.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_addr.c
@@ -83,5 +83,5 @@ uint8_t ll_addr_set(uint8_t addr_type, uint8_t const *const bdaddr)
 
 void bt_ctlr_set_public_addr(const uint8_t *addr)
 {
-    (void)memcpy(pub_addr, addr, sizeof(pub_addr));
+	(void)memcpy(pub_addr, addr, sizeof(pub_addr));
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -2494,8 +2494,10 @@ static void ext_disabled_cb(void *param)
 	struct lll_adv *lll = (void *)param;
 	struct node_rx_hdr *rx_hdr = (void *)lll->node_rx_adv_term;
 
-	/* Under race condition, if a connection has been established then
-	 * node_rx is already utilized to send terminate event on connection */
+	/*
+	 * Under race condition, if a connection has been established then
+	 * node_rx is already utilized to send terminate event on connection
+	 */
 	if (!rx_hdr) {
 		return;
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1689,6 +1689,7 @@ void ull_conn_tx_ack(uint16_t handle, memq_link_t *link, struct node_tx *tx)
 uint8_t ull_conn_llcp_req(void *conn)
 {
 	struct ll_conn * const conn_hdr = conn;
+
 	if (conn_hdr->llcp_req != conn_hdr->llcp_ack) {
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_connections.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_connections.c
@@ -1497,7 +1497,7 @@ void ull_conn_done(struct node_rx_event_done *done)
 			ull_drift_ticks_get(done, &ticks_drift_plus, &ticks_drift_minus);
 
 			/*
-			** EGON TODO to be verified
+			 * EGON TODO to be verified
 			*/
 			if (!ull_tx_q_peek(&conn->tx_q)) {
 				ull_conn_tx_demux(UINT8_MAX);
@@ -1662,18 +1662,18 @@ void ull_conn_done(struct node_rx_event_done *done)
 #endif /* CONFIG_BT_CTLR_CONN_RSSI_EVENT */
 
 	/*
-	** EGON TODO: verify what we need to do here
+	 * EGON TODO: verify what we need to do here
 	*/
 
 	/* break latency based on ctrl procedure pending */
 	/*
-	** Original code
-	if (((((conn->llcp_req - conn->llcp_ack) & 0x03) == 0x02) &&
-	     ((conn->llcp_type == LLCP_CONN_UPD) ||
-	      (conn->llcp_type == LLCP_CHAN_MAP))) ||
-	    (conn->llcp_cu.req != conn->llcp_cu.ack)) {
-		lll->latency_event = 0U;
-	}
+	 * Original code
+	 *	if (((((conn->llcp_req - conn->llcp_ack) & 0x03) == 0x02) &&
+	 *	     ((conn->llcp_type == LLCP_CONN_UPD) ||
+	 *	      (conn->llcp_type == LLCP_CHAN_MAP))) ||
+	 *	    (conn->llcp_cu.req != conn->llcp_cu.ack)) {
+	 *		lll->latency_event = 0U;
+	 *	}
 	*/
 
 	/* check if latency needs update */
@@ -1836,9 +1836,11 @@ void ull_conn_tx_ack(uint16_t handle, memq_link_t *link, struct node_tx *tx)
 			ull_cp_tx_ack(conn, tx);
 		}
 
-		/* If the link's next pointer points to the tx node itself,
+		/*
+		 *f the link's next pointer points to the tx node itself,
 		 * then the tx node belong to the ctrl pool and should be
-		 * free'ed (see tx_ull_dequeue) */
+		 * free'ed (see tx_ull_dequeue)
+		 */
 		if (link->next == (void *)tx) {
 			LL_ASSERT(link->next);
 			ull_cp_release_tx(tx);
@@ -1853,9 +1855,8 @@ void ull_conn_tx_ack(uint16_t handle, memq_link_t *link, struct node_tx *tx)
 	}
 
 	ll_tx_ack_put(handle, tx);
-
-	return;
 }
+
 
 uint8_t ull_conn_llcp_req(void *conn)
 {
@@ -2000,6 +2001,7 @@ static void tx_demux(void *param)
 static struct node_tx *tx_ull_dequeue(struct ll_conn *conn)
 {
 	struct node_tx *tx = NULL;
+
 	tx = ull_tx_q_dequeue(&conn->tx_q);
 	if (tx) {
 		struct pdu_data *pdu_tx;

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -828,8 +828,10 @@ void ull_cp_rx(struct ll_conn *conn, struct node_rx_pdu *rx)
 	pdu = (struct pdu_data *)rx->pdu;
 
 	if (!pdu_is_terminate(pdu)) {
-		/* Process non LL_TERMINATE_IND PDU's as responses to active
-		 * procedures */
+		/*
+		 *Process non LL_TERMINATE_IND PDU's as responses to active
+		 * procedures
+		 */
 
 		ctx = llcp_lr_peek(conn);
 		if (ctx && (pdu_is_expected(pdu, ctx) || pdu_is_unknown(pdu, ctx) ||

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.h
@@ -1,150 +1,150 @@
 /*
-* Copyright (c) 2020 Demant
-*
-* SPDX-License-Identifier: Apache-2.0
-*/
+ * Copyright (c) 2020 Demant
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 /* Temporary data structure to avoid change ll_conn/lll_conn to much
-* and having to update all the dependencies
-*/
+ * and having to update all the dependencies
+ */
 
 enum { ULL_CP_CONNECTED, ULL_CP_DISCONNECTED };
 
 /**
-* @brief Initialize the LL Control Procedure system.
-*/
+ * @brief Initialize the LL Control Procedure system.
+ */
 void ull_cp_init(void);
 
 /**
-* @brief Initialize the LL Control Procedure conenction data.
-*/
+ * @brief Initialize the LL Control Procedure connection data.
+ */
 void ll_conn_init(struct ll_conn *conn);
 
 /**
-* @brief XXX
-*/
+ * @brief XXX
+ */
 void ull_cp_state_set(struct ll_conn *conn, uint8_t state);
 
 /**
-*
-*/
+ *
+ */
 void ull_cp_release_tx(struct node_tx *tx);
 
 /**
-*
-*/
+ *
+ */
 void ull_cp_release_ntf(struct node_rx_pdu *ntf);
 
 /**
-* @brief Run pending LL Control Procedures.
-*/
+ * @brief Run pending LL Control Procedures.
+ */
 void ull_cp_run(struct ll_conn *conn);
 
 /**
-* @brief Handle TX ack PDU.
-*/
+ * @brief Handle TX ack PDU.
+ */
 void ull_cp_tx_ack(struct ll_conn *conn, struct node_tx *tx);
 
 /**
-* @brief Handle received LL Control PDU.
-*/
+ * @brief Handle received LL Control PDU.
+ */
 void ull_cp_rx(struct ll_conn *conn, struct node_rx_pdu *rx);
 
 #if defined(CONFIG_BT_CTLR_LE_PING)
 /**
-* @brief Initiate a LE Ping Procedure.
-*/
+ * @brief Initiate a LE Ping Procedure.
+ */
 uint8_t ull_cp_le_ping(struct ll_conn *conn);
 #endif /* CONFIG_BT_CTLR_LE_PING */
 
 /**
-* @brief Initiate a Version Exchange Procedure.
-*/
+ * @brief Initiate a Version Exchange Procedure.
+ */
 uint8_t ull_cp_version_exchange(struct ll_conn *conn);
 
 /**
-* @brief Initiate a Featue Exchange Procedure.
-*/
+ * @brief Initiate a Feature Exchange Procedure.
+ */
 uint8_t ull_cp_feature_exchange(struct ll_conn *conn);
 
 #if defined(CONFIG_BT_CTLR_MIN_USED_CHAN)
 /**
-* @brief Initiate a Minimum used channels Procedure.
-*/
+ * @brief Initiate a Minimum used channels Procedure.
+ */
 uint8_t ull_cp_min_used_chans(struct ll_conn *conn, uint8_t phys, uint8_t min_used_chans);
 #endif /* CONFIG_BT_CTLR_MIN_USED_CHAN */
 
 /**
-* @brief Initiate a Encryption Start Procedure.
-*/
+ * @brief Initiate a Encryption Start Procedure.
+ */
 uint8_t ull_cp_encryption_start(struct ll_conn *conn, const uint8_t rand[8], const uint8_t ediv[2],
 				const uint8_t ltk[16]);
 
 /**
-* @brief Initiate a Encryption Pause Procedure.
-*/
+ * @brief Initiate a Encryption Pause Procedure.
+ */
 uint8_t ull_cp_encryption_pause(struct ll_conn *conn, const uint8_t rand[8], const uint8_t ediv[2],
 				const uint8_t ltk[16]);
 
 /**
-* @brief Check if an encryption pause procedure is active.
-*/
+ * @brief Check if an encryption pause procedure is active.
+ */
 uint8_t ull_cp_encryption_paused(struct ll_conn *conn);
 
 /**
-*/
+ */
 void ull_cp_ltk_req_reply(struct ll_conn *conn, const uint8_t ltk[16]);
 
 /**
-*/
+ */
 void ull_cp_ltk_req_neq_reply(struct ll_conn *conn);
 
 /**
-* @brief Initiate a PHY Update Procedure.
-*/
+ * @brief Initiate a PHY Update Procedure.
+ */
 uint8_t ull_cp_phy_update(struct ll_conn *conn, uint8_t tx, uint8_t flags, uint8_t rx,
 			  uint8_t host_initiated);
 
 /**
-* @brief Initiate a Connection Parameter Request Procedure or Connection Update Procedure
-*/
+ * @brief Initiate a Connection Parameter Request Procedure or Connection Update Procedure
+ */
 uint8_t ull_cp_conn_update(struct ll_conn *conn, uint16_t interval_min, uint16_t interval_max,
 			   uint16_t latency, uint16_t timeout);
 
 /**
-* @brief Accept the remote device’s request to change connection parameters.
-*/
+ * @brief Accept the remote device’s request to change connection parameters.
+ */
 void ull_cp_conn_param_req_reply(struct ll_conn *conn);
 
 /**
-* @brief Reject the remote device’s request to change connection parameters.
-*/
+ * @brief Reject the remote device’s request to change connection parameters.
+ */
 void ull_cp_conn_param_req_neg_reply(struct ll_conn *conn, uint8_t error_code);
 
 /**
-* @brief Check if a remote data length update is in the works.
-*/
+ * @brief Check if a remote data length update is in the works.
+ */
 uint8_t ull_cp_remote_dle_pending(struct ll_conn *conn);
 
 /**
-* @brief Initiate a Termination Procedure.
-*/
+ * @brief Initiate a Termination Procedure.
+ */
 uint8_t ull_cp_terminate(struct ll_conn *conn, uint8_t error_code);
 
 /**
-* @brief Initiate a Channel Map Update Procedure.
-*/
+ * @brief Initiate a Channel Map Update Procedure.
+ */
 uint8_t ull_cp_chan_map_update(struct ll_conn *conn, const uint8_t chm[5]);
 
 /**
-* @brief Check if Channel Map Update Procedure is pending
-*/
+ * @brief Check if Channel Map Update Procedure is pending
+ */
 const uint8_t *ull_cp_chan_map_update_pending(struct ll_conn *conn);
 
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 /**
-* @brief Initiate a Data Length Update Procedure.
-*/
+ * @brief Initiate a Data Length Update Procedure.
+ */
 uint8_t ull_cp_data_length_update(struct ll_conn *conn, uint16_t max_tx_octets,
 				  uint16_t max_tx_time);
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_chmu.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_chmu.c
@@ -156,6 +156,7 @@ static void lp_chmu_check_instant(struct ll_conn *conn, struct proc_ctx *ctx, ui
 				  void *param)
 {
 	uint16_t event_counter = lp_event_counter(conn);
+
 	if (is_instant_reached_or_passed(ctx->data.chmu.instant, event_counter)) {
 		llcp_rr_set_incompat(conn, INCOMPAT_NO_COLLISION);
 		lp_chmu_complete(conn, ctx, evt, param);
@@ -257,6 +258,7 @@ static void rp_chmu_check_instant(struct ll_conn *conn, struct proc_ctx *ctx, ui
 				  void *param)
 {
 	uint16_t event_counter = rp_event_counter(conn);
+
 	if (((event_counter - ctx->data.chmu.instant) & 0xFFFF) <= 0x7FFF) {
 		rp_chmu_complete(conn, ctx, evt, param);
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
@@ -872,15 +872,17 @@ static void rp_comm_send_rsp(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t
 		break;
 #if defined(CONFIG_BT_CTLR_MIN_USED_CHAN) && defined(CONFIG_BT_CENTRAL)
 	case PROC_MIN_USED_CHANS:
-		/* Spec says (5.2, Vol.6, Part B, Section 5.1.11):
-		     The procedure has completed when the Link Layer acknowledgment of the
-		     LL_MIN_USED_CHANNELS_IND PDU is sent or received.
-		   In effect, for this procedure, this is equivalent to RX of PDU
-		*/
+		/*
+		 * Spec says (5.2, Vol.6, Part B, Section 5.1.11):
+		 *     The procedure has completed when the Link Layer acknowledgment of the
+		 *     LL_MIN_USED_CHANNELS_IND PDU is sent or received.
+		 *  In effect, for this procedure, this is equivalent to RX of PDU
+		 */
 		/* So we inititate a chmap update procedure, but only if acting as central, just in case ... */
 		if (conn->lll.role == BT_HCI_ROLE_CENTRAL &&
 		    ull_conn_lll_phy_active(conn, conn->llcp.muc.phys)) {
 			uint8_t chmap[5];
+
 			ull_chan_map_get((uint8_t *const)chmap);
 			ull_cp_chan_map_update(conn, chmap);
 			/* TODO - what to do on failure of ull_cp_chan_map_update() */

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_enc.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_enc.c
@@ -496,8 +496,10 @@ static void lp_enc_state_wait_rx_pause_enc_rsp(struct ll_conn *conn, struct proc
 {
 	switch (evt) {
 	case LP_ENC_EVT_PAUSE_ENC_RSP:
-		/* Pause Rx data; will be resumed when the encapsulated
-		 * Start Procedure is done. */
+		/*
+		 * Pause Rx data; will be resumed when the encapsulated
+		 * Start Procedure is done.
+		 */
 		ull_conn_pause_rx_data(conn);
 		lp_enc_send_pause_enc_rsp(conn, ctx, evt, param);
 		break;
@@ -1041,8 +1043,10 @@ static void rp_enc_state_wait_rx_pause_enc_req(struct ll_conn *conn, struct proc
 		/* Pause Tx data */
 		llcp_tx_pause_data(conn);
 		llcp_tx_flush(conn);
-		/* Pause Rx data; will be resumed when the encapsulated
-		 * Start Procedure is done. */
+		/*
+		 * Pause Rx data; will be resumed when the encapsulated
+		 * Start Procedure is done.
+		 */
 		ull_conn_pause_rx_data(conn);
 		rp_enc_send_pause_enc_rsp(conn, ctx, evt, param);
 		break;

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_hci.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_hci.c
@@ -102,7 +102,7 @@ uint8_t ll_apto_get(uint16_t handle, uint16_t *apto)
 		return BT_HCI_ERR_UNKNOWN_CONN_ID;
 	}
 
-	// apto unit is 10ms
+	/* apto unit is 10ms */
 	*apto = conn->apto_reload * conn->lll.interval * (CONN_INT_UNIT_US / 10) / 1000;
 
 	return 0;
@@ -117,7 +117,7 @@ uint8_t ll_apto_set(uint16_t handle, uint16_t apto)
 		return BT_HCI_ERR_UNKNOWN_CONN_ID;
 	}
 
-	// apto unit is 10ms, RADIO_CONN_EVENTS converts us to connection events
+	/* apto unit is 10ms, RADIO_CONN_EVENTS converts us to connection events */
 	conn->apto_reload =
 		RADIO_CONN_EVENTS(apto * 10U * 1000U, conn->lll.interval * CONN_INT_UNIT_US);
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
@@ -22,7 +22,7 @@ enum llcp_proc {
 	PROC_CTE_REQ,
 };
 
-#if defined (CONFIG_BT_CTLR_LE_ENC)
+#if defined(CONFIG_BT_CTLR_LE_ENC)
 struct llcp_enc {
 	uint8_t error;
 
@@ -132,7 +132,7 @@ struct proc_ctx {
 		} muc;
 #endif /* CONFIG_BT_CTLR_MIN_USED_CHAN */
 
-#if defined (CONFIG_BT_CTLR_LE_ENC)
+#if defined(CONFIG_BT_CTLR_LE_ENC)
 		/* Used by Encryption Procedure */
 		struct llcp_enc enc;
 #endif /* CONFIG_BT_CTLR_LE_ENC */
@@ -316,7 +316,7 @@ void llcp_rp_comm_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_
 void llcp_rp_comm_init_proc(struct proc_ctx *ctx);
 void llcp_rp_comm_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
 
-#if defined (CONFIG_BT_CTLR_LE_ENC)
+#if defined(CONFIG_BT_CTLR_LE_ENC)
 /*
  * LLCP Local Procedure Encryption
  */
@@ -451,11 +451,11 @@ void llcp_pdu_decode_feature_rsp(struct ll_conn *conn,
 /*
  * Minimum number of used channels Procedure Helper
  */
-#if defined (CONFIG_BT_PERIPHERAL)
+#if defined(CONFIG_BT_PERIPHERAL)
 void llcp_pdu_encode_min_used_chans_ind(struct proc_ctx *ctx, struct pdu_data *pdu);
 #endif /* CONFIG_BT_PERIPHERAL */
 
-#if defined (CONFIG_BT_CENTRAL)
+#if defined(CONFIG_BT_CENTRAL)
 void llcp_pdu_decode_min_used_chans_ind(struct ll_conn *conn, struct pdu_data *pdu);
 #endif /* CONFIG_BT_CENTRAL */
 #endif /* CONFIG_BT_CTLR_MIN_USED_CHAN */
@@ -467,15 +467,15 @@ void llcp_pdu_encode_version_ind(struct pdu_data *pdu);
 void llcp_ntf_encode_version_ind(struct ll_conn *conn, struct pdu_data *pdu);
 void llcp_pdu_decode_version_ind(struct ll_conn *conn, struct pdu_data *pdu);
 
-#if defined (CONFIG_BT_CTLR_LE_ENC)
+#if defined(CONFIG_BT_CTLR_LE_ENC)
 /*
  * Encryption Start Procedure Helper
  */
-#if defined (CONFIG_BT_CENTRAL)
+#if defined(CONFIG_BT_CENTRAL)
 void llcp_pdu_encode_enc_req(struct proc_ctx *ctx, struct pdu_data *pdu);
 #endif /* CONFIG_BT_CENTRAL */
 
-#if defined (CONFIG_BT_PERIPHERAL)
+#if defined(CONFIG_BT_PERIPHERAL)
 void llcp_ntf_encode_enc_req(struct proc_ctx *ctx, struct pdu_data *pdu);
 void llcp_pdu_encode_enc_rsp(struct pdu_data *pdu);
 void llcp_pdu_encode_start_enc_req(struct pdu_data *pdu);
@@ -483,7 +483,7 @@ void llcp_pdu_encode_start_enc_req(struct pdu_data *pdu);
 
 void llcp_pdu_encode_start_enc_rsp(struct pdu_data *pdu);
 
-#if defined (CONFIG_BT_CENTRAL)
+#if defined(CONFIG_BT_CENTRAL)
 void llcp_pdu_encode_pause_enc_req(struct pdu_data *pdu);
 #endif /* CONFIG_BT_CENTRAL */
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
@@ -311,7 +311,8 @@ static void lr_st_idle(struct ll_conn *conn, uint8_t evt, void *param)
 
 	switch (evt) {
 	case LR_EVT_RUN:
-		if ((ctx = llcp_lr_peek(conn))) {
+		ctx = llcp_lr_peek(conn);
+		if (ctx) {
 			lr_act_run(conn);
 			if (ctx->proc != PROC_TERMINATE) {
 				lr_set_state(conn, LR_STATE_ACTIVE);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_pdu.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_pdu.c
@@ -643,7 +643,7 @@ void llcp_pdu_decode_chan_map_update_ind(struct proc_ctx *ctx, struct pdu_data *
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 /*
  * Data Length Update Procedure Helpers
-*/
+ */
 void llcp_pdu_encode_length_req(struct ll_conn *conn, struct pdu_data *pdu)
 {
 	struct pdu_data_llctrl_length_req *p = &pdu->llctrl.length_req;
@@ -689,6 +689,7 @@ void llcp_ntf_encode_length_change(struct ll_conn *conn, struct pdu_data *pdu)
 void llcp_pdu_decode_length_req(struct ll_conn *conn, struct pdu_data *pdu)
 {
 	struct pdu_data_llctrl_length_req *p = &pdu->llctrl.length_req;
+
 	conn->lll.dle.remote.max_rx_octets = sys_le16_to_cpu(p->max_rx_octets);
 	conn->lll.dle.remote.max_tx_octets = sys_le16_to_cpu(p->max_tx_octets);
 	conn->lll.dle.remote.max_rx_time = sys_le16_to_cpu(p->max_rx_time);
@@ -698,6 +699,7 @@ void llcp_pdu_decode_length_req(struct ll_conn *conn, struct pdu_data *pdu)
 void llcp_pdu_decode_length_rsp(struct ll_conn *conn, struct pdu_data *pdu)
 {
 	struct pdu_data_llctrl_length_rsp *p = &pdu->llctrl.length_rsp;
+
 	conn->lll.dle.remote.max_rx_octets = sys_le16_to_cpu(p->max_rx_octets);
 	conn->lll.dle.remote.max_tx_octets = sys_le16_to_cpu(p->max_tx_octets);
 	conn->lll.dle.remote.max_rx_time = sys_le16_to_cpu(p->max_rx_time);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
@@ -290,9 +290,11 @@ static inline void pu_set_preferred_phys(struct ll_conn *conn, struct proc_ctx *
 	conn->phy_pref_rx = ctx->data.pu.rx;
 	conn->phy_pref_tx = ctx->data.pu.tx;
 
-	/* Note: Since 'flags' indicate local coded phy preference (S2 or S8) and
-	   this is not negotiated with the peer, it is simply reconfigured in conn->lll when
-	   the update is initiated, and takes effect whenever the coded phy is in use. */
+	/*
+	 * Note: Since 'flags' indicate local coded phy preference (S2 or S8) and
+	 * this is not negotiated with the peer, it is simply reconfigured in conn->lll when
+	 * the update is initiated, and takes effect whenever the coded phy is in use.
+	 */
 	conn->lll.phy_flags = ctx->data.pu.flags;
 }
 
@@ -303,17 +305,17 @@ static inline void pu_combine_phys(struct ll_conn *conn, struct proc_ctx *ctx, u
 	ctx->data.pu.rx &= rx;
 	ctx->data.pu.tx &= tx;
 	/* If either tx or rx is 'no change' at this point we force both to no change to
-	   comply with the spec
-		Spec. BT5.2 Vol6, Part B, section 5.1.10:
-		The remainder of this section shall apply irrespective of which device initiated
-		the procedure.
-
-		Irrespective of the above rules, the master may leave both directions
-		unchanged. If the slave specified a single PHY in both the TX_PHYS and
-		RX_PHYS fields and both fields are the same, the master shall either select
-		the PHY specified by the slave for both directions or shall leave both directions
-		unchanged.
-	*/
+	 * comply with the spec
+	 *	Spec. BT5.2 Vol6, Part B, section 5.1.10:
+	 *	The remainder of this section shall apply irrespective of which device initiated
+	 *	the procedure.
+	 *
+	 *	Irrespective of the above rules, the master may leave both directions
+	 *	unchanged. If the slave specified a single PHY in both the TX_PHYS and
+	 *	RX_PHYS fields and both fields are the same, the master shall either select
+	 *	the PHY specified by the slave for both directions or shall leave both directions
+	 *	unchanged.
+	 */
 	if (conn->lll.role == BT_HCI_ROLE_CENTRAL && (!ctx->data.pu.rx || !ctx->data.pu.tx)) {
 		ctx->data.pu.tx = 0;
 		ctx->data.pu.rx = 0;
@@ -492,10 +494,12 @@ static void lp_pu_st_wait_rx_phy_rsp(struct ll_conn *conn, struct proc_ctx *ctx,
 {
 	switch (evt) {
 	case LP_PU_EVT_PHY_RSP:
+		/* EGON TODO: should we swap the function call with variable declaration? */
 		llcp_rr_set_incompat(conn, INCOMPAT_RESERVED);
 		/* 'Prefer' the phys from the REQ */
 		uint8_t tx_pref = ctx->data.pu.tx;
 		uint8_t rx_pref = ctx->data.pu.rx;
+
 		llcp_pdu_decode_phy_rsp(ctx, (struct pdu_data *)param);
 		/* Pause data tx */
 		llcp_tx_pause_data(conn);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
@@ -70,6 +70,10 @@ enum {
 
 static bool proc_with_instant(struct proc_ctx *ctx)
 {
+	/*
+	 * EGON TODO: should we combine all the cases that return 0
+	 * and all the cases that return 1?
+	 */
 	switch (ctx->proc) {
 	case PROC_FEATURE_EXCHANGE:
 		return 0U;
@@ -465,6 +469,7 @@ static void rr_st_idle(struct ll_conn *conn, uint8_t evt, void *param)
 				/* Send reject */
 				struct node_rx_pdu *rx = (struct node_rx_pdu *)param;
 				struct pdu_data *pdu = (struct pdu_data *)rx->pdu;
+
 				conn->llcp.remote.reject_opcode = pdu->llctrl.opcode;
 				rr_act_reject(conn);
 			} else if (with_instant && incompat == INCOMPAT_RESERVED) {


### PR DESCRIPTION
Reduce the number of warnings and errors from checkpatch, mainly comment style and white-space related

Before: ca. 90 warnings/errors
After: ca. 30 warnings/errors, which seems to be false positives

Signed-off-by: Andries Kruithof <Andries.Kruithof@nordicsemi.no>