### PR TITLE
fs/shell: Fix formatting for output of ssize_t variable

### DIFF
--- a/subsys/fs/shell.c
+++ b/subsys/fs/shell.c
@@ -378,7 +378,7 @@ static int cmd_cat(const struct shell *shell, size_t argc, char **argv)
 		}
 
 		if (read < 0) {
-			shell_error(shell, "Failed to read from file %s (err: %d)",
+			shell_error(shell, "Failed to read from file %s (err: %zd)",
 				path, read);
 		}
 


### PR DESCRIPTION
Fix compilation error for devices where ssize_t can not
be formatted with %d, due to ssize_t not being equal int.

Fixes #39629

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>