### PR TITLE
PM: Fix device resume order

### DIFF
--- a/subsys/pm/power.c
+++ b/subsys/pm/power.c
@@ -151,9 +151,7 @@ static int pm_suspend_devices(void)
 
 static void pm_resume_devices(void)
 {
-	size_t i;
-
-	for (i = 0; i < num_susp; i++) {
+	for (int i = (num_susp - 1); i >= 0; i--) {
 		pm_device_state_set(__pm_device_slots_start[i],
 				    PM_DEVICE_STATE_ACTIVE);
 	}

--- a/tests/subsys/pm/power_mgmt/boards/native_posix.overlay
+++ b/tests/subsys/pm/power_mgmt/boards/native_posix.overlay
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2021 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	device_a: device_a {
+		label = "device_a";
+		compatible = "test-device-pm";
+	};
+
+	device_b: device_b {
+		label = "device_b";
+		compatible = "test-device-pm";
+	};
+
+	device_c: device_c {
+		label = "device_c";
+		compatible = "test-device-pm";
+	};
+};

--- a/tests/subsys/pm/power_mgmt/dts/bindings/test-device-pm.yaml
+++ b/tests/subsys/pm/power_mgmt/dts/bindings/test-device-pm.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2021, Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    This binding provides resources required to build and run the
+    tests/subsys/power/power_mgmt test in Zephyr.
+
+compatible: "test-device-pm"

--- a/tests/subsys/pm/power_mgmt/testcase.yaml
+++ b/tests/subsys/pm/power_mgmt/testcase.yaml
@@ -1,11 +1,4 @@
 tests:
   subsys.pm.device_pm:
-    # arch_irq_unlock(0) can't work correctly on these arch
-    arch_exclude: arc xtensa
-    platform_exclude: rv32m1_vega_ri5cy rv32m1_vega_zero_riscy litex_vexriscv
-       nrf5340dk_nrf5340_cpunet thingy53_nrf5340_cpunet bl5340_dvk_cpunet
-    integration_platforms:
-      - qemu_x86
-      - mps2_an385
-      - nucleo_l476rg
+    platform_allow: native_posix
     tags: power


### PR DESCRIPTION
It fixes a problem that was re-introduced in 81f1225040d317cc9c01ab7d5ef81e098b9ab6e8. 

Added a test to avoid it to happen again.

Changes done after initial review:

 - Tested moved from `device_wakeup_api` to `power_mgmt`
 - Change `power_mgmt` to run only in native posix since it is implementing everything in the application without using anything from platform and because there already is the test `power_mgmt_soc` for properly testing platform integration