### PR TITLE
drivers: gpio: code refactor and dts updates

### DIFF
--- a/boards/riscv/esp32c3_devkitm/esp32c3_devkitm.dts
+++ b/boards/riscv/esp32c3_devkitm/esp32c3_devkitm.dts
@@ -39,6 +39,7 @@
 &trng0 {
 	status = "okay";
 };
+
 &gpio0 {
 	status = "okay";
 };

--- a/boards/xtensa/esp32/esp32.dts
+++ b/boards/xtensa/esp32/esp32.dts
@@ -59,6 +59,14 @@
 	hw-flow-control;
 };
 
+&gpio0 {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};
+
 &i2c0 {
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;

--- a/boards/xtensa/esp32s2_saola/esp32s2_saola.dts
+++ b/boards/xtensa/esp32s2_saola/esp32s2_saola.dts
@@ -28,6 +28,14 @@
 	current-speed = <115200>;
 };
 
+&gpio0 {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};
+
 &timer0 {
 	status = "okay";
 };

--- a/drivers/gpio/Kconfig.esp32
+++ b/drivers/gpio/Kconfig.esp32
@@ -3,28 +3,8 @@
 # Copyright (c) 2017 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig GPIO_ESP32
+config GPIO_ESP32
 	bool "ESP32 GPIO"
 	depends on SOC_ESP32 || SOC_ESP32S2 || SOC_ESP32C3
 	help
 	  Enables the ESP32 GPIO driver
-
-if GPIO_ESP32
-
-config GPIO_ESP32_0
-	bool "ESP32 GPIO (pins 0-31)"
-	default y
-	help
-	  Include support for GPIO pins 0-31 on the ESP32.
-
-if !SOC_ESP32C3
-
-config GPIO_ESP32_1
-	bool "ESP32 GPIO (pins 32-39)"
-	default y
-	help
-	  Include support for GPIO pins 32-39 on the ESP32.
-
-endif # SOC_ESP32C3
-
-endif # GPIO_ESP32

--- a/drivers/pinmux/pinmux_esp32.c
+++ b/drivers/pinmux/pinmux_esp32.c
@@ -50,6 +50,7 @@ static int pinmux_pullup(const struct device *dev, uint32_t pin, uint8_t func)
 		gpio_ll_pullup_dis(&GPIO, pin);
 		break;
 	case PINMUX_PULLUP_ENABLE:
+		gpio_ll_pulldown_dis(&GPIO, pin);
 		gpio_ll_pullup_en(&GPIO, pin);
 		break;
 	default:

--- a/drivers/pwm/pwm_led_esp32.c
+++ b/drivers/pwm/pwm_led_esp32.c
@@ -12,6 +12,7 @@
 #include <esp32/rom/gpio.h>
 #include <soc/gpio_sig_map.h>
 #include <soc/ledc_reg.h>
+#include <drivers/gpio/gpio_esp32.h>
 
 #include <soc.h>
 #include <errno.h>
@@ -88,23 +89,6 @@ static inline void set_mask32(uint32_t v, uint32_t mem_addr)
 static inline void clear_mask32(uint32_t v, uint32_t mem_addr)
 {
 	sys_write32(sys_read32(mem_addr) & ~v, mem_addr);
-}
-
-static const char *esp32_get_gpio_for_pin(int pin)
-{
-	if (pin < 32) {
-#if defined(CONFIG_GPIO_ESP32_0)
-		return DT_INST_LABEL(0);
-#else
-		return NULL;
-#endif /* CONFIG_GPIO_ESP32_0 */
-	}
-
-#if defined(CONFIG_GPIO_ESP32_1)
-	return DT_INST_LABEL(1);
-#else
-	return NULL;
-#endif /* CONFIG_GPIO_ESP32_1 */
 }
 /* end Remove after PR 5113 */
 
@@ -225,7 +209,7 @@ static int pwm_led_esp32_channel_set(int pin, bool speed_mode, int channel,
 	pwm_led_esp32_bind_channel_timer(speed_mode, channel, timer);
 
 	/* Set pin */
-	device_name = esp32_get_gpio_for_pin(pin);
+	device_name = gpio_esp32_get_gpio_for_pin(pin);
 	if (!device_name) {
 		return -EINVAL;
 	}

--- a/include/drivers/gpio/gpio_esp32.h
+++ b/include/drivers/gpio/gpio_esp32.h
@@ -8,18 +8,18 @@
 static const char *gpio_esp32_get_gpio_for_pin(int pin)
 {
 	if (pin < 32) {
-#if defined(CONFIG_GPIO_ESP32_0)
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(gpio0), okay)
 		return DT_LABEL(DT_INST(0, espressif_esp32_gpio));
 #else
 		return NULL;
-#endif /* CONFIG_GPIO_ESP32_0 */
+#endif
 	}
 
-#if defined(CONFIG_GPIO_ESP32_1)
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(gpio1), okay)
 	return DT_LABEL(DT_INST(1, espressif_esp32_gpio));
 #else
 	return NULL;
-#endif /* CONFIG_GPIO_ESP32_1 */
+#endif
 }
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_GPIO_GPIO_ESP32_H_ */


### PR DESCRIPTION
This PR refactor ESP32 and ESP32S2 gpio implementation by using DTS definitions
instead of depending on kconfig values and ifdefs. It also fixes some pinmux and
missing function checks, which automatically fixes some gpio issues.

Closes #39601
Closes #39463