### PR TITLE
cmake: add and use new DT alias helpers

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -2572,6 +2572,49 @@ function(dt_nodelabel var)
 endfunction()
 
 # Usage:
+#   dt_alias(<var> PROPERTY <prop>)
+#
+# Get a node path for an /aliases node property.
+#
+# Example usage:
+#
+#   # The full path to the 'led0' alias is returned in 'path'.
+#   dt_alias(path PROPERTY "led0")
+#
+#   # The variable 'path' will be left undefined for a nonexistent
+#   # alias "does-not-exist".
+#   dt_alias(path PROPERTY "does-not-exist")
+#
+# The node's path will be returned in the <var> parameter. The
+# variable will be left undefined if the alias does not exist.
+#
+# <var>           : Return variable where the node path will be stored
+# PROPERTY <prop> : The alias to check
+function(dt_alias var)
+  set(req_single_args "PROPERTY")
+  cmake_parse_arguments(DT_ALIAS "" "${req_single_args}" "" ${ARGN})
+
+  if(${ARGV0} IN_LIST req_single_args)
+    message(FATAL_ERROR "dt_alias(${ARGV0} ...) missing return parameter.")
+  endif()
+
+  foreach(arg ${req_single_args})
+    if(NOT DEFINED DT_ALIAS_${arg})
+      message(FATAL_ERROR "dt_alias(${ARGV0} ...) "
+                          "missing required argument: ${arg}"
+      )
+    endif()
+  endforeach()
+
+  get_target_property(${var} devicetree_target "DT_ALIAS|${DT_ALIAS_PROPERTY}")
+  if(${${var}} STREQUAL ${var}-NOTFOUND)
+    set(${var})
+  endif()
+
+  set(${var} ${${var}} PARENT_SCOPE)
+endfunction()
+
+# Usage:
 #   dt_node_exists(<var> PATH <path>)
 #
 # Tests whether a node with path <path> exists in the devicetree.

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -2990,6 +2990,77 @@ function(dt_chosen var)
   endif()
 endfunction()
 
+# Internal helper. Canonicalizes a path 'path' into the output
+# variable 'var'. This resolves aliases, if any. Child nodes may be
+# accessed via alias as well. 'var' is left undefined if the path does
+# not refer to an existing node.
+#
+# Example devicetree:
+#
+#   / {
+#           foo {
+#                   my-label: bar {
+#                           baz {};
+#                   };
+#           };
+#           aliases {
+#                   my-alias = &my-label;
+#           };
+#   };
+#
+# Example usage:
+#
+#   dt_path_internal(ret "/foo/bar")     # sets ret to "/foo/bar"
+#   dt_path_internal(ret "my-alias")     # sets ret to "/foo/bar"
+#   dt_path_internal(ret "my-alias/baz") # sets ret to "/foo/bar/baz"
+#   dt_path_internal(ret "/blub")        # ret is undefined
+function(dt_path_internal var path)
+  string(FIND "${path}" "/" slash_index)
+
+  if("${slash_index}" EQUAL 0)
+    # If the string starts with a slash, it should be an existing
+    # canonical path.
+    dt_path_internal_exists(check "${path}")
+    if (check)
+      set(${var} "${path}" PARENT_SCOPE)
+      return()
+    endif()
+  else()
+    # Otherwise, try to expand a leading alias.
+    string(SUBSTRING "${path}" 0 "${slash_index}" alias_name)
+    dt_alias(alias_path PROPERTY "${alias_name}")
+
+    # If there is a leading alias, append the rest of the string
+    # onto it and see if that's an existing node.
+    if (DEFINED alias_path)
+      set(rest)
+      if (NOT "${slash_index}" EQUAL -1)
+        string(SUBSTRING "${path}" "${slash_index}" -1 rest)
+      endif()
+      dt_path_internal_exists(expanded_path_exists "${alias_path}${rest}")
+      if (expanded_path_exists)
+        set(${var} "${alias_path}${rest}" PARENT_SCOPE)
+        return()
+      endif()
+    endif()
+  endif()
+
+  # Failed search; ensure return variable is undefined.
+  set(${var} PARENT_SCOPE)
+endfunction()
+
+# Internal helper. Set 'var' to TRUE if a canonical path 'path' refers
+# to an existing node. Set it to FALSE otherwise. See
+# dt_path_internal for a definition and examples of 'canonical' paths.
+function(dt_path_internal_exists var path)
+  get_target_property(path_prop devicetree_target "DT_NODE|${path}")
+  if (path_prop)
+    set(${var} TRUE PARENT_SCOPE)
+  else()
+    set(${var} FALSE PARENT_SCOPE)
+  endif()
+endfunction()
+
 ########################################################
 # 5. Zephyr linker function
 ########################################################

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -21,6 +21,7 @@
 # 3.5. File system management
 # 4. Devicetree extensions
 # 4.1 dt_*
