### PR TITLE
boards: frdm_k64f: Solve conflict between UART3 and enet

### DIFF
--- a/boards/arm/frdm_k64f/frdm_k64f.dts
+++ b/boards/arm/frdm_k64f/frdm_k64f.dts
@@ -241,7 +241,8 @@ zephyr_udc0: &usbotg {
 		     &RMII0_MDC_PTB1>;
 	pinctrl-names = "default";
 	ptp {
-		status = "okay";
+		/* Be aware that PTC16 and PTC17 are also used for uart3 */
+		status = "disabled";
 		pinctrl-0 = <&ENET0_1588_TMR0_PTC16 &ENET0_1588_TMR1_PTC17
 			     &ENET0_1588_TMR2_PTC18>;
 		pinctrl-names = "default";

--- a/boards/arm/frdm_k64f/pinmux.c
+++ b/boards/arm/frdm_k64f/pinmux.c
@@ -104,9 +104,11 @@ static int frdm_k64f_pinmux_init(const struct device *dev)
 
 	pinmux_pin_set(portb,  1, PORT_PCR_MUX(kPORT_MuxAlt4));
 
+#if DT_NODE_HAS_STATUS(DT_CHILD(DT_NODELABEL(enet),  ptp), okay)
 	pinmux_pin_set(portc, 16, PORT_PCR_MUX(kPORT_MuxAlt4));
 	pinmux_pin_set(portc, 17, PORT_PCR_MUX(kPORT_MuxAlt4));
 	pinmux_pin_set(portc, 18, PORT_PCR_MUX(kPORT_MuxAlt4));
+#endif
 #endif
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(flexcan0), okay) && CONFIG_CAN

--- a/samples/net/gptp/boards/frdm_k64f.overlay
+++ b/samples/net/gptp/boards/frdm_k64f.overlay
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2021 Esco Medical Aps
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&enet {
+
+	ptp {
+		status = "ok";
+	};
+};

--- a/tests/net/ptp/clock/boards/frdm_k64f.overlay
+++ b/tests/net/ptp/clock/boards/frdm_k64f.overlay
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2021 Esco Medical Aps
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&enet {
+
+	ptp {
+		status = "ok";
+	};
+};


### PR DESCRIPTION
Arduino compatible boards should have a working UART on pin 0 & 1.
On frdm_k64f this is handled by uart3

Unfortunately pinmuxing of uart3 was destroyed when enabling NETWORKING,
because the uart3 RX/TX pins was reconfigured for 1588 timers.

1588 timers are enabled by the enet child node, ptp which by some reason
is enabled by default.
1588 timers aren't needed in most cases when ethernet is being used,
so this fix ensures ptp is by default disabled. Likewise pinmuxing of
the 1588 timer functionality is now dependant of ptp being active


Signed-off-by: Kim Bøndergaard <kim.boendergaard@escoglobal.com>