### PR TITLE
interrupt_controller: remove CONFIG_DW_ICTL_OFFSET

### DIFF
--- a/boards/xtensa/intel_s1000_crb/Kconfig.defconfig
+++ b/boards/xtensa/intel_s1000_crb/Kconfig.defconfig
@@ -15,9 +15,6 @@ config CAVS_ICTL_2_OFFSET
 config CAVS_ICTL_3_OFFSET
 	default 16
 
-config DW_ICTL_OFFSET
-	default 7
-
 config 2ND_LVL_INTR_00_OFFSET
 	default CAVS_ICTL_0_OFFSET
 config 2ND_LVL_INTR_01_OFFSET
@@ -27,7 +24,7 @@ config 2ND_LVL_INTR_02_OFFSET
 config 2ND_LVL_INTR_03_OFFSET
 	default CAVS_ICTL_3_OFFSET
 config 3RD_LVL_INTR_00_OFFSET
-	default DW_ICTL_OFFSET
+	default 7
 
 config MAX_IRQ_PER_AGGREGATOR
 	default 32

--- a/drivers/interrupt_controller/Kconfig.dw
+++ b/drivers/interrupt_controller/Kconfig.dw
@@ -17,12 +17,6 @@ config DW_ICTL_NAME
 	help
 	  Give a name for the instance of Designware Interrupt Controller
 
-config DW_ICTL_OFFSET
-	int "Parent interrupt number to which DW_ICTL maps"
-	default 0
-	help
-	  Parent interrupt number to which DW_ICTL maps
-
 config DW_ISR_TBL_OFFSET
 	int "Offset in the SW ISR Table"
 	default 0


### PR DESCRIPTION
This kconfig is only used for one board and is simply an alias
to another kconfig. So remove CONFIG_DW_ICTL_OFFSET and apply
the value directly to the other kconfig.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>