### PR TITLE
pm: device_runtime: API improvements

### DIFF
--- a/doc/guides/pm/device_runtime.rst
+++ b/doc/guides/pm/device_runtime.rst
@@ -142,23 +142,28 @@ special synchronization is required.
 
 To enable device runtime power management on a device, the driver needs to call
 :c:func:`pm_device_runtime_enable` at initialization time. Note that this
-function will put the device into the :c:enumerator:`PM_DEVICE_STATE_SUSPENDED`
-state. In case this does not reflect the actual device state, the init function
-must perform the necessary operations to suspend the device.
+function will suspend the device if its state is
+:c:enumerator:`PM_DEVICE_STATE_ACTIVE`. In case the device is physically
+suspended, the init function should call
+:c:func:`pm_device_runtime_init_suspended` before calling
+:c:func:`pm_device_runtime_enable`.
 
 .. code-block:: c
 
     /* device driver initialization function */
     static int mydev_init(const struct device *dev)
     {
+        int ret;
         ...
-        /* make sure the device physically is suspended */
+
+        /* OPTIONAL: mark device as suspended if it is physically suspended */
+        pm_device_runtime_init_suspended(dev);
+
         /* enable device runtime power management */
         ret = pm_device_runtime_enable(dev);
-        if (ret < 0) {
-                return ret;
+        if ((ret < 0) && (ret != -ENOSYS)) {
+            return ret;
         }
-        ...
     }
 
 Assuming an example device driver that implements an ``operation`` API call, the

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -241,7 +241,7 @@ int gpio_stm32_configure(const struct device *dev, int pin, int conf, int altf)
 /**
  * @brief GPIO port clock handling
  */
-int gpio_stm32_clock_request(const struct device *dev, bool on)
+static int gpio_stm32_clock_request(const struct device *dev, bool on)
 {
 	const struct gpio_stm32_config *cfg = dev->config;
 	int ret = 0;

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -481,7 +481,7 @@ static int gpio_stm32_config(const struct device *dev,
 
 	/* Release clock only if configuration doesn't require bank writes */
 	if ((flags & GPIO_OUTPUT) == 0) {
-		err = pm_device_runtime_put_async(dev);
+		err = pm_device_runtime_put(dev);
 		if (err < 0) {
 			return err;
 		}

--- a/drivers/gpio/gpio_stm32.h
+++ b/drivers/gpio/gpio_stm32.h
@@ -238,8 +238,10 @@ struct gpio_stm32_data {
  * @param pin IO pin
  * @param conf GPIO mode
  * @param altf Alternate function
+ *
+ * @return 0 on success, negative errno code on failure
  */
-void gpio_stm32_configure(const struct device *dev, int pin, int conf, int altf);
+int gpio_stm32_configure(const struct device *dev, int pin, int conf, int altf);
 
 /**
  * @brief Enable / disable GPIO port clock.

--- a/drivers/gpio/gpio_stm32.h
+++ b/drivers/gpio/gpio_stm32.h
@@ -243,12 +243,4 @@ struct gpio_stm32_data {
  */
 int gpio_stm32_configure(const struct device *dev, int pin, int conf, int altf);
 
-/**
- * @brief Enable / disable GPIO port clock.
- *
- * @param dev GPIO port device pointer
- * @param on boolean for on/off clock request
- */
-int gpio_stm32_clock_request(const struct device *dev, bool on);
-
 #endif /* ZEPHYR_DRIVERS_GPIO_GPIO_STM32_H_ */

--- a/drivers/pinctrl/pinctrl_stm32.c
+++ b/drivers/pinctrl/pinctrl_stm32.c
@@ -9,7 +9,6 @@
 #include <drivers/clock_control/stm32_clock_control.h>
 #include <drivers/pinctrl.h>
 #include <gpio/gpio_stm32.h>
-#include <pm/device_runtime.h>
 
 #include <stm32_ll_bus.h>
 #include <stm32_ll_gpio.h>
@@ -146,7 +145,6 @@ static int stm32_pins_remap(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt)
 static int stm32_pin_configure(uint32_t pin, uint32_t func, uint32_t altf)
 {
 	const struct device *port_device;
-	int ret;
 
 	if (STM32_PORT(pin) >= gpio_ports_cnt) {
 		return -EINVAL;
@@ -158,14 +156,7 @@ static int stm32_pin_configure(uint32_t pin, uint32_t func, uint32_t altf)
 		return -ENODEV;
 	}
 
-	ret = pm_device_runtime_get(port_device);
-	if (ret < 0) {
-		return ret;
-	}
-
-	gpio_stm32_configure(port_device, STM32_PIN(pin), func, altf);
-
-	return pm_device_runtime_put(port_device);
+	return gpio_stm32_configure(port_device, STM32_PIN(pin), func, altf);
 }
 
 int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,

--- a/drivers/pinctrl/pinctrl_stm32.c
+++ b/drivers/pinctrl/pinctrl_stm32.c
@@ -146,7 +146,7 @@ static int stm32_pins_remap(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt)
 static int stm32_pin_configure(uint32_t pin, uint32_t func, uint32_t altf)
 {
 	const struct device *port_device;
-	int ret = 0;
+	int ret;
 
 	if (STM32_PORT(pin) >= gpio_ports_cnt) {
 		return -EINVAL;
@@ -158,20 +158,14 @@ static int stm32_pin_configure(uint32_t pin, uint32_t func, uint32_t altf)
 		return -ENODEV;
 	}
 
-#ifdef CONFIG_PM_DEVICE_RUNTIME
 	ret = pm_device_runtime_get(port_device);
 	if (ret < 0) {
 		return ret;
 	}
-#endif
 
 	gpio_stm32_configure(port_device, STM32_PIN(pin), func, altf);
 
-#ifdef CONFIG_PM_DEVICE_RUNTIME
-	ret = pm_device_runtime_put(port_device);
-#endif
-
-	return ret;
+	return pm_device_runtime_put(port_device);
 }
 
 int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,

--- a/drivers/pinmux/pinmux_stm32.c
+++ b/drivers/pinmux/pinmux_stm32.c
@@ -92,7 +92,7 @@ SYS_INIT(stm32_pinmux_init_remap, PRE_KERNEL_1,
 static int stm32_pin_configure(uint32_t pin, uint32_t func, uint32_t altf)
 {
 	const struct device *port_device;
-	int ret = 0;
+	int ret;
 
 	if (STM32_PORT(pin) >= STM32_PORTS_MAX) {
 		return -EINVAL;
@@ -104,20 +104,14 @@ static int stm32_pin_configure(uint32_t pin, uint32_t func, uint32_t altf)
 		return -ENODEV;
 	}
 
-#ifdef CONFIG_PM_DEVICE_RUNTIME
 	ret = pm_device_runtime_get(port_device);
-	if (ret != 0) {
+	if (ret < 0) {
 		return ret;
 	}
-#endif
 
 	gpio_stm32_configure(port_device, STM32_PIN(pin), func, altf);
 
-#ifdef CONFIG_PM_DEVICE_RUNTIME
-	ret = pm_device_runtime_put(port_device);
-#endif
-
-	return ret;
+	return pm_device_runtime_put(port_device);
 }
 
 /**

--- a/drivers/pinmux/pinmux_stm32.c
+++ b/drivers/pinmux/pinmux_stm32.c
@@ -23,7 +23,6 @@
 #include <gpio/gpio_stm32.h>
 #include <drivers/clock_control/stm32_clock_control.h>
 #include <pinmux/pinmux_stm32.h>
-#include <pm/device_runtime.h>
 
 const struct device * const gpio_ports[STM32_PORTS_MAX] = {
 	DEVICE_DT_GET_OR_NULL(DT_NODELABEL(gpioa)),
@@ -92,7 +91,6 @@ SYS_INIT(stm32_pinmux_init_remap, PRE_KERNEL_1,
 static int stm32_pin_configure(uint32_t pin, uint32_t func, uint32_t altf)
 {
 	const struct device *port_device;
-	int ret;
 
 	if (STM32_PORT(pin) >= STM32_PORTS_MAX) {
 		return -EINVAL;
@@ -104,14 +102,7 @@ static int stm32_pin_configure(uint32_t pin, uint32_t func, uint32_t altf)
 		return -ENODEV;
 	}
 
-	ret = pm_device_runtime_get(port_device);
-	if (ret < 0) {
-		return ret;
-	}
-
-	gpio_stm32_configure(port_device, STM32_PIN(pin), func, altf);
-
-	return pm_device_runtime_put(port_device);
+	return gpio_stm32_configure(port_device, STM32_PIN(pin), func, altf);
 }
 
 /**

--- a/include/pm/device_runtime.h
+++ b/include/pm/device_runtime.h
@@ -131,6 +131,25 @@ int pm_device_runtime_put_async(const struct device *dev);
  */
 bool pm_device_runtime_is_enabled(const struct device *dev);
 
+/**
+ * @brief Initialize a device state to #PM_DEVICE_STATE_SUSPENDED.
+ *
+ * By default device state is initialized to #PM_DEVICE_STATE_ACTIVE. In
+ * general, this makes sense because the device initialization function will
+ * resume and configure a device, leaving it operational. However, when device
+ * runtime PM is enabled, the device may not be resumed and the init function
+ * will just enable device runtime PM. If that is the case, this function can be
+ * used to set the initial device state to #PM_DEVICE_STATE_SUSPENDED.
+ *
+ * @param dev Device instance.
+ */
+static inline void pm_device_runtime_init_suspended(const struct device *dev)
+{
+	struct pm_device *pm = dev->pm;
+
+	pm->state = PM_DEVICE_STATE_SUSPENDED;
+}
+
 #else
 static inline int pm_device_runtime_enable(const struct device *dev) { return -ENOSYS; }
 static inline int pm_device_runtime_disable(const struct device *dev) { return -ENOSYS; }
@@ -138,6 +157,7 @@ static inline int pm_device_runtime_get(const struct device *dev) { return 0; }
 static inline int pm_device_runtime_put(const struct device *dev) { return 0; }
 static inline int pm_device_runtime_put_async(const struct device *dev) { return 0; }
 static inline bool pm_device_runtime_is_enabled(const struct device *dev) { return false; }
+static inline void pm_device_runtime_init_suspended(const struct device *dev) { }
 #endif
 
 /** @} */

--- a/include/pm/device_runtime.h
+++ b/include/pm/device_runtime.h
@@ -65,9 +65,8 @@ int pm_device_runtime_disable(const struct device *dev);
  *
  * @param dev Device instance.
  *
- * @retval 0 If the device has been resumed successfully.
- * @retval -ENOSTUP If runtime PM is not enabled for the device.
- * @retval -ENOSYS If the functionality is not available.
+ * @retval 0 If it succeeds. In case device runtime PM is not enabled or not
+ * available this function will be a no-op and will also return 0.
  * @retval -errno Other negative errno, result of the PM action callback.
  */
 int pm_device_runtime_get(const struct device *dev);
@@ -84,9 +83,8 @@ int pm_device_runtime_get(const struct device *dev);
  *
  * @param dev Device instance.
  *
- * @retval 0 If device has been suspended successfully.
- * @retval -ENOSTUP If runtime PM is not enabled for the device.
- * @retval -ENOSYS If the functionality is not available.
+ * @retval 0 If it succeeds. In case device runtime PM is not enabled or not
+ * available this function will be a no-op and will also return 0.
  * @retval -EALREADY If device is already suspended (can only happen if get/put
  * calls are unbalanced).
  * @retval -errno Other negative errno, result of the action callback.
@@ -110,9 +108,8 @@ int pm_device_runtime_put(const struct device *dev);
  *
  * @param dev Device instance.
  *
- * @retval 0 If device has queued for suspend.
- * @retval -ENOSTUP If runtime PM is not enabled for the device.
- * @retval -ENOSYS If the functionality is not available.
+ * @retval 0 If it succeeds. In case device runtime PM is not enabled or not
+ * available this function will be a no-op and will also return 0.
  * @retval -EALREADY If device is already suspended (can only happen if get/put
  * calls are unbalanced).
  *
@@ -137,9 +134,9 @@ bool pm_device_runtime_is_enabled(const struct device *dev);
 #else
 static inline int pm_device_runtime_enable(const struct device *dev) { return -ENOSYS; }
 static inline int pm_device_runtime_disable(const struct device *dev) { return -ENOSYS; }
-static inline int pm_device_runtime_get(const struct device *dev) { return -ENOSYS; }
-static inline int pm_device_runtime_put(const struct device *dev) { return -ENOSYS; }
-static inline int pm_device_runtime_put_async(const struct device *dev) { return -ENOSYS; }
+static inline int pm_device_runtime_get(const struct device *dev) { return 0; }
+static inline int pm_device_runtime_put(const struct device *dev) { return 0; }
+static inline int pm_device_runtime_put_async(const struct device *dev) { return 0; }
 static inline bool pm_device_runtime_is_enabled(const struct device *dev) { return false; }
 #endif
 

--- a/include/pm/device_runtime.h
+++ b/include/pm/device_runtime.h
@@ -25,6 +25,9 @@ extern "C" {
 /**
  * @brief Enable device runtime PM
  *
+ * This function will enable runtime PM on the given device. If the device is
+ * in #PM_DEVICE_STATE_ACTIVE state, the device will be suspended.
+ *
  * @funcprops \pre_kernel_ok
  *
  * @param dev Device instance.
@@ -32,6 +35,9 @@ extern "C" {
  * @retval 0 If the device runtime PM is enabled successfully.
  * @retval -EPERM If device has power state locked.
  * @retval -ENOSYS If the functionality is not available.
+ * @retval -errno Other negative errno, result of suspending the device.
+ *
+ * @see pm_device_runtime_init_suspended()
  */
 int pm_device_runtime_enable(const struct device *dev);
 

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -25,7 +25,6 @@ LOG_MODULE_DECLARE(pm_device, CONFIG_PM_DEVICE_LOG_LEVEL);
  * @param async Perform operation asynchronously.
  *
  * @retval 0 If device has been suspended or queued for suspend.
- * @retval -ENOSTUP If runtime PM is not enabled for the device.
  * @retval -EALREADY If device is already suspended (can only happen if get/put
  * calls are unbalanced).
  * @retval -errno Other negative errno, result of the action callback.
@@ -42,7 +41,6 @@ static int runtime_suspend(const struct device *dev, bool async)
 	}
 
 	if ((pm->flags & BIT(PM_DEVICE_FLAG_RUNTIME_ENABLED)) == 0U) {
-		ret = -ENOTSUP;
 		goto unlock;
 	}
 
@@ -109,7 +107,6 @@ int pm_device_runtime_get(const struct device *dev)
 	}
 
 	if ((pm->flags & BIT(PM_DEVICE_FLAG_RUNTIME_ENABLED)) == 0U) {
-		ret = -ENOTSUP;
 		goto unlock;
 	}
 

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -188,6 +188,14 @@ int pm_device_runtime_enable(const struct device *dev)
 		pm->dev = dev;
 		k_work_init_delayable(&pm->work, runtime_suspend_work);
 	}
+
+	if (pm->state == PM_DEVICE_STATE_ACTIVE) {
+		ret = pm->action_cb(pm->dev, PM_DEVICE_ACTION_SUSPEND);
+		if (ret < 0) {
+			goto unlock;
+		}
+	}
+
 	pm->state = PM_DEVICE_STATE_SUSPENDED;
 	pm->usage = 0U;
 

--- a/tests/subsys/pm/device_runtime_api/src/main.c
+++ b/tests/subsys/pm/device_runtime_api/src/main.c
@@ -35,6 +35,7 @@ static void get_runner(void *arg1, void *arg2, void *arg3)
 static void test_api_setup(void)
 {
 	int ret;
+	enum pm_device_state state;
 
 	/* check API always returns 0 when runtime PM is disabled */
 	ret = pm_device_runtime_get(dev);
@@ -45,6 +46,13 @@ static void test_api_setup(void)
 	zassert_equal(ret, 0, NULL);
 
 	/* enable runtime PM */
+	ret = pm_device_runtime_enable(dev);
+	zassert_equal(ret, 0, NULL);
+
+	(void)pm_device_state_get(dev, &state);
+	zassert_equal(state, PM_DEVICE_STATE_SUSPENDED, NULL);
+
+	/* enabling again should succeed (no-op) */
 	ret = pm_device_runtime_enable(dev);
 	zassert_equal(ret, 0, NULL);
 }

--- a/tests/subsys/pm/device_runtime_api/src/main.c
+++ b/tests/subsys/pm/device_runtime_api/src/main.c
@@ -36,13 +36,13 @@ static void test_api_setup(void)
 {
 	int ret;
 
-	/* make sure API is not usable (runtime PM disabled) */
+	/* check API always returns 0 when runtime PM is disabled */
 	ret = pm_device_runtime_get(dev);
-	zassert_equal(ret, -ENOTSUP, NULL);
+	zassert_equal(ret, 0, NULL);
 	ret = pm_device_runtime_put(dev);
-	zassert_equal(ret, -ENOTSUP, NULL);
+	zassert_equal(ret, 0, NULL);
 	ret = pm_device_runtime_put_async(dev);
-	zassert_equal(ret, -ENOTSUP, NULL);
+	zassert_equal(ret, 0, NULL);
 
 	/* enable runtime PM */
 	ret = pm_device_runtime_enable(dev);


### PR DESCRIPTION
This PR introduces a few relevant changes:

1. pm: device_runtime: simplify error handling for get/put 

	  In case runtime PM is not enabled (or not built-in), the get/put
	  functions always return 0 (instead of -ENOTSUP/-ENOSYS). When runtime PM
	  is disabled, a device is left into active state. Similarly, when device
	  runtime PM is not built-in, it is safe to assume that a device will
	  be active when it is called. If a user implements a custom solution, it
	  is its responsability to make sure that a device is active when using
	  it. For all these reasons, the -ENOTSUP/-ENOSYS are error codes that
	  should always be ignored by devices using get/put, since in practice it
	  means that: device is active, function is a no-op. The example below
	  illustrates how error handling is simplified:
	  
	  ```c
	  /* before: safe to ignore -ENOSYS/-ENOTSUP since device is active (we
	   * can continue)
	   */
	  ret = pm_device_runtime_get(dev);
	  if ((ret < 0) && (ret != -ENOSYS) && (ret != -ENOTSUP)) {
		  return ret;
	  }
	  
	  /* now */
	  ret = pm_device_runtime_get(dev);
	  if (ret < 0) {
		  return ret;
	  }
	  ```
2. pm: device_runtime: suspend device on enable 

	  The pm_device_runtime_enable did not suspend devices, so it assumed that
	  the device was in a physically suspended state. This change makes sure
	  that device is left in a suspended state if the device is initially
	  active.

3. pm: device_runtime: add pm_device_runtime_init_suspended 

	  By default, device state is initialized to PM_DEVICE_STATE_ACTIVE. In
	  general, this makes sense because the device initialization function
	  will resume and configure a device, leaving it operational. However,
	  when device runtime PM is enabled, the device may not be resumed and the
	  init function will just enable device runtime PM. If that is the case,
	  this function can be used to set the initial device state to
	  PM_DEVICE_STATE_SUSPENDED.

As a result, the usage of the device runtime PM API has been improved in STM32 GPIO/pinmux drivers.