### PR TITLE
Bluetooth: Audio: Media control renaming plus Kconfig cleanup

### DIFF
--- a/include/bluetooth/mcc.h
+++ b/include/bluetooth/mcc.h
@@ -53,7 +53,7 @@ typedef void (*bt_mcc_discover_mcs_cb)(struct bt_conn *conn, int err);
  * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param name          Player name
  */
-typedef void (*bt_mcc_player_name_read_cb)(struct bt_conn *conn, int err, const char *name);
+typedef void (*bt_mcc_read_player_name_cb)(struct bt_conn *conn, int err, const char *name);
 
 #ifdef CONFIG_BT_OTC
 /**
@@ -65,7 +65,7 @@ typedef void (*bt_mcc_player_name_read_cb)(struct bt_conn *conn, int err, const 
  * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param icon_id       The ID of the Icon Object. This is a UINT48 in a uint64_t
  */
-typedef void (*bt_mcc_icon_obj_id_read_cb)(struct bt_conn *conn, int err, uint64_t id);
+typedef void (*bt_mcc_read_icon_obj_id_cb)(struct bt_conn *conn, int err, uint64_t id);
 #endif /* CONFIG_BT_OTC */
 
 /**
@@ -77,7 +77,7 @@ typedef void (*bt_mcc_icon_obj_id_read_cb)(struct bt_conn *conn, int err, uint64
  * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param icon_url      The URL of the Icon
  */
-typedef void (*bt_mcc_icon_url_read_cb)(struct bt_conn *conn, int err, const char *icon_url);
+typedef void (*bt_mcc_read_icon_url_cb)(struct bt_conn *conn, int err, const char *icon_url);
 
 /**
  * @brief Callback function for track changed notifications
@@ -102,7 +102,7 @@ typedef void (*bt_mcc_track_changed_ntf_cb)(struct bt_conn *conn, int err);
  * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param title         The title of the track
  */
-typedef void (*bt_mcc_track_title_read_cb)(struct bt_conn *conn, int err, const char *title);
+typedef void (*bt_mcc_read_track_title_cb)(struct bt_conn *conn, int err, const char *title);
 
 /**
  * @brief Callback function for bt_mcc_read_track_duration()
@@ -113,7 +113,7 @@ typedef void (*bt_mcc_track_title_read_cb)(struct bt_conn *conn, int err, const 
  * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param dur           The duration of the track
  */
-typedef void (*bt_mcc_track_duration_read_cb)(struct bt_conn *conn, int err, int32_t dur);
+typedef void (*bt_mcc_read_track_duration_cb)(struct bt_conn *conn, int err, int32_t dur);
 
 /**
  * @brief Callback function for bt_mcc_read_track_position()
@@ -124,7 +124,7 @@ typedef void (*bt_mcc_track_duration_read_cb)(struct bt_conn *conn, int err, int
  * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param pos           The Track Position
  */
-typedef void (*bt_mcc_track_position_read_cb)(struct bt_conn *conn, int err, int32_t pos);
+typedef void (*bt_mcc_read_track_position_cb)(struct bt_conn *conn, int err, int32_t pos);
 
 /**
  * @brief Callback function for bt_mcc_set_track_position()
@@ -135,7 +135,7 @@ typedef void (*bt_mcc_track_position_read_cb)(struct bt_conn *conn, int err, int
  * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param pos           The Track Position set (or attempted to set)
  */
-typedef void (*bt_mcc_track_position_set_cb)(struct bt_conn *conn, int err, int32_t pos);
+typedef void (*bt_mcc_set_track_position_cb)(struct bt_conn *conn, int err, int32_t pos);
 
 /**
  * @brief Callback function for bt_mcc_read_playback_speed()
@@ -146,7 +146,7 @@ typedef void (*bt_mcc_track_position_set_cb)(struct bt_conn *conn, int err, int3
  * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param speed         The Playback Speed
  */
-typedef void (*bt_mcc_playback_speed_read_cb)(struct bt_conn *conn, int err, int8_t speed);
+typedef void (*bt_mcc_read_playback_speed_cb)(struct bt_conn *conn, int err, int8_t speed);
 
 /**
  * @brief Callback function for bt_mcc_set_playback_speed()
@@ -157,7 +157,7 @@ typedef void (*bt_mcc_playback_speed_read_cb)(struct bt_conn *conn, int err, int
  * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param speed         The Playback Speed set (or attempted to set)
  */
-typedef void (*bt_mcc_playback_speed_set_cb)(struct bt_conn *conn, int err, int8_t speed);
+typedef void (*bt_mcc_set_playback_speed_cb)(struct bt_conn *conn, int err, int8_t speed);
 
 /**
  * @brief Callback function for bt_mcc_read_seeking_speed()
@@ -168,7 +168,7 @@ typedef void (*bt_mcc_playback_speed_set_cb)(struct bt_conn *conn, int err, int8
  * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param speed         The Seeking Speed
  */
-typedef void (*bt_mcc_seeking_speed_read_cb)(struct bt_conn *conn, int err, int8_t speed);
+typedef void (*bt_mcc_read_seeking_speed_cb)(struct bt_conn *conn, int err, int8_t speed);
 
 #ifdef CONFIG_BT_OTC
 /**
@@ -180,7 +180,7 @@ typedef void (*bt_mcc_seeking_speed_read_cb)(struct bt_conn *conn, int err, int8
  * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param id            The Track Segments Object ID (UINT48)
  */
-typedef void (*bt_mcc_segments_obj_id_read_cb)(struct bt_conn *conn, int err, uint64_t id);
+typedef void (*bt_mcc_read_segments_obj_id_cb)(struct bt_conn *conn, int err, uint64_t id);
 
 /**
  * @brief Callback function for bt_mcc_read_current_track_obj_id()
@@ -191,7 +191,7 @@ typedef void (*bt_mcc_segments_obj_id_read_cb)(struct bt_conn *conn, int err, ui
  * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param id            The Current Track Object ID (UINT48)
  */
-typedef void (*bt_mcc_current_track_obj_id_read_cb)(struct bt_conn *conn, int err, uint64_t id);
+typedef void (*bt_mcc_read_current_track_obj_id_cb)(struct bt_conn *conn, int err, uint64_t id);
 
 /**
  * @brief Callback function for bt_mcc_set_current_track_obj_id()
@@ -202,7 +202,7 @@ typedef void (*bt_mcc_current_track_obj_id_read_cb)(struct bt_conn *conn, int er
  * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param id            The Object ID (UINT48) set (or attempted to set)
  */
-typedef void (*bt_mcc_current_track_obj_id_set_cb)(struct bt_conn *conn, int err, uint64_t id);
+typedef void (*bt_mcc_set_current_track_obj_id_cb)(struct bt_conn *conn, int err, uint64_t id);
 
 /**
  * @brief Callback function for bt_mcc_read_next_track_obj_id_obj()
@@ -213,7 +213,7 @@ typedef void (*bt_mcc_current_track_obj_id_set_cb)(struct bt_conn *conn, int err
  * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param id            The Next Track Object ID (UINT48)
  */
-typedef void (*bt_mcc_next_track_obj_id_read_cb)(struct bt_conn *conn, int err, uint64_t id);
+typedef void (*bt_mcc_read_next_track_obj_id_cb)(struct bt_conn *conn, int err, uint64_t id);
 
 /**
  * @brief Callback function for bt_mcc_set_next_track_obj_id()
@@ -224,7 +224,7 @@ typedef void (*bt_mcc_next_track_obj_id_read_cb)(struct bt_conn *conn, int err, 
  * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param id            The Object ID (UINT48) set (or attempted to set)
  */
-typedef void (*bt_mcc_next_track_obj_id_set_cb)(struct bt_conn *conn, int err, uint64_t id);
+typedef void (*bt_mcc_set_next_track_obj_id_cb)(struct bt_conn *conn, int err, uint64_t id);
 
 /**
  * @brief Callback function for bt_mcc_read_parent_group_obj_id()
@@ -235,7 +235,7 @@ typedef void (*bt_mcc_next_track_obj_id_set_cb)(struct bt_conn *conn, int err, u
  * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param id            The Parent Group Object ID (UINT48)
  */
-typedef void (*bt_mcc_parent_group_obj_id_read_cb)(struct bt_conn *conn, int err, uint64_t id);
+typedef void (*bt_mcc_read_parent_group_obj_id_cb)(struct bt_conn *conn, int err, uint64_t id);
 
 /**
  * @brief Callback function for bt_mcc_read_current_group_obj_id()
@@ -246,7 +246,7 @@ typedef void (*bt_mcc_parent_group_obj_id_read_cb)(struct bt_conn *conn, int err
  * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param id            The Current Group Object ID (UINT48)
  */
-typedef void (*bt_mcc_current_group_obj_id_read_cb)(struct bt_conn *conn, int err, uint64_t id);
+typedef void (*bt_mcc_read_current_group_obj_id_cb)(struct bt_conn *conn, int err, uint64_t id);
 
 /**
  * @brief Callback function for bt_mcc_set_current_group_obj_id()
@@ -257,7 +257,7 @@ typedef void (*bt_mcc_current_group_obj_id_read_cb)(struct bt_conn *conn, int er
  * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param id            The Object ID (UINT48) set (or attempted to set)
  */
-typedef void (*bt_mcc_current_group_obj_id_set_cb)(struct bt_conn *conn, int err, uint64_t obj_id);
+typedef void (*bt_mcc_set_current_group_obj_id_cb)(struct bt_conn *conn, int err, uint64_t obj_id);
 
 #endif /* CONFIG_BT_OTC */
 
