### PR TITLE
Bluetooth ISO make some functions static

### DIFF
--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -376,7 +376,7 @@ void bt_iso_connected(struct bt_conn *iso)
 	}
 }
 
-void bt_iso_remove_data_path(struct bt_conn *iso)
+static void bt_iso_remove_data_path(struct bt_conn *iso)
 {
 	BT_DBG("%p", iso);
 

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -57,9 +57,6 @@ struct bt_iso_big bigs[CONFIG_BT_ISO_MAX_BIG];
 static struct bt_iso_big *lookup_big_by_handle(uint8_t big_handle);
 #endif /* CONFIG_BT_ISO_BROADCAST */
 
-/* Prototype */
-int hci_le_remove_cig(uint8_t cig_id);
-
 #if defined(CONFIG_BT_ISO_UNICAST) || defined(CONFIG_BT_ISO_BROADCASTER)
 static void bt_iso_send_cb(struct bt_conn *iso, void *user_data)
 {
@@ -940,7 +937,7 @@ void hci_le_cis_req(struct net_buf *buf)
 	}
 }
 
-int hci_le_remove_cig(uint8_t cig_id)
+static int hci_le_remove_cig(uint8_t cig_id)
 {
 	struct bt_hci_cp_le_remove_cig *req;
 	struct net_buf *buf;

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -113,7 +113,7 @@ void hci_iso(struct net_buf *buf)
 	bt_conn_unref(iso);
 }
 
-struct bt_conn *iso_new(void)
+static struct bt_conn *iso_new(void)
 {
 	struct bt_conn *iso = bt_conn_new(iso_conns, ARRAY_SIZE(iso_conns));
 

--- a/subsys/bluetooth/host/iso_internal.h
+++ b/subsys/bluetooth/host/iso_internal.h
@@ -73,9 +73,6 @@ void hci_iso(struct net_buf *buf);
 /* Allocates RX buffer */
 struct net_buf *bt_iso_get_rx(k_timeout_t timeout);
 
-/* Create new ISO connecting */
-struct bt_conn *iso_new(void);
-
 /* Process CIS Estabilished event */
 void hci_le_cis_estabilished(struct net_buf *buf);
 

--- a/subsys/bluetooth/host/iso_internal.h
+++ b/subsys/bluetooth/host/iso_internal.h
@@ -149,5 +149,3 @@ void bt_iso_chan_set_state(struct bt_iso_chan *chan, uint8_t state);
 
 /* Process incoming data for a connection */
 void bt_iso_recv(struct bt_conn *iso, struct net_buf *buf, uint8_t flags);
-
-void bt_iso_remove_data_path(struct bt_conn *iso);


### PR DESCRIPTION
Changes a few functions to be static as they are only used by iso.c