### PR TITLE
tests: kernel: disable for qemu_cortex_a9

### DIFF
--- a/tests/kernel/fatal/exception/testcase.yaml
+++ b/tests/kernel/fatal/exception/testcase.yaml
@@ -21,4 +21,6 @@ tests:
     tags: kernel ignore_faults userspace
   kernel.common.stack_sentinel:
     extra_args: CONF_FILE=sentinel.conf
+    # FIXME: See issue #39948
+    platform_exclude: qemu_cortex_a9
     tags: kernel ignore_faults


### PR DESCRIPTION
Currently this test [is failing](https://buildkite.com/zephyr/zephyr/builds/44959)

```
twister -i -p qemu_cortex_a9 -s tests/kernel/fatal/exception/kernel.common.stack_sentinel
```

Disable temporarily until a fix is in place.