### PR TITLE
Bluetooth: Controller: Fix Direct Advertising support in Extended Advertising Reports

### DIFF
--- a/include/bluetooth/addr.h
+++ b/include/bluetooth/addr.h
@@ -29,6 +29,12 @@ extern "C" {
 #define BT_ADDR_LE_RANDOM       0x01
 #define BT_ADDR_LE_PUBLIC_ID    0x02
 #define BT_ADDR_LE_RANDOM_ID    0x03
+#define BT_ADDR_LE_UNRESOLVED   0xFE /* Resolvable Private Address
+				      * (Controller unable to resolve)
+				      */
+#define BT_ADDR_LE_ANONYMOUS    0xFF /* No address provided
+				      * (anonymous advertisement)
+				      */
 
 /** Length in bytes of a standard Bluetooth address */
 #define BT_ADDR_SIZE 6

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -5190,6 +5190,7 @@ static void le_ext_adv_report(struct pdu_data *pdu_data,
 	uint8_t sec_phy = 0U;
 	uint8_t data_max_len;
 	uint8_t rl_idx = 0U;
+	bool direct = false;
 	int8_t rssi;
 
 	/* NOTE: This function uses a lot of initializers before the check and
@@ -5225,12 +5226,16 @@ static void le_ext_adv_report(struct pdu_data *pdu_data,
 		uint8_t hdr_len;
 		uint8_t *ptr;
 
-		/* The Link Layer currently returns RSSI as an absolute value */
-		rssi = -(node_rx_curr->hdr.rx_ftr.rssi);
+#if defined(CONFIG_BT_CTLR_EXT_SCAN_FP)
+		bool direct_curr = node_rx_curr->hdr.rx_ftr.direct;
+#endif /* CONFIG_BT_CTLR_EXT_SCAN_FP */
 
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 		uint8_t rl_idx_curr = node_rx_curr->hdr.rx_ftr.rl_idx;
 #endif /* CONFIG_BT_CTLR_PRIVACY */
+
+		/* The Link Layer currently returns RSSI as an absolute value */
+		rssi = -(node_rx_curr->hdr.rx_ftr.rssi);
 
 		BT_DBG("phy= 0x%x, type= 0x%x, len= %u, tat= %u, rat= %u,"
 		       " rssi=%d dB", phy, adv->type, adv->len, adv->tx_addr,
@@ -5387,6 +5392,9 @@ no_ext_hdr:
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 			rl_idx = rl_idx_curr;
 #endif /* CONFIG_BT_CTLR_PRIVACY */
+#if defined(CONFIG_BT_CTLR_EXT_SCAN_FP)
+			direct = direct_curr;
+#endif /* CONFIG_BT_CTLR_EXT_SCAN_FP */
 		} else {
 			/* TODO: Validate current value with previous */
 
@@ -5423,11 +5431,18 @@ no_ext_hdr:
 				 * fragment.
 				 */
 			}
+
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 			if (rl_idx >= ll_rl_size_get()) {
 				rl_idx = rl_idx_curr;
 			}
 #endif /* CONFIG_BT_CTLR_PRIVACY */
+
+#if defined(CONFIG_BT_CTLR_EXT_SCAN_FP)
+			if (!direct) {
+				direct = direct_curr;
+			}
+#endif /* CONFIG_BT_CTLR_EXT_SCAN_FP */
 		}
 
 		if (!node_rx_next) {

--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -280,7 +280,21 @@ struct node_rx_ftr {
 	uint32_t ticks_anchor;
 	uint32_t radio_end_us;
 	uint8_t  rssi;
+
+#if defined(CONFIG_BT_CTLR_PRIVACY)
+	uint8_t  rl_idx;
+	uint8_t  lrpa_used:1;
+#endif /* CONFIG_BT_CTLR_PRIVACY */
+
+#if defined(CONFIG_BT_CTLR_EXT_SCAN_FP)
+	uint8_t  direct:1;
+#endif /* CONFIG_BT_CTLR_EXT_SCAN_FP */
+
 #if defined(CONFIG_BT_CTLR_ADV_EXT) && defined(CONFIG_BT_OBSERVER)
+#if defined(CONFIG_BT_CTLR_PRIVACY)
+	uint8_t  direct_resolved:1;
+#endif /* CONFIG_BT_CTLR_PRIVACY */
+
 	uint8_t  aux_lll_sched:1;
 	uint8_t  aux_w4next:1;
 	uint8_t  aux_failed:1;
@@ -292,13 +306,7 @@ struct node_rx_ftr {
 	uint8_t  scan_req:1;
 	uint8_t  scan_rsp:1;
 #endif /* CONFIG_BT_CTLR_ADV_EXT && CONFIG_BT_OBSERVER */
-#if defined(CONFIG_BT_CTLR_EXT_SCAN_FP)
-	uint8_t  direct:1;
-#endif /* CONFIG_BT_CTLR_EXT_SCAN_FP */
-#if defined(CONFIG_BT_CTLR_PRIVACY)
-	uint8_t  lrpa_used:1;
-	uint8_t  rl_idx;
-#endif /* CONFIG_BT_CTLR_PRIVACY */
+
 #if defined(CONFIG_BT_HCI_MESH_EXT)
 	uint8_t  chan_idx;
 #endif /* CONFIG_BT_HCI_MESH_EXT */

--- a/subsys/bluetooth/controller/ll_sw/lll_filter.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_filter.h
@@ -73,6 +73,10 @@ struct lll_resolve_list {
 #endif /* CONFIG_BT_CTLR_SYNC_PERIODIC_ADV_LIST */
 };
 
+extern uint32_t ull_filter_lll_fal_match(struct lll_filter const *const filter,
+					 uint8_t addr_type,
+					 uint8_t const *const addr,
+					 uint8_t *devmatch_id);
 extern bool ull_filter_lll_lrpa_used(uint8_t rl_idx);
 extern bt_addr_t *ull_filter_lll_lrpa_get(uint8_t rl_idx);
 extern uint8_t *ull_filter_lll_irks_get(uint8_t *count);

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -1477,7 +1477,7 @@ uint32_t radio_ar_has_match(void)
 		!NRF_AAR->EVENTS_NOTRESOLVED);
 }
 
-void radio_ar_resolve(uint8_t *addr)
+void radio_ar_resolve(const uint8_t *addr)
 {
 	NRF_AAR->ENABLE = (AAR_ENABLE_ENABLE_Enabled << AAR_ENABLE_ENABLE_Pos) &
 			  AAR_ENABLE_ENABLE_Msk;

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.h
@@ -110,7 +110,7 @@ void radio_ar_configure(uint32_t nirk, void *irk, uint8_t flags);
 uint32_t radio_ar_match_get(void);
 void radio_ar_status_reset(void);
 uint32_t radio_ar_has_match(void);
-void radio_ar_resolve(uint8_t *addr);
+void radio_ar_resolve(const uint8_t *addr);
 
 /* Enables CTE inline configuration to automatically setup sampling and
  * switching according to CTEInfo in received PDU.

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -622,6 +622,7 @@ static void isr_rx(void *param)
 	uint8_t trx_done;
 	uint8_t crc_ok;
 	uint8_t rl_idx;
+	bool has_adva;
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
 		lll_prof_latency_capture();
@@ -660,19 +661,36 @@ static void isr_rx(void *param)
 
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
-	if (ull_filter_lll_rl_enabled() && !irkmatch_ok && pdu->tx_addr &&
-	    (pdu->type == PDU_ADV_TYPE_EXT_IND)) {
-		uint8_t count;
+	if (pdu->type == PDU_ADV_TYPE_EXT_IND) {
+		struct pdu_adv_ext_hdr *ext_hdr;
 
-		ull_filter_lll_irks_get(&count);
-		if (count) {
-			radio_ar_resolve(
-				&pdu->adv_ext_ind.ext_hdr.data[ADVA_OFFSET]);
-			irkmatch_ok = radio_ar_has_match();
-			irkmatch_id = radio_ar_match_get();
+		ext_hdr = &pdu->adv_ext_ind.ext_hdr;
+		if (ext_hdr->adv_addr) {
+			has_adva = true;
+
+			if (ull_filter_lll_rl_enabled() && pdu->tx_addr) {
+				uint8_t count;
+
+				ull_filter_lll_irks_get(&count);
+				if (count) {
+					uint8_t *adva =
+						&ext_hdr->data[ADVA_OFFSET];
+
+					radio_ar_resolve(adva);
+					irkmatch_ok = radio_ar_has_match();
+					irkmatch_id = radio_ar_match_get();
+				}
+			}
+		} else {
+			has_adva = false;
 		}
+	} else {
+		has_adva = true;
 	}
-#endif /* CONFIG_BT_CTLR_ADV_EXT */
+
+#else /* !CONFIG_BT_CTLR_ADV_EXT */
+	has_adva = true;
+#endif /* !CONFIG_BT_CTLR_ADV_EXT */
 
 	rl_idx = devmatch_ok ?
 		 ull_filter_lll_rl_idx(!!(lll->filter_policy & 0x01),
@@ -680,11 +698,13 @@ static void isr_rx(void *param)
 		 irkmatch_ok ? ull_filter_lll_rl_irk_idx(irkmatch_id) :
 			       FILTER_IDX_NONE;
 #else
+	has_adva = true;
 	rl_idx = FILTER_IDX_NONE;
 #endif /* CONFIG_BT_CTLR_PRIVACY */
 
-	if (crc_ok && isr_rx_scan_check(lll, irkmatch_ok, devmatch_ok,
-					rl_idx)) {
+	if (crc_ok &&
+	    (!has_adva ||
+	     isr_rx_scan_check(lll, irkmatch_ok, devmatch_ok, rl_idx))) {
 		int err;
 
 		err = isr_rx_pdu(lll, pdu, devmatch_ok, devmatch_id,

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -1003,10 +1003,10 @@ static inline bool isr_rx_scan_check(struct lll_scan *lll, uint8_t irkmatch_ok,
 {
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 	return (((lll->filter_policy & 0x01) == 0) &&
-		 (!devmatch_ok || ull_filter_lll_rl_idx_allowed(irkmatch_ok,
-								rl_idx))) ||
-		(((lll->filter_policy & 0x01) != 0) &&
-		 (devmatch_ok || ull_filter_lll_irk_in_fal(rl_idx)));
+		(!devmatch_ok || ull_filter_lll_rl_idx_allowed(irkmatch_ok,
+							       rl_idx))) ||
+	       (((lll->filter_policy & 0x01) != 0) &&
+		(devmatch_ok || ull_filter_lll_irk_in_fal(rl_idx)));
 #else
 	return ((lll->filter_policy & 0x01) == 0U) ||
 		devmatch_ok;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -166,7 +166,8 @@ bool lll_scan_adva_check(struct lll_scan *lll, uint8_t addr_type, uint8_t *addr,
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 bool lll_scan_ext_tgta_check(struct lll_scan *lll, bool pri, bool is_init,
-			     struct pdu_adv *pdu, uint8_t rl_idx)
+			     struct pdu_adv *pdu, uint8_t rl_idx,
+			     bool *dir_report)
 {
 	uint8_t is_directed;
 	uint8_t tx_addr;
@@ -201,7 +202,7 @@ bool lll_scan_ext_tgta_check(struct lll_scan *lll, bool pri, bool is_init,
 		((!is_directed) ||
 		 (is_directed &&
 		  isr_scan_tgta_check(lll, is_init, rx_addr, tgta, rl_idx,
-				      NULL))));
+				      dir_report))));
 }
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
 
@@ -1304,7 +1305,8 @@ static inline int isr_rx_pdu(struct lll_scan *lll, struct pdu_adv *pdu_adv_rx,
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 		  ((pdu_adv_rx->type == PDU_ADV_TYPE_EXT_IND) &&
 		   lll->phy && lll_scan_ext_tgta_check(lll, true, false,
-						       pdu_adv_rx, rl_idx)) ||
+						       pdu_adv_rx, rl_idx,
+						       &dir_report)) ||
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
 		  ((pdu_adv_rx->type == PDU_ADV_TYPE_SCAN_RSP) &&
 		   (pdu_adv_rx->len <= sizeof(struct pdu_adv_scan_rsp)) &&

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -676,51 +676,11 @@ static void isr_rx(void *param)
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 	if (pdu->type == PDU_ADV_TYPE_EXT_IND) {
-		struct pdu_adv_ext_hdr *ext_hdr;
-
-		ext_hdr = &pdu->adv_ext_ind.ext_hdr;
-		if (ext_hdr->adv_addr) {
-			uint8_t *adva =	&ext_hdr->data[ADVA_OFFSET];
-
-			has_adva = true;
-
-			if (IS_ENABLED(CONFIG_BT_CTLR_PRIVACY) &&
-			    ull_filter_lll_rl_enabled()) {
-				struct lll_filter *al =
-					ull_filter_lll_get(
-						!!(lll->filter_policy & 0x1));
-
-				devmatch_ok =
-					ull_filter_lll_al_match(al,
-								pdu->tx_addr,
-								adva,
-								&devmatch_id);
-				if (!devmatch_ok && pdu->tx_addr) {
-					uint8_t count;
-
-					ull_filter_lll_irks_get(&count);
-					if (count) {
-						radio_ar_resolve(adva);
-						irkmatch_ok =
-							radio_ar_has_match();
-						irkmatch_id =
-							radio_ar_match_get();
-					}
-				}
-			} else if (IS_ENABLED(CONFIG_BT_CTLR_FILTER) &&
-				   lll->filter_policy) {
-				struct lll_filter *al =
-					ull_filter_lll_get(true);
-
-				devmatch_ok =
-					ull_filter_lll_al_match(al,
-								pdu->tx_addr,
-								adva,
-								&devmatch_id);
-			}
-		} else {
-			has_adva = false;
-		}
+		has_adva = lll_scan_aux_addr_match_get(lll, pdu,
+						       &devmatch_ok,
+						       &devmatch_id,
+						       &irkmatch_ok,
+						       &irkmatch_id);
 	} else {
 		has_adva = true;
 	}

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -66,8 +66,6 @@ static void isr_abort(void *param);
 static void isr_done_cleanup(void *param);
 static void isr_cleanup(void *param);
 
-static inline bool isr_rx_scan_check(struct lll_scan *lll, uint8_t irkmatch_ok,
-				     uint8_t devmatch_ok, uint8_t rl_idx);
 static inline int isr_rx_pdu(struct lll_scan *lll, struct pdu_adv *pdu_adv_rx,
 			     uint8_t devmatch_ok, uint8_t devmatch_id,
 			     uint8_t irkmatch_ok, uint8_t irkmatch_id,
@@ -134,6 +132,21 @@ void lll_scan_isr_resume(void *param)
 
 	p.param = param;
 	resume_prepare_cb(&p);
+}
+
+bool lll_scan_isr_rx_check(struct lll_scan *lll, uint8_t irkmatch_ok,
+			   uint8_t devmatch_ok, uint8_t rl_idx)
+{
+#if defined(CONFIG_BT_CTLR_PRIVACY)
+	return (((lll->filter_policy & 0x01) == 0) &&
+		(!devmatch_ok || ull_filter_lll_rl_idx_allowed(irkmatch_ok,
+							       rl_idx))) ||
+	       (((lll->filter_policy & 0x01) != 0) &&
+		(devmatch_ok || ull_filter_lll_irk_in_fal(rl_idx)));
+#else
+	return ((lll->filter_policy & 0x01) == 0U) ||
+		devmatch_ok;
+#endif /* CONFIG_BT_CTLR_PRIVACY */
 }
 
 #if defined(CONFIG_BT_CENTRAL) || defined(CONFIG_BT_CTLR_ADV_EXT)
@@ -624,6 +637,7 @@ static void isr_rx(void *param)
 	uint8_t crc_ok;
 	uint8_t rl_idx;
 	bool has_adva;
+	int err;
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
 		lll_prof_latency_capture();
@@ -651,7 +665,7 @@ static void isr_rx(void *param)
 	lll = param;
 
 	/* No Rx */
-	if (!trx_done) {
+	if (!trx_done || !crc_ok) {
 		goto isr_rx_do_close;
 	}
 
@@ -726,21 +740,19 @@ static void isr_rx(void *param)
 	rl_idx = FILTER_IDX_NONE;
 #endif /* CONFIG_BT_CTLR_PRIVACY */
 
-	if (crc_ok &&
-	    (!has_adva ||
-	     isr_rx_scan_check(lll, irkmatch_ok, devmatch_ok, rl_idx))) {
-		int err;
+	if (has_adva &&
+	    !lll_scan_isr_rx_check(lll, irkmatch_ok, devmatch_ok, rl_idx)) {
+		goto isr_rx_do_close;
+	}
 
-		err = isr_rx_pdu(lll, pdu, devmatch_ok, devmatch_id,
-				 irkmatch_ok, irkmatch_id, rl_idx, rssi_ready,
-				 phy_flags_rx);
-		if (!err) {
-			if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
-				lll_prof_send();
-			}
-
-			return;
+	err = isr_rx_pdu(lll, pdu, devmatch_ok, devmatch_id, irkmatch_ok,
+			 irkmatch_id, rl_idx, rssi_ready, phy_flags_rx);
+	if (!err) {
+		if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+			lll_prof_send();
 		}
+
+		return;
 	}
 
 isr_rx_do_close:
@@ -1040,21 +1052,6 @@ static void isr_cleanup(void *param)
 #endif /* CONFIG_BT_CTLR_SCAN_INDICATION */
 
 	lll_isr_cleanup(param);
-}
-
-static inline bool isr_rx_scan_check(struct lll_scan *lll, uint8_t irkmatch_ok,
-				     uint8_t devmatch_ok, uint8_t rl_idx)
-{
-#if defined(CONFIG_BT_CTLR_PRIVACY)
-	return (((lll->filter_policy & 0x01) == 0) &&
-		(!devmatch_ok || ull_filter_lll_rl_idx_allowed(irkmatch_ok,
-							       rl_idx))) ||
-	       (((lll->filter_policy & 0x01) != 0) &&
-		(devmatch_ok || ull_filter_lll_irk_in_fal(rl_idx)));
-#else
-	return ((lll->filter_policy & 0x01) == 0U) ||
-		devmatch_ok;
-#endif /* CONFIG_BT_CTLR_PRIVACY */
 }
 
 static inline int isr_rx_pdu(struct lll_scan *lll, struct pdu_adv *pdu_adv_rx,

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -87,8 +87,8 @@ static inline bool isr_scan_tgta_rpa_check(struct lll_scan *lll,
 					   bool *dir_report);
 static inline bool isr_scan_rsp_adva_matches(struct pdu_adv *srsp);
 static int isr_rx_scan_report(struct lll_scan *lll, uint8_t rssi_ready,
-			      uint8_t phy_flags_rx, uint8_t rl_idx,
-			      bool dir_report);
+			      uint8_t phy_flags_rx, uint8_t irkmatch_ok,
+			      uint8_t rl_idx, bool dir_report);
 
 int lll_scan_init(void)
 {
@@ -1244,8 +1244,7 @@ static inline int isr_rx_pdu(struct lll_scan *lll, struct pdu_adv *pdu_adv_rx,
 
 		/* save the adv packet */
 		err = isr_rx_scan_report(lll, rssi_ready, phy_flags_rx,
-					 irkmatch_ok ? rl_idx : FILTER_IDX_NONE,
-					 false);
+					 irkmatch_ok, rl_idx, false);
 		if (err) {
 			return err;
 		}
@@ -1349,9 +1348,7 @@ static inline int isr_rx_pdu(struct lll_scan *lll, struct pdu_adv *pdu_adv_rx,
 
 		/* save the scan response packet */
 		err = isr_rx_scan_report(lll, rssi_ready, phy_flags_rx,
-					 irkmatch_ok ? rl_idx :
-						       FILTER_IDX_NONE,
-					 dir_report);
+					 irkmatch_ok, rl_idx, dir_report);
 		if (err) {
 			/* Auxiliary PDU LLL scanning has been setup */
 			if (IS_ENABLED(CONFIG_BT_CTLR_ADV_EXT) &&
@@ -1439,8 +1436,8 @@ static inline bool isr_scan_rsp_adva_matches(struct pdu_adv *srsp)
 }
 
 static int isr_rx_scan_report(struct lll_scan *lll, uint8_t rssi_ready,
-			      uint8_t phy_flags_rx, uint8_t rl_idx,
-			      bool dir_report)
+			      uint8_t phy_flags_rx, uint8_t irkmatch_ok,
+			      uint8_t rl_idx, bool dir_report)
 {
 	struct node_rx_pdu *node_rx;
 	int err = 0;
@@ -1521,12 +1518,18 @@ static int isr_rx_scan_report(struct lll_scan *lll, uint8_t rssi_ready,
 						  BT_HCI_LE_RSSI_NOT_AVAILABLE;
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 	/* save the resolving list index. */
-	node_rx->hdr.rx_ftr.rl_idx = rl_idx;
+	node_rx->hdr.rx_ftr.rl_idx = irkmatch_ok ? rl_idx : FILTER_IDX_NONE;
+
+#if defined(CONFIG_BT_CTLR_ADV_EXT)
+	node_rx->hdr.rx_ftr.direct_resolved = (rl_idx != FILTER_IDX_NONE);
+#endif /* CONFIG_BT_CTLR_ADV_EXT */
 #endif /* CONFIG_BT_CTLR_PRIVACY */
+
 #if defined(CONFIG_BT_CTLR_EXT_SCAN_FP)
 	/* save the directed adv report flag */
 	node_rx->hdr.rx_ftr.direct = dir_report;
 #endif /* CONFIG_BT_CTLR_EXT_SCAN_FP */
+
 #if defined(CONFIG_BT_HCI_MESH_EXT)
 	if (node_rx->hdr.type == NODE_RX_TYPE_MESH_REPORT) {
 		/* save channel and anchor point ticks. */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -660,27 +660,49 @@ static void isr_rx(void *param)
 
 	pdu = (void *)node_rx->pdu;
 
-#if defined(CONFIG_BT_CTLR_PRIVACY)
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 	if (pdu->type == PDU_ADV_TYPE_EXT_IND) {
 		struct pdu_adv_ext_hdr *ext_hdr;
 
 		ext_hdr = &pdu->adv_ext_ind.ext_hdr;
 		if (ext_hdr->adv_addr) {
+			uint8_t *adva =	&ext_hdr->data[ADVA_OFFSET];
+
 			has_adva = true;
 
-			if (ull_filter_lll_rl_enabled() && pdu->tx_addr) {
-				uint8_t count;
+			if (IS_ENABLED(CONFIG_BT_CTLR_PRIVACY) &&
+			    ull_filter_lll_rl_enabled()) {
+				struct lll_filter *al =
+					ull_filter_lll_get(
+						!!(lll->filter_policy & 0x1));
 
-				ull_filter_lll_irks_get(&count);
-				if (count) {
-					uint8_t *adva =
-						&ext_hdr->data[ADVA_OFFSET];
+				devmatch_ok =
+					ull_filter_lll_al_match(al,
+								pdu->tx_addr,
+								adva,
+								&devmatch_id);
+				if (!devmatch_ok && pdu->tx_addr) {
+					uint8_t count;
 
-					radio_ar_resolve(adva);
-					irkmatch_ok = radio_ar_has_match();
-					irkmatch_id = radio_ar_match_get();
+					ull_filter_lll_irks_get(&count);
+					if (count) {
+						radio_ar_resolve(adva);
+						irkmatch_ok =
+							radio_ar_has_match();
+						irkmatch_id =
+							radio_ar_match_get();
+					}
 				}
+			} else if (IS_ENABLED(CONFIG_BT_CTLR_FILTER) &&
+				   lll->filter_policy) {
+				struct lll_filter *al =
+					ull_filter_lll_get(true);
+
+				devmatch_ok =
+					ull_filter_lll_al_match(al,
+								pdu->tx_addr,
+								adva,
+								&devmatch_id);
 			}
 		} else {
 			has_adva = false;
@@ -693,6 +715,7 @@ static void isr_rx(void *param)
 	has_adva = true;
 #endif /* !CONFIG_BT_CTLR_ADV_EXT */
 
+#if defined(CONFIG_BT_CTLR_PRIVACY)
 	rl_idx = devmatch_ok ?
 		 ull_filter_lll_rl_idx(!!(lll->filter_policy & 0x01),
 				       devmatch_id) :

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -58,6 +58,7 @@ static void isr_rx_lll_schedule(void *param);
 static void isr_rx(struct lll_scan *lll, struct lll_scan_aux *lll_aux,
 		   uint8_t phy_aux);
 static int isr_rx_pdu(struct lll_scan *lll, struct lll_scan_aux *lll_aux,
+		      struct node_rx_pdu *node_rx, struct pdu_adv *pdu,
 		      uint8_t phy_aux, uint8_t phy_aux_flags_rx,
 		      uint8_t devmatch_ok, uint8_t devmatch_id,
 		      uint8_t irkmatch_ok, uint8_t irkmatch_id, uint8_t rl_idx,
@@ -351,6 +352,49 @@ void lll_scan_aux_isr_aux_setup(void *param)
 #endif /* CONFIG_BT_CTLR_GPIO_LNA_PIN */
 }
 
+bool lll_scan_aux_addr_match_get(const struct lll_scan *lll,
+				 const struct pdu_adv *pdu,
+				 uint8_t *const devmatch_ok,
+				 uint8_t *const devmatch_id,
+				 uint8_t *const irkmatch_ok,
+				 uint8_t *const irkmatch_id)
+{
+	const struct pdu_adv_ext_hdr *ext_hdr;
+
+	ext_hdr = &pdu->adv_ext_ind.ext_hdr;
+	if (!ext_hdr->adv_addr) {
+		return false;
+	}
+
+	if (IS_ENABLED(CONFIG_BT_CTLR_PRIVACY) && ull_filter_lll_rl_enabled()) {
+		struct lll_filter *fal =
+			ull_filter_lll_get(!!(lll->filter_policy & 0x1));
+		const uint8_t *adva = &ext_hdr->data[ADVA_OFFSET];
+
+		*devmatch_ok = ull_filter_lll_fal_match(fal, pdu->tx_addr, adva,
+							devmatch_id);
+		if (!*devmatch_ok && pdu->tx_addr) {
+			uint8_t count;
+
+			ull_filter_lll_irks_get(&count);
+			if (count) {
+				radio_ar_resolve(adva);
+				*irkmatch_ok = radio_ar_has_match();
+				*irkmatch_id = radio_ar_match_get();
+			}
+		}
+	} else if (IS_ENABLED(CONFIG_BT_CTLR_FILTER_ACCEPT_LIST) &&
+		   lll->filter_policy) {
+		struct lll_filter *fal = ull_filter_lll_get(true);
+		const uint8_t *adva = &ext_hdr->data[ADVA_OFFSET];
+
+		*devmatch_ok = ull_filter_lll_fal_match(fal, pdu->tx_addr, adva,
+							devmatch_id);
+	}
+
+	return true;
+}
+
 static int init_reset(void)
 {
 	return 0;
@@ -621,15 +665,18 @@ static void isr_rx_lll_schedule(void *param)
 static void isr_rx(struct lll_scan *lll, struct lll_scan_aux *lll_aux,
 		   uint8_t phy_aux)
 {
+	struct node_rx_pdu *node_rx;
 	uint8_t phy_aux_flags_rx;
 	uint8_t devmatch_ok;
 	uint8_t devmatch_id;
 	uint8_t irkmatch_ok;
 	uint8_t irkmatch_id;
+	struct pdu_adv *pdu;
 	uint8_t rssi_ready;
 	uint8_t trx_done;
 	uint8_t crc_ok;
 	uint8_t rl_idx;
+	bool has_adva;
 	int err;
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
@@ -664,6 +711,24 @@ static void isr_rx(struct lll_scan *lll, struct lll_scan_aux *lll_aux,
 		goto isr_rx_do_close;
 	}
 
+	node_rx = ull_pdu_rx_alloc_peek(3);
+	if (!node_rx) {
+		err = -ENOBUFS;
+
+		goto isr_rx_do_close;
+	}
+
+	pdu = (void *)node_rx->pdu;
+	if ((pdu->type != PDU_ADV_TYPE_EXT_IND) || !pdu->len) {
+		err = -EINVAL;
+
+		goto isr_rx_do_close;
+	}
+
+	has_adva = lll_scan_aux_addr_match_get(lll, pdu, &devmatch_ok,
+					       &devmatch_id, &irkmatch_ok,
+					       &irkmatch_id);
+
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 	rl_idx = devmatch_ok ?
 		 ull_filter_lll_rl_idx(!!(lll->filter_policy & 0x01),
@@ -674,9 +739,16 @@ static void isr_rx(struct lll_scan *lll, struct lll_scan_aux *lll_aux,
 	rl_idx = FILTER_IDX_NONE;
 #endif /* CONFIG_BT_CTLR_PRIVACY */
 
-	err = isr_rx_pdu(lll, lll_aux, phy_aux, phy_aux_flags_rx, devmatch_ok,
-			 devmatch_id, irkmatch_ok, irkmatch_ok, rl_idx,
-			 rssi_ready);
+	if (has_adva &&
+	    !lll_scan_isr_rx_check(lll, irkmatch_ok, devmatch_ok, rl_idx)) {
+		err = -EINVAL;
+
+		goto isr_rx_do_close;
+	}
+
+	err = isr_rx_pdu(lll, lll_aux, node_rx, pdu, phy_aux, phy_aux_flags_rx,
+			 devmatch_ok, devmatch_id, irkmatch_ok, irkmatch_ok,
+			 rl_idx, rssi_ready);
 	if (!err) {
 		if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
 			lll_prof_send();
@@ -728,26 +800,15 @@ isr_rx_do_close:
 }
 
 static int isr_rx_pdu(struct lll_scan *lll, struct lll_scan_aux *lll_aux,
+		      struct node_rx_pdu *node_rx, struct pdu_adv *pdu,
 		      uint8_t phy_aux, uint8_t phy_aux_flags_rx,
 		      uint8_t devmatch_ok, uint8_t devmatch_id,
 		      uint8_t irkmatch_ok, uint8_t irkmatch_id, uint8_t rl_idx,
 		      uint8_t rssi_ready)
 {
-	struct node_rx_pdu *node_rx;
 	struct node_rx_ftr *ftr;
-	struct pdu_adv *pdu;
 
 	bool dir_report = false;
-
-	node_rx = ull_pdu_rx_alloc_peek(3);
-	if (!node_rx) {
-		return -ENOBUFS;
-	}
-
-	pdu = (void *)node_rx->pdu;
-	if ((pdu->type != PDU_ADV_TYPE_EXT_IND) || !pdu->len) {
-		return -EINVAL;
-	}
 
 	if (0) {
 #if defined(CONFIG_BT_CENTRAL)

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -231,6 +231,126 @@ uint8_t lll_scan_aux_setup(struct pdu_adv *pdu, uint8_t pdu_phy,
 	return 1;
 }
 
+void lll_scan_aux_isr_aux_setup(void *param)
+{
+	struct pdu_adv_aux_ptr *aux_ptr;
+	struct node_rx_pdu *node_rx;
+	uint32_t window_widening_us;
+	uint32_t window_size_us;
+	struct node_rx_ftr *ftr;
+	uint32_t aux_offset_us;
+	uint32_t aux_start_us;
+	struct lll_scan *lll;
+	uint8_t phy_aux;
+	uint32_t hcto;
+
+	lll_isr_status_reset();
+
+	node_rx = param;
+	ftr = &node_rx->hdr.rx_ftr;
+	aux_ptr = ftr->aux_ptr;
+	phy_aux = BIT(aux_ptr->phy);
+	ftr->aux_phy = phy_aux;
+
+	lll = ftr->param;
+
+	/* Determine the window size */
+	if (aux_ptr->offs_units) {
+		window_size_us = OFFS_UNIT_300_US;
+	} else {
+		window_size_us = OFFS_UNIT_30_US;
+	}
+
+	/* Calculate the aux offset from start of the scan window */
+	aux_offset_us = (uint32_t) aux_ptr->offs * window_size_us;
+
+	/* Calculate the window widening that needs to be deducted */
+	if (aux_ptr->ca) {
+		window_widening_us = SCA_DRIFT_50_PPM_US(aux_offset_us);
+	} else {
+		window_widening_us = SCA_DRIFT_500_PPM_US(aux_offset_us);
+	}
+
+	/* Reset Tx/rx count */
+	trx_cnt = 0U;
+
+	/* Setup radio for auxiliary PDU scan */
+	radio_phy_set(phy_aux, 1);
+	radio_pkt_configure(8, LL_EXT_OCTETS_RX_MAX, (phy_aux << 1));
+	lll_chan_set(aux_ptr->chan_idx);
+
+	radio_pkt_rx_set(node_rx->pdu);
+
+	/* FIXME: we could (?) use isr_rx_ull_schedule if already have aux
+	 *        context allocated, i.e. some previous aux was scheduled from
+	 *        ull already.
+	 */
+	radio_isr_set(isr_rx_lll_schedule, node_rx);
+
+	/* setup tIFS switching */
+	radio_tmr_tifs_set(EVENT_IFS_US);
+	/* TODO: for passive scanning use complete_and_disable */
+	radio_switch_complete_and_tx(phy_aux, 0, phy_aux, 1);
+
+	/* TODO: skip filtering if AdvA was already found in previous PDU */
+
+	if (0) {
+#if defined(CONFIG_BT_CTLR_PRIVACY)
+	} else if (ull_filter_lll_rl_enabled()) {
+		struct lll_filter *filter = ull_filter_lll_get(
+			!!(lll->filter_policy & 0x1));
+		uint8_t count, *irks = ull_filter_lll_irks_get(&count);
+
+		radio_filter_configure(filter->enable_bitmask,
+				       filter->addr_type_bitmask,
+				       (uint8_t *) filter->bdaddr);
+
+		radio_ar_configure(count, irks, (phy_aux << 2) | BIT(1));
+#endif /* CONFIG_BT_CTLR_PRIVACY */
+	} else if (IS_ENABLED(CONFIG_BT_CTLR_FILTER_ACCEPT_LIST) && lll->filter_policy) {
+		/* Setup Radio Filter */
+		struct lll_filter *fal = ull_filter_lll_get(true);
+
+		radio_filter_configure(fal->enable_bitmask,
+				       fal->addr_type_bitmask,
+				       (uint8_t *) fal->bdaddr);
+	}
+
+	/* Setup radio rx on micro second offset. Note that radio_end_us stores
+	 * PDU start time in this case.
+	 */
+	aux_start_us = ftr->radio_end_us + aux_offset_us;
+	aux_start_us -= lll_radio_rx_ready_delay_get(phy_aux, 1);
+	aux_start_us -= window_widening_us;
+	aux_start_us -= EVENT_JITTER_US;
+	radio_tmr_start_us(0, aux_start_us);
+
+	/* Setup header complete timeout */
+	hcto = ftr->radio_end_us + aux_offset_us;
+	hcto += window_size_us;
+	hcto += window_widening_us;
+	hcto += EVENT_JITTER_US;
+	hcto += radio_rx_chain_delay_get(phy_aux, 1);
+	hcto += addr_us_get(phy_aux);
+	radio_tmr_hcto_configure(hcto);
+
+	/* capture end of Rx-ed PDU, extended scan to schedule auxiliary
+	 * channel chaining, create connection or to create periodic sync.
+	 */
+	radio_tmr_end_capture();
+
+	/* scanner always measures RSSI */
+	radio_rssi_measure();
+
+#if defined(CONFIG_BT_CTLR_GPIO_LNA_PIN)
+	radio_gpio_lna_setup();
+
+	radio_gpio_pa_lna_enable(aux_start_us +
+				 radio_rx_ready_delay_get(phy_aux, 1) -
+				 CONFIG_BT_CTLR_GPIO_LNA_OFFSET);
+#endif /* CONFIG_BT_CTLR_GPIO_LNA_PIN */
+}
+
 static int init_reset(void)
 {
 	return 0;
@@ -462,126 +582,6 @@ static void isr_done(void *param)
 	}
 
 	lll_isr_cleanup(param);
-}
-
-void lll_scan_aux_isr_aux_setup(void *param)
-{
-	struct pdu_adv_aux_ptr *aux_ptr;
-	struct node_rx_pdu *node_rx;
-	uint32_t window_widening_us;
-	uint32_t window_size_us;
-	struct node_rx_ftr *ftr;
-	uint32_t aux_offset_us;
-	uint32_t aux_start_us;
-	struct lll_scan *lll;
-	uint8_t phy_aux;
-	uint32_t hcto;
-
-	lll_isr_status_reset();
-
-	node_rx = param;
-	ftr = &node_rx->hdr.rx_ftr;
-	aux_ptr = ftr->aux_ptr;
-	phy_aux = BIT(aux_ptr->phy);
-	ftr->aux_phy = phy_aux;
-
-	lll = ftr->param;
-
-	/* Determine the window size */
-	if (aux_ptr->offs_units) {
-		window_size_us = OFFS_UNIT_300_US;
-	} else {
-		window_size_us = OFFS_UNIT_30_US;
-	}
-
-	/* Calculate the aux offset from start of the scan window */
-	aux_offset_us = (uint32_t) aux_ptr->offs * window_size_us;
-
-	/* Calculate the window widening that needs to be deducted */
-	if (aux_ptr->ca) {
-		window_widening_us = SCA_DRIFT_50_PPM_US(aux_offset_us);
-	} else {
-		window_widening_us = SCA_DRIFT_500_PPM_US(aux_offset_us);
-	}
-
-	/* Reset Tx/rx count */
-	trx_cnt = 0U;
-
-	/* Setup radio for auxiliary PDU scan */
-	radio_phy_set(phy_aux, 1);
-	radio_pkt_configure(8, LL_EXT_OCTETS_RX_MAX, (phy_aux << 1));
-	lll_chan_set(aux_ptr->chan_idx);
-
-	radio_pkt_rx_set(node_rx->pdu);
-
-	/* FIXME: we could (?) use isr_rx_ull_schedule if already have aux
-	 *        context allocated, i.e. some previous aux was scheduled from
-	 *        ull already.
-	 */
-	radio_isr_set(isr_rx_lll_schedule, node_rx);
-
-	/* setup tIFS switching */
-	radio_tmr_tifs_set(EVENT_IFS_US);
-	/* TODO: for passive scanning use complete_and_disable */
-	radio_switch_complete_and_tx(phy_aux, 0, phy_aux, 1);
-
-	/* TODO: skip filtering if AdvA was already found in previous PDU */
-
-	if (0) {
-#if defined(CONFIG_BT_CTLR_PRIVACY)
-	} else if (ull_filter_lll_rl_enabled()) {
-		struct lll_filter *filter = ull_filter_lll_get(
-			!!(lll->filter_policy & 0x1));
-		uint8_t count, *irks = ull_filter_lll_irks_get(&count);
-
-		radio_filter_configure(filter->enable_bitmask,
-				       filter->addr_type_bitmask,
-				       (uint8_t *) filter->bdaddr);
-
-		radio_ar_configure(count, irks, (phy_aux << 2) | BIT(1));
-#endif /* CONFIG_BT_CTLR_PRIVACY */
-	} else if (IS_ENABLED(CONFIG_BT_CTLR_FILTER_ACCEPT_LIST) && lll->filter_policy) {
-		/* Setup Radio Filter */
-		struct lll_filter *fal = ull_filter_lll_get(true);
-
-		radio_filter_configure(fal->enable_bitmask,
-				       fal->addr_type_bitmask,
-				       (uint8_t *) fal->bdaddr);
-	}
-
-	/* Setup radio rx on micro second offset. Note that radio_end_us stores
-	 * PDU start time in this case.
-	 */
-	aux_start_us = ftr->radio_end_us + aux_offset_us;
-	aux_start_us -= lll_radio_rx_ready_delay_get(phy_aux, 1);
-	aux_start_us -= window_widening_us;
-	aux_start_us -= EVENT_JITTER_US;
-	radio_tmr_start_us(0, aux_start_us);
-
-	/* Setup header complete timeout */
-	hcto = ftr->radio_end_us + aux_offset_us;
-	hcto += window_size_us;
-	hcto += window_widening_us;
-	hcto += EVENT_JITTER_US;
-	hcto += radio_rx_chain_delay_get(phy_aux, 1);
-	hcto += addr_us_get(phy_aux);
-	radio_tmr_hcto_configure(hcto);
-
-	/* capture end of Rx-ed PDU, extended scan to schedule auxiliary
-	 * channel chaining, create connection or to create periodic sync.
-	 */
-	radio_tmr_end_capture();
-
-	/* scanner always measures RSSI */
-	radio_rssi_measure();
-
-#if defined(CONFIG_BT_CTLR_GPIO_LNA_PIN)
-	radio_gpio_lna_setup();
-
-	radio_gpio_pa_lna_enable(aux_start_us +
-				 radio_rx_ready_delay_get(phy_aux, 1) -
-				 CONFIG_BT_CTLR_GPIO_LNA_OFFSET);
-#endif /* CONFIG_BT_CTLR_GPIO_LNA_PIN */
 }
 
 static void isr_rx_ull_schedule(void *param)

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -737,6 +737,8 @@ static int isr_rx_pdu(struct lll_scan *lll, struct lll_scan_aux *lll_aux,
 	struct node_rx_ftr *ftr;
 	struct pdu_adv *pdu;
 
+	bool dir_report = false;
+
 	node_rx = ull_pdu_rx_alloc_peek(3);
 	if (!node_rx) {
 		return -ENOBUFS;
@@ -753,7 +755,7 @@ static int isr_rx_pdu(struct lll_scan *lll, struct lll_scan_aux *lll_aux,
 	} else if (lll->conn && !lll->conn->central.cancelled &&
 		   (pdu->adv_ext_ind.adv_mode & BT_HCI_LE_ADV_PROP_CONN) &&
 		   lll_scan_ext_tgta_check(lll, false, true, pdu,
-					   rl_idx)) {
+					   rl_idx, NULL)) {
 		struct lll_scan_aux *lll_aux_to_use;
 		struct node_rx_ftr *ftr;
 		struct node_rx_pdu *rx;
@@ -945,13 +947,15 @@ static int isr_rx_pdu(struct lll_scan *lll, struct lll_scan_aux *lll_aux,
 		   ((lll_aux && !lll_aux->state) ||
 		    (lll->lll_aux && !lll->lll_aux->state)) &&
 		   (pdu->adv_ext_ind.adv_mode & BT_HCI_LE_ADV_PROP_SCAN) &&
-		   lll_scan_ext_tgta_check(lll, false, false, pdu, rl_idx)) {
+		   lll_scan_ext_tgta_check(lll, false, false, pdu, rl_idx,
+					   &dir_report)) {
 #else /* !CONFIG_BT_CENTRAL */
 	} else if (lll && lll->type &&
 		   ((lll_aux && !lll_aux->state) ||
 		    (lll->lll_aux && !lll->lll_aux->state)) &&
 		   (pdu->adv_ext_ind.adv_mode & BT_HCI_LE_ADV_PROP_SCAN) &&
-		   lll_scan_ext_tgta_check(lll, false, false, pdu, rl_idx)) {
+		   lll_scan_ext_tgta_check(lll, false, false, pdu, rl_idx,
+					   &dir_report)) {
 #endif /* !CONFIG_BT_CENTRAL */
 		struct node_rx_pdu *rx;
 		struct pdu_adv *pdu_tx;
@@ -1052,6 +1056,10 @@ static int isr_rx_pdu(struct lll_scan *lll, struct lll_scan_aux *lll_aux,
 		ftr->rl_idx = irkmatch_ok ? rl_idx : FILTER_IDX_NONE;
 #endif /* CONFIG_BT_CTLR_PRIVACY */
 
+#if defined(CONFIG_BT_CTLR_EXT_SCAN_FP)
+		ftr->direct = dir_report;
+#endif /* CONFIG_BT_CTLR_EXT_SCAN_FP */
+
 		ftr->aux_lll_sched = 0U;
 
 		ull_rx_put(node_rx->hdr.link, node_rx);
@@ -1064,11 +1072,13 @@ static int isr_rx_pdu(struct lll_scan *lll, struct lll_scan_aux *lll_aux,
 	} else if (!lll->conn &&
 		   ((lll_aux && lll_aux->is_chain_sched) ||
 		    (lll->lll_aux && lll->lll_aux->is_chain_sched) ||
-		    lll_scan_ext_tgta_check(lll, false, false, pdu, rl_idx))) {
+		    lll_scan_ext_tgta_check(lll, false, false, pdu, rl_idx,
+					    &dir_report))) {
 #else /* !CONFIG_BT_CENTRAL */
 	} else if ((lll_aux && lll_aux->is_chain_sched) ||
 		   (lll->lll_aux && lll->lll_aux->is_chain_sched) ||
-		   lll_scan_ext_tgta_check(lll, false, false, pdu, rl_idx)) {
+		   lll_scan_ext_tgta_check(lll, false, false, pdu, rl_idx,
+					   &dir_report)) {
 #endif /* !CONFIG_BT_CENTRAL */
 
 		ftr = &(node_rx->hdr.rx_ftr);
@@ -1118,6 +1128,10 @@ static int isr_rx_pdu(struct lll_scan *lll, struct lll_scan_aux *lll_aux,
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 		ftr->rl_idx = irkmatch_ok ? rl_idx : FILTER_IDX_NONE;
 #endif /* CONFIG_BT_CTLR_PRIVACY */
+
+#if defined(CONFIG_BT_CTLR_EXT_SCAN_FP)
+		ftr->direct = dir_report;
+#endif /* CONFIG_BT_CTLR_EXT_SCAN_FP */
 
 		ftr->aux_lll_sched = lll_scan_aux_setup(pdu, phy_aux,
 							phy_aux_flags_rx,

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_internal.h
@@ -20,3 +20,9 @@ uint8_t lll_scan_aux_setup(struct pdu_adv *pdu, uint8_t pdu_phy,
 			   uint8_t pdu_phy_flags_rx, radio_isr_cb_t setup_cb,
 			   void *param);
 void lll_scan_aux_isr_aux_setup(void *param);
+bool lll_scan_aux_addr_match_get(const struct lll_scan *lll,
+				 const struct pdu_adv *pdu,
+				 uint8_t *const devmatch_ok,
+				 uint8_t *const devmatch_id,
+				 uint8_t *const irkmatch_ok,
+				 uint8_t *const irkmatch_id);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_internal.h
@@ -8,7 +8,8 @@ void lll_scan_isr_resume(void *param);
 bool lll_scan_adva_check(struct lll_scan *lll, uint8_t addr_type, uint8_t *addr,
 			 uint8_t rl_idx);
 bool lll_scan_ext_tgta_check(struct lll_scan *lll, bool pri, bool is_init,
-			     struct pdu_adv *pdu, uint8_t rl_idx);
+			     struct pdu_adv *pdu, uint8_t rl_idx,
+			     bool *dir_report);
 void lll_scan_prepare_connect_req(struct lll_scan *lll, struct pdu_adv *pdu_tx,
 				  uint8_t phy, uint8_t adv_tx_addr,
 				  uint8_t *adv_addr, uint8_t init_tx_addr,

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_internal.h
@@ -5,6 +5,8 @@
  */
 
 void lll_scan_isr_resume(void *param);
+bool lll_scan_isr_rx_check(struct lll_scan *lll, uint8_t irkmatch_ok,
+			   uint8_t devmatch_ok, uint8_t rl_idx);
 bool lll_scan_adva_check(struct lll_scan *lll, uint8_t addr_type, uint8_t *addr,
 			 uint8_t rl_idx);
 bool lll_scan_ext_tgta_check(struct lll_scan *lll, bool pri, bool is_init,

--- a/subsys/bluetooth/controller/ll_sw/ull_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_filter.c
@@ -114,7 +114,8 @@ static struct k_work_delayable rpa_work;
 		    !memcmp(list[i].id_addr.val, addr, BDADDR_SIZE))
 
 static void fal_clear(void);
-static uint8_t fal_find(uint8_t addr_type, uint8_t *addr, uint8_t *free);
+static uint8_t fal_find(uint8_t addr_type, const uint8_t *const addr,
+			uint8_t *const free_idx);
 static uint32_t fal_add(bt_addr_le_t *id_addr);
 static uint32_t fal_remove(bt_addr_le_t *id_addr);
 static void fal_update(void);
@@ -136,8 +137,10 @@ static uint32_t filter_remove(struct lll_filter *filter, uint8_t addr_type,
 			   uint8_t *bdaddr);
 #endif /* !CONFIG_BT_CTLR_PRIVACY */
 
-static void filter_insert(struct lll_filter *filter, int index,
-			  uint8_t addr_type, uint8_t *bdaddr);
+static uint32_t filter_find(const struct lll_filter *const filter,
+			    uint8_t addr_type, const uint8_t *const bdaddr);
+static void filter_insert(struct lll_filter *const filter, int index,
+			  uint8_t addr_type, const uint8_t *const bdaddr);
 static void filter_clear(struct lll_filter *filter);
 
 #if defined(CONFIG_BT_CTLR_PRIVACY) && \
@@ -652,6 +655,16 @@ struct lll_filter *ull_filter_lll_get(bool filter)
 #endif
 }
 
+uint32_t ull_filter_lll_fal_match(const struct lll_filter *const filter,
+				  uint8_t addr_type,
+				  const uint8_t *const addr,
+				  uint8_t *devmatch_id)
+{
+	*devmatch_id = filter_find(filter, addr_type, addr);
+
+	return (*devmatch_id) == FILTER_IDX_NONE ? 0U : 1U;
+}
+
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 void ull_filter_adv_scan_state_cb(uint8_t bm)
 {
@@ -1005,7 +1018,8 @@ static void fal_clear(void)
 	}
 }
 
-static uint8_t fal_find(uint8_t addr_type, uint8_t *addr, uint8_t *free_idx)
+static uint8_t fal_find(uint8_t addr_type, const uint8_t *const addr,
+			uint8_t *const free_idx)
 {
 	int i;
 
@@ -1204,8 +1218,25 @@ static uint32_t filter_remove(struct lll_filter *filter, uint8_t addr_type,
 {
 	int index;
 
-	if (!filter->enable_bitmask) {
+	index = filter_find(filter, addr_type, bdaddr);
+	if (index == FILTER_IDX_NONE) {
 		return BT_HCI_ERR_INVALID_PARAM;
+	}
+
+	filter->enable_bitmask &= ~BIT(index);
+	filter->addr_type_bitmask &= ~BIT(index);
+
+	return 0;
+}
+#endif /* !CONFIG_BT_CTLR_PRIVACY */
+
+static uint32_t filter_find(const struct lll_filter *const filter,
+			    uint8_t addr_type, const uint8_t *const bdaddr)
+{
+	int index;
+
+	if (!filter->enable_bitmask) {
+		return FILTER_IDX_NONE;
 	}
 
 	index = FAL_SIZE;
@@ -1214,18 +1245,15 @@ static uint32_t filter_remove(struct lll_filter *filter, uint8_t addr_type,
 		    (((filter->addr_type_bitmask >> index) & 0x01) ==
 		     (addr_type & 0x01)) &&
 		    !memcmp(filter->bdaddr[index], bdaddr, BDADDR_SIZE)) {
-			filter->enable_bitmask &= ~BIT(index);
-			filter->addr_type_bitmask &= ~BIT(index);
-			return 0;
+			return index;
 		}
 	}
 
-	return BT_HCI_ERR_INVALID_PARAM;
+	return FILTER_IDX_NONE;
 }
-#endif /* !CONFIG_BT_CTLR_PRIVACY */
 
-static void filter_insert(struct lll_filter *filter, int index,
-			  uint8_t addr_type, uint8_t *bdaddr)
+static void filter_insert(struct lll_filter *const filter, int index,
+			  uint8_t addr_type, const uint8_t *const bdaddr)
 {
 	filter->enable_bitmask |= BIT(index);
 	filter->addr_type_bitmask |= ((addr_type & 0x01) << index);


### PR DESCRIPTION
Fix Extended scanning filter implementation to permit
ADV_EXT_IND PDUs without AdvA so that AUX_ADV_IND PDU can
be received and to filter that PDU based on whether AdvA
is present.

Fix Extended Advertising Report to return correct directed
address type.

Add implementation to filter using access list the received
extended auxiliary PDUs. Use resolving list addresses when
resolving list is enabled.

Add implementation to check auxiliary PDU device address
match by comparing the address in the AUX_ADV_IND PDU with
the addresses in the filter accept list.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>