### PR TITLE
drivers: sensors: fdc2x1x: Fixed warnings and bugs when PM_DEVICE is used

### DIFF
--- a/drivers/sensor/fdc2x1x/fdc2x1x.c
+++ b/drivers/sensor/fdc2x1x/fdc2x1x.c
@@ -485,7 +485,6 @@ static int fdc2x1x_device_pm_ctrl(const struct device *dev,
 				  enum pm_device_action action)
 {
 	int ret;
-	struct fdc2x1x_data *data = dev->data;
 	const struct fdc2x1x_config *cfg = dev->config;
 	enum pm_device_state curr_state;
 
@@ -613,7 +612,6 @@ static int fdc2x1x_sample_fetch(const struct device *dev,
 				enum sensor_channel chan)
 {
 #ifdef CONFIG_PM_DEVICE
-	struct fdc2x1x_data *data = dev->data;
 	enum pm_device_state state;
 
 	(void)pm_device_state_get(dev, &state);

--- a/samples/sensor/fdc2x1x/src/main.c
+++ b/samples/sensor/fdc2x1x/src/main.c
@@ -36,9 +36,6 @@ static void trigger_handler(const struct device *dev,
 #ifdef CONFIG_PM_DEVICE
 static void pm_info(enum pm_device_state state, int status)
 {
-	ARG_UNUSED(dev);
-	ARG_UNUSED(arg);
-
 	switch (state) {
 	case PM_DEVICE_STATE_ACTIVE:
 		printk("Enter ACTIVE_STATE ");
@@ -49,6 +46,8 @@ static void pm_info(enum pm_device_state state, int status)
 	case PM_DEVICE_STATE_OFF:
 		printk("Enter OFF_STATE ");
 		break;
+	default:
+		printk("Unknown power state");
 	}
 
 	if (status) {


### PR DESCRIPTION
When using PM_DEVICE I encountered some errors and unused warnings when compiling the driver with the corresponding sample. 
These are fixed with this patch.

Signed-off-by: Igor Knippenberg igor.knippenberg@gmail.com