### PR TITLE
drivers: serial: stm32 usart driver clears the RXNE through flag

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -900,8 +900,13 @@ static void uart_stm32_isr(const struct device *dev)
 #endif
 	} else if (LL_USART_IsEnabledIT_RXNE(UartInstance) &&
 			LL_USART_IsActiveFlag_RXNE(UartInstance)) {
+#ifdef USART_SR_RXNE
+		/* clear the RXNE flag, because Rx data was not read */
+		LL_USART_ClearFlag_RXNE(UartInstance);
+#else
 		/* clear the RXNE by flushing the fifo, because Rx data was not read */
 		LL_USART_RequestRxDataFlush(UartInstance);
+#endif /* USART_SR_RXNE */
 	}
 
 	/* Clear errors */


### PR DESCRIPTION
For some stm32 soc devices, the USART (or UART) flag RXNE is cleared
by the LL_USART_ClearFlag_RXNE function which directly writes the RXNE bit of the Status register. 
This flag is used as compilation choice instead of the STM32x serie to control the LL function.
This is the case with the stm32F1x, stm32F2x, stm32F4x, stm32L1x.

Some other are using the Rx Data Flushing function.

Signed-off-by: Francois Ramu <francois.ramu@st.com>