### PR TITLE
Bluetooth: Controller: ISO Sync payload number and timestamp

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -6425,7 +6425,7 @@ static void le_big_sync_established(struct pdu_data *pdu,
 	sep->pto = lll->pto;
 	sep->irc = lll->irc;
 	sep->max_pdu = sys_cpu_to_le16(lll->max_pdu);
-	sep->iso_interval = sys_cpu_to_le16(sync_iso->iso_interval);
+	sep->iso_interval = sys_cpu_to_le16(lll->iso_interval);
 	sep->num_bis = lll->num_bis;
 
 	/* FIXME: Connection handle list of all BISes in the BIG */

--- a/subsys/bluetooth/controller/ll_sw/lll_sync_iso.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_sync_iso.h
@@ -10,6 +10,8 @@ struct lll_sync_iso {
 	uint8_t seed_access_addr[4];
 	uint8_t base_crc_init[2];
 
+	uint16_t iso_interval;
+
 	uint16_t latency_prepare;
 	uint16_t latency_event;
 	uint16_t data_chan_prn_s;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
@@ -460,20 +460,23 @@ static void isr_rx(void *param)
 		if (!lll->payload[payload_index] &&
 		    ((payload_index >= lll->payload_tail) ||
 		     (payload_index < lll->payload_head))) {
-			struct node_rx_ftr *ftr;
+			struct node_rx_iso_meta *iso_meta;
 
 			ull_pdu_rx_alloc();
 
 			node_rx->hdr.type = NODE_RX_TYPE_SYNC_ISO_PDU;
 
-			ftr = &(node_rx->hdr.rx_ftr);
-			ftr->param = lll;
-			ftr->rssi = (rssi_ready) ? radio_rssi_get() :
-						   BT_HCI_LE_RSSI_NOT_AVAILABLE;
-			ftr->ticks_anchor = radio_tmr_start_get();
-			ftr->radio_end_us = radio_tmr_end_get() -
-					    radio_rx_chain_delay_get(lll->phy,
-								     PHY_FLAGS_S8);
+			iso_meta = &node_rx->hdr.rx_iso_meta;
+			iso_meta->payload_number = (lll->payload_count +
+						    (lll->ptc_curr *
+						     lll->pto) - 1U) /
+						   lll->bn;
+			iso_meta->timestamp =
+				HAL_TICKER_TICKS_TO_US(radio_tmr_start_get()) +
+				radio_tmr_aa_restore() - addr_us_get(lll->phy) +
+				(ceiling_fraction(lll->ptc_curr, lll->bn) *
+				 lll->iso_interval * CONN_INT_UNIT_US);
+			iso_meta->status = 0U;
 
 			lll->payload[payload_index] = node_rx;
 		}

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
@@ -327,8 +327,8 @@ void ull_sync_iso_setup(struct ll_sync_iso_set *sync_iso,
 		lll->payload[i] = NULL;
 	}
 
-	sync_iso->iso_interval = sys_le16_to_cpu(bi->iso_interval);
-	interval_us = sync_iso->iso_interval * CONN_INT_UNIT_US;
+	lll->iso_interval = sys_le16_to_cpu(bi->iso_interval);
+	interval_us = lll->iso_interval * CONN_INT_UNIT_US;
 
 	sync_iso->timeout_reload =
 		RADIO_SYNC_EVENTS((sync_iso->timeout * 10U * USEC_PER_MSEC),

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_types.h
@@ -89,7 +89,6 @@ struct ll_sync_iso_set {
 	/* Periodic Advertising Sync that contained the BIGInfo */
 	struct ll_sync_set *sync;
 
-	uint16_t iso_interval;
 	uint16_t timeout;
 
 	uint16_t volatile timeout_reload; /* Non-zero when sync established */


### PR DESCRIPTION
Add implementation to send ISO Sync payload number and
timestamp from LLL to HCI/ISOAL layer.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>