### PR TITLE
pm: device: Simplify device states

### DIFF
--- a/doc/reference/power_management/index.rst
+++ b/doc/reference/power_management/index.rst
@@ -230,20 +230,18 @@ in those states, kind of operations done to save power, and the impact on the
 device behavior due to the state transition. Device context includes device
 registers, clocks, memory etc.
 
-The four device power states:
+The three device power states:
 
 :code:`PM_DEVICE_STATE_ACTIVE`
 
    Normal operation of the device. All device context is retained.
 
-:code:`PM_DEVICE_STATE_LOW_POWER`
-
-   Device context is preserved by the HW and need not be restored by the driver.
-
 :code:`PM_DEVICE_STATE_SUSPENDED`
 
-   Most device context is lost by the hardware. Device drivers must save and
-   restore or reinitialize any context lost by the hardware.
+   The system is idle and entering a low power state. Most device context is
+   lost by the hardware. Device drivers must save and restore or reinitialize
+   any context lost by the hardware. Devices can check which state the system
+   is entering calling :c:func:`pm_power_state_next_get()` .
 
 :code:`PM_DEVICE_STATE_OFF`
 

--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -29,13 +29,6 @@ enum pm_device_state {
 	/** Device is in active or regular state. */
 	PM_DEVICE_STATE_ACTIVE,
 	/**
-	 * Device is in low power state.
-	 *
-	 * @note
-	 *     Device context is preserved.
-	 */
-	PM_DEVICE_STATE_LOW_POWER,
-	/**
 	 * Device is suspended.
 	 *
 	 * @note
@@ -78,8 +71,6 @@ enum pm_device_action {
 	PM_DEVICE_ACTION_TURN_OFF,
 	/** Force suspend. */
 	PM_DEVICE_ACTION_FORCE_SUSPEND,
-	/** Low power. */
-	PM_DEVICE_ACTION_LOW_POWER,
 };
 
 /**

--- a/include/pm/pm.h
+++ b/include/pm/pm.h
@@ -174,6 +174,16 @@ bool pm_constraint_get(enum pm_state state);
 void pm_power_state_set(struct pm_state_info info);
 
 /**
+ * @brief Gets the next power state that will be used.
+ *
+ * This function returns the next power state that will be used by the
+ * SoC.
+ *
+ * @return next pm_state_info that will be used
+ */
+const struct pm_state_info pm_power_state_next_get(void);
+
+/**
  * @brief Do any SoC or architecture specific post ops after sleep state exits.
  *
  * This function is a place holder to do any operations that may
@@ -198,6 +208,8 @@ void pm_power_state_exit_post_ops(struct pm_state_info info);
 
 #define pm_power_state_set(info)
 #define pm_power_state_exit_post_ops(info)
+#define pm_power_state_next_get() \
+	((struct pm_state_info){PM_STATE_ACTIVE, 0, 0})
 
 #endif /* CONFIG_PM */
 

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -56,11 +56,6 @@ int pm_suspend_devices(void)
 	return _pm_devices(PM_DEVICE_STATE_SUSPENDED);
 }
 
-int pm_low_power_devices(void)
-{
-	return _pm_devices(PM_DEVICE_STATE_LOW_POWER);
-}
-
 void pm_resume_devices(void)
 {
 	int32_t i;
@@ -79,8 +74,6 @@ const char *pm_device_state_str(enum pm_device_state state)
 	switch (state) {
 	case PM_DEVICE_STATE_ACTIVE:
 		return "active";
-	case PM_DEVICE_STATE_LOW_POWER:
-		return "low power";
 	case PM_DEVICE_STATE_SUSPENDED:
 		return "suspended";
 	case PM_DEVICE_STATE_OFF:
@@ -121,13 +114,6 @@ int pm_device_state_set(const struct device *dev,
 		}
 
 		action = PM_DEVICE_ACTION_RESUME;
-		break;
-	case PM_DEVICE_STATE_LOW_POWER:
-		if (pm->state == state) {
-			return -EALREADY;
-		}
-
-		action = PM_DEVICE_ACTION_LOW_POWER;
 		break;
 	case PM_DEVICE_STATE_OFF:
 		if (pm->state == state) {

--- a/subsys/pm/pm_priv.h
+++ b/subsys/pm/pm_priv.h
@@ -19,11 +19,6 @@ extern "C" {
 int pm_suspend_devices(void);
 
 /**
- * @brief Function to put the devices in PM device list in low power state
- */
-int pm_low_power_devices(void);
-
-/**
  * @brief Function to force suspend the devices in PM device list
  */
 int pm_force_suspend_devices(void);

--- a/subsys/pm/power.c
+++ b/subsys/pm/power.c
@@ -249,13 +249,7 @@ enum pm_state pm_system_suspend(int32_t ticks)
 	case PM_STATE_SUSPEND_TO_IDLE:
 		__fallthrough;
 	case PM_STATE_STANDBY:
-		/* low power peripherals. */
-		if (pm_low_power_devices()) {
-			SYS_PORT_TRACING_FUNC_EXIT(pm, system_suspend,
-					ticks, _handle_device_abort(z_power_state));
-			return _handle_device_abort(z_power_state);
-		}
-		break;
+		__fallthrough;
 	case PM_STATE_SUSPEND_TO_RAM:
 		__fallthrough;
 	case PM_STATE_SUSPEND_TO_DISK:

--- a/subsys/pm/power.c
+++ b/subsys/pm/power.c
@@ -242,28 +242,15 @@ enum pm_state pm_system_suspend(int32_t ticks)
 	}
 
 #if CONFIG_PM_DEVICE
+	bool should_resume_devices = false;
 
-	bool should_resume_devices = true;
-
-	switch (z_power_state.state) {
-	case PM_STATE_SUSPEND_TO_IDLE:
-		__fallthrough;
-	case PM_STATE_STANDBY:
-		__fallthrough;
-	case PM_STATE_SUSPEND_TO_RAM:
-		__fallthrough;
-	case PM_STATE_SUSPEND_TO_DISK:
-		__fallthrough;
-	case PM_STATE_SOFT_OFF:
+	if (z_power_state.state != PM_STATE_RUNTIME_IDLE) {
 		if (pm_suspend_devices()) {
 			SYS_PORT_TRACING_FUNC_EXIT(pm, system_suspend,
-					ticks, _handle_device_abort(z_power_state));
+				ticks, _handle_device_abort(z_power_state));
 			return _handle_device_abort(z_power_state);
 		}
-		break;
-	default:
-		should_resume_devices = false;
-		break;
+		should_resume_devices = true;
 	}
 #endif
 	/*

--- a/subsys/pm/power.c
+++ b/subsys/pm/power.c
@@ -323,3 +323,8 @@ int pm_notifier_unregister(struct pm_notifier *notifier)
 
 	return ret;
 }
+
+const struct pm_state_info pm_power_state_next_get(void)
+{
+	return z_power_state;
+}


### PR DESCRIPTION
- Remove PM_DEVICE_STATE_LOW_POWER and PM_DEVICE_STATE_OFF as proposed and discussed in PM: Simplify device power states #38619

- Add new function to query which will be the next power state to be used by the SoC

- Simplified fdc2x1x power management due the device power states changes. Not need to handle case where the device was suspended and then went to OFF.