### PR TITLE
coding guidelines: comply with MISRA C:2012 Rule 21.13

### DIFF
--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -521,7 +521,7 @@ static char get_entry_code(pentry_t value)
 
 		if ((value & MMU_US) != 0U) {
 			/* Uppercase indicates user mode access */
-			ret = toupper(ret);
+			ret = toupper((unsigned char)ret);
 		}
 	}
 

--- a/lib/libc/minimal/source/stdlib/atoi.c
+++ b/lib/libc/minimal/source/stdlib/atoi.c
@@ -33,7 +33,7 @@ int atoi(const char *s)
 	int n = 0;
 	int neg = 0;
 
-	while (isspace(*s)) {
+	while (isspace((unsigned char)*s)) {
 		s++;
 	}
 	switch (*s) {
@@ -51,7 +51,7 @@ int atoi(const char *s)
 		break;
 	}
 	/* Compute n as a negative number to avoid overflow on INT_MIN */
-	while (isdigit(*s)) {
+	while (isdigit((unsigned char)*s)) {
 		n = 10*n - (*s++ - '0');
 	}
 	return neg ? n : -n;

--- a/lib/libc/minimal/source/stdlib/strtol.c
+++ b/lib/libc/minimal/source/stdlib/strtol.c
@@ -57,7 +57,7 @@ long strtol(const char *nptr, char **endptr, register int base)
 	 */
 	do {
 		c = *s++;
-	} while (isspace(c));
+	} while (isspace((unsigned char)c));
 	if (c == '-') {
 		neg = 1;
 		c = *s++;
@@ -97,10 +97,10 @@ long strtol(const char *nptr, char **endptr, register int base)
 	cutlim = cutoff % (unsigned long)base;
 	cutoff /= (unsigned long)base;
 	for (acc = 0, any = 0;; c = *s++) {
-		if (isdigit(c)) {
+		if (isdigit((unsigned char)c)) {
 			c -= '0';
-		} else if (isalpha(c)) {
-			c -= isupper(c) ? 'A' - 10 : 'a' - 10;
+		} else if (isalpha((unsigned char)c)) {
+			c -= isupper((unsigned char)c) ? 'A' - 10 : 'a' - 10;
 		} else {
 			break;
 		}

--- a/lib/libc/minimal/source/stdlib/strtoul.c
+++ b/lib/libc/minimal/source/stdlib/strtoul.c
@@ -56,7 +56,7 @@ unsigned long strtoul(const char *nptr, char **endptr, register int base)
 	 */
 	do {
 		c = *s++;
-	} while (isspace(c));
+	} while (isspace((unsigned char)c));
 	if (c == '-') {
 		neg = 1;
 		c = *s++;
@@ -78,10 +78,10 @@ unsigned long strtoul(const char *nptr, char **endptr, register int base)
 	cutoff = (unsigned long)ULONG_MAX / (unsigned long)base;
 	cutlim = (unsigned long)ULONG_MAX % (unsigned long)base;
 	for (acc = 0, any = 0;; c = *s++) {
-		if (isdigit(c)) {
+		if (isdigit((unsigned char)c)) {
 			c -= '0';
-		} else if (isalpha(c)) {
-			c -= isupper(c) ? 'A' - 10 : 'a' - 10;
+		} else if (isalpha((unsigned char)c)) {
+			c -= isupper((unsigned char)c) ? 'A' - 10 : 'a' - 10;
 		} else {
 			break;
 		}

--- a/lib/libc/minimal/source/string/strncasecmp.c
+++ b/lib/libc/minimal/source/string/strncasecmp.c
@@ -17,7 +17,7 @@ strncasecmp(const char *s1, const char *s2, size_t n)
 
 		c = *s1++;
 		lower1 = tolower(c);
-		lower2 = tolower(*s2++);
+		lower2 = tolower((unsigned char)*s2++);
 
 		if (lower1 != lower2) {
 			return (lower1 > lower2) - (lower1 < lower2);

--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -905,7 +905,7 @@ static char *encode_float(double value,
 	 */
 	if (expo == BIT_MASK(EXPONENT_BITS)) {
 		if (fract == 0) {
-			if (isupper((int)c)) {
+			if (isupper((unsigned char)c)) {
 				*buf++ = 'I';
 				*buf++ = 'N';
 				*buf++ = 'F';
@@ -915,7 +915,7 @@ static char *encode_float(double value,
 				*buf++ = 'f';
 			}
 		} else {
-			if (isupper((int)c)) {
+			if (isupper((unsigned char)c)) {
 				*buf++ = 'N';
 				*buf++ = 'A';
 				*buf++ = 'N';
@@ -997,7 +997,7 @@ static char *encode_float(double value,
 		 * for a and X for A.
 		 */
 		struct conversion aconv = {
-			.specifier = isupper((int)c) ? 'X' : 'x',
+			.specifier = isupper((unsigned char)c) ? 'X' : 'x',
 		};
 		const char *spe = *bpe;
 		char *sp = bps + (spe - bps);
@@ -1771,7 +1771,7 @@ int cbvprintf(cbprintf_cb out, void *ctx, const char *fp, va_list ap)
 					OUTC(*cp++);
 				}
 			} else {
-				while (isdigit((int)*cp)) {
+				while (isdigit((unsigned char)*cp)) {
 					OUTC(*cp++);
 				}
 
@@ -1791,7 +1791,7 @@ int cbvprintf(cbprintf_cb out, void *ctx, const char *fp, va_list ap)
 						OUTC('0');
 					}
 				}
-				while (isdigit((int)*cp)) {
+				while (isdigit((unsigned char)*cp)) {
 					OUTC(*cp++);
 				}
 			}


### PR DESCRIPTION
MISRA C:2012 Rule 21.13 (Any value passed to a function in <ctype.h>
shall be representable as an unsigned char or be the value EOF).

Functions in <ctype.h> have undefined behavior if they are called with
any other value. Callers affected by this change are not prepared to
handle EOF anyway. The addition of these casts avoids the issue
and does not result in any performance penalty.

Signed-off-by: Abramo Bagnara <abramo.bagnara@bugseng.com>