### PR TITLE
samples: syscall_perf: use csr.h instead of main.h

### DIFF
--- a/samples/userspace/syscall_perf/src/csr.h
+++ b/samples/userspace/syscall_perf/src/csr.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef MAIN_H
-#define MAIN_H
+#ifndef CSR_H
+#define CSR_H
 
 #include <kernel.h>
 
@@ -17,4 +17,4 @@
 	__v;							\
 })
 
-#endif  /* MAIN_H */
+#endif  /* CSR_H */

--- a/samples/userspace/syscall_perf/src/main.c
+++ b/samples/userspace/syscall_perf/src/main.c
@@ -7,8 +7,15 @@
 #include <zephyr.h>
 #include <stdio.h>
 
-#include "main.h"
 #include "thread_def.h"
+
+#define THREAD_STACKSIZE        2048
+
+struct k_thread user_thread;
+K_THREAD_STACK_DEFINE(user_stack, THREAD_STACKSIZE);
+
+struct k_thread supervisor_thread;
+K_THREAD_STACK_DEFINE(supervisor_stack, THREAD_STACKSIZE);
 
 void main(void)
 {

--- a/samples/userspace/syscall_perf/src/test_supervisor.c
+++ b/samples/userspace/syscall_perf/src/test_supervisor.c
@@ -7,7 +7,7 @@
 #include <zephyr.h>
 #include <stdio.h>
 
-#include "main.h"
+#include "csr.h"
 
 /*
  * 0xB00 is CSR mcycle

--- a/samples/userspace/syscall_perf/src/test_user.c
+++ b/samples/userspace/syscall_perf/src/test_user.c
@@ -7,7 +7,7 @@
 #include <zephyr.h>
 #include <stdio.h>
 
-#include "main.h"
+#include "csr.h"
 
 /*
  * 0xC00 is CSR cycle

--- a/samples/userspace/syscall_perf/src/thread_def.h
+++ b/samples/userspace/syscall_perf/src/thread_def.h
@@ -7,16 +7,8 @@
 #ifndef THREAD_DEF_H
 #define THREAD_DEF_H
 
-#include <kernel.h>
-
-#define THREAD_STACKSIZE	2048
-
-struct k_thread user_thread;
-K_THREAD_STACK_DEFINE(user_stack, THREAD_STACKSIZE);
 void supervisor_thread_function(void *p1, void *p2, void *p3);
 
-struct k_thread supervisor_thread;
-K_THREAD_STACK_DEFINE(supervisor_stack, THREAD_STACKSIZE);
 void user_thread_function(void *p1, void *p2, void *p3);
 
 #endif /* THREAD_DEF_H */


### PR DESCRIPTION
Normally main.c file doesn't have a header file, because it doesn't
need to declare any interfaces to other modules.

In this sample, it's better to put the shared API in one file,
and provide the interface to other modules, such as test_user
and test_supervisor.

Signed-off-by: Paul He <pawpawhe@gmail.com>