### PR TITLE
Bluetooth: Reassemble periodic advertising reports

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -610,6 +610,17 @@ config BT_HOST_CCM
 	  controller's AES encryption functions if available, or BT_HOST_CRYPTO
 	  otherwise.
 
+config BT_PER_ADV_SYNC_BUF_SIZE
+	int "Maximum periodic advertising report size"
+	depends on BT_PER_ADV_SYNC
+	range 0 1650
+	default 0
+	help
+	  Maximum size of a fragmented periodic advertising report. If the periodic
+	  advertising report provided by the controller is fragmented and larger
+	  than this buffer size, then the data will be discarded.
+	  Unfragmented reports are forwarded as they are received.
+
 if BT_DEBUG
 config BT_DEBUG_SETTINGS
 	bool "Bluetooth storage debug"

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -202,6 +202,19 @@ struct bt_le_per_adv_sync {
 	uint8_t cte_type;
 #endif /* CONFIG_BT_DF_CONNECTIONLESS_CTE_RX */
 
+#if CONFIG_BT_PER_ADV_SYNC_BUF_SIZE > 0
+	/** Reassembly buffer for advertising reports */
+	struct net_buf_simple reassembly;
+
+	/** Storage for the reassembly buffer */
+	uint8_t reassembly_data[CONFIG_BT_PER_ADV_SYNC_BUF_SIZE];
+#endif /* CONFIG_BT_PER_ADV_SYNC_BUF_SIZE > 0 */
+
+	/** True if the following periodic adv reports up to and
+	 * including the next complete one should be dropped
+	 */
+	bool report_truncated;
+
 	/** Flags */
 	ATOMIC_DEFINE(flags, BT_PER_ADV_SYNC_NUM_FLAGS);
 };


### PR DESCRIPTION
Adds a buffer to the host to reassemble potentially fragmented
periodic advertising reports.
The buffer size is configurable through BT_PER_ADV_SYNC_BUF_SIZE.

Signed-off-by: Bernhard Wimmer <bernhard.wimmer@nordicsemi.no>