### PR TITLE
boards: mimxrt10xx: Disabled 1.8V support on mimxrt10xx platforms

### DIFF
--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -158,6 +158,7 @@ zephyr_udc0: &usb1 {
 
 &usdhc1 {
 	status = "okay";
+	no-1-8-v;
 	pwr-gpios = <&gpio1 5 GPIO_ACTIVE_HIGH>;
 	cd-gpios = <&gpio2 28 GPIO_ACTIVE_LOW>;
 };

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -180,6 +180,7 @@ zephyr_udc0: &usb1 {
 	status = "okay";
 	pwr-gpios = <&gpio1 5 GPIO_ACTIVE_HIGH>;
 	cd-gpios = <&gpio2 28 GPIO_ACTIVE_LOW>;
+	no-1-8-v;
 	status = "okay";
 };
 

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -230,6 +230,7 @@ zephyr_udc0: &usb1 {
 
 &usdhc1 {
 	status = "okay";
+	no-1-8-v;
 	pwr-gpios = <&gpio1 5 GPIO_ACTIVE_HIGH>;
 	cd-gpios = <&gpio2 28 GPIO_ACTIVE_LOW>;
 };


### PR DESCRIPTION
The mimxrt10xx evaluation boards that support NXP USDHC IP
communicate unreliably with SD cards at 1.8V using the USDHC driver.
This commit temporarily disables 1.8V communication for all rt10xx
boards that currently support the USDHC driver.

Fixes #32289 

