### PR TITLE
net: lwm2m: Replace float32_value_t with double

### DIFF
--- a/doc/releases/release-notes-3.0.rst
+++ b/doc/releases/release-notes-3.0.rst
@@ -34,6 +34,8 @@ Changes in this release
   * :c:func:`uart_tx`
   * :c:func:`uart_rx_enable`
 
+* Replaced custom LwM2M :c:struct:`float32_value` type with a native double type.
+
 ==========================
 
 Removed APIs in this release

--- a/include/net/lwm2m.h
+++ b/include/net/lwm2m.h
@@ -358,27 +358,6 @@ struct coap_block_context *lwm2m_firmware_get_block_context();
 #endif
 
 /**
- * @brief Data structure used to represent the LwM2M float type:
- * val1 is the whole number portion of the decimal
- * val2 is the decimal portion *1000000 for 32bit, *1000000000 for 64bit
- * Example: 123.456 == val1: 123, val2:456000
- * Example: 123.000456 = val1: 123, val2:456
- */
-
-/**
- * @brief Maximum precision value for 32-bit LwM2M float val2
- */
-#define LWM2M_FLOAT32_DEC_MAX 1000000
-
-/**
- * @brief 32-bit variant of the LwM2M float structure
- */
-typedef struct float32_value {
-	int32_t val1;
-	int32_t val2;
-} float32_value_t;
-
-/**
  * @brief Maximum value for ObjLnk resource fields
  */
 #define LWM2M_OBJLNK_MAX_ID USHRT_MAX
@@ -557,14 +536,14 @@ int lwm2m_engine_set_s64(char *pathstr, int64_t value);
 int lwm2m_engine_set_bool(char *pathstr, bool value);
 
 /**
- * @brief Set resource (instance) value (32-bit float structure)
+ * @brief Set resource (instance) value (double)
  *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[in] value 32-bit float value
+ * @param[in] value double value
  *
  * @return 0 for success or negative in case of error.
  */
-int lwm2m_engine_set_float32(char *pathstr, float32_value_t *value);
+int lwm2m_engine_set_float(char *pathstr, double *value);
 
 /**
  * @brief Set resource (instance) value (ObjLnk)
@@ -689,14 +668,14 @@ int lwm2m_engine_get_s64(char *pathstr, int64_t *value);
 int lwm2m_engine_get_bool(char *pathstr, bool *value);
 
 /**
- * @brief Get resource (instance) value (32-bit float structure)
+ * @brief Get resource (instance) value (double)
  *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[out] buf 32-bit float buffer to copy data into
+ * @param[out] buf double buffer to copy data into
  *
  * @return 0 for success or negative in case of error.
  */
-int lwm2m_engine_get_float32(char *pathstr, float32_value_t *buf);
+int lwm2m_engine_get_float(char *pathstr, double *buf);
 
 /**
  * @brief Get resource (instance) value (ObjLnk)

--- a/samples/net/lwm2m_client/boards/qemu_x86.conf
+++ b/samples/net/lwm2m_client/boards/qemu_x86.conf
@@ -1,0 +1,1 @@
+CONFIG_FPU=y

--- a/samples/net/lwm2m_client/src/lwm2m-client.c
+++ b/samples/net/lwm2m_client/src/lwm2m-client.c
@@ -190,7 +190,7 @@ static void *temperature_get_buf(uint16_t obj_inst_id, uint16_t res_id,
 				 uint16_t res_inst_id, size_t *data_len)
 {
 	/* Last read temperature value, will use 25.5C if no sensor available */
-	static struct float32_value v = { 25, 500000 };
+	static double v = 25.5;
 	const struct device *dev = NULL;
 
 #if defined(CONFIG_FXOS8700_TEMP)
@@ -198,17 +198,21 @@ static void *temperature_get_buf(uint16_t obj_inst_id, uint16_t res_id,
 #endif
 
 	if (dev != NULL) {
+		struct sensor_value val;
+
 		if (sensor_sample_fetch(dev)) {
 			LOG_ERR("temperature data update failed");
 		}
 
-		sensor_channel_get(dev, SENSOR_CHAN_DIE_TEMP,
-				  (struct sensor_value *) &v);
-		LOG_DBG("LWM2M temperature set to %d.%d", v.val1, v.val2);
+		sensor_channel_get(dev, SENSOR_CHAN_DIE_TEMP, &val);
+
+		v = sensor_value_to_double(&val);
+
+		LOG_DBG("LWM2M temperature set to %f", v);
 	}
 
 	/* echo the value back through the engine to update min/max values */
-	lwm2m_engine_set_float32("3303/0/5700", &v);
+	lwm2m_engine_set_float("3303/0/5700", &v);
 	*data_len = sizeof(v);
 	return &v;
 }

