### PR TITLE
drivers: display: dma: Refactor drivers to use shared init priority

### DIFF
--- a/drivers/display/display_mcux_elcdif.c
+++ b/drivers/display/display_mcux_elcdif.c
@@ -260,7 +260,7 @@ DEVICE_DT_INST_DEFINE(0,
 		    &mcux_elcdif_init,
 		    NULL,
 		    &mcux_elcdif_data_1, &mcux_elcdif_config_1,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    POST_KERNEL, CONFIG_DISPLAY_INIT_PRIORITY,
 		    &mcux_elcdif_api);
 
 static void mcux_elcdif_config_func_1(const struct device *dev)

--- a/drivers/display/mb_display.c
+++ b/drivers/display/mb_display.c
@@ -450,4 +450,4 @@ static int mb_display_init(const struct device *dev)
 	return 0;
 }
 
-SYS_INIT(mb_display_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+SYS_INIT(mb_display_init, POST_KERNEL, CONFIG_DISPLAY_INIT_PRIORITY);

--- a/drivers/dma/Kconfig
+++ b/drivers/dma/Kconfig
@@ -16,6 +16,12 @@ config DMA_64BIT
 	  When this option is true, 64 bit source and dest
 	  DMA addresses are supported.
 
+config DMA_INIT_PRIORITY
+	int "DMA init priority"
+	default KERNEL_INIT_PRIORITY_DEFAULT
+	help
+	  DMA driver device initialization priority.
+
 module = DMA
 module-str = dma
 source "subsys/logging/Kconfig.template.log_config"

--- a/drivers/dma/dma_dw.c
+++ b/drivers/dma/dma_dw.c
@@ -413,7 +413,7 @@ static const struct dma_driver_api dw_dma_driver_api = {
 			    NULL,					\
 			    &dw_dma##inst##_data,			\
 			    &dw_dma##inst##_config, POST_KERNEL,	\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+			    CONFIG_DMA_INIT_PRIORITY,			\
 			    &dw_dma_driver_api);			\
 									\
 	static void dw_dma##inst##_irq_config(void)			\

--- a/drivers/dma/dma_iproc_pax_v1.c
+++ b/drivers/dma/dma_iproc_pax_v1.c
@@ -995,5 +995,5 @@ DEVICE_DT_INST_DEFINE(0,
 		    &pax_dma_data,
 		    &pax_dma_cfg,
 		    POST_KERNEL,
-		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    CONFIG_DMA_INIT_PRIORITY,
 		    &pax_dma_driver_api);

--- a/drivers/dma/dma_iproc_pax_v2.c
+++ b/drivers/dma/dma_iproc_pax_v2.c
@@ -1111,5 +1111,5 @@ DEVICE_DT_INST_DEFINE(0,
 		    &pax_dma_data,
 		    &pax_dma_cfg,
 		    POST_KERNEL,
-		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    CONFIG_DMA_INIT_PRIORITY,
 		    &pax_dma_driver_api);

--- a/drivers/dma/dma_mcux_edma.c
+++ b/drivers/dma/dma_mcux_edma.c
@@ -456,7 +456,7 @@ struct dma_mcux_edma_data dma_data;
  */
 DEVICE_DT_INST_DEFINE(0, &dma_mcux_edma_init, NULL,
 		    &dma_data, &dma_config_0, POST_KERNEL,
-		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &dma_mcux_edma_api);
+		    CONFIG_DMA_INIT_PRIORITY, &dma_mcux_edma_api);
 
 void dma_imx_config_func_0(const struct device *dev)
 {

--- a/drivers/dma/dma_mcux_lpc.c
+++ b/drivers/dma/dma_mcux_lpc.c
@@ -561,7 +561,7 @@ static const struct dma_mcux_lpc_config dma_##n##_config = {	\
 			    &dma_mcux_lpc_init,				\
 			    NULL,					\
 			    &dma_data_##n, &dma_##n##_config,\
-			    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,\
+			    POST_KERNEL, CONFIG_DMA_INIT_PRIORITY,	\
 			    &dma_mcux_lpc_api);			\
 									\
 	DMA_MCUX_LPC_CONFIG_FUNC(n)				\

--- a/drivers/dma/dma_nios2_msgdma.c
+++ b/drivers/dma/dma_nios2_msgdma.c
@@ -235,4 +235,4 @@ static struct nios2_msgdma_dev_cfg dma0_nios2_config = {
 
 DEVICE_DT_INST_DEFINE(0, &nios2_msgdma0_initialize,
 		NULL, NULL, &dma0_nios2_config, POST_KERNEL,
-		CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &nios2_msgdma_driver_api);
+		CONFIG_DMA_INIT_PRIORITY, &nios2_msgdma_driver_api);

--- a/drivers/dma/dma_pl330.c
+++ b/drivers/dma/dma_pl330.c
@@ -590,5 +590,5 @@ static struct dma_pl330_dev_data pl330_data;
 
 DEVICE_DT_INST_DEFINE(0, &dma_pl330_initialize, NULL,
 		    &pl330_data, &pl330_config,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    POST_KERNEL, CONFIG_DMA_INIT_PRIORITY,
 		    &pl330_driver_api);

--- a/drivers/dma/dma_sam0.c
+++ b/drivers/dma/dma_sam0.c
@@ -459,4 +459,4 @@ static const struct dma_driver_api dma_sam0_api = {
 
 DEVICE_DT_INST_DEFINE(0, &dma_sam0_init, NULL,
 		    &dmac_data, NULL, PRE_KERNEL_1,
-		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &dma_sam0_api);
+		    CONFIG_DMA_INIT_PRIORITY, &dma_sam0_api);

--- a/drivers/dma/dma_sam_xdmac.c
+++ b/drivers/dma/dma_sam_xdmac.c
@@ -380,4 +380,4 @@ static struct sam_xdmac_dev_data dma0_sam_data;
 
 DEVICE_DT_INST_DEFINE(0, &sam_xdmac_initialize, NULL,
 		    &dma0_sam_data, &dma0_sam_config, POST_KERNEL,
-		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &sam_xdmac_driver_api);
+		    CONFIG_DMA_INIT_PRIORITY, &sam_xdmac_driver_api);

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -682,7 +682,7 @@ DEVICE_DT_INST_DEFINE(index,						\
 		    &dma_stm32_init,					\
 		    NULL,						\
 		    &dma_stm32_data_##index, &dma_stm32_config_##index,	\
-		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
+		    PRE_KERNEL_1, CONFIG_DMA_INIT_PRIORITY,		\
 		    &dma_funcs)
 
 #ifdef CONFIG_DMA_STM32_SHARED_IRQS

--- a/drivers/dma/dmamux_stm32.c
+++ b/drivers/dma/dmamux_stm32.c
@@ -316,7 +316,7 @@ DEVICE_DT_INST_DEFINE(index,						\
 		    &dmamux_stm32_init,					\
 		    NULL,						\
 		    &dmamux_stm32_data_##index, &dmamux_stm32_config_##index,\
-		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
+		    PRE_KERNEL_1, CONFIG_DMA_INIT_PRIORITY,		\
 		    &dma_funcs);
 
 DT_INST_FOREACH_STATUS_OKAY(DMAMUX_INIT)


### PR DESCRIPTION
Refactors all of the display and DMA drivers to use shared driver class initialization priority configurations to allow configuring each driver class separately from other devices. This is similar to other driver classes like I2C and SPI.