### PR TITLE
soc/intel_adsp: Use the cAVS IDC driver pervasively, remove IPM

### DIFF
--- a/boards/xtensa/intel_adsp_cavs15/intel_adsp_cavs15.dts
+++ b/boards/xtensa/intel_adsp_cavs15/intel_adsp_cavs15.dts
@@ -14,6 +14,5 @@
 
 	chosen {
 		zephyr,sram = &sram0;
-		zephyr,console = &ipm_console;
 	};
 };

--- a/dts/xtensa/intel/intel_cavs15.dtsi
+++ b/dts/xtensa/intel/intel_cavs15.dtsi
@@ -100,27 +100,6 @@
 			reg = <0x1200 0x80>;
 			interrupts = <8 0 0>;
 			interrupt-parent = <&cavs0>;
-		     };
-
-		mailbox: mailbox@1180 {
-			compatible = "intel,adsp-mailbox";
-			reg = <0x1180 0x20>;
-			interrupts = <0x7 0 3>;
-			interrupt-parent = <&cavs0>;
-			label = "IPM_0";
-		};
-
-		ipm_console: ipm_console {
-			compatible = "zephyr,ipm-console";
-			label="IPM_0";
-		};
-
-		mailbox: mailbox@1180 {
-			compatible = "intel,intel-adsp-mailbox";
-			reg = <0x1180 0x20>;
-			interrupts = <0x7 0 3>;
-			interrupt-parent = <&cavs0>;
-			label = "IPM_0";
 		};
 	};
 };

--- a/soc/xtensa/intel_adsp/cavs_v15/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/cavs_v15/Kconfig.defconfig.series
@@ -33,6 +33,12 @@ config IMR_DATA_ADDR
 config SMP
 	default y
 
+config MP_NUM_CPUS
+	default 2
+
+config SCHED_IPI_SUPPORTED
+	default y
+
 config XTENSA_TIMER
 	default n
 
@@ -77,21 +83,5 @@ config LOG_BACKEND_ADSP
 	default y
 
 endif # LOG
-
-if SMP
-
-config MP_NUM_CPUS
-	default 2
-
-config IPM
-       default y
-
-config IPM_CAVS_IDC
-	default y
-
-config SCHED_IPI_SUPPORTED
-	default y if IPM_CAVS_IDC
-
-endif # SMP
 
 endif # SOC_SERIES_INTEL_CAVS_V15

--- a/soc/xtensa/intel_adsp/cavs_v18/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/cavs_v18/Kconfig.defconfig.series
@@ -18,6 +18,13 @@ config SOC
 config SMP
        default y
 
+# FIXME: these DSPs can have more cores, but Zephyr only supports up to 2 cores on them
+config MP_NUM_CPUS
+	default 2
+
+config SCHED_IPI_SUPPORTED
+	default y
+
 config XTENSA_TIMER
 	default n
 
@@ -65,27 +72,5 @@ config LOG_BACKEND_ADSP
 	default y
 
 endif # LOG
-
-if SMP
-
-# FIXME: these DSPs can have more cores, but Zephyr only supports up to 2 cores on them
-config MP_NUM_CPUS
-	default 2
-
-config IPM
-	default y
-
-config IPM_CAVS_IDC
-	default y if IPM
-
-config SCHED_IPI_SUPPORTED
-	default y if IPM_CAVS_IDC
-
-config IPM_CONSOLE
-	default y
-	depends on CONSOLE
-	depends on IPM
-
-endif # SMP
 
 endif

--- a/soc/xtensa/intel_adsp/cavs_v20/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/cavs_v20/Kconfig.defconfig.series
@@ -18,6 +18,13 @@ config SOC
 config SMP
        default y
 
+# FIXME: these DSPs can have more cores, but Zephyr only supports up to 2 cores on them
+config MP_NUM_CPUS
+	default 2
+
+config SCHED_IPI_SUPPORTED
+	default y
+
 config XTENSA_TIMER
 	default n
 
@@ -65,22 +72,5 @@ config LOG_BACKEND_ADSP
 	default y
 
 endif # LOG
-
-if SMP
-
-# FIXME: these DSPs can have more cores, but Zephyr only supports up to 2 cores on them
-config MP_NUM_CPUS
-	default 2
-
-config IPM
-	default y
-
-config IPM_CAVS_IDC
-	default y if IPM
-
-config SCHED_IPI_SUPPORTED
-	default y if IPM_CAVS_IDC
-
-endif # SMP
 
 endif # SOC_SERIES_INTEL_CAVS_V20

--- a/soc/xtensa/intel_adsp/common/include/cavs-idc.h
+++ b/soc/xtensa/intel_adsp/common/include/cavs-idc.h
@@ -53,14 +53,14 @@
  *     IDC[src].core[dst].itc == IDC[dst].core[src].tfc
  *
  * Finally note the two control registers at the end of each core's
