### PR TITLE
drivers: sensor: Const sensor trigger data in trigger handler

### DIFF
--- a/include/drivers/sensor.h
+++ b/include/drivers/sensor.h
@@ -333,7 +333,7 @@ enum sensor_attribute {
  * @param trigger The trigger
  */
 typedef void (*sensor_trigger_handler_t)(const struct device *dev,
-					 struct sensor_trigger *trigger);
+					 const struct sensor_trigger *trigger);
 
 /**
  * @typedef sensor_attr_set_t
@@ -474,7 +474,7 @@ static inline int z_impl_sensor_attr_get(const struct device *dev,
  * @return 0 if successful, negative errno code if failure.
  */
 static inline int sensor_trigger_set(const struct device *dev,
-				     struct sensor_trigger *trig,
+				     const struct sensor_trigger *trig,
 				     sensor_trigger_handler_t handler)
 {
 	const struct sensor_driver_api *api =

--- a/samples/boards/96b_argonkey/sensors/src/main.c
+++ b/samples/boards/96b_argonkey/sensors/src/main.c
@@ -28,7 +28,7 @@ static inline float out_ev(struct sensor_value *val)
 static int lsm6dsl_trig_cnt;
 #ifdef CONFIG_LSM6DSL_TRIGGER
 static void lsm6dsl_trigger_handler(const struct device *dev,
-				    struct sensor_trigger *trig)
+				    const struct sensor_trigger *trig)
 {
 #ifdef ARGONKEY_TEST_LOG
 	char out_str[64];

--- a/samples/boards/reel_board/mesh_badge/src/periphs.c
+++ b/samples/boards/reel_board/mesh_badge/src/periphs.c
@@ -104,7 +104,7 @@ static void motion_timeout(struct k_work *work)
 }
 
 static void motion_handler(const struct device *dev,
-			   struct sensor_trigger *trig)
+			   const struct sensor_trigger *trig)
 {
 	int err;
 

--- a/samples/boards/sensortile_box/src/main.c
+++ b/samples/boards/sensortile_box/src/main.c
@@ -24,7 +24,7 @@
 static int lps22hh_trig_cnt;
 
 static void lps22hh_trigger_handler(const struct device *dev,
-				    struct sensor_trigger *trig)
+				    const struct sensor_trigger *trig)
 {
 	sensor_sample_fetch_chan(dev, SENSOR_CHAN_PRESS);
 	lps22hh_trig_cnt++;
@@ -35,7 +35,7 @@ static void lps22hh_trigger_handler(const struct device *dev,
 static int lis2dw12_trig_cnt;
 
 static void lis2dw12_trigger_handler(const struct device *dev,
-				     struct sensor_trigger *trig)
+				     const struct sensor_trigger *trig)
 {
 	sensor_sample_fetch_chan(dev, SENSOR_CHAN_ACCEL_XYZ);
 	lis2dw12_trig_cnt++;
@@ -48,21 +48,21 @@ static int lsm6dso_gyr_trig_cnt;
 static int lsm6dso_temp_trig_cnt;
 
 static void lsm6dso_acc_trig_handler(const struct device *dev,
-				     struct sensor_trigger *trig)
+				     const struct sensor_trigger *trig)
 {
 	sensor_sample_fetch_chan(dev, SENSOR_CHAN_ACCEL_XYZ);
 	lsm6dso_acc_trig_cnt++;
 }
 
 static void lsm6dso_gyr_trig_handler(const struct device *dev,
-				     struct sensor_trigger *trig)
+				     const struct sensor_trigger *trig)
 {
 	sensor_sample_fetch_chan(dev, SENSOR_CHAN_GYRO_XYZ);
 	lsm6dso_gyr_trig_cnt++;
 }
 
 static void lsm6dso_temp_trig_handler(const struct device *dev,
-				      struct sensor_trigger *trig)
+				      const struct sensor_trigger *trig)
 {
 	sensor_sample_fetch_chan(dev, SENSOR_CHAN_DIE_TEMP);
 	lsm6dso_temp_trig_cnt++;
@@ -73,7 +73,7 @@ static void lsm6dso_temp_trig_handler(const struct device *dev,
 static int stts751_trig_cnt;
 
 static void stts751_trigger_handler(const struct device *dev,
-				       struct sensor_trigger *trig)
+				    const struct sensor_trigger *trig)
 {
 	stts751_trig_cnt++;
 }
@@ -83,7 +83,7 @@ static void stts751_trigger_handler(const struct device *dev,
 static int iis3dhhc_trig_cnt;
 
 static void iis3dhhc_trigger_handler(const struct device *dev,
-				     struct sensor_trigger *trig)
+				     const struct sensor_trigger *trig)
 {
 	sensor_sample_fetch_chan(dev, SENSOR_CHAN_ACCEL_XYZ);
 	iis3dhhc_trig_cnt++;

--- a/samples/sensor/adt7420/src/main.c
+++ b/samples/sensor/adt7420/src/main.c
@@ -40,7 +40,7 @@ static const char *now_str(void)
 	return buf;
 }
 static void trigger_handler(const struct device *dev,
-			    struct sensor_trigger *trigger)
+			    const struct sensor_trigger *trigger)
 {
 	k_sem_give(&sem);
 }

