### PR TITLE
mgmt/mcumgr: Fix UART processing of TX frames

### DIFF
--- a/subsys/mgmt/mcumgr/serial_util.c
+++ b/subsys/mgmt/mcumgr/serial_util.c
@@ -306,26 +306,22 @@ int mcumgr_serial_tx_pkt(const uint8_t *data, int len, mcumgr_serial_tx_cb cb,
 			 void *arg)
 {
 	uint16_t crc;
-	int data_bytes_txed;
-	int src_off;
+	int data_bytes_txed = 0;
 	int rc;
 
 	/* Calculate CRC of entire packet. */
 	crc = mcumgr_serial_calc_crc(data, len);
 
 	/* Transmit packet as a sequence of frames. */
-	src_off = 0;
-	while (src_off < len) {
-		rc = mcumgr_serial_tx_frame(data + src_off,
-					    src_off == 0,
-					    len - src_off,
-					    crc, cb, arg,
+	while (len) {
+		rc = mcumgr_serial_tx_frame(data, data_bytes_txed == 0, len, crc, cb, arg,
 					    &data_bytes_txed);
 		if (rc != 0) {
 			return rc;
 		}
 
-		src_off += data_bytes_txed;
+		data += data_bytes_txed;
+		len -= data_bytes_txed;
 	}
 
 	return 0;

--- a/subsys/mgmt/mcumgr/serial_util.c
+++ b/subsys/mgmt/mcumgr/serial_util.c
@@ -1,5 +1,6 @@
 /*
  * Copyright Runtime.io 2018. All rights reserved.
+ * Copyright (c) 2021 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -196,17 +197,25 @@ int mcumgr_serial_tx_frame(const uint8_t *data, bool first, int len,
 {
 	uint8_t raw[3];
 	uint16_t u16;
-	int dst_off;
-	int src_off;
-	int rem;
-	int rc;
+	int src_off = 0;
+	int rc = 0;
+	int to_process;
+	bool last = false;
+	int reminder;
 
-	src_off = 0;
-	dst_off = 0;
+	/*
+	 * This is max input bytes that can be taken to the frame before encoding with Base64;
+	 * Base64 has three-to-four ratio, which means that for each three input bytes there are
+	 * going to be four bytes of output used.  The frame starts with two byte marker and ends
+	 * with newline character, which are not encoded (this is the "-3" in calculation).
+	 */
+	int max_input = (((MCUMGR_SERIAL_MAX_FRAME - 3) >> 2) * 3);
 
 	if (first) {
+		/* First frame marker */
 		u16 = sys_cpu_to_be16(MCUMGR_SERIAL_HDR_PKT);
 	} else {
+		/* Continuation frame marker */
 		u16 = sys_cpu_to_be16(MCUMGR_SERIAL_HDR_FRAG);
 	}
 
@@ -214,9 +223,11 @@ int mcumgr_serial_tx_frame(const uint8_t *data, bool first, int len,
 	if (rc != 0) {
 		return rc;
 	}
-	dst_off += 2;
 
-	/* Only the first fragment contains the packet length. */
+	/*
+	 * Only the first fragment contains the packet length; the packet length, which is two
+	 * byte long is paired with first byte of input buffer to form triplet for Base64 encoding.
+	 */
 	if (first) {
 		u16 = sys_cpu_to_be16(len);
 		memcpy(raw, &u16, sizeof(u16));
@@ -227,47 +238,65 @@ int mcumgr_serial_tx_frame(const uint8_t *data, bool first, int len,
 			return rc;
 		}
 
-		src_off++;
-		dst_off += 4;
+		++src_off;
+		/* One triple of allowed input already used */
+		max_input -= 3;
 	}
 
-	while (1) {
-		if (dst_off >= MCUMGR_SERIAL_MAX_FRAME - 4) {
-			/* Can't fit any more data in this frame. */
-			break;
-		}
+	/*
+	 * Only as much as fits into the frame can be processed, but we also need to fit in the
+	 * two byte CRC.  The frame can not be stretched and current logic does not allow to
+	 * send CRC separately so if CRC would not fit as a whole, shrink to_process by one byte
+	 * forcing one byte to the next frame, with the CRC.
+	 */
+	to_process = MIN(max_input, len - src_off);
+	reminder = max_input - (len - src_off);
 
-		/* If we have reached the end of the packet, we need to encode
-		 * and send the CRC.
+	if (reminder == 0 || reminder == 1) {
+		to_process -= 1;
+	} else if (reminder >= 2) {
+		last = true;
+	}
+
+	/*
+	 * Try to process input buffer by chunks of three bytes that will be output as four byte
+	 * chunks, due to Base64 encoding; the number of chunks that can be processed is calculated
+	 * from number of three byte, complete, chunks in input buffer,  but can not be greater
+	 * than the number of four byte, complete, chunks that the frame can accept.
+	 */
+	while (to_process >= 3) {
+		memcpy(raw, data + src_off, 3);
+		rc = mcumgr_serial_tx_small(raw, 3, cb, arg);
+		if (rc != 0) {
+			return rc;
+		}
+		src_off += 3;
+		to_process -= 3;
+	}
+
+	if (last) {
+		/*
+		 * Process the reminder bytes of the input buffer, after sending it in three byte
+		 * chunks, and CRC.
 		 */
-		rem = len - src_off;
-		if (rem == 0) {
+		switch (len - src_off) {
+		case 0:
 			raw[0] = (crc & 0xff00) >> 8;
 			raw[1] = crc & 0x00ff;
 			rc = mcumgr_serial_tx_small(raw, 2, cb, arg);
-			if (rc != 0) {
-				return rc;
-			}
 			break;
-		}
 
-		if (rem == 1) {
-			raw[0] = data[src_off];
-			src_off++;
+		case 1:
+			raw[0] = data[src_off++];
 
 			raw[1] = (crc & 0xff00) >> 8;
 			raw[2] = crc & 0x00ff;
 			rc = mcumgr_serial_tx_small(raw, 3, cb, arg);
-			if (rc != 0) {
-				return rc;
-			}
 			break;
-		}
 
-		if (rem == 2) {
-			raw[0] = data[src_off];
-			raw[1] = data[src_off + 1];
-			src_off += 2;
+		case 2:
+			raw[0] = data[src_off++];
+			raw[1] = data[src_off++];
 
 			raw[2] = (crc & 0xff00) >> 8;
 			rc = mcumgr_serial_tx_small(raw, 3, cb, arg);
@@ -277,20 +306,12 @@ int mcumgr_serial_tx_frame(const uint8_t *data, bool first, int len,
 
 			raw[0] = crc & 0x00ff;
 			rc = mcumgr_serial_tx_small(raw, 1, cb, arg);
-			if (rc != 0) {
-				return rc;
-			}
 			break;
 		}
 
-		/* Otherwise, just encode payload data. */
-		memcpy(raw, data + src_off, 3);
-		rc = mcumgr_serial_tx_small(raw, 3, cb, arg);
 		if (rc != 0) {
 			return rc;
 		}
-		src_off += 3;
-		dst_off += 4;
 	}
 
 	rc = cb("\n", 1, arg);


### PR DESCRIPTION
The commit fixes problem with UART TX frame processing, which was
caused by incorrect output buffer size evaulation, where input buffer
of certain len would cause entire output frame to be filled with no
place left for CRC causing a transmission to hang.
The commit, additionally, moves input buffer reminder processing out of
the input buffer processing loop.

Fixes #37893

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>