### PR TITLE
tests: kernel: device: add missing include

### DIFF
--- a/tests/kernel/device/src/dummy_driver.c
+++ b/tests/kernel/device/src/dummy_driver.c
@@ -6,6 +6,7 @@
 
 #include <zephyr.h>
 #include <device.h>
+#include <pm/device.h>
 
 
 #define DUMMY_DRIVER_NAME	"dummy_driver"

--- a/tests/kernel/device/src/main.c
+++ b/tests/kernel/device/src/main.c
@@ -9,6 +9,7 @@
 #include <init.h>
 #include <ztest.h>
 #include <sys/printk.h>
+#include <pm/device.h>
 #include <pm/device_runtime.h>
 #include <linker/sections.h>
 #include "abstract_driver.h"


### PR DESCRIPTION
<pm/device.h> header is now required after #40693, this test was missed.