### PR TITLE
driver: gpio: npcx: Fix API header

### DIFF
--- a/drivers/gpio/gpio_npcx.c
+++ b/drivers/gpio/gpio_npcx.c
@@ -177,7 +177,7 @@ static int gpio_npcx_port_set_masked_raw(const struct device *dev,
 }
 
 static int gpio_npcx_port_set_bits_raw(const struct device *dev,
-					gpio_port_value_t mask)
+				       gpio_port_pins_t mask)
 {
 	struct gpio_reg *const inst = HAL_INSTANCE(dev);
 
@@ -188,7 +188,7 @@ static int gpio_npcx_port_set_bits_raw(const struct device *dev,
 }
 
 static int gpio_npcx_port_clear_bits_raw(const struct device *dev,
-						gpio_port_value_t mask)
+					 gpio_port_pins_t mask)
 {
 	struct gpio_reg *const inst = HAL_INSTANCE(dev);
 
@@ -199,7 +199,7 @@ static int gpio_npcx_port_clear_bits_raw(const struct device *dev,
 }
 
 static int gpio_npcx_port_toggle_bits(const struct device *dev,
-						gpio_port_value_t mask)
+				      gpio_port_pins_t mask)
 {
 	struct gpio_reg *const inst = HAL_INSTANCE(dev);
 


### PR DESCRIPTION
For port_set_bits_raw(), port_clear_bits_raw(), and port_toggle_bits(),
the second parameter sould be gpio_port_pins_t type. Currently, it
doesn't have other side effect, but it sould be fix. This commit fixes
it.