### PR TITLE
boards: arm: qemu_cortex_a9: change board's timing parameters

### DIFF
--- a/boards/arm/qemu_cortex_a9/Kconfig.defconfig
+++ b/boards/arm/qemu_cortex_a9/Kconfig.defconfig
@@ -15,10 +15,10 @@ config BOARD
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	int
-	default 100000000
+	default 111111111
 
 config SYS_CLOCK_TICKS_PER_SEC
-	default 100
+	default 1000
 
 if CONSOLE
 
@@ -71,7 +71,7 @@ endif # NETWORKING
 if QEMU_ICOUNT
 
 	config QEMU_ICOUNT_SHIFT
-	default 8
+	default 3
 	config QEMU_ICOUNT_SLEEP
 	default y
 


### PR DESCRIPTION
- Fix the system clock frequency: should be 111.1 MHz instead
of 100 MHz.
- Set ticks per second to 1000 for higher system clock precision.
- Set QEMU icount shift value to 3 so that one instruction gets
executed every 2^3 = 8 ns.

Signed-off-by: Immo Birnbaum <Immo.Birnbaum@Weidmueller.com>