### PR TITLE
net: openthread: Fix for OT prompt in the Zephyr shell

### DIFF
--- a/subsys/net/lib/openthread/platform/shell.c
+++ b/subsys/net/lib/openthread/platform/shell.c
@@ -25,7 +25,18 @@ static bool is_shell_initialized;
 
 static int ot_console_cb(void *context, const char *format, va_list arg)
 {
+	char prompt_check[4];
+
 	ARG_UNUSED(context);
+
+	/* A temporary workaround to avoid printing OT prompt in Zehyr shell.
+	 * Eventually, OT should add an option which would allow to disable
+	 * prompt on the CLI output.
+	 */
+	vsnprintf(prompt_check, sizeof(prompt_check), format, arg);
+	if (strcmp(prompt_check, "> ") == 0) {
+		return 0;
+	}
 
 	if (shell_p == NULL) {
 		return 0;


### PR DESCRIPTION
OpenThread has changed it's behaviour in terms of promt printing in the
CLI module. Previously it was only printed on the UART CLI backend, now
it's printed on every CLI backend. This results in a double prompt being
printed when combined with Zephyr shell (one from OT and other form
Zephyr).

This commit adds a temporary fix to prevent OT prompt from being printed
in Zehpyr shell. As a long term solution we should add an option to
OpenThread to allow to disable prompt on the output.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>