### PR TITLE
tests: controller: remove outdated comment

### DIFF
--- a/tests/bluetooth/controller/ctrl_api/src/main.c
+++ b/tests/bluetooth/controller/ctrl_api/src/main.c
@@ -8,8 +8,6 @@
 #include <ztest.h>
 #include "kconfig.h"
 
-/* Kconfig Cheats */
-
 #include <bluetooth/hci.h>
 #include <sys/byteorder.h>
 #include <sys/slist.h>

--- a/tests/bluetooth/controller/ctrl_min_used_chans/src/main.c
+++ b/tests/bluetooth/controller/ctrl_min_used_chans/src/main.c
@@ -8,8 +8,6 @@
 #include <ztest.h>
 #include "kconfig.h"
 
-/* Kconfig Cheats */
-
 #include <bluetooth/hci.h>
 #include <sys/byteorder.h>
 #include <sys/slist.h>

--- a/tests/bluetooth/controller/ctrl_terminate/src/main.c
+++ b/tests/bluetooth/controller/ctrl_terminate/src/main.c
@@ -9,8 +9,6 @@
 #include <ztest.h>
 #include "kconfig.h"
 
-/* Kconfig Cheats */
-
 #include <bluetooth/hci.h>
 #include <sys/byteorder.h>
 #include <sys/slist.h>

--- a/tests/bluetooth/controller/ctrl_version/src/main.c
+++ b/tests/bluetooth/controller/ctrl_version/src/main.c
@@ -8,8 +8,6 @@
 #include <ztest.h>
 #include "kconfig.h"
 
-/* Kconfig Cheats */
-
 #include <bluetooth/hci.h>
 #include <sys/byteorder.h>
 #include <sys/slist.h>


### PR DESCRIPTION
The comment 'kconfig cheats' is outdated and misleading
and thus it must be removed

Signed-off-by: Andries Kruithof <Andries.Kruithof@nordicsemi.no>