### PR TITLE
Fix for:  mcumgr over serial does not add CRC to length of packet len

### DIFF
--- a/doc/releases/release-notes-3.0.rst
+++ b/doc/releases/release-notes-3.0.rst
@@ -302,6 +302,7 @@ Libraries / Subsystems
 
 * Management
 
+  * Fixed the mcumgr SMP protocol over serial not adding the length of the CRC16 to packet length.
 
 * CMSIS subsystem
 

--- a/include/mgmt/mcumgr/serial.h
+++ b/include/mgmt/mcumgr/serial.h
@@ -35,7 +35,8 @@
  * | -------------- | ------------------------------------------------------- |
  * | 0x06 0x09      | Byte pair indicating the start of a packet.             |
  * | 0x04 0x14      | Byte pair indicating the start of a continuation frame. |
- * | Packet length  | The combined total length of the *unencoded* body.      |
+ * | Packet length  | The combined total length of the *unencoded* body plus  |
+ * |                | the final CRC (2 bytes). Length is in Big-Endian format.|
  * | Body           | The actual SMP data (i.e., 8-byte header and CBOR       |
  * |                | key-value map).                                         |
  * | CRC16          | A CRC16 of the *unencoded* body of the entire packet.   |

--- a/subsys/mgmt/mcumgr/serial_util.c
+++ b/subsys/mgmt/mcumgr/serial_util.c
@@ -215,7 +215,8 @@ int mcumgr_serial_tx_frame(const uint8_t *data, bool first, int len,
 	 * byte long is paired with first byte of input buffer to form triplet for Base64 encoding.
 	 */
 	if (first) {
-		u16 = sys_cpu_to_be16(len);
+		/* The size of the CRC16 should be added to packet length */
+		u16 = sys_cpu_to_be16(len + 2);
 		memcpy(raw, &u16, sizeof(u16));
 		raw[2] = data[0];
 


### PR DESCRIPTION
Corrected documentation and fix in code.

https://github.com/zephyrproject-rtos/zephyr/issues/39546