### PR TITLE
feat(boards): Add generic Xiao interconnect.

### DIFF
--- a/boards/arm/seeeduino_xiao/seeed_xiao_connector.dtsi
+++ b/boards/arm/seeeduino_xiao/seeed_xiao_connector.dtsi
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021 Peter Johanson
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	xiao_d: connector {
+		compatible = "seeed,xiao-gpio";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map
+			= <0 0 &porta 2 0>		/* D0 */
+			, <1 0 &porta 4 0>		/* D1 */
+			, <2 0 &porta 10 0>		/* D2 */
+			, <3 0 &porta 11 0>		/* D3 */
+			, <4 0 &porta 8 0>		/* D4 */
+			, <5 0 &porta 9 0>		/* D5 */
+			, <6 0 &portb 8 0>		/* D6 */
+			, <7 0 &portb 9 0>		/* D7 */
+			, <8 0 &porta 7 0>		/* D8 */
+			, <9 0 &porta 5 0>		/* D9 */
+			, <10 0 &porta 6 0>		/* D10 */
+			;
+	};
+};
+
+xiao_spi: &sercom0 {};
+xiao_i2c: &sercom2 {};
+xiao_serial: &sercom4 {};

--- a/boards/arm/seeeduino_xiao/seeeduino_xiao.dts
+++ b/boards/arm/seeeduino_xiao/seeeduino_xiao.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include <atmel/samd21.dtsi>
+#include "seeed_xiao_connector.dtsi"
 
 / {
 	model = "Seeeduino XIAO";

--- a/dts/bindings/gpio/seeed-xiao-header.yaml
+++ b/dts/bindings/gpio/seeed-xiao-header.yaml
@@ -1,0 +1,33 @@
+# Copyright (c) 2019 Foundries.io
+# Copyright (C) 2019 Peter Bigot Consulting, LLC
+# Copyright (C) 2021 Peter Johanson
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    GPIO pins exposed on Seeeduino Xiao (and compatible devices) headers.
+
+    The Seeeeduino Xiao layout provides two headers, along opposite
+    edges of the board.
+
+    Proceeding counter-clockwise:
+    * A 7-pin Digital/Analog Input header.  This has input signals
+      labeled from 0 at the top through 6 at the bottom.
+    * An 7-pin header Power and Digital/Analog Input header.  This
+      has three power pins, followed by four inputs labeled 10 at the
+      top through 7 at the bottom.
+
+    This binding provides a nexus mapping for 10 pins where parent pins 0
+    through 10 correspond to D0 through D10, as depicted below:
+
+        0 D0                     5V   -
+        1 D1                     GND  -
+        2 D2                     3V3  -
+        3 D3                     D10 10
+        4 A4                     D9   9
+        5 D5                     D8   8
+        6 D6                     D7   7
+
+
+compatible: "seeed,xiao-gpio"
+
+include: [gpio-nexus.yaml, base.yaml]


### PR DESCRIPTION
* With existence of Adafruit Qt Py boards, and upcoming wireless
  Xiao from Seeeduino, define nexus node and peripheral node
  labels for use with shields that accept any Xiao format board.
* Adds `&xiao_d`, `&xiao_spi`, `&xiao_i2c` and `&xiao_serial` generic
  node labels.

Other boards that when added, should use the same generic interconnect:

* https://www.adafruit.com/product/4600
* https://www.adafruit.com/product/4900 (once we have #34835 in)
* Upcoming from Seeeduino: https://twitter.com/seeedstudio/status/1437716659062534147?s=20