### PR TITLE
arch: riscv: pmp: Support fixed SoC PMP regions

### DIFF
--- a/arch/riscv/include/core_pmp.h
+++ b/arch/riscv/include/core_pmp.h
@@ -36,6 +36,63 @@
 
 #endif /* CONFIG_PMP_STACK_GUARD */
 
+#define REGION_ROM_ATTR			(PMP_R | PMP_X | PMP_L)
+#define REGION_RAM_ATTR			(PMP_R | PMP_W | PMP_L)
+
+#if defined(CONFIG_PMP_POWER_OF_TWO_ALIGNMENT)
+# define PMP_MODE_DEFAULT		PMP_MODE_NAPOT
+# define PMP_USED_ENTRY_DEFAULT		1 /* NAPOT region use 1 PMP entry */
+#else /* CONFIG_PMP_POWER_OF_TWO_ALIGNMENT */
+# define PMP_MODE_DEFAULT		PMP_MODE_TOR
+# define PMP_USED_ENTRY_DEFAULT		2 /* TOR region use 2 PMP entry */
+#endif /* CONFIG_PMP_POWER_OF_TWO_ALIGNMENT */
+
+enum pmp_region_mode {
+	PMP_MODE_NA4,
+	/* If NAPOT mode region size is 4, apply NA4 region to PMP CSR. */
+	PMP_MODE_NAPOT,
+	PMP_MODE_TOR,
+};
+
+/* Region definition data structure */
+struct riscv_pmp_region {
+	ulong_t start;
+	ulong_t size;
+	const char *name;
+	uint8_t perm;
+	enum pmp_region_mode mode;
+};
+
+/* PMP configuration data structure */
+struct riscv_pmp_config {
+	/* Number of regions */
+	uint32_t num_regions;
+	/* Regions */
+	const struct riscv_pmp_region *pmp_regions;
+};
+
+#define PMP_REGION_ENTRY(_name, _start, _size, _perm) \
+	PMP_REGION_ENTRY_FULL(_name, _start, _size, _perm, PMP_MODE_DEFAULT)
+
+#define PMP_REGION_ENTRY_FULL(_name, _start, _size, _perm, _mode) \
+	{ \
+		.name = _name, \
+		.start = _start, \
+		.size  = _size, \
+		.perm  = _perm, \
+		.mode  = _mode, \
+	}
+
+/* Reference to the PMP configuration.
+ *
+ * This struct is defined and populated for each SoC (in the SoC definition),
+ * and holds the build-time configuration information for the fixed PMP
+ * regions enabled during kernel initialization. Dynamic PMP regions (e.g.
+ * for Thread Stack, Stack Guards, etc.) are programmed during runtime, thus,
+ * not kept here.
+ */
+extern const struct riscv_pmp_config pmp_config;
+
 #ifdef CONFIG_RISCV_PMP
 
 /*

--- a/soc/riscv/CMakeLists.txt
+++ b/soc/riscv/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+add_subdirectory(common)
+
 if(SOC_FAMILY)
   add_subdirectory(${SOC_FAMILY})
 else()

--- a/soc/riscv/Kconfig
+++ b/soc/riscv/Kconfig
@@ -1,0 +1,14 @@
+# General options of RISC-V SoCs
+
+# Copyright (c) 2021 Jim Shu
+# SPDX-License-Identifier: Apache-2.0
+
+config CPU_HAS_CUSTOM_FIXED_SOC_PMP_REGIONS
+	bool "Custom fixed SoC PMP region definition"
+	depends on RISCV_PMP
+	help
+	  If enabled, this option signifies that the SoC will
+	  define and configure its own fixed PMP regions in the
+	  SoC definition. These fixed PMP regions are currently
+	  used to set ROM and RAM default access policies and
+	  they are programmed at boot time.

--- a/soc/riscv/common/CMakeLists.txt
+++ b/soc/riscv/common/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_RISCV_PMP AND NOT CONFIG_CPU_HAS_CUSTOM_FIXED_SOC_PMP_REGIONS)
+
+  zephyr_library()
+  zephyr_library_sources(riscv_pmp_regions.c)
+
+endif()

--- a/soc/riscv/common/riscv_pmp_mem_cfg.h
+++ b/soc/riscv/common/riscv_pmp_mem_cfg.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021 Jim Shu
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _RISCV_PMP_MEM_CFG_H_
+#define _RISCV_PMP_MEM_CFG_H_
+
+#include <sys/util.h>
+
+/*
+ * Compute FLASH_BASE and FLASH_SIZE.
+ * It's copied from RISC-V linker script.
+ */
+#if DT_NODE_HAS_COMPAT_STATUS(DT_CHOSEN(zephyr_flash), soc_nv_flash, okay)
+# define FLASH_BASE	DT_REG_ADDR(DT_CHOSEN(zephyr_flash))
+# define FLASH_SIZE	DT_REG_SIZE(DT_CHOSEN(zephyr_flash))
+#elif DT_NODE_HAS_COMPAT_STATUS(DT_CHOSEN(zephyr_flash), jedec_spi_nor, okay)
+/* For jedec,spi-nor we expect the spi controller to memory map the flash
+ * and for that mapping to be the second register property of the spi
+ * controller.
+ */
+# define SPI_CTRL	DT_PARENT(DT_CHOSEN(zephyr_flash))
+# define FLASH_BASE	DT_REG_ADDR_BY_IDX(SPI_CTRL, 1)
+# define FLASH_SIZE	DT_REG_SIZE_BY_IDX(SPI_CTRL, 1)
+#endif
+
+#ifdef CONFIG_PMP_POWER_OF_TWO_ALIGNMENT
+/* To align power-of-2 PMP region size (NAPOT) */
+
+/* Flash Region Definitions */
+#if   FLASH_SIZE <= (64 << 10)
+#define REGION_FLASH_SIZE KB(64)
+#elif FLASH_SIZE <= (128 << 10)
+#define REGION_FLASH_SIZE KB(128)
+#elif FLASH_SIZE <= (256 << 10)
+#define REGION_FLASH_SIZE KB(256)
+#elif FLASH_SIZE <= (512 << 10)
+#define REGION_FLASH_SIZE KB(512)
+#elif FLASH_SIZE <= (1 << 20)
+#define REGION_FLASH_SIZE MB(1)
+#elif FLASH_SIZE <= (2 << 20)
+#define REGION_FLASH_SIZE MB(2)
+#elif FLASH_SIZE <= (4 << 20)
+#define REGION_FLASH_SIZE MB(4)
+#elif FLASH_SIZE <= (8 << 20)
+#define REGION_FLASH_SIZE MB(8)
+#elif FLASH_SIZE <= (16 << 20)
+#define REGION_FLASH_SIZE MB(16)
+#elif FLASH_SIZE <= (64 << 20)
+#define REGION_FLASH_SIZE MB(64)
+#else
+#error "Unsupported flash size configuration"
+#endif
+
+#else /* CONFIG_PMP_POWER_OF_TWO_ALIGNMENT */
+/* To align 4-byte PMP region size (TOR) */
+
+#define REGION_FLASH_SIZE ((FLASH_SIZE + 3) & ~3)
+
+#endif /* CONFIG_PMP_POWER_OF_TWO_ALIGNMENT */
+
+#endif /* _RISCV_PMP_MEM_CFG_H_ */

