### PR TITLE
coding guidelines: comply with MISRA C:2012 Rule 14.4

### DIFF
--- a/arch/arm/include/aarch32/cortex_m/tz_ns.h
+++ b/arch/arm/include/aarch32/cortex_m/tz_ns.h
@@ -65,7 +65,7 @@
 			"pop {r0-r3}\n\t" \
 			load_lr "\n\t" \
 			::); \
-	} while (0)
+	} while (false)
 
 /**
  * @brief Macro for "sandwiching" a function call (@p name) in two other calls

--- a/arch/nios2/include/kernel_arch_func.h
+++ b/arch/nios2/include/kernel_arch_func.h
@@ -53,15 +53,15 @@ void z_irq_do_offload(void);
 #if ALT_CPU_ICACHE_SIZE > 0
 void z_nios2_icache_flush_all(void);
 #else
-#define z_nios2_icache_flush_all() do { } while (0)
+#define z_nios2_icache_flush_all() do { } while (false)
 #endif
 
 #if ALT_CPU_DCACHE_SIZE > 0
 void z_nios2_dcache_flush_all(void);
 void z_nios2_dcache_flush_no_writeback(void *start, uint32_t len);
 #else
-#define z_nios2_dcache_flush_all() do { } while (0)
-#define z_nios2_dcache_flush_no_writeback(x, y) do { } while (0)
+#define z_nios2_dcache_flush_all() do { } while (false)
+#define z_nios2_dcache_flush_no_writeback(x, y) do { } while (false)
 #endif
 
 #endif /* _ASMLANGUAGE */

--- a/arch/x86/core/acpi.c
+++ b/arch/x86/core/acpi.c
@@ -137,7 +137,7 @@ void *z_acpi_find_table(uint32_t signature)
 		return NULL;
 	}
 
-	if (rsdp->rsdt_ptr) {
+	if (rsdp->rsdt_ptr != 0U) {
 		z_phys_map((uint8_t **)&rsdt, rsdp->rsdt_ptr, sizeof(*rsdt), 0);
 		tbl_found = false;
 
@@ -174,7 +174,7 @@ void *z_acpi_find_table(uint32_t signature)
 		return NULL;
 	}
 
-	if (rsdp->xsdt_ptr) {
+	if (rsdp->xsdt_ptr != 0ULL) {
 		z_phys_map((uint8_t **)&xsdt, rsdp->xsdt_ptr, sizeof(*xsdt), 0);
 
 		tbl_found = false;

--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -488,7 +488,7 @@ static inline void assert_region_page_aligned(void *addr, size_t size)
 
 #define COLOR(x)	printk(_CONCAT(ANSI_, x))
 #else
-#define COLOR(x)	do { } while (0)
+#define COLOR(x)	do { } while (false)
 #endif
 
 __pinned_func
@@ -697,7 +697,7 @@ static void dump_entry(int level, void *virt, pentry_t entry)
 			if ((entry & MMU_##bit) != 0U) { \
 				str_append(&pos, &sz, #bit " "); \
 			} \
-		} while (0)
+		} while (false)
 
 	DUMP_BIT(RW);
 	DUMP_BIT(US);

--- a/arch/x86/zefi/printf.h
+++ b/arch/x86/zefi/printf.h
@@ -5,6 +5,7 @@
  */
 #include <stdarg.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 /* Tiny, but not-as-primitive-as-it-looks implementation of something
  * like s/n/printf().  Handles %d, %x, %p, %c and %s only, allows a
@@ -24,7 +25,7 @@ static void (*z_putchar)(int c);
 
 static void pc(struct _pfr *r, int c)
 {
-	if (r->buf) {
+	if (r->buf != NULL) {
 		if (r->idx <= r->len) {
 			r->buf[r->idx] = c;
 		}
@@ -50,7 +51,7 @@ static void prdec(struct _pfr *r, long v)
 		v /= 10;
 	}
 
-	while (digs[++i]) {
+	while (digs[++i] != '\0') {
 		pc(r, digs[i]);
 	}
 }
@@ -64,7 +65,7 @@ static void endrec(struct _pfr *r)
 
 static int vpf(struct _pfr *r, const char *f, va_list ap)
 {
-	for (/**/; *f; f++) {
+	for (/**/; *f != '\0'; f++) {
 		bool islong = false;
 
 		if (*f != '%') {
@@ -100,7 +101,7 @@ static int vpf(struct _pfr *r, const char *f, va_list ap)
 		case 's': {
 			char *s = va_arg(ap, char *);
 
-			while (*s)
+			while (*s != '\0')
 				pc(r, *s++);
 			break;
 		}

--- a/boards/posix/native_posix/board_irq.h
+++ b/boards/posix/native_posix/board_irq.h
@@ -70,14 +70,14 @@ void posix_irq_priority_set(unsigned int irq, unsigned int prio,
 	} \
 	static inline int name##_body(void)
 
-#define ARCH_ISR_DIRECT_HEADER()   do { } while (0)
-#define ARCH_ISR_DIRECT_FOOTER(a)  do { } while (0)
+#define ARCH_ISR_DIRECT_HEADER()   do { } while (false)
+#define ARCH_ISR_DIRECT_FOOTER(a)  do { } while (false)
 
 #ifdef CONFIG_PM
 extern void posix_irq_check_idle_exit(void);
 #define ARCH_ISR_DIRECT_PM() posix_irq_check_idle_exit()
 #else
-#define ARCH_ISR_DIRECT_PM() do { } while (0)
+#define ARCH_ISR_DIRECT_PM() do { } while (false)
 #endif
 
 #ifdef __cplusplus

--- a/boards/posix/nrf52_bsim/board_irq.h
+++ b/boards/posix/nrf52_bsim/board_irq.h
@@ -70,14 +70,14 @@ void posix_irq_priority_set(unsigned int irq, unsigned int prio,
 	} \
 	static inline int name##_body(void)
 
-#define ARCH_ISR_DIRECT_HEADER()   do { } while (0)
-#define ARCH_ISR_DIRECT_FOOTER(a)  do { } while (0)
+#define ARCH_ISR_DIRECT_HEADER()   do { } while (false)
+#define ARCH_ISR_DIRECT_FOOTER(a)  do { } while (false)
 
 #ifdef CONFIG_PM
 extern void posix_irq_check_idle_exit(void);
 #define ARCH_ISR_DIRECT_PM() posix_irq_check_idle_exit()
 #else
-#define ARCH_ISR_DIRECT_PM() do { } while (0)
+#define ARCH_ISR_DIRECT_PM() do { } while (false)
 #endif
 
 #ifdef __cplusplus

--- a/drivers/adc/adc_cc32xx.c
+++ b/drivers/adc/adc_cc32xx.c
@@ -294,7 +294,7 @@ static const struct adc_driver_api cc32xx_driver_api = {
 			    adc_cc32xx_isr_ch##chan,		       \
 			    DEVICE_DT_INST_GET(index), 0);	       \
 		irq_enable(DT_INST_IRQ_BY_IDX(index, chan, irq));      \
-	} while (0)
+	} while (false)
 
 #define cc32xx_ADC_INIT(index)							 \
 										 \

--- a/drivers/adc/adc_sam0.c
+++ b/drivers/adc/adc_sam0.c
@@ -557,7 +557,7 @@ do {									\
 	adc->CALIB.reg = ADC_CALIB_BIASCOMP(comp) |			\
 			 ADC_CALIB_BIASR2R(r2r) |			\
 			 ADC_CALIB_BIASREFBUF(rbuf);			\
-} while (0)
+} while (false)
 
 #else
 
@@ -582,7 +582,7 @@ do {									\
 		      ADC_FUSES_BIASCAL_Msk) >> ADC_FUSES_BIASCAL_Pos;	\
 	adc->CALIB.reg = ADC_CALIB_BIAS_CAL(bias) |			\
 			 ADC_CALIB_LINEARITY_CAL(lin);			\
-} while (0)
+} while (false)
 
 #endif
 

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -779,7 +779,7 @@ static const struct can_driver_api mcux_flexcan_driver_api = {
 		mcux_flexcan_isr,					\
 		DEVICE_DT_INST_GET(id), 0);				\
 		irq_enable(DT_INST_IRQ_BY_NAME(id, name, irq));		\
-	} while (0)
+	} while (false)
 
 #define FLEXCAN_IRQ(id, name) \
 	COND_CODE_1(DT_INST_IRQ_HAS_NAME(id, name), \

--- a/drivers/clock_control/clock_control_lpc11u6x.c
+++ b/drivers/clock_control/clock_control_lpc11u6x.c
@@ -114,7 +114,7 @@ static void pinmux_enable_sysosc(void)
 	pinmux_pin_set(pinmux_dev, pin, func);
 }
 #else
-#define pinmux_enable_sysosc() do { } while (0)
+#define pinmux_enable_sysosc() do { } while (false)
 #endif
 
 static void syscon_peripheral_reset(struct lpc11u6x_syscon_regs *syscon,

--- a/drivers/dma/dma_sam0.c
+++ b/drivers/dma/dma_sam0.c
@@ -402,7 +402,7 @@ static int dma_sam0_get_status(const struct device *dev, uint32_t channel,
 			    DT_INST_IRQ_BY_IDX(0, n, priority),		 \
 			    dma_sam0_isr, DEVICE_DT_INST_GET(0), 0);	 \
 		irq_enable(DT_INST_IRQ_BY_IDX(0, n, irq));		 \
-	} while (0)
+	} while (false)
 
 static int dma_sam0_init(const struct device *dev)
 {

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -696,7 +696,7 @@ DEVICE_DT_INST_DEFINE(index,						\
 			    dma_stm32_shared_irq_handler,		\
 			    DEVICE_DT_INST_GET(dma), 0);		\
 		irq_enable(DT_INST_IRQ_BY_IDX(dma, chan, irq));		\
-	} while (0)
+	} while (false)
 
 
 #else /* CONFIG_DMA_STM32_SHARED_IRQS */
@@ -715,7 +715,7 @@ static void dma_stm32_irq_##dma##_##chan(const struct device *dev)	\
 			    dma_stm32_irq_##dma##_##chan,		\
 			    DEVICE_DT_INST_GET(dma), 0);		\
 		irq_enable(DT_INST_IRQ_BY_IDX(dma, chan, irq));		\
-	} while (0)
+	} while (false)
 
 #endif /* CONFIG_DMA_STM32_SHARED_IRQS */
 

--- a/drivers/ethernet/eth_e1000_priv.h
+++ b/drivers/ethernet/eth_e1000_priv.h
@@ -98,7 +98,7 @@ static const char *e1000_reg_to_string(enum e1000_reg_t r)
 #define iow32(_dev, _reg, _val) do {					\
 	LOG_DBG("iow32 %s 0x%08x", e1000_reg_to_string(_reg), (_val)); 	\
 	sys_write32(_val, (_dev)->address + (_reg));			\
-} while (0)
+} while (false)
 
 #define ior32(_dev, _reg)						\
 ({									\

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -1234,7 +1234,7 @@ static void eth_mcux_err_isr(const struct device *dev)
 			    DEVICE_DT_INST_GET(n),			\
 			    0);						\
 		irq_enable(DT_INST_IRQ_BY_NAME(n, name, irq));		\
-	} while (0)
+	} while (false)
 
 #define ETH_MCUX_IRQ(n, name)						\
 	COND_CODE_1(DT_INST_IRQ_HAS_NAME(n, name),			\
@@ -1252,7 +1252,7 @@ static void eth_mcux_err_isr(const struct device *dev)
 			    DEVICE_DT_INST_GET(n),					\
 			    0);								\
 		irq_enable(DT_IRQ_BY_NAME(PTP_INST_NODEID(n), ieee1588_tmr, irq));	\
-	} while (0)
+	} while (false)
 
 #define ETH_MCUX_IRQ_PTP(n)						\
 	COND_CODE_1(DT_NODE_HAS_STATUS(PTP_INST_NODEID(n), okay),	\

--- a/drivers/flash/flash_simulator.c
+++ b/drivers/flash/flash_simulator.c
@@ -69,7 +69,7 @@
 		if (U < STATS_PAGE_COUNT_THRESHOLD) {			     \
 			(*(&flash_sim_stats.erase_cycles_unit0 + (U)) += 1); \
 		}							     \
-	} while (0)
+	} while (false)
 
 #if (CONFIG_FLASH_SIMULATOR_STAT_PAGE_COUNT > STATS_PAGE_COUNT_THRESHOLD)
        /* Limitation above is caused by used UTIL_REPEAT                    */
@@ -135,7 +135,7 @@ STATS_NAME_END(flash_sim_thresholds);
 
 #else
 
