### PR TITLE
[RFC][WIP] boards: arm: add ethernet for teensy4 based on 34718

### DIFF
--- a/boards/arm/teensy4/Kconfig.defconfig
+++ b/boards/arm/teensy4/Kconfig.defconfig
@@ -21,4 +21,12 @@ endchoice
 config DISK_DRIVER_SDMMC
 	default y if DISK_DRIVERS
 
+if NETWORKING
+
+config NET_L2_ETHERNET
+	default n if BOARD_TEENSY40
+	default y if BOARD_TEENSY41
+
+endif # NETWORKING
+
 endif # BOARD_TEENSY40 || BOARD_TEENSY41

--- a/boards/arm/teensy4/pinmux.c
+++ b/boards/arm/teensy4/pinmux.c
@@ -411,5 +411,5 @@ static int teensy4_phy_reset(const struct device *dev)
 
 SYS_INIT(teensy4_init, PRE_KERNEL_1, 0);
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(enet), okay) && CONFIG_NET_L2_ETHERNET
-SYS_INIT(teensy4_phy_reset, PRE_KERNEL_2, 0);
+SYS_INIT(teensy4_phy_reset, POST_KERNEL, CONFIG_PHY_INIT_PRIORITY);
 #endif

--- a/boards/arm/teensy4/teensy41.dts
+++ b/boards/arm/teensy4/teensy41.dts
@@ -21,6 +21,24 @@
 	};
 };
 
+&enet {
+	status = "okay";
+	ptp {
+		status = "okay";
+	};
+	phy {
+		compatible = "ethernet-phy";
+		status = "okay";
+		no-reset;
+		late_mii_start;
+		address = <0>;
+		mdio = <&mdio>;
+	};
+	mdio: mdio {
+		status = "okay";
+	};
+};
+
 &lpspi3 {
 	status = "okay";
 };

--- a/drivers/mdio/CMakeLists.txt
+++ b/drivers/mdio/CMakeLists.txt
@@ -3,4 +3,5 @@
 zephyr_library()
 
 zephyr_library_sources_ifdef(CONFIG_MDIO_SHELL		mdio_shell.c)
+zephyr_library_sources_ifdef(CONFIG_MDIO_NXP_MCUX	mdio_mcux.c)
 zephyr_library_sources_ifdef(CONFIG_MDIO_ATMEL_SAM	mdio_sam.c)

--- a/drivers/mdio/Kconfig
+++ b/drivers/mdio/Kconfig
@@ -25,6 +25,7 @@ config MDIO_SHELL
 
 # Include these first so that any properties (e.g. defaults) below can be
 # overridden (by defining symbols in multiple locations)
+source "drivers/mdio/Kconfig.mcux"
 source "drivers/mdio/Kconfig.sam"
 
 config MDIO_INIT_PRIORITY

--- a/drivers/mdio/Kconfig.mcux
+++ b/drivers/mdio/Kconfig.mcux
@@ -1,0 +1,9 @@
+# Copyright (c) 2021 Bernhard Kraemer
+# SPDX-License-Identifier: Apache-2.0
+
+config MDIO_NXP_MCUX
+	bool "NXP MCUX MDIO driver"
+	depends on ETH_MCUX
+	default y
+	help
+	  Enable NXP MCUX MDIO driver.

