### PR TITLE
tests: net: net_pkt: Verify unchecked net_pkt functions results

### DIFF
--- a/tests/net/net_pkt/src/main.c
+++ b/tests/net/net_pkt/src/main.c
@@ -874,12 +874,14 @@ void test_net_pkt_headroom_copy(void)
 	struct net_pkt *pkt_dst;
 	struct net_buf *frag1_dst;
 	struct net_buf *frag2_dst;
+	int res;
 
 	/* Create et_pkt containing the bytes "0123" */
 	pkt_src = net_pkt_alloc_with_buffer(eth_if, 4,
 					AF_UNSPEC, 0, K_NO_WAIT);
 	zassert_true(pkt_src != NULL, "Pkt not allocated");
-	net_pkt_write(pkt_src, "0123", 4);
+	res = net_pkt_write(pkt_src, "0123", 4);
+	zassert_equal(res, 0, "Pkt write failed");
 
 	/* Create net_pkt consisting of net_buf fragments with reserved bytes */
 	pkt_dst = net_pkt_alloc_on_iface(eth_if, K_NO_WAIT);
@@ -899,7 +901,8 @@ void test_net_pkt_headroom_copy(void)
 	/* Copy to net_pkt which contains fragments with reserved bytes */
 	net_pkt_cursor_init(pkt_src);
 	net_pkt_cursor_init(pkt_dst);
-	net_pkt_copy(pkt_dst, pkt_src, 4);
+	res = net_pkt_copy(pkt_dst, pkt_src, 4);
+	zassert_equal(res, 0, "Pkt copy failed");
 	zassert_equal(net_pkt_available_buffer(pkt_dst), 0, "Wrong space left");
 	zassert_equal(net_pkt_get_len(pkt_dst), 4, "Length missmatch");
 


### PR DESCRIPTION
Some net_pkt functions in `test_net_pkt_headroom_copy()` did not have
their return values verified, causing coverity complains.

CID: 240661

Fixes #39841

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>