### PR TITLE
Bluetooth: Add missing header that defines BT_ISO_SDU_BUF_SIZE

### DIFF
--- a/subsys/bluetooth/host/hci_raw.c
+++ b/subsys/bluetooth/host/hci_raw.c
@@ -14,6 +14,7 @@
 #include <bluetooth/buf.h>
 #include <bluetooth/hci_raw.h>
 #include <bluetooth/l2cap.h>
+#include <bluetooth/iso.h>
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_CORE)
 #define LOG_MODULE_NAME bt_hci_raw


### PR DESCRIPTION
Add missing header iso.h to hci_raw.c, that defines the
BT_ISO_SDU_BUF_SIZE.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>