### PR TITLE
dts: can: nxp: flexcan: specify sample point instead of time quanta

### DIFF
--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -530,9 +530,7 @@
 			clk-source = <1>;
 			label = "CAN_0";
 			sjw = <1>;
-			prop-seg = <1>;
-			phase-seg1 = <3>;
-			phase-seg2 = <2>;
+			sample-point = <875>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/arm/nxp/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf.dtsi
@@ -414,9 +414,7 @@
 			clk-source = <1>;
 			label = "CAN_0";
 			sjw = <1>;
-			prop-seg = <1>;
-			phase-seg1 = <3>;
-			phase-seg2 = <2>;
+			sample-point = <875>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -432,9 +430,7 @@
 			clk-source = <1>;
 			label = "CAN_1";
 			sjw = <1>;
-			prop-seg = <1>;
-			phase-seg1 = <3>;
-			phase-seg2 = <2>;
+			sample-point = <875>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/arm/nxp/nxp_rt.dtsi
+++ b/dts/arm/nxp/nxp_rt.dtsi
@@ -643,9 +643,7 @@
 			clk-source = <2>;
 			label = "CAN_1";
 			sjw = <1>;
-			prop-seg = <1>;
-			phase-seg1 = <3>;
-			phase-seg2 = <2>;
+			sample-point = <875>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -660,9 +658,7 @@
 			clk-source = <2>;
 			label = "CAN_2";
 			sjw = <1>;
-			prop-seg = <1>;
-			phase-seg1 = <3>;
-			phase-seg2 = <2>;
+			sample-point = <875>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -677,9 +673,7 @@
 			clk-source = <2>;
 			label = "CAN_3";
 			sjw = <1>;
-			prop-seg = <1>;
-			phase-seg1 = <3>;
-			phase-seg2 = <2>;
+			sample-point = <875>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/arm/nxp/nxp_rt117x.dtsi
+++ b/dts/arm/nxp/nxp_rt117x.dtsi
@@ -712,9 +712,7 @@
 			clk-source = <2>;
 			label = "CAN_1";
 			sjw = <1>;
-			prop-seg = <1>;
-			phase-seg1 = <3>;
-			phase-seg2 = <2>;
+			sample-point = <875>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -729,9 +727,7 @@
 			clk-source = <2>;
 			label = "CAN_2";
 			sjw = <1>;
-			prop-seg = <1>;
-			phase-seg1 = <3>;
-			phase-seg2 = <2>;
+			sample-point = <875>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -746,9 +742,7 @@
 			clk-source = <2>;
 			label = "CAN_3";
 			sjw = <1>;
-			prop-seg = <1>;
-			phase-seg1 = <3>;
-			phase-seg2 = <2>;
+			sample-point = <875>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;


### PR DESCRIPTION
Convert all in-tree NXP FlexCAN instances from hardcoding the CAN bus timing in time quanta to specifying a desired sample point of 87.5% as recommended by CAN in Automation (CiA).

This allows for the CAN driver to calculate the optimal time quanta based on the CAN clock and the requested CAN bitrate.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>