### PR TITLE
[Backport v2.6-branch] Bluetooth: Controller: Fix node rx memory corruption regression

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -49,8 +49,8 @@
 #include "common/log.h"
 #include "hal/debug.h"
 
-static void invalid_release(struct lll_conn *lll, memq_link_t *link,
-			    struct node_rx_hdr *rx);
+static void invalid_release(struct ull_hdr *hdr, struct lll_conn *lll,
+			    memq_link_t *link, struct node_rx_hdr *rx);
 static void ticker_op_stop_adv_cb(uint32_t status, void *param);
 static void ticker_op_cb(uint32_t status, void *param);
 static void ticker_update_latency_cancel_op_cb(uint32_t ticker_status,
@@ -114,7 +114,7 @@ void ull_slave_setup(struct node_rx_hdr *rx, struct node_rx_ftr *ftr,
 	/* Do not connect twice to the same peer */
 	if (ull_conn_peer_connected(own_addr_type, own_addr,
 				    peer_addr_type, peer_id_addr)) {
-		invalid_release(lll, link, rx);
+		invalid_release(&adv->ull, lll, link, rx);
 
 		return;
 	}
@@ -136,7 +136,7 @@ void ull_slave_setup(struct node_rx_hdr *rx, struct node_rx_ftr *ftr,
 	lll->interval = sys_le16_to_cpu(pdu_adv->connect_ind.interval);
 	if ((lll->data_chan_count < 2) || (lll->data_chan_hop < 5) ||
 	    (lll->data_chan_hop > 16) || !lll->interval) {
-		invalid_release(lll, link, rx);
+		invalid_release(&adv->ull, lll, link, rx);
 
 		return;
 	}
@@ -551,9 +551,12 @@ uint8_t ll_start_enc_req_send(uint16_t handle, uint8_t error_code,
 }
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 
-static void invalid_release(struct lll_conn *lll, memq_link_t *link,
-			    struct node_rx_hdr *rx)
+static void invalid_release(struct ull_hdr *hdr, struct lll_conn *lll,
+			    memq_link_t *link, struct node_rx_hdr *rx)
 {
+	/* Reset the advertising disabled callback */
+	hdr->disabled_cb = NULL;
+
 	/* Let the advertiser continue with connectable advertising */
 	lll->slave.initiated = 0U;
 


### PR DESCRIPTION
Fix the node rx memory pool corruption regression introduced
due to same peer connection being rejected.

Regression introduced in commit 30f260dfaaf7 ("Bluetooth:
controller: Fix adv/scan context access post release").

Fixes #37634.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>