### PR TITLE
sensor: qdec_nrfx: fix PM callback signature

### DIFF
--- a/drivers/sensor/qdec_nrfx/qdec_nrfx.c
+++ b/drivers/sensor/qdec_nrfx/qdec_nrfx.c
@@ -207,9 +207,11 @@ static int qdec_nrfx_init(const struct device *dev)
 }
 
 #ifdef CONFIG_PM_DEVICE
-static int qdec_nrfx_pm_control(struct qdec_nrfx_data *data,
+static int qdec_nrfx_pm_control(const struct device *dev,
 				enum pm_device_action action)
 {
+	ARG_UNUSED(dev);
+
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
 		qdec_nrfx_gpio_ctrl(true);


### PR DESCRIPTION
The PM action callback had an incorrect signature, probably a leftover
from the actions conversion.

Fixes #39687 