### PR TITLE
pm: device: some cleanups

### DIFF
--- a/include/net/ethernet.h
+++ b/include/net/ethernet.h
@@ -827,9 +827,9 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
 
 #if defined(CONFIG_NET_VLAN)
 #define Z_ETH_NET_DEVICE_INIT(node_id, dev_name, drv_name, init_fn,	\
-			      pm_control_fn, data, cfg, prio, api, mtu)	\
+			      pm_control_cb, data, cfg, prio, api, mtu)	\
 	Z_DEVICE_DEFINE(node_id, dev_name, drv_name, init_fn,		\
-			pm_control_fn, data, cfg, POST_KERNEL,		\
+			pm_control_cb, data, cfg, POST_KERNEL,		\
 			prio, api);					\
 	NET_L2_DATA_INIT(dev_name, 0, NET_L2_GET_CTX_TYPE(ETHERNET_L2));\
 	NET_IF_INIT(dev_name, 0, ETHERNET_L2, mtu, NET_VLAN_MAX_COUNT)
@@ -837,9 +837,9 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
 #else /* CONFIG_NET_VLAN */
 
 #define Z_ETH_NET_DEVICE_INIT(node_id, dev_name, drv_name, init_fn,	\
-			      pm_control_fn, data, cfg, prio, api, mtu)	\
+			      pm_control_cb, data, cfg, prio, api, mtu)	\
 	Z_NET_DEVICE_INIT(node_id, dev_name, drv_name, init_fn,		\
-			  pm_control_fn, data, cfg, prio, api,		\
+			  pm_control_cb, data, cfg, prio, api,		\
 			  ETHERNET_L2, NET_L2_GET_CTX_TYPE(ETHERNET_L2),\
 			  mtu)
 #endif /* CONFIG_NET_VLAN */
@@ -853,7 +853,7 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
  * @param drv_name The name this instance of the driver exposes to
  * the system.
  * @param init_fn Address to the init function of the driver.
- * @param pm_control_fn Pointer to pm_control function.
+ * @param pm_control_cb Pointer to pm_control function.
  * Can be NULL if not implemented.
  * @param data Pointer to the device's private data.
  * @param cfg The address to the structure containing the
@@ -863,10 +863,10 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
  * used by the driver. Can be NULL.
  * @param mtu Maximum transfer unit in bytes for this network interface.
  */
-#define ETH_NET_DEVICE_INIT(dev_name, drv_name, init_fn, pm_control_fn,	\
+#define ETH_NET_DEVICE_INIT(dev_name, drv_name, init_fn, pm_control_cb,	\
 			    data, cfg, prio, api, mtu)			\
 	Z_ETH_NET_DEVICE_INIT(DT_INVALID_NODE, dev_name, drv_name,	\
-			      init_fn, pm_control_fn, data, cfg, prio,	\
+			      init_fn, pm_control_cb, data, cfg, prio,	\
 			      api, mtu)
 
 /**
@@ -877,7 +877,7 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
  *
  * @param node_id The devicetree node identifier.
  * @param init_fn Address to the init function of the driver.
- * @param pm_control_fn Pointer to pm_control function.
+ * @param pm_control_cb Pointer to pm_control function.
  * Can be NULL if not implemented.
  * @param data Pointer to the device's private data.
  * @param cfg The address to the structure containing the
@@ -887,11 +887,11 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
  * used by the driver. Can be NULL.
  * @param mtu Maximum transfer unit in bytes for this network interface.
  */
-#define ETH_NET_DEVICE_DT_DEFINE(node_id, init_fn, pm_control_fn, data,	\
+#define ETH_NET_DEVICE_DT_DEFINE(node_id, init_fn, pm_control_cb, data,	\
 			       cfg, prio, api, mtu)			\
 	Z_ETH_NET_DEVICE_INIT(node_id, Z_DEVICE_DT_DEV_NAME(node_id),	\
 			      DT_PROP_OR(node_id, label, ""),		\
-			      init_fn, pm_control_fn, data, cfg, prio,	\
+			      init_fn, pm_control_cb, data, cfg, prio,	\
 			      api, mtu)
 
 /**

--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -2248,10 +2248,10 @@ struct net_if_api {
 /* Network device initialization macros */
 
 #define Z_NET_DEVICE_INIT(node_id, dev_name, drv_name, init_fn,		\
