### PR TITLE
ITE MAINTAINERS: add tachometer path for compliance check

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1571,6 +1571,7 @@ ITE Platforms:
         - sjg20
     files:
         - boards/riscv/it8xxx2_evb/
+        - drivers/*/*/*it8xxx2*
         - drivers/*/*it8xxx2*
         - dts/bindings/*/*ite*
         - dts/riscv/*it8xxx2*


### PR DESCRIPTION
Add path: drivers/sensor/ite_tach_it8xxx2/*it8xxx2*
for compliance check.

Signed-off-by: Ruibin Chang <Ruibin.Chang@ite.com.tw>