### PR TITLE
drivers/flash/nrf_qspi_nor: Fix qspi_sfdp_read error path

### DIFF
--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -603,11 +603,13 @@ static int qspi_sfdp_read(const struct device *dev, off_t offset,
 		.io3_level = true,
 	};
 
-	int res = ANOMALY_122_INIT(dev);
+	int ret = ANOMALY_122_INIT(dev);
+	nrfx_err_t res = NRFX_SUCCESS;
 
-	if (res != NRFX_SUCCESS) {
-		LOG_DBG("ANOMALY_122_INIT: %x", res);
-		goto out;
+	if (ret != 0) {
+		LOG_DBG("ANOMALY_122_INIT: %d", ret);
+		ANOMALY_122_UNINIT(dev);
+		return ret;
 	}
 
 	qspi_lock(dev);


### PR DESCRIPTION
The commit fixes processing of a return value from the ANOMALY_122_INIT
call.

Fixes #39923.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>