### PR TITLE
mcumgr: Add latency control functionality

### DIFF
--- a/subsys/mgmt/mcumgr/Kconfig
+++ b/subsys/mgmt/mcumgr/Kconfig
@@ -274,15 +274,63 @@ config MCUMGR_SMP_BT
 	help
 	  Enables handling of SMP commands received over Bluetooth.
 
+if MCUMGR_SMP_BT
+
 config MCUMGR_SMP_BT_AUTHEN
 	bool "Authenticated requirement for Bluetooth mcumgr SMP transport"
-	depends on MCUMGR_SMP_BT
 	select BT_SMP
 	default y
 	help
 	  Enables encrypted and authenticated connection requirement to
 	  Bluetooth SMP transport.
 
+config MCUMGR_SMP_BT_LATENCY_CONTROL
+	bool "Request low latency connection when handling SMP commands"
+	depends on SYSTEM_WORKQUEUE_PRIORITY < 0
+	help
+	  Enables support for requesting low latency connection parameter when
+	  SMP commands are handled. This option allows to speed up the command
+	  exchange process.
+	  Its recommended to enable this if SMP is used for DFU.
+
+config MCUMGR_SMP_BT_LATENCY_CONTROL_DEFAULT_LATENCY
+	int "Default value for connection latency"
+	depends on MCUMGR_SMP_BT_LATENCY_CONTROL
+	default BT_PERIPHERAL_PREF_LATENCY if BT_GAP_PERIPHERAL_PREF_PARAMS
+	default 99
+	range 0 499
+	help
+	  The value is a default connection latency that is used when restoring
+	  from low latency mode.
+
+config MCUMGR_SMP_BT_LATENCY_CONTROL_RESTORE_TIME
+	int "Connection latency restore time in milliseconds"
+	depends on MCUMGR_SMP_BT_LATENCY_CONTROL
+	default 5000
+	range 1 65535
+	help
+	  The value is a time after which connection latency is restored
+	  to default value
+	  (:kconfig:`MCUMGR_SMP_BT_LATENCY_CONTROL_DEFAULT_LATENCY`). Latency
+	  restoration time could take up to twice as long as specified time.
+	  This is because of limiting CPU time needed to support this feature.
+	  The implementation periodically checks if the low latency is still
+	  needed every :kconfig:`MCUMGR_SMP_BT_LATENCY_CONTROL_RESTORE_TIME`.
+	  The default latency is restored during check only if there was no SMP
+	  command exchanged in period before the check
+
+config MCUMGR_SMP_BT_LATENCY_CONTROL_RESTORE_RETRY_TIME
+	int "Connection latency restore retry time in milliseconds"
+	depends on MCUMGR_SMP_BT_LATENCY_CONTROL
+	default 1000
+	range 1 5000
+	help
+	  In case connection latency restoration fails due to an error, this
+	  option specifies the time after retry to set the default latency
+	  (:kconfig:`MCUMGR_SMP_BT_LATENCY_CONTROL_DEFAULT_LATENCY`) would be
+	  executed.
+
+endif # MCUMGR_SMP_BT
 
 config MCUMGR_SMP_SHELL
 	bool "Shell mcumgr SMP transport"

--- a/subsys/mgmt/mcumgr/smp_bt.c
+++ b/subsys/mgmt/mcumgr/smp_bt.c
@@ -21,13 +21,31 @@
 
 #include <mgmt/mcumgr/smp.h>
 
-struct device;
+#define RESTORE_TIME	   COND_CODE_1(CONFIG_MCUMGR_SMP_BT_LATENCY_CONTROL, \
+				(CONFIG_MCUMGR_SMP_BT_LATENCY_CONTROL_RESTORE_TIME), (0))
+#define RESTORE_RETRY_TIME COND_CODE_1(CONFIG_MCUMGR_SMP_BT_LATENCY_CONTROL, \
+				(CONFIG_MCUMGR_SMP_BT_LATENCY_CONTROL_RESTORE_RETRY_TIME), (0))
+#define DEFAULT_LATENCY	   COND_CODE_1(CONFIG_MCUMGR_SMP_BT_LATENCY_CONTROL, \
+				(CONFIG_MCUMGR_SMP_BT_LATENCY_CONTROL_DEFAULT_LATENCY), (0))
+
 
 struct smp_bt_user_data {
 	struct bt_conn *conn;
 };
 
