### PR TITLE
kernel: mmu: make virtual region bitmap static

### DIFF
--- a/include/portability/cmsis_os.h
+++ b/include/portability/cmsis_os.h
@@ -291,7 +291,7 @@ static K_THREAD_STACK_ARRAY_DEFINE(stacks_##name, instances, CONFIG_CMSIS_THREAD
 static struct k_thread cm_thread_##name[instances]; \
 static struct k_poll_signal wait_signal_##name; \
 static struct k_poll_event wait_events_##name; \
-static SYS_BITARRAY_DEFINE(bitarray_##name, instances); \
+SYS_BITARRAY_DEFINE_STATIC(bitarray_##name, instances); \
 static osThreadDef_t os_thread_def_##name = \
 { (name), (priority), (instances), (stacksz), (void *)(stacks_##name), \
 	(cm_thread_##name), (&wait_signal_##name), \

--- a/include/sys/bitarray.h
+++ b/include/sys/bitarray.h
@@ -33,6 +33,27 @@ struct sys_bitarray {
 typedef struct sys_bitarray sys_bitarray_t;
 
 /**
+ * @def _SYS_BITARRAY_DEFINE
+ *
+ * @brief Create a bitarray object.
+ *
+ * @param name Name of the bitarray object.
+ * @param total_bits Total number of bits in this bitarray object.
+ * @param sba_mod Modifier to the bitarray variables.
+ */
+#define _SYS_BITARRAY_DEFINE(name, total_bits, sba_mod)			\
+	sba_mod uint32_t _sys_bitarray_bundles_##name			\
+		[(((total_bits + 8 - 1) / 8) + sizeof(uint32_t) - 1)	\
+		 / sizeof(uint32_t)] = {0U};				\
+	sba_mod sys_bitarray_t name = {					\
+		.num_bits = total_bits,					\
+		.num_bundles = (((total_bits + 8 - 1) / 8)		\
+				+ sizeof(uint32_t) - 1)			\
+			       / sizeof(uint32_t),			\
+		.bundles = _sys_bitarray_bundles_##name,		\
+	}
+
+/**
  * @def SYS_BITARRAY_DEFINE
  *
  * @brief Create a bitarray object.
@@ -41,16 +62,18 @@ typedef struct sys_bitarray sys_bitarray_t;
  * @param total_bits Total number of bits in this bitarray object.
  */
 #define SYS_BITARRAY_DEFINE(name, total_bits)				\
-	uint32_t _sys_bitarray_bundles_##name				\
-		[(((total_bits + 8 - 1) / 8) + sizeof(uint32_t) - 1)	\
-		 / sizeof(uint32_t)] = {0U};				\
-	sys_bitarray_t name = {						\
-		.num_bits = total_bits,					\
-		.num_bundles = (((total_bits + 8 - 1) / 8)		\
-				+ sizeof(uint32_t) - 1)			\
-			       / sizeof(uint32_t),			\
-		.bundles = _sys_bitarray_bundles_##name,		\
-	}
+	_SYS_BITARRAY_DEFINE(name, total_bits,)
+
+/**
+ * @def SYS_BITARRAY_DEFINE_STATIC
+ *
+ * @brief Create a static bitarray object.
+ *
+ * @param name Name of the bitarray object.
+ * @param total_bits Total number of bits in this bitarray object.
+ */
+#define SYS_BITARRAY_DEFINE_STATIC(name, total_bits)			\
+	_SYS_BITARRAY_DEFINE(name, total_bits, static)
 
 /**
  * Set a bit in a bit array

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -181,8 +181,8 @@ void z_page_frames_dump(void)
  * Note that bit #0 is the highest address so that allocation is
  * done in reverse from highest address.
  */
-SYS_BITARRAY_DEFINE(virt_region_bitmap,
-		    CONFIG_KERNEL_VM_SIZE / CONFIG_MMU_PAGE_SIZE);
+SYS_BITARRAY_DEFINE_STATIC(virt_region_bitmap,
+			   CONFIG_KERNEL_VM_SIZE / CONFIG_MMU_PAGE_SIZE);
 
 static bool virt_region_inited;
 


### PR DESCRIPTION
The virtual region bitmap bitarray struct is only used within
the source file, so it can be declared static.