### PR TITLE
Boards: Thingy52 config

### DIFF
--- a/boards/arm/thingy52_nrf52832/CMakeLists.txt
+++ b/boards/arm/thingy52_nrf52832/CMakeLists.txt
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_GPIO)
 zephyr_library()
 zephyr_library_sources(board.c)
+endif()

--- a/boards/arm/thingy52_nrf52832/Kconfig.board
+++ b/boards/arm/thingy52_nrf52832/Kconfig.board
@@ -5,5 +5,4 @@
 
 config BOARD_THINGY52_NRF52832
 	bool "Thingy52 NRF52832"
-	select GPIO
 	depends on SOC_NRF52832_QFAA

--- a/boards/arm/thingy52_nrf52832/Kconfig.defconfig
+++ b/boards/arm/thingy52_nrf52832/Kconfig.defconfig
@@ -11,6 +11,9 @@ config BOARD
 config I2C
 	default y
 
+config GPIO
+	default y
+
 config BT_CTLR
 	default BT
 


### PR DESCRIPTION
Changed the config to allow turning off GPIO for thingy52.
This will allow to deselect GPIO in project and reduce size.

Signed-off-by: Dominik Chat <dominik.chat@nordicsemi.no>