### PR TITLE
MSI/MSI-X Support for Generic Host PCIe Controller

### DIFF
--- a/drivers/interrupt_controller/intc_gicv3_its.c
+++ b/drivers/interrupt_controller/intc_gicv3_its.c
@@ -561,6 +561,13 @@ static unsigned int gicv3_its_alloc_intid(const struct device *dev)
 	return atomic_inc(&nlpi_intid);
 }
 
+static uint32_t gicv3_its_get_msi_addr(const struct device *dev)
+{
+	const struct gicv3_its_config *cfg = (const struct gicv3_its_config *)dev->config;
+
+	return cfg->base_addr + GITS_TRANSLATER;
+}
+
 #define ITS_RDIST_MAP(n)									  \
 	{											  \
 		const struct device *dev = DEVICE_DT_INST_GET(n);				  \
@@ -651,6 +658,7 @@ struct its_driver_api gicv3_its_api = {
 	.setup_deviceid = gicv3_its_init_device_id,
 	.map_intid = gicv3_its_map_intid,
 	.send_int = gicv3_its_send_int,
+	.get_msi_addr = gicv3_its_get_msi_addr,
 };
 
 #define GICV3_ITS_INIT(n)						       \

--- a/drivers/pcie/host/controller.c
+++ b/drivers/pcie/host/controller.c
@@ -410,3 +410,49 @@ void pcie_generic_ctrl_enumerate(const struct device *ctrl_dev, pcie_bdf_t bdf_s
 		}
 	}
 }
+
+#ifdef CONFIG_PCIE_MSI
+uint32_t pcie_msi_map(unsigned int irq, msi_vector_t *vector, uint8_t n_vector)
+{
+	ARG_UNUSED(irq);
+
+	return vector->arch.address;
+}
+
+uint16_t pcie_msi_mdr(unsigned int irq, msi_vector_t *vector)
+{
+	ARG_UNUSED(irq);
+
+	return vector->arch.eventid;
+}
+
+uint8_t arch_pcie_msi_vectors_allocate(unsigned int priority,
+				       msi_vector_t *vectors,
+				       uint8_t n_vector)
+{
+	const struct device *dev;
+
+	dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_pcie_controller));
+	if (!dev) {
+		LOG_ERR("Failed to get PCIe root complex");
+		return 0;
+	}
+
+	return pcie_ctrl_msi_device_setup(dev, priority, vectors, n_vector);
+}
+
+bool arch_pcie_msi_vector_connect(msi_vector_t *vector,
+				  void (*routine)(const void *parameter),
+				  const void *parameter,
+				  uint32_t flags)
+{
+	if (irq_connect_dynamic(vector->arch.irq, vector->arch.priority, routine,
+				parameter, flags) != vector->arch.irq) {
+		return false;
+	}
+
+	irq_enable(vector->arch.irq);
+
+	return true;
+}
+#endif

--- a/drivers/pcie/host/pcie_ecam.c
+++ b/drivers/pcie/host/pcie_ecam.c
@@ -11,6 +11,9 @@ LOG_MODULE_REGISTER(pcie_ecam, LOG_LEVEL_ERR);
 #include <device.h>
 #include <drivers/pcie/pcie.h>
 #include <drivers/pcie/controller.h>
+#ifdef CONFIG_GIC_V3_ITS
+#include <drivers/interrupt_controller/gicv3_its.h>
+#endif
 
 #define DT_DRV_COMPAT pci_host_ecam_generic
 
@@ -306,17 +309,84 @@ static bool pcie_ecam_region_translate(const struct device *dev, pcie_bdf_t bdf,
 	return true;
 }
 
+#if CONFIG_PCIE_MSI
+static uint8_t pcie_ecam_msi_device_setup(const struct device *dev, unsigned int priority,
+					  msi_vector_t *vectors, uint8_t n_vector)
+{
+#ifdef CONFIG_GIC_V3_ITS
+	const struct pcie_ctrl_config *cfg = (const struct pcie_ctrl_config *)dev->config;
+	unsigned int device_id;
+	pcie_bdf_t bdf;
+	int ret, i;
+
+	if (!n_vector) {
+		return 0;
+	}
+
+	bdf = vectors[0].bdf;
+
+	/* We do not support allocating vectors for multiple BDFs for now,
+	 * This would need tracking vectors already allocated for a BDF and
+	 * re-allocating a proper table in ITS for each BDF since we can't be
+	 * sure more vectors for each BDF will be allocated later.
+	 * Simply bail-out if it's the case here.
+	 */
+	for (i = 1; i < n_vector; i++) {
+		if (vectors[i].bdf != bdf) {
+			LOG_ERR("Multiple BDFs in a single MSI vector allocation isn't supported");
+			return 0;
+		}
+	}
+
+	device_id = PCI_BDF_TO_DEVID(bdf);
+
+	ret = its_setup_deviceid(cfg->msi_parent, device_id, n_vector);
+	if (ret) {
+		return 0;
+	}
+
+	for (i = 0; i < n_vector; i++) {
+		vectors[i].arch.irq = its_alloc_intid(cfg->msi_parent);
+		vectors[i].arch.address = its_get_msi_addr(cfg->msi_parent);
+		vectors[i].arch.eventid = i;
+		vectors[i].arch.priority = priority;
+
+		ret = its_map_intid(cfg->msi_parent, device_id,
+				    vectors[i].arch.eventid, vectors[i].arch.irq);
+		if (ret) {
+			break;
+		}
+	}
+
+	return i;
+#else
+	return 0;
+#endif
+}
+#endif
+
 static const struct pcie_ctrl_driver_api pcie_ecam_api = {
 	.conf_read = pcie_ecam_ctrl_conf_read,
 	.conf_write = pcie_ecam_ctrl_conf_write,
 	.region_allocate = pcie_ecam_region_allocate,
 	.region_get_allocate_base = pcie_ecam_region_get_allocate_base,
 	.region_translate = pcie_ecam_region_translate,
+#if CONFIG_PCIE_MSI
+	.msi_device_setup = pcie_ecam_msi_device_setup,
+#endif
 };
