### PR TITLE
stats: fixed implicit integer sign extension in stats_get_off()

### DIFF
--- a/subsys/stats/stats.c
+++ b/subsys/stats/stats.c
@@ -43,7 +43,7 @@ stats_get_name(const struct stats_hdr *hdr, int idx)
 static uint16_t
 stats_get_off(const struct stats_hdr *hdr, int idx)
 {
-	return sizeof(*hdr) + idx * hdr->s_size;
+	return (uint16_t) (sizeof(*hdr) + idx * (int) hdr->s_size);
 }
 
 /**


### PR DESCRIPTION
Introduced explicit casting for fixing static analyze issue.

fixes #39812

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>