### PR TITLE
Pm struct optimization

### DIFF
--- a/include/net/ethernet.h
+++ b/include/net/ethernet.h
@@ -827,21 +827,21 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
 
 #if defined(CONFIG_NET_VLAN)
 #define Z_ETH_NET_DEVICE_INIT(node_id, dev_name, drv_name, init_fn,	\
-			      pm_control_fn, data, cfg, prio, api, mtu)	\
+			      pm_control_fn, data, cfg, prio, api, mtu, use_pm)	\
 	Z_DEVICE_DEFINE(node_id, dev_name, drv_name, init_fn,		\
 			pm_control_fn, data, cfg, POST_KERNEL,		\
-			prio, api);					\
+			prio, api, use_pm);					\
 	NET_L2_DATA_INIT(dev_name, 0, NET_L2_GET_CTX_TYPE(ETHERNET_L2));\
 	NET_IF_INIT(dev_name, 0, ETHERNET_L2, mtu, NET_VLAN_MAX_COUNT)
 
 #else /* CONFIG_NET_VLAN */
 
 #define Z_ETH_NET_DEVICE_INIT(node_id, dev_name, drv_name, init_fn,	\
-			      pm_control_fn, data, cfg, prio, api, mtu)	\
+			      pm_control_fn, data, cfg, prio, api, mtu, use_pm)	\
 	Z_NET_DEVICE_INIT(node_id, dev_name, drv_name, init_fn,		\
 			  pm_control_fn, data, cfg, prio, api,		\
 			  ETHERNET_L2, NET_L2_GET_CTX_TYPE(ETHERNET_L2),\
-			  mtu)
+			  mtu, use_pm)
 #endif /* CONFIG_NET_VLAN */
 
 /**
@@ -867,7 +867,8 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
 			    data, cfg, prio, api, mtu)			\
 	Z_ETH_NET_DEVICE_INIT(DT_INVALID_NODE, dev_name, drv_name,	\
 			      init_fn, pm_control_fn, data, cfg, prio,	\
-			      api, mtu)
+			      api, mtu,					\
+			      Z_DEVICE_USE_PM(Z_CONST_ ## pm_control_fn))
 
 /**
  * @def ETH_NET_DEVICE_DT_DEFINE
@@ -892,7 +893,8 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
 	Z_ETH_NET_DEVICE_INIT(node_id, Z_DEVICE_DT_DEV_NAME(node_id),	\
 			      DT_PROP_OR(node_id, label, ""),		\
 			      init_fn, pm_control_fn, data, cfg, prio,	\
-			      api, mtu)
+			      api, mtu,					\
+			      Z_DEVICE_USE_PM(Z_CONST_ ## pm_control_fn))
 
 /**
  * @def ETH_NET_DEVICE_DT_INST_DEFINE
@@ -905,8 +907,14 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
  *
  * @param ... other parameters as expected by ETH_NET_DEVICE_DT_DEFINE.
  */
