### PR TITLE
mgmt/mcumgr: Add mising static to zephyr_smp_alloc_rsp

### DIFF
--- a/subsys/mgmt/mcumgr/smp.c
+++ b/subsys/mgmt/mcumgr/smp.c
@@ -1,5 +1,6 @@
 /*
  * Copyright Runtime.io 2018. All rights reserved.
+ * Copyright (c) 2021 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,26 +12,9 @@
 #include "smp/smp.h"
 #include "mgmt/mcumgr/smp.h"
 
-static mgmt_alloc_rsp_fn zephyr_smp_alloc_rsp;
-static mgmt_trim_front_fn zephyr_smp_trim_front;
-static mgmt_reset_buf_fn zephyr_smp_reset_buf;
-static mgmt_write_at_fn zephyr_smp_write_at;
-static mgmt_init_reader_fn zephyr_smp_init_reader;
-static mgmt_init_writer_fn zephyr_smp_init_writer;
-static mgmt_free_buf_fn zephyr_smp_free_buf;
-static smp_tx_rsp_fn zephyr_smp_tx_rsp;
+static const struct mgmt_streamer_cfg zephyr_smp_cbor_cfg;
 
-static const struct mgmt_streamer_cfg zephyr_smp_cbor_cfg = {
-	.alloc_rsp = zephyr_smp_alloc_rsp,
-	.trim_front = zephyr_smp_trim_front,
-	.reset_buf = zephyr_smp_reset_buf,
-	.write_at = zephyr_smp_write_at,
-	.init_reader = zephyr_smp_init_reader,
-	.init_writer = zephyr_smp_init_writer,
-	.free_buf = zephyr_smp_free_buf,
-};
-
-void *
+static void *
 zephyr_smp_alloc_rsp(const void *req, void *arg)
 {
 	const struct net_buf_pool *pool;
@@ -164,6 +148,22 @@ zephyr_smp_write_at(struct cbor_encoder_writer *writer, size_t offset,
 	return 0;
 }
 
+static void
+zephyr_smp_free_buf(void *buf, void *arg)
+{
+	struct zephyr_smp_transport *zst = arg;
+
+	if (!buf) {
+		return;
+	}
+
+	if (zst->zst_ud_free) {
+		zst->zst_ud_free(net_buf_user_data((struct net_buf *)buf));
+	}
+
+	mcumgr_buf_free(buf);
+}
+
 static int
 zephyr_smp_tx_rsp(struct smp_streamer *ns, void *rsp, void *arg)
 {
@@ -198,22 +198,6 @@ zephyr_smp_tx_rsp(struct smp_streamer *ns, void *rsp, void *arg)
 	}
 
 	return 0;
-}
-
-static void
-zephyr_smp_free_buf(void *buf, void *arg)
-{
-	struct zephyr_smp_transport *zst = arg;
-
-	if (!buf) {
-		return;
-	}
-
-	if (zst->zst_ud_free) {
-		zst->zst_ud_free(net_buf_user_data((struct net_buf *)buf));
-	}
-
-	mcumgr_buf_free(buf);
 }
 
 static int
@@ -281,6 +265,16 @@ zephyr_smp_handle_reqs(struct k_work *work)
 		zephyr_smp_process_packet(zst, nb);
 	}
 }
+
+static const struct mgmt_streamer_cfg zephyr_smp_cbor_cfg = {
+	.alloc_rsp = zephyr_smp_alloc_rsp,
+	.trim_front = zephyr_smp_trim_front,
+	.reset_buf = zephyr_smp_reset_buf,
+	.write_at = zephyr_smp_write_at,
+	.init_reader = zephyr_smp_init_reader,
+	.init_writer = zephyr_smp_init_writer,
+	.free_buf = zephyr_smp_free_buf,
+};
 
 void
 zephyr_smp_transport_init(struct zephyr_smp_transport *zst,


### PR DESCRIPTION
The commit adds missing static to the zephyr_smp_alloc_rsp
function definition; it also reorders some of definitions
and removes no longer needed block of forward declarations
of functions.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>