### PR TITLE
samples: prod_consumer: use app_shared.h instead of main.h

### DIFF
--- a/samples/userspace/prod_consumer/src/app_a.c
+++ b/samples/userspace/prod_consumer/src/app_a.c
@@ -10,7 +10,7 @@
 #include <logging/log.h>
 
 #include "sample_driver.h"
-#include "main.h"
+#include "app_shared.h"
 #include "app_a.h"
 #include "app_syscall.h"
 

--- a/samples/userspace/prod_consumer/src/app_b.c
+++ b/samples/userspace/prod_consumer/src/app_b.c
@@ -8,7 +8,7 @@
 #include <sys/libc-hooks.h>
 #include <logging/log.h>
 
-#include "main.h"
+#include "app_shared.h"
 #include "app_b.h"
 
 LOG_MODULE_REGISTER(app_b);

--- a/samples/userspace/prod_consumer/src/app_shared.c
+++ b/samples/userspace/prod_consumer/src/app_shared.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2019 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "app_shared.h"
+
+/* Define the shared partition, which will contain a memory region that
+ * will be accessible by both applications A and B.
+ */
+K_APPMEM_PARTITION_DEFINE(shared_partition);
+
+/* Define a memory pool to place in the shared area.
+ */
+K_APP_DMEM(shared_partition) struct sys_heap shared_pool;
+K_APP_DMEM(shared_partition) uint8_t shared_pool_mem[HEAP_BYTES];
+
+/* queues for exchanging data between App A and App B */
+K_QUEUE_DEFINE(shared_queue_incoming);
+K_QUEUE_DEFINE(shared_queue_outgoing);

--- a/samples/userspace/prod_consumer/src/app_shared.h
+++ b/samples/userspace/prod_consumer/src/app_shared.h
@@ -4,18 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef MAIN_H
-#define MAIN_H
+#ifndef APP_SHARED_H
+#define APP_SHARED_H
 
 #include <kernel.h>
 #include <app_memory/app_memdomain.h>
 #include <sys/sys_heap.h>
 
+#include "sample_driver.h"
+
+#define BLK_SIZE (SAMPLE_DRIVER_MSG_SIZE + sizeof(void *))
+
+#define HEAP_BYTES (BLK_SIZE * 16)
+
 extern struct k_mem_partition shared_partition;
-#define SHARED_DATA	K_APP_DMEM(shared_partition)
-#define SHARED_BSS	K_APP_BMEM(shared_partition)
 
 extern struct sys_heap shared_pool;
+extern uint8_t shared_pool_mem[HEAP_BYTES];
 extern struct k_queue shared_queue_incoming;
 extern struct k_queue shared_queue_outgoing;
 

--- a/samples/userspace/prod_consumer/src/main.c
+++ b/samples/userspace/prod_consumer/src/main.c
@@ -5,14 +5,11 @@
  */
 
 #include <kernel.h>
-#include <device.h>
 #include <sys/printk.h>
-#include <app_memory/app_memdomain.h>
 #include <sys/libc-hooks.h>
 #include <logging/log.h>
 
-#include "main.h"
-#include "sample_driver.h"
+#include "app_shared.h"
 #include "app_a.h"
 #include "app_b.h"
 
@@ -21,31 +18,13 @@
 
 LOG_MODULE_REGISTER(app_main);
 
-/* Define the shared partition, which will contain a memory region that
- * will be accessible by both applications A and B.
- */
-K_APPMEM_PARTITION_DEFINE(shared_partition);
-
-/* Define a memory pool to place in the shared area.
- */
-#define BLK_SIZE (SAMPLE_DRIVER_MSG_SIZE + sizeof(void *))
-
-#define HEAP_BYTES (BLK_SIZE * 16)
-
-K_APP_DMEM(shared_partition) struct sys_heap shared_pool;
-K_APP_DMEM(shared_partition) uint8_t shared_pool_mem[HEAP_BYTES];
-
-/* queues for exchanging data between App A and App B */
-K_QUEUE_DEFINE(shared_queue_incoming);
-K_QUEUE_DEFINE(shared_queue_outgoing);
-
 /* Define a thread for the root of application A.
- * We don't do this for Application B, instead we re-use the main thread
- * for it.
  */
 struct k_thread app_a_thread;
 K_THREAD_STACK_DEFINE(app_a_stack, APP_A_STACKSIZE);
 
+/* Define a thread for the root of application B.
+ */
 struct k_thread app_b_thread;
 K_THREAD_STACK_DEFINE(app_b_stack, APP_B_STACKSIZE);
 
@@ -55,6 +34,8 @@ void main(void)
 
 	LOG_INF("APP A partition: %p %zu", (void *)app_a_partition.start,
 		(size_t)app_a_partition.size);
+	LOG_INF("APP B partition: %p %zu", (void *)app_b_partition.start,
+		(size_t)app_b_partition.size);
 	LOG_INF("Shared partition: %p %zu", (void *)shared_partition.start,
 		(size_t)shared_partition.size);
 #ifdef Z_LIBC_PARTITION_EXISTS
@@ -69,7 +50,7 @@ void main(void)
 				   -1, K_INHERIT_PERMS, K_NO_WAIT);
 
 	/* Spawn supervisor entry for application B */
-	thread_b = k_thread_create(&app_b_thread, app_b_stack, APP_A_STACKSIZE,
+	thread_b = k_thread_create(&app_b_thread, app_b_stack, APP_B_STACKSIZE,
 				   app_b_entry, NULL, NULL, NULL,
 				   -1, K_INHERIT_PERMS, K_NO_WAIT);
 


### PR DESCRIPTION
Normally main.c file doesn't have a header file, because it doesn't
need to declare any interfaces to other modules.

In this sample, it's better to put the shared variables in one place,
and provide the interfaces to other modules, such as app_a, app_b,
and main.

Signed-off-by: Paul He <pawpawhe@gmail.com>