### PR TITLE
samples: cdc_acm: check return value of uart_fifo_read()

### DIFF
--- a/samples/subsys/usb/cdc_acm/src/main.c
+++ b/samples/subsys/usb/cdc_acm/src/main.c
@@ -40,6 +40,10 @@ static void interrupt_handler(const struct device *dev, void *user_data)
 					 sizeof(buffer));
 
 			recv_len = uart_fifo_read(dev, buffer, len);
+			if (recv_len < 0) {
+				LOG_ERR("Failed to read UART FIFO");
+				recv_len = 0;
+			};
 
 			rb_len = ring_buf_put(&ringbuf, buffer, recv_len);
 			if (rb_len < recv_len) {
@@ -47,8 +51,9 @@ static void interrupt_handler(const struct device *dev, void *user_data)
 			}
 
 			LOG_DBG("tty fifo -> ringbuf %d bytes", rb_len);
-
-			uart_irq_tx_enable(dev);
+			if (rb_len) {
+				uart_irq_tx_enable(dev);
+			}
 		}
 
 		if (uart_irq_tx_ready(dev)) {


### PR DESCRIPTION
uart_fifo_read() can return negative values in case
it is not implemented or CONFIG_UART_INTERRUPT_DRIVEN
is not enabled. Both cases can not actually happen in the
case of CDC ACM UART, check it anyway in case behavior
of the UART API changes unnoticed.

Align the code in RX path code of both camples and
enable TX interrupt only if data was received successfully.

Fixes: #39835
Fixes: #39824
Fixes: #39809
Coverity-CID: 240667
Coverity-CID: 240679
Coverity-CID: 240697