+
+#if CONFIG_PCIE_MSI
+#define DEVICE_DT_GET_MSI_PARENT(n)						\
+	.msi_parent = DEVICE_DT_GET(DT_PHANDLE(DT_DRV_INST(n), msi_parent)),
+#else
+#define DEVICE_DT_GET_MSI_PARENT(n)
+#endif
 
 #define PCIE_ECAM_INIT(n)							\
 	static struct pcie_ecam_data pcie_ecam_data##n;				\
 	static const struct pcie_ctrl_config pcie_ecam_config##n = {		\
+		DEVICE_DT_GET_MSI_PARENT(n)					\
 		.cfg_addr = DT_INST_REG_ADDR(n),				\
 		.cfg_size = DT_INST_REG_SIZE(n),				\
 		.ranges_count = DT_NUM_RANGES(DT_DRV_INST(n)),		\

--- a/include/drivers/interrupt_controller/gicv3_its.h
+++ b/include/drivers/interrupt_controller/gicv3_its.h
@@ -22,12 +22,14 @@ typedef int (*its_api_setup_deviceid_t)(const struct device *dev, uint32_t devic
 typedef int (*its_api_map_intid_t)(const struct device *dev, uint32_t device_id,
 				   uint32_t event_id, unsigned int intid);
 typedef int (*its_api_send_int_t)(const struct device *dev, uint32_t device_id, uint32_t event_id);
+typedef uint32_t (*its_api_get_msi_addr_t)(const struct device *dev);
 
 __subsystem struct its_driver_api {
 	its_api_alloc_intid_t alloc_intid;
 	its_api_setup_deviceid_t setup_deviceid;
 	its_api_map_intid_t map_intid;
 	its_api_send_int_t send_int;
+	its_api_get_msi_addr_t get_msi_addr;
 };
 
 static inline int its_alloc_intid(const struct device *dev)
@@ -62,6 +64,14 @@ static inline int its_send_int(const struct device *dev, uint32_t device_id, uin
 		(const struct its_driver_api *)dev->api;
 
 	return api->send_int(dev, device_id, event_id);
+}
+
+static inline uint32_t its_get_msi_addr(const struct device *dev)
+{
+	const struct its_driver_api *api =
+		(const struct its_driver_api *)dev->api;
+
+	return api->get_msi_addr(dev);
 }
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_GICV3_ITS_H_ */

--- a/include/drivers/pcie/msi.h
+++ b/include/drivers/pcie/msi.h
@@ -17,6 +17,23 @@
 extern "C" {
 #endif
 
+#ifdef CONFIG_PCIE_CONTROLLER
+struct msi_vector_generic {
+	unsigned int irq;
+	uint32_t address;
+	uint16_t eventid;
+	unsigned int priority;
+};
+
+typedef struct msi_vector_generic arch_msi_vector_t;
+
+#define PCI_DEVID(bus, dev, fn)	((((bus) & 0xff) << 8) | (((dev) & 0x1f) << 3) | ((fn) & 0x07))
+#define PCI_BDF_TO_DEVID(bdf)	PCI_DEVID(PCIE_BDF_TO_BUS(bdf), \
+					  PCIE_BDF_TO_DEV(bdf),	\
+					  PCIE_BDF_TO_FUNC(bdf))
+
+#endif
+
 struct msix_vector {
 	uint32_t msg_addr;
 	uint32_t msg_up_addr;


### PR DESCRIPTION
This PR is the second step into PCIe Host Controller support on non-x86 platforms (aka Generic or platform-agnostic) on top of #37668

This adds :

- An API for the GIC ITS to retrieve the MSI base address to be configured in the MSI/MSI-X table
- A generic MSI vector entry when non-x86
- generic controller MSI/MSI-X API and generic core functions for  Generic Host PCIe Controllers
- Implements MSI/MSI-X support for generic controllers & ECAM

Issues with implementation:
- Compliance test fails on: `WARNING:NEW_TYPEDEFS: do not add new typedefs` while adding new type for generic `arch_msi_vector_t` what is the best way to solve that ?

Testing has been done with QEMU with ITS support changes merged for next release.
A branch with ITS is available here:
https://github.com/superna9999/qemu/tree/gicv3-its-v8