### PR TITLE
samples: echo_server: Enable USB by the application

### DIFF
--- a/samples/net/sockets/echo_server/CMakeLists.txt
+++ b/samples/net/sockets/echo_server/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources_ifdef(CONFIG_NET_UDP app PRIVATE src/udp.c)
 target_sources_ifdef(CONFIG_NET_TCP app PRIVATE src/tcp.c)
 target_sources_ifdef(CONFIG_NET_VLAN app PRIVATE src/vlan.c)
 target_sources_ifdef(CONFIG_NET_L2_IPIP app PRIVATE src/tunnel.c)
+target_sources_ifdef(CONFIG_USB_DEVICE_STACK app PRIVATE src/usb.c)
 
 include(${ZEPHYR_BASE}/samples/net/common/common.cmake)
 

--- a/samples/net/sockets/echo_server/src/common.h
+++ b/samples/net/sockets/echo_server/src/common.h
@@ -97,3 +97,12 @@ static inline bool is_tunnel(struct net_if *iface)
 	return false;
 }
 #endif /* CONFIG_NET_L2_IPIP */
+
+#if defined(CONFIG_USB_DEVICE_STACK)
+int init_usb(void);
+#else
+static inline int init_usb(void)
+{
+	return 0;
+}
+#endif /* CONFIG_USB_DEVICE_STACK */

--- a/samples/net/sockets/echo_server/src/echo-server.c
+++ b/samples/net/sockets/echo_server/src/echo-server.c
@@ -198,6 +198,8 @@ static void init_app(void)
 
 	init_vlan();
 	init_tunnel();
+
+	init_usb();
 }
 
 static int cmd_sample_quit(const struct shell *shell,

--- a/samples/net/sockets/echo_server/src/usb.c
+++ b/samples/net/sockets/echo_server/src/usb.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2021 TiaC Systems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <logging/log.h>
+LOG_MODULE_DECLARE(net_echo_server_sample, LOG_LEVEL_DBG);
+
+#include <usb/usb_device.h>
+#include <net/net_config.h>
+
+int init_usb(void)
+{
+	int ret;
+
+	ret = usb_enable(NULL);
+	if (ret != 0) {
+		LOG_ERR("Cannot enable USB (%d)", ret);
+		return ret;
+	}
+
+	(void)net_config_init_app(NULL, "Initializing network");
+
+	return 0;
+}


### PR DESCRIPTION
This commit allows let build echo_server sample with overlay-netusb.conf.
USB subsystem must be enabled by the application.

Fixes #39195 