### PR TITLE
boards: imxrt10x0_evk_xxxx: fixes to alternative flexspi configurations

### DIFF
--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.dts
@@ -10,13 +10,17 @@
 
 / {
 	chosen {
-		/delete-property/ zephyr,flash-controller;
-		/delete-property/ zephyr,flash;
-		/delete-property/ zephyr,code-partition;
+		zephyr,flash-controller = &flexspi;
+		zephyr,flash = &is25wp064;
+		zephyr,code-partition = &slot0_partition;
 	};
 };
 
 &flexspi {
+	status = "okay";
+	ahb-prefetch;
+	ahb-read-addr-opt;
+	rx-clock-source = <1>;
 	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(8)>;
 	is25wp064: is25wp064@0 {
 		compatible = "nxp,imx-flexspi-nor";
@@ -26,5 +30,34 @@
 		spi-max-frequency = <133000000>;
 		status = "okay";
 		jedec-id = [9d 70 17];
+		erase-block-size = <4096>;
+		write-block-size = <1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			boot_partition: partition@0 {
+				label = "mcuboot";
+				reg = <0x00000000 DT_SIZE_K(64)>;
+			};
+			slot0_partition: partition@10000 {
+				label = "image-0";
+				reg = <0x00010000 DT_SIZE_M(3)>;
+			};
+			slot1_partition: partition@310000 {
+				label = "image-1";
+				reg = <0x00310000 DT_SIZE_M(3)>;
+			};
+			scratch_partition: partition@610000 {
+				label = "image-scratch";
+				reg = <0x00610000 DT_SIZE_K(128)>;
+			};
+			storage_partition: partition@630000 {
+				label = "storage";
+				reg = <0x00630000 DT_SIZE_K(1856)>;
+			};
+		};
 	};
 };

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk_hyperflash.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk_hyperflash.dts
@@ -10,13 +10,21 @@
 
 / {
 	chosen {
-		/delete-property/ zephyr,flash-controller;
-		/delete-property/ zephyr,flash;
-		/delete-property/ zephyr,code-partition;
+		zephyr,flash-controller = &s26ks512s0;
+		zephyr,flash = &s26ks512s0;
+		zephyr,code-partition = &slot0_partition;
 	};
 };
 
 &flexspi {
+	status = "okay";
+	ahb-prefetch;
+	ahb-read-addr-opt;
+	ahb-bufferable;
+	ahb-cacheable;
+	sck-differential-clock;
+	combination-mode;
+	rx-clock-source = <3>;
 	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(64)>;
 	s26ks512s0: s26ks512s@0 {
 		compatible = "nxp,imx-flexspi-hyperflash";
@@ -24,6 +32,42 @@
 		label = "S26KS512S";
 		reg = <0>;
 		spi-max-frequency = <166000000>;
+		word-addressable;
+		cs-interval-unit = <1>;
+		cs-interval = <2>;
+		cs-hold-time = <0>;
+		cs-setup-time = <3>;
+		data-valid-time = <1>;
+		column-space = <3>;
+		ahb-write-wait-unit = <2>;
+		ahb-write-wait-interval = <20>;
 		status = "okay";
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			boot_partition: partition@0 {
+				label = "mcuboot";
+				reg = <0x00000000 DT_SIZE_K(256)>;
+			};
+			slot0_partition: partition@40000 {
+				label = "image-0";
+				reg = <0x00040000 DT_SIZE_M(3)>;
+			};
+			slot1_partition: partition@340000 {
+				label = "image-1";
+				reg = <0x00340000 DT_SIZE_M(3)>;
+			};
+			scratch_partition: partition@640000 {
+				label = "image-scratch";
+				reg = <0x00640000 DT_SIZE_K(768)>;
+			};
+			storage_partition: partition@700000 {
+				label = "storage";
+				reg = <0x00700000 DT_SIZE_M(57)>;
+			};
+		};
 	};
 };


### PR DESCRIPTION
This fixes the build issue with chosen zephyr,flash missing.

Fixes: #40021

Signed-off-by: Nicolai Glud <nicolai.glud@prevas.dk>