### PR TITLE
Mark LE Audio services and clients as experiemental

### DIFF
--- a/subsys/bluetooth/audio/Kconfig.aics
+++ b/subsys/bluetooth/audio/Kconfig.aics
@@ -11,7 +11,7 @@ if BT_AUDIO
 ##################### Audio Input Control Service #####################
 
 config BT_AICS_MAX_INSTANCE_COUNT
-	int "Audio Input Control Service max instance count"
+	int "Audio Input Control Service max instance count [EXPERIMENTAL]"
 	default 0
 	range 0 15
 	help
@@ -21,6 +21,7 @@ config BT_AICS_MAX_INSTANCE_COUNT
 config BT_AICS
 	bool # hidden
 	default y if BT_AICS_MAX_INSTANCE_COUNT > 0
+	select EXPERIMENTAL
 	help
 	  This hidden option enables support for Audio Input Control Service.
 
@@ -46,7 +47,7 @@ endif # BT_AICS
 ##################### Audio Input Control Service Client #####################
 
 config BT_AICS_CLIENT_MAX_INSTANCE_COUNT
-	int "Audio Input Control Service client max instance count"
+	int "Audio Input Control Service client max instance count [EXPERIMENTAL]"
 	default 0
 	range 0 15
 	help
@@ -56,6 +57,7 @@ config BT_AICS_CLIENT_MAX_INSTANCE_COUNT
 config BT_AICS_CLIENT
 	bool # hidden
 	default y if BT_AICS_CLIENT_MAX_INSTANCE_COUNT > 0
+	select EXPERIMENTAL
 	help
 	  This hidden option enables support for Audio Input Control Service.
 

--- a/subsys/bluetooth/audio/Kconfig.mics
+++ b/subsys/bluetooth/audio/Kconfig.mics
@@ -11,8 +11,9 @@ if BT_AUDIO
 ##################### Microphone Input Control Service #####################
 
 config BT_MICS
-	bool "Microphone Input Control Service Support"
+	bool "Microphone Input Control Service Support [EXPERIMENTAL]"
 	default n
+	select EXPERIMENTAL
 	help
 	  This option enables support for Microphone Input Control Service.
 
@@ -47,9 +48,10 @@ endif # BT_MICS
 ##################### Microphone Control Profile Client #####################
 
 config BT_MICS_CLIENT
-	bool "Microphone Control Profile Support"
+	bool "Microphone Control Profile Support [EXPERIMENTAL]"
 	select BT_GATT_CLIENT
 	select BT_GATT_AUTO_DISCOVER_CCC
+	select EXPERIMENTAL
 	help
 	  This option enables support for Microphone Control Profile.
 

--- a/subsys/bluetooth/audio/Kconfig.vcs
+++ b/subsys/bluetooth/audio/Kconfig.vcs
@@ -11,8 +11,9 @@ if BT_AUDIO
 ##################### Volume Control Service #####################
 
 config BT_VCS
-	bool "Volume Control Service Support"
+	bool "Volume Control Service Support [EXPERIMENTAL]"
 	default n
+	select EXPERIMENTAL
 	help
 	  This option enables support for Volume Control Service.
 
@@ -61,9 +62,10 @@ endif # BT_VCS
 ##################### Volume Control Profile Client #####################
 
 config BT_VCS_CLIENT
-	bool "Volume Control Profile Support"
+	bool "Volume Control Profile Support [EXPERIMENTAL]"
 	select BT_GATT_CLIENT
 	select BT_GATT_AUTO_DISCOVER_CCC
+	select EXPERIMENTAL
 	default n
 	help
 	  This option enables support for Volume Control Profile.

--- a/subsys/bluetooth/audio/Kconfig.vocs
+++ b/subsys/bluetooth/audio/Kconfig.vocs
@@ -10,7 +10,7 @@ if BT_AUDIO
 ##################### Volume Offset Control Service #####################
 
 config BT_VOCS_MAX_INSTANCE_COUNT
-	int "Volume Offset Control Service max instance count"
+	int "Volume Offset Control Service max instance count [EXPERIMENTAL]"
 	default 0
 	range 0 15
 	help
@@ -20,6 +20,7 @@ config BT_VOCS_MAX_INSTANCE_COUNT
 config BT_VOCS
 	bool # hidden
 	default y if BT_VOCS_MAX_INSTANCE_COUNT > 0
+	select EXPERIMENTAL
 	help
 	  This hidden option enables support for Volume Control Service.
 
@@ -46,7 +47,7 @@ endif # BT_VOCS
 ##################### Volume Offset Control Service Client #####################
 
 config BT_VOCS_CLIENT_MAX_INSTANCE_COUNT
-	int "Volume Offset Control Service client max instance count"
+	int "Volume Offset Control Service client max instance count [EXPERIMENTAL]"
 	default 0
 	range 0 15
 	help
@@ -56,6 +57,7 @@ config BT_VOCS_CLIENT_MAX_INSTANCE_COUNT
 config BT_VOCS_CLIENT
 	bool # hidden
 	default y if BT_VOCS_CLIENT_MAX_INSTANCE_COUNT > 0
+	select EXPERIMENTAL
 	help
 	  This hidden option enables support for Volume Offset Control Service.
 


### PR DESCRIPTION
Adds missing marking of [EXPERIMENTAL] for AICS, MICS, VCS and VOCS. 