### PR TITLE
net: sockets: tls: Fix TCP disconnect detection in poll()

### DIFF
--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -2088,6 +2088,8 @@ static int ztls_socket_data_check(struct tls_context *ctx)
 
 		/* Treat any other error as fatal. */
 		return -EIO;
+	} else if (ret == 0 && ctx->type == SOCK_STREAM) {
+		return -ENOTCONN;
 	}
 
 	return mbedtls_ssl_get_bytes_avail(&ctx->ssl);


### PR DESCRIPTION
`ztls_socket_data_check()` function ignored a fact when
`mbedtls_ssl_read()` indicated that the underlying TCP connection was
closed. Fix this by returning `-ENOTCONN` in such case, allowing
`poll()` to detect such event.

Fixes #39660

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>