### PR TITLE
drivers: wifi: esp_at: fix connect to open network

### DIFF
--- a/drivers/wifi/esp_at/esp.c
+++ b/drivers/wifi/esp_at/esp.c
@@ -829,9 +829,10 @@ static int esp_mgmt_connect(const struct device *dev,
 	memcpy(&data->conn_cmd[len], params->ssid, params->ssid_length);
 	len += params->ssid_length;
 
-	if (params->security == WIFI_SECURITY_TYPE_PSK) {
-		len += snprintk(&data->conn_cmd[len],
+	len += snprintk(&data->conn_cmd[len],
 				sizeof(data->conn_cmd) - len, "\",\"");
+
+	if (params->security == WIFI_SECURITY_TYPE_PSK) {
 		memcpy(&data->conn_cmd[len], params->psk, params->psk_length);
 		len += params->psk_length;
 	}


### PR DESCRIPTION
According to ESP-AT documentation ([1] for version before 2.0 and [2]
for version 2.1) of AT+CWJAP command, both SSID and PSK are required.
Even for newest ESP-AT release 2.2 ([3]) "," (comma) is needed even if
SSID or PSK are not explicitly provided.

Send 'AT+CWJAP="SSID",""' instead of 'AT+CWJAP="SSID"' when connecting
to open WiFi network, to follow AT commands documentation.

Tested with ESP-AT firmware 2.1.

[1] https://www.espressif.com/sites/default/files/documentation/4a-esp8266_at_instruction_set_en.pdf
[2] https://github.com/espressif/esp-at/blob/release/v2.1.0.0_esp8266/docs/en/AT_Command_Set/Wi-Fi_AT_Commands.md#atcwjapconnects-to-an-ap
[3] https://github.com/espressif/esp-at/blob/release/v2.2.0.0_esp8266/docs/en/AT_Command_Set/Wi-Fi_AT_Commands.rst#refatcwjap-wifi-at-connect-to-an-ap

Fixes #39205