### PR TITLE
Zephyr tcpc driver

### DIFF
--- a/dts/arm/st/g0/stm32g071.dtsi
+++ b/dts/arm/st/g0/stm32g071.dtsi
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2021 The Chromium OS Authors
  * Copyright (c) 2019 Philippe Retornaz <philippe@shapescale.com>
  * Copyright (c) 2019 ST Microelectronics
  *
@@ -29,6 +30,24 @@
 
 		dmamux1: dmamux@40020800 {
 			dma-requests= <57>;
+		};
+
+		ucpd1: ucpd@4000a000 {
+			compatible = "st,stm32-ucpd";
+			reg = <0x4000a000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
+			interrupts = <8 0>;
+			status = "disabled";
+			label = "UCPD_1";
+		};
+
+		ucpd2: ucpd@4000a400 {
+			compatible = "st,stm32-ucpd";
+			reg = <0x4000a400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x04000000>;
+			interrupts = <8 0>;
+			status = "disabled";
+			label = "UCPD_2";
 		};
 	};
 };

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2021 The Chromium OS Authors
  * Copyright (c) 2019 Richard Osterloh <richard.osterloh@gmail.com>
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -600,6 +601,14 @@
 			label = "DMAMUX_1";
 		};
 
+		ucpd1: ucpd@4000a000 {
+			compatible = "st,stm32-ucpd";
+			reg = <0x4000a000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000010>;
+			interrupts = <63 0>;
+			status = "disabled";
+			label = "UCPD_1";
+		};
 	};
 
 	usb_fs_phy: usbphy {

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2021 The Chromium OS Authors
  * Copyright (c) 2020 Linaro Limited
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -578,6 +579,14 @@
 			label = "USB";
 		};
 
+		ucpd1: ucpd@4000dc00 {
+			compatible = "st,stm32-ucpd";
+			reg = <0x4000dc00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00800000>;
+			interrupts = <106 0>;
+			status = "disabled";
+			label = "UCPD_1";
+		};
 	};
 
 	usb_fs_phy: usbphy {

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2021 The Chromium OS Authors
  * Copyright (c) 2021 Linaro Limited
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -377,6 +378,15 @@
 			status = "disabled";
 			label = "ADC_4";
 			#io-channel-cells = <1>;
+		};
+
+		ucpd1: ucpd@4000dc00 {
+			compatible = "st,stm32-ucpd";
+			reg = <0x4000dc00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00800000>;
+			interrupts = <106 0>;
+			status = "disabled";
+			label = "UCPD_1";
 		};
 	};
 };

--- a/dts/bindings/tcpc/st,stm32-ucpd.yaml
+++ b/dts/bindings/tcpc/st,stm32-ucpd.yaml
@@ -1,0 +1,71 @@
+# Copyright 2021 The Chromium OS Authors
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    ST STM32 family USB Type-C / Power Delivery. The default values were
+    taken from the LL_UCPD_StructInit function defined in the HAL.
+
+compatible: "st,stm32-ucpd"
+
+include: base.yaml
+
+properties:
+    label:
+      required: true
+
+    reg:
+      required: true
+
+    clocks:
+      required: true
+
+    interrupts:
+      required: true
+
+    psc-ucpdclk:
+      required: false
+      default: 2
+      type: int
+      enum:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 16
+        - 32
+        - 64
+        - 128
+      description: |
+        Determines the division ratio of a kernel clock pre-scaler
+        producing UCPD peripheral clock (ucpd_clk). It is recommended
+        to use the pre-scaler so as to set the ucpd_clk frequency in
+        the range from 6 to 9 MHz.
+
+    ifrgap:
+      required: false
+      type: int
+      default: 17
+      description: |
+        Determines the division ratio of a ucpd_clk divider producing
+        inter-frame gap timer clock (tInterFrameGap).
+        The division ratio 15 is to apply for Tx clock at the USB PD 2.0
+        specification nominal value.
+        Valid range: 2 - 32
+
+    transwin:
+      required: false
+      type: int
+      default: 8
+      description: |
+        Determines the division ratio of a hbit_clk divider producing
+        tTransitionWindow interval.
+        Valid range: 2 - 32
+
+    hbitclkdiv:
+      required: false
+      type: int
+      default: 14
+      description: |
+        Determines the division ratio of a ucpd_clk divider producing
+        half-bit clock (hbit_clk)
+        Valid range: 1 - 64

--- a/modules/Kconfig.stm32
+++ b/modules/Kconfig.stm32
@@ -674,6 +674,12 @@ config USE_STM32_LL_TIM
 	help
 	  Enable STM32Cube Timer (TIM) LL module driver
 
+config USE_STM32_LL_UCPD
+	bool
+	help
+	  Enable STM32Cube USB Power Delivery device interface
+	  (UCPD) LL module driver
+
 config USE_STM32_LL_USART
 	bool
 	help


### PR DESCRIPTION
These pull requests are part of a larger effort to port the Google ChromeOS USB-C Stack to Zephyr. See [issue](https://github.com/zephyrproject-rtos/zephyr/issues/38371) #38371.  