### PR TITLE
kernel: mem_domain: let k_mem_domain_*() functions to return errors

### DIFF
--- a/arch/arm64/core/mmu.c
+++ b/arch/arm64/core/mmu.c
@@ -1006,8 +1006,8 @@ int arch_mem_domain_init(struct k_mem_domain *domain)
 	return 0;
 }
 
-static void private_map(struct arm_mmu_ptables *ptables, const char *name,
-			uintptr_t phys, uintptr_t virt, size_t size, uint32_t attrs)
+static int private_map(struct arm_mmu_ptables *ptables, const char *name,
+		       uintptr_t phys, uintptr_t virt, size_t size, uint32_t attrs)
 {
 	int ret;
 
@@ -1018,10 +1018,12 @@ static void private_map(struct arm_mmu_ptables *ptables, const char *name,
 	if (is_ptable_active(ptables)) {
 		invalidate_tlb_all();
 	}
+
+	return ret;
 }
 
-static void reset_map(struct arm_mmu_ptables *ptables, const char *name,
-		      uintptr_t addr, size_t size)
+static int reset_map(struct arm_mmu_ptables *ptables, const char *name,
+		     uintptr_t addr, size_t size)
 {
 	int ret;
 
@@ -1030,40 +1032,44 @@ static void reset_map(struct arm_mmu_ptables *ptables, const char *name,
 	if (is_ptable_active(ptables)) {
 		invalidate_tlb_all();
 	}
+
+	return ret;
 }
 
-void arch_mem_domain_partition_add(struct k_mem_domain *domain,
-				   uint32_t partition_id)
+int arch_mem_domain_partition_add(struct k_mem_domain *domain,
+				  uint32_t partition_id)
 {
 	struct arm_mmu_ptables *domain_ptables = &domain->arch.ptables;
 	struct k_mem_partition *ptn = &domain->partitions[partition_id];
 
-	private_map(domain_ptables, "partition", ptn->start, ptn->start,
-		    ptn->size, ptn->attr.attrs | MT_NORMAL);
+	return private_map(domain_ptables, "partition", ptn->start, ptn->start,
+			   ptn->size, ptn->attr.attrs | MT_NORMAL);
 }
 
-void arch_mem_domain_partition_remove(struct k_mem_domain *domain,
-				      uint32_t partition_id)
+int arch_mem_domain_partition_remove(struct k_mem_domain *domain,
+				     uint32_t partition_id)
 {
 	struct arm_mmu_ptables *domain_ptables = &domain->arch.ptables;
 	struct k_mem_partition *ptn = &domain->partitions[partition_id];
 
-	reset_map(domain_ptables, "partition removal", ptn->start, ptn->size);
+	return reset_map(domain_ptables, "partition removal",
+			 ptn->start, ptn->size);
 }
 
-static void map_thread_stack(struct k_thread *thread,
-			     struct arm_mmu_ptables *ptables)
+static int map_thread_stack(struct k_thread *thread,
+			    struct arm_mmu_ptables *ptables)
 {
-	private_map(ptables, "thread_stack", thread->stack_info.start,
-		    thread->stack_info.start, thread->stack_info.size,
-		    MT_P_RW_U_RW | MT_NORMAL);
+	return private_map(ptables, "thread_stack", thread->stack_info.start,
+			    thread->stack_info.start, thread->stack_info.size,
+			    MT_P_RW_U_RW | MT_NORMAL);
 }
 
-void arch_mem_domain_thread_add(struct k_thread *thread)
+int arch_mem_domain_thread_add(struct k_thread *thread)
 {
 	struct arm_mmu_ptables *old_ptables, *domain_ptables;
 	struct k_mem_domain *domain;
 	bool is_user, is_migration;
+	int ret = 0;
 
 	domain = thread->mem_domain_info.mem_domain;
 	domain_ptables = &domain->arch.ptables;
@@ -1073,7 +1079,7 @@ void arch_mem_domain_thread_add(struct k_thread *thread)
 	is_migration = (old_ptables != NULL) && is_user;
 
 	if (is_migration) {
-		map_thread_stack(thread, domain_ptables);
+		ret = map_thread_stack(thread, domain_ptables);
 	}
 
 	thread->arch.ptables = domain_ptables;
@@ -1089,12 +1095,14 @@ void arch_mem_domain_thread_add(struct k_thread *thread)
 	}
 
 	if (is_migration) {
-		reset_map(old_ptables, __func__, thread->stack_info.start,
+		ret = reset_map(old_ptables, __func__, thread->stack_info.start,
 				thread->stack_info.size);
 	}
+
+	return ret;
 }
 
-void arch_mem_domain_thread_remove(struct k_thread *thread)
+int arch_mem_domain_thread_remove(struct k_thread *thread)
 {
 	struct arm_mmu_ptables *domain_ptables;
 	struct k_mem_domain *domain;
@@ -1103,15 +1111,15 @@ void arch_mem_domain_thread_remove(struct k_thread *thread)
 	domain_ptables = &domain->arch.ptables;
 
 	if ((thread->base.user_options & K_USER) == 0) {
-		return;
+		return 0;
 	}
 
 	if ((thread->base.thread_state & _THREAD_DEAD) == 0) {
-		return;
+		return 0;
 	}
 
-	reset_map(domain_ptables, __func__, thread->stack_info.start,
-		  thread->stack_info.size);
+	return reset_map(domain_ptables, __func__, thread->stack_info.start,
+			 thread->stack_info.size);
 }
 
 static void z_arm64_swap_ptables(struct k_thread *incoming)

--- a/arch/riscv/include/core_pmp.h
+++ b/arch/riscv/include/core_pmp.h
@@ -94,8 +94,12 @@ void z_riscv_configure_user_allowed_stack(struct k_thread *thread);
  * @param addr   Start address of the memory area.
  * @param size   Size of the memory area.
  * @param flags  Pemissions: PMP_R, PMP_W, PMP_X, PMP_L
+ *
+ * @retval 0 if successful
+ * @retval -EINVAL if invalid parameters supplied
+ * @retval -ENOSPC if no free PMP entry
  */
-void z_riscv_pmp_add_dynamic(struct k_thread *thread,
+int z_riscv_pmp_add_dynamic(struct k_thread *thread,
 			ulong_t addr,
 			ulong_t size,
 			unsigned char flags);

--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -9,6 +9,7 @@
 #include <arch/x86/mmustructs.h>
 #include <sys/mem_manage.h>
 #include <sys/__assert.h>
+#include <sys/check.h>
 #include <logging/log.h>
 #include <errno.h>
 #include <ctype.h>
@@ -453,19 +454,61 @@ static inline void assert_addr_aligned(uintptr_t addr)
 }
 
 __pinned_func
+static inline bool is_addr_aligned(uintptr_t addr)
+{
+	if ((addr & (CONFIG_MMU_PAGE_SIZE - 1)) == 0U) {
+		return true;
+	} else {
+		return false;
+	}
+}
+
+__pinned_func
 static inline void assert_virt_addr_aligned(void *addr)
 {
 	assert_addr_aligned((uintptr_t)addr);
 }
 
 __pinned_func
-static inline void assert_region_page_aligned(void *addr, size_t size)
+static inline bool is_virt_addr_aligned(void *addr)
 {
-	assert_virt_addr_aligned(addr);
+	return is_addr_aligned((uintptr_t)addr);
+}
+
+__pinned_func
+static inline void assert_size_aligned(size_t size)
+{
 #if __ASSERT_ON
 	__ASSERT((size & (CONFIG_MMU_PAGE_SIZE - 1)) == 0U,
 		 "unaligned size %zu", size);
 #endif
+}
+
+__pinned_func
+static inline bool is_size_aligned(size_t size)
+{
+	if ((size & (CONFIG_MMU_PAGE_SIZE - 1)) == 0U) {
+		return true;
+	} else {
+		return false;
+	}
+}
+
+__pinned_func
+static inline void assert_region_page_aligned(void *addr, size_t size)
+{
+	assert_virt_addr_aligned(addr);
+	assert_size_aligned(size);
+}
+
+__pinned_func
+static inline bool is_region_page_aligned(void *addr, size_t size)
+{
+	if (!is_virt_addr_aligned(addr)) {
+		return false;
+	}
+
+	return is_size_aligned(size);
 }
 
 /*
@@ -946,13 +989,17 @@ static inline pentry_t pte_atomic_update(pentry_t *pte, pentry_t update_val,
  * @param mask What bits to update in the PTE (ignored if OPTION_RESET or
  *        OPTION_CLEAR)
  * @param options Control options, described above
+ *
+ * @retval 0 if successful
+ * @retval -EFAULT if large page encountered or missing page table level
  */
 __pinned_func
-static void page_map_set(pentry_t *ptables, void *virt, pentry_t entry_val,
-			 pentry_t *old_val_ptr, pentry_t mask, uint32_t options)
+static int page_map_set(pentry_t *ptables, void *virt, pentry_t entry_val,
+			pentry_t *old_val_ptr, pentry_t mask, uint32_t options)
 {
 	pentry_t *table = ptables;
 	bool flush = (options & OPTION_FLUSH) != 0U;
+	int ret = 0;
 
 	for (int level = 0; level < NUM_LEVELS; level++) {
 		int index;
@@ -971,20 +1018,40 @@ static void page_map_set(pentry_t *ptables, void *virt, pentry_t entry_val,
 			break;
 		}
 
-		/* We fail an assertion here due to no support for
+		/* We bail out early here due to no support for
 		 * splitting existing bigpage mappings.
 		 * If the PS bit is not supported at some level (like
 		 * in a PML4 entry) it is always reserved and must be 0
 		 */
-		__ASSERT((*entryp & MMU_PS) == 0U, "large page encountered");
+		CHECKIF(!((*entryp & MMU_PS) == 0U)) {
+			/* Cannot continue since we cannot split
+			 * bigpage mappings.
+			 */
+			LOG_ERR("large page encountered");
+			ret = -EFAULT;
+			goto out;
+		}
+
 		table = next_table(*entryp, level);
-		__ASSERT(table != NULL,
-			 "missing page table level %d when trying to map %p",
-			 level + 1, virt);
+
+		CHECKIF(!(table != NULL)) {
+			/* Cannot continue since table is NULL,
+			 * and it cannot be dereferenced in next loop
+			 * iteration.
+			 */
+			LOG_ERR("missing page table level %d when trying to map %p",
+				level + 1, virt);
+			ret = -EFAULT;
+			goto out;
+		}
 	}
+
+out:
 	if (flush) {
 		tlb_flush_page(virt);
 	}
+
+	return ret;
 }
 
 /**
@@ -1012,20 +1079,30 @@ static void page_map_set(pentry_t *ptables, void *virt, pentry_t entry_val,
  * @param mask What bits to update in each PTE. Un-set bits will never be
  *        modified. Ignored if OPTION_RESET or OPTION_CLEAR.
  * @param options Control options, described above
+ *
+ * @retval 0 if successful
+ * @retval -EINVAL if invalid parameters are supplied
+ * @retval -EFAULT if errors encountered when updating page tables
  */
 __pinned_func
-static void range_map_ptables(pentry_t *ptables, void *virt, uintptr_t phys,
-			      size_t size, pentry_t entry_flags, pentry_t mask,
-			      uint32_t options)
+static int range_map_ptables(pentry_t *ptables, void *virt, uintptr_t phys,
+			     size_t size, pentry_t entry_flags, pentry_t mask,
+			     uint32_t options)
 {
 	bool zero_entry = (options & (OPTION_RESET | OPTION_CLEAR)) != 0U;
+	int ret = 0, ret2;
 
-	assert_addr_aligned(phys);
-	__ASSERT((size & (CONFIG_MMU_PAGE_SIZE - 1)) == 0U,
-		 "unaligned size %zu", size);
-	__ASSERT((entry_flags & paging_levels[0].mask) == 0U,
-		 "entry_flags " PRI_ENTRY " overlaps address area",
-		 entry_flags);
+	CHECKIF(!is_addr_aligned(phys) || !is_size_aligned(size)) {
+		ret = -EINVAL;
+		goto out;
+	}
+
+	CHECKIF(!((entry_flags & paging_levels[0].mask) == 0U)) {
+		LOG_ERR("entry_flags " PRI_ENTRY " overlaps address area",
+			entry_flags);
+		ret = -EINVAL;
+		goto out;
+	}
 
 	/* This implementation is stack-efficient but not particularly fast.
 	 * We do a full page table walk for every page we are updating.
@@ -1041,9 +1118,16 @@ static void range_map_ptables(pentry_t *ptables, void *virt, uintptr_t phys,
 			entry_val = (pentry_t)(phys + offset) | entry_flags;
 		}
 
-		page_map_set(ptables, dest_virt, entry_val, NULL, mask,
-			     options);
+		ret2 = page_map_set(ptables, dest_virt, entry_val, NULL, mask,
+				   options);
+		ARG_UNUSED(ret2);
+		CHECKIF(ret2 != 0) {
+			ret = ret2;
+		}
 	}
+
+out:
+	return ret;
 }
 
 /**
@@ -1067,11 +1151,17 @@ static void range_map_ptables(pentry_t *ptables, void *virt, uintptr_t phys,
  *             be preserved. Ignored if OPTION_RESET.
  * @param options Control options. Do not set OPTION_USER here. OPTION_FLUSH
  *                will trigger a TLB shootdown after all tables are updated.
+ *
+ * @retval 0 if successful
+ * @retval -EINVAL if invalid parameters are supplied
+ * @retval -EFAULT if errors encountered when updating page tables
  */
 __pinned_func
-static void range_map(void *virt, uintptr_t phys, size_t size,
-		      pentry_t entry_flags, pentry_t mask, uint32_t options)
+static int range_map(void *virt, uintptr_t phys, size_t size,
+		     pentry_t entry_flags, pentry_t mask, uint32_t options)
 {
+	int ret = 0, ret2;
+
 	LOG_DBG("%s: %p -> %p (%zu) flags " PRI_ENTRY " mask "
 		PRI_ENTRY " opt 0x%x", __func__, (void *)phys, virt, size,
 		entry_flags, mask, options);
@@ -1086,7 +1176,11 @@ static void range_map(void *virt, uintptr_t phys, size_t size,
 		 virt, size);
 #endif /* CONFIG_X86_64 */
 
-	__ASSERT((options & OPTION_USER) == 0U, "invalid option for function");
+	CHECKIF(!((options & OPTION_USER) == 0U)) {
+		LOG_ERR("invalid option for mapping");
+		ret = -EINVAL;
+		goto out;
+	}
 
 	/* All virtual-to-physical mappings are the same in all page tables.
 	 * What can differ is only access permissions, defined by the memory
@@ -1102,30 +1196,46 @@ static void range_map(void *virt, uintptr_t phys, size_t size,
 		struct arch_mem_domain *domain =
 			CONTAINER_OF(node, struct arch_mem_domain, node);
 
-		range_map_ptables(domain->ptables, virt, phys, size,
-				  entry_flags, mask, options | OPTION_USER);
+		ret2 = range_map_ptables(domain->ptables, virt, phys, size,
+					 entry_flags, mask,
+					 options | OPTION_USER);
+		ARG_UNUSED(ret2);
+		CHECKIF(ret2 != 0) {
+			ret = ret2;
+		}
 	}
 #endif /* CONFIG_USERSPACE */
-	range_map_ptables(z_x86_kernel_ptables, virt, phys, size, entry_flags,
-			  mask, options);
 
+	ret2 = range_map_ptables(z_x86_kernel_ptables, virt, phys, size,
+				 entry_flags, mask, options);
+	ARG_UNUSED(ret2);
+	CHECKIF(ret2 != 0) {
+		ret = ret2;
+	}
+
+out:
 #ifdef CONFIG_SMP
 	if ((options & OPTION_FLUSH) != 0U) {
 		tlb_shootdown();
 	}
 #endif /* CONFIG_SMP */
+
+	return ret;
 }
 
 __pinned_func
-static inline void range_map_unlocked(void *virt, uintptr_t phys, size_t size,
-				      pentry_t entry_flags, pentry_t mask,
-				      uint32_t options)
+static inline int range_map_unlocked(void *virt, uintptr_t phys, size_t size,
+				     pentry_t entry_flags, pentry_t mask,
+				     uint32_t options)
 {
 	k_spinlock_key_t key;
+	int ret;
 
 	key = k_spin_lock(&x86_mmu_lock);
-	range_map(virt, phys, size, entry_flags, mask, options);
+	ret = range_map(virt, phys, size, entry_flags, mask, options);
 	k_spin_unlock(&x86_mmu_lock, key);
+
+	return ret;
 }
 
 __pinned_func
@@ -1171,15 +1281,23 @@ static pentry_t flags_to_entry(uint32_t flags)
 __pinned_func
 void arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
 {
-	range_map_unlocked(virt, phys, size, flags_to_entry(flags),
-			   MASK_ALL, 0);
+	int ret;
+
+	ret = range_map_unlocked(virt, phys, size, flags_to_entry(flags),
+				 MASK_ALL, 0);
+	__ASSERT_NO_MSG(ret == 0);
+	ARG_UNUSED(ret);
 }
 
 /* unmap region addr..addr+size, reset entries and flush TLB */
 void arch_mem_unmap(void *addr, size_t size)
 {
-	range_map_unlocked((void *)addr, 0, size, 0, 0,
-			   OPTION_FLUSH | OPTION_CLEAR);
+	int ret;
+
+	ret = range_map_unlocked((void *)addr, 0, size, 0, 0,
+				 OPTION_FLUSH | OPTION_CLEAR);
+	__ASSERT_NO_MSG(ret == 0);
+	ARG_UNUSED(ret);
 }
 
 #ifdef Z_VM_KERNEL
@@ -1241,6 +1359,8 @@ void z_x86_mmu_init(void)
 __pinned_func
 void z_x86_set_stack_guard(k_thread_stack_t *stack)
 {
+	int ret;
+
 	/* Applied to all page tables as this affects supervisor mode.
 	 * XXX: This never gets reset when the thread exits, which can
 	 * cause problems if the memory is later used for something else.
@@ -1249,8 +1369,10 @@ void z_x86_set_stack_guard(k_thread_stack_t *stack)
 	 * Guard page is always the first page of the stack object for both
 	 * kernel and thread stacks.
 	 */
-	range_map_unlocked(stack, 0, CONFIG_MMU_PAGE_SIZE,
-			   MMU_P | ENTRY_XD, MASK_PERM, OPTION_FLUSH);
+	ret = range_map_unlocked(stack, 0, CONFIG_MMU_PAGE_SIZE,
+				 MMU_P | ENTRY_XD, MASK_PERM, OPTION_FLUSH);
+	__ASSERT_NO_MSG(ret == 0);
+	ARG_UNUSED(ret);
 }
 #endif /* CONFIG_X86_STACK_PROTECTION */
 
@@ -1354,17 +1476,17 @@ int arch_buffer_validate(void *addr, size_t size, int write)
  */
 
 __pinned_func
-static inline void reset_region(uintptr_t start, size_t size)
+static inline int reset_region(uintptr_t start, size_t size)
 {
-	range_map_unlocked((void *)start, 0, size, 0, 0,
-			   OPTION_FLUSH | OPTION_RESET);
+	return range_map_unlocked((void *)start, 0, size, 0, 0,
+				  OPTION_FLUSH | OPTION_RESET);
 }
 
 __pinned_func
-static inline void apply_region(uintptr_t start, size_t size, pentry_t attr)
+static inline int apply_region(uintptr_t start, size_t size, pentry_t attr)
 {
-	range_map_unlocked((void *)start, 0, size, attr, MASK_PERM,
-			   OPTION_FLUSH);
+	return range_map_unlocked((void *)start, 0, size, attr, MASK_PERM,
+				  OPTION_FLUSH);
 }
 
 /* Cache of the current memory domain applied to the common page tables and
@@ -1448,44 +1570,46 @@ out_unlock:
  * page tables.
  */
 __pinned_func
-void arch_mem_domain_partition_remove(struct k_mem_domain *domain,
+int arch_mem_domain_partition_remove(struct k_mem_domain *domain,
 				      uint32_t partition_id)
 {
 	struct k_mem_partition *ptn;
 
 	if (domain != current_domain) {
-		return;
+		return 0;
 	}
 
 	ptn = &domain->partitions[partition_id];
-	reset_region(ptn->start, ptn->size);
+
+	return reset_region(ptn->start, ptn->size);
 }
 
 __pinned_func
-void arch_mem_domain_partition_add(struct k_mem_domain *domain,
+int arch_mem_domain_partition_add(struct k_mem_domain *domain,
 				   uint32_t partition_id)
 {
 	struct k_mem_partition *ptn;
 
 	if (domain != current_domain) {
-		return;
+		return 0;
 	}
 
 	ptn = &domain->partitions[partition_id];
-	apply_region(ptn->start, ptn->size, ptn->attr);
+
+	return apply_region(ptn->start, ptn->size, ptn->attr);
 }
 
 /* Rest of the APIs don't need to do anything */
 __pinned_func
-void arch_mem_domain_thread_add(struct k_thread *thread)
+int arch_mem_domain_thread_add(struct k_thread *thread)
 {
-
+	return 0;
 }
 
 __pinned_func
-void arch_mem_domain_thread_remove(struct k_thread *thread)
+int arch_mem_domain_thread_remove(struct k_thread *thread)
 {
-
+	return 0;
 }
 #else
 /* Memory domains each have a set of page tables assigned to them */
@@ -1605,10 +1729,11 @@ static int copy_page_table(pentry_t *dst, pentry_t *src, int level)
 }
 
 __pinned_func
-static void region_map_update(pentry_t *ptables, void *start,
+static int region_map_update(pentry_t *ptables, void *start,
 			      size_t size, pentry_t flags, bool reset)
 {
 	uint32_t options = OPTION_USER;
+	int ret;
 	k_spinlock_key_t key;
 
 	if (reset) {
@@ -1619,29 +1744,31 @@ static void region_map_update(pentry_t *ptables, void *start,
 	}
 
 	key = k_spin_lock(&x86_mmu_lock);
-	(void)range_map_ptables(ptables, start, 0, size, flags, MASK_PERM,
+	ret = range_map_ptables(ptables, start, 0, size, flags, MASK_PERM,
 				options);
 	k_spin_unlock(&x86_mmu_lock, key);
 
 #ifdef CONFIG_SMP
 	tlb_shootdown();
 #endif
+
+	return ret;
 }
 
 __pinned_func
-static inline void reset_region(pentry_t *ptables, void *start, size_t size)
+static inline int reset_region(pentry_t *ptables, void *start, size_t size)
 {
 	LOG_DBG("%s(%p, %p, %zu)", __func__, ptables, start, size);
-	region_map_update(ptables, start, size, 0, true);
+	return region_map_update(ptables, start, size, 0, true);
 }
 
 __pinned_func
-static inline void apply_region(pentry_t *ptables, void *start,
+static inline int apply_region(pentry_t *ptables, void *start,
 				size_t size, pentry_t attr)
 {
 	LOG_DBG("%s(%p, %p, %zu, " PRI_ENTRY ")", __func__, ptables, start,
 		size, attr);
-	region_map_update(ptables, start, size, attr, false);
+	return region_map_update(ptables, start, size, attr, false);
 }
 
 __pinned_func
@@ -1720,23 +1847,23 @@ int arch_mem_domain_init(struct k_mem_domain *domain)
 	return ret;
 }
 
-void arch_mem_domain_partition_remove(struct k_mem_domain *domain,
-				      uint32_t partition_id)
+int arch_mem_domain_partition_remove(struct k_mem_domain *domain,
+				     uint32_t partition_id)
 {
 	struct k_mem_partition *partition = &domain->partitions[partition_id];
 
 	/* Reset the partition's region back to defaults */
-	reset_region(domain->arch.ptables, (void *)partition->start,
-		     partition->size);
+	return reset_region(domain->arch.ptables, (void *)partition->start,
+			    partition->size);
 }
 
 /* Called on thread exit or when moving it to a different memory domain */
-void arch_mem_domain_thread_remove(struct k_thread *thread)
+int arch_mem_domain_thread_remove(struct k_thread *thread)
 {
 	struct k_mem_domain *domain = thread->mem_domain_info.mem_domain;
 
 	if ((thread->base.user_options & K_USER) == 0) {
-		return;
+		return 0;
 	}
 
 	if ((thread->base.thread_state & _THREAD_DEAD) == 0) {
@@ -1745,31 +1872,34 @@ void arch_mem_domain_thread_remove(struct k_thread *thread)
 		 * z_thread_abort().  Resetting the stack region will
 		 * take place in the forthcoming thread_add() call.
 		 */
-		return;
+		return 0;
 	}
 
 	/* Restore permissions on the thread's stack area since it is no
 	 * longer a member of the domain.
 	 */
-	reset_region(domain->arch.ptables, (void *)thread->stack_info.start,
-		     thread->stack_info.size);
+	return reset_region(domain->arch.ptables,
+			    (void *)thread->stack_info.start,
+			    thread->stack_info.size);
 }
 
 __pinned_func
-void arch_mem_domain_partition_add(struct k_mem_domain *domain,
+int arch_mem_domain_partition_add(struct k_mem_domain *domain,
 				   uint32_t partition_id)
 {
 	struct k_mem_partition *partition = &domain->partitions[partition_id];
 
 	/* Update the page tables with the partition info */
-	apply_region(domain->arch.ptables, (void *)partition->start,
-		     partition->size, partition->attr | MMU_P);
+	return apply_region(domain->arch.ptables, (void *)partition->start,
+			    partition->size, partition->attr | MMU_P);
 }
 
 /* Invoked from memory domain API calls, as well as during thread creation */
 __pinned_func
-void arch_mem_domain_thread_add(struct k_thread *thread)
+int arch_mem_domain_thread_add(struct k_thread *thread)
 {
+	int ret = 0;
+
 	/* New memory domain we are being added to */
 	struct k_mem_domain *domain = thread->mem_domain_info.mem_domain;
 	/* This is only set for threads that were migrating from some other
@@ -1804,8 +1934,9 @@ void arch_mem_domain_thread_add(struct k_thread *thread)
 	 * See #29601
 	 */
 	if (is_migration) {
-		reset_region(old_ptables, (void *)thread->stack_info.start,
-			     thread->stack_info.size);
+		ret = reset_region(old_ptables,
+				   (void *)thread->stack_info.start,
+				   thread->stack_info.size);
 	}
 
 #if !defined(CONFIG_X86_KPTI) && !defined(CONFIG_X86_COMMON_PAGE_TABLE)
@@ -1818,6 +1949,8 @@ void arch_mem_domain_thread_add(struct k_thread *thread)
 		z_x86_cr3_set(thread->arch.ptables);
 	}
 #endif /* CONFIG_X86_KPTI */
+
+	return ret;
 }
 #endif /* !CONFIG_X86_COMMON_PAGE_TABLE */
 
@@ -1947,22 +2080,28 @@ int arch_page_phys_get(void *virt, uintptr_t *phys)
 __pinned_func
 void arch_mem_page_out(void *addr, uintptr_t location)
 {
+	int ret;
 	pentry_t mask = PTE_MASK | MMU_P | MMU_A;
 
 	/* Accessed bit set to guarantee the entry is not completely 0 in
 	 * case of location value 0. A totally 0 PTE is un-mapped.
 	 */
-	range_map(addr, location, CONFIG_MMU_PAGE_SIZE,	MMU_A, mask,
-		  OPTION_FLUSH);
+	ret = range_map(addr, location, CONFIG_MMU_PAGE_SIZE, MMU_A, mask,
+			OPTION_FLUSH);
+	__ASSERT_NO_MSG(ret == 0);
+	ARG_UNUSED(ret);
 }
 
 __pinned_func
 void arch_mem_page_in(void *addr, uintptr_t phys)
 {
+	int ret;
 	pentry_t mask = PTE_MASK | MMU_P | MMU_D | MMU_A;
 
-	range_map(addr, phys, CONFIG_MMU_PAGE_SIZE,	MMU_P, mask,
-		  OPTION_FLUSH);
+	ret = range_map(addr, phys, CONFIG_MMU_PAGE_SIZE, MMU_P, mask,
+			OPTION_FLUSH);
+	__ASSERT_NO_MSG(ret == 0);
+	ARG_UNUSED(ret);
 }
 
 __pinned_func

--- a/include/app_memory/mem_domain.h
+++ b/include/app_memory/mem_domain.h
@@ -151,8 +151,12 @@ extern int k_mem_domain_init(struct k_mem_domain *domain, uint8_t num_parts,
  *
  * @param domain The memory domain to be added a memory partition.
  * @param part The memory partition to be added
+ *
+ * @retval 0 if successful
+ * @retval -EINVAL if invalid parameters supplied
+ * @retval -ENOSPC if no free partition slots available
  */
-extern void k_mem_domain_add_partition(struct k_mem_domain *domain,
+extern int k_mem_domain_add_partition(struct k_mem_domain *domain,
 				      struct k_mem_partition *part);
 
 /**
@@ -162,8 +166,12 @@ extern void k_mem_domain_add_partition(struct k_mem_domain *domain,
  *
  * @param domain The memory domain to be removed a memory partition.
  * @param part The memory partition to be removed
+ *
+ * @retval 0 if successful
+ * @retval -EINVAL if invalid parameters supplied
+ * @retval -ENOENT if no matching partition found
  */
-extern void k_mem_domain_remove_partition(struct k_mem_domain *domain,
+extern int k_mem_domain_remove_partition(struct k_mem_domain *domain,
 					 struct k_mem_partition *part);
 
 /**

--- a/include/app_memory/mem_domain.h
+++ b/include/app_memory/mem_domain.h
@@ -183,9 +183,10 @@ extern int k_mem_domain_remove_partition(struct k_mem_domain *domain,
  * @param domain The memory domain that the thread is going to be added into.
  * @param thread ID of thread going to be added into the memory domain.
  *
+ * @return 0 if successful, fails otherwise.
  */
-extern void k_mem_domain_add_thread(struct k_mem_domain *domain,
-				    k_tid_t thread);
+extern int k_mem_domain_add_thread(struct k_mem_domain *domain,
+				   k_tid_t thread);
 
 #ifdef __cplusplus
 }

--- a/include/app_memory/mem_domain.h
+++ b/include/app_memory/mem_domain.h
@@ -121,9 +121,13 @@ struct k_mem_partition;
  * @param num_parts The number of array items of "parts" parameter.
  * @param parts An array of pointers to the memory partitions. Can be NULL
  *              if num_parts is zero.
+ *
+ * @retval 0 if successful
+ * @retval -EINVAL if invalid parameters supplied
+ * @retval -ENOMEM if insufficient memory
  */
-extern void k_mem_domain_init(struct k_mem_domain *domain, uint8_t num_parts,
-			      struct k_mem_partition *parts[]);
+extern int k_mem_domain_init(struct k_mem_domain *domain, uint8_t num_parts,
+			     struct k_mem_partition *parts[]);
 
 /**
  * @brief Add a memory partition into a memory domain.

--- a/include/sys/arch_interface.h
+++ b/include/sys/arch_interface.h
@@ -581,8 +581,13 @@ int arch_mem_domain_init(struct k_mem_domain *domain);
  * thread is not already a member of this domain.
  *
  * @param thread Thread which needs to be configured.
+ *
+ * @retval 0 if successful
+ * @retval -EINVAL if invalid parameters supplied
+ * @retval -ENOSPC if running out of space in internal structures
+ *                    (e.g. translation tables)
  */
-void arch_mem_domain_thread_add(struct k_thread *thread);
+int arch_mem_domain_thread_add(struct k_thread *thread);
 
 /**
  * @brief Remove a thread from a memory domain (arch-specific)
@@ -594,8 +599,11 @@ void arch_mem_domain_thread_add(struct k_thread *thread);
  * is being removed from.
  *
  * @param thread Thread being removed from its memory domain
+ *
+ * @retval 0 if successful
+ * @retval -EINVAL if invalid parameters supplied
  */
-void arch_mem_domain_thread_remove(struct k_thread *thread);
+int arch_mem_domain_thread_remove(struct k_thread *thread);
 
 /**
  * @brief Remove a partition from the memory domain (arch-specific)
@@ -609,9 +617,13 @@ void arch_mem_domain_thread_remove(struct k_thread *thread);
  *
  * @param domain The memory domain structure
  * @param partition_id The partition index that needs to be deleted
+ *
+ * @retval 0 if successful
+ * @retval -EINVAL if invalid parameters supplied
+ * @retval -ENOENT if no matching partition found
  */
-void arch_mem_domain_partition_remove(struct k_mem_domain *domain,
-				      uint32_t partition_id);
+int arch_mem_domain_partition_remove(struct k_mem_domain *domain,
+				     uint32_t partition_id);
 
 /**
  * @brief Add a partition to the memory domain
@@ -621,9 +633,12 @@ void arch_mem_domain_partition_remove(struct k_mem_domain *domain,
  *
  * @param domain The memory domain structure
  * @param partition_id The partition that needs to be added
+ *
+ * @retval 0 if successful
+ * @retval -EINVAL if invalid parameters supplied
  */
-void arch_mem_domain_partition_add(struct k_mem_domain *domain,
-				   uint32_t partition_id);
+int arch_mem_domain_partition_add(struct k_mem_domain *domain,
+				  uint32_t partition_id);
 #endif /* CONFIG_ARCH_MEM_DOMAIN_SYNCHRONOUS_API */
 
 /**

--- a/samples/net/mqtt_publisher/src/main.c
+++ b/samples/net/mqtt_publisher/src/main.c
@@ -524,6 +524,8 @@ void main(void)
 #endif
 
 #if defined(CONFIG_USERSPACE)
+	int ret;
+
 	struct k_mem_partition *parts[] = {
 #if Z_LIBC_PARTITION_EXISTS
 		&z_libc_partition,
@@ -531,7 +533,10 @@ void main(void)
 		&app_partition
 	};
 
-	k_mem_domain_init(&app_domain, ARRAY_SIZE(parts), parts);
+	ret = k_mem_domain_init(&app_domain, ARRAY_SIZE(parts), parts);
+	__ASSERT(ret == 0, "k_mem_domain_init() failed %d", ret);
+	ARG_UNUSED(ret);
+
 	k_mem_domain_add_thread(&app_domain, app_thread);
 	k_thread_heap_assign(app_thread, &app_mem_pool);
 

--- a/samples/net/sockets/echo_client/src/echo-client.c
+++ b/samples/net/sockets/echo_client/src/echo-client.c
@@ -233,7 +233,10 @@ static void init_app(void)
 		&app_partition
 	};
 
-	k_mem_domain_init(&app_domain, ARRAY_SIZE(parts), parts);
+	int ret = k_mem_domain_init(&app_domain, ARRAY_SIZE(parts), parts);
+
+	__ASSERT(ret == 0, "k_mem_domain_init() failed %d", ret);
+	ARG_UNUSED(ret);
 #endif
 
 #if defined(CONFIG_NET_SOCKETS_SOCKOPT_TLS)

--- a/samples/net/sockets/echo_server/src/echo-server.c
+++ b/samples/net/sockets/echo_server/src/echo-server.c
@@ -131,7 +131,10 @@ static void init_app(void)
 		&app_partition
 	};
 
-	k_mem_domain_init(&app_domain, ARRAY_SIZE(parts), parts);
+	int ret = k_mem_domain_init(&app_domain, ARRAY_SIZE(parts), parts);
+
+	__ASSERT(ret == 0, "k_mem_domain_init() failed %d", ret);
+	ARG_UNUSED(ret);
 #endif
 
 #if defined(CONFIG_NET_SOCKETS_SOCKOPT_TLS) || \

--- a/samples/subsys/logging/logger/src/main.c
+++ b/samples/subsys/logging/logger/src/main.c
@@ -335,7 +335,11 @@ static void log_demo_supervisor(void *p1, void *p2, void *p3)
 	log_demo_thread(p1, p2, p3);
 
 #ifdef CONFIG_USERSPACE
-	k_mem_domain_init(&app_domain, ARRAY_SIZE(app_parts), app_parts);
+	int ret = k_mem_domain_init(&app_domain, ARRAY_SIZE(app_parts), app_parts);
+
+	__ASSERT(ret == 0, "k_mem_domain_init() failed %d\n", ret);
+	ARG_UNUSED(ret);
+
 	k_mem_domain_add_thread(&app_domain, k_current_get());
 	k_thread_user_mode_enter(log_demo_thread, p1, p2, p3);
 #endif

--- a/samples/userspace/prod_consumer/src/app_a.c
+++ b/samples/userspace/prod_consumer/src/app_a.c
@@ -189,6 +189,7 @@ static void writeback_entry(void *p1, void *p2, void *p3)
 /* Supervisor mode setup function for application A */
 void app_a_entry(void *p1, void *p2, void *p3)
 {
+	int ret;
 	struct k_mem_partition *parts[] = {
 #if Z_LIBC_PARTITION_EXISTS
 		&z_libc_partition,
@@ -207,7 +208,10 @@ void app_a_entry(void *p1, void *p2, void *p3)
 	 * partition, the shared partition, and any common libc partition
 	 * if it exists.
 	 */
-	k_mem_domain_init(&app_a_domain, ARRAY_SIZE(parts), parts);
+	ret = k_mem_domain_init(&app_a_domain, ARRAY_SIZE(parts), parts);
+	__ASSERT(ret == 0, "k_mem_domain_init failed %d", ret);
+	ARG_UNUSED(ret);
+
 	k_mem_domain_add_thread(&app_a_domain, k_current_get());
 
 	/* Assign a resource pool to serve for kernel-side allocations on

--- a/samples/userspace/prod_consumer/src/app_b.c
+++ b/samples/userspace/prod_consumer/src/app_b.c
@@ -76,12 +76,27 @@ static void processor_thread(void *p1, void *p2, void *p3)
 
 void app_b_entry(void *p1, void *p2, void *p3)
 {
+	int ret;
+
 	/* Much like how we are reusing the main thread as this application's
 	 * processor thread, we will re-use the default memory domain as the
 	 * domain for application B.
 	 */
-	k_mem_domain_add_partition(&k_mem_domain_default, &app_b_partition);
-	k_mem_domain_add_partition(&k_mem_domain_default, &shared_partition);
+	ret = k_mem_domain_add_partition(&k_mem_domain_default,
+					 &app_b_partition);
+	if (ret != 0) {
+		LOG_ERR("Failed to add app_b_partition to mem domain (%d)",
+			ret);
+		k_oops();
+	}
+
+	ret = k_mem_domain_add_partition(&k_mem_domain_default,
+					 &shared_partition);
+	if (ret != 0) {
+		LOG_ERR("Failed to add shared_partition to mem domain (%d)",
+			ret);
+		k_oops();
+	}
 
 	/* Assign a resource pool to serve for kernel-side allocations on
 	 * behalf of application A. Needed for k_queue_alloc_append().

--- a/samples/userspace/shared_mem/src/main.c
+++ b/samples/userspace/shared_mem/src/main.c
@@ -158,9 +158,19 @@ void main(void)
 	k_thread_access_grant(tCT, &allforone);
 	printk("CT Thread Created %p\n", tCT);
 	/* Re-using the default memory domain for CT */
-	k_mem_domain_add_partition(&k_mem_domain_default, &ct_part);
-	k_mem_domain_add_partition(&k_mem_domain_default, &blk_part);
+	ret = k_mem_domain_add_partition(&k_mem_domain_default, &ct_part);
+	if (ret != 0) {
+		printk("Failed to add ct_part to mem domain (%d)\n", ret);
+		k_oops();
+	}
 	printk("ct partitions installed\n");
+
+	ret = k_mem_domain_add_partition(&k_mem_domain_default, &blk_part);
+	if (ret != 0) {
+		printk("Failed to add blk_part to mem domain (%d)\n", ret);
+		k_oops();
+	}
+	printk("blk partitions installed\n");
 
 	k_thread_start(&enc_thread);
 	/* need to start all three threads.  let enc go first to perform init step */

--- a/samples/userspace/shared_mem/src/main.c
+++ b/samples/userspace/shared_mem/src/main.c
@@ -13,6 +13,9 @@
  *  DO NOT USE THIS CODE FOR SECURITY
  *
  */
+
+#include <sys/__assert.h>
+
 #include "main.h"
 #include "enc.h"
 /* the following definition name prefix is to avoid a conflict */
@@ -101,6 +104,7 @@ void main(void)
 	struct k_mem_partition *enc_parts[] = {&enc_part, &red_part, &blk_part};
 	struct k_mem_partition *pt_parts[] = {&user_part, &red_part};
 	k_tid_t tPT, tENC, tCT;
+	int ret;
 
 	fBUFIN = 0; /* clear flags */
 	fBUFOUT = 0;
@@ -124,7 +128,11 @@ void main(void)
 	k_thread_access_grant(tENC, &allforone);
 	/* use K_FOREVER followed by k_thread_start*/
 	printk("ENC Thread Created %p\n", tENC);
-	k_mem_domain_init(&enc_domain, 3, enc_parts);
+
+	ret = k_mem_domain_init(&enc_domain, 3, enc_parts);
+	__ASSERT(ret == 0, "k_mem_domain_init() on enc_domain failed %d", ret);
+	ARG_UNUSED(ret);
+
 	printk("Partitions added to enc_domain\n");
 	k_mem_domain_add_thread(&enc_domain, tENC);
 	printk("enc_domain Created\n");
@@ -136,7 +144,10 @@ void main(void)
 			K_FOREVER);
 	k_thread_access_grant(tPT, &allforone);
 	printk("PT Thread Created %p\n", tPT);
-	k_mem_domain_init(&pt_domain, 2, pt_parts);
+
+	ret = k_mem_domain_init(&pt_domain, 2, pt_parts);
+	__ASSERT(ret == 0, "k_mem_domain_init() on pt_domain failed %d", ret);
+
 	k_mem_domain_add_thread(&pt_domain, tPT);
 	printk("pt_domain Created\n");
 

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -501,17 +501,29 @@ int main(void)
 void main(void)
 {
 #ifdef CONFIG_USERSPACE
+	int ret;
+
 	/* Partition containing globals tagged with ZTEST_DMEM and ZTEST_BMEM
 	 * macros. Any variables that user code may reference need to be
 	 * placed in this partition if no other memory domain configuration
 	 * is made.
 	 */
-	k_mem_domain_add_partition(&k_mem_domain_default,
-				   &ztest_mem_partition);
+	ret = k_mem_domain_add_partition(&k_mem_domain_default,
+					 &ztest_mem_partition);
+	if (ret != 0) {
+		PRINT("ERROR: failed to add ztest_mem_partition to mem domain (%d)\n",
+		      ret);
+		k_oops();
+	}
 #ifdef Z_MALLOC_PARTITION_EXISTS
 	/* Allow access to malloc() memory */
-	k_mem_domain_add_partition(&k_mem_domain_default,
-				   &z_malloc_partition);
+	ret = k_mem_domain_add_partition(&k_mem_domain_default,
+					 &z_malloc_partition);
+	if (ret != 0) {
+		PRINT("ERROR: failed to add z_malloc_partition to mem domain (%d)\n",
+		      ret);
+		k_oops();
+	}
 #endif
 #endif /* CONFIG_USERSPACE */
 

--- a/tests/benchmarks/footprints/src/main.c
+++ b/tests/benchmarks/footprints/src/main.c
@@ -42,12 +42,15 @@ void main(void)
 	printk("Hello from %s!\n", CONFIG_BOARD);
 
 #ifdef CONFIG_USERSPACE
+	int ret;
 	struct k_mem_partition *mem_parts[] = {
 	&footprint_mem_partition
 	};
 
-	k_mem_domain_init(&footprint_mem_domain,
-			  ARRAY_SIZE(mem_parts), mem_parts);
+	ret = k_mem_domain_init(&footprint_mem_domain,
+				ARRAY_SIZE(mem_parts), mem_parts);
+	__ASSERT_NO_MSG(ret == 0);
+	ARG_UNUSED(ret);
 #endif /* CONFIG_USERSPACE */
 
 	run_thread_system();

--- a/tests/crypto/mbedtls/src/main.c
+++ b/tests/crypto/mbedtls/src/main.c
@@ -13,7 +13,12 @@ extern void test_mbedtls(void);
 void test_main(void)
 {
 #ifdef CONFIG_USERSPACE
-	k_mem_domain_add_partition(&k_mem_domain_default, &k_mbedtls_partition);
+	int ret = k_mem_domain_add_partition(&k_mem_domain_default,
+					     &k_mbedtls_partition);
+	if (ret != 0) {
+		printk("Failed to add memory partition (%d)\n", ret);
+		k_oops();
+	}
 #endif
 	ztest_test_suite(test_mbedtls_fn,
 		ztest_user_unit_test(test_mbedtls));

--- a/tests/kernel/mem_protect/mem_protect/boards/qemu_cortex_a53.conf
+++ b/tests/kernel/mem_protect/mem_protect/boards/qemu_cortex_a53.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# Simply needs more space for the translation table
+# for the mapping exhaustion test.
+CONFIG_MAX_XLAT_TABLES=18

--- a/tests/kernel/mem_protect/mem_protect/boards/qemu_cortex_a53_smp.conf
+++ b/tests/kernel/mem_protect/mem_protect/boards/qemu_cortex_a53_smp.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# Simply needs more space for the translation table
+# for the mapping exhaustion test.
+CONFIG_MAX_XLAT_TABLES=34

--- a/tests/kernel/mem_protect/mem_protect/src/inherit.c
+++ b/tests/kernel/mem_protect/mem_protect/src/inherit.c
@@ -100,9 +100,14 @@ static void test_thread_1_for_SU(void *p1, void *p2, void *p3)
  */
 void test_permission_inheritance(void)
 {
-	k_mem_domain_init(&inherit_mem_domain,
-			  ARRAY_SIZE(inherit_memory_partition_array),
-			  inherit_memory_partition_array);
+	int ret;
+
+	ret = k_mem_domain_init(&inherit_mem_domain,
+				ARRAY_SIZE(inherit_memory_partition_array),
+				inherit_memory_partition_array);
+	if (ret != 0) {
+		ztest_test_fail();
+	}
 
 	parent_tid = k_current_get();
 	k_mem_domain_add_thread(&inherit_mem_domain, parent_tid);

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -681,7 +681,11 @@ static void drop_user(volatile bool *to_modify)
 static void test_init_and_access_other_memdomain(void)
 {
 	struct k_mem_partition *parts[] = { &ztest_mem_partition, &alt_part };
-	k_mem_domain_init(&alternate_domain, ARRAY_SIZE(parts), parts);
+
+	zassert_equal(
+		k_mem_domain_init(&alternate_domain, ARRAY_SIZE(parts), parts),
+		0, "failed to initialize memory domain");
+
 	/* Switch to alternate_domain which does not have default_part that
 	 * contains default_bool. This should fault when we try to write it.
 	 */

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -722,7 +722,11 @@ static void test_domain_add_thread_drop_to_user(void)
 static void test_domain_add_part_drop_to_user(void)
 {
 	clear_fault();
-	k_mem_domain_add_partition(&k_mem_domain_default, &alt_part);
+
+	zassert_equal(
+		k_mem_domain_add_partition(&k_mem_domain_default, &alt_part),
+		0, "failed to add memory partition");
+
 	drop_user(&alt_bool);
 }
 
@@ -738,7 +742,11 @@ static void test_domain_remove_part_drop_to_user(void)
 	 * remove it, and then try to access again.
 	 */
 	set_fault(K_ERR_CPU_EXCEPTION);
-	k_mem_domain_remove_partition(&k_mem_domain_default, &alt_part);
+
+	zassert_equal(
+		k_mem_domain_remove_partition(&k_mem_domain_default, &alt_part),
+		0, "failed to remove partition");
+
 	drop_user(&alt_bool);
 }
 
@@ -763,7 +771,11 @@ static void test_domain_add_thread_context_switch(void)
 static void test_domain_add_part_context_switch(void)
 {
 	clear_fault();
-	k_mem_domain_add_partition(&k_mem_domain_default, &alt_part);
+
+	zassert_equal(
+		k_mem_domain_add_partition(&k_mem_domain_default, &alt_part),
+		0, "failed to add memory partition");
+
 	spawn_user(&alt_bool);
 }
 
@@ -780,7 +792,11 @@ static void test_domain_remove_part_context_switch(void)
 	 * remove it, and then try to access again.
 	 */
 	set_fault(K_ERR_CPU_EXCEPTION);
-	k_mem_domain_remove_partition(&k_mem_domain_default, &alt_part);
+
+	zassert_equal(
+		k_mem_domain_remove_partition(&k_mem_domain_default, &alt_part),
+		0, "failed to remove memory partition");
+
 	spawn_user(&alt_bool);
 }
 
@@ -967,8 +983,14 @@ void test_tls_pointer(void)
 
 void test_main(void)
 {
+	int ret;
+
 	/* Most of these scenarios use the default domain */
-	k_mem_domain_add_partition(&k_mem_domain_default, &default_part);
+	ret = k_mem_domain_add_partition(&k_mem_domain_default, &default_part);
+	if (ret != 0) {
+		printk("Failed to add default memory partition (%d)\n", ret);
+		k_oops();
+	}
 
 #if defined(CONFIG_ARM64)
 	struct z_arm64_thread_stack_header *hdr;

--- a/tests/kernel/threads/tls/src/main.c
+++ b/tests/kernel/threads/tls/src/main.c
@@ -209,6 +209,7 @@ void test_tls_userspace(void)
 void test_main(void)
 {
 #ifdef CONFIG_USERSPACE
+	int ret;
 	unsigned int i;
 
 	struct k_mem_partition *parts[] = {
@@ -220,7 +221,11 @@ void test_main(void)
 	};
 
 	parts[0] = &part_common;
-	k_mem_domain_init(&dom_common, ARRAY_SIZE(parts), parts);
+
+	ret = k_mem_domain_init(&dom_common, ARRAY_SIZE(parts), parts);
+	__ASSERT(ret == 0, "k_mem_domain_init() failed %d", ret);
+	ARG_UNUSED(ret);
+
 	k_mem_domain_add_thread(&dom_common, k_current_get());
 
 	for (i = 0; i < NUM_THREADS; i++) {

--- a/tests/subsys/edac/ibecc/src/ibecc.c
+++ b/tests/subsys/edac/ibecc/src/ibecc.c
@@ -326,7 +326,12 @@ void test_edac_dummy_api(void);
 void test_main(void)
 {
 #if defined(CONFIG_USERSPACE)
-	k_mem_domain_add_partition(&k_mem_domain_default, &default_part);
+	int ret = k_mem_domain_add_partition(&k_mem_domain_default,
+					     &default_part);
+	if (ret != 0) {
+		TC_PRINT("Failed to add to mem domain (%d)", ret);
+		k_oops();
+	}
 #endif
 
 	ztest_test_suite(ibecc,


### PR DESCRIPTION
This changes the `k_mem_domain_*()` functions to return errors. See individual commits for more details.

Fixes #24609