### PR TITLE
boards/arm/*/doc: Fix numbered list syntax in .rst

### DIFF
--- a/boards/arm/adafruit_feather_stm32f405/doc/index.rst
+++ b/boards/arm/adafruit_feather_stm32f405/doc/index.rst
@@ -101,8 +101,7 @@ of the built in DFU-Util bootloader is possible by following the
 Flashing
 ========
 
-#. Build the Zephyr kernel and the :ref:`blinky-sample` sample
-application:
+#. Build the Zephyr kernel and the :ref:`blinky-sample` sample application:
 
    .. zephyr-app-commands::
       :zephyr-app: samples/basic/blinky
@@ -110,8 +109,8 @@ application:
       :goals: build
       :compact:
 
-#. On the Adafruit Feather STM32F405, connect the 3.3V pin to the B0
-boot pin with a jumper wire.
+#. On the Adafruit Feather STM32F405, connect the 3.3V pin to the B0 boot pin
+   with a jumper wire.
 
 #. Flash the image:
 

--- a/boards/arm/bl654_usb/doc/bl654_usb.rst
+++ b/boards/arm/bl654_usb/doc/bl654_usb.rst
@@ -121,7 +121,7 @@ bootloader and flash them to the device. Make sure ``nrfutil`` is installed
 before proceeding. These instructions were tested with version 6.1.0.
 
 #. With the adapter plugged in, reset the board into the bootloader by pressing
-the RESET button.
+   the RESET button.
 
    The push button is in a pin-hole on the logo side of the USB adapter.
 

--- a/boards/arm/cy8ckit_062_ble/doc/index.rst
+++ b/boards/arm/cy8ckit_062_ble/doc/index.rst
@@ -238,7 +238,7 @@ revision (0.0.0) allows use of default connections.  The use of Arduino headers
 are only possible after rework the board and using the revision 1.0.0.
 
 #. Build the Zephyr kernel and the :ref:`hello_world` sample application for
-board revision 1.0.0:
+   board revision 1.0.0:
 
    .. zephyr-app-commands::
       :zephyr-app: samples/hello_world

--- a/boards/arm/rak4631_nrf52840/doc/index.rst
+++ b/boards/arm/rak4631_nrf52840/doc/index.rst
@@ -123,7 +123,7 @@ Flashing
    - Stop bits: 1
 
 #. Connect the RAK4631 board to your host computer using the USB debug port.
-Then build and flash the :ref:`hello_world` application.
+   Then build and flash the :ref:`hello_world` application.
 
    .. zephyr-app-commands::
       :zephyr-app: samples/hello_world

--- a/boards/arm/rak5010_nrf52840/doc/index.rst
+++ b/boards/arm/rak5010_nrf52840/doc/index.rst
@@ -127,7 +127,7 @@ Flashing
    - Stop bits: 1
 
 #. Connect the RAK5010 board to your host computer using the USB debug port.
-Then build and flash the :ref:`hello_world` application.
+   Then build and flash the :ref:`hello_world` application.
 
    .. zephyr-app-commands::
       :zephyr-app: samples/hello_world

--- a/boards/arm/sam4l_ek/doc/index.rst
+++ b/boards/arm/sam4l_ek/doc/index.rst
@@ -137,7 +137,7 @@ Flashing
    - Stop bits: 1
 
 #. Connect the SAM4L-EK board to your host computer using the USB debug port.
-Then build and flash the :ref:`hello_world` application.
+   Then build and flash the :ref:`hello_world` application.
 
    .. zephyr-app-commands::
       :zephyr-app: samples/hello_world


### PR DESCRIPTION
For reStructuredText, continuing text in a numbered list must be aligned to the first line.

These lines are searched by the following regex:

``` shell
ag '#\. .*\n[^ #\n]' **/*.rst
```