### PR TITLE
Bluetooth: controller: allow to cancel per adv after ull_scan_setup

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -321,7 +321,8 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 		 * Setup synchronization if address and SID match in the
 		 * Periodic Advertiser List or with the explicitly supplied.
 		 */
-		if (sync && adi && ull_sync_setup_sid_match(scan, adi->sid)) {
+		if ((sync && sync->timeout_reload == 0) && adi &&
+		    ull_sync_setup_sid_match(scan, adi->sid)) {
 			ull_sync_setup(scan, aux, rx, si);
 		}
 #endif /* CONFIG_BT_CTLR_SYNC_PERIODIC */


### PR DESCRIPTION
ll_sync_create_cancel called after ull_scan_setup and before
periodic advertising synchronization estalished will end
with BT_HCI_ERR_CMD_DISALLOWED error.
It should be possible to call the cancel function after
until periodic advertising synchronization is established
(first AUX_SYNC_IND pdu is received after call to
ll_sync_create).

The commit moves clearing scan->per_scan.sync to
ull_sync_established_report from ull_scan_setup.
That allows to call the function until sync is
successfully established.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>