### PR TITLE
Bluetooth: Controller: Fix missing traversal of TargetA

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -149,6 +149,13 @@ static int prepare_cb(struct lll_prepare_param *p)
 		pri_dptr += BDADDR_SIZE;
 	}
 
+	/* traverse through tgt_addr, if present */
+	if (pri_hdr->tgt_addr) {
+		pri_dptr += BDADDR_SIZE;
+	}
+
+	/* No CTEInfo flag in primary and secondary channel PDU */
+
 	/* traverse through adi, if present */
 	if (pri_hdr->adi) {
 		pri_dptr += sizeof(struct pdu_adv_adi);

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -1120,10 +1120,19 @@ struct pdu_adv_aux_ptr *ull_adv_aux_lll_offset_fill(struct pdu_adv *pdu,
 	h = (void *)pri_com_hdr->ext_hdr_adv_data;
 	ptr = h->data;
 
+	/* traverse through adv_addr, if present */
 	if (h->adv_addr) {
 		ptr += BDADDR_SIZE;
 	}
 
+	/* traverse through tgt_addr, if present */
+	if (h->tgt_addr) {
+		ptr += BDADDR_SIZE;
+	}
+
+	/* No CTEInfo flag in primary and secondary channel PDU */
+
+	/* traverse through adi, if present */
 	if (h->adi) {
 		ptr += sizeof(struct pdu_adv_adi);
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -1590,18 +1590,29 @@ static inline struct pdu_adv_sync_info *sync_info_get(struct pdu_adv *pdu)
 	h = (void *)p->ext_hdr_adv_data;
 	ptr = h->data;
 
+	/* traverse through adv_addr, if present */
 	if (h->adv_addr) {
 		ptr += BDADDR_SIZE;
 	}
 
+	/* traverse through tgt_addr, if present */
+	if (h->tgt_addr) {
+		ptr += BDADDR_SIZE;
+	}
+
+	/* No CTEInfo flag in primary and secondary channel PDU */
+
+	/* traverse through adi, if present */
 	if (h->adi) {
 		ptr += sizeof(struct pdu_adv_adi);
 	}
 
+	/* traverse through aux ptr, if present */
 	if (h->aux_ptr) {
 		ptr += sizeof(struct pdu_adv_aux_ptr);
 	}
 
+	/* return pointer offset to sync_info */
 	return (void *)ptr;
 }
 


### PR DESCRIPTION
Fix missing traversal of TargetA field in advertised Common
Extended Payload Format. This will cause invalid offset used
for fields following the TargetA when Extended Directed
Advertising is used.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>