### PR TITLE
tracing: improve Doxygen usage

### DIFF
--- a/doc/guides/debug_tools/tracing/index.rst
+++ b/doc/guides/debug_tools/tracing/index.rst
@@ -351,85 +351,83 @@ API
 Common
 ======
 
-.. doxygengroup:: tracing_apis
+.. doxygengroup:: subsys_tracing_apis
 
 Threads
 =======
 
-.. doxygengroup:: thread_tracing_apis
-
+.. doxygengroup:: subsys_tracing_apis_thread
 
 Work Queues
 ===========
 
-.. doxygengroup:: work_tracing_apis
-
+.. doxygengroup:: subsys_tracing_apis_work
 
 Poll
 ====
 
-.. doxygengroup:: poll_tracing_apis
+.. doxygengroup:: subsys_tracing_apis_poll
 
 Semaphore
 =========
 
-.. doxygengroup:: sem_tracing_apis
+.. doxygengroup:: subsys_tracing_apis_sem
 
 Mutex
 =====
 
-.. doxygengroup:: mutex_tracing_apis
+.. doxygengroup:: subsys_tracing_apis_mutex
 
 Condition Variables
 ===================
 
-.. doxygengroup:: condvar_tracing_apis
+.. doxygengroup:: subsys_tracing_apis_condvar
 
 Queues
 ======
 
-.. doxygengroup:: queue_tracing_apis
+.. doxygengroup:: subsys_tracing_apis_queue
 
 FIFO
 ====
 
-.. doxygengroup:: fifo_tracing_apis
+.. doxygengroup:: subsys_tracing_apis_fifo
 
 LIFO
 ====
-.. doxygengroup:: lifo_tracing_apis
+.. doxygengroup:: subsys_tracing_apis_lifo
 
 Stacks
 ======
 
-.. doxygengroup:: stack_tracing_apis
+.. doxygengroup:: subsys_tracing_apis_stack
 
 Message Queues
 ==============
 
-.. doxygengroup:: msgq_tracing_apis
+.. doxygengroup:: subsys_tracing_apis_msgq
 
 Mailbox
 =======
 
-.. doxygengroup:: mbox_tracing_apis
+.. doxygengroup:: subsys_tracing_apis_mbox
 
 Pipes
 ======
 
-.. doxygengroup:: pipe_tracing_apis
+.. doxygengroup:: subsys_tracing_apis_pipe
 
 Heaps
 =====
 
-.. doxygengroup:: heap_tracing_apis
+.. doxygengroup:: subsys_tracing_apis_heap
 
 Memory Slabs
 ============
 
-.. doxygengroup:: mslab_tracing_apis
+.. doxygengroup:: subsys_tracing_apis_mslab
 
 Timers
 ======
 
-.. doxygengroup:: timer_tracing_apis
+.. doxygengroup:: subsys_tracing_apis_timer

--- a/include/tracing/tracing.h
+++ b/include/tracing/tracing.h
@@ -10,22 +10,58 @@
 
 #if defined CONFIG_SEGGER_SYSTEMVIEW
 #include "tracing_sysview.h"
-
 #elif defined CONFIG_TRACING_CTF
 #include "tracing_ctf.h"
-
 #elif defined CONFIG_TRACING_TEST
 #include "tracing_test.h"
-
 #elif defined CONFIG_TRACING_USER
 #include "tracing_user.h"
-
 #else
+/**
+ * @brief Tracing
+ *
+ * The tracing subsystem provides hooks that permits you to collect data from
+ * your application and allows tools running on a host to visualize the
+ * inner-working of the kernel and various other subsystems.
+ *
+ * @defgroup subsys_tracing Tracing
+ * @ingroup subsys
+ * @{
+ */
+
+/**
+ * @brief Tracing APIs
+ * @defgroup subsys_tracing_apis Tracing APIs
+ * @{
+ */
+
+#if defined(CONFIG_PERCEPIO_TRACERECORDER)
+#include "tracing_tracerecorder.h"
+#else
+/**
+ * @brief Called when entering an ISR
+ */
+void sys_trace_isr_enter(void);
+
+/**
+ * @brief Called when exiting an ISR
+ */
+void sys_trace_isr_exit(void);
+
+/**
+ * @brief Called when exiting an ISR and switching to scheduler
+ */
+void sys_trace_isr_exit_to_scheduler(void);
+
+/**
+ * @brief Called when the cpu enters the idle state
+ */
+void sys_trace_idle(void);
+#endif /* CONFIG_PERCEPIO_TRACERECORDER */
 
 /**
  * @brief Thread Tracing APIs
- * @defgroup thread_tracing_apis Thread Tracing APIs
- * @ingroup tracing_apis
+ * @defgroup subsys_tracing_apis_thread Thread Tracing APIs
  * @{
  */
 
