### PR TITLE
net: dsa: Several DSA (Distributed Switch Architecture) related fixes for ip_k66f board

### DIFF
--- a/drivers/ethernet/dsa_ksz8794.h
+++ b/drivers/ethernet/dsa_ksz8794.h
@@ -257,13 +257,27 @@
 #define KSZ8794_GLOBAL_CTRL20_LOWSPEED_28MA          0x07
 
 enum {
+	/*
+	 * KSZ8794 register's MAP
+	 * (0x00 - 0x0F): Global Registers
+	 * Port registers (offsets):
+	 * (0x10): Port 1
+	 * (0x20): Port 2
+	 * (0x30): Port 3
+	 * (0x40): Reserved
+	 * (0x50): Port 4
+	 */
 	/* LAN ports for the ksz8794 switch */
 	KSZ8794_PORT1 = 0,
 	KSZ8794_PORT2,
 	KSZ8794_PORT3,
-	KSZ8794_PORT4,
-	/* SWITCH <-> CPU port */
-	KSZ8794_PORT5,
+	/*
+	 * SWITCH <-> CPU port
+	 *
+	 * We also need to consider the "Reserved' offset
+	 * defined above.
+	 */
+	KSZ8794_PORT4 = 4,
 };
 
 #define KSZ8794_REG_IND_DATA_8                        0x70
