### PR TITLE
Bluetooth: Controller: Fix to use ADI flag in Periodic Adv Enable

### DIFF
--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -1375,6 +1375,9 @@ struct bt_hci_cp_le_set_per_adv_data {
 	uint8_t  data[251];
 } __packed;
 
+#define BT_HCI_LE_SET_PER_ADV_ENABLE_ENABLE     BIT(0)
+#define BT_HCI_LE_SET_PER_ADV_ENABLE_ADI        BIT(1)
+
 #define BT_HCI_OP_LE_SET_PER_ADV_ENABLE         BT_OP(BT_OGF_LE, 0x0040)
 struct bt_hci_cp_le_set_per_adv_enable {
 	uint8_t  enable;

--- a/tests/bluetooth/bsim_bt/bsim_test_advx/src/main.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_advx/src/main.c
@@ -701,7 +701,7 @@ static void test_advx_main(void)
 	}
 
 	printk("enabling periodic...");
-	err = ll_adv_sync_enable(handle, 1);
+	err = ll_adv_sync_enable(handle, BT_HCI_LE_SET_PER_ADV_ENABLE_ENABLE);
 	if (err) {
 		goto exit;
 	}
@@ -795,7 +795,9 @@ static void test_advx_main(void)
 	k_sleep(K_MSEC(1000));
 
 	printk("enabling periodic...");
-	err = ll_adv_sync_enable(handle, 1);
+	err = ll_adv_sync_enable(handle,
+				 (BT_HCI_LE_SET_PER_ADV_ENABLE_ENABLE |
+				  BT_HCI_LE_SET_PER_ADV_ENABLE_ADI));
 	if (err) {
 		goto exit;
 	}
@@ -972,7 +974,7 @@ static void test_advx_main(void)
 	printk("success.\n");
 
 	printk("enabling periodic...");
-	err = ll_adv_sync_enable(handle, 1);
+	err = ll_adv_sync_enable(handle, BT_HCI_LE_SET_PER_ADV_ENABLE_ENABLE);
 	if (err) {
 		goto exit;
 	}


### PR DESCRIPTION
Fix implementation to use ADI flag in Periodic Advertising
enable command to add ADI field in Periodic Advertising
PDUs.

Related to commit 6433a6a ("Bluetooth: Controller:
Add Periodic Advertising ADI support").

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>