### PR TITLE
Bluetooth: Controller: Select CSA#2 for Extended Advertising Support

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -445,6 +445,7 @@ config BT_CTLR_CHAN_SEL_2
 config BT_CTLR_ADV_EXT
 	bool "LE Advertising Extensions" if !BT_LL_SW_SPLIT
 	depends on BT_CTLR_ADV_EXT_SUPPORT
+	select BT_CTLR_CHAN_SEL_2 if BT_LL_SW_SPLIT && BT_BROADCASTER
 	select BT_CTLR_SCAN_REQ_NOTIFY if BT_LL_SW_SPLIT && BT_BROADCASTER
 	# Enable by default for BT_LL_SW_SPLIT when "LE Advertising Set Terminated event" is implemented
 	default y if BT_EXT_ADV && !BT_LL_SW_SPLIT


### PR DESCRIPTION
Select CONFIG_BT_CTLR_CHAN_SEL_2 when CONFIG_BT_CTLR_ADV_EXT
is enabled.

Relates to commit 651137ee1173 ("Bluetooth: Controller: Fix
Extended Advertising channel use").

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>