### PR TITLE
storage/flash_map: Add FLASH_AREA_DEVICE macro

### DIFF
--- a/include/storage/flash_map.h
+++ b/include/storage/flash_map.h
@@ -271,6 +271,16 @@ uint8_t flash_area_erased_val(const struct flash_area *fa);
 #define FLASH_AREA_SIZE(label) \
 	DT_REG_SIZE(DT_NODE_BY_FIXED_PARTITION_LABEL(label))
 
+/**
+ * Get device pointer for device the area/partition resides on
+ *
+ * @param label partition label
+ *
+ * @return const struct device type pointer
+ */
+#define FLASH_AREA_DEVICE(label) \
+	DEVICE_DT_GET(DT_MTD_FROM_FIXED_PARTITION(DT_NODE_BY_FIXED_PARTITION_LABEL(label)))
+
 #ifdef __cplusplus
 }
 #endif

--- a/samples/subsys/nvs/src/main.c
+++ b/samples/subsys/nvs/src/main.c
@@ -48,8 +48,7 @@
 
 static struct nvs_fs fs;
 
-#define STORAGE_NODE DT_NODE_BY_FIXED_PARTITION_LABEL(storage)
-#define FLASH_NODE DT_MTD_FROM_FIXED_PARTITION(STORAGE_NODE)
+#define STORAGE_NODE_LABEL storage
 
 /* 1000 msec = 1 sec */
 #define SLEEP_TIME      100
@@ -78,7 +77,7 @@ void main(void)
 	 *	3 sectors
 	 *	starting at FLASH_AREA_OFFSET(storage)
 	 */
-	flash_dev = DEVICE_DT_GET(FLASH_NODE);
+	flash_dev = FLASH_AREA_DEVICE(STORAGE_NODE_LABEL);
 	if (!device_is_ready(flash_dev)) {
 		printk("Flash device %s is not ready\n", flash_dev->name);
 		return;

--- a/tests/subsys/storage/flash_map/src/main.c
+++ b/tests/subsys/storage/flash_map/src/main.c
@@ -26,12 +26,16 @@ void test_flash_area_get_sectors(void)
 	uint8_t wd[256];
 	uint8_t rd[256];
 	const struct device *flash_dev;
+	const struct device *flash_dev_a = FLASH_AREA_DEVICE(image_1);
 
 	rc = flash_area_open(FLASH_AREA_ID(image_1), &fa);
 	zassert_true(rc == 0, "flash_area_open() fail");
 
 	/* First erase the area so it's ready for use. */
 	flash_dev = flash_area_get_device(fa);
+
+	/* Device obtained by label should match the one from fa object */
+	zassert_equal(flash_dev, flash_dev_a, "Device for image_1 do not match");
 
 	rc = flash_erase(flash_dev, fa->fa_off, fa->fa_size);
 	zassert_true(rc == 0, "flash area erase fail");


### PR DESCRIPTION
The macro returns pointer to a device object the flash area
exists on.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>