### PR TITLE
Bluetooth: Mesh: Fix incorrect write conn_count

### DIFF
--- a/subsys/bluetooth/mesh/proxy_srv.c
+++ b/subsys/bluetooth/mesh/proxy_srv.c
@@ -880,10 +880,9 @@ static void gatt_disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	conn_count--;
-
 	client = find_client(conn);
 	if (client->cli) {
+		conn_count--;
 		bt_mesh_proxy_role_cleanup(client->cli);
 		client->cli = NULL;
 	}


### PR DESCRIPTION
When Device use pb-gatt bearer provisioning, and first
provisioning failed due to some reasons(invalid oob etc..).

Which cause `proxy:gatt_disconnectd` incorrected write `conn_count`

Cause this var euqals `-1`.

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>