@@ -270,7 +270,7 @@ typedef void (*bt_mcc_current_group_obj_id_set_cb)(struct bt_conn *conn, int err
  * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param order         The playback order
  */
-typedef void (*bt_mcc_playing_order_read_cb)(struct bt_conn *conn, int err, uint8_t order);
+typedef void (*bt_mcc_read_playing_order_cb)(struct bt_conn *conn, int err, uint8_t order);
 
 /**
  * @brief Callback function for bt_mcc_set_playing_order()
@@ -281,7 +281,7 @@ typedef void (*bt_mcc_playing_order_read_cb)(struct bt_conn *conn, int err, uint
  * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param order         The Playing Order set (or attempted to set)
  */
-typedef void (*bt_mcc_playing_order_set_cb)(struct bt_conn *conn, int err, uint8_t order);
+typedef void (*bt_mcc_set_playing_order_cb)(struct bt_conn *conn, int err, uint8_t order);
 
 /**
  * @brief Callback function for bt_mcc_read_playing_orders_supported()
@@ -292,7 +292,7 @@ typedef void (*bt_mcc_playing_order_set_cb)(struct bt_conn *conn, int err, uint8
  * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param orders        The playing orders supported (bitmap)
  */
-typedef void (*bt_mcc_playing_orders_supported_read_cb)(struct bt_conn *conn, int err,
+typedef void (*bt_mcc_read_playing_orders_supported_cb)(struct bt_conn *conn, int err,
 							uint16_t orders);
 
 /**
@@ -304,7 +304,7 @@ typedef void (*bt_mcc_playing_orders_supported_read_cb)(struct bt_conn *conn, in
  * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param state         The Media State
  */
-typedef void (*bt_mcc_media_state_read_cb)(struct bt_conn *conn, int err, uint8_t state);
+typedef void (*bt_mcc_read_media_state_cb)(struct bt_conn *conn, int err, uint8_t state);
 
 /**
  * @brief Callback function for bt_mcc_send_cmd()
@@ -315,7 +315,7 @@ typedef void (*bt_mcc_media_state_read_cb)(struct bt_conn *conn, int err, uint8_
  * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param cmd           The command sent
  */
-typedef void (*bt_mcc_cmd_send_cb)(struct bt_conn *conn, int err, struct mpl_cmd cmd);
+typedef void (*bt_mcc_send_cmd_cb)(struct bt_conn *conn, int err, struct mpl_cmd cmd);
 
 /**
  * @brief Callback function for command notifications
@@ -341,7 +341,7 @@ typedef void (*bt_mcc_cmd_ntf_cb)(struct bt_conn *conn, int err, struct mpl_cmd_
  * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param opcodes       The supported opcodes
  */
-typedef void (*bt_mcc_opcodes_supported_read_cb)(struct bt_conn *conn, int err,
+typedef void (*bt_mcc_read_opcodes_supported_cb)(struct bt_conn *conn, int err,
 						 uint32_t opcodes);
 
 #ifdef CONFIG_BT_OTC
@@ -354,7 +354,7 @@ typedef void (*bt_mcc_opcodes_supported_read_cb)(struct bt_conn *conn, int err,
  * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param search        The search set (or attempted to set)
  */
-typedef void (*bt_mcc_search_send_cb)(struct bt_conn *conn, int err,
+typedef void (*bt_mcc_send_search_cb)(struct bt_conn *conn, int err,
 				      struct mpl_search search);
 
 /**
@@ -386,7 +386,7 @@ typedef void (*bt_mcc_search_ntf_cb)(struct bt_conn *conn, int err,
  * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param id            The Search Results Object ID (UINT48)
  */
-typedef void (*bt_mcc_search_results_obj_id_read_cb)(struct bt_conn *conn,
+typedef void (*bt_mcc_read_search_results_obj_id_cb)(struct bt_conn *conn,
 						     int err, uint64_t id);
 #endif /* CONFIG_BT_OTC */
 
@@ -399,8 +399,8 @@ typedef void (*bt_mcc_search_results_obj_id_read_cb)(struct bt_conn *conn,
  * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param ccid          The Content Control ID
  */
-typedef void (*bt_mcc_content_control_id_read_cb)(struct bt_conn *conn,
-						    int err, uint8_t ccid);
+typedef void (*bt_mcc_read_content_control_id_cb)(struct bt_conn *conn,
+						  int err, uint8_t ccid);
 #ifdef CONFIG_BT_OTC
 /**** Callback functions for the included Object Transfer service *************/
 
@@ -516,42 +516,42 @@ typedef void (*bt_mcc_otc_read_current_group_object_cb)(struct bt_conn *conn, in
  */
 struct bt_mcc_cb {
 	bt_mcc_discover_mcs_cb                   discover_mcs;
-	bt_mcc_player_name_read_cb               player_name_read;
+	bt_mcc_read_player_name_cb               read_player_name;
 #ifdef CONFIG_BT_OTC
-	bt_mcc_icon_obj_id_read_cb               icon_obj_id_read;
+	bt_mcc_read_icon_obj_id_cb               read_icon_obj_id;
 #endif /* CONFIG_BT_OTC */
-	bt_mcc_icon_url_read_cb                  icon_url_read;
+	bt_mcc_read_icon_url_cb                  read_icon_url;
 	bt_mcc_track_changed_ntf_cb              track_changed_ntf;
-	bt_mcc_track_title_read_cb               track_title_read;
-	bt_mcc_track_duration_read_cb            track_duration_read;
-	bt_mcc_track_position_read_cb            track_position_read;
-	bt_mcc_track_position_set_cb             track_position_set;
-	bt_mcc_playback_speed_read_cb            playback_speed_read;
-	bt_mcc_playback_speed_set_cb             playback_speed_set;
-	bt_mcc_seeking_speed_read_cb             seeking_speed_read;
+	bt_mcc_read_track_title_cb               read_track_title;
+	bt_mcc_read_track_duration_cb            read_track_duration;
+	bt_mcc_read_track_position_cb            read_track_position;
+	bt_mcc_set_track_position_cb             set_track_position;
+	bt_mcc_read_playback_speed_cb            read_playback_speed;
+	bt_mcc_set_playback_speed_cb             set_playback_speed;
+	bt_mcc_read_seeking_speed_cb             read_seeking_speed;
 #ifdef CONFIG_BT_OTC
-	bt_mcc_segments_obj_id_read_cb           segments_obj_id_read;
-	bt_mcc_current_track_obj_id_read_cb      current_track_obj_id_read;
-	bt_mcc_current_track_obj_id_set_cb       current_track_obj_id_set;
-	bt_mcc_next_track_obj_id_read_cb         next_track_obj_id_read;
-	bt_mcc_next_track_obj_id_set_cb          next_track_obj_id_set;
-	bt_mcc_current_group_obj_id_read_cb      current_group_obj_id_read;
-	bt_mcc_current_group_obj_id_set_cb       current_group_obj_id_set;
-	bt_mcc_parent_group_obj_id_read_cb       parent_group_obj_id_read;
+	bt_mcc_read_segments_obj_id_cb           read_segments_obj_id;
+	bt_mcc_read_current_track_obj_id_cb      read_current_track_obj_id;
+	bt_mcc_set_current_track_obj_id_cb       set_current_track_obj_id;
+	bt_mcc_read_next_track_obj_id_cb         read_next_track_obj_id;
+	bt_mcc_set_next_track_obj_id_cb          set_next_track_obj_id;
+	bt_mcc_read_current_group_obj_id_cb      read_current_group_obj_id;
+	bt_mcc_set_current_group_obj_id_cb       set_current_group_obj_id;
+	bt_mcc_read_parent_group_obj_id_cb       read_parent_group_obj_id;
 #endif /* CONFIG_BT_OTC */
-	bt_mcc_playing_order_read_cb	         playing_order_read;
-	bt_mcc_playing_order_set_cb              playing_order_set;
-	bt_mcc_playing_orders_supported_read_cb  playing_orders_supported_read;
-	bt_mcc_media_state_read_cb               media_state_read;
-	bt_mcc_cmd_send_cb                       cmd_send;
+	bt_mcc_read_playing_order_cb	         read_playing_order;
+	bt_mcc_set_playing_order_cb              set_playing_order;
+	bt_mcc_read_playing_orders_supported_cb  read_playing_orders_supported;
+	bt_mcc_read_media_state_cb               read_media_state;
+	bt_mcc_send_cmd_cb                       send_cmd;
 	bt_mcc_cmd_ntf_cb                        cmd_ntf;
-	bt_mcc_opcodes_supported_read_cb         opcodes_supported_read;
+	bt_mcc_read_opcodes_supported_cb         read_opcodes_supported;
 #ifdef CONFIG_BT_OTC
-	bt_mcc_search_send_cb                    search_send;
+	bt_mcc_send_search_cb                    send_search;
 	bt_mcc_search_ntf_cb                     search_ntf;
-	bt_mcc_search_results_obj_id_read_cb     search_results_obj_id_read;
+	bt_mcc_read_search_results_obj_id_cb     read_search_results_obj_id;
 #endif /* CONFIG_BT_OTC */
-	bt_mcc_content_control_id_read_cb        content_control_id_read;
+	bt_mcc_read_content_control_id_cb        read_content_control_id;
 #ifdef CONFIG_BT_OTC
 	bt_mcc_otc_obj_selected_cb               otc_obj_selected;
 	bt_mcc_otc_obj_metadata_cb               otc_obj_metadata;

--- a/subsys/bluetooth/host/audio/Kconfig.mcs
+++ b/subsys/bluetooth/host/audio/Kconfig.mcs
@@ -23,13 +23,13 @@ config BT_MCS_MEDIA_PLAYER_NAME
 	string "Media Player Name"
 	default "Player0"
 	help
-	  Sets the name of the media player
+	  Use this option to set the name of the media player.
 
 config BT_MCS_ICON_URL
 	string "Media player Icon URL"
 	default "http://server.some.where/path/icon.png"
 	help
-	  This option sets the URL of the Media Player Icon
+	  Use this option to set the URL of the Media Player Icon.
 
 #### Debug logs ################################################################
 
@@ -80,7 +80,7 @@ config BT_MCC_TOTAL_OBJ_CONTENT_MEM
 	  Sets the total memory size (in octets) to use for storing the content
 	  of objects.
 	  This is used for the total memory pool buffer size from which memory
-	  is allocated when reading object content
+	  is allocated when reading object content.
 
 config BT_MCC_TRACK_SEGS_MAX_CNT
 	int "Maximum number of tracks segments in a track segment object"
@@ -89,7 +89,7 @@ config BT_MCC_TRACK_SEGS_MAX_CNT
 	help
 	  Sets the maximum number of tracks segments in a track segment object.
 	  If the received object is bigger, the remaining data in the object
-	  will be ignored
+	  will be ignored.
 
 config BT_MCC_GROUP_RECORDS_MAX
 	int "Maximum number of records in a group object"
@@ -129,7 +129,7 @@ config BT_MCS_MEDIA_PLAYER_NAME_MAX
 	range 1 255
 	help
 	  Sets the maximum number of bytes (including the null termination) of
-	  the name of the media player
+	  the name of the media player.
 
 config BT_MCS_ICON_URL_MAX
 	int "Max length of media player icon URL"
@@ -137,7 +137,7 @@ config BT_MCS_ICON_URL_MAX
 	range 1 255
 	help
 	  Sets the maximum number of bytes (including the null termination) of
-	  the media player icon URL
+	  the media player icon URL.
 
 config BT_MCS_TRACK_TITLE_MAX
 	int "Max length of the title of a track"
@@ -145,7 +145,7 @@ config BT_MCS_TRACK_TITLE_MAX
 	range 1 255
 	help
 	  Sets the maximum number of bytes (including the null termination) of
-	  the title of any track in the media player
+	  the title of any track in the media player.
 
 config BT_MCS_GROUP_TITLE_MAX
 	int "Max length of the title of a group of tracks"
@@ -153,7 +153,7 @@ config BT_MCS_GROUP_TITLE_MAX
 	range 1 255
 	help
 	  Sets the maximum number of bytes (including the null termination) of
-	  the title of any track in the media player
+	  the title of any track in the media player.
 
 config BT_MCS_SEGMENT_NAME_MAX
 	int "Max length of the name of a track segment"
@@ -161,7 +161,7 @@ config BT_MCS_SEGMENT_NAME_MAX
 	range 1 255
 	help
 	  Sets the the maximum number of bytes (including the null termination)
-	  of the name of any track segment in the media player
+	  of the name of any track segment in the media player.
 
 config BT_MCS_ICON_BITMAP_SIZE
 	int "Media player Icon bitmap object size"
@@ -173,19 +173,19 @@ config BT_MCS_TRACK_SEG_MAX_SIZE
 	int "Maximum size for a track segment object"
 	default 127
 	help
-	  This option sets the maximum size (in octets) of a track segment object
+	  This option sets the maximum size (in octets) of a track segment object.
 
 config BT_MCS_TRACK_MAX_SIZE
 	int "Maximum size for a track object"
 	default 127
 	help
-	  This option sets the maximum size (in octets) of a track object
+	  This option sets the maximum size (in octets) of a track object.
 
 config BT_MCS_GROUP_MAX_SIZE
 	int "Maximum size for a group object"
 	default 127
 	help
-	  This option sets the maximum size (in octets) of a group object
+	  This option sets the maximum size (in octets) of a group object.
 
 config BT_MCS_MAX_OBJ_SIZE
 	int "Total memory size to use for storing the content of objects"

--- a/subsys/bluetooth/host/audio/mcc.c
+++ b/subsys/bluetooth/host/audio/mcc.c
@@ -193,8 +193,8 @@ static uint8_t mcc_read_player_name_cb(struct bt_conn *conn, uint8_t err,
 		BT_DBG("Player name: %s", log_strdup(name));
 	}
 
-	if (mcc_cb && mcc_cb->player_name_read) {
-		mcc_cb->player_name_read(conn, cb_err, name);
+	if (mcc_cb && mcc_cb->read_player_name) {
+		mcc_cb->read_player_name(conn, cb_err, name);
 	}
 
 	return BT_GATT_ITER_STOP;
@@ -222,8 +222,8 @@ static uint8_t mcc_read_icon_obj_id_cb(struct bt_conn *conn, uint8_t err,
 		BT_DBG_OBJ_ID("Icon Object ID: ", id);
 	}
 
-	if (mcc_cb && mcc_cb->icon_obj_id_read) {
-		mcc_cb->icon_obj_id_read(conn, cb_err, id);
+	if (mcc_cb && mcc_cb->read_icon_obj_id) {
+		mcc_cb->read_icon_obj_id(conn, cb_err, id);
 	}
 
 	return BT_GATT_ITER_STOP;
@@ -252,8 +252,8 @@ static uint8_t mcc_read_icon_url_cb(struct bt_conn *conn, uint8_t err,
 		BT_DBG("Icon URL: %s", log_strdup(url));
 	}
 
-	if (mcc_cb && mcc_cb->icon_url_read) {
-		mcc_cb->icon_url_read(conn, cb_err, url);
+	if (mcc_cb && mcc_cb->read_icon_url) {
+		mcc_cb->read_icon_url(conn, cb_err, url);
 	}
 
 	return BT_GATT_ITER_STOP;
@@ -282,8 +282,8 @@ static uint8_t mcc_read_track_title_cb(struct bt_conn *conn, uint8_t err,
 		BT_DBG("Track title: %s", log_strdup(title));
 	}
 
-	if (mcc_cb && mcc_cb->track_title_read) {
-		mcc_cb->track_title_read(conn, cb_err, title);
+	if (mcc_cb && mcc_cb->read_track_title) {
+		mcc_cb->read_track_title(conn, cb_err, title);
 	}
 
 	return BT_GATT_ITER_STOP;
@@ -308,8 +308,8 @@ static uint8_t mcc_read_track_duration_cb(struct bt_conn *conn, uint8_t err,
 		BT_HEXDUMP_DBG(data, sizeof(int32_t), "Track duration");
 	}
 
-	if (mcc_cb && mcc_cb->track_duration_read) {
-		mcc_cb->track_duration_read(conn, cb_err, dur);
+	if (mcc_cb && mcc_cb->read_track_duration) {
+		mcc_cb->read_track_duration(conn, cb_err, dur);
 	}
 
 	return BT_GATT_ITER_STOP;
@@ -334,8 +334,8 @@ static uint8_t mcc_read_track_position_cb(struct bt_conn *conn, uint8_t err,
 		BT_HEXDUMP_DBG(data, sizeof(pos), "Track position");
 	}
 
-	if (mcc_cb && mcc_cb->track_position_read) {
-		mcc_cb->track_position_read(conn, cb_err, pos);
+	if (mcc_cb && mcc_cb->read_track_position) {
+		mcc_cb->read_track_position(conn, cb_err, pos);
 	}
 
 	return BT_GATT_ITER_STOP;
@@ -360,8 +360,8 @@ static void mcs_write_track_position_cb(struct bt_conn *conn, uint8_t err,
 			       "Track position in callback");
 	}
 
-	if (mcc_cb && mcc_cb->track_position_set) {
-		mcc_cb->track_position_set(conn, cb_err, pos);
+	if (mcc_cb && mcc_cb->set_track_position) {
+		mcc_cb->set_track_position(conn, cb_err, pos);
 	}
 }
 
@@ -384,8 +384,8 @@ static uint8_t mcc_read_playback_speed_cb(struct bt_conn *conn, uint8_t err,
 		BT_HEXDUMP_DBG(data, sizeof(int8_t), "Playback speed");
 	}
 
-	if (mcc_cb && mcc_cb->playback_speed_read) {
-		mcc_cb->playback_speed_read(conn, cb_err, speed);
+	if (mcc_cb && mcc_cb->read_playback_speed) {
+		mcc_cb->read_playback_speed(conn, cb_err, speed);
 	}
 
 	return BT_GATT_ITER_STOP;
@@ -408,8 +408,8 @@ static void mcs_write_playback_speed_cb(struct bt_conn *conn, uint8_t err,
 		BT_DBG("Playback_speed: %d", speed);
 	}
 
-	if (mcc_cb && mcc_cb->playback_speed_set) {
-		mcc_cb->playback_speed_set(conn, cb_err, speed);
+	if (mcc_cb && mcc_cb->set_playback_speed) {
+		mcc_cb->set_playback_speed(conn, cb_err, speed);
 	}
 }
 
@@ -432,8 +432,8 @@ static uint8_t mcc_read_seeking_speed_cb(struct bt_conn *conn, uint8_t err,
 		BT_HEXDUMP_DBG(data, sizeof(int8_t), "Seeking speed");
 	}
 
-	if (mcc_cb && mcc_cb->seeking_speed_read) {
-		mcc_cb->seeking_speed_read(conn, cb_err, speed);
+	if (mcc_cb && mcc_cb->read_seeking_speed) {
+		mcc_cb->read_seeking_speed(conn, cb_err, speed);
 	}
 
 	return BT_GATT_ITER_STOP;
@@ -462,8 +462,8 @@ static uint8_t mcc_read_segments_obj_id_cb(struct bt_conn *conn, uint8_t err,
 		cb_err = 0;
 	}
 
-	if (mcc_cb && mcc_cb->segments_obj_id_read) {
-		mcc_cb->segments_obj_id_read(conn, cb_err, id);
+	if (mcc_cb && mcc_cb->read_segments_obj_id) {
+		mcc_cb->read_segments_obj_id(conn, cb_err, id);
 	}
 
 	return BT_GATT_ITER_STOP;
@@ -491,8 +491,8 @@ static uint8_t mcc_read_current_track_obj_id_cb(struct bt_conn *conn, uint8_t er
 		cb_err = 0;
 	}
 
-	if (mcc_cb && mcc_cb->current_track_obj_id_read) {
-		mcc_cb->current_track_obj_id_read(conn, cb_err, id);
+	if (mcc_cb && mcc_cb->read_current_track_obj_id) {
+		mcc_cb->read_current_track_obj_id(conn, cb_err, id);
 	}
 
 	return BT_GATT_ITER_STOP;
@@ -515,8 +515,8 @@ static void mcs_write_current_track_obj_id_cb(struct bt_conn *conn, uint8_t err,
 		BT_DBG_OBJ_ID("Object ID: ", obj_id);
 	}
 
-	if (mcc_cb && mcc_cb->current_track_obj_id_set) {
-		mcc_cb->current_track_obj_id_set(conn, cb_err, obj_id);
+	if (mcc_cb && mcc_cb->set_current_track_obj_id) {
+		mcc_cb->set_current_track_obj_id(conn, cb_err, obj_id);
 	}
 }
 
@@ -542,8 +542,8 @@ static uint8_t mcc_read_next_track_obj_id_cb(struct bt_conn *conn, uint8_t err,
 		BT_DBG_OBJ_ID("Next Track Object ID: ", id);
 	}
 
-	if (mcc_cb && mcc_cb->next_track_obj_id_read) {
-		mcc_cb->next_track_obj_id_read(conn, cb_err, id);
+	if (mcc_cb && mcc_cb->read_next_track_obj_id) {
+		mcc_cb->read_next_track_obj_id(conn, cb_err, id);
 	}
 
 	return BT_GATT_ITER_STOP;
@@ -566,8 +566,8 @@ static void mcs_write_next_track_obj_id_cb(struct bt_conn *conn, uint8_t err,
 		BT_DBG_OBJ_ID("Object ID: ", obj_id);
 	}
 
-	if (mcc_cb && mcc_cb->next_track_obj_id_set) {
-		mcc_cb->next_track_obj_id_set(conn, cb_err, obj_id);
+	if (mcc_cb && mcc_cb->set_next_track_obj_id) {
+		mcc_cb->set_next_track_obj_id(conn, cb_err, obj_id);
 	}
 }
 
@@ -591,8 +591,8 @@ static uint8_t mcc_read_parent_group_obj_id_cb(struct bt_conn *conn, uint8_t err
 		BT_DBG_OBJ_ID("Parent Group Object ID: ", id);
 	}
 
-	if (mcc_cb && mcc_cb->parent_group_obj_id_read) {
-		mcc_cb->parent_group_obj_id_read(conn, cb_err, id);
+	if (mcc_cb && mcc_cb->read_parent_group_obj_id) {
+		mcc_cb->read_parent_group_obj_id(conn, cb_err, id);
 	}
 
 	return BT_GATT_ITER_STOP;
@@ -618,8 +618,8 @@ static uint8_t mcc_read_current_group_obj_id_cb(struct bt_conn *conn, uint8_t er
 		BT_DBG_OBJ_ID("Current Group Object ID: ", id);
 	}
 
-	if (mcc_cb && mcc_cb->current_group_obj_id_read) {
-		mcc_cb->current_group_obj_id_read(conn, cb_err, id);
+	if (mcc_cb && mcc_cb->read_current_group_obj_id) {
+		mcc_cb->read_current_group_obj_id(conn, cb_err, id);
 	}
 
 	return BT_GATT_ITER_STOP;
@@ -642,8 +642,8 @@ static void mcs_write_current_group_obj_id_cb(struct bt_conn *conn, uint8_t err,
 		BT_DBG_OBJ_ID("Object ID: ", obj_id);
 	}
 
-	if (mcc_cb && mcc_cb->current_group_obj_id_set) {
-		mcc_cb->current_group_obj_id_set(conn, cb_err, obj_id);
+	if (mcc_cb && mcc_cb->set_current_group_obj_id) {
+		mcc_cb->set_current_group_obj_id(conn, cb_err, obj_id);
 	}
 }
 #endif /* CONFIG_BT_MCC_OTS */
@@ -667,8 +667,8 @@ static uint8_t mcc_read_playing_order_cb(struct bt_conn *conn, uint8_t err,
 		BT_HEXDUMP_DBG(data, sizeof(order), "Playing order");
 	}
 
-	if (mcc_cb && mcc_cb->playing_order_read) {
-		mcc_cb->playing_order_read(conn, cb_err, order);
+	if (mcc_cb && mcc_cb->read_playing_order) {
+		mcc_cb->read_playing_order(conn, cb_err, order);
 	}
 
 	return BT_GATT_ITER_STOP;
@@ -691,8 +691,8 @@ static void mcs_write_playing_order_cb(struct bt_conn *conn, uint8_t err,
 		BT_DBG("Playing order: %d", *(uint8_t *)params->data);
 	}
 
-	if (mcc_cb && mcc_cb->playing_order_set) {
-		mcc_cb->playing_order_set(conn, cb_err, order);
+	if (mcc_cb && mcc_cb->set_playing_order) {
+		mcc_cb->set_playing_order(conn, cb_err, order);
 	}
 }
 
@@ -715,8 +715,8 @@ static uint8_t mcc_read_playing_orders_supported_cb(struct bt_conn *conn, uint8_
 		BT_HEXDUMP_DBG(data, sizeof(orders), "Playing orders supported");
 	}
 
-	if (mcc_cb && mcc_cb->playing_orders_supported_read) {
-		mcc_cb->playing_orders_supported_read(conn, cb_err, orders);
+	if (mcc_cb && mcc_cb->read_playing_orders_supported) {
+		mcc_cb->read_playing_orders_supported(conn, cb_err, orders);
 	}
 
 	return BT_GATT_ITER_STOP;
@@ -741,8 +741,8 @@ static uint8_t mcc_read_media_state_cb(struct bt_conn *conn, uint8_t err,
 		BT_HEXDUMP_DBG(data, sizeof(uint8_t), "Media state");
 	}
 
-	if (mcc_cb && mcc_cb->media_state_read) {
-		mcc_cb->media_state_read(conn, cb_err, state);
+	if (mcc_cb && mcc_cb->read_media_state) {
+		mcc_cb->read_media_state(conn, cb_err, state);
 	}
 
 	return BT_GATT_ITER_STOP;
@@ -776,8 +776,8 @@ static void mcs_write_cp_cb(struct bt_conn *conn, uint8_t err,
 		}
 	}
 
-	if (mcc_cb && mcc_cb->cmd_send) {
-		mcc_cb->cmd_send(conn, cb_err, cmd);
+	if (mcc_cb && mcc_cb->send_cmd) {
+		mcc_cb->send_cmd(conn, cb_err, cmd);
 	}
 }
 
@@ -802,8 +802,8 @@ static uint8_t mcc_read_opcodes_supported_cb(struct bt_conn *conn, uint8_t err,
 		BT_HEXDUMP_DBG(data, sizeof(operations), "Opcodes_supported");
 	}
 
-	if (mcc_cb && mcc_cb->opcodes_supported_read) {
-		mcc_cb->opcodes_supported_read(conn, cb_err, operations);
+	if (mcc_cb && mcc_cb->read_opcodes_supported) {
+		mcc_cb->read_opcodes_supported(conn, cb_err, operations);
 	}
 
 	return BT_GATT_ITER_STOP;
@@ -830,8 +830,8 @@ static void mcs_write_scp_cb(struct bt_conn *conn, uint8_t err,
 		BT_DBG("Length of returned value in callback: %d", search.len);
 	}
 
-	if (mcc_cb && mcc_cb->search_send) {
-		mcc_cb->search_send(conn, cb_err, search);
+	if (mcc_cb && mcc_cb->send_search) {
+		mcc_cb->send_search(conn, cb_err, search);
 	}
 }
 
@@ -858,8 +858,8 @@ static uint8_t mcc_read_search_results_obj_id_cb(struct bt_conn *conn, uint8_t e
 		BT_DBG_OBJ_ID("Search Results Object ID: ", id);
 	}
 
-	if (mcc_cb && mcc_cb->search_results_obj_id_read) {
-		mcc_cb->search_results_obj_id_read(conn, cb_err, id);
+	if (mcc_cb && mcc_cb->read_search_results_obj_id) {
+		mcc_cb->read_search_results_obj_id(conn, cb_err, id);
 	}
 
 	return BT_GATT_ITER_STOP;
@@ -886,8 +886,8 @@ static uint8_t mcc_read_content_control_id_cb(struct bt_conn *conn, uint8_t err,
 		BT_DBG("Content control ID: %d", ccid);
 	}
 
-	if (mcc_cb && mcc_cb->content_control_id_read) {
-		mcc_cb->content_control_id_read(conn, cb_err, ccid);
+	if (mcc_cb && mcc_cb->read_content_control_id) {
+		mcc_cb->read_content_control_id(conn, cb_err, ccid);
 	}
 
 	return BT_GATT_ITER_STOP;

--- a/subsys/bluetooth/host/audio/mcs.c
+++ b/subsys/bluetooth/host/audio/mcs.c
@@ -34,11 +34,11 @@ static struct media_proxy_sctrl_cbs cbs;
  * of attribute configuration changes.
  * Functions for notifications are placed after the service defition.
  */
-static ssize_t player_name_read(struct bt_conn *conn,
+static ssize_t read_player_name(struct bt_conn *conn,
 				const struct bt_gatt_attr *attr, void *buf,
 				uint16_t len, uint16_t offset)
 {
-	const char *name = media_proxy_sctrl_player_name_get();
+	const char *name = media_proxy_sctrl_get_player_name();
 
 	BT_DBG("Player name read: %s", log_strdup(name));
 
@@ -53,11 +53,11 @@ static void player_name_cfg_changed(const struct bt_gatt_attr *attr,
 }
 
 #ifdef CONFIG_BT_OTS
-static ssize_t icon_id_read(struct bt_conn *conn,
+static ssize_t read_icon_id(struct bt_conn *conn,
 			    const struct bt_gatt_attr *attr, void *buf,
 			    uint16_t len, uint16_t offset)
 {
-	uint64_t icon_id = media_proxy_sctrl_icon_id_get();
+	uint64_t icon_id = media_proxy_sctrl_get_icon_id();
 
 	BT_DBG_OBJ_ID("Icon object read: ", icon_id);
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, &icon_id,
@@ -65,11 +65,11 @@ static ssize_t icon_id_read(struct bt_conn *conn,
 }
 #endif /* CONFIG_BT_OTS */
 
-static ssize_t icon_url_read(struct bt_conn *conn,
+static ssize_t read_icon_url(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr, void *buf,
 			     uint16_t len, uint16_t offset)
 {
-	const char *url = media_proxy_sctrl_icon_url_get();
+	const char *url = media_proxy_sctrl_get_icon_url();
 
 	BT_DBG("Icon URL read, offset: %d, len:%d, URL: %s", offset, len,
 	       log_strdup(url));
@@ -83,11 +83,11 @@ static void track_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 	BT_DBG("value 0x%04x", value);
 }
 
-static ssize_t track_title_read(struct bt_conn *conn,
+static ssize_t read_track_title(struct bt_conn *conn,
 				const struct bt_gatt_attr *attr,
 				void *buf, uint16_t len, uint16_t offset)
 {
-	const char *title = media_proxy_sctrl_track_title_get();
+	const char *title = media_proxy_sctrl_get_track_title();
 
 	BT_DBG("Track title read, offset: %d, len:%d, title: %s", offset, len,
 	       log_strdup(title));
@@ -102,11 +102,11 @@ static void track_title_cfg_changed(const struct bt_gatt_attr *attr,
 	BT_DBG("value 0x%04x", value);
 }
 
-static ssize_t track_duration_read(struct bt_conn *conn,
+static ssize_t read_track_duration(struct bt_conn *conn,
 				   const struct bt_gatt_attr *attr, void *buf,
 				   uint16_t len, uint16_t offset)
 {
-	int32_t duration = media_proxy_sctrl_track_duration_get();
+	int32_t duration = media_proxy_sctrl_get_track_duration();
 
 	BT_DBG("Track duration read: %d (0x%08x)", duration, duration);
 
@@ -120,11 +120,11 @@ static void track_duration_cfg_changed(const struct bt_gatt_attr *attr,
 	BT_DBG("value 0x%04x", value);
 }
 
-static ssize_t track_position_read(struct bt_conn *conn,
+static ssize_t read_track_position(struct bt_conn *conn,
 				   const struct bt_gatt_attr *attr, void *buf,
 				   uint16_t len, uint16_t offset)
 {
-	int32_t position = media_proxy_sctrl_track_position_get();
+	int32_t position = media_proxy_sctrl_get_track_position();
 
 	BT_DBG("Track position read: %d (0x%08x)", position, position);
 
@@ -132,7 +132,7 @@ static ssize_t track_position_read(struct bt_conn *conn,
 				 sizeof(position));
 }
 
-static ssize_t track_position_write(struct bt_conn *conn,
+static ssize_t write_track_position(struct bt_conn *conn,
 				    const struct bt_gatt_attr *attr,
 				    const void *buf, uint16_t len,
 				    uint16_t offset, uint8_t flags)
@@ -148,7 +148,7 @@ static ssize_t track_position_write(struct bt_conn *conn,
 
 	memcpy(&position, buf, len);
 
-	media_proxy_sctrl_track_position_set(position);
+	media_proxy_sctrl_set_track_position(position);
 
 	BT_DBG("Track position write: %d", position);
 
@@ -161,11 +161,11 @@ static void track_position_cfg_changed(const struct bt_gatt_attr *attr,
 	BT_DBG("value 0x%04x", value);
 }
 
-static ssize_t playback_speed_read(struct bt_conn *conn,
+static ssize_t read_playback_speed(struct bt_conn *conn,
 				   const struct bt_gatt_attr *attr, void *buf,
 				   uint16_t len, uint16_t offset)
 {
-	int8_t speed = media_proxy_sctrl_playback_speed_get();
+	int8_t speed = media_proxy_sctrl_get_playback_speed();
 
 	BT_DBG("Playback speed read: %d", speed);
 
@@ -173,7 +173,7 @@ static ssize_t playback_speed_read(struct bt_conn *conn,
 				 sizeof(speed));
 }
 
-static ssize_t playback_speed_write(struct bt_conn *conn,
+static ssize_t write_playback_speed(struct bt_conn *conn,
 				    const struct bt_gatt_attr *attr,
 				    const void *buf, uint16_t len, uint16_t offset,
 				    uint8_t flags)
@@ -189,7 +189,7 @@ static ssize_t playback_speed_write(struct bt_conn *conn,
 
 	memcpy(&speed, buf, len);
 
-	media_proxy_sctrl_playback_speed_set(speed);
+	media_proxy_sctrl_set_playback_speed(speed);
 
 	BT_DBG("Playback speed write: %d", speed);
 
@@ -202,11 +202,11 @@ static void playback_speed_cfg_changed(const struct bt_gatt_attr *attr,
 	BT_DBG("value 0x%04x", value);
 }
 
-static ssize_t seeking_speed_read(struct bt_conn *conn,
+static ssize_t read_seeking_speed(struct bt_conn *conn,
 				  const struct bt_gatt_attr *attr, void *buf,
 				  uint16_t len, uint16_t offset)
 {
-	int8_t speed = media_proxy_sctrl_seeking_speed_get();
+	int8_t speed = media_proxy_sctrl_get_seeking_speed();
 
 	BT_DBG("Seeking speed read: %d", speed);
 
@@ -221,29 +221,29 @@ static void seeking_speed_cfg_changed(const struct bt_gatt_attr *attr,
 }
 
 #ifdef CONFIG_BT_OTS
-static ssize_t track_segments_id_read(struct bt_conn *conn,
+static ssize_t read_track_segments_id(struct bt_conn *conn,
 				      const struct bt_gatt_attr *attr,
 				      void *buf, uint16_t len, uint16_t offset)
 {
-	uint64_t track_segments_id = media_proxy_sctrl_track_segments_id_get();
+	uint64_t track_segments_id = media_proxy_sctrl_get_track_segments_id();
 
 	BT_DBG_OBJ_ID("Track segments ID read: ", track_segments_id);
 	return bt_gatt_attr_read(conn, attr, buf, len, offset,
 				 &track_segments_id, BT_OTS_OBJ_ID_SIZE);
 }
 
-static ssize_t current_track_id_read(struct bt_conn *conn,
+static ssize_t read_current_track_id(struct bt_conn *conn,
 				     const struct bt_gatt_attr *attr, void *buf,
 				     uint16_t len, uint16_t offset)
 {
-	uint64_t track_id = media_proxy_sctrl_current_track_id_get();
+	uint64_t track_id = media_proxy_sctrl_get_current_track_id();
 
 	BT_DBG_OBJ_ID("Current track ID read: ", track_id);
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, &track_id,
 				 BT_OTS_OBJ_ID_SIZE);
 }
 
-static ssize_t current_track_id_write(struct bt_conn *conn,
+static ssize_t write_current_track_id(struct bt_conn *conn,
 				      const struct bt_gatt_attr *attr,
 				      const void *buf, uint16_t len, uint16_t offset,
 				      uint8_t flags)
@@ -269,7 +269,7 @@ static ssize_t current_track_id_write(struct bt_conn *conn,
 		       offset, len, log_strdup(str));
 	}
 
-	media_proxy_sctrl_current_track_id_set(id);
+	media_proxy_sctrl_set_current_track_id(id);
 
 	return BT_OTS_OBJ_ID_SIZE;
 }
@@ -280,11 +280,11 @@ static void current_track_id_cfg_changed(const struct bt_gatt_attr *attr,
 	BT_DBG("value 0x%04x", value);
 }
 
-static ssize_t next_track_id_read(struct bt_conn *conn,
+static ssize_t read_next_track_id(struct bt_conn *conn,
 				  const struct bt_gatt_attr *attr, void *buf,
 				  uint16_t len, uint16_t offset)
 {
-	uint64_t track_id = media_proxy_sctrl_next_track_id_get();
+	uint64_t track_id = media_proxy_sctrl_get_next_track_id();
 
 	if (track_id == MPL_NO_TRACK_ID) {
 		BT_DBG("Next track read, but it is empty");
@@ -295,10 +295,10 @@ static ssize_t next_track_id_read(struct bt_conn *conn,
 
 	BT_DBG_OBJ_ID("Next track read: ", track_id);
 	return bt_gatt_attr_read(conn, attr, buf, len, offset,
-					 &track_id, BT_OTS_OBJ_ID_SIZE);
+				 &track_id, BT_OTS_OBJ_ID_SIZE);
 }
 
-static ssize_t next_track_id_write(struct bt_conn *conn,
+static ssize_t write_next_track_id(struct bt_conn *conn,
 				   const struct bt_gatt_attr *attr,
 				   const void *buf, uint16_t len, uint16_t offset,
 				   uint8_t flags)
@@ -324,7 +324,7 @@ static ssize_t next_track_id_write(struct bt_conn *conn,
 		       offset, len, log_strdup(str));
 	}
 
-	media_proxy_sctrl_next_track_id_set(id);
+	media_proxy_sctrl_set_next_track_id(id);
 
 	return BT_OTS_OBJ_ID_SIZE;
 }
@@ -335,11 +335,11 @@ static void next_track_id_cfg_changed(const struct bt_gatt_attr *attr,
 	BT_DBG("value 0x%04x", value);
 }
 
-static ssize_t parent_group_id_read(struct bt_conn *conn,
+static ssize_t read_parent_group_id(struct bt_conn *conn,
 				    const struct bt_gatt_attr *attr, void *buf,
 				    uint16_t len, uint16_t offset)
 {
-	uint64_t group_id = media_proxy_sctrl_parent_group_id_get();
+	uint64_t group_id = media_proxy_sctrl_get_parent_group_id();
 
 	BT_DBG_OBJ_ID("Parent group read: ", group_id);
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, &group_id,
@@ -352,21 +352,21 @@ static void parent_group_id_cfg_changed(const struct bt_gatt_attr *attr,
 	BT_DBG("value 0x%04x", value);
 }
 
-static ssize_t current_group_id_read(struct bt_conn *conn,
-			     const struct bt_gatt_attr *attr, void *buf,
-			     uint16_t len, uint16_t offset)
+static ssize_t read_current_group_id(struct bt_conn *conn,
+				     const struct bt_gatt_attr *attr, void *buf,
+				     uint16_t len, uint16_t offset)
 {
-	uint64_t group_id = media_proxy_sctrl_current_group_id_get();
+	uint64_t group_id = media_proxy_sctrl_get_current_group_id();
 
 	BT_DBG_OBJ_ID("Current group read: ", group_id);
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, &group_id,
 				 BT_OTS_OBJ_ID_SIZE);
 }
 
-static ssize_t current_group_id_write(struct bt_conn *conn,
-			      const struct bt_gatt_attr *attr,
-			      const void *buf, uint16_t len, uint16_t offset,
-			      uint8_t flags)
+static ssize_t write_current_group_id(struct bt_conn *conn,
+				      const struct bt_gatt_attr *attr,
+				      const void *buf, uint16_t len, uint16_t offset,
+				      uint8_t flags)
 {
 	uint64_t id;
 
@@ -389,7 +389,7 @@ static ssize_t current_group_id_write(struct bt_conn *conn,
 		       offset, len, log_strdup(str));
 	}
 
-	media_proxy_sctrl_current_group_id_set(id);
+	media_proxy_sctrl_set_current_group_id(id);
 
 	return BT_OTS_OBJ_ID_SIZE;
 }
@@ -400,11 +400,11 @@ static void current_group_id_cfg_changed(const struct bt_gatt_attr *attr, uint16
 }
 #endif /* CONFIG_BT_OTS */
 
-static ssize_t playing_order_read(struct bt_conn *conn,
+static ssize_t read_playing_order(struct bt_conn *conn,
 				  const struct bt_gatt_attr *attr, void *buf,
 				  uint16_t len, uint16_t offset)
 {
-	uint8_t order = media_proxy_sctrl_playing_order_get();
+	uint8_t order = media_proxy_sctrl_get_playing_order();
 
 	BT_DBG("Playing order read: %d (0x%02x)", order, order);
 
@@ -412,7 +412,7 @@ static ssize_t playing_order_read(struct bt_conn *conn,
 				 sizeof(order));
 }
 
-static ssize_t playing_order_write(struct bt_conn *conn,
+static ssize_t write_playing_order(struct bt_conn *conn,
 				   const struct bt_gatt_attr *attr,
 				   const void *buf, uint16_t len, uint16_t offset,
 				   uint8_t flags)
@@ -430,7 +430,7 @@ static ssize_t playing_order_write(struct bt_conn *conn,
 
 	memcpy(&order, buf, len);
 
-	media_proxy_sctrl_playing_order_set(order);
+	media_proxy_sctrl_set_playing_order(order);
 
 	BT_DBG("Playing order write: %d", order);
 
@@ -443,11 +443,11 @@ static void playing_order_cfg_changed(const struct bt_gatt_attr *attr,
 	BT_DBG("value 0x%04x", value);
 }
 
-static ssize_t playing_orders_supported_read(struct bt_conn *conn,
+static ssize_t read_playing_orders_supported(struct bt_conn *conn,
 					     const struct bt_gatt_attr *attr,
 					     void *buf, uint16_t len, uint16_t offset)
 {
-	uint16_t orders = media_proxy_sctrl_playing_orders_supported_get();
+	uint16_t orders = media_proxy_sctrl_get_playing_orders_supported();
 
 	BT_DBG("Playing orders read: %d (0x%04x)", orders, orders);
 
@@ -455,11 +455,11 @@ static ssize_t playing_orders_supported_read(struct bt_conn *conn,
 				 sizeof(orders));
 }
 
-static ssize_t media_state_read(struct bt_conn *conn,
+static ssize_t read_media_state(struct bt_conn *conn,
 				const struct bt_gatt_attr *attr, void *buf,
 				uint16_t len, uint16_t offset)
 {
-	uint8_t state = media_proxy_sctrl_media_state_get();
+	uint8_t state = media_proxy_sctrl_get_media_state();
 
 	BT_DBG("Media state read: %d", state);
 
@@ -473,7 +473,7 @@ static void media_state_cfg_changed(const struct bt_gatt_attr *attr,
 	BT_DBG("value 0x%04x", value);
 }
 
-static ssize_t control_point_write(struct bt_conn *conn,
+static ssize_t write_control_point(struct bt_conn *conn,
 				   const struct bt_gatt_attr *attr,
 				   const void *buf, uint16_t len, uint16_t offset,
 				   uint8_t flags)
@@ -501,22 +501,22 @@ static ssize_t control_point_write(struct bt_conn *conn,
 		BT_DBG("Parameter: %d", command.param);
 	}
 
-	media_proxy_sctrl_command_send(command);
+	media_proxy_sctrl_send_command(command);
 
 	return len;
 }
 
 static void control_point_cfg_changed(const struct bt_gatt_attr *attr,
-					 uint16_t value)
+				      uint16_t value)
 {
 	BT_DBG("value 0x%04x", value);
 }
 
-static ssize_t opcodes_supported_read(struct bt_conn *conn,
+static ssize_t read_opcodes_supported(struct bt_conn *conn,
 				      const struct bt_gatt_attr *attr,
 				      void *buf, uint16_t len, uint16_t offset)
 {
-	uint32_t opcodes = media_proxy_sctrl_commands_supported_get();
+	uint32_t opcodes = media_proxy_sctrl_get_commands_supported();
 
 	BT_DBG("Opcodes_supported read: %d (0x%08x)", opcodes, opcodes);
 
@@ -531,7 +531,7 @@ static void opcodes_supported_cfg_changed(const struct bt_gatt_attr *attr,
 }
 
 #ifdef CONFIG_BT_OTS
-static ssize_t search_control_point_write(struct bt_conn *conn,
+static ssize_t write_search_control_point(struct bt_conn *conn,
 					  const struct bt_gatt_attr *attr,
 					  const void *buf, uint16_t len,
 					  uint16_t offset, uint8_t flags)
@@ -551,7 +551,7 @@ static ssize_t search_control_point_write(struct bt_conn *conn,
 	BT_DBG("Search length: %d", len);
 	BT_HEXDUMP_DBG(&search.search, search.len, "Search content");
 
-	media_proxy_sctrl_search_send(search);
+	media_proxy_sctrl_send_search(search);
 
 	return len;
 }
@@ -562,11 +562,11 @@ static void search_control_point_cfg_changed(const struct bt_gatt_attr *attr,
 	BT_DBG("value 0x%04x", value);
 }
 
-static ssize_t search_results_id_read(struct bt_conn *conn,
+static ssize_t read_search_results_id(struct bt_conn *conn,
 				      const struct bt_gatt_attr *attr,
 				      void *buf, uint16_t len, uint16_t offset)
 {
-	uint64_t search_id = media_proxy_sctrl_search_results_id_get();
+	uint64_t search_id = media_proxy_sctrl_get_search_results_id();
 
 	BT_DBG_OBJ_ID("Search results id read: ", search_id);
 
@@ -595,11 +595,11 @@ static void search_results_id_cfg_changed(const struct bt_gatt_attr *attr,
 }
 #endif /* CONFIG_BT_OTS */
 
-static ssize_t content_ctrl_id_read(struct bt_conn *conn,
+static ssize_t read_content_ctrl_id(struct bt_conn *conn,
 				    const struct bt_gatt_attr *attr, void *buf,
 				    uint16_t len, uint16_t offset)
 {
-	uint8_t id = media_proxy_sctrl_content_ctrl_id_get();
+	uint8_t id = media_proxy_sctrl_get_content_ctrl_id();
 
 	BT_DBG("Content control ID read: %d", id);
 
@@ -612,18 +612,18 @@ static ssize_t content_ctrl_id_read(struct bt_conn *conn,
 #define ICON_OBJ_ID_CHARACTERISTIC_IF_OTS  \
 	BT_GATT_CHARACTERISTIC(BT_UUID_MCS_ICON_OBJ_ID,	\
 	BT_GATT_CHRC_READ, BT_GATT_PERM_READ_ENCRYPT, \
-	icon_id_read, NULL, NULL),
+	read_icon_id, NULL, NULL),
 #define SEGMENTS_TRACK_GROUP_ID_CHARACTERISTICS_IF_OTS  \
 	BT_GATT_CHARACTERISTIC(BT_UUID_MCS_TRACK_SEGMENTS_OBJ_ID,	\
 			       BT_GATT_CHRC_READ, BT_GATT_PERM_READ_ENCRYPT, \
-			       track_segments_id_read, NULL, NULL), \
+			       read_track_segments_id, NULL, NULL), \
 	BT_GATT_CHARACTERISTIC(BT_UUID_MCS_CURRENT_TRACK_OBJ_ID, \
 			       BT_GATT_CHRC_READ | BT_GATT_CHRC_WRITE | \
 			       BT_GATT_CHRC_WRITE_WITHOUT_RESP | \
 			       BT_GATT_CHRC_NOTIFY, \
 			       BT_GATT_PERM_READ_ENCRYPT | \
 			       BT_GATT_PERM_WRITE_ENCRYPT, \
-			       current_track_id_read, current_track_id_write, \
+			       read_current_track_id, write_current_track_id, \
 			       NULL), \
 	BT_GATT_CCC(current_track_id_cfg_changed, \
 		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE_ENCRYPT), \
@@ -633,13 +633,13 @@ static ssize_t content_ctrl_id_read(struct bt_conn *conn,
 			       BT_GATT_CHRC_NOTIFY, \
 			       BT_GATT_PERM_READ_ENCRYPT | \
 			       BT_GATT_PERM_WRITE_ENCRYPT, \
-			       next_track_id_read, next_track_id_write, NULL), \
+			       read_next_track_id, write_next_track_id, NULL), \
 	BT_GATT_CCC(next_track_id_cfg_changed, \
 		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE_ENCRYPT), \
 	BT_GATT_CHARACTERISTIC(BT_UUID_MCS_PARENT_GROUP_OBJ_ID, \
 			       BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY, \
 			       BT_GATT_PERM_READ_ENCRYPT, \
-			       parent_group_id_read, NULL, NULL), \
+			       read_parent_group_id, NULL, NULL), \
 	BT_GATT_CCC(parent_group_id_cfg_changed, \
 		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE_ENCRYPT), \
 	BT_GATT_CHARACTERISTIC(BT_UUID_MCS_CURRENT_GROUP_OBJ_ID, \
@@ -648,7 +648,7 @@ static ssize_t content_ctrl_id_read(struct bt_conn *conn,
 			       BT_GATT_CHRC_NOTIFY, \
 			       BT_GATT_PERM_READ_ENCRYPT | \
 			       BT_GATT_PERM_WRITE_ENCRYPT, \
-			       current_group_id_read, current_group_id_write, NULL), \
+			       read_current_group_id, write_current_group_id, NULL), \
 	BT_GATT_CCC(current_group_id_cfg_changed, \
 		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE_ENCRYPT),
 #define	SEARCH_CHARACTERISTICS_IF_OTS \
@@ -657,13 +657,13 @@ static ssize_t content_ctrl_id_read(struct bt_conn *conn,
 			       BT_GATT_CHRC_WRITE_WITHOUT_RESP | \
 			       BT_GATT_CHRC_NOTIFY, \
 			       BT_GATT_PERM_WRITE_ENCRYPT, \
-			       NULL, search_control_point_write, NULL), \
+			       NULL, write_search_control_point, NULL), \
 	BT_GATT_CCC(search_control_point_cfg_changed, \
 		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE_ENCRYPT), \
 	BT_GATT_CHARACTERISTIC(BT_UUID_MCS_SEARCH_RESULTS_OBJ_ID, \
 			       BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY, \
 			       BT_GATT_PERM_READ_ENCRYPT, \
-			       search_results_id_read, NULL, NULL), \
+			       read_search_results_id, NULL, NULL), \
 	BT_GATT_CCC(search_results_id_cfg_changed, \
 		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE_ENCRYPT),
 
@@ -680,13 +680,13 @@ static ssize_t content_ctrl_id_read(struct bt_conn *conn,
 	BT_GATT_CHARACTERISTIC(BT_UUID_MCS_PLAYER_NAME, \
 			       BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY, \
 			       BT_GATT_PERM_READ_ENCRYPT, \
-			       player_name_read, NULL, NULL), \
+			       read_player_name, NULL, NULL), \
 	BT_GATT_CCC(player_name_cfg_changed, \
 		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE_ENCRYPT), \
 	ICON_OBJ_ID_CHARACTERISTIC_IF_OTS \
 	BT_GATT_CHARACTERISTIC(BT_UUID_MCS_ICON_URL, \
 			       BT_GATT_CHRC_READ, BT_GATT_PERM_READ_ENCRYPT, \
-			       icon_url_read, NULL, NULL), \
+			       read_icon_url, NULL, NULL), \
 	BT_GATT_CHARACTERISTIC(BT_UUID_MCS_TRACK_CHANGED, \
 			       BT_GATT_CHRC_NOTIFY, BT_GATT_PERM_NONE, \
 			       NULL, NULL, NULL), \
@@ -695,13 +695,13 @@ static ssize_t content_ctrl_id_read(struct bt_conn *conn,
 	BT_GATT_CHARACTERISTIC(BT_UUID_MCS_TRACK_TITLE, \
 			       BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY, \
 			       BT_GATT_PERM_READ_ENCRYPT, \
-			       track_title_read, NULL, NULL), \
+			       read_track_title, NULL, NULL), \
 	BT_GATT_CCC(track_title_cfg_changed, \
 		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE_ENCRYPT), \
 	BT_GATT_CHARACTERISTIC(BT_UUID_MCS_TRACK_DURATION, \
 			       BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY, \
 			       BT_GATT_PERM_READ_ENCRYPT, \
-			       track_duration_read, NULL, NULL), \
+			       read_track_duration, NULL, NULL), \
 	BT_GATT_CCC(track_duration_cfg_changed, \
 		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE_ENCRYPT), \
 	BT_GATT_CHARACTERISTIC(BT_UUID_MCS_TRACK_POSITION, \
@@ -710,8 +710,8 @@ static ssize_t content_ctrl_id_read(struct bt_conn *conn,
 			       BT_GATT_CHRC_NOTIFY, \
 			       BT_GATT_PERM_READ_ENCRYPT | \
 			       BT_GATT_PERM_WRITE_ENCRYPT, \
-			       track_position_read, \
-			       track_position_write, NULL), \
+			       read_track_position, \
+			       write_track_position, NULL), \
 	BT_GATT_CCC(track_position_cfg_changed, \
 		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE_ENCRYPT), \
 	BT_GATT_CHARACTERISTIC(BT_UUID_MCS_PLAYBACK_SPEED, \
@@ -720,14 +720,14 @@ static ssize_t content_ctrl_id_read(struct bt_conn *conn,
 			       BT_GATT_CHRC_NOTIFY, \
 			       BT_GATT_PERM_READ_ENCRYPT | \
 			       BT_GATT_PERM_WRITE_ENCRYPT, \
-			       playback_speed_read, playback_speed_write, \
+			       read_playback_speed, write_playback_speed, \
 			       NULL), \
 	BT_GATT_CCC(playback_speed_cfg_changed, \
 		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE_ENCRYPT), \
 	BT_GATT_CHARACTERISTIC(BT_UUID_MCS_SEEKING_SPEED, \
 			       BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY, \
 			       BT_GATT_PERM_READ_ENCRYPT, \
-			       seeking_speed_read, NULL, NULL), \
+			       read_seeking_speed, NULL, NULL), \
 	BT_GATT_CCC(seeking_speed_cfg_changed, \
 		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE_ENCRYPT), \
 	SEGMENTS_TRACK_GROUP_ID_CHARACTERISTICS_IF_OTS \
@@ -737,16 +737,16 @@ static ssize_t content_ctrl_id_read(struct bt_conn *conn,
 			       BT_GATT_CHRC_NOTIFY, \
 			       BT_GATT_PERM_READ_ENCRYPT | \
 			       BT_GATT_PERM_WRITE_ENCRYPT, \
-			       playing_order_read, playing_order_write, NULL), \
+			       read_playing_order, write_playing_order, NULL), \
 	BT_GATT_CCC(playing_order_cfg_changed, \
 		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE_ENCRYPT), \
 	BT_GATT_CHARACTERISTIC(BT_UUID_MCS_PLAYING_ORDERS, \
 			       BT_GATT_CHRC_READ, BT_GATT_PERM_READ_ENCRYPT, \
-			       playing_orders_supported_read, NULL, NULL), \
+			       read_playing_orders_supported, NULL, NULL), \
 	BT_GATT_CHARACTERISTIC(BT_UUID_MCS_MEDIA_STATE, \
 			       BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY, \
 			       BT_GATT_PERM_READ_ENCRYPT, \
-			       media_state_read, NULL, NULL), \
+			       read_media_state, NULL, NULL), \
 	BT_GATT_CCC(media_state_cfg_changed, \
 		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE_ENCRYPT), \
 	BT_GATT_CHARACTERISTIC(BT_UUID_MCS_MEDIA_CONTROL_POINT, \
@@ -754,20 +754,20 @@ static ssize_t content_ctrl_id_read(struct bt_conn *conn,
 			       BT_GATT_CHRC_WRITE_WITHOUT_RESP | \
 			       BT_GATT_CHRC_NOTIFY, \
 			       BT_GATT_PERM_WRITE_ENCRYPT, \
-			       NULL, control_point_write, NULL), \
+			       NULL, write_control_point, NULL), \
 	BT_GATT_CCC(control_point_cfg_changed, \
 		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE_ENCRYPT), \
 	BT_GATT_CHARACTERISTIC(BT_UUID_MCS_MEDIA_CONTROL_OPCODES, \
 			       BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY, \
 			       BT_GATT_PERM_READ_ENCRYPT, \
-			       opcodes_supported_read, NULL, NULL), \
+			       read_opcodes_supported, NULL, NULL), \
 	BT_GATT_CCC(opcodes_supported_cfg_changed, \
 		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE_ENCRYPT), \
 	SEARCH_CHARACTERISTICS_IF_OTS \
 	BT_GATT_CHARACTERISTIC(BT_UUID_CCID, \
 			       BT_GATT_CHRC_READ, \
 			       BT_GATT_PERM_READ_ENCRYPT, \
-			       content_ctrl_id_read, NULL, NULL)
+			       read_content_ctrl_id, NULL, NULL)
 
 static struct bt_gatt_attr svc_attrs[] = { BT_MCS_SERVICE_DEFINITION };
 static struct bt_gatt_service mcs;

--- a/subsys/bluetooth/host/audio/media_proxy.c
+++ b/subsys/bluetooth/host/audio/media_proxy.c
@@ -68,147 +68,147 @@ int media_proxy_sctrl_register(struct media_proxy_sctrl_cbs *sctrl_cbs)
 	return 0;
 };
 
-const char *media_proxy_sctrl_player_name_get(void)
+const char *media_proxy_sctrl_get_player_name(void)
 {
 	/* TODO: Add check for whether function pointer is non-NULL everywhere */
-	return mprx.local_player.calls->player_name_get();
+	return mprx.local_player.calls->get_player_name();
 }
 
 #ifdef CONFIG_BT_OTS
-uint64_t media_proxy_sctrl_icon_id_get(void)
+uint64_t media_proxy_sctrl_get_icon_id(void)
 {
-	return mprx.local_player.calls->icon_id_get();
+	return mprx.local_player.calls->get_icon_id();
 }
 #endif /* CONFIG_BT_OTS */
 
-const char *media_proxy_sctrl_icon_url_get(void)
+const char *media_proxy_sctrl_get_icon_url(void)
 {
-	return mprx.local_player.calls->icon_url_get();
+	return mprx.local_player.calls->get_icon_url();
 }
 
-const char *media_proxy_sctrl_track_title_get(void)
+const char *media_proxy_sctrl_get_track_title(void)
 {
-	return mprx.local_player.calls->track_title_get();
+	return mprx.local_player.calls->get_track_title();
 }
 
-int32_t media_proxy_sctrl_track_duration_get(void)
+int32_t media_proxy_sctrl_get_track_duration(void)
 {
-	return mprx.local_player.calls->track_duration_get();
+	return mprx.local_player.calls->get_track_duration();
 }
 
-int32_t media_proxy_sctrl_track_position_get(void)
+int32_t media_proxy_sctrl_get_track_position(void)
 {
-	return mprx.local_player.calls->track_position_get();
+	return mprx.local_player.calls->get_track_position();
 }
 
-void media_proxy_sctrl_track_position_set(int32_t position)
+void media_proxy_sctrl_set_track_position(int32_t position)
 {
-	mprx.local_player.calls->track_position_set(position);
+	mprx.local_player.calls->set_track_position(position);
 }
 
-int8_t media_proxy_sctrl_playback_speed_get(void)
+int8_t media_proxy_sctrl_get_playback_speed(void)
 {
-	return mprx.local_player.calls->playback_speed_get();
+	return mprx.local_player.calls->get_playback_speed();
 }
 
-void media_proxy_sctrl_playback_speed_set(int8_t speed)
+void media_proxy_sctrl_set_playback_speed(int8_t speed)
 {
-	mprx.local_player.calls->playback_speed_set(speed);
+	mprx.local_player.calls->set_playback_speed(speed);
 }
 
-int8_t media_proxy_sctrl_seeking_speed_get(void)
+int8_t media_proxy_sctrl_get_seeking_speed(void)
 {
-	return mprx.local_player.calls->seeking_speed_get();
+	return mprx.local_player.calls->get_seeking_speed();
 }
 
 #ifdef CONFIG_BT_OTS
-uint64_t media_proxy_sctrl_track_segments_id_get(void)
+uint64_t media_proxy_sctrl_get_track_segments_id(void)
 {
-	return mprx.local_player.calls->track_segments_id_get();
+	return mprx.local_player.calls->get_track_segments_id();
 }
 
-uint64_t media_proxy_sctrl_current_track_id_get(void)
+uint64_t media_proxy_sctrl_get_current_track_id(void)
 {
-	return mprx.local_player.calls->current_track_id_get();
+	return mprx.local_player.calls->get_current_track_id();
 }
 
-void media_proxy_sctrl_current_track_id_set(uint64_t id)
+void media_proxy_sctrl_set_current_track_id(uint64_t id)
 {
-	mprx.local_player.calls->current_track_id_set(id);
+	mprx.local_player.calls->set_current_track_id(id);
 }
 
-uint64_t media_proxy_sctrl_next_track_id_get(void)
+uint64_t media_proxy_sctrl_get_next_track_id(void)
 {
-	return mprx.local_player.calls->next_track_id_get();
+	return mprx.local_player.calls->get_next_track_id();
 }
 
-void media_proxy_sctrl_next_track_id_set(uint64_t id)
+void media_proxy_sctrl_set_next_track_id(uint64_t id)
 {
-	mprx.local_player.calls->next_track_id_set(id);
+	mprx.local_player.calls->set_next_track_id(id);
 }
 
-uint64_t media_proxy_sctrl_parent_group_id_get(void)
+uint64_t media_proxy_sctrl_get_parent_group_id(void)
 {
-	return mprx.local_player.calls->parent_group_id_get();
+	return mprx.local_player.calls->get_parent_group_id();
 }
 
-uint64_t media_proxy_sctrl_current_group_id_get(void)
+uint64_t media_proxy_sctrl_get_current_group_id(void)
 {
-	return mprx.local_player.calls->current_group_id_get();
+	return mprx.local_player.calls->get_current_group_id();
 }
 
-void media_proxy_sctrl_current_group_id_set(uint64_t id)
+void media_proxy_sctrl_set_current_group_id(uint64_t id)
 {
-	mprx.local_player.calls->current_group_id_set(id);
+	mprx.local_player.calls->set_current_group_id(id);
 }
 #endif /* CONFIG_BT_OTS */
 
-uint8_t media_proxy_sctrl_playing_order_get(void)
+uint8_t media_proxy_sctrl_get_playing_order(void)
 {
-	return mprx.local_player.calls->playing_order_get();
+	return mprx.local_player.calls->get_playing_order();
 }
 
-void media_proxy_sctrl_playing_order_set(uint8_t order)
+void media_proxy_sctrl_set_playing_order(uint8_t order)
 {
-	mprx.local_player.calls->playing_order_set(order);
+	mprx.local_player.calls->set_playing_order(order);
 }
 
-uint16_t media_proxy_sctrl_playing_orders_supported_get(void)
+uint16_t media_proxy_sctrl_get_playing_orders_supported(void)
 {
-	return mprx.local_player.calls->playing_orders_supported_get();
+	return mprx.local_player.calls->get_playing_orders_supported();
 }
 
-uint8_t media_proxy_sctrl_media_state_get(void)
+uint8_t media_proxy_sctrl_get_media_state(void)
 {
-	return mprx.local_player.calls->media_state_get();
+	return mprx.local_player.calls->get_media_state();
 }
 
-void media_proxy_sctrl_command_send(struct mpl_cmd cmd)
+void media_proxy_sctrl_send_command(struct mpl_cmd cmd)
 {
-	mprx.local_player.calls->command_send(cmd);
+	mprx.local_player.calls->send_command(cmd);
 }
 
-uint32_t media_proxy_sctrl_commands_supported_get(void)
+uint32_t media_proxy_sctrl_get_commands_supported(void)
 {
-	return mprx.local_player.calls->commands_supported_get();
+	return mprx.local_player.calls->get_commands_supported();
 }
 
 #ifdef CONFIG_BT_OTS
-void media_proxy_sctrl_search_send(struct mpl_search search)
+void media_proxy_sctrl_send_search(struct mpl_search search)
 {
-	mprx.local_player.calls->search_send(search);
+	mprx.local_player.calls->send_search(search);
 }
 
-uint64_t media_proxy_sctrl_search_results_id_get(void)
+uint64_t media_proxy_sctrl_get_search_results_id(void)
 {
-	return mprx.local_player.calls->search_results_id_get();
+	return mprx.local_player.calls->get_search_results_id();
 }
 void media_proxy_sctrl_search_results_id_cb(uint64_t id);
 #endif /* CONFIG_BT_OTS */
 
-uint8_t media_proxy_sctrl_content_ctrl_id_get(void)
+uint8_t media_proxy_sctrl_get_content_ctrl_id(void)
 {
-	return mprx.local_player.calls->content_ctrl_id_get();
+	return mprx.local_player.calls->get_content_ctrl_id();
 }
 
 
@@ -230,7 +230,7 @@ static void mcc_discover_mcs_cb(struct bt_conn *conn, int err)
 	}
 }
 
-static void mcc_player_name_read_cb(struct bt_conn *conn, int err, const char *name)
+static void mcc_read_player_name_cb(struct bt_conn *conn, int err, const char *name)
 {
 	/* Debug statements for at least a couple of the callbacks, to show flow */
 	BT_DBG("MCC player name callback");
@@ -247,7 +247,7 @@ static void mcc_player_name_read_cb(struct bt_conn *conn, int err, const char *n
 }
 
 #ifdef CONFIG_BT_MCC_OTS
-static void mcc_icon_obj_id_read_cb(struct bt_conn *conn, int err, uint64_t id)
+static void mcc_read_icon_obj_id_cb(struct bt_conn *conn, int err, uint64_t id)
 {
 	BT_DBG("Icon Object ID callback");
 
@@ -263,7 +263,7 @@ static void mcc_icon_obj_id_read_cb(struct bt_conn *conn, int err, uint64_t id)
 }
 #endif /* CONFIG_BT_MCC_OTS */
 
-static void mcc_icon_url_read_cb(struct bt_conn *conn, int err, const char *url)
+static void mcc_read_icon_url_cb(struct bt_conn *conn, int err, const char *url)
 {
 	if (err) {
 		BT_ERR("Icon URL read failed (%d)", err);
@@ -290,7 +290,7 @@ static void mcc_track_changed_ntf_cb(struct bt_conn *conn, int err)
 	}
 }
 
-static void mcc_track_title_read_cb(struct bt_conn *conn, int err, const char *title)
+static void mcc_read_track_title_cb(struct bt_conn *conn, int err, const char *title)
 {
 	if (err) {
 		BT_ERR("Track title read failed (%d)", err);
@@ -303,7 +303,7 @@ static void mcc_track_title_read_cb(struct bt_conn *conn, int err, const char *t
 	}
 }
 
-static void mcc_track_duration_read_cb(struct bt_conn *conn, int err, int32_t dur)
+static void mcc_read_track_duration_cb(struct bt_conn *conn, int err, int32_t dur)
 {
 	if (err) {
 		BT_ERR("Track duration read failed (%d)", err);
@@ -316,7 +316,7 @@ static void mcc_track_duration_read_cb(struct bt_conn *conn, int err, int32_t du
 	}
 }
 
-static void mcc_track_position_read_cb(struct bt_conn *conn, int err, int32_t pos)
+static void mcc_read_track_position_cb(struct bt_conn *conn, int err, int32_t pos)
 {
 	if (err) {
 		BT_ERR("Track position read failed (%d)", err);
@@ -329,7 +329,7 @@ static void mcc_track_position_read_cb(struct bt_conn *conn, int err, int32_t po
 	}
 }
 
-static void mcc_track_position_set_cb(struct bt_conn *conn, int err, int32_t pos)
+static void mcc_set_track_position_cb(struct bt_conn *conn, int err, int32_t pos)
 {
 	if (err) {
 		BT_ERR("Track Position set failed (%d)", err);
@@ -342,7 +342,7 @@ static void mcc_track_position_set_cb(struct bt_conn *conn, int err, int32_t pos
 	}
 }
 
-static void mcc_playback_speed_read_cb(struct bt_conn *conn, int err, int8_t speed)
+static void mcc_read_playback_speed_cb(struct bt_conn *conn, int err, int8_t speed)
 {
 	if (err) {
 		BT_ERR("Playback speed read failed (%d)", err);
@@ -355,7 +355,7 @@ static void mcc_playback_speed_read_cb(struct bt_conn *conn, int err, int8_t spe
 	}
 }
 
-static void mcc_playback_speed_set_cb(struct bt_conn *conn, int err, int8_t speed)
+static void mcc_set_playback_speed_cb(struct bt_conn *conn, int err, int8_t speed)
 {
 	if (err) {
 		BT_ERR("Playback speed set failed (%d)", err);
@@ -368,7 +368,7 @@ static void mcc_playback_speed_set_cb(struct bt_conn *conn, int err, int8_t spee
 	}
 }
 
-static void mcc_seeking_speed_read_cb(struct bt_conn *conn, int err, int8_t speed)
+static void mcc_read_seeking_speed_cb(struct bt_conn *conn, int err, int8_t speed)
 {
 	if (err) {
 		BT_ERR("Seeking speed read failed (%d)", err);
@@ -382,7 +382,7 @@ static void mcc_seeking_speed_read_cb(struct bt_conn *conn, int err, int8_t spee
 }
 
 #ifdef CONFIG_BT_MCC_OTS
-static void mcc_segments_obj_id_read_cb(struct bt_conn *conn, int err, uint64_t id)
+static void mcc_read_segments_obj_id_cb(struct bt_conn *conn, int err, uint64_t id)
 {
 	if (err) {
 		BT_ERR("Track Segments Object ID read failed (%d)", err);
@@ -395,7 +395,7 @@ static void mcc_segments_obj_id_read_cb(struct bt_conn *conn, int err, uint64_t 
 	}
 }
 
-static void mcc_current_track_obj_id_read_cb(struct bt_conn *conn, int err, uint64_t id)
+static void mcc_read_current_track_obj_id_cb(struct bt_conn *conn, int err, uint64_t id)
 {
 	if (err) {
 		BT_ERR("Current Track Object ID read failed (%d)", err);
@@ -410,7 +410,7 @@ static void mcc_current_track_obj_id_read_cb(struct bt_conn *conn, int err, uint
 
 /* TODO: current track set callback - must be added to MCC first */
 
-static void mcc_next_track_obj_id_read_cb(struct bt_conn *conn, int err, uint64_t id)
+static void mcc_read_next_track_obj_id_cb(struct bt_conn *conn, int err, uint64_t id)
 {
 	if (err) {
 		BT_ERR("Next Track Object ID read failed (%d)", err);
@@ -425,7 +425,7 @@ static void mcc_next_track_obj_id_read_cb(struct bt_conn *conn, int err, uint64_
 
 /* TODO: next track set callback - must be added to MCC first */
 
-static void mcc_parent_group_obj_id_read_cb(struct bt_conn *conn, int err, uint64_t id)
+static void mcc_read_parent_group_obj_id_cb(struct bt_conn *conn, int err, uint64_t id)
 {
 	if (err) {
 		BT_ERR("Parent Group Object ID read failed (%d)", err);
@@ -438,7 +438,7 @@ static void mcc_parent_group_obj_id_read_cb(struct bt_conn *conn, int err, uint6
 	}
 }
 
-static void mcc_current_group_obj_id_read_cb(struct bt_conn *conn, int err, uint64_t id)
+static void mcc_read_current_group_obj_id_cb(struct bt_conn *conn, int err, uint64_t id)
 {
 	if (err) {
 		BT_ERR("Current Group Object ID read failed (%d)", err);
@@ -455,7 +455,7 @@ static void mcc_current_group_obj_id_read_cb(struct bt_conn *conn, int err, uint
 
 #endif /* CONFIG_BT_MCC_OTS */
 
-static void mcc_playing_order_read_cb(struct bt_conn *conn, int err, uint8_t order)
+static void mcc_read_playing_order_cb(struct bt_conn *conn, int err, uint8_t order)
 {
 	if (err) {
 		BT_ERR("Playing order read failed (%d)", err);
@@ -468,7 +468,7 @@ static void mcc_playing_order_read_cb(struct bt_conn *conn, int err, uint8_t ord
 	}
 }
 
-static void mcc_playing_order_set_cb(struct bt_conn *conn, int err, uint8_t order)
+static void mcc_set_playing_order_cb(struct bt_conn *conn, int err, uint8_t order)
 {
 	if (err) {
 		BT_ERR("Playing order set failed (%d)", err);
@@ -481,7 +481,7 @@ static void mcc_playing_order_set_cb(struct bt_conn *conn, int err, uint8_t orde
 	}
 }
 
-static void mcc_playing_orders_supported_read_cb(struct bt_conn *conn, int err, uint16_t orders)
+static void mcc_read_playing_orders_supported_cb(struct bt_conn *conn, int err, uint16_t orders)
 {
 	if (err) {
 		BT_ERR("Playing orders supported read failed (%d)", err);
@@ -494,7 +494,7 @@ static void mcc_playing_orders_supported_read_cb(struct bt_conn *conn, int err, 
 	}
 }
 
-static void mcc_media_state_read_cb(struct bt_conn *conn, int err, uint8_t state)
+static void mcc_read_media_state_cb(struct bt_conn *conn, int err, uint8_t state)
 {
 	if (err) {
 		BT_ERR("Media State read failed (%d)", err);
@@ -507,7 +507,7 @@ static void mcc_media_state_read_cb(struct bt_conn *conn, int err, uint8_t state
 	}
 }
 
-static void mcc_cmd_send_cb(struct bt_conn *conn, int err, struct mpl_cmd cmd)
+static void mcc_send_cmd_cb(struct bt_conn *conn, int err, struct mpl_cmd cmd)
 {
 	if (err) {
 		BT_ERR("Command send failed (%d) - opcode: %d, param: %d",
@@ -536,7 +536,7 @@ static void mcc_cmd_ntf_cb(struct bt_conn *conn, int err,
 	}
 }
 
-static void mcc_opcodes_supported_read_cb(struct bt_conn *conn, int err, uint32_t opcodes)
+static void mcc_read_opcodes_supported_cb(struct bt_conn *conn, int err, uint32_t opcodes)
 {
 	if (err) {
 		BT_ERR("Opcodes supported read failed (%d)", err);
@@ -550,7 +550,7 @@ static void mcc_opcodes_supported_read_cb(struct bt_conn *conn, int err, uint32_
 }
 
 #ifdef CONFIG_BT_MCC_OTS
-static void mcc_search_send_cb(struct bt_conn *conn, int err, struct mpl_search search)
+static void mcc_send_search_cb(struct bt_conn *conn, int err, struct mpl_search search)
 {
 	if (err) {
 		BT_ERR("Search send failed (%d)", err);
@@ -577,7 +577,7 @@ static void mcc_search_ntf_cb(struct bt_conn *conn, int err, uint8_t result_code
 	}
 }
 
-static void mcc_search_results_obj_id_read_cb(struct bt_conn *conn, int err, uint64_t id)
+static void mcc_read_search_results_obj_id_cb(struct bt_conn *conn, int err, uint64_t id)
 {
 	if (err) {
 		BT_ERR("Search Results Object ID read failed (%d)", err);
@@ -591,7 +591,7 @@ static void mcc_search_results_obj_id_read_cb(struct bt_conn *conn, int err, uin
 }
 #endif /* CONFIG_BT_MCC_OTS */
 
-static void mcc_content_control_id_read_cb(struct bt_conn *conn, int err, uint8_t ccid)
+static void mcc_read_content_control_id_cb(struct bt_conn *conn, int err, uint8_t ccid)
 {
 	if (err) {
 		BT_ERR("Content Control ID read failed (%d)", err);
@@ -630,39 +630,39 @@ int media_proxy_ctrl_discover_player(struct bt_conn *conn)
 
 	/* Initialize MCC */
 	mcc_cbs.discover_mcs                  = mcc_discover_mcs_cb;
-	mcc_cbs.player_name_read              = mcc_player_name_read_cb;
+	mcc_cbs.read_player_name              = mcc_read_player_name_cb;
 #ifdef CONFIG_BT_MCC_OTS
-	mcc_cbs.icon_obj_id_read              = mcc_icon_obj_id_read_cb;
+	mcc_cbs.read_icon_obj_id              = mcc_read_icon_obj_id_cb;
 #endif /* CONFIG_BT_MCC_OTS */
-	mcc_cbs.icon_url_read                 = mcc_icon_url_read_cb;
+	mcc_cbs.read_icon_url                 = mcc_read_icon_url_cb;
 	mcc_cbs.track_changed_ntf             = mcc_track_changed_ntf_cb;
-	mcc_cbs.track_title_read              = mcc_track_title_read_cb;
-	mcc_cbs.track_duration_read           = mcc_track_duration_read_cb;
-	mcc_cbs.track_position_read           = mcc_track_position_read_cb;
-	mcc_cbs.track_position_set            = mcc_track_position_set_cb;
-	mcc_cbs.playback_speed_read           = mcc_playback_speed_read_cb;
-	mcc_cbs.playback_speed_set            = mcc_playback_speed_set_cb;
-	mcc_cbs.seeking_speed_read            = mcc_seeking_speed_read_cb;
+	mcc_cbs.read_track_title              = mcc_read_track_title_cb;
+	mcc_cbs.read_track_duration           = mcc_read_track_duration_cb;
+	mcc_cbs.read_track_position           = mcc_read_track_position_cb;
+	mcc_cbs.set_track_position            = mcc_set_track_position_cb;
+	mcc_cbs.read_playback_speed           = mcc_read_playback_speed_cb;
+	mcc_cbs.set_playback_speed            = mcc_set_playback_speed_cb;
+	mcc_cbs.read_seeking_speed            = mcc_read_seeking_speed_cb;
 #ifdef CONFIG_BT_MCC_OTS
-	mcc_cbs.segments_obj_id_read          = mcc_segments_obj_id_read_cb;
-	mcc_cbs.current_track_obj_id_read     = mcc_current_track_obj_id_read_cb;
-	mcc_cbs.next_track_obj_id_read        = mcc_next_track_obj_id_read_cb;
-	mcc_cbs.parent_group_obj_id_read      = mcc_parent_group_obj_id_read_cb;
-	mcc_cbs.current_group_obj_id_read     = mcc_current_group_obj_id_read_cb;
+	mcc_cbs.read_segments_obj_id          = mcc_read_segments_obj_id_cb;
+	mcc_cbs.read_current_track_obj_id     = mcc_read_current_track_obj_id_cb;
+	mcc_cbs.read_next_track_obj_id        = mcc_read_next_track_obj_id_cb;
+	mcc_cbs.read_parent_group_obj_id      = mcc_read_parent_group_obj_id_cb;
+	mcc_cbs.read_current_group_obj_id     = mcc_read_current_group_obj_id_cb;
 #endif /* CONFIG_BT_MCC_OTS */
-	mcc_cbs.playing_order_read	      = mcc_playing_order_read_cb;
-	mcc_cbs.playing_order_set             = mcc_playing_order_set_cb;
-	mcc_cbs.playing_orders_supported_read = mcc_playing_orders_supported_read_cb;
-	mcc_cbs.media_state_read              = mcc_media_state_read_cb;
-	mcc_cbs.cmd_send                      = mcc_cmd_send_cb;
+	mcc_cbs.read_playing_order	      = mcc_read_playing_order_cb;
+	mcc_cbs.set_playing_order             = mcc_set_playing_order_cb;
+	mcc_cbs.read_playing_orders_supported = mcc_read_playing_orders_supported_cb;
+	mcc_cbs.read_media_state              = mcc_read_media_state_cb;
+	mcc_cbs.send_cmd                      = mcc_send_cmd_cb;
 	mcc_cbs.cmd_ntf                       = mcc_cmd_ntf_cb;
-	mcc_cbs.opcodes_supported_read        = mcc_opcodes_supported_read_cb;
+	mcc_cbs.read_opcodes_supported        = mcc_read_opcodes_supported_cb;
 #ifdef CONFIG_BT_MCC_OTS
-	mcc_cbs.search_send                   = mcc_search_send_cb;
+	mcc_cbs.send_search                   = mcc_send_search_cb;
 	mcc_cbs.search_ntf                    = mcc_search_ntf_cb;
-	mcc_cbs.search_results_obj_id_read    = mcc_search_results_obj_id_read_cb;
+	mcc_cbs.read_search_results_obj_id    = mcc_read_search_results_obj_id_cb;
 #endif /* CONFIG_BT_MCC_OTS */
-	mcc_cbs.content_control_id_read       = mcc_content_control_id_read_cb;
+	mcc_cbs.read_content_control_id       = mcc_read_content_control_id_cb;
 
 	err = bt_mcc_init(&mcc_cbs);
 	if (err) {
@@ -684,7 +684,7 @@ int media_proxy_ctrl_discover_player(struct bt_conn *conn)
 }
 #endif /* CONFIG_BT_MCC	*/
 
-int media_proxy_ctrl_player_name_get(struct media_player *player)
+int media_proxy_ctrl_get_player_name(struct media_player *player)
 {
 	CHECKIF(player == NULL) {
 		BT_DBG("player is NULL");
@@ -693,8 +693,8 @@ int media_proxy_ctrl_player_name_get(struct media_player *player)
 
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		BT_DBG("Local player");
-		if (mprx.local_player.calls->player_name_get) {
-			const char *name = mprx.local_player.calls->player_name_get();
+		if (mprx.local_player.calls->get_player_name) {
+			const char *name = mprx.local_player.calls->get_player_name();
 
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->player_name_recv) {
 				mprx.ctrlr.cbs->player_name_recv(&mprx.local_player, 0, name);
@@ -718,7 +718,7 @@ int media_proxy_ctrl_player_name_get(struct media_player *player)
 	return -EOPNOTSUPP;
 }
 
-int media_proxy_ctrl_icon_id_get(struct media_player *player)
+int media_proxy_ctrl_get_icon_id(struct media_player *player)
 {
 	CHECKIF(player == NULL) {
 		BT_DBG("player is NULL");
@@ -726,8 +726,8 @@ int media_proxy_ctrl_icon_id_get(struct media_player *player)
 	}
 
 	if (mprx.local_player.registered && player == &mprx.local_player) {
-		if (mprx.local_player.calls->icon_id_get) {
-			uint64_t id = mprx.local_player.calls->icon_id_get();
+		if (mprx.local_player.calls->get_icon_id) {
+			uint64_t id = mprx.local_player.calls->get_icon_id();
 
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->icon_id_recv) {
 				mprx.ctrlr.cbs->icon_id_recv(&mprx.local_player, 0, id);
@@ -750,7 +750,7 @@ int media_proxy_ctrl_icon_id_get(struct media_player *player)
 	return -EOPNOTSUPP;
 }
 
-int media_proxy_ctrl_icon_url_get(struct media_player *player)
+int media_proxy_ctrl_get_icon_url(struct media_player *player)
 {
 	CHECKIF(player == NULL) {
 		BT_DBG("player is NULL");
@@ -758,8 +758,8 @@ int media_proxy_ctrl_icon_url_get(struct media_player *player)
 	}
 
 	if (mprx.local_player.registered && player == &mprx.local_player) {
-		if (mprx.local_player.calls->icon_url_get) {
-			const char *url = mprx.local_player.calls->icon_url_get();
+		if (mprx.local_player.calls->get_icon_url) {
+			const char *url = mprx.local_player.calls->get_icon_url();
 
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->icon_url_recv) {
 				mprx.ctrlr.cbs->icon_url_recv(player, 0, url);
@@ -782,7 +782,7 @@ int media_proxy_ctrl_icon_url_get(struct media_player *player)
 	return -EOPNOTSUPP;
 }
 
-int media_proxy_ctrl_track_title_get(struct media_player *player)
+int media_proxy_ctrl_get_track_title(struct media_player *player)
 {
 	CHECKIF(player == NULL) {
 		BT_DBG("player is NULL");
@@ -790,8 +790,8 @@ int media_proxy_ctrl_track_title_get(struct media_player *player)
 	}
 
 	if (mprx.local_player.registered && player == &mprx.local_player) {
-		if (mprx.local_player.calls->track_title_get) {
-			const char *title = mprx.local_player.calls->track_title_get();
+		if (mprx.local_player.calls->get_track_title) {
+			const char *title = mprx.local_player.calls->get_track_title();
 
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_title_recv) {
 				mprx.ctrlr.cbs->track_title_recv(player, 0, title);
@@ -814,7 +814,7 @@ int media_proxy_ctrl_track_title_get(struct media_player *player)
 	return -EOPNOTSUPP;
 }
 
-int media_proxy_ctrl_track_duration_get(struct media_player *player)
+int media_proxy_ctrl_get_track_duration(struct media_player *player)
 {
 	CHECKIF(player == NULL) {
 		BT_DBG("player is NULL");
@@ -822,8 +822,8 @@ int media_proxy_ctrl_track_duration_get(struct media_player *player)
 	}
 
 	if (mprx.local_player.registered && player == &mprx.local_player) {
-		if (mprx.local_player.calls->track_duration_get) {
-			int32_t duration = mprx.local_player.calls->track_duration_get();
+		if (mprx.local_player.calls->get_track_duration) {
+			int32_t duration = mprx.local_player.calls->get_track_duration();
 
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_duration_recv) {
 				mprx.ctrlr.cbs->track_duration_recv(player, 0, duration);
@@ -845,7 +845,7 @@ int media_proxy_ctrl_track_duration_get(struct media_player *player)
 	return -EOPNOTSUPP;
 }
 
-int media_proxy_ctrl_track_position_get(struct media_player *player)
+int media_proxy_ctrl_get_track_position(struct media_player *player)
 {
 	CHECKIF(player == NULL) {
 		BT_DBG("player is NULL");
@@ -853,8 +853,8 @@ int media_proxy_ctrl_track_position_get(struct media_player *player)
 	}
 
 	if (mprx.local_player.registered && player == &mprx.local_player) {
-		if (mprx.local_player.calls->track_position_get) {
-			int32_t position = mprx.local_player.calls->track_position_get();
+		if (mprx.local_player.calls->get_track_position) {
+			int32_t position = mprx.local_player.calls->get_track_position();
 
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_position_recv) {
 				mprx.ctrlr.cbs->track_position_recv(player, 0, position);
@@ -877,7 +877,7 @@ int media_proxy_ctrl_track_position_get(struct media_player *player)
 	return -EOPNOTSUPP;
 }
 
-int media_proxy_ctrl_track_position_set(struct media_player *player, int32_t position)
+int media_proxy_ctrl_set_track_position(struct media_player *player, int32_t position)
 {
 	CHECKIF(player == NULL) {
 		BT_DBG("player is NULL");
@@ -885,8 +885,8 @@ int media_proxy_ctrl_track_position_set(struct media_player *player, int32_t pos
 	}
 
 	if (mprx.local_player.registered && player == &mprx.local_player) {
-		if (mprx.local_player.calls->track_position_set) {
-			mprx.local_player.calls->track_position_set(position);
+		if (mprx.local_player.calls->set_track_position) {
+			mprx.local_player.calls->set_track_position(position);
 
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_position_write) {
 				mprx.ctrlr.cbs->track_position_write(player, 0, position);
@@ -909,7 +909,7 @@ int media_proxy_ctrl_track_position_set(struct media_player *player, int32_t pos
 	return -EOPNOTSUPP;
 }
 
-int media_proxy_ctrl_playback_speed_get(struct media_player *player)
+int media_proxy_ctrl_get_playback_speed(struct media_player *player)
 {
 	CHECKIF(player == NULL) {
 		BT_DBG("player is NULL");
@@ -917,8 +917,8 @@ int media_proxy_ctrl_playback_speed_get(struct media_player *player)
 	}
 
 	if (mprx.local_player.registered && player == &mprx.local_player) {
-		if (mprx.local_player.calls->playback_speed_get) {
-			int8_t speed = mprx.local_player.calls->playback_speed_get();
+		if (mprx.local_player.calls->get_playback_speed) {
+			int8_t speed = mprx.local_player.calls->get_playback_speed();
 
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->playback_speed_recv) {
 				mprx.ctrlr.cbs->playback_speed_recv(player, 0, speed);
@@ -941,7 +941,7 @@ int media_proxy_ctrl_playback_speed_get(struct media_player *player)
 	return -EOPNOTSUPP;
 }
 
-int media_proxy_ctrl_playback_speed_set(struct media_player *player, int8_t speed)
+int media_proxy_ctrl_set_playback_speed(struct media_player *player, int8_t speed)
 {
 	CHECKIF(player == NULL) {
 		BT_DBG("player is NULL");
@@ -949,8 +949,8 @@ int media_proxy_ctrl_playback_speed_set(struct media_player *player, int8_t spee
 	}
 
 	if (mprx.local_player.registered && player == &mprx.local_player) {
-		if (mprx.local_player.calls->playback_speed_set) {
-			mprx.local_player.calls->playback_speed_set(speed);
+		if (mprx.local_player.calls->set_playback_speed) {
+			mprx.local_player.calls->set_playback_speed(speed);
 
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->playback_speed_write) {
 				mprx.ctrlr.cbs->playback_speed_write(player, 0, speed);
@@ -973,7 +973,7 @@ int media_proxy_ctrl_playback_speed_set(struct media_player *player, int8_t spee
 	return -EOPNOTSUPP;
 }
 
-int media_proxy_ctrl_seeking_speed_get(struct media_player *player)
+int media_proxy_ctrl_get_seeking_speed(struct media_player *player)
 {
 	CHECKIF(player == NULL) {
 		BT_DBG("player is NULL");
@@ -981,8 +981,8 @@ int media_proxy_ctrl_seeking_speed_get(struct media_player *player)
 	}
 
 	if (mprx.local_player.registered && player == &mprx.local_player) {
-		if (mprx.local_player.calls->seeking_speed_get) {
-			int8_t speed = mprx.local_player.calls->seeking_speed_get();
+		if (mprx.local_player.calls->get_seeking_speed) {
+			int8_t speed = mprx.local_player.calls->get_seeking_speed();
 
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->seeking_speed_recv) {
 				mprx.ctrlr.cbs->seeking_speed_recv(player, 0, speed);
@@ -1005,7 +1005,7 @@ int media_proxy_ctrl_seeking_speed_get(struct media_player *player)
 	return -EOPNOTSUPP;
 }
 
-int media_proxy_ctrl_track_segments_id_get(struct media_player *player)
+int media_proxy_ctrl_get_track_segments_id(struct media_player *player)
 {
 	CHECKIF(player == NULL) {
 		BT_DBG("player is NULL");
@@ -1013,8 +1013,8 @@ int media_proxy_ctrl_track_segments_id_get(struct media_player *player)
 	}
 
 	if (mprx.local_player.registered && player == &mprx.local_player) {
-		if (mprx.local_player.calls->track_segments_id_get) {
-			uint64_t id = mprx.local_player.calls->track_segments_id_get();
+		if (mprx.local_player.calls->get_track_segments_id) {
+			uint64_t id = mprx.local_player.calls->get_track_segments_id();
 
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_segments_id_recv) {
 				mprx.ctrlr.cbs->track_segments_id_recv(player, 0, id);
@@ -1037,7 +1037,7 @@ int media_proxy_ctrl_track_segments_id_get(struct media_player *player)
 	return -EOPNOTSUPP;
 }
 
-int media_proxy_ctrl_current_track_id_get(struct media_player *player)
+int media_proxy_ctrl_get_current_track_id(struct media_player *player)
 {
 	CHECKIF(player == NULL) {
 		BT_DBG("player is NULL");
@@ -1045,8 +1045,8 @@ int media_proxy_ctrl_current_track_id_get(struct media_player *player)
 	}
 
 	if (mprx.local_player.registered && player == &mprx.local_player) {
-		if (mprx.local_player.calls->current_track_id_get) {
-			uint64_t id = mprx.local_player.calls->current_track_id_get();
+		if (mprx.local_player.calls->get_current_track_id) {
+			uint64_t id = mprx.local_player.calls->get_current_track_id();
 
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->current_track_id_recv) {
 				mprx.ctrlr.cbs->current_track_id_recv(player, 0, id);
@@ -1069,7 +1069,7 @@ int media_proxy_ctrl_current_track_id_get(struct media_player *player)
 	return -EOPNOTSUPP;
 }
 
-int media_proxy_ctrl_current_track_id_set(struct media_player *player, uint64_t id)
+int media_proxy_ctrl_set_current_track_id(struct media_player *player, uint64_t id)
 {
 	CHECKIF(player == NULL) {
 		BT_DBG("player is NULL");
@@ -1077,8 +1077,8 @@ int media_proxy_ctrl_current_track_id_set(struct media_player *player, uint64_t 
 	}
 
 	if (mprx.local_player.registered && player == &mprx.local_player) {
-		if (mprx.local_player.calls->current_track_id_set) {
-			mprx.local_player.calls->current_track_id_set(id);
+		if (mprx.local_player.calls->set_current_track_id) {
+			mprx.local_player.calls->set_current_track_id(id);
 
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->current_track_id_write) {
 				mprx.ctrlr.cbs->current_track_id_write(player, 0, id);
@@ -1102,7 +1102,7 @@ int media_proxy_ctrl_current_track_id_set(struct media_player *player, uint64_t 
 	return -EOPNOTSUPP;
 }
 
-int media_proxy_ctrl_next_track_id_get(struct media_player *player)
+int media_proxy_ctrl_get_next_track_id(struct media_player *player)
 {
 	CHECKIF(player == NULL) {
 		BT_DBG("player is NULL");
@@ -1110,8 +1110,8 @@ int media_proxy_ctrl_next_track_id_get(struct media_player *player)
 	}
 
 	if (mprx.local_player.registered && player == &mprx.local_player) {
-		if (mprx.local_player.calls->next_track_id_get) {
-			uint64_t id = mprx.local_player.calls->next_track_id_get();
+		if (mprx.local_player.calls->get_next_track_id) {
+			uint64_t id = mprx.local_player.calls->get_next_track_id();
 
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->next_track_id_recv) {
 				mprx.ctrlr.cbs->next_track_id_recv(player, 0, id);
@@ -1134,7 +1134,7 @@ int media_proxy_ctrl_next_track_id_get(struct media_player *player)
 	return -EOPNOTSUPP;
 }
 
-int media_proxy_ctrl_next_track_id_set(struct media_player *player, uint64_t id)
+int media_proxy_ctrl_set_next_track_id(struct media_player *player, uint64_t id)
 {
 	CHECKIF(player == NULL) {
 		BT_DBG("player is NULL");
@@ -1142,8 +1142,8 @@ int media_proxy_ctrl_next_track_id_set(struct media_player *player, uint64_t id)
 	}
 
 	if (mprx.local_player.registered && player == &mprx.local_player) {
-		if (mprx.local_player.calls->next_track_id_set) {
-			mprx.local_player.calls->next_track_id_set(id);
+		if (mprx.local_player.calls->set_next_track_id) {
+			mprx.local_player.calls->set_next_track_id(id);
 
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->next_track_id_write) {
 				mprx.ctrlr.cbs->next_track_id_write(player, 0, id);
@@ -1167,7 +1167,7 @@ int media_proxy_ctrl_next_track_id_set(struct media_player *player, uint64_t id)
 	return -EOPNOTSUPP;
 }
 
-int media_proxy_ctrl_parent_group_id_get(struct media_player *player)
+int media_proxy_ctrl_get_parent_group_id(struct media_player *player)
 {
 	CHECKIF(player == NULL) {
 		BT_DBG("player is NULL");
@@ -1175,8 +1175,8 @@ int media_proxy_ctrl_parent_group_id_get(struct media_player *player)
 	}
 
 	if (mprx.local_player.registered && player == &mprx.local_player) {
-		if (mprx.local_player.calls->parent_group_id_get) {
-			uint64_t id = mprx.local_player.calls->parent_group_id_get();
+		if (mprx.local_player.calls->get_parent_group_id) {
+			uint64_t id = mprx.local_player.calls->get_parent_group_id();
 
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->parent_group_id_recv) {
 				mprx.ctrlr.cbs->parent_group_id_recv(player, 0, id);
@@ -1199,7 +1199,7 @@ int media_proxy_ctrl_parent_group_id_get(struct media_player *player)
 	return -EOPNOTSUPP;
 }
 
-int media_proxy_ctrl_current_group_id_get(struct media_player *player)
+int media_proxy_ctrl_get_current_group_id(struct media_player *player)
 {
 	CHECKIF(player == NULL) {
 		BT_DBG("player is NULL");
@@ -1207,8 +1207,8 @@ int media_proxy_ctrl_current_group_id_get(struct media_player *player)
 	}
 
 	if (mprx.local_player.registered && player == &mprx.local_player) {
-		if (mprx.local_player.calls->current_group_id_get) {
-			uint64_t id = mprx.local_player.calls->current_group_id_get();
+		if (mprx.local_player.calls->get_current_group_id) {
+			uint64_t id = mprx.local_player.calls->get_current_group_id();
 
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->current_group_id_recv) {
 				mprx.ctrlr.cbs->current_group_id_recv(player, 0, id);
@@ -1231,7 +1231,7 @@ int media_proxy_ctrl_current_group_id_get(struct media_player *player)
 	return -EOPNOTSUPP;
 }
 
-int media_proxy_ctrl_current_group_id_set(struct media_player *player, uint64_t id)
+int media_proxy_ctrl_set_current_group_id(struct media_player *player, uint64_t id)
 {
 	CHECKIF(player == NULL) {
 		BT_DBG("player is NULL");
@@ -1239,8 +1239,8 @@ int media_proxy_ctrl_current_group_id_set(struct media_player *player, uint64_t 
 	}
 
 	if (mprx.local_player.registered && player == &mprx.local_player) {
-		if (mprx.local_player.calls->current_group_id_set) {
-			mprx.local_player.calls->current_group_id_set(id);
+		if (mprx.local_player.calls->set_current_group_id) {
+			mprx.local_player.calls->set_current_group_id(id);
 
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->current_group_id_write) {
 				mprx.ctrlr.cbs->current_group_id_write(player, 0, id);
@@ -1264,7 +1264,7 @@ int media_proxy_ctrl_current_group_id_set(struct media_player *player, uint64_t 
 	return -EOPNOTSUPP;
 }
 
-int media_proxy_ctrl_playing_order_get(struct media_player *player)
+int media_proxy_ctrl_get_playing_order(struct media_player *player)
 {
 	CHECKIF(player == NULL) {
 		BT_DBG("player is NULL");
@@ -1272,8 +1272,8 @@ int media_proxy_ctrl_playing_order_get(struct media_player *player)
 	}
 
 	if (mprx.local_player.registered && player == &mprx.local_player) {
-		if (mprx.local_player.calls->playing_order_get) {
-			uint8_t order = mprx.local_player.calls->playing_order_get();
+		if (mprx.local_player.calls->get_playing_order) {
+			uint8_t order = mprx.local_player.calls->get_playing_order();
 
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->playing_order_recv) {
 				mprx.ctrlr.cbs->playing_order_recv(player, 0, order);
@@ -1297,7 +1297,7 @@ int media_proxy_ctrl_playing_order_get(struct media_player *player)
 	return -EOPNOTSUPP;
 }
 
-int media_proxy_ctrl_playing_order_set(struct media_player *player, uint8_t order)
+int media_proxy_ctrl_set_playing_order(struct media_player *player, uint8_t order)
 {
 	CHECKIF(player == NULL) {
 		BT_DBG("player is NULL");
@@ -1305,8 +1305,8 @@ int media_proxy_ctrl_playing_order_set(struct media_player *player, uint8_t orde
 	}
 
 	if (mprx.local_player.registered && player == &mprx.local_player) {
-		if (mprx.local_player.calls->playing_order_set) {
-			mprx.local_player.calls->playing_order_set(order);
+		if (mprx.local_player.calls->set_playing_order) {
+			mprx.local_player.calls->set_playing_order(order);
 
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->playing_order_write) {
 				mprx.ctrlr.cbs->playing_order_write(player, 0, order);
@@ -1329,7 +1329,7 @@ int media_proxy_ctrl_playing_order_set(struct media_player *player, uint8_t orde
 	return -EOPNOTSUPP;
 }
 
-int media_proxy_ctrl_playing_orders_supported_get(struct media_player *player)
+int media_proxy_ctrl_get_playing_orders_supported(struct media_player *player)
 {
 	CHECKIF(player == NULL) {
 		BT_DBG("player is NULL");
@@ -1337,8 +1337,8 @@ int media_proxy_ctrl_playing_orders_supported_get(struct media_player *player)
 	}
 
 	if (mprx.local_player.registered && player == &mprx.local_player) {
-		if (mprx.local_player.calls->playing_orders_supported_get) {
-			uint16_t orders = mprx.local_player.calls->playing_orders_supported_get();
+		if (mprx.local_player.calls->get_playing_orders_supported) {
+			uint16_t orders = mprx.local_player.calls->get_playing_orders_supported();
 
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->playing_orders_supported_recv) {
 				mprx.ctrlr.cbs->playing_orders_supported_recv(player, 0, orders);
@@ -1361,7 +1361,7 @@ int media_proxy_ctrl_playing_orders_supported_get(struct media_player *player)
 	return -EOPNOTSUPP;
 }
 
-int media_proxy_ctrl_media_state_get(struct media_player *player)
+int media_proxy_ctrl_get_media_state(struct media_player *player)
 {
 	CHECKIF(player == NULL) {
 		BT_DBG("player is NULL");
@@ -1369,8 +1369,8 @@ int media_proxy_ctrl_media_state_get(struct media_player *player)
 	}
 
 	if (mprx.local_player.registered && player == &mprx.local_player) {
-		if (mprx.local_player.calls->media_state_get) {
-			uint8_t state = mprx.local_player.calls->media_state_get();
+		if (mprx.local_player.calls->get_media_state) {
+			uint8_t state = mprx.local_player.calls->get_media_state();
 
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->media_state_recv) {
 				mprx.ctrlr.cbs->media_state_recv(player, 0, state);
@@ -1393,7 +1393,7 @@ int media_proxy_ctrl_media_state_get(struct media_player *player)
 	return -EOPNOTSUPP;
 }
 
-int media_proxy_ctrl_command_send(struct media_player *player, struct mpl_cmd cmd)
+int media_proxy_ctrl_send_command(struct media_player *player, struct mpl_cmd cmd)
 {
 	CHECKIF(player == NULL) {
 		BT_DBG("player is NULL");
@@ -1401,8 +1401,8 @@ int media_proxy_ctrl_command_send(struct media_player *player, struct mpl_cmd cm
 	}
 
 	if (mprx.local_player.registered && player == &mprx.local_player) {
-		if (mprx.local_player.calls->command_send) {
-			mprx.local_player.calls->command_send(cmd);
+		if (mprx.local_player.calls->send_command) {
+			mprx.local_player.calls->send_command(cmd);
 
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->command_send) {
 				mprx.ctrlr.cbs->command_send(player, 0, cmd);
@@ -1425,7 +1425,7 @@ int media_proxy_ctrl_command_send(struct media_player *player, struct mpl_cmd cm
 	return -EOPNOTSUPP;
 }
 
-int media_proxy_ctrl_commands_supported_get(struct media_player *player)
+int media_proxy_ctrl_get_commands_supported(struct media_player *player)
 {
 	CHECKIF(player == NULL) {
 		BT_DBG("player is NULL");
@@ -1433,8 +1433,8 @@ int media_proxy_ctrl_commands_supported_get(struct media_player *player)
 	}
 
 	if (mprx.local_player.registered && player == &mprx.local_player) {
-		if (mprx.local_player.calls->commands_supported_get) {
-			uint32_t opcodes = mprx.local_player.calls->commands_supported_get();
+		if (mprx.local_player.calls->get_commands_supported) {
+			uint32_t opcodes = mprx.local_player.calls->get_commands_supported();
 
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->commands_supported_recv) {
 				mprx.ctrlr.cbs->commands_supported_recv(player, 0, opcodes);
@@ -1457,7 +1457,7 @@ int media_proxy_ctrl_commands_supported_get(struct media_player *player)
 	return -EOPNOTSUPP;
 }
 
-int media_proxy_ctrl_search_send(struct media_player *player, struct mpl_search search)
+int media_proxy_ctrl_send_search(struct media_player *player, struct mpl_search search)
 {
 	CHECKIF(player == NULL) {
 		BT_DBG("player is NULL");
@@ -1465,8 +1465,8 @@ int media_proxy_ctrl_search_send(struct media_player *player, struct mpl_search 
 	}
 
 	if (mprx.local_player.registered && player == &mprx.local_player) {
-		if (mprx.local_player.calls->search_send) {
-			mprx.local_player.calls->search_send(search);
+		if (mprx.local_player.calls->send_search) {
+			mprx.local_player.calls->send_search(search);
 
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->search_send) {
 				mprx.ctrlr.cbs->search_send(player, 0, search);
@@ -1489,7 +1489,7 @@ int media_proxy_ctrl_search_send(struct media_player *player, struct mpl_search 
 	return -EOPNOTSUPP;
 }
 
-int media_proxy_ctrl_search_results_id_get(struct media_player *player)
+int media_proxy_ctrl_get_search_results_id(struct media_player *player)
 {
 	CHECKIF(player == NULL) {
 		BT_DBG("player is NULL");
@@ -1497,8 +1497,8 @@ int media_proxy_ctrl_search_results_id_get(struct media_player *player)
 	}
 
 	if (mprx.local_player.registered && player == &mprx.local_player) {
-		if (mprx.local_player.calls->search_results_id_get) {
-			uint64_t id = mprx.local_player.calls->search_results_id_get();
+		if (mprx.local_player.calls->get_search_results_id) {
+			uint64_t id = mprx.local_player.calls->get_search_results_id();
 
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->search_results_id_recv) {
 				mprx.ctrlr.cbs->search_results_id_recv(player, 0, id);
@@ -1521,7 +1521,7 @@ int media_proxy_ctrl_search_results_id_get(struct media_player *player)
 	return -EOPNOTSUPP;
 }
 
-uint8_t media_proxy_ctrl_content_ctrl_id_get(struct media_player *player)
+uint8_t media_proxy_ctrl_get_content_ctrl_id(struct media_player *player)
 {
 	CHECKIF(player == NULL) {
 		BT_DBG("player is NULL");
@@ -1529,8 +1529,8 @@ uint8_t media_proxy_ctrl_content_ctrl_id_get(struct media_player *player)
 	}
 
 	if (mprx.local_player.registered && player == &mprx.local_player) {
-		if (mprx.local_player.calls->content_ctrl_id_get) {
-			uint8_t ccid = mprx.local_player.calls->content_ctrl_id_get();
+		if (mprx.local_player.calls->get_content_ctrl_id) {
+			uint8_t ccid = mprx.local_player.calls->get_content_ctrl_id();
 
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->content_ctrl_id_recv) {
 				mprx.ctrlr.cbs->content_ctrl_id_recv(player, 0, ccid);

--- a/subsys/bluetooth/host/audio/media_proxy.h
+++ b/subsys/bluetooth/host/audio/media_proxy.h
@@ -287,7 +287,7 @@ struct media_proxy_ctrl_cbs {
 	 * @brief Media Player Icon Object ID receive callback
 	 *
 	 * Called when the Media Player Icon Object ID is read
-	 * See also media_proxy_ctrl_icon_id_get()
+	 * See also media_proxy_ctrl_get_icon_id()
 	 *
 	 * @param player   Media player instance pointer
 	 * @param err      Error value. 0 on success, GATT error on positive value
@@ -300,7 +300,7 @@ struct media_proxy_ctrl_cbs {
 	 * @brief Media Player Icon URL receive callback
 	 *
 	 * Called when the Media Player Icon URL is read
-	 * See also media_proxy_ctrl_icon_url_get()
+	 * See also media_proxy_ctrl_get_icon_url()
 	 *
 	 * @param player   Media player instance pointer
 	 * @param err      Error value. 0 on success, GATT error on positive value
@@ -324,7 +324,7 @@ struct media_proxy_ctrl_cbs {
 	 * @brief Track Title receive callback
 	 *
 	 * Called when the Track Title is read or changed
-	 * See also media_proxy_ctrl_track_title_get()
+	 * See also media_proxy_ctrl_get_track_title()
 	 *
 	 * @param player   Media player instance pointer
 	 * @param err      Error value. 0 on success, GATT error on positive value
@@ -337,7 +337,7 @@ struct media_proxy_ctrl_cbs {
 	 * @brief Track Duration receive callback
 	 *
 	 * Called when the Track Duration is read or changed
-	 * Seel also media_proxy_ctrl_track_duration_get()
+	 * Seel also media_proxy_ctrl_get_track_duration()
 	 *
 	 * @param player     Media player instance pointer
 	 * @param err        Error value. 0 on success, GATT error on positive value
@@ -350,8 +350,8 @@ struct media_proxy_ctrl_cbs {
 	 * @brief Track Position receive callback
 	 *
 	 * Called when the Track Position is read or changed
-	 * See also media_proxy_ctrl_track_position_get() and
-	 * media_proxy_ctrl_track_position_set()
+	 * See also media_proxy_ctrl_get_track_position() and
+	 * media_proxy_ctrl_set_track_position()
 	 *
 	 * @param player     Media player instance pointer
 	 * @param err        Error value. 0 on success, GATT error on positive value
@@ -364,7 +364,7 @@ struct media_proxy_ctrl_cbs {
 	 * @brief Track Position write callback
 	 *
 	 * Called when the Track Position is written
-	 * See also media_proxy_ctrl_track_position_set().
+	 * See also media_proxy_ctrl_set_track_position().
 	 *
 	 * @param player     Media player instance pointer
 	 * @param err        Error value. 0 on success, GATT error on positive value
@@ -377,8 +377,8 @@ struct media_proxy_ctrl_cbs {
 	 * @brief Playback Speed receive callback
 	 *
 	 * Called when the Playback Speed is read or changed
-	 * See also media_proxy_ctrl_playback_speed_get() and
-	 * media_proxy_ctrl_playback_speed_set()
+	 * See also media_proxy_ctrl_get_playback_speed() and
+	 * media_proxy_ctrl_set_playback_speed()
 	 *
 	 * @param player   Media player instance pointer
 	 * @param err      Error value. 0 on success, GATT error on positive value
@@ -391,7 +391,7 @@ struct media_proxy_ctrl_cbs {
 	 * @brief Playback Speed write callback
 	 *
 	 * Called when the Playback Speed is written
-	 * See also media_proxy_ctrl_playback_speed_set()
+	 * See also media_proxy_ctrl_set_playback_speed()
 	 *
 	 * @param player   Media player instance pointer
 	 * @param err      Error value. 0 on success, GATT error on positive value
@@ -404,7 +404,7 @@ struct media_proxy_ctrl_cbs {
 	 * @brief Seeking Speed receive callback
 	 *
 	 * Called when the Seeking Speed is read or changed
-	 * See also media_proxy_ctrl_seeking_speed_get()
+	 * See also media_proxy_ctrl_get_seeking_speed()
 	 *
 	 * @param player   Media player instance pointer
 	 * @param err      Error value. 0 on success, GATT error on positive value
@@ -417,7 +417,7 @@ struct media_proxy_ctrl_cbs {
 	 * @brief Track Segments Object ID receive callback
 	 *
 	 * Called when the Track Segments Object ID is read
-	 * See also media_proxy_ctrl_track_segments_id_get()
+	 * See also media_proxy_ctrl_get_track_segments_id()
 	 *
 	 * @param player   Media player instance pointer
 	 * @param err      Error value. 0 on success, GATT error on positive value
@@ -430,8 +430,8 @@ struct media_proxy_ctrl_cbs {
 	 * @brief Current Track Object ID receive callback
 	 *
 	 * Called when the Current Track Object ID is read or changed
-	 * See also media_proxy_ctrl_current_track_id_get() and
-	 * media_proxy_ctrl_current_track_id_set()
+	 * See also media_proxy_ctrl_get_current_track_id() and
+	 * media_proxy_ctrl_set_current_track_id()
 	 *
 	 * @param player   Media player instance pointer
 	 * @param err      Error value. 0 on success, GATT error on positive value
@@ -444,7 +444,7 @@ struct media_proxy_ctrl_cbs {
 	 * @brief Current Track Object ID write callback
 	 *
 	 * Called when the Current Track Object ID is written
-	 * See also media_proxy_ctrl_current_track_id_set()
+	 * See also media_proxy_ctrl_set_current_track_id()
 	 *
 	 * @param player   Media player instance pointer
 	 * @param err      Error value. 0 on success, GATT error on positive value
@@ -457,8 +457,8 @@ struct media_proxy_ctrl_cbs {
 	 * @brief Next Track Object ID receive callback
 	 *
 	 * Called when the Next Track Object ID is read or changed
-	 * See also media_proxy_ctrl_next_track_id_get() and
-	 * media_proxy_ctrl_next_track_id_set()
+	 * See also media_proxy_ctrl_get_next_track_id() and
+	 * media_proxy_ctrl_set_next_track_id()
 	 *
 	 * @param player   Media player instance pointer
 	 * @param err      Error value. 0 on success, GATT error on positive value
@@ -471,7 +471,7 @@ struct media_proxy_ctrl_cbs {
 	 * @brief Next Track Object ID write callback
 	 *
 	 * Called when the Next Track Object ID is written
-	 * See also media_proxy_ctrl_next_track_id_set()
+	 * See also media_proxy_ctrl_set_next_track_id()
 	 *
 	 * @param player   Media player instance pointer
 	 * @param err      Error value. 0 on success, GATT error on positive value
@@ -484,7 +484,7 @@ struct media_proxy_ctrl_cbs {
 	 * @brief Parent Group Object ID receive callback
 	 *
 	 * Called when the Parent Group Object ID is read or changed
-	 * See also media_proxy_ctrl_parent_group_id_get()
+	 * See also media_proxy_ctrl_get_parent_group_id()
 	 *
 	 * @param player   Media player instance pointer
 	 * @param err      Error value. 0 on success, GATT error on positive value
@@ -497,8 +497,8 @@ struct media_proxy_ctrl_cbs {
 	 * @brief Current Group Object ID receive callback
 	 *
 	 * Called when the Current Group Object ID is read or changed
-	 * See also media_proxy_ctrl_current_group_id_get() and
-	 * media_proxy_ctrl_current_group_id_set()
+	 * See also media_proxy_ctrl_get_current_group_id() and
+	 * media_proxy_ctrl_set_current_group_id()
 	 *
 	 * @param player   Media player instance pointer
 	 * @param err      Error value. 0 on success, GATT error on positive value
@@ -511,7 +511,7 @@ struct media_proxy_ctrl_cbs {
 	 * @brief Current Group Object ID write callback
 	 *
 	 * Called when the Current Group Object ID is written
-	 * See also media_proxy_ctrl_current_group_id_set()
+	 * See also media_proxy_ctrl_set_current_group_id()
 	 *
 	 * @param player   Media player instance pointer
 	 * @param err      Error value. 0 on success, GATT error on positive value
@@ -524,8 +524,8 @@ struct media_proxy_ctrl_cbs {
 	 * @brief Playing Order receive callback
 	 *
 	 * Called when the Playing Order is read or changed
-	 * See also media_proxy_ctrl_playing_order_get() and
-	 * media_proxy_ctrl_playing_order_set()
+	 * See also media_proxy_ctrl_get_playing_order() and
+	 * media_proxy_ctrl_set_playing_order()
 	 *
 	 * @param player   Media player instance pointer
 	 * @param err      Error value. 0 on success, GATT error on positive value
@@ -538,7 +538,7 @@ struct media_proxy_ctrl_cbs {
 	 * @brief Playing Order write callback
 	 *
 	 * Called when the Playing Order is written
-	 * See also media_proxy_ctrl_playing_order_set()
+	 * See also media_proxy_ctrl_set_playing_order()
 	 *
 	 * @param player   Media player instance pointer
 	 * @param err      Error value. 0 on success, GATT error on positive value
@@ -551,7 +551,7 @@ struct media_proxy_ctrl_cbs {
 	 * @brief Playing Orders Supported receive callback
 	 *
 	 * Called when the Playing Orders Supported is read
-	 * See also media_proxy_ctrl_playing_orders_supported_get()
+	 * See also media_proxy_ctrl_get_playing_orders_supported()
 	 *
 	 * @param player   Media player instance pointer
 	 * @param err      Error value. 0 on success, GATT error on positive value
@@ -565,8 +565,8 @@ struct media_proxy_ctrl_cbs {
 	 * @brief Media State receive callback
 	 *
 	 * Called when the Media State is read or changed
-	 * See also media_proxy_ctrl_media_state_get() and
-	 * media_proxy_ctrl_command_send()
+	 * See also media_proxy_ctrl_get_media_state() and
+	 * media_proxy_ctrl_send_command()
 	 *
 	 * @param player   Media player instance pointer
 	 * @param err      Error value. 0 on success, GATT error on positive value
@@ -579,7 +579,7 @@ struct media_proxy_ctrl_cbs {
 	 * @brief Command send callback
 	 *
 	 * Called when a command has been sent
-	 * See also media_proxy_ctrl_command_send()
+	 * See also media_proxy_ctrl_send_command()
 	 *
 	 * @param player   Media player instance pointer
 	 * @param err      Error value. 0 on success, GATT error on positive value
@@ -592,7 +592,7 @@ struct media_proxy_ctrl_cbs {
 	 * @brief Command result receive callback
 	 *
 	 * Called when a command result has been received
-	 * See also media_proxy_ctrl_command_send()
+	 * See also media_proxy_ctrl_send_command()
 	 *
 	 * @param player   Media player instance pointer
 	 * @param err      Error value. 0 on success, GATT error on positive value
@@ -605,7 +605,7 @@ struct media_proxy_ctrl_cbs {
 	 * @brief Commands supported receive callback
 	 *
 	 * Called when the Commands Supported is read or changed
-	 * See also media_proxy_ctrl_commands_supported_get()
+	 * See also media_proxy_ctrl_get_commands_supported()
 	 *
 	 * @param player       Media player instance pointer
 	 * @param err          Error value. 0 on success, GATT error on positive value
@@ -618,7 +618,7 @@ struct media_proxy_ctrl_cbs {
 	 * @brief Search send callback
 	 *
 	 * Called when a search has been sent
-	 * See also media_proxy_ctrl_search_send()
+	 * See also media_proxy_ctrl_send_search()
 	 *
 	 * @param player        Media player instance pointer
 	 * @param err           Error value. 0 on success, GATT error on positive value
@@ -631,7 +631,7 @@ struct media_proxy_ctrl_cbs {
 	 * @brief Search result code receive callback
 	 *
 	 * Called when a search result code has been received
-	 * See also media_proxy_ctrl_search_send()
+	 * See also media_proxy_ctrl_send_search()
 	 *
 	 * The search result code tells whether the search was successful or not.
 	 * For a successful search, the actual results of the search (i.e. what was found
@@ -647,7 +647,7 @@ struct media_proxy_ctrl_cbs {
 
 	/**
 	 * @brief Search Results Object ID receive callback
-	 * See also media_proxy_ctrl_search_results_id_get()
+	 * See also media_proxy_ctrl_get_search_results_id()
 	 *
 	 * Called when the Search Results Object ID is read or changed
 	 *
@@ -662,7 +662,7 @@ struct media_proxy_ctrl_cbs {
 	 * @brief Content Control ID receive callback
 	 *
 	 * Called when the Content Control ID is read
-	 * See also media_proxy_ctrl_content_ctrl_id_get()
+	 * See also media_proxy_ctrl_get_content_ctrl_id()
 	 *
 	 * @param player   Media player instance pointer
 	 * @param err      Error value. 0 on success, GATT error on positive value
@@ -707,7 +707,7 @@ int media_proxy_ctrl_discover_player(struct bt_conn *conn);
  *
  * @return 0 if success, errno on failure.
  */
-int media_proxy_ctrl_player_name_get(struct media_player *player);
+int media_proxy_ctrl_get_player_name(struct media_player *player);
 
 /**
  * @brief Read Icon Object ID
@@ -724,7 +724,7 @@ int media_proxy_ctrl_player_name_get(struct media_player *player);
  *
  * @return 0 if success, errno on failure.
  */
-int media_proxy_ctrl_icon_id_get(struct media_player *player);
+int media_proxy_ctrl_get_icon_id(struct media_player *player);
 
 /**
  * @brief Read Icon URL
@@ -733,7 +733,7 @@ int media_proxy_ctrl_icon_id_get(struct media_player *player);
  *
  * @param player   Media player instance pointer
  */
-int media_proxy_ctrl_icon_url_get(struct media_player *player);
+int media_proxy_ctrl_get_icon_url(struct media_player *player);
 
 /**
  * @brief Read Track Title
@@ -742,7 +742,7 @@ int media_proxy_ctrl_icon_url_get(struct media_player *player);
  *
  * @return 0 if success, errno on failure.
  */
-int media_proxy_ctrl_track_title_get(struct media_player *player);
+int media_proxy_ctrl_get_track_title(struct media_player *player);
 
 /**
  * @brief Read Track Duration
@@ -754,7 +754,7 @@ int media_proxy_ctrl_track_title_get(struct media_player *player);
  *
  * @return 0 if success, errno on failure.
  */
-int media_proxy_ctrl_track_duration_get(struct media_player *player);
+int media_proxy_ctrl_get_track_duration(struct media_player *player);
 
 /**
  * @brief Read Track Position
@@ -767,7 +767,7 @@ int media_proxy_ctrl_track_duration_get(struct media_player *player);
  *
  * @return 0 if success, errno on failure.
  */
-int media_proxy_ctrl_track_position_get(struct media_player *player);
+int media_proxy_ctrl_get_track_position(struct media_player *player);
 
 /**
  * @brief Set Track Position
@@ -783,7 +783,7 @@ int media_proxy_ctrl_track_position_get(struct media_player *player);
  *
  * @return 0 if success, errno on failure.
  */
-int media_proxy_ctrl_track_position_set(struct media_player *player, int32_t position);
+int media_proxy_ctrl_set_track_position(struct media_player *player, int32_t position);
 
 /**
  * @brief Get Playback Speed
@@ -802,12 +802,12 @@ int media_proxy_ctrl_track_position_set(struct media_player *player, int32_t pos
  *
  * @return 0 if success, errno on failure.
  */
-int media_proxy_ctrl_playback_speed_get(struct media_player *player);
+int media_proxy_ctrl_get_playback_speed(struct media_player *player);
 
 /**
  * @brief Set Playback Speed
  *
- * See the playback_speed_get() function for an explanation of
+ * See the get_playback_speed() function for an explanation of
  * the playback speed parameter.
  *
  * Note that the media player may not support all possible
@@ -823,7 +823,7 @@ int media_proxy_ctrl_playback_speed_get(struct media_player *player);
  *
  * @return 0 if success, errno on failure.
  */
-int media_proxy_ctrl_playback_speed_set(struct media_player *player, int8_t speed);
+int media_proxy_ctrl_set_playback_speed(struct media_player *player, int8_t speed);
 
 /**
  * @brief Get Seeking Speed
@@ -841,7 +841,7 @@ int media_proxy_ctrl_playback_speed_set(struct media_player *player, int8_t spee
  *
  * @return 0 if success, errno on failure.
  */
-int media_proxy_ctrl_seeking_speed_get(struct media_player *player);
+int media_proxy_ctrl_get_seeking_speed(struct media_player *player);
 
 /**
  * @brief Read Current Track Segments Object ID
@@ -858,7 +858,7 @@ int media_proxy_ctrl_seeking_speed_get(struct media_player *player);
  *
  * @return 0 if success, errno on failure.
  */
-int media_proxy_ctrl_track_segments_id_get(struct media_player *player);
+int media_proxy_ctrl_get_track_segments_id(struct media_player *player);
 
 /**
  * @brief Read Current Track Object ID
@@ -875,7 +875,7 @@ int media_proxy_ctrl_track_segments_id_get(struct media_player *player);
  *
  * @return 0 if success, errno on failure.
  */
-int media_proxy_ctrl_current_track_id_get(struct media_player *player);
+int media_proxy_ctrl_get_current_track_id(struct media_player *player);
 
 /**
  * @brief Set Current Track Object ID
@@ -890,7 +890,7 @@ int media_proxy_ctrl_current_track_id_get(struct media_player *player);
  *
  * @return 0 if success, errno on failure.
  */
-int media_proxy_ctrl_current_track_id_set(struct media_player *player, uint64_t id);
+int media_proxy_ctrl_set_current_track_id(struct media_player *player, uint64_t id);
 
 /**
  * @brief Read Next Track Object ID
@@ -904,7 +904,7 @@ int media_proxy_ctrl_current_track_id_set(struct media_player *player, uint64_t 
  *
  * @return 0 if success, errno on failure.
  */
-int media_proxy_ctrl_next_track_id_get(struct media_player *player);
+int media_proxy_ctrl_get_next_track_id(struct media_player *player);
 
 /**
  * @brief Set Next Track Object ID
@@ -918,7 +918,7 @@ int media_proxy_ctrl_next_track_id_get(struct media_player *player);
  *
  * @return 0 if success, errno on failure.
  */
-int media_proxy_ctrl_next_track_id_set(struct media_player *player, uint64_t id);
+int media_proxy_ctrl_set_next_track_id(struct media_player *player, uint64_t id);
 
 /**
  * @brief Read Parent Group Object ID
@@ -937,7 +937,7 @@ int media_proxy_ctrl_next_track_id_set(struct media_player *player, uint64_t id)
  *
  * @return 0 if success, errno on failure.
  */
-int media_proxy_ctrl_parent_group_id_get(struct media_player *player);
+int media_proxy_ctrl_get_parent_group_id(struct media_player *player);
 
 /**
  * @brief Read Current Group Object ID
@@ -954,7 +954,7 @@ int media_proxy_ctrl_parent_group_id_get(struct media_player *player);
  *
  * @return 0 if success, errno on failure.
  */
-int media_proxy_ctrl_current_group_id_get(struct media_player *player);
+int media_proxy_ctrl_get_current_group_id(struct media_player *player);
 
 /**
  * @brief Set Current Group Object ID
@@ -969,7 +969,7 @@ int media_proxy_ctrl_current_group_id_get(struct media_player *player);
  *
  * @return 0 if success, errno on failure.
  */
-int media_proxy_ctrl_current_group_id_set(struct media_player *player, uint64_t id);
+int media_proxy_ctrl_set_current_group_id(struct media_player *player, uint64_t id);
 
 /**
  * @brief Read Playing Order
@@ -978,7 +978,7 @@ int media_proxy_ctrl_current_group_id_set(struct media_player *player, uint64_t 
  *
  * @return 0 if success, errno on failure.
  */
-int media_proxy_ctrl_playing_order_get(struct media_player *player);
+int media_proxy_ctrl_get_playing_order(struct media_player *player);
 
 /**
  * @brief Set Playing Order
@@ -990,7 +990,7 @@ int media_proxy_ctrl_playing_order_get(struct media_player *player);
  *
  * @return 0 if success, errno on failure.
  */
-int media_proxy_ctrl_playing_order_set(struct media_player *player, uint8_t order);
+int media_proxy_ctrl_set_playing_order(struct media_player *player, uint8_t order);
 
 /**
  * @brief Read Playing Orders Supported
@@ -1002,7 +1002,7 @@ int media_proxy_ctrl_playing_order_set(struct media_player *player, uint8_t orde
  *
  * @return 0 if success, errno on failure.
  */
-int media_proxy_ctrl_playing_orders_supported_get(struct media_player *player);
+int media_proxy_ctrl_get_playing_orders_supported(struct media_player *player);
 
 /**
  * @brief Read Media State
@@ -1013,7 +1013,7 @@ int media_proxy_ctrl_playing_orders_supported_get(struct media_player *player);
  *
  * @return 0 if success, errno on failure.
  */
-int media_proxy_ctrl_media_state_get(struct media_player *player);
+int media_proxy_ctrl_get_media_state(struct media_player *player);
 
 /**
  * @brief Send Command
@@ -1028,7 +1028,7 @@ int media_proxy_ctrl_media_state_get(struct media_player *player);
  *
  * @return 0 if success, errno on failure.
  */
-int media_proxy_ctrl_command_send(struct media_player *player, struct mpl_cmd command);
+int media_proxy_ctrl_send_command(struct media_player *player, struct mpl_cmd command);
 
 /**
  * @brief Read Commands Supported
@@ -1040,7 +1040,7 @@ int media_proxy_ctrl_command_send(struct media_player *player, struct mpl_cmd co
  *
  * @return 0 if success, errno on failure.
  */
-int media_proxy_ctrl_commands_supported_get(struct media_player *player);
+int media_proxy_ctrl_get_commands_supported(struct media_player *player);
 
 /**
  * @brief Set Search
@@ -1061,7 +1061,7 @@ int media_proxy_ctrl_commands_supported_get(struct media_player *player);
  *
  * @return 0 if success, errno on failure.
  */
-int media_proxy_ctrl_search_send(struct media_player *player, struct mpl_search search);
+int media_proxy_ctrl_send_search(struct media_player *player, struct mpl_search search);
 
 /**
  * @brief Read Search Results Object ID
@@ -1079,7 +1079,7 @@ int media_proxy_ctrl_search_send(struct media_player *player, struct mpl_search 
  *
  * @return 0 if success, errno on failure.
  */
-int media_proxy_ctrl_search_results_id_get(struct media_player *player);
+int media_proxy_ctrl_get_search_results_id(struct media_player *player);
 
 /**
  * @brief Read Content Control ID
@@ -1092,7 +1092,7 @@ int media_proxy_ctrl_search_results_id_get(struct media_player *player);
  *
  * @return 0 if success, errno on failure.
  */
-uint8_t media_proxy_ctrl_content_ctrl_id_get(struct media_player *player);
+uint8_t media_proxy_ctrl_get_content_ctrl_id(struct media_player *player);
 
 
 /* PUBLIC API FOR PLAYERS */
@@ -1108,7 +1108,7 @@ struct media_proxy_pl_calls {
 	 *
 	 * @return The name of the media player
 	 */
-	const char *(*player_name_get)(void);
+	const char *(*get_player_name)(void);
 
 	/**
 	 * @brief Read Icon Object ID
@@ -1121,7 +1121,7 @@ struct media_proxy_pl_calls {
 	 *
 	 * @return The Icon Object ID
 	 */
-	uint64_t (*icon_id_get)(void);
+	uint64_t (*get_icon_id)(void);
 
 	/**
 	 * @brief Read Icon URL
@@ -1130,14 +1130,14 @@ struct media_proxy_pl_calls {
 	 *
 	 * @return The URL of the Icon
 	 */
-	const char *(*icon_url_get)(void);
+	const char *(*get_icon_url)(void);
 
 	/**
 	 * @brief Read Track Title
 	 *
 	 * @return The title of the current track
 	 */
-	const char *(*track_title_get)(void);
+	const char *(*get_track_title)(void);
 
 	/**
 	 * @brief Read Track Duration
@@ -1147,7 +1147,7 @@ struct media_proxy_pl_calls {
 	 *
 	 * @return The duration of the current track
 	 */
-	int32_t (*track_duration_get)(void);
+	int32_t (*get_track_duration)(void);
 
 	/**
 	 * @brief Read Track Position
@@ -1158,7 +1158,7 @@ struct media_proxy_pl_calls {
 	 *
 	 * @return The position of the player in the current track
 	 */
-	int32_t (*track_position_get)(void);
+	int32_t (*get_track_position)(void);
 
 	/**
 	 * @brief Set Track Position
@@ -1171,7 +1171,7 @@ struct media_proxy_pl_calls {
 	 *
 	 * @param position    The player position to set
 	 */
-	void (*track_position_set)(int32_t position);
+	void (*set_track_position)(int32_t position);
 
 	/**
 	 * @brief Get Playback Speed
@@ -1188,12 +1188,12 @@ struct media_proxy_pl_calls {
 	 *
 	 * @return The playback speed parameter
 	 */
-	int8_t (*playback_speed_get)(void);
+	int8_t (*get_playback_speed)(void);
 
 	/**
 	 * @brief Set Playback Speed
 	 *
-	 * See the playback_speed_get() function for an explanation of
+	 * See the get_playback_speed() function for an explanation of
 	 * the playback speed parameter.
 	 *
 	 * Note that the media player may not support all possible
@@ -1206,7 +1206,7 @@ struct media_proxy_pl_calls {
 	 *
 	 * @param speed The playback speed parameter to set
 	 */
-	void (*playback_speed_set)(int8_t speed);
+	void (*set_playback_speed)(int8_t speed);
 
 	/**
 	 * @brief Get Seeking Speed
@@ -1222,7 +1222,7 @@ struct media_proxy_pl_calls {
 	 *
 	 * @return The seeking speed factor
 	 */
-	int8_t (*seeking_speed_get)(void);
+	int8_t (*get_seeking_speed)(void);
 
 	/**
 	 * @brief Read Current Track Segments Object ID
@@ -1235,7 +1235,7 @@ struct media_proxy_pl_calls {
 	 *
 	 * @return Current The Track Segments Object ID
 	 */
-	uint64_t (*track_segments_id_get)(void);
+	uint64_t (*get_track_segments_id)(void);
 
 	/**
 	 * @brief Read Current Track Object ID
@@ -1248,7 +1248,7 @@ struct media_proxy_pl_calls {
 	 *
 	 * @return The Current Track Object ID
 	 */
-	uint64_t (*current_track_id_get)(void);
+	uint64_t (*get_current_track_id)(void);
 
 	/**
 	 * @brief Set Current Track Object ID
@@ -1258,7 +1258,7 @@ struct media_proxy_pl_calls {
 	 *
 	 * @param id    The ID of a track object
 	 */
-	void (*current_track_id_set)(uint64_t id);
+	void (*set_current_track_id)(uint64_t id);
 
 	/**
 	 * @brief Read Next Track Object ID
@@ -1268,7 +1268,7 @@ struct media_proxy_pl_calls {
 	 *
 	 * @return The Next Track Object ID
 	 */
-	uint64_t (*next_track_id_get)(void);
+	uint64_t (*get_next_track_id)(void);
 
 	/**
 	 * @brief Set Next Track Object ID
@@ -1277,7 +1277,7 @@ struct media_proxy_pl_calls {
 	 *
 	 * @param id    The ID of a track object
 	 */
-	void (*next_track_id_set)(uint64_t id);
+	void (*set_next_track_id)(uint64_t id);
 
 	/**
 	 * @brief Read Parent Group Object ID
@@ -1292,7 +1292,7 @@ struct media_proxy_pl_calls {
 	 *
 	 * @return The Current Group Object ID
 	 */
-	uint64_t (*parent_group_id_get)(void);
+	uint64_t (*get_parent_group_id)(void);
 
 	/**
 	 * @brief Read Current Group Object ID
@@ -1305,7 +1305,7 @@ struct media_proxy_pl_calls {
 	 *
 	 * @return The Current Group Object ID
 	 */
-	uint64_t (*current_group_id_get)(void);
+	uint64_t (*get_current_group_id)(void);
 
 	/**
 	 * @brief Set Current Group Object ID
@@ -1315,14 +1315,14 @@ struct media_proxy_pl_calls {
 	 *
 	 * @param id    The ID of a group object
 	 */
-	void (*current_group_id_set)(uint64_t id);
+	void (*set_current_group_id)(uint64_t id);
 
 	/**
 	 * @brief Read Playing Order
 	 *
 	 * return The media player's current playing order
 	 */
-	uint8_t (*playing_order_get)(void);
+	uint8_t (*get_playing_order)(void);
 
 	/**
 	 * @brief Set Playing Order
@@ -1333,7 +1333,7 @@ struct media_proxy_pl_calls {
 	 *
 	 * @param order	The playing order to set
 	 */
-	void (*playing_order_set)(uint8_t order);
+	void (*set_playing_order)(uint8_t order);
 
 	/**
 	 * @brief Read Playing Orders Supported
@@ -1346,7 +1346,7 @@ struct media_proxy_pl_calls {
 	 *
 	 * @return The media player's supported playing orders
 	 */
-	uint16_t (*playing_orders_supported_get)(void);
+	uint16_t (*get_playing_orders_supported)(void);
 
 	/**
 	 * @brief Read Media State
@@ -1357,7 +1357,7 @@ struct media_proxy_pl_calls {
 	 *
 	 * @return The media player's state
 	 */
-	uint8_t (*media_state_get)(void);
+	uint8_t (*get_media_state)(void);
 
 	/**
 	 * @brief Send Command
@@ -1369,7 +1369,7 @@ struct media_proxy_pl_calls {
 	 *
 	 * @param command	The command to send
 	 */
-	void (*command_send)(struct mpl_cmd command);
+	void (*send_command)(struct mpl_cmd command);
 
 	/**
 	 * @brief Read Commands Supported
@@ -1381,7 +1381,7 @@ struct media_proxy_pl_calls {
 	 *
 	 * @return The media player's supported command opcodes
 	 */
-	uint32_t (*commands_supported_get)(void);
+	uint32_t (*get_commands_supported)(void);
 
 	/**
 	 * @brief Set Search
@@ -1392,7 +1392,7 @@ struct media_proxy_pl_calls {
 	 *
 	 * @param search	The search to write
 	 */
-	void (*search_send)(struct mpl_search search);
+	void (*send_search)(struct mpl_search search);
 
 	/**
 	 * @brief Read Search Results Object ID
@@ -1406,7 +1406,7 @@ struct media_proxy_pl_calls {
 	 *
 	 * @return The Search Results Object ID
 	 */
-	uint64_t (*search_results_id_get)(void);
+	uint64_t (*get_search_results_id)(void);
 
 	/**
 	 * @brief Read Content Control ID
@@ -1417,7 +1417,7 @@ struct media_proxy_pl_calls {
 	 *
 	 * @return The content control ID for the media player
 	 */
-	uint8_t (*content_ctrl_id_get)(void);
+	uint8_t (*get_content_ctrl_id)(void);
 };
 
 /**

--- a/subsys/bluetooth/host/audio/media_proxy_internal.h
+++ b/subsys/bluetooth/host/audio/media_proxy_internal.h
@@ -71,59 +71,59 @@ struct media_proxy_sctrl_cbs {
 int media_proxy_sctrl_register(struct media_proxy_sctrl_cbs *sctrl_cbs);
 
 
-const char *media_proxy_sctrl_player_name_get(void);
+const char *media_proxy_sctrl_get_player_name(void);
 
 #ifdef CONFIG_BT_OTS
-uint64_t media_proxy_sctrl_icon_id_get(void);
+uint64_t media_proxy_sctrl_get_icon_id(void);
 #endif /* CONFIG_BT_OTS */
 
-const char *media_proxy_sctrl_icon_url_get(void);
+const char *media_proxy_sctrl_get_icon_url(void);
 
 
-const char *media_proxy_sctrl_track_title_get(void);
+const char *media_proxy_sctrl_get_track_title(void);
 
-int32_t media_proxy_sctrl_track_duration_get(void);
+int32_t media_proxy_sctrl_get_track_duration(void);
 
-int32_t media_proxy_sctrl_track_position_get(void);
-void media_proxy_sctrl_track_position_set(int32_t position);
+int32_t media_proxy_sctrl_get_track_position(void);
+void media_proxy_sctrl_set_track_position(int32_t position);
 
-int8_t media_proxy_sctrl_playback_speed_get(void);
-void media_proxy_sctrl_playback_speed_set(int8_t speed);
+int8_t media_proxy_sctrl_get_playback_speed(void);
+void media_proxy_sctrl_set_playback_speed(int8_t speed);
 
-int8_t media_proxy_sctrl_seeking_speed_get(void);
+int8_t media_proxy_sctrl_get_seeking_speed(void);
 
 #ifdef CONFIG_BT_OTS
-uint64_t media_proxy_sctrl_track_segments_id_get(void);
+uint64_t media_proxy_sctrl_get_track_segments_id(void);
 
-uint64_t media_proxy_sctrl_current_track_id_get(void);
-void media_proxy_sctrl_current_track_id_set(uint64_t id);
+uint64_t media_proxy_sctrl_get_current_track_id(void);
+void media_proxy_sctrl_set_current_track_id(uint64_t id);
 
-uint64_t media_proxy_sctrl_next_track_id_get(void);
-void media_proxy_sctrl_next_track_id_set(uint64_t id);
+uint64_t media_proxy_sctrl_get_next_track_id(void);
+void media_proxy_sctrl_set_next_track_id(uint64_t id);
 
-uint64_t media_proxy_sctrl_current_group_id_get(void);
-void media_proxy_sctrl_current_group_id_set(uint64_t id);
+uint64_t media_proxy_sctrl_get_current_group_id(void);
+void media_proxy_sctrl_set_current_group_id(uint64_t id);
 
-uint64_t media_proxy_sctrl_parent_group_id_get(void);
+uint64_t media_proxy_sctrl_get_parent_group_id(void);
 #endif /* CONFIG_BT_OTS */
 
-uint8_t media_proxy_sctrl_playing_order_get(void);
-void media_proxy_sctrl_playing_order_set(uint8_t order);
+uint8_t media_proxy_sctrl_get_playing_order(void);
+void media_proxy_sctrl_set_playing_order(uint8_t order);
 
-uint16_t media_proxy_sctrl_playing_orders_supported_get(void);
+uint16_t media_proxy_sctrl_get_playing_orders_supported(void);
 
-uint8_t media_proxy_sctrl_media_state_get(void);
+uint8_t media_proxy_sctrl_get_media_state(void);
 
-void media_proxy_sctrl_command_send(struct mpl_cmd command);
+void media_proxy_sctrl_send_command(struct mpl_cmd command);
 
-uint32_t media_proxy_sctrl_commands_supported_get(void);
+uint32_t media_proxy_sctrl_get_commands_supported(void);
 
 #ifdef CONFIG_BT_OTS
-void media_proxy_sctrl_search_send(struct mpl_search search);
+void media_proxy_sctrl_send_search(struct mpl_search search);
 
-uint64_t media_proxy_sctrl_search_results_id_get(void);
+uint64_t media_proxy_sctrl_get_search_results_id(void);
 #endif /* CONFIG_BT_OTS */
 
-uint8_t media_proxy_sctrl_content_ctrl_id_get(void);
+uint8_t media_proxy_sctrl_get_content_ctrl_id(void);
 
 #endif /* ZEPHYR_INCLUDE_BLUETOOTH_AUDIO_MEDIA_PROXY_INTERNAL_H_ */

--- a/subsys/bluetooth/host/audio/mpl.c
+++ b/subsys/bluetooth/host/audio/mpl.c
@@ -2324,39 +2324,39 @@ static bool find_group_by_id(const struct mpl_mediaplayer *pl, uint64_t id,
 }
 #endif /* CONFIG_BT_OTS */
 
-const char *player_name_get(void)
+const char *get_player_name(void)
 {
 	return pl.name;
 }
 
 #ifdef CONFIG_BT_OTS
-uint64_t icon_id_get(void)
+uint64_t get_icon_id(void)
 {
 	return pl.icon_id;
 }
 #endif /* CONFIG_BT_OTS */
 
-const char *icon_url_get(void)
+const char *get_icon_url(void)
 {
 	return pl.icon_url;
 }
 
-const char *track_title_get(void)
+const char *get_track_title(void)
 {
 	return pl.group->track->title;
 }
 
-int32_t track_duration_get(void)
+int32_t get_track_duration(void)
 {
 	return pl.group->track->duration;
 }
 
-int32_t track_position_get(void)
+int32_t get_track_position(void)
 {
 	return pl.track_pos;
 }
 
-void track_position_set(int32_t position)
+void set_track_position(int32_t position)
 {
 	int32_t old_pos = pl.track_pos;
 	int32_t new_pos;
@@ -2389,12 +2389,12 @@ void track_position_set(int32_t position)
 	}
 }
 
-int8_t playback_speed_get(void)
+int8_t get_playback_speed(void)
 {
 	return pl.playback_speed_param;
 }
 
-void playback_speed_set(int8_t speed)
+void set_playback_speed(int8_t speed)
 {
 	/* Set new speed parameter and notify, if different from current */
 	if (speed != pl.playback_speed_param) {
@@ -2403,23 +2403,23 @@ void playback_speed_set(int8_t speed)
 	}
 }
 
-int8_t seeking_speed_get(void)
+int8_t get_seeking_speed(void)
 {
 	return pl.seeking_speed_factor;
 }
 
 #ifdef CONFIG_BT_OTS
-uint64_t track_segments_id_get(void)
+uint64_t get_track_segments_id(void)
 {
 	return pl.group->track->segments_id;
 }
 
-uint64_t current_track_id_get(void)
+uint64_t get_current_track_id(void)
 {
 	return pl.group->track->id;
 }
 
-void current_track_id_set(uint64_t id)
+void set_current_track_id(uint64_t id)
 {
 	struct mpl_group *group;
 	struct mpl_track *track;
@@ -2450,7 +2450,7 @@ void current_track_id_set(uint64_t id)
 	 */
 }
 
-uint64_t next_track_id_get(void)
+uint64_t get_next_track_id(void)
 {
 	/* If the next track has been set explicitly */
 	if (pl.next_track_set) {
@@ -2466,7 +2466,7 @@ uint64_t next_track_id_get(void)
 	return MPL_NO_TRACK_ID;
 }
 
-void next_track_id_set(uint64_t id)
+void set_next_track_id(uint64_t id)
 {
 	struct mpl_group *group;
 	struct mpl_track *track;
@@ -2485,17 +2485,17 @@ void next_track_id_set(uint64_t id)
 	BT_DBG("Track not found");
 }
 
-uint64_t parent_group_id_get(void)
+uint64_t get_parent_group_id(void)
 {
 	return pl.group->parent->id;
 }
 
-uint64_t current_group_id_get(void)
+uint64_t get_current_group_id(void)
 {
 	return pl.group->id;
 }
 
-void current_group_id_set(uint64_t id)
+void set_current_group_id(uint64_t id)
 {
 	struct mpl_group *group;
 	bool track_change;
@@ -2522,12 +2522,12 @@ void current_group_id_set(uint64_t id)
 }
 #endif /* CONFIG_BT_OTS */
 
-uint8_t playing_order_get(void)
+uint8_t get_playing_order(void)
 {
 	return pl.playing_order;
 }
 
-void playing_order_set(uint8_t order)
+void set_playing_order(uint8_t order)
 {
 	if (order != pl.playing_order) {
 		if (BIT(order - 1) & pl.playing_orders_supported) {
@@ -2537,17 +2537,17 @@ void playing_order_set(uint8_t order)
 	}
 }
 
-uint16_t playing_orders_supported_get(void)
+uint16_t get_playing_orders_supported(void)
 {
 	return pl.playing_orders_supported;
 }
 
-uint8_t media_state_get(void)
+uint8_t get_media_state(void)
 {
 	return pl.state;
 }
 
-void command_send(struct mpl_cmd command)
+void send_command(struct mpl_cmd command)
 {
 	struct mpl_cmd_ntf ntf;
 
@@ -2561,7 +2561,7 @@ void command_send(struct mpl_cmd command)
 	}
 }
 
-uint32_t commands_supported_get(void)
+uint32_t get_commands_supported(void)
 {
 	return pl.opcodes_supported;
 }
@@ -2621,7 +2621,7 @@ static void parse_search(struct mpl_search search)
 	media_proxy_pl_search_results_id_cb(pl.search_results_id);
 }
 
-void search_send(struct mpl_search search)
+void send_search(struct mpl_search search)
 {
 	if (search.len > SEARCH_LEN_MAX) {
 		BT_WARN("Search too long: %d", search.len);
@@ -2632,13 +2632,13 @@ void search_send(struct mpl_search search)
 	parse_search(search);
 }
 
-uint64_t search_results_id_get(void)
+uint64_t get_search_results_id(void)
 {
 	return pl.search_results_id;
 }
 #endif /* CONFIG_BT_OTS */
 
-uint8_t content_ctrl_id_get(void)
+uint8_t get_content_ctrl_id(void)
 {
 	return pl.content_ctrl_id;
 }
@@ -2697,38 +2697,38 @@ int media_proxy_pl_init(void)
 #endif /* CONFIG_BT_OTS */
 
 	/* Set up the calls structure */
-	pl.calls.player_name_get              = player_name_get;
+	pl.calls.get_player_name              = get_player_name;
 #ifdef CONFIG_BT_OTS
-	pl.calls.icon_id_get                  = icon_id_get;
+	pl.calls.get_icon_id                  = get_icon_id;
 #endif /* CONFIG_BT_OTS */
-	pl.calls.icon_url_get                 = icon_url_get;
-	pl.calls.track_title_get              = track_title_get;
-	pl.calls.track_duration_get           = track_duration_get;
-	pl.calls.track_position_get           = track_position_get;
-	pl.calls.track_position_set           = track_position_set;
-	pl.calls.playback_speed_get           = playback_speed_get;
-	pl.calls.playback_speed_set           = playback_speed_set;
-	pl.calls.seeking_speed_get            = seeking_speed_get;
+	pl.calls.get_icon_url                 = get_icon_url;
+	pl.calls.get_track_title              = get_track_title;
+	pl.calls.get_track_duration           = get_track_duration;
+	pl.calls.get_track_position           = get_track_position;
+	pl.calls.set_track_position           = set_track_position;
+	pl.calls.get_playback_speed           = get_playback_speed;
+	pl.calls.set_playback_speed           = set_playback_speed;
+	pl.calls.get_seeking_speed            = get_seeking_speed;
 #ifdef CONFIG_BT_OTS
-	pl.calls.track_segments_id_get        = track_segments_id_get;
-	pl.calls.current_track_id_get         = current_track_id_get;
-	pl.calls.current_track_id_set         = current_track_id_set;
-	pl.calls.next_track_id_get            = next_track_id_get;
-	pl.calls.next_track_id_set            = next_track_id_set;
-	pl.calls.parent_group_id_get          = parent_group_id_get;
-	pl.calls.current_group_id_get         = current_group_id_get;
-	pl.calls.current_group_id_set         = current_group_id_set;
+	pl.calls.get_track_segments_id        = get_track_segments_id;
+	pl.calls.get_current_track_id         = get_current_track_id;
+	pl.calls.set_current_track_id         = set_current_track_id;
+	pl.calls.get_next_track_id            = get_next_track_id;
+	pl.calls.set_next_track_id            = set_next_track_id;
+	pl.calls.get_parent_group_id          = get_parent_group_id;
+	pl.calls.get_current_group_id         = get_current_group_id;
+	pl.calls.set_current_group_id         = set_current_group_id;
 #endif /* CONFIG_BT_OTS */
-	pl.calls.playing_order_get            = playing_order_get;
-	pl.calls.playing_order_set            = playing_order_set;
-	pl.calls.playing_orders_supported_get = playing_orders_supported_get;
-	pl.calls.media_state_get              = media_state_get;
-	pl.calls.command_send                 = command_send;
+	pl.calls.get_playing_order            = get_playing_order;
+	pl.calls.set_playing_order            = set_playing_order;
+	pl.calls.get_playing_orders_supported = get_playing_orders_supported;
+	pl.calls.get_media_state              = get_media_state;
+	pl.calls.send_command                 = send_command;
 #ifdef CONFIG_BT_OTS
-	pl.calls.search_send                  = search_send;
-	pl.calls.search_results_id_get        = search_results_id_get;
+	pl.calls.send_search                  = send_search;
+	pl.calls.get_search_results_id        = get_search_results_id;
 #endif /* CONFIG_BT_OTS */
-	pl.calls.content_ctrl_id_get          = content_ctrl_id_get;
+	pl.calls.get_content_ctrl_id          = get_content_ctrl_id;
 
 	ret = media_proxy_pl_register(&pl.calls);
 	if (ret < 0) {

--- a/subsys/bluetooth/shell/mcc.c
+++ b/subsys/bluetooth/shell/mcc.c
@@ -54,7 +54,7 @@ static void mcc_discover_mcs_cb(struct bt_conn *conn, int err)
 	shell_print(ctx_shell, "Discovery complete");
 }
 
-static void mcc_player_name_read_cb(struct bt_conn *conn, int err, const char *name)
+static void mcc_read_player_name_cb(struct bt_conn *conn, int err, const char *name)
 {
 	if (err) {
 		shell_error(ctx_shell, "Player Name read failed (%d)", err);
@@ -65,7 +65,7 @@ static void mcc_player_name_read_cb(struct bt_conn *conn, int err, const char *n
 }
 
 #ifdef CONFIG_BT_MCC_OTS
-static void mcc_icon_obj_id_read_cb(struct bt_conn *conn, int err, uint64_t id)
+static void mcc_read_icon_obj_id_cb(struct bt_conn *conn, int err, uint64_t id)
 {
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
@@ -81,7 +81,7 @@ static void mcc_icon_obj_id_read_cb(struct bt_conn *conn, int err, uint64_t id)
 }
 #endif /* CONFIG_BT_MCC_OTS */
 
-static void mcc_icon_url_read_cb(struct bt_conn *conn, int err, const char *url)
+static void mcc_read_icon_url_cb(struct bt_conn *conn, int err, const char *url)
 {
 	if (err) {
 		shell_error(ctx_shell, "Icon URL read failed (%d)", err);
@@ -91,7 +91,7 @@ static void mcc_icon_url_read_cb(struct bt_conn *conn, int err, const char *url)
 	shell_print(ctx_shell, "Icon URL: 0x%s", url);
 }
 
-static void mcc_track_title_read_cb(struct bt_conn *conn, int err, const char *title)
+static void mcc_read_track_title_cb(struct bt_conn *conn, int err, const char *title)
 {
 	if (err) {
 		shell_error(ctx_shell, "Track title read failed (%d)", err);
@@ -111,7 +111,7 @@ static void mcc_track_changed_ntf_cb(struct bt_conn *conn, int err)
 	shell_print(ctx_shell, "Track changed");
 }
 
-static void mcc_track_duration_read_cb(struct bt_conn *conn, int err, int32_t dur)
+static void mcc_read_track_duration_cb(struct bt_conn *conn, int err, int32_t dur)
 {
 	if (err) {
 		shell_error(ctx_shell, "Track duration read failed (%d)", err);
@@ -121,7 +121,7 @@ static void mcc_track_duration_read_cb(struct bt_conn *conn, int err, int32_t du
 	shell_print(ctx_shell, "Track duration: %d", dur);
 }
 
-static void mcc_track_position_read_cb(struct bt_conn *conn, int err, int32_t pos)
+static void mcc_read_track_position_cb(struct bt_conn *conn, int err, int32_t pos)
 {
 	if (err) {
 		shell_error(ctx_shell, "Track position read failed (%d)", err);
@@ -131,7 +131,7 @@ static void mcc_track_position_read_cb(struct bt_conn *conn, int err, int32_t po
 	shell_print(ctx_shell, "Track Position: %d", pos);
 }
 
-static void mcc_track_position_set_cb(struct bt_conn *conn, int err, int32_t pos)
+static void mcc_set_track_position_cb(struct bt_conn *conn, int err, int32_t pos)
 {
 	if (err) {
 		shell_error(ctx_shell, "Track Position set failed (%d)", err);
@@ -141,7 +141,7 @@ static void mcc_track_position_set_cb(struct bt_conn *conn, int err, int32_t pos
 	shell_print(ctx_shell, "Track Position: %d", pos);
 }
 
-static void mcc_playback_speed_read_cb(struct bt_conn *conn, int err,
+static void mcc_read_playback_speed_cb(struct bt_conn *conn, int err,
 				       int8_t speed)
 {
 	if (err) {
@@ -152,7 +152,7 @@ static void mcc_playback_speed_read_cb(struct bt_conn *conn, int err,
 	shell_print(ctx_shell, "Playback speed: %d", speed);
 }
 
-static void mcc_playback_speed_set_cb(struct bt_conn *conn, int err, int8_t speed)
+static void mcc_set_playback_speed_cb(struct bt_conn *conn, int err, int8_t speed)
 {
 	if (err) {
 		shell_error(ctx_shell, "Playback speed set failed (%d)", err);
@@ -162,7 +162,7 @@ static void mcc_playback_speed_set_cb(struct bt_conn *conn, int err, int8_t spee
 	shell_print(ctx_shell, "Playback speed: %d", speed);
 }
 
-static void mcc_seeking_speed_read_cb(struct bt_conn *conn, int err,
+static void mcc_read_seeking_speed_cb(struct bt_conn *conn, int err,
 				      int8_t speed)
 {
 	if (err) {
@@ -175,7 +175,7 @@ static void mcc_seeking_speed_read_cb(struct bt_conn *conn, int err,
 
 
 #ifdef CONFIG_BT_MCC_OTS
-static void mcc_segments_obj_id_read_cb(struct bt_conn *conn, int err,
+static void mcc_read_segments_obj_id_cb(struct bt_conn *conn, int err,
 					uint64_t id)
 {
 	char str[BT_OTS_OBJ_ID_STR_LEN];
@@ -193,7 +193,7 @@ static void mcc_segments_obj_id_read_cb(struct bt_conn *conn, int err,
 }
 
 
-static void mcc_current_track_obj_id_read_cb(struct bt_conn *conn, int err,
+static void mcc_read_current_track_obj_id_cb(struct bt_conn *conn, int err,
 					     uint64_t id)
 {
 	char str[BT_OTS_OBJ_ID_STR_LEN];
@@ -211,7 +211,7 @@ static void mcc_current_track_obj_id_read_cb(struct bt_conn *conn, int err,
 }
 
 
-static void mcc_current_track_obj_id_set_cb(struct bt_conn *conn, int err,
+static void mcc_set_current_track_obj_id_cb(struct bt_conn *conn, int err,
 					    uint64_t id)
 {
 	char str[BT_OTS_OBJ_ID_STR_LEN];
@@ -226,7 +226,7 @@ static void mcc_current_track_obj_id_set_cb(struct bt_conn *conn, int err,
 }
 
 
-static void mcc_next_track_obj_id_read_cb(struct bt_conn *conn, int err,
+static void mcc_read_next_track_obj_id_cb(struct bt_conn *conn, int err,
 					  uint64_t id)
 {
 	char str[BT_OTS_OBJ_ID_STR_LEN];
@@ -248,7 +248,7 @@ static void mcc_next_track_obj_id_read_cb(struct bt_conn *conn, int err,
 }
 
 
-static void mcc_next_track_obj_id_set_cb(struct bt_conn *conn, int err,
+static void mcc_set_next_track_obj_id_cb(struct bt_conn *conn, int err,
 					    uint64_t id)
 {
 	char str[BT_OTS_OBJ_ID_STR_LEN];
@@ -263,7 +263,7 @@ static void mcc_next_track_obj_id_set_cb(struct bt_conn *conn, int err,
 }
 
 
-static void mcc_parent_group_obj_id_read_cb(struct bt_conn *conn, int err,
+static void mcc_read_parent_group_obj_id_cb(struct bt_conn *conn, int err,
 					    uint64_t id)
 {
 	char str[BT_OTS_OBJ_ID_STR_LEN];
@@ -281,7 +281,7 @@ static void mcc_parent_group_obj_id_read_cb(struct bt_conn *conn, int err,
 }
 
 
-static void mcc_current_group_obj_id_read_cb(struct bt_conn *conn, int err,
+static void mcc_read_current_group_obj_id_cb(struct bt_conn *conn, int err,
 					     uint64_t id)
 {
 	char str[BT_OTS_OBJ_ID_STR_LEN];
@@ -298,7 +298,7 @@ static void mcc_current_group_obj_id_read_cb(struct bt_conn *conn, int err,
 	obj_ids.current_group_obj_id = id;
 }
 
-static void mcc_current_group_obj_id_set_cb(struct bt_conn *conn, int err,
+static void mcc_set_current_group_obj_id_cb(struct bt_conn *conn, int err,
 					    uint64_t id)
 {
 	char str[BT_OTS_OBJ_ID_STR_LEN];
@@ -314,7 +314,7 @@ static void mcc_current_group_obj_id_set_cb(struct bt_conn *conn, int err,
 #endif /* CONFIG_BT_MCC_OTS */
 
 
-static void mcc_playing_order_read_cb(struct bt_conn *conn, int err, uint8_t order)
+static void mcc_read_playing_order_cb(struct bt_conn *conn, int err, uint8_t order)
 {
 	if (err) {
 		shell_error(ctx_shell, "Playing order read failed (%d)", err);
@@ -324,7 +324,7 @@ static void mcc_playing_order_read_cb(struct bt_conn *conn, int err, uint8_t ord
 	shell_print(ctx_shell, "Playing order: %d", order);
 }
 
-static void mcc_playing_order_set_cb(struct bt_conn *conn, int err, uint8_t order)
+static void mcc_set_playing_order_cb(struct bt_conn *conn, int err, uint8_t order)
 {
 	if (err) {
 		shell_error(ctx_shell, "Playing order set failed (%d)", err);
@@ -334,7 +334,7 @@ static void mcc_playing_order_set_cb(struct bt_conn *conn, int err, uint8_t orde
 	shell_print(ctx_shell, "Playing order: %d", order);
 }
 
-static void mcc_playing_orders_supported_read_cb(struct bt_conn *conn, int err,
+static void mcc_read_playing_orders_supported_cb(struct bt_conn *conn, int err,
 						 uint16_t orders)
 {
 	if (err) {
@@ -346,7 +346,7 @@ static void mcc_playing_orders_supported_read_cb(struct bt_conn *conn, int err,
 	shell_print(ctx_shell, "Playing orders supported: %d", orders);
 }
 
-static void mcc_media_state_read_cb(struct bt_conn *conn, int err, uint8_t state)
+static void mcc_read_media_state_cb(struct bt_conn *conn, int err, uint8_t state)
 {
 	if (err) {
 		shell_error(ctx_shell, "Media State read failed (%d)", err);
@@ -356,7 +356,7 @@ static void mcc_media_state_read_cb(struct bt_conn *conn, int err, uint8_t state
 	shell_print(ctx_shell, "Media State: %d", state);
 }
 
-static void mcc_cmd_send_cb(struct bt_conn *conn, int err, struct mpl_cmd cmd)
+static void mcc_send_cmd_cb(struct bt_conn *conn, int err, struct mpl_cmd cmd)
 {
 	if (err) {
 		shell_error(ctx_shell,
@@ -382,7 +382,7 @@ static void mcc_cmd_ntf_cb(struct bt_conn *conn, int err,
 		    ntf.requested_opcode, ntf.result_code);
 }
 
-static void mcc_opcodes_supported_read_cb(struct bt_conn *conn, int err,
+static void mcc_read_opcodes_supported_cb(struct bt_conn *conn, int err,
 					    uint32_t opcodes)
 {
 	if (err) {
@@ -395,7 +395,7 @@ static void mcc_opcodes_supported_read_cb(struct bt_conn *conn, int err,
 }
 
 #ifdef CONFIG_BT_MCC_OTS
-static void mcc_search_send_cb(struct bt_conn *conn, int err,
+static void mcc_send_search_cb(struct bt_conn *conn, int err,
 			       struct mpl_search search)
 {
 	if (err) {
@@ -420,7 +420,7 @@ static void mcc_search_ntf_cb(struct bt_conn *conn, int err, uint8_t result_code
 		    result_code);
 }
 
-static void mcc_search_results_obj_id_read_cb(struct bt_conn *conn, int err,
+static void mcc_read_search_results_obj_id_cb(struct bt_conn *conn, int err,
 					      uint64_t id)
 {
 	char str[BT_OTS_OBJ_ID_STR_LEN];
@@ -442,7 +442,7 @@ static void mcc_search_results_obj_id_read_cb(struct bt_conn *conn, int err,
 }
 #endif /* CONFIG_BT_MCC_OTS */
 
-static void mcc_content_control_id_read_cb(struct bt_conn *conn, int err, uint8_t ccid)
+static void mcc_read_content_control_id_cb(struct bt_conn *conn, int err, uint8_t ccid)
 {
 	if (err) {
 		shell_error(ctx_shell, "Content Control ID read failed (%d)", err);
@@ -568,42 +568,42 @@ int cmd_mcc_init(const struct shell *shell, size_t argc, char **argv)
 
 	/* Set up the callbacks */
 	cb.discover_mcs                  = mcc_discover_mcs_cb;
-	cb.player_name_read              = mcc_player_name_read_cb;
+	cb.read_player_name              = mcc_read_player_name_cb;
 #ifdef CONFIG_BT_MCC_OTS
-	cb.icon_obj_id_read              = mcc_icon_obj_id_read_cb;
+	cb.read_icon_obj_id              = mcc_read_icon_obj_id_cb;
 #endif /* CONFIG_BT_MCC_OTS */
-	cb.icon_url_read                 = mcc_icon_url_read_cb;
+	cb.read_icon_url                 = mcc_read_icon_url_cb;
 	cb.track_changed_ntf             = mcc_track_changed_ntf_cb;
-	cb.track_title_read              = mcc_track_title_read_cb;
-	cb.track_duration_read           = mcc_track_duration_read_cb;
-	cb.track_position_read           = mcc_track_position_read_cb;
-	cb.track_position_set            = mcc_track_position_set_cb;
-	cb.playback_speed_read           = mcc_playback_speed_read_cb;
-	cb.playback_speed_set            = mcc_playback_speed_set_cb;
-	cb.seeking_speed_read            = mcc_seeking_speed_read_cb;
+	cb.read_track_title              = mcc_read_track_title_cb;
+	cb.read_track_duration           = mcc_read_track_duration_cb;
+	cb.read_track_position           = mcc_read_track_position_cb;
+	cb.set_track_position            = mcc_set_track_position_cb;
+	cb.read_playback_speed           = mcc_read_playback_speed_cb;
+	cb.set_playback_speed            = mcc_set_playback_speed_cb;
+	cb.read_seeking_speed            = mcc_read_seeking_speed_cb;
 #ifdef CONFIG_BT_MCC_OTS
-	cb.segments_obj_id_read          = mcc_segments_obj_id_read_cb;
-	cb.current_track_obj_id_read     = mcc_current_track_obj_id_read_cb;
-	cb.current_track_obj_id_set      = mcc_current_track_obj_id_set_cb;
-	cb.next_track_obj_id_read        = mcc_next_track_obj_id_read_cb;
-	cb.next_track_obj_id_set         = mcc_next_track_obj_id_set_cb;
-	cb.parent_group_obj_id_read      = mcc_parent_group_obj_id_read_cb;
-	cb.current_group_obj_id_read     = mcc_current_group_obj_id_read_cb;
-	cb.current_group_obj_id_set      = mcc_current_group_obj_id_set_cb;
+	cb.read_segments_obj_id          = mcc_read_segments_obj_id_cb;
+	cb.read_current_track_obj_id     = mcc_read_current_track_obj_id_cb;
+	cb.set_current_track_obj_id      = mcc_set_current_track_obj_id_cb;
+	cb.read_next_track_obj_id        = mcc_read_next_track_obj_id_cb;
+	cb.set_next_track_obj_id         = mcc_set_next_track_obj_id_cb;
+	cb.read_parent_group_obj_id      = mcc_read_parent_group_obj_id_cb;
+	cb.read_current_group_obj_id     = mcc_read_current_group_obj_id_cb;
+	cb.set_current_group_obj_id      = mcc_set_current_group_obj_id_cb;
 #endif /* CONFIG_BT_MCC_OTS */
-	cb.playing_order_read            = mcc_playing_order_read_cb;
-	cb.playing_order_set             = mcc_playing_order_set_cb;
-	cb.playing_orders_supported_read = mcc_playing_orders_supported_read_cb;
-	cb.media_state_read              = mcc_media_state_read_cb;
-	cb.cmd_send                      = mcc_cmd_send_cb;
+	cb.read_playing_order            = mcc_read_playing_order_cb;
+	cb.set_playing_order             = mcc_set_playing_order_cb;
+	cb.read_playing_orders_supported = mcc_read_playing_orders_supported_cb;
+	cb.read_media_state              = mcc_read_media_state_cb;
+	cb.send_cmd                      = mcc_send_cmd_cb;
 	cb.cmd_ntf                       = mcc_cmd_ntf_cb;
-	cb.opcodes_supported_read        = mcc_opcodes_supported_read_cb;
+	cb.read_opcodes_supported        = mcc_read_opcodes_supported_cb;
 #ifdef CONFIG_BT_MCC_OTS
-	cb.search_send                   = mcc_search_send_cb;
+	cb.send_search                   = mcc_send_search_cb;
 	cb.search_ntf                    = mcc_search_ntf_cb;
-	cb.search_results_obj_id_read    = mcc_search_results_obj_id_read_cb;
+	cb.read_search_results_obj_id    = mcc_read_search_results_obj_id_cb;
 #endif /* CONFIG_BT_MCC_OTS */
-	cb.content_control_id_read       = mcc_content_control_id_read_cb;
+	cb.read_content_control_id       = mcc_read_content_control_id_cb;
 #ifdef CONFIG_BT_MCC_OTS
 	cb.otc_obj_selected              = mcc_otc_obj_selected_cb;
 	cb.otc_obj_metadata              = mcc_otc_obj_metadata_cb;

--- a/subsys/bluetooth/shell/media_controller.c
+++ b/subsys/bluetooth/shell/media_controller.c
@@ -493,7 +493,7 @@ static int cmd_media_discover_player(const struct shell *sh, size_t argc, char *
 
 static int cmd_media_read_player_name(const struct shell *sh, size_t argc, char *argv[])
 {
-	int err = media_proxy_ctrl_player_name_get(current_player);
+	int err = media_proxy_ctrl_get_player_name(current_player);
 
 	if (err) {
 		shell_error(ctx_shell, "Player name get failed (%d)", err);
@@ -505,7 +505,7 @@ static int cmd_media_read_player_name(const struct shell *sh, size_t argc, char 
 #ifdef CONFIG_BT_OTS
 static int cmd_media_read_icon_obj_id(const struct shell *sh, size_t argc, char *argv[])
 {
-	int err = media_proxy_ctrl_icon_id_get(current_player);
+	int err = media_proxy_ctrl_get_icon_id(current_player);
 
 	if (err) {
 		shell_error(ctx_shell, "Icon ID get failed (%d)", err);
@@ -517,7 +517,7 @@ static int cmd_media_read_icon_obj_id(const struct shell *sh, size_t argc, char 
 
 static int cmd_media_read_icon_url(const struct shell *sh, size_t argc, char *argv[])
 {
-	int err = media_proxy_ctrl_icon_url_get(current_player);
+	int err = media_proxy_ctrl_get_icon_url(current_player);
 
 	if (err) {
 		shell_error(ctx_shell, "Icon URL get failed (%d)", err);
@@ -528,7 +528,7 @@ static int cmd_media_read_icon_url(const struct shell *sh, size_t argc, char *ar
 
 static int cmd_media_read_track_title(const struct shell *sh, size_t argc, char *argv[])
 {
-	int err = media_proxy_ctrl_track_title_get(current_player);
+	int err = media_proxy_ctrl_get_track_title(current_player);
 
 	if (err) {
 		shell_error(ctx_shell, "Track title get failed (%d)", err);
@@ -539,7 +539,7 @@ static int cmd_media_read_track_title(const struct shell *sh, size_t argc, char 
 
 static int cmd_media_read_track_duration(const struct shell *sh, size_t argc, char *argv[])
 {
-	int err = media_proxy_ctrl_track_duration_get(current_player);
+	int err = media_proxy_ctrl_get_track_duration(current_player);
 
 	if (err) {
 		shell_error(ctx_shell, "Track duration get failed (%d)", err);
@@ -550,7 +550,7 @@ static int cmd_media_read_track_duration(const struct shell *sh, size_t argc, ch
 
 static int cmd_media_read_track_position(const struct shell *sh, size_t argc, char *argv[])
 {
-	int err = media_proxy_ctrl_track_position_get(current_player);
+	int err = media_proxy_ctrl_get_track_position(current_player);
 
 	if (err) {
 		shell_error(ctx_shell, "Track position get failed (%d)", err);
@@ -565,7 +565,7 @@ static int cmd_media_set_track_position(const struct shell *sh, size_t argc,
 	/* Todo: Check input "pos" for validity, or for errors in conversion? */
 	int32_t position = strtol(argv[1], NULL, 0);
 
-	int err = media_proxy_ctrl_track_position_set(current_player, position);
+	int err = media_proxy_ctrl_set_track_position(current_player, position);
 
 	if (err) {
 		shell_error(ctx_shell, "Track position set failed (%d)", err);
@@ -576,7 +576,7 @@ static int cmd_media_set_track_position(const struct shell *sh, size_t argc,
 
 static int cmd_media_read_playback_speed(const struct shell *sh, size_t argc, char *argv[])
 {
-	int err = media_proxy_ctrl_playback_speed_get(current_player);
+	int err = media_proxy_ctrl_get_playback_speed(current_player);
 
 	if (err) {
 		shell_error(ctx_shell, "Playback speed get get failed (%d)", err);
@@ -589,7 +589,7 @@ static int cmd_media_read_playback_speed(const struct shell *sh, size_t argc, ch
 static int cmd_media_set_playback_speed(const struct shell *sh, size_t argc, char *argv[])
 {
 	int8_t speed = strtol(argv[1], NULL, 0);
-	int err = media_proxy_ctrl_playback_speed_set(current_player, speed);
+	int err = media_proxy_ctrl_set_playback_speed(current_player, speed);
 
 	if (err) {
 		shell_error(ctx_shell, "Playback speed set failed (%d)", err);
@@ -600,7 +600,7 @@ static int cmd_media_set_playback_speed(const struct shell *sh, size_t argc, cha
 
 static int cmd_media_read_seeking_speed(const struct shell *sh, size_t argc, char *argv[])
 {
-	int err = media_proxy_ctrl_seeking_speed_get(current_player);
+	int err = media_proxy_ctrl_get_seeking_speed(current_player);
 
 	if (err) {
 		shell_error(ctx_shell, "Seeking speed get failed (%d)", err);
@@ -612,7 +612,7 @@ static int cmd_media_read_seeking_speed(const struct shell *sh, size_t argc, cha
 #ifdef CONFIG_BT_OTS
 static int cmd_media_read_track_segments_obj_id(const struct shell *sh, size_t argc, char *argv[])
 {
-	int err = media_proxy_ctrl_track_segments_id_get(current_player);
+	int err = media_proxy_ctrl_get_track_segments_id(current_player);
 
 	if (err) {
 		shell_error(ctx_shell, "Track segments ID get failed (%d)", err);
@@ -623,7 +623,7 @@ static int cmd_media_read_track_segments_obj_id(const struct shell *sh, size_t a
 
 static int cmd_media_read_current_track_obj_id(const struct shell *sh, size_t argc, char *argv[])
 {
-	int err = media_proxy_ctrl_current_track_id_get(current_player);
+	int err = media_proxy_ctrl_get_current_track_id(current_player);
 
 	if (err) {
 		shell_error(ctx_shell, "Current track ID get failed (%d)", err);
@@ -636,7 +636,7 @@ static int cmd_media_read_current_track_obj_id(const struct shell *sh, size_t ar
 
 static int cmd_media_read_next_track_obj_id(const struct shell *sh, size_t argc, char *argv[])
 {
-	int err = media_proxy_ctrl_next_track_id_get(current_player);
+	int err = media_proxy_ctrl_get_next_track_id(current_player);
 
 	if (err) {
 		shell_error(ctx_shell, "Nect track ID get failed (%d)", err);
@@ -647,7 +647,7 @@ static int cmd_media_read_next_track_obj_id(const struct shell *sh, size_t argc,
 
 static int cmd_media_read_current_group_obj_id(const struct shell *sh, size_t argc, char *argv[])
 {
-	int err = media_proxy_ctrl_current_group_id_get(current_player);
+	int err = media_proxy_ctrl_get_current_group_id(current_player);
 
 	if (err) {
 		shell_error(ctx_shell, "Current group ID get failed (%d)", err);
@@ -659,7 +659,7 @@ static int cmd_media_read_current_group_obj_id(const struct shell *sh, size_t ar
 
 static int cmd_media_read_parent_group_obj_id(const struct shell *sh, size_t argc, char *argv[])
 {
-	int err = media_proxy_ctrl_parent_group_id_get(current_player);
+	int err = media_proxy_ctrl_get_parent_group_id(current_player);
 
 	if (err) {
 		shell_error(ctx_shell, "Parent group ID get failed (%d)", err);
@@ -671,7 +671,7 @@ static int cmd_media_read_parent_group_obj_id(const struct shell *sh, size_t arg
 
 static int cmd_media_read_playing_order(const struct shell *sh, size_t argc, char *argv[])
 {
-	int err = media_proxy_ctrl_playing_order_get(current_player);
+	int err = media_proxy_ctrl_get_playing_order(current_player);
 
 	if (err) {
 		shell_error(ctx_shell, "Playing order get failed (%d)", err);
@@ -684,7 +684,7 @@ static int cmd_media_set_playing_order(const struct shell *sh, size_t argc, char
 {
 	uint8_t order = strtol(argv[1], NULL, 0);
 
-	int err = media_proxy_ctrl_playing_order_set(current_player, order);
+	int err = media_proxy_ctrl_set_playing_order(current_player, order);
 
 	if (err) {
 		shell_error(ctx_shell, "Playing order set failed (%d)", err);
@@ -696,7 +696,7 @@ static int cmd_media_set_playing_order(const struct shell *sh, size_t argc, char
 static int cmd_media_read_playing_orders_supported(const struct shell *sh, size_t argc,
 						   char *argv[])
 {
-	int err = media_proxy_ctrl_playing_orders_supported_get(current_player);
+	int err = media_proxy_ctrl_get_playing_orders_supported(current_player);
 
 	if (err) {
 		shell_error(ctx_shell, "Icon URL get failed (%d)", err);
@@ -707,7 +707,7 @@ static int cmd_media_read_playing_orders_supported(const struct shell *sh, size_
 
 static int cmd_media_read_media_state(const struct shell *sh, size_t argc, char *argv[])
 {
-	int err = media_proxy_ctrl_media_state_get(current_player);
+	int err = media_proxy_ctrl_get_media_state(current_player);
 
 	if (err) {
 		shell_error(ctx_shell, "Icon URL get failed (%d)", err);
@@ -731,7 +731,7 @@ static int cmd_media_send_command(const struct shell *sh, size_t argc, char *arg
 		cmd.param = 0;
 	}
 
-	err = media_proxy_ctrl_command_send(current_player, cmd);
+	err = media_proxy_ctrl_send_command(current_player, cmd);
 
 	if (err) {
 		shell_error(ctx_shell, "Command send failed (%d)", err);
@@ -742,7 +742,7 @@ static int cmd_media_send_command(const struct shell *sh, size_t argc, char *arg
 
 static int cmd_media_read_commands_supported(const struct shell *sh, size_t argc, char *argv[])
 {
-	int err = media_proxy_ctrl_commands_supported_get(current_player);
+	int err = media_proxy_ctrl_get_commands_supported(current_player);
 
 	if (err) {
 		shell_error(ctx_shell, "Commands supported read failed (%d)", err);
@@ -765,7 +765,7 @@ int cmd_media_set_search(const struct shell *sh, size_t argc, char *argv[])
 	memcpy(search.search, argv[1], search.len);
 	BT_DBG("Search string: %s", log_strdup(argv[1]));
 
-	err = media_proxy_ctrl_search_send(current_player, search);
+	err = media_proxy_ctrl_send_search(current_player, search);
 	if (err) {
 		shell_error(ctx_shell, "Search send failed (%d)", err);
 	}
@@ -776,7 +776,7 @@ int cmd_media_set_search(const struct shell *sh, size_t argc, char *argv[])
 static int cmd_media_read_search_results_obj_id(const struct shell *sh, size_t argc,
 						char *argv[])
 {
-	int err = media_proxy_ctrl_search_results_id_get(current_player);
+	int err = media_proxy_ctrl_get_search_results_id(current_player);
 
 	if (err) {
 		shell_error(ctx_shell, "Search results ID get failed (%d)", err);
@@ -789,7 +789,7 @@ static int cmd_media_read_search_results_obj_id(const struct shell *sh, size_t a
 static int cmd_media_read_content_control_id(const struct shell *sh, size_t argc,
 					     char *argv[])
 {
-	int err = media_proxy_ctrl_content_ctrl_id_get(current_player);
+	int err = media_proxy_ctrl_get_content_ctrl_id(current_player);
 
 	if (err) {
 		shell_error(ctx_shell, "Content control ID get failed (%d)", err);

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/mcc_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/mcc_test.c
@@ -92,7 +92,7 @@ static void mcc_discover_mcs_cb(struct bt_conn *conn, int err)
 	SET_FLAG(discovery_done);
 }
 
-static void mcc_player_name_read_cb(struct bt_conn *conn, int err, const char *name)
+static void mcc_read_player_name_cb(struct bt_conn *conn, int err, const char *name)
 {
 	if (err) {
 		FAIL("Player Name read failed (%d)\n", err);
@@ -102,7 +102,7 @@ static void mcc_player_name_read_cb(struct bt_conn *conn, int err, const char *n
 	SET_FLAG(player_name_read);
 }
 
-static void mcc_icon_obj_id_read_cb(struct bt_conn *conn, int err, uint64_t id)
+static void mcc_read_icon_obj_id_cb(struct bt_conn *conn, int err, uint64_t id)
 {
 	if (err) {
 		FAIL("Icon Object ID read failed (%d)", err);
@@ -113,7 +113,7 @@ static void mcc_icon_obj_id_read_cb(struct bt_conn *conn, int err, uint64_t id)
 	SET_FLAG(icon_object_id_read);
 }
 
-static void mcc_icon_url_read_cb(struct bt_conn *conn, int err, const char *url)
+static void mcc_read_icon_url_cb(struct bt_conn *conn, int err, const char *url)
 {
 	if (err) {
 		FAIL("Icon URL read failed (%d)", err);
@@ -133,7 +133,7 @@ static void mcc_track_changed_ntf_cb(struct bt_conn *conn, int err)
 	SET_FLAG(track_change_notified);
 }
 
-static void mcc_track_title_read_cb(struct bt_conn *conn, int err, const char *title)
+static void mcc_read_track_title_cb(struct bt_conn *conn, int err, const char *title)
 {
 	if (err) {
 		FAIL("Track title read failed (%d)", err);
@@ -143,7 +143,7 @@ static void mcc_track_title_read_cb(struct bt_conn *conn, int err, const char *t
 	SET_FLAG(track_title_read);
 }
 
-static void mcc_track_duration_read_cb(struct bt_conn *conn, int err, int32_t dur)
+static void mcc_read_track_duration_cb(struct bt_conn *conn, int err, int32_t dur)
 {
 	if (err) {
 		FAIL("Track duration read failed (%d)", err);
@@ -153,7 +153,7 @@ static void mcc_track_duration_read_cb(struct bt_conn *conn, int err, int32_t du
 	SET_FLAG(track_duration_read);
 }
 
-static void mcc_track_position_read_cb(struct bt_conn *conn, int err, int32_t pos)
+static void mcc_read_track_position_cb(struct bt_conn *conn, int err, int32_t pos)
 {
 	if (err) {
 		FAIL("Track position read failed (%d)", err);
@@ -164,7 +164,7 @@ static void mcc_track_position_read_cb(struct bt_conn *conn, int err, int32_t po
 	SET_FLAG(track_position_read);
 }
 
-static void mcc_track_position_set_cb(struct bt_conn *conn, int err, int32_t pos)
+static void mcc_set_track_position_cb(struct bt_conn *conn, int err, int32_t pos)
 {
 	if (err) {
 		FAIL("Track Position set failed (%d)", err);
@@ -175,7 +175,7 @@ static void mcc_track_position_set_cb(struct bt_conn *conn, int err, int32_t pos
 	SET_FLAG(track_position_set);
 }
 
-static void mcc_playback_speed_read_cb(struct bt_conn *conn, int err,
+static void mcc_read_playback_speed_cb(struct bt_conn *conn, int err,
 				       int8_t speed)
 {
 	if (err) {
@@ -187,7 +187,7 @@ static void mcc_playback_speed_read_cb(struct bt_conn *conn, int err,
 	SET_FLAG(playback_speed_read);
 }
 
-static void mcc_playback_speed_set_cb(struct bt_conn *conn, int err, int8_t speed)
+static void mcc_set_playback_speed_cb(struct bt_conn *conn, int err, int8_t speed)
 {
 	if (err) {
 		FAIL("Playback speed set failed (%d)", err);
@@ -198,7 +198,7 @@ static void mcc_playback_speed_set_cb(struct bt_conn *conn, int err, int8_t spee
 	SET_FLAG(playback_speed_set);
 }
 
-static void mcc_seeking_speed_read_cb(struct bt_conn *conn, int err,
+static void mcc_read_seeking_speed_cb(struct bt_conn *conn, int err,
 				      int8_t speed)
 {
 	if (err) {
@@ -209,7 +209,7 @@ static void mcc_seeking_speed_read_cb(struct bt_conn *conn, int err,
 	SET_FLAG(seeking_speed_read);
 }
 
-static void mcc_segments_obj_id_read_cb(struct bt_conn *conn, int err,
+static void mcc_read_segments_obj_id_cb(struct bt_conn *conn, int err,
 					uint64_t id)
 {
 	if (err) {
@@ -221,7 +221,7 @@ static void mcc_segments_obj_id_read_cb(struct bt_conn *conn, int err,
 	SET_FLAG(track_segments_object_id_read);
 }
 
-static void mcc_current_track_obj_id_read_cb(struct bt_conn *conn, int err,
+static void mcc_read_current_track_obj_id_cb(struct bt_conn *conn, int err,
 					     uint64_t id)
 {
 	if (err) {
@@ -233,7 +233,7 @@ static void mcc_current_track_obj_id_read_cb(struct bt_conn *conn, int err,
 	SET_FLAG(current_track_object_id_read);
 }
 
-static void mcc_current_track_obj_id_set_cb(struct bt_conn *conn, int err,
+static void mcc_set_current_track_obj_id_cb(struct bt_conn *conn, int err,
 					    uint64_t id)
 {
 	if (err) {
@@ -245,7 +245,7 @@ static void mcc_current_track_obj_id_set_cb(struct bt_conn *conn, int err,
 	SET_FLAG(current_track_object_id_set);
 }
 
-static void mcc_next_track_obj_id_read_cb(struct bt_conn *conn, int err,
+static void mcc_read_next_track_obj_id_cb(struct bt_conn *conn, int err,
 					     uint64_t id)
 {
 	if (err) {
@@ -257,7 +257,7 @@ static void mcc_next_track_obj_id_read_cb(struct bt_conn *conn, int err,
 	SET_FLAG(next_track_object_id_read);
 }
 
-static void mcc_next_track_obj_id_set_cb(struct bt_conn *conn, int err,
+static void mcc_set_next_track_obj_id_cb(struct bt_conn *conn, int err,
 					    uint64_t id)
 {
 	if (err) {
@@ -269,7 +269,7 @@ static void mcc_next_track_obj_id_set_cb(struct bt_conn *conn, int err,
 	SET_FLAG(next_track_object_id_set);
 }
 
-static void mcc_parent_group_obj_id_read_cb(struct bt_conn *conn, int err,
+static void mcc_read_parent_group_obj_id_cb(struct bt_conn *conn, int err,
 					    uint64_t id)
 {
 	if (err) {
@@ -281,7 +281,7 @@ static void mcc_parent_group_obj_id_read_cb(struct bt_conn *conn, int err,
 	SET_FLAG(parent_group_object_id_read);
 }
 
-static void mcc_current_group_obj_id_read_cb(struct bt_conn *conn, int err,
+static void mcc_read_current_group_obj_id_cb(struct bt_conn *conn, int err,
 					     uint64_t id)
 {
 	if (err) {
@@ -293,7 +293,7 @@ static void mcc_current_group_obj_id_read_cb(struct bt_conn *conn, int err,
 	SET_FLAG(current_group_object_id_read);
 }
 
-static void mcc_current_group_obj_id_set_cb(struct bt_conn *conn, int err,
+static void mcc_set_current_group_obj_id_cb(struct bt_conn *conn, int err,
 					    uint64_t id)
 {
 	if (err) {
@@ -305,7 +305,7 @@ static void mcc_current_group_obj_id_set_cb(struct bt_conn *conn, int err,
 	SET_FLAG(current_group_object_id_set);
 }
 
-static void mcc_playing_order_read_cb(struct bt_conn *conn, int err, uint8_t order)
+static void mcc_read_playing_order_cb(struct bt_conn *conn, int err, uint8_t order)
 {
 	if (err) {
 		FAIL("Playing order read failed (%d)", err);
@@ -316,7 +316,7 @@ static void mcc_playing_order_read_cb(struct bt_conn *conn, int err, uint8_t ord
 	SET_FLAG(playing_order_read);
 }
 
-static void mcc_playing_order_set_cb(struct bt_conn *conn, int err, uint8_t order)
+static void mcc_set_playing_order_cb(struct bt_conn *conn, int err, uint8_t order)
 {
 	if (err) {
 		FAIL("Playing order set failed (%d)", err);
@@ -327,7 +327,7 @@ static void mcc_playing_order_set_cb(struct bt_conn *conn, int err, uint8_t orde
 	SET_FLAG(playing_order_set);
 }
 
-static void mcc_playing_orders_supported_read_cb(struct bt_conn *conn, int err,
+static void mcc_read_playing_orders_supported_cb(struct bt_conn *conn, int err,
 						 uint16_t orders)
 {
 	if (err) {
@@ -338,7 +338,7 @@ static void mcc_playing_orders_supported_read_cb(struct bt_conn *conn, int err,
 	SET_FLAG(playing_orders_supported_read);
 }
 
-static void mcc_media_state_read_cb(struct bt_conn *conn, int err, uint8_t state)
+static void mcc_read_media_state_cb(struct bt_conn *conn, int err, uint8_t state)
 {
 	if (err) {
 		FAIL("Media State read failed (%d)", err);
@@ -372,7 +372,7 @@ static void mcc_cmd_ntf_cb(struct bt_conn *conn, int err, struct mpl_cmd_ntf ntf
 	SET_FLAG(command_notified);
 }
 
-static void mcc_search_send_cb(struct bt_conn *conn, int err,
+static void mcc_send_search_cb(struct bt_conn *conn, int err,
 			       struct mpl_search search)
 {
 	if (err) {
@@ -395,7 +395,7 @@ static void mcc_search_ntf_cb(struct bt_conn *conn, int err, uint8_t result_code
 	SET_FLAG(search_notified);
 }
 
-static void mcc_search_results_obj_id_read_cb(struct bt_conn *conn, int err,
+static void mcc_read_search_results_obj_id_cb(struct bt_conn *conn, int err,
 					      uint64_t id)
 {
 	if (err) {
@@ -407,7 +407,7 @@ static void mcc_search_results_obj_id_read_cb(struct bt_conn *conn, int err,
 	SET_FLAG(search_results_object_id_read);
 }
 
-static void mcc_content_control_id_read_cb(struct bt_conn *conn, int err, uint8_t ccid)
+static void mcc_read_content_control_id_cb(struct bt_conn *conn, int err, uint8_t ccid)
 {
 	if (err) {
 		FAIL("Content control ID read failed (%d)", err);
@@ -507,35 +507,35 @@ int do_mcc_init(void)
 {
 	/* Set up the callbacks */
 	mcc_cb.discover_mcs                  = mcc_discover_mcs_cb;
-	mcc_cb.player_name_read              = mcc_player_name_read_cb;
-	mcc_cb.icon_obj_id_read              = mcc_icon_obj_id_read_cb;
-	mcc_cb.icon_url_read                 = mcc_icon_url_read_cb;
+	mcc_cb.read_player_name              = mcc_read_player_name_cb;
+	mcc_cb.read_icon_obj_id              = mcc_read_icon_obj_id_cb;
+	mcc_cb.read_icon_url                 = mcc_read_icon_url_cb;
 	mcc_cb.track_changed_ntf             = mcc_track_changed_ntf_cb;
-	mcc_cb.track_title_read              = mcc_track_title_read_cb;
-	mcc_cb.track_duration_read           = mcc_track_duration_read_cb;
-	mcc_cb.track_position_read           = mcc_track_position_read_cb;
-	mcc_cb.track_position_set            = mcc_track_position_set_cb;
-	mcc_cb.playback_speed_read           = mcc_playback_speed_read_cb;
-	mcc_cb.playback_speed_set            = mcc_playback_speed_set_cb;
-	mcc_cb.seeking_speed_read            = mcc_seeking_speed_read_cb;
-	mcc_cb.current_track_obj_id_read     = mcc_current_track_obj_id_read_cb;
-	mcc_cb.current_track_obj_id_set      = mcc_current_track_obj_id_set_cb;
-	mcc_cb.next_track_obj_id_read        = mcc_next_track_obj_id_read_cb;
-	mcc_cb.next_track_obj_id_set         = mcc_next_track_obj_id_set_cb;
-	mcc_cb.segments_obj_id_read          = mcc_segments_obj_id_read_cb;
-	mcc_cb.parent_group_obj_id_read      = mcc_parent_group_obj_id_read_cb;
-	mcc_cb.current_group_obj_id_read     = mcc_current_group_obj_id_read_cb;
-	mcc_cb.current_group_obj_id_set      = mcc_current_group_obj_id_set_cb;
-	mcc_cb.playing_order_read            = mcc_playing_order_read_cb;
-	mcc_cb.playing_order_set             = mcc_playing_order_set_cb;
-	mcc_cb.playing_orders_supported_read = mcc_playing_orders_supported_read_cb;
-	mcc_cb.media_state_read              = mcc_media_state_read_cb;
-	mcc_cb.cmd_send                      = mcc_send_command_cb;
+	mcc_cb.read_track_title              = mcc_read_track_title_cb;
+	mcc_cb.read_track_duration           = mcc_read_track_duration_cb;
+	mcc_cb.read_track_position           = mcc_read_track_position_cb;
+	mcc_cb.set_track_position            = mcc_set_track_position_cb;
+	mcc_cb.read_playback_speed           = mcc_read_playback_speed_cb;
+	mcc_cb.set_playback_speed            = mcc_set_playback_speed_cb;
+	mcc_cb.read_seeking_speed            = mcc_read_seeking_speed_cb;
+	mcc_cb.read_current_track_obj_id     = mcc_read_current_track_obj_id_cb;
+	mcc_cb.set_current_track_obj_id      = mcc_set_current_track_obj_id_cb;
+	mcc_cb.read_next_track_obj_id        = mcc_read_next_track_obj_id_cb;
+	mcc_cb.set_next_track_obj_id         = mcc_set_next_track_obj_id_cb;
+	mcc_cb.read_segments_obj_id          = mcc_read_segments_obj_id_cb;
+	mcc_cb.read_parent_group_obj_id      = mcc_read_parent_group_obj_id_cb;
+	mcc_cb.read_current_group_obj_id     = mcc_read_current_group_obj_id_cb;
+	mcc_cb.set_current_group_obj_id      = mcc_set_current_group_obj_id_cb;
+	mcc_cb.read_playing_order            = mcc_read_playing_order_cb;
+	mcc_cb.set_playing_order             = mcc_set_playing_order_cb;
+	mcc_cb.read_playing_orders_supported = mcc_read_playing_orders_supported_cb;
+	mcc_cb.read_media_state              = mcc_read_media_state_cb;
+	mcc_cb.send_cmd                      = mcc_send_command_cb;
 	mcc_cb.cmd_ntf                       = mcc_cmd_ntf_cb;
-	mcc_cb.search_send                   = mcc_search_send_cb;
+	mcc_cb.send_search                   = mcc_send_search_cb;
 	mcc_cb.search_ntf                    = mcc_search_ntf_cb;
-	mcc_cb.search_results_obj_id_read    = mcc_search_results_obj_id_read_cb;
-	mcc_cb.content_control_id_read       = mcc_content_control_id_read_cb;
+	mcc_cb.read_search_results_obj_id    = mcc_read_search_results_obj_id_cb;
+	mcc_cb.read_content_control_id       = mcc_read_content_control_id_cb;
 	mcc_cb.otc_obj_selected              = mcc_otc_obj_selected_cb;
 	mcc_cb.otc_obj_metadata              = mcc_otc_obj_metadata_cb;
 	mcc_cb.otc_icon_object               = mcc_icon_object_read_cb;

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/media_controller_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/media_controller_test.c
@@ -603,7 +603,7 @@ static bool test_verify_media_state_wait_flags(uint8_t expected_state)
 	int err;
 
 	UNSET_FLAG(media_state_read);
-	err = media_proxy_ctrl_media_state_get(current_player);
+	err = media_proxy_ctrl_get_media_state(current_player);
 	if (err) {
 		FAIL("Failed to read media state: %d", err);
 		return false;
@@ -630,7 +630,7 @@ static void test_send_cmd_wait_flags(struct mpl_cmd cmd)
 
 	UNSET_FLAG(command_sent_flag);
 	UNSET_FLAG(command_results_flag);
-	err = media_proxy_ctrl_command_send(current_player, cmd);
+	err = media_proxy_ctrl_send_command(current_player, cmd);
 	if (err) {
 		FAIL("Failed to send command: %d, opcode: %u",
 		     err, cmd.opcode);
@@ -748,7 +748,7 @@ static void test_cp_move_relative(void)
 	 * if the player is playing.
 	 */
 	UNSET_FLAG(track_position);
-	err = media_proxy_ctrl_track_position_get(current_player);
+	err = media_proxy_ctrl_get_track_position(current_player);
 	if (err) {
 		FAIL("Failed to read track position: %d\n", err);
 		return;
@@ -769,7 +769,7 @@ static void test_cp_move_relative(void)
 	}
 
 	UNSET_FLAG(track_position);
-	err = media_proxy_ctrl_track_position_get(current_player);
+	err = media_proxy_ctrl_get_track_position(current_player);
 	if (err) {
 		FAIL("Failed to read track position: %d\n", err);
 		return;
@@ -893,7 +893,7 @@ static void test_read_current_track_object_id_wait_flags(void)
 	int err;
 
 	UNSET_FLAG(current_track_object_id_read);
-	err = media_proxy_ctrl_current_track_id_get(current_player);
+	err = media_proxy_ctrl_get_current_track_id(current_player);
 	if (err) {
 		FAIL("Failed to read current track object ID: %d", err);
 		return;
@@ -1061,7 +1061,7 @@ static void test_read_current_group_object_id_wait_flags(void)
 	int err;
 
 	UNSET_FLAG(current_group_object_id_read);
-	err = media_proxy_ctrl_current_group_id_get(current_player);
+	err = media_proxy_ctrl_get_current_group_id(current_player);
 	if (err) {
 		FAIL("Failed to read current group object ID: %d", err);
 		return;
@@ -1234,7 +1234,7 @@ static void test_scp(void)
 	 */
 
 	UNSET_FLAG(search_results_object_id_read);
-	err = media_proxy_ctrl_search_results_id_get(current_player);
+	err = media_proxy_ctrl_get_search_results_id(current_player);
 
 	if (err) {
 		FAIL("Failed to read search results object ID: %d", err);
@@ -1272,7 +1272,7 @@ static void test_scp(void)
 	UNSET_FLAG(search_result_code_flag);
 	UNSET_FLAG(search_results_object_id_read);
 
-	err = media_proxy_ctrl_search_send(current_player, search);
+	err = media_proxy_ctrl_send_search(current_player, search);
 	if (err) {
 		FAIL("Failed to write to search control point\n");
 		return;
@@ -1310,7 +1310,7 @@ void test_media_controller_player(struct media_player *player)
 	int err;
 
 	UNSET_FLAG(player_name_read);
-	err = media_proxy_ctrl_player_name_get(current_player);
+	err = media_proxy_ctrl_get_player_name(current_player);
 	if (err) {
 		FAIL("Failed to read media player name ID: %d", err);
 		return;
@@ -1321,7 +1321,7 @@ void test_media_controller_player(struct media_player *player)
 
 	/* Read icon object id  ******************************************/
 	UNSET_FLAG(icon_object_id_read);
-	err = media_proxy_ctrl_icon_id_get(current_player);
+	err = media_proxy_ctrl_get_icon_id(current_player);
 	if (err) {
 		FAIL("Failed to read icon object ID: %d", err);
 		return;
@@ -1332,7 +1332,7 @@ void test_media_controller_player(struct media_player *player)
 
 	/* Read icon url *************************************************/
 	UNSET_FLAG(icon_url_read);
-	err =  media_proxy_ctrl_icon_url_get(current_player);
+	err =  media_proxy_ctrl_get_icon_url(current_player);
 	if (err) {
 		FAIL("Failed to read icon url: %d", err);
 		return;
@@ -1343,7 +1343,7 @@ void test_media_controller_player(struct media_player *player)
 
 	/* Read track_title ******************************************/
 	UNSET_FLAG(track_title_read);
-	err = media_proxy_ctrl_track_title_get(current_player);
+	err = media_proxy_ctrl_get_track_title(current_player);
 	if (err) {
 		FAIL("Failed to read track_title: %d", err);
 		return;
@@ -1354,7 +1354,7 @@ void test_media_controller_player(struct media_player *player)
 
 	/* Read track_duration ******************************************/
 	UNSET_FLAG(track_duration_read);
-	err = media_proxy_ctrl_track_duration_get(current_player);
+	err = media_proxy_ctrl_get_track_duration(current_player);
 	if (err) {
 		FAIL("Failed to read track_duration: %d", err);
 		return;
@@ -1365,7 +1365,7 @@ void test_media_controller_player(struct media_player *player)
 
 	/* Read and set track_position *************************************/
 	UNSET_FLAG(track_position);
-	err = media_proxy_ctrl_track_position_get(current_player);
+	err = media_proxy_ctrl_get_track_position(current_player);
 	if (err) {
 		FAIL("Failed to read track position: %d", err);
 		return;
@@ -1377,7 +1377,7 @@ void test_media_controller_player(struct media_player *player)
 	int32_t pos = g_pos + 1200; /*12 seconds further into the track */
 
 	UNSET_FLAG(track_position);
-	err = media_proxy_ctrl_track_position_set(current_player, pos);
+	err = media_proxy_ctrl_set_track_position(current_player, pos);
 	if (err) {
 		FAIL("Failed to set track position: %d", err);
 		return;
@@ -1393,7 +1393,7 @@ void test_media_controller_player(struct media_player *player)
 
 	/* Read and set playback speed *************************************/
 	UNSET_FLAG(playback_speed);
-	err = media_proxy_ctrl_playback_speed_get(current_player);
+	err = media_proxy_ctrl_get_playback_speed(current_player);
 	if (err) {
 		FAIL("Failed to read playback speed: %d", err);
 		return;
@@ -1405,7 +1405,7 @@ void test_media_controller_player(struct media_player *player)
 	int8_t pb_speed = g_pb_speed + 8; /* 2^(8/64) faster than current speed */
 
 	UNSET_FLAG(playback_speed);
-	err = media_proxy_ctrl_playback_speed_set(current_player, pb_speed);
+	err = media_proxy_ctrl_set_playback_speed(current_player, pb_speed);
 	if (err) {
 		FAIL("Failed to set playback speed: %d", err);
 		return;
@@ -1419,7 +1419,7 @@ void test_media_controller_player(struct media_player *player)
 
 	/* Read seeking speed *************************************/
 	UNSET_FLAG(seeking_speed_read);
-	err = media_proxy_ctrl_seeking_speed_get(current_player);
+	err = media_proxy_ctrl_get_seeking_speed(current_player);
 	if (err) {
 		FAIL("Failed to read seeking speed: %d", err);
 		return;
@@ -1430,7 +1430,7 @@ void test_media_controller_player(struct media_player *player)
 
 	/* Read track segments object *****************************************/
 	UNSET_FLAG(track_segments_object_id_read);
-	err = media_proxy_ctrl_track_segments_id_get(current_player);
+	err = media_proxy_ctrl_get_track_segments_id(current_player);
 	if (err) {
 		FAIL("Failed to read track segments object ID: %d", err);
 		return;
@@ -1441,7 +1441,7 @@ void test_media_controller_player(struct media_player *player)
 
 	/* Read current track object ******************************************/
 	UNSET_FLAG(current_track_object_id_read);
-	err = media_proxy_ctrl_current_track_id_get(current_player);
+	err = media_proxy_ctrl_get_current_track_id(current_player);
 	if (err) {
 		FAIL("Failed to read current track object ID: %d", err);
 		return;
@@ -1452,7 +1452,7 @@ void test_media_controller_player(struct media_player *player)
 
 	/* Read next track object ******************************************/
 	UNSET_FLAG(next_track_object_id_read);
-	err = media_proxy_ctrl_next_track_id_get(current_player);
+	err = media_proxy_ctrl_get_next_track_id(current_player);
 	if (err) {
 		FAIL("Failed to read next track object ID: %d", err);
 		return;
@@ -1463,7 +1463,7 @@ void test_media_controller_player(struct media_player *player)
 
 	/* Read parent group object ******************************************/
 	UNSET_FLAG(parent_group_object_id_read);
-	err = media_proxy_ctrl_parent_group_id_get(current_player);
+	err = media_proxy_ctrl_get_parent_group_id(current_player);
 	if (err) {
 		FAIL("Failed to read parent group object ID: %d", err);
 		return;
@@ -1474,7 +1474,7 @@ void test_media_controller_player(struct media_player *player)
 
 	/* Read current group object ******************************************/
 	UNSET_FLAG(current_group_object_id_read);
-	err = media_proxy_ctrl_current_group_id_get(current_player);
+	err = media_proxy_ctrl_get_current_group_id(current_player);
 	if (err) {
 		FAIL("Failed to read current group object ID: %d", err);
 		return;
@@ -1485,7 +1485,7 @@ void test_media_controller_player(struct media_player *player)
 
 	/* Read and set playing order *************************************/
 	UNSET_FLAG(playing_order_flag);
-	err = media_proxy_ctrl_playing_order_get(current_player);
+	err = media_proxy_ctrl_get_playing_order(current_player);
 	if (err) {
 		FAIL("Failed to read playing order: %d", err);
 		return;
@@ -1503,7 +1503,7 @@ void test_media_controller_player(struct media_player *player)
 	}
 
 	UNSET_FLAG(playing_order_flag);
-	err = media_proxy_ctrl_playing_order_set(current_player, playing_order);
+	err = media_proxy_ctrl_set_playing_order(current_player, playing_order);
 	if (err) {
 		FAIL("Failed to set playing_order: %d", err);
 		return;
@@ -1517,7 +1517,7 @@ void test_media_controller_player(struct media_player *player)
 
 	/* Read playing orders supported  *************************************/
 	UNSET_FLAG(playing_orders_supported_read);
-	err = media_proxy_ctrl_playing_orders_supported_get(current_player);
+	err = media_proxy_ctrl_get_playing_orders_supported(current_player);
 	if (err) {
 		FAIL("Failed to read playing orders supported: %d", err);
 		return;
@@ -1528,7 +1528,7 @@ void test_media_controller_player(struct media_player *player)
 
 	/* Read media state  ***************************************************/
 	UNSET_FLAG(media_state_read);
-	err = media_proxy_ctrl_media_state_get(current_player);
+	err = media_proxy_ctrl_get_media_state(current_player);
 	if (err) {
 		FAIL("Failed to read media state: %d", err);
 		return;
@@ -1539,7 +1539,7 @@ void test_media_controller_player(struct media_player *player)
 
 	/* Read content control ID  *******************************************/
 	UNSET_FLAG(ccid_read);
-	err = media_proxy_ctrl_content_ctrl_id_get(current_player);
+	err = media_proxy_ctrl_get_content_ctrl_id(current_player);
 	if (err) {
 		FAIL("Failed to read content control ID: %d", err);
 		return;


### PR DESCRIPTION
The first commit is a minor cleanup of the media control kconfig file, mainly to add punctuation to the help texts.

The second commit is a pure renaming of API functions, to follow the pattern <module>_<action>_<object>, as discussed in https://github.com/zephyrproject-rtos/zephyr/pull/30892

There are no functional changes in this PR.
