### PR TITLE
west.yml: Update mcumgr to backport fix for issue #38502

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -161,7 +161,7 @@ manifest:
       revision: 70bfbd21cdf5f6d1402bc8d0031e197222ed2ec0
       path: bootloader/mcuboot
     - name: mcumgr
-      revision: 31a2aa9cea58d3ceecbf0d5b91361bff7c94aeca
+      revision: 9ffebd5e92d9d069667b9af2a3a028f4a033cfd3
       path: modules/lib/mcumgr
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
The commit updates mcumgr revision to include backport of
   345caab img_mgmt: fix callback parameter values
           (backport-upstream-137-to-v2.7-branch)

Fixes  #38502.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>