### PR TITLE
tests: remove device PM tests from kernel tests

### DIFF
--- a/tests/kernel/device/src/dummy_driver.c
+++ b/tests/kernel/device/src/dummy_driver.c
@@ -6,7 +6,6 @@
 
 #include <zephyr.h>
 #include <device.h>
-#include <pm/device.h>
 
 
 #define DUMMY_DRIVER_NAME	"dummy_driver"
@@ -33,19 +32,11 @@ int dummy_init(const struct device *dev)
 	return 0;
 }
 
-int dummy_pm_action(const struct device *dev, enum pm_device_action action)
-{
-	return 0;
-}
-
 /**
  * @cond INTERNAL_HIDDEN
  */
-PM_DEVICE_DEFINE(dummy_driver, dummy_pm_action);
-
-DEVICE_DEFINE(dummy_driver, DUMMY_DRIVER_NAME, dummy_init,
-		PM_DEVICE_REF(dummy_driver), NULL, NULL, POST_KERNEL,
-		CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &funcs);
+DEVICE_DEFINE(dummy_driver, DUMMY_DRIVER_NAME, dummy_init, NULL, NULL, NULL,
+	      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &funcs);
 
 /**
  * @endcond

--- a/tests/subsys/pm/power_mgmt/src/main.c
+++ b/tests/subsys/pm/power_mgmt/src/main.c
@@ -366,6 +366,32 @@ void test_device_order(void)
 	testing_device_order = false;
 }
 
+/**
+ * @brief Test the device busy APIs.
+ */
+void test_busy(void)
+{
+	bool busy;
+
+	busy = pm_device_is_any_busy();
+	zassert_false(busy, NULL);
+
+	pm_device_busy_set(device_dummy);
+
+	busy = pm_device_is_any_busy();
+	zassert_true(busy, NULL);
+
+	busy = pm_device_is_busy(device_dummy);
+	zassert_true(busy, NULL);
+
+	pm_device_busy_clear(device_dummy);
+
+	busy = pm_device_is_any_busy();
+	zassert_false(busy, NULL);
+
+	busy = pm_device_is_busy(device_dummy);
+	zassert_false(busy, NULL);
+}
 
 void test_main(void)
 {
@@ -376,7 +402,8 @@ void test_main(void)
 			 ztest_1cpu_unit_test(test_power_idle),
 			 ztest_1cpu_unit_test(test_power_state_trans),
 			 ztest_1cpu_unit_test(test_device_order),
-			 ztest_1cpu_unit_test(test_power_state_notification));
+			 ztest_1cpu_unit_test(test_power_state_notification),
+			 ztest_1cpu_unit_test(test_busy));
 	ztest_run_test_suite(power_management_test);
 	pm_notifier_unregister(&notifier);
 }


### PR DESCRIPTION
```
tests: kernel: device: remove PM related tests 

The PM subsystem is tested in tests/subsys/pm, the removed tests were
not relevant for devices. The test_build_suspend_device_list test has
been renamed to test_device_list since the API is not strictly related
to PM (and does not depend on it).
```

 ```
tests: subsys: pm: add device busy API test 

Add a test case for the device PM busy API (previously part of kernel
device tests).
```