### PR TITLE
drivers: adc: Refactor drivers to use shared init priority

### DIFF
--- a/boards/shields/lmp90100_evb/Kconfig.defconfig
+++ b/boards/shields/lmp90100_evb/Kconfig.defconfig
@@ -14,6 +14,9 @@ config ADC_LMP90XXX
 config ADC_LMP90XXX_GPIO
 	default y
 
+config ADC_INIT_PRIORITY
+	default 80
+
 endif # ADC
 
 if EEPROM

--- a/boards/shields/mikroe_adc_click/Kconfig.defconfig
+++ b/boards/shields/mikroe_adc_click/Kconfig.defconfig
@@ -11,6 +11,9 @@ config SPI
 config ADC_MCP320X
 	default y
 
+config ADC_INIT_PRIORITY
+	default 80
+
 endif # ADC
 
 endif # SHIELD_MIKROE_ADC_CLICK

--- a/drivers/adc/Kconfig
+++ b/drivers/adc/Kconfig
@@ -34,6 +34,12 @@ config ADC_ASYNC
 	help
 	  This option enables the asynchronous API calls.
 
+config ADC_INIT_PRIORITY
+	int "ADC init priority"
+	default KERNEL_INIT_PRIORITY_DEVICE
+	help
+	  ADC driver device initialization priority.
+
 module = ADC
 module-str = ADC
 source "subsys/logging/Kconfig.template.log_config"

--- a/drivers/adc/Kconfig.lmp90xxx
+++ b/drivers/adc/Kconfig.lmp90xxx
@@ -15,12 +15,6 @@ config ADC_LMP90XXX
 
 if ADC_LMP90XXX
 
-config ADC_LMP90XXX_INIT_PRIORITY
-	int "Init priority"
-	default 80
-	help
-	  LMP90xxx ADC device driver initialization priority.
-
 config ADC_LMP90XXX_ACQUISITION_THREAD_STACK_SIZE
 	int "Stack size for the ADC data acquisition thread"
 	default 400

--- a/drivers/adc/Kconfig.mcp320x
+++ b/drivers/adc/Kconfig.mcp320x
@@ -14,12 +14,6 @@ config ADC_MCP320X
 
 if ADC_MCP320X
 
-config ADC_MCP320X_INIT_PRIORITY
-	int "Init priority"
-	default 80
-	help
-	  MCP320x ADC device driver initialization priority.
-
 config ADC_MCP320X_ACQUISITION_THREAD_STACK_SIZE
 	int "Stack size for the ADC data acquisition thread"
 	default 512

--- a/drivers/adc/Kconfig.mcux
+++ b/drivers/adc/Kconfig.mcux
@@ -61,12 +61,6 @@ config ADC_MCUX_ADC16_ENABLE_EDMA
 
 if ADC_MCUX_ADC16_ENABLE_EDMA
 
-config ADC_MCUX_ADC16_INIT_PRIORITY
-	int "Init priority"
-	default 70
-	help
-	  Device driver initialization priority.
-
 config ADC_MCUX_ADC16_HW_TRIGGER
 	bool "ADC HW TRIGGER"
 	default y

