### PR TITLE
libc: minimal: Add strtoll() and strtoull()

### DIFF
--- a/doc/guides/portability/posix.rst
+++ b/doc/guides/portability/posix.rst
@@ -308,9 +308,9 @@ This is implemented as part of the minimal C library available in Zephyr.
     strtok_r(),+
     strtol(),+
     strtold(),
-    strtoll(),
+    strtoll(),+
     strtoul(),+
-    strtoull(),
+    strtoull(),+
     strtoumax(),
     strxfrm(),
     time(),+

--- a/lib/libc/minimal/CMakeLists.txt
+++ b/lib/libc/minimal/CMakeLists.txt
@@ -8,6 +8,8 @@ zephyr_library_sources(
   source/stdlib/atoi.c
   source/stdlib/strtol.c
   source/stdlib/strtoul.c
+  source/stdlib/strtoll.c
+  source/stdlib/strtoull.c
   source/stdlib/malloc.c
   source/stdlib/bsearch.c
   source/stdlib/exit.c

--- a/lib/libc/minimal/include/stdlib.h
+++ b/lib/libc/minimal/include/stdlib.h
@@ -18,6 +18,8 @@ extern "C" {
 
 unsigned long strtoul(const char *nptr, char **endptr, int base);
 long strtol(const char *nptr, char **endptr, int base);
+unsigned long long strtoull(const char *nptr, char **endptr, int base);
+long long strtoll(const char *nptr, char **endptr, int base);
 int atoi(const char *s);
 
 void *malloc(size_t size);

--- a/lib/libc/minimal/source/stdlib/strtoll.c
+++ b/lib/libc/minimal/source/stdlib/strtoll.c
@@ -1,0 +1,110 @@
+/* SPDX-License-Identifier: BSD-4-Clause-UC */
+/*-
+ * Copyright (c) 1990, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgment:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+#include <limits.h>
+#include <ctype.h>
+#include <errno.h>
+#include <stdlib.h>
+
+/*
+ * Convert a string to a long long integer.
+ *
+ * Ignores `locale' stuff.  Assumes that the upper and lower case
+ * alphabets and digits are each contiguous.
+ */
+long long strtoll(const char *nptr, char **endptr, register int base)
+{
+	register const char *s = nptr;
+	register unsigned long long acc;
+	register int c;
+	register unsigned long long cutoff;
+	register int neg = 0, any, cutlim;
+
+	/*
+	 * See strtol for comments as to the logic used.
+	 */
+	do {
+		c = *s++;
+	} while (isspace(c));
+	if (c == '-') {
+		neg = 1;
+		c = *s++;
+	} else if (c == '+') {
+		c = *s++;
+	}
+
+	if ((base == 0 || base == 16) && c == '0' && (*s == 'x' || *s == 'X')) {
+		c = s[1];
+		s += 2;
+		base = 16;
+	}
+
+	if (base == 0) {
+		base = c == '0' ? 8 : 10;
+	}
+
+	cutoff = neg ? -(unsigned long long)LLONG_MIN : LLONG_MAX;
+	cutlim = cutoff % (unsigned long long)base;
+	cutoff /= (unsigned long long)base;
+	for (acc = 0, any = 0;; c = *s++) {
+		if (isdigit(c)) {
+			c -= '0';
+		} else if (isalpha(c)) {
+			c -= isupper(c) ? 'A' - 10 : 'a' - 10;
+		} else {
+			break;
+		}
+		if (c >= base) {
+			break;
+		}
+		if (any < 0 || acc > cutoff || (acc == cutoff && c > cutlim)) {
+			any = -1;
+		} else {
+			any = 1;
+			acc *= base;
+			acc += c;
+		}
+	}
+
+	if (any < 0) {
+		acc = neg ? LLONG_MIN : LLONG_MAX;
+		errno = ERANGE;
+	} else if (neg) {
+		acc = -acc;
+	}
+
+	if (endptr != NULL) {
+		*endptr = (char *)(any ? s - 1 : nptr);
+	}
+	return acc;
+}

--- a/lib/libc/minimal/source/stdlib/strtoull.c
+++ b/lib/libc/minimal/source/stdlib/strtoull.c
@@ -1,0 +1,108 @@
+/* SPDX-License-Identifier: BSD-4-Clause-UC */
+
+/*
+ * Copyright (c) 1990, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgment:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+#include <limits.h>
+#include <ctype.h>
+#include <errno.h>
+#include <stdlib.h>
+
+/*
+ * Convert a string to an unsigned long long integer.
+ *
+ * Ignores `locale' stuff.  Assumes that the upper and lower case
+ * alphabets and digits are each contiguous.
+ */
+unsigned long long strtoull(const char *nptr, char **endptr, register int base)
+{
+	register const char *s = nptr;
+	register unsigned long long acc;
+	register int c;
+	register unsigned long long cutoff;
+	register int neg = 0, any, cutlim;
+
+	/*
+	 * See strtol for comments as to the logic used.
+	 */
+	do {
+		c = *s++;
+	} while (isspace(c));
+	if (c == '-') {
+		neg = 1;
+		c = *s++;
+	} else if (c == '+') {
+		c = *s++;
+	}
+
+	if ((base == 0 || base == 16) && c == '0' && (*s == 'x' || *s == 'X')) {
+		c = s[1];
+		s += 2;
+		base = 16;
+	}
+
+	if (base == 0) {
+		base = c == '0' ? 8 : 10;
+	}
+
+	cutoff = (unsigned long long)ULLONG_MAX / (unsigned long long)base;
+	cutlim = (unsigned long long)ULLONG_MAX % (unsigned long long)base;
+	for (acc = 0, any = 0;; c = *s++) {
+		if (isdigit(c)) {
+			c -= '0';
+		} else if (isalpha(c)) {
+			c -= isupper(c) ? 'A' - 10 : 'a' - 10;
+		} else {
+			break;
+		}
+		if (c >= base) {
+			break;
+		}
+		if (any < 0 || acc > cutoff || (acc == cutoff && c > cutlim)) {
+			any = -1;
+		} else {
+			any = 1;
+			acc *= base;
+			acc += c;
+		}
+	}
+	if (any < 0) {
+		acc = ULLONG_MAX;
+		errno = ERANGE;
+	} else if (neg) {
+		acc = -acc;
+	}
+	if (endptr != NULL) {
+		*endptr = (char *)(any ? s - 1 : nptr);
+	}
+	return acc;
+}

--- a/samples/net/civetweb/common/include/libc_extensions.h
+++ b/samples/net/civetweb/common/include/libc_extensions.h
@@ -26,10 +26,8 @@ size_t strspn(const char *s1, const char *s2);
 int iscntrl(int c);
 
 double atof(const char *str);
-long long strtoll(const char *str, char **endptr, int base);
 int sscanf(const char *s, const char *format, ...);
 char *strerror(int err);
-unsigned long long strtoull(const char *str, char **endptr, int base);
 
 time_t time(time_t *t);
 struct tm *gmtime(const time_t *ptime);

--- a/samples/net/civetweb/common/src/libc_extensions.c
+++ b/samples/net/civetweb/common/src/libc_extensions.c
@@ -153,12 +153,6 @@ double atof(const char *str)
 	return (double)atoi(str);
 }
 
-long long strtoll(const char *str, char **endptr, int base)
-{
-	/* XXX good enough for civetweb uses */
-	return (long long)strtol(str, endptr, base);
-}
-
 /*
  * Most of the wrappers below are copies of the wrappers in net/sockets.h,
  * but they are available only if CONFIG_NET_SOCKETS_POSIX_NAMES is enabled

--- a/tests/lib/c_lib/src/main.c
+++ b/tests/lib/c_lib/src/main.c
@@ -814,6 +814,163 @@ void test_strtoul(void)
 
 /**
  *
+ * @brief test strtoll function
+ *
+ * @see strtoll().
+ *
+ */
+void test_strtoll(void)
+{
+	static const char buf1[] = "+10379aegi";
+	static const char buf2[] = "   -10379aegi";
+	static const char buf3[] = "-010379aegi";
+	static const char buf4[] = "0x10379aegi";
+	static const char buf5[] = "0X10379aegi";
+	static const char buf6[] = "01037aegi";
+	static const char buf7[] = "1037aegi";
+	static const char buf8[] = "++1037aegi";
+	static const char buf9[] = "A1037aegi";
+	static const char buf10[] = "a1037aegi";
+	static const char str_normal[] = "-1011 This stopped it";
+	static const char str_abnormal[] = "ABCDEFGH";
+	char *stop = NULL;
+	long long ret;
+
+	/* test function strtoll() */
+	ret = strtoll(buf3, NULL, 8);
+	zassert_equal(ret, -543, "strtoll base = 8 failed");
+	ret = strtoll(buf1, NULL, 10);
+	zassert_equal(ret, 10379, "strtoll base = 10 failed");
+	ret = strtoll(buf2, NULL, 10);
+	zassert_equal(ret, -10379, "strtoll base = 10 failed");
+	ret = strtoll(buf4, NULL, 16);
+	zassert_equal(ret, 17004974, "strtoll base = 16 failed");
+	ret = strtoll(buf4, NULL, 0);
+	zassert_equal(ret, 17004974, "strtoll base = 16 failed");
+	ret = strtoll(buf5, NULL, 0);
+	zassert_equal(ret, 17004974, "strtoll base = 16 failed");
+	ret = strtoll(buf6, NULL, 0);
+	zassert_equal(ret, 543, "strtoll base = 8 failed");
+	ret = strtoll(buf7, NULL, 0);
+	zassert_equal(ret, 1037, "strtoll base = 10 failed");
+	ret = strtoll(buf8, NULL, 10);
+	zassert_not_equal(ret, 1037, "strtoll base = 10 failed");
+	ret = strtoll(buf9, NULL, 10);
+	zassert_not_equal(ret, 1037, "strtoll base = 10 failed");
+	ret = strtoll(buf10, NULL, 10);
+	zassert_not_equal(ret, 1037, "strtoll base = 10 failed");
+
+	ret = strtoll(str_normal, &stop, 10);
+	zassert_equal(ret, -1011, "strtoll base = 10 failed");
+	zassert_true((strcmp(stop, " This stopped it") == 0), "strtoll get stop failed");
+
+	ret = strtoll(str_abnormal, &stop, 0);
+	zassert_equal(ret, 0, "strtoll base = 0 failed");
+	zassert_true((strcmp(stop, "ABCDEFGH") == 0), "strtoll get stop failed");
+
+	char border1[] = "-9223372036854775808";
+	char border2[] = "+9223372036854775807";
+	char border3[] = "+9223372036854775806";
+	char border4[] = "922337203685477580000000";
+	char border5[] = "0x0000000000000000000000000000000000001";
+	char border6[] = "10000000000000000000000000000000000001";
+	char border7[] = "-10000000000000000000000000000000000001";
+
+	ret = strtoll(border1, NULL, 10);
+	zassert_equal(ret, LLONG_MIN, "strtoll base = 10 failed");
+	ret = strtoll(border2, NULL, 10);
+	zassert_equal(ret, LLONG_MAX, "strtoll base = 10 failed");
+	ret = strtoll(border3, NULL, 10);
+	zassert_equal(ret, 9223372036854775806, "strtoll base = 10 failed");
+	ret = strtoll(border4, NULL, 10);
+	zassert_equal(ret, LLONG_MAX, "strtoll base = 10 failed");
+	ret = strtoull(border5, NULL, 16);
+	zassert_equal(ret, 1, "strtoull base = 16 failed, %s != 0x%x", border5, ret);
+	ret = strtoull(border6, NULL, 10);
+	zassert_equal(errno, ERANGE, "strtoull base = 10 failed, %s != %lld", border6, ret);
+	ret = strtoull(border7, NULL, 10);
+	zassert_equal(errno, ERANGE, "strtoull base = 10 failed, %s != %lld", border7, ret);
+}
+
+/**
+ *
+ * @brief test strtoull function
+ *
+ * @see strtoull().
+ *
+ */
+void test_strtoull(void)
+{
+	static const char buf1[] = "+10379aegi";
+	static const char buf2[] = "   -10379aegi";
+	static const char buf3[] = "-010379aegi";
+	static const char buf4[] = "0x10379aegi";
+	static const char buf5[] = "0X10379aegi";
+	static const char buf6[] = "01037aegi";
+	static const char buf7[] = "1037aegi";
+	static const char buf8[] = "++1037aegi";
+	static const char buf9[] = "A1037aegi";
+	static const char buf10[] = "a1037aegi";
+	static const char str_normal[] = "-1011 This stopped it";
+	static const char str_abnormal[] = "ABCDEFGH";
+	char *stop = NULL;
+	unsigned long long ret;
+
+	/* test function strtoull() */
+	ret = strtoull(buf3, NULL, 8);
+	zassert_equal(ret, -543, "strtoull base = 8 failed");
+	ret = strtoull(buf1, NULL, 10);
+	zassert_equal(ret, 10379, "strtoull base = 10 failed");
+	ret = strtoull(buf2, NULL, 10);
+	zassert_equal(ret, -10379, "strtoull base = 10 failed");
+	ret = strtoull(buf4, NULL, 16);
+	zassert_equal(ret, 17004974, "strtoull base = 16 failed");
+	ret = strtoull(buf4, NULL, 0);
+	zassert_equal(ret, 17004974, "strtoull base = 16 failed");
+	ret = strtoull(buf5, NULL, 0);
+	zassert_equal(ret, 17004974, "strtoull base = 16 failed");
+	ret = strtoull(buf6, NULL, 0);
+	zassert_equal(ret, 543, "strtoull base = 8 failed");
+	ret = strtoull(buf7, NULL, 0);
+	zassert_equal(ret, 1037, "strtoull base = 10 failed");
+	ret = strtoull(buf8, NULL, 10);
+	zassert_not_equal(ret, 1037, "strtoull base = 10 failed");
+	ret = strtoull(buf9, NULL, 10);
+	zassert_not_equal(ret, 1037, "strtoull base = 10 failed");
+	ret = strtoull(buf10, NULL, 10);
+	zassert_not_equal(ret, 1037, "strtoull base = 10 failed");
+
+	ret = strtoull(str_normal, &stop, 10);
+	zassert_equal(ret, -1011, "strtoull base = 10 failed");
+	zassert_true((strcmp(stop, " This stopped it") == 0), "strtoull get stop failed");
+
+	ret = strtoull(str_abnormal, &stop, 0);
+	zassert_equal(ret, 0, "strtoull base = 0 failed");
+	zassert_true((strcmp(stop, "ABCDEFGH") == 0), "strtoull get stop failed");
+
+	char border1[] = "+18446744073709551615";
+	char border2[] = "-18446744073709551615000";
+	char border3[] = "+18446744073709551619";
+	char border4[] = "0x0000000000000000000000000000000000001";
+	char border5[] = "10000000000000000000000000000000000001";
+	char border6[] = "-10000000000000000000000000000000000001";
+
+	ret = strtoull(border1, NULL, 10);
+	zassert_equal(ret, ULLONG_MAX, "strtoull base = 10 failed");
+	ret = strtoull(border2, NULL, 10);
+	zassert_equal(ret, ULLONG_MAX, "strtoull base = 10 failed");
+	ret = strtoull(border3, NULL, 10);
+	zassert_equal(ret, ULLONG_MAX, "strtoull base = 10 failed");
+	ret = strtoull(border4, NULL, 16);
+	zassert_equal(ret, 1, "strtoull base = 16 failed, %s != 0x%x", border4, ret);
+	ret = strtoull(border5, NULL, 10);
+	zassert_equal(errno, ERANGE, "strtoull base = 10 failed, %s != %lld", border5, ret);
+	ret = strtoull(border6, NULL, 10);
+	zassert_equal(errno, ERANGE, "strtoull base = 10 failed, %s != %lld", border6, ret);
+}
+
+/**
+ *
  * @brief test convert function
  *
  */
@@ -1075,6 +1232,8 @@ void test_main(void)
 			 ztest_unit_test(test_strncmp),
 			 ztest_unit_test(test_strtol),
 			 ztest_unit_test(test_strtoul),
+			 ztest_unit_test(test_strtoll),
+			 ztest_unit_test(test_strtoull),
 			 ztest_unit_test(test_checktype),
 			 ztest_unit_test(test_memchr),
 			 ztest_unit_test(test_memcpy),


### PR DESCRIPTION
strtoll() and strtoull() are copies of strtol() and strtoul() with types
changed to long long instead of long.

Signed-off-by: Gerhard Jörges <joerges@metratec.com>

Closes #36645