### PR TITLE
LE audio unicast client callbacks

### DIFF
--- a/include/bluetooth/audio.h
+++ b/include/bluetooth/audio.h
@@ -1172,10 +1172,82 @@ struct bt_audio_broadcast_sink_cb {
 
 /** @brief Stream operation. */
 struct bt_audio_stream_ops {
+	/** @brief Stream configured callback
+	 *
+	 *  Configured callback is called whenever an Audio Stream has been
+	 *  configured.
+	 *
+	 *  @param stream Stream object that has been configured.
+	 */
+	void (*configured)(struct bt_audio_stream *stream);
+
+	/** @brief Stream QoS set callback
+	 *
+	 *  QoS set callback is called whenever an Audio Stream Quality of
+	 *  Service has been set or updated.
+	 *
+	 *  @param stream Stream object that had its QoS updated.
+	 */
+	void (*qos_set)(struct bt_audio_stream *stream);
+
+	/** @brief Stream enabled callback
+	 *
+	 *  Enabled callback is called whenever an Audio Stream has been
+	 *  enabled.
+	 *
+	 *  @param stream Stream object that has been enabled.
+	 */
+	void (*enabled)(struct bt_audio_stream *stream);
+
+	/** @brief Stream started callback
+	 *
+	 *  Started callback is called whenever an Audio Stream has been started
+	 *  and will be usable for streaming.
+	 *
+	 *  @param stream Stream object that has been started.
+	 */
+	void (*started)(struct bt_audio_stream *stream);
+
+	/** @brief Stream metadata updated callback
+	 *
+	 *  Metadata Updated callback is called whenever an Audio Stream's
+	 *  metadata has been updated.
+	 *
+	 *  @param stream Stream object that had its metadata updated.
+	 */
+	void (*metadata_updated)(struct bt_audio_stream *stream);
+
+	/** @brief Stream disabled callback
+	 *
+	 *  Disabled callback is called whenever an Audio Stream has been
+	 *  disabled.
+	 *
+	 *  @param stream Stream object that has been disabled.
+	 */
+	void (*disabled)(struct bt_audio_stream *stream);
+
+	/** @brief Stream stopped callback
+	 *
+	 *  Stopped callback is called whenever an Audio Stream has been
+	 *  stopped.
+	 *
+	 *  @param stream Stream object that has been stopped.
+	 */
+	void (*stopped)(struct bt_audio_stream *stream);
+
+	/** @brief Stream released callback
+	 *
+	 *  Released callback is called whenever a Audio Stream has been
+	 *  released and can be deallocated.
+	 *
+	 *  @param stream Stream object that has been released.
+	 */
+	void (*released)(struct bt_audio_stream *stream);
+
 	/** @brief Stream connected callback
 	 *
-	 *  If this callback is provided it will be called whenever the
-	 *  connection completes.
+	 *  If this callback is provided it will be called when the
+	 *  isochronous stream is connected.
 	 *
 	 *  @param stream The stream that has been connected
 	 */
@@ -1183,8 +1255,8 @@ struct bt_audio_stream_ops {
 
 	/** @brief Stream disconnected callback
 	 *
-	 *  If this callback is provided it will be called whenever the
-	 *  stream is disconnected, including when a connection gets
+	 *  If this callback is provided it will be called when the
+	 *  isochronous stream is disconnected, including when a connection gets
 	 *  rejected.
 	 *
 	 *  @param stream The stream that has been Disconnected

--- a/include/bluetooth/audio.h
+++ b/include/bluetooth/audio.h
@@ -1487,16 +1487,18 @@ int bt_audio_discover(struct bt_conn *conn,
  *  remote endpoint, local capability and codec configuration.
  *
  *  @param conn Connection object
+ *  @param stream Stream object being configured
  *  @param ep Remote Audio Endpoint being configured
  *  @param cap Local Audio Capability being configured
  *  @param codec Codec configuration
  *
  *  @return Allocated Audio Stream object or NULL in case of error.
  */
-struct bt_audio_stream *bt_audio_stream_config(struct bt_conn *conn,
-					       struct bt_audio_ep *ep,
-					       struct bt_audio_capability *cap,
-					       struct bt_codec *codec);
+int bt_audio_stream_config(struct bt_conn *conn,
+			   struct bt_audio_stream *stream,
+			   struct bt_audio_ep *ep,
+			   struct bt_audio_capability *cap,
+			   struct bt_codec *codec);
 
 /** @brief Reconfigure Audio Stream
  *

--- a/samples/bluetooth/unicast_audio_client/src/main.c
+++ b/samples/bluetooth/unicast_audio_client/src/main.c
@@ -550,12 +550,12 @@ static int configure_stream(struct bt_audio_stream **stream)
 {
 	int err;
 
-	*stream = bt_audio_stream_config(default_conn, sinks[0],
-					 remote_capabilities[0],
-					 &preset_16_2_1.codec);
-	if (*stream == NULL) {
+	err = bt_audio_stream_config(default_conn, &audio_stream, sinks[0],
+				     remote_capabilities[0],
+				     &preset_16_2_1.codec);
+	if (err != 0) {
 		printk("Could not configure stream\n");
-		return -ENOENT;
+		return err;
 	}
 
 	err = k_sem_take(&sem_stream_configured, K_FOREVER);

--- a/subsys/bluetooth/host/audio/bap_internal.h
+++ b/subsys/bluetooth/host/audio/bap_internal.h
@@ -1,0 +1,11 @@
+/* @file
+ * @brief Internal APIs for BAP
+
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+int bap_config(struct bt_audio_stream *stream,
+	       struct bt_audio_capability *cap,
+	       struct bt_codec *codec);

--- a/subsys/bluetooth/host/audio/endpoint.c
+++ b/subsys/bluetooth/host/audio/endpoint.c
@@ -303,7 +303,8 @@ struct bt_audio_ep *bt_audio_ep_get(struct bt_conn *conn, uint8_t dir,
 static void ep_idle(struct bt_audio_ep *ep, struct net_buf_simple *buf)
 {
 	struct bt_audio_stream *stream = ep->stream;
-	/* Notify local capability */
+
+	/* Notify upper layer */
 	if (stream != NULL && stream->ops != NULL &&
 	    stream->ops->released != NULL) {
 		stream->ops->released(stream);
@@ -375,7 +376,7 @@ static void ep_config(struct bt_audio_ep *ep, struct net_buf_simple *buf)
 			      sys_le16_to_cpu(cfg->codec.vid),
 			      buf, cfg->cc_len, NULL);
 
-	/* Notify local capability */
+	/* Notify upper layer */
 	if (stream->ops != NULL && stream->ops->configured != NULL) {
 		stream->ops->configured(stream);
 	}
@@ -423,7 +424,7 @@ static void ep_qos(struct bt_audio_ep *ep, struct net_buf_simple *buf)
 		bt_audio_stream_disconnect(stream);
 	}
 
-	/* Notify local capability */
+	/* Notify upper layer */
 	if (stream->ops != NULL && stream->ops->qos_set != NULL) {
 		stream->ops->qos_set(stream);
 	}
@@ -452,7 +453,7 @@ static void ep_enabling(struct bt_audio_ep *ep, struct net_buf_simple *buf)
 
 	bt_audio_ep_set_metadata(ep, buf, enable->metadata_len, NULL);
 
-	/* Notify local capability */
+	/* Notify upper layer */
 	if (stream->ops != NULL && stream->ops->enabled != NULL) {
 		stream->ops->enabled(stream);
 	}
@@ -481,7 +482,7 @@ static void ep_streaming(struct bt_audio_ep *ep, struct net_buf_simple *buf)
 	BT_DBG("dir 0x%02x cig 0x%02x cis 0x%02x", stream->cap->type,
 	       ep->cig_id, ep->cis_id);
 
-	/* Notify local capability */
+	/* Notify upper layer */
 	if (stream->ops != NULL && stream->ops->started != NULL) {
 		stream->ops->started(stream);
 	}
@@ -508,7 +509,7 @@ static void ep_disabling(struct bt_audio_ep *ep, struct net_buf_simple *buf)
 	BT_DBG("dir 0x%02x cig 0x%02x cis 0x%02x", stream->cap->type,
 	       ep->cig_id, ep->cis_id);
 
-	/* Notify local capability */
+	/* Notify upper layer */
 	if (stream->ops != NULL && stream->ops->disabled != NULL) {
 		stream->ops->disabled(stream);
 	}
@@ -527,7 +528,7 @@ static void ep_releasing(struct bt_audio_ep *ep, struct net_buf_simple *buf)
 
 	BT_DBG("dir 0x%02x", stream->cap->type);
 
-	/* Notify local capability */
+	/* Notify upper layer */
 	if (stream->ops != NULL && stream->ops->stopped != NULL) {
 		stream->ops->stopped(stream);
 	}

--- a/subsys/bluetooth/shell/bap.c
+++ b/subsys/bluetooth/shell/bap.c
@@ -447,13 +447,22 @@ static int cmd_config(const struct shell *sh, size_t argc, char *argv[])
 		}
 	} else {
 		struct bt_audio_stream *stream;
+		int err;
 
-		stream = bt_audio_stream_config(default_conn, ep, cap,
-						&named_preset->preset.codec);
-		if (stream == NULL) {
-			shell_error(sh, "Unable to config stream");
-			return -ENOEXEC;
+		if (default_stream == NULL) {
+			stream = &streams[0];
+		} else {
+			stream = default_stream;
 		}
+
+		err = bt_audio_stream_config(default_conn, stream, ep, cap,
+					     &named_preset->preset.codec);
+		if (err != 0) {
+			shell_error(sh, "Unable to config stream: %d");
+			return err;
+		}
+
+		default_stream = stream;
 	}
 
 	shell_print(sh, "ASE config: preset %s", named_preset->name);

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/unicast_client_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/unicast_client_test.c
@@ -57,8 +57,6 @@ static int lc3_reconfig(struct bt_audio_stream *stream,
 
 	print_codec(codec);
 
-	SET_FLAG(flag_stream_configured);
-
 	return 0;
 }
 
@@ -68,8 +66,6 @@ static int lc3_qos(struct bt_audio_stream *stream, struct bt_codec_qos *qos)
 
 	print_qos(qos);
 
-	SET_FLAG(flag_stream_qos);
-
 	return 0;
 }
 
