### PR TITLE
logging: rtt: Fix compilation error when multithreading disable

### DIFF
--- a/subsys/logging/log_backend_rtt.c
+++ b/subsys/logging/log_backend_rtt.c
@@ -235,13 +235,13 @@ static int data_out_overwrite_mode(uint8_t *data, size_t length, void *ctx)
 {
 	if (!is_sync_mode()) {
 		RTT_LOCK();
-	}
+		SEGGER_RTT_WriteWithOverwriteNoLock(CONFIG_LOG_BACKEND_RTT_BUFFER,
+						    data, length);
 
-	SEGGER_RTT_WriteWithOverwriteNoLock(CONFIG_LOG_BACKEND_RTT_BUFFER,
-					    data, length);
-
-	if (!is_sync_mode()) {
 		RTT_UNLOCK();
+	} else {
+		SEGGER_RTT_WriteWithOverwriteNoLock(CONFIG_LOG_BACKEND_RTT_BUFFER,
+						    data, length);
 	}
 
 	return length;


### PR DESCRIPTION
Fixes #39538

RTT_UNLOCK() uses a variable defined in RTT_LOCK() making mandatory
to use both function in the same block

Signed-off-by: Guillaume Lager <g.lager@innoseis.com>