### PR TITLE
Bluetooth: Controller: Fix erroneous merge conflict resolution

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -310,7 +310,6 @@ struct node_rx_ftr {
 				*/
 		void *aux_ptr;
 		uint8_t aux_phy;
-		uint8_t aux_sched;
 		struct cte_conn_iq_report *iq_report;
 	};
 	uint32_t ticks_anchor;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -422,12 +422,6 @@ static int prepare_cb(struct lll_prepare_param *p)
 	lll_aux = p->param;
 	lll = ull_scan_aux_lll_parent_get(lll_aux, &is_lll_scan);
 
-	/* Initialize scanning state */
-	lll_aux->state = 0U;
-
-	/* Reset Tx/rx count */
-	trx_cnt = 0U;
-
 #if defined(CONFIG_BT_CTLR_SYNC_PERIODIC)
 	/* Check if this aux scan is for periodic advertising train */
 	if (!is_lll_scan) {
@@ -455,7 +449,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 #endif /* CONFIG_BT_CENTRAL */
 
 	/* Initialize scanning state */
-	lll->state = 0U;
+	lll_aux->state = 0U;
 
 	/* Reset Tx/rx count */
 	trx_cnt = 0U;


### PR DESCRIPTION
Fix erroneous merge conflict resolution.

Regression in commit f023b5f611df ("Bluetooth: controller:
push topic branch to main") and
commit 2e2900f1bb4f ("Bluetooth: controller: revert
erroneous deletion").

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>