### PR TITLE
Bluetooth: host: Expose per adv evt counter in CTE IQ report.

### DIFF
--- a/include/bluetooth/direction.h
+++ b/include/bluetooth/direction.h
@@ -101,6 +101,8 @@ struct bt_df_per_adv_sync_iq_samples_report {
 	uint8_t slot_durations;
 	/** Status of received PDU with CTE (@ref bt_df_packet_status). */
 	uint8_t packet_status;
+	/** Value of the paEventCounter of the AUX_SYNC_IND PDU. */
+	uint16_t per_evt_counter;
 	/** Number of IQ samples in report. */
 	uint8_t sample_count;
 	/** Pinter to IQ samples data. */

--- a/subsys/bluetooth/host/direction.c
+++ b/subsys/bluetooth/host/direction.c
@@ -351,6 +351,7 @@ void hci_df_prepare_connectionless_iq_report(struct net_buf *buf,
 	report->cte_type = BIT(evt->cte_type);
 	report->packet_status = evt->packet_status;
 	report->slot_durations = evt->slot_durations;
+	report->per_evt_counter = sys_le16_to_cpu(evt->per_evt_counter);
 	report->sample_count = evt->sample_count;
 	report->sample = &evt->sample[0];
 

--- a/subsys/bluetooth/host/direction.c
+++ b/subsys/bluetooth/host/direction.c
@@ -346,7 +346,7 @@ void hci_df_prepare_connectionless_iq_report(struct net_buf *buf,
 	}
 
 	report->chan_idx = evt->chan_idx;
-	report->rssi = evt->rssi;
+	report->rssi = sys_le16_to_cpu(evt->rssi);
 	report->rssi_ant_id = evt->rssi_ant_id;
 	report->cte_type = BIT(evt->cte_type);
 	report->packet_status = evt->packet_status;


### PR DESCRIPTION
The periodic advertising event counter is present in the `HCI_LE_Connectionless_IQ_Report` but until now not availible for the application to access. This pull request fixes that.

Signed-off-by: Jakob Krantz <jakob.krantz@u-blox.com>