### PR TITLE
drivers/flash/nrf_qspi_nor: Default write_from_nvmc buffer size to 4 

### DIFF
--- a/drivers/flash/Kconfig.nordic_qspi_nor
+++ b/drivers/flash/Kconfig.nordic_qspi_nor
@@ -28,7 +28,7 @@ config NORDIC_QSPI_NOR_FLASH_LAYOUT_PAGE_SIZE
 
 config NORDIC_QSPI_NOR_STACK_WRITE_BUFFER_SIZE
 	int "Size of a stack-based buffer to support writes from NVMC"
-	default 0
+	default 4
 	help
 	  The QSPI peripheral uses DMA and cannot write data that is
 	  read from the internal flash.  A non-zero value here enables

--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -967,8 +967,6 @@ static inline nrfx_err_t write_sub_word(const struct device *dev, off_t addr,
 BUILD_ASSERT((CONFIG_NORDIC_QSPI_NOR_STACK_WRITE_BUFFER_SIZE % 4) == 0,
 	     "NOR stack buffer must be multiple of 4 bytes");
 
-#define NVMC_WRITE_OK (CONFIG_NORDIC_QSPI_NOR_STACK_WRITE_BUFFER_SIZE > 0)
-
 /* If enabled write using a stack-allocated aligned SRAM buffer as
  * required for DMA transfers by QSPI peripheral.
  *
@@ -977,28 +975,28 @@ BUILD_ASSERT((CONFIG_NORDIC_QSPI_NOR_STACK_WRITE_BUFFER_SIZE % 4) == 0,
 static inline nrfx_err_t write_from_nvmc(const struct device *dev, off_t addr,
 					 const void *sptr, size_t slen)
 {
-#if NVMC_WRITE_OK
-	uint8_t __aligned(4) buf[CONFIG_NORDIC_QSPI_NOR_STACK_WRITE_BUFFER_SIZE];
-	const uint8_t *sp = sptr;
 	nrfx_err_t res = NRFX_SUCCESS;
 
-	while ((slen > 0) && (res == NRFX_SUCCESS)) {
-		size_t len = MIN(slen, sizeof(buf));
+	if (CONFIG_NORDIC_QSPI_NOR_STACK_WRITE_BUFFER_SIZE > 0) {
+		uint8_t __aligned(4) buf[CONFIG_NORDIC_QSPI_NOR_STACK_WRITE_BUFFER_SIZE];
+		const uint8_t *sp = sptr;
 
-		memcpy(buf, sp, len);
-		res = nrfx_qspi_write(buf, sizeof(buf),
-				      addr);
-		qspi_wait_for_completion(dev, res);
+		while ((slen > 0) && (res == NRFX_SUCCESS)) {
+			size_t len = MIN(slen, sizeof(buf));
 
-		if (res == NRFX_SUCCESS) {
-			slen -= len;
-			sp += len;
-			addr += len;
+			memcpy(buf, sp, len);
+			res = nrfx_qspi_write(buf, sizeof(buf), addr);
+			qspi_wait_for_completion(dev, res);
+
+			if (res == NRFX_SUCCESS) {
+				slen -= len;
+				sp += len;
+				addr += len;
+			}
 		}
+	} else {
+		res = NRFX_ERROR_INVALID_ADDR;
 	}
-#else /* NVMC_WRITE_OK */
-	nrfx_err_t res = NRFX_ERROR_INVALID_ADDR;
-#endif /* NVMC_WRITE_OK */
 	return res;
 }
 


### PR DESCRIPTION
The commit changes the default size of write_from_nvmc,
defined by CONFIG_NORDIC_QSPI_NOR_STACK_WRITE_BUFFER_SIZE, to 4,
making the write_from_nvmc operation enabled by default.
The Kconfig description for the option has been changes more clearly
describe how does the option impact compilation.