### PR TITLE
twister: fix the testcase-schema.yaml

### DIFF
--- a/scripts/schemas/twister/testcase-schema.yaml
+++ b/scripts/schemas/twister/testcase-schema.yaml
@@ -12,115 +12,115 @@ type: map
 mapping:
   "common":
     type: map
-    required: no
+    required: false
     mapping:
       "arch_exclude":
         type: str
-        required: no
+        required: false
       "arch_allow":
         type: str
-        required: no
+        required: false
       "build_only":
         type: bool
-        required: no
+        required: false
       "build_on_all":
         type: bool
-        required: no
+        required: false
       "depends_on":
         type: str
-        required: no
+        required: false
       "extra_args":
         type: str
-        required: no
+        required: false
       "extra_sections":
         type: str
-        required: no
+        required: false
       "filter":
         type: str
-        required: no
+        required: false
       "integration_platforms":
         type: seq
-        required: no
+        required: false
         sequence:
           - type: str
       "harness":
         type: str
-        required: no
+        required: false
       "harness_config":
         type: map
-        required: no
+        required: false
         mapping:
           "type":
             type: str
-            required: no
+            required: false
           "fixture":
             type: str
-            required: no
+            required: false
           "ordered":
             type: bool
-            required: no
+            required: false
           "repeat":
             type: int
-            required: no
+            required: false
           "pytest_root":
             type: str
-            required: no
+            required: false
           "regex":
             type: seq
-            required: no
+            required: false
             sequence:
               - type: str
           "record":
             type: map
-            required: no
+            required: false
             mapping:
               "regex":
                 type: str
-                required: no
+                required: false
       "min_ram":
         type: int
-        required: no
+        required: false
       "min_flash":
         type: int
-        required: no
+        required: false
       "platform_exclude":
         type: str
-        required: no
+        required: false
       "platform_allow":
         type: str
-        required: no
+        required: false
       "tags":
         type: str
-        required: no
+        required: false
       "timeout":
         type: int
-        required: no
+        required: false
       "toolchain_exclude":
         type: str
-        required: no
+        required: false
       "toolchain_allow":
         type: str
-        required: no
+        required: false
       "type":
         type: str
         enum: ["unit"]
       "skip":
         type: bool
-        required: no
+        required: false
       "slow":
         type: bool
-        required: no
+        required: false
   # The sample descriptor, if present
   "sample":
     type: map
-    required: no
+    required: false
     mapping:
       "name":
         type: str
-        required: yes
+        required: true
       "description":
         type: str
-        required: no
+        required: false
   # The list of testcases -- IDK why this is a sequence of
   # maps maps, shall just be a sequence of maps
   # maybe it is just an artifact?
@@ -129,112 +129,112 @@ mapping:
     matching-rule: "any"
     mapping:
       # The key for the testname is any, so
-      # regex;(([a-zA-Z0-9_]+)) for this to work, note below we
-      # make it required: no
+      # regex;(([a-zA-Z0-9_]+)) for this to work, falsete below we
+      # make it required: false
       regex;(([a-zA-Z0-9_]+)):
         type: map
-        # has to be not-required, otherwise the parser gets
+        # has to be falset-required, otherwise the parser gets
         # confused and things it never found it
-        required: no
+        required: false
         mapping:
           "arch_exclude":
             type: str
-            required: no
+            required: false
           "arch_allow":
             type: str
-            required: no
+            required: false
           "build_only":
             type: bool
-            required: no
+            required: false
           "build_on_all":
             type: bool
-            required: no
+            required: false
           "depends_on":
             type: str
-            required: no
+            required: false
           "extra_args":
             type: str
-            required: no
+            required: false
           "extra_configs":
             type: seq
-            required: no
+            required: false
             sequence:
               - type: str
           "extra_sections":
             type: str
-            required: no
+            required: false
           "filter":
             type: str
-            required: no
+            required: false
           "integration_platforms":
             type: seq
-            required: no
+            required: false
             sequence:
               - type: str
           "harness":
             type: str
-            required: no
+            required: false
           "harness_config":
             type: map
-            required: no
+            required: false
             mapping:
               "type":
                 type: str
-                required: no
+                required: false
               "fixture":
                 type: str
-                required: no
+                required: false
               "ordered":
                 type: bool
-                required: no
+                required: false
               "repeat":
                 type: int
-                required: no
+                required: false
               "pytest_root":
                 type: str
-                required: no
+                required: false
               "regex":
                 type: seq
-                required: no
+                required: false
                 sequence:
                   - type: str
               "record":
                 type: map
-                required: no
+                required: false
                 mapping:
                   "regex":
                     type: str
-                    required: no
+                    required: false
           "min_ram":
             type: int
-            required: no
+            required: false
           "min_flash":
             type: int
-            required: no
+            required: false
           "platform_exclude":
             type: str
-            required: no
+            required: false
           "platform_allow":
             type: str
-            required: no
+            required: false
           "tags":
             type: str
-            required: no
+            required: false
           "timeout":
             type: int
-            required: no
+            required: false
           "toolchain_exclude":
             type: str
-            required: no
+            required: false
           "toolchain_allow":
             type: str
-            required: no
+            required: false
           "type":
             type: str
             enum: ["unit"]
           "skip":
             type: bool
-            required: no
+            required: false
           "slow":
             type: bool
-            required: no
+            required: false


### PR DESCRIPTION
Change the "yes/no" value to "true/false".
Otherwise pykwalify 1.8.0 will report below errors when loading the schema:
- Value: 'no' for required keyword must be a boolean: Path: '/mapping/common'>
- Value: 'yes' for required keyword must be a boolean: Path: '/mapping/sample/mapping/name'>

Signed-off-by: Shao Ming <ming.shao@intel.com>