### PR TITLE
Bluetooth: Controller: Fix missing auxiliary context release

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -858,6 +858,7 @@ static void isr_rx_aux_chain(void *param)
 		return;
 	}
 
+isr_rx_aux_chain_done:
 	if (!crc_ok) {
 		struct node_rx_pdu *node_rx;
 
@@ -873,7 +874,6 @@ static void isr_rx_aux_chain(void *param)
 		ull_rx_sched();
 	}
 
-isr_rx_aux_chain_done:
 	if (lll->is_aux_sched) {
 		lll->is_aux_sched = 0U;
 


### PR DESCRIPTION
Fix missing auxiliary context release when reception of
Periodic Advertising Chain PDU fails due to header complete
timeout, i.e. no reception of on-air PDU. Also, fix missing
generation of auxiliary reception failure notification when
no auxiliary context was allocated for chain PDU reception.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>