### PR TITLE
Add ARC_MPY_OPTION to kconfig

### DIFF
--- a/arch/arc/Kconfig
+++ b/arch/arc/Kconfig
@@ -263,7 +263,6 @@ config CODE_DENSITY
 config ARC_HAS_ACCL_REGS
 	bool "Reg Pair ACCL:ACCH (FPU and/or MPY > 6)"
 	default y if CPU_HS3X
-	default y if FPU
 	help
 	  Depending on the configuration, CPU can contain accumulator reg-pair
 	  (also referred to as r58:r59). These can also be used by gcc as GPR so

--- a/soc/arc/snps_arc_hsdk/Kconfig.defconfig
+++ b/soc/arc/snps_arc_hsdk/Kconfig.defconfig
@@ -47,4 +47,7 @@ config UART_NS16550_ACCESS_WORD_ONLY
 	default y
 	depends on UART_NS16550
 
+config ARC_HAS_ACCL_REGS
+	default y
+
 endif # ARC_HSDK

--- a/soc/arc/snps_nsim/Kconfig.defconfig.em
+++ b/soc/arc/snps_nsim/Kconfig.defconfig.em
@@ -50,4 +50,7 @@ config ZTEST_STACKSIZE
 
 endif # ARC_MPU_VER
 
+config ARC_HAS_ACCL_REGS
+	default y
+
 endif # SOC_NSIM_EM

--- a/soc/arc/snps_nsim/Kconfig.defconfig.em7d_v22
+++ b/soc/arc/snps_nsim/Kconfig.defconfig.em7d_v22
@@ -47,4 +47,7 @@ config ZTEST_STACKSIZE
 
 endif # ARC_MPU_VER
 
+config ARC_HAS_ACCL_REGS
+	default y
+
 endif # SOC_NSIM_EM

--- a/soc/arc/snps_nsim/Kconfig.defconfig.hs
+++ b/soc/arc/snps_nsim/Kconfig.defconfig.hs
@@ -30,4 +30,7 @@ config ARC_FIRQ
 config CACHE_MANAGEMENT
 	default y
 
+config ARC_HAS_ACCL_REGS
+	default y
+
 endif # SOC_NSIM_HS

--- a/soc/arc/snps_nsim/Kconfig.defconfig.hs_mpuv6
+++ b/soc/arc/snps_nsim/Kconfig.defconfig.hs_mpuv6
@@ -36,4 +36,7 @@ config ARC_FIRQ
 config CACHE_MANAGEMENT
 	default y
 
+config ARC_HAS_ACCL_REGS
+	default y
+
 endif # SOC_NSIM_HS_MPUV6

--- a/soc/arc/snps_nsim/Kconfig.defconfig.sem
+++ b/soc/arc/snps_nsim/Kconfig.defconfig.sem
@@ -33,4 +33,7 @@ config ARC_FIRQ
 config CACHE_MANAGEMENT
 	default y
 
+config ARC_HAS_ACCL_REGS
+	default y
+
 endif # SOC_NSIM_SEM


### PR DESCRIPTION
The CONFIG_ARC_HAS_ACCL_REGS is not set for most of ARC targets. When it is set, it provides saving & restoring to r58 and r59 which are acch and accl registers. The condition to set CONFIG_ARC_HAS_ACCL_REGS should be FPU and/or MPY > 6 but there's no corresponding kconfig item for MPY. 
The issue mentioned in #39392 was caused by this, CONFIG_ARC_HAS_ACCL_REGS was not set but arcmwdt compiler uses accl and acch as general purpose registers which are corrupted during IRQ. 
This PR add a new ARC_MPY_OPTION to kconfig to patch this problem.

Fixes #39392