### PR TITLE
usb: fix bulk endpoint configuration for high-speed capable device

### DIFF
--- a/drivers/usb/device/Kconfig
+++ b/drivers/usb/device/Kconfig
@@ -10,6 +10,11 @@ menuconfig USB_DEVICE_DRIVER
 
 if USB_DEVICE_DRIVER
 
+config USB_DC_HAS_HS_SUPPORT
+	bool "USB device controller supports high speed"
+	help
+	  USB device controller supports high speed.
+
 config USB_DEVICE_REMOTE_WAKEUP
 	bool
 	help
@@ -59,10 +64,14 @@ config USB_DC_SAM_USBC
 	help
 	  SAM4L family USBC device controller Driver.
 
+DT_SAM_USBHS := $(dt_nodelabel_path,usbhs)
+DT_SAM_USBHS_SPEED := $(dt_node_str_prop_equals,$(DT_SAM_USBHS),maximum-speed,high-speed)
+
 config USB_DC_SAM_USBHS
 	bool "SAM series USB HS Device Controller driver"
 	depends on SOC_SERIES_SAME70 || \
 		   SOC_SERIES_SAMV71
+	imply USB_DC_HAS_HS_SUPPORT if "$(DT_SAM_USBHS_SPEED)"
 	help
 	  SAM family USB HS device controller Driver.
 

--- a/drivers/usb/device/usb_dc_sam_usbhs.c
+++ b/drivers/usb/device/usb_dc_sam_usbhs.c
@@ -46,11 +46,8 @@ LOG_MODULE_REGISTER(usb_dc_sam_usbhs);
 #endif
 
 #define NUM_OF_EP_MAX		DT_INST_PROP(0, num_bidir_endpoints)
