### PR TITLE
Bluetooth: Controller: Fix Periodic Sync Failed to be Established

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -6036,18 +6036,20 @@ static void le_per_adv_sync_established(struct pdu_data *pdu_data,
 
 	se = (void *)pdu_data;
 	sep->status = se->status;
-	sep->handle = sys_cpu_to_le16(node_rx->hdr.handle);
 
-	if (sep->status != BT_HCI_ERR_SUCCESS && sep->status != BT_HCI_ERR_UNSUPP_REMOTE_FEATURE) {
+	if (se->status == BT_HCI_ERR_OP_CANCELLED_BY_HOST) {
 		return;
 	}
 
+	sep->handle = sys_cpu_to_le16(node_rx->hdr.handle);
+
 	scan = node_rx->hdr.rx_ftr.param;
 
-	sep->sid = scan->per_scan.sid;
 	/* Resolved address, if private, has been populated in ULL */
 	sep->adv_addr.type = scan->per_scan.adv_addr_type;
 	memcpy(&sep->adv_addr.a.val[0], scan->per_scan.adv_addr, BDADDR_SIZE);
+
+	sep->sid = scan->per_scan.sid;
 	sep->phy = find_lsb_set(se->phy);
 	sep->interval = sys_cpu_to_le16(se->interval);
 	sep->clock_accuracy = se->sca;

--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -25,6 +25,9 @@
 #define SCAN_INT_UNIT_US 625U
 #define CONN_INT_UNIT_US 1250U
 
+/* Intervals after which connection or sync establishment is considered lost */
+#define CONN_ESTAB_COUNTDOWN 6U
+
 #if defined(CONFIG_BT_CTLR_XTAL_ADVANCED)
 #define XON_BITMASK BIT(31) /* XTAL has been retained from previous prepare */
 #endif /* CONFIG_BT_CTLR_XTAL_ADVANCED */

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -1370,11 +1370,41 @@ void ll_rx_mem_release(void **node_rx)
 		{
 			struct node_rx_sync *se =
 				(void *)((struct node_rx_pdu *)rx_free)->pdu;
+			uint8_t status = se->status;
 
-			if (!se->status) {
+			/* Below status codes use node_rx_sync_estab, hence
+			 * release the node_rx memory and release sync context
+			 * if sync establishment failed.
+			 */
+			if ((status == BT_HCI_ERR_SUCCESS) ||
+			    (status == BT_HCI_ERR_UNSUPP_REMOTE_FEATURE) ||
+			    (status == BT_HCI_ERR_CONN_FAIL_TO_ESTAB)) {
+				struct ll_sync_set *sync;
+				struct ll_scan_set *scan;
+
+				/* pick the scan context before node_rx
+				 * release.
+				 */
+				scan = (void *)rx_free->rx_ftr.param;
+
 				mem_release(rx_free, &mem_pdu_rx.free);
 
+				/* pick the sync context before scan context
+				 * is cleanup of sync context association.
+				 */
+				sync = scan->per_scan.sync;
+
+				ull_sync_setup_complete(scan);
+
+				if (status != BT_HCI_ERR_SUCCESS) {
+					ull_sync_release(sync);
+				}
+
 				break;
+			} else {
+				LL_ASSERT(status == BT_HCI_ERR_OP_CANCELLED_BY_HOST);
+
+				/* Fall through and release sync context */
 			}
 		}
 		/* Pass through */
@@ -1387,6 +1417,7 @@ void ll_rx_mem_release(void **node_rx)
 			ull_sync_release(sync);
 		}
 		break;
+
 #if defined(CONFIG_BT_CTLR_DF_SCAN_CTE_RX)
 		case NODE_RX_TYPE_IQ_SAMPLE_REPORT:
 		{

--- a/subsys/bluetooth/controller/ll_sw/ull_central.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central.c
@@ -255,7 +255,7 @@ uint8_t ll_create_connection(uint16_t scan_interval, uint16_t scan_window,
 	memset(&conn_lll->conn_meta, 0, sizeof(conn_lll->conn_meta));
 #endif /* CONFIG_BT_CTLR_CONN_META */
 
-	conn->connect_expire = 6U;
+	conn->connect_expire = CONN_ESTAB_COUNTDOWN;
 	conn->supervision_expire = 0U;
 	conn_interval_us = (uint32_t)interval * CONN_INT_UNIT_US;
 	conn->supervision_reload = RADIO_CONN_EVENTS(timeout * 10000U,

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -275,7 +275,7 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 #if defined(CONFIG_BT_CTLR_SYNC_PERIODIC)
 		/* Check if Periodic Advertising Synchronization to be created
 		 */
-		if (sync) {
+		if (sync && (scan->per_scan.state != LL_SYNC_STATE_CREATED)) {
 			/* Check address and update internal state */
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 			ull_sync_setup_addr_check(scan, pdu->tx_addr, ptr,
@@ -536,7 +536,7 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 
 ull_scan_aux_rx_flush:
 #if defined(CONFIG_BT_CTLR_SYNC_PERIODIC)
-	if (sync) {
+	if (sync && (scan->per_scan.state != LL_SYNC_STATE_CREATED)) {
 		scan->per_scan.state = LL_SYNC_STATE_IDLE;
 	}
 #endif /* CONFIG_BT_CTLR_SYNC_PERIODIC */

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -56,8 +56,8 @@ static void sync_ticker_cleanup(struct ll_sync_set *sync, ticker_op_func stop_of
 static void ticker_cb(uint32_t ticks_at_expire, uint32_t ticks_drift,
 		      uint32_t remainder, uint16_t lazy, uint8_t force,
 		      void *param);
-static void ticker_op_cb(uint32_t status, void *param);
-static void ticker_update_sync_op_cb(uint32_t status, void *param);
+static void ticker_start_op_cb(uint32_t status, void *param);
+static void ticker_update_op_cb(uint32_t status, void *param);
 static void ticker_stop_op_cb(uint32_t status, void *param);
 static void sync_lost(void *param);
 #if defined(CONFIG_BT_CTLR_CHECK_SAME_PEER_SYNC)
@@ -648,7 +648,8 @@ void ull_sync_setup(struct ll_scan_set *scan, struct ll_scan_aux_set *aux,
 			   HAL_TICKER_REMAINDER(interval_us),
 			   TICKER_NULL_LAZY,
 			   (sync->ull.ticks_slot + ticks_slot_overhead),
-			   ticker_cb, sync, ticker_op_cb, (void *)__LINE__);
+			   ticker_cb, sync,
+			   ticker_start_op_cb, (void *)__LINE__);
 	LL_ASSERT((ret == TICKER_STATUS_SUCCESS) ||
 		  (ret == TICKER_STATUS_BUSY));
 }
@@ -817,16 +818,21 @@ void ull_sync_done(struct node_rx_event_done *done)
 			uint32_t ticker_status;
 
 			/* Call to ticker_update can fail under the race
-			 * condition where in the periodic sync role is being stopped
-			 * but at the same time it is preempted by periodic sync event
-			 * that gets into close state. Accept failure when periodic sync
-			 * role is being stopped.
+			 * condition where in the periodic sync role is being
+			 * stopped but at the same time it is preempted by
+			 * periodic sync event that gets into close state.
+			 * Accept failure when periodic sync role is being
+			 * stopped.
 			 */
 			ticker_status =
-				ticker_update(TICKER_INSTANCE_ID_CTLR, TICKER_USER_ID_ULL_HIGH,
-					      (TICKER_ID_SCAN_SYNC_BASE + sync_handle),
-					      ticks_drift_plus, ticks_drift_minus, 0, 0, lazy,
-					      force, ticker_update_sync_op_cb, sync);
+				ticker_update(TICKER_INSTANCE_ID_CTLR,
+					      TICKER_USER_ID_ULL_HIGH,
+					      (TICKER_ID_SCAN_SYNC_BASE +
+					       sync_handle),
+					      ticks_drift_plus,
+					      ticks_drift_minus, 0, 0,
+					      lazy, force,
+					      ticker_update_op_cb, sync);
 			LL_ASSERT((ticker_status == TICKER_STATUS_SUCCESS) ||
 				  (ticker_status == TICKER_STATUS_BUSY) ||
 				  ((void *)sync == ull_disable_mark_get()));
@@ -1017,13 +1023,13 @@ static void ticker_cb(uint32_t ticks_at_expire, uint32_t ticks_drift,
 	DEBUG_RADIO_PREPARE_O(1);
 }
 
-static void ticker_op_cb(uint32_t status, void *param)
+static void ticker_start_op_cb(uint32_t status, void *param)
 {
 	ARG_UNUSED(param);
 	LL_ASSERT(status == TICKER_STATUS_SUCCESS);
 }
 
-static void ticker_update_sync_op_cb(uint32_t status, void *param)
+static void ticker_update_op_cb(uint32_t status, void *param)
 {
 	LL_ASSERT(status == TICKER_STATUS_SUCCESS ||
 		  param == ull_disable_mark_get());

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_internal.h
@@ -14,6 +14,7 @@ void ull_sync_setup_addr_check(struct ll_scan_set *scan, uint8_t addr_type,
 bool ull_sync_setup_sid_match(struct ll_scan_set *scan, uint8_t sid);
 void ull_sync_setup(struct ll_scan_set *scan, struct ll_scan_aux_set *aux,
 		    struct node_rx_hdr *node_rx, struct pdu_adv_sync_info *si);
+void ull_sync_setup_complete(struct ll_scan_set *scan);
 void ull_sync_established_report(memq_link_t *link, struct node_rx_hdr *rx);
 void ull_sync_done(struct node_rx_event_done *done);
 void ull_sync_chm_update(uint8_t sync_handle, uint8_t *acad, uint8_t acad_len);

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_types.h
@@ -41,6 +41,8 @@ struct ll_sync_set {
 	uint8_t sync_term:1;
 #endif /* CONFIG_BT_CTLR_SYNC_PERIODIC_CTE_TYPE_FILTERING && !CONFIG_BT_CTLR_CTEINLINE_SUPPORT */
 
+	uint8_t sync_expire:3; /* countdown of 6 before fail to establish */
+
 #if defined(CONFIG_BT_CTLR_CHECK_SAME_PEER_SYNC)
 	uint8_t sid;
 #endif /* CONFIG_BT_CTLR_CHECK_SAME_PEER_SYNC */


### PR DESCRIPTION
Fix Periodic Advertising Synchronize implementation to
generate Synchronization Failed to be Established event
when 6 AUX_SYNC_IND PDUs are not received when establishing
synchronization.

Fixes #40209

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>