### PR TITLE
drivers/flash/qspi_nor_flash: Remove dev null check

### DIFF
--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -650,10 +650,6 @@ static inline void qspi_fill_init_struct(nrfx_qspi_config_t *initstruct)
 /* Configures QSPI memory for the transfer */
 static int qspi_nrfx_configure(const struct device *dev)
 {
-	if (!dev) {
-		return -ENXIO;
-	}
-
 	struct qspi_nor_data *dev_data = dev->data;
 
 	qspi_fill_init_struct(&QSPIconfig);


### PR DESCRIPTION
The PR contains two commits:

 - e33123b2f1 drivers/flash/nrf_qspi_nor: Remove qspi_nor_read_id param flash_id;
 - ef6d36e1ec drivers/flash/qspi_nor_flash: Remove dev null check.
 
Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>