### PR TITLE
scripts: gen_relocate_app: check if argument matches

### DIFF
--- a/scripts/gen_relocate_app.py
+++ b/scripts/gen_relocate_app.py
@@ -399,6 +399,9 @@ def create_dict_wrt_mem():
     if args.input_rel_dict == '':
         sys.exit("Disable CONFIG_CODE_DATA_RELOCATION if no file needs relocation")
     for line in args.input_rel_dict.split(';'):
+        if ':' not in line:
+            continue
+
         mem_region, file_name = line.split(':', 1)
 
         file_name_list = glob.glob(file_name)


### PR DESCRIPTION
Check each line whether contains the correct pattern ${location}:${file} before splitting because it
turns out that script passes also compile definitions added in project CMakeLists.txt such as:

`add_compile_definitions(ABCD="XYZ")`

which results in the following failure:

<pre>
[241/253] Generating code_relocation.c, include/generated/linker_relocate.ld
Traceback (most recent call last):
  File "/home/bartekk/zephyr/scripts/gen_relocate_app.py", line 465, in <module>
    main()
  File "/home/bartekk/zephyr/scripts/gen_relocate_app.py", line 430, in main
    rel_dict = create_dict_wrt_mem()
  File "/home/bartekk/zephyr/scripts/gen_relocate_app.py", line 404, in create_dict_wrt_mem
    mem_region, file_name = line.split(':', 1)
ValueError: not enough values to unpack (expected 2, got 1)
ninja: build stopped: subcommand failed.
</pre>

because `args.input_rel_dict.split(';')` contains

<pre>
['ITCM_TEXT:/home/bartekk/zephyr-builds-test/zephyr/drivers/memc/memc_mcux_flexspi.c',
'ITCM_TEXT:/home/bartekk/zephyr-builds-test/modules/hal/nxp/mcux/drivers/imx/fsl_flexspi.c',
'ABCD=XYZ']
</pre>

Signed-off-by: Bartosz Bilas <b.bilas@grinn-global.com>