@@ -290,17 +326,11 @@
  */
 #define sys_port_trace_k_thread_sched_suspend(thread)
 
-/**
- * @}
- */ /* end of thread_tracing_apis */
-
-
-
+/** @}c*/ /* end of subsys_tracing_apis_thread */
 
 /**
  * @brief Work Tracing APIs
- * @defgroup work_tracing_apis Work Tracing APIs
- * @ingroup tracing_apis
+ * @defgroup subsys_tracing_apis_work Work Tracing APIs
  * @{
  */
 
@@ -393,17 +423,11 @@
  */
 #define sys_port_trace_k_work_cancel_sync_exit(work, sync, ret)
 
-/**
- * @}
- */ /* end of work_tracing_apis */
-
-
-
+/** @} */ /* end of subsys_tracing_apis_work */
 
 /**
  * @brief Work Queue Tracing APIs
- * @defgroup work_q_tracing_apis Work Queue Tracing APIs
- * @ingroup tracing_apis
+ * @defgroup subsys_tracing_apis_work_q Work Queue Tracing APIs
  * @{
  */
 
@@ -451,17 +475,11 @@
  */
 #define sys_port_trace_k_work_queue_unplug_exit(queue, ret)
 
-/**
- * @}
- */ /* end of work_q_tracing_apis */
-
-
-
+/** @} */ /* end of subsys_tracing_apis_work_q */
 
 /**
  * @brief Work Delayable Tracing APIs
- * @defgroup work_delayable_tracing_apis Work Delayable Tracing APIs
- * @ingroup tracing_apis
+ * @defgroup subsys_tracing_apis_work_delayable Work Delayable Tracing APIs
  * @{
  */
 
@@ -578,17 +596,11 @@
  */
 #define sys_port_trace_k_work_cancel_delayable_sync_exit(dwork, sync, ret)
 
-/**
- * @}
- */ /* end of work_delayable_tracing_apis */
-
-
-
+/** @} */ /* end of subsys_tracing_apis_work_delayable */
 
 /**
  * @brief Work Poll Tracing APIs
- * @defgroup work_poll_tracing_apis Work Poll Tracing APIs
- * @ingroup tracing_apis
+ * @defgroup subsys_tracing_apis_work_poll Work Poll Tracing APIs
  * @{
  */
 
@@ -657,17 +669,11 @@
  */
 #define sys_port_trace_k_work_poll_cancel_exit(work, ret)
 
-/**
- * @}
- */ /* end of work_poll_tracing_apis */
-
-
-
+/** @} */ /* end of subsys_tracing_apis_work_poll */
 
 /**
  * @brief Poll Tracing APIs
- * @defgroup poll_tracing_apis Poll Tracing APIs
- * @ingroup tracing_apis
+ * @defgroup subsys_tracing_apis_poll Poll Tracing APIs
  * @{
  */
 
@@ -715,17 +721,11 @@
  */
 #define sys_port_trace_k_poll_api_signal_raise(signal, ret)
 
-/**
- * @}
- */ /* end of poll_tracing_apis */
-
-
-
+/** @} */ /* end of subsys_tracing_apis_poll */
 
 /**
  * @brief Semaphore Tracing APIs
- * @defgroup sem_tracing_apis Semaphore Tracing APIs
- * @ingroup tracing_apis
+ * @defgroup subsys_tracing_apis_sem Semaphore Tracing APIs
  * @{
  */
 
@@ -776,17 +776,11 @@
  */
 #define sys_port_trace_k_sem_reset(sem)
 
