### PR TITLE
Rt11xx DMA Support

### DIFF
--- a/boards/arm/mimxrt1160_evk/doc/index.rst
+++ b/boards/arm/mimxrt1160_evk/doc/index.rst
@@ -111,6 +111,8 @@ features:
 +-----------+------------+-------------------------------------+
 | PWM       | on-chip    | pwm                                 |
 +-----------+------------+-------------------------------------+
+| DMA       | on-chip    | dma                                 |
++-----------+------------+-------------------------------------+
 
 The default configuration can be found in the defconfig file:
 ``boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm7_defconfig``

--- a/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm7.dts
+++ b/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm7.dts
@@ -66,3 +66,7 @@
 &wdog1 {
 	status = "okay";
 };
+
+&edma0 {
+	status = "okay";
+};

--- a/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm7.yaml
+++ b/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm7.yaml
@@ -22,3 +22,4 @@ supported:
   - watchdog
   - i2c
   - pwm
+  - dma

--- a/boards/arm/mimxrt1170_evk/doc/index.rst
+++ b/boards/arm/mimxrt1170_evk/doc/index.rst
@@ -111,6 +111,8 @@ features:
 | UART      | on-chip    | serial port-polling;                |
 |           |            | serial port-interrupt               |
 +-----------+------------+-------------------------------------+
+| DMA       | on-chip    | dma                                 |
++-----------+------------+-------------------------------------+
 
 The default configuration can be found in the defconfig file:
 ``boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm7_defconfig``

--- a/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm7.dts
+++ b/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm7.dts
@@ -69,3 +69,7 @@
 	detect-dat3;
 	pwr-gpios = <&gpio10 2 GPIO_ACTIVE_LOW>;
 };
+
+&edma0 {
+	status = "okay";
+};

--- a/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm7.yaml
+++ b/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm7.yaml
@@ -22,3 +22,4 @@ supported:
   - adc
   - i2c
   - pwm
+  - dma

