### PR TITLE
Add FS_MOUNT_FLAG_USE_DISK_ACCESS to fs_mount flags

### DIFF
--- a/dts/bindings/fs/zephyr,fstab-common.yaml
+++ b/dts/bindings/fs/zephyr,fstab-common.yaml
@@ -41,3 +41,11 @@ properties:
 
       This causes the FS_MOUNT_FLAG_NO_FORMAT option to be set in the
       mount descriptor generated for the file system.
+
+  disk-access:
+    type: boolean
+    description: |
+      Use disk-access for accessing storage media.
+
+      This causes the FS_MOUNT_FLAG_USE_DISK_ACCESS option to be set in
+      the mount descriptor generated for the file system.

--- a/subsys/fs/fat_fs.c
+++ b/subsys/fs/fat_fs.c
@@ -441,6 +441,10 @@ static int fatfs_mount(struct fs_mount_t *mountp)
 	}
 #endif /* CONFIG_FS_FATFS_MOUNT_MKFS */
 
+	if (res == FR_OK) {
+		mountp->flags |= FS_MOUNT_FLAG_USE_DISK_ACCESS;
+	}
+
 	return translate_error(res);
 
 }

--- a/subsys/fs/littlefs_fs.c
+++ b/subsys/fs/littlefs_fs.c
@@ -573,6 +573,11 @@ static int littlefs_mount(struct fs_mount_t *mountp)
 		LFS_VERSION_MAJOR, LFS_VERSION_MINOR,
 		LFS_DISK_VERSION_MAJOR, LFS_DISK_VERSION_MINOR);
 
+	if (mountp->flags & FS_MOUNT_FLAG_USE_DISK_ACCESS) {
+		LOG_DBG("LittleFS does not support Disk Access API");
+		return -ENOTSUP;
+	}
+
 	if (fs->area) {
 		return -EBUSY;
 	}

--- a/tests/subsys/fs/fat_fs_api/src/test_fat_mount.c
+++ b/tests/subsys/fs/fat_fs_api/src/test_fat_mount.c
@@ -51,17 +51,30 @@ static int test_mount_rd_only_no_sys(void)
 	return TC_PASS;
 }
 
-static int test_mount(void)
+static int test_mount_use_disk_access(void)
 {
 	int res;
 
+	fatfs_mnt.flags = FS_MOUNT_FLAG_USE_DISK_ACCESS;
 	res = fs_mount(&fatfs_mnt);
 	if (res < 0) {
 		TC_PRINT("Error mounting fs [%d]\n", res);
 		return TC_FAIL;
 	}
+	return ((fatfs_mnt.flags & FS_MOUNT_FLAG_USE_DISK_ACCESS) ? TC_PASS : TC_FAIL);
+}
 
-	return TC_PASS;
+static int test_mount(void)
+{
+	int res;
+
+	fatfs_mnt.flags = 0;
+	res = fs_mount(&fatfs_mnt);
+	if (res < 0) {
+		TC_PRINT("Error mounting fs [%d]\n", res);
+		return TC_FAIL;
+	}
+	return ((fatfs_mnt.flags & FS_MOUNT_FLAG_USE_DISK_ACCESS) ? TC_PASS : TC_FAIL);
 }
 
 static int test_unmount(void)
@@ -79,6 +92,8 @@ void test_fat_mount(void)
 	zassert_false(test_unmount() == TC_PASS, NULL);
 	zassert_true(test_mount_no_format() == TC_PASS, NULL);
 	zassert_true(test_mount_rd_only_no_sys() == TC_PASS, NULL);
+	zassert_true(test_mount_use_disk_access() == TC_PASS, NULL);
+	zassert_true(test_unmount() == TC_PASS, NULL);
 	zassert_true(test_mount() == TC_PASS, NULL);
 	zassert_false(test_mount() == TC_PASS, NULL);
 }


### PR DESCRIPTION
The commit adds new mount flag: FS_MOUNT_FLAG_USE_DISK_ACCESS that request using Disk Access API, when a file system driver supports it. File systems should by default use Flash API, but in case when they support Disk Access API, this flag makes them choose that API.
In case when File systems, like for example FAT, only support the DIsk Access API, then existence of the flag does not matter, but the file system, upon mount, should set the flag to indicate that it is using the Disk Access API.
When a file system does not support the flag and it is set, then fs_mount of the file system should return -ENOSUP.