-/**
- * @}
- */ /* end of sem_tracing_apis */
-
-
-
+/** @} */ /* end of subsys_tracing_apis_sem */
 
 /**
  * @brief Mutex Tracing APIs
- * @defgroup mutex_tracing_apis Mutex Tracing APIs
- * @ingroup tracing_apis
+ * @defgroup subsys_tracing_apis_mutex Mutex Tracing APIs
  * @{
  */
 
@@ -830,17 +824,11 @@
  */
 #define sys_port_trace_k_mutex_unlock_exit(mutex, ret)
 
-/**
- * @}
- */ /* end of mutex_tracing_apis */
-
-
-
+/** @} */ /* end of subsys_tracing_apis_mutex */
 
 /**
  * @brief Conditional Variable Tracing APIs
- * @defgroup condvar_tracing_apis Conditional Variable Tracing APIs
- * @ingroup tracing_apis
+ * @defgroup subsys_tracing_apis_condvar Conditional Variable Tracing APIs
  * @{
  */
 
@@ -897,17 +885,11 @@
  */
 #define sys_port_trace_k_condvar_wait_exit(condvar, ret)
 
-/**
- * @}
- */ /* end of condvar_tracing_apis */
-
-
-
+/** @} */ /* end of subsys_tracing_apis_condvar */
 
 /**
  * @brief Queue Tracing APIs
- * @defgroup queue_tracing_apis Queue Tracing APIs
- * @ingroup tracing_apis
+ * @defgroup subsys_tracing_apis_queue Queue Tracing APIs
  * @{
  */
 
@@ -1104,17 +1086,11 @@
  */
 #define sys_port_trace_k_queue_peek_tail(queue, ret)
 
-/**
- * @}
- */ /* end of queue_tracing_apis */
-
-
-
+/** @} */ /* end of subsys_tracing_apis_queue */
 
 /**
  * @brief FIFO Tracing APIs
- * @defgroup fifo_tracing_apis FIFO Tracing APIs
- * @ingroup tracing_apis
+ * @defgroup subsys_tracing_apis_fifo FIFO Tracing APIs
  * @{
  */
 
@@ -1242,17 +1218,11 @@
  */
 #define sys_port_trace_k_fifo_peek_tail_exit(fifo, ret)
 
-/**
- * @}
- */ /* end of fifo_tracing_apis */
-
-
-
+/** @} */ /* end of subsys_tracing_apis_fifo */
 
 /**
  * @brief LIFO Tracing APIs
- * @defgroup lifo_tracing_apis LIFO Tracing APIs
- * @ingroup tracing_apis
+ * @defgroup subsys_tracing_apis_lifo LIFO Tracing APIs
  * @{
  */
 
@@ -1312,17 +1282,11 @@
  */
 #define sys_port_trace_k_lifo_get_exit(lifo, timeout, ret)
 
-/**
- * @}
- */ /* end of lifo_tracing_apis */
-
-
-
+/** @} */ /* end of subsys_tracing_apis_lifo */
 
 /**
  * @brief Stack Tracing APIs
- * @defgroup stack_tracing_apis Stack Tracing APIs
- * @ingroup tracing_apis
+ * @defgroup subsys_tracing_apis_stack Stack Tracing APIs
  * @{
  */
 
@@ -1393,17 +1357,11 @@
  */
 #define sys_port_trace_k_stack_pop_exit(stack, timeout, ret)
 
-/**
- * @}
- */ /* end of stack_tracing_apis */
-
-
-
+/** @} */ /* end of subsys_tracing_apis_stack */
 
 /**
  * @brief Message Queue Tracing APIs
- * @defgroup msgq_tracing_apis Message Queue Tracing APIs
- * @ingroup tracing_apis
+ * @defgroup subsys_tracing_apis_msgq Message Queue Tracing APIs
  * @{
  */
 
@@ -1496,17 +1454,11 @@
  */
 #define sys_port_trace_k_msgq_purge(msgq)
 
-/**
- * @}
- */ /* end of msgq_tracing_apis */
-
-
-
+/** @} */ /* end of subsys_tracing_apis_msgq */
 
 /**
  * @brief Mailbox Tracing APIs
- * @defgroup mbox_tracing_apis Mailbox Tracing APIs
- * @ingroup tracing_apis
+ * @defgroup subsys_tracing_apis_mbox Mailbox Tracing APIs
  * @{
  */
 
