### PR TITLE
mbedtls: config: enable sha384 if sha512 is enabled

### DIFF
--- a/modules/mbedtls/configs/config-tls-generic.h
+++ b/modules/mbedtls/configs/config-tls-generic.h
@@ -250,6 +250,7 @@
 #endif
 
 #if defined(CONFIG_MBEDTLS_MAC_SHA512_ENABLED)
+#define MBEDTLS_SHA384_C
 #define MBEDTLS_SHA512_C
 #endif
 


### PR DESCRIPTION
There is no specific switch for sha384 oid. Enable it if sha512 present
