### PR TITLE
SPI API: frame format configuration option (TI vs Motorola)

### DIFF
--- a/dts/bindings/spi/spi-device.yaml
+++ b/dts/bindings/spi/spi-device.yaml
@@ -29,3 +29,17 @@ properties:
       enum:
         - 0
         - 2048
+    frame-format:
+      type: int
+      default: 0
+      required: false
+      description: |
+        Motorola or TI frame format. By default it's always Motorola's,
+        thus 0 as this is, by far, the most common format.
+        Use the macros not the actual enum value, here is the concordance
+        list (see dt-bindings/spi/spi.h)
+          0     SPI_FRAME_FORMAT_MOTOROLA
+          32768 SPI_FRAME_FORMAT_TI
+      enum:
+        - 0
+        - 32768

--- a/include/drivers/spi.h
+++ b/include/drivers/spi.h
@@ -118,6 +118,22 @@ extern "C" {
 /** @} */
 
 /**
+ * @name SPI Frame Format
+ * @{
+ *
+ * 2 frame formats are exposed: Motorola and TI.
+ * The main difference is the behavior of the CS line. In Motorala it stays
+ * active the whole transfer. In TI, it's active only one serial clock period
+ * prior to actually make the transfer, it is thus inactive during the transfer,
+ * which ends when the clocks ends as well.
+ * By default, as it is the most commonly used, the Motorola frame format
+ * will prevail.
+ */
+#define SPI_FRAME_FORMAT_MOTOROLA	(0U << 15)
+#define SPI_FRAME_FORMAT_TI		(1U << 15)
+/** @} */
+
+/**
  * @name SPI MISO lines (if @kconfig{CONFIG_SPI_EXTENDED_MODES} is enabled)
  * @{
  *
@@ -248,7 +264,7 @@ struct spi_cs_control {
  *     cs_hold             [ 12 ]      - Hold on the CS line if possible.
  *     lock_on             [ 13 ]      - Keep resource locked for the caller.
  *     cs_active_high      [ 14 ]      - Active high CS logic.
- *     reserved            [ 15 ]      - reserved for future use.
+ *     format              [ 15 ]      - Motorola or TI frame format (optional).
  * if @kconfig{CONFIG_SPI_EXTENDED_MODES} is defined:
  *     lines               [ 16 : 17 ] - MISO lines: Single/Dual/Quad/Octal.
  *     reserved            [ 18 : 31 ] - reserved for future use.

--- a/include/drivers/spi.h
+++ b/include/drivers/spi.h
@@ -118,22 +118,6 @@ extern "C" {
 /** @} */
 
 /**
- * @name SPI Frame Format
- * @{
- *
- * 2 frame formats are exposed: Motorola and TI.
- * The main difference is the behavior of the CS line. In Motorala it stays
- * active the whole transfer. In TI, it's active only one serial clock period
- * prior to actually make the transfer, it is thus inactive during the transfer,
- * which ends when the clocks ends as well.
- * By default, as it is the most commonly used, the Motorola frame format
- * will prevail.
- */
-#define SPI_FRAME_FORMAT_MOTOROLA	(0U << 15)
-#define SPI_FRAME_FORMAT_TI		(1U << 15)
-/** @} */
-
-/**
  * @name SPI MISO lines (if @kconfig{CONFIG_SPI_EXTENDED_MODES} is enabled)
  * @{
  *

--- a/include/dt-bindings/spi/spi.h
+++ b/include/dt-bindings/spi/spi.h
@@ -25,6 +25,22 @@
 /** @} */
 
 /**
+ * @name SPI Frame Format
+ * @{
+ *
+ * 2 frame formats are exposed: Motorola and TI.
+ * The main difference is the behavior of the CS line. In Motorala it stays
+ * active the whole transfer. In TI, it's active only one serial clock period
+ * prior to actually make the transfer, it is thus inactive during the transfer,
+ * which ends when the clocks ends as well.
+ * By default, as it is the most commonly used, the Motorola frame format
+ * will prevail.
+ */
+#define SPI_FRAME_FORMAT_MOTOROLA	(0U << 15)
+#define SPI_FRAME_FORMAT_TI		(1U << 15)
+/** @} */
+
+/**
  * @}
  */
 


### PR DESCRIPTION
Adding a configuration bit to switch between TI and Motorola frame formats.
