### PR TITLE
Bluetooth: Audio: CCID module

### DIFF
--- a/include/bluetooth/uuid.h
+++ b/include/bluetooth/uuid.h
@@ -1484,6 +1484,15 @@ struct bt_uuid_128 {
  */
 #define BT_UUID_VOCS_DESCRIPTION \
 	BT_UUID_DECLARE_16(BT_UUID_VOCS_DESCRIPTION_VAL)
+/** @def BT_UUID_CCID_VAL
+ *  @brief Content Control ID value
+ */
+#define BT_UUID_CCID_VAL 0x2BBA
+/** @def BT_UUID_CCID
+ *  @brief Content Control ID
+ */
+#define BT_UUID_CCID \
+	BT_UUID_DECLARE_16(BT_UUID_CCID_VAL)
 /** @def BT_UUID_MICS_MUTE_VAL
  *  @brief Microphone Input Control Service Mute value
  */

--- a/subsys/bluetooth/audio/CMakeLists.txt
+++ b/subsys/bluetooth/audio/CMakeLists.txt
@@ -22,4 +22,6 @@ if (CONFIG_BT_MICS OR CONFIG_BT_MICS_CLIENT)
 endif()
 zephyr_library_sources_ifdef(CONFIG_BT_MICS_CLIENT mics_client.c)
 
+zephyr_library_sources_ifdef(CONFIG_BT_CCID ccid.c)
+
 zephyr_library_link_libraries(subsys__bluetooth)

--- a/subsys/bluetooth/audio/Kconfig
+++ b/subsys/bluetooth/audio/Kconfig
@@ -19,8 +19,7 @@ menuconfig BT_AUDIO
 if BT_AUDIO
 
 config BT_CCID
-	bool # hidden
-	default n
+	bool
 	help
 	  This hidden option is enabled when any of the content control
 	  features are enabled.

--- a/subsys/bluetooth/audio/Kconfig
+++ b/subsys/bluetooth/audio/Kconfig
@@ -18,6 +18,13 @@ menuconfig BT_AUDIO
 
 if BT_AUDIO
 
+config BT_CCID
+	bool # hidden
+	default n
+	help
+	  This hidden option is enabled when any of the content control
+	  features are enabled.
+
 if BT_CONN
 
 config BT_AUDIO_UNICAST

--- a/subsys/bluetooth/audio/ccid.c
+++ b/subsys/bluetooth/audio/ccid.c
@@ -2,18 +2,24 @@
 
 /*
  * Copyright (c) 2020 Bose Corporation
+ * Copyright (c) 2021 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "ccid_internal.h"
 
-
-uint8_t ccid_get_value(void)
+uint8_t bt_ccid_get_value(void)
 {
 	static uint8_t ccid_value;
 
-	__ASSERT(ccid_value != 0xFF,
+	/* By spec, the CCID can take all values up to and including 0xFF.
+	 * But since this is a value we provide, we do not have to use all of
+	 * them.  254 CCID values on a device should be plenty, the last one
+	 * can be used to prevent wraparound.
+	 */
+	__ASSERT(ccid_value != UINT8_MAX,
 		 "Cannot allocate any more control control IDs");
+
 	return ccid_value++;
 }

--- a/subsys/bluetooth/audio/ccid.c
+++ b/subsys/bluetooth/audio/ccid.c
@@ -1,0 +1,19 @@
+/*  Bluetooth Audio Content Control */
+
+/*
+ * Copyright (c) 2020 Bose Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "ccid_internal.h"
+
+
+uint8_t ccid_get_value(void)
+{
+	static uint8_t ccid_value;
+
+	__ASSERT(ccid_value != 0xFF,
+		 "Cannot allocate any more control control IDs");
+	return ccid_value++;
+}

--- a/subsys/bluetooth/audio/ccid_internal.h
+++ b/subsys/bluetooth/audio/ccid_internal.h
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (c) 2020 Bose Corporation
+ * Copyright (c) 2021 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -20,6 +21,6 @@
  *
  * @return uint8_t A content control ID value.
  */
-uint8_t ccid_get_value(void);
+uint8_t bt_ccid_get_value(void);
 
 #endif /* ZEPHYR_INCLUDE_BLUETOOTH_CCID_H_ */

--- a/subsys/bluetooth/audio/ccid_internal.h
+++ b/subsys/bluetooth/audio/ccid_internal.h
@@ -1,0 +1,25 @@
+/*  Bluetooth Audio Content Control Identifier */
+
+/*
+ * Copyright (c) 2020 Bose Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_BLUETOOTH_CCID_H_
+#define ZEPHYR_INCLUDE_BLUETOOTH_CCID_H_
+
+#include <device.h>
+#include <zephyr/types.h>
+
+/**
+ * @brief Gets a free CCID value.
+ *
+ * The maximum number of CCID values that can retrieved on the device is 0xFE,
+ * one less than per the GSS specification.
+ *
+ * @return uint8_t A content control ID value.
+ */
+uint8_t ccid_get_value(void);
+
+#endif /* ZEPHYR_INCLUDE_BLUETOOTH_CCID_H_ */


### PR DESCRIPTION
The Content Control ID (CCID) characteristic is a separately defined characteristic used in the media control service and in the telephone bearer service in LE Audio.  The purpose of the CCID is to provide device-unique identifiers for content control services on that device.

This PR is part of the upmerge of le-audio host code from the topic-le-audio branch.  This CCID module has existed (unchanged) in that branch since before March 2020 (and in another repo before that).