### PR TITLE
Bluetooth: Host: Remove blocking behaviour from `gatt_req_alloc`

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -3113,6 +3113,13 @@ struct bt_att_req *bt_att_req_alloc(k_timeout_t timeout)
 {
 	struct bt_att_req *req = NULL;
 
+	if (k_current_get() == bt_recv_thread_id) {
+		/* No req will be fulfilled while blocking on the bt_recv thread.
+		 * Blocking would cause deadlock.
+		 */
+		timeout = K_NO_WAIT;
+	}
+
 	/* Reserve space for request */
 	if (k_mem_slab_alloc(&req_slab, (void **)&req, timeout)) {
 		BT_DBG("No space for req");

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3387,8 +3387,14 @@ void hci_event_prio(struct net_buf *buf)
 	}
 }
 
+k_tid_t bt_recv_thread_id;
+
 int bt_recv(struct net_buf *buf)
 {
+	if (bt_recv_thread_id == NULL) {
+		bt_recv_thread_id = k_current_get();
+	}
+
 	bt_monitor_send(bt_monitor_opcode(buf), buf->data, buf->len);
 
 	BT_DBG("buf %p len %u", buf, buf->len);

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -470,3 +470,8 @@ void bt_hci_synchronous_conn_complete(struct net_buf *buf);
 
 void bt_hci_le_df_connection_iq_report(struct net_buf *buf);
 void bt_hci_le_df_cte_req_failed(struct net_buf *buf);
+
+/** First thread that called bt_recv. NULL if not yet called.
+ *  Updated non-atomically; may be used only to compare to current thread id.
+ */
+extern k_tid_t bt_recv_thread_id;


### PR DESCRIPTION
bt_gatt_write would block in call to gatt_req_alloc if there were no
free req objects. `bt_gatt_write` is documented as async, so it should
not block.  This also affects all other `bt_gatt_*` functions that
allocate a req object.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/39624 where
if `bt_gatt_write` is called from BT RX thread (as can happen if it is
called from a bluetooth callback), the BT RX thread can be blocked and
prevented from processing the request responses and unblocking itself.
This was the cause of a soft 30s deadlock until gatt_req_alloc timeouts.

Signed-off-by: Aleksander Wasaznik <aleksander.wasaznik@nordicsemi.no>