### PR TITLE
coding guidelines: comply with MISRA C:2012 Rule 8.2

### DIFF
--- a/arch/x86/core/intel64/irq.c
+++ b/arch/x86/core/intel64/irq.c
@@ -26,7 +26,7 @@ unsigned char _irq_to_interrupt_vector[CONFIG_MAX_IRQ_LINES];
 
 #define NR_IRQ_VECTORS (IV_NR_VECTORS - IV_IRQS)  /* # vectors free for IRQs */
 
-void (*x86_irq_funcs[NR_IRQ_VECTORS])(const void *);
+void (*x86_irq_funcs[NR_IRQ_VECTORS])(const void *arg);
 const void *x86_irq_args[NR_IRQ_VECTORS];
 
 static void irq_spurious(const void *arg)

--- a/arch/x86/core/intel64/thread.c
+++ b/arch/x86/core/intel64/thread.c
@@ -10,7 +10,7 @@
 #include <offsets_short.h>
 #include <x86_mmu.h>
 
-extern void x86_sse_init(struct k_thread *); /* in locore.S */
+extern void x86_sse_init(struct k_thread *thread); /* in locore.S */
 
 /* FIXME: This exists to make space for a "return address" at the top
  * of the stack.  Obviously this is unused at runtime, but is required

--- a/arch/x86/zefi/efi.h
+++ b/arch/x86/zefi/efi.h
@@ -10,10 +10,10 @@
 
 #define __abi __attribute__((ms_abi))
 
-typedef uintptr_t __abi (*efi_fn1_t)(void *);
-typedef uintptr_t __abi (*efi_fn2_t)(void *, void *);
-typedef uintptr_t __abi (*efi_fn3_t)(void *, void *, void *);
-typedef uintptr_t __abi (*efi_fn4_t)(void *, void *, void *, void *);
+typedef uintptr_t __abi (*efi_fn1_t)(void *arg1);
+typedef uintptr_t __abi (*efi_fn2_t)(void *arg1, void *arg2);
+typedef uintptr_t __abi (*efi_fn3_t)(void *arg1, void *arg2, void *arg3);
+typedef uintptr_t __abi (*efi_fn4_t)(void *arg1, void *arg2, void *arg3, void *arg4);
 
 struct efi_simple_text_output {
 	efi_fn2_t Reset;

--- a/drivers/console/uart_console.c
+++ b/drivers/console/uart_console.c
@@ -96,7 +96,7 @@ static int console_out(int c)
 #endif
 
 #if defined(CONFIG_STDOUT_CONSOLE)
-extern void __stdout_hook_install(int (*hook)(int));
+extern void __stdout_hook_install(int (*hook)(int c));
 #else
 #define __stdout_hook_install(x) \
 	do {    /* nothing */	 \
@@ -104,7 +104,7 @@ extern void __stdout_hook_install(int (*hook)(int));
 #endif
 
 #if defined(CONFIG_PRINTK)
-extern void __printk_hook_install(int (*fn)(int));
+extern void __printk_hook_install(int (*fn)(int c));
 #else
 #define __printk_hook_install(x) \
 	do {    /* nothing */	 \

--- a/lib/libc/minimal/source/stdout/stdout_console.c
+++ b/lib/libc/minimal/source/stdout/stdout_console.c
@@ -18,9 +18,9 @@ static int _stdout_hook_default(int c)
 	return EOF;
 }
 
-static int (*_stdout_hook)(int) = _stdout_hook_default;
+static int (*_stdout_hook)(int c) = _stdout_hook_default;
 
-void __stdout_hook_install(int (*hook)(int))
+void __stdout_hook_install(int (*hook)(int c))
 {
 	_stdout_hook = hook;
 }

--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -47,7 +47,7 @@ __attribute__((weak)) int arch_printk_char_out(int c)
 }
 /* LCOV_EXCL_STOP */
 
-int (*_char_out)(int) = arch_printk_char_out;
+int (*_char_out)(int c) = arch_printk_char_out;
 
 /**
  * @brief Install the character output routine for printk
@@ -58,7 +58,7 @@ int (*_char_out)(int) = arch_printk_char_out;
  *
  * @return N/A
  */
-void __printk_hook_install(int (*fn)(int))
+void __printk_hook_install(int (*fn)(int c))
 {
 	_char_out = fn;
 }


### PR DESCRIPTION
MISRA C:2012 Rule 8.2 (Function types shall be in prototype form
with named parameters.)

Added missing parameter names and uncommented a prototype.

Signed-off-by: Abramo Bagnara <abramo.bagnara@bugseng.com>