@@ -287,8 +301,8 @@ enum {
 #define KSZ8XXX_CHIP_ID0_ID_DEFAULT             KSZ8794_CHIP_ID0_ID_DEFAULT
 #define KSZ8XXX_CHIP_ID1_ID_DEFAULT             KSZ8794_CHIP_ID1_ID_DEFAULT
 #define KSZ8XXX_FIRST_PORT                      KSZ8794_PORT1
-#define KSZ8XXX_LAST_PORT                       KSZ8794_PORT5
-#define KSZ8XXX_CPU_PORT                        KSZ8794_PORT5
+#define KSZ8XXX_LAST_PORT                       KSZ8794_PORT3
+#define KSZ8XXX_CPU_PORT                        KSZ8794_PORT4
 #define KSZ8XXX_REG_IND_CTRL_0                  KSZ8794_REG_IND_CTRL_0
 #define KSZ8XXX_REG_IND_CTRL_1                  KSZ8794_REG_IND_CTRL_1
 #define KSZ8XXX_REG_IND_DATA_8                  KSZ8794_REG_IND_DATA_8

--- a/drivers/ethernet/dsa_ksz8xxx.c
+++ b/drivers/ethernet/dsa_ksz8xxx.c
@@ -914,7 +914,7 @@ struct net_pkt *dsa_ksz8xxx_xmit_pkt(struct net_if *iface, struct net_pkt *pkt)
 	if (dsa_is_port_master(iface)) {
 		port_idx = DSA_KSZ8795_TAIL_TAG_LOOKUP;
 	} else {
-		port_idx = (1 << (ctx->dsa_port_idx - 1));
+		port_idx = (1 << (ctx->dsa_port_idx));
 	}
 
 	NET_DBG("TT - port: 0x%x[%p] LEN: %d 0x%x 0x%x 0x%x 0x%x 0x%x 0x%x",

--- a/drivers/ethernet/dsa_ksz8xxx.c
+++ b/drivers/ethernet/dsa_ksz8xxx.c
@@ -320,7 +320,7 @@ static int dsa_ksz8xxx_switch_setup(struct ksz8xxx_data *pdev)
 		dsa_ksz8xxx_write_reg(pdev, KSZ8794_CTRL2_PORTn(i), tmp);
 	}
 
-#if defined(DSA_KSZ_TAIL_TAGGING)
+#if defined(CONFIG_DSA_KSZ_TAIL_TAGGING)
 	/* Enable tail tag feature */
 	dsa_ksz8xxx_read_reg(pdev, KSZ8794_GLOBAL_CTRL10, &tmp);
 	tmp |= KSZ8794_GLOBAL_CTRL10_TAIL_TAG_EN;
@@ -854,7 +854,7 @@ static int dsa_ksz8xxx_get_mac_table_entry(const struct device *dev,
 	return 0;
 }
 
-#if defined(DSA_KSZ_TAIL_TAGGING)
+#if defined(CONFIG_DSA_KSZ_TAIL_TAGGING)
 #define DSA_KSZ8795_TAIL_TAG_OVRD	BIT(6)
 #define DSA_KSZ8795_TAIL_TAG_LOOKUP	BIT(7)
 
@@ -1066,7 +1066,7 @@ static struct dsa_api dsa_api_f = {
 	.switch_write = dsa_ksz8xxx_sw_write_reg,
 	.switch_set_mac_table_entry = dsa_ksz8xxx_set_mac_table_entry,
 	.switch_get_mac_table_entry = dsa_ksz8xxx_get_mac_table_entry,
-#if defined(DSA_KSZ_TAIL_TAGGING)
+#if defined(CONFIG_DSA_KSZ_TAIL_TAGGING)
 	.dsa_xmit_pkt = dsa_ksz8xxx_xmit_pkt,
 	.dsa_get_iface = dsa_ksz8xxx_get_iface,
 #endif

--- a/drivers/ethernet/dsa_ksz8xxx.c
+++ b/drivers/ethernet/dsa_ksz8xxx.c
@@ -312,11 +312,6 @@ static int dsa_ksz8xxx_switch_setup(struct ksz8xxx_data *pdev)
 	 * disabled.
 	 */
 	for (i = KSZ8XXX_FIRST_PORT; i <= KSZ8XXX_LAST_PORT; i++) {
-		/* Skip Switch <-> CPU Port */
-		if (i == KSZ8XXX_CPU_PORT) {
-			continue;
-		}
-
 		/* Enable transmission, reception and switch address learning */
 		dsa_ksz8xxx_read_reg(pdev, KSZ8794_CTRL2_PORTn(i), &tmp);
 		tmp |= KSZ8794_CTRL2_TRANSMIT_EN;

--- a/include/net/dsa.h
+++ b/include/net/dsa.h
@@ -28,7 +28,7 @@
  * Size of the DSA TAG:
  * - KSZ8794 - 1 byte
  */
-#if defined(CONFIG_DSA_KSZ8794) && defined(DSA_KSZ_TAIL_TAGGING)
+#if defined(CONFIG_DSA_KSZ8794) && defined(CONFIG_DSA_KSZ_TAIL_TAGGING)
 #define DSA_TAG_SIZE 1
 #else
 #define DSA_TAG_SIZE 0

--- a/subsys/net/l2/ethernet/dsa/dsa.c
+++ b/subsys/net/l2/ethernet/dsa/dsa.c
@@ -205,7 +205,7 @@ struct net_if *dsa_get_slave_port(struct net_if *iface, int slave_num)
 
 int dsa_switch_read(struct net_if *iface, uint16_t reg_addr, uint8_t *value)
 {
-	const struct device *dev = iface->if_dev->dev;
+	const struct device *dev = net_if_get_device(iface);
 	struct dsa_context *context = dev->data;
 	const struct dsa_api *api =
 		(const struct dsa_api *)context->dapi;
@@ -215,7 +215,7 @@ int dsa_switch_read(struct net_if *iface, uint16_t reg_addr, uint8_t *value)
 
 int dsa_switch_write(struct net_if *iface, uint16_t reg_addr, uint8_t value)
 {
-	const struct device *dev = iface->if_dev->dev;
+	const struct device *dev = net_if_get_device(iface);
 	struct dsa_context *context = dev->data;
 	const struct dsa_api *api =
 		(const struct dsa_api *)context->dapi;
@@ -240,7 +240,7 @@ int dsa_switch_set_mac_table_entry(struct net_if *iface,
 					uint16_t tbl_entry_idx,
 					uint16_t flags)
 {
-	const struct device *dev = iface->if_dev->dev;
+	const struct device *dev = net_if_get_device(iface);
 	struct dsa_context *context = dev->data;
 	const struct dsa_api *api =
 		(const struct dsa_api *)context->dapi;
@@ -262,7 +262,7 @@ int dsa_switch_get_mac_table_entry(struct net_if *iface,
 					uint8_t *buf,
 					uint16_t tbl_entry_idx)
 {
-	const struct device *dev = iface->if_dev->dev;
+	const struct device *dev = net_if_get_device(iface);
 	struct dsa_context *context = dev->data;
 	const struct dsa_api *api =
 		(const struct dsa_api *)context->dapi;

--- a/subsys/net/l2/ethernet/dsa/dsa.c
+++ b/subsys/net/l2/ethernet/dsa/dsa.c
@@ -206,8 +206,9 @@ struct net_if *dsa_get_slave_port(struct net_if *iface, int slave_num)
 int dsa_switch_read(struct net_if *iface, uint16_t reg_addr, uint8_t *value)
 {
 	const struct device *dev = iface->if_dev->dev;
+	struct dsa_context *context = dev->data;
 	const struct dsa_api *api =
-		(const struct dsa_api *)dev->api;
+		(const struct dsa_api *)context->dapi;
 
 	return api->switch_read(dev, reg_addr, value);
 }
@@ -215,8 +216,9 @@ int dsa_switch_read(struct net_if *iface, uint16_t reg_addr, uint8_t *value)
 int dsa_switch_write(struct net_if *iface, uint16_t reg_addr, uint8_t value)
 {
 	const struct device *dev = iface->if_dev->dev;
+	struct dsa_context *context = dev->data;
 	const struct dsa_api *api =
-		(const struct dsa_api *)dev->api;
+		(const struct dsa_api *)context->dapi;
 
 	return api->switch_write(dev, reg_addr, value);
 }
@@ -239,8 +241,9 @@ int dsa_switch_set_mac_table_entry(struct net_if *iface,
 					uint16_t flags)
 {
 	const struct device *dev = iface->if_dev->dev;
+	struct dsa_context *context = dev->data;
 	const struct dsa_api *api =
-		(const struct dsa_api *)dev->api;
+		(const struct dsa_api *)context->dapi;
 
 	return api->switch_set_mac_table_entry(dev, mac, fw_port,
 							tbl_entry_idx, flags);
@@ -260,8 +263,9 @@ int dsa_switch_get_mac_table_entry(struct net_if *iface,
 					uint16_t tbl_entry_idx)
 {
 	const struct device *dev = iface->if_dev->dev;
+	struct dsa_context *context = dev->data;
 	const struct dsa_api *api =
-		(const struct dsa_api *)dev->api;
+		(const struct dsa_api *)context->dapi;
 
 	return api->switch_get_mac_table_entry(dev, buf, tbl_entry_idx);
 }

--- a/subsys/net/l2/ethernet/dsa/dsa.c
+++ b/subsys/net/l2/ethernet/dsa/dsa.c
@@ -226,7 +226,7 @@ int dsa_switch_write(struct net_if *iface, uint16_t reg_addr, uint8_t value)
 /**
  * @brief      Write static MAC table entry
  *
- * @param      iface          Master DSA interface
+ * @param      iface          DSA interface
  * @param[in]  mac            MAC address
  * @param[in]  fw_port        The firmware port
  * @param[in]  tbl_entry_idx  Table entry index
@@ -252,7 +252,7 @@ int dsa_switch_set_mac_table_entry(struct net_if *iface,
 /**
  * @brief      Read static MAC table entry
  *
- * @param      iface          Master DSA interface
+ * @param      iface          DSA interface
  * @param      buf            Buffer to receive MAC address
  * @param[in]  tbl_entry_idx  Table entry index
  *


### PR DESCRIPTION
This pull request provides several fixes for `ip_k66f` board related to proper DSA operation.

This fixes arose after the driver for ksz8794 IC has been extended to support other ksz devices.

For having the `./zephyr/samples/net/dsa/` sample working again (built with 
`west build --pristine -b ip_k66f ./zephyr/samples/net/dsa/ -- -DCONF_FILE=prj.conf`) one needs to also apply
fix from https://github.com/zephyrproject-rtos/zephyr/pull/40340