@@ -77,8 +73,6 @@ static int lc3_enable(struct bt_audio_stream *stream, uint8_t meta_count,
 		      struct bt_codec_data *meta)
 {
 	printk("Enable: stream %p meta_count %u\n", stream, meta_count);
-
-	SET_FLAG(flag_stream_enabled);
 
 	return 0;
 }
@@ -142,6 +136,52 @@ static struct bt_audio_capability caps[] = {
 	}
 };
 
+static void stream_configured(struct bt_audio_stream *stream)
+{
+	printk("Configured stream %p\n", stream);
+
+	SET_FLAG(flag_stream_configured);
+}
+
+static void stream_qos_set(struct bt_audio_stream *stream)
+{
+	printk("QoS set stream %p\n", stream);
+
+	SET_FLAG(flag_stream_qos);
+}
+
+static void stream_enabled(struct bt_audio_stream *stream)
+{
+	printk("Enabled stream %p\n", stream);
+
+	SET_FLAG(flag_stream_enabled);
+}
+
+static void stream_started(struct bt_audio_stream *stream)
+{
+	printk("Started stream %p\n", stream);
+}
+
+static void stream_metadata_updated(struct bt_audio_stream *stream)
+{
+	printk("Metadata updated stream %p\n", stream);
+}
+
+static void stream_disabled(struct bt_audio_stream *stream)
+{
+	printk("Disabled stream %p\n", stream);
+}
+
+static void stream_stopped(struct bt_audio_stream *stream)
+{
+	printk("Stopped stream %p\n", stream);
+}
+
+static void stream_released(struct bt_audio_stream *stream)
+{
+	printk("Released stream %p\n", stream);
+}
+
 static void stream_connected(struct bt_audio_stream *stream)
 {
 	printk("Audio Stream %p connected\n", stream);
@@ -154,8 +194,16 @@ static void stream_disconnected(struct bt_audio_stream *stream, uint8_t reason)
 }
 
 static struct bt_audio_stream_ops stream_ops = {
-	.connected	= stream_connected,
-	.disconnected	= stream_disconnected,
+	.configured = stream_configured,
+	.qos_set = stream_qos_set,
+	.enabled = stream_enabled,
+	.started = stream_started,
+	.metadata_updated = stream_metadata_updated,
+	.disabled = stream_disabled,
+	.stopped = stream_stopped,
+	.released = stream_released,
+	.connected = stream_connected,
+	.disconnected = stream_disconnected,
 };
 
 static void add_remote_sink(struct bt_audio_ep *ep, uint8_t index)


### PR DESCRIPTION
Update the unicast client to use the newly introduced stream callbacks, instead of relying on the capabilities callbacks. 

The callbacks can also, if wanted, be used by the unicast server, although not necessary. 