### PR TITLE
LE Audio: ASCS use server callbacks 

### DIFF
--- a/include/bluetooth/audio.h
+++ b/include/bluetooth/audio.h
@@ -836,6 +836,132 @@ struct bt_audio_stream {
 	};
 };
 
+/** Unicast Server callback structure */
+struct bt_audio_unicast_server_cb {
+	/** @brief Endpoint config request callback
+	 *
+	 *  Config callback is called whenever an endpoint is requested to be
+	 *  configured
+	 *
+	 *  @param[in]  conn    Connection object.
+	 *  @param[in]  ep      Local Audio Endpoint being configured.
+	 *  @param[in]  cap     Local Audio Capability being configured.
+	 *  @param[in]  codec   Codec configuration.
+	 *  @param[out] stream  Pointer to stream that will be configured for
+	 *                      the endpoint.
+	 *
+	 *  @return 0 in case of success or negative value in case of error.
+	 */
+	int (*config)(struct bt_conn *conn,
+		      const struct bt_audio_ep *ep,
+		      const struct bt_audio_capability *cap,
+		      const struct bt_codec *codec,
+		      struct bt_audio_stream **stream);
+
+	/** @brief Stream reconfig request callback
+	 *
+	 *  Reconfig callback is called whenever an Audio Stream needs to be
+	 *  reconfigured with different codec configuration.
+	 *
+	 *  @param stream  Stream object being reconfigured.
+	 *  @param cap     Local Audio Capability being reconfigured.
+	 *  @param codec   Codec configuration.
+	 *
+	 *  @return 0 in case of success or negative value in case of error.
+	 */
+	int (*reconfig)(struct bt_audio_stream *stream,
+			const struct bt_audio_capability *cap,
+			const struct bt_codec *codec);
+
+	/** @brief Stream QoS request callback
+	 *
+	 *  QoS callback is called whenever an Audio Stream Quality of
+	 *  Service needs to be configured.
+	 *
+	 *  @param stream  Stream object being reconfigured.
+	 *  @param qos     Quality of Service configuration.
+	 *
+	 *  @return 0 in case of success or negative value in case of error.
+	 */
+	int (*qos)(struct bt_audio_stream *stream,
+		   const struct bt_codec_qos *qos);
+
+	/** @brief Stream Enable request callback
+	 *
+	 *  Enable callback is called whenever an Audio Stream is requested to
+	 *  be enabled to stream.
+	 *
+	 *  @param stream      Stream object being enabled.
+	 *  @param meta_count  Number of metadata entries
+	 *  @param meta        Metadata entries
+	 *
+	 *  @return 0 in case of success or negative value in case of error.
+	 */
+	int (*enable)(struct bt_audio_stream *stream, uint8_t meta_count,
+		      const struct bt_codec_data *meta);
+
+	/** @brief Stream Start request callback
+	 *
+	 *  Start callback is called whenever an Audio Stream is requested to
+	 *  start streaming.
+	 *
+	 *  @param stream Stream object.
+	 *
+	 *  @return 0 in case of success or negative value in case of error.
+	 */
+	int (*start)(struct bt_audio_stream *stream);
+
+	/** @brief Stream Metadata update request callback
+	 *
+	 *  Metadata callback is called whenever an Audio Stream is requested to
+	 *  update its metadata.
+	 *
+	 *  @param stream       Stream object.
+	 *  @param meta_count   Number of metadata entries
+	 *  @param meta         Metadata entries
+	 *
+	 *  @return 0 in case of success or negative value in case of error.
+	 */
+	int (*metadata)(struct bt_audio_stream *stream, uint8_t meta_count,
+			const struct bt_codec_data *meta);
+
+	/** @brief Stream Disable request callback
+	 *
+	 *  Disable callback is called whenever an Audio Stream is requested to
+	 *  disable the stream.
+	 *
+	 *  @param stream Stream object being disabled.
+	 *
+	 *  @return 0 in case of success or negative value in case of error.
+	 */
+	int (*disable)(struct bt_audio_stream *stream);
+
+	/** @brief Stream Stop callback
+	 *
+	 *  Stop callback is called whenever an Audio Stream is requested to
+	 *  stop streaming.
+	 *
+	 *  @param stream Stream object.
+	 *
+	 *  @return 0 in case of success or negative value in case of error.
+	 */
+	int (*stop)(struct bt_audio_stream *stream);
+
+	/** @brief Stream release callback
+	 *
+	 *  Release callback is called whenever a new Audio Stream needs to be
+	 *  released and thus deallocated.
+	 *
+	 *  @param stream Stream object.
+	 *
+	 *  @return 0 in case of success or negative value in case of error.
+	 */
+	int (*release)(struct bt_audio_stream *stream);
+
+	/* Internally used list node */
+	sys_snode_t node;
+};
+
 /** @brief Capability operations structure.
  *
  *  These are only used for unicast streams and broadcast sink streams.
@@ -1212,6 +1338,28 @@ int bt_audio_capability_unregister(struct bt_audio_capability *cap);
  */
 void bt_audio_stream_cb_register(struct bt_audio_stream *stream,
 				 struct bt_audio_stream_ops *ops);