--- a/samples/sensor/adxl362/src/main.c
+++ b/samples/sensor/adxl362/src/main.c
@@ -12,7 +12,7 @@
 K_SEM_DEFINE(sem, 0, 1);
 
 static void trigger_handler(const struct device *dev,
-			    struct sensor_trigger *trig)
+			    const struct sensor_trigger *trig)
 {
 	switch (trig->type) {
 	case SENSOR_TRIG_DATA_READY:

--- a/samples/sensor/adxl372/src/main.c
+++ b/samples/sensor/adxl372/src/main.c
@@ -33,7 +33,7 @@ static double sqrt(double value)
 K_SEM_DEFINE(sem, 0, 1);
 
 static void trigger_handler(const struct device *dev,
-			    struct sensor_trigger *trigger)
+			    const struct sensor_trigger *trigger)
 {
 	ARG_UNUSED(trigger);
 

--- a/samples/sensor/amg88xx/src/main.c
+++ b/samples/sensor/amg88xx/src/main.c
@@ -15,7 +15,7 @@ static struct sensor_value temp_value[64];
 K_SEM_DEFINE(sem, 0, 1);
 
 static void trigger_handler(const struct device *dev,
-			    struct sensor_trigger *trigger)
+			    const struct sensor_trigger *trigger)
 {
 	ARG_UNUSED(dev);
 	ARG_UNUSED(trigger);

--- a/samples/sensor/apds9960/src/main.c
+++ b/samples/sensor/apds9960/src/main.c
@@ -15,7 +15,7 @@
 K_SEM_DEFINE(sem, 0, 1);
 
 static void trigger_handler(const struct device *dev,
-			    struct sensor_trigger *trigger)
+			    const struct sensor_trigger *trigger)
 {
 	ARG_UNUSED(dev);
 	ARG_UNUSED(trigger);

--- a/samples/sensor/bmg160/src/main.c
+++ b/samples/sensor/bmg160/src/main.c
@@ -70,7 +70,7 @@ static void test_polling_mode(const struct device *bmg160)
 }
 
 static void trigger_handler(const struct device *bmg160,
-			    struct sensor_trigger *trigger)
+			    const struct sensor_trigger *trigger)
 {
 	if (trigger->type != SENSOR_TRIG_DATA_READY &&
 	    trigger->type != SENSOR_TRIG_DELTA) {

--- a/samples/sensor/ccs811/src/main.c
+++ b/samples/sensor/ccs811/src/main.c
@@ -79,7 +79,7 @@ static int do_fetch(const struct device *dev)
 #ifndef CONFIG_CCS811_TRIGGER_NONE
 
 static void trigger_handler(const struct device *dev,
-			    struct sensor_trigger *trig)
+			    const struct sensor_trigger *trig)
 {
 	int rc = do_fetch(dev);
 

--- a/samples/sensor/fdc2x1x/src/main.c
+++ b/samples/sensor/fdc2x1x/src/main.c
@@ -17,7 +17,7 @@ K_SEM_DEFINE(sem, 0, 1);
 
 #ifdef CONFIG_FDC2X1X_TRIGGER
 static void trigger_handler(const struct device *dev,
-			    struct sensor_trigger *trigger)
+			    const struct sensor_trigger *trigger)
 {
 	switch (trigger->type) {
 	case SENSOR_TRIG_DATA_READY:

--- a/samples/sensor/fxas21002/src/main.c
+++ b/samples/sensor/fxas21002/src/main.c
@@ -11,7 +11,7 @@
 K_SEM_DEFINE(sem, 0, 1);	/* starts off "not available" */
 
 static void trigger_handler(const struct device *dev,
-			    struct sensor_trigger *trigger)
+			    const struct sensor_trigger *trigger)
 {
 	k_sem_give(&sem);
 }

--- a/samples/sensor/fxos8700-hid/src/main.c
+++ b/samples/sensor/fxos8700-hid/src/main.c
@@ -160,7 +160,7 @@ static bool read_accel(const struct device *dev)
 }
 
 static void trigger_handler(const struct device *dev,
-			    struct sensor_trigger *tr)
+			    const struct sensor_trigger *tr)
 {
 	ARG_UNUSED(tr);
 

--- a/samples/sensor/fxos8700/src/main.c
+++ b/samples/sensor/fxos8700/src/main.c
@@ -13,7 +13,7 @@ K_SEM_DEFINE(sem, 0, 1);	/* starts off "not available" */
 
 #if !defined(CONFIG_FXOS8700_TRIGGER_NONE)
 static void trigger_handler(const struct device *dev,
-			    struct sensor_trigger *trigger)
+			    const struct sensor_trigger *trigger)
 {
 	ARG_UNUSED(trigger);
 

--- a/samples/sensor/hts221/src/main.c
+++ b/samples/sensor/hts221/src/main.c
@@ -41,7 +41,7 @@ static void process_sample(const struct device *dev)
 }
 
 static void hts221_handler(const struct device *dev,
-			   struct sensor_trigger *trig)
+			   const struct sensor_trigger *trig)
 {
 	process_sample(dev);
 }

