### PR TITLE
zephyr: MAINTAINERS: correct maintainer name

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1542,7 +1542,7 @@ Espressif Platforms:
     maintainers:
         - sylvioalves
         - glaubermaroto
-        - ulipe
+        - uLipe
     files:
         - drivers/*/*esp32*.c
         - boards/xtensa/esp32*/


### PR DESCRIPTION
ulipe was typed wrongly, the correct is uLipe.

Signed-off-by: Felipe Neves <felipe.neves@espressif.com>