### PR TITLE
manifest: Update CANopenNode to include v1.3 heartbeat consumer fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -26,7 +26,7 @@ manifest:
   # Please add items below based on alphabetical order
   projects:
     - name: canopennode
-      revision: f167efe85c8c7de886f1bc47f9173cfb8a346bb5
+      revision: 1052dae561497bef901f931ef75e117c9224aecd
       path: modules/lib/canopennode
     - name: civetweb
       revision: 094aeb41bb93e9199d24d665ee43e9e05d6d7b1c


### PR DESCRIPTION
Update the CANopenNode library to latest upstream branch v1.3-master to bring in hearbeat consumer fixes.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>