### PR TITLE
Bluetooth: Mesh: Add all missing configuration client model shell command

### DIFF
--- a/doc/reference/bluetooth/mesh/shell.rst
+++ b/doc/reference/bluetooth/mesh/shell.rst
@@ -567,6 +567,15 @@ The Configuration Client uses the general messages parameters set by ``mesh dst`
 	* ``Model ID``: The model ID of the model to add the subscription to.
 	* ``Company ID``: If present, determines the Company ID of the model. If omitted, the model is a Bluetooth SIG defined model.
 
+``mesh mod-sub-del-all <elem addr> <Model ID> [Company ID]``
+-------------------------------------------------------------------
+
+	Remove all group and virtual address subscriptions from of a model.
+
+	* ``elem addr``: Address of the element the model is on.
+	* ``Model ID``: The model ID of the model to Unsubscribe all.
+	* ``Company ID``: If present, determines the Company ID of the model. If omitted, the model is a Bluetooth SIG defined model.
+
 ``mesh mod-sub-get <elem addr> <Model ID> [Company ID]``
 --------------------------------------------------------
 

--- a/doc/reference/bluetooth/mesh/shell.rst
+++ b/doc/reference/bluetooth/mesh/shell.rst
@@ -372,6 +372,14 @@ The Configuration Client uses the general messages parameters set by ``mesh dst`
 	* ``count``: Sets the new relay retransmit count if ``val`` is ``on``. Ignored if ``val`` is ``off``. Defaults to ``2`` if omitted.
 	* ``interval``: Sets the new relay retransmit interval in milliseconds if ``val`` is ``on``. Ignored if ``val`` is ``off``. Defaults to ``20`` if omitted.
 
+``mesh node-id <NetKeyIndex> [Identity]``
+-----------------------------------------
+
+	Get or Set of current Node Identity state of a subnet.
+
+	* ``NetKeyIndex``: The network key index to Get/Set.
+	* ``Identity``: If present, sets the identity of Node Identity state.
+
 ``mesh polltimeout-get <LPN Address>``
 --------------------------------------
 

--- a/doc/reference/bluetooth/mesh/shell.rst
+++ b/doc/reference/bluetooth/mesh/shell.rst
@@ -557,6 +557,15 @@ The Configuration Client uses the general messages parameters set by ``mesh dst`
 	* ``Model ID``: The model ID of the model to add the subscription to.
 	* ``Company ID``: If present, determines the Company ID of the model. If omitted, the model is a Bluetooth SIG defined model.
 
+``mesh mod-sub-ow-va <elem addr> <Label UUID> <Model ID> [Company ID]``
+------------------------------------------------------------------------
+
+	Overwrite all model subscriptions with a single new virtual address. Models only receive messages sent to their unicast address or a group or virtual address they subscribe to. Models may subscribe to multiple group and virtual addresses.
+
+	* ``elem addr``: Address of the element the model is on.
+	* ``Label UUID``: 128-bit label UUID of the virtual address as the new Address to be added to the subscription list. Any omitted bytes will be zero.
+	* ``Model ID``: The model ID of the model to add the subscription to.
+	* ``Company ID``: If present, determines the Company ID of the model. If omitted, the model is a Bluetooth SIG defined model.
 
 ``mesh mod-sub-get <elem addr> <Model ID> [Company ID]``
 --------------------------------------------------------

--- a/doc/reference/bluetooth/mesh/shell.rst
+++ b/doc/reference/bluetooth/mesh/shell.rst
@@ -372,6 +372,12 @@ The Configuration Client uses the general messages parameters set by ``mesh dst`
 	* ``count``: Sets the new relay retransmit count if ``val`` is ``on``. Ignored if ``val`` is ``off``. Defaults to ``2`` if omitted.
 	* ``interval``: Sets the new relay retransmit interval in milliseconds if ``val`` is ``on``. Ignored if ``val`` is ``off``. Defaults to ``20`` if omitted.
 
+``mesh polltimeout-get <LPN Address>``
+--------------------------------------
+
+	Get current value of the PollTimeout timer of the LPN within a Friend node.
+
+	* ``addr`` Address of Low Power node.
 
 ``mesh net-transmit-param [<count: 0-7> <interval: 10-320>]``
 -------------------------------------------------------------

