### PR TITLE
drivers: ethernet: stm32: PTP L2 timestamping support

### DIFF
--- a/doc/reference/networking/gptp.rst
+++ b/doc/reference/networking/gptp.rst
@@ -36,6 +36,9 @@ support must be enabled in ethernet drivers.
 Boards supported:
 
 - :ref:`frdm_k64f`
+- :ref:`nucleo_h743zi_board`
+- :ref:`nucleo_h745zi_q_board`
+- :ref:`nucleo_f767zi_board`
 - :ref:`sam_e70_xplained`
 - :ref:`native_posix` (only usable for simple testing, limited capabilities
   due to lack of hardware clock)

--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -112,4 +112,46 @@ config ETH_STM32_MODE_HALFDUPLEX
 
 endif # !ETH_STM32_AUTO_NEGOTIATION_ENABLE
 
+if SOC_SERIES_STM32F7X || SOC_SERIES_STM32H7X
+
+config PTP_CLOCK_STM32_HAL
+	bool "STM32 HAL PTP clock driver support"
+	default y
+	depends on PTP_CLOCK || NET_L2_PTP
+	help
+	  Enable STM32 PTP clock support.
+
+config ETH_STM32_HAL_PTP_CLOCK_SRC_HZ
+	int "Frequency of the clock source for the PTP timer"
+	default 50000000
+	depends on PTP_CLOCK_STM32_HAL
+	help
+	  Set the frequency in Hz sourced to the PTP timer.
+	  If the value is set properly, the timer will be accurate.
+
+config ETH_STM32_HAL_PTP_CLOCK_ADJ_MIN_PCT
+	int "Lower bound of clock frequency adjustment (in percent)"
+	default 90
+	depends on PTP_CLOCK_STM32_HAL
+	help
+	  Specifies lower bound of PTP clock rate adjustment.
+
+config ETH_STM32_HAL_PTP_CLOCK_ADJ_MAX_PCT
+	int "Upper bound of clock frequency adjustment (in percent)"
+	default 110
+	depends on PTP_CLOCK_STM32_HAL
+	help
+	  Specifies upper bound of PTP clock rate adjustment.
+
+config ETH_STM32_HAL_PTP_CLOCK_INIT_PRIO
+	int
+	default 85
+	depends on PTP_CLOCK_STM32_HAL
+	help
+	  STM32 PTP Clock initialization priority level. There is
+	  a dependency from the network stack that this device
+	  initializes before network stack (NET_INIT_PRIO).
+
+endif # SOC_SERIES_STM32F7X || SOC_SERIES_STM32H7X
+
 endif # ETH_STM32_HAL

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017 Erwin Rol <erwin@erwinrol.com>
  * Copyright (c) 2020 Alexander Kozhinov <AlexanderKozhinov@yandex.com>
+ * Copyright (c) 2021 Carbon Robotics
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -28,6 +29,10 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <drivers/clock_control/stm32_clock_control.h>
 #include <drivers/pinctrl.h>
 
+#if defined(CONFIG_PTP_CLOCK_STM32_HAL)
+#include <drivers/ptp_clock.h>
+#endif /* CONFIG_PTP_CLOCK_STM32_HAL */
+
 #include "eth.h"
 #include "eth_stm32_hal_priv.h"
 
@@ -43,7 +48,6 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define PHY_BSR  ((uint16_t)0x0001U)  /*!< Transceiver Basic Status Register */
 #define PHY_LINKED_STATUS  ((uint16_t)0x0004U)  /*!< Valid link established */
 
-#define GET_FIRST_DMA_TX_DESC(heth)	(heth->Init.TxDesc)
 #define IS_ETH_DMATXDESC_OWN(dma_tx_desc)	(dma_tx_desc->DESC3 & \
 							ETH_DMATXNDESCRF_OWN)
 
@@ -59,7 +63,6 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define ETH_TXBUF_DEF_NB	1U
 #else
 
-#define GET_FIRST_DMA_TX_DESC(heth)	(heth->TxDesc)
 #define IS_ETH_DMATXDESC_OWN(dma_tx_desc)	(dma_tx_desc->Status & \
 							ETH_DMATXDESC_OWN)
 
@@ -169,6 +172,34 @@ static inline void disable_mcast_filter(ETH_HandleTypeDef *heth)
 #endif /* CONFIG_SOC_SERIES_STM32H7X) */
 }
 
