### PR TITLE
drivers: serial: neorv32: use shared serial driver init priority

### DIFF
--- a/drivers/serial/Kconfig.neorv32
+++ b/drivers/serial/Kconfig.neorv32
@@ -11,11 +11,3 @@ config UART_NEORV32
 	select SERIAL_SUPPORT_INTERRUPT
 	help
 	  This option enables the UART driver for the NEORV32.
-
-config UART_NEORV32_INIT_PRIORITY
-	int "Driver inititalization priority"
-	default 55
-	depends on UART_NEORV32
-	help
-	  Device driver initialization priority. This driver must be
-	  initialized after the syscon driver.

--- a/drivers/serial/uart_neorv32.c
+++ b/drivers/serial/uart_neorv32.c
@@ -540,7 +540,7 @@ static const struct uart_driver_api neorv32_uart_driver_api = {
 			 &neorv32_uart_##n##_data,			\
 			 &neorv32_uart_##n##_config,			\
 			 PRE_KERNEL_1,					\
-			 CONFIG_UART_NEORV32_INIT_PRIORITY,		\
+			 CONFIG_SERIAL_INIT_PRIORITY,			\
 			 &neorv32_uart_driver_api)
 
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(uart0), DT_DRV_COMPAT, okay)

--- a/soc/riscv/riscv-privilege/neorv32/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-privilege/neorv32/Kconfig.defconfig.series
@@ -21,4 +21,8 @@ config RISCV_GP
 config SYSCON
 	default y
 
+config SERIAL_INIT_PRIORITY
+	default 55
+	depends on SERIAL
+
 endif # SOC_SERIES_NEORV32


### PR DESCRIPTION
Use the shared CONFIG_SERIAL_INIT_PRIORITY for driver initialization priority.

Override the default value for the NEORV32 SoC to ensure the serial driver is initialized after the syscon driver by default.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>