### PR TITLE
drivers: sensor: ina23x: convert to use i2c_dt_spec

### DIFF
--- a/drivers/sensor/ina23x/Kconfig
+++ b/drivers/sensor/ina23x/Kconfig
@@ -10,8 +10,21 @@ config INA23X
 
 if INA23X
 
+choice
+	prompt "VARIANT"
+	default INA23X_VARIANT_230
+
+config INA23X_VARIANT_230
+	bool "INA230"
+
+config INA23X_VARIANT_237
+	bool "INA237"
+
+endchoice
+
 config INA23X_TRIGGER
 	bool "Trigger mode"
+	depends on !INA23X_VARIANT_237
 	help
 	  Set to enable trigger mode using gpio interrupt, where
 	  interrupts are configured to line ALERT PIN.

--- a/drivers/sensor/ina23x/ina23x.h
+++ b/drivers/sensor/ina23x/ina23x.h
@@ -8,6 +8,7 @@
 #define ZEPHYR_DRIVERS_SENSOR_INA23X_H_
 
 #include <drivers/gpio.h>
+#include <drivers/i2c.h>
 
 #ifdef CONFIG_INA23X_VARIANT_230
 #define INA23X_REG_CONFIG     0x00
@@ -54,8 +55,7 @@ struct ina23x_data {
 };
 
 struct ina23x_config {
-	const struct device *bus;
-	const uint16_t i2c_slv_addr;
+	struct i2c_dt_spec i2c;
 	uint16_t config;
 	uint16_t adc_config;
 	uint16_t current_lsb;

--- a/drivers/sensor/ina23x/ina23x.h
+++ b/drivers/sensor/ina23x/ina23x.h
@@ -9,6 +9,7 @@
 
 #include <drivers/gpio.h>
 
+#ifdef CONFIG_INA23X_VARIANT_230
 #define INA23X_REG_CONFIG     0x00
 #define INA23X_REG_SHUNT_VOLT 0x01
 #define INA23X_REG_BUS_VOLT   0x02
@@ -17,12 +18,33 @@
 #define INA23X_REG_CALIB      0x05
 #define INA23X_REG_MASK       0x06
 #define INA23X_REG_ALERT      0x07
+#else
+#define INA23X_REG_CONFIG     0x00
+#define INA23X_ADC_CONFIG     0x01
+#define INA23X_REG_CALIB      0x02
+#define INA23X_REG_SHUNT_VOLT 0x04
+#define INA23X_REG_BUS_VOLT   0x05
+#define INA23X_REG_MASK       0x06
+#define INA23X_REG_CURRENT    0x07
+#define INA23X_REG_POWER      0x08
+#define INA23X_REG_ALERT      0x0B
+#define INA23X_REG_SOVL       0x0C
+#define INA23X_REG_SUVL       0x0D
+#define INA23X_REG_BOVL       0x0E
+#define INA23X_REG_BUVL       0x0F
+#define INA23X_REG_TEMP_LIMIT 0x10
+#define INA23X_REG_PWR_LIMIT  0x11
+#endif
 
 struct ina23x_data {
 	const struct device *dev;
 	uint16_t current;
 	uint16_t bus_voltage;
+#ifdef CONFIG_INA23X_VARIANT_230
 	uint16_t power;
+#else
+	uint32_t power;
+#endif
 #ifdef CONFIG_INA23X_TRIGGER
 	const struct device *gpio;
 	struct gpio_callback gpio_cb;
@@ -35,6 +57,7 @@ struct ina23x_config {
 	const struct device *bus;
 	const uint16_t i2c_slv_addr;
 	uint16_t config;
+	uint16_t adc_config;
 	uint16_t current_lsb;
 	uint16_t rshunt;
 #ifdef CONFIG_INA23X_TRIGGER

--- a/dts/bindings/sensor/ti,ina23x.yaml
+++ b/dts/bindings/sensor/ti,ina23x.yaml
@@ -6,7 +6,7 @@
 
 
 description: |
-    TI INA230 and INA231 Bidirectional Current and Power Monitor.
+    TI INA230, INA231 and INA237 Bidirectional Current and Power Monitor.
     The <include/dt-bindings/sensor/ina23x.h> file should be included
     in the DeviceTree and it provides Macros that can be used for
     initializing the Configuration register.
@@ -20,6 +20,11 @@ properties:
       type: int
       required: true
       description: Configuration register
+
+    adc_config:
+      type: int
+      required: false
+      description: ADC configuration register (only for INA237)
 
     current_lsb:
       type: int


### PR DESCRIPTION
Convert `ina23x` driver to use i2c_dt_spec helpers.

Depends on https://github.com/zephyrproject-rtos/zephyr/pull/40320

Signed-off-by: Bartosz Bilas b.bilas@grinn-global.com