### PR TITLE
modules/mbedtls: add ./library directory to includes

### DIFF
--- a/modules/mbedtls/CMakeLists.txt
+++ b/modules/mbedtls/CMakeLists.txt
@@ -8,6 +8,7 @@ if(CONFIG_MBEDTLS_BUILTIN)
 
   target_include_directories(mbedTLS INTERFACE
     ${ZEPHYR_CURRENT_MODULE_DIR}/include
+    ${ZEPHYR_CURRENT_MODULE_DIR}/library
     configs
 	)
 


### PR DESCRIPTION
Since migration form v2.7 to 3.x.x mbedts/library contains
header files which might be needed by the applicaton.

For insentience MCUboot might require rsa_alt_helpers.h in order
to be build with RSA image encryption feature.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>

fixes #40114