### PR TITLE
pm: device: runtime: Do not suspend devices when runtime is enabled

### DIFF
--- a/include/pm/device_runtime.h
+++ b/include/pm/device_runtime.h
@@ -116,12 +116,27 @@ int pm_device_runtime_put(const struct device *dev);
  */
 int pm_device_runtime_put_async(const struct device *dev);
 
+/**
+ * @brief Check if device runtime is enabled for a given device.
+ *
+ * @funcprops \pre_kernel_ok
+ *
+ * @param dev Device instance.
+ *
+ * @retval true If device has device runtime PM enabled.
+ * @retval false If the device has device runtime PM disabled.
+ *
+ * @see pm_device_runtime_enable()
+ */
+bool pm_device_runtime_is_enabled(const struct device *dev);
+
 #else
 static inline void pm_device_runtime_enable(const struct device *dev) { }
 static inline int pm_device_runtime_disable(const struct device *dev) { return -ENOSYS; }
 static inline int pm_device_runtime_get(const struct device *dev) { return -ENOSYS; }
 static inline int pm_device_runtime_put(const struct device *dev) { return -ENOSYS; }
 static inline int pm_device_runtime_put_async(const struct device *dev) { return -ENOSYS; }
+static inline bool pm_device_runtime_is_enabled(const struct device *dev) { return false; }
 #endif
 
 /** @} */

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -241,3 +241,19 @@ unlock:
 
 	return ret;
 }
+
+bool pm_device_runtime_is_enabled(const struct device *dev)
+{
+	bool ret = false;
+	struct pm_device *pm = dev->pm;
+
+	if (!k_is_pre_kernel()) {
+		(void)k_mutex_lock(&pm->lock, K_FOREVER);
+		ret = pm->enable;
+		(void)k_mutex_unlock(&pm->lock);
+	} else {
+		ret = pm->enable;
+	}
+
+	return ret;
+}

--- a/subsys/pm/power.c
+++ b/subsys/pm/power.c
@@ -11,6 +11,7 @@
 #include <init.h>
 #include <string.h>
 #include <pm/device.h>
+#include <pm/device_runtime.h>
 #include <pm/pm.h>
 #include <pm/state.h>
 #include <pm/policy.h>
@@ -120,8 +121,12 @@ static int pm_suspend_devices(void)
 	for (const struct device *dev = devs + devc - 1; dev >= devs; dev--) {
 		int ret;
 
-		/* ignore busy devices */
-		if (pm_device_is_busy(dev) || pm_device_wakeup_is_enabled(dev)) {
+		/*
+		 * ignore busy devices, wake up source and devices with
+		 * runtime PM enabled.
+		 */
+		if (pm_device_is_busy(dev) || pm_device_wakeup_is_enabled(dev)
+				|| pm_device_runtime_is_enabled(dev)) {
 			continue;
 		}
 


### PR DESCRIPTION
- Add API to check if a device has runtime pm enabled
- Do not suspend a device if it is using device runtime