### PR TITLE
drivers/eeprom: add support for m24c16 eeprom in at2x eeprom driver

### DIFF
--- a/drivers/eeprom/eeprom_at2x.c
+++ b/drivers/eeprom/eeprom_at2x.c
@@ -582,7 +582,7 @@ static const struct eeprom_driver_api eeprom_at2x_api = {
 };
 
 #define ASSERT_AT24_ADDR_W_VALID(w) \
-	BUILD_ASSERT(w == 8U || w == 16U,		\
+	BUILD_ASSERT(w == 8U || w == 16U || w == 11U,		\
 		     "Unsupported address width")
 
 #define ASSERT_AT25_ADDR_W_VALID(w)			\


### PR DESCRIPTION
**This PR follows on from PR #39548 which is obsolete.**

Modification of atmel eeprom at2x driver to support ST eeprom m24c16 driver :
adding of the use of 11 bits addressing.

This driver has been tested with the zephyr test software for eeprom (in zephyr/tests/drivers/eeprom) on a custom board with STM32F091.
In the prj.conf of zephyr/tests/drivers/eeprom, I added the following :

CONFIG_I2C=y
CONFIG_EEPROM_AT24=y

Example of a part of my dts :
```
i2c1 {
    pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
    clock-frequency = <I2C_BITRATE_FAST>;
    status = "okay";

    eeprom_m24c16: m24c16@a0 {
        compatible = "atmel,at24";
        label = "EEPROM_0";
        reg = <0x50>;
        size = <DT_SIZE_K(2)>;
        pagesize = <16>;
        address-width = <11>;
        timeout = <5>; /* Maximum write time */
        status = "okay";
    };  
};
```

You find the datasheet of the eeprom [here](https://www.st.com/resource/en/datasheet/m24c16-w.pdf).
