### PR TITLE
Zephyr sysbuild / multi image

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -725,6 +725,7 @@ scripts/build/gen_image_info.py           @tejlmand
 /scripts/build/uf2conv.py                 @petejohanson
 /scripts/build/user_wordsize.py           @cfriedt
 /scripts/valgrind.supp                    @aescolar @daor-oti
+/share/sysbuild/                          @tejlmand
 /share/zephyr-package/                    @tejlmand
 /share/zephyrunittest-package/            @tejlmand
 /subsys/bluetooth/                        @alwa-nordic @jhedberg @Vudentz

--- a/cmake/modules/kconfig.cmake
+++ b/cmake/modules/kconfig.cmake
@@ -149,10 +149,10 @@ set(EXTRA_KCONFIG_TARGET_COMMAND_FOR_hardenconfig
   ${ZEPHYR_BASE}/scripts/kconfig/hardenconfig.py
   )
 
+set_ifndef(KCONFIG_TARGETS menuconfig guiconfig hardenconfig)
+
 foreach(kconfig_target
-    menuconfig
-    guiconfig
-    hardenconfig
+    ${KCONFIG_TARGETS}
     ${EXTRA_KCONFIG_TARGETS}
     )
   add_custom_target(

--- a/cmake/modules/kconfig.cmake
+++ b/cmake/modules/kconfig.cmake
@@ -59,7 +59,7 @@ else()
   set(KCONFIG_ROOT ${ZEPHYR_BASE}/Kconfig)
 endif()
 
-set(BOARD_DEFCONFIG ${BOARD_DIR}/${BOARD}_defconfig)
+set_ifndef(BOARD_DEFCONFIG ${BOARD_DIR}/${BOARD}_defconfig)
 set(DOTCONFIG                  ${PROJECT_BINARY_DIR}/.config)
 set(PARSED_KCONFIG_SOURCES_TXT ${PROJECT_BINARY_DIR}/kconfig/sources.txt)
 

--- a/cmake/modules/kconfig.cmake
+++ b/cmake/modules/kconfig.cmake
@@ -17,6 +17,8 @@ set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${AUTOCONF_H})
 file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/kconfig/include/generated)
 file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/kconfig/include/config)
 
+set_ifndef(KCONFIG_NAMESPACE "CONFIG")
+
 # Support multiple SOC_ROOT, remove ZEPHYR_BASE as that is always sourced.
 set(kconfig_soc_root ${SOC_ROOT})
 list(REMOVE_ITEM kconfig_soc_root ${ZEPHYR_BASE})
@@ -109,6 +111,7 @@ set(COMMON_KCONFIG_ENV_SETTINGS
   PYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}
   srctree=${ZEPHYR_BASE}
   KERNELVERSION=${KERNELVERSION}
+  CONFIG_=${KCONFIG_NAMESPACE}_
   KCONFIG_CONFIG=${DOTCONFIG}
   # Set environment variables so that Kconfig can prune Kconfig source
   # files for other architectures
