### PR TITLE
manifest: mcuboot upgrade

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -168,7 +168,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: c61538748ead773ea75a551a7beee299228bdcaf
+      revision: 225b02468bf77806bdd5f503725256cb345970d2
       path: bootloader/mcuboot
     - name: mcumgr
       revision: c854c85ec75d624c47058bc4ac0ab9b12e2dd0e7


### PR DESCRIPTION
MCUboot was synchronized with the upstream SHA:
a9c6d8495e4dbe7d02edf14bb8a9fa1d4e955c0

This version is post MCUboot v1.8.0 version.
It contain a few small fixes more than mentioned release.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>