### PR TITLE
 system Window WatchDog support on the stm32u5

### DIFF
--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -207,6 +207,15 @@
 			status = "disabled";
 		};
 
+		wwdg1: watchdog@40002c00 {
+			compatible = "st,stm32-window-watchdog";
+			reg = <0x40002c00 0x1000>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000800>;
+			interrupts = <0 7>;
+			status = "disabled";
+			label = "WWDG_1";
+		};
+
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;


### PR DESCRIPTION
Add the WWDG node for stm32u5 socs.

Note that the target board b_u585i_iot02a should enable the wwdg1 instance if needed (which is _not_ here)
with **boards/arm/b_u585i_iot02a/b_u585i_iot02a.dts** as follows:
```
+&wwdg1 {
+	status = "okay";
+};

```
Signed-off-by: Francois Ramu <francois.ramu@st.com>