### PR TITLE
drivers: dac: Refactor drivers to use shared init priority

### DIFF
--- a/boards/arm/bl5340_dvk/Kconfig.defconfig
+++ b/boards/arm/bl5340_dvk/Kconfig.defconfig
@@ -20,6 +20,16 @@ if BOARD_BL5340_DVK_CPUAPP
 config NORDIC_QSPI_NOR
 	default y
 
+if DAC
+
+config DAC_MCP4725
+	default y
+
+config I2C
+	default y
+
+endif # DAC
+
 endif # BOARD_BL5340_DVK_CPUAPP
 
 # By default, if we build for a Non-Secure version of the board,

--- a/boards/arm/bl5340_dvk/Kconfig.defconfig
+++ b/boards/arm/bl5340_dvk/Kconfig.defconfig
@@ -25,6 +25,9 @@ if DAC
 config DAC_MCP4725
 	default y
 
+config DAC_INIT_PRIORITY
+	default 80
+
 config I2C
 	default y
 

--- a/boards/arm/bl652_dvk/Kconfig.defconfig
+++ b/boards/arm/bl652_dvk/Kconfig.defconfig
@@ -16,6 +16,9 @@ if DAC
 config DAC_MCP4725
 	default y
 
+config DAC_INIT_PRIORITY
+	default 80
+
 config I2C
 	default y
 

--- a/boards/arm/bl652_dvk/Kconfig.defconfig
+++ b/boards/arm/bl652_dvk/Kconfig.defconfig
@@ -11,4 +11,14 @@ config BOARD
 config BT_CTLR
 	default BT
 
+if DAC
+
+config DAC_MCP4725
+	default y
+
+config I2C
+	default y
+
+endif # DAC
+
 endif # BOARD_BL652_DVK

--- a/boards/arm/bl652_dvk/bl652_dvk.dts
+++ b/boards/arm/bl652_dvk/bl652_dvk.dts
@@ -82,6 +82,15 @@
 	status = "okay";
 	sda-pin = <26>;
 	scl-pin = <27>;
