### PR TITLE
Bluetooth: Mesh: Add option to call update cb on every retransmission

### DIFF
--- a/doc/reference/bluetooth/mesh/access.rst
+++ b/doc/reference/bluetooth/mesh/access.rst
@@ -100,6 +100,16 @@ populate the :c:member:`bt_mesh_model_pub.update` callback. The
 message is published, allowing the model to change the payload to reflect its
 current state.
 
+By setting :c:member:`bt_mesh_model_pub.retr_update` to 1, the model can
+configure the :c:member:`bt_mesh_model_pub.update` callback to be triggered
+on every retransmission. This can, for example, be used by models that make
+use of a Delay parameter, which can be adjusted for every retransmission.
+The :c:func:`bt_mesh_model_pub_is_retransmission` function can be
+used to differentiate a first publication and a retransmission.
+The :c:macro:`BT_MESH_PUB_MSG_TOTAL` and :c:macro:`BT_MESH_PUB_MSG_NUM` macros
+can be used to return total number of transmissions and the retransmission
+number within one publication interval.
+
 Extended models
 ===============
 

--- a/subsys/bluetooth/mesh/access.c
+++ b/subsys/bluetooth/mesh/access.c
@@ -241,6 +241,15 @@ static void mod_publish(struct k_work *work)
 
 	if (pub->count) {
 		pub->count--;
+
+		if (pub->retr_update && pub->update &&
+		    bt_mesh_model_pub_is_retransmission(pub->mod)) {
+			err = pub->update(pub->mod);
+			if (err) {
+				publish_sent(err, pub->mod);
+				return;
+			}
+		}
 	} else {
 		/* First publication in this period */
 		err = pub_period_start(pub);
@@ -766,7 +775,7 @@ int bt_mesh_model_publish(struct bt_mesh_model *model)
 	}
 
 	/* Account for initial transmission */
-	pub->count = BT_MESH_PUB_TRANSMIT_COUNT(pub->retransmit) + 1;
+	pub->count = BT_MESH_PUB_MSG_TOTAL(pub);
 
 	BT_DBG("Publish Retransmit Count %u Interval %ums", pub->count,
 	       BT_MESH_PUB_TRANSMIT_INT(pub->retransmit));


### PR DESCRIPTION
A user may want to control message parameters (for example, delay
parameter) on every retransmission of a published message (for example,
see section 1.4.1 of the mesh model specification). This is essential
for lighting messages as time gap between messages retransmitted via
the publish-retransmit mechanism introduces unwanted jitter/pop-corn
when such retransmissions are received by a large 'group' of lights.

This commit adds an option to `struct bt_mesh_model_pub` to make the
access layer call `bt_mesh_model_pub.update` callback on every
retransmission. This also addes few macros and functions that can be
used for further calculations.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>