### PR TITLE
actions: exclude Python 3.6 tests on macos-latest

### DIFF
--- a/.github/workflows/devicetree_checks.yml
+++ b/.github/workflows/devicetree_checks.yml
@@ -22,6 +22,9 @@ jobs:
       matrix:
         python-version: [3.6, 3.7, 3.8]
         os: [ubuntu-latest, macos-latest, windows-latest]
+        exclude:
+          - os: macos-latest
+            python-version: 3.6
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/west_cmds.yml
+++ b/.github/workflows/west_cmds.yml
@@ -23,6 +23,9 @@ jobs:
       matrix:
         python-version: [3.6, 3.7, 3.8]
         os: [ubuntu-latest, macos-latest, windows-latest]
+        exclude:
+          - os: macos-latest
+            python-version: 3.6
     steps:
     - name: checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
Python 3.6 support is no longer available on macos-latest. Exclude it.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>