### PR TITLE
drivers: timer: extend nrf_rtc_timer to handle overflow

### DIFF
--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -13,8 +13,6 @@
 #include <drivers/timer/nrf_rtc_timer.h>
 #include <sys_clock.h>
 #include <hal/nrf_rtc.h>
-#include <spinlock.h>
-
 
 #define EXT_CHAN_COUNT CONFIG_NRF_RTC_TIMER_USER_CHAN_COUNT
 #define CHAN_COUNT (EXT_CHAN_COUNT + 1)
@@ -26,7 +24,8 @@
 
 BUILD_ASSERT(CHAN_COUNT <= RTC_CH_COUNT, "Not enough compare channels");
 
-#define COUNTER_SPAN BIT(24)
+#define COUNTER_BIT_WIDTH 24U
+#define COUNTER_SPAN BIT(COUNTER_BIT_WIDTH)
 #define COUNTER_MAX (COUNTER_SPAN - 1U)
 #define COUNTER_HALF_SPAN (COUNTER_SPAN / 2U)
 #define CYC_PER_TICK (sys_clock_hw_cycles_per_sec()	\
@@ -34,18 +33,25 @@ BUILD_ASSERT(CHAN_COUNT <= RTC_CH_COUNT, "Not enough compare channels");
 #define MAX_TICKS ((COUNTER_HALF_SPAN - CYC_PER_TICK) / CYC_PER_TICK)
 #define MAX_CYCLES (MAX_TICKS * CYC_PER_TICK)
 
-static struct k_spinlock lock;
+#define OVERFLOW_RISK_RANGE_END (COUNTER_SPAN / 16)
+#define ANCHOR_RANGE_START (COUNTER_SPAN / 8)
+#define ANCHOR_RANGE_END (7 * COUNTER_SPAN / 8)
+#define TARGET_TIME_INVALID (UINT64_MAX)
 
-static uint32_t last_count;
+static volatile uint32_t overflow_cnt;
+static volatile uint64_t anchor;
+static uint64_t last_count;
 
 struct z_nrf_rtc_timer_chan_data {
 	z_nrf_rtc_timer_compare_handler_t callback;
 	void *user_context;
+	volatile uint64_t target_time;
 };
 
 static struct z_nrf_rtc_timer_chan_data cc_data[CHAN_COUNT];
 static atomic_t int_mask;
 static atomic_t alloc_mask;
+static atomic_t force_isr_mask;
 
 static uint32_t counter_sub(uint32_t a, uint32_t b)
 {
@@ -82,9 +88,33 @@ static uint32_t counter(void)
 	return nrf_rtc_counter_get(RTC);
 }
 
-uint32_t z_nrf_rtc_timer_read(void)
+static uint32_t absolute_time_to_cc(uint64_t absolute_time)
 {
-	return nrf_rtc_counter_get(RTC);
+	/* 24 least significant bits represent target CC value */
+	return absolute_time & COUNTER_MAX;
+}
+
+static uint32_t full_int_lock(void)
+{
+	uint32_t mcu_critical_state;
+
+	if (IS_ENABLED(CONFIG_ZERO_LATENCY_IRQS)) {
+		mcu_critical_state = __get_PRIMASK();
+		__disable_irq();
+	} else {
+		mcu_critical_state = irq_lock();
+	}
+
+	return mcu_critical_state;
+}
+
+static void full_int_unlock(uint32_t mcu_critical_state)
+{
+	if (IS_ENABLED(CONFIG_ZERO_LATENCY_IRQS)) {
+		__set_PRIMASK(mcu_critical_state);
+	} else {
+		irq_unlock(mcu_critical_state);
+	}
 }
 
 uint32_t z_nrf_rtc_timer_compare_evt_address_get(int32_t chan)
@@ -93,25 +123,42 @@ uint32_t z_nrf_rtc_timer_compare_evt_address_get(int32_t chan)
 	return nrf_rtc_event_address_get(RTC, nrf_rtc_compare_event_get(chan));
 }
 
