### PR TITLE
boards: arm: nxp: Add pinctrl-names

### DIFF
--- a/boards/arm/frdm_k22f/frdm_k22f.dts
+++ b/boards/arm/frdm_k22f/frdm_k22f.dts
@@ -125,6 +125,7 @@
 arduino_i2c: &i2c0 {
 	status = "okay";
 	pinctrl-0 = <&I2C0_SCL_PTB2 &I2C0_SDA_PTB3>;
+	pinctrl-names = "default";
 
 	fxos8700@1c {
 		compatible = "nxp,fxos8700";
@@ -147,6 +148,7 @@ arduino_spi: &spi0 {
 	status = "okay";
 	pinctrl-0 = <&SPI0_PCS4_PTC0 &SPI0_SCK_PTD1
 		     &SPI0_SOUT_PTD2 &SPI0_SIN_PTD3>;
+	pinctrl-names = "default";
 };
 
 &ftm0 {
@@ -154,16 +156,19 @@ arduino_spi: &spi0 {
 	compatible = "nxp,kinetis-ftm-pwm";
 	#pwm-cells = <3>;
 	pinctrl-0 = <&FTM0_CH6_PTA1 &FTM0_CH7_PTA2 &FTM0_CH5_PTD5>;
+	pinctrl-names = "default";
 };
 
 &uart1 {
 	status = "okay";
 	current-speed = <115200>;
 	pinctrl-0 = <&UART1_RX_PTE1 &UART1_TX_PTE0>;
+	pinctrl-names = "default";
 };
 
 &uart2 {
 	pinctrl-0 = <&UART2_RX_PTD2 &UART2_TX_PTD3>;
+	pinctrl-names = "default";
 };
 
 zephyr_udc0: &usbotg {

--- a/boards/arm/frdm_k64f/frdm_k64f.dts
+++ b/boards/arm/frdm_k64f/frdm_k64f.dts
@@ -96,6 +96,7 @@ arduino_serial: &uart3 {
 	status = "okay";
 	current-speed = <115200>;
 	pinctrl-0 = <&UART3_RX_PTC16 &UART3_TX_PTC17>;
+	pinctrl-names = "default";
 };
 
 &cpu0 {
@@ -122,6 +123,7 @@ arduino_serial: &uart3 {
 arduino_i2c: &i2c0 {
 	status = "okay";
 	pinctrl-0 = <&I2C0_SCL_PTE24 &I2C0_SDA_PTE25>;
+	pinctrl-names = "default";
 
 	fxos8700@1d {
 		compatible = "nxp,fxos8700";
@@ -135,6 +137,7 @@ arduino_i2c: &i2c0 {
 arduino_spi: &spi0 {
 	status = "okay";
 	pinctrl-0 = <&SPI0_PCS0_PTD0 &SPI0_SCK_PTD1 &SPI0_SOUT_PTD2 &SPI0_SIN_PTD3>;
+	pinctrl-names = "default";
 };
 
 &ftm0 {
@@ -142,6 +145,7 @@ arduino_spi: &spi0 {
 	compatible = "nxp,kinetis-ftm-pwm";
 	#pwm-cells = <3>;
 	pinctrl-0 = <&FTM0_CH0_PTC1>;
+	pinctrl-names = "default";
 };
 
 &ftm3 {
@@ -149,16 +153,19 @@ arduino_spi: &spi0 {
 	compatible = "nxp,kinetis-ftm-pwm";
 	#pwm-cells = <3>;
 	pinctrl-0 = <&FTM3_CH4_PTC8 &FTM3_CH5_PTC9>;
+	pinctrl-names = "default";
 };
 
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;
 	pinctrl-0 = <&UART0_RX_PTB16 &UART0_TX_PTB17>;
+	pinctrl-names = "default";
 };
 
 &uart2 {
 	pinctrl-0 = <&UART2_RTS_b_PTD0 &UART2_CTS_b_PTD1 &UART2_RX_PTD2 &UART2_TX_PTD3>;
+	pinctrl-names = "default";
 };
 
 zephyr_udc0: &usbotg {
@@ -232,10 +239,12 @@ zephyr_udc0: &usbotg {
 		     &RMII0_TXEN_PTA15 &RMII0_TXD0_PTA16
 		     &RMII0_TXD1_PTA17 &RMII0_MDIO_PTB0
 		     &RMII0_MDC_PTB1>;
+	pinctrl-names = "default";
 	ptp {
 		status = "okay";
 		pinctrl-0 = <&ENET0_1588_TMR0_PTC16 &ENET0_1588_TMR1_PTC17
 			     &ENET0_1588_TMR2_PTC18>;
+		pinctrl-names = "default";
 	};
 };
 
@@ -247,6 +256,7 @@ zephyr_udc0: &usbotg {
 &flexcan0 {
 	status = "okay";
 	pinctrl-0 = <&CAN0_TX_PTB18 &CAN0_RX_PTB19>;
+	pinctrl-names = "default";
 	bus-speed = <125000>;
 };
 

--- a/boards/arm/frdm_k82f/frdm_k82f.dts
+++ b/boards/arm/frdm_k82f/frdm_k82f.dts
@@ -114,6 +114,7 @@
 &adc0 {
 	status = "okay";
 	pinctrl-0 = <&ADC0_SE15_PTC1>;
+	pinctrl-names = "default";
 };
 
 &gpioa {
@@ -169,6 +170,7 @@
 &i2c3 {
 	status = "okay";
 	pinctrl-0 = <&I2C3_SDA_PTA1 &I2C3_SCL_PTA2>;
+	pinctrl-names = "default";
 
 	fxos8700@1c {
 		compatible = "nxp,fxos8700";
@@ -189,6 +191,7 @@
 &lpuart4 {
 	status = "okay";
 	pinctrl-0 = <&LPUART4_RX_PTC14 &LPUART4_TX_PTC15>;
+	pinctrl-names = "default";
 	current-speed = <115200>;
 };
 
@@ -197,6 +200,7 @@
 	compatible = "nxp,kinetis-ftm-pwm";
 	#pwm-cells = <3>;
 	pinctrl-0 = <&FTM3_CH4_PTC8 &FTM3_CH5_PTC9 &FTM3_CH6_PTC10>;
+	pinctrl-names = "default";
 };
 
 &spi1 {
@@ -204,6 +208,7 @@
 
 	pinctrl-0 = <&SPI1_SCK_PTE1 &SPI1_SOUT_PTE2
 		     &SPI1_SIN_PTE4 &SPI1_PCS0_PTE5>;
+	pinctrl-names = "default";
 
 	mx25u32: mx25u3235f@0 {
 		compatible = "jedec,spi-nor";
@@ -236,6 +241,7 @@ zephyr_udc0: &usbotg {
 arduino_i2c: &i2c0 {
 	status = "okay";
 	pinctrl-0 = <&I2C0_SDA_PTB3 &I2C0_SCL_PTB2>;
+	pinctrl-names = "default";
 };
 
 &I2C0_SDA_PTB3 {
@@ -249,4 +255,5 @@ arduino_i2c: &i2c0 {
 arduino_spi: &spi0 {
 	status = "okay";
 	pinctrl-0 = <&SPI0_SCK_PTD1 &SPI0_SOUT_PTD2 &SPI0_SIN_PTD3 &SPI0_PCS1_PTD4>;
+	pinctrl-names = "default";
 };

--- a/boards/arm/frdm_kl25z/frdm_kl25z.dts
+++ b/boards/arm/frdm_kl25z/frdm_kl25z.dts
@@ -93,11 +93,13 @@
 &adc0 {
 	status = "okay";
 	pinctrl-0 = <&ADC0_SE12_PTB2>;
+	pinctrl-names = "default";
 };
 
 &i2c0 {
 	status = "okay";
 	pinctrl-0 = <&I2C0_SCL_PTE24 &I2C0_SDA_PTE25>;
+	pinctrl-names = "default";
 
 	mma8451q@1d {
 		compatible = "nxp,fxos8700","nxp,mma8451q";
@@ -120,6 +122,7 @@
 	status = "okay";
 	current-speed = <115200>;
 	pinctrl-0 = <&UART0_RX_PTA1 &UART0_TX_PTA2>;
+	pinctrl-names = "default";
 };
 
 &gpioa {

--- a/boards/arm/frdm_kw41z/frdm_kw41z.dts
+++ b/boards/arm/frdm_kw41z/frdm_kw41z.dts
@@ -110,11 +110,13 @@
 &adc0 {
 	status = "okay";
 	pinctrl-0 = <&ADC0_SE3_PTB2>;
+	pinctrl-names = "default";
 };
 
 &i2c1 {
 	status = "okay";
 	pinctrl-0 = <&I2C1_SCL_PTC2 &I2C1_SDA_PTC3>;
+	pinctrl-names = "default";
 
 	fxos8700@1f {
 		compatible = "nxp,fxos8700";
@@ -135,6 +137,7 @@
 &lpuart0 {
 	status = "okay";
 	pinctrl-0 = <&UART0_RX_PTC6 &UART0_TX_PTC7>;
+	pinctrl-names = "default";
 	current-speed = <115200>;
 };
 
@@ -150,11 +153,13 @@
 	status = "okay";
 	pinctrl-0 = <&SPI0_SCK_PTC16 &SPI0_SOUT_PTC17
 		     &SPI0_SIN_PTC18 &SPI0_PCS0_PTC19>;
+	pinctrl-names = "default";
 };
 
 &tpm0 {
 	status = "okay";
 	pinctrl-0 = <&TPM0_CH2_PTC1>;
+	pinctrl-names = "default";
 };
 
 &tpm1 {
@@ -164,4 +169,5 @@
 &tpm2 {
 	status = "okay";
 	pinctrl-0 = <&TPM2_CH1_PTA19 &TPM2_CH0_PTA18>;
+	pinctrl-names = "default";
 };

--- a/boards/arm/hexiwear_k64/hexiwear_k64.dts
+++ b/boards/arm/hexiwear_k64/hexiwear_k64.dts
@@ -81,11 +81,13 @@
 	compatible = "nxp,kinetis-ftm-pwm";
 	#pwm-cells = <3>;
 	pinctrl-0 = <&FTM3_CH4_PTC8 &FTM3_CH5_PTC9 &FTM3_CH0_PTD0>;
+	pinctrl-names = "default";
 };
 
 &i2c0 {
 	status = "okay";
 	pinctrl-0 = <&I2C0_SCL_PTB0 &I2C0_SDA_PTB1>;
+	pinctrl-names = "default";
 
 	max30101@57 {
 		status = "disabled";
@@ -106,6 +108,7 @@
 &i2c1 {
 	status = "okay";
 	pinctrl-0 = <&I2C1_SCL_PTC10 &I2C1_SDA_PTC11>;
+	pinctrl-names = "default";
 
 	fxos8700@1e {
 		compatible = "nxp,fxos8700";
@@ -136,12 +139,14 @@
 	status = "okay";
 	current-speed = <115200>;
 	pinctrl-0 = <&UART0_RX_PTB16 &UART0_TX_PTB17>;
+	pinctrl-names = "default";
 };
 
 &uart4 {
 	status = "okay";
 	current-speed = <115200>;
 	pinctrl-0 = <&UART4_RX_PTE25 &UART4_TX_PTE24>;
+	pinctrl-names = "default";
 };
 
 &gpiob {

--- a/boards/arm/hexiwear_kw40z/hexiwear_kw40z.dts
+++ b/boards/arm/hexiwear_kw40z/hexiwear_kw40z.dts
@@ -22,12 +22,14 @@
 &adc0 {
 	status = "okay";
 	pinctrl-0 = <&ADC0_SE1_PTB1>;
+	pinctrl-names = "default";
 };
 
 &lpuart0 {
 	status = "okay";
 	current-speed = <115200>;
 	pinctrl-0 = <&UART0_RX_PTC6 &UART0_TX_PTC7>;
+	pinctrl-names = "default";
 };
 
 &gpioa {

--- a/boards/arm/ip_k66f/ip_k66f.dts
+++ b/boards/arm/ip_k66f/ip_k66f.dts
@@ -107,6 +107,7 @@
 		     &RMII0_CRS_DV_PTA14 &RMII0_TXEN_PTA15
 		     &RMII0_TXD0_PTA16 &RMII0_TXD1_PTA17
 		     &ENET_1588_CLKIN_PTE26 /* used for RMII ref clk */>;
+	pinctrl-names = "default";
 
 	fixed-link {
 		speed = <100>;
@@ -118,6 +119,7 @@
 	status = "okay";
 	pinctrl-0 = <&SPI1_PCS0_PTB10 &SPI1_SCK_PTB11
 		     &SPI1_SOUT_PTB16 &SPI1_SIN_PTB17>;
+	pinctrl-names = "default";
 
 	clock-frequency = <44000000>;
 	cs-gpios = <&gpioe 4 GPIO_ACTIVE_LOW>;

--- a/boards/arm/twr_ke18f/twr_ke18f.dts
+++ b/boards/arm/twr_ke18f/twr_ke18f.dts
@@ -140,6 +140,7 @@
 	clkout-source = <1>;
 	clkout-divider = <0>;
 	pinctrl-0 = <&CLKOUT_PTE10>;
+	pinctrl-names = "default";
 };
 
 &scg {
@@ -207,6 +208,7 @@
 	status = "okay";
 	current-speed = <115200>;
 	pinctrl-0 = <&LPUART0_RX_PTB0 &LPUART0_TX_PTB1>;
+	pinctrl-names = "default";
 };
 
 &ftm0 {
@@ -214,6 +216,7 @@
 	compatible = "nxp,kinetis-ftm-pwm";
 	#pwm-cells = <3>;
 	pinctrl-0 = <&FTM0_CH0_PTD15 &FTM0_CH1_PTD16 &FTM0_CH5_PTB5>;
+	pinctrl-names = "default";
 };
 
 &ftm3 {
@@ -222,11 +225,13 @@
 	#pwm-cells = <3>;
 	pinctrl-0 = <&FTM3_CH4_PTC10 &FTM3_CH5_PTC11
 		     &FTM3_CH6_PTC12 &FTM3_CH7_PTC13>;
+	pinctrl-names = "default";
 };
 
 &lpi2c0 {
 	status = "okay";
 	pinctrl-0 = <&LPI2C0_SDA_PTA2 &LPI2C0_SCL_PTA3>;
+	pinctrl-names = "default";
 
 	fxos8700: fxos8700@1d {
 		compatible = "nxp,fxos8700";
@@ -239,29 +244,34 @@
 &lpi2c1 {
 	status = "okay";
 	pinctrl-0 = <&LPI2C1_SDA_PTD8 &LPI2C1_SCL_PTD9>;
+	pinctrl-names = "default";
 };
 
 &lpspi0 {
 	status = "okay";
 	pinctrl-0 = <&LPSPI0_SCK_PTE0 &LPSPI0_SIN_PTE1
 		     &LPSPI0_SOUT_PTE2 &LPSPI0_PCS2_PTE6>;
+	pinctrl-names = "default";
 };
 
 &lpspi1 {
 	status = "okay";
 	pinctrl-0 = <&LPSPI1_SCK_PTD0 &LPSPI1_SIN_PTD1
 		     &LPSPI1_SOUT_PTD2 &LPSPI1_PCS0_PTD3>;
+	pinctrl-names = "default";
 };
 
 &dac0 {
 	status = "okay";
 	pinctrl-0 = <&DAC0_OUT_PTE9>;
+	pinctrl-names = "default";
 };
 
 &adc0 {
 	status = "okay";
 	sample-time = <12>;
 	pinctrl-0 = <&ADC0_SE0_PTA0 &ADC0_SE1_PTA1 &ADC0_SE12_PTC14>;
+	pinctrl-names = "default";
 };
 
 &temp0 {
@@ -272,6 +282,7 @@
 	status = "okay";
 	bus-speed = <125000>;
 	pinctrl-0 = <&CAN0_RX_PTE4 &CAN0_TX_PTE5>;
+	pinctrl-names = "default";
 };
 
 &gpioa {

--- a/boards/arm/twr_kv58f220m/twr_kv58f220m.dts
+++ b/boards/arm/twr_kv58f220m/twr_kv58f220m.dts
@@ -132,6 +132,7 @@
 &i2c1 {
 	status = "okay";
 	pinctrl-0 = <&I2C1_SCL_PTD8 &I2C1_SDA_PTD9>;
+	pinctrl-names = "default";
 
 	fxos8700@1c {
 		compatible = "nxp,fxos8700";
@@ -154,4 +155,5 @@
 	status = "okay";
 	current-speed = <115200>;
 	pinctrl-0 = <&UART0_RX_PTB0 &UART0_TX_PTB1>;
+	pinctrl-names = "default";
 };

--- a/boards/arm/usb_kw24d512/usb_kw24d512.dts
+++ b/boards/arm/usb_kw24d512/usb_kw24d512.dts
@@ -60,6 +60,7 @@
 	status = "okay";
 	current-speed = <115200>;
 	pinctrl-0 = <&UART0_RX_PTA1 &UART0_TX_PTA2>;
+	pinctrl-names = "default";
 };
 
 zephyr_udc0: &usbd {


### PR DESCRIPTION
Add "pinctrl-names" property for "default" to all NXP kinetis
based boards.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>