### PR TITLE
scripts: footprint: fix print alignment and color

### DIFF
--- a/scripts/footprint/size_report
+++ b/scripts/footprint/size_report
@@ -687,13 +687,14 @@ def print_any_tree(root, total_size, depth):
 
         cc = cr = ""
         if not row.node.children:
-            cc = Fore.CYAN
-            cr = Fore.RESET
+            if row.node.name != "(hidden)":
+                cc = Fore.CYAN
+                cr = Fore.RESET
         elif row.node.name.endswith(SRC_FILE_EXT):
             cc = Fore.GREEN
             cr = Fore.RESET
 
-        print(f"{row.pre}{cc}{row.node.name}{cr} {s} {Fore.BLUE}{percent:5.2f}%{Fore.RESET}")
+        print(f"{row.pre}{cc}{row.node.name} {s} {cr}{Fore.BLUE}{percent:6.2f}%{Fore.RESET}")
     print('=' * 110)
     print(f'{total_size:>101}')
 


### PR DESCRIPTION
The size percentage was doing "xx.xx%" so 100% would not be
aligned correctly when printed. So add a space for percentage
printing.

Also change the coloring of "(hidden)" node so it would not
have the same color as files or symbols.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>