### PR TITLE
cmake: use find_package() instead of literal include in tests and samples

### DIFF
--- a/drivers/flash/spi_flash_at45.c
+++ b/drivers/flash/spi_flash_at45.c
@@ -542,7 +542,6 @@ static int power_down_op(const struct device *dev, uint8_t opcode,
 
 static int spi_flash_at45_init(const struct device *dev)
 {
-	struct spi_flash_at45_data *dev_data = get_dev_data(dev);
 	const struct spi_flash_at45_config *dev_config = get_dev_config(dev);
 	int err;
 

--- a/samples/arch/smp/pktqueue/CMakeLists.txt
+++ b/samples/arch/smp/pktqueue/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(smp_pktqueue)
 
 FILE(GLOB pktqueue_sources src/*.c)

--- a/samples/bluetooth/central_ht/CMakeLists.txt
+++ b/samples/bluetooth/central_ht/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20.0)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(central_ht)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/bluetooth/hci_usb_h4/CMakeLists.txt
+++ b/samples/bluetooth/hci_usb_h4/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20.0)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(hci_usb_h4)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/boards/ti/cc13x2_cc26x2/system_off/CMakeLists.txt
+++ b/samples/boards/ti/cc13x2_cc26x2/system_off/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20.0)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(ti_cc13x2_cc26x2_system_off)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/drivers/clock_control_litex/CMakeLists.txt
+++ b/samples/drivers/clock_control_litex/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20.0)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(clock_control_litex)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/drivers/i2s/litex/CMakeLists.txt
+++ b/samples/drivers/i2s/litex/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(i2s_litex)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/drivers/kscan_touch/CMakeLists.txt
+++ b/samples/drivers/kscan_touch/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20.0)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(kscan)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/drivers/spi_flash_at45/CMakeLists.txt
+++ b/samples/drivers/spi_flash_at45/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20.0)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(spi_flash_at45)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/mpr/CMakeLists.txt
+++ b/samples/sensor/mpr/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20.0)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mpr)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/subsys/mgmt/hawkbit/CMakeLists.txt
+++ b/samples/subsys/mgmt/hawkbit/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required(VERSION 3.20.0)
 # This application has its own Kconfig options.
 set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
 
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(hawkbit)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/subsys/usb/audio/headphones_microphone/CMakeLists.txt
+++ b/samples/subsys/usb/audio/headphones_microphone/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20.0)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(audio)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/subsys/usb/audio/headset/CMakeLists.txt
+++ b/samples/subsys/usb/audio/headset/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20.0)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(audio)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/userspace/hello_world_user/CMakeLists.txt
+++ b/samples/userspace/hello_world_user/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(hello_world_user)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/userspace/syscall_perf/CMakeLists.txt
+++ b/samples/userspace/syscall_perf/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(syscall_perf)
 
 set_property(

--- a/tests/drivers/clock_control/onoff/CMakeLists.txt
+++ b/tests/drivers/clock_control/onoff/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/posix/eventfd/CMakeLists.txt
+++ b/tests/posix/eventfd/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20.0)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(eventfd)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/posix/eventfd_basic/CMakeLists.txt
+++ b/tests/posix/eventfd_basic/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20.0)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(eventfd_basic)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/subsys/fs/fs_api/CMakeLists.txt
+++ b/tests/subsys/fs/fs_api/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20.0)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(fs_api)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/subsys/logging/log_core_additional/CMakeLists.txt
+++ b/tests/subsys/logging/log_core_additional/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20.0)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(log_core_additional)
 
 if(${USERSPACE_TEST})

--- a/tests/subsys/openthread/CMakeLists.txt
+++ b/tests/subsys/openthread/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Boilerplate code, which pulls in the Zephyr build system.
 cmake_minimum_required(VERSION 3.20.0)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(openthread_tests)
 

--- a/tests/subsys/storage/stream/stream_flash/CMakeLists.txt
+++ b/tests/subsys/storage/stream/stream_flash/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 
 cmake_minimum_required(VERSION 3.20.0)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(stream_flash)
 
 FILE(GLOB app_sources src/*.c)


### PR DESCRIPTION
Convert remaining tests and samples to using find_package() instead of literally including the CMake boilerplate code.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>