### PR TITLE
bindings: nrf-ipc: Enable DT helpers

### DIFF
--- a/dts/bindings/mbox/nordic,mbox-nrf-ipc.yaml
+++ b/dts/bindings/mbox/nordic,mbox-nrf-ipc.yaml
@@ -5,7 +5,7 @@ description: Nordic nRF family IPC (MBOX Interprocessor Communication)
 
 compatible: "nordic,mbox-nrf-ipc"
 
-include: base.yaml
+include: [base.yaml, mailbox-controller.yaml]
 
 properties:
     tx-mask:
@@ -20,3 +20,6 @@ properties:
 
     interrupts:
       required: true
+
+mbox-cells:
+  - channel

--- a/samples/drivers/mbox/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/drivers/mbox/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -12,6 +12,7 @@
 			tx-mask = <0x0000ffff>;
 			rx-mask = <0x0000ffff>;
 			interrupts = <42 NRF_DEFAULT_IRQ_PRIORITY>;
+			#mbox-cells = <1>;
 			status = "okay";
 		};
 	};

--- a/samples/drivers/mbox/remote/boards/nrf5340dk_nrf5340_cpunet.overlay
+++ b/samples/drivers/mbox/remote/boards/nrf5340dk_nrf5340_cpunet.overlay
@@ -12,6 +12,7 @@
 			tx-mask = <0x0000ffff>;
 			rx-mask = <0x0000ffff>;
 			interrupts = <18 NRF_DEFAULT_IRQ_PRIORITY>;
+			#mbox-cells = <1>;
 			status = "okay";
 		};
 	};


### PR DESCRIPTION
Make the MBOX NRF IPC instances referenceable using the MBOX DT helpers.