### PR TITLE
Bluetooth: shell: VCS: Use BT_VOCS_MIN_OFFSET/BT_VOCS_MAX_OFFSET

### DIFF
--- a/subsys/bluetooth/shell/vcs.c
+++ b/subsys/bluetooth/shell/vcs.c
@@ -432,9 +432,9 @@ static int cmd_vcs_vocs_offset_set(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	if (offset > UINT8_MAX || offset < -UINT8_MAX) {
+	if (offset > BT_VOCS_MAX_OFFSET || offset < BT_VOCS_MIN_OFFSET) {
 		shell_error(sh, "Offset shall be %d-%d, was %d",
-			    -UINT8_MAX, UINT8_MAX, offset);
+			    BT_VOCS_MIN_OFFSET, BT_VOCS_MAX_OFFSET, offset);
 		return -ENOEXEC;
 	}
 

--- a/subsys/bluetooth/shell/vcs_client.c
+++ b/subsys/bluetooth/shell/vcs_client.c
@@ -622,9 +622,9 @@ static int cmd_vcs_client_vocs_offset_set(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	if (offset > UINT8_MAX || offset < -UINT8_MAX) {
+	if (offset > BT_VOCS_MAX_OFFSET || offset < BT_VOCS_MIN_OFFSET) {
 		shell_error(sh, "Offset shall be %d-%d, was %d",
-			    -UINT8_MAX, UINT8_MAX, offset);
+			    BT_VOCS_MIN_OFFSET, BT_VOCS_MAX_OFFSET, offset);
 		return -ENOEXEC;
 	}
 


### PR DESCRIPTION
Use the defined min and max values for offset instead
of UINT8_MAX.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

fixes https://github.com/zephyrproject-rtos/zephyr/issues/40236