### PR TITLE
ci: inclusive language, use nodes instead of slaves

### DIFF
--- a/scripts/ci/run_ci.sh
+++ b/scripts/ci/run_ci.sh
@@ -183,7 +183,7 @@ while getopts ":p:m:b:r:M:cfslR:" opt; do
 			matrix=$OPTARG
 			;;
 		M)
-			echo "Running a matrix of $OPTARG slaves" >&2
+			echo "Running a matrix of $OPTARG nodes" >&2
 			matrix_builds=$OPTARG
 			;;
 		b)


### PR DESCRIPTION

﻿Fix the usage of the word slaves and replace with nodes.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
