### PR TITLE
tests/net: Raise TLS timeout option on waitall checks

### DIFF
--- a/tests/net/socket/tls/src/main.c
+++ b/tests/net/socket/tls/src/main.c
@@ -228,7 +228,7 @@ void test_v4_msg_waitall(void)
 	uint8_t rx_buf[sizeof(TEST_STR_SMALL) - 1] = { 0 };
 	struct timeval timeo_optval = {
 		.tv_sec = 0,
-		.tv_usec = 200000,
+		.tv_usec = 500000,
 	};
 
 	prepare_sock_tls_v4(CONFIG_NET_CONFIG_MY_IPV4_ADDR, ANY_PORT,
@@ -306,7 +306,7 @@ void test_v6_msg_waitall(void)
 	uint8_t rx_buf[sizeof(TEST_STR_SMALL) - 1] = { 0 };
 	struct timeval timeo_optval = {
 		.tv_sec = 0,
-		.tv_usec = 200000,
+		.tv_usec = 500000,
 	};
 
 	prepare_sock_tls_v6(CONFIG_NET_CONFIG_MY_IPV6_ADDR, ANY_PORT,


### PR DESCRIPTION
Previous timeouts values were done when local TCP replies wourd occur
within sender's thread. This was a known behavior: no context switch,
shorter timings for sending packets (locally only) thus shorter
timeouts.

Such behavior changed when local replies had to go through TCP's work
queue. See commit 798588e7092741996a5e27e4d0f411e60a35a606

Fixes #40129

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>
Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>