### PR TITLE
Bluetooth: Controller: Cleanup scan event LLL done handling

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -455,10 +455,8 @@ static void isr_done(void *param)
 	lll_isr_status_reset();
 
 	if (!trx_cnt) {
-		e = ull_event_done_extra_get();
+		e = ull_done_extra_type_set(EVENT_DONE_EXTRA_TYPE_SCAN_AUX);
 		LL_ASSERT(e);
-
-		e->type = EVENT_DONE_EXTRA_TYPE_SCAN_AUX;
 	}
 
 	lll_isr_cleanup(param);
@@ -1421,10 +1419,8 @@ static void isr_early_abort(void *param)
 {
 	struct event_done_extra *e;
 
-	e = ull_event_done_extra_get();
+	e = ull_done_extra_type_set(EVENT_DONE_EXTRA_TYPE_SCAN_AUX);
 	LL_ASSERT(e);
-
-	e->type = EVENT_DONE_EXTRA_TYPE_SCAN_AUX;
 
 	lll_isr_early_abort(param);
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -489,19 +489,15 @@ void ull_scan_done(struct node_rx_event_done *done)
 		return;
 	}
 
-	rx_hdr = (void *)scan->node_rx_scan_term;
-	if (!rx_hdr) {
-		/* Prevent generation if another scan instance already did so.
-		 */
-		return;
-	}
+	/* Prevent duplicate terminate event generation */
+	lll->duration_reload = 0U;
 
 	handle = ull_scan_handle_get(scan);
 	LL_ASSERT(handle < BT_CTLR_SCAN_SET);
 
 #if defined(CONFIG_BT_CTLR_PHY_CODED)
-	/* Reset the singular node rx buffer, so that it does not get used if
-	 * ull_scan_done get called by the other scan instance.
+	/* Prevent duplicate terminate event if ull_scan_done get called by
+	 * the other scan instance.
 	 */
 	struct ll_scan_set *scan_other;
 
@@ -510,9 +506,10 @@ void ull_scan_done(struct node_rx_event_done *done)
 	} else {
 		scan_other = ull_scan_set_get(SCAN_HANDLE_1M);
 	}
-	scan_other->node_rx_scan_term = NULL;
+	scan_other->lll.duration_reload = 0U;
 #endif /* CONFIG_BT_CTLR_PHY_CODED */
 
+	rx_hdr = (void *)scan->node_rx_scan_term;
 	rx_hdr->type = NODE_RX_TYPE_EXT_SCAN_TERMINATE;
 	rx_hdr->handle = handle;
 


### PR DESCRIPTION
Cleanup the scan event LLL done handling for abort on late
schedule, preemption pipeline abort, preemption current
event yield, duration expire, and connection establishment.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>