### PR TITLE
subsys: logging: Add MIPI sys-t support for v2 logging subsystem.

### DIFF
--- a/samples/subsys/logging/syst/sample.yaml
+++ b/samples/subsys/logging/syst/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: syst sample
 tests:
-  sample.logger.syst:
+  sample.logger.syst.v1:
     platform_allow: mps2_an385 sam_e70_xplained
     tags: logging
     harness: console
@@ -9,3 +9,13 @@ tests:
       type: one_line
       regex:
         - "SYS-T RAW DATA: "
+  sample.logger.syst.v2.deferred:
+    platform_allow: mps2_an385 sam_e70_xplained
+    tags: logging
+    harness: console
+    harness_config:
+      type: one_line
+      regex:
+        - "SYS-T RAW DATA: "
+    extra_configs:
+      - CONFIG_LOG2_MODE_DEFERRED=y

--- a/samples/subsys/logging/syst/src/main.c
+++ b/samples/subsys/logging/syst/src/main.c
@@ -34,12 +34,13 @@ void main(void)
 	struct test_frame frame = { 0 };
 	const uint8_t data[DATA_MAX_DLEN] = { 0x01, 0x02, 0x03, 0x04,
 					0x05, 0x06, 0x07, 0x08 };
-	struct log_msg_ids src_level = {
-		.level = LOG_LEVEL_INTERNAL_RAW_STRING,
-		.source_id = 0, /* not used as level indicates raw string. */
-		.domain_id = 0, /* not used as level indicates raw string. */
-	};
-
+	#ifndef CONFIG_LOG2
+		struct log_msg_ids src_level = {
+			.level = LOG_LEVEL_INTERNAL_RAW_STRING,
+			.source_id = 0, /* not used as level indicates raw string. */
+			.domain_id = 0, /* not used as level indicates raw string. */
+		};
+	#endif
 
 	/* standard print */
 	LOG_ERR("Error message example.");
@@ -67,6 +68,9 @@ void main(void)
 	/* raw string */
 	printk("hello sys-t on board %s\n", CONFIG_BOARD);
 
-	/* log output string */
-	log_string_sync(src_level, "%s", "log string sync");
+	#ifndef CONFIG_LOG2
+		/* log output string */
+		log_string_sync(src_level, "%s", "log string sync");
+	#endif
+
 }

--- a/subsys/logging/log_backend_rtt.c
+++ b/subsys/logging/log_backend_rtt.c
@@ -320,6 +320,8 @@ static void process(const struct log_backend *const backend,
 {
 	uint32_t flags = log_backend_std_get_flags();
 
+	flags |= IS_ENABLED(CONFIG_LOG_BACKEND_RTT_SYST_ENABLE) ? LOG_OUTPUT_FLAG_FORMAT_SYST : 0;
+
 	log_output_msg2_process(&log_output_rtt, &msg->log, flags);
 }
 

--- a/subsys/logging/log_backend_swo.c
+++ b/subsys/logging/log_backend_swo.c
@@ -87,6 +87,8 @@ static void log_backend_swo_process(const struct log_backend *const backend,
 {
 	uint32_t flags = log_backend_std_get_flags();
 
+	flags |= IS_ENABLED(CONFIG_LOG_BACKEND_SWO_SYST_ENABLE) ? LOG_OUTPUT_FLAG_FORMAT_SYST : 0;
+
 	log_output_msg2_process(&log_output_swo, &msg->log, flags);
 }
 

--- a/subsys/logging/log_backend_uart.c
+++ b/subsys/logging/log_backend_uart.c
@@ -65,6 +65,8 @@ static void process(const struct log_backend *const backend,
 {
 	uint32_t flags = log_backend_std_get_flags();
 
+	flags |= IS_ENABLED(CONFIG_LOG_BACKEND_UART_SYST_ENABLE) ? LOG_OUTPUT_FLAG_FORMAT_SYST : 0;
+
 	if (IS_ENABLED(CONFIG_LOG_BACKEND_UART_OUTPUT_DICTIONARY)) {
 		log_dict_output_msg2_process(&log_output_uart,
 					     &msg->log, flags);

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -48,6 +48,8 @@ static uint32_t timestamp_div;
 
 extern void log_output_msg_syst_process(const struct log_output *output,
 				struct log_msg *msg, uint32_t flag);
+extern void log_output_msg2_syst_process(const struct log_output *output,
+				struct log_msg2 *msg, uint32_t flag);
 extern void log_output_string_syst_process(const struct log_output *output,
 				struct log_msg_ids src_level,
 				const char *fmt, va_list ap, uint32_t flag);
@@ -589,10 +591,7 @@ void log_output_msg2_process(const struct log_output *output,
 
 	if (IS_ENABLED(CONFIG_LOG_MIPI_SYST_ENABLE) &&
 	    flags & LOG_OUTPUT_FLAG_FORMAT_SYST) {
-		__ASSERT_NO_MSG(0);
-		/* todo not supported
-		 * log_output_msg_syst_process(output, msg, flags);
-		 */
+		log_output_msg2_syst_process(output, msg, flags);
 		return;
 	}
 


### PR DESCRIPTION
Adding functions log_output_msg2_syst_process and hexdump2_print to support v2 logging subsystem. Also adding v2 logging support for sys-t sample.