### PR TITLE
drivers: sensor: ms5607: convert to spi_dt_spec

### DIFF
--- a/drivers/sensor/ms5607/ms5607.c
+++ b/drivers/sensor/ms5607/ms5607.c
@@ -325,8 +325,8 @@ static const struct sensor_driver_api ms5607_api_funcs = {
 	{								\
 		.bus = DEVICE_DT_GET(DT_INST_BUS(inst)),		\
 		.tf = &ms5607_spi_transfer_function,			\
-		.bus_cfg.spi_cfg =					\
-			SPI_CONFIG_DT_INST(inst,			\
+		.bus_cfg.spi_bus =					\
+			SPI_DT_SPEC_INST_GET(inst,			\
 					   MS5607_SPI_OPERATION,	\
 					   0),				\
 	}

--- a/drivers/sensor/ms5607/ms5607.h
+++ b/drivers/sensor/ms5607/ms5607.h
@@ -95,7 +95,7 @@ struct ms5607_config {
 		uint16_t i2c_addr;
 #endif
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
-		struct spi_config spi_cfg;
+		struct spi_dt_spec spi_bus;
 #endif
 	} bus_cfg;
 };

--- a/drivers/sensor/ms5607/ms5607_spi.c
+++ b/drivers/sensor/ms5607/ms5607_spi.c
@@ -29,7 +29,7 @@ static int ms5607_spi_raw_cmd(const struct ms5607_config *config, uint8_t cmd)
 		.count = 1,
 	};
 
-	return spi_write(config->bus, &config->bus_cfg.spi_cfg, &buf_set);
+	return spi_write_dt(&config->bus_cfg.spi_bus, &buf_set);
 }
 
 static int ms5607_spi_reset(const struct ms5607_config *config)
@@ -79,8 +79,7 @@ static int ms5607_spi_read_prom(const struct ms5607_config *config, uint8_t cmd,
 		.count = 1,
 	};
 
-	err = spi_transceive(config->bus,
-			     &config->bus_cfg.spi_cfg,
+	err = spi_transceive_dt(&config->bus_cfg.spi_bus,
 			     &tx_buf_set,
 			     &rx_buf_set);
 	if (err < 0) {
@@ -130,8 +129,7 @@ static int ms5607_spi_read_adc(const struct ms5607_config *config, uint32_t *val
 		.count = 1,
 	};
 
-	err = spi_transceive(config->bus,
-			     &config->bus_cfg.spi_cfg,
+	err = spi_transceive_dt(&config->bus_cfg.spi_bus,
 			     &tx_buf_set,
 			     &rx_buf_set);
 	if (err < 0) {
@@ -145,19 +143,9 @@ static int ms5607_spi_read_adc(const struct ms5607_config *config, uint32_t *val
 
 static int ms5607_spi_check(const struct ms5607_config *config)
 {
-	const struct spi_cs_control *cs = config->bus_cfg.spi_cfg.cs;
-
-	if (!device_is_ready(config->bus)) {
+	if (!spi_is_ready(&config->bus_cfg.spi_bus)) {
 		LOG_DBG("SPI bus %s not ready", config->bus->name);
 		return -ENODEV;
-	}
-
-	if (cs) {
-		if (!device_is_ready(cs->gpio_dev)) {
-			LOG_DBG("SPI CS GPIO controller %s not ready", cs->gpio_dev->name);
-			return -ENODEV;
-		}
-		LOG_DBG("SPI GPIO CS configured on %s:%u", cs->gpio_dev->name, cs->gpio_pin);
 	}
 
 	return 0;


### PR DESCRIPTION
Convert ms5607 driver to use spi_dt_spec helpers.

Signed-off-by: Bartosz Bilas <bartosz.bilas@hotmail.com>