### PR TITLE
pm: optimize slots usage

### DIFF
--- a/include/device.h
+++ b/include/device.h
@@ -730,28 +730,12 @@ static inline bool device_is_ready(const struct device *dev)
 	static struct device_state Z_DEVICE_STATE_NAME(dev_name)	\
 	__attribute__((__section__(".z_devstate")));
 
-/* If device power management is enabled, this macro defines a pointer to a
- * device in the z_pm_device_slots region. When invoked for each device, this
- * will effectively result in a device pointer array with the same size of the
- * actual devices list. This is used internally by the device PM subsystem to
- * keep track of suspended devices during system power transitions.
- */
-#if CONFIG_PM_DEVICE
-#define Z_DEVICE_DEFINE_PM_SLOT(dev_name)				\
-	static const Z_DECL_ALIGN(struct device *)			\
-	_CONCAT(__pm_device_slot_, DEVICE_NAME_GET(dev_name)) __used	\
-	__attribute__((__section__(".z_pm_device_slots")));
-#else
-#define Z_DEVICE_DEFINE_PM_SLOT(dev_name)
-#endif
-
 /* Construct objects that are referenced from struct device. These
  * include power management and dependency handles.
  */
 #define Z_DEVICE_DEFINE_PRE(node_id, dev_name, ...)			\
 	Z_DEVICE_DEFINE_HANDLES(node_id, dev_name, __VA_ARGS__)		\
-	Z_DEVICE_STATE_DEFINE(node_id, dev_name)			\
-	Z_DEVICE_DEFINE_PM_SLOT(dev_name)
+	Z_DEVICE_STATE_DEFINE(node_id, dev_name)
 
 /* Initial build provides a record that associates the device object
  * with its devicetree ordinal, and provides the dependency ordinals.

--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -151,6 +151,22 @@ struct pm_device {
  */
 #define Z_PM_DEVICE_NAME(dev_name) _CONCAT(__pm_device__, dev_name)
 
+/**
+ * @brief Define device PM slot.
+ *
+ * This macro defines a pointer to a device in the z_pm_device_slots region.
+ * When invoked for each device with PM, it will effectively result in a device
+ * pointer array with the same size of the actual devices with PM enabled. This
+ * is used internally by the PM subsystem to keep track of suspended devices
+ * during system power transitions.
+ *
+ * @param dev_name Device name.
+ */
+#define Z_PM_DEVICE_DEFINE_SLOT(dev_name)				\
+	static const Z_DECL_ALIGN(struct device *)			\
+	_CONCAT(Z_PM_DEVICE_NAME(dev_name), slot) __used		\
+	__attribute__((__section__(".z_pm_device_slots")))
+
 #ifdef CONFIG_PM_DEVICE
 /**
  * Define device PM resources for the given node identifier.
@@ -160,6 +176,7 @@ struct pm_device {
  * @param pm_action_cb PM control callback.
  */
 #define Z_PM_DEVICE_DEFINE(node_id, dev_name, pm_action_cb)		\
+	Z_PM_DEVICE_DEFINE_SLOT(dev_name);				\
 	static struct pm_device Z_PM_DEVICE_NAME(dev_name) =		\
 	Z_PM_DEVICE_INIT(Z_PM_DEVICE_NAME(dev_name), node_id,		\
 			 pm_action_cb)


### PR DESCRIPTION
```
pm: device: move Z_DEVICE_PM_DEFINE_PM_SLOT to pm 

The macro has been moved to the pm/device.h header, being now called by
the Z_PM_DEVICE_DEFINE macro. This means that a slot will only be
created if the device uses PM, thus reducing memory usage.
```