--- a/drivers/clock_control/clock_control_mcux_ccm_rev2.c
+++ b/drivers/clock_control/clock_control_mcux_ccm_rev2.c
@@ -63,7 +63,10 @@ static int mcux_ccm_get_subsys_rate(const struct device *dev,
 
 #ifdef CONFIG_DMA_MCUX_EDMA
 	case IMX_CCM_EDMA_CLK:
-		clock_root = kCLOCK_Root_Bus + instance;
+		clock_root = kCLOCK_Root_Bus;
+		break;
+	case IMX_CCM_EDMA_LPSR_CLK:
+		clock_root = kCLOCK_Root_Bus_Lpsr;
 		break;
 #endif
 

--- a/drivers/clock_control/clock_control_mcux_ccm_rev2.c
+++ b/drivers/clock_control/clock_control_mcux_ccm_rev2.c
@@ -63,7 +63,7 @@ static int mcux_ccm_get_subsys_rate(const struct device *dev,
 
 #ifdef CONFIG_DMA_MCUX_EDMA
 	case IMX_CCM_EDMA_CLK:
-		clock_root = kCLOCK_Root_Edma + instance;
+		clock_root = kCLOCK_Root_Bus + instance;
 		break;
 #endif
 

--- a/drivers/dma/dma_mcux_edma.c
+++ b/drivers/dma/dma_mcux_edma.c
@@ -441,114 +441,80 @@ static int dma_mcux_edma_init(const struct device *dev)
 	return 0;
 }
 
-static void dma_imx_config_func_0(const struct device *dev);
+#define IRQ_CONFIG(node_id, idx, fn)					\
+	IF_ENABLED(DT_IRQ_HAS_IDX(node_id, idx), (			\
+		IRQ_CONNECT(DT_IRQ_BY_IDX(node_id, idx, irq),		\
+		DT_IRQ_BY_IDX(node_id, idx, priority),			\
+		fn,							\
+		DEVICE_DT_GET(node_id), 0);				\
+		irq_enable(DT_IRQ_BY_IDX(node_id, idx, irq));		\
+		))
 
-static const struct dma_mcux_edma_config dma_config_0 = {
-	.base = (DMA_Type *)DT_INST_REG_ADDR(0),
-	.dmamux_base = (DMAMUX_Type *)DT_INST_REG_ADDR_BY_IDX(0, 1),
-	.dma_channels = DT_INST_PROP(0, dma_channels),
-	.irq_config_func = dma_imx_config_func_0,
-};
+#define DMA_MCUX_EDMA_CONFIG_FUNC(n)					\
+	static void dma_imx_config_func_##n(const struct device *dev)	\
+	{								\
+		ARG_UNUSED(dev);					\
+									\
+		IRQ_CONFIG(DT_DRV_INST(n), 0,				\
+			dma_mcux_edma_irq_handler);			\
+		IRQ_CONFIG(DT_DRV_INST(n), 1,				\
+			dma_mcux_edma_irq_handler);			\
+		IRQ_CONFIG(DT_DRV_INST(n), 2,				\
+			dma_mcux_edma_irq_handler);			\
+		IRQ_CONFIG(DT_DRV_INST(n), 3,				\
+			dma_mcux_edma_irq_handler);			\
+		IRQ_CONFIG(DT_DRV_INST(n), 4,				\
+			dma_mcux_edma_irq_handler);			\
+		IRQ_CONFIG(DT_DRV_INST(n), 5,				\
+			dma_mcux_edma_irq_handler);			\
+		IRQ_CONFIG(DT_DRV_INST(n), 6,				\
+			dma_mcux_edma_irq_handler);			\
+		IRQ_CONFIG(DT_DRV_INST(n), 7,				\
+			dma_mcux_edma_irq_handler);			\
+		IRQ_CONFIG(DT_DRV_INST(n), 8,				\
+			dma_mcux_edma_irq_handler);			\
+		IRQ_CONFIG(DT_DRV_INST(n), 9,				\
+			dma_mcux_edma_irq_handler);			\
+		IRQ_CONFIG(DT_DRV_INST(n), 10,				\
+			dma_mcux_edma_irq_handler);			\
+		IRQ_CONFIG(DT_DRV_INST(n), 11,				\
+			dma_mcux_edma_irq_handler);			\
+		IRQ_CONFIG(DT_DRV_INST(n), 12,				\
+			dma_mcux_edma_irq_handler);			\
+		IRQ_CONFIG(DT_DRV_INST(n), 13,				\
+			dma_mcux_edma_irq_handler);			\
+		IRQ_CONFIG(DT_DRV_INST(n), 14,				\
+			dma_mcux_edma_irq_handler);			\
+		IRQ_CONFIG(DT_DRV_INST(n), 15,				\
+			dma_mcux_edma_irq_handler);			\
+									\
+		IRQ_CONFIG(DT_DRV_INST(n), 16,				\
+			dma_mcux_edma_error_irq_handler);		\
+									\
+		LOG_DBG("install irq done");				\
+	}
 
-struct dma_mcux_edma_data dma_data;
 /*
  * define the dma
  */
-DEVICE_DT_INST_DEFINE(0, &dma_mcux_edma_init, NULL,
-		    &dma_data, &dma_config_0, POST_KERNEL,
-		    CONFIG_DMA_INIT_PRIORITY, &dma_mcux_edma_api);
+#define DMA_INIT(n)							\
+	static void dma_imx_config_func_##n(const struct device *dev);	\
+	static const struct dma_mcux_edma_config dma_config_##n = {	\
+		.base = (DMA_Type *)DT_INST_REG_ADDR(n),		\
+		.dmamux_base =						\
+			(DMAMUX_Type *)DT_INST_REG_ADDR_BY_IDX(n, 1),	\
+		.dma_channels = DT_INST_PROP(n, dma_channels),		\
+		.irq_config_func = dma_imx_config_func_##n,		\
+	};								\
+									\
+	struct dma_mcux_edma_data dma_data_##n;				\
+									\
+	DEVICE_DT_INST_DEFINE(n,					\
+			    &dma_mcux_edma_init, NULL,			\
+			    &dma_data_##n, &dma_config_##n,		\
+			    POST_KERNEL, CONFIG_DMA_INIT_PRIORITY,	\
+			    &dma_mcux_edma_api);			\
+									\
+	DMA_MCUX_EDMA_CONFIG_FUNC(n);
 
