### PR TITLE
tests: bluetooth: tester: Add support for L2CAP channels options

### DIFF
--- a/tests/bluetooth/tester/src/bttester.h
+++ b/tests/bluetooth/tester/src/bttester.h
@@ -739,6 +739,9 @@ struct l2cap_read_supported_commands_rp {
 	uint8_t data[0];
 } __packed;
 
+#define L2CAP_CONNECT_OPT_ECFC		0x01
+#define L2CAP_CONNECT_OPT_HOLD_CREDIT	0x02
+
 #define L2CAP_CONNECT			0x02
 struct l2cap_connect_cmd {
 	uint8_t address_type;
@@ -746,7 +749,7 @@ struct l2cap_connect_cmd {
 	uint16_t psm;
 	uint16_t mtu;
 	uint8_t num;
-	uint8_t ecfc;
+	uint8_t options;
 } __packed;
 struct l2cap_connect_rp {
 	uint8_t num;


### PR DESCRIPTION
This allows for better control over IUT behaviour by Upper Tester.

PTS and TS require inconsistent behaviour in terms of how IUT should
return credits. Some tests require return on explicit UT request and
some require that IUT returns credits autonomously.

Signed-off-by: Szymon Janc <szymon.janc@codecoup.pl>