### PR TITLE
dts: arm: stm32u5 fix register address for spi3 node

### DIFF
--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -274,7 +274,7 @@
 			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <46002000 0x400>;
+			reg = <0x46002000 0x400>;
 			interrupts = <99 5>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB3 0x00000020>;
 			status = "disabled";


### PR DESCRIPTION
this PR is correcting the address of the spi3 bank

The register address of the SPI was wrong

Signed-off-by: Francois Ramu <francois.ramu@st.com>