-#define ERASE_CYCLES_INC(U) do {} while (0)
+#define ERASE_CYCLES_INC(U) do {} while (false)
 #define FLASH_SIM_STATS_INC(group__, var__)
 #define FLASH_SIM_STATS_INCN(group__, var__, n__)
 #define FLASH_SIM_STATS_INIT_AND_REG(group__, size__, name__)

--- a/drivers/gpio/gpio_litex.c
+++ b/drivers/gpio/gpio_litex.c
@@ -284,7 +284,7 @@ static const struct gpio_driver_api gpio_litex_driver_api = {
 			    DEVICE_DT_INST_GET(n), 0); \
 \
 		irq_enable(DT_INST_IRQN(n)); \
-	} while (0)
+	} while (false)
 
 #define GPIO_LITEX_INIT(n) \
 	static int gpio_litex_port_init_##n(const struct device *dev); \

--- a/drivers/gpio/gpio_lpc11u6x.c
+++ b/drivers/gpio/gpio_lpc11u6x.c
@@ -511,7 +511,7 @@ do {							                \
 		    DT_INST_IRQ_BY_IDX(0, n, priority),			\
 		    gpio_lpc11u6x_isr, &gpio_lpc11u6x_shared, 0);	\
 	irq_enable(DT_INST_IRQ_BY_IDX(0, n, irq));			\
-} while (0)
+} while (false)
 
 static int gpio_lpc11u6x_init(const struct device *dev)
 {

--- a/drivers/gpio/gpio_mcux.c
+++ b/drivers/gpio/gpio_mcux.c
@@ -264,7 +264,7 @@ static const struct gpio_driver_api gpio_mcux_driver_api = {
 			    DEVICE_DT_INST_GET(n), 0);			\
 									\
 		irq_enable(DT_INST_IRQN(n));				\
-	} while (0)
+	} while (false)
 
 #define GPIO_PORT_BASE_ADDR(n) DT_REG_ADDR(DT_INST_PHANDLE(n, nxp_kinetis_port))
 

--- a/drivers/gpio/gpio_mcux_igpio.c
+++ b/drivers/gpio/gpio_mcux_igpio.c
@@ -209,7 +209,7 @@ static const struct gpio_driver_api mcux_igpio_driver_api = {
 			    DEVICE_DT_INST_GET(n), 0);			\
 									\
 		irq_enable(DT_INST_IRQ_BY_IDX(n, i, irq));		\
-	} while (0)
+	} while (false)
 
 #define MCUX_IGPIO_INIT(n)						\
 	static int mcux_igpio_##n##_init(const struct device *dev);	\

--- a/drivers/gpio/gpio_mcux_lpc.c
+++ b/drivers/gpio/gpio_mcux_lpc.c
@@ -370,7 +370,7 @@ static const clock_ip_name_t gpio_clock_names[] = GPIO_CLOCKS;
 			    gpio_mcux_lpc_port_isr, DEVICE_DT_INST_GET(n), 0);		\
 		irq_enable(DT_INST_IRQ_BY_IDX(n, m, irq));				\
 		data->isr_list[data->isr_list_idx++] = DT_INST_IRQ_BY_IDX(n, m, irq);	\
-	} while (0)
+	} while (false)
 
 #define GPIO_MCUX_LPC_IRQ(n, m)								\
 	COND_CODE_1(DT_INST_IRQ_HAS_IDX(n, m), (GPIO_MCUX_LPC_IRQ_CONNECT(n, m)), ())

--- a/drivers/gpio/gpio_sam4l.c
+++ b/drivers/gpio/gpio_sam4l.c
@@ -248,7 +248,7 @@ int gpio_sam_init(const struct device *dev)
 			    gpio_sam_isr,				\
 			    DEVICE_DT_INST_GET(n), 0);			\
 		irq_enable(DT_INST_IRQ_BY_IDX(n, m, irq));		\
-	} while (0)
+	} while (false)
 
 #define GPIO_SAM_INIT(n)						\
 	static void port_##n##_sam_config_func(const struct device *dev);\

--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -276,7 +276,7 @@ static int i2c_stm32_init(const struct device *dev)
 			    stm32_i2c_combined_isr,			\
 			    DEVICE_DT_GET(DT_NODELABEL(name)), 0);	\
 		irq_enable(DT_IRQN(DT_NODELABEL(name)));		\
-	} while (0)
+	} while (false)
 #else
 #define STM32_I2C_IRQ_CONNECT_AND_ENABLE(name)				\
 	do {								\
@@ -293,7 +293,7 @@ static int i2c_stm32_init(const struct device *dev)
 			    stm32_i2c_error_isr,			\
 			    DEVICE_DT_GET(DT_NODELABEL(name)), 0);	\
 		irq_enable(DT_IRQ_BY_NAME(DT_NODELABEL(name), error, irq));\
-	} while (0)
+	} while (false)
 #endif /* CONFIG_I2C_STM32_COMBINED_INTERRUPT */
 
 #define STM32_I2C_IRQ_HANDLER_DECL(name)				\

--- a/drivers/i2c/i2c_sam0.c
+++ b/drivers/i2c/i2c_sam0.c
@@ -761,7 +761,7 @@ static const struct i2c_driver_api i2c_sam0_driver_api = {
 			    i2c_sam0_isr,				\
 			    DEVICE_DT_INST_GET(n), 0);			\
 		irq_enable(DT_INST_IRQ_BY_IDX(n, m, irq));		\
-	} while (0)
+	} while (false)
 
 #if DT_INST_IRQ_HAS_IDX(0, 3)
 #define I2C_SAM0_IRQ_HANDLER(n)						\

--- a/drivers/ieee802154/ieee802154_kw41z.c
+++ b/drivers/ieee802154/ieee802154_kw41z.c
@@ -68,7 +68,7 @@ int kw41_dbg_idx;
 		if (++kw41_dbg_idx == KW41_DBG_TRACE_SIZE) { \
 			kw41_dbg_idx = 0; \
 		} \
-	} while (0)
+	} while (false)
 
 #else
 

--- a/drivers/interrupt_controller/intc_esp32.c
+++ b/drivers/interrupt_controller/intc_esp32.c
@@ -41,7 +41,7 @@ LOG_MODULE_REGISTER(esp32_intc, CONFIG_LOG_DEFAULT_LEVEL);
 #ifdef CONFIG_INTC_ESP32_DECISIONS_LOG
 # define INTC_LOG(...) LOG_INF(__VA_ARGS__)
 #else
-# define INTC_LOG(...) do {} while (0)
+# define INTC_LOG(...) do {} while (false)
 #endif
 
 /* Typedef for C-callable interrupt handler function */

--- a/drivers/interrupt_controller/intc_loapic.c
+++ b/drivers/interrupt_controller/intc_loapic.c
@@ -335,7 +335,7 @@ int z_irq_controller_isr_vector_get(void)
 	 */
 	for (block = 7; likely(block > 0); block--) {
 		pReg = x86_read_loapic(LOAPIC_ISR + (block * 0x10));
-		if (pReg) {
+		if (pReg != 0) {
 			return (block * 32) + (find_msb_set(pReg) - 1);
 		}
 

--- a/drivers/interrupt_controller/intc_sam0_eic.c
+++ b/drivers/interrupt_controller/intc_sam0_eic.c
@@ -332,7 +332,7 @@ uint32_t sam0_eic_interrupt_pending(int port)
 			    DT_INST_IRQ_BY_IDX(0, n, priority),		\
 			    sam0_eic_isr, DEVICE_DT_INST_GET(0), 0);	\
 		irq_enable(DT_INST_IRQ_BY_IDX(0, n, irq));		\
-	} while (0)
+	} while (false)
 
 static int sam0_eic_init(const struct device *dev)
 {

--- a/drivers/led_strip/ws2812_gpio.c
+++ b/drivers/led_strip/ws2812_gpio.c
@@ -89,7 +89,7 @@ static const struct ws2812_gpio_cfg *dev_cfg(const struct device *dev)
 			DELAY_TxL			\
 			::				\
 			[r] "l" (base),		\
-			[p] "l" (pin)); } while (0)
+			[p] "l" (pin)); } while (false)
 
 /* Send out a 0 bit's pulse */
 #define ZERO_BIT(base, pin) do {			\
@@ -99,7 +99,7 @@ static const struct ws2812_gpio_cfg *dev_cfg(const struct device *dev)
 			DELAY_TxL			\
 			::				\
 			[r] "l" (base),		\
-			[p] "l" (pin)); } while (0)
+			[p] "l" (pin)); } while (false)
 
 static int send_buf(const struct device *dev, uint8_t *buf, size_t len)
 {

--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -360,7 +360,7 @@ static const char TIME_STRING_FORMAT[] = "\"yy/MM/dd,hh:mm:ss?zz\"";
 			LOG_ERR("%s result:%d", (c), ret);                     \
 			goto error;                                            \
 		}                                                              \
-	} while (0)
+	} while (false)
 
 #define SEND_AT_CMD_IGNORE_ERROR(c)                                            \
 	do {                                                                   \
@@ -368,7 +368,7 @@ static const char TIME_STRING_FORMAT[] = "\"yy/MM/dd,hh:mm:ss?zz\"";
 		if (ret < 0) {                                                 \
 			LOG_ERR("%s result:%d", (c), ret);                     \
 		}                                                              \
-	} while (0)
+	} while (false)
 
 #define SEND_AT_CMD_EXPECT_OK(c)                                               \
 	do {                                                                   \
@@ -378,7 +378,7 @@ static const char TIME_STRING_FORMAT[] = "\"yy/MM/dd,hh:mm:ss?zz\"";
 			LOG_ERR("%s result:%d", (c), ret);                     \
 			goto error;                                            \
 		}                                                              \
-	} while (0)
+	} while (false)
 
 /* Complex has "no_id_resp" set to true because the sending command
  * is the command used to process the respone
@@ -391,7 +391,7 @@ static const char TIME_STRING_FORMAT[] = "\"yy/MM/dd,hh:mm:ss?zz\"";
 			LOG_ERR("%s result:%d", (c), ret);                     \
 			goto error;                                            \
 		}                                                              \
-	} while (0)
+	} while (false)
 
 NET_BUF_POOL_DEFINE(mdm_recv_pool, CONFIG_MODEM_HL7800_RECV_BUF_CNT,
 		    CONFIG_MODEM_HL7800_RECV_BUF_SIZE, 0, NULL);
@@ -2784,7 +2784,7 @@ static bool on_cmd_polte_registration(struct net_buf **buf, uint16_t len)
 			break;
 		}
 		parsed = true;
-	} while (0);
+	} while (false);
 
 	if (parsed && data.user && data.password) {
 		data.status = 0;
@@ -2829,7 +2829,7 @@ static bool on_cmd_polte_locate_cmd_rsp(struct net_buf **buf, uint16_t len)
 		rsp[out_len] = 0;
 
 		data.status = (uint32_t)strtoul(rsp, NULL, 10);
-	} while (0);
+	} while (false);
 
 	event_handler(HL7800_EVENT_POLTE_LOCATE_STATUS, &data);
 
@@ -2926,7 +2926,7 @@ static bool on_cmd_polte_location(struct net_buf **buf, uint16_t len)
 		}
 
 		parsed = true;
-	} while (0);
+	} while (false);
 
 	if (!parsed) {
 		LOG_HEXDUMP_ERR(rsp, out_len, "Unable to parse PoLTE location");

--- a/drivers/pcie/host/msi.c
+++ b/drivers/pcie/host/msi.c
@@ -240,7 +240,7 @@ static void enable_msi(pcie_bdf_t bdf,
 
 	mdr = pcie_msi_mdr(irq, vectors);
 	mcr = pcie_conf_read(bdf, base + PCIE_MSI_MCR);
-	if (mcr & PCIE_MSI_MCR_64) {
+	if ((mcr & PCIE_MSI_MCR_64) != 0U) {
 		pcie_conf_write(bdf, base + PCIE_MSI_MAP1_64, 0U);
 		pcie_conf_write(bdf, base + PCIE_MSI_MDR_64, mdr);
 	} else {

--- a/drivers/pcie/host/pcie.c
+++ b/drivers/pcie/host/pcie.c
@@ -53,12 +53,12 @@ uint32_t pcie_get_cap(pcie_bdf_t bdf, uint32_t cap_id)
 	uint32_t data;
 
 	data = pcie_conf_read(bdf, PCIE_CONF_CMDSTAT);
-	if (data & PCIE_CONF_CMDSTAT_CAPS) {
+	if ((data & PCIE_CONF_CMDSTAT_CAPS) != 0U) {
 		data = pcie_conf_read(bdf, PCIE_CONF_CAPPTR);
 		reg = PCIE_CONF_CAPPTR_FIRST(data);
 	}
 
-	while (reg) {
+	while (reg != 0U) {
 		data = pcie_conf_read(bdf, reg);
 
 		if (PCIE_CONF_CAP_ID(data) == cap_id) {
@@ -76,7 +76,7 @@ uint32_t pcie_get_ext_cap(pcie_bdf_t bdf, uint32_t cap_id)
 	unsigned int reg = PCIE_CONF_EXT_CAPPTR; /* Start at end of the PCI configuration space */
 	uint32_t data;
 
