### PR TITLE
modules: tfm: Split trusted-firmware-m repository

### DIFF
--- a/doc/guides/tfm/build.rst
+++ b/doc/guides/tfm/build.rst
@@ -56,8 +56,8 @@ When :kconfig:`CONFIG_TFM_BL2` is set to ``y``, TF-M uses a secure bootloader
 is validated by the bootloader during updates using the corresponding public
 key, which is stored inside the secure bootloader firmware image.
 
-By default, ``tfm/bl2/ext/mcuboot/root-rsa-3072.pem`` is used to sign secure
-images, and ``tfm/bl2/ext/mcuboot/root-rsa-3072_1.pem`` is used to sign
+By default, ``<tfm-dir>/bl2/ext/mcuboot/root-rsa-3072.pem`` is used to sign secure
+images, and ``<tfm-dir>/bl2/ext/mcuboot/root-rsa-3072_1.pem`` is used to sign
 non-secure images. Theses default .pem keys can (and **should**) be overridden
 using the :kconfig:`CONFIG_TFM_KEY_FILE_S` and
 :kconfig:`CONFIG_TFM_KEY_FILE_NS` config flags.

--- a/doc/guides/tfm/overview.rst
+++ b/doc/guides/tfm/overview.rst
@@ -190,7 +190,7 @@ Note that the starting state of our device is controlled by the secure firmware,
 meaning that when the non-secure Zephyr application starts, peripherals may
 not be in the HW-default reset state. In case of doubts, be sure to consult
 the board support packages in TF-M, available in the ``platform/ext/target/``
