### PR TITLE
drivers/usb: stm23: Fix deprecated macro declaration

### DIFF
--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -44,8 +44,8 @@ LOG_MODULE_REGISTER(usb_dc_stm32);
 #elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_usb)
 #define DT_DRV_COMPAT st_stm32_usb
 #define USB_IRQ_NAME  usb
-#if DT_INST_NODE_HAS_PROP(0, enable_pin_remap)
-#define USB_ENABLE_PIN_REMAP	__DEPRECATED_MACRO DT_INST_PROP(0, enable_pin_remap)
+#if DT_INST_PROP(0, enable_pin_remap)
+#define USB_ENABLE_PIN_REMAP	DT_INST_PROP(0, enable_pin_remap)
 #warning "Property deprecated in favor of property 'remap-pa11-pa12' from 'st-stm32-pinctrl'"
 #endif
 #endif


### PR DESCRIPTION
Use of '__DEPRECATED_MACRO' was not compatible with the way macro
is used later in this driver.
Remove it and keep the warning as vector for deprecation information.

Additionally, replace DT_NODE_HAS_PROP with DT_INST_PROP as
using the former is not recommended with boolean properties.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>