### PR TITLE
drivers/disk: sdmmc: stm32: DMA header requested on L4/F7 series

### DIFF
--- a/drivers/disk/Kconfig.sdmmc
+++ b/drivers/disk/Kconfig.sdmmc
@@ -47,6 +47,7 @@ config SDMMC_STM32
 	select USE_STM32_HAL_SD
 	select USE_STM32_HAL_SD_EX if SOC_SERIES_STM32L4X
 	select USE_STM32_LL_SDMMC
+	select USE_STM32_HAL_DMA if (SOC_SERIES_STM32L4X || SOC_SERIES_STM32F7X)
 	default $(dt_compat_enabled,$(DT_COMPAT_ST_STM32_SDMMC))
 	help
 	  File system on sdmmc accessed through stm32 sdmmc.


### PR DESCRIPTION
Even if not used DMA HAL is required in L4/F7 SD HAL driver.
Add them for these specific series.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>