### PR TITLE
samples: shell_module: fix build on 64bit platforms

### DIFF
--- a/samples/subsys/shell/shell_module/src/main.c
+++ b/samples/subsys/shell/shell_module/src/main.c
@@ -154,9 +154,9 @@ static int cmd_demo_getopt(const struct shell *shell, size_t argc, char **argv)
 
 static int cmd_demo_params(const struct shell *shell, size_t argc, char **argv)
 {
-	shell_print(shell, "argc = %d", argc);
+	shell_print(shell, "argc = %zd", argc);
 	for (size_t cnt = 0; cnt < argc; cnt++) {
-		shell_print(shell, "  argv[%d] = %s", cnt, argv[cnt]);
+		shell_print(shell, "  argv[%zd] = %s", cnt, argv[cnt]);
 	}
 
 	return 0;
@@ -164,9 +164,9 @@ static int cmd_demo_params(const struct shell *shell, size_t argc, char **argv)
 
 static int cmd_demo_hexdump(const struct shell *shell, size_t argc, char **argv)
 {
-	shell_print(shell, "argc = %d", argc);
+	shell_print(shell, "argc = %zd", argc);
 	for (size_t cnt = 0; cnt < argc; cnt++) {
-		shell_print(shell, "argv[%d]", cnt);
+		shell_print(shell, "argv[%zd]", cnt);
 		shell_hexdump(shell, argv[cnt], strlen(argv[cnt]));
 	}
 


### PR DESCRIPTION
After the __printf_like validation was added to the shell_fprintf functions we got warnings while building the 'samples/subsys/shell/shell_module' due to incorrect specifiers while printing size_t variables. Fix that.

Fixes: #39386
Fixes: fe2075d140 "shell: Add __printf_like to shell_fprintf"