### PR TITLE
MAINTAINERS: add ppryga to Bluetooth controller collaborators

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -196,6 +196,7 @@ Bluetooth controller:
         - carlescufi
         - thoh-ot
         - kruithofa
+        - ppryga
     files:
         - subsys/bluetooth/controller/
     labels:


### PR DESCRIPTION
Add ppryga account to collaborator list of Bluetooth controller.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>