### PR TITLE
esp32 & esp32s2: lint: kconfig

### DIFF
--- a/soc/xtensa/esp32/Kconfig.soc
+++ b/soc/xtensa/esp32/Kconfig.soc
@@ -60,142 +60,147 @@ config ESP_HEAP_SEARCH_ALL_REGIONS
 menu "SPI RAM config"
 	depends on ESP_SPIRAM
 
-	choice SPIRAM_TYPE
-		prompt "Type of SPI RAM chip in use"
-		default SPIRAM_TYPE_ESPPSRAM16
+choice SPIRAM_TYPE
+	prompt "Type of SPI RAM chip in use"
+	default SPIRAM_TYPE_ESPPSRAM16
 
-		config SPIRAM_TYPE_ESPPSRAM16
-			bool "ESP-PSRAM16 or APS1604"
+config SPIRAM_TYPE_ESPPSRAM16
+	bool "ESP-PSRAM16 or APS1604"
 
-		config SPIRAM_TYPE_ESPPSRAM32
-			bool "ESP-PSRAM32 or IS25WP032"
+config SPIRAM_TYPE_ESPPSRAM32
+	bool "ESP-PSRAM32 or IS25WP032"
 
-		config SPIRAM_TYPE_ESPPSRAM64
-			bool "ESP-PSRAM64 or LY68L6400"
+config SPIRAM_TYPE_ESPPSRAM64
+	bool "ESP-PSRAM64 or LY68L6400"
 
-	endchoice
+endchoice # SPIRAM_TYPE
 
-	config ESP_SPIRAM_SIZE
-		int "Size of SPIRAM part"
-		default 2097152 if SPIRAM_TYPE_ESPPSRAM16
-		default 4194304 if SPIRAM_TYPE_ESPPSRAM32
-		default 8388608 if SPIRAM_TYPE_ESPPSRAM64
-		help
-		  Specify size of SPIRAM part.
-		  NOTE: If SPIRAM size is greater than 4MB, only
-		  lower 4MB can be allocated using k_malloc().
+config ESP_SPIRAM_SIZE
+	int "Size of SPIRAM part"
+	default 2097152 if SPIRAM_TYPE_ESPPSRAM16
+	default 4194304 if SPIRAM_TYPE_ESPPSRAM32
+	default 8388608 if SPIRAM_TYPE_ESPPSRAM64
+	help
+	  Specify size of SPIRAM part.
+	  NOTE: If SPIRAM size is greater than 4MB, only
+	  lower 4MB can be allocated using k_malloc().
 
-	choice SPIRAM_SPEED
-		prompt "Set RAM clock speed"
-		default SPIRAM_SPEED_40M
-		help
-		  Select the speed for the SPI RAM chip.
-		  If SPI RAM is enabled, we only support three combinations of SPI speed mode we supported now:
+choice SPIRAM_SPEED
+	prompt "Set RAM clock speed"
+	default SPIRAM_SPEED_40M
+	help
+	  Select the speed for the SPI RAM chip.
+	  If SPI RAM is enabled, we only support three combinations of SPI speed mode we supported now:
 
-		  1. Flash SPI running at 40Mhz and RAM SPI running at 40Mhz
-		  2. Flash SPI running at 80Mhz and RAM SPI running at 40Mhz
-		  3. Flash SPI running at 80Mhz and RAM SPI running at 80Mhz
+	  1. Flash SPI running at 40MHz and RAM SPI running at 40MHz
+	  2. Flash SPI running at 80MHz and RAM SPI running at 40MHz
+	  3. Flash SPI running at 80MHz and RAM SPI running at 80MHz
 
-		  Note: If the third mode(80Mhz+80Mhz) is enabled for SPI RAM of type 32MBit, one of the HSPI/VSPI host
-		  will be occupied by the system. Which SPI host to use can be selected by the config item
-		  SPIRAM_OCCUPY_SPI_HOST. Application code should never touch HSPI/VSPI hardware in this case. The
-		  option to select 80MHz will only be visible if the flash SPI speed is also 80MHz.
-		  (ESPTOOLPY_FLASHFREQ_79M is true)
+	  Note: If the third mode(80MHz+80MHz) is enabled for SPI RAM of type 32MBit, one of the HSPI/VSPI host
+	  will be occupied by the system. Which SPI host to use can be selected by the config item
+	  SPIRAM_OCCUPY_SPI_HOST. Application code should never touch HSPI/VSPI hardware in this case. The
+	  option to select 80MHz will only be visible if the flash SPI speed is also 80MHz.
+	  (ESPTOOLPY_FLASHFREQ_79M is true)
 
