### PR TITLE
tests: add integration_platforms to socket/tls test

### DIFF
--- a/tests/net/socket/tls/testcase.yaml
+++ b/tests/net/socket/tls/testcase.yaml
@@ -3,6 +3,8 @@ common:
   min_ram: 32
   tags: net socket tls
   filter: TOOLCHAIN_HAS_NEWLIB == 1
+  integration_platforms:
+    - qemu_x86
 tests:
   net.socket.tls:
     extra_configs:


### PR DESCRIPTION
Run only on defined integration platforms in CI.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
