### PR TITLE
drivers: gsm: improve modem context RSSI member

### DIFF
--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -1113,7 +1113,7 @@ static int gsm_init(const struct device *dev)
 	gsm->context.data_imsi = minfo.mdm_imsi;
 	gsm->context.data_iccid = minfo.mdm_iccid;
 #endif	/* CONFIG_MODEM_SIM_NUMBERS */
-	gsm->context.data_rssi = minfo.mdm_rssi;
+	gsm->context.data_rssi = &minfo.mdm_rssi;
 #endif	/* CONFIG_MODEM_SHELL */
 
 	gsm->context.is_automatic_oper = false;

--- a/drivers/modem/modem_context.h
+++ b/drivers/modem/modem_context.h
@@ -71,7 +71,7 @@ struct modem_context {
 	int   data_lac;
 	int   data_cellid;
 #endif
-	int   data_rssi;
+	int   *data_rssi;
 	bool  is_automatic_oper;
 	/* pin config */
 	struct modem_pin *pins;

--- a/drivers/modem/modem_receiver.h
+++ b/drivers/modem/modem_receiver.h
@@ -37,7 +37,7 @@ struct mdm_receiver_context {
 	char *data_imsi;
 #endif
 	char *data_iccid;
-	int   data_rssi;
+	int  *data_rssi;
 };
 
 /**

--- a/drivers/modem/modem_shell.c
+++ b/drivers/modem/modem_shell.c
@@ -88,7 +88,7 @@ static int cmd_modem_list(const struct shell *shell, size_t argc,
 			       mdm_ctx->data_lac,
 			       mdm_ctx->data_cellid,
 #endif
-			       mdm_ctx->data_rssi);
+			       mdm_ctx->data_rssi ? *mdm_ctx->data_rssi : 0);
 		}
 	}
 
@@ -223,7 +223,7 @@ static int cmd_modem_info(const struct shell *shell, size_t argc, char *argv[])
 		      mdm_ctx->data_model,
 		      mdm_ctx->data_revision,
 		      mdm_ctx->data_imei,
-		      mdm_ctx->data_rssi);
+		      mdm_ctx->data_rssi ? *mdm_ctx->data_rssi : 0);
 
 	shell_fprintf(shell, SHELL_NORMAL,
 		      "GSM 07.10 muxing : %s\n",

--- a/drivers/modem/quectel-bg9x.c
+++ b/drivers/modem/quectel-bg9x.c
@@ -231,14 +231,14 @@ MODEM_CMD_DEFINE(on_cmd_atcmdinfo_rssi_csq)
 
 	/* Check the RSSI value. */
 	if (rssi == 31) {
-		mctx.data_rssi = -51;
+		mdata.mdm_rssi = -51;
 	} else if (rssi >= 0 && rssi <= 31) {
-		mctx.data_rssi = -114 + ((rssi * 2) + 1);
+		mdata.mdm_rssi = -114 + ((rssi * 2) + 1);
 	} else {
-		mctx.data_rssi = -1000;
+		mdata.mdm_rssi = -1000;
 	}
 
-	LOG_INF("RSSI: %d", mctx.data_rssi);
+	LOG_INF("RSSI: %d", mdata.mdm_rssi);
 	return 0;
 }
 
@@ -1035,13 +1035,13 @@ restart_rssi:
 
 	/* Keep trying to read RSSI until we get a valid value - Eventually, exit. */
 	while (counter++ < MDM_WAIT_FOR_RSSI_COUNT &&
-	      (mctx.data_rssi >= 0 || mctx.data_rssi <= -1000)) {
+	      (mdata.mdm_rssi >= 0 || mdata.mdm_rssi <= -1000)) {
 		modem_rssi_query_work(NULL);
 		k_sleep(MDM_WAIT_FOR_RSSI_DELAY);
 	}
 
 	/* Is the RSSI invalid ? */
-	if (mctx.data_rssi >= 0 || mctx.data_rssi <= -1000) {
+	if (mdata.mdm_rssi >= 0 || mdata.mdm_rssi <= -1000) {
 		rssi_retry_count++;
 
 		if (rssi_retry_count >= MDM_NETWORK_RETRY_COUNT) {
@@ -1180,6 +1180,7 @@ static int modem_init(const struct device *dev)
 	mctx.data_imsi	       = mdata.mdm_imsi;
 	mctx.data_iccid	       = mdata.mdm_iccid;
 #endif /* #if defined(CONFIG_MODEM_SIM_NUMBERS) */
+	mctx.data_rssi = &mdata.mdm_rssi;
 
 	/* pin setup */
 	mctx.pins	       = modem_pins;

--- a/drivers/modem/quectel-bg9x.h
+++ b/drivers/modem/quectel-bg9x.h
@@ -100,6 +100,7 @@ struct modem_data {
 	char mdm_imsi[MDM_IMSI_LENGTH];
 	char mdm_iccid[MDM_ICCID_LENGTH];
 #endif /* #if defined(CONFIG_MODEM_SIM_NUMBERS) */
+	int mdm_rssi;
 
 	/* bytes written to socket in last transaction */
 	int sock_written;


### PR DESCRIPTION
The previous bf68b67 commit incorrectly passes minfo.mdm_rssi value to the modem context data_rssi member during the driver initialization which causes the `modem info` shell command to return 0 as RSSI value. Fix that by changing data_rssi
modem ctx member to a pointer that is assigned to the RSSI variable stored within the modem driver context structure.

MR has been tested using Telit ME910C1-WW GSM module.

Signed-off-by: Bartosz Bilas <bartosz.bilas@hotmail.com>