### PR TITLE
ITE: soc: add cpu idle task

### DIFF
--- a/drivers/interrupt_controller/intc_ite_it8xxx2.c
+++ b/drivers/interrupt_controller/intc_ite_it8xxx2.c
@@ -198,6 +198,8 @@ uint8_t get_irq(void *arg)
 	intc_irq -= IVECT_OFFSET_WITH_IRQ;
 	/* clear interrupt status */
 	ite_intc_isr_clear(intc_irq);
+	/* Clear flag on each interrupt. */
+	wait_interrupt_fired = 0;
 	/* return interrupt number */
 	return intc_irq;
 }

--- a/drivers/interrupt_controller/intc_ite_it8xxx2.h
+++ b/drivers/interrupt_controller/intc_ite_it8xxx2.h
@@ -9,4 +9,7 @@
 #include <dt-bindings/interrupt-controller/ite-intc.h>
 #include <soc.h>
 
+/* use data type int here not bool to get better instruction number. */
+volatile int wait_interrupt_fired;
+
 #endif /* ZEPHYR_DRIVERS_INTERRUPT_CONTROLLER_INTC_ITE_IT8XXX2_H_ */

--- a/soc/riscv/riscv-ite/it8xxx2/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-ite/it8xxx2/Kconfig.defconfig.series
@@ -23,6 +23,9 @@ config UART_NS16550_WA_ISR_REENABLE_INTERRUPT
 	default y
 	depends on UART_NS16550
 
+config RISCV_HAS_CPU_IDLE
+	default y
+
 if ITE_IT8XXX2_INTC
 config NUM_IRQS
 	default 185


### PR DESCRIPTION
Implement the CPU idle task. The system should enter this task when
there is no any task to ensure power saving.

Tested on it8xxx2_evb board. It will reduce 12.5mA when system enters
the CPU idle task.

Signed-off-by: Tim Lin <tim2.lin@ite.corp-partner.google.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zephyrproject-rtos/zephyr/39172)
<!-- Reviewable:end -->
