### PR TITLE
codeowners: Add sjanc to Bluetooth tester app

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -696,6 +696,7 @@
 /tests/bluetooth/                         @joerchan @jhedberg @Vudentz
 /tests/bluetooth/bsim_bt/                 @joerchan @jhedberg @Vudentz @aescolar @wopu-ot
 /tests/bluetooth/bsim_bt/bsim_test_audio/ @joerchan @jhedberg @Vudentz @aescolar @wopu-ot @Thalley @asbjornsabo
+/tests/bluetooth/tester/                  @joerchan @jhedberg @Vudentz @sjanc
 /tests/posix/                             @pfalcon
 /tests/crypto/                            @ceolin
 /tests/crypto/mbedtls/                    @nashif @ceolin


### PR DESCRIPTION
This is used by autoPTS project so make sure Szymon is aware of all
changes in tester application.

Signed-off-by: Szymon Janc <szymon.janc@codecoup.pl>