### PR TITLE
USB OTG full-speed support on the stm32u575/585

### DIFF
--- a/boards/arm/b_u585i_iot02a/b_u585i_iot02a.dts
+++ b/boards/arm/b_u585i_iot02a/b_u585i_iot02a.dts
@@ -67,6 +67,11 @@
 	status = "okay";
 };
 
+zephyr_udc0: &usbotg_fs {
+	pinctrl-0 = <&usb_otg_fs_dm_pa11 &usb_otg_fs_dp_pa12>;
+	status = "okay";
+};
+
 &dac1 {
 	pinctrl-0 = <&dac1_out1_pa4>;
 	status = "okay";

--- a/boards/arm/b_u585i_iot02a/b_u585i_iot02a.yaml
+++ b/boards/arm/b_u585i_iot02a/b_u585i_iot02a.yaml
@@ -12,6 +12,7 @@ supported:
   - arduino_i2c
   - arduino_spi
   - hts221
+  - usb_device
   - spi
   - dac
   - watchdog

--- a/boards/arm/b_u585i_iot02a/doc/index.rst
+++ b/boards/arm/b_u585i_iot02a/doc/index.rst
@@ -186,6 +186,8 @@ The Zephyr b_u585i_iot02a board configuration supports the following hardware fe
 +-----------+------------+-------------------------------------+
 | WATCHDOG  | on-chip    | independent watchdog                |
 +-----------+------------+-------------------------------------+
+| USB       | on-chip    | usb_device                          |
++-----------+------------+-------------------------------------+
 
 The default configuration can be found in the defconfig file:
 
@@ -211,6 +213,7 @@ Default Zephyr Peripheral Mapping:
 - I2C_1 SDA/SDL : PB9/PB8 (Arduino I2C)
 - I2C_2 SDA/SDL : PH5/PH4
 - DAC1 CH1 : PA4 (STMOD+1)
+- USB OTG : PA11/PA12
 
 System Clock
 ------------

--- a/drivers/usb/device/Kconfig
+++ b/drivers/usb/device/Kconfig
@@ -28,7 +28,7 @@ config USB_DC_STM32
 	select USE_STM32_HAL_PCD
 	select USE_STM32_HAL_PCD_EX
 	help
-	  Enable USB support on the STM32 F0, F1, F2, F3, F4, F7, L0, L4 and G4 family of
+	  Enable USB support on the STM32 F0, F1, F2, F3, F4, F7, L0, L4, G4, U5 family of
 	  processors.
 
 config USB_DC_STM32_DISCONN_ENABLE

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -203,12 +203,13 @@ static int usb_dc_stm32_clock_enable(void)
 #if defined(RCC_HSI48_SUPPORT) || \
 	defined(CONFIG_SOC_SERIES_STM32WBX) || \
 	defined(CONFIG_SOC_SERIES_STM32H7X) || \
-	defined(CONFIG_SOC_SERIES_STM32L5X)
+	defined(CONFIG_SOC_SERIES_STM32L5X) || \
+	defined(CONFIG_SOC_SERIES_STM32U5X)
 
 	/*
 	 * In STM32L0 series, HSI48 requires VREFINT and its buffer
 	 * with 48 MHz RC to be enabled.
-	 * See ENREF_HSI48 in referenc maual RM0367 section10.2.3:
+	 * See ENREF_HSI48 in reference manual RM0367 section10.2.3:
 	 * "Reference control and status register (SYSCFG_CFGR3)"
 	 */
 #ifdef CONFIG_SOC_SERIES_STM32L0X
@@ -229,6 +230,11 @@ static int usb_dc_stm32_clock_enable(void)
 	}
 
 	LL_RCC_SetUSBClockSource(LL_RCC_USB_CLKSOURCE_HSI48);
+
+#ifdef CONFIG_SOC_SERIES_STM32U5X
+	/* VDDUSB independent USB supply (PWR clock is on) */
+	LL_PWR_EnableVDDUSB();
+#endif /* CONFIG_SOC_SERIES_STM32U5X */
 
 #if !defined(CONFIG_SOC_SERIES_STM32WBX)
 	/* Specially for STM32WB, don't unlock the HSEM to prevent M0 core

--- a/dts/arm/st/u5/stm32u575.dtsi
+++ b/dts/arm/st/u5/stm32u575.dtsi
@@ -5,3 +5,28 @@
  */
 
 #include <st/u5/stm32u5.dtsi>
+
+
+/ {
+	soc {
+		usbotg_fs: otgfs@42040000 {
+			compatible = "st,stm32-otgfs";
+			reg = <0x42040000 0x80000>;
+			interrupts = <73 0>;
+			interrupt-names = "otgfs";
+			num-bidir-endpoints = <6>;
+			ram-size = <1280>;
+			maximum-speed = "full-speed";
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00004000>;
+			phys = <&otgfs_phy>;
+			status = "disabled";
+			label= "OTGFS";
+		};
+	};
+
+	otgfs_phy: otgfs_phy {
+		compatible = "usb-nop-xceiv";
+		#phy-cells = <0>;
+		label = "OTGFS_PHY";
+	};
+};


### PR DESCRIPTION
This PR adds the support of the USB  on-the-go full-speed (OTG_FS) peripheral on the stm32U575 and stm32U585
and enables the instance of this peripheral on the disco board b_u585i_iot02a
This target offers a USB type C connector.

Signed-off-by: Francois Ramu francois.ramu@st.com