### PR TITLE
net: sockets: tls: Clarify missing entropy warning

### DIFF
--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -283,7 +283,7 @@ static int tls_init(const struct device *unused)
 
 #if !defined(CONFIG_ENTROPY_HAS_DRIVER)
 	NET_WARN("No entropy device on the system, "
-		 "TLS communication may be insecure!");
+		 "TLS communication is insecure!");
 #endif
 
 	(void)memset(tls_contexts, 0, sizeof(tls_contexts));


### PR DESCRIPTION
Change the wording of the warning printed when there is no entropy to
hopefully remove any doubt that there might be security in TLS without
an entropy source.  TLS connections with insufficient entropy are
trivially decodable, and should not be relied on for any type of
security.

Signed-off-by: David Brown <david.brown@linaro.org>