### PR TITLE
devicetree: add instance based macros for DT_ENUM_IDX(_OR)

### DIFF
--- a/drivers/dac/dac_sam0.c
+++ b/drivers/dac/dac_sam0.c
@@ -95,7 +95,7 @@ static const struct dac_driver_api api_sam0_driver_api = {
 
 #define SAM0_DAC_REFSEL(n)						       \
 	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, reference),		       \
-		    (DT_ENUM_IDX(DT_DRV_INST(n), reference)), (0))
+		    (DT_INST_ENUM_IDX(n, reference)), (0))
 
 #define SAM0_DAC_INIT(n)						       \
 	static const struct dac_sam0_cfg dac_sam0_cfg_##n = {		       \

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -1107,7 +1107,7 @@ static int gmac_init(Gmac *gmac, uint32_t gmac_ncfgr_val)
 	/* Setup Network Configuration Register */
 	gmac->GMAC_NCFGR = gmac_ncfgr_val | mck_divisor;
 
-	gmac->GMAC_UR = DT_ENUM_IDX(DT_DRV_INST(0), phy_connection_type);
+	gmac->GMAC_UR = DT_INST_ENUM_IDX(0, phy_connection_type);
 
 #if defined(CONFIG_PTP_CLOCK_SAM_GMAC)
 	/* Initialize PTP Clock Registers */

--- a/drivers/ethernet/phy/phy_mii.c
+++ b/drivers/ethernet/phy/phy_mii.c
@@ -403,7 +403,7 @@ static const struct ethphy_driver_api phy_mii_driver_api = {
 static const struct phy_mii_dev_config phy_mii_dev_config_##n = {	 \
 	.phy_addr = DT_PROP(DT_DRV_INST(n), address),			 \
 	.fixed = IS_FIXED_LINK(n),					 \
-	.fixed_speed = DT_ENUM_IDX_OR(DT_DRV_INST(n), fixed_link, 0),	 \
+	.fixed_speed = DT_INST_ENUM_IDX_OR(n, fixed_link, 0),		 \
 	.mdio = UTIL_AND(UTIL_NOT(IS_FIXED_LINK(n)),			 \
 			 DEVICE_DT_GET(DT_PHANDLE(DT_DRV_INST(n), mdio)))\
 };

--- a/drivers/i2c/i2c_sam4l_twim.c
+++ b/drivers/i2c/i2c_sam4l_twim.c
@@ -593,8 +593,6 @@ static const struct i2c_driver_api i2c_sam_twim_driver_api = {
 	.transfer = i2c_sam_twim_transfer,
 };
 
-#define DT_INST_ENUM_IDX(inst, prop) DT_ENUM_IDX(DT_DRV_INST(inst), prop)
-
 #define I2C_TWIM_SAM_SLEW_REGS(n)					\
 	.std_clk_slew_lim = DT_INST_ENUM_IDX(n, std_clk_slew_lim),	\
 	.std_clk_strength_low = DT_INST_ENUM_IDX(n, std_clk_strength_low),\

--- a/drivers/lora/sx127x.c
+++ b/drivers/lora/sx127x.c
@@ -135,7 +135,7 @@ BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(semtech_sx1272) +
 #define SX127X_PA_OUTPUT(power)		SX127X_PA_BOOST
 #elif DT_INST_NODE_HAS_PROP(0, power_amplifier_output)
 #define SX127X_PA_OUTPUT(power)				\
-	DT_ENUM_IDX(DT_DRV_INST(0), power_amplifier_output)
+	DT_INST_ENUM_IDX(0, power_amplifier_output)
 #else
 BUILD_ASSERT(0, "None of rfo-enable-gpios, pa-boost-enable-gpios and "
 	     "power-amplifier-output has been specified. "

--- a/drivers/mdio/mdio_sam.c
+++ b/drivers/mdio/mdio_sam.c
@@ -131,7 +131,7 @@ static const struct mdio_driver_api mdio_sam_driver_api = {
 #define MDIO_SAM_CONFIG(n)						\
 static const struct mdio_sam_dev_config mdio_sam_dev_config_##n = {	\
 	.regs = (Gmac *)DT_REG_ADDR(DT_PARENT(DT_DRV_INST(n))),		\
-	.protocol = DT_ENUM_IDX(DT_DRV_INST(n), protocol),		\
+	.protocol = DT_INST_ENUM_IDX(n, protocol),			\
 };
 
 #define MDIO_SAM_DEVICE(n)						\

--- a/drivers/sensor/bmp388/bmp388.c
+++ b/drivers/sensor/bmp388/bmp388.c
@@ -710,15 +710,15 @@ static int bmp388_init(const struct device *dev)
 
 #define BMP388_INST(inst)						   \
 	static struct bmp388_data bmp388_data_##inst = {		   \
-		.odr = DT_ENUM_IDX(DT_DRV_INST(inst), odr),		   \
-		.osr_pressure = DT_ENUM_IDX(DT_DRV_INST(inst), osr_press), \
-		.osr_temp = DT_ENUM_IDX(DT_DRV_INST(inst), osr_temp),	   \
+		.odr = DT_INST_ENUM_IDX(inst, odr),			   \
+		.osr_pressure = DT_INST_ENUM_IDX(inst, osr_press),	   \
+		.osr_temp = DT_INST_ENUM_IDX(inst, osr_temp),		   \
 	};								   \
 	static const struct bmp388_config bmp388_config_##inst = {	   \
 		.bus = DEVICE_DT_GET(DT_INST_BUS(inst)),		   \
 		BMP388_BUS_CFG(inst),					   \
 		BMP388_INT_CFG(inst)					   \
