### PR TITLE
MAINTAINERS: fix github user name for Ruud

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1297,7 +1297,7 @@ SPARC arch:
 Synopsys Platforms:
     status: maintained
     maintainers:
-        - ruudw
+        - ruuddw
     collaborators:
         - abrodkin
         - evgeniy-paltsev


### PR DESCRIPTION
Fixed typo in user name.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
