### PR TITLE
Bluetooth: Controller: Remove misplaced function declaration

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_internal.h
@@ -31,7 +31,6 @@ static inline void ull_hdr_init(struct ull_hdr *hdr)
 	hdr->disabled_cb = hdr->disabled_param = NULL;
 }
 
-void ll_tx_ack_put(uint16_t handle, struct node_tx *node_tx);
 void *ll_rx_link_alloc(void);
 void ll_rx_link_release(void *link);
 void *ll_rx_alloc(void);


### PR DESCRIPTION
Remove misplaced declaration of ll_tx_ack_put in
ull_internal.h file while it is already present in
ull_conn_internal.h.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>