### PR TITLE
pm: Update API and subsystem to support SMP

### DIFF
--- a/include/pm/pm.h
+++ b/include/pm/pm.h
@@ -189,6 +189,8 @@ const struct pm_state_info pm_power_state_next_get(void);
  * be needed to be done after sleep state exits. Currently it enables
  * interrupts after resuming from sleep state. In future, the enabling
  * of interrupts may be moved into the kernel.
+ *
+ * @param info Power state that the given cpu is leaving.
  */
 void pm_power_state_exit_post_ops(struct pm_state_info info);
 

--- a/include/pm/pm.h
+++ b/include/pm/pm.h
@@ -178,9 +178,10 @@ void pm_power_state_set(struct pm_state_info info);
  * This function returns the next power state that will be used by the
  * SoC.
  *
+ * @param cpu CPU index.
  * @return next pm_state_info that will be used
  */
-const struct pm_state_info pm_power_state_next_get(void);
+const struct pm_state_info pm_power_state_next_get(uint8_t cpu);
 
 /**
  * @brief Do any SoC or architecture specific post ops after sleep state exits.
@@ -209,7 +210,7 @@ void pm_power_state_exit_post_ops(struct pm_state_info info);
 
 #define pm_power_state_set(info)
 #define pm_power_state_exit_post_ops(info)
-#define pm_power_state_next_get() \
+#define pm_power_state_next_get(cpu) \
 	((struct pm_state_info){PM_STATE_ACTIVE, 0, 0})
 
 #endif /* CONFIG_PM */

