### PR TITLE
net: sockets: prevent zephyr fatal in dns resolving callback

### DIFF
--- a/subsys/net/lib/sockets/getaddrinfo.c
+++ b/subsys/net/lib/sockets/getaddrinfo.c
@@ -163,7 +163,7 @@ int z_impl_z_zsock_getaddrinfo_internal(const char *host, const char *service,
 	int st1 = DNS_EAI_ADDRFAMILY, st2 = DNS_EAI_ADDRFAMILY;
 	struct sockaddr *ai_addr;
 	int ret;
-	struct getaddrinfo_state ai_state;
+	static struct getaddrinfo_state ai_state;
 
 	if (hints) {
 		family = hints->ai_family;


### PR DESCRIPTION
if dns request was attempted
in the absence of network connection,
and then network is present again after more than
CONFIG_NET_SOCKETS_DNS_TIMEOUT + 100,
ZEPHYR FATAL happens

Fixes #39242

Signed-off-by: Andrey Dodonov <andrey.dodonov@endress.com>