### PR TITLE
net: openthread: Fix RCP stuck in forever loop in uart_callback

### DIFF
--- a/drivers/serial/uart_b91.c
+++ b/drivers/serial/uart_b91.c
@@ -427,7 +427,8 @@ static int uart_b91_irq_tx_ready(const struct device *dev)
 {
 	volatile struct uart_b91_t *uart = GET_UART(dev);
 
-	return (uart_b91_get_tx_bufcnt(uart) < UART_TX_BUF_CNT) ? 1 : 0;
+	return ((uart_b91_get_tx_bufcnt(uart) < UART_TX_BUF_CNT) &&
+		((uart->ctrl0 & UART_TX_IRQ_MASK) != 0)) ? 1 : 0;
 }
 
 /* API implementation: irq_tx_complete */

--- a/include/drivers/uart.h
+++ b/include/drivers/uart.h
@@ -903,7 +903,8 @@ static inline void z_impl_uart_irq_tx_disable(const struct device *dev)
  *
  * @param dev UART device structure.
  *
- * @retval 1 If at least one char can be written to UART.
+ * @retval 1 If TX interrupt is enabled and at least one char can be
+ *           written to UART.
  * @retval 0 If device is not ready to write a new byte.
  * @retval -ENOSYS  if this function is not supported.
  * @retval -ENOTSUP if API is not enabled.


### PR DESCRIPTION
Issue description:
If run OpenThread RCP device (net/openthread/coprocessor sample) using tlsr9518adk80d board for many hours with several thread devices connected to the RCP, the RCP stuck in uart_callback for forever.
The issue potentially could be reproduced with other boards,  see the description below.

**Forever Loop description:**
1. `uart_callback` is running
``` 
103 static void uart_callback(const struct device *dev, void *user_data)
104 {
105	ARG_UNUSED(user_data);
106
107	while (uart_irq_update(dev) && uart_irq_is_pending(dev)) {
108
109		if (uart_irq_rx_ready(dev)) {
110			uart_rx_handle(dev);
111		}
112
113		if (uart_irq_tx_ready(dev) &&
114		    atomic_get(&ot_uart.tx_busy) == 1) {
115			uart_tx_handle(dev);
116		}
117	}
118}
```
2. `uart_irq_is_pending(dev)` (line 107) returns `true` because TX IRQ is enabled, to clear pending flag need to disable TX IRQ. 
3. Disabling of TX IRQ is part of `uart_tx_handle` (line 115) but it is not called because `ot_uart.tx_busy` equals 0 (line114).
4. So, forever loop happens if TX IRQ is enabled and `ot_uart.tx_busy` equals 0.

**How it is possible that TX IRQ is enabled and  `ot_uart.tx_busy` equals 0. Description:**

 `otPlatUartSend` is running (original version)
```
221 otError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
222 {
223	if (aBuf == NULL) {
224		return OT_ERROR_FAILED;
225	}
226
227	if (atomic_cas(&(ot_uart.tx_busy), 0, 1)) {
228		write_buffer = aBuf;
229		write_length = aBufLength;
230
231		if (is_panic_mode) {
232			/* In panic mode all data have to be send immediately
233			 * without using interrupts
234			 */
235			otPlatUartFlush();
236		} else {
237			uart_irq_tx_enable(ot_uart.dev);
238		}
239		return OT_ERROR_NONE;
240	}
241
242	return OT_ERROR_BUSY;
242}
```
If RX IRQ happens between line 227 and 229 (when `tx_busy` is already set to 1 but `write_length` is not set yet), the `ot_uart.tx_busy` flag is set back to 0 inside `uart_callback`: `uart_irq_tx_ready` returns true (line 113) because TX buffer is empty,  `ot_uart.tx_busy` also is true (line 114) because we have just set it to 1 and as result `uart_tx_handle` is called (line 115). `uart_tx_handle` sets `ot_uart.tx_busy` flag to 0 if `write_length` equals 0.
So, when we com back to line 237, here we enable TX IRQ and `ot_uart.tx_busy` is 0.

**SOLUTION:**
`write_length` must be set before `ot_uart.tx_busy`.
