### PR TITLE
ite: drivers/i2c: fix potential NULL pointer dereference

### DIFF
--- a/drivers/i2c/i2c_ite_it8xxx2.c
+++ b/drivers/i2c/i2c_ite_it8xxx2.c
@@ -772,8 +772,8 @@ static int i2c_transaction(const struct device *dev)
 static int i2c_it8xxx2_transfer(const struct device *dev, struct i2c_msg *msgs,
 		uint8_t num_msgs, uint16_t addr)
 {
-	struct i2c_it8xxx2_data *data = DEV_DATA(dev);
-	const struct i2c_it8xxx2_config *config = DEV_CFG(dev);
+	struct i2c_it8xxx2_data *data;
+	const struct i2c_it8xxx2_config *config;
 	int res;
 
 	/* Check for NULL pointers */
@@ -785,6 +785,9 @@ static int i2c_it8xxx2_transfer(const struct device *dev, struct i2c_msg *msgs,
 		LOG_ERR("Device message is NULL");
 		return -EINVAL;
 	}
+
+	data = DEV_DATA(dev);
+	config = DEV_CFG(dev);
 
 	/* Lock mutex of i2c controller */
 	k_mutex_lock(&data->mutex, K_FOREVER);


### PR DESCRIPTION
reorganize code so that null pointer check is done prior to accessing
element.

Signed-off-by: Jacob Siverskog <jacob@teenage.engineering>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zephyrproject-rtos/zephyr/39877)
<!-- Reviewable:end -->
