### PR TITLE
shell: fix assert in panic mode

### DIFF
--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -629,6 +629,7 @@ struct shell_flags {
 	uint32_t last_nl     :8; /*!< Last received new line character */
 	uint32_t cmd_ctx     :1; /*!< Shell is executing command */
 	uint32_t print_noinit:1; /*!< Print request from not initialized shell*/
+	uint32_t panic_mode  :1; /*!< Shell in panic mode */
 };
 
 BUILD_ASSERT((sizeof(struct shell_flags) == sizeof(uint32_t)),

--- a/subsys/shell/shell_log_backend.c
+++ b/subsys/shell/shell_log_backend.c
@@ -289,6 +289,7 @@ static void panic(const struct log_backend *const backend)
 	if (err == 0) {
 		shell->log_backend->control_block->state =
 						SHELL_LOG_BACKEND_PANIC;
+		z_flag_panic_mode_set(shell, true);
 
 		/* Move to the start of next line. */
 		z_shell_multiline_data_calc(&shell->ctx->vt100_ctx.cons,

--- a/subsys/shell/shell_ops.c
+++ b/subsys/shell/shell_ops.c
@@ -479,19 +479,20 @@ void z_shell_vfprintf(const struct shell *shell, enum shell_vt100_color color,
 	}
 }
 
-void z_shell_fprintf(const struct shell *shell,
-			    enum shell_vt100_color color,
-			    const char *fmt, ...)
+void z_shell_fprintf(const struct shell *sh,
+		     enum shell_vt100_color color,
+		     const char *fmt, ...)
 {
-	__ASSERT_NO_MSG(shell);
-	__ASSERT(!k_is_in_isr(), "Thread context required.");
-	__ASSERT_NO_MSG(shell->ctx);
-	__ASSERT_NO_MSG(shell->fprintf_ctx);
+	__ASSERT_NO_MSG(sh);
+	__ASSERT_NO_MSG(sh->ctx);
+	__ASSERT_NO_MSG(sh->fprintf_ctx);
 	__ASSERT_NO_MSG(fmt);
+	__ASSERT(z_flag_panic_mode_get(sh) || !k_is_in_isr(),
+		 "Thread context required.");
 
 	va_list args;
 
 	va_start(args, fmt);
-	z_shell_vfprintf(shell, color, fmt, args);
+	z_shell_vfprintf(sh, color, fmt, args);
 	va_end(args);
 }

--- a/subsys/shell/shell_ops.h
+++ b/subsys/shell/shell_ops.h
@@ -219,6 +219,19 @@ static inline bool z_flag_print_noinit_set(const struct shell *shell, bool val)
 	return ret;
 }
 
+static inline bool z_flag_panic_mode_get(const struct shell *sh)
+{
+	return sh->ctx->internal.flags.panic_mode == 1;
+}
+
+static inline bool z_flag_panic_mode_set(const struct shell *sh, bool val)
+{
+	bool ret;
+
+	Z_SHELL_SET_FLAG_ATOMIC(sh, panic_mode, val, ret);
+	return ret;
+}
+
 void z_shell_op_cursor_vert_move(const struct shell *shell, int32_t delta);
 void z_shell_op_cursor_horiz_move(const struct shell *shell, int32_t delta);
 


### PR DESCRIPTION
In panic mode, the function: z_shell_fprintf is expected to be
called from an interrupt context. Therefore, the dedicated assert
cannot be checked in this case.

Fixes #38612

Signed-off-by: Jakub Rzeszutko <jakub.rzeszutko@nordicsemi.no>