### PR TITLE
xtensa: ADSP: Intel: fix booting on APL with XCC

### DIFF
--- a/soc/xtensa/intel_adsp/common/bootloader/boot_loader.c
+++ b/soc/xtensa/intel_adsp/common/bootloader/boot_loader.c
@@ -68,6 +68,7 @@ static inline void bmemcpy(void *dest, void *src, size_t bytes)
 	uint32_t *s = src;
 	int i;
 
+	z_xtensa_cache_inv(src, bytes);
 	for (i = 0; i < (bytes >> 2); i++)
 		d[i] = s[i];
 
@@ -167,10 +168,13 @@ static void parse_manifest(void)
 	struct sof_man_module *mod;
 	int i;
 
+	z_xtensa_cache_inv(hdr, sizeof(*hdr));
+
 	/* copy module to SRAM  - skip bootloader module */
 	for (i = MAN_SKIP_ENTRIES; i < hdr->num_module_entries; i++) {
 
 		mod = (void *)((uintptr_t)desc + SOF_MAN_MODULE_OFFSET(i));
+		z_xtensa_cache_inv(mod, sizeof(*mod));
 		parse_module(hdr, mod);
 	}
 }

--- a/soc/xtensa/intel_adsp/common/bootloader/boot_loader.c
+++ b/soc/xtensa/intel_adsp/common/bootloader/boot_loader.c
@@ -99,12 +99,12 @@ static void parse_module(struct sof_man_fw_header *hdr,
 		switch (mod->segment[i].flags.r.type) {
 		case SOF_MAN_SEGMENT_TEXT:
 		case SOF_MAN_SEGMENT_DATA:
-			bias = (mod->segment[i].file_offset -
-				SOF_MAN_ELF_TEXT_OFFSET);
+			bias = mod->segment[i].file_offset -
+				SOF_MAN_ELF_TEXT_OFFSET;
 
 			/* copy from IMR to SRAM */
 			bmemcpy((void *)mod->segment[i].v_base_addr,
-				(void *)((int)hdr + bias),
+				(uint8_t *)hdr + bias,
 				mod->segment[i].flags.r.length *
 				HOST_PAGE_SIZE);
 			break;
@@ -140,8 +140,8 @@ static uint32_t get_fw_size_in_use(void)
 
 	/* Calculate fw size passed in BASEFW module in MANIFEST */
 	for (i = MAN_SKIP_ENTRIES; i < hdr->num_module_entries; i++) {
-		mod = (struct sof_man_module *)((char *)desc +
-						SOF_MAN_MODULE_OFFSET(i));
+		mod = desc->man_module + i;
+
 		if (strcmp((char *)mod->name, "BASEFW"))
 			continue;
 		for (i = 0; i < MANIFEST_SEGMENT_COUNT; i++) {
@@ -172,8 +172,8 @@ static void parse_manifest(void)
 
 	/* copy module to SRAM  - skip bootloader module */
 	for (i = MAN_SKIP_ENTRIES; i < hdr->num_module_entries; i++) {
+		mod = desc->man_module + i;
 
-		mod = (void *)((uintptr_t)desc + SOF_MAN_MODULE_OFFSET(i));
 		z_xtensa_cache_inv(mod, sizeof(*mod));
 		parse_module(hdr, mod);
 	}

--- a/soc/xtensa/intel_adsp/common/bootloader/manifest.h
+++ b/soc/xtensa/intel_adsp/common/bootloader/manifest.h
@@ -156,6 +156,7 @@ struct sof_man_fw_desc {
 	 * struct sof_man_mod_config mod_config[];
 	 */
 
+	struct sof_man_module man_module[];
 } __attribute__((packed));
 
 /*
@@ -188,12 +189,5 @@ struct sof_man_module_manifest {
 	struct sof_man_module module;
 	uint32_t text_size;
 };
-
-/*
- * Module offset in manifest.
- */
-#define SOF_MAN_MODULE_OFFSET(index) \
-	(sizeof(struct sof_man_fw_header) + \
-		(index) * sizeof(struct sof_man_module))
 
 #endif


### PR DESCRIPTION
When built with XCC for Apollolake, Zephyr fails to boot with the default multi-core option enabled - see https://github.com/thesofproject/sof/issues/4645. invalidating firmware image caches fixes the problem, but I'm not certain, that this is the correct fix. Shouldn't the complete cache be invalidated when starting the firmware? If this isn't done, how do all other configurations work?