### PR TITLE
MAINTAINERS: add Laird Connectivity to mcumgr

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1069,6 +1069,8 @@ MCU Manager:
     status: maintained
     maintainers:
         - de-nordic
+    collaborators:
+        - @LairdCP/zephyr
     files:
         - subsys/mgmt/mcumgr/
         - include/mgmt/mcumgr/


### PR DESCRIPTION
Laird Connectivity relies on mcumgr as the main
communication solution for our products over BLE and
UART.
