### PR TITLE
cmake: allow alternate name for board.cmake file

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -612,6 +612,7 @@ set(KERNEL_STAT_NAME  ${KERNEL_NAME}.stat)
 set(KERNEL_STRIP_NAME ${KERNEL_NAME}.strip)
 
 include(${BOARD_DIR}/board.cmake OPTIONAL)
+include(${BOARD_DIR}/${BOARD}.cmake OPTIONAL)
 
 # If we are using a suitable ethernet driver inside qemu, then these options
 # must be set, otherwise a zephyr instance cannot receive any network packets.

--- a/doc/guides/porting/board_porting.rst
+++ b/doc/guides/porting/board_porting.rst
@@ -160,7 +160,8 @@ The mandatory files are:
 
 The optional files are:
 
-- :file:`board.cmake`: used for :ref:`flash-and-debug-support`
+- :file:`board.cmake`: used for :ref:`flash-and-debug-support`. This file can
+  alternatively be named after your board, e.g. :file:`plank.cmake`.
 - :file:`CMakeLists.txt`: if you need to add additional source files to
   your build.
 


### PR DESCRIPTION
Currently in a board directory there are a number of configuration files specific to a board. For example, for the `nrf52dk_nrf52832`, there are the following:

- `nrf52dk_nrf52832_defconfig`
- `nrf52dk_nrf52832.dts`
- `nrf52dk_nrf52832.yaml`
- `Kconfig`
- `Kconfig.board`
- `Kconfig.defconfig`
- `board.cmake`

When searching for a file associated with a specific board, it's very helpful for the board name to appear as part of the file name. This commit allows the `board.cmake` file to alternatively be named `${BOARD}.cmake`, e.g. `nrf52dk_nrf52832.cmake`. 

Longer term it would also be nice if the various `Kconfig.*` files could also be named after their respective boards instead of generically, but that can be implemented independently.