+# 4.2. *_if_dt_node
 # 5. Zephyr linker functions
 # 5.1. zephyr_linker*
 
@@ -3105,6 +3106,36 @@ function(dt_path_internal_exists var path)
     set(${var} TRUE PARENT_SCOPE)
   else()
     set(${var} FALSE PARENT_SCOPE)
+  endif()
+endfunction()
+
+# 4.2. *_if_dt_node
+#
+# This section is similar to the extensions named *_ifdef, except
+# actions are performed if the devicetree contains some node.
+# *_if_dt_node functions may be added as needed, or if they are likely
+# to be useful for user applications.
+
+# Add item(s) to a target's SOURCES list if a devicetree node exists.
+#
+# Example usage:
+#
+#   # If the devicetree alias "led0" refers to a node, this
+#   # adds "blink_led.c" to the sources list for the "app" target.
+#   target_sources_if_dt_node("led0" app PRIVATE blink_led.c)
+#
+#   # If the devicetree path "/soc/serial@4000" is a node, this
+#   # adds "uart.c" to the sources list for the "lib" target,
+#   target_sources_if_dt_node("/soc/serial@4000" lib PRIVATE uart.c)
+#
+# <path>    : Path to devicetree node to check
+# <target>  : Build system target whose sources to add to
+# <scope>   : Scope to add items to
+# <item>    : Item (or items) to add to the target
+function(target_sources_if_dt_node path target scope item)
+  dt_node_exists(check PATH "${path}")
+  if(${check})
+    target_sources(${target} ${scope} ${item} ${ARGN})
   endif()
 endfunction()
 

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -2520,8 +2520,16 @@ endfunction()
 #
 # The following methods are for retrieving devicetree information in CMake.
 #
-# Note: In CMake we refer to the nodes using the node's path, therefore there
-# is no dt_path(...) function for obtaining a node identifier.
+# Notes:
+#
+# - In CMake, we refer to the nodes using the node's path, therefore
+#   there is no dt_path(...) function for obtaining a node identifier
+#   like there is in the C devicetree.h API.
+#
+# - As another difference from the C API, you can generally use an
+#   alias at the beginning of a path interchangeably with the full
+#   path to the aliased node in these functions. The usage comments
+#   will make this clear in each case.
 
 # Usage:
 #   dt_nodelabel(<var> NODELABEL <label>)
@@ -2619,6 +2627,12 @@ endfunction()
 #
 # Tests whether a node with path <path> exists in the devicetree.
 #
+# The <path> value may be any of these:
+#
+# - absolute path to a node, like '/foo/bar'
+# - a node alias, like 'my-alias'
+# - a node alias followed by a path to a child node, like 'my-alias/child-node'
+#
 # The result of the check, either TRUE or FALSE, will be returned in
 # the <var> parameter.
 #
@@ -2640,10 +2654,9 @@ function(dt_node_exists var)
     endif()
   endforeach()
 
-  get_target_property(${var} devicetree_target "DT_NODE|${DT_NODE_PATH}")
-
-  if(${var})
-    set(${var} ${${var}} PARENT_SCOPE)
+  dt_path_internal(canonical "${DT_NODE_PATH}")
+  if (DEFINED canonical)
+    set(${var} TRUE PARENT_SCOPE)
   else()
     set(${var} FALSE PARENT_SCOPE)
   endif()
@@ -2657,6 +2670,12 @@ endfunction()
 # - has a status property matching the <status> argument
 #   (a missing status or an “ok” status is treated as if it
 #    were “okay” instead)
