### PR TITLE
 drivers: net: loopback: Register loopback IP address to the interface 

### DIFF
--- a/drivers/net/loopback.c
+++ b/drivers/net/loopback.c
@@ -33,9 +33,31 @@ int loopback_dev_init(const struct device *dev)
 
 static void loopback_init(struct net_if *iface)
 {
+	struct net_if_addr *ifaddr;
+
 	/* RFC 7042, s.2.1.1. address to use in documentation */
 	net_if_set_link_addr(iface, "\x00\x00\x5e\x00\x53\xff", 6,
 			     NET_LINK_DUMMY);
+
+	if (IS_ENABLED(CONFIG_NET_IPV4)) {
+		struct in_addr ipv4_loopback = INADDR_LOOPBACK_INIT;
+
+		ifaddr = net_if_ipv4_addr_add(iface, &ipv4_loopback,
+					      NET_ADDR_AUTOCONF, 0);
+		if (!ifaddr) {
+			LOG_ERR("Failed to register IPv4 loopback address");
+		}
+	}
+
+	if (IS_ENABLED(CONFIG_NET_IPV6)) {
+		struct in6_addr ipv6_loopback = IN6ADDR_LOOPBACK_INIT;
+
+		ifaddr = net_if_ipv6_addr_add(iface, &ipv6_loopback,
+					      NET_ADDR_AUTOCONF, 0);
+		if (!ifaddr) {
+			LOG_ERR("Failed to register IPv6 loopback address");
+		}
+	}
 }
 
 static int loopback_send(const struct device *dev, struct net_pkt *pkt)

--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -390,6 +390,8 @@ extern const struct in6_addr in6addr_loopback;
 #define INADDR_ANY 0
 #define INADDR_ANY_INIT { { { INADDR_ANY } } }
 
+#define INADDR_LOOPBACK_INIT  { { { 127, 0, 0, 1 } } }
+
 /** @endcond */
 
 enum net_ip_mtu {

--- a/subsys/net/ip/Kconfig.ipv4
+++ b/subsys/net/ip/Kconfig.ipv4
@@ -28,6 +28,7 @@ config NET_IF_MAX_IPV4_COUNT
 config NET_IF_UNICAST_IPV4_ADDR_COUNT
 	int "Max number of unicast IPv4 addresses per network interface"
 	default 2 if NET_IPV4_AUTO
+	default 2 if NET_LOOPBACK
 	default 1
 
 config NET_IF_MCAST_IPV4_ADDR_COUNT

--- a/subsys/net/ip/Kconfig.ipv6
+++ b/subsys/net/ip/Kconfig.ipv6
@@ -24,6 +24,7 @@ config NET_IF_MAX_IPV6_COUNT
 config NET_IF_UNICAST_IPV6_ADDR_COUNT
 	int "Max number of unicast IPv6 addresses per network interface"
 	default 6 if NET_L2_OPENTHREAD
+	default 3 if NET_LOOPBACK
 	default 2
 
 config NET_IF_MCAST_IPV6_ADDR_COUNT

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -1248,7 +1248,9 @@ void net_if_start_dad(struct net_if *iface)
 	for (i = 0; i < NET_IF_MAX_IPV6_ADDR; i++) {
 		if (!ipv6->unicast[i].is_used ||
 		    ipv6->unicast[i].address.family != AF_INET6 ||
-		    &ipv6->unicast[i] == ifaddr) {
+		    &ipv6->unicast[i] == ifaddr ||
+		    net_ipv6_is_addr_loopback(
+			    &ipv6->unicast[i].address.in6_addr)) {
 			continue;
 		}
 
@@ -1683,7 +1685,8 @@ struct net_if_addr *net_if_ipv6_addr_add(struct net_if *iface,
 			iface, log_strdup(net_sprint_ipv6_addr(addr)),
 			net_addr_type2str(addr_type));
 
-		if (!(l2_flags_get(iface) & NET_L2_POINT_TO_POINT)) {
+		if (!(l2_flags_get(iface) & NET_L2_POINT_TO_POINT) &&
+		    !net_ipv6_is_addr_loopback(addr)) {
 			/* RFC 4862 5.4.2
 			 * Before sending a Neighbor Solicitation, an interface
 			 * MUST join the all-nodes multicast address and the


### PR DESCRIPTION
Regsiter loopback IPv4/IPv6 to the loopback interface during
interface initialization.

Fixes #39075

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>