### PR TITLE
Bluetooth: controller: Add missing NULL assign to df_cfg in ll_adv_set

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -2057,6 +2057,13 @@ static int init_reset(void)
 	for (handle = 0U; handle < BT_CTLR_ADV_SET; handle++) {
 		lll_adv_data_init(&ll_adv[handle].lll.adv_data);
 		lll_adv_data_init(&ll_adv[handle].lll.scan_rsp);
+#if defined(CONFIG_BT_CTLR_DF_ADV_CTE_TX)
+		/* Pointer to DF configuration must be cleared on reset. In other case it will point
+		 * to a memory pool address that should be released. It may be used by the pool
+		 * itself. In such situation it may cause error.
+		 */
+		ll_adv[handle].df_cfg = NULL;
+#endif /* CONFIG_BT_CTLR_DF_ADV_CTE_TX */
 	}
 
 	/* Make sure that set #0 is initialized with empty legacy PDUs. This is


### PR DESCRIPTION
ll_adv_set stores poitner to direction finding TX configuration.
When ll_reset is executed the pointer was not NULL assigned.
That lead to erroneous behavior e.g. df_cfg->is_enabled was set
to TRUE even the functionality was not enabled.
DF configuration is stored in memory pool. The memory pool uses
free elements to store its internal data. On reset whole pool is
expected to be free, so ll_adv_set->df_cfg may not point to any
element allocated from memory pool.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>