### PR TITLE
driver: gpio: nct38xx: Improve kconfig prompt

### DIFF
--- a/drivers/gpio/Kconfig.nct38xx
+++ b/drivers/gpio/Kconfig.nct38xx
@@ -12,26 +12,26 @@ config GPIO_NCT38XX
 if GPIO_NCT38XX
 
 config GPIO_NCT38XX_INIT_PRIORITY
-	int "Init priority"
+	int "NCT38XX GPIO init priority"
 	default 30
 	help
 	  Device driver initialization priority. The priority should be lower
 	  than I2C device.
 
 config GPIO_NCT38XX_PORT_INIT_PRIORITY
-	int "Init priority"
+	int "NCT38XX GPIO port init priority"
 	default 40
 	help
 	  Device driver initialization priority. The priority should be lower
 	  than I2C & GPIO_NCT38XX_INIT_PRIORITY device.
 
 config GPIO_NCT38XX_INTERRUPT
-	bool "Interrupt enable"
+	bool "NCT38XX GPIO interrupt"
 	help
 	  Enable interrupt support in NCT38XX driver.
 
 config GPIO_NCT38XX_ALERT_INIT_PRIORITY
-	int "Init priority"
+	int "NCT38XX GPIO alert handler init priority"
 	default 40
 	depends on GPIO_NCT38XX_INTERRUPT
 	help


### PR DESCRIPTION
As per the guidelines:
https://docs.zephyrproject.org/latest/guides/build/kconfig/tips.html#prompt-strings
This improves the NCT38XX Kconfig prompt string.

Signed-off-by: Wealian Liao <WHLIAO@nuvoton.com>