### PR TITLE
Bluetooth: Shell: Fix bad string formats in GATT shell

### DIFF
--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -719,7 +719,7 @@ static int cmd_show_db(const struct shell *sh, size_t argc, char *argv[])
 	total_len += stats.ccc_count * sizeof(struct _bt_gatt_ccc);
 
 	shell_print(sh, "=================================================");
-	shell_print(sh, "Total: %u services %u attributes (%u bytes)",
+	shell_print(sh, "Total: %u services %u attributes (%zu bytes)",
 		    stats.svc_count, stats.attr_count, total_len);
 
 	return 0;
@@ -1046,7 +1046,7 @@ static uint8_t get_cb(const struct bt_gatt_attr *attr, uint16_t handle,
 
 	ret = attr->read(NULL, attr, (void *)buf, sizeof(buf), 0);
 	if (ret < 0) {
-		shell_print(sh, "Failed to read: %d", ret);
+		shell_print(sh, "Failed to read: %zd", ret);
 		return BT_GATT_ITER_STOP;
 	}
 
@@ -1099,7 +1099,7 @@ static uint8_t set_cb(const struct bt_gatt_attr *attr, uint16_t handle,
 	ret = attr->write(NULL, attr, (void *)buf, i, 0, 0);
 	if (ret < 0) {
 		data->err = ret;
-		shell_error(data->sh, "Failed to write: %d", ret);
+		shell_error(data->sh, "Failed to write: %zd", ret);
 		return BT_GATT_ITER_STOP;
 	}
 
@@ -1135,7 +1135,7 @@ int cmd_att_mtu(const struct shell *sh, size_t argc, char *argv[])
 
 	if (default_conn) {
 		mtu = bt_gatt_get_mtu(default_conn);
-		shell_print(sh, "MTU size: %d", mtu);
+		shell_print(sh, "MTU size: %u", mtu);
 	} else {
 		shell_print(sh, "No default connection");
 	}


### PR DESCRIPTION
Some shell prints didn't use the correct format for some
values, causing warnings/build errors.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>