### PR TITLE
arm64: add nocache memory segment support

### DIFF
--- a/arch/arm64/core/Kconfig
+++ b/arch/arm64/core/Kconfig
@@ -104,6 +104,7 @@ config ARMV8_A
 	select ATOMIC_OPERATIONS_BUILTIN
 	select CPU_HAS_MMU
 	select ARCH_HAS_USERSPACE if ARM_MMU
+	select ARCH_HAS_NOCACHE_MEMORY_SUPPORT if ARM_MMU
 	help
 	  This option signifies the use of an ARMv8-A processor
 	  implementation.

--- a/arch/arm64/core/mmu.c
+++ b/arch/arm64/core/mmu.c
@@ -668,6 +668,14 @@ static const struct arm_mmu_flat_range mmu_zephyr_ranges[] = {
 	  .start = __rodata_region_start,
 	  .end   = __rodata_region_end,
 	  .attrs = MT_NORMAL | MT_P_RO_U_RO | MT_DEFAULT_SECURE_STATE },
+
+#ifdef CONFIG_NOCACHE_MEMORY
+	/* Mark nocache segment noncachable, read-write and execute-never */
+	{ .name  = "nocache_data",
+	  .start = _nocache_ram_start,
+	  .end   = _nocache_ram_end,
+	  .attrs = MT_NORMAL_NC | MT_P_RW_U_RW | MT_DEFAULT_SECURE_STATE },
+#endif
 };
 
 static inline void add_arm_mmu_flat_range(struct arm_mmu_ptables *ptables,

--- a/arch/common/nocache.ld
+++ b/arch/common/nocache.ld
@@ -10,11 +10,19 @@
 /* Non-cached region of RAM */
 SECTION_DATA_PROLOGUE(_NOCACHE_SECTION_NAME,(NOLOAD),)
 {
+#if defined(CONFIG_MMU)
+	MMU_ALIGN;
+#else
 	MPU_ALIGN(_nocache_ram_size);
+#endif
 	_nocache_ram_start = .;
 	*(.nocache)
 	*(".nocache.*")
+#if defined(CONFIG_MMU)
+	MMU_ALIGN;
+#else
 	MPU_ALIGN(_nocache_ram_size);
+#endif
 	_nocache_ram_end = .;
 } GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
 _nocache_ram_size = _nocache_ram_end - _nocache_ram_start;


### PR DESCRIPTION
In some drivers, noncache memory need to be used for dma coherent
memroy, so add nocache memory segment mapping and support for ARM64
platforms.

The following variables definition example shows they will use nocache
memory allocation:
   int var1 __nocache;
   int var2 __attribute__((__section__(".nocache")));

Signed-off-by: Jiafei Pan <Jiafei.Pan@nxp.com>