### PR TITLE
Revert "ITE drivers/pwm: cleanup it8xxx2 pwm driver"

### DIFF
--- a/boards/riscv/it8xxx2_evb/it8xxx2_evb.dts
+++ b/boards/riscv/it8xxx2_evb/it8xxx2_evb.dts
@@ -12,6 +12,11 @@
 	model = "IT8XXX2 EV-Board";
 	compatible = "riscv,it8xxx2-evb";
 
+	aliases {
+		pwm-led0 = &led0;
+		pwm-led1 = &led1;
+	};
+
 	chosen {
 		zephyr,console = &uart1;
 		zephyr,shell-uart = &uart1;
@@ -21,6 +26,19 @@
 		zephyr,flash-controller = &flashctrl;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,keyboard-scan = &kscan0;
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+		/* NOTE: &pwm number needs same with channel number */
+		led0: led_0 {
+			pwms = <&pwm7 PWM_CHANNEL_7 PWM_POLARITY_INVERTED>;
+			label = "LED0_GREEN";
+		};
+		led1: led_1 {
+			pwms = <&pwm0 PWM_CHANNEL_0 PWM_POLARITY_NORMAL>;
+			label = "LED1_BLUE";
+		};
 	};
 };
 &adc0 {

--- a/dts/bindings/pwm/ite,it8xxx2-pwm.yaml
+++ b/dts/bindings/pwm/ite,it8xxx2-pwm.yaml
@@ -21,18 +21,14 @@ properties:
       type: int
       required: true
       enum:
-            - 0
-            - 1
-            - 2
-            - 3
-            - 4
-            - 5
-            - 6
-            - 7
-      description: |
-        0 = PWM_CHANNEL_0, 1 = PWM_CHANNEL_1, 2 = PWM_CHANNEL_2,
-        3 = PWM_CHANNEL_3, 4 = PWM_CHANNEL_4, 5 = PWM_CHANNEL_5,
-        6 = PWM_CHANNEL_6, 7 = PWM_CHANNEL_7
+            - 0 #PWM_CHANNEL_0
+            - 1 #PWM_CHANNEL_1
+            - 2 #PWM_CHANNEL_2
+            - 3 #PWM_CHANNEL_3
+            - 4 #PWM_CHANNEL_4
+            - 5 #PWM_CHANNEL_5
+            - 6 #PWM_CHANNEL_6
+            - 7 #PWM_CHANNEL_7
 
     pwmctrl:
         type: phandle
@@ -48,10 +44,9 @@ properties:
       type: int
       required: true
       enum:
-            - 1
-            - 2
-            - 3
-      description: 1 = PWM_PRESCALER_C4, 2 = PWM_PRESCALER_C6, 3 = PWM_PRESCALER_C7
+            - 1 #PWM_PRESCALER_C4
+            - 2 #PWM_PRESCALER_C6
+            - 3 #PWM_PRESCALER_C7
 
     pwm-output-frequency:
       type: int


### PR DESCRIPTION
Reverts zephyrproject-rtos/zephyr#40274  until tachometer PR lands.

Signed-off-by: Ruibin Chang <Ruibin.Chang@ite.com.tw>