@@ -1595,17 +1547,11 @@
  */
 #define sys_port_trace_k_mbox_data_get(rx_msg)
 
-/**
- * @}
- */ /* end of mbox_tracing_apis */
-
-
-
+/** @} */ /* end of subsys_tracing_apis_mbox */
 
 /**
  * @brief Pipe Tracing APIs
- * @defgroup pipe_tracing_apis Pipe Tracing APIs
- * @ingroup tracing_apis
+ * @defgroup subsys_tracing_apis_pipe Pipe Tracing APIs
  * @{
  */
 
@@ -1699,17 +1645,11 @@
  */
 #define sys_port_trace_k_pipe_block_put_exit(pipe, sem)
 
-/**
- * @}
- */ /* end of pipe_tracing_apis */
-
-
-
+/** @} */ /* end of subsys_tracing_apis_pipe */
 
 /**
  * @brief Heap Tracing APIs
- * @defgroup heap_tracing_apis Heap Tracing APIs
- * @ingroup tracing_apis
+ * @defgroup subsys_tracing_apis_heap Heap Tracing APIs
  * @{
  */
 
@@ -1813,17 +1753,11 @@
  */
 #define sys_port_trace_k_heap_sys_k_calloc_exit(heap, ret)
 
-/**
- * @}
- */ /* end of heap_tracing_apis */
-
-
-
+/** @} */ /* end of subsys_tracing_apis_heap */
 
 /**
  * @brief Memory Slab Tracing APIs
- * @defgroup mslab_tracing_apis Memory Slab Tracing APIs
- * @ingroup tracing_apis
+ * @defgroup subsys_tracing_apis_mslab Memory Slab Tracing APIs
  * @{
  */
 
@@ -1868,17 +1802,11 @@
  */
 #define sys_port_trace_k_mem_slab_free_exit(slab)
 
-/**
- * @}
- */ /* end of mslab_tracing_apis */
-
-
-
+/** @} */ /* end of subsys_tracing_apis_mslab */
 
 /**
  * @brief Timer Tracing APIs
- * @defgroup timer_tracing_apis Timer Tracing APIs
- * @ingroup tracing_apis
+ * @defgroup subsys_tracing_apis_timer Timer Tracing APIs
  * @{
  */
 
@@ -1920,14 +1848,11 @@
  */
 #define sys_port_trace_k_timer_status_sync_exit(timer, result)
 
-/**
- * @}
- */ /* end of timer_tracing_apis */
+/** @} */ /* end of subsys_tracing_apis_timer */
 
 /**
  * @brief Event Tracing APIs
- * @defgroup event_tracing_apis Event Tracing APIs
- * @ingroup tracing_apis
+ * @defgroup subsys_tracing_apis_event Event Tracing APIs
  * @{
  */
 
@@ -1979,15 +1904,11 @@
  */
 #define sys_port_trace_k_event_wait_exit(event, events, ret)
 
-/**
- * @}
- */ /* end of event_tracing_apis */
-
+/** @} */ /* end of subsys_tracing_apis_event */
 
 /**
  * @brief System PM Tracing APIs
- * @defgroup pm_system_tracing_apis System PM Tracing APIs
- * @ingroup tracing_apis
+ * @defgroup subsys_tracing_apis_pm_system System PM Tracing APIs
  * @{
  */
 
@@ -2004,12 +1925,11 @@
  */
 #define sys_port_trace_pm_system_suspend_exit(ticks, state)
 
-/** @} */ /* end of pm_system_tracing_apis */
+/** @} */ /* end of subsys_tracing_apis_pm_system */
 
 /**
  * @brief PM Device Runtime Tracing APIs
- * @defgroup pm_device_runtime_tracing_apis PM Device Runtime Tracing APIs
- * @ingroup tracing_apis
+ * @defgroup subsys_tracing_apis_pm_device_runtime PM Device Runtime Tracing APIs
  * @{
  */
 
@@ -2077,42 +1997,11 @@
  */
 #define sys_port_trace_pm_device_runtime_disable_exit(dev, ret)
 
-/** @} */ /* end of pm_device_runtime_tracing_apis */
+/** @} */ /* end of subsys_tracing_apis_pm_device_runtime */
 
