### PR TITLE
Update NXP HAL to add mcux-sdk

### DIFF
--- a/soc/arm/nxp_lpc/lpc54xxx/soc.c
+++ b/soc/arm/nxp_lpc/lpc54xxx/soc.c
@@ -24,7 +24,9 @@
 #include <fsl_clock.h>
 #include <fsl_common.h>
 #include <fsl_device_registers.h>
+#ifdef CONFIG_GPIO_MCUX_LPC
 #include <fsl_pint.h>
+#endif
 
 /**
  *

--- a/soc/arm/nxp_lpc/lpc55xxx/soc.c
+++ b/soc/arm/nxp_lpc/lpc55xxx/soc.c
@@ -24,7 +24,9 @@
 #include <fsl_clock.h>
 #include <fsl_common.h>
 #include <fsl_device_registers.h>
+#ifdef CONFIG_GPIO_MCUX_LPC
 #include <fsl_pint.h>
+#endif
 #if CONFIG_USB_DC_NXP_LPCIP3511
 #include "usb_phy.h"
 #include "usb_dc_mcux.h"

--- a/west.yml
+++ b/west.yml
@@ -98,7 +98,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 47262f22f0f832d456d0ad8d0cb4cd4dde56be30
+      revision: 66db7c2a57ec1adfd3574169346ed3af9bf17c0b
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
`mcux-sdk` is added to get SDK drivers from the `mcux-sdk` github repo