### PR TITLE
drivers/pinmux: stm32f1: Fix broken cast in remap

### DIFF
--- a/drivers/pinctrl/pinctrl_stm32.c
+++ b/drivers/pinctrl/pinctrl_stm32.c
@@ -108,7 +108,7 @@ static int stm32_pins_remap(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt)
 	volatile uint32_t *reg;
 	uint16_t remap;
 
-	remap = (uint8_t)STM32_DT_PINMUX_REMAP(pins[0].pinmux);
+	remap = (uint16_t)STM32_DT_PINMUX_REMAP(pins[0].pinmux);
 
 	/* not remappable */
 	if (remap == NO_REMAP) {

--- a/drivers/pinmux/pinmux_stm32.c
+++ b/drivers/pinmux/pinmux_stm32.c
@@ -219,7 +219,7 @@ int stm32_dt_pinctrl_remap(const struct soc_gpio_pinctrl *pinctrl,
 	volatile uint32_t *reg;
 	uint16_t remap;
 
-	remap = (uint8_t)STM32_DT_PINMUX_REMAP(pinctrl[0].pinmux);
+	remap = (uint16_t)STM32_DT_PINMUX_REMAP(pinctrl[0].pinmux);
 
 	/* not remappable */
 	if (remap == NO_REMAP) {


### PR DESCRIPTION
remap information is coded in 10 bits, uint16_t should be used
to cast it.

Fixes #40688

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>