### PR TITLE
drivers: flash: cast offset value into ssize_t

### DIFF
--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -241,7 +241,7 @@ static int flash_flexspi_nor_erase_sector(const struct device *dev,
 		.dataSize = 0,
 	};
 
-	LOG_DBG("Erasing sector at 0x%08x", offset);
+	LOG_DBG("Erasing sector at 0x%08zx", (ssize_t) offset);
 
 	return memc_flexspi_transfer(data->controller, &transfer);
 }
@@ -282,7 +282,7 @@ static int flash_flexspi_nor_page_program(const struct device *dev,
 		.dataSize = len,
 	};
 
-	LOG_DBG("Page programming %d bytes to 0x%08x", len, offset);
+	LOG_DBG("Page programming %d bytes to 0x%08zx", len, (ssize_t) offset);
 
 	return memc_flexspi_transfer(data->controller, &transfer);
 }


### PR DESCRIPTION
To fix compiler warnings cast offset value into ssize_t.

<pre>
zephyr/drivers/flash/flash_mcux_flexspi_nor.c:244:10: warning: format '%x' expects argument of type 'unsigned int', but argument 2 has type 'off_t' {aka 'long int'} [-Wformat=]
  244 |  LOG_DBG("Erasing sector at 0x%08x", offset);
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~
      |                                      |
      |                                      off_t {aka long int}


zephyr/drivers/flash/flash_mcux_flexspi_nor.c:285:10: warning: format '%x' expects argument of type 'unsigned int', but argument 3 has type 'off_t' {aka 'long int'} [-Wformat=]
  285 |  LOG_DBG("Page programming %d bytes to 0x%08x", len, offset);
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~       ~~~~~~
      |                                                      |
      |                                                      off_t {aka long int}

</pre>

Signed-off-by: Bartosz Bilas <b.bilas@grinn-global.com>