### PR TITLE
RFC: Reformat FS subsystem to 100 characters per line

### DIFF
--- a/include/fs/fs.h
+++ b/include/fs/fs.h
@@ -33,16 +33,13 @@ enum fs_dir_entry_type {
 
 /** @brief Enumeration to uniquely identify file system types.
  *
- * Zephyr supports in-tree file systems and external ones.  Each
- * requires a unique identifier used to register the file system
- * implementation and to associate a mount point with the file system
- * type.  This anonymous enum defines global identifiers for the
- * in-tree file systems.
+ * Zephyr supports in-tree file systems and external ones.  Each requires a unique identifier used
+ * to register the file system implementation and to associate a mount point with the file system
+ * type.  This anonymous enum defines global identifiers for the in-tree file systems.
  *
- * External file systems should be registered using unique identifiers
- * starting at @c FS_TYPE_EXTERNAL_BASE.  It is the responsibility of
- * applications that use external file systems to ensure that these
- * identifiers are unique if multiple file system implementations are
+ * External file systems should be registered using unique identifiers starting at
+ * @c FS_TYPE_EXTERNAL_BASE.  It is the responsibility of applications that use external file
+ * systems to ensure that these identifiers are unique if multiple file system implementations are
  * used by the application.
  */
 enum {
@@ -60,8 +57,7 @@ enum {
 #define FS_MOUNT_FLAG_NO_FORMAT BIT(0)
 /** Flag makes mounted file system read-only */
 #define FS_MOUNT_FLAG_READ_ONLY BIT(1)
-/** Flag used in pre-defined mount structures that are to be mounted
- * on startup.
+/** Flag used in pre-defined mount structures that are to be mounted on startup.
  *
  * This flag has no impact in user-defined mount structures.
  */
@@ -95,8 +91,7 @@ struct fs_mount_t {
 /**
  * @brief Structure to receive file or directory information
  *
- * Used in functions that reads the directory entries to get
- * file or directory information.
+ * Used in functions that reads the directory entries to get file or directory information.
  *
  * @param dir_entry_type Whether file or directory
  * - FS_DIR_ENTRY_FILE
@@ -113,8 +108,7 @@ struct fs_dirent {
 /**
  * @brief Structure to receive volume statistics
  *
- * Used to retrieve information about total and available space
- * in the volume.
+ * Used to retrieve information about total and available space in the volume.
  *
  * @param f_bsize Optimal transfer block size
  * @param f_frsize Allocation unit size
@@ -178,10 +172,8 @@ struct fs_statvfs {
 /*
  * @brief Get the common mount flags for an fstab entry.
 
- * @param node_id the node identifier for a child entry in a
- * zephyr,fstab node.
- * @return a value suitable for initializing an fs_mount_t flags
- * member.
+ * @param node_id the node identifier for a child entry in a zephyr,fstab node.
+ * @return a value suitable for initializing an fs_mount_t flags member.
  */
 #define FSTAB_ENTRY_DT_MOUNT_FLAGS(node_id)				\
 	((DT_PROP(node_id, automount) ? FS_MOUNT_FLAG_AUTOMOUNT : 0)	\
@@ -189,25 +181,22 @@ struct fs_statvfs {
 	 | (DT_PROP(node_id, no_format) ? FS_MOUNT_FLAG_NO_FORMAT : 0))
 
 /**
- * @brief The name under which a zephyr,fstab entry mount structure is
- * defined.
+ * @brief The name under which a zephyr,fstab entry mount structure is defined.
  */
 #define FS_FSTAB_ENTRY(node_id) _CONCAT(z_fsmp_, node_id)
 
 /**
- * @brief Generate a declaration for the externally defined fstab
- * entry.
+ * @brief Generate a declaration for the externally defined fstab entry.
  *
  * This will evaluate to the name of a struct fs_mount_t object.
  */
-#define FS_FSTAB_DECLARE_ENTRY(node_id)		\
-	extern struct fs_mount_t FS_FSTAB_ENTRY(node_id)
+#define FS_FSTAB_DECLARE_ENTRY(node_id)	extern struct fs_mount_t FS_FSTAB_ENTRY(node_id)
 
 /**
  * @brief Initialize fs_file_t object
  *
- * Initializes the fs_file_t object; the function needs to be invoked
- * on object before first use with fs_open.
+ * Initializes the fs_file_t object; the function needs to be invoked on object before first use
+ * with fs_open.
  *
  * @param zfp Pointer to file object
  *
@@ -220,8 +209,8 @@ static inline void fs_file_t_init(struct fs_file_t *zfp)
 /**
  * @brief Initialize fs_dir_t object
  *
- * Initializes the fs_dir_t object; the function needs to be invoked
- * on object before first use with fs_opendir.
+ * Initializes the fs_dir_t object; the function needs to be invoked on object before first use
+ * with fs_opendir.
  *
  * @param zdp Pointer to file object
  *
@@ -237,16 +226,15 @@ static inline void fs_dir_t_init(struct fs_dir_t *zdp)
  * Opens or possibly creates a file and associates a stream with it.
  *
  * @details
- * @p flags can be 0 or a binary combination of one or more of the following
- * identifiers:
+ * @p flags can be 0 or a binary combination of one or more of the following identifiers:
  *   - @c FS_O_READ open for read
  *   - @c FS_O_WRITE open for write
  *   - @c FS_O_RDWR open for read/write (<tt>FS_O_READ | FS_O_WRITE</tt>)
  *   - @c FS_O_CREATE create file if it does not exist
  *   - @c FS_O_APPEND move to end of file before each write
  *
- * If @p flags are set to 0 the function will attempt to open an existing file
- * with no read/write access; this may be used to e.g. check if the file exists.
+ * If @p flags are set to 0 the function will attempt to open an existing file with no read/write
+ * access; this may be used to e.g. check if the file exists.
  *
  * @param zfp Pointer to a file object
  * @param file_name The name of a file to open
@@ -254,9 +242,8 @@ static inline void fs_dir_t_init(struct fs_dir_t *zdp)
  *
  * @retval 0 on success;
  * @retval -EINVAL when a bad file name is given;
- * @retval -EROFS when opening read-only file for write, or attempting to
- *	   create a file on a system that has been mounted with the
- *	   FS_MOUNT_FLAG_READ_ONLY flag;
+ * @retval -EROFS when opening read-only file for write, or attempting to create a file on a system
+ *	   that has been mounted with the FS_MOUNT_FLAG_READ_ONLY flag;
  * @retval -ENOENT when the file path is not possible (bad mount point);
  * @retval <0 an other negative errno code, depending on a file system back-end.
  */
@@ -282,8 +269,8 @@ int fs_close(struct fs_file_t *zfp);
  * @param path Path to the file or directory to delete
  *
  * @retval 0 on success;
- * @retval -EROFS if file is read-only, or when file system has been mounted
- *	   with the FS_MOUNT_FLAG_READ_ONLY flag;
+ * @retval -EROFS if file is read-only, or when file system has been mounted with
+ *	   the FS_MOUNT_FLAG_READ_ONLY flag;
  * @retval -ENOTSUP when not implemented by underlying file system driver;
  * @retval <0 an other negative errno code on error.
  */
@@ -292,16 +279,13 @@ int fs_unlink(const char *path);
 /**
  * @brief Rename file or directory
  *
- * Performs a rename and / or move of the specified source path to the
- * specified destination.  The source path can refer to either a file or a
- * directory.  All intermediate directories in the destination path must
- * already exist.  If the source path refers to a file, the destination path
- * must contain a full filename path, rather than just the new parent
- * directory.  If an object already exists at the specified destination path,
- * this function causes it to be unlinked prior to the rename (i.e., the
- * destination gets clobbered).
- * @note Current implementation does not allow moving files between mount
- * points.
+ * Performs a rename and / or move of the specified source path to the specified destination.
+ * The source path can refer to either a file or a directory.  All intermediate directories in
+ * the destination path must already exist.  If the source path refers to a file, the destination
+ * path must contain a full filename path, rather than just the new parent directory.
+ * If an object already exists at the specified destination path, this function causes it to be
+ * unlinked prior to the rename (i.e., the destination gets clobbered).
+ * @note Current implementation does not allow moving files between mount points.
  *
  * @param from The source path
  * @param to The destination path
@@ -315,9 +299,8 @@ int fs_rename(const char *from, const char *to);
 /**
  * @brief Read file
  *
- * Reads up to @p size bytes of data to @p ptr pointed buffer, returns number
- * of bytes read.  A returned value may be lower than @p size if there were
- * fewer bytes available than requested.
+ * Reads up to @p size bytes of data to @p ptr pointed buffer, returns number of bytes read.
+ * A returned value may be lower than @p size if there were fewer bytes available than requested.
  *
  * @param zfp Pointer to the file object
  * @param ptr Pointer to the data buffer
@@ -331,12 +314,10 @@ ssize_t fs_read(struct fs_file_t *zfp, void *ptr, size_t size);
 /**
  * @brief Write file
  *
- * Attempts to write @p size number of bytes to the specified file.
- * If a negative value is returned from the function, the file pointer has not
- * been advanced.
- * If the function returns a non-negative number that is lower than @p size,
- * the global @c errno variable should be checked for an error code,
- * as the device may have no free space for data.
+ * Attempts to write @p size number of bytes to the specified file.  If a negative value is returned
+ * from the function, the file pointer has not been advanced.
+ * If the function returns a non-negative number that is lower than @p size, the global @c errno
+ * variable should be checked for an error code, as the device may have no free space for data.
  *
  * @param zfp Pointer to the file object
  * @param ptr Pointer to the data buffer
@@ -351,8 +332,8 @@ ssize_t fs_write(struct fs_file_t *zfp, const void *ptr, size_t size);
 /**
  * @brief Seek file
  *
- * Moves the file position to a new location in the file. The @p offset is added
- * to file position based on the @p whence parameter.
+ * Moves the file position to a new location in the file. The @p offset is added to file position
+ * based on the @p whence parameter.
  *
  * @param zfp Pointer to the file object
  * @param offset Relative location to move the file pointer to
@@ -385,14 +366,13 @@ off_t fs_tell(struct fs_file_t *zfp);
 /**
  * @brief Truncate or extend an open file to a given size
  *
- * Truncates the file to the new length if it is shorter than the current
- * size of the file. Expands the file if the new length is greater than the
- * current size of the file. The expanded region would be filled with zeroes.
+ * Truncates the file to the new length if it is shorter than the current size of the file. Expands
+ * the file if the new length is greater than the current size of the file.  The expanded region
+ * would be filled with zeroes.
  *
- * @note In the case of expansion, if the volume got full during the
- * expansion process, the function will expand to the maximum possible length
- * and return success.  Caller should check if the expanded size matches the
- * requested length.
+ * @note In the case of expansion, if the volume got full during the expansion process, the function
+ * will expand to the maximum possible length and return success.
+ * Caller should check if the expanded size matches the requested length.
  *
  * @param zfp Pointer to the file object
  * @param length New size of the file in bytes
@@ -406,11 +386,10 @@ int fs_truncate(struct fs_file_t *zfp, off_t length);
 /**
  * @brief Flush cached write data buffers of an open file
  *
- * The function flushes the cache of an open file; it can be invoked to ensure
- * data gets written to the storage media immediately, e.g. to avoid data loss
- * in case if power is removed unexpectedly.
- * @note Closing a file will cause caches to be flushed correctly so the
- * function need not be called when the file is being closed.
+ * The function flushes the cache of an open file; it can be invoked to ensure data gets written to
+ * the storage media immediately, e.g. to avoid data loss in case if power is removed unexpectedly.
+ * @note Closing a file will cause caches to be flushed correctly so the function need not be called
+ * when the file is being closed.
  *
  * @param zfp Pointer to the file object
  *
@@ -448,12 +427,11 @@ int fs_opendir(struct fs_dir_t *zdp, const char *path);
 /**
  * @brief Directory read entry
  *
- * Reads directory entries of an open directory. In end-of-dir condition,
- * the function will return 0 and set the <tt>entry->name[0]</tt> to 0.
+ * Reads directory entries of an open directory. In end-of-dir condition, the function will return 0
+ * and set the <tt>entry->name[0]</tt> to 0.
  *
- * @note: Most existing underlying file systems do not generate POSIX
- * special directory entries "." or "..".  For consistency the
- * abstraction layer will remove these from lower layer results so
+ * @note: Most existing underlying file systems do not generate POSIX special directory entries "."
+ * or "..".  For consistency the abstraction layer will remove these from lower layer results so
  * higher layers see consistent results.
  *
  * @param zdp Pointer to the directory object
@@ -479,26 +457,22 @@ int fs_closedir(struct fs_dir_t *zdp);
 /**
  * @brief Mount filesystem
  *
- * Perform steps needed for mounting a file system like
- * calling the file system specific mount function and adding
- * the mount point to mounted file system list.
+ * Perform steps needed for mounting a file system like calling the file system specific mount
+ * function and adding the mount point to mounted file system list.
  *
- * @note Current implementation of ELM FAT driver allows only following mount
- * points: "/RAM:","/NAND:","/CF:","/SD:","/SD2:","/USB:","/USB2:","/USB3:"
+ * @note Current implementation of ELM FAT driver allows only following mount points:
+ * "/RAM:", "/NAND:", "/CF:", "/SD:", "/SD2:", "/USB:", "/USB2:", "/USB3:"
  * or mount points that consist of single digit, e.g: "/0:", "/1:" and so forth.
  *
- * @param mp Pointer to the fs_mount_t structure.  Referenced object
- *	     is not changed if the mount operation failed.
- *	     A reference is captured in the fs infrastructure if the
- *	     mount operation succeeds, and the application must not
- *	     mutate the structure contents until fs_unmount is
- *	     successfully invoked on the same pointer.
+ * @param mp Pointer to the fs_mount_t structure.  Referenced object is not changed if the mount
+ *	     operation failed.  A reference is captured in the fs infrastructure if the mount
+ *	     operation succeeds, and the application must not mutate the structure contents until
+ *	     fs_unmount is successfully invoked on the same pointer.
  *
  * @retval 0 on success;
  * @retval -ENOENT when file system type has not been registered;
  * @retval -ENOTSUP when not supported by underlying file system driver;
- * @retval -EROFS if system requires formatting but @c FS_MOUNT_FLAG_READ_ONLY
- *	   has been set;
+ * @retval -EROFS if system requires formatting but @c FS_MOUNT_FLAG_READ_ONLY has been set;
  * @retval <0 an other negative errno code on error.
  */
 int fs_mount(struct fs_mount_t *mp);
@@ -506,9 +480,8 @@ int fs_mount(struct fs_mount_t *mp);
 /**
  * @brief Unmount filesystem
  *
- * Perform steps needed to unmount a file system like
- * calling the file system specific unmount function and removing
- * the mount point from mounted file system list.
+ * Perform steps needed to unmount a file system like calling the file system specific unmount
+ * function and removing the mount point from mounted file system list.
  *
  * @param mp Pointer to the fs_mount_t structure
  *
@@ -522,10 +495,9 @@ int fs_unmount(struct fs_mount_t *mp);
 /**
  * @brief Get path of mount point at index
  *
- * This function iterates through the list of mount points and returns
- * the directory name of the mount point at the given @p index.
- * On success @p index is incremented and @p name is set to the mount directory
- * name.  If a mount point with the given @p index does not exist, @p name will
+ * This function iterates through the list of mount points and returns the directory name of
+ * the mount point at the given @p index.  On success @p index is incremented and @p name is set to
+ * the mount directory name.  If a mount point with the given @p index does not exist, @p name will
  * be set to @c NULL.
  *
  * @param index Pointer to mount point index
@@ -543,8 +515,7 @@ int fs_readmount(int *index, const char **name);
  * @note The file on a storage device may not be updated until it is closed.
  *
  * @param path Path to the file or directory
- * @param entry Pointer to the zfs_dirent structure to fill if the file or
- * directory exists.
+ * @param entry Pointer to the zfs_dirent structure to fill if the file or directory exists.
  *
  * @retval 0 on success;
  * @retval <0 negative errno code on error.

--- a/subsys/fs/Kconfig
+++ b/subsys/fs/Kconfig
@@ -19,28 +19,24 @@ config APP_LINK_WITH_FS
 	bool "Link 'app' with FS"
 	default y
 	help
-	  Add FS header files to the 'app' include path. It may be
-	  disabled if the include paths for FS are causing aliasing
-	  issues for 'app'.
+	  Add FS header files to the 'app' include path. It may be disabled if the include paths
+	  for FS are causing aliasing issues for 'app'.
 
 config FILE_SYSTEM_MAX_TYPES
 	int "Maximum number of distinct file system types allowed"
 	default 2
 	help
-	  Zephyr provides several file system types including FatFS and
-	  LittleFS, but it is possible to define additional ones and
-	  register them.  A slot is required for each type.
+	  Zephyr provides several file system types including FatFS and LittleFS, but it is possible
+	  to define additional ones and register them.  A slot is required for each type.
 
 config FILE_SYSTEM_MAX_FILE_NAME
        int "Optional override for maximum file name length"
        default -1
        help
-         Specify the maximum file name allowed across all enabled file
-         system types.  Zero or a negative value selects the maximum
-         file name length for enabled in-tree file systems.  This
-         default may be inappropriate when registering an out-of-tree
-         file system.  Selecting a value less than the actual length
-         supported by a file system may result in memory access
+	 Specify the maximum file name allowed across all enabled file system types.  Zero or
+	 a negative value selects the maximum file name length for enabled in-tree file systems.
+	 This default may be inappropriate when registering an out-of-tree file system.  Selecting
+	 a value less than the actual length supported by a file system may result in memory access
          violations.
 
 config FILE_SYSTEM_SHELL
@@ -48,8 +44,7 @@ config FILE_SYSTEM_SHELL
 	depends on SHELL
 	depends on HEAP_MEM_POOL_SIZE > 0
 	help
-	  This shell provides basic browsing of the contents of the
-	  file system.
+	  This shell provides basic browsing of the contents of the file system.
 
 config FUSE_FS_ACCESS
 	bool "Enable FUSE based access to file system partitions"

--- a/subsys/fs/Kconfig.fatfs
+++ b/subsys/fs/Kconfig.fatfs
@@ -17,31 +17,26 @@ menu "ELM FAT file system settings"
 config FS_FATFS_READ_ONLY
 	bool "Read-only support for all volumes"
 	help
-	  The option excludes write code from ELM FAT file system driver;
-	  when selected, it no longer will be possible to write data on
-	  the FAT FS.
-	  If write support is not needed, enabling this flag will slightly
-	  reduce application size.
-	  This option translates to _FS_READONLY within ELM FAT file system
-	  driver; it enables exclusion, from compilation, of write supporting
-	  code.
+	  The option excludes write code from ELM FAT file system driver; when selected, it no
+	  longer will be possible to write data on the FAT FS.  If write support is not needed,
+	  enabling this flag will slightly reduce application size.
+	  This option translates to _FS_READONLY within ELM FAT file system driver; it enables
+	  exclusion, from compilation, of write supporting code.
 
 config FS_FATFS_MKFS
 	bool
 	help
-	  This option translates to _USE_MKFS within ELM FAT file system
-	  driver; it enables additional code that is required for formatting
-	  volumes to ELM FAT.
+	  This option translates to _USE_MKFS within ELM FAT file system driver; it enables
+	  additional code that is required for formatting volumes to ELM FAT.
 
 config FS_FATFS_MOUNT_MKFS
 	bool "Allow formatting volume when mounting fails"
 	default y
 	select FS_FATFS_MKFS
 	help
-	  This option adds code that allows fs_mount to attempt to format
-	  a volume if no file system is found.
-	  If formatting is not needed, disabling this flag will slightly
-	  reduce application size.
+	  This option adds code that allows fs_mount to attempt to format a volume if no file system
+	  is found.  If formatting is not needed, disabling this flag will slightly reduce
+	  application size.
 
 config FS_FATFS_EXFAT
 	bool "Enable exFAT support"
@@ -60,8 +55,8 @@ config FS_FATFS_NUM_DIRS
 config FS_FATFS_LFN
 	bool "Enable long filenames (LFN)"
 	help
-	  Without long filenames enabled, file names are limited to 8.3 format.
-	  This option increases working buffer size.
+	  Without long filenames enabled, file names are limited to 8.3 format.  This option
+	  increases working buffer size.
 
 if FS_FATFS_LFN
 
@@ -91,9 +86,8 @@ config FS_FATFS_MAX_LFN
 	range 12 255
 	default 255
 	help
-	  The working buffer occupies (FS_FATFS_MAX_LFN + 1) * 2 bytes and
-	  additional 608 bytes at exFAT enabled.
-	  It should be set 255 to support full featured LFN operations.
+	  The working buffer occupies (FS_FATFS_MAX_LFN + 1) * 2 bytes and additional 608 bytes at
+	  exFAT enabled.  It should be set 255 to support full featured LFN operations.
 
 endif # FS_FATFS_LFN
 

--- a/subsys/fs/Kconfig.littlefs
+++ b/subsys/fs/Kconfig.littlefs
@@ -44,29 +44,25 @@ config FS_LITTLEFS_CACHE_SIZE
 	int "Size of block caches in bytes"
 	default 64
 	help
-	  Each cache buffers a portion of a block in RAM.  The littlefs
-	  needs a read cache, a program cache, and one additional cache
-	  per file. Larger caches can improve performance by storing
-	  more data and reducing the number of disk accesses. Must be a
-	  multiple of the read and program sizes of the underlying flash
-	  device, and a factor of the block size.
+	  Each cache buffers a portion of a block in RAM.  The littlefs needs a read cache,
+	  a program cache, and one additional cache per file. Larger caches can improve performance
+	  by storing more data and reducing the number of disk accesses.  Must be a multiple of
+	  the read and program sizes of the underlying flash device, and a factor of the block size.
 
 config FS_LITTLEFS_LOOKAHEAD_SIZE
 	int "Size of lookahead buffer in bytes"
 	default 32
 	help
-	  A larger lookahead buffer increases the number of blocks found
-	  during an allocation pass. The lookahead buffer is stored as a
-	  compact bitmap, so each byte of RAM can track 8 blocks. Must
-	  be a multiple of 8.
+	  A larger lookahead buffer increases the number of blocks found during an allocation pass.
+	  The lookahead buffer is stored as a compact bitmap, so each byte of RAM can track
+	  8 blocks. Must be a multiple of 8.
 
 config FS_LITTLEFS_BLOCK_CYCLES
 	int "Number of erase cycles before moving data to another block"
 	default 512
 	help
-	  For dynamic wear leveling, the number of erase cycles before data
-	  is moved to another block.  Set to a non-positive value to
-	  disable leveling.
+	  For dynamic wear leveling, the number of erase cycles before data is moved to another
+	  block.  Set to a non-positive value to disable leveling.
 
 endmenu
 
@@ -76,18 +72,15 @@ config FS_LITTLEFS_FC_HEAP_SIZE
 	help
 	  littlefs requires a per-file buffer to cache data.
 
-	  When applications customize littlefs configurations and support
-	  different cache sizes for different partitions this preallocation is
-	  inadequate as an application might require a small number of files
-	  using a large cache size and a larger number of files using a
-	  smaller cache size.  In that case application should provide a
-	  positive value for the heap size.  Be aware that there is a
-	  per-allocation overhead that affects how much usable space is
-	  present in the heap.
+	  When applications customize littlefs configurations and support different cache sizes for
+	  different partitions this preallocation is inadequate as an application might require
+	  a small number of files using a large cache size and a larger number of files using
+	  a smaller cache size.  In that case application should provide a positive value for
+	  the heap size.  Be aware that there is a per-allocation overhead that affects how much
+	  usable space is present in the heap.
 
-	  If this option is set to a non-positive value the heap is sized to
-	  support up to FS_LITTLE_FS_NUM_FILES blocks of
-	  FS_LITTLEFS_CACHE_SIZE bytes.
+	  If this option is set to a non-positive value the heap is sized to support up to
+	  the FS_LITTLE_FS_NUM_FILES blocks of the FS_LITTLEFS_CACHE_SIZE bytes.
 
 if FS_LITTLEFS_FC_HEAP_SIZE <= 0
 
@@ -95,12 +88,11 @@ config FS_LITTLEFS_HEAP_PER_ALLOC_OVERHEAD_SIZE
 	int "Size of per-allocation overhead for littleFS heap in bytes"
 	default 32
 	help
-	  In case when total size of littleFS heap is automatically calculated
-	  we need to take into account overhead caused per block allocation.
-	  For the purpose of heap size calculation the size of each cache block
-	  will be increased by this value.
-	  NOTE: when your app fails to open pre-defined number of files, as set
-	  by FS_LITTLEFS_NUM_FILES, try to increase the value.
+	  In case when total size of littleFS heap is automatically calculated we need to take into
+	  account overhead caused per block allocation.  For the purpose of heap size calculation
+	  the size of each cache block will be increased by this value.
+	  NOTE: when your app fails to open pre-defined number of files, as set by
+	  the FS_LITTLEFS_NUM_FILES, try to increase the value.
 
 endif # FS_LITTLEFS_FC_HEAP_SIZE <= 0
 

--- a/subsys/fs/fat_fs.c
+++ b/subsys/fs/fat_fs.c
@@ -18,12 +18,10 @@
 #define FATFS_MAX_FILE_NAME 12 /* Uses 8.3 SFN */
 
 /* Memory pool for FatFs directory objects */
-K_MEM_SLAB_DEFINE(fatfs_dirp_pool, sizeof(DIR),
-			CONFIG_FS_FATFS_NUM_DIRS, 4);
+K_MEM_SLAB_DEFINE(fatfs_dirp_pool, sizeof(DIR), CONFIG_FS_FATFS_NUM_DIRS, 4);
 
 /* Memory pool for FatFs file objects */
-K_MEM_SLAB_DEFINE(fatfs_filep_pool, sizeof(FIL),
-			CONFIG_FS_FATFS_NUM_FILES, 4);
+K_MEM_SLAB_DEFINE(fatfs_filep_pool, sizeof(FIL), CONFIG_FS_FATFS_NUM_FILES, 4);
 
 static int translate_error(int error)
 {
@@ -71,11 +69,10 @@ static uint8_t translate_flags(fs_mode_t flags)
 	fat_mode |= (flags & FS_O_READ) ? FA_READ : 0;
 	fat_mode |= (flags & FS_O_WRITE) ? FA_WRITE : 0;
 	fat_mode |= (flags & FS_O_CREATE) ? FA_OPEN_ALWAYS : 0;
-	/* NOTE: FA_APPEND is not translated because FAT FS does not
-	 * support append semantics of the Zephyr, where file position
-	 * is forwarded to the end before each write, the fatfs_write
-	 * will be tasked with setting a file position to the end,
-	 * if FA_APPEND flag is present.
+	/* NOTE: FA_APPEND is not translated because FAT FS does not support append semantics of
+	 * the Zephyr, where file position is forwarded to the end before each write, the
+	 * fatfs_write will be tasked with setting a file position to the end, if FA_APPEND flag is
+	 * present.
 	 */
 
 	return fat_mode;
@@ -251,9 +248,8 @@ static int fatfs_truncate(struct fs_file_t *zfp, off_t length)
 		res = f_truncate(zfp->filep);
 	} else {
 		/*
-		 * Get actual length after expansion. This could be
-		 * less if there was not enough space in the volume
-		 * to expand to the requested length
+		 * Get actual length after expansion. This could be less if there was not enough
+		 * space in the volume to expand to the requested length
 		 */
 		length = f_tell((FIL *)zfp->filep);
 
@@ -263,10 +259,8 @@ static int fatfs_truncate(struct fs_file_t *zfp, off_t length)
 		}
 
 		/*
-		 * The FS module does caching and optimization of
-		 * writes. Here we write 1 byte at a time to avoid
-		 * using additional code and memory for doing any
-		 * optimization.
+		 * The FS module does caching and optimization of writes. Here we write 1 byte at
+		 * a time to avoid using additional code and memory for doing any optimization.
 		 */
 		unsigned int bw;
 		uint8_t c = 0U;
@@ -393,9 +387,9 @@ static int fatfs_statvfs(struct fs_mount_t *mountp,
 	stat->f_bfree = f_bfree;
 
 	/*
-	 * If FF_MIN_SS and FF_MAX_SS differ, variable sector size support is
-	 * enabled and the file system object structure contains the actual sector
-	 * size, otherwise it is configured to a fixed value give by FF_MIN_SS.
+	 * If FF_MIN_SS and FF_MAX_SS differ, variable sector size support is enabled and the file
+	 * system object structure contains the actual sector size, otherwise it is configured to
+	 * a fixed value give by FF_MIN_SS.
 	 */
 #if FF_MAX_SS != FF_MIN_SS
 	stat->f_bsize = fs->ssize;
@@ -422,8 +416,7 @@ static int fatfs_mount(struct fs_mount_t *mountp)
 		return -EROFS;
 	}
 	/* If no file system found then create one */
-	if (res == FR_NO_FILESYSTEM &&
-	    (mountp->flags & FS_MOUNT_FLAG_NO_FORMAT) == 0) {
+	if (res == FR_NO_FILESYSTEM && (mountp->flags & FS_MOUNT_FLAG_NO_FORMAT) == 0) {
 		uint8_t work[FF_MAX_SS];
 		MKFS_PARM mkfs_opt = {
 			.fmt = FM_FAT | FM_SFD,	/* Any suitable FAT */

--- a/subsys/fs/fat_fs.c
+++ b/subsys/fs/fat_fs.c
@@ -142,8 +142,9 @@ static int fatfs_rename(struct fs_mount_t *mountp, const char *from,
 	res = f_stat(&to[1], &fno);
 	if (FR_OK == res) {
 		res = f_unlink(&to[1]);
-		if (FR_OK != res)
+		if (res != FR_OK) {
 			return translate_error(res);
+		}
 	}
 
 	res = f_rename(&from[1], &to[1]);

--- a/subsys/fs/fs.c
+++ b/subsys/fs/fs.c
@@ -40,8 +40,7 @@ static inline void registry_clear_entry(struct registry_entry *ep)
 	ep->fstp = NULL;
 }
 
-static int registry_add(int type,
-			const struct fs_file_system_t *fstp)
+static int registry_add(int type, const struct fs_file_system_t *fstp)
 {
 	int rv = -ENOSPC;
 
@@ -121,8 +120,9 @@ static int fs_get_mnt_point(struct fs_mount_t **mnt_pntp,
 	}
 
 	*mnt_pntp = mnt_p;
-	if (match_len)
+	if (match_len) {
 		*match_len = mnt_p->mountp_len;
+	}
 
 	return 0;
 }
@@ -136,8 +136,7 @@ int fs_open(struct fs_file_t *zfp, const char *file_name, fs_mode_t flags)
 	/* COpy flags to zfp for use with other fs_ API calls */
 	zfp->flags = flags;
 
-	if ((file_name == NULL) ||
-			(strlen(file_name) <= 1) || (file_name[0] != '/')) {
+	if ((file_name == NULL) || (strlen(file_name) <= 1) || (file_name[0] != '/')) {
 		LOG_ERR("invalid file name!!");
 		return -EINVAL;
 	}
@@ -152,8 +151,7 @@ int fs_open(struct fs_file_t *zfp, const char *file_name, fs_mode_t flags)
 		return rc;
 	}
 
-	if (((mp->flags & FS_MOUNT_FLAG_READ_ONLY) != 0) &&
-	    (flags & FS_O_CREATE || flags & FS_O_WRITE)) {
+	if ((mp->flags & FS_MOUNT_FLAG_READ_ONLY) && (flags & (FS_O_CREATE | FS_O_WRITE))) {
 		return -EROFS;
 	}
 
@@ -321,8 +319,7 @@ int fs_opendir(struct fs_dir_t *zdp, const char *abs_path)
 	struct fs_mount_t *mp;
 	int rc = -EINVAL;
 
-	if ((abs_path == NULL) ||
-			(strlen(abs_path) < 1) || (abs_path[0] != '/')) {
+	if ((abs_path == NULL) || (strlen(abs_path) < 1) || (abs_path[0] != '/')) {
 		LOG_ERR("invalid file name!!");
 		return -EINVAL;
 	}
@@ -392,6 +389,7 @@ int fs_readdir(struct fs_dir_t *zdp, struct fs_dirent *entry)
 				break;
 			}
 		}
+
 		if (rc < 0) {
 			LOG_ERR("directory read error (%d)", rc);
 		}
@@ -422,8 +420,7 @@ int fs_readdir(struct fs_dir_t *zdp, struct fs_dirent *entry)
 			mnt = CONTAINER_OF(node, struct fs_mount_t, node);
 
 			entry->type = FS_DIR_ENTRY_DIR;
-			strncpy(entry->name, mnt->mnt_point + 1,
-				sizeof(entry->name) - 1);
+			strncpy(entry->name, mnt->mnt_point + 1, sizeof(entry->name) - 1);
 			entry->name[sizeof(entry->name) - 1] = 0;
 			entry->size = 0;
 
@@ -477,8 +474,7 @@ int fs_mkdir(const char *abs_path)
 	struct fs_mount_t *mp;
 	int rc = -EINVAL;
 
-	if ((abs_path == NULL) ||
-			(strlen(abs_path) <= 1) || (abs_path[0] != '/')) {
+	if ((abs_path == NULL) || (strlen(abs_path) <= 1) || (abs_path[0] != '/')) {
 		LOG_ERR("invalid file name!!");
 		return -EINVAL;
 	}
@@ -510,8 +506,7 @@ int fs_unlink(const char *abs_path)
 	struct fs_mount_t *mp;
 	int rc = -EINVAL;
 
-	if ((abs_path == NULL) ||
-			(strlen(abs_path) <= 1) || (abs_path[0] != '/')) {
+	if ((abs_path == NULL) || (strlen(abs_path) <= 1) || (abs_path[0] != '/')) {
 		LOG_ERR("invalid file name!!");
 		return -EINVAL;
 	}
@@ -545,7 +540,7 @@ int fs_rename(const char *from, const char *to)
 	int rc = -EINVAL;
 
 	if ((from == NULL) || (strlen(from) <= 1) || (from[0] != '/') ||
-			(to == NULL) || (strlen(to) <= 1) || (to[0] != '/')) {
+	    (to == NULL) || (strlen(to) <= 1) || (to[0] != '/')) {
 		LOG_ERR("invalid file name!!");
 		return -EINVAL;
 	}
@@ -583,8 +578,7 @@ int fs_stat(const char *abs_path, struct fs_dirent *entry)
 	struct fs_mount_t *mp;
 	int rc = -EINVAL;
 
-	if ((abs_path == NULL) ||
-			(strlen(abs_path) <= 1) || (abs_path[0] != '/')) {
+	if ((abs_path == NULL) || (strlen(abs_path) <= 1) || (abs_path[0] != '/')) {
 		LOG_ERR("invalid file name!!");
 		return -EINVAL;
 	}
@@ -613,8 +607,7 @@ int fs_statvfs(const char *abs_path, struct fs_statvfs *stat)
 	struct fs_mount_t *mp;
 	int rc;
 
-	if ((abs_path == NULL) ||
-			(strlen(abs_path) <= 1) || (abs_path[0] != '/')) {
+	if ((abs_path == NULL) || (strlen(abs_path) <= 1) || (abs_path[0] != '/')) {
 		LOG_ERR("invalid file name!!");
 		return -EINVAL;
 	}

--- a/subsys/fs/fs_impl.c
+++ b/subsys/fs/fs_impl.c
@@ -8,8 +8,7 @@
 #include <fs/fs.h>
 #include "fs_impl.h"
 
-const char *fs_impl_strip_prefix(const char *path,
-				 const struct fs_mount_t *mp)
+const char *fs_impl_strip_prefix(const char *path, const struct fs_mount_t *mp)
 {
 	static const char *const root = "/";
 

--- a/subsys/fs/fs_impl.h
+++ b/subsys/fs/fs_impl.h
@@ -22,12 +22,10 @@ extern "C" {
  *
  * @param mp a pointer to the mount point within which @p path is found
  *
- * @return the absolute path within the mount point.  Behavior is
- * undefined if @p path does not start with the mount point prefix.
+ * @return the absolute path within the mount point.  Behavior is undefined if @p path does not
+ * start with the mount point prefix.
  */
-const char *fs_impl_strip_prefix(const char *path,
-				 const struct fs_mount_t *mp);
-
+const char *fs_impl_strip_prefix(const char *path, const struct fs_mount_t *mp);
 
 #ifdef __cplusplus
 }

--- a/subsys/fs/littlefs_fs.c
+++ b/subsys/fs/littlefs_fs.c
@@ -37,12 +37,11 @@ static K_MEM_SLAB_DEFINE(file_data_pool, sizeof(struct lfs_file_data),
 static K_MEM_SLAB_DEFINE(lfs_dir_pool, sizeof(struct lfs_dir),
 			 CONFIG_FS_LITTLEFS_NUM_DIRS, 4);
 
-/* Inferred overhead, in bytes, for each k_heap_aligned allocation for
- * the filecache heap.  This relates to the CHUNK_UNIT parameter in
- * the heap implementation, but that value is not visible outside the
- * kernel.
- * FIXME: value for this macro should be rather taken from the Kernel
- * internals than set by user, but we do not have a way to do so now.
+/* Inferred overhead, in bytes, for each k_heap_aligned allocation for the filecache heap.
+ * This relates to the CHUNK_UNIT parameter in the heap implementation, but that value is not
+ * visible outside the kernel.
+ * FIXME: value for this macro should be rather taken from the Kernel internals than set by user,
+ * but we do not have a way to do so now.
  */
 #define FC_HEAP_PER_ALLOC_OVERHEAD CONFIG_FS_LITTLEFS_HEAP_PER_ALLOC_OVERHEAD_SIZE
 
@@ -52,7 +51,7 @@ BUILD_ASSERT((CONFIG_FS_LITTLEFS_HEAP_PER_ALLOC_OVERHEAD_SIZE % 8) == 0);
 #undef CONFIG_FS_LITTLEFS_FC_HEAP_SIZE
 #define CONFIG_FS_LITTLEFS_FC_HEAP_SIZE						\
 	((CONFIG_FS_LITTLEFS_CACHE_SIZE + FC_HEAP_PER_ALLOC_OVERHEAD) *		\
-	CONFIG_FS_LITTLEFS_NUM_FILES)
+	 CONFIG_FS_LITTLEFS_NUM_FILES)
 #endif /* CONFIG_FS_LITTLEFS_FC_HEAP_SIZE */
 
 static K_HEAP_DEFINE(file_cache_heap, CONFIG_FS_LITTLEFS_FC_HEAP_SIZE);
@@ -152,8 +151,8 @@ static int errno_to_lfs(int error)
 }
 
 
-static int lfs_api_read(const struct lfs_config *c, lfs_block_t block,
-			lfs_off_t off, void *buffer, lfs_size_t size)
+static int lfs_api_read(const struct lfs_config *c, lfs_block_t block, lfs_off_t off, void *buffer,
+			lfs_size_t size)
 {
 	const struct flash_area *fa = c->context;
 	size_t offset = block * c->block_size + off;
@@ -163,8 +162,8 @@ static int lfs_api_read(const struct lfs_config *c, lfs_block_t block,
 	return errno_to_lfs(rc);
 }
 
-static int lfs_api_prog(const struct lfs_config *c, lfs_block_t block,
-			lfs_off_t off, const void *buffer, lfs_size_t size)
+static int lfs_api_prog(const struct lfs_config *c, lfs_block_t block, lfs_off_t off,
+			const void *buffer, lfs_size_t size)
 {
 	const struct flash_area *fa = c->context;
 	size_t offset = block * c->block_size + off;
@@ -205,8 +204,8 @@ static int lfs_flags_from_zephyr(unsigned int zflags)
 {
 	int flags = (zflags & FS_O_CREATE) ? LFS_O_CREAT : 0;
 
-	/* LFS_O_READONLY and LFS_O_WRONLY can be selected at the same time,
-	 * this is not a mistake, together they create RDWR access.
+	/* LFS_O_READONLY and LFS_O_WRONLY can be selected at the same time, this is not a mistake,
+	 * together they create RDWR access.
 	 */
 	flags |= (zflags & FS_O_READ) ? LFS_O_RDONLY : 0;
 	flags |= (zflags & FS_O_WRITE) ? LFS_O_WRONLY : 0;
@@ -216,8 +215,7 @@ static int lfs_flags_from_zephyr(unsigned int zflags)
 	return flags;
 }
 
-static int littlefs_open(struct fs_file_t *fp, const char *path,
-			 fs_mode_t zflags)
+static int littlefs_open(struct fs_file_t *fp, const char *path, fs_mode_t zflags)
 {
 	struct fs_littlefs *fs = fp->mp->fs_data;
 	struct lfs *lfs = &fs->lfs;
@@ -243,8 +241,7 @@ static int littlefs_open(struct fs_file_t *fp, const char *path,
 
 	fs_lock(fs);
 
-	ret = lfs_file_opencfg(&fs->lfs, &fdp->file,
-			       path, flags, &fdp->config);
+	ret = lfs_file_opencfg(&fs->lfs, &fdp->file, path, flags, &fdp->config);
 
 	fs_unlock(fs);
 out:
@@ -284,8 +281,7 @@ static int littlefs_unlink(struct fs_mount_t *mountp, const char *path)
 	return lfs_to_errno(ret);
 }
 
-static int littlefs_rename(struct fs_mount_t *mountp, const char *from,
-			   const char *to)
+static int littlefs_rename(struct fs_mount_t *mountp, const char *from, const char *to)
 {
 	struct fs_littlefs *fs = mountp->fs_data;
 
@@ -324,9 +320,8 @@ static ssize_t littlefs_write(struct fs_file_t *fp, const void *ptr, size_t len)
 	return lfs_to_errno(ret);
 }
 
-BUILD_ASSERT((FS_SEEK_SET == LFS_SEEK_SET)
-	     && (FS_SEEK_CUR == LFS_SEEK_CUR)
-	     && (FS_SEEK_END == LFS_SEEK_END));
+BUILD_ASSERT((FS_SEEK_SET == LFS_SEEK_SET) && (FS_SEEK_CUR == LFS_SEEK_CUR) &&
+	     (FS_SEEK_END == LFS_SEEK_END));
 
 static int littlefs_seek(struct fs_file_t *fp, off_t off, int whence)
 {
@@ -421,8 +416,7 @@ static int littlefs_opendir(struct fs_dir_t *dp, const char *path)
 
 static void info_to_dirent(const struct lfs_info *info, struct fs_dirent *entry)
 {
-	entry->type = ((info->type == LFS_TYPE_DIR) ?
-		       FS_DIR_ENTRY_DIR : FS_DIR_ENTRY_FILE);
+	entry->type = ((info->type == LFS_TYPE_DIR) ?  FS_DIR_ENTRY_DIR : FS_DIR_ENTRY_FILE);
 	entry->size = info->size;
 	strncpy(entry->name, info->name, sizeof(entry->name));
 	entry->name[sizeof(entry->name) - 1] = '\0';
@@ -464,8 +458,7 @@ static int littlefs_closedir(struct fs_dir_t *dp)
 	return lfs_to_errno(ret);
 }
 
-static int littlefs_stat(struct fs_mount_t *mountp,
-			 const char *path, struct fs_dirent *entry)
+static int littlefs_stat(struct fs_mount_t *mountp, const char *path, struct fs_dirent *entry)
 {
 	struct fs_littlefs *fs = mountp->fs_data;
 
@@ -486,8 +479,7 @@ static int littlefs_stat(struct fs_mount_t *mountp,
 	return lfs_to_errno(ret);
 }
 
-static int littlefs_statvfs(struct fs_mount_t *mountp,
-			    const char *path, struct fs_statvfs *stat)
+static int littlefs_statvfs(struct fs_mount_t *mountp, const char *path, struct fs_statvfs *stat)
 {
 	struct fs_littlefs *fs = mountp->fs_data;
 	struct lfs *lfs = &fs->lfs;
@@ -512,8 +504,8 @@ static int littlefs_statvfs(struct fs_mount_t *mountp,
 	return lfs_to_errno(ret);
 }
 
-/* Return maximum page size in a flash area.  There's no flash_area
- * API to implement this, so we have to make one here.
+/* Return maximum page size in a flash area.  There's no flash_area API to implement this, so we
+ * have to make one here.
  */
 struct get_page_ctx {
 	const struct flash_area *area;
@@ -544,10 +536,9 @@ static bool get_page_cb(const struct flash_pages_info *info, void *ctxp)
 	return true;
 }
 
-/* Iterate over all page groups in the flash area and return the
- * largest page size we see.  This works as long as the partition is
- * aligned so that erasing with this size is supported throughout the
- * partition.
+/* Iterate over all page groups in the flash area and return the largest page size we see.
+ * This works as long as the partition is aligned so that erasing with this size is supported
+ * throughout the partition.
  */
 static lfs_size_t get_block_size(const struct flash_area *fa)
 {
@@ -569,8 +560,7 @@ static int littlefs_mount(struct fs_mount_t *mountp)
 	unsigned int area_id = (uintptr_t)mountp->storage_dev;
 	const struct device *dev;
 
-	LOG_INF("LittleFS version %u.%u, disk version %u.%u",
-		LFS_VERSION_MAJOR, LFS_VERSION_MINOR,
+	LOG_INF("LittleFS version %u.%u, disk version %u.%u", LFS_VERSION_MAJOR, LFS_VERSION_MINOR,
 		LFS_DISK_VERSION_MAJOR, LFS_DISK_VERSION_MINOR);
 
 	if (fs->area) {
@@ -588,8 +578,7 @@ static int littlefs_mount(struct fs_mount_t *mountp)
 		ret = -ENODEV;
 		goto out;
 	}
-	LOG_DBG("FS area %u at 0x%x for %u bytes",
-		area_id, (uint32_t)fs->area->fa_off,
+	LOG_DBG("FS area %u at 0x%x for %u bytes", area_id, (uint32_t)fs->area->fa_off,
 		(uint32_t)fs->area->fa_size);
 
 	dev = flash_area_get_device(fs->area);
@@ -661,11 +650,11 @@ static int littlefs_mount(struct fs_mount_t *mountp)
 	/* No, you don't get to override this. */
 	lfs_size_t block_count = fs->area->fa_size / block_size;
 
-	LOG_INF("FS at %s:0x%x is %u 0x%x-byte blocks with %u cycle",
-		log_strdup(dev->name), (uint32_t)fs->area->fa_off,
-		block_count, block_size, block_cycles);
-	LOG_INF("sizes: rd %u ; pr %u ; ca %u ; la %u",
-		read_size, prog_size, cache_size, lookahead_size);
+	LOG_INF("FS at %s:0x%x is %u 0x%x-byte blocks with %u cycle", log_strdup(dev->name),
+		(uint32_t)fs->area->fa_off, block_count, block_size, block_cycles);
+
+	LOG_INF("sizes: rd %u ; pr %u ; ca %u ; la %u", read_size, prog_size, cache_size,
+		lookahead_size);
 
 	__ASSERT_NO_MSG(prog_size != 0);
 	__ASSERT_NO_MSG(read_size != 0);
@@ -674,10 +663,8 @@ static int littlefs_mount(struct fs_mount_t *mountp)
 
 	__ASSERT((fs->area->fa_size % block_size) == 0,
 		 "partition size must be multiple of block size");
-	__ASSERT((block_size % prog_size) == 0,
-		 "erase size must be multiple of write size");
-	__ASSERT((block_size % cache_size) == 0,
-		 "cache size incompatible with block size");
+	__ASSERT((block_size % prog_size) == 0, "erase size must be multiple of write size");
+	__ASSERT((block_size % cache_size) == 0, "cache size incompatible with block size");
 
 	/* Set the validated/defaulted values. */
 	lcp->context = (void *)fs->area;
@@ -695,8 +682,7 @@ static int littlefs_mount(struct fs_mount_t *mountp)
 
 	/* Mount it, formatting if needed. */
 	ret = lfs_mount(&fs->lfs, &fs->cfg);
-	if (ret < 0 &&
-	    (mountp->flags & FS_MOUNT_FLAG_NO_FORMAT) == 0) {
+	if (ret < 0 && (mountp->flags & FS_MOUNT_FLAG_NO_FORMAT) == 0) {
 		LOG_WRN("can't mount (LFS %d); formatting", ret);
 		if ((mountp->flags & FS_MOUNT_FLAG_READ_ONLY) == 0) {
 			ret = lfs_format(&fs->lfs, &fs->cfg);
@@ -814,17 +800,14 @@ DT_INST_FOREACH_STATUS_OKAY(DEFINE_FS)
 
 static void mount_init(struct fs_mount_t *mp)
 {
-
 	LOG_INF("littlefs partition at %s", mp->mnt_point);
 	if ((mp->flags & FS_MOUNT_FLAG_AUTOMOUNT) != 0) {
 		int rc = fs_mount(mp);
 
 		if (rc < 0) {
-			LOG_ERR("Automount %s failed: %d",
-				mp->mnt_point, rc);
+			LOG_ERR("Automount %s failed: %d", mp->mnt_point, rc);
 		} else {
-			LOG_INF("Automount %s succeeded",
-				mp->mnt_point);
+			LOG_INF("Automount %s succeeded", mp->mnt_point);
 		}
 	}
 }

--- a/subsys/fs/shell.c
+++ b/subsys/fs/shell.c
@@ -159,8 +159,7 @@ static int cmd_ls(const struct shell *shell, size_t argc, char **argv)
 			break;
 		}
 
-		shell_print(shell, "%s%s", entry.name,
-			      (entry.type == FS_DIR_ENTRY_DIR) ? "/" : "");
+		shell_print(shell, "%s%s", entry.name, (entry.type == FS_DIR_ENTRY_DIR) ? "/" : "");
 	}
 
 	fs_closedir(&dir);
@@ -268,8 +267,7 @@ static int cmd_read(const struct shell *shell, size_t argc, char **argv)
 
 	err = fs_stat(path, &dirent);
 	if (err) {
-		shell_error(shell, "Failed to obtain file %s (err: %d)",
-			    path, err);
+		shell_error(shell, "Failed to obtain file %s (err: %d)", path, err);
 		return -ENOEXEC;
 	}
 
@@ -290,8 +288,7 @@ static int cmd_read(const struct shell *shell, size_t argc, char **argv)
 	if (offset > 0) {
 		err = fs_seek(&file, offset, FS_SEEK_SET);
 		if (err) {
-			shell_error(shell, "Failed to seek %s (%d)",
-				    path, err);
+			shell_error(shell, "Failed to seek %s (%d)", path, err);
 			fs_close(&file);
 			return -ENOEXEC;
 		}
@@ -350,8 +347,7 @@ static int cmd_cat(const struct shell *shell, size_t argc, char **argv)
 
 		err = fs_stat(path, &dirent);
 		if (err < 0) {
-			shell_error(shell, "Failed to obtain file %s (err: %d)",
-					path, err);
+			shell_error(shell, "Failed to obtain file %s (err: %d)", path, err);
 			continue;
 		}
 
@@ -378,8 +374,7 @@ static int cmd_cat(const struct shell *shell, size_t argc, char **argv)
 		}
 
 		if (read < 0) {
-			shell_error(shell, "Failed to read from file %s (err: %zd)",
-				path, read);
+			shell_error(shell, "Failed to read from file %s (err: %zd)", path, read);
 		}
 
 		fs_close(&file);
@@ -459,8 +454,7 @@ static int cmd_write(const struct shell *shell, size_t argc, char **argv)
 		if ((buf_len == BUF_CNT) || (arg_offset == argc)) {
 			err = fs_write(&file, buf, buf_len);
 			if (err < 0) {
-				shell_error(shell, "Failed to write %s (%d)",
-					      path, err);
+				shell_error(shell, "Failed to write %s (%d)", path, err);
 				fs_close(&file);
 				return -ENOEXEC;
 			}
@@ -496,21 +490,18 @@ static int cmd_mount_fat(const struct shell *shell, size_t argc, char **argv)
 
 	mntpt = mntpt_prepare(argv[1]);
 	if (!mntpt) {
-		shell_error(shell,
-			    "Failed to allocate  buffer for mount point");
+		shell_error(shell, "Failed to allocate  buffer for mount point");
 		return -ENOEXEC;
 	}
 
 	fatfs_mnt.mnt_point = (const char *)mntpt;
 	res = fs_mount(&fatfs_mnt);
 	if (res != 0) {
-		shell_error(shell,
-			"Error mounting fat fs.Error Code [%d]", res);
+		shell_error(shell, "Error mounting fat fs.Error Code [%d]", res);
 		return -ENOEXEC;
 	}
 
-	shell_print(shell, "Successfully mounted fat fs:%s",
-			fatfs_mnt.mnt_point);
+	shell_print(shell, "Successfully mounted fat fs:%s", fatfs_mnt.mnt_point);
 
 	return 0;
 }
@@ -544,18 +535,14 @@ static int cmd_mount_littlefs(const struct shell *shell, size_t argc, char **arg
 }
 #endif
 
-#if defined(CONFIG_FAT_FILESYSTEM_ELM)		\
-	|| defined(CONFIG_FILE_SYSTEM_LITTLEFS)
+#if defined(CONFIG_FAT_FILESYSTEM_ELM) || defined(CONFIG_FILE_SYSTEM_LITTLEFS)
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_fs_mount,
 #if defined(CONFIG_FAT_FILESYSTEM_ELM)
-	SHELL_CMD_ARG(fat, NULL,
-		      "Mount fatfs. fs mount fat <mount-point>",
-		      cmd_mount_fat, 2, 0),
+	SHELL_CMD_ARG(fat, NULL, "Mount fatfs. fs mount fat <mount-point>", cmd_mount_fat, 2, 0),
 #endif
 
 #if defined(CONFIG_FILE_SYSTEM_LITTLEFS)
-	SHELL_CMD_ARG(littlefs, NULL,
-		      "Mount littlefs. fs mount littlefs <mount-point>",
+	SHELL_CMD_ARG(littlefs, NULL, "Mount littlefs. fs mount littlefs <mount-point>",
 		      cmd_mount_littlefs, 2, 0),
 #endif
 
@@ -563,8 +550,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_fs_mount,
 );
 #endif
 
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_fs,
-	SHELL_CMD(cd, NULL, "Change working directory", cmd_cd),
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_fs, SHELL_CMD(cd, NULL, "Change working directory", cmd_cd),
 	SHELL_CMD(ls, NULL, "List files in current directory", cmd_ls),
 	SHELL_CMD_ARG(mkdir, NULL, "Create directory", cmd_mkdir, 2, 0),
 #if defined(CONFIG_FAT_FILESYSTEM_ELM)		\
@@ -574,9 +560,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_fs,
 #endif
 	SHELL_CMD(pwd, NULL, "Print current working directory", cmd_pwd),
 	SHELL_CMD_ARG(read, NULL, "Read from file", cmd_read, 2, 255),
-	SHELL_CMD_ARG(cat, NULL,
-		"Concatenate files and print on the standard output",
-		cmd_cat, 2, 255),
+	SHELL_CMD_ARG(cat, NULL, "Concatenate files and print on the standard output",
+		      cmd_cat, 2, 255),
 	SHELL_CMD_ARG(rm, NULL, "Remove file", cmd_rm, 2, 0),
 	SHELL_CMD_ARG(statvfs, NULL, "Show file system state", cmd_statvfs, 2, 0),
 	SHELL_CMD_ARG(trunc, NULL, "Truncate file", cmd_trunc, 2, 255),


### PR DESCRIPTION
The PR re-formats VFS, FATFS and LittleFS driver to 100 characters per line to unify usage of the line length across sources, allowing to concatenate some of the source lines and improve code readability; the change also removes doubt whether using 100 characters would break source style.