### PR TITLE
uart: sifive: align txcnt of UART1 with UART0

### DIFF
--- a/drivers/serial/Kconfig.sifive
+++ b/drivers/serial/Kconfig.sifive
@@ -52,7 +52,7 @@ config UART_SIFIVE_PORT_1_RXCNT_IRQ
 
 config UART_SIFIVE_PORT_1_TXCNT_IRQ
 	int "Port 1 TX Interrupt Threshold Count"
-	default 0
+	default 1
 	depends on UART_SIFIVE_PORT_1
 	help
 	  Port 1 TX Threshold at which the TX FIFO interrupt triggers.


### PR DESCRIPTION
The UART1 is not actually accessible on the HiFive1 since the QFN48 package for the FE310, used by this board, does not expose the required pads. However, it is still possible to use the UART1 on HiFive1 emulators (e.g. using UART0 for debugging and UART1 for SLIP).

Unfortunately, the UART0 and UART1 currently have different default configurations when it comes to the configured transmission watermark (txcnt). With a txcnt of zero (the default for UART1) the UART is not actually usable (see #18118). Contrary to UART0 (see #23699), the UART1 does therefore not work by default on Zephyr which took me some time to figure out.

This commit aligns the default UART1 configuration with the UART0, thereby making it work by default.