### PR TITLE
MAINTAINERS: Add mtpr-ot and wopu-ot as collaborators

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -197,6 +197,8 @@ Bluetooth controller:
         - thoh-ot
         - kruithofa
         - ppryga
+        - mtpr-ot
+        - wopu-ot
     files:
         - subsys/bluetooth/controller/
     labels:


### PR DESCRIPTION
Add mtpr-ot and wopu-ot as collaborators for the Bluetooth controller.

Signed-off-by: Wolfgang Puffitsch <wopu@demant.com>