### PR TITLE
drivers: spi: mark old spi_cs_control fields deprecated

### DIFF
--- a/doc/releases/release-notes-3.1.rst
+++ b/doc/releases/release-notes-3.1.rst
@@ -43,6 +43,11 @@ Deprecated in this release
 * The TinyCBOR module has been deprecated in favor of the new zcbor CBOR
   library, included with Zephyr in this release.
 
+* SPI
+
+  * Deprecated the `gpio_dev`, `gpio_pin` and `gpio_dt_flags` members from
+    spi_cs_control struct in favor of `gpio_dt_spec` gpio.
+
 Stable API changes in this release
 ==================================
 

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -152,9 +152,9 @@ struct spi_cs_control {
 	union {
 		struct gpio_dt_spec gpio;
 		struct {
-			const struct device *gpio_dev;
-			gpio_pin_t gpio_pin;
-			gpio_dt_flags_t gpio_dt_flags;
+			const struct device *gpio_dev __deprecated;
+			gpio_pin_t gpio_pin __deprecated;
+			gpio_dt_flags_t gpio_dt_flags __deprecated;
 		};
 	};
 	/**


### PR DESCRIPTION
Since gpio_dt_spec is finally available in the spi_cs_control struct, mark the old fields deprecated in order to use the gpio_dt_spec struct.

Depends on https://github.com/zephyrproject-rtos/zephyr/pull/37498 and https://github.com/zephyrproject-rtos/zephyr/pull/39341

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>
Co-authored-by: Jordan Yates <jordan.yates@data61.csiro.au>
Signed-off-by: Bartosz Bilas <bartosz.bilas@hotmail.com>
Co-authored-by: Bartosz Bilas <bartosz.bilas@hotmail.com>