### PR TITLE
drivers: gpio: add combined drive strength flags and mask

### DIFF
--- a/drivers/gpio/gpio_b91.c
+++ b/drivers/gpio/gpio_b91.c
@@ -328,7 +328,7 @@ static int gpio_b91_pin_configure(const struct device *dev,
 	}
 
 	/* Strengths not implemented */
-	if ((flags & (GPIO_DS_ALT_LOW | GPIO_DS_ALT_HIGH)) != 0) {
+	if ((flags & GPIO_DS_ALT) != 0) {
 		return -ENOTSUP;
 	}
 

--- a/drivers/gpio/gpio_cy8c95xx.c
+++ b/drivers/gpio/gpio_cy8c95xx.c
@@ -106,7 +106,7 @@ static int cy8c95xx_config(const struct device *dev,
 	}
 
 	/* Strengths not implemented */
-	if ((flags & (GPIO_DS_ALT_LOW | GPIO_DS_ALT_HIGH)) != 0) {
+	if ((flags & GPIO_DS_ALT) != 0) {
 		return -ENOTSUP;
 	}
 

--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -140,11 +140,11 @@ static int gpio_esp32_config(const struct device *dev,
 		 * to either low or high states. Alternative drive strength is weak-only,
 		 * while any other intermediary combination is considered invalid.
 		 */
-		switch (flags & (GPIO_DS_LOW_MASK | GPIO_DS_HIGH_MASK)) {
-		case GPIO_DS_DFLT_LOW | GPIO_DS_DFLT_HIGH:
+		switch (flags & GPIO_DS_MASK) {
+		case GPIO_DS_DFLT:
 			gpio_ll_set_drive_capability(cfg->gpio_base, io_pin, GPIO_DRIVE_CAP_3);
 			break;
-		case GPIO_DS_ALT_LOW | GPIO_DS_ALT_HIGH:
+		case GPIO_DS_ALT:
 			gpio_ll_set_drive_capability(cfg->gpio_base, io_pin, GPIO_DRIVE_CAP_0);
 			break;
 		default:

--- a/drivers/gpio/gpio_mcux.c
+++ b/drivers/gpio/gpio_mcux.c
@@ -98,12 +98,12 @@ static int gpio_mcux_configure(const struct device *dev,
 
 #if defined(FSL_FEATURE_PORT_HAS_DRIVE_STRENGTH) && FSL_FEATURE_PORT_HAS_DRIVE_STRENGTH
 	/* Determine the drive strength */
-	switch (flags & (GPIO_DS_LOW_MASK | GPIO_DS_HIGH_MASK)) {
-	case GPIO_DS_DFLT_LOW | GPIO_DS_DFLT_HIGH:
+	switch (flags & GPIO_DS_MASK) {
+	case GPIO_DS_DFLT:
 		/* Default is low drive strength */
 		mask |= PORT_PCR_DSE_MASK;
 		break;
-	case GPIO_DS_ALT_LOW | GPIO_DS_ALT_HIGH:
+	case GPIO_DS_ALT:
 		/* Alternate is high drive strength */
 		pcr |= PORT_PCR_DSE_MASK;
 		break;

--- a/drivers/gpio/gpio_nrfx.c
+++ b/drivers/gpio/gpio_nrfx.c
@@ -164,7 +164,7 @@ static int gpio_nrfx_config(const struct device *port,
 
 	switch (flags & (GPIO_DS_LOW_MASK | GPIO_DS_HIGH_MASK |
 			 GPIO_OPEN_DRAIN)) {
-	case GPIO_DS_DFLT_LOW | GPIO_DS_DFLT_HIGH:
+	case GPIO_DS_DFLT:
 		drive = NRF_GPIO_PIN_S0S1;
 		break;
 	case GPIO_DS_DFLT_LOW | GPIO_DS_ALT_HIGH:
@@ -177,7 +177,7 @@ static int gpio_nrfx_config(const struct device *port,
 	case GPIO_DS_ALT_LOW | GPIO_DS_DFLT_HIGH:
 		drive = NRF_GPIO_PIN_H0S1;
 		break;
-	case GPIO_DS_ALT_LOW | GPIO_DS_ALT_HIGH:
+	case GPIO_DS_ALT:
 		drive = NRF_GPIO_PIN_H0H1;
 		break;
 	case GPIO_DS_ALT_LOW | GPIO_OPEN_DRAIN:

--- a/drivers/gpio/gpio_pca953x.c
+++ b/drivers/gpio/gpio_pca953x.c
@@ -203,7 +203,7 @@ static int gpio_pca953x_config(const struct device *dev, gpio_pin_t pin,
 	 * Until something more general is available reject any
 	 * attempt to set a non-default drive strength.
 	 */
-	if ((flags & (GPIO_DS_ALT_LOW | GPIO_DS_ALT_HIGH)) != 0) {
+	if ((flags & GPIO_DS_ALT) != 0) {
 		return -ENOTSUP;
 	}
 

--- a/drivers/gpio/gpio_pcal6408a.c
+++ b/drivers/gpio/gpio_pcal6408a.c
@@ -144,7 +144,7 @@ static int pcal6408a_pin_configure(const struct device *dev,
 	/* Drive strength configuration in this device is incompatible with
 	 * the currently available GPIO API flags, hence it is not supported.
 	 */
-	if ((flags & (GPIO_DS_ALT_LOW | GPIO_DS_ALT_HIGH)) != 0) {
+	if ((flags & GPIO_DS_ALT) != 0) {
 		return -ENOTSUP;
 	}
 

--- a/drivers/gpio/gpio_sx1509b.c
+++ b/drivers/gpio/gpio_sx1509b.c
@@ -313,7 +313,7 @@ static int sx1509b_config(const struct device *dev,
 	 * Until something more general is available reject any
 	 * attempt to set a non-default drive strength.
 	 */
-	if ((flags & (GPIO_DS_ALT_LOW | GPIO_DS_ALT_HIGH)) != 0) {
+	if ((flags & GPIO_DS_ALT) != 0) {
 		return -ENOTSUP;
 	}
 

--- a/include/drivers/gpio.h
+++ b/include/drivers/gpio.h
@@ -259,6 +259,19 @@ extern "C" {
  * use the default drive strength.
  */
 #define GPIO_DS_ALT_HIGH (0x1U << GPIO_DS_HIGH_POS)
+
+/** Combined default drive strength.
+ */
+#define GPIO_DS_DFLT (GPIO_DS_DFLT_LOW | GPIO_DS_DFLT_HIGH)
+
+/** Combined alternative drive strength.
+ */
+#define GPIO_DS_ALT (GPIO_DS_ALT_LOW | GPIO_DS_ALT_HIGH)
+
+/** @cond INTERNAL_HIDDEN */
+#define GPIO_DS_MASK (GPIO_DS_LOW_MASK | GPIO_DS_HIGH_MASK)
+/** @endcond */
+
 /** @} */
 
 /** @cond INTERNAL_HIDDEN */


### PR DESCRIPTION
Introduce combined GPIO drive strength flags for GPIO controllers only supporting either default or alternative drive strength regardless if the pin is driven to a high or a low level.

Fixes: #30329

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>