### PR TITLE
soc: intel_adsp: Unify IDC drivers, eliminate IPM_CAVS_IDC

### DIFF
--- a/boards/xtensa/intel_adsp_cavs15/intel_adsp_cavs15.dts
+++ b/boards/xtensa/intel_adsp_cavs15/intel_adsp_cavs15.dts
@@ -14,6 +14,5 @@
 
 	chosen {
 		zephyr,sram = &sram0;
-		zephyr,console = &ipm_console;
 	};
 };

--- a/dts/xtensa/intel/intel_cavs15.dtsi
+++ b/dts/xtensa/intel/intel_cavs15.dtsi
@@ -90,27 +90,6 @@
 			reg = <0x1200 0x80>;
 			interrupts = <8 0 0>;
 			interrupt-parent = <&cavs0>;
-		     };
-
-		mailbox: mailbox@1180 {
-			compatible = "intel,adsp-mailbox";
-			reg = <0x1180 0x20>;
-			interrupts = <0x7 0 3>;
-			interrupt-parent = <&cavs0>;
-			label = "IPM_0";
-		};
-
-		ipm_console: ipm_console {
-			compatible = "zephyr,ipm-console";
-			label="IPM_0";
-		};
-
-		mailbox: mailbox@1180 {
-			compatible = "intel,intel-adsp-mailbox";
-			reg = <0x1180 0x20>;
-			interrupts = <0x7 0 3>;
-			interrupt-parent = <&cavs0>;
-			label = "IPM_0";
 		};
 	};
 };

--- a/soc/xtensa/intel_adsp/cavs_v15/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/cavs_v15/Kconfig.defconfig.series
@@ -18,6 +18,12 @@ config SOC
 config SMP
 	default y
 
+config MP_NUM_CPUS
+	default 2
+
+config SCHED_IPI_SUPPORTED
+	default y
+
 config XTENSA_TIMER
 	default n
 
@@ -62,21 +68,5 @@ config LOG_BACKEND_ADSP
 	default y
 
 endif # LOG
-
-if SMP
-
-config MP_NUM_CPUS
-	default 2
-
-config IPM
-       default y
-
-config IPM_CAVS_IDC
-	default y
-
-config SCHED_IPI_SUPPORTED
-	default y if IPM_CAVS_IDC
-
-endif # SMP
 
 endif # SOC_SERIES_INTEL_CAVS_V15

--- a/soc/xtensa/intel_adsp/cavs_v18/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/cavs_v18/Kconfig.defconfig.series
@@ -18,6 +18,13 @@ config SOC
 config SMP
        default y
 
+# FIXME: these DSPs can have more cores, but Zephyr only supports up to 2 cores on them
+config MP_NUM_CPUS
+	default 2
+
+config SCHED_IPI_SUPPORTED
+	default y
+
 config XTENSA_TIMER
 	default n
 
@@ -65,27 +72,5 @@ config LOG_BACKEND_ADSP
 	default y
 
 endif # LOG
-
-if SMP
-
-# FIXME: these DSPs can have more cores, but Zephyr only supports up to 2 cores on them
-config MP_NUM_CPUS
-	default 2
-
-config IPM
-	default y
-
-config IPM_CAVS_IDC
-	default y if IPM
-
-config SCHED_IPI_SUPPORTED
-	default y if IPM_CAVS_IDC
-
-config IPM_CONSOLE
-	default y
-	depends on CONSOLE
-	depends on IPM
-
-endif # SMP
 
 endif

--- a/soc/xtensa/intel_adsp/cavs_v20/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/cavs_v20/Kconfig.defconfig.series
@@ -18,6 +18,13 @@ config SOC
 config SMP
        default y
 
+# FIXME: these DSPs can have more cores, but Zephyr only supports up to 2 cores on them
+config MP_NUM_CPUS
+	default 2
+
+config SCHED_IPI_SUPPORTED
+	default y
+
 config XTENSA_TIMER
 	default n
 
@@ -65,22 +72,5 @@ config LOG_BACKEND_ADSP
 	default y
 
 endif # LOG
-
-if SMP
-
-# FIXME: these DSPs can have more cores, but Zephyr only supports up to 2 cores on them
-config MP_NUM_CPUS
-	default 2
-
-config IPM
-	default y
-
-config IPM_CAVS_IDC
-	default y if IPM
-
-config SCHED_IPI_SUPPORTED
-	default y if IPM_CAVS_IDC
-
-endif # SMP
 
 endif # SOC_SERIES_INTEL_CAVS_V20


### PR DESCRIPTION
[Split out from #39603]

Have all platforms use the same underling IPI mechanism.
Unfortunately I can't remove the ipm_cavs_idc driver entirely as it's
still used by the intel_s1000 board (which also should be unified with
cavs, but I don't have that hardware anymore).

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>