### PR TITLE
Bluetooth: controller: support not passing invalid SDUs on HCI data path

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -646,6 +646,13 @@ config BT_CTLR_CONN_ISO_STREAMS_PER_GROUP
 	help
 	  Maximum supported CISes per CIG.
 
+config BT_CTLR_CONN_ISO_HCI_DATAPATH_SKIP_INVALID_DATA
+	bool "Do not pass invalid SDUs on HCI datapath"
+	depends on BT_CTLR_CONN_ISO
+	help
+	  This allows for applications to decide whether to
+	  forward invalid SDUs through HCI upwards.
+
 config BT_CTLR_ISO
 	bool
 	default BT_CTLR_BROADCAST_ISO || BT_CTLR_CONN_ISO

--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -116,7 +116,16 @@ isoal_status_t sink_sdu_emit_hci(const struct isoal_sink         *sink_ctx,
 
 	buf = (struct net_buf *) valid_sdu->contents.dbuf;
 
+
 	if (buf) {
+#if defined(CONFIG_BT_CTLR_CONN_ISO_HCI_DATAPATH_SKIP_INVALID_DATA)
+		if (valid_sdu->status != ISOAL_SDU_STATUS_VALID) {
+			/* unref buffer if invalid fragment */
+			net_buf_unref(buf);
+
+			return ISOAL_STATUS_OK;
+		}
+#endif /* CONFIG_BT_CTLR_CONN_ISO_HCI_DATAPATH_SKIP_INVALID_DATA */
 		data_hdr = net_buf_push(buf, BT_HCI_ISO_TS_DATA_HDR_SIZE);
 		hdr = net_buf_push(buf, BT_HCI_ISO_HDR_SIZE);
 


### PR DESCRIPTION
In testing ISO with EDTT it has become clear that EDTT does not deal too well with being flooded by invalid SDUs.
Thus I have come up with this suggestion on how to allow for enabling the skipping sending these SDUs upwards on the HCI data path.

Adding a KConfig to allow for disabling of the passing of invalid SDUs through the ISOAL HCI data path.
Defaults to keeping current behavior.

