### PR TITLE
drivers: uart stm32 flushing Rx register once the RXNE irq is enabled

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -886,7 +886,7 @@ static void uart_stm32_isr(const struct device *dev)
 			uart_stm32_dma_rx_flush(dev);
 		}
 	} else if (LL_USART_IsEnabledIT_TC(UartInstance) &&
-			  LL_USART_IsActiveFlag_TC(UartInstance)) {
+			LL_USART_IsActiveFlag_TC(UartInstance)) {
 
 		LL_USART_DisableIT_TC(UartInstance);
 		LL_USART_ClearFlag_TC(UartInstance);
@@ -896,6 +896,10 @@ static void uart_stm32_isr(const struct device *dev)
 #ifdef CONFIG_PM
 		uart_stm32_pm_constraint_release(dev);
 #endif
+	} else if (LL_USART_IsEnabledIT_RXNE(UartInstance) &&
+			LL_USART_IsActiveFlag_RXNE(UartInstance)) {
+		/* clear the RXNE by flushing the fifo, because Rx data was not read */
+		LL_USART_RequestRxDataFlush(UartInstance);
 	}
 
 	/* Clear errors */
@@ -977,7 +981,7 @@ static int uart_stm32_async_rx_disable(const struct device *dev)
 	data->rx_next_buffer = NULL;
 	data->rx_next_buffer_len = 0;
 
-	/*when async rx is disabled, enable interruptable instance of uart to function normally*/
+	/* When async rx is disabled, enable interruptable instance of uart to function normally*/
 	LL_USART_EnableIT_RXNE(UartInstance);
 
 	LOG_DBG("rx: disabled");


### PR DESCRIPTION
When the "Read data register not empty" irq occurs,
this commit is cleaning the RXNE flag by flushing the RX register
since the Receive Data Reg. (USART_RDR) has not be read previously
This could be the case when aborting a Rx for example.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/39703

Signed-off-by: Francois Ramu <francois.ramu@st.com>