### PR TITLE
tests: build_all: Add device pm configuration for sensor drivers

### DIFF
--- a/drivers/sensor/bq274xx/bq274xx.c
+++ b/drivers/sensor/bq274xx/bq274xx.c
@@ -648,10 +648,6 @@ static int bq274xx_gauge_configure(const struct device *dev)
 		return -EIO;
 	}
 
-#ifdef CONFIG_PM_DEVICE
-	bq274xx->pm_state = PM_DEVICE_STATE_ACTIVE;
-#endif
-
 	return 0;
 }
 

--- a/drivers/sensor/ina219/ina219.c
+++ b/drivers/sensor/ina219/ina219.c
@@ -219,6 +219,8 @@ static int ina219_channel_get(const struct device *dev,
 #ifdef CONFIG_PM_DEVICE
 static int ina219_pm_ctrl(const struct device *dev, enum pm_device_action action)
 {
+	uint16_t reg_val;
+
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
 		return ina219_init(dev);

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -563,6 +563,7 @@ test_i2c_bq274xx: bq27xx@47 {
 	design-capacity = <1800>;
 	taper-current = <45>;
 	terminate-voltage = <3000>;
+	int-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_mpr: mpr@18 {

--- a/tests/drivers/build_all/sensor/testcase.yaml
+++ b/tests/drivers/build_all/sensor/testcase.yaml
@@ -7,3 +7,7 @@ tests:
     extra_args: OVERLAY_CONFIG=sensors_trigger_own.conf
   sensors.build:
     tags: sensors
+  sensors.build.pm:
+    extra_configs:
+      - CONFIG_PM=y
+      - CONFIG_PM_DEVICE=y


### PR DESCRIPTION
Adds another test configuration to ensure we build sensor drivers with
device power management enabled, in addition to the existing test that
builds sensor drivers with device power management disabled.

Signed-off-by: Maureen Helm <maureen.helm@intel.com>

Fixes #39721

@ceolin @gmarull I think we need to start doing this for other driver classes (SPI, I2C, etc) too.