### PR TITLE
linker: add DWARF-5 debug sections

### DIFF
--- a/include/linker/debug-sections.ld
+++ b/include/linker/debug-sections.ld
@@ -41,3 +41,7 @@
 	SECTION_PROLOGUE(.debug_ranges, 0,)    { *(.debug_ranges) }
 	/* DWARF Extension. */
 	SECTION_PROLOGUE(.debug_macro, 0,)     { *(.debug_macro) }
+	/* DWARF 5 */
+	SECTION_PROLOGUE(.debug_line_str, 0,)  { *(.debug_line_str) }
+	SECTION_PROLOGUE(.debug_loclists, 0,)  { *(.debug_loclists) }
+	SECTION_PROLOGUE(.debug_rnglists, 0,)  { *(.debug_rnglists) }


### PR DESCRIPTION
DWARF-5 standard replaced the location list (.debug_loc) and range
list (.debug_ranges) sections with new sections (.debug_loclists
and .debug_rnglists).
They weren't handled which resulted in many orphan sections
reported as warnings by linker.

Signed-off-by: Michał Barnaś <mb@semihalf.com>