### PR TITLE
Bluetooth: host: Make sure request is removed from channel's list

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -251,6 +251,7 @@ static int chan_req_send(struct bt_att_chan *chan, struct bt_att_req *req)
 	if (err) {
 		/* We still have the ownership of the buffer */
 		req->buf = buf;
+		chan->req = NULL;
 	}
 
 	return err;

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -2518,7 +2518,6 @@ struct net_buf *bt_att_create_pdu(struct bt_conn *conn, uint8_t op, size_t len)
 
 static void att_reset(struct bt_att *att)
 {
-	struct bt_att_req *req, *tmp;
 	struct net_buf *buf;
 
 #if CONFIG_BT_ATT_PREPARE_COUNT > 0
@@ -2535,7 +2534,12 @@ static void att_reset(struct bt_att *att)
 	att->conn = NULL;
 
 	/* Notify pending requests */
-	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&att->reqs, req, tmp, node) {
+	while (!sys_slist_is_empty(&att->reqs)) {
+		struct bt_att_req *req;
+		sys_snode_t *node;
+
+		node = sys_slist_get_not_empty(&att->reqs);
+		req = CONTAINER_OF(node, struct bt_att_req, node);
 		if (req->func) {
 			req->func(NULL, BT_ATT_ERR_UNLIKELY, NULL, 0,
 				  req->user_data);


### PR DESCRIPTION
Request has to be removed from channel's ATT request list to avoid
corrupting the list. Without this change this could happen when
att_handle_rsp was called:

1. reqs before call:
head: 0x2000f8e8, tail: 0x2000f8c0, elements:
- addr 0x2000f8e8, function pointer NULL
- addr 0x2000f8c0, function pointer 0x35c1d

2. att_handle_rsp called, calling bt_att_req_free with address
0x2000f8e8

3. reqs after call:
head: 0x2000f8e8, tail:	0x2000f8c0, elements:
- addr 0x2000f8e8, function pointer NULL
- addr 0x2000f8d4, function pointer NULL
- addr 0x2000f8ac, function pointer NULL
- addr 0x2000f898, function pointer NULL
- addr 0x2000f884, function pointer NULL
- addr 0x2000f870, function pointer 0xd92b7e7c
- addr 0x2000f85c, function pointer 0x462a03a9
- addr 0x2000f848, function pointer 0xf77b2f4b
- addr 0x2000f834, function pointer 0x33714775
- addr 0x2000f820, function pointer 0x31ba37f8
- addr 0x2000f80c, function pointer 0x5fda8494
- addr 0x2000f7f8, function pointer 0xbcff174e
- addr 0x2000f7e4, function pointer 0x341393f
- addr 0x2000f7d0, function pointer 0xbcfee8b8
- addr 0x2000f7bc, function pointer 0x1e73d9e5

which obviously is broken.

Closes #39506.

Signed-off-by: Jacob Siverskog <jacob@teenage.engineering>