### PR TITLE
Bluetooth: Controller: Fix HCI fragment of Extended Advertising Report

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -5594,6 +5594,16 @@ static void ext_adv_data_frag(const struct node_rx_pdu *node_rx_data,
 
 		node_rx_data = node_rx_data->hdr.rx_ftr.extra;
 		if (node_rx_data) {
+			if (*data_len) {
+				ext_adv_pdu_frag(evt_type, phy, *sec_phy,
+						 adv_addr_type, adv_addr,
+						 direct_addr_type, direct_addr,
+						 rl_idx, tx_pwr, rssi,
+						 interval_le16, adi,
+						 data_len_max, &data_len_total,
+						 data_len, data, buf, evt_buf);
+			}
+
 			*data_len = ext_adv_data_get(node_rx_data, sec_phy,
 						     data);
 		}

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -5548,7 +5548,7 @@ static void ext_adv_pdu_frag(uint8_t evt_type, uint8_t phy, uint8_t sec_phy,
 			     int8_t tx_pwr, int8_t rssi, uint16_t interval_le16,
 			     const struct pdu_adv_adi *adi,
 			     uint8_t data_len_max,
-			     uint8_t *const data_len_total,
+			     uint16_t *const data_len_total,
 			     uint8_t *const data_len,
 			     const uint8_t **const data, struct net_buf *buf,
 			     struct net_buf **const evt_buf)
@@ -5578,7 +5578,7 @@ static void ext_adv_data_frag(const struct node_rx_pdu *node_rx_data,
 			      int8_t tx_pwr, int8_t rssi,
 			      uint16_t interval_le16,
 			      const struct pdu_adv_adi *adi,
-			      uint8_t data_len_max, uint8_t data_len_total,
+			      uint8_t data_len_max, uint16_t data_len_total,
 			      uint8_t *const data_len,
 			      const uint8_t **const data, struct net_buf *buf,
 			      struct net_buf **const evt_buf)
@@ -5618,9 +5618,9 @@ static void le_ext_adv_report(struct pdu_data *pdu_data,
 	struct node_rx_pdu *node_rx_scan_data = NULL;
 	struct node_rx_pdu *node_rx_data = NULL;
 	const struct pdu_adv_adi *adi = NULL;
+	uint16_t scan_data_len_total = 0U;
 	struct node_rx_pdu *node_rx_curr;
 	struct node_rx_pdu *node_rx_next;
-	uint8_t scan_data_len_total = 0U;
 	const uint8_t *scan_data = NULL;
 	uint8_t scan_data_status = 0U;
 	uint8_t direct_addr_type = 0U;


### PR DESCRIPTION
Fix HCI fragment of Extended Advertising Report when chain
PDUs are received. Implementation was missing HCI event
generation for last frag of each PDU when there was a next
chain PDU.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>