### PR TITLE
device: remove device PM header inclusion

### DIFF
--- a/drivers/display/display_st7735r.c
+++ b/drivers/display/display_st7735r.c
@@ -16,6 +16,7 @@
 #include <device.h>
 #include <drivers/spi.h>
 #include <drivers/gpio.h>
+#include <pm/device.h>
 #include <sys/byteorder.h>
 #include <drivers/display.h>
 

--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -15,6 +15,7 @@
 #include <device.h>
 #include <drivers/spi.h>
 #include <drivers/gpio.h>
+#include <pm/device.h>
 #include <sys/byteorder.h>
 #include <drivers/display.h>
 

--- a/drivers/entropy/entropy_neorv32_trng.c
+++ b/drivers/entropy/entropy_neorv32_trng.c
@@ -9,6 +9,7 @@
 #include <device.h>
 #include <drivers/syscon.h>
 #include <drivers/entropy.h>
+#include <pm/device.h>
 #include <sys/sys_io.h>
 
 #include <logging/log.h>

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -30,6 +30,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <net/net_if.h>
 #include <net/ethernet.h>
 #include <ethernet/eth_stats.h>
+#include <pm/device.h>
 
 #if defined(CONFIG_PTP_CLOCK_MCUX)
 #include <drivers/ptp_clock.h>

--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -9,6 +9,7 @@
 #include <errno.h>
 #include <drivers/flash.h>
 #include <init.h>
+#include <pm/device.h>
 #include <string.h>
 #include <logging/log.h>
 LOG_MODULE_REGISTER(qspi_nor, CONFIG_FLASH_LOG_LEVEL);

--- a/drivers/flash/spi_flash_at45.c
+++ b/drivers/flash/spi_flash_at45.c
@@ -6,6 +6,7 @@
 
 #include <drivers/flash.h>
 #include <drivers/spi.h>
+#include <pm/device.h>
 #include <sys/byteorder.h>
 #include <logging/log.h>
 

--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -13,6 +13,7 @@
 #include "gpio_dw.h"
 #include "gpio_utils.h"
 
+#include <pm/device.h>
 #include <soc.h>
 #include <sys/sys_io.h>
 #include <init.h>

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -13,6 +13,7 @@
 #include <drivers/i2c.h>
 #include <kernel.h>
 #include <init.h>
+#include <pm/device.h>
 #include <arch/cpu.h>
 #include <string.h>
 

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -7,6 +7,7 @@
 
 #include <drivers/i2c.h>
 #include <dt-bindings/i2c/i2c.h>
+#include <pm/device.h>
 #include <nrfx_twi.h>
 
 #include <logging/log.h>

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -7,6 +7,7 @@
 
 #include <drivers/i2c.h>
 #include <dt-bindings/i2c/i2c.h>
+#include <pm/device.h>
 #include <nrfx_twim.h>
 #include <sys/util.h>
 

--- a/drivers/interrupt_controller/intc_ioapic.c
+++ b/drivers/interrupt_controller/intc_ioapic.c
@@ -58,6 +58,7 @@
 #include <toolchain.h>
 #include <linker/sections.h>
 #include <device.h>
+#include <pm/device.h>
 #include <string.h>
 
 #include <drivers/interrupt_controller/ioapic.h> /* public API declarations */

--- a/drivers/interrupt_controller/intc_loapic.c
+++ b/drivers/interrupt_controller/intc_loapic.c
@@ -10,6 +10,7 @@
 #include <kernel.h>
 #include <kernel_structs.h>
 #include <arch/cpu.h>
+#include <pm/device.h>
 #include <zephyr/types.h>
 #include <string.h>
 #include <sys/__assert.h>

--- a/drivers/led/led_pwm.c
+++ b/drivers/led/led_pwm.c
@@ -14,6 +14,7 @@
 #include <drivers/led.h>
 #include <drivers/pwm.h>
 #include <device.h>
+#include <pm/device.h>
 #include <zephyr.h>
 #include <sys/math_extras.h>
 

--- a/drivers/modem/modem_receiver.c
+++ b/drivers/modem/modem_receiver.c
@@ -14,6 +14,7 @@
 #include <kernel.h>
 #include <init.h>
 #include <drivers/uart.h>
