### PR TITLE
shell: Add __printf_like to shell_fprintf

### DIFF
--- a/drivers/edac/shell.c
+++ b/drivers/edac/shell.c
@@ -131,7 +131,7 @@ static int cmd_inject_addr(const struct shell *shell, size_t argc, char **argv)
 		}
 
 		shell_fprintf(shell, SHELL_NORMAL,
-			      "Injection address base: 0x%lx\n", addr);
+			      "Injection address base: 0x%llx\n", addr);
 	} else {
 		unsigned long value = strtoul(argv[1], NULL, 16);
 
@@ -177,12 +177,12 @@ static int cmd_inject_mask(const struct shell *shell, size_t argc, char **argv)
 		}
 
 		shell_fprintf(shell, SHELL_NORMAL,
-			      "Injection address mask: 0x%lx\n", mask);
+			      "Injection address mask: 0x%llx\n", mask);
 	} else {
 		uint64_t value = strtoul(argv[1], NULL, 16);
 
 		shell_fprintf(shell, SHELL_NORMAL,
-			      "Set injection address mask to %lx\n", value);
+			      "Set injection address mask to %llx\n", value);
 
 		err = edac_inject_set_param2(dev, value);
 		if (err != 0) {
@@ -354,7 +354,7 @@ static int cmd_ecc_error_show(const struct shell *shell, size_t argc,
 		return err;
 	}
 
-	shell_fprintf(shell, SHELL_NORMAL, "ECC Error: 0x%lx\n", error);
+	shell_fprintf(shell, SHELL_NORMAL, "ECC Error: 0x%llx\n", error);
 
 	if (error != 0) {
 		decode_ecc_error(shell, error);
@@ -413,7 +413,7 @@ static int cmd_parity_error_show(const struct shell *shell, size_t argc,
 		return err;
 	}
 
-	shell_fprintf(shell, SHELL_NORMAL, "Parity Error: 0x%lx\n", error);
+	shell_fprintf(shell, SHELL_NORMAL, "Parity Error: 0x%llx\n", error);
 
 	return 0;
 }

--- a/drivers/pcie/host/shell.c
+++ b/drivers/pcie/host/shell.c
@@ -89,7 +89,7 @@ static void show_bars(const struct shell *shell, pcie_bdf_t bdf)
 		}
 
 		shell_fprintf(shell, SHELL_NORMAL, "%08x\n",
-			      PCIE_CONF_BAR_ADDR(data));
+			      (uint32_t)PCIE_CONF_BAR_ADDR(data));
 	}
 }
 

--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -902,8 +902,9 @@ int shell_stop(const struct shell *shell);
  * @param[in] fmt	Format string.
  * @param[in] ...	List of parameters to print.
  */
