### PR TITLE
boards: xtensa: Use a CMake variable to set the rimage target name

### DIFF
--- a/boards/xtensa/intel_adsp_cavs15/board.cmake
+++ b/boards/xtensa/intel_adsp_cavs15/board.cmake
@@ -2,3 +2,5 @@
 
 board_set_flasher_ifnset(misc-flasher)
 board_finalize_runner_args(misc-flasher)
+
+board_set_rimage_target(apl)

--- a/boards/xtensa/intel_adsp_cavs18/board.cmake
+++ b/boards/xtensa/intel_adsp_cavs18/board.cmake
@@ -2,3 +2,5 @@
 
 board_set_flasher_ifnset(misc-flasher)
 board_finalize_runner_args(misc-flasher)
+
+board_set_rimage_target(cnl)

--- a/boards/xtensa/intel_adsp_cavs20/board.cmake
+++ b/boards/xtensa/intel_adsp_cavs20/board.cmake
@@ -2,3 +2,5 @@
 
 board_set_flasher_ifnset(misc-flasher)
 board_finalize_runner_args(misc-flasher)
+
+board_set_rimage_target(icl)

--- a/boards/xtensa/intel_adsp_cavs25/board.cmake
+++ b/boards/xtensa/intel_adsp_cavs25/board.cmake
@@ -2,3 +2,5 @@
 
 board_set_flasher_ifnset(misc-flasher)
 board_finalize_runner_args(misc-flasher)
+
+board_set_rimage_target(tgl)

--- a/boards/xtensa/nxp_adsp_imx8/board.cmake
+++ b/boards/xtensa/nxp_adsp_imx8/board.cmake
@@ -2,3 +2,5 @@
 
 board_set_flasher_ifnset(misc-flasher)
 board_finalize_runner_args(misc-flasher)
+
+board_set_rimage_target(imx8)

--- a/boards/xtensa/nxp_adsp_imx8m/board.cmake
+++ b/boards/xtensa/nxp_adsp_imx8m/board.cmake
@@ -2,3 +2,5 @@
 
 board_set_flasher_ifnset(misc-flasher)
 board_finalize_runner_args(misc-flasher)
+
+board_set_rimage_target(imx8m)

--- a/boards/xtensa/nxp_adsp_imx8x/board.cmake
+++ b/boards/xtensa/nxp_adsp_imx8x/board.cmake
@@ -2,3 +2,5 @@
 
 board_set_flasher_ifnset(misc-flasher)
 board_finalize_runner_args(misc-flasher)
+
+board_set_rimage_target(imx8)

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -825,6 +825,11 @@ function(board_finalize_runner_args runner)
   set_property(GLOBAL APPEND PROPERTY ZEPHYR_RUNNERS ${runner})
 endfunction()
 
+function(board_set_rimage_target target)
+  zephyr_check_cache(RIMAGE_TARGET)
+  set(RIMAGE_TARGET ${target} CACHE STRING "rimage target")
+endfunction()
+
 # Zephyr board revision:
 #
 # This section provides a function for revision checking.

--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -390,25 +390,6 @@ class ImgtoolSigner(Signer):
 
 class RimageSigner(Signer):
 
-    @staticmethod
-    def edt_get_rimage_target(board):
-        if 'intel_adsp_cavs15' in board:
-            return 'apl'
-        if 'intel_adsp_cavs18' in board:
-            return 'cnl'
-        if 'intel_adsp_cavs20' in board:
-            return 'icl'
-        if 'intel_adsp_cavs25' in board:
-            return 'tgl'
-        if 'nxp_adsp_imx8m' in board:
-            return 'imx8m'
-        if 'nxp_adsp_imx8x' in board:
-            return 'imx8'
-        if 'nxp_adsp_imx8' in board:
-            return 'imx8'
-
-        log.die('Signing not supported for board ' + board)
-
     def sign(self, command, build_dir, build_conf, formats):
         args = command.args
 
@@ -426,9 +407,10 @@ class RimageSigner(Signer):
         b = pathlib.Path(build_dir)
         cache = CMakeCache.from_build_dir(build_dir)
 
-        board = cache['CACHED_BOARD']
-        log.inf('Signing for board ' + board)
-        target = self.edt_get_rimage_target(board)
+        target = cache.get('RIMAGE_TARGET')
+        if not target:
+            log.die('rimage target not defined')
+
         conf = target + '.toml'
         log.inf('Signing for SOC target ' + target + ' using ' + conf)
 


### PR DESCRIPTION
Removes hardcoded logic in the west signing script that translates
Zephyr board names to rimage target names. Instead, use a cached CMake
variable set at the board level to define its respective rimage target
name. This eliminates the need to modify the west signing script when
new SOF-supported boards are introduced to Zephyr.

Signed-off-by: Maureen Helm <maureen.helm@intel.com>

Fixes #39604