### PR TITLE
console: Kconfig: Remove EXPERIMENTAL marker

### DIFF
--- a/subsys/console/Kconfig
+++ b/subsys/console/Kconfig
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig CONSOLE_SUBSYS
-	bool "Console subsystem/support routines [EXPERIMENTAL]"
+	bool "Console subsystem/support routines"
 	help
 	  Console subsystem and helper functions
 


### PR DESCRIPTION
Originally, it was added to allow to slightly vary API (e.g. function
signatures) without burdening the subsys with compatibility stabs.
There were not many changes recently, and with EXPERIMENTAL master
switch which is planned to be added soon, it's better to remove
this marker so the subsys remained accessible as it was before.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>