### PR TITLE
pm: policy: Fix logging module name

### DIFF
--- a/subsys/pm/policy/policy_dummy.c
+++ b/subsys/pm/policy/policy_dummy.c
@@ -10,7 +10,7 @@
 #include <pm/policy.h>
 
 #include <logging/log.h>
-LOG_MODULE_DECLARE(power, CONFIG_PM_LOG_LEVEL);
+LOG_MODULE_DECLARE(pm, CONFIG_PM_LOG_LEVEL);
 
 #define STATE_ACTIVE \
 	(struct pm_state_info){PM_STATE_ACTIVE, 0, 0}

--- a/subsys/pm/policy/policy_residency.c
+++ b/subsys/pm/policy/policy_residency.c
@@ -11,9 +11,8 @@
 #include <pm/policy.h>
 #include <sys/check.h>
 
-#define LOG_LEVEL CONFIG_PM_LOG_LEVEL /* From power module Kconfig */
 #include <logging/log.h>
-LOG_MODULE_DECLARE(power);
+LOG_MODULE_DECLARE(pm, CONFIG_PM_LOG_LEVEL);
 
 #if DT_NODE_EXISTS(DT_PATH(cpus))
 


### PR DESCRIPTION
LOG_MODULE_DECLARE was referring to power name which was renamed
to pm by faa06ac. This results in compilation failure.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>