### PR TITLE
doc: release: 2.7: correct single backticks

### DIFF
--- a/doc/releases/release-notes-2.7.rst
+++ b/doc/releases/release-notes-2.7.rst
@@ -433,9 +433,14 @@ Drivers and Sensors
 
 * IPM
 
-  * STM32: Add HSEM based IPM driver for STM32H7 series
+  * Added STM32 HSEM IPM driver.
 
 * Interrupt Controller
+
+
+* IPM
+
+  * STM32: Add HSEM based IPM driver for STM32H7 series
 
 * LED
 

--- a/doc/releases/release-notes-2.7.rst
+++ b/doc/releases/release-notes-2.7.rst
@@ -558,6 +558,10 @@ Networking
     address info entries, when multiple IP addresses were obtained from the
     server.
 
+* DNS-SD:
+
+  * Added Service Type Enumeration support (``_services._dns_sd._udp.local``)
+
 * HTTP:
 
   * Switched the library to use ``zsock_*`` API, to improve compatibility with

--- a/doc/releases/release-notes-2.7.rst
+++ b/doc/releases/release-notes-2.7.rst
@@ -557,10 +557,6 @@ Networking
     address info entries, when multiple IP addresses were obtained from the
     server.
 
-* DNS-SD:
-
-  * Added Service Type Enumeration support (`_services._dns_sd._udp.local`)
-
 * HTTP:
 
   * Switched the library to use ``zsock_*`` API, to improve compatibility with

--- a/doc/releases/release-notes-2.7.rst
+++ b/doc/releases/release-notes-2.7.rst
@@ -433,14 +433,10 @@ Drivers and Sensors
 
 * IPM
 
-  * Added STM32 HSEM IPM driver.
+  * STM32: Add HSEM based IPM driver for STM32H7 series
 
 * Interrupt Controller
 
-
-* IPM
-
-  * STM32: Add HSEM based IPM driver for STM32H7 series
 
 * LED
 


### PR DESCRIPTION
RST uses two backticks rather than 1

Original merge in #39447 failed to produce docs