-bool z_nrf_rtc_timer_compare_int_lock(int32_t chan)
+static bool compare_int_lock(int32_t chan)
 {
-	__ASSERT_NO_MSG(chan && chan < CHAN_COUNT);
-
 	atomic_val_t prev = atomic_and(&int_mask, ~BIT(chan));
 
 	nrf_rtc_int_disable(RTC, RTC_CHANNEL_INT_MASK(chan));
 
+	__DMB();
+	__ISB();
+
 	return prev & BIT(chan);
+}
+
+
+bool z_nrf_rtc_timer_compare_int_lock(int32_t chan)
+{
+	__ASSERT_NO_MSG(chan && chan < CHAN_COUNT);
+
+	return compare_int_lock(chan);
+}
+
+static void compare_int_unlock(int32_t chan, bool key)
+{
+	if (key) {
+		atomic_or(&int_mask, BIT(chan));
+		nrf_rtc_int_enable(RTC, RTC_CHANNEL_INT_MASK(chan));
+		if (atomic_get(&force_isr_mask) & BIT(chan)) {
+			NVIC_SetPendingIRQ(RTC_IRQn);
+		}
+	}
 }
 
 void z_nrf_rtc_timer_compare_int_unlock(int32_t chan, bool key)
 {
 	__ASSERT_NO_MSG(chan && chan < CHAN_COUNT);
 
-	if (key) {
-		atomic_or(&int_mask, BIT(chan));
-		nrf_rtc_int_enable(RTC, RTC_CHANNEL_INT_MASK(chan));
-	}
+	compare_int_unlock(chan, key);
 }
 
 uint32_t z_nrf_rtc_timer_compare_read(int32_t chan)
@@ -121,41 +168,48 @@ uint32_t z_nrf_rtc_timer_compare_read(int32_t chan)
 	return nrf_rtc_cc_get(RTC, chan);
 }
 
-int z_nrf_rtc_timer_get_ticks(k_timeout_t t)
+uint64_t z_nrf_rtc_timer_get_ticks(k_timeout_t t)
 {
-	uint32_t curr_count;
+	uint64_t curr_time;
 	int64_t curr_tick;
 	int64_t result;
 	int64_t abs_ticks;
 
 	do {
-		curr_count = counter();
+		curr_time = z_nrf_rtc_timer_read();
 		curr_tick = sys_clock_tick_get();
-	} while (curr_count != counter());
+	} while (curr_time != z_nrf_rtc_timer_read());
 
 	abs_ticks = Z_TICK_ABS(t.ticks);
 	if (abs_ticks < 0) {
 		/* relative timeout */
-		return (t.ticks > COUNTER_HALF_SPAN) ?
-			-EINVAL : ((curr_count + t.ticks) & COUNTER_MAX);
+		return (t.ticks > COUNTER_SPAN) ?
+			-EINVAL : (curr_time + t.ticks);
 	}
 
 	/* absolute timeout */
 	result = abs_ticks - curr_tick;
 
-	if ((result > COUNTER_HALF_SPAN) ||
-	    (result < -(int64_t)COUNTER_HALF_SPAN)) {
+	if (result > COUNTER_SPAN) {
 		return -EINVAL;
 	}
 
-	return (curr_count + result) & COUNTER_MAX;
+	return curr_time + result;
 }
 
-/* Function safely sets absolute alarm. It assumes that provided value is
- * less than COUNTER_HALF_SPAN from now. It detects late setting and also
- * handle +1 cycle case.
+/** @brief Function safely sets absolute alarm.
+ *
+ * It assumes that provided value is less than COUNTER_HALF_SPAN from now.
+ * It detects late setting and also handle +1 cycle case.
+ *
+ * @param[in] chan A channel for which a new CC value is to be set.
+ *
+ * @param[in] abs_val An absolute value of CC register to be set.
+ *
+ * @returns CC value that was actually set. It is equal to @p abs_val or
+ *  shifted ahead if @p abs_val was too near in the future (+1 case).
  */
-static void set_absolute_alarm(int32_t chan, uint32_t abs_val)
+static uint32_t set_absolute_alarm(int32_t chan, uint32_t abs_val)
 {
 	uint32_t now;
 	uint32_t now2;
@@ -179,7 +233,6 @@ static void set_absolute_alarm(int32_t chan, uint32_t abs_val)
 			k_busy_wait(19);
 		}
 
-
 		/* If requested cc_val is in the past or next tick, set to 2
 		 * ticks from now. RTC may not generate event if CC is set for
 		 * 1 tick from now.
@@ -202,38 +255,143 @@ static void set_absolute_alarm(int32_t chan, uint32_t abs_val)
 		 */
 	} while ((now2 != now) &&
 		 (counter_sub(cc_val, now2 + 2) > COUNTER_HALF_SPAN));
