### PR TITLE
arm64: mmu: don't use a Level block is PA is not aligned

### DIFF
--- a/arch/arm64/core/mmu.c
+++ b/arch/arm64/core/mmu.c
@@ -104,6 +104,19 @@ static inline uint64_t *pte_desc_table(uint64_t desc)
 	return (uint64_t *)address;
 }
 
+static inline bool is_desc_block_aligned(uint64_t desc, unsigned int level_size)
+{
+	uint64_t mask = GENMASK(47, PAGE_SIZE_SHIFT);
+	bool aligned = !((desc & mask) & (level_size - 1));
+
+	if (!aligned) {
+		MMU_DEBUG("misaligned desc 0x%016llx for block size 0x%x\n",
+			  desc, level_size);
+	}
+
+	return aligned;
+}
+
 static inline bool is_desc_superset(uint64_t desc1, uint64_t desc2,
 				    unsigned int level)
 {
@@ -259,7 +272,8 @@ static int set_mapping(struct arm_mmu_ptables *ptables,
 			goto move_on;
 		}
 
-		if ((size < level_size) || (virt & (level_size - 1))) {
+		if ((size < level_size) || (virt & (level_size - 1)) ||
+		    !is_desc_block_aligned(desc, level_size)) {
 			/* Range doesn't fit, create subtable */
 			table = expand_to_table(pte, level);
 			if (!table) {


### PR DESCRIPTION
When mapping the following:
device_map(&base0, DEVA_BASE, DEVA_SIZE, K_MEM_CACHE_NONE);
device_map(&base1, DEVB_BASE , DEVB_SIZE, K_MEM_CACHE_NONE);

with:
- DEVA_SIZE not multiple of a 4KB granule L2 block size (0x200000)
- DEVB_SIZE more than 2 x 4KB granule L2 block size

The mmu code will fill the first device_map() in a L3 table, then
on the second mapping the mmu code will complete the previous L3
table.
At the end of this table, the actual code will select an L2 block
instead of a table because the *virtual address* is multiple with
the L2 block size.

But if the physical address is not, the virtual block offset will
be ORed to the physical address, and not added.

Leading to a weird scenario where virtual memory is duplicated
resulting of the addresses ORing and not addition.

Example:
device_map(&base0, DEVA_BASE, 0x20000, K_MEM_CACHE_NONE);
device_map(&base1, 0x44000000 , 0x400000, K_MEM_CACHE_NONE);

First will result in VA 0x5ffe0000 and second in VA 0x5fbe0000.

The MMU code will use a table to map 0x5ffe0000 to 0x5fbfffff.

For 0x5fc00000 to 0x5fdfffff, since the VA is multiple of an L2
block size, the L3 table is not used.

But the L2 block description entry address is 0x44060000, meaning
that for each access in this L2 block, the following will be done:

0x44060000 | (VA & 1FFFFF)

This is working for the 0x5fc40000 to 0x5fc5ffff access, but for the
0x5fbc60000 (0x5fbe0000 + 0x80000) access the PA gets calculated as :

0x44060000 | (0x5fc60000 & 1FFFFF) = 0x44060000 | 0x60000 = 0x44060000

Instead of the expected 0x44080000.

The solution is to check if the PA descriptor is aligned with the
level block size, if not move to the next level.

Signed-off-by: Neil Armstrong <narmstrong@baylibre.com>