### PR TITLE
pm: Kconfig and logging cleanup

### DIFF
--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -1008,7 +1008,7 @@ release:
 * :github:`31928` - usb loopback not work on nrf52840
 * :github:`31924` - IVSHMEM with ACRN not working
 * :github:`31921` - west flash not working with pyocd
-* :github:`31920` - BME280: Use of deprecated `CONFIG_DEVICE_POWER_MANAGEMENT`
+* :github:`31920` - BME280: Use of deprecated ``CONFIG_DEVICE_POWER_MANAGEMENT``
 * :github:`31911` - Bluetooth: Mesh: Network buffer overflow on too long proxy messages
 * :github:`31907` - settings: Unhandled error in NVS backend
 * :github:`31905` - Question : Friend & Low power node with nRF52840

--- a/soc/arm/nordic_nrf/Kconfig.defconfig
+++ b/soc/arm/nordic_nrf/Kconfig.defconfig
@@ -28,7 +28,7 @@ config ARCH_HAS_CUSTOM_BUSY_WAIT
 	default y
 
 config PM
-	default y if SYS_CLOCK_EXISTS && !HAS_NO_SYS_PM && MULTITHREADING
+	default y if SYS_CLOCK_EXISTS && !HAS_NO_PM && MULTITHREADING
 
 config BUILD_OUTPUT_HEX
 	default y

--- a/soc/arm/nordic_nrf/nrf53/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf53/Kconfig.soc
@@ -106,7 +106,7 @@ config SOC_NRF5340_CPUNET
 	select HAS_HW_NRF_TWIS0
 	select HAS_HW_NRF_UARTE0
 	select HAS_HW_NRF_WDT
-	select HAS_NO_SYS_PM
+	select HAS_NO_PM
 
 choice
 	prompt "nRF53x MCU Selection"

--- a/subsys/pm/Kconfig
+++ b/subsys/pm/Kconfig
@@ -15,6 +15,10 @@ menuconfig PM
 
 if PM
 
+module = PM
+module-str = System Power Management
+source "subsys/logging/Kconfig.template.log_config"
+
 config PM_STATS
 	bool "System Power Management Stats"
 	depends on STATS
@@ -22,11 +26,6 @@ config PM_STATS
 	  Enable System Power Management Stats.
 
 source "subsys/pm/policy/Kconfig"
-
-module = PM
-module-str = System Power Management
-source "subsys/logging/Kconfig.template.log_config"
-
 
 endif # PM
 
@@ -49,11 +48,19 @@ config PM_DEVICE
 	  like turning off device clocks and peripherals. The device drivers
 	  may also save and restore states in these hook functions.
 
+if PM_DEVICE
+
+module = PM_DEVICE
+module-str = Device Power Management
+source "subsys/logging/Kconfig.template.log_config"
+
 config PM_DEVICE_RUNTIME
 	bool "Runtime Device Power Management"
-	depends on PM_DEVICE
 	help
 	  Enable Runtime Power Management to save power. With device runtime PM
 	  enabled, devices can be suspended or resumed based on the device
 	  usage even while the CPU or system is running.
+
+endif # PM_DEVICE
+
 endmenu

--- a/subsys/pm/Kconfig
+++ b/subsys/pm/Kconfig
@@ -4,12 +4,6 @@
 
 menu "Power Management"
 
-config SYS_POWER_MANAGEMENT
-	bool "System Power management"
-	select PM
-	help
-	  This option is deprecated. Please use CONFIG_PM instead.
-
 menuconfig PM
 	bool "System Power Management"
 	depends on SYS_CLOCK_EXISTS && !HAS_NO_SYS_PM
@@ -54,12 +48,6 @@ config PM_DEVICE
 	  device drivers to do any necessary power management operations
 	  like turning off device clocks and peripherals. The device drivers
 	  may also save and restore states in these hook functions.
-
-config DEVICE_POWER_MANAGEMENT
-	bool "Device Power Management"
-	select PM_DEVICE
-	help
-	  This option is deprecated, please use CONFIG_PM_DEVICE instead.
 
 config PM_DEVICE_RUNTIME
 	bool "Runtime Device Power Management"

--- a/subsys/pm/Kconfig
+++ b/subsys/pm/Kconfig
@@ -52,7 +52,6 @@ config PM_DEVICE
 config PM_DEVICE_RUNTIME
 	bool "Runtime Device Power Management"
 	depends on PM_DEVICE
