### PR TITLE
ITE drivers/pwm: cleanup it8xxx2 pwm driver

### DIFF
--- a/boards/riscv/it8xxx2_evb/it8xxx2_evb.dts
+++ b/boards/riscv/it8xxx2_evb/it8xxx2_evb.dts
@@ -12,11 +12,6 @@
 	model = "IT8XXX2 EV-Board";
 	compatible = "riscv,it8xxx2-evb";
 
-	aliases {
-		pwm-led0 = &led0;
-		pwm-led1 = &led1;
-	};
-
 	chosen {
 		zephyr,console = &uart1;
 		zephyr,shell-uart = &uart1;
@@ -26,19 +21,6 @@
 		zephyr,flash-controller = &flashctrl;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,keyboard-scan = &kscan0;
-	};
-
-	pwmleds {
-		compatible = "pwm-leds";
-		/* NOTE: &pwm number needs same with channel number */
-		led0: led_0 {
-			pwms = <&pwm7 PWM_CHANNEL_7 PWM_POLARITY_INVERTED>;
-			label = "LED0_GREEN";
-		};
-		led1: led_1 {
-			pwms = <&pwm0 PWM_CHANNEL_0 PWM_POLARITY_NORMAL>;
-			label = "LED1_BLUE";
-		};
 	};
 };
 &adc0 {

--- a/drivers/pwm/pwm_ite_it8xxx2.c
+++ b/drivers/pwm/pwm_ite_it8xxx2.c
@@ -13,16 +13,26 @@
 #include <errno.h>
 #include <kernel.h>
 #include <soc.h>
+#include <soc_dt.h>
 #include <stdlib.h>
 
 #include <logging/log.h>
 LOG_MODULE_REGISTER(pwm_ite_it8xxx2, CONFIG_PWM_LOG_LEVEL);
 
 #define PWM_CTRX_MIN	100
-#define PWM_EC_FREQ	MHZ(8)
+#define PWM_FREQ	EC_FREQ
 #define PCSSG_MASK	0x3
 
 /* Device config */
+struct pwm_alt_cfg {
+	/* Pinmux control device structure */
+	const struct device *pinctrls;
+	/* GPIO pin */
+	uint8_t pin;
+	/* Alternate function */
+	uint8_t alt_fun;
+};
+
 struct pwm_it8xxx2_cfg {
 	/* PWM channel duty cycle register */
 	uintptr_t reg_dcr;
@@ -35,28 +45,16 @@ struct pwm_it8xxx2_cfg {
 	/* PWM channel */
 	int channel;
 	/* PWM prescaler control register base */
-	uintptr_t base;
+	struct pwm_it8xxx2_regs *base;
 	/* Select PWM prescaler that output to PWM channel */
 	int prs_sel;
-	/* Pinmux control device structure */
-	const struct device *pinctrls;
-	/* GPIO pin */
-	uint8_t pin;
-	/* Alternate function */
-	uint8_t alt_fun;
+	/* PWM alternate configuration list */
+	const struct pwm_alt_cfg *alt_list;
 };
-
-/* Driver convenience defines */
-#define DRV_CONFIG(dev)		((const struct pwm_it8xxx2_cfg * const)(dev)->config)
-#define DRV_REG(dev)		(struct pwm_it8xxx2_regs *)(DRV_CONFIG(dev)->base)
-#define DEV_PINMUX(inst)	\
-	DEVICE_DT_GET(DT_PHANDLE_BY_IDX(DT_NODELABEL(pinctrl_pwm##inst), pinctrls, 0))
-#define DEV_PIN(inst)		DT_PHA(DT_INST_PINCTRL_0(inst, 0), pinctrls, pin)
-#define DEV_ALT_FUN(inst)	DT_PHA(DT_INST_PINCTRL_0(inst, 0), pinctrls, alt_func)
 
 static void pwm_enable(const struct device *dev, int enabled)
 {
-	const struct pwm_it8xxx2_cfg *config = DRV_CONFIG(dev);
+	const struct pwm_it8xxx2_cfg *config = dev->config;
 	volatile uint8_t *reg_pcsgr = (uint8_t *)config->reg_pcsgr;
 	int ch = config->channel;
 
@@ -71,15 +69,15 @@ static void pwm_enable(const struct device *dev, int enabled)
 static int pwm_it8xxx2_get_cycles_per_sec(const struct device *dev,
 					     uint32_t pwm, uint64_t *cycles)
 {
-	const struct pwm_it8xxx2_cfg *config = DRV_CONFIG(dev);
-	struct pwm_it8xxx2_regs *const inst = DRV_REG(dev);
+	const struct pwm_it8xxx2_cfg *config = dev->config;
+	struct pwm_it8xxx2_regs *const inst = config->base;
 	int prs_sel = config->prs_sel;
 
 	ARG_UNUSED(pwm);
 
 	/* Get clock source cycles per second that output to prescaler */
 	if ((inst->PCFSR) & BIT(prs_sel))
-		*cycles = (uint64_t) PWM_EC_FREQ;
+		*cycles = (uint64_t) PWM_FREQ;
 	else
 		*cycles = (uint64_t) 32768;
 
@@ -90,8 +88,8 @@ static int pwm_it8xxx2_pin_set(const struct device *dev,
 				uint32_t pwm, uint32_t period_cycles,
 				uint32_t pulse_cycles, pwm_flags_t flags)
 {
-	const struct pwm_it8xxx2_cfg *config = DRV_CONFIG(dev);
-	struct pwm_it8xxx2_regs *const inst = DRV_REG(dev);
+	const struct pwm_it8xxx2_cfg *config = dev->config;
+	struct pwm_it8xxx2_regs *const inst = config->base;
 	volatile uint8_t *reg_dcr = (uint8_t *)config->reg_dcr;
 	volatile uint8_t *reg_pwmpol = (uint8_t *)config->reg_pwmpol;
 	int ch = config->channel;
@@ -191,8 +189,8 @@ static int pwm_it8xxx2_pin_set(const struct device *dev,
 
 static int pwm_it8xxx2_init(const struct device *dev)
 {
-	const struct pwm_it8xxx2_cfg *config = DRV_CONFIG(dev);
-	struct pwm_it8xxx2_regs *const inst = DRV_REG(dev);
+	const struct pwm_it8xxx2_cfg *config = dev->config;
+	struct pwm_it8xxx2_regs *const inst = config->base;
 	volatile uint8_t *reg_pcssg = (uint8_t *)config->reg_pcssg;
 	int ch = config->channel;
 	int prs_sel = config->prs_sel;
@@ -226,8 +224,9 @@ static int pwm_it8xxx2_init(const struct device *dev)
 	inst->ZTIER |= IT8XXX2_PWM_PCCE;
 
 	/* Set alternate mode of PWM pin */
-	pinmux_pin_set(config->pinctrls, config->pin, config->alt_fun);
-
+	pinmux_pin_set(config->alt_list->pinctrls,
+		       config->alt_list->pin,
+		       config->alt_list->alt_fun);
 	return 0;
 }
 
@@ -238,17 +237,19 @@ static const struct pwm_driver_api pwm_it8xxx2_api = {
 
 /* Device Instance */
 #define PWM_IT8XXX2_INIT(inst)								\
+	static const struct pwm_alt_cfg							\
+		pwm_alt_##inst[DT_INST_NUM_PINCTRLS_BY_IDX(inst, 0)] =			\
+			IT8XXX2_DT_ALT_ITEMS_LIST(inst);				\
+											\
 	static const struct pwm_it8xxx2_cfg pwm_it8xxx2_cfg_##inst = {			\
 		.reg_dcr = DT_INST_REG_ADDR_BY_IDX(inst, 0),				\
 		.reg_pcssg = DT_INST_REG_ADDR_BY_IDX(inst, 1),				\
 		.reg_pcsgr = DT_INST_REG_ADDR_BY_IDX(inst, 2),				\
 		.reg_pwmpol = DT_INST_REG_ADDR_BY_IDX(inst, 3),				\
 		.channel = DT_PROP(DT_INST(inst, ite_it8xxx2_pwm), channel),		\
-		.base = DT_REG_ADDR(DT_NODELABEL(prs)),					\
+		.base = (struct pwm_it8xxx2_regs *) DT_REG_ADDR(DT_NODELABEL(prs)),	\
 		.prs_sel = DT_PROP(DT_INST(inst, ite_it8xxx2_pwm), prescaler_cx),	\
-		.pinctrls = DEV_PINMUX(inst),						\
-		.pin = DEV_PIN(inst),							\
-		.alt_fun = DEV_ALT_FUN(inst),						\
+		.alt_list = pwm_alt_##inst,						\
 	};										\
 											\
 	DEVICE_DT_INST_DEFINE(inst,							\

--- a/dts/bindings/pwm/ite,it8xxx2-pwm.yaml
+++ b/dts/bindings/pwm/ite,it8xxx2-pwm.yaml
@@ -21,14 +21,18 @@ properties:
       type: int
       required: true
       enum:
-            - 0 #PWM_CHANNEL_0
-            - 1 #PWM_CHANNEL_1
-            - 2 #PWM_CHANNEL_2
-            - 3 #PWM_CHANNEL_3
-            - 4 #PWM_CHANNEL_4
-            - 5 #PWM_CHANNEL_5
-            - 6 #PWM_CHANNEL_6
-            - 7 #PWM_CHANNEL_7
+            - 0
+            - 1
+            - 2
+            - 3
+            - 4
+            - 5
+            - 6
+            - 7
+      description: |
+        0 = PWM_CHANNEL_0, 1 = PWM_CHANNEL_1, 2 = PWM_CHANNEL_2,
+        3 = PWM_CHANNEL_3, 4 = PWM_CHANNEL_4, 5 = PWM_CHANNEL_5,
+        6 = PWM_CHANNEL_6, 7 = PWM_CHANNEL_7
 
     pwmctrl:
         type: phandle
@@ -44,9 +48,10 @@ properties:
       type: int
       required: true
       enum:
-            - 1 #PWM_PRESCALER_C4
-            - 2 #PWM_PRESCALER_C6
-            - 3 #PWM_PRESCALER_C7
+            - 1
+            - 2
+            - 3
+      description: 1 = PWM_PRESCALER_C4, 2 = PWM_PRESCALER_C6, 3 = PWM_PRESCALER_C7
 
     pwm-output-frequency:
       type: int


### PR DESCRIPTION
1.Putting the PWM_CHANNEL_X, PWM_PRESCALER_CX information
  in the description.

2.Use the common definition EC_FREQ.

3.Use the common macro IT8XXX2_DT_ALT_ITEMS_LIST.

4.Stop using DRV_CONFIG, DRV_REG macro.

5.Delete pwmleds node in dts, because there isn't led in evb board.

Signed-off-by: Ruibin Chang <Ruibin.Chang@ite.com.tw>