### PR TITLE
net: lwm2m: Fix device obj missing error code ri

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_obj_device.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_device.c
@@ -142,6 +142,9 @@ static int reset_error_list_cb(uint16_t obj_inst_id,
 		error_code_ri[i].res_inst_id = RES_INSTANCE_NOT_CREATED;
 	}
 
+	/* Default error code indicating no error */
+	error_code_ri[0].res_inst_id = 0;
+
 	return 0;
 }
 
@@ -182,12 +185,12 @@ int lwm2m_device_add_err(uint8_t error_code)
 	int i;
 
 	for (i = 0; i < DEVICE_ERROR_CODE_MAX; i++) {
-		if (error_code_ri[i].res_inst_id == RES_INSTANCE_NOT_CREATED) {
+		if (error_code_list[i] == 0) {
 			break;
 		}
 
 		/* No duplicate error codes allowed */
-		if (*(uint8_t *)error_code_ri[i].data_ptr == error_code) {
+		if (error_code_list[i] == error_code) {
 			return 0;
 		}
 	}
@@ -282,6 +285,9 @@ static int lwm2m_device_init(const struct device *dev)
 	if (ret < 0) {
 		LOG_DBG("Create LWM2M instance 0 error: %d", ret);
 	}
+
+	/* Create the default error code resource instance */
+	lwm2m_device_add_err(0);
 
 	/* call device_periodic_service() every 10 seconds */
 	ret = lwm2m_engine_add_service(device_periodic_service,


### PR DESCRIPTION
From the OMA LwM2M Object and Resource Registry: "When the single Device
Object Instance is initiated, there is only one error code Resource
Instance whose value is equal to 0 that means no error."

This fix creates that initial error code resource instance, and makes
sure that it doesn't get deleted by the Reset Error Code resource.

Signed-off-by: Tjerand Bjornsen <tjerand.bjornsen@nordicsemi.no>