### PR TITLE
Bluetooth: Controller: Use sys_get_le24 to fetch 24-bit data 

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.h
@@ -5,6 +5,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define RADIO_CRC_POLYNOMIAL ((0x5bUL) | ((0x06UL) << 8) | ((0x00UL) << 16))
+
+
 typedef void (*radio_isr_cb_t) (void *param);
 
 void isr_radio(void);

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.h
@@ -5,9 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define RADIO_CRC_POLYNOMIAL ((0x5bUL) | ((0x06UL) << 8) | ((0x00UL) << 16))
-
-
 typedef void (*radio_isr_cb_t) (void *param);
 
 void isr_radio(void);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -901,8 +901,8 @@ static int prepare_cb(struct lll_prepare_param *p)
 
 	aa = sys_cpu_to_le32(PDU_AC_ACCESS_ADDR);
 	radio_aa_set((uint8_t *)&aa);
-	radio_crc_configure(RADIO_CRC_POLYNOMIAL,
-			    0x555555);
+	radio_crc_configure(PDU_CRC_POLYNOMIAL,
+                PDU_AC_CRC_IV);
 
 	lll->chan_map_curr = lll->chan_map;
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -902,7 +902,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 	aa = sys_cpu_to_le32(PDU_AC_ACCESS_ADDR);
 	radio_aa_set((uint8_t *)&aa);
 	radio_crc_configure(PDU_CRC_POLYNOMIAL,
-                PDU_AC_CRC_IV);
+					PDU_AC_CRC_IV);
 
 	lll->chan_map_curr = lll->chan_map;
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -901,7 +901,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 
 	aa = sys_cpu_to_le32(PDU_AC_ACCESS_ADDR);
 	radio_aa_set((uint8_t *)&aa);
-	radio_crc_configure(((0x5bUL) | ((0x06UL) << 8) | ((0x00UL) << 16)),
+	radio_crc_configure(RADIO_CRC_POLYNOMIAL,
 			    0x555555);
 
 	lll->chan_map_curr = lll->chan_map;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -186,7 +186,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 	aa = sys_cpu_to_le32(PDU_AC_ACCESS_ADDR);
 	radio_aa_set((uint8_t *)&aa);
 	radio_crc_configure(PDU_CRC_POLYNOMIAL,
-                PDU_AC_CRC_IV);
+					PDU_AC_CRC_IV);
 
 	/* Use channel idx in aux_ptr */
 	lll_chan_set(aux_ptr->chan_idx);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -185,8 +185,8 @@ static int prepare_cb(struct lll_prepare_param *p)
 	/* Access address and CRC */
 	aa = sys_cpu_to_le32(PDU_AC_ACCESS_ADDR);
 	radio_aa_set((uint8_t *)&aa);
-	radio_crc_configure(RADIO_CRC_POLYNOMIAL,
-			    0x555555);
+	radio_crc_configure(PDU_CRC_POLYNOMIAL,
+                PDU_AC_CRC_IV);
 
 	/* Use channel idx in aux_ptr */
 	lll_chan_set(aux_ptr->chan_idx);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -185,7 +185,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 	/* Access address and CRC */
 	aa = sys_cpu_to_le32(PDU_AC_ACCESS_ADDR);
 	radio_aa_set((uint8_t *)&aa);
-	radio_crc_configure(((0x5bUL) | ((0x06UL) << 8) | ((0x00UL) << 16)),
+	radio_crc_configure(RADIO_CRC_POLYNOMIAL,
 			    0x555555);
 
 	/* Use channel idx in aux_ptr */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
@@ -175,7 +175,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 	radio_pkt_configure(8, PDU_AC_PAYLOAD_SIZE_MAX, (phy_s << 1));
 	radio_aa_set(lll->access_addr);
 	radio_crc_configure(PDU_CRC_POLYNOMIAL,
-                sys_get_le24(lll->crc_init));
+				sys_get_le24(lll->crc_init));
 	lll_chan_set(data_chan_use);
 
 	upd = 0U;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
@@ -174,8 +174,8 @@ static int prepare_cb(struct lll_prepare_param *p)
 	radio_phy_set(phy_s, lll->adv->phy_flags);
 	radio_pkt_configure(8, PDU_AC_PAYLOAD_SIZE_MAX, (phy_s << 1));
 	radio_aa_set(lll->access_addr);
