### PR TITLE
drivers: can: Fixed timeout values comparison

### DIFF
--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -469,9 +469,9 @@ int mcux_flexcan_recover(const struct device *dev, k_timeout_t timeout)
 	start_time = k_uptime_ticks();
 	config->base->CTRL1 &= ~CAN_CTRL1_BOFFREC_MASK;
 
-	if (timeout != K_NO_WAIT) {
+	if (!K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
 		while (mcux_flexcan_get_state(dev, NULL) == CAN_BUS_OFF) {
-			if (timeout != K_FOREVER &&
+			if (!K_TIMEOUT_EQ(timeout, K_FOREVER) &&
 			    k_uptime_ticks() - start_time >= timeout.ticks) {
 				ret = CAN_TIMEOUT;
 			}

--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -593,7 +593,7 @@ int can_stm32_recover(const struct device *dev, k_timeout_t timeout)
 	start_time = k_uptime_ticks();
 
 	while (can->ESR & CAN_ESR_BOFF) {
-		if (timeout != K_FOREVER &&
+		if (!K_TIMEOUT_EQ(timeout, K_FOREVER) &&
 		    k_uptime_ticks() - start_time >= timeout.ticks) {
 			goto done;
 		}


### PR DESCRIPTION
Trivial fix of compilation error "invalid operands to binary "
when CONFIG_CAN_AUTO_BUS_OFF_RECOVERY = n
by using K_TIMEOUT_EQ macro.

Signed-off-by: Lucas Dietrich <ld.adecy@gmail.com>

Fixes #40290