### PR TITLE
Bluetooth: Controller: Fix ASSERTION FAIL [!hdr->disabled_cb] 

### DIFF
--- a/samples/bluetooth/central_multilink/Kconfig
+++ b/samples/bluetooth/central_multilink/Kconfig
@@ -1,0 +1,14 @@
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+mainmenu "Bluetooth: Central Multilink"
+
+config SAMPLE_CONN_ITERATIONS
+	int "Connection iterations"
+	range 0 255
+	default 0
+	help
+	  Number of times to connect and disconnect to peripheral_identity
+	  sample.
+
+source "Kconfig.zephyr"

--- a/samples/bluetooth/central_multilink/src/main.c
+++ b/samples/bluetooth/central_multilink/src/main.c
@@ -6,9 +6,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-int init_central(void);
+#include <stdint.h>
+
+int init_central(uint8_t iterations);
 
 void main(void)
 {
-	(void)init_central();
+	(void)init_central(CONFIG_SAMPLE_CONN_ITERATIONS);
 }

--- a/samples/bluetooth/peripheral_identity/Kconfig
+++ b/samples/bluetooth/peripheral_identity/Kconfig
@@ -1,0 +1,14 @@
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+mainmenu "Bluetooth: Central Multilink"
+
+config SAMPLE_CONN_ITERATIONS
+	int "Connection iterations"
+	range 0 255
+	default 0
+	help
+	  Expected number of times connect and disconnect from
+	  central_multilink sample.
+
+source "Kconfig.zephyr"

--- a/samples/bluetooth/peripheral_identity/src/main.c
+++ b/samples/bluetooth/peripheral_identity/src/main.c
@@ -6,9 +6,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-int init_peripheral(void);
+#include <stdint.h>
+
+int init_peripheral(uint8_t iterations);
 
 void main(void)
 {
-	(void)init_peripheral();
+	(void)init_peripheral(CONFIG_SAMPLE_CONN_ITERATIONS);
 }

--- a/samples/bluetooth/peripheral_identity/src/peripheral_identity.c
+++ b/samples/bluetooth/peripheral_identity/src/peripheral_identity.c
@@ -16,6 +16,7 @@
 static struct k_work work_adv_start;
 static uint8_t volatile conn_count;
 static uint8_t id_current;
+static bool volatile is_disconnecting;
 
 static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
@@ -44,6 +45,10 @@ static void adv_start(struct k_work *work)
 		id = bt_id_create(NULL, NULL);
 		if (id < 0) {
 			printk("Create id failed (%d)\n", id);
+			if (id_current == 0) {
+				id_current = CONFIG_BT_MAX_CONN;
+			}
+			id_current--;
 		} else {
 			printk("New id: %d\n", id);
 		}
@@ -93,7 +98,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 
 	printk("Disconnected %s (reason 0x%02x)\n", addr, reason);
 