+#if defined(CONFIG_PTP_CLOCK_STM32_HAL)
+static bool eth_is_ptp_pkt(struct net_if *iface, struct net_pkt *pkt)
+{
+#if defined(CONFIG_NET_VLAN)
+	struct net_eth_vlan_hdr *hdr_vlan;
+	struct ethernet_context *eth_ctx;
+
+	eth_ctx = net_if_l2_data(iface);
+	if (net_eth_is_vlan_enabled(eth_ctx, iface)) {
+		hdr_vlan = (struct net_eth_vlan_hdr *)NET_ETH_HDR(pkt);
+
+		if (ntohs(hdr_vlan->type) != NET_ETH_PTYPE_PTP) {
+			return false;
+		}
+	} else
+#endif
+	{
+		if (ntohs(NET_ETH_HDR(pkt)->type) != NET_ETH_PTYPE_PTP) {
+			return false;
+		}
+	}
+
+	net_pkt_set_priority(pkt, NET_PRIORITY_CA);
+
+	return true;
+}
+#endif /* CONFIG_PTP_CLOCK_STM32_HAL */
+
 static int eth_tx(const struct device *dev, struct net_pkt *pkt)
 {
 	struct eth_stm32_hal_dev_data *dev_data = DEV_DATA(dev);
@@ -178,6 +209,9 @@ static int eth_tx(const struct device *dev, struct net_pkt *pkt)
 	size_t total_len;
 	__IO ETH_DMADescTypeDef *dma_tx_desc;
 	HAL_StatusTypeDef hal_ret = HAL_OK;
+#if defined(CONFIG_PTP_CLOCK_STM32_HAL)
+	bool timestamped_frame;
+#endif /* CONFIG_PTP_CLOCK_STM32_HAL */
 
 	__ASSERT_NO_MSG(pkt != NULL);
 	__ASSERT_NO_MSG(pkt->frags != NULL);
@@ -196,13 +230,29 @@ static int eth_tx(const struct device *dev, struct net_pkt *pkt)
 	}
 
 #if defined(CONFIG_SOC_SERIES_STM32H7X)
-	const uint32_t cur_tx_desc_idx = 0;  /* heth->TxDescList.CurTxDesc; */
+	uint32_t cur_tx_desc_idx;
+
+	cur_tx_desc_idx = heth->TxDescList.CurTxDesc;
+	dma_tx_desc = (ETH_DMADescTypeDef *)heth->TxDescList.TxDesc[cur_tx_desc_idx];
+#else
+	dma_tx_desc = heth->TxDesc;
 #endif
 
-	dma_tx_desc = GET_FIRST_DMA_TX_DESC(heth);
 	while (IS_ETH_DMATXDESC_OWN(dma_tx_desc) != (uint32_t)RESET) {
 		k_yield();
 	}
+
+#if defined(CONFIG_PTP_CLOCK_STM32_HAL)
+	timestamped_frame = eth_is_ptp_pkt(net_pkt_iface(pkt), pkt);
+	if (timestamped_frame) {
+		/* Enable transmit timestamp */
+#if defined(CONFIG_SOC_SERIES_STM32H7X)
+		dma_tx_desc->DESC2 |= ETH_DMATXNDESCRF_TTSE;
+#else
+		dma_tx_desc->Status |= ETH_DMATXDESC_TTSE;
+#endif /* CONFIG_SOC_SERIES_STM32H7X */
+	}
+#endif /* CONFIG_PTP_CLOCK_STM32_HAL */
 
 #if defined(CONFIG_SOC_SERIES_STM32H7X)
 	dma_buffer = dma_tx_buffer[cur_tx_desc_idx];
@@ -216,16 +266,14 @@ static int eth_tx(const struct device *dev, struct net_pkt *pkt)
 	}
 
 #if defined(CONFIG_SOC_SERIES_STM32H7X)
-	ETH_BufferTypeDef tx_buffer_def[ETH_TXBUF_DEF_NB];
+	ETH_BufferTypeDef tx_buffer_def;
 
-	memset(tx_buffer_def, 0, ETH_TXBUF_DEF_NB*sizeof(ETH_BufferTypeDef));
-
-	tx_buffer_def[cur_tx_desc_idx].buffer = dma_buffer;
-	tx_buffer_def[cur_tx_desc_idx].len = total_len;
-	tx_buffer_def[cur_tx_desc_idx].next = NULL;
+	tx_buffer_def.buffer = dma_buffer;
+	tx_buffer_def.len = total_len;
+	tx_buffer_def.next = NULL;
 
 	tx_config.Length = total_len;
