### PR TITLE
Bluetooth: Audio: Update capability QoS/Preferences

### DIFF
--- a/include/bluetooth/audio.h
+++ b/include/bluetooth/audio.h
@@ -660,8 +660,11 @@ enum bt_audio_pac_type {
 #define BT_AUDIO_CONTENT_MAN_MACHINE     BIT(6)
 #define BT_AUDIO_CONTENT_EMERGENCY       BIT(7)
 
-/** @def BT_AUDIO_QOS
- *  @brief Helper to declare elements of bt_audio_qos
+#define BT_AUDIO_CAPABILITY_UNFRAMED_SUPPORTED     0x00
+#define BT_AUDIO_CAPABILITY_UNFRAMED_NOT_SUPPORTED 0x01
+
+/** @def BT_AUDIO_CAPABILITY_PREF
+ *  @brief Helper to declare elements of @ref bt_audio_capability_pref
  *
  *  @param _framing Framing
  *  @param _phy Target PHY
@@ -670,7 +673,7 @@ enum bt_audio_pac_type {
  *  @param _pd_min Minimum Presentation Delay (usec)
  *  @param _pd_max Maximum Presentation Delay (usec)
  */
-#define BT_AUDIO_QOS(_framing, _phy, _rtn, _latency, _pd_min, _pd_max) \
+#define BT_AUDIO_CAPABILITY_PREF(_framing, _phy, _rtn, _latency, _pd_min, _pd_max) \
 	{ \
 		.framing = _framing, \
 		.phy = _phy, \
@@ -680,19 +683,39 @@ enum bt_audio_pac_type {
 		.pd_max = _pd_max, \
 	}
 
-/** @brief Audio Capability QoS structure. */
-struct bt_audio_qos {
-	/** QoS Framing */
+/** @brief Audio Capability Preference structure. */
+struct bt_audio_capability_pref {
+	/** @brief Supported framing
+	 *
+	 *  Unlike the other fields, this is not a preference but whether
+	 *  the capability supports framed ISOAL PDUs.
+	 *
+	 *  Possible values: BT_AUDIO_CAPABILITY_UNFRAMED_SUPPORTED and
+	 *  BT_AUDIO_CAPABILITY_UNFRAMED_NOT_SUPPORTED.
+	 */
 	uint8_t  framing;
-	/** QoS PHY */
+
+	/** Preferred PHY */
 	uint8_t  phy;
-	/** QoS Retransmission Number */
+
+	/** Preferred Retransmission Number */
 	uint8_t  rtn;
-	/** QoS Transport Latency */
+
+	/** Preferred Transport Latency */
 	uint16_t latency;
-	/** QoS Minimun Presentation Delay */
+
+	/** @brief Minimun Presentation Delay
+	 *
+	 *  Unlike the other fields, this is not a preference but a minimum
+	 *  requirement.
+	 */
 	uint32_t pd_min;
-	/** QoS Maximun Presentation Delay */
+
+	/** @brief Maximum Presentation Delay
+	 *
+	 *  Unlike the other fields, this is not a preference but a maximum
+	 *  requirement.
+	 */
 	uint32_t pd_max;
 };
 
@@ -709,8 +732,8 @@ struct bt_audio_capability {
 	uint16_t context;
 	/** Capability codec reference */
 	struct bt_codec *codec;
-	/** Capability QoS */
-	struct bt_audio_qos qos;
+	/** Capability preferences */
+	struct bt_audio_capability_pref pref;
 	/** Capability operations reference */
 	struct bt_audio_capability_ops *ops;
 	sys_snode_t node;

--- a/include/bluetooth/audio.h
+++ b/include/bluetooth/audio.h
@@ -717,6 +717,12 @@ struct bt_audio_capability_pref {
 	 *  requirement.
 	 */
 	uint32_t pd_max;
+
+	/** @brief Preferred minimun Presentation Delay */
+	uint32_t pref_pd_min;
+
+	/** @brief Preferred maximum Presentation Delay	*/
+	uint32_t pref_pd_max;
 };
 
 /** @brief Audio Capability structure.

--- a/samples/bluetooth/unicast_audio_client/src/main.c
+++ b/samples/bluetooth/unicast_audio_client/src/main.c
@@ -246,8 +246,9 @@ static struct bt_audio_capability_ops lc3_ops = {
 static struct bt_audio_capability caps[] = {
 	{
 		.type = BT_AUDIO_SOURCE,
-		.qos = BT_AUDIO_QOS(BT_CODEC_QOS_UNFRAMED, BT_GAP_LE_PHY_2M,
-				    0x02, 10, 40000, 40000),
+		.pref = BT_AUDIO_CAPABILITY_PREF(
+				BT_AUDIO_CAPABILITY_UNFRAMED_SUPPORTED,
+				BT_GAP_LE_PHY_2M, 0x02, 10, 40000, 40000),
 		.codec = &preset_16_2_1.codec,
 		.ops = &lc3_ops,
 	}

--- a/samples/bluetooth/unicast_audio_server/src/main.c
+++ b/samples/bluetooth/unicast_audio_server/src/main.c
@@ -249,8 +249,9 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
 static struct bt_audio_capability caps[] = {
 	{
 		.type = BT_AUDIO_SINK,
-		.qos = BT_AUDIO_QOS(BT_CODEC_QOS_UNFRAMED, BT_GAP_LE_PHY_2M,
-				    0x02, 10, 40000, 40000),
+		.pref = BT_AUDIO_CAPABILITY_PREF(
+				BT_AUDIO_CAPABILITY_UNFRAMED_SUPPORTED,
+				BT_GAP_LE_PHY_2M, 0x02, 10, 40000, 40000),
 		.codec = &preset_16_2_1.codec,
 		.ops = &lc3_ops,
 	}

--- a/subsys/bluetooth/host/audio/chan.c
+++ b/subsys/bluetooth/host/audio/chan.c
@@ -404,17 +404,17 @@ int bt_audio_chan_qos(struct bt_audio_chan *chan, struct bt_codec_qos *qos)
 		return -ENOTSUP;
 	}
 
-	if (chan->cap->qos.latency < qos->latency) {
+	if (chan->cap->pref.latency < qos->latency) {
 		BT_ERR("Latency not within range: max %u latency %u",
-		       chan->cap->qos.latency, qos->latency);
+		       chan->cap->pref.latency, qos->latency);
 		qos->latency = 0u;
 		return -ENOTSUP;
 	}
 
-	if (!IN_RANGE(chan->cap->qos.pd_min, chan->cap->qos.pd_max,
+	if (!IN_RANGE(chan->cap->pref.pd_min, chan->cap->pref.pd_max,
 		      qos->pd)) {
 		BT_ERR("Presentation Delay not within range: min %u max %u "
-		       "pd %u", chan->cap->qos.pd_min, chan->cap->qos.pd_max,
+		       "pd %u", chan->cap->pref.pd_min, chan->cap->pref.pd_max,
 		       qos->pd);
 		qos->pd = 0u;
 		return -ENOTSUP;

--- a/subsys/bluetooth/host/audio/endpoint.c
+++ b/subsys/bluetooth/host/audio/endpoint.c
@@ -358,6 +358,8 @@ static void ep_config(struct bt_audio_ep *ep, struct net_buf_simple *buf)
 	pref->latency = sys_le16_to_cpu(cfg->latency);
 	pref->pd_min = sys_get_le24(cfg->pd_min);
 	pref->pd_max = sys_get_le24(cfg->pd_max);
+	pref->pref_pd_min = sys_get_le24(cfg->prefer_pd_min);
+	pref->pref_pd_max = sys_get_le24(cfg->prefer_pd_max);
 
 	BT_DBG("dir 0x%02x framing 0x%02x phy 0x%02x rtn %u latency %u "
 	       "pd_min %u pd_max %u codec 0x%02x ", ep->chan->cap->type,
@@ -674,8 +676,8 @@ static void ep_get_status_config(struct bt_audio_ep *ep,
 	cfg->latency = sys_cpu_to_le16(pref->latency);
 	sys_put_le24(pref->pd_min, cfg->pd_min);
 	sys_put_le24(pref->pd_max, cfg->pd_max);
-	sys_put_le24(BT_ASCS_PD_NO_PREF, cfg->prefer_pd_min);
-	sys_put_le24(BT_ASCS_PD_NO_PREF, cfg->prefer_pd_max);
+	sys_put_le24(pref->pref_pd_min, cfg->prefer_pd_min);
+	sys_put_le24(pref->pref_pd_max, cfg->prefer_pd_max);
 	cfg->codec.id = ep->codec.id;
 	cfg->codec.cid = sys_cpu_to_le16(ep->codec.cid);
 	cfg->codec.vid = sys_cpu_to_le16(ep->codec.vid);

--- a/subsys/bluetooth/host/audio/endpoint.c
+++ b/subsys/bluetooth/host/audio/endpoint.c
@@ -320,7 +320,7 @@ static void ep_qos_reset(struct bt_audio_ep *ep)
 static void ep_config(struct bt_audio_ep *ep, struct net_buf_simple *buf)
 {
 	struct bt_ascs_ase_status_config *cfg;
-	struct bt_audio_qos *qos;
+	struct bt_audio_capability_pref *pref;
 
 	if (buf->len < sizeof(*cfg)) {
 		BT_ERR("Config status too short");
@@ -349,20 +349,20 @@ static void ep_config(struct bt_audio_ep *ep, struct net_buf_simple *buf)
 	/* Reset any exiting QoS configuration */
 	ep_qos_reset(ep);
 
-	qos = &ep->chan->cap->qos;
+	pref = &ep->chan->cap->pref;
 
 	/* Convert to interval representation so they can be matched by QoS */
-	qos->framing = cfg->framing;
-	qos->phy = cfg->phy;
-	qos->rtn = cfg->rtn;
-	qos->latency = sys_le16_to_cpu(cfg->latency);
-	qos->pd_min = sys_get_le24(cfg->pd_min);
-	qos->pd_max = sys_get_le24(cfg->pd_max);
+	pref->framing = cfg->framing;
+	pref->phy = cfg->phy;
+	pref->rtn = cfg->rtn;
+	pref->latency = sys_le16_to_cpu(cfg->latency);
+	pref->pd_min = sys_get_le24(cfg->pd_min);
+	pref->pd_max = sys_get_le24(cfg->pd_max);
 
 	BT_DBG("dir 0x%02x framing 0x%02x phy 0x%02x rtn %u latency %u "
 	       "pd_min %u pd_max %u codec 0x%02x ", ep->chan->cap->type,
-	       qos->framing, qos->phy, qos->rtn, qos->latency, qos->pd_min,
-	       qos->pd_max, ep->chan->codec->id);
+	       pref->framing, pref->phy, pref->rtn, pref->latency, pref->pd_min,
+	       pref->pd_max, ep->chan->codec->id);
 
 	bt_audio_ep_set_codec(ep, cfg->codec.id,
 			      sys_le16_to_cpu(cfg->codec.cid),
@@ -665,15 +665,15 @@ static void ep_get_status_config(struct bt_audio_ep *ep,
 				 struct net_buf_simple *buf)
 {
 	struct bt_ascs_ase_status_config *cfg;
-	struct bt_audio_qos *qos = &ep->chan->cap->qos;
+	struct bt_audio_capability_pref *pref = &ep->chan->cap->pref;
 
 	cfg = net_buf_simple_add(buf, sizeof(*cfg));
-	cfg->framing = qos->framing;
-	cfg->phy = qos->phy;
-	cfg->rtn = qos->rtn;
-	cfg->latency = sys_cpu_to_le16(qos->latency);
-	sys_put_le24(qos->pd_min, cfg->pd_min);
-	sys_put_le24(qos->pd_max, cfg->pd_max);
+	cfg->framing = pref->framing;
+	cfg->phy = pref->phy;
+	cfg->rtn = pref->rtn;
+	cfg->latency = sys_cpu_to_le16(pref->latency);
+	sys_put_le24(pref->pd_min, cfg->pd_min);
+	sys_put_le24(pref->pd_max, cfg->pd_max);
 	sys_put_le24(BT_ASCS_PD_NO_PREF, cfg->prefer_pd_min);
 	sys_put_le24(BT_ASCS_PD_NO_PREF, cfg->prefer_pd_max);
 	cfg->codec.id = ep->codec.id;
@@ -682,8 +682,8 @@ static void ep_get_status_config(struct bt_audio_ep *ep,
 
 	BT_DBG("dir 0x%02x framing 0x%02x phy 0x%02x rtn %u latency %u "
 	       "pd_min %u pd_max %u codec 0x%02x ", ep->chan->cap->type,
-	       qos->framing, qos->phy, qos->rtn, qos->latency, qos->pd_min,
-	       qos->pd_max, ep->chan->codec->id);
+	       pref->framing, pref->phy, pref->rtn, pref->latency, pref->pd_min,
+	       pref->pd_max, ep->chan->codec->id);
 
 	cfg->cc_len = buf->len;
 	codec_data_add(buf, "data", ep->codec.data_count, ep->codec.data);

--- a/subsys/bluetooth/shell/bap.c
+++ b/subsys/bluetooth/shell/bap.c
@@ -1123,13 +1123,17 @@ static struct bt_audio_chan_ops chan_ops = {
 static struct bt_audio_capability caps[MAX_PAC] = {
 	{
 		.type = BT_AUDIO_SOURCE,
-		.qos = BT_AUDIO_QOS(0x00, 0x02, 0u, 60u, 20000u, 40000u),
+		.pref = BT_AUDIO_CAPABILITY_PREF(
+				BT_AUDIO_CAPABILITY_UNFRAMED_SUPPORTED,
+				BT_GAP_LE_PHY_2M, 0u, 60u, 20000u, 40000u),
 		.codec = &lc3_codec,
 		.ops = &lc3_ops,
 	},
 	{
 		.type = BT_AUDIO_SINK,
-		.qos = BT_AUDIO_QOS(0x00, 0x02, 0u, 60u, 20000u, 40000u),
+		.pref = BT_AUDIO_CAPABILITY_PREF(
+				BT_AUDIO_CAPABILITY_UNFRAMED_SUPPORTED,
+				BT_GAP_LE_PHY_2M, 0u, 60u, 20000u, 40000u),
 		.codec = &lc3_codec,
 		.ops = &lc3_ops,
 	},

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/broadcast_sink_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/broadcast_sink_test.c
@@ -102,7 +102,9 @@ static int init(void)
 	int err;
 	static struct bt_audio_capability caps = {
 		.type = BT_AUDIO_SINK,
-		.qos = BT_AUDIO_QOS(0x00, 0x02, 0u, 60u, 20000u, 40000u),
+		.pref = BT_AUDIO_CAPABILITY_PREF(
+				BT_AUDIO_CAPABILITY_UNFRAMED_SUPPORTED,
+				BT_GAP_LE_PHY_2M, 0u, 60u, 20000u, 40000u),
 		.codec = &lc3_codec,
 		.ops = &lc3_ops,
 	};


### PR DESCRIPTION
Renames the struct from QoS to preferences, and update the struct a bit to be more descriptive and flexible. 