### PR TITLE
tests: bluetooth: tester: Fix not marking chan as unused on disconnect

### DIFF
--- a/tests/bluetooth/tester/src/l2cap.c
+++ b/tests/bluetooth/tester/src/l2cap.c
@@ -133,6 +133,8 @@ static void disconnected_cb(struct bt_l2cap_chan *l2cap_chan)
 		}
 	}
 
+	chan->in_use = false;
+
 	tester_send(BTP_SERVICE_ID_L2CAP, L2CAP_EV_DISCONNECTED,
 		    CONTROLLER_INDEX, (uint8_t *) &ev, sizeof(ev));
 }


### PR DESCRIPTION
This fix not being able to re-connect channel after disconnect.

Signed-off-by: Szymon Janc <szymon.janc@codecoup.pl>