### PR TITLE
spi: Fix the Pcs setup for NXP's K6xF processors

### DIFF
--- a/drivers/spi/spi_mcux_dspi.c
+++ b/drivers/spi/spi_mcux_dspi.c
@@ -582,7 +582,7 @@ static int spi_mcux_configure(const struct device *dev,
 
 	DSPI_MasterGetDefaultConfig(&master_config);
 
-	master_config.whichPcs = spi_cfg->slave;
+	master_config.whichPcs = 1U << spi_cfg->slave;
 	master_config.whichCtar = config->which_ctar;
 	master_config.pcsActiveHighOrLow =
 		(spi_cfg->operation & SPI_CS_ACTIVE_HIGH) ?
@@ -646,7 +646,7 @@ static int spi_mcux_configure(const struct device *dev,
 	/* record frame_size setting for DMA */
 	data->frame_size = word_size;
 	/* keep the pcs settings */
-	data->which_pcs = spi_cfg->slave;
+	data->which_pcs = 1U << spi_cfg->slave;
 #ifdef CONFIG_MCUX_DSPI_EDMA_SHUFFLE_DATA
 	mcux_init_inner_buffer_with_cmd(dev, 0);
 #endif


### PR DESCRIPTION
Without this change, when DTS SPI device node has node ID = <0>, the
value of 0 is assigned during SPI configuration and written to
whichPcs member in master_config structure.
This value wrongly overrides the default value read from NXP's DSPI
HAL (kDSPI_Pcs0 = 1U << 0).

Such situation occurs on ip_k66f board, where the DSA device -
controlled via SPI has the node ID equal to 0.

When one wants to use PCS = 0, it shall add the slave's node ID value
to the default value (it is increased by 1).

Signed-off-by: Lukasz Majewski <lukma@denx.de>