### PR TITLE
Bluetooth: GATT: Document some macro arguments

### DIFF
--- a/doc/build/kconfig/setting.rst
+++ b/doc/build/kconfig/setting.rst
@@ -45,7 +45,7 @@ between *visible* and *invisible* symbols.
   direct control over their value. They instead get their value from defaults
   or from other symbols.
 
-  Here's an example or an invisible symbol:
+  Here's an example of an invisible symbol:
 
   .. code-block:: none
 

--- a/doc/develop/application/index.rst
+++ b/doc/develop/application/index.rst
@@ -1134,7 +1134,7 @@ boilerplate with ``find_package(Zephyr ...)``.
 .. note::
 
    When specifying ``BOARD_ROOT`` in a CMakeLists.txt, then an absolute path must
-   be provided, for example ``list(APPEND BOARD_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/<extra-board-root>``.
+   be provided, for example ``list(APPEND BOARD_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/<extra-board-root>)``.
    When using ``-DBOARD_ROOT=<board-root>`` both absolute and relative paths can
    be used. Relative paths are treated relatively to the application directory.
 

--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -30,7 +30,7 @@ extern "C" {
 #endif
 
 /** GATT attribute permission bit field values */
-enum {
+enum bt_gatt_perm {
 	/** No operations supported, e.g. for notify-only */
 	BT_GATT_PERM_NONE = 0,
 
@@ -108,44 +108,54 @@ enum {
 	BT_GATT_WRITE_FLAG_EXECUTE = BIT(2),
 };
 
+/* Forward declaration of GATT Attribute structure */
+struct bt_gatt_attr;
+
+/** @typedef bt_gatt_attr_read_func_t
+ *  @brief Attribute read callback
+ *
+ *  The callback can also be used locally to read the contents of the
+ *  attribute in which case no connection will be set.
+ *
+ *  @param conn   The connection that is requesting to read
+ *  @param attr   The attribute that's being read
+ *  @param buf    Buffer to place the read result in
+ *  @param len    Length of data to read
+ *  @param offset Offset to start reading from
+ *
+ *  @return Number of bytes read, or in case of an error
+ *          BT_GATT_ERR() with a specific ATT error code.
+ */
+typedef ssize_t (*bt_gatt_attr_read_func_t)(struct bt_conn *conn,
+					    const struct bt_gatt_attr *attr,
+					    void *buf, uint16_t len,
+					    uint16_t offset);
+
+/** @typedef bt_gatt_attr_write_func_t
+ *  @brief Attribute write callback
+ *
+ *  @param conn   The connection that is requesting to write
+ *  @param attr   The attribute that's being written
+ *  @param buf    Buffer with the data to write
+ *  @param len    Number of bytes in the buffer
+ *  @param offset Offset to start writing from
+ *  @param flags  Flags (BT_GATT_WRITE_FLAG_*)
+ *
+ *  @return Number of bytes written, or in case of an error
+ *          BT_GATT_ERR() with a specific ATT error code.
+ */
+typedef ssize_t (*bt_gatt_attr_write_func_t)(struct bt_conn *conn,
+					     const struct bt_gatt_attr *attr,
+					     const void *buf, uint16_t len,
+					     uint16_t offset, uint8_t flags);
+
 /** @brief GATT Attribute structure. */
 struct bt_gatt_attr {
 	/** Attribute UUID */
 	const struct bt_uuid *uuid;
-
-	/** @brief Attribute read callback
-	 *
-	 *  The callback can also be used locally to read the contents of the
-	 *  attribute in which case no connection will be set.
-	 *
-	 *  @param conn   The connection that is requesting to read
-	 *  @param attr   The attribute that's being read
-	 *  @param buf    Buffer to place the read result in
-	 *  @param len    Length of data to read
-	 *  @param offset Offset to start reading from
-	 *
-	 *  @return Number fo bytes read, or in case of an error
-	 *          BT_GATT_ERR() with a specific ATT error code.
-	 */
-	ssize_t (*read)(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-			void *buf, uint16_t len, uint16_t offset);
-
-	/** @brief Attribute write callback
-	 *
-	 *  @param conn   The connection that is requesting to write
-	 *  @param attr   The attribute that's being written
-	 *  @param buf    Buffer with the data to write
-	 *  @param len    Number of bytes in the buffer
-	 *  @param offset Offset to start writing from
-	 *  @param flags  Flags (BT_GATT_WRITE_FLAG_*)
-	 *
-	 *  @return Number of bytes written, or in case of an error
-	 *          BT_GATT_ERR() with a specific ATT error code.
-	 */
-	ssize_t	(*write)(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-			 const void *buf, uint16_t len, uint16_t offset,
-			 uint8_t flags);
-
+	bt_gatt_attr_read_func_t read;
+	/** Attribute write callback */
+	bt_gatt_attr_write_func_t write;
 	/** Attribute user data */
 	void *user_data;
 	/** Attribute handle */
@@ -666,10 +676,14 @@ ssize_t bt_gatt_attr_read_chrc(struct bt_conn *conn,
  *  attribute value.
  *
  *  @param _uuid Characteristic attribute uuid.
- *  @param _props Characteristic attribute properties.
- *  @param _perm Characteristic Attribute access permissions.
- *  @param _read Characteristic Attribute read callback.
- *  @param _write Characteristic Attribute write callback.
+ *  @param _props Characteristic attribute properties,
+ *                a bitmap of BT_GATT_CHRC_* macros.
+ *  @param _perm Characteristic Attribute access permissions,
+ *               a bitmap of @ref bt_gatt_perm values.
+ *  @param _read Characteristic Attribute read callback
+ *               (@ref bt_gatt_attr_read_func_t).
+ *  @param _write Characteristic Attribute write callback
+ *                (@ref bt_gatt_attr_write_func_t).
  *  @param _user_data Characteristic Attribute user data.
  */
 #define BT_GATT_CHARACTERISTIC(_uuid, _props, _perm, _read, _write, _user_data) \
@@ -804,7 +818,8 @@ ssize_t bt_gatt_attr_write_ccc(struct bt_conn *conn,
  *  Helper macro to declare a Managed CCC attribute.
  *
  *  @param _ccc CCC attribute user data, shall point to a _bt_gatt_ccc.
- *  @param _perm CCC access permissions.
+ *  @param _perm CCC access permissions,
+ *               a bitmap of @ref bt_gatt_perm values.
  */
 #define BT_GATT_CCC_MANAGED(_ccc, _perm)				\
 	BT_GATT_ATTRIBUTE(BT_UUID_GATT_CCC, _perm,			\
@@ -817,7 +832,8 @@ ssize_t bt_gatt_attr_write_ccc(struct bt_conn *conn,
  *  Helper macro to declare a CCC attribute.
  *
  *  @param _changed Configuration changed callback.
- *  @param _perm CCC access permissions.
+ *  @param _perm CCC access permissions,
+ *               a bitmap of @ref bt_gatt_perm values.
  */
 #define BT_GATT_CCC(_changed, _perm)				\
 	BT_GATT_CCC_MANAGED(((struct _bt_gatt_ccc[])			\
@@ -881,7 +897,8 @@ ssize_t bt_gatt_attr_read_cud(struct bt_conn *conn,
  *  Helper macro to declare a CUD attribute.
  *
  *  @param _value User description NULL-terminated C string.
- *  @param _perm Descriptor attribute access permissions.
+ *  @param _perm Descriptor attribute access permissions,
+ *               a bitmap of @ref bt_gatt_perm values.
  */
 #define BT_GATT_CUD(_value, _perm)					\
 	BT_GATT_DESCRIPTOR(BT_UUID_GATT_CUD, _perm, bt_gatt_attr_read_cud, \
@@ -924,9 +941,12 @@ ssize_t bt_gatt_attr_read_cpf(struct bt_conn *conn,
  *  Helper macro to declare a descriptor attribute.
  *
  *  @param _uuid Descriptor attribute uuid.
- *  @param _perm Descriptor attribute access permissions.
- *  @param _read Descriptor attribute read callback.
- *  @param _write Descriptor attribute write callback.
+ *  @param _perm Descriptor attribute access permissions,
+ *               a bitmap of @ref bt_gatt_perm values.
+ *  @param _read Descriptor attribute read callback
+ *               (@ref bt_gatt_attr_read_func_t).
+ *  @param _write Descriptor attribute write callback
+ *                (@ref bt_gatt_attr_write_func_t).
  *  @param _user_data Descriptor attribute user data.
  */
 #define BT_GATT_DESCRIPTOR(_uuid, _perm, _read, _write, _user_data)	\
@@ -938,9 +958,10 @@ ssize_t bt_gatt_attr_read_cpf(struct bt_conn *conn,
  *  Helper macro to declare an attribute.
  *
  *  @param _uuid Attribute uuid.
- *  @param _perm Attribute access permissions.
- *  @param _read Attribute read callback.
- *  @param _write Attribute write callback.
+ *  @param _perm Attribute access permissions,
+ *               a bitmap of @ref bt_gatt_perm values.
+ *  @param _read Attribute read callback (@ref bt_gatt_attr_read_func_t).
+ *  @param _write Attribute write callback (@ref bt_gatt_attr_write_func_t).
  *  @param _user_data Attribute user data.
  */
 #define BT_GATT_ATTRIBUTE(_uuid, _perm, _read, _write, _user_data)	\

--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -137,7 +137,7 @@ struct bt_gatt_attr {
 	 *  @param buf    Buffer with the data to write
 	 *  @param len    Number of bytes in the buffer
 	 *  @param offset Offset to start writing from
-	 *  @param flags  Flags (BT_GATT_WRITE_*)
+	 *  @param flags  Flags (BT_GATT_WRITE_FLAG_*)
 	 *
 	 *  @return Number of bytes written, or in case of an error
 	 *          BT_GATT_ERR() with a specific ATT error code.

--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -124,7 +124,7 @@ struct bt_gatt_attr;
  *  @param offset Offset to start reading from
  *
  *  @return Number of bytes read, or in case of an error
- *          BT_GATT_ERR() with a specific ATT error code.
+ *          BT_GATT_ERR() with a specific BT_ATT_ERR_* error code.
  */
 typedef ssize_t (*bt_gatt_attr_read_func_t)(struct bt_conn *conn,
 					    const struct bt_gatt_attr *attr,
@@ -142,7 +142,7 @@ typedef ssize_t (*bt_gatt_attr_read_func_t)(struct bt_conn *conn,
  *  @param flags  Flags (BT_GATT_WRITE_FLAG_*)
  *
  *  @return Number of bytes written, or in case of an error
- *          BT_GATT_ERR() with a specific ATT error code.
+ *          BT_GATT_ERR() with a specific BT_ATT_ERR_* error code.
  */
 typedef ssize_t (*bt_gatt_attr_write_func_t)(struct bt_conn *conn,
 					     const struct bt_gatt_attr *attr,


### PR DESCRIPTION
Name some types in bluetooth/gatt.h and use those names to document the expected values of some of the BT_GATT_* macro arguments, in an attempt to make understanding the API a little easier.

BTW, could BT_GATT_CHRC_* macros be enum members instead?