### PR TITLE
net: lwm2m: Add observe callback for observe and notification events

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_object.h
+++ b/subsys/net/lib/lwm2m/lwm2m_object.h
@@ -148,14 +148,6 @@ struct lwm2m_message;
 #define LWM2M_PATH_LEVEL_RESOURCE_INST 4
 
 /* path representing object instances */
-struct lwm2m_obj_path {
-	uint16_t obj_id;
-	uint16_t obj_inst_id;
-	uint16_t res_id;
-	uint16_t res_inst_id;
-	uint8_t  level;  /* 0/1/2/3/4 (4 = resource instance) */
-};
-
 #define OBJ_FIELD(_id, _perm, _type) \
 	{ .res_id = _id, \
 	  .permissions = LWM2M_PERM_ ## _perm, \

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -1052,7 +1052,8 @@ static void lwm2m_rd_client_service(struct k_work *work)
 }
 
 void lwm2m_rd_client_start(struct lwm2m_ctx *client_ctx, const char *ep_name,
-			   uint32_t flags, lwm2m_ctx_event_cb_t event_cb)
+			   uint32_t flags, lwm2m_ctx_event_cb_t event_cb,
+			   lwm2m_observe_cb_t observe_cb)
 {
 	k_mutex_lock(&client.mutex, K_FOREVER);
 
@@ -1068,6 +1069,7 @@ void lwm2m_rd_client_start(struct lwm2m_ctx *client_ctx, const char *ep_name,
 	client.ctx = client_ctx;
 	client.ctx->sock_fd = -1;
 	client.ctx->fault_cb = socket_fault_cb;
+	client.ctx->observe_cb = observe_cb;
 	client.event_cb = event_cb;
 	client.use_bootstrap = flags & LWM2M_RD_CLIENT_FLAG_BOOTSTRAP;
 


### PR DESCRIPTION
Added an observe callback so that the application can register to
receive events like observer added/deleted, and notification acked/
timed out. The notifications can be traced back to the exact data
contained within them by use of the user_data pointer.

Fixes #38531.

Signed-off-by: Maik Vermeulen <maik.vermeulen@innotractor.com>