### PR TITLE
kernel: timer: Call user handler without spinlock

### DIFF
--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -43,7 +43,10 @@ void z_timer_expiration_handler(struct _timeout *t)
 
 	/* invoke timer expiry function */
 	if (timer->expiry_fn != NULL) {
+		/* Unlock for user handler. */
+		k_spin_unlock(&lock, key);
 		timer->expiry_fn(timer);
+		key = k_spin_lock(&lock);
 	}
 
 	if (!IS_ENABLED(CONFIG_MULTITHREADING)) {


### PR DESCRIPTION
Add spinlock unlocking before calling timer expiration
handler. Locking was introduced by dde3d6c.

Fixes #40000.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>