### PR TITLE
boards: 96b_nitrogen: Remove stale pyOCD installation instructions

### DIFF
--- a/boards/arm/96b_nitrogen/doc/index.rst
+++ b/boards/arm/96b_nitrogen/doc/index.rst
@@ -229,29 +229,11 @@ which is provided by the micro USB interface to the LPC11U35 chip.
 Using the CMSIS-DAP interface, the board can be flashed via the USB storage
 interface (drag-and-drop) and also via `pyOCD`_.
 
-Installing pyOCD
-================
-
-The latest stable version of `pyOCD`_ can be installed via pip as follows:
-
-.. code-block:: console
-
-   $ pip install --pre -U pyocd
-
-To install the latest development version (master branch), do the following:
-
-.. code-block:: console
-
-   $ pip install --pre -U git+https://github.com/mbedmicro/pyOCD.git#egg=pyOCD
-
-You can then verify that your board is detected by pyOCD by running:
-
-.. code-block:: console
-
-   $ pyocd-flashtool -l
+To use ``pyOCD``, install the :ref:`pyocd-debug-host-tools` and make sure they
+are in your search path.
 
 Common Errors
--------------
+=============
 
 No connected boards
 -------------------


### PR DESCRIPTION
Use a link to the standard pyOCD Debug Host Tools documentation section
instead of outdated links to non-existent GitHub repos.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>