### PR TITLE
Bluetooth: host: Deprecate bt_gatt_cancel

### DIFF
--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -1579,13 +1579,6 @@ enum {
 	 */
 	BT_GATT_SUBSCRIBE_FLAG_NO_RESUB,
 
-	/** @brief Write pending flag
-	 *
-	 *  If set, indicates write operation is pending waiting remote end to
-	 *  respond.
-	 */
-	BT_GATT_SUBSCRIBE_FLAG_WRITE_PENDING,
-
 	BT_GATT_SUBSCRIBE_NUM_FLAGS
 };
 
@@ -1671,8 +1664,15 @@ int bt_gatt_unsubscribe(struct bt_conn *conn,
  *
  *  @param conn Connection object.
  *  @param params Requested params address.
+ *
+ *  \deprecated
+ *  This function was incorrectly implemented and never did anything useful.
+ *  It now a no-op, and may be removed in the future. There is no replacement.
  */
-void bt_gatt_cancel(struct bt_conn *conn, void *params);
+__deprecated
+inline void bt_gatt_cancel(struct bt_conn *conn, void *params)
+{
+}
 
 /** @} */
 

--- a/subsys/bluetooth/host/att_internal.h
+++ b/subsys/bluetooth/host/att_internal.h
@@ -296,9 +296,6 @@ int bt_att_send(struct bt_conn *conn, struct net_buf *buf, bt_conn_tx_cb_t cb,
 /* Send ATT Request over a connection */
 int bt_att_req_send(struct bt_conn *conn, struct bt_att_req *req);
 
-/* Cancel ATT request */
-void bt_att_req_cancel(struct bt_conn *conn, struct bt_att_req *req);
-
 /* Connect EATT channels */
 int bt_eatt_connect(struct bt_conn *conn, uint8_t num_channels);
 


### PR DESCRIPTION
This function was implemented incorrectly and did nothing useful.

Signed-off-by: Aleksander Wasaznik <aleksander.wasaznik@nordicsemi.no>