-	radio_crc_configure(RADIO_CRC_POLYNOMIAL,
-				sys_get_le24(lll->crc_init));
+	radio_crc_configure(PDU_CRC_POLYNOMIAL,
+                sys_get_le24(lll->crc_init));
 	lll_chan_set(data_chan_use);
 
 	upd = 0U;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
@@ -8,6 +8,8 @@
 
 #include <soc.h>
 
+#include <sys/byteorder.h>
+
 #include "hal/cpu.h"
 #include "hal/ccm.h"
 #include "hal/radio.h"
@@ -172,10 +174,8 @@ static int prepare_cb(struct lll_prepare_param *p)
 	radio_phy_set(phy_s, lll->adv->phy_flags);
 	radio_pkt_configure(8, PDU_AC_PAYLOAD_SIZE_MAX, (phy_s << 1));
 	radio_aa_set(lll->access_addr);
-	radio_crc_configure(((0x5bUL) | ((0x06UL) << 8) | ((0x00UL) << 16)),
-			    (((uint32_t)lll->crc_init[2] << 16) |
-			     ((uint32_t)lll->crc_init[1] << 8) |
-			     ((uint32_t)lll->crc_init[0])));
+	radio_crc_configure(RADIO_CRC_POLYNOMIAL,
+				sys_get_le24(lll->crc_init));
 	lll_chan_set(data_chan_use);
 
 	upd = 0U;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central.c
@@ -10,6 +10,7 @@
 #include <toolchain.h>
 
 #include <sys/util.h>
+#include <sys/byteorder.h>
 
 #include "hal/ccm.h"
 #include "hal/radio.h"
@@ -153,10 +154,8 @@ static int prepare_cb(struct lll_prepare_param *p)
 #endif
 
 	radio_aa_set(lll->access_addr);
-	radio_crc_configure(((0x5bUL) | ((0x06UL) << 8) | ((0x00UL) << 16)),
-			    (((uint32_t)lll->crc_init[2] << 16) |
-			     ((uint32_t)lll->crc_init[1] << 8) |
-			     ((uint32_t)lll->crc_init[0])));
+	radio_crc_configure(RADIO_CRC_POLYNOMIAL,
+			    sys_get_le24(lll->crc_init));
 	lll_chan_set(data_chan_use);
 
 	/* setup the radio tx packet buffer */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central.c
@@ -155,7 +155,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 
 	radio_aa_set(lll->access_addr);
 	radio_crc_configure(PDU_CRC_POLYNOMIAL,
-                sys_get_le24(lll->crc_init));
+					sys_get_le24(lll->crc_init));
 	lll_chan_set(data_chan_use);
 
 	/* setup the radio tx packet buffer */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central.c
@@ -154,8 +154,8 @@ static int prepare_cb(struct lll_prepare_param *p)
 #endif
 
 	radio_aa_set(lll->access_addr);
-	radio_crc_configure(RADIO_CRC_POLYNOMIAL,
-			    sys_get_le24(lll->crc_init));
+	radio_crc_configure(PDU_CRC_POLYNOMIAL,
+                sys_get_le24(lll->crc_init));
 	lll_chan_set(data_chan_use);
 
 	/* setup the radio tx packet buffer */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral.c
@@ -195,8 +195,8 @@ static int prepare_cb(struct lll_prepare_param *p)
 	lll_conn_rx_pkt_set(lll);
 
 	radio_aa_set(lll->access_addr);
-	radio_crc_configure(RADIO_CRC_POLYNOMIAL,
-			    sys_get_le24(lll->crc_init));
+	radio_crc_configure(PDU_CRC_POLYNOMIAL,
+                sys_get_le24(lll->crc_init));
 
 	lll_chan_set(data_chan_use);
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral.c
@@ -9,6 +9,7 @@
 #include <toolchain.h>
 
 #include <sys/util.h>
+#include <sys/byteorder.h>
 
 #include "hal/ccm.h"
 #include "hal/radio.h"
@@ -194,10 +195,8 @@ static int prepare_cb(struct lll_prepare_param *p)
 	lll_conn_rx_pkt_set(lll);
 
 	radio_aa_set(lll->access_addr);
