### PR TITLE
stm32: sdmmc: Add IT mode and HW flow control

### DIFF
--- a/drivers/disk/Kconfig.sdmmc
+++ b/drivers/disk/Kconfig.sdmmc
@@ -51,6 +51,14 @@ config SDMMC_STM32
 	help
 	  File system on sdmmc accessed through stm32 sdmmc.
 
+config SDMMC_STM32_HWFC
+	bool "STM32 SDMMC Hardware Flow control"
+	depends on SDMMC_STM32
+	depends on SOC_SERIES_STM32H7X || SOC_SERIES_STM32F7X || SOC_SERIES_STM32L4X
+	help
+	  Enable SDMMC Hardware Flow Control to avoid FIFO underrun (TX mode) and
+	  overrun (RX mode) errors.
+
 module = SDMMC
 module-str = sdmmc
 source "subsys/logging/Kconfig.template.log_config"

--- a/drivers/disk/sdmmc_stm32.c
+++ b/drivers/disk/sdmmc_stm32.c
@@ -22,7 +22,12 @@ LOG_MODULE_REGISTER(stm32_sdmmc, CONFIG_SDMMC_LOG_LEVEL);
 #define MMC_TypeDef SDMMC_TypeDef
 #endif
 
+typedef void (*irq_config_func_t)(const struct device *dev);
+
 struct stm32_sdmmc_priv {
+	irq_config_func_t irq_config;
+	struct k_sem thread_lock;
+	struct k_sem sync;
 	SD_HandleTypeDef hsd;
 	int status;
 	struct k_work work;
@@ -45,6 +50,43 @@ struct stm32_sdmmc_priv {
 		size_t len;
 	} pinctrl;
 };