-		.iir_filter = DT_ENUM_IDX(DT_DRV_INST(inst), iir_filter),  \
+		.iir_filter = DT_INST_ENUM_IDX(inst, iir_filter),	   \
 	};								   \
 	DEVICE_DT_INST_DEFINE(						   \
 		inst,							   \

--- a/drivers/sensor/fdc2x1x/fdc2x1x.c
+++ b/drivers/sensor/fdc2x1x/fdc2x1x.c
@@ -1014,9 +1014,9 @@ static int fdc2x1x_init(const struct device *dev)
 		.active_channel = DT_INST_PROP(n, active_channel),	   \
 		.deglitch = DT_INST_PROP(n, deglitch),			   \
 		.sensor_activate_sel =					   \
-			DT_ENUM_IDX(DT_DRV_INST(n), sensor_activate_sel),  \
-		.clk_src = DT_ENUM_IDX(DT_DRV_INST(n), ref_clk_src),	   \
-		.current_drv = DT_ENUM_IDX(DT_DRV_INST(n), current_drive), \
+			DT_INST_ENUM_IDX(n, sensor_activate_sel),	   \
+		.clk_src = DT_INST_ENUM_IDX(n, ref_clk_src),		   \
+		.current_drv = DT_INST_ENUM_IDX(n, current_drive),	   \
 		.output_gain = DT_INST_PROP(n, output_gain),		   \
 		.ch_cfg =       ch_cfg_##n,				   \
 		.num_channels = ARRAY_SIZE(fdc2x1x_sample_buf_##n),	   \

--- a/drivers/sensor/icm42605/icm42605.c
+++ b/drivers/sensor/icm42605/icm42605.c
@@ -457,8 +457,8 @@ static const struct sensor_driver_api icm42605_driver_api = {
 		.gpio_dt_flags = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(index),	\
 		.accel_hz = DT_INST_PROP(index, accel_hz),		\
 		.gyro_hz = DT_INST_PROP(index, gyro_hz),		\
-		.accel_fs = DT_ENUM_IDX(DT_DRV_INST(index), accel_fs),	\
-		.gyro_fs = DT_ENUM_IDX(DT_DRV_INST(index), gyro_fs),	\
+		.accel_fs = DT_INST_ENUM_IDX(index, accel_fs),		\
+		.gyro_fs = DT_INST_ENUM_IDX(index, gyro_fs),		\
 	}
 
 #define ICM42605_INIT(index)						\

--- a/drivers/sensor/shtcx/shtcx.c
+++ b/drivers/sensor/shtcx/shtcx.c
@@ -242,8 +242,8 @@ static int shtcx_init(const struct device *dev)
 	{								       \
 		.bus = DEVICE_DT_GET(DT_INST_BUS(inst)),		       \
 		.base_address = DT_INST_REG_ADDR(inst),			       \
-		.chip = DT_ENUM_IDX(DT_DRV_INST(inst), chip),		       \
-		.measure_mode = DT_ENUM_IDX(DT_DRV_INST(inst), measure_mode),  \
+		.chip = DT_INST_ENUM_IDX(inst, chip),			       \
+		.measure_mode = DT_INST_ENUM_IDX(inst, measure_mode),	       \
 		.clock_stretching = DT_INST_PROP(inst, clock_stretching)       \
 	}
 

--- a/drivers/sensor/vcnl4040/vcnl4040.c
+++ b/drivers/sensor/vcnl4040/vcnl4040.c
@@ -354,11 +354,11 @@ static const struct vcnl4040_config vcnl4040_config = {
 	.gpio_flags = 0,
 #endif
 #endif
-	.led_i = DT_ENUM_IDX(DT_DRV_INST(0), led_current),
-	.led_dc = DT_ENUM_IDX(DT_DRV_INST(0), led_duty_cycle),
-	.als_it = DT_ENUM_IDX(DT_DRV_INST(0), als_it),
-	.proxy_it = DT_ENUM_IDX(DT_DRV_INST(0), proximity_it),
-	.proxy_type = DT_ENUM_IDX(DT_DRV_INST(0), proximity_trigger),
+	.led_i = DT_INST_ENUM_IDX(0, led_current),
+	.led_dc = DT_INST_ENUM_IDX(0, led_duty_cycle),
+	.als_it = DT_INST_ENUM_IDX(0, als_it),
+	.proxy_it = DT_INST_ENUM_IDX(0, proximity_it),
+	.proxy_type = DT_INST_ENUM_IDX(0, proximity_trigger),
 };
 
 static struct vcnl4040_data vcnl4040_data;

--- a/drivers/sensor/wsen_itds/itds.c
+++ b/drivers/sensor/wsen_itds/itds.c
@@ -397,8 +397,8 @@ static const struct itds_device_config itds_config_##idx = {		\
 	.gpio_port = DT_INST_GPIO_LABEL(idx, int_gpios),		\
 	.int_pin = DT_INST_GPIO_PIN(idx, int_gpios),			\
 	.int_flags = DT_INST_GPIO_FLAGS(idx, int_gpios),		\
-	.def_odr = DT_ENUM_IDX(DT_DRV_INST(idx), odr),			\
-	.def_op_mode = DT_ENUM_IDX(DT_DRV_INST(idx), op_mode),		\
+	.def_odr = DT_INST_ENUM_IDX(idx, odr),				\
+	.def_op_mode = DT_INST_ENUM_IDX(idx, op_mode),			\
 };									\
 									\
 DEVICE_DT_INST_DEFINE(idx, itds_init, NULL,				\

--- a/drivers/serial/uart_mcux_flexcomm.c
+++ b/drivers/serial/uart_mcux_flexcomm.c
@@ -332,7 +332,7 @@ static const struct mcux_flexcomm_config mcux_flexcomm_##n##_config = {	\
 	.clock_subsys =				\
 	(clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),\
 	.baud_rate = DT_INST_PROP(n, current_speed),			\
-	.parity = DT_ENUM_IDX_OR(DT_DRV_INST(n), parity, UART_CFG_PARITY_NONE), \
+	.parity = DT_INST_ENUM_IDX_OR(n, parity, UART_CFG_PARITY_NONE), \
 	IRQ_FUNC_INIT							\
 }
 

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1603,7 +1603,7 @@ static const struct uart_stm32_config uart_stm32_cfg_##index = {	\
 		    .enr = DT_INST_CLOCKS_CELL(index, bits)		\
 	},								\
 	.hw_flow_control = DT_INST_PROP(index, hw_flow_control),	\
