### PR TITLE
cmake: cleanup all intermediate build files.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1479,12 +1479,14 @@ endif()
 
 # Cleanup intermediate files
 if(CONFIG_CLEANUP_INTERMEDIATE_FILES)
+  foreach(index RANGE ${ZEPHYR_CURRENT_LINKER_PASS})
+    # Those files can be very large in some cases, delete them as we do not need them.
     list(APPEND
       post_build_commands
       COMMAND
-      # This file can be very large in some cases, delete it as we do not need it.
-      ${CMAKE_COMMAND} -E remove ${ZEPHYR_LINK_STAGE_EXECUTABLE}.elf
+      ${CMAKE_COMMAND} -E remove zephyr_pre${index}.elf
       )
+  endforeach()
 endif()
 
 if(CONFIG_BUILD_OUTPUT_S19)


### PR DESCRIPTION
Fixes: #40643

The intermediate build files produced by the build system may be very
large.

The last pre-built image has been removed when
`CONFIG_CLEANUP_INTERMEDIATE_FILES=y` but when the gen_handles.py call
was moved from the last pre-built image to the first image, the first
image increased in size.
But first image was never cleaned after build.

This commit updates the behaviour so that all intermediate images are
removed when `CONFIG_CLEANUP_INTERMEDIATE_FILES=y` and not only the
final image.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>