### PR TITLE
ISO Header Struct Fixes

### DIFF
--- a/drivers/bluetooth/hci/h4.c
+++ b/drivers/bluetooth/hci/h4.c
@@ -135,7 +135,7 @@ static inline void get_iso_hdr(void)
 	if (!rx.remaining) {
 		struct bt_hci_iso_hdr *hdr = &rx.iso;
 
-		rx.remaining = sys_le16_to_cpu(hdr->len);
+		rx.remaining = bt_iso_hdr_len(sys_le16_to_cpu(hdr->len));
 		BT_DBG("Got ISO header. Payload %u bytes", rx.remaining);
 		rx.have_hdr = true;
 	}

--- a/drivers/bluetooth/hci/hci_esp32.c
+++ b/drivers/bluetooth/hci/hci_esp32.c
@@ -147,7 +147,7 @@ static struct net_buf *bt_esp_iso_recv(uint8_t *data, size_t remaining)
 		return NULL;
 	}
 
-	if (remaining != sys_le16_to_cpu(hdr.len)) {
+	if (remaining != bt_iso_hdr_len(sys_le16_to_cpu(hdr.len))) {
 		BT_ERR("ISO payload length is not correct");
 		net_buf_unref(buf);
 		return NULL;

--- a/drivers/bluetooth/hci/rpmsg.c
+++ b/drivers/bluetooth/hci/rpmsg.c
@@ -147,7 +147,7 @@ static struct net_buf *bt_rpmsg_iso_recv(uint8_t *data, size_t remaining)
 		return NULL;
 	}
 
-	if (remaining != sys_le16_to_cpu(hdr.len)) {
+	if (remaining != bt_iso_hdr_len(sys_le16_to_cpu(hdr.len))) {
 		BT_ERR("ISO payload length is not correct");
 		net_buf_unref(buf);
 		return NULL;

--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -74,6 +74,7 @@ struct bt_hci_acl_hdr {
 	(((pb) & 0x0003) | (((ts) & 0x0001) << 2))
 #define bt_iso_handle_pack(h, pb, ts) \
 	((h) | (bt_iso_pack_flags(pb, ts) << 12))
+#define bt_iso_hdr_len(h)                ((h) & BIT_MASK(14))
 
 #define BT_ISO_DATA_VALID                0x00
 #define BT_ISO_DATA_INVALID              0x01
@@ -96,8 +97,8 @@ struct bt_hci_iso_ts_data_hdr {
 #define BT_HCI_ISO_TS_DATA_HDR_SIZE     8
 
 struct bt_hci_iso_hdr {
-	uint16_t handle;
-	uint16_t len;
+	uint16_t handle; /* 12 bit handle, 2 bit PB flags, 1 bit TS_Flag, 1 bit RFU */
+	uint16_t len; /* 14 bits, 2 bits RFU */
 } __packed;
 #define BT_HCI_ISO_HDR_SIZE             4
 

--- a/samples/bluetooth/hci_rpmsg/src/main.c
+++ b/samples/bluetooth/hci_rpmsg/src/main.c
@@ -126,7 +126,7 @@ static struct net_buf *hci_rpmsg_iso_recv(uint8_t *data, size_t remaining)
 		return NULL;
 	}
 
-	if (remaining != sys_le16_to_cpu(hdr->len)) {
+	if (remaining != bt_iso_hdr_len(sys_le16_to_cpu(hdr->len))) {
 		LOG_ERR("ISO payload length is not correct");
 		net_buf_unref(buf);
 		return NULL;

--- a/samples/bluetooth/hci_uart/src/main.c
+++ b/samples/bluetooth/hci_uart/src/main.c
@@ -81,7 +81,8 @@ static uint32_t get_len(const uint8_t *hdr_buf, uint8_t type)
 	case H4_CMD:
 		return ((const struct bt_hci_cmd_hdr *)hdr_buf)->param_len;
 	case H4_ISO:
-		return sys_le16_to_cpu(((const struct bt_hci_iso_hdr *)hdr_buf)->len);
+		return bt_iso_hdr_len(
+			sys_le16_to_cpu(((const struct bt_hci_iso_hdr *)hdr_buf)->len));
 	case H4_ACL:
 		return sys_le16_to_cpu(((const struct bt_hci_acl_hdr *)hdr_buf)->len);
 	default:

--- a/samples/bluetooth/hci_uart/src/main.c
+++ b/samples/bluetooth/hci_uart/src/main.c
@@ -81,7 +81,7 @@ static uint32_t get_len(const uint8_t *hdr_buf, uint8_t type)
 	case H4_CMD:
 		return ((const struct bt_hci_cmd_hdr *)hdr_buf)->param_len;
 	case H4_ISO:
-		return sys_le16_to_cpu(((const struct bt_hci_iso_data_hdr *)hdr_buf)->slen);
+		return sys_le16_to_cpu(((const struct bt_hci_iso_hdr *)hdr_buf)->len);
 	case H4_ACL:
 		return sys_le16_to_cpu(((const struct bt_hci_acl_hdr *)hdr_buf)->len);
 	default:
@@ -97,7 +97,7 @@ static int hdr_len(uint8_t type)
 	case H4_CMD:
 		return sizeof(struct bt_hci_cmd_hdr);
 	case H4_ISO:
-		return sizeof(struct bt_hci_iso_data_hdr);
+		return sizeof(struct bt_hci_iso_hdr);
 	case H4_ACL:
 		return sizeof(struct bt_hci_acl_hdr);
 	default:

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -85,7 +85,7 @@ void hci_iso(struct net_buf *buf)
 	BT_ASSERT(buf->len >= sizeof(*hdr));
 
 	hdr = net_buf_pull_mem(buf, sizeof(*hdr));
-	len = sys_le16_to_cpu(hdr->len);
+	len = bt_iso_hdr_len(sys_le16_to_cpu(hdr->len));
 	handle = sys_le16_to_cpu(hdr->handle);
 	flags = bt_iso_flags(handle);
 

--- a/subsys/usb/class/bluetooth.c
+++ b/subsys/usb/class/bluetooth.c
@@ -195,11 +195,11 @@ static uint16_t hci_pkt_get_len(struct net_buf *buf,
 		break;
 	}
 	case BT_BUF_ISO_OUT: {
-		struct bt_hci_iso_data_hdr *iso_hdr;
+		struct bt_hci_iso_hdr *iso_hdr;
 
 		hdr_len = sizeof(*iso_hdr);
-		iso_hdr = (struct bt_hci_iso_data_hdr *)data;
-		len = sys_le16_to_cpu(iso_hdr->slen) + hdr_len;
+		iso_hdr = (struct bt_hci_iso_hdr *)data;
+		len = sys_le16_to_cpu(iso_hdr->len) + hdr_len;
 		break;
 	}
 	default:

--- a/subsys/usb/class/bluetooth.c
+++ b/subsys/usb/class/bluetooth.c
@@ -199,7 +199,7 @@ static uint16_t hci_pkt_get_len(struct net_buf *buf,
 
 		hdr_len = sizeof(*iso_hdr);
 		iso_hdr = (struct bt_hci_iso_hdr *)data;
-		len = sys_le16_to_cpu(iso_hdr->len) + hdr_len;
+		len = bt_iso_hdr_len(sys_le16_to_cpu(iso_hdr->len)) + hdr_len;
 		break;
 	}
 	default:


### PR DESCRIPTION
Fixes use of wrong ISO header structure, and adds a bitmask to ensure that iso header length value ignores RFU bits: 

![image](https://user-images.githubusercontent.com/2520413/141124586-5ad6987f-82d7-4474-a511-35f59e7668b3.png)
