### PR TITLE
SPI: Add API support for DDR, Dual, Quad and Octal modes 

### DIFF
--- a/drivers/spi/Kconfig
+++ b/drivers/spi/Kconfig
@@ -38,10 +38,8 @@ config SPI_EXTENDED_MODES
 	bool "Extended modes [EXPERIMENTAL]"
 	select EXPERIMENTAL
 	help
-	  Enables extended operations in the SPI API. Currently, this
-	  enables the possibility to select the line mode (single/dual/
-	  quad/octal), though none of these mode are really supported as
-	  it would require more features exposed into the SPI buffer.
+	  Enables extended operations in the SPI API: Double Data Rate and
+	  dual/quad/octal modes.
 
 config SPI_INIT_PRIORITY
 	int "Init priority"


### PR DESCRIPTION
(#20564 could not be reopened, so creating a new one.)

SPI extended modes
================

DDR: Double Data Rate
Dual: Dual MOSI lines
Quad: Quad MOSI lines
Octal: Octal MOSI lines
DQO: Dual Quand Octal

These modes comprise: DDR, Dual, Quad, Octal and the
specific command/address/data format


Uses cases
---------------

- single MOSI line: cmd / addr / data ddr
- single MOSI line: cmd / addr ddr / data ddr
- single MOSI line: cmd ddr / addr ddr / data ddr
- single MOSI line: cmd ddr
- single MOSI line: data ddr
- DQO MOSI lines: cmd single/addr single/data
- DQO MOSI lines: cmd single/addr/data
- DQO MOSI lines: cmd/addr/data
- DQO MOSI lines: cmd
- DQO MOSI lines: data
- DBO uses cases with DDR


Design
---------

Besides the operation attribute of struct spi_config, all goes through
a newly added u16_t attribute in struct spi_buf: flags.

Firts 9 bits are containing config flags, next 2 bits are the command
length (set to 0 if the cmd/addr format is not in use) and the last 5 bits
are the address length (set to 0 if the addr is not present or if the cmd/addr
format is not in use). Command length is a multiple of 4 (4, 8, 12, 16, ...)
and address length is a multiple of 2 factor 4 (4, 8, 16 ...)

**The good side of this approach:** it does not require changes on any existing SPI controller
drivers nor SPI device drivers.

**The drawback:** if only one SPI controller can support these modes, it adds up
16bits to each and every struct spi_buf in the system. Hopefully this is still
a relatively small amount of data (looks like uncommon for a driver to use more
than 2 struct spi_buf, and if does it will usually be due to a lack of factorization).

SPI configuration
----------------------

```
spi_config {
	   ...
	   .operation = SPI_LINES_<SINGLE/DUAL/QUAD/OCTAL> | SPI_EXTENDED_MODES,
	   ...
}
```

Basic cmd/addr format transaction usage
----------------------------------------------------

Note: 8bits length cmd/addr are used for these examples, but it's trivial to
use other size.

**TX only:**

```
u8_t tx_buf[] = { CMD, ADDR };

struct spi_buf buf[2] =  {
	{
		.buf = tx_buf,
       		.len = 2,
		.flags = SPI_EM_CMD_<mode> | SPI_EM_ADDR_<mode> |
       	      	       SPI_EM_CMD_LENGTH_SET(SPI_EM_CMD_LEN_8_BITS) |
		       SPI_EM_ADR_LENGTH_SET(SPI_EM_ADR_LEN_8_BITS)
	},
	{
		.buf = data,
 		.len = data_length
	}
};

struct spi_buf_set tx {
       .buffers = buf,
       .count = 2
};

spi_transceive(spi_dev, spi_cfg, &tx, NULL)
```

**RX added**

```
u8_t tx_buf[] = { CMD, ADDR };

struct spi_buf buf_tx[1] =  {
	{
		.buf = tx_buf,
       		.len = 2,
		.flags = SPI_EM_CMD_<mode> | SPI_EM_ADDR_<mode> |
       	      	       SPI_EM_CMD_LENGTH_SET(SPI_EM_CMD_LEN_8_BITS) |
		       SPI_EM_ADR_LENGTH_SET(SPI_EM_ADR_LEN_8_BITS)
	}
};

struct spi_buf_set tx {
       .buffers = buf_tx,
       .count = 1
};

struct spi_buf buf_rx[1] =  {
	{
		.buf = data,
 		.len = data_length
	}
};

struct spi_buf_set rx {
       .buffers = buf_rx,
       .count = 1
};

spi_transceive(spi_dev, spi_cfg, &tx, &rx)
```

**In case no address is given**

```
u8_t tx_buf[] = { CMD };

struct spi_buf buf_tx[1] =  {
	{
		.buf = tx_buf,
       		.len = 2,
		.flags = SPI_EM_CMD_<mode> | SPI_EM_ADDR_<mode> |
       	      	       SPI_EM_CMD_LENGTH_SET(SPI_EM_CMD_LEN_8_BITS) |
		       SPI_EM_ADR_LENGTH_SET(SPI_EM_ADR_NONE)
	}
};
```

etc ...
