### PR TITLE
.github: exempt the 'Process' label from stale issues

### DIFF
--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -19,5 +19,5 @@ jobs:
         stale-issue-label: 'Stale'
         stale-pr-label: 'Stale'
         exempt-pr-labels: 'Blocked,In progress'
-        exempt-issue-labels: 'In progress,Enhancement,Feature,Feature Request,RFC,Meta'
+        exempt-issue-labels: 'In progress,Enhancement,Feature,Feature Request,RFC,Meta,Process'
         operations-per-run: 400


### PR DESCRIPTION
Process issues are tracked and do not need to be automatically made
stale.

Suggested-by: Anas Nashif <anas.nashif@intel.com>
Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>