### PR TITLE
west.yml: Update mcumgr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -161,7 +161,7 @@ manifest:
       revision: c61538748ead773ea75a551a7beee299228bdcaf
       path: bootloader/mcuboot
     - name: mcumgr
-      revision: a7301143b3b46a8f7d410b12580a875cc1b6f8c8
+      revision: c854c85ec75d624c47058bc4ac0ab9b12e2dd0e7
       path: modules/lib/mcumgr
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Commits affecting Zephyr that are included with the new revision:

- 12b496e Add IMG_MGMT_FRUGAL_LIST configuration option;
- 18c628d cborattr: fixes missing error handling;
- 2e385b6 zephyr: Fix usage of zephyr_img_mgmt_flash_area_id.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>