### PR TITLE
drivers: pwm: mcux: ftm: return -EBUSY if PWM capture in progress

### DIFF
--- a/drivers/pwm/pwm_mcux_ftm.c
+++ b/drivers/pwm/pwm_mcux_ftm.c
@@ -228,8 +228,8 @@ static int mcux_ftm_pin_enable_capture(const struct device *dev, uint32_t pwm)
 	}
 
 	if (FTM_GetEnabledInterrupts(config->base) & BIT(PAIR_2ND_CH(pair))) {
-		LOG_WRN("Capture already active on channel pair %d", pair);
-		return 0;
+		LOG_ERR("Capture already active on channel pair %d", pair);
+		return -EBUSY;
 	}
 
 	FTM_ClearStatusFlags(config->base, BIT(PAIR_1ST_CH(pair)) |


### PR DESCRIPTION
Return -EBUSY (not 0) from pwm_pin_enable_capture() if PWM capture is already in progress.

Fixes: #39817

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>