### PR TITLE
Bluetooth: controller: mark new LLCP as experimental

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -119,10 +119,11 @@ menu "Advanced features"
 	visible if BT_CTLR_ADVANCED_FEATURES
 
 config BT_LL_SW_SPLIT_LLCP_LEGACY
-	bool "Legacy software-based BLE Link Layer"
+	bool "Legacy software-based BLE Link Layer [EXPERIMENTAL]"
 	default y
 	help
 	  Use Zephyr legacy software BLE Link Layer ULL LLL split implementation.
+	  When not selected the experimental refactored LLCP implementation is used.
 
 config BT_CTLR_SW_DEFERRED_PRIVACY
 	bool "LE Controller-based Software Privacy"


### PR DESCRIPTION
Add text in Kconfig to notify users that the refactored
LLCP is experimental

Signed-off-by: Andries Kruithof <Andries.Kruithof@nordicsemi.no>