-	radio_crc_configure(((0x5bUL) | ((0x06UL) << 8) | ((0x00UL) << 16)),
-			    (((uint32_t)lll->crc_init[2] << 16) |
-			     ((uint32_t)lll->crc_init[1] << 8) |
-			     ((uint32_t)lll->crc_init[0])));
+	radio_crc_configure(RADIO_CRC_POLYNOMIAL,
+			    sys_get_le24(lll->crc_init));
 
 	lll_chan_set(data_chan_use);
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral.c
@@ -196,7 +196,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 
 	radio_aa_set(lll->access_addr);
 	radio_crc_configure(PDU_CRC_POLYNOMIAL,
-                sys_get_le24(lll->crc_init));
+				sys_get_le24(lll->crc_init));
 
 	lll_chan_set(data_chan_use);
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -367,8 +367,8 @@ static int common_prepare_cb(struct lll_prepare_param *p, bool is_resume)
 
 	aa = sys_cpu_to_le32(PDU_AC_ACCESS_ADDR);
 	radio_aa_set((uint8_t *)&aa);
-	radio_crc_configure(RADIO_CRC_POLYNOMIAL,
-			    0x555555);
+	radio_crc_configure(PDU_CRC_POLYNOMIAL,
+                PDU_AC_CRC_IV);
 
 	lll_chan_set(37 + lll->chan);
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -368,7 +368,7 @@ static int common_prepare_cb(struct lll_prepare_param *p, bool is_resume)
 	aa = sys_cpu_to_le32(PDU_AC_ACCESS_ADDR);
 	radio_aa_set((uint8_t *)&aa);
 	radio_crc_configure(PDU_CRC_POLYNOMIAL,
-                PDU_AC_CRC_IV);
+					PDU_AC_CRC_IV);
 
 	lll_chan_set(37 + lll->chan);
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -367,7 +367,7 @@ static int common_prepare_cb(struct lll_prepare_param *p, bool is_resume)
 
 	aa = sys_cpu_to_le32(PDU_AC_ACCESS_ADDR);
 	radio_aa_set((uint8_t *)&aa);
-	radio_crc_configure(((0x5bUL) | ((0x06UL) << 8) | ((0x00UL) << 16)),
+	radio_crc_configure(RADIO_CRC_POLYNOMIAL,
 			    0x555555);
 
 	lll_chan_set(37 + lll->chan);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -306,8 +306,8 @@ static int prepare_cb(struct lll_prepare_param *p)
 
 	aa = sys_cpu_to_le32(PDU_AC_ACCESS_ADDR);
 	radio_aa_set((uint8_t *)&aa);
-	radio_crc_configure(RADIO_CRC_POLYNOMIAL,
-			    0x555555);
+	radio_crc_configure(PDU_CRC_POLYNOMIAL,
+                PDU_AC_CRC_IV);
 
 	lll_chan_set(lll->chan);
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -307,7 +307,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 	aa = sys_cpu_to_le32(PDU_AC_ACCESS_ADDR);
 	radio_aa_set((uint8_t *)&aa);
 	radio_crc_configure(PDU_CRC_POLYNOMIAL,
-                PDU_AC_CRC_IV);
+				PDU_AC_CRC_IV);
 
 	lll_chan_set(lll->chan);
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -306,7 +306,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 
 	aa = sys_cpu_to_le32(PDU_AC_ACCESS_ADDR);
 	radio_aa_set((uint8_t *)&aa);