+#include <pm/device.h>
 
 #include <logging/log.h>
 

--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -5,6 +5,7 @@
  */
 #include <nrfx_pwm.h>
 #include <drivers/pwm.h>
+#include <pm/device.h>
 #include <hal/nrf_gpio.h>
 #include <stdbool.h>
 

--- a/drivers/sensor/apds9960/apds9960.c
+++ b/drivers/sensor/apds9960/apds9960.c
@@ -14,6 +14,7 @@
 #include <device.h>
 #include <drivers/sensor.h>
 #include <drivers/i2c.h>
+#include <pm/device.h>
 #include <sys/__assert.h>
 #include <sys/byteorder.h>
 #include <init.h>

--- a/drivers/sensor/bme280/bme280.c
+++ b/drivers/sensor/bme280/bme280.c
@@ -12,6 +12,7 @@
 #include <drivers/sensor.h>
 #include <init.h>
 #include <drivers/gpio.h>
+#include <pm/device.h>
 #include <sys/byteorder.h>
 #include <sys/__assert.h>
 

--- a/drivers/sensor/bmp388/bmp388.c
+++ b/drivers/sensor/bmp388/bmp388.c
@@ -14,6 +14,7 @@
 #include <sys/byteorder.h>
 #include <drivers/i2c.h>
 #include <drivers/sensor.h>
+#include <pm/device.h>
 
 #include "bmp388.h"
 

--- a/drivers/sensor/bmp388/bmp388_trigger.c
+++ b/drivers/sensor/bmp388/bmp388_trigger.c
@@ -13,6 +13,7 @@
 #include <kernel.h>
 #include <drivers/sensor.h>
 #include <drivers/gpio.h>
+#include <pm/device.h>
 #include <logging/log.h>
 
 #include "bmp388.h"

--- a/drivers/sensor/bq274xx/bq274xx.c
+++ b/drivers/sensor/bq274xx/bq274xx.c
@@ -9,6 +9,7 @@
 #include <drivers/i2c.h>
 #include <init.h>
 #include <drivers/sensor.h>
+#include <pm/device.h>
 #include <sys/__assert.h>
 #include <string.h>
 #include <sys/byteorder.h>

--- a/drivers/sensor/fdc2x1x/fdc2x1x.c
+++ b/drivers/sensor/fdc2x1x/fdc2x1x.c
@@ -9,6 +9,7 @@
 #define DT_DRV_COMPAT ti_fdc2x1x
 
 #include <device.h>
+#include <pm/device.h>
 #include <sys/util.h>
 #include <logging/log.h>
 #include <math.h>

--- a/drivers/sensor/ina219/ina219.c
+++ b/drivers/sensor/ina219/ina219.c
@@ -11,6 +11,7 @@
 #include <kernel.h>
 #include <drivers/sensor.h>
 #include <logging/log.h>
+#include <pm/device.h>
 #include <sys/byteorder.h>
 
 #include "ina219.h"

--- a/drivers/sensor/lis2mdl/lis2mdl.c
+++ b/drivers/sensor/lis2mdl/lis2mdl.c
@@ -14,6 +14,7 @@
 #include <sys/__assert.h>
 #include <sys/byteorder.h>
 #include <drivers/sensor.h>
+#include <pm/device.h>
 #include <string.h>
 #include <logging/log.h>
 #include "lis2mdl.h"

--- a/drivers/sensor/lm77/lm77.c
+++ b/drivers/sensor/lm77/lm77.c
@@ -11,6 +11,7 @@
 #include <drivers/i2c.h>
 #include <drivers/sensor.h>
 #include <logging/log.h>
+#include <pm/device.h>
 #include <sys/byteorder.h>
 
 LOG_MODULE_REGISTER(lm77, CONFIG_SENSOR_LOG_LEVEL);

--- a/drivers/sensor/qdec_nrfx/qdec_nrfx.c
+++ b/drivers/sensor/qdec_nrfx/qdec_nrfx.c
@@ -5,6 +5,7 @@
  */
 
 #include <drivers/sensor.h>
+#include <pm/device.h>
 
 #include <nrfx_qdec.h>
 #include <hal/nrf_gpio.h>

