### PR TITLE
modem: Update modem sockets poll to allow eventfd

### DIFF
--- a/drivers/modem/modem_socket.h
+++ b/drivers/modem/modem_socket.h
@@ -39,12 +39,11 @@ __net_socket struct modem_socket {
 	/** data ready semaphore */
 	struct k_sem sem_data_ready;
 	/** data ready poll signal */
-	struct k_poll_signal sem_poll;
+	struct k_poll_signal sig_data_ready;
 
 	/** socket state */
 	bool is_connected;
 	bool is_waiting;
-	bool is_polled;
 
 	/** temporary socket data */
 	void *data;
@@ -72,6 +71,11 @@ struct modem_socket *modem_socket_from_newid(struct modem_socket_config *cfg);
 void modem_socket_put(struct modem_socket_config *cfg, int sock_fd);
 int modem_socket_poll(struct modem_socket_config *cfg, struct zsock_pollfd *fds, int nfds,
 		      int msecs);
+int modem_socket_poll_update(struct modem_socket *sock, struct zsock_pollfd *pfd,
+			     struct k_poll_event **pev);
+int modem_socket_poll_prepare(struct modem_socket_config *cfg, struct modem_socket *sock,
+			      struct zsock_pollfd *pfd, struct k_poll_event **pev,
+			      struct k_poll_event *pev_end);
 void modem_socket_wait_data(struct modem_socket_config *cfg, struct modem_socket *sock);
 void modem_socket_data_ready(struct modem_socket_config *cfg, struct modem_socket *sock);
 int modem_socket_init(struct modem_socket_config *cfg, const struct socket_op_vtable *vtable);

--- a/drivers/modem/quectel-bg9x.c
+++ b/drivers/modem/quectel-bg9x.c
@@ -636,55 +636,31 @@ static ssize_t offload_write(void *obj, const void *buffer, size_t count)
 	return offload_sendto(obj, buffer, count, 0, NULL, 0);
 }
 
