### PR TITLE
drivers: uart: Add support for st half-duplex mode

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1585,6 +1585,11 @@ static int uart_stm32_init(const struct device *dev)
 	/* Set the default baudrate */
 	uart_stm32_set_baudrate(dev, data->baud_rate);
 
+	/* Enable the single wire / half-duplex mode */
+	if (config->single_wire) {
+		LL_USART_EnableHalfDuplex(UartInstance);
+	}
+
 	LL_USART_Enable(UartInstance);
 
 #ifdef USART_ISR_TEACK
@@ -1701,6 +1706,7 @@ static const struct uart_stm32_config uart_stm32_cfg_##index = {	\
 	.hw_flow_control = DT_INST_PROP(index, hw_flow_control),	\
 	.parity = DT_INST_ENUM_IDX_OR(index, parity, UART_CFG_PARITY_NONE),	\
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),			\
+	.single_wire = DT_INST_PROP_OR(index, single_wire, false), \
 	STM32_UART_POLL_IRQ_HANDLER_FUNC(index)				\
 };									\
 									\

--- a/drivers/serial/uart_stm32.h
+++ b/drivers/serial/uart_stm32.h
@@ -23,6 +23,8 @@ struct uart_stm32_config {
 	bool hw_flow_control;
 	/* initial parity, 0 for none, 1 for odd, 2 for even */
 	int  parity;
+	/* switch to enable single wire / half duplex feature */
+	bool single_wire;
 	const struct pinctrl_dev_config *pcfg;
 #if defined(CONFIG_PM) \
 	&& !defined(CONFIG_UART_INTERRUPT_DRIVEN) \

--- a/dts/bindings/serial/st,stm32-uart.yaml
+++ b/dts/bindings/serial/st,stm32-uart.yaml
@@ -11,6 +11,15 @@ properties:
     interrupts:
       required: true
 
+    single-wire:
+      type: boolean
+      required: false
+      description: |
+        Enable the single wire half-duplex communication.
+        Using this mode, TX and RX lines are internally connected and
+        only TX pin is used afterwards and should be configured.
+        RX/TX conflicts must be handled on user side.
+
     pinctrl-0:
       required: true
 

--- a/dts/bindings/serial/st,stm32-usart.yaml
+++ b/dts/bindings/serial/st,stm32-usart.yaml
@@ -11,6 +11,15 @@ properties:
     interrupts:
       required: true
 
+    single-wire:
+      type: boolean
+      required: false
+      description: |
+        Enable the single wire half-duplex communication.
+        Using this mode, TX and RX lines are internally connected and
+        only TX pin is used afterwards and should be configured.
+        RX/TX conflicts must be handled on user side.
+
     pinctrl-0:
       required: true
 

--- a/samples/drivers/uart/stm32/single_wire/CMakeLists.txt
+++ b/samples/drivers/uart/stm32/single_wire/CMakeLists.txt
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(uart_stm32_single_wire)
+
+target_sources(app PRIVATE
+    src/main.c
+    )

--- a/samples/drivers/uart/stm32/single_wire/README.rst
+++ b/samples/drivers/uart/stm32/single_wire/README.rst
@@ -1,0 +1,33 @@
+.. _sample_uart_stm32_single_wire:
+
+STM32 Single Wire UART
+######################
+
+Overview
+********
+
+A simple application demonstrating how to use the single wire / half-duplex UART
+functionality of STM32. Without adaptions this example runs on STM32F3 discovery
+board. You need to establish a physical connection between pins PA2 (USART2_TX) and
+PC10 (UART4_TX).
+
+Add a `single_wire_uart_loopback` fixture to your board in the hardware map to allow
+twister to verify this sample's output automatically.
+
+Building and Running
+********************
+
+Build and flash as follows, replacig ``stm32f3_disco`` with your board:
+
+ .. zephyr-app-commands::
+    :zephyr-app: samples/drivers/uart/stm32/single_wire
+    :board: stm32f3_disco
+    :goals: build flash
+    :compact:
+
+After flashing the console output should not show any failure reports,
+but the following message repeated every 2s:
+
+.. code-block:: none
+
+    Received c

--- a/samples/drivers/uart/stm32/single_wire/boards/stm32f3_disco.overlay
+++ b/samples/drivers/uart/stm32/single_wire/boards/stm32f3_disco.overlay
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2021 Jonathan Hahn
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	 aliases {
+		single-line-uart1 = &usart2;
+		single-line-uart2 = &uart4;
+	};
+};
+
+&usart2 {
+	pinctrl-0 = <&usart2_tx_pa2>;
+	single-wire;
+};
+
+&uart4 {
+	pinctrl-0 = <&uart4_tx_pc10>;
+	single-wire;
+};

--- a/samples/drivers/uart/stm32/single_wire/prj.conf
+++ b/samples/drivers/uart/stm32/single_wire/prj.conf
@@ -1,0 +1,1 @@
+# Nothing needed here

--- a/samples/drivers/uart/stm32/single_wire/sample.yaml
+++ b/samples/drivers/uart/stm32/single_wire/sample.yaml
@@ -1,0 +1,12 @@
+sample:
+  name: STM32 Single Wire UART sample
+tests:
+  sample.drivers.uart.stm32.single_wire:
+    platform_allow: stm32f3_disco
+    tags: drivers uart
+    harness: console
+    harness_config:
+      fixture: single_line_uart_loopback
+      type: one_line
+      regex:
+        - "Received c"

--- a/samples/drivers/uart/stm32/single_wire/src/main.c
+++ b/samples/drivers/uart/stm32/single_wire/src/main.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021 Jonathan Hahn
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include "kernel.h"
+#include <device.h>
+#include <devicetree.h>
+#include <drivers/uart.h>
+
+#define UART_NODE1 DT_ALIAS(single_line_uart1)
+#define UART_NODE2 DT_ALIAS(single_line_uart2)
+
+const struct device *sl_uart1 = DEVICE_DT_GET(UART_NODE1);
+const struct device *sl_uart2 = DEVICE_DT_GET(UART_NODE2);
+
+void main(void)
+{
+	unsigned char recv;
+
+	if (!device_is_ready(sl_uart1) || !device_is_ready(sl_uart2)) {
+		printk("uart devices not ready\n");
+		return;
+	}
+
+	while (true) {
+
+		uart_poll_out(sl_uart1, 'c');
+
+		/* give the uarts some time to get the data through */
+		k_sleep(K_MSEC(50));
+
+		int ret = uart_poll_in(sl_uart2, &recv);
+
+		if (ret < 0) {
+			printk("Receiving failed. Error: %d", ret);
+		} else {
+			printk("Received %c\n", recv);
+		}
+
+		k_sleep(K_MSEC(2000));
+	}
+}


### PR DESCRIPTION
This PR is a WIP proposal to integrate st's half-duplex uart mode into zephyr.
Thereby rx and tx are connected and only tx pin is used.
Code is put together quickly, to gather feedback on that feature and I did not
put any effort into test implementation, because I am not to sure, where to put it.