### PR TITLE
tests: ARC: enable back tests/lib/ringbuffer on qemu_arc_hs6x

### DIFF
--- a/tests/lib/ringbuffer/testcase.yaml
+++ b/tests/lib/ringbuffer/testcase.yaml
@@ -3,8 +3,6 @@ common:
 
 tests:
   libraries.ring_buffer:
-    # FIXME: qemu_arc_hs6x excluded, see #37861
-    platform_exclude: qemu_arc_hs6x
     integration_platforms:
       - native_posix
 


### PR DESCRIPTION
tests/lib/ringbuffer is now finally fixed with commit 15e834a687, so we can enable it back on qemu_arc_hs6x.

Related issue: #37861