### PR TITLE
Remove LE audio channel link

### DIFF
--- a/include/bluetooth/audio.h
+++ b/include/bluetooth/audio.h
@@ -826,7 +826,6 @@ struct bt_audio_chan {
 	struct bt_iso_chan *iso;
 	/** Audio channel operations */
 	struct bt_audio_chan_ops *ops;
-	sys_slist_t links;
 	sys_snode_t node;
 
 	union {

--- a/include/bluetooth/audio.h
+++ b/include/bluetooth/audio.h
@@ -1464,8 +1464,6 @@ int bt_audio_unicast_group_delete(struct bt_audio_unicast_group *unicast_group);
 /** @brief Create audio broadcast source.
  *
  *  Create a new audio broadcast source with one or more audio channels.
- *  To create a broadcast source with multiple channels, the channels must be
- *  linked with bt_audio_chan_link().
  *
  *  The broadcast source will be visible for scanners once this has been called,
  *  and the device will advertise audio announcements.
@@ -1571,11 +1569,9 @@ int bt_audio_broadcast_sink_scan_stop(void);
  *  @param indexes_bitfield   Bitfield of the BIS index to sync to. To sync to
  *                            e.g. BIS index 1 and 2, this should have the value
  *                            of BIT(1) | BIT(2).
- *  @param chan               Channel object to be used for the receiver. If
+ *  @param chans              Channel objects to be used for the receiver. If
  *                            multiple BIS indexes shall be synchronized,
- *                            multiple channels shall be provided. To provide
- *                            multiple channels use bt_audio_chan_link to link
- *                            them.
+ *                            multiple channels shall be provided.
  *  @param broadcast_code     The 16-octet broadcast code. Shall be supplied if
  *                            the broadcast is encrypted (see the syncable
  *                            callback).
@@ -1584,7 +1580,7 @@ int bt_audio_broadcast_sink_scan_stop(void);
  */
 int bt_audio_broadcast_sink_sync(struct bt_audio_broadcast_sink *sink,
 				 uint32_t indexes_bitfield,
-				 struct bt_audio_chan *chan,
+				 struct bt_audio_chan *chans,
 				 const uint8_t broadcast_code[16]);
 
 /** @brief Stop audio broadcast sink.

--- a/include/bluetooth/audio.h
+++ b/include/bluetooth/audio.h
@@ -1393,32 +1393,6 @@ int bt_audio_chan_stop(struct bt_audio_chan *chan);
  */
 int bt_audio_chan_release(struct bt_audio_chan *chan, bool cache);
 
-/** @brief Link Audio Channels
- *
- *  This procedure links channels so that any procedure on either of the
- *  channel is replicated on the other.
- *
- *  @param chan1 First Channel object
- *  @param chan2 Second Channel object
- *
- *  @return 0 in case of success or negative value in case of error.
- */
-int bt_audio_chan_link(struct bt_audio_chan *chan1,
-		       struct bt_audio_chan *chan2);
-
-/** @brief Unlink Audio Channels
- *
- *  This procedure links channels so that any procedure on either of the
- *  channel is replicated on the other.
- *
- *  @param chan1 First Channel object
- *  @param chan2 Second Channel object
- *
- *  @return 0 in case of success or negative value in case of error.
- */
-int bt_audio_chan_unlink(struct bt_audio_chan *chan1,
-			 struct bt_audio_chan *chan2);
-
 /** @brief Send data to Audio channel
  *
  *  Send data from buffer to the channel.

--- a/subsys/bluetooth/host/audio/chan.c
+++ b/subsys/bluetooth/host/audio/chan.c
@@ -89,8 +89,6 @@ struct bt_audio_chan *bt_audio_chan_config(struct bt_conn *conn,
 		return chan;
 	}
 
-	sys_slist_init(&chan->links);
-
 	bt_audio_chan_attach(conn, chan, ep, cap, codec);
 
 	if (ep->type == BT_AUDIO_EP_LOCAL) {

--- a/subsys/bluetooth/shell/bap.c
+++ b/subsys/bluetooth/shell/bap.c
@@ -667,12 +667,9 @@ static int cmd_list(const struct shell *sh, size_t argc, char *argv[])
 		struct bt_audio_chan *chan = &chans[i];
 
 		if (chan->conn) {
-			shell_print(sh, "  %s#%u: chan %p dir 0x%02x "
-				    "group %p linked %s",
+			shell_print(sh, "  %s#%u: chan %p dir 0x%02x group %p",
 				    chan == default_chan ? "*" : " ", i, chan,
-				    chan->cap->type, chan->group,
-				    sys_slist_is_empty(&chan->links) ? "no" :
-				    "yes");
+				    chan->cap->type, chan->group);
 		}
 	}
 
@@ -743,86 +740,6 @@ static int cmd_select(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	set_channel(chan);
-
-	return 0;
-}
-
-static int cmd_link(const struct shell *sh, size_t argc, char *argv[])
-{
-	struct bt_audio_chan *chan1, *chan2;
-	int index1, index2, err;
-
-	index1 = strtol(argv[1], NULL, 0);
-	if (index1 < 0 || index1 > ARRAY_SIZE(chans)) {
-		shell_error(sh, "Invalid index1");
-		return -ENOEXEC;
-	}
-
-	index2 = strtol(argv[2], NULL, 0);
-	if (index2 < 0 || index2 > ARRAY_SIZE(chans)) {
-		shell_error(sh, "Invalid index2");
-		return -ENOEXEC;
-	}
-
-	chan1 = &chans[index1 - 1];
-	if (!chan1->conn) {
-		shell_error(sh, "Invalid index1");
-		return -ENOEXEC;
-	}
-
-	chan2 = &chans[index2 - 1];
-	if (!chan2->conn) {
-		shell_error(sh, "Invalid index2");
-		return -ENOEXEC;
-	}
-
-	err = bt_audio_chan_link(chan1, chan2);
-	if (err) {
-		shell_error(sh, "Unable to bind: %d", err);
-		return -ENOEXEC;
-	}
-
-	shell_print(sh, "channnels %d:%d linked", index1, index2);
-
-	return 0;
-}
-
-static int cmd_unlink(const struct shell *sh, size_t argc, char *argv[])
-{
-	struct bt_audio_chan *chan1, *chan2;
-	int index1, index2, err;
-
-	index1 = strtol(argv[1], NULL, 0);
-	if (index1 < 0 || index1 > ARRAY_SIZE(chans)) {
-		shell_error(sh, "Invalid index1");
-		return -ENOEXEC;
-	}
-
-	index2 = strtol(argv[2], NULL, 0);
-	if (index2 < 0 || index2 > ARRAY_SIZE(chans)) {
-		shell_error(sh, "Invalid index2");
-		return -ENOEXEC;
-	}
-
-	chan1 = &chans[index1 - 1];
-	if (!chan1->conn) {
-		shell_error(sh, "Invalid index1");
-		return -ENOEXEC;
-	}
-
-	chan2 = &chans[index2 - 1];
-	if (!chan2->conn) {
-		shell_error(sh, "Invalid index2");
-		return -ENOEXEC;
-	}
-
-	err = bt_audio_chan_unlink(chan1, chan2);
-	if (err) {
-		shell_error(sh, "Unable to bind: %d", err);
-		return -ENOEXEC;
-	}
-
-	shell_print(sh, "ases %d:%d unbound", index1, index2);
 
 	return 0;
 }
@@ -1499,8 +1416,6 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bap_cmds,
 	SHELL_CMD_ARG(release, NULL, NULL, cmd_release, 1, 0),
 	SHELL_CMD_ARG(list, NULL, NULL, cmd_list, 1, 0),
 	SHELL_CMD_ARG(select, NULL, "<chan> [broadcast]", cmd_select, 2, 0),
-	SHELL_CMD_ARG(link, NULL, "<chan1> <chan2>", cmd_link, 3, 0),
-	SHELL_CMD_ARG(unlink, NULL, "<chan1> <chan2>", cmd_unlink, 3, 0),
 	SHELL_CMD_ARG(connect, NULL,
 		      "<direction: sink, source> <index>  [codec] [preset]",
 		      cmd_connect, 3, 2),


### PR DESCRIPTION
Remove the concept of linking channels. The concept has been confusing to use, and did not provide the same level of flexibility as the BAP and ASCS specs provide, as all channels that were linked would share a single secondary argument, instead of an argument per channel. 