### PR TITLE
shell + logging: do not alias atomic_t

### DIFF
--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -659,7 +659,7 @@ BUILD_ASSERT((sizeof(struct shell_backend_ctx_flags) == sizeof(uint32_t)),
  * @internal @brief Union for internal shell usage.
  */
 union shell_backend_cfg {
-	uint32_t value;
+	atomic_t value;
 	struct shell_backend_config_flags flags;
 };
 

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -85,7 +85,7 @@ static bool backend_attached;
 static atomic_t buffered_cnt;
 static atomic_t dropped_cnt;
 static k_tid_t proc_tid;
-static uint32_t log_strdup_in_use;
+static atomic_t log_strdup_in_use;
 static uint32_t log_strdup_max;
 static uint32_t log_strdup_longest;
 static struct k_timer log_process_thread_timer;
@@ -939,7 +939,7 @@ void z_log_free(void *str)
 	if (atomic_dec(&dup->refcount) == 1) {
 		k_mem_slab_free(&log_strdup_pool, (void **)&dup);
 		if (IS_ENABLED(CONFIG_LOG_STRDUP_POOL_PROFILING)) {
-			atomic_dec((atomic_t *)&log_strdup_in_use);
+			atomic_dec(&log_strdup_in_use);
 		}
 	}
 }


### PR DESCRIPTION
Previously, a `uint32_t` was aliased as an `atomic_t`. However, with #39531, `atomic_t` is now a `long` under the hood, which is 64-bit on 64-bit platforms.

Fixes #40369
