### PR TITLE
samples: subsys: dfu: update URL of the MCUboot zephyr readme

### DIFF
--- a/samples/subsys/usb/dfu/README.rst
+++ b/samples/subsys/usb/dfu/README.rst
@@ -107,4 +107,4 @@ USB DFU sample, showing this output to the console:
   ***** Booting Zephyr OS v1.11.0-830-g9df01813c4 *****
 
 .. _MCUboot GitHub repo: https://github.com/runtimeco/mcuboot
-.. _Using MCUboot with Zephyr: https://mcuboot.com/mcuboot/readme-zephyr.html
+.. _Using MCUboot with Zephyr: https://mcuboot.com/documentation/readme-zephyr/


### PR DESCRIPTION
Switch to the new MCUboot zephyr documentation URL since the old one returns error 404.

Signed-off-by: Bartosz Bilas <b.bilas@grinn-global.com>