### PR TITLE
Revert trace changes and restore C99 compatibility in kernel.h

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -76,22 +76,6 @@ struct k_mem_domain;
 struct k_mem_partition;
 struct k_futex;
 struct k_event;
-struct k_condvar;
-struct k_mbox_msg;
-struct k_work;
-struct k_work_q;
-struct k_work_user;
-struct k_work_sync;
-struct k_work_delayable;
-struct k_work_queue_config;
-
-typedef void (*k_thread_user_cb_t)(const struct k_thread *thread,
-				   void *user_data);
-typedef void (*k_timer_expiry_t)(struct k_timer *timer);
-typedef void (*k_timer_stop_t)(struct k_timer *timer);
-typedef uintptr_t stack_data_t;
-typedef void (*k_work_handler_t)(struct k_work *work);
-typedef void (*k_work_user_handler_t)(struct k_work_user *work);
 
 enum execution_context_types {
 	K_ISR = 0,
@@ -102,8 +86,6 @@ enum execution_context_types {
 /* private, used by k_poll and k_work_poll */
 struct k_work_poll;
 typedef int (*_poller_cb_t)(struct k_poll_event *event, uint32_t state);
-
-#include <tracing/tracing.h>
 
 /**
  * @addtogroup thread_apis
@@ -5910,6 +5892,7 @@ int k_thread_runtime_stats_all_get(k_thread_runtime_stats_t *stats);
 }
 #endif
 
+#include <tracing/tracing.h>
 #include <syscalls/kernel.h>
 
 #endif /* !_ASMLANGUAGE */

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -359,7 +359,6 @@ static inline void k_thread_heap_assign(struct k_thread *thread,
 					struct k_heap *heap)
 {
 	thread->resource_pool = heap;
-	SYS_PORT_TRACING_FUNC(k_thread, heap_assign, thread, heap);
 }
 
 #if defined(CONFIG_INIT_STACKS) && defined(CONFIG_THREAD_STACK_INFO)

--- a/include/tracing/tracing.h
+++ b/include/tracing/tracing.h
@@ -326,13 +326,6 @@ void sys_trace_idle(void);
  */
 #define sys_port_trace_k_thread_sched_suspend(thread)
 
-/**
- * @brief Trace thread heap assignment
- * @param thread Thread object
- * @param heap Heap object
- */
-#define sys_port_trace_k_thread_heap_assign(thread, heap)
-
 /** @}c*/ /* end of subsys_tracing_apis_thread */
 
 /**


### PR DESCRIPTION
Revert PRs  #40279 and #40112 and fix
https://github.com/zephyrproject-rtos/zephyr/issues/40411

Alternative to
https://github.com/zephyrproject-rtos/zephyr/pull/40412

C99 explicitly forbids redefining typedefs (allowed in C11). At least the xtensa compilers do not allow disabling/ignoring this.
