### PR TITLE
west.yml: Bump open-amp to v2021.10.0

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -144,7 +144,7 @@ manifest:
       groups:
         - hal
     - name: libmetal
-      revision: 39d049d4ae68e6f6d595fce7de1dcfc1024fb4eb
+      revision: f237c9d420a51cc43bc37d744e41191ad613f348
       path: modules/hal/libmetal
       groups:
         - hal
@@ -190,7 +190,7 @@ manifest:
       revision: a47e326ca772ddd14cc3b9d4ca30a9ab44ecca16
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
-      revision: 6010f0523cbc75f551d9256cf782f173177acdef
+      revision: cfd050ff38a9d028dc211690b2ec35971128e45e
       path: modules/lib/open-amp
     - name: openthread
       revision: 15d9f0401eb458b35c82e327299969b8b745231f


### PR DESCRIPTION
Change the manifest to pickup the new versions for libmetal and
open-amp.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>