### PR TITLE
subsys: bluetooth: controller: Increase maximum PA offset time

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -709,7 +709,7 @@ config BT_CTLR_GPIO_PA_POL_INV
 config BT_CTLR_GPIO_PA_OFFSET
 	int "Time from PA ON to Tx ready"
 	default 5
-	range 0 15
+	range 0 23
 	help
 	  Time before Tx ready to turn on PA in micro seconds.
 


### PR DESCRIPTION
The maximum value of the PA offset time when using a power amplifier in
Bluetooth needs to be larger than the current maximum to work with some
FEM devices, increasing to 23us.

Signed-off-by: Jamie McCrae <jamie.mccrae@lairdconnect.com>