@@ -170,15 +173,15 @@ foreach(kconfig_target
 endforeach()
 
 # Support assigning Kconfig symbols on the command-line with CMake
-# cache variables prefixed with 'CONFIG_'. This feature is
-# experimental and undocumented until it has undergone more
+# cache variables prefixed according to the Kconfig namespace.
+# This feature is experimental and undocumented until it has undergone more
 # user-testing.
 unset(EXTRA_KCONFIG_OPTIONS)
 get_cmake_property(cache_variable_names CACHE_VARIABLES)
 foreach (name ${cache_variable_names})
-  if("${name}" MATCHES "^CONFIG_")
-    # When a cache variable starts with 'CONFIG_', it is assumed to be
-    # a Kconfig symbol assignment from the CMake command line.
+  if("${name}" MATCHES "^${KCONFIG_NAMESPACE}_")
+    # When a cache variable starts with the 'KCONFIG_NAMESPACE' value, it is
+    # assumed to be a Kconfig symbol assignment from the CMake command line.
     set(EXTRA_KCONFIG_OPTIONS
       "${EXTRA_KCONFIG_OPTIONS}\n${name}=${${name}}"
       )
@@ -316,18 +319,18 @@ add_custom_target(config-twister DEPENDS ${DOTCONFIG})
 # CMakeCache.txt. If the symbols end up in DOTCONFIG they will be
 # re-introduced to the namespace through 'import_kconfig'.
 foreach (name ${cache_variable_names})
-  if("${name}" MATCHES "^CONFIG_")
+  if("${name}" MATCHES "^${KCONFIG_NAMESPACE}_")
     unset(${name})
     unset(${name} CACHE)
   endif()
 endforeach()
 
-# Parse the lines prefixed with CONFIG_ in the .config file from Kconfig
-import_kconfig(CONFIG_ ${DOTCONFIG})
+# Import the .config file and make all settings available in CMake processing.
+import_kconfig(${KCONFIG_NAMESPACE} ${DOTCONFIG})
 
 # Re-introduce the CLI Kconfig symbols that survived
 foreach (name ${cache_variable_names})
-  if("${name}" MATCHES "^CONFIG_")
+  if("${name}" MATCHES "^${KCONFIG_NAMESPACE}_")
     if(DEFINED ${name})
       set(${name} ${${name}} CACHE STRING "")
     endif()

--- a/scripts/west_commands/build_helpers.py
+++ b/scripts/west_commands/build_helpers.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from west import log
 from west.configuration import config
 from west.util import escapes_directory
+from domains import Domains
 
 DEFAULT_BUILD_DIR = 'build'
 '''Name of the default Zephyr build directory.'''
@@ -133,3 +134,19 @@ def is_zephyr_build(path):
     log.dbg(f'{path} is NOT a valid zephyr build directory',
             level=log.VERBOSE_EXTREME)
     return False
+
+
+def load_domains(path):
+    '''Load domains from a domains.yaml.
+
+    If domains.yaml is not found, then a single 'app' domain referring to the
+    top-level build folder is created and returned.
+    '''
+    domains_file = Path(path) / 'domains.yaml'
+
+    if not domains_file.is_file():
+        return Domains.from_data({'default': 'app',
+                                  'build_dir': path,
+                                  'domains': [{'name': 'app', 'build_dir': path}]})
+
+    return Domains.from_file(domains_file)

--- a/scripts/west_commands/domains.py
+++ b/scripts/west_commands/domains.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+'''Domain handling for west extension commands.
+
+This provides parsing of domains yaml file and creation of objects of the
+Domain class.
+'''
+
+import yaml
+import pykwalify.core
+from west import log
+
+DOMAINS_SCHEMA = '''
+## A pykwalify schema for basic validation of the structure of a
+## domains YAML file.
+##
+# The domains.yaml file is a simple list of domains from a multi image build
+# along with the default domain to use.
+type: map
+mapping:
+  default:
+    required: true
+    type: str
+  build_dir:
+    required: true
+    type: str
+  domains:
+    required: false
+    type: seq
+    sequence:
+      - type: map
+        mapping:
+          name:
+            required: true
+            type: str
+          build_dir:
+            required: true
+            type: str
+'''
+
+schema = yaml.safe_load(DOMAINS_SCHEMA)
+
+
+class Domains:
+
+    def __init__(self, data):
+        self._domains = []
+        self._domain_names = []
+        self._domain_default = []
+
+        self._build_dir = data.get('build_dir')
+        domain_list = data.get('domains')
+        if not domain_list:
+            log.wrn("no domains defined; this probably won't work")
+
+        for d in domain_list:
+            domain = Domain(d['name'], d['build_dir'])
+            self._domains.append(domain)
+            self._domain_names.append(domain.name)
+            if domain.name == data['default']:
+                self._default_domain = domain
+
+    @staticmethod
+    def from_file(domains_file):
+        '''Load domains from domains.yaml.
+
+        Exception raised:
+           - ``FileNotFoundError`` if the domains file is not found.
+        '''
+        try:
+            with open(domains_file, 'r') as f:
+                domains = yaml.safe_load(f.read())
+        except FileNotFoundError:
+            log.die(f'domains.yaml file not found: {domains_file}')
+
+        try:
+            pykwalify.core.Core(source_data=domains, schema_data=schema)\
+                .validate()
+        except pykwalify.errors.SchemaError:
+            log.die(f'ERROR: Malformed yaml in file: {domains_file}')
+
+        return Domains(domains)
+
+    @staticmethod
+    def from_data(domains_data):
+        '''Load domains from domains dictionary.
+        '''
+        return Domains(domains_data)
+
+    def get_domains(self, names=None):
+        ret = []
+
+        if not names:
+            return self._domains
+
+        for n in names:
+            found = False
+            for d in self._domains:
+                if n == d.name:
+                    ret.append(d)
+                    found = True
+                    break
+            # Getting here means the domain was not found.
+            # Todo: throw an error.
+            if not found:
+                log.die(f'domain {n} not found, '
+                        f'valid domains are:', *self._domain_names)
+        return ret
+
+    def get_default_domain(self):
+        return self._default_domain
+
+    def get_top_build_dir(self):
+        return self._build_dir
+
+
+class Domain:
+
+    def __init__(self, name, build_dir):
+        self.name = name
+        self.build_dir = build_dir
+
+    @property
+    def name(self):
+        return self._name
+
+    @name.setter
+    def name(self, value):
+        self._name = value
+
+    @property
+    def build_dir(self):
+        return self._build_dir
+
+    @build_dir.setter
+    def build_dir(self, value):
+        self._build_dir = value

--- a/scripts/west_commands/flash.py
+++ b/scripts/west_commands/flash.py
@@ -8,7 +8,8 @@
 
 from west.commands import WestCommand
 
-from run_common import add_parser_common, do_run_common
+from run_common import add_parser_common, do_run_common, get_build_dir
+from build_helpers import load_domains
 
 
 class Flash(WestCommand):
@@ -26,4 +27,6 @@ class Flash(WestCommand):
         return add_parser_common(self, parser_adder)
 
     def do_run(self, my_args, runner_args):
-        do_run_common(self, my_args, runner_args)
+        build_dir = get_build_dir(my_args)
+        domains = load_domains(build_dir).get_domains(my_args.domain)
+        do_run_common(self, my_args, runner_args, domains=domains)

--- a/share/sysbuild/CMakeLists.txt
+++ b/share/sysbuild/CMakeLists.txt
@@ -37,6 +37,8 @@ ExternalZephyrProject_Add(
   MAIN_APP
 )
 
+add_subdirectory(bootloader)
+
 # This allows for board and app specific images to be included.
 include(${BOARD_DIR}/sysbuild.cmake OPTIONAL)
 include(${APP_DIR}/sysbuild.cmake OPTIONAL)

--- a/share/sysbuild/CMakeLists.txt
+++ b/share/sysbuild/CMakeLists.txt
@@ -30,6 +30,31 @@ set(IMAGES)
 get_filename_component(APP_DIR  ${APP_DIR} ABSOLUTE)
 get_filename_component(app_name ${APP_DIR} NAME)
 
+# Propagate bootloader and signing settings from this system to the MCUboot and
+# application image build systems.
+if(SB_CONFIG_BOOTLOADER_MCUBOOT)
+  set(${app_name}_CONFIG_BOOTLOADER_MCUBOOT y CACHE STRING
+      "MCUBOOT is enabled as bootloader" FORCE
+  )
+  set(${app_name}_CONFIG_MCUBOOT_SIGNATURE_KEY_FILE
+      \"${SB_CONFIG_BOOT_SIGNATURE_KEY_FILE}\" CACHE STRING
+      "Signature key file for signing" FORCE
+  )
+
+  # Set corresponding values in mcuboot
+  set(mcuboot_CONFIG_BOOT_SIGNATURE_TYPE_${SB_CONFIG_SIGNATURE_TYPE} y CACHE STRING
+      "MCUBOOT signature type" FORCE
+  )
+  set(mcuboot_CONFIG_BOOT_SIGNATURE_KEY_FILE
+      \"${SB_CONFIG_BOOT_SIGNATURE_KEY_FILE}\" CACHE STRING
+      "Signature key file for signing" FORCE
+  )
+else()
+  set(${app_name}_CONFIG_BOOTLOADER_MCUBOOT n CACHE STRING
+      "MCUBOOT is disabled as bootloader" FORCE
+  )
+endif()
+
 # This adds the primary application to the build.
 ExternalZephyrProject_Add(
   APPLICATION ${app_name}

--- a/share/sysbuild/CMakeLists.txt
+++ b/share/sysbuild/CMakeLists.txt
@@ -1,0 +1,42 @@
+# Copyright (c) 2021 Nordic Semiconductor
+#
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20)
+
+if(NOT DEFINED APP_DIR)
+  message(FATAL_ERROR "No main application specified")
+endif()
+
+# This will update the APP_DIR cache variable to PATH type and apply a comment.
+# If APP_DIR is a relative path, then CMake will adjust to absolute path based
+# on current working dir.
+set(APP_DIR ${APP_DIR} CACHE PATH "Main Application Source Directory")
+
+# Add sysbuild/cmake/modules to CMAKE_MODULE_PATH which allows us to integrate
+# sysbuild CMake modules with general Zephyr CMake modules.
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/modules)
+# List of Zephyr and sysbuild CMake modules we need for sysbuild.
+# Note: sysbuild_kconfig will internally load kconfig CMake module.
+set(zephyr_modules extensions sysbuild_extensions python west root zephyr_module boards shields sysbuild_kconfig)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE} COMPONENTS ${zephyr_modules})
+
+project(sysbuild LANGUAGES)
+
+# Global list of images enabled in this multi image build system.
+set(IMAGES)
+
+get_filename_component(APP_DIR  ${APP_DIR} ABSOLUTE)
+get_filename_component(app_name ${APP_DIR} NAME)
+
+# This adds the primary application to the build.
+ExternalZephyrProject_Add(
+  APPLICATION ${app_name}
+  SOURCE_DIR ${APP_DIR}
+  MAIN_APP
+)
+
+# This allows for board and app specific images to be included.
+include(${BOARD_DIR}/sysbuild.cmake OPTIONAL)
+include(${APP_DIR}/sysbuild.cmake OPTIONAL)

