### PR TITLE
drivers: display: st7789v: Remove explicit cast

### DIFF
--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -113,7 +113,7 @@ static void st7789v_reset_display(struct st7789v_data *data)
 
 static int st7789v_blanking_on(const struct device *dev)
 {
-	struct st7789v_data *data = (struct st7789v_data *)dev->data;
+	struct st7789v_data *data = dev->data;
 
 	st7789v_transmit(data, ST7789V_CMD_DISP_OFF, NULL, 0);
 	return 0;
@@ -121,7 +121,7 @@ static int st7789v_blanking_on(const struct device *dev)
 
 static int st7789v_blanking_off(const struct device *dev)
 {
-	struct st7789v_data *data = (struct st7789v_data *)dev->data;
+	struct st7789v_data *data = dev->data;
 
 	st7789v_transmit(data, ST7789V_CMD_DISP_ON, NULL, 0);
 	return 0;
@@ -159,7 +159,7 @@ static int st7789v_write(const struct device *dev,
 			 const struct display_buffer_descriptor *desc,
 			 const void *buf)
 {
-	struct st7789v_data *data = (struct st7789v_data *)dev->data;
+	struct st7789v_data *data = dev->data;
 	const uint8_t *write_data_start = (uint8_t *) buf;
 	struct spi_buf tx_buf;
 	struct spi_buf_set tx_bufs;
@@ -221,7 +221,7 @@ static int st7789v_set_contrast(const struct device *dev,
 static void st7789v_get_capabilities(const struct device *dev,
 			      struct display_capabilities *capabilities)
 {
-	struct st7789v_data *data = (struct st7789v_data *)dev->data;
+	struct st7789v_data *data = dev->data;
 
 	memset(capabilities, 0, sizeof(struct display_capabilities));
 	capabilities->x_resolution = data->width;
@@ -334,7 +334,7 @@ static void st7789v_lcd_init(struct st7789v_data *data)
 
 static int st7789v_init(const struct device *dev)
 {
-	struct st7789v_data *data = (struct st7789v_data *)dev->data;
+	struct st7789v_data *data = dev->data;
 
 	data->spi_dev = device_get_binding(DT_INST_BUS_LABEL(0));
 	if (data->spi_dev == NULL) {
@@ -400,7 +400,7 @@ static int st7789v_init(const struct device *dev)
 static int st7789v_pm_action(const struct device *dev,
 			     enum pm_device_action action)
 {
-	struct st7789v_data *data = (struct st7789v_data *)dev->data;
+	struct st7789v_data *data = dev->data;
 	int ret = 0;
 
 	switch (action) {


### PR DESCRIPTION
Remove explicit cast of `data`.

Signed-off-by: Casper Meijn <casper@meijn.net>