### PR TITLE
scripts: build meta file workspace status extension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1470,6 +1470,7 @@ if(CONFIG_BUILD_OUTPUT_META)
             ${ZEPHYR_MODULES_ARG}
             ${ZEPHYR_EXTRA_MODULES_ARG}
             --meta-out ${KERNEL_META_NAME}
+            $<$<BOOL:${CONFIG_BUILD_OUTPUT_META_STATE_PROPAGATE}>:--meta-state-propagate>
   )
   list(APPEND
     post_build_byproducts

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -512,7 +512,15 @@ config BUILD_OUTPUT_META
 	  Create a build meta file in the build directory containing lists of:
 	  - Zephyr: path and revision (if git repo)
 	  - Zephyr modules: name, path, and revision (if git repo)
-	  - West projects: path and revision
+	  - West:
+	    - manifest: path and revision
+	    - projects: path and revision
+	  - Workspace:
+	    - dirty: one or more repositories are marked dirty
+	    - extra: extra Zephyr modules are manually included in the build
+	    - off:   the SHA of one or more west projects are not what the manifest
+	             defined when `west update` was run the last time (`manifest-rev`).
+	             The off state is only present if a west workspace is found.
 	  File extension is .meta
 
 endmenu

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -523,6 +523,24 @@ config BUILD_OUTPUT_META
 	             The off state is only present if a west workspace is found.
 	  File extension is .meta
 
+config BUILD_OUTPUT_META_STATE_PROPAGATE
+	bool "Propagate module and project state"
+	depends on BUILD_OUTPUT_META
+	help
+	  Propagate to state of each module to the Zephyr revision field.
+	  If west is used the state of each west project is also propagated to
+	  the Zephyr revision field.
+	  West manifest repo revision field will also
+	  be marked with the same state as the Zephyr revision.
+	  The final revision will become: <SHA>-<state1>-<state2>-<state3>...
+	  If no states are appended to the SHA it means the build is of a clean
+	  tree.
+	  - dirty: one or more repositories are marked dirty
+	  - extra: extra Zephyr modules are manually included in the build
+	  - off:   the SHA of one or more west projects are not what the manifest
+	           defined when `west update` was run the last time (`manifest-rev`).
+	           The off state is only present if a west workspace is found.
+
 endmenu
 
 config EXPERIMENTAL


### PR DESCRIPTION
The PR #39382 raised a discussion on build reproducibility and knowledge
of west projects being out of sync with the west manifest.

Similar to how `git submodules` will report the working tree dirty if
any of the submodules HEAD points to a SHA different than the one
recorded in the super project.

Based on this discussion this commit extends the Zephyr build meta file
with overall workspace status included in the meta file.

It add the following meta info to the build meta file:
> workspace:
>  dirty: false / true
>  extra: false / true
>  off: false / true

A project using west and having an extra Zephyr module loaded not
controlled using git and a west project at a SHA different than the
SHA referenced by the manifest can look like:
```
zephyr:
  path: /.../zephyr
  revision: 863600c
modules:
- name: mcuboot
  path: /.../bootloader/mcuboot
  revision: c61538748ead773ea75a551a7beee299228bdcaf
- name: local_module
  path: /.../local_module
  revision: null
west:
  manifest: /.../zephyr/west.yml
  projects:
  - path: /.../zephyr
    revision: 863600c
  - path: /.../bootloader/mcuboot
    revision: c61538748ead773ea75a551a7beee299228bdcaf-off
  - path: /.../tools/net-tools
    revision: f49bd1354616fae4093bf36e5eaee43c51a55127
workspace:
  dirty: false
  extra: true
  'off': true
```

And without west:
```
zephyr:
  path: /.../zephyr
  revision: 863600c
modules:
- name: hal_nordic
  path: /.../modules/hal/nordic
  revision: a6e5299041f152da5ae0ab17b2e44e088bb96d6d
- name: local_module
  path: /.../local_module
  revision: null
west: null
workspace:
  dirty: false
  extra: true
  'off': false
```

The workspace status can be propagated to the Zephyr revision, where the final revision will become: <SHA>-<state1>-<state2>-<state3>

For example:
> zephyr:
>  path: /.../zephyr
>  revision: <SHA>-dirty-extra-off

or
> zephyr:
>  path: /.../zephyr
>  revision: <SHA>-extra

The `BUILD_OUTPUT_META_STATE_PROPAGATE` Kconfig setting is introduced
to provide user control of this behavior.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>