### PR TITLE
doc: bluetooth: List BLE controller HW requirements

### DIFF
--- a/arch/arm/core/aarch32/irq_manage.c
+++ b/arch/arm/core/aarch32/irq_manage.c
@@ -165,7 +165,7 @@ void _arch_isr_direct_pm(void)
 	|| defined(CONFIG_ARMV7_R)
 	unsigned int key;
 
-	/* irq_lock() does what we wan for this CPU */
+	/* irq_lock() does what we want for this CPU */
 	key = irq_lock();
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
 	/* Lock all interrupts. irq_lock() will on this CPU only disable those

--- a/doc/guides/bluetooth/bluetooth-arch.rst
+++ b/doc/guides/bluetooth/bluetooth-arch.rst
@@ -405,6 +405,93 @@ bt_enable() API).
 Bluetooth Low Energy Controller
 *******************************
 
+Hardware Requirements
+=====================
+
+The Bluetooth Low Energy Controller implementation requires the following hardware
+peripherals.
+
+#. Clock
+
+   * A Low Frequency Clock (LFCLOCK) or sleep clock, for low power consumption
+     between Bluetooth radio events
+   * A High Frequency Clock (HFCLOCK) or active clock, for high precision
+     packet timing and software based transceiver state switching with
+     inter-frame space (tIFS) timing inside Bluetooth radio events
+
+#. Real Time Counter (RTC)
+
+   * 1 instance
+   * 2 capture/compare registers
+
+#. Timer
+
+   * 2 instances, one each for packet timing and tIFS software switching,
+     respectively
+   * 7 capture/compare registers (3 mandatory, 1 optional for ISR profiling, 4
+     for single timer tIFS switching) on first instance
+   * 4 capture/compare registers for second instance, if single tIFS timer is
+     not used.
+
+#. Programmable Peripheral Interconnect (PPI)
+
+   * 21 channels (20 channels when not using pre-defined channels)
+   * 2 channel groups for software-based tIFS switching
+
+#. Distributed Programmable Peripheral Interconnect (DPPI)
+
+   * 20 channels
+   * 2 channel groups for s/w tIFS switching
+
+#. Software Interrupt (SWI)
+
+   * 3 instances, for Lower Link Layer, Upper Link Layer High priority, and
+     Upper Link Layer Low priority execution
+
+#. Radio
+
+   * 2.4 GHz radio transceiver with multiple radio standards such as 1 Mbps, 2
+     Mbps and Long Range Bluetooth Low Energy technology
+
+#. Random Number Generator (RNG)
+
+   * 1 instance
+
+#. AES electronic codebook mode encryption (ECB)
+
+   * 1 instance
+
+#. Cipher Block Chaining - Message Authentication Code with Counter Mode
+   encryption (CCM)
+
+   * 1 instance
+
+#. Accelerated address resolver (AAR)
+
+   * 1 instance
+
+#. GPIO
+
+   * 2 GPIO pins for PA and LNA, 1 each.
+   * 10 Debug GPIO pins (optional)
+
+#. GPIO tasks and events (GPIOTE)
+
+   * 1 instance
+   * 1 channel for PA/LNA
+
+#. Temperature sensor (TEMP)
+
+   * For RC calibration
+
+#. Interprocess Communication peripheral (IPC)
+
+   * For HCI interface
+
+#. UART
+
+   * For HCI interface
+
 Standard
 ========
 

--- a/doc/guides/bluetooth/bluetooth-arch.rst
+++ b/doc/guides/bluetooth/bluetooth-arch.rst
@@ -29,7 +29,7 @@ protocol stack:
   way.
 * **Controller**: The Controller implements the Link Layer (LE LL), the
   low-level, real-time protocol which provides, in conjunction with the Radio
-  Hardware, standard interoperable over the air communication. The LL schedules
+  Hardware, standard-interoperable over-the-air communication. The LL schedules
   packet reception and transmission, guarantees the delivery of data, and
   handles all the LL control procedures.
 * **Radio Hardware**: Hardware implements the required analog and digital

--- a/doc/guides/bluetooth/bluetooth-arch.rst
+++ b/doc/guides/bluetooth/bluetooth-arch.rst
@@ -402,8 +402,8 @@ Once enabled, it is the responsibility of the application to call
 settings_load() after having initialized Bluetooth (using the
 bt_enable() API).
 
-BLE Controller
-**************
+Bluetooth Low Energy Controller
+*******************************
 
 Standard
 ========

--- a/doc/reference/kernel/threads/index.rst
+++ b/doc/reference/kernel/threads/index.rst
@@ -326,7 +326,7 @@ The following thread options are supported.
     SSE registers. Also see :c:macro:`K_FP_REGS`.
 
     By default, the kernel does not attempt to save and restore the contents
-    of this register when scheduling the thread.
+    of these registers when scheduling the thread.
 
 :c:macro:`K_FP_REGS`
     This option indicate that the thread uses the CPU's floating point


### PR DESCRIPTION
Add a list of hardware/peripheral requirements of the BLE controller,
as provided by Vinayak Kariappa Chettimada on Discord #nordic.

Throw in a few more doc/comment tweaks.

@carlescufi, @cvinayak, please comment with, or push your amendments.