### PR TITLE
Bluetooth: Mesh: Fix missing enable adv thread

### DIFF
--- a/subsys/bluetooth/mesh/pb_gatt.c
+++ b/subsys/bluetooth/mesh/pb_gatt.c
@@ -117,6 +117,14 @@ int bt_mesh_pb_gatt_close(struct bt_conn *conn)
 
 static int link_accept(const struct prov_bearer_cb *cb, void *cb_data)
 {
+	int err;
+
+	err = bt_mesh_adv_enable();
+	if (err) {
+		BT_ERR("Failed enabling advertiser");
+		return err;
+	}
+
 	(void)bt_mesh_pb_gatt_enable();
 	bt_mesh_adv_update();
 


### PR DESCRIPTION
When user only use pb-gatt provisioning, which unable to
send out connectable advertising, due to adv thread not started.

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>