-void dma_imx_config_func_0(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	/*install the dma error handle*/
-
-	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 0, irq),
-		    DT_INST_IRQ_BY_IDX(0, 0, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
-	irq_enable(DT_INST_IRQ_BY_IDX(0, 0, irq));
-
-	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 1, irq),
-		    DT_INST_IRQ_BY_IDX(0, 1, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
-	irq_enable(DT_INST_IRQ_BY_IDX(0, 1, irq));
-
-	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 2, irq),
-		    DT_INST_IRQ_BY_IDX(0, 2, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
-	irq_enable(DT_INST_IRQ_BY_IDX(0, 2, irq));
-
-	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 3, irq),
-		    DT_INST_IRQ_BY_IDX(0, 3, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
-	irq_enable(DT_INST_IRQ_BY_IDX(0, 3, irq));
-
-	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 4, irq),
-		    DT_INST_IRQ_BY_IDX(0, 4, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
-	irq_enable(DT_INST_IRQ_BY_IDX(0, 4, irq));
-
-	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 5, irq),
-		    DT_INST_IRQ_BY_IDX(0, 5, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
-	irq_enable(DT_INST_IRQ_BY_IDX(0, 5, irq));
-
-	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 6, irq),
-		    DT_INST_IRQ_BY_IDX(0, 6, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
-	irq_enable(DT_INST_IRQ_BY_IDX(0, 6, irq));
-
-	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 7, irq),
-		    DT_INST_IRQ_BY_IDX(0, 7, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
-	irq_enable(DT_INST_IRQ_BY_IDX(0, 7, irq));
-
-	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 8, irq),
-		    DT_INST_IRQ_BY_IDX(0, 8, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
-	irq_enable(DT_INST_IRQ_BY_IDX(0, 8, irq));
-
-	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 9, irq),
-		    DT_INST_IRQ_BY_IDX(0, 9, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
-	irq_enable(DT_INST_IRQ_BY_IDX(0, 9, irq));
-
-	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 10, irq),
-		    DT_INST_IRQ_BY_IDX(0, 10, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
-	irq_enable(DT_INST_IRQ_BY_IDX(0, 10, irq));
-
-	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 11, irq),
-		    DT_INST_IRQ_BY_IDX(0, 11, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
-	irq_enable(DT_INST_IRQ_BY_IDX(0, 11, irq));
-
-	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 12, irq),
-		    DT_INST_IRQ_BY_IDX(0, 12, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
-	irq_enable(DT_INST_IRQ_BY_IDX(0, 12, irq));
-
-	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 13, irq),
-		    DT_INST_IRQ_BY_IDX(0, 13, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
-	irq_enable(DT_INST_IRQ_BY_IDX(0, 13, irq));
-
-	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 14, irq),
-		    DT_INST_IRQ_BY_IDX(0, 14, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
-	irq_enable(DT_INST_IRQ_BY_IDX(0, 14, irq));
-
-	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 15, irq),
-		    DT_INST_IRQ_BY_IDX(0, 15, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
-	irq_enable(DT_INST_IRQ_BY_IDX(0, 15, irq));
-
-	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 16, irq),
-		    DT_INST_IRQ_BY_IDX(0, 16, priority),
-		    dma_mcux_edma_error_irq_handler,
-		    DEVICE_DT_INST_GET(0), 0);
-	irq_enable(DT_INST_IRQ_BY_IDX(0, 16, irq));
-
-	LOG_DBG("install irq done");
-}
+DT_INST_FOREACH_STATUS_OKAY(DMA_INIT)

--- a/dts/arm/nxp/nxp_rt1160_cm4.dtsi
+++ b/dts/arm/nxp/nxp_rt1160_cm4.dtsi
@@ -52,18 +52,18 @@
 			#gpio-cells = <2>;
 		};
 
