### PR TITLE
drivers: spi: Initial support for GD32 spi

### DIFF
--- a/boards/arm/gd32f450i_eval/gd32f450i_eval-pinctrl.dtsi
+++ b/boards/arm/gd32f450i_eval/gd32f450i_eval-pinctrl.dtsi
@@ -30,4 +30,13 @@
 			drive-open-drain;
 		};
 	};
+
+	spi5_default: spi5_default {
+		group1 {
+			pinmux = <SPI5_SCK_PG13>, <SPI5_MOSI_PG14>,
+				 <SPI5_MISO_PG12>,
+				 /* Use pinmux to pullup pg10 and pg11. */
+				 <SPI5_IO2_PG10>, <SPI5_IO3_PG11>;
+		};
+	};
 };

--- a/boards/arm/gd32f450i_eval/gd32f450i_eval.dts
+++ b/boards/arm/gd32f450i_eval/gd32f450i_eval.dts
@@ -89,6 +89,14 @@
 	status = "okay";
 };
 
+&gpioi {
+	status = "okay";
+};
+
+&gpiog {
+	status = "okay";
+};
+
 &usart0 {
 	status = "okay";
 	current-speed = <115200>;
@@ -126,5 +134,22 @@
 		pagesize = <8>;
 		address-width = <8>;
 		timeout = <5>;
+	};
+};
+
+&spi5 {
+	status = "okay";
+	pinctrl-0 = <&spi5_default>;
+	pinctrl-names = "default";
+	cs-gpios = <&gpioi 8 GPIO_ACTIVE_LOW>;
+
+	nor_flash: gd25q16@0 {
+		compatible ="jedec,spi-nor";
+		size = <0x1000000>;
+		label = "GD25Q16";
+		reg = <0>;
+		spi-max-frequency = <4000000>;
+		status = "okay";
+		jedec-id = [c8 40 15];
 	};
 };

--- a/boards/riscv/gd32vf103v_eval/gd32vf103v_eval-pinctrl.dtsi
+++ b/boards/riscv/gd32vf103v_eval/gd32vf103v_eval-pinctrl.dtsi
@@ -23,4 +23,11 @@
 			pinmux = <TIMER0_CH0_PA8_OUT_NORMP>;
 		};
 	};
+
+	spi0_default: spi0_default {
+		group1 {
+			pinmux = <SPI0_SCK_PA5_OUT_NORMP>, <SPI0_MOSI_PA7_OUT_NORMP>,
+				 <SPI0_MISO_PA6_OUT_NORMP>;
+		};
+	};
 };

--- a/boards/riscv/gd32vf103v_eval/gd32vf103v_eval.dts
+++ b/boards/riscv/gd32vf103v_eval/gd32vf103v_eval.dts
@@ -120,3 +120,20 @@
 		pinctrl-names = "default";
 	};
 };
+
+&spi0 {
+	status = "okay";
+	pinctrl-0 = <&spi0_default>;
+	pinctrl-names = "default";
+	cs-gpios = <&gpioe 3 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+
+	nor_flash: gd25q16@0 {
+		compatible ="jedec,spi-nor";
+		size = <0x1000000>;
+		label = "GD25Q16";
+		reg = <0>;
+		spi-max-frequency = <4000000>;
+		status = "okay";
+		jedec-id = [c8 40 15];
+	};
+};

--- a/drivers/spi/CMakeLists.txt
+++ b/drivers/spi/CMakeLists.txt
@@ -28,5 +28,6 @@ zephyr_library_sources_ifdef(CONFIG_SPI_PSOC6		spi_psoc6.c)
 zephyr_library_sources_ifdef(CONFIG_SPI_NPCX_FIU	spi_npcx_fiu.c)
 zephyr_library_sources_ifdef(CONFIG_SPI_BITBANG		spi_bitbang.c)
 zephyr_library_sources_ifdef(CONFIG_SPI_XEC_QMSPI_LDMA	spi_xec_qmspi_ldma.c)
+zephyr_library_sources_ifdef(CONFIG_SPI_GD32		spi_gd32.c)
 
 zephyr_library_sources_ifdef(CONFIG_USERSPACE		spi_handlers.c)

--- a/drivers/spi/Kconfig
+++ b/drivers/spi/Kconfig
@@ -99,4 +99,6 @@ source "drivers/spi/Kconfig.bitbang"
 
 source "drivers/spi/Kconfig.xec_qmspi_ldma"
 
+source "drivers/spi/Kconfig.gd32"
+
 endif # SPI

