### PR TITLE
canbus: isotp: fix net_buf usage in recv function

### DIFF
--- a/include/canbus/isotp.h
+++ b/include/canbus/isotp.h
@@ -406,6 +406,8 @@ struct isotp_recv_ctx {
 	const struct device *can_dev;
 	struct net_buf *buf;
 	struct net_buf *act_frag;
+	/* buffer currently processed in isotp_recv */
+	struct net_buf *recv_buf;
 	sys_snode_t alloc_node;
 	uint32_t length;
 	int error_nr;


### PR DESCRIPTION
isotp_recv and the called pull_frags functions were violating the net_buf
API by interacting directly with net_buf fragments pulled from a k_fifo.

This commit reworks the isotp_recv function. The currently processed
net_buf is stored in an additional context variable so that reading from
it can be continued in the next call to isotp_recv if not all fragments could
be fit into the provided uint8_t *data buffer.

Fixes #40070