+#
+# The <path> value may be any of these:
+#
+# - absolute path to a node, like '/foo/bar'
+# - a node alias, like 'my-alias'
+# - a node alias followed by a path to a child node, like 'my-alias/child-node'
 #
 # The result of the check, either TRUE or FALSE, will be returned in
 # the <var> parameter.
@@ -2680,13 +2699,13 @@ function(dt_node_has_status var)
     endif()
   endforeach()
 
-  dt_node_exists(${var} PATH ${DT_NODE_PATH})
-  if(NOT ${${var}})
+  dt_path_internal(canonical ${DT_NODE_PATH})
+  if(NOT DEFINED canonical)
     set(${var} FALSE PARENT_SCOPE)
     return()
   endif()
 
-  dt_prop(${var} PATH ${DT_NODE_PATH} PROPERTY status)
+  dt_prop(${var} PATH ${canonical} PROPERTY status)
 
   if(NOT DEFINED ${var} OR "${${var}}" STREQUAL ok)
     set(${var} okay)
@@ -2705,6 +2724,12 @@ endfunction()
 #
 # Get a devicetree property value. The value will be returned in the
 # <var> parameter.
+#
+# The <path> value may be any of these:
+#
+# - absolute path to a node, like '/foo/bar'
+# - a node alias, like 'my-alias'
+# - a node alias followed by a path to a child node, like 'my-alias/child-node'
 #
 # This function currently only supports properties with the following
 # devicetree binding types: string, int, boolean, array, uint8-array,
@@ -2760,8 +2785,9 @@ function(dt_prop var)
     endif()
   endforeach()
 
+  dt_path_internal(canonical "${DT_PROP_PATH}")
   get_property(exists TARGET devicetree_target
-      PROPERTY "DT_PROP|${DT_PROP_PATH}|${DT_PROP_PROPERTY}"
+      PROPERTY "DT_PROP|${canonical}|${DT_PROP_PROPERTY}"
       SET
   )
 
@@ -2771,7 +2797,7 @@ function(dt_prop var)
   endif()
 
   get_target_property(val devicetree_target
-      "DT_PROP|${DT_PROP_PATH}|${DT_PROP_PROPERTY}"
+      "DT_PROP|${canonical}|${DT_PROP_PROPERTY}"
   )
 
   if(DEFINED DT_PROP_INDEX)
@@ -2791,6 +2817,12 @@ endfunction()
 #
 # The value will be returned in the <var> parameter.
 #
+# The <path> value may be any of these:
+#
+# - absolute path to a node, like '/foo/bar'
+# - a node alias, like 'my-alias'
+# - a node alias followed by a path to a child node, like 'my-alias/child-node'
+#
 # <var>          : Return variable where the property value will be stored
 # PATH <path>    : Node path
 function(dt_num_regs var)
@@ -2809,7 +2841,8 @@ function(dt_num_regs var)
     endif()
   endforeach()
 
-  get_target_property(${var} devicetree_target "DT_REG|${DT_REG_PATH}|NUM")
+  dt_path_internal(canonical "${DT_REG_PATH}")
+  get_target_property(${var} devicetree_target "DT_REG|${canonical}|NUM")
 
   set(${var} ${${var}} PARENT_SCOPE)
 endfunction()
@@ -2821,6 +2854,12 @@ endfunction()
 # If <idx> is omitted, then the value at index 0 will be returned.
 #
 # The value will be returned in the <var> parameter.
+#
+# The <path> value may be any of these:
+#
+# - absolute path to a node, like '/foo/bar'
+# - a node alias, like 'my-alias'
+# - a node alias followed by a path to a child node, like 'my-alias/child-node'
 #
 # Results can be:
 # - The base address of the register block
@@ -2851,7 +2890,8 @@ function(dt_reg_addr var)
     set(DT_REG_INDEX 0)
   endif()
 
-  get_target_property(${var}_list devicetree_target "DT_REG|${DT_REG_PATH}|ADDR")
+  dt_path_internal(canonical "${DT_REG_PATH}")
+  get_target_property(${var}_list devicetree_target "DT_REG|${canonical}|ADDR")
 
   list(GET ${var}_list ${DT_REG_INDEX} ${var})
 
@@ -2869,6 +2909,12 @@ endfunction()
 # If INDEX is omitted, then the value at index 0 will be returned.
 #
 # The value will be returned in the <value> parameter.
