### PR TITLE
MAINTAINERS: add self as x86 collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1420,6 +1420,7 @@ Intel Platforms (X86):
     collaborators:
         - jhedberg
         - aasthagr
+        - laurenmurphyx64
     files:
         - boards/x86/
         - soc/x86/
@@ -1688,6 +1689,7 @@ x86 arch:
         - ceolin
         - enjiamai
         - aasthagr
+        - laurenmurphyx64
     files:
         - arch/x86/
         - include/arch/x86/


### PR DESCRIPTION
Adds myself as a collaborator for x86 architecture and platforms.

Signed-off-by: Lauren Murphy <lauren.murphy@intel.com>