### PR TITLE
[RFC] doc: replace breathe with Sphinx-Doxygen bridge

### DIFF
--- a/doc/_extensions/zephyr/doxybridge.py
+++ b/doc/_extensions/zephyr/doxybridge.py
@@ -1,0 +1,133 @@
+"""
+Copyright (c) 2021 Nordic Semiconductor ASA
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+from docutils import nodes
+
+from sphinx.addnodes import pending_xref
+from sphinx.application import Sphinx
+from sphinx.transforms.post_transforms import SphinxPostTransform
+from sphinx.util import logging
+
+import xml.etree.ElementTree as ET
+
+
+logger = logging.getLogger(__name__)
+
+
+KIND_D2S = {
+    "define": "macro",
+    "variable": "var",
+    "typedef": "type",
+    "enum": "enum",
+    "function": "func",
+}
+"""Mapping between Doxygen memberdef kind and Sphinx kinds"""
+
+
+class DoxygenReferencer(SphinxPostTransform):
+
+    default_priority = 5
+
+    def run(self, **kwargs: Any) -> None:
+        for node in self.document.traverse(pending_xref):
+            if node.get("refdomain") != "c":
+                continue
+
+            reftype = node.get("reftype")
+            entry = self.app.env.doxybridge_cache.get(reftype)
+            if not entry:
+                continue
+
+            reftarget = node.get("reftarget")
+            id = entry.get(reftarget)
+            if not id:
+                continue
+
+            if reftype in ("struct", "union"):
+                doxygen_target = f"{id}.html"
+            else:
+                split = id.split("_")
+                doxygen_target = f"{'_'.join(split[:-1])}.html#{split[-1][1:]}"
+
+            doxygen_target = (
+                str(self.app.config.doxybridge_dir) + "/html/" + doxygen_target
+            )
+
+            doc_dir = os.path.dirname(self.document.get("source"))
+            doc_dest = os.path.join(
+                self.app.outdir,
+                os.path.relpath(doc_dir, self.app.srcdir),
+            )
+            rel_uri = os.path.relpath(doxygen_target, doc_dest)
+
+            refnode = nodes.reference(
+                "", "", internal=True, refuri=rel_uri, reftitle=""
+            )
+            refnode.append(node[0].deepcopy())
+
+            node.replace_self([refnode])
+
+
+def doxygen_parse(app: Sphinx) -> None:
+    app.env.doxybridge_cache = {
+        "macro": {},
+        "var": {},
+        "type": {},
+        "enum": {},
+        "func": {},
+        "union": {},
+        "struct": {},
+    }
+
+    xmldir = Path(app.config.doxybridge_dir) / "xml"
+    for file in xmldir.glob("*_8[a-z].xml"):
+        root = ET.parse(file).getroot()
+
+        compounddef = root.find("compounddef")
+        if not compounddef or compounddef.attrib["kind"] != "file":
+            logger.warning(f"Unexpected file content in {file}")
+            continue
+
+        memberdefs = compounddef.findall(".//memberdef")
+        for memberdef in memberdefs:
+            kind = KIND_D2S.get(memberdef.attrib["kind"])
+            if not kind:
+                logger.warning(f"Unsupported kind: {kind}")
+                continue
+
+            id = memberdef.attrib["id"]
+            name = memberdef.find("name").text
+
+            app.env.doxybridge_cache[kind][name] = id
+
+        innerclasses = compounddef.findall(".//innerclass")
+        for innerclass in innerclasses:
+            refid = innerclass.get("refid")
+            if refid.startswith("union"):
+                kind = "union"
+            elif refid.startswith("struct"):
+                kind = "struct"
+            else:
+                continue
+
+            name = innerclass.text
+            app.env.doxybridge_cache[kind][name] = refid
+
+
+def setup(app: Sphinx) -> Dict[str, Any]:
+    app.add_config_value("doxybridge_dir", None, "env")
+
+    app.add_post_transform(DoxygenReferencer)
+    app.connect("builder-inited", doxygen_parse)
+
+    return {
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -79,6 +79,7 @@ extensions = [
     "sphinx_tabs.tabs",
     "zephyr.warnings_filter",
     "zephyr.doxyrunner",
+    "zephyr.doxybridge",
     "notfound.extension",
     "zephyr.external_content",
 ]
@@ -181,6 +182,10 @@ doxyrunner_doxyfile = ZEPHYR_BASE / "doc" / "zephyr.doxyfile.in"
 doxyrunner_outdir = ZEPHYR_BUILD / "doxygen"
 doxyrunner_fmt = True
 doxyrunner_fmt_vars = {"ZEPHYR_BASE": str(ZEPHYR_BASE), "ZEPHYR_VERSION": version}
+
+# -- Options for zephyr.doxybridge plugin ---------------------------------
+
+doxybridge_dir = doxyrunner_outdir
 
 # -- Options for html_redirect plugin -------------------------------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -67,7 +67,6 @@ release = version
 # -- General configuration ------------------------------------------------
 
 extensions = [
-    "breathe",
     "sphinx.ext.todo",
     "sphinx.ext.extlinks",
     "sphinx.ext.autodoc",
@@ -182,31 +181,6 @@ doxyrunner_doxyfile = ZEPHYR_BASE / "doc" / "zephyr.doxyfile.in"
 doxyrunner_outdir = ZEPHYR_BUILD / "doxygen"
 doxyrunner_fmt = True
 doxyrunner_fmt_vars = {"ZEPHYR_BASE": str(ZEPHYR_BASE), "ZEPHYR_VERSION": version}
-
-# -- Options for Breathe plugin -------------------------------------------
-
-breathe_projects = {"Zephyr": str(doxyrunner_outdir / "xml")}
-breathe_default_project = "Zephyr"
-breathe_domain_by_extension = {
-    "h": "c",
-    "c": "c",
-}
-breathe_show_enumvalue_initializer = True
-breathe_default_members = ("members", )
-
-cpp_id_attributes = [
-    "__syscall",
-    "__deprecated",
-    "__may_alias",
-    "__used",
-    "__unused",
-    "__weak",
-    "__attribute_const__",
-    "__DEPRECATED_MACRO",
-    "FUNC_NORETURN",
-    "__subsystem",
-]
-c_id_attributes = cpp_id_attributes
 
 # -- Options for html_redirect plugin -------------------------------------
 

--- a/doc/guides/debug_tools/coredump.rst
+++ b/doc/guides/debug_tools/coredump.rst
@@ -340,6 +340,6 @@ the following needs to be done:
 API documentation
 *****************
 
-.. doxygengroup:: coredump_apis
 
-.. doxygengroup:: arch-coredump
+
+

--- a/doc/guides/debug_tools/thread-analyzer.rst
+++ b/doc/guides/debug_tools/thread-analyzer.rst
@@ -84,4 +84,4 @@ Configure this module using the following options.
 API documentation
 *****************
 
-.. doxygengroup:: thread_analyzer
+

--- a/doc/guides/debug_tools/tracing/index.rst
+++ b/doc/guides/debug_tools/tracing/index.rst
@@ -351,85 +351,85 @@ API
 Common
 ======
 
-.. doxygengroup:: tracing_apis
+
 
 Threads
 =======
 
-.. doxygengroup:: thread_tracing_apis
+
 
 
 Work Queues
 ===========
 
-.. doxygengroup:: work_tracing_apis
+
 
 
 Poll
 ====
 
-.. doxygengroup:: poll_tracing_apis
+
 
 Semaphore
 =========
 
-.. doxygengroup:: sem_tracing_apis
+
 
 Mutex
 =====
 
-.. doxygengroup:: mutex_tracing_apis
+
 
 Condition Variables
 ===================
 
-.. doxygengroup:: condvar_tracing_apis
+
 
 Queues
 ======
 
-.. doxygengroup:: queue_tracing_apis
+
 
 FIFO
 ====
 
-.. doxygengroup:: fifo_tracing_apis
+
 
 LIFO
 ====
-.. doxygengroup:: lifo_tracing_apis
+
 
 Stacks
 ======
 
-.. doxygengroup:: stack_tracing_apis
+
 
 Message Queues
 ==============
 
-.. doxygengroup:: msgq_tracing_apis
+
 
 Mailbox
 =======
 
-.. doxygengroup:: mbox_tracing_apis
+
 
 Pipes
 ======
 
-.. doxygengroup:: pipe_tracing_apis
+
 
 Heaps
 =====
 
-.. doxygengroup:: heap_tracing_apis
+
 
 Memory Slabs
 ============
 
-.. doxygengroup:: mslab_tracing_apis
+
 
 Timers
 ======
 
-.. doxygengroup:: timer_tracing_apis
+

--- a/doc/guides/porting/arch.rst
+++ b/doc/guides/porting/arch.rst
@@ -841,41 +841,41 @@ API Reference
 Timing
 ======
 
-.. doxygengroup:: arch-timing
+
 
 Threads
 =======
 
-.. doxygengroup:: arch-threads
 
-.. doxygengroup:: arch-tls
+
+
 
 Power Management
 ================
 
-.. doxygengroup:: arch-pm
+
 
 Symmetric Multi-Processing
 ==========================
 
-.. doxygengroup:: arch-smp
+
 
 Interrupts
 ==========
 
-.. doxygengroup:: arch-irq
+
 
 Userspace
 =========
 
-.. doxygengroup:: arch-userspace
+
 
 Memory Management
 =================
 
-.. doxygengroup:: arch-mmu
+
 
 Miscellaneous Architecture APIs
 ===============================
 
-.. doxygengroup:: arch-misc
+

--- a/doc/guides/test/ztest.rst
+++ b/doc/guides/test/ztest.rst
@@ -299,7 +299,7 @@ API reference
 Running tests
 =============
 
-.. doxygengroup:: ztest_test
+
 
 Assertions
 ==========
@@ -318,7 +318,7 @@ Example output for a failed macro from
     Assertion failed at main.c:62: test_get_single_buffer: Invalid refcount (buf->ref not equal to 2)
     Aborted at unit test function
 
-.. doxygengroup:: ztest_assert
+
 
 Mocking
 =======
@@ -337,7 +337,7 @@ expect the values ``a=2`` and ``b=3``, and telling ``returns_int`` to return
    :language: c
    :linenos:
 
-.. doxygengroup:: ztest_mock
+
 
 Customizing Test Output
 ***********************

--- a/doc/reference/audio/codec.rst
+++ b/doc/reference/audio/codec.rst
@@ -18,4 +18,4 @@ Related configuration options:
 API Reference
 *************
 
-.. doxygengroup:: audio_codec_interface
+

--- a/doc/reference/audio/dmic.rst
+++ b/doc/reference/audio/dmic.rst
@@ -18,4 +18,4 @@ Related configuration options:
 API Reference
 *************
 
-.. doxygengroup:: audio_dmic_interface
+

--- a/doc/reference/audio/i2s.rst
+++ b/doc/reference/audio/i2s.rst
@@ -21,4 +21,4 @@ Related configuration options:
 API Reference
 *************
 
-.. doxygengroup:: i2s_interface
+

--- a/doc/reference/bluetooth/connection_mgmt.rst
+++ b/doc/reference/bluetooth/connection_mgmt.rst
@@ -27,4 +27,4 @@ also get hold of the connection object through the return value of the
 API Reference
 *************
 
-.. doxygengroup:: bt_conn
+

--- a/doc/reference/bluetooth/controller.rst
+++ b/doc/reference/bluetooth/controller.rst
@@ -7,4 +7,4 @@ Bluetooth Controller
 API Reference
 *************
 
-.. doxygengroup:: bt_ctrl
+

--- a/doc/reference/bluetooth/crypto.rst
+++ b/doc/reference/bluetooth/crypto.rst
@@ -7,4 +7,4 @@ Cryptography
 API Reference
 *************
 
-.. doxygengroup:: bt_crypto
+

--- a/doc/reference/bluetooth/data_buffer.rst
+++ b/doc/reference/bluetooth/data_buffer.rst
@@ -7,4 +7,4 @@ Data Buffers
 API Reference
 *************
 
-.. doxygengroup:: bt_buf
+

--- a/doc/reference/bluetooth/gap.rst
+++ b/doc/reference/bluetooth/gap.rst
@@ -6,8 +6,8 @@ Generic Access Profile (GAP)
 API Reference
 *************
 
-.. doxygengroup:: bt_gap
 
-.. doxygengroup:: bt_addr
 
-.. doxygengroup:: bt_gap_defines
+
+
+

--- a/doc/reference/bluetooth/gatt.rst
+++ b/doc/reference/bluetooth/gatt.rst
@@ -95,14 +95,14 @@ being triggered for the same attribute. Subscriptions can be removed with use of
 API Reference
 *************
 
-.. doxygengroup:: bt_gatt
+
 
 GATT Server
 ===========
 
-.. doxygengroup:: bt_gatt_server
+
 
 GATT Client
 ===========
 
-.. doxygengroup:: bt_gatt_client
+

--- a/doc/reference/bluetooth/hci_drivers.rst
+++ b/doc/reference/bluetooth/hci_drivers.rst
@@ -8,4 +8,4 @@ HCI Drivers
 API Reference
 *************
 
-.. doxygengroup:: bt_hci_driver
+

--- a/doc/reference/bluetooth/hci_raw.rst
+++ b/doc/reference/bluetooth/hci_raw.rst
@@ -15,4 +15,4 @@ are sent and received by the Bluetooth HCI driver.
 API Reference
 *************
 
-.. doxygengroup:: hci_raw
+

--- a/doc/reference/bluetooth/hfp.rst
+++ b/doc/reference/bluetooth/hfp.rst
@@ -7,4 +7,4 @@ Hands Free Profile (HFP)
 API Reference
 *************
 
-.. doxygengroup:: bt_hfp
+

--- a/doc/reference/bluetooth/l2cap.rst
+++ b/doc/reference/bluetooth/l2cap.rst
@@ -38,4 +38,4 @@ Note that the later can also disconnect channel instances created by servers.
 API Reference
 *************
 
-.. doxygengroup:: bt_l2cap
+

--- a/doc/reference/bluetooth/mesh/access.rst
+++ b/doc/reference/bluetooth/mesh/access.rst
@@ -142,4 +142,4 @@ details.
 API reference
 *************
 
-.. doxygengroup:: bt_mesh_access
+

--- a/doc/reference/bluetooth/mesh/cfg.rst
+++ b/doc/reference/bluetooth/mesh/cfg.rst
@@ -17,4 +17,4 @@ scenarios, this API can be used to change the configuration locally.
 API reference
 *************
 
-.. doxygengroup:: bt_mesh_cfg
+

--- a/doc/reference/bluetooth/mesh/cfg_cli.rst
+++ b/doc/reference/bluetooth/mesh/cfg_cli.rst
@@ -23,4 +23,4 @@ first element if it is present in the composition data.
 API reference
 *************
 
-.. doxygengroup:: bt_mesh_cfg_cli
+

--- a/doc/reference/bluetooth/mesh/cfg_srv.rst
+++ b/doc/reference/bluetooth/mesh/cfg_srv.rst
@@ -20,4 +20,4 @@ should be instantiated in the first element.
 API reference
 *************
 
-.. doxygengroup:: bt_mesh_cfg_srv
+

--- a/doc/reference/bluetooth/mesh/core.rst
+++ b/doc/reference/bluetooth/mesh/core.rst
@@ -55,4 +55,4 @@ volnurability and flash wear out.
 API reference
 **************
 
-.. doxygengroup:: bt_mesh
+

--- a/doc/reference/bluetooth/mesh/health_cli.rst
+++ b/doc/reference/bluetooth/mesh/health_cli.rst
@@ -20,4 +20,4 @@ fault values.
 API reference
 *************
 
-.. doxygengroup:: bt_mesh_health_cli
+

--- a/doc/reference/bluetooth/mesh/health_srv.rst
+++ b/doc/reference/bluetooth/mesh/health_srv.rst
@@ -48,7 +48,7 @@ The remaining time for the attention period may be queried through
 API reference
 *************
 
-.. doxygengroup:: bt_mesh_health_srv
+
 
 .. _bluetooth_mesh_health_faults:
 
@@ -57,4 +57,4 @@ Health faults
 
 Fault values defined by the Bluetooth mesh specification.
 
-.. doxygengroup:: bt_mesh_health_faults
+

--- a/doc/reference/bluetooth/mesh/heartbeat.rst
+++ b/doc/reference/bluetooth/mesh/heartbeat.rst
@@ -62,4 +62,4 @@ When the Heartbeat subscription period ends, the
 API reference
 **************
 
-.. doxygengroup:: bt_mesh_heartbeat
+

--- a/doc/reference/bluetooth/mesh/msg.rst
+++ b/doc/reference/bluetooth/mesh/msg.rst
@@ -10,4 +10,4 @@ contexts.
 API reference
 *************
 
-.. doxygengroup:: bt_mesh_msg
+

--- a/doc/reference/bluetooth/mesh/provisioning.rst
+++ b/doc/reference/bluetooth/mesh/provisioning.rst
@@ -184,4 +184,4 @@ should use a static OOB value and OOB public key transfer.
 API reference
 *************
 
-.. doxygengroup:: bt_mesh_prov
+

--- a/doc/reference/bluetooth/mesh/proxy.rst
+++ b/doc/reference/bluetooth/mesh/proxy.rst
@@ -12,4 +12,4 @@ can be set with :c:member:`bt_mesh_cfg_srv.gatt_proxy`.
 API reference
 *************
 
-.. doxygengroup:: bt_mesh_proxy
+

--- a/doc/reference/bluetooth/rfcomm.rst
+++ b/doc/reference/bluetooth/rfcomm.rst
@@ -8,4 +8,4 @@ Serial Port Emulation (RFCOMM)
 API Reference
 *************
 
-.. doxygengroup:: bt_rfcomm
+

--- a/doc/reference/bluetooth/sdp.rst
+++ b/doc/reference/bluetooth/sdp.rst
@@ -6,4 +6,4 @@ Service Discovery Protocol (SDP)
 API Reference
 **************
 
-.. doxygengroup:: bt_sdp
+

--- a/doc/reference/bluetooth/uuid.rst
+++ b/doc/reference/bluetooth/uuid.rst
@@ -7,4 +7,4 @@ Universal Unique Identifiers (UUIDs)
 API Reference
 *************
 
-.. doxygengroup:: bt_uuid
+

--- a/doc/reference/crypto/index.rst
+++ b/doc/reference/crypto/index.rst
@@ -10,4 +10,4 @@ Overview
 API Reference
 *************
 
-.. doxygengroup:: crypto_cipher
+

--- a/doc/reference/data_structures/dlist.rst
+++ b/doc/reference/data_structures/dlist.rst
@@ -97,4 +97,4 @@ nodes, where one node represents the list tracking struct.
 Doubly-linked List API Reference
 --------------------------------
 
-.. doxygengroup:: doubly-linked-list_apis
+

--- a/doc/reference/data_structures/rbtree.rst
+++ b/doc/reference/data_structures/rbtree.rst
@@ -118,4 +118,4 @@ somewhat unique to Zephyr.
 Red/Black Tree API Reference
 --------------------------------
 
-.. doxygengroup:: rbtree_apis
+

--- a/doc/reference/data_structures/ring_buffers.rst
+++ b/doc/reference/data_structures/ring_buffers.rst
@@ -412,4 +412,4 @@ API Reference
 
 The following ring buffer APIs are provided by :zephyr_file:`include/sys/ring_buffer.h`:
 
-.. doxygengroup:: ring_buffer_apis
+

--- a/doc/reference/data_structures/slist.rst
+++ b/doc/reference/data_structures/slist.rst
@@ -117,9 +117,9 @@ simpler slist code.
 Single-linked List API Reference
 --------------------------------
 
-.. doxygengroup:: single-linked-list_apis
+
 
 Flagged List API Reference
 --------------------------------
 
-.. doxygengroup:: flagged-single-linked-list_apis
+

--- a/doc/reference/devicetree/api.rst
+++ b/doc/reference/devicetree/api.rst
@@ -38,7 +38,7 @@ child node, respectively.
 
 The following macros create or operate on node identifiers.
 
-.. doxygengroup:: devicetree-generic-id
+
 
 .. _devicetree-property-access:
 
@@ -52,7 +52,7 @@ and :ref:`devicetree-interrupts-property`.
 Property values can be read using these macros even if the node is disabled,
 as long as it has a matching binding.
 
-.. doxygengroup:: devicetree-generic-prop
+
 
 .. _devicetree-reg-property:
 
@@ -64,7 +64,7 @@ Use these APIs instead of :ref:`devicetree-property-access` to access the
 devicetree specification, these macros can be used even for nodes without
 matching bindings.
 
-.. doxygengroup:: devicetree-reg-prop
+
 
 .. _devicetree-interrupts-property:
 
@@ -78,7 +78,7 @@ Because this property's semantics are defined by the devicetree specification,
 some of these macros can be used even for nodes without matching bindings. This
 does not apply to macros which take cell names as arguments.
 
-.. doxygengroup:: devicetree-interrupts-prop
+
 
 For-each macros
 ===============
@@ -91,7 +91,7 @@ There are special-purpose for-each macros, like
 :c:func:`DT_INST_FOREACH_STATUS_OKAY`, but these require ``DT_DRV_COMPAT`` to
 be defined before use.
 
-.. doxygengroup:: devicetree-generic-foreach
+
 
 Existence checks
 ================
@@ -102,7 +102,7 @@ properties, etc. Some macros used for special purposes (such as
 :c:func:`DT_IRQ_HAS_IDX` and all macros which require ``DT_DRV_COMPAT``) are
 documented elsewhere on this page.
 
-.. doxygengroup:: devicetree-generic-exist
+
 
 .. _devicetree-dep-ord:
 
@@ -139,7 +139,7 @@ cause errors, so it's safe to assume there are none when using these macros.
 There are instance number-based conveniences as well; see
 :c:func:`DT_INST_DEP_ORD` and subsequent documentation.
 
-.. doxygengroup:: devicetree-dep-ord
+
 
 Bus helpers
 ===========
@@ -149,7 +149,7 @@ bindings to declare that nodes with a given compatible describe system buses.
 In this case, child nodes are considered to be on a bus of the given type, and
 the following APIs may be used.
 
-.. doxygengroup:: devicetree-generic-bus
+
 
 .. _devicetree-inst-apis:
 
@@ -198,7 +198,7 @@ to use any of these without that macro defined.
 Note that there are also helpers available for
 specific hardware; these are documented in :ref:`devicetree-hw-api`.
 
-.. doxygengroup:: devicetree-inst
+
 
 .. _devicetree-hw-api:
 
@@ -214,7 +214,7 @@ Clocks
 These conveniences may be used for nodes which describe clock sources, and
 properties related to them.
 
-.. doxygengroup:: devicetree-clocks
+
 
 DMA
 ===
@@ -222,7 +222,7 @@ DMA
 These conveniences may be used for nodes which describe direct memory access
 controllers or channels, and properties related to them.
 
-.. doxygengroup:: devicetree-dmas
+
 
 .. _devicetree-flash-api:
 
@@ -234,7 +234,7 @@ compatible used to encode information about flash memory partitions in the
 device tree. See :zephyr_file:`dts/bindings/mtd/partition.yaml` for this
 compatible's binding.
 
-.. doxygengroup:: devicetree-fixed-partition
+
 
 .. _devicetree-gpio-api:
 
@@ -244,7 +244,7 @@ GPIO
 These conveniences may be used for nodes which describe GPIO controllers/pins,
 and properties related to them.
 
-.. doxygengroup:: devicetree-gpio
+
 
 IO channels
 ===========
@@ -252,7 +252,7 @@ IO channels
 These are commonly used by device drivers which need to use IO
 channels (e.g. ADC or DAC channels) for conversion.
 
-.. doxygengroup:: devicetree-io-channels
+
 
 .. _devicetree-pinctrl-api:
 
@@ -282,7 +282,7 @@ Above, ``pinctrl-0`` has name ``"default"``, and ``pinctrl-1`` has name
 ``&foo``, ``&bar``, etc. phandles within the properties point to nodes whose
 contents vary by platform, and which describe a pin configuration for the node.
 
-.. doxygengroup:: devicetree-pinctrl
+
 
 PWM
 ===
@@ -290,7 +290,7 @@ PWM
 These conveniences may be used for nodes which describe PWM controllers and
 properties related to them.
 
-.. doxygengroup:: devicetree-pwms
+
 
 SPI
 ===
@@ -298,7 +298,7 @@ SPI
 These conveniences may be used for nodes which describe either SPI controllers
 or devices, depending on the case.
 
-.. doxygengroup:: devicetree-spi
+
 
 .. _devicetree-chosen-nodes:
 
@@ -309,13 +309,13 @@ The special ``/chosen`` node contains properties whose values describe
 system-wide settings. The :c:func:`DT_CHOSEN()` macro can be used to get a node
 identifier for a chosen node.
 
-.. doxygengroup:: devicetree-generic-chosen
+
    :project: Zephyr
 
 There are also conveniences for commonly used zephyr-specific properties of the
 ``/chosen`` node.
 
-.. doxygengroup:: devicetree-zephyr
+
    :project: Zephyr
 
 The following table documents some commonly used Zephyr-specific chosen nodes.

--- a/doc/reference/display/index.rst
+++ b/doc/reference/display/index.rst
@@ -1,6 +1,6 @@
 .. comment
    not documenting
-   .. doxygengroup:: display_interfaces
+   
 
 .. _display_api:
 
@@ -15,19 +15,19 @@ API Reference
 Generic Display Interface
 =========================
 
-.. doxygengroup:: display_interface
+
 
 Grove LCD Display
 =================
 
-.. doxygengroup:: grove_display
+
 
 BBC micro:bit Display
 =====================
 
-.. doxygengroup:: mb_display
+
 
 Monochrome Character Framebuffer
 ================================
 
-.. doxygengroup:: monochrome_character_framebuffer
+

--- a/doc/reference/drivers/index.rst
+++ b/doc/reference/drivers/index.rst
@@ -592,4 +592,4 @@ For these cases, DEVICE_MMIO_ROM directives may be omitted.
 API Reference
 **************
 
-.. doxygengroup:: device_model
+

--- a/doc/reference/edac/index.rst
+++ b/doc/reference/edac/index.rst
@@ -6,4 +6,4 @@ Error Detection And Correction (EDAC) API
 API Reference
 *************
 
-.. doxygengroup:: edac
+

--- a/doc/reference/file_system/index.rst
+++ b/doc/reference/file_system/index.rst
@@ -60,4 +60,4 @@ Here is the list of samples worth looking at:
 API Reference
 *************
 
-.. doxygengroup:: file_system_api
+

--- a/doc/reference/iterable_sections/index.rst
+++ b/doc/reference/iterable_sections/index.rst
@@ -65,4 +65,4 @@ The data can then be accessed using `STRUCT_SECTION_FOREACH()`.
 API Reference
 *************
 
-.. doxygengroup:: iterable_section_apis
+

--- a/doc/reference/kernel/data_passing/fifos.rst
+++ b/doc/reference/kernel/data_passing/fifos.rst
@@ -159,4 +159,4 @@ Related configuration options:
 API Reference
 *************
 
-.. doxygengroup:: fifo_apis
+

--- a/doc/reference/kernel/data_passing/lifos.rst
+++ b/doc/reference/kernel/data_passing/lifos.rst
@@ -147,4 +147,4 @@ Related configuration options:
 API Reference
 *************
 
-.. doxygengroup:: lifo_apis
+

--- a/doc/reference/kernel/data_passing/mailboxes.rst
+++ b/doc/reference/kernel/data_passing/mailboxes.rst
@@ -634,4 +634,4 @@ Related configuration options:
 API Reference
 *************
 
-.. doxygengroup:: mailbox_apis
+

--- a/doc/reference/kernel/data_passing/message_queues.rst
+++ b/doc/reference/kernel/data_passing/message_queues.rst
@@ -221,4 +221,4 @@ Related configuration options:
 API Reference
 *************
 
-.. doxygengroup:: msgq_apis
+

--- a/doc/reference/kernel/data_passing/pipes.rst
+++ b/doc/reference/kernel/data_passing/pipes.rst
@@ -176,4 +176,4 @@ Related configuration options:
 API Reference
 *************
 
-.. doxygengroup:: pipe_apis
+

--- a/doc/reference/kernel/data_passing/queues.rst
+++ b/doc/reference/kernel/data_passing/queues.rst
@@ -20,4 +20,4 @@ Related configuration options:
 API Reference
 *************
 
-.. doxygengroup:: queue_apis
+

--- a/doc/reference/kernel/data_passing/stacks.rst
+++ b/doc/reference/kernel/data_passing/stacks.rst
@@ -139,4 +139,4 @@ Related configuration options:
 API Reference
 *************
 
-.. doxygengroup:: stack_apis
+

--- a/doc/reference/kernel/memory/heap.rst
+++ b/doc/reference/kernel/memory/heap.rst
@@ -217,4 +217,4 @@ Related configuration options:
 API Reference
 =============
 
-.. doxygengroup:: heap_apis
+

--- a/doc/reference/kernel/memory/slabs.rst
+++ b/doc/reference/kernel/memory/slabs.rst
@@ -144,4 +144,4 @@ Related configuration options:
 API Reference
 *************
 
-.. doxygengroup:: mem_slab_apis
+

--- a/doc/reference/kernel/other/atomic.rst
+++ b/doc/reference/kernel/other/atomic.rst
@@ -116,4 +116,4 @@ API Reference
 .. important::
     All atomic services APIs can be used by both threads and ISRs.
 
-.. doxygengroup:: atomic_apis
+

--- a/doc/reference/kernel/other/cpu_idle.rst
+++ b/doc/reference/kernel/other/cpu_idle.rst
@@ -138,4 +138,4 @@ i.e. not doing any real work, like in this example below.
 API Reference
 *************
 
-.. doxygengroup:: cpu_idle_apis
+

--- a/doc/reference/kernel/other/fatal.rst
+++ b/doc/reference/kernel/other/fatal.rst
@@ -251,4 +251,4 @@ this function for additional details and constraints.
 API Reference
 *************
 
-.. doxygengroup:: fatal_apis
+

--- a/doc/reference/kernel/other/float.rst
+++ b/doc/reference/kernel/other/float.rst
@@ -351,4 +351,4 @@ support for SSEx instructions.
 API Reference
 *************
 
-.. doxygengroup:: float_apis
+

--- a/doc/reference/kernel/other/interrupts.rst
+++ b/doc/reference/kernel/other/interrupts.rst
@@ -479,4 +479,4 @@ also exist.
 API Reference
 *************
 
-.. doxygengroup:: isr_apis
+

--- a/doc/reference/kernel/other/polling.rst
+++ b/doc/reference/kernel/other/polling.rst
@@ -282,4 +282,4 @@ Related configuration options:
 API Reference
 *************
 
-.. doxygengroup:: poll_apis
+

--- a/doc/reference/kernel/other/version.rst
+++ b/doc/reference/kernel/other/version.rst
@@ -8,5 +8,5 @@ Kernel version handling and APIs related to kernel version being used.
 API Reference
 **************
 
-.. doxygengroup:: version_apis
+
    :content-only:

--- a/doc/reference/kernel/synchronization/condvar.rst
+++ b/doc/reference/kernel/synchronization/condvar.rst
@@ -135,4 +135,4 @@ Related configuration options:
 API Reference
 **************
 
-.. doxygengroup:: condvar_apis
+

--- a/doc/reference/kernel/synchronization/events.rst
+++ b/doc/reference/kernel/synchronization/events.rst
@@ -169,4 +169,4 @@ Related configuration options:
 API Reference
 **************
 
-.. doxygengroup:: event_apis
+

--- a/doc/reference/kernel/synchronization/mutexes.rst
+++ b/doc/reference/kernel/synchronization/mutexes.rst
@@ -164,7 +164,7 @@ Related configuration options:
 API Reference
 *************
 
-.. doxygengroup:: mutex_apis
+
 
 Futex API Reference
 *******************
@@ -175,7 +175,7 @@ to shared memory. k_futex are tracked as kernel objects and can live in
 user memory so that any access bypasses the kernel object permission
 management mechanism.
 
-.. doxygengroup:: futex_apis
+
 
 User Mode Mutex API Reference
 *****************************
@@ -184,4 +184,4 @@ sys_mutex behaves almost exactly like k_mutex, with the added advantage
 that a sys_mutex instance can reside in user memory. When user mode isn't
 enabled, sys_mutex behaves like k_mutex.
 
-.. doxygengroup:: user_mutex_apis
+

--- a/doc/reference/kernel/synchronization/semaphores.rst
+++ b/doc/reference/kernel/synchronization/semaphores.rst
@@ -135,7 +135,7 @@ Related configuration options:
 API Reference
 **************
 
-.. doxygengroup:: semaphore_apis
+
 
 User Mode Semaphore API Reference
 *********************************
@@ -144,4 +144,4 @@ The sys_sem exists in user memory working as counter semaphore for user mode
 thread when user mode enabled. When user mode isn't enabled, sys_sem behaves
 like k_sem.
 
-.. doxygengroup:: user_semaphore_apis
+

--- a/doc/reference/kernel/threads/index.rst
+++ b/doc/reference/kernel/threads/index.rst
@@ -577,6 +577,6 @@ Related configuration options:
 API Reference
 **************
 
-.. doxygengroup:: thread_apis
 
-.. doxygengroup:: thread_stack_api
+
+

--- a/doc/reference/kernel/threads/workqueue.rst
+++ b/doc/reference/kernel/threads/workqueue.rst
@@ -549,4 +549,4 @@ Related configuration options:
 API Reference
 **************
 
-.. doxygengroup:: workqueue_apis
+

--- a/doc/reference/kernel/timing/clocks.rst
+++ b/doc/reference/kernel/timing/clocks.rst
@@ -352,4 +352,4 @@ value, and should never be called iteratively in a loop.
 API Reference
 *************
 
-.. doxygengroup:: clock_apis
+

--- a/doc/reference/kernel/timing/timers.rst
+++ b/doc/reference/kernel/timing/timers.rst
@@ -242,4 +242,4 @@ Related configuration options:
 API Reference
 *************
 
-.. doxygengroup:: timer_apis
+

--- a/doc/reference/libc/index.rst
+++ b/doc/reference/libc/index.rst
@@ -55,7 +55,7 @@ aligned.
 Below is a list of the error number definitions. For the actual numeric values
 please refer to `errno.h`_.
 
-.. doxygengroup:: system_errno
+
 
 .. _`POSIX errno.h specification`: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/errno.h.html
 .. _`errno.h`: https://github.com/zephyrproject-rtos/zephyr/blob/main/lib/libc/minimal/include/errno.h

--- a/doc/reference/logging/index.rst
+++ b/doc/reference/logging/index.rst
@@ -798,24 +798,24 @@ API Reference
 Logger API
 ==========
 
-.. doxygengroup:: log_api
+
 
 Logger control
 ==============
 
-.. doxygengroup:: log_ctrl
+
 
 Log message
 ===========
 
-.. doxygengroup:: log_msg
+
 
 Logger backend interface
 ========================
 
-.. doxygengroup:: log_backend
+
 
 Logger output formatting
 ========================
 
-.. doxygengroup:: log_output
+

--- a/doc/reference/memory_management/demand_paging.rst
+++ b/doc/reference/memory_management/demand_paging.rst
@@ -178,17 +178,17 @@ function if so desired.
 API Reference
 *************
 
-.. doxygengroup:: mem-demand-paging
+
    :project: Zephyr
 
 Eviction Algorithm APIs
 =======================
 
-.. doxygengroup:: mem-demand-paging-eviction
+
    :project: Zephyr
 
 Backing Store APIs
 ==================
 
-.. doxygengroup:: mem-demand-paging-backing-store
+
    :project: Zephyr

--- a/doc/reference/memory_management/shared_multi_heap.rst
+++ b/doc/reference/memory_management/shared_multi_heap.rst
@@ -80,5 +80,5 @@ Currently only two memory attributes are supported: ``cacheable`` and
 1. Add the new ``enum`` for the attribute in the :c:enum:`smh_reg_attr`
 2. Add the corresponding attribute name in :file:`shared-multi-heap.yaml`
 
-.. doxygengroup:: shared_multi_heap
+
    :project: Zephyr

--- a/doc/reference/misc/formatted_output.rst
+++ b/doc/reference/misc/formatted_output.rst
@@ -129,4 +129,4 @@ formatting since address changes whenever package is copied.
 API Reference
 *************
 
-.. doxygengroup:: cbprintf_apis
+

--- a/doc/reference/misc/index.rst
+++ b/doc/reference/misc/index.rst
@@ -5,8 +5,8 @@ Miscellaneous APIs
 
 .. comment
    not documenting
-   .. doxygengroup:: checksum
-   .. doxygengroup:: structured_data
+   
+   
 
 Checksum APIs
 *************
@@ -14,7 +14,7 @@ Checksum APIs
 CRC
 =====
 
-.. doxygengroup:: crc
+
 
 Structured Data APIs
 ********************
@@ -22,7 +22,7 @@ Structured Data APIs
 JSON
 ====
 
-.. doxygengroup:: json
+
 
 JWT
 ===
@@ -33,4 +33,4 @@ claims securely between two parties.  Although JWT is fairly flexible,
 this API is limited to creating the simplistic tokens needed to
 authenticate with the Google Core IoT infrastructure.
 
-.. doxygengroup:: jwt
+

--- a/doc/reference/misc/notify.rst
+++ b/doc/reference/misc/notify.rst
@@ -34,4 +34,4 @@ API that uses :c:struct:`k_poll_signal` for notification.
 API Reference
 *************
 
-.. doxygengroup:: sys_notify_apis
+

--- a/doc/reference/misc/timeutil.rst
+++ b/doc/reference/misc/timeutil.rst
@@ -65,7 +65,7 @@ The inverse transformation is not standardized: APIs like ``mktime()`` expect
 information about time zones.  Zephyr provides this transformation with
 :c:func:`timeutil_timegm` and :c:func:`timeutil_timegm64`.
 
-.. doxygengroup:: timeutil_repr_apis
+
 
 .. _timeutil_sync:
 
@@ -104,7 +104,7 @@ process:
   instances stored in the state structure by
   :c:func:`timeutil_sync_estimate_skew`.
 
-.. doxygengroup:: timeutil_sync_apis
+
 
 .. _timeutil_concepts:
 

--- a/doc/reference/modbus/index.rst
+++ b/doc/reference/modbus/index.rst
@@ -37,6 +37,6 @@ gateway with Zephyr OS.
 API Reference
 *************
 
-.. doxygengroup:: modbus
+
 
 .. _`MODBUS Protocol Specifications`: https://www.modbus.org/specs.php

--- a/doc/reference/networking/can_api.rst
+++ b/doc/reference/networking/can_api.rst
@@ -375,4 +375,4 @@ We have two ready-to-build samples demonstrating use of the Zephyr CAN API
 API Reference
 *************
 
-.. doxygengroup:: can_interface
+

--- a/doc/reference/networking/can_isotp.rst
+++ b/doc/reference/networking/can_isotp.rst
@@ -44,4 +44,4 @@ many CF the sender is allowed to send, before he has to wait for another FC.
 API Reference
 *************
 
-.. doxygengroup:: can_isotp
+

--- a/doc/reference/networking/capture.rst
+++ b/doc/reference/networking/capture.rst
@@ -25,4 +25,4 @@ See :ref:`Network capture sample application <net-capture-sample>` and
 API Reference
 *************
 
-.. doxygengroup:: net_capture
+

--- a/doc/reference/networking/coap.rst
+++ b/doc/reference/networking/coap.rst
@@ -203,4 +203,4 @@ Sample output of ttcn3 tests looks like this.
 API Reference
 *************
 
-.. doxygengroup:: coap
+

--- a/doc/reference/networking/dhcpv4.rst
+++ b/doc/reference/networking/dhcpv4.rst
@@ -28,4 +28,4 @@ See :ref:`dhcpv4-client-sample` for details.
 API Reference
 *************
 
-.. doxygengroup:: dhcpv4
+

--- a/doc/reference/networking/dns_resolve.rst
+++ b/doc/reference/networking/dns_resolve.rst
@@ -40,4 +40,4 @@ See :ref:`DNS resolve sample application <dns-resolve-sample>` for details.
 API Reference
 *************
 
-.. doxygengroup:: dns_resolve
+

--- a/doc/reference/networking/ethernet.rst
+++ b/doc/reference/networking/ethernet.rst
@@ -42,6 +42,6 @@ currently supported Ethernet features.
 API Reference
 *************
 
-.. doxygengroup:: ethernet
 
-.. doxygengroup:: ethernet_mii
+
+

--- a/doc/reference/networking/ethernet_mgmt.rst
+++ b/doc/reference/networking/ethernet_mgmt.rst
@@ -30,4 +30,4 @@ when the corresponding status changes.
 API Reference
 *************
 
-.. doxygengroup:: ethernet_mgmt
+

--- a/doc/reference/networking/gptp.rst
+++ b/doc/reference/networking/gptp.rst
@@ -72,4 +72,4 @@ source distribution can be used for testing.
 API Reference
 *************
 
-.. doxygengroup:: gptp
+

--- a/doc/reference/networking/ieee802154.rst
+++ b/doc/reference/networking/ieee802154.rst
@@ -28,9 +28,9 @@ API Reference
 IEEE 802.15.4
 =============
 
-.. doxygengroup:: ieee802154
+
 
 IEEE 802.15.4 Management
 ========================
 
-.. doxygengroup:: ieee802154_mgmt
+

--- a/doc/reference/networking/ip_4_6.rst
+++ b/doc/reference/networking/ip_4_6.rst
@@ -15,4 +15,4 @@ Miscellaneous defines and helper functions for IP addresses and IP protocols.
 API Reference
 *************
 
-.. doxygengroup:: ip_4_6
+

--- a/doc/reference/networking/lldp.rst
+++ b/doc/reference/networking/lldp.rst
@@ -20,4 +20,4 @@ For more information, see this
 API Reference
 *************
 
-.. doxygengroup:: lldp
+

--- a/doc/reference/networking/lwm2m.rst
+++ b/doc/reference/networking/lwm2m.rst
@@ -415,7 +415,7 @@ For a more detailed LwM2M client sample see: :ref:`lwm2m-client-sample`.
 API Reference
 *************
 
-.. doxygengroup:: lwm2m_api
+
 
 .. _LwM2M:
    https://www.omaspecworks.org/what-is-oma-specworks/iot/lightweight-m2m-lwm2m/

--- a/doc/reference/networking/mqtt.rst
+++ b/doc/reference/networking/mqtt.rst
@@ -169,4 +169,4 @@ An example of how to use TLS with MQTT is also present in
 API Reference
 *************
 
-.. doxygengroup:: mqtt_socket
+

--- a/doc/reference/networking/net_buf.rst
+++ b/doc/reference/networking/net_buf.rst
@@ -136,4 +136,4 @@ automatically placed back to the free buffers pool.
 API Reference
 *************
 
-.. doxygengroup:: net_buf
+

--- a/doc/reference/networking/net_config.rst
+++ b/doc/reference/networking/net_config.rst
@@ -71,4 +71,4 @@ starts.
 API Reference
 *************
 
-.. doxygengroup:: net_config
+

--- a/doc/reference/networking/net_core.rst
+++ b/doc/reference/networking/net_core.rst
@@ -23,4 +23,4 @@ for sending and receiving network data.
 API Reference
 *************
 
-.. doxygengroup:: net_core
+

--- a/doc/reference/networking/net_hostname.rst
+++ b/doc/reference/networking/net_hostname.rst
@@ -35,4 +35,4 @@ that. The postfix can be set only once.
 API Reference
 *************
 
-.. doxygengroup:: net_hostname
+

--- a/doc/reference/networking/net_if.rst
+++ b/doc/reference/networking/net_if.rst
@@ -58,4 +58,4 @@ See :ref:`promiscuous_interface` API for more details.
 API Reference
 *************
 
-.. doxygengroup:: net_if
+

--- a/doc/reference/networking/net_l2.rst
+++ b/doc/reference/networking/net_l2.rst
@@ -153,4 +153,4 @@ Each IEEE 802.15.4 device driver, in the end, will need to call
 API Reference
 *************
 
-.. doxygengroup:: net_l2
+

--- a/doc/reference/networking/net_linkaddr.rst
+++ b/doc/reference/networking/net_linkaddr.rst
@@ -18,4 +18,4 @@ layer address length is 8 bytes.
 API Reference
 *************
 
-.. doxygengroup:: net_linkaddr
+

--- a/doc/reference/networking/net_mgmt.rst
+++ b/doc/reference/networking/net_mgmt.rst
@@ -170,4 +170,4 @@ for example :zephyr_file:`include/net/ieee802154_mgmt.h` would be the right plac
 API Reference
 *************
 
-.. doxygengroup:: net_mgmt
+

--- a/doc/reference/networking/net_offload.rst
+++ b/doc/reference/networking/net_offload.rst
@@ -21,7 +21,7 @@ HAL instead of the Zephyr network stack.
 API Reference
 *************
 
-.. doxygengroup:: net_offload
+
 
 .. _net_socket_offloading:
 

--- a/doc/reference/networking/net_pkt.rst
+++ b/doc/reference/networking/net_pkt.rst
@@ -359,4 +359,4 @@ contiguity at all, it just advances the cursor via
 API Reference
 *************
 
-.. doxygengroup:: net_pkt
+

--- a/doc/reference/networking/net_stats.rst
+++ b/doc/reference/networking/net_stats.rst
@@ -35,4 +35,4 @@ show statistics information with ``net stats`` command.
 API Reference
 *************
 
-.. doxygengroup:: net_stats
+

--- a/doc/reference/networking/net_timeout.rst
+++ b/doc/reference/networking/net_timeout.rst
@@ -58,4 +58,4 @@ remaining time.
 API Reference
 *************
 
-.. doxygengroup:: net_timeout
+

--- a/doc/reference/networking/promiscuous.rst
+++ b/doc/reference/networking/promiscuous.rst
@@ -76,4 +76,4 @@ See :ref:`net-promiscuous-mode-sample` for a more comprehensive example.
 API Reference
 *************
 
-.. doxygengroup:: promiscuous
+

--- a/doc/reference/networking/ptp_time.rst
+++ b/doc/reference/networking/ptp_time.rst
@@ -19,4 +19,4 @@ in :ref:`gptp_interface` implementation.
 API Reference
 *************
 
-.. doxygengroup:: ptp_time
+

--- a/doc/reference/networking/sntp.rst
+++ b/doc/reference/networking/sntp.rst
@@ -19,4 +19,4 @@ SNTP provides a way to synchronize clocks in computer networks.
 API Reference
 *************
 
-.. doxygengroup:: sntp
+

--- a/doc/reference/networking/sockets.rst
+++ b/doc/reference/networking/sockets.rst
@@ -141,7 +141,7 @@ Secure Sockets options
 
 Secure sockets offer the following options for socket management:
 
-.. doxygengroup:: secure_sockets_options
+
 
 API Reference
 *************
@@ -149,9 +149,9 @@ API Reference
 BSD Sockets
 ===========
 
-.. doxygengroup:: bsd_sockets
+
 
 TLS Credentials
 ===============
 
-.. doxygengroup:: tls_credentials
+

--- a/doc/reference/networking/trickle.rst
+++ b/doc/reference/networking/trickle.rst
@@ -21,4 +21,4 @@ robust, energy efficient, simple, and scalable manner.
 API Reference
 *************
 
-.. doxygengroup:: trickle
+

--- a/doc/reference/networking/vlan.rst
+++ b/doc/reference/networking/vlan.rst
@@ -51,4 +51,4 @@ See the `IEEE 802.1Q spec`_ for more information about ethernet VLANs.
 API Reference
 *************
 
-.. doxygengroup:: vlan_api
+

--- a/doc/reference/networking/websocket.rst
+++ b/doc/reference/networking/websocket.rst
@@ -74,4 +74,4 @@ When done, the Websocket transport socket must be closed.
 API Reference
 *************
 
-.. doxygengroup:: websocket
+

--- a/doc/reference/peripherals/adc.rst
+++ b/doc/reference/peripherals/adc.rst
@@ -10,4 +10,4 @@ Overview
 API Reference
 *************
 
-.. doxygengroup:: adc_interface
+

--- a/doc/reference/peripherals/clock_control.rst
+++ b/doc/reference/peripherals/clock_control.rst
@@ -19,4 +19,4 @@ Related configuration options:
 API Reference
 *************
 
-.. doxygengroup:: clock_control_interface
+

--- a/doc/reference/peripherals/counter.rst
+++ b/doc/reference/peripherals/counter.rst
@@ -10,4 +10,4 @@ Overview
 API Reference
 *************
 
-.. doxygengroup:: counter_interface
+

--- a/doc/reference/peripherals/dac.rst
+++ b/doc/reference/peripherals/dac.rst
@@ -18,4 +18,4 @@ Related configuration options:
 API Reference
 *************
 
-.. doxygengroup:: dac_interface
+

--- a/doc/reference/peripherals/dma.rst
+++ b/doc/reference/peripherals/dma.rst
@@ -10,4 +10,4 @@ Overview
 API Reference
 *************
 
-.. doxygengroup:: dma_interface
+

--- a/doc/reference/peripherals/ec_host_cmd_periph.rst
+++ b/doc/reference/peripherals/ec_host_cmd_periph.rst
@@ -10,4 +10,4 @@ Overview
 API Reference
 *************
 
-.. doxygengroup:: ec_host_cmd_periph_interface
+

--- a/doc/reference/peripherals/eeprom.rst
+++ b/doc/reference/peripherals/eeprom.rst
@@ -22,4 +22,4 @@ Related configuration options:
 API Reference
 *************
 
-.. doxygengroup:: eeprom_interface
+

--- a/doc/reference/peripherals/entropy.rst
+++ b/doc/reference/peripherals/entropy.rst
@@ -14,4 +14,4 @@ suitable to be used as random number generation functions.
 API Reference
 *************
 
-.. doxygengroup:: entropy_interface
+

--- a/doc/reference/peripherals/espi.rst
+++ b/doc/reference/peripherals/espi.rst
@@ -21,7 +21,7 @@ See `eSPI interface specification`_ for additional details.
 API Reference
 *************
 
-.. doxygengroup:: espi_interface
+
 
 .. _eSPI interface specification:
     https://www.intel.com/content/dam/support/us/en/documents/software/chipset-software/327432-004_espi_base_specification_rev1.0_cb.pdf

--- a/doc/reference/peripherals/flash.rst
+++ b/doc/reference/peripherals/flash.rst
@@ -21,8 +21,8 @@ API for retrieving the layout of pages).
 
 User API Reference
 ******************
-.. doxygengroup:: flash_interface
+
 
 Implementation interface API Reference
 **************************************
-.. doxygengroup:: flash_internal_interface
+

--- a/doc/reference/peripherals/gna.rst
+++ b/doc/reference/peripherals/gna.rst
@@ -19,4 +19,4 @@ Related configuration options:
 API Reference
 *************
 
-.. doxygengroup:: gna_interface
+

--- a/doc/reference/peripherals/gpio.rst
+++ b/doc/reference/peripherals/gpio.rst
@@ -17,4 +17,4 @@ Related configuration options:
 API Reference
 *************
 
-.. doxygengroup:: gpio_interface
+

--- a/doc/reference/peripherals/hwinfo.rst
+++ b/doc/reference/peripherals/hwinfo.rst
@@ -24,4 +24,4 @@ Related configuration options:
 API Reference
 *************
 
-.. doxygengroup:: hwinfo_interface
+

--- a/doc/reference/peripherals/i2c.rst
+++ b/doc/reference/peripherals/i2c.rst
@@ -62,7 +62,7 @@ Related configuration options:
 API Reference
 *************
 
-.. doxygengroup:: i2c_interface
+
 
 .. _i2c-specification:
    https://www.nxp.com/docs/en/user-guide/UM10204.pdf

--- a/doc/reference/peripherals/i2c_eeprom_slave.rst
+++ b/doc/reference/peripherals/i2c_eeprom_slave.rst
@@ -9,4 +9,4 @@ Overview
 API Reference
 **************
 
-.. doxygengroup:: i2c_eeprom_slave_api
+

--- a/doc/reference/peripherals/ipm.rst
+++ b/doc/reference/peripherals/ipm.rst
@@ -10,4 +10,4 @@ Overview
 API Reference
 *************
 
-.. doxygengroup:: ipm_interface
+

--- a/doc/reference/peripherals/kscan.rst
+++ b/doc/reference/peripherals/kscan.rst
@@ -28,4 +28,4 @@ Related configuration options:
 API Reference
 *************
 
-.. doxygengroup:: kscan_interface
+

--- a/doc/reference/peripherals/led.rst
+++ b/doc/reference/peripherals/led.rst
@@ -23,9 +23,9 @@ API Reference
 LED
 ===
 
-.. doxygengroup:: led_interface
+
 
 LED Strip
 =========
 
-.. doxygengroup:: led_strip_interface
+

--- a/doc/reference/peripherals/mdio.rst
+++ b/doc/reference/peripherals/mdio.rst
@@ -16,5 +16,5 @@ used by user firmware.
 API Reference
 *************
 
-.. doxygengroup:: mdio_interface
+
    :project: Zephyr

--- a/doc/reference/peripherals/peci.rst
+++ b/doc/reference/peripherals/peci.rst
@@ -24,4 +24,4 @@ Related configuration options:
 API Reference
 *************
 
-.. doxygengroup:: peci_interface
+

--- a/doc/reference/peripherals/pinmux.rst
+++ b/doc/reference/peripherals/pinmux.rst
@@ -10,4 +10,4 @@ Overview
 API Reference
 *************
 
-.. doxygengroup:: pinmux_interface
+

--- a/doc/reference/peripherals/ps2.rst
+++ b/doc/reference/peripherals/ps2.rst
@@ -24,4 +24,4 @@ Related configuration options:
 API Reference
 *************
 
-.. doxygengroup:: ps2_interface
+

--- a/doc/reference/peripherals/pwm.rst
+++ b/doc/reference/peripherals/pwm.rst
@@ -10,4 +10,4 @@ Overview
 API Reference
 *************
 
-.. doxygengroup:: pwm_interface
+

--- a/doc/reference/peripherals/regulators.rst
+++ b/doc/reference/peripherals/regulators.rst
@@ -40,4 +40,4 @@ driver for the corresponding node, e.g. a sensor.
 API Reference
 **************
 
-.. doxygengroup:: regulator_interface
+

--- a/doc/reference/peripherals/rtc.rst
+++ b/doc/reference/peripherals/rtc.rst
@@ -13,4 +13,4 @@ device-specific API for counters with real-time support.
 API Reference
 *************
 
-.. doxygengroup:: rtc_interface
+

--- a/doc/reference/peripherals/sensor.rst
+++ b/doc/reference/peripherals/sensor.rst
@@ -120,4 +120,4 @@ by the driver's configuration.
 API Reference
 **************
 
-.. doxygengroup:: sensor_interface
+

--- a/doc/reference/peripherals/spi.rst
+++ b/doc/reference/peripherals/spi.rst
@@ -10,4 +10,4 @@ Overview
 API Reference
 *************
 
-.. doxygengroup:: spi_interface
+

--- a/doc/reference/peripherals/uart.rst
+++ b/doc/reference/peripherals/uart.rst
@@ -9,4 +9,4 @@ Overview
 API Reference
 *************
 
-.. doxygengroup:: uart_interface
+

--- a/doc/reference/peripherals/video.rst
+++ b/doc/reference/peripherals/video.rst
@@ -53,6 +53,6 @@ Related configuration options:
 API Reference
 *************
 
-.. doxygengroup:: video_interface
 
-.. doxygengroup:: video_controls
+
+

--- a/doc/reference/peripherals/watchdog.rst
+++ b/doc/reference/peripherals/watchdog.rst
@@ -10,4 +10,4 @@ Overview
 API Reference
 *************
 
-.. doxygengroup:: watchdog_interface
+

--- a/doc/reference/pinctrl/index.rst
+++ b/doc/reference/pinctrl/index.rst
@@ -3,9 +3,9 @@
 Pin Control
 ###########
 
-.. doxygengroup:: pinctrl_interface
+
 
 Dynamic pin control
 *******************
 
-.. doxygengroup:: pinctrl_interface_dynamic
+

--- a/doc/reference/power_management/index.rst
+++ b/doc/reference/power_management/index.rst
@@ -93,19 +93,19 @@ The list of available power states is defined by :c:enum:`pm_state`. In
 general power states with higher indexes will offer greater power savings and
 have higher wake latencies. Following is a thorough list of available states:
 
-.. doxygenenumvalue:: PM_STATE_ACTIVE
 
-.. doxygenenumvalue:: PM_STATE_RUNTIME_IDLE
 
-.. doxygenenumvalue:: PM_STATE_SUSPEND_TO_IDLE
 
-.. doxygenenumvalue:: PM_STATE_STANDBY
 
-.. doxygenenumvalue:: PM_STATE_SUSPEND_TO_RAM
 
-.. doxygenenumvalue:: PM_STATE_SUSPEND_TO_DISK
 
-.. doxygenenumvalue:: PM_STATE_SOFT_OFF
+
+
+
+
+
+
+
 
 .. _pm_constraints:
 
@@ -119,11 +119,11 @@ tasks in background to avoid the system to go to a specific state where it would
 lose context. Constraints can be set, released and checked using the
 follow APIs:
 
-.. doxygenfunction:: pm_constraint_set
 
-.. doxygenfunction:: pm_constraint_release
 
-.. doxygenfunction:: pm_constraint_get
+
+
+
 
 Power Management Policies
 =========================
@@ -533,14 +533,14 @@ API Reference
 Power Management Hook Interface
 ===============================
 
-.. doxygengroup:: power_management_hook_interface
+
 
 System Power Management APIs
 ============================
 
-.. doxygengroup:: system_power_management_api
+
 
 Device Power Management APIs
 ============================
 
-.. doxygengroup:: device_power_management_api
+

--- a/doc/reference/random/index.rst
+++ b/doc/reference/random/index.rst
@@ -89,4 +89,4 @@ to make the initialization of the CTR-DRBG as unique as possible.
 API Reference
 *************
 
-.. doxygengroup:: random_api
+

--- a/doc/reference/resource_management/index.rst
+++ b/doc/reference/resource_management/index.rst
@@ -84,4 +84,4 @@ state.
    :c:type:`onoff_manager`, with only a small reduction in functionality
    (primarily no support for the monitor API).
 
-.. doxygengroup:: resource_mgmt_onoff_apis
+

--- a/doc/reference/settings/index.rst
+++ b/doc/reference/settings/index.rst
@@ -304,16 +304,15 @@ The Settings subsystem APIs are provided by ``settings.h``:
 
 API for general settings usage
 ==============================
-.. doxygengroup:: settings
+
 
 API for key-name processing
 ===========================
-.. doxygengroup:: settings_name_proc
+
 
 API for runtime settings manipulation
 =====================================
-.. doxygengroup:: settings_rt
+
 
 API of backend interface
 ========================
-..  doxygengroup:: settings_backend

--- a/doc/reference/shell/index.rst
+++ b/doc/reference/shell/index.rst
@@ -641,4 +641,4 @@ the shell will only print the subcommands registered for this command:
 API Reference
 *************
 
-.. doxygengroup:: shell_api
+

--- a/doc/reference/storage/disk/access.rst
+++ b/doc/reference/storage/disk/access.rst
@@ -62,7 +62,7 @@ Related configuration options:
 API Reference
 *************
 
-.. doxygengroup:: disk_access_interface
+
 
 Disk Driver Configuration Options
 *********************************
@@ -74,4 +74,4 @@ Related driver configuration options:
 Disk Driver Interface
 *********************
 
-.. doxygengroup:: disk_driver_interface
+

--- a/doc/reference/storage/fcb/fcb.rst
+++ b/doc/reference/storage/fcb/fcb.rst
@@ -71,8 +71,8 @@ The FCB subsystem APIs are provided by ``fcb.h``:
 
 Data structures
 ===============
-.. doxygengroup:: fcb_data_structures
+
 
 API functions
 =============
-.. doxygengroup:: fcb_api
+

--- a/doc/reference/storage/flash_map/flash_map.rst
+++ b/doc/reference/storage/flash_map/flash_map.rst
@@ -94,4 +94,4 @@ with a devicetree label like ``"image-0"``, use something like this:
 API Reference
 *************
 
-.. doxygengroup:: flash_area_api
+

--- a/doc/reference/storage/nvs/nvs.rst
+++ b/doc/reference/storage/nvs/nvs.rst
@@ -125,10 +125,10 @@ API Reference
 
 The NVS subsystem APIs are provided by ``nvs.h``:
 
-.. doxygengroup:: nvs_data_structures
 
-.. doxygengroup:: nvs_high_level_api
+
+
 
 .. comment
    not documenting
-   .. doxygengroup:: nvs
+   

--- a/doc/reference/storage/stream/stream_flash.rst
+++ b/doc/reference/storage/stream/stream_flash.rst
@@ -31,4 +31,4 @@ module. The API can be enabled using :kconfig:`CONFIG_STREAM_FLASH_PROGRESS`.
 API Reference
 *************
 
-.. doxygengroup:: stream_flash
+

--- a/doc/reference/task_wdt/index.rst
+++ b/doc/reference/task_wdt/index.rst
@@ -51,4 +51,4 @@ Related configuration options can be found under
 API Reference
 *************
 
-.. doxygengroup:: task_wdt_api
+

--- a/doc/reference/timing_functions/index.rst
+++ b/doc/reference/timing_functions/index.rst
@@ -77,4 +77,4 @@ This shows an example on how to use the timing functions:
 API documentation
 *****************
 
-.. doxygengroup:: timing_api
+

--- a/doc/reference/usb/hid.rst
+++ b/doc/reference/usb/hid.rst
@@ -38,12 +38,12 @@ Example of a HID Report Descriptor:
 HID items reference
 *******************
 
-.. doxygengroup:: usb_hid_items
+
 
 HID types reference
 *******************
 
-.. doxygengroup:: usb_hid_types
+
 
 HID Mouse and Keyboard report descriptors
 *****************************************
@@ -51,11 +51,11 @@ HID Mouse and Keyboard report descriptors
 The pre-defined Mouse and Keyboard report descriptors can be used by
 a HID device implementation or simply as examples.
 
-.. doxygengroup:: usb_hid_mk_report_desc
+
 
 HID Class Device API reference
 ******************************
 
 USB HID devices like mouse, keyboard, or any other specific device use this API.
 
-.. doxygengroup:: usb_hid_device_api
+

--- a/doc/reference/usb/udc.rst
+++ b/doc/reference/usb/udc.rst
@@ -14,4 +14,4 @@ instance at runtime.
 API reference
 *************
 
-.. doxygengroup:: _usb_device_controller_api
+

--- a/doc/reference/usb/uds.rst
+++ b/doc/reference/usb/uds.rst
@@ -145,4 +145,4 @@ High level API
   not have to implement endpoint callback and should set this callback to the
   generic usb_transfer_ep_callback.
 
-.. doxygengroup:: _usb_device_core_api
+

--- a/doc/reference/usermode/kernelobjects.rst
+++ b/doc/reference/usermode/kernelobjects.rst
@@ -269,4 +269,4 @@ Related configuration options:
 API Reference
 *************
 
-.. doxygengroup:: usermode_apis
+

--- a/doc/reference/usermode/memory_domain.rst
+++ b/doc/reference/usermode/memory_domain.rst
@@ -441,4 +441,4 @@ API Reference
 
 The following memory domain APIs are provided by :zephyr_file:`include/kernel.h`:
 
-.. doxygengroup:: mem_domain_apis
+

--- a/doc/reference/util/index.rst
+++ b/doc/reference/util/index.rst
@@ -6,4 +6,4 @@ Utilities
 This page contains reference documentation for ``<sys/util.h>``, which provides
 miscellaneous utility functions and macros.
 
-.. doxygengroup:: sys-util
+

--- a/doc/reference/virtualization/ivshmem.rst
+++ b/doc/reference/virtualization/ivshmem.rst
@@ -41,4 +41,4 @@ enabling :kconfig:`CONFIG_IVSHMEM_SHELL`.
 API Reference
 *************
 
-.. doxygengroup:: ivshmem
+

--- a/samples/drivers/clock_control_litex/README.rst
+++ b/samples/drivers/clock_control_litex/README.rst
@@ -40,9 +40,6 @@ Driver Usage
 
 The driver is interfaced with the :ref:`Clock Control API <clock_control_api>` function ``clock_control_on()`` and a LiteX driver specific structure:
 
-.. doxygenstruct:: litex_clk_setup
-   :project: Zephyr
-
 | To change clock parameter it is needed to cast a pointer to structure ``litex_clk_setup`` onto ``clock_control_subsys_t`` and use it with ``clock_control_on()``.
 | This code will try to set on ``clk0`` frequency 50MHz, 90 degrees of phase offset and 75% duty cycle.
 

--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -1,6 +1,5 @@
 # DOC: used to generate docs
 
-breathe~=4.23,!=4.29.0
 sphinx~=3.3
 sphinx_rtd_theme>=0.5.2,<1.0
 sphinx-tabs


### PR DESCRIPTION
This PR adds a new extension that converts Sphinx C domain roles (e.g., ``:c:func:`zephyr_api_call` ``) to links to Doxygen pages.

The end goal is to use Doxygen and not breathe to render APIs. There are a few reasons to do that:

- Doxygen is faster to render API docs (hard to measure “how faster” as not all API are part of Sphinx today).
- As of today, not all APIs are rendered using breathe, creating a sort of incomplete documentation
- Doxygen renders everything automatically, there is no need to explicitly enable groups
- Doxygen docs look & feel is now more in line with Zephyr docs

Sphinx should still be the central place for documentation: GSG, usage guidelines, examples, tutorials, etc. These are the type of docs where rich content is important and where Sphinx is clearly better than Doxygen.

Note: The extension is a proof of concept, so it may have issues (e.g., PDF not supported yet, does not support incremental builds properly, etc.).

Live PoC: https://teslabs.github.io/zephyr-doctest/