### PR TITLE
Bluetooth: host: Enable CONFIG_BT_SETTINGS_CCC_STORE_ON_WRITE

### DIFF
--- a/doc/releases/release-notes-3.0.rst
+++ b/doc/releases/release-notes-3.0.rst
@@ -106,6 +106,9 @@ Bluetooth
 
 * Host
 
+  * The :kconfig:`CONFIG_BT_SETTINGS_CCC_STORE_ON_WRITE` is enabled by default.
+    Storing CCC right after it's written reduces risk of inconsistency of CCC values between bonded peers.
+
 * Mesh
 
 * Bluetooth LE split software Controller

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -151,14 +151,11 @@ config BT_SETTINGS_CCC_LAZY_LOADING
 config BT_SETTINGS_CCC_STORE_ON_WRITE
 	bool "Store CCC value immediately after it has been written"
 	depends on BT_CONN
+	default y
 	help
 	  Store Client Configuration Characteristic value right after it has
-	  been updated.
-
-	  By default, CCC is only stored on disconnection.
-	  Choosing this option is safer for battery-powered devices or devices
-	  that expect to be reset suddenly. However, it requires additional
-	  workqueue stack space.
+	  been updated. If the option is disabled, the CCC is only stored on
+	  disconnection.
 
 config BT_SETTINGS_USE_PRINTK
 	bool "Use snprintk to encode Bluetooth settings key strings"


### PR DESCRIPTION
Storing CCC right after it's written reduces risk of inconsistency of CCC values between bonded peers. The option should be enabled by default. The developer could explicitly disable it to reduce memory usage. After disabling the option explicitly, the developer is aware of related potential issues.

Fixes: #40758