### PR TITLE
samples: tfm_secure_partition: Remove conditional from partition

### DIFF
--- a/samples/tfm_integration/tfm_secure_partition/dummy_partition/tfm_manifest_list.yaml.in
+++ b/samples/tfm_integration/tfm_secure_partition/dummy_partition/tfm_manifest_list.yaml.in
@@ -17,7 +17,6 @@
       "manifest": "${APPLICATION_SOURCE_DIR}/dummy_partition/tfm_dummy_partition.yaml",
       "output_path": "${TFM_BINARY_DIR}/dummy_partition",
       "tfm_partition_ipc": true,
-      "conditional": "TFM_PARTITION_DUMMY_PARTITION",
       "version_major": 0,
       "version_minor": 1,
       "linker_pattern": {


### PR DESCRIPTION
Remove the conditional attribute from the sample partition manifest.
The conditional behavior will change with TF-M 1.5 to only accept
cmake bool values on/off enabled/disabled true/false and is intended
to be generated by the build system.
Since the partition is supposed to always be enabled in the sample
there is no need to have a conditional for it.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>