### PR TITLE
stm32: clock_configuration: Add test suite

### DIFF
--- a/tests/drivers/clock_control/stm32_clock_configuration/CMakeLists.txt
+++ b/tests/drivers/clock_control/stm32_clock_configuration/CMakeLists.txt
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(stm32_clock_configuration)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/clock_control/stm32_clock_configuration/boards/b_u585i_iot02a_msis_24.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/boards/b_u585i_iot02a_msis_24.overlay
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay relies on initial board configuration.
+ *          For clarity, nodes are over written instead of deleted.
+ *          Any change to board configuration has impact on this file.
+ */
+
+&clk_lse {
+	status = "okay";
+};
+
+&clk_msis {
+	status = "okay";
+	msi-range = <1>;			/* Range 1: 24MHz */
+	msi-pll-mode;
+};
+
+&pll1 { 					/* PLL disabled */
+	/delete-property/ div-m;
+	/delete-property/ mul-n;
+	/delete-property/ div-q;
+	/delete-property/ div-r;
+	/delete-property/ clocks;
+	status = "disabled";
+};
+
+&rcc {
+	clocks = <&clk_msis>;			/* clck src MSIS */
+	clock-frequency = <DT_FREQ_M(24)>;	/* clck freq 24MHz */
+	ahb-prescaler = <1>;
+	apb1-prescaler = <1>;
+	apb2-prescaler = <1>;
+	apb3-prescaler = <1>;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/boards/b_u585i_iot02a_msis_48.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/boards/b_u585i_iot02a_msis_48.overlay
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay relies on initial board configuration.
+ *          For clarity, nodes are over written instead of deleted.
+ *          Any change to board configuration has impact on this file.
+ */
+
+&clk_lse {
+	status = "okay";
+};
+
+&clk_msis {
+	status = "okay";
+	msi-range = <0>;			/* Range 0: 48MHz */
+	msi-pll-mode;
+};
+
+&pll1 { 					/* PLL disabled */
+	/delete-property/ div-m;
+	/delete-property/ mul-n;
+	/delete-property/ div-q;
+	/delete-property/ div-r;
+	/delete-property/ clocks;
+	status = "disabled";
+};
+
+&rcc {
+	clocks = <&clk_msis>;			/* clck src MSIS */
+	clock-frequency = <DT_FREQ_M(48)>;	/* clck freq 48MHz */
+	ahb-prescaler = <1>;
+	apb1-prescaler = <1>;
+	apb2-prescaler = <1>;
+	apb3-prescaler = <1>;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/boards/b_u585i_iot02a_pll_hsi_160.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/boards/b_u585i_iot02a_pll_hsi_160.overlay
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay relies on initial board configuration.
+ *          For clarity, nodes are over written instead of deleted.
+ *          Any change to board configuration has impact on this file.
+ */
+
+&clk_lse {
+	status = "disabled";			/* LSE disabled */
+};
+
+&clk_msis {					/* MSI disabled */
+	status = "disabled";
+	/delete-property/ msi-range;
+	/delete-property/ msi-pll-mode;
+};
+
+&clk_hsi {					/* HSI enabled */
+	status = "okay";
+};
+
+&pll1 {
+	div-m = <4>;				/* Update PLL config */
+	mul-n = <40>;
+	div-q = <2>;
+	div-r = <1>;
+	clocks = <&clk_hsi>;			/* PLL src HSI */
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&pll1>;
+	clock-frequency = <DT_FREQ_M(160)>;	/* clck freq 40MHz */
+	ahb-prescaler = <1>;
+	apb1-prescaler = <1>;
+	apb2-prescaler = <1>;
+	apb3-prescaler = <1>;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/boards/b_u585i_iot02a_pll_hsi_40.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/boards/b_u585i_iot02a_pll_hsi_40.overlay
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay relies on initial board configuration.
+ *          For clarity, nodes are over written instead of deleted.
+ *          Any change to board configuration has impact on this file.
+ */
+
+&clk_lse {
+	status = "disabled";			/* LSE disabled */
+};
+
+&clk_msis {					/* MSI disabled */
+	status = "disabled";
+	/delete-property/ msi-range;
+	/delete-property/ msi-pll-mode;
+};
+
+&clk_hsi {					/* HSI enabled */
+	status = "okay";
+};
+
+&pll1 {
+	div-m = <4>;				/* Update PLL config */
+	mul-n = <10>;
+	div-q = <2>;
+	div-r = <1>;
+	clocks = <&clk_hsi>;			/* PLL src HSI */
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&pll1>;
+	clock-frequency = <DT_FREQ_M(40)>;	/* clck freq 40MHz */
+	ahb-prescaler = <1>;
+	apb1-prescaler = <1>;
+	apb2-prescaler = <1>;
+	apb3-prescaler = <1>;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/boards/b_u585i_iot02a_pll_msi_80.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/boards/b_u585i_iot02a_pll_msi_80.overlay
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay relies on initial board configuration.
+ *          For clarity, nodes are over written instead of deleted.
+ *          Any change to board configuration has impact on this file.
+ */
+
+&clk_lse {
+	status = "okay";
+};
+
+&clk_msis {
+	status = "okay";
+	msi-range = <4>;
+	msi-pll-mode;
+};
+
+&pll1 {
+	div-m = <2>;				/* Update PLL config */
+	mul-n = <40>;
+	div-q = <2>;
+	div-r = <1>;
+	clocks = <&clk_msis>;
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&pll1>;
+	clock-frequency = <DT_FREQ_M(80)>;	/* clck freq 80MHz */
+	ahb-prescaler = <1>;
+	apb1-prescaler = <1>;
+	apb2-prescaler = <1>;
+	apb3-prescaler = <1>;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/boards/nucleo_u575zi_q_pll_hse_160.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/boards/nucleo_u575zi_q_pll_hse_160.overlay
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay relies on initial board configuration.
+ *          For clarity, nodes are over written instead of deleted.
+ *          Any change to board configuration has impact on this file.
+ */
+
+/*
+ * Warning: HSE is not implmeneed on the board, hence:
+ *          This configuration is only available for build
+ */
+
+&clk_lse {
+	status = "disabled";			/* LSE disabled */
+};
+
+&clk_msis {					/* MSI disabled */
+	status = "disabled";
+	/delete-property/ msi-range;
+	/delete-property/ msi-pll-mode;
+};
+
+&clk_hse {					/* HSE enabled */
+	status = "okay";
+	clock-frequency = <DT_FREQ_M(16)>;	/* HSE clk freq 16MHz */
+	hse-bypass;
+};
+
+&pll1 {
+	div-m = <4>;				/* Update PLL config */
+	mul-n = <40>;
+	div-q = <2>;
+	div-r = <1>;
+	clocks = <&clk_hse>;			/* PLL src HSE */
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&pll>;
+	clock-frequency = <DT_FREQ_M(160)>;
+	ahb-prescaler = <1>;
+	apb1-prescaler = <1>;
+	apb2-prescaler = <1>;
+	apb3-prescaler = <1>;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/prj.conf
+++ b/tests/drivers/clock_control/stm32_clock_configuration/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/drivers/clock_control/stm32_clock_configuration/src/test_stm32_clock_configuration.c
+++ b/tests/drivers/clock_control/stm32_clock_configuration/src/test_stm32_clock_configuration.c
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2021 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <ztest.h>
+#include <soc.h>
+#include <drivers/clock_control.h>
+#include <drivers/clock_control/stm32_clock_control.h>
+#include <logging/log.h>
+LOG_MODULE_REGISTER(test);
+
+static void test_sysclk_freq(void)
+{
+	uint32_t soc_sys_clk_freq;
+
+	soc_sys_clk_freq = HAL_RCC_GetSysClockFreq();
+
+	zassert_equal(CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC, soc_sys_clk_freq,
+			"Expected sysclockfreq: %d. Actual sysclockfreq: %d",
+			CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC, soc_sys_clk_freq);
+}
+
+static void test_sysclk_src(void)
+{
+	int sys_clk_src = __HAL_RCC_GET_SYSCLK_SOURCE();
+
+#if STM32_SYSCLK_SRC_PLL
+	zassert_equal(RCC_SYSCLKSOURCE_STATUS_PLLCLK, sys_clk_src,
+			"Expected sysclk src: PLL1. Actual sysclk src: %d",
+			sys_clk_src);
+#elif STM32_SYSCLK_SRC_HSE
+	zassert_equal(RCC_SYSCLKSOURCE_STATUS_HSE, sys_clk_src,
+			"Expected sysclk src: HSE. Actual sysclk src: %d",
+			sys_clk_src);
+#elif STM32_SYSCLK_SRC_HSI
+	zassert_equal(RCC_SYSCLKSOURCE_STATUS_HSI, sys_clk_src,
+			"Expected sysclk src: HSI. Actual sysclk src: %d",
+			sys_clk_src);
+#elif STM32_SYSCLK_SRC_MSIS
+	zassert_equal(RCC_SYSCLKSOURCE_STATUS_MSI, sys_clk_src,
+			"Expected sysclk src: MSI. Actual sysclk src: %d",
+			sys_clk_src);
+#else
+	/* Case not expected */
+	zassert_true((STM32_SYSCLK_SRC_PLL ||
+		      STM32_SYSCLK_SRC_HSE ||
+		      STM32_SYSCLK_SRC_HSI ||
+		      STM32_SYSCLK_SRC_MSIS),
+		      "Not expected. sys_clk_src: %d\n", sys_clk_src);
+#endif
+
+}
+
+static void test_pll_src(void)
+{
+	uint32_t pll_src = __HAL_RCC_GET_PLL_OSCSOURCE();
+
+#if STM32_PLL_SRC_HSE
+	zassert_equal(RCC_PLLSOURCE_HSE, pll_src,
+			"Expected PLL src: HSE. Actual PLL src: %d",
+			pll_src);
+#elif STM32_PLL_SRC_HSI
+	zassert_equal(RCC_PLLSOURCE_HSI, pll_src,
+			"Expected PLL src: HSI. Actual PLL src: %d",
+			pll_src);
+#elif STM32_PLL_SRC_MSIS
+	zassert_equal(RCC_PLLSOURCE_MSI, pll_src,
+			"Expected PLL src: MSI. Actual PLL src: %d",
+			pll_src);
+#else
+	zassert_equal(RCC_PLLSOURCE_NONE, pll_src,
+			"Expected PLL src: None. Actual PLL src: %d",
+			pll_src);
+#endif
+
+}
+
+void test_main(void)
+{
+	ztest_test_suite(test_stm32_syclck_config,
+		ztest_unit_test(test_sysclk_freq),
+		ztest_unit_test(test_sysclk_src),
+		ztest_unit_test(test_pll_src)
+			 );
+	ztest_run_test_suite(test_stm32_syclck_config);
+}

--- a/tests/drivers/clock_control/stm32_clock_configuration/testcase.yaml
+++ b/tests/drivers/clock_control/stm32_clock_configuration/testcase.yaml
@@ -1,0 +1,29 @@
+tests:
+  drivers.stm32_clock_configuration.u5.sysclksrc_pll_msis_160:
+    timeout: 5
+    platform_allow: b_u585i_iot02a
+  drivers.stm32_clock_configuration.u5.sysclksrc_pll_msis_80:
+    extra_args: DTC_OVERLAY_FILE=boards/b_u585i_iot02a_pll_msi_80.overlay
+    timeout: 5
+    platform_allow: b_u585i_iot02a
+  drivers.stm32_clock_configuration.u5.sysclksrc_pll_hsi_160:
+    extra_args: DTC_OVERLAY_FILE=boards/b_u585i_iot02a_pll_hsi_160.overlay
+    platform_allow: b_u585i_iot02a
+    timeout: 5
+  drivers.stm32_clock_configuration.u5.sysclksrc_pll_hsi_40:
+    extra_args: DTC_OVERLAY_FILE=boards/b_u585i_iot02a_pll_hsi_40.overlay
+    platform_allow: b_u585i_iot02a
+    timeout: 5
+  drivers.stm32_clock_configuration.u5.sysclksrc_msis_48:
+    extra_args: DTC_OVERLAY_FILE=boards/b_u585i_iot02a_msis_48.overlay
+    platform_allow: b_u585i_iot02a
+    timeout: 5
+  drivers.stm32_clock_configuration.u5.sysclksrc_msis_24:
+    extra_args: DTC_OVERLAY_FILE=boards/b_u585i_iot02a_msis_24.overlay
+    platform_allow: b_u585i_iot02a
+    timeout: 5
+  drivers.stm32_clock_configuration.u5.sysclksrc_pll_hse_160:
+    extra_args: DTC_OVERLAY_FILE=boards/nucleo_u575zi_q_pll_hse_160.overlay
+    timeout: 5
+    platform_allow: nucleo_u575zi_q
+    build_only: true # Build only as HSE not implemened on the board


### PR DESCRIPTION
Add a test suite for stm32 clock configuration driver.

For now limited to stm32u5 as a demonstrator, it relies on STM32Cube HAL to check target clock configuration is programmed as expected. Overlays are added to propose various test configurations.

Additionally, add a change on stm32u5 VCO configuration.