-	while (reg) {
+	while (reg != 0U) {
 		data = pcie_conf_read(bdf, reg);
 		if (!data || data == 0xffffffffU) {
 			return 0;
@@ -191,7 +191,7 @@ static unsigned int irq_alloc(void)
 	for (i = 0; i < ARRAY_SIZE(irq_reserved); i++) {
 		unsigned int fz, irq;
 
-		while ((fz = find_lsb_set(~atomic_get(&irq_reserved[i])))) {
+		while ((fz = find_lsb_set(~atomic_get(&irq_reserved[i]))) != 0U) {
 			irq = (fz - 1) + (i * sizeof(atomic_val_t) * 8);
 			if (irq >= CONFIG_MAX_IRQ_LINES) {
 				break;

--- a/drivers/serial/uart_cc13xx_cc26xx.c
+++ b/drivers/serial/uart_cc13xx_cc26xx.c
@@ -477,7 +477,7 @@ static const struct uart_driver_api uart_cc13xx_cc26xx_driver_api = {
 		Power_registerNotify(&get_dev_data(dev)->postNotify,	\
 			PowerCC26XX_AWAKE_STANDBY,			\
 			postNotifyFxn, (uintptr_t)dev);			\
-	} while (0)
+	} while (false)
 #else
 #define UART_CC13XX_CC26XX_POWER_UART(n)				\
 	do {								\
@@ -508,7 +508,7 @@ static const struct uart_driver_api uart_cc13xx_cc26xx_driver_api = {
 			PRCM_DOMAIN_POWER_ON) {				     \
 			continue;					     \
 		}							     \
-	} while (0)
+	} while (false)
 #endif
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
@@ -524,7 +524,7 @@ static const struct uart_driver_api uart_cc13xx_cc26xx_driver_api = {
 		irq_enable(DT_INST_IRQN(n));				\
 		/* Causes an initial TX ready INT when TX INT enabled */\
 		UARTCharPutNonBlocking(get_dev_conf(dev)->regs, '\0');  \
-	} while (0)
+	} while (false)
 
 #define UART_CC13XX_CC26XX_INT_FIELDS					\
 	.callback = NULL,						\

--- a/drivers/serial/uart_mcux_iuart.c
+++ b/drivers/serial/uart_mcux_iuart.c
@@ -276,7 +276,7 @@ static const struct uart_driver_api mcux_iuart_driver_api = {
 			    mcux_iuart_isr, DEVICE_DT_INST_GET(n), 0);	\
 									\
 		irq_enable(DT_INST_IRQ_BY_IDX(n, i, irq));		\
-	} while (0)
+	} while (false)
 #define IUART_MCUX_CONFIG_FUNC(n)					\
 	static void mcux_iuart_config_func_##n(const struct device *dev) \
 	{								\

--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -405,7 +405,7 @@ static const struct uart_driver_api mcux_lpuart_driver_api = {
 			    mcux_lpuart_isr, DEVICE_DT_INST_GET(n), 0);	\
 									\
 		irq_enable(DT_INST_IRQ_BY_IDX(n, i, irq));		\
-	} while (0)
+	} while (false)
 #define LPUART_MCUX_CONFIG_FUNC(n)					\
 	static void mcux_lpuart_config_func_##n(const struct device *dev) \
 	{								\

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1931,7 +1931,7 @@ static int uarte_nrfx_pm_control(const struct device *dev,
 		IRQ_CONNECT(DT_IRQN(UARTE(idx)), DT_IRQ(UARTE(idx), priority), \
 			    isr_handler, DEVICE_DT_GET(UARTE(idx)), 0); \
 		irq_enable(DT_IRQN(UARTE(idx)));			       \
-	} while (0)
+	} while (false)
 
 #define HWFC_CONFIG_CHECK(idx) \
 	BUILD_ASSERT( \

--- a/drivers/serial/uart_sam0.c
+++ b/drivers/serial/uart_sam0.c
@@ -1171,7 +1171,7 @@ static const struct uart_driver_api uart_sam0_driver_api = {
 			    uart_sam0_isr,				\
 			    DEVICE_DT_INST_GET(n), 0);			\
 		irq_enable(DT_INST_IRQ_BY_IDX(n, m, irq));		\
-	} while (0)
+	} while (false)
 
 #define UART_SAM0_IRQ_HANDLER_DECL(n)					\
 	static void uart_sam0_irq_config_##n(const struct device *dev)

--- a/drivers/serial/uart_xlnx_uartlite.c
+++ b/drivers/serial/uart_xlnx_uartlite.c
@@ -343,7 +343,7 @@ static const struct uart_driver_api xlnx_uartlite_driver_api = {
 			    DEVICE_DT_INST_GET(n), 0);			\
 									\
 		irq_enable(DT_INST_IRQ_BY_IDX(n, i, irq));		\
-	} while (0)
+	} while (false)
 #define XLNX_UARTLITE_CONFIG_FUNC(n)					\
 	static void xlnx_uartlite_config_func_##n(const struct device *dev) \
 	{								\

--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -253,7 +253,7 @@ static const struct spi_driver_api spi_cc13xx_cc26xx_driver_api = {
 		} else {						  \
 			Power_setDependency(PowerCC26XX_PERIPH_SSI1);	  \
 		}							  \
-	} while (0)
+	} while (false)
 #else
 #define SPI_CC13XX_CC26XX_POWER_SPI(n)					  \
 	do {								  \
@@ -286,7 +286,7 @@ static const struct spi_driver_api spi_cc13xx_cc26xx_driver_api = {
 			PRCM_DOMAIN_POWER_ON) {				  \
 			continue;					  \
 		}							  \
-	} while (0)
+	} while (false)
 #endif
 
 #define SPI_CC13XX_CC26XX_DEVICE_INIT(n)				    \

--- a/drivers/usb/device/usb_dc_sam0.c
+++ b/drivers/usb/device/usb_dc_sam0.c
@@ -207,7 +207,7 @@ static void usb_sam0_load_padcal(void)
 		    DT_INST_IRQ_BY_IDX(0, n, priority),		\
 		    usb_sam0_isr, 0, 0);			\
 	irq_enable(DT_INST_IRQ_BY_IDX(0, n, irq));		\
-	} while (0)
+	} while (false)
 
 /* Attach by initializing the device */
 int usb_dc_attach(void)

--- a/include/logging/log_backend.h
+++ b/include/logging/log_backend.h
@@ -136,7 +136,7 @@ static inline void log_backend_put_sync_string(
 {
 	__ASSERT_NO_MSG(backend != NULL);
 
-	if (backend->api->put_sync_string) {
+	if (backend->api->put_sync_string != NULL) {
 		backend->api->put_sync_string(backend, src_level,
 					      timestamp, fmt, ap);
 	}
@@ -160,7 +160,7 @@ static inline void log_backend_put_sync_hexdump(
 {
 	__ASSERT_NO_MSG(backend != NULL);
 
-	if (backend->api->put_sync_hexdump) {
+	if (backend->api->put_sync_hexdump != NULL) {
 		backend->api->put_sync_hexdump(backend, src_level, timestamp,
 					       metadata, data, len);
 	}

--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -215,7 +215,7 @@ extern "C" {
 	}; \
 	Z_LOG_INTERNAL2(is_user_context, src_level, \
 			Z_LOG_STR(_level, __VA_ARGS__)); \
-} while (0)
+} while (false)
 
 #define _LOG_INTERNAL_0(_src_level, _str) \
 	log_0(_str, _src_level)
@@ -479,7 +479,7 @@ enum log_strdup_action {
 	Z_LOG_MSG2_CREATE(!IS_ENABLED(CONFIG_USERSPACE), _mode, \
 			  CONFIG_LOG_DOMAIN_ID, NULL, \
 			  LOG_LEVEL_INTERNAL_RAW_STRING, NULL, 0, __VA_ARGS__);\
-} while (0)
+} while (false)
 
 
 /** @brief Get name of the log source.

--- a/include/logging/log_msg2.h
+++ b/include/logging/log_msg2.h
@@ -209,7 +209,7 @@ enum z_log_msg2_mode {
 		     Z_LOG_MSG_DESC_INITIALIZER(_domain_id, _level, \
 			   (uint32_t)_plen, _dlen); \
 	z_log_msg2_finalize(_msg, _source, _desc, _data); \
-} while (0)
+} while (false)
 
 #define Z_LOG_MSG2_STACK_CREATE(_domain_id, _source, _level, _data, _dlen, ...)\
 do { \
@@ -222,7 +222,7 @@ do { \
 	} \
 	struct log_msg2 *_msg; \
 	Z_LOG_MSG2_ON_STACK_ALLOC(_msg, Z_LOG_MSG2_LEN(_plen, 0)); \
-	if (_plen) { \
+	if (_plen != 0) { \
 		CBPRINTF_STATIC_PACKAGE(_msg->data, _plen, \
 					_plen, Z_LOG_MSG2_ALIGN_OFFSET, \
 					0, __VA_ARGS__);\
@@ -233,7 +233,7 @@ do { \
 	LOG_MSG2_DBG("creating message on stack: package len: %d, data len: %d\n", \
 			_plen, (int)(_dlen)); \
 	z_log_msg2_static_create((void *)_source, _desc, _msg->data, _data); \
-} while (0)
+} while (false)
 
 #if CONFIG_LOG_SPEED
 #define Z_LOG_MSG2_SIMPLE_CREATE(_domain_id, _source, _level, ...) do { \
@@ -252,7 +252,7 @@ do { \
 					0, __VA_ARGS__); \
 	} \
 	z_log_msg2_finalize(_msg, (void *)_source, _desc, NULL); \
-} while (0)
+} while (false)
 #else
 /* Alternative empty macro created to speed up compilation when LOG_SPEED is
  * disabled (default).
@@ -352,7 +352,7 @@ do {\
 				  _level, (uint8_t *)_data, _dlen,\
 				  Z_LOG_FMT_ARGS(_fmt, ##__VA_ARGS__));\
 	_mode = Z_LOG_MSG2_MODE_RUNTIME; \
-} while (0)
+} while (false)
 #elif CONFIG_LOG2_MODE_IMMEDIATE /* CONFIG_LOG2_ALWAYS_RUNTIME */
 #define Z_LOG_MSG2_CREATE2(_try_0cpy, _mode,  _cstr_cnt, _domain_id, _source,\
 			  _level, _data, _dlen, ...) \
@@ -369,7 +369,7 @@ do { \
 				_data, _dlen, Z_LOG_FMT_ARGS(_fmt, ##__VA_ARGS__)); \
 		_mode = Z_LOG_MSG2_MODE_SYNC; \
 	} \
-} while (0)
+} while (false)
 #else /* CONFIG_LOG2_ALWAYS_RUNTIME */
 #define Z_LOG_MSG2_CREATE2(_try_0cpy, _mode,  _cstr_cnt, _domain_id, _source,\
 			  _level, _data, _dlen, ...) \
@@ -393,7 +393,7 @@ do { \
 		_mode = Z_LOG_MSG2_MODE_FROM_STACK; \
 	} \
 	(void)_mode; \
-} while (0)
+} while (false)
 #endif /* CONFIG_LOG2_ALWAYS_RUNTIME */
 
 #define Z_LOG_MSG2_CREATE(_try_0cpy, _mode,  _domain_id, _source,\

--- a/include/sys/cbprintf_cxx.h
+++ b/include/sys/cbprintf_cxx.h
@@ -9,52 +9,52 @@
 #ifdef __cplusplus
 
 /* C++ version for detecting a pointer to a string. */
-static inline int z_cbprintf_cxx_is_pchar(char *)
+static inline bool z_cbprintf_cxx_is_pchar(char *)
 {
-	return 1;
+	return true;
 }
 
-static inline int z_cbprintf_cxx_is_pchar(const char *)
+static inline bool z_cbprintf_cxx_is_pchar(const char *)
 {
-	return 1;
+	return true;
 }
 
-static inline int z_cbprintf_cxx_is_pchar(volatile char *)
+static inline bool z_cbprintf_cxx_is_pchar(volatile char *)
 {
-	return 1;
+	return true;
 }
 
