### PR TITLE
subsys: mqtt: Return meaningful error code from mqtt_init() function

### DIFF
--- a/subsys/net/lib/mqtt/mqtt.c
+++ b/subsys/net/lib/mqtt/mqtt.c
@@ -649,7 +649,7 @@ int mqtt_input(struct mqtt_client *client)
 	if (MQTT_HAS_STATE(client, MQTT_STATE_TCP_CONNECTED)) {
 		err_code = client_read(client);
 	} else {
-		err_code = -EACCES;
+		err_code = -ENOTCONN;
 	}
 
 	mqtt_mutex_unlock(client);


### PR DESCRIPTION
The condition checks whether the connection was established or not. The
return value should reflect that.

Signed-off-by: Caspar Friedrich <c.s.w.friedrich@gmail.com>