### PR TITLE
doc: fix C domain reference usage

### DIFF
--- a/doc/reference/bluetooth/connection_mgmt.rst
+++ b/doc/reference/bluetooth/connection_mgmt.rst
@@ -17,7 +17,7 @@ to a connection.
 
 An application may track connections by registering a
 :c:struct:`bt_conn_cb` struct using the :c:func:`bt_conn_cb_register`
-or c:func:`BT_CONN_CB_DEFINE()` APIs. This struct lets the application
+or :c:macro:`BT_CONN_CB_DEFINE` APIs. This struct lets the application
 define callbacks for connection & disconnection events, as well as other
 events related to a connection such as a change in the security level or
 the connection parameters. When acting as a central the application will

--- a/doc/reference/iterable_sections/index.rst
+++ b/doc/reference/iterable_sections/index.rst
@@ -5,7 +5,7 @@ Iterable Sections
 
 This page contains the reference documentation for the iterable sections APIs,
 which can be used for defining iterable areas of equally-sized data structures,
-that can be iterated on using `STRUCT_SECTION_FOREACH()`.
+that can be iterated on using :c:macro:`STRUCT_SECTION_FOREACH`.
 
 Usage
 *****
@@ -34,10 +34,10 @@ instantiated anywhere in the code base.
 
 Then the linker has to be setup to place the place the structure in a
 contiguous segment using one of the linker macros such as
-`ITERABLE_SECTION_RAM()` or `ITERABLE_SECTION_ROM()`. Custom linker snippets
-are normally declared using one of the ``zephyr_linker_sources()`` CMake
-functions, using the appropriate section identifier, ``DATA_SECTIONS`` for RAM
-structures and ``SECTIONS`` for ROM ones.
+:c:macro:`ITERABLE_SECTION_RAM` or :c:macro:`ITERABLE_SECTION_ROM`. Custom
+linker snippets are normally declared using one of the
+``zephyr_linker_sources()`` CMake functions, using the appropriate section
+identifier, ``DATA_SECTIONS`` for RAM structures and ``SECTIONS`` for ROM ones.
 
 .. code-block:: cmake
 
@@ -49,7 +49,7 @@ structures and ``SECTIONS`` for ROM ones.
    # iterables.ld
    ITERABLE_SECTION_RAM(my_data, 4)
 
-The data can then be accessed using `STRUCT_SECTION_FOREACH()`.
+The data can then be accessed using :c:macro:`STRUCT_SECTION_FOREACH`.
 
 .. code-block:: c
 

--- a/doc/reference/networking/can_api.rst
+++ b/doc/reference/networking/can_api.rst
@@ -208,7 +208,7 @@ Frames are only received when they match a filter.
 The following code snippets show how to receive frames by attaching filters.
 
 Here we have an example for a receiving callback.
-It is used for `can_attach_isr` or `can_attach_workq`.
+It is used for :c:func:`can_attach_isr` or :c:func:`can_attach_workq`.
 The argument arg is passed when the filter is attached.
 
 .. code-block:: C
@@ -246,7 +246,7 @@ The filter for this example is configured to match the identifier 0x123 exactly.
   }
 
 This example shows how to attach a callback from a work-queue.
-In contrast to the `can_attach_isr` function, here the callback is called from the
+In contrast to the :c:func:`can_attach_isr` function, here the callback is called from the
 work-queue provided. In this case, it is the system work queue. Blocking is
 generally allowed in the callback but could result in a frame backlog when it is
 not limited. For the reason of a backlog, a ring-buffer is applied for every
@@ -277,8 +277,8 @@ The filter for this example is configured to match a filter range from
     LOG_ERR("Unable to attach isr [%d]", filter_id);
   }
 
-Here an example for `can_attach_msgq` is shown. With this function, it is
-possible to receive frames synchronously. This function can be called from
+Here an example for :c:func:`can_attach_msgq` is shown. With this function, it
+is possible to receive frames synchronously. This function can be called from
 userspace context.
 The size of the message queue should be as big as the expected backlog.
 
