### PR TITLE
drivers: ieee802154_rf2xx: convert to use spi_dt_spec

### DIFF
--- a/drivers/ieee802154/ieee802154_rf2xx.h
+++ b/drivers/ieee802154/ieee802154_rf2xx.h
@@ -80,13 +80,6 @@ struct rf2xx_dt_gpio_t {
 	uint32_t flags;
 };
 
-struct rf2xx_dt_spi_t {
-	const char *devname;
-	uint32_t freq;
-	uint32_t addr;
-	struct rf2xx_dt_gpio_t cs;
-};
-
 struct rf2xx_config {
 	struct rf2xx_dt_gpio_t irq;
 	struct rf2xx_dt_gpio_t reset;
@@ -94,7 +87,7 @@ struct rf2xx_config {
 	struct rf2xx_dt_gpio_t dig2;
 	struct rf2xx_dt_gpio_t clkm;
 
-	struct rf2xx_dt_spi_t spi;
+	struct spi_dt_spec spi;
 
 	uint8_t inst;
 	uint8_t has_mac;
@@ -110,10 +103,6 @@ struct rf2xx_context {
 	const struct device *slptr_gpio;
 	const struct device *dig2_gpio;
 	const struct device *clkm_gpio;
-
-	const struct device *spi;
-	struct spi_config spi_cfg;
-	struct spi_cs_control spi_cs;
 
 	struct gpio_callback irq_cb;
 

--- a/drivers/ieee802154/ieee802154_rf2xx_iface.c
+++ b/drivers/ieee802154/ieee802154_rf2xx_iface.c
@@ -56,7 +56,7 @@ void rf2xx_iface_phy_tx_start(const struct device *dev)
 uint8_t rf2xx_iface_reg_read(const struct device *dev,
 			     uint8_t addr)
 {
-	const struct rf2xx_context *ctx = dev->data;
+	const struct rf2xx_config *conf = dev->config;
 	uint8_t status;
 	uint8_t regval = 0;
 
@@ -85,7 +85,7 @@ uint8_t rf2xx_iface_reg_read(const struct device *dev,
 		.count = 2
 	};
 
-	if (spi_transceive(ctx->spi, &ctx->spi_cfg, &tx, &rx) != 0) {
+	if (spi_transceive_dt(&conf->spi, &tx, &rx) != 0) {
 		LOG_ERR("Failed to exec rf2xx_reg_read CMD at address %d",
 			addr);
 	}
@@ -100,7 +100,7 @@ void rf2xx_iface_reg_write(const struct device *dev,
 			   uint8_t addr,
 			   uint8_t data)
 {
-	const struct rf2xx_context *ctx = dev->data;
+	const struct rf2xx_config *conf = dev->config;
 	uint8_t status;
 
 	addr |= RF2XX_RF_CMD_REG_W;
@@ -128,7 +128,7 @@ void rf2xx_iface_reg_write(const struct device *dev,
 		.count = 1
 	};
 
-	if (spi_transceive(ctx->spi, &ctx->spi_cfg, &tx, &rx) != 0) {
+	if (spi_transceive_dt(&conf->spi, &tx, &rx) != 0) {
 		LOG_ERR("Failed to exec rf2xx_reg_write at address %d",
 			addr);
 	}
@@ -171,7 +171,7 @@ void rf2xx_iface_frame_read(const struct device *dev,
 			    uint8_t *data,
 			    uint8_t length)
 {
-	const struct rf2xx_context *ctx = dev->data;
+	const struct rf2xx_config *conf = dev->config;
 	uint8_t cmd = RF2XX_RF_CMD_FRAME_R;
 
 	const struct spi_buf tx_buf = {
@@ -191,7 +191,7 @@ void rf2xx_iface_frame_read(const struct device *dev,
 		.count = 1
 	};
 
-	if (spi_transceive(ctx->spi, &ctx->spi_cfg, &tx, &rx) != 0) {
+	if (spi_transceive_dt(&conf->spi, &tx, &rx) != 0) {
 		LOG_ERR("Failed to exec rf2xx_frame_read PHR");
 	}
 
@@ -203,7 +203,7 @@ void rf2xx_iface_frame_write(const struct device *dev,
 			     uint8_t *data,
 			     uint8_t length)
 {
-	const struct rf2xx_context *ctx = dev->data;
+	const struct rf2xx_config *conf = dev->config;
 	uint8_t cmd = RF2XX_RF_CMD_FRAME_W;
 	uint8_t status;
 	uint8_t phr;
@@ -242,7 +242,7 @@ void rf2xx_iface_frame_write(const struct device *dev,
 		.count = 1
 	};
 
-	if (spi_transceive(ctx->spi, &ctx->spi_cfg, &tx, &rx) != 0) {
+	if (spi_transceive_dt(&conf->spi, &tx, &rx) != 0) {
 		LOG_ERR("Failed to exec rf2xx_frame_write");
 	}
 
@@ -255,7 +255,7 @@ void rf2xx_iface_sram_read(const struct device *dev,
 			    uint8_t *data,
 			    uint8_t length)
 {
-	const struct rf2xx_context *ctx = dev->data;
+	const struct rf2xx_config *conf = dev->config;
 	uint8_t cmd = RF2XX_RF_CMD_SRAM_R;
 	uint8_t status[2];
 
@@ -288,7 +288,7 @@ void rf2xx_iface_sram_read(const struct device *dev,
 		.count = 2
 	};
 
-	if (spi_transceive(ctx->spi, &ctx->spi_cfg, &tx, &rx) != 0) {
+	if (spi_transceive_dt(&conf->spi, &tx, &rx) != 0) {
 		LOG_ERR("Failed to exec rf2xx_sram_read");
 	}
 


### PR DESCRIPTION
Convert ieee802154_rf2xx driver to use `spi_dt_spec` helpers.

Signed-off-by: Bartosz Bilas <bartosz.bilas@hotmail.com>