### PR TITLE
mgmt/mcumgr/lib: Reduce taskstat to Zephyr supported statistics

### DIFF
--- a/subsys/mgmt/mcumgr/Kconfig
+++ b/subsys/mgmt/mcumgr/Kconfig
@@ -239,6 +239,21 @@ config OS_MGMT_TASKSTAT
 	bool "Support for taskstat command"
 	default y
 
+if OS_MGMT_TASKSTAT
+
+config OS_MGMT_TASKSTAT_ONLY_SUPPORTED_STATS
+	bool "Send only data gathered by Zephyr"
+	default y
+	help
+	  Response will not include fields the Zephyr does not collect statistic for.
+	  Enable this if your client software is able to process "taskstat" response
+	  that would be missing "runtime", "cswcnt", "last_checkin" and "next_checkin"
+	  map entries for each listed task.
+	  Enabling this option will slightly reduce code size.
+
+endif
+
+
 config OS_MGMT_ECHO
 	bool "Support for echo command"
 	default y

--- a/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/include/os_mgmt/os_mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/include/os_mgmt/os_mgmt.h
@@ -29,10 +29,12 @@ struct os_mgmt_task_info {
 	uint8_t oti_state;
 	uint16_t oti_stkusage;
 	uint16_t oti_stksize;
+#ifndef CONFIG_OS_MGMT_TASKSTAT_ONLY_SUPPORTED_STATS
 	uint32_t oti_cswcnt;
 	uint32_t oti_runtime;
 	uint32_t oti_last_checkin;
 	uint32_t oti_next_checkin;
+#endif
 
 	char oti_name[OS_MGMT_TASK_NAME_LEN];
 };

--- a/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/src/os_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/src/os_mgmt.c
@@ -79,6 +79,7 @@ os_mgmt_taskstat_encode_one(struct CborEncoder *encoder, const struct os_mgmt_ta
 	err |= cbor_encode_uint(&task_map, task_info->oti_stkusage);
 	err |= cbor_encode_text_stringz(&task_map, "stksiz");
 	err |= cbor_encode_uint(&task_map, task_info->oti_stksize);
+#ifndef CONFIG_OS_MGMT_TASKSTAT_ONLY_SUPPORTED_STATS
 	err |= cbor_encode_text_stringz(&task_map, "cswcnt");
 	err |= cbor_encode_uint(&task_map, task_info->oti_cswcnt);
 	err |= cbor_encode_text_stringz(&task_map, "runtime");
@@ -87,6 +88,7 @@ os_mgmt_taskstat_encode_one(struct CborEncoder *encoder, const struct os_mgmt_ta
 	err |= cbor_encode_uint(&task_map, task_info->oti_last_checkin);
 	err |= cbor_encode_text_stringz(&task_map, "next_checkin");
 	err |= cbor_encode_uint(&task_map, task_info->oti_next_checkin);
+#endif
 	err |= cbor_encoder_close_container(encoder, &task_map);
 
 	if (err != 0) {


### PR DESCRIPTION
The commit adds CONFIG_OS_MGMT_TASKSTAT_ONLY_SUPPORTED_STATS
Kconfig option that disables code filling in task statistics, for
mcumgr command `taskstat`, that are not collected or supported by
Zephyr.
Setting this option to y will skip following statistics in response:
"runtime", "cswcnt", "last_checkin" and "next_checkin".

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

Note: instead of removing the code, the option has been added to disable, so that existing tools that expect the fields would not get broken. This has been done to give developers time to adjust.

Building smp_svr for serial console, for nrf52840dk_nrf52840 with this **option disabled** gives:
```
Memory region         Used Size  Region Size  %age Used
           FLASH:       73860 B       412 KB     17.51%
            SRAM:       22606 B       256 KB      8.62%
        IDT_LIST:          0 GB         2 KB      0.00%
```
with **option enabled**:
```
Memory region         Used Size  Region Size  %age Used
           FLASH:       73708 B       412 KB     17.47%
            SRAM:       22606 B       256 KB      8.62%
        IDT_LIST:          0 GB         2 KB      0.00%
```