### PR TITLE
doc: Fix K_EVENT_DEFINE macro code-block example (Fix #39497)

### DIFF
--- a/doc/reference/kernel/synchronization/events.rst
+++ b/doc/reference/kernel/synchronization/events.rst
@@ -66,7 +66,7 @@ The following code has the same effect as the code segment above.
 
 .. code-block:: c
 
-    K_EVENT_DEFINE(my_event, 0, 1);
+    K_EVENT_DEFINE(my_event);
 
 Setting Events
 ==============


### PR DESCRIPTION
This commit resolves issue #39497 wherein it was observed that there was a mismatch between the code-block example in the documentation for K_EVENT_DEFINE() and its definition in include/kernel.h. That code-block example in the documentation now correctly shows that K_EVENT_DEFINE() accepts one argument.

Fixes #39497