### PR TITLE
ITE: soc: pull-down GPIO L/K groups and set GPIOH7 output low at default

### DIFF
--- a/drivers/gpio/gpio_ite_it8xxx2.c
+++ b/drivers/gpio/gpio_ite_it8xxx2.c
@@ -601,3 +601,27 @@ DEVICE_DT_INST_DEFINE(inst,                                        \
 		&gpio_ite_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(GPIO_ITE_DEV_CFG_DATA)
+
+static int gpio_it8xxx2_init_set(const struct device *arg)
+{
+	ARG_UNUSED(arg);
+
+	if (IS_ENABLED(CONFIG_SOC_IT8XXX2_GPIO_GROUP_K_L_DEFAULT_PULL_DOWN)) {
+		const struct device *gpiok = DEVICE_DT_GET(DT_NODELABEL(gpiok));
+		const struct device *gpiol = DEVICE_DT_GET(DT_NODELABEL(gpiol));
+
+		for (int i = 0; i < 8; i++) {
+			gpio_pin_configure(gpiok, i, GPIO_INPUT | GPIO_PULL_DOWN);
+			gpio_pin_configure(gpiol, i, GPIO_INPUT | GPIO_PULL_DOWN);
+		}
+	}
+
+	if (IS_ENABLED(CONFIG_SOC_IT8XXX2_GPIO_H7_DEFAULT_OUTPUT_LOW)) {
+		const struct device *gpioh = DEVICE_DT_GET(DT_NODELABEL(gpioh));
+
+		gpio_pin_configure(gpioh, 7, GPIO_OUTPUT_LOW);
+	}
+
+	return 0;
+}
+SYS_INIT(gpio_it8xxx2_init_set, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);

--- a/soc/riscv/riscv-ite/it8xxx2/Kconfig.soc
+++ b/soc/riscv/riscv-ite/it8xxx2/Kconfig.soc
@@ -23,6 +23,24 @@ config SOC_IT8XXX2_PLL_FLASH_48M
 	  Set n to use the default settings.
 	  (PLL and CPU run at 48MHz, flash frequency is 16MHz)
 
+config SOC_IT8XXX2_GPIO_GROUP_K_L_DEFAULT_PULL_DOWN
+	bool "The pins of GPIO group K and L aren't bonding with pad"
+	default y
+	help
+	  On IT81202 (128-pins package), the pins of GPIO group K and L aren't
+	  bonding with pad. So we configure these pins as internal pull-down
+	  at default to prevent leakage current due to floating.
+
+config SOC_IT8XXX2_GPIO_H7_DEFAULT_OUTPUT_LOW
+	bool "The GPIOH7 isn't bonding with pad and is left floating internally"
+	default y
+	help
+	  On IT81202/IT81302, the GPIOH7 isn't bonding with pad and is left
+	  floating internally. We need to enable internal pull-down for the pin
+	  to prevent leakage current, but IT81202/IT81302 doesn't have the
+	  capability to pull it down. We can only set it as output low,
+	  so we enable output low for it at initialization to prevent leakage.
+
 choice
 	prompt "Clock source for PLL reference clock"
 


### PR DESCRIPTION
GPIO L/K groups:
On IT81202 (128-pins package), the pins of GPIO group K and L aren't
bonding with pad. So we configure these pins as internal pull-down
at default to prevent leakage current due to floating.

GPIOH7:
On IT81202/IT81302, the GPIOH7 isn't bonding with pad and is left
floating internally. We need to enable internal pull-down for the pin
to prevent leakage current, but IT81202/IT81302 doesn't have the
capability to pull it down. We can only set it as output low,
so we enable output low for it at initialization to prevent leakage.

After setting: power saving=2.26mA

Signed-off-by: Tim Lin <tim2.lin@ite.corp-partner.google.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zephyrproject-rtos/zephyr/39081)
<!-- Reviewable:end -->
