### PR TITLE
tests: drivers: spi_loopback: enable GPIO driver for sam_v71* and cy8ckit_062_ble_m0 boards

### DIFF
--- a/tests/drivers/spi/spi_loopback/boards/cy8ckit_062_ble_m0.conf
+++ b/tests/drivers/spi/spi_loopback/boards/cy8ckit_062_ble_m0.conf
@@ -1,0 +1,1 @@
+CONFIG_GPIO=y

--- a/tests/drivers/spi/spi_loopback/boards/sam_v71_xult.conf
+++ b/tests/drivers/spi/spi_loopback/boards/sam_v71_xult.conf
@@ -1,0 +1,1 @@
+CONFIG_GPIO=y

--- a/tests/drivers/spi/spi_loopback/boards/sam_v71b_xult.conf
+++ b/tests/drivers/spi/spi_loopback/boards/sam_v71b_xult.conf
@@ -1,0 +1,1 @@
+CONFIG_GPIO=y


### PR DESCRIPTION
Enable GPIO driver which is needed to handle CS GPIOS in SPI driver.

Signed-off-by: Bartosz Bilas bartosz.bilas@hotmail.com