### PR TITLE
kconfig: experimental settings now uses `select EXPERIMENTAL`

### DIFF
--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -328,6 +328,7 @@ config UART_MUX
 	bool "Enable UART muxing (GSM 07.10) support [EXPERIMENTAL]"
 	depends on SERIAL_SUPPORT_INTERRUPT && GSM_MUX
 	select UART_INTERRUPT_DRIVEN
+	select EXPERIMENTAL
 	help
 	  Enable this option to create UART muxer that run over a physical
 	  UART. The GSM 07.10 muxing protocol is used to separate the data

--- a/drivers/crypto/Kconfig
+++ b/drivers/crypto/Kconfig
@@ -8,6 +8,7 @@
 #
 menuconfig CRYPTO
 	bool "Crypto Drivers [EXPERIMENTAL]"
+	select EXPERIMENTAL
 
 if CRYPTO
 
@@ -29,6 +30,7 @@ config CRYPTO_TINYCRYPT_SHIM
 	select TINYCRYPT_AES_CTR
 	select TINYCRYPT_AES_CCM
 	select TINYCRYPT_AES_CMAC
+	select EXPERIMENTAL
 	help
 	  Enable TinyCrypt shim layer compliant with crypto APIs.
 
@@ -51,6 +53,7 @@ config CRYPTO_MBEDTLS_SHIM
 	bool "Enable mbedTLS shim driver [EXPERIMENTAL]"
 	select MBEDTLS
 	select MBEDTLS_ENABLE_HEAP
+	select EXPERIMENTAL
 	help
 	  Enable mbedTLS shim layer compliant with crypto APIs. You will need
 	  to fill in a relevant value to CONFIG_MBEDTLS_HEAP_SIZE.

--- a/drivers/ethernet/Kconfig.e1000
+++ b/drivers/ethernet/Kconfig.e1000
@@ -27,6 +27,7 @@ config ETH_E1000_VERBOSE_DEBUG
 config ETH_E1000_PTP_CLOCK
 	bool "Enable PTP clock driver support [EXPERIMENTAL]"
 	depends on PTP_CLOCK
+	select EXPERIMENTAL
 	default y
 	help
 	  Enable PTP clock support. This is still a dummy that is only used

--- a/drivers/gpio/Kconfig.emul
+++ b/drivers/gpio/Kconfig.emul
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config GPIO_EMUL
-	bool "[EXPERIMENTAL] Emulated GPIO driver"
+	bool "Emulated GPIO driver"
 	help
 	  Enable the emulated GPIO driver. Mainly used for testing, this
 	  driver allows for an arbitrary number of emulated GPIO controllers

--- a/drivers/lora/Kconfig
+++ b/drivers/lora/Kconfig
@@ -10,6 +10,7 @@ menuconfig LORA
 	bool "LoRa support [EXPERIMENTAL]"
 	select REQUIRES_FULL_LIBC
 	select POLL
+	select EXPERIMENTAL
 	help
 	  Include LoRa drivers in the system configuration.
 

--- a/drivers/memc/Kconfig
+++ b/drivers/memc/Kconfig
@@ -5,6 +5,7 @@
 
 menuconfig MEMC
 	bool "Memory controllers [EXPERIMENTAL]"
+	select EXPERIMENTAL
 	help
 	  Add support for memory controllers
 

--- a/drivers/modem/Kconfig
+++ b/drivers/modem/Kconfig
@@ -38,6 +38,7 @@ config MODEM_RECEIVER_MAX_CONTEXTS
 
 config MODEM_CONTEXT
 	bool "Modem context helper driver [EXPERIMENTAL]"
+	select EXPERIMENTAL
 	help
 	  This driver allows modem drivers to communicate with an interface
 	  using custom defined protocols. Driver doesn't inspect received data

--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -53,10 +53,10 @@ config UART_USE_RUNTIME_CONFIGURE
 	  applications that do not require runtime UART configuration.
 
 config UART_ASYNC_API
-	bool "Enable new asynchronous UART API [EXPERIMENTAL]"
+	bool "Enable asynchronous UART API"
 	depends on SERIAL_SUPPORT_ASYNC
 	help
-	  This option enables new asynchronous UART API.
+	  This option enables asynchronous UART API.
 
 config UART_INTERRUPT_DRIVEN
 	bool "Enable UART Interrupt support"

--- a/drivers/spi/Kconfig
+++ b/drivers/spi/Kconfig
@@ -21,6 +21,7 @@ config SPI_ASYNC
 
 config SPI_SLAVE
 	bool "Enable Slave support [EXPERIMENTAL]"
+	select EXPERIMENTAL
 	help
 	  Enables Driver SPI slave operations. Slave support depends
 	  on the driver and the hardware it runs on.

--- a/drivers/timer/Kconfig.stm32_lptim
+++ b/drivers/timer/Kconfig.stm32_lptim
@@ -8,6 +8,7 @@ menuconfig STM32_LPTIM_TIMER
 	depends on "$(dt_nodelabel_enabled,lptim1)"
 	depends on CLOCK_CONTROL && PM
 	select TICKLESS_CAPABLE
