### PR TITLE
Fix PM tests in kernel/device and guard PM APIs

### DIFF
--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -172,6 +172,9 @@ bool pm_device_is_any_busy(void)
 	devc = z_device_get_all_static(&devs);
 
 	for (const struct device *dev = devs; dev < (devs + devc); dev++) {
+		if (dev->pm_control == NULL) {
+			continue;
+		}
 		if (atomic_test_bit(&dev->pm->flags, PM_DEVICE_FLAG_BUSY)) {
 			return true;
 		}
@@ -182,22 +185,35 @@ bool pm_device_is_any_busy(void)
 
 bool pm_device_is_busy(const struct device *dev)
 {
+	if (dev->pm_control == NULL) {
+		return false;
+	}
 	return atomic_test_bit(&dev->pm->flags, PM_DEVICE_FLAG_BUSY);
 }
 
 void pm_device_busy_set(const struct device *dev)
 {
+	if (dev->pm_control == NULL) {
+		return;
+	}
 	atomic_set_bit(&dev->pm->flags, PM_DEVICE_FLAG_BUSY);
 }
 
 void pm_device_busy_clear(const struct device *dev)
 {
+	if (dev->pm_control == NULL) {
+		return;
+	}
 	atomic_clear_bit(&dev->pm->flags, PM_DEVICE_FLAG_BUSY);
 }
 
 bool pm_device_wakeup_enable(struct device *dev, bool enable)
 {
 	atomic_val_t flags, new_flags;
+
+	if (dev->pm_control == NULL) {
+		return false;
+	}
 
 	flags =	 atomic_get(&dev->pm->flags);
 
@@ -217,12 +233,18 @@ bool pm_device_wakeup_enable(struct device *dev, bool enable)
 
 bool pm_device_wakeup_is_enabled(const struct device *dev)
 {
+	if (dev->pm_control == NULL) {
+		return false;
+	}
 	return atomic_test_bit(&dev->pm->flags,
 			       PM_DEVICE_FLAGS_WS_ENABLED);
 }
 
 bool pm_device_wakeup_is_capable(const struct device *dev)
 {
+	if (dev->pm_control == NULL) {
+		return false;
+	}
 	return atomic_test_bit(&dev->pm->flags,
 			       PM_DEVICE_FLAGS_WS_CAPABLE);
 }

--- a/tests/kernel/device/src/dummy_driver.c
+++ b/tests/kernel/device/src/dummy_driver.c
@@ -32,11 +32,16 @@ int dummy_init(const struct device *dev)
 	return 0;
 }
 
+int dummy_pm_control(const struct device *dev, enum pm_device_action action)
+{
+	return 0;
+}
+
 /**
  * @cond INTERNAL_HIDDEN
  */
-DEVICE_DEFINE(dummy_driver, DUMMY_DRIVER_NAME, &dummy_init,
-		NULL, NULL, NULL, POST_KERNEL,
+DEVICE_DEFINE(dummy_driver, DUMMY_DRIVER_NAME, dummy_init,
+		dummy_pm_control, NULL, NULL, POST_KERNEL,
 		CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &funcs);
 
 /**


### PR DESCRIPTION
Add PM control to the kernel/device dummy driver so the PM APIs are actually tested.
Guard all PM APIs to verify the device enabled PM control.