### PR TITLE
scripts: gen_relocate_app.py: Support relocating noinit sections

### DIFF
--- a/cmake/linker/arcmwdt/target.cmake
+++ b/cmake/linker/arcmwdt/target.cmake
@@ -205,6 +205,8 @@ macro(toolchain_ld_relocation)
        "${PROJECT_BINARY_DIR}/include/generated/linker_sram_data_relocate.ld")
   set(MEM_RELOCATION_SRAM_BSS_LD
        "${PROJECT_BINARY_DIR}/include/generated/linker_sram_bss_relocate.ld")
+  set(MEM_RELOCATION_SRAM_NOINIT_LD
+       "${PROJECT_BINARY_DIR}/include/generated/linker_sram_noinit_relocate.ld")
   set(MEM_RELOCATION_CODE "${PROJECT_BINARY_DIR}/code_relocation.c")
 
   add_custom_command(
@@ -218,6 +220,7 @@ macro(toolchain_ld_relocation)
     -o ${MEM_RELOCATION_LD}
     -s ${MEM_RELOCATION_SRAM_DATA_LD}
     -b ${MEM_RELOCATION_SRAM_BSS_LD}
+    -n ${MEM_RELOCATION_SRAM_NOINIT_LD}
     -c ${MEM_RELOCATION_CODE}
     DEPENDS app kernel ${ZEPHYR_LIBS_PROPERTY}
     )

--- a/cmake/linker/ld/target_relocation.cmake
+++ b/cmake/linker/ld/target_relocation.cmake
@@ -8,6 +8,8 @@ macro(toolchain_ld_relocation)
        "${PROJECT_BINARY_DIR}/include/generated/linker_sram_data_relocate.ld")
   set(MEM_RELOCATION_SRAM_BSS_LD
        "${PROJECT_BINARY_DIR}/include/generated/linker_sram_bss_relocate.ld")
+  set(MEM_RELOCATION_SRAM_NOINIT_LD
+       "${PROJECT_BINARY_DIR}/include/generated/linker_sram_noinit_relocate.ld")
   set(MEM_RELOCATION_CODE "${PROJECT_BINARY_DIR}/code_relocation.c")
 
   add_custom_command(
@@ -21,6 +23,7 @@ macro(toolchain_ld_relocation)
     -o ${MEM_RELOCATION_LD}
     -s ${MEM_RELOCATION_SRAM_DATA_LD}
     -b ${MEM_RELOCATION_SRAM_BSS_LD}
+    -n ${MEM_RELOCATION_SRAM_NOINIT_LD}
     -c ${MEM_RELOCATION_CODE}
     DEPENDS app kernel ${ZEPHYR_LIBS_PROPERTY}
     )

--- a/doc/kernel/code-relocation.rst
+++ b/doc/kernel/code-relocation.rst
@@ -5,7 +5,7 @@ Code And Data Relocation
 
 Overview
 ********
-This feature will allow relocating .text, .rodata, .data, and .bss sections from
+This feature will allow relocating .text, .rodata, .data, .bss and .noinit sections from
 required files and place them in the required memory region. The memory region
 and file are given to the :ref:`gen_relocate_app.py` script in the form
 of a string. This script is always invoked from inside cmake.
@@ -79,7 +79,7 @@ This section shows additional configuration options that can be set in
      zephyr_code_relocate(src/file1.c SRAM2)
      zephyr_code_relocate(src/file2.c.c SRAM)
 
-* if the memory type is appended with _DATA, _TEXT, _RODATA or _BSS, only the
+* if the memory type is appended with _DATA, _TEXT, _RODATA, _BSS or _NOINIT, only the
   selected memory is placed in the required memory region.
   for example:
 

--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -176,10 +176,14 @@ do {                                                                    \
 				"." Z_STRINGIFY(c))))
 #define __in_section(a, b, c) ___in_section(a, b, c)
 
-#define __in_section_unique(seg) ___in_section(seg, __FILE__, __COUNTER__)
+#ifndef Z_UNIQUE_FILE_ID
+#define Z_UNIQUE_FILE_ID __FILE__
+#endif
+
+#define __in_section_unique(seg) ___in_section(seg, Z_UNIQUE_FILE_ID, __COUNTER__)
 
 #define __in_section_unique_named(seg, name) \
-	___in_section(seg, __FILE__, name)
+	___in_section(seg, Z_UNIQUE_FILE_ID, name)
 
 /* When using XIP, using '__ramfunc' places a function into RAM instead
  * of FLASH. Make sure '__ramfunc' is defined only when


### PR DESCRIPTION
This PR adds support for relocating `noinit` sections with the `zephyr_code_relocate` cmake extension.