### PR TITLE
west.yml: Add zscilib reference

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -220,6 +220,9 @@ manifest:
       revision: 00d0e38cf89656b0f3ef8d1757109c0ea021a780
       groups:
         - tee
+    - name: zscilib
+      path: modules/lib/zscilib
+      revision: 12bfe3f0a9fcbfe3edab7eabc9678b6c62875d34
 
   group-filter:
     - -ci


### PR DESCRIPTION
Adds a reference to zscilib, now that it's available under
zephyrproject-rtos/zscilib.

Signed-off-by: Kevin Townsend <kevin@ktownsend.com>