### PR TITLE
Add function to get info of ISO channel

### DIFF
--- a/include/bluetooth/iso.h
+++ b/include/bluetooth/iso.h
@@ -98,6 +98,14 @@ enum {
 	BT_ISO_DISCONNECT,
 };
 
+
+enum bt_iso_chan_type {
+	BT_ISO_CHAN_TYPE_NONE,
+	BT_ISO_CHAN_TYPE_CONNECTED,
+	BT_ISO_CHAN_TYPE_BROADCASTER,
+	BT_ISO_CHAN_TYPE_SYNC_RECEIVER
+};
+
 /** @brief ISO Channel structure. */
 struct bt_iso_chan {
 	/** Channel connection reference */

--- a/include/bluetooth/iso.h
+++ b/include/bluetooth/iso.h
@@ -607,6 +607,31 @@ int bt_iso_chan_disconnect(struct bt_iso_chan *chan);
  */
 int bt_iso_chan_send(struct bt_iso_chan *chan, struct net_buf *buf);
 
+/** ISO channel Info Structure */
+struct bt_iso_info {
+	/** Channel Type. */
+	enum bt_iso_chan_type type;
+};
+
+/** @brief Get ISO channel info
+ *
+ *  @param chan Channel object.
+ *  @param info Channel info object.
+ *
+ *  @return Zero on success or (negative) error code on failure.
+ */
+int bt_iso_chan_get_info(const struct bt_iso_chan *chan,
+			 struct bt_iso_info *info);
+
+/** @brief Get the type of an ISO channel
+ *
+ * @param chan Channel object.
+ *
+ * @return enum bt_iso_chan_type The type of the channel. If @p is NULL this
+ *                               will be BT_ISO_CHAN_TYPE_NONE.
+ */
+enum bt_iso_chan_type bt_iso_chan_get_type(const struct bt_iso_chan *chan);
+
 /** @brief Creates a BIG as a broadcaster
  *
  *  @param[in] padv      Pointer to the periodic advertising object the BIGInfo shall be sent on.

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2240,7 +2240,8 @@ int bt_conn_get_info(const struct bt_conn *conn, struct bt_conn_info *info)
 #endif
 #if defined(CONFIG_BT_ISO)
 	case BT_CONN_TYPE_ISO:
-		if (!conn->iso.is_bis) {
+		if (IS_ENABLED(CONFIG_BT_ISO_UNICAST) &&
+		    conn->iso.type == BT_ISO_CHAN_TYPE_CONNECTED) {
 			info->le.dst = &conn->iso.acl->le.dst;
 			info->le.src = &bt_dev.id_addr[conn->iso.acl->id];
 		} else {

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -4,9 +4,12 @@
 
 /*
  * Copyright (c) 2015 Intel Corporation
+ * Copyright (c) 2021 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#include <bluetooth/iso.h>
 
 typedef enum __packed {
 	BT_CONN_DISCONNECTED,
@@ -121,8 +124,8 @@ struct bt_conn_iso {
 		uint8_t			bis_id;
 	};
 
-	/** If true, this is a ISO for a BIS, else it is a ISO for a CIS */
-	bool is_bis;
+	/** Type of the ISO channel */
+	enum bt_iso_chan_type type;
 };
 
 typedef void (*bt_conn_tx_cb_t)(struct bt_conn *conn, void *user_data);

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -559,6 +559,29 @@ void bt_iso_chan_set_state(struct bt_iso_chan *chan, uint8_t state)
 }
 #endif /* CONFIG_BT_DEBUG_ISO */
 
