### PR TITLE
arm: cortex-m: initialise ptr_esf in get_esf() in fault.c.

### DIFF
--- a/arch/arm/core/aarch32/cortex_m/fault.c
+++ b/arch/arm/core/aarch32/cortex_m/fault.c
@@ -849,7 +849,7 @@ static inline z_arch_esf_t *get_esf(uint32_t msp, uint32_t psp, uint32_t exc_ret
 	bool *nested_exc)
 {
 	bool alternative_state_exc = false;
-	z_arch_esf_t *ptr_esf;
+	z_arch_esf_t *ptr_esf = NULL;
 
 	*nested_exc = false;
 


### PR DESCRIPTION
This patch simply initialises a local variable in `get_esf()` in the Cortex-M `fault.c` to prevent a warning and potential invalid return value.

This is the full warning:

```
/work/zephyrproject/zephyr/arch/arm/core/aarch32/cortex_m/fault.c:944:6: warning: variable 'ptr_esf' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]
        if (!alternative_state_exc) {
            ^~~~~~~~~~~~~~~~~~~~~~
/work/zephyrproject/zephyr/arch/arm/core/aarch32/cortex_m/fault.c:956:9: note: uninitialized use occurs here
        return ptr_esf;
               ^~~~~~~
/work/zephyrproject/zephyr/arch/arm/core/aarch32/cortex_m/fault.c:944:2: note: remove the 'if' if its condition is always true
        if (!alternative_state_exc) {
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/work/zephyrproject/zephyr/arch/arm/core/aarch32/cortex_m/fault.c:852:23: note: initialize the variable 'ptr_esf' to silence this warning
        z_arch_esf_t *ptr_esf;
                             ^
                              = NULL
1 warning generated.
```