### PR TITLE
net: if: Fix parameter in NET_DEVICE_DT_DEFINE_INSTANCE

### DIFF
--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -2391,13 +2391,14 @@ struct net_if_api {
  * @param l2_ctx_type Type of L2 context data.
  * @param mtu Maximum transfer unit in bytes for this network interface.
  */
-#define NET_DEVICE_DT_DEFINE_INSTANCE(node_id, instance, init_fn,		\
-				    pm_control_fn, data, cfg, prio,	\
-				    api, l2, l2_ctx_type, mtu)		\
-	Z_NET_DEVICE_INIT_INSTANCE(node_id, node_id, DT_LABEL(node_id),	\
-				   instance, init_fn, pm_control_fn,	\
-				   data, cfg, prio, api, l2,		\
-				   l2_ctx_type, mtu)
+#define NET_DEVICE_DT_DEFINE_INSTANCE(node_id, instance, init_fn,	\
+				      pm_control_fn, data, cfg, prio,	\
+				      api, l2, l2_ctx_type, mtu)	\
+	Z_NET_DEVICE_INIT_INSTANCE(node_id,				\
+				   Z_DEVICE_DT_DEV_NAME(node_id),	\
+				   DT_LABEL(node_id), instance,		\
+				   pm_control_fn, data, cfg, prio, api,	\
+				   l2, l2_ctx_type, mtu)
 
 /**
  * @def NET_DEVICE_DT_INST_DEFINE_INSTANCE


### PR DESCRIPTION
The NET_DEVICE_DT_DEFINE_INSTANCE() macro was passing an invalid
dev_name to Z_NET_DEVICE_INIT_INSTANCE(). Change this parameter to get
device name based on the node_id, matching other macros.

Signed-off-by: Keith Short <keithshort@google.com>