### PR TITLE
doc: autopts-linux: fix GSG reference

### DIFF
--- a/doc/guides/bluetooth/autopts/autopts-linux.rst
+++ b/doc/guides/bluetooth/autopts/autopts-linux.rst
@@ -9,6 +9,9 @@ Overview
 This tutorial shows how to setup AutoPTS client on Linux with AutoPTS server running on Windows 10
 virtual machine. Tested with Ubuntu 20.4 and Linux Mint 20.4.
 
+You must have a Zephyr development environment set up. See
+:ref:`getting_started` for details.
+
 Supported methods to test zephyr bluetooth host:
 
 - Testing Zephyr Host Stack on QEMU
@@ -22,11 +25,6 @@ For running with QEMU or native posix, please visit:
 
 Setup Linux
 ===========================
-
-Setup Zephyr project
----------------------
-
-Do the setup from `Getting Started Guide <https://docs.zephyrproject.org/latest/getting_started/index.html>`_.
 
 Install nrftools (only required in the actual hardware test mode)
 =================================================================


### PR DESCRIPTION
Commit 3f6737f6886880f4fe4245d7aa8f30a2e11f3f51
("doc: autopts: Remove duplication of getting started guide") removed
duplicated text by linking to the getting started guide.

However, the link format is not correct. It is using a link to the
latest upstream Zephyr getting started guide. This has two problems:

  1. It will link to the wrong document when the autopts guide
     is part of an official release documentation. For example,
     the Zephyr 3.0 release documentation HTML page for these
     docs will be linking to the main branch GSG, not the v3.0
     getting started guide. This combination will not be correct
     in general because dependencies change.

  2. It breaks downstream distributions which bundle their own
     versions of the Zephyr documentation as well, for similar
     reasons.

The two documents are part of the same Sphinx docset, so the right way
to do this is with :ref. Fix it.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>