-	.parity = DT_ENUM_IDX_OR(DT_DRV_INST(index), parity, UART_CFG_PARITY_NONE),	\
+	.parity = DT_INST_ENUM_IDX_OR(index, parity, UART_CFG_PARITY_NONE),	\
 	STM32_UART_POLL_IRQ_HANDLER_FUNC(index)				\
 	.pinctrl_list = uart_pins_##index,				\
 	.pinctrl_list_size = ARRAY_SIZE(uart_pins_##index),		\

--- a/drivers/spi/spi_b91.c
+++ b/drivers/spi/spi_b91.c
@@ -463,7 +463,7 @@ static struct spi_driver_api spi_b91_api = {
 	};									\
 										\
 	static struct spi_b91_cfg spi_b91_cfg_##inst = {			\
-		.peripheral_id = DT_ENUM_IDX(DT_DRV_INST(inst), peripheral_id),	\
+		.peripheral_id = DT_INST_ENUM_IDX(inst, peripheral_id),		\
 		.cs_pin[0] = DT_STRING_TOKEN(DT_DRV_INST(inst), cs0_pin),	\
 		.cs_pin[1] = DT_STRING_TOKEN(DT_DRV_INST(inst), cs1_pin),	\
 		.cs_pin[2] = DT_STRING_TOKEN(DT_DRV_INST(inst), cs2_pin),	\

--- a/drivers/usb/device/usb_dc_sam_usbc.c
+++ b/drivers/usb/device/usb_dc_sam_usbc.c
@@ -699,7 +699,7 @@ int usb_dc_attach(void)
 	/* Select the speed with pads detached */
 	regval = USBC_UDCON_DETACH;
 
-	switch (DT_ENUM_IDX(DT_DRV_INST(0), maximum_speed)) {
+	switch (DT_INST_ENUM_IDX(0, maximum_speed)) {
 	case 1:
 		WRITE_BIT(regval, USBC_UDCON_LS_Pos, 0);
 		break;

--- a/drivers/usb/device/usb_dc_sam_usbhs.c
+++ b/drivers/usb/device/usb_dc_sam_usbhs.c
@@ -47,7 +47,7 @@ LOG_MODULE_REGISTER(usb_dc_sam_usbhs);
 
 #define NUM_OF_EP_MAX		DT_INST_PROP(0, num_bidir_endpoints)
 #if DT_INST_NODE_HAS_PROP(0, maximum_speed)
-#define USB_MAXIMUM_SPEED	DT_ENUM_IDX(DT_DRV_INST(0), maximum_speed)
+#define USB_MAXIMUM_SPEED	DT_INST_ENUM_IDX(0, maximum_speed)
 #else
 #define USB_MAXIMUM_SPEED	2 /* Default to high-speed */
 #endif

--- a/dts/bindings/test/vnd,enum-holder-inst.yaml
+++ b/dts/bindings/test/vnd,enum-holder-inst.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: Test enum property container (instance based)
+
+compatible: "vnd,enum-holder-inst"
+
+include: [base.yaml, "vnd,enum-holder.yaml"]

--- a/dts/bindings/test/vnd,enum-required-false-holder-inst.yaml
+++ b/dts/bindings/test/vnd,enum-required-false-holder-inst.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: Test enum property container (instance based)
+
+compatible: "vnd,enum-required-false-holder-inst"
+
+include: [base.yaml, "vnd,enum-required-false-holder.yaml"]

--- a/include/devicetree.h
+++ b/include/devicetree.h
@@ -2457,6 +2457,26 @@
 	DT_FOREACH_CHILD_VARGS(DT_DRV_INST(inst), fn, __VA_ARGS__)
 
 /**
+ * @brief Get a DT_DRV_COMPAT value's index into its enumeration values
+ * @param inst instance number
+ * @param prop lowercase-and-underscores property name
+ * @return zero-based index of the property's value in its enum: list
+ */
+#define DT_INST_ENUM_IDX(inst, prop) \
+	DT_ENUM_IDX(DT_DRV_INST(inst), prop)
+
+/**
+ * @brief Like DT_INST_ENUM_IDX(), but with a fallback to a default enum index
+ * @param inst instance number
+ * @param prop lowercase-and-underscores property name
+ * @param default_idx_value a fallback index value to expand to
+ * @return zero-based index of the property's value in its enum if present,
+ *         default_idx_value ohterwise
+ */
+#define DT_INST_ENUM_IDX_OR(inst, prop, default_idx_value) \
+	DT_ENUM_IDX_OR(DT_DRV_INST(inst), prop, default_idx_value)
+
+/**
  * @brief Get a DT_DRV_COMPAT instance property
  * @param inst instance number
  * @param prop lowercase-and-underscores property name

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -90,6 +90,15 @@
 			compatible = "vnd,enum-int-required-false-holder";
 		};
 
+		enum-6 {
+			compatible = "vnd,enum-holder-inst";
+			val = "zero";
+		};
+
+		enum-7 {
+			compatible = "vnd,enum-required-false-holder-inst";
+		};
+
 		/*
 		 * This should be the only node with this
 		 * compatible in the tree.

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -1539,6 +1539,18 @@ static void test_enums_required_false(void)
 		      4, "");
 }
 
+static void test_inst_enums(void)
+{
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT vnd_enum_holder_inst
+	zassert_equal(DT_INST_ENUM_IDX(0, val), 0, "");
+	zassert_equal(DT_INST_ENUM_IDX_OR(0, val, 2), 0, "");
+
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT vnd_enum_required_false_holder_inst
+	zassert_equal(DT_INST_ENUM_IDX_OR(0, val, 2), 2, "");
+}
+
 #undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT vnd_adc_temp_sensor
 static void test_clocks(void)
@@ -2263,6 +2275,7 @@ void test_main(void)
 			 ztest_unit_test(test_chosen),
 			 ztest_unit_test(test_enums),
 			 ztest_unit_test(test_enums_required_false),
+			 ztest_unit_test(test_inst_enums),
 			 ztest_unit_test(test_clocks),
 			 ztest_unit_test(test_parent),
 			 ztest_unit_test(test_child_nodes_list),


### PR DESCRIPTION
The `DT_ENUM_IDX` and `DT_ENUM_IDX_OR` macros did not have the instance
based equivalents. Added tests and simplified some drivers.