### PR TITLE
Bluetooth: Audio: Update BT_AUDIO_CAPABILITY_PREF

### DIFF
--- a/include/bluetooth/audio.h
+++ b/include/bluetooth/audio.h
@@ -666,14 +666,17 @@ enum bt_audio_pac_type {
 /** @def BT_AUDIO_CAPABILITY_PREF
  *  @brief Helper to declare elements of @ref bt_audio_capability_pref
  *
- *  @param _framing Framing
- *  @param _phy Target PHY
- *  @param _rtn Retransmission number
- *  @param _latency Maximum Transport Latency (msec)
+ *  @param _framing Framing Support
+ *  @param _phy Preferred Target PHY
+ *  @param _rtn Preferred Retransmission number
+ *  @param _latency Preferred Maximum Transport Latency (msec)
  *  @param _pd_min Minimum Presentation Delay (usec)
  *  @param _pd_max Maximum Presentation Delay (usec)
+ *  @param _pref_pd_min Preferred Minimum Presentation Delay (usec)
+ *  @param _pref_pd_max Preferred Maximum Presentation Delay (usec)
  */
-#define BT_AUDIO_CAPABILITY_PREF(_framing, _phy, _rtn, _latency, _pd_min, _pd_max) \
+#define BT_AUDIO_CAPABILITY_PREF(_framing, _phy, _rtn, _latency, _pd_min, \
+				 _pd_max, _pref_pd_min, _pref_pd_max) \
 	{ \
 		.framing = _framing, \
 		.phy = _phy, \
@@ -681,6 +684,8 @@ enum bt_audio_pac_type {
 		.latency = _latency, \
 		.pd_min = _pd_min, \
 		.pd_max = _pd_max, \
+		.pref_pd_min = _pref_pd_min, \
+		.pref_pd_max = _pref_pd_max, \
 	}
 
 /** @brief Audio Capability Preference structure. */

--- a/samples/bluetooth/unicast_audio_client/src/main.c
+++ b/samples/bluetooth/unicast_audio_client/src/main.c
@@ -248,7 +248,8 @@ static struct bt_audio_capability caps[] = {
 		.type = BT_AUDIO_SOURCE,
 		.pref = BT_AUDIO_CAPABILITY_PREF(
 				BT_AUDIO_CAPABILITY_UNFRAMED_SUPPORTED,
-				BT_GAP_LE_PHY_2M, 0x02, 10, 40000, 40000),
+				BT_GAP_LE_PHY_2M, 0x02, 10, 40000, 40000,
+				40000, 40000),
 		.codec = &preset_16_2_1.codec,
 		.ops = &lc3_ops,
 	}

--- a/samples/bluetooth/unicast_audio_server/src/main.c
+++ b/samples/bluetooth/unicast_audio_server/src/main.c
@@ -251,7 +251,8 @@ static struct bt_audio_capability caps[] = {
 		.type = BT_AUDIO_SINK,
 		.pref = BT_AUDIO_CAPABILITY_PREF(
 				BT_AUDIO_CAPABILITY_UNFRAMED_SUPPORTED,
-				BT_GAP_LE_PHY_2M, 0x02, 10, 40000, 40000),
+				BT_GAP_LE_PHY_2M, 0x02, 10, 40000, 40000,
+				40000, 40000),
 		.codec = &preset_16_2_1.codec,
 		.ops = &lc3_ops,
 	}

--- a/subsys/bluetooth/shell/bap.c
+++ b/subsys/bluetooth/shell/bap.c
@@ -1125,7 +1125,8 @@ static struct bt_audio_capability caps[MAX_PAC] = {
 		.type = BT_AUDIO_SOURCE,
 		.pref = BT_AUDIO_CAPABILITY_PREF(
 				BT_AUDIO_CAPABILITY_UNFRAMED_SUPPORTED,
-				BT_GAP_LE_PHY_2M, 0u, 60u, 20000u, 40000u),
+				BT_GAP_LE_PHY_2M, 0u, 60u, 20000u, 40000u,
+				20000u, 40000u),
 		.codec = &lc3_codec,
 		.ops = &lc3_ops,
 	},
@@ -1133,7 +1134,8 @@ static struct bt_audio_capability caps[MAX_PAC] = {
 		.type = BT_AUDIO_SINK,
 		.pref = BT_AUDIO_CAPABILITY_PREF(
 				BT_AUDIO_CAPABILITY_UNFRAMED_SUPPORTED,
-				BT_GAP_LE_PHY_2M, 0u, 60u, 20000u, 40000u),
+				BT_GAP_LE_PHY_2M, 0u, 60u, 20000u, 40000u,
+				20000u, 40000u),
 		.codec = &lc3_codec,
 		.ops = &lc3_ops,
 	},

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/broadcast_sink_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/broadcast_sink_test.c
@@ -104,7 +104,8 @@ static int init(void)
 		.type = BT_AUDIO_SINK,
 		.pref = BT_AUDIO_CAPABILITY_PREF(
 				BT_AUDIO_CAPABILITY_UNFRAMED_SUPPORTED,
-				BT_GAP_LE_PHY_2M, 0u, 60u, 20000u, 40000u),
+				BT_GAP_LE_PHY_2M, 0u, 60u, 20000u, 40000u,
+				20000u, 40000u),
 		.codec = &lc3_codec,
 		.ops = &lc3_ops,
 	};


### PR DESCRIPTION
Updates the macro to also include the preferred min/max
presentation delay that was recently added to the struct.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>