### PR TITLE
MAINTAINERS: include the CANopenNode module in the CAN bus group

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -563,6 +563,7 @@
 /lib/libc/                                @nashif
 /lib/libc/arcmwdt/                        @abrodkin @ruuddw @evgeniy-paltsev
 /modules/                                 @nashif
+/modules/canopennode/                     @henrikbrixandersen
 /modules/mbedtls/                         @ceolin @d3zd3z
 /modules/trusted-firmware-m/              @ioannisg @microbuilder
 /kernel/device.c                          @andyross @nashif
@@ -581,6 +582,7 @@
 /samples/drivers/ht16k33/                 @henrikbrixandersen
 /samples/drivers/lora/                    @Mani-Sadhasivam
 /samples/subsys/lorawan/                  @Mani-Sadhasivam
+/samples/modules/canopennode/             @henrikbrixandersen
 /samples/net/                             @rlubos @tbursztyka @pfalcon
 /samples/net/cloud/tagoio_http_post/      @nandojve
 /samples/net/dns_resolve/                 @rlubos @tbursztyka @pfalcon

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -465,6 +465,8 @@ Documentation:
         - tests/drivers/can/
         - samples/subsys/canbus/
         - doc/reference/networking/can_api.rst
+        - modules/canopennode/
+        - samples/modules/canopennode/
     labels:
         - "area: CAN"
 


### PR DESCRIPTION
Include the CANopenNode module integration files in the CAN bus maintainers group and assign ownership to me.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>