-#define ETH_NET_DEVICE_DT_INST_DEFINE(inst, ...) \
-	ETH_NET_DEVICE_DT_DEFINE(DT_DRV_INST(inst), __VA_ARGS__)
+#define ETH_NET_DEVICE_DT_INST_DEFINE(inst, init_fn, pm_control_fn,	\
+				      data, cfg, prio, api, mtu) 	\
+	Z_ETH_NET_DEVICE_INIT(DT_DRV_INST(inst),			\
+			      Z_DEVICE_DT_DEV_NAME(DT_DRV_INST(inst)),	\
+			      DT_PROP_OR(DT_DRV_INST(inst), label, ""),	\
+			      init_fn, pm_control_fn, data, cfg, prio,	\
+			      api, mtu,					\
+			      Z_DEVICE_USE_PM(Z_CONST_ ## pm_control_fn))
 
 /**
  * @brief Inform ethernet L2 driver that ethernet carrier is detected.

--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -2249,10 +2249,10 @@ struct net_if_api {
 
 #define Z_NET_DEVICE_INIT(node_id, dev_name, drv_name, init_fn,		\
 			pm_control_fn, data, cfg, prio, api, l2,	\
-			l2_ctx_type, mtu)				\
+			l2_ctx_type, mtu, use_pm)			\
 	Z_DEVICE_DEFINE(node_id, dev_name, drv_name, init_fn,		\
 			pm_control_fn, data,				\
-			cfg, POST_KERNEL, prio, api);			\
+			cfg, POST_KERNEL, prio, api, use_pm);		\
 	NET_L2_DATA_INIT(dev_name, 0, l2_ctx_type);			\
 	NET_IF_INIT(dev_name, 0, l2, mtu, NET_IF_MAX_CONFIGS)
 
@@ -2282,7 +2282,8 @@ struct net_if_api {
 			l2_ctx_type, mtu)				\
 	Z_NET_DEVICE_INIT(DT_INVALID_NODE, dev_name, drv_name, init_fn,	\
 			pm_control_fn, data, cfg, prio, api, l2,	\
-			l2_ctx_type, mtu)
+			l2_ctx_type, mtu,				\
+			Z_DEVICE_USE_PM(Z_CONST_ ## pm_control_fn))
 
 /**
  * @def NET_DEVICE_DT_DEFINE
@@ -2309,7 +2310,8 @@ struct net_if_api {
 	Z_NET_DEVICE_INIT(node_id, Z_DEVICE_DT_DEV_NAME(node_id),	\
 			  DT_PROP_OR(node_id, label, ""), init_fn,	\
 			  pm_control_fn, data, cfg, prio, api, l2,	\
-			  l2_ctx_type, mtu)
+			  l2_ctx_type, mtu,				\
+			  Z_DEVICE_USE_PM(Z_CONST_ ## pm_control_fn))
 
 /**
  * @def NET_DEVICE_DT_INST_DEFINE
@@ -2321,16 +2323,22 @@ struct net_if_api {
  *
  * @param ... other parameters as expected by NET_DEVICE_DT_DEFINE.
  */
-#define NET_DEVICE_DT_INST_DEFINE(inst, ...) \
-	NET_DEVICE_DT_DEFINE(DT_DRV_INST(inst), __VA_ARGS__)
+#define NET_DEVICE_DT_INST_DEFINE(inst, init_fn, pm_control_fn, data,	\
+				  cfg, prio, api, l2, l2_ctx_type, mtu)	\
+	Z_NET_DEVICE_INIT(DT_DRV_INST(inst),				\
+			  Z_DEVICE_DT_DEV_NAME(DT_DRV_INST(inst)),	\
+			  DT_PROP_OR(DT_DRV_INST(inst), label, ""),	\
+			  init_fn, pm_control_fn, data, cfg, prio, api,	\
+			  l2, l2_ctx_type, mtu,				\
+			  Z_DEVICE_USE_PM(Z_CONST_ ## pm_control_fn))
 
 #define Z_NET_DEVICE_INIT_INSTANCE(node_id, dev_name, drv_name,		\
 				   instance, init_fn, pm_control_fn,	\
 				   data, cfg, prio, api, l2,		\
-				   l2_ctx_type, mtu)			\
+				   l2_ctx_type, mtu, use_pm)		\
 	Z_DEVICE_DEFINE(node_id, dev_name, drv_name, init_fn,		\
 			pm_control_fn, data, cfg, POST_KERNEL,		\
-			prio, api);					\
+			prio, api, use_pm);				\
 	NET_L2_DATA_INIT(dev_name, instance, l2_ctx_type);		\
 	NET_IF_INIT(dev_name, instance, l2, mtu, NET_IF_MAX_CONFIGS)
 