--- a/samples/sensor/icm42605/src/main.c
+++ b/samples/sensor/icm42605/src/main.c
@@ -73,7 +73,7 @@ static struct sensor_trigger tap_trigger;
 static struct sensor_trigger double_tap_trigger;
 
 static void handle_icm42605_drdy(const struct device *dev,
-				 struct sensor_trigger *trig)
+				 const struct sensor_trigger *trig)
 {
 	int rc = process_icm42605(dev);
 
@@ -85,13 +85,13 @@ static void handle_icm42605_drdy(const struct device *dev,
 }
 
 static void handle_icm42605_tap(const struct device *dev,
-				 struct sensor_trigger *trig)
+				const struct sensor_trigger *trig)
 {
 	printf("Tap Detected!\n");
 }
 
 static void handle_icm42605_double_tap(const struct device *dev,
-				 struct sensor_trigger *trig)
+				       const struct sensor_trigger *trig)
 {
 	printf("Double Tap detected!\n");
 }

--- a/samples/sensor/isl29035/src/main.c
+++ b/samples/sensor/isl29035/src/main.c
@@ -16,7 +16,7 @@ static volatile bool alerted;
 struct k_sem sem;
 
 static void trigger_handler(const struct device *dev,
-			    struct sensor_trigger *trig)
+			    const struct sensor_trigger *trig)
 {
 #ifdef CONFIG_ISL29035_TRIGGER
 	alerted = !alerted;

--- a/samples/sensor/lis2dh/src/main.c
+++ b/samples/sensor/lis2dh/src/main.c
@@ -42,7 +42,7 @@ static void fetch_and_display(const struct device *sensor)
 
 #ifdef CONFIG_LIS2DH_TRIGGER
 static void trigger_handler(const struct device *dev,
-			    struct sensor_trigger *trig)
+			    const struct sensor_trigger *trig)
 {
 	fetch_and_display(dev);
 }

