### PR TITLE
entropy (Random Nb Generator) support on the stm32u5

### DIFF
--- a/boards/arm/b_u585i_iot02a/b_u585i_iot02a.dts
+++ b/boards/arm/b_u585i_iot02a/b_u585i_iot02a.dts
@@ -63,6 +63,10 @@
 	};
 };
 
+&rng {
+	status = "okay";
+};
+
 &dac1 {
 	pinctrl-0 = <&dac1_out1_pa4>;
 	status = "okay";

--- a/boards/arm/b_u585i_iot02a/doc/index.rst
+++ b/boards/arm/b_u585i_iot02a/doc/index.rst
@@ -139,6 +139,7 @@ They operate at a frequency of up to 160 MHz.
 
 - CRC calculation unit
 - Development support: serial wire debug (SWD), JTAG, Embedded Trace Macrocell |trade|
+- True Random Number Generator (RNG)
 
 - Graphic features
 
@@ -175,6 +176,8 @@ The Zephyr b_u585i_iot02a board configuration supports the following hardware fe
 +-----------+------------+-------------------------------------+
 | GPIO      | on-chip    | gpio                                |
 +-----------+------------+-------------------------------------+
+| RNG       | on-chip    | True Random number generator        |
++-------------+------------+-----------------------------------+
 | I2C       | on-chip    | i2c                                 |
 +-----------+------------+-------------------------------------+
 | SPI       | on-chip    | spi                                 |

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -12,6 +12,10 @@
 #include <freq.h>
 
 / {
+	chosen {
+		zephyr,entropy = &rng;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -318,6 +322,15 @@
 			interrupt-names = "wakeup";
 			status = "disabled";
 			label = "LPTIM_1";
+		};
+
+		rng: rng@420c0800 {
+			compatible = "st,stm32-rng";
+			reg = <0x420c0800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00040000>;
+			interrupts = <94 0>;
+			status = "disabled";
+			label = "RNG";
 		};
 
 		dac1: dac@46021800 {


### PR DESCRIPTION
This PR adds the support of the RNG which is a true random number generator that provides full entropy outputs to the
application as 32-bit samples
This  peripheral is enabled on the disco board b_u585i_iot02a
For more details on the stm32 True random number generator (RNG), please refer to the [refMan of the stm32u5](https://www.st.com/content/ccc/resource/technical/document/reference_manual/group0/f3/60/ca/d2/98/c8/47/88/DM00477635/files/DM00477635.pdf/jcr:content/translations/en.DM00477635.pdf) device.

Signed-off-by: Francois Ramu francois.ramu@st.com