### PR TITLE
doc: guides: tfm: Add pages on test suites

### DIFF
--- a/doc/guides/tfm/index.rst
+++ b/doc/guides/tfm/index.rst
@@ -10,3 +10,4 @@ Trusted Firmware-M
    requirements.rst
    build.rst
    integration.rst
+   testsuites.rst

--- a/doc/guides/tfm/testsuites.rst
+++ b/doc/guides/tfm/testsuites.rst
@@ -1,0 +1,43 @@
+Test Suites
+###########
+
+TF-M includes two sets of test suites:
+
+* tf-m-tests - Standard TF-M specific regression tests
+* psa-arch-tests - Test suites for specific PSA APIs (secure storage, etc.)
+
+These test suites can be run from Zephyr via an appropriate sample application
+in the samples/tfm_integration folder.
+
+TF-M Regression Tests
+*********************
+
+The regression test suite can be run via the :ref:`tfm_regression_test` sample.
+
+This sample tests various services and communication mechanisms across the
+NS/S boundary via the PSA APIs. They provide a useful sanity check for proper
+integration between the NS RTOS (Zephyr in this case) and the secure
+application (TF-M).
+
+PSA Arch Tests
+**************
+
+The PSA Arch Test suite, available via :ref:`tfm_psa_test`, contains a number of
+test suites that can be used to validate that PSA API specifications are
+being followed by the secure application, TF-M being an implementation of
+the Platform Securtity Architecture (PSA).
+
+Only one of these suites can be run at a time, with the available test suites
+described via ``CONFIG_TFM_PSA_TEST_*`` KConfig flags:
+
+Purpose
+*******
+
+The output of these test suites is required to obtain PSA Certification for
+your specific board, RTOS (Zephyr here), and PSA implementation (TF-M in this
+case).
+
+They also provide a useful test case to validate any PRs that make meaningful
+changes to TF-M, such as enabling a new TF-M board target, or making changes
+to the core TF-M module(s). They should generally be run as a coherence check
+before publishing a new PR for new board support, etc.

--- a/samples/tfm_integration/tfm_psa_test/README.rst
+++ b/samples/tfm_integration/tfm_psa_test/README.rst
@@ -18,6 +18,25 @@ Building and Running
 
 You must choose a suite via the CONFIG_TFM_PSA_TEST_* configs.
 
+Only one of these suites can be run at a time, with the test suite set via one
+of the following kconfig options:
+
+* ``CONFIG_TFM_PSA_TEST_CRYPTO``
+* ``CONFIG_TFM_PSA_TEST_PROTECTED_STORAGE``
+* ``CONFIG_TFM_PSA_TEST_INTERNAL_TRUSTED_STORAGE``
+* ``CONFIG_TFM_PSA_TEST_STORAGE``
+* ``CONFIG_TFM_PSA_TEST_INITIAL_ATTESTATION``
+
+You can indicate the desired test suite at build time via a config flag:
+
+   .. code-block:: bash
+
+     $ west build samples/tfm_integration/tfm_psa_test/ \
+       -p -b mps2_an521_ns -t run -- \
+       -DCONFIG_TFM_PSA_TEST_STORAGE=y
+
+Note that not all test suites are valid on all boards.
+
 On Target
 =========
 


### PR DESCRIPTION
Adds notes on how to run the two main test suites for TF-M using
the supplied sample applications.

Signed-off-by: Kevin Townsend <kevin.townsend@linaro.org>