### PR TITLE
LE Audio ensure unicast client is central

### DIFF
--- a/subsys/bluetooth/host/audio/bap.c
+++ b/subsys/bluetooth/host/audio/bap.c
@@ -1887,9 +1887,16 @@ int bt_audio_discover(struct bt_conn *conn,
 		      struct bt_audio_discover_params *params)
 {
 	static bool conn_cb_registered;
+	uint8_t role;
 
 	if (!conn || conn->state != BT_CONN_CONNECTED) {
 		return -ENOTCONN;
+	}
+
+	role = conn->role;
+	if (role != BT_HCI_ROLE_CENTRAL) {
+		BT_DBG("Invalid conn role: %u, shall be central", role);
+		return -EINVAL;
 	}
 
 	if (params->type == BT_AUDIO_SINK) {


### PR DESCRIPTION
The unicast client shall be the central. Ensure that control point operations and discovery is only done as the central. 