### PR TITLE
samples: Bluetooth: periodic_adv: Add Extended Advertising disable

### DIFF
--- a/samples/bluetooth/periodic_adv/src/main.c
+++ b/samples/bluetooth/periodic_adv/src/main.c
@@ -48,24 +48,41 @@ void main(void)
 		return;
 	}
 
-	/* Start extended advertising */
-	err = bt_le_ext_adv_start(adv, BT_LE_EXT_ADV_START_DEFAULT);
-	if (err) {
-		printk("Failed to start extended advertising (err %d)\n", err);
-		return;
-	}
-
 	while (true) {
-		k_sleep(K_SECONDS(10));
-
-		mfg_data[2]++;
-
-		printk("Set Periodic Advertising Data...");
-		err = bt_le_per_adv_set_data(adv, ad, ARRAY_SIZE(ad));
+		printk("Start Extended Advertising...");
+		err = bt_le_ext_adv_start(adv, BT_LE_EXT_ADV_START_DEFAULT);
 		if (err) {
-			printk("Failed (err %d)\n", err);
+			printk("Failed to start extended advertising "
+			       "(err %d)\n", err);
 			return;
 		}
 		printk("done.\n");
+
+		for (int i = 0; i < 3; i++) {
+			k_sleep(K_SECONDS(10));
+
+			mfg_data[2]++;
+
+			printk("Set Periodic Advertising Data...");
+			err = bt_le_per_adv_set_data(adv, ad, ARRAY_SIZE(ad));
+			if (err) {
+				printk("Failed (err %d)\n", err);
+				return;
+			}
+			printk("done.\n");
+		}
+
+		k_sleep(K_SECONDS(10));
+
+		printk("Stop Extended Advertising...");
+		err = bt_le_ext_adv_stop(adv);
+		if (err) {
+			printk("Failed to stop extended advertising "
+			       "(err %d)\n", err);
+			return;
+		}
+		printk("done.\n");
+
+		k_sleep(K_SECONDS(10));
 	}
 }


### PR DESCRIPTION
Add implementation to iteratively perform Extended
Advertising enable and disable while Periodic Advertising is
active.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>