-/* Func: offload_poll
- * Desc: This function polls on a given socket object.
- */
-static int offload_poll(struct zsock_pollfd *fds, int nfds, int msecs)
-{
-	int i;
-	void *obj;
-
-	/* Only accept modem sockets. */
-	for (i = 0; i < nfds; i++) {
-		if (fds[i].fd < 0) {
-			continue;
-		}
-
-		/* If vtable matches, then it's modem socket. */
-		obj = z_get_fd_obj(fds[i].fd,
-				   (const struct fd_op_vtable *) &offload_socket_fd_op_vtable,
-				   EINVAL);
-		if (obj == NULL) {
-			return -1;
-		}
-	}
-
-	return modem_socket_poll(&mdata.socket_config, fds, nfds, msecs);
-}
-
 /* Func: offload_ioctl
  * Desc: Function call to handle various misc requests.
  */
 static int offload_ioctl(void *obj, unsigned int request, va_list args)
 {
 	switch (request) {
-	case ZFD_IOCTL_POLL_PREPARE:
-		return -EXDEV;
+	case ZFD_IOCTL_POLL_PREPARE: {
+		struct zsock_pollfd *pfd;
+		struct k_poll_event **pev;
+		struct k_poll_event *pev_end;
 
-	case ZFD_IOCTL_POLL_UPDATE:
-		return -EOPNOTSUPP;
+		pfd = va_arg(args, struct zsock_pollfd *);
+		pev = va_arg(args, struct k_poll_event **);
+		pev_end = va_arg(args, struct k_poll_event *);
 
-	case ZFD_IOCTL_POLL_OFFLOAD:
-	{
-		/* Poll on the given socket. */
-		struct zsock_pollfd *fds;
-		int nfds, timeout;
+		return modem_socket_poll_prepare(&mdata.socket_config, obj, pfd, pev, pev_end);
+	}
+	case ZFD_IOCTL_POLL_UPDATE: {
+		struct zsock_pollfd *pfd;
+		struct k_poll_event **pev;
 
-		fds = va_arg(args, struct zsock_pollfd *);
-		nfds = va_arg(args, int);
-		timeout = va_arg(args, int);
+		pfd = va_arg(args, struct zsock_pollfd *);
+		pev = va_arg(args, struct k_poll_event **);
 
-		return offload_poll(fds, nfds, timeout);
+		return modem_socket_poll_update(obj, pfd, pev);
 	}
 
 	default:

--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -1606,31 +1606,6 @@ static int offload_connect(void *obj, const struct sockaddr *addr,
 	return 0;
 }
 
-/* support for POLLIN only for now. */
-static int offload_poll(struct zsock_pollfd *fds, int nfds, int msecs)
-{
-	int i;
-	void *obj;
-
-	/* Only accept modem sockets. */
-	for (i = 0; i < nfds; i++) {
-		if (fds[i].fd < 0) {
-			continue;
-		}
-
-		/* If vtable matches, then it's modem socket. */
-		obj = z_get_fd_obj(fds[i].fd,
-				   (const struct fd_op_vtable *)
-						&offload_socket_fd_op_vtable,
-				   EINVAL);
-		if (obj == NULL) {
-			return -1;
-		}
-	}
-
-	return modem_socket_poll(&mdata.socket_config, fds, nfds, msecs);
-}
-
 static ssize_t offload_recvfrom(void *obj, void *buf, size_t len,
 				int flags, struct sockaddr *from,
 				socklen_t *fromlen)
@@ -1744,22 +1719,25 @@ static ssize_t offload_sendto(void *obj, const void *buf, size_t len,
 static int offload_ioctl(void *obj, unsigned int request, va_list args)
 {
 	switch (request) {
-	case ZFD_IOCTL_POLL_PREPARE:
-		return -EXDEV;
+	case ZFD_IOCTL_POLL_PREPARE: {
+		struct zsock_pollfd *pfd;
+		struct k_poll_event **pev;
+		struct k_poll_event *pev_end;
 
-	case ZFD_IOCTL_POLL_UPDATE:
-		return -EOPNOTSUPP;
+		pfd = va_arg(args, struct zsock_pollfd *);
+		pev = va_arg(args, struct k_poll_event **);
+		pev_end = va_arg(args, struct k_poll_event *);
 
-	case ZFD_IOCTL_POLL_OFFLOAD: {
-		struct zsock_pollfd *fds;
-		int nfds;
-		int timeout;
+		return modem_socket_poll_prepare(&mdata.socket_config, obj, pfd, pev, pev_end);
+	}
+	case ZFD_IOCTL_POLL_UPDATE: {
+		struct zsock_pollfd *pfd;
+		struct k_poll_event **pev;
 
-		fds = va_arg(args, struct zsock_pollfd *);
-		nfds = va_arg(args, int);
-		timeout = va_arg(args, int);
+		pfd = va_arg(args, struct zsock_pollfd *);
+		pev = va_arg(args, struct k_poll_event **);
 
-		return offload_poll(fds, nfds, timeout);
+		return modem_socket_poll_update(obj, pfd, pev);
 	}
 
 	case F_GETFL:


### PR DESCRIPTION
The modem sockets poll implementation does not allow a combination of poll on modem sockets and on other sockets like eventfd. This blocks trivial async application signalling . Current users are using a poll timeout, which needs to check if other (transmit) work needs to be done in the thread (eg: lwm2m engine). To allow proper signalling with eventfd, the non offload poll methods needs to work for the modem sockets. This commit is implementing this for POLLIN.

There is no user in the pull request, but the ublox & bg9x driver could make use of this. 
I've implemented & tested this in my own bg95 driver (derived from bg9x)
The both could be using the poll behavior updated with following changes in ioctl function:
(not code formatted to zephyr standard)

```
static int offload_ioctl(void* obj, unsigned int request, va_list args)
{
    switch(request)
    {
        case ZFD_IOCTL_POLL_PREPARE:
        {

            struct zsock_pollfd*  pfd;
            struct k_poll_event** pev;
            struct k_poll_event*  pev_end;

            pfd     = va_arg(args, struct zsock_pollfd*);
            pev     = va_arg(args, struct k_poll_event**);
            pev_end = va_arg(args, struct k_poll_event*);

            return modem_socket_poll_prepare(&mdata.socket_config, obj, pfd, pev, pev_end);
        }
        case ZFD_IOCTL_POLL_UPDATE:
        {

            struct zsock_pollfd*  pfd;
            struct k_poll_event** pev;

            pfd = va_arg(args, struct zsock_pollfd*);
            pev = va_arg(args, struct k_poll_event**);

            return modem_socket_poll_update(obj, pfd, pev);
        }

        default: errno = EINVAL; return -1;
    }
}
```


Signed-off-by: Wouter Cappelle <wouter.cappelle@crodeon.com>