### PR TITLE
subsys: hawkbit: remove body check workaround

### DIFF
--- a/subsys/mgmt/hawkbit/hawkbit.c
+++ b/subsys/mgmt/hawkbit/hawkbit.c
@@ -695,13 +695,6 @@ static void response_cb(struct http_response *rsp,
 			 */
 			body_len -= (rsp->body_start - rsp->recv_buf);
 			hb_context.dl.http_content_size = rsp->content_length;
-		} else {
-			/*
-			 * more general case where body data is set, but no need
-			 * to take the HTTP header into account
-			 */
-			body_data = rsp->body_start;
-			body_len = rsp->data_len;
 		}
 
 		if ((rsp->body_found == 1) && (body_data == NULL)) {
@@ -769,13 +762,6 @@ static void response_cb(struct http_response *rsp,
 			 */
 			body_len -= (rsp->body_start - rsp->recv_buf);
 			hb_context.dl.http_content_size = rsp->content_length;
-		} else {
-			/*
-			 * more general case where body data is set, but no need
-			 * to take the HTTP header into account
-			 */
-			body_data = rsp->body_start;
-			body_len = rsp->data_len;
 		}
 
 		if ((rsp->body_found == 1) && (body_data == NULL)) {
@@ -832,13 +818,6 @@ static void response_cb(struct http_response *rsp,
 			 */
 			body_len -= (rsp->body_start - rsp->recv_buf);
 			hb_context.dl.http_content_size = rsp->content_length;
-		} else {
-			/*
-			 * more general case where body data is set, but no need
-			 * to take the HTTP header into account
-			 */
-			body_data = rsp->body_start;
-			body_len = rsp->data_len;
 		}
 
 		if ((rsp->body_found == 1) && (body_data == NULL)) {


### PR DESCRIPTION
The snippet code removed in this PR was initally
added to overcome an issue related to http_client
final packet response.

That issue is now fixed by #38553.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>