### PR TITLE
tests/subsys/storage/flash_map: get flash device from flash area

### DIFF
--- a/tests/subsys/storage/flash_map/src/main.c
+++ b/tests/subsys/storage/flash_map/src/main.c
@@ -31,8 +31,7 @@ void test_flash_area_get_sectors(void)
 	zassert_true(rc == 0, "flash_area_open() fail");
 
 	/* First erase the area so it's ready for use. */
-	flash_dev =
-		device_get_binding(DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
+	flash_dev = flash_area_get_device(fa);
 
 	rc = flash_erase(flash_dev, fa->fa_off, fa->fa_size);
 	zassert_true(rc == 0, "flash area erase fail");


### PR DESCRIPTION
Get flash device from flash area instead of the hardcoded `DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL`. This makes the test possible to be ran on device that has `image_1` defined in external flash.