### PR TITLE
checkpatch: ignore NEW_TYPEDEFS

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -29,4 +29,5 @@
 --ignore MULTISTATEMENT_MACRO_USE_DO_WHILE
 --ignore ENOSYS
 --ignore IS_ENABLED_CONFIG
+--ignore NEW_TYPEDEFS
 --exclude ext


### PR DESCRIPTION
A warning that almost always override, so lets just ignore it, it does
not apply to Zephyr at all.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
