### PR TITLE
board: arm64: refine the dts of fvp-baser-aemv8r

### DIFF
--- a/boards/arm64/fvp_baser_aemv8r/fvp_baser_aemv8r.dts
+++ b/boards/arm64/fvp_baser_aemv8r/fvp_baser_aemv8r.dts
@@ -5,9 +5,7 @@
 
 /dts-v1/;
 
-#include <mem.h>
-#include <arm64/armv8-r.dtsi>
-#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <arm64/fvp-aemv8r/fvp-aemv8r.dtsi>
 
 / {
 	model = "FVP BaseR AEMv8R";
@@ -29,78 +27,7 @@
 		label = "PSCI";
 	};
 
-	cpus {
-		#address-cells = <1>;
-		#size-cells = <0>;
-
-		cpu@0 {
-			device_type = "cpu";
-			compatible = "arm,cortex-r82";
-			reg = <0>;
-		};
-
-		cpu@1 {
-			device_type = "cpu";
-			compatible = "arm,cortex-r82";
-			reg = <1>;
-		};
-
-		cpu@2 {
-			device_type = "cpu";
-			compatible = "arm,cortex-r82";
-			reg = <2>;
-		};
-
-		cpu@3 {
-			device_type = "cpu";
-			compatible = "arm,cortex-r82";
-			reg = <3>;
-		};
-	};
-
-	timer {
-		compatible = "arm,armv8-timer";
-		interrupt-parent = <&gic>;
-		interrupts = <GIC_PPI 13 IRQ_TYPE_LEVEL
-			      IRQ_DEFAULT_PRIORITY>,
-			     <GIC_PPI 14 IRQ_TYPE_LEVEL
-			      IRQ_DEFAULT_PRIORITY>,
-			     <GIC_PPI 11 IRQ_TYPE_LEVEL
-			      IRQ_DEFAULT_PRIORITY>,
-			     <GIC_PPI 10 IRQ_TYPE_LEVEL
-			      IRQ_DEFAULT_PRIORITY>;
-		label = "arch_timer";
-	};
-
-	uartclk: apb-pclk {
-		compatible = "fixed-clock";
-		clock-frequency = <24000000>;
-		#clock-cells = <0>;
-	};
-
 	soc {
-		interrupt-parent = <&gic>;
-
-		gic: interrupt-controller@af000000 {
-			compatible = "arm,gic";
-			reg = <0xaf000000 0x1000>,
-			      <0xaf100000 0x100>;
-			interrupt-controller;
-			#interrupt-cells = <4>;
-			label = "GIC";
-			status = "okay";
-		};
-
-		uart0: uart@9c090000 {
-			compatible = "arm,pl011";
-			reg = <0x9c090000 0x1000>;
-			status = "disabled";
-			interrupts = <GIC_SPI 1 0 IRQ_TYPE_LEVEL>;
-			interrupt-names = "irq_0";
-			label = "UART_0";
-			clocks = <&uartclk>;
-		};
-
 		flash0: flash@0 {
 			compatible = "soc-nv-flash";
 			reg = <0x0 DT_SIZE_K(64)>;

--- a/dts/arm64/fvp-aemv8r/fvp-aemv8r.dtsi
+++ b/dts/arm64/fvp-aemv8r/fvp-aemv8r.dtsi
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2021 Arm Limited (or its affiliates). All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <arm64/armv8-r.dtsi>
+#include <dt-bindings/interrupt-controller/arm-gic.h>
+
+/ {
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,cortex-r82";
+			reg = <0>;
+		};
+
+		cpu@1 {
+			device_type = "cpu";
+			compatible = "arm,cortex-r82";
+			reg = <1>;
+		};
+
+		cpu@2 {
+			device_type = "cpu";
+			compatible = "arm,cortex-r82";
+			reg = <2>;
+		};
+
+		cpu@3 {
+			device_type = "cpu";
+			compatible = "arm,cortex-r82";
+			reg = <3>;
+		};
+	};
+
+	timer {
+		compatible = "arm,armv8-timer";
+		interrupt-parent = <&gic>;
+		interrupts = <GIC_PPI 13 IRQ_TYPE_LEVEL
+			      IRQ_DEFAULT_PRIORITY>,
+			     <GIC_PPI 14 IRQ_TYPE_LEVEL
+			      IRQ_DEFAULT_PRIORITY>,
+			     <GIC_PPI 11 IRQ_TYPE_LEVEL
+			      IRQ_DEFAULT_PRIORITY>,
+			     <GIC_PPI 10 IRQ_TYPE_LEVEL
+			      IRQ_DEFAULT_PRIORITY>;
+		label = "arch_timer";
+	};
+
+	uartclk: apb-pclk {
+		compatible = "fixed-clock";
+		clock-frequency = <24000000>;
+		#clock-cells = <0>;
+	};
+
+	soc {
+		interrupt-parent = <&gic>;
+
+		gic: interrupt-controller@af000000 {
+			compatible = "arm,gic";
+			reg = <0xaf000000 0x1000>,
+			      <0xaf100000 0x100>;
+			interrupt-controller;
+			#interrupt-cells = <4>;
+			label = "GIC";
+			status = "okay";
+		};
+
+		uart0: uart@9c090000 {
+			compatible = "arm,pl011";
+			reg = <0x9c090000 0x1000>;
+			status = "disabled";
+			interrupts = <GIC_SPI 1 0 IRQ_TYPE_LEVEL>;
+			interrupt-names = "irq_0";
+			label = "UART_0";
+			clocks = <&uartclk>;
+		};
+	};
+};


### PR DESCRIPTION
Pick those common node in 'fvp-baser-aemv8r.dts' to 'fvp-aemv8r.dtsi'
which reside in 'dts/arm64/fvp-aemv8r' directory.

Signed-off-by: Huifeng Zhang <Huifeng.Zhang@arm.com>