### PR TITLE
tests: subsys: libcxx: extend the timeout for cpp.libcxx.newlib_nano

### DIFF
--- a/tests/subsys/cpp/libcxx/testcase.yaml
+++ b/tests/subsys/cpp/libcxx/testcase.yaml
@@ -16,7 +16,7 @@ tests:
     toolchain_exclude: xcc
     min_flash: 54
     tags: cpp
-    timeout: 30
+    timeout: 60
     extra_configs:
         - CONFIG_NEWLIB_LIBC=y
         - CONFIG_NEWLIB_LIBC_NANO=y


### PR DESCRIPTION
Extend the timeout to prevent the cpp.libcxx.newlib_nano testcase runs
failed in acrn_ehl_crb, ehl_crb and up_squared. We need to give these
boards more time to finish the testcase's automation.

Fixes #36852

Signed-off-by: Enjia Mai <enjia.mai@intel.com>