### PR TITLE
fs: core: remove include of <sys/stat.h> from fs.c.

### DIFF
--- a/subsys/fs/fs.c
+++ b/subsys/fs/fs.c
@@ -14,7 +14,6 @@
 #include <fs/fs.h>
 #include <fs/fs_sys.h>
 #include <sys/check.h>
-#include <sys/stat.h>
 
 
 #define LOG_LEVEL CONFIG_FS_LOG_LEVEL


### PR DESCRIPTION
This include is not used at all by fs.c. Zephyr includes a minimal `sys/stat.h`, but only for the minimal libc. If another libc is used, such as armstdc, the include will fail.

Another alternative fix would be to duplicate `./lib/libc/minimal/include/sys/stat.h` to `./lib/libc/armstdc/include/sys/stat.h`. There are other includes of `sys/stat.h` in Zephyr, but only in POSIX-related code. So this is a simpler solution that also happens to clean up an unused include.