### PR TITLE
Bluetooth HCI: Fix incomplete acl mtu setup bug

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3291,6 +3291,12 @@ static int hci_init(void)
 		BT_ERR("Non-BR/EDR controller detected");
 		return -EIO;
 	}
+#if defined(CONFIG_BT_CONN)
+	else if (!bt_dev.le.acl_mtu) {
+		BT_ERR("ACL BR/EDR buffers not initialized");
+		return -EIO;
+	}
+#endif
 
 	err = set_event_mask();
 	if (err) {


### PR DESCRIPTION
This change is supposed to fix the issue of incomplete acl mtu
initialization in the absence of BREDR. Find further information here:
Fixes #39549