-	radio_crc_configure(((0x5bUL) | ((0x06UL) << 8) | ((0x00UL) << 16)),
+	radio_crc_configure(RADIO_CRC_POLYNOMIAL,
 			    0x555555);
 
 	lll_chan_set(lll->chan);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -7,6 +7,7 @@
 
 #include <toolchain.h>
 #include <sys/util.h>
+#include <sys/byteorder.h>
 
 #include "hal/ccm.h"
 #include "hal/radio.h"
@@ -160,10 +161,8 @@ void lll_sync_aux_prepare_cb(struct lll_sync *lll,
 
 	/* Set access address for sync */
 	radio_aa_set(lll->access_addr);
-	radio_crc_configure(((0x5bUL) | ((0x06UL) << 8) | ((0x00UL) << 16)),
-			    (((uint32_t)lll->crc_init[2] << 16) |
-			     ((uint32_t)lll->crc_init[1] << 8) |
-			     ((uint32_t)lll->crc_init[0])));
+	radio_crc_configure(RADIO_CRC_POLYNOMIAL,
+			    sys_get_le24(lll->crc_init));
 
 	lll_chan_set(lll_aux->chan);
 
@@ -395,10 +394,8 @@ static int prepare_cb_common(struct lll_prepare_param *p, uint8_t chan_idx)
 	radio_phy_set(lll->phy, 1);
 	radio_pkt_configure(8, LL_EXT_OCTETS_RX_MAX, (lll->phy << 1));
 	radio_aa_set(lll->access_addr);
-	radio_crc_configure(((0x5bUL) | ((0x06UL) << 8) | ((0x00UL) << 16)),
-			    (((uint32_t)lll->crc_init[2] << 16) |
-			     ((uint32_t)lll->crc_init[1] << 8) |
-			     ((uint32_t)lll->crc_init[0])));
+	radio_crc_configure(RADIO_CRC_POLYNOMIAL,
+			    sys_get_le24(lll->crc_init));
 
 	lll_chan_set(chan_idx);
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -162,7 +162,7 @@ void lll_sync_aux_prepare_cb(struct lll_sync *lll,
 	/* Set access address for sync */
 	radio_aa_set(lll->access_addr);
 	radio_crc_configure(PDU_CRC_POLYNOMIAL,
-                sys_get_le24(lll->crc_init));
+				sys_get_le24(lll->crc_init));
 
 	lll_chan_set(lll_aux->chan);
 
@@ -395,7 +395,7 @@ static int prepare_cb_common(struct lll_prepare_param *p, uint8_t chan_idx)
 	radio_pkt_configure(8, LL_EXT_OCTETS_RX_MAX, (lll->phy << 1));
 	radio_aa_set(lll->access_addr);
 	radio_crc_configure(PDU_CRC_POLYNOMIAL,
-                sys_get_le24(lll->crc_init));
+					sys_get_le24(lll->crc_init));
 
 	lll_chan_set(chan_idx);
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -161,8 +161,8 @@ void lll_sync_aux_prepare_cb(struct lll_sync *lll,
 
 	/* Set access address for sync */
 	radio_aa_set(lll->access_addr);
-	radio_crc_configure(RADIO_CRC_POLYNOMIAL,
-			    sys_get_le24(lll->crc_init));
+	radio_crc_configure(PDU_CRC_POLYNOMIAL,
+                sys_get_le24(lll->crc_init));
 
 	lll_chan_set(lll_aux->chan);
 
@@ -394,8 +394,8 @@ static int prepare_cb_common(struct lll_prepare_param *p, uint8_t chan_idx)
 	radio_phy_set(lll->phy, 1);
 	radio_pkt_configure(8, LL_EXT_OCTETS_RX_MAX, (lll->phy << 1));
 	radio_aa_set(lll->access_addr);
-	radio_crc_configure(RADIO_CRC_POLYNOMIAL,
-			    sys_get_le24(lll->crc_init));
+	radio_crc_configure(PDU_CRC_POLYNOMIAL,
+                sys_get_le24(lll->crc_init));
 
 	lll_chan_set(chan_idx);
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_test.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_test.c
@@ -18,6 +18,8 @@
 
 #include "util/memq.h"
 
+#include "pdu.h"
+
 #include "lll.h"
 #include "lll_clock.h"
 #include "lll_internal.h"
@@ -195,7 +197,7 @@ static uint32_t init(uint8_t chan, uint8_t phy, void (*isr)(void *))
 	radio_tx_power_max_set();
 	radio_freq_chan_set((chan << 1) + 2);
 	radio_aa_set((uint8_t *)&test_sync_word);
-	radio_crc_configure(0x65b, 0x555555);
+	radio_crc_configure(0x65b, PDU_AC_CRC_IV);
 	radio_pkt_configure(8, 255, (test_phy << 1));
 
 	return 0;

--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -70,6 +70,12 @@
 /* Advertisement channel Access Address */
 #define PDU_AC_ACCESS_ADDR     0x8e89bed6
 
+/* Advertisement channel CRC init value */
+#define PDU_AC_CRC_IV          0x555555
+
+/* CRC polynomial */
+#define PDU_CRC_POLYNOMIAL     ((0x5bUL) | ((0x06UL) << 8) | ((0x00UL) << 16))
+
 /* Data channel minimum payload size and time */
 #define PDU_DC_PAYLOAD_SIZE_MIN 27
 #define PDU_DC_PAYLOAD_TIME_MIN 328


### PR DESCRIPTION
Use sys_get_le24 to pass CRC init value.
Define RADIO_CRC_POLYNOMIAL to replace the magic number.

Fixes #27971.

Signed-off-by: Adhipta Putra <adhipta.putra@nordicsemi.no>