### PR TITLE
MAINTAINERS: add alxelax as Bluetooth Mesh collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -211,6 +211,7 @@ Bluetooth Mesh:
     collaborators:
         - jhedberg
         - LingaoM
+        - alxelax
     files:
         - subsys/bluetooth/mesh/
         - include/bluetooth/mesh/


### PR DESCRIPTION
Add alxelax as Bluetooth Mesh collaborator.

Signed-off-by: Aleksandr Khromykh <Aleksandr.Khromykh@nordicsemi.no>