### PR TITLE
net: coap: FETCH, PATCH and iPATCH support

### DIFF
--- a/include/net/coap.h
+++ b/include/net/coap.h
@@ -73,6 +73,7 @@ enum coap_method {
 	COAP_METHOD_POST = 2,
 	COAP_METHOD_PUT = 3,
 	COAP_METHOD_DELETE = 4,
+	COAP_METHOD_FETCH = 5,
 };
 
 #define COAP_REQUEST_MASK 0x07
@@ -139,6 +140,7 @@ enum coap_response_code {
 	COAP_RESPONSE_CODE_REQUEST_TOO_LARGE = coap_make_response_code(4, 13),
 	COAP_RESPONSE_CODE_UNSUPPORTED_CONTENT_FORMAT =
 						coap_make_response_code(4, 15),
+	COAP_RESPONSE_CODE_UNPROCESSABLE_ENTITY = coap_make_response_code(4, 22),
 	COAP_RESPONSE_CODE_INTERNAL_ERROR = coap_make_response_code(5, 0),
 	COAP_RESPONSE_CODE_NOT_IMPLEMENTED = coap_make_response_code(5, 1),
 	COAP_RESPONSE_CODE_BAD_GATEWAY = coap_make_response_code(5, 2),
@@ -203,7 +205,7 @@ typedef void (*coap_notify_t)(struct coap_resource *resource,
  */
 struct coap_resource {
 	/** Which function to be called for each CoAP method */
-	coap_method_t get, post, put, del;
+	coap_method_t get, post, put, del, fetch;
 	coap_notify_t notify;
 	const char * const *path;
 	void *user_data;

--- a/include/net/coap.h
+++ b/include/net/coap.h
@@ -74,6 +74,8 @@ enum coap_method {
 	COAP_METHOD_PUT = 3,
 	COAP_METHOD_DELETE = 4,
 	COAP_METHOD_FETCH = 5,
+	COAP_METHOD_PATCH = 6,
+	COAP_METHOD_IPATCH = 7,
 };
 
 #define COAP_REQUEST_MASK 0x07
@@ -136,6 +138,7 @@ enum coap_response_code {
 	COAP_RESPONSE_CODE_NOT_ALLOWED = coap_make_response_code(4, 5),
 	COAP_RESPONSE_CODE_NOT_ACCEPTABLE = coap_make_response_code(4, 6),
 	COAP_RESPONSE_CODE_INCOMPLETE = coap_make_response_code(4, 8),
+	COAP_RESPONSE_CODE_CONFLICT = coap_make_response_code(4, 9),
 	COAP_RESPONSE_CODE_PRECONDITION_FAILED = coap_make_response_code(4, 12),
 	COAP_RESPONSE_CODE_REQUEST_TOO_LARGE = coap_make_response_code(4, 13),
 	COAP_RESPONSE_CODE_UNSUPPORTED_CONTENT_FORMAT =
@@ -166,6 +169,8 @@ enum coap_content_format {
 	COAP_CONTENT_FORMAT_APP_OCTET_STREAM = 42,
 	COAP_CONTENT_FORMAT_APP_EXI = 47,
 	COAP_CONTENT_FORMAT_APP_JSON = 50,
+	COAP_CONTENT_FORMAT_APP_JSON_PATCH_JSON = 51,
+	COAP_CONTENT_FORMAT_APP_MERGE_PATCH_JSON = 52,
 	COAP_CONTENT_FORMAT_APP_CBOR = 60,
 };
 
@@ -205,7 +210,7 @@ typedef void (*coap_notify_t)(struct coap_resource *resource,
  */
 struct coap_resource {
 	/** Which function to be called for each CoAP method */
-	coap_method_t get, post, put, del, fetch;
+	coap_method_t get, post, put, del, fetch, patch, ipatch;
 	coap_notify_t notify;
 	const char * const *path;
 	void *user_data;

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -706,6 +706,8 @@ uint8_t coap_header_get_code(const struct coap_packet *cpkt)
 	case COAP_METHOD_PUT:
 	case COAP_METHOD_DELETE:
 	case COAP_METHOD_FETCH:
+	case COAP_METHOD_PATCH:
+	case COAP_METHOD_IPATCH:
 
 	/* All the defined response codes */
 	case COAP_RESPONSE_CODE_OK:
@@ -723,6 +725,7 @@ uint8_t coap_header_get_code(const struct coap_packet *cpkt)
 	case COAP_RESPONSE_CODE_NOT_ALLOWED:
 	case COAP_RESPONSE_CODE_NOT_ACCEPTABLE:
 	case COAP_RESPONSE_CODE_INCOMPLETE:
+	case COAP_RESPONSE_CODE_CONFLICT:
 	case COAP_RESPONSE_CODE_PRECONDITION_FAILED:
 	case COAP_RESPONSE_CODE_REQUEST_TOO_LARGE:
 	case COAP_RESPONSE_CODE_UNSUPPORTED_CONTENT_FORMAT:
@@ -830,6 +833,10 @@ static coap_method_t method_from_code(const struct coap_resource *resource,
 		return resource->del;
 	case COAP_METHOD_FETCH:
 		return resource->fetch;
+	case COAP_METHOD_PATCH:
+		return resource->patch;
+	case COAP_METHOD_IPATCH:
+		return resource->ipatch;
 	default:
 		return NULL;
 	}

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -705,6 +705,7 @@ uint8_t coap_header_get_code(const struct coap_packet *cpkt)
 	case COAP_METHOD_POST:
 	case COAP_METHOD_PUT:
 	case COAP_METHOD_DELETE:
+	case COAP_METHOD_FETCH:
 
 	/* All the defined response codes */
 	case COAP_RESPONSE_CODE_OK:
@@ -725,6 +726,7 @@ uint8_t coap_header_get_code(const struct coap_packet *cpkt)
 	case COAP_RESPONSE_CODE_PRECONDITION_FAILED:
 	case COAP_RESPONSE_CODE_REQUEST_TOO_LARGE:
 	case COAP_RESPONSE_CODE_UNSUPPORTED_CONTENT_FORMAT:
+	case COAP_RESPONSE_CODE_UNPROCESSABLE_ENTITY:
 	case COAP_RESPONSE_CODE_INTERNAL_ERROR:
 	case COAP_RESPONSE_CODE_NOT_IMPLEMENTED:
 	case COAP_RESPONSE_CODE_BAD_GATEWAY:
@@ -826,6 +828,8 @@ static coap_method_t method_from_code(const struct coap_resource *resource,
 		return resource->put;
 	case COAP_METHOD_DELETE:
 		return resource->del;
+	case COAP_METHOD_FETCH:
+		return resource->fetch;
 	default:
 		return NULL;
 	}


### PR DESCRIPTION
Adds support for new CoAP methods based on the RFC 8132 - PATCH and FETCH Methods for the Constrained Application Protocol (CoAP). 
* FETCH
* PATCH
* iPATCH 

Additionally to the methods the RFC adds two new error codes
* 4.09 (Conflict)
* 4.22 (Unprocessable Entity). 
