### PR TITLE
boards: nrf21540dk_nrf52840: Assign nRF21540 FEM to Radio device

### DIFF
--- a/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840.dts
+++ b/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840.dts
@@ -233,6 +233,10 @@ fem_spi: &spi3 {
 	};
 };
 
+&radio {
+	fem = <&nrf_radio_fem>;
+};
+
 &flash0 {
 
 	partitions {


### PR DESCRIPTION
nRF21540 DK has nRF21540 Front End Module connected with
nRF52840 CPU, assign the FEM as default to Radio device.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>