### PR TITLE
doc: remove incorrect info about sensor_value

### DIFF
--- a/doc/reference/peripherals/sensor.rst
+++ b/doc/reference/peripherals/sensor.rst
@@ -55,12 +55,6 @@ compensates data for both channels.
    :lines: 12-
    :linenos:
 
-The example assumes that the returned values have type :c:struct:`sensor_value`,
-which is the case for BME280.  A real application
-supporting multiple sensors should inspect the :c:data:`type` field of
-the :c:data:`temp` and :c:data:`press` values and use the other fields
-of the structure accordingly.
-
 Configuration and Attributes
 ****************************
 


### PR DESCRIPTION
After removing the "type" and "dval" members, the documenation still
referred to these fields. This commit removes the paragraph
about checking the type of values returned from sensor.

Signed-off-by: Michał Barnaś <mb@semihalf.com>