### PR TITLE
openocd: esp32: add openocd config file

### DIFF
--- a/boards/common/esp32.board.cmake
+++ b/boards/common/esp32.board.cmake
@@ -5,8 +5,6 @@ board_set_debugger_ifnset(openocd)
 
 board_runner_args(openocd  --no-init --no-halt --no-targets --no-load)
 board_runner_args(openocd  --gdb-init "set remote hardware-watchpoint-limit 2")
-board_runner_args(openocd  --gdb-init "set disassemble-next-line on")
-board_runner_args(openocd  --gdb-init "set print pretty on")
 
 board_runner_args(openocd  --gdb-init "flushregs")
 board_runner_args(openocd  --gdb-init "mon reset halt")

--- a/boards/riscv/esp32c3_devkitm/board.cmake
+++ b/boards/riscv/esp32c3_devkitm/board.cmake
@@ -1,3 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(NOT "${OPENOCD}" MATCHES "^${ESPRESSIF_TOOLCHAIN_PATH}/.*")
+  set(OPENOCD OPENOCD-NOTFOUND)
+endif()
+find_program(OPENOCD openocd PATHS ${ESPRESSIF_TOOLCHAIN_PATH}/openocd-esp32/bin NO_DEFAULT_PATH)
+
 include(${ZEPHYR_BASE}/boards/common/esp32.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/riscv/esp32c3_devkitm/support/openocd.cfg
+++ b/boards/riscv/esp32c3_devkitm/support/openocd.cfg
@@ -1,0 +1,11 @@
+set ESP_RTOS none
+
+# ESP32C3 has built-in JTAG interface over USB port in pins GPIO18/GPIO19 (D-/D+).
+# Uncomment the line below to enable USB debugging.
+# source [find interface/esp_usb_jtag.cfg]
+
+# Otherwise, use external JTAG programmer as ESP-Prog
+source [find interface/ftdi/esp32_devkitj_v1.cfg]
+
+source [find target/esp32c3.cfg]
+adapter_khz 5000

--- a/boards/xtensa/esp32/board.cmake
+++ b/boards/xtensa/esp32/board.cmake
@@ -1,17 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(openocd  --cmd-pre-init "set ESP_RTOS none")
-board_runner_args(openocd  --cmd-pre-init "set ESP32_ONLYCPU 1")
-
-# select FT2232 as default interface (as in ESP-WROVER-KIT or ESP-Prog)
-board_runner_args(openocd  --config "interface/ftdi/esp32_devkitj_v1.cfg")
-board_runner_args(openocd  --config "target/esp32.cfg")
-
-set (ESPRESSIF_OPENOCD_TOOL ${ESPRESSIF_TOOLCHAIN_PATH}/openocd-esp32/bin/openocd)
-set (ESPRESSIF_OPENOCD_SCRIPTS ${ESPRESSIF_TOOLCHAIN_PATH}/openocd-esp32/share/openocd/scripts)
-
-set(OPENOCD ${ESPRESSIF_OPENOCD_TOOL})
-set(OPENOCD_DEFAULT_PATH ${ESPRESSIF_OPENOCD_SCRIPTS})
+if(NOT "${OPENOCD}" MATCHES "^${ESPRESSIF_TOOLCHAIN_PATH}/.*")
+  set(OPENOCD OPENOCD-NOTFOUND)
+endif()
+find_program(OPENOCD openocd PATHS ${ESPRESSIF_TOOLCHAIN_PATH}/openocd-esp32/bin NO_DEFAULT_PATH)
 
 include(${ZEPHYR_BASE}/boards/common/esp32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/xtensa/esp32/support/openocd.cfg
+++ b/boards/xtensa/esp32/support/openocd.cfg
@@ -1,0 +1,5 @@
+set ESP_RTOS none
+set ESP32_ONLYCPU 1
+
+source [find interface/ftdi/esp32_devkitj_v1.cfg]
+source [find target/esp32.cfg]

--- a/boards/xtensa/esp32s2_saola/board.cmake
+++ b/boards/xtensa/esp32s2_saola/board.cmake
@@ -1,17 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(openocd  --cmd-pre-init "set ESP_RTOS none")
-board_runner_args(openocd  --cmd-pre-init "set ESP32_ONLYCPU 1")
-
-# select FT2232 as default interface (as in ESP-WROVER-KIT or ESP-Prog)
-board_runner_args(openocd  --config "interface/ftdi/esp32s2_kaluga_v1.cfg")
-board_runner_args(openocd  --config "target/esp32s2.cfg")
-
-set (ESPRESSIF_OPENOCD_TOOL ${ESPRESSIF_TOOLCHAIN_PATH}/openocd-esp32/bin/openocd)
-set (ESPRESSIF_OPENOCD_SCRIPTS ${ESPRESSIF_TOOLCHAIN_PATH}/openocd-esp32/share/openocd/scripts)
-
-set(OPENOCD ${ESPRESSIF_OPENOCD_TOOL})
-set(OPENOCD_DEFAULT_PATH ${ESPRESSIF_OPENOCD_SCRIPTS})
+if(NOT "${OPENOCD}" MATCHES "^${ESPRESSIF_TOOLCHAIN_PATH}/.*")
+  set(OPENOCD OPENOCD-NOTFOUND)
+endif()
+find_program(OPENOCD openocd PATHS ${ESPRESSIF_TOOLCHAIN_PATH}/openocd-esp32/bin NO_DEFAULT_PATH)
 
 include(${ZEPHYR_BASE}/boards/common/esp32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/xtensa/esp32s2_saola/support/openocd.cfg
+++ b/boards/xtensa/esp32s2_saola/support/openocd.cfg
@@ -1,0 +1,4 @@
+set ESP_RTOS none
+
+source [find interface/ftdi/esp32s2_kaluga_v1.cfg]
+source [find target/esp32s2.cfg]


### PR DESCRIPTION
Openocd script supports custom configuration by adding it in
boards/support/openocd.cfg file. Therefore, instead of fixing the configuration
in the board.cmake file and to improve maintainability, move default configs
to this config file.
 
This PR also sets proper OPENOCD path so that CMakeCache gets
correct path value.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>