--- a/samples/sensor/lps22hh/src/main.c
+++ b/samples/sensor/lps22hh/src/main.c
@@ -43,7 +43,7 @@ static void process_sample(const struct device *dev)
 }
 
 static void lps22hh_handler(const struct device *dev,
-			    struct sensor_trigger *trig)
+			    const struct sensor_trigger *trig)
 {
 	process_sample(dev);
 }

--- a/samples/sensor/lsm6dsl/src/main.c
+++ b/samples/sensor/lsm6dsl/src/main.c
@@ -29,7 +29,7 @@ static struct sensor_value press_out, temp_out;
 
 #ifdef CONFIG_LSM6DSL_TRIGGER
 static void lsm6dsl_trigger_handler(const struct device *dev,
-				    struct sensor_trigger *trig)
+				    const struct sensor_trigger *trig)
 {
 	static struct sensor_value accel_x, accel_y, accel_z;
 	static struct sensor_value gyro_x, gyro_y, gyro_z;

--- a/samples/sensor/lsm6dso/src/main.c
+++ b/samples/sensor/lsm6dso/src/main.c
@@ -79,7 +79,7 @@ static int set_sampling_freq(const struct device *dev)
 
 #ifdef CONFIG_LSM6DSO_TRIGGER
 static void trigger_handler(const struct device *dev,
-			    struct sensor_trigger *trig)
+			    const struct sensor_trigger *trig)
 {
 	fetch_and_display(dev);
 }

--- a/samples/sensor/mcp9808/src/main.c
+++ b/samples/sensor/mcp9808/src/main.c
@@ -80,7 +80,7 @@ static inline int set_window_ucel(const struct device *dev,
 }
 
 static void trigger_handler(const struct device *dev,
-			    struct sensor_trigger *trig)
+			    const struct sensor_trigger *trig)
 {
 	struct sensor_value temp;
 	static size_t cnt;

--- a/samples/sensor/mcux_acmp/src/main.c
+++ b/samples/sensor/mcux_acmp/src/main.c
@@ -64,7 +64,7 @@ static void acmp_input_handler(bool above_threshold)
 }
 
 static void acmp_trigger_handler(const struct device *dev,
-				 struct sensor_trigger *trigger)
+				 const struct sensor_trigger *trigger)
 {
 	ARG_UNUSED(dev);
 

--- a/samples/sensor/mpu6050/src/main.c
+++ b/samples/sensor/mpu6050/src/main.c
@@ -72,7 +72,7 @@ static int process_mpu6050(const struct device *dev)
 static struct sensor_trigger trigger;
 
 static void handle_mpu6050_drdy(const struct device *dev,
-				struct sensor_trigger *trig)
+				const struct sensor_trigger *trig)
 {
 	int rc = process_mpu6050(dev);
 

--- a/samples/sensor/sht3xd/src/main.c
+++ b/samples/sensor/sht3xd/src/main.c
@@ -16,7 +16,7 @@
 static volatile bool alerted;
 
 static void trigger_handler(const struct device *dev,
-			    struct sensor_trigger *trig)
+			    const struct sensor_trigger *trig)
 {
 	alerted = !alerted;
 }

--- a/samples/sensor/sm351lt/src/main.c
+++ b/samples/sensor/sm351lt/src/main.c
@@ -33,7 +33,7 @@ static void fetch_and_display(const struct device *sensor)
 
 #ifdef CONFIG_SM351LT_TRIGGER
 static void trigger_handler(const struct device *dev,
-			    struct sensor_trigger *trig)
+			    const struct sensor_trigger *trig)
 {
 	fetch_and_display(dev);
 }

