### PR TITLE
MAINTAINERS: add LingaoM as Bluetooth Mesh collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -208,6 +208,7 @@ Bluetooth Mesh:
         - trond-snekvik
     collaborators:
         - jhedberg
+        - LingaoM
     files:
         - subsys/bluetooth/mesh/
         - include/bluetooth/mesh/


### PR DESCRIPTION
Add LingaoM as Bluetooth Mesh collaborator.

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>