### PR TITLE
scripts: gen_relocate_app: fix C0201 pylint warning

### DIFF
--- a/scripts/gen_relocate_app.py
+++ b/scripts/gen_relocate_app.py
@@ -251,7 +251,7 @@ def string_create_helper(region, memory_type,
         else:
             if memory_type != 'SRAM' and region == 'rodata':
                 align_size = 0
-                if memory_type in mpu_align.keys():
+                if memory_type in mpu_align:
                     align_size = mpu_align[memory_type]
 
                 linker_string += LINKER_SECTION_SEQ_MPU.format(memory_type.lower(), region, memory_type.upper(),


### PR DESCRIPTION
As pylint says "Consider iterating the dictionary directly instead of calling .keys()" don't use .keys() method.

Signed-off-by: Bartosz Bilas <bartosz.bilas@hotmail.com>