-static inline int z_cbprintf_cxx_is_pchar(const volatile char *)
+static inline bool z_cbprintf_cxx_is_pchar(const volatile char *)
 {
-	return 1;
+	return true;
 }
 
-static inline int z_cbprintf_cxx_is_pchar(wchar_t *)
+static inline bool z_cbprintf_cxx_is_pchar(wchar_t *)
 {
-	return 1;
+	return true;
 }
 
-static inline int z_cbprintf_cxx_is_pchar(const wchar_t *)
+static inline bool z_cbprintf_cxx_is_pchar(const wchar_t *)
 {
-	return 1;
+	return true;
 }
 
-static inline int z_cbprintf_cxx_is_pchar(volatile wchar_t *)
+static inline bool z_cbprintf_cxx_is_pchar(volatile wchar_t *)
 {
-	return 1;
+	return true;
 }
 
-static inline int z_cbprintf_cxx_is_pchar(const volatile wchar_t *)
+static inline bool z_cbprintf_cxx_is_pchar(const volatile wchar_t *)
 {
-	return 1;
+	return true;
 }
 
 template < typename T >
-static inline int z_cbprintf_cxx_is_pchar(T arg)
+static inline bool z_cbprintf_cxx_is_pchar(T arg)
 {
 	_Pragma("GCC diagnostic push")
 	_Pragma("GCC diagnostic ignored \"-Wpointer-arith\"")
-	return 0;
+	return false;
 	_Pragma("GCC diagnostic pop")
 }
 

--- a/include/sys/cbprintf_internal.h
+++ b/include/sys/cbprintf_internal.h
@@ -73,32 +73,32 @@ extern "C" {
  * to take the alignment into consideration and copy 64-bit arguments
  * as 32-bit words.
  */
-#define Z_CBPRINTF_VA_STACK_LL_DBL_MEMCPY	1
+#define Z_CBPRINTF_VA_STACK_LL_DBL_MEMCPY	true
 #else
-#define Z_CBPRINTF_VA_STACK_LL_DBL_MEMCPY	0
+#define Z_CBPRINTF_VA_STACK_LL_DBL_MEMCPY	false
 #endif
 
-/** @brief Return 1 if argument is a pointer to char or wchar_t
+/** @brief Return true if argument is a pointer to char or wchar_t
  *
  * @param x argument.
  *
- * @return 1 if char * or wchar_t *, 0 otherwise.
+ * @return true if char * or wchar_t *, false otherwise.
  */
 #ifdef __cplusplus
 #define Z_CBPRINTF_IS_PCHAR(x) z_cbprintf_cxx_is_pchar(x)
 #else
 #define Z_CBPRINTF_IS_PCHAR(x) \
 	_Generic((x) + 0, \
-		char * : 1, \
-		const char * : 1, \
-		volatile char * : 1, \
-		const volatile char * : 1, \
-		wchar_t * : 1, \
-		const wchar_t * : 1, \
-		volatile wchar_t * : 1, \
-		const volatile wchar_t * : 1, \
+		char * : true, \
+		const char * : true, \
+		volatile char * : true, \
+		const volatile char * : true, \
+		wchar_t * : true, \
+		const wchar_t * : true, \
+		volatile wchar_t * : true, \
+		const volatile wchar_t * : true, \
 		default : \
-			0)
+			false)
 #endif
 
 /** @brief Calculate number of char * or wchar_t * arguments in the arguments.
@@ -200,7 +200,7 @@ extern "C" {
 			default : \
 				(const void **)buf) = arg; \
 	} \
-} while (0)
+} while (false)
 #endif
 
 /** @brief Return alignment needed for given argument.
@@ -266,7 +266,7 @@ do { \
 			Z_CBPRINTF_IS_LONGDOUBLE(_arg) && \
 			!IS_ENABLED(CONFIG_CBPRINTF_PACKAGE_LONGDOUBLE)),\
 			"Packaging of long double not enabled in Kconfig."); \
-	while (_align_offset % Z_CBPRINTF_ALIGNMENT(_arg)) { \
+	while (_align_offset % Z_CBPRINTF_ALIGNMENT(_arg) != 0UL) { \
 		_idx += sizeof(int); \
 		_align_offset += sizeof(int); \
 	} \
@@ -279,7 +279,7 @@ do { \
 	} \
 	_idx += _arg_size; \
 	_align_offset += _arg_size; \
-} while (0)
+} while (false)
 
 /** @brief Package single argument.
  *
@@ -373,7 +373,7 @@ do { \
 	_total_len = _pkg_len; \
 	if (str_idxs) {\
 		_total_len += _s_cnt; \
-		if (_pbuf) { \
+		if (_pbuf != NULL) { \
 			for (int i = 0; i < _s_cnt; i++) { \
 				_pbuf[_pkg_len + i] = _s_buffer[i]; \
 			} \
@@ -382,7 +382,7 @@ do { \
 	/* Store length */ \
 	_outlen = (_total_len > (int)_pmax) ? -ENOSPC : _total_len; \
 	/* Store length in the header, set number of dumped strings to 0 */ \
-	if (_pbuf) { \
+	if (_pbuf != NULL) { \
 		union z_cbprintf_hdr hdr = { \
 			.desc = { \
 				.len = (uint8_t)(_pkg_len / sizeof(int)), \
@@ -393,7 +393,7 @@ do { \
 		*_len_loc = hdr; \
 	} \
 	_Pragma("GCC diagnostic pop") \
-} while (0)
+} while (false)
 
 #if Z_C_GENERIC
 #define Z_CBPRINTF_STATIC_PACKAGE(packaged, inlen, outlen, align_offset, flags, \
@@ -410,7 +410,7 @@ do { \
 	} else { \
 		outlen = cbprintf_package(NULL, align_offset, flags, __VA_ARGS__); \
 	} \
-} while (0)
+} while (false)
 #endif /* Z_C_GENERIC */
 
 #ifdef __cplusplus

--- a/include/sys/device_mmio.h
+++ b/include/sys/device_mmio.h
@@ -265,7 +265,7 @@ struct z_device_mmio_rom {
 		   DEVICE_MMIO_ROM_PTR(dev)->size, \
 		   (flags))
 #else