-	select POLL
 	help
 	  Enable Runtime Power Management to save power. With device runtime PM
 	  enabled, devices can be suspended or resumed based on the device

--- a/subsys/pm/Kconfig
+++ b/subsys/pm/Kconfig
@@ -6,7 +6,7 @@ menu "Power Management"
 
 menuconfig PM
 	bool "System Power Management"
-	depends on SYS_CLOCK_EXISTS && !HAS_NO_SYS_PM
+	depends on SYS_CLOCK_EXISTS && !HAS_NO_PM
 	help
 	  This option enables the board to implement extra power management
 	  policies whenever the kernel becomes idle. The kernel informs the
@@ -29,7 +29,7 @@ source "subsys/pm/policy/Kconfig"
 
 endif # PM
 
-config HAS_NO_SYS_PM
+config HAS_NO_PM
 	bool
 	help
 	  This option blocks selection of PM.  It can be selected in SOC

--- a/subsys/pm/Kconfig
+++ b/subsys/pm/Kconfig
@@ -38,7 +38,7 @@ config HAS_NO_PM
 	  the responsibility of a different core.
 
 config PM_DEVICE
-	bool "Device power management"
+	bool "Device Power Management"
 	help
 	  This option enables the device power management interface.  The
 	  interface consists of hook functions implemented by device drivers

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -7,9 +7,8 @@
 #include <device.h>
 #include <pm/device.h>
 
-#define LOG_LEVEL CONFIG_PM_LOG_LEVEL /* From power module Kconfig */
 #include <logging/log.h>
-LOG_MODULE_DECLARE(power);
+LOG_MODULE_REGISTER(pm_device, CONFIG_PM_DEVICE_LOG_LEVEL);
 
 #if defined(CONFIG_PM_DEVICE)
 extern const struct device *__pm_device_slots_start[];

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -7,9 +7,8 @@
 #include <sys/__assert.h>
 #include <pm/device_runtime.h>
 
-#define LOG_LEVEL CONFIG_PM_LOG_LEVEL /* From power module Kconfig */
 #include <logging/log.h>
-LOG_MODULE_DECLARE(power);
+LOG_MODULE_DECLARE(pm_device, CONFIG_PM_DEVICE_LOG_LEVEL);
 
 /* Device PM request type */
 #define PM_DEVICE_SYNC          BIT(0)

--- a/subsys/pm/pm_ctrl.c
+++ b/subsys/pm/pm_ctrl.c
@@ -10,9 +10,8 @@
 #include <sys/atomic.h>
 #include <pm/state.h>
 
-#define LOG_LEVEL CONFIG_PM_LOG_LEVEL /* From power module Kconfig */
 #include <logging/log.h>
-LOG_MODULE_DECLARE(power);
+LOG_MODULE_DECLARE(pm, CONFIG_PM_LOG_LEVEL);
 
 #define PM_STATES_LEN (1 + PM_STATE_SOFT_OFF - PM_STATE_ACTIVE)
 

--- a/subsys/pm/power.c
+++ b/subsys/pm/power.c
@@ -17,9 +17,8 @@
 #include "pm_priv.h"
 
 #define PM_STATES_LEN (1 + PM_STATE_SOFT_OFF - PM_STATE_ACTIVE)
-#define LOG_LEVEL CONFIG_PM_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(power);
+LOG_MODULE_REGISTER(pm, CONFIG_PM_LOG_LEVEL);
 
 static int post_ops_done = 1;
 static struct pm_state_info z_power_state;


### PR DESCRIPTION
```
pm: remove deprecated Kconfig options 

SYS_POWER_MANAGEMENT and DEVICE_POWER_MANAGEMENT were deprecated in
2.5.0, remove them now.
```
```
pm: device: runtime: remove dependency on POLL

POLL is not a dependency of runtime device PM since it now uses
conditional variables to notify waiting threads.
```
```
pm: improve logging

List of improvements:

- The PM logging module was only available if CONFIG_PM=y, however, it
  was also used by Device PM (which can be selected without PM). A new
  logging module has been created for Device PM.
- Log level is passed to LOG_MODULE_(DECLARE|REGISTER)
- Logger name has been adjusted to `pm` (was `power`)
```
```
pm: rename HAS_NO_SYS_PM to HAS_NO_PM

Align name with other Kconfig options (CONFIG_PM).
```
```
pm: adjust PM_DEVICE prompt

Other prompts use Capitalized Words.
```