### PR TITLE
task_wdt: fix overflow in current_ticks making wdt get stuck

### DIFF
--- a/subsys/task_wdt/task_wdt.c
+++ b/subsys/task_wdt/task_wdt.c
@@ -50,7 +50,7 @@ static int hw_wdt_channel;
 static bool hw_wdt_started;
 #endif
 
-static void schedule_next_timeout(uint32_t current_ticks)
+static void schedule_next_timeout(int64_t current_ticks)
 {
 	int next_channel_id;	/* channel which will time out next */
 	int64_t next_timeout;   /* timeout in absolute ticks of this channel */


### PR DESCRIPTION
The task_wdt was getting stuck after approx. 36 hours on e.g. nRF52840, which has a SysTick with 32768 Hz. This corresponds to an overflow of the `uint32_t current_ticks` in `schedule_next_timeout`.

This commit fixes the accidentally introduced narrowing conversion.

Thanks to @ehughes for identifying the bug and nailing it down with extensive testing and thanks to @alexanderendian for finding the potential solution!

Fixes #40152

Tested with multiple nRF52840 DKs for several days (see linked issue).