### PR TITLE
uart_stm32: Fix conflit between poll_out and irq API

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -473,13 +473,19 @@ static void uart_stm32_poll_out(const struct device *dev,
 					unsigned char c)
 {
 	USART_TypeDef *UartInstance = UART_STRUCT(dev);
+	struct uart_stm32_data *data = DEV_DATA(dev);
 
 	/* Wait for TXE flag to be raised */
-	while (!LL_USART_IsActiveFlag_TXE(UartInstance)) {
+	while (1) {
+		if (atomic_cas(&data->tx_lock, 0, 1)) {
+			if (LL_USART_IsActiveFlag_TXE(UartInstance)) {
+				break;
+			}
+			atomic_set(&data->tx_lock, 0);
+		}
 	}
 
 #ifdef CONFIG_PM
-	struct uart_stm32_data *data = DEV_DATA(dev);
 
 	if (!data->tx_poll_stream_on) {
 		data->tx_poll_stream_on = true;
@@ -497,6 +503,7 @@ static void uart_stm32_poll_out(const struct device *dev,
 #endif /* CONFIG_PM */
 
 	LL_USART_TransmitData8(UartInstance, (uint8_t)c);
+	atomic_set(&data->tx_lock, 0);
 }
 
 static int uart_stm32_err_check(const struct device *dev)
@@ -593,10 +600,12 @@ static int uart_stm32_fifo_read(const struct device *dev, uint8_t *rx_data,
 static void uart_stm32_irq_tx_enable(const struct device *dev)
 {
 	USART_TypeDef *UartInstance = UART_STRUCT(dev);
-
-#ifdef CONFIG_PM
 	struct uart_stm32_data *data = DEV_DATA(dev);
 
+	while (atomic_cas(&data->tx_lock, 0, 1) == false) {
+	}
+
+#ifdef CONFIG_PM
 	data->tx_poll_stream_on = false;
 	uart_stm32_pm_constraint_set(dev);
 #endif
@@ -606,8 +615,11 @@ static void uart_stm32_irq_tx_enable(const struct device *dev)
 static void uart_stm32_irq_tx_disable(const struct device *dev)
 {
 	USART_TypeDef *UartInstance = UART_STRUCT(dev);
+	struct uart_stm32_data *data = DEV_DATA(dev);
 
 	LL_USART_DisableIT_TC(UartInstance);
+
+	atomic_set(&data->tx_lock, 0);
 
 #ifdef CONFIG_PM
 	uart_stm32_pm_constraint_release(dev);

--- a/drivers/serial/uart_stm32.h
+++ b/drivers/serial/uart_stm32.h
@@ -58,6 +58,7 @@ struct uart_stm32_data {
 	uint32_t baud_rate;
 	/* clock device */
 	const struct device *clock;
+	atomic_t tx_lock;
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	uart_irq_callback_user_data_t user_cb;
 	void *user_data;


### PR DESCRIPTION
Despite the fix #39752 I sent, I continue to have some troubles with the stm32 usart when I'm using console and shell in same time.

I made this branch to illustrate this behavior: https://github.com/jdascenzio/zephyr/commits/shell_bug
The bug can be triggered in shell_module sample
When a "help" command is sent, the answer is received character by character with the printk text:
```
*** Booting Zephyr OS build v2.7.99-1161-g9db9ca0d2e98  ***
printk! nucleo_l432kc


uart:~$ printk! nucleo_l432kc
printk! nucleo_l432kc
printk! nucleo_l432kc
printk! nucleo_l432kc
printk! nucleo_l432kc
printk! nucleo_l432kc
printk! nucleo_l432kc
printk! nucleo_l432kc
printk! nucleo_l432kc
printk! nucleo_l432kc
printk! nucleo_l432kc
helpprintk! nucleo_l432kc

Please press the <Tab> button to see all available commands.
You can also use the <Tab> button to prompt or auto-complete all commands or its subcommands.
You can try to call commands with <-h> or <--help> parameter for more information.

Shell supports following meta-keys:
  Ctrl + (a key from: abcdefklnpuw)
  Alt  + (a key from: bf)
Please refer to shell documentation for morprintk! nucleo_l432kc
perintk! nucleo_l432kc
p rintk! nucleo_l432kc
pdrintk! nucleo_l432kc
perintk! nucleo_l432kc
ptrintk! nucleo_l432kc
parintk! nucleo_l432kc
pirintk! nucleo_l432kc
plrintk! nucleo_l432kc
psrintk! nucleo_l432kc
```
To fix this, I added a lock between  poll_out and irq API