@@ -312,7 +312,7 @@ The filter for this example is configured to match the extended identifier
     ... do something with the frame ...
   }
 
-`can_detach` removes the given filter.
+:c:func:`can_detach` removes the given filter.
 
 .. code-block:: C
 
@@ -322,13 +322,14 @@ Setting the bitrate
 *******************
 
 The bitrate and sampling point is initially set at runtime. To change it from
-the application, one can use the `can_set_timing` API. This function takes three
-arguments. The first timing parameter sets the timing for classic CAN and
-arbitration phase for CAN-FD. The second parameter sets the timing of the data
-phase for CAN-FD. For classic CAN, you can use only the first parameter and put
-NULL to the second one. The `can_calc_timing` function can calculate timing from
-a bitrate and sampling point in permille. The following example sets the bitrate
-to 250k baud with the sampling point at 87.5%.
+the application, one can use the :c:func:`can_set_timing` API. This function
+takes three arguments. The first timing parameter sets the timing for classic
+CAN and arbitration phase for CAN-FD. The second parameter sets the timing of
+the data phase for CAN-FD. For classic CAN, you can use only the first
+parameter and put NULL to the second one. The :c:func:`can_calc_timing`
+function can calculate timing from a bitrate and sampling point in permille.
+The following example sets the bitrate to 250k baud with the sampling point at
+87.5%.
 
 .. code-block:: C
 

--- a/doc/reference/peripherals/hwinfo.rst
+++ b/doc/reference/peripherals/hwinfo.rst
@@ -9,10 +9,11 @@ Overview
 The HW Info API provides access to hardware information such as device
 identifiers and reset cause flags.
 
-Reset cause flags can be used to determine why the device was reset; for example
-due to a watchdog timeout or due to power cycling. Different devices support different
-subset of flags. Use `hwinfo_get_supported_reset_cause` to retrieve the flags
-that are supported by that device.
+Reset cause flags can be used to determine why the device was reset; for
+example due to a watchdog timeout or due to power cycling. Different devices
+support different subset of flags. Use
+:c:func:`hwinfo_get_supported_reset_cause` to retrieve the flags that are
+supported by that device.
 
 Configuration Options
 *********************

--- a/doc/reference/storage/fcb/fcb.rst
+++ b/doc/reference/storage/fcb/fcb.rst
@@ -40,28 +40,28 @@ Usage
 
 To add an entry to circular buffer:
 
-- Call `fcb_append` to get the location where data can be written. If
-  this fails due to lack of space, you can call `fcb_rotate` to erase
-  the oldest sector which will make the space. And then call `fcb_append`
-  again.
-- Use `flash_area_write` to write entry contents.
-- Call `fcb_append_finish` when done. This completes the writing of the
+- Call :c:func:`fcb_append` to get the location where data can be written. If
+  this fails due to lack of space, you can call :c:func:`fcb_rotate` to erase
+  the oldest sector which will make the space. And then call
+  :c:func:`fcb_append` again.
+- Use :c:func:`flash_area_write` to write entry contents.
+- Call :c:func:`fcb_append_finish` when done. This completes the writing of the
   entry by calculating the checksum.
 
 To read contents of the circular buffer:
 
-- Call `fcb_walk` with a pointer to your callback function.
+- Call :c:func:`fcb_walk` with a pointer to your callback function.
 - Within callback function copy in data from the entry using
-  `flash_area_read`. You can tell when all data from within a sector
+  :c:func:`flash_area_read`. You can tell when all data from within a sector
   has been read by monitoring the returned entry's area pointer. Then you
-  can call `fcb_rotate`, if you're done with that data.
+  can call :c:func:`fcb_rotate`, if you're done with that data.
 
 Alternatively:
 
-- Call `fcb_getnext` with 0 in entry offset to get the pointer to
+- Call :c:func:`fcb_getnext` with 0 in entry offset to get the pointer to
   the oldest entry.
