### PR TITLE
testsuite: ztest: Do logging flush only when default thread is used

### DIFF
--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -380,8 +380,10 @@ static int run_test(struct unit_test *test)
 	test->teardown();
 	phase = TEST_PHASE_FRAMEWORK;
 
-	/* Flush all logs in case deferred mode is used. */
-	while (IS_ENABLED(CONFIG_TEST_LOGGING_FLUSH_AFTER_TEST) && log_data_pending()) {
+	/* Flush all logs in case deferred mode and default logging thread are used. */
+	while (IS_ENABLED(CONFIG_TEST_LOGGING_FLUSH_AFTER_TEST) &&
+	       IS_ENABLED(CONFIG_LOG_PROCESS_THREAD) &&
+	       log_data_pending()) {
 		k_msleep(100);
 	}
 


### PR DESCRIPTION
Add guard to not pend until all logs are flushed when default
logging thread is disabled. In that case, logging has no control
where logs are processed and sleeping may not lead to flushing
log data. That may result in test hanging.

Fixes #40724.

It is a fixup to #40452 where flushing after each test case was introduced.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>