### PR TITLE
Independent WatchDog support on the stm32u5

### DIFF
--- a/boards/arm/b_u585i_iot02a/b_u585i_iot02a.dts
+++ b/boards/arm/b_u585i_iot02a/b_u585i_iot02a.dts
@@ -67,3 +67,7 @@
 	pinctrl-0 = <&dac1_out1_pa4>;
 	status = "okay";
 };
+
+&iwdg1 {
+	status = "okay";
+};

--- a/boards/arm/b_u585i_iot02a/b_u585i_iot02a.yaml
+++ b/boards/arm/b_u585i_iot02a/b_u585i_iot02a.yaml
@@ -14,3 +14,4 @@ supported:
   - hts221
   - spi
   - dac
+  - watchdog

--- a/boards/arm/b_u585i_iot02a/doc/index.rst
+++ b/boards/arm/b_u585i_iot02a/doc/index.rst
@@ -181,6 +181,8 @@ The Zephyr b_u585i_iot02a board configuration supports the following hardware fe
 +-----------+------------+-------------------------------------+
 | DAC       | on-chip    | dac                                 |
 +-----------+------------+-------------------------------------+
+| WATCHDOG  | on-chip    | independent watchdog                |
++-----------+------------+-------------------------------------+
 
 The default configuration can be found in the defconfig file:
 

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -195,6 +195,14 @@
 			};
 		};
 
+		iwdg1: watchdog@40003000 {
+			compatible = "st,stm32-watchdog";
+			reg = <0x40003000 0x400>;
+			interrupts = <27 7>;
+			label = "IWDG_1";
+			status = "disabled";
+		};
+
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;


### PR DESCRIPTION
This PR adds the support of the  Independent watchdog (IWDG) peripheral on the stm32U585
and enables the instance IWDG1 of this peripheral on the disco board b_u585i_iot02a

Signed-off-by: Francois Ramu francois.ramu@st.com