### PR TITLE
west.yml: Update mcumgr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -161,7 +161,7 @@ manifest:
       revision: 70bfbd21cdf5f6d1402bc8d0031e197222ed2ec0
       path: bootloader/mcuboot
     - name: mcumgr
-      revision: 31a2aa9cea58d3ceecbf0d5b91361bff7c94aeca
+      revision: df9be737619956efbdeb65d4d6935ee0432a580f
       path: modules/lib/mcumgr
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Commits affecting Zephyr that are included with the new revision:
    edb485c samples/smp_svr/zephyr: Increase main stack size;
    c0cb989 zephyr: Do not use CONFIG_IMG_MGMT_UPDATABLE_IMAGE_NUMBER
            directly;
    10cda4e zephyr: Fix assert when image number out of range;
    347a418 zephyr: Fix erase command failing for multi-image configuration;
    e06e772 zephyr: Fix possible memory leak in
            img_mgmt_impl_write_image_data;
    345caab img_mgmt: fix callback parameter values.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>