### PR TITLE
stm32 qspi  driver adding callback functions for Abort and Fifo Threshold events

### DIFF
--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -547,6 +547,17 @@ void HAL_QSPI_FifoThresholdCallback(QSPI_HandleTypeDef *hqspi)
 	k_sem_give(&dev_data->sync);
 }
 
+/*
+ * Status Abort Completed callback.
+ */
+void HAL_QSPI_AbortCpltCallback(QSPI_HandleTypeDef *hqspi)
+{
+	struct flash_stm32_qspi_data *dev_data =
+		CONTAINER_OF(hqspi, struct flash_stm32_qspi_data, hqspi);
+
+	k_sem_give(&dev_data->sync);
+}
+
 #if defined(CONFIG_FLASH_PAGE_LAYOUT)
 static void flash_stm32_qspi_pages_layout(const struct device *dev,
 				const struct flash_pages_layout **layout,

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -536,6 +536,17 @@ void HAL_QSPI_TimeOutCallback(QSPI_HandleTypeDef *hqspi)
 	k_sem_give(&dev_data->sync);
 }
 
+/*
+ * Status FifoThreshold callback.
+ */
+void HAL_QSPI_FifoThresholdCallback(QSPI_HandleTypeDef *hqspi)
+{
+	struct flash_stm32_qspi_data *dev_data =
+		CONTAINER_OF(hqspi, struct flash_stm32_qspi_data, hqspi);
+
+	k_sem_give(&dev_data->sync);
+}
+
 #if defined(CONFIG_FLASH_PAGE_LAYOUT)
 static void flash_stm32_qspi_pages_layout(const struct device *dev,
 				const struct flash_pages_layout **layout,


### PR DESCRIPTION
This PR adds a callback function for the Abort Completed event and the FIFO Threshold event
on the QSPI of the stm32 device.

Signed-off-by: Francois Ramu <francois.ramu@st.com>