--- a/doc/reference/bluetooth/mesh/shell.rst
+++ b/doc/reference/bluetooth/mesh/shell.rst
@@ -547,6 +547,16 @@ The Configuration Client uses the general messages parameters set by ``mesh dst`
 	* ``Model ID``: The model ID of the model to add the subscription to.
 	* ``Company ID``: If present, determines the Company ID of the model. If omitted, the model is a Bluetooth SIG defined model.
 
+``mesh mod-sub-ow <elem addr> <sub addr> <Model ID> [Company ID]``
+-------------------------------------------------------------------
+
+	Overwrite all model subscriptios with a single new group address.
+
+	* ``elem addr``: Address of the element the model is on.
+	* ``sub addr``: 16-bit group address the model should added to the subscription list (``0xc000`` to ``0xFEFF``).
+	* ``Model ID``: The model ID of the model to add the subscription to.
+	* ``Company ID``: If present, determines the Company ID of the model. If omitted, the model is a Bluetooth SIG defined model.
+
 
 ``mesh mod-sub-get <elem addr> <Model ID> [Company ID]``
 --------------------------------------------------------

--- a/doc/reference/bluetooth/mesh/shell.rst
+++ b/doc/reference/bluetooth/mesh/shell.rst
@@ -405,6 +405,14 @@ The Configuration Client uses the general messages parameters set by ``mesh dst`
 	* ``val``: If present, sets the key value as a 128-bit hexadecimal value. Any missing bytes will be zero. Only valid if the key does not already exist in the Configuration Database. If omitted, the default key value is used.
 
 
+``mesh net-key-upd <NetKeyIndex> [val]``
+----------------------------------------
+
+	Update a network key to the target node.
+
+	* ``NetKeyIndex``: The network key index to updated.
+	* ``val``: If present, sets the key value as a 128-bit hexadecimal value. Any missing bytes will be zero. If omitted, the default key value is used.
+
 ``mesh net-key-get``
 --------------------
 

--- a/doc/reference/bluetooth/mesh/shell.rst
+++ b/doc/reference/bluetooth/mesh/shell.rst
@@ -436,6 +436,14 @@ The Configuration Client uses the general messages parameters set by ``mesh dst`
 	* ``AppKeyIndex``: The application key index to add.
 	* ``val``: If present, sets the key value as a 128-bit hexadecimal value. Any missing bytes will be zero. Only valid if the key does not already exist in the Configuration Database. If omitted, the default key value is used.
 
+``mesh app-key-upd <NetKeyIndex> <AppKeyIndex> [val]``
+------------------------------------------------------
+
+	Update an application key to the target node.
+
+	* ``NetKeyIndex``: The network key index the application key is bound to.
+	* ``AppKeyIndex``: The application key index to update.
+	* ``val``: If present, sets the key value as a 128-bit hexadecimal value. Any missing bytes will be zero. If omitted, the default key value is used.
 
 ``mesh app-key-get <NetKeyIndex>``
 ----------------------------------

--- a/doc/reference/bluetooth/mesh/shell.rst
+++ b/doc/reference/bluetooth/mesh/shell.rst
@@ -592,6 +592,14 @@ The Configuration Client uses the general messages parameters set by ``mesh dst`
 	* ``Company ID``: If present, determines the Company ID of the model. If omitted, the model is a Bluetooth SIG defined model.
 
 
+``mesh krp <NetKeyIdx> [Phase]``
+-------------------------------------
+
+	Get or set the key refresh phase of a subnet.
+
+	* ``NetKeyIdx``: The identified network key used to Get/Set the current Key Refresh Phase state.
+	* ``Phase``: New Key Refresh Phase. Valid phases are 0, 1 or 2.
+
 ``mesh hb-sub [<src> <dst> <period>]``
 --------------------------------------
 

