### PR TITLE
west.yml: Update mcumgr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -161,7 +161,7 @@ manifest:
       revision: 70bfbd21cdf5f6d1402bc8d0031e197222ed2ec0
       path: bootloader/mcuboot
     - name: mcumgr
-      revision: df9be737619956efbdeb65d4d6935ee0432a580f
+      revision: a7301143b3b46a8f7d410b12580a875cc1b6f8c8
       path: modules/lib/mcumgr
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Commits affecting Zephyr that are included with the new revision:

-  47fdde0 Fix missing else in configuration;
-  30cf9fe zephyr: Fix BUILD_ASSERT failing build with correct number  of images.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>