### PR TITLE
Docs: Clarification of CONTAINER_OF

### DIFF
--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -124,7 +124,7 @@ extern "C" {
 	((ptr) && ((ptr) >= &array[0] && (ptr) < &array[ARRAY_SIZE(array)]))
 
 /**
- * @brief Get a pointer to a container structure from an element
+ * @brief Get a pointer to a structure containing the element
  *
  * Example:
  *


### PR DESCRIPTION
This is a small reordering of the CONTAINER_OF description to
clarify its purpose.

Signed-off-by: Chris Pearson <ctpearson@gmail.com>