+	select EXPERIMENTAL
 	help
 	  This module implements a kernel device driver for the LowPower Timer
 	  and provides the standard "system clock driver" interfaces.

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -343,6 +343,7 @@ endmenu
 config GDBSTUB
 	bool "GDB remote serial protocol support [EXPERIMENTAL]"
 	depends on ARCH_HAS_GDBSTUB
+	select EXPERIMENTAL
 	help
 	  This option enable support the target using GDB, or any other
 	  application that supports GDB protocol.

--- a/subsys/lorawan/Kconfig
+++ b/subsys/lorawan/Kconfig
@@ -8,6 +8,7 @@ menuconfig LORAWAN
 	depends on LORA
 	select HAS_SEMTECH_LORAMAC
 	select HAS_SEMTECH_SOFT_SE
+	select EXPERIMENTAL
 	help
 	  This option enables LoRaWAN support.
 

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -38,7 +38,7 @@ config NET_NATIVE_UDP
 	default y if NET_UDP
 
 config NET_OFFLOAD
-	bool "Offload IP stack [EXPERIMENTAL]"
+	bool "Offload IP stack"
 	help
 	  Enables TCP/IP stack to be offload to a co-processor.
 
@@ -211,6 +211,7 @@ config NET_TC_THREAD_COOPERATIVE
 config NET_TC_THREAD_PREEMPTIVE
 	bool "Use pre-emptive TX/RX threads [EXPERIMENTAL]"
 	depends on PREEMPT_ENABLED
+	select EXPERIMENTAL
 	help
 	  With pre-emptive threads, the thread can be pre-empted.
 
@@ -664,6 +665,7 @@ config NET_BUF_FIXED_DATA_SIZE
 
 config NET_BUF_VARIABLE_DATA_SIZE
 	bool "Variable data size buffer [EXPERIMENTAL]"
+	select EXPERIMENTAL
 	help
 	  The buffer is dynamically allocated from runtime requested size.
 
@@ -825,7 +827,7 @@ config NET_PKT_TXTIME_STATS_DETAIL
 	  command.
 
 config NET_PROMISCUOUS_MODE
-	bool "Enable promiscuous mode support [EXPERIMENTAL]"
+	bool "Enable promiscuous mode support"
 	select NET_MGMT
 	select NET_MGMT_EVENT
 	select NET_L2_ETHERNET_MGMT if NET_L2_ETHERNET

--- a/subsys/net/ip/Kconfig.ipv4
+++ b/subsys/net/ip/Kconfig.ipv4
@@ -75,6 +75,7 @@ config NET_DHCPV4_INITIAL_DELAY_MAX
 config NET_IPV4_AUTO
 	bool "Enable IPv4 autoconfiguration [EXPERIMENTAL]"
 	depends on NET_ARP
+	select EXPERIMENTAL
 	help
 	  Enables IPv4 auto IP address configuration (see RFC 3927)
 

--- a/subsys/net/l2/ethernet/gptp/Kconfig
+++ b/subsys/net/l2/ethernet/gptp/Kconfig
@@ -4,6 +4,7 @@
 menuconfig NET_GPTP
 	bool "Enable IEEE 802.1AS (gPTP) support [EXPERIMENTAL]"
 	select NET_L2_PTP
+	select EXPERIMENTAL
 	help
 	  Enable gPTP driver that send and receives gPTP packets
 	  and handles network packet timestamps.

--- a/subsys/net/l2/ieee802154/Kconfig
+++ b/subsys/net/l2/ieee802154/Kconfig
@@ -115,6 +115,7 @@ config NET_L2_IEEE802154_REASSEMBLY_TIMEOUT
 
 config NET_L2_IEEE802154_SECURITY
 	bool "Enable IEEE 802.15.4 security [EXPERIMENTAL]"
+	select EXPERIMENTAL
 	help
 	  Enable 802.15.4 frame security handling, in order to bring data
 	  confidentiality and authenticity.

--- a/subsys/net/l2/ppp/Kconfig
+++ b/subsys/net/l2/ppp/Kconfig
@@ -3,6 +3,7 @@
 
 menuconfig NET_L2_PPP
 	bool "Enable point-to-point (PPP) support [EXPERIMENTAL]"
+	select EXPERIMENTAL
 	help
 	  Add support for PPP.
 

--- a/subsys/net/lib/conn_mgr/Kconfig
+++ b/subsys/net/lib/conn_mgr/Kconfig
@@ -7,6 +7,7 @@ menuconfig NET_CONNECTION_MANAGER
 	select NET_MGMT
 	select NET_MGMT_EVENT
 	select NET_MGMT_EVENT_INFO
+	select EXPERIMENTAL
 	help
 	  When enabled, this will start the connection manager that will
 	  listen to network interface and IP events in order to verify