+int bt_iso_chan_get_info(const struct bt_iso_chan *chan,
+			 struct bt_iso_info *info)
+{
+	CHECKIF(chan == NULL) {
+		BT_DBG("chan is NULL");
+		return -EINVAL;
+	}
+
+	CHECKIF(chan->iso == NULL) {
+		BT_DBG("chan->iso is NULL");
+		return -EINVAL;
+	}
+
+	CHECKIF(info == NULL) {
+		BT_DBG("info is NULL");
+		return -EINVAL;
+	}
+
+	info->type = chan->iso->iso.type;
+
+	return 0;
+}
+
 #if defined(CONFIG_BT_ISO_UNICAST) || defined(CONFIG_BT_ISO_SYNC_RECEIVER)
 struct net_buf *bt_iso_get_rx(k_timeout_t timeout)
 {

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -1172,15 +1172,18 @@ static int cig_init_cis(struct bt_iso_cig *cig,
 		struct bt_iso_chan *cis = param->cis_channels[i];
 
 		if (cis->iso == NULL) {
+			struct bt_conn_iso *iso_conn;
+
 			cis->iso = iso_new();
 			if (cis->iso == NULL) {
 				BT_ERR("Unable to allocate CIS connection");
 				return -ENOMEM;
 			}
+			iso_conn = &cis->iso->iso;
 
-			cis->iso->iso.cig_id = cig->id;
-			cis->iso->iso.type = BT_ISO_CHAN_TYPE_CONNECTED;
-			cis->iso->iso.cis_id = cig->num_cis++;
+			iso_conn->cig_id = cig->id;
+			iso_conn->type = BT_ISO_CHAN_TYPE_CONNECTED;
+			iso_conn->cis_id = cig->num_cis++;
 
 			bt_iso_chan_add(cis->iso, cis);
 
@@ -1707,6 +1710,7 @@ static int big_init_bis(struct bt_iso_big *big,
 {
 	for (uint8_t i = 0; i < num_bis; i++) {
 		struct bt_iso_chan *bis = bis_channels[i];
+		struct bt_conn_iso *iso_conn;
 
 		bis->iso = iso_new();
 
@@ -1714,11 +1718,12 @@ static int big_init_bis(struct bt_iso_big *big,
 			BT_ERR("Unable to allocate BIS connection");
 			return -ENOMEM;
 		}
+		iso_conn = &bis->iso->iso;
 
-		bis->iso->iso.big_handle = big->handle;
-		bis->iso->iso.type = broadcaster ? BT_ISO_CHAN_TYPE_BROADCASTER
-						 : BT_ISO_CHAN_TYPE_SYNC_RECEIVER;
-		bis->iso->iso.bis_id = bt_conn_index(bis->iso);
+		iso_conn->big_handle = big->handle;
+		iso_conn->type = broadcaster ? BT_ISO_CHAN_TYPE_BROADCASTER
+					     : BT_ISO_CHAN_TYPE_SYNC_RECEIVER;
+		iso_conn->bis_id = bt_conn_index(bis->iso);
 
 		bt_iso_chan_add(bis->iso, bis);
 

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -307,18 +307,16 @@ static int bt_iso_setup_data_path(struct bt_conn *iso)
 		out_path = &disabled_path;
 	}
 
-	if (iso->iso.is_bis) {
-		/* Only set one data path for BIS as per the spec */
-		if (tx_qos) {
-			dir = BT_HCI_DATAPATH_DIR_HOST_TO_CTLR;
-			return hci_le_setup_iso_data_path(iso, dir, in_path);
-
-		} else {
-			dir = BT_HCI_DATAPATH_DIR_CTLR_TO_HOST;
-			return hci_le_setup_iso_data_path(iso, dir, out_path);
-		}
-
-	} else {
+	if (IS_ENABLED(CONFIG_BT_ISO_BROADCASTER) &&
+	    iso->iso.type == BT_ISO_CHAN_TYPE_BROADCASTER && tx_qos) {
+		dir = BT_HCI_DATAPATH_DIR_HOST_TO_CTLR;
+		return hci_le_setup_iso_data_path(iso, dir, in_path);
+	} else if (IS_ENABLED(CONFIG_BT_ISO_SYNC_RECEIVER) &&
+		   iso->iso.type == BT_ISO_CHAN_TYPE_SYNC_RECEIVER) {
+		dir = BT_HCI_DATAPATH_DIR_CTLR_TO_HOST;
+		return hci_le_setup_iso_data_path(iso, dir, out_path);
+	} else if (IS_ENABLED(CONFIG_BT_ISO_UNICAST) &&
+		   iso->iso.type == BT_ISO_CHAN_TYPE_CONNECTED) {
 		/* Setup both directions for CIS*/
 		dir = BT_HCI_DATAPATH_DIR_HOST_TO_CTLR;
 		err = hci_le_setup_iso_data_path(iso, dir, in_path);
@@ -328,6 +326,9 @@ static int bt_iso_setup_data_path(struct bt_conn *iso)
 
 		dir = BT_HCI_DATAPATH_DIR_CTLR_TO_HOST;
 		return hci_le_setup_iso_data_path(iso, dir, out_path);
+	} else {
+		__ASSERT(false, "Invalid iso.type: %u", iso->iso.type);
+		return -EINVAL;
 	}
 }
 
@@ -346,7 +347,8 @@ void bt_iso_connected(struct bt_conn *iso)
 	if (bt_iso_setup_data_path(iso)) {
 		BT_ERR("Unable to setup data path");
 #if defined(CONFIG_BT_ISO_BROADCAST)
-		if (iso->iso.is_bis) {
+		if (iso->iso.type == BT_ISO_CHAN_TYPE_BROADCASTER ||
+		    iso->iso.type == BT_ISO_CHAN_TYPE_SYNC_RECEIVER) {
 			struct bt_iso_big *big;
 			int err;
 
@@ -356,11 +358,14 @@ void bt_iso_connected(struct bt_conn *iso)
 			if (err != 0) {
 				BT_ERR("Could not terminate BIG: %d", err);
 			}
-		} else if (IS_ENABLED(CONFIG_BT_ISO_UNICAST))
+		}
 #endif /* CONFIG_BT_ISO_BROADCAST */
-		{
+		if (IS_ENABLED(CONFIG_BT_ISO_UNICAST) &&
+		    iso->iso.type == BT_ISO_CHAN_TYPE_CONNECTED) {
 			bt_conn_disconnect(iso,
 					   BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+		} else {
+			__ASSERT(false, "Invalid iso.type: %u", iso->iso.type);
 		}
 		return;
 	}
@@ -382,7 +387,10 @@ static void bt_iso_remove_data_path(struct bt_conn *iso)
 {
 	BT_DBG("%p", iso);
 
-	if (iso->iso.is_bis) {
+	if ((IS_ENABLED(CONFIG_BT_ISO_BROADCASTER) &&
+		iso->iso.type == BT_ISO_CHAN_TYPE_BROADCASTER) ||
+	    (IS_ENABLED(CONFIG_BT_ISO_SYNC_RECEIVER) &&
+		iso->iso.type == BT_ISO_CHAN_TYPE_SYNC_RECEIVER)) {
 		struct bt_iso_chan *chan;
 		struct bt_iso_chan_io_qos *tx_qos;
 		uint8_t dir;
@@ -402,7 +410,8 @@ static void bt_iso_remove_data_path(struct bt_conn *iso)
 		}
 
 		(void)hci_le_remove_iso_data_path(iso, dir);
-	} else {
+	} else if (IS_ENABLED(CONFIG_BT_ISO_UNICAST) &&
+		   iso->iso.type == BT_ISO_CHAN_TYPE_CONNECTED) {
 		/* Remove both directions for CIS*/
 
 		/* TODO: Check which has been setup first to avoid removing
@@ -412,6 +421,8 @@ static void bt_iso_remove_data_path(struct bt_conn *iso)
 						  BT_HCI_DATAPATH_DIR_CTLR_TO_HOST);
 		(void)hci_le_remove_iso_data_path(iso,
 						  BT_HCI_DATAPATH_DIR_HOST_TO_CTLR);
+	} else {
+		__ASSERT(false, "Invalid iso.type: %u", iso->iso.type);
 	}
 }
 
@@ -426,7 +437,8 @@ static void bt_iso_chan_disconnected(struct bt_iso_chan *chan, uint8_t reason)
 	/* The peripheral does not have the concept of a CIG, so once a CIS
 	 * disconnects it is completely freed by unref'ing it
 	 */
-	if (IS_ENABLED(CONFIG_BT_ISO_UNICAST) && !chan->iso->iso.is_bis) {
+	if (IS_ENABLED(CONFIG_BT_ISO_UNICAST) &&
+	    chan->iso->iso.type == BT_ISO_CHAN_TYPE_CONNECTED) {
 		bt_iso_cleanup_acl(chan->iso);
 
 		if (chan->iso->role == BT_HCI_ROLE_PERIPHERAL) {
@@ -1144,7 +1156,7 @@ static int cig_init_cis(struct bt_iso_cig *cig,
 			}
 
 			cis->iso->iso.cig_id = cig->id;
-			cis->iso->iso.is_bis = false;
+			cis->iso->iso.type = BT_ISO_CHAN_TYPE_CONNECTED;
 			cis->iso->iso.cis_id = cig->num_cis++;
 
 			bt_iso_chan_add(cis->iso, cis);
@@ -1681,7 +1693,8 @@ static int big_init_bis(struct bt_iso_big *big,
 		}
 
 		bis->iso->iso.big_handle = big->handle;
-		bis->iso->iso.is_bis = true;
+		bis->iso->iso.type = broadcaster ? BT_ISO_CHAN_TYPE_BROADCASTER
+						 : BT_ISO_CHAN_TYPE_SYNC_RECEIVER;
 		bis->iso->iso.bis_id = bt_conn_index(bis->iso);
 
 		bt_iso_chan_add(bis->iso, bis);


### PR DESCRIPTION
Implements bt_iso_chan_get_info such that the application may get information about a bt_iso_chan object. 

fixes https://github.com/zephyrproject-rtos/zephyr/issues/41595