-	if (conn_count == CONFIG_BT_MAX_CONN) {
+	if ((conn_count == 1U) && is_disconnecting) {
 		k_work_submit(&work_adv_start);
 	}
 	conn_count--;
@@ -122,6 +127,33 @@ static void le_param_updated(struct bt_conn *conn, uint16_t interval,
 	printk("LE conn param updated: %s int 0x%04x lat %d to %d\n",
 	       addr, interval, latency, timeout);
 }
+
+#if defined(CONFIG_BT_USER_PHY_UPDATE)
+static void le_phy_updated(struct bt_conn *conn,
+			   struct bt_conn_le_phy_info *param)
+{
+	char addr[BT_ADDR_LE_STR_LEN];
+
+	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+
+	printk("LE PHY Updated: %s Tx 0x%x, Rx 0x%x\n", addr, param->tx_phy,
+	       param->rx_phy);
+}
+#endif /* CONFIG_BT_USER_PHY_UPDATE */
+
+#if defined(CONFIG_BT_USER_DATA_LEN_UPDATE)
+static void le_data_len_updated(struct bt_conn *conn,
+				struct bt_conn_le_data_len_info *info)
+{
+	char addr[BT_ADDR_LE_STR_LEN];
+
+	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+
+	printk("Data length updated: %s max tx %u (%u us) max rx %u (%u us)\n",
+	       addr, info->tx_max_len, info->tx_max_time, info->rx_max_len,
+	       info->rx_max_time);
+}
+#endif /* CONFIG_BT_USER_DATA_LEN_UPDATE */
 
 #if defined(CONFIG_BT_SMP)
 static void security_changed(struct bt_conn *conn, bt_security_t level,
@@ -158,9 +190,18 @@ static struct bt_conn_cb conn_callbacks = {
 	.disconnected = disconnected,
 	.le_param_req = le_param_req,
 	.le_param_updated = le_param_updated,
+
 #if defined(CONFIG_BT_SMP)
 	.security_changed = security_changed,
 #endif /* CONFIG_BT_SMP */
+
+#if defined(CONFIG_BT_USER_PHY_UPDATE)
+	.le_phy_updated = le_phy_updated,
+#endif /* CONFIG_BT_USER_PHY_UPDATE */
+
+#if defined(CONFIG_BT_USER_DATA_LEN_UPDATE)
+	.le_data_len_updated = le_data_len_updated,
+#endif /* CONFIG_BT_USER_DATA_LEN_UPDATE */
 };
 
 #if defined(CONFIG_BT_OBSERVER)
@@ -180,7 +221,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 }
 #endif /* CONFIG_BT_OBSERVER */
 
-int init_peripheral(void)
+int init_peripheral(uint8_t iterations)
 {
 	size_t id_count;
 	int err;
@@ -224,13 +265,55 @@ int init_peripheral(void)
 	/* rotate identities so reconnections are attempted in case of any
 	 * disconnections
 	 */
+	uint8_t prev_count = conn_count;
 	while (1) {
-		k_sleep(K_SECONDS(1));
-
+		/* If maximum connections is reached, wait for disconnections
+		 * initiated by peer central devices.
+		 */
 		if (conn_count == CONFIG_BT_MAX_CONN) {
-			break;
+			if (!iterations) {
+				break;
+			}
+			iterations--;
+			printk("Iterations remaining: %u\n", iterations);
+
+			printk("Wait for disconnections...\n");
+			is_disconnecting = true;
+			while (conn_count != 0) {
+				k_sleep(K_MSEC(10));
+			}
+			is_disconnecting = false;
+			printk("All disconnected.\n");
+
+			continue;
 		}
 
+		/* As long as there is connection count changes, identity
+		 * rotation in this loop is not needed.
+		 */
+		if (prev_count != conn_count) {
+			prev_count = conn_count;
+
+			continue;
+		} else {
+			uint16_t wait = 1200U;
+
+			/* Maximum duration without connection count change, central
+			 * waiting before disconnecting all its connections plus few
+			 * seconds of margin.
+			 */
+			while ((prev_count == conn_count) && wait) {
+				wait--;
+
+				k_sleep(K_MSEC(10));
+			}
+
+			if (wait) {
+				continue;
+			}
+		}
+
+		/* Stopping and restarting advertising to use new identity */
 		printk("Stop advertising...\n");
 		err = bt_le_adv_stop();
 		if (err) {

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -537,6 +537,11 @@ static int is_abort_cb(void *next, void *curr, lll_prepare_cb_t *resume_cb)
 	}
 
 	if (0) {
+#if defined(CONFIG_BT_CENTRAL)
+	} else if (lll->conn && lll->conn->central.initiated) {
+		/* Connection Establishment initiated, do not abort */
+		return 0;
+#endif /* CONFIG_BT_CENTRAL */
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 	} else if (unlikely(lll->duration_reload && !lll->duration_expire)) {
 		/* Duration expired, do not continue, close and generate

--- a/tests/bluetooth/bsim_bt/bsim_test_advx/src/main.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_advx/src/main.c
@@ -634,6 +634,25 @@ static void test_advx_main(void)
 
 	k_sleep(K_MSEC(400));
 
+	printk("Starting directed advertising...");
+	const bt_addr_le_t direct_addr = {
+		.type = BT_ADDR_LE_RANDOM,
+		.a = {
+			.val = {0x11, 0x22, 0x33, 0x44, 0x55, 0xC6}
+		}
+	};
+	const struct bt_le_adv_param adv_param = {
+		.options = BT_LE_ADV_OPT_CONNECTABLE,
+		.peer = &direct_addr,
+	};
+	err = bt_le_adv_start(&adv_param, NULL, 0, NULL, 0);
+	if (err) {
+		goto exit;
+	}
+	printk("success.\n");
+
+	k_sleep(K_MSEC(2000));
+
 	printk("Disabling...");
 	err = ll_adv_enable(handle, 0, 0, 0);
 	if (err) {
@@ -1420,6 +1439,8 @@ static void test_scanx_main(void)
 	printk("done.\n");
 
 	scan_param.timeout = 0;
+
+	k_sleep(K_MSEC(2000));
 
 	printk("Start scanning for Periodic Advertisements...");
 	is_periodic = false;

--- a/tests/bluetooth/bsim_bt/bsim_test_advx/src/main.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_advx/src/main.c
@@ -341,6 +341,8 @@ static void test_advx_main(void)
 	printk("success.\n");
 
 	printk("Start advertising...");
+	ext_adv_param.timeout = 0;
+	ext_adv_param.num_events = 0;
 	err = bt_le_ext_adv_start(adv, &ext_adv_param);
 	if (err) {
 		goto exit;

--- a/tests/bluetooth/bsim_bt/bsim_test_multiple/prj.conf
+++ b/tests/bluetooth/bsim_bt/bsim_test_multiple/prj.conf
@@ -1,16 +1,37 @@
 CONFIG_BT=y
 CONFIG_BT_PERIPHERAL=y
 CONFIG_BT_CENTRAL=y
-CONFIG_BT_AUTO_PHY_UPDATE=n
 CONFIG_BT_PRIVACY=y
 
 CONFIG_BT_DEVICE_NAME="Multiple"
-CONFIG_BT_GAP_AUTO_UPDATE_CONN_PARAMS=n
+
+CONFIG_BT_USER_PHY_UPDATE=y
+CONFIG_BT_AUTO_PHY_UPDATE=y
+CONFIG_BT_USER_DATA_LEN_UPDATE=y
+CONFIG_BT_AUTO_DATA_LEN_UPDATE=y
 
 CONFIG_BT_MAX_CONN=62
 CONFIG_BT_ID_MAX=62
+
+# L2CAP, ATT and SMP usage cause data transmission deadlock due to shortage
+# of buffers when transactions crossover amongst the connections in the same
+# device. Hence, keeping them disabled in this test until future investigations.
+
+CONFIG_BT_GAP_AUTO_UPDATE_CONN_PARAMS=n
 
 # CONFIG_BT_GATT_CLIENT=y
 
 # CONFIG_BT_SMP=y
 # CONFIG_BT_MAX_PAIRED=62
+
+CONFIG_BT_BUF_CMD_TX_SIZE=255
+CONFIG_BT_BUF_EVT_RX_SIZE=255
+CONFIG_BT_BUF_EVT_DISCARDABLE_SIZE=255
+CONFIG_BT_BUF_ACL_TX_SIZE=251
+CONFIG_BT_BUF_ACL_RX_SIZE=251
+
+CONFIG_BT_CTLR_DATA_LENGTH_MAX=251
+
+# Each PHY update can pause connections for 6 interval hence to let other
+# parallel connection establishment to succeed increase Rx buffer count.
+CONFIG_BT_CTLR_RX_BUFFERS=6

--- a/tests/bluetooth/bsim_bt/bsim_test_multiple/src/main.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_multiple/src/main.c
@@ -18,8 +18,10 @@
 #include "time_machine.h"
 #include "bstests.h"
 
-int init_central(void);
-int init_peripheral(void);
+#define ITERATIONS 10
+
+int init_central(uint8_t iterations);
+int init_peripheral(uint8_t iterations);
 
 #define FAIL(...)					\
 	do {						\
@@ -39,7 +41,7 @@ static void test_central_main(void)
 {
 	int err;
 
-	err = init_central();
+	err = init_central(ITERATIONS);
 	if (err) {
 		goto exit;
 	}
@@ -63,7 +65,7 @@ static void test_peripheral_main(void)
 {
 	int err;
 
-	err = init_peripheral();
+	err = init_peripheral(ITERATIONS);
 	if (err) {
 		goto exit;
 	}
@@ -79,7 +81,7 @@ exit:
 
 static void test_multiple_init(void)
 {
-	bst_ticker_set_next_tick_absolute(30e6);
+	bst_ticker_set_next_tick_absolute(600e6);
 	bst_result = In_progress;
 }
 

--- a/tests/bluetooth/bsim_bt/bsim_test_multiple/tests_scripts/multiple.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_multiple/tests_scripts/multiple.sh
@@ -13,7 +13,7 @@ function Execute(){
  compile it?)\e[39m"
     exit 1
   fi
-  timeout 30 $@ & process_ids="$process_ids $!"
+  timeout 300 $@ & process_ids="$process_ids $!"
 }
 
 : "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
@@ -30,7 +30,7 @@ Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_multiple_prj_conf\
   -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
-  -D=2 -sim_length=30e6 $@
+  -D=2 -sim_length=600e6 $@
 
 for process_id in $process_ids; do
   wait $process_id || let "exit_code=$?"


### PR DESCRIPTION
Fix ASSERTION FAIL [!hdr->disabled_cb] @ ull_conn.c:882

When initiating a connection using continuous scan window
if there is preemption by the next window then the ISR
callback was overwritten to switch to next scan window
instead of the initiator event being closed.

Fixed by not aborting the initiating state when requested
by the next continuous scan window.

Add iterations of connections and disconnections to
Babblesim test of Bluetooth Low Energy Central role
functionality by scanning for other devices and establishing
connection to upto 62 peripherals with a strong enough
signal.

Add mixed Legacy Directed Advertising and Extended Advertising
test in the babblesim coverage for Extended Advertising
feature.

Enable Auto PHY Update and Auto Data Length Update procedure
in the central_multilink sample.

Enable Auto PHY Update and Auto Data Length Update procedure
in the peripheral_identity sample. Fixed issues related
rotation of identities after maximum number of connection
iterations are repeated.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>