### PR TITLE
Bluetooth: shell: Fix uninitalized values for iso big create

### DIFF
--- a/subsys/bluetooth/shell/iso.c
+++ b/subsys/bluetooth/shell/iso.c
@@ -417,6 +417,8 @@ static int cmd_big_create(const struct shell *sh, size_t argc, char *argv[])
 	param.bis_channels = bis_channels;
 	param.num_bis = BIS_ISO_CHAN_COUNT;
 	param.encryption = false;
+	param.packing = BT_ISO_PACKING_SEQUENTIAL;
+	param.framing = BT_ISO_FRAMING_UNFRAMED;
 
 	if (argc > 1) {
 		if (!strcmp(argv[1], "enc")) {
@@ -431,6 +433,8 @@ static int cmd_big_create(const struct shell *sh, size_t argc, char *argv[])
 			shell_help(sh);
 			return SHELL_CMD_HELP_PRINTED;
 		}
+	} else {
+		memset(param.bcode, 0, sizeof(param.bcode));
 	}
 
 	err = bt_iso_big_create(adv, &param, &big);


### PR DESCRIPTION
A few values were not initialized when creating a
big in the iso shell.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

fixes https://github.com/zephyrproject-rtos/zephyr/issues/39857