### PR TITLE
runners: jlink: exit with error in case of a failure

### DIFF
--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -251,7 +251,10 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                 self.run_client(client_cmd)
 
     def flash(self, **kwargs):
-        lines = ['r'] # Reset and halt the target
+        lines = [
+            'ExitOnError 1',  # Treat any command-error as fatal
+            'r',  # Reset and halt the target
+        ]
 
         if self.erase:
             lines.append('erase') # Erase all flash sectors


### PR DESCRIPTION
Add "ExitOnError 1" argument that treats any command-error as fatal thus in the case of a programming error the "west flash" command will return the correct error code instead of the default 0. It fixes the false positive return codes when e.g we call west flash command without a connected programmer or with the disconnected board.

That's updated version of https://github.com/zephyrproject-rtos/zephyr/pull/39656 with solution suggested by @ratho787 

Signed-off-by: Bartosz Bilas <b.bilas@grinn-global.com>