### PR TITLE
intel_adsp bootloader minification

### DIFF
--- a/soc/xtensa/intel_adsp/common/bootloader/boot_entry.S
+++ b/soc/xtensa/intel_adsp/common/bootloader/boot_entry.S
@@ -58,8 +58,8 @@ l2_cache_pref:
 	.word SHIM_L2_PREF_CFG
 #endif
 
-sof_stack_base:
-	.word L2_SRAM_BASE + L2_SRAM_SIZE
+imr_stack_base:
+	.word CONFIG_IMR_MANIFEST_ADDR
 
 wnd0_base:
 	.word DT_REG_ADDR(DT_NODELABEL(win))
@@ -184,7 +184,7 @@ boot_init:
 #endif
 
 	/* reprogram stack to the area defined by main FW */
-	l32r	a3, sof_stack_base
+	l32r	a3, imr_stack_base
 	mov	sp, a3
 
 	/* set status register to 0x00000005 in wnd0 */

--- a/soc/xtensa/intel_adsp/common/include/cavs-mem.h
+++ b/soc/xtensa/intel_adsp/common/include/cavs-mem.h
@@ -23,31 +23,8 @@
 #define HP_SRAM_WIN3_BASE (L2_SRAM_BASE + CONFIG_ADSP_WIN3_OFFSET)
 #define HP_SRAM_WIN3_SIZE 0x2000
 
-/* IMR memory layout in the bootloader.  Sort of needlessly complex to
- * put all these sections in specific sized regions, it's all the same
- * memory and the bootloader doesn't do any mapping or protection
- * management
- */
 #define IMR_BOOT_LDR_MANIFEST_BASE CONFIG_IMR_MANIFEST_ADDR
-#define IMR_BOOT_LDR_DATA_BASE     CONFIG_IMR_DATA_ADDR
-#define IMR_BOOT_LDR_BSS_BASE      0xb0100000
-
-#define IMR_BOOT_LDR_TEXT_ENTRY_SIZE 0x0120
-#define IMR_BOOT_LDR_LIT_SIZE        0x0100
-#define IMR_BOOT_LDR_TEXT_SIZE       0x1c00
-#define IMR_BOOT_LDR_DATA_SIZE       0x1000
-#define BOOT_LDR_STACK_SIZE          0x4000
-
-#ifdef CONFIG_SOC_SERIES_INTEL_CAVS_V15
-# define IMR_BOOT_LDR_BSS_SIZE       0x10000 /* (vestigial typo?) */
-#else
-# define IMR_BOOT_LDR_BSS_SIZE       0x1000
-#endif
-
 #define IMR_BOOT_LDR_TEXT_ENTRY_BASE (IMR_BOOT_LDR_MANIFEST_BASE + 0x6000)
-#define IMR_BOOT_LDR_LIT_BASE (IMR_BOOT_LDR_TEXT_ENTRY_BASE + IMR_BOOT_LDR_TEXT_ENTRY_SIZE)
-#define IMR_BOOT_LDR_TEXT_BASE (IMR_BOOT_LDR_LIT_BASE + IMR_BOOT_LDR_LIT_SIZE)
-#define BOOT_LDR_STACK_BASE (L2_SRAM_BASE + L2_SRAM_SIZE - BOOT_LDR_STACK_SIZE)
 
 /* These are fake section addresses used only in the linker scripts */
 #define IDT_BASE		(L2_SRAM_BASE + L2_SRAM_SIZE)


### PR DESCRIPTION
This is another, much smaller cleanup pass that sits before other stuff I'm working on.

This shrinks the bootloader a bit, vastly simplifies the linkage (in preparation for moving it into the main Zephyr build), and moves the very early stack into IMR memory so that (in a future patch) we can run C code before the SRAM is powered up.