+enum {
+	CONN_LOW_LATENCY_ENABLED	= BIT(0),
+	CONN_LOW_LATENCY_REQUIRED	= BIT(1),
+};
+
+struct conn_param_data {
+	struct bt_conn *conn;
+	struct k_work_delayable dwork;
+	uint8_t latency_state;
+};
+
 static struct zephyr_smp_transport smp_bt_transport;
+static struct conn_param_data conn_data[CONFIG_BT_MAX_CONN];
 
 /* SMP service.
  * {8D53DC1D-1DB7-4CD3-868B-8A527460AA84}
@@ -40,6 +58,95 @@ static struct bt_uuid_128 smp_bt_svc_uuid = BT_UUID_INIT_128(
  */
 static struct bt_uuid_128 smp_bt_chr_uuid = BT_UUID_INIT_128(
 	BT_UUID_128_ENCODE(0xda2e7828, 0xfbce, 0x4e01, 0xae9e, 0x261174997c48));
+
+/* Helper function that allocates conn_param_data for a conn. */
+static struct conn_param_data *alloc_conn_param_data(struct bt_conn *conn)
+{
+	for (size_t i = 0; i < ARRAY_SIZE(conn_data); i++) {
+		if (conn_data[i].conn == NULL) {
+			conn_data[i].conn = conn;
+			return &conn_data[i];
+		}
+	}
+
+	/* Conn data must exists. */
+	__ASSERT_NO_MSG(false);
+	return NULL;
+}
+
+/* Helper function that returns conn_param_data associated with a conn. */
+static struct conn_param_data *get_conn_param_data(const struct bt_conn *conn)
+{
+	for (size_t i = 0; i < ARRAY_SIZE(conn_data); i++) {
+		if (conn_data[i].conn == conn) {
+			return &conn_data[i];
+		}
+	}
+
+	/* Conn data must exists. */
+	__ASSERT_NO_MSG(false);
+	return NULL;
+}
+
+/* Sets connection parameters for a given conn. */
+static void set_conn_latency(struct bt_conn *conn, bool low_latency)
+{
+	struct bt_le_conn_param params;
+	struct conn_param_data *cpd;
+	struct bt_conn_info info;
+	int ret = 0;
+
+	cpd = get_conn_param_data(conn);
+
+	ret = bt_conn_get_info(conn, &info);
+	__ASSERT_NO_MSG(!ret);
+
+	if ((low_latency && (info.le.latency == 0)) ||
+	    ((!low_latency) && (info.le.latency == DEFAULT_LATENCY))) {
+		/* Already updated. */
+		return;
+	}
+
+	params.interval_min = info.le.interval;
+	params.interval_max = info.le.interval;
+	params.latency = (low_latency) ? (0) : (DEFAULT_LATENCY);
+	params.timeout = info.le.timeout;
+
+	ret = bt_conn_le_param_update(cpd->conn, &params);
+	if (ret && (ret != -EALREADY)) {
+		if (!low_latency) {
+			/* Try again to avoid stucking in low latency. */
+			(void)k_work_reschedule(&cpd->dwork, K_MSEC(RESTORE_RETRY_TIME));
+		}
+	}
+}
+
+
+/* Work handler function for restoring the default latency for the connection. */
+static void restore_default_latency(struct k_work *work)
+{
+	struct conn_param_data *cpd;
+
+	cpd = CONTAINER_OF(work, struct conn_param_data, dwork);
+
+	if (cpd->latency_state & CONN_LOW_LATENCY_REQUIRED) {
+		cpd->latency_state &= ~CONN_LOW_LATENCY_REQUIRED;
+		(void)k_work_reschedule(&cpd->dwork, K_MSEC(RESTORE_TIME));
+	} else {
+		set_conn_latency(cpd->conn, false);
+	}
+}
+
+static void enable_low_latency(struct bt_conn *conn)
+{
+	struct conn_param_data *cpd = get_conn_param_data(conn);
+
+	if (cpd->latency_state & CONN_LOW_LATENCY_ENABLED) {
+		cpd->latency_state |= CONN_LOW_LATENCY_REQUIRED;
+	} else {
+		set_conn_latency(conn, true);
+	}
+}
 
 /**
  * Write handler for the SMP characteristic; processes an incoming SMP request.
@@ -60,6 +167,10 @@ static ssize_t smp_bt_chr_write(struct bt_conn *conn,
 
 	ud = net_buf_user_data(nb);
 	ud->conn = bt_conn_ref(conn);
+
+	if (IS_ENABLED(CONFIG_MCUMGR_SMP_BT_LATENCY_CONTROL)) {
+		enable_low_latency(conn);
+	}
 
 	zephyr_smp_rx_req(&smp_bt_transport, nb);
 
@@ -188,9 +299,65 @@ int smp_bt_unregister(void)
 	return bt_gatt_service_unregister(&smp_bt_svc);
 }
 
+/* BT connected callback. */
+static void connected(struct bt_conn *conn, uint8_t err)
+{
+	if (err == 0) {
+		alloc_conn_param_data(conn);
+	}
+}
+
+/* BT disconnected callback. */
+static void disconnected(struct bt_conn *conn, uint8_t reason)
+{
+	struct conn_param_data *cpd = get_conn_param_data(conn);
+
+	/* Cancel work if ongoing. */
+	(void)k_work_cancel_delayable(&cpd->dwork);
+
+	/* Clear cpd. */
+	cpd->latency_state = 0;
+	cpd->conn = NULL;
+}
+
+/* BT LE connection parameters updated callback. */
+static void le_param_updated(struct bt_conn *conn, uint16_t interval,
+			     uint16_t latency, uint16_t timeout)
+{
+	struct conn_param_data *cpd = get_conn_param_data(conn);
+
+	if (latency == 0) {
+		cpd->latency_state |= CONN_LOW_LATENCY_ENABLED;
+		cpd->latency_state &= ~CONN_LOW_LATENCY_REQUIRED;
+		(void)k_work_reschedule(&cpd->dwork, K_MSEC(RESTORE_TIME));
+	} else {
+		cpd->latency_state &= ~CONN_LOW_LATENCY_ENABLED;
+		(void)k_work_cancel_delayable(&cpd->dwork);
+	}
+}
+
+static void init_latency_control_support(void)
+{
+	/* Register BT callbacks */
+	static struct bt_conn_cb conn_callbacks = {
+		.connected = connected,
+		.disconnected = disconnected,
+		.le_param_updated = le_param_updated,
+	};
+	bt_conn_cb_register(&conn_callbacks);
+
+	for (size_t i = 0; i < ARRAY_SIZE(conn_data); i++) {
+		k_work_init_delayable(&conn_data[i].dwork, restore_default_latency);
+	}
+}
+
 static int smp_bt_init(const struct device *dev)
 {
 	ARG_UNUSED(dev);
+
+	if (IS_ENABLED(CONFIG_MCUMGR_SMP_BT_LATENCY_CONTROL)) {
+		init_latency_control_support();
+	}
 
 	zephyr_smp_transport_init(&smp_bt_transport, smp_bt_tx_pkt,
 				  smp_bt_get_mtu, smp_bt_ud_copy,


### PR DESCRIPTION
This change adds a posibility to enable low latency connection
parameters for BT when SMP commands are handled.

Support for this functionality is disabled by the default and
can be enabled by CONFIG_MCUMGR_SMP_BT_LATENCY_CONTROL=y option.

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>