### PR TITLE
twister: Fix skipping unskippable tests when --subset is used

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -3285,6 +3285,7 @@ class TestSuite(DisablePyTestCollectionMixin):
         self.discards = discards
         self.selected_platforms = set(p.platform.name for p in self.instances.values())
 
+        remove_from_discards = [] # configurations to be removed from discards.
         for instance in self.discards:
             instance.reason = self.discards[instance]
             # If integration mode is on all skips on integration_platforms are treated as errors.
@@ -3294,12 +3295,18 @@ class TestSuite(DisablePyTestCollectionMixin):
                 instance.reason += " but is one of the integration platforms"
                 instance.fill_results_by_status()
                 self.instances[instance.name] = instance
+                # Such configuration has to be removed from discards to make sure it won't get skipped
+                remove_from_discards.append(instance)
             else:
                 instance.status = "skipped"
                 instance.fill_results_by_status()
 
         self.filtered_platforms = set(p.platform.name for p in self.instances.values()
                                       if p.status != "skipped" )
+
+        # Remove from discards configururations that must not be discarded (e.g. integration_platforms when --integration was used)
+        for instance in remove_from_discards:
+            del self.discards[instance]
 
         return discards
 

--- a/scripts/twister
+++ b/scripts/twister
@@ -1178,11 +1178,13 @@ def main():
 
         sliced_instances = islice(to_run.items(), start, end)
         skipped = {k : v for k,v in suite.instances.items() if v.status == 'skipped'}
+        errors = {k : v for k,v in suite.instances.items() if v.status == 'error'}
         suite.instances = OrderedDict(sliced_instances)
         if subset == 1:
-            # add all pre-filtered tests that are skipped to the first set to
-            # allow for better distribution among all sets.
+            # add all pre-filtered tests that are skipped or got error status
+            # to the first set to allow for better distribution among all sets.
             suite.instances.update(skipped)
+            suite.instances.update(errors)
 
     if options.save_tests:
         suite.csv_report(options.save_tests)


### PR DESCRIPTION
Fixes a bug causing tests with error status get silently skipped
when --subset is used.

Fixes: #39619

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>