### PR TITLE
RFC: Automatic syscall tracing

### DIFF
--- a/include/tracing/tracing.h
+++ b/include/tracing/tracing.h
@@ -1940,6 +1940,20 @@
 
 #define sys_port_trace_pm_device_disable_exit(dev)
 
+/**
+ * @brief Syscall Tracing APIs
+ * @defgroup syscall_tracing_apis Syscall Tracing APIs
+ * @ingroup tracing_apis
+ * @{
+ */
+
+#define sys_port_trace_syscall_enter(syscall)
+
+#define sys_port_trace_syscall_exit(syscall)
+
+/**
+ * @}
+ */ /* end of syscall_tracing_apis */
 
 #if defined CONFIG_PERCEPIO_TRACERECORDER
 #include "tracing_tracerecorder.h"

--- a/include/tracing/tracing_syscall.h
+++ b/include/tracing/tracing_syscall.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2021 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_TRACING_SYSCALL_H_
+#define ZEPHYR_INCLUDE_TRACING_SYSCALL_H_
+
+#ifndef CONFIG_TRACING
+
+#define sys_port_tracing_syscall_enter(func) do { } while (false)
+#define sys_port_tracing_syscall_exit(func) do { } while (false)
+
+#endif
+
+
+#endif /* ZEPHYR_INCLUDE_TRACING_SYSCALL_H_ */


### PR DESCRIPTION
From an idea while talking to @andyross, when generating syscall wrappers, call a tracing macro with the name of the syscall as the sole parameter when entering and leaving the syscall, this is a POC and doesn't actually work, looking to get feedback if folks feel this is a possibly useful addition or have ideas on improving it.

I ran into an issue when trying to include <tracing/tracing.h> in the generated syscall wrapper code, so some indirection like kernel.h does might be needed.

I get that some implementations might need a mapping from func name to a integer id, there is syscall_list.h but might need a little finagling to get that syscall id and make it useful to something like systemview