### PR TITLE
drivers: entropy: introduce shared init priority and logging

### DIFF
--- a/drivers/entropy/Kconfig
+++ b/drivers/entropy/Kconfig
@@ -10,6 +10,16 @@ menuconfig ENTROPY_GENERATOR
 
 if ENTROPY_GENERATOR
 
+module = ENTROPY
+module-str = entropy
+source "subsys/logging/Kconfig.template.log_config"
+
+config ENTROPY_INIT_PRIORITY
+	int "Entropy driver init priority"
+	default KERNEL_INIT_PRIORITY_DEVICE
+	help
+	  Entropy driver device initialization priority.
+
 source "drivers/entropy/Kconfig.b91"
 source "drivers/entropy/Kconfig.cc13xx_cc26xx"
 source "drivers/entropy/Kconfig.mcux"

--- a/drivers/entropy/entropy_b91_trng.c
+++ b/drivers/entropy/entropy_b91_trng.c
@@ -67,5 +67,5 @@ static const struct entropy_driver_api entropy_b91_trng_api = {
 /* Entropy driver registration */
 DEVICE_DT_INST_DEFINE(0, entropy_b91_trng_init,
 		      NULL, NULL, NULL,
-		      PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		      PRE_KERNEL_1, CONFIG_ENTROPY_INIT_PRIORITY,
 		      &entropy_b91_trng_api);

--- a/drivers/entropy/entropy_cc13xx_cc26xx.c
+++ b/drivers/entropy/entropy_cc13xx_cc26xx.c
@@ -353,5 +353,5 @@ DEVICE_DT_INST_DEFINE(0,
 		entropy_cc13xx_cc26xx_init,
 		entropy_cc13xx_cc26xx_pm_control,
 		&entropy_cc13xx_cc26xx_data, NULL,
-		PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		PRE_KERNEL_1, CONFIG_ENTROPY_INIT_PRIORITY,
 		&entropy_cc13xx_cc26xx_driver_api);

--- a/drivers/entropy/entropy_esp32.c
+++ b/drivers/entropy/entropy_esp32.c
@@ -70,5 +70,5 @@ static const struct entropy_driver_api entropy_esp32_api_funcs = {
 
 DEVICE_DT_INST_DEFINE(0,
 		    entropy_esp32_init, NULL, NULL, NULL,
-		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    PRE_KERNEL_1, CONFIG_ENTROPY_INIT_PRIORITY,
 		    &entropy_esp32_api_funcs);

--- a/drivers/entropy/entropy_gecko_trng.c
+++ b/drivers/entropy/entropy_gecko_trng.c
@@ -102,5 +102,5 @@ static struct entropy_driver_api entropy_gecko_trng_api_funcs = {
 DEVICE_DT_INST_DEFINE(0,
 			entropy_gecko_trng_init, NULL,
 			NULL, NULL,
-			PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+			PRE_KERNEL_1, CONFIG_ENTROPY_INIT_PRIORITY,
 			&entropy_gecko_trng_api_funcs);

--- a/drivers/entropy/entropy_litex.c
+++ b/drivers/entropy/entropy_litex.c
@@ -61,5 +61,5 @@ static const struct entropy_driver_api entropy_prbs_api = {
 
 DEVICE_DT_INST_DEFINE(0,
 		    entropy_prbs_init, NULL, NULL, NULL,
-		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    PRE_KERNEL_1, CONFIG_ENTROPY_INIT_PRIORITY,
 		    &entropy_prbs_api);

--- a/drivers/entropy/entropy_mcux_rng.c
+++ b/drivers/entropy/entropy_mcux_rng.c
@@ -45,7 +45,7 @@ static int entropy_mcux_rng_init(const struct device *);
 DEVICE_DT_INST_DEFINE(0,
 		    entropy_mcux_rng_init, NULL, NULL,
 		    &entropy_mcux_config,
-		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    PRE_KERNEL_1, CONFIG_ENTROPY_INIT_PRIORITY,
 		    &entropy_mcux_rng_api_funcs);
 
 static int entropy_mcux_rng_init(const struct device *dev)

--- a/drivers/entropy/entropy_mcux_rnga.c
+++ b/drivers/entropy/entropy_mcux_rnga.c
@@ -61,7 +61,7 @@ static int entropy_mcux_rnga_init(const struct device *);
 
 DEVICE_DT_INST_DEFINE(0,
 		    entropy_mcux_rnga_init, NULL, NULL, NULL,
-		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    PRE_KERNEL_1, CONFIG_ENTROPY_INIT_PRIORITY,
 		    &entropy_mcux_rnga_api_funcs);
 
 static int entropy_mcux_rnga_init(const struct device *dev)

--- a/drivers/entropy/entropy_mcux_trng.c
+++ b/drivers/entropy/entropy_mcux_trng.c
@@ -45,7 +45,7 @@ static int entropy_mcux_trng_init(const struct device *);
 DEVICE_DT_INST_DEFINE(0,
 		    entropy_mcux_trng_init, NULL, NULL,
 		    &entropy_mcux_config,
-		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    PRE_KERNEL_1, CONFIG_ENTROPY_INIT_PRIORITY,
 		    &entropy_mcux_trng_api_funcs);
 
 static int entropy_mcux_trng_init(const struct device *dev)

--- a/drivers/entropy/entropy_nrf5.c
+++ b/drivers/entropy/entropy_nrf5.c
@@ -334,7 +334,7 @@ static const struct entropy_driver_api entropy_nrf5_api_funcs = {
 DEVICE_DT_INST_DEFINE(0,
 		    entropy_nrf5_init, NULL,
 		    &entropy_nrf5_data, NULL,
-		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    PRE_KERNEL_1, CONFIG_ENTROPY_INIT_PRIORITY,
 		    &entropy_nrf5_api_funcs);
 
 static int entropy_nrf5_init(const struct device *dev)

--- a/drivers/entropy/entropy_rv32m1_trng.c
+++ b/drivers/entropy/entropy_rv32m1_trng.c
@@ -45,7 +45,7 @@ static int entropy_rv32m1_trng_init(const struct device *);
 DEVICE_DT_INST_DEFINE(0,
 		    entropy_rv32m1_trng_init, NULL,
 		    NULL, &entropy_rv32m1_config,
-		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    PRE_KERNEL_1, CONFIG_ENTROPY_INIT_PRIORITY,
 		    &entropy_rv32m1_trng_api_funcs);
 
 static int entropy_rv32m1_trng_init(const struct device *dev)

--- a/drivers/entropy/entropy_sam.c
+++ b/drivers/entropy/entropy_sam.c
@@ -186,5 +186,5 @@ static const struct trng_sam_dev_cfg trng_sam_cfg = {
 DEVICE_DT_INST_DEFINE(0,
 		    entropy_sam_init, NULL,
 		    NULL, &trng_sam_cfg,
-		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    PRE_KERNEL_1, CONFIG_ENTROPY_INIT_PRIORITY,
 		    &entropy_sam_api);

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -520,5 +520,5 @@ static const struct entropy_driver_api entropy_stm32_rng_api = {
 DEVICE_DT_INST_DEFINE(0,
 		    entropy_stm32_rng_init, NULL,
 		    &entropy_stm32_rng_data, &entropy_stm32_rng_config,
-		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    PRE_KERNEL_1, CONFIG_ENTROPY_INIT_PRIORITY,
 		    &entropy_stm32_rng_api);

--- a/drivers/entropy/fake_entropy_native_posix.c
+++ b/drivers/entropy/fake_entropy_native_posix.c
@@ -78,7 +78,7 @@ static const struct entropy_driver_api entropy_native_posix_api_funcs = {
 DEVICE_DT_INST_DEFINE(0,
 		    entropy_native_posix_init, NULL,
 		    NULL, NULL,
-		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    PRE_KERNEL_1, CONFIG_ENTROPY_INIT_PRIORITY,
 		    &entropy_native_posix_api_funcs);
 
 static void add_fake_entropy_option(void)


### PR DESCRIPTION
Introduce Kconfig for setting the driver initialization priority across the entropy drivers and add a call to the logging template.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>