--- a/drivers/adc/adc_cc32xx.c
+++ b/drivers/adc/adc_cc32xx.c
@@ -313,7 +313,7 @@ static const struct adc_driver_api cc32xx_driver_api = {
 	DEVICE_DT_INST_DEFINE(index,						 \
 			      &adc_cc32xx_init, NULL, &adc_cc32xx_data_##index,	 \
 			      &adc_cc32xx_cfg_##index, POST_KERNEL,		 \
-			      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,		 \
+			      CONFIG_ADC_INIT_PRIORITY,				 \
 			      &cc32xx_driver_api);				 \
 										 \
 	static void adc_cc32xx_cfg_func_##index(void)				 \

--- a/drivers/adc/adc_emul.c
+++ b/drivers/adc/adc_emul.c
@@ -574,7 +574,7 @@ static int adc_emul_init(const struct device *dev)
 	DEVICE_DT_INST_DEFINE(_num, adc_emul_init, NULL,		\
 			      &adc_emul_data_##_num,			\
 			      &adc_emul_config_##_num, POST_KERNEL,	\
-			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\
+			      CONFIG_ADC_INIT_PRIORITY,			\
 			      &adc_emul_api_##_num)
 
 DT_INST_FOREACH_STATUS_OKAY(ADC_EMUL_INIT);

--- a/drivers/adc/adc_ite_it8xxx2.c
+++ b/drivers/adc/adc_ite_it8xxx2.c
@@ -335,5 +335,5 @@ DEVICE_DT_INST_DEFINE(0, adc_it8xxx2_init,
 		      NULL,
 		      &adc_it8xxx2_data_0,
 		      &adc_it8xxx2_cfg_0, PRE_KERNEL_1,
-		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		      CONFIG_ADC_INIT_PRIORITY,
 		      &api_it8xxx2_driver_api);

--- a/drivers/adc/adc_lmp90xxx.c
+++ b/drivers/adc/adc_lmp90xxx.c
@@ -1073,7 +1073,7 @@ static const struct adc_driver_api lmp90xxx_adc_api = {
 			 &lmp90xxx_init, NULL, \
 			 &lmp##t##_data_##n, \
 			 &lmp##t##_config_##n, POST_KERNEL, \
-			 CONFIG_ADC_LMP90XXX_INIT_PRIORITY, \
+			 CONFIG_ADC_INIT_PRIORITY, \
 			 &lmp90xxx_adc_api);
 
 #define LMP90XXX_FOREACH_STATUS_OKAY(compat, fn)		\

--- a/drivers/adc/adc_mchp_xec.c
+++ b/drivers/adc/adc_mchp_xec.c
@@ -309,5 +309,5 @@ static struct adc_xec_data adc_xec_dev_data_0 = {
 
 DEVICE_DT_INST_DEFINE(0, adc_xec_init, NULL,
 		    &adc_xec_dev_data_0, NULL,
-		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    PRE_KERNEL_1, CONFIG_ADC_INIT_PRIORITY,
 		    &adc_xec_api);

--- a/drivers/adc/adc_mchp_xec_v2.c
+++ b/drivers/adc/adc_mchp_xec_v2.c
@@ -344,5 +344,5 @@ static struct adc_xec_data adc_xec_dev_data_0 = {
 
 DEVICE_DT_INST_DEFINE(0, adc_xec_init, NULL,
 		    &adc_xec_dev_data_0, &adc_xec_dev_cfg_0,
-		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    PRE_KERNEL_1, CONFIG_ADC_INIT_PRIORITY,
 		    &adc_xec_api);

--- a/drivers/adc/adc_mcp320x.c
+++ b/drivers/adc/adc_mcp320x.c
@@ -329,7 +329,7 @@ static const struct adc_driver_api mcp320x_adc_api = {
 			 &mcp320x_init, NULL, \
 			 &mcp##t##_data_##n, \
 			 &mcp##t##_config_##n, POST_KERNEL, \
-			 CONFIG_ADC_MCP320X_INIT_PRIORITY, \
+			 CONFIG_ADC_INIT_PRIORITY, \
 			 &mcp320x_adc_api)
 
 /*

--- a/drivers/adc/adc_mcux_adc12.c
+++ b/drivers/adc/adc_mcux_adc12.c
@@ -286,7 +286,7 @@ static const struct adc_driver_api mcux_adc12_driver_api = {
 	DEVICE_DT_INST_DEFINE(n, &mcux_adc12_init,			\
 			    NULL, &mcux_adc12_data_##n,			\
 			    &mcux_adc12_config_##n, POST_KERNEL,	\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+			    CONFIG_ADC_INIT_PRIORITY,			\
 			    &mcux_adc12_driver_api);			\
 									\
 	static void mcux_adc12_config_func_##n(const struct device *dev) \

--- a/drivers/adc/adc_mcux_adc16.c
+++ b/drivers/adc/adc_mcux_adc16.c
@@ -462,7 +462,7 @@ static const struct adc_driver_api mcux_adc16_driver_api = {
 			      &mcux_adc16_data_##n,	\
 			      &mcux_adc16_config_##n,	\
 			      POST_KERNEL,		\
-			      CONFIG_ADC_MCUX_ADC16_INIT_PRIORITY,	\
+			      CONFIG_ADC_INIT_PRIORITY,	\
 			      &mcux_adc16_driver_api);
 #else
 #define ACD16_MCUX_INIT(n)						\
@@ -488,7 +488,7 @@ static const struct adc_driver_api mcux_adc16_driver_api = {
 			      &mcux_adc16_data_##n,	\
 			      &mcux_adc16_config_##n,	\
 			      POST_KERNEL,		\
-			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\
+			      CONFIG_ADC_INIT_PRIORITY,	\
 			      &mcux_adc16_driver_api);			\
 									\
 	static void mcux_adc16_config_func_##n(const struct device *dev) \

--- a/drivers/adc/adc_mcux_lpadc.c
+++ b/drivers/adc/adc_mcux_lpadc.c
@@ -427,7 +427,7 @@ static const struct adc_driver_api mcux_lpadc_driver_api = {
 	DEVICE_DT_INST_DEFINE(n,						\
 		&mcux_lpadc_init, NULL, &mcux_lpadc_data_##n,			\
 		&mcux_lpadc_config_##n, POST_KERNEL,				\
-		CONFIG_KERNEL_INIT_PRIORITY_DEVICE,					\
+		CONFIG_ADC_INIT_PRIORITY,					\
 		&mcux_lpadc_driver_api);							\
 										\
 	static void mcux_lpadc_config_func_##n(const struct device *dev)	\

--- a/drivers/adc/adc_npcx.c
+++ b/drivers/adc/adc_npcx.c
@@ -325,7 +325,7 @@ DEVICE_DT_INST_DEFINE(0,
 		    adc_npcx_init, NULL,
 		    &adc_npcx_data_0, &adc_npcx_cfg_0,
 		    PRE_KERNEL_1,
-		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+		    CONFIG_ADC_INIT_PRIORITY,
 		    &adc_npcx_driver_api);
 
 static int adc_npcx_init(const struct device *dev)

--- a/drivers/adc/adc_nrfx_adc.c
+++ b/drivers/adc/adc_nrfx_adc.c
@@ -292,7 +292,7 @@ static const struct adc_driver_api adc_nrfx_driver_api = {
 	DEVICE_DT_INST_DEFINE(0,					\
 			    init_adc, NULL, NULL, NULL,			\
 			    POST_KERNEL,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+			    CONFIG_ADC_INIT_PRIORITY,			\
 			    &adc_nrfx_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(ADC_INIT)

--- a/drivers/adc/adc_nrfx_saadc.c
+++ b/drivers/adc/adc_nrfx_saadc.c
@@ -433,7 +433,7 @@ static const struct adc_driver_api adc_nrfx_driver_api = {
 			    NULL,					\
 			    NULL,					\
 			    POST_KERNEL,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+			    CONFIG_ADC_INIT_PRIORITY,			\
 			    &adc_nrfx_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(SAADC_INIT)

--- a/drivers/adc/adc_sam0.c
+++ b/drivers/adc/adc_sam0.c
@@ -605,7 +605,7 @@ do {									\
 	DEVICE_DT_INST_DEFINE(n, adc_sam0_init, NULL,			\
 			    &adc_sam_data_##n,				\
 			    &adc_sam_cfg_##n, POST_KERNEL,		\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+			    CONFIG_ADC_INIT_PRIORITY,			\
 			    &adc_sam0_api);				\
 	static void adc_sam0_config_##n(const struct device *dev)	\
 	{								\

--- a/drivers/adc/adc_sam_afec.c
+++ b/drivers/adc/adc_sam_afec.c
@@ -368,7 +368,7 @@ static void adc_sam_isr(const struct device *dev)
 	DEVICE_DT_INST_DEFINE(n, adc_sam_init, NULL,			\
 			    &adc##n##_sam_data,				\
 			    &adc##n##_sam_cfg, POST_KERNEL,		\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+			    CONFIG_ADC_INIT_PRIORITY,			\
 			    &adc_sam_api);				\
 									\
 	static void adc##n##_sam_cfg_func(const struct device *dev)	\

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -1008,7 +1008,7 @@ static struct adc_stm32_data adc_stm32_data_##index = {			\
 DEVICE_DT_INST_DEFINE(index,						\
 		    &adc_stm32_init, NULL,				\
 		    &adc_stm32_data_##index, &adc_stm32_cfg_##index,	\
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
+		    POST_KERNEL, CONFIG_ADC_INIT_PRIORITY,		\
 		    &api_stm32_driver_api);				\
 									\
 static void adc_stm32_cfg_func_##index(void)				\

--- a/drivers/gpio/gpio_lmp90xxx.c
+++ b/drivers/gpio/gpio_lmp90xxx.c
@@ -159,7 +159,7 @@ static const struct gpio_driver_api gpio_lmp90xxx_api = {
 };
 
 BUILD_ASSERT(CONFIG_GPIO_LMP90XXX_INIT_PRIORITY >
-	     CONFIG_ADC_LMP90XXX_INIT_PRIORITY,
+	     CONFIG_ADC_INIT_PRIORITY,
 	     "LMP90xxx GPIO driver must be initialized after LMP90xxx ADC "
 	     "driver");
 

--- a/soc/arm/nxp_kinetis/Kconfig.defconfig
+++ b/soc/arm/nxp_kinetis/Kconfig.defconfig
@@ -4,4 +4,8 @@ config SERIAL_INIT_PRIORITY
 	default 55
 	depends on SERIAL
 
+config ADC_INIT_PRIORITY
+	default 80 if ADC_MCUX_ADC16_ENABLE_EDMA
+	depends on ADC
+
 source "soc/arm/nxp_kinetis/*/Kconfig.defconfig.series"


### PR DESCRIPTION
Refactors all of the ADC drivers to use a shared driver class
initialization priority configuration, CONFIG_ADC_INIT_PRIORITY, to
allow configuring ADC drivers separately from other devices. This is
similar to other driver classes like I2C and SPI.

The default is set to CONFIG_KERNEL_INIT_PRIORITY_DEVICE to preserve the
existing default initialization priority for most drivers. The
exceptions are lmp90xxx, mcp320x, and mcux_adc16 drivers which have
dependencies on GPIO, SPI, and/or DMA drivers and must therefore
initialize later than the default device priority.

Signed-off-by: Maureen Helm <maureen.helm@intel.com>