### PR TITLE
arm: Use correct macro for z_interrupt_stacks declaration in stack.h

### DIFF
--- a/arch/arm/include/aarch32/cortex_m/stack.h
+++ b/arch/arm/include/aarch32/cortex_m/stack.h
@@ -26,7 +26,7 @@
 extern "C" {
 #endif
 
-extern K_KERNEL_STACK_ARRAY_DEFINE(z_interrupt_stacks, CONFIG_MP_NUM_CPUS,
+K_KERNEL_STACK_ARRAY_EXTERN(z_interrupt_stacks, CONFIG_MP_NUM_CPUS,
 				   CONFIG_ISR_STACK_SIZE);
 
 /**


### PR DESCRIPTION
There are two macros for declaring stack arrays:

K_KERNEL_STACK_ARRAY_DEFINE:

	Defines the array, allocating storage and setting the section name

K_KERNEL_STACK_ARRAY_EXTERN

	Declares the name of a stack array allowing code to reference
	the array which must be defined elsewhere

arch/arm/include/aarch32/cortex_m/stack.h was mis-using
K_KERNEL_STACK_ARRAY_DEFINE to declare z_interrupt_stacks by sticking
'extern' in front of the macro use. However, when this macro also set
the object file section for the symbol, having two of those caused a
conflict in the compiler due to the automatic unique name mechanism used
for sections to allow unused symbols to be discarded during linking.

This patch makes the header use the correct macro.

Signed-off-by: Keith Packard <keithp@keithp.com>