### PR TITLE
poll: modify the function z_vrfy_k_poll

### DIFF
--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -348,7 +348,7 @@ static inline int z_vrfy_k_poll(struct k_poll_event *events,
 	/* Validate the events buffer and make a copy of it in an
 	 * allocated kernel-side buffer.
 	 */
-	if (Z_SYSCALL_VERIFY(num_events >= 0U)) {
+	if (Z_SYSCALL_VERIFY(num_events >= 0)) {
 		ret = -EINVAL;
 		goto out;
 	}


### PR DESCRIPTION
Removing the `U `to avoid the type of num_events changed.
And make sure it is meaningful Z_SYSCALL_VERIFY micro.

Fixed #40614

Signed-off-by: NingX Zhao <ningx.zhao@intel.com>