### PR TITLE
twister: implement platform-specific test timeout management

### DIFF
--- a/boards/arc/nsim/nsim_hs6x_smp.yaml
+++ b/boards/arc/nsim/nsim_hs6x_smp.yaml
@@ -7,6 +7,7 @@ toolchain:
   - cross-compile
   - zephyr
 testing:
+  timeout_multiplier: 1.5
   ignore_tags:
     - net
     - bluetooth

--- a/boards/arc/nsim/nsim_hs_smp.yaml
+++ b/boards/arc/nsim/nsim_hs_smp.yaml
@@ -7,6 +7,7 @@ toolchain:
   - zephyr
   - arcmwdt
 testing:
+  timeout_multiplier: 1.5
   default: true
   ignore_tags:
     - net

--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -7,6 +7,7 @@ import os
 import contextlib
 import string
 import mmap
+import math
 import sys
 import re
 import subprocess
@@ -423,7 +424,7 @@ class Handler:
 
         self.name = instance.name
         self.instance = instance
-        self.timeout = instance.testcase.timeout
+        self.timeout = math.ceil(instance.testcase.timeout * instance.platform.timeout_multiplier)
         self.sourcedir = instance.testcase.source_dir
         self.build_dir = instance.build_dir
         self.log = os.path.join(self.build_dir, "handler.log")
@@ -1626,6 +1627,7 @@ class Platform:
         # if no RAM size is specified by the board, take a default of 128K
         self.ram = 128
 
+        self.timeout_multiplier = 1.0
         self.ignore_tags = []
         self.only_tags = []
         self.default = False
@@ -1651,6 +1653,7 @@ class Platform:
         # if no RAM size is specified by the board, take a default of 128K
         self.ram = data.get("ram", 128)
         testing = data.get("testing", {})
+        self.timeout_multiplier = testing.get("timeout_multiplier", 1.0)
         self.ignore_tags = testing.get("ignore_tags", [])
         self.only_tags = testing.get("only_tags", [])
         self.default = testing.get("default", False)

--- a/scripts/schemas/twister/platform-schema.yaml
+++ b/scripts/schemas/twister/platform-schema.yaml
@@ -48,6 +48,9 @@ mapping:
   "testing":
     type: map
     mapping:
+      "timeout_multiplier":
+        type: number
+        required: false
       "default":
         type: bool
       "only_tags":


### PR DESCRIPTION
Twister allows us to control maximum execution time for each test with timeout value in test's `.yaml` configuration. This
helps us to prevent slow tests from stopping by timeout.

However it's hard to choose test timeout for all platforms as some platforms are naturally slow. It could be a HW board with
power-efficient but slow CPU or simulation platform which can perform instruction accurate simulation but does it slowly.

As we don't want to increase test timeout infinitely to meet the needs of the slowest platform let's introduce platform-specific test timeout management. It's implemented as an optional 'timeout_multiplier' field in board `.yaml` configuration. Setting it to some value multiplies each test timeout by this value. By that we can increase timeouts only for the platforms where it's required.