### PR TITLE
Bluetooth: Controller: Fix cpu sleep for simulation targets

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/cpu.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/cpu.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 Nordic Semiconductor ASA
+ * Copyright (c) 2016-2021 Nordic Semiconductor ASA
  * Copyright (c) 2016 Vinayak Kariappa Chettimada
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -9,7 +9,8 @@ static inline void cpu_sleep(void)
 {
 #if defined(CONFIG_CPU_CORTEX_M0) || \
 	defined(CONFIG_CPU_CORTEX_M4) || \
-	defined(CONFIG_CPU_CORTEX_M33)
+	defined(CONFIG_CPU_CORTEX_M33) || \
+	defined(CONFIG_SOC_SERIES_BSIM_NRFXX)
 	__WFE();
 	__SEV();
 	__WFE();

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2020 Nordic Semiconductor ASA
+ * Copyright (c) 2021 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr.h>
+#include <soc.h>
 #include <sys/byteorder.h>
 #include <bluetooth/bluetooth.h>
 


### PR DESCRIPTION
Use __WFE and __SEV for CPU sleep in simulation too to
avoid stalling and to let ISRs execute during CPU sleep.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>