### PR TITLE
cmake + toolchain: Unique source file ID

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -65,6 +65,27 @@
 #  zephyr_compile_options()     --->  target_compile_options()
 #
 
+# override the target_sources function to inject a unique ID definition for each source file
+function(target_sources target_name)
+  foreach(src ${ARGN})
+    if(NOT src STREQUAL "PRIVATE" AND
+       NOT src STREQUAL "PUBLIC" AND
+       NOT src STREQUAL "INTERFACE"
+    )
+      # convert to an absolute path to be unique
+      cmake_path(ABSOLUTE_PATH src NORMALIZE)
+      # replace special characters with an underscore
+      string(REGEX REPLACE "[\\\/\.]" "_" unique_id ${src})
+      # add the definition
+      set_property(SOURCE ${src}
+        APPEND PROPERTY COMPILE_DEFINITIONS
+        "Z_UNIQUE_FILE_ID=${unique_id}")
+    endif()
+  endforeach()
+
+  # Call the original function
+  _target_sources(${target_name} ${ARGN})
+endfunction()
 
 # https://cmake.org/cmake/help/latest/command/target_sources.html
 function(zephyr_sources)

--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -154,10 +154,14 @@ do {                                                                    \
 				"." Z_STRINGIFY(c))))
 #define __in_section(a, b, c) ___in_section(a, b, c)
 
-#define __in_section_unique(seg) ___in_section(seg, __FILE__, __COUNTER__)
+#ifndef Z_UNIQUE_FILE_ID
+#define Z_UNIQUE_FILE_ID __FILE__
+#endif
+
+#define __in_section_unique(seg) ___in_section(seg, Z_UNIQUE_FILE_ID, __COUNTER__)
 
 #define __in_section_unique_named(seg, name) \
-	___in_section(seg, __FILE__, name)
+	___in_section(seg, Z_UNIQUE_FILE_ID, name)
 
 /* When using XIP, using '__ramfunc' places a function into RAM instead
  * of FLASH. Make sure '__ramfunc' is defined only when


### PR DESCRIPTION
This PR introduces a mechanism to add a unique ID for each source file. This mechanism is then used to generate unique section names that do not contain any `\/.` characters.

This fixes an issue where it was impossible to relocate variables/functions using the cmake `zephyr_code_relocate` function if they were placed in a unique section.