### PR TITLE
MAINTAINERS: Replace joerchan with alwa-nordic

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -168,7 +168,7 @@ Bluetooth:
     maintainers:
         - jhedberg
     collaborators:
-        - joerchan
+        - alwa-nordic
         - Vudentz
         - Thalley
         - asbjornsabo


### PR DESCRIPTION
I'm taking over for joerchan at Nordic Semiconductor as a Zephyr
Bluetooth host collaborator.

Signed-off-by: Aleksander Wasaznik <aleksander.wasaznik@nordicsemi.no>