### PR TITLE
ci: doc-build: set timeout to 30 minutes

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -36,6 +36,7 @@ jobs:
   doc-build-html:
     name: "Documentation Build (HTML)"
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
     - name: checkout
@@ -89,6 +90,7 @@ jobs:
     name: "Documentation Build (PDF)"
     runs-on: ubuntu-latest
     container: texlive/texlive:latest
+    timeout-minutes: 30
 
     steps:
     - name: checkout


### PR DESCRIPTION
Give documentation build up to 30 minutes to finish. This should improve
the user experience when Sphinx hangs due to broken references, a
problem that needs some investigation.