-		config SPIRAM_SPEED_40M
-		    bool "40MHz clock speed"
-		config SPIRAM_SPEED_80M
-			depends on ESPTOOLPY_FLASHFREQ_80M
-			bool "80MHz clock speed"
-	endchoice
+config SPIRAM_SPEED_40M
+	bool "40MHz clock speed"
 
-	menu "PSRAM clock and cs IO for ESP32-DOWD"
+config SPIRAM_SPEED_80M
+	depends on ESPTOOLPY_FLASHFREQ_80M
+	bool "80MHz clock speed"
 
-		config D0WD_PSRAM_CLK_IO
-			int "PSRAM CLK IO number"
-			range 0 33
-			default 17
-			help
-			  The PSRAM CLOCK IO can be any unused GPIO, user can config it based on hardware design. If user use
-			  1.8V flash and 1.8V psram, this value can only be one of 6, 7, 8, 9, 10, 11, 16, 17.
+endchoice # SPIRAM_SPEED
 
-		config D0WD_PSRAM_CS_IO
-			int "PSRAM CS IO number"
-			range 0 33
-			default 16
-			help
-			  The PSRAM CS IO can be any unused GPIO, user can config it based on hardware design. If user use
-			  1.8V flash and 1.8V psram, this value can only be one of 6, 7, 8, 9, 10, 11, 16, 17.
-	endmenu
+menu "PSRAM clock and cs IO for ESP32-DOWD"
 
-	menu "PSRAM clock and cs IO for ESP32-D2WD"
+config D0WD_PSRAM_CLK_IO
+	int "PSRAM CLK IO number"
+	range 0 33
+	default 17
+	help
+	  The PSRAM CLOCK IO can be any unused GPIO, user can config it based on hardware design. If user use
+	  1.8V flash and 1.8V psram, this value can only be one of 6, 7, 8, 9, 10, 11, 16, 17.
 
-		config D2WD_PSRAM_CLK_IO
-			int "PSRAM CLK IO number"
-			range 0 33
-			default 9
-			help
-			  User can config it based on hardware design. For ESP32-D2WD chip, the psram can only be 1.8V psram,
-			  so this value can only be one of 6, 7, 8, 9, 10, 11, 16, 17.
+config D0WD_PSRAM_CS_IO
+	int "PSRAM CS IO number"
+	range 0 33
+	default 16
+	help
+	  The PSRAM CS IO can be any unused GPIO, user can config it based on hardware design. If user use
+	  1.8V flash and 1.8V psram, this value can only be one of 6, 7, 8, 9, 10, 11, 16, 17.
 
-		config D2WD_PSRAM_CS_IO
-			int "PSRAM CS IO number"
-			range 0 33
-			default 10
-			help
-			  User can config it based on hardware design. For ESP32-D2WD chip, the psram can only be 1.8V psram,
-			  so this value can only be one of 6, 7, 8, 9, 10, 11, 16, 17.
-		endmenu
+endmenu # PSRAM clock and cs IO for ESP32-DOWD
 
-	menu "PSRAM clock and cs IO for ESP32-PICO"
+menu "PSRAM clock and cs IO for ESP32-D2WD"
 
-		config PICO_PSRAM_CS_IO
-			int "PSRAM CS IO number"
-			range 0 33
-			default 10
-			help
-			  The PSRAM CS IO can be any unused GPIO, user can config it based on hardware design.
+config D2WD_PSRAM_CLK_IO
+	int "PSRAM CLK IO number"
+	range 0 33
+	default 9
+	help
+	  User can config it based on hardware design. For ESP32-D2WD chip, the psram can only be 1.8V psram,
+	  so this value can only be one of 6, 7, 8, 9, 10, 11, 16, 17.
 
