### PR TITLE
shell: Add mising CONSOLE dependency of serial backend.

### DIFF
--- a/subsys/shell/backends/Kconfig.backends
+++ b/subsys/shell/backends/Kconfig.backends
@@ -20,6 +20,7 @@ config SHELL_BACKEND_SERIAL
 	default y if !HAS_DTS
 	select SERIAL
 	select RING_BUFFER
+	select CONSOLE
 	help
 	  Enable serial backend.
 


### PR DESCRIPTION
This commits adds CONFIG_CONSOLE dependency on missing serial backend
in order to fix not working nrf52840dongle_nrf52840 console.

Signed-off-by: Przemyslaw Bida <przemyslaw.bida@nordicsemi.no>