--- a/drivers/spi/Kconfig.gd32
+++ b/drivers/spi/Kconfig.gd32
@@ -1,0 +1,12 @@
+# Copyright (c) 2021 BrainCo Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Workaround for not being able to have commas in macro arguments
+DT_COMPAT_GD_GD32_SPI := gd,gd32-spi
+
+config SPI_GD32
+	bool "Gigadevice GD32 SPI driver"
+	depends on (SOC_FAMILY_GD32 || SOC_SERIES_GD32VF103)
+	default $(dt_compat_enabled,$(DT_COMPAT_GD_GD32_SPI))
+	help
+	  Enables Gigadevice GD32 SPI driver.

--- a/drivers/spi/spi_gd32.c
+++ b/drivers/spi/spi_gd32.c
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2021 BrainCo Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT gd_gd32_spi
+
+#include <errno.h>
+#include <kernel.h>
+#include <drivers/pinctrl.h>
+#include <drivers/spi.h>
+#include <soc.h>
+
+#include <logging/log.h>
+LOG_MODULE_REGISTER(spi_gd32);
+
+#include "spi_context.h"
+
+/* SPI error status mask. */
+#define SPI_GD32_ERR_MASK	(SPI_STAT_RXORERR | SPI_STAT_CONFERR | SPI_STAT_CRCERR)
+
+#define GD32_SPI_PSC_MAX	0x7U
+
+#if defined(CONFIG_SOC_SERIES_GD32F4XX) || \
+	defined(CONFIG_SOC_SERIES_GD32F403) || \
+	defined(CONFIG_SOC_SERIES_GD32VF103) || \
+	defined(CONFIG_SOC_SERIES_GD32E10X)
+#define RCU_APB1EN_OFFSET	APB1EN_REG_OFFSET
+#elif defined(CONFIG_SOC_SERIES_GD32F3X0)
+#define RCU_APB1EN_OFFSET	IDX_APB1EN
+#else
+#error Unknown GD32 soc series
+#endif
+
+/* Obtain RCU register offset from RCU clock value */
+#define RCU_CLOCK_OFFSET(rcu_clock) ((rcu_clock) >> 6U)
+
+struct spi_gd32_config {
+	uint32_t reg;
+	uint32_t rcu_periph_clock;
+	const struct pinctrl_dev_config *pcfg;
+};
+
+struct spi_gd32_data {
+	struct spi_context ctx;
+};
+
+static int spi_gd32_get_err(const struct spi_gd32_config *cfg)
+{
+	uint32_t stat = SPI_STAT(cfg->reg);
+
+	if (stat & SPI_GD32_ERR_MASK) {
+		LOG_ERR("spi%u error status detected, err = %u",
+			cfg->reg, stat & (uint32_t)SPI_GD32_ERR_MASK);
+
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static bool spi_gd32_transfer_ongoing(struct spi_gd32_data *data)
+{
+	return spi_context_tx_on(&data->ctx) ||
+	       spi_context_rx_on(&data->ctx);
+}
+
+static uint32_t spi_gd32_bus_freq_get(uint32_t rcu_periph_clock)
+{
+	uint32_t rcu_bus;
+
+	if (RCU_CLOCK_OFFSET(rcu_periph_clock) == RCU_APB1EN_OFFSET) {
+		rcu_bus = CK_APB1;
+	} else {
+		rcu_bus = CK_APB2;
+	}
+
+	return rcu_clock_freq_get(rcu_bus);
+}
+
+static int spi_gd32_configure(const struct device *dev,
+			      const struct spi_config *config)
+{
+	struct spi_gd32_data *data = dev->data;
+	const struct spi_gd32_config *cfg = dev->config;
+	uint32_t bus_freq;
+
+	if (spi_context_configured(&data->ctx, config)) {
+		return 0;
+	}
+
+	if (SPI_OP_MODE_GET(config->operation) == SPI_OP_MODE_SLAVE) {
+		LOG_ERR("Slave mode not supported");
+		return -ENOTSUP;
+	}
+
+	SPI_CTL0(cfg->reg) &= ~SPI_CTL0_SPIEN;
+
+	SPI_CTL0(cfg->reg) |= SPI_MASTER;
+	SPI_CTL0(cfg->reg) &= ~SPI_TRANSMODE_BDTRANSMIT;
+
+	if (SPI_WORD_SIZE_GET(config->operation) == 8) {
+		SPI_CTL0(cfg->reg) |= SPI_FRAMESIZE_8BIT;
+	} else {
+		SPI_CTL0(cfg->reg) |= SPI_FRAMESIZE_16BIT;
+	}
+
+	/* Reset to hardware NSS mode. */
+	SPI_CTL0(cfg->reg) &= ~SPI_CTL0_SWNSSEN;
+	if (config->cs != NULL) {
+		SPI_CTL0(cfg->reg) |= SPI_CTL0_SWNSSEN;
+	} else {
+		/*
+		 * For single master env,
+		 * hardware NSS mode also need to set the NSSDRV bit.
+		 */
+		SPI_CTL1(cfg->reg) |= SPI_CTL1_NSSDRV;
+	}
+
+	SPI_CTL0(cfg->reg) &= ~SPI_CTL0_LF;
+	if (config->operation & SPI_TRANSFER_LSB) {
+		SPI_CTL0(cfg->reg) |= SPI_CTL0_LF;
+	}
+
+	SPI_CTL0(cfg->reg) &= ~SPI_CTL0_CKPL;
+	if (config->operation & SPI_MODE_CPOL) {
+		SPI_CTL0(cfg->reg) |= SPI_CTL0_CKPL;
+	}
+
+	SPI_CTL0(cfg->reg) &= ~SPI_CTL0_CKPH;
+	if (config->operation & SPI_MODE_CPHA) {
+		SPI_CTL0(cfg->reg) |= SPI_CTL0_CKPH;
+	}
+
+	bus_freq = spi_gd32_bus_freq_get(cfg->rcu_periph_clock);
+
+	for (uint8_t i = 0U; i <= GD32_SPI_PSC_MAX; i++) {
+		bus_freq = bus_freq >> 1U;
+		if (bus_freq <= config->frequency) {
+			SPI_CTL0(cfg->reg) &= ~SPI_CTL0_PSC;
+			SPI_CTL0(cfg->reg) |= CTL0_PSC(i);
+			break;
+		}
+	}
+
+	data->ctx.config = config;
+
+	return 0;
+}
+
+static int spi_gd32_frame_exchange(const struct device *dev)
+{
+	struct spi_gd32_data *data = dev->data;
+	const struct spi_gd32_config *cfg = dev->config;
+	struct spi_context *ctx = &data->ctx;
+	uint16_t tx_frame = 0U, rx_frame = 0U;
+
+	if (SPI_WORD_SIZE_GET(ctx->config->operation) == 8) {
+		if (spi_context_tx_buf_on(ctx)) {
+			tx_frame = UNALIGNED_GET((uint8_t *)(data->ctx.tx_buf));
+		}
+		/* For 8 bits mode, spi will forced SPI_DATA[15:8] to 0. */
+		SPI_DATA(cfg->reg) = tx_frame;
+
+		spi_context_update_tx(ctx, 1, 1);
+	} else {
+		if (spi_context_tx_buf_on(ctx)) {
+			tx_frame = UNALIGNED_GET((uint8_t *)(data->ctx.tx_buf));
+		}
+		SPI_DATA(cfg->reg) = tx_frame;
+
+		spi_context_update_tx(ctx, 2, 1);
+	}
+
+	while ((SPI_STAT(cfg->reg) & SPI_STAT_RBNE) == 0) {
+		/* NOP */
+	}
+
+	if (SPI_WORD_SIZE_GET(data->ctx.config->operation) == 8) {
+		/* For 8 bits mode, spi will forced SPI_DATA[15:8] to 0. */
+		rx_frame = SPI_DATA(cfg->reg);
+		if (spi_context_rx_buf_on(ctx)) {
+			UNALIGNED_PUT(rx_frame, (uint8_t *)data->ctx.rx_buf);
+		}
+
+		spi_context_update_rx(ctx, 1, 1);
+	} else {
+		rx_frame = SPI_DATA(cfg->reg);
+		if (spi_context_rx_buf_on(ctx)) {
+			UNALIGNED_PUT(rx_frame, (uint16_t *)data->ctx.rx_buf);
+		}
+
+		spi_context_update_rx(ctx, 2, 1);
+	}
+
+	return spi_gd32_get_err(cfg);
+}
+
+static int spi_gd32_transceive(const struct device *dev,
+			       const struct spi_config *config,
+			       const struct spi_buf_set *tx_bufs,
+			       const struct spi_buf_set *rx_bufs)
+{
+	struct spi_gd32_data *data = dev->data;
+	const struct spi_gd32_config *cfg = dev->config;
+	int ret;
+
+	spi_context_lock(&data->ctx, false, NULL, config);
+
+	ret = spi_gd32_configure(dev, config);
+	if (ret < 0) {
+		goto error;
+	}
+
+	SPI_CTL0(cfg->reg) |= SPI_CTL0_SPIEN;
+
+	spi_context_buffers_setup(&data->ctx, tx_bufs, rx_bufs, 1);
+
+	spi_context_cs_control(&data->ctx, true);
+
+	do {
+		ret = spi_gd32_frame_exchange(dev);
+		if (ret < 0) {
+			break;
+		}
+	} while (spi_gd32_transfer_ongoing(data));
+
+	spi_context_cs_control(&data->ctx, false);
+
+	SPI_CTL0(cfg->reg) &= ~SPI_CTL0_SPIEN;
+
+error:
+	spi_context_release(&data->ctx, ret);
+
+	return ret;
+}
+
+static int spi_gd32_release(const struct device *dev,
+			    const struct spi_config *config)
+{
+	struct spi_gd32_data *data = dev->data;
+
+	spi_context_unlock_unconditionally(&data->ctx);
+
+	return 0;
+}
+
+static struct spi_driver_api spi_gd32_driver_api = {
+	.transceive = spi_gd32_transceive,
+	.release = spi_gd32_release
+};
+
+int spi_gd32_init(const struct device *dev)
+{
+	struct spi_gd32_data *data = dev->data;
+	const struct spi_gd32_config *cfg = dev->config;
+	int ret;
+
+	rcu_periph_clock_enable(cfg->rcu_periph_clock);
+
+	ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
+	if (ret) {
+		LOG_ERR("Failed to apply pinctrl state");
+		return ret;
+	}
+
+	ret = spi_context_cs_configure_all(&data->ctx);
+	if (ret < 0) {
+		return ret;
+	}
+
+	spi_context_unlock_unconditionally(&data->ctx);
+
+	return 0;
+}
+
+#define GD32_SPI_INIT(idx)							\
+	PINCTRL_DT_INST_DEFINE(idx);						\
+	static struct spi_gd32_data spi_gd32_data_##idx = {			\
+		SPI_CONTEXT_INIT_LOCK(spi_gd32_data_##idx, ctx),		\
+		SPI_CONTEXT_INIT_SYNC(spi_gd32_data_##idx, ctx),		\
+		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(idx), ctx)		\
+	};									\
+	static struct spi_gd32_config spi_gd32_config_##idx = {			\
+		.reg = DT_INST_REG_ADDR(idx),					\
+		.rcu_periph_clock = DT_INST_PROP(idx, rcu_periph_clock),	\
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(idx),			\
+	};									\
+	DEVICE_DT_INST_DEFINE(idx, &spi_gd32_init, NULL, &spi_gd32_data_##idx,	\
+			      &spi_gd32_config_##idx, POST_KERNEL,		\
+			      CONFIG_SPI_INIT_PRIORITY, &spi_gd32_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(GD32_SPI_INIT)

--- a/dts/arm/gigadevice/gd32f403/gd32f403.dtsi
+++ b/dts/arm/gigadevice/gd32f403/gd32f403.dtsi
@@ -95,6 +95,39 @@
 			label = "USART_4";
 		};
 
+		spi0: spi@40013000 {
+			compatible = "gd,gd32-spi";
+			reg = <0x40013000 0x400>;
+			interrupts = <35 0>;
+			rcu-periph-clock = <0x60c>;
+			status = "disabled";
+			label = "SPI_0";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		spi1: spi@40003800 {
+			compatible = "gd,gd32-spi";
+			reg = <0x40003800 0x400>;
+			interrupts = <36 0>;
+			rcu-periph-clock = <0x70e>;
+			status = "disabled";
+			label = "SPI_1";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		spi2: spi@40003c00 {
+			compatible = "gd,gd32-spi";
+			reg = <0x40003c00 0x400>;
+			interrupts = <51 0>;
+			rcu-periph-clock = <0x70f>;
+			status = "disabled";
+			label = "SPI_2";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
 		exti: interrupt-controller@40010400 {
 			compatible = "gd,gd32-exti";
 			interrupt-controller;

--- a/dts/arm/gigadevice/gd32f4xx/gd32f450.dtsi
+++ b/dts/arm/gigadevice/gd32f4xx/gd32f450.dtsi
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2021 BrainCo Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gigadevice/gd32f4xx/gd32f4xx.dtsi>
+
+/ {
+	soc {
+		spi3: spi@40013400 {
+			compatible = "gd,gd32-spi";
+			reg = <0x40013400 0x400>;
+			interrupts = <84 0>;
+			rcu-periph-clock = <0x110d>;
+			status = "disabled";
+			label = "SPI_3";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		spi4: spi@40015000 {
+			compatible = "gd,gd32-spi";
+			reg = <0x40015000 0x400>;
+			interrupts = <85 0>;
+			rcu-periph-clock = <0x1114>;
+			status = "disabled";
+			label = "SPI_4";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		spi5: spi@40015400 {
+			compatible = "gd,gd32-spi";
+			reg = <0x40015400 0x400>;
+			interrupts = <86 0>;
+			rcu-periph-clock = <0x1115>;
+			status = "disabled";
+			label = "SPI_5";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+	};
+};

--- a/dts/arm/gigadevice/gd32f4xx/gd32f450ik.dtsi
+++ b/dts/arm/gigadevice/gd32f4xx/gd32f450ik.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <mem.h>
-#include <gigadevice/gd32f4xx/gd32f4xx.dtsi>
+#include <gigadevice/gd32f4xx/gd32f450.dtsi>
 
 / {
 	soc {

--- a/dts/arm/gigadevice/gd32f4xx/gd32f4xx.dtsi
+++ b/dts/arm/gigadevice/gd32f4xx/gd32f4xx.dtsi
@@ -171,6 +171,39 @@
 			label = "I2C_2";
 		};
 
+		spi0: spi@40013000 {
+			compatible = "gd,gd32-spi";
+			reg = <0x40013000 0x400>;
+			interrupts = <35 0>;
+			rcu-periph-clock = <0x110c>;
+			status = "disabled";
+			label = "SPI_0";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		spi1: spi@40003800 {
+			compatible = "gd,gd32-spi";
+			reg = <0x40003800 0x400>;
+			interrupts = <36 0>;
+			rcu-periph-clock = <0x100e>;
+			status = "disabled";
+			label = "SPI_1";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		spi2: spi@40003c00 {
+			compatible = "gd,gd32-spi";
+			reg = <0x40003c00 0x400>;
+			interrupts = <51 0>;
+			rcu-periph-clock = <0x100f>;
+			status = "disabled";
+			label = "SPI_2";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
 		syscfg: syscfg@40013800 {
 			compatible = "gd,gd32-syscfg";
 			reg = <0x40013800 0x400>;

--- a/dts/bindings/spi/gd,gd32-spi.yaml
+++ b/dts/bindings/spi/gd,gd32-spi.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) 2021 BrainCo Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+description: GigaDevice GD32 SPI
+
+compatible: "gd,gd32-spi"
+
+include: [spi-controller.yaml, pinctrl-device.yaml]
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true
+
+  rcu-periph-clock:
+    type: int
+    description: Peripheral RCU(Reset Clock Unit) Clock ID
+    required: true
+
+  pinctrl-0:
+    required: true
+
+  pinctrl-names:
+    required: true

--- a/dts/riscv/gigadevice/gd32vf103.dtsi
+++ b/dts/riscv/gigadevice/gd32vf103.dtsi
@@ -123,6 +123,18 @@
 			label = "I2C_0";
 		};
 
+		spi0: spi@40013000 {
+			compatible = "gd,gd32-spi";
+			reg = <0x40013000 0x400>;
+			interrupts = <54 0>;
+			interrupt-parent = <&eclic>;
+			rcu-periph-clock = <0x60c>;
+			status = "disabled";
+			label = "SPI_0";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
 		afio: afio@40010000 {
 			compatible = "gd,gd32-afio";
 			reg = <0x40010000 0x400>;

--- a/samples/drivers/spi_flash/boards/gd32f450i_eval.conf
+++ b/samples/drivers/spi_flash/boards/gd32f450i_eval.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2022 BrainCo Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_SPI_NOR=y

--- a/samples/drivers/spi_flash/boards/gd32vf103v_eval.conf
+++ b/samples/drivers/spi_flash/boards/gd32vf103v_eval.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2022 BrainCo Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_SPI_NOR=y


### PR DESCRIPTION
Add initail support for GigaDevice GD32 SPI controller.

More GD32 support can be found in #38657.

[EDIT]
TODO-List:
- [x] pinctrl for spi, use @gmarull GD32 pinctrl
- [x] spi_flash sample available for gd32vf103v_eval board
- [x] software CS, use @gmarull GD32 gpio
- [x] clock control, for max-frequency check.
~~ASYNC support~~(close this feature) 