### PR TITLE
boards: arm: stm32l562e_dk and nucleo_l552ze_q add openocd support

### DIFF
--- a/boards/arm/nucleo_l552ze_q/doc/nucleol552ze_q.rst
+++ b/boards/arm/nucleo_l552ze_q/doc/nucleol552ze_q.rst
@@ -255,19 +255,17 @@ flashed in the usual way (see :ref:`build_an_application` and
 Flashing
 ========
 
-Nucleo L552ZE Q board includes an ST-LINK/V3E embedded debug tool
-interface. This interface is not yet supported by the openocd version.
-Instead, support can be enabled on pyocd by adding "pack" support with
-the following pyocd command:
+Nucleo L552ZE Q board includes an ST-LINK/V2-1 embedded debug tool
+interface. Support can be enabled on pyocd by adding "pack" support with the
+following pyocd command:
 
 .. code-block:: console
 
    $ pyocd pack --update
    $ pyocd pack --install stm32l552ze
 
-Nucleo L552ZE Q board includes an ST-LINK/V2-1 embedded debug tool
-interface.  This interface is supported by the openocd version
-included in the Zephyr SDK since v0.9.2.
+Alternatively, this interface is supported by the openocd version
+included in the Zephyr SDK since v0.13.1.
 
 Flashing an application to Nucleo L552ZE Q
 ------------------------------------------

--- a/boards/arm/nucleo_l552ze_q/support/openocd.cfg
+++ b/boards/arm/nucleo_l552ze_q/support/openocd.cfg
@@ -1,0 +1,19 @@
+source [find interface/stlink.cfg]
+
+transport select hla_swd
+
+source [find target/stm32l5x.cfg]
+
+# use hardware reset
+reset_config srst_only srst_nogate
+
+$_TARGETNAME configure -event gdb-attach {
+        echo "Debugger attaching: halting execution"
+        reset halt
+        gdb_breakpoint_override hard
+}
+
+$_TARGETNAME configure -event gdb-detach {
+        echo "Debugger detaching: resuming execution"
+        resume
+}

--- a/boards/arm/stm32l562e_dk/doc/index.rst
+++ b/boards/arm/stm32l562e_dk/doc/index.rst
@@ -252,18 +252,16 @@ Flashing
 ========
 
 STM32L562E-DK Discovery board includes an ST-LINK/V3E embedded debug tool
-interface. This interface is not yet supported by the openocd version.
-Instead, support can be enabled on pyocd by adding "pack" support with
-the following pyocd command:
+interface. Support can be enabled on pyocd by adding "pack" support with the
+following pyocd command:
 
 .. code-block:: console
 
    $ pyocd pack --update
    $ pyocd pack --install stm32l562qe
 
-STM32L562E-DK Discovery board includes an ST-LINK/V2-1 embedded debug tool
-interface.  This interface is supported by the openocd version
-included in the Zephyr SDK since v0.9.2.
+Alternatively, this interface is supported by the openocd version
+included in the Zephyr SDK since v0.13.1.
 
 Flashing an application to STM32L562E-DK Discovery
 --------------------------------------------------

--- a/boards/arm/stm32l562e_dk/support/openocd.cfg
+++ b/boards/arm/stm32l562e_dk/support/openocd.cfg
@@ -1,0 +1,19 @@
+source [find interface/stlink.cfg]
+
+transport select hla_swd
+
+source [find target/stm32l5x.cfg]
+
+# use hardware reset
+reset_config srst_only srst_nogate
+
+$_TARGETNAME configure -event gdb-attach {
+        echo "Debugger attaching: halting execution"
+        reset halt
+        gdb_breakpoint_override hard
+}
+
+$_TARGETNAME configure -event gdb-detach {
+        echo "Debugger detaching: resuming execution"
+        resume
+}


### PR DESCRIPTION
boards: arm: stm32l562e_dk and nucleo_l552ze_q add openocd support

OpenOCD was partially implemented in board.cmake,
it is now functional.
