### PR TITLE
net: ethernet: Fix vlan tag verification

### DIFF
--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -941,7 +941,7 @@ int net_eth_vlan_enable(struct net_if *iface, uint16_t tag)
 		return -EPERM;
 	}
 
-	if (tag == NET_VLAN_TAG_UNSPEC) {
+	if (tag >= NET_VLAN_TAG_UNSPEC) {
 		return -EBADF;
 	}
 


### PR DESCRIPTION
`net_eth_vlan_enable()` allowed to use illegal vlan tag values, fix this
by disallowing any tag value higher or equal to 0xfff (which is a limit
for the tag and a reserved value).

Fixes #39516

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>