-			pm_control_fn, data, cfg, prio, api, l2,	\
+			pm_control_cb, data, cfg, prio, api, l2,	\
 			l2_ctx_type, mtu)				\
 	Z_DEVICE_DEFINE(node_id, dev_name, drv_name, init_fn,		\
-			pm_control_fn, data,				\
+			pm_control_cb, data,				\
 			cfg, POST_KERNEL, prio, api);			\
 	NET_L2_DATA_INIT(dev_name, 0, l2_ctx_type);			\
 	NET_IF_INIT(dev_name, 0, l2, mtu, NET_IF_MAX_CONFIGS)
@@ -2265,7 +2265,7 @@ struct net_if_api {
  * @param drv_name The name this instance of the driver exposes to
  * the system.
  * @param init_fn Address to the init function of the driver.
- * @param pm_control_fn Pointer to pm_control function.
+ * @param pm_control_cb Pointer to pm_control function.
  * Can be NULL if not implemented.
  * @param data Pointer to the device's private data.
  * @param cfg The address to the structure containing the
@@ -2277,11 +2277,11 @@ struct net_if_api {
  * @param l2_ctx_type Type of L2 context data.
  * @param mtu Maximum transfer unit in bytes for this network interface.
  */
-#define NET_DEVICE_INIT(dev_name, drv_name, init_fn, pm_control_fn,	\
+#define NET_DEVICE_INIT(dev_name, drv_name, init_fn, pm_control_cb,	\
 			data, cfg, prio, api, l2,			\
 			l2_ctx_type, mtu)				\
 	Z_NET_DEVICE_INIT(DT_INVALID_NODE, dev_name, drv_name, init_fn,	\
-			pm_control_fn, data, cfg, prio, api, l2,	\
+			pm_control_cb, data, cfg, prio, api, l2,	\
 			l2_ctx_type, mtu)
 
 /**
@@ -2292,7 +2292,7 @@ struct net_if_api {
  *
  * @param node_id The devicetree node identifier.
  * @param init_fn Address to the init function of the driver.
- * @param pm_control_fn Pointer to pm_control function.
+ * @param pm_control_cb Pointer to pm_control function.
  * Can be NULL if not implemented.
  * @param data Pointer to the device's private data.
  * @param cfg The address to the structure containing the
@@ -2304,11 +2304,11 @@ struct net_if_api {
  * @param l2_ctx_type Type of L2 context data.
  * @param mtu Maximum transfer unit in bytes for this network interface.
  */
-#define NET_DEVICE_DT_DEFINE(node_id, init_fn, pm_control_fn, data, cfg,	\
+#define NET_DEVICE_DT_DEFINE(node_id, init_fn, pm_control_cb, data, cfg,	\
 			   prio, api, l2, l2_ctx_type, mtu)		\
 	Z_NET_DEVICE_INIT(node_id, Z_DEVICE_DT_DEV_NAME(node_id),	\
 			  DT_PROP_OR(node_id, label, ""), init_fn,	\
-			  pm_control_fn, data, cfg, prio, api, l2,	\
+			  pm_control_cb, data, cfg, prio, api, l2,	\
 			  l2_ctx_type, mtu)
 
 /**
@@ -2325,11 +2325,11 @@ struct net_if_api {
 	NET_DEVICE_DT_DEFINE(DT_DRV_INST(inst), __VA_ARGS__)
 
 #define Z_NET_DEVICE_INIT_INSTANCE(node_id, dev_name, drv_name,		\
-				   instance, init_fn, pm_control_fn,	\
+				   instance, init_fn, pm_control_cb,	\
 				   data, cfg, prio, api, l2,		\
 				   l2_ctx_type, mtu)			\
 	Z_DEVICE_DEFINE(node_id, dev_name, drv_name, init_fn,		\
-			pm_control_fn, data, cfg, POST_KERNEL,		\
+			pm_control_cb, data, cfg, POST_KERNEL,		\
 			prio, api);					\
 	NET_L2_DATA_INIT(dev_name, instance, l2_ctx_type);		\
 	NET_IF_INIT(dev_name, instance, l2, mtu, NET_IF_MAX_CONFIGS)
@@ -2347,7 +2347,7 @@ struct net_if_api {
  * the system.
  * @param instance Instance identifier.
  * @param init_fn Address to the init function of the driver.
- * @param pm_control_fn Pointer to pm_control function.
+ * @param pm_control_cb Pointer to pm_control function.
  * Can be NULL if not implemented.
  * @param data Pointer to the device's private data.
  * @param cfg The address to the structure containing the
@@ -2360,10 +2360,10 @@ struct net_if_api {
  * @param mtu Maximum transfer unit in bytes for this network interface.
  */
 #define NET_DEVICE_INIT_INSTANCE(dev_name, drv_name, instance, init_fn,	\
