### PR TITLE
ipc_service: Add open_instance function

### DIFF
--- a/include/ipc/ipc_service.h
+++ b/include/ipc/ipc_service.h
@@ -116,6 +116,19 @@ struct ipc_ept_cfg {
 	void *priv;
 };
 
+/** @brief Open an instance
+ *
+ *  Optional function to be used to open an instance before being able to
+ *  register a new endpoint on it.
+ *
+ *  @retval -EIO when no backend is registered.
+ *  @retval -EINVAL when instance or endpoint configuration is invalid.
+ *  @retval -EALREADY when the instance is already opened.
+ *  @retval Other errno codes depending on the implementation of the backend.
+ */
+int ipc_service_open_instance(const struct device *instance);
+
+
 /** @brief Register IPC endpoint onto an instance.
  *
  *  Registers IPC endpoint onto an instance to enable communication with a

--- a/include/ipc/ipc_service_backend.h
+++ b/include/ipc/ipc_service_backend.h
@@ -25,6 +25,14 @@ extern "C" {
  *  This structure is used for configuration backend during registration.
  */
 struct ipc_service_backend {
+	/** @brief Pointer to the function that will be used to open an instance
+	 *
+	 *  @param instance Instance pointer.
+	 *
+	 *  @retval Status code.
+	 */
+	int (*open_instance)(const struct device *instance);
+
 	/** @brief Pointer to the function that will be used to send data to the endpoint.
 	 *
 	 *  @param instance Instance pointer.

--- a/subsys/ipc/ipc_service/ipc_service.c
+++ b/subsys/ipc/ipc_service/ipc_service.c
@@ -14,6 +14,25 @@
 
 LOG_MODULE_REGISTER(ipc_service, CONFIG_IPC_SERVICE_LOG_LEVEL);
 
+int ipc_service_open_instance(const struct device *instance)
+{
+	const struct ipc_service_backend *backend;
+
+	if (!instance) {
+		LOG_ERR("Invalid instance");
+		return -EINVAL;
+	}
+
+	backend = (const struct ipc_service_backend *) instance->api;
+
+	if (!backend || !backend->open_instance) {
+		LOG_ERR("Invalid backend configuration");
+		return -EIO;
+	}
+
+	return backend->open_instance(instance);
+}
+
 int ipc_service_register_endpoint(const struct device *instance,
 				  struct ipc_ept *ept,
 				  const struct ipc_ept_cfg *cfg)


### PR DESCRIPTION
As know, an instance is the external representation of a physical communication channel between two domains / CPUs.

This communication channel must be usually known and initialized (that is "opened") by both parties in the communication before a proper communication can be instaurated using endpoints.

Depending on the backend and on the library / protocol used by the backend, this "opening" can go through some handshaking or synchronization procedure run by the parties that sometimes can be blocking or time-consuming.

For example in the simplest case of a backend using OpenAMP, the remote side of the communication is waiting for the local part to be up and running by loop-waiting on some flag set in the shared memory by the local party.

This is a blocking process so a particular attention must be paid to where this is going to be placed in the backend code.

Currently it is only possible to have this synchronization procedure in two points: (1) the init function of the instance, (2) during
ipc_service_register_endpoint().

It should be highly discouraged to put any blocking routine in the init code, so (1) must be excluded. It is also frowned upon using the endpoint registration function (2) because the synchronization is something concerning the instance, not the single endpoints.

This patch is adding a new optional ipc_service_open_instance() function that can be used to host the handshaking or synchronization code between the two parties of the instance.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>