--- a/include/pm/policy.h
+++ b/include/pm/policy.h
@@ -22,11 +22,12 @@ extern "C" {
  * idle and returns the most appropriate state based on the number of
  * ticks to the next event.
  *
+ * @param cpu CPU index.
  * @param ticks The number of ticks to the next scheduled event.
  *
- * @return The power state the system should use.
+ * @return The power state the system should use for the given cpu.
  */
-struct pm_state_info pm_policy_next_state(int32_t ticks);
+struct pm_state_info pm_policy_next_state(uint8_t cpu, int32_t ticks);
 
 /** @endcond */
 

--- a/kernel/idle.c
+++ b/kernel/idle.c
@@ -32,7 +32,7 @@ static void pm_save_idle(void)
 	/*
 	 * Call the suspend hook function of the soc interface to allow
 	 * entry into a low power state. The function returns
-	 * PM_STATE_ACTIVE if low power state was not entered, in which
+	 * false if low power state was not entered, in which
 	 * case, kernel does normal idle processing.
 	 *
 	 * This function is entered with interrupts disabled. If a low power
@@ -42,7 +42,7 @@ static void pm_save_idle(void)
 	 * idle processing re-enables interrupts which is essential for
 	 * the kernel's scheduling logic.
 	 */
-	if (pm_system_suspend(ticks) == PM_STATE_ACTIVE) {
+	if (pm_system_suspend(ticks) == false) {
 		k_cpu_idle();
 	}
 #endif

--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -240,8 +240,10 @@ void z_mem_manage_boot_finish(void);
  *
  * This function is entered with interrupts disabled. It should re-enable
  * interrupts if it had entered a power state.
+ *
+ * @return True if the system suspended, otherwise return false
  */
-enum pm_state pm_system_suspend(int32_t ticks);
+bool pm_system_suspend(int32_t ticks);
 
 /**
  * Notify exit from kernel idling after PM operations

--- a/subsys/pm/policy/policy_dummy.c
+++ b/subsys/pm/policy/policy_dummy.c
@@ -18,11 +18,13 @@ LOG_MODULE_DECLARE(power, CONFIG_PM_LOG_LEVEL);
 static const struct pm_state_info pm_dummy_states[] =
 	PM_STATE_INFO_DT_ITEMS_LIST(DT_NODELABEL(cpu0));
 
-struct pm_state_info pm_policy_next_state(int32_t ticks)
+struct pm_state_info pm_policy_next_state(uint8_t cpu, int32_t ticks)
 {
 	static struct pm_state_info cur_pm_state_info;
 	int i = (int)cur_pm_state_info.state;
 	uint8_t states_len = ARRAY_SIZE(pm_dummy_states);
+
+	ARG_UNUSED(cpu);
 
 	if (states_len == 0) {
 		/* No power states to go through. */

--- a/subsys/pm/policy/policy_residency.c
+++ b/subsys/pm/policy/policy_residency.c
@@ -16,9 +16,11 @@ LOG_MODULE_DECLARE(power);
 static const struct pm_state_info pm_min_residency[] =
 	PM_STATE_INFO_DT_ITEMS_LIST(DT_NODELABEL(cpu0));
 
-struct pm_state_info pm_policy_next_state(int32_t ticks)
+struct pm_state_info pm_policy_next_state(uint8_t cpu, int32_t ticks)
 {
 	int i;
+
+	ARG_UNUSED(cpu);
 
 	for (i = ARRAY_SIZE(pm_min_residency) - 1; i >= 0; i--) {
 		uint32_t min_residency, exit_latency;

--- a/subsys/pm/policy/policy_residency.c
+++ b/subsys/pm/policy/policy_residency.c
@@ -4,48 +4,72 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <devicetree.h>
 #include <zephyr.h>
 #include <kernel.h>
 #include <pm/pm.h>
 #include <pm/policy.h>
+#include <sys/check.h>
 
 #define LOG_LEVEL CONFIG_PM_LOG_LEVEL /* From power module Kconfig */
 #include <logging/log.h>
 LOG_MODULE_DECLARE(power);
 
-static const struct pm_state_info pm_min_residency[] =
-	PM_STATE_INFO_DT_ITEMS_LIST(DT_NODELABEL(cpu0));
+#if DT_NODE_EXISTS(DT_PATH(cpus))
+
+#define CPU_STATES(n) (struct pm_state_info[])PM_STATE_INFO_DT_ITEMS_LIST(n),
+
+static const struct pm_state_info *pm_min_residency[] = {
+	DT_FOREACH_CHILD(DT_PATH(cpus), CPU_STATES)
+};
+
+#define CPU_STATES_SIZE(n) PM_STATE_DT_ITEMS_LEN(n),
+
+static int pm_min_residency_sizes[] = {
+	DT_FOREACH_CHILD(DT_PATH(cpus), CPU_STATES_SIZE)
+};
+#else
+static const struct pm_state_info *pm_min_residency[CONFIG_MP_NUM_CPUS] = {};
+static int pm_min_residency_sizes[CONFIG_MP_NUM_CPUS] = {};
+#endif	/* DT_NODE_EXISTS(DT_PATH(cpus)) */
 
 struct pm_state_info pm_policy_next_state(uint8_t cpu, int32_t ticks)
 {
 	int i;
 
-	ARG_UNUSED(cpu);
+	CHECKIF(cpu >= ARRAY_SIZE(pm_min_residency_sizes)) {
+		goto error;
+	}
 
-	for (i = ARRAY_SIZE(pm_min_residency) - 1; i >= 0; i--) {
+	i = pm_min_residency_sizes[cpu];
+	const struct pm_state_info *states = (const struct pm_state_info *)
+		pm_min_residency[cpu];
+
+	for (i = i - 1; i >= 0; i--) {
 		uint32_t min_residency, exit_latency;
 
-		if (!pm_constraint_get(pm_min_residency[i].state)) {
+		if (!pm_constraint_get(states[i].state)) {
 			continue;
 		}
 
 		min_residency = k_us_to_ticks_ceil32(
-			    pm_min_residency[i].min_residency_us);
+			    states[i].min_residency_us);
 		exit_latency = k_us_to_ticks_ceil32(
-			    pm_min_residency[i].exit_latency_us);
+			    states[i].exit_latency_us);
 		__ASSERT(min_residency > exit_latency,
 				"min_residency_us < exit_latency_us");
 
 		if ((ticks == K_TICKS_FOREVER) ||
 		    (ticks >= (min_residency + exit_latency))) {
 			LOG_DBG("Selected power state %d "
-				"(ticks: %d, min_residency: %u)",
-				pm_min_residency[i].state, ticks,
-				pm_min_residency[i].min_residency_us);
-			return pm_min_residency[i];
+				"(ticks: %d, min_residency: %u) to cpu %d",
+				states[i].state, ticks,
+				states[i].min_residency_us, cpu);
+			return states[i];
 		}
 	}
 
-	LOG_DBG("No suitable power state found!");
+error:
+	LOG_DBG("No suitable power state found for cpu: %d!", cpu);
 	return (struct pm_state_info){PM_STATE_ACTIVE, 0, 0};
 }

--- a/subsys/pm/power.c
+++ b/subsys/pm/power.c
@@ -365,7 +365,7 @@ int pm_notifier_unregister(struct pm_notifier *notifier)
 	return ret;
 }
 
-const struct pm_state_info pm_power_state_next_get(void)
+const struct pm_state_info pm_power_state_next_get(uint8_t cpu)
 {
-	return z_power_states[_current_cpu->id];
+	return z_power_states[cpu];
 }

--- a/subsys/pm/power.c
+++ b/subsys/pm/power.c
@@ -229,9 +229,13 @@ void pm_system_resume(void)
 	 * notification is not required.
 	 */
 	if (!post_ops_done) {
+		uint8_t id = _current_cpu->id;
+
 		post_ops_done = true;
-		exit_pos_ops(z_power_states[_current_cpu->id]);
+		exit_pos_ops(z_power_states[id]);
 		pm_state_notify(false);
+		z_power_states[id] = (struct pm_state_info){PM_STATE_ACTIVE,
+			0, 0};
 	}
 }
 

--- a/subsys/pm/power.c
+++ b/subsys/pm/power.c
@@ -267,7 +267,7 @@ static enum pm_state _handle_device_abort(struct pm_state_info info)
 }
 #endif
 
