### PR TITLE
samples: sockets: http_get: increase main thread stack size

### DIFF
--- a/samples/net/sockets/http_get/prj.conf
+++ b/samples/net/sockets/http_get/prj.conf
@@ -1,4 +1,5 @@
 # General config
+CONFIG_MAIN_STACK_SIZE=1536
 CONFIG_NEWLIB_LIBC=y
 
 # Networking config


### PR DESCRIPTION
After commit eeb15aa3930a ("timer: hpet: enable 64 bit mode for
better usages") was applied, main thread stack usage on qemu_x86
platform increased from 984 to 1040 bytes.

Default stack size, which is 1024, is no longer enough. Change that to
1536 to make sure this sample runs correctly on qemu_x86.

Fixes: #39627