--- a/samples/sensor/sx9500/src/main.c
+++ b/samples/sensor/sx9500/src/main.c
@@ -12,7 +12,7 @@
 #ifdef CONFIG_SX9500_TRIGGER
 
 static void sensor_trigger_handler(const struct device *dev,
-				   struct sensor_trigger *trig)
+				   const struct sensor_trigger *trig)
 {
 	struct sensor_value prox_value;
 	int ret;

--- a/samples/sensor/vcnl4040/src/main.c
+++ b/samples/sensor/vcnl4040/src/main.c
@@ -64,7 +64,7 @@ static void test_polling_mode(const struct device *dev)
 
 #if defined(CONFIG_VCNL4040_TRIGGER)
 static void trigger_handler(const struct device *dev,
-			    struct sensor_trigger *trig)
+			    const struct sensor_trigger *trig)
 {
 	switch (trig->type) {
 	case SENSOR_TRIG_THRESHOLD:

--- a/samples/sensor/wsen_itds/src/main.c
+++ b/samples/sensor/wsen_itds/src/main.c
@@ -67,7 +67,7 @@ static void test_polling_mode(const struct device *itds)
 
 #if defined(CONFIG_ITDS_TRIGGER)
 static void trigger_handler(const struct device *itds,
-			    struct sensor_trigger *trigger)
+			    const struct sensor_trigger *trigger)
 {
 	switch (trigger->type) {
 	case SENSOR_TRIG_DATA_READY:

--- a/samples/shields/x_nucleo_iks01a1/src/main.c
+++ b/samples/shields/x_nucleo_iks01a1/src/main.c
@@ -14,7 +14,7 @@
 static int lis3mdl_trig_cnt;
 
 static void lis3mdl_trigger_handler(const struct device *dev,
-				    struct sensor_trigger *trig)
+				    const struct sensor_trigger *trig)
 {
 	sensor_sample_fetch_chan(dev, trig->chan);
 	lis3mdl_trig_cnt++;

--- a/samples/shields/x_nucleo_iks01a2/sensorhub/src/main.c
+++ b/samples/shields/x_nucleo_iks01a2/sensorhub/src/main.c
@@ -14,7 +14,7 @@
 static int lsm6dsl_trig_cnt;
 
 static void lsm6dsl_trigger_handler(const struct device *dev,
-				     struct sensor_trigger *trig)
+				    const struct sensor_trigger *trig)
 {
 	sensor_sample_fetch_chan(dev, SENSOR_CHAN_ALL);
 	lsm6dsl_trig_cnt++;

--- a/samples/shields/x_nucleo_iks01a2/standard/src/main.c
+++ b/samples/shields/x_nucleo_iks01a2/standard/src/main.c
@@ -14,7 +14,7 @@
 static int lsm6dsl_trig_cnt;
 
 static void lsm6dsl_trigger_handler(const struct device *dev,
-				     struct sensor_trigger *trig)
+				    const struct sensor_trigger *trig)
 {
 	sensor_sample_fetch_chan(dev, SENSOR_CHAN_ALL);
 	lsm6dsl_trig_cnt++;

--- a/samples/shields/x_nucleo_iks01a3/sensorhub/src/main.c
+++ b/samples/shields/x_nucleo_iks01a3/sensorhub/src/main.c
@@ -14,7 +14,7 @@
 static int lis2dw12_trig_cnt;
 
 static void lis2dw12_trigger_handler(const struct device *dev,
-				     struct sensor_trigger *trig)
+				     const struct sensor_trigger *trig)
 {
 	sensor_sample_fetch_chan(dev, SENSOR_CHAN_ACCEL_XYZ);
 	lis2dw12_trig_cnt++;
@@ -27,21 +27,21 @@ static int lsm6dso_gyr_trig_cnt;
 static int lsm6dso_temp_trig_cnt;
 
 static void lsm6dso_acc_trig_handler(const struct device *dev,
-				     struct sensor_trigger *trig)
+				     const struct sensor_trigger *trig)
 {
 	sensor_sample_fetch_chan(dev, SENSOR_CHAN_ACCEL_XYZ);
 	lsm6dso_acc_trig_cnt++;
 }
 
 static void lsm6dso_gyr_trig_handler(const struct device *dev,
-				     struct sensor_trigger *trig)
+				     const struct sensor_trigger *trig)
 {
 	sensor_sample_fetch_chan(dev, SENSOR_CHAN_GYRO_XYZ);
 	lsm6dso_gyr_trig_cnt++;
 }
 
 static void lsm6dso_temp_trig_handler(const struct device *dev,
-				      struct sensor_trigger *trig)
+				      const struct sensor_trigger *trig)
 {
 	sensor_sample_fetch_chan(dev, SENSOR_CHAN_DIE_TEMP);
 	lsm6dso_temp_trig_cnt++;

--- a/samples/shields/x_nucleo_iks01a3/standard/src/main.c
+++ b/samples/shields/x_nucleo_iks01a3/standard/src/main.c
@@ -14,7 +14,7 @@
 static int lis2mdl_trig_cnt;
 
 static void lis2mdl_trigger_handler(const struct device *dev,
-				    struct sensor_trigger *trig)
+				    const struct sensor_trigger *trig)
 {
 	sensor_sample_fetch_chan(dev, SENSOR_CHAN_ALL);
 	lis2mdl_trig_cnt++;
@@ -25,7 +25,7 @@ static void lis2mdl_trigger_handler(const struct device *dev,
 static int lps22hh_trig_cnt;
 
 static void lps22hh_trigger_handler(const struct device *dev,
-				    struct sensor_trigger *trig)
+				    const struct sensor_trigger *trig)
 {
 	sensor_sample_fetch_chan(dev, SENSOR_CHAN_PRESS);
 	lps22hh_trig_cnt++;
@@ -36,7 +36,7 @@ static void lps22hh_trigger_handler(const struct device *dev,
 static int stts751_trig_cnt;
 
 static void stts751_trigger_handler(const struct device *dev,
-				       struct sensor_trigger *trig)
+				    const struct sensor_trigger *trig)
 {
 	stts751_trig_cnt++;
 }
@@ -46,7 +46,7 @@ static void stts751_trigger_handler(const struct device *dev,
 static int lis2dw12_trig_cnt;
 
 static void lis2dw12_trigger_handler(const struct device *dev,
-				     struct sensor_trigger *trig)
+				     const struct sensor_trigger *trig)
 {
 	sensor_sample_fetch_chan(dev, SENSOR_CHAN_ACCEL_XYZ);
 	lis2dw12_trig_cnt++;
@@ -59,21 +59,21 @@ static int lsm6dso_gyr_trig_cnt;
 static int lsm6dso_temp_trig_cnt;
 
 static void lsm6dso_acc_trig_handler(const struct device *dev,
-				     struct sensor_trigger *trig)
+				     const struct sensor_trigger *trig)
 {
 	sensor_sample_fetch_chan(dev, SENSOR_CHAN_ACCEL_XYZ);
 	lsm6dso_acc_trig_cnt++;
 }
 
 static void lsm6dso_gyr_trig_handler(const struct device *dev,
-				     struct sensor_trigger *trig)
+				     const struct sensor_trigger *trig)
 {
 	sensor_sample_fetch_chan(dev, SENSOR_CHAN_GYRO_XYZ);
 	lsm6dso_gyr_trig_cnt++;
 }
 
 static void lsm6dso_temp_trig_handler(const struct device *dev,
-				      struct sensor_trigger *trig)
+				      const struct sensor_trigger *trig)
 {
 	sensor_sample_fetch_chan(dev, SENSOR_CHAN_DIE_TEMP);
 	lsm6dso_temp_trig_cnt++;

--- a/samples/shields/x_nucleo_iks02a1/sensorhub/src/main.c
+++ b/samples/shields/x_nucleo_iks02a1/sensorhub/src/main.c
@@ -14,7 +14,7 @@
 static int iis2dlpc_trig_cnt;
 
 static void iis2dlpc_trigger_handler(const struct device *dev,
-				     struct sensor_trigger *trig)
+				     const struct sensor_trigger *trig)
 {
 	sensor_sample_fetch_chan(dev, SENSOR_CHAN_ACCEL_XYZ);
 	iis2dlpc_trig_cnt++;
@@ -27,21 +27,21 @@ static int ism330dhcx_gyr_trig_cnt;
 static int ism330dhcx_temp_trig_cnt;
 
 static void ism330dhcx_acc_trig_handler(const struct device *dev,
-					struct sensor_trigger *trig)
+					const struct sensor_trigger *trig)
 {
 	sensor_sample_fetch_chan(dev, SENSOR_CHAN_ACCEL_XYZ);
 	ism330dhcx_acc_trig_cnt++;
 }
 
 static void ism330dhcx_gyr_trig_handler(const struct device *dev,
-					struct sensor_trigger *trig)
+					const struct sensor_trigger *trig)
 {
 	sensor_sample_fetch_chan(dev, SENSOR_CHAN_GYRO_XYZ);
 	ism330dhcx_gyr_trig_cnt++;
 }
 
 static void ism330dhcx_temp_trig_handler(const struct device *dev,
-					 struct sensor_trigger *trig)
+					 const struct sensor_trigger *trig)
 {
 	sensor_sample_fetch_chan(dev, SENSOR_CHAN_DIE_TEMP);
 	ism330dhcx_temp_trig_cnt++;

--- a/samples/shields/x_nucleo_iks02a1/standard/src/main.c
+++ b/samples/shields/x_nucleo_iks02a1/standard/src/main.c
@@ -14,7 +14,7 @@
 static int iis2dlpc_trig_cnt;
 
 static void iis2dlpc_trigger_handler(const struct device *dev,
-				     struct sensor_trigger *trig)
+				     const struct sensor_trigger *trig)
 {
 	sensor_sample_fetch_chan(dev, SENSOR_CHAN_ACCEL_XYZ);
 	iis2dlpc_trig_cnt++;
@@ -25,7 +25,7 @@ static void iis2dlpc_trigger_handler(const struct device *dev,
 static int iis2mdc_trig_cnt;
 
 static void iis2mdc_trigger_handler(const struct device *dev,
-				    struct sensor_trigger *trig)
+				    const struct sensor_trigger *trig)
 {
 	sensor_sample_fetch_chan(dev, SENSOR_CHAN_ALL);
 	iis2mdc_trig_cnt++;
@@ -37,14 +37,14 @@ static int ism330dhcx_acc_trig_cnt;
 static int ism330dhcx_gyr_trig_cnt;
 
 static void ism330dhcx_acc_trigger_handler(const struct device *dev,
-					   struct sensor_trigger *trig)
+					   const struct sensor_trigger *trig)
 {
 	sensor_sample_fetch_chan(dev, SENSOR_CHAN_ACCEL_XYZ);
 	ism330dhcx_acc_trig_cnt++;
 }
 
 static void ism330dhcx_gyr_trigger_handler(const struct device *dev,
-					   struct sensor_trigger *trig)
+					   const struct sensor_trigger *trig)
 {
 	sensor_sample_fetch_chan(dev, SENSOR_CHAN_GYRO_XYZ);
 	ism330dhcx_gyr_trig_cnt++;

--- a/tests/drivers/sensor/generic/src/main.c
+++ b/tests/drivers/sensor/generic/src/main.c
@@ -141,7 +141,7 @@ void test_sensor_get_channels(void)
 }
 
 static void trigger_handler(const struct device *dev,
-				struct sensor_trigger *trigger)
+			    const struct sensor_trigger *trigger)
 {
 	ARG_UNUSED(dev);
 	ARG_UNUSED(trigger);


### PR DESCRIPTION
This commit adds const modifier in second argument for
sensor trigger handler.
There is no reason to modify this data and this change
would allow to store trigger configuration also in FLASH.

Fixes: #38929

Signed-off-by: Radoslaw Koppel <radoslaw.koppel@nordicsemi.no>