### PR TITLE
west: spdx: Fix --init for Windows builds

### DIFF
--- a/scripts/west_commands/zspdx/sbom.py
+++ b/scripts/west_commands/zspdx/sbom.py
@@ -55,8 +55,9 @@ def setupCmakeQuery(build_dir):
         # file exists, we're good
         return True
     else:
-        # file doesn't exist, let's create it
-        os.mknod(queryFilePath)
+        # file doesn't exist, let's create an empty file
+        cm_fd = open(queryFilePath, "w")
+        cm_fd.close()
         return True
 
 # main entry point for SBOM maker


### PR DESCRIPTION
Currently, west spdx --init uses os.mknod to create an empty file
to enable the Cmake file-based API system. As reported in #39311,
Python on Windows does not implement os.mknod.

This commit switches to using open()/close() instead of os.mknod()
to address this issue.

Fixes #39311 

Signed-off-by: Steve Winslow <steve@swinslow.net>