### PR TITLE
littlefs : Upgrade to v2.4.1 in west manifest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -152,7 +152,7 @@ manifest:
       path: modules/fs/littlefs
       groups:
         - fs
-      revision: 9e4498d1c73009acd84bb36036ee5e2869112a6c
+      revision: 33509ed9c3d369cdb9d909cd40c5eea8f64a902c
     - name: loramac-node
       revision: 12019623bbad9eb54fe51066847a7cbd4b4eac57
       path: modules/lib/loramac-node


### PR DESCRIPTION
1. Upgrade west sha id to point to https://github.com/zephyrproject-rtos/littlefs/pull/7 ( upgrade littleFS to v2.4.1)
