### PR TITLE
tests/msgq_usage: Correct memory usage for cache-incoherent platforms

### DIFF
--- a/tests/kernel/msgq/msgq_usage/src/main.c
+++ b/tests/kernel/msgq/msgq_usage/src/main.c
@@ -50,7 +50,7 @@ enum message_info {
 
 static void service_manager_entry(void *p1, void *p2, void *p3)
 {
-	unsigned long data[2];
+	static unsigned long data[2];
 
 	while (1) {
 		k_msgq_get(&manager_q, data, K_FOREVER);
@@ -96,7 +96,7 @@ static void start_service_manager(void)
 
 static void service1_entry(void *p1, void *p2, void *p3)
 {
-	unsigned long service_data[2];
+	static unsigned long service_data[2];
 	struct k_msgq *client;
 	int ret;
 
@@ -127,7 +127,7 @@ static void service1_entry(void *p1, void *p2, void *p3)
 
 static void service2_entry(void *p1, void *p2, void *p3)
 {
-	unsigned long service_data[2];
+	static unsigned long service_data[2];
 	struct k_msgq *client;
 	int ret;
 
@@ -174,8 +174,8 @@ static void register_service(void)
 
 static void client_entry(void *p1, void *p2, void *p3)
 {
-	unsigned long client_data[2];
-	unsigned long service_data[2];
+	static unsigned long client_data[2];
+	static unsigned long service_data[2];
 	struct k_msgq *service1q;
 	struct k_msgq *service2q;
 	bool query_service = false;


### PR DESCRIPTION
When CONFIG_KERNEL_COHERENCE=y (e.g on the various intel_adsp
platforms under SMP) it's not legal to share stack memory between
CPUs, because the stack is cached, and the L1 cache is incoherent.
The kernel will automatically detect the mistake when the memory
contains a kernel object (spinlock, IPC object, etc...).  But here the
test was just passing async buffers into the msgq layer, and nothing
watches that.

The fix is simple: make them static.

Fixes #35857

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>