### PR TITLE
drivers: spi_nrfx_spim/spi: Fix initialization of CS GPIOs

### DIFF
--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -339,7 +339,7 @@ static int spi_nrfx_pm_action(const struct device *dev,
 	static struct spi_nrfx_data spi_##idx##_data = {		       \
 		SPI_CONTEXT_INIT_LOCK(spi_##idx##_data, ctx),		       \
 		SPI_CONTEXT_INIT_SYNC(spi_##idx##_data, ctx),		       \
-		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(idx), ctx)	       \
+		SPI_CONTEXT_CS_GPIOS_INITIALIZE(SPI(idx), ctx)		       \
 		.dev  = DEVICE_DT_GET(SPI(idx)),			       \
 		.busy = false,						       \
 	};								       \

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -405,7 +405,7 @@ static int spim_nrfx_pm_action(const struct device *dev,
 	static struct spi_nrfx_data spi_##idx##_data = {		       \
 		SPI_CONTEXT_INIT_LOCK(spi_##idx##_data, ctx),		       \
 		SPI_CONTEXT_INIT_SYNC(spi_##idx##_data, ctx),		       \
-		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(idx), ctx)         \
+		SPI_CONTEXT_CS_GPIOS_INITIALIZE(SPIM(idx), ctx)		       \
 		.dev  = DEVICE_DT_GET(SPIM(idx)),			       \
 		.busy = false,						       \
 	};								       \


### PR DESCRIPTION
This is a follow-up to commits 99daca9bba2136aff244b7ca36050a178c324036
and ae03c0a6bff293fdd8785b88026ee4e1bf163658.

nRF SPI driver shims cannot use devicetree instance indexes, they need
to use the DT_NODELABEL macro and SoC peripheral instance indexes.
Correct the macros used in initialization of CS GPIOs in those shims.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>