### PR TITLE
twister: Reword exception text when zephyr toolchain is not found

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -2898,7 +2898,7 @@ class TestSuite(DisablePyTestCollectionMixin):
 
         try:
             if result['returncode']:
-                raise TwisterRuntimeError("E: Variable ZEPHYR_TOOLCHAIN_VARIANT is not defined")
+                raise TwisterRuntimeError("E: Unable to locate zephyr toolchain. Check the variable ZEPHYR_TOOLCHAIN_VARIANT.")
         except Exception as e:
             print(str(e))
             sys.exit(2)


### PR DESCRIPTION
Reword exception text to cover the scenario where the variable
ZEPHYR_TOOLCHAIN_VARIANT was set but was pointing to a location where
no zephyr toolchain was found.

Signed-off-by: Balaji Srinivasan <balaji.srinivasan@nordicsemi.no>