### PR TITLE
Bluetooth: Mesh: Fix crash on disconnect

### DIFF
--- a/subsys/bluetooth/mesh/pb_gatt_srv.c
+++ b/subsys/bluetooth/mesh/pb_gatt_srv.c
@@ -115,7 +115,10 @@ static void gatt_disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	cli = NULL;
+	if (cli) {
+		bt_mesh_proxy_role_cleanup(cli);
+		cli = NULL;
+	}
 
 	bt_mesh_pb_gatt_close(conn);
 

--- a/subsys/bluetooth/mesh/proxy_msg.c
+++ b/subsys/bluetooth/mesh/proxy_msg.c
@@ -219,14 +219,8 @@ struct bt_mesh_proxy_role *bt_mesh_proxy_role_setup(struct bt_conn *conn,
 	return role;
 }
 
-static void gatt_disconnected(struct bt_conn *conn, uint8_t reason)
+void bt_mesh_proxy_role_cleanup(struct bt_mesh_proxy_role *role)
 {
-	struct bt_mesh_proxy_role *role;
-
-	BT_DBG("conn %p reason 0x%02x", (void *)conn, reason);
-
-	role = &roles[bt_conn_index(conn)];
-
 	/* If this fails, the work handler exits early, as
 	 * there's no active connection.
 	 */
@@ -236,7 +230,3 @@ static void gatt_disconnected(struct bt_conn *conn, uint8_t reason)
 
 	bt_mesh_adv_update();
 }
-
-BT_CONN_CB_DEFINE(conn_callbacks) = {
-	.disconnected = gatt_disconnected,
-};

--- a/subsys/bluetooth/mesh/proxy_msg.h
+++ b/subsys/bluetooth/mesh/proxy_msg.h
@@ -54,5 +54,6 @@ int bt_mesh_proxy_msg_send(struct bt_mesh_proxy_role *role, uint8_t type,
 struct bt_mesh_proxy_role *bt_mesh_proxy_role_setup(struct bt_conn *conn,
 						    proxy_send_cb_t send,
 						    proxy_recv_cb_t recv);
+void bt_mesh_proxy_role_cleanup(struct bt_mesh_proxy_role *role);
 
 #endif /* ZEPHYR_SUBSYS_BLUETOOTH_MESH_PROXY_MSG_H_ */

--- a/subsys/bluetooth/mesh/proxy_srv.c
+++ b/subsys/bluetooth/mesh/proxy_srv.c
@@ -883,7 +883,10 @@ static void gatt_disconnected(struct bt_conn *conn, uint8_t reason)
 	conn_count--;
 
 	client = find_client(conn);
-	client->cli = NULL;
+	if (client->cli) {
+		bt_mesh_proxy_role_cleanup(client->cli);
+		client->cli = NULL;
+	}
 }
 
 static int proxy_send(struct bt_conn *conn,


### PR DESCRIPTION
bt_mesh_proxy_role_setup() is called conditionally when peer is
connected and gatt_disconnected() is always called. This leads
to unbalance in role->conn reference count and crash.

Instead of hot-fixing this in gatt_disconnected(), this commit adds
proper bt_mesh_proxy_role_cleanup() API that is called by roles
implementations if cleanup is needed.

Signed-off-by: Szymon Janc <szymon.janc@codecoup.pl>