### PR TITLE
ISO broadcast tx complete fix

### DIFF
--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -133,6 +133,12 @@ config BT_MAX_CONN
 	  Maximum number of simultaneous Bluetooth connections
 	  supported.
 
+config BT_CONN_TX
+	bool
+	default BT_CONN || BT_ISO_BROADCASTER
+	help
+	  Hidden configuration that is true if ACL or broadcast ISO is enabled
+
 if BT_CONN
 config BT_HCI_ACL_FLOW_CONTROL
 	bool "Controller to Host ACL flow control support"

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -46,7 +46,9 @@ struct tx_meta {
 #define tx_data(buf) ((struct tx_meta *)net_buf_user_data(buf))
 K_FIFO_DEFINE(free_tx);
 
+#if defined(CONFIG_BT_CONN_TX)
 static void tx_complete_work(struct k_work *work);
+#endif /* CONFIG_BT_CONN_TX */
 
 /* Group Connected BT_CONN only in this */
 #if defined(CONFIG_BT_CONN)
@@ -214,7 +216,9 @@ struct bt_conn *bt_conn_new(struct bt_conn *conns, size_t size)
 #if defined(CONFIG_BT_CONN)
 	k_work_init_delayable(&conn->deferred_work, deferred_work);
 #endif /* CONFIG_BT_CONN */
+#if defined(CONFIG_BT_CONN_TX)
 	k_work_init(&conn->tx_complete_work, tx_complete_work);
+#endif /* CONFIG_BT_CONN_TX */
 
 	return conn;
 }
@@ -1196,6 +1200,7 @@ struct net_buf *bt_conn_create_pdu_timeout(struct net_buf_pool *pool,
 	return buf;
 }
 
+#if defined(CONFIG_BT_CONN_TX)
 static void tx_complete_work(struct k_work *work)
 {
 	struct bt_conn *conn = CONTAINER_OF(work, struct bt_conn,
@@ -1205,6 +1210,7 @@ static void tx_complete_work(struct k_work *work)
 
 	tx_notify(conn);
 }
+#endif /* CONFIG_BT_CONN_TX */
 
 /* Group Connected BT_CONN only in this */
 #if defined(CONFIG_BT_CONN)

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -7,6 +7,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
 typedef enum __packed {
 	BT_CONN_DISCONNECTED,
 	BT_CONN_DISCONNECT_COMPLETE,
@@ -177,8 +178,9 @@ struct bt_conn {
 
 	/* Completed TX for which we need to call the callback */
 	sys_slist_t		tx_complete;
+#if defined(CONFIG_BT_CONN_TX)
 	struct k_work           tx_complete_work;
-
+#endif /* CONFIG_BT_CONN_TX */
 
 	/* Queue for outgoing ACL data */
 	struct k_fifo		tx_queue;

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -362,7 +362,7 @@ uint8_t bt_get_phy(uint8_t hci_phy)
 	}
 }
 
-#if defined(CONFIG_BT_CONN) || defined(CONFIG_BT_ISO)
+#if defined(CONFIG_BT_CONN_TX)
 static void hci_num_completed_packets(struct net_buf *buf)
 {
 	struct bt_hci_evt_num_completed_packets *evt = (void *)buf->data;
@@ -422,7 +422,7 @@ static void hci_num_completed_packets(struct net_buf *buf)
 		bt_conn_unref(conn);
 	}
 }
-#endif /* CONFIG_BT_CONN || CONFIG_BT_ISO */
+#endif /* CONFIG_BT_CONN_TX */
 
 #if defined(CONFIG_BT_CONN)
 static void hci_acl(struct net_buf *buf)
@@ -3339,11 +3339,11 @@ static const struct event_handler prio_events[] = {
 	EVENT_HANDLER(BT_HCI_EVT_DISCONN_COMPLETE, hci_disconn_complete_prio,
 		      sizeof(struct bt_hci_evt_disconn_complete)),
 #endif /* CONFIG_BT_CONN */
-#if defined(CONFIG_BT_CONN) || defined(CONFIG_BT_ISO)
+#if defined(CONFIG_BT_CONN_TX)
 	EVENT_HANDLER(BT_HCI_EVT_NUM_COMPLETED_PACKETS,
 		      hci_num_completed_packets,
 		      sizeof(struct bt_hci_evt_num_completed_packets)),
-#endif /* CONFIG_BT_CONN || CONFIG_BT_ISO */
+#endif /* CONFIG_BT_CONN_TX */
 };
 
 void hci_event_prio(struct net_buf *buf)


### PR DESCRIPTION
Fixes an issue with ISO broadcast only builds, where the lack of tx_complete_work caused a fatal error as that is needed for the ISO `sent` callback. 