### PR TITLE
pm: optimize resources

### DIFF
--- a/drivers/display/display_st7735r.c
+++ b/drivers/display/display_st7735r.c
@@ -573,7 +573,10 @@ static const struct display_driver_api st7735r_api = {
 		.x_offset = DT_INST_PROP(inst, x_offset),			\
 		.y_offset = DT_INST_PROP(inst, y_offset),			\
 	};									\
-	DEVICE_DT_INST_DEFINE(inst, st7735r_init, st7735r_pm_action,		\
+										\
+	PM_DEVICE_DT_INST_DEFINE(inst, st7735r_pm_action);			\
+										\
+	DEVICE_DT_INST_DEFINE(inst, st7735r_init, PM_DEVICE_DT_INST_REF(inst),	\
 			      &st7735r_data_ ## inst, &st7735r_config_ ## inst,	\
 			      POST_KERNEL, CONFIG_DISPLAY_INIT_PRIORITY,	\
 			      &st7735r_api);

--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -438,6 +438,8 @@ static struct st7789v_data st7789v_data = {
 	.y_offset = DT_INST_PROP(0, y_offset),
 };
 
+PM_DEVICE_DT_INST_DEFINE(0, st7789v_pm_action);
+
 DEVICE_DT_INST_DEFINE(0, &st7789v_init,
-	      st7789v_pm_action, &st7789v_data, NULL, POST_KERNEL,
+	      PM_DEVICE_DT_INST_REF(0), &st7789v_data, NULL, POST_KERNEL,
 	      CONFIG_DISPLAY_INIT_PRIORITY, &st7789v_api);

--- a/drivers/entropy/entropy_cc13xx_cc26xx.c
+++ b/drivers/entropy/entropy_cc13xx_cc26xx.c
@@ -349,9 +349,11 @@ static struct entropy_cc13xx_cc26xx_data entropy_cc13xx_cc26xx_data = {
 	.sync = Z_SEM_INITIALIZER(entropy_cc13xx_cc26xx_data.sync, 0, 1),
 };
 
+PM_DEVICE_DT_INST_DEFINE(0, entropy_cc13xx_cc26xx_pm_action);
+
 DEVICE_DT_INST_DEFINE(0,
 		entropy_cc13xx_cc26xx_init,
-		entropy_cc13xx_cc26xx_pm_action,
+		PM_DEVICE_DT_INST_REF(0),
 		&entropy_cc13xx_cc26xx_data, NULL,
 		PRE_KERNEL_1, CONFIG_ENTROPY_INIT_PRIORITY,
 		&entropy_cc13xx_cc26xx_driver_api);

--- a/drivers/entropy/entropy_neorv32_trng.c
+++ b/drivers/entropy/entropy_neorv32_trng.c
@@ -129,20 +129,16 @@ static const struct entropy_driver_api neorv32_trng_driver_api = {
 	.get_entropy_isr = neorv32_trng_get_entropy_isr,
 };
 
-#ifdef CONFIG_PM_DEVICE
-#define NEORV32_TRNG_PM_ACTION_CB neorv32_trng_pm_action
-#else /* CONFIG_PM_DEVICE */
-#define NEORV32_TRNG_PM_ACTION_CB NULL
-#endif /* ! CONFIG_PM_DEVICE */
-
 #define NEORV32_TRNG_INIT(n)						\
 	static const struct neorv32_trng_config neorv32_trng_##n##_config = { \
 		.syscon = DEVICE_DT_GET(DT_INST_PHANDLE(n, syscon)),	\
 		.base = DT_INST_REG_ADDR(n),				\
 	};								\
 									\
+	PM_DEVICE_DT_INST_DEFINE(n, neorv32_trng_pm_action);		\
+									\
 	DEVICE_DT_INST_DEFINE(n, &neorv32_trng_init,			\
-			 NEORV32_TRNG_PM_ACTION_CB,			\
+			 PM_DEVICE_DT_INST_REF(n),			\
 			 NULL,						\
 			 &neorv32_trng_##n##_config,			\
 			 PRE_KERNEL_1,					\

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -230,11 +230,6 @@ out:
 
 	return ret;
 }
-
-#define ETH_MCUX_PM_ACTION_CB eth_mcux_device_pm_action
-
-#else
-#define ETH_MCUX_PM_ACTION_CB NULL
 #endif /* CONFIG_NET_POWER_MANAGEMENT */
 
 #if ETH_MCUX_FIXED_LINK
@@ -1393,9 +1388,11 @@ static void eth_mcux_err_isr(const struct device *dev)
 		ETH_MCUX_PTP_FRAMEINFO(n)				\
 	};								\
 									\
