### PR TITLE
doc: bluetooth: Clarify BLE HW reqs are for Nordic

### DIFF
--- a/doc/guides/bluetooth/bluetooth-arch.rst
+++ b/doc/guides/bluetooth/bluetooth-arch.rst
@@ -408,8 +408,11 @@ Bluetooth Low Energy Controller
 Hardware Requirements
 =====================
 
-The Bluetooth Low Energy Controller implementation requires the following hardware
-peripherals.
+Nordic Semiconductor
+--------------------
+
+The Nordic Semiconductor Bluetooth Low Energy Controller implementation
+requires the following hardware peripherals.
 
 #. Clock
 


### PR DESCRIPTION
Make it clearer that the listed BLE controller hardware/peripheral
requirements concern the Nordic Semiconductor implementation only,
in the Bluetooth guide.

Signed-off-by: Nikolai Kondrashov <spbnick@gmail.com>