### PR TITLE
Bluetooth: Controller: Limit maximum ACL Tx buffer size to 251 octets

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -1286,7 +1286,7 @@ static void le_read_buffer_size(struct net_buf *buf, struct net_buf **evt)
 
 	rp->status = 0x00;
 
-	rp->le_max_len = sys_cpu_to_le16(CONFIG_BT_BUF_ACL_TX_SIZE);
+	rp->le_max_len = sys_cpu_to_le16(LL_LENGTH_OCTETS_TX_MAX);
 	rp->le_max_num = CONFIG_BT_BUF_ACL_TX_COUNT;
 }
 
@@ -1299,7 +1299,7 @@ static void le_read_buffer_size_v2(struct net_buf *buf, struct net_buf **evt)
 
 	rp->status = 0x00;
 
-	rp->acl_max_len = sys_cpu_to_le16(CONFIG_BT_BUF_ACL_TX_SIZE);
+	rp->acl_max_len = sys_cpu_to_le16(LL_LENGTH_OCTETS_TX_MAX);
 	rp->acl_max_num = CONFIG_BT_BUF_ACL_TX_COUNT;
 	rp->iso_max_len = sys_cpu_to_le16(CONFIG_BT_CTLR_ISO_TX_BUFFER_SIZE);
 	rp->iso_max_num = CONFIG_BT_CTLR_ISO_TX_BUFFERS;
@@ -4774,7 +4774,7 @@ int hci_acl_handle(struct net_buf *buf, struct net_buf **evt)
 		return -EINVAL;
 	}
 
-	if (len > CONFIG_BT_BUF_ACL_TX_SIZE) {
+	if (len > LL_LENGTH_OCTETS_TX_MAX) {
 		BT_ERR("Invalid HCI ACL Data length");
 		return -EINVAL;
 	}

--- a/subsys/bluetooth/controller/include/ll_feat.h
+++ b/subsys/bluetooth/controller/include/ll_feat.h
@@ -37,6 +37,12 @@
 #define LL_FEAT_BIT_PING 0
 #endif /* !CONFIG_BT_CTLR_LE_PING */
 
+/* Maximum supported ACL Tx fragement size is limited by uint8_t len field in
+ * the PDU structure of the Controller implementation. 4 octets reserved for
+ * MIC in encrypted ACL PDUs, hence ACL Tx fragment maximum size of 251 octets.
+ */
+#define LL_LENGTH_OCTETS_TX_MAX MIN(CONFIG_BT_BUF_ACL_TX_SIZE, 251U)
+
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH_MAX)
 #define LL_FEAT_BIT_DLE BIT64(BT_LE_FEAT_BIT_DLE)
 #define LL_LENGTH_OCTETS_RX_MAX CONFIG_BT_CTLR_DATA_LENGTH_MAX

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -175,7 +175,7 @@ static uint8_t force_md_cnt_calc(struct lll_conn *lll_conn, uint32_t tx_rate);
 
 #define CONN_TX_BUF_SIZE MROUND(offsetof(struct node_tx, pdu) + \
 				offsetof(struct pdu_data, lldata) + \
-				(CONFIG_BT_BUF_ACL_TX_SIZE + \
+				(LL_LENGTH_OCTETS_TX_MAX + \
 				BT_CTLR_USER_TX_BUFFER_OVERHEAD))
 
 /**
@@ -647,13 +647,13 @@ uint32_t ll_length_req_send(uint16_t handle, uint16_t tx_octets,
 #if defined(CONFIG_BT_CTLR_PARAM_CHECK)
 #if defined(CONFIG_BT_CTLR_PHY_CODED)
 	uint16_t tx_time_max =
-			PDU_DC_MAX_US(CONFIG_BT_BUF_ACL_TX_SIZE, PHY_CODED);
+			PDU_DC_MAX_US(LL_LENGTH_OCTETS_TX_MAX, PHY_CODED);
 #else /* !CONFIG_BT_CTLR_PHY_CODED */
 	uint16_t tx_time_max =
-			PDU_DC_MAX_US(CONFIG_BT_BUF_ACL_TX_SIZE, PHY_1M);
+			PDU_DC_MAX_US(LL_LENGTH_OCTETS_TX_MAX, PHY_1M);
 #endif /* !CONFIG_BT_CTLR_PHY_CODED */
 
-	if ((tx_octets > CONFIG_BT_BUF_ACL_TX_SIZE) ||
+	if ((tx_octets > LL_LENGTH_OCTETS_TX_MAX) ||
 	    (tx_time > tx_time_max)) {
 		return BT_HCI_ERR_INVALID_PARAM;
 	}


### PR DESCRIPTION
Limit the maximum ACL Tx buffer size to 251 octets due to
implementation restricted use of uint8_t for PDU len field,
also used as the Tx buffer size data type.'

Relates to #40459.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>