### PR TITLE
subsys: net: lwm2m: Add option to force close the connection

### DIFF
--- a/include/net/lwm2m.h
+++ b/include/net/lwm2m.h
@@ -995,9 +995,11 @@ void lwm2m_rd_client_start(struct lwm2m_ctx *client_ctx, const char *ep_name,
  *
  * @param[in] client_ctx LwM2M context
  * @param[in] event_cb Client event callback function
+ * @param[in] deregister True to deregister the client if registered.
+ *                       False to force close the connection.
  */
 void lwm2m_rd_client_stop(struct lwm2m_ctx *client_ctx,
-			  lwm2m_ctx_event_cb_t event_cb);
+			  lwm2m_ctx_event_cb_t event_cb, bool deregister);
 
 /**
  * @brief Trigger a Registration Update of the LwM2M RD Client

--- a/samples/net/lwm2m_client/src/lwm2m-client.c
+++ b/samples/net/lwm2m_client/src/lwm2m-client.c
@@ -445,7 +445,7 @@ static void rd_client_event(struct lwm2m_ctx *client,
 
 	case LWM2M_RD_CLIENT_EVENT_NETWORK_ERROR:
 		LOG_ERR("LwM2M engine reported a network erorr.");
-		lwm2m_rd_client_stop(client, rd_client_event);
+		lwm2m_rd_client_stop(client, rd_client_event, true);
 		break;
 	}
 }

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -1080,14 +1080,14 @@ void lwm2m_rd_client_start(struct lwm2m_ctx *client_ctx, const char *ep_name,
 }
 
 void lwm2m_rd_client_stop(struct lwm2m_ctx *client_ctx,
-			   lwm2m_ctx_event_cb_t event_cb)
+			   lwm2m_ctx_event_cb_t event_cb, bool deregister)
 {
 	k_mutex_lock(&client.mutex, K_FOREVER);
 
 	client.ctx = client_ctx;
 	client.event_cb = event_cb;
 
-	if (sm_is_registered()) {
+	if (sm_is_registered() && deregister) {
 		set_sm_state(ENGINE_DEREGISTER);
 	} else {
 		if (client.ctx->sock_fd > -1) {


### PR DESCRIPTION
Add an option to force close the LwM2M connection
instead of always trying to deregister.
If on a cellular connection and the connection is dropped,
deregistering will never complete and take a long time
before retries fail. This option allows the app to close the
socket and quickly re-establish the connection when the
network connection is available again.
