### PR TITLE
boards: pinetime_devkit0: Change backlight labels

### DIFF
--- a/boards/arm/pinetime_devkit0/pinetime_devkit0.dts
+++ b/boards/arm/pinetime_devkit0/pinetime_devkit0.dts
@@ -38,15 +38,15 @@
 		compatible = "gpio-leds";
 		blled0: bl_led_0 {
 			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
-			label = "Backlight LED 0";
+			label = "Backlight Low";
 		};
 		blled1: bl_led_1 {
 			gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;
-			label = "Backlight LED 1";
+			label = "Backlight Medium";
 		};
 		blled2: bl_led_2 {
 			gpios = <&gpio0 23 GPIO_ACTIVE_LOW>;
-			label = "Backlight LED 2";
+			label = "Backlight High";
 		};
 		statusled: led_3 {
 			gpios = <&gpio0 27 GPIO_ACTIVE_LOW>;


### PR DESCRIPTION
There is one backlight in the pinetime device. The three gpio pins power
the backlight using a different resistor. Therfore they control the
brightness of the backlight.  Change the label to represent that.

Signed-off-by: Casper Meijn <casper@meijn.net>