### PR TITLE
pm: Remove unused parameter

### DIFF
--- a/arch/arc/core/isr_wrapper.S
+++ b/arch/arc/core/isr_wrapper.S
@@ -249,8 +249,6 @@ rirq_path:
 #if defined(CONFIG_PM)
 	clri r0 /* do not interrupt exiting tickless idle operations */
 	MOVR r1, _kernel
-	/* z_kernel.idle is 32 bit despite of platform bittnes */
-	ld_s r3, [r1, _kernel_offset_to_idle] /* requested idle duration */
 	breq r3, 0, _skip_pm_save_idle_exit
 
 	st 0, [r1, _kernel_offset_to_idle] /* zero idle duration */

--- a/arch/arm/core/aarch32/irq_manage.c
+++ b/arch/arm/core/aarch32/irq_manage.c
@@ -181,10 +181,8 @@ void _arch_isr_direct_pm(void)
 #endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
 
 	if (_kernel.idle) {
-		int32_t idle_val = _kernel.idle;
-
 		_kernel.idle = 0;
-		z_pm_save_idle_exit(idle_val);
+		z_pm_save_idle_exit();
 	}
 
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE) \

--- a/arch/posix/core/swap.c
+++ b/arch/posix/core/swap.c
@@ -111,10 +111,8 @@ void arch_switch_to_main_thread(struct k_thread *main_thread, char *stack_ptr,
 void posix_irq_check_idle_exit(void)
 {
 	if (_kernel.idle) {
-		int32_t idle_val = _kernel.idle;
-
 		_kernel.idle = 0;
-		z_pm_save_idle_exit(idle_val);
+		z_pm_save_idle_exit();
 	}
 }
 #endif

--- a/arch/x86/core/ia32/intstub.S
+++ b/arch/x86/core/ia32/intstub.S
@@ -301,8 +301,6 @@ nestedInterrupt:
 handle_idle:
 	pushl	%eax
 	pushl	%edx
-	/* Populate 'ticks' argument to z_pm_save_idle_exit */
-	push	_kernel_offset_to_idle(%ecx)
 	/* Zero out _kernel.idle */
 	movl	$0, _kernel_offset_to_idle(%ecx)
 
@@ -314,8 +312,6 @@ handle_idle:
 	 */
 
 	call	z_pm_save_idle_exit
-	/* discard 'ticks' argument passed on the stack */
-	add	$0x4, %esp
 	popl	%edx
 	popl	%eax
 	jmp	alreadyOnIntStack

--- a/include/arch/x86/ia32/arch.h
+++ b/include/arch/x86/ia32/arch.h
@@ -244,10 +244,8 @@ typedef struct s_isrList {
 static inline void arch_irq_direct_pm(void)
 {
 	if (_kernel.idle) {
-		int32_t idle_val = _kernel.idle;
-
 		_kernel.idle = 0;
-		z_pm_save_idle_exit(idle_val);
+		z_pm_save_idle_exit();
 	}
 }
 

--- a/include/pm/pm.h
+++ b/include/pm/pm.h
@@ -215,7 +215,7 @@ void pm_power_state_exit_post_ops(struct pm_state_info info);
 
 #endif /* CONFIG_PM */
 
-void z_pm_save_idle_exit(int32_t ticks);
+void z_pm_save_idle_exit(void);
 
 #ifdef __cplusplus
 }

--- a/kernel/idle.c
+++ b/kernel/idle.c
@@ -48,7 +48,7 @@ static void pm_save_idle(void)
 #endif
 }
 
-void z_pm_save_idle_exit(int32_t ticks)
+void z_pm_save_idle_exit(void)
 {
 #ifdef CONFIG_PM
 	/* Some CPU low power states require notification at the ISR


### PR DESCRIPTION
The number of ticks on z_pm_save_idle_exit is not used and there is
no need to have it.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>