### PR TITLE
cmake: run `gen_handles.py` before `zephyr_prebuilt.elf`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -979,6 +979,7 @@ if(CONFIG_USERSPACE)
 endif()
 
 # Read global variables into local variables
+get_property(GASF GLOBAL PROPERTY GENERATED_APP_SOURCE_FILES)
 get_property(GKOF GLOBAL PROPERTY GENERATED_KERNEL_OBJECT_FILES)
 get_property(GKSF GLOBAL PROPERTY GENERATED_KERNEL_SOURCE_FILES)
 
@@ -1273,7 +1274,7 @@ set_property(TARGET
   )
 
 # FIXME: Is there any way to get rid of empty_file.c?
-add_executable(       ${ZEPHYR_PREBUILT_EXECUTABLE} misc/empty_file.c)
+add_executable(       ${ZEPHYR_PREBUILT_EXECUTABLE} misc/empty_file.c ${GASF})
 toolchain_ld_link_elf(
   TARGET_ELF            ${ZEPHYR_PREBUILT_EXECUTABLE}
   OUTPUT_MAP            ${PROJECT_BINARY_DIR}/${ZEPHYR_PREBUILT_EXECUTABLE}.map
@@ -1322,7 +1323,7 @@ else()
     ${ZEPHYR_INCLUDE_DIRS}
   )
 