-	tx_config.TxBuffer = tx_buffer_def;
+	tx_config.TxBuffer = &tx_buffer_def;
 
 	/* Reset TX complete interrupt semaphore before TX request*/
 	k_sem_reset(&dev_data->tx_int_sem);
@@ -306,6 +354,68 @@ static int eth_tx(const struct device *dev, struct net_pkt *pkt)
 	}
 #endif /* CONFIG_SOC_SERIES_STM32H7X */
 
+#if defined(CONFIG_PTP_CLOCK_STM32_HAL)
+	if (timestamped_frame) {
+		/* Retrieve transmission timestamp from last DMA TX descriptor */
+#if defined(CONFIG_SOC_SERIES_STM32H7X)
+		ETH_TxDescListTypeDef * dma_tx_desc_list;
+
+		__IO ETH_DMADescTypeDef *last_dma_tx_desc;
+
+		dma_tx_desc_list = &heth->TxDescList;
+		for (uint32_t i = 0; i < ETH_TX_DESC_CNT; i++) {
+			const uint32_t last_desc_idx = (cur_tx_desc_idx + i) % ETH_TX_DESC_CNT;
+
+			last_dma_tx_desc =
+				(ETH_DMADescTypeDef *)dma_tx_desc_list->TxDesc[last_desc_idx];
+			if (last_dma_tx_desc->DESC3 & ETH_DMATXNDESCWBF_LD) {
+				break;
+			}
+		}
+
+		while (IS_ETH_DMATXDESC_OWN(last_dma_tx_desc) != (uint32_t)RESET) {
+			/* Wait for transmission */
+			k_yield();
+		}
+
+		if ((last_dma_tx_desc->DESC3 & ETH_DMATXNDESCWBF_LD) &&
+				(last_dma_tx_desc->DESC3 & ETH_DMATXNDESCWBF_TTSS)) {
+			pkt->timestamp.second = last_dma_tx_desc->DESC1;
+			pkt->timestamp.nanosecond = last_dma_tx_desc->DESC0;
+		} else {
+			/* Invalid value */
+			pkt->timestamp.second = UINT64_MAX;
+			pkt->timestamp.nanosecond = UINT32_MAX;
+		}
+#else
+		__IO ETH_DMADescTypeDef *last_dma_tx_desc = dma_tx_desc;
+
+		while (!(last_dma_tx_desc->Status & ETH_DMATXDESC_LS) &&
+				last_dma_tx_desc->Buffer2NextDescAddr) {
+			last_dma_tx_desc =
+				(ETH_DMADescTypeDef *)last_dma_tx_desc->Buffer2NextDescAddr;
+		}
+
+		while (IS_ETH_DMATXDESC_OWN(last_dma_tx_desc) != (uint32_t)RESET) {
+			/* Wait for transmission */
+			k_yield();
+		}
+
+		if (last_dma_tx_desc->Status & ETH_DMATXDESC_LS &&
+				last_dma_tx_desc->Status & ETH_DMATXDESC_TTSS) {
+			pkt->timestamp.second = last_dma_tx_desc->TimeStampHigh;
+			pkt->timestamp.nanosecond = last_dma_tx_desc->TimeStampLow;
+		} else {
+			/* Invalid value */
+			pkt->timestamp.second = UINT64_MAX;
+			pkt->timestamp.nanosecond = UINT32_MAX;
+		}
+#endif /* CONFIG_SOC_SERIES_STM32H7X */
+
+		net_if_add_tx_timestamp(pkt);
+	}
+#endif /* CONFIG_PTP_CLOCK_STM32_HAL */
+
 	res = 0;
 error:
 	k_mutex_unlock(&dev_data->tx_mutex);
@@ -343,6 +453,12 @@ static struct net_pkt *eth_rx(const struct device *dev, uint16_t *vlan_tag)
 	size_t total_len;
 	uint8_t *dma_buffer;
 	HAL_StatusTypeDef hal_ret = HAL_OK;
+#if defined(CONFIG_PTP_CLOCK_STM32_HAL)
+	struct net_ptp_time timestamp;
+	/* Default to invalid value. */
+	timestamp.second = UINT64_MAX;
+	timestamp.nanosecond = UINT32_MAX;
+#endif /* CONFIG_PTP_CLOCK_STM32_HAL */
 
 	__ASSERT_NO_MSG(dev != NULL);
 
@@ -387,6 +503,49 @@ static struct net_pkt *eth_rx(const struct device *dev, uint16_t *vlan_tag)
 	total_len = heth->RxFrameInfos.length;
 	dma_buffer = (uint8_t *)heth->RxFrameInfos.buffer;
 #endif /* CONFIG_SOC_SERIES_STM32H7X */
