### PR TITLE
drivers: sensor: lsm6dsl: convert to use spi_dt_spec and i2c_dt_spec

### DIFF
--- a/drivers/sensor/lsm6dsl/lsm6dsl.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl.c
@@ -780,13 +780,6 @@ static int lsm6dsl_init_chip(const struct device *dev)
 static int lsm6dsl_init(const struct device *dev)
 {
 	const struct lsm6dsl_config * const config = dev->config;
-	struct lsm6dsl_data *data = dev->data;
-
-	data->bus = device_get_binding(config->bus_name);
-	if (!data->bus) {
-		LOG_DBG("master not found: %s", config->bus_name);
-		return -EINVAL;
-	}
 
 	config->bus_init(dev);
 
@@ -836,44 +829,6 @@ static int lsm6dsl_init(const struct device *dev)
  * Instantiation macros used when a device is on a SPI bus.
  */
 
-#define LSM6DSL_HAS_CS(inst) DT_INST_SPI_DEV_HAS_CS_GPIOS(inst)
-
-#define LSM6DSL_DATA_SPI_CS(inst)					\
-	{ .cs_ctrl = {							\
-		.gpio_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(inst),		\
-		.gpio_dt_flags = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(inst),	\
-		},							\
-	}
-
-#define LSM6DSL_DATA_SPI(inst)						\
-	COND_CODE_1(LSM6DSL_HAS_CS(inst),				\
-		    (LSM6DSL_DATA_SPI_CS(inst)),			\
-		    ({}))
-
-#define LSM6DSL_SPI_CS_PTR(inst)					\
-	COND_CODE_1(LSM6DSL_HAS_CS(inst),				\
-		    (&(lsm6dsl_data_##inst.cs_ctrl)),			\
-		    (NULL))
-
-#define LSM6DSL_SPI_CS_LABEL(inst)					\
-	COND_CODE_1(LSM6DSL_HAS_CS(inst),				\
-		    (DT_INST_SPI_DEV_CS_GPIOS_LABEL(inst)), (NULL))
-
-#define LSM6DSL_SPI_CFG(inst)						\
-	(&(struct lsm6dsl_spi_cfg) {					\
-		.spi_conf = {						\
-			.frequency =					\
-				DT_INST_PROP(inst, spi_max_frequency),	\
-			.operation = (SPI_WORD_SET(8) |			\
-				      SPI_OP_MODE_MASTER |		\
-				      SPI_MODE_CPOL |			\
-				      SPI_MODE_CPHA),			\
-			.slave = DT_INST_REG_ADDR(inst),		\
-			.cs = LSM6DSL_SPI_CS_PTR(inst),			\
-		},							\
-		.cs_gpios_label = LSM6DSL_SPI_CS_LABEL(inst),		\
-	})
-
 #ifdef CONFIG_LSM6DSL_TRIGGER
 #define LSM6DSL_CFG_IRQ(inst) \
 		.irq_dev_name = DT_INST_GPIO_LABEL(inst, irq_gpios),	\
@@ -883,18 +838,19 @@ static int lsm6dsl_init(const struct device *dev)
 #define LSM6DSL_CFG_IRQ(inst)
 #endif /* CONFIG_LSM6DSL_TRIGGER */
 
-#define LSM6DSL_CONFIG_SPI(inst)					\
-	{								\
-		.bus_name = DT_INST_BUS_LABEL(inst),			\
-		.bus_init = lsm6dsl_spi_init,				\
-		.bus_cfg = { .spi_cfg = LSM6DSL_SPI_CFG(inst)	},	\
-		COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, irq_gpios),	\
-		(LSM6DSL_CFG_IRQ(inst)), ())				\
+#define LSM6DSL_CONFIG_SPI(inst)						\
+	{									\
+		.bus_init = lsm6dsl_spi_init,					\
+		.bus_cfg.spi = SPI_DT_SPEC_INST_GET(inst, SPI_WORD_SET(8) |	\
+				      SPI_OP_MODE_MASTER |			\
+				      SPI_MODE_CPOL |				\
+				      SPI_MODE_CPHA, 0),			\
+		COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, irq_gpios),		\
+		(LSM6DSL_CFG_IRQ(inst)), ())					\
 	}
 
 #define LSM6DSL_DEFINE_SPI(inst)					\
-	static struct lsm6dsl_data lsm6dsl_data_##inst =		\
-		LSM6DSL_DATA_SPI(inst);					\
+	static struct lsm6dsl_data lsm6dsl_data_##inst;			\
 	static const struct lsm6dsl_config lsm6dsl_config_##inst =	\
 		LSM6DSL_CONFIG_SPI(inst);				\
 	LSM6DSL_DEVICE_INIT(inst)
