### PR TITLE
drivers: uart: esp32: set device to initialize pre-kernel

### DIFF
--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -551,7 +551,7 @@ DEVICE_DT_DEFINE(DT_NODELABEL(uart##idx),				       \
 		    NULL,				       \
 		    &uart_esp32_data_##idx,				       \
 		    &uart_esp32_cfg_port_##idx,				       \
-		    POST_KERNEL,					       \
+		    PRE_KERNEL_2,					       \
 		    CONFIG_SERIAL_INIT_PRIORITY,			       \
 		    &uart_esp32_api);
 


### PR DESCRIPTION
Uart post kernel initialization does not allow starting shell
properly. As UART driver depends on pinmux, uart requires
to be initialized as PRE_KERNEL_2.

Closes #40198 

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>