### PR TITLE
board: thingy53_nrf5340: Remove outdated nrf21540 FEM pins

### DIFF
--- a/boards/arm/thingy53_nrf5340/Kconfig
+++ b/boards/arm/thingy53_nrf5340/Kconfig
@@ -3,13 +3,6 @@
 # Copyright (c) 2021 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-config THINGY53_MISO_WORKAROUND
-	bool "MISO workaround"
-	default SPI
-	help
-	  Workaround SPI bus MISO issues. The workaround sets dedicated pin
-	  high in order to avoid voltage drops on the SPI MISO line.
-
 config THINGY53_INIT_PRIORITY
 	int "Init priority"
 	default 79

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
@@ -83,12 +83,13 @@
 		regulator-boot-on;
 	};
 
-	nrf21540fem_ctrl: nrf21540fem-ctrl {
+	nrf_radio_fem: fem {
 		compatible = "nordic,nrf21540-fem";
 		rx-en-gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
 		mode-gpios  = <&gpio1 12 GPIO_ACTIVE_HIGH>;
 		pdn-gpios   = <&gpio1 10 GPIO_ACTIVE_HIGH>;
 		tx-en-gpios = <&gpio0 30 GPIO_ACTIVE_HIGH>;
+		spi-if = <&nrf_radio_fem_spi>;
 	};
 
 	aliases {
@@ -180,7 +181,7 @@
 		int1-gpios = <&gpio0 23 0>;
 	};
 
-	nrf21540fem: spi-dev-nrf21540fem@2 {
+	nrf_radio_fem_spi: fem_spi@2 {
 		compatible = "nordic,nrf21540-fem-spi";
 		status = "okay";
 		reg = <2>;

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpunet.dts
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpunet.dts
@@ -50,12 +50,12 @@
 		};
 	};
 
-	nrf_radio_fem: nrf21540_fem {
+	nrf_radio_fem: fem {
 		compatible = "nordic,nrf21540-fem";
-		rx-en-gpios = <&gpio1 11 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
-		mode-gpios = <&gpio1 12 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
-		pdn-gpios = <&gpio1 10 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
-		tx-en-gpios = <&gpio0 30 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
+		rx-en-gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+		mode-gpios  = <&gpio1 12 GPIO_ACTIVE_HIGH>;
+		pdn-gpios   = <&gpio1 10 GPIO_ACTIVE_HIGH>;
+		tx-en-gpios = <&gpio0 30 GPIO_ACTIVE_HIGH>;
 	};
 
 	aliases {


### PR DESCRIPTION
Remove outdated nrf21540 FEM pins. The configuration for these are
outdated as more pins have been added later.
The module that uses these document the addition of this to be added
as overlays from the application, and the mcu selection is handled by
the MPSL FEM module.

The current setup would not work with TFM enabled since the mcu select
code would not be included in the secure image.
Since this is the responsebility of the MPSL FEM module remove it so
that there is only one place that needs to be updated for TFM.

Copy FEM pin configuration for Thingy:53 board from cpunet device tree
configuration to the application device tree configuration so that it is
added for both application and network core as documented in user guide
for FEM in GPIO mode.

Add nrf_radio_fem_spi node to application device tree configuration.

This removes the GPIO_PULL_DOWN configuration which was not correct.