### PR TITLE
modules: mbedtls: Remove MBEDTLS_ECP_MAX_BITS from generic config

### DIFF
--- a/modules/mbedtls/configs/config-tls-generic.h
+++ b/modules/mbedtls/configs/config-tls-generic.h
@@ -422,7 +422,6 @@
 #if defined(CONFIG_MBEDTLS_OPENTHREAD_OPTIMIZATIONS_ENABLED)
 #define MBEDTLS_MPI_WINDOW_SIZE            1 /**< Maximum windows size used. */
 #define MBEDTLS_MPI_MAX_SIZE              32 /**< Maximum number of bytes for usable MPIs. */
-#define MBEDTLS_ECP_MAX_BITS             256 /**< Maximum bit size of groups */
 #define MBEDTLS_ECP_WINDOW_SIZE            2 /**< Maximum window size used */
 #define MBEDTLS_ECP_FIXED_POINT_OPTIM      0 /**< Enable fixed-point speed-up */
 #define MBEDTLS_ENTROPY_MAX_SOURCES        1 /**< Maximum number of sources supported */


### PR DESCRIPTION
MBEDTLS_ECP_MAX_BITS is now set automatically by mbed TLS, redefining it
in the config file ends up in compilation warnings.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>