### PR TITLE
samples: stm32 power mngt enters low power

### DIFF
--- a/samples/boards/stm32/power_mgmt/blinky/src/main.c
+++ b/samples/boards/stm32/power_mgmt/blinky/src/main.c
@@ -23,9 +23,6 @@ void main(void)
 
 	printk("Device ready\n");
 
-	/* Don't let the system power off / low power this device */
-	pm_device_busy_set(led.port);
-
 	while (true) {
 		gpio_pin_configure_dt(&led, GPIO_OUTPUT_ACTIVE);
 		gpio_pin_set(led.port, led.pin, (int)led_is_on);


### PR DESCRIPTION
Remove this line because the pm_device_busy_set function will
prevent the system to enter low power.
This sample application wants to.

Signed-off-by: Francois Ramu <francois.ramu@st.com>