### PR TITLE
task_wdt: ensure hw wdt is started before being fed

### DIFF
--- a/subsys/task_wdt/task_wdt.c
+++ b/subsys/task_wdt/task_wdt.c
@@ -164,7 +164,6 @@ int task_wdt_add(uint32_t reload_period, task_wdt_callback_t callback,
 			channels[id].user_data = user_data;
 			channels[id].timeout_abs_ticks = K_TICKS_FOREVER;
 			channels[id].callback = callback;
-			task_wdt_feed(id);
 
 #ifdef CONFIG_TASK_WDT_HW_FALLBACK
 			if (!hw_wdt_started && hw_wdt_dev) {
@@ -174,6 +173,9 @@ int task_wdt_add(uint32_t reload_period, task_wdt_callback_t callback,
 				hw_wdt_started = true;
 			}
 #endif
+			/* must be called after hw wdt has been started */
+			task_wdt_feed(id);
+
 			return id;
 		}
 	}


### PR DESCRIPTION
If a fallback hardware watchdog is used, it is fed together with the task watchdog in `task_wdt_feed`. However, the hardware watchdog was not yet set up before the first call to `task_wdt_feed`.

This commit fixes the order of `wdt_setup` and `task_wdt_feed` calls.

Fixes #39523