### PR TITLE
MAINTAINERS: add section for state machine library

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1349,6 +1349,20 @@ SPARC arch:
     labels:
         - "area: SPARC"
 
+State machine framework:
+    status: maintained
+    maintainers:
+        - sambhurst
+    collaborators:
+        - keith-zephyr
+    files:
+        - doc/guides/smf/
+        - include/smf.h
+        - lib/smf/
+        - tests/lib/smf/
+    labels:
+        - "area: State Machine Framework"
+
 Synopsys Platforms:
     status: maintained
     maintainers:


### PR DESCRIPTION
Add "State machine framework" section for the smf library.

Signed-off-by: Keith Short <keithshort@google.com>