-void shell_fprintf(const struct shell *shell, enum shell_vt100_color color,
-		   const char *fmt, ...);
+void __printf_like(3, 4) shell_fprintf(const struct shell *shell,
+				       enum shell_vt100_color color,
+				       const char *fmt, ...);
 
 /**
  * @brief vprintf-like function which sends formatted data stream to the shell.

--- a/samples/drivers/flash_shell/src/main.c
+++ b/samples/drivers/flash_shell/src/main.c
@@ -351,7 +351,7 @@ static int cmd_write_block_size(const struct shell *shell, size_t argc,
 	int err = check_flash_device(shell);
 
 	if (!err) {
-		PR_SHELL(shell, "%d\n",
+		PR_SHELL(shell, "%zu\n",
 			 flash_get_write_block_size(flash_device));
 	}
 
@@ -535,7 +535,7 @@ static bool page_layout_cb(const struct flash_pages_info *info, void *datav)
 	sz = info->size;
 	PR_SHELL(data->shell,
 		 "\tPage %u: start 0x%08x, length 0x%lx (%lu, %lu KB)\n",
-		 info->index, info->start_offset, sz, sz, sz / KB(1));
+		 info->index, (uint32_t)info->start_offset, sz, sz, sz / KB(1));
 	return true;
 }
 
@@ -653,8 +653,8 @@ static int cmd_page_erase(const struct shell *shell, size_t argc, char **argv)
 		}
 		PR_SHELL(shell, "Erasing page %u (start offset 0x%x,"
 				" size 0x%x)\n",
-		       info.index, info.start_offset, info.size);
-		ret = do_erase(shell, info.start_offset, info.size);
+		       info.index, (uint32_t)info.start_offset, (uint32_t)info.size);
+		ret = do_erase(shell, info.start_offset, (uint32_t)info.size);
 		if (ret) {
 			return ret;
 		}
@@ -690,7 +690,7 @@ static int cmd_page_write(const struct shell *shell, size_t argc, char **argv)
 	for (i = 0; i < argc; i++) {
 		if (parse_u8(argv[i], &buf[i])) {
 			PR_ERROR(shell, "Argument %d (%s) is not a byte.\n",
-				 i + 2, argv[i]);
+				 (int)i + 2, argv[i]);
 			ret = -EINVAL;
 			goto bail;
 		}

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -1670,7 +1670,7 @@ static int cmd_per_adv_sync_delete(const struct shell *sh, size_t argc,
 	}
 
 	if (index >= ARRAY_SIZE(per_adv_syncs)) {
-		shell_error(sh, "Maximum index is %u but %u was requested",
+		shell_error(sh, "Maximum index is %ld but %d was requested",
 			    ARRAY_SIZE(per_adv_syncs) - 1, index);
 	}
 
@@ -1807,7 +1807,7 @@ static int cmd_per_adv_sync_transfer(const struct shell *sh, size_t argc,
 	}
 
 	if (index >= ARRAY_SIZE(per_adv_syncs)) {
-		shell_error(sh, "Maximum index is %u but %u was requested",
+		shell_error(sh, "Maximum index is %ld but %d was requested",
 			    ARRAY_SIZE(per_adv_syncs) - 1, index);
 	}
 

--- a/subsys/bluetooth/shell/iso.c
+++ b/subsys/bluetooth/shell/iso.c
@@ -510,7 +510,7 @@ static int cmd_big_term(const struct shell *sh, size_t argc, char *argv[])
 
 	err = bt_iso_big_terminate(big);
 	if (err) {
-		shell_error(sh, "Unable to terminate BIG", err);
+		shell_error(sh, "Unable to terminate BIG (err %d)", err);
 		return 0;
 	}
 

--- a/subsys/bluetooth/shell/l2cap.c
+++ b/subsys/bluetooth/shell/l2cap.c
@@ -131,7 +131,7 @@ static void l2cap_sent(struct bt_l2cap_chan *chan)
 
 static void l2cap_status(struct bt_l2cap_chan *chan, atomic_t *status)
 {
-	shell_print(ctx_shell, "Channel %p status %u", chan, status);
+	shell_print(ctx_shell, "Channel %p status %u", chan, (uint32_t)*status);
 }
 
 static void l2cap_connected(struct bt_l2cap_chan *chan)

--- a/subsys/bluetooth/shell/mics.c
+++ b/subsys/bluetooth/shell/mics.c
@@ -135,7 +135,7 @@ static int cmd_mics_param(const struct shell *sh, size_t argc, char **argv)
 		return result;
 	}
 
-	shell_print(sh, "MICS initialized", result);
+	shell_print(sh, "MICS initialized: %d", result);
 
 	result = bt_mics_included_get(NULL, &mics_included);
 	if (result != 0) {

--- a/subsys/fs/shell.c
+++ b/subsys/fs/shell.c
@@ -307,7 +307,7 @@ static int cmd_read(const struct shell *shell, size_t argc, char **argv)
 			break;
 		}
 
-		shell_fprintf(shell, SHELL_NORMAL, "%08X  ", offset);
+		shell_fprintf(shell, SHELL_NORMAL, "%08X  ", (uint32_t)offset);
 
 		for (i = 0; i < read; i++) {
 			shell_fprintf(shell, SHELL_NORMAL, "%02X ", buf[i]);

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -1059,7 +1059,7 @@ static void print_tc_tx_stats(const struct shell *shell, struct net_if *iface)
 			   GET_STAT(iface, tc.sent[i].pkts),
 			   GET_STAT(iface, tc.sent[i].bytes));
 		} else {
-			PR("[%d] %s (%d)\t%d\t\t%d\t%lu us%s\n", i,
+			PR("[%d] %s (%d)\t%d\t\t%d\t%u us%s\n", i,
 			   priority2str(GET_STAT(iface, tc.sent[i].priority)),
 			   GET_STAT(iface, tc.sent[i].priority),
 			   GET_STAT(iface, tc.sent[i].pkts),
@@ -1118,7 +1118,7 @@ static void print_tc_rx_stats(const struct shell *shell, struct net_if *iface)
 			   GET_STAT(iface, tc.recv[i].pkts),
 			   GET_STAT(iface, tc.recv[i].bytes));
 		} else {
-			PR("[%d] %s (%d)\t%d\t\t%d\t%lu us%s\n", i,
+			PR("[%d] %s (%d)\t%d\t\t%d\t%u us%s\n", i,
 			   priority2str(GET_STAT(iface, tc.recv[i].priority)),
 			   GET_STAT(iface, tc.recv[i].priority),
 			   GET_STAT(iface, tc.recv[i].pkts),
@@ -1167,7 +1167,7 @@ static void print_net_pm_stats(const struct shell *shell, struct net_if *iface)
 	PR("\tAverage time  : %u ms\n",
 	   (uint32_t)(GET_STAT(iface, pm.overall_suspend_time) /
 		   GET_STAT(iface, pm.suspend_count)));
-	PR("\tTotal time    : %llu ms\n",
+	PR("\tTotal time    : %" PRIu64 " ms\n",
 	   GET_STAT(iface, pm.overall_suspend_time));
 	PR("\tHow many times: %u\n",
 	   GET_STAT(iface, pm.suspend_count));
@@ -3004,9 +3004,9 @@ static void gptp_print_port_info(const struct shell *shell, int port)
 	PR("Estimate of the ratio of the frequency with the peer          "
 	   ": %u\n", (uint32_t)port_ds->neighbor_rate_ratio);
 	PR("Asymmetry on the link relative to the grand master time base  "
-	   ": %lld\n", port_ds->delay_asymmetry);
+	   ": %" PRId64 "\n", port_ds->delay_asymmetry);
 	PR("Maximum interval between sync %s                        "
-	   ": %llu\n", "messages",
+	   ": %" PRIu64 "\n", "messages",
 	   port_ds->sync_receipt_timeout_time_itv);
 	PR("Maximum number of Path Delay Requests without a response      "
 	   ": %d\n", port_ds->allowed_lost_responses);
@@ -3041,16 +3041,16 @@ static void gptp_print_port_info(const struct shell *shell, int port)
 	   gptp_uscaled_ns_to_timer_ms(
 		   &port_bmca_data->ann_rcpt_timeout_time_interval),
 	   port_ds->announce_receipt_timeout);
-	PR("Time without receiving sync %s %s      : %llu ms (%d)\n",
+	PR("Time without receiving sync %s %s      : %" PRIu64 " ms (%d)\n",
 	   "messages", "before running BMCA",
 	   (port_ds->sync_receipt_timeout_time_itv >> 16) /
 					(NSEC_PER_SEC / MSEC_PER_SEC),
 	   port_ds->sync_receipt_timeout);
-	PR("Sync event %s                 : %llu ms\n",
+	PR("Sync event %s                 : %" PRIu64 " ms\n",
 	   "transmission interval for the port",
 	   USCALED_NS_TO_NS(port_ds->half_sync_itv.low) /
 					(NSEC_PER_USEC * USEC_PER_MSEC));
-	PR("Path Delay Request %s         : %llu ms\n",
+	PR("Path Delay Request %s         : %" PRIu64 " ms\n",
 	   "transmission interval for the port",
 	   USCALED_NS_TO_NS(port_ds->pdelay_req_itv.low) /
 					(NSEC_PER_USEC * USEC_PER_MSEC));
@@ -3068,9 +3068,9 @@ static void gptp_print_port_info(const struct shell *shell, int port)
 	PR("\tCurrent state                                    "
 	   ": %s\n", pdelay_req2str(port_state->pdelay_req.state));
 	PR("\tInitial Path Delay Response Peer Timestamp       "
-	   ": %llu\n", port_state->pdelay_req.ini_resp_evt_tstamp);
+	   ": %" PRIu64 "\n", port_state->pdelay_req.ini_resp_evt_tstamp);
 	PR("\tInitial Path Delay Response Ingress Timestamp    "
-	   ": %llu\n", port_state->pdelay_req.ini_resp_ingress_tstamp);
+	   ": %" PRIu64 "\n", port_state->pdelay_req.ini_resp_ingress_tstamp);
 	PR("\tPath Delay Response %s %s            : %u\n",
 	   "messages", "received",
 	   port_state->pdelay_req.rcvd_pdelay_resp);
@@ -3106,7 +3106,7 @@ static void gptp_print_port_info(const struct shell *shell, int port)
 	   port_state->sync_rcv.follow_up_timeout_expired ? "yes" : "no");
 	PR("\tTime at which a Sync %s without Follow Up\n"
 	   "\t                             will be discarded   "
-	   ": %llu\n", "Message",
+	   ": %" PRIu64 "\n", "Message",
 	   port_state->sync_rcv.follow_up_receipt_timeout);
 
 	PR("SyncSend state machine variables:\n");
@@ -3134,10 +3134,10 @@ static void gptp_print_port_info(const struct shell *shell, int port)
 	PR("\tCurrent state                                    "
 	   ": %s\n", pss_send2str(port_state->pss_send.state));
 	PR("\tFollow Up Correction Field of last recv PSS      "
-	   ": %lld\n",
+	   ": %" PRId64 "\n",
 	   port_state->pss_send.last_follow_up_correction_field);
 	PR("\tUpstream Tx Time of the last recv PortSyncSync   "
-	   ": %llu\n", port_state->pss_send.last_upstream_tx_time);
+	   ": %" PRIu64 "\n", port_state->pss_send.last_upstream_tx_time);
 	PR("\tRate Ratio of the last received PortSyncSync     "
 	   ": %f\n",
 	   port_state->pss_send.last_rate_ratio);
@@ -4785,7 +4785,7 @@ static void tcp_recv_cb(struct net_context *context, struct net_pkt *pkt,
 		return;
 	}
 
-	PR_SHELL(tcp_shell, "%d bytes received\n", net_pkt_get_len(pkt));
+	PR_SHELL(tcp_shell, "%zu bytes received\n", net_pkt_get_len(pkt));
 }
 #endif
 
@@ -5614,7 +5614,7 @@ static void websocket_context_cb(struct websocket_context *context,
 
 	net_ctx = z_get_fd_obj(context->real_sock, NULL, 0);
 	if (net_ctx == NULL) {
-		PR_ERROR("Invalid fd %d");
+		PR_ERROR("Invalid fd %d", context->real_sock);
 		return;
 	}
 

--- a/subsys/shell/modules/devmem_service.c
+++ b/subsys/shell/modules/devmem_service.c
@@ -135,7 +135,7 @@ static int cmd_load(const struct shell *sh, size_t argc, char **argv)
 
 static int memory_read(const struct shell *sh, mem_addr_t addr, uint8_t width)
 {
-	uint64_t value;
+	uint32_t value;
 	int err = 0;
 
 	switch (width) {
@@ -155,7 +155,7 @@ static int memory_read(const struct shell *sh, mem_addr_t addr, uint8_t width)
 	}
 
 	if (err == 0) {
-		shell_fprintf(sh, SHELL_NORMAL, "Read value 0x%lx\n", value);
+		shell_fprintf(sh, SHELL_NORMAL, "Read value 0x%x\n", value);
 	}
 
 	return err;
@@ -223,7 +223,7 @@ static int cmd_devmem(const struct shell *sh, size_t argc, char **argv)
 
 	value = strtoul(argv[3], NULL, 16);
 
-	shell_fprintf(sh, SHELL_NORMAL, "Writing value 0x%lx\n", value);
+	shell_fprintf(sh, SHELL_NORMAL, "Writing value 0x%x\n", value);
 
 	return memory_write(sh, addr, width, value);
 }

--- a/subsys/shell/modules/kernel_service.c
+++ b/subsys/shell/modules/kernel_service.c
@@ -73,12 +73,13 @@ static void shell_tdata_dump(const struct k_thread *cthread, void *user_data)
 		      (thread == k_current_get()) ? "*" : " ",
 		      thread,
 		      tname ? tname : "NA");
-	shell_print(shell, "\toptions: 0x%x, priority: %d timeout: %d",
+	/* Cannot use lld as it's less portable. */
+	shell_print(shell, "\toptions: 0x%x, priority: %d timeout: %" PRId64,
 		      thread->base.user_options,
 		      thread->base.prio,
-		      thread->base.timeout.dticks);
+		      (int64_t)thread->base.timeout.dticks);
 	shell_print(shell, "\tstate: %s, entry: %p", k_thread_state_str(thread),
-		    thread->entry);
+		    thread->entry.pEntry);
 
 #ifdef CONFIG_THREAD_RUNTIME_STATS
 	ret = 0;
