### PR TITLE
lorawan: run dr changed callback on manual update

### DIFF
--- a/include/lorawan/lorawan.h
+++ b/include/lorawan/lorawan.h
@@ -161,8 +161,10 @@ void lorawan_register_downlink_callback(struct lorawan_downlink_cb *cb);
 /**
  * @brief Register a callback to be called when the datarate changes
  *
- * The callback is called once upon successfully joining a network and again
- * each time the datarate changes due to ADR.
+ * The callback is called in the following situations:
+ *     * Upon successfully joining a network.
+ *     * Each time the datarate changes due to ADR.
+ *     * When the datarate is changed by a call to @ref lorawan_set_datarate.
  *
  * The callback function takes one parameter:
  *	- dr - updated datarate

--- a/subsys/lorawan/lorawan.c
+++ b/subsys/lorawan/lorawan.c
@@ -394,6 +394,11 @@ int lorawan_set_datarate(enum lorawan_datarate dr)
 		return -EINVAL;
 	}
 
+	/* Run DR callback if datarate was changed */
+	if (dr_change_cb && (current_datarate != dr)) {
+		dr_change_cb(dr);
+	}
+
 	default_datarate = dr;
 	current_datarate = dr;
 


### PR DESCRIPTION
Also run the callback given to `lorawan_register_dr_changed_callback`
when the datarate is manually changed in non-ADR mode by a call to
`lorawan_set_datarate`. Code that needs to be notified of changes to
datarates may be logically distinct from the code performing the change.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>