@@ -2365,7 +2373,8 @@ struct net_if_api {
 	Z_NET_DEVICE_INIT_INSTANCE(DT_INVALID_NODE, dev_name, drv_name,	\
 				   instance, init_fn, pm_control_fn,	\
 				   data, cfg, prio, api, l2,		\
-				   l2_ctx_type, mtu)
+				   l2_ctx_type, mtu,			\
+				   Z_DEVICE_USE_PM(Z_CONST_ ## pm_control_fn))
 
 /**
  * @def NET_DEVICE_DT_DEFINE_INSTANCE
@@ -2392,13 +2401,14 @@ struct net_if_api {
  * @param mtu Maximum transfer unit in bytes for this network interface.
  */
 #define NET_DEVICE_DT_DEFINE_INSTANCE(node_id, instance, init_fn,	\
-				    pm_control_fn, data, cfg, prio,	\
-				    api, l2, l2_ctx_type, mtu)		\
+				      pm_control_fn, data, cfg, prio,	\
+				      api, l2, l2_ctx_type, mtu)	\
 	Z_NET_DEVICE_INIT_INSTANCE(node_id,				\
 				   Z_DEVICE_DT_DEV_NAME(node_id),	\
 				   DT_LABEL(node_id), instance, init_fn,\
 				   pm_control_fn, data, cfg, prio, api,	\
-				   l2, l2_ctx_type, mtu)
+				   l2, l2_ctx_type, mtu,		\
+				   Z_DEVICE_USE_PM(Z_CONST_ ## pm_control_fn))
 
 /**
  * @def NET_DEVICE_DT_INST_DEFINE_INSTANCE
@@ -2411,14 +2421,24 @@ struct net_if_api {
  *
  * @param ... other parameters as expected by NET_DEVICE_DT_DEFINE_INSTANCE.
  */
-#define NET_DEVICE_DT_INST_DEFINE_INSTANCE(inst, ...) \
-	NET_DEVICE_DT_DEFINE_INSTANCE(DT_DRV_INST(inst), __VA_ARGS__)
+#define NET_DEVICE_DT_INST_DEFINE_INSTANCE(inst, instance, init_fn,	\
+					   pm_control_fn, data, cfg,	\
+					   prio, api, l2, l2_ctx_type,	\
+					   mtu)				\
+	Z_NET_DEVICE_INIT_INSTANCE(DT_DRV_INST(inst),			\
+				   Z_DEVICE_DT_DEV_NAME(DT_DRV_INST(inst)),\
+				   DT_LABEL(DT_DRV_INST(inst)),		\
+				   instance, init_fn, pm_control_fn,	\
+				   data, cfg, prio, api, l2,		\
+				   l2_ctx_type, mtu,			\
+				   Z_DEVICE_USE_PM(Z_CONST_ ## pm_control_fn))
 
 #define Z_NET_DEVICE_OFFLOAD_INIT(node_id, dev_name, drv_name, init_fn,	\
 				  pm_control_fn, data, cfg, prio,	\
-				  api, mtu)				\
+				  api, mtu, use_pm)			\
 	Z_DEVICE_DEFINE(node_id, dev_name, drv_name, init_fn,		\
-			pm_control_fn, data, cfg, POST_KERNEL, prio, api);\
+			pm_control_fn, data, cfg, POST_KERNEL, prio,	\
+			api, use_pm);	\
 	NET_IF_OFFLOAD_INIT(dev_name, 0, mtu)
 
 /**
@@ -2446,7 +2466,8 @@ struct net_if_api {
 				pm_control_fn, data, cfg, prio, api, mtu)\
 	Z_NET_DEVICE_OFFLOAD_INIT(DT_INVALID_NODE, dev_name, drv_name,	\
 				init_fn, pm_control_fn, data, cfg, prio,\
-				api, mtu)
+				api, mtu,				\
+				Z_DEVICE_USE_PM(Z_CONST_ ## pm_control_fn))
 
 /**
  * @def NET_DEVICE_DT_OFFLOAD_DEFINE
@@ -2473,7 +2494,8 @@ struct net_if_api {
 	Z_NET_DEVICE_OFFLOAD_INIT(node_id, Z_DEVICE_DT_DEV_NAME(node_id), \
 				  DT_PROP_OR(node_id, label, NULL),	\
 				  init_fn, pm_control_fn, data, cfg,	\
-				  prio, api, mtu)
+				  prio, api, mtu,			\
+				  Z_DEVICE_USE_PM(Z_CONST_ ## pm_control_fn))
 
 /**
  * @def NET_DEVICE_DT_INST_OFFLOAD_DEFINE
@@ -2486,8 +2508,14 @@ struct net_if_api {
  *
  * @param ... other parameters as expected by NET_DEVICE_DT_OFFLOAD_DEFINE.
  */
