### PR TITLE
boards: arm: bl654_usb: Fix USB enablement issues

### DIFF
--- a/boards/arm/bl654_usb/CMakeLists.txt
+++ b/boards/arm/bl654_usb/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Copyright (c) 2021 Laird Connectivity.
+# SPDX-License-Identifier: Apache-2.0
+
+if (CONFIG_BOARD_BL654_USB AND CONFIG_BOARD_ENABLE_USB_AUTOMATICALLY)
+zephyr_library()
+zephyr_library_sources(bl654_usb_enable_usb.c)
+endif()

--- a/boards/arm/bl654_usb/Kconfig
+++ b/boards/arm/bl654_usb/Kconfig
@@ -8,3 +8,19 @@ config BOARD_ENABLE_DCDC
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_BL654_USB
+
+config BOARD_ENABLE_USB_AUTOMATICALLY
+	bool "Enable USB automatically"
+	default y if USB_UART_CONSOLE
+	depends on BOARD_BL654_USB
+	help
+	  Will automatically enable the USB peripheral upon boot if USB console
+	  mode is selected, which means manually enabling USB from user-code is
+	  not required
+
+config BOARD_ENABLE_USB_AUTOMATICALLY_INIT_PRIORITY
+	int "USB automatic init priority"
+	default 96
+	depends on BOARD_ENABLE_USB_AUTOMATICALLY
+	help
+	  Automatic USB peripheral enablement initialisation priority

--- a/boards/arm/bl654_usb/Kconfig.defconfig
+++ b/boards/arm/bl654_usb/Kconfig.defconfig
@@ -26,7 +26,10 @@ config FLASH_LOAD_OFFSET
 if USB_DEVICE_STACK
 
 config USB_UART_CONSOLE
-	default y
+	default y if !USB_DEVICE_BLUETOOTH
+
+config USB_CDC_ACM
+	default n if USB_DEVICE_BLUETOOTH
 
 config UART_LINE_CTRL
 	default y

--- a/boards/arm/bl654_usb/bl654_usb_enable_usb.c
+++ b/boards/arm/bl654_usb/bl654_usb_enable_usb.c
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2021 Laird Connectivity
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <init.h>
+#include <usb/usb_device.h>
+
+static int usb_enable_boot(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+	usb_enable(NULL);
+
+	return 0;
+}
+
+SYS_INIT(usb_enable_boot, POST_KERNEL,
+	 CONFIG_BOARD_ENABLE_USB_AUTOMATICALLY_INIT_PRIORITY);


### PR DESCRIPTION
This addresses USB issues with the BL654 USB dongle which prevent USB
from working properly (e.g. hci_usb) or do not automatically give
access to the console of the board (most other samples) by adding a
feature that will automatically enable the USB peripheral on startup
without needing to be manually added to sample/user applications.

Signed-off-by: Jamie McCrae <jamie.mccrae@lairdconnect.com>

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/39904 and addresses https://github.com/zephyrproject-rtos/zephyr/issues/39969