### PR TITLE
kernel: thread.c: remove unused THREAD_COOKIE macro.

### DIFF
--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -499,8 +499,6 @@ static char *setup_thread_stack(struct k_thread *new_thread,
 	return stack_ptr;
 }
 
-#define THREAD_COOKIE	0x1337C0D3
-
 /*
  * The provided stack_size value is presumed to be either the result of
  * K_THREAD_STACK_SIZEOF(stack), or the size value passed to the instance


### PR DESCRIPTION
This macro is cute (0x1337C0D3 🤣), but was not referenced anywhere.
