### PR TITLE
gen_app_partitions: add .sdata/.sbss section into app_smem

### DIFF
--- a/scripts/gen_app_partitions.py
+++ b/scripts/gen_app_partitions.py
@@ -56,7 +56,7 @@ data_template = """
 """
 
 library_data_template = """
-		*{0}:*(.data .data.*)
+		*{0}:*(.data .data.* .sdata .sdata.*)
 """
 
 bss_template = """
@@ -65,7 +65,7 @@ bss_template = """
 """
 
 library_bss_template = """
-		*{0}:*(.bss .bss.* COMMON COMMON.*)
+		*{0}:*(.bss .bss.* .sbss .sbss.* COMMON COMMON.*)
 """
 
 footer_template = """


### PR DESCRIPTION
Some architectures (e.g. RISC-V) has .sdata/.sbss section for small globals in .data/.bss. These globals in the library should also be placed into memory partition in userspace, so user thread could use the library.
(For example, newlib _impure_ptr (in .sdata) and __malloc_top_pad (in .sbss) symbols in RISC-V.)

This PR put globals in .sdata/.sbss section into memory partition in app_smem. It fixes `tests/lib/mem_alloc` and `tests/crypto/mbedtls/crypto.mbedtls` tests in qemu_riscv32 when userspace is enabled.

Before fix:
```
nm -n zephyr/zephyr.elf | grep -e _impure_ptr -e malloc_top -e z_libc_partition_part
80022000 D z_data_smem_z_libc_partition_part_start
80022800 D z_data_smem_z_libc_partition_part_end
8002295c B __malloc_top_pad
8002545c D _impure_ptr
```

After fix:
```
nm -n zephyr/zephyr.elf | grep -e _impure_ptr -e malloc_top -e z_libc_partition_part
80022000 D z_data_smem_z_libc_partition_part_start
80022290 D _impure_ptr
800226d8 D __malloc_top_pad
80022800 D z_data_smem_z_libc_partition_part_end
```

Fixes #39300

**Additional context**
Related to PR #39299