### PR TITLE
drivers: ramdisk: add checks for the upper boundary

### DIFF
--- a/drivers/disk/ramdisk.c
+++ b/drivers/disk/ramdisk.c
@@ -1,28 +1,29 @@
 /*
  * Copyright (c) 2016 Intel Corporation.
+ * Copyright (c) 2021, Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <string.h>
 #include <zephyr/types.h>
-#include <sys/__assert.h>
 #include <drivers/disk.h>
 #include <errno.h>
 #include <init.h>
 #include <device.h>
+#include <logging/log.h>
+
+LOG_MODULE_REGISTER(ramdisk, CONFIG_RAMDISK_LOG_LEVEL);
 
 #define RAMDISK_SECTOR_SIZE 512
 #define RAMDISK_VOLUME_SIZE (CONFIG_DISK_RAM_VOLUME_SIZE * 1024)
+#define RAMDISK_SECTOR_COUNT (RAMDISK_VOLUME_SIZE / RAMDISK_SECTOR_SIZE)
 
 static uint8_t ramdisk_buf[RAMDISK_VOLUME_SIZE];
 
 static void *lba_to_address(uint32_t lba)
 {
-	__ASSERT(((lba * RAMDISK_SECTOR_SIZE) < RAMDISK_VOLUME_SIZE),
-		 "FS bound error");
-
-	return &ramdisk_buf[(lba * RAMDISK_SECTOR_SIZE)];
+	return &ramdisk_buf[lba * RAMDISK_SECTOR_SIZE];
 }
 
 static int disk_ram_access_status(struct disk_info *disk)
@@ -38,6 +39,14 @@ static int disk_ram_access_init(struct disk_info *disk)
 static int disk_ram_access_read(struct disk_info *disk, uint8_t *buff,
 				uint32_t sector, uint32_t count)
 {
+	uint32_t last_sector = sector + count;
+
+	if (last_sector < sector || last_sector > RAMDISK_SECTOR_COUNT) {
+		LOG_ERR("Sector %" PRIu32 " is outside the range %u",
+			last_sector, RAMDISK_SECTOR_COUNT);
+		return -EIO;
+	}
+
 	memcpy(buff, lba_to_address(sector), count * RAMDISK_SECTOR_SIZE);
 
 	return 0;
@@ -46,6 +55,14 @@ static int disk_ram_access_read(struct disk_info *disk, uint8_t *buff,
 static int disk_ram_access_write(struct disk_info *disk, const uint8_t *buff,
 				 uint32_t sector, uint32_t count)
 {
+	uint32_t last_sector = sector + count;
+
+	if (last_sector < sector || last_sector > RAMDISK_SECTOR_COUNT) {
+		LOG_ERR("Sector %" PRIu32 " is outside the range %u",
+			last_sector, RAMDISK_SECTOR_COUNT);
+		return -EIO;
+	}
+
 	memcpy(lba_to_address(sector), buff, count * RAMDISK_SECTOR_SIZE);
 
 	return 0;
@@ -57,7 +74,7 @@ static int disk_ram_access_ioctl(struct disk_info *disk, uint8_t cmd, void *buff
 	case DISK_IOCTL_CTRL_SYNC:
 		break;
 	case DISK_IOCTL_GET_SECTOR_COUNT:
-		*(uint32_t *)buff = RAMDISK_VOLUME_SIZE / RAMDISK_SECTOR_SIZE;
+		*(uint32_t *)buff = RAMDISK_SECTOR_COUNT;
 		break;
 	case DISK_IOCTL_GET_SECTOR_SIZE:
 		*(uint32_t *)buff = RAMDISK_SECTOR_SIZE;


### PR DESCRIPTION
Add checks for the upper boundary in access_read/access_write
instead of the homeopathic ASSERTS.