### PR TITLE
west.yml: Update hal_stm32 with recent cube packages

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -124,7 +124,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 6fc9b5f7e0229ef64a882e37213266d346ebfadb
+      revision: pull/124/head
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
update stm32 cube:
. stm32wb to version V1.12.1
. stm32mp1 to version V1.5.0
+ update stm32cube/common_ll

see https://github.com/zephyrproject-rtos/hal_stm32/pull/124

Signed-off-by: Francois Ramu <francois.ramu@st.com>