### PR TITLE
drivers: spi: convert spi_cs_control to use gpio_dt_spec

### DIFF
--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -183,29 +183,34 @@ gpio_dt_flags_t spi_context_cs_active_level(struct spi_context *ctx)
 	return GPIO_ACTIVE_LOW;
 }
 
-static inline void spi_context_cs_configure(struct spi_context *ctx)
+static inline int spi_context_cs_configure(struct spi_context *ctx)
 {
-	if (ctx->config->cs && ctx->config->cs->gpio_dev) {
+	int ret;
+
+	if (ctx->config->cs && ctx->config->cs->gpio.port) {
 		/* Validate CS active levels are equivalent */
 		__ASSERT(spi_context_cs_active_level(ctx) ==
-			 (ctx->config->cs->gpio_dt_flags & GPIO_ACTIVE_LOW),
+			 (ctx->config->cs->gpio.dt_flags & GPIO_ACTIVE_LOW),
 			 "Devicetree and spi_context CS levels are not equal");
-		gpio_pin_configure(ctx->config->cs->gpio_dev,
-				   ctx->config->cs->gpio_pin,
-				   ctx->config->cs->gpio_dt_flags |
-				   GPIO_OUTPUT_INACTIVE);
+		ret = gpio_pin_configure_dt(&ctx->config->cs->gpio,
+				      GPIO_OUTPUT_INACTIVE);
+		if (ret < 0) {
+			LOG_ERR("Failed to configure 'cs' gpio: %d", ret);
+			return ret;
+		}
 	} else {
 		LOG_INF("CS control inhibited (no GPIO device)");
 	}
+
+	return 0;
 }
 
 static inline void _spi_context_cs_control(struct spi_context *ctx,
 					   bool on, bool force_off)
 {
-	if (ctx->config && ctx->config->cs && ctx->config->cs->gpio_dev) {
+	if (ctx->config && ctx->config->cs && ctx->config->cs->gpio.port) {
 		if (on) {
-			gpio_pin_set(ctx->config->cs->gpio_dev,
-				     ctx->config->cs->gpio_pin, 1);
+			gpio_pin_set_dt(&ctx->config->cs->gpio, 1);
 			k_busy_wait(ctx->config->cs->delay);
 		} else {
 			if (!force_off &&
@@ -214,8 +219,7 @@ static inline void _spi_context_cs_control(struct spi_context *ctx,
 			}
 
 			k_busy_wait(ctx->config->cs->delay);
-			gpio_pin_set(ctx->config->cs->gpio_dev,
-				     ctx->config->cs->gpio_pin, 0);
+			gpio_pin_set_dt(&ctx->config->cs->gpio, 0);
 		}
 	}
 }

--- a/include/devicetree/spi.h
+++ b/include/devicetree/spi.h
@@ -117,6 +117,46 @@ extern "C" {
 #define DT_SPI_DEV_HAS_CS_GPIOS(spi_dev) DT_SPI_HAS_CS_GPIOS(DT_BUS(spi_dev))
 
 /**
+ * @brief Get a SPI device's chip select devicetree specification
+ *
+ * Example devicetree fragment:
+ *
+ * @code{.devicetree}
+ *     gpio1: gpio@... { ... };
+ *
+ *     gpio2: gpio@... { ... };
+ *
+ *     spi@... {
+ *             compatible = "vnd,spi";
+ *             cs-gpios = <&gpio1 10 GPIO_ACTIVE_LOW>,
+ *                        <&gpio2 20 GPIO_ACTIVE_LOW>;
+ *
+ *             a: spi-dev-a@0 {
+ *                     reg = <0>;
+ *             };
+ *
+ *             b: spi-dev-b@1 {
+ *                     reg = <1>;
+ *             };
+ *     };
+ * @endcode
+ *
+ * Example usage:
+ *
+ * @code{.c}
+ *     DT_SPI_DEV_CS_GPIOS_DT_SPEC_GET(DT_NODELABEL(a)) \
+ *           // { DEVICE_DT_GET(DT_NODELABEL(gpio1)), 10, GPIO_ACTIVE_LOW }
+ *     DT_SPI_DEV_CS_GPIOS_DT_SPEC_GET(DT_NODELABEL(b)) \
+ *           // { DEVICE_DT_GET(DT_NODELABEL(gpio2)), 20, GPIO_ACTIVE_LOW }
+ * @endcode
+ *
+ * @param spi_dev a SPI device node identifier
+ * @return #gpio_dt_spec struct corresponding with spi_dev's chip select
+ */
+#define DT_SPI_DEV_CS_GPIOS_DT_SPEC_GET(spi_dev) \
+	GPIO_DT_SPEC_GET_BY_IDX(DT_BUS(spi_dev), cs_gpios, DT_REG_ADDR(spi_dev))
+
+/**
  * @brief Get a SPI device's chip select GPIO controller's node identifier
  *
  * Example devicetree fragment:

--- a/include/drivers/spi.h
+++ b/include/drivers/spi.h
@@ -124,22 +124,28 @@ extern "C" {
  * This can be used to control a CS line via a GPIO line, instead of
  * using the controller inner CS logic.
  *
- * @param gpio_dev is a valid pointer to an actual GPIO device. A NULL pointer
- *        can be provided to full inhibit CS control if necessary.
- * @param gpio_pin is a number representing the gpio PIN that will be used
- *    to act as a CS line
- * @param delay is a delay in microseconds to wait before starting the
- *    transmission and before releasing the CS line
- * @param gpio_dt_flags is the devicetree flags corresponding to how the CS
- *    line should be driven. GPIO_ACTIVE_LOW/GPIO_ACTIVE_HIGH should be
- *    equivalent to SPI_CS_ACTIVE_HIGH/SPI_CS_ACTIVE_LOW options in struct
- *    spi_config.
  */
 struct spi_cs_control {
-	const struct device	*gpio_dev;
-	uint32_t		delay;
-	gpio_pin_t		gpio_pin;
-	gpio_dt_flags_t		gpio_dt_flags;
+	/**
+	 * GPIO devicetree specification of CS GPIO.
+	 * The device pointer can be set to NULL to fully inhibit CS control if
+	 * necessary. The GPIO flags GPIO_ACTIVE_LOW/GPIO_ACTIVE_HIGH should be
+	 * equivalent to SPI_CS_ACTIVE_HIGH/SPI_CS_ACTIVE_LOW options in struct
+	 * spi_config.
+	 */
+	union {
+		struct gpio_dt_spec gpio;
+		struct {
+			const struct device *gpio_dev;
+			gpio_pin_t gpio_pin;
+			gpio_dt_flags_t gpio_dt_flags;
+		};
+	};
+	/**
+	 * Delay in microseconds to wait before starting the
+	 * transmission and before releasing the CS line.
+	 */
+	uint32_t delay;
 };
 
 #ifndef __cplusplus

--- a/include/drivers/spi.h
+++ b/include/drivers/spi.h
@@ -193,13 +193,10 @@ struct spi_cs_control {
  * @param delay_ The @p delay field to set in the @p spi_cs_control
  * @return a pointer to the @p spi_cs_control structure
  */
-#define SPI_CS_CONTROL_PTR_DT(node_id, delay_)				\
-	(&(struct spi_cs_control) {						\
-		.gpio_dev = DEVICE_DT_GET(				\
-			DT_SPI_DEV_CS_GPIOS_CTLR(node_id)),		\
-		.delay = (delay_),					\
-		.gpio_pin = DT_SPI_DEV_CS_GPIOS_PIN(node_id),		\
-		.gpio_dt_flags = DT_SPI_DEV_CS_GPIOS_FLAGS(node_id),	\
+#define SPI_CS_CONTROL_PTR_DT(node_id, delay_)			  \
+	(&(struct spi_cs_control) {				  \
+		.gpio = DT_SPI_DEV_CS_GPIOS_DT_SPEC_GET(node_id), \
+		.delay = (delay_),				  \
 	})
 
 /**
@@ -439,7 +436,7 @@ static inline bool spi_is_ready(const struct spi_dt_spec *spec)
 	}
 	/* Validate CS gpio port is ready, if it is used */
 	if (spec->config.cs &&
-	    !device_is_ready(spec->config.cs->gpio_dev)) {
+	    !device_is_ready(spec->config.cs->gpio.port)) {
 		return false;
 	}
 	return true;


### PR DESCRIPTION
This MR contains changes and improvements related to gpio_dt_spec struct use within spi_cs_control struct.

It's based on the @JordanYates work that has been done here https://github.com/csiro-wsn/zephyr/commits/210801_spi_cs and because I didn't want to duplicate the work I've decided to take these changes and send to upstream as it's blocking the https://github.com/zephyrproject-rtos/zephyr/pull/37325 merge request.

@JordanYates If you have any objections to this MR please let me know. 