### PR TITLE
boards: arm: qemu_cortex_a9: use SUPPORTED_EMU_PLATFORMS

### DIFF
--- a/boards/arm/qemu_cortex_a9/board.cmake
+++ b/boards/arm/qemu_cortex_a9/board.cmake
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set(EMU_PLATFORM qemu)
+set(SUPPORTED_EMU_PLATFORMS qemu)
 set(QEMU_ARCH xilinx-aarch64)
 
 set(QEMU_CPU_TYPE_${ARCH} cortex-a9)


### PR DESCRIPTION
All other emu targets have been updated to use `SUPPORTED_EMU_PLATFORMS` instead of `EMU_PLATFORM`.

There was a bit of a synchronization issue with `qemu_cortex_a9` though because #38102 was not rebased
for a month before it was merged.
