### PR TITLE
Bluetooth: Controller: Fix extended advertising set remove

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 Nordic Semiconductor ASA
+ * Copyright (c) 2018-2021 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -289,6 +289,29 @@ int lll_adv_data_reset(struct lll_adv_pdu *pdu)
 	pdu->extra_data[0] = NULL;
 	pdu->extra_data[1] = NULL;
 #endif /* CONFIG_BT_CTLR_ADV_EXT_PDU_EXTRA_DATA_MEMORY */
+	return 0;
+}
+
+int lll_adv_data_dequeue(struct lll_adv_pdu *pdu)
+{
+	uint8_t first;
+	void *p;
+
+	first = pdu->first;
+	if (first == pdu->last) {
+		return -ENOMEM;
+	}
+
+	p = pdu->pdu[first];
+	pdu->pdu[first] = NULL;
+	mem_release(p, &mem_pdu.free);
+
+	first++;
+	if (first == DOUBLE_BUFFER_SIZE) {
+		first = 0U;
+	}
+	pdu->first = first;
+
 	return 0;
 }
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -411,11 +411,6 @@ struct pdu_adv *lll_adv_pdu_alloc_pdu_adv(void)
 }
 
 #if defined(CONFIG_BT_CTLR_ADV_PDU_LINK)
-void lll_adv_pdu_release(struct pdu_adv *pdu)
-{
-	mem_release(pdu, &mem_pdu.free);
-}
-
 void lll_adv_pdu_linked_release_all(struct pdu_adv *pdu_first)
 {
 	struct pdu_adv *pdu = pdu_first;
@@ -425,7 +420,7 @@ void lll_adv_pdu_linked_release_all(struct pdu_adv *pdu_first)
 
 		pdu_next = PDU_ADV_NEXT_PTR(pdu);
 		PDU_ADV_NEXT_PTR(pdu) = NULL;
-		lll_adv_pdu_release(pdu);
+		mem_release(pdu, &mem_pdu.free);
 		pdu = pdu_next;
 	}
 }

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_pdu.h
@@ -188,8 +188,6 @@ static inline void *lll_adv_sync_extra_data_curr_get(struct lll_adv_sync *lll)
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
 
 #if defined(CONFIG_BT_CTLR_ADV_PDU_LINK)
-/* Release single PDU, shall only be called from ULL */
-void lll_adv_pdu_release(struct pdu_adv *pdu);
 /* Release PDU and all linked PDUs, shall only be called from ULL */
 void lll_adv_pdu_linked_release_all(struct pdu_adv *pdu_first);
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_pdu.h
@@ -18,6 +18,7 @@
 
 int lll_adv_data_init(struct lll_adv_pdu *pdu);
 int lll_adv_data_reset(struct lll_adv_pdu *pdu);
+int lll_adv_data_dequeue(struct lll_adv_pdu *pdu);
 int lll_adv_data_release(struct lll_adv_pdu *pdu);
 
 static inline void lll_adv_pdu_enqueue(struct lll_adv_pdu *pdu, uint8_t idx)

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -342,6 +342,7 @@ uint8_t ll_adv_aux_set_remove(uint8_t handle)
 {
 	struct ll_adv_set *adv;
 	struct lll_adv *lll;
+	int err;
 
 	/* Get the advertising set instance */
 	adv = ull_adv_is_created_get(handle);
@@ -389,6 +390,26 @@ uint8_t ll_adv_aux_set_remove(uint8_t handle)
 		lll->aux = NULL;
 
 		ull_adv_aux_release(aux);
+	}
+
+	/* Release any allocated advertising data double buffers and
+	 * initialize with one initial buffer.
+	 */
+	lll_adv_data_release(&adv->lll.adv_data);
+	lll_adv_data_reset(&adv->lll.adv_data);
+	err = lll_adv_data_init(&adv->lll.adv_data);
+	if (err) {
+		return BT_HCI_ERR_CMD_DISALLOWED;
+	}
+
+	/* Release any allocated scan response double buffers and
+	 * initialize with one initial buffer.
+	 */
+	lll_adv_data_release(&adv->lll.scan_rsp);
+	lll_adv_data_reset(&adv->lll.scan_rsp);
+	err = lll_adv_data_init(&adv->lll.scan_rsp);
+	if (err) {
+		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
 
 	adv->is_created = 0;


### PR DESCRIPTION
Fix extended advertising set remove and clear, to reset the
PDU double buffer to keep one initialized PDU. This is done
to prevent common extended payload format contents from
being overwritten and corrupted due to same primary PDU
buffer being used to remove AdvA if auxiliary PDU is
allocated.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>