### PR TITLE
drivers: ethernet: mcux: Bugfix ptp_clock_adjust

### DIFF
--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -1456,7 +1456,8 @@ static int ptp_clock_mcux_adjust(const struct device *dev, int increment)
 
 	ARG_UNUSED(dev);
 
-	if ((increment <= -NSEC_PER_SEC) || (increment >= NSEC_PER_SEC)) {
+	if ((increment <= (int32_t)(-NSEC_PER_SEC)) ||
+			(increment >= (int32_t)NSEC_PER_SEC)) {
 		ret = -EINVAL;
 	} else {
 		key = irq_lock();


### PR DESCRIPTION
ptp_clock_adjust() API call for mcux driver has a bug where increment gets compared with an unsigned int, causing it to always return -EINVAL.

Signed-off-by: Alex Sergeev <asergeev@carbonrobotics.com>