-#define DEVICE_MMIO_MAP(dev, flags) do { } while (0)
+#define DEVICE_MMIO_MAP(dev, flags) do { } while (false)
 #endif
 
 /**
@@ -470,7 +470,7 @@ struct z_device_mmio_rom {
 		   (DEVICE_MMIO_NAMED_ROM_PTR((dev), name)->size), \
 		   (flags))
 #else
-#define DEVICE_MMIO_NAMED_MAP(dev, name, flags) do { } while (0)
+#define DEVICE_MMIO_NAMED_MAP(dev, name, flags) do { } while (false)
 #endif
 
 /**
@@ -654,7 +654,7 @@ struct z_device_mmio_rom {
 		   Z_TOPLEVEL_ROM_NAME(name).phys_addr, \
 		   Z_TOPLEVEL_ROM_NAME(name).size, flags)
 #else
-#define DEVICE_MMIO_TOPLEVEL_MAP(name, flags) do { } while (0)
+#define DEVICE_MMIO_TOPLEVEL_MAP(name, flags) do { } while (false)
 #endif
 
 /**

--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -202,9 +202,8 @@ do {                                                                    \
 #endif
 #define ARG_UNUSED(x) (void)(x)
 
-#define likely(x)   __builtin_expect((bool)!!(x), true)
-#define unlikely(x) __builtin_expect((bool)!!(x), false)
-
+#define likely(x)   (__builtin_expect((bool)!!(x), true) != 0L)
+#define unlikely(x) (__builtin_expect((bool)!!(x), false) != 0L)
 #define popcount(x) __builtin_popcount(x)
 
 #ifndef __no_optimization

--- a/kernel/include/kswap.h
+++ b/kernel/include/kswap.h
@@ -60,7 +60,7 @@ static inline void wait_for_switch(struct k_thread *thread)
  */
 static ALWAYS_INLINE unsigned int do_swap(unsigned int key,
 					  struct k_spinlock *lock,
-					  int is_spinlock)
+					  bool is_spinlock)
 {
 	ARG_UNUSED(lock);
 	struct k_thread *new_thread, *old_thread;
@@ -159,17 +159,17 @@ static ALWAYS_INLINE unsigned int do_swap(unsigned int key,
 
 static inline int z_swap_irqlock(unsigned int key)
 {
-	return do_swap(key, NULL, 0);
+	return do_swap(key, NULL, false);
 }
 
 static inline int z_swap(struct k_spinlock *lock, k_spinlock_key_t key)
 {
-	return do_swap(key.key, lock, 1);
+	return do_swap(key.key, lock, true);
 }
 
 static inline void z_swap_unlocked(void)
 {
-	(void) do_swap(arch_irq_lock(), NULL, 1);
+	(void) do_swap(arch_irq_lock(), NULL, true);
 }
 
 #else /* !CONFIG_USE_SWITCH */

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -69,7 +69,7 @@ static bool page_frames_initialized;
 
 #define COLOR(x)	printk(_CONCAT(ANSI_, x))
 #else
-#define COLOR(x)	do { } while (0)
+#define COLOR(x)	do { } while (false)
 #endif
 
 static void page_frame_dump(struct z_page_frame *pf)

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -286,8 +286,8 @@ static ALWAYS_INLINE struct k_thread *next_up(void)
 		end_thread(_current);
 	}
 
-	int queued = z_is_thread_queued(_current);
-	int active = !z_is_thread_prevented_from_running(_current);
+	bool queued = z_is_thread_queued(_current);
+	bool active = !z_is_thread_prevented_from_running(_current);
 
 	if (thread == NULL) {
 		thread = _current_cpu->idle_thread;

--- a/kernel/smp.c
+++ b/kernel/smp.c
@@ -29,7 +29,7 @@ unsigned int z_smp_global_lock(void)
 
 void z_smp_global_unlock(unsigned int key)
 {
-	if (_current->base.global_lock_count) {
+	if (_current->base.global_lock_count != 0U) {
 		_current->base.global_lock_count--;
 
 		if (!_current->base.global_lock_count) {

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -143,7 +143,7 @@ void z_impl_k_timer_stop(struct k_timer *timer)
 {
 	SYS_PORT_TRACING_OBJ_FUNC(k_timer, stop, timer);
 
-	int inactive = z_abort_timeout(&timer->timeout) != 0;
+	bool inactive = z_abort_timeout(&timer->timeout) != 0;
 
 	if (inactive) {
 		return;

--- a/lib/libc/minimal/source/stdlib/exit.c
+++ b/lib/libc/minimal/source/stdlib/exit.c
@@ -10,6 +10,6 @@
 void _exit(int status)
 {
 	printk("exit\n");
-	while (1) {
+	while (true) {
 	}
 }

--- a/lib/libc/minimal/source/stdlib/strtol.c
+++ b/lib/libc/minimal/source/stdlib/strtol.c
@@ -119,7 +119,7 @@ long strtol(const char *nptr, char **endptr, register int base)
 	if (any < 0) {
 		acc = neg ? LONG_MIN : LONG_MAX;
 		errno = ERANGE;
-	} else if (neg) {
+	} else if (neg != 0) {
 		acc = -acc;
 	}
 

--- a/lib/libc/minimal/source/stdlib/strtoul.c
+++ b/lib/libc/minimal/source/stdlib/strtoul.c
@@ -99,7 +99,7 @@ unsigned long strtoul(const char *nptr, char **endptr, register int base)
 	if (any < 0) {
 		acc = ULONG_MAX;
 		errno = ERANGE;
-	} else if (neg) {
+	} else if (neg != 0) {
 		acc = -acc;
 	}
 	if (endptr != NULL) {

--- a/lib/libc/minimal/source/string/string.c
+++ b/lib/libc/minimal/source/string/string.c
@@ -92,7 +92,7 @@ char *strrchr(const char *s, int c)
 		if (*s == (char)c) {
 			match = (char *)s;
 		}
-	} while (*s++);
+	} while (*s++ != '\0');
 
 	return match;
 }

--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -979,7 +979,7 @@ static char *encode_float(double value,
 			/* Round only if the bit that would round is
 			 * set.
 			 */
-			if (fract & mask) {
+			if ((fract & mask) != 0ULL) {
 				fract += mask;
 			}
 		}
@@ -1160,7 +1160,7 @@ static char *encode_float(double value,
 
 	/* Round the value to the last digit being printed. */
 	uint64_t round = BIT64(59); /* 0.5 */
-	while (decimals--) {
+	while (decimals-- != 0) {
 		_ldiv10(&round);
 	}
 	fract += round;
@@ -1803,7 +1803,7 @@ int cbvprintf(cbprintf_cb out, void *ctx, const char *fp, va_list ap)
 
 			OUTS(cp, bpe);
 		} else {
-			if (conv->altform_0c | conv->altform_0) {
+			if ((conv->altform_0c | conv->altform_0) != 0) {
 				OUTC('0');
 			}
 

--- a/lib/os/crc7_sw.c
+++ b/lib/os/crc7_sw.c
@@ -8,7 +8,7 @@
 
 uint8_t crc7_be(uint8_t seed, const uint8_t *src, size_t len)
 {
-	while (len--) {
+	while (len-- != 0UL) {
 		uint8_t e = seed ^ *src++;
 		uint8_t f = e ^ (e >> 4) ^ (e >> 7);
 

--- a/lib/os/crc8_sw.c
+++ b/lib/os/crc8_sw.c
@@ -37,13 +37,13 @@ uint8_t crc8(const uint8_t *src, size_t len, uint8_t polynomial, uint8_t initial
 
 		for (j = 0; j < 8; j++) {
 			if (reversed) {
-				if (crc & 0x01) {
+				if ((crc & 0x01) != 0) {
 					crc = (crc >> 1) ^ polynomial;
 				} else {
 					crc >>= 1;
 				}
 			} else {
-				if (crc & 0x80) {
+				if ((crc & 0x80) != 0) {
 					crc = (crc << 1) ^ polynomial;
 				} else {
 					crc <<= 1;

--- a/lib/os/dec.c
+++ b/lib/os/dec.c
@@ -25,7 +25,7 @@ uint8_t u8_to_dec(char *buf, uint8_t buflen, uint8_t value)
 		divisor /= 10;
 	}
 
-	if (buflen) {
+	if (buflen != 0U) {
 		*buf = '\0';
 	}
 

--- a/lib/os/fdtable.c
+++ b/lib/os/fdtable.c
@@ -151,7 +151,7 @@ void *z_get_fd_obj_and_vtable(int fd, const struct fd_op_vtable **vtable,
 	entry = &fdtable[fd];
 	*vtable = entry->vtable;
 
-	if (lock) {
+	if (lock != NULL) {
 		*lock = &entry->lock;
 	}
 

--- a/lib/os/heap-validate.c
+++ b/lib/os/heap-validate.c
@@ -17,7 +17,7 @@
  * running one and corrupting it. YMMV.
  */
 
-#define VALIDATE(cond) do { if (!(cond)) { return false; } } while (0)
+#define VALIDATE(cond) do { if (!(cond)) { return false; } } while (false)
 
 static bool in_bounds(struct z_heap *h, chunkid_t c)
 {
@@ -328,7 +328,7 @@ void heap_print_info(struct z_heap *h, bool dump_chunks)
 		chunksz_t largest = 0;
 		int count = 0;
 
-		if (first) {
+		if (first != 0U) {
 			chunkid_t curr = first;
 			do {
 				count++;
@@ -336,7 +336,7 @@ void heap_print_info(struct z_heap *h, bool dump_chunks)
 				curr = next_free_chunk(h, curr);
 			} while (curr != first);
 		}
-		if (count) {
+		if (count != 0) {
 			printk("%9d %12d %12d %12d %12zd\n",
 			       i, (1 << i) - 1 + min_chunk_size(h), count,
 			       largest, chunksz_to_bytes(h, largest));

--- a/lib/os/heap.c
+++ b/lib/os/heap.c
@@ -188,7 +188,7 @@ static chunkid_t alloc_chunk(struct z_heap *h, chunksz_t sz)
 	 * fragmentation waste of the order of the block allocated
 	 * only.
 	 */
-	if (b->next) {
+	if (b->next != 0U) {
 		chunkid_t first = b->next;
 		int i = CONFIG_SYS_HEAP_ALLOC_LOOPS;
 		do {

--- a/lib/os/hex.c
+++ b/lib/os/hex.c
@@ -65,7 +65,7 @@ size_t hex2bin(const char *hex, size_t hexlen, uint8_t *buf, size_t buflen)
 	}
 
 	/* if hexlen is uneven, insert leading zero nibble */
-	if (hexlen % 2) {
+	if ((hexlen % 2) != 0UL) {
 		if (char2hex(hex[0], &dec) < 0) {
 			return 0;
 		}

--- a/lib/os/mpsc_pbuf.c
+++ b/lib/os/mpsc_pbuf.c
@@ -14,7 +14,7 @@
 			mpsc_state_print(buffer); \
 		} \
 	} \
-} while (0)
+} while (false)
 
 static inline void mpsc_state_print(struct mpsc_pbuf_buffer *buffer)
 {

--- a/lib/os/onoff.c
+++ b/lib/os/onoff.c
@@ -173,7 +173,7 @@ static void notify_one(struct onoff_manager *mgr,
 	onoff_client_callback cb =
 		(onoff_client_callback)sys_notify_finalize(&cli->notify, res);
 
-	if (cb) {
+	if (cb != NULL) {
 		cb(mgr, cli, state, res);
 	}
 }
@@ -644,7 +644,7 @@ int onoff_sync_finalize(struct onoff_sync_service *srv,
 
 	k_spin_unlock(&srv->lock, key);
 
-	if (cli) {
+	if (cli != NULL) {
 		/* Detect service mis-use: onoff does not callback on transition
 		 * to off, so no client should have been passed.
 		 */

--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -126,7 +126,7 @@ void vprintk(const char *fmt, va_list ap)
 
 		cbvprintf(buf_char_out, &ctx, fmt, ap);
 
-		if (ctx.buf_count) {
+		if (ctx.buf_count != 0U) {
 			buf_flush(&ctx);
 		}
 	} else {

--- a/samples/bluetooth/ipsp/src/main.c
+++ b/samples/bluetooth/ipsp/src/main.c
@@ -80,7 +80,7 @@ static inline void init_app(void)
 
 		ifaddr = net_if_ipv6_addr_add(net_if_get_default(),
 					      &in6addr_my, NET_ADDR_MANUAL, 0);
-	} while (0);
+	} while (false);
 }
 
 static inline bool get_context(struct net_context **udp_recv6,

--- a/samples/drivers/lcd_hd44780/src/main.c
+++ b/samples/drivers/lcd_hd44780/src/main.c
@@ -143,7 +143,7 @@
 		if (gpio_pin_set_raw((dev), (pin), (bit))) {			\
 			printk("Err set " GPIO_NAME "%d! %x\n", (pin), (bit));	\
 		}								\
-	} while (0)								\
+	} while (false)								\
 
 
 #define GPIO_PIN_CFG(dev, pin, dir)						\
@@ -151,7 +151,7 @@
 		if (gpio_pin_configure((dev), (pin), (dir))) {			\
 			printk("Err cfg " GPIO_NAME "%d! %x\n", (pin), (dir));	\
 		}								\
-	} while (0)
+	} while (false)
 
 
 struct pi_lcd_data {

--- a/samples/net/sockets/tcp/src/main.c
+++ b/samples/net/sockets/tcp/src/main.c
@@ -21,7 +21,7 @@
 do {									\
 	printf("Error: " fmt "(): %s\n" ## args, strerror(errno));	\
 	exit(errno);							\
-} while (0)								\
+} while (false)								\
 
 /*
  * This application is used together with the TTCN-3 based sanity check

--- a/samples/posix/eventfd/src/main.c
+++ b/samples/posix/eventfd/src/main.c
@@ -13,7 +13,7 @@
 #include <stdint.h>
 
 #define fatal(msg) \
-	do { perror(msg); exit(EXIT_FAILURE); } while (0)
+	do { perror(msg); exit(EXIT_FAILURE); } while (false)
 
 /* As Zephyr doesn't provide command-line args, emulate them. */
 char *input_argv[] = {"argv0", "1", "2", "3", "4"};

--- a/samples/subsys/fs/fat_fs/src/main.c
+++ b/samples/subsys/fs/fat_fs/src/main.c
@@ -60,7 +60,7 @@ void main(void)
 
 		memory_size_mb = (uint64_t)block_count * block_size;
 		printk("Memory Size(MB) %u\n", (uint32_t)(memory_size_mb >> 20));
-	} while (0);
+	} while (false);
 
 	mp.mnt_point = disk_mount_pt;
 

--- a/samples/subsys/shell/shell_module/src/qsort.c
+++ b/samples/subsys/shell/shell_module/src/qsort.c
@@ -34,6 +34,7 @@ static const char sccsid[] = "@(#)qsort.c	8.1 (Berkeley) 6/4/93";
 #endif /* LIBC_SCCS and not lint */
 #include <sys/cdefs.h>
 #include <stdlib.h>
+#include <stdbool.h>
 
 #ifdef I_AM_QSORT_R
 typedef int		 cmp_t(void *, const void *, const void *);
@@ -65,7 +66,7 @@ swapfunc(char *a, char *b, size_t es)
 		if ((n) > 0) {			\
 			swapfunc(a, b, n);	\
 		}				\
-	} while (0)
+	} while (false)
 
 #ifdef I_AM_QSORT_R
 #define	CMP(t, x, y) (cmp((t), (x), (y)))

--- a/soc/arm/cypress/common/cypress_psoc6_dt.h
+++ b/soc/arm/cypress/common/cypress_psoc6_dt.h
@@ -100,7 +100,7 @@
 			    isr, DEVICE_DT_INST_GET(n), 0);\
 		CY_PSOC6_NVIC_MUX_MAP(n);		\
 		irq_enable(CY_PSOC6_NVIC_MUX_IRQN(n));	\
-	} while (0)
+	} while (false)
 
 /*
  * Devicetree related macros to construct pin control config data

--- a/soc/arm/nuvoton_npcx/common/soc_dt.h
+++ b/soc/arm/nuvoton_npcx/common/soc_dt.h
@@ -414,7 +414,7 @@
 			DT_PROP(child, group_mask),                            \
 			0);						       \
 		irq_enable(DT_PROP(child, irq));                               \
-	} while (0)
+	} while (false)
 
 /**
  * @brief Get a child node from path '/npcx-espi-vws-map/name'.

--- a/subsys/bluetooth/common/log.h
+++ b/subsys/bluetooth/common/log.h
@@ -63,7 +63,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME, LOG_LEVEL);
 			BT_ASSERT_PRINT(cond);   \
 			BT_ASSERT_DIE();         \
 		}                                \
-	} while (0)
+	} while (false)
 
 #define BT_ASSERT_MSG(cond, fmt, ...)                              \
 	do {                                                       \
@@ -72,7 +72,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME, LOG_LEVEL);
 			BT_ASSERT_PRINT_MSG(fmt, ##__VA_ARGS__);   \
 			BT_ASSERT_DIE();                           \
 		}                                                  \
-	} while (0)
+	} while (false)
 #else
 #define BT_ASSERT(cond) __ASSERT_NO_MSG(cond)
 #define BT_ASSERT_MSG(cond, msg, ...) __ASSERT(cond, msg, ##__VA_ARGS__)

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/debug.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/debug.h
@@ -63,7 +63,7 @@
 		DEBUG_PORT->PIN_CNF[DEBUG_PIN_IDX9] = \
 			(GPIO_PIN_CNF_MCUSEL_NetworkMCU << \
 			 GPIO_PIN_CNF_MCUSEL_Pos); \
-	} while (0)
+	} while (false)
 #endif /* CONFIG_BOARD_NRF5340DK_NRF5340_CPUAPP */
 #elif defined(CONFIG_BOARD_NRF52840DK_NRF52840)
 #define DEBUG_PORT       NRF_P1
@@ -120,7 +120,7 @@
 	do { \
 		DEBUG_PORT->DIRSET = DEBUG_PIN_MASK; \
 		DEBUG_PORT->OUTCLR = DEBUG_PIN_MASK; \
-	} while (0)
+	} while (false)
 
 #define DEBUG_CPU_SLEEP(flag) \
 	do { \
@@ -131,7 +131,7 @@
 			DEBUG_PORT->OUTCLR = DEBUG_PIN0; \
 			DEBUG_PORT->OUTSET = DEBUG_PIN0; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_TICKER_ISR(flag) \
 	do { \
@@ -142,7 +142,7 @@
 			DEBUG_PORT->OUTSET = DEBUG_PIN1; \
 			DEBUG_PORT->OUTCLR = DEBUG_PIN1; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_TICKER_TASK(flag) \
 	do { \
@@ -153,7 +153,7 @@
 			DEBUG_PORT->OUTSET = DEBUG_PIN1; \
 			DEBUG_PORT->OUTCLR = DEBUG_PIN1; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_TICKER_JOB(flag) \
 	do { \
@@ -164,7 +164,7 @@
 			DEBUG_PORT->OUTSET = DEBUG_PIN2; \
 			DEBUG_PORT->OUTCLR = DEBUG_PIN2; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_ISR(flag) \
 	do { \
@@ -175,7 +175,7 @@
 			DEBUG_PORT->OUTSET = DEBUG_PIN7; \
 			DEBUG_PORT->OUTCLR = DEBUG_PIN7; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_XTAL(flag) \
 	do { \
@@ -186,7 +186,7 @@
 			DEBUG_PORT->OUTSET = DEBUG_PIN8; \
 			DEBUG_PORT->OUTCLR = DEBUG_PIN8; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_ACTIVE(flag) \
 	do { \
@@ -197,7 +197,7 @@
 			DEBUG_PORT->OUTSET = DEBUG_PIN9; \
 			DEBUG_PORT->OUTCLR = DEBUG_PIN9; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_CLOSE(flag) \
 	do { \
@@ -207,7 +207,7 @@
 		} else { \
 			DEBUG_PORT->OUTCLR = DEBUG_CLOSE_MASK; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_PREPARE_A(flag) \
 	do { \
@@ -218,7 +218,7 @@
 			DEBUG_PORT->OUTCLR = DEBUG_PIN3; \
 			DEBUG_PORT->OUTSET = DEBUG_PIN3; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_START_A(flag) \
 	do { \
@@ -229,7 +229,7 @@
 			DEBUG_PORT->OUTCLR = DEBUG_PIN3; \
 			DEBUG_PORT->OUTSET = DEBUG_PIN3; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_CLOSE_A(flag) \
 	do { \
@@ -239,7 +239,7 @@
 		} else { \
 			DEBUG_PORT->OUTCLR = DEBUG_PIN3; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_PREPARE_S(flag) \
 	do { \
@@ -250,7 +250,7 @@
 			DEBUG_PORT->OUTCLR = DEBUG_PIN4; \
 			DEBUG_PORT->OUTSET = DEBUG_PIN4; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_START_S(flag) \
 	do { \
@@ -261,7 +261,7 @@
 			DEBUG_PORT->OUTCLR = DEBUG_PIN4; \
 			DEBUG_PORT->OUTSET = DEBUG_PIN4; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_CLOSE_S(flag) \
 	do { \
@@ -271,7 +271,7 @@
 		} else { \
 			DEBUG_PORT->OUTCLR = DEBUG_PIN4; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_PREPARE_O(flag) \
 	do { \
@@ -282,7 +282,7 @@
 			DEBUG_PORT->OUTCLR = DEBUG_PIN5; \
 			DEBUG_PORT->OUTSET = DEBUG_PIN5; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_START_O(flag) \
 	do { \
@@ -293,7 +293,7 @@
 			DEBUG_PORT->OUTCLR = DEBUG_PIN5; \
 			DEBUG_PORT->OUTSET = DEBUG_PIN5; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_CLOSE_O(flag) \
 	do { \
@@ -303,7 +303,7 @@
 		} else { \
 			DEBUG_PORT->OUTCLR = DEBUG_PIN5; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_PREPARE_M(flag) \
 	do { \
@@ -314,7 +314,7 @@
 			DEBUG_PORT->OUTCLR = DEBUG_PIN6; \
 			DEBUG_PORT->OUTSET = DEBUG_PIN6; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_START_M(flag) \
 	do { \
@@ -325,7 +325,7 @@
 			DEBUG_PORT->OUTCLR = DEBUG_PIN6; \
 			DEBUG_PORT->OUTSET = DEBUG_PIN6; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_CLOSE_M(flag) \
 	do { \
@@ -335,7 +335,7 @@
 		} else { \
 			DEBUG_PORT->OUTCLR = DEBUG_PIN6; \
 		} \
-	} while (0)
+	} while (false)
 
 #else
 #define DEBUG_INIT()

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -73,7 +73,7 @@ static uint8_t force_md_cnt;
 			if (force_md_cnt) { \
 				force_md_cnt--; \
 			} \
-		} while (0)
+		} while (false)
 
 #define FORCE_MD_CNT_GET() force_md_cnt
 
@@ -83,7 +83,7 @@ static uint8_t force_md_cnt;
 			    (trx_cnt >= ((CONFIG_BT_BUF_ACL_TX_COUNT) - 1))) { \
 				force_md_cnt = BT_CTLR_FORCE_MD_COUNT; \
 			} \
-		} while (0)
+		} while (false)
 
 #else /* !CONFIG_BT_CTLR_FORCE_MD_COUNT */
 #define FORCE_MD_CNT_INIT()

--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/debug.h
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/debug.h
@@ -87,7 +87,7 @@ extern const struct device *vega_debug_portd;
 		\
 		gpio_pin_set(DEBUG0_PORT, DEBUG0_PIN, 1); \
 		gpio_pin_set(DEBUG0_PORT, DEBUG0_PIN, 0); \
-	} while (0)
+	} while (false)
 
 #define DEBUG_CPU_SLEEP(flag) gpio_pin_set(DEBUG0_PORT, DEBUG0_PIN, flag)
 
@@ -111,7 +111,7 @@ extern const struct device *vega_debug_portd;
 			gpio_pin_set(DEBUG5_PORT, DEBUG5_PIN, flag); \
 			gpio_pin_set(DEBUG6_PORT, DEBUG6_PIN, flag); \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_PREPARE_A(flag) \
 		gpio_pin_set(DEBUG3_PORT, DEBUG3_PIN, flag)

--- a/subsys/mgmt/osdp/src/osdp_common.h
+++ b/subsys/mgmt/osdp/src/osdp_common.h
@@ -35,7 +35,7 @@
 	do {                                                    \
 		TO_CP(p)->current_pd = TO_PD(p, i);             \
 		TO_CP(p)->pd_offset = i;                        \
-	} while (0)
+	} while (false)
 #define PD_MASK(ctx) \
 	(uint32_t)((1 << (TO_CP(ctx)->num_pd)) - 1)
 #define AES_PAD_LEN(x)                 ((x + 16 - 1) & (~(16 - 1)))

--- a/subsys/net/ip/ipv6_mld.c
+++ b/subsys/net/ip/ipv6_mld.c
@@ -291,7 +291,7 @@ drop:
 		NET_DBG("%s %s from %s to %s", action, pkt_str,         \
 			log_strdup(net_sprint_ipv6_addr(src)),		\
 			log_strdup(net_sprint_ipv6_addr(dst)));		\
-	} while (0)
+	} while (false)
 
 #define dbg_addr_recv(pkt_str, src, dst)	\
 	dbg_addr("Received", pkt_str, src, dst)

--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -474,7 +474,7 @@ static void dbg_update_neighbor_lladdr_raw(uint8_t *new_lladdr,
 			log_strdup(net_sprint_ipv6_addr(dst)),		\
 			net_pkt_iface(pkt),				\
 			net_if_get_by_iface(net_pkt_iface(pkt)));	\
-	} while (0)
+	} while (false)
 
 #define dbg_addr_recv(pkt_str, src, dst, pkt)	\
 	dbg_addr("Received", pkt_str, src, dst, pkt)
@@ -492,7 +492,7 @@ static void dbg_update_neighbor_lladdr_raw(uint8_t *new_lladdr,
 			log_strdup(net_sprint_ipv6_addr(target)),	\
 			net_pkt_iface(pkt),				\
 			net_if_get_by_iface(net_pkt_iface(pkt)));	\
-	} while (0)
+	} while (false)
 
 #define dbg_addr_recv_tgt(pkt_str, src, dst, tgt, pkt)		\
 	dbg_addr_with_tgt("Received", pkt_str, src, dst, tgt, pkt)

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -121,7 +121,7 @@ static sys_slist_t timestamp_callbacks;
 			net_if_get_by_iface(net_pkt_iface(pkt)));	\
 									\
 		NET_ASSERT(pkt->frags);					\
-	} while (0)
+	} while (false)
 #else
 #define debug_check_packet(...)
 #endif /* CONFIG_NET_IF_LOG_LEVEL >= LOG_LEVEL_DBG */

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -260,7 +260,7 @@ void net_pkt_allocs_foreach(net_pkt_allocs_cb_t cb, void *user_data)
 			NET_ERR("**ERROR** frag %p not in use (%s:%s():%d)", \
 				frag, __FILE__, __func__, __LINE__);     \
 		}                                                       \
-	} while (0)
+	} while (false)
 
 const char *net_pkt_slab2str(struct k_mem_slab *slab)
 {

--- a/subsys/net/ip/route.c
+++ b/subsys/net/ip/route.c
@@ -248,7 +248,7 @@ static int nbr_nexthop_put(struct net_nbr *nbr)
 			log_strdup(net_sprint_ipv6_addr(dst)),		\
 			log_strdup(net_sprint_ipv6_addr(naddr)),	\
 			route->iface);					\
-	} } while (0)
+	} } while (false)
 
 /* Route was accessed, so place it in front of the routes list */
 static inline void update_route_access(struct net_route_entry *route)

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -550,7 +550,7 @@ static void tcp_send_timer_cancel(struct tcp *conn)
 static const char *tcp_state_to_str(enum tcp_state state, bool prefix)
 {
 	const char *s = NULL;
-#define _(_x) case _x: do { s = #_x; goto out; } while (0)
+#define _(_x) case _x: do { s = #_x; goto out; } while (false)
 	switch (state) {
 	_(TCP_LISTEN);
 	_(TCP_SYN_SENT);

--- a/subsys/net/ip/tp.c
+++ b/subsys/net/ip/tp.c
@@ -334,7 +334,7 @@ enum tp_type tp_msg_to_type(const char *s)
 		type = _type;		\
 		goto out;		\
 	}				\
-} while (0)
+} while (false)
 
 	is_tp(s, TP_COMMAND);
 	is_tp(s, TP_CONFIG_REQUEST);

--- a/subsys/net/ip/tp_priv.h
+++ b/subsys/net/ip/tp_priv.h
@@ -20,7 +20,7 @@ extern "C" {
 #define tp_err(fmt, args...) do {				\
 	printk("%s: Error: " fmt "\n", __func__, ## args);	\
 	k_oops();						\
-} while (0)
+} while (false)
 
 #define tp_assert(cond, fmt, args...) do {			\
 	if ((cond) == false) {					\
@@ -28,7 +28,7 @@ extern "C" {
 			__func__, #cond, ## args);		\
 		k_oops();					\
 	}							\
-} while (0)
+} while (false)
 
 #define is(_a, _b) (strcmp((_a), (_b)) == 0)
 #define ip_get(_x) ((struct net_ipv4_hdr *) net_pkt_ip_data((_x)))

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -624,7 +624,7 @@ static int init_listener(void)
 		} else {
 			ok++;
 		}
-	} while (0);
+	} while (false);
 ipv6_out:
 #endif /* CONFIG_NET_IPV6 */
 
@@ -650,7 +650,7 @@ ipv6_out:
 		} else {
 			ok++;
 		}
-	} while (0);
+	} while (false);
 ipv4_out:
 #endif /* CONFIG_NET_IPV4 */
 

--- a/subsys/net/lib/http/http_parser.c
+++ b/subsys/net/lib/http/http_parser.c
@@ -72,7 +72,7 @@ do {                                                                       \
 	if (!FOR##_mark) {                                                 \
 		FOR##_mark = p;                                            \
 	}                                                                  \
-} while (0)
+} while (false)
 
 /* Don't allow the total size of the HTTP headers (including the status
  * line) to exceed HTTP_MAX_HEADER_SIZE.  This check is here to protect

--- a/subsys/net/lib/http/http_parser_url.c
+++ b/subsys/net/lib/http/http_parser_url.c
@@ -44,7 +44,7 @@ do {                                                                       \
 	if (!FOR##_mark) {                                                 \
 		FOR##_mark = p;                                            \
 	}                                                                  \
-} while (0)
+} while (false)
 
 
 #ifdef HTTP_PARSER_STRICT

--- a/subsys/net/lib/mqtt/mqtt_internal.h
+++ b/subsys/net/lib/mqtt/mqtt_internal.h
@@ -115,14 +115,14 @@ extern "C" {
 		if ((param) == NULL) { \
 			return -EINVAL; \
 		} \
-	} while (0)
+	} while (false)
 
 #define NULL_PARAM_CHECK_VOID(param) \
 	do { \
 		if ((param) == NULL) { \
 			return; \
 		} \
-	} while (0)
+	} while (false)
 
 /** Buffer context to iterate over buffer. */
 struct buf_ctx {

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -52,7 +52,7 @@ LOG_MODULE_REGISTER(net_sock, CONFIG_NET_SOCKETS_LOG_LEVEL);
 		k_mutex_unlock(lock);                        \
 							     \
 		return ret;				     \
-	} while (0)
+	} while (false)
 
 const struct socket_op_vtable sock_fd_op_vtable;
 

--- a/subsys/shell/shell_ops.h
+++ b/subsys/shell/shell_ops.h
@@ -33,7 +33,7 @@ static inline void z_shell_raw_fprintf(const struct shell_fprintf *const ctx,
 									\
 		static const char cmd[] = _cmd_;			\
 		z_shell_raw_fprintf(_shell_->fprintf_ctx, "%s", cmd);	\
-	} while (0)
+	} while (false)
 
 /* Function sends VT100 command to clear the screen from cursor position to
  * end of the screen.
@@ -77,7 +77,7 @@ static inline void z_cursor_next_line_move(const struct shell *shell)
 						   ~_internal_.value);		\
 		}								\
 		_ret_ = (_internal_.flags._flag_ != 0);				\
-	} while (0)
+	} while (false)
 
 static inline bool z_flag_insert_mode_get(const struct shell *shell)
 {

--- a/subsys/testsuite/include/tc_util.h
+++ b/subsys/testsuite/include/tc_util.h
@@ -49,7 +49,7 @@
 #ifdef TC_RUNID
 #define TC_PRINT_RUNID PRINT_DATA("RunID: " TC_STR(TC_RUNID) "\n")
 #else
-#define TC_PRINT_RUNID do {} while (0)
+#define TC_PRINT_RUNID do {} while (false)
 #endif
 
 #ifndef PRINT_LINE
@@ -118,7 +118,7 @@ static inline void test_time_ms(void)
 	do {                                                 \
 		PRINT_DATA(FMT_ERROR, "FAIL", __func__, __LINE__); \
 		PRINT_DATA(fmt, ##__VA_ARGS__);                  \
-	} while (0)
+	} while (false)
 #endif
 
 #ifndef TC_PRINT
@@ -130,7 +130,7 @@ static inline void test_time_ms(void)
 	do {								\
 		PRINT_DATA("START - %s\n", name);			\
 		get_start_time_cyc();					\
-	} while (0)
+	} while (false)
 #endif
 
 #ifndef TC_END
@@ -146,7 +146,7 @@ static inline void test_time_ms(void)
 			TC_RESULT_TO_STR(result), func, tc_spend_time/1000,	\
 			tc_spend_time%1000);					\
 		PRINT_LINE;							\
-	} while (0)
+	} while (false)
 #endif
 
 #ifndef TC_END_RESULT
@@ -159,7 +159,7 @@ static inline void test_time_ms(void)
 	do {							\
 		TC_PRINT("Running test suite %s\n", name);	\
 		PRINT_LINE;					\
-	} while (0)
+	} while (false)
 #endif
 
 #ifndef TC_SUITE_END
@@ -170,7 +170,7 @@ static inline void test_time_ms(void)
 		} else {						\
 			TC_PRINT("Test suite %s failed.\n", name);	\
 		}							\
-	} while (0)
+	} while (false)
 #endif
 
 #if defined(CONFIG_ARCH_POSIX)
@@ -188,7 +188,7 @@ static inline void test_time_ms(void)
 		       "PROJECT EXECUTION %s\n",               \
 		       (result) == TC_PASS ? "SUCCESSFUL" : "FAILED");	\
 		TC_END_POST(result);                                    \
-	} while (0)
+	} while (false)
 #endif
 
 #if defined(CONFIG_SHELL)

--- a/subsys/testsuite/ztest/include/ztest_assert.h
+++ b/subsys/testsuite/ztest/include/ztest_assert.h
@@ -107,7 +107,7 @@ static inline bool z_zassert(bool cond,
 			    (COND_CODE_1(CONFIG_MULTITHREADING, (), (return;))), \
 			    ()) \
 	} \
-} while (0)
+} while (false)
 
 /**
  * @brief Assert that this function call won't be reached

--- a/subsys/tracing/sysview/tracing_sysview.h
+++ b/subsys/tracing/sysview/tracing_sysview.h
@@ -173,7 +173,7 @@ void sys_trace_thread_info(struct k_thread *thread);
 	do {                                                                                       \
 		SEGGER_SYSVIEW_OnTaskCreate((uint32_t)(uintptr_t)new_thread);                      \
 		sys_trace_thread_info(new_thread);                                                 \
-	} while (0)
+	} while (false)
 
 #define sys_port_trace_k_thread_user_mode_enter()                                                  \
 	SEGGER_SYSVIEW_RecordVoid(TID_THREAD_USERMODE_ENTER)
@@ -237,7 +237,7 @@ void sys_trace_thread_info(struct k_thread *thread);
 #define sys_port_trace_k_thread_name_set(thread, ret) do { \
 		SEGGER_SYSVIEW_RecordU32(TID_THREAD_NAME_SET, (uint32_t)(uintptr_t)thread); \
 		sys_trace_thread_info(thread);	\
-	} while (0)
+	} while (false)
 
 #define sys_port_trace_k_thread_switched_out() sys_trace_k_thread_switched_out()
 

--- a/tests/benchmarks/app_kernel/src/pipe_b.c
+++ b/tests/benchmarks/app_kernel/src/pipe_b.c
@@ -29,7 +29,7 @@
 	PRINT_STRING("|   size(B) |       time/packet (usec)       |        "\
 		  "  MB/sec                |\n", output_file);            \
 	PRINT_STRING(dashline, output_file);\
-	} while (0)
+	} while (false)
 
 #define  PRINT_1_TO_N()                                               \
 	PRINT_F(output_file,						\
@@ -62,7 +62,7 @@
 	PRINT_STRING("|   size(B) |       time/packet (nsec)       |        "\
 		  "  KB/sec                |\n", output_file);            \
 	PRINT_STRING(dashline, output_file); \
-	} while (0)
+	} while (false)
 
 #define  PRINT_1_TO_N()                                              \
 	PRINT_F(output_file,                                            \

--- a/tests/benchmarks/footprints/src/system_thread.c
+++ b/tests/benchmarks/footprints/src/system_thread.c
@@ -52,7 +52,7 @@ void thread_yield0(void *p1, void *p2, void *p3)
 void thread_yield1(void *p1, void *p2, void *p3)
 {
 	k_sem_give(&yield_sem);
-	while (1) {
+	while (true) {
 		k_yield();
 	}
 }

--- a/tests/benchmarks/mbedtls/src/benchmark.c
+++ b/tests/benchmarks/mbedtls/src/benchmark.c
@@ -188,7 +188,7 @@ do {                                                                  \
 	mbedtls_printf("%9lu KiB/s,  %9lu ns/byte\n",                 \
 		       ii * BUFSIZE / 1024,                           \
 		       (unsigned long)(delta / (jj * BUFSIZE)));      \
-} while (0)
+} while (false)
 
 #if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C) && defined(MBEDTLS_MEMORY_DEBUG)
 
@@ -240,7 +240,7 @@ do {                                                                  \
 	}                                                             \
 								      \
 	(void)k_work_cancel_delayable_sync(&mbedtls_alarm, &work_sync);\
-} while (0)
+} while (false)
 
 static int myrand(void *rng_state, unsigned char *output, size_t len)
 {

--- a/tests/bluetooth/bsim_bt/bsim_test_advx/src/main.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_advx/src/main.c
@@ -53,13 +53,13 @@
 	do {						\
 		bst_result = Failed;			\
 		bs_trace_error_time_line(__VA_ARGS__);	\
-	} while (0)
+	} while (false)
 
 #define PASS(...)					\
 	do {						\
 		bst_result = Passed;			\
 		bs_trace_info_time(1, __VA_ARGS__);	\
-	} while (0)
+	} while (false)
 
 extern enum bst_result_t bst_result;
 

--- a/tests/bluetooth/bsim_bt/bsim_test_app/src/test_connect1.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_app/src/test_connect1.c
@@ -64,13 +64,13 @@ extern enum bst_result_t bst_result;
 	do {						\
 		bst_result = Failed;			\
 		bs_trace_error_time_line(__VA_ARGS__);	\
-	} while (0)
+	} while (false)
 
 #define PASS(...)					\
 	do {						\
 		bst_result = Passed;			\
 		bs_trace_info_time(1, __VA_ARGS__);	\
-	} while (0)
+	} while (false)
 
 static void test_con1_init(void)
 {

--- a/tests/bluetooth/bsim_bt/bsim_test_app/src/test_connect2.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_app/src/test_connect2.c
@@ -43,13 +43,13 @@ extern enum bst_result_t bst_result;
 	do {						\
 		bst_result = Failed;			\
 		bs_trace_error_time_line(__VA_ARGS__);	\
-	} while (0)
+	} while (false)
 
 #define PASS(...)					\
 	do {						\
 		bst_result = Passed;			\
 		bs_trace_info_time(1, __VA_ARGS__);	\
-	} while (0)
+	} while (false)
 
 static void test_con2_init(void)
 {

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/common.h
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/common.h
@@ -44,13 +44,13 @@
 	do { \
 		bst_result = Failed; \
 		bs_trace_error_time_line(__VA_ARGS__); \
-	} while (0)
+	} while (false)
 
 #define PASS(...) \
 	do { \
 		bst_result = Passed; \
 		bs_trace_info_time(1, __VA_ARGS__); \
-	} while (0)
+	} while (false)
 
 #define AD_SIZE 1
 extern const struct bt_data ad[AD_SIZE];

--- a/tests/bluetooth/bsim_bt/bsim_test_iso/src/main.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_iso/src/main.c
@@ -25,13 +25,13 @@
 	do {						\
 		bst_result = Failed;			\
 		bs_trace_error_time_line(__VA_ARGS__);	\
-	} while (0)
+	} while (false)
 
 #define PASS(...)					\
 	do {						\
 		bst_result = Passed;			\
 		bs_trace_info_time(1, __VA_ARGS__);	\
-	} while (0)
+	} while (false)
 
 extern enum bst_result_t bst_result;
 

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/mesh_test.h
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/mesh_test.h
@@ -36,13 +36,13 @@
 	do {                                                                   \
 		bst_result = Failed;                                           \
 		bs_trace_error_time_line(msg "\n", ##__VA_ARGS__);             \
-	} while (0)
+	} while (false)
 
 #define PASS()                                                                 \
 	do {                                                                   \
 		bst_result = Passed;                                           \
 		bs_trace_info_time(1, "%s PASSED\n", __func__);                \
-	} while (0)
+	} while (false)
 
 #define ASSERT_OK(cond, ...)                                                   \
 	do {                                                                   \
@@ -52,7 +52,7 @@
 			bs_trace_error_time_line(                              \
 				#cond " failed with error %d\n", _err);        \
 		}                                                              \
-	} while (0)
+	} while (false)
 
 #define ASSERT_TRUE(cond, ...)                                                 \
 	do {                                                                   \
@@ -61,7 +61,7 @@
 			bs_trace_error_time_line(                              \
 				#cond " is false.", ##__VA_ARGS__);             \
 		}                                                              \
-	} while (0)
+	} while (false)
 
 #define ASSERT_FALSE(cond, ...)                                                \
 	do {                                                                   \
@@ -70,7 +70,7 @@
 			bs_trace_error_time_line(                              \
 				#cond " is true.", ##__VA_ARGS__);             \
 		}                                                              \
-	} while (0)
+	} while (false)
 
 #define ASSERT_EQUAL(expected, got)                                            \
 	do {                                                                   \
@@ -80,7 +80,7 @@
 				#expected " not equal to " #got ": %d != %d\n",\
 				(expected), (got));                            \
 		}                                                              \
-	} while (0)
+	} while (false)
 
 
 struct bt_mesh_test_cfg {

--- a/tests/bluetooth/bsim_bt/bsim_test_multiple/src/main.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_multiple/src/main.c
@@ -25,13 +25,13 @@ int init_peripheral(void);
 	do {						\
 		bst_result = Failed;			\
 		bs_trace_error_time_line(__VA_ARGS__);	\
-	} while (0)
+	} while (false)
 
 #define PASS(...)					\
 	do {						\
 		bst_result = Passed;			\
 		bs_trace_info_time(1, __VA_ARGS__);	\
-	} while (0)
+	} while (false)
 
 extern enum bst_result_t bst_result;
 

--- a/tests/drivers/uart/uart_pm/src/main.c
+++ b/tests/drivers/uart/uart_pm/src/main.c
@@ -119,7 +119,7 @@ static void communication_verify(const struct device *dev, bool active)
 	int err = pm_device_state_get(dev, &power_state); \
 	zassert_equal(err, 0, "Unexpected err: %d", err); \
 	zassert_equal(power_state, exp_state, NULL); \
-} while (0)
+} while (false)
 
 static void state_set(const struct device *dev, enum pm_device_state state,
 		      int exp_err)

--- a/tests/kernel/common/src/clock.c
+++ b/tests/kernel/common/src/clock.c
@@ -12,14 +12,14 @@
 		uint32_t t = k_uptime_get_32();   \
 		while (t == k_uptime_get_32()) \
 			k_busy_wait(50);       \
-	} while (0)
+	} while (false)
 #else
 #define ALIGN_MS_BOUNDARY		       \
 	do {				       \
 		uint32_t t = k_uptime_get_32();   \
 		while (t == k_uptime_get_32()) \
 			;		       \
-	} while (0)
+	} while (false)
 #endif
 
 struct timer_data {

--- a/tests/kernel/mem_protect/protection/src/main.c
+++ b/tests/kernel/mem_protect/protection/src/main.c
@@ -40,11 +40,11 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
 /* Must set LSB of function address to call in Thumb mode. */
 #define PTR_TO_FUNC(x) (int (*)(int))((uintptr_t)(x) | 0x1)
 /* Flush preceding data writes and instruction fetches. */
-#define DO_BARRIERS() do { __DSB(); __ISB(); } while (0)
+#define DO_BARRIERS() do { __DSB(); __ISB(); } while (false)
 #else
 #define FUNC_TO_PTR(x) (void *)(x)
 #define PTR_TO_FUNC(x) (int (*)(int))(x)
-#define DO_BARRIERS() do { } while (0)
+#define DO_BARRIERS() do { } while (false)
 #endif
 
 static int __attribute__((noinline)) add_one(int i)

--- a/tests/kernel/semaphore/semaphore/src/main.c
+++ b/tests/kernel/semaphore/semaphore/src/main.c
@@ -27,19 +27,19 @@
 	int _act = k_sem_take((sem), (timeout)); \
 	int _exp = (exp); \
 	zassert_equal(_act, _exp, (str), _act, _exp); \
-} while (0)
+} while (false)
 
 #define expect_k_sem_init(sem, init, max, exp, str) do { \
 	int _act = k_sem_init((sem), (init), (max)); \
 	int _exp = (exp); \
 	zassert_equal(_act, _exp, (str), _act, _exp); \
