### PR TITLE
devicetree: remove support for DTC_OVERLAY_FILE in environment

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -489,10 +489,7 @@ zephyr_boilerplate_watch(CONF_FILE)
 
 if(DTC_OVERLAY_FILE)
   # DTC_OVERLAY_FILE has either been specified on the cmake CLI or is already
-  # in the CMakeCache.txt. This has precedence over the environment
-  # variable DTC_OVERLAY_FILE
-elseif(DEFINED ENV{DTC_OVERLAY_FILE})
-  set(DTC_OVERLAY_FILE $ENV{DTC_OVERLAY_FILE})
+  # in the CMakeCache.txt.
 elseif(APP_BOARD_DTS)
   set(DTC_OVERLAY_FILE ${APP_BOARD_DTS})
 elseif(EXISTS          ${APPLICATION_SOURCE_DIR}/${BOARD}.overlay)

--- a/doc/guides/dts/howtos.rst
+++ b/doc/guides/dts/howtos.rst
@@ -210,7 +210,6 @@ Here are some ways to set it:
    (``-DDTC_OVERLAY_FILE="file1.overlay;file2.overlay"``)
 #. with the CMake ``set()`` command in the application ``CMakeLists.txt``,
    before including zephyr's :file:`boilerplate.cmake` file
-#. using a ``DTC_OVERLAY_FILE`` environment variable (deprecated)
 #. create a ``boards/<BOARD>_<revision>.overlay`` file in the application
    folder for the current board revision. This requires that the board supports
    multiple revisions, see :ref:`porting_board_revisions`.


### PR DESCRIPTION
Setting of DTC_OVERLAY_FILE as an environment setting was deprecated
before Zephyr 1.14 LTS.

This commit remove the support for this possibility and thus cleans up
the build system.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>