-			  For ESP32-PICO chip, the psram share clock with flash, so user do not need to configure the clock
-			  IO.
-			  For the reference hardware design, please refer to
-			  https://www.espressif.com/sites/default/files/documentation/esp32-pico-d4_datasheet_en.pdf
+config D2WD_PSRAM_CS_IO
+	int "PSRAM CS IO number"
+	range 0 33
+	default 10
+	help
+	  User can config it based on hardware design. For ESP32-D2WD chip, the psram can only be 1.8V psram,
+	  so this value can only be one of 6, 7, 8, 9, 10, 11, 16, 17.
 
-	endmenu
+endmenu # PSRAM clock and cs IO for ESP32-D2WD
 
-	config SPIRAM_CUSTOM_SPIWP_SD3_PIN
-		bool "Use custom SPI PSRAM WP(SD3) Pin when flash pins set in eFuse (read help)"
-		default y if SPIRAM_SPIWP_SD3_PIN != 7  # backwards compatibility, can remove in IDF 5
-		default n
-		help
-		  This setting is only used if the SPI flash pins have been overridden by setting the eFuses
-		  SPI_PAD_CONFIG_xxx, and the SPI flash mode is DIO or DOUT.
+menu "PSRAM clock and cs IO for ESP32-PICO"
 
-		  When this is the case, the eFuse config only defines 3 of the 4 Quad I/O data pins. The WP pin (aka
-		  ESP32 pin "SD_DATA_3" or SPI flash pin "IO2") is not specified in eFuse. The psram only has QPI
-		  mode, so a WP pin setting is necessary.
+config PICO_PSRAM_CS_IO
+	int "PSRAM CS IO number"
+	range 0 33
+	default 10
+	help
+	  The PSRAM CS IO can be any unused GPIO, user can config it based on hardware design.
 
-		  If this config item is set to N (default), the correct WP pin will be automatically used for any
-		  Espressif chip or module with integrated flash. If a custom setting is needed, set this config item
-		  to Y and specify the GPIO number connected to the WP pin.
+	  For ESP32-PICO chip, the psram share clock with flash, so user do not need to configure the clock
+	  IO.
+	  For the reference hardware design, please refer to
+	  https://www.espressif.com/sites/default/files/documentation/esp32-pico-d4_datasheet_en.pdf
 
-		  When flash mode is set to QIO or QOUT, the PSRAM WP pin will be set the same as the SPI Flash WP pin
-		  configured in the bootloader.
+endmenu # PSRAM clock and cs IO for ESP32-PICO
 
-	config SPIRAM_SPIWP_SD3_PIN
-		int "Custom SPI PSRAM WP(SD3) Pin"
-		range 0 33
-		default 7
-		help
-		  The option "Use custom SPI PSRAM WP(SD3) pin" must be set or this value is ignored
+config SPIRAM_CUSTOM_SPIWP_SD3_PIN
+	bool "Use custom SPI PSRAM WP(SD3) Pin when flash pins set in eFuse (read help)"
+	default y if SPIRAM_SPIWP_SD3_PIN != 7  # backwards compatibility, can remove in IDF 5
+	default n
+	help
+	  This setting is only used if the SPI flash pins have been overridden by setting the eFuses
+	  SPI_PAD_CONFIG_xxx, and the SPI flash mode is DIO or DOUT.
 
-		  If burning a customized set of SPI flash pins in eFuse and using DIO or DOUT mode for flash, set this
-		  value to the GPIO number of the SPIRAM WP pin.
+	  When this is the case, the eFuse config only defines 3 of the 4 Quad I/O data pins. The WP pin (aka
+	  ESP32 pin "SD_DATA_3" or SPI flash pin "IO2") is not specified in eFuse. The psram only has QPI
+	  mode, so a WP pin setting is necessary.
 
