### PR TITLE
sys/util: Stricter bytecpy impl

### DIFF
--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -253,7 +253,7 @@ static inline void bytecpy(void *dst, const void *src, size_t size)
 	size_t i;
 
 	for (i = 0; i < size; ++i) {
-		((uint8_t *)dst)[i] = ((const uint8_t *)src)[i];
+		((volatile uint8_t *)dst)[i] = ((volatile const uint8_t *)src)[i];
 	}
 }
 


### PR DESCRIPTION
The docstring for this function states that it is guaranteed to perform a copy byte by byte, but this is not true in general without a `volatile` storage type on the casted pointer.

For reference, here's a compiler explorer link showing that both clang and GCC will transform the original function into wider reads & stores at appropriate optimization levels: https://godbolt.org/z/xPfnxMaa9

And here's the updated version showing (sometimes unrolled) only single byte reads and stores: https://godbolt.org/z/rzxfTv1Yz