### PR TITLE
riscv: linker.ld: Fix undefined reference linker error

### DIFF
--- a/include/arch/riscv/common/linker.ld
+++ b/include/arch/riscv/common/linker.ld
@@ -320,7 +320,7 @@ GROUP_START(ITCM)
 	} GROUP_LINK_IN(ITCM AT> ROMABLE_REGION)
 
 	__itcm_size = __itcm_end - __itcm_start;
-	__itcm_rom_start = LOADADDR(_ITCM_SECTION_NAME);
+	__itcm_load_start = LOADADDR(_ITCM_SECTION_NAME);
 
 GROUP_END(ITCM)
 #endif
@@ -355,7 +355,7 @@ GROUP_START(DTCM)
 
 	__dtcm_end = .;
 
-	__dtcm_data_rom_start = LOADADDR(_DTCM_DATA_SECTION_NAME);
+	__dtcm_data_load_start = LOADADDR(_DTCM_DATA_SECTION_NAME);
 
 GROUP_END(DTCM)
 #endif


### PR DESCRIPTION
The commit a28830b aligned the data and rename some symbols.  However there are two symbols at riscv linker script that were missing, which causes below linker error:

```
kernel/xip.c:28: undefined reference to `__itcm_load_start'
kernel/xip.c:43: undefined reference to `__dtcm_data_load_start'
```
Rename below symbols to fix the issues.

```
__itcm_rom_start -> __itcm_load_start
__dtcm_data_rom_start -> __dtcm_data_load_start
```
Signed-off-by: Gerson Fernando Budke <nandojve@gmail.com>