+
+/** @brief Register unicast server callbacks.
+ *
+ *  Only one callback structure can be registered, and attempting to
+ *  registering more than one will result in an error.
+ *
+ *  @param cb  Unicast server callback structure.
+ *
+ *  @return 0 in case of success or negative value in case of error.
+ */
+int bt_audio_unicast_server_register_cb(const struct bt_audio_unicast_server_cb *cb);
+
+/** @brief Unregister unicast server callbacks.
+ *
+ *  May only unregister a callback structure that has previously been
+ *  registered by bt_audio_unicast_server_register_cb().
+ *
+ *  @param cb  Unicast server callback structure.
+ *
+ *  @return 0 in case of success or negative value in case of error.
+ */
+int bt_audio_unicast_server_unregister_cb(const struct bt_audio_unicast_server_cb *cb);
 
 /**
  * @defgroup bt_audio_client Audio Client APIs

--- a/subsys/bluetooth/host/audio/ascs.c
+++ b/subsys/bluetooth/host/audio/ascs.c
@@ -661,8 +661,13 @@ static int ase_config(struct bt_ascs *ascs, struct bt_ascs_ase *ase,
 		}
 
 		if (ase->ep.stream != NULL) {
-			err = bt_audio_stream_reconfig(ase->ep.stream, cap,
-						       &ase->ep.codec);
+			if (server_cb != NULL && server_cb->config != NULL) {
+				err = server_cb->reconfig(ase->ep.stream, cap,
+							  &ase->ep.codec);
+			} else {
+				err = -EACCES;
+			}
+
 			if (err) {
 				uint8_t reason = BT_ASCS_REASON_CODEC_DATA;
 

--- a/subsys/bluetooth/host/audio/ascs.c
+++ b/subsys/bluetooth/host/audio/ascs.c
@@ -793,8 +793,7 @@ static int ase_stream_qos(struct bt_audio_stream *stream, struct bt_codec_qos *q
 {
 	BT_DBG("stream %p qos %p", stream, qos);
 
-	if (stream == NULL || stream->ep == NULL || stream->cap == NULL ||
-	    stream->cap->ops == NULL || qos == NULL) {
+	if (stream == NULL || stream->ep == NULL || qos == NULL) {
 		return -EINVAL;
 	}
 
@@ -818,10 +817,10 @@ static int ase_stream_qos(struct bt_audio_stream *stream, struct bt_codec_qos *q
 		return -EINVAL;
 	}
 
-	if (stream->cap->ops->qos != NULL) {
+	if (server_cb != NULL && server_cb->config != NULL) {
 		int err;
 
-		err = stream->cap->ops->qos(stream, qos);
+		err = server_cb->qos(stream, qos);
 		if (err != 0) {
 			return err;
 		}

--- a/subsys/bluetooth/host/audio/ascs.c
+++ b/subsys/bluetooth/host/audio/ascs.c
@@ -9,6 +9,7 @@
 
 #include <zephyr.h>
 #include <sys/byteorder.h>
+#include <sys/check.h>
 
 #include <device.h>
 #include <init.h>
@@ -54,6 +55,42 @@ struct bt_ascs {
 };
 
 static struct bt_ascs sessions[CONFIG_BT_MAX_CONN];
+
+static const struct bt_audio_unicast_server_cb *server_cb;
+
+int bt_audio_unicast_server_register_cb(const struct bt_audio_unicast_server_cb *cb)
+{
+	CHECKIF(cb == NULL) {
+		BT_DBG("cb is NULL");
+		return -EINVAL;
+	}
+
+	if (server_cb != NULL) {
+		BT_DBG("callback structure already registered");
+		return -EALREADY;
+	}
+
+	server_cb = cb;
+
+	return 0;
+}
+
+int bt_audio_unicast_server_unregister_cb(const struct bt_audio_unicast_server_cb *cb)
+{
+	CHECKIF(cb == NULL) {
+		BT_DBG("cb is NULL");
+		return -EINVAL;
+	}
+
+	if (server_cb != cb) {
+		BT_DBG("callback structure not registered");
+		return -EINVAL;
+	}
+
+	server_cb = NULL;
+
+	return 0;
+}
 
 static void ascs_ase_cfg_changed(const struct bt_gatt_attr *attr,
 				 uint16_t value)

--- a/subsys/bluetooth/host/audio/ascs.c
+++ b/subsys/bluetooth/host/audio/ascs.c
@@ -230,7 +230,7 @@ static void ase_release(struct bt_ascs_ase *ase, bool cache)
 	if (server_cb != NULL && server_cb->release != NULL) {
 		err = server_cb->release(ase->ep.stream);
 	} else {
-		err = -EACCES;
+		err = -EOPNOTSUPP;
 	}
 
 	if (err) {
@@ -299,7 +299,7 @@ static void ase_disable(struct bt_ascs_ase *ase)
 	if (server_cb != NULL && server_cb->release != NULL) {
 		err = server_cb->disable(stream);
 	} else {
-		err = -EACCES;
+		err = -EOPNOTSUPP;
 	}
 
 	if (err) {
@@ -711,7 +711,7 @@ static int ase_config(struct bt_ascs *ascs, struct bt_ascs_ase *ase,
 				err = server_cb->reconfig(ase->ep.stream, cap,
 							  &ase->ep.codec);
 			} else {
-				err = -EACCES;
+				err = -EOPNOTSUPP;
 			}
 
 			if (err) {
@@ -733,7 +733,7 @@ static int ase_config(struct bt_ascs *ascs, struct bt_ascs_ase *ase,
 							cap, &ase->ep.codec,
 							&stream);
 			} else {
-				err = -EACCES;
+				err = -EOPNOTSUPP;
 			}
 
 			if (err || stream == NULL) {
@@ -1027,7 +1027,7 @@ static int ase_metadata(struct bt_ascs_ase *ase, uint8_t op,
 		err = server_cb->metadata(stream, ep->codec.meta_count,
 					  ep->codec.meta);
 	} else {
-		err = -EACCES;
+		err = -EOPNOTSUPP;
 	}
 
 	if (err) {
@@ -1083,7 +1083,7 @@ static int ase_enable(struct bt_ascs_ase *ase, struct bt_ascs_metadata *meta,
 		err = server_cb->enable(stream, ep->codec.meta_count,
 					ep->codec.meta);
 	} else {
-		err = -EACCES;
+		err = -EOPNOTSUPP;
 	}
 
 	if (err) {
@@ -1194,7 +1194,7 @@ static void ase_start(struct bt_ascs_ase *ase)
 	if (server_cb != NULL && server_cb->start != NULL) {
 		err = server_cb->start(stream);
 	} else {
-		err = -EACCES;
+		err = -EOPNOTSUPP;
 	}
 
 	if (err) {
@@ -1326,7 +1326,7 @@ static void ase_stop(struct bt_ascs_ase *ase)
 	if (server_cb != NULL && server_cb->stop != NULL) {
 		err = server_cb->stop(stream);
 	} else {
-		err = -EACCES;
+		err = -EOPNOTSUPP;
 	}
 
 	if (err) {

--- a/subsys/bluetooth/host/audio/capabilities.c
+++ b/subsys/bluetooth/host/audio/capabilities.c
@@ -27,6 +27,129 @@
 static sys_slist_t snks;
 static sys_slist_t srcs;
 
+#if defined(CONFIG_BT_AUDIO_UNICAST_SERVER) && defined(CONFIG_BT_ASCS)
+/* TODO: The unicast server callbacks uses `const` for many of the pointers,
+ * wheras the capabilities callbacks do no. The latter should be updated to use
+ * `const` where possible.
+ */
+static int unicast_server_config_cb(struct bt_conn *conn,
+				    const struct bt_audio_ep *ep,
+				    const struct bt_audio_capability *cap,
+				    const struct bt_codec *codec,
+				    struct bt_audio_stream **stream)
+{
+	if (cap->ops == NULL || cap->ops->config == NULL) {
+		return -EACCES;
+	}
+
+	*stream = cap->ops->config(conn,
+				   (struct bt_audio_ep *)ep,
+				   (struct bt_audio_capability *)cap,
+				   (struct bt_codec *)codec);
+
+	if (*stream == NULL) {
+		return -ENOMEM;
+	}
+
+	return 0;
+}
+
+static int unicast_server_reconfig_cb(struct bt_audio_stream *stream,
+				      const struct bt_audio_capability *cap,
+				      const struct bt_codec *codec)
+{
+	if (cap->ops == NULL || cap->ops->reconfig == NULL) {
+		return -EACCES;
+	}
+
+	return cap->ops->reconfig(stream,
+				  (struct bt_audio_capability *)cap,
+				  (struct bt_codec *)codec);
+}
+
+static int unicast_server_qos_cb(struct bt_audio_stream *stream,
+				 const struct bt_codec_qos *qos)
+{
+	if (stream->cap->ops == NULL || stream->cap->ops->qos == NULL) {
+		return -EACCES;
+	}
+
+	return stream->cap->ops->qos(stream, (struct bt_codec_qos *)qos);
+}
+
+static int unicast_server_enable_cb(struct bt_audio_stream *stream,
+				    uint8_t meta_count,
+				    const struct bt_codec_data *meta)
+{
+	if (stream->cap->ops == NULL || stream->cap->ops->enable == NULL) {
+		return -EACCES;
+	}
+
+	return stream->cap->ops->enable(stream, meta_count,
+					(struct bt_codec_data *)meta);
+}
+
+static int unicast_server_start_cb(struct bt_audio_stream *stream)
+{
+	if (stream->cap->ops == NULL || stream->cap->ops->start == NULL) {
+		return -EACCES;
+	}
+
+	return stream->cap->ops->start(stream);
+}
+
+static int unicast_server_metadata_cb(struct bt_audio_stream *stream,
+				      uint8_t meta_count,
+				      const struct bt_codec_data *meta)
+{
+	if (stream->cap->ops == NULL || stream->cap->ops->metadata == NULL) {
+		return -EACCES;
+	}
+
+	return stream->cap->ops->metadata(stream, meta_count,
+					  (struct bt_codec_data *)meta);
+}
+
+static int unicast_server_disable_cb(struct bt_audio_stream *stream)
+{
+	if (stream->cap->ops == NULL || stream->cap->ops->disable == NULL) {
+		return -EACCES;
+	}
+
+	return stream->cap->ops->disable(stream);
+}
+
+static int unicast_server_stop_cb(struct bt_audio_stream *stream)
+{
+	if (stream->cap->ops == NULL || stream->cap->ops->stop == NULL) {
+		return -EACCES;
+	}
+
+	return stream->cap->ops->stop(stream);
+}
+
+static int unicast_server_release_cb(struct bt_audio_stream *stream)
+{
+	if (stream->cap->ops == NULL || stream->cap->ops->release == NULL) {
+		return -EACCES;
+	}
+
+	return stream->cap->ops->release(stream);
+}
+
+static struct bt_audio_unicast_server_cb unicast_server_cb = {
+	.config = unicast_server_config_cb,
+	.reconfig = unicast_server_reconfig_cb,
+	.qos = unicast_server_qos_cb,
+	.enable = unicast_server_enable_cb,
+	.start = unicast_server_start_cb,
+	.metadata = unicast_server_metadata_cb,
+	.disable = unicast_server_disable_cb,
+	.stop = unicast_server_stop_cb,
+	.release = unicast_server_release_cb,
+};
+#endif /* CONFIG_BT_AUDIO_UNICAST_SERVER && CONFIG_BT_ASCS */
+
 sys_slist_t *bt_audio_capability_get(uint8_t type)
 {
 	switch (type) {
@@ -57,6 +180,28 @@ int bt_audio_capability_register(struct bt_audio_capability *cap)
 	       "codec vid 0x%04x", cap, cap->type, cap->codec->id,
 	       cap->codec->cid, cap->codec->vid);
 
+#if defined(CONFIG_BT_AUDIO_UNICAST_SERVER) && defined(CONFIG_BT_ASCS)
+	/* Using the capabilities instead of the unicast server directly will
+	 * require the capabilities to register the callbacks, which not only
+	 * will forward the unicast server callbacks, but also ensure that the
+	 * unicast server callbacks are not registered elsewhere
+	 */
+	static bool unicast_server_cb_registered;
+
+	if (!unicast_server_cb_registered) {
+		int err;
+
+		err = bt_audio_unicast_server_register_cb(&unicast_server_cb);
+		if (err != 0) {
+			BT_DBG("Failed to register unicast server callbacks: %d",
+			       err);
+			return err;
+		}
+
+		unicast_server_cb_registered = true;
+	}
+#endif /* CONFIG_BT_AUDIO_UNICAST_SERVER && CONFIG_BT_ASCS */
+
 	sys_slist_append(lst, &cap->node);
 
 #if defined(CONFIG_BT_PACS)
@@ -85,6 +230,22 @@ int bt_audio_capability_unregister(struct bt_audio_capability *cap)
 	if (!sys_slist_find_and_remove(lst, &cap->node)) {
 		return -ENOENT;
 	}
+
+#if defined(CONFIG_BT_AUDIO_UNICAST_SERVER) && defined(CONFIG_BT_ASCS)
+	/* If we are removing the last audio capability as the unicast
+	 * server, we unregister the callbacks.
+	 */
+	if (sys_slist_is_empty(&snks) && sys_slist_is_empty(&srcs)) {
+		int err;
+
+		err = bt_audio_unicast_server_unregister_cb(&unicast_server_cb);
+		if (err != 0) {
+			BT_DBG("Failed to register unicast server callbacks: %d",
+			       err);
+			return err;
+		}
+	}
+#endif /* CONFIG_BT_AUDIO_UNICAST_SERVER && CONFIG_BT_ASCS */
 
 #if defined(CONFIG_BT_PACS)
 	bt_pacs_remove_capability(cap->type);


### PR DESCRIPTION
ASCS will now use the newly created unicast server callbacks instead of using the public stream functions and the capabilities callbacks. 