### PR TITLE
soc: arm: renesas: r8a77951: fix defconfig

### DIFF
--- a/soc/arm/renesas_rcar/gen3/Kconfig.defconfig.r8a77951
+++ b/soc/arm/renesas_rcar/gen3/Kconfig.defconfig.r8a77951
@@ -1,9 +1,9 @@
 # Copyright (c) 2021 IoT.bzh
 # SPDX-License-Identifier: Apache-2.0
 
-if SOC_R8A77950
+if SOC_R8A77951
 
 config SOC
 	default "r8a77951"
 
-endif # SOC_R8A77950
+endif # SOC_R8A77951


### PR DESCRIPTION
Fixed an error that could cause problems if
a driver reads "SOC" in the future.

Signed-off-by: Aymeric Aillet <aymeric.aillet@iot.bzh>