### PR TITLE
sara-r4: increase socket processing prio

### DIFF
--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -1973,7 +1973,12 @@ static bool offload_is_supported(int family, int type, int proto)
 	return true;
 }
 
-NET_SOCKET_REGISTER(ublox_sara_r4, NET_SOCKET_DEFAULT_PRIO, AF_UNSPEC,
+#define SARA_R4_SOCKET_PRIORITY 40
+
+BUILD_ASSERT(SARA_R4_SOCKET_PRIORITY < CONFIG_NET_SOCKETS_TLS_PRIORITY,
+	     "SARA_R4_SOCKET_PRIORITY must be < than NET_SOCKETS_TLS_PRIORITY");
+
+NET_SOCKET_REGISTER(ublox_sara_r4, SARA_R4_SOCKET_PRIORITY, AF_UNSPEC,
 		    offload_is_supported, offload_socket);
 
 #if defined(CONFIG_DNS_RESOLVER)


### PR DESCRIPTION
Higher socket processing prio is required for offloaded sockets

Resolves #40074 

Ping @rlubos 