### PR TITLE
pm:device-constraint: Add power management constraints to devices

### DIFF
--- a/doc/guides/pm/device_runtime.rst
+++ b/doc/guides/pm/device_runtime.rst
@@ -154,7 +154,10 @@ must perform the necessary operations to suspend the device.
         ...
         /* make sure the device physically is suspended */
         /* enable device runtime power management */
-        pm_device_runtime_enable(dev);
+        ret = pm_device_runtime_enable(dev);
+        if (ret < 0) {
+                return ret;
+        }
         ...
     }
 

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -612,9 +612,7 @@ static int gpio_stm32_init(const struct device *dev)
 #endif
 
 #ifdef CONFIG_PM_DEVICE_RUNTIME
-	pm_device_runtime_enable(dev);
-
-	return 0;
+	return pm_device_runtime_enable(dev);
 #else
 	return gpio_stm32_clock_request(dev, true);
 #endif

--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -298,6 +298,7 @@ const char *pm_device_state_str(enum pm_device_state state);
  * @retval -EALREADY If device is already at the requested state.
  * @retval -EBUSY If device is changing its state.
  * @retval -ENOSYS If device does not support PM.
+ * @retval -EPERM If device has power state locked.
  * @retval Errno Other negative errno on failure.
  */
 __deprecated int pm_device_state_set(const struct device *dev,
@@ -417,6 +418,8 @@ bool pm_device_wakeup_is_capable(const struct device *dev);
  * locked the device power state will not be changed by
  * system power management or device runtime power
  * management until unlocked.
+ *
+ * @note The given device should not have device runtime enabled.
  *
  * @see pm_device_state_unlock
  *

--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -39,6 +39,8 @@ enum pm_device_flag {
 	PM_DEVICE_FLAG_WS_ENABLED,
 	/** Indicates if device runtime is enabled  */
 	PM_DEVICE_FLAG_RUNTIME_ENABLED,
+	/** Indicates if the device pm is locked.  */
+	PM_DEVICE_FLAG_STATE_LOCKED,
 };
 
 /** @endcond */
@@ -407,6 +409,42 @@ bool pm_device_wakeup_is_enabled(const struct device *dev);
  * @retval false If the device is not wake up capable.
  */
 bool pm_device_wakeup_is_capable(const struct device *dev);
+
+/**
+ * @brief Lock current device state.
+ *
+ * This function locks the current device power state. Once
+ * locked the device power state will not be changed by
+ * system power management or device runtime power
+ * management until unlocked.
+ *
+ * @see pm_device_state_unlock
+ *
+ * @param dev Device instance.
+ */
+void pm_device_state_lock(const struct device *dev);
+
+/**
+ * @brief Unlock the current device state.
+ *
+ * Unlocks a previously locked device pm.
+ *
+ * @see pm_device_state_lock
+ *
+ * @param dev Device instance.
+ */
+void pm_device_state_unlock(const struct device *dev);
+
+/**
+ * @brief Check if the device pm is locked.
+ *
+ * @param dev Device instance.
+ *
+ * @retval true If device is locked.
+ * @retval false If device is not locked.
+ */
+bool pm_device_state_is_locked(const struct device *dev);
+
 #else
 static inline void pm_device_busy_set(const struct device *dev) {}
 static inline void pm_device_busy_clear(const struct device *dev) {}
@@ -421,6 +459,12 @@ static inline bool pm_device_wakeup_is_enabled(const struct device *dev)
 	return false;
 }
 static inline bool pm_device_wakeup_is_capable(const struct device *dev)
+{
+	return false;
+}
+static inline void pm_device_state_lock(const struct device *dev) {}
+static inline void pm_device_state_unlock(const struct device *dev) {}
+static inline bool pm_device_state_is_locked(const struct device *dev)
 {
 	return false;
 }

