### PR TITLE
lora: Use generic node name "lora" for all lora nodes

### DIFF
--- a/boards/arm/96b_wistrio/96b_wistrio.dts
+++ b/boards/arm/96b_wistrio/96b_wistrio.dts
@@ -106,7 +106,7 @@
 	status = "okay";
 	cs-gpios = <&gpiob 0 GPIO_ACTIVE_LOW>;
 
-	lora: sx1276@0 {
+	lora: lora@0 {
 		compatible = "semtech,sx1276";
 		reg = <0>;
 		label = "sx1276";

--- a/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.dts
+++ b/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.dts
@@ -119,7 +119,7 @@ arduino_i2c: &i2c1 {};
 	status = "okay";
 	cs-gpios = <&gpioa 15 GPIO_ACTIVE_LOW>;
 
-	lora: sx1276@0 {
+	lora: lora@0 {
 		compatible = "semtech,sx1276";
 		reg = <0>;
 		label = "sx1276";

--- a/boards/arm/rak4631_nrf52840/rak4631_nrf52840.dts
+++ b/boards/arm/rak4631_nrf52840/rak4631_nrf52840.dts
@@ -102,7 +102,7 @@
 	pinctrl-0 = <&spi1_default>;
 	pinctrl-1 = <&spi1_sleep>;
 	pinctrl-names = "default", "sleep";
-	lora: sx1262@0 {
+	lora: lora@0 {
 		compatible = "semtech,sx1262";
 		reg = <0>;
 		label = "sx1262";

--- a/boards/shields/semtech_sx1272mb2das/semtech_sx1272mb2das.overlay
+++ b/boards/shields/semtech_sx1272mb2das/semtech_sx1272mb2das.overlay
@@ -15,7 +15,7 @@
 
 	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;	/* D10 */
 
-	lora: sx1272@0 {
+	lora: lora@0 {
 		compatible = "semtech,sx1272";
 		reg = <0x0>;
 		label = "sx1272";

--- a/dts/arm/acsip/s76s.dtsi
+++ b/dts/arm/acsip/s76s.dtsi
@@ -15,7 +15,7 @@
 	cs-gpios = <&gpiob 12 GPIO_ACTIVE_LOW>;
 	status = "okay";
 
-	lora: sx1276@0 {
+	lora: lora@0 {
 		compatible = "semtech,sx1276";
 		reg = <0>;
 		label = "sx1276";


### PR DESCRIPTION
The current devicetree specification (master branch [1]) lists "lora" as a
generic node name. Hence, all devicetree files in Zephyr should use the same.
    
~~As a result of this change, we no longer need an alias for LoRa and the
applications can now use DT_NODELABEL for getting the node identifiers instead
of DT_ALIAS.~~
    
[1] https://github.com/devicetree-org/devicetree-specification/blob/main/source/chapter2-devicetree-basics.rst
    
Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>