### PR TITLE
drivers: clock_control: Add API to set the clock rate

### DIFF
--- a/include/drivers/clock_control.h
+++ b/include/drivers/clock_control.h
@@ -54,6 +54,14 @@ enum clock_control_status {
  */
 typedef void *clock_control_subsys_t;
 
+/**
+ * clock_control_subsys_rate_t is a type to identify a clock
+ * controller sub-system rate.  Such data pointed is opaque and
+ * relevant only to set the clock controller rate of the driver
+ * instance being used.
+ */
+typedef void *clock_control_subsys_rate_t;
+
 /** @brief Callback called on clock started.
  *
  * @param dev		Device structure whose driver controls the clock.
@@ -82,7 +90,7 @@ typedef enum clock_control_status (*clock_control_get_status_fn)(
 
 typedef int (*clock_control_set)(const struct device *dev,
 				 clock_control_subsys_t sys,
-				 uint32_t rate);
+				 clock_control_subsys_rate_t rate);
 
 struct clock_control_driver_api {
 	clock_control			on;
@@ -245,7 +253,7 @@ static inline int clock_control_get_rate(const struct device *dev,
  *
  * @param dev Device structure whose driver controls the clock.
  * @param sys Opaque data representing the clock.
- * @param rate Subsystem clock rate.
+ * @param rate Opaque data representing the clock rate to be used.
  *
  * @retval -EALREADY if clock was already in the given rate.
  * @retval -ENOTSUP If the requested mode of operation is not supported.
@@ -254,7 +262,7 @@ static inline int clock_control_get_rate(const struct device *dev,
  */
 static inline int clock_control_set_rate(const struct device *dev,
 		clock_control_subsys_t sys,
-		uint32_t rate)
+		clock_control_subsys_rate_t rate)
 {
 	int ret = device_usable_check(dev);
 


### PR DESCRIPTION
~Add a new API to set the clock rate synchronously and asynchronously.~

v2:
 - As discussed in the last PM meeting, the async API was removed and only synchronous API is implemented now.
