### PR TITLE
NXP USDHC timing fix

### DIFF
--- a/boards/arm/mimxrt1060_evk/pinmux.c
+++ b/boards/arm/mimxrt1060_evk/pinmux.c
@@ -54,6 +54,9 @@ static void mimxrt1060_evk_usdhc_pinmux(uint16_t nusdhc, bool init, uint32_t spe
 	}
 
 	if (init) {
+		/* Enable pull up on clock */
+		clk |= IOMUXC_SW_PAD_CTL_PAD_PUS(1);
+
 		IOMUXC_SetPinMux(IOMUXC_GPIO_AD_B0_05_GPIO1_IO05, 0U);
 
 		/* SD_CD */

--- a/drivers/disk/usdhc.c
+++ b/drivers/disk/usdhc.c
@@ -2386,12 +2386,14 @@ APP_SEND_OP_COND_AGAIN:
 		/* high capacity check */
 		if (cmd->response[0U] & SD_OCR_CARD_CAP_FLAG) {
 			priv->card_info.card_flags |= SDHC_HIGH_CAPACITY_FLAG;
+			LOG_DBG("SD card reports high capacity support");
 		}
 
 		if (priv->config->no_1_8_v == false) {
 			/* 1.8V support */
 			if (cmd->response[0U] & SD_OCR_SWITCH_18_ACCEPT_FLAG) {
 				priv->card_info.card_flags |= SDHC_1800MV_FLAG;
+				LOG_DBG("SD card reports 1.8V (LVS) support");
 			}
 		}
 		priv->card_info.raw_ocr = cmd->response[0U];

--- a/drivers/disk/usdhc.c
+++ b/drivers/disk/usdhc.c
@@ -716,12 +716,9 @@ enum usdhc_reset {
 	/*!< All reset types */
 };
 
-static void usdhc_millsec_delay(unsigned int cycles_to_wait)
+static void usdhc_millsec_delay(unsigned int millis)
 {
-	unsigned int start = sys_clock_cycle_get_32();
-
-	while (sys_clock_cycle_get_32() - start < (cycles_to_wait * 1000))
-		;
+	k_msleep(millis);
 }
 
 uint32_t g_usdhc_boot_dummy __aligned(64);
@@ -1617,12 +1614,12 @@ static int usdhc_vol_switch(struct usdhc_priv *priv)
 	/* host switch to 1.8V */
 	usdhc_select_1_8_vol(base, true);
 
-	usdhc_millsec_delay(20000U);
+	usdhc_millsec_delay(100U);
 
 	/*enable force clock on*/
 	usdhc_force_clk_on(base, true);
-	/* dealy 1ms,not exactly correct when use while */
-	usdhc_millsec_delay(20000U);
+	/* delay 10ms,not exactly correct when use while */
+	usdhc_millsec_delay(10U);
 	/*disable force clock on*/
 	usdhc_force_clk_on(base, false);
 

--- a/soc/arm/nxp_imx/rt/soc.h
+++ b/soc/arm/nxp_imx/rt/soc.h
@@ -27,8 +27,7 @@ extern "C" {
 typedef void (*usdhc_pin_cfg_cb)(uint16_t nusdhc, bool init,
 	uint32_t speed, uint32_t strength);
 
-void imxrt_usdhc_pinmux(uint16_t nusdhc,
-	bool init, uint32_t speed, uint32_t strength);
+void imxrt_usdhc_pinmux(uint16_t nusdhc, uint32_t freq);
 
 void imxrt_usdhc_pinmux_cb_register(usdhc_pin_cfg_cb cb);
 

--- a/soc/arm/nxp_imx/rt/soc_rt10xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt10xx.c
@@ -197,15 +197,15 @@ static ALWAYS_INLINE void clock_init(void)
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(usdhc1), okay) && CONFIG_DISK_DRIVER_SDMMC
 	/* Configure USDHC clock source and divider */
-	CLOCK_InitSysPfd(kCLOCK_Pfd0, 0x12U);
-	CLOCK_SetDiv(kCLOCK_Usdhc1Div, 0U);
+	CLOCK_InitSysPfd(kCLOCK_Pfd0, 24U);
+	CLOCK_SetDiv(kCLOCK_Usdhc1Div, 1U);
 	CLOCK_SetMux(kCLOCK_Usdhc1Mux, 1U);
 	CLOCK_EnableClock(kCLOCK_Usdhc1);
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(usdhc2), okay) && CONFIG_DISK_DRIVER_SDMMC
 	/* Configure USDHC clock source and divider */
-	CLOCK_InitSysPfd(kCLOCK_Pfd0, 0x12U);
-	CLOCK_SetDiv(kCLOCK_Usdhc2Div, 0U);
+	CLOCK_InitSysPfd(kCLOCK_Pfd0, 24U);
+	CLOCK_SetDiv(kCLOCK_Usdhc2Div, 1U);
 	CLOCK_SetMux(kCLOCK_Usdhc2Mux, 1U);
 	CLOCK_EnableClock(kCLOCK_Usdhc2);
 #endif
@@ -254,12 +254,24 @@ void imxrt_usdhc_pinmux_cb_register(usdhc_pin_cfg_cb cb)
 	g_usdhc_pin_cfg_cb = cb;
 }
 
-void imxrt_usdhc_pinmux(uint16_t nusdhc, bool init,
-	uint32_t speed, uint32_t strength)
+void imxrt_usdhc_pinmux(uint16_t nusdhc, uint32_t freq)
 {
-	if (g_usdhc_pin_cfg_cb)
-		g_usdhc_pin_cfg_cb(nusdhc, init,
+	uint32_t speed = 0U, strength = 0U;
+
+	if (g_usdhc_pin_cfg_cb) {
+		if (freq <= 50000000) {
+			speed    = 0U;
+			strength = 7U;
+		} else if (freq <= 100000000) {
+			speed    = 2U;
+			strength = 7U;
+		} else {
+			speed    = 3U;
+			strength = 7U;
+		}
+		g_usdhc_pin_cfg_cb(nusdhc, false,
 			speed, strength);
+	}
 }
 #endif
 


### PR DESCRIPTION
This PR improves the timing functionality in the NXP USDHC driver. Previously, the driver used system clock cycles to approximate millisecond delays. This resulted in unreliable communication with SD cards using this driver. Changing the delay function in the driver to use millisecond delay functions provided by Zephyr reduces timing errors when communicating with SD cards.