### PR TITLE
sys: Fix warning for stripped const qualifier

### DIFF
--- a/include/fatal.h
+++ b/include/fatal.h
@@ -14,6 +14,10 @@
 #include <arch/cpu.h>
 #include <toolchain.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @defgroup fatal_apis Fatal error APIs
  * @ingroup kernel_apis
@@ -99,5 +103,9 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *esf);
 void z_fatal_error(unsigned int reason, const z_arch_esf_t *esf);
 
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZEPHYR_INCLUDE_FATAL_H */

--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -549,7 +549,7 @@ enum log_strdup_action {
 static inline uint32_t log_const_source_id(
 				const struct log_source_const_data *data)
 {
-	return ((uint8_t *)data - (uint8_t *)__log_const_start)/
+	return ((const uint8_t *)data - (uint8_t *)__log_const_start)/
 			sizeof(struct log_source_const_data);
 }
 

--- a/include/logging/log_msg2.h
+++ b/include/logging/log_msg2.h
@@ -496,7 +496,7 @@ static inline void z_log_msg2_runtime_create(uint8_t domain_id,
 	va_end(ap);
 }
 
-static inline bool z_log_item_is_msg(union log_msg2_generic *msg)
+static inline bool z_log_item_is_msg(const union log_msg2_generic *msg)
 {
 	return msg->generic.type == Z_LOG_MSG2_LOG;
 }
@@ -520,10 +520,10 @@ static inline uint32_t log_msg2_get_total_wlen(const struct log_msg2_desc desc)
  */
 static inline uint32_t log_msg2_generic_get_wlen(const union mpsc_pbuf_generic *item)
 {
-	union log_msg2_generic *generic_msg = (union log_msg2_generic *)item;
+	const union log_msg2_generic *generic_msg = (const union log_msg2_generic *)item;
 
 	if (z_log_item_is_msg(generic_msg)) {
-		struct log_msg2 *msg = (struct log_msg2 *)generic_msg;
+		const struct log_msg2 *msg = (const struct log_msg2 *)generic_msg;
 
 		return log_msg2_get_total_wlen(msg->hdr.desc);
 	}

--- a/include/logging/log_msg2.h
+++ b/include/logging/log_msg2.h
@@ -28,7 +28,7 @@ extern "C" {
 #define LOG_MSG2_DEBUG 0
 #define LOG_MSG2_DBG(...) IF_ENABLED(LOG_MSG2_DEBUG, (printk(__VA_ARGS__)))
 
-#if CONFIG_LOG_TIMESTAMP_64BIT
+#ifdef CONFIG_LOG_TIMESTAMP_64BIT
 typedef uint64_t log_timestamp_t;
 #else
 typedef uint32_t log_timestamp_t;
@@ -137,7 +137,7 @@ enum z_log_msg2_mode {
 /* Messages are aligned to alignment required by cbprintf package. */
 #define Z_LOG_MSG2_ALIGNMENT CBPRINTF_PACKAGE_ALIGNMENT
 
-#if CONFIG_LOG2_USE_VLA
+#ifdef CONFIG_LOG2_USE_VLA
 #define Z_LOG_MSG2_ON_STACK_ALLOC(ptr, len) \
 	long long _ll_buf[ceiling_fraction(len, sizeof(long long))]; \
 	long double _ld_buf[ceiling_fraction(len, sizeof(long double))]; \
@@ -235,7 +235,7 @@ do { \
 	z_log_msg2_static_create((void *)_source, _desc, _msg->data, _data); \
 } while (0)
 
-#if CONFIG_LOG_SPEED
+#ifdef CONFIG_LOG_SPEED
 #define Z_LOG_MSG2_SIMPLE_CREATE(_domain_id, _source, _level, ...) do { \
 	int _plen; \
 	CBPRINTF_STATIC_PACKAGE(NULL, 0, _plen, Z_LOG_MSG2_ALIGN_OFFSET, \
@@ -343,7 +343,7 @@ do { \
  *
  * @param ...  Optional string with arguments (fmt, ...). It may be empty.
  */
-#if CONFIG_LOG2_ALWAYS_RUNTIME
+#ifdef CONFIG_LOG2_ALWAYS_RUNTIME
 #define Z_LOG_MSG2_CREATE2(_try_0cpy, _mode,  _cstr_cnt, _domain_id, _source,\
 			  _level, _data, _dlen, ...) \
 do {\
@@ -353,7 +353,7 @@ do {\
 				  Z_LOG_FMT_ARGS(_fmt, ##__VA_ARGS__));\
 	_mode = Z_LOG_MSG2_MODE_RUNTIME; \
 } while (0)
-#elif CONFIG_LOG2_MODE_IMMEDIATE /* CONFIG_LOG2_ALWAYS_RUNTIME */
+#elif defined(CONFIG_LOG2_MODE_IMMEDIATE) /* CONFIG_LOG2_ALWAYS_RUNTIME */
 #define Z_LOG_MSG2_CREATE2(_try_0cpy, _mode,  _cstr_cnt, _domain_id, _source,\
 			  _level, _data, _dlen, ...) \
 do { \

--- a/include/sys/__assert.h
+++ b/include/sys/__assert.h
@@ -8,6 +8,7 @@
 #define ZEPHYR_INCLUDE_SYS___ASSERT_H_
 
 #include <stdbool.h>
+#include <sys/printk.h>
 
 #ifdef CONFIG_ASSERT
 #ifndef __ASSERT_ON

--- a/include/sys/cbprintf_cxx.h
+++ b/include/sys/cbprintf_cxx.h
@@ -11,6 +11,7 @@
 /* C++ version for detecting a pointer to a string. */
 static inline int z_cbprintf_cxx_is_pchar(char *, bool const_as_fixed)
 {
+	ARG_UNUSED(const_as_fixed);
 	return 1;
 }
 

--- a/include/sys/cbprintf_cxx.h
+++ b/include/sys/cbprintf_cxx.h
@@ -57,6 +57,7 @@ static inline int z_cbprintf_cxx_is_pchar(const volatile wchar_t *, bool const_a
 template < typename T >
 static inline int z_cbprintf_cxx_is_pchar(T arg, bool const_as_fixed)
 {
+	ARG_UNUSED(arg);
 	_Pragma("GCC diagnostic push")
 	_Pragma("GCC diagnostic ignored \"-Wpointer-arith\"")
 	ARG_UNUSED(const_as_fixed);

--- a/include/sys/cbprintf_internal.h
+++ b/include/sys/cbprintf_internal.h
@@ -315,7 +315,7 @@ union z_cbprintf_hdr {
  * if argument is a stirng literal. Suppression is added here instead of
  * the macro which generates the warning to not slow down the compiler.
  */
-#if __clang__ == 1
+#ifdef __clang__
 #define Z_CBPRINTF_SUPPRESS_SIZEOF_ARRAY_DECAY \
 	_Pragma("GCC diagnostic ignored \"-Wsizeof-array-decay\"")
 #else

--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -253,7 +253,7 @@ static inline void bytecpy(void *dst, const void *src, size_t size)
 	size_t i;
 
 	for (i = 0; i < size; ++i) {
-		((uint8_t *)dst)[i] = ((uint8_t *)src)[i];
+		((uint8_t *)dst)[i] = ((const uint8_t *)src)[i];
 	}
 }
 


### PR DESCRIPTION
Fix several errors caused by adding stricter warnings used by pigweed

Signed-off-by: Yuval Peress <peress@google.com>