### PR TITLE
pm: Fix device resume order

### DIFF
--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -66,9 +66,9 @@ int pm_low_power_devices(void)
 
 void pm_resume_devices(void)
 {
-	size_t i;
+	int32_t i;
 
-	for (i = 0; i < num_susp; i++) {
+	for (i = (num_susp - 1); i >= 0; i--) {
 		pm_device_state_set(__pm_device_slots_start[i],
 				    PM_DEVICE_STATE_ACTIVE);
 	}


### PR DESCRIPTION
Devices need to be resumed in the reverse order they are suspended.
e.g: devA +---> devB ---> devD
                 |
                +---> devC

They are initialized in the following order, devA -> devB -> devC ->
devD, and suspended starting from the end of the list, devD -> devC ->
devB -> devA. When they are suspended they are temporary put in a list
that is used later to resume them.

This list has to be iterated from the end to the beginning, otherwise a
device may be resumed before its parent.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>