+
+#if defined(CONFIG_PTP_CLOCK_STM32_HAL)
+#if defined(CONFIG_SOC_SERIES_STM32H7X)
+	ETH_RxDescListTypeDef * dma_rx_desc_list;
+
+	dma_rx_desc_list = &heth->RxDescList;
+	if (dma_rx_desc_list->AppDescNbr) {
+		__IO ETH_DMADescTypeDef *last_dma_rx_desc;
+
+		const uint32_t last_desc_idx =
+			(dma_rx_desc_list->FirstAppDesc + dma_rx_desc_list->AppDescNbr - 1U)
+				% ETH_RX_DESC_CNT;
+
+		last_dma_rx_desc =
+			(ETH_DMADescTypeDef *)dma_rx_desc_list->RxDesc[last_desc_idx];
+
+		if (dma_rx_desc_list->AppContextDesc &&
+				last_dma_rx_desc->DESC1 & ETH_DMARXNDESCWBF_TSA) {
+			/* Retrieve timestamp from context DMA descriptor */
+			__IO ETH_DMADescTypeDef *context_dma_rx_desc;
+
+			const uint32_t context_desc_idx = (last_desc_idx + 1U) % ETH_RX_DESC_CNT;
+
+			context_dma_rx_desc =
+				(ETH_DMADescTypeDef *)dma_rx_desc_list->RxDesc[context_desc_idx];
+			if (context_dma_rx_desc->DESC1 != UINT32_MAX ||
+					context_dma_rx_desc->DESC0 != UINT32_MAX) {
+				timestamp.second = context_dma_rx_desc->DESC1;
+				timestamp.nanosecond = context_dma_rx_desc->DESC0;
+			}
+		}
+	}
+#else
+	__IO ETH_DMADescTypeDef *last_dma_rx_desc;
+
+	last_dma_rx_desc = heth->RxFrameInfos.LSRxDesc;
+	if (last_dma_rx_desc->TimeStampHigh != UINT32_MAX ||
+			last_dma_rx_desc->TimeStampLow != UINT32_MAX) {
+		timestamp.second = last_dma_rx_desc->TimeStampHigh;
+		timestamp.nanosecond = last_dma_rx_desc->TimeStampLow;
+	}
+#endif /* CONFIG_SOC_SERIES_STM32H7X */
+#endif /* CONFIG_PTP_CLOCK_STM32_HAL */
 
 	pkt = net_pkt_rx_alloc_with_buffer(get_iface(dev_data, *vlan_tag),
 					   total_len, AF_UNSPEC, 0, K_MSEC(100));
@@ -453,6 +612,17 @@ release_desc:
 		net_pkt_set_iface(pkt, dev_data->iface);
 	}
 #endif /* CONFIG_NET_VLAN */
+
+#if defined(CONFIG_PTP_CLOCK_STM32_HAL)
+	if (eth_is_ptp_pkt(get_iface(dev_data, *vlan_tag), pkt)) {
+		pkt->timestamp.second = timestamp.second;
+		pkt->timestamp.nanosecond = timestamp.nanosecond;
+	} else {
+		/* Invalid value */
+		pkt->timestamp.second = UINT64_MAX;
+		pkt->timestamp.nanosecond = UINT32_MAX;
+	}
+#endif /* CONFIG_PTP_CLOCK_STM32_HAL */
 
 	if (!pkt) {
 		eth_stats_update_errors_rx(get_iface(dev_data, *vlan_tag));
@@ -692,6 +862,17 @@ static int eth_initialize(const struct device *dev)
 		return -EINVAL;
 	}
 
+#if defined(CONFIG_PTP_CLOCK_STM32_HAL)
+	/* Enable timestamping of RX packets. We enable all packets to be
+	 * timestamped to cover both IEEE 1588 and gPTP.
+	 */
+#if defined(CONFIG_SOC_SERIES_STM32H7X)
+	heth->Instance->MACTSCR |= ETH_MACTSCR_TSENALL;
+#else
+	heth->Instance->PTPTSCR |= ETH_PTPTSSR_TSSARFE;
+#endif /* CONFIG_SOC_SERIES_STM32H7X */
+#endif /* CONFIG_PTP_CLOCK_STM32_HAL */
+
 #if defined(CONFIG_SOC_SERIES_STM32H7X)
 	/* Tx config init: */
 	memset(&tx_config, 0, sizeof(ETH_TxPacketConfig));
