### PR TITLE
Bluetooth: controller: Introduce preferred central conn spacing config

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -337,6 +337,26 @@ config BT_CTLR_SCHED_ADVANCED
 	  Disabling this feature will lead to overlapping role in timespace
 	  leading to skipped events amongst active roles.
 
+config BT_CTLR_SCHED_ADVANCED_CENTRAL_CONN_SPACING
+	int "Advanced scheduling central preferred connection spacing"
+	depends on BT_CTLR_SCHED_ADVANCED
+	default 0
+	help
+	  The central preferred connection spacing defines an additional spacing
+	  in microseconds, added to the fixed ~1250 us spacing obtained by enabling
+	  BT_CTLR_SCHED_ADVANCED. Specifying 0 (default) will obtain a spacing of
+	  ~1250 us, whereas specifying 1250 will yield a spacing of ~2500 us.
+	  The spacing is defined as the distance in time between the anchor points
+	  of the established central role connections.
+	  The precision is determined by the resolution of the platform dependent
+	  ticker clock.
+	  When spefifying values above 6.25 ms, the spacing may be unobtainable if
+	  the connection interval becomes smaller than the total spacing. In that
+	  case, modulo is applied and a total spacing of 15 ms on a 10 ms connection
+	  interval yields 5 ms spacing.
+	  For multiple connections, it may become impossible to honor the preferred
+	  spacing, in which case overlapping will occur.
+
 config BT_CTLR_LLL_PRIO
 	int "Lower Link Layer (Radio) IRQ priority" if (BT_CTLR_ULL_LLL_PRIO_SUPPORT && !BT_CTLR_ZLI)
 	range 0 3 if SOC_SERIES_NRF51X

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -50,6 +50,12 @@
 /* Maximum primary Advertising Radio Channels to scan */
 #define ADV_CHAN_MAX 3U
 
+#if defined(CONFIG_BT_CENTRAL) && defined(CONFIG_BT_CTLR_SCHED_ADVANCED)
+#define CONN_SPACING CONFIG_BT_CTLR_SCHED_ADVANCED_CENTRAL_CONN_SPACING
+#else
+#define CONN_SPACING 0U
+#endif /* CONFIG_BT_CENTRAL && CONFIG_BT_CTLR_SCHED_ADVANCED */
+
 static int init_reset(void);
 static int prepare_cb(struct lll_prepare_param *p);
 static int resume_prepare_cb(struct lll_prepare_param *p);
@@ -287,7 +293,8 @@ void lll_scan_prepare_connect_req(struct lll_scan *lll, struct pdu_adv *pdu_tx,
 		*conn_space_us = conn_offset_us;
 		pdu_tx->connect_ind.win_offset = sys_cpu_to_le16(0);
 	} else {
-		uint32_t win_offset_us = lll->conn_win_offset_us;
+		uint32_t win_offset_us = lll->conn_win_offset_us +
+					 CONN_SPACING;
 
 		while ((win_offset_us & ((uint32_t)1 << 31)) ||
 		       (win_offset_us < conn_offset_us)) {


### PR DESCRIPTION
Adds configuration BT_CTLR_SCHED_ADVANCED_CENTRAL_CONN_SPACING to enable
per-application preferred central connection spacing. This is an
extension of feature BT_CTLR_SCHED_ADVANCED, which when enabled, adds
user defined spacing between existing, and new central initiated
connections.

This is crucial for ensuring that centrals acting as ACL connection
based multi-channel streaming sources do not get overlapping
connections, and that spacing allows full frame transfer without
scheduling collision.

Due to the simple, compile-time configuration, use is limited to
specific applications in which the specified spacing is required.

Signed-off-by: Morten Priess <mtpr@oticon.com>