### PR TITLE
twister: reenable build samples on Windows OS

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -24,7 +24,6 @@ import glob
 import concurrent
 import xml.etree.ElementTree as ET
 import logging
-import pty
 from pathlib import Path
 from distutils.spawn import find_executable
 from colorama import Fore
@@ -57,6 +56,14 @@ try:
     import psutil
 except ImportError:
     print("Install psutil python module with pip to run in Qemu.")
+
+try:
+    import pty
+except ImportError as capture_error:
+    if os.name == "nt":  # "nt" means that program is running on Windows OS
+        pass  # "--device-serial-pty" option is not supported on Windows OS
+    else:
+        raise capture_error
 
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
 if not ZEPHYR_BASE:
@@ -2799,7 +2806,7 @@ class TestSuite(DisablePyTestCollectionMixin):
             logger.info("Cannot read zephyr version.")
 
     def get_platform_instances(self, platform):
-        filtered_dict = {k:v for k,v in self.instances.items() if k.startswith(platform + "/")}
+        filtered_dict = {k:v for k,v in self.instances.items() if k.startswith(platform + os.sep)}
         return filtered_dict
 
     def config(self):

--- a/scripts/twister
+++ b/scripts/twister
@@ -635,6 +635,7 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
                         help="""Script for controlling pseudoterminal.
                         Twister believes that it interacts with a terminal
                         when it actually interacts with the script.
+                        Not supported on Windows OS.
 
                         E.g "twister --device-testing
                         --device-serial-pty <script>
@@ -838,6 +839,10 @@ def main():
 
     if not options.coverage_platform:
         options.coverage_platform = options.platform
+
+    if options.device_serial_pty and os.name == "nt":  # OS is Windows
+        logger.error("--device-serial-pty is not supported on Windows OS")
+        sys.exit(1)
 
     if options.size:
         for fn in options.size:
@@ -1322,5 +1327,6 @@ if __name__ == "__main__":
     try:
         main()
     finally:
-        if os.isatty(1): # stdout is interactive
+        if (os.name != "nt") and os.isatty(1):
+            # (OS is not Windows) and (stdout is interactive)
             os.system("stty sane")


### PR DESCRIPTION
Fix few limitation which do not allow to run Twister on Windows OS.
Especially turn off "import pty" module, due to the fact, that this module
can be used only on POSIX OS.

Fixes #40007

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>