-				 pm_control_fn, data, cfg, prio,	\
+				 pm_control_cb, data, cfg, prio,	\
 				 api, l2, l2_ctx_type, mtu)		\
 	Z_NET_DEVICE_INIT_INSTANCE(DT_INVALID_NODE, dev_name, drv_name,	\
-				   instance, init_fn, pm_control_fn,	\
+				   instance, init_fn, pm_control_cb,	\
 				   data, cfg, prio, api, l2,		\
 				   l2_ctx_type, mtu)
 
@@ -2379,7 +2379,7 @@ struct net_if_api {
  * @param node_id The devicetree node identifier.
  * @param instance Instance identifier.
  * @param init_fn Address to the init function of the driver.
- * @param pm_control_fn Pointer to pm_control function.
+ * @param pm_control_cb Pointer to pm_control function.
  * Can be NULL if not implemented.
  * @param data Pointer to the device's private data.
  * @param cfg The address to the structure containing the
@@ -2392,12 +2392,12 @@ struct net_if_api {
  * @param mtu Maximum transfer unit in bytes for this network interface.
  */
 #define NET_DEVICE_DT_DEFINE_INSTANCE(node_id, instance, init_fn,	\
-				      pm_control_fn, data, cfg, prio,	\
+				      pm_control_cb, data, cfg, prio,	\
 				      api, l2, l2_ctx_type, mtu)	\
 	Z_NET_DEVICE_INIT_INSTANCE(node_id,				\
 				   Z_DEVICE_DT_DEV_NAME(node_id),	\
 				   DT_LABEL(node_id), instance,		\
-				   pm_control_fn, data, cfg, prio, api,	\
+				   pm_control_cb, data, cfg, prio, api,	\
 				   l2, l2_ctx_type, mtu)
 
 /**
@@ -2415,10 +2415,10 @@ struct net_if_api {
 	NET_DEVICE_DT_DEFINE_INSTANCE(DT_DRV_INST(inst), __VA_ARGS__)
 
 #define Z_NET_DEVICE_OFFLOAD_INIT(node_id, dev_name, drv_name, init_fn,	\
-				  pm_control_fn, data, cfg, prio,	\
+				  pm_control_cb, data, cfg, prio,	\
 				  api, mtu)				\
 	Z_DEVICE_DEFINE(node_id, dev_name, drv_name, init_fn,		\
-			pm_control_fn, data, cfg, POST_KERNEL, prio, api);\
+			pm_control_cb, data, cfg, POST_KERNEL, prio, api);\
 	NET_IF_OFFLOAD_INIT(dev_name, 0, mtu)
 
 /**
@@ -2432,7 +2432,7 @@ struct net_if_api {
  * @param drv_name The name this instance of the driver exposes to
  * the system.
  * @param init_fn Address to the init function of the driver.
- * @param pm_control_fn Pointer to pm_control function.
+ * @param pm_control_cb Pointer to pm_control function.
  * Can be NULL if not implemented.
  * @param data Pointer to the device's private data.
  * @param cfg The address to the structure containing the
@@ -2443,9 +2443,9 @@ struct net_if_api {
  * @param mtu Maximum transfer unit in bytes for this network interface.
  */
 #define NET_DEVICE_OFFLOAD_INIT(dev_name, drv_name, init_fn,		\
-				pm_control_fn, data, cfg, prio, api, mtu)\
+				pm_control_cb, data, cfg, prio, api, mtu)\
 	Z_NET_DEVICE_OFFLOAD_INIT(DT_INVALID_NODE, dev_name, drv_name,	\
-				init_fn, pm_control_fn, data, cfg, prio,\
+				init_fn, pm_control_cb, data, cfg, prio,\
 				api, mtu)
 
 /**
@@ -2458,7 +2458,7 @@ struct net_if_api {
  *
  * @param node_id The devicetree node identifier.
  * @param init_fn Address to the init function of the driver.
- * @param pm_control_fn Pointer to pm_control function.
+ * @param pm_control_cb Pointer to pm_control function.
  * Can be NULL if not implemented.
  * @param data Pointer to the device's private data.
  * @param cfg The address to the structure containing the
@@ -2468,11 +2468,11 @@ struct net_if_api {
  * used by the driver. Can be NULL.
  * @param mtu Maximum transfer unit in bytes for this network interface.
  */
