### PR TITLE
lorawan: adding NVM support for LoRaWAN and a reference SE implementation

### DIFF
--- a/include/lorawan/lorawan.h
+++ b/include/lorawan/lorawan.h
@@ -182,6 +182,16 @@ void lorawan_register_dr_changed_callback(void (*dr_cb)(enum lorawan_datarate));
  */
 int lorawan_join(const struct lorawan_join_config *config);
 
+
+/**
+ * Initialize the LoRaWAN stack.
+ *
+ * Must be called before any other lorawan_xxx() functions
+ *
+ * @return 0 if successful, negative errno code if failure
+ */
+int lorawan_init(void);
+
 /**
  * @brief Start the LoRaWAN stack
  *

--- a/modules/loramac-node/CMakeLists.txt
+++ b/modules/loramac-node/CMakeLists.txt
@@ -33,9 +33,9 @@ if(${CONFIG_HAS_SEMTECH_LORAMAC})
   )
 endif()
 
-zephyr_library_compile_definitions_ifdef(CONFIG_HAS_SEMTECH_SOFT_SE SOFT_SE)
+zephyr_library_compile_definitions_ifdef(CONFIG_LORAWAN_SE_SOFT SOFT_SE)
 
-zephyr_library_sources_ifdef(CONFIG_HAS_SEMTECH_SOFT_SE
+zephyr_library_sources_ifdef(CONFIG_LORAWAN_SE_SOFT
   ${ZEPHYR_LORAMAC_NODE_MODULE_DIR}/src/peripherals/soft-se/aes.c
   ${ZEPHYR_LORAMAC_NODE_MODULE_DIR}/src/peripherals/soft-se/cmac.c
   ${ZEPHYR_LORAMAC_NODE_MODULE_DIR}/src/peripherals/soft-se/soft-se.c

--- a/modules/loramac-node/Kconfig
+++ b/modules/loramac-node/Kconfig
@@ -29,10 +29,3 @@ config HAS_SEMTECH_LORAMAC
 	depends on HAS_SEMTECH_RADIO_DRIVERS
 	help
 	  This option enables the use of Semtech's LoRaMac stack
-
-config HAS_SEMTECH_SOFT_SE
-	bool "Semtech Secure Element software implementation"
-	depends on HAS_SEMTECH_LORAMAC
-	help
-	  This option enables the use of Semtech's Secure Element
-	  software implementation

--- a/subsys/lorawan/CMakeLists.txt
+++ b/subsys/lorawan/CMakeLists.txt
@@ -22,4 +22,5 @@ zephyr_compile_definitions_ifdef(CONFIG_LORAMAC_REGION_RU864 REGION_RU864)
 
 zephyr_library_sources_ifdef(CONFIG_LORAWAN lorawan.c)
 zephyr_library_sources_ifdef(CONFIG_LORAWAN lw_priv.c)
+add_subdirectory(nvm)
 add_subdirectory(se)

--- a/subsys/lorawan/CMakeLists.txt
+++ b/subsys/lorawan/CMakeLists.txt
@@ -22,3 +22,4 @@ zephyr_compile_definitions_ifdef(CONFIG_LORAMAC_REGION_RU864 REGION_RU864)
 
 zephyr_library_sources_ifdef(CONFIG_LORAWAN lorawan.c)
 zephyr_library_sources_ifdef(CONFIG_LORAWAN lw_priv.c)
+add_subdirectory(se)

--- a/subsys/lorawan/Kconfig
+++ b/subsys/lorawan/Kconfig
@@ -68,4 +68,6 @@ endchoice
 
 rsource "se/Kconfig"
 
+rsource "nvm/Kconfig"
+
 endif # LORAWAN

--- a/subsys/lorawan/Kconfig
+++ b/subsys/lorawan/Kconfig
@@ -1,13 +1,13 @@
 # LoRaWAN configuration options
 
 # Copyright (c) 2020 Manivannan Sadhasivam <mani@kernel.org>
+# Copyright (c) 2021 Intellinium <giuliano.franchetto@intellinium.com>
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig LORAWAN
 	bool "LoRaWAN support [EXPERIMENTAL]"
 	depends on LORA
 	select HAS_SEMTECH_LORAMAC
-	select HAS_SEMTECH_SOFT_SE
 	select EXPERIMENTAL
 	help
 	  This option enables LoRaWAN support.
@@ -65,5 +65,7 @@ config LORAMAC_REGION_RU864
 	bool "Russia 864MHz Frequency band"
 
 endchoice
+
+rsource "se/Kconfig"
 
 endif # LORAWAN

--- a/subsys/lorawan/lorawan.c
+++ b/subsys/lorawan/lorawan.c
@@ -576,7 +576,7 @@ int lorawan_start(void)
 	return 0;
 }
 
-static int lorawan_init(const struct device *dev)
+int lorawan_init(void)
 {
 	LoRaMacStatus_t status;
 
@@ -591,6 +591,7 @@ static int lorawan_init(const struct device *dev)
 	macCallbacks.NvmDataChange = NULL;
 	macCallbacks.MacProcessNotify = OnMacProcessNotify;
 
+
 	status = LoRaMacInitialization(&macPrimitives, &macCallbacks,
 				       LORAWAN_REGION);
 	if (status != LORAMAC_STATUS_OK) {
@@ -603,5 +604,3 @@ static int lorawan_init(const struct device *dev)
 
 	return 0;
 }
-
-SYS_INIT(lorawan_init, APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);

--- a/subsys/lorawan/lorawan.c
+++ b/subsys/lorawan/lorawan.c
@@ -576,6 +576,10 @@ int lorawan_start(void)
 	return 0;
 }
 
+#if !defined(CONFIG_LORAWAN_NVM_NONE)
+#include "nvm/lorawan_nvm.h"
+#endif
+
 int lorawan_init(void)
 {
 	LoRaMacStatus_t status;
@@ -588,7 +592,11 @@ int lorawan_init(void)
 	macPrimitives.MacMlmeIndication = MlmeIndication;
 	macCallbacks.GetBatteryLevel = getBatteryLevelLocal;
 	macCallbacks.GetTemperatureLevel = NULL;
+#if !defined(CONFIG_LORAWAN_NVM_NONE)
+	macCallbacks.NvmDataChange = lorawan_nvm_data_mgmt_event;
+#else
 	macCallbacks.NvmDataChange = NULL;
+#endif
 	macCallbacks.MacProcessNotify = OnMacProcessNotify;
 
 
@@ -599,6 +607,11 @@ int lorawan_init(void)
 			lorawan_status2str(status));
 		return -EINVAL;
 	}
+
+#if !defined(CONFIG_LORAWAN_NVM_NONE)
+	lorawan_nvm_data_restore();
+#endif
+
 
 	LOG_DBG("LoRaMAC Initialized");
 

--- a/subsys/lorawan/nvm/CMakeLists.txt
+++ b/subsys/lorawan/nvm/CMakeLists.txt
@@ -1,0 +1,1 @@
+zephyr_library_sources_ifdef(CONFIG_LORAWAN_NVM_SETTINGS lorawan_nvm_settings.c)

--- a/subsys/lorawan/nvm/Kconfig
+++ b/subsys/lorawan/nvm/Kconfig
@@ -1,0 +1,22 @@
+# LoRaWAN Non Volatile Memory configuration options
+
+# Copyright (c) 2021 Intellinium <giuliano.franchetto@intellinium.com>
+# SPDX-License-Identifier: Apache-2.0
+
+choice LORAWAN_NVM
+	bool "LoRaWAN NVM backend"
+	default LORAWAN_NVM_SETTINGS if SETTINGS
+	default LORAWAN_NVM_NONE
+
+config LORAWAN_NVM_NONE
+	bool "No NVM backend for LoRaWAN"
+	help
+	  This configuration should only be used during testing as all
+	  the join request using OTAA will fail because of anti-replay
+	  protection
+
+config LORAWAN_NVM_SETTINGS
+	bool "Settings based NVM"
+	depends on SETTINGS
+
+endchoice

--- a/subsys/lorawan/nvm/lorawan_nvm.h
+++ b/subsys/lorawan/nvm/lorawan_nvm.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2021 Intellinium <giuliano.franchetto@intellinium.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef LORAWAN_NVM_H
+#define LORAWAN_NVM_H
+
+#include <zephyr.h>
+
+void lorawan_nvm_data_mgmt_event(uint16_t notifyFlags);
+
+int lorawan_nvm_data_restore(void);
+
+#endif /* LORAWAN_NVM_H */

