### PR TITLE
net: arp: Fix ARP retransmission source address selection

### DIFF
--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -303,8 +303,10 @@ static inline struct net_pkt *arp_prepare(struct net_if *iface,
 	memcpy(hdr->src_hwaddr.addr, net_pkt_lladdr_src(pkt)->addr,
 	       sizeof(struct net_eth_addr));
 
-	if (!entry || net_pkt_ipv4_auto(pkt)) {
+	if (net_pkt_ipv4_auto(pkt)) {
 		my_addr = current_ip;
+	} else if (!entry) {
+		my_addr = &NET_IPV4_HDR(pending)->src;
 	} else {
 		my_addr = if_get_addr(entry->iface, current_ip);
 	}


### PR DESCRIPTION
There was a problem with source address selection for ARP
retransmissions, when an ARP entry was already pending. In such case,
the `entry` value passed to `arp_prepare()` is NULL, which in result
caused the `current_ip` variable being used as the source value. The
problem with this approach is, that the `current_ip` is only set in
IPv4 autoconf, the Ethernet L2 does not set this variable. In result,
every retransmission of an ARP packet was sent with unspecified source
address, preventing the response from being handled.

Fix this by partially restoring the behaviour of the ARP source address
assignment from before IPv4 autoconf was introduced. If the ARP is sent
by the IPv4 autoconf, use the `current_ip` value provided. If entry is
not set, use the source IPv4 address set in the actual data packet.
Otherwise, search for a source address on the interface corresponding to
the `entry`.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>