### PR TITLE
kconfig: fix typo in compiler options

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -309,7 +309,7 @@ config NO_OPTIMIZATIONS
 endchoice
 
 config COMPILER_COLOR_DIAGNOSTICS
-	bool "Enable colored diganostics"
+	bool "Enable colored diagnostics"
 	default y
 	help
 	  Compiler diagnostic messages are colorized.


### PR DESCRIPTION
This commit fix the misspelling of the word "diagnostics"

Signed-off-by: MORGER Patrick <patrick.morger@leica-geosystems.com>