--- a/doc/reference/bluetooth/mesh/shell.rst
+++ b/doc/reference/bluetooth/mesh/shell.rst
@@ -484,6 +484,25 @@ The Configuration Client uses the general messages parameters set by ``mesh dst`
 		* ``count``: Number of retransmission for each published message (``0`` to ``7``).
 		* ``interval`` The interval between each retransmission, in milliseconds. Must be a multiple of 50.
 
+``mesh mod-pub-va <addr> <UUID> <AppKeyIndex> <cred: off, on> <ttl> <period> <count> <interval> <mod id> [cid]``
+------------------------------------------------------------------------------------------------------------------
+
+	Set the publication parameters of a model.
+
+	* ``addr``: Address of the element the model is on.
+	* ``Model ID``: The model ID of the model to get the bound keys of.
+	* ``cid``: If present, determines the Company ID of the model. If omitted, the model is a Bluetooth SIG defined model.
+
+	Publication parameters:
+
+		* ``UUID``: The destination virtual address to publish to.
+		* ``AppKeyIndex``: The application key index to publish with.
+		* ``cred``: Whether to publish with Friendship credentials when acting as a Low Power Node.
+		* ``ttl``: TTL value to publish with (``0x00`` to ``0x07f``).
+		* ``period``: Encoded publication period, or 0 to disable periodic publication.
+		* ``count``: Number of retransmission for each published message (``0`` to ``7``).
+		* ``interval`` The interval between each retransmission, in milliseconds. Must be a multiple of 50.
+
 
 ``mesh mod-sub-add <elem addr> <sub addr> <Model ID> [Company ID]``
 -------------------------------------------------------------------

--- a/subsys/bluetooth/mesh/shell.c
+++ b/subsys/bluetooth/mesh/shell.c
@@ -1629,16 +1629,24 @@ static int mod_pub_get(const struct shell *shell, uint16_t addr, uint16_t mod_id
 	return 0;
 }
 
-static int mod_pub_set(const struct shell *shell, uint16_t addr, uint16_t mod_id,
-		       uint16_t cid, char *argv[])
+static int mod_pub_set(const struct shell *sh, uint16_t addr, bool is_va,
+		       uint16_t mod_id, uint16_t cid, char *argv[])
 {
 	struct bt_mesh_cfg_mod_pub pub;
 	uint8_t status, count;
 	uint16_t interval;
+	uint8_t uuid[16];
+	uint8_t len;
 	int err;
 
-	pub.addr = strtoul(argv[0], NULL, 0);
-	pub.uuid = NULL;
+	if (!is_va) {
+		pub.addr = strtoul(argv[0], NULL, 0);
+	} else {
+		len = hex2bin(argv[0], strlen(argv[1]), uuid, sizeof(uuid));
+		memset(uuid + len, 0, sizeof(uuid) - len);
+		pub.uuid = (const uint8_t *)&uuid;
+	}
+
 	pub.app_idx = strtoul(argv[1], NULL, 0);
 	pub.cred_flag = str2bool(argv[2]);
 	pub.ttl = strtoul(argv[3], NULL, 0);
@@ -1646,13 +1654,13 @@ static int mod_pub_set(const struct shell *shell, uint16_t addr, uint16_t mod_id
 
 	count = strtoul(argv[5], NULL, 0);
 	if (count > 7) {
-		shell_print(shell, "Invalid retransmit count");
+		shell_print(sh, "Invalid retransmit count");
 		return -EINVAL;
 	}
 
 	interval = strtoul(argv[6], NULL, 0);
 	if (interval > (31 * 50) || (interval % 50)) {
-		shell_print(shell, "Invalid retransmit interval %u", interval);
+		shell_print(sh, "Invalid retransmit interval %u", interval);
 		return -EINVAL;
 	}
 
@@ -1667,16 +1675,16 @@ static int mod_pub_set(const struct shell *shell, uint16_t addr, uint16_t mod_id
 	}
 
 	if (err) {
-		shell_error(shell, "Model Publication Set failed (err %d)",
+		shell_error(sh, "Model Publication Set failed (err %d)",
 			    err);
 		return 0;
 	}
 
 	if (status) {
-		shell_print(shell, "Model Publication Set failed "
+		shell_print(sh, "Model Publication Set failed "
 			    "(status 0x%02x)", status);
 	} else {
-		shell_print(shell, "Model Publication successfully set");
+		shell_print(sh, "Model Publication successfully set");
 	}
 
 	return 0;
@@ -1709,10 +1717,26 @@ static int cmd_mod_pub(const struct shell *shell, size_t argc, char *argv[])
 			return -EINVAL;
 		}
 
-		return mod_pub_set(shell, addr, mod_id, cid, argv);
+		return mod_pub_set(shell, addr, false, mod_id, cid, argv);
 	} else {
 		return mod_pub_get(shell, addr, mod_id, cid);
 	}
+}
+
+static int cmd_mod_pub_va(const struct shell *sh, size_t argc, char *argv[])
+{
+	uint16_t addr, mod_id, cid = CID_NVAL;
+
+	addr = strtoul(argv[1], NULL, 0);
+	mod_id = strtoul(argv[9], NULL, 0);
+
+	if (argc > 10) {
+		cid = strtoul(argv[10], NULL, 0);
+	}
+
+	argv += 2;
+
+	return mod_pub_set(sh, addr, true, mod_id, cid, argv);
 }
 
 static void hb_sub_print(const struct shell *shell,
@@ -2726,6 +2750,10 @@ SHELL_STATIC_SUBCMD_SET_CREATE(mesh_cmds,
 	SHELL_CMD_ARG(mod-pub, NULL, "<addr> <mod id> [cid] [<PubAddr> "
 		      "<AppKeyIndex> <cred: off, on> <ttl> <period> <count> <interval>]",
 		      cmd_mod_pub, 3, 1 + 7),
+	SHELL_CMD_ARG(mod-pub-va, NULL, "<addr> <UUID: 16 hex values> "
+		      "<AppKeyIndex> <cred: off, on> <ttl> <period> <count> <interval> "
+		      "<mod id> [cid]",
+		      cmd_mod_pub_va, 10, 1),
 	SHELL_CMD_ARG(mod-sub-add, NULL,
 		      "<elem addr> <sub addr> <Model ID> [Company ID]",
 		      cmd_mod_sub_add, 4, 1),

--- a/subsys/bluetooth/mesh/shell.c
+++ b/subsys/bluetooth/mesh/shell.c
@@ -1067,6 +1067,45 @@ static int cmd_net_key_add(const struct shell *shell, size_t argc, char *argv[])
 	return 0;
 }
 
+
+static int cmd_net_key_update(const struct shell *sh, size_t argc, char *argv[])
+{
+	bool has_key_val = (argc > 2);
+	uint8_t key_val[16];
+	uint16_t key_net_idx;
+	uint8_t status;
+	int err;
+
+	key_net_idx = strtoul(argv[1], NULL, 0);
+
+	if (has_key_val) {
+		size_t len;
+
+		len = hex2bin(argv[2], strlen(argv[2]),
+			      key_val, sizeof(key_val));
+		(void)memset(key_val, 0, sizeof(key_val) - len);
+	} else {
+		memcpy(key_val, default_key, sizeof(key_val));
+	}
+
+	err = bt_mesh_cfg_net_key_update(net.net_idx, net.dst, key_net_idx,
+					 key_val, &status);
+	if (err) {
+		shell_print(sh, "Unable to send NetKey Update (err %d)", err);
+		return 0;
+	}
+
+	if (status) {
+		shell_print(sh, "NetKeyUpdate failed with status 0x%02x",
+			    status);
+	} else {
+		shell_print(sh, "NetKey updated with NetKey Index 0x%03x",
+			    key_net_idx);
+	}
+
+	return 0;
+}
+
 static int cmd_net_key_get(const struct shell *shell, size_t argc, char *argv[])
 {
 	uint16_t keys[16];
@@ -2946,6 +2985,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(mesh_cmds,
 		      "[<val: off, on> [<count: 0-7> [interval: 10-320]]]",
 		      cmd_relay, 1, 3),
 	SHELL_CMD_ARG(net-key-add, NULL, "<NetKeyIndex> [val]", cmd_net_key_add,
+		      2, 1),
+	SHELL_CMD_ARG(net-key-upd, NULL, "<NetKeyIndex> [val]", cmd_net_key_update,
 		      2, 1),
 	SHELL_CMD_ARG(net-key-get, NULL, NULL, cmd_net_key_get, 1, 0),
 	SHELL_CMD_ARG(net-key-del, NULL, "<NetKeyIndex>", cmd_net_key_del, 2,

--- a/subsys/bluetooth/mesh/shell.c
+++ b/subsys/bluetooth/mesh/shell.c
@@ -1219,6 +1219,46 @@ static int cmd_app_key_get(const struct shell *shell, size_t argc, char *argv[])
 	return 0;
 }
 
+static int cmd_node_id(const struct shell *sh, size_t argc, char *argv[])
+{
+	uint16_t net_idx;
+	uint8_t status, identify;
+	int err;
+
+	net_idx = strtoul(argv[1], NULL, 0);
+
+	if (argc < 2) {
+		err = bt_mesh_cfg_node_identity_get(net.net_idx, net.dst,
+						    net_idx, &status,
+						    &identify);
+		if (err) {
+			shell_print(sh, "Unable to send Node Identify Get (err %d)", err);
+			return 0;
+		}
+	} else {
+		uint8_t new_identify = strtoul(argv[1], NULL, 0);
+
+		err = bt_mesh_cfg_node_identity_set(net.net_idx, net.dst,
+						    net_idx, new_identify,
+						    &status, &identify);
+		if (err) {
+			shell_print(sh, "Unable to send Node Identify Set (err %d)", err);
+			return 0;
+		}
+	}
+
+
+	if (status) {
+		shell_print(sh, "Node Identify Get/Set failed with status 0x%02x",
+			    status);
+	} else {
+		shell_print(sh, "Node Identify Get/Set successful with identify 0x%02x",
+			    identify);
+	}
+
+	return 0;
+}
+
 static int cmd_app_key_del(const struct shell *shell, size_t argc, char *argv[])
 {
 	uint16_t key_net_idx, key_app_idx;
@@ -2916,6 +2956,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(mesh_cmds,
 		      cmd_app_key_del, 3, 0),
 	SHELL_CMD_ARG(app-key-get, NULL, "<NetKeyIndex>", cmd_app_key_get, 2,
 		      0),
+	SHELL_CMD_ARG(node-id, NULL, "<NetKeyIndex> [Identify]", cmd_node_id, 2, 1),
 	SHELL_CMD_ARG(polltimeout-get, NULL, "<LPN Address>", cmd_polltimeout_get, 2, 0),
 	SHELL_CMD_ARG(net-transmit-param, NULL, "[<count: 0-7>"
 			" <interval: 10-320>]", cmd_net_transmit, 1, 2),

--- a/subsys/bluetooth/mesh/shell.c
+++ b/subsys/bluetooth/mesh/shell.c
@@ -1536,6 +1536,46 @@ static int cmd_mod_sub_del_va(const struct shell *shell, size_t argc,
 	return 0;
 }
 
+static int cmd_mod_sub_ow(const struct shell *sh, size_t argc, char *argv[])
+{
+	uint16_t elem_addr, sub_addr, mod_id, cid;
+	uint8_t status;
+	int err;
+
+	if (argc < 4) {
+		return -EINVAL;
+	}
+
+	elem_addr = strtoul(argv[1], NULL, 0);
+	sub_addr = strtoul(argv[2], NULL, 0);
+	mod_id = strtoul(argv[3], NULL, 0);
+
+	if (argc > 4) {
+		cid = strtoul(argv[4], NULL, 0);
+		err = bt_mesh_cfg_mod_sub_overwrite_vnd(net.net_idx, net.dst,
+							elem_addr, sub_addr, mod_id,
+							cid, &status);
+	} else {
+		err = bt_mesh_cfg_mod_sub_overwrite(net.net_idx, net.dst, elem_addr,
+						    sub_addr, mod_id, &status);
+	}
+
+	if (err) {
+		shell_error(sh, "Unable to send Model Subscription Overwrite "
+			    "(err %d)", err);
+		return 0;
+	}
+
+	if (status) {
+		shell_print(sh, "Model Subscription Overwrite failed with "
+			    "status 0x%02x", status);
+	} else {
+		shell_print(sh, "Model subscription overwrite was successful");
+	}
+
+	return 0;
+}
+
 static int cmd_mod_sub_get(const struct shell *shell, size_t argc,
 			      char *argv[])
 {
@@ -2766,6 +2806,9 @@ SHELL_STATIC_SUBCMD_SET_CREATE(mesh_cmds,
 	SHELL_CMD_ARG(mod-sub-del-va, NULL,
 		      "<elem addr> <Label UUID> <Model ID> [Company ID]",
 		      cmd_mod_sub_del_va, 4, 1),
+	SHELL_CMD_ARG(mod-sub-ow, NULL,
+		      "<elem addr> <sub addr> <Model ID> [Company ID]",
+		      cmd_mod_sub_ow, 4, 1),
 	SHELL_CMD_ARG(mod-sub-get, NULL,
 		      "<elem addr> <Model ID> [Company ID]",
 		      cmd_mod_sub_get, 3, 1),

--- a/subsys/bluetooth/mesh/shell.c
+++ b/subsys/bluetooth/mesh/shell.c
@@ -889,6 +889,29 @@ static int cmd_gatt_proxy(const struct shell *shell, size_t argc, char *argv[])
 	return 0;
 }
 
+static int cmd_polltimeout_get(const struct shell *sh,
+			       size_t argc, char *argv[])
+{
+	uint16_t lpn_address;
+	int32_t poll_timeout;
+	int err;
+
+	lpn_address = strtoul(argv[1], NULL, 0);
+
+	err = bt_mesh_cfg_lpn_timeout_get(net.net_idx,
+					  net.dst, lpn_address,
+					  &poll_timeout);
+	if (err) {
+		shell_error(sh, "Unable to send LPN PollTimeout Get"
+				   " (err %d)", err);
+		return 0;
+	}
+
+	shell_print(sh, "PollTimeout value %d", poll_timeout);
+
+	return 0;
+}
+
 static int cmd_net_transmit(const struct shell *shell,
 		size_t argc, char *argv[])
 {
@@ -2863,6 +2886,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(mesh_cmds,
 		      cmd_app_key_del, 3, 0),
 	SHELL_CMD_ARG(app-key-get, NULL, "<NetKeyIndex>", cmd_app_key_get, 2,
 		      0),
+	SHELL_CMD_ARG(polltimeout-get, NULL, "<LPN Address>", cmd_polltimeout_get, 2, 0),
 	SHELL_CMD_ARG(net-transmit-param, NULL, "[<count: 0-7>"
 			" <interval: 10-320>]", cmd_net_transmit, 1, 2),
 	SHELL_CMD_ARG(mod-app-bind, NULL,

--- a/subsys/bluetooth/mesh/shell.c
+++ b/subsys/bluetooth/mesh/shell.c
@@ -1737,6 +1737,36 @@ static int cmd_mod_sub_get(const struct shell *shell, size_t argc,
 	return 0;
 }
 
+static int cmd_krp(const struct shell *sh, size_t argc, char *argv[])
+{
+	uint8_t status, phase;
+	uint16_t key_net_idx;
+	int err;
+
+	key_net_idx = strtoul(argv[1], NULL, 0);
+
+	if (argc < 3) {
+		err = bt_mesh_cfg_krp_get(net.net_idx, net.dst, key_net_idx,
+					  &status, &phase);
+	} else {
+		uint16_t trans = strtoul(argv[2], NULL, 0);
+
+		err = bt_mesh_cfg_krp_set(net.net_idx, net.dst, key_net_idx,
+					  trans, &status, &phase);
+	}
+
+	if (err) {
+		shell_error(sh, "Unable to send krp Get/Set "
+			    "(err %d)", err);
+		return 0;
+	}
+
+	shell_print(sh, "Krp Get/Set with status 0x%02x and phase 0x%02x",
+			    status, phase);
+
+	return 0;
+}
+
 static int mod_pub_get(const struct shell *shell, uint16_t addr, uint16_t mod_id,
 		       uint16_t cid)
 {
@@ -2929,6 +2959,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(mesh_cmds,
 	SHELL_CMD_ARG(mod-sub-get, NULL,
 		      "<elem addr> <Model ID> [Company ID]",
 		      cmd_mod_sub_get, 3, 1),
+	SHELL_CMD_ARG(krp, NULL, "<NetKeyIndex> [Phase]",
+		      cmd_krp, 2, 1),
 	SHELL_CMD_ARG(hb-sub, NULL, "[<src> <dst> <period>]", cmd_hb_sub, 1, 3),
 	SHELL_CMD_ARG(hb-pub, NULL,
 		      "[<dst> <count> <period> <ttl> <features> <NetKeyIndex>]",

--- a/subsys/bluetooth/mesh/shell.c
+++ b/subsys/bluetooth/mesh/shell.c
@@ -1224,6 +1224,49 @@ static int cmd_app_key_add(const struct shell *shell, size_t argc, char *argv[])
 	return 0;
 }
 
+static int cmd_app_key_upd(const struct shell *sh, size_t argc, char *argv[])
+{
+	uint8_t key_val[16];
+	uint16_t key_net_idx, key_app_idx;
+	bool has_key_val = (argc > 3);
+	uint8_t status;
+	int err;
+
+	if (argc < 3) {
+		return -EINVAL;
+	}
+
+	key_net_idx = strtoul(argv[1], NULL, 0);
+	key_app_idx = strtoul(argv[2], NULL, 0);
+
+	if (has_key_val) {
+		size_t len;
+
+		len = hex2bin(argv[3], strlen(argv[3]),
+			      key_val, sizeof(key_val));
+		(void)memset(key_val, 0, sizeof(key_val) - len);
+	} else {
+		memcpy(key_val, default_key, sizeof(key_val));
+	}
+
+	err = bt_mesh_cfg_app_key_update(net.net_idx, net.dst, key_net_idx,
+					 key_app_idx, key_val, &status);
+	if (err) {
+		shell_error(sh, "Unable to send App Key Update (err %d)", err);
+		return 0;
+	}
+
+	if (status) {
+		shell_print(sh, "AppKey update failed with status 0x%02x",
+			    status);
+	} else {
+		shell_print(sh, "AppKey updated, NetKeyIndex 0x%04x "
+			    "AppKeyIndex 0x%04x", key_net_idx, key_app_idx);
+	}
+
+	return 0;
+}
+
 static int cmd_app_key_get(const struct shell *shell, size_t argc, char *argv[])
 {
 	uint16_t net_idx;
@@ -2993,6 +3036,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(mesh_cmds,
 		      0),
 	SHELL_CMD_ARG(app-key-add, NULL, "<NetKeyIndex> <AppKeyIndex> [val]",
 		      cmd_app_key_add, 3, 1),
+	SHELL_CMD_ARG(app-key-upd, NULL, "<NetKeyIndex> <AppKeyIndex> [val]",
+		      cmd_app_key_upd, 3, 1),
 	SHELL_CMD_ARG(app-key-del, NULL, "<NetKeyIndex> <AppKeyIndex>",
 		      cmd_app_key_del, 3, 0),
 	SHELL_CMD_ARG(app-key-get, NULL, "<NetKeyIndex>", cmd_app_key_get, 2,

--- a/subsys/bluetooth/mesh/shell.c
+++ b/subsys/bluetooth/mesh/shell.c
@@ -1576,6 +1576,54 @@ static int cmd_mod_sub_ow(const struct shell *sh, size_t argc, char *argv[])
 	return 0;
 }
 
+static int cmd_mod_sub_ow_va(const struct shell *sh, size_t argc,
+			     char *argv[])
+{
+	uint16_t elem_addr, sub_addr, mod_id, cid;
+	uint8_t label[16];
+	uint8_t status;
+	size_t len;
+	int err;
+
+	if (argc < 4) {
+		return -EINVAL;
+	}
+
+	elem_addr = strtoul(argv[1], NULL, 0);
+
+	len = hex2bin(argv[2], strlen(argv[2]), label, sizeof(label));
+	(void)memset(label + len, 0, sizeof(label) - len);
+
+	mod_id = strtoul(argv[3], NULL, 0);
+
+	if (argc > 4) {
+		cid = strtoul(argv[4], NULL, 0);
+		err = bt_mesh_cfg_mod_sub_va_overwrite_vnd(net.net_idx, net.dst,
+							   elem_addr, label, mod_id,
+							   cid, &sub_addr, &status);
+	} else {
+		err = bt_mesh_cfg_mod_sub_va_overwrite(net.net_idx, net.dst,
+						       elem_addr, label, mod_id,
+						       &sub_addr, &status);
+	}
+
+	if (err) {
+		shell_error(sh, "Unable to send Mod Sub VA Overwrite (err %d)",
+			    err);
+		return 0;
+	}
+
+	if (status) {
+		shell_print(sh, "Mod Sub VA Overwrite failed with status 0x%02x",
+			    status);
+	} else {
+		shell_print(sh, "0x%04x overwrite to Label UUID %s "
+			    "(va 0x%04x)", elem_addr, argv[2], sub_addr);
+	}
+
+	return 0;
+}
+
 static int cmd_mod_sub_get(const struct shell *shell, size_t argc,
 			      char *argv[])
 {
@@ -2809,6 +2857,9 @@ SHELL_STATIC_SUBCMD_SET_CREATE(mesh_cmds,
 	SHELL_CMD_ARG(mod-sub-ow, NULL,
 		      "<elem addr> <sub addr> <Model ID> [Company ID]",
 		      cmd_mod_sub_ow, 4, 1),
+	SHELL_CMD_ARG(mod-sub-ow-va, NULL,
+		      "<elem addr> <Label UUID> <Model ID> [Company ID]",
+		      cmd_mod_sub_ow_va, 4, 1),
 	SHELL_CMD_ARG(mod-sub-get, NULL,
 		      "<elem addr> <Model ID> [Company ID]",
 		      cmd_mod_sub_get, 3, 1),

--- a/subsys/bluetooth/mesh/shell.c
+++ b/subsys/bluetooth/mesh/shell.c
@@ -1624,6 +1624,45 @@ static int cmd_mod_sub_ow_va(const struct shell *sh, size_t argc,
 	return 0;
 }
 
+static int cmd_mod_sub_del_all(const struct shell *sh, size_t argc, char *argv[])
+{
+	uint16_t elem_addr, mod_id, cid;
+	uint8_t status;
+	int err;
+
+	if (argc < 3) {
+		return -EINVAL;
+	}
+
+	elem_addr = strtoul(argv[1], NULL, 0);
+	mod_id = strtoul(argv[2], NULL, 0);
+
+	if (argc > 3) {
+		cid = strtoul(argv[3], NULL, 0);
+		err = bt_mesh_cfg_mod_sub_del_all_vnd(net.net_idx, net.dst,
+						      elem_addr, mod_id,
+						      cid, &status);
+	} else {
+		err = bt_mesh_cfg_mod_sub_del_all(net.net_idx, net.dst, elem_addr,
+						  mod_id, &status);
+	}
+
+	if (err) {
+		shell_error(sh, "Unable to send Model Subscription Delete All"
+			    "(err %d)", err);
+		return 0;
+	}
+
+	if (status) {
+		shell_print(sh, "Model Subscription Delete All failed with "
+			    "status 0x%02x", status);
+	} else {
+		shell_print(sh, "Model subscription deltion all was successful");
+	}
+
+	return 0;
+}
+
 static int cmd_mod_sub_get(const struct shell *shell, size_t argc,
 			      char *argv[])
 {
@@ -2860,6 +2899,9 @@ SHELL_STATIC_SUBCMD_SET_CREATE(mesh_cmds,
 	SHELL_CMD_ARG(mod-sub-ow-va, NULL,
 		      "<elem addr> <Label UUID> <Model ID> [Company ID]",
 		      cmd_mod_sub_ow_va, 4, 1),
+	SHELL_CMD_ARG(mod-sub-del-all, NULL,
+		      "<elem addr> <Model ID> [Company ID]",
+		      cmd_mod_sub_del_all, 3, 1),
 	SHELL_CMD_ARG(mod-sub-get, NULL,
 		      "<elem addr> <Model ID> [Company ID]",
 		      cmd_mod_sub_get, 3, 1),


### PR DESCRIPTION
Add all missing configuration client model shell command.

Included:

- model publish virtual address set
- model subscription overwrite
- model subscription overwrite virtual address
- model subscription delete all
- low power node poll_timeout get
- key refresh phase get
- node identity get/set
- network key update
- application key update