### PR TITLE
Bluetooth: controller: Introduction of RXFIFO composite

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -307,7 +307,14 @@ static struct k_sem *sem_recv;
  */
 static MFIFO_DEFINE(prep, sizeof(struct lll_event), EVENT_PIPELINE_MAX);
 
-/* Declare done-event FIFO: mfifo_done.
+/* Declare done-event RXFIFO. This is a composite pool-backed MFIFO for rx_nodes.
+ * The declaration constructs the following data structures:
+ * - mfifo_done:    FIFO with pointers to struct node_rx_event_done
+ * - mem_done:      Backing data pool for struct node_rx_event_done elements
+ * - mem_link_done: Pool of memq_link_t elements
+ *
+ * An extra link may be reserved for use by the ull_done memq (EVENT_DONE_LINK_CNT).
+ *
  * Queue of pointers to struct node_rx_event_done.
  * The actual backing behind these pointers is mem_done.
  *
@@ -338,19 +345,8 @@ static MFIFO_DEFINE(prep, sizeof(struct lll_event), EVENT_PIPELINE_MAX);
 #define EVENT_DONE_MAX VENDOR_EVENT_DONE_MAX
 #endif
 
-static MFIFO_DEFINE(done, sizeof(struct node_rx_event_done *), EVENT_DONE_MAX);
-
-/* Backing storage for elements in mfifo_done */
-static struct {
-	void *free;
-	uint8_t pool[sizeof(struct node_rx_event_done) * EVENT_DONE_MAX];
-} mem_done;
-
-static struct {
-	void *free;
-	uint8_t pool[sizeof(memq_link_t) *
-		     (EVENT_DONE_MAX + EVENT_DONE_LINK_CNT)];
-} mem_link_done;
+static RXFIFO_DEFINE(done, sizeof(struct node_rx_event_done),
+		     EVENT_DONE_MAX, EVENT_DONE_LINK_CNT);
 
 /* Minimum number of node rx for ULL to LL/HCI thread per connection.
  * Increasing this by times the max. simultaneous connection count will permit
@@ -471,7 +467,6 @@ static void perform_lll_reset(void *param);
 static inline void *mark_set(void **m, void *param);
 static inline void *mark_unset(void **m, void *param);
 static inline void *mark_get(void *m);
-static inline void done_alloc(void);
 static inline void rx_alloc(uint8_t max);
 static void rx_demux(void *param);
 #if defined(CONFIG_BT_CTLR_LOW_LAT_ULL)
@@ -742,9 +737,6 @@ void ll_reset(void)
 
 	/* Re-initialize the prep mfifo */
 	MFIFO_INIT(prep);
-
-	/* Re-initialize the free done mfifo */
-	MFIFO_INIT(done);
 
 	/* Re-initialize the free rx mfifo */
 	MFIFO_INIT(pdu_rx_free);
