### PR TITLE
dma: channel type consistency

### DIFF
--- a/include/drivers/dma.h
+++ b/include/drivers/dma.h
@@ -210,8 +210,8 @@ struct dma_status {
  *
  */
 struct dma_context {
-	int32_t magic;
-	int dma_channels;
+	uint32_t magic;
+	uint32_t dma_channels;
 	atomic_t *atomic;
 };
 
@@ -386,7 +386,7 @@ __syscall int dma_request_channel(const struct device *dev,
 static inline int z_impl_dma_request_channel(const struct device *dev,
 					     void *filter_param)
 {
-	int i = 0;
+	uint32_t i = 0;
 	int channel = -EINVAL;
 	const struct dma_driver_api *api =
 		(const struct dma_driver_api *)dev->api;


### PR DESCRIPTION
channels in dma.h use int type where all API use uint32, also
magic is int but is a bounded 32bit number

This is a resubmit of [#39578](https://github.com/zephyrproject-rtos/zephyr/pull/39578) due to a stuff up in rebasing, apologies.
