### PR TITLE
net: coap: block1 option fixes

### DIFF
--- a/include/net/coap.h
+++ b/include/net/coap.h
@@ -640,6 +640,22 @@ int coap_update_from_block(const struct coap_packet *cpkt,
 			   struct coap_block_context *ctx);
 
 /**
+ * @brief Updates @a ctx according to @a option set in @a cpkt
+ * so after this is called the current entry indicates the correct
+ * offset in the body of data being transferred.
+ *
+ * @param cpkt Packet in which to look for block-wise transfers options
+ * @param ctx Block context to be updated
+ * @param option Either COAP_OPTION_BLOCK1 or COAP_OPTION_BLOCK2
+ *
+ * @return The offset in the block-wise transfer, 0 if the transfer
+ * has finished or a negative value in case of an error.
+ */
+int coap_next_block_for_option(const struct coap_packet *cpkt,
+			       struct coap_block_context *ctx,
+			       enum coap_option_num option);
+
+/**
  * @brief Updates @a ctx so after this is called the current entry
  * indicates the correct offset in the body of data being
  * transferred.

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -1008,7 +1008,10 @@ static int update_control_block1(struct coap_block_context *ctx,
 	}
 
 	ctx->block_size = GET_BLOCK_SIZE(block);
-	ctx->total_size = size;
+
+	if (size >= 0) {
+		ctx->total_size = size;
+	}
 
 	return 0;
 }
@@ -1046,16 +1049,13 @@ int coap_update_from_block(const struct coap_packet *cpkt,
 	size1 = coap_get_option_int(cpkt, COAP_OPTION_SIZE1);
 	size2 = coap_get_option_int(cpkt, COAP_OPTION_SIZE2);
 
-	size1 = size1 == -ENOENT ? 0 : size1;
-	size2 = size2 == -ENOENT ? 0 : size2;
-
 	if (is_request(cpkt)) {
 		r = update_control_block2(ctx, block2, size2);
 		if (r) {
 			return r;
 		}
 
-		return update_descriptive_block(ctx, block1, size1);
+		return update_descriptive_block(ctx, block1, size1 == -ENOENT ? 0 : size1);
 	}
 
 	r = update_control_block1(ctx, block1, size1);
@@ -1063,7 +1063,7 @@ int coap_update_from_block(const struct coap_packet *cpkt,
 		return r;
 	}
 
-	return update_descriptive_block(ctx, block2, size2);
+	return update_descriptive_block(ctx, block2, size2 == -ENOENT ? 0 : size2);
 }
 
 size_t coap_next_block(const struct coap_packet *cpkt,

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -1066,15 +1066,20 @@ int coap_update_from_block(const struct coap_packet *cpkt,
 	return update_descriptive_block(ctx, block2, size2 == -ENOENT ? 0 : size2);
 }
 
-size_t coap_next_block(const struct coap_packet *cpkt,
-		       struct coap_block_context *ctx)
+int coap_next_block_for_option(const struct coap_packet *cpkt,
+			       struct coap_block_context *ctx,
+			       enum coap_option_num option)
 {
 	int block;
 
-	if (is_request(cpkt)) {
-		block = coap_get_option_int(cpkt, COAP_OPTION_BLOCK1);
-	} else {
-		block = coap_get_option_int(cpkt, COAP_OPTION_BLOCK2);
+	if (option != COAP_OPTION_BLOCK1 && option != COAP_OPTION_BLOCK2) {
+		return -EINVAL;
+	}
+
+	block = coap_get_option_int(cpkt, option);
+
+	if (block < 0) {
+		return block;
 	}
 
 	if (!GET_MORE(block)) {
@@ -1083,7 +1088,19 @@ size_t coap_next_block(const struct coap_packet *cpkt,
 
 	ctx->current += coap_block_size_to_bytes(ctx->block_size);
 
-	return ctx->current;
+	return (int)ctx->current;
+}
+
+size_t coap_next_block(const struct coap_packet *cpkt,
+		       struct coap_block_context *ctx)
+{
+	enum coap_option_num option;
+	int ret;
+
+	option = is_request(cpkt) ? COAP_OPTION_BLOCK1 : COAP_OPTION_BLOCK2;
+	ret = coap_next_block_for_option(cpkt, ctx, option);
+
+	return MAX(ret, 0);
 }
 
 int coap_pending_init(struct coap_pending *pending,


### PR DESCRIPTION
This PR fixes issues related to transferring blocked data to a CoAP server.

A CoAP server can respond with a `block1` option indicating if it is willing and able to handle the transfer request. The client should handle this option accordingly.

The `coap_next_block` function only handled the `block1` option in case of a request, however a response can have the `block1` all the same. The function is kept for backwards compatibility.