### PR TITLE
tests: bluetooth: tester: Set Config Client timeout to larger value

### DIFF
--- a/tests/bluetooth/tester/src/mesh.c
+++ b/tests/bluetooth/tester/src/mesh.c
@@ -885,6 +885,8 @@ static void composition_data_get(uint8_t *data, uint16_t len)
 
 	LOG_DBG("");
 
+	bt_mesh_cfg_cli_timeout_set(10 * MSEC_PER_SEC);
+
 	net_buf_simple_init(comp, 0);
 
 	err = bt_mesh_cfg_comp_data_get(cmd->net_idx, cmd->address, cmd->page,


### PR DESCRIPTION
In some scenarios when there is a need for multiple re-transmissions of
segmented messages the default value of 2 seconds may be not enough.

In my experience this improves stability of Configuration Client tests
involving multiple PTS instances.

Signed-off-by: Michał Narajowski <michal.narajowski@codecoup.pl>