### PR TITLE
west.yml: esp32: wpa_supplicant update due to mbedtls 3.0.0

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -62,7 +62,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 8265fef8d88746c3ebb1a3c28917f2762bdecfe8
+      revision: 2308568ea25817f1fa61cc218b3693cc87949c57
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
Espressif wpa_supplicant depends on mbedtls. Due to latest
update to 3.0.0, a few updates were needed to be compliant
with api changes.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>