--- a/drivers/sensor/sgp40/sgp40.c
+++ b/drivers/sensor/sgp40/sgp40.c
@@ -11,6 +11,7 @@
 #include <kernel.h>
 #include <drivers/sensor.h>
 #include <logging/log.h>
+#include <pm/device.h>
 #include <sys/byteorder.h>
 #include <sys/crc.h>
 

--- a/drivers/sensor/si7210/si7210.c
+++ b/drivers/sensor/si7210/si7210.c
@@ -9,6 +9,7 @@
 #include <kernel.h>
 #include <drivers/i2c.h>
 #include <drivers/sensor.h>
+#include <pm/device.h>
 #include <sys/__assert.h>
 #include <sys/byteorder.h>
 #include <logging/log.h>

--- a/drivers/sensor/vcnl4040/vcnl4040.c
+++ b/drivers/sensor/vcnl4040/vcnl4040.c
@@ -7,6 +7,7 @@
 #define DT_DRV_COMPAT vishay_vcnl4040
 
 #include "vcnl4040.h"
+#include <pm/device.h>
 #include <sys/__assert.h>
 #include <sys/byteorder.h>
 #include <sys/util.h>

--- a/drivers/serial/uart_neorv32.c
+++ b/drivers/serial/uart_neorv32.c
@@ -9,6 +9,7 @@
 #include <device.h>
 #include <drivers/syscon.h>
 #include <drivers/uart.h>
+#include <pm/device.h>
 #include <sys/sys_io.h>
 
 #include <logging/log.h>

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -9,6 +9,7 @@
  */
 
 #include <drivers/uart.h>
+#include <pm/device.h>
 #include <hal/nrf_uart.h>
 
 #ifdef CONFIG_PINCTRL

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -9,7 +9,7 @@
  */
 
 #include <drivers/uart.h>
-
+#include <pm/device.h>
 #include <hal/nrf_uarte.h>
 #include <nrfx_timer.h>
 #include <sys/util.h>

--- a/drivers/spi/spi_dw.c
+++ b/drivers/spi/spi_dw.c
@@ -33,6 +33,7 @@ LOG_MODULE_REGISTER(spi_dw);
 #include <soc.h>
 #include <device.h>
 #include <init.h>
+#include <pm/device.h>
 
 #include <sys/sys_io.h>
 #include <sys/util.h>

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -5,6 +5,7 @@
  */
 
 #include <drivers/spi.h>
+#include <pm/device.h>
 #include <nrfx_spi.h>
 
 #define LOG_DOMAIN "spi_nrfx_spi"

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -5,6 +5,7 @@
  */
 
 #include <drivers/spi.h>
+#include <pm/device.h>
 #ifdef CONFIG_SOC_NRF52832_ALLOW_SPIM_DESPITE_PAN_58
 #include <nrfx_gpiote.h>
 #include <nrfx_ppi.h>

--- a/include/device.h
+++ b/include/device.h
@@ -28,7 +28,6 @@
 
 #include <init.h>
 #include <linker/sections.h>
-#include <pm/device.h>
 #include <sys/device_mmio.h>
 #include <sys/util.h>
 
@@ -361,6 +360,8 @@ struct device_state {
 	 */
 	bool initialized : 1;
 };
