### PR TITLE
net: ppp: custom MTU/MRU and option to disable autostart in a driver

### DIFF
--- a/drivers/net/Kconfig
+++ b/drivers/net/Kconfig
@@ -83,6 +83,12 @@ config PPP_CLIENT_CLIENTSERVER
 	  This is only necessary if a ppp connection should be
 	  established with a Microsoft Windows PC.
 
+config PPP_NET_IF_NO_AUTO_START
+	bool "Disable PPP interface auto-start"
+	help
+	  This option allows user to disable autostarting of the PPP interface
+	  immediately after initialization.
+
 module = NET_PPP
 module-dep = LOG
 module-str = Log level for ppp driver

--- a/drivers/net/ppp.c
+++ b/drivers/net/ppp.c
@@ -781,10 +781,12 @@ use_random_mac:
 
 	memset(ppp->buf, 0, sizeof(ppp->buf));
 
-	/* If we have a GSM modem with PPP support, then do not start the
-	 * interface automatically but only after the modem is ready.
+	/* If we have a GSM modem with PPP support or interface autostart is disabled
+	 * from Kconfig, then do not start the interface automatically but only
+	 * after the modem is ready or when manually started.
 	 */
-	if (IS_ENABLED(CONFIG_MODEM_GSM_PPP)) {
+	if (IS_ENABLED(CONFIG_MODEM_GSM_PPP) ||
+	    IS_ENABLED(CONFIG_PPP_NET_IF_NO_AUTO_START)) {
 		net_if_flag_set(iface, NET_IF_NO_AUTO_START);
 	}
 }

--- a/subsys/net/l2/ppp/lcp.c
+++ b/subsys/net/l2/ppp/lcp.c
@@ -147,6 +147,11 @@ static void lcp_lower_down(struct ppp_context *ctx)
 
 static void lcp_lower_up(struct ppp_context *ctx)
 {
+#if defined(CONFIG_NET_L2_PPP_OPTION_MRU)
+	/* Get currently set MTU */
+	ctx->lcp.my_options.mru = net_if_get_mtu(ctx->iface);
+#endif
+
 	ppp_fsm_lower_up(&ctx->lcp.fsm);
 }
 
@@ -304,7 +309,7 @@ static void lcp_init(struct ppp_context *ctx)
 	ppp_fsm_name_set(&ctx->lcp.fsm, ppp_proto2str(PPP_LCP));
 
 #if defined(CONFIG_NET_L2_PPP_OPTION_MRU)
-	ctx->lcp.my_options.mru = PPP_MRU;
+	ctx->lcp.my_options.mru = net_if_get_mtu(ctx->iface);
 	ctx->lcp.fsm.my_options.info = lcp_my_options;
 	ctx->lcp.fsm.my_options.data = ctx->lcp.my_options_data;
 	ctx->lcp.fsm.my_options.count = ARRAY_SIZE(lcp_my_options);


### PR DESCRIPTION
This PR adds options to:
- have a custom MTU/MRU into LCP negotiation of the MRU. e.g. set by net_if_set_mtu()
- disable autostarting of the ppp net_if. Can be done by using new Kconfig option CONFIG_PPP_NET_IF_NO_AUTO_START.