### PR TITLE
net: bridge: make the orig_iface info available

### DIFF
--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -86,7 +86,7 @@ struct net_pkt {
 
 	/** @cond ignore */
 
-#if defined(CONFIG_NET_ROUTING)
+#if defined(CONFIG_NET_ROUTING) || defined(CONFIG_NET_ETHERNET_BRIDGE)
 	struct net_if *orig_iface; /* Original network interface */
 #endif
 
@@ -311,7 +311,7 @@ static inline void net_pkt_set_iface(struct net_pkt *pkt, struct net_if *iface)
 
 static inline struct net_if *net_pkt_orig_iface(struct net_pkt *pkt)
 {
-#if defined(CONFIG_NET_ROUTING)
+#if defined(CONFIG_NET_ROUTING) || defined(CONFIG_NET_ETHERNET_BRIDGE)
 	return pkt->orig_iface;
 #else
 	return pkt->iface;
@@ -321,7 +321,7 @@ static inline struct net_if *net_pkt_orig_iface(struct net_pkt *pkt)
 static inline void net_pkt_set_orig_iface(struct net_pkt *pkt,
 					  struct net_if *iface)
 {
-#if defined(CONFIG_NET_ROUTING)
+#if defined(CONFIG_NET_ROUTING) || defined(CONFIG_NET_ETHERNET_BRIDGE)
 	pkt->orig_iface = iface;
 #endif
 }


### PR DESCRIPTION
The per-packet orig_iface information is available when
CONFIG_NET_ROUTING is set. It is pretty useful to have it
available with CONFIG_NET_ETHERNET_BRIDGE as well.
