### PR TITLE
fs: Fix fs_statvfs returning 0 when statvfs not implemented

### DIFF
--- a/subsys/fs/fs.c
+++ b/subsys/fs/fs.c
@@ -625,11 +625,13 @@ int fs_statvfs(const char *abs_path, struct fs_statvfs *stat)
 		return rc;
 	}
 
-	if (mp->fs->statvfs != NULL) {
-		rc = mp->fs->statvfs(mp, abs_path, stat);
-		if (rc < 0) {
-			LOG_ERR("failed get file or dir stat (%d)", rc);
-		}
+	CHECKIF(mp->fs->statvfs == NULL) {
+		return -ENOTSUP;
+	}
+
+	rc = mp->fs->statvfs(mp, abs_path, stat);
+	if (rc < 0) {
+		LOG_ERR("failed get file or dir stat (%d)", rc);
 	}
 
 	return rc;

--- a/tests/subsys/fs/fs_api/src/test_fs_dir_file.c
+++ b/tests/subsys/fs/fs_api/src/test_fs_dir_file.c
@@ -219,9 +219,9 @@ void test_file_statvfs(void)
 	ret = fs_statvfs("/SDCARD:", &stat);
 	zassert_not_equal(ret, 0, "Get volume info by no-exist path");
 
-	/* It's ok if there is no stat interface */
+	/* System with no statvfs interface */
 	ret = fs_statvfs(NOOP_MNTP, &stat);
-	zassert_equal(ret, 0, "fs has no statvfs functionality");
+	zassert_equal(ret, -ENOTSUP, "fs has no statvfs functionality");
 
 	ret = fs_statvfs(TEST_FS_MNTP, &stat);
 	zassert_equal(ret, 0, "Error getting voluem stats");


### PR DESCRIPTION
The fs_statvfs is supposed to return, as all VFS functions, -ENOTSUP
error when underlying file-system driver does not implement the
API call.
The fs_statvfs was returning 0 for success and when API call is not
implemented, which means it is indistinguishable whether stat
structure has been filled by diver with any data or not touched at all.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>