### PR TITLE
soc: it8xxx2: enable CONFIG_RISCV_GP

### DIFF
--- a/soc/riscv/riscv-ite/common/vector.S
+++ b/soc/riscv/riscv-ite/common/vector.S
@@ -16,6 +16,14 @@ GTEXT(__initialize)
 GTEXT(__irq_wrapper)
 
 SECTION_FUNC(vectors, __start)
+#ifdef CONFIG_RISCV_GP
+	.option push
+	.option norelax
+	/* Configure the GP register */
+	la gp, __global_pointer$
+	.option pop
+#endif
+
 	.option norvc;
 
 	/*

--- a/soc/riscv/riscv-ite/it8xxx2/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-ite/it8xxx2/Kconfig.defconfig.series
@@ -13,6 +13,9 @@ config ITE_IT8XXX2_INTC
 	select FLASH_HAS_DRIVER_ENABLED
 	select HAS_FLASH_LOAD_OFFSET
 
+config RISCV_GP
+	default y
+
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 32768
 


### PR DESCRIPTION
This will bring better performance on accessing global variables
that are in 4K span by the GP register.

Signed-off-by: Dino Li <Dino.Li@ite.com.tw>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zephyrproject-rtos/zephyr/39222)
<!-- Reviewable:end -->
