### PR TITLE
Tracing: Fixed TraceRecorder inclusion problem

### DIFF
--- a/include/tracing/tracing.h
+++ b/include/tracing/tracing.h
@@ -35,30 +35,6 @@
  * @{
  */
 
-#if defined(CONFIG_PERCEPIO_TRACERECORDER)
-#include "tracing_tracerecorder.h"
-#else
-/**
- * @brief Called when entering an ISR
- */
-void sys_trace_isr_enter(void);
-
-/**
- * @brief Called when exiting an ISR
- */
-void sys_trace_isr_exit(void);
-
-/**
- * @brief Called when exiting an ISR and switching to scheduler
- */
-void sys_trace_isr_exit_to_scheduler(void);
-
-/**
- * @brief Called when the cpu enters the idle state
- */
-void sys_trace_idle(void);
-#endif /* CONFIG_PERCEPIO_TRACERECORDER */
-
 /**
  * @brief Thread Tracing APIs
  * @defgroup subsys_tracing_apis_thread Thread Tracing APIs
@@ -1998,6 +1974,30 @@ void sys_trace_idle(void);
 #define sys_port_trace_pm_device_runtime_disable_exit(dev, ret)
 
 /** @} */ /* end of subsys_tracing_apis_pm_device_runtime */
+
+#if defined(CONFIG_PERCEPIO_TRACERECORDER)
+#include "tracing_tracerecorder.h"
+#else
+/**
+ * @brief Called when entering an ISR
+ */
+void sys_trace_isr_enter(void);
+
+/**
+ * @brief Called when exiting an ISR
+ */
+void sys_trace_isr_exit(void);
+
+/**
+ * @brief Called when exiting an ISR and switching to scheduler
+ */
+void sys_trace_isr_exit_to_scheduler(void);
+
+/**
+ * @brief Called when the cpu enters the idle state
+ */
+void sys_trace_idle(void);
+#endif /* CONFIG_PERCEPIO_TRACERECORDER */
 
 /** @} */ /* end of subsys_tracing_apis */
 


### PR DESCRIPTION
Moved conditional inclusion of tracing_tracerecorder.h
from the start of tracing.h to the bottom. This was the
initial placement of this include but it was moved as
part of PR #40126. If this file is included at the
start of tracing.h the TraceRecorder module hooks
will not map correctly and completely breaks
that module.

Signed-off-by: Torbjörn Leksell <torbjorn.leksell@percepio.com>