### PR TITLE
MAINTAINERS: add jeremybettis as collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -219,6 +219,7 @@ Build system:
     maintainers:
         - tejlmand
     collaborators:
+        - jeremybettis
         - nashif
         - SebastianBoe
     files:
@@ -1748,6 +1749,8 @@ ZTest:
     status: maintained
     maintainers:
         - nashif
+    collaborators:
+        - jeremybettis
     files:
         - subsys/testsuite/
         - tests/ztest/


### PR DESCRIPTION
Add jeremybettis as a collaborator to the Build system and ZTest.

Signed-off-by: Keith Short <keithshort@google.com>