### PR TITLE
Added stop-bits field to uart-controller.yaml,

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1420,6 +1420,7 @@ static int uart_stm32_init(const struct device *dev)
 	USART_TypeDef *UartInstance = UART_STRUCT(dev);
 	uint32_t ll_parity;
 	uint32_t ll_datawidth;
+	uint32_t ll_stopbits;
 	int err;
 
 	__uart_stm32_get_clock(dev);
@@ -1463,12 +1464,12 @@ static int uart_stm32_init(const struct device *dev)
 		ll_parity = LL_USART_PARITY_NONE;
 		ll_datawidth = LL_USART_DATAWIDTH_8B;
 	}
-
+	ll_stopbits = uart_stm32_cfg2ll_stopbits(config->stop_bits);
 	/* Set datawidth and parity, 1 start bit, 1 stop bit  */
 	LL_USART_ConfigCharacter(UartInstance,
 				 ll_datawidth,
 				 ll_parity,
-				 LL_USART_STOPBITS_1);
+				 ll_stopbits);
 
 	if (config->hw_flow_control) {
 		uart_stm32_set_hwctrl(dev, LL_USART_HWCONTROL_RTS_CTS);
@@ -1593,6 +1594,7 @@ static const struct uart_stm32_config uart_stm32_cfg_##index = {	\
 	},								\
 	.hw_flow_control = DT_INST_PROP(index, hw_flow_control),	\
 	.parity = DT_ENUM_IDX_OR(DT_DRV_INST(index), parity, UART_CFG_PARITY_NONE),	\
+	.stop_bits = DT_ENUM_IDX_OR(DT_DRV_INST(index), stop_bits, UART_CFG_STOP_BITS_1), \
 	STM32_UART_POLL_IRQ_HANDLER_FUNC(index)				\
 	.pinctrl_list = uart_pins_##index,				\
 	.pinctrl_list_size = ARRAY_SIZE(uart_pins_##index),		\

--- a/drivers/serial/uart_stm32.h
+++ b/drivers/serial/uart_stm32.h
@@ -23,6 +23,9 @@ struct uart_stm32_config {
 	bool hw_flow_control;
 	/* initial parity, 0 for none, 1 for odd, 2 for even */
 	int  parity;
+	/* initial stop-bits, 
+	*  0 for 1, 1 for 0.5, 2 for 1.5, 3 for 2 */
+	int stop_bits;
 	const struct soc_gpio_pinctrl *pinctrl_list;
 	size_t pinctrl_list_size;
 #if defined(CONFIG_PM) \

--- a/dts/bindings/serial/st,stm32-usart.yaml
+++ b/dts/bindings/serial/st,stm32-usart.yaml
@@ -20,3 +20,13 @@ properties:
 
         For example the USART1 would be
            pinctrl-0 = <&usart1_tx_pb6 &usart1_rx_pb7>;
+
+    stop-bits:
+      required: false
+      type: string
+      description: Inital stop-bits setting for UART
+      enum:
+        - "1"
+        - "0.5"
+        - "1.5"
+        - "2"


### PR DESCRIPTION
using in drivers/serial/uart_stm32.c .
For some reason, stop-bits option was not configurable
from dts (was hard-coded).
This means that if another stop-bits configuration is desired,
you have to call uart_configure on runtime.
There's no reason for that.

Signed-off-by: Avi Green <avigreen1978@yandex.com>