### PR TITLE
drivers/pinmux: stm32f1: Rework remap field encoding

### DIFF
--- a/drivers/pinmux/pinmux_stm32.h
+++ b/drivers/pinmux/pinmux_stm32.h
@@ -99,12 +99,11 @@ int stm32_dt_pinctrl_configure(const struct soc_gpio_pinctrl *pinctrl,
  *
  * @param *pinctrl pointer to soc_gpio_pinctrl list
  * @param list_size list size
- * @param base device base register value
  *
  * @return 0 value on success, -EINVAL otherwise
  */
 int stm32_dt_pinctrl_remap(const struct soc_gpio_pinctrl *pinctrl,
-			   size_t list_size, uint32_t base);
+			   size_t list_size);
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32f1_pinctrl) */
 
 #ifdef __cplusplus

--- a/drivers/pinmux/pinmux_stm32.h
+++ b/drivers/pinmux/pinmux_stm32.h
@@ -37,26 +37,21 @@ struct soc_gpio_pinctrl {
  * value
  */
 #define STM32_DT_PINMUX_PORT(__pin) \
-	(((__pin) >> 12) & 0xf)
+	(((__pin) >> STM32_PORT_SHIFT) & STM32_PORT_MASK)
 
 /**
  * @brief helper to extract IO pin number from STM32_PINMUX() encoded
  * value
  */
 #define STM32_DT_PINMUX_LINE(__pin) \
-	(((__pin) >> 8) & 0xf)
+	(((__pin) >> STM32_LINE_SHIFT) & STM32_LINE_MASK)
 
 /**
  * @brief helper to extract IO pin func from STM32_PINMUX() encoded
  * value
  */
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32f1_pinctrl)
 #define STM32_DT_PINMUX_FUNC(__pin) \
-	(((__pin) >> 6) & 0x3)
-#else
-#define STM32_DT_PINMUX_FUNC(__pin) \
-	((__pin) & 0xff)
-#endif
+	(((__pin) >> STM32_MODE_SHIFT) & STM32_MODE_MASK)
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32f1_pinctrl)
 /**
@@ -64,7 +59,7 @@ struct soc_gpio_pinctrl {
  * value
  */
 #define STM32_DT_PINMUX_REMAP(__pin) \
-	((__pin) & 0x1fU)
+	(((__pin) >> STM32_REMAP_SHIFT) & STM32_REMAP_MASK)
 #endif
 
 /**

--- a/include/dt-bindings/pinctrl/stm32-pinctrl.h
+++ b/include/dt-bindings/pinctrl/stm32-pinctrl.h
@@ -35,11 +35,34 @@
 
 /**
  * @brief Macro to generate pinmux int using port, pin number and mode arguments
- * This is taken from Linux equivalent st,stm32f429-pinctrl binding
+ * This is inspired from Linux equivalent st,stm32f429-pinctrl binding
  */
 
