### PR TITLE
Microchip: MEC172x: eSPI driver

### DIFF
--- a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
+++ b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
@@ -97,6 +97,10 @@
 	status = "okay";
 };
 
+&emi0 {
+	status = "okay";
+};
+
 &p80bd0 {
 	status = "okay";
 };

--- a/drivers/espi/Kconfig.xec_v2
+++ b/drivers/espi/Kconfig.xec_v2
@@ -10,6 +10,22 @@ config ESPI_XEC_V2
 	help
 	  Enable the Microchip XEC ESPI driver for MEC172x series.
 
+config ESPI_XEC_PERIPHERAL_ACPI_SHD_MEM_SIZE
+	int "Host I/O peripheral port size for shared memory in MEC172X series"
+	depends on ESPI_XEC_V2 || ESPI_PERIPHERAL_ACPI_SHM_REGION
+	default 256
+	help
+	  This is the port size used by the Host and EC to communicate over
+	  the shared memory region to return the ACPI response data.
+
+config ESPI_XEC_PERIPHERAL_HOST_CMD_PARAM_SIZE
+	int "Host I/O peripheral port size for ec host command in MEC172X series"
+	depends on ESPI_XEC_V2 || ESPI_PERIPHERAL_EC_HOST_CMD
+	default 256
+	help
+	  This is the port size used by the Host and EC to communicate over
+	  the shared memory region to return the host command parameter data.
+
 if ESPI_XEC_V2
 
 config ESPI_OOB_CHANNEL

--- a/soc/arm/microchip_mec/mec172x/reg/mec172x_emi.h
+++ b/soc/arm/microchip_mec/mec172x/reg/mec172x_emi.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021 Microchip Technology Inc. and its subsidiaries.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _MEC172X_EMI_H
+#define _MEC172X_EMI_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+/** @brief Embedded Memory Interface (EMI) Registers */
+struct emi_regs {
+	volatile uint8_t RT_HOST_TO_EC;
+	volatile uint8_t RT_EC_TO_HOST;
+	volatile uint8_t EC_ADDR_LSB;
+	volatile uint8_t EC_ADDR_MSB;
+	volatile uint8_t EC_DATA_0;		/* +0x04 */
+	volatile uint8_t EC_DATA_1;
+	volatile uint8_t EC_DATA_2;
+	volatile uint8_t EC_DATA_3;
+	volatile uint8_t INTR_SRC_LSB;	/* +0x08 */
+	volatile uint8_t INTR_SRC_MSB;
+	volatile uint8_t INTR_MSK_LSB;
+	volatile uint8_t INTR_MSK_MSB;
+	volatile uint8_t APPID;			/* +0x0C */
+	uint16_t RSVD1[3];
+	volatile uint8_t APPID_ASSGN;	/* +0x10 */
+	uint16_t RSVD2[3];
+	uint32_t RSVD3[(0x100 - 0x14) / 4];
+	volatile uint8_t HOST_TO_EC;	/* +0x100 */
+	volatile uint8_t EC_TO_HOST;
+	uint16_t RSVD4[1];
+	volatile uint32_t MEM_BA_0;		/* +0x104 */
+	volatile uint16_t MEM_RL_0;		/* +0x108 */
+	volatile uint16_t MEM_WL_0;
+	volatile uint32_t MEM_BA_1;		/* +0x10C */
+	volatile uint16_t MEM_RL_1;		/* +0x110 */
+	volatile uint16_t MEM_WL_1;
+	volatile uint16_t INTR_SET;		/* +0x114 */
+	volatile uint16_t HOST_CLR_EN;	/* +0x116 */
+	uint32_t RSVD5[2];
+	volatile uint32_t APPID_STS_1;	/* +0x120 */
+	volatile uint32_t APPID_STS_2;
+	volatile uint32_t APPID_STS_3;
+	volatile uint32_t APPID_STS_4;
+};
+
+#endif /* #ifndef _MEC172X_EMI_H */

--- a/soc/arm/microchip_mec/mec172x/soc.h
+++ b/soc/arm/microchip_mec/mec172x/soc.h
@@ -39,6 +39,7 @@
 #include "reg/mec172x_pcr.h"
 #include "reg/mec172x_qspi.h"
 #include "reg/mec172x_vbat.h"
+#include "reg/mec172x_emi.h"
 
 /* common peripheral register defines */
 #include "../common/reg/mec_acpi_ec.h"


### PR DESCRIPTION
Updates to MEC172x eSPI driver to support ACPI shared
memory region and EC Host Command Subsystem through
ACPI_EC1 and Embedded Memory Interface (EMI).

Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>