### PR TITLE
cmake: kconfig: fix issue if Kconfig symbol name contains lower case

### DIFF
--- a/misc/generated/CMakeLists.txt
+++ b/misc/generated/CMakeLists.txt
@@ -9,7 +9,7 @@ file(STRINGS
   ENCODING "UTF-8"
   )
 foreach (CONFIG ${LIST_OF_CONFIGS})
-  string(REGEX REPLACE "#define (CONFIG_[A-Z|_|0-9]*) (.*)" "GEN_ABSOLUTE_SYM_KCONFIG(\\1, \\2)" CONFIG ${CONFIG})
+  string(REGEX REPLACE "#define (CONFIG_[A-Za-z|_|0-9]*) (.*)" "GEN_ABSOLUTE_SYM_KCONFIG(\\1, \\2)" CONFIG ${CONFIG})
   string(REGEX REPLACE "\"(.*)\"" "1" CONFIG ${CONFIG})
   set(GEN_ABS_SYM_LIST "${GEN_ABS_SYM_LIST}${CONFIG};\n")
 endforeach()


### PR DESCRIPTION
Fixes: #40420

If a Kconfig has lower case in its symbol name, then the file configs.c
is wrongly generated.

For example a Kconfig snippet like this:
```
 config FAIL_this
 	bool "Test fail"
	default y
```

will create an autoconf.h containing this:
```
 #define CONFIG_FAIL_this 1
```

but the configs.c will wrongly contain the same
```
 #define CONFIG_FAIL_this 1
```

instead of:
```
 GEN_ABSOLUTE_SYM_KCONFIG(CONFIG_FAIL_this, 1);
```

which results in following error at compile time
```
.../build/zephyr/misc/generated/configs.c: In function '_ConfigAbsSyms':
.../build/zephyr/misc/generated/configs.c:309: warning:
    "CONFIG_FAIL_this" redefined
  309 | #define CONFIG_FAIL_this 1;
      |
In file included from <command-line>:
.../build/zephyr/include/generated/autoconf.h:299: note: this is the
  location of the previous definition
  299 | #define CONFIG_FAIL_this 1
      |
```

The file `misc/generated/CMakeLists.txt` has been updated to correctly
handled lower casing in Kconfig symbol names.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>