### PR TITLE
Bluetooth: Controller: Fix ISO Sync anchor point PDU CRC ok

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
@@ -124,6 +124,9 @@ uint8_t ll_big_sync_create(uint8_t big_handle, uint16_t sync_handle,
 	lll->latency_event = 0U;
 	lll->window_widening_prepare_us = 0U;
 	lll->window_widening_event_us = 0U;
+	lll->ctrl = 0U;
+	lll->cssn_curr = 0U;
+	lll->cssn_next = 0U;
 
 	/* Initialize ULL and LLL headers */
 	ull_hdr_init(&sync_iso->ull);


### PR DESCRIPTION
Fix ISO Sync implementation to use the CRC ok status of
anchor point PDU, and not the last PDU receive, when
generating the event done message.

Without this fix, ISO sync is lost if there is continous
CRC error in the last PDU before the event is done.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>