### PR TITLE
ITE: dts: cpu/yaml: fix the name of compatible

### DIFF
--- a/dts/bindings/cpu/ite,riscv-ite.yaml
+++ b/dts/bindings/cpu/ite,riscv-ite.yaml
@@ -3,6 +3,6 @@
 
 description: ITE IT8XXX2 RISC-V CPU
 
-compatible: "riscv-ite"
+compatible: "ite,riscv-ite"
 
 include: cpu.yaml


### PR DESCRIPTION
This name should be the same as cpus node in dtsi. After the power
policy is added, the cpu-power-states in the CPU properties can
be used.

Signed-off-by: Tim Lin <tim2.lin@ite.corp-partner.google.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zephyrproject-rtos/zephyr/39080)
<!-- Reviewable:end -->
