### PR TITLE
samples: ipc: openamp: Fix build for use with west

### DIFF
--- a/samples/subsys/ipc/openamp/CMakeLists.txt
+++ b/samples/subsys/ipc/openamp/CMakeLists.txt
@@ -41,5 +41,6 @@ ExternalProject_Add(
   # NB: Do we need to pass on more CMake variables?
   BUILD_ALWAYS True
 )
+add_dependencies(app openamp_remote)
 
 target_include_directories(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
The image for the 2nd cpu should be a dependency of the app not just
the default target.  With this fix the following will work:

```bash
$ west build -b mps2_an521 \
     zephyr/samples/subsys/ipc/openamp -t run
```

Without this fix the above would not build the 2nd cpu image and the
qemu command will fail.  If west is used without the -t run the 2nd cpu
image will be built but will be deleted when the -t run target is used.

NOTE: This is a provisional, sub-optimal solution (having a dependency
from app --> openamp_remote). Further rework required to cleanly specify
dependencies, at which point this provisional solution can be revisited.

Authored-by: Bill Mills <bill.mills@linaro.org>
Signed-off-by: Kevin Townsend <kevin.townsend@linaro.org>