### PR TITLE
net: lwm2m: Fix meaningless operant result coverity issue

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_util.c
+++ b/subsys/net/lib/lwm2m/lwm2m_util.c
@@ -347,7 +347,7 @@ int lwm2m_atof(const char *input, double *out)
 
 	errno = 0;
 	val = strtol(buf, &end, 10);
-	if (errno || *end || val < INT_MIN) {
+	if (errno || *end) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
There is no need to veirfy the result value of the strtol() operation,
as we copy the result to a 64 bit buffer anyway.

CID: 240696

Fixes #39810

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>