### PR TITLE
data: json: include missing toolchain.h

### DIFF
--- a/include/data/json.h
+++ b/include/data/json.h
@@ -9,6 +9,7 @@
 
 #include <sys/util.h>
 #include <stddef.h>
+#include <toolchain.h>
 #include <zephyr/types.h>
 #include <sys/types.h>
 


### PR DESCRIPTION
This header is needed in order to use __deprecated macro.