### PR TITLE
drivers/timers: stm32_lptim: Set LSI as default LPTIM clck source

### DIFF
--- a/drivers/timer/Kconfig.stm32_lptim
+++ b/drivers/timer/Kconfig.stm32_lptim
@@ -17,15 +17,15 @@ if STM32_LPTIM_TIMER
 choice STM32_LPTIM_CLOCK
 	prompt "LPTIM clock value configuration"
 
-config STM32_LPTIM_CLOCK_LSE
-	bool "LSE"
-	help
-	  Use LSE as LPTIM clock
-
 config STM32_LPTIM_CLOCK_LSI
 	bool "LSI"
 	help
 	  Use LSI as LPTIM clock
+
+config STM32_LPTIM_CLOCK_LSE
+	bool "LSE"
+	help
+	  Use LSE as LPTIM clock
 
 endchoice
 


### PR DESCRIPTION
Timer STM32 LPTIM currently supports 2 clocks sources: LSE & LSI.
LSE (external) is defined as default but its availability depends
on board support package and then may not be available.

This ends up in situations where users have LSE implicitly selected
while no crystal is available on board, leading to non functional
LPTIM.

To avoid this situation, makes LSI clock, which is always available
(since internal to the SoC), the default LPTIM source clock.
Then, default case will be functional. Users will then be able to
select LSE if needed.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>