### PR TITLE
settings: Add name to backend choice in Kconfig

### DIFF
--- a/subsys/settings/Kconfig
+++ b/subsys/settings/Kconfig
@@ -33,7 +33,7 @@ config SETTINGS_ENCODE_LEN
 	depends on SETTINGS
 	bool
 
-choice
+choice SETTINGS_BACKEND
 	prompt "Storage back-end"
 	default SETTINGS_NVS if NVS
 	default SETTINGS_FCB if FCB


### PR DESCRIPTION
Unless a choice is named, its default value
cannot be changed in another Kconfig file.

Signed-off-by: Pavel Hübner <pavel.hubner@hardwario.com>