--- a/share/sysbuild/CMakeLists.txt
+++ b/share/sysbuild/CMakeLists.txt
@@ -36,9 +36,13 @@ ExternalZephyrProject_Add(
   SOURCE_DIR ${APP_DIR}
   MAIN_APP
 )
+list(APPEND IMAGES "${app_name}")
+set(DEFAULT_IMAGE "${app_name}")
 
 add_subdirectory(bootloader)
 
 # This allows for board and app specific images to be included.
 include(${BOARD_DIR}/sysbuild.cmake OPTIONAL)
 include(${APP_DIR}/sysbuild.cmake OPTIONAL)
+
+include(cmake/domains.cmake)

--- a/share/sysbuild/Kconfig
+++ b/share/sysbuild/Kconfig
@@ -1,0 +1,34 @@
+# Copyright (c) 2021 Nordic Semiconductor
+#
+# SPDX-License-Identifier: Apache-2.0
+
+comment "Sysbuild image configuration"
+
+osource "$(BOARD_DIR)/Kconfig.sysbuild"
+
+config EXPERIMENTAL
+	bool
+	help
+	  Symbol that must be selected by a feature if it is considered to be
+	  at an experimental implementation stage.
+
+config WARN_EXPERIMENTAL
+	bool
+	prompt "Warn on experimental usage"
+	help
+	  Print a warning when the Kconfig tree is parsed if any experimental
+	  features are enabled.
+
+config DEPRECATED
+	bool
+	help
+	  Symbol that must be selected by a feature or module if it is
+	  considered to be deprecated.
+
+config WARN_DEPRECATED
+	bool
+	default y
+	prompt "Warn on deprecated usage"
+	help
+	  Print a warning when the Kconfig tree is parsed if any deprecated
+	  features are enabled.