--- a/drivers/mdio/mdio_mcux.c
+++ b/drivers/mdio/mdio_mcux.c
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2021 IP-Logix Inc.
+ * Copyright (c) 2021 Bernhard Kraemer
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT nxp_kinetis_mdio
+
+#include <errno.h>
+#include <device.h>
+#include <init.h>
+#include <soc.h>
+#include "mdio_mcux.h"
+
+#include <logging/log.h>
+LOG_MODULE_REGISTER(mdio_mcux, CONFIG_MDIO_LOG_LEVEL);
+
+/*! @brief MDC frequency. */
+#define MDC_FREQUENCY 2500000U
+/*! @brief NanoSecond in one second. */
+#define NANOSECOND_ONE_SECOND 1000000000U
+
+struct mdio_mcux_dev_data {
+	struct k_sem idle_sem;
+	struct k_sem complete_sem;
+};
+
+/** MII - Register Layout Typedef */
+struct mdio_mcux_regs {
+		 uint8_t RESERVED_0[64];
+	__IO uint32_t MMFR;	/**< MII Management Frame Register, offset: 0x40 */
+	__IO uint32_t MSCR;	/**< MII Speed Control Register, offset: 0x44 */
+};
+#define MII_Type struct mdio_mcux_regs
+
+struct mdio_mcux_dev_config {
+	MII_Type * const base;
+	int protocol;
+};
+
+#define DEV_NAME(dev) ((dev)->name)
+#define DEV_DATA(dev) ((struct mdio_mcux_dev_data *const)(dev)->data)
+#define DEV_CFG(dev) \
+	((const struct mdio_mcux_dev_config *const)(dev)->config)
+
+static int mdio_transfer(const struct device *dev, uint8_t prtad,
+			  uint8_t devad, uint8_t rw, uint16_t data_in,
+			  uint16_t *data_out)
+{
+	const struct mdio_mcux_dev_config *const cfg = DEV_CFG(dev);
+	struct mdio_mcux_dev_data *const data = DEV_DATA(dev);
+
+	k_sem_take(&data->idle_sem, K_FOREVER);
+	k_sem_take(&data->complete_sem, K_NO_WAIT);
+
+	LOG_DBG("rw: %u, prtad: 0x%02x, devad: 0x%02x, data_in: 0x%04x", rw, prtad, devad, data_in);
+
+	/* Write mdio transaction */
+	if (cfg->protocol == CLAUSE_45) {
+		cfg->base->MMFR = ENET_MMFR_ST(0U)
+					 | (ENET_MMFR_OP(rw ? 0x2 : 0x3))
+				     | ENET_MMFR_PA(prtad)
+				     | ENET_MMFR_RA(devad)
+				     | ENET_MMFR_TA(2U)
+				     | ENET_MMFR_DATA(data_in);
+	} else if (cfg->protocol == CLAUSE_22) {
+		cfg->base->MMFR = ENET_MMFR_ST(1U)
+				     | (ENET_MMFR_OP(rw ? 0x2 : 0x1))
+				     | ENET_MMFR_PA(prtad)
+				     | ENET_MMFR_RA(devad)
+					 | ENET_MMFR_TA(2U)
+				     | ENET_MMFR_DATA(data_in);
+	} else {
+		LOG_ERR("Unsupported protocol");
+	}
+
+	/* Wait until done */
+	if (k_sem_take(&data->complete_sem, K_MSEC(5)) != 0) {
+		k_sem_give(&data->idle_sem);
+		LOG_ERR("transfer timedout %s", DEV_NAME(dev));
+		return -ETIMEDOUT;
+	}
+
+	if (data_out) {
+		*data_out =
+			(uint16_t)((cfg->base->MMFR & ENET_MMFR_DATA_MASK) >> ENET_MMFR_DATA_SHIFT);
+		LOG_DBG("data_out: 0x%04x", *data_out);
+	}
+
+	k_sem_give(&data->idle_sem);
+	return 0;
+}
+
+static int mdio_mcux_read(const struct device *dev, uint8_t prtad, uint8_t devad,
+			 uint16_t *data)
+{
+	return mdio_transfer(dev, prtad, devad, 1, 0, data);
+}
+
+static int mdio_mcux_write(const struct device *dev, uint8_t prtad,
+			  uint8_t devad, uint16_t data)
+{
+	return mdio_transfer(dev, prtad, devad, 0, data, NULL);
+}
+
+static void mdio_mcux_bus_enable(const struct device *dev)
+{
+	const struct mdio_mcux_dev_config *const cfg = DEV_CFG(dev);
+	uint32_t srcClock_Hz = CLOCK_GetFreq(kCLOCK_CoreSysClk);
+	uint32_t clkCycle = 0;
+	uint32_t speed    = 0;
+
+	/* Due to bits limitation of SPEED and HOLDTIME, */
+	/* srcClock_Hz must ensure MDC <= 2.5M and holdtime >= 10ns. */
+	assert((srcClock_Hz != 0U) && (srcClock_Hz <= 320000000U));
+
+	/* Use (param + N - 1) / N to increase accuracy with rounding. */
+	/* Calculate the MII speed which controls the frequency of the MDC. */
+	speed = (srcClock_Hz + 2U * MDC_FREQUENCY - 1U) / (2U * MDC_FREQUENCY) - 1U;
+	/* Calculate the hold time on the MDIO output. */
+	clkCycle = (10U + NANOSECOND_ONE_SECOND / srcClock_Hz - 1U) /
+				(NANOSECOND_ONE_SECOND / srcClock_Hz) - 1U;
+
+	cfg->base->MSCR = ENET_MSCR_MII_SPEED(speed) | ENET_MSCR_HOLDTIME(clkCycle);
+}
+
+static void mdio_mcux_bus_disable(const struct device *dev)
+{
+	const struct mdio_mcux_dev_config *const cfg = DEV_CFG(dev);
+
+	cfg->base->MSCR = 0U;
+}
+
+static int mdio_mcux_initialize(const struct device *dev)
+{
+	struct mdio_mcux_dev_data *const data = DEV_DATA(dev);
+
+	k_sem_init(&data->idle_sem, 1, 1);
+	k_sem_init(&data->complete_sem, 0, 1);
+
+	return 0;
+}
+
+static const struct mdio_driver_api mdio_mcux_driver_api = {
+	.read = mdio_mcux_read,
+	.write = mdio_mcux_write,
+	.bus_enable = mdio_mcux_bus_enable,
+	.bus_disable = mdio_mcux_bus_disable,
+};
+
+void z_impl_mdio_mcux_transfer_complete(const struct device *dev)
+{
+	struct mdio_mcux_dev_data *const data = DEV_DATA(dev);
+
+	k_sem_give(&data->complete_sem);
+}
+
+#define MDIO_MCUX_CONFIG(n)						\
+static const struct mdio_mcux_dev_config mdio_mcux_dev_config_##n = {	\
+	.base = (MII_Type *)DT_REG_ADDR(DT_PARENT(DT_DRV_INST(n))),				\
+	.protocol = DT_ENUM_IDX(DT_DRV_INST(n), protocol),		\
+};
+
+#define MDIO_MCUX_DEVICE(n)						\
+	MDIO_MCUX_CONFIG(n);						\
+	static struct mdio_mcux_dev_data mdio_mcux_dev_data##n;		\
+	DEVICE_DT_INST_DEFINE(n,					\
+			    &mdio_mcux_initialize,			\
+			    NULL,					\
+			    &mdio_mcux_dev_data##n,			\
+			    &mdio_mcux_dev_config_##n, POST_KERNEL,	\
+			    CONFIG_MDIO_INIT_PRIORITY,			\
+			    &mdio_mcux_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(MDIO_MCUX_DEVICE)

--- a/drivers/mdio/mdio_mcux.h
+++ b/drivers/mdio/mdio_mcux.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2021 Bernhard Kraemer
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_DRIVERS_MDIO_MCUX_H_
+#define ZEPHYR_INCLUDE_DRIVERS_MDIO_MCUX_H_
+
+#include <drivers/mdio.h>
+
+/**
+ * @brief      Signal Transfer Complete
+ *
+ * @param[in]  dev   Pointer to the device structure for the controller
+ *
+ */
+__syscall void mdio_mcux_transfer_complete(const struct device *dev);
+
+#include <syscalls/mdio_mcux.h>
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_MDIO_MCUX_H_ */

--- a/dts/arm/nxp/nxp_rt.dtsi
+++ b/dts/arm/nxp/nxp_rt.dtsi
@@ -527,6 +527,11 @@
 				interrupts = <115 0>;
 				interrupt-names = "IEEE1588_TMR";
 			};
