### PR TITLE
drivers/sensor: lsm6dso: Prevent device entering I3C

### DIFF
--- a/drivers/sensor/lsm6dso/lsm6dso.c
+++ b/drivers/sensor/lsm6dso/lsm6dso.c
@@ -753,6 +753,12 @@ static int lsm6dso_init_chip(const struct device *dev)
 		return -EIO;
 	}
 
+	/* I3C disable stay preserved after s/w reset */
+	if (lsm6dso_i3c_disable_set(ctx, LSM6DSO_I3C_DISABLE) < 0) {
+		LOG_DBG("Failed to disable I3C");
+		return -EIO;
+	}
+
 	/* reset device */
 	if (lsm6dso_reset_set(ctx, 1) < 0) {
 		return -EIO;


### PR DESCRIPTION
On LSM6DSO sensor the INT1 pin is used for both generating the drdy
interrupt and for switching to I3C hotjoin mode just after reset if
it is at logical '1' level. It might happen that after a board
reset the logical level '1' is preserved (maybe a level shifter)
forcing the LSM6DSO to enter erroneously in I3C mode, breaking any
attempt to communicate with it. (Fix #38902)
