### PR TITLE
drivers: lora: fix RtcGetCalendarTime()

### DIFF
--- a/drivers/lora/hal_common.c
+++ b/drivers/lora/hal_common.c
@@ -43,9 +43,9 @@ void RtcBkupRead(uint32_t *data0, uint32_t *data1)
 
 uint32_t RtcGetCalendarTime(uint16_t *milliseconds)
 {
-	uint32_t now = k_uptime_get_32();
+	int64_t now = k_uptime_get();
 
-	*milliseconds = now;
+	*milliseconds = now % MSEC_PER_SEC;
 
 	/* Return in seconds */
 	return now / MSEC_PER_SEC;


### PR DESCRIPTION
Uptime in milliseconds is assigned to uint32_t variable, which results
in integer overflow after enough time has expired. Additionally
milliseconds part (which should be 0-999) is assigned directly from
uptime, without subtracting full seconds.

Fix both issues by using int64_t variable and calculating milliseconds
with modulo.