### PR TITLE
esp32: fix unable to start debugserver or debug session with west

### DIFF
--- a/boards/xtensa/esp32/board.cmake
+++ b/boards/xtensa/esp32/board.cmake
@@ -7,6 +7,9 @@ board_runner_args(openocd  --cmd-pre-init "set ESP32_ONLYCPU 1")
 board_runner_args(openocd  --config "interface/ftdi/esp32_devkitj_v1.cfg")
 board_runner_args(openocd  --config "target/esp32.cfg")
 
+# Don't use default reset/halt commands
+board_runner_args(openocd  --no-cmd-reset-halt)
+
 set (ESPRESSIF_OPENOCD_TOOL ${ESPRESSIF_TOOLCHAIN_PATH}/openocd-esp32/bin/openocd)
 set (ESPRESSIF_OPENOCD_SCRIPTS ${ESPRESSIF_TOOLCHAIN_PATH}/openocd-esp32/share/openocd/scripts)
 


### PR DESCRIPTION
ESP32's OpenOCD won't start if "-c `reset halt`" is passed as command line arguments (which is the default in openocd west runner), complaining 'reset' being invalid command name. So change the openocd west runner script to allow skipping this command, and ESP32 not using these commands.