### PR TITLE
gitattributes: consider SVG files generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,10 @@
 .gitignore export-ignore
 .mailmap export-ignore
 
+# Tell git to not diff certain files
+*.svg -diff
+
 # Tell linguist that generated test pattern files should not be included in the
 # language statistics.
-*.pat linguist-generated=true
+*.pat linguist-generated
+*.svg linguist-generated


### PR DESCRIPTION
SVG files are usually created or generated using editors, e.g. Inkscape.
Exclude them from diffs to improve review process by marking them as
generated.