@@ -822,6 +1003,9 @@ static enum ethernet_hw_caps eth_stm32_hal_get_capabilities(const struct device 
 #if defined(CONFIG_NET_PROMISCUOUS_MODE)
 		| ETHERNET_PROMISC_MODE
 #endif
+#if defined(CONFIG_PTP_CLOCK_STM32_HAL)
+		| ETHERNET_PTP
+#endif
 		;
 }
 
@@ -875,9 +1059,20 @@ static int eth_stm32_hal_set_config(const struct device *dev,
 	return -ENOTSUP;
 }
 
+#if defined(CONFIG_PTP_CLOCK_STM32_HAL)
+static const struct device *eth_stm32_get_ptp_clock(const struct device *dev)
+{
+	struct eth_stm32_hal_dev_data *dev_data = dev->data;
+
+	return dev_data->ptp_clock;
+}
+#endif /* CONFIG_PTP_CLOCK_STM32_HAL */
+
 static const struct ethernet_api eth_api = {
 	.iface_api.init = eth_iface_init,
-
+#if defined(CONFIG_PTP_CLOCK_STM32_HAL)
+	.get_ptp_clock = eth_stm32_get_ptp_clock,
+#endif /* CONFIG_PTP_CLOCK_STM32_HAL */
 	.get_capabilities = eth_stm32_hal_get_capabilities,
 	.set_config = eth_stm32_hal_set_config,
 	.send = eth_tx,
@@ -953,3 +1148,293 @@ static struct eth_stm32_hal_dev_data eth0_data = {
 ETH_NET_DEVICE_DT_INST_DEFINE(0, eth_initialize,
 		    NULL, &eth0_data, &eth0_config,
 		    CONFIG_ETH_INIT_PRIORITY, &eth_api, ETH_STM32_HAL_MTU);
+
+#if defined(CONFIG_PTP_CLOCK_STM32_HAL)
+
+struct ptp_context {
+	struct eth_stm32_hal_dev_data *eth_dev_data;
+};
+
+static struct ptp_context ptp_stm32_0_context;
+
+static int ptp_clock_stm32_set(const struct device *dev,
+			      struct net_ptp_time *tm)
+{
+	struct ptp_context *ptp_context = dev->data;
+	struct eth_stm32_hal_dev_data *eth_dev_data = ptp_context->eth_dev_data;
+	ETH_HandleTypeDef *heth = &eth_dev_data->heth;
+	int key;
+
+	key = irq_lock();
+
+#if defined(CONFIG_SOC_SERIES_STM32H7X)
+	heth->Instance->MACSTSUR = tm->second;
+	heth->Instance->MACSTNUR = tm->nanosecond;
+	heth->Instance->MACTSCR |= ETH_MACTSCR_TSINIT;
+	while (heth->Instance->MACTSCR & ETH_MACTSCR_TSINIT_Msk) {
+		/* spin lock */
+	}
+#else
+	heth->Instance->PTPTSHUR = tm->second;
+	heth->Instance->PTPTSLUR = tm->nanosecond;
+	heth->Instance->PTPTSCR |= ETH_PTPTSCR_TSSTI;
+	while (heth->Instance->PTPTSCR & ETH_PTPTSCR_TSSTI_Msk) {
+		/* spin lock */
+	}
+#endif /* CONFIG_SOC_SERIES_STM32H7X */
+
+	irq_unlock(key);
+
+	return 0;
+}
+
+static int ptp_clock_stm32_get(const struct device *dev,
+			      struct net_ptp_time *tm)
+{
+	struct ptp_context *ptp_context = dev->data;
+	struct eth_stm32_hal_dev_data *eth_dev_data = ptp_context->eth_dev_data;
+	ETH_HandleTypeDef *heth = &eth_dev_data->heth;
+	int key;
+
+	key = irq_lock();
+
+#if defined(CONFIG_SOC_SERIES_STM32H7X)
+	tm->second = heth->Instance->MACSTSR;
+	tm->nanosecond = heth->Instance->MACSTNR;
+#else
+	tm->second = heth->Instance->PTPTSHR;
+	tm->nanosecond = heth->Instance->PTPTSLR;
+#endif /* CONFIG_SOC_SERIES_STM32H7X */
+
+	irq_unlock(key);
+
+	return 0;
+}
+
+static int ptp_clock_stm32_adjust(const struct device *dev, int increment)
+{
+	struct ptp_context *ptp_context = dev->data;
+	struct eth_stm32_hal_dev_data *eth_dev_data = ptp_context->eth_dev_data;
+	ETH_HandleTypeDef *heth = &eth_dev_data->heth;
+	int key, ret;
+
+	if ((increment <= (int32_t)(-NSEC_PER_SEC)) ||
+			(increment >= (int32_t)NSEC_PER_SEC)) {
+		ret = -EINVAL;
+	} else {
+		key = irq_lock();
+
+#if defined(CONFIG_SOC_SERIES_STM32H7X)
+		heth->Instance->MACSTSUR = 0;
+		if (increment >= 0) {
+			heth->Instance->MACSTNUR = increment;
+		} else {
+			heth->Instance->MACSTNUR = ETH_MACSTNUR_ADDSUB | (NSEC_PER_SEC + increment);
+		}
+		heth->Instance->MACTSCR |= ETH_MACTSCR_TSUPDT;
+		while (heth->Instance->MACTSCR & ETH_MACTSCR_TSUPDT_Msk) {
+			/* spin lock */
+		}
+#else
+		heth->Instance->PTPTSHUR = 0;
+		if (increment >= 0) {
+			heth->Instance->PTPTSLUR = increment;
+		} else {
+			heth->Instance->PTPTSLUR = ETH_PTPTSLUR_TSUPNS | (-increment);
+		}
+		heth->Instance->PTPTSCR |= ETH_PTPTSCR_TSSTU;
+		while (heth->Instance->PTPTSCR & ETH_PTPTSCR_TSSTU_Msk) {
+			/* spin lock */
+		}
+#endif /* CONFIG_SOC_SERIES_STM32H7X */
+
+		ret = 0;
+		irq_unlock(key);
+	}
+
+	return ret;
+}
+
+static int ptp_clock_stm32_rate_adjust(const struct device *dev, float ratio)
+{
+	struct ptp_context *ptp_context = dev->data;
+	struct eth_stm32_hal_dev_data *eth_dev_data = ptp_context->eth_dev_data;
+	ETH_HandleTypeDef *heth = &eth_dev_data->heth;
+	int key, ret;
+	uint32_t addend_val;
+
+	/* No change needed */
+	if (ratio == 1.0f) {
+		return 0;
+	}
+
+	key = irq_lock();
+
+	ratio *= eth_dev_data->clk_ratio_adj;
+
+	/* Limit possible ratio */
+	if (ratio * 100 < CONFIG_ETH_STM32_HAL_PTP_CLOCK_ADJ_MIN_PCT ||
+			ratio * 100 > CONFIG_ETH_STM32_HAL_PTP_CLOCK_ADJ_MAX_PCT) {
+		ret = -EINVAL;
+		goto error;
+	}
+
+	/* Save new ratio */
+	eth_dev_data->clk_ratio_adj = ratio;
+
+	/* Update addend register */
+	addend_val = UINT32_MAX * eth_dev_data->clk_ratio * ratio;
+
+#if defined(CONFIG_SOC_SERIES_STM32H7X)
+	heth->Instance->MACTSAR = addend_val;
+	heth->Instance->MACTSCR |= ETH_MACTSCR_TSADDREG;
+	while (heth->Instance->MACTSCR & ETH_MACTSCR_TSADDREG_Msk) {
+		/* spin lock */
+	}
+#else
+	heth->Instance->PTPTSAR = addend_val;
+	heth->Instance->PTPTSCR |= ETH_PTPTSCR_TSARU;
+	while (heth->Instance->PTPTSCR & ETH_PTPTSCR_TSARU_Msk) {
+		/* spin lock */
+	}
+#endif /* CONFIG_SOC_SERIES_STM32H7X */
+
+	ret = 0;
+
+error:
+	irq_unlock(key);
+
+	return ret;
+}
+
+static const struct ptp_clock_driver_api api = {
+	.set = ptp_clock_stm32_set,
+	.get = ptp_clock_stm32_get,
+	.adjust = ptp_clock_stm32_adjust,
+	.rate_adjust = ptp_clock_stm32_rate_adjust,
+};
+
+static int ptp_stm32_init(const struct device *port)
+{
+	const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(mac));
+	struct eth_stm32_hal_dev_data *eth_dev_data = DEV_DATA(dev);
+	const struct eth_stm32_hal_dev_cfg *eth_cfg = DEV_CFG(dev);
+	struct ptp_context *ptp_context = port->data;
+	ETH_HandleTypeDef *heth = &eth_dev_data->heth;
+	int ret;
+	uint32_t ptp_hclk_rate;
+	uint32_t ss_incr_ns;
+	uint32_t addend_val;
+
+	eth_dev_data->ptp_clock = port;
+	ptp_context->eth_dev_data = eth_dev_data;
+
+	/* Mask the Timestamp Trigger interrupt */
+#if defined(CONFIG_SOC_SERIES_STM32H7X)
+	heth->Instance->MACIER &= ~(ETH_MACIER_TSIE);
+#else
+	heth->Instance->MACIMR &= ~(ETH_MACIMR_TSTIM);
+#endif /* CONFIG_SOC_SERIES_STM32H7X */
+
+	/* Enable timestamping */
+#if defined(CONFIG_SOC_SERIES_STM32H7X)
+	heth->Instance->MACTSCR |= ETH_MACTSCR_TSENA;
+#else
+	heth->Instance->PTPTSCR |= ETH_PTPTSCR_TSE;
+#endif /* CONFIG_SOC_SERIES_STM32H7X */
+
+	/* Query ethernet clock rate */
+	ret = clock_control_get_rate(eth_dev_data->clock,
+#if defined(CONFIG_SOC_SERIES_STM32H7X)
+		(clock_control_subsys_t *)&eth_cfg->pclken,
+#else
+		(clock_control_subsys_t *)&eth_cfg->pclken_ptp,
+#endif /* CONFIG_SOC_SERIES_STM32H7X */
+		&ptp_hclk_rate);
+	if (ret) {
+		LOG_ERR("Failed to query ethernet clock");
+		return -EIO;
+	}
+
+	/* Program the subsecond increment register based on the PTP clock freq */
+	if (NSEC_PER_SEC % CONFIG_ETH_STM32_HAL_PTP_CLOCK_SRC_HZ != 0) {
+		LOG_ERR("PTP clock period must be an integer nanosecond value");
+		return -EINVAL;
+	}
+	ss_incr_ns = NSEC_PER_SEC / CONFIG_ETH_STM32_HAL_PTP_CLOCK_SRC_HZ;
+	if (ss_incr_ns > UINT8_MAX) {
+		LOG_ERR("PTP clock period is more than %d nanoseconds", UINT8_MAX);
+		return -EINVAL;
+	}
+#if defined(CONFIG_SOC_SERIES_STM32H7X)
+	heth->Instance->MACSSIR = ss_incr_ns << ETH_MACMACSSIR_SSINC_Pos;
+#else
+	heth->Instance->PTPSSIR = ss_incr_ns;
+#endif /* CONFIG_SOC_SERIES_STM32H7X */
+
+	/* Program timestamp addend register */
+	eth_dev_data->clk_ratio =
+		((double)CONFIG_ETH_STM32_HAL_PTP_CLOCK_SRC_HZ) / ((double)ptp_hclk_rate);
+	/*
+	 * clk_ratio is a ratio between desired PTP clock frequency and HCLK rate.
+	 * Because HCLK is defined by a physical oscillator, it might drift due
+	 * to manufacturing tolerances and environmental effects (e.g. temperature).
+	 * clk_ratio_adj compensates for such inaccuracies. It starts off as 1.0
+	 * and gets adjusted by calling ptp_clock_stm32_rate_adjust().
+	 */
+	eth_dev_data->clk_ratio_adj = 1.0f;
+	addend_val =
+		UINT32_MAX * eth_dev_data->clk_ratio * eth_dev_data->clk_ratio_adj;
+#if defined(CONFIG_SOC_SERIES_STM32H7X)
+	heth->Instance->MACTSAR = addend_val;
+	heth->Instance->MACTSCR |= ETH_MACTSCR_TSADDREG;
+	while (heth->Instance->MACTSCR & ETH_MACTSCR_TSADDREG_Msk) {
+		k_yield();
+	}
+#else
+	heth->Instance->PTPTSAR = addend_val;
+	heth->Instance->PTPTSCR |= ETH_PTPTSCR_TSARU;
+	while (heth->Instance->PTPTSCR & ETH_PTPTSCR_TSARU_Msk) {
+		k_yield();
+	}
+#endif /* CONFIG_SOC_SERIES_STM32H7X */
+
+	/* Enable fine timestamp correction method */
+#if defined(CONFIG_SOC_SERIES_STM32H7X)
+	heth->Instance->MACTSCR |= ETH_MACTSCR_TSCFUPDT;
+#else
+	heth->Instance->PTPTSCR |= ETH_PTPTSCR_TSFCU;
+#endif /* CONFIG_SOC_SERIES_STM32H7X */
+
+	/* Enable nanosecond rollover into a new second */
+#if defined(CONFIG_SOC_SERIES_STM32H7X)
+	heth->Instance->MACTSCR |= ETH_MACTSCR_TSCTRLSSR;
+#else
+	heth->Instance->PTPTSCR |= ETH_PTPTSSR_TSSSR;
+#endif /* CONFIG_SOC_SERIES_STM32H7X */
+
+	/* Initialize timestamp */
+#if defined(CONFIG_SOC_SERIES_STM32H7X)
+	heth->Instance->MACSTSUR = 0;
+	heth->Instance->MACSTNUR = 0;
+	heth->Instance->MACTSCR |= ETH_MACTSCR_TSINIT;
+	while (heth->Instance->MACTSCR & ETH_MACTSCR_TSINIT_Msk) {
+		k_yield();
+	}
+#else
+	heth->Instance->PTPTSHUR = 0;
+	heth->Instance->PTPTSLUR = 0;
+	heth->Instance->PTPTSCR |= ETH_PTPTSCR_TSSTI;
+	while (heth->Instance->PTPTSCR & ETH_PTPTSCR_TSSTI_Msk) {
+		k_yield();
+	}
+#endif /* CONFIG_SOC_SERIES_STM32H7X */
+
+	return 0;
+}
+
+DEVICE_DEFINE(stm32_ptp_clock_0, PTP_CLOCK_NAME, ptp_stm32_init,
+		NULL, &ptp_stm32_0_context, NULL, POST_KERNEL,
+		CONFIG_ETH_STM32_HAL_PTP_CLOCK_INIT_PRIO, &api);
+
+#endif /* CONFIG_PTP_CLOCK_STM32_HAL */

--- a/drivers/ethernet/eth_stm32_hal_priv.h
+++ b/drivers/ethernet/eth_stm32_hal_priv.h
@@ -48,6 +48,11 @@ struct eth_stm32_hal_dev_data {
 		CONFIG_ETH_STM32_HAL_RX_THREAD_STACK_SIZE);
 	struct k_thread rx_thread;
 	bool link_up;
+#if defined(CONFIG_PTP_CLOCK_STM32_HAL)
+	const struct device *ptp_clock;
+	float clk_ratio;
+	float clk_ratio_adj;
+#endif /* CONFIG_PTP_CLOCK_STM32_HAL */
 };
 
 #define DEV_CFG(dev) \

