### PR TITLE
tracing: add external tracing module support

### DIFF
--- a/include/tracing/tracing.h
+++ b/include/tracing/tracing.h
@@ -18,6 +18,8 @@
 #include "tracing_test.h"
 #elif defined CONFIG_TRACING_USER
 #include "tracing_user.h"
+#elif defined CONFIG_TRACING_EXTERNAL
+#include "tracing_external.h"
 #else
 /**
  * @brief Tracing

--- a/modules/external-tracing/Kconfig
+++ b/modules/external-tracing/Kconfig
@@ -1,0 +1,10 @@
+# Zephyr module config for external tracing.
+# The real Kconfig for the module is located externally,
+# this file is to ensure ZEPHYR_EXTERNALTRACING_MODULE is defined also when the
+# module is unavailable.
+
+# Copyright (c) 2021 Jon Lamb <jon@auxon.io>
+# SPDX-License-Identifier: Apache-2.0
+
+config ZEPHYR_EXTERNALTRACING_MODULE
+	bool

--- a/subsys/tracing/Kconfig
+++ b/subsys/tracing/Kconfig
@@ -65,6 +65,12 @@ config TRACING_USER
 	help
 	  Use user-defined functions for tracing task switching and irqs
 
+config TRACING_EXTERNAL
+	bool "External tracing support"
+	depends on ZEPHYR_EXTERNALTRACING_MODULE
+	help
+	  Enable external tracing module support.
+
 endchoice
 
 


### PR DESCRIPTION
This commit adds support for an external tracing module.
It stubs out a new config `TRACING_EXTERNAL`, which depends on
`ZEPHYR_EXTERNALTRACING_MODULE`, to be defined externally
by the module implementing tracing.

Fixes #37912

Signed-off-by: Jon Lamb <jon@auxon.io>