### PR TITLE
drivers: wifi: cc32xx: add AP support

### DIFF
--- a/drivers/wifi/simplelink/Kconfig.simplelink
+++ b/drivers/wifi/simplelink/Kconfig.simplelink
@@ -47,4 +47,49 @@ config WIFI_SIMPLELINK_FAST_CONNECT_TIMEOUT
 	  timeout, the SimpleLink driver will fail to initialize,
 	  and LOG an error.
 
+config WIFI_SIMPLELINK_AP_COUNTRY_CODE
+	string "AP country code"
+	default "US"
+
+config WIFI_SIMPLELINK_AP_IP_ADDR
+	string "AP IPv4 address"
+	default "192.0.2.1"
+	help
+	  Static IP used in AP mode
+
+config WIFI_SIMPLELINK_AP_IP_GW
+	string "AP IPv4 gateway"
+	default "192.0.2.1"
+	help
+	  Static gateway used in AP mode
+
+config WIFI_SIMPLELINK_AP_IP_NETMASK
+	string "AP IPv4 netmask"
+	default "255.255.255.0"
+	help
+	  Static netmask used in AP mode
+
+config WIFI_SIMPLELINK_AP_DHCP
+	bool "Use DHCP server in AP mode"
+	help
+	  Enable DHCP server
+
+config WIFI_SIMPLELINK_AP_DHCP_LEASE_TIME
+	int "DHCP lease time"
+	default 5000
+	range 1 9999
+	depends on WIFI_SIMPLELINK_AP_DHCP
+	help
+	  DHCP server lease time, seconds
+
+config WIFI_SIMPLELINK_AP_DHCP_BEGIN
+	string "First IP used by DHCP"
+	default "192.0.2.10"
+	depends on WIFI_SIMPLELINK_AP_DHCP
+
+config WIFI_SIMPLELINK_AP_DHCP_END
+	string "Last IP used by DHCP"
+	default "192.0.2.16"
+	depends on WIFI_SIMPLELINK_AP_DHCP
+
 endif # WIFI_SIMPLELINK

--- a/drivers/wifi/simplelink/simplelink.c
+++ b/drivers/wifi/simplelink/simplelink.c
@@ -188,6 +188,18 @@ static int simplelink_mgmt_disconnect(const struct device *dev)
 	return ret ? -EIO : ret;
 }
 
+static int simplelink_mgmt_ap(const struct device *dev,
+	struct wifi_connect_req_params *params)
+{
+	return z_simplelink_ap(params);
+}
+
+static int simplelink_mgmt_ap_stop(const struct device *dev)
+{
+	LOG_ERR("stop");
+	return z_simplelink_ap_stop();
+}
+
 static int simplelink_dummy_get(sa_family_t family,
 				enum net_sock_type type,
 				enum net_ip_protocol ip_proto,
@@ -267,6 +279,8 @@ static const struct net_wifi_mgmt_offload simplelink_api = {
 	.scan		= simplelink_mgmt_scan,
 	.connect	= simplelink_mgmt_connect,
 	.disconnect	= simplelink_mgmt_disconnect,
+	.ap_enable	= simplelink_mgmt_ap,
+	.ap_disable	= simplelink_mgmt_ap_stop,
 };
 
 static int simplelink_init(const struct device *dev)

--- a/drivers/wifi/simplelink/simplelink_support.h
+++ b/drivers/wifi/simplelink/simplelink_support.h
@@ -44,6 +44,8 @@ extern void z_simplelink_get_mac(unsigned char *mac);
 extern int z_simplelink_init(simplelink_wifi_cb_t wifi_cb);
 extern int z_simplelink_connect(struct wifi_connect_req_params *params);
 extern int z_simplelink_disconnect(void);
+extern int z_simplelink_ap(struct wifi_connect_req_params *params);
+extern int z_simplelink_ap_stop(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
1) Implement WiFi Ap start/stop functions
2) Add simplelink DHCP support (offload)
3) Implement sock sendmsg
4) Reboot on NWP fatal

Signed-off-by: Pavlo Hamov <p.hamov@venstar.com>