### PR TITLE
actions: only publish docs from zephyr repo

### DIFF
--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -20,6 +20,7 @@ jobs:
     name: Publish Documentation
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: github.repository == 'zephyrproject-rtos/zephyr'
 
     steps:
     - name: Download artifacts


### PR DESCRIPTION
Do not run doc publication job on other reports, only on the main zephyr
repo.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
