### PR TITLE
soc: intel_adsp: cavs_v20: fix overlapping .noinit and .cached

### DIFF
--- a/soc/xtensa/intel_adsp/cavs_v20/linker.ld
+++ b/soc/xtensa/intel_adsp/cavs_v20/linker.ld
@@ -44,8 +44,15 @@ PROVIDE(_MemErrorHandler = 0x00000000);
  *
  * (Note clumsy syntax because XCC doesn't understand the "~" operator)
  */
+#ifdef CONFIG_KERNEL_COHERENCE
 #define SEGSTART_CACHED   (ALIGN(64) | 0x20000000)
 #define SEGSTART_UNCACHED (ALIGN(64) & 0xdfffffff) /* == ~0x20000000 */
+#else
+#define SEGSTART_CACHED   /**/
+#define SEGSTART_UNCACHED /**/
+#define ucram ram
+#define ucram_phdr ram_phdr
+#endif
 
 MEMORY
 {
@@ -115,9 +122,11 @@ MEMORY
   ram :
 	org = RAM_BASE,
 	len = RAM_SIZE
+#ifdef CONFIG_KERNEL_COHERENCE
   ucram :
 	org = RAM_BASE - 0x20000000,
 	len = RAM_SIZE
+#endif
 #ifdef CONFIG_GEN_ISR_TABLES
   IDT_LIST :
 	org = IDT_BASE,
@@ -166,7 +175,9 @@ PHDRS
   vector_double_lit_phdr PT_LOAD;
   vector_double_text_phdr PT_LOAD;
   ram_phdr PT_LOAD;
+#ifdef CONFIG_KERNEL_COHERENCE
   ucram_phdr PT_LOAD;
+#endif
   static_uuid_entries_phdr PT_NOTE;
   static_log_entries_phdr PT_NOTE;
   metadata_entries_phdr PT_NOTE;
@@ -456,17 +467,14 @@ SECTIONS
     *(.gnu.linkonce.lit4.*)
     _lit4_end = ABSOLUTE(.);
   } >ram :ram_phdr
-  .cached :
-  {
-    *(.cached .cached.*)
-  } >ram :ram_phdr
 
+#ifdef CONFIG_KERNEL_COHERENCE
 /* These values need to change in our scheme, where the common-ram
  * sections need to be linked in safe/uncached memory but common-rom
  * wants to use the cache
  */
-
   . = SEGSTART_UNCACHED;
+#endif
 
 #undef RAMABLE_REGION
 #undef ROMABLE_REGION
@@ -479,10 +487,19 @@ SECTIONS
     *(.tm_clone_table)
   } >ram :ram_phdr
 
-  .bss (NOLOAD) : ALIGN(4096)
+  /* This section is cached.  By default it contains only declared
+   * thread stacks, but applications can put symbols here too.
+   */
+  .cached SEGSTART_CACHED :
   {
-    . = ALIGN(4096);
-    _bss_start = ABSOLUTE(.);
+    *(.cached .cached.*)
+  } >ram :ram_phdr
+
+  . = ALIGN(4096);
+
+  .bss SEGSTART_UNCACHED (NOLOAD) : ALIGN(4096)
+  {
+    _bss_start = .;
     *(.dynsbss)
     *(.sbss)
     *(.sbss.*)
@@ -497,18 +514,24 @@ SECTIONS
     *(.gnu.linkonce.b.*)
     *(COMMON)
     . = ALIGN(8);
-    _bss_end = ABSOLUTE(.);
+    _bss_end = .;
   } >ucram :ucram_phdr
 
+#ifdef CONFIG_KERNEL_COHERENCE
   . = SEGSTART_UNCACHED;
+#endif
   _end = ALIGN(8);
   PROVIDE(end = ALIGN(8));
 
   /* Re-adjust to the upper mapping for the final symbols below */
+#ifdef CONFIG_KERNEL_COHERENCE
   . = SEGSTART_CACHED;
+#endif
   __stack = L2_SRAM_BASE + L2_SRAM_SIZE;
 
+#ifdef CONFIG_KERNEL_COHERENCE
   . = SEGSTART_UNCACHED;
+#endif
 
   /* dma buffers */
   .lpbuf (NOLOAD): ALIGN(4)
@@ -519,7 +542,9 @@ SECTIONS
   } >LP_SRAM_REGION
 
   . = L2_SRAM_BASE + L2_SRAM_SIZE;
+#ifdef CONFIG_KERNEL_COHERENCE
   . = SEGSTART_UNCACHED;
+#endif
   _heap_sentry = .;
 
   .comment  0 :  { *(.comment) }


### PR DESCRIPTION
Previous changes to linker script for intel_adsp/cavs_v20 to fix
XCC build issues resulted in another problem where .noinit
and .cached both had overlapping "cached" addresses. Rimage
thus refused to build the firmware.

This updates the linker script to align it closer to cavs_v25
which is working with rimage.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>