--- a/share/sysbuild/Kconfig
+++ b/share/sysbuild/Kconfig
@@ -32,3 +32,5 @@ config WARN_DEPRECATED
 	help
 	  Print a warning when the Kconfig tree is parsed if any deprecated
 	  features are enabled.
+
+rsource "bootloader/Kconfig"

--- a/share/sysbuild/bootloader/CMakeLists.txt
+++ b/share/sysbuild/bootloader/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Copyright (c) 2022 Nordic Semiconductor
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Include MCUboot if enabled.
+if(SB_CONFIG_BOOTLOADER_MCUBOOT)
+  ExternalZephyrProject_Add(
+    APPLICATION mcuboot
+    SOURCE_DIR ${ZEPHYR_MCUBOOT_MODULE_DIR}/boot/zephyr/
+  )
+endif()

--- a/share/sysbuild/bootloader/CMakeLists.txt
+++ b/share/sysbuild/bootloader/CMakeLists.txt
@@ -8,4 +8,7 @@ if(SB_CONFIG_BOOTLOADER_MCUBOOT)
     APPLICATION mcuboot
     SOURCE_DIR ${ZEPHYR_MCUBOOT_MODULE_DIR}/boot/zephyr/
   )
+  # MCUBoot default configuration is to perform a full chip erase.
+  # Placing MCUBoot first in list to ensure it is flashed before other images.
+  set(IMAGES "mcuboot" ${IMAGES} PARENT_SCOPE)
 endif()

--- a/share/sysbuild/bootloader/Kconfig
+++ b/share/sysbuild/bootloader/Kconfig
@@ -1,0 +1,29 @@
+# Copyright (c) 2022 Nordic Semiconductor
+#
+# SPDX-License-Identifier: Apache-2.0
+
+config SUPPORT_BOOTLOADER
+	bool
+	default y
+
+config SUPPORT_BOOTLOADER_MCUBOOT_ZEPHYR
+	bool
+	default y
+
+choice BOOTLOADER
+	prompt "Bootloader support"
+	default BOOTLOADER_NONE
+	depends on SUPPORT_BOOTLOADER
+
+config BOOTLOADER_NONE
+	bool "None"
+	help
+	  Do not Include a bootloader in the build
+
+config BOOTLOADER_MCUBOOT
+	bool "MCUboot"
+	depends on SUPPORT_BOOTLOADER_MCUBOOT_ZEPHYR
+	help
+	  Include MCUboot (Zephyr port) as the bootloader to use
+
+endchoice

--- a/share/sysbuild/bootloader/Kconfig
+++ b/share/sysbuild/bootloader/Kconfig
@@ -27,3 +27,41 @@ config BOOTLOADER_MCUBOOT
 	  Include MCUboot (Zephyr port) as the bootloader to use
 
 endchoice
+
+if BOOTLOADER_MCUBOOT
+
+config SIGNATURE_TYPE
+	string
+	default NONE if BOOT_SIGNATURE_TYPE_NONE
+	default RSA  if BOOT_SIGNATURE_TYPE_RSA
+	default ECDSA_P256 if BOOT_SIGNATURE_TYPE_ECDSA_P256
+	default ED25519 if BOOT_SIGNATURE_TYPE_ED25519
+
+choice
+	prompt "Signature type"
+	default BOOT_SIGNATURE_TYPE_RSA
+
+config BOOT_SIGNATURE_TYPE_NONE
+	bool "No signature; use only hash check"
+
+config BOOT_SIGNATURE_TYPE_RSA
+	bool "RSA signatures"
+
+config BOOT_SIGNATURE_TYPE_ECDSA_P256
+	bool "Elliptic curve digital signatures with curve P-256"
+
+config BOOT_SIGNATURE_TYPE_ED25519
+	bool "Edwards curve digital signatures using ed25519"
+
+endchoice
+
+config BOOT_SIGNATURE_KEY_FILE
+	string "PEM key file"
+	default "$(ZEPHYR_MCUBOOT_MODULE_DIR)/root-ec-p256.pem" if BOOT_SIGNATURE_TYPE_ECDSA_P256
+	default "$(ZEPHYR_MCUBOOT_MODULE_DIR)/root-ed25519.pem" if BOOT_SIGNATURE_TYPE_ED25519
+	default "$(ZEPHYR_MCUBOOT_MODULE_DIR)/root-rsa-2048.pem" if BOOT_SIGNATURE_TYPE_RSA
+	default ""
+	help
+	  Absolute path to key file to use with MCUBoot.
+
+endif

