### PR TITLE
pm: clean usage of PM action callback

### DIFF
--- a/doc/reference/power_management/index.rst
+++ b/doc/reference/power_management/index.rst
@@ -274,7 +274,7 @@ Device Model with Power Management Support
 Drivers initialize the devices using macros. See :ref:`device_model_api` for
 details on how these macros are used. Use the DEVICE_DEFINE macro to initialize
 drivers providing power management support via the PM control function.
-One of the macro parameters is the pointer to the pm_control handler function.
+One of the macro parameters is the pointer to the PM action callback.
 If the driver doesn't implement any power control operations, it can initialize
 the corresponding pointer with ``NULL``.
 
@@ -307,8 +307,7 @@ Device Set Power State
 
    int pm_device_state_set(const struct device *dev, enum pm_device_state state);
 
-Calls the :c:func:`pm_control()` handler function implemented by the
-device driver with the provided state.
+Calls the device PM action callback with the provided state.
 
 Device Get Power State
 ----------------------

--- a/drivers/display/display_st7735r.c
+++ b/drivers/display/display_st7735r.c
@@ -494,8 +494,8 @@ static int st7735r_init(const struct device *dev)
 }
 
 #ifdef CONFIG_PM_DEVICE
-static int st7735r_pm_control(const struct device *dev,
-			      enum pm_device_action action)
+static int st7735r_pm_action(const struct device *dev,
+			     enum pm_device_action action)
 {
 	int ret = 0;
 	struct st7735r_data *data = (struct st7735r_data *)dev->data;
@@ -573,7 +573,7 @@ static const struct display_driver_api st7735r_api = {
 		.x_offset = DT_INST_PROP(inst, x_offset),			\
 		.y_offset = DT_INST_PROP(inst, y_offset),			\
 	};									\
-	DEVICE_DT_INST_DEFINE(inst, st7735r_init, st7735r_pm_control,		\
+	DEVICE_DT_INST_DEFINE(inst, st7735r_init, st7735r_pm_action,		\
 			      &st7735r_data_ ## inst, &st7735r_config_ ## inst,	\
 			      POST_KERNEL, CONFIG_DISPLAY_INIT_PRIORITY,	\
 			      &st7735r_api);

--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -396,8 +396,8 @@ static int st7789v_init(const struct device *dev)
 }
 
 #ifdef CONFIG_PM_DEVICE
-static int st7789v_pm_control(const struct device *dev,
-			      enum pm_device_action action)
+static int st7789v_pm_action(const struct device *dev,
+			     enum pm_device_action action)
 {
 	struct st7789v_data *data = (struct st7789v_data *)dev->data;
 	int ret = 0;
@@ -439,5 +439,5 @@ static struct st7789v_data st7789v_data = {
 };
 
 DEVICE_DT_INST_DEFINE(0, &st7789v_init,
-	      st7789v_pm_control, &st7789v_data, NULL, POST_KERNEL,
+	      st7789v_pm_action, &st7789v_data, NULL, POST_KERNEL,
 	      CONFIG_DISPLAY_INIT_PRIORITY, &st7789v_api);

--- a/drivers/entropy/entropy_cc13xx_cc26xx.c
+++ b/drivers/entropy/entropy_cc13xx_cc26xx.c
@@ -264,8 +264,8 @@ static int post_notify_fxn(unsigned int eventType, uintptr_t eventArg,
 #endif
 
 #ifdef CONFIG_PM_DEVICE
-static int entropy_cc13xx_cc26xx_pm_control(const struct device *dev,
-					    enum pm_device_action action)
+static int entropy_cc13xx_cc26xx_pm_action(const struct device *dev,
+					   enum pm_device_action action)
 {
 	struct entropy_cc13xx_cc26xx_data *data = get_dev_data(dev);
 
@@ -351,7 +351,7 @@ static struct entropy_cc13xx_cc26xx_data entropy_cc13xx_cc26xx_data = {
 
 DEVICE_DT_INST_DEFINE(0,
 		entropy_cc13xx_cc26xx_init,
-		entropy_cc13xx_cc26xx_pm_control,
+		entropy_cc13xx_cc26xx_pm_action,
 		&entropy_cc13xx_cc26xx_data, NULL,
 		PRE_KERNEL_1, CONFIG_ENTROPY_INIT_PRIORITY,
 		&entropy_cc13xx_cc26xx_driver_api);

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -183,8 +183,8 @@ static int ts_tx_rd, ts_tx_wr;
 static void eth_mcux_phy_enter_reset(struct eth_context *context);
 void eth_mcux_phy_stop(struct eth_context *context);
 
-static int eth_mcux_device_pm_control(const struct device *dev,
-				      enum pm_device_action action)
+static int eth_mcux_device_pm_action(const struct device *dev,
+				     enum pm_device_action action)
 {
 	struct eth_context *eth_ctx = (struct eth_context *)dev->data;
 	int ret = 0;
@@ -231,10 +231,10 @@ out:
 	return ret;
 }
 
-#define ETH_MCUX_PM_FUNC eth_mcux_device_pm_control
+#define ETH_MCUX_PM_ACTION_CB eth_mcux_device_pm_action
 
 #else
-#define ETH_MCUX_PM_FUNC NULL
+#define ETH_MCUX_PM_ACTION_CB NULL
 #endif /* CONFIG_NET_POWER_MANAGEMENT */
 
 #if ETH_MCUX_FIXED_LINK
@@ -1395,7 +1395,7 @@ static void eth_mcux_err_isr(const struct device *dev)
 									\
 	ETH_NET_DEVICE_DT_INST_DEFINE(n,					\
 			    eth_init,					\
-			    ETH_MCUX_PM_FUNC,				\
+			    ETH_MCUX_PM_ACTION_CB,			\
 			    &eth##n##_context,				\
 			    &eth##n##_buffer_config,			\
 			    CONFIG_ETH_INIT_PRIORITY,			\

--- a/drivers/flash/spi_flash_at45.c
+++ b/drivers/flash/spi_flash_at45.c
@@ -593,8 +593,8 @@ static int spi_flash_at45_init(const struct device *dev)
 }
 
 #if IS_ENABLED(CONFIG_PM_DEVICE)
-static int spi_flash_at45_pm_control(const struct device *dev,
-				     enum pm_device_action action)
+static int spi_flash_at45_pm_action(const struct device *dev,
+				    enum pm_device_action action)
 {
 	const struct spi_flash_at45_config *dev_config = get_dev_config(dev);
 
@@ -700,7 +700,7 @@ static const struct flash_driver_api spi_flash_at45_api = {
 			"atmel,at45 is not compatible with its "	     \
 			"total size");))				     \
 	DEVICE_DT_INST_DEFINE(idx,					     \
-		      spi_flash_at45_init, spi_flash_at45_pm_control,	     \
+		      spi_flash_at45_init, spi_flash_at45_pm_action,	     \
 		      &inst_##idx##_data, &inst_##idx##_config,		     \
 		      POST_KERNEL, CONFIG_SPI_FLASH_AT45_INIT_PRIORITY,      \
 		      &spi_flash_at45_api);

--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -429,8 +429,8 @@ static inline int gpio_dw_manage_callback(const struct device *port,
 * Implements the driver control management functionality
 * the *context may include IN data or/and OUT data
 */
-static int gpio_dw_device_ctrl(const struct device *dev,
-			       enum pm_device_action action)
+static int gpio_dw_device_pm_action(const struct device *dev,
+				    enum pm_device_action action)
 {
 	switch (action) {
 	case PM_DEVICE_ACTION_SUSPEND:
@@ -535,7 +535,7 @@ static struct gpio_dw_runtime gpio_0_runtime = {
 };
 
 DEVICE_DT_INST_DEFINE(0,
-	      gpio_dw_initialize, gpio_dw_device_ctrl, &gpio_0_runtime,
+	      gpio_dw_initialize, gpio_dw_device_pm_action, &gpio_0_runtime,
 	      &gpio_config_0, POST_KERNEL, CONFIG_GPIO_DW_INIT_PRIORITY,
 	      &api_funcs);
 
@@ -597,7 +597,7 @@ static struct gpio_dw_runtime gpio_1_runtime = {
 };
 
 DEVICE_DT_INST_DEFINE(1,
-	      gpio_dw_initialize, gpio_dw_device_ctrl, &gpio_1_runtime,
+	      gpio_dw_initialize, gpio_dw_device_pm_action, &gpio_1_runtime,
 	      &gpio_dw_config_1, POST_KERNEL, CONFIG_GPIO_DW_INIT_PRIORITY,
 	      &api_funcs);
 
@@ -658,7 +658,7 @@ static struct gpio_dw_runtime gpio_2_runtime = {
 };
 
 DEVICE_DT_INST_DEFINE(2,
-	      gpio_dw_initialize, gpio_dw_device_ctrl, &gpio_2_runtime,
+	      gpio_dw_initialize, gpio_dw_device_pm_action, &gpio_2_runtime,
 	      &gpio_dw_config_2, POST_KERNEL, CONFIG_GPIO_DW_INIT_PRIORITY,
 	      &api_funcs);
 
@@ -719,7 +719,7 @@ static struct gpio_dw_runtime gpio_3_runtime = {
 };
 
 DEVICE_DT_INST_DEFINE(3,
-	      gpio_dw_initialize, gpio_dw_device_ctrl, &gpio_3_runtime,
+	      gpio_dw_initialize, gpio_dw_device_pm_action, &gpio_3_runtime,
 	      &gpio_dw_config_3, POST_KERNEL, CONFIG_GPIO_DW_INIT_PRIORITY,
 	      &api_funcs);
 

--- a/drivers/gpio/gpio_emul.c
+++ b/drivers/gpio/gpio_emul.c
@@ -664,8 +664,8 @@ static int gpio_emul_init(const struct device *dev)
 }
 
 #ifdef CONFIG_PM_DEVICE
-static int gpio_emul_pm_device_ctrl(const struct device *dev,
-		enum pm_device_action action)
+static int gpio_emul_pm_device_pm_action(const struct device *dev,
+					 enum pm_device_action action)
 {
 	ARG_UNUSED(dev);
 	ARG_UNUSED(action);
@@ -673,7 +673,7 @@ static int gpio_emul_pm_device_ctrl(const struct device *dev,
 	return 0;
 }
 #else
-#define gpio_emul_pm_device_ctrl NULL
+#define gpio_emul_pm_device_pm_action NULL
 #endif
 
 /*
@@ -710,7 +710,7 @@ static int gpio_emul_pm_device_ctrl(const struct device *dev,
 	};								\
 									\
 	DEVICE_DT_INST_DEFINE(_num, gpio_emul_init,			\
-			    gpio_emul_pm_device_ctrl,			\
+			    gpio_emul_pm_device_pm_action,		\
 			    &gpio_emul_data_##_num,			\
 			    &gpio_emul_config_##_num, POST_KERNEL,	\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -570,8 +570,8 @@ static const struct gpio_driver_api gpio_stm32_driver = {
 };
 
 #ifdef CONFIG_PM_DEVICE
-static int gpio_stm32_pm_device_ctrl(const struct device *dev,
-				     enum pm_device_action action)
+static int gpio_stm32_pm_action(const struct device *dev,
+				enum pm_device_action action)
 {
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
@@ -632,7 +632,7 @@ static int gpio_stm32_init(const struct device *dev)
 	static struct gpio_stm32_data gpio_stm32_data_## __suffix;	       \
 	DEVICE_DT_DEFINE(__node,					       \
 			    gpio_stm32_init,				       \
-			    gpio_stm32_pm_device_ctrl,			       \
+			    gpio_stm32_pm_action,			       \
 			    &gpio_stm32_data_## __suffix,		       \
 			    &gpio_stm32_cfg_## __suffix,		       \
 			    PRE_KERNEL_1,				       \

--- a/drivers/i2c/i2c_cc13xx_cc26xx.c
+++ b/drivers/i2c/i2c_cc13xx_cc26xx.c
@@ -326,8 +326,8 @@ static int postNotifyFxn(unsigned int eventType, uintptr_t eventArg,
 #endif
 
 #ifdef CONFIG_PM_DEVICE
-static int i2c_cc13xx_cc26xx_pm_control(const struct device *dev,
-					enum pm_device_action action)
+static int i2c_cc13xx_cc26xx_pm_action(const struct device *dev,
+				       enum pm_device_action action)
 {
 	int ret = 0;
 
@@ -437,7 +437,7 @@ static struct i2c_cc13xx_cc26xx_data i2c_cc13xx_cc26xx_data = {
 
 DEVICE_DT_INST_DEFINE(0,
 		i2c_cc13xx_cc26xx_init,
-		i2c_cc13xx_cc26xx_pm_control,
+		i2c_cc13xx_cc26xx_pm_action,
 		&i2c_cc13xx_cc26xx_data, &i2c_cc13xx_cc26xx_config,
 		POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,
 		&i2c_cc13xx_cc26xx_driver_api);

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -225,8 +225,8 @@ static int init_twi(const struct device *dev)
 }
 
 #ifdef CONFIG_PM_DEVICE
-static int twi_nrfx_pm_control(const struct device *dev,
-			       enum pm_device_action action)
+static int twi_nrfx_pm_action(const struct device *dev,
+			      enum pm_device_action action)
 {
 	int ret = 0;
 
@@ -287,7 +287,7 @@ static int twi_nrfx_pm_control(const struct device *dev,
 	};								       \
 	DEVICE_DT_DEFINE(I2C(idx),					       \
 		      twi_##idx##_init,					       \
-		      twi_nrfx_pm_control,				       \
+		      twi_nrfx_pm_action,				       \
 		      &twi_##idx##_data,				       \
 		      &twi_##idx##z_config,				       \
 		      POST_KERNEL,					       \

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -290,8 +290,8 @@ static int init_twim(const struct device *dev)
 }
 
 #ifdef CONFIG_PM_DEVICE
-static int twim_nrfx_pm_control(const struct device *dev,
-				enum pm_device_action action)
+static int twim_nrfx_pm_action(const struct device *dev,
+			       enum pm_device_action action)
 {
 	int ret = 0;
 
@@ -372,7 +372,7 @@ static int twim_nrfx_pm_control(const struct device *dev,
 	};								       \
 	DEVICE_DT_DEFINE(I2C(idx),					       \
 		      twim_##idx##_init,				       \
-		      twim_nrfx_pm_control,				       \
+		      twim_nrfx_pm_action,				       \
 		      &twim_##idx##_data,				       \
 		      &twim_##idx##z_config,				       \
 		      POST_KERNEL,					       \

--- a/drivers/interrupt_controller/intc_ioapic.c
+++ b/drivers/interrupt_controller/intc_ioapic.c
@@ -309,8 +309,8 @@ int ioapic_resume_from_suspend(const struct device *port)
 * the *context may include IN data or/and OUT data
 */
 __pinned_func
-static int ioapic_device_ctrl(const struct device *dev,
-			      enum pm_device_action action)
+static int ioapic_pm_action(const struct device *dev,
+			    enum pm_device_action action)
 {
 	int ret = 0;
 
@@ -497,7 +497,7 @@ static void IoApicRedUpdateLo(unsigned int irq,
 
 
 #ifdef CONFIG_PM_DEVICE
-SYS_DEVICE_DEFINE("ioapic", ioapic_init, ioapic_device_ctrl, PRE_KERNEL_1,
+SYS_DEVICE_DEFINE("ioapic", ioapic_init, ioapic_pm_action, PRE_KERNEL_1,
 		  CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 #else
 SYS_INIT(ioapic_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/drivers/interrupt_controller/intc_loapic.c
+++ b/drivers/interrupt_controller/intc_loapic.c
@@ -408,8 +408,8 @@ int loapic_resume(const struct device *port)
 * the *context may include IN data or/and OUT data
 */
 __pinned_func
-static int loapic_device_ctrl(const struct device *dev,
-			      enum pm_device_action action)
+static int loapic_pm_action(const struct device *dev,
+			    enum pm_device_action action)
 {
 	int ret = 0;
 
@@ -427,7 +427,7 @@ static int loapic_device_ctrl(const struct device *dev,
 	return ret;
 }
 
-SYS_DEVICE_DEFINE("loapic", loapic_init, loapic_device_ctrl, PRE_KERNEL_1,
+SYS_DEVICE_DEFINE("loapic", loapic_init, loapic_pm_action, PRE_KERNEL_1,
 		  CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 #else
 SYS_INIT(loapic_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/drivers/led/led_pwm.c
+++ b/drivers/led/led_pwm.c
@@ -114,8 +114,8 @@ static int led_pwm_init(const struct device *dev)
 }
 
 #ifdef CONFIG_PM_DEVICE
-static int led_pwm_pm_control(const struct device *dev,
-			      enum pm_device_action action)
+static int led_pwm_pm_action(const struct device *dev,
+			     enum pm_device_action action)
 {
 	const struct led_pwm_config *config = DEV_CFG(dev);
 
@@ -176,7 +176,7 @@ static const struct led_pwm_config led_pwm_config_##id = {	\
 	.led		= led_pwm_##id,				\
 };								\
 								\
-DEVICE_DT_INST_DEFINE(id, &led_pwm_init, led_pwm_pm_control,	\
+DEVICE_DT_INST_DEFINE(id, &led_pwm_init, led_pwm_pm_action,	\
 		      NULL, &led_pwm_config_##id, POST_KERNEL,	\
 		      CONFIG_LED_INIT_PRIORITY, &led_pwm_api);
 

--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -294,8 +294,8 @@ static void pwm_nrfx_uninit(const struct device *dev)
 	memset(dev->data, 0, sizeof(struct pwm_nrfx_data));
 }
 
-static int pwm_nrfx_pm_control(const struct device *dev,
-			       enum pm_device_action action)
+static int pwm_nrfx_pm_action(const struct device *dev,
+			      enum pm_device_action action)
 {
 	int err = 0;
 
@@ -314,7 +314,7 @@ static int pwm_nrfx_pm_control(const struct device *dev,
 }
 #else
 
-#define pwm_nrfx_pm_control NULL
+#define pwm_nrfx_pm_action NULL
 
 #endif /* CONFIG_PM_DEVICE */
 
@@ -369,7 +369,7 @@ static int pwm_nrfx_pm_control(const struct device *dev,
 		.seq.length = NRF_PWM_CHANNEL_COUNT			      \
 	};								      \
 	DEVICE_DT_DEFINE(PWM(idx),					      \
-		      pwm_nrfx_init, pwm_nrfx_pm_control,		      \
+		      pwm_nrfx_init, pwm_nrfx_pm_action,		      \
 		      &pwm_nrfx_##idx##_data,				      \
 		      &pwm_nrfx_##idx##config,				      \
 		      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	      \

--- a/drivers/sensor/apds9960/apds9960.c
+++ b/drivers/sensor/apds9960/apds9960.c
@@ -408,8 +408,8 @@ static int apds9960_init_interrupt(const struct device *dev)
 }
 
 #ifdef CONFIG_PM_DEVICE
-static int apds9960_device_ctrl(const struct device *dev,
-				enum pm_device_action action)
+static int apds9960_pm_action(const struct device *dev,
+			      enum pm_device_action action)
 {
 	const struct apds9960_config *config = dev->config;
 	struct apds9960_data *data = dev->data;
@@ -535,5 +535,5 @@ static const struct apds9960_config apds9960_config = {
 static struct apds9960_data apds9960_data;
 
 DEVICE_DT_INST_DEFINE(0, apds9960_init,
-	      apds9960_device_ctrl, &apds9960_data, &apds9960_config,
+	      apds9960_pm_action, &apds9960_data, &apds9960_config,
 	      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &apds9960_driver_api);

--- a/drivers/sensor/bme280/bme280.c
+++ b/drivers/sensor/bme280/bme280.c
@@ -394,7 +394,7 @@ static int bme280_chip_init(const struct device *dev)
 }
 
 #ifdef CONFIG_PM_DEVICE
-int bme280_pm_ctrl(const struct device *dev, enum pm_device_action action)
+int bme280_pm_action(const struct device *dev, enum pm_device_action action)
 {
 	int ret = 0;
 
@@ -448,7 +448,7 @@ int bme280_pm_ctrl(const struct device *dev, enum pm_device_action action)
 			    (BME280_CONFIG_I2C(inst)));			\
 	DEVICE_DT_INST_DEFINE(inst,					\
 			 bme280_chip_init,				\
-			 bme280_pm_ctrl,				\
+			 bme280_pm_action,				\
 			 &bme280_data_##inst,				\
 			 &bme280_config_##inst,				\
 			 POST_KERNEL,					\

--- a/drivers/sensor/bme280/bme280.c
+++ b/drivers/sensor/bme280/bme280.c
@@ -394,7 +394,8 @@ static int bme280_chip_init(const struct device *dev)
 }
 
 #ifdef CONFIG_PM_DEVICE
-int bme280_pm_action(const struct device *dev, enum pm_device_action action)
+static int bme280_pm_action(const struct device *dev,
+			    enum pm_device_action action)
 {
 	int ret = 0;
 

--- a/drivers/sensor/bmp388/bmp388.c
+++ b/drivers/sensor/bmp388/bmp388.c
@@ -549,8 +549,8 @@ static int bmp388_get_calibration_data(const struct device *dev)
 }
 
 #ifdef CONFIG_PM_DEVICE
-static int bmp388_device_ctrl(const struct device *dev,
-			      enum pm_device_action action)
+static int bmp388_pm_action(const struct device *dev,
+			    enum pm_device_action action)
 {
 	uint8_t reg_val;
 
@@ -723,7 +723,7 @@ static int bmp388_init(const struct device *dev)
 	DEVICE_DT_INST_DEFINE(						   \
 		inst,							   \
 		bmp388_init,						   \
-		bmp388_device_ctrl,					   \
+		bmp388_pm_action,					   \
 		&bmp388_data_##inst,					   \
 		&bmp388_config_##inst,					   \
 		POST_KERNEL,						   \

--- a/drivers/sensor/bq274xx/bq274xx.c
+++ b/drivers/sensor/bq274xx/bq274xx.c
@@ -727,8 +727,8 @@ static int bq274xx_exit_shutdown_mode(const struct device *dev)
 	return 0;
 }
 
-static int bq274xx_pm_control(const struct device *dev,
-			      enum pm_device_action action)
+static int bq274xx_pm_action(const struct device *dev,
+			     enum pm_device_action action)
 {
 	int ret;
 	struct bq274xx_data *data = dev->data;
@@ -773,7 +773,7 @@ static const struct sensor_driver_api bq274xx_battery_driver_api = {
 		.terminate_voltage = DT_INST_PROP(index, terminate_voltage),   \
 	};                                                                     \
 									       \
-	DEVICE_DT_INST_DEFINE(index, &bq274xx_gauge_init, bq274xx_pm_control,  \
+	DEVICE_DT_INST_DEFINE(index, &bq274xx_gauge_init, bq274xx_pm_action,   \
 			    &bq274xx_driver_##index,                           \
 			    &bq274xx_config_##index, POST_KERNEL,              \
 			    CONFIG_SENSOR_INIT_PRIORITY,                       \

--- a/drivers/sensor/fdc2x1x/fdc2x1x.c
+++ b/drivers/sensor/fdc2x1x/fdc2x1x.c
@@ -481,8 +481,8 @@ static int fdc2x1x_set_shutdown(const struct device *dev, bool enable)
  * @param pm_state - power management state
  * @return 0 in case of success, negative error code otherwise.
  */
-static int fdc2x1x_device_pm_ctrl(const struct device *dev,
-				  enum pm_device_action action)
+static int fdc2x1x_device_pm_action(const struct device *dev,
+				    enum pm_device_action action)
 {
 	int ret;
 	const struct fdc2x1x_config *cfg = dev->config;
@@ -1027,7 +1027,7 @@ static int fdc2x1x_init(const struct device *dev)
 									   \
 	DEVICE_DT_INST_DEFINE(n,					   \
 			      fdc2x1x_init,				   \
-			      fdc2x1x_device_pm_ctrl,			   \
+			      fdc2x1x_device_pm_action,			   \
 			      &fdc2x1x_data_##n,			   \
 			      &fdc2x1x_config_##n,			   \
 			      POST_KERNEL,				   \

--- a/drivers/sensor/ina219/ina219.c
+++ b/drivers/sensor/ina219/ina219.c
@@ -217,7 +217,8 @@ static int ina219_channel_get(const struct device *dev,
 }
 
 #ifdef CONFIG_PM_DEVICE
-static int ina219_pm_ctrl(const struct device *dev, enum pm_device_action action)
+static int ina219_pm_action(const struct device *dev,
+			    enum pm_device_action action)
 {
 	uint16_t reg_val;
 
@@ -303,7 +304,7 @@ static const struct sensor_driver_api ina219_api = {
 								\
 	DEVICE_DT_INST_DEFINE(n,				\
 			      ina219_init,			\
-			      ina219_pm_ctrl,\
+			      ina219_pm_action,			\
 			      &ina219_data_##n,			\
 			      &ina219_config_##n,		\
 			      POST_KERNEL,			\

--- a/drivers/sensor/lis2mdl/lis2mdl.c
+++ b/drivers/sensor/lis2mdl/lis2mdl.c
@@ -442,8 +442,8 @@ static int lis2mdl_init(const struct device *dev)
 }
 
 #ifdef CONFIG_PM_DEVICE
-static int lis2mdl_pm_control(const struct device *dev,
-			      enum pm_device_action action)
+static int lis2mdl_pm_action(const struct device *dev,
+			     enum pm_device_action action)
 {
 	const struct lis2mdl_config *config = dev->config;
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&config->ctx;
@@ -490,7 +490,7 @@ static int lis2mdl_pm_control(const struct device *dev,
 #define LIS2MDL_DEVICE_INIT(inst)					\
 	DEVICE_DT_INST_DEFINE(inst,					\
 			    lis2mdl_init,				\
-			    lis2mdl_pm_control,				\
+			    lis2mdl_pm_action,				\
 			    &lis2mdl_data_##inst,			\
 			    &lis2mdl_config_##inst,			\
 			    POST_KERNEL,				\

--- a/drivers/sensor/lm77/lm77.c
+++ b/drivers/sensor/lm77/lm77.c
@@ -361,7 +361,8 @@ static int lm77_init(const struct device *dev)
 }
 
 #ifdef CONFIG_PM_DEVICE
-static int lm77_pm_control(const struct device *dev, enum pm_device_action action)
+static int lm77_pm_action(const struct device *dev,
+			  enum pm_device_action action)
 {
 	const struct lm77_config *config = dev->config;
 	union lm77_reg_config creg = config->config_dt;
@@ -395,9 +396,9 @@ static int lm77_pm_control(const struct device *dev, enum pm_device_action actio
 #endif /* ! LM77_TRIGGER_SUPPORT */
 
 #ifdef CONFIG_PM_DEVICE
-#define LM77_PM_CONTROL_FUNC lm77_pm_control
+#define LM77_PM_ACTION_CB lm77_pm_action
 #else /* CONFIG_PM_DEVICE */
-#define LM77_PM_CONTROL_FUNC NULL
+#define LM77_PM_ACTION_CB NULL
 #endif /* ! CONFIG_PM_DEVICE */
 
 #define LM77_INIT(n)							\
@@ -417,7 +418,7 @@ static int lm77_pm_control(const struct device *dev, enum pm_device_action actio
 	};								\
 									\
 	DEVICE_DT_INST_DEFINE(n, lm77_init,				\
-			      LM77_PM_CONTROL_FUNC,			\
+			      LM77_PM_ACTION_CB,			\
 			      &lm77_data_##n,				\
 			      &lm77_config_##n, POST_KERNEL,		\
 			      CONFIG_SENSOR_INIT_PRIORITY,		\

--- a/drivers/sensor/qdec_nrfx/qdec_nrfx.c
+++ b/drivers/sensor/qdec_nrfx/qdec_nrfx.c
@@ -207,8 +207,8 @@ static int qdec_nrfx_init(const struct device *dev)
 }
 
 #ifdef CONFIG_PM_DEVICE
-static int qdec_nrfx_pm_control(const struct device *dev,
-				enum pm_device_action action)
+static int qdec_nrfx_pm_action(const struct device *dev,
+			       enum pm_device_action action)
 {
 	ARG_UNUSED(dev);
 
@@ -242,5 +242,5 @@ static const struct sensor_driver_api qdec_nrfx_driver_api = {
 };
 
 DEVICE_DT_INST_DEFINE(0, qdec_nrfx_init,
-		qdec_nrfx_pm_control, NULL, NULL, POST_KERNEL,
+		qdec_nrfx_pm_action, NULL, NULL, POST_KERNEL,
 		CONFIG_SENSOR_INIT_PRIORITY, &qdec_nrfx_driver_api);

--- a/drivers/sensor/sgp40/sgp40.c
+++ b/drivers/sensor/sgp40/sgp40.c
@@ -186,7 +186,8 @@ static int sgp40_channel_get(const struct device *dev,
 
 
 #ifdef CONFIG_PM_DEVICE
-static int sgp40_pm_ctrl(const struct device *dev, enum pm_device_action action)
+static int sgp40_pm_action(const struct device *dev,
+			   enum pm_device_action action)
 {
 	uint16_t cmd;
 
@@ -256,7 +257,7 @@ static const struct sensor_driver_api sgp40_api = {
 								\
 	DEVICE_DT_INST_DEFINE(n,				\
 			      sgp40_init,			\
-			      sgp40_pm_ctrl,\
+			      sgp40_pm_action,			\
 			      &sgp40_data_##n,			\
 			      &sgp40_config_##n,		\
 			      POST_KERNEL,			\

--- a/drivers/sensor/si7210/si7210.c
+++ b/drivers/sensor/si7210/si7210.c
@@ -425,7 +425,7 @@ static const struct sensor_driver_api si7210_api_funcs = {
 };
 
 #ifdef CONFIG_PM_DEVICE
-int si7210_pm_ctrl(const struct device *dev, enum pm_device_action action)
+static int si7210_pm_ctrl(const struct device *dev, enum pm_device_action action)
 {
 	int rc;
 

--- a/drivers/sensor/si7210/si7210.c
+++ b/drivers/sensor/si7210/si7210.c
@@ -425,7 +425,8 @@ static const struct sensor_driver_api si7210_api_funcs = {
 };
 
 #ifdef CONFIG_PM_DEVICE
-static int si7210_pm_ctrl(const struct device *dev, enum pm_device_action action)
+static int si7210_pm_action(const struct device *dev,
+			    enum pm_device_action action)
 {
 	int rc;
 
@@ -536,7 +537,7 @@ static int si7210_init(const struct device *dev)
 	static const struct si7210_config si7210_config_##inst = { \
 		.bus = I2C_DT_SPEC_INST_GET(inst), \
 	}; \
-	DEVICE_DT_INST_DEFINE(inst, si7210_init, si7210_pm_ctrl, \
+	DEVICE_DT_INST_DEFINE(inst, si7210_init, si7210_pm_action, \
 		&si7210_data_##inst, &si7210_config_##inst, POST_KERNEL, \
 		CONFIG_SENSOR_INIT_PRIORITY, &si7210_api_funcs);
 

--- a/drivers/sensor/vcnl4040/vcnl4040.c
+++ b/drivers/sensor/vcnl4040/vcnl4040.c
@@ -218,8 +218,8 @@ static int vcnl4040_ambient_setup(const struct device *dev)
 #endif
 
 #ifdef CONFIG_PM_DEVICE
-static int vcnl4040_device_ctrl(const struct device *dev,
-				enum pm_device_action action)
+static int vcnl4040_pm_action(const struct device *dev,
+			      enum pm_device_action action)
 {
 	int ret = 0;
 	uint16_t ps_conf;
@@ -364,5 +364,5 @@ static const struct vcnl4040_config vcnl4040_config = {
 static struct vcnl4040_data vcnl4040_data;
 
 DEVICE_DT_INST_DEFINE(0, vcnl4040_init,
-	      vcnl4040_device_ctrl, &vcnl4040_data, &vcnl4040_config,
+	      vcnl4040_pm_action, &vcnl4040_data, &vcnl4040_config,
 	      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &vcnl4040_driver_api);

--- a/drivers/serial/uart_cc13xx_cc26xx.c
+++ b/drivers/serial/uart_cc13xx_cc26xx.c
@@ -397,8 +397,8 @@ static int postNotifyFxn(unsigned int eventType, uintptr_t eventArg,
 #endif
 
 #ifdef CONFIG_PM_DEVICE
-static int uart_cc13xx_cc26xx_pm_control(const struct device *dev,
-					 enum pm_device_action action)
+static int uart_cc13xx_cc26xx_pm_action(const struct device *dev,
+					enum pm_device_action action)
 {
 	int ret = 0;
 
@@ -537,7 +537,7 @@ static const struct uart_driver_api uart_cc13xx_cc26xx_driver_api = {
 #define UART_CC13XX_CC26XX_DEVICE_DEFINE(n)				     \
 	DEVICE_DT_INST_DEFINE(n,					     \
 		uart_cc13xx_cc26xx_init_##n,				     \
-		uart_cc13xx_cc26xx_pm_control,				     \
+		uart_cc13xx_cc26xx_pm_action,				     \
 		&uart_cc13xx_cc26xx_data_##n, &uart_cc13xx_cc26xx_config_##n,\
 		PRE_KERNEL_1, CONFIG_SERIAL_INIT_PRIORITY,		     \
 		&uart_cc13xx_cc26xx_driver_api)

--- a/drivers/serial/uart_neorv32.c
+++ b/drivers/serial/uart_neorv32.c
@@ -440,7 +440,8 @@ static int neorv32_uart_init(const struct device *dev)
 }
 
 #ifdef CONFIG_PM_DEVICE
-static int neorv32_uart_pm_control(const struct device *dev, enum pm_device_action action)
+static int neorv32_uart_pm_action(const struct device *dev,
+				  enum pm_device_action action)
 {
 	uint32_t ctrl = neorv32_uart_read_ctrl(dev);
 
@@ -484,9 +485,9 @@ static const struct uart_driver_api neorv32_uart_driver_api = {
 };
 
 #ifdef CONFIG_PM_DEVICE
-#define NEORV32_UART_PM_CONTROL_FUNC neorv32_uart_pm_control
+#define NEORV32_UART_PM_ACTION_CB neorv32_uart_pm_action
 #else /* CONFIG_PM_DEVICE */
-#define NEORV32_UART_PM_CONTROL_FUNC NULL
+#define NEORV32_UART_PM_ACTION_CB NULL
 #endif /* ! CONFIG_PM_DEVICE */
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
@@ -536,7 +537,7 @@ static const struct uart_driver_api neorv32_uart_driver_api = {
 	};								\
 									\
 	DEVICE_DT_DEFINE(node_id, &neorv32_uart_init,			\
-			 NEORV32_UART_PM_CONTROL_FUNC,			\
+			 NEORV32_UART_PM_ACTION_CB,			\
 			 &neorv32_uart_##n##_data,			\
 			 &neorv32_uart_##n##_config,			\
 			 PRE_KERNEL_1,					\

--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -438,8 +438,8 @@ static inline bool uart_npcx_device_is_transmitting(const struct device *dev)
 	return 0;
 }
 
-static inline int uart_npcx_pm_action(const struct device *dev,
-				      enum pm_device_action action)
+static int uart_npcx_pm_action(const struct device *dev,
+			       enum pm_device_action action)
 {
 	/* If next device power state is SUSPEND power state */
 	switch (action) {

--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -438,8 +438,8 @@ static inline bool uart_npcx_device_is_transmitting(const struct device *dev)
 	return 0;
 }
 
-static inline int uart_npcx_pm_control(const struct device *dev,
-				       enum pm_device_action action)
+static inline int uart_npcx_pm_action(const struct device *dev,
+				      enum pm_device_action action)
 {
 	/* If next device power state is SUSPEND power state */
 	switch (action) {
@@ -504,7 +504,7 @@ static inline int uart_npcx_pm_control(const struct device *dev,
 									       \
 	DEVICE_DT_INST_DEFINE(inst,					       \
 			&uart_npcx_init,                                       \
-			uart_npcx_pm_control,				       \
+			uart_npcx_pm_action,				       \
 			&uart_npcx_data_##inst, &uart_npcx_cfg_##inst,         \
 			PRE_KERNEL_1, CONFIG_SERIAL_INIT_PRIORITY,	       \
 			&uart_npcx_driver_api);                                \

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -1142,8 +1142,8 @@ static void uart_nrfx_pins_enable(const struct device *dev, bool enable)
 	}
 }
 
-static int uart_nrfx_pm_control(const struct device *dev,
-				enum pm_device_action action)
+static int uart_nrfx_pm_action(const struct device *dev,
+			       enum pm_device_action action)
 {
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
@@ -1183,7 +1183,7 @@ static struct uart_nrfx_data uart_nrfx_uart0_data = {
 
 DEVICE_DT_INST_DEFINE(0,
 	      uart_nrfx_init,
-	      uart_nrfx_pm_control,
+	      uart_nrfx_pm_action,
 	      &uart_nrfx_uart0_data,
 	      NULL,
 	      /* Initialize UART device before UART console. */

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1831,8 +1831,8 @@ static void wait_for_tx_stopped(const struct device *dev)
 }
 
 
-static int uarte_nrfx_pm_control(const struct device *dev,
-				 enum pm_device_action action)
+static int uarte_nrfx_pm_action(const struct device *dev,
+				enum pm_device_action action)
 {
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
 #if defined(CONFIG_UART_ASYNC_API) || defined(UARTE_INTERRUPT_DRIVEN)
@@ -1999,7 +1999,7 @@ static int uarte_nrfx_pm_control(const struct device *dev,
 	}								       \
 	DEVICE_DT_DEFINE(UARTE(idx),					       \
 		      uarte_##idx##_init,				       \
-		      uarte_nrfx_pm_control,				       \
+		      uarte_nrfx_pm_action,				       \
 		      &uarte_##idx##_data,				       \
 		      &uarte_##idx##z_config,				       \
 		      PRE_KERNEL_1,					       \

--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -208,8 +208,8 @@ static int spi_cc13xx_cc26xx_release(const struct device *dev,
 }
 
 #ifdef CONFIG_PM_DEVICE
-static int spi_cc13xx_cc26xx_pm_control(const struct device *dev,
-					enum pm_device_action action)
+static int spi_cc13xx_cc26xx_pm_action(const struct device *dev,
+				       enum pm_device_action action)
 {
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
@@ -292,7 +292,7 @@ static const struct spi_driver_api spi_cc13xx_cc26xx_driver_api = {
 #define SPI_CC13XX_CC26XX_DEVICE_INIT(n)				    \
 	DEVICE_DT_INST_DEFINE(n,						    \
 		spi_cc13xx_cc26xx_init_##n,				    \
-		spi_cc13xx_cc26xx_pm_control,				    \
+		spi_cc13xx_cc26xx_pm_action,				    \
 		&spi_cc13xx_cc26xx_data_##n, &spi_cc13xx_cc26xx_config_##n, \
 		POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,			    \
 		&spi_cc13xx_cc26xx_driver_api)

--- a/drivers/spi/spi_esp32_spim.c
+++ b/drivers/spi/spi_esp32_spim.c
@@ -453,7 +453,7 @@ static const struct spi_driver_api spi_api = {
 	};	\
 		\
 	DEVICE_DT_DEFINE(DT_NODELABEL(spi##idx), &spi_esp32_init,	\
-			      device_pm_control_no, &spi_data_##idx,	\
+			      NULL, &spi_data_##idx,	\
 			      &spi_config_##idx, POST_KERNEL,	\
 			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &spi_api);
 

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -273,8 +273,8 @@ static const struct spi_driver_api spi_nrfx_driver_api = {
 
 
 #ifdef CONFIG_PM_DEVICE
-static int spi_nrfx_pm_control(const struct device *dev,
-			       enum pm_device_action action)
+static int spi_nrfx_pm_action(const struct device *dev,
+			      enum pm_device_action action)
 {
 	int ret = 0;
 	struct spi_nrfx_data *data = get_dev_data(dev);
@@ -351,7 +351,7 @@ static int spi_nrfx_pm_control(const struct device *dev,
 	};								       \
 	DEVICE_DT_DEFINE(SPI(idx),					       \
 		      spi_##idx##_init,					       \
-		      spi_nrfx_pm_control,				       \
+		      spi_nrfx_pm_action,				       \
 		      &spi_##idx##_data,				       \
 		      &spi_##idx##z_config,				       \
 		      POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,		       \

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -330,8 +330,8 @@ static const struct spi_driver_api spi_nrfx_driver_api = {
 };
 
 #ifdef CONFIG_PM_DEVICE
-static int spim_nrfx_pm_control(const struct device *dev,
-				enum pm_device_action action)
+static int spim_nrfx_pm_action(const struct device *dev,
+			       enum pm_device_action action)
 {
 	int ret = 0;
 	struct spi_nrfx_data *data = get_dev_data(dev);
@@ -420,7 +420,7 @@ static int spim_nrfx_pm_control(const struct device *dev,
 	};								       \
 	DEVICE_DT_DEFINE(SPIM(idx),					       \
 		      spi_##idx##_init,					       \
-		      spim_nrfx_pm_control,				       \
+		      spim_nrfx_pm_action,				       \
 		      &spi_##idx##_data,				       \
 		      &spi_##idx##z_config,				       \
 		      POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,		       \

--- a/drivers/video/ov2640.c
+++ b/drivers/video/ov2640.c
@@ -1060,7 +1060,7 @@ static int ov2640_init_0(const struct device *dev)
 	return ov2640_init(dev);
 }
 
-DEVICE_DT_INST_DEFINE(0, &ov2640_init_0, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, &ov2640_init_0, NULL,
 			&ov2640_data_0, NULL,
 			POST_KERNEL, CONFIG_VIDEO_INIT_PRIORITY,
 			&ov2640_driver_api);

--- a/include/device.h
+++ b/include/device.h
@@ -98,10 +98,7 @@ typedef int16_t device_handle_t;
 /**
  * @def DEVICE_DEFINE
  *
- * @brief Create device object and set it up for boot time initialization,
- * with the option to pm_control. In case of Device Idle Power
- * Management is enabled, make sure the device is in suspended state after
- * initialization.
+ * @brief Create device object and set it up for boot time initialization.
  *
  * @details This macro defines a device object that is automatically
  * configured by the kernel during system initialization. Note that

--- a/include/net/ethernet.h
+++ b/include/net/ethernet.h
@@ -827,9 +827,9 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
 
 #if defined(CONFIG_NET_VLAN)
 #define Z_ETH_NET_DEVICE_INIT(node_id, dev_name, drv_name, init_fn,	\
-			      pm_control_cb, data, cfg, prio, api, mtu)	\
+			      pm_action_cb, data, cfg, prio, api, mtu)	\
 	Z_DEVICE_DEFINE(node_id, dev_name, drv_name, init_fn,		\
-			pm_control_cb, data, cfg, POST_KERNEL,		\
+			pm_action_cb, data, cfg, POST_KERNEL,		\
 			prio, api);					\
 	NET_L2_DATA_INIT(dev_name, 0, NET_L2_GET_CTX_TYPE(ETHERNET_L2));\
 	NET_IF_INIT(dev_name, 0, ETHERNET_L2, mtu, NET_VLAN_MAX_COUNT)
@@ -837,9 +837,9 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
 #else /* CONFIG_NET_VLAN */
 
 #define Z_ETH_NET_DEVICE_INIT(node_id, dev_name, drv_name, init_fn,	\
-			      pm_control_cb, data, cfg, prio, api, mtu)	\
+			      pm_action_cb, data, cfg, prio, api, mtu)	\
 	Z_NET_DEVICE_INIT(node_id, dev_name, drv_name, init_fn,		\
-			  pm_control_cb, data, cfg, prio, api,		\
+			  pm_action_cb, data, cfg, prio, api,		\
 			  ETHERNET_L2, NET_L2_GET_CTX_TYPE(ETHERNET_L2),\
 			  mtu)
 #endif /* CONFIG_NET_VLAN */
@@ -853,7 +853,7 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
  * @param drv_name The name this instance of the driver exposes to
  * the system.
  * @param init_fn Address to the init function of the driver.
- * @param pm_control_cb Pointer to pm_control function.
+ * @param pm_action_cb Pointer to PM action callback.
  * Can be NULL if not implemented.
  * @param data Pointer to the device's private data.
  * @param cfg The address to the structure containing the
@@ -863,10 +863,10 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
  * used by the driver. Can be NULL.
  * @param mtu Maximum transfer unit in bytes for this network interface.
  */
-#define ETH_NET_DEVICE_INIT(dev_name, drv_name, init_fn, pm_control_cb,	\
+#define ETH_NET_DEVICE_INIT(dev_name, drv_name, init_fn, pm_action_cb,	\
 			    data, cfg, prio, api, mtu)			\
 	Z_ETH_NET_DEVICE_INIT(DT_INVALID_NODE, dev_name, drv_name,	\
-			      init_fn, pm_control_cb, data, cfg, prio,	\
+			      init_fn, pm_action_cb, data, cfg, prio,	\
 			      api, mtu)
 
 /**
@@ -877,7 +877,7 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
  *
  * @param node_id The devicetree node identifier.
  * @param init_fn Address to the init function of the driver.
- * @param pm_control_cb Pointer to pm_control function.
+ * @param pm_action_cb Pointer to PM action callback.
  * Can be NULL if not implemented.
  * @param data Pointer to the device's private data.
  * @param cfg The address to the structure containing the
@@ -887,11 +887,11 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
  * used by the driver. Can be NULL.
  * @param mtu Maximum transfer unit in bytes for this network interface.
  */
-#define ETH_NET_DEVICE_DT_DEFINE(node_id, init_fn, pm_control_cb, data,	\
+#define ETH_NET_DEVICE_DT_DEFINE(node_id, init_fn, pm_action_cb, data,	\
 			       cfg, prio, api, mtu)			\
 	Z_ETH_NET_DEVICE_INIT(node_id, Z_DEVICE_DT_DEV_NAME(node_id),	\
 			      DT_PROP_OR(node_id, label, ""),		\
-			      init_fn, pm_control_cb, data, cfg, prio,	\
+			      init_fn, pm_action_cb, data, cfg, prio,	\
 			      api, mtu)
 
 /**

--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -2248,10 +2248,10 @@ struct net_if_api {
 /* Network device initialization macros */
 
 #define Z_NET_DEVICE_INIT(node_id, dev_name, drv_name, init_fn,		\
-			pm_control_cb, data, cfg, prio, api, l2,	\
+			pm_action_cb, data, cfg, prio, api, l2,	\
 			l2_ctx_type, mtu)				\
 	Z_DEVICE_DEFINE(node_id, dev_name, drv_name, init_fn,		\
-			pm_control_cb, data,				\
+			pm_action_cb, data,				\
 			cfg, POST_KERNEL, prio, api);			\
 	NET_L2_DATA_INIT(dev_name, 0, l2_ctx_type);			\
 	NET_IF_INIT(dev_name, 0, l2, mtu, NET_IF_MAX_CONFIGS)
@@ -2265,7 +2265,7 @@ struct net_if_api {
  * @param drv_name The name this instance of the driver exposes to
  * the system.
  * @param init_fn Address to the init function of the driver.
- * @param pm_control_cb Pointer to pm_control function.
+ * @param pm_action_cb Pointer to PM action callback.
  * Can be NULL if not implemented.
  * @param data Pointer to the device's private data.
  * @param cfg The address to the structure containing the
@@ -2277,11 +2277,11 @@ struct net_if_api {
  * @param l2_ctx_type Type of L2 context data.
  * @param mtu Maximum transfer unit in bytes for this network interface.
  */
-#define NET_DEVICE_INIT(dev_name, drv_name, init_fn, pm_control_cb,	\
+#define NET_DEVICE_INIT(dev_name, drv_name, init_fn, pm_action_cb,	\
 			data, cfg, prio, api, l2,			\
 			l2_ctx_type, mtu)				\
 	Z_NET_DEVICE_INIT(DT_INVALID_NODE, dev_name, drv_name, init_fn,	\
-			pm_control_cb, data, cfg, prio, api, l2,	\
+			pm_action_cb, data, cfg, prio, api, l2,	\
 			l2_ctx_type, mtu)
 
 /**
@@ -2292,7 +2292,7 @@ struct net_if_api {
  *
  * @param node_id The devicetree node identifier.
  * @param init_fn Address to the init function of the driver.
- * @param pm_control_cb Pointer to pm_control function.
+ * @param pm_action_cb Pointer to PM action callback.
  * Can be NULL if not implemented.
  * @param data Pointer to the device's private data.
  * @param cfg The address to the structure containing the
@@ -2304,11 +2304,11 @@ struct net_if_api {
  * @param l2_ctx_type Type of L2 context data.
  * @param mtu Maximum transfer unit in bytes for this network interface.
  */
-#define NET_DEVICE_DT_DEFINE(node_id, init_fn, pm_control_cb, data, cfg,	\
+#define NET_DEVICE_DT_DEFINE(node_id, init_fn, pm_action_cb, data, cfg,	\
 			   prio, api, l2, l2_ctx_type, mtu)		\
 	Z_NET_DEVICE_INIT(node_id, Z_DEVICE_DT_DEV_NAME(node_id),	\
 			  DT_PROP_OR(node_id, label, ""), init_fn,	\
-			  pm_control_cb, data, cfg, prio, api, l2,	\
+			  pm_action_cb, data, cfg, prio, api, l2,	\
 			  l2_ctx_type, mtu)
 
 /**
@@ -2325,11 +2325,11 @@ struct net_if_api {
 	NET_DEVICE_DT_DEFINE(DT_DRV_INST(inst), __VA_ARGS__)
 
 #define Z_NET_DEVICE_INIT_INSTANCE(node_id, dev_name, drv_name,		\
-				   instance, init_fn, pm_control_cb,	\
+				   instance, init_fn, pm_action_cb,	\
 				   data, cfg, prio, api, l2,		\
 				   l2_ctx_type, mtu)			\
 	Z_DEVICE_DEFINE(node_id, dev_name, drv_name, init_fn,		\
-			pm_control_cb, data, cfg, POST_KERNEL,		\
+			pm_action_cb, data, cfg, POST_KERNEL,		\
 			prio, api);					\
 	NET_L2_DATA_INIT(dev_name, instance, l2_ctx_type);		\
 	NET_IF_INIT(dev_name, instance, l2, mtu, NET_IF_MAX_CONFIGS)
@@ -2347,7 +2347,7 @@ struct net_if_api {
  * the system.
  * @param instance Instance identifier.
  * @param init_fn Address to the init function of the driver.
- * @param pm_control_cb Pointer to pm_control function.
+ * @param pm_action_cb Pointer to PM action callback.
  * Can be NULL if not implemented.
  * @param data Pointer to the device's private data.
  * @param cfg The address to the structure containing the
@@ -2360,10 +2360,10 @@ struct net_if_api {
  * @param mtu Maximum transfer unit in bytes for this network interface.
  */
 #define NET_DEVICE_INIT_INSTANCE(dev_name, drv_name, instance, init_fn,	\
-				 pm_control_cb, data, cfg, prio,	\
+				 pm_action_cb, data, cfg, prio,	\
 				 api, l2, l2_ctx_type, mtu)		\
 	Z_NET_DEVICE_INIT_INSTANCE(DT_INVALID_NODE, dev_name, drv_name,	\
-				   instance, init_fn, pm_control_cb,	\
+				   instance, init_fn, pm_action_cb,	\
 				   data, cfg, prio, api, l2,		\
 				   l2_ctx_type, mtu)
 
@@ -2379,7 +2379,7 @@ struct net_if_api {
  * @param node_id The devicetree node identifier.
  * @param instance Instance identifier.
  * @param init_fn Address to the init function of the driver.
- * @param pm_control_cb Pointer to pm_control function.
+ * @param pm_action_cb Pointer to PM action callback.
  * Can be NULL if not implemented.
  * @param data Pointer to the device's private data.
  * @param cfg The address to the structure containing the
@@ -2392,12 +2392,12 @@ struct net_if_api {
  * @param mtu Maximum transfer unit in bytes for this network interface.
  */
 #define NET_DEVICE_DT_DEFINE_INSTANCE(node_id, instance, init_fn,	\
-				      pm_control_cb, data, cfg, prio,	\
+				      pm_action_cb, data, cfg, prio,	\
 				      api, l2, l2_ctx_type, mtu)	\
 	Z_NET_DEVICE_INIT_INSTANCE(node_id,				\
 				   Z_DEVICE_DT_DEV_NAME(node_id),	\
 				   DT_LABEL(node_id), instance,		\
-				   pm_control_cb, data, cfg, prio, api,	\
+				   pm_action_cb, data, cfg, prio, api,	\
 				   l2, l2_ctx_type, mtu)
 
 /**
@@ -2415,10 +2415,10 @@ struct net_if_api {
 	NET_DEVICE_DT_DEFINE_INSTANCE(DT_DRV_INST(inst), __VA_ARGS__)
 
 #define Z_NET_DEVICE_OFFLOAD_INIT(node_id, dev_name, drv_name, init_fn,	\
-				  pm_control_cb, data, cfg, prio,	\
+				  pm_action_cb, data, cfg, prio,	\
 				  api, mtu)				\
 	Z_DEVICE_DEFINE(node_id, dev_name, drv_name, init_fn,		\
-			pm_control_cb, data, cfg, POST_KERNEL, prio, api);\
+			pm_action_cb, data, cfg, POST_KERNEL, prio, api);\
 	NET_IF_OFFLOAD_INIT(dev_name, 0, mtu)
 
 /**
@@ -2432,7 +2432,7 @@ struct net_if_api {
  * @param drv_name The name this instance of the driver exposes to
  * the system.
  * @param init_fn Address to the init function of the driver.
- * @param pm_control_cb Pointer to pm_control function.
+ * @param pm_action_cb Pointer to PM action callback.
  * Can be NULL if not implemented.
  * @param data Pointer to the device's private data.
  * @param cfg The address to the structure containing the
@@ -2443,9 +2443,9 @@ struct net_if_api {
  * @param mtu Maximum transfer unit in bytes for this network interface.
  */
 #define NET_DEVICE_OFFLOAD_INIT(dev_name, drv_name, init_fn,		\
-				pm_control_cb, data, cfg, prio, api, mtu)\
+				pm_action_cb, data, cfg, prio, api, mtu)\
 	Z_NET_DEVICE_OFFLOAD_INIT(DT_INVALID_NODE, dev_name, drv_name,	\
-				init_fn, pm_control_cb, data, cfg, prio,\
+				init_fn, pm_action_cb, data, cfg, prio,\
 				api, mtu)
 
 /**
@@ -2458,7 +2458,7 @@ struct net_if_api {
  *
  * @param node_id The devicetree node identifier.
  * @param init_fn Address to the init function of the driver.
- * @param pm_control_cb Pointer to pm_control function.
+ * @param pm_action_cb Pointer to PM action callback.
  * Can be NULL if not implemented.
  * @param data Pointer to the device's private data.
  * @param cfg The address to the structure containing the
@@ -2468,11 +2468,11 @@ struct net_if_api {
  * used by the driver. Can be NULL.
  * @param mtu Maximum transfer unit in bytes for this network interface.
  */
-#define NET_DEVICE_DT_OFFLOAD_DEFINE(node_id, init_fn, pm_control_cb,	\
+#define NET_DEVICE_DT_OFFLOAD_DEFINE(node_id, init_fn, pm_action_cb,	\
 				   data, cfg, prio, api, mtu)		\
 	Z_NET_DEVICE_OFFLOAD_INIT(node_id, Z_DEVICE_DT_DEV_NAME(node_id), \
 				  DT_PROP_OR(node_id, label, NULL),	\
-				  init_fn, pm_control_cb, data, cfg,	\
+				  init_fn, pm_action_cb, data, cfg,	\
 				  prio, api, mtu)
 
 /**

--- a/include/net/virtual.h
+++ b/include/net/virtual.h
@@ -274,10 +274,10 @@ net_virtual_get_iface_capabilities(struct net_if *iface)
 }
 
 #define Z_NET_VIRTUAL_INTERFACE_INIT(node_id, dev_name, drv_name,	\
-				     init_fn, pm_control_cb, data, cfg, \
+				     init_fn, pm_action_cb, data, cfg, \
 				     prio, api, mtu)			\
 	Z_NET_DEVICE_INIT(node_id, dev_name, drv_name, init_fn,		\
-			  pm_control_cb, data, cfg, prio, api,		\
+			  pm_action_cb, data, cfg, prio, api,		\
 			  VIRTUAL_L2, NET_L2_GET_CTX_TYPE(VIRTUAL_L2),	\
 			  mtu)
 /** @endcond */
@@ -294,7 +294,7 @@ net_virtual_get_iface_capabilities(struct net_if *iface)
  * @param drv_name The name this instance of the driver exposes to
  * the system.
  * @param init_fn Address to the init function of the driver.
- * @param pm_control_cb Pointer to pm_control function.
+ * @param pm_action_cb Pointer to PM action callback.
  * Can be NULL if not implemented.
  * @param data Pointer to the device's private data.
  * @param cfg The address to the structure containing the
@@ -306,10 +306,10 @@ net_virtual_get_iface_capabilities(struct net_if *iface)
  * This is the default value and its value can be tweaked at runtime.
  */
 #define NET_VIRTUAL_INTERFACE_INIT(dev_name, drv_name, init_fn,		\
-				   pm_control_cb,			\
+				   pm_action_cb,			\
 				   data, cfg, prio, api, mtu)		\
 	Z_NET_VIRTUAL_INTERFACE_INIT(DT_INVALID_NODE, dev_name,		\
-				     drv_name, init_fn, pm_control_cb,	\
+				     drv_name, init_fn, pm_action_cb,	\
 				     data, cfg, prio, api, mtu)
 
 /**

--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -253,9 +253,6 @@ __deprecated static inline int device_busy_check(const struct device *dev)
 	return pm_device_is_busy(dev) ? -EBUSY : 0;
 }
 
-/** Alias for legacy use of device_pm_control_nop */
-#define device_pm_control_nop __DEPRECATED_MACRO NULL
-
 /**
  * @brief Enable a power management wakeup source
  *

--- a/samples/subsys/pm/device_pm/src/dummy_driver.c
+++ b/samples/subsys/pm/device_pm/src/dummy_driver.c
@@ -77,8 +77,8 @@ static int dummy_close(const struct device *dev)
 	return ret;
 }
 
-static int dummy_device_pm_ctrl(const struct device *dev,
-				enum pm_device_action action)
+static int dummy_device_pm_action(const struct device *dev,
+				  enum pm_device_action action)
 {
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
@@ -114,5 +114,5 @@ int dummy_init(const struct device *dev)
 }
 
 DEVICE_DEFINE(dummy_driver, DUMMY_DRIVER_NAME, &dummy_init,
-		    dummy_device_pm_ctrl, NULL, NULL, APPLICATION,
+		    dummy_device_pm_action, NULL, NULL, APPLICATION,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &funcs);

--- a/samples/subsys/pm/device_pm/src/dummy_parent.c
+++ b/samples/subsys/pm/device_pm/src/dummy_parent.c
@@ -24,8 +24,8 @@ static int dummy_transfer(const struct device *dev, uint32_t cmd,
 	return 0;
 }
 
-static int dummy_parent_pm_ctrl(const struct device *dev,
-				enum pm_device_action action)
+static int dummy_parent_pm_action(const struct device *dev,
+				  enum pm_device_action action)
 {
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
@@ -52,5 +52,5 @@ int dummy_parent_init(const struct device *dev)
 }
 
 DEVICE_DEFINE(dummy_parent, DUMMY_PARENT_NAME, &dummy_parent_init,
-		    dummy_parent_pm_ctrl, NULL, NULL, POST_KERNEL,
+		    dummy_parent_pm_action, NULL, NULL, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &funcs);

--- a/tests/benchmarks/footprints/src/pm_device.c
+++ b/tests/benchmarks/footprints/src/pm_device.c
@@ -21,15 +21,15 @@ static int dummy_init(const struct device *dev)
 	return 0;
 }
 
-static int dummy_device_pm_ctrl(const struct device *dev,
-				enum pm_device_action action)
+static int dummy_device_pm_action(const struct device *dev,
+				  enum pm_device_action action)
 {
 	return 0;
 }
 
 /* Define a driver with and without power management enabled */
 DEVICE_DEFINE(dummy_pm_driver, DUMMY_PM_DRIVER_NAME, &dummy_init,
-		    dummy_device_pm_ctrl, NULL, NULL, APPLICATION,
+		    dummy_device_pm_action, NULL, NULL, APPLICATION,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
 
 DEVICE_DEFINE(dummy_driver, DUMMY_DRIVER_NAME, &dummy_init,

--- a/tests/kernel/device/src/dummy_driver.c
+++ b/tests/kernel/device/src/dummy_driver.c
@@ -32,7 +32,7 @@ int dummy_init(const struct device *dev)
 	return 0;
 }
 
-int dummy_pm_control(const struct device *dev, enum pm_device_action action)
+int dummy_pm_action(const struct device *dev, enum pm_device_action action)
 {
 	return 0;
 }
@@ -41,7 +41,7 @@ int dummy_pm_control(const struct device *dev, enum pm_device_action action)
  * @cond INTERNAL_HIDDEN
  */
 DEVICE_DEFINE(dummy_driver, DUMMY_DRIVER_NAME, dummy_init,
-		dummy_pm_control, NULL, NULL, POST_KERNEL,
+		dummy_pm_action, NULL, NULL, POST_KERNEL,
 		CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &funcs);
 
 /**

--- a/tests/net/pm/src/main.c
+++ b/tests/net/pm/src/main.c
@@ -21,8 +21,8 @@ struct fake_dev_context {
 	struct net_if *iface;
 };
 
-static int fake_dev_pm_control(const struct device *dev,
-			       enum pm_device_action action)
+static int fake_dev_pm_action(const struct device *dev,
+			      enum pm_device_action action)
 {
 	struct fake_dev_context *ctx = dev->data;
 	int ret;
@@ -100,7 +100,7 @@ static struct dummy_api fake_dev_if_api = {
 #define _ETH_L2_CTX_TYPE NET_L2_GET_CTX_TYPE(DUMMY_L2)
 
 NET_DEVICE_INIT(fake_dev, "fake_dev",
-		fake_dev_init, fake_dev_pm_control,
+		fake_dev_init, fake_dev_pm_action,
 		&fake_dev_context_data, NULL,
 		CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		&fake_dev_if_api, _ETH_L2_LAYER, _ETH_L2_CTX_TYPE, 127);

--- a/tests/subsys/pm/device_runtime_api/src/test_driver.c
+++ b/tests/subsys/pm/device_runtime_api/src/test_driver.c
@@ -14,8 +14,8 @@ struct test_driver_data {
 	struct k_sem sync;
 };
 
-static int test_driver_action_cb(const struct device *dev,
-				 enum pm_device_action action)
+static int test_driver_action(const struct device *dev,
+			      enum pm_device_action action)
 {
 	struct test_driver_data *data = dev->data;
 
@@ -64,5 +64,5 @@ int test_driver_init(const struct device *dev)
 static struct test_driver_data data;
 
 DEVICE_DEFINE(test_driver, "test_driver", &test_driver_init,
-	      test_driver_action_cb, &data, NULL, POST_KERNEL,
+	      test_driver_action, &data, NULL, POST_KERNEL,
 	      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, NULL);

--- a/tests/subsys/pm/power_mgmt/src/dummy_driver.c
+++ b/tests/subsys/pm/power_mgmt/src/dummy_driver.c
@@ -19,8 +19,8 @@ static int dummy_close(const struct device *dev)
 	return pm_device_runtime_put(dev);
 }
 
-static int dummy_device_pm_ctrl(const struct device *dev,
-				enum pm_device_action action)
+static int dummy_device_pm_action(const struct device *dev,
+				  enum pm_device_action action)
 {
 	return 0;
 }
@@ -37,5 +37,5 @@ int dummy_init(const struct device *dev)
 }
 
 DEVICE_DEFINE(dummy_driver, DUMMY_DRIVER_NAME, &dummy_init,
-		    dummy_device_pm_ctrl, NULL, NULL, APPLICATION,
+		    dummy_device_pm_action, NULL, NULL, APPLICATION,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &funcs);

--- a/tests/subsys/pm/power_mgmt/src/main.c
+++ b/tests/subsys/pm/power_mgmt/src/main.c
@@ -165,7 +165,7 @@ void test_power_state_trans(void)
  *  - device driver notify its power state change by pm_device_runtime_get and
  *    pm_device_runtime_put_async
  *  - system inform device system power state change through device interface
- *    pm_control
+ *    pm_action_cb
  *
  * @see pm_device_runtime_get(), pm_device_runtime_put_async(),
  *      pm_device_state_set(), pm_device_state_get()


### PR DESCRIPTION
- Use consistent callback naming, not referencing "pm_control" as it is no longer used
- Update the networking device macros to use action naming
- Fixed some small issues (see commit list)
- Updated docs