### PR TITLE
drivers: pwm: stm32: add pwm capture support

### DIFF
--- a/tests/drivers/pwm/pwm_loopback/boards/disco_l475_iot1.overlay
+++ b/tests/drivers/pwm/pwm_loopback/boards/disco_l475_iot1.overlay
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021 Tilmann Unte
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <dt-bindings/pwm/pwm.h>
+
+/ {
+	pwm_loopback_0 {
+		compatible = "test-pwm-loopback";
+		/* first index must be a 32-Bit timer */
+		pwms = <&pwm2 1 0 PWM_POLARITY_NORMAL>,
+			<&pwm15 1 0 PWM_POLARITY_NORMAL>;
+	};
+};
+
+/* 32-Bit timers */
+&timers2 {
+	status = "okay";
+	pwm2: pwm {
+		status = "okay";
+		pinctrl-0 = <&tim2_ch1_pa5>; /* CN1 D13 */
+	};
+};
+
+&timers5 {
+	status = "okay";
+	pwm5: pwm {
+		status = "okay";
+		pinctrl-0 = <&tim5_ch1_pa0>; /* CN3 D1 */
+	};
+};
+
+/* 16-Bit timers */
+&timers3 {
+	status = "okay";
+	st,prescaler = <255>;
+	pwm3: pwm {
+		status = "okay";
+		pinctrl-0 = <&tim3_ch1_pa6>; /* CN1 D12 */
+	};
+};
+
+&timers15 {
+	status = "okay";
+	st,prescaler = <255>;
+	pwm15: pwm {
+		status = "okay";
+		pinctrl-0 = <&tim15_ch1_pa2>; /* CN1 D10 */
+	};
+};


### PR DESCRIPTION
Extends STM32 PWM driver to support capturing pulse width, period,
or both.

Fixes #39394

Signed-off-by: Tilmann Unte <unte@es-augsburg.de>