### PR TITLE
MXRT600: Fix secure/non-secure definition for FLEXSPI

### DIFF
--- a/boards/arm/mimxrt685_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt685_evk/Kconfig.defconfig
@@ -17,6 +17,9 @@ config SYSOSC_SETTLING_US
 config FLASH_MCUX_FLEXSPI_MX25UM51345G
 	default y if FLASH
 
+config FLASH_SIZE
+	default $(dt_node_int_prop_int,/soc/spi@134000/mx25um51345g@2,size,K)
+
 config FLASH_MCUX_FLEXSPI_XIP
 	default y if FLASH
 	depends on MEMC_MCUX_FLEXSPI

--- a/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.dts
+++ b/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.dts
@@ -204,10 +204,9 @@ i2s1: &flexcomm3 {
 };
 
 &flexspi {
-	reg = <0x50134000 0x4000>, <0x18000000 DT_SIZE_M(64)>;
 	mx25um51345g: mx25um51345g@2 {
 		compatible = "nxp,imx-flexspi-mx25um51345g";
-		size = <536870912>;
+		size = <DT_SIZE_M(64)>;
 		label = "MX25UM51345G";
 		reg = <2>;
 		spi-max-frequency = <200000000>;

--- a/dts/arm/nxp/nxp_rt6xx.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx.dtsi
@@ -5,9 +5,6 @@
  */
 
 #include <mem.h>
-#include <arm/armv8-m.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
 
 / {
 	soc {
@@ -17,6 +14,9 @@
 
 		peripheral: peripheral@50000000 {
 			ranges = <0x0 0x50000000 0x10000000>;
+		};
+		flexspi: spi@134000 {
+			reg = <0x5134000 0x1000>, <0x18000000 DT_SIZE_M(64)>;
 		};
 	};
 };

--- a/dts/arm/nxp/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx_common.dtsi
@@ -116,14 +116,6 @@
 		port = <2>;
 	};
 
-	flexspi: spi@134000 {
-		compatible = "nxp,imx-flexspi";
-		reg = <0x134000 0x1000>;
-		interrupts = <42 0>;
-		label = "FLEXSPI";
-		#address-cells = <1>;
-		#size-cells = <0>;
-	};
 
 	flexcomm0: flexcomm@106000 {
 		compatible = "nxp,lpc-flexcomm";
@@ -391,6 +383,14 @@
 		prescale = <0>;
 		label = "CTIMER_4";
 	};
+};
+
+&flexspi {
+	compatible = "nxp,imx-flexspi";
+	interrupts = <42 0>;
+	label = "FLEXSPI";
+	#address-cells = <1>;
+	#size-cells = <0>;
 };
 
 &nvic {

--- a/dts/arm/nxp/nxp_rt6xx_ns.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx_ns.dtsi
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <mem.h>
+
 / {
 	soc {
 		sram: sram@20180000 {
@@ -12,6 +14,9 @@
 
 		peripheral: peripheral@40000000 {
 			ranges = <0x0 0x40000000 0x10000000>;
+		};
+		flexspi: spi@134000 {
+			reg = <0x4134000 0x1000>, <0x08000000 DT_SIZE_M(64)>;
 		};
 	};
 };

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -168,7 +168,19 @@ def _node_reg_size(node, index, unit):
     return node.regs[int(index)].size >> _dt_units_to_scale(unit)
 
 
-def _node_int_prop(node, prop):
+def _node_int_prop(node, prop, unit=None):
+    """
+    This function takes a 'node' and  will look to see if that 'node' has a
+    property called 'prop' and if that 'prop' is an integer type will return
+    the value of the property 'prop' as either a string int or string hex
+    value, if not we return 0.
+
+    The function will divide the value based on 'unit':
+        None        No division
+        'k' or 'K'  divide by 1024 (1 << 10)
+        'm' or 'M'  divide by 1,048,576 (1 << 20)
+        'g' or 'G'  divide by 1,073,741,824 (1 << 30)
+    """
     if not node:
         return 0
 
@@ -178,7 +190,7 @@ def _node_int_prop(node, prop):
     if node.props[prop].type != "int":
         return 0
 
-    return node.props[prop].val
+    return node.props[prop].val >> _dt_units_to_scale(unit)
 
 
 def _dt_chosen_reg_addr(kconf, chosen, index=0, unit=None):
@@ -349,15 +361,20 @@ def dt_node_has_prop(kconf, _, label, prop):
 
     return "n"
 
-def dt_node_int_prop(kconf, name, path, prop):
+def dt_node_int_prop(kconf, name, path, prop, unit=None):
     """
     This function takes a 'path' and property name ('prop') looks for an EDT
     node at that path. If it finds an EDT node, it will look to see if that
     node has a property called 'prop' and if that 'prop' is an integer type
     will return the value of the property 'prop' as either a string int or
     string hex value, if not we return 0.
-    """
 
+    The function will divide the value based on 'unit':
+        None        No division
+        'k' or 'K'  divide by 1024 (1 << 10)
+        'm' or 'M'  divide by 1,048,576 (1 << 20)
+        'g' or 'G'  divide by 1,073,741,824 (1 << 30)
+    """
     if doc_mode or edt is None:
         return "0"
 
@@ -367,9 +384,9 @@ def dt_node_int_prop(kconf, name, path, prop):
         return "0"
 
     if name == "dt_node_int_prop_int":
-        return str(_node_int_prop(node, prop))
+        return str(_node_int_prop(node, prop, unit))
     if name == "dt_node_int_prop_hex":
-        return hex(_node_int_prop(node, prop))
+        return hex(_node_int_prop(node, prop, unit))
 
 
 def dt_compat_enabled(kconf, _, compat):
@@ -472,8 +489,8 @@ functions = {
         "dt_node_reg_size_hex": (dt_node_reg, 1, 3),
         "dt_node_has_bool_prop": (dt_node_has_bool_prop, 2, 2),
         "dt_node_has_prop": (dt_node_has_prop, 2, 2),
-        "dt_node_int_prop_int": (dt_node_int_prop, 2, 2),
-        "dt_node_int_prop_hex": (dt_node_int_prop, 2, 2),
+        "dt_node_int_prop_int": (dt_node_int_prop, 2, 3),
+        "dt_node_int_prop_hex": (dt_node_int_prop, 2, 3),
         "dt_nodelabel_has_compat": (dt_nodelabel_has_compat, 2, 2),
         "dt_nodelabel_path": (dt_nodelabel_path, 1, 1),
         "shields_list_contains": (shields_list_contains, 1, 1),

--- a/soc/arm/nxp_imx/rt6xx/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt6xx/Kconfig.defconfig.series
@@ -17,11 +17,13 @@ config NUM_IRQS
 config PM
 	select CODE_DATA_RELOCATION_SRAM
 
-config FLASH_SIZE
-	default $(dt_node_reg_size_int,/soc/peripheral@50000000/spi@134000,1,K)
-
+#
+# The base address of the external flash comes from the FLEXSPI base
+# address. The size of the flash is defined by what is populated and
+# described in the board devicetree file.
+#
 config FLASH_BASE_ADDRESS
-	default $(dt_node_reg_addr_hex,/soc/peripheral@50000000/spi@134000,1)
+	default $(dt_node_reg_addr_hex,/soc/spi@134000,1)
 
 config ENTROPY_MCUX_TRNG
 	default y if HAS_MCUX_TRNG


### PR DESCRIPTION
The Flexspi memory address defines the location of the externally
attached flash to the MXRT600 based board. The flexspi has two
different memory spaces for secure and non-secure access that are
not aligned for the Flexspi register space and the memory map
address space. The normal method of handling this via the two
different dts files for secure/non-secure is not able to handle
this because a base address is applied uniformly across multiple
reg items.

Changes include:

- pull flexspi out of peripherals block to allow it to be explicitly
expressed in the respective secure/non-secure SOC DTS files.
- move the flash size definition to the board level definition and
use the size of the actual flash device found on the board.