### PR TITLE
ci: hotfix: disable test exclusion by tags

### DIFF
--- a/scripts/ci/get_twister_opt.py
+++ b/scripts/ci/get_twister_opt.py
@@ -200,4 +200,5 @@ if __name__ == "__main__":
     find_boards(files)
     find_archs(files)
     find_tests(files)
-    find_tags(files)
+    # disabling for now due to #40235
+    #find_tags(files)


### PR DESCRIPTION
Many tests and CI activties are being missed by excluding tests
mistakingly when running twister.
This is visibile when you change one or more tests in kernel/ for
example, twister does not run those tests that have changed at all and
marking the PR as tested and ready to be merged.

Temporary fix for #40235.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