--- a/samples/net/gptp/README.rst
+++ b/samples/net/gptp/README.rst
@@ -25,9 +25,10 @@ Building and Running
 
 A good way to run this sample is to run this gPTP application inside
 native_posix board as described in :ref:`networking_with_native_posix` or with
-embedded device like NXP FRDM-K64F or Atmel SAM-E70 Xplained. Note that gPTP is
-only supported for boards that have an Ethernet port and which has support for
-collecting timestamps for sent and received Ethernet frames.
+embedded device like NXP FRDM-K64F, Nucleo-H743-ZI, Nucleo-H745ZI-Q,
+Nucleo-F767ZI or Atmel SAM-E70 Xplained. Note that gPTP is only supported for
+boards that have an Ethernet port and which has support for collecting
+timestamps for sent and received Ethernet frames.
 
 Follow these steps to build the gPTP sample application:
 

--- a/samples/net/gptp/boards/frdm_k64f.conf
+++ b/samples/net/gptp/boards/frdm_k64f.conf
@@ -1,3 +1,0 @@
-# MCUX driver settings
-CONFIG_ETH_MCUX=y
-CONFIG_PTP_CLOCK_MCUX=y

--- a/samples/net/gptp/sample.yaml
+++ b/samples/net/gptp/sample.yaml
@@ -6,5 +6,5 @@ sample:
   name: gPTP sample app
 tests:
   sample.net.gptp:
-    platform_allow: frdm_k64f sam_e70_xplained native_posix native_posix_64
+    platform_allow: frdm_k64f sam_e70_xplained native_posix native_posix_64 nucleo_f767zi nucleo_h743zi nucleo_h745zi_q_m7
     depends_on: netif

--- a/west.yml
+++ b/west.yml
@@ -124,7 +124,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 6fc9b5f7e0229ef64a882e37213266d346ebfadb
+      revision: 5ca535df5874d1f9ab931265a2b1f691b76df9ce
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Adds support for PTP timestamping to STM32 H7 and F7 families.  Depends on https://github.com/zephyrproject-rtos/hal_stm32/pull/116 bugfix for STM32 H7 functionality to work correctly.

Signed-off-by: Alex Sergeev <asergeev@carbonrobotics.com>