### PR TITLE
drivers: spi: esp32: fix frequency config

### DIFF
--- a/drivers/spi/spi_esp32_spim.c
+++ b/drivers/spi/spi_esp32_spim.c
@@ -271,7 +271,7 @@ static int IRAM_ATTR spi_esp32_configure(const struct device *dev,
 	spi_hal_timing_param_t timing_param = {
 		.half_duplex = hal_dev->half_duplex,
 		.no_compensate = hal_dev->no_compensate,
-		.clock_speed_hz = cfg->frequency,
+		.clock_speed_hz = spi_cfg->frequency,
 		.duty_cycle = cfg->duty_cycle == 0 ? 128 : cfg->duty_cycle,
 		.input_delay_ns = cfg->input_delay_ns,
 		.use_gpio = true
@@ -432,7 +432,6 @@ static const struct spi_driver_api spi_api = {
 		.spi = (spi_dev_t *)DT_REG_ADDR(DT_NODELABEL(spi##idx)),	\
 			\
 		.clock_dev = DEVICE_DT_GET(DT_CLOCKS_CTLR(DT_NODELABEL(spi##idx))),	\
-		.frequency = SPI_MASTER_FREQ_8M,\
 		.duty_cycle = 0, \
 		.input_delay_ns = 0, \
 		.irq_source = DT_IRQN(DT_NODELABEL(spi##idx)), \

--- a/drivers/spi/spi_esp32_spim.c
+++ b/drivers/spi/spi_esp32_spim.c
@@ -415,7 +415,7 @@ static const struct spi_driver_api spi_api = {
 	static struct spi_esp32_data spi_data_##idx = {	\
 		SPI_CONTEXT_INIT_LOCK(spi_data_##idx, ctx),	\
 		SPI_CONTEXT_INIT_SYNC(spi_data_##idx, ctx),	\
-		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(idx), ctx)	\
+		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_NODELABEL(spi##idx), ctx)	\
 		.hal = {	\
 			.hw = (spi_dev_t *)DT_REG_ADDR(DT_NODELABEL(spi##idx)),	\
 		},	\

--- a/drivers/spi/spi_esp32_spim.h
+++ b/drivers/spi/spi_esp32_spim.h
@@ -21,7 +21,6 @@
 struct spi_esp32_config {
 	spi_dev_t *spi;
 	const struct device *clock_dev;
-	int frequency;
 	int duty_cycle;
 	int input_delay_ns;
 	int irq_source;


### PR DESCRIPTION
Current implementation is using hardcoded frequency
and not the one provided by the spi api. 
This also fix missing CS pin configuration when
custom GPIO is selected.


Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>