### PR TITLE
Bluetooth: controller: add missing ADI support in per adv chains

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
@@ -424,7 +424,11 @@ static void pdu_b2b_aux_ptr_update(struct pdu_adv *pdu, uint8_t phy, uint8_t fla
 		dptr++;
 	}
 
-	LL_ASSERT(!hdr->adi);
+	if (IS_ENABLED(CONFIG_BT_CTLR_ADV_PERIODIC_ADI_SUPPORT) && hdr->adi != 0) {
+		dptr += sizeof(struct pdu_adv_adi);
+	} else {
+		LL_ASSERT(!hdr->adi);
+	}
 
 	/* Update AuxPtr */
 	aux_ptr = (void *)dptr;

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
@@ -95,6 +95,7 @@ void ull_adv_aux_release(struct ll_adv_aux_set *aux);
 void ull_adv_aux_offset_get(struct ll_adv_set *adv);
 
 /* Below are BT Spec v5.2, Vol 6, Part B Section 2.3.4 Table 2.12 defined */
+#define ULL_ADV_PDU_HDR_FIELD_NONE      0
 #define ULL_ADV_PDU_HDR_FIELD_ADVA      BIT(0)
 #define ULL_ADV_PDU_HDR_FIELD_TARGETA   BIT(1)
 #define ULL_ADV_PDU_HDR_FIELD_CTE_INFO  BIT(2)
@@ -129,6 +130,11 @@ void ull_adv_sync_pdu_init(struct pdu_adv *pdu, uint8_t ext_hdr_flags);
 /* helper to add cte_info field to extended advertising header */
 uint8_t ull_adv_sync_pdu_cte_info_set(struct pdu_adv *pdu, const struct pdu_cte_info *cte_info);
 
+/* helper to get information whether ADI field is avaialbe in extended advertising PDU */
+static inline bool ull_adv_sync_pdu_had_adi(const struct pdu_adv *pdu)
+{
+	return pdu->adv_ext_ind.ext_hdr.adi;
+}
 /* helper function to calculate common ext adv payload header length and
  * adjust the data pointer.
  * NOTE: This function reverts the header data pointer if there is no

--- a/tests/bluetooth/df/connectionless_cte_chains/src/common.c
+++ b/tests/bluetooth/df/connectionless_cte_chains/src/common.c
@@ -76,7 +76,9 @@ struct ll_adv_set *common_create_adv_set(uint8_t hci_handle)
 	 */
 	lll_sync = &g_sync_set.lll;
 	adv_set->lll.sync = &g_sync_set.lll;
+	lll_hdr_init(&adv_set->lll, adv_set);
 	g_sync_set.lll.adv = &adv_set->lll;
+	lll_hdr_init(lll_sync, &g_sync_set);
 
 	err = lll_adv_init();
 	zassert_equal(err, 0, "Unexpected error while initialization advertising set, err: %d",
@@ -137,6 +139,7 @@ void common_create_per_adv_chain(struct ll_adv_set *adv_set, uint8_t pdu_count)
 	char pdu_buff[PDU_PAULOAD_BUFF_SIZE];
 	void *extra_data_prev, *extra_data;
 	struct lll_adv_sync *lll_sync;
+	bool adi_in_sync_ind;
 	uint8_t err, pdu_idx;
 
 	lll_sync = adv_set->lll.sync;
@@ -153,10 +156,15 @@ void common_create_per_adv_chain(struct ll_adv_set *adv_set, uint8_t pdu_count)
 
 	/* Create AUX_SYNC_IND PDU as a head of chain */
 	err = ull_adv_sync_pdu_set_clear(lll_sync, pdu_prev, pdu,
-					 (pdu_count > 1 ? ULL_ADV_PDU_HDR_FIELD_AUX_PTR : 0), 0,
-					 NULL);
+					 (pdu_count > 1 ? ULL_ADV_PDU_HDR_FIELD_AUX_PTR :
+								ULL_ADV_PDU_HDR_FIELD_NONE),
+					 ULL_ADV_PDU_HDR_FIELD_NONE, NULL);
 	zassert_equal(err, 0, "Unexpected error during initialization of extended PDU, err: %d",
 		      err);
