### PR TITLE
Bluetooth: Controller: Fix compile warning filling 24-bit value

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -6418,7 +6418,7 @@ static void le_big_sync_established(struct pdu_data *pdu,
 	}
 
 	/* FIXME: Fill latency */
-	sys_put_le32(0, sep->latency);
+	sys_put_le24(0, sep->latency);
 
 	sep->nse = lll->nse;
 	sep->bn = lll->bn;


### PR DESCRIPTION
Fix compile warning filling 24-bit value in 3 octets using
sys_put_le32, used sys_put_le24 instead.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>