### PR TITLE
test: tracing.osawareness.openocd: multiple fixies

### DIFF
--- a/samples/subsys/tracing/prj.conf
+++ b/samples/subsys/tracing/prj.conf
@@ -1,1 +1,2 @@
 # enable to use thread names
+CONFIG_THREAD_NAME=y

--- a/samples/subsys/tracing/prj.conf
+++ b/samples/subsys/tracing/prj.conf
@@ -1,2 +1,4 @@
 # enable to use thread names
 CONFIG_THREAD_NAME=y
+CONFIG_MP_NUM_CPUS=1
+CONFIG_DEBUG_THREAD_INFO=y

--- a/samples/subsys/tracing/sample.yaml
+++ b/samples/subsys/tracing/sample.yaml
@@ -14,7 +14,6 @@ tests:
     extra_configs:
       - CONFIG_MP_NUM_CPUS=1
       - CONFIG_DEBUG_THREAD_INFO=y
-      - CONFIG_SMP=n
     arch_exclude: posix xtensa
     platform_exclude: qemu_x86_64
   tracing.transport.uart:

--- a/samples/subsys/tracing/sample.yaml
+++ b/samples/subsys/tracing/sample.yaml
@@ -11,9 +11,6 @@ tests:
     platform_allow: nrf52840dk_nrf52840 mimxrt1050_evk mimxrt1064_evk
     extra_args: CONF_FILE="prj_sysview.conf"
   tracing.osawareness.openocd:
-    extra_configs:
-      - CONFIG_MP_NUM_CPUS=1
-      - CONFIG_DEBUG_THREAD_INFO=y
     arch_exclude: posix xtensa
     platform_exclude: qemu_x86_64
   tracing.transport.uart:


### PR DESCRIPTION
- Fix execution on platforms with CONFIG_THREAD_NAME not enabled by default: enable CONFIG_THREAD_NAME in test config.
- Fix execution on SMP platforms: don't disable CONFIG_SMP in addition to setting CONFIG_MP_NUM_CPUS=1 as not SMP platforms allow this. Instead of it use only CONFIG_MP_NUM_CPUS=1 to provide execution on single core. This fixes execution on hsdk and hsdk_2cores platforms.