### PR TITLE
doc: ARM Compiler 6 description added to the 3rd party toolchain page

### DIFF
--- a/doc/getting_started/toolchain_3rd_party_x_compilers.rst
+++ b/doc/getting_started/toolchain_3rd_party_x_compilers.rst
@@ -8,14 +8,14 @@ external organization. Several of these are available.
 
 .. _toolchain_gnuarmemb:
 
-GNU ARM Embedded
+GNU Arm Embedded
 ****************
 
    .. warning::
 
       Do not install the toolchain into a path with spaces.
 
-#. Download and install a `GNU ARM Embedded`_ build for your operating system
+#. Download and install a `GNU Arm Embedded`_ build for your operating system
    and extract it on your file system.
 
    .. note::
@@ -210,6 +210,6 @@ You can build toolchains from source code using crosstool-NG.
       $ echo $XTOOLS_TOOLCHAIN_PATH
       /Volumes/CrossToolNGNew/build/output/
 
-.. _GNU ARM Embedded: https://developer.arm.com/open-source/gnu-toolchain/gnu-rm
+.. _GNU Arm Embedded: https://developer.arm.com/open-source/gnu-toolchain/gnu-rm
 .. _crosstool-ng site: http://crosstool-ng.org
 .. _Arm Compiler 6: https://developer.arm.com/tools-and-software/embedded/arm-compiler/downloads/version-6

--- a/doc/getting_started/toolchain_3rd_party_x_compilers.rst
+++ b/doc/getting_started/toolchain_3rd_party_x_compilers.rst
@@ -61,6 +61,57 @@ GNU ARM Embedded
       - Set :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``gnuarmemb``.
       - Set :envvar:`GNUARMEMB_TOOLCHAIN_PATH` to the brew installation directory (something like ``/usr/local``)
 
+.. _toolchain_armclang:
+
+Arm Compiler 6
+**************
+
+#. Download and install a development suite containing the `Arm Compiler 6`_
+   for your operating system.
+
+#. :ref:`Set these environment variables <env_vars>`:
+
+   - Set :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``armclang``.
+   - Set :envvar:`ARMCLANG_TOOLCHAIN_PATH` to the toolchain installation
+     directory.
+
+#. The Arm Compiler 6 needs the :envvar:`ARMLMD_LICENSE_FILE` environment
+   variable to point to your license file or server.
+
+For example:
+
+   .. code-block:: console
+
+      # Linux, macOS, license file:
+      export ARMLMD_LICENSE_FILE=/<path>/license_armds.dat
+      # Linux, macOS, license server:
+      export ARMLMD_LICENSE_FILE=8224@myserver
+
+      # Windows, license file:
+      > set ARMLMD_LICENSE_FILE=c:\<path>\license_armds.dat
+      # Windows, license server:
+      > set ARMLMD_LICENSE_FILE=8224@myserver
+
+#. If the Arm Compiler 6 was installed as part of an Arm Development Studio, then
+   you must set the :envvar:`ARM_PRODUCT_DEF` to point to the product definition file:
+   See also: `Product and toolkit configuration <https://developer.arm.com/tools-and-software/software-development-tools/license-management/resources/product-and-toolkit-configuration>`_.
+   For example if the Arm Development Studio is installed in:
+   ``/opt/armds-2020-1`` with a Gold license, then set :envvar:`ARM_PRODUCT_DEF`
+   to point to ``/opt/armds-2020-1/gold.elmap``.
+
+   .. note::
+
+      The Arm Compiler 6 uses ``armlink`` for linking. This is incompatible
+      with Zephyr's linker script template, which works with GNU ld. Zephyr's
+      Arm Compiler 6 support Zephyr's CMake linker script generator, which
+      supports generating scatter files. Basic scatter file support is in
+      place, but there are still areas covered in ld templates which are not
+      fully supported by the CMake linker script generator.
+
+      Some Zephyr subsystems or modules may also contain C or assembly code
+      that relies on GNU intrinsics and have not yet been updated to work fully
+      with ``armclang``.
+
 Intel oneAPI Toolkit
 *********************
 
@@ -161,3 +212,4 @@ You can build toolchains from source code using crosstool-NG.
 
 .. _GNU ARM Embedded: https://developer.arm.com/open-source/gnu-toolchain/gnu-rm
 .. _crosstool-ng site: http://crosstool-ng.org
+.. _Arm Compiler 6: https://developer.arm.com/tools-and-software/embedded/arm-compiler/downloads/version-6


### PR DESCRIPTION
This commit adds description on how to use the ARM Compiler 6 / armclang
toolchain with Zephyr.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>