### PR TITLE
modules: loramac-node: Fix the build issue for US915 and AU915 regions

### DIFF
--- a/modules/loramac-node/CMakeLists.txt
+++ b/modules/loramac-node/CMakeLists.txt
@@ -61,6 +61,7 @@ zephyr_library_sources_ifdef(CONFIG_LORAMAC_REGION_EU868
   ${ZEPHYR_LORAMAC_NODE_MODULE_DIR}/src/mac/region/RegionEU868.c
 )
 zephyr_library_sources_ifdef(CONFIG_LORAMAC_REGION_US915
+  ${ZEPHYR_LORAMAC_NODE_MODULE_DIR}/src/mac/region/RegionBaseUS.c
   ${ZEPHYR_LORAMAC_NODE_MODULE_DIR}/src/mac/region/RegionUS915.c
 )
 zephyr_library_sources_ifdef(CONFIG_LORAMAC_REGION_CN779
@@ -70,6 +71,7 @@ zephyr_library_sources_ifdef(CONFIG_LORAMAC_REGION_EU433
   ${ZEPHYR_LORAMAC_NODE_MODULE_DIR}/src/mac/region/RegionEU433.c
 )
 zephyr_library_sources_ifdef(CONFIG_LORAMAC_REGION_AU915
+  ${ZEPHYR_LORAMAC_NODE_MODULE_DIR}/src/mac/region/RegionBaseUS.c
   ${ZEPHYR_LORAMAC_NODE_MODULE_DIR}/src/mac/region/RegionAU915.c
 )
 zephyr_library_sources_ifdef(CONFIG_LORAMAC_REGION_AS923


### PR DESCRIPTION
These 2 regions depends on the RegionBaseUS.c file.

Fixes: #39297

Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>