### PR TITLE
toolchain: xcc: add macro __in_section_unique_named()

### DIFF
--- a/include/toolchain/xcc.h
+++ b/include/toolchain/xcc.h
@@ -117,6 +117,12 @@
 #define __in_section_unique(seg) \
 	__attribute__((section("." STRINGIFY(seg) "." STRINGIFY(__COUNTER__))))
 
+#undef __in_section_unique_named
+#define __in_section_unique_named(seg, name) \
+	__attribute__((section("." STRINGIFY(seg) \
+			       "." STRINGIFY(__COUNTER__) \
+			       "." STRINGIFY(name))))
+
 #ifndef __GCC_LINKER_CMD__
 #include <xtensa/config/core.h>
 


### PR DESCRIPTION
XCC doesn't like having quotes in the section name, so
workaround it by overriding __in_section_unique_named()
similar to __in_section_unique().

Signed-off-by: Daniel Leung <daniel.leung@intel.com>