--- a/subsys/net/lib/lwm2m/ipso_accelerometer.c
+++ b/subsys/net/lib/lwm2m/ipso_accelerometer.c
@@ -42,11 +42,11 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 /* resource state */
 struct ipso_accel_data {
-	float32_value_t x_value;
-	float32_value_t y_value;
-	float32_value_t z_value;
-	float32_value_t min_range;
-	float32_value_t max_range;
+	double x_value;
+	double y_value;
+	double z_value;
+	double min_range;
+	double max_range;
 };
 
 static struct ipso_accel_data accel_data[MAX_INSTANCE_COUNT];

--- a/subsys/net/lib/lwm2m/ipso_generic_sensor.c
+++ b/subsys/net/lib/lwm2m/ipso_generic_sensor.c
@@ -56,12 +56,12 @@ BUILD_ASSERT(SENSOR_TYPE_STR_MAX_SIZE >=
 #define RESOURCE_INSTANCE_COUNT (NUMBER_OF_OBJ_FIELDS - 1)
 
 /* resource state variables */
-static float32_value_t sensor_value[MAX_INSTANCE_COUNT];
+static double sensor_value[MAX_INSTANCE_COUNT];
 static char units[MAX_INSTANCE_COUNT][UNIT_STR_MAX_SIZE];
-static float32_value_t min_measured_value[MAX_INSTANCE_COUNT];
-static float32_value_t max_measured_value[MAX_INSTANCE_COUNT];
-static float32_value_t min_range_value[MAX_INSTANCE_COUNT];
-static float32_value_t max_range_value[MAX_INSTANCE_COUNT];
+static double min_measured_value[MAX_INSTANCE_COUNT];
+static double max_measured_value[MAX_INSTANCE_COUNT];
+static double min_range_value[MAX_INSTANCE_COUNT];
+static double max_range_value[MAX_INSTANCE_COUNT];
 static char app_type[MAX_INSTANCE_COUNT][APP_TYPE_STR_MAX_SIZE];
 static char sensor_type[MAX_INSTANCE_COUNT][SENSOR_TYPE_STR_MAX_SIZE];
 
@@ -91,15 +91,13 @@ static struct lwm2m_engine_res_inst res_inst[MAX_INSTANCE_COUNT]
 
 static void update_min_measured(uint16_t obj_inst_id, int index)
 {
-	min_measured_value[index].val1 = sensor_value[index].val1;
-	min_measured_value[index].val2 = sensor_value[index].val2;
+	min_measured_value[index] = sensor_value[index];
 	NOTIFY_OBSERVER(IPSO_OBJECT_ID, obj_inst_id, MIN_MEASURED_VALUE_RID);
 }
 
 static void update_max_measured(uint16_t obj_inst_id, int index)
 {
-	max_measured_value[index].val1 = sensor_value[index].val1;
-	max_measured_value[index].val2 = sensor_value[index].val2;
+	max_measured_value[index] = sensor_value[index];
 	NOTIFY_OBSERVER(IPSO_OBJECT_ID, obj_inst_id, MAX_MEASURED_VALUE_RID);
 }
 
@@ -126,35 +124,15 @@ static int sensor_value_write_cb(uint16_t obj_inst_id, uint16_t res_id,
 				 size_t total_size)
 {
 	int i;
-	bool update_min = false;
-	bool update_max = false;
 
 	for (i = 0; i < MAX_INSTANCE_COUNT; i++) {
 		if (inst[i].obj && inst[i].obj_inst_id == obj_inst_id) {
 			/* update min / max */
-			if (sensor_value[i].val1 < min_measured_value[i].val1) {
-				update_min = true;
-			} else if (sensor_value[i].val1 ==
-					   min_measured_value[i].val1 &&
-				   sensor_value[i].val2 <
-					   min_measured_value[i].val2) {
-				update_min = true;
-			}
-
-			if (sensor_value[i].val1 > max_measured_value[i].val1) {
-				update_max = true;
-			} else if (sensor_value[i].val1 ==
-					   max_measured_value[i].val1 &&
-				   sensor_value[i].val2 >
-					   max_measured_value[i].val2) {
-				update_max = true;
-			}
-
-			if (update_min) {
+			if (sensor_value[i] < min_measured_value[i]) {
 				update_min_measured(obj_inst_id, i);
 			}
 
-			if (update_max) {
+			if (sensor_value[i] > max_measured_value[i]) {
 				update_max_measured(obj_inst_id, i);
 			}
 		}
@@ -190,17 +168,12 @@ static struct lwm2m_engine_obj_inst *generic_sensor_create(uint16_t obj_inst_id)
 	}
 
 	/* Set default values */
-	sensor_value[index].val1 = 0;
-	sensor_value[index].val2 = 0;
+	sensor_value[index] = 0;
 	units[index][0] = '\0';
-	min_measured_value[index].val1 = INT32_MAX;
-	min_measured_value[index].val2 = 0;
-	max_measured_value[index].val1 = -INT32_MAX;
-	max_measured_value[index].val2 = 0;
-	min_range_value[index].val1 = 0;
-	min_range_value[index].val2 = 0;
-	max_range_value[index].val1 = 0;
-	max_range_value[index].val2 = 0;
+	min_measured_value[index] = INT32_MAX;
+	max_measured_value[index] = -INT32_MAX;
+	min_range_value[index] = 0;
+	max_range_value[index] = 0;
 	app_type[index][0] = '\0';
 	strncpy(sensor_type[index], CONFIG_LWM2M_IPSO_GENERIC_SENSOR_TYPE,
 		SENSOR_TYPE_STR_MAX_SIZE);

--- a/subsys/net/lib/lwm2m/ipso_humidity_sensor.c
+++ b/subsys/net/lib/lwm2m/ipso_humidity_sensor.c
@@ -45,12 +45,12 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define RESOURCE_INSTANCE_COUNT (NUMBER_OF_OBJ_FIELDS - 1)
 
 /* resource state variables */
-static float32_value_t sensor_value[MAX_INSTANCE_COUNT];
+static double sensor_value[MAX_INSTANCE_COUNT];
 static char units[MAX_INSTANCE_COUNT][UNIT_STR_MAX_SIZE];
-static float32_value_t min_measured_value[MAX_INSTANCE_COUNT];
-static float32_value_t max_measured_value[MAX_INSTANCE_COUNT];
-static float32_value_t min_range_value[MAX_INSTANCE_COUNT];
-static float32_value_t max_range_value[MAX_INSTANCE_COUNT];
+static double min_measured_value[MAX_INSTANCE_COUNT];
+static double max_measured_value[MAX_INSTANCE_COUNT];
+static double min_range_value[MAX_INSTANCE_COUNT];
+static double max_range_value[MAX_INSTANCE_COUNT];
 
 static struct lwm2m_engine_obj sensor;
 static struct lwm2m_engine_obj_field fields[] = {
@@ -77,15 +77,13 @@ static struct lwm2m_engine_res_inst res_inst[MAX_INSTANCE_COUNT]
 
 static void update_min_measured(uint16_t obj_inst_id, int index)
 {
-	min_measured_value[index].val1 = sensor_value[index].val1;
-	min_measured_value[index].val2 = sensor_value[index].val2;
+	min_measured_value[index] = sensor_value[index];
 	NOTIFY_OBSERVER(IPSO_OBJECT_ID, obj_inst_id, MIN_MEASURED_VALUE_RID);
 }
 
 static void update_max_measured(uint16_t obj_inst_id, int index)
 {
-	max_measured_value[index].val1 = sensor_value[index].val1;
-	max_measured_value[index].val2 = sensor_value[index].val2;
+	max_measured_value[index] = sensor_value[index];
 	NOTIFY_OBSERVER(IPSO_OBJECT_ID, obj_inst_id, MAX_MEASURED_VALUE_RID);
 }
 
@@ -112,35 +110,15 @@ static int sensor_value_write_cb(uint16_t obj_inst_id, uint16_t res_id,
 				 size_t total_size)
 {
 	int i;
-	bool update_min = false;
-	bool update_max = false;
 
 	for (i = 0; i < MAX_INSTANCE_COUNT; i++) {
 		if (inst[i].obj && inst[i].obj_inst_id == obj_inst_id) {
 			/* update min / max */
-			if (sensor_value[i].val1 < min_measured_value[i].val1) {
-				update_min = true;
-			} else if (sensor_value[i].val1 ==
-					   min_measured_value[i].val1 &&
-				   sensor_value[i].val2 <
-					   min_measured_value[i].val2) {
-				update_min = true;
-			}
-
-			if (sensor_value[i].val1 > max_measured_value[i].val1) {
-				update_max = true;
-			} else if (sensor_value[i].val1 ==
-					   max_measured_value[i].val1 &&
-				   sensor_value[i].val2 >
-					   max_measured_value[i].val2) {
-				update_max = true;
-			}
-
-			if (update_min) {
+			if (sensor_value[i] < min_measured_value[i]) {
 				update_min_measured(obj_inst_id, i);
 			}
 
-			if (update_max) {
+			if (sensor_value[i] > max_measured_value[i]) {
 				update_max_measured(obj_inst_id, i);
 			}
 		}
@@ -177,17 +155,12 @@ humidity_sensor_create(uint16_t obj_inst_id)
 	}
 
 	/* Set default values */
-	sensor_value[index].val1 = 0;
-	sensor_value[index].val2 = 0;
+	sensor_value[index] = 0;
 	units[index][0] = '\0';
-	min_measured_value[index].val1 = INT32_MAX;
-	min_measured_value[index].val2 = 0;
-	max_measured_value[index].val1 = -INT32_MAX;
-	max_measured_value[index].val2 = 0;
-	min_range_value[index].val1 = 0;
-	min_range_value[index].val2 = 0;
-	max_range_value[index].val1 = 0;
-	max_range_value[index].val2 = 0;
+	min_measured_value[index] = INT32_MAX;
+	max_measured_value[index] = -INT32_MAX;
+	min_range_value[index] = 0;
+	max_range_value[index] = 0;
 
 	(void)memset(res[index], 0,
 		     sizeof(res[index][0]) * ARRAY_SIZE(res[index]));

--- a/subsys/net/lib/lwm2m/ipso_light_control.c
+++ b/subsys/net/lib/lwm2m/ipso_light_control.c
@@ -45,8 +45,8 @@ static bool on_off_value[MAX_INSTANCE_COUNT];
 static uint8_t dimmer_value[MAX_INSTANCE_COUNT];
 static int32_t on_time_value[MAX_INSTANCE_COUNT];
 static uint32_t on_time_offset[MAX_INSTANCE_COUNT];
-static float32_value_t cumulative_active_value[MAX_INSTANCE_COUNT];
-static float32_value_t power_factor_value[MAX_INSTANCE_COUNT];
+static double cumulative_active_value[MAX_INSTANCE_COUNT];
+static double power_factor_value[MAX_INSTANCE_COUNT];
 static char colour[MAX_INSTANCE_COUNT][LIGHT_STRING_LONG];
 static char units[MAX_INSTANCE_COUNT][LIGHT_STRING_SHORT];
 
@@ -148,10 +148,8 @@ static struct lwm2m_engine_obj_inst *light_control_create(uint16_t obj_inst_id)
 	dimmer_value[avail] = 0U;
 	on_time_value[avail] = 0;
 	on_time_offset[avail] = 0U;
-	cumulative_active_value[avail].val1 = 0;
-	cumulative_active_value[avail].val2 = 0;
-	power_factor_value[avail].val1 = 0;
-	power_factor_value[avail].val2 = 0;
+	cumulative_active_value[avail] = 0;
+	power_factor_value[avail] = 0;
 	colour[avail][0] = '\0';
 	units[avail][0] = '\0';
 

--- a/subsys/net/lib/lwm2m/ipso_pressure_sensor.c
+++ b/subsys/net/lib/lwm2m/ipso_pressure_sensor.c
@@ -45,12 +45,12 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define RESOURCE_INSTANCE_COUNT (NUMBER_OF_OBJ_FIELDS - 1)
 
 /* resource state variables */
-static float32_value_t sensor_value[MAX_INSTANCE_COUNT];
+static double sensor_value[MAX_INSTANCE_COUNT];
 static char units[MAX_INSTANCE_COUNT][UNIT_STR_MAX_SIZE];
-static float32_value_t min_measured_value[MAX_INSTANCE_COUNT];
-static float32_value_t max_measured_value[MAX_INSTANCE_COUNT];
-static float32_value_t min_range_value[MAX_INSTANCE_COUNT];
-static float32_value_t max_range_value[MAX_INSTANCE_COUNT];
+static double min_measured_value[MAX_INSTANCE_COUNT];
+static double max_measured_value[MAX_INSTANCE_COUNT];
+static double min_range_value[MAX_INSTANCE_COUNT];
+static double max_range_value[MAX_INSTANCE_COUNT];
 
 static struct lwm2m_engine_obj sensor;
 static struct lwm2m_engine_obj_field fields[] = {
@@ -78,15 +78,13 @@ static struct lwm2m_engine_res_inst res_inst[MAX_INSTANCE_COUNT]
 
 static void update_min_measured(uint16_t obj_inst_id, int index)
 {
-	min_measured_value[index].val1 = sensor_value[index].val1;
-	min_measured_value[index].val2 = sensor_value[index].val2;
+	min_measured_value[index] = sensor_value[index];
 	NOTIFY_OBSERVER(IPSO_OBJECT_ID, obj_inst_id, MIN_MEASURED_VALUE_RID);
 }
 
 static void update_max_measured(uint16_t obj_inst_id, int index)
 {
-	max_measured_value[index].val1 = sensor_value[index].val1;
-	max_measured_value[index].val2 = sensor_value[index].val2;
+	max_measured_value[index] = sensor_value[index];
 	NOTIFY_OBSERVER(IPSO_OBJECT_ID, obj_inst_id, MAX_MEASURED_VALUE_RID);
 }
 
@@ -113,35 +111,15 @@ static int sensor_value_write_cb(uint16_t obj_inst_id, uint16_t res_id,
 				 size_t total_size)
 {
 	int i;
-	bool update_min = false;
-	bool update_max = false;
 
 	for (i = 0; i < MAX_INSTANCE_COUNT; i++) {
 		if (inst[i].obj && inst[i].obj_inst_id == obj_inst_id) {
 			/* update min / max */
-			if (sensor_value[i].val1 < min_measured_value[i].val1) {
-				update_min = true;
-			} else if (sensor_value[i].val1 ==
-					   min_measured_value[i].val1 &&
-				   sensor_value[i].val2 <
-					   min_measured_value[i].val2) {
-				update_min = true;
-			}
-
-			if (sensor_value[i].val1 > max_measured_value[i].val1) {
-				update_max = true;
-			} else if (sensor_value[i].val1 ==
-					   max_measured_value[i].val1 &&
-				   sensor_value[i].val2 >
-					   max_measured_value[i].val2) {
-				update_max = true;
-			}
-
-			if (update_min) {
+			if (sensor_value[i] < min_measured_value[i]) {
 				update_min_measured(obj_inst_id, i);
 			}
 
-			if (update_max) {
+			if (sensor_value[i] > max_measured_value[i]) {
 				update_max_measured(obj_inst_id, i);
 			}
 		}
@@ -178,17 +156,12 @@ pressure_sensor_create(uint16_t obj_inst_id)
 	}
 
 	/* Set default values */
-	sensor_value[index].val1 = 0;
-	sensor_value[index].val2 = 0;
+	sensor_value[index] = 0;
 	units[index][0] = '\0';
-	min_measured_value[index].val1 = INT32_MAX;
-	min_measured_value[index].val2 = 0;
-	max_measured_value[index].val1 = -INT32_MAX;
-	max_measured_value[index].val2 = 0;
-	min_range_value[index].val1 = 0;
-	min_range_value[index].val2 = 0;
-	max_range_value[index].val1 = 0;
-	max_range_value[index].val2 = 0;
+	min_measured_value[index] = INT32_MAX;
+	max_measured_value[index] = -INT32_MAX;
+	min_range_value[index] = 0;
+	max_range_value[index] = 0;
 
 	(void)memset(res[index], 0,
 		     sizeof(res[index][0]) * ARRAY_SIZE(res[index]));

--- a/subsys/net/lib/lwm2m/ipso_temp_sensor.c
+++ b/subsys/net/lib/lwm2m/ipso_temp_sensor.c
@@ -46,12 +46,12 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define RESOURCE_INSTANCE_COUNT	(TEMP_MAX_ID - 1)
 
 /* resource state variables */
-static float32_value_t sensor_value[MAX_INSTANCE_COUNT];
+static double sensor_value[MAX_INSTANCE_COUNT];
 static char units[MAX_INSTANCE_COUNT][UNIT_STR_MAX_SIZE];
-static float32_value_t min_measured_value[MAX_INSTANCE_COUNT];
-static float32_value_t max_measured_value[MAX_INSTANCE_COUNT];
-static float32_value_t min_range_value[MAX_INSTANCE_COUNT];
-static float32_value_t max_range_value[MAX_INSTANCE_COUNT];
+static double min_measured_value[MAX_INSTANCE_COUNT];
+static double max_measured_value[MAX_INSTANCE_COUNT];
+static double min_range_value[MAX_INSTANCE_COUNT];
+static double max_range_value[MAX_INSTANCE_COUNT];
 
 static struct lwm2m_engine_obj temp_sensor;
 static struct lwm2m_engine_obj_field fields[] = {
@@ -78,16 +78,14 @@ static struct lwm2m_engine_res_inst
 
 static void update_min_measured(uint16_t obj_inst_id, int index)
 {
-	min_measured_value[index].val1 = sensor_value[index].val1;
-	min_measured_value[index].val2 = sensor_value[index].val2;
+	min_measured_value[index] = sensor_value[index];
 	NOTIFY_OBSERVER(IPSO_OBJECT_TEMP_SENSOR_ID, obj_inst_id,
 			MIN_MEASURED_VALUE_RID);
 }
 
 static void update_max_measured(uint16_t obj_inst_id, int index)
 {
-	max_measured_value[index].val1 = sensor_value[index].val1;
-	max_measured_value[index].val2 = sensor_value[index].val2;
+	max_measured_value[index] = sensor_value[index];
 	NOTIFY_OBSERVER(IPSO_OBJECT_TEMP_SENSOR_ID, obj_inst_id,
 			MAX_MEASURED_VALUE_RID);
 }
@@ -115,35 +113,15 @@ static int sensor_value_write_cb(uint16_t obj_inst_id,
 				 bool last_block, size_t total_size)
 {
 	int i;
-	bool update_min = false;
-	bool update_max = false;
 
 	for (i = 0; i < MAX_INSTANCE_COUNT; i++) {
 		if (inst[i].obj && inst[i].obj_inst_id == obj_inst_id) {
 			/* update min / max */
-			if (sensor_value[i].val1 < min_measured_value[i].val1) {
-				update_min = true;
-			} else if (sensor_value[i].val1 ==
-					min_measured_value[i].val1 &&
-				   sensor_value[i].val2 <
-					min_measured_value[i].val2) {
-				update_min = true;
-			}
-
-			if (sensor_value[i].val1 > max_measured_value[i].val1) {
-				update_max = true;
-			} else if (sensor_value[i].val1 ==
-					max_measured_value[i].val1 &&
-				   sensor_value[i].val2 >
-					max_measured_value[i].val2) {
-				update_max = true;
-			}
-
-			if (update_min) {
+			if (sensor_value[i] < min_measured_value[i]) {
 				update_min_measured(obj_inst_id, i);
 			}
 
-			if (update_max) {
+			if (sensor_value[i] > max_measured_value[i]) {
 				update_max_measured(obj_inst_id, i);
 			}
 		}
@@ -178,17 +156,12 @@ static struct lwm2m_engine_obj_inst *temp_sensor_create(uint16_t obj_inst_id)
 	}
 
 	/* Set default values */
-	sensor_value[index].val1 = 0;
-	sensor_value[index].val2 = 0;
+	sensor_value[index] = 0;
 	units[index][0] = '\0';
-	min_measured_value[index].val1 = INT32_MAX;
-	min_measured_value[index].val2 = 0;
-	max_measured_value[index].val1 = -INT32_MAX;
-	max_measured_value[index].val2 = 0;
-	min_range_value[index].val1 = 0;
-	min_range_value[index].val2 = 0;
-	max_range_value[index].val1 = 0;
-	max_range_value[index].val2 = 0;
+	min_measured_value[index] = INT32_MAX;
+	max_measured_value[index] = -INT32_MAX;
+	min_range_value[index] = 0;
+	max_range_value[index] = 0;
 
 	(void)memset(res[index], 0,
 		     sizeof(res[index][0]) * ARRAY_SIZE(res[index]));

--- a/subsys/net/lib/lwm2m/lwm2m_obj_location.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_location.c
@@ -37,11 +37,11 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define RESOURCE_INSTANCE_COUNT	(LOCATION_MAX_ID)
 
 /* resource state */
-static float32_value_t latitude;
-static float32_value_t longitude;
-static float32_value_t altitude;
-static float32_value_t radius;
-static float32_value_t speed;
+static double latitude;
+static double longitude;
+static double altitude;
+static double radius;
+static double speed;
 static int32_t timestamp;
 
 static struct lwm2m_engine_obj location;

--- a/subsys/net/lib/lwm2m/lwm2m_object.h
+++ b/subsys/net/lib/lwm2m/lwm2m_object.h
@@ -347,7 +347,7 @@ struct lwm2m_attr {
 
 	/* values */
 	union {
-		float32_value_t float_val;
+		double float_val;
 		int32_t int_val;
 	};
 
@@ -515,9 +515,9 @@ struct lwm2m_writer {
 	size_t (*put_string)(struct lwm2m_output_context *out,
 			     struct lwm2m_obj_path *path,
 			     char *buf, size_t buflen);
-	size_t (*put_float32fix)(struct lwm2m_output_context *out,
-				 struct lwm2m_obj_path *path,
-				 float32_value_t *value);
+	size_t (*put_float)(struct lwm2m_output_context *out,
+			    struct lwm2m_obj_path *path,
+			    double *value);
 	size_t (*put_bool)(struct lwm2m_output_context *out,
 			   struct lwm2m_obj_path *path,
 			   bool value);
@@ -538,8 +538,8 @@ struct lwm2m_reader {
 			  int64_t *value);
 	size_t (*get_string)(struct lwm2m_input_context *in,
 			     uint8_t *buf, size_t buflen);
-	size_t (*get_float32fix)(struct lwm2m_input_context *in,
-				 float32_value_t *value);
+	size_t (*get_float)(struct lwm2m_input_context *in,
+			    double *value);
 	size_t (*get_bool)(struct lwm2m_input_context *in,
 			   bool *value);
 	size_t (*get_opaque)(struct lwm2m_input_context *in,
@@ -703,11 +703,11 @@ static inline size_t engine_put_string(struct lwm2m_output_context *out,
 	return out->writer->put_string(out, path, buf, buflen);
 }
 
-static inline size_t engine_put_float32fix(struct lwm2m_output_context *out,
-					   struct lwm2m_obj_path *path,
-					   float32_value_t *value)
+static inline size_t engine_put_float(struct lwm2m_output_context *out,
+				      struct lwm2m_obj_path *path,
+				      double *value)
 {
-	return out->writer->put_float32fix(out, path, value);
+	return out->writer->put_float(out, path, value);
 }
 
 static inline size_t engine_put_bool(struct lwm2m_output_context *out,
@@ -763,10 +763,10 @@ static inline size_t engine_get_string(struct lwm2m_input_context *in,
 	return in->reader->get_string(in, buf, buflen);
 }
 
-static inline size_t engine_get_float32fix(struct lwm2m_input_context *in,
-					   float32_value_t *value)
+static inline size_t engine_get_float(struct lwm2m_input_context *in,
+				      double *value)
 {
-	return in->reader->get_float32fix(in, value);
+	return in->reader->get_float(in, value);
 }
 
 static inline size_t engine_get_bool(struct lwm2m_input_context *in,

--- a/subsys/net/lib/lwm2m/lwm2m_rw_json.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_json.c
@@ -491,14 +491,14 @@ static size_t put_string(struct lwm2m_output_context *out,
 	return len;
 }
 
-static size_t put_float32fix(struct lwm2m_output_context *out,
-			     struct lwm2m_obj_path *path,
-			     float32_value_t *value)
+static size_t put_float(struct lwm2m_output_context *out,
+			struct lwm2m_obj_path *path,
+			double *value)
 {
 	size_t len;
 
 	len = put_json_prefix(out, path, "\"v\"");
-	len += plain_text_put_float32fix(out, path, value);
+	len += plain_text_put_float(out, path, value);
 	len += put_json_postfix(out);
 	return len;
 }
@@ -612,8 +612,8 @@ static size_t get_string(struct lwm2m_input_context *in,
 	return fd->value_len;
 }
 
-static size_t get_float32fix(struct lwm2m_input_context *in,
-			     float32_value_t *value)
+static size_t get_float(struct lwm2m_input_context *in,
+			double *value)
 {
 	struct json_in_formatter_data *fd;
 
@@ -652,7 +652,7 @@ static size_t get_float32fix(struct lwm2m_input_context *in,
 
 	buf[i] = '\0';
 
-	if (lwm2m_atof32(buf, value) != 0) {
+	if (lwm2m_atof(buf, value) != 0) {
 		LOG_ERR("Failed to parse float value");
 	}
 
@@ -729,7 +729,7 @@ const struct lwm2m_writer json_writer = {
 	.put_s32 = put_s32,
 	.put_s64 = put_s64,
 	.put_string = put_string,
-	.put_float32fix = put_float32fix,
+	.put_float = put_float,
 	.put_bool = put_bool,
 	.put_objlnk = put_objlnk,
 };
@@ -738,7 +738,7 @@ const struct lwm2m_reader json_reader = {
 	.get_s32 = get_s32,
 	.get_s64 = get_s64,
 	.get_string = get_string,
-	.get_float32fix = get_float32fix,
+	.get_float = get_float,
 	.get_bool = get_bool,
 	.get_opaque = get_opaque,
 	.get_objlnk = get_objlnk,

--- a/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
@@ -510,30 +510,30 @@ static size_t put_string(struct lwm2m_output_context *out,
 	return len;
 }
 
-static size_t put_float32fix(struct lwm2m_output_context *out,
+static size_t put_float(struct lwm2m_output_context *out,
 			     struct lwm2m_obj_path *path,
-			     float32_value_t *value)
+			     double *value)
 {
 	struct tlv_out_formatter_data *fd;
 	size_t len;
 	struct oma_tlv tlv;
 	int ret;
-	uint8_t b32[4];
+	uint8_t b64[8];
 
 	fd = engine_get_out_user_data(out);
 	if (!fd) {
 		return 0;
 	}
 
-	ret = lwm2m_f32_to_b32(value, b32, sizeof(b32));
+	ret = lwm2m_float_to_b64(value, b64, sizeof(b64));
 	if (ret < 0) {
 		LOG_ERR("float32 conversion error: %d", ret);
 		return 0;
 	}
 
 	tlv_setup(&tlv, tlv_calc_type(fd->writer_flags),
-		  tlv_calc_id(fd->writer_flags, path), sizeof(b32));
-	len = oma_tlv_put(&tlv, out, b32, false);
+		  tlv_calc_id(fd->writer_flags, path), sizeof(b64));
+	len = oma_tlv_put(&tlv, out, b64, false);
 	return len;
 }
 
@@ -647,8 +647,8 @@ static size_t get_string(struct lwm2m_input_context *in,
 }
 
 /* convert float to fixpoint */
-static size_t get_float32fix(struct lwm2m_input_context *in,
-			     float32_value_t *value)
+static size_t get_float(struct lwm2m_input_context *in,
+			double *value)
 {
 	struct oma_tlv tlv;
 	size_t size = oma_tlv_get(&tlv, in, false);
@@ -679,9 +679,9 @@ static size_t get_float32fix(struct lwm2m_input_context *in,
 		}
 
 		if (tlv.length == 4U) {
-			ret = lwm2m_b32_to_f32(buf, 4, value);
+			ret = lwm2m_b32_to_float(buf, 4, value);
 		} else {
-			ret = lwm2m_b64_to_f32(buf, 8, value);
+			ret = lwm2m_b64_to_float(buf, 8, value);
 		}
 
 		if (ret < 0) {
@@ -752,7 +752,7 @@ const struct lwm2m_writer oma_tlv_writer = {
 	.put_s32 = put_s32,
 	.put_s64 = put_s64,
 	.put_string = put_string,
-	.put_float32fix = put_float32fix,
+	.put_float = put_float,
 	.put_bool = put_bool,
 	.put_opaque = put_opaque,
 	.put_objlnk = put_objlnk,
@@ -762,7 +762,7 @@ const struct lwm2m_reader oma_tlv_reader = {
 	.get_s32 = get_s32,
 	.get_s64 = get_s64,
 	.get_string = get_string,
-	.get_float32fix = get_float32fix,
+	.get_float = get_float,
 	.get_bool = get_bool,
 	.get_opaque = get_opaque,
 	.get_objlnk = get_objlnk,

--- a/subsys/net/lib/lwm2m/lwm2m_rw_plain_text.h
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_plain_text.h
@@ -52,9 +52,9 @@ extern const struct lwm2m_reader plain_text_reader;
 size_t plain_text_put_format(struct lwm2m_output_context *out,
 			     const char *format, ...);
 
-size_t plain_text_put_float32fix(struct lwm2m_output_context *out,
-				 struct lwm2m_obj_path *path,
-				 float32_value_t *value);
+size_t plain_text_put_float(struct lwm2m_output_context *out,
+			    struct lwm2m_obj_path *path,
+			    double *value);
 
 
 int do_read_op_plain_text(struct lwm2m_message *msg, int content_format);

--- a/subsys/net/lib/lwm2m/lwm2m_util.h
+++ b/subsys/net/lib/lwm2m/lwm2m_util.h
@@ -9,15 +9,17 @@
 
 #include <net/lwm2m.h>
 
-/* convert float struct to binary format */
-int lwm2m_f32_to_b32(float32_value_t *f32, uint8_t *b32, size_t len);
-int lwm2m_f32_to_b64(float32_value_t *f32, uint8_t *b64, size_t len);
+/* convert float to binary format */
+int lwm2m_float_to_b32(double *in, uint8_t *b32, size_t len);
+int lwm2m_float_to_b64(double *in, uint8_t *b64, size_t len);
 
-/* convert binary format to float struct */
-int lwm2m_b32_to_f32(uint8_t *b32, size_t len, float32_value_t *f32);
-int lwm2m_b64_to_f32(uint8_t *b64, size_t len, float32_value_t *f32);
+/* convert binary format to float */
+int lwm2m_b32_to_float(uint8_t *b32, size_t len, double *out);
+int lwm2m_b64_to_float(uint8_t *b64, size_t len, double *out);
 
-/* convert string to float struct */
-int lwm2m_atof32(const char *input, float32_value_t *out);
+/* convert string to float */
+int lwm2m_atof(const char *input, double *out);
+/* convert float to string */
+int lwm2m_ftoa(double *input, char *out, size_t outlen, int8_t dec_limit);
 
 #endif /* LWM2M_UTIL_H_ */


### PR DESCRIPTION
Replace the custom float32_value_t LwM2M type with native double, to
facilitate LwM2M API and improve floating point precission.

A follow up on #37146, this time LwM2M no longer enforces FPU, enabling to use soft FP as well. Tested with qemu_x86 and native_posix, work fine in both cases.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>