### PR TITLE
tests: m2gl025_miv: exclude slow platform from some tests

### DIFF
--- a/tests/crypto/tinycrypt/testcase.yaml
+++ b/tests/crypto/tinycrypt/testcase.yaml
@@ -1,7 +1,7 @@
 tests:
   crypto.tinycrypt:
     tags: tinycrypt crypto aes ccm
-    platform_exclude: qemu_arc_em qemu_arc_hs intel_adsp_cavs15
+    platform_exclude: qemu_arc_em qemu_arc_hs intel_adsp_cavs15 m2gl025_miv
     timeout: 300
     integration_platforms:
       - native_posix

--- a/tests/crypto/tinycrypt_hmac_prng/testcase.yaml
+++ b/tests/crypto/tinycrypt_hmac_prng/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   crypto.tinycrypt.hmac_prng:
     tags: tinycrypt crypto sha256 hmac prng
-    platform_exclude: mec15xxevb_assy6853 mec1501modular_assy6885
+    platform_exclude: mec15xxevb_assy6853 mec1501modular_assy6885 m2gl025_miv
     integration_platforms:
       - native_posix

--- a/tests/lib/time/testcase.yaml
+++ b/tests/lib/time/testcase.yaml
@@ -2,5 +2,6 @@ tests:
   libraries.libc.time:
     tags: libc
     filter: not CONFIG_ARCH_POSIX or CONFIG_NATIVE_POSIX_SLOWDOWN_TO_REAL_TIME
+    timeout: 180
     integration_platforms:
       - mps2_an385


### PR DESCRIPTION
This platform is slow on some tests and times out on non-hardware
related tests, so exclude it or increase timeout for some of the tests
to avoid false negatives in the test results due to timeouts.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
