### PR TITLE
Bluetooth: Controller: Fix missing initialization of crc_ok

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -823,6 +823,8 @@ static void isr_rx_aux_chain(void *param)
 		 */
 		lll_isr_status_reset();
 
+		crc_ok =  0U;
+
 		goto isr_rx_aux_chain_done;
 	}
 


### PR DESCRIPTION
Fix missing initialization of crc_ok in the Periodic
Advertising Sync implementation.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>