--- a/subsys/net/lib/http/Kconfig
+++ b/subsys/net/lib/http/Kconfig
@@ -26,6 +26,7 @@ config HTTP_CLIENT
 	bool "HTTP client API [EXPERIMENTAL]"
 	select HTTP_PARSER
 	select HTTP_PARSER_URL
+	select EXPERIMENTAL
 	help
 	  HTTP client API
 

--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -68,6 +68,7 @@ config NET_SOCKETS_SOCKOPT_TLS
 	bool "Enable TCP TLS socket option support [EXPERIMENTAL]"
 	imply TLS_CREDENTIALS
 	select MBEDTLS if NET_NATIVE
+	select EXPERIMENTAL
 	help
 	  Enable TLS socket option support which automatically establishes
 	  a TLS connection to the remote host.
@@ -99,6 +100,7 @@ config NET_SOCKETS_ENABLE_DTLS
 	bool "Enable DTLS socket support [EXPERIMENTAL]"
 	depends on NET_SOCKETS_SOCKOPT_TLS
 	select MBEDTLS_DTLS if NET_NATIVE
+	select EXPERIMENTAL
 	help
 	  Enable DTLS socket support. By default only TLS over TCP is supported.
 
@@ -152,6 +154,7 @@ config NET_SOCKETS_TLS_MAX_APP_PROTOCOLS
 
 config NET_SOCKETS_OFFLOAD
 	bool "Offload Socket APIs [EXPERIMENTAL]"
+	select EXPERIMENTAL
 	help
 	  Enables direct offloading of socket operations to dedicated TCP/IP
 	  hardware.
@@ -196,6 +199,7 @@ config NET_SOCKETS_PACKET_DGRAM
 config NET_SOCKETS_CAN
 	bool "Enable socket CAN support [EXPERIMENTAL]"
 	select NET_L2_CANBUS_RAW
+	select EXPERIMENTAL
 	help
 	  The value depends on your network needs.
 
@@ -209,6 +213,7 @@ config NET_SOCKETS_CAN_RECEIVERS
 
 config NET_SOCKETPAIR
 	bool "Support for the socketpair syscall [EXPERIMENTAL]"
+	select EXPERIMENTAL
 	depends on HEAP_MEM_POOL_SIZE != 0
 	help
 	  Choose y here if you would like to use the socketpair(2)
@@ -226,6 +231,7 @@ config NET_SOCKETS_NET_MGMT
 	bool "Enable network management socket support [EXPERIMENTAL]"
 	depends on NET_MGMT_EVENT
 	select NET_MGMT_EVENT_INFO
+	select EXPERIMENTAL
 	help
 	  Select this if you want to use socket API to get network
 	  managements events to your application.

--- a/subsys/net/lib/tftp/Kconfig
+++ b/subsys/net/lib/tftp/Kconfig
@@ -7,6 +7,7 @@ config TFTP_LIB
 	bool "Socket TFTP Library Support [EXPERIMENTAL]"
 	select NET_SOCKETS
 	select NET_SOCKETS_POSIX_NAMES
+	select EXPERIMENTAL
 	help
 	  Enable the Zephyr TFTP Library
 

--- a/subsys/net/lib/websocket/Kconfig
+++ b/subsys/net/lib/websocket/Kconfig
@@ -9,6 +9,7 @@ menuconfig WEBSOCKET_CLIENT
 	select HTTP_CLIENT
 	select MBEDTLS
 	select BASE64
+	select EXPERIMENTAL
 	help
 	  Enable Websocket client library.
 

--- a/subsys/shell/Kconfig.backends
+++ b/subsys/shell/Kconfig.backends
@@ -230,7 +230,8 @@ config SHELL_TELNET_SEND_TIMEOUT
 	  in when a line buffer is not empty but did not yet meet the line feed.
 
 config SHELL_TELNET_SUPPORT_COMMAND
-	bool "Add support for telnet commands (IAC) [Experimental]"
+	bool "Add support for telnet commands (IAC) [EXPERIMENTAL]"
+	select EXPERIMENTAL
 	help
 	  Current support is so limited it's not interesting to enable it.
 	  However, if proven to be needed at some point, it will be possible


### PR DESCRIPTION
Continuation of: #33566

This PR is opened independently to allow proper review of all setting having experimental in their title, as requested at API-meeting:
See https://github.com/zephyrproject-rtos/zephyr/pull/33566#issuecomment-810396251
> Review all options that are currently marked as EXPERIMENTAL in their title

To reviewers, the important thing to review is not whether the `select EXPERIMENTAL` is correct but to consider whether or not the feature itself is still experimental or if `EXPERIMENTAL` should be removed.

**If approving the PR, then please make a comment regarding which area you have verified, for example:**
> EXPERIMENTAL on subsys/net verified


Also, if you have the knowledge, then as per: https://lwn.net/Articles/520867/
>  For items that really are experimental, maintainers should use "default
>  n", optionally include "(EXPERIMENTAL)" in the title, and add language to
>  the help text indicating why the item should be considered experimental.

feel free to add a comment under the setting stating why the feature is considered experimental and I will update the help text with the proposed text in this PR.
