### PR TITLE
soc: esp32: use same rom func prefix

### DIFF
--- a/drivers/clock_control/clock_control_esp32.h
+++ b/drivers/clock_control/clock_control_esp32.h
@@ -13,10 +13,10 @@
  * Convenience macros for the above functions.
  */
 #define I2C_WRITEREG_RTC(block, reg_add, indata) \
-	esp32_rom_i2c_writeReg(block, block##_HOSTID,  reg_add, indata)
+	esp_rom_i2c_writeReg(block, block##_HOSTID,  reg_add, indata)
 
 #define I2C_READREG_RTC(block, reg_add)	\
-	esp32_rom_i2c_readReg(block, block##_HOSTID,  reg_add)
+	esp_rom_i2c_readReg(block, block##_HOSTID,  reg_add)
 
 /*
  * Get voltage level for CPU to run at 240 MHz, or for flash/PSRAM to run at 80 MHz.

--- a/drivers/flash/flash_esp32.c
+++ b/drivers/flash/flash_esp32.c
@@ -159,9 +159,9 @@ static void IRAM_ATTR flash_esp32_flush_cache(size_t start_addr, size_t length)
 #if CONFIG_ESP_SPIRAM
 			esp_spiram_writeback_cache();
 #endif
-			esp32_rom_Cache_Flush(0);
+			esp_rom_Cache_Flush(0);
 #ifdef CONFIG_SMP
-			esp32_rom_Cache_Flush(1);
+			esp_rom_Cache_Flush(1);
 #endif
 			return;
 		}

--- a/soc/xtensa/esp32/esp32-mp.c
+++ b/soc/xtensa/esp32/esp32-mp.c
@@ -56,10 +56,10 @@ void smp_log(const char *msg)
 	k_spinlock_key_t key = k_spin_lock(&loglock);
 
 	while (*msg) {
-		esp32_rom_uart_tx_one_char(*msg++);
+		esp_rom_uart_tx_one_char(*msg++);
 	}
-	esp32_rom_uart_tx_one_char('\r');
-	esp32_rom_uart_tx_one_char('\n');
+	esp_rom_uart_tx_one_char('\r');
+	esp_rom_uart_tx_one_char('\n');
 
 	k_spin_unlock(&loglock, key);
 }
@@ -170,8 +170,8 @@ static void appcpu_start(void)
 	 * definition, so we can skip that complexity and just call
 	 * the ROM directly.
 	 */
-	esp32_rom_Cache_Flush(1);
-	esp32_rom_Cache_Read_Enable(1);
+	esp_rom_Cache_Flush(1);
+	esp_rom_Cache_Read_Enable(1);
 
 	RTC_CNTL_SW_CPU_STALL &= ~RTC_CNTL_SW_STALL_APPCPU_C1;
 	RTC_CNTL_OPTIONS0     &= ~RTC_CNTL_SW_STALL_APPCPU_C0;
@@ -185,7 +185,7 @@ static void appcpu_start(void)
 	/* Seems weird that you set the boot address AFTER starting
 	 * the CPU, but this is how they do it...
 	 */
-	esp32_rom_ets_set_appcpu_boot_addr((void *)appcpu_entry1);
+	esp_rom_ets_set_appcpu_boot_addr((void *)appcpu_entry1);
 
 	smp_log("ESP32: APPCPU start sequence complete");
 }

--- a/soc/xtensa/esp32/soc.c
+++ b/soc/xtensa/esp32/soc.c
@@ -133,9 +133,9 @@ void __attribute__((section(".iram1"))) __start(void)
 int IRAM_ATTR arch_printk_char_out(int c)
 {
 	if (c == '\n') {
-		esp32_rom_uart_tx_one_char('\r');
+		esp_rom_uart_tx_one_char('\r');
 	}
-	esp32_rom_uart_tx_one_char(c);
+	esp_rom_uart_tx_one_char(c);
 	return 0;
 }
 
@@ -156,9 +156,9 @@ void IRAM_ATTR esp_restart_noos(void)
 	soc_ll_stall_core(other_core_id);
 
 	/* Flush any data left in UART FIFOs */
-	esp32_rom_uart_tx_wait_idle(0);
-	esp32_rom_uart_tx_wait_idle(1);
-	esp32_rom_uart_tx_wait_idle(2);
+	esp_rom_uart_tx_wait_idle(0);
+	esp_rom_uart_tx_wait_idle(1);
+	esp_rom_uart_tx_wait_idle(2);
 
 	/* Disable cache */
 	Cache_Read_Disable(0);

--- a/soc/xtensa/esp32/soc.h
+++ b/soc/xtensa/esp32/soc.h
@@ -29,7 +29,7 @@ static inline void esp32_clear_mask32(uint32_t v, uint32_t mem_addr)
 	sys_write32(sys_read32(mem_addr) & ~v, mem_addr);
 }
 
-extern void esp32_rom_intr_matrix_set(int cpu_no, uint32_t model_num, uint32_t intr_num);
+extern void esp_rom_intr_matrix_set(int cpu_no, uint32_t model_num, uint32_t intr_num);
 
 extern int esp_rom_gpio_matrix_in(uint32_t gpio, uint32_t signal_index,
 				    bool inverted);
@@ -37,18 +37,18 @@ extern int esp_rom_gpio_matrix_out(uint32_t gpio, uint32_t signal_index,
 				     bool out_inverted,
 				     bool out_enabled_inverted);
 
-extern void esp32_rom_uart_attach(void);
-extern void esp32_rom_uart_tx_wait_idle(uint8_t uart_no);
-extern STATUS esp32_rom_uart_tx_one_char(uint8_t chr);
-extern STATUS esp32_rom_uart_rx_one_char(uint8_t *chr);
+extern void esp_rom_uart_attach(void);
+extern void esp_rom_uart_tx_wait_idle(uint8_t uart_no);
+extern STATUS esp_rom_uart_tx_one_char(uint8_t chr);
+extern STATUS esp_rom_uart_rx_one_char(uint8_t *chr);
 
-extern void esp32_rom_Cache_Flush(int cpu);
-extern void esp32_rom_Cache_Read_Enable(int cpu);
-extern void esp32_rom_ets_set_appcpu_boot_addr(void *addr);
+extern void esp_rom_Cache_Flush(int cpu);
+extern void esp_rom_Cache_Read_Enable(int cpu);
+extern void esp_rom_ets_set_appcpu_boot_addr(void *addr);
 
 /* ROM functions which read/write internal i2c control bus for PLL, APLL */
-extern uint8_t esp32_rom_i2c_readReg(uint8_t block, uint8_t host_id, uint8_t reg_add);
-extern void esp32_rom_i2c_writeReg(uint8_t block, uint8_t host_id, uint8_t reg_add, uint8_t data);
+extern uint8_t esp_rom_i2c_readReg(uint8_t block, uint8_t host_id, uint8_t reg_add);
+extern void esp_rom_i2c_writeReg(uint8_t block, uint8_t host_id, uint8_t reg_add, uint8_t data);
 
 /* ROM information related to SPI Flash chip timing and device */
 extern esp_rom_spiflash_chip_t g_rom_flashchip;

--- a/west.yml
+++ b/west.yml
@@ -62,7 +62,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 2308568ea25817f1fa61cc218b3693cc87949c57
+      revision: a360365cb7858826809c82e375524ee5faf497ac
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
This sets esp32 to use common rom functions
prefix among SoCs.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>