### PR TITLE
net: lwm2m: Way to pass a destination hostname to socket 

### DIFF
--- a/include/net/lwm2m.h
+++ b/include/net/lwm2m.h
@@ -75,6 +75,11 @@ struct lwm2m_ctx {
 	/** Destination address storage */
 	struct sockaddr remote_addr;
 
+	/** When MBEDTLS SNI is enabled socket must be set with destination
+	 *  hostname server.
+	 */
+	char *desthostname;
+
 	/** Private CoAP and networking structures */
 	struct coap_pending pendings[CONFIG_LWM2M_ENGINE_MAX_PENDING];
 	struct coap_reply replies[CONFIG_LWM2M_ENGINE_MAX_REPLIES];
@@ -98,6 +103,7 @@ struct lwm2m_ctx {
 	 *  the default behavior of load_tls_credential() in lwm2m_engine.c
 	 */
 	int (*load_credentials)(struct lwm2m_ctx *client_ctx);
+
 #endif
 	/** Flag to indicate if context should use DTLS.
 	 *  Enabled via the use of coaps:// protocol prefix in connection

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -4697,6 +4697,16 @@ int lwm2m_socket_start(struct lwm2m_ctx *client_ctx)
 			lwm2m_engine_context_close(client_ctx);
 			return -errno;
 		}
+
+#if defined(CONFIG_MBEDTLS_SERVER_NAME_INDICATION)
+		ret = setsockopt(client_ctx->sock_fd, SOL_TLS, TLS_HOSTNAME,
+				client_ctx->desthostname, strlen(client_ctx->desthostname));
+		if (ret < 0){
+			LOG_ERR("Failed to set TLS_HOSTNAME option: %d",
+							errno);
+			return -errno;
+		}
+#endif
 	}
 #endif /* CONFIG_LWM2M_DTLS_SUPPORT */
 
@@ -4716,7 +4726,8 @@ int lwm2m_socket_start(struct lwm2m_ctx *client_ctx)
 	return lwm2m_socket_add(client_ctx);
 }
 
-int lwm2m_parse_peerinfo(char *url, struct sockaddr *addr, bool *use_dtls, bool is_firmware_uri)
+int lwm2m_parse_peerinfo(char *url, struct sockaddr *addr, bool *use_dtls,
+		char *desthostname,	bool is_firmware_uri)
 {
 	struct http_parser_url parser;
 #if defined(CONFIG_LWM2M_DNS_SUPPORT)
@@ -4772,6 +4783,8 @@ int lwm2m_parse_peerinfo(char *url, struct sockaddr *addr, bool *use_dtls, bool 
 	/* truncate host portion */
 	tmp = url[off + len];
 	url[off + len] = '\0';
+
+	memcpy(desthostname, url + off, len);
 
 	/* initialize addr */
 	(void)memset(addr, 0, sizeof(*addr));
@@ -4848,7 +4861,7 @@ int lwm2m_engine_start(struct lwm2m_ctx *client_ctx)
 
 	url[url_len] = '\0';
 	ret = lwm2m_parse_peerinfo(url, &client_ctx->remote_addr,
-				   &client_ctx->use_dtls, false);
+				   &client_ctx->use_dtls, client_ctx->desthostname, false);
 	if (ret < 0) {
 		return ret;
 	}

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -4701,7 +4701,7 @@ int lwm2m_socket_start(struct lwm2m_ctx *client_ctx)
 #if defined(CONFIG_MBEDTLS_SERVER_NAME_INDICATION)
 		ret = setsockopt(client_ctx->sock_fd, SOL_TLS, TLS_HOSTNAME,
 				client_ctx->desthostname, strlen(client_ctx->desthostname));
-		if (ret < 0){
+		if (ret < 0) {
 			LOG_ERR("Failed to set TLS_HOSTNAME option: %d",
 							errno);
 			return -errno;

--- a/subsys/net/lib/lwm2m/lwm2m_engine.h
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.h
@@ -144,6 +144,7 @@ const char *lwm2m_engine_get_attr_name(const struct lwm2m_attr *attr);
 int  lwm2m_socket_add(struct lwm2m_ctx *ctx);
 void lwm2m_socket_del(struct lwm2m_ctx *ctx);
 int  lwm2m_socket_start(struct lwm2m_ctx *client_ctx);
-int  lwm2m_parse_peerinfo(char *url, struct sockaddr *addr, bool *use_dtls, bool is_firmware_uri);
+int  lwm2m_parse_peerinfo(char *url, struct sockaddr *addr, bool *use_dtls, 
+							char *desthostname, bool is_firmware_uri);
 
 #endif /* LWM2M_ENGINE_H */

--- a/subsys/net/lib/lwm2m/lwm2m_engine.h
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.h
@@ -144,7 +144,6 @@ const char *lwm2m_engine_get_attr_name(const struct lwm2m_attr *attr);
 int  lwm2m_socket_add(struct lwm2m_ctx *ctx);
 void lwm2m_socket_del(struct lwm2m_ctx *ctx);
 int  lwm2m_socket_start(struct lwm2m_ctx *client_ctx);
-int  lwm2m_parse_peerinfo(char *url, struct sockaddr *addr, bool *use_dtls, 
-							char *desthostname, bool is_firmware_uri);
+int  lwm2m_parse_peerinfo(char *url, struct sockaddr *addr, bool *use_dtls, char *desthostname, bool is_firmware_uri);
 
 #endif /* LWM2M_ENGINE_H */

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
@@ -387,7 +387,7 @@ static void firmware_transfer(void)
 #endif
 
 	ret = lwm2m_parse_peerinfo(server_addr, &firmware_ctx.remote_addr,
-				   &firmware_ctx.use_dtls, true);
+				   &firmware_ctx.use_dtls, firmware_ctx.desthostname, true);
 	if (ret < 0) {
 		LOG_ERR("Failed to parse server URI.");
 		goto error;


### PR DESCRIPTION
net: lwm2m: When mbedtls CONFIG_MBEDTLS_SERVER_NAME_INDICATION is enabled, a destination hostname must be passed to socket to properly connect do lwm2m server.