### PR TITLE
tests: latency_measure: remove qemu_x86_64 exclusion

### DIFF
--- a/tests/benchmarks/latency_measure/testcase.yaml
+++ b/tests/benchmarks/latency_measure/testcase.yaml
@@ -2,7 +2,7 @@ tests:
   benchmark.kernel.latency:
     arch_allow: x86 arm riscv32 riscv64
     # FIXME: no DWT and no RTC_TIMER for qemu_cortex_m0
-    platform_exclude: qemu_x86_64 qemu_cortex_m0 m2gl025_miv
+    platform_exclude: qemu_cortex_m0 m2gl025_miv
     filter: CONFIG_PRINTK and not CONFIG_SOC_FAMILY_STM32
     tags: benchmark
     harness: console


### PR DESCRIPTION
The latency measure test can run on qemu_x86_64 so remove it
from the platform_exclude list.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>