### PR TITLE
samples: drivers: watchdog: remove accidential copy-paste

### DIFF
--- a/samples/drivers/watchdog/src/main.c
+++ b/samples/drivers/watchdog/src/main.c
@@ -43,8 +43,6 @@
 #define WDT_NODE DT_INST(0, microchip_xec_watchdog)
 #elif DT_HAS_COMPAT_STATUS_OKAY(ti_cc32xx_watchdog)
 #define WDT_NODE DT_INST(0, ti_cc32xx_watchdog)
-#elif DT_HAS_COMPAT_STATUS_OKAY(espressif_esp32_watchdog)
-#define WDT_NODE DT_INST(0, espressif_esp32_watchdog)
 #endif
 
 #ifndef WDT_ALLOW_CALLBACK


### PR DESCRIPTION
watchdog dts instance was already present for esp32 family

Signed-off-by: Pavlo Hamov <p.hamov@venstar.com>