### PR TITLE
tests: bluetooth: tester: Reading multiple variable length characteristics

### DIFF
--- a/tests/bluetooth/tester/src/bttester.h
+++ b/tests/bluetooth/tester/src/bttester.h
@@ -707,6 +707,8 @@ struct gatt_change_db_cmd {
 	uint8_t visibility;
 } __packed;
 
+#define GATT_READ_MULTIPLE_VAR		0x20
+
 /* GATT events */
 #define GATT_EV_NOTIFICATION		0x80
 struct gatt_notification_ev {

--- a/tests/bluetooth/tester/src/gatt.c
+++ b/tests/bluetooth/tester/src/gatt.c
@@ -181,7 +181,7 @@ static uint8_t btp2bt_uuid(const uint8_t *uuid, uint8_t len,
 
 static void supported_commands(uint8_t *data, uint16_t len)
 {
-	uint8_t cmds[4];
+	uint8_t cmds[5];
 	struct gatt_read_supported_commands_rp *rp = (void *) cmds;
 
 	(void)memset(cmds, 0, sizeof(cmds));
@@ -212,6 +212,7 @@ static void supported_commands(uint8_t *data, uint16_t len)
 	tester_set_bit(cmds, GATT_GET_ATTRIBUTES);
 	tester_set_bit(cmds, GATT_GET_ATTRIBUTE_VALUE);
 	tester_set_bit(cmds, GATT_DISC_ALL_PRIM);
+	tester_set_bit(cmds, GATT_READ_MULTIPLE_VAR);
 
 	tester_send(BTP_SERVICE_ID_GATT, GATT_READ_SUPPORTED_COMMANDS,
 		    CONTROLLER_INDEX, (uint8_t *) rp, sizeof(cmds));
@@ -1511,7 +1512,7 @@ fail_conn:
 		   BTP_STATUS_FAILED);
 }
 
-static void read_multiple(uint8_t *data, uint16_t len)
+static void read_multiple(uint8_t *data, uint16_t len, uint8_t opcode)
 {
 	const struct gatt_read_multiple_cmd *cmd = (void *) data;
 	uint16_t handles[cmd->handles_count];
@@ -1534,10 +1535,10 @@ static void read_multiple(uint8_t *data, uint16_t len)
 	read_params.func = read_cb;
 	read_params.handle_count = i;
 	read_params.multiple.handles = handles; /* not used in read func */
-	read_params.multiple.variable = false;
+	read_params.multiple.variable = (opcode == GATT_READ_MULTIPLE_VAR);
 
 	/* TODO should be handled as user_data via CONTAINER_OF macro */
-	btp_opcode = GATT_READ_MULTIPLE;
+	btp_opcode = opcode;
 
 	if (bt_gatt_read(conn, &read_params) < 0) {
 		gatt_buf_clear();
@@ -2029,7 +2030,8 @@ void tester_handle_gatt(uint8_t opcode, uint8_t index, uint8_t *data,
 		read_long(data, len);
 		return;
 	case GATT_READ_MULTIPLE:
-		read_multiple(data, len);
+	case GATT_READ_MULTIPLE_VAR:
+		read_multiple(data, len, opcode);
 		return;
 	case GATT_WRITE_WITHOUT_RSP:
 		write_without_rsp(data, len, opcode, false);


### PR DESCRIPTION
Adds support for reading multiple variable length characteristics.
Previously read_multiple() always set the variable flag to false.

This is used by GATT/CL/GAT/BV-03-C.

Signed-off-by: Herman Berget <herman.berget@nordicsemi.no>