### PR TITLE
device: supported device API

### DIFF
--- a/include/device.h
+++ b/include/device.h
@@ -498,6 +498,47 @@ device_required_handles_get(const struct device *dev,
 }
 
 /**
+ * @brief Get the set of handles that this device supports.
+ *
+ * The set of supported devices is inferred from devicetree, and does not
+ * include any software constructs that may depend on the device.
+ *
+ * @param dev the device for which supports are desired.
+ *
+ * @param count pointer to a place to store the number of devices provided at
+ * the returned pointer. The value is not set if the call returns a null
+ * pointer. The value may be set to zero.
+ *
+ * @return a pointer to a sequence of @p *count device handles, or a null
+ * pointer if @p dh does not provide dependency information.
+ */
+static inline const device_handle_t *
+device_supported_handles_get(const struct device *dev,
+			     size_t *count)
+{
+	const device_handle_t *rv = dev->handles;
+	size_t region = 0;
+	size_t i = 0;
+
+	if (rv != NULL) {
+		/* Fast forward to supporting devices */
+		while (region != 2) {
+			if (*rv == DEVICE_HANDLE_SEP) {
+				region++;
+			}
+			rv++;
+		}
+		/* Count supporting devices */
+		while (rv[i] != DEVICE_HANDLE_ENDS) {
+			++i;
+		}
+		*count = i;
+	}
+
+	return rv;
+}
+
+/**
  * @brief Visit every device that @p dev directly requires.
  *
  * Zephyr maintains information about which devices are directly required by
@@ -533,6 +574,42 @@ device_required_handles_get(const struct device *dev,
 int device_required_foreach(const struct device *dev,
 			  device_visitor_callback_t visitor_cb,
 			  void *context);
+
+/**
+ * @brief Visit every device that @p dev directly supports.
+ *
+ * Zephyr maintains information about which devices are directly supported by
+ * another device; for example an I2C controller will support an I2C-based
+ * sensor driver. Supported devices can derive from statically-defined
+ * devicetree relationships.
+ *
+ * This API supports operating on the set of supported devices. Example uses
+ * include iterating over the devices connected to a regulator when it is
+ * powered on.
+ *
+ * There is no guarantee on the order in which required devices are visited.
+ *
+ * If the @p visitor function returns a negative value iteration is halted,
+ * and the returned value from the visitor is returned from this function.
+ *
+ * @note This API is not available to unprivileged threads.
+ *
+ * @param dev a device of interest. The devices that this device supports
+ * will be used as the set of devices to visit. This parameter must not be
+ * null.
+ *
+ * @param visitor_cb the function that should be invoked on each device in the
+ * support set. This parameter must not be null.
+ *
+ * @param context state that is passed through to the visitor function. This
+ * parameter may be null if @p visitor tolerates a null @p context.
+ *
+ * @return The number of devices that were visited if all visits succeed, or
+ * the negative value returned from the first visit that did not succeed.
+ */
+int device_supported_foreach(const struct device *dev,
+			     device_visitor_callback_t visitor_cb,
+			     void *context);
 
 /**
  * @brief Retrieve the device structure for a driver by name

--- a/include/device.h
+++ b/include/device.h
@@ -703,6 +703,26 @@ static inline bool device_is_ready(const struct device *dev)
  * in a distinct pass1 section (which will be replaced by
  * postprocessing).
  *
+ * Before processing in gen_handles.py, the array format is:
+ * {
+ *     DEVICE_ORDINAL (or DEVICE_HANDLE_NULL if not a devicetree node),
+ *     List of devicetree dependency ordinals (if any),
+ *     DEVICE_HANDLE_SEP,
+ *     List of injected dependency ordinals (if any),
+ *     DEVICE_HANDLE_SEP,
+ *     List of devicetree supporting ordinals (if any),
+ * }
+ *
+ * After processing in gen_handles.py, the format is updated to:
+ * {
+ *     List of existing devicetree dependency handles (if any),
+ *     DEVICE_HANDLE_SEP,
+ *     List of injected dependency ordinals (if any),
+ *     DEVICE_HANDLE_SEP,
+ *     List of existing devicetree support handles (if any),
+ *     DEVICE_HANDLE_NULL
+ * }
+ *
  * It is also (experimentally) necessary to provide explicit alignment
  * on each object. Otherwise x86-64 builds will introduce padding
  * between objects in the same input section in individual object
@@ -731,6 +751,9 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 		))							\
 			DEVICE_HANDLE_SEP,				\
 			Z_DEVICE_EXTRA_HANDLES(__VA_ARGS__)		\
+			DEVICE_HANDLE_SEP,				\
+	COND_CODE_1(DT_NODE_EXISTS(node_id),				\
+			(DT_SUPPORTS_DEP_ORDS(node_id)), ())		\
 		};
 
 #ifdef CONFIG_PM_DEVICE

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -162,14 +162,11 @@ bool z_device_ready(const struct device *dev)
 	return dev->state->initialized && (dev->state->init_res == 0U);
 }
 
-int device_required_foreach(const struct device *dev,
-			  device_visitor_callback_t visitor_cb,
-			  void *context)
+static int device_visitor(const device_handle_t *handles,
+			   size_t handle_count,
+			   device_visitor_callback_t visitor_cb,
+			   void *context)
 {
-	size_t handle_count = 0;
-	const device_handle_t *handles =
-		device_required_handles_get(dev, &handle_count);
-
 	/* Iterate over fixed devices */
 	for (size_t i = 0; i < handle_count; ++i) {
 		device_handle_t dh = handles[i];
@@ -182,4 +179,24 @@ int device_required_foreach(const struct device *dev,
 	}
 
 	return handle_count;
+}
+
+int device_required_foreach(const struct device *dev,
+			    device_visitor_callback_t visitor_cb,
+			    void *context)
+{
+	size_t handle_count = 0;
+	const device_handle_t *handles = device_required_handles_get(dev, &handle_count);
+
+	return device_visitor(handles, handle_count, visitor_cb, context);
+}
+
+int device_supported_foreach(const struct device *dev,
+			     device_visitor_callback_t visitor_cb,
+			     void *context)
+{
+	size_t handle_count = 0;
+	const device_handle_t *handles = device_supported_handles_get(dev, &handle_count);
+
+	return device_visitor(handles, handle_count, visitor_cb, context);
 }

