### PR TITLE
doc: release: 2.7: Add release note for aarch32

### DIFF
--- a/doc/releases/release-notes-2.7.rst
+++ b/doc/releases/release-notes-2.7.rst
@@ -162,6 +162,7 @@ Architectures
      * Updated CMSIS version to 5.8.0
      * Added support for FPU in QEMU for Cortex-M, allowing to build and execute
        tests in CI with FPU and FPU_SHARING options enabled.
+     * Added MPU support for Cortex-R
 
 
   * AARCH64


### PR DESCRIPTION
Mention the addition of MPU support for Cortex-R.

Signed-off-by: Bradley Bolen <bbolen@lexmark.com>