### PR TITLE
drivers: ti: cc13xx/cc26xx watchdog timer support

### DIFF
--- a/drivers/watchdog/CMakeLists.txt
+++ b/drivers/watchdog/CMakeLists.txt
@@ -8,6 +8,7 @@ zephyr_library_sources_ifdef(CONFIG_WWDG_STM32 wdt_wwdg_stm32.c)
 zephyr_library_sources_ifdef(CONFIG_WDOG_CMSDK_APB wdt_cmsdk_apb.c)
 
 zephyr_library_sources_ifdef(CONFIG_WDT_CC32XX wdt_cc32xx.c)
+zephyr_library_sources_ifdef(CONFIG_WDT_CC13XX_CC26XX wdt_cc13xx_cc26xx.c)
 zephyr_library_sources_ifdef(CONFIG_WDT_ESP32 wdt_esp32.c)
 zephyr_library_sources_ifdef(CONFIG_WDT_GECKO wdt_gecko.c)
 zephyr_library_sources_ifdef(CONFIG_WDT_ITE_IT8XXX2 wdt_ite_it8xxx2.c)

--- a/drivers/watchdog/Kconfig
+++ b/drivers/watchdog/Kconfig
@@ -82,5 +82,7 @@ source "drivers/watchdog/Kconfig.npcx"
 
 source "drivers/watchdog/Kconfig.cc32xx"
 
+source "drivers/watchdog/Kconfig.cc13xx_cc26xx"
+
 source "drivers/watchdog/Kconfig.it8xxx2"
 endif

--- a/drivers/watchdog/Kconfig.cc13xx_cc26xx
+++ b/drivers/watchdog/Kconfig.cc13xx_cc26xx
@@ -1,0 +1,21 @@
+# Copyright (c) 2021 Florin Stancu <niflostancu@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+DT_COMPAT_TI_CC13XX_CC26XX_WDG := ti,cc13xx-cc26xx-watchdog
+
+config WDT_CC13XX_CC26XX
+	bool "Watchdog Driver for CC13xx / CC26xx family of MCUs"
+	default $(dt_compat_enabled,$(DT_COMPAT_TI_CC13XX_CC26XX_WDG))
+	depends on SOC_SERIES_CC13X2_CC26X2
+	depends on SOC_FAMILY_TISIMPLELINK
+	help
+	  Enable watchdog for CC13xx / CC26xx family of MCUs
+
+config WDT_CC13XX_CC26XX_INITIAL_TIMEOUT
+	int "Value for WDT timeout in ms"
+	depends on WDT_CC13XX_CC26XX
+	default 2000
+	range 1 2863311
+	help
+	  Max value depends on system frequency (WDT uses fixed 32 scaler).
+	  48 Mhz: 0xFFFFFFFF / (48^9 / 32 / 1000) ms

