### PR TITLE
[backport v2.7-branch] bluetooth: mesh: Fix incorrect return value

### DIFF
--- a/subsys/bluetooth/mesh/gatt_services.c
+++ b/subsys/bluetooth/mesh/gatt_services.c
@@ -833,8 +833,8 @@ bool bt_mesh_proxy_relay(struct net_buf *buf, uint16_t dst)
 		}
 
 		if (client->filter_type == PROV) {
-			BT_ERR("Invalid PDU type for Proxy Client");
-			return -EINVAL;
+			BT_WARN("Invalid PDU type for Proxy Client");
+			continue;
 		}
 
 		/* Proxy PDU sending modifies the original buffer,


### PR DESCRIPTION
Should be continue when client->type not equal PROXY.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/40159

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>