### PR TITLE
arm: aarch32: mpu: Fix build issue with assert

### DIFF
--- a/arch/arm/core/aarch32/mpu/arm_core_mpu.c
+++ b/arch/arm/core/aarch32/mpu/arm_core_mpu.c
@@ -278,7 +278,7 @@ void z_arm_configure_dynamic_mpu_regions(struct k_thread *thread)
 
 		__ASSERT((uintptr_t)&z_priv_stacks_ram_start <= guard_start,
 		"Guard start: (0x%lx) below privilege stacks boundary: (%p)",
-		guard_start, &z_priv_stacks_ram_start);
+		guard_start, z_priv_stacks_ram_start);
 	} else
 #endif /* CONFIG_USERSPACE */
 	{


### PR DESCRIPTION
The assert log of z_priv_stacks_ram_start failed to build due to passing
&z_priv_stacks_ram_start instead of just z_priv_stacks_ram_start.

Fixes #39190

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>