+
+	return cc_val;
 }
 
-static void compare_set(int32_t chan, uint32_t cc_value,
+static int compare_set_nolocks(int32_t chan, uint64_t target_time,
 			z_nrf_rtc_timer_compare_handler_t handler,
 			void *user_data)
 {
+	int ret = 0;
+	uint32_t cc_value = absolute_time_to_cc(target_time);
+	uint64_t curr_time = z_nrf_rtc_timer_read();
+
+	if (curr_time < target_time) {
+		if (target_time - curr_time > COUNTER_SPAN) {
+			/* Target time is too distant. */
+			return -EINVAL;
+		}
+
+		if (target_time != cc_data[chan].target_time) {
+			/* Target time is valid and is different than currently set.
+			 * Set CC value.
+			 */
+			uint32_t cc_set = set_absolute_alarm(chan, cc_value);
+
+			target_time += counter_sub(cc_set, cc_value);
+		}
+	} else {
+		/* Force ISR handling when exiting from critical section. */
+		atomic_or(&force_isr_mask, BIT(chan));
+	}
+
+	cc_data[chan].target_time = target_time;
 	cc_data[chan].callback = handler;
 	cc_data[chan].user_context = user_data;
 
-	set_absolute_alarm(chan, cc_value);
+	return ret;
 }
 
-void z_nrf_rtc_timer_compare_set(int32_t chan, uint32_t cc_value,
-			      z_nrf_rtc_timer_compare_handler_t handler,
-			      void *user_data)
+static int compare_set(int32_t chan, uint64_t target_time,
+			z_nrf_rtc_timer_compare_handler_t handler,
+			void *user_data)
+{
+	bool key;
+
+	key = compare_int_lock(chan);
+
+	int ret = compare_set_nolocks(chan, target_time, handler, user_data);
+
+	compare_int_unlock(chan, key);
+
+	return ret;
+}
+
+int z_nrf_rtc_timer_set(int32_t chan, uint64_t target_time,
+			 z_nrf_rtc_timer_compare_handler_t handler,
+			 void *user_data)
 {
 	__ASSERT_NO_MSG(chan && chan < CHAN_COUNT);
 
-	bool key = z_nrf_rtc_timer_compare_int_lock(chan);
+	return compare_set(chan, target_time, handler, user_data);
+}
 
-	compare_set(chan, cc_value, handler, user_data);
+void z_nrf_rtc_timer_abort(int32_t chan)
+{
+	__ASSERT_NO_MSG(chan && chan < CHAN_COUNT);
 
-	z_nrf_rtc_timer_compare_int_unlock(chan, key);
+	bool key = compare_int_lock(chan);
+
+	cc_data[chan].target_time = TARGET_TIME_INVALID;
+	event_clear(chan);
+	event_disable(chan);
+	(void)atomic_and(&force_isr_mask, ~BIT(chan));
+
+	compare_int_unlock(chan, key);
+}
+
+uint64_t z_nrf_rtc_timer_read(void)
+{
+	uint64_t val = ((uint64_t)overflow_cnt) << COUNTER_BIT_WIDTH;
+
+	__DMB();
+
+	uint32_t cntr = counter();
+
+	val += cntr;
+
+	if (cntr < OVERFLOW_RISK_RANGE_END) {
+		/* `overflow_cnt` can have incorrect value due to still unhandled overflow or
+		 * due to possibility that this code preempted overflow interrupt before final write
+		 * of `overflow_cnt`. Update of `anchor` occurs far in time from this moment, so
+		 * `anchor` is considered valid and stable. Because of this timing there is no risk
+		 * of incorrect `anchor` value caused by non-atomic read of 64-bit `anchor`.
+		 */
+		if (val < anchor) {
+			/* Unhandled overflow, detected, let's add correction */
+			val += COUNTER_SPAN;
+		}
+	} else {
+		/* `overflow_cnt` is considered valid and stable in this range, no need to
+		 * check validity using `anchor`
+		 */
+	}
+
+	return val;
+}
+
+static inline bool in_anchor_range(uint32_t cc_value)
+{
+	return (cc_value >= ANCHOR_RANGE_START) && (cc_value < ANCHOR_RANGE_END);
+}
+
+static inline bool anchor_update(uint32_t cc_value)
+{
+	/* Update anchor when far from overflow */
+	if (in_anchor_range(cc_value)) {
+		/* In this range `overflow_cnt` is considered valid and stable.
+		 * Write of 64-bit `anchor` is non atomic. However it happens
+		 * far in time from the moment the `anchor` is read in
+		 * `z_nrf_rtc_timer_read`.
+		 */
+		anchor = (((uint64_t)overflow_cnt) << COUNTER_BIT_WIDTH) + cc_value;
+		return true;
+	}
+
+	return false;
 }
 
 static void sys_clock_timeout_handler(int32_t chan,
-				      uint32_t cc_value,
+				      uint64_t expire_time,
 				      void *user_data)
 {
-	uint32_t dticks = counter_sub(cc_value, last_count) / CYC_PER_TICK;
+	uint32_t cc_value = absolute_time_to_cc(expire_time);
+	uint64_t dticks = (expire_time - last_count) / CYC_PER_TICK;
 
 	last_count += dticks * CYC_PER_TICK;
+
+	bool anchor_updated = anchor_update(cc_value);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		/* protection is not needed because we are in the RTC interrupt
@@ -244,7 +402,80 @@ static void sys_clock_timeout_handler(int32_t chan,
 	}
 
 	sys_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ?
-						dticks : (dticks > 0));
+			   (int32_t)dticks : (dticks > 0));
+
+	if (cc_value == get_comparator(chan)) {
+		/* New value was not set. Set something that can update anchor.
+		 * If anchor was updated we can enable same CC value to trigger
+		 * interrupt after full cycle. Else set event in anchor update
+		 * range. Since anchor was not updated we know that it's very
+		 * far from mid point so setting is done without any protection.
+		 */
+		if (!anchor_updated) {
+			set_comparator(chan, COUNTER_HALF_SPAN);
+		}
+		event_enable(chan);
+	}
+}
+
+static bool channel_processing_check_and_clear(int32_t chan)
+{
+	bool result = false;
+
+	uint32_t mcu_critical_state = full_int_lock();
+
+	if (nrf_rtc_int_enable_check(RTC, RTC_CHANNEL_INT_MASK(chan))) {
+		/* The processing of channel can be caused by CC match
+		 * or be forced.
+		 */
+		result = atomic_and(&force_isr_mask, ~BIT(chan)) ||
+			 nrf_rtc_event_check(RTC, RTC_CHANNEL_EVENT_ADDR(chan));
+
+		if (result) {
+			event_clear(chan);
+		}
+	}
+
+	full_int_unlock(mcu_critical_state);
+
+	return result;
+}
+
+static void process_channel(int32_t chan)
+{
+	if (channel_processing_check_and_clear(chan)) {
+		void *user_context;
+		uint32_t mcu_critical_state;
+		uint64_t curr_time;
+		uint64_t expire_time;
+		z_nrf_rtc_timer_compare_handler_t handler = NULL;
+
+		curr_time = z_nrf_rtc_timer_read();
+
+		/* This critical section is used to provide atomic access to
+		 * cc_data structure and prevent higher priority contexts
+		 * (including ZLIs) from overwriting it.
+		 */
+		mcu_critical_state = full_int_lock();
+
+		/* If target_time is in the past or is equal to current time
+		 * value, execute the handler.
+		 */
+		expire_time = cc_data[chan].target_time;
+		if (curr_time >= expire_time) {
+			handler = cc_data[chan].callback;
+			user_context = cc_data[chan].user_context;
+			cc_data[chan].callback = NULL;
+			cc_data[chan].target_time = TARGET_TIME_INVALID;
+			event_disable(chan);
+		}
+
+		full_int_unlock(mcu_critical_state);
+
+		if (handler) {
+			handler(chan, expire_time, user_context);
+		}
+	}
 }
 
 /* Note: this function has public linkage, and MUST have this
@@ -259,34 +490,14 @@ void rtc_nrf_isr(const void *arg)
 {
 	ARG_UNUSED(arg);
 
+	if (nrf_rtc_int_enable_check(RTC, NRF_RTC_INT_OVERFLOW_MASK) &&
+	    nrf_rtc_event_check(RTC, NRF_RTC_EVENT_OVERFLOW)) {
+		nrf_rtc_event_clear(RTC, NRF_RTC_EVENT_OVERFLOW);
+		overflow_cnt++;
+	}
+
 	for (int32_t chan = 0; chan < CHAN_COUNT; chan++) {
-		if (nrf_rtc_int_enable_check(RTC, RTC_CHANNEL_INT_MASK(chan)) &&
-		    nrf_rtc_event_check(RTC, RTC_CHANNEL_EVENT_ADDR(chan))) {
-			uint32_t cc_val;
-			uint32_t now;
-			z_nrf_rtc_timer_compare_handler_t handler;
-
-			event_clear(chan);
-			event_disable(chan);
-			cc_val = get_comparator(chan);
-			now = counter();
-
-			/* Higher priority interrupt may already changed cc_val
-			 * which now points to the future. In that case return
-			 * current counter value. It is less precise than
-			 * returning exact CC value but this one is already lost.
-			 */
-			if (counter_sub(now, cc_val) > COUNTER_HALF_SPAN) {
-				cc_val = now;
-			}
-
-			handler = cc_data[chan].callback;
-			cc_data[chan].callback = NULL;
-			if (handler) {
-				handler(chan, cc_val,
-					cc_data[chan].user_context);
-			}
-		}
+		process_channel(chan);
 	}
 }
 
