### PR TITLE
net: lwm2m: Add option to configure device service period

### DIFF
--- a/include/net/lwm2m.h
+++ b/include/net/lwm2m.h
@@ -882,6 +882,18 @@ int lwm2m_engine_delete_res_inst(char *pathstr);
 int lwm2m_engine_update_service_period(k_work_handler_t service, uint32_t period_ms);
 
 /**
+ * @brief Update the period of the device service.
+ *
+ * Change the duration of the periodic device service that notifies the
+ * current time.
+ *
+ * @param[in] period_ms New period for the device service (in milliseconds)
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_update_device_service_period(uint32_t period_ms);
+
+/**
  * @brief Start the LwM2M engine
  *
  * LwM2M clients normally do not need to call this function as it is called

--- a/subsys/net/lib/lwm2m/lwm2m_obj_device.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_device.c
@@ -211,6 +211,11 @@ static void device_periodic_service(struct k_work *work)
 	NOTIFY_OBSERVER(LWM2M_OBJECT_DEVICE_ID, 0, DEVICE_CURRENT_TIME_ID);
 }
 
+int lwm2m_update_device_service_period(uint32_t period_ms)
+{
+	return lwm2m_engine_update_service_period(device_periodic_service, period_ms);
+}
+
 static struct lwm2m_engine_obj_inst *device_create(uint16_t obj_inst_id)
 {
 	int i = 0, j = 0;


### PR DESCRIPTION
The device service creates a notification of the current time resource
every 10s. This commit adds the possibility to change this timer to a
different value thus giving more control over the way the device object
is notified.

Signed-off-by: Sebastian Salveter <sebastian.salveter@grandcentrix.net>