### PR TITLE
drivers: sensor_shell: add missing power sensor channel

### DIFF
--- a/drivers/sensor/sensor_shell.c
+++ b/drivers/sensor/sensor_shell.c
@@ -49,6 +49,7 @@ const char *sensor_channel_name[SENSOR_CHAN_ALL] = {
 	[SENSOR_CHAN_GAS_RES] =		"gas_resistance",
 	[SENSOR_CHAN_VOLTAGE] =		"voltage",
 	[SENSOR_CHAN_CURRENT] =		"current",
+	[SENSOR_CHAN_POWER] =		"power",
 	[SENSOR_CHAN_RESISTANCE] =	"resistance",
 	[SENSOR_CHAN_ROTATION] =	"rotation",
 	[SENSOR_CHAN_POS_DX] =		"pos_dx",


### PR DESCRIPTION
There is no power channel within the name array that
is used by e.g INA23X so let's add it to have support
in sensor shell commands.

Signed-off-by: Bartosz Bilas <b.bilas@grinn-global.com>