--- a/subsys/lorawan/nvm/lorawan_nvm_settings.c
+++ b/subsys/lorawan/nvm/lorawan_nvm_settings.c
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2021 Intellinium <giuliano.franchetto@intellinium.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <LoRaMac.h>
+#include <settings/settings.h>
+#include "lorawan_nvm.h"
+#include <logging/log.h>
+#if defined(CONFIG_LORAWAN_SE_HAS_OWN_NVM)
+#include "../se/lorawan_se.h"
+#endif
+
+LOG_MODULE_REGISTER(lorawan_nvm, CONFIG_LORAWAN_LOG_LEVEL);
+
+static uint16_t nvm_notify_flag;
+
+#define LORAWAN_SETTINGS_BASE                "lorawan/nvm"
+
+#define flag_set(f)        ((nvm_notify_flag & (f)) == (f))
+
+#define SAVE_SETTINGS(nvm, flag, name)					\
+if (flag_set(flag)) {							\
+	LOG_DBG("Saving configuration " LORAWAN_SETTINGS_BASE "/" # name);\
+	int err = settings_save_one(LORAWAN_SETTINGS_BASE "/" # name,	\
+				&(nvm)->name,				\
+				sizeof((nvm)->name));			\
+	if (err) {							\
+		LOG_ERR("Could not save settings" # name", error %d",	\
+			err);						\
+	}								\
+}
+
+static void nvm_settings_work(struct k_work *work)
+{
+	ARG_UNUSED(work);
+
+	MibRequestConfirm_t mibReq;
+
+	LOG_DBG("Saving LoRaWAN settings");
+
+	/* Retrieve the actual context */
+	mibReq.Type = MIB_NVM_CTXS;
+	if (LoRaMacMibGetRequestConfirm(&mibReq) != LORAMAC_STATUS_OK) {
+		LOG_ERR("Could not get NVM context");
+		return;
+	}
+
+	LoRaMacNvmData_t *nvm = mibReq.Param.Contexts;
+
+	LOG_DBG("Crypto version: %"PRIu32", DevNonce: %d, JoinNonce: %"PRIu32,
+		mibReq.Param.Contexts->Crypto.LrWanVersion.Value,
+		mibReq.Param.Contexts->Crypto.DevNonce,
+		mibReq.Param.Contexts->Crypto.JoinNonce);
+
+	/* Wait for LoRa to be idle */
+	while (LoRaMacStop() != LORAMAC_STATUS_OK) {
+		k_sleep(K_MSEC(100));
+	}
+
+	SAVE_SETTINGS(nvm, LORAMAC_NVM_NOTIFY_FLAG_CRYPTO, Crypto)
+	SAVE_SETTINGS(nvm, LORAMAC_NVM_NOTIFY_FLAG_MAC_GROUP1, MacGroup1)
+	SAVE_SETTINGS(nvm, LORAMAC_NVM_NOTIFY_FLAG_MAC_GROUP2, MacGroup2)
+#if !defined(CONFIG_LORAWAN_SE_HAS_OWN_NVM)
+	SAVE_SETTINGS(nvm, LORAMAC_NVM_NOTIFY_FLAG_SECURE_ELEMENT,
+		      SecureElement)
+#else
+	lorawan_se_update(&nvm->SecureElement);
+#endif
+	SAVE_SETTINGS(nvm, LORAMAC_NVM_NOTIFY_FLAG_REGION_GROUP1, RegionGroup1)
+	SAVE_SETTINGS(nvm, LORAMAC_NVM_NOTIFY_FLAG_REGION_GROUP2, RegionGroup2)
+	SAVE_SETTINGS(nvm, LORAMAC_NVM_NOTIFY_FLAG_CLASS_B, ClassB)
+
+	settings_save();
+	/* Clean notification flag */
+	nvm_notify_flag = LORAMAC_NVM_NOTIFY_FLAG_NONE;
+
+	/* Restart LoRaMAC */
+	LoRaMacStart();
+}
+K_WORK_DEFINE(nvm_settings_worker, nvm_settings_work);
+
+void lorawan_nvm_data_mgmt_event(uint16_t notifyFlags)
+{
+	LOG_WRN("New NVM notify flag: 0x%04X", notifyFlags);
+
+	nvm_notify_flag = notifyFlags;
+
+	if (notifyFlags != LORAMAC_NVM_NOTIFY_FLAG_NONE) {
+		k_work_submit(&nvm_settings_worker);
+	}
+}
+
+static int load_setting(void *tgt, size_t tgt_size,
+			const char *key, size_t len,
+			settings_read_cb read_cb, void *cb_arg)
+{
+	if (len != tgt_size) {
+		LOG_ERR("Can't load '%s' state, size mismatch.",
+			log_strdup(key));
+		return -EINVAL;
+	}
+
+	if (!tgt) {
+		LOG_ERR("Can't load '%s' state, no target.",
+			log_strdup(key));
+		return -EINVAL;
+	}
+
+	if (read_cb(cb_arg, tgt, len) != len) {
+		LOG_ERR("Can't load '%s' state, short read.",
+			log_strdup(key));
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+/* @formatter:off */
+#define LOAD_SETTINGS(nvm, name)					\
+({									\
+int $err = -EAGAIN;							\
+if (strcmp(#name, key) == 0) {					\
+	$err = load_setting(&(nvm)->name,				\
+			   sizeof((nvm)->name),			\
+			   key, len, read_cb, cb_arg);		\
+	if ($err) {							\
+		LOG_ERR("Could not read settings" # name);		\
+	}								\
+	$err = 0;							\
+}									\
+$err;									\
+})
+/* @formatter: on */
+
+static int on_setting_loaded(const char *key, size_t len,
+			   settings_read_cb read_cb,
+			   void *cb_arg, void *param)
+{
+	int err;
+	LoRaMacNvmData_t *nvm = param;
+
+	LOG_DBG("Key: %s", log_strdup(key));
+
+	err = LOAD_SETTINGS(nvm, Crypto);
+	if (err != -EAGAIN) {
+		return err;
+	}
+
+	err = LOAD_SETTINGS(nvm, MacGroup1);
+	if (err != -EAGAIN) {
+		return err;
+	}
+
+	err = LOAD_SETTINGS(nvm, MacGroup2);
+	if (err != -EAGAIN) {
+		return err;
+	}
+
+#if !defined(CONFIG_LORAWAN_SE_HAS_OWN_NVM)
+	err = LOAD_SETTINGS(nvm, SecureElement);
+	if (err != -EAGAIN) {
+		return err;
+	}
+#endif
+
+	err = LOAD_SETTINGS(nvm, RegionGroup1);
+	if (err != -EAGAIN) {
+		return err;
+	}
+
+	err = LOAD_SETTINGS(nvm, RegionGroup2);
+	if (err != -EAGAIN) {
+		return err;
+	}
+
+	err = LOAD_SETTINGS(nvm, ClassB);
+	if (err != -EAGAIN) {
+		return err;
+	}
+
+	LOG_WRN("Unknown LoRaWAN setting: %s", log_strdup(key));
+	return 0;
+}
+
+int lorawan_nvm_data_restore(void)
+{
+	int err;
+	LoRaMacStatus_t status;
+	MibRequestConfirm_t mibReq;
+
+	/* Retrieve the actual context */
+	mibReq.Type = MIB_NVM_CTXS;
+	if (LoRaMacMibGetRequestConfirm(&mibReq) != LORAMAC_STATUS_OK) {
+		LOG_ERR("Could not get NVM context");
+		return -EINVAL;
+	}
+
+	err = settings_load_subtree_direct(LORAWAN_SETTINGS_BASE,
+					   on_setting_loaded,
+					   mibReq.Param.Contexts);
+	if (err) {
+		LOG_ERR("Could not load LoRaWAN settings, error %d", err);
+		return err;
+	}
+
+	LOG_DBG("LoRaWAN context restored");
+	LOG_DBG("Crypto version: %"PRIu32", DevNonce: %d, JoinNonce: %"PRIu32,
+		mibReq.Param.Contexts->Crypto.LrWanVersion.Value,
+		mibReq.Param.Contexts->Crypto.DevNonce,
+		mibReq.Param.Contexts->Crypto.JoinNonce);
+
+	mibReq.Type = MIB_NVM_CTXS;
+	status = LoRaMacMibSetRequestConfirm(&mibReq);
+	if (status != LORAMAC_STATUS_OK) {
+		LOG_ERR("Could not set the NVM context, error %d", status);
+		return -EINVAL;
+	}
+
+	return 0;
+}

--- a/subsys/lorawan/se/CMakeLists.txt
+++ b/subsys/lorawan/se/CMakeLists.txt
@@ -1,0 +1,6 @@
+zephyr_library_sources(lorawan_se.c)
+add_subdirectory_ifdef(CONFIG_LORAWAN_SE_SETTINGS settings-se)
+
+if (CONFIG_LORAWAN_SE_SETTINGS)
+    zephyr_compile_definitions(MBEDTLS_CMAC_C)
+endif ()

--- a/subsys/lorawan/se/Kconfig
+++ b/subsys/lorawan/se/Kconfig
@@ -1,0 +1,38 @@
+# LoRaWAN Secure Element configuration options
+
+# Copyright (c) 2021 Intellinium <giuliano.franchetto@intellinium.com>
+# SPDX-License-Identifier: Apache-2.0
+
+config LORAWAN_SE_HAS_OWN_NVM
+	bool
+
+choice LORAWAN_SE
+	bool "LoRaWAN Secure element backend"
+	default LORAWAN_SE_SETTINGS if SETTINGS
+	default LORAWAN_SE_SOFT
+
+config LORAWAN_SE_SOFT
+	bool "Software secure element backend"
+
+config LORAWAN_SE_SETTINGS
+	bool "nRFx series Key management secure element backend"
+	select MBEDTLS
+	depends on SETTINGS
+	help
+	  This option also links mbedTLS to manage all the
+	  cryptographic operations.
+
+endchoice
+
+config LORAWAN_SE_GENERATE_DEVEUI
+	bool "Generate devEUI automatically using hardware information"
+	select HWINFO
+	help
+	  The devEUI will be generated using the unique
+	  identifier of the board.
+	  If this option is enabled, the devEUI shall never be
+	  updated.
+
+if (LORAWAN_SE_SETTINGS)
+rsource "settings-se/Kconfig"
+endif

--- a/subsys/lorawan/se/lorawan_se.c
+++ b/subsys/lorawan/se/lorawan_se.c
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2021 Intellinium <giuliano.franchetto@intellinium.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "lorawan_se.h"
+#include <secure-element.h>
+
+/**
+ * Active Secure Element used by the LoRaWAN stack
+ * Must be set before any operation is done by the LoRaWAN stack
+ */
+static const struct lorawan_se *active_se;
+
+void lorawan_se_register(const struct lorawan_se *se)
+{
+	__ASSERT(!active_se,
+		 "Only one Secure Element can be active at all time");
+	__ASSERT_NO_MSG(se->get_joineui);
+	__ASSERT_NO_MSG(se->set_joineui);
+	__ASSERT_NO_MSG(se->get_pin);
+	__ASSERT_NO_MSG(se->set_pin);
+	__ASSERT_NO_MSG(se->set_deveui);
+	__ASSERT_NO_MSG(se->get_deveui);
+	__ASSERT_NO_MSG(se->init);
+	__ASSERT_NO_MSG(se->set_key);
+	__ASSERT_NO_MSG(se->compute_cmac);
+	__ASSERT_NO_MSG(se->verify_cmac);
+	__ASSERT_NO_MSG(se->encrypt);
+	__ASSERT_NO_MSG(se->derive);
+	__ASSERT_NO_MSG(se->process_join_accept);
+
+	active_se = se;
+}
+
+int lorawan_se_update(SecureElementNvmData_t *data)
+{
+	__ASSERT(active_se, "No Secure Element is registered");
+
+	return active_se->update(data);
+}
+
+SecureElementStatus_t SecureElementInit(SecureElementNvmData_t *nvm)
+{
+	__ASSERT(active_se, "No Secure Element is registered");
+
+	return active_se->init(nvm);
+}
+
+SecureElementStatus_t SecureElementSetKey(KeyIdentifier_t keyID, uint8_t *key)
+{
+	__ASSERT(active_se, "No Secure Element is registered");
+
+	return active_se->set_key(keyID, key);
+}
+
+SecureElementStatus_t SecureElementComputeAesCmac(uint8_t *micBxBuffer,
+						  uint8_t *buffer,
+						  uint16_t size,
+						  KeyIdentifier_t keyID,
+						  uint32_t *cmac)
+{
+	__ASSERT(active_se, "No Secure Element is registered");
+
+	return active_se->compute_cmac(micBxBuffer,
+				       buffer,
+				       size,
+				       keyID,
+				       cmac);
+}
+
+SecureElementStatus_t SecureElementVerifyAesCmac(uint8_t *buffer,
+						 uint16_t size,
+						 uint32_t expectedCmac,
+						 KeyIdentifier_t keyID)
+{
+	__ASSERT(active_se, "No Secure Element is registered");
+
+	return active_se->verify_cmac(buffer, size, expectedCmac, keyID);
+}
+
+SecureElementStatus_t SecureElementAesEncrypt(uint8_t *buffer,
+					      uint16_t size,
+					      KeyIdentifier_t keyID,
+					      uint8_t *encBuffer)
+{
+	__ASSERT(active_se, "No Secure Element is registered");
+
+	return active_se->encrypt(buffer, size, keyID, encBuffer);
+}
+
+SecureElementStatus_t
+SecureElementDeriveAndStoreKey(uint8_t *input,
+			       KeyIdentifier_t rootKeyID,
+			       KeyIdentifier_t targetKeyID)
+{
+	__ASSERT(active_se, "No Secure Element is registered");
+
+	return active_se->derive(input, rootKeyID, targetKeyID);
+}
+
+SecureElementStatus_t
+SecureElementProcessJoinAccept(JoinReqIdentifier_t joinReqType,
+			       uint8_t *joinEui,
+			       uint16_t devNonce,
+			       uint8_t *encJoinAccept,
+			       uint8_t encJoinAcceptSize,
+			       uint8_t *decJoinAccept,
+			       uint8_t *versionMinor)
+{
+	__ASSERT(active_se, "No Secure Element is registered");
+
+	return active_se->process_join_accept(joinReqType,
+					      joinEui,
+					      devNonce,
+					      encJoinAccept,
+					      encJoinAcceptSize,
+					      decJoinAccept,
+					      versionMinor);
+}
+
+SecureElementStatus_t SecureElementSetDevEui(uint8_t *devEui)
+{
+	__ASSERT(active_se, "No Secure Element is registered");
+
+	return active_se->set_deveui(devEui);
+}
+
+uint8_t *SecureElementGetDevEui(void)
+{
+	__ASSERT(active_se, "No Secure Element is registered");
+
+	return active_se->get_deveui();
+}
+
+SecureElementStatus_t SecureElementSetJoinEui(uint8_t *joinEui)
+{
+	__ASSERT(active_se, "No Secure Element is registered");
+
+	return active_se->set_joineui(joinEui);
+}
+
+uint8_t *SecureElementGetJoinEui(void)
+{
+	__ASSERT(active_se, "No Secure Element is registered");
+
+	return active_se->get_joineui();
+}
+
+SecureElementStatus_t SecureElementSetPin(uint8_t *pin)
+{
+	__ASSERT(active_se, "No Secure Element is registered");
+
+	return active_se->set_pin(pin);
+}
+
+uint8_t *SecureElementGetPin(void)
+{
+	__ASSERT(active_se, "No Secure Element is registered");
+
+	return active_se->get_pin();
+}

--- a/subsys/lorawan/se/lorawan_se.h
+++ b/subsys/lorawan/se/lorawan_se.h
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2021 Intellinium <giuliano.franchetto@intellinium.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef LORAWAN_SE_H
+#define LORAWAN_SE_H
+
+#include <zephyr.h>
+#include <secure-element-nvm.h>
+
+struct lorawan_se {
+	/**
+	 * Initialization of Secure Element driver
+	 *
+	 * @param nvm	Pointer to the non-volatile memory data
+	 *		structure.
+	 * @return	Status of the operation
+	 */
+	int (*init)(SecureElementNvmData_t *data);
+
+	/**
+	 * Updates the data stored by the Secure Element driver
+	 *
+	 * @param nvm	Pointer to the non-volatile memory data
+	 *		structure.
+	 * @return	Status of the operation
+	 */
+	int (*update)(SecureElementNvmData_t *data);
+
+	/**
+	 * Sets a key
+	 *
+	 * @param keyID		Key identifier
+	 * @param key		Key value
+	 * @return		Status of the operation
+	 */
+	int (*set_key)(KeyIdentifier_t keyID, uint8_t *key);
+
+	/**
+	 * Computes a CMAC of a message using provided initial Bx block
+	 *
+	 * @param micBxBuffer	Buffer containing the initial Bx block
+	 * @param buffer	Data buffer
+	 * @param size		Data buffer size
+	 * @param keyID		Key identifier to determine the AES
+	 *			key to be used
+	 * @param cmac		Computed cmac
+	 * @return		Status of the operation
+	 */
+	int (*compute_cmac)(uint8_t *micBxBuffer,
+			    uint8_t *buffer, uint16_t size,
+			    KeyIdentifier_t keyID, uint32_t *cmac);
+
+	/**
+	 * Verifies a CMAC (computes and compare with expected cmac)
+	 *
+	 * @param buffer	Data buffer
+	 * @param size		Data buffer size
+	 * @param expectedCmac	Expected cmac
+	 * @param keyID		Key identifier to determine the AES
+	 *			key to be used
+	 * @return		Status of the operation
+	 */
+	int (*verify_cmac)(uint8_t *buffer, uint16_t size,
+			   uint32_t expectedCmac, KeyIdentifier_t keyID);
+
+	/**
+	 * Encrypt a buffer
+	 *
+	 * @param buffer	Data buffer
+	 * @param size		Data buffer size
+	 * @param keyID		Key identifier to determine the AES
+	 *			key to be used
+	 * @param encBuffer	Encrypted buffer
+	 * @return		Status of the operation
+	 */
+	int (*encrypt)(uint8_t *buffer, uint16_t size,
+		       KeyIdentifier_t keyID, uint8_t *encBuffer);
+
+	/**
+	 * Derives and store a key
+	 *
+	 * @param input		Input data from which the key
+	 *			is derived ( 16 byte )
+	 * @param rootKeyID	Key identifier of the root key to use
+	 *			to perform the derivation
+	 * @param targetKeyID	Key identifier of the key which will be derived
+	 * @return		Status of the operation
+	 */
+	int (*derive)(uint8_t *input,
+		      KeyIdentifier_t rootKeyID,
+		      KeyIdentifier_t targetKeyID);
+
+	/**
+	 * Process JoinAccept message.
+	 *
+	 * \param encJoinAccept		Received encrypted JoinAccept message
+	 * \param encJoinAcceptSize	Received encrypted JoinAccept
+	 *				message Size
+	 * \param decJoinAccept		Decrypted and validated JoinAccept
+	 *				message
+	 * \param versionMinor		Detected LoRaWAN specification version
+	 *				minor field.
+	 *					0 -> LoRaWAN 1.0.x
+	 *					1 -> LoRaWAN 1.1.x
+	 * @return			Status of the operation
+	 */
+	int (*process_join_accept)(JoinReqIdentifier_t joinReqType,
+				   uint8_t *joinEui,
+				   uint16_t devNonce,
+				   uint8_t *encJoinAccept,
+				   uint8_t encJoinAcceptSize,
+				   uint8_t *decJoinAccept,
+				   uint8_t *versionMinor);
+
+	/**
+	 * Sets the DevEUI
+	 *
+	 * @param devEui	Pointer to the 8-byte devEUI
+	 * @return		Status of the operation
+	 */
+	int (*set_deveui)(uint8_t *devEui);
+
+	/**
+	 * Gets the DevEUI
+	 *
+	 * @return		Pointer to the 8-byte devEUI
+	 */
+	uint8_t *(*get_deveui)(void);
+
+	/**
+	 * Sets the JoinEUI
+	 *
+	 * @param joinEui	Pointer to the 8-byte joinEui
+	 * @return		Status of the operation
+	 */
+	int (*set_joineui)(uint8_t *joinEui);
+
+	/**
+	 * Gets the DevEUI
+	 *
+	 * @return		Pointer to the 8-byte joinEui
+	 */
+	uint8_t *(*get_joineui)(void);
+
+	/**
+	 * Sets the pin
+	 *
+	 * @param pin		Pointer to the 4-byte pin
+	 * @return		Status of the operation
+	 */
+	int (*set_pin)(uint8_t *pin);
+
+	/**
+	 * Gets the Pin
+	 *
+	 * @return		Pointer to the 4-byte pin
+	 */
+	uint8_t *(*get_pin)(void);
+};
+
+/**
+ * Registers an active Secure Element that will be used by the LoRaWAN stack
+ *
+ * The pointer must remain valid all the time
+ *
+ * @param se	The secure element
+ */
+void lorawan_se_register(const struct lorawan_se *se);
+
+/**
+ * Updates the data stored by the Secure Element driver
+ *
+ * @param data	Pointer to the non-volatile memory data
+ *		structure.
+ * @return	Status of the operation
+ */
+int lorawan_se_update(SecureElementNvmData_t *data);
+
+#if defined(CONFIG_LORAWAN_SE_SETTINGS_USE_ENCRYPTED)
+int lorawan_se_set_enc_key(const uint8_t *enc_key, size_t size);
+#endif
+
+#endif /* LORAWAN_SE_H */

--- a/subsys/lorawan/se/settings-se/CMakeLists.txt
+++ b/subsys/lorawan/se/settings-se/CMakeLists.txt
@@ -1,0 +1,4 @@
+zephyr_library_sources(settings_se.c)
+zephyr_library_sources(settings_se_settings.c)
+
+zephyr_link_libraries(mbedTLS)

--- a/subsys/lorawan/se/settings-se/Kconfig
+++ b/subsys/lorawan/se/settings-se/Kconfig
@@ -1,0 +1,8 @@
+# LoRaWAN Secure Element settings configuration options
+
+# Copyright (c) 2021 Intellinium <giuliano.franchetto@intellinium.com>
+# SPDX-License-Identifier: Apache-2.0
+
+config LORAWAN_SE_SETTINGS_USE_ENCRYPTED
+	bool "Encrypt keys stored in settings"
+	default n

--- a/subsys/lorawan/se/settings-se/settings_se.c
+++ b/subsys/lorawan/se/settings-se/settings_se.c
@@ -1,0 +1,554 @@
+/*
+ * Copyright (c) 2021 Intellinium <giuliano.franchetto@intellinium.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+#include <string.h>
+#include <nrfx.h>
+#if defined(CONFIG_LORAWAN_SE_GENERATE_DEVEUI)
+#include <drivers/hwinfo.h>
+#endif
+
+#include "LoRaMacHeaderTypes.h"
+
+#include "secure-element.h"
+#include "secure-element-nvm.h"
+#include "settings_se_priv.h"
+#include <logging/log.h>
+#include <mbedtls/aes.h>
+#include <mbedtls/cipher.h>
+#include <mbedtls/cmac.h>
+#include "../lorawan_se.h"
+
+LOG_MODULE_REGISTER(settings_se, CONFIG_LORAWAN_LOG_LEVEL);
+
+static SecureElementNvmData_t *se_nvm;
+
+#if defined(CONFIG_LORAWAN_SE_SETTINGS_USE_ENCRYPTED)
+static const uint8_t *enc_key;
+static size_t enc_key_size;
+#endif
+
+#if defined(CONFIG_LORAWAN_SE_GENERATE_DEVEUI)
+static int settings_gen_deveui(uint8_t *buf)
+{
+	ssize_t len;
+
+	len = hwinfo_get_device_id(buf, 8);
+	if (len < 0) {
+		return len;
+	}
+
+	__ASSERT_NO_MSG(len == 8);
+	return 0;
+}
+
+static int settings_se_check_or_gen_deveui(SecureElementNvmData_t *nvm)
+{
+	int err;
+	bool init = false;
+	uint8_t devEUI[8] = {0};
+
+	for (int i = 0; i < sizeof(nvm->DevEui); i++) {
+		if (nvm->DevEui[i] != 0x00) {
+			init = true;
+			break;
+		}
+	}
+
+	err = settings_gen_deveui(devEUI);
+	if (err) {
+		return err;
+	}
+
+	if (!init) {
+		memcpy(nvm->DevEui, devEUI, 8);
+	} else {
+		__ASSERT(memcmp(nvm->DevEui, devEUI, 8) == 0,
+			 "The stored devEUI is not the generated one!");
+	}
+
+	return 0;
+}
+#endif
+
+#if defined(CONFIG_LORAWAN_SE_SETTINGS_USE_ENCRYPTED)
+static int settings_se_encrypt_key(uint8_t *in, uint8_t *out)
+{
+	int err;
+	mbedtls_aes_context ctx = {0};
+
+	mbedtls_aes_init(&ctx);
+
+	err = mbedtls_aes_setkey_enc(&ctx, enc_key, 8 * enc_key_size);
+	if (err != 0) {
+		LOG_ERR("Could not set key, error %d", err);
+		mbedtls_aes_free(&ctx);
+		return SECURE_ELEMENT_ERROR;
+	}
+
+	mbedtls_internal_aes_encrypt(&ctx, in, out);
+	mbedtls_aes_free(&ctx);
+
+	return 0;
+}
+
+static int settings_se_decrypt_key(uint8_t *in, uint8_t *out)
+{
+	int err;
+	mbedtls_aes_context ctx = {0};
+
+	mbedtls_aes_init(&ctx);
+	err = mbedtls_aes_setkey_dec(&ctx, enc_key, 8 * enc_key_size);
+	if (err != 0) {
+		mbedtls_aes_free(&ctx);
+		return SECURE_ELEMENT_ERROR;
+	}
+
+	mbedtls_internal_aes_decrypt(&ctx, in, out);
+	mbedtls_aes_free(&ctx);
+
+	return SECURE_ELEMENT_SUCCESS;
+}
+#endif
+
+static int settings_se_init(SecureElementNvmData_t *nvm)
+{
+	se_nvm = nvm;
+
+#if defined(CONFIG_LORAWAN_SE_GENERATE_DEVEUI)
+	int err;
+
+	err = settings_se_check_or_gen_deveui(nvm);
+	if (err) {
+		return err;
+	}
+#endif
+
+	/* Nothing to do with JoinEUI as it is managed by the
+	 * NVM backend, as the JoinEUI is public
+	 */
+
+	return SECURE_ELEMENT_SUCCESS;
+}
+
+static int settings_se_set_key(KeyIdentifier_t keyID, uint8_t *key)
+{
+	int err = 0;
+	struct settings_se_key se_key;
+
+	if (!key) {
+		return SECURE_ELEMENT_ERROR_NPE;
+	}
+
+	if (keyID == MC_KEY_0 ||
+		keyID == MC_KEY_1 ||
+		keyID == MC_KEY_2 ||
+		keyID == MC_KEY_3) {
+
+		if (SecureElementAesEncrypt(key,
+					    16,
+					    MC_KE_KEY,
+					    se_key.value)) {
+			return SECURE_ELEMENT_FAIL_ENCRYPT;
+		}
+	}
+
+#if defined(CONFIG_LORAWAN_SE_SETTINGS_USE_ENCRYPTED)
+	err = settings_se_encrypt_key(key, se_key.value);
+	if (err) {
+		return err;
+	}
+#else
+	memcpy(se_key.value, key, 16);
+#endif
+	err = settings_se_keys_save(keyID, &se_key);
+	if (err) {
+		LOG_ERR("Could not save key, error %d", err);
+		return SECURE_ELEMENT_ERROR;
+	}
+
+	return SECURE_ELEMENT_SUCCESS;
+}
+
+static int settings_se_get_decrypted_key(KeyIdentifier_t id, uint8_t *out)
+{
+	int err;
+	struct settings_se_key se_key;
+
+	err = settings_se_keys_load(id, &se_key);
+	if (err) {
+		return err;
+	}
+
+#if defined(CONFIG_LORAWAN_SE_SETTINGS_USE_ENCRYPTED)
+	err = settings_se_decrypt_key(se_key.value, out);
+	if (err) {
+		return err;
+	}
+#else
+	memcpy(out, se_key.value, 16);
+#endif
+	return SECURE_ELEMENT_SUCCESS;
+}
+
+/** Computes a CMAC of a message using provided initial Bx block
+ *
+ *  cmac = aes128_cmac(keyID, blocks[i].Buffer)
+ *
+ * @param[IN]  micBxBuffer    - Buffer containing the initial Bx block
+ * @param[IN]  buffer         - Data buffer
+ * @param[IN]  size           - Data buffer size
+ * @param[IN]  keyID          - Key identifier to determine the AES key to be used
+ * @param[OUT] cmac           - Computed cmac
+ * @retval                    - Status of the operation
+ */
+static SecureElementStatus_t compute_cmac(uint8_t *micBxBuffer,
+					  uint8_t *buffer,
+					  uint16_t size,
+					  KeyIdentifier_t keyID,
+					  uint32_t *cmac)
+{
+	int err;
+	uint8_t cmac_val[16];
+	uint8_t key[16] = {0};
+	mbedtls_cipher_context_t m_ctx;
+	const mbedtls_cipher_info_t *cipher_info;
+
+	if (!buffer || !cmac) {
+		return SECURE_ELEMENT_ERROR_NPE;
+	}
+
+	cipher_info = mbedtls_cipher_info_from_type(MBEDTLS_CIPHER_AES_128_ECB);
+	if (!cipher_info) {
+		return SECURE_ELEMENT_FAIL_CMAC;
+	}
+
+	mbedtls_cipher_init(&m_ctx);
+
+	if (mbedtls_cipher_setup(&m_ctx, cipher_info)) {
+		mbedtls_cipher_free(&m_ctx);
+		return SECURE_ELEMENT_FAIL_CMAC;
+	}
+
+	err = settings_se_get_decrypted_key(keyID, key);
+	if (err) {
+		mbedtls_cipher_free(&m_ctx);
+		return err;
+	}
+
+	err = mbedtls_cipher_cmac_starts(&m_ctx, key, 16 * 8);
+	if (err) {
+		mbedtls_cipher_free(&m_ctx);
+		return SECURE_ELEMENT_FAIL_CMAC;
+	}
+
+	if (micBxBuffer != NULL) {
+		err = mbedtls_cipher_cmac_update(&m_ctx, micBxBuffer, 16);
+		if (err) {
+			mbedtls_cipher_free(&m_ctx);
+			return SECURE_ELEMENT_FAIL_CMAC;
+		}
+	}
+
+	err = mbedtls_cipher_cmac_update(&m_ctx, buffer, size);
+	if (err) {
+		mbedtls_cipher_free(&m_ctx);
+		return SECURE_ELEMENT_FAIL_CMAC;
+	}
+
+	err = mbedtls_cipher_cmac_finish(&m_ctx, cmac_val);
+	if (err) {
+		mbedtls_cipher_free(&m_ctx);
+		return SECURE_ELEMENT_FAIL_CMAC;
+	}
+
+	*cmac = (uint32_t) ((uint32_t) cmac_val[3] << 24 |
+		(uint32_t) cmac_val[2] << 16 |
+		(uint32_t) cmac_val[1] << 8 |
+		(uint32_t) cmac_val[0]);
+
+	mbedtls_cipher_free(&m_ctx);
+	return SECURE_ELEMENT_SUCCESS;
+}
+
+static int settings_se_compute_cmac(uint8_t *micBxBuffer,
+				    uint8_t *buffer,
+				    uint16_t size,
+				    KeyIdentifier_t keyID,
+				    uint32_t *cmac)
+{
+	if (keyID >= LORAMAC_CRYPTO_MULTICAST_KEYS) {
+		return SECURE_ELEMENT_ERROR_INVALID_KEY_ID;
+	}
+
+	return compute_cmac(micBxBuffer, buffer, size, keyID, cmac);
+}
+
+static int settings_se_verify_cmac(uint8_t *buffer, uint16_t size,
+				   uint32_t expectedCmac,
+				   KeyIdentifier_t keyID)
+{
+	uint32_t compCmac = 0;
+	SecureElementStatus_t err;
+
+	if (buffer == NULL) {
+		return SECURE_ELEMENT_ERROR_NPE;
+	}
+
+	err = compute_cmac(NULL, buffer, size, keyID, &compCmac);
+	if (err != SECURE_ELEMENT_SUCCESS) {
+		return err;
+	}
+
+	if (expectedCmac != compCmac) {
+		err = SECURE_ELEMENT_FAIL_CMAC;
+	}
+
+	return err;
+}
+
+static int settings_se_encrypt(uint8_t *buffer,
+			       uint16_t size,
+			       KeyIdentifier_t keyID,
+			       uint8_t *encBuffer)
+{
+	uint8_t local_key[16] = {0};
+	SecureElementStatus_t err;
+	mbedtls_aes_context ctx = {0};
+
+	if (!buffer || !encBuffer) {
+		return SECURE_ELEMENT_ERROR_NPE;
+	}
+
+	/* Check if the size is divisible by 16 */
+	if ((size % 16) != 0) {
+		return SECURE_ELEMENT_ERROR_BUF_SIZE;
+	}
+
+	err = settings_se_get_decrypted_key(keyID, local_key);
+	if (err) {
+		return err;
+	}
+
+	mbedtls_aes_init(&ctx);
+
+	err = mbedtls_aes_setkey_enc(&ctx, local_key, 8 * 16);
+	if (err != 0) {
+		memset(local_key, 0, 16);
+		mbedtls_aes_free(&ctx);
+		LOG_ERR("Could not set shadow KMU ECB encrypt key.");
+		return err;
+	}
+
+	for (int i = 0; i < size / 16; i++) {
+		mbedtls_internal_aes_encrypt(&ctx,
+					     &buffer[i * 16],
+					     &encBuffer[i * 16]);
+	}
+
+	memset(local_key, 0, 16);
+	mbedtls_aes_free(&ctx);
+
+	return 0;
+}
+
+static int settings_se_derive(uint8_t *input,
+			      KeyIdentifier_t rootKeyID,
+			      KeyIdentifier_t targetKeyID)
+{
+	uint8_t key[16] = {0};
+	SecureElementStatus_t err;
+
+	if (!input) {
+		return SECURE_ELEMENT_ERROR_NPE;
+	}
+
+	/* In case of MC_KE_KEY, only McRootKey can be used as root key */
+	if (targetKeyID == MC_KE_KEY && rootKeyID != MC_ROOT_KEY) {
+		return SECURE_ELEMENT_ERROR_INVALID_KEY_ID;
+	}
+
+	err = SecureElementAesEncrypt(input, 16, rootKeyID, key);
+	if (err != SECURE_ELEMENT_SUCCESS) {
+		return err;
+	}
+
+	err = SecureElementSetKey(targetKeyID, key);
+	if (err != SECURE_ELEMENT_SUCCESS) {
+		return err;
+	}
+
+	return SECURE_ELEMENT_SUCCESS;
+}
+
+int settings_process_join_accept(JoinReqIdentifier_t joinReqType,
+				 uint8_t *joinEui,
+				 uint16_t devNonce,
+				 uint8_t *encJoinAccept,
+				 uint8_t encJoinAcceptSize,
+				 uint8_t *decJoinAccept,
+				 uint8_t *versionMinor)
+{
+#if (USE_LRWAN_1_1_X_CRYPTO == 0)
+	ARG_UNUSED(joinEui);
+	ARG_UNUSED(devNonce);
+#endif
+
+	uint32_t mic;
+	KeyIdentifier_t encKeyID = NWK_KEY;
+
+	if (!encJoinAccept ||
+		!decJoinAccept ||
+		!versionMinor) {
+		return SECURE_ELEMENT_ERROR_NPE;
+	}
+
+	/* Check that frame size isn't bigger than a
+	 * JoinAccept with CFList size
+	 */
+	if (encJoinAcceptSize > LORAMAC_JOIN_ACCEPT_FRAME_MAX_SIZE) {
+		return SECURE_ELEMENT_ERROR_BUF_SIZE;
+	}
+
+	if (joinReqType != JOIN_REQ) {
+		encKeyID = J_S_ENC_KEY;
+	}
+
+	memcpy(decJoinAccept, encJoinAccept, encJoinAcceptSize);
+
+	if (SecureElementAesEncrypt(encJoinAccept + LORAMAC_MHDR_FIELD_SIZE,
+				    encJoinAcceptSize - LORAMAC_MHDR_FIELD_SIZE,
+				    encKeyID,
+				    decJoinAccept + LORAMAC_MHDR_FIELD_SIZE)) {
+		return SECURE_ELEMENT_FAIL_ENCRYPT;
+	}
+
+	*versionMinor = ((decJoinAccept[11] & 0x80) == 0x80) ? 1 : 0;
+
+	mic = ((uint32_t) decJoinAccept[encJoinAcceptSize
+		- LORAMAC_MIC_FIELD_SIZE] << 0);
+	mic |= ((uint32_t) decJoinAccept[encJoinAcceptSize
+		- LORAMAC_MIC_FIELD_SIZE + 1] << 8);
+	mic |= ((uint32_t) decJoinAccept[encJoinAcceptSize
+		- LORAMAC_MIC_FIELD_SIZE + 2] << 16);
+	mic |= ((uint32_t) decJoinAccept[encJoinAcceptSize
+		- LORAMAC_MIC_FIELD_SIZE + 3] << 24);
+
+	/*  - Header buffer to be used for MIC computation
+	 *        - LoRaWAN 1.0.x : micHeader = [MHDR(1)]
+	 *        - LoRaWAN 1.1.x : micHeader = [JoinReqType(1), JoinEUI(8), DevNonce(2), MHDR(1)]
+	 */
+
+	/* Verify mic */
+	if (*versionMinor == 0) {
+		/* For LoRaWAN 1.0.x
+		 *   cmac = aes128_cmac(NwkKey, MHDR |  JoinNonce | NetID |
+		 *       DevAddr | DLSettings | RxDelay | CFList |
+		 *   CFListType)
+		 */
+		size_t size = encJoinAcceptSize - LORAMAC_MIC_FIELD_SIZE;
+
+		if (SecureElementVerifyAesCmac(decJoinAccept,
+					       size,
+					       mic,
+					       NWK_KEY)) {
+			return SECURE_ELEMENT_FAIL_CMAC;
+		}
+	}
+#if (USE_LRWAN_1_1_X_CRYPTO == 1)
+		/* TODO */
+#endif
+	else {
+		return SECURE_ELEMENT_ERROR_INVALID_LORAWAM_SPEC_VERSION;
+	}
+
+	return SECURE_ELEMENT_SUCCESS;
+}
+
+static int settings_se_set_deveui(uint8_t *devEui)
+{
+#if defined(CONFIG_LORAWAN_SE_GENERATE_DEVEUI)
+	ARG_UNUSED(devEui);
+
+	return SECURE_ELEMENT_SUCCESS;
+#else
+	if (!devEui) {
+		return SECURE_ELEMENT_ERROR_NPE;
+	}
+	memcpy(se_nvm->DevEui, devEui, SE_EUI_SIZE);
+	return SECURE_ELEMENT_SUCCESS;
+#endif
+}
+
+uint8_t *settings_get_deveui(void)
+{
+	return se_nvm->DevEui;
+}
+
+static int settings_se_set_join_eui(uint8_t *joinEui)
+{
+	if (!joinEui) {
+		return SECURE_ELEMENT_ERROR_NPE;
+	}
+
+	memcpy(se_nvm->JoinEui, joinEui, SE_EUI_SIZE);
+
+	return SECURE_ELEMENT_SUCCESS;
+}
+
+uint8_t *settings_get_join_eui(void)
+{
+	return se_nvm->JoinEui;
+}
+
+static int settings_se_set_pin(uint8_t *pin)
+{
+	ARG_UNUSED(pin);
+
+	return SECURE_ELEMENT_SUCCESS;
+}
+
+uint8_t *settings_se_get_pin(void)
+{
+	return se_nvm->Pin;
+}
+
+#if defined(CONFIG_LORAWAN_SE_SETTINGS_USE_ENCRYPTED)
+int lorawan_se_set_enc_key(const uint8_t *key, size_t size)
+{
+	enc_key = key;
+	enc_key_size = size;
+
+	return 0;
+}
+#endif
+
+static const struct lorawan_se settings_se = {
+	.init = settings_se_init,
+	.set_key = settings_se_set_key,
+	.compute_cmac = settings_se_compute_cmac,
+	.verify_cmac = settings_se_verify_cmac,
+	.encrypt = settings_se_encrypt,
+	.derive = settings_se_derive,
+	.process_join_accept = settings_process_join_accept,
+	.set_deveui = settings_se_set_deveui,
+	.get_deveui = settings_get_deveui,
+	.set_joineui = settings_se_set_join_eui,
+	.get_joineui = settings_get_join_eui,
+	.set_pin = settings_se_set_pin,
+	.get_pin = settings_se_get_pin
+};
+
+#include <init.h>
+static int settings_se_register(const struct device *device)
+{
+	ARG_UNUSED(device);
+
+	lorawan_se_register(&settings_se);
+
+	return 0;
+}
+SYS_INIT(settings_se_register, POST_KERNEL, 0);

--- a/subsys/lorawan/se/settings-se/settings_se_priv.h
+++ b/subsys/lorawan/se/settings-se/settings_se_priv.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2021 Intellinium <giuliano.franchetto@intellinium.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef SETTINGS_SE_PRIV_H
+#define SETTINGS_SE_PRIV_H
+
+#include <zephyr/types.h>
+#include <LoRaMacTypes.h>
+
+struct settings_se_key {
+	/*!
+	 * Key value
+	 */
+	uint8_t value[16];
+
+	/*!
+	 * Random used for derivation
+	 */
+	uint8_t random[32];
+};
+
+int settings_se_keys_load(KeyIdentifier_t id, struct settings_se_key *key);
+
+int settings_se_keys_save(KeyIdentifier_t id, struct settings_se_key *key);
+
+#endif /* SETTINGS_SE_PRIV_H */

--- a/subsys/lorawan/se/settings-se/settings_se_settings.c
+++ b/subsys/lorawan/se/settings-se/settings_se_settings.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2021 Intellinium <giuliano.franchetto@intellinium.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "settings_se_priv.h"
+#include <zephyr.h>
+#include <settings/settings.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <logging/log.h>
+LOG_MODULE_REGISTER(lorawan_nrfx_se_sng, CONFIG_LORAWAN_LOG_LEVEL);
+
+#define LORAWAN_KEYS_SETTINGS_BASE                "lorawan/keys"
+
+static int load_setting(void *tgt, size_t tgt_size,
+			const char *key, size_t len,
+			settings_read_cb read_cb, void *cb_arg)
+{
+	if (len != tgt_size) {
+		return -EINVAL;
+	}
+
+	if (!tgt) {
+		return -EINVAL;
+	}
+
+	if (read_cb(cb_arg, tgt, len) != len) {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+K_SEM_DEFINE(nrfx_keys_sem, 1, 1)
+
+static KeyIdentifier_t current_id;
+
+static int on_setting_loaded(const char *key, size_t len,
+			     settings_read_cb read_cb,
+			     void *cb_arg, void *param)
+{
+	int err;
+	struct settings_se_key *se_key = param;
+
+	if (atoi(key) == current_id) {
+		err = load_setting(se_key,
+				   sizeof(*se_key),
+				   key, len, read_cb, cb_arg);
+		if (err) {
+			return err;
+		}
+
+		return 0;
+	}
+
+	return 0;
+}
+
+int settings_se_keys_load(KeyIdentifier_t id, struct settings_se_key *key)
+{
+	int err;
+
+	k_sem_take(&nrfx_keys_sem, K_FOREVER);
+
+	current_id = id;
+	err = settings_load_subtree_direct(LORAWAN_KEYS_SETTINGS_BASE,
+					   on_setting_loaded,
+					   key);
+
+	k_sem_give(&nrfx_keys_sem);
+
+	return err;
+}
+
+int settings_se_keys_save(KeyIdentifier_t id, struct settings_se_key *key)
+{
+	int err;
+	char path[sizeof(LORAWAN_KEYS_SETTINGS_BASE) + 1 + 4] = {0};
+
+	k_sem_take(&nrfx_keys_sem, K_FOREVER);
+
+	sprintf(path, LORAWAN_KEYS_SETTINGS_BASE"/%d", id);
+	err = settings_save_one(path, key, sizeof(*key));
+
+	k_sem_give(&nrfx_keys_sem);
+
+	return err;
+}


### PR DESCRIPTION
For now, I have removed all the cryptographic calls from the implementation, as it was originally done using Nordic specific modules (mostly HUK and CryptoCell).

- [x] Need to abstract the crypto layer to not store the keys unencrytped on the flash
- [x] Various crypto must be managed, with great modularity. That will come from the fact that crypto API are very low-level stuff, and vendor dependent. I don't think you will have a Zephyr abstraction layer that will fit all use cases.
- [ ] Cryptos may come from west sub-project, and not zephyr tree

A more low-level implementation with key encryption using a daughter key can be found on the NCS repo: https://github.com/nrfconnect/sdk-zephyr/pull/678

Signed-off-by: Giuliano Franchetto <giuliano.franchetto@intellinium.com>