### PR TITLE
drivers: usb_dc_native_posix fill in data amount

### DIFF
--- a/drivers/usb/device/usb_dc_native_posix.c
+++ b/drivers/usb/device/usb_dc_native_posix.c
@@ -555,7 +555,7 @@ int handle_usb_data(struct usbip_header *hdr)
 		ep_ctrl->cb(ep, USB_DC_EP_DATA_OUT);
 
 		/* Send ACK reply */
-		if (!usbip_send_common(ep, 0)) {
+		if (!usbip_send_common(ep, ep_ctrl->data_len)) {
 			return -EIO;
 		}
 	} else {


### PR DESCRIPTION
Fill in received bytes in USBIP_RET_SUBMIT packet

Currently this field is unconditionally set to 0 and therefore not
filled in conveniently. This may mislead the USB host which is correctly
acknowledged that the transaction was sucessful but it cannot check the
actual received bytes.

Test application:

```python
import usb

data = (0xFF, 0xFF)
print("Opening loopback device")
device = usb.core.find(idVendor=0x2FE3, idProduct=0x0009)
print("Writing test data", data)
written = device.write(0x1, data)
print("Written", written, "bytes")
```

Before:
```
$ ./test_loopback.py
Opening loopback device
Writing test data (255, 255)
Written 0 bytes
```

After:
```
$ ./test_loopback.py
Opening loopback device
Writing test data (255, 255)
Written 2 bytes
```

Signed-off-by: Raúl Sánchez Siles <rsanchezs@k-lagan.com>