### PR TITLE
drivers: watchdog: esp32: added support for esp32c3 soc to wdt driver

### DIFF
--- a/boards/riscv/esp32c3_devkitm/esp32c3_devkitm.dts
+++ b/boards/riscv/esp32c3_devkitm/esp32c3_devkitm.dts
@@ -55,6 +55,10 @@
 	status = "okay";
 };
 
+&wdt0 {
+	status = "okay";
+};
+
 &flash0 {
 	status = "okay";
 	partitions {

--- a/drivers/watchdog/Kconfig.esp32
+++ b/drivers/watchdog/Kconfig.esp32
@@ -7,7 +7,7 @@ DT_COMPAT_ESP32_WDT := espressif,esp32-watchdog
 
 config WDT_ESP32
 	bool "ESP32 Watchdog (WDT) Driver"
-	depends on SOC_ESP32 || SOC_ESP32S2
+	depends on SOC_ESP32 || SOC_ESP32S2 || SOC_ESP32C3
 	default $(dt_compat_enabled,$(DT_COMPAT_ESP32_WDT))
 	help
 	  Enable WDT driver for ESP32.

--- a/dts/riscv/espressif/esp32c3.dtsi
+++ b/dts/riscv/espressif/esp32c3.dtsi
@@ -140,6 +140,25 @@
 			status = "disabled";
 			use-iomux;
 		};
+
+		wdt0: watchdog@6001f048  {
+			compatible = "espressif,esp32-watchdog";
+			reg = <0x6001f048 0x20>;
+			interrupts = <TG0_WDT_LEVEL_INTR_SOURCE>;
+			interrupt-parent = <&intc>;
+			label = "WDT_0";
+			status = "disabled";
+		};
+
+		wdt1: watchdog@60020048 {
+			compatible = "espressif,esp32-watchdog";
+			reg = <0x60020048 0x20>;
+			interrupts = <TG1_WDT_LEVEL_INTR_SOURCE>;
+			interrupt-parent = <&intc>;
+			label = "WDT_1";
+			status = "disabled";
+		};
+
 	};
 
 };


### PR DESCRIPTION
This PR adds the ESP32C3 as supported SoC to the ESP32 unified watchdog driver using the TIMG_WDT peripheral. 