### PR TITLE
drivers/uart: stm32: fix a bug during transmission

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -594,11 +594,13 @@ static void uart_stm32_irq_tx_enable(const struct device *dev)
 {
 	USART_TypeDef *UartInstance = UART_STRUCT(dev);
 
-	LL_USART_EnableIT_TC(UartInstance);
-
 #ifdef CONFIG_PM
+	struct uart_stm32_data *data = DEV_DATA(dev);
+
+	data->tx_poll_stream_on = false;
 	uart_stm32_pm_constraint_set(dev);
 #endif
+	LL_USART_EnableIT_TC(UartInstance);
 }
 
 static void uart_stm32_irq_tx_disable(const struct device *dev)


### PR DESCRIPTION
If a transmission is made with poll_out and immediately after an other transmission is made with interrupt api the transmission is locked. We fix this behavior by clearing the tx_poll_stream_on flag during the irq_tx_enable function

I made this branch to illustrate this behavior: https://github.com/jdascenzio/zephyr/commits/shell_bug
I triggered the bug in the shell_module sample

The Zephy banner is send on console with the usart poll api and then the shell is locked when it wants to send characters with the usart interrupt api.

I'm also surprised that there is no lock mechanism in usart stm32 driver. I think that some conflicts could append between poll api (used by console driver) and interrupt api.