### PR TITLE
stats: Fix format specifier type in shell_printf() usage

### DIFF
--- a/subsys/stats/stats_shell.c
+++ b/subsys/stats/stats_shell.c
@@ -33,7 +33,7 @@ static int stats_group_cb(struct stats_hdr *hdr, void *arg)
 {
 	struct shell *sh = arg;
 
-	shell_print(sh, "Stats Group %s (hdr addr: %x)", hdr->s_name, (void *)hdr);
+	shell_print(sh, "Stats Group %s (hdr addr: %p)", hdr->s_name, (void *)hdr);
 	return stats_walk(hdr, stats_cb, arg);
 }
 


### PR DESCRIPTION
Fixes the format specifier type in a call to shell_printf().
Instead of printing with %x (which expects an unsigned int) for
an address, it is now using %p.

Signed-off-by: Peter Mitsis <peter.mitsis@intel.com>