### PR TITLE
doc: release-notes-2.7: Added CAN release notes

### DIFF
--- a/doc/releases/release-notes-2.7.rst
+++ b/doc/releases/release-notes-2.7.rst
@@ -322,6 +322,8 @@ Drivers and Sensors
 
 * CAN
 
+  * Renesas R-Car driver added
+
 
 * Clock Control
 


### PR DESCRIPTION
This commit adds the CAN specific release-notes for the 2.7
release.