### PR TITLE
Tracing: Added missing k_thread_heap_assign trace hook

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -359,6 +359,7 @@ static inline void k_thread_heap_assign(struct k_thread *thread,
 					struct k_heap *heap)
 {
 	thread->resource_pool = heap;
+	SYS_PORT_TRACING_FUNC(k_thread, heap_assign, thread, heap);
 }
 
 #if defined(CONFIG_INIT_STACKS) && defined(CONFIG_THREAD_STACK_INFO)

--- a/include/tracing/tracing.h
+++ b/include/tracing/tracing.h
@@ -326,6 +326,13 @@ void sys_trace_idle(void);
  */
 #define sys_port_trace_k_thread_sched_suspend(thread)
 
+/**
+ * @brief Trace thread heap assignment
+ * @param thread Thread object
+ * @param heap Heap object
+ */
+#define sys_port_trace_k_thread_heap_assign(thread, heap)
+
 /** @}c*/ /* end of subsys_tracing_apis_thread */
 
 /**


### PR DESCRIPTION
Added missing k_thread_heap_assign trace hook call
which all trace systems have defined but which was
never called by the system.

Signed-off-by: Torbjörn Leksell <torbjorn.leksell@percepio.com>