### PR TITLE
soc: nordic_nrf: Add query items for HW peripherals missing

### DIFF
--- a/soc/arm/nordic_nrf/Kconfig.peripherals
+++ b/soc/arm/nordic_nrf/Kconfig.peripherals
@@ -30,6 +30,9 @@ config HAS_HW_NRF_CLOCK
 config HAS_HW_NRF_COMP
 	bool
 
+config HAS_HW_NRF_DCNF
+	bool
+
 config HAS_HW_NRF_DPPIC
 	bool
 
@@ -78,6 +81,9 @@ config HAS_HW_NRF_LPCOMP
 config HAS_HW_NRF_MPU
 	bool
 
+config HAS_HW_NRF_MUTEX
+	bool
+
 config HAS_HW_NRF_MWU
 	bool
 
@@ -86,6 +92,9 @@ config HAS_HW_NRF_NFCT
 
 # NVMC supports partial erase
 config HAS_HW_NRF_NVMC_PE
+	bool
+
+config HAS_HW_NRF_OSCILLATORS
 	bool
 
 config HAS_HW_NRF_PDM
@@ -131,6 +140,12 @@ config HAS_HW_NRF_RADIO_BLE_CODED
 	bool
 
 config HAS_HW_NRF_RADIO_IEEE802154
+	bool
+
+config HAS_HW_NRF_REGULATORS
+	bool
+
+config HAS_HW_NRF_RESET
 	bool
 
 config HAS_HW_NRF_RNG
@@ -272,6 +287,9 @@ config HAS_HW_NRF_USBD
 	bool
 
 config HAS_HW_NRF_USBREG
+	bool
+
+config HAS_HW_NRF_VMC
 	bool
 
 config HAS_HW_NRF_WDT

--- a/soc/arm/nordic_nrf/nrf53/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf53/Kconfig.soc
@@ -12,6 +12,7 @@ config SOC_NRF5340_CPUAPP
 	select HAS_HW_NRF_CC312
 	select HAS_HW_NRF_COMP
 	select HAS_HW_NRF_CLOCK
+	select HAS_HW_NRF_DCNF
 	select HAS_HW_NRF_DPPIC
 	select HAS_HW_NRF_EGU0
 	select HAS_HW_NRF_EGU1
@@ -26,8 +27,10 @@ config SOC_NRF5340_CPUAPP
 	select HAS_HW_NRF_IPC
 	select HAS_HW_NRF_KMU
 	select HAS_HW_NRF_LPCOMP
+	select HAS_HW_NRF_MUTEX
 	select HAS_HW_NRF_NFCT
 	select HAS_HW_NRF_NVMC_PE
+	select HAS_HW_NRF_OSCILLATORS
 	select HAS_HW_NRF_PDM
 	select HAS_HW_NRF_POWER
 	select HAS_HW_NRF_PWM0
@@ -37,6 +40,8 @@ config SOC_NRF5340_CPUAPP
 	select HAS_HW_NRF_QDEC0
 	select HAS_HW_NRF_QDEC1
 	select HAS_HW_NRF_QSPI
+	select HAS_HW_NRF_REGULATORS
+	select HAS_HW_NRF_RESET
 	select HAS_HW_NRF_RTC0
 	select HAS_HW_NRF_RTC1
 	select HAS_HW_NRF_SAADC
@@ -67,6 +72,7 @@ config SOC_NRF5340_CPUAPP
 	select HAS_HW_NRF_UARTE3
 	select HAS_HW_NRF_USBD
 	select HAS_HW_NRF_USBREG
+	select HAS_HW_NRF_VMC
 	select HAS_HW_NRF_WDT0
 	select HAS_HW_NRF_WDT1
 

--- a/soc/arm/nordic_nrf/nrf91/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf91/Kconfig.soc
@@ -27,6 +27,7 @@ config SOC_NRF9160
 	select HAS_HW_NRF_PWM1
 	select HAS_HW_NRF_PWM2
 	select HAS_HW_NRF_PWM3
+	select HAS_HW_NRF_REGULATORS
 	select HAS_HW_NRF_RTC0
 	select HAS_HW_NRF_RTC1
 	select HAS_HW_NRF_SAADC
@@ -54,6 +55,7 @@ config SOC_NRF9160
 	select HAS_HW_NRF_UARTE1
 	select HAS_HW_NRF_UARTE2
 	select HAS_HW_NRF_UARTE3
+	select HAS_HW_NRF_VMC
 	select HAS_HW_NRF_WDT
 
 choice


### PR DESCRIPTION
Add Kconfig items that can be used to query if the current SoC
support the HW peripherals for some peripherals that are missing.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>