-enum pm_state pm_system_suspend(int32_t ticks)
+bool pm_system_suspend(int32_t ticks)
 {
 	uint8_t id = _current_cpu->id;
 
@@ -340,7 +340,7 @@ enum pm_state pm_system_suspend(int32_t ticks)
 	k_sched_unlock();
 	SYS_PORT_TRACING_FUNC_EXIT(pm, system_suspend, ticks,
 				   z_power_states[id].state);
-	return z_power_states[id].state;
+	return true;
 }
 
 void pm_notifier_register(struct pm_notifier *notifier)

--- a/subsys/pm/power.c
+++ b/subsys/pm/power.c
@@ -272,7 +272,7 @@ enum pm_state pm_system_suspend(int32_t ticks)
 	uint8_t id = _current_cpu->id;
 
 	SYS_PORT_TRACING_FUNC_ENTER(pm, system_suspend, ticks);
-	z_power_states[id] = pm_policy_next_state(ticks);
+	z_power_states[id] = pm_policy_next_state(id, ticks);
 	if (z_power_states[id].state == PM_STATE_ACTIVE) {
 		LOG_DBG("No PM operations done.");
 		SYS_PORT_TRACING_FUNC_EXIT(pm, system_suspend, ticks,

--- a/subsys/pm/power.c
+++ b/subsys/pm/power.c
@@ -20,7 +20,7 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(pm, CONFIG_PM_LOG_LEVEL);
 
-static int post_ops_done = 1;
+static bool post_ops_done = true;
 static struct pm_state_info z_power_state;
 static sys_slist_t pm_notifiers = SYS_SLIST_STATIC_INIT(&pm_notifiers);
 static struct k_spinlock pm_notifier_lock;
@@ -226,7 +226,7 @@ void pm_system_resume(void)
 	 * notification is not required.
 	 */
 	if (!post_ops_done) {
-		post_ops_done = 1;
+		post_ops_done = true;
 		exit_pos_ops(z_power_state);
 		pm_state_notify(false);
 	}
@@ -243,7 +243,7 @@ void pm_power_state_force(struct pm_state_info info)
 
 	(void)arch_irq_lock();
 	z_power_state = info;
-	post_ops_done = 0;
+	apost_ops_done = false;
 	pm_state_notify(true);
 
 	k_sched_lock();
@@ -276,7 +276,7 @@ enum pm_state pm_system_suspend(int32_t ticks)
 		SYS_PORT_TRACING_FUNC_EXIT(pm, system_suspend, ticks, z_power_state.state);
 		return z_power_state.state;
 	}
-	post_ops_done = 0;
+	post_ops_done = false;
 
 	if (ticks != K_TICKS_FOREVER) {
 		/*

--- a/subsys/tracing/sysview/SYSVIEW_Zephyr.txt
+++ b/subsys/tracing/sysview/SYSVIEW_Zephyr.txt
@@ -162,7 +162,7 @@ TaskState 0xBF 1=dummy, 2=Waiting, 4=New, 8=Terminated, 16=Suspended, 32=Termina
 154 k_lifo_alloc_put             lifo=%I, data=%I
 
 
-155 pm_system_suspend            ticks=%u | Returns %PowerState
+155 pm_system_suspend            ticks=%u | Returns %Bool
 156 pm_device_runtime_get        dev=%I | Returns %u
 157 pm_device_runtime_put        dev=%I | Returns %u
 158 pm_device_runtime_put_async  dev=%I | Returns %u

--- a/tests/kernel/profiling/profiling_api/src/main.c
+++ b/tests/kernel/profiling/profiling_api/src/main.c
@@ -23,9 +23,11 @@ static void tdata_dump_callback(const struct k_thread *thread, void *user_data)
 }
 
 /* Our PM policy handler */
-struct pm_state_info pm_policy_next_state(int32_t ticks)
+struct pm_state_info pm_policy_next_state(uint8_t cpu, int32_t ticks)
 {
 	static bool test_flag;
+
+	ARG_UNUSED(cpu);
 
 	/* Call k_thread_foreach only once otherwise it will
 	 * flood the console with stack dumps.

--- a/tests/subsys/pm/device_wakeup_api/src/main.c
+++ b/tests/subsys/pm/device_wakeup_api/src/main.c
@@ -57,8 +57,10 @@ void pm_power_state_exit_post_ops(struct pm_state_info info)
 	irq_unlock(0);
 }
 
-struct pm_state_info pm_policy_next_state(int32_t ticks)
+struct pm_state_info pm_policy_next_state(uint8_t cpu, int32_t ticks)
 {
+	ARG_UNUSED(cpu);
+
 	while (sleep_count < 3) {
 		sleep_count++;
 		return (struct pm_state_info){PM_STATE_SUSPEND_TO_RAM, 0, 0, 0};

--- a/tests/subsys/pm/power_mgmt/src/main.c
+++ b/tests/subsys/pm/power_mgmt/src/main.c
@@ -57,9 +57,11 @@ void pm_power_state_exit_post_ops(struct pm_state_info info)
 }
 
 /* Our PM policy handler */
-struct pm_state_info pm_policy_next_state(int ticks)
+struct pm_state_info pm_policy_next_state(uint8_t cpu, int ticks)
 {
 	struct pm_state_info info = {};
+
+	ARG_UNUSED(cpu);
 
 	/* make sure this is idle thread */
 	zassert_true(z_is_idle_thread_object(_current), NULL);


### PR DESCRIPTION
- ~Change the power management API that is implemented by the
  architecture adding a parameter with which CPU is idle.~
- Update policy API to handle multiple CPUs
  - Change the residency policy to get power states per CPUs and properly use them
- Track power states per core (instead of a global state)

Changes from initial version:

- Properly handle device power management on SMP environment
- Use unsigned int to reference a cpu
- Remove `_handle_device_abort` . It was only called in one place and it was simple enough to be inline in the caller.
