### PR TITLE
dts: bindings: imx-flexspi: flexspi clock to be configured from dts.

### DIFF
--- a/dts/bindings/spi/nxp,imx-flexspi.yaml
+++ b/dts/bindings/spi/nxp,imx-flexspi.yaml
@@ -68,6 +68,35 @@ properties:
         Source clock for flash read. See the RXCLKSRC field in register MCR0.
         The default corresponds to the reset value of the register field.
 
+    pll3-pfd0-div:
+      type: int
+      required: false
+      default: 24
+      description: |
+        Divisor for PLL3_PFD0. Output frequency is input to flexspi clock
+        selection mux.
+
+    flexspi-sel-mux:
+      type: int
+      required: false
+      default: 3
+      enum:
+        - 0 # SEMC root clock
+        - 1 # PLL2_PFD2 clock
+        - 2 # PLL3_SW clock
+        - 3 # PLL3_PFD0 clock
+      description: |
+        Source clock for flexspi clock.
+
+    flexspi-clock-div:
+      type: int
+      required: false
+      default: 2
+      description: |
+        Divisor for flexspi clock. The output frequency is (mux_output/(1+div)).
+
+
+
 child-binding:
     description: NXP FlexSPI port
 

--- a/soc/arm/nxp_imx/rt/soc_rt10xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt10xx.c
@@ -224,9 +224,16 @@ static ALWAYS_INLINE void clock_init(void)
 	defined(CONFIG_MEMC_MCUX_FLEXSPI) && \
 	DT_NODE_HAS_STATUS(DT_NODELABEL(flexspi), okay)
 	CLOCK_DisableClock(kCLOCK_FlexSpi);
-	CLOCK_InitUsb1Pfd(kCLOCK_Pfd0, 24);
-	CLOCK_SetMux(kCLOCK_FlexspiMux, 3);
-	CLOCK_SetDiv(kCLOCK_FlexspiDiv, 2);
+#endif
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(flexspi), okay) && \
+	defined(CONFIG_MEMC_MCUX_FLEXSPI)
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd0, DT_PROP(DT_NODELABEL(flexspi),
+				pll3_pfd0_div));
+	CLOCK_SetMux(kCLOCK_FlexspiMux, DT_PROP(DT_NODELABEL(flexspi),
+				flexspi_sel_mux));
+	CLOCK_SetDiv(kCLOCK_FlexspiDiv, DT_PROP(DT_NODELABEL(flexspi),
+				flexspi_clock_div));
 #endif
 
 	/* Keep the system clock running so SYSTICK can wake up the system from


### PR DESCRIPTION
This enables a finer tuning of flexspi clock from the dts for boards
with different clock settings than what is currently hardcoded.

Signed-off-by: Nicolai Glud <nicolai.glud@prevas.dk>