### PR TITLE
net: openthread: Fix alarm timers reference calculation

### DIFF
--- a/subsys/net/lib/openthread/platform/alarm.c
+++ b/subsys/net/lib/openthread/platform/alarm.c
@@ -80,8 +80,7 @@ void otPlatAlarmMilliStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt)
 {
 	ARG_UNUSED(aInstance);
 
-	int64_t reftime = (int64_t)aT0 + (int64_t)aDt;
-	int64_t delta = -k_uptime_delta(&reftime);
+	int32_t delta = (int32_t)(aT0 + aDt - otPlatAlarmMilliGetNow());
 
 	if (delta > 0) {
 		k_timer_start(&ot_ms_timer, K_MSEC(delta), K_NO_WAIT);
@@ -101,9 +100,7 @@ void otPlatAlarmMicroStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt)
 {
 	ARG_UNUSED(aInstance);
 
-	uint64_t reftime = aT0 + aDt;
-	uint64_t curtime = k_ticks_to_us_floor64(k_uptime_ticks());
-	int64_t delta = reftime - curtime;
+	int32_t delta = (int32_t)(aT0 + aDt - otPlatAlarmMicroGetNow());
 
 	if (delta > 0) {
 		k_timer_start(&ot_us_timer, K_USEC(delta), K_NO_WAIT);


### PR DESCRIPTION
The OpenThread stack uses uint32_t to calculate expiry time for alarms, while comparing to zephyr's uint64_t uptime.

This commit fixes broken milliseconds alarms after ~49.7 days of uptime.

Fixes #39704