-} while (0)
+} while (false)
 
 #define expect_k_sem_count_get(sem, exp, str) do { \
 	unsigned int _act = k_sem_count_get(sem); \
 	unsigned int _exp = (exp); \
 	zassert_equal(_act, _exp, (str), _act, _exp); \
-} while (0)
+} while (false)
 
 #define expect_k_sem_take_nomsg(sem, timeout, exp) \
 	expect_k_sem_take((sem), (timeout), (exp), "k_sem_take incorrect return value: %d != %d")

--- a/tests/kernel/tickless/tickless_concept/src/main.c
+++ b/tests/kernel/tickless/tickless_concept/src/main.c
@@ -33,14 +33,14 @@ static struct k_thread tdata[NUM_THREAD];
 		uint32_t t = k_uptime_get_32();   \
 		while (t == k_uptime_get_32()) \
 			k_busy_wait(50);       \
-	} while (0)
+	} while (false)
 #else
 #define ALIGN_MS_BOUNDARY()		       \
 	do {				       \
 		uint32_t t = k_uptime_get_32();   \
 		while (t == k_uptime_get_32()) \
 			;		       \
-	} while (0)
+	} while (false)
 #endif
 K_SEM_DEFINE(sema, 0, NUM_THREAD);
 static int64_t elapsed_slice;

