### PR TITLE
soc: nrf52: Add Kconfig option for enabling REG0 DC/DC converter

### DIFF
--- a/boards/arm/nrf52840dk_nrf52840/Kconfig
+++ b/boards/arm/nrf52840dk_nrf52840/Kconfig
@@ -3,8 +3,16 @@
 # Copyright (c) 2016 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+if BOARD_NRF52840DK_NRF52840
+
 config BOARD_ENABLE_DCDC
 	bool "Enable DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
-	depends on BOARD_NRF52840DK_NRF52840
+
+config BOARD_ENABLE_DCDC_HV
+	bool "Enable High Voltage DCDC converter"
+	select SOC_DCDC_NRF52X_HV
+	default y
+
+endif # BOARD_NRF52840DK_NRF52840

--- a/boards/arm/nrf52840dongle_nrf52840/Kconfig
+++ b/boards/arm/nrf52840dongle_nrf52840/Kconfig
@@ -10,6 +10,11 @@ config BOARD_ENABLE_DCDC
 	select SOC_DCDC_NRF52X
 	default y
 
+config BOARD_ENABLE_DCDC_HV
+	bool "Enable High Voltage DCDC converter"
+	select SOC_DCDC_NRF52X_HV
+	default y
+
 config BOARD_HAS_NRF5_BOOTLOADER
 	bool "Board has nRF5 bootloader"
 	default y

--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -1932,7 +1932,8 @@ static int usb_init(const struct device *arg)
 		.dcdcen = IS_ENABLED(CONFIG_SOC_DCDC_NRF52X) ||
 			  IS_ENABLED(CONFIG_SOC_DCDC_NRF53X_APP),
 #if NRFX_POWER_SUPPORTS_DCDCEN_VDDH
-		.dcdcenhv = IS_ENABLED(CONFIG_SOC_DCDC_NRF53X_HV),
+		.dcdcenhv = IS_ENABLED(CONFIG_SOC_DCDC_NRF52X_HV) ||
+			    IS_ENABLED(CONFIG_SOC_DCDC_NRF53X_HV),
 #endif
 	};
 

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.soc
@@ -459,6 +459,12 @@ config SOC_DCDC_NRF52X
 	help
 	  Enable nRF52 series System on Chip DC/DC converter.
 
+config SOC_DCDC_NRF52X_HV
+	bool
+	depends on SOC_NRF52840
+	help
+	  Enable nRF52 series System on Chip High Voltage DC/DC converter.
+
 config GPIO_AS_PINRESET
 	bool "GPIO as pin reset (reset button)"
 	depends on SOC_SERIES_NRF52X

--- a/soc/arm/nordic_nrf/nrf52/soc.c
+++ b/soc/arm/nordic_nrf/nrf52/soc.c
@@ -71,6 +71,9 @@ static int nordicsemi_nrf52_init(const struct device *arg)
 #if defined(CONFIG_SOC_DCDC_NRF52X)
 	nrf_power_dcdcen_set(NRF_POWER, true);
 #endif
+#if NRF_POWER_HAS_DCDCEN_VDDH && defined(CONFIG_SOC_DCDC_NRF52X_HV)
+	nrf_power_dcdcen_vddh_set(NRF_POWER, true);
+#endif
 
 	/* Install default handler that simply resets the CPU
 	* if configured in the kernel, NOP otherwise


### PR DESCRIPTION
Add a Kconfig option, similar to the one that is already available
for nRF5340, that allows enabling the REG0 (VDDH) DC/DC converter
in nRF52840. Make use of this option in Nordic boards: nRF52840 DK
and nRF52840 Dongle.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>