### PR TITLE
shell: Fix various build issues with string formattors

### DIFF
--- a/drivers/eeprom/eeprom_shell.c
+++ b/drivers/eeprom/eeprom_shell.c
@@ -173,7 +173,7 @@ static int cmd_fill(const struct shell *shell, size_t argc, char **argv)
 		return -EINVAL;
 	}
 
-	shell_print(shell, "Writing %d bytes of 0x%02x to EEPROM...", len,
+	shell_print(shell, "Writing %d bytes of 0x%02lx to EEPROM...", len,
 		    pattern);
 
 	addr = initial_offset;

--- a/drivers/hwinfo/hwinfo_shell.c
+++ b/drivers/hwinfo/hwinfo_shell.c
@@ -22,11 +22,11 @@ static int cmd_get_device_id(const struct shell *shell, size_t argc, char **argv
 		shell_error(shell, "Not supported by hardware");
 		return -ENOTSUP;
 	} else if (length < 0) {
-		shell_error(shell, "Error: %d", length);
+		shell_error(shell, "Error: %zd", length);
 		return length;
 	}
 
-	shell_fprintf(shell, SHELL_NORMAL, "Length: %d\n", length);
+	shell_fprintf(shell, SHELL_NORMAL, "Length: %zd\n", length);
 	shell_fprintf(shell, SHELL_NORMAL, "ID: 0x");
 
 	for (i = 0 ; i < length ; i++) {

--- a/subsys/shell/modules/kernel_service.c
+++ b/subsys/shell/modules/kernel_service.c
@@ -104,8 +104,8 @@ static void shell_tdata_dump(const struct k_thread *cthread, void *user_data)
 		 * targets.
 		 */
 #ifdef CONFIG_64BIT
-		shell_print(shell, "\tTotal execution cycles: %llu (%u %%)",
-			    rt_stats_thread.execution_cycles,
+		shell_print(shell, "\tTotal execution cycles: %" PRIu64 " (%u %%)",
+			    (uint64_t)rt_stats_thread.execution_cycles,
 			    pcnt);
 #else
 		shell_print(shell, "\tTotal execution cycles: %u (%u %%)",

--- a/subsys/stats/stats_shell.c
+++ b/subsys/stats/stats_shell.c
@@ -25,7 +25,7 @@ static int stats_cb(struct stats_hdr *hdr, void *arg, const char *name, uint16_t
 		val = *(uint64_t *)(addr);
 		break;
 	}
-	shell_print(sh, "\t%s (offset: %u, addr: %p): %llu", name, off, addr, val);
+	shell_print(sh, "\t%s (offset: %u, addr: %p): %" PRIu64, name, off, addr, val);
 	return 0;
 }
 


### PR DESCRIPTION
We get a few different CI failures associated with data type
differences on various platforms.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>