### PR TITLE
runners: jlink: verify the success of the programming 

### DIFF
--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -638,8 +638,8 @@ class ZephyrBinaryRunner(abc.ABC):
         '''
         self._log_cmd(cmd)
         if _DRY_RUN:
-            return
-        subprocess.check_call(cmd, **kwargs)
+            return None
+        return subprocess.check_call(cmd, **kwargs)
 
     def check_output(self, cmd: List[str], **kwargs) -> bytes:
         '''Subclass subprocess.check_output() wrapper.

--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -314,4 +314,12 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
             kwargs = {}
             if not self.logger.isEnabledFor(logging.DEBUG):
                 kwargs['stdout'] = subprocess.DEVNULL
-            self.check_call(cmd, **kwargs)
+
+            try:
+                self.check_call(cmd, **kwargs)
+                # Workaround to detect if programmer is connected
+                output = self.check_output(cmd)
+                if 'Cannot connect to J-Link' in str(output):
+                    raise RuntimeError('Connecting to J-Link failed')
+            except subprocess.CalledProcessError as error:
+                print('Flashing error {}'.format(error))


### PR DESCRIPTION
It turned out that when we call west flash command without
a connected programmer the return code is 0 so add some
checks to be sure that device flashing is successful.

Signed-off-by: Bartosz Bilas <b.bilas@grinn-global.com>