-#if defined CONFIG_PERCEPIO_TRACERECORDER
-#include "tracing_tracerecorder.h"
-#else
-/**
- * @brief Tracing APIs
- * @defgroup tracing_apis Tracing APIs
- * @{
- */
+/** @} */ /* end of subsys_tracing_apis */
 
-/**
- * @brief Called when entering an ISR
- */
-void sys_trace_isr_enter(void);
-
-/**
- * @brief Called when exiting an ISR
- */
-void sys_trace_isr_exit(void);
-
-/**
- * @brief Called when exiting an ISR and switching to scheduler
- */
-void sys_trace_isr_exit_to_scheduler(void);
-
-/**
- * @brief Called when the cpu enters the idle state
- */
-void sys_trace_idle(void);
-
-/**
- * @}
- */
-#endif
-
+/** @} */ /* end of subsys_tracing */
 
 #endif
-#endif
+#endif /* ZEPHYR_INCLUDE_TRACING_TRACING_H_ */

--- a/include/tracing/tracing_format.h
+++ b/include/tracing/tracing_format.h
@@ -14,8 +14,13 @@ extern "C" {
 #endif
 
 /**
- * @brief A structure to represent tracing data format.
+ * @brief Tracing format APIs
+ * @defgroup subsys_tracing_format_apis Tracing format APIs
+ * @ingroup subsys_tracing
+ * @{
  */
+
+/** @brief A structure to represent tracing data format. */
 typedef struct tracing_data {
 	uint8_t *data;
 	uint32_t length;
@@ -23,6 +28,9 @@ typedef struct tracing_data {
 
 /**
  * @brief Macro to trace a message in string format.
+ *
+ * @param fmt The format string.
+ * @param ... The format arguments.
  */
 #define TRACING_STRING(fmt, ...)					       \
 	do {								       \
@@ -31,6 +39,8 @@ typedef struct tracing_data {
 
 /**
  * @brief Macro to format data to tracing data format.
+ *
+ * @param x Data field.
  */
 #define TRACING_FORMAT_DATA(x)						       \
 	((struct tracing_data){.data = (uint8_t *)&(x), .length = sizeof((x))})
@@ -72,8 +82,10 @@ void tracing_format_raw_data(uint8_t *data, uint32_t length);
  */
 void tracing_format_data(tracing_data_t *tracing_data_array, uint32_t count);
 
+/** @} */ /* end of subsys_tracing_format_apis */
+
 #ifdef __cplusplus
 }
 #endif
 
-#endif
+#endif /* ZEPHYR_INCLUDE_TRACING_TRACING_FORMAT_H */

--- a/include/tracing/tracing_macros.h
+++ b/include/tracing/tracing_macros.h
@@ -6,7 +6,7 @@
 #ifndef ZEPHYR_INCLUDE_TRACING_TRACING_MACROS_H_
 #define ZEPHYR_INCLUDE_TRACING_TRACING_MACROS_H_
 
-#ifndef CONFIG_TRACING
+#if !defined(CONFIG_TRACING) && !defined(__DOXYGEN__)
 
 #define SYS_PORT_TRACING_FUNC(type, func, ...) do { } while (false)
 #define SYS_PORT_TRACING_FUNC_ENTER(type, func, ...) do { } while (false)
@@ -20,8 +20,19 @@
 
 #else
 
-/* Helper macros used by the extended tracing system
+/**
+ * @brief Tracing utility macros
+ * @defgroup subsys_tracing_macros Tracing utility macros
+ * @ingroup subsys_tracing
+ * @{
  */
+
+/** @cond INTERNAL_HIDDEN */
+
+/*
+ * Helper macros used by the extended tracing system
+ */
+
 #define _SYS_PORT_TRACING_TYPE_MASK(type) \
 	sys_port_trace_type_mask_ ## type
 #define _SYS_PORT_TRACING_FUNC(name, func) \
@@ -43,8 +54,8 @@
 #define _SYS_PORT_TRACING_OBJ_FUNC_EXIT(name, func) \
 	sys_port_trace_ ## name ## _ ## func ## _exit
 
-
-/* Object trace macros part of the system for checking if certain
+/*
+ * Object trace macros part of the system for checking if certain
  * objects should be traced or not depending on the tracing configuration.
  */
 #if defined(CONFIG_TRACING_THREAD)
@@ -151,10 +162,9 @@
 	#define sys_port_trace_type_mask_k_event(trace_call)
 #endif
 
+/** @endcond */
 
 /**
- * @def SYS_PORT_TRACING_OBJ_MASK
- *
  * @brief Checks if an object type should be traced or not.
  *
  * @param type Tracing event type/object
@@ -162,9 +172,6 @@
  */
 #define SYS_PORT_TRACING_TYPE_MASK(type, trace_call) \
 	_SYS_PORT_TRACING_TYPE_MASK(type)(trace_call)
-
-
-
 
 /**
  * @def SYS_PORT_TRACING_FUNC
@@ -248,8 +255,6 @@
 	} while (false)
 
 /**
- * @def SYS_PORT_TRACING_OBJ_FUNC
- *
  * @brief Tracing macro for simple object function calls often without returns or branching.
  *
  * @param obj_type The type of object associated with the call (k_thread, k_sem, k_mutex etc.)
@@ -266,8 +271,6 @@
 	} while (false)
 
 /**
- * @def SYS_PORT_TRACING_OBJ_FUNC_ENTER
- *
  * @brief Tracing macro for the entry into a function that might or might not return
  * a value.
  *
@@ -285,8 +288,6 @@
 	} while (false)
 
 /**
- * @def SYS_PORT_TRACING_OBJ_FUNC_BLOCKING
- *
  * @brief Tracing macro for when a function blocks during its execution.
  *
  * @param obj_type The type of object associated with the call (k_thread, k_sem, k_mutex etc.)
@@ -294,6 +295,7 @@
  * match the name of the function but should rather match what the user called in case of
  * system calls etc. That is, we can often omit the z_vrfy/z_impl part of the name.
  * @param obj Object
+ * @param timeout Timeout
  * @param ... Additional parameters relevant to the tracing call
  */
 #define SYS_PORT_TRACING_OBJ_FUNC_BLOCKING(obj_type, func, obj, timeout, ...) \
@@ -304,8 +306,6 @@
 	} while (false)
 
 /**
- * @def SYS_PORT_TRACING_OBJ_FUNC_EXIT
- *
  * @brief Tracing macro for when a function ends its execution. Potential return values
  * can be given as additional arguments.
  *
@@ -321,5 +321,9 @@
 		SYS_PORT_TRACING_TYPE_MASK(obj_type, \
 			_SYS_PORT_TRACING_OBJ_FUNC_EXIT(obj_type, func)(obj, ##__VA_ARGS__)); \
 	} while (false)
+
+/** @} */ /* end of subsys_tracing_macros */
+
 #endif /* CONFIG_TRACING */
-#endif
+
+#endif /* ZEPHYR_INCLUDE_TRACING_TRACING_MACROS_H_ */

--- a/include/tracing/tracing_syscall.h
+++ b/include/tracing/tracing_syscall.h
@@ -8,19 +8,15 @@
 #define ZEPHYR_INCLUDE_TRACING_SYSCALL_H_
 
 #if defined CONFIG_SEGGER_SYSTEMVIEW
-
 #include "tracing_sysview_syscall.h"
-
 #elif defined CONFIG_TRACING_TEST
-
 #include "tracing_test_syscall.h"
-
 #else
 
 /**
  * @brief Syscall Tracing APIs
- * @defgroup syscall_tracing_apis Syscall Tracing APIs
- * @ingroup tracing_apis
+ * @defgroup subsys_tracing_apis_syscall Syscall Tracing APIs
+ * @ingroup subsys_tracing_apis
  * @{
  */
 
@@ -41,9 +37,7 @@
  */
 #define sys_port_trace_syscall_exit(id, name, ...)
 
-/**
- * @}
- */ /* end of syscall_tracing_apis */
+/** @} */ /* end of subsys_tracing_syscall_apis */
 
 #endif
 


### PR DESCRIPTION
This PR improves the overall usage of Doxygen in the tracing subsystem:

- Make tracing part of the `subsys` Doxygen group
- Create groups for macros/format APIs (were not exposed)
- Fixed some Doxygen issues