### PR TITLE
test: device: Specify address and size cells.

### DIFF
--- a/tests/kernel/device/app.overlay
+++ b/tests/kernel/device/app.overlay
@@ -14,6 +14,9 @@
  */
 
 / {
+	#address-cells = <1>;
+	#size-cells = <1>;
+
 	fakedriver@E0000000 {
 		compatible = "fakedriver";
 		reg = <0xE0000000 0x2000>;


### PR DESCRIPTION
The test is wrongly assuming that all the archs have #address-cells =
<1> and #size-cells = <1> at the DT root. This is not always true, and
it makes the test failing for AArch64. Fix the wrong assumption.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>