### PR TITLE
Bluetooth: host: Fix MIC generation in Bluetooth CCM encryption

### DIFF
--- a/subsys/bluetooth/host/aes_ccm.c
+++ b/subsys/bluetooth/host/aes_ccm.c
@@ -223,7 +223,7 @@ int bt_ccm_encrypt(const uint8_t key[16], uint8_t nonce[13],
 		return -EINVAL;
 	}
 
-	ccm_auth(key, nonce, enc_data, len, aad, aad_len, mic, mic_size);
+	ccm_auth(key, nonce, plaintext, len, aad, aad_len, mic, mic_size);
 
 	ccm_crypt(key, nonce, plaintext, enc_data, len);
 


### PR DESCRIPTION
bt_ccm_encrypt only works when encrypting in place. To fix this ccm_auth() inside bt_ccm_encrypt() must take plaintext instead of enc_data, to not rely on assumption that plain and cypher data are the same memory.

Signed-off-by: Ilya Makarov <ilya.makarov.592@gmail.com>

Fixes: #40069