--- a/drivers/watchdog/wdt_cc13xx_cc26xx.c
+++ b/drivers/watchdog/wdt_cc13xx_cc26xx.c
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2021 Florin Stancu <niflostancu@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT ti_cc13xx_cc26xx_watchdog
+
+#include <drivers/watchdog.h>
+#include <soc.h>
+#include <errno.h>
+
+#define LOG_LEVEL CONFIG_WDT_LOG_LEVEL
+#include <logging/log.h>
+#include <logging/log_ctrl.h>
+LOG_MODULE_REGISTER(wdt_cc13xx_cc26xx);
+
+/* Driverlib includes */
+#include <inc/hw_types.h>
+#include <inc/hw_wdt.h>
+#include <driverlib/rom.h>
+#include <driverlib/prcm.h>
+#include <driverlib/watchdog.h>
+
+#define CPU_FREQ DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency)
+
+#define WDT_INST_IDX            0
+#define MAX_RELOAD_VALUE        0xFFFFFFFF
+#define WATCHDOG_DIV_RATIO      32            /* Watchdog division ratio */
+
+struct wdt_cc13xx_cc26xx_data {
+	uint32_t reload;
+	wdt_callback_t cb;
+	uint8_t flags;
+} wdt_cc13xx_cc26xx_data = {
+	.reload = CONFIG_WDT_CC13XX_CC26XX_INITIAL_TIMEOUT,
+	.cb = NULL,
+	.flags = 0,
+};
+
+struct wdt_cc13xx_cc26xx_cfg {
+	const unsigned long reg; /* note: unused */
+} wdt_cc13xx_cc26xx_cfg = {
+	.reg = (unsigned long)DT_INST_REG_ADDR(WDT_INST_IDX),
+};
+
+static uint32_t wdt_cc13xx_cc26xx_msToTicks(uint32_t ms)
+{
+	const uint32_t ratio = CPU_FREQ / WATCHDOG_DIV_RATIO / 1000;
+	const uint32_t maxMs = MAX_RELOAD_VALUE / ratio;
+
+	if (ms > maxMs) {
+		return maxMs;
+	}
+
+	return ms * ratio;
+}
+
+static int wdt_cc13xx_cc26xx_enable(const struct device *dev)
+{
+	struct wdt_cc13xx_cc26xx_data *data = dev->data;
+	const uint32_t reload = wdt_cc13xx_cc26xx_msToTicks(data->reload);
+
+	WatchdogIntClear();
+	WatchdogReloadSet(reload);
+
+	switch ((data->flags & WDT_FLAG_RESET_MASK)) {
+	case WDT_FLAG_RESET_CPU_CORE:
+	case WDT_FLAG_RESET_SOC:
+		LOG_DBG("reset enabled");
+		WatchdogResetEnable();
+		break;
+	case WDT_FLAG_RESET_NONE:
+		LOG_DBG("reset disabled");
+		WatchdogResetDisable();
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	WatchdogEnable();
+	LOG_DBG("Enabled");
+	return 0;
+}
+
+static int wdt_cc13xx_cc26xx_setup(const struct device *dev, uint8_t options)
+{
+	int rv;
+
+	if (options & WDT_OPT_PAUSE_IN_SLEEP) {
+		return -ENOTSUP;
+	}
+
+	WatchdogUnlock();
+	if (options & WDT_OPT_PAUSE_HALTED_BY_DBG) {
+		WatchdogStallEnable();
+	} else {
+		WatchdogStallDisable();
+	}
+	rv = wdt_cc13xx_cc26xx_enable(dev);
+	WatchdogLock();
+	return rv;
+}
+
+static int wdt_cc13xx_cc26xx_disable(const struct device *dev)
+{
+	return -ENOTSUP;
+}
+
+static int wdt_cc13xx_cc26xx_install_timeout(const struct device *dev,
+				      const struct wdt_timeout_cfg *cfg)
+{
+	struct wdt_cc13xx_cc26xx_data *data = dev->data;
+
+	if (cfg->window.min != 0U || cfg->window.max == 0U) {
+		return -EINVAL;
+	}
+	if (COND_CODE_1(CONFIG_WDT_MULTISTAGE, (cfg->next), (0))) {
+		return -ENOTSUP;
+	}
+
+	data->reload = cfg->window.max;
+	data->cb = cfg->callback;
+	data->flags = cfg->flags;
+	LOG_DBG("Reload time %d", data->reload);
+	return 0;
+}
+
+static int wdt_cc13xx_cc26xx_feed(const struct device *dev, int channel_id)
+{
+	struct wdt_cc13xx_cc26xx_data *data = dev->data;
+	const uint32_t reload = wdt_cc13xx_cc26xx_msToTicks(data->reload);
+	bool inIsr = k_is_in_isr();
+
+	if (!inIsr) {
+		WatchdogUnlock();
+	}
+	WatchdogIntClear();
+	WatchdogReloadSet(reload);
+	if (!inIsr) {
+		WatchdogLock();
+	}
+	LOG_DBG("Feed %i", reload);
+	return 0;
+}
+
+static void wdt_cc13xx_cc26xx_isr(const struct device *dev)
+{
+	struct wdt_cc13xx_cc26xx_data *data = dev->data;
+
+	LOG_DBG("ISR");
+	if (data->cb) {
+		data->cb(dev, 0);
+	}
+}
+
+static int wdt_cc13xx_cc26xx_init(const struct device *dev)
+{
+	int rv;
+
+	LOG_DBG("init");
+	IRQ_CONNECT(DT_INST_IRQN(WDT_INST_IDX), DT_INST_IRQ(WDT_INST_IDX, priority),
+			wdt_cc13xx_cc26xx_isr, DEVICE_DT_INST_GET(WDT_INST_IDX), 0);
+	irq_enable(DT_INST_IRQN(WDT_INST_IDX));
+
+	if (IS_ENABLED(CONFIG_WDT_DISABLE_AT_BOOT)) {
+		return 0;
+	}
+
+	WatchdogUnlock();
+	rv = wdt_cc13xx_cc26xx_enable(dev);
+	WatchdogLock();
+	return rv;
+}
+
+static const struct wdt_driver_api wdt_cc13xx_cc26xx_api = {
+	.setup = wdt_cc13xx_cc26xx_setup,
+	.disable = wdt_cc13xx_cc26xx_disable,
+	.install_timeout = wdt_cc13xx_cc26xx_install_timeout,
+	.feed = wdt_cc13xx_cc26xx_feed,
+};
+
+#if DT_NODE_HAS_STATUS(DT_DRV_INST(WDT_INST_IDX), okay)
+DEVICE_DT_INST_DEFINE(WDT_INST_IDX,
+			wdt_cc13xx_cc26xx_init, NULL,
+			&wdt_cc13xx_cc26xx_data, &wdt_cc13xx_cc26xx_cfg,
+			POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+			&wdt_cc13xx_cc26xx_api);
+#endif

--- a/dts/arm/ti/cc13x2_cc26x2.dtsi
+++ b/dts/arm/ti/cc13x2_cc26x2.dtsi
@@ -8,6 +8,12 @@
 #include <dt-bindings/i2c/i2c.h>
 #include <dt-bindings/gpio/gpio.h>
 
+#define INT_WDT    30          // Watchdog Timer
+
+/* Note: Zephyr uses exception numbers, vs the IRQ #s used by the TI SDK */
+/* which are offset by 16: */
+#define EXP_WDT    (INT_WDT - 16)
+
 / {
 	chosen {
 		zephyr,entropy = &trng;
@@ -124,6 +130,14 @@
 			interrupts = <4 0>;  /* interrupt #20 = 4 + 16 */
 			status = "disabled";
 			label = "RTC";
+		};
+
+		wdt0: watchdog@40080000 {
+			compatible = "ti,cc13xx-cc26xx-watchdog";
+			reg = <0x40080000 0x1000>;
+			interrupts = <EXP_WDT 0>;
+			label = "WDT_0";
+			status = "disabled";
 		};
 	};
 };

