### PR TITLE
ci: doc-publish: fix run condition syntax

### DIFF
--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -19,8 +19,9 @@ jobs:
   doc-publish:
     name: Publish Documentation
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    if: github.repository == 'zephyrproject-rtos/zephyr'
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      github.repository == 'zephyrproject-rtos/zephyr'
 
     steps:
     - name: Download artifacts


### PR DESCRIPTION
To restrict the job to the upstream repository, a new `if` entry was
added, however, another `if` was already present (violates yaml).
Combined the conditions into a single expression.

Note: I haven't tested this, just used GH docs to come up with this patch.