--- a/soc/riscv/common/riscv_pmp_regions.c
+++ b/soc/riscv/common/riscv_pmp_regions.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021 Jim Shu
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <kernel.h>
+#include <linker/linker-defs.h>
+
+#include "../../../arch/riscv/include/core_pmp.h"
+#include "riscv_pmp_mem_cfg.h"
+
+#ifndef CONFIG_CPU_HAS_CUSTOM_FIXED_SOC_PMP_REGIONS
+#ifdef CONFIG_XIP
+static const struct riscv_pmp_region pmp_regions[] = {
+	PMP_REGION_ENTRY("FLASH_0",
+			 FLASH_BASE,
+			 REGION_FLASH_SIZE,
+			 REGION_ROM_ATTR),
+};
+#else /* CONFIG_XIP */
+static const struct riscv_pmp_region pmp_regions[] = {
+	PMP_REGION_ENTRY("ROM",
+			 (ulong_t) __rom_region_start,
+			 (ulong_t) __rom_region_size,
+			 REGION_ROM_ATTR),
+};
+#endif /* CONFIG_XIP */
+
+const struct riscv_pmp_config pmp_config = {
+	.num_regions = ARRAY_SIZE(pmp_regions),
+	.pmp_regions = pmp_regions,
+};
+#endif /* !CONFIG_CPU_HAS_CUSTOM_FIXED_SOC_PMP_REGIONS */

