### PR TITLE
Bluetooth: Controller: Fix missing DTM Tx/Rx reset on HCI Reset Command

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_test.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_test.c
@@ -166,7 +166,7 @@ static uint32_t init(uint8_t chan, uint8_t phy, void (*isr)(void *))
 	int err;
 
 	if (started) {
-		return 1;
+		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
 
 	/* start coarse timer */
@@ -209,7 +209,7 @@ uint32_t ll_test_tx(uint8_t chan, uint8_t len, uint8_t type, uint8_t phy)
 	uint32_t err;
 
 	if ((type > 0x07) || !phy || (phy > 0x04)) {
-		return 1;
+		return BT_HCI_ERR_UNSUPP_FEATURE_PARAM_VAL;
 	}
 
 	err = init(chan, phy, isr_tx);
@@ -285,7 +285,7 @@ uint32_t ll_test_rx(uint8_t chan, uint8_t phy, uint8_t mod_idx)
 	uint32_t err;
 
 	if (!phy || (phy > 0x03)) {
-		return 1;
+		return BT_HCI_ERR_UNSUPP_FEATURE_PARAM_VAL;
 	}
 
 	err = init(chan, phy, isr_rx);
@@ -312,7 +312,7 @@ uint32_t ll_test_end(uint16_t *num_rx)
 	uint8_t ack;
 
 	if (!started) {
-		return 1;
+		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
 
 	/* Return packets Rx-ed/Completed */

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -73,6 +73,7 @@
 
 #include "ll.h"
 #include "ll_feat.h"
+#include "ll_test.h"
 #include "ll_settings.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
@@ -783,6 +784,14 @@ void ll_reset(void)
 	err = ull_adv_reset_finalize();
 	LL_ASSERT(!err);
 #endif /* CONFIG_BT_BROADCASTER */
+
+	/* Reset/End DTM Tx or Rx commands */
+	if (IS_ENABLED(CONFIG_BT_CTLR_DTM)) {
+		uint16_t num_rx;
+
+		(void)ll_test_end(&num_rx);
+		ARG_UNUSED(num_rx);
+	}
 
 	/* Common to init and reset */
 	err = init_reset();


### PR DESCRIPTION
Fix missing implementation to reset DTM Tx/Rx reset on HCI
Reset Command.

Fixes #39973.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>