--- a/share/sysbuild/cmake/domains.cmake
+++ b/share/sysbuild/cmake/domains.cmake
@@ -1,0 +1,12 @@
+# Copyright (c) 2021 Nordic Semiconductor
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set(domains_yaml "default: ${DEFAULT_IMAGE}")
+set(domains_yaml "${domains_yaml}\nbuild_dir: ${CMAKE_BINARY_DIR}")
+set(domains_yaml "${domains_yaml}\ndomains:")
+foreach(image ${IMAGES})
+  set(domains_yaml "${domains_yaml}\n  - name: ${image}")
+  set(domains_yaml "${domains_yaml}\n    build_dir: $<TARGET_PROPERTY:${image},_EP_BINARY_DIR>")
+endforeach()
+file(GENERATE OUTPUT ${CMAKE_BINARY_DIR}/domains.yaml CONTENT "${domains_yaml}")

--- a/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
@@ -1,0 +1,187 @@
+# Copyright (c) 2021 Nordic Semiconductor
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Usage:
+#   ExternalZephyrProject_Add(APPLICATION <name>
+#                             SOURCE_DIR <dir>
+#                             [BOARD <board>]
+#                             [MAIN_APP]
+#   )
+#
+# This function includes a Zephyr based build system into the multiimage
+# build system
+#
+# APPLICATION: <name>: Name of the application, name will also be used for build
+#                      folder of the application
+# SOURCE_DIR <dir>:    Source directory of the application
+# BOARD <board>:       Use <board> for application build instead user defined BOARD.
+# MAIN_APP:            Flag indicating this application is the main application
+#                      and where user defined settings should be passed on as-is
+#                      except for multi image build flags.
+#                      For example, -DCONF_FILES=<files> will be passed on to the
+#                      MAIN_APP unmodified.
+#
+function(ExternalZephyrProject_Add)
+  cmake_parse_arguments(ZBUILD "MAIN_APP" "APPLICATION;BOARD;SOURCE_DIR" "" ${ARGN})
+
+  if(ZBUILD_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR
+      "ExternalZephyrProject_Add(${ARGV0} <val> ...) given unknown arguments:"
+      " ${ZBUILD_UNPARSED_ARGUMENTS}"
+    )
+  endif()
+
+  set(sysbuild_vars
+      "APP_DIR"
+      "SB_CONF_FILE"
+  )
+
+  # General variables that should be propagated to all Zephyr builds, for example:
+  # - ZEPHYR_MODULES / ZEPHYR_EXTRA_MODULES
+  # - ZEPHYR_TOOLCHAIN_VARIANT
+  # - *_TOOLCHAIN_PATH
+  # - *_ROOT
+  # etc.
+  # Note: setting vars on a single image can be done by using
+  #       `<image>_CONF_FILE`, like `mcuboot_CONF_FILE`
+  set(
+    shared_image_variables_list
+    CMAKE_BUILD_TYPE
+    CMAKE_VERBOSE_MAKEFILE
+    BOARD
+    ZEPHYR_MODULES
+    ZEPHYR_EXTRA_MODULES
+    ZEPHYR_TOOLCHAIN_VARIANT
+    EXTRA_KCONFIG_TARGETS
+  )
+
+  set(shared_image_variables_regex
+      "^[^_]*_TOOLCHAIN_PATH|^[^_]*_ROOT"
+  )
+
+  set(app_cache_file ${CMAKE_BINARY_DIR}/CMake${ZBUILD_APPLICATION}PreloadCache.txt)
+
+  if(EXISTS ${app_cache_file})
+    file(STRINGS ${app_cache_file} app_cache_strings)
+    set(app_cache_strings_current ${app_cache_strings})
+  endif()
+
+  get_cmake_property(variables_cached CACHE_VARIABLES)
+  foreach(var_name ${variables_cached})
+    # Any var of the form `<app>_<var>` should be propagated.
+    # For example mcuboot_<VAR>=<val> ==> -D<VAR>=<val> for mcuboot build.
+    if("${var_name}" MATCHES "^${ZBUILD_APPLICATION}_.*")
+      list(APPEND application_vars ${var_name})
+      continue()
+    endif()
+
+    # This means there is a match to another image than current one, ignore.
+    if("${var_name}" MATCHES "^.*_CONFIG_.*")
+      continue()
+    endif()
+
+    # sysbuild reserved namespace.
+    if(var_name IN_LIST sysbuild_vars OR "${var_name}" MATCHES "^SB_CONFIG_.*")
+      continue()
+    endif()
+
+    if("${var_name}" MATCHES "^CONFIG_.*")
+      if(ZBUILD_MAIN_APP)
+        list(APPEND application_vars ${var_name})
+      endif()
+      continue()
+    endif()
+
+    if(var_name IN_LIST shared_image_variables_list)
+      list(APPEND application_vars ${var_name})
+      continue()
+    endif()
+
+    if("${var_name}" MATCHES "${shared_image_variables_regex}")
+      list(APPEND application_vars ${var_name})
+    endif()
+  endforeach()
+
+  foreach(app_var_name ${application_vars})
+    string(REGEX REPLACE "^${ZBUILD_APPLICATION}_" "" var_name "${app_var_name}")
+    get_property(var_type  CACHE ${app_var_name} PROPERTY TYPE)
+    set(new_cache_entry "${var_name}:${var_type}=${${app_var_name}}")
+    if(NOT new_cache_entry IN_LIST app_cache_strings)
+      # This entry does not exists, let's see if it has been updated.
+      foreach(entry ${app_cache_strings})
+        if("${entry}" MATCHES "^${var_name}:.*")
+          list(REMOVE_ITEM app_cache_strings "${entry}")
+          break()
+        endif()
+      endforeach()
+      list(APPEND app_cache_strings "${var_name}:${var_type}=${${app_var_name}}")
+      list(APPEND app_cache_entries "-D${var_name}:${var_type}=${${app_var_name}}")
+    endif()
+  endforeach()
+
+  if(NOT "${app_cache_strings_current}" STREQUAL "${app_cache_strings}")
+    string(REPLACE ";" "\n" app_cache_strings "${app_cache_strings}")
+    file(WRITE ${app_cache_file} ${app_cache_strings})
+  endif()
+
+  if(DEFINED ZBUILD_BOARD)
+    list(APPEND app_cache_entries "-DBOARD=${ZBUILD_BOARD}")
+  elseif(NOT ZBUILD_MAIN_APP)
+    list(APPEND app_cache_entries "-DBOARD=${BOARD}")
+  endif()
+
+  set(image_banner "* Running CMake for ${ZBUILD_APPLICATION} *")
+  string(LENGTH "${image_banner}" image_banner_width)
+  string(REPEAT "*" ${image_banner_width} image_banner_header)
+  message(STATUS "\n   ${image_banner_header}\n"
+                 "   ${image_banner}\n"
+                 "   ${image_banner_header}\n"
+  )
+
+  execute_process(
+    COMMAND ${CMAKE_COMMAND}
+      -G${CMAKE_GENERATOR}
+      ${app_cache_entries}
+      -B${CMAKE_BINARY_DIR}/${ZBUILD_APPLICATION}
+      -S${ZBUILD_SOURCE_DIR}
+    RESULT_VARIABLE   return_val
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  )
+
+  if(return_val)
+    message(FATAL_ERROR
+            "CMake configure failed for Zephyr project: ${ZBUILD_APPLICATION}\n"
+            "Location: ${ZBUILD_SOURCE_DIR}"
+    )
+  endif()
+
+  foreach(kconfig_target
+      menuconfig
+      hardenconfig
+      guiconfig
+      ${EXTRA_KCONFIG_TARGETS}
+      )
+
+    if(NOT ZBUILD_MAIN_APP)
+      set(image_prefix "${ZBUILD_APPLICATION}_")
+    endif()
+
+    add_custom_target(${image_prefix}${kconfig_target}
+      ${CMAKE_MAKE_PROGRAM} ${kconfig_target}
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/${ZBUILD_APPLICATION}
+      USES_TERMINAL
+      )
+  endforeach()
+  include(ExternalProject)
+  ExternalProject_Add(
+    ${ZBUILD_APPLICATION}
+    SOURCE_DIR ${ZBUILD_SOURCE_DIR}
+    BINARY_DIR ${CMAKE_BINARY_DIR}/${ZBUILD_APPLICATION}
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ${CMAKE_COMMAND} --build .
+    INSTALL_COMMAND ""
+    BUILD_ALWAYS True
+    USES_TERMINAL_BUILD True
+  )
+endfunction()