-	ETH_NET_DEVICE_DT_INST_DEFINE(n,					\
+	PM_DEVICE_DT_INST_DEFINE(n, eth_mcux_device_pm_action);		\
+									\
+	ETH_NET_DEVICE_DT_INST_DEFINE(n,				\
 			    eth_init,					\
-			    ETH_MCUX_PM_ACTION_CB,			\
+			    PM_DEVICE_DT_INST_REF(n),			\
 			    &eth##n##_context,				\
 			    &eth##n##_buffer_config,			\
 			    CONFIG_ETH_INIT_PRIORITY,			\

--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -1139,8 +1139,6 @@ static int qspi_nor_pm_action(const struct device *dev,
 
 	return 0;
 }
-#else
-#define qspi_nor_pm_action NULL
 #endif /* CONFIG_PM_DEVICE */
 
 static struct qspi_nor_data qspi_nor_dev_data = {
@@ -1196,7 +1194,9 @@ static const struct qspi_nor_config qspi_nor_dev_config = {
 	.id = DT_INST_PROP(0, jedec_id),
 };
 
-DEVICE_DT_INST_DEFINE(0, qspi_nor_init, qspi_nor_pm_action,
+PM_DEVICE_DT_INST_DEFINE(0, qspi_nor_pm_action);
+
+DEVICE_DT_INST_DEFINE(0, qspi_nor_init, PM_DEVICE_DT_INST_REF(0),
 		      &qspi_nor_dev_data, &qspi_nor_dev_config,
 		      POST_KERNEL, CONFIG_NORDIC_QSPI_NOR_INIT_PRIORITY,
 		      &qspi_nor_api);

--- a/drivers/flash/spi_flash_at45.c
+++ b/drivers/flash/spi_flash_at45.c
@@ -699,8 +699,11 @@ static const struct flash_driver_api spi_flash_at45_api = {
 			"Page size specified for instance " #idx " of "	     \
 			"atmel,at45 is not compatible with its "	     \
 			"total size");))				     \
+									     \
+	PM_DEVICE_DT_INST_DEFINE(idx, spi_flash_at45_pm_action);	     \
+									     \
 	DEVICE_DT_INST_DEFINE(idx,					     \
-		      spi_flash_at45_init, spi_flash_at45_pm_action,	     \
+		      spi_flash_at45_init, PM_DEVICE_DT_INST_REF(idx),	     \
 		      &inst_##idx##_data, &inst_##idx##_config,		     \
 		      POST_KERNEL, CONFIG_SPI_FLASH_AT45_INIT_PRIORITY,      \
 		      &spi_flash_at45_api);

--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -534,8 +534,10 @@ static struct gpio_dw_runtime gpio_0_runtime = {
 	.base_addr = DT_INST_REG_ADDR(0),
 };
 
+PM_DEVICE_DT_INST_DEFINE(0, gpio_dw_device_pm_action);
+
 DEVICE_DT_INST_DEFINE(0,
-	      gpio_dw_initialize, gpio_dw_device_pm_action, &gpio_0_runtime,
+	      gpio_dw_initialize, PM_DEVICE_DT_INST_REF(0), &gpio_0_runtime,
 	      &gpio_config_0, POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
 	      &api_funcs);
 
@@ -596,8 +598,10 @@ static struct gpio_dw_runtime gpio_1_runtime = {
 	.base_addr = DT_INST_REG_ADDR(1),
 };
 
+PM_DEVICE_DT_INST_DEFINE(1, gpio_dw_device_pm_action);
+
 DEVICE_DT_INST_DEFINE(1,
-	      gpio_dw_initialize, gpio_dw_device_pm_action, &gpio_1_runtime,
+	      gpio_dw_initialize, PM_DEVICE_DT_INST_REF(1), &gpio_1_runtime,
 	      &gpio_dw_config_1, POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
 	      &api_funcs);
 
@@ -657,8 +661,10 @@ static struct gpio_dw_runtime gpio_2_runtime = {
 	.base_addr = DT_INST_REG_ADDR(2),
 };
 
+PM_DEVICE_DT_INST_DEFINE(2, gpio_dw_device_pm_action);
+
 DEVICE_DT_INST_DEFINE(2,
-	      gpio_dw_initialize, gpio_dw_device_pm_action, &gpio_2_runtime,
+	      gpio_dw_initialize, PM_DEVICE_DT_INST_REF(2), &gpio_2_runtime,
 	      &gpio_dw_config_2, POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
 	      &api_funcs);
 
@@ -718,8 +724,10 @@ static struct gpio_dw_runtime gpio_3_runtime = {
 	.base_addr = DT_INST_REG_ADDR(3),
 };
 
+PM_DEVICE_DT_INST_DEFINE(3, gpio_dw_device_pm_action);
+
 DEVICE_DT_INST_DEFINE(3,
-	      gpio_dw_initialize, gpio_dw_device_pm_action, &gpio_3_runtime,
+	      gpio_dw_initialize, PM_DEVICE_DT_INST_REF(3), &gpio_3_runtime,
 	      &gpio_dw_config_3, POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
 	      &api_funcs);
 

--- a/drivers/gpio/gpio_emul.c
+++ b/drivers/gpio/gpio_emul.c
@@ -672,8 +672,6 @@ static int gpio_emul_pm_device_pm_action(const struct device *dev,
 
 	return 0;
 }
-#else
-#define gpio_emul_pm_device_pm_action NULL
 #endif
 
 /*
@@ -709,8 +707,10 @@ static int gpio_emul_pm_device_pm_action(const struct device *dev,
 		.flags = gpio_emul_flags_##_num,			\
 	};								\
 									\
+	PM_DEVICE_DT_INST_DEFINE(_num, gpio_emul_pm_device_pm_action);	\
+									\
 	DEVICE_DT_INST_DEFINE(_num, gpio_emul_init,			\
-			    gpio_emul_pm_device_pm_action,		\
+			    PM_DEVICE_DT_INST_REF(_num),		\
 			    &gpio_emul_data_##_num,			\
 			    &gpio_emul_config_##_num, POST_KERNEL,	\
 			    CONFIG_GPIO_INIT_PRIORITY,			\

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -630,9 +630,10 @@ static int gpio_stm32_init(const struct device *dev)
 		.pclken = { .bus = __bus, .enr = __cenr }		       \
 	};								       \
 	static struct gpio_stm32_data gpio_stm32_data_## __suffix;	       \
+	PM_DEVICE_DT_DEFINE(__node, gpio_stm32_pm_action);		       \
 	DEVICE_DT_DEFINE(__node,					       \
 			    gpio_stm32_init,				       \
-			    gpio_stm32_pm_action,			       \
+			    PM_DEVICE_DT_REF(__node),			       \
 			    &gpio_stm32_data_## __suffix,		       \
 			    &gpio_stm32_cfg_## __suffix,		       \
 			    PRE_KERNEL_1,				       \

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -717,6 +717,6 @@ static int gpio_stm32_afio_init(const struct device *dev)
 	return 0;
 }
 
-SYS_DEVICE_DEFINE("gpio_stm32_afio", gpio_stm32_afio_init, NULL, PRE_KERNEL_1, 0);
+SYS_DEVICE_DEFINE("gpio_stm32_afio", gpio_stm32_afio_init, PRE_KERNEL_1, 0);
 
 #endif /* CONFIG_SOC_SERIES_STM32F1X && !CONFIG_GPIO_STM32_SWJ_ENABLE */

--- a/drivers/i2c/i2c_cc13xx_cc26xx.c
+++ b/drivers/i2c/i2c_cc13xx_cc26xx.c
@@ -435,9 +435,11 @@ static struct i2c_cc13xx_cc26xx_data i2c_cc13xx_cc26xx_data = {
 	.error = I2C_MASTER_ERR_NONE
 };
 
+PM_DEVICE_DT_INST_DEFINE(0, i2c_cc13xx_cc26xx_pm_action);
+
 DEVICE_DT_INST_DEFINE(0,
 		i2c_cc13xx_cc26xx_init,
-		i2c_cc13xx_cc26xx_pm_action,
+		PM_DEVICE_DT_INST_REF(0),
 		&i2c_cc13xx_cc26xx_data, &i2c_cc13xx_cc26xx_config,
 		POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,
 		&i2c_cc13xx_cc26xx_driver_api);

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -285,9 +285,10 @@ static int twi_nrfx_pm_action(const struct device *dev,
 			.frequency = I2C_FREQUENCY(idx),		       \
 		}							       \
 	};								       \
+	PM_DEVICE_DT_DEFINE(I2C(idx), twi_nrfx_pm_action);		       \
 	DEVICE_DT_DEFINE(I2C(idx),					       \
 		      twi_##idx##_init,					       \
-		      twi_nrfx_pm_action,				       \
+		      PM_DEVICE_DT_REF(I2C(idx)),			       \
 		      &twi_##idx##_data,				       \
 		      &twi_##idx##z_config,				       \
 		      POST_KERNEL,					       \

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -370,9 +370,10 @@ static int twim_nrfx_pm_action(const struct device *dev,
 		.concat_buf_size = CONCAT_BUF_SIZE(idx),		       \
 		.flash_buf_max_size = FLASH_BUF_MAX_SIZE(idx),		       \
 	};								       \
+	PM_DEVICE_DT_DEFINE(I2C(idx), twim_nrfx_pm_action);		       \
 	DEVICE_DT_DEFINE(I2C(idx),					       \
 		      twim_##idx##_init,				       \
-		      twim_nrfx_pm_action,				       \
+		      PM_DEVICE_DT_REF(I2C(idx)),			       \
 		      &twim_##idx##_data,				       \
 		      &twim_##idx##z_config,				       \
 		      POST_KERNEL,					       \

--- a/drivers/interrupt_controller/intc_ioapic.c
+++ b/drivers/interrupt_controller/intc_ioapic.c
@@ -495,10 +495,5 @@ static void IoApicRedUpdateLo(unsigned int irq,
 	ioApicRedSetLo(irq, (ioApicRedGetLo(irq) & ~mask) | (value & mask));
 }
 
-
-#ifdef CONFIG_PM_DEVICE
-SYS_DEVICE_DEFINE("ioapic", ioapic_init, ioapic_pm_action, PRE_KERNEL_1,
-		  CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
-#else
-SYS_INIT(ioapic_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
-#endif
+DEVICE_DEFINE(ioapic, "ioapic", ioapic_init, ioapic_pm_action, NULL, NULL,
+	      PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);

--- a/drivers/interrupt_controller/intc_ioapic.c
+++ b/drivers/interrupt_controller/intc_ioapic.c
@@ -495,5 +495,7 @@ static void IoApicRedUpdateLo(unsigned int irq,
 	ioApicRedSetLo(irq, (ioApicRedGetLo(irq) & ~mask) | (value & mask));
 }
 
-DEVICE_DEFINE(ioapic, "ioapic", ioapic_init, ioapic_pm_action, NULL, NULL,
+PM_DEVICE_DEFINE(ioapic, ioapic_pm_action);
+
+DEVICE_DEFINE(ioapic, "ioapic", ioapic_init, PM_DEVICE_REF(ioapic), NULL, NULL,
 	      PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);

--- a/drivers/interrupt_controller/intc_loapic.c
+++ b/drivers/interrupt_controller/intc_loapic.c
@@ -426,13 +426,10 @@ static int loapic_pm_action(const struct device *dev,
 
 	return ret;
 }
+#endif /* CONFIG_PM_DEVICE */
 
-SYS_DEVICE_DEFINE("loapic", loapic_init, loapic_pm_action, PRE_KERNEL_1,
-		  CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
-#else
-SYS_INIT(loapic_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
-#endif   /* CONFIG_PM_DEVICE */
-
+DEVICE_DEFINE(loapic, "loapic", loapic_init, loapic_pm_action, NULL, NULL,
+	      PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
 
 #if CONFIG_LOAPIC_SPURIOUS_VECTOR
 extern void z_loapic_spurious_handler(void);

--- a/drivers/interrupt_controller/intc_loapic.c
+++ b/drivers/interrupt_controller/intc_loapic.c
@@ -428,7 +428,9 @@ static int loapic_pm_action(const struct device *dev,
 }
 #endif /* CONFIG_PM_DEVICE */
 
-DEVICE_DEFINE(loapic, "loapic", loapic_init, loapic_pm_action, NULL, NULL,
+PM_DEVICE_DEFINE(loapic, loapic_pm_action);
+
+DEVICE_DEFINE(loapic, "loapic", loapic_init, PM_DEVICE_REF(loapic), NULL, NULL,
 	      PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
 
 #if CONFIG_LOAPIC_SPURIOUS_VECTOR

--- a/drivers/led/led_pwm.c
+++ b/drivers/led/led_pwm.c
@@ -176,8 +176,11 @@ static const struct led_pwm_config led_pwm_config_##id = {	\
 	.led		= led_pwm_##id,				\
 };								\
 								\
-DEVICE_DT_INST_DEFINE(id, &led_pwm_init, led_pwm_pm_action,	\
-		      NULL, &led_pwm_config_##id, POST_KERNEL,	\
+PM_DEVICE_DT_INST_DEFINE(id, led_pwm_pm_action);		\
+								\
+DEVICE_DT_INST_DEFINE(id, &led_pwm_init,			\
+		      PM_DEVICE_DT_INST_REF(id), NULL,		\
+		      &led_pwm_config_##id, POST_KERNEL,	\
 		      CONFIG_LED_INIT_PRIORITY, &led_pwm_api);
 
 DT_INST_FOREACH_STATUS_OKAY(LED_PWM_DEVICE)

--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -368,8 +368,9 @@ static int pwm_nrfx_pm_action(const struct device *dev,
 		.seq.values.p_raw = pwm_nrfx_##idx##_data.current,	      \
 		.seq.length = NRF_PWM_CHANNEL_COUNT			      \
 	};								      \
+	PM_DEVICE_DT_DEFINE(PWM(idx), pwm_nrfx_pm_action);		      \
 	DEVICE_DT_DEFINE(PWM(idx),					      \
-		      pwm_nrfx_init, pwm_nrfx_pm_action,		      \
+		      pwm_nrfx_init, PM_DEVICE_DT_REF(PWM(idx)),	      \
 		      &pwm_nrfx_##idx##_data,				      \
 		      &pwm_nrfx_##idx##config,				      \
 		      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	      \

--- a/drivers/sensor/apds9960/apds9960.c
+++ b/drivers/sensor/apds9960/apds9960.c
@@ -534,6 +534,8 @@ static const struct apds9960_config apds9960_config = {
 
 static struct apds9960_data apds9960_data;
 
+PM_DEVICE_DT_INST_DEFINE(0, apds9960_pm_action);
+
 DEVICE_DT_INST_DEFINE(0, apds9960_init,
-	      apds9960_pm_action, &apds9960_data, &apds9960_config,
+	      PM_DEVICE_DT_INST_REF(0), &apds9960_data, &apds9960_config,
 	      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &apds9960_driver_api);

--- a/drivers/sensor/bme280/bme280.c
+++ b/drivers/sensor/bme280/bme280.c
@@ -447,9 +447,12 @@ static int bme280_pm_action(const struct device *dev,
 		COND_CODE_1(DT_INST_ON_BUS(inst, spi),			\
 			    (BME280_CONFIG_SPI(inst)),			\
 			    (BME280_CONFIG_I2C(inst)));			\
+									\
+	PM_DEVICE_DT_INST_DEFINE(inst, bme280_pm_action);		\
+									\
 	DEVICE_DT_INST_DEFINE(inst,					\
 			 bme280_chip_init,				\
-			 bme280_pm_action,				\
+			 PM_DEVICE_DT_INST_REF(inst),			\
 			 &bme280_data_##inst,				\
 			 &bme280_config_##inst,				\
 			 POST_KERNEL,					\

--- a/drivers/sensor/bmp388/bmp388.c
+++ b/drivers/sensor/bmp388/bmp388.c
@@ -720,10 +720,11 @@ static int bmp388_init(const struct device *dev)
 		BMP388_INT_CFG(inst)					   \
 		.iir_filter = DT_ENUM_IDX(DT_DRV_INST(inst), iir_filter),  \
 	};								   \
+	PM_DEVICE_DT_INST_DEFINE(inst, bmp388_pm_action);		   \
 	DEVICE_DT_INST_DEFINE(						   \
 		inst,							   \
 		bmp388_init,						   \
-		bmp388_pm_action,					   \
+		PM_DEVICE_DT_INST_REF(inst),				   \
 		&bmp388_data_##inst,					   \
 		&bmp388_config_##inst,					   \
 		POST_KERNEL,						   \

--- a/drivers/sensor/bq274xx/bq274xx.c
+++ b/drivers/sensor/bq274xx/bq274xx.c
@@ -773,7 +773,10 @@ static const struct sensor_driver_api bq274xx_battery_driver_api = {
 		.terminate_voltage = DT_INST_PROP(index, terminate_voltage),   \
 	};                                                                     \
 									       \
-	DEVICE_DT_INST_DEFINE(index, &bq274xx_gauge_init, bq274xx_pm_action,   \
+	PM_DEVICE_DT_INST_DEFINE(index, bq274xx_pm_action);		       \
+									       \
+	DEVICE_DT_INST_DEFINE(index, &bq274xx_gauge_init,		       \
+			    PM_DEVICE_DT_INST_REF(index),		       \
 			    &bq274xx_driver_##index,                           \
 			    &bq274xx_config_##index, POST_KERNEL,              \
 			    CONFIG_SENSOR_INIT_PRIORITY,                       \

--- a/drivers/sensor/fdc2x1x/fdc2x1x.c
+++ b/drivers/sensor/fdc2x1x/fdc2x1x.c
@@ -1025,9 +1025,11 @@ static int fdc2x1x_init(const struct device *dev)
 		FDC2X1X_INTB(n)						   \
 	};								   \
 									   \
+	PM_DEVICE_DT_INST_DEFINE(n, fdc2x1x_device_pm_action);		   \
+									   \
 	DEVICE_DT_INST_DEFINE(n,					   \
 			      fdc2x1x_init,				   \
-			      fdc2x1x_device_pm_action,			   \
+			      PM_DEVICE_DT_INST_REF(n),			   \
 			      &fdc2x1x_data_##n,			   \
 			      &fdc2x1x_config_##n,			   \
 			      POST_KERNEL,				   \

--- a/drivers/sensor/ina219/ina219.c
+++ b/drivers/sensor/ina219/ina219.c
@@ -302,9 +302,11 @@ static const struct sensor_driver_api ina219_api = {
 		.mode = INA219_MODE_NORMAL			\
 	};							\
 								\
+	PM_DEVICE_DT_INST_DEFINE(n, ina219_pm_action);		\
+								\
 	DEVICE_DT_INST_DEFINE(n,				\
 			      ina219_init,			\
-			      ina219_pm_action,			\
+			      PM_DEVICE_DT_INST_REF(n),		\
 			      &ina219_data_##n,			\
 			      &ina219_config_##n,		\
 			      POST_KERNEL,			\

--- a/drivers/sensor/lis2mdl/lis2mdl.c
+++ b/drivers/sensor/lis2mdl/lis2mdl.c
@@ -488,9 +488,11 @@ static int lis2mdl_pm_action(const struct device *dev,
  */
 
 #define LIS2MDL_DEVICE_INIT(inst)					\
+	PM_DEVICE_DT_INST_DEFINE(inst, lis2mdl_pm_action);		\
+									\
 	DEVICE_DT_INST_DEFINE(inst,					\
 			    lis2mdl_init,				\
-			    lis2mdl_pm_action,				\
+			    PM_DEVICE_DT_INST_REF(inst),		\
 			    &lis2mdl_data_##inst,			\
 			    &lis2mdl_config_##inst,			\
 			    POST_KERNEL,				\

--- a/drivers/sensor/lm77/lm77.c
+++ b/drivers/sensor/lm77/lm77.c
@@ -395,12 +395,6 @@ static int lm77_pm_action(const struct device *dev,
 #define LM77_INT_GPIO_INIT(n)
 #endif /* ! LM77_TRIGGER_SUPPORT */
 
-#ifdef CONFIG_PM_DEVICE
-#define LM77_PM_ACTION_CB lm77_pm_action
-#else /* CONFIG_PM_DEVICE */
-#define LM77_PM_ACTION_CB NULL
-#endif /* ! CONFIG_PM_DEVICE */
-
 #define LM77_INIT(n)							\
 	static struct lm77_data lm77_data_##n;				\
 									\
@@ -417,8 +411,10 @@ static int lm77_pm_action(const struct device *dev,
 		LM77_INT_GPIO_INIT(n)					\
 	};								\
 									\
+	PM_DEVICE_DT_INST_DEFINE(n, lm77_pm_action);			\
+									\
 	DEVICE_DT_INST_DEFINE(n, lm77_init,				\
-			      LM77_PM_ACTION_CB,			\
+			      PM_DEVICE_DT_INST_REF(n),			\
 			      &lm77_data_##n,				\
 			      &lm77_config_##n, POST_KERNEL,		\
 			      CONFIG_SENSOR_INIT_PRIORITY,		\

--- a/drivers/sensor/qdec_nrfx/qdec_nrfx.c
+++ b/drivers/sensor/qdec_nrfx/qdec_nrfx.c
@@ -241,6 +241,8 @@ static const struct sensor_driver_api qdec_nrfx_driver_api = {
 	.trigger_set  = qdec_nrfx_trigger_set,
 };
 
+PM_DEVICE_DT_INST_DEFINE(0, qdec_nrfx_pm_action);
+
 DEVICE_DT_INST_DEFINE(0, qdec_nrfx_init,
-		qdec_nrfx_pm_action, NULL, NULL, POST_KERNEL,
+		PM_DEVICE_DT_INST_REF(0), NULL, NULL, POST_KERNEL,
 		CONFIG_SENSOR_INIT_PRIORITY, &qdec_nrfx_driver_api);

--- a/drivers/sensor/sgp40/sgp40.c
+++ b/drivers/sensor/sgp40/sgp40.c
@@ -255,9 +255,11 @@ static const struct sensor_driver_api sgp40_api = {
 		.selftest = DT_INST_PROP(n, enable_selftest),	\
 	};							\
 								\
+	PM_DEVICE_DT_INST_DEFINE(n, sgp40_pm_action);		\
+								\
 	DEVICE_DT_INST_DEFINE(n,				\
 			      sgp40_init,			\
-			      sgp40_pm_action,			\
+			      PM_DEVICE_DT_INST_REF(n),	\
 			      &sgp40_data_##n,			\
 			      &sgp40_config_##n,		\
 			      POST_KERNEL,			\

--- a/drivers/sensor/si7210/si7210.c
+++ b/drivers/sensor/si7210/si7210.c
@@ -537,7 +537,8 @@ static int si7210_init(const struct device *dev)
 	static const struct si7210_config si7210_config_##inst = { \
 		.bus = I2C_DT_SPEC_INST_GET(inst), \
 	}; \
-	DEVICE_DT_INST_DEFINE(inst, si7210_init, si7210_pm_action, \
+	PM_DEVICE_DT_INST_DEFINE(inst, si7210_pm_action); \
+	DEVICE_DT_INST_DEFINE(inst, si7210_init, PM_DEVICE_DT_INST_REF(inst), \
 		&si7210_data_##inst, &si7210_config_##inst, POST_KERNEL, \
 		CONFIG_SENSOR_INIT_PRIORITY, &si7210_api_funcs);
 

--- a/drivers/sensor/vcnl4040/vcnl4040.c
+++ b/drivers/sensor/vcnl4040/vcnl4040.c
@@ -363,6 +363,8 @@ static const struct vcnl4040_config vcnl4040_config = {
 
 static struct vcnl4040_data vcnl4040_data;
 
+PM_DEVICE_DT_INST_DEFINE(0, vcnl4040_pm_action);
+
 DEVICE_DT_INST_DEFINE(0, vcnl4040_init,
-	      vcnl4040_pm_action, &vcnl4040_data, &vcnl4040_config,
+	      PM_DEVICE_DT_INST_REF(0), &vcnl4040_data, &vcnl4040_config,
 	      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &vcnl4040_driver_api);

--- a/drivers/serial/uart_cc13xx_cc26xx.c
+++ b/drivers/serial/uart_cc13xx_cc26xx.c
@@ -535,9 +535,11 @@ static const struct uart_driver_api uart_cc13xx_cc26xx_driver_api = {
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 
 #define UART_CC13XX_CC26XX_DEVICE_DEFINE(n)				     \
+	PM_DEVICE_DT_INST_DEFINE(n, uart_cc13xx_cc26xx_pm_action);	     \
+									     \
 	DEVICE_DT_INST_DEFINE(n,					     \
 		uart_cc13xx_cc26xx_init_##n,				     \
-		uart_cc13xx_cc26xx_pm_action,				     \
+		PM_DEVICE_DT_INST_REF(n),				     \
 		&uart_cc13xx_cc26xx_data_##n, &uart_cc13xx_cc26xx_config_##n,\
 		PRE_KERNEL_1, CONFIG_SERIAL_INIT_PRIORITY,		     \
 		&uart_cc13xx_cc26xx_driver_api)

--- a/drivers/serial/uart_ite_it8xxx2.c
+++ b/drivers/serial/uart_ite_it8xxx2.c
@@ -129,8 +129,9 @@ static int uart_it8xxx2_init(const struct device *dev)
 		.port = DT_INST_PROP(inst, port_num),                          \
 		.gpio_wui = GPIO_DT_SPEC_INST_GET(inst, gpios),                \
 	};                                                                     \
+	PM_DEVICE_DT_INST_DEFINE(inst, uart_it8xxx2_pm_action);                \
 	DEVICE_DT_INST_DEFINE(inst, &uart_it8xxx2_init,                        \
-			      uart_it8xxx2_pm_action,                          \
+			      PM_DEVICE_DT_INST_REF(inst),                     \
 			      NULL, &uart_it8xxx2_cfg_##inst,                  \
 			      PRE_KERNEL_1,                                    \
 			      CONFIG_SERIAL_INIT_PRIORITY,                     \

--- a/drivers/serial/uart_neorv32.c
+++ b/drivers/serial/uart_neorv32.c
@@ -484,12 +484,6 @@ static const struct uart_driver_api neorv32_uart_driver_api = {
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 };
 
-#ifdef CONFIG_PM_DEVICE
-#define NEORV32_UART_PM_ACTION_CB neorv32_uart_pm_action
-#else /* CONFIG_PM_DEVICE */
-#define NEORV32_UART_PM_ACTION_CB NULL
-#endif /* ! CONFIG_PM_DEVICE */
-
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 #define NEORV32_UART_CONFIG_FUNC(node_id, n)	\
 	static void neorv32_uart_config_func_##n(const struct device *dev) \
@@ -536,8 +530,10 @@ static const struct uart_driver_api neorv32_uart_driver_api = {
 		NEORV32_UART_CONFIG_INIT(node_id, n)			\
 	};								\
 									\
+	PM_DEVICE_DT_DEFINE(node_id, neorv32_uart_pm_action);		\
+									\
 	DEVICE_DT_DEFINE(node_id, &neorv32_uart_init,			\
-			 NEORV32_UART_PM_ACTION_CB,			\
+			 PM_DEVICE_DT_REF(node_id),			\
 			 &neorv32_uart_##n##_data,			\
 			 &neorv32_uart_##n##_config,			\
 			 PRE_KERNEL_1,					\

--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -502,9 +502,11 @@ static int uart_npcx_pm_action(const struct device *dev,
 		.baud_rate = DT_INST_PROP(inst, current_speed)                 \
 	};                                                                     \
 									       \
+	PM_DEVICE_DT_INST_DEFINE(inst, uart_npcx_pm_action);		       \
+									       \
 	DEVICE_DT_INST_DEFINE(inst,					       \
 			&uart_npcx_init,                                       \
-			uart_npcx_pm_action,				       \
+			PM_DEVICE_DT_INST_REF(inst),			       \
 			&uart_npcx_data_##inst, &uart_npcx_cfg_##inst,         \
 			PRE_KERNEL_1, CONFIG_SERIAL_INIT_PRIORITY,	       \
 			&uart_npcx_driver_api);                                \

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -1182,9 +1182,11 @@ static struct uart_nrfx_data uart_nrfx_uart0_data = {
 	}
 };
 
+PM_DEVICE_DT_INST_DEFINE(0, uart_nrfx_pm_action);
+
 DEVICE_DT_INST_DEFINE(0,
 	      uart_nrfx_init,
-	      uart_nrfx_pm_action,
+	      PM_DEVICE_DT_INST_REF(0),
 	      &uart_nrfx_uart0_data,
 	      NULL,
 	      /* Initialize UART device before UART console. */

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1997,9 +1997,12 @@ static int uarte_nrfx_pm_action(const struct device *dev,
 			dev,						       \
 			IS_ENABLED(CONFIG_UART_##idx##_INTERRUPT_DRIVEN));     \
 	}								       \
+									       \
+	PM_DEVICE_DT_DEFINE(UARTE(idx), uarte_nrfx_pm_action);		       \
+									       \
 	DEVICE_DT_DEFINE(UARTE(idx),					       \
 		      uarte_##idx##_init,				       \
-		      uarte_nrfx_pm_action,				       \
+		      PM_DEVICE_DT_REF(UARTE(idx)),			       \
 		      &uarte_##idx##_data,				       \
 		      &uarte_##idx##z_config,				       \
 		      PRE_KERNEL_1,					       \

--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -288,9 +288,11 @@ static const struct spi_driver_api spi_cc13xx_cc26xx_driver_api = {
 #endif
 
 #define SPI_CC13XX_CC26XX_DEVICE_INIT(n)				    \
-	DEVICE_DT_INST_DEFINE(n,						    \
+	PM_DEVICE_DT_INST_DEFINE(n, spi_cc13xx_cc26xx_pm_action);	    \
+									    \
+	DEVICE_DT_INST_DEFINE(n,					    \
 		spi_cc13xx_cc26xx_init_##n,				    \
-		spi_cc13xx_cc26xx_pm_action,				    \
+		PM_DEVICE_DT_INST_REF(n),				    \
 		&spi_cc13xx_cc26xx_data_##n, &spi_cc13xx_cc26xx_config_##n, \
 		POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,			    \
 		&spi_cc13xx_cc26xx_driver_api)

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -354,9 +354,10 @@ static int spi_nrfx_pm_action(const struct device *dev,
 			.miso_pull = SPI_NRFX_MISO_PULL(idx),		       \
 		}							       \
 	};								       \
+	PM_DEVICE_DT_DEFINE(SPI(idx), spi_nrfx_pm_action);		       \
 	DEVICE_DT_DEFINE(SPI(idx),					       \
 		      spi_##idx##_init,					       \
-		      spi_nrfx_pm_action,				       \
+		      PM_DEVICE_DT_REF(SPI(idx)),			       \
 		      &spi_##idx##_data,				       \
 		      &spi_##idx##z_config,				       \
 		      POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,		       \

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -531,9 +531,10 @@ static int spim_nrfx_pm_action(const struct device *dev,
 				SPIM_PROP(idx, anomaly_58_workaround),),       \
 			())						       \
 	};								       \
+	PM_DEVICE_DT_DEFINE(SPIM(idx), spim_nrfx_pm_action);		       \
 	DEVICE_DT_DEFINE(SPIM(idx),					       \
 		      spi_##idx##_init,					       \
-		      spim_nrfx_pm_action,				       \
+		      PM_DEVICE_DT_REF(SPIM(idx)),			       \
 		      &spi_##idx##_data,				       \
 		      &spi_##idx##z_config,				       \
 		      POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,		       \

--- a/drivers/timer/sys_clock_init.c
+++ b/drivers/timer/sys_clock_init.c
@@ -30,12 +30,6 @@ int __weak sys_clock_driver_init(const struct device *dev)
 	return 0;
 }
 
-int __weak sys_clock_device_ctrl(const struct device *dev,
-				 enum pm_device_action action)
-{
-	return -ENOSYS;
-}
-
 void __weak sys_clock_set_timeout(int32_t ticks, bool idle)
 {
 }
@@ -48,5 +42,5 @@ void __weak sys_clock_disable(void)
 {
 }
 
-SYS_DEVICE_DEFINE("sys_clock", sys_clock_driver_init, sys_clock_device_ctrl,
+SYS_DEVICE_DEFINE("sys_clock", sys_clock_driver_init,
 		PRE_KERNEL_2, CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/include/device.h
+++ b/include/device.h
@@ -83,16 +83,14 @@ typedef int16_t device_handle_t;
 /**
  * @def SYS_DEVICE_DEFINE
  *
- * @brief Run an initialization function at boot at specified priority,
- * and define device PM control function.
+ * @brief Run an initialization function at boot at specified priority.
  *
  * @details Invokes DEVICE_DEFINE() with no power management support
  * (@p pm_action_cb), no API (@p api_ptr), and a device name derived from
  * the @p init_fn name (@p dev_name).
  */
-#define SYS_DEVICE_DEFINE(drv_name, init_fn, pm_action_cb, level, prio) \
-	DEVICE_DEFINE(Z_SYS_NAME(init_fn), drv_name, init_fn,		\
-		      pm_action_cb,					\
+#define SYS_DEVICE_DEFINE(drv_name, init_fn, level, prio)		\
+	DEVICE_DEFINE(Z_SYS_NAME(init_fn), drv_name, init_fn, NULL,	\
 		      NULL, NULL, level, prio, NULL)
 
 /**

--- a/include/device.h
+++ b/include/device.h
@@ -86,7 +86,7 @@ typedef int16_t device_handle_t;
  * @brief Run an initialization function at boot at specified priority.
  *
  * @details Invokes DEVICE_DEFINE() with no power management support
- * (@p pm_action_cb), no API (@p api_ptr), and a device name derived from
+ * (@p pm_device), no API (@p api_ptr), and a device name derived from
  * the @p init_fn name (@p dev_name).
  */
 #define SYS_DEVICE_DEFINE(drv_name, init_fn, level, prio)		\
@@ -112,8 +112,7 @@ typedef int16_t device_handle_t;
  *
  * @param init_fn Address to the init function of the driver.
  *
- * @param pm_action_cb Pointer to PM action callback.
- * Can be NULL if not implemented.
+ * @param pm_device PM device resources reference (NULL if device does not use PM).
  *
  * @param data_ptr Pointer to the device's private data.
  *
@@ -129,10 +128,10 @@ typedef int16_t device_handle_t;
  * @param api_ptr Provides an initial pointer to the API function struct
  * used by the driver. Can be NULL.
  */
-#define DEVICE_DEFINE(dev_name, drv_name, init_fn, pm_action_cb,	\
+#define DEVICE_DEFINE(dev_name, drv_name, init_fn, pm_device,		\
 		      data_ptr, cfg_ptr, level, prio, api_ptr)		\
 	Z_DEVICE_DEFINE(DT_INVALID_NODE, dev_name, drv_name, init_fn,	\
-			pm_action_cb,					\
+			pm_device,					\
 			data_ptr, cfg_ptr, level, prio, api_ptr)
 
 /**
@@ -170,8 +169,7 @@ typedef int16_t device_handle_t;
  *
  * @param init_fn Address to the init function of the driver.
  *
- * @param pm_action_cb Pointer to PM action callback.
- * Can be NULL if not implemented.
+ * @param pm_device PM device resources reference (NULL if device does not use PM).
  *
  * @param data_ptr Pointer to the device's private data.
  *
@@ -187,12 +185,12 @@ typedef int16_t device_handle_t;
  * @param api_ptr Provides an initial pointer to the API function struct
  * used by the driver. Can be NULL.
  */
-#define DEVICE_DT_DEFINE(node_id, init_fn, pm_action_cb,		\
+#define DEVICE_DT_DEFINE(node_id, init_fn, pm_device,			\
 			 data_ptr, cfg_ptr, level, prio,		\
 			 api_ptr, ...)					\
 	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_NAME(node_id),		\
 			DEVICE_DT_NAME(node_id), init_fn,		\
-			pm_action_cb,					\
+			pm_device,					\
 			data_ptr, cfg_ptr, level, prio,			\
 			api_ptr, __VA_ARGS__)
 
@@ -362,11 +360,6 @@ struct device_state {
 	 * invoked.
 	 */
 	bool initialized : 1;
-
-#ifdef CONFIG_PM_DEVICE
-	/* Power management data */
-	struct pm_device pm;
-#endif /* CONFIG_PM_DEVICE */
 };
 
 /**
@@ -392,7 +385,7 @@ struct device {
 	 */
 	const device_handle_t *const handles;
 #ifdef CONFIG_PM_DEVICE
-	/** Pointer to device instance power management data */
+	/** Reference to the device PM resources. */
 	struct pm_device * const pm;
 #endif
 };
@@ -650,26 +643,15 @@ static inline bool device_is_ready(const struct device *dev)
 #define Z_DEVICE_EXTRA_HANDLES(...)				\
 	FOR_EACH_NONEMPTY_TERM(IDENTITY, (,), __VA_ARGS__)
 
-#ifdef CONFIG_PM_DEVICE
-#define Z_DEVICE_STATE_PM_INIT(node_id, dev_name, pm_action_cb)		\
-	.pm = Z_PM_DEVICE_INIT(Z_DEVICE_STATE_NAME(dev_name).pm,	\
-			       node_id, pm_action_cb),
-#else
-#define Z_DEVICE_STATE_PM_INIT(node_id, dev_name, pm_action_cb)
-#endif
-
 /**
  * @brief Utility macro to define and initialize the device state.
 
  * @param node_id Devicetree node id of the device.
  * @param dev_name Device name.
- * @param pm_action_cb Device PM action callback.
  */
-#define Z_DEVICE_STATE_DEFINE(node_id, dev_name, pm_action_cb)		\
+#define Z_DEVICE_STATE_DEFINE(node_id, dev_name)			\
 	static struct device_state Z_DEVICE_STATE_NAME(dev_name)	\
-	__attribute__((__section__(".z_devstate"))) = {			\
-		Z_DEVICE_STATE_PM_INIT(node_id, dev_name, pm_action_cb) \
-	};
+	__attribute__((__section__(".z_devstate")));
 
 /* If device power management is enabled, this macro defines a pointer to a
  * device in the z_pm_device_slots region. When invoked for each device, this
@@ -689,9 +671,9 @@ static inline bool device_is_ready(const struct device *dev)
 /* Construct objects that are referenced from struct device. These
  * include power management and dependency handles.
  */
-#define Z_DEVICE_DEFINE_PRE(node_id, dev_name, pm_action_cb, ...)	\
+#define Z_DEVICE_DEFINE_PRE(node_id, dev_name, ...)			\
 	Z_DEVICE_DEFINE_HANDLES(node_id, dev_name, __VA_ARGS__)		\
-	Z_DEVICE_STATE_DEFINE(node_id, dev_name, pm_action_cb)		\
+	Z_DEVICE_STATE_DEFINE(node_id, dev_name)			\
 	Z_DEVICE_DEFINE_PM_SLOT(dev_name)
 
 /* Initial build provides a record that associates the device object
@@ -731,23 +713,15 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 			Z_DEVICE_EXTRA_HANDLES(__VA_ARGS__)		\
 		};
 
-#ifdef CONFIG_PM_DEVICE
-#define Z_DEVICE_DEFINE_PM_INIT(dev_name)		\
-	.pm = &Z_DEVICE_STATE_NAME(dev_name).pm,
-#else
-#define Z_DEVICE_DEFINE_PM_INIT(dev_name)
-#endif
-
 #define Z_DEVICE_DEFINE_INIT(node_id, dev_name)				\
-		.handles = Z_DEVICE_HANDLE_NAME(node_id, dev_name),	\
-		Z_DEVICE_DEFINE_PM_INIT(dev_name)
+	.handles = Z_DEVICE_HANDLE_NAME(node_id, dev_name),
 
 /* Like DEVICE_DEFINE but takes a node_id AND a dev_name, and trailing
  * dependency handles that come from outside devicetree.
  */
-#define Z_DEVICE_DEFINE(node_id, dev_name, drv_name, init_fn, pm_action_cb, \
+#define Z_DEVICE_DEFINE(node_id, dev_name, drv_name, init_fn, pm_device,\
 			data_ptr, cfg_ptr, level, prio, api_ptr, ...)	\
-	Z_DEVICE_DEFINE_PRE(node_id, dev_name, pm_action_cb, __VA_ARGS__) \
+	Z_DEVICE_DEFINE_PRE(node_id, dev_name, __VA_ARGS__)		\
 	COND_CODE_1(DT_NODE_EXISTS(node_id), (), (static))		\
 		const Z_DECL_ALIGN(struct device)			\
 		DEVICE_NAME_GET(dev_name) __used			\
@@ -757,6 +731,7 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 		.api = (api_ptr),					\
 		.state = &Z_DEVICE_STATE_NAME(dev_name),		\
 		.data = (data_ptr),					\
+		COND_CODE_1(CONFIG_PM_DEVICE, (.pm = pm_device,), ())	\
 		Z_DEVICE_DEFINE_INIT(node_id, dev_name)			\
 	};								\
 	BUILD_ASSERT(sizeof(Z_STRINGIFY(drv_name)) <= Z_DEVICE_MAX_NAME_LEN, \

--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -144,7 +144,114 @@ struct pm_device {
 				(0)) << PM_DEVICE_FLAG_WS_CAPABLE),	\
 	}
 
+/**
+ * Get the name of device PM resources.
+ *
+ * @param dev_name Device name.
+ */
+#define Z_PM_DEVICE_NAME(dev_name) _CONCAT(__pm_device__, dev_name)
+
+#ifdef CONFIG_PM_DEVICE
+/**
+ * Define device PM resources for the given node identifier.
+ *
+ * @param node_id Node identifier (DT_NODE_INVALID if not a DT device).
+ * @param dev_name Device name.
+ * @param pm_action_cb PM control callback.
+ */
+#define Z_PM_DEVICE_DEFINE(node_id, dev_name, pm_action_cb)		\
+	static struct pm_device Z_PM_DEVICE_NAME(dev_name) =		\
+	Z_PM_DEVICE_INIT(Z_PM_DEVICE_NAME(dev_name), node_id,		\
+			 pm_action_cb)
+
+/**
+ * Get a reference to the device PM resources.
+ *
+ * @param dev_name Device name.
+ */
+#define Z_PM_DEVICE_REF(dev_name) &Z_PM_DEVICE_NAME(dev_name)
+
+#else
+#define Z_PM_DEVICE_DEFINE(node_id, dev_name, pm_action_cb)
+#define Z_PM_DEVICE_REF(dev_name) NULL
+#endif /* CONFIG_PM_DEVICE */
+
 /** @endcond */
+
+/**
+ * Define device PM resources for the given device name.
+ *
+ * @note This macro is a no-op if @kconfig{CONFIG_PM_DEVICE} is not enabled.
+ *
+ * @param dev_name Device name.
+ * @param pm_action_cb PM control callback.
+ *
+ * @see #PM_DEVICE_DT_DEFINE, #PM_DEVICE_DT_INST_DEFINE
+ */
+#define PM_DEVICE_DEFINE(dev_name, pm_action_cb) \
+	Z_PM_DEVICE_DEFINE(DT_INVALID_NODE, dev_name, pm_action_cb)
+
+/**
+ * Define device PM resources for the given node identifier.
+ *
+ * @note This macro is a no-op if @kconfig{CONFIG_PM_DEVICE} is not enabled.
+ *
+ * @param node_id Node identifier.
+ * @param pm_action_cb PM control callback.
+ *
+ * @see #PM_DEVICE_DT_INST_DEFINE, #PM_DEVICE_DEFINE
+ */
+#define PM_DEVICE_DT_DEFINE(node_id, pm_action_cb)			\
+	Z_PM_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_NAME(node_id),	\
+			   pm_action_cb)
+
+/**
+ * Define device PM resources for the given instance.
+ *
+ * @note This macro is a no-op if @kconfig{CONFIG_PM_DEVICE} is not enabled.
+ *
+ * @param idx Instance index.
+ * @param pm_action_cb PM control callback.
+ *
+ * @see #PM_DEVICE_DT_DEFINE, #PM_DEVICE_DEFINE
+ */
+#define PM_DEVICE_DT_INST_DEFINE(idx, pm_action_cb)			\
+	Z_PM_DEVICE_DEFINE(DT_DRV_INST(idx),				\
+			   Z_DEVICE_DT_DEV_NAME(DT_DRV_INST(idx)),	\
+			   pm_action_cb)
+
+/**
+ * @brief Obtain a reference to the device PM resources for the given device.
+ *
+ * @param dev_name Device name.
+ *
+ * @return Reference to the device PM resources (NULL if device
+ * @kconfig{CONFIG_PM_DEVICE} is disabled).
+ */
+#define PM_DEVICE_REF(dev_name) \
+	Z_PM_DEVICE_REF(dev_name)
+
+/**
+ * @brief Obtain a reference to the device PM resources for the given node.
+ *
+ * @param node_id Node identifier.
+ *
+ * @return Reference to the device PM resources (NULL if device
+ * @kconfig{CONFIG_PM_DEVICE} is disabled).
+ */
+#define PM_DEVICE_DT_REF(node_id) \
+	PM_DEVICE_REF(Z_DEVICE_DT_DEV_NAME(node_id))
+
+/**
+ * @brief Obtain a reference to the device PM resources for the given instance.
+ *
+ * @param idx Instance index.
+ *
+ * @return Reference to the device PM resources (NULL if device
+ * @kconfig{CONFIG_PM_DEVICE} is disabled).
+ */
+#define PM_DEVICE_DT_INST_REF(idx) \
+	PM_DEVICE_DT_REF(DT_DRV_INST(idx))
 
 /**
  * @brief Get name of device PM state

--- a/samples/bluetooth/hci_spi/src/main.c
+++ b/samples/bluetooth/hci_spi/src/main.c
@@ -279,7 +279,7 @@ static int hci_spi_init(const struct device *unused)
 	return 0;
 }
 
-SYS_DEVICE_DEFINE("hci_spi", hci_spi_init, NULL,
+SYS_DEVICE_DEFINE("hci_spi", hci_spi_init,
 		  APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
 
 void main(void)

--- a/samples/bluetooth/hci_uart/src/main.c
+++ b/samples/bluetooth/hci_uart/src/main.c
@@ -343,7 +343,7 @@ static int hci_uart_init(const struct device *unused)
 	return 0;
 }
 
-SYS_DEVICE_DEFINE("hci_uart", hci_uart_init, NULL,
+SYS_DEVICE_DEFINE("hci_uart", hci_uart_init,
 		  APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
 
 void main(void)

--- a/samples/subsys/pm/device_pm/src/dummy_driver.c
+++ b/samples/subsys/pm/device_pm/src/dummy_driver.c
@@ -113,6 +113,8 @@ int dummy_init(const struct device *dev)
 	return 0;
 }
 
+PM_DEVICE_DEFINE(dummy_driver, dummy_device_pm_action);
+
 DEVICE_DEFINE(dummy_driver, DUMMY_DRIVER_NAME, &dummy_init,
-		    dummy_device_pm_action, NULL, NULL, APPLICATION,
+		    PM_DEVICE_REF(dummy_driver), NULL, NULL, APPLICATION,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &funcs);

--- a/samples/subsys/pm/device_pm/src/dummy_parent.c
+++ b/samples/subsys/pm/device_pm/src/dummy_parent.c
@@ -51,6 +51,8 @@ int dummy_parent_init(const struct device *dev)
 	return 0;
 }
 
+PM_DEVICE_DEFINE(dummy_parent, dummy_parent_pm_action);
+
 DEVICE_DEFINE(dummy_parent, DUMMY_PARENT_NAME, &dummy_parent_init,
-		    dummy_parent_pm_action, NULL, NULL, POST_KERNEL,
+		    PM_DEVICE_REF(dummy_parent), NULL, NULL, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &funcs);

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -31,7 +31,7 @@ int pm_device_state_set(const struct device *dev,
 	enum pm_device_action action;
 	struct pm_device *pm = dev->pm;
 
-	if (pm->action_cb == NULL) {
+	if (pm == NULL) {
 		return -ENOSYS;
 	}
 
@@ -78,7 +78,7 @@ int pm_device_state_get(const struct device *dev,
 {
 	struct pm_device *pm = dev->pm;
 
-	if (pm->action_cb == NULL) {
+	if (pm == NULL) {
 		return -ENOSYS;
 	}
 
@@ -97,7 +97,7 @@ bool pm_device_is_any_busy(void)
 	for (const struct device *dev = devs; dev < (devs + devc); dev++) {
 		struct pm_device *pm = dev->pm;
 
-		if (pm->action_cb == NULL) {
+		if (pm == NULL) {
 			continue;
 		}
 
@@ -113,7 +113,7 @@ bool pm_device_is_busy(const struct device *dev)
 {
 	struct pm_device *pm = dev->pm;
 
-	if (pm->action_cb == NULL) {
+	if (pm == NULL) {
 		return false;
 	}
 
@@ -124,7 +124,7 @@ void pm_device_busy_set(const struct device *dev)
 {
 	struct pm_device *pm = dev->pm;
 
-	if (pm->action_cb == NULL) {
+	if (pm == NULL) {
 		return;
 	}
 
@@ -135,7 +135,7 @@ void pm_device_busy_clear(const struct device *dev)
 {
 	struct pm_device *pm = dev->pm;
 
-	if (pm->action_cb == NULL) {
+	if (pm == NULL) {
 		return;
 	}
 
@@ -147,7 +147,7 @@ bool pm_device_wakeup_enable(struct device *dev, bool enable)
 	atomic_val_t flags, new_flags;
 	struct pm_device *pm = dev->pm;
 
-	if (pm->action_cb == NULL) {
+	if (pm == NULL) {
 		return false;
 	}
 
@@ -171,7 +171,7 @@ bool pm_device_wakeup_is_enabled(const struct device *dev)
 {
 	struct pm_device *pm = dev->pm;
 
-	if (pm->action_cb == NULL) {
+	if (pm == NULL) {
 		return false;
 	}
 
@@ -183,7 +183,7 @@ bool pm_device_wakeup_is_capable(const struct device *dev)
 {
 	struct pm_device *pm = dev->pm;
 
-	if (pm->action_cb == NULL) {
+	if (pm == NULL) {
 		return false;
 	}
 

--- a/subsys/pm/power.c
+++ b/subsys/pm/power.c
@@ -125,8 +125,9 @@ static int pm_suspend_devices(void)
 		 * ignore busy devices, wake up source and devices with
 		 * runtime PM enabled.
 		 */
-		if (pm_device_is_busy(dev) || pm_device_wakeup_is_enabled(dev)
-				|| pm_device_runtime_is_enabled(dev)) {
+		if (pm_device_is_busy(dev) ||
+		    pm_device_wakeup_is_enabled(dev) ||
+		    ((dev->pm != NULL) && pm_device_runtime_is_enabled(dev))) {
 			continue;
 		}
 

--- a/tests/benchmarks/footprints/src/pm_device.c
+++ b/tests/benchmarks/footprints/src/pm_device.c
@@ -28,8 +28,10 @@ static int dummy_device_pm_action(const struct device *dev,
 }
 
 /* Define a driver with and without power management enabled */
+PM_DEVICE_DEFINE(dummy_pm_driver, dummy_device_pm_action);
+
 DEVICE_DEFINE(dummy_pm_driver, DUMMY_PM_DRIVER_NAME, &dummy_init,
-		    dummy_device_pm_action, NULL, NULL, APPLICATION,
+		    PM_DEVICE_REF(dummy_pm_driver), NULL, NULL, APPLICATION,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
 
 DEVICE_DEFINE(dummy_driver, DUMMY_DRIVER_NAME, &dummy_init,

--- a/tests/kernel/device/src/dummy_driver.c
+++ b/tests/kernel/device/src/dummy_driver.c
@@ -40,8 +40,10 @@ int dummy_pm_action(const struct device *dev, enum pm_device_action action)
 /**
  * @cond INTERNAL_HIDDEN
  */
+PM_DEVICE_DEFINE(dummy_driver, dummy_pm_action);
+
 DEVICE_DEFINE(dummy_driver, DUMMY_DRIVER_NAME, dummy_init,
-		dummy_pm_action, NULL, NULL, POST_KERNEL,
+		PM_DEVICE_REF(dummy_driver), NULL, NULL, POST_KERNEL,
 		CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &funcs);
 
 /**

--- a/tests/net/pm/src/main.c
+++ b/tests/net/pm/src/main.c
@@ -99,8 +99,10 @@ static struct dummy_api fake_dev_if_api = {
 #define _ETH_L2_LAYER    DUMMY_L2
 #define _ETH_L2_CTX_TYPE NET_L2_GET_CTX_TYPE(DUMMY_L2)
 
+PM_DEVICE_DEFINE(fake_dev, fake_dev_pm_action);
+
 NET_DEVICE_INIT(fake_dev, "fake_dev",
-		fake_dev_init, fake_dev_pm_action,
+		fake_dev_init, PM_DEVICE_REF(fake_dev),
 		&fake_dev_context_data, NULL,
 		CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		&fake_dev_if_api, _ETH_L2_LAYER, _ETH_L2_CTX_TYPE, 127);

--- a/tests/posix/common/testcase.yaml
+++ b/tests/posix/common/testcase.yaml
@@ -24,12 +24,14 @@ tests:
     extra_configs:
       - CONFIG_NEWLIB_LIBC=n
       - CONFIG_THREAD_LOCAL_STORAGE=y
+      - CONFIG_MAIN_STACK_SIZE=1152
   portability.posix.common.tls.newlib:
     platform_exclude: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard ehl_crb
     filter: TOOLCHAIN_HAS_NEWLIB == 1 and CONFIG_ARCH_HAS_THREAD_LOCAL_STORAGE and CONFIG_TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
       - CONFIG_THREAD_LOCAL_STORAGE=y
+      - CONFIG_MAIN_STACK_SIZE=1152
   portability.posix.common.nsim:
     platform_allow: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard
     extra_configs:

--- a/tests/subsys/pm/device_runtime_api/src/test_driver.c
+++ b/tests/subsys/pm/device_runtime_api/src/test_driver.c
@@ -61,8 +61,10 @@ int test_driver_init(const struct device *dev)
 	return 0;
 }
 
+PM_DEVICE_DEFINE(test_driver, test_driver_action);
+
 static struct test_driver_data data;
 
 DEVICE_DEFINE(test_driver, "test_driver", &test_driver_init,
-	      test_driver_action, &data, NULL, POST_KERNEL,
+	      PM_DEVICE_REF(test_driver), &data, NULL, POST_KERNEL,
 	      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, NULL);

--- a/tests/subsys/pm/power_mgmt/src/dummy_driver.c
+++ b/tests/subsys/pm/power_mgmt/src/dummy_driver.c
@@ -36,6 +36,8 @@ int dummy_init(const struct device *dev)
 	return 0;
 }
 
+PM_DEVICE_DEFINE(dummy_driver, dummy_device_pm_action);
+
 DEVICE_DEFINE(dummy_driver, DUMMY_DRIVER_NAME, &dummy_init,
-		    dummy_device_pm_action, NULL, NULL, APPLICATION,
-		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &funcs);
+	      PM_DEVICE_REF(dummy_driver), NULL, NULL, APPLICATION,
+	      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &funcs);

--- a/tests/subsys/pm/power_mgmt/src/main.c
+++ b/tests/subsys/pm/power_mgmt/src/main.c
@@ -70,8 +70,10 @@ static int device_a_pm_action(const struct device *dev,
 	return 0;
 }
 
+PM_DEVICE_DT_DEFINE(DT_INST(0, test_device_pm), device_a_pm_action);
+
 DEVICE_DT_DEFINE(DT_INST(0, test_device_pm), device_init,
-		device_a_pm_action, NULL, NULL,
+		PM_DEVICE_DT_REF(DT_INST(0, test_device_pm)), NULL, NULL,
 		PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		NULL);
 
@@ -113,8 +115,10 @@ static int device_b_pm_action(const struct device *dev,
 	return 0;
 }
 
+PM_DEVICE_DT_DEFINE(DT_INST(1, test_device_pm), device_b_pm_action);
+
 DEVICE_DT_DEFINE(DT_INST(1, test_device_pm), device_init,
-		device_b_pm_action, NULL, NULL,
+		PM_DEVICE_DT_REF(DT_INST(1, test_device_pm)), NULL, NULL,
 		PRE_KERNEL_2, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		NULL);
 
@@ -127,8 +131,10 @@ static int device_c_pm_action(const struct device *dev,
 	return 0;
 }
 
+PM_DEVICE_DT_DEFINE(DT_INST(2, test_device_pm), device_c_pm_action);
+
 DEVICE_DT_DEFINE(DT_INST(2, test_device_pm), device_init,
-		device_c_pm_action, NULL, NULL,
+		PM_DEVICE_DT_REF(DT_INST(2, test_device_pm)), NULL, NULL,
 		POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		NULL);
 


### PR DESCRIPTION
It is well known that PM subsystem has never been optimized in terms of
resource usage. The situation is particularly bad in case the PM runtime
API is enabled. What this patch does is to move the responsibility of PM
resource definition to the device driver like this:

- Device is responsible to define PM resources, using a new set of
  macros: PM_DEVICE_*DEFINE().
- DEVICE_*DEFINE macro accepts a reference to the device PM state, which
  can be obtained using PM_DEVICE_*REF() set of macros. This
  allows device to initialize the dev->pm reference.

This method decouples a bit more PM from devices since devices just keep
a reference to the device PM state. It also means that future PM changes
will have less chances to impact all devices, but only devices that
support PM.

Stats for `west build -b nrf52840dk_nrf52840 samples/hello_world --  -DCONFIG_PM=y -DCONFIG_PM_DEVICE=y -DCONFIG_PM_DEVICE_RUNTIME=y`

main:
```
Memory region         Used Size  Region Size  %age Used
           FLASH:       19632 B         1 MB      1.87%
            SRAM:        7360 B       256 KB      2.81%
        IDT_LIST:          0 GB         2 KB      0.00%
```

This PR:
```
Memory region         Used Size  Region Size  %age Used
           FLASH:       19188 B         1 MB      1.83%
            SRAM:        6912 B       256 KB      2.64%
        IDT_LIST:          0 GB         2 KB      0.00%
```