+
+struct pm_device;
 
 /**
  * @brief Runtime device structure (in ROM) per driver instance

--- a/include/drivers/timer/system_timer.h
+++ b/include/drivers/timer/system_timer.h
@@ -39,17 +39,6 @@ extern "C" {
 extern int sys_clock_driver_init(const struct device *dev);
 
 /**
- * @brief Initialize system clock driver
- *
- * The system clock is a Zephyr device created globally.  This is its
- * device control callback, used in a few devices for power
- * management.  It is a weak symbol that will be implemented as a noop
- * if undefined in the clock driver.
- */
-extern int clock_device_ctrl(const struct device *dev,
-			     enum pm_device_state state);
-
-/**
  * @brief Set system clock timeout
  *
  * Informs the system clock driver that the next needed call to

--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -7,6 +7,7 @@
 #ifndef ZEPHYR_INCLUDE_PM_DEVICE_H_
 #define ZEPHYR_INCLUDE_PM_DEVICE_H_
 
+#include <device.h>
 #include <kernel.h>
 #include <sys/atomic.h>
 

--- a/samples/boards/nrf/system_off/src/main.c
+++ b/samples/boards/nrf/system_off/src/main.c
@@ -9,6 +9,7 @@
 #include <device.h>
 #include <init.h>
 #include <pm/pm.h>
+#include <pm/device.h>
 #include "retained.h"
 #include <hal/nrf_gpio.h>
 

--- a/samples/subsys/pm/device_pm/src/dummy_driver.c
+++ b/samples/subsys/pm/device_pm/src/dummy_driver.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <pm/device.h>
 #include <pm/device_runtime.h>
 #include <sys/printk.h>
 #include "dummy_parent.h"

--- a/samples/subsys/pm/device_pm/src/dummy_parent.c
+++ b/samples/subsys/pm/device_pm/src/dummy_parent.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <pm/device.h>
 #include <pm/device_runtime.h>
 #include <sys/printk.h>
 #include "dummy_parent.h"

--- a/soc/arm/st_stm32/stm32u5/power.c
+++ b/soc/arm/st_stm32/stm32u5/power.c
@@ -76,14 +76,7 @@ __weak void pm_power_state_set(struct pm_state_info info)
 	case PM_STATE_SOFT_OFF:
 		set_mode_shutdown(info.substate_id);
 		break;
-	/* Following states are not supported */
-	case PM_STATE_RUNTIME_IDLE:
-		__fallthrough;
-	case PM_STATE_ACTIVE:
-		__fallthrough;
-	case PM_STATE_SUSPEND_TO_RAM:
-		__fallthrough;
-	case PM_STATE_SUSPEND_TO_DISK:
+	default:
 		LOG_DBG("Unsupported power state %u", info.state);
 		return;
 	}

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -15,6 +15,7 @@ LOG_MODULE_REGISTER(net_shell, LOG_LEVEL_DBG);
 
 #include <zephyr.h>
 #include <kernel_internal.h>
+#include <pm/device.h>
 #include <random/rand32.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/subsys/shell/modules/device_service.c
+++ b/subsys/shell/modules/device_service.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <device.h>
+#include <pm/device.h>
 #include <sys/arch_interface.h>
 
 extern const struct device __device_PRE_KERNEL_1_start[];

--- a/tests/net/pm/src/main.c
+++ b/tests/net/pm/src/main.c
@@ -8,6 +8,7 @@
 
 #include <zephyr.h>
 #include <linker/sections.h>
+#include <pm/device.h>
 #include <ztest.h>
 #include <random/rand32.h>
 

--- a/tests/subsys/pm/device_runtime_api/src/test_driver.c
+++ b/tests/subsys/pm/device_runtime_api/src/test_driver.c
@@ -7,6 +7,7 @@
 #include "test_driver.h"
 
 #include <kernel.h>
+#include <pm/device.h>
 
 struct test_driver_data {
 	bool ongoing;

--- a/tests/subsys/pm/device_wakeup_api/src/main.c
+++ b/tests/subsys/pm/device_wakeup_api/src/main.c
@@ -6,8 +6,8 @@
 
 #include <zephyr.h>
 #include <ztest.h>
-#include <device.h>
 #include <pm/pm.h>
+#include <pm/device.h>
 
 #define DEV_NAME DT_NODELABEL(gpio0)
 

--- a/tests/subsys/pm/power_mgmt/src/dummy_driver.c
+++ b/tests/subsys/pm/power_mgmt/src/dummy_driver.c
@@ -6,6 +6,7 @@
 
 #include <sys/printk.h>
 #include <zephyr/types.h>
+#include <pm/device.h>
 #include <pm/device_runtime.h>
 #include "dummy_driver.h"
 


### PR DESCRIPTION
The device PM subsystem depends on devices, not vice-versa. Devices
only hold a reference to `struct pm_device` now, and initialize this
reference with the value provided in `Z_DEVICE_DEFINE`. This requirement
can be solved with a forward struct declaration, meaning there is no
need to include device PM headers.

This PR ends with the coupling between `device.h` -> `pm/device.h`.