+			mdio: mdio {
+				compatible = "nxp,kinetis-mdio";
+				label = "MDIO_0";
+				status = "disabled";
+			};
 		};
 
 		src: reset-controller@400f8000 {

--- a/dts/arm/nxp/nxp_rt1060.dtsi
+++ b/dts/arm/nxp/nxp_rt1060.dtsi
@@ -33,6 +33,11 @@
 				interrupts = <153 0>;
 				interrupt-names = "IEEE1588_TMR";
 			};
+			mdio2: mdio {
+			compatible = "nxp,kinetis-mdio";
+			label = "MDIO_1";
+			status = "disabled";
+			};
 		};
 	};
 };

--- a/dts/bindings/ethernet/ethernet-phy.yaml
+++ b/dts/bindings/ethernet/ethernet-phy.yaml
@@ -22,6 +22,9 @@ properties:
       type: boolean
       required: false
       description: Do not reset the PHY during initialization
+    late_mii_start:
+      type: boolean
+      description: Start MII communication when callback is registered (instead of init)
     fixed-link:
       type: string
       required: false

--- a/dts/bindings/mdio/nxp,kinetis-mdio.yaml
+++ b/dts/bindings/mdio/nxp,kinetis-mdio.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2021 Bernhard Kraemer
+# SPDX-License-Identifier: Apache-2.0
+
+description: NXP Kinetis Family MDIO Driver node
+
+compatible: "nxp,kinetis-mdio"
+
+include: mdio-controller.yaml
+
+properties:
+  reg:
+    required: false


### PR DESCRIPTION
This PR provides a solution to support ethernet on teensy4 board based on #34718. Also affects mcux ethernet driver, which must be adapted to work with new separate phy+mdio drivers.

The solution is working, but there are some points that need improvement:

**Solution structure**
Architecture is rather complex. NXP imx soc´s have the mdio bus integrated within the ethernet peripheral. Especially a flag within ethernet interrupt is used to signal successfull mii data transfer. Therefore the mii communication to phy must not start before ethernet module is initialized.

This determines the starting order:
- init MDIO driver
- init PHY driver (but prevent enabling mdio bus)
- init ETH_MCUX driver
- enable mdio bus and start communication by setting the ```phy_link_callback``` in ETH_MCUX driver.

The last step is causing ugly changes in the generic phy driver ```phy_mii.c```. Any ideas to avoid this would be welcome.

**MII interrupt flag**
The soc design prevents complete separation of mdio and eth driver. Since mii flag is part of the eth-interrupt, the mdio driver has no chance to know about successful transmission. This is currently solved by ```mdio_mcux_transfer_complete``` callback, which extends the mdio api. Any ideas to simplify?

**Devicetree structure**
Since (theoretically) there could be more than one phy attached to the mdio bus, the correct devicetree would look something like this:

```
&enet {
	status = "okay";
	ptp {
		status = "okay";
	};
	mdio {
		status = "okay";
		phy {
			compatible = "ethernet-phy";
			status = "okay";
			no-reset;
			late_mii_start;
			address = <0>;
		};

		phy { /* ... */ };
	};
};
```
Is there a way to achieve this? Haven't found it so far.

**Ethernet driver ```eth_mcux.c```**
This file is getting an '#ifdef hell'. Would it be a better solution to provide a separate driver file like ```eth_mcux_mdio.c``` instead? This new file would give the opportunity to further develop to an nxp-hal independent driver solution in the future.