### PR TITLE
cmake: remove `LINKER_PASS2` define

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1296,12 +1296,9 @@ else()
   # The final linker pass uses the same source linker script of the
   # previous passes, but this time with a different output
   # file and preprocessed with the define LINKER_ZEPHYR_FINAL.
-  #
-  # LINKER_PASS2 is deprecated but being kept to avoid breaking
-  # external projects. It will be removed in the future.
   configure_linker_script(
     linker.cmd
-    "-DLINKER_ZEPHYR_FINAL;-DLINKER_PASS2"
+    "-DLINKER_ZEPHYR_FINAL"
     ${CODE_RELOCATION_DEP}
     ${ZEPHYR_PREBUILT_EXECUTABLE}
     zephyr_generated_headers

--- a/cmake/linker/armlink/target.cmake
+++ b/cmake/linker/armlink/target.cmake
@@ -33,7 +33,7 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
 
   if("${linker_pass_define}" STREQUAL "-DLINKER_ZEPHYR_PREBUILT")
     set(PASS 1)
-  elseif("${linker_pass_define}" STREQUAL "-DLINKER_ZEPHYR_FINAL;-DLINKER_PASS2")
+  elseif("${linker_pass_define}" STREQUAL "-DLINKER_ZEPHYR_FINAL")
     set(PASS 2)
     set(STEERING_FILE ${CMAKE_CURRENT_BINARY_DIR}/armlink_symbol_steering.steer)
     set(STEERING_C ${CMAKE_CURRENT_BINARY_DIR}/armlink_symbol_steering.c)

--- a/cmake/linker/ld/target.cmake
+++ b/cmake/linker/ld/target.cmake
@@ -34,7 +34,7 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
   if(CONFIG_CMAKE_LINKER_GENERATOR)
     if("${linker_pass_define}" STREQUAL "-DLINKER_ZEPHYR_PREBUILT")
       set(PASS 1)
-    elseif("${linker_pass_define}" STREQUAL "-DLINKER_ZEPHYR_FINAL;-DLINKER_PASS2")
+    elseif("${linker_pass_define}" STREQUAL "-DLINKER_ZEPHYR_FINAL")
       set(PASS 2)
     endif()
 


### PR DESCRIPTION
This option was deprecated for the v2.6 release, and has therefore met
the 2 release deprecation cycle requirements.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>