### PR TITLE
drivers: display: st7789v: Fix software reset

### DIFF
--- a/dts/bindings/display/sitronix,st7789v.yaml
+++ b/dts/bindings/display/sitronix,st7789v.yaml
@@ -11,7 +11,7 @@ include: spi-device.yaml
 properties:
     reset-gpios:
       type: phandle-array
-      required: true
+      required: false
       description: |
         RESET pin.
 


### PR DESCRIPTION
Software reset is already implemented in the driver when the
`reset_gpio` is not defined. However it could not be activated
because the `reset_gpio` is a required field in the DTS
binding.

Signed-off-by: Casper Meijn <casper@meijn.net>