--- a/soc/riscv/riscv-privilege/sifive-freedom/CMakeLists.txt
+++ b/soc/riscv/riscv-privilege/sifive-freedom/CMakeLists.txt
@@ -4,3 +4,7 @@ zephyr_sources()
 zephyr_sources_ifdef(CONFIG_SOC_RISCV_SIFIVE_FREEDOM fe310_clock.c)
 zephyr_sources_ifdef(CONFIG_SOC_RISCV_SIFIVE_FU540 fu540_clock.c)
 zephyr_sources_ifdef(CONFIG_SOC_RISCV_SIFIVE_FU740 fu740_clock.c)
+
+if(CONFIG_RISCV_PMP AND CONFIG_CPU_HAS_CUSTOM_FIXED_SOC_PMP_REGIONS)
+  zephyr_sources(pmp_regions.c)
+endif()

--- a/soc/riscv/riscv-privilege/sifive-freedom/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-privilege/sifive-freedom/Kconfig.defconfig.series
@@ -20,6 +20,10 @@ config RISCV_HAS_PLIC
 config RISCV_GP
 	default y
 
+config CPU_HAS_CUSTOM_FIXED_SOC_PMP_REGIONS
+	default y if SOC_RISCV_SIFIVE_FREEDOM && XIP
+	default n
+
 config 2ND_LVL_ISR_TBL_OFFSET
 	default 12
 

--- a/soc/riscv/riscv-privilege/sifive-freedom/pmp_regions.c
+++ b/soc/riscv/riscv-privilege/sifive-freedom/pmp_regions.c
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2021 Jim Shu
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <kernel.h>
+#include <linker/linker-defs.h>
+
+#include "../../../arch/riscv/include/core_pmp.h"
+#include "../../common/riscv_pmp_mem_cfg.h"
+
+#if defined(CONFIG_CPU_HAS_CUSTOM_FIXED_SOC_PMP_REGIONS) && defined(CONFIG_XIP)
+static const struct riscv_pmp_region pmp_regions[] = {
+	PMP_REGION_ENTRY("FLASH_0",
+			 0x20000000,
+			 REGION_FLASH_SIZE,
+			 REGION_ROM_ATTR),
+};
+#endif
+
+const struct riscv_pmp_config pmp_config = {
+	.num_regions = ARRAY_SIZE(pmp_regions),
+	.pmp_regions = pmp_regions,
+};


### PR DESCRIPTION
Support fixed SoC PMP regions to set ROM and RAM default access policies. 
And it provide each SoC to customize these regions based on it's memory layout.
In this PR, we only implement ROM protection. RAM protection support is the future work.

This PR introduce 2 ways to use SoC PMP regions:

1. By default, SoC use common SoC PMP regions
2. SoC could define and use custom SoC PMP regions by new Kconfig option: `CONFIG_CPU_HAS_CUSTOM_FIXED_SOC_PMP_REGIONS`

If SoC only use 1 FLASH + 1 SRAM and the all start addresses of them match the alignment of PMP region, SoC could use common PMP regions. Otherwise, SoC needs to use custom PMP regions.
Lets FE310 SoC use custom PMP regions to align the flash start in PMP region of some FE310 boards

Also, this PR create new directory `soc/riscv/common` to place common fixed SoC PMP regions, which follows Cortex-M design in `soc/arm/common`. Another way is placing them in `soc/riscv/riscv-privilege/common/`.  I am not sure if any non-privileged SoC has standard RISC-V PMP or not (vexriscv PMP plugin?). Because PMP implementation is at `arch/riscv/`, I assume non-privileged SoCs may use it so I places them in `soc/riscv/common`.

Fix #39922

depend on #39299 (This PR only contains last 2 commits)