### PR TITLE
Bluetooth: Controller: Fix Periodic Advertising Sync aux context leak

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -6142,7 +6142,6 @@ static void le_per_adv_sync_report(struct pdu_data *pdu_data,
 	if (!(event_mask & BT_EVT_MASK_LE_META_EVENT) ||
 	    (!(le_event_mask & BT_EVT_MASK_LE_PER_ADVERTISING_REPORT) &&
 	     !(le_event_mask & BT_EVT_MASK_LE_BIGINFO_ADV_REPORT))) {
-		node_rx_extra_list_release(node_rx->hdr.rx_ftr.extra);
 		return;
 	}
 
@@ -6214,10 +6213,6 @@ static void le_per_adv_sync_report(struct pdu_data *pdu_data,
 
 		aux_ptr = (void *)ptr;
 		if (aux_ptr->phy > EXT_ADV_AUX_PHY_LE_CODED) {
-			struct node_rx_ftr *ftr;
-
-			ftr = &node_rx->hdr.rx_ftr;
-			node_rx_extra_list_release(ftr->extra);
 			return;
 		}
 

--- a/subsys/bluetooth/controller/ll_sw/lll_scan.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_scan.h
@@ -27,14 +27,14 @@ struct lll_scan {
 	uint8_t  is_stop:1;
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
+	/* Reference to aux context when scanning auxiliary PDU */
+	struct lll_scan_aux *lll_aux;
+
 	uint16_t duration_reload;
 	uint16_t duration_expire;
 	uint8_t  phy:3;
 	uint8_t  is_adv_ind:1;
 	uint8_t  is_aux_sched:1;
-
-	/* temporary storage when aux scan was scheduled from LLL */
-	struct lll_scan_aux *lll_aux;
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
 
 #if defined(CONFIG_BT_CENTRAL)

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -921,7 +921,7 @@ static void isr_rx_done_cleanup(struct lll_sync *lll, uint8_t crc_ok, bool sync_
 static void isr_done(void *param)
 {
 	lll_isr_status_reset();
-	isr_rx_done_cleanup(param, ((trx_cnt > 1U) ? 1U : 0U), false);
+	isr_rx_done_cleanup(param, ((trx_cnt) ? 1U : 0U), false);
 }
 
 #if defined(CONFIG_BT_CTLR_DF_SCAN_CTE_RX)

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_internal.h
@@ -85,3 +85,6 @@ struct ll_scan_aux_set *ull_scan_aux_is_valid_get(struct ll_scan_aux_set *aux);
 
 /* Helper function to flush and release incomplete auxiliary PDU chaining */
 void ull_scan_aux_release(memq_link_t *link, struct node_rx_hdr *rx);
+
+/* Helper function to stop auxiliary scan context */
+int ull_scan_aux_stop(struct ll_scan_aux_set *aux);

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -323,6 +323,7 @@ uint8_t ll_sync_create_cancel(void **rx)
 
 uint8_t ll_sync_terminate(uint16_t handle)
 {
+	struct lll_scan_aux *lll_aux;
 	memq_link_t *link_sync_lost;
 	struct ll_sync_set *sync;
 	int err;
@@ -337,6 +338,17 @@ uint8_t ll_sync_terminate(uint16_t handle)
 	LL_ASSERT(err == 0 || err == -EALREADY);
 	if (err) {
 		return BT_HCI_ERR_CMD_DISALLOWED;
+	}
+
+	lll_aux = sync->lll.lll_aux;
+	if (lll_aux) {
+		struct ll_scan_aux_set *aux;
+
+		aux = HDR_LLL2ULL(lll_aux);
+		err = ull_scan_aux_stop(aux);
+		if (err) {
+			return BT_HCI_ERR_CMD_DISALLOWED;
+		}
 	}
 
 	link_sync_lost = sync->node_rx_lost.hdr.link;


### PR DESCRIPTION
Fix Periodic Advertising Synchronization Auxiliary context
leak when failing to receive chain PDUs.
Auxiliary context has not being associated with sync context
when ULL scheduling was used.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>