### PR TITLE
drivers: clock_control: nrf: Fix calibration dependencies

### DIFF
--- a/drivers/clock_control/CMakeLists.txt
+++ b/drivers/clock_control/CMakeLists.txt
@@ -17,9 +17,7 @@ zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_MCUX_SIM            clock_cont
 zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_MCUX_SYSCON         clock_control_mcux_syscon.c)
 zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_NPCX                clock_control_npcx.c)
 zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_NRF                 clock_control_nrf.c)
-if(CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC_CALIBRATION AND NOT CONFIG_CLOCK_CONTROL_NRF_FORCE_ALT)
-  zephyr_library_sources(nrf_clock_calibration.c)
-endif()
+zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_NRF_DRIVER_CALIBRATION nrf_clock_calibration.c)
 zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_RCAR_CPG_MSSR       clock_control_rcar_cpg_mssr.c)
 zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_RV32M1_PCC          clock_control_rv32m1_pcc.c)
 

--- a/drivers/clock_control/Kconfig.nrf
+++ b/drivers/clock_control/Kconfig.nrf
@@ -65,6 +65,13 @@ config CLOCK_CONTROL_NRF_K32SRC_RC_CALIBRATION
 
 if CLOCK_CONTROL_NRF_K32SRC_RC_CALIBRATION
 
+config CLOCK_CONTROL_NRF_DRIVER_CALIBRATION
+	bool
+	depends on !CLOCK_CONTROL_NRF_FORCE_ALT
+	default y
+	help
+	  Enabling indicates that calibration is perfomed by the clock control driver.
+
 config CLOCK_CONTROL_NRF_CALIBRATION_LF_ALWAYS_ON
 	bool "LF clock is always on"
 	default y if NRF_RTC_TIMER
@@ -101,6 +108,8 @@ config CLOCK_CONTROL_NRF_CALIBRATION_TEMP_DIFF
 	  Calibration is triggered if the temperature has changed by at least
 	  this amount since the last calibration.
 
+if CLOCK_CONTROL_NRF_DRIVER_CALIBRATION
+
 config CLOCK_CONTROL_NRF_CALIBRATION_DEBUG
 	bool "Calibration instrumentation"
 	help
@@ -115,6 +124,7 @@ config CLOCK_CONTROL_NRF_USES_TEMP_SENSOR
 	select TEMP_NRF5
 	select SENSOR
 
+endif # CLOCK_CONTROL_NRF_DRIVER_CALIBRATION
 endif # CLOCK_CONTROL_NRF_K32SRC_RC_CALIBRATION
 
 choice CLOCK_CONTROL_NRF_ACCURACY_PPM

--- a/drivers/clock_control/clock_control_nrf.c
+++ b/drivers/clock_control/clock_control_nrf.c
@@ -211,8 +211,7 @@ static void lfclk_start(void)
 
 static void lfclk_stop(void)
 {
-	if (IS_ENABLED(CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC_CALIBRATION) &&
-	    !IS_ENABLED(CONFIG_CLOCK_CONTROL_NRF_FORCE_ALT)) {
+	if (IS_ENABLED(CONFIG_CLOCK_CONTROL_NRF_DRIVER_CALIBRATION)) {
 		z_nrf_clock_calibration_lfclk_stopped();
 	}
 
@@ -599,15 +598,13 @@ static void clock_event_handler(nrfx_clock_evt_type_t event)
 		break;
 #endif
 	case NRFX_CLOCK_EVT_LFCLK_STARTED:
-		if (IS_ENABLED(CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC_CALIBRATION) &&
-		    !IS_ENABLED(CONFIG_CLOCK_CONTROL_NRF_FORCE_ALT)) {
+		if (IS_ENABLED(CONFIG_CLOCK_CONTROL_NRF_DRIVER_CALIBRATION)) {
 			z_nrf_clock_calibration_lfclk_started();
 		}
 		clkstarted_handle(dev, CLOCK_CONTROL_NRF_TYPE_LFCLK);
 		break;
 	case NRFX_CLOCK_EVT_CAL_DONE:
-		if (IS_ENABLED(CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC_CALIBRATION) &&
-		    !IS_ENABLED(CONFIG_CLOCK_CONTROL_NRF_FORCE_ALT)) {
+		if (IS_ENABLED(CONFIG_CLOCK_CONTROL_NRF_DRIVER_CALIBRATION)) {
 			z_nrf_clock_calibration_done_handler();
 		} else {
 			/* Should not happen when calibration is disabled. */
@@ -660,8 +657,7 @@ static int clk_init(const struct device *dev)
 
 	hfclkaudio_init();
 
-	if (IS_ENABLED(CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC_CALIBRATION) &&
-	    !IS_ENABLED(CONFIG_CLOCK_CONTROL_NRF_FORCE_ALT)) {
+	if (IS_ENABLED(CONFIG_CLOCK_CONTROL_NRF_DRIVER_CALIBRATION)) {
 		struct nrf_clock_control_data *data = dev->data;
 
 		z_nrf_clock_calibration_init(data->mgr);


### PR DESCRIPTION
When CLOCK_CONTROL_NRF_FORCE_ALT is enabled then calibration is
performed outside of the driver. In that case certain Kconfig
options where present which were dedicated for case when calibration
is performed by the driver. Side effects of those options lead to
conflicts when CLOCK_CONTROL_NRF_FORCE_ALT was enabled. Fixed
those conflicts by introducing Kconfig option which indicates
whether calibration is performed by the driver or not.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>