### PR TITLE
RFC: drivers: serial: Use microseconds to represent timeout

### DIFF
--- a/doc/releases/release-notes-3.0.rst
+++ b/doc/releases/release-notes-3.0.rst
@@ -29,6 +29,11 @@ API Changes
 
 Changes in this release
 
+* Following functions in UART Asynchronous API are using microseconds to represent
+  timeout instead of milliseconds:
+  * :c:func:`uart_tx`
+  * :c:func:`uart_rx_enable`
+
 ==========================
 
 Removed APIs in this release

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -448,7 +448,7 @@ static int uart_nrfx_tx_abort(const struct device *dev)
 		return -EINVAL;
 	}
 #if	HW_FLOW_CONTROL_AVAILABLE
-	if (uart0_cb.tx_timeout != SYS_FOREVER_MS) {
+	if (uart0_cb.tx_timeout != SYS_FOREVER_US) {
 		k_timer_stop(&uart0_cb.tx_timeout_timer);
 	}
 #endif
@@ -527,7 +527,7 @@ static int uart_nrfx_rx_disable(const struct device *dev)
 	}
 
 	uart0_cb.rx_enabled = 0;
-	if (uart0_cb.rx_timeout != SYS_FOREVER_MS) {
+	if (uart0_cb.rx_timeout != SYS_FOREVER_US) {
 		k_timer_stop(&uart0_cb.rx_timeout_timer);
 	}
 	nrf_uart_task_trigger(uart0_addr, NRF_UART_TASK_STOPRX);
@@ -599,15 +599,15 @@ static void rx_isr(const struct device *dev)
 		uart0_cb.rx_counter++;
 		if (uart0_cb.rx_timeout == 0) {
 			rx_rdy_evt(dev);
-		} else if (uart0_cb.rx_timeout != SYS_FOREVER_MS) {
+		} else if (uart0_cb.rx_timeout != SYS_FOREVER_US) {
 			k_timer_start(&uart0_cb.rx_timeout_timer,
-				      K_MSEC(uart0_cb.rx_timeout),
+				      K_USEC(uart0_cb.rx_timeout),
 				      K_NO_WAIT);
 		}
 	}
 
 	if (uart0_cb.rx_buffer_length == uart0_cb.rx_counter) {
-		if (uart0_cb.rx_timeout != SYS_FOREVER_MS) {
+		if (uart0_cb.rx_timeout != SYS_FOREVER_US) {
 			k_timer_stop(&uart0_cb.rx_timeout_timer);
 		}
 		rx_rdy_evt(dev);
@@ -643,9 +643,9 @@ static void tx_isr(const struct device *dev)
 	if (uart0_cb.tx_counter < uart0_cb.tx_buffer_length &&
 	    !uart0_cb.tx_abort) {
 #if	HW_FLOW_CONTROL_AVAILABLE
-		if (uart0_cb.tx_timeout != SYS_FOREVER_MS) {
+		if (uart0_cb.tx_timeout != SYS_FOREVER_US) {
 			k_timer_start(&uart0_cb.tx_timeout_timer,
-				      K_MSEC(uart0_cb.tx_timeout),
+				      K_USEC(uart0_cb.tx_timeout),
 				      K_NO_WAIT);
 		}
 #endif
@@ -657,7 +657,7 @@ static void tx_isr(const struct device *dev)
 	} else {
 #if	HW_FLOW_CONTROL_AVAILABLE
 
-		if (uart0_cb.tx_timeout != SYS_FOREVER_MS) {
+		if (uart0_cb.tx_timeout != SYS_FOREVER_US) {
 			k_timer_stop(&uart0_cb.tx_timeout_timer);
 		}
 #endif
@@ -686,7 +686,7 @@ static void tx_isr(const struct device *dev)
 
 static void error_isr(const struct device *dev)
 {
-	if (uart0_cb.rx_timeout != SYS_FOREVER_MS) {
+	if (uart0_cb.rx_timeout != SYS_FOREVER_US) {
 		k_timer_stop(&uart0_cb.rx_timeout_timer);
 	}
 	nrf_uart_event_clear(uart0_addr, NRF_UART_EVENT_ERROR);
@@ -766,7 +766,7 @@ static void tx_timeout(struct k_timer *timer)
 {
 	struct uart_event evt;
 
-	if (uart0_cb.tx_timeout != SYS_FOREVER_MS) {
+	if (uart0_cb.tx_timeout != SYS_FOREVER_US) {
 		k_timer_stop(&uart0_cb.tx_timeout_timer);
 	}
 	nrf_uart_task_trigger(uart0_addr, NRF_UART_TASK_STOPTX);

--- a/drivers/serial/uart_sam0.c
+++ b/drivers/serial/uart_sam0.c
@@ -283,7 +283,7 @@ static void uart_sam0_dma_rx_done(const struct device *dma_dev, void *arg,
 	 * reception.  This also catches the case of DMA completion during
 	 * timeout handling.
 	 */
-	if (dev_data->rx_timeout_time != SYS_FOREVER_MS) {
+	if (dev_data->rx_timeout_time != SYS_FOREVER_US) {
 		dev_data->rx_waiting_for_irq = true;
 		regs->INTENSET.reg = SERCOM_USART_INTENSET_RXC;
 		irq_unlock(key);
@@ -356,7 +356,7 @@ static void uart_sam0_rx_timeout(struct k_work *work)
 	if (dev_data->rx_timeout_from_isr) {
 		dev_data->rx_timeout_from_isr = false;
 		k_work_reschedule(&dev_data->rx_timeout_work,
-				      K_MSEC(dev_data->rx_timeout_chunk));
+				      K_USEC(dev_data->rx_timeout_chunk));
 		irq_unlock(key);
 		return;
 	}
@@ -378,7 +378,7 @@ static void uart_sam0_rx_timeout(struct k_work *work)
 				      dev_data->rx_timeout_chunk);
 
 		k_work_reschedule(&dev_data->rx_timeout_work,
-				      K_MSEC(remaining));
+				      K_USEC(remaining));
 	}
 
 	irq_unlock(key);
@@ -755,11 +755,11 @@ static void uart_sam0_isr(const struct device *dev)
 		 * If we have a timeout, restart the time remaining whenever
 		 * we see data.
 		 */
-		if (dev_data->rx_timeout_time != SYS_FOREVER_MS) {
+		if (dev_data->rx_timeout_time != SYS_FOREVER_US) {
 			dev_data->rx_timeout_from_isr = true;
 			dev_data->rx_timeout_start = k_uptime_get_32();
 			k_work_reschedule(&dev_data->rx_timeout_work,
-					      K_MSEC(dev_data->rx_timeout_chunk));
+					      K_USEC(dev_data->rx_timeout_chunk));
 		}
 
 		/* DMA will read the currently ready byte out */
@@ -945,9 +945,9 @@ static int uart_sam0_tx(const struct device *dev, const uint8_t *buf,
 		return retval;
 	}
 
-	if (timeout != SYS_FOREVER_MS) {
+	if (timeout != SYS_FOREVER_US) {
 		k_work_reschedule(&dev_data->tx_timeout_work,
-				      K_MSEC(timeout));
+				      K_USEC(timeout));
 	}
 
 	return dma_start(cfg->dma_dev, cfg->tx_dma_channel);

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -808,10 +808,10 @@ static inline void async_evt_rx_buf_release(struct uart_stm32_data *data)
 static inline void async_timer_start(struct k_work_delayable *work,
 				     int32_t timeout)
 {
-	if ((timeout != SYS_FOREVER_MS) && (timeout != 0)) {
+	if ((timeout != SYS_FOREVER_US) && (timeout != 0)) {
 		/* start timer */
-		LOG_DBG("async timer started for %d ms", timeout);
-		k_work_reschedule(work, K_MSEC(timeout));
+		LOG_DBG("async timer started for %d us", timeout);
+		k_work_reschedule(work, K_USEC(timeout));
 	}
 }
 

--- a/include/drivers/uart.h
+++ b/include/drivers/uart.h
@@ -486,8 +486,8 @@ static inline int uart_callback_set(const struct device *dev,
  * @param dev     UART device structure.
  * @param buf     Pointer to transmit buffer.
  * @param len     Length of transmit buffer.
- * @param timeout Timeout in milliseconds. Valid only if flow control is
- *		  enabled. @ref SYS_FOREVER_MS disables timeout.
+ * @param timeout Timeout in microseconds. Valid only if flow control is
+ *		  enabled. @ref SYS_FOREVER_US disables timeout.
  *
  * @retval -ENOTSUP If not supported.
  * @retval -EBUSY   There is already an ongoing transfer.
@@ -550,7 +550,7 @@ static inline int z_impl_uart_tx_abort(const struct device *dev)
  * @param len     Buffer length.
  * @param timeout Inactivity period after receiving at least a byte which
  *		  triggers  @ref uart_event_type::UART_RX_RDY event. Given in
- *		  milliseconds. @ref SYS_FOREVER_MS disables timeout. See
+ *		  microseconds. @ref SYS_FOREVER_US disables timeout. See
  *		  @ref uart_event_type for details.
  *
  * @retval -ENOTSUP If not supported.

--- a/include/sys/time_units.h
+++ b/include/sys/time_units.h
@@ -20,6 +20,12 @@ extern "C" {
  */
 #define SYS_FOREVER_MS (-1)
 
+/** @brief System-wide macro to denote "forever" in microseconds
+ *
+ * See @ref SYS_FOREVER_MS.
+ */
+#define SYS_FOREVER_US (-1)
+
 /** @brief System-wide macro to convert milliseconds to kernel timeouts
  */
 #define SYS_TIMEOUT_MS(ms) ((ms) == SYS_FOREVER_MS ? K_FOREVER : K_MSEC(ms))

--- a/tests/drivers/uart/uart_mix_fifo_poll/src/main.c
+++ b/tests/drivers/uart/uart_mix_fifo_poll/src/main.c
@@ -89,7 +89,7 @@ static void counter_top_handler(const struct device *dev, void *user_data)
 		int err;
 
 		err = uart_rx_enable(uart_dev, async_rx_buf,
-				     sizeof(async_rx_buf), 1);
+				     sizeof(async_rx_buf), 1 * USEC_PER_MSEC);
 		zassert_true(err >= 0, NULL);
 		async_rx_enabled = true;
 	} else if (int_driven) {
@@ -248,7 +248,7 @@ static void int_async_thread_func(void *p_data, void *base, void *range)
 
 			buf = &int_async_data->buf[data->cnt & 0xF];
 			data->cnt++;
-			err = uart_tx(uart_dev, buf, 1, 1000);
+			err = uart_tx(uart_dev, buf, 1, 1000 * USEC_PER_MSEC);
 			zassert_true(err >= 0,
 					"Unexpected err:%d", err);
 		} else {

--- a/tests/drivers/uart/uart_pm/src/main.c
+++ b/tests/drivers/uart/uart_pm/src/main.c
@@ -83,11 +83,11 @@ static bool async_verify(const struct device *dev, bool active)
 	zassert_equal(err, 0, "Unexpected err: %d", err);
 
 	if (HAS_RX) {
-		err = uart_rx_enable(dev, rxbuf, sizeof(rxbuf), 1);
+		err = uart_rx_enable(dev, rxbuf, sizeof(rxbuf), 1 * USEC_PER_MSEC);
 		zassert_equal(err, 0, "Unexpected err: %d", err);
 	}
 
-	err = uart_tx(dev, txbuf, sizeof(txbuf), 10);
+	err = uart_tx(dev, txbuf, sizeof(txbuf), 10 * USEC_PER_MSEC);
 	zassert_equal(err, 0, "Unexpected err: %d", err);
 
 	k_busy_wait(10000);


### PR DESCRIPTION
Updated uart_rx_enable() and uart_tx() to use timeout given
in microseconds. Previously argument was given in milliseconds.
However, there are cases when milliseconds granularity is not
enough and can significantly reduce a throughput, e.g. 1ms is
100 bytes at 1Mb.
    
Updated 4 drivers which implement asynchronous API. Updated
places where API was used.

Additionally, added `SYS_FOREVER_US` to represent inifinity in microseconds (similar to `SYS_FOREVER_MS`).

Fixes #30861.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>