### PR TITLE
ARC: MWDT: enable BUILD_ASSERT macro

### DIFF
--- a/include/arch/arc/arch.h
+++ b/include/arch/arc/arch.h
@@ -248,24 +248,46 @@ BUILD_ASSERT(CONFIG_PRIVILEGED_STACK_SIZE % Z_ARC_MPU_ALIGN == 0,
 /*
  * BUILD_ASSERT in case of MWDT is a bit more picky in performing compile-time check.
  * For example it can't evaluate variable address at build time like GCC toolchain can do.
- * That's why we don't provide _ARCH_MEM_PARTITION_ALIGN_CHECK for MWDT toolchain.
+ * That's why we provide custom _ARCH_MEM_PARTITION_ALIGN_CHECK implementation for MWDT toolchain
+ * with additional check for arguments availability in compile time.
  */
-#ifndef __CCAC__
+#ifdef __CCAC__
+#define IS_BUILTIN_MWDT(val) __builtin_constant_p((uintptr_t)(val))
 #if CONFIG_ARC_MPU_VER == 2
-#define _ARCH_MEM_PARTITION_ALIGN_CHECK(start, size) \
-	BUILD_ASSERT(!(((size) & ((size) - 1))) && (size) >= Z_ARC_MPU_ALIGN \
-		 && !((uint32_t)(start) & ((size) - 1)), \
-		"the size of the partition must be power of 2" \
-		" and greater than or equal to the mpu adddress alignment." \
-		"start address of the partition must align with size.")
+#define _ARCH_MEM_PARTITION_ALIGN_CHECK(start, size)						\
+	BUILD_ASSERT(IS_BUILTIN_MWDT(size) ? !((size) & ((size) - 1)) : 1,			\
+		"partition size must be power of 2");						\
+	BUILD_ASSERT(IS_BUILTIN_MWDT(size) ? (size) >= Z_ARC_MPU_ALIGN : 1,			\
+		"partition size must be >= mpu address alignment.");				\
+	BUILD_ASSERT(IS_BUILTIN_MWDT(size) ? IS_BUILTIN_MWDT(start) ?				\
+		!((uintptr_t)(start) & ((size) - 1)) : 1 : 1,					\
+		"partition start address must align with size.")
 #elif CONFIG_ARC_MPU_VER == 4
-#define _ARCH_MEM_PARTITION_ALIGN_CHECK(start, size) \
-	BUILD_ASSERT((size) % Z_ARC_MPU_ALIGN == 0 && \
-		     (size) >= Z_ARC_MPU_ALIGN && \
-		     (uint32_t)(start) % Z_ARC_MPU_ALIGN == 0, \
-		     "the size of the partition must align with 32" \
-		     " and greater than or equal to 32." \
-		     "start address of the partition must align with 32.")
+#define _ARCH_MEM_PARTITION_ALIGN_CHECK(start, size)						\
+	BUILD_ASSERT(IS_BUILTIN_MWDT(size) ? (size) % Z_ARC_MPU_ALIGN == 0 : 1,			\
+		"partition size must align with " STRINGIFY(Z_ARC_MPU_ALIGN));			\
+	BUILD_ASSERT(IS_BUILTIN_MWDT(size) ? (size) >= Z_ARC_MPU_ALIGN : 1,			\
+		"partition size must be >= " STRINGIFY(Z_ARC_MPU_ALIGN));			\
+	BUILD_ASSERT(IS_BUILTIN_MWDT(start) ? (uintptr_t)(start) % Z_ARC_MPU_ALIGN == 0 : 1,	\
+		"partition start address must align with " STRINGIFY(Z_ARC_MPU_ALIGN))
+#endif
+#else /* __CCAC__ */
+#if CONFIG_ARC_MPU_VER == 2
+#define _ARCH_MEM_PARTITION_ALIGN_CHECK(start, size)						\
+	BUILD_ASSERT(!((size) & ((size) - 1)),							\
+		"partition size must be power of 2");						\
+	BUILD_ASSERT((size) >= Z_ARC_MPU_ALIGN,							\
+		"partition size must be >= mpu address alignment.");				\
+	BUILD_ASSERT(!((uintptr_t)(start) & ((size) - 1)),					\
+		"partition start address must align with size.")
+#elif CONFIG_ARC_MPU_VER == 4
+#define _ARCH_MEM_PARTITION_ALIGN_CHECK(start, size)						\
+	BUILD_ASSERT((size) % Z_ARC_MPU_ALIGN == 0,						\
+		"partition size must align with " STRINGIFY(Z_ARC_MPU_ALIGN));			\
+	BUILD_ASSERT((size) >= Z_ARC_MPU_ALIGN,							\
+		"partition size must be >= " STRINGIFY(Z_ARC_MPU_ALIGN));			\
+	BUILD_ASSERT((uintptr_t)(start) % Z_ARC_MPU_ALIGN == 0,					\
+		"partition start address must align with " STRINGIFY(Z_ARC_MPU_ALIGN))
 #endif
 #endif /* __CCAC__ */
 #endif /* CONFIG_ARC_MPU*/

--- a/include/arch/arc/arch.h
+++ b/include/arch/arc/arch.h
@@ -245,6 +245,12 @@ BUILD_ASSERT(CONFIG_PRIVILEGED_STACK_SIZE % Z_ARC_MPU_ALIGN == 0,
 #define K_MEM_PARTITION_IS_EXECUTABLE(attr) \
 	((attr) & (AUX_MPU_ATTR_KE | AUX_MPU_ATTR_UE))
 
+/*
+ * BUILD_ASSERT in case of MWDT is a bit more picky in performing compile-time check.
+ * For example it can't evaluate variable address at build time like GCC toolchain can do.
+ * That's why we don't provide _ARCH_MEM_PARTITION_ALIGN_CHECK for MWDT toolchain.
+ */
+#ifndef __CCAC__
 #if CONFIG_ARC_MPU_VER == 2
 #define _ARCH_MEM_PARTITION_ALIGN_CHECK(start, size) \
 	BUILD_ASSERT(!(((size) & ((size) - 1))) && (size) >= Z_ARC_MPU_ALIGN \
@@ -261,6 +267,7 @@ BUILD_ASSERT(CONFIG_PRIVILEGED_STACK_SIZE % Z_ARC_MPU_ALIGN == 0,
 		     " and greater than or equal to 32." \
 		     "start address of the partition must align with 32.")
 #endif
+#endif /* __CCAC__ */
 #endif /* CONFIG_ARC_MPU*/
 
 /* Typedef for the k_mem_partition attribute*/

--- a/include/toolchain/mwdt.h
+++ b/include/toolchain/mwdt.h
@@ -84,13 +84,12 @@
 
 #include <toolchain/gcc.h>
 
-/* Metaware toolchain has _Static_assert. However it not able to calculate
- * conditional expression in build time for some realy complex cases. ARC GNU
- * toolchain works fine in this cases, so it looks like MWDT bug. So, disable
- * BUILD_ASSERT macro until we fix that issue in MWDT toolchain.
- */
 #undef BUILD_ASSERT
-#define BUILD_ASSERT(EXPR, MSG...)
+#ifdef __cplusplus
+#define BUILD_ASSERT(EXPR, MSG...) static_assert(EXPR, "" MSG)
+#else
+#define BUILD_ASSERT(EXPR, MSG...) _Static_assert(EXPR, "" MSG)
+#endif
 
 #define __builtin_arc_nop()	_nop()
 


### PR DESCRIPTION
BUILD_ASSERT macro was disabled for MWDT toolchain from the moment of adding MWDT support to Zephyr. Built-in `_Static_assert` is now working fine for the most of the cases with MWDT toolchain so we can use it in BUILD_ASSERT.

The only exception is `_ARCH_MEM_PARTITION_ALIGN_CHECK` macro as it often used with variable addresses as parameters which need to be checked at compile time. `_Static_assert` (which is used in `BUILD_ASSERT`) in case of MWDT is a bit more picky in performing compile-time check in comparison to GCC toolchain (it's generic LLVM feature / issue). As a workaround we provide custom `_ARCH_MEM_PARTITION_ALIGN_CHECK` implementation for MWDT toolchain with additional check for arguments availability in compile time.