### PR TITLE
xenvm: drivers: xen: add new Xen-related features (event channels, irq console and consoleio Dom0 console)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -345,6 +345,7 @@
 /drivers/serial/serial_test.c             @str4t0m
 /drivers/serial/Kconfig.xen               @lorc @firscity
 /drivers/serial/uart_hvc_xen.c            @lorc @firscity
+/drivers/serial/uart_hvc_xen_consoleio.c  @lorc @firscity
 /drivers/serial/Kconfig.it8xxx2           @GTLin08
 /drivers/serial/uart_ite_it8xxx2.c        @GTLin08
 /drivers/disk/                            @jfischer-no

--- a/arch/arm64/core/xen/CMakeLists.txt
+++ b/arch/arm64/core/xen/CMakeLists.txt
@@ -8,3 +8,4 @@ zephyr_compile_options($<$<COMPILE_LANGUAGE:ASM>:-D__ASSEMBLY__>)
 zephyr_compile_options(-D__XEN_INTERFACE_VERSION__=0x00040e00)
 
 zephyr_library_sources(hypercall.S)
+zephyr_library_sources(enlighten.c)

--- a/arch/arm64/core/xen/enlighten.c
+++ b/arch/arm64/core/xen/enlighten.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2021 EPAM Systems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <arch/arm64/hypercall.h>
+#include <xen/events.h>
+#include <xen/generic.h>
+#include <xen/public/xen.h>
+#include <xen/public/memory.h>
+
+#include <device.h>
+#include <init.h>
+#include <kernel.h>
+#include <kernel/thread.h>
+#include <logging/log.h>
+
+LOG_MODULE_REGISTER(xen_enlighten);
+
+/*
+ * During Xen Enlighten initialization we need to have allocated memory page,
+ * where hypervisor shared_info will be mapped. k_aligned_alloc() is not
+ * available on PRE_KERNEL_1 stage, so we will use statically allocated buffer,
+ * which will be casted to 'struct shared_info'. It is needed to initialize Xen
+ * event channels as soon as possible after start.
+ */
+static uint8_t shared_info_buf[XEN_PAGE_SIZE] __aligned(XEN_PAGE_SIZE);
+
+/* Remains NULL until mapping will be finished by Xen */
+shared_info_t *HYPERVISOR_shared_info;
+
+static int xen_map_shared_info(const shared_info_t *shared_page)
+{
+	struct xen_add_to_physmap xatp;
+
+	xatp.domid = DOMID_SELF;
+	xatp.idx = 0;
+	xatp.space = XENMAPSPACE_shared_info;
+	xatp.gpfn = (((xen_pfn_t) shared_page) >> XEN_PAGE_SHIFT);
+
+	return HYPERVISOR_memory_op(XENMEM_add_to_physmap, &xatp);
+}
+
+static int xen_enlighten_init(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+	int ret = 0;
+	shared_info_t *info = (shared_info_t *) shared_info_buf;
+
+	ret = xen_map_shared_info(info);
+	if (ret) {
+		LOG_ERR("%s: failed to map for Xen shared page, ret = %d\n",
+			__func__, ret);
+		return ret;
+	}
+
+	/* Set value for globally visible pointer */
+	HYPERVISOR_shared_info = info;
+
+	ret = xen_events_init();
+	if (ret) {
+		LOG_ERR("%s: failed init Xen event channels, ret = %d\n",
+			__func__, ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+SYS_INIT(xen_enlighten_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);

--- a/boards/arm64/xenvm/Kconfig.defconfig
+++ b/boards/arm64/xenvm/Kconfig.defconfig
@@ -6,6 +6,12 @@ if BOARD_XENVM
 config BUILD_OUTPUT_BIN
 	default y
 
+config XEN_INITIAL_DOMAIN
+	bool "Zephyr as Xen Domain 0"
+	default n
+	help
+	  Built binary will be used as Xen privileged domain.
+
 config BOARD
 	default "xenvm"
 

--- a/boards/arm64/xenvm/doc/index.rst
+++ b/boards/arm64/xenvm/doc/index.rst
@@ -78,16 +78,15 @@ configuration by altering device tree and Kconfig options. This will be covered
 in detail in next section.
 
 Most of Xen-specific features are not supported at the moment. This includes:
-
-* Xen Enlighten memory page (under development)
-* XenBus
-* Xen event channels (under development)
-* Xen grant tables
+* XenBus (under development)
+* Xen grant tables (under development)
 * Xen PV drivers
 
 Now only following features are supported:
-* Xen PV console (UART-like driver with poll API, IRQ driven is under development)
-* Xen early console_io interface (mainly for debug purposes)
+* Xen Enlighten memory page
+* Xen event channels (currently only pre-defined - PV console, Xenbus)
+* Xen PV console (2 versions: regular ring buffer based for DomU and consoleio for Dom0)
+* Xen early console_io interface (mainly for debug purposes - requires debug version of Xen)
 
 Building and Running
 ********************

--- a/drivers/serial/CMakeLists.txt
+++ b/drivers/serial/CMakeLists.txt
@@ -45,6 +45,7 @@ zephyr_library_sources_ifdef(CONFIG_UART_XEC uart_mchp_xec.c)
 zephyr_library_sources_ifdef(CONFIG_UART_NEORV32 uart_neorv32.c)
 zephyr_library_sources_ifdef(CONFIG_USART_GD32 usart_gd32.c)
 zephyr_library_sources_ifdef(CONFIG_UART_XEN_HVC uart_hvc_xen.c)
+zephyr_library_sources_ifdef(CONFIG_UART_XEN_HVC_CONSOLEIO uart_hvc_xen_consoleio.c)
 
 zephyr_library_sources_ifdef(CONFIG_USERSPACE   uart_handlers.c)
 

--- a/drivers/serial/Kconfig.xen
+++ b/drivers/serial/Kconfig.xen
@@ -7,6 +7,7 @@
 config UART_XEN_HVC
 	bool "Xen hypervisor console UART Driver"
 	select SERIAL_HAS_DRIVER
+	select SERIAL_SUPPORT_INTERRUPT
 	depends on BOARD_XENVM
 	default y
 	help

--- a/drivers/serial/Kconfig.xen
+++ b/drivers/serial/Kconfig.xen
@@ -5,17 +5,29 @@
 #
 
 config UART_XEN_HVC
-	bool "Xen hypervisor console UART Driver"
+	bool "Xen hypervisor DomU console UART driver"
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
 	depends on BOARD_XENVM
+	depends on !XEN_INITIAL_DOMAIN
 	default y
 	help
-	  Enable Xen hypervisor console driver.
+	  Enable Xen ring buffer based hypervisor console driver. Used
+	  for Zephyr as unprivileged domain.
+
+config UART_XEN_HVC_CONSOLEIO
+	bool "Xen hypervisor Dom0 console UART driver"
+	select SERIAL_HAS_DRIVER
+	depends on BOARD_XENVM
+	depends on XEN_INITIAL_DOMAIN
+	default y
+	help
+	  Enable Xen hypervisor console driver. Used for Zephyr as
+	  privileged domain (Dom0).
 
 config XEN_HVC_INIT_PRIORITY
 	int "Xen hypervisor console init priority"
-	depends on UART_XEN_HVC
+	depends on UART_XEN_HVC || UART_XEN_HVC_CONSOLEIO
 	default 55
 	help
 	  Set init priority for Xen HVC, should be inited before UART
@@ -24,6 +36,7 @@ config XEN_HVC_INIT_PRIORITY
 config XEN_EARLY_CONSOLEIO
 	bool "Early printk/stdout through console_io Xen interface"
 	depends on BOARD_XENVM
+	depends on UART_XEN_HVC
 	default n
 	help
 	  Enable setting of console_io symbol hook for stdout and printk.

--- a/drivers/serial/uart_hvc_xen.c
+++ b/drivers/serial/uart_hvc_xen.c
@@ -10,6 +10,7 @@
 #include <xen/generic.h>
 #include <xen/hvm.h>
 #include <xen/public/io/console.h>
+#include <xen/public/sched.h>
 #include <xen/public/xen.h>
 
 #include <device.h>
@@ -21,6 +22,10 @@
 LOG_MODULE_REGISTER(uart_hvc_xen);
 
 static struct hvc_xen_data hvc_data = {0};
+
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+static void hvc_uart_evtchn_cb(void *priv);
+#endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 
 static int read_from_ring(const struct device *dev, char *str, int len)
 {
@@ -100,10 +105,124 @@ static void xen_hvc_poll_out(const struct device *dev,
 	(void) write_to_ring(dev, &c, sizeof(c));
 }
 
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+static int xen_hvc_fifo_fill(const struct device *dev, const uint8_t *tx_data,
+			 int len)
+{
+	int ret = 0, sent = 0;
+
+	while (len) {
+		sent = write_to_ring(dev, tx_data, len);
+
+		ret += sent;
+		tx_data += sent;
+		len -= sent;
+
+		if (len) {
+			/* Need to be able to read it from another domain */
+			HYPERVISOR_sched_op(SCHEDOP_yield, NULL);
+		}
+	}
+
+	return ret;
+}
+
+static int xen_hvc_fifo_read(const struct device *dev, uint8_t *rx_data,
+			 const int size)
+{
+	return read_from_ring(dev, rx_data, size);
+}
+
+static void xen_hvc_irq_tx_enable(const struct device *dev)
+{
+	/*
+	 * Need to explicitly call UART callback on TX enabling to
+	 * process available buffered TX actions, because no HV events
+	 * will be generated on tx_enable.
+	 */
+	hvc_uart_evtchn_cb(dev->data);
+}
+
+static int xen_hvc_irq_tx_ready(const struct device *dev)
+{
+	return 1;
+}
+
+static void xen_hvc_irq_rx_enable(const struct device *dev)
+{
+	/*
+	 * Need to explicitly call UART callback on RX enabling to
+	 * process available buffered RX actions, because no HV events
+	 * will be generated on rx_enable.
+	 */
+	hvc_uart_evtchn_cb(dev->data);
+}
+
+static int xen_hvc_irq_tx_complete(const struct device *dev)
+{
+	/*
+	 * TX is performed by copying in ring buffer by fifo_fill,
+	 * so it will be always completed.
+	 */
+	return 1;
+}
+
+static int xen_hvc_irq_rx_ready(const struct device *dev)
+{
+	struct hvc_xen_data *data = dev->data;
+
+	/* RX is ready only if data is available in ring buffer */
+	return (data->intf->in_prod != data->intf->in_cons);
+}
+
+static int xen_hvc_irq_is_pending(const struct device *dev)
+{
+	return xen_hvc_irq_rx_ready(dev);
+}
+
+static int xen_hvc_irq_update(const struct device *dev)
+{
+	/* Nothing needs to be updated before actual ISR */
+	return 1;
+}
+
+static void xen_hvc_irq_callback_set(const struct device *dev,
+		 uart_irq_callback_user_data_t cb, void *user_data)
+{
+	struct hvc_xen_data *data = dev->data;
+
+	data->irq_cb = cb;
+	data->irq_cb_data = user_data;
+}
+#endif /* CONFIG_UART_INTERRUPT_DRIVEN */
+
 static const struct uart_driver_api xen_hvc_api = {
 	.poll_in = xen_hvc_poll_in,
 	.poll_out = xen_hvc_poll_out,
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	.fifo_fill = xen_hvc_fifo_fill,
+	.fifo_read = xen_hvc_fifo_read,
+	.irq_tx_enable = xen_hvc_irq_tx_enable,
+	.irq_tx_ready = xen_hvc_irq_tx_ready,
+	.irq_rx_enable = xen_hvc_irq_rx_enable,
+	.irq_tx_complete = xen_hvc_irq_tx_complete,
+	.irq_rx_ready = xen_hvc_irq_rx_ready,
+	.irq_is_pending = xen_hvc_irq_is_pending,
+	.irq_update = xen_hvc_irq_update,
+	.irq_callback_set = xen_hvc_irq_callback_set,
+#endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 };
+
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+static void hvc_uart_evtchn_cb(void *priv)
+{
+	struct hvc_xen_data *data = priv;
+
+	if (data->irq_cb) {
+		data->irq_cb(data->dev, data->irq_cb_data);
+	}
+}
+#endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 
 int xen_console_init(const struct device *dev)
 {
@@ -133,6 +252,10 @@ int xen_console_init(const struct device *dev)
 		K_MEM_CACHE_WB);
 
 	data->intf = (struct xencons_interface *) DEVICE_MMIO_GET(dev);
+
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	bind_event_channel(data->evtchn, hvc_uart_evtchn_cb, data);
+#endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 
 	LOG_INF("Xen HVC inited successfully\n");
 

--- a/drivers/serial/uart_hvc_xen_consoleio.c
+++ b/drivers/serial/uart_hvc_xen_consoleio.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2021 EPAM Systems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This driver implements input/output API for Xen domain through the
+ * Xen consoleio interface. This should be used only for Zephyr as initial
+ * domain (Dom0). For unprivileged domains regular ring buffer HVC driver
+ * should be used (uart_hvc_xen.c), this console will not be available.
+ */
+
+#include <arch/arm64/hypercall.h>
+#include <xen/public/xen.h>
+
+#include <device.h>
+#include <drivers/uart.h>
+#include <init.h>
+#include <kernel.h>
+
+static int xen_consoleio_poll_in(const struct device *dev,
+			unsigned char *c)
+{
+	int ret = 0;
+	char temp;
+
+	ret = HYPERVISOR_console_io(CONSOLEIO_read, sizeof(temp), &temp);
+	if (!ret) {
+		/* Char was not received */
+		return -1;
+	}
+
+	*c = temp;
+	return 0;
+}
+
+static void xen_consoleio_poll_out(const struct device *dev,
+			unsigned char c)
+{
+	(void) HYPERVISOR_console_io(CONSOLEIO_write, sizeof(c), &c);
+}
+
+static const struct uart_driver_api xen_consoleio_hvc_api = {
+	.poll_in = xen_consoleio_poll_in,
+	.poll_out = xen_consoleio_poll_out,
+};
+
+int xen_consoleio_init(const struct device *dev)
+{
+	/* Nothing to do, but still needed for device API */
+	return 0;
+}
+
+DEVICE_DT_DEFINE(DT_NODELABEL(xen_consoleio_hvc), xen_consoleio_init, NULL, NULL,
+		NULL, PRE_KERNEL_1, CONFIG_XEN_HVC_INIT_PRIORITY,
+		&xen_consoleio_hvc_api);

--- a/drivers/xen/events.c
+++ b/drivers/xen/events.c
@@ -9,17 +9,176 @@
 #include <xen/public/event_channel.h>
 #include <xen/events.h>
 
+#include <errno.h>
+#include <kernel.h>
+#include <logging/log.h>
+
+LOG_MODULE_REGISTER(xen_events);
+
+extern shared_info_t *HYPERVISOR_shared_info;
+
+static evtchn_handle_t event_channels[EVTCHN_2L_NR_CHANNELS];
+
+static void empty_callback(void *data) { }
+
 void notify_evtchn(evtchn_port_t port)
 {
 	struct evtchn_send send;
 
-	if (port >= EVTCHN_2L_NR_CHANNELS) {
-		printk("%s: trying to send notify for invalid evtchn #%u\n",
-				__func__, port);
-		return;
-	}
+	__ASSERT(port < EVTCHN_2L_NR_CHANNELS,
+		"%s: trying to send notify for invalid evtchn #%u\n",
+		__func__, port);
 
 	send.port = port;
 
 	HYPERVISOR_event_channel_op(EVTCHNOP_send, &send);
+}
+
+int bind_event_channel(evtchn_port_t port, evtchn_cb_t cb, void *data)
+{
+	__ASSERT(port < EVTCHN_2L_NR_CHANNELS,
+		"%s: trying to bind invalid evtchn #%u\n",
+		__func__, port);
+	__ASSERT(cb != NULL, "%s: NULL callback for evtchn #%u\n",
+		__func__, port);
+
+
+	if (event_channels[port].cb != empty_callback)
+		LOG_WRN("%s: re-bind callback for evtchn #%u\n",
+				__func__, port);
+
+	event_channels[port].priv = data;
+	event_channels[port].cb = cb;
+
+	return 0;
+}
+
+int unbind_event_channel(evtchn_port_t port)
+{
+	__ASSERT(port < EVTCHN_2L_NR_CHANNELS,
+		"%s: trying to unbind invalid evtchn #%u\n",
+		__func__, port);
+
+	event_channels[port].cb = empty_callback;
+	event_channels[port].priv = NULL;
+
+	return 0;
+}
+
+int mask_event_channel(evtchn_port_t port)
+{
+	shared_info_t *s = HYPERVISOR_shared_info;
+
+	__ASSERT(port < EVTCHN_2L_NR_CHANNELS,
+		"%s: trying to mask invalid evtchn #%u\n",
+		__func__, port);
+
+
+	sys_bitfield_set_bit((mem_addr_t) s->evtchn_mask, port);
+
+	return 0;
+}
+
+int unmask_event_channel(evtchn_port_t port)
+{
+	shared_info_t *s = HYPERVISOR_shared_info;
+
+	__ASSERT(port < EVTCHN_2L_NR_CHANNELS,
+		"%s: trying to unmask invalid evtchn #%u\n",
+		__func__, port);
+
+	sys_bitfield_clear_bit((mem_addr_t) s->evtchn_mask, port);
+
+	return 0;
+}
+
+static void clear_event_channel(evtchn_port_t port)
+{
+	shared_info_t *s = HYPERVISOR_shared_info;
+
+	sys_bitfield_clear_bit((mem_addr_t) s->evtchn_pending, port);
+}
+
+static inline xen_ulong_t get_pending_events(xen_ulong_t pos)
+{
+	shared_info_t *s = HYPERVISOR_shared_info;
+
+	return (s->evtchn_pending[pos] & ~(s->evtchn_mask[pos]));
+}
+
+static void process_event(evtchn_port_t port)
+{
+	evtchn_handle_t channel = event_channels[port];
+
+	clear_event_channel(port);
+	channel.cb(channel.priv);
+}
+
+static void events_isr(void *data)
+{
+	ARG_UNUSED(data);
+
+	/* Needed for 2-level unwrapping */
+	xen_ulong_t pos_selector;   /* bits are positions in pending array */
+	xen_ulong_t events_pending; /* bits - events in pos_selector element */
+	uint32_t pos_index, event_index; /* bit indexes */
+
+	evtchn_port_t port; /* absolute event index */
+
+	/* TODO: SMP? XEN_LEGACY_MAX_VCPUS == 1*/
+	vcpu_info_t *vcpu = &HYPERVISOR_shared_info->vcpu_info[0];
+
+	/*
+	 * Need to set it to 0 /before/ checking for pending work, thus
+	 * avoiding a set-and-check race (check struct vcpu_info_t)
+	 */
+	vcpu->evtchn_upcall_pending = 0;
+
+	compiler_barrier();
+
+	/* Can not use system atomic_t/atomic_set() due to 32-bit casting */
+	pos_selector = __atomic_exchange_n(&vcpu->evtchn_pending_sel,
+					0, __ATOMIC_SEQ_CST);
+
+	while (pos_selector) {
+		/* Find first position, clear it in selector and process */
+		pos_index = __builtin_ffsl(pos_selector) - 1;
+		pos_selector &= ~(1 << pos_index);
+
+		/* Find all active evtchn on selected position */
+		while ((events_pending = get_pending_events(pos_index)) != 0) {
+			event_index =  __builtin_ffsl(events_pending) - 1;
+			events_pending &= (1 << event_index);
+
+			port = (pos_index * 8 * sizeof(xen_ulong_t))
+					+ event_index;
+			process_event(port);
+		}
+	}
+}
+
+int xen_events_init(void)
+{
+	int i;
+
+	if (!HYPERVISOR_shared_info) {
+		/* shared info was not mapped */
+		LOG_ERR("%s: shared_info - NULL, can't setup events\n", __func__);
+		return -EINVAL;
+	}
+
+	/* bind all ports with default callback */
+	for (i = 0; i < EVTCHN_2L_NR_CHANNELS; i++) {
+		event_channels[i].cb = empty_callback;
+		event_channels[i].priv = NULL;
+	}
+
+	IRQ_CONNECT(DT_IRQ_BY_IDX(DT_INST(0, xen_xen), 0, irq),
+		DT_IRQ_BY_IDX(DT_INST(0, xen_xen), 0, priority), events_isr,
+		NULL, DT_IRQ_BY_IDX(DT_INST(0, xen_xen), 0, flags));
+
+	irq_enable(DT_IRQ_BY_IDX(DT_INST(0, xen_xen), 0, irq));
+
+	LOG_INF("%s: events inited\n", __func__);
+	return 0;
 }

--- a/include/xen/console.h
+++ b/include/xen/console.h
@@ -16,6 +16,11 @@ struct hvc_xen_data {
 	const struct device *dev;
 	struct xencons_interface *intf;
 	uint64_t evtchn;
+
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	uart_irq_callback_user_data_t irq_cb;
+	void *irq_cb_data;
+#endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 };
 
 int xen_console_init(const struct device *dev);

--- a/include/xen/events.h
+++ b/include/xen/events.h
@@ -8,6 +8,21 @@
 
 #include <xen/public/event_channel.h>
 
+#include <kernel.h>
+
+typedef void (*evtchn_cb_t)(void *priv);
+
+struct event_channel_handle {
+	evtchn_cb_t cb;
+	void *priv;
+};
+
+typedef struct event_channel_handle evtchn_handle_t;
+
 void notify_evtchn(evtchn_port_t port);
+int bind_event_channel(evtchn_port_t port, evtchn_cb_t cb, void *data);
+int unbind_event_channel(evtchn_port_t port);
+
+int xen_events_init(void);
 
 #endif /* __XEN_EVENTS_H__ */


### PR DESCRIPTION
This pull-request introduces new features, related to Xen virtualization support.

It includes:
1. Xen enlighten driver. This driver allows usage of pre-defined Xen event-channels (XenBus, PV console) on single (boot) CPU, allocation and other VCPU registration (VCPUOP_register_vcpu_info) will be added in future versions. 
2. Interrupt-driven API for Xen PV console over event channels.
3. Consoleio driver for Zephyr as Dom0 (privileged) domain (only for Dom0 console input/output work in regular Xen build, for debug build output works for other domain - already implemented in uart-xen-hvc).

Also XenVM doc was updated according to new changes.