### PR TITLE
Bluetooth: controller: remove obsolete defines

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -214,33 +214,6 @@
 
 #define PKT_BIS_US(octets, mic, phy) PDU_MAX_US((octets), (mic), (phy))
 
-/* TODO: verify if the following lines are correct */
-/* Extra bytes for enqueued node_rx metadata: rssi (always), resolving
- * index, directed adv report, and mesh channel and instant.
- */
-#define PDU_AC_SIZE_RSSI 1
-#if defined(CONFIG_BT_CTLR_PRIVACY)
-#define PDU_AC_SIZE_PRIV 1
-#else
-#define PDU_AC_SIZE_PRIV 0
-#endif /* CONFIG_BT_CTLR_PRIVACY */
-#if defined(CONFIG_BT_CTLR_EXT_SCAN_FP)
-#define PDU_AC_SIZE_SCFP 1
-#else
-#define PDU_AC_SIZE_SCFP 0
-#endif /* CONFIG_BT_CTLR_EXT_SCAN_FP */
-#if defined(CONFIG_BT_HCI_MESH_EXT)
-#define PDU_AC_SIZE_MESH 5
-#else
-#define PDU_AC_SIZE_MESH 0
-#endif /* CONFIG_BT_HCI_MESH_EXT */
-
-#define PDU_AC_LL_SIZE_EXTRA (PDU_AC_SIZE_RSSI + \
-			      PDU_AC_SIZE_PRIV + \
-			      PDU_AC_SIZE_SCFP + \
-			      PDU_AC_SIZE_MESH)
-
-
 struct pdu_adv_adv_ind {
 	uint8_t addr[BDADDR_SIZE];
 	uint8_t data[PDU_AC_DATA_SIZE_MAX];

--- a/tests/bluetooth/controller/mock_ctrl/src/ull.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/ull.c
@@ -61,12 +61,14 @@ static MFIFO_DEFINE(pdu_rx_free, sizeof(void *), PDU_RX_CNT);
 #define NODE_RX_HEADER_SIZE (offsetof(struct node_rx_pdu, pdu))
 #define NODE_RX_STRUCT_OVERHEAD (NODE_RX_HEADER_SIZE)
 
-#define PDU_ADVERTIZE_SIZE (PDU_AC_LL_SIZE_MAX + PDU_AC_LL_SIZE_EXTRA)
+#define PDU_ADV_SIZE  MAX(PDU_AC_LL_SIZE_MAX, \
+			  (PDU_AC_LL_HEADER_SIZE + LL_EXT_OCTETS_RX_MAX))
+
 #define PDU_DATA_SIZE (PDU_DC_LL_HEADER_SIZE + LL_LENGTH_OCTETS_RX_MAX)
 
 #define PDU_RX_NODE_POOL_ELEMENT_SIZE                                                              \
 	MROUND(NODE_RX_STRUCT_OVERHEAD +                                                           \
-	       MAX(MAX(PDU_ADVERTIZE_SIZE, PDU_DATA_SIZE), PDU_RX_USER_PDU_OCTETS_MAX))
+	       MAX(MAX(PDU_ADV_SIZE, PDU_DATA_SIZE), PDU_RX_USER_PDU_OCTETS_MAX))
 
 /*
  * just a big number


### PR DESCRIPTION
The define for PDU_AC_LL_SIZE_EXTRA was removed in main, but not in
the topic-branch. The merge of topic/branch erroneously reintroduced
this define, so it needs to be removed

Signed-off-by: Andries Kruithof <Andries.Kruithof@nordicsemi.no>