### PR TITLE
flash: add bank configuration support to qpsi flash modules for stm32

### DIFF
--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -886,6 +886,11 @@ static struct flash_stm32_qspi_data flash_stm32_qspi_dev_data = {
 			.SampleShifting = QSPI_SAMPLE_SHIFTING_NONE,
 			.ChipSelectHighTime = QSPI_CS_HIGH_TIME_1_CYCLE,
 			.ClockMode = QSPI_CLOCK_MODE_0,
+#if DT_PROP(STM32_QSPI_NODE, bank) == 1
+			.FlashID = QSPI_FLASH_ID_1,
+#elif DT_PROP(STM32_QSPI_NODE, bank) == 2
+			.FlashID = QSPI_FLASH_ID_2,
+#endif
 			},
 	},
 	QSPI_DMA_CHANNEL(STM32_QSPI_NODE, tx_rx)

--- a/dts/bindings/qspi/st,stm32-qspi.yaml
+++ b/dts/bindings/qspi/st,stm32-qspi.yaml
@@ -48,3 +48,13 @@ properties:
     pinctrl-0:
       type: phandles
       required: true
+
+    bank:
+      type: int
+      description: qspi bank pins to configure
+      required: false
+      enum:
+        - 1
+        - 2
+      default: 1
+


### PR DESCRIPTION
adds the ability to define the optional bank parameter in the dts, and handles the flash ID for the bank in the driver