### PR TITLE
mgmt/osdp: Handle errors in uart_fifo_read()

### DIFF
--- a/subsys/mgmt/osdp/src/osdp.c
+++ b/subsys/mgmt/osdp/src/osdp.c
@@ -75,7 +75,7 @@ static void osdp_uart_isr(const struct device *dev, void *user_data)
 
 		if (uart_irq_rx_ready(dev)) {
 			len = uart_fifo_read(dev, buf, sizeof(buf));
-			if (len) {
+			if (len > 0) {
 				osdp_handle_in_byte(p, buf, len);
 			}
 		}


### PR DESCRIPTION
Since 581c20e2422 ("drivers: uart: Cleanup not supported API handling")
uart_fifo_read() returns -ve on errors. Correct the check on its return
value to work with this new API.

CID: 240662
Fixes: #39840
Signed-off-by: Siddharth Chandrasekaran <sidcha.dev@gmail.com>