--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -75,7 +75,7 @@ extern void test_time_conversions(void);
 			k_timer_stop(tmr);	 \
 			zassert_true(exp, NULL); \
 		}				 \
-	} while (0)
+	} while (false)
 
 static void init_timer_data(void)
 {

--- a/tests/lib/cbprintf_package/src/test.inc
+++ b/tests/lib/cbprintf_package/src/test.inc
@@ -92,7 +92,7 @@ static void unpack(const char *desc, struct out_buffer *buf,
 	zassert_equal(len, outlen, NULL); \
 	dump("static", pkg, len); \
 	unpack("static", &st_buf, pkg, len); \
-} while (0)
+} while (false)
 
 void test_cbprintf_package(void)
 {

--- a/tests/lib/cmsis_dsp/common/math_helper.h
+++ b/tests/lib/cmsis_dsp/common/math_helper.h
@@ -60,7 +60,7 @@
 		if (isnan((val))) {	\
 			return 0.0;	\
 		}			\
-	} while (0)
+	} while (false)
 
 #define IFINFINITERETURN(val, def)		\
 	do {					\
@@ -71,7 +71,7 @@
 				return -def;	\
 			}			\
 		}				\
-	} while (0)
+	} while (false)
 
 static inline double arm_snr_f64(const double *pRef, const double *pTest,
 	uint32_t buffSize)

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -1301,13 +1301,13 @@ static void test_foreach_status_okay(void)
 	 * using macros with side effects in the current scope.
 	 */
 	val = 0;