@@ -312,6 +523,7 @@ void z_nrf_rtc_timer_chan_free(int32_t chan)
 	atomic_or(&alloc_mask, BIT(chan));
 }
 
+
 void sys_clock_set_timeout(int32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
@@ -324,7 +536,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	ticks = (ticks == K_TICKS_FOREVER) ? MAX_TICKS : ticks;
 	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
 
-	uint32_t unannounced = counter_sub(counter(), last_count);
+	uint32_t unannounced = z_nrf_rtc_timer_read() - last_count;
 
 	/* If we haven't announced for more than half the 24-bit wrap
 	 * duration, then force an announce to avoid loss of a wrap
@@ -349,8 +561,9 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 		cyc = MAX_CYCLES;
 	}
 
-	cyc += last_count;
-	compare_set(0, cyc, sys_clock_timeout_handler, NULL);
+	uint64_t target_time = cyc + last_count;
+
+	compare_set(0, target_time, sys_clock_timeout_handler, NULL);
 }
 
 uint32_t sys_clock_elapsed(void)
@@ -359,16 +572,12 @@ uint32_t sys_clock_elapsed(void)
 		return 0;
 	}
 
-	return counter_sub(counter(), last_count) / CYC_PER_TICK;
+	return (z_nrf_rtc_timer_read() - last_count) / CYC_PER_TICK;
 }
 
 uint32_t sys_clock_cycle_get_32(void)
 {
-	k_spinlock_key_t key = k_spin_lock(&lock);
-	uint32_t ret = counter_sub(counter(), last_count) + last_count;
-
-	k_spin_unlock(&lock, key);
-	return ret;
+	return (uint32_t)z_nrf_rtc_timer_read();
 }
 
 static int sys_clock_driver_init(const struct device *dev)
@@ -384,8 +593,11 @@ static int sys_clock_driver_init(const struct device *dev)
 	/* TODO: replace with counter driver to access RTC */
 	nrf_rtc_prescaler_set(RTC, 0);
 	for (int32_t chan = 0; chan < CHAN_COUNT; chan++) {
+		cc_data[chan].target_time = TARGET_TIME_INVALID;
 		nrf_rtc_int_enable(RTC, RTC_CHANNEL_INT_MASK(chan));
 	}
+
+	nrf_rtc_int_enable(RTC, NRF_RTC_INT_OVERFLOW_MASK);
 
 	NVIC_ClearPendingIRQ(RTC_IRQn);
 
@@ -400,6 +612,12 @@ static int sys_clock_driver_init(const struct device *dev)
 	if (CONFIG_NRF_RTC_TIMER_USER_CHAN_COUNT) {
 		alloc_mask = BIT_MASK(EXT_CHAN_COUNT) << 1;
 	}
+
+	uint32_t initial_timeout = IS_ENABLED(CONFIG_TICKLESS_KERNEL) ?
+		(COUNTER_HALF_SPAN - 1) :
+		(counter() + CYC_PER_TICK);
+
+	compare_set(0, initial_timeout, sys_clock_timeout_handler, NULL);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		compare_set(0, counter() + CYC_PER_TICK,

--- a/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_lp_timer_zephyr.c
+++ b/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_lp_timer_zephyr.c
@@ -15,51 +15,146 @@
 #include "platform/nrf_802154_clock.h"
 #include "nrf_802154_sl_utils.h"
 
+struct timer_desc {
+	z_nrf_rtc_timer_compare_handler_t handler;
+	uint64_t target_time;
+	int32_t chan;
+	int32_t int_lock_key;
+	bool is_running;
+};
+
+static struct timer_desc m_timer;
+static struct timer_desc m_sync_timer;
 static volatile bool m_clock_ready;
-static bool m_is_running;
-static int32_t m_rtc_channel;
 static bool m_in_critical_section;
 
-void rtc_irq_handler(int32_t id, uint32_t cc_value, void *user_data)
+/**
+ * @brief RTC IRQ handler for LP timer channel.
+ */
+void timer_handler(int32_t id, uint64_t expire_time, void *user_data)
 {
-	(void)cc_value;
+	(void)expire_time;
 	(void)user_data;
-	nrf_802154_sl_mcu_critical_state_t state;
 
-	assert(id == m_rtc_channel);
+	assert(id == m_timer.chan);
 
-	nrf_802154_sl_mcu_critical_enter(state);
-
-	m_is_running = false;
-	(void)z_nrf_rtc_timer_compare_int_lock(m_rtc_channel);
-
-	nrf_802154_sl_mcu_critical_exit(state);
+	m_timer.is_running = false;
 
 	nrf_802154_lp_timer_fired();
 }
 
 /**
+ * @brief RTC IRQ handler for synchronization timer channel.
+ */
+void sync_timer_handler(int32_t id, uint64_t expire_time, void *user_data)
+{
+	(void)user_data;
+
+	assert(id == m_sync_timer.chan);
+
+	m_sync_timer.is_running = false;
+	/**
+	 * Expire time might have been different than the desired target
+	 * time. Update it so that a more accurate value can be returned
+	 * by nrf_802154_lp_timer_sync_time_get.
+	 */
+	m_sync_timer.target_time = NRF_802154_SL_RTC_TICKS_TO_US(expire_time);
+
+	nrf_802154_lp_timer_synchronized();
+}
+
+/**
+ * @brief Convert 32-bit target time to absolute 64-bit target time.
+ */
+uint64_t target_time_convert_to_64_bits(uint32_t t0, uint32_t dt)
+{
+	/**
+	 * Target time is provided as two 32-bit integers defining a moment in time
+	 * in microsecond domain. In order to use bit-shifting instead of modulo
+	 * division, calculations are performed in microsecond domain, not in RTC ticks.
+	 *
+	 * Maximum possible value of target time specified with two 32-bit unsigned
+	 * integers is equal 2 * (2^32 - 1), or 2^33 - 2. However, instead of extending
+	 * the bit-width to 64 to fit that number, let the addition of t0 and dt
+	 * overflow at 32 bits.
+	 *
+	 * The target time can point to a moment in the future, but can be overdue
+	 * as well. In order to determine what's the case and correctly set the
+	 * absolute target time, it's necessary to compare the least significant
+	 * 32 bits of the current time, 64-bit time with the provided 32-bit target
+	 * time. Let's assume that half of the 32-bit range can be used for specifying
+	 * target times in the future, and the other half - in the past.
+	 */
+	uint64_t now_us = NRF_802154_SL_RTC_TICKS_TO_US(z_nrf_rtc_timer_read());
+	uint32_t now_us_wrapped = (uint32_t)now_us;
+	uint32_t target_time_us_wrapped = (uint32_t)(t0 + dt);
+	uint32_t time_diff = target_time_us_wrapped - now_us_wrapped;
+	uint64_t result = UINT64_C(0);
+
+	if (time_diff < 0x80000000) {
+		/**
+		 * Target time is assumed to be in the future. Check if a 32-bit overflow
+		 * occurs between the current time and the target time.
+		 */
+		if (now_us_wrapped > target_time_us_wrapped) {
+			/**
+			 * Add a 32-bit overflow and replace the least significant 32 bits
+			 * with the provided target time.
+			 */
+			result = now_us + UINT32_MAX + 1;
+			result &= ~(uint64_t)UINT32_MAX;
+			result |= target_time_us_wrapped;
+		} else {
+			/**
+			 * Leave the most significant 32 bits and replace the least significant
+			 * 32 bits with the provided target time.
+			 */
+			result = (now_us & (~(uint64_t)UINT32_MAX)) | target_time_us_wrapped;
+		}
+	} else {
+		/**
+		 * Target time is assumed to be in the past. Check if a 32-bit overflow
+		 * occurs between the target time and the current time.
+		 */
+		if (now_us_wrapped > target_time_us_wrapped) {
+			/**
+			 * Leave the most significant 32 bits and replace the least significant
+			 * 32 bits with the provided target time.
+			 */
+			result = (now_us & (~(uint64_t)UINT32_MAX)) | target_time_us_wrapped;
+		} else {
+			/**
+			 * Subtract a 32-bit overflow and replace the least significant
+			 * 32 bits with the provided target time.
+			 */
+			result = now_us - (UINT32_MAX + 1);
+			result &= ~(uint64_t)UINT32_MAX;
+			result |= target_time_us_wrapped;
+		}
+	}
+
+	/* Convert the result from microseconds domain to RTC ticks domain. */
+	return NRF_802154_SL_US_TO_RTC_TICKS(result);
+}
+
+/**
  * @brief Start one-shot timer that expires at specified time on desired channel.
  *
- * Start one-shot timer that will expire @p dt microseconds after @p t0 time on channel @p channel.
+ * Start one-shot timer that will expire when @p target_time is reached on channel @p channel.
  *
- * @param[in]  channel  Compare channel on which timer will be started.
- * @param[in]  t0       Number of microseconds representing timer start time.
- * @param[in]  dt       Time of timer expiration as time elapsed from @p t0 [us].
+ * @param[inout] timer        Pointer to descriptor of timer to set.
+ * @param[in]    target_time  Absolute target time in microseconds.
  */
-static void timer_start_at(uint32_t channel,
-			   uint32_t t0,
-			   uint32_t dt)
+static void timer_start_at(struct timer_desc *timer, uint64_t target_time)
 {
-	uint32_t cc_value = NRF_802154_SL_US_TO_RTC_TICKS(t0 + dt);
 	nrf_802154_sl_mcu_critical_state_t state;
 
-	z_nrf_rtc_timer_compare_set(m_rtc_channel, cc_value, rtc_irq_handler, NULL);
+	z_nrf_rtc_timer_set(timer->chan, target_time, timer->handler, NULL);
 
 	nrf_802154_sl_mcu_critical_enter(state);
 
-	m_is_running = true;
-	z_nrf_rtc_timer_compare_int_unlock(m_rtc_channel, (m_in_critical_section == false));
+	timer->is_running = true;
+	timer->target_time = NRF_802154_SL_RTC_TICKS_TO_US(target_time);
 
 	nrf_802154_sl_mcu_critical_exit(state);
 }
@@ -72,7 +167,10 @@ void nrf_802154_clock_lfclk_ready(void)
 void nrf_802154_lp_timer_init(void)
 {
 	m_in_critical_section = false;
-	m_is_running = false;
+	m_timer.is_running = false;
+	m_timer.handler = timer_handler;
+	m_sync_timer.is_running = false;
+	m_sync_timer.handler = sync_timer_handler;
 
 	/* Setup low frequency clock. */
 	nrf_802154_clock_lfclk_start();
@@ -81,20 +179,27 @@ void nrf_802154_lp_timer_init(void)
 		/* Intentionally empty */
 	}
 
-	m_rtc_channel = z_nrf_rtc_timer_chan_alloc();
-	if (m_rtc_channel < 0) {
+	m_timer.chan = z_nrf_rtc_timer_chan_alloc();
+	if (m_timer.chan < 0) {
 		assert(false);
 		return;
 	}
 
-	(void)z_nrf_rtc_timer_compare_int_lock(m_rtc_channel);
+	m_sync_timer.chan = z_nrf_rtc_timer_chan_alloc();
+	if (m_sync_timer.chan < 0) {
+		assert(false);
+		return;
+	}
 }
 
 void nrf_802154_lp_timer_deinit(void)
 {
-	(void)z_nrf_rtc_timer_compare_int_lock(m_rtc_channel);
+	(void)z_nrf_rtc_timer_compare_int_lock(m_timer.chan);
 
-	z_nrf_rtc_timer_chan_free(m_rtc_channel);
+	nrf_802154_lp_timer_sync_stop();
+
+	z_nrf_rtc_timer_chan_free(m_timer.chan);
+	z_nrf_rtc_timer_chan_free(m_sync_timer.chan);
 
 	nrf_802154_clock_lfclk_stop();
 }
@@ -106,7 +211,8 @@ void nrf_802154_lp_timer_critical_section_enter(void)
 	nrf_802154_sl_mcu_critical_enter(state);
 
 	if (!m_in_critical_section) {
-		(void)z_nrf_rtc_timer_compare_int_lock(m_rtc_channel);
+		m_timer.int_lock_key = z_nrf_rtc_timer_compare_int_lock(m_timer.chan);
+		m_sync_timer.int_lock_key = z_nrf_rtc_timer_compare_int_lock(m_sync_timer.chan);
 		m_in_critical_section = true;
 	}
 
@@ -121,15 +227,15 @@ void nrf_802154_lp_timer_critical_section_exit(void)
 
 	m_in_critical_section = false;
 
-	z_nrf_rtc_timer_compare_int_unlock(m_rtc_channel, m_is_running);
+	z_nrf_rtc_timer_compare_int_unlock(m_timer.chan, m_timer.int_lock_key);
+	z_nrf_rtc_timer_compare_int_unlock(m_sync_timer.chan, m_sync_timer.int_lock_key);
 
 	nrf_802154_sl_mcu_critical_exit(state);
 }
 
 uint32_t nrf_802154_lp_timer_time_get(void)
 {
-	/* Please note that this function does not handle RTC overflow */
-	return NRF_802154_SL_RTC_TICKS_TO_US(z_nrf_rtc_timer_read());
+	return (uint32_t)NRF_802154_SL_RTC_TICKS_TO_US(z_nrf_rtc_timer_read());
 }
 
 uint32_t nrf_802154_lp_timer_granularity_get(void)
@@ -139,12 +245,15 @@ uint32_t nrf_802154_lp_timer_granularity_get(void)
 
 void nrf_802154_lp_timer_start(uint32_t t0, uint32_t dt)
 {
-	timer_start_at(m_rtc_channel, t0, dt);
+	uint64_t target_time = target_time_convert_to_64_bits(t0, dt);
+
+	timer_start_at(&m_timer, target_time);
 }
 
 bool nrf_802154_lp_timer_is_running(void)
 {
-	return m_is_running;
+	/* We're not interested here if synchronization timer is running. */
+	return m_timer.is_running;
 }
 
 void nrf_802154_lp_timer_stop(void)
@@ -153,39 +262,42 @@ void nrf_802154_lp_timer_stop(void)
 
 	nrf_802154_sl_mcu_critical_enter(state);
 
-	m_is_running = false;
-	(void)z_nrf_rtc_timer_compare_int_lock(m_rtc_channel);
+	m_timer.is_running = false;
 
 	nrf_802154_sl_mcu_critical_exit(state);
 }
 
 void nrf_802154_lp_timer_sync_start_now(void)
 {
-	/* Currently not supported */
+	uint64_t now = z_nrf_rtc_timer_read();
+
+	/**
+	 * Despite this function's name, synchronization is not expected to be
+	 * scheduled for the current tick. Add a safe 3-tick margin
+	 */
+	timer_start_at(&m_sync_timer, now + 3);
 }
 
 void nrf_802154_lp_timer_sync_start_at(uint32_t t0, uint32_t dt)
 {
-	(void)t0;
-	(void)dt;
-	/* Currently not supported */
+	uint64_t target_time = target_time_convert_to_64_bits(t0, dt);
+
+	timer_start_at(&m_sync_timer, target_time);
 }
 
 void nrf_802154_lp_timer_sync_stop(void)
 {
-	/* Currently not supported */
+	z_nrf_rtc_timer_abort(m_sync_timer.chan);
 }
 
 uint32_t nrf_802154_lp_timer_sync_event_get(void)
 {
-	/* Currently not supported */
-	return 0;
+	return z_nrf_rtc_timer_compare_evt_address_get(m_sync_timer.chan);
 }
 
 uint32_t nrf_802154_lp_timer_sync_time_get(void)
 {
-	/* Currently not supported */
-	return 0;
+	return m_sync_timer.target_time;
 }
 
 #ifndef UNITY_ON_TARGET


### PR DESCRIPTION
nrf_rtc_timer is extended with a capability to handle RTC overflow,
allowing it to operate on absolute RTC ticks, rather than relative
ticks. The overflow handling is ZLI-proof, due to use of exclusive
access instructions instead of Zephyr's synchronization primitives.
Callbacks are given an absolute RTC tick value as a parameter instead
of CC register's value.

Signed-off-by: Jedrzej Ciupis <jedrzej.ciupis@nordicsemi.no>
Signed-off-by: Paweł Kwiek <pawel.kwiek@nordicsemi.no>