### PR TITLE
boards: nucleo_wl55jc: assert SRST before any target connection

### DIFF
--- a/boards/arm/nucleo_wl55jc/support/openocd.cfg
+++ b/boards/arm/nucleo_wl55jc/support/openocd.cfg
@@ -4,4 +4,4 @@ transport select hla_swd
 
 source [find target/stm32wlx.cfg]
 
-reset_config srst_only
+reset_config srst_only srst_nogate connect_assert_srst


### PR DESCRIPTION
Failed to flash blinky example to stock nucleo_wl55jc due to default
application entering low power mode using WFI. To connect to a sleeping
stm32wl55 a system reset is required.