### PR TITLE
shell: fix compilation error

### DIFF
--- a/subsys/shell/shell_cmds.c
+++ b/subsys/shell/shell_cmds.c
@@ -192,7 +192,6 @@ static int terminal_size_get(const struct shell *shell)
 	return ret_val;
 }
 
-#ifdef CONFIG_SHELL_VT100_COMMANDS
 static int cmd_clear(const struct shell *shell, size_t argc, char **argv)
 {
 	ARG_UNUSED(argv);
@@ -202,7 +201,6 @@ static int cmd_clear(const struct shell *shell, size_t argc, char **argv)
 
 	return 0;
 }
-#endif
 
 static int cmd_bacskpace_mode_backspace(const struct shell *shell, size_t argc,
 					char **argv)
@@ -226,7 +224,6 @@ static int cmd_bacskpace_mode_delete(const struct shell *shell, size_t argc,
 	return 0;
 }
 
-#ifdef CONFIG_SHELL_VT100_COMMANDS
 static int cmd_colors_off(const struct shell *shell, size_t argc, char **argv)
 {
 	ARG_UNUSED(argc);
@@ -246,7 +243,6 @@ static int cmd_colors_on(const struct shell *shell, size_t argc, char **argv)
 
 	return 0;
 }
-#endif
 
 static int cmd_echo_off(const struct shell *shell, size_t argc, char **argv)
 {
@@ -395,13 +391,13 @@ static int cmd_select(const struct shell *shell, size_t argc, char **argv)
 	return -EINVAL;
 }
 
-#ifdef CONFIG_SHELL_VT100_COMMANDS
 SHELL_STATIC_SUBCMD_SET_CREATE(m_sub_colors,
-	SHELL_CMD_ARG(off, NULL, SHELL_HELP_COLORS_OFF, cmd_colors_off, 1, 0),
-	SHELL_CMD_ARG(on, NULL, SHELL_HELP_COLORS_ON, cmd_colors_on, 1, 0),
+	SHELL_COND_CMD_ARG(CONFIG_SHELL_VT100_COMMANDS, off, NULL,
+			   SHELL_HELP_COLORS_OFF, cmd_colors_off, 1, 0),
+	SHELL_COND_CMD_ARG(CONFIG_SHELL_VT100_COMMANDS, on, NULL,
+			   SHELL_HELP_COLORS_ON, cmd_colors_on, 1, 0),
 	SHELL_SUBCMD_SET_END
 );
-#endif
 
 SHELL_STATIC_SUBCMD_SET_CREATE(m_sub_echo,
 	SHELL_CMD_ARG(off, NULL, SHELL_HELP_ECHO_OFF, cmd_echo_off, 1, 0),


### PR DESCRIPTION
Fixed compilation error when shell sample has been built with flag
CONFIG_SHELL_VT100_COMMANDS set to n.

Fixes: #40124

Signed-off-by: Jakub Rzeszutko <jakub.rzeszutko@nordicsemi.no>