### PR TITLE
drivers/flash/qspi_nor_flash: Fix qspi_sfdp_read qspi_unlock on err

### DIFF
--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -771,7 +771,7 @@ static int qspi_sfdp_read(const struct device *dev, off_t offset,
 
 	if (res != NRFX_SUCCESS) {
 		LOG_DBG("ANOMALY_122_INIT: %x", res);
-		goto out;
+		goto out_failed_init;
 	}
 
 	qspi_lock(dev);
@@ -796,6 +796,7 @@ static int qspi_sfdp_read(const struct device *dev, off_t offset,
 out:
 	qspi_unlock(dev);
 	ANOMALY_122_UNINIT(dev);
+out_failed_init:
 	return qspi_get_zephyr_ret_code(res);
 }
 


### PR DESCRIPTION
The commit fixes situation where failed call to ANOMALY_122_INIT
would call qspi_unlock on lock that have not yet been obtained.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>