@@ -2028,16 +2020,8 @@ static inline int init_reset(void)
 {
 	memq_link_t *link;
 
-	/* Initialize done pool. */
-	mem_init(mem_done.pool, sizeof(struct node_rx_event_done),
-		 EVENT_DONE_MAX, &mem_done.free);
-
-	/* Initialize done link pool. */
-	mem_init(mem_link_done.pool, sizeof(memq_link_t), EVENT_DONE_MAX +
-		 EVENT_DONE_LINK_CNT, &mem_link_done.free);
-
-	/* Allocate done buffers */
-	done_alloc();
+	/* Initialize and allocate done pool */
+	RXFIFO_INIT_ALLOC(done);
 
 	/* Initialize rx pool. */
 	mem_init(mem_pdu_rx.pool, (PDU_RX_NODE_POOL_ELEMENT_SIZE),
@@ -2138,51 +2122,6 @@ static inline void *mark_unset(void **m, void *param)
 static inline void *mark_get(void *m)
 {
 	return m;
-}
-
-/**
- * @brief Allocate buffers for done events
- */
-static inline void done_alloc(void)
-{
-	uint8_t idx;
-
-	/* mfifo_done is a queue of pointers */
-	while (MFIFO_ENQUEUE_IDX_GET(done, &idx)) {
-		memq_link_t *link;
-		struct node_rx_hdr *rx;
-
-		link = mem_acquire(&mem_link_done.free);
-		if (!link) {
-			break;
-		}
-
-		rx = mem_acquire(&mem_done.free);
-		if (!rx) {
-			mem_release(link, &mem_link_done.free);
-			break;
-		}
-
-		rx->link = link;
-
-		MFIFO_BY_IDX_ENQUEUE(done, idx, rx);
-	}
-}
-
-static inline void *done_release(memq_link_t *link,
-				 struct node_rx_event_done *done)
-{
-	uint8_t idx;
-
-	if (!MFIFO_ENQUEUE_IDX_GET(done, &idx)) {
-		return NULL;
-	}
-
-	done->hdr.link = link;
-
-	MFIFO_BY_IDX_ENQUEUE(done, idx, done);
-
-	return done;
 }
 
 static inline void rx_alloc(uint8_t max)
@@ -2753,9 +2692,9 @@ static inline void rx_demux_event_done(memq_link_t *link,
 		break;
 	}
 
-	/* release done */
+	/* Release done */
 	done->extra.type = 0U;
-	release = done_release(link, done);
+	release = RXFIFO_RELEASE(done, link, done);
 	LL_ASSERT(release == done);
 
 #if defined(CONFIG_BT_CTLR_LOW_LAT_ULL_DONE)
@@ -2775,4 +2714,56 @@ static inline void rx_demux_event_done(memq_link_t *link,
 static void disabled_cb(void *param)
 {
 	k_sem_give(param);
+}
+
+/**
+ * @brief   Support function for RXFIFO_ALLOC macro
+ * @details This function allocates up to 'max' number of MFIFO elements by
+ *          enqueuing pointers to memory elements with associated memq links.
+ */
+void ull_rxfifo_alloc(uint8_t s, uint8_t n, uint8_t f, uint8_t *l, uint8_t *m,
+		      void *mem_free, void *link_free, uint8_t max)
+{
+	uint8_t idx;
+
+	while ((max--) && mfifo_enqueue_idx_get(n, f, *l, &idx)) {
+		memq_link_t *link;
+		struct node_rx_hdr *rx;
+
+		link = mem_acquire(link_free);
+		if (!link) {
+			break;
+		}
+
+		rx = mem_acquire(mem_free);
+		if (!rx) {
+			mem_release(link, link_free);
+			break;
+		}
+
+		link->mem = NULL;
+		rx->link = link;
+
+		mfifo_by_idx_enqueue(m, s, idx, rx, l);
+	}
+}
+
+/**
+ * @brief   Support function for RXFIFO_RELEASE macro
+ * @details This function releases a node by returning it to the FIFO.
+ */
+void *ull_rxfifo_release(uint8_t s, uint8_t n, uint8_t f, uint8_t *l, uint8_t *m,
+			 memq_link_t *link, struct node_rx_hdr *rx)
+{
+	uint8_t idx;
+
+	if (!mfifo_enqueue_idx_get(n, f, *l, &idx)) {
+		return NULL;
+	}
+
+	rx->link = link;
+
+	mfifo_by_idx_enqueue(m, s, idx, rx, l);
+
+	return rx;
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_internal.h
@@ -53,3 +53,79 @@ int ull_disable(void *param);
 void ull_drift_ticks_get(struct node_rx_event_done *done,
 			 uint32_t *ticks_drift_plus,
 			 uint32_t *ticks_drift_minus);
+
+/**
+ * @brief   RX FIFO macro frontend
+ * @details The RXFIFO data composite consists of an MFIFO with pointers to
+ *          data elements backed by a memory pool and memq link elements.
+ *          Link memq elements have a separate pool of (_count + _extra_links)
+ *          elements. Extra links may be used for initializing one or more
+ *          external memq instances. The following data structures are created
+ *          with RXFIFO_DEFINE():
+ *          - mfifo_<_name>:    FIFO with pointers to RX node elements.
+ *          - mem_<_name>:      Backing data pool of <_count> RX node elements
+ *                              of size <_size>.
+ *          - mem_link_<_name>: Pool of <_count + _extra_links> memq_link_t
+ *                              elements.
+ */
+#define RXFIFO_DEFINE(_name, _size, _count, _extra_links) \
+	MFIFO_DEFINE(_name, sizeof(void *), _count); \
+	\
+	static struct { \
+		void *free; \
+		uint16_t size; \
+		uint8_t count; \
+		uint8_t extra_links; \
+		uint8_t pool[MROUND(_size) * (_count)]; \
+	} mem_##_name = { .size = MROUND(_size), .count = _count, \
+			  .extra_links = _extra_links }; \
+	\
+	static struct { \
+		void *free; \
+		uint8_t pool[sizeof(memq_link_t) * \
+		     (_count + _extra_links)]; \
+	} mem_link_##_name
+
+/**
+ * @brief   Initializes MFIFO and pools
+ * @details This makes the MFIFO empty and will subsequently need
+ *          RXFIFO_ALLOC. Memory pools are initialized.
+ */
+#define RXFIFO_INIT(_name) \
+	MFIFO_INIT(_name); \
+	mem_init(mem_##_name.pool, mem_##_name.size, \
+		 mem_##_name.count, &mem_##_name.free); \
+	\
+	mem_init(mem_link_##_name.pool, sizeof(memq_link_t), mem_##_name.count + \
+		 mem_##_name.extra_links, &mem_link_##_name.free)
+
+/**
+ * @brief   Allocate FIFO elements with backing
+ * @details This function allocates up to <_count> number of MFIFO elements by
+ *          enqueuing pointers to memory elements with associated memq links.
+ */
+#define RXFIFO_ALLOC(_name, _count) \
+	ull_rxfifo_alloc(mfifo_##_name.s, mfifo_##_name.n, mfifo_##_name.f, \
+			 &mfifo_##_name.l, mfifo_##_name.m, &mem_##_name.free, \
+			 &mem_link_##_name.free, _count)
+
+/**
+ * @brief Initialize and allocate MFIFO and pools
+ */
+#define RXFIFO_INIT_ALLOC(_name) \
+	RXFIFO_INIT(_name); \
+	RXFIFO_ALLOC(_name, mem_##_name.count)
+
+/**
+ * @brief   Release RX node
+ * @details Enqueues an RX node back into the FIFO.
+ */
+#define RXFIFO_RELEASE(_name, _link, _rx) \
+	ull_rxfifo_release(mfifo_##_name.s, mfifo_##_name.n, mfifo_##_name.f, \
+			   &mfifo_##_name.l, mfifo_##_name.m, _link, \
+			   (struct node_rx_hdr *)_rx)
+
+void ull_rxfifo_alloc(uint8_t s, uint8_t n, uint8_t f, uint8_t *l, uint8_t *m,
+		      void *mem_free, void *link_free, uint8_t max);
+void *ull_rxfifo_release(uint8_t s, uint8_t n, uint8_t f, uint8_t *l, uint8_t *m,
+			 memq_link_t *link, struct node_rx_hdr *rx);


### PR DESCRIPTION
By use of the new macro RXFIFO_DEFINE, a complete set of data
structures for supporting a MEMQ'able FIFO with data pool backing is
created. This is intended for RX nodes such as done-events, RX PDU-
and ISO PDU events. The purpose is to simplify the data management
and code complexity, and provide re-usability.

This commit implements the existing done structures (MFIFO, mem pool,
mem link pool) as an RXFIFO. ISO is the next customer, and later the
pdu_rx_free MFIFO- and related pools may be refactored.

Signed-off-by: Morten Priess <mtpr@oticon.com>