--- a/scripts/gen_handles.py
+++ b/scripts/gen_handles.py
@@ -246,15 +246,19 @@ def main():
         hvi = 1
         handle.dev_deps = []
         handle.ext_deps = []
-        deps = handle.dev_deps
+        handle.dev_sups = []
+        hdls = handle.dev_deps
         while hvi < len(hv):
             h = hv[hvi]
             if h == DEVICE_HANDLE_ENDS:
                 break
             if h == DEVICE_HANDLE_SEP:
-                deps = handle.ext_deps
+                if hdls == handle.dev_deps:
+                    hdls = handle.ext_deps
+                else:
+                    hdls = handle.dev_sups
             else:
-                deps.append(h)
+                hdls.append(h)
                 n = edt
             hvi += 1
 
@@ -264,22 +268,36 @@ def main():
     root = edt.dep_ord2node[0]
     assert root not in used_nodes
 
-    for sn in used_nodes:
+    for n in used_nodes:
         # Where we're storing the final set of nodes: these are all used
-        sn.__depends = set()
+        n.__depends = set()
+        n.__supports = set()
 
-        deps = set(sn.depends_on)
-        debug("\nNode: %s\nOrig deps:\n\t%s" % (sn.path, "\n\t".join([dn.path for dn in deps])))
+        deps = set(n.depends_on)
+        debug("\nNode: %s\nOrig deps:\n\t%s" % (n.path, "\n\t".join([dn.path for dn in deps])))
         while len(deps) > 0:
             dn = deps.pop()
             if dn in used_nodes:
                 # this is used
-                sn.__depends.add(dn)
+                n.__depends.add(dn)
             elif dn != root:
                 # forward the dependency up one level
                 for ddn in dn.depends_on:
                     deps.add(ddn)