-		edma1: dma-controller@40c14000 {
+		edma_lpsr0: dma-controller@40c14000 {
 			#dma-cells = <2>;
 			compatible = "nxp,mcux-edma";
 			dma-channels = <32>;
-			dma-requests = <128>;
+			dma-requests = <208>;
 			nxp,mem2mem;
 			nxp,a_on;
 			reg = <0x40c14000 0x4000>,
-				<0x400c1800 0x4000>;
-			clocks = <&ccm IMX_CCM_EDMA_CLK 0x7C 0x000000C0>;
+				<0x40c18000 0x4000>;
+			clocks = <&ccm IMX_CCM_EDMA_LPSR_CLK 0x7C 0x000000C0>;
 			status = "disabled";
-			label = "EDMA1";
+			label = "DMA_0";
 			interrupts = <0 0>, <1 0>, <2 0>, <3 0>,
 				<4 0>, <5 0>, <6 0>, <7 0>,
 				<8 0>, <9 0>, <10 0>, <11 0>,

--- a/dts/arm/nxp/nxp_rt1160_cm7.dtsi
+++ b/dts/arm/nxp/nxp_rt1160_cm7.dtsi
@@ -63,14 +63,14 @@
 			#dma-cells = <2>;
 			compatible = "nxp,mcux-edma";
 			dma-channels = <32>;
-			dma-requests = <128>;
+			dma-requests = <208>;
 			nxp,mem2mem;
 			nxp,a_on;
 			reg = <0x40070000 0x4000>,
 				<0x40074000 0x4000>;
 			clocks = <&ccm IMX_CCM_EDMA_CLK 0x7C 0x000000C0>;
 				status = "disabled";
-			label = "EDMA0";
+			label = "DMA_0";
 			interrupts = <0 0>, <1 0>, <2 0>, <3 0>,
 				<4 0>, <5 0>, <6 0>, <7 0>,
 				<8 0>, <9 0>, <10 0>, <11 0>,

--- a/dts/arm/nxp/nxp_rt1170_cm4.dtsi
+++ b/dts/arm/nxp/nxp_rt1170_cm4.dtsi
@@ -52,18 +52,18 @@
 			#gpio-cells = <2>;
 		};
 
-		edma1: dma-controller@40c14000 {
+		edma_lpsr0: dma-controller@40c14000 {
 			#dma-cells = <2>;
 			compatible = "nxp,mcux-edma";
 			dma-channels = <32>;
-			dma-requests = <128>;
+			dma-requests = <208>;
 			nxp,mem2mem;
 			nxp,a_on;
 			reg = <0x40c14000 0x4000>,
-				<0x400c1800 0x4000>;
-			clocks = <&ccm IMX_CCM_EDMA_CLK 0x7C 0x000000C0>;
+				<0x40c18000 0x4000>;
+			clocks = <&ccm IMX_CCM_EDMA_LPSR_CLK 0x7C 0x000000C0>;
 			status = "disabled";
-			label = "EDMA1";
+			label = "DMA_0";
 			interrupts = <0 0>, <1 0>, <2 0>, <3 0>,
 				<4 0>, <5 0>, <6 0>, <7 0>,
 				<8 0>, <9 0>, <10 0>, <11 0>,

--- a/dts/arm/nxp/nxp_rt1170_cm7.dtsi
+++ b/dts/arm/nxp/nxp_rt1170_cm7.dtsi
@@ -63,14 +63,14 @@
 			#dma-cells = <2>;
 			compatible = "nxp,mcux-edma";
 			dma-channels = <32>;
-			dma-requests = <128>;
+			dma-requests = <208>;
 			nxp,mem2mem;
 			nxp,a_on;
 			reg = <0x40070000 0x4000>,
 				<0x40074000 0x4000>;
 			clocks = <&ccm IMX_CCM_EDMA_CLK 0x7C 0x000000C0>;
 				status = "disabled";
-			label = "EDMA0";
+			label = "DMA_0";
 			interrupts = <0 0>, <1 0>, <2 0>, <3 0>,
 				<4 0>, <5 0>, <6 0>, <7 0>,
 				<8 0>, <9 0>, <10 0>, <11 0>,

--- a/soc/arm/nxp_imx/rt/soc_rt11xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt11xx.c
@@ -134,7 +134,7 @@ static ALWAYS_INLINE void clock_init(void)
 	DCDC_SetVDD1P0BuckModeTargetVoltage(DCDC, kDCDC_1P0BuckTarget1P15V);
 #endif
 
-/* RT1160 does not have Foward Body Biasing on the CM7 core */
+/* RT1160 does not have Forward Body Biasing on the CM7 core */
 #if defined(CONFIG_SOC_MIMXRT1176_CM4) || defined(CONFIG_SOC_MIMXRT1176_CM7)
 	/* Check if FBB need to be enabled in OverDrive(OD) mode */
 	if (((OCOTP->FUSEN[7].FUSE & 0x10U) >> 4U) != 1) {
@@ -301,9 +301,13 @@ static ALWAYS_INLINE void clock_init(void)
 #endif
 
 	/* Configure BUS_LPSR using SYS_PLL3_CLK */
-#if defined(CONFIG_SOC_MIMXRT1176_CM4) || defined(CONFIG_SOC_MIMXRT1166_CM4)
+#if defined(CONFIG_SOC_MIMXRT1176_CM4)
 	rootCfg.mux = kCLOCK_BUS_LPSR_ClockRoot_MuxSysPll3Out;
 	rootCfg.div = 3;
+	CLOCK_SetRootClock(kCLOCK_Root_Bus_Lpsr, &rootCfg);
+#elif defined(CONFIG_SOC_MIMXRT1166_CM4)
+	rootCfg.mux = kCLOCK_BUS_LPSR_ClockRoot_MuxSysPll3Out;
+	rootCfg.div = 4;
 	CLOCK_SetRootClock(kCLOCK_Root_Bus_Lpsr, &rootCfg);
 #endif
 

--- a/tests/drivers/dma/chan_link_transfer/testcase.yaml
+++ b/tests/drivers/dma/chan_link_transfer/testcase.yaml
@@ -3,11 +3,11 @@ tests:
     min_ram: 16
     depends_on: dma
     tags: drivers dma
-    platform_allow: frdm_k64f mimxrt1060_evk mimxrt1064_evk
+    platform_allow: frdm_k64f mimxrt1060_evk mimxrt1064_evk mimxrt1160_evk_cm7
   drivers.dma.interactive:
     depends_on: dma
     extra_args: CONF_FILE=prj_shell.conf
     min_ram: 16
     tags: drivers dma
     harness: keyboard
-    platform_allow: frdm_k64f mimxrt1060_evk mimxrt1064_evk
+    platform_allow: frdm_k64f mimxrt1060_evk mimxrt1064_evk mimxrt1160_evk_cm7

--- a/tests/drivers/dma/chan_link_transfer/testcase.yaml
+++ b/tests/drivers/dma/chan_link_transfer/testcase.yaml
@@ -3,11 +3,11 @@ tests:
     min_ram: 16
     depends_on: dma
     tags: drivers dma
-    platform_allow: frdm_k64f mimxrt1060_evk mimxrt1064_evk mimxrt1160_evk_cm7
+    platform_allow: frdm_k64f mimxrt1060_evk mimxrt1064_evk mimxrt1160_evk_cm7 mimxrt1170_evk_cm7
   drivers.dma.interactive:
     depends_on: dma
     extra_args: CONF_FILE=prj_shell.conf
     min_ram: 16
     tags: drivers dma
     harness: keyboard
-    platform_allow: frdm_k64f mimxrt1060_evk mimxrt1064_evk mimxrt1160_evk_cm7
+    platform_allow: frdm_k64f mimxrt1060_evk mimxrt1064_evk mimxrt1160_evk_cm7 mimxrt1170_evk_cm7


### PR DESCRIPTION
Enables DMA support for RT11xx SOCs and evaluation boards. DMA support is enabled on the Cortex M7 core, and has been tested using the `loop_transfer` dma test.