@@ -107,7 +108,7 @@ static void shell_tdata_dump(const struct k_thread *cthread, void *user_data)
 			    rt_stats_thread.execution_cycles,
 			    pcnt);
 #else
-		shell_print(shell, "\tTotal execution cycles: %lu (%u %%)",
+		shell_print(shell, "\tTotal execution cycles: %u (%u %%)",
 			    (uint32_t)rt_stats_thread.execution_cycles,
 			    pcnt);
 #endif
@@ -167,7 +168,7 @@ static void shell_stack_dump(const struct k_thread *thread, void *user_data)
 	pcnt = ((size - unused) * 100U) / size;
 
 	shell_print((const struct shell *)user_data,
-		"%p %-10s (real size %u):\tunused %u\tusage %u / %u (%u %%)",
+		"%p %-10s (real size %zu):\tunused %zu\tusage %zu / %zu (%u %%)",
 		      thread,
 		      tname ? tname : "NA",
 		      size, unused, size - unused, size, pcnt);

--- a/subsys/shell/shell_cmds.c
+++ b/subsys/shell/shell_cmds.c
@@ -296,7 +296,7 @@ static int cmd_history(const struct shell *shell, size_t argc, char **argv)
 
 		if (len) {
 			shell_print(shell, "[%3d] %s",
-				    i++, shell->ctx->temp_buff);
+				    (int)i++, shell->ctx->temp_buff);
 
 		} else {
 			break;


### PR DESCRIPTION
Add __printf_like modifier to validate strings used by shell.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>