### PR TITLE
soc: rt6xx: Default Flexspi logging to disabled

### DIFF
--- a/soc/arm/nxp_imx/rt6xx/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt6xx/Kconfig.defconfig.series
@@ -33,6 +33,19 @@ config ADC_MCUX_LPADC
 	default y if HAS_MCUX_LPADC
 	depends on ADC
 
+if FLASH_MCUX_FLEXSPI_XIP
+
+# Avoid RWW hazards by defaulting logging to disabled
+choice FLASH_LOG_LEVEL_CHOICE
+	default FLASH_LOG_LEVEL_OFF
+endchoice
+
+choice MEMC_LOG_LEVEL_CHOICE
+	default MEMC_LOG_LEVEL_OFF
+endchoice
+
+endif
+
 #
 # MBEDTLS is larger but much faster than TinyCrypt so choose wisely
 #


### PR DESCRIPTION
RT600 uses the mcux flexspi driver, which can produce RWW hazards when calling code linked into flash (such as the logging subsystem). Disable logging in flexspi driver by default for RT600 series, to prevent RWW hazards and fix the CI failure this warning produces

Fixes #40744