### PR TITLE
tests: correct some testsuite name

### DIFF
--- a/tests/kernel/mutex/mutex_error_case/src/test_mutex_error.c
+++ b/tests/kernel/mutex/mutex_error_case/src/test_mutex_error.c
@@ -211,7 +211,7 @@ void test_main(void)
 	k_thread_access_grant(k_current_get(), &tdata, &tstack,
 		       &mutex, &sem, &pipe, &queue);
 
-	ztest_test_suite(mutex_api,
+	ztest_test_suite(mutex_api_error,
 		 ztest_user_unit_test(test_mutex_init_null),
 		 ztest_user_unit_test(test_mutex_init_invalid_obj),
 		 ztest_user_unit_test(test_mutex_lock_null),
@@ -219,5 +219,5 @@ void test_main(void)
 		 ztest_user_unit_test(test_mutex_unlock_null),
 		 ztest_user_unit_test(test_mutex_unlock_invalid_obj)
 		 );
-	ztest_run_test_suite(mutex_api);
+	ztest_run_test_suite(mutex_api_error);
 }

--- a/tests/kernel/threads/thread_stack/src/main.c
+++ b/tests/kernel/threads/thread_stack/src/main.c
@@ -490,9 +490,9 @@ void test_main(void)
 	k_thread_system_pool_assign(k_current_get());
 
 	/* Run a thread that self-exits, triggering idle cleanup */
-	ztest_test_suite(userspace,
+	ztest_test_suite(userspace_thread_stack,
 			 ztest_1cpu_unit_test(test_stack_buffer),
 			 ztest_1cpu_unit_test(test_idle_stack)
 			 );
-	ztest_run_test_suite(userspace);
+	ztest_run_test_suite(userspace_thread_stack);
 }

--- a/tests/kernel/timer/timer_error_case/src/main.c
+++ b/tests/kernel/timer/timer_error_case/src/main.c
@@ -366,7 +366,7 @@ void test_timeout_end_calc(void)
 void test_main(void)
 {
 	k_thread_access_grant(k_current_get(), &tdata, &tstack, &mytimer, &sync_timer);
-	ztest_test_suite(timer_api,
+	ztest_test_suite(timer_api_error,
 			 ztest_user_unit_test(test_timer_stop_null),
 			 ztest_user_unit_test(test_timer_status_get_null),
 			 ztest_user_unit_test(test_timer_status_sync_null),
@@ -377,5 +377,5 @@ void test_main(void)
 			 ztest_user_unit_test(test_timer_add_timeout),
 			 ztest_unit_test(test_timeout_end_calc),
 			 ztest_user_unit_test(test_timer_start_null));
-	ztest_run_test_suite(timer_api);
+	ztest_run_test_suite(timer_api_error);
 }

--- a/tests/unit/net_timeout/main.c
+++ b/tests/unit/net_timeout/main.c
@@ -360,7 +360,7 @@ static void test_nop(void)
 void test_main(void)
 {
 
-	ztest_test_suite(test_prf,
+	ztest_test_suite(test_net_timeout,
 			 ztest_unit_test(test_basics),
 			 ztest_unit_test(test_set),
 			 ztest_unit_test(test_deadline),
@@ -369,5 +369,5 @@ void test_main(void)
 			 ztest_unit_test(test_evaluate_whitebox),
 			 ztest_unit_test(test_nop)
 			 );
-	ztest_run_test_suite(test_prf);
+	ztest_run_test_suite(test_net_timeout);
 }


### PR DESCRIPTION
Some of the testsuite names are duplicated. Try to rename them
to adequate ones.

Signed-off-by: Enjia Mai <enjia.mai@intel.com>