### PR TITLE
samples: shell_module: fix missing qsort reference

### DIFF
--- a/samples/subsys/shell/shell_module/src/dynamic_cmd.c
+++ b/samples/subsys/shell/shell_module/src/dynamic_cmd.c
@@ -7,6 +7,7 @@
 #include <shell/shell.h>
 #include <ctype.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #define MAX_CMD_CNT (20u)
 #define MAX_CMD_LEN (33u)


### PR DESCRIPTION
PR #39980 added qsort to minimal libc but caused
shell_modules sample to fail building.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>