### PR TITLE
ITE: drivers/i2c: returning negative values for error

### DIFF
--- a/drivers/i2c/i2c_ite_it8xxx2.c
+++ b/drivers/i2c/i2c_ite_it8xxx2.c
@@ -164,6 +164,33 @@ static const struct i2c_pin i2c_pin_regs[] = {
 	{ &GPDMRA, &GPDMRA,	0x10, 0x20},
 };
 
+static int i2c_parsing_return_value(const struct device *dev)
+{
+	struct i2c_it8xxx2_data *data = DEV_DATA(dev);
+	const struct i2c_it8xxx2_config *config = DEV_CFG(dev);
+
+	if (!data->err)
+		return 0;
+
+	/* Connection timed out */
+	if (data->err == ETIMEDOUT)
+		return -ETIMEDOUT;
+
+	if (config->port < I2C_STANDARD_PORT_COUNT) {
+		/* The device does not respond ACK */
+		if (data->err == HOSTA_NACK)
+			return -ENXIO;
+		else
+			return -EIO;
+	} else {
+		/* The device does not respond ACK */
+		if (data->err == E_HOSTA_ACK)
+			return -ENXIO;
+		else
+			return -EIO;
+	}
+}
+
 static int i2c_get_line_levels(const struct device *dev)
 {
 	const struct i2c_it8xxx2_config *config = DEV_CFG(dev);
@@ -835,7 +862,7 @@ static int i2c_it8xxx2_transfer(const struct device *dev, struct i2c_msg *msgs,
 	/* Unlock mutex of i2c controller */
 	k_mutex_unlock(&data->mutex);
 
-	return data->err;
+	return i2c_parsing_return_value(dev);
 }
 
 static void i2c_it8xxx2_isr(void *arg)


### PR DESCRIPTION
Fixes: #38959

Currently, the I2C driver returns I2C status register value as error
code when error happen. This PR fixes returning system number and
the return values is negative for error.

Signed-off-by: Tim Lin <tim2.lin@ite.corp-partner.google.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zephyrproject-rtos/zephyr/39078)
<!-- Reviewable:end -->
