### PR TITLE
coding guidelines: partially comply with MISRA C:2012 Rule 10.2

### DIFF
--- a/lib/libc/minimal/source/stdlib/strtol.c
+++ b/lib/libc/minimal/source/stdlib/strtol.c
@@ -98,9 +98,9 @@ long strtol(const char *nptr, char **endptr, register int base)
 	cutoff /= (unsigned long)base;
 	for (acc = 0, any = 0;; c = *s++) {
 		if (isdigit((unsigned char)c)) {
-			c -= '0';
+			c = (char)c - '0';
 		} else if (isalpha((unsigned char)c)) {
-			c -= isupper((unsigned char)c) ? 'A' - 10 : 'a' - 10;
+			c = (char)c - (isupper(c) ? 'A' : 'a') + 10;
 		} else {
 			break;
 		}

--- a/lib/libc/minimal/source/stdlib/strtoul.c
+++ b/lib/libc/minimal/source/stdlib/strtoul.c
@@ -79,9 +79,9 @@ unsigned long strtoul(const char *nptr, char **endptr, register int base)
 	cutlim = (unsigned long)ULONG_MAX % (unsigned long)base;
 	for (acc = 0, any = 0;; c = *s++) {
 		if (isdigit((unsigned char)c)) {
-			c -= '0';
+			c = (char)c - '0';
 		} else if (isalpha((unsigned char)c)) {
-			c -= isupper((unsigned char)c) ? 'A' - 10 : 'a' - 10;
+			c = (char)c - (isupper(c) ? 'A' : 'a') + 10;
 		} else {
 			break;
 		}

--- a/lib/os/dec.c
+++ b/lib/os/dec.c
@@ -15,7 +15,7 @@ uint8_t u8_to_dec(char *buf, uint8_t buflen, uint8_t value)
 	while (buflen > 0 && divisor > 0) {
 		digit = value / divisor;
 		if (digit != 0 || divisor == 1 || num_digits != 0) {
-			*buf = (char)digit + '0';
+			*buf = digit + '0';
 			buf++;
 			buflen--;
 			num_digits++;


### PR DESCRIPTION
MISRA C:2012 Rule 10.2 (Expressions of essentially character type
shall not be used inappropriately in addition and subtraction
operations.)

Use the compliant form char - integer instead of the non-compliant
one integer - char.

Signed-off-by: Abramo Bagnara <abramo.bagnara@bugseng.com>