-  add_executable(       ${ZEPHYR_FINAL_EXECUTABLE} misc/empty_file.c ${GKSF})
+  add_executable(       ${ZEPHYR_FINAL_EXECUTABLE} misc/empty_file.c ${GASF} ${GKSF})
   toolchain_ld_link_elf(
     TARGET_ELF            ${ZEPHYR_FINAL_EXECUTABLE}
     OUTPUT_MAP            ${PROJECT_BINARY_DIR}/${ZEPHYR_FINAL_EXECUTABLE}.map

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -367,8 +367,9 @@ endif()
 # TODO: Archiver arguments
 # ar_option(D)
 
-# Generate app_smem when enabling CONFIG_USERSPACE
-set(LINK_APP_SMEM ${CONFIG_USERSPACE})
+# Generate app_smem when scripts need to process an initial .elf
+# file, whose results will end up changing the size of variables.
+set(LINK_APP_SMEM ${CONFIG_USERSPACE} OR ${CONFIG_HAS_DTS})
 
 # Declare MPU userspace dependencies before the linker scripts to make
 # sure the order of dependencies are met
@@ -795,7 +796,7 @@ if(CONFIG_GEN_ISR_TABLES)
 endif()
 
 if(CONFIG_HAS_DTS)
-  # dev_handles.c is generated from ${ZEPHYR_PREBUILT_EXECUTABLE} by
+  # dev_handles.c is generated from app_smem_unaligned_prebuilt by
   # gen_handles.py
   add_custom_command(
     OUTPUT dev_handles.c
@@ -803,12 +804,12 @@ if(CONFIG_HAS_DTS)
     ${PYTHON_EXECUTABLE}
     ${ZEPHYR_BASE}/scripts/gen_handles.py
     --output-source dev_handles.c
-    --kernel $<TARGET_FILE:${ZEPHYR_PREBUILT_EXECUTABLE}>
+    --kernel $<TARGET_FILE:app_smem_unaligned_prebuilt>
     --zephyr-base ${ZEPHYR_BASE}
     --start-symbol "$<TARGET_PROPERTY:linker,devices_start_symbol>"
-    DEPENDS ${ZEPHYR_PREBUILT_EXECUTABLE}
+    DEPENDS app_smem_unaligned_prebuilt
     )
-  set_property(GLOBAL APPEND PROPERTY GENERATED_KERNEL_SOURCE_FILES dev_handles.c)
+  set_property(GLOBAL APPEND PROPERTY GENERATED_APP_SOURCE_FILES dev_handles.c)
 endif()
 
 if(CONFIG_CODE_DATA_RELOCATION)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -367,9 +367,12 @@ endif()
 # TODO: Archiver arguments
 # ar_option(D)
 
+# Generate app_smem when enabling CONFIG_USERSPACE
+set(LINK_APP_SMEM ${CONFIG_USERSPACE})
+
 # Declare MPU userspace dependencies before the linker scripts to make
 # sure the order of dependencies are met
-if(CONFIG_USERSPACE)
+if(LINK_APP_SMEM)
   add_custom_target(app_smem)
   set(APP_SMEM_ALIGNED_DEP app_smem_aligned_linker)
   set(APP_SMEM_UNALIGNED_DEP app_smem_unaligned_linker)
@@ -992,32 +995,60 @@ set(CMAKE_C_COMPILE_FEATURES ${compile_features_${CSTD}} PARENT_SCOPE)
 # @Intent: Configure linker scripts, i.e. generate linker scripts with variables substituted
 toolchain_ld_configure_files()
 
-if(CONFIG_USERSPACE)
+if(LINK_APP_SMEM)
   set(APP_SMEM_ALIGNED_LD "${PROJECT_BINARY_DIR}/include/generated/app_smem_aligned.ld")
   set(APP_SMEM_UNALIGNED_LD "${PROJECT_BINARY_DIR}/include/generated/app_smem_unaligned.ld")
 
-  if(CONFIG_LINKER_USE_PINNED_SECTION)
-    set(APP_SMEM_PINNED_ALIGNED_LD
-         "${PROJECT_BINARY_DIR}/include/generated/app_smem_pinned_aligned.ld")
-    set(APP_SMEM_PINNED_UNALIGNED_LD
-         "${PROJECT_BINARY_DIR}/include/generated/app_smem_pinned_unaligned.ld")
+  if(CONFIG_USERSPACE)
+    if(CONFIG_LINKER_USE_PINNED_SECTION)
+      set(APP_SMEM_PINNED_ALIGNED_LD
+          "${PROJECT_BINARY_DIR}/include/generated/app_smem_pinned_aligned.ld")
+      set(APP_SMEM_PINNED_UNALIGNED_LD
+          "${PROJECT_BINARY_DIR}/include/generated/app_smem_pinned_unaligned.ld")
 
-    if(NOT CONFIG_LINKER_GENERIC_SECTIONS_PRESENT_AT_BOOT)
-      # The libc partition may hold symbols that are required during boot process,
-      # for example, stack guard (if enabled). So the libc partition must be pinned
-      # if not sections are in physical memory at boot, as the paging mechanism is
-      # only initialized post-kernel.
-      set_property(TARGET app_smem APPEND PROPERTY pinned_partitions "z_libc_partition")
+      if(NOT CONFIG_LINKER_GENERIC_SECTIONS_PRESENT_AT_BOOT)
+        # The libc partition may hold symbols that are required during boot process,
+        # for example, stack guard (if enabled). So the libc partition must be pinned
+        # if not sections are in physical memory at boot, as the paging mechanism is
+        # only initialized post-kernel.
+        set_property(TARGET app_smem APPEND PROPERTY pinned_partitions "z_libc_partition")
+      endif()
+
+      get_property(APP_SMEM_PINNED_PARTITION_LIST TARGET app_smem PROPERTY pinned_partitions)
+      if(APP_SMEM_PINNED_PARTITION_LIST)
+        list(JOIN APP_SMEM_PINNED_PARTITION_LIST "," APP_SMEM_PINNED_PARTITION_LIST_ARG_CSL)
+        set(APP_SMEM_PINNED_PARTITION_LIST_ARG "--pinpartitions=${APP_SMEM_PINNED_PARTITION_LIST_ARG_CSL}")
+      endif()
     endif()
 
-    get_property(APP_SMEM_PINNED_PARTITION_LIST TARGET app_smem PROPERTY pinned_partitions)
-    if(APP_SMEM_PINNED_PARTITION_LIST)
-      list(JOIN APP_SMEM_PINNED_PARTITION_LIST "," APP_SMEM_PINNED_PARTITION_LIST_ARG_CSL)
-      set(APP_SMEM_PINNED_PARTITION_LIST_ARG "--pinpartitions=${APP_SMEM_PINNED_PARTITION_LIST_ARG_CSL}")
+    set(OBJ_FILE_DIR "${PROJECT_BINARY_DIR}/../")
+
+    if(CONFIG_NEWLIB_LIBC)
+      set(NEWLIB_PART -l libc.a z_libc_partition)
     endif()
+    if(CONFIG_NEWLIB_LIBC_NANO)
+      set(NEWLIB_PART -l libc_nano.a z_libc_partition)
+    endif()
+
+    add_custom_command(
+      OUTPUT ${APP_SMEM_UNALIGNED_LD} ${APP_SMEM_PINNED_UNALIGNED_LD}
+      COMMAND ${PYTHON_EXECUTABLE}
+      ${ZEPHYR_BASE}/scripts/gen_app_partitions.py
+      -d ${OBJ_FILE_DIR}
+      -o ${APP_SMEM_UNALIGNED_LD}
+      $<$<BOOL:${APP_SMEM_PINNED_UNALIGNED_LD}>:--pinoutput=${APP_SMEM_PINNED_UNALIGNED_LD}>
+      ${APP_SMEM_PINNED_PARTITION_LIST_ARG}
+      ${NEWLIB_PART}
+      $<TARGET_PROPERTY:zephyr_property_target,COMPILE_OPTIONS>
+      $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
+      DEPENDS
+      kernel
+      ${ZEPHYR_LIBS_PROPERTY}
+      WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/
+      COMMAND_EXPAND_LISTS
+      COMMENT "Generating app_smem_unaligned linker section"
+      )
   endif()
-
-  set(OBJ_FILE_DIR "${PROJECT_BINARY_DIR}/../")
 
   add_custom_target(
     ${APP_SMEM_ALIGNED_DEP}
@@ -1031,32 +1062,6 @@ if(CONFIG_USERSPACE)
     DEPENDS
     ${APP_SMEM_UNALIGNED_LD}
     ${APP_SMEM_PINNED_UNALIGNED_LD}
-    )
-
-  if(CONFIG_NEWLIB_LIBC)
-    set(NEWLIB_PART -l libc.a z_libc_partition)
-  endif()
-  if(CONFIG_NEWLIB_LIBC_NANO)
-    set(NEWLIB_PART -l libc_nano.a z_libc_partition)
-  endif()
-
-  add_custom_command(
-    OUTPUT ${APP_SMEM_UNALIGNED_LD} ${APP_SMEM_PINNED_UNALIGNED_LD}
-    COMMAND ${PYTHON_EXECUTABLE}
-    ${ZEPHYR_BASE}/scripts/gen_app_partitions.py
-    -d ${OBJ_FILE_DIR}
-    -o ${APP_SMEM_UNALIGNED_LD}
-    $<$<BOOL:${APP_SMEM_PINNED_UNALIGNED_LD}>:--pinoutput=${APP_SMEM_PINNED_UNALIGNED_LD}>
-    ${APP_SMEM_PINNED_PARTITION_LIST_ARG}
-    ${NEWLIB_PART}
-    $<TARGET_PROPERTY:zephyr_property_target,COMPILE_OPTIONS>
-    $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
-    DEPENDS
-    kernel
-    ${ZEPHYR_LIBS_PROPERTY}
-    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/
-    COMMAND_EXPAND_LISTS
-    COMMENT "Generating app_smem_unaligned linker section"
     )
 
   configure_linker_script(
@@ -1097,25 +1102,27 @@ if(CONFIG_USERSPACE)
   set_property(TARGET   app_smem_unaligned_prebuilt PROPERTY LINK_DEPENDS ${PROJECT_BINARY_DIR}/linker_app_smem_unaligned.cmd)
   add_dependencies(     app_smem_unaligned_prebuilt linker_app_smem_unaligned_script ${OFFSETS_LIB})
 
-  add_custom_command(
-    OUTPUT ${APP_SMEM_ALIGNED_LD} ${APP_SMEM_PINNED_ALIGNED_LD}
-    COMMAND ${PYTHON_EXECUTABLE}
-    ${ZEPHYR_BASE}/scripts/gen_app_partitions.py
-    -e $<TARGET_FILE:app_smem_unaligned_prebuilt>
-    -o ${APP_SMEM_ALIGNED_LD}
-    $<$<BOOL:${APP_SMEM_PINNED_ALIGNED_LD}>:--pinoutput=${APP_SMEM_PINNED_ALIGNED_LD}>
-    ${APP_SMEM_PINNED_PARTITION_LIST_ARG}
-    ${NEWLIB_PART}
-    $<TARGET_PROPERTY:zephyr_property_target,COMPILE_OPTIONS>
-    $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
-    DEPENDS
-    kernel
-    ${ZEPHYR_LIBS_PROPERTY}
-    app_smem_unaligned_prebuilt
-    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/
-    COMMAND_EXPAND_LISTS
-    COMMENT "Generating app_smem_aligned linker section"
-    )
+  if (CONFIG_USERSPACE)
+    add_custom_command(
+      OUTPUT ${APP_SMEM_ALIGNED_LD} ${APP_SMEM_PINNED_ALIGNED_LD}
+      COMMAND ${PYTHON_EXECUTABLE}
+      ${ZEPHYR_BASE}/scripts/gen_app_partitions.py
+      -e $<TARGET_FILE:app_smem_unaligned_prebuilt>
+      -o ${APP_SMEM_ALIGNED_LD}
+      $<$<BOOL:${APP_SMEM_PINNED_ALIGNED_LD}>:--pinoutput=${APP_SMEM_PINNED_ALIGNED_LD}>
+      ${APP_SMEM_PINNED_PARTITION_LIST_ARG}
+      ${NEWLIB_PART}
+      $<TARGET_PROPERTY:zephyr_property_target,COMPILE_OPTIONS>
+      $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
+      DEPENDS
+      kernel
+      ${ZEPHYR_LIBS_PROPERTY}
+      app_smem_unaligned_prebuilt
+      WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/
+      COMMAND_EXPAND_LISTS
+      COMMENT "Generating app_smem_aligned linker section"
+      )
+  endif()
 endif()
 
 if(CONFIG_USERSPACE)

--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -50,6 +50,14 @@ define_property(GLOBAL PROPERTY ZEPHYR_INTERFACE_LIBS
 zephyr_interface_library_named() appends libs to this list.")
 set_property(GLOBAL PROPERTY ZEPHYR_INTERFACE_LIBS "")
 
+define_property(GLOBAL PROPERTY GENERATED_APP_SOURCE_FILES
+  BRIEF_DOCS "Source files that are generated after Zephyr has been linked once."
+  FULL_DOCS "\
+Source files that are generated after Zephyr has been linked once.\
+May include dev_handles.c etc."
+  )
+set_property(GLOBAL PROPERTY GENERATED_APP_SOURCE_FILES "")
+
 define_property(GLOBAL PROPERTY GENERATED_KERNEL_OBJECT_FILES
   BRIEF_DOCS "Object files that are generated after symbol addresses are fixed."
   FULL_DOCS "\

--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -51,17 +51,17 @@ zephyr_interface_library_named() appends libs to this list.")
 set_property(GLOBAL PROPERTY ZEPHYR_INTERFACE_LIBS "")
 
 define_property(GLOBAL PROPERTY GENERATED_KERNEL_OBJECT_FILES
-  BRIEF_DOCS "Object files that are generated after Zephyr has been linked once."
+  BRIEF_DOCS "Object files that are generated after symbol addresses are fixed."
   FULL_DOCS "\
-Object files that are generated after Zephyr has been linked once.\
+Object files that are generated after symbol addresses are fixed.\
 May include mmu tables, etc."
   )
 set_property(GLOBAL PROPERTY GENERATED_KERNEL_OBJECT_FILES "")
 
 define_property(GLOBAL PROPERTY GENERATED_KERNEL_SOURCE_FILES
-  BRIEF_DOCS "Source files that are generated after Zephyr has been linked once."
+  BRIEF_DOCS "Source files that are generated after symbol addresses are fixed."
   FULL_DOCS "\
-Source files that are generated after Zephyr has been linked once.\
+Source files that are generated after symbol addresses are fixed.\
 May include isr_tables.c etc."
   )
 set_property(GLOBAL PROPERTY GENERATED_KERNEL_SOURCE_FILES "")

--- a/include/device.h
+++ b/include/device.h
@@ -699,51 +699,6 @@ static inline bool device_is_ready(const struct device *dev)
 	Z_DEVICE_STATE_DEFINE(node_id, dev_name, pm_action_cb)		\
 	Z_DEVICE_DEFINE_PM_SLOT(dev_name)
 
-/* Helper macros needed for CONFIG_DEVICE_HANDLE_PADDING. These should
- * be deleted when that option is removed.
- *
- * This is implemented "by hand" -- rather than using a helper macro
- * like UTIL_LISTIFY() -- because we need to allow users to wrap
- * DEVICE_DT_DEFINE with UTIL_LISTIFY, like this:
- *
- *     #define DEFINE_FOO_DEVICE(...) DEVICE_DT_DEFINE(...)
- *     UTIL_LISTIFY(N, DEFINE_FOO_DEVICE)
- *
- * If Z_DEVICE_HANDLE_PADDING uses UTIL_LISTIFY, this type of code
- * would fail, because the UTIL_LISTIFY token within the
- * Z_DEVICE_DEFINE_HANDLES expansion would not be expanded again,
- * since it appears in a context where UTIL_LISTIFY is already being
- * expanded. Standard C does not reexpand macros appearing in their
- * own expansion; this would lead to infinite recursions in general.
- */
-#define Z_DEVICE_HANDLE_PADDING \
-	Z_DEVICE_HANDLE_PADDING_(CONFIG_DEVICE_HANDLE_PADDING)
-#define Z_DEVICE_HANDLE_PADDING_(count) \
-	Z_DEVICE_HANDLE_PADDING__(count)
-#define Z_DEVICE_HANDLE_PADDING__(count) \
-	Z_DEVICE_HANDLE_PADDING_ ## count
-#define Z_DEVICE_HANDLE_PADDING_10 \
-	DEVICE_HANDLE_ENDS, Z_DEVICE_HANDLE_PADDING_9
-#define Z_DEVICE_HANDLE_PADDING_9 \
-	DEVICE_HANDLE_ENDS, Z_DEVICE_HANDLE_PADDING_8
-#define Z_DEVICE_HANDLE_PADDING_8 \
-	DEVICE_HANDLE_ENDS, Z_DEVICE_HANDLE_PADDING_7
-#define Z_DEVICE_HANDLE_PADDING_7 \
-	DEVICE_HANDLE_ENDS, Z_DEVICE_HANDLE_PADDING_6
-#define Z_DEVICE_HANDLE_PADDING_6 \
-	DEVICE_HANDLE_ENDS, Z_DEVICE_HANDLE_PADDING_5
-#define Z_DEVICE_HANDLE_PADDING_5 \
-	DEVICE_HANDLE_ENDS, Z_DEVICE_HANDLE_PADDING_4
-#define Z_DEVICE_HANDLE_PADDING_4 \
-	DEVICE_HANDLE_ENDS, Z_DEVICE_HANDLE_PADDING_3
-#define Z_DEVICE_HANDLE_PADDING_3 \
-	DEVICE_HANDLE_ENDS, Z_DEVICE_HANDLE_PADDING_2
-#define Z_DEVICE_HANDLE_PADDING_2 \
-	DEVICE_HANDLE_ENDS, Z_DEVICE_HANDLE_PADDING_1
-#define Z_DEVICE_HANDLE_PADDING_1 \
-	DEVICE_HANDLE_ENDS, Z_DEVICE_HANDLE_PADDING_0
-#define Z_DEVICE_HANDLE_PADDING_0 EMPTY
-
 /* Initial build provides a record that associates the device object
  * with its devicetree ordinal, and provides the dependency ordinals.
  * These are provided as weak definitions (to prevent the reference
@@ -779,7 +734,6 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 		))							\
 			DEVICE_HANDLE_SEP,				\
 			Z_DEVICE_EXTRA_HANDLES(__VA_ARGS__)		\
-			Z_DEVICE_HANDLE_PADDING				\
 		};
 
 #ifdef CONFIG_PM_DEVICE

--- a/include/linker/common-rom.ld
+++ b/include/linker/common-rom.ld
@@ -219,10 +219,10 @@
 	SECTION_DATA_PROLOGUE(device_handles,,)
 	{
 		__device_handles_start = .;
-#ifdef LINKER_ZEPHYR_FINAL
-		KEEP(*(SORT(.__device_handles_pass2*)));
-#else /* LINKER_ZEPHYR_FINAL */
+#ifdef LINKER_APP_SMEM_UNALIGNED
 		KEEP(*(SORT(.__device_handles_pass1*)));
-#endif /* LINKER_ZEPHYR_FINAL */
+#else
+		KEEP(*(SORT(.__device_handles_pass2*)));
+#endif /* !LINKER_APP_SMEM_UNALIGNED */
 		__device_handles_end = .;
 	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -303,22 +303,6 @@ config WAITQ_DUMB
 
 endchoice # WAITQ_ALGORITHM
 
-config DEVICE_HANDLE_PADDING
-	int "Number of additional device handles to use for padding"
-	default 0
-	range 0 10
-	help
-	  This is a "fudge factor" which works around build system
-	  limitations. It is safe to ignore unless you get a specific
-	  build system error about it.
-
-	  The option's value is the number of superfluous device handle
-	  values which are introduced into the array pointed to by each
-	  device's 'handles' member during the first linker pass.
-
-	  Each handle uses 2 bytes, so a value of 3 would use an extra
-	  6 bytes of ROM for every device.
-
 menu "Kernel Debugging and Metrics"
 
 config INIT_STACKS

--- a/scripts/gen_handles.py
+++ b/scripts/gen_handles.py
@@ -306,21 +306,8 @@ def main():
                 hdls.append(DEVICE_HANDLE_SEP)
                 hdls.extend(hs.ext_deps)
 
-            # When CONFIG_USERSPACE is enabled the pre-built elf is
-            # also used to get hashes that identify kernel objects by
-            # address. We can't allow the size of any object in the
-            # final elf to change. We also must make sure at least one
-            # DEVICE_HANDLE_ENDS is inserted.
-            padding = len(hs.handles) - len(hdls)
-            assert padding > 0, \
-                (f"device {dev.sym.name}: "
-                 "linker pass 1 left no room to insert DEVICE_HANDLE_ENDS. "
-                 "To work around, increase CONFIG_DEVICE_HANDLE_PADDING by " +
-                 str(1 + (-padding)))
-            while padding > 0:
-                hdls.append(DEVICE_HANDLE_ENDS)
-                padding -= 1
-            assert len(hdls) == len(hs.handles), "%s handle overflow" % (dev.sym.name,)
+            # Terminate the array with the end symbol
+            hdls.append(DEVICE_HANDLE_ENDS)
 
             lines = [
                 '',


### PR DESCRIPTION
This PR resolves multiple issues relating to resizing variables between linker passes.

The primary linker stage limitation is that the address space CANNOT shift between `zephyr_prebuilt.elf` and `zephyr.elf`, as kernel object addresses from `zephyr_prebuilt.elf` are used to generate hash tables for `zephyr.elf` when `CONFIG_USERSPACE` is enabled.

Rather that introducing a new linker stage, we can extend the use of an apparently little known third linker stage that is generated before `zephyr_prebuilt.elf`, `app_smem_unaligned_prebuilt.elf`. This stage is currently used when `CONFIG_USERSPACE` is enabled to count kernel objects in order to reserve space in `zephyr_prebuilt.elf`. This is basically the same thing we want to do with the device handle arrays.

With these changes, the final device handle arrays are already present in `zephyr_prebuilt.elf`. This finally resolves the initial reason the device dependency feature was reverted in #31548.

As an added bonus, the size of `.rodata` is strictly reduced, as devices no longer need multiple `DEVICE_HANDLE_ENDS` to pad the arrays.