### PR TITLE
Bluetooth: ISO: Store SDU and PHY for peripheral

### DIFF
--- a/include/bluetooth/iso.h
+++ b/include/bluetooth/iso.h
@@ -405,6 +405,10 @@ struct bt_iso_chan_ops {
 	 *  If this callback is provided it will be called whenever the
 	 *  connection completes.
 	 *
+	 *  For a peripheral, the QoS values (see @ref bt_iso_chan_io_qos)
+	 *  are set when this is called. The peripheral does not have any
+	 *  information about the RTN though.
+	 *
 	 *  @param chan The channel that has been connected
 	 */
 	void (*connected)(struct bt_iso_chan *chan);

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -818,6 +818,28 @@ void hci_le_cis_estabilished(struct net_buf *buf)
 	}
 
 	if (!evt->status) {
+		if (iso->role == BT_HCI_ROLE_PERIPHERAL) {
+			struct bt_iso_chan *chan = iso->iso.chan;
+			struct bt_iso_chan_io_qos *rx;
+			struct bt_iso_chan_io_qos *tx;
+
+			__ASSERT(chan != NULL && chan->qos != NULL,
+				 "Invalid ISO chan");
+
+			rx = chan->qos->rx;
+			tx = chan->qos->tx;
+
+			if (rx != NULL) {
+				rx->phy = evt->c_phy;
+				rx->sdu = evt->c_max_pdu;
+			}
+
+			if (tx != NULL) {
+				tx->phy = evt->p_phy;
+				tx->sdu = evt->p_max_pdu;
+			}
+		} /* values are already set for central */
+
 		/* TODO: Add CIG sync delay */
 		bt_conn_set_state(iso, BT_CONN_CONNECTED);
 		bt_conn_unref(iso);


### PR DESCRIPTION
When an CIS is connected, the peripheral did not have
any information about the QoS settings. This commit
adds information about the PHY and SDU. For some reason
the peripheral won't ever have information about the RTN.

The remaining values in the event (interval, delay and
latency) are still not exposed, nor is framing or
packing, the latter of which are not part of the event.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

fixes https://github.com/zephyrproject-rtos/zephyr/issues/31180