### PR TITLE
dts: sitronix,st7789v: fix binding whitespace

### DIFF
--- a/dts/bindings/display/sitronix,st7789v.yaml
+++ b/dts/bindings/display/sitronix,st7789v.yaml
@@ -12,7 +12,8 @@ properties:
     reset-gpios:
       type: phandle-array
       required: true
-      description: RESET pin.
+      description: |
+        RESET pin.
 
         The RESET pin of ST7789V is active low.
         If connected directly the MCU pin should be configured
@@ -21,7 +22,8 @@ properties:
     cmd-data-gpios:
       type: phandle-array
       required: true
-      description: D/CX pin.
+      description: |
+        D/CX pin.
 
         The D/CX pin of ST7789V is active low (transmission command byte).
         If connected directly the MCU pin should be configured


### PR DESCRIPTION
Clean up multi-line strings so they will show up properly in the
bindings index in the HTML documentation.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>