### PR TITLE
pm: ownership: Add device power management ownership API

### DIFF
--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -36,6 +36,11 @@ enum pm_device_flag {
 	PM_DEVICE_FLAG_WS_CAPABLE,
 	/** Indicates if the device is being used as wakeup source. */
 	PM_DEVICE_FLAG_WS_ENABLED,
+	/**
+	 * Indicates if the device power management ownership belongs to
+	 * the application.
+	 */
+	PM_DEVICE_FLAG_APP_OWNERSHIP,
 };
 
 /** @endcond */
@@ -261,6 +266,44 @@ bool pm_device_wakeup_is_enabled(const struct device *dev);
  * @retval false If the device is not wake up capable.
  */
 bool pm_device_wakeup_is_capable(const struct device *dev);
+
+/**
+ * @brief Take device power management ownership.
+ *
+ * This function transfer the power management ownership from the kernel
+ * (pm subsystem) to the application. If this operation successed, the power
+ * subsystem will not longer suspend / resume the device when the system goes
+ * to sleep nor allow device runtime operations.
+ *
+ * @note If the device is active this operation will fail.
+ *
+ * @param dev Device instance.
+ *
+ * @retval true If the application got the device pm ownership.
+ * @retval false If the application is in use by the system.
+ */
+bool pm_device_ownership_get(struct device *dev);
+
+/**
+ * @brief Transfer device power management ownership to the kernel.
+ *
+ * This operation transfers the device power management ownership from from
+ * the application to the kernel (power management subsystem).
+ *
+ * @param dev Device instance.
+ */
+void pm_device_ownership_put(struct device *dev);
+
+/**
+ * @brief Check if the device power management belongs to the application.
+ *
+ * @param dev Device instance.
+ *
+ * @retval true If the application owns the device pm
+ * @retval false If the device pm belongs to the kernel
+ */
+bool pm_device_ownership_check(const struct device *dev);
+
 #else
 static inline void pm_device_busy_set(const struct device *dev) {}
 static inline void pm_device_busy_clear(const struct device *dev) {}
@@ -275,6 +318,20 @@ static inline bool pm_device_wakeup_is_enabled(const struct device *dev)
 	return false;
 }
 static inline bool pm_device_wakeup_is_capable(const struct device *dev)
+{
+	return false;
+}
+
+static inline bool pm_device_ownership_get(struct device *dev)
+{
+	return false;
+}
+
+static inline void pm_device_ownership_put(struct device *dev)
+{
+}
+
+static inline bool pm_device_ownership_check(const struct device *dev)
 {
 	return false;
 }

--- a/include/pm/device_runtime.h
+++ b/include/pm/device_runtime.h
@@ -42,6 +42,7 @@ void pm_device_runtime_enable(const struct device *dev);
  *
  * @retval 0 If the device runtime PM is disabled successfully.
  * @retval -ENOSYS If the functionality is not available.
+ * @retval -EPERM If the device pm onwership belongs to the application.
  * @retval -errno Other negative errno, result of resuming the device.
  */
 int pm_device_runtime_disable(const struct device *dev);
@@ -64,6 +65,7 @@ int pm_device_runtime_disable(const struct device *dev);
  * @retval 0 If the device has been resumed successfully.
  * @retval -ENOSTUP If runtime PM is not enabled for the device.
  * @retval -ENOSYS If the functionality is not available.
+ * @retval -EPERM If the device pm onwership belongs to the application.
  * @retval -errno Other negative errno, result of the PM action callback.
  */
 int pm_device_runtime_get(const struct device *dev);
@@ -85,6 +87,7 @@ int pm_device_runtime_get(const struct device *dev);
  * @retval -ENOSYS If the functionality is not available.
  * @retval -EALREADY If device is already suspended (can only happen if get/put
  * calls are unbalanced).
+ * @retval -EPERM If the device pm onwership belongs to the application.
  * @retval -errno Other negative errno, result of the action callback.
  *
  * @see pm_device_runtime_put_async()
@@ -111,6 +114,7 @@ int pm_device_runtime_put(const struct device *dev);
  * @retval -ENOSYS If the functionality is not available.
  * @retval -EALREADY If device is already suspended (can only happen if get/put
  * calls are unbalanced).
+ * @retval -EPERM If the device pm onwership belongs to the application.
  *
  * @see pm_device_runtime_put()
  */

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -190,3 +190,32 @@ bool pm_device_wakeup_is_capable(const struct device *dev)
 	return atomic_test_bit(&pm->flags,
 			       PM_DEVICE_FLAG_WS_CAPABLE);
 }
+
+bool pm_device_ownership_get(struct device *dev)
+{
+	struct pm_device *pm = dev->pm;
+
+	if (pm->state != PM_DEVICE_STATE_SUSPENDED) {
+		return false;
+	}
+
+	return atomic_test_and_set_bit(&pm->flags,
+			PM_DEVICE_FLAG_APP_OWNERSHIP);
+}
+
+void pm_device_ownership_put(struct device *dev)
+{
+	atomic_clear_bit(&(dev->pm->flags), PM_DEVICE_FLAG_APP_OWNERSHIP);
+}
+
+bool pm_device_ownership_check(const struct device *dev)
+{
+	struct pm_device *pm = dev->pm;
+
+	if (pm->action_cb == NULL) {
+		return false;
+	}
+
+	return atomic_test_bit(&pm->flags,
+			       PM_DEVICE_FLAG_APP_OWNERSHIP);
+}

--- a/subsys/pm/power.c
+++ b/subsys/pm/power.c
@@ -128,7 +128,8 @@ static int pm_suspend_devices(void)
 		 * runtime PM enabled.
 		 */
 		if (pm_device_is_busy(dev) || pm_device_wakeup_is_enabled(dev)
-				|| pm_device_runtime_is_enabled(dev)) {
+				|| pm_device_runtime_is_enabled(dev)
+				|| pm_device_ownership_check(dev)) {
 			continue;
 		}
 


### PR DESCRIPTION
Add a new API to allow to transfer a device power management ownership
from the kernel (power management subsystem) to the application.

When the device ownership belongs to the application, the kernel will
no longer suspend / resume devices when the system goes to sleep and
device runtime power management operations will fail.
