### PR TITLE
sys: Fix warning for stripped const qualifier

### DIFF
--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -253,7 +253,7 @@ static inline void bytecpy(void *dst, const void *src, size_t size)
 	size_t i;
 
 	for (i = 0; i < size; ++i) {
-		((uint8_t *)dst)[i] = ((uint8_t *)src)[i];
+		((uint8_t *)dst)[i] = ((const uint8_t *)src)[i];
 	}
 }
 


### PR DESCRIPTION
This causes an issue when compiling with `-Werror=cast-qual`