### PR TITLE
west: add "--save-temps" parameter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,12 @@ endif()
 # Apply the final optimization flag(s)
 zephyr_compile_options(${OPTIMIZATION_FLAG})
 
+# Save temporary objects if needed
+option(COMPILER_SAVE_TEMPS "Save temporary objects" OFF)
+if(COMPILER_SAVE_TEMPS)
+  zephyr_compile_options(-save-temps=obj)
+endif()
+
 # @Intent: Obtain compiler specific flags related to C++ that are not influenced by kconfig
 zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:$<TARGET_PROPERTY:compiler-cpp,required>>)
 

--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -122,6 +122,9 @@ class Build(Forceable):
         group.add_argument('-n', '--just-print', '--dry-run', '--recon',
                             dest='dry_run', action='store_true',
                             help="just print build commands; don't run them")
+        group.add_argument('--save-temps',
+                            dest='save_temps', action='store_true',
+                            help="save temporary objects created by compiler")
 
         group = parser.add_argument_group('pristine builds',
                                           PRISTINE_DESCRIPTION)
@@ -152,6 +155,12 @@ class Build(Forceable):
                 level=log.VERBOSE_EXTREME)
         self._sanity_precheck()
         self._setup_build_dir()
+
+        if self.args.save_temps:
+            if self.args.cmake_opts:
+                self.args.cmake_opts.append("-DCOMPILER_SAVE_TEMPS=ON")
+            else:
+                self.args.cmake_opts = ["-DCOMPILER_SAVE_TEMPS=ON"]
 
         if args.pristine is not None:
             pristine = args.pristine


### PR DESCRIPTION
Add option that tells compiler to save temporary objects files.
This may be useful when debugging or writing device-tree related
logic. It allows to easily introspect the resolution of macros
done by the preprocessor.

Signed-off-by: Michał Barnaś <mb@semihalf.com>