### PR TITLE
Bluetooth: host: Add handling of failures in per sync established evt

### DIFF
--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -1153,6 +1153,9 @@ struct bt_le_per_adv_sync_term_info {
 
 	/** Advertiser SID */
 	uint8_t sid;
+
+	/** Cause of periodic advertising termination */
+	uint8_t reason;
 };
 
 struct bt_le_per_adv_sync_recv_info {


### PR DESCRIPTION
Handling of HCI_LE_Periodic_Advertising_Sync_Established didn't
have implemented handling of possible failures of periodic
advertising synchronization.
There are two situations definded by BT 5.3 Core spec:
- There is no AUX_SYNC_IND pdu within 6 periodic advertising events.
  If that happens, status of the command is set to (0x3E) Connection
  Failed To Be Established / Synchronization Timeout.
- Periodic advertising has wrong CTE type while periodic advertising
  list is not used to determine the advertiser to listen.
  In this case status of the command is set to (0x1A) Unsupported
  Remote Feature.

The commit provides missing functionality.
In case of error, the periodic advertising will be deleted and
application will be notified by call to terminated callback.
The callback data were extended by err member. It provides
information why periodic advertising was terminated.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>