--- a/dts/bindings/watchdog/ti,cc13xx-cc26xx-watchdog.yaml
+++ b/dts/bindings/watchdog/ti,cc13xx-cc26xx-watchdog.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2021 Florin Stancu <niflostancu@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+description: CC13xx / CC26xx watchdog
+
+compatible: "ti,cc13xx-cc26xx-watchdog"
+
+include: base.yaml
+
+properties:
+    reg:
+      required: true
+
+    label:
+      required: true

--- a/samples/drivers/watchdog/boards/cc1352p1_launchxl.overlay
+++ b/samples/drivers/watchdog/boards/cc1352p1_launchxl.overlay
@@ -1,0 +1,3 @@
+&wdt0 {
+	status = "okay";
+};

--- a/samples/drivers/watchdog/boards/cc1352r1_launchxl.overlay
+++ b/samples/drivers/watchdog/boards/cc1352r1_launchxl.overlay
@@ -1,0 +1,3 @@
+&wdt0 {
+	status = "okay";
+};

--- a/samples/drivers/watchdog/src/main.c
+++ b/samples/drivers/watchdog/src/main.c
@@ -43,6 +43,8 @@
 #define WDT_NODE DT_INST(0, microchip_xec_watchdog)
 #elif DT_HAS_COMPAT_STATUS_OKAY(ti_cc32xx_watchdog)
 #define WDT_NODE DT_INST(0, ti_cc32xx_watchdog)
+#elif DT_HAS_COMPAT_STATUS_OKAY(ti_cc13xx_cc26xx_watchdog)
+#define WDT_NODE DT_INST(0, ti_cc13xx_cc26xx_watchdog)
 #elif DT_HAS_COMPAT_STATUS_OKAY(nxp_imx_wdog)
 #define WDT_NODE DT_INST(0, nxp_imx_wdog)
 #endif


### PR DESCRIPTION
Implemented new WDT driver for TI CC13xx/CC26xx family using HAL TI routines.
Supports interrupts & MCU soft reset on timeout.

Code was based on Zephyr's CC32XX driver, but the HAL SDK functions don't take a register parameter (so I removed multiple instances support) + this watchdog supports auto-reset.

Fixes #39331

Tested on CC1352R1 LaunchXL using `samples/drivers/watchdog`.
```txt
*** Booting Zephyr OS build v2.7.0-rc2-42-g26fa469e60ed  ***
Watchdog sample application
Attempting to test pre-reset callback
Feeding watchdog 5 times
Feeding watchdog...
[00:00:00.000,030] <dbg> wdt_cc13xx_cc26xx.wdt_cc13xx_cc26xx_init: init
[00:00:00.000,030] <dbg> wdt_cc13xx_cc26xx.wdt_cc13xx_cc26xx_enable: reset disabled
[00:00:00.000,061] <dbg> wdt_cc13xx_cc26xx.wdt_cc13xx_cc26xx_enable: Enabled
[00:00:00.011,291] <dbg> wdt_cc13xx_cc26xx.wdt_cc13xx_cc26xx_install_timeout: Reload time 1000
[00:00:00.011,291] <dbg> wdt_cc13xx_cc26xx.wdt_cc13xx_cc26xx_enable: reset enabled
[00:00:00.011,291] <dbg> wdt_cc13xx_cc26xx.wdt_cc13xx_cc26xx_enable: EnabledFeeding watchdog...

[00:00:00.015,502] <dbg> wdt_cc13xx_cc26xx.wdt_cc13xx_cc26xx_feed: Feed 1500000
[00:00:00.067,474] <dbg> wdt_cc13xx_cc26xx.wdt_cc13xx_cc26xx_feed: Feed 1500000
Feeding watchdog...
Feeding watchdog...
Feeding watchdog...
Waiting for reset...
Handled things..ready to reset
*** Booting Zephyr OS build v2.7.0-rc2-42-g26fa469e60ed  ***
... then here we go again
```