+
+	dac0: mcp4725@60 {
+		/* MCP4725 not populated at factory */
+		compatible = "microchip,mcp4725";
+		reg = <0x60>;
+		label = "MCP4725";
+		#io-channel-cells = <1>;
+		status = "disabled";
+	};
 };
 
 &pwm0 {

--- a/boards/arm/bl653_dvk/Kconfig.defconfig
+++ b/boards/arm/bl653_dvk/Kconfig.defconfig
@@ -15,4 +15,14 @@ config IEEE802154_NRF5
 config BT_CTLR
 	default BT
 
+if DAC
+
+config DAC_MCP4725
+	default y
+
+config I2C
+	default y
+
+endif # DAC
+
 endif # BOARD_BL653_DVK

--- a/boards/arm/bl653_dvk/Kconfig.defconfig
+++ b/boards/arm/bl653_dvk/Kconfig.defconfig
@@ -20,6 +20,9 @@ if DAC
 config DAC_MCP4725
 	default y
 
+config DAC_INIT_PRIORITY
+	default 80
+
 config I2C
 	default y
 

--- a/boards/arm/bl653_dvk/bl653_dvk.dts
+++ b/boards/arm/bl653_dvk/bl653_dvk.dts
@@ -106,6 +106,15 @@
 	status = "okay";
 	sda-pin = <26>;
 	scl-pin = <27>;
+
+	dac0: mcp4725@60 {
+		/* MCP4725 not populated at factory */
+		compatible = "microchip,mcp4725";
+		reg = <0x60>;
+		label = "MCP4725";
+		#io-channel-cells = <1>;
+		status = "disabled";
+	};
 };
 
 &pwm0 {

--- a/boards/arm/bl654_dvk/Kconfig.defconfig
+++ b/boards/arm/bl654_dvk/Kconfig.defconfig
@@ -11,4 +11,14 @@ config BOARD
 config BT_CTLR
 	default BT
 
+if DAC
+
+config DAC_MCP4725
+	default y
+
+config I2C
+	default y
+
+endif # DAC
+
 endif # BOARD_BL654_DVK

--- a/boards/arm/bl654_dvk/Kconfig.defconfig
+++ b/boards/arm/bl654_dvk/Kconfig.defconfig
@@ -16,6 +16,9 @@ if DAC
 config DAC_MCP4725
 	default y
 
+config DAC_INIT_PRIORITY
+	default 80
+
 config I2C
 	default y
 

--- a/boards/arm/bl654_dvk/bl654_dvk.dts
+++ b/boards/arm/bl654_dvk/bl654_dvk.dts
@@ -106,6 +106,15 @@
 	status = "okay";
 	sda-pin = <26>;
 	scl-pin = <27>;
+
+	dac0: mcp4725@60 {
+		/* MCP4725 not populated at factory */
+		compatible = "microchip,mcp4725";
+		reg = <0x60>;
+		label = "MCP4725";
+		#io-channel-cells = <1>;
+		status = "disabled";
+	};
 };
 
 &pwm0 {

--- a/boards/shields/dac80508_evm/Kconfig.defconfig
+++ b/boards/shields/dac80508_evm/Kconfig.defconfig
@@ -11,6 +11,9 @@ config SPI
 config DAC_DACX0508
 	default y
 
+config DAC_INIT_PRIORITY
+	default 80
+
 endif # DAC
 
 endif # SHIELD_DAC80508_EVM

--- a/drivers/dac/Kconfig
+++ b/drivers/dac/Kconfig
@@ -24,6 +24,12 @@ config DAC_SHELL
 	help
 	  Enable DAC related shell commands.
 
+config DAC_INIT_PRIORITY
+	int "DAC init priority"
+	default KERNEL_INIT_PRIORITY_DEVICE
+	help
+	  DAC driver device initialization priority.
+
 source "drivers/dac/Kconfig.mcux"
 
 source "drivers/dac/Kconfig.stm32"

--- a/drivers/dac/Kconfig.dacx0508
+++ b/drivers/dac/Kconfig.dacx0508
@@ -9,13 +9,3 @@ config DAC_DACX0508
 	depends on SPI
 	help
 	  Enable the driver for the TI DACx0508.
-
-if DAC_DACX0508
-
-config DAC_DACX0508_INIT_PRIORITY
-	int "Init priority"
-	default 80
-	help
-	  DACx0508 DAC device driver initialization priority.
-
-endif # DAC_DACX0508

--- a/drivers/dac/Kconfig.dacx3608
+++ b/drivers/dac/Kconfig.dacx3608
@@ -9,10 +9,3 @@ config DAC_DACX3608
 	depends on I2C
 	help
 	  Enable the driver for the TI DACX3608.
-
-config DAC_DACX3608_INIT_PRIORITY
-	int "Init priority"
-	depends on DAC_DACX3608
-	default 80
-	help
-	  DACX3608 DAC device driver initialization priority.

--- a/drivers/dac/Kconfig.mcp4725
+++ b/drivers/dac/Kconfig.mcp4725
@@ -9,13 +9,3 @@ config DAC_MCP4725
 	depends on I2C
 	help
 	  Enable the driver for the Microchip MCP4725.
-
-if DAC_MCP4725
-
-config DAC_MCP4725_INIT_PRIORITY
-	int "Init priority"
-	default 80
-	help
-	  MCP4725 DAC device driver initialization priority.
-
-endif # DAC_MCP4725

--- a/drivers/dac/dac_dacx0508.c
+++ b/drivers/dac/dac_dacx0508.c
@@ -385,7 +385,7 @@ static const struct dac_driver_api dacx0508_driver_api = {
 			    &dacx0508_init, NULL, \
 			    &dac##t##_data_##n, \
 			    &dac##t##_config_##n, POST_KERNEL, \
-			    CONFIG_DAC_DACX0508_INIT_PRIORITY, \
+			    CONFIG_DAC_INIT_PRIORITY, \
 			    &dacx0508_driver_api)
 
 /*

--- a/drivers/dac/dac_dacx3608.c
+++ b/drivers/dac/dac_dacx3608.c
@@ -258,7 +258,7 @@ static const struct dac_driver_api dacx3608_driver_api = {
 				&dacx3608_init, NULL, \
 				&dac##t##_data_##n, \
 				&dac##t##_config_##n, POST_KERNEL, \
-				CONFIG_DAC_DACX3608_INIT_PRIORITY, \
+				CONFIG_DAC_INIT_PRIORITY, \
 				&dacx3608_driver_api)
 
 /*

--- a/drivers/dac/dac_mcp4725.c
+++ b/drivers/dac/dac_mcp4725.c
@@ -142,7 +142,7 @@ static const struct dac_driver_api mcp4725_driver_api = {
 			    NULL,					\
 			    NULL,					\
 			    &mcp4725_config_##index, POST_KERNEL,	\
-			    CONFIG_DAC_MCP4725_INIT_PRIORITY,		\
+			    CONFIG_DAC_INIT_PRIORITY,			\
 			    &mcp4725_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(INST_DT_MCP4725);

--- a/drivers/dac/dac_mcux_dac.c
+++ b/drivers/dac/dac_mcux_dac.c
@@ -108,7 +108,7 @@ static const struct dac_driver_api mcux_dac_driver_api = {
 	DEVICE_DT_INST_DEFINE(n, mcux_dac_init, NULL,			\
 			&mcux_dac_data_##n,				\
 			&mcux_dac_config_##n,				\
-			POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,\
+			POST_KERNEL, CONFIG_DAC_INIT_PRIORITY,		\
 			&mcux_dac_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(MCUX_DAC_INIT)

--- a/drivers/dac/dac_mcux_dac32.c
+++ b/drivers/dac/dac_mcux_dac32.c
@@ -114,7 +114,7 @@ static const struct dac_driver_api mcux_dac32_driver_api = {
 	DEVICE_DT_INST_DEFINE(n, mcux_dac32_init, NULL,			\
 			&mcux_dac32_data_##n,				\
 			&mcux_dac32_config_##n,				\
-			POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,\
+			POST_KERNEL, CONFIG_DAC_INIT_PRIORITY,		\
 			&mcux_dac32_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(MCUX_DAC32_INIT)

--- a/drivers/dac/dac_sam.c
+++ b/drivers/dac/dac_sam.c
@@ -173,5 +173,5 @@ static const struct dac_sam_dev_cfg dacc_sam_config = {
 static struct dac_sam_dev_data dacc_sam_data;
 
 DEVICE_DT_INST_DEFINE(0, dac_sam_init, NULL, &dacc_sam_data, &dacc_sam_config,
-		      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		      POST_KERNEL, CONFIG_DAC_INIT_PRIORITY,
 		      &dac_sam_driver_api);

--- a/drivers/dac/dac_sam0.c
+++ b/drivers/dac/dac_sam0.c
@@ -108,7 +108,7 @@ static const struct dac_driver_api api_sam0_driver_api = {
 									       \
 	DEVICE_DT_INST_DEFINE(n, &dac_sam0_init, NULL, NULL,		       \
 			    &dac_sam0_cfg_##n, POST_KERNEL,		       \
-			    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	       \
+			    CONFIG_DAC_INIT_PRIORITY,			       \
 			    &api_sam0_driver_api)
 
 DT_INST_FOREACH_STATUS_OKAY(SAM0_DAC_INIT);

--- a/drivers/dac/dac_stm32.c
+++ b/drivers/dac/dac_stm32.c
@@ -168,7 +168,7 @@ static struct dac_stm32_data dac_stm32_data_##index = {			\
 DEVICE_DT_INST_DEFINE(index, &dac_stm32_init, NULL,			\
 		    &dac_stm32_data_##index,				\
 		    &dac_stm32_cfg_##index, POST_KERNEL,		\
-		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,		\
+		    CONFIG_DAC_INIT_PRIORITY,				\
 		    &api_stm32_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(STM32_DAC_INIT)

--- a/samples/drivers/dac/boards/bl5340_dvk_cpuapp.conf
+++ b/samples/drivers/dac/boards/bl5340_dvk_cpuapp.conf
@@ -1,7 +1,0 @@
-#
-# Copyright (c) 2021 Laird Connectivity
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-CONFIG_I2C=y
-CONFIG_DAC_MCP4725=y

--- a/samples/drivers/dac/boards/bl652_dvk.conf
+++ b/samples/drivers/dac/boards/bl652_dvk.conf
@@ -1,6 +1,0 @@
-#
-# Copyright (c) 2021 Laird Connectivity
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-CONFIG_DAC_MCP4725=y

--- a/samples/drivers/dac/boards/bl652_dvk.overlay
+++ b/samples/drivers/dac/boards/bl652_dvk.overlay
@@ -4,11 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&i2c0 {
-	dac0: mcp4725@60 {
-		compatible = "microchip,mcp4725";
-		reg = <0x60>;
-		label = "MCP4725";
-		#io-channel-cells = <1>;
-	};
+&dac0 {
+	status = "okay";
 };

--- a/samples/drivers/dac/boards/bl653_dvk.conf
+++ b/samples/drivers/dac/boards/bl653_dvk.conf
@@ -1,6 +1,0 @@
-#
-# Copyright (c) 2021 Laird Connectivity
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-CONFIG_DAC_MCP4725=y

--- a/samples/drivers/dac/boards/bl653_dvk.overlay
+++ b/samples/drivers/dac/boards/bl653_dvk.overlay
@@ -4,11 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&i2c0 {
-	dac0: mcp4725@60 {
-		compatible = "microchip,mcp4725";
-		reg = <0x60>;
-		label = "MCP4725";
-		#io-channel-cells = <1>;
-	};
+&dac0 {
+	status = "okay";
 };

--- a/samples/drivers/dac/boards/bl654_dvk.conf
+++ b/samples/drivers/dac/boards/bl654_dvk.conf
@@ -1,6 +1,0 @@
-#
-# Copyright (c) 2021 Laird Connectivity
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-CONFIG_DAC_MCP4725=y

--- a/samples/drivers/dac/boards/bl654_dvk.overlay
+++ b/samples/drivers/dac/boards/bl654_dvk.overlay
@@ -4,11 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&i2c0 {
-	dac0: mcp4725@60 {
-		compatible = "microchip,mcp4725";
-		reg = <0x60>;
-		label = "MCP4725";
-		#io-channel-cells = <1>;
-	};
+&dac0 {
+	status = "okay";
 };

--- a/tests/drivers/dac/dac_api/boards/bl5340_dvk_cpuapp.conf
+++ b/tests/drivers/dac/dac_api/boards/bl5340_dvk_cpuapp.conf
@@ -1,7 +1,0 @@
-#
-# Copyright (c) 2021 Laird Connectivity
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-CONFIG_I2C=y
-CONFIG_DAC_MCP4725=y

--- a/tests/drivers/dac/dac_api/boards/bl652_dvk.conf
+++ b/tests/drivers/dac/dac_api/boards/bl652_dvk.conf
@@ -1,7 +1,0 @@
-#
-# Copyright (c) 2021 Laird Connectivity
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-CONFIG_I2C=y
-CONFIG_DAC_MCP4725=y

--- a/tests/drivers/dac/dac_api/boards/bl652_dvk.overlay
+++ b/tests/drivers/dac/dac_api/boards/bl652_dvk.overlay
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&i2c0 {
-	dac0: mcp4725@60 {
-		/* MCP4725 not populated at factory */
-		compatible = "microchip,mcp4725";
-		reg = <0x60>;
-		label = "MCP4725";
-		#io-channel-cells = <1>;
-	};
+&dac0 {
+	status = "okay";
 };

