### PR TITLE
kernel: work_q: use flags_get() in work_delayable_busy_get_locked().

### DIFF
--- a/kernel/work.c
+++ b/kernel/work.c
@@ -829,7 +829,7 @@ void k_work_init_delayable(struct k_work_delayable *dwork,
 
 static inline int work_delayable_busy_get_locked(const struct k_work_delayable *dwork)
 {
-	return atomic_get(&dwork->work.flags) & K_WORK_MASK;
+	return flags_get(&dwork->work.flags) & K_WORK_MASK;
 }
 
 int k_work_delayable_busy_get(const struct k_work_delayable *dwork)


### PR DESCRIPTION
The `k_work::flags` field is not an `atomic_t` and would cause a -Wpointer-sign warning on some compilers when `atomic_get()` is called, since that function accepts an `int`.

Since `work_delayable_busy_get_locked()` was the only function one in `work.c` to use atomics, it's kind of pointless. Switched to `flags_get()` like the rest of the code in `work.c`. If atomicity is required, then it should be applied by modifying all of the static helper functions at the top of the file.

Full warning:

```
/work/zephyrproject/zephyr/kernel/work.c:832:20: warning: passing 'const uint32_t *' (aka 'const unsigned int *') to parameter of type 'const atomic_t *' (aka 'const int *') converts between pointers to integer types with different sign [-Wpointer-sign]
        return atomic_get(&dwork->work.flags) & K_WORK_MASK;
                          ^~~~~~~~~~~~~~~~~~
/work/zephyrproject/zephyr/include/sys/atomic_builtin.h:138:55: note: passing argument to parameter 'target' here
static inline atomic_val_t atomic_get(const atomic_t *target)
                                                      ^
1 warning generated.
```