### PR TITLE
drivers: spi_context: Fix timeout in slave mode and handling of zero-length buffers

### DIFF
--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -318,10 +318,10 @@ void spi_context_buffers_setup(struct spi_context *ctx,
 #endif /* CONFIG_SPI_SLAVE */
 
 	LOG_DBG("current_tx %p (%zu), current_rx %p (%zu),"
-		    " tx buf/len %p/%zu, rx buf/len %p/%zu",
-		    ctx->current_tx, ctx->tx_count,
-		    ctx->current_rx, ctx->rx_count,
-		    ctx->tx_buf, ctx->tx_len, ctx->rx_buf, ctx->rx_len);
+		" tx buf/len %p/%zu, rx buf/len %p/%zu",
+		ctx->current_tx, ctx->tx_count,
+		ctx->current_rx, ctx->rx_count,
+		ctx->tx_buf, ctx->tx_len, ctx->rx_buf, ctx->rx_len);
 }
 
 static ALWAYS_INLINE

--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -272,6 +272,25 @@ static inline void spi_context_unlock_unconditionally(struct spi_context *ctx)
 	}
 }
 
+static inline void *spi_context_get_next_buf(const struct spi_buf **current,
+					     size_t *count,
+					     size_t *buf_len,
+					     uint8_t dfs)
+{
+	/* This loop skips zero-length buffers in the set, if any. */
+	while (*count) {
+		if (((*current)->len / dfs) != 0) {
+			*buf_len = (*current)->len / dfs;
+			return (*current)->buf;
+		}
+		++(*current);
+		--(*count);
+	}
+
+	*buf_len = 0;
+	return NULL;
+}
+
 static inline
 void spi_context_buffers_setup(struct spi_context *ctx,
 			       const struct spi_buf_set *tx_bufs,
@@ -280,29 +299,17 @@ void spi_context_buffers_setup(struct spi_context *ctx,
 {
 	LOG_DBG("tx_bufs %p - rx_bufs %p - %u", tx_bufs, rx_bufs, dfs);
 
-	if (tx_bufs) {
-		ctx->current_tx = tx_bufs->buffers;
-		ctx->tx_count = tx_bufs->count;
-		ctx->tx_buf = (const uint8_t *)ctx->current_tx->buf;
-		ctx->tx_len = ctx->current_tx->len / dfs;
-	} else {
-		ctx->current_tx = NULL;
-		ctx->tx_count = 0;
-		ctx->tx_buf = NULL;
-		ctx->tx_len = 0;
-	}
+	ctx->current_tx = tx_bufs ? tx_bufs->buffers : NULL;
+	ctx->tx_count = ctx->current_tx ? tx_bufs->count : 0;
+	ctx->tx_buf = (const uint8_t *)
+		spi_context_get_next_buf(&ctx->current_tx, &ctx->tx_count,
+					 &ctx->tx_len, dfs);
 
-	if (rx_bufs) {
-		ctx->current_rx = rx_bufs->buffers;
-		ctx->rx_count = rx_bufs->count;
-		ctx->rx_buf = (uint8_t *)ctx->current_rx->buf;
-		ctx->rx_len = ctx->current_rx->len / dfs;
-	} else {
-		ctx->current_rx = NULL;
-		ctx->rx_count = 0;
-		ctx->rx_buf = NULL;
-		ctx->rx_len = 0;
-	}
+	ctx->current_rx = rx_bufs ? rx_bufs->buffers : NULL;
+	ctx->rx_count = ctx->current_rx ? rx_bufs->count : 0;
+	ctx->rx_buf = (uint8_t *)
+		spi_context_get_next_buf(&ctx->current_rx, &ctx->rx_count,
+					 &ctx->rx_len, dfs);
 
 	ctx->sync_status = 0;
 
@@ -331,14 +338,13 @@ void spi_context_update_tx(struct spi_context *ctx, uint8_t dfs, uint32_t len)
 
 	ctx->tx_len -= len;
 	if (!ctx->tx_len) {
-		ctx->tx_count--;
-		if (ctx->tx_count) {
-			ctx->current_tx++;
-			ctx->tx_buf = (const uint8_t *)ctx->current_tx->buf;
-			ctx->tx_len = ctx->current_tx->len / dfs;
-		} else {
-			ctx->tx_buf = NULL;
-		}
+		/* Current buffer is done. Get the next one to be processed. */
+		++ctx->current_tx;
+		--ctx->tx_count;
+		ctx->tx_buf = (const uint8_t *)
+			spi_context_get_next_buf(&ctx->current_tx,
+						 &ctx->tx_count,
+						 &ctx->tx_len, dfs);
 	} else if (ctx->tx_buf) {
 		ctx->tx_buf += dfs * len;
 	}
@@ -379,14 +385,13 @@ void spi_context_update_rx(struct spi_context *ctx, uint8_t dfs, uint32_t len)
 
 	ctx->rx_len -= len;
 	if (!ctx->rx_len) {
-		ctx->rx_count--;
-		if (ctx->rx_count) {
-			ctx->current_rx++;
-			ctx->rx_buf = (uint8_t *)ctx->current_rx->buf;
-			ctx->rx_len = ctx->current_rx->len / dfs;
-		} else {
-			ctx->rx_buf = NULL;
-		}
+		/* Current buffer is done. Get the next one to be processed. */
+		++ctx->current_rx;
+		--ctx->rx_count;
+		ctx->rx_buf = (uint8_t *)
+			spi_context_get_next_buf(&ctx->current_rx,
+						 &ctx->rx_count,
+						 &ctx->rx_len, dfs);
 	} else if (ctx->rx_buf) {
 		ctx->rx_buf += dfs * len;
 	}

--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -128,22 +128,34 @@ static inline void spi_context_release(struct spi_context *ctx, int status)
 static inline int spi_context_wait_for_completion(struct spi_context *ctx)
 {
 	int status = 0;
-	uint32_t timeout_ms;
+	k_timeout_t timeout;
 
-	timeout_ms = MAX(ctx->tx_len, ctx->rx_len) * 8 * 1000 /
-		     ctx->config->frequency;
-	timeout_ms += CONFIG_SPI_COMPLETION_TIMEOUT_TOLERANCE;
+	/* Do not use any timeout in the slave mode, as in this case it is not
+	 * known when the transfer will actually start and what the frequency
+	 * will be.
+	 */
+	if (IS_ENABLED(CONFIG_SPI_SLAVE) && spi_context_is_slave(ctx)) {
+		timeout = K_FOREVER;
+	} else {
+		uint32_t timeout_ms;
+
+		timeout_ms = MAX(ctx->tx_len, ctx->rx_len) * 8 * 1000 /
+			     ctx->config->frequency;
+		timeout_ms += CONFIG_SPI_COMPLETION_TIMEOUT_TOLERANCE;
+
+		timeout = K_MSEC(timeout_ms);
+	}
 
 #ifdef CONFIG_SPI_ASYNC
 	if (!ctx->asynchronous) {
-		if (k_sem_take(&ctx->sync, K_MSEC(timeout_ms))) {
+		if (k_sem_take(&ctx->sync, timeout)) {
 			LOG_ERR("Timeout waiting for transfer complete");
 			return -ETIMEDOUT;
 		}
 		status = ctx->sync_status;
 	}
 #else
-	if (k_sem_take(&ctx->sync, K_MSEC(timeout_ms))) {
+	if (k_sem_take(&ctx->sync, timeout)) {
 		LOG_ERR("Timeout waiting for transfer complete");
 		return -ETIMEDOUT;
 	}


### PR DESCRIPTION
_drivers: spi_context: Do not use transfer timeout in slave mode_

Do not use any timeout in the slave mode, as in this case it is not
known when the transfer will actually start and what the frequency
will be.

Fixes #39609.

_drivers: spi_context: Fix handling of zero-length buffers_

In some cases, it is quite useful to have the possibility to also
include zero-length buffers in a buffer set used in transfers
(for example, when frames in a protocol consist of several parts,
of which some are optional). So far, the behavior of spi_context
update functions was that the transfer in a given direction was
finished when a zero-length buffer was encountered in the buffer
set. Change those functions to simply skip such buffers. Correct
in the same way also the spi_context_buffers_setup() function.

Fixes #39594.