### PR TITLE
cmake: Test the compiler before testing compiler flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,11 +36,6 @@ endif()
 #     -fmacro-prefix-map=${ZEPHYR_BASE}=
 
 
-# Verify that the toolchain can compile a dummy file, if it is not we
-# won't be able to test for compatibility with certain C flags.
-zephyr_check_compiler_flag(C "" toolchain_is_ok)
-assert(toolchain_is_ok "The toolchain is unable to build a dummy C file. See CMakeError.log.")
-
 # In some cases the "final" things are not used at all and "_prebuilt"
 # is the last station. See "logical_target_for_zephyr_elf" below for
 # details.

--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -605,11 +605,18 @@ project(Zephyr-Kernel VERSION ${PROJECT_VERSION})
 # windows now.
 list(APPEND CMAKE_ASM_SOURCE_FILE_EXTENSIONS "S")
 enable_language(C CXX ASM)
+
 # The setup / configuration of the toolchain itself and the configuration of
 # supported compilation flags are now split, as this allows to use the toolchain
 # for generic purposes, for example DTS, and then test the toolchain for
 # supported flags at stage two.
 # Testing the toolchain flags requires the enable_language() to have been called in CMake.
+
+# Verify that the toolchain can compile a dummy file, if it is not we
+# won't be able to test for compatibility with certain C flags.
+zephyr_check_compiler_flag(C "" toolchain_is_ok)
+assert(toolchain_is_ok "The toolchain is unable to build a dummy C file. See CMakeError.log.")
+
 include(${ZEPHYR_BASE}/cmake/target_toolchain_flags.cmake)
 
 # 'project' sets PROJECT_BINARY_DIR to ${CMAKE_CURRENT_BINARY_DIR},


### PR DESCRIPTION
We used to test that the compiler works at all, before testing
compiler flags. But during some toolchain refactoring this got
re-arranged.

This commit corrects the ordering.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>