### PR TITLE
lib/os: Add sys_heap_block_size()

### DIFF
--- a/include/sys/sys_heap.h
+++ b/include/sys/sys_heap.h
@@ -149,6 +149,22 @@ void *sys_heap_aligned_realloc(struct sys_heap *heap, void *ptr,
 #define sys_heap_realloc(heap, ptr, bytes) \
 	sys_heap_aligned_realloc(heap, ptr, 0, bytes)
 
+/** @brief Return allocated memory size
+ *
+ * Returns the size, in bytes, of a block returned from a successful
+ * sys_heap_alloc() or sys_heap_alloc_aligned() call.  The value
+ * returned is the size of the heap-managed memory, which may be
+ * larger than the number of bytes requested due to allocation
+ * granularity.  The heap code is guaranteed to make no access to this
+ * region of memory until a subsequent sys_heap_free() on the same
+ * pointer.
+ *
+ * @param heap Heap containing the block
+ * @param mem Pointer to memory allocated from this heap
+ * @return Size in bytes of the memory region
+ */
+size_t sys_heap_usable_size(struct sys_heap *heap, void *mem);
+
 /** @brief Validate heap integrity
  *
  * Validates the internal integrity of a sys_heap.  Intended for unit

--- a/lib/os/heap.c
+++ b/lib/os/heap.c
@@ -167,6 +167,17 @@ void sys_heap_free(struct sys_heap *heap, void *mem)
 	free_chunk(h, c);
 }
 
+size_t sys_heap_usable_size(struct sys_heap *heap, void *mem)
+{
+	struct z_heap *h = heap->heap;
+	chunkid_t c = mem_to_chunkid(h, mem);
+	size_t addr = (size_t)mem;
+	size_t chunk_base = (size_t)&chunk_buf(h)[c];
+	size_t chunk_sz = chunk_size(h, c) * CHUNK_UNIT;
+
+	return chunk_sz - (addr - chunk_base);
+}
+
 static chunkid_t alloc_chunk(struct z_heap *h, chunksz_t sz)
 {
 	int bi = bucket_idx(h, sz);

--- a/tests/lib/heap/src/main.c
+++ b/tests/lib/heap/src/main.c
@@ -106,6 +106,23 @@ void *testalloc(void *arg, size_t bytes)
 {
 	void *ret = sys_heap_alloc(arg, bytes);
 
+	if (ret != NULL) {
+		/* White box: the heap internals will allocate memory
+		 * in 8 chunk units, no more than needed, but with a
+		 * header prepended that is 4 or 8 bytes.  Use this to
+		 * validate the block_size predicate.
+		 */
+		size_t blksz = sys_heap_usable_size(arg, ret);
+		size_t addr = (size_t) ret;
+		size_t chunk = ROUND_DOWN(addr - 1, 8);
+		size_t hdr = addr - chunk;
+		size_t expect = ROUND_UP(bytes + hdr, 8) - hdr;
+
+		zassert_equal(blksz, expect,
+			      "wrong size block returned bytes = %ld ret = %ld",
+			      bytes, blksz);
+	}
+
 	fill_block(ret, bytes);
 	sys_heap_validate(arg);
 	return ret;


### PR DESCRIPTION
Add a simple internal block size predicate to expose the internal memory region reserved for an allocation.  The immediate use case is cache-incoherent systems wanting to do an invalidate of freed memory, but it might be useful for apps doing e.g. string processing to better optimize size changes, etc... 