### PR TITLE
cmake: bugfix imarcos flags not being picked up

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,7 +211,7 @@ if(CONFIG_CODING_GUIDELINE_CHECK)
 endif()
 
 # @Intent: Set compiler specific macro inclusion of AUTOCONF_H
-zephyr_compile_options("SHELL: $<TARGET_PROPERTY:compiler,imacros> ${AUTOCONF_H}")
+zephyr_compile_options("SHELL: $<TARGET_PROPERTY:compiler,imacros>${AUTOCONF_H}")
 
 # @Intent: Set compiler specific flag for bare metal freestanding option
 zephyr_compile_options($<TARGET_PROPERTY:compiler,freestanding>)
@@ -237,7 +237,7 @@ zephyr_compile_options($<$<COMPILE_LANGUAGE:ASM>:$<TARGET_PROPERTY:asm,required>
 
 # @Intent: Enforce standard integer type correspondance to match Zephyr usage.
 # (must be after compiler specific flags)
-zephyr_compile_options("SHELL: $<TARGET_PROPERTY:compiler,imacros> ${ZEPHYR_BASE}/include/toolchain/zephyr_stdint.h")
+zephyr_compile_options("SHELL: $<TARGET_PROPERTY:compiler,imacros>${ZEPHYR_BASE}/include/toolchain/zephyr_stdint.h")
 
 # Common toolchain-agnostic assembly flags
 zephyr_compile_options(


### PR DESCRIPTION
When using imacros on some compilers the extra white space prevents the
flags from being picked up.
This patch simply removes the extra white space.