+
+static void stm32_sdmmc_isr(const struct device *dev)
+{
+	struct stm32_sdmmc_priv *priv = dev->data;
+
+	HAL_SD_IRQHandler(&priv->hsd);
+}
+
+void HAL_SD_TxCpltCallback(SD_HandleTypeDef *hsd)
+{
+	struct stm32_sdmmc_priv *priv =
+		CONTAINER_OF(hsd, struct stm32_sdmmc_priv, hsd);
+
+	priv->status = hsd->ErrorCode;
+
+	k_sem_give(&priv->sync);
+}
+
+void HAL_SD_RxCpltCallback(SD_HandleTypeDef *hsd)
+{
+	struct stm32_sdmmc_priv *priv =
+		CONTAINER_OF(hsd, struct stm32_sdmmc_priv, hsd);
+
+	priv->status = hsd->ErrorCode;
+
+	k_sem_give(&priv->sync);
+}
+
+void HAL_SD_ErrorCallback(SD_HandleTypeDef *hsd)
+{
+	struct stm32_sdmmc_priv *priv =
+		CONTAINER_OF(hsd, struct stm32_sdmmc_priv, hsd);
+
+	priv->status = hsd->ErrorCode;
+
+	k_sem_give(&priv->sync);
+}
 
 static int stm32_sdmmc_clock_enable(struct stm32_sdmmc_priv *priv)
 {
@@ -135,19 +177,32 @@ static int stm32_sdmmc_access_read(struct disk_info *disk, uint8_t *data_buf,
 {
 	const struct device *dev = disk->dev;
 	struct stm32_sdmmc_priv *priv = dev->data;
-	int err;
+	int err = 0;
 
-	err = HAL_SD_ReadBlocks(&priv->hsd, data_buf, start_sector,
-				num_sector, 30000);
+	k_sem_take(&priv->thread_lock, K_FOREVER);
+
+	err = HAL_SD_ReadBlocks_IT(&priv->hsd, data_buf, start_sector,
+				num_sector);
 	if (err != HAL_OK) {
 		LOG_ERR("sd read block failed %d", err);
-		return -EIO;
+		err = -EIO;
+		goto end;
 	}
 
-	while (HAL_SD_GetCardState(&priv->hsd) != HAL_SD_CARD_TRANSFER)
-		;
+	k_sem_take(&priv->sync, K_FOREVER);
 
-	return 0;
+	if (priv->status != DISK_STATUS_OK) {
+		LOG_ERR("sd read error %d", priv->status);
+		err = -EIO;
+		goto end;
+	}
+
+	while (HAL_SD_GetCardState(&priv->hsd) != HAL_SD_CARD_TRANSFER) {
+	}
+
+end:
+	k_sem_give(&priv->thread_lock);
+	return err;
 }
 
 static int stm32_sdmmc_access_write(struct disk_info *disk,
@@ -156,18 +211,32 @@ static int stm32_sdmmc_access_write(struct disk_info *disk,
 {
 	const struct device *dev = disk->dev;
 	struct stm32_sdmmc_priv *priv = dev->data;
-	int err;
+	int err = 0;
 
-	err = HAL_SD_WriteBlocks(&priv->hsd, (uint8_t *)data_buf, start_sector,
-				 num_sector, 30000);
+	k_sem_take(&priv->thread_lock, K_FOREVER);
+
+	err = HAL_SD_WriteBlocks_IT(&priv->hsd, (uint8_t *)data_buf, start_sector,
+				 num_sector);
 	if (err != HAL_OK) {
 		LOG_ERR("sd write block failed %d", err);
-		return -EIO;
+		err = -EIO;
+		goto end;
 	}
-	while (HAL_SD_GetCardState(&priv->hsd) != HAL_SD_CARD_TRANSFER)
-		;
 
-	return 0;
+	k_sem_take(&priv->sync, K_FOREVER);
+
+	if (priv->status != DISK_STATUS_OK) {
+		LOG_ERR("sd write error %d", priv->status);
+		err = -EIO;
+		goto end;
+	}
+
+	while (HAL_SD_GetCardState(&priv->hsd) != HAL_SD_CARD_TRANSFER) {
+	}
+
+end:
+	k_sem_give(&priv->thread_lock);
+	return err;
 }
 
 static int stm32_sdmmc_access_ioctl(struct disk_info *disk, uint8_t cmd,
@@ -369,6 +438,12 @@ static int disk_stm32_sdmmc_init(const struct device *dev)
 		return err;
 	}
 
+	priv->irq_config(dev);
+
+	/* Initialize semaphores */
+	k_sem_init(&priv->thread_lock, 1, 1);
+	k_sem_init(&priv->sync, 0, 1);
+
 	err = stm32_sdmmc_card_detect_init(priv);
 	if (err) {
 		return err;
@@ -404,7 +479,17 @@ err_card_detect:
 static const struct soc_gpio_pinctrl sdmmc_pins_1[] =
 						ST_STM32_DT_INST_PINCTRL(0, 0);
 
+static void stm32_sdmmc_irq_config_func(const struct device *dev)
+{
+	IRQ_CONNECT(DT_INST_IRQN(0),
+		DT_INST_IRQ(0, priority),
+		stm32_sdmmc_isr, DEVICE_DT_INST_GET(0),
+		0);
+	irq_enable(DT_INST_IRQN(0));
+}
+
 static struct stm32_sdmmc_priv stm32_sdmmc_priv_1 = {
+	.irq_config = stm32_sdmmc_irq_config_func,
 	.hsd = {
 		.Instance = (MMC_TypeDef *)DT_INST_REG_ADDR(0),
 	},

--- a/drivers/disk/sdmmc_stm32.c
+++ b/drivers/disk/sdmmc_stm32.c
@@ -287,6 +287,15 @@ static struct disk_info stm32_sdmmc_info = {
 	.ops = &stm32_sdmmc_ops,
 };
 
+#ifdef CONFIG_SDMMC_STM32_HWFC
+static void stm32_sdmmc_fc_enable(struct stm32_sdmmc_priv *priv)
+{
+	MMC_TypeDef *sdmmcx = priv->hsd.Instance;
+
+	sdmmcx->CLKCR |= SDMMC_CLKCR_HWFC_EN;
+}
+#endif
+
 /*
  * Check if the card is present or not. If no card detect gpio is set, assume
  * the card is present. If reading the gpio fails for some reason, assume the
@@ -443,6 +452,10 @@ static int disk_stm32_sdmmc_init(const struct device *dev)
 	/* Initialize semaphores */
 	k_sem_init(&priv->thread_lock, 1, 1);
 	k_sem_init(&priv->sync, 0, 1);
+
+#ifdef CONFIG_SDMMC_STM32_HWFC
+	stm32_sdmmc_fc_enable(priv);
+#endif
 
 	err = stm32_sdmmc_card_detect_init(priv);
 	if (err) {

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -44,8 +44,8 @@ LOG_MODULE_REGISTER(usb_dc_stm32);
 #elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_usb)
 #define DT_DRV_COMPAT st_stm32_usb
 #define USB_IRQ_NAME  usb
-#if DT_INST_NODE_HAS_PROP(0, enable_pin_remap)
-#define USB_ENABLE_PIN_REMAP	__DEPRECATED_MACRO DT_INST_PROP(0, enable_pin_remap)
+#if DT_INST_PROP(0, enable_pin_remap)
+#define USB_ENABLE_PIN_REMAP	DT_INST_PROP(0, enable_pin_remap)
 #warning "Property deprecated in favor of property 'remap-pa11-pa12' from 'st-stm32-pinctrl'"
 #endif
 #endif

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -730,6 +730,7 @@
 			compatible = "st,stm32-sdmmc";
 			reg = <0x40012c00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000800>;
+			interrupts = <49 0>;
 			status = "disabled";
 			label = "SDMMC_1";
 		};

--- a/dts/arm/st/f7/stm32f723.dtsi
+++ b/dts/arm/st/f7/stm32f723.dtsi
@@ -36,6 +36,7 @@
 			compatible = "st,stm32-sdmmc";
 			reg = <0x40011c00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000080>;
+			interrupts = <103 0>;
 			status = "disabled";
 			label = "SDMMC_2";
 		};

--- a/dts/arm/st/f7/stm32f767.dtsi
+++ b/dts/arm/st/f7/stm32f767.dtsi
@@ -86,6 +86,7 @@
 			compatible = "st,stm32-sdmmc";
 			reg = <0x40011c00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000080>;
+			interrupts = <103 0>;
 			status = "disabled";
 			label = "SDMMC_2";
 		};

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -804,6 +804,7 @@
 			compatible = "st,stm32-sdmmc";
 			reg = <0x52007000 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x00010000>;
+			interrupts = <49 0>;
 			status = "disabled";
 			label = "SDMMC_1";
 		};
@@ -812,6 +813,7 @@
 			compatible = "st,stm32-sdmmc";
 			reg = <0x48022400 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00000100>;
+			interrupts = <124 0>;
 			status = "disabled";
 			label = "SDMMC_2";
 		};

--- a/dts/arm/st/l4/stm32l471.dtsi
+++ b/dts/arm/st/l4/stm32l471.dtsi
@@ -238,6 +238,7 @@
 			compatible = "st,stm32-sdmmc";
 			reg = <0x40012800 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000400>;
+			interrupts = <49 0>;
 			status = "disabled";
 			label = "SDMMC_1";
 		};

--- a/dts/arm/st/l4/stm32l4r5.dtsi
+++ b/dts/arm/st/l4/stm32l4r5.dtsi
@@ -296,6 +296,7 @@
 			compatible = "st,stm32-sdmmc";
 			reg = <0x50062400 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x400000>;
+			interrupts = <49 0>;
 			status = "disabled";
 			label = "SDMMC_1";
 		};


### PR DESCRIPTION
Fixes #39136

Convert existing SDMMC polling mode to IT driver r/w procedures.
Additionally, add a Kconfig option to enable HWFC feature.