### PR TITLE
cmake: use <app>/board/<board> as APPLICATION_CONFIG_DIR when present

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -438,9 +438,14 @@ if(DEFINED APPLICATION_CONFIG_DIR)
     get_filename_component(APPLICATION_CONFIG_DIR ${APPLICATION_CONFIG_DIR} ABSOLUTE)
   endif()
 else()
-  # Application config dir is not set, so we default to the  application
-  # source directory as configuration directory.
-  set(APPLICATION_CONFIG_DIR ${APPLICATION_SOURCE_DIR})
+  # Application config dir is not set, so we default to the board specific
+  # folder application directory <app>/boards/<board>/ if it exists, else use
+  # the application source directory as configuration directory.
+  if(IS_DIRECTORY ${APPLICATION_SOURCE_DIR}/boards/${BOARD})
+    set(APPLICATION_CONFIG_DIR ${APPLICATION_SOURCE_DIR}/boards/${BOARD})
+  else()
+    set(APPLICATION_CONFIG_DIR ${APPLICATION_SOURCE_DIR})
+  endif()
 endif()
 
 if(DEFINED CONF_FILE)

--- a/doc/application/index.rst
+++ b/doc/application/index.rst
@@ -618,7 +618,9 @@ highest priority listed first.
    ``find_package(Zephyr)`` then this folder is used a the application's
    configuration directory.
 
-2. The application's source directory.
+2. The directory :file:`boards/<BOARD>`, if it exists.
+
+3. The application's source directory.
 
 .. _application-kconfig:
 

--- a/tests/cmake/config_dir/boards/native_posix/prj.conf
+++ b/tests/cmake/config_dir/boards/native_posix/prj.conf
@@ -1,0 +1,3 @@
+# If this config is loaded, then the test will pass and using a board specific
+# configuration dir worked correctly.
+CONFIG_FAIL_TEST=n

--- a/tests/cmake/config_dir/testcase.yaml
+++ b/tests/cmake/config_dir/testcase.yaml
@@ -3,3 +3,6 @@ tests:
     platform_allow: native_posix
     build_only: true
     extra_args: APPLICATION_CONFIG_DIR:PATH=foo
+  config_dir.board:
+    platform_allow: native_posix
+    build_only: true


### PR DESCRIPTION
To support the common case of locating configurations on a per board
basis then support for <app>/boards/<board>/ folder is natively
supported.
This means that if a sample is built for board `foo` and folder
`<app>/boards/foo/` exists, then this folder will be used as the
APPLICATION_CONFIG_DIR, else the APPLICATION_SOURCE_DIR will be used as
the default configuration folder.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>

-------

~Depends on: #38229~
~Only review last commit in this PR~