-        debug("final deps:\n\t%s\n" % ("\n\t".join([ _dn.path for _dn in sn.__depends])))
+        debug("Final deps:\n\t%s\n" % ("\n\t".join([ _dn.path for _dn in n.__depends])))
+
+        sups = set(n.required_by)
+        debug("\nOrig sups:\n\t%s" % ("\n\t".join([dn.path for dn in sups])))
+        while len(sups) > 0:
+            sn = sups.pop()
+            if sn in used_nodes:
+                # this is used
+                n.__supports.add(sn)
+            else:
+                # forward the support down one level
+                for ssn in sn.required_by:
+                    sups.add(ssn)
+        debug("\nFinal sups:\n\t%s" % ("\n\t".join([_sn.path for _sn in n.__supports])))
 
     with open(args.output_source, "w") as fp:
         fp.write('#include <device.h>\n')
@@ -290,6 +308,7 @@ def main():
             assert hs, "no hs for %s" % (dev.sym.name,)
             dep_paths = []
             ext_paths = []
+            sup_paths = []
             hdls = []
 
             sn = hs.node
@@ -300,11 +319,23 @@ def main():
                         dep_paths.append(dn.path)
                     else:
                         dep_paths.append('(%s)' % dn.path)
+            # Force separator to signal start of injected dependencies
+            hdls.append(DEVICE_HANDLE_SEP)
             if len(hs.ext_deps) > 0:
                 # TODO: map these to something smaller?
                 ext_paths.extend(map(str, hs.ext_deps))
                 hdls.append(DEVICE_HANDLE_SEP)
                 hdls.extend(hs.ext_deps)
+
+            # Force separator to signal start of supported devices
+            hdls.append(DEVICE_HANDLE_SEP)
+            if len(hs.dev_sups) > 0:
+                for dn in sn.required_by:
+                    if dn in sn.__supports:
+                        sup_paths.append(dn.path)
+                    else:
+                        sup_paths.append('(%s)' % dn.path)
+                hdls.extend(dn.__device.dev_handle for dn in sn.__supports)
 
             # Terminate the array with the end symbol
             hdls.append(DEVICE_HANDLE_ENDS)
@@ -315,9 +346,14 @@ def main():
             ]
 
             if len(dep_paths) > 0:
-                lines.append(' * - %s' % ('\n * - '.join(dep_paths)))
+                lines.append(' * Direct Dependencies:')
+                lines.append(' *   - %s' % ('\n *   - '.join(dep_paths)))
             if len(ext_paths) > 0:
-                lines.append(' * + %s' % ('\n * + '.join(ext_paths)))
+                lines.append(' * Injected Dependencies:')
+                lines.append(' *   - %s' % ('\n *   - '.join(ext_paths)))
+            if len(sup_paths) > 0:
+                lines.append(' * Supported:')
+                lines.append(' *   - %s' % ('\n *   - '.join(sup_paths)))
 
             lines.extend([
                 ' */',

--- a/tests/lib/devicetree/devices/app.overlay
+++ b/tests/lib/devicetree/devices/app.overlay
@@ -57,6 +57,28 @@
 				supply-gpios = <&test_gpiox 2 0>;
 				label = "TEST_I2C_DEV_12";
 			};
+
+			test_dev_c: test-i2c-dev@13 {
+				compatible = "vnd,i2c-device";
+				label = "TEST_SPI_DEV_0";
+				reg = <13>;
+				status = "disabled";
+
+				partitions {
+					compatible = "fixed-partitions";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					test_p0: partition@0 {
+						label = "partition-0";
+						reg = <0x000000000 0x0000C000>;
+					};
+					test_p1: partition@c000 {
+						label = "partition-1";
+						reg = <0x0000C000 0x00067000>;
+					};
+				};
+			};
 		};
 	};
 };


### PR DESCRIPTION
Resurrection of #37836, which was reverted in #38834, due to build system fixes in #39959

Implements an API to iterate over devicetree devices that an arbitrary device supports.
Follows the conventions setup by the dependent devices API.
In addition to the original functionality, this PR now forwards supports when an intermediate device is not present in the final build (For example flash partitions under a flash device, with an intermediate "fixed-partitions" node).

Implements #37793.