### PR TITLE
coding guidelines: partially comply with MISRA C:2012 Rule 10.5

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1895,7 +1895,7 @@ __syscall int k_queue_is_empty(struct k_queue *queue);
 
 static inline int z_impl_k_queue_is_empty(struct k_queue *queue)
 {
-	return (int)sys_sflist_is_empty(&queue->data_q);
+	return sys_sflist_is_empty(&queue->data_q) ? 1 : 0;
 }
 
 /**

--- a/lib/os/timeutil.c
+++ b/lib/os/timeutil.c
@@ -147,7 +147,7 @@ int timeutil_sync_ref_from_local(const struct timeutil_sync_state *tsp,
 			rv = -ERANGE;
 		} else {
 			*refp = ref_abs;
-			rv = (int)(tsp->skew != 1.0f);
+			rv = (tsp->skew != 1.0f) ? 1 : 0;
 		}
 	}
 
@@ -174,7 +174,7 @@ int timeutil_sync_local_from_ref(const struct timeutil_sync_state *tsp,
 				    + (int64_t)local_delta;
 
 		*localp = local_abs;
-		rv = (int)(tsp->skew != 1.0f);
+		rv = (tsp->skew != 1.0f) ? 1 : 0;
 	}
 
 	return rv;

--- a/scripts/gen_syscalls.py
+++ b/scripts/gen_syscalls.py
@@ -212,6 +212,8 @@ def wrapper_defs(func_name, func_type, args):
     elif func_type == "void":
         wrap += "\t\t" + "%s;\n" % invoke
         wrap += "\t\t" + "return;\n"
+    elif func_type == "bool":
+        wrap += "\t\t" + "return %s != 0U;\n" % (invoke)
     else:
         wrap += "\t\t" + "return (%s) %s;\n" % (func_type, invoke)
 


### PR DESCRIPTION
MISRA C:2012 Rule 10.5 (The value of an expression should not be cast
to an inappropriate essential type.)

Avoid integer-to-Boolean and Boolean-to-integer type casts.

Signed-off-by: Abramo Bagnara <abramo.bagnara@bugseng.com>