### PR TITLE
ARC: forbid FIRQ or multiple register banks with 1 IRQ priority level

### DIFF
--- a/arch/arc/Kconfig
+++ b/arch/arc/Kconfig
@@ -136,6 +136,7 @@ config NUM_IRQS
 config RGF_NUM_BANKS
 	int "Number of General Purpose Register Banks"
 	depends on ARC_FIRQ
+	depends on NUM_IRQ_PRIO_LEVELS > 1
 	range 1 2
 	default 2
 	help
@@ -145,10 +146,15 @@ config RGF_NUM_BANKS
 	  If fast interrupts are supported but there is only 1
 	  register bank, the fast interrupt handler must save
 	  and restore general purpose registers.
+	  NOTE: it's required to have more than one interrupt priority level
+	  to use second register bank - otherwise all interrupts will use
+	  same register bank. Such configuration isn't supported in software
+	  and it is not beneficial from the performance point of view.
 
 config ARC_FIRQ
 	bool "FIRQ enable"
 	depends on ISA_ARCV2
+	depends on NUM_IRQ_PRIO_LEVELS > 1
 	default y
 	help
 	  Fast interrupts are supported (FIRQ). If FIRQ enabled, for interrupts
@@ -156,6 +162,10 @@ config ARC_FIRQ
 	  other regs will be saved according to the number of register bank;
 	  If FIRQ is disabled, the handle of interrupts with highest priority
 	  will be same with other interrupts.
+	  NOTE: we don't allow the configuration with FIRQ enabled and only one
+	  interrupt priority level (so all interrupts are FIRQ). Such
+	  configuration isn't supported in software and it is not beneficial
+	  from the performance point of view.
 
 config ARC_FIRQ_STACK
 	bool "Enable separate firq stack"

--- a/include/arch/arc/arch.h
+++ b/include/arch/arc/arch.h
@@ -43,6 +43,40 @@
 #endif
 #endif
 
+#if defined(CONFIG_ARC_FIRQ) && defined(CONFIG_ISA_ARCV3)
+#error "Unsupported configuration: ARC_FIRQ and ISA_ARCV3"
+#endif
+
+/*
+ * We don't allow the configuration with FIRQ enabled and only one interrupt priority level
+ * (so all interrupts are FIRQ). Such configuration isn't supported in software and it is not
+ * beneficial from the performance point of view.
+ */
+#if defined(CONFIG_ARC_FIRQ) && CONFIG_NUM_IRQ_PRIO_LEVELS < 2
+#error "Unsupported configuration: ARC_FIRQ and (NUM_IRQ_PRIO_LEVELS < 2)"
+#endif
+
+#if CONFIG_RGF_NUM_BANKS > 1 && !defined(CONFIG_ARC_FIRQ)
+#error "Unsupported configuration: (RGF_NUM_BANKS > 1) and !ARC_FIRQ"
+#endif
+
+/*
+ * It's required to have more than one interrupt priority level to use second register bank
+ * - otherwise all interrupts will use same register bank. Such configuration isn't supported in
+ * software and it is not beneficial from the performance point of view.
+ */
+#if CONFIG_RGF_NUM_BANKS > 1 && CONFIG_NUM_IRQ_PRIO_LEVELS < 2
+#error "Unsupported configuration: (RGF_NUM_BANKS > 1) and (NUM_IRQ_PRIO_LEVELS < 2)"
+#endif
+
+#if defined(CONFIG_ARC_FIRQ_STACK) && !defined(CONFIG_ARC_FIRQ)
+#error "Unsupported configuration: ARC_FIRQ_STACK and !ARC_FIRQ"
+#endif
+
+#if defined(CONFIG_ARC_FIRQ_STACK) && CONFIG_RGF_NUM_BANKS < 2
+#error "Unsupported configuration: ARC_FIRQ_STACK and (RGF_NUM_BANKS < 2)"
+#endif
+
 #ifndef _ASMLANGUAGE
 
 #ifdef __cplusplus


### PR DESCRIPTION
Don't allow to enable multiple register banks / fast interrupts if we have only one interrupt priority level. Such configurations are not supported in software and they are not beneficial from the performance point of view.

Fixes #39240
Fixes #38309