### PR TITLE
Bluetooth: Controller: Fix build for hci_uart sample with new LLCP

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -46,6 +46,10 @@
 
 #include "ll_sw/isoal.h"
 
+#if !defined(CONFIG_BT_LL_SW_LLCP_LEGACY)
+#include "ull_tx_queue.h"
+#endif
+
 #include "ll_sw/ull_adv_types.h"
 #include "ll_sw/ull_scan_types.h"
 #include "ll_sw/ull_sync_types.h"
@@ -53,10 +57,6 @@
 #include "ll_sw/ull_iso_types.h"
 #include "ll_sw/ull_conn_iso_types.h"
 #include "ll_sw/ull_df_types.h"
-
-#if !defined(CONFIG_BT_LL_SW_LLCP_LEGACY)
-#include "ull_tx_queue.h"
-#endif
 
 #include "ll_sw/ull_adv_internal.h"
 #include "ll_sw/ull_sync_internal.h"


### PR DESCRIPTION
ull_tx_queue.h needs to be included before ll_sw/ull_conn_types.h

zephyr/zephyr/subsys/bluetooth/controller/hci/hci.c
In file included from zephyr/zephyr/subsys/bluetooth/controller/hci/hci.c:52:
../../subsys/bluetooth/controller/./ll_sw/ull_conn_types.h:453:18: error: field 'tx_q' has incomplete type
  453 |  struct ull_tx_q tx_q;
      |                  ^~~~

Signed-off-by: Szymon Janc <szymon.janc@codecoup.pl>