### PR TITLE
Tracing: TRACING_SYSCALL status ignored fix

### DIFF
--- a/scripts/gen_syscalls.py
+++ b/scripts/gen_syscalls.py
@@ -136,6 +136,7 @@ uintptr_t %s(uintptr_t arg1, uintptr_t arg2, uintptr_t arg3,
 # enable/disable of syscall tracing. Used for returning functions
 # Note that the last argument to the exit macro is the return value.
 syscall_tracer_with_return_template = """
+#if (CONFIG_TRACING_SYSCALL == 1)
 #ifndef DISABLE_SYSCALL_TRACING
 {trace_diagnostic}
 #define {func_name}({argnames}) ({{ \
@@ -146,12 +147,14 @@ syscall_tracer_with_return_template = """
 	retval; \
 }})
 #endif
+#endif
 """
 
 # defines a macro wrapper which supercedes the syscall when used
 # and provides tracing enter/exit hooks while allowing per compilation unit
 # enable/disable of syscall tracing. Used for non-returning (void) functions
 syscall_tracer_void_template = """
+#if (CONFIG_TRACING_SYSCALL == 1)
 #ifndef DISABLE_SYSCALL_TRACING
 {trace_diagnostic}
 #define {func_name}({argnames}) do {{ \
@@ -159,6 +162,7 @@ syscall_tracer_void_template = """
 	{func_name}({argnames}); \
 	sys_port_trace_syscall_exit({syscall_id}, {func_name}{trace_argnames}); \
 }} while(false)
+#endif
 #endif
 """
 


### PR DESCRIPTION
Added check to respect the TRACING_SYSCALL tracing option
when generating syscall tracing overrides in gen_syscalls.py.

Signed-off-by: Torbjörn Leksell <torbjorn.leksell@percepio.com>