### PR TITLE
drivers: spi_context: fix null pointer dereferencing

### DIFF
--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -201,16 +201,6 @@ static inline void spi_context_complete(struct spi_context *ctx, int status)
 #endif /* CONFIG_SPI_ASYNC */
 }
 
-static inline
-gpio_dt_flags_t spi_context_cs_active_level(struct spi_context *ctx)
-{
-	if (ctx->config->operation & SPI_CS_ACTIVE_HIGH) {
-		return GPIO_ACTIVE_HIGH;
-	}
-
-	return GPIO_ACTIVE_LOW;
-}
-
 static inline int spi_context_cs_configure_all(struct spi_context *ctx)
 {
 	int ret;
@@ -222,11 +212,6 @@ static inline int spi_context_cs_configure_all(struct spi_context *ctx)
 				cs_gpio->port->name, cs_gpio->pin);
 			return -ENODEV;
 		}
-
-		/* Validate CS active levels are equivalent */
-		__ASSERT(spi_context_cs_active_level(ctx) ==
-			 (cs_gpio->dt_flags & GPIO_ACTIVE_LOW),
-			 "Devicetree and spi_context CS levels are not equal");
 
 		ret = gpio_pin_configure_dt(cs_gpio, GPIO_OUTPUT_INACTIVE);
 		if (ret < 0) {


### PR DESCRIPTION
commit 54907c7014f2
("drivers: spi: spi_context: improve support of multiple cs gpios")
added function to initialize all CS GPIOs defined in devicetree.
This function, spi_context_cs_configure_all, is intended to be
called during SPI driver initialization (POST_KERNEL init level).
It is also obvious that a SPI driver was not used at that time,
and no bus configuration (struct spi_config) is assigned to
SPI bus (spi_context.config).

The spi_context_cs_configure_all function has a homeopathic
ASSERT to validate CS levels, which causes a null pointer
dereferencing by ctx->config->operation if asserts are
enabled.