### PR TITLE
checkpatch: Ignore IS_ENABLED_CONFIG warnings

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -28,4 +28,5 @@
 --ignore COMPLEX_MACRO
 --ignore MULTISTATEMENT_MACRO_USE_DO_WHILE
 --ignore ENOSYS
+--ignore IS_ENABLED_CONFIG
 --exclude ext


### PR DESCRIPTION
Warning IS_ENABLED_CONFIG allows checkpatch.pl to generate a warning
when IS_ENABLED macro is used with an argument which is not a CONFIG_
symbol.
This is abusive as the macro definition implicitly mentions it could
be used with other symbols ("It is often used with a @p CONFIG_FOO").

In Zephyr, IS_ENABLED macro is also used with for instance DT macros,
which generates github CI failures, which then requires waiver from
maintainers.
Make things more simple by just removing this warning.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>