### PR TITLE
drivers: watchdog: stm32H7 and MP1 window watchdog during debug

### DIFF
--- a/drivers/watchdog/wdt_wwdg_stm32.c
+++ b/drivers/watchdog/wdt_wwdg_stm32.c
@@ -168,6 +168,8 @@ static int wwdg_stm32_setup(const struct device *dev, uint8_t options)
 		LL_APB1_GRP2_EnableClock(LL_APB1_GRP2_PERIPH_DBGMCU);
 #elif defined(CONFIG_SOC_SERIES_STM32L0X)
 		LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_DBGMCU);
+#elif defined(CONFIG_SOC_SERIES_STM32G0X)
+		LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_DBGMCU);
 #endif
 #if defined(CONFIG_SOC_SERIES_STM32H7X)
 		LL_DBGMCU_APB3_GRP1_FreezePeriph(LL_DBGMCU_APB3_GRP1_WWDG1_STOP);

--- a/drivers/watchdog/wdt_wwdg_stm32.c
+++ b/drivers/watchdog/wdt_wwdg_stm32.c
@@ -169,7 +169,11 @@ static int wwdg_stm32_setup(const struct device *dev, uint8_t options)
 #elif defined(CONFIG_SOC_SERIES_STM32L0X)
 		LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_DBGMCU);
 #endif
+#if defined(CONFIG_SOC_SERIES_STM32H7X)
+		LL_DBGMCU_APB3_GRP1_FreezePeriph(LL_DBGMCU_APB3_GRP1_WWDG1_STOP);
+#else
 		LL_DBGMCU_APB1_GRP1_FreezePeriph(LL_DBGMCU_APB1_GRP1_WWDG_STOP);
+#endif /* CONFIG_SOC_SERIES_STM32H7X */
 	}
 
 	if (options & WDT_OPT_PAUSE_IN_SLEEP) {

--- a/drivers/watchdog/wdt_wwdg_stm32.c
+++ b/drivers/watchdog/wdt_wwdg_stm32.c
@@ -171,6 +171,8 @@ static int wwdg_stm32_setup(const struct device *dev, uint8_t options)
 #endif
 #if defined(CONFIG_SOC_SERIES_STM32H7X)
 		LL_DBGMCU_APB3_GRP1_FreezePeriph(LL_DBGMCU_APB3_GRP1_WWDG1_STOP);
+#elif defined(CONFIG_SOC_SERIES_STM32MP1X)
+		LL_DBGMCU_APB1_GRP1_FreezePeriph(LL_DBGMCU_APB1_GRP1_WWDG1_STOP);
 #else
 		LL_DBGMCU_APB1_GRP1_FreezePeriph(LL_DBGMCU_APB1_GRP1_WWDG_STOP);
 #endif /* CONFIG_SOC_SERIES_STM32H7X */


### PR DESCRIPTION
This commit is controlling the WWDG during the Stop mode in debug.
WWDG is frozen while the core is in Debug mode, 
for the stm32H7 soc devices : setting the bit of the DBGMCU APB3 peripheral freeze register (DBGMCU_APB3FZ1)
for the stm32MP1 soc devices. the WWDG is referenced as WWDG1
for the stm32G0 soc device, the DBGMCU clock is enabled before use.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/40663

Signed-off-by: Francois Ramu <francois.ramu@st.com>