-#define NET_DEVICE_DT_OFFLOAD_DEFINE(node_id, init_fn, pm_control_fn,	\
+#define NET_DEVICE_DT_OFFLOAD_DEFINE(node_id, init_fn, pm_control_cb,	\
 				   data, cfg, prio, api, mtu)		\
 	Z_NET_DEVICE_OFFLOAD_INIT(node_id, Z_DEVICE_DT_DEV_NAME(node_id), \
 				  DT_PROP_OR(node_id, label, NULL),	\
-				  init_fn, pm_control_fn, data, cfg,	\
+				  init_fn, pm_control_cb, data, cfg,	\
 				  prio, api, mtu)
 
 /**

--- a/include/net/virtual.h
+++ b/include/net/virtual.h
@@ -274,10 +274,10 @@ net_virtual_get_iface_capabilities(struct net_if *iface)
 }
 
 #define Z_NET_VIRTUAL_INTERFACE_INIT(node_id, dev_name, drv_name,	\
-				     init_fn, pm_control_fn, data, cfg, \
+				     init_fn, pm_control_cb, data, cfg, \
 				     prio, api, mtu)			\
 	Z_NET_DEVICE_INIT(node_id, dev_name, drv_name, init_fn,		\
-			  pm_control_fn, data, cfg, prio, api,		\
+			  pm_control_cb, data, cfg, prio, api,		\
 			  VIRTUAL_L2, NET_L2_GET_CTX_TYPE(VIRTUAL_L2),	\
 			  mtu)
 /** @endcond */
@@ -294,7 +294,7 @@ net_virtual_get_iface_capabilities(struct net_if *iface)
  * @param drv_name The name this instance of the driver exposes to
  * the system.
  * @param init_fn Address to the init function of the driver.
- * @param pm_control_fn Pointer to pm_control function.
+ * @param pm_control_cb Pointer to pm_control function.
  * Can be NULL if not implemented.
  * @param data Pointer to the device's private data.
  * @param cfg The address to the structure containing the
@@ -306,10 +306,10 @@ net_virtual_get_iface_capabilities(struct net_if *iface)
  * This is the default value and its value can be tweaked at runtime.
  */
 #define NET_VIRTUAL_INTERFACE_INIT(dev_name, drv_name, init_fn,		\
-				   pm_control_fn,			\
+				   pm_control_cb,			\
 				   data, cfg, prio, api, mtu)		\
 	Z_NET_VIRTUAL_INTERFACE_INIT(DT_INVALID_NODE, dev_name,		\
-				     drv_name, init_fn, pm_control_fn,	\
+				     drv_name, init_fn, pm_control_cb,	\
 				     data, cfg, prio, api, mtu)
 
 /**

--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -83,7 +83,7 @@ enum pm_device_action {
 };
 
 /**
- * @brief Device power management control function callback.
+ * @brief Device PM action callback.
  *
  * @param dev Device instance.
  * @param action Requested action.
@@ -92,8 +92,8 @@ enum pm_device_action {
  * @retval -ENOTSUP If the requested action is not supported.
  * @retval Errno Other negative errno on failure.
  */
-typedef int (*pm_device_control_callback_t)(const struct device *dev,
-					    enum pm_device_action action);
+typedef int (*pm_device_action_cb_t)(const struct device *dev,
+				     enum pm_device_action action);
 
 /**
  * @brief Device PM info
@@ -118,8 +118,8 @@ struct pm_device {
 	atomic_t flags;
 	/** Device power state */
 	enum pm_device_state state;
-	/** Device PM control callback */
-	pm_device_control_callback_t pm_control;
+	/** Device PM action callback */
+	pm_device_action_cb_t action_cb;
 };
 
 #ifdef CONFIG_PM_DEVICE_RUNTIME
