### PR TITLE
drivers: led: pca9633: add support for multiple devices

### DIFF
--- a/drivers/led/pca9633.c
+++ b/drivers/led/pca9633.c
@@ -31,7 +31,7 @@ LOG_MODULE_REGISTER(pca9633);
 /* PCA9633 control register */
 #define PCA9633_MODE1           0x00
 #define PCA9633_MODE2           0x01
-#define PCA9633_PWM_BASE        0x02
+#define PCA9633_PWM_BASE        0x02	/* Reg 0x02-0x05 for brightness control LED01-04 */
 #define PCA9633_GRPPWM          0x06
 #define PCA9633_GRPFREQ         0x07
 #define PCA9633_LEDOUT          0x08
@@ -43,8 +43,11 @@ LOG_MODULE_REGISTER(pca9633);
 
 #define PCA9633_MASK            0x03
 
+struct pca9633_config {
+	struct i2c_dt_spec i2c;
+};
+
 struct pca9633_data {
-	const struct device *i2c;
 	struct led_data dev_data;
 };
 
@@ -52,6 +55,7 @@ static int pca9633_led_blink(const struct device *dev, uint32_t led,
 			     uint32_t delay_on, uint32_t delay_off)
 {
 	struct pca9633_data *data = dev->data;
+	const struct pca9633_config *config = dev->config;
 	struct led_data *dev_data = &data->dev_data;
 	uint8_t gdc, gfrq;
 	uint32_t period;
@@ -69,7 +73,7 @@ static int pca9633_led_blink(const struct device *dev, uint32_t led,
 	 *		GDC = ((time_on * 256) / period)
 	 */
 	gdc = delay_on * 256U / period;
-	if (i2c_reg_write_byte(data->i2c, DT_INST_REG_ADDR(0),
+	if (i2c_reg_write_byte_dt(&config->i2c,
 			       PCA9633_GRPPWM,
 			       gdc)) {
 		LOG_ERR("LED reg write failed");
@@ -83,7 +87,7 @@ static int pca9633_led_blink(const struct device *dev, uint32_t led,
 	 *		GFRQ = ((period * 24 / 1000) - 1)
 	 */
 	gfrq = (period * 24U / 1000) - 1;
-	if (i2c_reg_write_byte(data->i2c, DT_INST_REG_ADDR(0),
+	if (i2c_reg_write_byte_dt(&config->i2c,
 			       PCA9633_GRPFREQ,
 			       gfrq)) {
 		LOG_ERR("LED reg write failed");
@@ -91,7 +95,7 @@ static int pca9633_led_blink(const struct device *dev, uint32_t led,
 	}
 
 	/* Enable blinking mode */
-	if (i2c_reg_update_byte(data->i2c, DT_INST_REG_ADDR(0),
+	if (i2c_reg_update_byte_dt(&config->i2c,
 				PCA9633_MODE2,
 				PCA9633_MODE2_DMBLNK,
 				PCA9633_MODE2_DMBLNK)) {
@@ -100,7 +104,7 @@ static int pca9633_led_blink(const struct device *dev, uint32_t led,
 	}
 
 	/* Select the GRPPWM source to drive the LED outpout */
-	if (i2c_reg_update_byte(data->i2c, DT_INST_REG_ADDR(0),
+	if (i2c_reg_update_byte_dt(&config->i2c,
 				PCA9633_LEDOUT,
 				PCA9633_MASK << (led << 1),
 				PCA9633_LED_GRP_PWM << (led << 1))) {
@@ -114,6 +118,7 @@ static int pca9633_led_blink(const struct device *dev, uint32_t led,
 static int pca9633_led_set_brightness(const struct device *dev, uint32_t led,
 				      uint8_t value)
 {
+	const struct pca9633_config *config = dev->config;
 	struct pca9633_data *data = dev->data;
 	struct led_data *dev_data = &data->dev_data;
 	uint8_t val;
@@ -125,7 +130,7 @@ static int pca9633_led_set_brightness(const struct device *dev, uint32_t led,
 
 	/* Set the LED brightness value */
 	val = (value * 255U) / dev_data->max_brightness;
-	if (i2c_reg_write_byte(data->i2c, DT_INST_REG_ADDR(0),
+	if (i2c_reg_write_byte_dt(&config->i2c,
 			       PCA9633_PWM_BASE + led,
 			       val)) {
 		LOG_ERR("LED reg write failed");
@@ -133,7 +138,7 @@ static int pca9633_led_set_brightness(const struct device *dev, uint32_t led,
 	}
 
 	/* Set the LED driver to be controlled through its PWMx register. */
-	if (i2c_reg_update_byte(data->i2c, DT_INST_REG_ADDR(0),
+	if (i2c_reg_update_byte_dt(&config->i2c,
 				PCA9633_LEDOUT,
 				PCA9633_MASK << (led << 1),
 				PCA9633_LED_PWM << (led << 1))) {
@@ -146,10 +151,10 @@ static int pca9633_led_set_brightness(const struct device *dev, uint32_t led,
 
 static inline int pca9633_led_on(const struct device *dev, uint32_t led)
 {
-	struct pca9633_data *data = dev->data;
+	const struct pca9633_config *config = dev->config;
 
 	/* Set LED state to ON */
-	if (i2c_reg_update_byte(data->i2c, DT_INST_REG_ADDR(0),
+	if (i2c_reg_update_byte_dt(&config->i2c,
 				PCA9633_LEDOUT,
 				PCA9633_MASK << (led << 1),
 				PCA9633_LED_ON << (led << 1))) {
@@ -162,10 +167,10 @@ static inline int pca9633_led_on(const struct device *dev, uint32_t led)
 
 static inline int pca9633_led_off(const struct device *dev, uint32_t led)
 {
-	struct pca9633_data *data = dev->data;
+	const struct pca9633_config *config = dev->config;
 
 	/* Set LED state to OFF */
-	if (i2c_reg_update_byte(data->i2c, DT_INST_REG_ADDR(0),
+	if (i2c_reg_update_byte_dt(&config->i2c,
 				PCA9633_LEDOUT,
 				PCA9633_MASK << (led << 1),
 				PCA9633_LED_OFF)) {
@@ -178,17 +183,17 @@ static inline int pca9633_led_off(const struct device *dev, uint32_t led)
 
 static int pca9633_led_init(const struct device *dev)
 {
+	const struct pca9633_config *config = dev->config;
 	struct pca9633_data *data = dev->data;
 	struct led_data *dev_data = &data->dev_data;
 
-	data->i2c = device_get_binding(DT_INST_BUS_LABEL(0));
-	if (data->i2c == NULL) {
-		LOG_DBG("Failed to get I2C device");
-		return -EINVAL;
+	if (!device_is_ready(config->i2c.bus)) {
+		LOG_ERR("I2C bus is not ready");
+		return -ENODEV;
 	}
 
 	/* Take the LED driver out from Sleep mode. */
-	if (i2c_reg_update_byte(data->i2c, DT_INST_REG_ADDR(0),
+	if (i2c_reg_update_byte_dt(&config->i2c,
 				PCA9633_MODE1,
 				PCA9633_MODE1_SLEEP,
 				~PCA9633_MODE1_SLEEP)) {
@@ -204,8 +209,6 @@ static int pca9633_led_init(const struct device *dev)
 	return 0;
 }
 
-static struct pca9633_data pca9633_led_data;
-
 static const struct led_driver_api pca9633_led_api = {
 	.blink = pca9633_led_blink,
 	.set_brightness = pca9633_led_set_brightness,
@@ -213,7 +216,16 @@ static const struct led_driver_api pca9633_led_api = {
 	.off = pca9633_led_off,
 };
 
-DEVICE_DT_INST_DEFINE(0, &pca9633_led_init, NULL,
-		    &pca9633_led_data,
-		    NULL, POST_KERNEL, CONFIG_LED_INIT_PRIORITY,
-		    &pca9633_led_api);
+#define PCA9633_DEVICE(id)						\
+	static const struct pca9633_config pca9633_##id##_cfg = {	\
+		.i2c = I2C_DT_SPEC_INST_GET(id)				\
+	};								\
+	static struct pca9633_data pca9633_##id##_data;			\
+									\
+	DEVICE_DT_INST_DEFINE(id, &pca9633_led_init, NULL,		\
+			&pca9633_##id##_data,				\
+			&pca9633_##id##_cfg, POST_KERNEL,		\
+			CONFIG_LED_INIT_PRIORITY,			\
+			&pca9633_led_api);
+
+DT_INST_FOREACH_STATUS_OKAY(PCA9633_DEVICE)


### PR DESCRIPTION
PCA9633 only supports one device.
Rewrite of the driver to support multiple devices.
Fixes #40076