### PR TITLE
drivers/timer/cavs_timer: Fix race in k_cycle_get_64()

### DIFF
--- a/drivers/timer/cavs_timer.c
+++ b/drivers/timer/cavs_timer.c
@@ -77,17 +77,6 @@ static uint32_t count32(void)
 	return shim_regs->walclk32_lo;
 }
 
-static uint64_t count64(void)
-{
-	k_spinlock_key_t key = k_spin_lock(&lock);
-	uint64_t ret = shim_regs->walclk32_lo;
-
-	ret |= (uint64_t)shim_regs->walclk32_hi << 32;
-
-	k_spin_unlock(&lock, key);
-	return ret;
-}
-
 static void compare_isr(const void *arg)
 {
 	ARG_UNUSED(arg);
@@ -195,7 +184,7 @@ uint32_t sys_clock_cycle_get_32(void)
 
 uint64_t sys_clock_cycle_get_64(void)
 {
-	return count64();
+	return count();
 }
 
 /* Runs on secondary cores */


### PR DESCRIPTION
[Split out from #39603]

In commit 918a574c88c3 ("clock: add k_cycle_get_64") this driver was
augmented with a count64() method to get a 64 bit cycle output from
the two-32-bit-word device registers.

Unfortunately it appeared to be trying to use a spinlock around the
two (low/high) reads to protect against overflow.  But that doesn't
work: spinlocks protect against other CPU code using the same
spinlock, not against a hardware counter that is incrementing in real
time!

Thankfully there was already a count() routine in place that does a
detect-overflow-and-retry loop to solve this.  Use that.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>