### PR TITLE
drivers: usb_dc_native_posix: check return value from recv()

### DIFF
--- a/drivers/usb/device/usb_dc_native_posix.c
+++ b/drivers/usb/device/usb_dc_native_posix.c
@@ -526,7 +526,10 @@ int handle_usb_control(struct usbip_header *hdr)
 	if (ntohl(hdr->common.direction) == USBIP_DIR_OUT) {
 		/* Data OUT stage availably */
 		ep_ctrl->data_len = ntohl(hdr->u.submit.transfer_buffer_length);
-		usbip_recv(ep_ctrl->buf, ep_ctrl->data_len);
+		if (usbip_recv(ep_ctrl->buf, ep_ctrl->data_len) < 0) {
+			return -EIO;
+		}
+
 		LOG_DBG("DATA OUT event ep 0x%02x %u",
 			ep_idx, ep_ctrl->data_len);
 		ep_ctrl->cb(ep_idx, USB_DC_EP_DATA_OUT);
@@ -549,9 +552,11 @@ int handle_usb_data(struct usbip_header *hdr)
 		ep_ctrl = &usbip_ctrl.out_ep_ctrl[ep_idx];
 		ep = ep_idx | USB_EP_DIR_OUT;
 		ep_ctrl->data_len = ntohl(hdr->u.submit.transfer_buffer_length);
-		usbip_recv(ep_ctrl->buf, ep_ctrl->data_len);
-		LOG_DBG("DATA OUT event ep 0x%02x %u", ep, ep_ctrl->data_len);
+		if (usbip_recv(ep_ctrl->buf, ep_ctrl->data_len) < 0) {
+			return -EIO;
+		}
 
+		LOG_DBG("DATA OUT event ep 0x%02x %u", ep, ep_ctrl->data_len);
 		ep_ctrl->cb(ep, USB_DC_EP_DATA_OUT);
 
 		/* Send ACK reply */


### PR DESCRIPTION
Check return value from recv() passed by usbip_recv().

Fixes: #39849
Fixes: #39869
Coverity-CID: 240221
Coverity-CID: 240244