### PR TITLE
Fix west debug with openocd runner

### DIFF
--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -278,12 +278,12 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
             pre_init_cmd.append("-c")
             pre_init_cmd.append("$_TARGETNAME configure -rtos Zephyr")
 
-        server_cmd = (self.openocd_cmd + self.serial +
+        server_cmd = (self.openocd_cmd + self.serial + self.cfg_cmd +
                       ['-c', 'tcl_port {}'.format(self.tcl_port),
                        '-c', 'telnet_port {}'.format(self.telnet_port),
                        '-c', 'gdb_port {}'.format(self.gdb_port)] +
                       pre_init_cmd + self.init_arg + self.targets_arg +
-                      self.halt_arg + self.cfg_cmd)
+                      self.halt_arg)
         gdb_cmd = (self.gdb_cmd + self.tui_arg +
                    ['-ex', 'target remote :{}'.format(self.gdb_port),
                     self.elf_name])

--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -289,10 +289,10 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
                     self.elf_name])
         if command == 'debug':
             gdb_cmd.extend(self.load_arg)
-
-        for i in self.gdb_init:
-            gdb_cmd.append("-ex")
-            gdb_cmd.append(i)
+        if self.gdb_init is not None:
+            for i in self.gdb_init:
+                gdb_cmd.append("-ex")
+                gdb_cmd.append(i)
 
         self.require(gdb_cmd[0])
         self.print_gdbserver_message()

--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -285,7 +285,7 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
                       pre_init_cmd + self.init_arg + self.targets_arg +
                       self.halt_arg)
         gdb_cmd = (self.gdb_cmd + self.tui_arg +
-                   ['-ex', 'target remote :{}'.format(self.gdb_port),
+                   ['-ex', 'target extended-remote :{}'.format(self.gdb_port),
                     self.elf_name])
         if command == 'debug':
             gdb_cmd.extend(self.load_arg)


### PR DESCRIPTION
This PR fix possible regression introduced in #38557 for boards providing their own configuration
file 'openocd.cfg', which prevent to run west debug command.

This also fix a warning about gdb 'target remote' deprecation.

Thanks !

