### PR TITLE
drivers: modem: gsm: allow the user to get modem information

### DIFF
--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -353,16 +353,16 @@ MODEM_CMD_DEFINE(on_cmd_atcmdinfo_rssi_cesq)
 	rxlev = ATOI(argv[0], 0, "rxlev");
 
 	if (rsrp >= 0 && rsrp <= 97) {
-		gsm.context.data_rssi = -140 + (rsrp - 1);
-		LOG_INF("RSRP: %d", gsm.context.data_rssi);
+		minfo.mdm_rssi = -140 + (rsrp - 1);
+		LOG_INF("RSRP: %d", minfo.mdm_rssi);
 	} else if (rscp >= 0 && rscp <= 96) {
-		gsm.context.data_rssi = -120 + (rscp - 1);
-		LOG_INF("RSCP: %d", gsm.context.data_rssi);
+		minfo.mdm_rssi = -120 + (rscp - 1);
+		LOG_INF("RSCP: %d", minfo.mdm_rssi);
 	} else if (rxlev >= 0 && rxlev <= 63) {
-		gsm.context.data_rssi = -110 + (rxlev - 1);
-		LOG_INF("RSSI: %d", gsm.context.data_rssi);
+		minfo.mdm_rssi = -110 + (rxlev - 1);
+		LOG_INF("RSSI: %d", minfo.mdm_rssi);
 	} else {
-		gsm.context.data_rssi = GSM_RSSI_INVALID;
+		minfo.mdm_rssi = GSM_RSSI_INVALID;
 		LOG_INF("RSRP/RSCP/RSSI not known");
 	}
 
@@ -382,7 +382,7 @@ MODEM_CMD_DEFINE(on_cmd_atcmdinfo_rssi_csq)
 			rssi = GSM_RSSI_INVALID;
 		}
 
-		gsm.context.data_rssi = rssi;
+		minfo.mdm_rssi = rssi;
 		LOG_INF("RSSI: %d", rssi);
 	}
 
@@ -697,8 +697,8 @@ attaching:
 		/* Read connection quality (RSSI) before PPP carrier is ON */
 		rssi_handler(NULL);
 
