### PR TITLE
pm: remove irrelevant type qualifier on pm_power_state_next_get

### DIFF
--- a/include/pm/pm.h
+++ b/include/pm/pm.h
@@ -111,7 +111,7 @@ int pm_notifier_unregister(struct pm_notifier *notifier);
  * @param cpu CPU index.
  * @return next pm_state_info that will be used
  */
-const struct pm_state_info pm_power_state_next_get(uint8_t cpu);
+struct pm_state_info pm_power_state_next_get(uint8_t cpu);
 
 /**
  * @}

--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -294,7 +294,7 @@ int pm_notifier_unregister(struct pm_notifier *notifier)
 	return ret;
 }
 
-const struct pm_state_info pm_power_state_next_get(uint8_t cpu)
+struct pm_state_info pm_power_state_next_get(uint8_t cpu)
 {
 	return z_power_states[cpu];
 }


### PR DESCRIPTION
The type qualifier of the return type is causing warnings if
-Wignored-qualifiers, and it's irrelevant anyways since
the function returns a value and not a pointer

Please correct me if I'm wrong, or suggest another way to solve this. I tried to typecast the variable to const before returning, but warning is still there.