+#
+# The <path> value may be any of these:
+#
+# - absolute path to a node, like '/foo/bar'
+# - a node alias, like 'my-alias'
+# - a node alias followed by a path to a child node, like 'my-alias/child-node'
 #
 # <var>          : Return variable where the size value will be stored
 # PATH <path>    : Node path
@@ -2894,7 +2940,8 @@ function(dt_reg_size var)
     set(DT_REG_INDEX 0)
   endif()
 
-  get_target_property(${var}_list devicetree_target "DT_REG|${DT_REG_PATH}|SIZE")
+  dt_path_internal(canonical "${DT_REG_PATH}")
+  get_target_property(${var}_list devicetree_target "DT_REG|${canonical}|SIZE")
 
   list(GET ${var}_list ${DT_REG_INDEX} ${var})
 

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -2640,6 +2640,7 @@ function(dt_node_has_status var)
   dt_node_exists(${var} PATH ${DT_NODE_PATH})
   if(NOT ${${var}})
     set(${var} FALSE PARENT_SCOPE)
+    return()
   endif()
 
   dt_prop(${var} PATH ${DT_NODE_PATH} PROPERTY status)
@@ -2916,7 +2917,8 @@ endfunction()
 #
 # Get a node path for a /chosen node property.
 #
-# the node path will be returned in the <value> parameter.
+# The node's path will be returned in the <var> parameter. The
+# variable will be left undefined if the chosen node does not exist.
 #
 # <var>           : Return variable where the node path will be stored
 # PROPERTY <prop> : Chosen property
@@ -2925,7 +2927,7 @@ function(dt_chosen var)
   cmake_parse_arguments(DT_CHOSEN "" "${req_single_args}" "" ${ARGN})
 
   if(${ARGV0} IN_LIST req_single_args)
-    message(FATAL_ERROR "dt_has_chosen(${ARGV0} ...) missing return parameter.")
+    message(FATAL_ERROR "dt_chosen(${ARGV0} ...) missing return parameter.")
   endif()
 
   foreach(arg ${req_single_args})

--- a/doc/releases/release-notes-3.0.rst
+++ b/doc/releases/release-notes-3.0.rst
@@ -287,6 +287,21 @@ USB
 Build and Infrastructure
 ************************
 
+* Build system
+
+  * New CMake extension functions:
+
+    * ``dt_alias()``
+    * ``target_sources_if_dt_node()``
+
+  * The following CMake extension functions now handle devicetree aliases:
+
+    * ``dt_node_exists()``
+    * ``dt_node_has_status()``
+    * ``dt_prop()``
+    * ``dt_num_regs()``
+    * ``dt_reg_addr()``
+    * ``dt_reg_size()``
 
 * Devicetree
 

--- a/scripts/dts/gen_dts_cmake.py
+++ b/scripts/dts/gen_dts_cmake.py
@@ -83,8 +83,9 @@ def main():
     # macros.bnf for C macros.
 
     cmake_props = []
-    for node in edt.chosen_nodes:
-        path = edt.chosen_nodes[node].path
+    chosen_nodes = edt.chosen_nodes
+    for node in chosen_nodes:
+        path = chosen_nodes[node].path
         cmake_props.append(f'"DT_CHOSEN|{node}" "{path}"')
 
     for node in edt.nodes:

--- a/scripts/dts/gen_dts_cmake.py
+++ b/scripts/dts/gen_dts_cmake.py
@@ -88,6 +88,13 @@ def main():
         path = chosen_nodes[node].path
         cmake_props.append(f'"DT_CHOSEN|{node}" "{path}"')
 
+    # The separate loop over edt.nodes here is meant to keep
+    # all of the alias-related properties in one place.
+    for node in edt.nodes:
+        path = node.path
+        for alias in node.aliases:
+            cmake_props.append(f'"DT_ALIAS|{alias}" "{path}"')
+
     for node in edt.nodes:
         cmake_props.append(f'"DT_NODE|{node.path}" TRUE')
 


### PR DESCRIPTION
Add convenience functions for dealing with devicetree aliases to extensions.cmake. Document them properly and mention them in the release notes. Document that they are expected to be added on an as-needed basis.