-	config SPIRAM
-		bool
-		default y
-endmenu
+	  If this config item is set to N (default), the correct WP pin will be automatically used for any
+	  Espressif chip or module with integrated flash. If a custom setting is needed, set this config item
+	  to Y and specify the GPIO number connected to the WP pin.
+
+	  When flash mode is set to QIO or QOUT, the PSRAM WP pin will be set the same as the SPI Flash WP pin
+	  configured in the bootloader.
+
+config SPIRAM_SPIWP_SD3_PIN
+	int "Custom SPI PSRAM WP(SD3) Pin"
+	range 0 33
+	default 7
+	help
+	  The option "Use custom SPI PSRAM WP(SD3) pin" must be set or this value is ignored
+
+	  If burning a customized set of SPI flash pins in eFuse and using DIO or DOUT mode for flash, set this
+	  value to the GPIO number of the SPIRAM WP pin.
+
+config SPIRAM
+	bool
+	default y
+
+endmenu # SPI RAM config
 
 choice ESP32_UNIVERSAL_MAC_ADDRESSES
 	bool "Number of universally administered (by IEEE) MAC address"
@@ -215,19 +220,19 @@ choice ESP32_UNIVERSAL_MAC_ADDRESSES
 	  When using a custom universal MAC address range, the correct setting will depend on the
 	  allocation of MAC addresses in this range (either 2 or 4 per device.)
 
-	config ESP32_UNIVERSAL_MAC_ADDRESSES_TWO
-		bool "Two"
-		select ESP_MAC_ADDR_UNIVERSE_WIFI_STA
-		select ESP_MAC_ADDR_UNIVERSE_BT
+config ESP32_UNIVERSAL_MAC_ADDRESSES_TWO
+	bool "Two"
+	select ESP_MAC_ADDR_UNIVERSE_WIFI_STA
+	select ESP_MAC_ADDR_UNIVERSE_BT
 
-	config ESP32_UNIVERSAL_MAC_ADDRESSES_FOUR
-		bool "Four"
-		select ESP_MAC_ADDR_UNIVERSE_WIFI_STA
-		select ESP_MAC_ADDR_UNIVERSE_WIFI_AP
-		select ESP_MAC_ADDR_UNIVERSE_BT
-		select ESP_MAC_ADDR_UNIVERSE_ETH
+config ESP32_UNIVERSAL_MAC_ADDRESSES_FOUR
+	bool "Four"
+	select ESP_MAC_ADDR_UNIVERSE_WIFI_STA
+	select ESP_MAC_ADDR_UNIVERSE_WIFI_AP
+	select ESP_MAC_ADDR_UNIVERSE_BT
+	select ESP_MAC_ADDR_UNIVERSE_ETH
 
-endchoice
+endchoice # ESP32_UNIVERSAL_MAC_ADDRESSES
 
 config ESP_MAC_ADDR_UNIVERSE_WIFI_AP
 	bool

--- a/soc/xtensa/esp32s2/Kconfig.soc
+++ b/soc/xtensa/esp32s2/Kconfig.soc
@@ -87,16 +87,16 @@ choice ESP32S2_UNIVERSAL_MAC_ADDRESSES
 	  When using a custom universal MAC address range, the correct setting will depend on the
 	  allocation of MAC addresses in this range (either 1 or 2 per device).
 
-	config ESP32S2_UNIVERSAL_MAC_ADDRESSES_ONE
-		bool "Two"
-		select ESP_MAC_ADDR_UNIVERSE_WIFI_STA
+config ESP32S2_UNIVERSAL_MAC_ADDRESSES_ONE
+	bool "Two"
+	select ESP_MAC_ADDR_UNIVERSE_WIFI_STA
 
-	config ESP32S2_UNIVERSAL_MAC_ADDRESSES_TWO
-		bool "Two"
-		select ESP_MAC_ADDR_UNIVERSE_WIFI_STA
-		select ESP_MAC_ADDR_UNIVERSE_WIFI_AP
+config ESP32S2_UNIVERSAL_MAC_ADDRESSES_TWO
+	bool "Two"
+	select ESP_MAC_ADDR_UNIVERSE_WIFI_STA
+	select ESP_MAC_ADDR_UNIVERSE_WIFI_AP
 
-endchoice
+endchoice # ESP32S2_UNIVERSAL_MAC_ADDRESSES
 
 config ESP_MAC_ADDR_UNIVERSE_WIFI_AP
 	bool


### PR DESCRIPTION
Fixes indentation of esp32 and esp32s2 `Kconfig.soc` files.