### PR TITLE
drivers: i2c: fix i2c_gpio log typo

### DIFF
--- a/drivers/i2c/i2c_gpio.c
+++ b/drivers/i2c/i2c_gpio.c
@@ -137,7 +137,7 @@ static int i2c_gpio_init(const struct device *dev)
 
 	context->sda_gpio = device_get_binding(config->sda_gpio_name);
 	if (!context->sda_gpio) {
-		LOG_ERR("failed to get SCL GPIO device");
+		LOG_ERR("failed to get SDA GPIO device");
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Fix typo with error logging the gpio pin name for sda

Signed-off-by: Ryan McClelland <ryanmcclelland@fb.com>