### PR TITLE
drivers: gpio: Refactor drivers to use shared init priority

### DIFF
--- a/boards/arc/em_starterkit/Kconfig.defconfig
+++ b/boards/arc/em_starterkit/Kconfig.defconfig
@@ -7,6 +7,9 @@ config BOARD
 
 if GPIO
 
+config GPIO_INIT_PRIORITY
+	default 70
+
 config GPIO_DW
 	default y
 

--- a/boards/arc/emsdp/Kconfig.defconfig
+++ b/boards/arc/emsdp/Kconfig.defconfig
@@ -11,6 +11,9 @@ config BOARD
 
 if GPIO
 
+config GPIO_INIT_PRIORITY
+	default 70
+
 config GPIO_DW
 	default y
 

--- a/boards/arc/hsdk/Kconfig.defconfig
+++ b/boards/arc/hsdk/Kconfig.defconfig
@@ -8,6 +8,9 @@ config BOARD
 
 if GPIO
 
+config GPIO_INIT_PRIORITY
+	default 60
+
 config GPIO_DW
 	default y
 

--- a/boards/arm/thingy52_nrf52832/Kconfig
+++ b/boards/arm/thingy52_nrf52832/Kconfig
@@ -11,7 +11,7 @@ config BOARD_VDD_PWR_CTRL_INIT_PRIORITY
 	depends on GPIO
 	help
 	  Initialization priority for the VDD power rail. Has to be greater
-	  than GPIO_NRF_INIT_PRIORITY.
+	  than GPIO_INIT_PRIORITY.
 
 config BOARD_CCS_VDD_PWR_CTRL_INIT_PRIORITY
 	int "CCS_VDD power rail init priority"

--- a/boards/arm/thingy52_nrf52832/board.c
+++ b/boards/arm/thingy52_nrf52832/board.c
@@ -42,8 +42,8 @@ static int pwr_ctrl_init(const struct device *dev)
  * constraints.
  */
 
-#if CONFIG_BOARD_VDD_PWR_CTRL_INIT_PRIORITY <= CONFIG_GPIO_NRF_INIT_PRIORITY
-#error GPIO_NRF_INIT_PRIORITY must be lower than \
+#if CONFIG_BOARD_VDD_PWR_CTRL_INIT_PRIORITY <= CONFIG_GPIO_INIT_PRIORITY
+#error GPIO_INIT_PRIORITY must be lower than \
 	BOARD_VDD_PWR_CTRL_INIT_PRIORITY
 #endif
 

--- a/boards/shields/lmp90100_evb/Kconfig.defconfig
+++ b/boards/shields/lmp90100_evb/Kconfig.defconfig
@@ -19,6 +19,13 @@ config ADC_INIT_PRIORITY
 
 endif # ADC
 
+if GPIO
+
+config GPIO_INIT_PRIORITY
+	default 99
+
+endif # GPIO
+
 if EEPROM
 
 config I2C

--- a/boards/xtensa/intel_s1000_crb/Kconfig.defconfig
+++ b/boards/xtensa/intel_s1000_crb/Kconfig.defconfig
@@ -119,6 +119,9 @@ config INTEL_GNA
 
 if GPIO
 
+config GPIO_INIT_PRIORITY
+	default 70
+
 config GPIO_DW
 	default y
 

--- a/drivers/gpio/Kconfig
+++ b/drivers/gpio/Kconfig
@@ -21,6 +21,12 @@ config GPIO_SHELL
 	help
 	  Enable GPIO Shell for testing.
 
+config GPIO_INIT_PRIORITY
+	int "GPIO init priority"
+	default KERNEL_INIT_PRIORITY_DEFAULT
+	help
+	  GPIO driver device initialization priority.
+
 source "drivers/gpio/Kconfig.b91"
 
 source "drivers/gpio/Kconfig.dw"

--- a/drivers/gpio/Kconfig.creg_gpio
+++ b/drivers/gpio/Kconfig.creg_gpio
@@ -6,18 +6,8 @@
 # Workaround for not being able to have commas in macro arguments
 DT_COMPAT_SNPS_CREG_GPIO := snps,creg-gpio
 
-menuconfig GPIO_SNPS_CREG
+config GPIO_SNPS_CREG
 	bool "SNPS CREG GPIO"
 	default $(dt_compat_enabled,$(DT_COMPAT_SNPS_CREG_GPIO))
 	help
 	  Enable driver for SNPS CREG GPIO.
