### PR TITLE
Bluetooth: Controller: Use 32-bit value for time reservations

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -2045,6 +2045,11 @@ static uint16_t adv_time_get(struct pdu_adv *pdu, struct pdu_adv *pdu_scan,
 {
 	uint16_t time_us = EVENT_OVERHEAD_START_US + EVENT_OVERHEAD_END_US;
 
+	/* NOTE: 16-bit value is sufficient to calculate the maximum radio
+	 *       event time reservation for PDUs on primary advertising
+	 *       channels (37, 38, and 39 channel indices of 1M and Coded PHY).
+	 */
+
 	/* Calculate the PDU Tx Time and hence the radio event length */
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 	if (pdu->type == PDU_ADV_TYPE_EXT_IND) {

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -51,7 +51,7 @@ static inline uint16_t sync_handle_get(struct ll_adv_sync_set *sync);
 static inline uint8_t sync_remove(struct ll_adv_sync_set *sync,
 				  struct ll_adv_set *adv, uint8_t enable);
 static uint8_t sync_chm_update(uint8_t handle);
-static uint16_t sync_time_get(struct ll_adv_sync_set *sync,
+static uint32_t sync_time_get(struct ll_adv_sync_set *sync,
 			      struct pdu_adv *pdu);
 
 static void mfy_sync_offset_get(void *param);
@@ -766,7 +766,7 @@ uint8_t ull_adv_sync_time_update(struct ll_adv_sync_set *sync,
 	uint32_t ticks_minus;
 	uint32_t ticks_plus;
 	uint32_t time_ticks;
-	uint16_t time_us;
+	uint32_t time_us;
 	uint32_t ret;
 
 	time_us = sync_time_get(sync, pdu);
@@ -1468,12 +1468,19 @@ static uint8_t sync_chm_update(uint8_t handle)
 	return 0;
 }
 
-static uint16_t sync_time_get(struct ll_adv_sync_set *sync,
+static uint32_t sync_time_get(struct ll_adv_sync_set *sync,
 			      struct pdu_adv *pdu)
 {
 	struct lll_adv_sync *lll_sync;
 	struct lll_adv *lll;
 	uint32_t time_us;
+
+	/* NOTE: 16-bit values are sufficient for minimum radio event time
+	 *       reservation, 32-bit are used here so that reservations for
+	 *       whole back-to-back chaining of PDUs can be accomodated where
+	 *       the required microseconds could overflow 16-bits, example,
+	 *       back-to-back chained Coded PHY PDUs.
+	 */
 
 	lll_sync = &sync->lll;
 	lll = lll_sync->adv;


### PR DESCRIPTION
Use 32-bit value variables when calculating Periodic
Advertising radio event time reservations.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>