### PR TITLE
ci: doc-publish: specify artifacts run_id

### DIFF
--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -28,6 +28,7 @@ jobs:
       uses: dawidd6/action-download-artifact@v2
       with:
         workflow: doc-build.yml
+        run_id: ${{ github.event.workflow_run.id }}
 
     - name: Uncompress HTML docs
       run: |


### PR DESCRIPTION
Set the artifact run_id to the one from the doc-build workflow. This way
the downloaded artifact should always match the one from the build
action that triggered publish.

NOTE: not tested, but I think it should fix the issue. Also used here https://github.com/nrfconnect/sdk-nrf/blob/main/.github/workflows/docpublish.yml#L21