### PR TITLE
soc: esp32: fix number of supported cores

### DIFF
--- a/soc/xtensa/esp32/Kconfig.defconfig
+++ b/soc/xtensa/esp32/Kconfig.defconfig
@@ -12,7 +12,7 @@ config IRQ_OFFLOAD_INTNUM
 	default 7
 
 config MP_NUM_CPUS
-	default 2
+	default 1
 
 config MINIMAL_LIBC_OPTIMIZE_STRING_FOR_SIZE
 	default n


### PR DESCRIPTION
Current ESP32 implementation does not support 2 CPUS.
Explicit set this to single core.

Closes #39487

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>