### PR TITLE
scripts/arch: remove usage of deprecated LooseVersion

### DIFF
--- a/arch/x86/gen_gdt.py
+++ b/arch/x86/gen_gdt.py
@@ -40,14 +40,14 @@ import sys
 import struct
 import os
 
-from distutils.version import LooseVersion
+from packaging import version
 
 import elftools
 from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import SymbolTableSection
 
 
-if LooseVersion(elftools.__version__) < LooseVersion('0.24'):
+if version.parse(elftools.__version__) < version.parse('0.24'):
     sys.exit("pyelftools is out of date, need version 0.24 or later")
 
 

--- a/arch/x86/gen_idt.py
+++ b/arch/x86/gen_idt.py
@@ -33,11 +33,11 @@ import sys
 import struct
 import os
 import elftools
-from distutils.version import LooseVersion
+from packaging import version
 from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import SymbolTableSection
 
-if LooseVersion(elftools.__version__) < LooseVersion('0.24'):
+if version.parse(elftools.__version__) < version.parse('0.24'):
     sys.exit("pyelftools is out of date, need version 0.24 or later")
 
 # This will never change, first selector in the GDT after the null selector

--- a/arch/x86/gen_mmu.py
+++ b/arch/x86/gen_mmu.py
@@ -74,13 +74,13 @@ import struct
 import re
 import textwrap
 
-from distutils.version import LooseVersion
+from packaging import version
 
 import elftools
 from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import SymbolTableSection
 
-if LooseVersion(elftools.__version__) < LooseVersion('0.24'):
+if version.parse(elftools.__version__) < version.parse('0.24'):
     sys.exit("pyelftools is out of date, need version 0.24 or later")
 
 

--- a/scripts/footprint/size_report
+++ b/scripts/footprint/size_report
@@ -18,7 +18,7 @@ import re
 from pathlib import Path
 import json
 
-from distutils.version import LooseVersion
+from packaging import version
 
 from colorama import init, Fore
 
@@ -34,7 +34,7 @@ from elftools.dwarf.descriptions import (
 from elftools.dwarf.locationlists import (
     LocationExpr, LocationParser)
 
-if LooseVersion(elftools.__version__) < LooseVersion('0.24'):
+if version.parse(elftools.__version__) < version.parse('0.24'):
     sys.exit("pyelftools is out of date, need version 0.24 or later")
 
 

--- a/scripts/gen_handles.py
+++ b/scripts/gen_handles.py
@@ -31,7 +31,7 @@ import argparse
 import os
 import struct
 import pickle
-from distutils.version import LooseVersion
+from packaging import version
 
 import elftools
 from elftools.elf.elffile import ELFFile
@@ -43,7 +43,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__),
                              'dts', 'python-devicetree', 'src'))
 from devicetree import edtlib  # pylint: disable=unused-import
 
-if LooseVersion(elftools.__version__) < LooseVersion('0.24'):
+if version.parse(elftools.__version__) < version.parse('0.24'):
     sys.exit("pyelftools is out of date, need version 0.24 or later")
 
 scr = os.path.basename(sys.argv[0])

--- a/scripts/gen_kobject_list.py
+++ b/scripts/gen_kobject_list.py
@@ -57,13 +57,13 @@ import math
 import os
 import struct
 import json
-from distutils.version import LooseVersion
+from packaging import version
 
 import elftools
 from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import SymbolTableSection
 
-if LooseVersion(elftools.__version__) < LooseVersion('0.24'):
+if version.parse(elftools.__version__) < version.parse('0.24'):
     sys.exit("pyelftools is out of date, need version 0.24 or later")
 
 from collections import OrderedDict

--- a/scripts/gen_kobject_placeholders.py
+++ b/scripts/gen_kobject_placeholders.py
@@ -85,7 +85,7 @@ def generate_linker_headers(obj):
             continue
 
         name = one_sect.name
-        if name in sections.keys():
+        if name in sections:
             # Need section alignment and size
             sections[name]['align'] = one_sect['sh_addralign']
             sections[name]['size'] = one_sect['sh_size']

--- a/scripts/gen_kobject_placeholders.py
+++ b/scripts/gen_kobject_placeholders.py
@@ -17,13 +17,13 @@ the same during later stages of linking.
 import sys
 import argparse
 import os
-from distutils.version import LooseVersion
+from packaging import version
 
 import elftools
 from elftools.elf.elffile import ELFFile
 
 
-if LooseVersion(elftools.__version__) < LooseVersion('0.24'):
+if version.parse(elftools.__version__) < version.parse('0.24'):
     sys.exit("pyelftools is out of date, need version 0.24 or later")
 
 

--- a/scripts/process_gperf.py
+++ b/scripts/process_gperf.py
@@ -21,7 +21,7 @@ import sys
 import argparse
 import os
 import re
-from distutils.version import LooseVersion
+from packaging import version
 
 # --- debug stuff ---
 
@@ -90,9 +90,9 @@ def process_line(line, fp):
 
     m = re.search("gperf version (.*) [*][/]$", line)
     if m:
-        v = LooseVersion(m.groups()[0])
-        v_lo = LooseVersion("3.0")
-        v_hi = LooseVersion("3.1")
+        v = version.parse(m.groups()[0])
+        v_lo = version.parse("3.0")
+        v_hi = version.parse("3.1")
         if (v < v_lo or v > v_hi):
             warn("gperf %s is not tested, versions %s through %s supported" %
                  (v, v_lo, v_hi))


### PR DESCRIPTION
replace with version.parse from packaging module.

prevent this warning message:
DeprecationWarning: The distutils package is deprecated
and slated for removal in Python 3.12. Use setuptools or
check PEP 632 for potential alternatives

Signed-off-by: Julien Massot <julien.massot@iot.bzh>