### PR TITLE
samples: mbox: Fix incorrect DT addressing

### DIFF
--- a/samples/drivers/mbox/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/drivers/mbox/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -6,14 +6,18 @@
 
 / {
 	soc {
-		mbox: mbox@2a000 {
-			compatible = "nordic,mbox-nrf-ipc";
-			reg = <0x2a000 0x1000>;
-			tx-mask = <0x0000ffff>;
-			rx-mask = <0x0000ffff>;
-			interrupts = <42 NRF_DEFAULT_IRQ_PRIORITY>;
-			#mbox-cells = <1>;
-			status = "okay";
+		peripheral@50000000 {
+			/delete-node/ ipc@2a000;
+
+			mbox: mbox@2a000 {
+				compatible = "nordic,mbox-nrf-ipc";
+				reg = <0x2a000 0x1000>;
+				tx-mask = <0x0000ffff>;
+				rx-mask = <0x0000ffff>;
+				interrupts = <42 NRF_DEFAULT_IRQ_PRIORITY>;
+				#mbox-cells = <1>;
+				status = "okay";
+			};
 		};
 	};
 };

--- a/samples/drivers/mbox/remote/boards/nrf5340dk_nrf5340_cpunet.overlay
+++ b/samples/drivers/mbox/remote/boards/nrf5340dk_nrf5340_cpunet.overlay
@@ -6,6 +6,8 @@
 
 / {
 	soc {
+		/delete-node/ ipc@41012000;
+
 		mbox: mbox@41012000 {
 			compatible = "nordic,mbox-nrf-ipc";
 			reg = <0x41012000 0x1000>;


### PR DESCRIPTION
Place the nodes to the proper place into the DT. The driver is calling
directly into the NRFX without using any direct memory addressing so
this is mostly a cosmetic fix.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>