@@ -139,12 +139,12 @@ struct pm_device {
  *
  * @param obj Name of the #pm_device structure being initialized.
  * @param node_id Devicetree node for the initialized device (can be invalid).
- * @param pm_control_fn Device PM control callback function.
+ * @param pm_action_cb Device PM control callback function.
  */
-#define Z_PM_DEVICE_INIT(obj, node_id, pm_control_fn)			\
+#define Z_PM_DEVICE_INIT(obj, node_id, pm_action_cb)			\
 	{								\
 		INIT_PM_DEVICE_RUNTIME(obj)				\
-		.pm_control = pm_control_fn,				\
+		.action_cb = pm_action_cb,				\
 		.state = PM_DEVICE_STATE_ACTIVE,			\
 		.flags = ATOMIC_INIT(COND_CODE_1(			\
 				DT_NODE_EXISTS(node_id),		\

--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -83,6 +83,19 @@ enum pm_device_action {
 };
 
 /**
+ * @brief Device power management control function callback.
+ *
+ * @param dev Device instance.
+ * @param action Requested action.
+ *
+ * @retval 0 If successful.
+ * @retval -ENOTSUP If the requested action is not supported.
+ * @retval Errno Other negative errno on failure.
+ */
+typedef int (*pm_device_control_callback_t)(const struct device *dev,
+					    enum pm_device_action action);
+
+/**
  * @brief Device PM info
  */
 struct pm_device {
@@ -105,6 +118,8 @@ struct pm_device {
 	atomic_t flags;
 	/** Device power state */
 	enum pm_device_state state;
+	/** Device PM control callback */
+	pm_device_control_callback_t pm_control;
 };
 
 #ifdef CONFIG_PM_DEVICE_RUNTIME
@@ -124,29 +139,18 @@ struct pm_device {
  *
  * @param obj Name of the #pm_device structure being initialized.
  * @param node_id Devicetree node for the initialized device (can be invalid).
+ * @param pm_control_fn Device PM control callback function.
  */
-#define Z_PM_DEVICE_INIT(obj, node_id)					\
+#define Z_PM_DEVICE_INIT(obj, node_id, pm_control_fn)			\
 	{								\
 		INIT_PM_DEVICE_RUNTIME(obj)				\
+		.pm_control = pm_control_fn,				\
 		.state = PM_DEVICE_STATE_ACTIVE,			\
 		.flags = ATOMIC_INIT(COND_CODE_1(			\
 				DT_NODE_EXISTS(node_id),		\
 				(DT_PROP_OR(node_id, wakeup_source, 0)),\
 				(0)) << PM_DEVICE_FLAGS_WS_CAPABLE),	\
 	}
-
-/**
- * @brief Device power management control function callback.
- *
- * @param dev Device instance.
- * @param action Requested action.
- *
- * @retval 0 If successful.
- * @retval -ENOTSUP If the requested action is not supported.
- * @retval Errno Other negative errno on failure.
- */
-typedef int (*pm_device_control_callback_t)(const struct device *dev,
-					    enum pm_device_action action);
 
 /**
  * @brief Get name of device PM state

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -4,11 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <kernel.h>
-#include <string.h>
 #include <device.h>
-#include <pm/policy.h>
+#include <pm/device.h>
 
 #define LOG_LEVEL CONFIG_PM_LOG_LEVEL /* From power module Kconfig */
 #include <logging/log.h>

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -97,7 +97,7 @@ int pm_device_state_set(const struct device *dev,
 	enum pm_device_action action;
 	struct pm_device *pm = dev->pm;
 
-	if (dev->pm_control == NULL) {
+	if (pm->pm_control == NULL) {
 		return -ENOSYS;
 	}
 
@@ -140,7 +140,7 @@ int pm_device_state_set(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	ret = dev->pm_control(dev, action);
+	ret = pm->pm_control(dev, action);
 	if (ret < 0) {
 		return ret;
 	}
@@ -155,7 +155,7 @@ int pm_device_state_get(const struct device *dev,
 {
 	struct pm_device *pm = dev->pm;
 
-	if (dev->pm_control == NULL) {
+	if (pm->pm_control == NULL) {
 		return -ENOSYS;
 	}
 
@@ -174,7 +174,7 @@ bool pm_device_is_any_busy(void)
 	for (const struct device *dev = devs; dev < (devs + devc); dev++) {
 		struct pm_device *pm = dev->pm;
 
-		if (dev->pm_control == NULL) {
+		if (pm->pm_control == NULL) {
 			continue;
 		}
 
@@ -190,7 +190,7 @@ bool pm_device_is_busy(const struct device *dev)
 {
 	struct pm_device *pm = dev->pm;
 
-	if (dev->pm_control == NULL) {
+	if (pm->pm_control == NULL) {
 		return false;
 	}
 
@@ -201,7 +201,7 @@ void pm_device_busy_set(const struct device *dev)
 {
 	struct pm_device *pm = dev->pm;
 
-	if (dev->pm_control == NULL) {
+	if (pm->pm_control == NULL) {
 		return;
 	}
 
@@ -212,7 +212,7 @@ void pm_device_busy_clear(const struct device *dev)
 {
 	struct pm_device *pm = dev->pm;
 
-	if (dev->pm_control == NULL) {
+	if (pm->pm_control == NULL) {
 		return;
 	}
 
@@ -224,7 +224,7 @@ bool pm_device_wakeup_enable(struct device *dev, bool enable)
 	atomic_val_t flags, new_flags;
 	struct pm_device *pm = dev->pm;
 
-	if (dev->pm_control == NULL) {
+	if (pm->pm_control == NULL) {
 		return false;
 	}
 
@@ -248,7 +248,7 @@ bool pm_device_wakeup_is_enabled(const struct device *dev)
 {
 	struct pm_device *pm = dev->pm;
 
-	if (dev->pm_control == NULL) {
+	if (pm->pm_control == NULL) {
 		return false;
 	}
 
@@ -260,7 +260,7 @@ bool pm_device_wakeup_is_capable(const struct device *dev)
 {
 	struct pm_device *pm = dev->pm;
 
-	if (dev->pm_control == NULL) {
+	if (pm->pm_control == NULL) {
 		return false;
 	}
 

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -97,7 +97,7 @@ int pm_device_state_set(const struct device *dev,
 	enum pm_device_action action;
 	struct pm_device *pm = dev->pm;
 
-	if (pm->pm_control == NULL) {
+	if (pm->action_cb == NULL) {
 		return -ENOSYS;
 	}
 
@@ -140,7 +140,7 @@ int pm_device_state_set(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	ret = pm->pm_control(dev, action);
+	ret = pm->action_cb(dev, action);
 	if (ret < 0) {
 		return ret;
 	}
@@ -155,7 +155,7 @@ int pm_device_state_get(const struct device *dev,
 {
 	struct pm_device *pm = dev->pm;
 
-	if (pm->pm_control == NULL) {
+	if (pm->action_cb == NULL) {
 		return -ENOSYS;
 	}
 
@@ -174,7 +174,7 @@ bool pm_device_is_any_busy(void)
 	for (const struct device *dev = devs; dev < (devs + devc); dev++) {
 		struct pm_device *pm = dev->pm;
 
-		if (pm->pm_control == NULL) {
+		if (pm->action_cb == NULL) {
 			continue;
 		}
 
@@ -190,7 +190,7 @@ bool pm_device_is_busy(const struct device *dev)
 {
 	struct pm_device *pm = dev->pm;
 
-	if (pm->pm_control == NULL) {
+	if (pm->action_cb == NULL) {
 		return false;
 	}
 
@@ -201,7 +201,7 @@ void pm_device_busy_set(const struct device *dev)
 {
 	struct pm_device *pm = dev->pm;
 
-	if (pm->pm_control == NULL) {
+	if (pm->action_cb == NULL) {
 		return;
 	}
 
@@ -212,7 +212,7 @@ void pm_device_busy_clear(const struct device *dev)
 {
 	struct pm_device *pm = dev->pm;
 
-	if (pm->pm_control == NULL) {
+	if (pm->action_cb == NULL) {
 		return;
 	}
 
@@ -224,7 +224,7 @@ bool pm_device_wakeup_enable(struct device *dev, bool enable)
 	atomic_val_t flags, new_flags;
 	struct pm_device *pm = dev->pm;
 
-	if (pm->pm_control == NULL) {
+	if (pm->action_cb == NULL) {
 		return false;
 	}
 
@@ -248,7 +248,7 @@ bool pm_device_wakeup_is_enabled(const struct device *dev)
 {
 	struct pm_device *pm = dev->pm;
 
-	if (pm->pm_control == NULL) {
+	if (pm->action_cb == NULL) {
 		return false;
 	}
 
@@ -260,7 +260,7 @@ bool pm_device_wakeup_is_capable(const struct device *dev)
 {
 	struct pm_device *pm = dev->pm;
 
-	if (pm->pm_control == NULL) {
+	if (pm->action_cb == NULL) {
 		return false;
 	}
 

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -95,41 +95,42 @@ int pm_device_state_set(const struct device *dev,
 {
 	int ret;
 	enum pm_device_action action;
+	struct pm_device *pm = dev->pm;
 
 	if (dev->pm_control == NULL) {
 		return -ENOSYS;
 	}
 
-	if (atomic_test_bit(&dev->pm->flags, PM_DEVICE_FLAG_TRANSITIONING)) {
+	if (atomic_test_bit(&pm->flags, PM_DEVICE_FLAG_TRANSITIONING)) {
 		return -EBUSY;
 	}
 
 	switch (state) {
 	case PM_DEVICE_STATE_SUSPENDED:
-		if (dev->pm->state == PM_DEVICE_STATE_SUSPENDED) {
+		if (pm->state == PM_DEVICE_STATE_SUSPENDED) {
 			return -EALREADY;
-		} else if (dev->pm->state == PM_DEVICE_STATE_OFF) {
+		} else if (pm->state == PM_DEVICE_STATE_OFF) {
 			return -ENOTSUP;
 		}
 
 		action = PM_DEVICE_ACTION_SUSPEND;
 		break;
 	case PM_DEVICE_STATE_ACTIVE:
-		if (dev->pm->state == PM_DEVICE_STATE_ACTIVE) {
+		if (pm->state == PM_DEVICE_STATE_ACTIVE) {
 			return -EALREADY;
 		}
 
 		action = PM_DEVICE_ACTION_RESUME;
 		break;
 	case PM_DEVICE_STATE_LOW_POWER:
-		if (dev->pm->state == state) {
+		if (pm->state == state) {
 			return -EALREADY;
 		}
 
 		action = PM_DEVICE_ACTION_LOW_POWER;
 		break;
 	case PM_DEVICE_STATE_OFF:
-		if (dev->pm->state == state) {
+		if (pm->state == state) {
 			return -EALREADY;
 		}
 
@@ -144,7 +145,7 @@ int pm_device_state_set(const struct device *dev,
 		return ret;
 	}
 
-	dev->pm->state = state;
+	pm->state = state;
 
 	return 0;
 }
@@ -152,11 +153,13 @@ int pm_device_state_set(const struct device *dev,
 int pm_device_state_get(const struct device *dev,
 			enum pm_device_state *state)
 {
+	struct pm_device *pm = dev->pm;
+
 	if (dev->pm_control == NULL) {
 		return -ENOSYS;
 	}
 
-	*state = dev->pm->state;
+	*state = pm->state;
 
 	return 0;
 }
@@ -169,10 +172,13 @@ bool pm_device_is_any_busy(void)
 	devc = z_device_get_all_static(&devs);
 
 	for (const struct device *dev = devs; dev < (devs + devc); dev++) {
+		struct pm_device *pm = dev->pm;
+
 		if (dev->pm_control == NULL) {
 			continue;
 		}
-		if (atomic_test_bit(&dev->pm->flags, PM_DEVICE_FLAG_BUSY)) {
+
+		if (atomic_test_bit(&pm->flags, PM_DEVICE_FLAG_BUSY)) {
 			return true;
 		}
 	}
@@ -182,37 +188,47 @@ bool pm_device_is_any_busy(void)
 
 bool pm_device_is_busy(const struct device *dev)
 {
+	struct pm_device *pm = dev->pm;
+
 	if (dev->pm_control == NULL) {
 		return false;
 	}
-	return atomic_test_bit(&dev->pm->flags, PM_DEVICE_FLAG_BUSY);
+
+	return atomic_test_bit(&pm->flags, PM_DEVICE_FLAG_BUSY);
 }
 
 void pm_device_busy_set(const struct device *dev)
 {
+	struct pm_device *pm = dev->pm;
+
 	if (dev->pm_control == NULL) {
 		return;
 	}
-	atomic_set_bit(&dev->pm->flags, PM_DEVICE_FLAG_BUSY);
+
+	atomic_set_bit(&pm->flags, PM_DEVICE_FLAG_BUSY);
 }
 
 void pm_device_busy_clear(const struct device *dev)
 {
+	struct pm_device *pm = dev->pm;
+
 	if (dev->pm_control == NULL) {
 		return;
 	}
-	atomic_clear_bit(&dev->pm->flags, PM_DEVICE_FLAG_BUSY);
+
+	atomic_clear_bit(&pm->flags, PM_DEVICE_FLAG_BUSY);
 }
 
 bool pm_device_wakeup_enable(struct device *dev, bool enable)
 {
 	atomic_val_t flags, new_flags;
+	struct pm_device *pm = dev->pm;
 
 	if (dev->pm_control == NULL) {
 		return false;
 	}
 
-	flags =	 atomic_get(&dev->pm->flags);
+	flags =	atomic_get(&pm->flags);
 
 	if ((flags & BIT(PM_DEVICE_FLAGS_WS_CAPABLE)) == 0U) {
 		return false;
@@ -225,23 +241,29 @@ bool pm_device_wakeup_enable(struct device *dev, bool enable)
 		new_flags = flags & ~BIT(PM_DEVICE_FLAGS_WS_ENABLED);
 	}
 
-	return atomic_cas(&dev->pm->flags, flags, new_flags);
+	return atomic_cas(&pm->flags, flags, new_flags);
 }
 
 bool pm_device_wakeup_is_enabled(const struct device *dev)
 {
+	struct pm_device *pm = dev->pm;
+
 	if (dev->pm_control == NULL) {
 		return false;
 	}
-	return atomic_test_bit(&dev->pm->flags,
+
+	return atomic_test_bit(&pm->flags,
 			       PM_DEVICE_FLAGS_WS_ENABLED);
 }
 
 bool pm_device_wakeup_is_capable(const struct device *dev)
 {
+	struct pm_device *pm = dev->pm;
+
 	if (dev->pm_control == NULL) {
 		return false;
 	}
-	return atomic_test_bit(&dev->pm->flags,
+
+	return atomic_test_bit(&pm->flags,
 			       PM_DEVICE_FLAGS_WS_CAPABLE);
 }

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -179,7 +179,7 @@ void pm_device_enable(const struct device *dev)
 	SYS_PORT_TRACING_FUNC_ENTER(pm, device_enable, dev);
 	if (k_is_pre_kernel()) {
 		pm->dev = dev;
-		if (pm->pm_control != NULL) {
+		if (pm->action_cb != NULL) {
 			pm->enable = true;
 			pm->state = PM_DEVICE_STATE_SUSPENDED;
 			k_work_init_delayable(&pm->work, pm_work_handler);
@@ -188,7 +188,7 @@ void pm_device_enable(const struct device *dev)
 	}
 
 	(void)k_mutex_lock(&pm->lock, K_FOREVER);
-	if (pm->pm_control == NULL) {
+	if (pm->action_cb == NULL) {
 		pm->enable = false;
 		goto out_unlock;
 	}

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -179,7 +179,7 @@ void pm_device_enable(const struct device *dev)
 	SYS_PORT_TRACING_FUNC_ENTER(pm, device_enable, dev);
 	if (k_is_pre_kernel()) {
 		pm->dev = dev;
-		if (dev->pm_control != NULL) {
+		if (pm->pm_control != NULL) {
 			pm->enable = true;
 			pm->state = PM_DEVICE_STATE_SUSPENDED;
 			k_work_init_delayable(&pm->work, pm_work_handler);
@@ -188,7 +188,7 @@ void pm_device_enable(const struct device *dev)
 	}
 
 	(void)k_mutex_lock(&pm->lock, K_FOREVER);
-	if (dev->pm_control == NULL) {
+	if (pm->pm_control == NULL) {
 		pm->enable = false;
 		goto out_unlock;
 	}

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -4,12 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <kernel.h>
-#include <device.h>
 #include <sys/__assert.h>
 #include <pm/device_runtime.h>
-#include <spinlock.h>
 
 #define LOG_LEVEL CONFIG_PM_LOG_LEVEL /* From power module Kconfig */
 #include <logging/log.h>


### PR DESCRIPTION
Some minor cleanups (more will come soon) to the PM subsystem (devices):

```
pm: device: remove unnecessary includes

Some includes were already performed by the device(_runtime).h header/s,
others like were not necessary.
```
```
pm: device: access members of pm_device directly

Accessing members from pm_device improves code readability, since it
removes dev-> from most accesses.
```
```
pm: move control callback to pm_device 

Move PM specific callback to the pm_device structure.
```
```
pm: rename pm_control(_fn) to (pm_)action_cb

- Rename to "action" to make its purpose more clear
- Use the _cb suffix to align with naming used for callbacks in other
  areas.
```