-
-if GPIO_SNPS_CREG
-
-config GPIO_SNPS_CREG_INIT_PRIORITY
-	int "Init priority"
-	default 70
-	help
-	  Device driver initialization priority.
-
-endif # GPIO_SNPS_CREG

--- a/drivers/gpio/Kconfig.dw
+++ b/drivers/gpio/Kconfig.dw
@@ -13,12 +13,6 @@ if GPIO_DW
 config GPIO_DW_SHARED_IRQ
 	bool
 
-config GPIO_DW_INIT_PRIORITY
-	int "Init priority"
-	default 60
-	help
-	  Device driver initialization priority.
-
 config GPIO_DW_CLOCK_GATE
 	bool "Enable clock gating"
 	select CLOCK_CONTROL

--- a/drivers/gpio/Kconfig.lmp90xxx
+++ b/drivers/gpio/Kconfig.lmp90xxx
@@ -3,7 +3,7 @@
 # Copyright (c) 2019 Vestas Wind Systems A/S
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig GPIO_LMP90XXX
+config GPIO_LMP90XXX
 	bool "LMP90xxx GPIO driver"
 	depends on ADC_LMP90XXX_GPIO
 	help
@@ -14,11 +14,3 @@ menuconfig GPIO_LMP90XXX
 
 	  The GPIO port of the LMP90xxx (D6 to D0) is exposed as a
 	  GPIO controller driver with read/write support.
-
-config GPIO_LMP90XXX_INIT_PRIORITY
-	int "Driver init priority"
-	default 99
-	depends on GPIO_LMP90XXX
-	help
-	  Device driver initialization priority. This driver must be
-	  initialized after the LMP90xxx ADC driver.

--- a/drivers/gpio/Kconfig.nrfx
+++ b/drivers/gpio/Kconfig.nrfx
@@ -11,12 +11,6 @@ menuconfig GPIO_NRFX
 
 if GPIO_NRFX
 
-config GPIO_NRF_INIT_PRIORITY
-	int "nRF GPIO initialization priority"
-	default 40
-	help
-	  Initialization priority for nRF GPIO.
-
 choice
 	prompt "nRF GPIO edge interrupts mechanism"
 	default GPIO_NRF_INT_EDGE_USING_GPIOTE

--- a/drivers/gpio/Kconfig.sx1509b
+++ b/drivers/gpio/Kconfig.sx1509b
@@ -15,12 +15,6 @@ menuconfig GPIO_SX1509B
 
 if GPIO_SX1509B
 
-config GPIO_SX1509B_INIT_PRIORITY
-	int "Init priority"
-	default 70
-	help
-	  Device driver initialization priority.
-
 config GPIO_SX1509B_INTERRUPT
 	bool "Interrupt enable"
 	default n

--- a/drivers/gpio/gpio_andes_atcgpio100.c
+++ b/drivers/gpio/gpio_andes_atcgpio100.c
@@ -353,7 +353,7 @@ static int gpio_atcgpio100_init(const struct device *port)
 		&gpio_atcgpio100_data_##n,				\
 		&gpio_atcgpio100_config_##n,				\
 		POST_KERNEL,						\
-		CONFIG_KERNEL_INIT_PRIORITY_DEVICE,			\
+		CONFIG_GPIO_INIT_PRIORITY,				\
 		&gpio_atcgpio100_api);					\
 									\
 	static void gpio_atcgpio100_cfg_func_##n(void)			\

--- a/drivers/gpio/gpio_b91.c
+++ b/drivers/gpio/gpio_b91.c
@@ -562,7 +562,7 @@ static void gpio_b91_irq_connect_4(void)
 			      &gpio_b91_data_##n,			    \
 			      &gpio_b91_config_##n,			    \
 			      POST_KERNEL,				    \
-			      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	    \
+			      CONFIG_GPIO_INIT_PRIORITY,		    \
 			      &gpio_b91_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(GPIO_B91_INIT)

