### PR TITLE
Bluetooth: host: Update CCC after connection is encrypted

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -4900,8 +4900,6 @@ void bt_gatt_connected(struct bt_conn *conn)
 		settings_load_subtree_direct(key, ccc_set_direct, (void *)key);
 	}
 
-	bt_gatt_foreach_attr(0x0001, 0xffff, update_ccc, &data);
-
 	/* BLUETOOTH CORE SPECIFICATION Version 5.1 | Vol 3, Part C page 2192:
 	 *
 	 * 10.3.1.1 Handling of GATT indications and notifications


### PR DESCRIPTION
The CCC update should be done after the connection is encrypted. Before the connection is encrypted, the GATT Server does not know if the reconnecting peer was actually bonded.

Fixes: #40759