### PR TITLE
riscv: Fix C++ exception handling info linking

### DIFF
--- a/include/arch/riscv/common/linker.ld
+++ b/include/arch/riscv/common/linker.ld
@@ -243,7 +243,6 @@ SECTIONS
 	}  GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
 
 #include <linker/common-noinit.ld>
-#include <linker/cplusplus-ram.ld>
 
     SECTION_DATA_PROLOGUE(_DATA_SECTION_NAME,,)
 	{
@@ -287,6 +286,7 @@ SECTIONS
 
 #include <linker/common-ram.ld>
 #include <linker/kobject-data.ld>
+#include <linker/cplusplus-ram.ld>
 
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.

--- a/tests/subsys/cpp/libcxx/testcase.yaml
+++ b/tests/subsys/cpp/libcxx/testcase.yaml
@@ -6,6 +6,7 @@ tests:
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     toolchain_exclude: xcc
     min_flash: 54
+    min_ram: 24
     tags: cpp
     extra_configs:
         - CONFIG_NEWLIB_LIBC=y


### PR DESCRIPTION
The RISC-V architecture linker script was including `cplusplus-ram.ld`
linker script before `__data_region_start`, and this caused the content
of `.gcc_except_table` section to be not copied to the RAM by the
`z_data_copy` function; leading to the C++ exception handling
malfunction.

This commit relocates the `cplusplus-ram.ld` linker script inclusion
such that the contents of the relevant sections are properly copied by
the `z_data_copy` function.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Fixes #40770.