### PR TITLE
MAINTAINERS: add module path for TF-M

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1531,6 +1531,7 @@ TF-M Integration:
         - ioannisg
     files:
         - samples/tfm_integration/
+        - modules/trusted-firmware-m/
     labels:
         - "area: TF-M"
 


### PR DESCRIPTION
Previously `modules/trusted-firmware-m/` was missing from the maintainers file.