- * register block, which store a bitmask of cores that are allowed to
- * send that core an interrupt via either ITC (set high "BUSY" bit) or
+ * register block, which store a bitmask of cores that it is allowed
+ * to signal with an interrupt via either ITC (set high "BUSY" bit) or
  * TFC (clear high "DONE" bit).  This masking is in ADDITION to the
  * level 2 bit for IDC in the per-core INTCTRL DSP register AND the
  * Xtensa architectural INTENABLE SR.  You must enable IDC interrupts
  * form core "src" to core "dst" with:
  *
- *     IDC[dst].busy_int |= BIT(src)  // Or disable with "&= ~BIT(src)" of course
+ *     IDC[src].busy_int |= BIT(dst)  // Or disable with "&= ~BIT(dst)" of course
  */
 struct cavs_idc {
 	struct {

--- a/soc/xtensa/intel_adsp/common/include/cavs-shim.h
+++ b/soc/xtensa/intel_adsp/common/include/cavs-shim.h
@@ -126,7 +126,8 @@ struct cavs_win {
 #define CAVS15_CLKCTL_LMPCS           BIT(1)
 #define CAVS15_CLKCTL_HMPCS           BIT(0)
 
-#define SHIM_PWRCTL_TCPDSPPG(x) BIT(x)
+#define CAVS_PWRCTL_TCPDSPPG(x) BIT(x)
+#define CAVS_PWRSTS_PDSPPGS(x)  BIT(x)
 
 #ifdef SOC_SERIES_INTEL_CAVS_V25
 # define SHIM_LDOCTL_HPSRAM_LDO_ON     (3 << 0 | 3 << 16)

--- a/soc/xtensa/intel_adsp/common/soc.c
+++ b/soc/xtensa/intel_adsp/common/soc.c
@@ -254,7 +254,7 @@ static void power_init(void)
 #endif
 
 	/* Disable power gating for first cores */
-	CAVS_SHIM.pwrctl |= SHIM_PWRCTL_TCPDSPPG(0);
+	CAVS_SHIM.pwrctl |= CAVS_PWRCTL_TCPDSPPG(0);
 
 #ifndef CONFIG_SOC_SERIES_INTEL_CAVS_V15
 	/* On cAVS 1.8+, we must demand ownership of the timestamping

--- a/soc/xtensa/intel_adsp/common/soc_mp.c
+++ b/soc/xtensa/intel_adsp/common/soc_mp.c
@@ -316,9 +316,9 @@ void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
 	 * turn itself off when it gets to the WAITI instruction in
 	 * the idle thread.
 	 */
-	CAVS_SHIM.pwrctl |= BIT(cpu_num);
+	CAVS_SHIM.pwrctl |= CAVS_PWRCTL_TCPDSPPG(cpu_num);
 	if (!IS_ENABLED(CONFIG_SOC_SERIES_INTEL_CAVS_V15)) {
-		CAVS_SHIM.clkctl |= BIT(16 + cpu_num);
+		CAVS_SHIM.clkctl |= CAVS_CLKCTL_TCPLCG(cpu_num);
 	}
 
 	/* Send power-up message to the other core.  Start address
@@ -429,7 +429,7 @@ int soc_relaunch_cpu(int id)
 		goto out;
 	}
 
-	if (CAVS_SHIM.pwrsts & BIT(id)) {
+	if (CAVS_SHIM.pwrsts & CAVS_PWRSTS_PDSPPGS(id)) {
 		ret = -EINVAL;
 		goto out;
 	}
@@ -473,11 +473,11 @@ int soc_halt_cpu(int id)
 	 * be woken up by scheduler IPIs
 	 */
 	CAVS_INTCTRL[id].l2.set = CAVS_L2_IDC;
-	CAVS_SHIM.pwrctl &= ~BIT(id);
-	CAVS_SHIM.clkctl &= ~BIT(16 + id);
+	CAVS_SHIM.pwrctl &= ~CAVS_PWRCTL_TCPDSPPG(id);
+	CAVS_SHIM.clkctl &= ~CAVS_CLKCTL_TCPLCG(id);
 
 	/* Wait for the CPU to reach an idle state before returing */
-	while (CAVS_SHIM.pwrsts & BIT(id)) {
+	while (CAVS_SHIM.pwrsts & CAVS_PWRSTS_PDSPPGS(id)) {
 	}
 
  out:


### PR DESCRIPTION
This is a series which continues the now-merged cleanup pass, enabling the new/unified IDC driver as the only sched_ipi() implementation for all platforms, doing a little more cleanup, and fixing a bug on APL that has to do with a startup latency races.

Note that this is ready for review, but not merge yet.  We need validation of the fix on APL with SOF still, and consensus about the mechanism (I'm like 84% sure myself -- it sure makes more sense than previous theories).

Also there are at least two spots where this series makes a change and then invalidates it by removing the relevant code.  That's silly and I should squash those changes.  It's left in currently for better history of the understanding.