--- a/tests/drivers/dac/dac_api/boards/bl653_dvk.conf
+++ b/tests/drivers/dac/dac_api/boards/bl653_dvk.conf
@@ -1,7 +1,0 @@
-#
-# Copyright (c) 2021 Laird Connectivity
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-CONFIG_I2C=y
-CONFIG_DAC_MCP4725=y

--- a/tests/drivers/dac/dac_api/boards/bl653_dvk.overlay
+++ b/tests/drivers/dac/dac_api/boards/bl653_dvk.overlay
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&i2c0 {
-	dac0: mcp4725@60 {
-		/* MCP4725 not populated at factory */
-		compatible = "microchip,mcp4725";
-		reg = <0x60>;
-		label = "MCP4725";
-		#io-channel-cells = <1>;
-	};
+&dac0 {
+	status = "okay";
 };

--- a/tests/drivers/dac/dac_api/boards/bl654_dvk.conf
+++ b/tests/drivers/dac/dac_api/boards/bl654_dvk.conf
@@ -1,7 +1,0 @@
-#
-# Copyright (c) 2021 Laird Connectivity
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-CONFIG_I2C=y
-CONFIG_DAC_MCP4725=y

--- a/tests/drivers/dac/dac_api/boards/bl654_dvk.overlay
+++ b/tests/drivers/dac/dac_api/boards/bl654_dvk.overlay
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&i2c0 {
-	dac0: mcp4725@60 {
-		/* MCP4725 not populated at factory */
-		compatible = "microchip,mcp4725";
-		reg = <0x60>;
-		label = "MCP4725";
-		#io-channel-cells = <1>;
-	};
+&dac0 {
+	status = "okay";
 };

--- a/tests/drivers/dac/dac_loopback/boards/bl5340_dvk_cpuapp.conf
+++ b/tests/drivers/dac/dac_loopback/boards/bl5340_dvk_cpuapp.conf
@@ -1,7 +1,0 @@
-#
-# Copyright (c) 2021 Laird Connectivity
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-CONFIG_I2C=y
-CONFIG_DAC_MCP4725=y

--- a/tests/drivers/dac/dac_loopback/boards/bl652_dvk.conf
+++ b/tests/drivers/dac/dac_loopback/boards/bl652_dvk.conf
@@ -1,7 +1,0 @@
-#
-# Copyright (c) 2021 Laird Connectivity
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-CONFIG_I2C=y
-CONFIG_DAC_MCP4725=y

--- a/tests/drivers/dac/dac_loopback/boards/bl652_dvk.overlay
+++ b/tests/drivers/dac/dac_loopback/boards/bl652_dvk.overlay
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&i2c0 {
-	dac0: mcp4725@60 {
-		/* MCP4725 not populated at factory */
-		compatible = "microchip,mcp4725";
-		reg = <0x60>;
-		label = "MCP4725";
-		#io-channel-cells = <1>;
-	};
+&dac0 {
+	status = "okay";
 };

--- a/tests/drivers/dac/dac_loopback/boards/bl653_dvk.conf
+++ b/tests/drivers/dac/dac_loopback/boards/bl653_dvk.conf
@@ -1,7 +1,0 @@
-#
-# Copyright (c) 2021 Laird Connectivity
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-CONFIG_I2C=y
-CONFIG_DAC_MCP4725=y

--- a/tests/drivers/dac/dac_loopback/boards/bl653_dvk.overlay
+++ b/tests/drivers/dac/dac_loopback/boards/bl653_dvk.overlay
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&i2c0 {
-	dac0: mcp4725@60 {
-		/* MCP4725 not populated at factory */
-		compatible = "microchip,mcp4725";
-		reg = <0x60>;
-		label = "MCP4725";
-		#io-channel-cells = <1>;
-	};
+&dac0 {
+	status = "okay";
 };

--- a/tests/drivers/dac/dac_loopback/boards/bl654_dvk.conf
+++ b/tests/drivers/dac/dac_loopback/boards/bl654_dvk.conf
@@ -1,7 +1,0 @@
-#
-# Copyright (c) 2021 Laird Connectivity
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-CONFIG_I2C=y
-CONFIG_DAC_MCP4725=y

--- a/tests/drivers/dac/dac_loopback/boards/bl654_dvk.overlay
+++ b/tests/drivers/dac/dac_loopback/boards/bl654_dvk.overlay
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&i2c0 {
-	mcp4725@60 {
-		/* MCP4725 not populated at factory */
-		compatible = "microchip,mcp4725";
-		reg = <0x60>;
-		label = "MCP4725";
-		#io-channel-cells = <1>;
-	};
+&dac0 {
+	status = "okay";
 };


### PR DESCRIPTION
Refactors all of the DAC drivers to use a shared driver class
initialization priority configuration, CONFIG_DAC_INIT_PRIORITY, to
allow configuring DAC drivers separately from other devices. This is
similar to other driver classes like I2C and SPI.

The default is set to CONFIG_KERNEL_INIT_PRIORITY_DEVICE to preserve the
existing default initialization priority for most drivers. The
exceptions are dacx0508, dacx3608, and mcp4725 drivers which have
dependencies on SPI or I2C drivers and must therefore initialize later
than the default device priority.

Signed-off-by: Maureen Helm <maureen.helm@intel.com>