-folder of the TF-M module (which is in ``modules/tee/tfm/trusted-firmware-m/``
+folder of the TF-M module (which is in ``modules/tee/tf-m/trusted-firmware-m/``
 within a default Zephyr west workspace.)
 
 Secure Services

--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -184,15 +184,15 @@ if (CONFIG_BUILD_WITH_TFM)
   # TODO: Add support for cross-compile toolchain variant
   # TODO: Enforce GCC version check against TF-M compiler requirements
   if(${ZEPHYR_TOOLCHAIN_VARIANT} STREQUAL "zephyr")
-    set(TFM_TOOLCHAIN_FILE "trusted-firmware-m/toolchain_GNUARM.cmake")
+    set(TFM_TOOLCHAIN_FILE "toolchain_GNUARM.cmake")
     set(TFM_TOOLCHAIN_PREFIX "arm-zephyr-eabi")
     set(TFM_TOOLCHAIN_PATH ${ZEPHYR_SDK_INSTALL_DIR}/arm-zephyr-eabi/bin)
   elseif(${ZEPHYR_TOOLCHAIN_VARIANT} STREQUAL "gnuarmemb")
-    set(TFM_TOOLCHAIN_FILE "trusted-firmware-m/toolchain_GNUARM.cmake")
+    set(TFM_TOOLCHAIN_FILE "toolchain_GNUARM.cmake")
     set(TFM_TOOLCHAIN_PREFIX "arm-none-eabi")
     set(TFM_TOOLCHAIN_PATH ${GNUARMEMB_TOOLCHAIN_PATH}/bin)
   elseif(${ZEPHYR_TOOLCHAIN_VARIANT} STREQUAL "xtools")
-    set(TFM_TOOLCHAIN_FILE "trusted-firmware-m/toolchain_GNUARM.cmake")
+    set(TFM_TOOLCHAIN_FILE "toolchain_GNUARM.cmake")
     set(TFM_TOOLCHAIN_PREFIX "arm-zephyr-eabi")
     set(TFM_TOOLCHAIN_PATH ${XTOOLS_TOOLCHAIN_PATH}/arm-zephyr-eabi/bin)
   else()
@@ -201,7 +201,7 @@ if (CONFIG_BUILD_WITH_TFM)
 
   if(CONFIG_BOARD_LPCXPRESSO55S69_CPU0)
     # Supply path to NXP HAL sources used for TF-M build
-    set(TFM_PLATFORM_NXP_HAL_FILE_PATH ${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/trusted-firmware-m/platform/ext/target/nxp/)
+    set(TFM_PLATFORM_NXP_HAL_FILE_PATH ${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/platform/ext/target/nxp/)
     list(APPEND TFM_CMAKE_ARGS -DTFM_PLATFORM_NXP_HAL_FILE_PATH=${TFM_PLATFORM_NXP_HAL_FILE_PATH})
   endif()
 
@@ -226,10 +226,10 @@ if (CONFIG_BUILD_WITH_TFM)
       -DTFM_PLATFORM=${CONFIG_TFM_BOARD}
       ${TFM_CMAKE_ARGS}
       $<GENEX_EVAL:$<TARGET_PROPERTY:zephyr_property_target,TFM_CMAKE_OPTIONS>>
-      -DTFM_TEST_REPO_PATH=${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/tf-m-tests
+      -DTFM_TEST_REPO_PATH=${ZEPHYR_TF_M_TESTS_MODULE_DIR}
       -DMBEDCRYPTO_PATH=$<IF:$<BOOL:$<TARGET_PROPERTY:zephyr_property_target,TFM_MBEDCRYPTO_PATH>>,$<TARGET_PROPERTY:zephyr_property_target,TFM_MBEDCRYPTO_PATH>,${ZEPHYR_MBEDTLS_MODULE_DIR}>
-      -DPSA_ARCH_TESTS_PATH=${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/psa-arch-tests
-      ${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/trusted-firmware-m
+      -DPSA_ARCH_TESTS_PATH=${ZEPHYR_PSA_ARCH_TESTS_MODULE_DIR}
+      ${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}
     WORKING_DIRECTORY ${TFM_BINARY_DIR}
     COMMAND_EXPAND_LISTS
   )
@@ -251,7 +251,7 @@ if (CONFIG_BUILD_WITH_TFM)
 
   ExternalProject_Add(
     tfm
-    SOURCE_DIR ${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/trusted-firmware-m
+    SOURCE_DIR ${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}
     BINARY_DIR ${TFM_BINARY_DIR}
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ${CMAKE_COMMAND} --build . ${PARALLEL_JOBS}
@@ -300,7 +300,7 @@ if (CONFIG_BUILD_WITH_TFM)
     )
 
   target_include_directories(tfm_api PRIVATE
-    ${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/trusted-firmware-m/interface/include
+    ${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/interface/include
     )
 
   zephyr_library_link_libraries(
@@ -327,7 +327,7 @@ if (CONFIG_BUILD_WITH_TFM)
   if (CONFIG_TFM_BL2)
     set(PREPROCESSED_FILE_S "${CMAKE_BINARY_DIR}/tfm/bl2/ext/mcuboot/CMakeFiles/signing_layout_s.dir/signing_layout_s.o")
     set(PREPROCESSED_FILE_NS "${CMAKE_BINARY_DIR}/tfm/bl2/ext/mcuboot/CMakeFiles/signing_layout_ns.dir/signing_layout_ns.o")
-    set(TFM_MCUBOOT_DIR "${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/trusted-firmware-m/bl2/ext/mcuboot")
+    set(TFM_MCUBOOT_DIR "${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/bl2/ext/mcuboot")
   endif()
 
   # Configure which format (full or hash) to include the public key in

--- a/modules/trusted-firmware-m/Kconfig.tfm
+++ b/modules/trusted-firmware-m/Kconfig.tfm
@@ -52,7 +52,7 @@ if BUILD_WITH_TFM
 config TFM_KEY_FILE_S
 	string "Path to private key used to sign secure firmware images."
 	depends on BUILD_WITH_TFM
-	default "${ZEPHYR_BASE}/../modules/tee/tfm/trusted-firmware-m/bl2/ext/mcuboot/root-RSA-3072.pem"
+	default "${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/bl2/ext/mcuboot/root-RSA-3072.pem"
 	help
 	  The path and filename for the .pem file containing the private key
 	  that should be used by the BL2 bootloader when signing secure
@@ -61,7 +61,7 @@ config TFM_KEY_FILE_S
 config TFM_KEY_FILE_NS
 	string "Path to private key used to sign non-secure firmware images."
 	depends on BUILD_WITH_TFM
-	default "${ZEPHYR_BASE}/../modules/tee/tfm/trusted-firmware-m/bl2/ext/mcuboot/root-RSA-3072_1.pem"
+	default "${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/bl2/ext/mcuboot/root-RSA-3072_1.pem"
 	help
 	  The path and filename for the .pem file containing the private key
 	  that should be used by the BL2 bootloader when signing non-secure

--- a/samples/tfm_integration/psa_crypto/CMakeLists.txt
+++ b/samples/tfm_integration/psa_crypto/CMakeLists.txt
@@ -16,7 +16,7 @@ target_sources(app PRIVATE src/util_app_log.c)
 target_sources(app PRIVATE src/util_sformat.c)
 
 target_include_directories(app PRIVATE
-  ${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/trusted-firmware-m/interface/include
+  ${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/interface/include
 )
 
 # In TF-M, default value of CRYPTO_ENGINE_BUF_SIZE is 0x2080. It causes

--- a/samples/tfm_integration/psa_protected_storage/CMakeLists.txt
+++ b/samples/tfm_integration/psa_protected_storage/CMakeLists.txt
@@ -13,5 +13,5 @@ project(protected_storage)
 target_sources(app PRIVATE src/main.c)
 
 target_include_directories(app PRIVATE
-  ${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/trusted-firmware-m/interface/include
+  ${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/interface/include
 )

--- a/samples/tfm_integration/tfm_ipc/CMakeLists.txt
+++ b/samples/tfm_integration/tfm_ipc/CMakeLists.txt
@@ -9,5 +9,5 @@ project(tfm_ipc)
 target_sources(app PRIVATE src/main.c)
 
 target_include_directories(app PRIVATE
-  ${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/trusted-firmware-m/interface/include
+  ${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/interface/include
 )

--- a/samples/tfm_integration/tfm_psa_test/CMakeLists.txt
+++ b/samples/tfm_integration/tfm_psa_test/CMakeLists.txt
@@ -13,5 +13,5 @@ project(tfm_psa_storage_test)
 target_sources(app PRIVATE src/main.c)
 
 target_include_directories(app PRIVATE
-  ${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/trusted-firmware-m/interface/include
+  ${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/interface/include
 )

--- a/tests/arch/arm/arm_thread_swap_tz/CMakeLists.txt
+++ b/tests/arch/arm/arm_thread_swap_tz/CMakeLists.txt
@@ -13,5 +13,5 @@ FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
 
 target_include_directories(app PRIVATE
-  ${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/trusted-firmware-m/interface/include
+  ${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/interface/include
 )

--- a/west.yml
+++ b/west.yml
@@ -211,8 +211,18 @@ manifest:
       groups:
         - debug
     - name: trusted-firmware-m
-      path: modules/tee/tfm
-      revision: 00d0e38cf89656b0f3ef8d1757109c0ea021a780
+      revision: 400f58ff53eb1dea5234925e96c5279154515cc7
+      path: modules/tee/tf-m/trusted-firmware-m
+      groups:
+        - tee
+    - name: tf-m-tests
+      revision: 93dad5cb3cfc2e2d82de61d1b2781f84881ce839
+      path: modules/tee/tf-m/tf-m-tests
+      groups:
+        - tee
+    - name: psa-arch-tests
+      revision: 077b8e5cd5fe9e27718a499b004e79bfca2d2e89
+      path: modules/tee/tf-m/psa-arch-tests
       groups:
         - tee
 


### PR DESCRIPTION
Split the zephyr project maintained repository trusted-firmware-m into
forks of the individual upstream repositories.

https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git
Upstream: TF-Mv1.4.1
Additions:
zephyr: module: Add zephyr module file
trusted-firmware-m: platform: lpcxpresso55s69: Update SDK

https://git.trustedfirmware.org/TF-M/tf-m-tests.git
Upstream: 51ff2bdfae043f6dd0813b000d928c4bda172660
Additions:
zephyr: module: Add module file for tf-m-tests

https://github.com/ARM-software/psa-arch-tests.git
Upstream: 60faad2ead1b967ec8e73accd793d3ed0e5c56bd
Additions:
zephyr: module: Add module file for psa-arch-tests
psa-arch-tests: Allow overriding of toolchain file

The organization of folders remain the same with the following
exceptions:
Moved:
root folder moved from modules/tee/tfm to modules/tee/tf-m to avoid
problems with west update.
zephyr/module.yml to trusted-firmware-m/zephyr/module.yml and
${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR} points to what was previously
${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/trusted-firmware-m.
Added:
psa-arch-tests/zephyr/module.yml and ${ZEPHYR_PSA_ARCH_TESTS_MODULE_DIR}
tf-m-tests/zephyr/module/ and ${ZEPHYR_TF_M_TESTS_MODULE_DIR}
Removed:
init-git.sh
README.rst

Fixes: #39353

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>