-#define INC(inst_ignored) do { val++; } while (0);
+#define INC(inst_ignored) do { val++; } while (false);
 	DT_INST_FOREACH_STATUS_OKAY(INC)
 	zassert_equal(val, 2, "");
 #undef INC
 
 	val = 0;
-#define INC_ARG(arg) do { val++; val += arg; } while (0)
+#define INC_ARG(arg) do { val++; val += arg; } while (false)
 #define INC(inst_ignored, arg) INC_ARG(arg);
 	DT_INST_FOREACH_STATUS_OKAY_VARGS(INC, 1)
 	zassert_equal(val, 4, "");

--- a/tests/net/ip-addr/src/main.c
+++ b/tests/net/ip-addr/src/main.c
@@ -42,7 +42,7 @@ static struct net_if *default_iface;
 		net_byte_to_hex(out, value, 'A', true);		 \
 		zassert_false(strcmp(out, expected),		 \
 			      "Test 0x%s failed.\n", expected);	 \
-	} while (0)
+	} while (false)
 
 #define TEST_BYTE_2(value, expected)				 \
 	do {							 \
@@ -50,7 +50,7 @@ static struct net_if *default_iface;
 		net_byte_to_hex(out, value, 'a', true);		 \
 		zassert_false(strcmp(out, expected),		 \
 			      "Test 0x%s failed.\n", expected);	 \
-	} while (0)
+	} while (false)
 
 #define TEST_LL_6(a, b, c, d, e, f, expected)				\
 	do {								\
@@ -58,7 +58,7 @@ static struct net_if *default_iface;
 		zassert_false(strcmp(net_sprint_ll_addr(ll, sizeof(ll)),\
 				     expected),				\
 			      "Test %s failed.\n", expected);		\
-	} while (0)
+	} while (false)
 
 #define TEST_LL_8(a, b, c, d, e, f, g, h, expected)			\
 	do {								\
@@ -66,7 +66,7 @@ static struct net_if *default_iface;
 		zassert_false(strcmp(net_sprint_ll_addr(ll, sizeof(ll)), \
 				     expected),				\
 			      "Test %s failed.\n", expected);		\
-	} while (0)
+	} while (false)
 
 #define TEST_LL_6_TWO(a, b, c, d, e, f, expected)			\
 	do {								\
@@ -81,7 +81,7 @@ static struct net_if *default_iface;
 		zassert_false(strcmp(out, expected),			\
 			      "Test %s failed, got %s\n", expected,	\
 			      out);					\
-	} while (0)
+	} while (false)
 
 #define TEST_IPV6(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, expected)  \
 	do {								     \
@@ -91,7 +91,7 @@ static struct net_if *default_iface;
 		zassert_false(strcmp(ptr, expected),			     \
 			      "Test %s failed, got %s\n", expected,	     \
 			      ptr);					     \
-	} while (0)
+	} while (false)
 
 #define TEST_IPV4(a, b, c, d, expected)					\
 	do {								\
@@ -100,7 +100,7 @@ static struct net_if *default_iface;
 		zassert_false(strcmp(ptr, expected),			\
 			      "Test %s failed, got %s\n", expected,	\
 			      ptr);					\
-	} while (0)
+	} while (false)
 
 struct net_test_context {
 	uint8_t mac_addr[6];

--- a/tests/subsys/fs/common/test_fs_open_flags.c
+++ b/tests/subsys/fs/common/test_fs_open_flags.c
@@ -127,7 +127,7 @@ do {					\
 	ZUNLINK(ts);			\
 	ZOPEN(ts, FS_O_CREATE, 0);	\
 	ZCLOSE(ts);			\
-} while (0)
+} while (false)
 
 void test_fs_open_flags(void)
 {

--- a/tests/subsys/logging/log_benchmark/src/main.c
+++ b/tests/subsys/logging/log_benchmark/src/main.c
@@ -107,7 +107,7 @@ struct backend_cb backend_ctrl_blk;
 		DBG_PRINT("%d log message with %d arguments fit in %d space.\n", \
 			_cnt, nargs, CONFIG_LOG_BUFFER_SIZE); \
 	} \
-} while (0)
+} while (false)
 
 /** Test how many messages fits in the logging buffer in deferred mode. Test
  * serves as the comparison between logging versions.
@@ -145,7 +145,7 @@ void test_log_capacity(void)
 		  "%d message logged in %u cycles.\n", \
 			nargs, cyc / _msg_cnt, k_cyc_to_us_ceil32(cyc) / _msg_cnt, \
 			_msg_cnt, cyc); \
-} while (0)
+} while (false)
 
 void test_log_message_store_time_no_overwrite(void)
 {
@@ -185,7 +185,7 @@ void test_log_message_store_time_no_overwrite(void)
 		  "%d message logged in %u cycles.\n", \
 			nargs, cyc / _msg_cnt, k_cyc_to_us_ceil32(cyc) / _msg_cnt, \
 			_msg_cnt, cyc); \
-} while (0)
+} while (false)
 
 void test_log_message_store_time_overwrite(void)
 {

--- a/tests/subsys/storage/stream/stream_flash/src/main.c
+++ b/tests/subsys/storage/stream/stream_flash/src/main.c
@@ -49,7 +49,7 @@ do { \
 	rc = flash_read(fdev, FLASH_BASE + start, read_buf, size); \
 	zassert_equal(rc, 0, "should succeed"); \
 	zassert_mem_equal(read_buf, buf, size, "should equal %s", #buf);\
-} while (0)
+} while (false)
 
 #define VERIFY_WRITTEN(start, size) VERIFY_BUF(start, size, written_pattern)
 #define VERIFY_ERASED(start, size) VERIFY_BUF(start, size, erased_pattern)

--- a/tests/unit/cbprintf/main.c
+++ b/tests/unit/cbprintf/main.c
@@ -319,7 +319,7 @@ static int rawprf(const char *format, ...)
 		} \
 	} \
 	*rc = prf(sp_buf, _fmt, __VA_ARGS__); \
-} while (0)
+} while (false)
 
 #define TEST_PRF(rc, _fmt, ...) \
 	TEST_PRF2(rc, WRAP_FMT(_fmt), PASS_ARG(__VA_ARGS__))

--- a/tests/unit/util/test.inc
+++ b/tests/unit/util/test.inc
@@ -169,7 +169,7 @@ void test_UTIL_LISTIFY(void)
 #define INC(x, n, m)		\
 	do {			\
 		i += (x + n + m);\
-	} while (0);
+	} while (false);
 
 #define DEFINE(x, y) int a##x = x * y;
 #define MARK_UNUSED(x, _) ARG_UNUSED(a##x);

--- a/tests/ztest/custom_output/include/tc_util_user_override.h
+++ b/tests/ztest/custom_output/include/tc_util_user_override.h
@@ -18,7 +18,7 @@
 #define TC_START(original)  do { \
 	static int count; \
 	printk("%d: Test [%s]", ++count, original); \
-} while (0)
+} while (false)
 
 /* Example: Change result string output formats. */
 #define TC_PASS_STR "(PASS)"
@@ -32,6 +32,6 @@
 	printk(" reported %s no. %d\n", \
 		TC_RESULT_TO_STR(result), \
 		result_keeper[result]); \
-} while (0)
+} while (false)
 
 #endif /* __TC_UTIL_USER_OVERRIDE_H__ */


### PR DESCRIPTION
MISRA C:2012 Rule 14.4 (The controlling expression of an if statement
and the controlling expression of an iteration-statement shall have
essentially Boolean type.)

Use `do { ... } while (false)` instead of `do { ... } while (0)`.
Use comparisons with zero instead of implicitly testing integers.
Use comparisons with `NULL` instead of implicitly testing pointers.
Use comparisons with NUL instead of implicitly testing plain chars.
Use `bool` instead of `int` to represent Boolean values.
Use `while (true)` instead of `while (1)` to express infinite loops.

Signed-off-by: Abramo Bagnara <abramo.bagnara@bugseng.com>