### PR TITLE
drivers: i2c: nrfx: Add implementation of i2c_recover_bus API function

### DIFF
--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -195,9 +195,18 @@ static int i2c_nrfx_twi_configure(const struct device *dev,
 	return 0;
 }
 
+static int i2c_nrfx_twi_recover_bus(const struct device *dev)
+{
+	nrfx_err_t err = nrfx_twi_bus_recover(get_dev_config(dev)->config.scl,
+					      get_dev_config(dev)->config.sda);
+
+	return (err == NRFX_SUCCESS ? 0 : -EBUSY);
+}
+
 static const struct i2c_driver_api i2c_nrfx_twi_driver_api = {
-	.configure = i2c_nrfx_twi_configure,
-	.transfer  = i2c_nrfx_twi_transfer,
+	.configure   = i2c_nrfx_twi_configure,
+	.transfer    = i2c_nrfx_twi_transfer,
+	.recover_bus = i2c_nrfx_twi_recover_bus,
 };
 
 static int init_twi(const struct device *dev)

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -259,9 +259,18 @@ static int i2c_nrfx_twim_configure(const struct device *dev,
 	return 0;
 }
 
+static int i2c_nrfx_twim_recover_bus(const struct device *dev)
+{
+	nrfx_err_t err = nrfx_twim_bus_recover(get_dev_config(dev)->config.scl,
+					       get_dev_config(dev)->config.sda);
+
+	return (err == NRFX_SUCCESS ? 0 : -EBUSY);
+}
+
 static const struct i2c_driver_api i2c_nrfx_twim_driver_api = {
-	.configure = i2c_nrfx_twim_configure,
-	.transfer  = i2c_nrfx_twim_transfer,
+	.configure   = i2c_nrfx_twim_configure,
+	.transfer    = i2c_nrfx_twim_transfer,
+	.recover_bus = i2c_nrfx_twim_recover_bus,
 };
 
 static int init_twim(const struct device *dev)


### PR DESCRIPTION
Both nRF I2C drivers (i2c_nrfx_twi and i2c_nrfx_twim) perform the bus
recovery procedure in reaction to timeout (500 ms) of any requested
message transfer. Add implementation of the I2C API recovery function
in both these drivers so that it is also possible to execute this
procedure directly.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>