### PR TITLE
mmu: fix virt_region_alloc() unused region free when aligned

### DIFF
--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -313,8 +313,10 @@ static void *virt_region_alloc(size_t size, size_t align)
 		/* Free the two unused regions */
 		virt_region_free(UINT_TO_POINTER(dest_addr),
 				 aligned_dest_addr - dest_addr);
-		virt_region_free(UINT_TO_POINTER(aligned_dest_addr + size),
-				 (dest_addr + alloc_size) - (aligned_dest_addr + size));
+		if (((dest_addr + alloc_size) - (aligned_dest_addr + size)) > 0) {
+			virt_region_free(UINT_TO_POINTER(aligned_dest_addr + size),
+					 (dest_addr + alloc_size) - (aligned_dest_addr + size));
+		}
 
 		dest_addr = aligned_dest_addr;
 	}


### PR DESCRIPTION
In the case where the aligned memory range is on top of the allocated
memory range, freeing the 0 sized top unused memory will trigger
an assert in the virt_region_free() call since vaddr could be equal
to Z_VIRT_REGION_END_ADDR.

Fixes #39186 

Signed-off-by: Neil Armstrong <narmstrong@baylibre.com>