-#define PIN_NO(port, line)	(((port) - 'A') * 0x10 + (line))
-#define STM32_PINMUX(port, line, mode) (((PIN_NO(port, line)) << 8) | (STM32_ ## mode))
+/**
+ * @brief Pin configuration configuration bit field.
+ *
+ * Fields:
+ *
+ * - mode [ 0 : 4 ]
+ * - line [ 5 : 8 ]
+ * - port [ 9 : 12 ]
+ *
+ * @param port Port ('A'..'K')
+ * @param line Pin (0..15)
+ * @param mode Mode (ANALOG, GPIO_IN, ALTERNATE).
+ */
+
+#define STM32_MODE_SHIFT 0U
+#define STM32_MODE_MASK  0x1FU
+#define STM32_LINE_SHIFT 5U
+#define STM32_LINE_MASK  0xFU
+#define STM32_PORT_SHIFT 9U
+#define STM32_PORT_MASK  0xFU
+
+#define STM32_PINMUX(port, line, mode)					       \
+		(((((port) - 'A') & STM32_PORT_MASK) << STM32_PORT_SHIFT) |    \
+		(((line) & STM32_LINE_MASK) << STM32_LINE_SHIFT) |	       \
+		(((STM32_ ## mode) & STM32_MODE_MASK) << STM32_MODE_SHIFT))
 
 /**
  * @brief PIN configuration bitfield

--- a/include/dt-bindings/pinctrl/stm32f1-afio.h
+++ b/include/dt-bindings/pinctrl/stm32f1-afio.h
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2021 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_STM32_AFIO_H_
+#define ZEPHYR_STM32_AFIO_H_
+
+/**
+ * @brief STM32F1 Remap configuration bit field.
+ *
+ * - reg   (0/1)      [ 0 : 0 ]
+ * - shift (0..31)    [ 1 : 5 ]
+ * - mask  (0x1, 0x3) [ 6 : 7 ]
+ * - val   (0..3)     [ 8 : 9 ]
+ *
+ * @param reg AFIO_MAPRx register (MAPR, MAPR2).
+ * @param shift Position within AFIO_MAPRx.
+ * @param mask Mask for the AFIO_MAPRx field.
+ * @param val Remap value (0, 1, 2 or 3).
+ */
+
+#define STM32_REMAP_REG_MASK    0x1U
+#define STM32_REMAP_REG_SHIFT   0U
+#define STM32_REMAP_SHIFT_MASK  0x1FU
+#define STM32_REMAP_SHIFT_SHIFT 1U
+#define STM32_REMAP_MASK_MASK   0x3U
+#define STM32_REMAP_MASK_SHIFT  6U
+#define STM32_REMAP_VAL_MASK    0x3U
+#define STM32_REMAP_VAL_SHIFT   8U
+
+#define STM32_REMAP(val, mask, shift, reg)				       \
+	((((reg) & STM32_REMAP_REG_MASK) << STM32_REMAP_REG_SHIFT) |	       \
+	 (((shift) & STM32_REMAP_SHIFT_MASK) << STM32_REMAP_SHIFT_SHIFT) |     \
+	 (((mask) & STM32_REMAP_MASK_MASK) << STM32_REMAP_MASK_SHIFT) |	       \
+	 (((val) & STM32_REMAP_VAL_MASK) << STM32_REMAP_VAL_SHIFT))
+
+
+/* Accessors for remap value */
+
+/**
+ * Obtain register field from remap configuration.
+ *
+ * @param remap Remap bit field value.
+ */
+#define STM32_REMAP_REG_GET(remap) \
+	(((remap) >> STM32_REMAP_REG_SHIFT) & STM32_REMAP_REG_MASK)
+
+/**
+ * Obtain position field from remap configuration.
+ *
+ * @param remap Remap bit field value.
+ */
+#define STM32_REMAP_SHIFT_GET(remap) \
+	(((remap) >> STM32_REMAP_SHIFT_SHIFT) & STM32_REMAP_SHIFT_MASK)
+
+/**
+ * Obtain mask field from remap configuration.
+ *
+ * @param remap Remap bit field value.
+ */
+#define STM32_REMAP_MASK_GET(remap) \
+	(((remap) >> STM32_REMAP_MASK_SHIFT) & STM32_REMAP_MASK_MASK)
+
+/**
+ * Obtain value field from remap configuration.
+ *
+ * @param remap Remap bit field value.
+ */
+#define STM32_REMAP_VAL_GET(remap) \
+	(((remap) >> STM32_REMAP_VAL_SHIFT) & STM32_REMAP_VAL_MASK)
+
+
+/* Remap values definitions, according to RM0008.pdf */
+
+#define STM32_AFIO_MAPR		0U
+#define STM32_AFIO_MAPR2	1U
+
+/** Device not remappable **/
+#define NO_REMAP		0
+
+/** SPI1 (no remap) */
+#define SPI1_REMAP0		STM32_REMAP(0U, 0x1U, 0U, STM32_AFIO_MAPR)
+/** SPI1 (remap) */
+#define SPI1_REMAP1		STM32_REMAP(1U, 0x1U, 0U, STM32_AFIO_MAPR)
+
+/** I2C1 (no remap) */
+#define I2C1_REMAP0		STM32_REMAP(0U, 0x1U, 1U, STM32_AFIO_MAPR)
+/** I2C1 (remap) */
+#define I2C1_REMAP1		STM32_REMAP(1U, 0x1U, 1U, STM32_AFIO_MAPR)
+
+/** USART1 (no remap) */
+#define USART1_REMAP0		STM32_REMAP(0U, 0x1U, 2U, STM32_AFIO_MAPR)
+/** USART1 (remap) */
+#define USART1_REMAP1		STM32_REMAP(1U, 0x1U, 2U, STM32_AFIO_MAPR)
+
+/** USART2 (no remap) */
+#define USART2_REMAP0		STM32_REMAP(0U, 0x1U, 3U, STM32_AFIO_MAPR)
+/** USART2 (remap) */
+#define USART2_REMAP1		STM32_REMAP(1U, 0x1U, 3U, STM32_AFIO_MAPR)
+
+/** USART3 (no remap) */
+#define USART3_REMAP0		STM32_REMAP(0U, 0x3U, 4U, STM32_AFIO_MAPR)
+/** USART3 (partial remap) */
+#define USART3_REMAP1		STM32_REMAP(1U, 0x3U, 4U, STM32_AFIO_MAPR)
+/** USART3 (full remap) */
+#define USART3_REMAP2		STM32_REMAP(3U, 0x3U, 4U, STM32_AFIO_MAPR)
+
+/** TIM1 (no remap) */
+#define TIM1_REMAP0		STM32_REMAP(0U, 0x3U, 6U, STM32_AFIO_MAPR)
+/** TIM1 (partial remap) */
+#define TIM1_REMAP1		STM32_REMAP(1U, 0x3U, 6U, STM32_AFIO_MAPR)
+/** TIM1 (full remap) */
+#define TIM1_REMAP2		STM32_REMAP(3U, 0x3U, 6U, STM32_AFIO_MAPR)
+
+/** TIM2 (no remap) */
+#define TIM2_REMAP0		STM32_REMAP(0U, 0x3U, 8U, STM32_AFIO_MAPR)
+/** TIM2 (partial remap 1) */
+#define TIM2_REMAP1		STM32_REMAP(1U, 0x3U, 8U, STM32_AFIO_MAPR)
+/** TIM2 (partial remap 2) */
+#define TIM2_REMAP2		STM32_REMAP(2U, 0x3U, 8U, STM32_AFIO_MAPR)
+/** TIM2 (full remap) */
+#define TIM2_REMAP3		STM32_REMAP(3U, 0x3U, 8U, STM32_AFIO_MAPR)
+
+/** TIM3 (no remap) */
+#define TIM3_REMAP0		STM32_REMAP(0U, 0x3U, 10U, STM32_AFIO_MAPR)
+/** TIM3 (partial remap 1) */
+#define TIM3_REMAP1		STM32_REMAP(1U, 0x3U, 10U, STM32_AFIO_MAPR)
+/** TIM3 (partial remap 2) */
+#define TIM3_REMAP2		STM32_REMAP(2U, 0x3U, 10U, STM32_AFIO_MAPR)
+/** TIM3 (full remap) */
+#define TIM3_REMAP3		STM32_REMAP(3U, 0x3U, 10U, STM32_AFIO_MAPR)
+
+/** TIM4 (no remap) */
+#define TIM4_REMAP0		STM32_REMAP(0U, 0x1U, 12U, STM32_AFIO_MAPR)
+/** TIM4 (remap) */
+#define TIM4_REMAP1		STM32_REMAP(1U, 0x1U, 12U, STM32_AFIO_MAPR)
+
+/** CAN (no remap) */
+#define CAN_REMAP0		STM32_REMAP(0U, 0x3U, 13U, STM32_AFIO_MAPR)
+/** CAN (partial remap) */
+#define CAN_REMAP1		STM32_REMAP(2U, 0x3U, 13U, STM32_AFIO_MAPR)
+/** CAN (full remap) */
+#define CAN_REMAP2		STM32_REMAP(3U, 0x3U, 13U, STM32_AFIO_MAPR)
+
+/** CAN1 alias */
+#define CAN1_REMAP0		CAN_REMAP0
+#define CAN1_REMAP1		CAN_REMAP1
+#define CAN1_REMAP2		CAN_REMAP2
+
+/** ETH (no remap) */
+#define ETH_REMAP0		STM32_REMAP(0U, 0x1U, 20U, STM32_AFIO_MAPR)
+/** ETH (remap) */
+#define ETH_REMAP1		STM32_REMAP(1U, 0x1U, 20U, STM32_AFIO_MAPR)
+
+/** CAN2 (no remap) */
+#define CAN2_REMAP0		STM32_REMAP(0U, 0x1U, 21U, STM32_AFIO_MAPR)
+/** CAN2 (remap) */
+#define CAN2_REMAP1		STM32_REMAP(1U, 0x1U, 21U, STM32_AFIO_MAPR)
+
+/** SPI3 (no remap) */
+#define SPI3_REMAP0		STM32_REMAP(0U, 0x1U, 27U, STM32_AFIO_MAPR)
+/** SPI3 (remap) */
+#define SPI3_REMAP1		STM32_REMAP(1U, 0x1U, 27U, STM32_AFIO_MAPR)
+
+/** I2S3 (SPI3) (no remap) */
+#define I2S3_REMAP0		SPI3_REMAP0
+/** I2S3 (SPI3) (remap) */
+#define I2S3_REMAP1		SPI3_REMAP1
+
+/** TIM9 (no remap) */
+#define TIM9_REMAP0		STM32_REMAP(0U, 0x1U, 5U, STM32_AFIO_MAPR2)
+/** TIM9 (remap) */
+#define TIM9_REMAP1		STM32_REMAP(1U, 0x1U, 5U, STM32_AFIO_MAPR2)
+
+/** TIM10 (no remap) */
+#define TIM10_REMAP0		STM32_REMAP(0U, 0x1U, 6U, STM32_AFIO_MAPR2)
+/** TIM10 (remap) */
+#define TIM10_REMAP1		STM32_REMAP(1U, 0x1U, 6U, STM32_AFIO_MAPR2)
+
+/** TIM11 (no remap) */
+#define TIM11_REMAP0		STM32_REMAP(0U, 0x1U, 7U, STM32_AFIO_MAPR2)
+/** TIM11 (remap) */
+#define TIM11_REMAP1		STM32_REMAP(1U, 0x1U, 7U, STM32_AFIO_MAPR2)
+
+/** TIM13 (no remap) */
+#define TIM13_REMAP0		STM32_REMAP(0U, 0x1U, 8U, STM32_AFIO_MAPR2)
+/** TIM13 (remap) */
+#define TIM13_REMAP1		STM32_REMAP(1U, 0x1U, 8U, STM32_AFIO_MAPR2)
+
+/** TIM14 (no remap) */
+#define TIM14_REMAP0		STM32_REMAP(0U, 0x1U, 9U, STM32_AFIO_MAPR2)
+/** TIM14 (remap) */
+#define TIM14_REMAP1		STM32_REMAP(1U, 0x1U, 9U, STM32_AFIO_MAPR2)
+
+/** TIM15 (no remap) */
+#define TIM15_REMAP0		STM32_REMAP(0U, 0x1U, 0U, STM32_AFIO_MAPR2)
+/** TIM15 (remap) */
+#define TIM15_REMAP1		STM32_REMAP(1U, 0x1U, 0U, STM32_AFIO_MAPR2)
+
+/** TIM16 (no remap) */
+#define TIM16_REMAP0		STM32_REMAP(0U, 0x1U, 1U, STM32_AFIO_MAPR2)
+/** TIM16 (remap) */
+#define TIM16_REMAP1		STM32_REMAP(1U, 0x1U, 1U, STM32_AFIO_MAPR2)
+
+/** TIM17 (no remap) */
+#define TIM17_REMAP0		STM32_REMAP(0U, 0x1U, 2U, STM32_AFIO_MAPR2)
+/** TIM17 (remap) */
+#define TIM17_REMAP1		STM32_REMAP(1U, 0x1U, 2U, STM32_AFIO_MAPR2)
+
+#endif	/* ZEPHYR_STM32_AFIO_H_ */

--- a/include/dt-bindings/pinctrl/stm32f1-pinctrl.h
+++ b/include/dt-bindings/pinctrl/stm32f1-pinctrl.h
@@ -8,6 +8,7 @@
 #define ZEPHYR_STM32_PINCTRLF1_H_
 
 #include <dt-bindings/pinctrl/stm32-pinctrl-common.h>
+#include <dt-bindings/pinctrl/stm32f1-afio.h>
 
 /* Adapted from Linux: include/dt-bindings/pinctrl/stm32-pinfunc.h */
 
@@ -24,7 +25,7 @@
  * - mode  [ 0 : 1 ]
  * - line  [ 2 : 5 ]
  * - port  [ 6 : 9 ]
- * - remap [ 10 : 12 ]
+ * - remap [ 10 : 19 ]
  *
  * @param port Port ('A'..'K')
  * @param line Pin (0..15)
@@ -39,7 +40,7 @@
 #define STM32_PORT_SHIFT  6U
 #define STM32_PORT_MASK   0xFU
 #define STM32_REMAP_SHIFT 10U
-#define STM32_REMAP_MASK  0x1FU
+#define STM32_REMAP_MASK  0x3FFU
 
 #define STM32F1_PINMUX(port, line, mode, remap)				       \
 		(((((port) - 'A') & STM32_PORT_MASK) << STM32_PORT_SHIFT) |    \
@@ -54,16 +55,6 @@
 #define ALTERNATE	0x0  /* Alternate function output */
 #define GPIO_IN		0x1  /* Input */
 #define ANALOG		0x2  /* Analog */
-
-/**
- * @brief Pin remapping configurations
- */
-
-#define NO_REMAP	0x0  /* No remapping */
-#define REMAP_1		0x1  /* Partial remapping 1 */
-#define REMAP_2		0x2  /* Partial remapping 2 */
-#define REMAP_3		0x3  /* Partial remapping 3 */
-#define REMAP_FULL	0x4  /* Full remapping */
 
 /**
  * @brief PIN configuration bitfield

--- a/include/dt-bindings/pinctrl/stm32f1-pinctrl.h
+++ b/include/dt-bindings/pinctrl/stm32f1-pinctrl.h
@@ -16,9 +16,36 @@
  * This is adapted from Linux equivalent st,stm32f429-pinctrl binding
  */
 
-#define PIN_NO(port, line)	(((port) - 'A') * 0x10 + (line))
-#define STM32F1_PINMUX(port, line, mode, remap) \
-			(((PIN_NO(port, line)) << 8) | (mode << 6) | (remap))
+/**
+ * @brief Pin configuration configuration bit field.
+ *
+ * Fields:
+ *
+ * - mode  [ 0 : 1 ]
+ * - line  [ 2 : 5 ]
+ * - port  [ 6 : 9 ]
+ * - remap [ 10 : 12 ]
+ *
+ * @param port Port ('A'..'K')
+ * @param line Pin (0..15)
+ * @param mode Pin mode (ANALOG, GPIO_IN, ALTERNATE).
+ * @param remap Pin remapping configuration (NO_REMAP, REMAP_1, ...)
+ */
+
+#define STM32_MODE_SHIFT  0U
+#define STM32_MODE_MASK   0x3U
+#define STM32_LINE_SHIFT  2U
+#define STM32_LINE_MASK   0xFU
+#define STM32_PORT_SHIFT  6U
+#define STM32_PORT_MASK   0xFU
+#define STM32_REMAP_SHIFT 10U
+#define STM32_REMAP_MASK  0x1FU
+
+#define STM32F1_PINMUX(port, line, mode, remap)				       \
+		(((((port) - 'A') & STM32_PORT_MASK) << STM32_PORT_SHIFT) |    \
+		(((line) & STM32_LINE_MASK) << STM32_LINE_SHIFT) |	       \
+		(((mode) & STM32_MODE_MASK) << STM32_MODE_SHIFT) |	       \
+		(((remap) & STM32_REMAP_MASK) << STM32_REMAP_SHIFT))
 
 /**
  * @brief Pin modes

--- a/west.yml
+++ b/west.yml
@@ -124,7 +124,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 5c8275071ec1cf160bfe8c18bbd9330a7d714dc8
+      revision: 6fc9b5f7e0229ef64a882e37213266d346ebfadb
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Suggested by @gmarull in https://github.com/zephyrproject-rtos/zephyr/pull/40194#issuecomment-972648478.

Aim of the change is to stop requiring device reg address information in STM32F1 pinmux api.
This is done by adding all the information required for pin remap configuration directly inside remap
field which is provided in pinctrl device tree description.

This is an alternate solution to https://github.com/zephyrproject-rtos/zephyr/pull/40430,
which was raised to enable new pinctrl API deployment in case of STM32F1 PWM (issue described [here](https://github.com/zephyrproject-rtos/zephyr/pull/40194#issuecomment-965031732).
