### PR TITLE
gpio_emul: Fix bug with input & output pins

### DIFF
--- a/boards/posix/native_posix/native_posix.yaml
+++ b/boards/posix/native_posix/native_posix.yaml
@@ -14,5 +14,6 @@ supported:
   - adc
   - i2c
   - spi
+  - gpio
 testing:
   default: true

--- a/boards/posix/native_posix/native_posix_64.yaml
+++ b/boards/posix/native_posix/native_posix_64.yaml
@@ -12,3 +12,4 @@ supported:
   - netif:eth
   - usb_device
   - adc
+  - gpio

--- a/drivers/gpio/gpio_emul.c
+++ b/drivers/gpio/gpio_emul.c
@@ -294,10 +294,8 @@ int gpio_emul_input_set_masked_pend(const struct device *port, gpio_port_pins_t 
 	}
 
 	if (~config->common.port_pin_mask & mask) {
-		return -EINVAL;
-	}
-
-	if (values & ~mask) {
+		LOG_ERR("Pin not supported port_pin_mask=%x mask=%x",
+			config->common.port_pin_mask, mask);
 		return -EINVAL;
 	}
 
@@ -305,13 +303,15 @@ int gpio_emul_input_set_masked_pend(const struct device *port, gpio_port_pins_t 
 
 	input_mask = get_input_pins(port);
 	if (~input_mask & mask) {
+		LOG_ERR("Not input pin input_mask=%x mask=%x", input_mask,
+			mask);
 		ret = -EINVAL;
 		goto unlock;
 	}
 
 	prev_values = drv_data->input_vals;
 	drv_data->input_vals &= ~mask;
-	drv_data->input_vals |= values;
+	drv_data->input_vals |= values & mask;
 	values = drv_data->input_vals;
 
 	if (pend) {
@@ -392,6 +392,7 @@ static int gpio_emul_pin_configure(const struct device *port, gpio_pin_t pin,
 		(struct gpio_emul_data *)port->data;
 	const struct gpio_emul_config *config =
 		(const struct gpio_emul_config *)port->config;
+	int rv;
 
 	if (flags & GPIO_OPEN_DRAIN) {
 		return -ENOTSUP;
@@ -412,20 +413,30 @@ static int gpio_emul_pin_configure(const struct device *port, gpio_pin_t pin,
 			drv_data->output_vals &= ~BIT(pin);
 			if (flags & GPIO_INPUT) {
 				/* for push-pull mode to generate interrupts */
-				gpio_emul_input_set_masked_pend(port, BIT(pin), drv_data->output_vals, false);
+				rv = gpio_emul_input_set_masked_pend(
+					port, BIT(pin), drv_data->output_vals,
+					false);
+				__ASSERT_NO_MSG(rv == 0);
 			}
 		} else if (flags & GPIO_OUTPUT_INIT_HIGH) {
 			drv_data->output_vals |= BIT(pin);
 			if (flags & GPIO_INPUT) {
 				/* for push-pull mode to generate interrupts */
-				gpio_emul_input_set_masked_pend(port, BIT(pin), drv_data->output_vals, false);
+				rv = gpio_emul_input_set_masked_pend(
+					port, BIT(pin), drv_data->output_vals,
+					false);
+				__ASSERT_NO_MSG(rv == 0);
 			}
 		}
 	} else if (flags & GPIO_INPUT) {
 		if (flags & GPIO_PULL_UP) {
-			gpio_emul_input_set_masked_pend(port, BIT(pin), BIT(pin), false);
+			rv = gpio_emul_input_set_masked_pend(port, BIT(pin), BIT(pin),
+				false);
+			__ASSERT_NO_MSG(rv == 0);
 		} else if (flags & GPIO_PULL_DOWN) {
-			gpio_emul_input_set_masked_pend(port, BIT(pin), 0, false);
+			rv = gpio_emul_input_set_masked_pend(
+				port, BIT(pin), 0, false);
+			__ASSERT_NO_MSG(rv == 0);
 		}
 	}
 
@@ -459,18 +470,22 @@ static int gpio_emul_port_set_masked_raw(const struct device *port,
 	gpio_port_pins_t prev_values;
 	struct gpio_emul_data *drv_data =
 		(struct gpio_emul_data *)port->data;
+	int rv;
 
 	k_mutex_lock(&drv_data->mu, K_FOREVER);
 	output_mask = get_output_pins(port);
 	mask &= output_mask;
 	prev_values = drv_data->output_vals;
 	prev_values &= output_mask;
-	values &= output_mask;
+	values &= mask;
 	drv_data->output_vals &= ~mask;
 	drv_data->output_vals |= values;
 	/* in push-pull, set input values & fire interrupts */
-	gpio_emul_input_set_masked(port, mask & get_input_pins(port), drv_data->output_vals);
+	rv = gpio_emul_input_set_masked(port, mask & get_input_pins(port),
+		drv_data->output_vals);
 	k_mutex_unlock(&drv_data->mu);
+	__ASSERT_NO_MSG(rv == 0);
+
 	/* for output-wiring, so the user can take action based on ouput */
 	if (prev_values ^ values) {
 		gpio_fire_callbacks(&drv_data->callbacks, port, mask & ~get_input_pins(port));
@@ -484,12 +499,16 @@ static int gpio_emul_port_set_bits_raw(const struct device *port,
 {
 	struct gpio_emul_data *drv_data =
 		(struct gpio_emul_data *)port->data;
+	int rv;
 
 	k_mutex_lock(&drv_data->mu, K_FOREVER);
 	pins &= get_output_pins(port);
 	drv_data->output_vals |= pins;
 	/* in push-pull, set input values & fire interrupts */
-	gpio_emul_input_set_masked(port, pins & get_input_pins(port), drv_data->output_vals);
+	rv = gpio_emul_input_set_masked(port, pins & get_input_pins(port),
+		drv_data->output_vals);
+	__ASSERT_NO_MSG(rv == 0);
+
 	k_mutex_unlock(&drv_data->mu);
 	/* for output-wiring, so the user can take action based on ouput */
 	gpio_fire_callbacks(&drv_data->callbacks, port, pins & ~get_input_pins(port));
@@ -502,13 +521,15 @@ static int gpio_emul_port_clear_bits_raw(const struct device *port,
 {
 	struct gpio_emul_data *drv_data =
 		(struct gpio_emul_data *)port->data;
+	int rv;
 
 	k_mutex_lock(&drv_data->mu, K_FOREVER);
 	pins &= get_output_pins(port);
 	drv_data->output_vals &= ~pins;
 	/* in push-pull, set input values & fire interrupts */
-	gpio_emul_input_set_masked(port, pins & get_input_pins(port), drv_data->output_vals);
+	rv = gpio_emul_input_set_masked(port, pins & get_input_pins(port), drv_data->output_vals);
 	k_mutex_unlock(&drv_data->mu);
+	__ASSERT_NO_MSG(rv == 0);
 	/* for output-wiring, so the user can take action based on ouput */
 	gpio_fire_callbacks(&drv_data->callbacks, port, pins & ~get_input_pins(port));
 
@@ -519,12 +540,15 @@ static int gpio_emul_port_toggle_bits(const struct device *port, gpio_port_pins_
 {
 	struct gpio_emul_data *drv_data =
 		(struct gpio_emul_data *)port->data;
+	int rv;
 
 	k_mutex_lock(&drv_data->mu, K_FOREVER);
 	drv_data->output_vals ^= (pins & get_output_pins(port));
 	/* in push-pull, set input values but do not fire interrupts (yet) */
-	gpio_emul_input_set_masked_pend(port, pins & get_input_pins(port), drv_data->output_vals, false);
+	rv = gpio_emul_input_set_masked_pend(port, pins & get_input_pins(port),
+		drv_data->output_vals, false);
 	k_mutex_unlock(&drv_data->mu);
+	__ASSERT_NO_MSG(rv == 0);
 	/* for output-wiring, so the user can take action based on ouput */
 	gpio_fire_callbacks(&drv_data->callbacks, port, pins);
 


### PR DESCRIPTION
Change gpio_emul_input_set_masked_pend to log when it returns an error.
Changed all calls to gpio_emul_input_set_masked* to check the return
value.

Added a test case that sets and reads emulated 2 gpios to make sure
they don't interact with each other. Fails before this cl, passes
afterwards.

./scripts/twister -T tests/drivers/gpio

The function gpio_emul_input_set_masked_pend will not set the input
values if there are bits set in the value that are not in the mask. In
almost every call to that function, the value wasn't being limited to
bits set in the mask, so they were failing if there was more than one
gpio configured for INPUT|OUTPUT with a value of 1.
