### PR TITLE
west: build.py: resolve symlinks in cached source directory check

### DIFF
--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -368,7 +368,7 @@ class Build(Forceable):
         # If the build directory specifies a source app, make sure it's
         # consistent with --source-dir.
         apps_mismatched = (source_abs and cached_abs and
-            pathlib.PurePath(source_abs) != pathlib.PurePath(cached_abs))
+            pathlib.Path(source_abs).resolve() != pathlib.Path(cached_abs).resolve())
 
         self.check_force(
             not apps_mismatched or self.auto_pristine,


### PR DESCRIPTION
Fixes the following error:
```
ERROR: Build directory "<whatever>" is for application "<symbolic source
  dir in CMakeCache.txt>", but source directory "<resolved source dir>"
  was specified; please clean it, use --pristine, or use --build-dir to
  set another build directory
FATAL ERROR: refusing to proceed without --force due to above error
```
Fixes initial commit ab82264ace163 ("scripts: add west build, flash, and
debug commands")

Signed-off-by: Marc Herbert <marc.herbert@intel.com>