### PR TITLE
Bluetooth:host: Fix notify multiple issue

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -1987,12 +1987,7 @@ static int gatt_notify(struct bt_conn *conn, uint16_t handle,
 
 #if defined(CONFIG_BT_GATT_NOTIFY_MULTIPLE)
 	if (gatt_cf_notify_multi(conn)) {
-		int err;
-
-		err = gatt_notify_mult(conn, handle, params);
-		if (err && err != -ENOMEM) {
-			return err;
-		}
+		return gatt_notify_mult(conn, handle, params);
 	}
 #endif /* CONFIG_BT_GATT_NOTIFY_MULTIPLE */
 


### PR DESCRIPTION
When multiple notify feature is enabled, notifications are pushed
twice. Host sends multiple notify with BT_ATT_OP_NOTIFY_MULT and
then continues to send regular notification with BT_ATT_OP_NOTIFY.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/40546

Signed-off-by: Ilhan Ates <ilhan.ates@nordicsemi.no>