### PR TITLE
tests: bluetooth: tester: Fix memory corruption in reconfigured_cb

### DIFF
--- a/tests/bluetooth/tester/src/l2cap.c
+++ b/tests/bluetooth/tester/src/l2cap.c
@@ -142,7 +142,7 @@ static void reconfigured_cb(struct bt_l2cap_chan *l2cap_chan)
 	struct l2cap_reconfigured_ev ev;
 	struct channel *chan = CONTAINER_OF(l2cap_chan, struct channel, le);
 
-	(void)memset(&ev, 0, sizeof(struct l2cap_disconnected_ev));
+	(void)memset(&ev, 0, sizeof(ev));
 
 	ev.chan_id = chan->chan_id;
 	ev.mtu_remote = sys_cpu_to_le16(chan->le.tx.mtu);


### PR DESCRIPTION
Pass proper length when memsetting struct.

Signed-off-by: Szymon Janc <szymon.janc@codecoup.pl>