### PR TITLE
doc: west: build-flash-debug: fix cmake arg example

### DIFF
--- a/doc/guides/west/build-flash-debug.rst
+++ b/doc/guides/west/build-flash-debug.rst
@@ -75,7 +75,7 @@ Here are some ``west build`` usage examples, grouped by area.
 Forcing CMake to Run Again
 --------------------------
 
-To force a CMake re-run, use the ``--cmake`` (or ``--c``) option::
+To force a CMake re-run, use the ``--cmake`` (or ``-c``) option::
 
   west build -c
 


### PR DESCRIPTION
The shorter version of `--cmake` argument should contain one dash only.

Signed-off-by: Bartosz Bilas <bartosz.bilas@hotmail.com>