### PR TITLE
Bluetooth: Audio: Refactor bt_audio_chan_qos to use unicast group

### DIFF
--- a/include/bluetooth/audio.h
+++ b/include/bluetooth/audio.h
@@ -1292,14 +1292,19 @@ int bt_audio_chan_reconfig(struct bt_audio_chan *chan,
 /** @brief Configure Audio Channel QoS
  *
  *  This procedure is used by a client to configure the Quality of Service of
- *  a channel. This shall only be used to configure a unicast channel.
+ *  channels in a unicast group. All channels in the group for the specified
+ *  @p conn will have the Quality of Service configured.
+ *  This shall only be used to configure unicast channels.
  *
- *  @param chan Channel object
- *  @param qos Quality of Service configuration
+ *  @param conn  Connection object
+ *  @param group Unicast group object
+ *  @param qos   Quality of Service configuration
  *
  *  @return 0 in case of success or negative value in case of error.
  */
-int bt_audio_chan_qos(struct bt_audio_chan *chan, struct bt_codec_qos *qos);
+int bt_audio_chan_qos(struct bt_conn *conn,
+		      struct bt_audio_unicast_group *group,
+		      struct bt_codec_qos *qos);
 
 /** @brief Enable Audio Channel
  *

--- a/samples/bluetooth/unicast_audio_client/src/main.c
+++ b/samples/bluetooth/unicast_audio_client/src/main.c
@@ -579,11 +579,12 @@ static int create_group(struct bt_audio_chan *chan)
 	return 0;
 }
 
-static int set_chan_qos(struct bt_audio_chan *chan)
+static int set_chan_qos(void)
 {
 	int err;
 
-	err = bt_audio_chan_qos(chan, &preset_16_2_1.qos);
+	err = bt_audio_chan_qos(default_conn, unicast_group,
+				&preset_16_2_1.qos);
 	if (err != 0) {
 		printk("Unable to setup QoS: %d", err);
 		return err;
@@ -666,7 +667,7 @@ void main(void)
 	printk("Unicast group created\n");
 
 	printk("Setting channel QoS\n");
-	err = set_chan_qos(chan);
+	err = set_chan_qos();
 	if (err != 0) {
 		return;
 	}

--- a/subsys/bluetooth/host/audio/chan.h
+++ b/subsys/bluetooth/host/audio/chan.h
@@ -37,10 +37,6 @@ enum bt_audio_state {
 	BT_AUDIO_EP_STATE_RELEASING =        0x06,
 };
 
-/* Bind ISO channel */
-struct bt_conn_iso *bt_audio_cig_create(struct bt_audio_chan *chan,
-					struct bt_codec_qos *qos);
-
 /* Unbind ISO channel */
 int bt_audio_cig_terminate(struct bt_audio_chan *chan);
 
@@ -61,3 +57,10 @@ int bt_audio_chan_codec_qos_to_iso_qos(struct bt_iso_chan_qos *qos,
 				       struct bt_codec_qos *codec);
 
 void bt_audio_chan_detach(struct bt_audio_chan *chan);
+
+bool bt_audio_valid_qos(const struct bt_codec_qos *qos);
+
+bool bt_audio_valid_chan_qos(const struct bt_audio_chan *chan,
+			     const struct bt_codec_qos *qos);
+
+int bt_audio_chan_iso_listen(struct bt_audio_chan *chan);

--- a/subsys/bluetooth/host/audio/endpoint.c
+++ b/subsys/bluetooth/host/audio/endpoint.c
@@ -1172,7 +1172,7 @@ int bt_audio_ep_config(struct bt_audio_ep *ep, struct net_buf_simple *buf,
 }
 
 int bt_audio_ep_qos(struct bt_audio_ep *ep, struct net_buf_simple *buf,
-		    uint8_t cig, uint8_t cis, struct bt_codec_qos *qos)
+		    struct bt_codec_qos *qos)
 {
 	struct bt_ascs_qos *req;
 
@@ -1196,14 +1196,15 @@ int bt_audio_ep_qos(struct bt_audio_ep *ep, struct net_buf_simple *buf,
 
 	BT_DBG("id 0x%02x cig 0x%02x cis 0x%02x interval %u framing 0x%02x "
 	       "phy 0x%02x sdu %u rtn %u latency %u pd %u", ep->status.id,
-	       cig, cis, qos->interval, qos->framing, qos->phy, qos->sdu,
+	       ep->iso.iso->iso.cig_id, ep->iso.iso->iso.cis_id,
+	       qos->interval, qos->framing, qos->phy, qos->sdu,
 	       qos->rtn, qos->latency, qos->pd);
 
 	req = net_buf_simple_add(buf, sizeof(*req));
 	req->ase = ep->status.id;
 	/* TODO: don't hardcode CIG and CIS, they should come from ISO */
-	req->cig = cig;
-	req->cis = cis;
+	req->cig = ep->iso.iso->iso.cig_id;
+	req->cis = ep->iso.iso->iso.cis_id;
 	sys_put_le24(qos->interval, req->interval);
 	req->framing = qos->framing;
 	req->phy = qos->phy;

--- a/subsys/bluetooth/host/audio/endpoint.h
+++ b/subsys/bluetooth/host/audio/endpoint.h
@@ -72,6 +72,8 @@ struct bt_audio_ep {
 };
 
 struct bt_audio_unicast_group {
+	/* QoS used to create the CIG */
+	struct bt_codec_qos *qos;
 	struct bt_iso_cig *cig;
 	/* The ISO API for CIG creation requires an array of pointers to ISO channels */
 	struct bt_iso_chan *cis[UNICAST_GROUP_STREAM_CNT];
@@ -177,7 +179,7 @@ int bt_audio_ep_config(struct bt_audio_ep *ep, struct net_buf_simple *buf,
 		       struct bt_audio_capability *cap, struct bt_codec *codec);
 
 int bt_audio_ep_qos(struct bt_audio_ep *ep, struct net_buf_simple *buf,
-		    uint8_t cig, uint8_t cis, struct bt_codec_qos *qos);
+		    struct bt_codec_qos *qos);
 
 int bt_audio_ep_enable(struct bt_audio_ep *ep, struct net_buf_simple *buf,
 		       uint8_t meta_count, struct bt_codec_data *meta);


### PR DESCRIPTION
Refactors the function bt_audio_chan_qos to work on unicast groups instead of individual channels.

When setting the QoS as a client, all channels that share a CIG (i.e. a group) shall be set in a single write command, which this API refactor allows.

The implementation is also being updated to decouple the unicast client and server a bit.