@@ -905,9 +861,8 @@ static int lsm6dsl_init(const struct device *dev)
 
 #define LSM6DSL_CONFIG_I2C(inst)					\
 	{								\
-		.bus_name = DT_INST_BUS_LABEL(inst),			\
 		.bus_init = lsm6dsl_i2c_init,				\
-		.bus_cfg = { .i2c_slv_addr = DT_INST_REG_ADDR(inst), },	\
+		.bus_cfg.i2c = I2C_DT_SPEC_INST_GET(inst),		\
 		COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, irq_gpios),	\
 		(LSM6DSL_CFG_IRQ(inst)), ())				\
 	}

--- a/drivers/sensor/lsm6dsl/lsm6dsl.h
+++ b/drivers/sensor/lsm6dsl/lsm6dsl.h
@@ -611,25 +611,17 @@
 #define LSM6DSL_GYRO_ODR_RUNTIME 1
 #endif
 
-#if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
-struct lsm6dsl_spi_cfg {
-	struct spi_config spi_conf;
-	const char *cs_gpios_label;
-};
-#endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(spi) */
-
 union lsm6dsl_bus_cfg {
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
-	uint16_t i2c_slv_addr;
+	struct i2c_dt_spec i2c;
 #endif
 
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
-	const struct lsm6dsl_spi_cfg *spi_cfg;
+	struct spi_dt_spec spi;
 #endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(spi) */
 };
 
 struct lsm6dsl_config {
-	char *bus_name;
 	int (*bus_init)(const struct device *dev);
 	const union lsm6dsl_bus_cfg bus_cfg;
 #ifdef CONFIG_LSM6DSL_TRIGGER
@@ -653,11 +645,6 @@ struct lsm6dsl_transfer_function {
 };
 
 struct lsm6dsl_data {
-	const struct device *bus;
-#if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
-	struct spi_cs_control cs_ctrl;
-#endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(spi) */
-
 	int accel_sample_x;
 	int accel_sample_y;
 	int accel_sample_z;

--- a/drivers/sensor/lsm6dsl/lsm6dsl_i2c.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl_i2c.c
@@ -21,43 +21,33 @@ LOG_MODULE_DECLARE(LSM6DSL, CONFIG_SENSOR_LOG_LEVEL);
 static int lsm6dsl_i2c_read_data(const struct device *dev, uint8_t reg_addr,
 				 uint8_t *value, uint8_t len)
 {
-	struct lsm6dsl_data *data = dev->data;
 	const struct lsm6dsl_config *cfg = dev->config;
 
-	return i2c_burst_read(data->bus, cfg->bus_cfg.i2c_slv_addr,
-			      reg_addr, value, len);
+	return i2c_burst_read_dt(&cfg->bus_cfg.i2c, reg_addr, value, len);
 }
 
 static int lsm6dsl_i2c_write_data(const struct device *dev, uint8_t reg_addr,
 				  uint8_t *value, uint8_t len)
 {
-	struct lsm6dsl_data *data = dev->data;
 	const struct lsm6dsl_config *cfg = dev->config;
 
-	return i2c_burst_write(data->bus, cfg->bus_cfg.i2c_slv_addr,
-			       reg_addr, value, len);
+	return i2c_burst_write_dt(&cfg->bus_cfg.i2c, reg_addr, value, len);
 }
 
 static int lsm6dsl_i2c_read_reg(const struct device *dev, uint8_t reg_addr,
 				uint8_t *value)
 {
-	struct lsm6dsl_data *data = dev->data;
 	const struct lsm6dsl_config *cfg = dev->config;
 
-	return i2c_reg_read_byte(data->bus,
-				 cfg->bus_cfg.i2c_slv_addr,
-				 reg_addr, value);
+	return i2c_reg_read_byte_dt(&cfg->bus_cfg.i2c, reg_addr, value);
 }
 
 static int lsm6dsl_i2c_update_reg(const struct device *dev, uint8_t reg_addr,
 				uint8_t mask, uint8_t value)
 {
-	struct lsm6dsl_data *data = dev->data;
 	const struct lsm6dsl_config *cfg = dev->config;
 
-	return i2c_reg_update_byte(data->bus,
-				  cfg->bus_cfg.i2c_slv_addr,
-				  reg_addr, mask, value);
+	return i2c_reg_update_byte_dt(&cfg->bus_cfg.i2c, reg_addr, mask, value);
 }
 
 
@@ -71,8 +61,13 @@ static const struct lsm6dsl_transfer_function lsm6dsl_i2c_transfer_fn = {
 int lsm6dsl_i2c_init(const struct device *dev)
 {
 	struct lsm6dsl_data *data = dev->data;
+	const struct lsm6dsl_config *cfg = dev->config;
 
 	data->hw_tf = &lsm6dsl_i2c_transfer_fn;
+
+	if (!device_is_ready(cfg->bus_cfg.i2c.bus)) {
+		return -ENODEV;
+	}
 
 	return 0;
 }

--- a/drivers/sensor/lsm6dsl/lsm6dsl_spi.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl_spi.c
@@ -23,9 +23,7 @@ LOG_MODULE_DECLARE(LSM6DSL, CONFIG_SENSOR_LOG_LEVEL);
 static int lsm6dsl_raw_read(const struct device *dev, uint8_t reg_addr,
 			    uint8_t *value, uint8_t len)
 {
-	struct lsm6dsl_data *data = dev->data;
 	const struct lsm6dsl_config *cfg = dev->config;
-	const struct spi_config *spi_cfg = &cfg->bus_cfg.spi_cfg->spi_conf;
 	uint8_t buffer_tx[2] = { reg_addr | LSM6DSL_SPI_READ, 0 };
 	const struct spi_buf tx_buf = {
 			.buf = buffer_tx,
@@ -55,7 +53,7 @@ static int lsm6dsl_raw_read(const struct device *dev, uint8_t reg_addr,
 		return -EIO;
 	}
 
-	if (spi_transceive(data->bus, spi_cfg, &tx, &rx)) {
+	if (spi_transceive_dt(&cfg->bus_cfg.spi, &tx, &rx)) {
 		return -EIO;
 	}
 
@@ -65,9 +63,7 @@ static int lsm6dsl_raw_read(const struct device *dev, uint8_t reg_addr,
 static int lsm6dsl_raw_write(const struct device *dev, uint8_t reg_addr,
 			     uint8_t *value, uint8_t len)
 {
-	struct lsm6dsl_data *data = dev->data;
 	const struct lsm6dsl_config *cfg = dev->config;
-	const struct spi_config *spi_cfg = &cfg->bus_cfg.spi_cfg->spi_conf;
 	uint8_t buffer_tx[1] = { reg_addr & ~LSM6DSL_SPI_READ };
 	const struct spi_buf tx_buf[2] = {
 		{
@@ -89,7 +85,7 @@ static int lsm6dsl_raw_write(const struct device *dev, uint8_t reg_addr,
 		return -EIO;
 	}
 
-	if (spi_write(data->bus, spi_cfg, &tx)) {
+	if (spi_write_dt(&cfg->bus_cfg.spi, &tx)) {
 		return -EIO;
 	}
 
@@ -136,22 +132,11 @@ int lsm6dsl_spi_init(const struct device *dev)
 {
 	struct lsm6dsl_data *data = dev->data;
 	const struct lsm6dsl_config *cfg = dev->config;
-	const struct lsm6dsl_spi_cfg *spi_cfg = cfg->bus_cfg.spi_cfg;
 
 	data->hw_tf = &lsm6dsl_spi_transfer_fn;
 
-	if (spi_cfg->cs_gpios_label != NULL) {
-
-		/* handle SPI CS thru GPIO if it is the case */
-		data->cs_ctrl.gpio_dev =
-			    device_get_binding(spi_cfg->cs_gpios_label);
-		if (!data->cs_ctrl.gpio_dev) {
-			LOG_ERR("Unable to get GPIO SPI CS device");
-			return -ENODEV;
-		}
-
-		LOG_DBG("SPI GPIO CS configured on %s:%u",
-			spi_cfg->cs_gpios_label, data->cs_ctrl.gpio_pin);
+	if (!spi_is_ready(&cfg->bus_cfg.spi)) {
+		return -ENODEV;
 	}
 
 	return 0;


### PR DESCRIPTION
Convert lsm6dsl driver to use `spi_dt_spec` and `i2c_dt_spec` helpers.

Signed-off-by: Bartosz Bilas <b.bilas@grinn-global.com>

EDIT::
MR has been tested using MIMXRT1060-EVK + STEVAL-MKI89V1 connected via I2C. Regarding the SPI I rely on the buildkite results only.

uart:~$ sensor get LSM6DSL
channel idx=0 accel_x =  -9.214000
channel idx=1 accel_y =  -0.690000
channel idx=2 accel_z =   2.467000
channel idx=3 accel_xyz x =  -9.214000 y =  -0.690000 z =   2.467000
channel idx=4 gyro_x =   0.655000
channel idx=5 gyro_y =   0.281000
channel idx=6 gyro_z =   0.912000
channel idx=7 gyro_xyz x =   0.655000 y =   0.281000 z =   0.912000