--- a/drivers/gpio/gpio_cc13xx_cc26xx.c
+++ b/drivers/gpio/gpio_cc13xx_cc26xx.c
@@ -283,5 +283,5 @@ static const struct gpio_driver_api gpio_cc13xx_cc26xx_driver_api = {
 DEVICE_DT_INST_DEFINE(0, gpio_cc13xx_cc26xx_init,
 		    NULL, &gpio_cc13xx_cc26xx_data_0,
 		    &gpio_cc13xx_cc26xx_cfg_0,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
 		    &gpio_cc13xx_cc26xx_driver_api);

--- a/drivers/gpio/gpio_cc32xx.c
+++ b/drivers/gpio/gpio_cc32xx.c
@@ -263,7 +263,7 @@ static const struct gpio_driver_api api_funcs = {
 	DEVICE_DT_INST_DEFINE(n, &gpio_cc32xx_a##n##_init,		     \
 			NULL, &gpio_cc32xx_a##n##_data,			     \
 			&gpio_cc32xx_a##n##_config,			     \
-			POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,     \
+			POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,		     \
 			&api_funcs)
 
 #define GPIO_CC32XX_INIT(n)						     \

--- a/drivers/gpio/gpio_cmsdk_ahb.c
+++ b/drivers/gpio/gpio_cmsdk_ahb.c
@@ -277,7 +277,7 @@ static int gpio_cmsdk_ahb_init(const struct device *dev)
 			    NULL,						\
 			    &gpio_cmsdk_port_##n##_data,			\
 			    &gpio_cmsdk_port_## n ##_config,			\
-			    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
+			    POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,		\
 			    &gpio_cmsdk_ahb_drv_api_funcs);			\
 										\
 	static void gpio_cmsdk_port_##n##_config_func(const struct device *dev)	\

--- a/drivers/gpio/gpio_creg_gpio.c
+++ b/drivers/gpio/gpio_creg_gpio.c
@@ -156,5 +156,5 @@ static struct creg_gpio_drv_data creg_gpio_drvdata = {
 
 DEVICE_DT_INST_DEFINE(0, creg_gpio_init, NULL,
 		      &creg_gpio_drvdata, &creg_gpio_cfg,
-		      POST_KERNEL, CONFIG_GPIO_SNPS_CREG_INIT_PRIORITY,
+		      POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
 		      &api_table);

--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -536,7 +536,7 @@ static struct gpio_dw_runtime gpio_0_runtime = {
 
 DEVICE_DT_INST_DEFINE(0,
 	      gpio_dw_initialize, gpio_dw_device_pm_action, &gpio_0_runtime,
-	      &gpio_config_0, POST_KERNEL, CONFIG_GPIO_DW_INIT_PRIORITY,
+	      &gpio_config_0, POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
 	      &api_funcs);
 
 #if DT_INST_IRQ_HAS_CELL(0, flags)
@@ -598,7 +598,7 @@ static struct gpio_dw_runtime gpio_1_runtime = {
 
 DEVICE_DT_INST_DEFINE(1,
 	      gpio_dw_initialize, gpio_dw_device_pm_action, &gpio_1_runtime,
-	      &gpio_dw_config_1, POST_KERNEL, CONFIG_GPIO_DW_INIT_PRIORITY,
+	      &gpio_dw_config_1, POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
 	      &api_funcs);
 
 #if DT_INST_IRQ_HAS_CELL(1, flags)
@@ -659,7 +659,7 @@ static struct gpio_dw_runtime gpio_2_runtime = {
 
 DEVICE_DT_INST_DEFINE(2,
 	      gpio_dw_initialize, gpio_dw_device_pm_action, &gpio_2_runtime,
-	      &gpio_dw_config_2, POST_KERNEL, CONFIG_GPIO_DW_INIT_PRIORITY,
+	      &gpio_dw_config_2, POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
 	      &api_funcs);
 
 #if DT_INST_IRQ_HAS_CELL(2, flags)
@@ -720,7 +720,7 @@ static struct gpio_dw_runtime gpio_3_runtime = {
 
 DEVICE_DT_INST_DEFINE(3,
 	      gpio_dw_initialize, gpio_dw_device_pm_action, &gpio_3_runtime,
-	      &gpio_dw_config_3, POST_KERNEL, CONFIG_GPIO_DW_INIT_PRIORITY,
+	      &gpio_dw_config_3, POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
 	      &api_funcs);
 
 #if DT_INST_IRQ_HAS_CELL(3, flags)

--- a/drivers/gpio/gpio_emul.c
+++ b/drivers/gpio/gpio_emul.c
@@ -713,7 +713,7 @@ static int gpio_emul_pm_device_pm_action(const struct device *dev,
 			    gpio_emul_pm_device_pm_action,		\
 			    &gpio_emul_data_##_num,			\
 			    &gpio_emul_config_##_num, POST_KERNEL,	\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+			    CONFIG_GPIO_INIT_PRIORITY,			\
 			    &gpio_emul_driver)
 
 DT_INST_FOREACH_STATUS_OKAY(DEFINE_GPIO_EMUL);

--- a/drivers/gpio/gpio_eos_s3.c
+++ b/drivers/gpio/gpio_eos_s3.c
@@ -404,5 +404,5 @@ DEVICE_DT_INST_DEFINE(0,
 		    &gpio_eos_s3_data,
 		    &gpio_eos_s3_config,
 		    POST_KERNEL,
-		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+		    CONFIG_GPIO_INIT_PRIORITY,
 		    &gpio_eos_s3_driver_api);

--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -418,7 +418,7 @@ static const struct gpio_driver_api gpio_esp32_driver_api = {
 			&gpio_data_##_id,					\
 			&gpio_config_##_id,					\
 			PRE_KERNEL_2,						\
-			CONFIG_KERNEL_INIT_PRIORITY_DEVICE,			\
+			CONFIG_GPIO_INIT_PRIORITY,				\
 			&gpio_esp32_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(ESP_SOC_GPIO_INIT);

--- a/drivers/gpio/gpio_gecko.c
+++ b/drivers/gpio/gpio_gecko.c
@@ -13,6 +13,11 @@
 
 #include "gpio_utils.h"
 
+#if CONFIG_GPIO_GECKO_COMMON_INIT_PRIORITY >= CONFIG_GPIO_INIT_PRIORITY
+#error CONFIG_GPIO_GECKO_COMMON_INIT_PRIORITY must be less than \
+	CONFIG_GPIO_INIT_PRIORITY.
+#endif
+
 /*
  * Macros to set the GPIO MODE registers
  *
@@ -325,7 +330,7 @@ DEVICE_DT_INST_DEFINE(idx, \
 		    NULL, \
 		    &gpio_gecko_port##idx##_data, \
 		    &gpio_gecko_port##idx##_config, \
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, \
+		    POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY, \
 		    &gpio_gecko_driver_api); \
 \
 static int gpio_gecko_port##idx##_init(const struct device *dev) \

--- a/drivers/gpio/gpio_imx.c
+++ b/drivers/gpio/gpio_imx.c
@@ -226,7 +226,7 @@ static const struct gpio_driver_api imx_gpio_driver_api = {
 			    &imx_gpio_##n##_data,			\
 			    &imx_gpio_##n##_config,			\
 			    POST_KERNEL,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
+			    CONFIG_GPIO_INIT_PRIORITY,			\
 			    &imx_gpio_driver_api);			\
 									\
 	static int imx_gpio_##n##_init(const struct device *port)	\

--- a/drivers/gpio/gpio_intel.c
+++ b/drivers/gpio/gpio_intel.c
@@ -596,7 +596,7 @@ int gpio_intel_init(const struct device *dev)
 			      NULL,					       \
 			      &gpio_intel_data_##n,			       \
 			      &gpio_intel_cfg_##n,			       \
-			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
+			      POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,	       \
 			      &gpio_intel_api);
 
 /* "sub" devices.  no more than GPIO_INTEL_NR_SUBDEVS of these! */

--- a/drivers/gpio/gpio_ite_it8xxx2.c
+++ b/drivers/gpio/gpio_ite_it8xxx2.c
@@ -597,7 +597,7 @@ DEVICE_DT_INST_DEFINE(inst,                                        \
 		&gpio_ite_data_##inst,                             \
 		&gpio_ite_cfg_##inst,                              \
 		POST_KERNEL,                                       \
-		CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,               \
+		CONFIG_GPIO_INIT_PRIORITY,                         \
 		&gpio_ite_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(GPIO_ITE_DEV_CFG_DATA)
@@ -624,4 +624,4 @@ static int gpio_it8xxx2_init_set(const struct device *arg)
 
 	return 0;
 }
-SYS_INIT(gpio_it8xxx2_init_set, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+SYS_INIT(gpio_it8xxx2_init_set, POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY);

--- a/drivers/gpio/gpio_litex.c
+++ b/drivers/gpio/gpio_litex.c
@@ -317,7 +317,7 @@ static const struct gpio_driver_api gpio_litex_driver_api = {
 			    &gpio_litex_data_##n, \
 			    &gpio_litex_cfg_##n, \
 			    POST_KERNEL, \
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
+			    CONFIG_GPIO_INIT_PRIORITY, \
 			    &gpio_litex_driver_api \
 			   ); \
 \

--- a/drivers/gpio/gpio_lmp90xxx.c
+++ b/drivers/gpio/gpio_lmp90xxx.c
@@ -158,7 +158,7 @@ static const struct gpio_driver_api gpio_lmp90xxx_api = {
 	.port_get_raw = gpio_lmp90xxx_port_get_raw,
 };
 
-BUILD_ASSERT(CONFIG_GPIO_LMP90XXX_INIT_PRIORITY >
+BUILD_ASSERT(CONFIG_GPIO_INIT_PRIORITY >
 	     CONFIG_ADC_INIT_PRIORITY,
 	     "LMP90xxx GPIO driver must be initialized after LMP90xxx ADC "
 	     "driver");
@@ -179,7 +179,7 @@ BUILD_ASSERT(CONFIG_GPIO_LMP90XXX_INIT_PRIORITY >
 			    NULL,					\
 			    &gpio_lmp90xxx_##id##_data,			\
 			    &gpio_lmp90xxx_##id##_cfg, POST_KERNEL,	\
-			    CONFIG_GPIO_LMP90XXX_INIT_PRIORITY,		\
+			    CONFIG_GPIO_INIT_PRIORITY,			\
 			    &gpio_lmp90xxx_api);
 
 DT_INST_FOREACH_STATUS_OKAY(GPIO_LMP90XXX_DEVICE)

--- a/drivers/gpio/gpio_lpc11u6x.c
+++ b/drivers/gpio/gpio_lpc11u6x.c
@@ -593,7 +593,7 @@ DEVICE_DT_DEFINE(DT_NODELABEL(gpio##id),				\
 		    NULL,						\
 		    &gpio_lpc11u6x_data_##id,				\
 		    &gpio_lpc11u6x_config_##id,				\
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\
+		    POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,		\
 		    &gpio_lpc11u6x_driver_api)
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(gpio0), okay)

--- a/drivers/gpio/gpio_mchp_xec.c
+++ b/drivers/gpio/gpio_mchp_xec.c
@@ -355,7 +355,7 @@ DEVICE_DT_DEFINE(DT_NODELABEL(gpio_000_036),
 		    gpio_xec_port000_036_init,
 		    NULL,
 		    &gpio_xec_port000_036_data, &gpio_xec_port000_036_config,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+		    POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
 		    &gpio_xec_driver_api);
 
 static int gpio_xec_port000_036_init(const struct device *dev)
@@ -401,7 +401,7 @@ DEVICE_DT_DEFINE(DT_NODELABEL(gpio_040_076),
 		    gpio_xec_port040_076_init,
 		    NULL,
 		    &gpio_xec_port040_076_data, &gpio_xec_port040_076_config,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+		    POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
 		    &gpio_xec_driver_api);
 
 static int gpio_xec_port040_076_init(const struct device *dev)
@@ -447,7 +447,7 @@ DEVICE_DT_DEFINE(DT_NODELABEL(gpio_100_136),
 		    gpio_xec_port100_136_init,
 		    NULL,
 		    &gpio_xec_port100_136_data, &gpio_xec_port100_136_config,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+		    POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
 		    &gpio_xec_driver_api);
 
 static int gpio_xec_port100_136_init(const struct device *dev)
@@ -493,7 +493,7 @@ DEVICE_DT_DEFINE(DT_NODELABEL(gpio_140_176),
 		    gpio_xec_port140_176_init,
 		    NULL,
 		    &gpio_xec_port140_176_data, &gpio_xec_port140_176_config,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+		    POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
 		    &gpio_xec_driver_api);
 
 static int gpio_xec_port140_176_init(const struct device *dev)
@@ -539,7 +539,7 @@ DEVICE_DT_DEFINE(DT_NODELABEL(gpio_200_236),
 		    gpio_xec_port200_236_init,
 		    NULL,
 		    &gpio_xec_port200_236_data, &gpio_xec_port200_236_config,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+		    POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
 		    &gpio_xec_driver_api);
 
 static int gpio_xec_port200_236_init(const struct device *dev)
@@ -585,7 +585,7 @@ DEVICE_DT_DEFINE(DT_NODELABEL(gpio_240_276),
 		    gpio_xec_port240_276_init,
 		    NULL,
 		    &gpio_xec_port240_276_data, &gpio_xec_port240_276_config,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+		    POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
 		    &gpio_xec_driver_api);
 
 static int gpio_xec_port240_276_init(const struct device *dev)

--- a/drivers/gpio/gpio_mchp_xec_v2.c
+++ b/drivers/gpio/gpio_mchp_xec_v2.c
@@ -420,7 +420,7 @@ static const struct gpio_driver_api gpio_xec_driver_api = {
 									\
 	DEVICE_DT_INST_DEFINE(n, gpio_xec_port_init_##n, NULL,		\
 		&gpio_xec_port_data_##n, &xec_gpio_config_##n,		\
-		POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
+		POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,			\
 		&gpio_xec_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(XEC_GPIO_PORT)

--- a/drivers/gpio/gpio_mcux.c
+++ b/drivers/gpio/gpio_mcux.c
@@ -304,7 +304,7 @@ static const struct gpio_driver_api gpio_mcux_driver_api = {
 			    &gpio_mcux_port## n ##_data,		\
 			    &gpio_mcux_port## n##_config,		\
 			    POST_KERNEL,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
+			    CONFIG_GPIO_INIT_PRIORITY,			\
 			    &gpio_mcux_driver_api);			\
 									\
 	static int gpio_mcux_port## n ##_init(const struct device *dev)	\

--- a/drivers/gpio/gpio_mcux_igpio.c
+++ b/drivers/gpio/gpio_mcux_igpio.c
@@ -229,7 +229,7 @@ static const struct gpio_driver_api mcux_igpio_driver_api = {
 			    &mcux_igpio_##n##_data,			\
 			    &mcux_igpio_##n##_config,			\
 			    POST_KERNEL,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
+			    CONFIG_GPIO_INIT_PRIORITY,			\
 			    &mcux_igpio_driver_api);			\
 									\
 	static int mcux_igpio_##n##_init(const struct device *dev)	\

--- a/drivers/gpio/gpio_mcux_lpc.c
+++ b/drivers/gpio/gpio_mcux_lpc.c
@@ -395,7 +395,7 @@ static const clock_ip_name_t gpio_clock_names[] = GPIO_CLOCKS;
 	DEVICE_DT_INST_DEFINE(n, lpc_gpio_init_##n, NULL,				\
 		    &gpio_mcux_lpc_data_##n,						\
 		    &gpio_mcux_lpc_config_##n, POST_KERNEL,				\
-		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,				\
+		    CONFIG_GPIO_INIT_PRIORITY,						\
 		    &gpio_mcux_lpc_driver_api);						\
 											\
 	static int lpc_gpio_init_##n(const struct device *dev)				\

--- a/drivers/gpio/gpio_neorv32.c
+++ b/drivers/gpio/gpio_neorv32.c
@@ -235,7 +235,7 @@ static const struct gpio_driver_api neorv32_gpio_driver_api = {
 			&neorv32_gpio_##n##_data,			\
 			&neorv32_gpio_##n##_config,			\
 			POST_KERNEL,					\
-			CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,		\
+			CONFIG_GPIO_INIT_PRIORITY,			\
 			&neorv32_gpio_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(NEORV32_GPIO_INIT)

--- a/drivers/gpio/gpio_npcx.c
+++ b/drivers/gpio/gpio_npcx.c
@@ -336,7 +336,7 @@ int gpio_npcx_init(const struct device *dev)
 			    &gpio_npcx_data_##inst,                            \
 			    &gpio_npcx_cfg_##inst,                             \
 			    POST_KERNEL,                                       \
-			    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	       \
+			    CONFIG_GPIO_INIT_PRIORITY,                         \
 			    &gpio_npcx_driver);
 
 DT_INST_FOREACH_STATUS_OKAY(NPCX_GPIO_DEVICE_INIT)

--- a/drivers/gpio/gpio_nrfx.c
+++ b/drivers/gpio/gpio_nrfx.c
@@ -597,7 +597,7 @@ static int gpio_nrfx_init(const struct device *port)
 			 &gpio_nrfx_p##id##_data,			\
 			 &gpio_nrfx_p##id##_cfg,			\
 			 POST_KERNEL,					\
-			 CONFIG_GPIO_NRF_INIT_PRIORITY,			\
+			 CONFIG_GPIO_INIT_PRIORITY,			\
 			 &gpio_nrfx_drv_api_funcs);
 
 DT_INST_FOREACH_STATUS_OKAY(GPIO_NRF_DEVICE)

--- a/drivers/gpio/gpio_psoc6.c
+++ b/drivers/gpio/gpio_psoc6.c
@@ -269,7 +269,7 @@ int gpio_psoc6_init(const struct device *dev)
 	DEVICE_DT_INST_DEFINE(n, gpio_psoc6_init, NULL,			\
 			    &port_##n##_psoc6_runtime,			\
 			    &port_##n##_psoc6_config, POST_KERNEL,	\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+			    CONFIG_GPIO_INIT_PRIORITY,			\
 			    &gpio_psoc6_api);				\
 									\
 	static void port_##n##_psoc6_config_func(const struct device *dev) \

--- a/drivers/gpio/gpio_rcar.c
+++ b/drivers/gpio/gpio_rcar.c
@@ -310,7 +310,7 @@ static const struct gpio_driver_api gpio_rcar_driver_api = {
 			      &gpio_rcar_data_##n,		    \
 			      &gpio_rcar_cfg_##n,		    \
 			      POST_KERNEL,			    \
-			      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,  \
+			      CONFIG_GPIO_INIT_PRIORITY,	    \
 			      &gpio_rcar_driver_api		    \
 			      );				    \
 	static void gpio_rcar_##n##_init(const struct device *dev)  \

--- a/drivers/gpio/gpio_rv32m1.c
+++ b/drivers/gpio/gpio_rv32m1.c
@@ -318,7 +318,7 @@ static const struct gpio_driver_api gpio_rv32m1_driver_api = {
 			    &gpio_rv32m1_##n##_data,			\
 			    &gpio_rv32m1_##n##_config,			\
 			    POST_KERNEL,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
+			    CONFIG_GPIO_INIT_PRIORITY,			\
 			    &gpio_rv32m1_driver_api);			\
 									\
 	static int gpio_rv32m1_##n##_init(const struct device *dev)	\

--- a/drivers/gpio/gpio_sam.c
+++ b/drivers/gpio/gpio_sam.c
@@ -325,7 +325,7 @@ int gpio_sam_init(const struct device *dev)
 	DEVICE_DT_INST_DEFINE(n, gpio_sam_init, NULL,			\
 			    &port_##n##_sam_runtime,			\
 			    &port_##n##_sam_config, POST_KERNEL,	\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+			    CONFIG_GPIO_INIT_PRIORITY,			\
 			    &gpio_sam_api);				\
 									\
 	static void port_##n##_sam_config_func(const struct device *dev)	\

--- a/drivers/gpio/gpio_sam0.c
+++ b/drivers/gpio/gpio_sam0.c
@@ -306,7 +306,7 @@ static struct gpio_sam0_data gpio_sam0_data_0;
 DEVICE_DT_DEFINE(DT_NODELABEL(porta),
 		    gpio_sam0_init, NULL,
 		    &gpio_sam0_data_0, &gpio_sam0_config_0,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
 		    &gpio_sam0_api);
 #endif
 
@@ -328,7 +328,7 @@ static struct gpio_sam0_data gpio_sam0_data_1;
 DEVICE_DT_DEFINE(DT_NODELABEL(portb),
 		    gpio_sam0_init, NULL,
 		    &gpio_sam0_data_1, &gpio_sam0_config_1,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
 		    &gpio_sam0_api);
 #endif
 
@@ -350,7 +350,7 @@ static struct gpio_sam0_data gpio_sam0_data_2;
 DEVICE_DT_DEFINE(DT_NODELABEL(portc),
 		    gpio_sam0_init, NULL,
 		    &gpio_sam0_data_2, &gpio_sam0_config_2,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
 		    &gpio_sam0_api);
 #endif
 
@@ -372,6 +372,6 @@ static struct gpio_sam0_data gpio_sam0_data_3;
 DEVICE_DT_DEFINE(DT_NODELABEL(portd),
 		    gpio_sam0_init, NULL,
 		    &gpio_sam0_data_3, &gpio_sam0_config_3,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
 		    &gpio_sam0_api);
 #endif

--- a/drivers/gpio/gpio_sam4l.c
+++ b/drivers/gpio/gpio_sam4l.c
@@ -267,7 +267,7 @@ int gpio_sam_init(const struct device *dev)
 	DEVICE_DT_INST_DEFINE(n, gpio_sam_init, NULL,			\
 			    &port_##n##_sam_runtime,			\
 			    &port_##n##_sam_config, POST_KERNEL,	\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+			    CONFIG_GPIO_INIT_PRIORITY,			\
 			    &gpio_sam_api);				\
 									\
 	static void port_##n##_sam_config_func(const struct device *dev)\

--- a/drivers/gpio/gpio_sifive.c
+++ b/drivers/gpio/gpio_sifive.c
@@ -361,7 +361,7 @@ DEVICE_DT_INST_DEFINE(0,
 		    gpio_sifive_init,
 		    NULL,
 		    &gpio_sifive_data0, &gpio_sifive_config0,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
 		    &gpio_sifive_driver);
 
 #define		IRQ_INIT(n)					\

--- a/drivers/gpio/gpio_stellaris.c
+++ b/drivers/gpio/gpio_stellaris.c
@@ -255,7 +255,7 @@ static const struct gpio_driver_api gpio_stellaris_driver_api = {
 			    NULL,							\
 			    &port_## n ##_stellaris_runtime,				\
 			    &gpio_stellaris_port_## n ##_config,			\
-			    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,		\
+			    POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,			\
 			    &gpio_stellaris_driver_api);				\
 											\
 	static void port_## n ##_stellaris_config_func(const struct device *dev)		\

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -636,7 +636,7 @@ static int gpio_stm32_init(const struct device *dev)
 			    &gpio_stm32_data_## __suffix,		       \
 			    &gpio_stm32_cfg_## __suffix,		       \
 			    PRE_KERNEL_1,				       \
-			    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	       \
+			    CONFIG_GPIO_INIT_PRIORITY,			       \
 			    &gpio_stm32_driver)
 
 #define GPIO_DEVICE_INIT_STM32(__suffix, __SUFFIX)			\

--- a/drivers/gpio/gpio_sx1509b.c
+++ b/drivers/gpio/gpio_sx1509b.c
@@ -786,5 +786,5 @@ static struct sx1509b_drv_data sx1509b_drvdata = {
 
 DEVICE_DT_INST_DEFINE(0, sx1509b_init, NULL,
 		 &sx1509b_drvdata, &sx1509b_cfg,
-		 POST_KERNEL, CONFIG_GPIO_SX1509B_INIT_PRIORITY,
+		 POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
 		 &api_table);

--- a/drivers/gpio/gpio_xlnx_axi.c
+++ b/drivers/gpio/gpio_xlnx_axi.c
@@ -287,7 +287,7 @@ static const struct gpio_driver_api gpio_xlnx_axi_driver_api = {
 			&gpio_xlnx_axi_##n##_2_data,			\
 			&gpio_xlnx_axi_##n##_2_config,			\
 			POST_KERNEL,					\
-			CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,		\
+			CONFIG_GPIO_INIT_PRIORITY,			\
 			&gpio_xlnx_axi_driver_api);
 
 #define GPIO_XLNX_AXI_INIT(n)						\
@@ -315,7 +315,7 @@ static const struct gpio_driver_api gpio_xlnx_axi_driver_api = {
 			&gpio_xlnx_axi_##n##_data,			\
 			&gpio_xlnx_axi_##n##_config,			\
 			POST_KERNEL,					\
-			CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,		\
+			CONFIG_GPIO_INIT_PRIORITY,			\
 			&gpio_xlnx_axi_driver_api);			\
 	GPIO_XLNX_AXI_GPIO2_COND_INIT(n);
 


### PR DESCRIPTION
Refactors all of the GPIO drivers to use a shared driver class
initialization priority configuration, CONFIG_GPIO_INIT_PRIORITY, to
allow configuring GPIO drivers separately from other devices. This is
similar to other driver classes like I2C and SPI.

The default is set to CONFIG_KERNEL_INIT_PRIORITY_DEVICE to preserve the
existing default initialization priority for most drivers. Exceptions
are snps_creg, cy8c95xx, and dw drivers which need to initialize later
than the default device priority; and nrf and gecko drivers which need
to initialize earlier than the default device priority.

Signed-off-by: Maureen Helm <maureen.helm@intel.com>