--- a/include/pm/device_runtime.h
+++ b/include/pm/device_runtime.h
@@ -28,8 +28,12 @@ extern "C" {
  * @funcprops \pre_kernel_ok
  *
  * @param dev Device instance.
+ *
+ * @retval 0 If the device runtime PM is enabled successfully.
+ * @retval -EPERM If device has power state locked.
+ * @retval -ENOSYS If the functionality is not available.
  */
-void pm_device_runtime_enable(const struct device *dev);
+int pm_device_runtime_enable(const struct device *dev);
 
 /**
  * @brief Disable device runtime PM
@@ -131,7 +135,7 @@ int pm_device_runtime_put_async(const struct device *dev);
 bool pm_device_runtime_is_enabled(const struct device *dev);
 
 #else
-static inline void pm_device_runtime_enable(const struct device *dev) { }
+static inline int pm_device_runtime_enable(const struct device *dev) { return -ENOSYS; }
 static inline int pm_device_runtime_disable(const struct device *dev) { return -ENOSYS; }
 static inline int pm_device_runtime_get(const struct device *dev) { return -ENOSYS; }
 static inline int pm_device_runtime_put(const struct device *dev) { return -ENOSYS; }

--- a/include/tracing/tracing.h
+++ b/include/tracing/tracing.h
@@ -1983,8 +1983,9 @@ void sys_trace_idle(void);
 /**
  * @brief Trace enabling device runtime PM call exit.
  * @param dev Device instance.
+ * @param ret Return value.
  */
-#define sys_port_trace_pm_device_runtime_enable_exit(dev)
+#define sys_port_trace_pm_device_runtime_enable_exit(dev, ret)
 
 /**
  * @brief Trace disabling device runtime PM call entry.

--- a/samples/subsys/pm/device_pm/src/dummy_driver.c
+++ b/samples/subsys/pm/device_pm/src/dummy_driver.c
@@ -109,9 +109,7 @@ int dummy_init(const struct device *dev)
 		printk("parent not found\n");
 	}
 
-	pm_device_runtime_enable(dev);
-
-	return 0;
+	return pm_device_runtime_enable(dev);
 }
 
 PM_DEVICE_DEFINE(dummy_driver, dummy_device_pm_action);

--- a/samples/subsys/pm/device_pm/src/dummy_parent.c
+++ b/samples/subsys/pm/device_pm/src/dummy_parent.c
@@ -48,8 +48,7 @@ static const struct dummy_parent_api funcs = {
 
 int dummy_parent_init(const struct device *dev)
 {
-	pm_device_runtime_enable(dev);
-	return 0;
+	return pm_device_runtime_enable(dev);
 }
 
 PM_DEVICE_DEFINE(dummy_parent, dummy_parent_pm_action);

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -6,6 +6,7 @@
 
 #include <device.h>
 #include <pm/device.h>
+#include <pm/device_runtime.h>
 
 #include <logging/log.h>
 LOG_MODULE_REGISTER(pm_device, CONFIG_PM_DEVICE_LOG_LEVEL);
@@ -33,6 +34,10 @@ int pm_device_state_set(const struct device *dev,
 
 	if (pm == NULL) {
 		return -ENOSYS;
+	}
+
+	if (pm_device_state_is_locked(dev)) {
+		return -EPERM;
 	}
 
 	switch (state) {
@@ -246,7 +251,7 @@ void pm_device_state_lock(const struct device *dev)
 {
 	struct pm_device *pm = dev->pm;
 
-	if (pm != NULL) {
+	if ((pm != NULL) && !pm_device_runtime_is_enabled(dev)) {
 		atomic_set_bit(&pm->flags, PM_DEVICE_FLAG_STATE_LOCKED);
 	}
 }

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -241,3 +241,33 @@ bool pm_device_wakeup_is_capable(const struct device *dev)
 	return atomic_test_bit(&pm->flags,
 			       PM_DEVICE_FLAG_WS_CAPABLE);
 }
+
+void pm_device_state_lock(const struct device *dev)
+{
+	struct pm_device *pm = dev->pm;
+
+	if (pm != NULL) {
+		atomic_set_bit(&pm->flags, PM_DEVICE_FLAG_STATE_LOCKED);
+	}
+}
+
+void pm_device_state_unlock(const struct device *dev)
+{
+	struct pm_device *pm = dev->pm;
+
+	if (pm != NULL) {
+		atomic_clear_bit(&pm->flags, PM_DEVICE_FLAG_STATE_LOCKED);
+	}
+}
+
+bool pm_device_state_is_locked(const struct device *dev)
+{
+	struct pm_device *pm = dev->pm;
+
+	if (pm == NULL) {
+		return false;
+	}
+
+	return atomic_test_bit(&pm->flags,
+			       PM_DEVICE_FLAG_STATE_LOCKED);
+}

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -172,6 +172,10 @@ void pm_device_runtime_enable(const struct device *dev)
 
 	SYS_PORT_TRACING_FUNC_ENTER(pm, device_runtime_enable, dev);
 
+	if (pm_device_state_is_locked(dev)) {
+		goto end;
+	}
+
 	if (!k_is_pre_kernel()) {
 		(void)k_mutex_lock(&pm->lock, K_FOREVER);
 	}
@@ -195,6 +199,7 @@ unlock:
 		k_mutex_unlock(&pm->lock);
 	}
 
+end:
 	SYS_PORT_TRACING_FUNC_EXIT(pm, device_runtime_enable, dev);
 }
 

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -166,13 +166,15 @@ int pm_device_runtime_put_async(const struct device *dev)
 	return ret;
 }
 
-void pm_device_runtime_enable(const struct device *dev)
+int pm_device_runtime_enable(const struct device *dev)
 {
+	int ret = 0;
 	struct pm_device *pm = dev->pm;
 
 	SYS_PORT_TRACING_FUNC_ENTER(pm, device_runtime_enable, dev);
 
 	if (pm_device_state_is_locked(dev)) {
+		ret = -EPERM;
 		goto end;
 	}
 
@@ -200,7 +202,8 @@ unlock:
 	}
 
 end:
-	SYS_PORT_TRACING_FUNC_EXIT(pm, device_runtime_enable, dev);
+	SYS_PORT_TRACING_FUNC_EXIT(pm, device_runtime_enable, dev, ret);
+	return ret;
 }
 
 int pm_device_runtime_disable(const struct device *dev)

--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -56,8 +56,8 @@ static int pm_suspend_devices(void)
 		 * ignore busy devices, wake up source and devices with
 		 * runtime PM enabled.
 		 */
-		if (pm_device_is_busy(dev) ||
-		    pm_device_wakeup_is_enabled(dev) ||
+		if (pm_device_is_busy(dev) || pm_device_state_is_locked(dev)
+		    || pm_device_wakeup_is_enabled(dev) ||
 		    ((dev->pm != NULL) && pm_device_runtime_is_enabled(dev))) {
 			continue;
 		}

--- a/subsys/tracing/ctf/tracing_ctf.h
+++ b/subsys/tracing/ctf/tracing_ctf.h
@@ -331,7 +331,7 @@ extern "C" {
 #define sys_port_trace_pm_device_runtime_put_async_enter(dev)
 #define sys_port_trace_pm_device_runtime_put_async_exit(dev, ret)
 #define sys_port_trace_pm_device_runtime_enable_enter(dev)
-#define sys_port_trace_pm_device_runtime_enable_exit(dev)
+#define sys_port_trace_pm_device_runtime_enable_exit(dev, ret)
 #define sys_port_trace_pm_device_runtime_disable_enter(dev)
 #define sys_port_trace_pm_device_runtime_disable_exit(dev, ret)
 

--- a/subsys/tracing/sysview/SYSVIEW_Zephyr.txt
+++ b/subsys/tracing/sysview/SYSVIEW_Zephyr.txt
@@ -166,5 +166,5 @@ TaskState 0xBF 1=dummy, 2=Waiting, 4=New, 8=Terminated, 16=Suspended, 32=Termina
 156 pm_device_runtime_get        dev=%I | Returns %u
 157 pm_device_runtime_put        dev=%I | Returns %u
 158 pm_device_runtime_put_async  dev=%I | Returns %u
-159 pm_device_runtime_enable     dev=%I
+159 pm_device_runtime_enable     dev=%I | Returns %u
 160 pm_device_runtime_disable    dev=%I | Returns %u

--- a/subsys/tracing/sysview/tracing_sysview.h
+++ b/subsys/tracing/sysview/tracing_sysview.h
@@ -639,8 +639,9 @@ void sys_trace_k_thread_info(struct k_thread *thread);
 #define sys_port_trace_pm_device_runtime_enable_enter(dev)		       \
 	SEGGER_SYSVIEW_RecordU32(TID_PM_DEVICE_RUNTIME_ENABLE,		       \
 				 (uint32_t)(uintptr_t)dev)
-#define sys_port_trace_pm_device_runtime_enable_exit(dev) \
-	SEGGER_SYSVIEW_RecordEndCall(TID_PM_DEVICE_RUNTIME_ENABLE)
+#define sys_port_trace_pm_device_runtime_enable_exit(dev, ret)		       \
+	SEGGER_SYSVIEW_RecordEndCall(TID_PM_DEVICE_RUNTIME_ENABLE,	       \
+				     (uint32_t)ret)
 #define sys_port_trace_pm_device_runtime_disable_enter(dev)		       \
 	SEGGER_SYSVIEW_RecordU32(TID_PM_DEVICE_RUNTIME_DISABLE,		       \
 				 (uint32_t)(uintptr_t)dev)

--- a/subsys/tracing/test/tracing_test.h
+++ b/subsys/tracing/test/tracing_test.h
@@ -439,7 +439,7 @@
 #define sys_port_trace_pm_device_runtime_put_async_enter(dev)
 #define sys_port_trace_pm_device_runtime_put_async_exit(dev, ret)
 #define sys_port_trace_pm_device_runtime_enable_enter(dev)
-#define sys_port_trace_pm_device_runtime_enable_exit(dev)
+#define sys_port_trace_pm_device_runtime_enable_exit(dev, ret)
 #define sys_port_trace_pm_device_runtime_disable_enter(dev)
 #define sys_port_trace_pm_device_runtime_disable_exit(dev, ret)
 

--- a/tests/subsys/pm/device_runtime_api/src/main.c
+++ b/tests/subsys/pm/device_runtime_api/src/main.c
@@ -45,7 +45,8 @@ static void test_api_setup(void)
 	zassert_equal(ret, -ENOTSUP, NULL);
 
 	/* enable runtime PM */
-	pm_device_runtime_enable(dev);
+	ret = pm_device_runtime_enable(dev);
+	zassert_equal(ret, 0, NULL);
 }
 
 static void test_api_teardown(void)
@@ -190,6 +191,22 @@ static void test_api(void)
 
 	(void)pm_device_state_get(dev, &state);
 	zassert_equal(state, PM_DEVICE_STATE_ACTIVE, NULL);
+
+	/* Put operation should fail due the state be locked. */
+	ret = pm_device_runtime_disable(dev);
+	zassert_equal(ret, 0, NULL);
+
+	pm_device_state_lock(dev);
+
+	/* This operation should not succeed.  */
+	ret = pm_device_runtime_enable(dev);
+	zassert_equal(ret, -EPERM, NULL);
+
+	/* After unlock the state, enable runtime should work. */
+	pm_device_state_unlock(dev);
+
+	ret = pm_device_runtime_enable(dev);
+	zassert_equal(ret, 0, NULL);
 }
 
 void test_main(void)

--- a/tests/subsys/pm/power_mgmt/src/dummy_driver.c
+++ b/tests/subsys/pm/power_mgmt/src/dummy_driver.c
@@ -33,8 +33,7 @@ static const struct dummy_driver_api funcs = {
 
 int dummy_init(const struct device *dev)
 {
-	pm_device_runtime_enable(dev);
-	return 0;
+	return pm_device_runtime_enable(dev);
 }
 
 PM_DEVICE_DEFINE(dummy_driver, dummy_device_pm_action);

--- a/tests/subsys/pm/power_mgmt/src/main.c
+++ b/tests/subsys/pm/power_mgmt/src/main.c
@@ -304,7 +304,8 @@ void test_power_state_trans(void)
 	k_sleep(SLEEP_TIMEOUT);
 	zassert_true(leave_idle, NULL);
 
-	pm_device_runtime_enable(device_dummy);
+	ret = pm_device_runtime_enable(device_dummy);
+	zassert_true(ret == 0, "Failed to enable device runtime PM");
 
 	pm_notifier_unregister(&notifier);
 }

--- a/tests/subsys/pm/power_mgmt/src/main.c
+++ b/tests/subsys/pm/power_mgmt/src/main.c
@@ -27,6 +27,7 @@ static bool leave_idle;
 static bool idle_entered;
 static bool testing_device_runtime;
 static bool testing_device_order;
+static bool testing_device_lock;
 
 static const struct device *device_dummy;
 static struct dummy_driver_api *api;
@@ -142,10 +143,25 @@ DEVICE_DT_DEFINE(DT_INST(2, test_device_pm), device_init,
 
 void pm_power_state_set(struct pm_state_info info)
 {
+	enum pm_device_state device_power_state;
+
 	/* If testing device order this function does not need to anything */
 	if (testing_device_order) {
 		return;
 	}
+
+	if (testing_device_lock) {
+		pm_device_state_get(device_a, &device_power_state);
+
+		/*
+		 * If the device has its state locked the device has
+		 * to be ACTIVE
+		 */
+		zassert_true(device_power_state == PM_DEVICE_STATE_ACTIVE,
+				NULL);
+		return;
+	}
+
 
 	/* at this point, notify_pm_state_entry() implemented in
 	 * this file has been called and set_pm should have been set
@@ -154,7 +170,6 @@ void pm_power_state_set(struct pm_state_info info)
 		     "Notification to enter suspend was not sent to the App");
 
 	/* this function is called after devices enter low power state */
-	enum pm_device_state device_power_state;
 	pm_device_state_get(device_dummy, &device_power_state);
 
 	if (testing_device_runtime) {
@@ -394,6 +409,21 @@ void test_busy(void)
 	zassert_false(busy, NULL);
 }
 
+void test_device_state_lock(void)
+{
+	pm_device_state_lock((struct device *)device_a);
+	zassert_true(pm_device_state_is_locked(device_a), NULL);
+
+	testing_device_lock = true;
+	enter_low_power = true;
+
+	k_sleep(SLEEP_TIMEOUT);
+
+	pm_device_state_unlock((struct device *)device_a);
+
+	testing_device_lock = false;
+}
+
 void test_main(void)
 {
 	device_dummy = device_get_binding(DUMMY_DRIVER_NAME);
@@ -403,6 +433,7 @@ void test_main(void)
 			 ztest_1cpu_unit_test(test_power_idle),
 			 ztest_1cpu_unit_test(test_power_state_trans),
 			 ztest_1cpu_unit_test(test_device_order),
+			 ztest_1cpu_unit_test(test_device_state_lock),
 			 ztest_1cpu_unit_test(test_power_state_notification),
 			 ztest_1cpu_unit_test(test_busy));
 	ztest_run_test_suite(power_management_test);


### PR DESCRIPTION
Allow to set a pm constraint on a device. When a device has a pm constraint it won't change its state until the constraint be released.
Device pm API will return `-EPERM` when the device has a constraint.

v2:
 - Fix commit messages
 -  Add test for this API
 
v3:
 - Change API namespace to `pm_device_state_lock*`
 - No longer reference counted (save memory using `device->pm->flags`)
 - "lock" a device state is only allowed when device pm runtime is disabled
 - Split the API test in device_runtime and pm_mgmt tests