### PR TITLE
tf-m: Fix flashing of samples on nrf5340

### DIFF
--- a/boards/arm/bl5340_dvk/Kconfig.defconfig
+++ b/boards/arm/bl5340_dvk/Kconfig.defconfig
@@ -45,10 +45,9 @@ if BUILD_WITH_TFM
 
 # By default, if we build with TF-M, instruct build system to
 # flash the combined TF-M (Secure) & Zephyr (Non Secure) image
-# (when building in-tree tests).
 config TFM_FLASH_MERGED_BINARY
 	bool
-	default y if TEST_ARM_CORTEX_M
+	default y
 
 endif # BUILD_WITH_TFM
 

--- a/boards/arm/nrf5340dk_nrf5340/Kconfig.defconfig
+++ b/boards/arm/nrf5340dk_nrf5340/Kconfig.defconfig
@@ -18,10 +18,9 @@ if BUILD_WITH_TFM
 
 # By default, if we build with TF-M, instruct build system to
 # flash the combined TF-M (Secure) & Zephyr (Non Secure) image
-# (when building in-tree tests).
 config TFM_FLASH_MERGED_BINARY
 	bool
-	default y if TEST_ARM_CORTEX_M
+	default y
 
 endif # BUILD_WITH_TFM
 

--- a/boards/arm/nrf9160dk_nrf9160/Kconfig.defconfig
+++ b/boards/arm/nrf9160dk_nrf9160/Kconfig.defconfig
@@ -18,10 +18,9 @@ if BUILD_WITH_TFM
 
 # By default, if we build with TF-M, instruct build system to
 # flash the combined TF-M (Secure) & Zephyr (Non Secure) image
-# (when building in-tree tests).
 config TFM_FLASH_MERGED_BINARY
 	bool
-	default y if TEST_ARM_CORTEX_M
+	default y
 
 endif # BUILD_WITH_TFM
 


### PR DESCRIPTION
Always flash the merged hex file.

This fixes flashing for samples. Before "west flash" only worked for
tests.

I don't know why this was not done from the get-go.

This also fixes builds that enables CONFIG_TFM_REGRESSION_NS, which will
use the tfm_ns application file instead of the zephyr application, and
will merge tfm_ns hex into the merged hex file. Otherwise the wrong
application hex file will be flashed.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>