### PR TITLE
PCIe Express Generic Bridge enumeration

### DIFF
--- a/drivers/pcie/host/controller.c
+++ b/drivers/pcie/host/controller.c
@@ -71,13 +71,14 @@ static void pcie_generic_ctrl_enumerate_type1(const struct device *ctrl_dev, pci
 	/* Not yet supported */
 }
 
-static void pcie_generic_ctrl_type0_enumerate_bars(const struct device *ctrl_dev, pcie_bdf_t bdf)
+static void pcie_generic_ctrl_enumerate_bars(const struct device *ctrl_dev, pcie_bdf_t bdf,
+					     unsigned int nbars)
 {
 	unsigned int bar, reg, data;
 	uintptr_t scratch, bar_bus_addr;
 	size_t size, bar_size;
 
-	for (bar = 0, reg = PCIE_CONF_BAR0; reg <= PCIE_CONF_BAR5; reg ++, bar++) {
+	for (bar = 0, reg = PCIE_CONF_BAR0; bar < nbars && reg <= PCIE_CONF_BAR5; reg ++, bar++) {
 		bool found_mem64 = false;
 		bool found_mem = false;
 
@@ -163,7 +164,7 @@ static void pcie_generic_ctrl_type0_enumerate_bars(const struct device *ctrl_dev
 static void pcie_generic_ctrl_enumerate_type0(const struct device *ctrl_dev, pcie_bdf_t bdf)
 {
 	/* Setup Type0 BARs */
-	pcie_generic_ctrl_type0_enumerate_bars(ctrl_dev, bdf);
+	pcie_generic_ctrl_enumerate_bars(ctrl_dev, bdf, 6);
 }
 
 void pcie_generic_ctrl_enumerate(const struct device *ctrl_dev, pcie_bdf_t bdf_start)

--- a/drivers/pcie/host/controller.c
+++ b/drivers/pcie/host/controller.c
@@ -66,11 +66,6 @@ void pcie_generic_ctrl_conf_write(mm_reg_t cfg_addr, pcie_bdf_t bdf,
 	bdf_cfg_mem[reg] = data;
 }
 
-static void pcie_generic_ctrl_enumerate_type1(const struct device *ctrl_dev, pcie_bdf_t bdf)
-{
-	/* Not yet supported */
-}
-
 static void pcie_generic_ctrl_enumerate_bars(const struct device *ctrl_dev, pcie_bdf_t bdf,
 					     unsigned int nbars)
 {
@@ -161,24 +156,128 @@ static void pcie_generic_ctrl_enumerate_bars(const struct device *ctrl_dev, pcie
 	}
 }
 
+static bool pcie_generic_ctrl_enumerate_type1(const struct device *ctrl_dev, pcie_bdf_t bdf,
+					      unsigned int bus_number)
+{
+	uint32_t class = pcie_conf_read(bdf, PCIE_CONF_CLASSREV);
+
+	/* Handle only PCI-to-PCI bridge for now */
+	if (PCIE_CONF_CLASSREV_CLASS(class) == 0x06 &&
+	    PCIE_CONF_CLASSREV_SUBCLASS(class) == 0x04) {
+		uint32_t number = pcie_conf_read(bdf, PCIE_BUS_NUMBER);
+		uintptr_t bar_base_addr;
+
+		pcie_generic_ctrl_enumerate_bars(ctrl_dev, bdf, 2);
+
+		/* Configure bus number registers */
+		pcie_conf_write(bdf, PCIE_BUS_NUMBER,
+				PCIE_BUS_NUMBER_VAL(PCIE_BDF_TO_BUS(bdf),
+						    bus_number,
+						    0xff, /* set max until we finished scanning */
+						    PCIE_SECONDARY_LATENCY_TIMER(number)));
+
+		/* I/O align on 4k boundary */
+		if (pcie_ctrl_region_get_allocate_base(ctrl_dev, bdf, false, false,
+						       KB(4), &bar_base_addr)) {
+			uint32_t io = pcie_conf_read(bdf, PCIE_IO_SEC_STATUS);
+			uint32_t io_upper = pcie_conf_read(bdf, PCIE_IO_BASE_LIMIT_UPPER);
+
+			pcie_conf_write(bdf, PCIE_IO_SEC_STATUS,
+					PCIE_IO_SEC_STATUS_VAL(PCIE_IO_BASE(io),
+							       PCIE_IO_LIMIT(io),
+							       PCIE_SEC_STATUS(io)));
+
+			pcie_conf_write(bdf, PCIE_IO_BASE_LIMIT_UPPER,
+				PCIE_IO_BASE_LIMIT_UPPER_VAL(PCIE_IO_BASE_UPPER(io_upper),
+							     PCIE_IO_LIMIT_UPPER(io_upper)));
+
+			pcie_set_cmd(bdf, PCIE_CONF_CMDSTAT_IO, true);
+		}
+
+		/* MEM align on 1MiB boundary */
+		if (pcie_ctrl_region_get_allocate_base(ctrl_dev, bdf, true, false,
+						       MB(1), &bar_base_addr)) {
+			uint32_t mem = pcie_conf_read(bdf, PCIE_MEM_BASE_LIMIT);
+
+			pcie_conf_write(bdf, PCIE_MEM_BASE_LIMIT,
+					PCIE_MEM_BASE_LIMIT_VAL((bar_base_addr & 0xfff00000) >> 16,
+								PCIE_MEM_LIMIT(mem)));
+
+			pcie_set_cmd(bdf, PCIE_CONF_CMDSTAT_MEM, true);
+		}
+
+		/* TODO: add support for prefetchable */
+
+		pcie_set_cmd(bdf, PCIE_CONF_CMDSTAT_MASTER, true);
+
+		return true;
+	}
+
+	return false;
+}
+
+static void pcie_generic_ctrl_post_enumerate_type1(const struct device *ctrl_dev, pcie_bdf_t bdf,
+						   unsigned int bus_number)
+{
+	uint32_t number = pcie_conf_read(bdf, PCIE_BUS_NUMBER);
+	uintptr_t bar_base_addr;
+
+	/* Configure bus subordinate */
+	pcie_conf_write(bdf, PCIE_BUS_NUMBER,
+			PCIE_BUS_NUMBER_VAL(PCIE_BUS_PRIMARY_NUMBER(number),
+				PCIE_BUS_SECONDARY_NUMBER(number),
+				bus_number - 1,
+				PCIE_SECONDARY_LATENCY_TIMER(number)));
+
+	/* I/O align on 4k boundary */
+	if (pcie_ctrl_region_get_allocate_base(ctrl_dev, bdf, false, false,
+					       KB(4), &bar_base_addr)) {
+		uint32_t io = pcie_conf_read(bdf, PCIE_IO_SEC_STATUS);
+		uint32_t io_upper = pcie_conf_read(bdf, PCIE_IO_BASE_LIMIT_UPPER);
+
+		pcie_conf_write(bdf, PCIE_IO_SEC_STATUS,
+				PCIE_IO_SEC_STATUS_VAL(PCIE_IO_BASE(io),
+					((bar_base_addr - 1) & 0x0000f000) >> 16,
+					PCIE_SEC_STATUS(io)));
+
+		pcie_conf_write(bdf, PCIE_IO_BASE_LIMIT_UPPER,
+				PCIE_IO_BASE_LIMIT_UPPER_VAL(PCIE_IO_BASE_UPPER(io_upper),
+					((bar_base_addr - 1) & 0xffff0000) >> 16));
+	}
+
+	/* MEM align on 1MiB boundary */
+	if (pcie_ctrl_region_get_allocate_base(ctrl_dev, bdf, true, false,
+					       MB(1), &bar_base_addr)) {
+		uint32_t mem = pcie_conf_read(bdf, PCIE_MEM_BASE_LIMIT);
+
+		pcie_conf_write(bdf, PCIE_MEM_BASE_LIMIT,
+				PCIE_MEM_BASE_LIMIT_VAL(PCIE_MEM_BASE(mem),
+					(bar_base_addr - 1) >> 16));
+	}
+
+	/* TODO: add support for prefetchable */
+}
+
 static void pcie_generic_ctrl_enumerate_type0(const struct device *ctrl_dev, pcie_bdf_t bdf)
 {
 	/* Setup Type0 BARs */
 	pcie_generic_ctrl_enumerate_bars(ctrl_dev, bdf, 6);
 }
 
-static void pcie_generic_ctrl_enumerate_endpoint(const struct device *ctrl_dev,
-						 pcie_bdf_t bdf, bool *skip_next_func)
+static bool pcie_generic_ctrl_enumerate_endpoint(const struct device *ctrl_dev,
+						 pcie_bdf_t bdf, unsigned int bus_number,
+						 bool *skip_next_func)
 {
 	bool multifunction_device = false;
 	bool layout_type_1 = false;
 	uint32_t data, class, id;
+	bool is_bridge = false;
 
 	*skip_next_func = false;
 
 	id = pcie_conf_read(bdf, PCIE_CONF_ID);
 	if (id == PCIE_ID_NONE) {
-		return;
+		return false;
 	}
 
 	class = pcie_conf_read(bdf, PCIE_CONF_CLASSREV);
@@ -204,16 +303,20 @@ static void pcie_generic_ctrl_enumerate_endpoint(const struct device *ctrl_dev,
 	}
 
 	if (layout_type_1) {
-		pcie_generic_ctrl_enumerate_type1(ctrl_dev, bdf);
+		is_bridge = pcie_generic_ctrl_enumerate_type1(ctrl_dev, bdf, bus_number);
 	} else {
 		pcie_generic_ctrl_enumerate_type0(ctrl_dev, bdf);
 	}
+
+	return is_bridge;
 }
 
 void pcie_generic_ctrl_enumerate(const struct device *ctrl_dev, pcie_bdf_t bdf_start)
 {
 	uint32_t data, class, id;
+	unsigned int bus_number = PCIE_BDF_TO_BUS(bdf_start) + 1;
 	bool skip_next_func = false;
+	bool is_bridge = false;
 	unsigned int dev = PCIE_BDF_TO_DEV(bdf_start),
 		     func = 0,
 		     bus = PCIE_BDF_TO_BUS(bdf_start);
@@ -223,7 +326,15 @@ void pcie_generic_ctrl_enumerate(const struct device *ctrl_dev, pcie_bdf_t bdf_s
 		for (; func <= PCIE_MAX_FUNC; func++) {
 			pcie_bdf_t bdf = PCIE_BDF(bus, dev, func);
 
-			pcie_generic_ctrl_enumerate_endpoint(ctrl_dev, bdf, &skip_next_func);
+			is_bridge = pcie_generic_ctrl_enumerate_endpoint(ctrl_dev, bdf,
+									  bus_number,
+									  &skip_next_func);
+
+			if (is_bridge) {
+				bus_number++;
+				pcie_generic_ctrl_post_enumerate_type1(ctrl_dev, bdf,
+							               bus_number);
+			}
 
 			if (skip_next_func) {
 				break;

--- a/include/drivers/pcie/controller.h
+++ b/include/drivers/pcie/controller.h
@@ -76,6 +76,25 @@ typedef bool (*pcie_ctrl_region_allocate_t)(const struct device *dev, pcie_bdf_t
 					    uintptr_t *bar_bus_addr);
 
 /**
+ * @brief Function called to get the current allocation base of a memory region subset
+ * for an endpoint Base Address Register.
+ *
+ * When enumerating PCIe Endpoints, Type1 bridge endpoints requires a range of memory
+ * allocated by all endpoints in the bridged bus.
+ *
+ * @param dev PCI Express Controller device pointer
+ * @param bdf PCI(e) endpoint
+ * @param mem True if the BAR is of memory type
+ * @param mem64 True if the BAR is of 64bit memory type
+ * @param align size to take in account for alignment
+ * @param bar_base_addr bus-centric address allocation base
+ * @return True if allocation was possible, False if allocation failed
+ */
+typedef bool (*pcie_ctrl_region_get_allocate_base_t)(const struct device *dev, pcie_bdf_t bdf,
+						     bool mem, bool mem64, size_t align,
+						     uintptr_t *bar_base_addr);
+
+/**
  * @brief Function called to translate an endpoint Base Address Register bus-centric address
  * into Physical address.
  *
@@ -147,6 +166,7 @@ __subsystem struct pcie_ctrl_driver_api {
 	pcie_ctrl_conf_read_t conf_read;
 	pcie_ctrl_conf_write_t conf_write;
 	pcie_ctrl_region_allocate_t region_allocate;
+	pcie_ctrl_region_get_allocate_base_t region_get_allocate_base;
 	pcie_ctrl_region_translate_t region_translate;
 };
 
@@ -215,6 +235,31 @@ static inline bool pcie_ctrl_region_allocate(const struct device *dev, pcie_bdf_
 		(const struct pcie_ctrl_driver_api *)dev->api;
 
 	return api->region_allocate(dev, bdf, mem, mem64, bar_size, bar_bus_addr);
+}
+
+/**
+ * @brief Function called to get the current allocation base of a memory region subset
+ * for an endpoint Base Address Register.
+ *
+ * When enumerating PCIe Endpoints, Type1 bridge endpoints requires a range of memory
+ * allocated by all endpoints in the bridged bus.
+ *
+ * @param dev PCI Express Controller device pointer
+ * @param bdf PCI(e) endpoint
+ * @param mem True if the BAR is of memory type
+ * @param mem64 True if the BAR is of 64bit memory type
+ * @param align size to take in account for alignment
+ * @param bar_base_addr bus-centric address allocation base
+ * @return True if allocation was possible, False if allocation failed
+ */
+static inline bool pcie_ctrl_region_get_allocate_base(const struct device *dev, pcie_bdf_t bdf,
+						      bool mem, bool mem64, size_t align,
+						      uintptr_t *bar_base_addr)
+{
+	const struct pcie_ctrl_driver_api *api =
+		(const struct pcie_ctrl_driver_api *)dev->api;
+
+	return api->region_get_allocate_base(dev, bdf, mem, mem64, align, bar_base_addr);
 }
 
 /**

--- a/include/drivers/pcie/pcie.h
+++ b/include/drivers/pcie/pcie.h
@@ -298,6 +298,67 @@ extern bool pcie_connect_dynamic_irq(pcie_bdf_t bdf,
 	 (((w) & 0x00000006U) == 0x00000002U))
 
 /*
+ * Type 1 Header has files related to bus management
+ */
+#define PCIE_BUS_NUMBER         6U
+
+#define PCIE_BUS_PRIMARY_NUMBER(w)      ((w) & 0xffUL)
+#define PCIE_BUS_SECONDARY_NUMBER(w)    (((w) >> 8) & 0xffUL)
+#define PCIE_BUS_SUBORDINATE_NUMBER(w)  (((w) >> 16) & 0xffUL)
+#define PCIE_SECONDARY_LATENCY_TIMER(w) (((w) >> 24) & 0xffUL)
+
+#define PCIE_BUS_NUMBER_VAL(prim, sec, sub, lat) \
+	(((prim) & 0xffUL) |			 \
+	 (((sec) & 0xffUL) << 8) |		 \
+	 (((sub) & 0xffUL) << 16) |		 \
+	 (((lat) & 0xffUL) << 24))
+
+/*
+ * Type 1 words 7 to 12 setups Bridge Memory base and limits
+ */
+#define PCIE_IO_SEC_STATUS      7U
+
+#define PCIE_IO_BASE(w)         ((w) & 0xffUL)
+#define PCIE_IO_LIMIT(w)        (((w) >> 8) & 0xffUL)
+#define PCIE_SEC_STATUS(w)      (((w) >> 16) & 0xffffUL)
+
+#define PCIE_IO_SEC_STATUS_VAL(iob, iol, sec_status) \
+	(((iob) & 0xffUL) |			     \
+	 (((iol) & 0xffUL) << 8) |		     \
+	 (((sec_status) & 0xffffUL) << 16))
+
+#define PCIE_MEM_BASE_LIMIT     8U
+
+#define PCIE_MEM_BASE(w)        ((w) & 0xffffUL)
+#define PCIE_MEM_LIMIT(w)       (((w) >> 16) & 0xffffUL)
+
+#define PCIE_MEM_BASE_LIMIT_VAL(memb, meml) \
+	(((memb) & 0xffffUL) |		    \
+	 (((meml) & 0xffffUL) << 16))
+
+#define PCIE_PREFETCH_BASE_LIMIT        9U
+
+#define PCIE_PREFETCH_BASE(w)   ((w) & 0xffffUL)
+#define PCIE_PREFETCH_LIMIT(w)  (((w) >> 16) & 0xffffUL)
+
+#define PCIE_PREFETCH_BASE_LIMIT_VAL(pmemb, pmeml) \
+	(((pmemb) & 0xffffUL) |			   \
+	 (((pmeml) & 0xffffUL) << 16))
+
+#define PCIE_PREFETCH_BASE_UPPER        10U
+
+#define PCIE_PREFETCH_LIMIT_UPPER       11U
+
+#define PCIE_IO_BASE_LIMIT_UPPER        12U
+
+#define PCIE_IO_BASE_UPPER(w)   ((w) & 0xffffUL)
+#define PCIE_IO_LIMIT_UPPER(w)  (((w) >> 16) & 0xffffUL)
+
+#define PCIE_IO_BASE_LIMIT_UPPER_VAL(iobu, iolu) \
+	(((iobu) & 0xffffUL) |			 \
+	 (((iolu) & 0xffffUL) << 16))
+
+/*
  * Word 15 contains information related to interrupts.
  *
  * We're only interested in the low byte, which is [supposed to be] set by


### PR DESCRIPTION
This adds support for PCIe Bridge & Switches enumeration.

The actual code only supports PCIe devices on the primary root bus, also known as Root Controller Integrated Endpoints for internal PCIe devices without any external facing ports.

This adds support for Type 1 Bridge devices support and exploration of sub-busses when such devices are enumerated.

Usually bridge enumeration is done recursivelly, but this is not an option with a stack constrained OS like Zephyr.
So a non-recursive algorithm was written to enumerate all the possible bridges.

A new PCIe Controller API is needed to get the current allocation base address in order to configure the Bridges before and after enumeration.

Testing has been done with QEMU, but any Bridge or Switch needs MSI support, so was tested using a version with ITS support changes merged for next release.
A branch with ITS is available here:
https://github.com/superna9999/qemu/tree/gicv3-its-v8