### PR TITLE
drivers: lpuart: Fix Usage Fault on MIMXRT1064 shell fs sample

### DIFF
--- a/arch/arm/core/aarch32/cortex_m/exc_exit.S
+++ b/arch/arm/core/aarch32/cortex_m/exc_exit.S
@@ -84,6 +84,8 @@ SECTION_SUBSEC_FUNC(TEXT, _HandlerModeExit, z_arm_exc_exit)
 _ExcExitWithGdbStub:
 
 _EXIT_EXC:
+	dsb
+	isb
 #endif /* CONFIG_PREEMPT_ENABLED */
 
 #ifdef CONFIG_STACK_SENTINEL


### PR DESCRIPTION
This commit fixes a usage fault encountered on the MIMXRT1064 EVK. The usage fault occurs when running the shell fs example (samples/subsys/shell/fs) between commits 0a50ebe and 30cd046. The specific issue is caused by the LPUART interrupt firing directly after being enabled, putting the chip into a bad state. This results in GDB reporting that 'program memory is no longer writable", and instructions not executing as expected (for example, `ldm` does not actually load data into the registers provided to it). The actual usage fault occurs at [this line](https://github.com/zephyrproject-rtos/zephyr/blob/30cd0467600711d2cfc40e7943cdf3bedc7de2c6/arch/arm/core/aarch32/isr_wrapper.S#L234) of isr_wrapper.S.

Fixes #39340 