### PR TITLE
dts: stm32u5 has one iwdg watchdog node

### DIFF
--- a/boards/arm/b_u585i_iot02a/b_u585i_iot02a.dts
+++ b/boards/arm/b_u585i_iot02a/b_u585i_iot02a.dts
@@ -89,6 +89,6 @@ zephyr_udc0: &usbotg_fs {
 	status = "okay";
 };
 
-&iwdg1 {
+&iwdg {
 	status = "okay";
 };

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -200,11 +200,10 @@
 			};
 		};
 
-		iwdg1: watchdog@40003000 {
+		iwdg: watchdog@40003000 {
 			compatible = "st,stm32-watchdog";
 			reg = <0x40003000 0x400>;
-			interrupts = <27 7>;
-			label = "IWDG_1";
+			label = "IWDG";
 			status = "disabled";
 		};
 


### PR DESCRIPTION
The stm32u5 device has a single iwdg node entry and label
without any need for interrupt. Even if it exists the irq entry is not required.

Removing the reference to node 1

Signed-off-by: Francois Ramu <francois.ramu@st.com>