### PR TITLE
test: drivers: pwm: extends pwm_loopback test

### DIFF
--- a/tests/drivers/pwm/pwm_loopback/src/test_pwm_loopback.c
+++ b/tests/drivers/pwm/pwm_loopback/src/test_pwm_loopback.c
@@ -339,6 +339,9 @@ void test_capture_busy(void)
 					&data);
 	zassert_equal(err, -EBUSY, "pwm capture not busy (err %d)", err);
 
+	err = pwm_pin_enable_capture(in.dev, in.pwm);
+	zassert_equal(err, -EBUSY, "pwm capture not busy (err %d)", err);
+
 	err = pwm_pin_disable_capture(in.dev, in.pwm);
 	zassert_equal(err, 0, "failed to disable pwm capture (err %d)", err);
 }


### PR DESCRIPTION
Adds a new zassert to check whether PWM capture has previously been
enabled and correctly returns -EBUSY on a second call.
While working on #39694 this was found to be a missing test case.
The new test case has been verified against the suggested changes of
that PR.

Signed-off-by: Tilmann Unte <unte@es-augsburg.de>