### PR TITLE
Bluetooth: Mesh: Moved composition data out of mesh shell

### DIFF
--- a/doc/reference/bluetooth/mesh/shell.rst
+++ b/doc/reference/bluetooth/mesh/shell.rst
@@ -11,7 +11,7 @@ The Bluetooth mesh shell interface provides access to most Bluetooth mesh featur
 Prerequisites
 *************
 
-The Bluetooth mesh shell subsystem depends on the :ref:`bluetooth_mesh_models_cfg_cli` and :ref:`bluetooth_mesh_models_health_cli` models.
+The Bluetooth mesh shell subsystem depends on the application to create the composition data and do the mesh initialization.
 
 Application
 ***********
@@ -125,7 +125,7 @@ General configuration
 ``mesh init``
 -------------
 
-	Initialize the mesh. This command must be run before any other mesh command.
+	Initialize the mesh shell. This command must be run before any other mesh command.
 
 
 ``mesh reset <addr>``
@@ -298,7 +298,7 @@ Provisioning
 Configuration Client model
 ==========================
 
-The Bluetooth mesh shell module instantiates a Configuration Client model for configuring itself and other nodes in the mesh network.
+The Configuration Client model is an optional mesh subsystem that can be enabled through the :kconfig:`CONFIG_BT_MESH_CFG_CLI` configuration option. If included, the Bluetooth mesh shell module instantiates a Configuration Client model for configuring itself and other nodes in the mesh network.
 
 The Configuration Client uses the general messages parameters set by ``mesh dst`` and ``mesh netidx`` to target specific nodes. When the Bluetooth mesh shell node is provisioned, the Configuration Client model targets itself by default. When another node has been provisioned by the Bluetooth mesh shell, the Configuration Client model targets the new node. The Configuration Client always sends messages using the Device key bound to the destination address, so it will only be able to configure itself and mesh nodes it provisioned.
 
@@ -583,7 +583,7 @@ The Configuration Client uses the general messages parameters set by ``mesh dst`
 Health Client model
 ===================
 
-The Bluetooth mesh shell module instantiates a Health Client model for configuring itself and other nodes in the mesh network.
+The Health Client model is an optional mesh subsystem that can be enabled through the :kconfig:`CONFIG_BT_MESH_HEALTH_CLI` configuration option. If included, the Bluetooth mesh shell module instantiates a Health Client model for configuring itself and other nodes in the mesh network.
 
 The Health Client uses the general messages parameters set by ``mesh dst`` and ``mesh netidx`` to target specific nodes. When the Bluetooth mesh shell node is provisioned, the Health Client model targets itself by default. When another node has been provisioned by the Bluetooth mesh shell, the Health Client model targets the new node. The Health Client always sends messages using the Device key bound to the destination address, so it will only be able to configure itself and mesh nodes it provisioned.
 

--- a/include/bluetooth/mesh/shell.h
+++ b/include/bluetooth/mesh/shell.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_SHELL_H_
+#define ZEPHYR_INCLUDE_BLUETOOTH_MESH_SHELL_H_
+
+#include <bluetooth/mesh.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Maximum number of faults the health server can have. */
+#define BT_MESH_SHELL_CUR_FAULTS_MAX 4
+
+/** @def BT_MESH_SHELL_HEALTH_PUB_DEFINE
+ *
+ *  A helper to define a health publication context for shell with the shell's
+ *  maximum number of faults the element can have.
+ *
+ *  @param _name Name given to the publication context variable.
+ */
+#define BT_MESH_SHELL_HEALTH_PUB_DEFINE(_name)                                 \
+		BT_MESH_HEALTH_PUB_DEFINE(_name,                               \
+					  BT_MESH_SHELL_CUR_FAULTS_MAX);
+
+/** @brief External reference to health server */
+extern struct bt_mesh_health_srv bt_mesh_shell_health_srv;
+
+/** @brief External reference to health client */
+extern struct bt_mesh_health_cli bt_mesh_shell_health_cli;
+
+/** @brief External reference to provisioning handler. */
+extern struct bt_mesh_prov bt_mesh_shell_prov;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_BLUETOOTH_MESH_SHELL_H_ */

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -717,8 +717,6 @@ config BT_MESH_HEALTH_CLI
 config BT_MESH_SHELL
 	bool "Enable Bluetooth mesh shell"
 	select SHELL
-	depends on BT_MESH_CFG_CLI
-	depends on BT_MESH_HEALTH_CLI
 	help
 	  Activate shell module that provides Bluetooth mesh commands to
 	  the console.

--- a/tests/bluetooth/mesh_shell/src/main.c
+++ b/tests/bluetooth/mesh_shell/src/main.c
@@ -5,12 +5,77 @@
  */
 
 #include <sys/printk.h>
+#include <stdlib.h>
 #include <zephyr.h>
 
 #include <shell/shell.h>
 
+#include <bluetooth/bluetooth.h>
+#include <bluetooth/mesh.h>
+#include <bluetooth/mesh/shell.h>
+
+static struct bt_mesh_cfg_cli cfg_cli;
+
+BT_MESH_SHELL_HEALTH_PUB_DEFINE(health_pub);
+
+static struct bt_mesh_model root_models[] = {
+	BT_MESH_MODEL_CFG_SRV,
+	BT_MESH_MODEL_CFG_CLI(&cfg_cli),
+	BT_MESH_MODEL_HEALTH_SRV(&bt_mesh_shell_health_srv, &health_pub),
+	BT_MESH_MODEL_HEALTH_CLI(&bt_mesh_shell_health_cli),
+};
+
+static struct bt_mesh_elem elements[] = {
+	BT_MESH_ELEM(0, root_models, BT_MESH_MODEL_NONE),
+};
+
+static const struct bt_mesh_comp comp = {
+	.cid = CONFIG_BT_COMPANY_ID,
+	.elem = elements,
+	.elem_count = ARRAY_SIZE(elements),
+};
+
+static void bt_ready(int err)
+{
+	if (err && err != -EALREADY) {
+		printk("Bluetooth init failed (err %d)\n", err);
+		return;
+	}
+
+	printk("Bluetooth initialized\n");
+
+	err = bt_mesh_init(&bt_mesh_shell_prov, &comp);
+	if (err) {
+		printk("Initializing mesh failed (err %d)\n", err);
+		return;
+	}
+
+	if (IS_ENABLED(CONFIG_SETTINGS)) {
+		settings_load();
+	}
+
+	printk("Mesh initialized\n");
+
+	if (bt_mesh_is_provisioned()) {
+		printk("Mesh network restored from flash\n");
+	} else {
+		printk("Use \"pb-adv on\" or \"pb-gatt on\" to "
+			    "enable advertising\n");
+	}
+}
+
 void main(void)
 {
+	int err;
+
+	printk("Initializing...\n");
+
+	/* Initialize the Bluetooth Subsystem */
+	err = bt_enable(bt_ready);
+	if (err && err != -EALREADY) {
+		printk("Bluetooth init failed (err %d)\n", err);
+	}
+
 	printk("Press the <Tab> button for supported commands.\n");
 	printk("Before any Mesh commands you must run \"mesh init\"\n");
 }


### PR DESCRIPTION
The mesh shell module owns the composition data for the shell application,
which makes it impossible to use it outside of the application itself.
To support the shell as a generic debugging component that can be added
to any application, we have moved the composition data out of shell.c,
and into the application.

Signed-off-by: Ingar Kulbrandstad <ingar.kulbrandstad@nordicsemi.no>