--- a/share/sysbuild/cmake/modules/sysbuild_kconfig.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_kconfig.cmake
@@ -1,0 +1,60 @@
+# Copyright (c) 2021 Nordic Semiconductor
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set(EXTRA_KCONFIG_TARGET_COMMAND_FOR_sysbuild_menuconfig
+  ${ZEPHYR_BASE}/scripts/kconfig/menuconfig.py
+)
+
+set(EXTRA_KCONFIG_TARGET_COMMAND_FOR_sysbuild_guiconfig
+  ${ZEPHYR_BASE}/scripts/kconfig/guiconfig.py
+)
+
+set(KCONFIG_TARGETS sysbuild_menuconfig sysbuild_guiconfig)
+list(TRANSFORM EXTRA_KCONFIG_TARGETS PREPEND "sysbuild_")
+
+if(DEFINED SB_CONF_FILE)
+  # SB_CONF_FILE already set so nothing to do.
+elseif(DEFINED ENV{SB_CONF_FILE})
+  set(SB_CONF_FILE $ENV{SB_CONF_FILE})
+elseif(EXISTS      ${APP_DIR}/sysbuild.conf)
+  set(SB_CONF_FILE ${APP_DIR}/sysbuild.conf)
+else()
+  # Because SYSBuild is opt-in feature, then it is permitted to not have a
+  # SYSBuild dedicated configuration file.
+endif()
+
+if(DEFINED SB_CONF_FILE AND NOT IS_ABSOLUTE SB_CONF_FILE)
+  cmake_path(ABSOLUTE_PATH SB_CONF_FILE BASE_DIRECTORY ${APP_DIR} OUTPUT_VARIABLE SB_CONF_FILE)
+endif()
+
+if(DEFINED SB_CONF_FILE AND NOT DEFINED CACHE{SB_CONF_FILE})
+  # We only want to set this in cache it has been defined and is not already there.
+  set(SB_CONF_FILE ${SB_CONF_FILE} CACHE STRING "If desired, you can build the application with \
+  SYSbuild configuration settings specified in an alternate .conf file using this parameter. \
+  These settings will override the settings in the application’s SYSBuild config file or its \
+  default .conf file. Multiple files may be listed, e.g. SB_CONF_FILE=\"sys1.conf sys2.conf\"")
+endif()
+
+if(NOT DEFINED SB_CONF_FILE)
+  # If there is no SB_CONF_FILE, then use empty.conf to make kconfiglib happy.
+  # Not adding it to CMake cache ensures that a later created sysbuild.conf
+  # will be automatically detected.
+  set(SB_CONF_FILE ${CMAKE_CURRENT_BINARY_DIR}/empty.conf)
+endif()
+
+# Empty files to make kconfig.py happy.
+file(TOUCH ${CMAKE_CURRENT_BINARY_DIR}/empty.conf)
+set(APPLICATION_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+set(KCONFIG_BINARY_DIR     ${CMAKE_CURRENT_BINARY_DIR})
+set(AUTOCONF_H             ${CMAKE_CURRENT_BINARY_DIR}/autoconf.h)
+set(CONF_FILE              ${SB_CONF_FILE})
+set(BOARD_DEFCONFIG        "${CMAKE_CURRENT_BINARY_DIR}/empty.conf")
+list(APPEND ZEPHYR_KCONFIG_MODULES_DIR BOARD=${BOARD})
+set(KCONFIG_NAMESPACE SB_CONFIG)
+
+if(EXISTS ${APP_DIR}/Kconfig.sysbuild)
+  set(KCONFIG_ROOT ${APP_DIR}/Kconfig.sysbuild)
+endif()
+include(${ZEPHYR_BASE}/cmake/modules/kconfig.cmake)
+set(CONF_FILE)


### PR DESCRIPTION
This is an PR for a direction of multi image support in Zephyr, as discussed in dev-review meeting Nov. 11. 2021.

Fixes: #40309 

Documentation PR: #43846

~Depends on: #41301~

With #37872 the issue regarding multi image build system came up again.

This PR takes another direction, as it does not interfere with the existing Zephyr CMake build system infrastructure.

Zephyr build code and samples are not impacted with this PR.

Instead a dedicated west build project has been created in `<zephyr>/sysbuild` (feel free to propose alternative location).
This project is capable of building a regular Zephyr sample as well as MCUBoot.

Each sample is seen as a dedicated project.

`west build` has been extended to support multi image for building, as well as `west flash` supports flashing of all images in the multi image build.

Per default, everything builds as normal, that is a single image build IS Still build as:
```
west build -bnrf52840dk_nrf52840 samples/hello_world
```
which gives:
```
-- west build: making build dir /projects/github/ncs/zephyr/build pristine
-- west build: generating a build system
Loading Zephyr default modules (Zephyr base).
-- Application: /projects/github/ncs/zephyr/samples/hello_world
...
```

but the same sample can now also be build and flash with `mcuboot` (or in principle any other multi image setup), simply by enabling MCUboot and build with sysbuild option:
```
$ west build -bnrf52840dk_nrf52840 samples/hello_world/ --sysbuild -- -DSB_CONFIG_BOOTLOADER_MCUBOOT=y
...
   *********************************
   * Running CMake for hello_world *
   *********************************
...
-- Build files have been written to: /projects/github/ncs/zephyr/build/hello_world
-- 
   *****************************
   * Running CMake for mcuboot *
   *****************************
...
-- Build files have been written to: /projects/github/ncs/zephyr/build/mcuboot
-- Configuring done
-- Generating done
-- Build files have been written to: /projects/github/ncs/zephyr/build
-- west build: building application
[9/16] Performing build step for 'mcuboot'
[1/257] Preparing syscall dependency handling

[247/257] Linking C executable zephyr/zephyr_pre0.elf

[251/257] Linking C executable zephyr/zephyr_pre1.elf

[257/257] Linking C executable zephyr/zephyr.elf
Memory region         Used Size  Region Size  %age Used
           FLASH:       37836 B        48 KB     76.98%
            SRAM:       23808 B       256 KB      9.08%
        IDT_LIST:          0 GB         2 KB      0.00%
[11/16] Performing build step for 'hello_world'
[1/155] Preparing syscall dependency handling

[145/155] Linking C executable zephyr/zephyr_pre0.elf

[149/155] Linking C executable zephyr/zephyr_pre1.elf

[155/155] Linking C executable zephyr/zephyr.elf
Memory region         Used Size  Region Size  %age Used
           FLASH:       17680 B       412 KB      4.19%
            SRAM:        5440 B       256 KB      2.08%
        IDT_LIST:          0 GB         2 KB      0.00%
[16/16] Completed 'hello_world'
```

where it can be seen that both `hello_world` and `mcuboot` were successfully build.

Both samples can be flash in a single invocation with `west flash`:
```
$ west flash
-- west flash: rebuilding
[0/6] Performing build step for 'mcuboot'
ninja: no work to do.
[1/6] Performing build step for 'hello_world'
ninja: no work to do.
[6/6] Completed 'hello_world'
-- west flash: using runner nrfjprog
-- runners.nrfjprog: mass erase requested
Using board 683848500
-- runners.nrfjprog: Flashing file: /projects/github/ncs/zephyr/build/mcuboot/zephyr/zephyr.hex
Parsing image file.
Applying system reset.
Verified OK.
Enabling pin reset.
Applying pin reset.
-- runners.nrfjprog: Board with serial number 683848500 flashed successfully.
-- west flash: using runner nrfjprog
Using board 683848500
-- runners.nrfjprog: Flashing file: /projects/github/ncs/zephyr/build/hello_world/zephyr/zephyr.signed.hex
-- runners.nrfjprog: Flashing file: /projects/github/ncs/zephyr/build/hello_world/zephyr/zephyr.signed.hex
Parsing image file.
Applying system reset.
Verified OK.
Enabling pin reset.
Applying pin reset.
-- runners.nrfjprog: Board with serial number 683848500 flashed successfully.
-- runners.nrfjprog: Board with serial number 683848500 flashed successfully.
```

Resulting in following output on the terminal.
```
*** Booting Zephyr OS build v2.7.99-1479-g6fb2ea314f83  ***
I: Starting bootloader
I: Primary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3
I: Secondary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3
I: Boot source: none
I: Swap type: none
I: Bootloader chainload address offset: 0xc000
I: Jumping to the first image slot
*** Booting Zephyr OS build v2.7.99-1479-g6fb2ea314f83  ***
Hello World! nrf52840dk_nrf52840
```

Running `ninja -Cbuild sysbuild_menuconfig` will provide a sysbuild configuration interface:
![image](https://user-images.githubusercontent.com/9802583/142871611-1e640117-1dab-4df6-b310-8d202db3716e.png)

`menuconfig` for `hello_world` is started as always so that the user doesn't need to change workflow.
- `west build -bnrf52840dk_nrf52840 samples/hello_world -t menuconfig`
    ![image](https://user-images.githubusercontent.com/9802583/142871902-1255ae22-edb3-4b92-8969-9a9c537013d5.png)

`menuconfig` for mcuboot can be started by pre-fixing menuconfig with the name of the image.
- `west build -bnrf52840dk_nrf52840 samples/hello_world/ -t mcuboot_menuconfig`
   ![image](https://user-images.githubusercontent.com/9802583/142872030-b4edaead-ce7f-40e6-84cf-6182848388e2.png)


If users want to build using sysbuild per default, then a config build option can be set, like:
```
$ west config build.sysbuild true
```

which will build using sysbuild per default.
A user enabling `sysbuild` per default can still choose to build without sysbuild in specific cases by applying `--no-sysbuild`, like:
```
$ west build -bnrf52840dk_nrf52840 samples/hello_world/ ---no-sysbuild
```


Slides from devreview presentaion:
[SYSBuild architectural overview](https://docs.google.com/presentation/d/1d4Jr7DPiAJdTqQGLzY3Zn6hbytdA0NlMl4ug91idHA8/edit#slide=id.p)

------------

List of alternative name proposals instead of sysbuild:
- [Aeolus](https://en.wikipedia.org/wiki/Aeolus_(Odyssey)), proposed [here](https://github.com/zephyrproject-rtos/zephyr/pull/40555#issuecomment-1024078906)
  > In Greek mythology, Aeolus was the keeper of the winds

  