+
+	if (IS_ENABLED(CONFIG_BT_CTLR_ADV_PERIODIC_ADI_SUPPORT)) {
+		adi_in_sync_ind = ull_adv_sync_pdu_had_adi(pdu);
+	}
 
 	/* Add some AD for testing */
 	snprintf(pdu_buff, ARRAY_SIZE(pdu_buff), "test%" PRIu8 " test%" PRIu8 " test%" PRIu8 "", 0,
@@ -171,9 +179,20 @@ void common_create_per_adv_chain(struct ll_adv_set *adv_set, uint8_t pdu_count)
 		zassert_not_null(pdu_new, "Cannot allocate new PDU.");
 		/* Initialize new empty PDU. Last AUX_CHAIN_IND may not include AuxPtr. */
 		if (idx < pdu_count - 1) {
-			ull_adv_sync_pdu_init(pdu_new, ULL_ADV_PDU_HDR_FIELD_AUX_PTR);
+			if (IS_ENABLED(CONFIG_BT_CTLR_ADV_PERIODIC_ADI_SUPPORT) &&
+			    adi_in_sync_ind) {
+				ull_adv_sync_pdu_init(pdu_new, ULL_ADV_PDU_HDR_FIELD_AUX_PTR |
+								       ULL_ADV_PDU_HDR_FIELD_ADI);
+			} else {
+				ull_adv_sync_pdu_init(pdu_new, ULL_ADV_PDU_HDR_FIELD_AUX_PTR);
+			}
 		} else {
-			ull_adv_sync_pdu_init(pdu_new, 0);
+			if (IS_ENABLED(CONFIG_BT_CTLR_ADV_PERIODIC_ADI_SUPPORT) &&
+			    adi_in_sync_ind) {
+				ull_adv_sync_pdu_init(pdu_new, ULL_ADV_PDU_HDR_FIELD_ADI);
+			} else {
+				ull_adv_sync_pdu_init(pdu_new, ULL_ADV_PDU_HDR_FIELD_NONE);
+			}
 		}
 		/* Add some AD for testing */
 		common_pdu_adv_data_set(pdu_new, pdu_buff, strlen(pdu_buff));
@@ -246,14 +265,6 @@ void common_validate_per_adv_pdu(struct pdu_adv *pdu, enum test_pdu_ext_adv_type
 				      "Unexpected AdvA field in extended advertising header");
 			zassert_false(ext_hdr->tgt_addr,
 				      "Unexpected TargetA field in extended advertising header");
-			if (type == TEST_PDU_EXT_ADV_SYNC_IND) {
-				zassert_false(
-					ext_hdr->adi,
-					"Unexpected ADI field in extended advertising header");
-			}
-			zassert_false(ext_hdr->sync_info,
-				      "Unexpected SyncInfo field in extended advertising header");
-
 			if (exp_ext_hdr_flags & ULL_ADV_PDU_HDR_FIELD_CTE_INFO) {
 				zassert_true(
 					ext_hdr->cte_info,
@@ -264,8 +275,7 @@ void common_validate_per_adv_pdu(struct pdu_adv *pdu, enum test_pdu_ext_adv_type
 					ext_hdr->cte_info,
 					"Unexpected CteInfo field in extended advertising header");
 			}
-			if (type == TEST_PDU_EXT_ADV_SYNC_IND &&
-			    (exp_ext_hdr_flags & ULL_ADV_PDU_HDR_FIELD_ADI)) {
+			if (exp_ext_hdr_flags & ULL_ADV_PDU_HDR_FIELD_ADI) {
 				zassert_true(
 					ext_hdr->adi,
 					"Missing expected ADI field in extended advertising header");
@@ -285,6 +295,8 @@ void common_validate_per_adv_pdu(struct pdu_adv *pdu, enum test_pdu_ext_adv_type
 					ext_hdr->aux_ptr,
 					"Unexpected AuxPtr field in extended advertising header");
 			}
+			zassert_false(ext_hdr->sync_info,
+				      "Unexpected SyncInfo field in extended advertising header");
 			if (exp_ext_hdr_flags & ULL_ADV_PDU_HDR_FIELD_TX_POWER) {
 				zassert_true(
 					ext_hdr->tx_pwr,
@@ -361,6 +373,11 @@ void common_validate_per_adv_chain(struct ll_adv_set *adv, uint8_t pdu_count)
 	} else {
 		ext_hdr_flags = ULL_ADV_PDU_HDR_FIELD_AD_DATA;
 	}
+
+	if (IS_ENABLED(CONFIG_BT_CTLR_ADV_PERIODIC_ADI_SUPPORT)) {
+		ext_hdr_flags |= ULL_ADV_PDU_HDR_FIELD_ADI;
+	}
+
 	common_validate_per_adv_pdu(pdu, TEST_PDU_EXT_ADV_SYNC_IND, ext_hdr_flags);
 	pdu = lll_adv_pdu_linked_next_get(pdu);
 	if (pdu_count > 1) {
@@ -378,6 +395,11 @@ void common_validate_per_adv_chain(struct ll_adv_set *adv, uint8_t pdu_count)
 		} else {
 			ext_hdr_flags = ULL_ADV_PDU_HDR_FIELD_AD_DATA;
 		}
+
+		if (IS_ENABLED(CONFIG_BT_CTLR_ADV_PERIODIC_ADI_SUPPORT)) {
+			ext_hdr_flags |= ULL_ADV_PDU_HDR_FIELD_ADI;
+		}
+
 		common_validate_per_adv_pdu(pdu, TEST_PDU_EXT_ADV_CHAIN_IND, ext_hdr_flags);
 		pdu = lll_adv_pdu_linked_next_get(pdu);
 		if (idx != (pdu_count - 1)) {
@@ -417,6 +439,11 @@ void common_validate_chain_with_cte(struct ll_adv_set *adv, uint8_t cte_count,
 	if (ad_data_pdu_count > 0) {
 		ext_hdr_flags |= ULL_ADV_PDU_HDR_FIELD_AD_DATA;
 	}
+
+	if (IS_ENABLED(CONFIG_BT_CTLR_ADV_PERIODIC_ADI_SUPPORT)) {
+		ext_hdr_flags |= ULL_ADV_PDU_HDR_FIELD_ADI;
+	}
+
 	common_validate_per_adv_pdu(pdu, TEST_PDU_EXT_ADV_SYNC_IND, ext_hdr_flags);
 
 	pdu_count = MAX(cte_count, ad_data_pdu_count);
@@ -440,6 +467,11 @@ void common_validate_chain_with_cte(struct ll_adv_set *adv, uint8_t cte_count,
 		if (idx < ad_data_pdu_count) {
 			ext_hdr_flags |= ULL_ADV_PDU_HDR_FIELD_AD_DATA;
 		}
+
+		if (IS_ENABLED(CONFIG_BT_CTLR_ADV_PERIODIC_ADI_SUPPORT)) {
+			ext_hdr_flags |= ULL_ADV_PDU_HDR_FIELD_ADI;
+		}
+
 		common_validate_per_adv_pdu(pdu, TEST_PDU_EXT_ADV_CHAIN_IND, ext_hdr_flags);
 
 		pdu = lll_adv_pdu_linked_next_get(pdu);


### PR DESCRIPTION
Recenlty there was added ADI support to periodic advertising.
There was missing implementation of ADI for periodic advertising
chained PDUs and direction finding. Also unit tests for periodic
advertising chains required update to handle ADI field.

The commit provides missing implementation.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>