-		if (!(gsm->context.data_rssi && gsm->context.data_rssi != GSM_RSSI_INVALID &&
-			gsm->context.data_rssi < GSM_RSSI_MAXVAL)) {
+		if (!(minfo.mdm_rssi && minfo.mdm_rssi != GSM_RSSI_INVALID &&
+			minfo.mdm_rssi < GSM_RSSI_MAXVAL)) {
 
 			LOG_DBG("Not valid RSSI, %s", "retrying...");
 			if (gsm->rssi_retries-- > 0) {
@@ -1113,6 +1113,7 @@ static int gsm_init(const struct device *dev)
 	gsm->context.data_imsi = minfo.mdm_imsi;
 	gsm->context.data_iccid = minfo.mdm_iccid;
 #endif	/* CONFIG_MODEM_SIM_NUMBERS */
+	gsm->context.data_rssi = minfo.mdm_rssi;
 #endif	/* CONFIG_MODEM_SHELL */
 
 	gsm->context.is_automatic_oper = false;

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -15,7 +15,7 @@ LOG_MODULE_REGISTER(modem_gsm, CONFIG_MODEM_LOG_LEVEL);
 #include <sys/ring_buffer.h>
 #include <sys/util.h>
 #include <net/ppp.h>
-#include <drivers/gsm_ppp.h>
+#include <drivers/modem/gsm_ppp.h>
 #include <drivers/uart.h>
 #include <drivers/console/uart_mux.h>
 

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -85,6 +85,7 @@ static struct gsm_modem {
 	bool mux_setup_done : 1;
 	bool setup_done : 1;
 	bool attached : 1;
+	bool modem_info_queried : 1;
 
 	void *user_data;
 
@@ -98,6 +99,7 @@ K_KERNEL_STACK_DEFINE(gsm_rx_stack, GSM_RX_STACK_SIZE);
 
 struct k_thread gsm_rx_thread;
 static struct k_work_delayable rssi_work_handle;
+static struct gsm_ppp_modem_info minfo;
 
 #if defined(CONFIG_MODEM_GSM_ENABLE_CESQ_RSSI)
 	/* helper macro to keep readability */
@@ -194,27 +196,6 @@ MODEM_CMD_DEFINE(on_cmd_atcmdinfo_cops)
 
 	return 0;
 }
-
-#if defined(CONFIG_MODEM_SHELL)
-#define MDM_MANUFACTURER_LENGTH  10
-#define MDM_MODEL_LENGTH         16
-#define MDM_REVISION_LENGTH      64
-#define MDM_IMEI_LENGTH          16
-#define MDM_IMSI_LENGTH          16
-#define MDM_ICCID_LENGTH         32
-
-struct modem_info {
-	char mdm_manufacturer[MDM_MANUFACTURER_LENGTH];
-	char mdm_model[MDM_MODEL_LENGTH];
-	char mdm_revision[MDM_REVISION_LENGTH];
-	char mdm_imei[MDM_IMEI_LENGTH];
-#if defined(CONFIG_MODEM_SIM_NUMBERS)
-	char mdm_imsi[MDM_IMSI_LENGTH];
-	char mdm_iccid[MDM_ICCID_LENGTH];
-#endif
-};
-
-static struct modem_info minfo;
 
 /*
  * Provide modem info if modem shell is enabled. This can be shown with
@@ -358,7 +339,6 @@ static int gsm_query_cellinfo(struct gsm_modem *gsm)
 	return ret;
 }
 #endif /* CONFIG_MODEM_CELL_INFO */
-#endif /* CONFIG_MODEM_SHELL */
 
 #if defined(CONFIG_MODEM_GSM_ENABLE_CESQ_RSSI)
 /*
@@ -420,6 +400,18 @@ static const struct modem_cmd read_rssi_cmd =
 	MODEM_CMD("+CSQ:", on_cmd_atcmdinfo_rssi_csq, 2U, ",");
 #endif
 
+static const struct setup_cmd setup_modem_info_cmds[] = {
+	/* query modem info */
+	SETUP_CMD("AT+CGMI", "", on_cmd_atcmdinfo_manufacturer, 0U, ""),
+	SETUP_CMD("AT+CGMM", "", on_cmd_atcmdinfo_model, 0U, ""),
+	SETUP_CMD("AT+CGMR", "", on_cmd_atcmdinfo_revision, 0U, ""),
+	SETUP_CMD("AT+CGSN", "", on_cmd_atcmdinfo_imei, 0U, ""),
+#if defined(CONFIG_MODEM_SIM_NUMBERS)
+	SETUP_CMD("AT+CIMI", "", on_cmd_atcmdinfo_imsi, 0U, ""),
+	SETUP_CMD("AT+CCID", "", on_cmd_atcmdinfo_iccid, 0U, ""),
+#endif
+};
+
 static const struct setup_cmd setup_cmds[] = {
 	/* no echo */
 	SETUP_CMD_NOHANDLE("ATE0"),
@@ -427,18 +419,6 @@ static const struct setup_cmd setup_cmds[] = {
 	SETUP_CMD_NOHANDLE("ATH"),
 	/* extender errors in numeric form */
 	SETUP_CMD_NOHANDLE("AT+CMEE=1"),
-
-#if defined(CONFIG_MODEM_SHELL)
-	/* query modem info */
-	SETUP_CMD("AT+CGMI", "", on_cmd_atcmdinfo_manufacturer, 0U, ""),
-	SETUP_CMD("AT+CGMM", "", on_cmd_atcmdinfo_model, 0U, ""),
-	SETUP_CMD("AT+CGMR", "", on_cmd_atcmdinfo_revision, 0U, ""),
-# if defined(CONFIG_MODEM_SIM_NUMBERS)
-	SETUP_CMD("AT+CIMI", "", on_cmd_atcmdinfo_imsi, 0U, ""),
-	SETUP_CMD("AT+CCID", "", on_cmd_atcmdinfo_iccid, 0U, ""),
-# endif
-	SETUP_CMD("AT+CGSN", "", on_cmd_atcmdinfo_imei, 0U, ""),
-#endif
 
 	/* disable unsolicited network registration codes */
 	SETUP_CMD_NOHANDLE("AT+CREG=0"),
@@ -474,6 +454,30 @@ static const struct setup_cmd connect_cmds[] = {
 	/* connect to network */
 	SETUP_CMD_NOHANDLE("ATD*99#"),
 };
+
+static int gsm_query_modem_info(struct gsm_modem *gsm)
+{
+	int ret;
+
+	if (gsm->modem_info_queried) {
+		return 0;
+	}
+
+	ret =  modem_cmd_handler_setup_cmds_nolock(&gsm->context.iface,
+						  &gsm->context.cmd_handler,
+						  setup_modem_info_cmds,
+						  ARRAY_SIZE(setup_modem_info_cmds),
+						  &gsm->sem_response,
+						  GSM_CMD_SETUP_TIMEOUT);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	gsm->modem_info_queried = true;
+
+	return 0;
+}
 
 static int gsm_setup_mccmno(struct gsm_modem *gsm)
 {
@@ -641,6 +645,13 @@ static void gsm_finalize_connection(struct gsm_modem *gsm)
 	if (ret < 0) {
 		LOG_DBG("modem setup returned %d, %s",
 			ret, "retrying...");
+		(void)k_work_reschedule(&gsm->gsm_configure_work, K_SECONDS(1));
+		return;
+	}
+
+	ret = gsm_query_modem_info(gsm);
+	if (ret < 0) {
+		LOG_DBG("Unable to query modem information %d", ret);
 		(void)k_work_reschedule(&gsm->gsm_configure_work, K_SECONDS(1));
 		return;
 	}
@@ -1057,6 +1068,13 @@ void gsm_ppp_register_modem_power_callback(const struct device *dev,
 	gsm->modem_off_cb = modem_off;
 
 	gsm->user_data = user_data;
+}
+
+const struct gsm_ppp_modem_info *gsm_ppp_modem_info(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	return &minfo;
 }
 
 static int gsm_init(const struct device *dev)

--- a/include/drivers/modem/gsm_ppp.h
+++ b/include/drivers/modem/gsm_ppp.h
@@ -7,6 +7,24 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_MODEM_GSM_PPP_H_
 #define ZEPHYR_INCLUDE_DRIVERS_MODEM_GSM_PPP_H_
 
+#define GSM_PPP_MDM_MANUFACTURER_LENGTH  10
+#define GSM_PPP_MDM_MODEL_LENGTH         16
+#define GSM_PPP_MDM_REVISION_LENGTH      64
+#define GSM_PPP_MDM_IMEI_LENGTH          16
+#define GSM_PPP_MDM_IMSI_LENGTH          16
+#define GSM_PPP_MDM_ICCID_LENGTH         32
+
+struct gsm_ppp_modem_info {
+	char mdm_manufacturer[GSM_PPP_MDM_MANUFACTURER_LENGTH];
+	char mdm_model[GSM_PPP_MDM_MODEL_LENGTH];
+	char mdm_revision[GSM_PPP_MDM_REVISION_LENGTH];
+	char mdm_imei[GSM_PPP_MDM_IMEI_LENGTH];
+#if defined(CONFIG_MODEM_SIM_NUMBERS)
+	char mdm_imsi[GSM_PPP_MDM_IMSI_LENGTH];
+	char mdm_iccid[GSM_PPP_MDM_ICCID_LENGTH];
+#endif
+};
+
 /** @cond INTERNAL_HIDDEN */
 struct device;
 typedef void (*gsm_modem_power_cb)(const struct device *, void *);
@@ -31,5 +49,14 @@ void gsm_ppp_register_modem_power_callback(const struct device *dev,
 					   gsm_modem_power_cb modem_on,
 					   gsm_modem_power_cb modem_off,
 					   void *user_data);
+
+/**
+ * @brief Get GSM modem information.
+ *
+ * @param dev: GSM modem device.
+ *
+ * @retval struct gsm_ppp_modem_info * pointer to modem information structure.
+ */
+const struct gsm_ppp_modem_info *gsm_ppp_modem_info(const struct device *dev);
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_MODEM_GSM_PPP_H_ */

--- a/include/drivers/modem/gsm_ppp.h
+++ b/include/drivers/modem/gsm_ppp.h
@@ -23,6 +23,7 @@ struct gsm_ppp_modem_info {
 	char mdm_imsi[GSM_PPP_MDM_IMSI_LENGTH];
 	char mdm_iccid[GSM_PPP_MDM_ICCID_LENGTH];
 #endif
+	int  mdm_rssi;
 };
 
 /** @cond INTERNAL_HIDDEN */

--- a/include/drivers/modem/gsm_ppp.h
+++ b/include/drivers/modem/gsm_ppp.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef GSM_PPP_H_
-#define GSM_PPP_H_
+#ifndef ZEPHYR_INCLUDE_DRIVERS_MODEM_GSM_PPP_H_
+#define ZEPHYR_INCLUDE_DRIVERS_MODEM_GSM_PPP_H_
 
 /** @cond INTERNAL_HIDDEN */
 struct device;
@@ -32,4 +32,4 @@ void gsm_ppp_register_modem_power_callback(const struct device *dev,
 					   gsm_modem_power_cb modem_off,
 					   void *user_data);
 
-#endif /* GSM_PPP_H_ */
+#endif /* ZEPHYR_INCLUDE_DRIVERS_MODEM_GSM_PPP_H_ */


### PR DESCRIPTION
Make modem_info structure public in order to allow the user
to get modem information using gsm_ppp_modem_info function.

Signed-off-by: Bartosz Bilas <b.bilas@grinn-global.com>