### PR TITLE
Tracing: k_free tracing hook heap reference added

### DIFF
--- a/include/tracing/tracing.h
+++ b/include/tracing/tracing.h
@@ -1791,14 +1791,16 @@
 /**
  * @brief Trace System Heap free entry
  * @param heap Heap object
+ * @param heap_ref Heap reference
  */
-#define sys_port_trace_k_heap_sys_k_free_enter(heap)
+#define sys_port_trace_k_heap_sys_k_free_enter(heap, heap_ref)
 
 /**
  * @brief Trace System Heap free exit
  * @param heap Heap object
+ * @param heap_ref Heap reference
  */
-#define sys_port_trace_k_heap_sys_k_free_exit(heap)
+#define sys_port_trace_k_heap_sys_k_free_exit(heap, heap_ref)
 
 /**
  * @brief Trace System heap calloc enter

--- a/kernel/mempool.c
+++ b/kernel/mempool.c
@@ -48,11 +48,11 @@ void k_free(void *ptr)
 		heap_ref = ptr;
 		ptr = --heap_ref;
 
-		SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_heap_sys, k_free, *heap_ref);
+		SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_heap_sys, k_free, *heap_ref, heap_ref);
 
 		k_heap_free(*heap_ref, ptr);
 
-		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_heap_sys, k_free, *heap_ref);
+		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_heap_sys, k_free, *heap_ref, heap_ref);
 	}
 }
 

--- a/subsys/tracing/ctf/tracing_ctf.h
+++ b/subsys/tracing/ctf/tracing_ctf.h
@@ -290,8 +290,8 @@ extern "C" {
 #define sys_port_trace_k_heap_sys_k_aligned_alloc_exit(heap, ret)
 #define sys_port_trace_k_heap_sys_k_malloc_enter(heap)
 #define sys_port_trace_k_heap_sys_k_malloc_exit(heap, ret)
-#define sys_port_trace_k_heap_sys_k_free_enter(heap)
-#define sys_port_trace_k_heap_sys_k_free_exit(heap)
+#define sys_port_trace_k_heap_sys_k_free_enter(heap, heap_ref)
+#define sys_port_trace_k_heap_sys_k_free_exit(heap, heap_ref)
 #define sys_port_trace_k_heap_sys_k_calloc_enter(heap)
 #define sys_port_trace_k_heap_sys_k_calloc_exit(heap, ret)
 

--- a/subsys/tracing/sysview/tracing_sysview.h
+++ b/subsys/tracing/sysview/tracing_sysview.h
@@ -555,8 +555,8 @@ void sys_trace_thread_info(struct k_thread *thread);
 #define sys_port_trace_k_heap_sys_k_aligned_alloc_exit(heap, ret)
 #define sys_port_trace_k_heap_sys_k_malloc_enter(heap)
 #define sys_port_trace_k_heap_sys_k_malloc_exit(heap, ret)
-#define sys_port_trace_k_heap_sys_k_free_enter(heap)
-#define sys_port_trace_k_heap_sys_k_free_exit(heap)
+#define sys_port_trace_k_heap_sys_k_free_enter(heap, heap_ref)
+#define sys_port_trace_k_heap_sys_k_free_exit(heap, heap_ref)
 #define sys_port_trace_k_heap_sys_k_calloc_enter(heap)
 #define sys_port_trace_k_heap_sys_k_calloc_exit(heap, ret)
 

--- a/subsys/tracing/test/tracing_string_format_test.c
+++ b/subsys/tracing/test/tracing_string_format_test.c
@@ -376,12 +376,12 @@ void sys_trace_k_heap_aligned_alloc_exit(struct k_heap *h, size_t bytes,
 	TRACING_STRING("%s: %p\n", __func__, h);
 }
 
-void sys_trace_k_heap_sys_k_free_enter(struct k_heap *h)
+void sys_trace_k_heap_sys_k_free_enter(struct k_heap *h, struct k_heap **hr)
 {
 	TRACING_STRING("%s: %p\n", __func__, h);
 }
 
-void sys_trace_k_heap_sys_k_free_exit(struct k_heap *h)
+void sys_trace_k_heap_sys_k_free_exit(struct k_heap *h, struct k_heap **hr)
 {
 	TRACING_STRING("%s: %p\n", __func__, h);
 }

--- a/subsys/tracing/test/tracing_test.h
+++ b/subsys/tracing/test/tracing_test.h
@@ -382,8 +382,10 @@
 	sys_trace_k_heap_sys_k_malloc_enter(heap, size)
 #define sys_port_trace_k_heap_sys_k_malloc_exit(heap, ret)                                         \
 	sys_trace_k_heap_sys_k_malloc_exit(heap, size, ret)
-#define sys_port_trace_k_heap_sys_k_free_enter(heap) sys_trace_k_heap_sys_k_free_enter(heap)
-#define sys_port_trace_k_heap_sys_k_free_exit(heap) sys_trace_k_heap_sys_k_free_exit(heap)
+#define sys_port_trace_k_heap_sys_k_free_enter(heap, heap_ref)                                     \
+	sys_trace_k_heap_sys_k_free_enter(heap, heap_ref)
+#define sys_port_trace_k_heap_sys_k_free_exit(heap, heap_ref)                                      \
+	sys_trace_k_heap_sys_k_free_exit(heap, heap_ref)
 #define sys_port_trace_k_heap_sys_k_calloc_enter(heap)                                             \
 	sys_trace_k_heap_sys_k_calloc_enter(heap, nmemb, size)
 #define sys_port_trace_k_heap_sys_k_calloc_exit(heap, ret)                                         \
@@ -651,8 +653,8 @@ void sys_trace_k_heap_sys_k_aligned_alloc_exit(struct k_heap *h, size_t align, s
 					       void *ret);
 void sys_trace_k_heap_sys_k_malloc_enter(struct k_heap *h, size_t size);
 void sys_trace_k_heap_sys_k_malloc_exit(struct k_heap *h, size_t size, void *ret);
-void sys_trace_k_heap_sys_k_free_enter(struct k_heap *h);
-void sys_trace_k_heap_sys_k_free_exit(struct k_heap *h);
+void sys_trace_k_heap_sys_k_free_enter(struct k_heap *h, struct k_heap **heap_ref);
+void sys_trace_k_heap_sys_k_free_exit(struct k_heap *h, struct k_heap **heap_ref);
 void sys_trace_k_heap_sys_k_calloc_enter(struct k_heap *h, size_t nmemb, size_t size);
 void sys_trace_k_heap_sys_k_calloc_exit(struct k_heap *h, size_t nmemb, size_t size, void *ret);
 

--- a/subsys/tracing/user/tracing_user.h
+++ b/subsys/tracing/user/tracing_user.h
@@ -271,8 +271,8 @@ void sys_trace_idle(void);
 #define sys_port_trace_k_heap_sys_k_aligned_alloc_exit(heap, ret)
 #define sys_port_trace_k_heap_sys_k_malloc_enter(heap)
 #define sys_port_trace_k_heap_sys_k_malloc_exit(heap, ret)
-#define sys_port_trace_k_heap_sys_k_free_enter(heap)
-#define sys_port_trace_k_heap_sys_k_free_exit(heap)
+#define sys_port_trace_k_heap_sys_k_free_enter(heap, heap_ref)
+#define sys_port_trace_k_heap_sys_k_free_exit(heap, heap_ref)
 #define sys_port_trace_k_heap_sys_k_calloc_enter(heap)
 #define sys_port_trace_k_heap_sys_k_calloc_exit(heap, ret)
 


### PR DESCRIPTION
Added heap reference parameter to k_free tracing
hook to allow tracing of the pointer which was
passed as a parameter to a k_free call.
As part of this update the defines
(for this hook) in the various tracing formats
was also updated.

Signed-off-by: Torbjörn Leksell <torbjorn.leksell@percepio.com>