-- Use `flash_area_read` to read entry contents.
-- Call `fcb_getnext` with pointer to current entry to get the next one.
+- Use :c:func:`flash_area_read` to read entry contents.
+- Call :c:func:`fcb_getnext` with pointer to current entry to get the next one.
   And so on.
 
 API Reference

--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -49,9 +49,9 @@ API Changes
   for instance enable bootstrap procedure in the curent session.
 
 * LwM2M execute now supports arguments. The execute callback
-  `lwm2m_engine_execute_cb_t` is extended with an ``args`` parameter which points
-  to the CoAP payload that comprises the arguments, and an ``args_len`` parameter
-  to indicate the length of the ``args`` data.
+  :c:type:`lwm2m_engine_execute_cb_t` is extended with an ``args`` parameter
+  which points to the CoAP payload that comprises the arguments, and an
+  ``args_len`` parameter to indicate the length of the ``args`` data.
 
 * Changed vcnl4040 dts binding default for property 'proximity-trigger'.
   Changed the default to match the HW POR state for this property.
@@ -817,11 +817,11 @@ Libraries / Subsystems
 
   * API
 
-    * Added c:func:`fs_file_t_init` function for initialization of
-      c:type:`fs_file_t` objects.
+    * Added :c:func:`fs_file_t_init` function for initialization of
+      :c:type:`fs_file_t` objects.
 
-    * Added c:func:`fs_dir_t_init` function for initialization of
-      c:type:`fs_dir_t` objects.
+    * Added :c:func:`fs_dir_t_init` function for initialization of
+      :c:type:`fs_dir_t` objects.
 
   * ``CONFIG_FS_LITTLEFS_FC_MEM_POOL`` has been deprecated and
     should be replaced by :kconfig:`CONFIG_FS_LITTLEFS_FC_HEAP_SIZE`.

--- a/doc/releases/release-notes-2.6.rst
+++ b/doc/releases/release-notes-2.6.rst
@@ -879,7 +879,8 @@ Libraries / Subsystems
   * MCUmgr
 
     * Fixed an issue with the file system management failing to
-      open files due to missing initializations of `fs_file_t` structures.
+      open files due to missing initializations of :c:type:`fs_file_t`
+      structures.
     * Fixed an issue where multiple SMP commands sent one after the other would
       corrupt CBOR payload.
     * Fixed problem where mcumgr over shell would stall and wait for

--- a/samples/boards/esp32/spiram_test/README.rst
+++ b/samples/boards/esp32/spiram_test/README.rst
@@ -6,11 +6,13 @@ Espressif ESP32 SPIRAM test
 Overview
 ********
 
-This sample allocates memory from internal DRAM and SPIRAM by calling `k_malloc`, frees
-allocated memory by calling `k_free` and checks if memory can be allocated again.
-Capability of allocated memory is decided by ESP_HEAP_MIN_EXTRAM_THRESHOLD. If size is less than
-ESP_HEAP_MIN_EXTRAM_THRESHOLD, memory is allocated from internal DRAM. If size is greater than
-ESP_HEAP_MIN_EXTRAM_THRESHOLD, memory is allocated from SPIRAM.
+This sample allocates memory from internal DRAM and SPIRAM by calling
+:c:func:`k_malloc`, frees allocated memory by calling :c:func:`k_free` and
+checks if memory can be allocated again. Capability of allocated memory is
+decided by ESP_HEAP_MIN_EXTRAM_THRESHOLD. If size is less than
+ESP_HEAP_MIN_EXTRAM_THRESHOLD, memory is allocated from internal DRAM. If
+size is greater than ESP_HEAP_MIN_EXTRAM_THRESHOLD, memory is allocated from
+SPIRAM.
 
 Building and Running
 ********************


### PR DESCRIPTION
This patch fixes multiple issues when referencing to the C domain. In
some cases there were typos (e.g., missing :), in some others no domain
syntax was used for referencing, etc.