### PR TITLE
net: tcp: Fix referencing tcp connection in macro

### DIFF
--- a/subsys/net/ip/tcp2_priv.h
+++ b/subsys/net/ip/tcp2_priv.h
@@ -127,7 +127,7 @@
 		NET_DBG("conn: %p total=%zd, unacked_len=%d, "                 \
 			"send_win=%hu, mss=%hu",                               \
 			(_conn), net_pkt_get_len((_conn)->send_data),          \
-			conn->unacked_len, conn->send_win,                     \
+			_conn->unacked_len, _conn->send_win,                   \
 			(uint16_t)conn_mss((_conn)));                          \
 		NET_DBG("conn: %p send_data_timer=%hu, send_data_retries=%hu", \
 			(_conn),                                               \

--- a/subsys/net/ip/tcp2_priv.h
+++ b/subsys/net/ip/tcp2_priv.h
@@ -22,13 +22,13 @@
 
 #define tcp_slist(_conn, _slist, _op, _type, _link)			\
 ({									\
-	k_mutex_lock(&conn->lock, K_FOREVER);				\
+	k_mutex_lock(&_conn->lock, K_FOREVER);				\
 									\
 	sys_snode_t *_node = sys_slist_##_op(_slist);			\
 									\
 	_type * _x = _node ? CONTAINER_OF(_node, _type, _link) : NULL;	\
 									\
-	k_mutex_unlock(&conn->lock);					\
+	k_mutex_unlock(&_conn->lock);					\
 									\
 	_x;								\
 })

--- a/subsys/net/ip/tcp2_priv.h
+++ b/subsys/net/ip/tcp2_priv.h
@@ -167,14 +167,14 @@ struct tcphdr {
 } __packed;
 
 enum th_flags {
-	FIN = 1,
-	SYN = 1 << 1,
-	RST = 1 << 2,
-	PSH = 1 << 3,
-	ACK = 1 << 4,
-	URG = 1 << 5,
-	ECN = 1 << 6,
-	CWR = 1 << 7,
+	FIN = BIT(0),
+	SYN = BIT(1),
+	RST = BIT(2),
+	PSH = BIT(3),
+	ACK = BIT(4),
+	URG = BIT(5),
+	ECN = BIT(6),
+	CWR = BIT(7),
 };
 
 enum tcp_state {


### PR DESCRIPTION
Fixes error in referencing macro arguments, the crash is not happening since the general connection name `conn` is used.