### PR TITLE
Gsm ppp setup hooks

### DIFF
--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -587,7 +587,8 @@ static void rssi_handler(struct k_work *work)
 static void gsm_finalize_connection(struct k_work *work)
 {
 	int ret = 0;
-	struct gsm_modem *gsm = CONTAINER_OF(work, struct gsm_modem,
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct gsm_modem *gsm = CONTAINER_OF(dwork, struct gsm_modem,
 					     gsm_configure_work);
 
 	/* If already attached, jump right to RSSI readout */
@@ -840,7 +841,8 @@ static int mux_attach(const struct device *mux, const struct device *uart,
 
 static void mux_setup(struct k_work *work)
 {
-	struct gsm_modem *gsm = CONTAINER_OF(work, struct gsm_modem,
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct gsm_modem *gsm = CONTAINER_OF(dwork, struct gsm_modem,
 					     gsm_configure_work);
 	const struct device *uart = DEVICE_DT_GET(GSM_UART_NODE);
 	int ret;
@@ -946,7 +948,8 @@ fail:
 
 static void gsm_configure(struct k_work *work)
 {
-	struct gsm_modem *gsm = CONTAINER_OF(work, struct gsm_modem,
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct gsm_modem *gsm = CONTAINER_OF(dwork, struct gsm_modem,
 					     gsm_configure_work);
 	int ret = -1;
 

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -969,16 +969,14 @@ static void gsm_configure(struct k_work *work)
 
 		ret = mux_enable(gsm);
 		if (ret == 0) {
-			gsm->mux_enabled = true;
+			LOG_DBG("GSM muxing %s", "enabled");
+			gsm->gsm_state = GSM_PPP_STATE_MUX_ENABLED;
 		} else {
-			gsm->mux_enabled = false;
+			LOG_DBG("GSM muxing %s", "disabled");
 			(void)k_work_reschedule(&gsm->gsm_configure_work,
 						K_NO_WAIT);
 			return;
 		}
-
-		LOG_DBG("GSM muxing %s", gsm->mux_enabled ? "enabled" :
-							    "disabled");
 
 		if (gsm->mux_enabled) {
 			gsm->state = STATE_INIT;

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -940,10 +940,8 @@ static void mux_setup(struct k_work *work)
 	return;
 
 fail:
-	/* FIXME: If something fails and ended up here, currently there is nothing being done to
-	 * recover the modem
-	 */
-	gsm->gsm_state = GSM_PPP_STATE_INIT;
+	/* FIXME: The driver can potentially stuck here retrying forever */
+	(void)k_work_reschedule(&gsm->gsm_configure_work, K_SECONDS(1));
 }
 
 static void gsm_configure(struct k_work *work)

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -82,8 +82,6 @@ static struct gsm_modem {
 	int rssi_retries;
 	int attach_retries;
 	bool mux_enabled : 1;
-	bool mux_setup_done : 1;
-	bool setup_done : 1;
 	bool attached : 1;
 
 	void *user_data;
@@ -716,8 +714,6 @@ attaching:
 		return;
 	}
 
-	gsm->setup_done = true;
-
 	set_ppp_carrier_on(gsm);
 
 	if (IS_ENABLED(CONFIG_GSM_MUX) && gsm->mux_enabled) {
@@ -970,7 +966,6 @@ static void gsm_configure(struct k_work *work)
 
 	if (IS_ENABLED(CONFIG_GSM_MUX) && ret == 0 &&
 	    gsm->mux_enabled == false) {
-		gsm->mux_setup_done = false;
 
 		ret = mux_enable(gsm);
 		if (ret == 0) {

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -592,7 +592,7 @@ static void gsm_finalize_connection(struct gsm_modem *gsm)
 		goto attaching;
 	}
 
-	if (IS_ENABLED(CONFIG_GSM_MUX) && gsm->mux_enabled) {
+	if (IS_ENABLED(CONFIG_GSM_MUX)) {
 		ret = modem_cmd_send_nolock(&gsm->context.iface,
 					    &gsm->context.cmd_handler,
 					    &response_cmds[0],
@@ -714,7 +714,7 @@ attaching:
 
 	set_ppp_carrier_on(gsm);
 
-	if (IS_ENABLED(CONFIG_GSM_MUX) && gsm->mux_enabled) {
+	if (IS_ENABLED(CONFIG_GSM_MUX)) {
 		/* Re-use the original iface for AT channel */
 		ret = modem_iface_uart_init_dev(&gsm->context.iface,
 						gsm->at_dev);
@@ -918,7 +918,6 @@ static void mux_setup(struct k_work *work)
 						gsm->ppp_dev);
 		if (ret < 0) {
 			LOG_DBG("iface %suart error %d", "PPP ", ret);
-			gsm->mux_enabled = false;
 			goto fail;
 		}
 
@@ -976,16 +975,14 @@ static void gsm_configure(struct k_work *work)
 			return;
 		}
 
-		if (gsm->mux_enabled) {
-			gsm->state = STATE_INIT;
+		gsm->state = STATE_INIT;
 
-			k_work_init_delayable(&gsm->gsm_configure_work,
-					      mux_setup);
+		k_work_init_delayable(&gsm->gsm_configure_work,
+					mux_setup);
 
-			(void)k_work_reschedule(&gsm->gsm_configure_work,
-						K_NO_WAIT);
-			return;
-		}
+		(void)k_work_reschedule(&gsm->gsm_configure_work,
+					K_NO_WAIT);
+		return;
 	}
 
 	gsm_finalize_connection(gsm);

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -865,12 +865,12 @@ static void mux_setup(struct k_work *work)
 			}
 		}
 
-		gsm->gsm_state = GSM_PPP_STATE_PPP_CHANNEL;
-
 		ret = mux_attach(gsm->control_dev, uart, DLCI_CONTROL, gsm);
 		if (ret < 0) {
 			goto fail;
 		}
+
+		gsm->gsm_state = GSM_PPP_STATE_PPP_CHANNEL;
 
 		break;
 
@@ -884,12 +884,12 @@ static void mux_setup(struct k_work *work)
 			}
 		}
 
-		gsm->gsm_state = GSM_PPP_STATE_AT_CHANNEL;
-
 		ret = mux_attach(gsm->ppp_dev, uart, DLCI_PPP, gsm);
 		if (ret < 0) {
 			goto fail;
 		}
+
+		gsm->gsm_state = GSM_PPP_STATE_AT_CHANNEL;
 
 		break;
 
@@ -903,12 +903,12 @@ static void mux_setup(struct k_work *work)
 			}
 		}
 
-		gsm->gsm_state = GSM_PPP_STATE_DONE;
-
 		ret = mux_attach(gsm->at_dev, uart, DLCI_AT, gsm);
 		if (ret < 0) {
 			goto fail;
 		}
+
+		gsm->gsm_state = GSM_PPP_STATE_DONE;
 
 		break;
 

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -606,8 +606,7 @@ static void gsm_finalize_connection(struct gsm_modem *gsm)
 					    "AT", &gsm->sem_response,
 					    GSM_CMD_AT_TIMEOUT);
 		if (ret < 0) {
-			LOG_ERR("modem setup returned %d, %s",
-				ret, "retrying...");
+			LOG_ERR("%s returned %d, %s", "AT", ret, "retrying...");
 			(void)k_work_reschedule(&gsm->gsm_configure_work,
 						K_SECONDS(1));
 			return;
@@ -625,10 +624,8 @@ static void gsm_finalize_connection(struct gsm_modem *gsm)
 	}
 
 	ret = gsm_setup_mccmno(gsm);
-
 	if (ret < 0) {
-		LOG_ERR("modem setup returned %d, %s",
-				ret, "retrying...");
+		LOG_ERR("%s returned %d, %s", "gsm_setup_mccmno", ret, "retrying...");
 
 		(void)k_work_reschedule(&gsm->gsm_configure_work,
 							K_SECONDS(1));
@@ -642,8 +639,7 @@ static void gsm_finalize_connection(struct gsm_modem *gsm)
 						  &gsm->sem_response,
 						  GSM_CMD_SETUP_TIMEOUT);
 	if (ret < 0) {
-		LOG_DBG("modem setup returned %d, %s",
-			ret, "retrying...");
+		LOG_DBG("%s returned %d, %s", "setup_cmds", ret, "retrying...");
 		(void)k_work_reschedule(&gsm->gsm_configure_work, K_SECONDS(1));
 		return;
 	}
@@ -704,7 +700,7 @@ attaching:
 #endif
 	}
 
-	LOG_DBG("modem setup returned %d, %s", ret, "enable PPP");
+	LOG_DBG("modem RSSI: %d, %s", gsm->context.data_rssi, "enable PPP");
 
 	ret = modem_cmd_handler_setup_cmds_nolock(&gsm->context.iface,
 						  &gsm->context.cmd_handler,
@@ -713,8 +709,7 @@ attaching:
 						  &gsm->sem_response,
 						  GSM_CMD_SETUP_TIMEOUT);
 	if (ret < 0) {
-		LOG_DBG("modem setup returned %d, %s",
-			ret, "retrying...");
+		LOG_DBG("%s returned %d, %s", "connect_cmds", ret, "retrying...");
 		(void)k_work_reschedule(&gsm->gsm_configure_work, K_SECONDS(1));
 		return;
 	}
@@ -738,7 +733,7 @@ attaching:
 				"AT", &gsm->sem_response,
 				GSM_CMD_AT_TIMEOUT);
 			if (ret < 0) {
-				LOG_WRN("modem setup returned %d, %s",
+				LOG_WRN("%s returned %d, %s", "modem setup",
 					ret, "AT cmds failed");
 			} else {
 				LOG_INF("AT channel %d connected to %s",

--- a/drivers/modem/modem_cmd_handler.h
+++ b/drivers/modem/modem_cmd_handler.h
@@ -164,6 +164,8 @@ int modem_cmd_handler_update_cmds(struct modem_cmd_handler_data *data,
  *
  * @param  *iface: interface to use
  * @param  *handler: command handler to use
+ * @param  *handler_cmds: commands to attach
+ * @param  handler_cmds_len: size of commands array
  * @param  *buf: NULL terminated send buffer
  * @param  *sem: wait for response semaphore
  * @param  timeout: timeout of command
@@ -182,6 +184,8 @@ int modem_cmd_send_ext(struct modem_iface *iface,
  *
  * @param  *iface: interface to use
  * @param  *handler: command handler to use
+ * @param  *handler_cmds: commands to attach
+ * @param  handler_cmds_len: size of commands array
  * @param  *buf: NULL terminated send buffer
  * @param  *sem: wait for response semaphore
  * @param  timeout: timeout of command
@@ -205,6 +209,8 @@ static inline int modem_cmd_send_nolock(struct modem_iface *iface,
  *
  * @param  *iface: interface to use
  * @param  *handler: command handler to use
+ * @param  *handler_cmds: commands to attach
+ * @param  handler_cmds_len: size of commands array
  * @param  *buf: NULL terminated send buffer
  * @param  *sem: wait for response semaphore
  * @param  timeout: timeout of command
@@ -271,18 +277,25 @@ int modem_cmd_handler_init(struct modem_cmd_handler *handler,
  * @brief  Lock the modem for sending cmds
  *
  * This is semaphore-based rather than mutex based, which means there's no
- * requirements of thread ownership for the user. These functions are useful
+ * requirements of thread ownership for the user. This function is useful
  * when one needs to prevent threads from sending UART data to the modem for an
  * extended period of time (for example during modem reset).
  *
  * @param  *handler: command handler to lock
- * @param  lock: set true to lock, false to unlock
  * @param  timeout: give up after timeout
  *
  * @retval 0 if ok, < 0 if error.
  */
 int modem_cmd_handler_tx_lock(struct modem_cmd_handler *handler,
 			      k_timeout_t timeout);
+
+/**
+ * @brief  Unlock the modem for sending cmds
+ *
+ * @param  *handler: command handler to unlock
+ *
+ * @retval None.
+ */
 void modem_cmd_handler_tx_unlock(struct modem_cmd_handler *handler);
 
 

--- a/include/drivers/gsm_ppp.h
+++ b/include/drivers/gsm_ppp.h
@@ -47,4 +47,32 @@ void gsm_ppp_register_modem_power_callback(const struct device *dev,
 					   gsm_modem_power_cb modem_off,
 					   void *user_data);
 
+struct modem_context;
+
+/**
+ * @brief Weakly linked hook for augmenting modem setup.
+ *
+ * This will get called just before PDP context creation, but after initial
+ * setup.
+ *
+ * @param ctx: Todo.
+ * @param sem: Todo.
+ *
+ * @retval Todo.
+ */
+int gsm_ppp_setup_hook(struct modem_context *ctx, struct k_sem *sem);
+
+/**
+ * @brief Weakly linked hook for augmenting modem setup.
+ *
+ * This will get called after network connection has been established, just
+ * before activating PPP.
+ *
+ * @param ctx: Todo.
+ * @param sem: Todo.
+ *
+ * @retval Todo.
+ */
+int gsm_ppp_pre_connect_hook(struct modem_context *ctx, struct k_sem *sem);
+
 #endif /* GSM_PPP_H_ */

--- a/include/drivers/gsm_ppp.h
+++ b/include/drivers/gsm_ppp.h
@@ -11,8 +11,23 @@
 struct device;
 typedef void (*gsm_modem_power_cb)(const struct device *, void *);
 
-void gsm_ppp_start(const struct device *dev);
-void gsm_ppp_stop(const struct device *dev);
+/**
+ * @brief  Start the GSM PPP modem.
+ *
+ * @param  dev: Modem device struct
+ *
+ * @retval 0 if success, errno.h values otherwise.
+ */
+int gsm_ppp_start(const struct device *dev);
+
+/**
+ * @brief  Stop the GSM PPP modem.
+ *
+ * @param  dev: Modem device struct
+ *
+ * @retval 0 if success, errno.h values otherwise.
+ */
+int gsm_ppp_stop(const struct device *dev);
 /** @endcond */
 
 /**


### PR DESCRIPTION
This actually works fine but is not quite ready to leave the WIP stage before some more input. It's based on an unmerged PR (https://github.com/zephyrproject-rtos/zephyr/pull/38596) for convenience only. Some background to why this is an important patch:  

We're currently using U-Blox SARA R4 modems for multiple projects, and recently I've been using both Simcom and Quectel modems for projects. We're using Zephyr gsm_ppp for all of them. They've all had some minor or major quirks that required patching the gsm_ppp driver. For the Ublox modem, we've had to patch in support for a ton of required AT commands. The Simcom modem had a bunch of quirks that needed to be worked around using AT. I'm sure we're not the only ones.

I've tried porting our Ublox patches to use my proposed hook system instead and it works fine. Which basically means that this should cover almost all conceivable use cases :D 

A snippet of typical usage follows:

```
// file: gsm_ppp_ublox_sara_r4.c
...

int gsm_ppp_setup_hook(struct modem_context *ctx, struct k_sem *sem)
{
	int ret;

       /* Set the profile */
       ret = modem_cmd_send_nolock(&ctx->iface,
				   &ctx->cmd_handler,
				   NULL, 0,
				   "AT+UMNOPROF=" STRINGIFY(CONFIG_MODEM_GSM_MNOPROF),
				   sem,
				   K_SECONDS(2));
        if (ret < 0) return ret;

	ret = gsm_setup_psm(ctx, sem);
	if (ret < 0) {
		LOG_WRN("gsm_setup_psm returned %d", ret);
		return ret;
	}

	ret = gsm_setup_urat(ctx, sem);
	if (ret < 0) {
		LOG_WRN("gsm_setup_urat returned %d", ret);
		return ret;
	}

	ret = gsm_setup_ubandmask(ctx, sem);
	if (ret < 0) {
		LOG_WRN("gsm_setup_ubandmask returned %d", ret);
		return ret;
	}

	return ret;
}
```

This file gets compiled as part of my application, but of course it's 100% conceivable to upstream special modem setups as well. 

My main gripe with it is the need to use internal APIs (modem_context and modem_cmd_handler). But because these hooks are used for extending a driver, not for application logic, maybe it's not a huge deal.
