### PR TITLE
ARC: boards: HS6x: nSIM: drop unsupported dcache_uncached_region from mdb.args

### DIFF
--- a/boards/arc/nsim/support/mdb_hs6x.args
+++ b/boards/arc/nsim/support/mdb_hs6x.args
@@ -10,7 +10,6 @@
 	-prop=nsim_isa_vec64=1
 	-dcache=65536,64,2,a
 	-dcache_feature=2
-	-dcache_uncached_region
 	-dcache_mem_cycles=2
 	-icache=65536,64,4,a
 	-icache_feature=2

--- a/boards/arc/nsim/support/mdb_hs6x_smp.args
+++ b/boards/arc/nsim/support/mdb_hs6x_smp.args
@@ -10,7 +10,6 @@
 	-prop=nsim_isa_vec64=1
 	-dcache=65536,64,2,a
 	-dcache_feature=2
-	-dcache_uncached_region
 	-dcache_mem_cycles=2
 	-icache=65536,64,4,a
 	-icache_feature=2


### PR DESCRIPTION
HS6x nSIM doesn't support dcache_uncached_region property. Its presence in configs (mdb.args) causes issues with 2021.06 nSIM, so let's drop this property as it isn't used anyway.