### PR TITLE
Bluetooth: Host: Fix setting long adv data with long AD fields

### DIFF
--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -511,7 +511,7 @@ static int hci_set_adv_ext_fragmented(struct bt_le_ext_adv *adv, uint16_t hci_op
 				if (offset == 0) {
 					set_data->data[0] = len + 1;
 					set_data->data[1] = type;
-					memcpy(&set_data->data[2], data[j].data, set_data->len);
+					memcpy(&set_data->data[2], data[j].data, set_data->len - 2);
 					offset += set_data->len - 2;
 				} else {
 					memcpy(&set_data->data[0], &data[j].data[offset],


### PR DESCRIPTION
Previously, if the AD field length was greater than the maximum
fragment size - 2 bytes, an out of bounds access would occur.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/39852