### PR TITLE
doc: extensions: vcs_link: only run for HTML builder

### DIFF
--- a/doc/_extensions/zephyr/vcs_link.py
+++ b/doc/_extensions/zephyr/vcs_link.py
@@ -67,6 +67,9 @@ def vcs_link_get_url(app: Sphinx, pagename: str) -> Optional[str]:
 
 
 def add_jinja_filter(app: Sphinx):
+    if app.builder.name != "html":
+        return
+
     app.builder.templates.environment.filters["vcs_link_get_url"] = partial(
         vcs_link_get_url, app
     )


### PR DESCRIPTION
The vcs_link should only run for the HTML builder, since it is the only
target of this extension. The other builders do not have the templates
instance, making them fail.