### PR TITLE
native_posix: macos: use -fuse-ld=lld

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,6 +353,11 @@ zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:$<TARGET_PROPERTY:compiler-cpp,
 # 'cmake -DEXTRA_CFLAGS="-Werror -Wno-deprecated-declarations" ..'
 include(cmake/extra_flags.cmake)
 
+if (${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Darwin" AND CONFIG_ARCH_POSIX)
+zephyr_cc_option(-fhash-long-section-names=16)
+zephyr_cc_option(-hashed-section-names=zephyr_renamed_sections.csv)
+endif()
+
 zephyr_cc_option(-fno-asynchronous-unwind-tables)
 zephyr_cc_option(-fno-pie)
 zephyr_cc_option(-fno-pic)
@@ -418,9 +423,12 @@ if(CONFIG_USERSPACE)
   set(KOBJECT_LINKER_DEP kobject_linker)
 endif()
 
+# Actually, the '-T' option is not required for LLVM's LLD
+if (NOT (${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Darwin" AND CONFIG_ARCH_POSIX))
 get_property(TOPT GLOBAL PROPERTY TOPT)
 set_ifndef(  TOPT -Wl,-T) # clang doesn't pick -T for some reason and complains,
                           # while -Wl,-T works for both, gcc and clang
+endif()
 
 if(CONFIG_HAVE_CUSTOM_LINKER_SCRIPT)
   set(LINKER_SCRIPT ${APPLICATION_SOURCE_DIR}/${CONFIG_CUSTOM_LINKER_SCRIPT})
@@ -1536,6 +1544,8 @@ if(CONFIG_OUTPUT_DISASSEMBLE_ALL)
 endif()
 
 if(CONFIG_OUTPUT_STAT)
+# probably some equivalent command exists to read stats from a Mach-O binary
+if (NOT (${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Darwin" AND CONFIG_ARCH_POSIX))
 #  zephyr_post_build(TOOLS bintools COMMAND readelf FLAGS headers INFILE file OUTFILE outfile)
   list(APPEND
     post_build_commands
@@ -1550,6 +1560,7 @@ if(CONFIG_OUTPUT_STAT)
     post_build_byproducts
     ${KERNEL_STAT_NAME}
     )
+endif()
 endif()
 
 if(CONFIG_BUILD_OUTPUT_STRIPPED)

--- a/cmake/linker/ld/target.cmake
+++ b/cmake/linker/ld/target.cmake
@@ -100,8 +100,13 @@ endmacro()
 
 # Force symbols to be entered in the output file as undefined symbols
 function(toolchain_ld_force_undefined_symbols)
+  if (CONFIG_ARCH_POSIX AND ${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Darwin")
+    set(symbol_prefix "_")
+  else()
+    set(symbol_prefix "")
+  endif()
   foreach(symbol ${ARGN})
-    zephyr_link_libraries(${LINKERFLAGPREFIX},-u,${symbol})
+    zephyr_link_libraries(${LINKERFLAGPREFIX},-u,${symbol_prefix}${symbol})
   endforeach()
 endfunction()
 
@@ -130,6 +135,21 @@ function(toolchain_ld_link_elf)
     set(use_linker "-fuse-ld=bfd")
   endif()
 
+  if (CONFIG_ARCH_POSIX AND ${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Darwin")
+    set(map_opt "-map,")
+    set(whole_archive "-Wl,-all_load")
+    set(no_whole_archive "")
+    set(use_linker "-fuse-ld=lld")
+    # FIXME: not reading linker script for some reason
+    # fails with "ld64.lld: error: zephyr/linker_zephyr_pre0.ld: unhandled file type"
+    set(TOOLCHAIN_LD_LINK_ELF_LINKER_SCRIPT "")
+    set(MACOS_OPTS "-Wl,-flat_namespace, -Wl,-undefined,warning")
+  else()
+    set(map_opt "-Map=")
+    set(whole_archive "${LINKERFLAGPREFIX},--whole-archive")
+    set(no_whole_archive "${LINKERFLAGPREFIX},--no-whole-archive")
+  endif()
+
   target_link_libraries(
     ${TOOLCHAIN_LD_LINK_ELF_TARGET_ELF}
     ${TOOLCHAIN_LD_LINK_ELF_LIBRARIES_PRE_SCRIPT}
@@ -138,10 +158,12 @@ function(toolchain_ld_link_elf)
     ${TOOLCHAIN_LD_LINK_ELF_LINKER_SCRIPT}
     ${TOOLCHAIN_LD_LINK_ELF_LIBRARIES_POST_SCRIPT}
 
-    ${LINKERFLAGPREFIX},-Map=${TOOLCHAIN_LD_LINK_ELF_OUTPUT_MAP}
-    ${LINKERFLAGPREFIX},--whole-archive
+    ${MACOS_OPTS}
+
+    ${LINKERFLAGPREFIX},${map_opt}${TOOLCHAIN_LD_LINK_ELF_OUTPUT_MAP}
+    ${whole_archive}
     ${ZEPHYR_LIBS_PROPERTY}
-    ${LINKERFLAGPREFIX},--no-whole-archive
+    ${no_whole_archive}
     kernel
     $<TARGET_OBJECTS:${OFFSETS_LIB}>
     ${LIB_INCLUDE_DIR}

--- a/drivers/timer/sys_clock_init.c
+++ b/drivers/timer/sys_clock_init.c
@@ -17,7 +17,17 @@
 #include <drivers/timer/system_timer.h>
 
 /* Weak-linked noop defaults for optional driver interfaces*/
-
+#if defined(__APPLE__) && defined(__MACH__)
+extern void sys_clock_isr(void *arg);
+extern int sys_clock_driver_init(const struct device *dev);
+int sys_clock_device_ctrl(const struct device *dev, uint32_t ctrl_command,
+			  enum pm_device_state *state);
+void sys_clock_set_timeout(int32_t ticks, bool idle);
+void sys_clock_idle_exit(void)
+{
+}
+void sys_clock_disable(void);
+#else /* defined(__APPLE__) && defined(__MACH__) */
 void __weak sys_clock_isr(void *arg)
 {
 	__ASSERT_NO_MSG(false);
@@ -41,6 +51,7 @@ void __weak sys_clock_idle_exit(void)
 void __weak sys_clock_disable(void)
 {
 }
+#endif /* defined(__APPLE__) && defined(__MACH__) */
 
 SYS_DEVICE_DEFINE("sys_clock", sys_clock_driver_init,
 		PRE_KERNEL_2, CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/include/device.h
+++ b/include/device.h
@@ -728,7 +728,7 @@ static inline bool device_is_ready(const struct device *dev)
  */
 #define Z_DEVICE_STATE_DEFINE(node_id, dev_name)			\
 	static struct device_state Z_DEVICE_STATE_NAME(dev_name)	\
-	__attribute__((__section__(".z_devstate")));
+	__z_section(".z_devstate");
 
 /* Construct objects that are referenced from struct device. These
  * include power management and dependency handles.
@@ -781,8 +781,8 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 		Z_DEVICE_HANDLE_NAME(node_id, dev_name)[];		\
 	const device_handle_t						\
 	__aligned(sizeof(device_handle_t))				\
-	__attribute__((__weak__,					\
-		       __section__(".__device_handles_pass1")))		\
+	__weak \
+	__z_section(".__device_handles_pass1")		\
 	Z_DEVICE_HANDLE_NAME(node_id, dev_name)[] = {			\
 	COND_CODE_1(DT_NODE_EXISTS(node_id), (				\
 			DT_DEP_ORD(node_id),				\
@@ -809,7 +809,7 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 	COND_CODE_1(DT_NODE_EXISTS(node_id), (), (static))		\
 		const Z_DECL_ALIGN(struct device)			\
 		DEVICE_NAME_GET(dev_name) __used			\
-	__attribute__((__section__(".z_device_" #level STRINGIFY(prio)"_"))) = { \
+		__z_section(".z_device_" #level STRINGIFY(prio)"_") = { \
 		.name = drv_name,					\
 		.config = (cfg_ptr),					\
 		.api = (api_ptr),					\

--- a/include/init.h
+++ b/include/init.h
@@ -82,13 +82,12 @@ void z_sys_init_run_level(int32_t level);
  * @param prio The initialization priority of the object, relative to
  * other objects of the same initialization level. See SYS_INIT().
  */
-#define Z_INIT_ENTRY_DEFINE(_entry_name, _init_fn, _device, _level, _prio)	\
-	static const Z_DECL_ALIGN(struct init_entry)			\
-		_CONCAT(__init_, _entry_name) __used			\
-	__attribute__((__section__(".z_init_" #_level STRINGIFY(_prio)"_"))) = { \
-		.init = (_init_fn),					\
-		.dev = (_device),					\
-	}
+#define Z_INIT_ENTRY_DEFINE(_entry_name, _init_fn, _device, _level, _prio)                         \
+	static const Z_DECL_ALIGN(struct init_entry) _CONCAT(__init_, _entry_name)                 \
+		__used __z_section(".z_init_" #_level STRINGIFY(_prio) "_") = {                    \
+			.init = (_init_fn),                                                        \
+			.dev = (_device),                                                          \
+		}
 
 /**
  * @def SYS_INIT

--- a/include/toolchain/llvm.h
+++ b/include/toolchain/llvm.h
@@ -11,5 +11,7 @@
 #define __no_optimization __attribute__((optnone))
 #include <toolchain/gcc.h>
 
+#undef __weak
+#define __weak
 
 #endif /* ZEPHYR_INCLUDE_TOOLCHAIN_LLVM_H_ */

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -18,7 +18,6 @@ target_link_libraries(kernel INTERFACE ${libkernel})
 else()
 
 list(APPEND kernel_files
-  main_weak.c
   banner.c
   device.c
   errno.c
@@ -29,6 +28,12 @@ list(APPEND kernel_files
   thread.c
   version.c
   )
+
+if (NOT (${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Darwin" AND CONFIG_ARCH_POSIX))
+list(APPEND kernel_files
+  main_weak.c
+  )
+endif()
 
 if(CONFIG_MULTITHREADING)
 list(APPEND kernel_files

--- a/kernel/fatal.c
+++ b/kernel/fatal.c
@@ -18,6 +18,7 @@
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 /* LCOV_EXCL_START */
+#if !(defined(__APPLE__) && defined(__MACH__))
 FUNC_NORETURN __weak void arch_system_halt(unsigned int reason)
 {
 	ARG_UNUSED(reason);
@@ -31,6 +32,7 @@ FUNC_NORETURN __weak void arch_system_halt(unsigned int reason)
 		/* Spin endlessly */
 	}
 }
+#endif /* !(defined(__APPLE__) && defined(__MACH__)) */
 /* LCOV_EXCL_STOP */
 
 /* LCOV_EXCL_START */

--- a/lib/os/cbprintf_packaged.c
+++ b/lib/os/cbprintf_packaged.c
@@ -69,8 +69,10 @@ struct __va_list {
 	int	__vr_offs;
 };
 
+#if !(defined(__APPLE__) && defined(__MACH__))
 BUILD_ASSERT(sizeof(va_list) == sizeof(struct __va_list),
 	     "architecture specific support is wrong");
+#endif /* !(defined(__APPLE__) && defined(__MACH__)) */
 
 static int cbprintf_via_va_list(cbprintf_cb out, void *ctx,
 				const char *fmt, void *buf)

--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -38,6 +38,13 @@ static struct k_spinlock lock;
  * @return 0
  */
 /* LCOV_EXCL_START */
+#if defined(__APPLE__) && defined(__MACH__)
+int arch_printk_char_out(int c)
+{
+	extern int putchar(int c);
+	return putchar(c);
+}
+#else /* defined(__APPLE__) && defined(__MACH__) */
 __attribute__((weak)) int arch_printk_char_out(int c)
 {
 	ARG_UNUSED(c);
@@ -45,6 +52,7 @@ __attribute__((weak)) int arch_printk_char_out(int c)
 	/* do nothing */
 	return 0;
 }
+#endif /* defined(__APPLE__) && defined(__MACH__) */
 /* LCOV_EXCL_STOP */
 
 int (*_char_out)(int) = arch_printk_char_out;

--- a/scripts/gen_handles.py
+++ b/scripts/gen_handles.py
@@ -32,6 +32,7 @@ import os
 import struct
 import pickle
 from packaging import version
+import magic
 
 import elftools
 from elftools.elf.elffile import ELFFile
@@ -168,11 +169,6 @@ def main():
     parse_args()
 
     assert args.kernel, "--kernel ELF required to extract data"
-    elf = ELFFile(open(args.kernel, "rb"))
-
-    edtser = os.path.join(os.path.split(args.kernel)[0], "edt.pickle")
-    with open(edtser, 'rb') as f:
-        edt = pickle.load(f)
 
     devices = []
     handles = []
@@ -182,6 +178,19 @@ def main():
                           "_DEVICE_STRUCT_SIZEOF",
                           "_DEVICE_STRUCT_HANDLES_OFFSET"])
     ld_constants = dict()
+
+    filetype = magic.from_file(args.kernel)
+    if filetype.startswith('Mach-O'):
+        with open(args.output_source, "w") as fp:
+            # not sure if anything needs to be written here
+            pass
+        return
+
+    elf = ELFFile(open(args.kernel, "rb"))
+
+    edtser = os.path.join(os.path.split(args.kernel)[0], "edt.pickle")
+    with open(edtser, 'rb') as f:
+        edt = pickle.load(f)
 
     for section in elf.iter_sections():
         if isinstance(section, SymbolTableSection):

--- a/scripts/gen_offset_header.py
+++ b/scripts/gen_offset_header.py
@@ -14,7 +14,9 @@ intended for use in assembly code.
 
 from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import SymbolTableSection
+import magic
 import argparse
+import subprocess
 import sys
 
 
@@ -38,21 +40,46 @@ def gen_offset_header(input_name, input_file, output_file):
 #ifndef %s
 #define %s\n\n""" % (include_guard, include_guard))
 
-    obj = ELFFile(input_file)
-    for sym in get_symbol_table(obj).iter_symbols():
-        if isinstance(sym.name, bytes):
-            sym.name = str(sym.name, 'ascii')
+    filetype = magic.from_file(input_name)
 
-        if not sym.name.endswith(('_OFFSET', '_SIZEOF')):
-            continue
-        if sym.entry['st_shndx'] != 'SHN_ABS':
-            continue
-        if sym.entry['st_info']['bind'] != 'STB_GLOBAL':
-            continue
+    if filetype.startswith('ELF'):
+        obj = ELFFile(input_file)
+        for sym in get_symbol_table(obj).iter_symbols():
+            if isinstance(sym.name, bytes):
+                sym.name = str(sym.name, 'ascii')
 
-        output_file.write(
-            "#define %s 0x%x\n" %
-            (sym.name, sym.entry['st_value']))
+            if not sym.name.endswith(('_OFFSET', '_SIZEOF')):
+                continue
+            if sym.entry['st_shndx'] != 'SHN_ABS':
+                continue
+            if sym.entry['st_info']['bind'] != 'STB_GLOBAL':
+                continue
+
+            output_file.write(
+                "#define %s 0x%x\n" %
+                (sym.name, sym.entry['st_value']))
+
+    elif filetype.startswith('Mach-O'):
+        process = subprocess.run('nm -g {}'.format(input_name), shell=True,
+                                 check=True, stdout=subprocess.PIPE, universal_newlines=True)
+        output = process.stdout
+
+        for line in output.splitlines():
+            word = line.split()
+            if len(word) != 3:
+                continue
+
+            sym = type('', (), {})()
+            sym.entry = word[0]
+            sym.type = word[1]
+            sym.name = word[2]
+
+            if not sym.name.endswith(('_OFFSET', '_SIZEOF')):
+                continue
+            if sym.type != 'A':
+                continue
+
+            output_file.write('#define {} 0x{}\n'.format(sym.name, sym.entry))
 
     output_file.write("\n#endif /* %s */\n" % include_guard)
 

--- a/soc/posix/inf_clock/soc.h
+++ b/soc/posix/inf_clock/soc.h
@@ -44,7 +44,7 @@ void posix_soc_clean_up(void);
  */
 #define NATIVE_TASK(fn, level, prio)	\
 	static void (*_CONCAT(__native_task_, fn)) __used	\
-	__attribute__((__section__(".native_" #level STRINGIFY(prio) "_task")))\
+	__z_section(".native_" #level STRINGIFY(prio) "_task") \
 	= fn
 
 


### PR DESCRIPTION
This is a preview of the changes that would be required to support `native_posix` on macOS with my [Clang work](https://github.com/llvm/llvm-project/compare/main...cfriedt:fhash-long-section-names).

Specifically, I added two options to Clang to work around the MachO 16-character section name limitation.
* `-fhash-long-section-names=N`
* `-hashed-section-names=outputfile.csv`

It's definitely less invasive than my [previous approach](https://github.com/zephyrproject-rtos/zephyr/pull/37123) but this will not build in CI for macOS and will require a new toolchain, so please don't review with any seriousness yet.

The options above result in the following section names:
```
% objdump --headers build/zephyr/zephyr.exe 

build/zephyr/zephyr.exe:        file format mach-o arm64

Sections:
Idx Name             Size     VMA              Type
  0 __text           0000cbdc 0000000100000d68 TEXT
  1 __stubs          000001d4 000000010000d944 TEXT
  2 __stub_helper    000001ec 000000010000db18 TEXT
  3 __cstring        00000f55 000000010000dd04 DATA
  4 __const          0000014d 000000010000ec5c DATA
  5 __literal8       00000058 000000010000edb0 DATA
  6 __literal16      00000010 000000010000ee10 DATA
  7 __got            00000090 0000000100010000 DATA
  8 __const          00000080 0000000100010090 DATA
  9 __la_symbol_ptr  00000138 0000000100014000 DATA
 10 __data           00000460 0000000100014138 DATA
 11 ee505i1iDSJ38lW6 00000020 0000000100014598 DATA
 12 X3OkufZugPkMRV0u 00000008 00000001000145b8 DATA
 13 gSbov272cOSyitB9 00000008 00000001000145c0 DATA
 14 PWCnD+vO5fLbOTNC 00000010 00000001000145c8 DATA
 15 ISGPhW3oi0+QmD32 00000006 00000001000145d8 DATA
 16 .z_devstate      00000004 00000001000145e0 DATA
 17 g689RYj/NgI8BJm1 00000030 00000001000145e8 DATA
 18 KPvctDvcsEzL2GeJ 00000010 0000000100014618 DATA
 19 kSBlhTrw6lGfb4bH 00000400 0000000100014628 DATA
 20 2ykHVrz1H6C6zM7x 00000800 0000000100014a28 DATA
 21 M7LnbayK+Apx90Az 00000100 0000000100015228 DATA
 22 DSRqIUjHqO6d+Nny 00000040 0000000100015328 DATA
 23 yXwPRdgDQM/TZ0qv 00000030 0000000100015368 DATA
 24 AivJBhsGJLg4nCaa 00000050 0000000100015398 DATA
 25 0G3gaNFfoLgkTC6u 00000640 00000001000153e8 DATA
 26 xcc74YkFJpO/l+79 00000030 0000000100015a28 DATA
 27 kOons3eUg3xDONU5 00000050 0000000100015a58 DATA
 28 66dcYG27Liq2h08v 000004b0 0000000100015aa8 DATA
 29 oinUk81sKcoS+CT2 00000010 0000000100015f58 DATA
 30 U9Ufj7zPekAbDTSR 00000400 0000000100015f68 DATA
 31 __bss            00000555 0000000100016370 BSS
 32 __common         00000239 00000001000168c8 BSS
 ```
 
 and the output of `build/zephyr_renamed_sections.csv` is below (some duplicates are expected and fine)
```
._k_mutex.static.fdtable_lock   ee505i1iDSJ38lW6
.z_init_PRE_KERNEL_199_ PWCnD+vO5fLbOTNC
.__device_handles_pass1 ISGPhW3oi0+QmD32
.z_device_PRE_KERNEL_20_        g689RYj/NgI8BJm1
.z_init_PRE_KERNEL_20_  KPvctDvcsEzL2GeJ
.z_init_PRE_KERNEL_130_ DSRqIUjHqO6d+Nny
.noinit."ZEPHYR_BASE/kernel/init.c".0   kSBlhTrw6lGfb4bH
.noinit."ZEPHYR_BASE/kernel/init.c".1   M7LnbayK+Apx90Az
.noinit."ZEPHYR_BASE/kernel/init.c".2   2ykHVrz1H6C6zM7x
.z_init_PRE_KERNEL_130_ DSRqIUjHqO6d+Nny
.noinit."ZEPHYR_BASE/kernel/mailbox.c".0        AivJBhsGJLg4nCaa
._k_stack.static.async_msg_free yXwPRdgDQM/TZ0qv
.noinit."ZEPHYR_BASE/kernel/mailbox.c".1        0G3gaNFfoLgkTC6u
.z_init_PRE_KERNEL_130_ DSRqIUjHqO6d+Nny
.noinit."ZEPHYR_BASE/kernel/pipes.c".0  kOons3eUg3xDONU5
._k_stack.static.pipe_async_msgs        xcc74YkFJpO/l+79
.noinit."ZEPHYR_BASE/kernel/pipes.c".1  66dcYG27Liq2h08v
.z_init_PRE_KERNEL_130_ DSRqIUjHqO6d+Nny
.noinit."ZEPHYR_BASE/kernel/system_work_q.c".0  U9Ufj7zPekAbDTSR
.z_init_POST_KERNEL40_  oinUk81sKcoS+CT2
```

Additionally, I think it would make a lot of sense to use [LLD](https://lld.llvm.org/) for linking on macOS, as it apparently has support for GNU linker scripts and is faster / uses less memory. It should work with `-fuse-ld=lld` but currently it ends up failing with the message below:

```
ld64.lld: error: zephyr/linker_zephyr_pre0.cmd: unhandled file type
```