### PR TITLE
doc: replace buildkite with github actions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,9 +8,10 @@
 
    <a href="https://bestpractices.coreinfrastructure.org/projects/74"><img
    src="https://bestpractices.coreinfrastructure.org/projects/74/badge"></a>
-   <a href="https://buildkite.com/zephyr/zephyr">
+   <a
+   href="https://github.com/zephyrproject-rtos/zephyr/actions/workflows/twister.yaml?query=branch%3Amain">
    <img
-   src="https://badge.buildkite.com/f5bd0dc88306cee17c9b38e78d11bb74a6291e3f40e7d13f31.svg?branch=main"></a>
+   src="https://github.com/zephyrproject-rtos/zephyr/actions/workflows/twister.yaml/badge.svg?event=push"></a>
 
 
 The Zephyr Project is a scalable real-time operating system (RTOS) supporting
@@ -62,8 +63,7 @@ Here's a quick summary of resources to help you find your way around:
   `Zephyr Development mailing list`_. The other `Zephyr mailing list
   subgroups`_ have their own archives and sign-up pages.
 * **Nightly CI Build Status**: https://lists.zephyrproject.org/g/builds
-  The builds@lists.zephyrproject.org mailing list archives the CI
-  (buildkite) nightly build results.
+  The builds@lists.zephyrproject.org mailing list archives the CI nightly build results.
 * **Chat**: Real-time chat happens in Zephyr's Discord Server. Use
   this `Discord Invite`_ to register.
 * **Contributing**: see the `Contribution Guide`_

--- a/doc/contribute/index.rst
+++ b/doc/contribute/index.rst
@@ -179,8 +179,8 @@ on https://github.com and have Git tools available on your development system.
    (Linux, macOS, and Windows) but some of the tools used in the sections below
    are only available on Linux and macOS. On Windows, instead of running these
    tools yourself, you will need to rely on the Continuous Integration (CI)
-   service ``buildkite``, which runs automatically on GitHub when you submit
-   your Pull Request (PR).  You can see any failure results in the Buildkite
+   service using Github Actions, which runs automatically on GitHub when you submit
+   your Pull Request (PR).  You can see any failure results in the workflow
    details link near the end of the PR conversation list. See
    `Continuous Integration`_ for more information
 
@@ -696,11 +696,10 @@ every Pull Request (PR) in order to verify several aspects of the PR:
 * Twister builds for multiple architectures and boards
 * Documentation build to verify any doc changes
 
-CI is run both on the ``buildkite`` cloud service and Github Actions and it uses
-the same tools described in the `Contribution Tools`_ section.
-The CI results must be green indicating "All checks have passed" before
-the Pull Request can be merged.  CI is run when the PR is created, and
-again every time the PR is modified with a commit.
+CI is run on Github Actions and it uses the same tools described in the
+`Contribution Tools`_ section.  The CI results must be green indicating "All
+checks have passed" before the Pull Request can be merged.  CI is run when the
+PR is created, and again every time the PR is modified with a commit.
 
 The current status of the CI run can always be found at the bottom of the
 GitHub PR page, below the review status. Depending on the success or failure
@@ -710,17 +709,16 @@ of the run you will see:
 * "All checks have failed"
 
 In case of failure you can click on the "Details" link presented below the
-failure message in order to navigate to ``buildkite`` or ``Github Actions``
-and inspect the results.
-Once you click on the link you will be taken to the ``buildkite`` summary
+failure message in order to navigate to ``Github Actions`` and inspect the
+results.
+Once you click on the link you will be taken to the ``Github actions`` summary
 results page where a table with all the different builds will be shown. To see
 what build or test failed click on the row that contains the failed (i.e.
-non-green) build and then click on the "Tests" tab to see the console output
-messages indicating the failure.
+non-green) build.
 
 The `builds@lists.zephyrproject.org mailing list
-<https://lists.zephyrproject.org/g/builds>`_
-archives the CI (buildkite) nightly build results.
+<https://lists.zephyrproject.org/g/builds>`_ archives any nightly build results
+produced by CI.
 
 Contributions to External Modules
 **********************************


### PR DESCRIPTION
Update CI docs and the badge with links pointing to GH actions rather
than buildkite.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
