### PR TITLE
drivers: ieee802154: b91: Kconfig update with new params.

### DIFF
--- a/drivers/ieee802154/Kconfig.b91
+++ b/drivers/ieee802154/Kconfig.b91
@@ -22,6 +22,19 @@ config IEEE802154_B91_INIT_PRIO
 	  Set the initialization priority number. Do not mess with it unless
 	  you know what you are doing.
 
+config IEEE802154_B91_SET_TXRX_DELAY_US
+	int "Tx/Rx modes switching delay time (us)"
+	default 120
+	help
+	  Delay time needed for PLL stabilization during Tx/Rx modes switching.
+
+config IEEE802154_B91_CCA_RSSI_THRESHOLD
+	int "CCA procedure RSSI threshold"
+	default -50
+	help
+	  CCA procedure returns true if the current RSSI value is less than
+	  this parameter.
+
 config IEEE802154_B91_RANDOM_MAC
 	bool "Random MAC address"
 	default y

--- a/drivers/ieee802154/ieee802154_b91.c
+++ b/drivers/ieee802154/ieee802154_b91.c
@@ -244,7 +244,7 @@ static void b91_send_ack(uint8_t seq_num)
 
 	b91_set_tx_payload(ack_buf, sizeof(ack_buf));
 	rf_set_txmode();
-	delay_us(B91_SET_TRX_MODE_DELAY_US);
+	delay_us(CONFIG_IEEE802154_B91_SET_TXRX_DELAY_US);
 	rf_tx_pkt(data.tx_buffer);
 }
 
@@ -410,7 +410,7 @@ static int b91_cca(const struct device *dev)
 	unsigned int t1 = stimer_get_tick();
 
 	while (!clock_time_exceed(t1, B91_CCA_TIME_MAX_US)) {
-		if (rf_get_rssi() < B91_CCA_RSSI_MIN) {
+		if (rf_get_rssi() < CONFIG_IEEE802154_B91_CCA_RSSI_THRESHOLD) {
 			return 0;
 		}
 	}
@@ -479,7 +479,7 @@ static int b91_start(const struct device *dev)
 	/* check if RF is already started */
 	if (!data.is_started) {
 		rf_set_rxmode();
-		delay_us(B91_SET_TRX_MODE_DELAY_US);
+		delay_us(CONFIG_IEEE802154_B91_SET_TXRX_DELAY_US);
 		riscv_plic_irq_enable(DT_INST_IRQN(0));
 		data.is_started = true;
 	}
@@ -496,7 +496,7 @@ static int b91_stop(const struct device *dev)
 	if (data.is_started) {
 		riscv_plic_irq_disable(DT_INST_IRQN(0));
 		rf_set_tx_rx_off();
-		delay_us(B91_SET_TRX_MODE_DELAY_US);
+		delay_us(CONFIG_IEEE802154_B91_SET_TXRX_DELAY_US);
 		data.is_started = false;
 	}
 
@@ -529,7 +529,7 @@ static int b91_tx(const struct device *dev,
 
 	/* start transmission */
 	rf_set_txmode();
-	delay_us(B91_SET_TRX_MODE_DELAY_US);
+	delay_us(CONFIG_IEEE802154_B91_SET_TXRX_DELAY_US);
 	rf_tx_pkt(data.tx_buffer);
 
 	/* wait for tx done */

--- a/drivers/ieee802154/ieee802154_b91.h
+++ b/drivers/ieee802154/ieee802154_b91.h
@@ -10,7 +10,6 @@
 /* Timeouts */
 #define B91_TX_WAIT_TIME_MS                 (10)
 #define B91_ACK_WAIT_TIME_MS                (10)
-#define B91_SET_TRX_MODE_DELAY_US           (100)
 
 /* Received data parsing */
 #define B91_PAYLOAD_OFFSET                  (5)
@@ -39,7 +38,6 @@
 #define B91_TRX_LENGTH                      (256)
 #define B91_RSSI_TO_LQI_SCALE               (3)
 #define B91_RSSI_TO_LQI_MIN                 (-87)
-#define B91_CCA_RSSI_MIN                    (-60)
 #define B91_CCA_TIME_MAX_US                 (200)
 #define B91_LOGIC_CHANNEL_TO_PHYSICAL(p)    (((p) - 10) * 5)
 


### PR DESCRIPTION
Added SET_TXRX_DELAY_US and CCA_RSSI_THRESHOLD params to Kconfig.

Signed-off-by: Yuriy Vynnychek <yura.vynnychek@telink-semi.com>