-#define NET_DEVICE_DT_INST_OFFLOAD_DEFINE(inst, ...) \
-	NET_DEVICE_DT_OFFLOAD_DEFINE(DT_DRV_INST(inst), __VA_ARGS__)
+#define NET_DEVICE_DT_INST_OFFLOAD_DEFINE(inst, init_fn, pm_control_fn,	\
+				   data, cfg, prio, api, mtu)		\
+	Z_NET_DEVICE_OFFLOAD_INIT(DT_DRV_INST(inst),			\
+				  Z_DEVICE_DT_DEV_NAME(DT_DRV_INST(inst)),	\
+				  DT_PROP_OR(DT_DRV_INST(inst), label, NULL),	\
+				  init_fn, pm_control_fn, data, cfg,	\
+				  prio, api, mtu,			\
+				  Z_DEVICE_USE_PM(Z_CONST_ ## pm_control_fn))
 
 #ifdef __cplusplus
 }

--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -2391,13 +2391,14 @@ struct net_if_api {
  * @param l2_ctx_type Type of L2 context data.
  * @param mtu Maximum transfer unit in bytes for this network interface.
  */
-#define NET_DEVICE_DT_DEFINE_INSTANCE(node_id, instance, init_fn,		\
+#define NET_DEVICE_DT_DEFINE_INSTANCE(node_id, instance, init_fn,	\
 				    pm_control_fn, data, cfg, prio,	\
 				    api, l2, l2_ctx_type, mtu)		\
-	Z_NET_DEVICE_INIT_INSTANCE(node_id, node_id, DT_LABEL(node_id),	\
-				   instance, init_fn, pm_control_fn,	\
-				   data, cfg, prio, api, l2,		\
-				   l2_ctx_type, mtu)
+	Z_NET_DEVICE_INIT_INSTANCE(node_id,				\
+				   Z_DEVICE_DT_DEV_NAME(node_id),	\
+				   DT_LABEL(node_id), instance, init_fn,\
+				   pm_control_fn, data, cfg, prio, api,	\
+				   l2, l2_ctx_type, mtu)
 
 /**
  * @def NET_DEVICE_DT_INST_DEFINE_INSTANCE

--- a/include/net/virtual.h
+++ b/include/net/virtual.h
@@ -275,11 +275,11 @@ net_virtual_get_iface_capabilities(struct net_if *iface)
 
 #define Z_NET_VIRTUAL_INTERFACE_INIT(node_id, dev_name, drv_name,	\
 				     init_fn, pm_control_fn, data, cfg, \
-				     prio, api, mtu)			\
+				     prio, api, mtu, use_pm)		\
 	Z_NET_DEVICE_INIT(node_id, dev_name, drv_name, init_fn,		\
 			  pm_control_fn, data, cfg, prio, api,		\
 			  VIRTUAL_L2, NET_L2_GET_CTX_TYPE(VIRTUAL_L2),	\
-			  mtu)
+			  mtu, use_pm)
 /** @endcond */
 
 /**
@@ -310,7 +310,8 @@ net_virtual_get_iface_capabilities(struct net_if *iface)
 				   data, cfg, prio, api, mtu)		\
 	Z_NET_VIRTUAL_INTERFACE_INIT(DT_INVALID_NODE, dev_name,		\
 				     drv_name, init_fn, pm_control_fn,	\
-				     data, cfg, prio, api, mtu)
+				     data, cfg, prio, api, mtu,		\
+				     Z_DEVICE_USE_PM(Z_CONST_ ## pm_control_fn))
 
 /**
  * @}


### PR DESCRIPTION
Update the Z_DEVICE_DEFINE macro to conditionally compile in the power management structures.  This uses macro concatenation to detect when the pm_control_fn parameter is NULL.  Due to macro expansion, many of the intermediate macros had to be converted to call Z_DEVICE_DEFINE directly.

This saves considerable RAM space (over 4500 bytes) in a Chrome EC implementation as only a couple drivers actually require the power management callback.

An alternate approach could be to create separate macros for drivers that need PM support, but this would be a substantial API change.