### PR TITLE
Bluetooth: Vendor specific ISO data path

### DIFF
--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -2169,6 +2169,23 @@ void bt_foreach_bond(uint8_t id, void (*func)(const struct bt_bond_info *info,
 					   void *user_data),
 		     void *user_data);
 
+/** @brief Configure vendor data path
+ *
+ *  Request the Controller to configure the data transport path in a given direction between
+ *  the Controller and the Host.
+ *
+ *  @param dir            Direction to be configured, BT_HCI_DATAPATH_DIR_HOST_TO_CTLR or
+ *                        BT_HCI_DATAPATH_DIR_CTLR_TO_HOST
+ *  @param id             Vendor specific logical transport channel ID, range
+ *                        [BT_HCI_DATAPATH_ID_VS..BT_HCI_DATAPATH_ID_VS_END]
+ *  @param vs_config_len  Length of additional vendor specific configuration data
+ *  @param vs_config      Pointer to additional vendor specific configuration data
+ *
+ *  @return 0 in case of success or negative value in case of error.
+ */
+int bt_configure_data_path(uint8_t dir, uint8_t id, uint8_t vs_config_len,
+			   const uint8_t *vs_config);
+
 /**
  * @}
  */

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -292,15 +292,10 @@ static int bt_iso_setup_data_path(struct bt_conn *iso)
 	rx_qos = chan->qos->rx;
 
 	in_path.path = tx_qos && tx_qos->path ? tx_qos->path : &default_path;
+	in_path.pid  = tx_qos ? tx_qos->path->pid : BT_ISO_DATA_PATH_DISABLED;
+
 	out_path.path = rx_qos && rx_qos->path ? rx_qos->path : &default_path;
-
-	if (!tx_qos) {
-		in_path.pid = BT_ISO_DATA_PATH_DISABLED;
-	}
-
-	if (!rx_qos) {
-		out_path.pid = BT_ISO_DATA_PATH_DISABLED;
-	}
+	out_path.pid  = rx_qos ? rx_qos->path->pid : BT_ISO_DATA_PATH_DISABLED;
 
 	if (iso->iso.is_bis) {
 		/* Only set one data path for BIS as per the spec */


### PR DESCRIPTION
**Bluetooth: controller: Framework for vendor ISO data path**

Added weak function for data path dependent ISO-AL sink creation. This
is required for vendor specific ISO-AL data sink operation. Invoke sink
creation for vendor specific data path.

**Bluetooth: host: Add bt_configure_data_path for vendor data path**

Implemented host function for configuring vendor specific data path for
use with ISO, and fixed passing of path ID in setup.