### PR TITLE
modbus: stop bits can now be set individually

### DIFF
--- a/include/modbus/modbus.h
+++ b/include/modbus/modbus.h
@@ -406,6 +406,13 @@ struct modbus_serial_param {
 	 *    UART_CFG_PARITY_ODD
 	 */
 	enum uart_config_parity parity;
+	/** stop_bits_client UART's stop bits setting if in client mode:
+	 *    UART_CFG_STOP_BITS_0_5,
+	 *    UART_CFG_STOP_BITS_1,
+	 *    UART_CFG_STOP_BITS_1_5,
+	 *    UART_CFG_STOP_BITS_2,
+	 */
+	enum uart_config_stop_bits stop_bits_client;
 };
 
 /**

--- a/samples/subsys/modbus/rtu_client/src/main.c
+++ b/samples/subsys/modbus/rtu_client/src/main.c
@@ -20,6 +20,7 @@ const static struct modbus_iface_param client_param = {
 	.serial = {
 		.baud = 19200,
 		.parity = UART_CFG_PARITY_NONE,
+		.stop_bits_client = UART_CFG_STOP_BITS_2,
 	},
 };
 

--- a/subsys/modbus/modbus_core.c
+++ b/subsys/modbus/modbus_core.c
@@ -238,6 +238,8 @@ int modbus_init_server(const int iface, struct modbus_iface_param param)
 		goto init_server_error;
 	}
 
+	ctx->client = false;
+
 	switch (param.mode) {
 	case MODBUS_MODE_RTU:
 	case MODBUS_MODE_ASCII:
@@ -262,7 +264,6 @@ int modbus_init_server(const int iface, struct modbus_iface_param param)
 		goto init_server_error;
 	}
 
-	ctx->client = false;
 	ctx->unit_id = param.server.unit_id;
 	ctx->mbs_user_cb = param.server.user_cb;
 	if (IS_ENABLED(CONFIG_MODBUS_FC08_DIAGNOSTIC)) {
@@ -298,6 +299,8 @@ int modbus_init_client(const int iface, struct modbus_iface_param param)
 		goto init_client_error;
 	}
 
+	ctx->client = true;
+
 	switch (param.mode) {
 	case MODBUS_MODE_RTU:
 	case MODBUS_MODE_ASCII:
@@ -322,7 +325,6 @@ int modbus_init_client(const int iface, struct modbus_iface_param param)
 		goto init_client_error;
 	}
 
-	ctx->client = true;
 	ctx->unit_id = 0;
 	ctx->mbs_user_cb = NULL;
 	ctx->rxwait_to = param.rx_timeout;

--- a/subsys/modbus/modbus_serial.c
+++ b/subsys/modbus/modbus_serial.c
@@ -540,6 +540,20 @@ int modbus_serial_init(struct modbus_context *ctx,
 		return -EINVAL;
 	}
 
+	if (ctx->client) {
+		/* Allow custom stop bit settings only in client mode */
+		switch (param.serial.stop_bits_client) {
+		case UART_CFG_STOP_BITS_0_5:
+		case UART_CFG_STOP_BITS_1:
+		case UART_CFG_STOP_BITS_1_5:
+		case UART_CFG_STOP_BITS_2:
+			uart_cfg.stop_bits = param.serial.stop_bits_client;
+			break;
+		default:
+			return -EINVAL;
+		}
+	}
+
 	if (uart_configure(cfg->dev, &uart_cfg) != 0) {
 		LOG_ERR("Failed to configure UART");
 		return -EINVAL;

--- a/tests/subsys/modbus/src/test_modbus_client.c
+++ b/tests/subsys/modbus/src/test_modbus_client.c
@@ -208,6 +208,7 @@ static struct modbus_iface_param client_param = {
 	.serial = {
 		.baud = MB_TEST_BAUDRATE_LOW,
 		.parity = UART_CFG_PARITY_ODD,
+		.stop_bits_client = UART_CFG_STOP_BITS_1,
 	},
 };
 
@@ -221,6 +222,7 @@ void test_client_setup_low_none(void)
 	client_param.mode = MODBUS_MODE_RTU;
 	client_param.serial.baud = MB_TEST_BAUDRATE_LOW;
 	client_param.serial.parity = UART_CFG_PARITY_NONE;
+	client_param.serial.stop_bits_client = UART_CFG_STOP_BITS_2;
 
 	err = modbus_init_client(client_iface, client_param);
 	zassert_equal(err, 0, "Failed to configure RTU client");
@@ -236,6 +238,7 @@ void test_client_setup_low_odd(void)
 	client_param.mode = MODBUS_MODE_RTU;
 	client_param.serial.baud = MB_TEST_BAUDRATE_LOW;
 	client_param.serial.parity = UART_CFG_PARITY_ODD;
+	client_param.serial.stop_bits_client = UART_CFG_STOP_BITS_1;
 
 	err = modbus_init_client(client_iface, client_param);
 	zassert_equal(err, 0, "Failed to configure RTU client");
@@ -251,6 +254,7 @@ void test_client_setup_high_even(void)
 	client_param.mode = MODBUS_MODE_RTU;
 	client_param.serial.baud = MB_TEST_BAUDRATE_HIGH;
 	client_param.serial.parity = UART_CFG_PARITY_EVEN;
+	client_param.serial.stop_bits_client = UART_CFG_STOP_BITS_1;
 
 	err = modbus_init_client(client_iface, client_param);
 	zassert_equal(err, 0, "Failed to configure RTU client");
@@ -266,6 +270,7 @@ void test_client_setup_ascii(void)
 	client_param.mode = MODBUS_MODE_ASCII;
 	client_param.serial.baud = MB_TEST_BAUDRATE_HIGH;
 	client_param.serial.parity = UART_CFG_PARITY_EVEN;
+	client_param.serial.stop_bits_client = UART_CFG_STOP_BITS_1;
 
 	err = modbus_init_client(client_iface, client_param);
 


### PR DESCRIPTION
Added the stop_bits parameter to the modbus_serial_param struct.
Being able to configure the number of stop bits independently
from the parity setting, allows to support modbus devices
that do not follow the MODBUS over Serial Line Specification
and Implementation Guide.

Signed-off-by: Constantin Krischke <constantin.krischke@lemonbeat.com>