### PR TITLE
net: openthread: Change OT net log to display current role in text

### DIFF
--- a/samples/net/lwm2m_client/README.rst
+++ b/samples/net/lwm2m_client/README.rst
@@ -214,7 +214,7 @@ networking do the following:
    :compact:
 
 Note: If not provisioned (fully erased before flash), device will form
-new OpenThread network and promote himself as leader (Current role: leader).
+new OpenThread network and promote itself to leader (Current role: leader).
 To join into already existing OT network, either enable CONFIG_OPENTHREAD_JOINER=y
 and CONFIG_OPENTHREAD_JOINER_AUTOSTART=y and send join request from other
 already joined device with joiner capabilities, or provision it manually

--- a/samples/net/lwm2m_client/README.rst
+++ b/samples/net/lwm2m_client/README.rst
@@ -214,7 +214,7 @@ networking do the following:
    :compact:
 
 Note: If not provisioned (fully erased before flash), device will form
-new OpenThread network and promote himself as leader (Current role: 4).
+new OpenThread network and promote himself as leader (Current role: leader).
 To join into already existing OT network, either enable CONFIG_OPENTHREAD_JOINER=y
 and CONFIG_OPENTHREAD_JOINER_AUTOSTART=y and send join request from other
 already joined device with joiner capabilities, or provision it manually

--- a/subsys/net/l2/openthread/openthread.c
+++ b/subsys/net/l2/openthread/openthread.c
@@ -169,7 +169,9 @@ static void ot_state_changed_handler(uint32_t flags, void *context)
 	struct openthread_context *ot_context = context;
 
 	NET_INFO("State changed! Flags: 0x%08" PRIx32 " Current role: %s",
-		 flags, otThreadDeviceRoleToString( otThreadGetDeviceRole(ot_context->instance)));
+		flags,
+		log_strdup(otThreadDeviceRoleToString(otThreadGetDeviceRole(ot_context->instance)))
+		);
 
 	if (flags & OT_CHANGED_IP6_ADDRESS_REMOVED) {
 		NET_DBG("Ipv6 address removed");

--- a/subsys/net/l2/openthread/openthread.c
+++ b/subsys/net/l2/openthread/openthread.c
@@ -168,8 +168,8 @@ static void ot_state_changed_handler(uint32_t flags, void *context)
 {
 	struct openthread_context *ot_context = context;
 
-	NET_INFO("State changed! Flags: 0x%08" PRIx32 " Current role: %d",
-		 flags, otThreadGetDeviceRole(ot_context->instance));
+	NET_INFO("State changed! Flags: 0x%08" PRIx32 " Current role: %s",
+		 flags, otThreadDeviceRoleToString( otThreadGetDeviceRole(ot_context->instance)));
 
 	if (flags & OT_CHANGED_IP6_ADDRESS_REMOVED) {
 		NET_DBG("Ipv6 address removed");


### PR DESCRIPTION
If CONFIG_NET_LOG=y is set, OpenThread will output the current OT
role whenever the state changes.

To simplify understanding of the log output, this change replaces
the numerical role ID with the text name of the role. This also
required a change to a documentation file to replace an instance
of a numerical ID.

Example of the previous numeric output:
`<inf> net_l2_openthread: State changed! Flags: 0x00000001 Current Role: 3`

Example of the text output:
`<inf> net_l2_openthread: State changed! Flags: 0x00000001 Current Role: router`

NOTE: This is potentially a breaking change should anyone be using
test scripts that monitor the OpenThread state changes and look
for the numerical ID. This does not seem to be the case for the
Zephyr tests, however.

Signed-off-by: Chris Pearson <ctpearson@gmail.com>