### PR TITLE
doc: fix broken link to DAPlink reel board fw

### DIFF
--- a/boards/arm/reel_board/doc/index.rst
+++ b/boards/arm/reel_board/doc/index.rst
@@ -569,4 +569,4 @@ References
    https://www.phytec.de/reelboard/
 
 .. _DAPLink reel board Firmware:
-   https://github.com/jfischer-phytec-iot/DAPLink/tree/reel-board
+   https://github.com/PHYTEC-Messtechnik-GmbH/DAPLink/tree/reel-board


### PR DESCRIPTION
The repository to the DAPlink firmware for the reel board has been moved to the Github organization _PHYTEC-Messtechnik-GmbH_. This commit replaces the link in the Zephyr reel board documentation accordingly.