### PR TITLE
 usb: move USB_DEVICE_REMOTE_WAKEUP option to drivers, remove USB_SCD_ATTRIBUTES macro

### DIFF
--- a/drivers/usb/device/Kconfig
+++ b/drivers/usb/device/Kconfig
@@ -10,6 +10,11 @@ menuconfig USB_DEVICE_DRIVER
 
 if USB_DEVICE_DRIVER
 
+config USB_DEVICE_REMOTE_WAKEUP
+	bool
+	help
+	  USB device controller supports remote wakeup feature.
+
 config USB_DW
 	bool "Designware USB Device Controller Driver"
 	help
@@ -67,6 +72,7 @@ config USB_NRFX
 	depends on HAS_HW_NRF_USBD
 	select NRFX_USBD
 	select NRFX_POWER
+	select USB_DEVICE_REMOTE_WAKEUP
 	help
 	  nRF USB Device Controller Driver
 

--- a/include/usb/usb_ch9.h
+++ b/include/usb/usb_ch9.h
@@ -220,11 +220,6 @@ struct usb_association_descriptor {
 #define USB_SCD_RESERVED	BIT(7)
 #define USB_SCD_SELF_POWERED	BIT(6)
 #define USB_SCD_REMOTE_WAKEUP	BIT(5)
-#define USB_SCD_ATTRIBUTES	(USB_SCD_RESERVED |			      \
-				 COND_CODE_1(CONFIG_USB_SELF_POWERED,	      \
-					     (USB_SCD_SELF_POWERED), (0)) |   \
-				 COND_CODE_1(CONFIG_USB_DEVICE_REMOTE_WAKEUP, \
-					     (USB_SCD_REMOTE_WAKEUP), (0)))
 
 /** USB Defined Base Class Codes from https://www.usb.org/defined-class-codes */
 #define USB_BCC_AUDIO			0x01

--- a/samples/subsys/usb/hid-mouse/Kconfig
+++ b/samples/subsys/usb/hid-mouse/Kconfig
@@ -4,7 +4,4 @@
 config USB_DEVICE_PID
 	default USB_PID_HID_MOUSE_SAMPLE
 
-config USB_DEVICE_REMOTE_WAKEUP
-	default y if NRFX_USBD
-
 source "Kconfig.zephyr"

--- a/subsys/usb/Kconfig
+++ b/subsys/usb/Kconfig
@@ -99,11 +99,6 @@ config USB_DEVICE_SOF
 	bool "Enable Start of Frame processing in events"
 	default y if (USB_DEVICE_AUDIO && NRFX_USBD)
 
-config USB_DEVICE_REMOTE_WAKEUP
-	bool "Enable support for remote wakeup"
-	help
-	  This option requires USBD peripheral driver to also support remote wakeup.
-
 config USB_DEVICE_BOS
 	bool "Enable USB Binary Device Object Store (BOS)"
 

--- a/subsys/usb/class/dfu/usb_dfu.c
+++ b/subsys/usb/class/dfu/usb_dfu.c
@@ -155,7 +155,11 @@ struct dev_dfu_mode_descriptor dfu_mode_desc = {
 		.bNumInterfaces = 1,
 		.bConfigurationValue = 1,
 		.iConfiguration = 0,
-		.bmAttributes = USB_SCD_ATTRIBUTES,
+		.bmAttributes = USB_SCD_RESERVED |
+				COND_CODE_1(CONFIG_USB_SELF_POWERED,
+					    (USB_SCD_SELF_POWERED), (0)) |
+				COND_CODE_1(CONFIG_USB_DEVICE_REMOTE_WAKEUP,
+					    (USB_SCD_REMOTE_WAKEUP), (0)),
 		.bMaxPower = CONFIG_USB_MAX_POWER,
 	},
 	.sec_dfu_cfg = {

--- a/subsys/usb/usb_descriptor.c
+++ b/subsys/usb/usb_descriptor.c
@@ -90,7 +90,11 @@ USBD_DEVICE_DESCR_DEFINE(primary) struct common_descriptor common_desc = {
 		.bNumInterfaces = 0,
 		.bConfigurationValue = 1,
 		.iConfiguration = 0,
-		.bmAttributes = USB_SCD_ATTRIBUTES,
+		.bmAttributes = USB_SCD_RESERVED |
+				COND_CODE_1(CONFIG_USB_SELF_POWERED,
+					    (USB_SCD_SELF_POWERED), (0)) |
+				COND_CODE_1(CONFIG_USB_DEVICE_REMOTE_WAKEUP,
+					    (USB_SCD_REMOTE_WAKEUP), (0)),
 		.bMaxPower = CONFIG_USB_MAX_POWER,
 	},
 };


### PR DESCRIPTION
Remove USB_SCD_ATTRIBUTES macro.
USB_SCD_ATTRIBUTES is a configuration dependent macro
that does not map any part of the spec and does not
belong to usb_ch9 header.

Move USB_DEVICE_REMOTE_WAKEUP option to drivers.
Kconfig USB_DEVICE_REMOTE_WAKEUP option depends only on
USB device controller capability, but is not controlled
by the USB device controller drivers configuration.
Move USB_DEVICE_REMOTE_WAKEUP option to drivers and
make it promptless.