-#if DT_INST_NODE_HAS_PROP(0, maximum_speed)
-#define USB_MAXIMUM_SPEED	DT_INST_ENUM_IDX(0, maximum_speed)
-#else
-#define USB_MAXIMUM_SPEED	2 /* Default to high-speed */
-#endif
+#define USB_MAXIMUM_SPEED	DT_INST_ENUM_IDX_OR(0, maximum_speed, 1)
+BUILD_ASSERT(USB_MAXIMUM_SPEED, "low-speed is not supported");
 
 struct usb_device_ep_data {
 	uint16_t mps;
@@ -312,18 +309,12 @@ int usb_dc_attach(void)
 
 	/* Select the speed */
 	regval = USBHS_DEVCTRL_DETACH;
-#if USB_MAXIMUM_SPEED == 0
-	/* low-speed */
-	regval |= USBHS_DEVCTRL_LS;
-	regval |= USBHS_DEVCTRL_SPDCONF_LOW_POWER;
-#elif USB_MAXIMUM_SPEED == 1
-	/* full-speed */
-	regval |= USBHS_DEVCTRL_SPDCONF_LOW_POWER;
-#elif USB_MAXIMUM_SPEED == 2
+#if (USB_MAXIMUM_SPEED == 2) && IS_ENABLED(CONFIG_USB_DC_HAS_HS_SUPPORT)
 	/* high-speed */
 	regval |= USBHS_DEVCTRL_SPDCONF_NORMAL;
 #else
-#error "Unsupported maximum speed defined in device tree."
+	/* full-speed */
+	regval |= USBHS_DEVCTRL_SPDCONF_LOW_POWER;
 #endif
 	USBHS->USBHS_DEVCTRL = regval;
 

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -341,7 +341,7 @@
 			reg = <0x40038000 0x4000>;
 			interrupts = <34 0>;
 			interrupt-names = "usbhs";
-			maximum-speed = "full-speed";
+			maximum-speed = "high-speed";
 			num-bidir-endpoints = <10>;
 			peripheral-id = <34>;
 			status = "disabled";

--- a/samples/net/wpanusb/src/wpanusb.c
+++ b/samples/net/wpanusb/src/wpanusb.c
@@ -28,7 +28,11 @@ LOG_MODULE_REGISTER(wpanusb);
 #define WPANUSB_PROTOCOL	0
 
 /* Max packet size for endpoints */
+#if IS_ENABLED(CONFIG_USB_DC_HAS_HS_SUPPORT)
+#define WPANUSB_BULK_EP_MPS		512
+#else
 #define WPANUSB_BULK_EP_MPS		64
+#endif
 
 #define WPANUSB_IN_EP_IDX		0
 

--- a/samples/subsys/usb/webusb/src/webusb.c
+++ b/samples/subsys/usb/webusb/src/webusb.c
@@ -23,7 +23,12 @@ LOG_MODULE_REGISTER(webusb);
 #include "webusb.h"
 
 /* Max packet size for Bulk endpoints */
+#if IS_ENABLED(CONFIG_USB_DC_HAS_HS_SUPPORT)
+#define WEBUSB_BULK_EP_MPS		512
+#else
 #define WEBUSB_BULK_EP_MPS		64
+#endif
+
 /* Number of interfaces */
 #define WEBUSB_NUM_ITF			0x01
 /* Number of Endpoints in the custom interface */
@@ -34,7 +39,7 @@ LOG_MODULE_REGISTER(webusb);
 
 static struct webusb_req_handlers *req_handlers;
 
-uint8_t rx_buf[64];
+uint8_t rx_buf[WEBUSB_BULK_EP_MPS];
 
 #define INITIALIZER_IF(num_ep, iface_class)				\
 	{								\

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -388,6 +388,32 @@ def dt_node_int_prop(kconf, name, path, prop, unit=None):
     if name == "dt_node_int_prop_hex":
         return hex(_node_int_prop(node, prop, unit))
 
+def dt_node_str_prop_equals(kconf, _, path, prop, val):
+    """
+    This function takes a 'path' and property name ('prop') looks for an EDT
+    node at that path. If it finds an EDT node, it will look to see if that
+    node has a property 'prop' of type string. If that 'prop' is equal to 'val'
+    it will return "y" otherwise return "n".
+    """
+
+    if doc_mode or edt is None:
+        return "n"
+
+    try:
+        node = edt.get_node(path)
+    except edtlib.EDTError:
+        return "n"
+
+    if prop not in node.props:
+        return "n"
+
+    if node.props[prop].type != "string":
+        return "n"
+
+    if node.props[prop].val == val:
+        return "y"
+
+    return "n"
 
 def dt_compat_enabled(kconf, _, compat):
     """
@@ -491,6 +517,7 @@ functions = {
         "dt_node_has_prop": (dt_node_has_prop, 2, 2),
         "dt_node_int_prop_int": (dt_node_int_prop, 2, 3),
         "dt_node_int_prop_hex": (dt_node_int_prop, 2, 3),
+        "dt_node_str_prop_equals": (dt_node_str_prop_equals, 3, 3),
         "dt_nodelabel_has_compat": (dt_nodelabel_has_compat, 2, 2),
         "dt_nodelabel_path": (dt_nodelabel_path, 1, 1),
         "shields_list_contains": (shields_list_contains, 1, 1),

--- a/subsys/usb/class/Kconfig.cdc
+++ b/subsys/usb/class/Kconfig.cdc
@@ -32,6 +32,7 @@ config CDC_ACM_INTERRUPT_EP_MPS
 
 config CDC_ACM_BULK_EP_MPS
 	int
+	default 512 if USB_DC_HAS_HS_SUPPORT
 	default 64
 	help
 	  CDC ACM class bulk endpoints size

--- a/subsys/usb/class/Kconfig.msc
+++ b/subsys/usb/class/Kconfig.msc
@@ -38,8 +38,8 @@ config MASS_STORAGE_INQ_REVISION
 
 config MASS_STORAGE_BULK_EP_MPS
 	int
+	default 512 if USB_DC_HAS_HS_SUPPORT
 	default 64
-	range 8 64
 	help
 	  Mass storage device class bulk endpoints size
 

--- a/subsys/usb/class/Kconfig.test
+++ b/subsys/usb/class/Kconfig.test
@@ -9,6 +9,7 @@ config USB_DEVICE_LOOPBACK
 config LOOPBACK_BULK_EP_MPS
 	int
 	depends on USB_DEVICE_LOOPBACK
+	default 512 if USB_DC_HAS_HS_SUPPORT
 	default 64
 	help
 	  Loopback Function bulk endpoint size

--- a/subsys/usb/class/netusb/Kconfig
+++ b/subsys/usb/class/netusb/Kconfig
@@ -41,6 +41,7 @@ config CDC_ECM_INTERRUPT_EP_MPS
 
 config CDC_ECM_BULK_EP_MPS
 	int
+	default 512 if USB_DC_HAS_HS_SUPPORT
 	default 64
 	help
 	  CDC ECM class bulk endpoint size
@@ -58,6 +59,7 @@ endif # USB_DEVICE_NETWORK_ECM
 
 config CDC_EEM_BULK_EP_MPS
 	int
+	default 512 if USB_DC_HAS_HS_SUPPORT
 	default 64
 	depends on USB_DEVICE_NETWORK_EEM
 
@@ -71,6 +73,7 @@ config RNDIS_INTERRUPT_EP_MPS
 
 config RNDIS_BULK_EP_MPS
 	int
+	default 512 if USB_DC_HAS_HS_SUPPORT
 	default 64
 	help
 	  RNDIS bulk endpoint size

--- a/tests/subsys/usb/desc_sections/src/desc_sections.c
+++ b/tests/subsys/usb/desc_sections/src/desc_sections.c
@@ -33,7 +33,12 @@ struct usb_test_config {
 	struct usb_ep_descriptor if0_in2_ep;
 } __packed;
 
+#if IS_ENABLED(CONFIG_USB_DC_HAS_HS_SUPPORT)
+#define TEST_BULK_EP_MPS		512
+#else
 #define TEST_BULK_EP_MPS		64
+#endif
+
 #define TEST_DESCRIPTOR_TABLE_SPAN	157
 
 #define INITIALIZER_IF							\

--- a/tests/subsys/usb/device/src/main.c
+++ b/tests/subsys/usb/device/src/main.c
@@ -11,7 +11,11 @@
 #include <usb/usb_device.h>
 
 /* Max packet size for endpoints */
+#if IS_ENABLED(CONFIG_USB_DC_HAS_HS_SUPPORT)
+#define BULK_EP_MPS		512
+#else
 #define BULK_EP_MPS		64
+#endif
 
 #define ENDP_BULK_IN		0x81
 


### PR DESCRIPTION
In the current USB device support, the sizes of bulk endpoint
are mostly configure through Kconfig and do not care if a device
is high-speed capable. The information if a USB device controller
supports high-speed comes from devicetree. Add a Kconfig option to
map this information and configure bulk endpoint sizes
accordingly.