### PR TITLE
usb: Add API for getting status of remote wakeup

### DIFF
--- a/doc/releases/release-notes-3.0.rst
+++ b/doc/releases/release-notes-3.0.rst
@@ -36,6 +36,8 @@ Changes in this release
 
 * Replaced custom LwM2M :c:struct:`float32_value` type with a native double type.
 
+* Added function for getting status of USB device remote wakeup feature.
+
 ==========================
 
 Removed APIs in this release

--- a/include/usb/usb_device.h
+++ b/include/usb/usb_device.h
@@ -434,6 +434,13 @@ bool usb_transfer_is_busy(uint8_t ep);
 int usb_wakeup_request(void);
 
 /**
+ * @brief Get status of the USB remote wakeup feature
+ *
+ * @return true if remote wakeup has been enabled by the host, false otherwise.
+ */
+bool usb_get_remote_wakeup_status(void);
+
+/**
  * @}
  */
 

--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -1369,10 +1369,15 @@ int usb_ep_read_continue(uint8_t ep)
 	return usb_dc_ep_read_continue(ep);
 }
 
+bool usb_get_remote_wakeup_status(void)
+{
+	return usb_dev.remote_wakeup;
+}
+
 int usb_wakeup_request(void)
 {
 	if (IS_ENABLED(CONFIG_USB_DEVICE_REMOTE_WAKEUP)) {
-		if (usb_dev.remote_wakeup) {
+		if (usb_get_remote_wakeup_status()) {
 			return usb_dc_wakeup_request();
 		}
 		return -EACCES;


### PR DESCRIPTION
This change adds a posibility to check the status of
remote wakeup feature.

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>