### PR TITLE
modules: trusted-firmware-m: Fix mcuboot imgtool not found on path

### DIFF
--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -358,6 +358,10 @@ if (CONFIG_BUILD_WITH_TFM)
       set(pad_args --pad --pad-header)
     endif()
     set (${OUT_ARG}
+      # Add the MCUBoot script to the path so that if there is a version of imgtool in there then
+      # it gets used over the system imgtool. Used so that imgtool from upstream
+      # mcuboot is preferred over system imgtool
+      ${CMAKE_COMMAND} -E env PYTHONPATH=${ZEPHYR_MCUBOOT_MODULE_DIR}/scripts
       ${PYTHON_EXECUTABLE} ${TFM_MCUBOOT_DIR}/scripts/wrapper/wrapper.py
       --layout ${PREPROCESSED_FILE_${SUFFIX}}
       -k ${CONFIG_TFM_KEY_FILE_${SUFFIX}}


### PR DESCRIPTION
Fix issue with TFM signing of images not using the correct imgtool.
The wrapper command expects the mcuboot scripts folder to be the
current working directory when called in order to find its own
version of imgtool.
Since the command is using a different current working directory
this is not found and the system imgtool is used instead.
This causes the commands to be run with 2 different version of imgtool
if the system imgtool is found and does not have any issues.
The system imgtool could not be installed or have compatibility issues
as 1.7.2 version of imgtool is currently required by the wrapper script

Fixes: #40254

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>