### PR TITLE
twister: add option to ignore skipped tests in reports

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -122,9 +122,9 @@ jobs:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.13.2
       CLANG_ROOT_DIR: /usr/lib/llvm-12
       TWISTER_COMMON: ' --inline-logs -v -N -M --retry-failed 3 '
-      DAILY_OPTIONS: ' -M --build-only --all '
-      PR_OPTIONS: ' --clobber-output --integration '
-      PUSH_OPTIONS: ' --clobber-output -M '
+      DAILY_OPTIONS: ' -M --build-only --all --no-skipped-report'
+      PR_OPTIONS: ' --clobber-output --integration --no-skipped-report'
+      PUSH_OPTIONS: ' --clobber-output -M --no-skipped-report'
       COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
       BASE_REF: ${{ github.base_ref }}
     steps:

--- a/scripts/twister
+++ b/scripts/twister
@@ -578,6 +578,11 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
              "faster compilation since builds will be incremental.")
 
     parser.add_argument(
+        "--no-skipped-report", action="store_true",
+        help="""Do not report skipped test cases in junit output. [Experimental]
+        """)
+
+    parser.add_argument(
         "-O", "--outdir",
         default=os.path.join(os.getcwd(), "twister-out"),
         help="Output directory for logs and binaries. "
@@ -1359,7 +1364,8 @@ def main():
                        options.release,
                        options.only_failed,
                        options.platform_reports,
-                       options.json_report
+                       options.json_report,
+                       not options.no_skipped_report
                        )
 
     # FIXME: remove later


### PR DESCRIPTION
With --no-skipped, twister will skip over all tests marked as skipped
(filtered) in the junit report.

This is useful for CI where have 1000s of filtered tests that appear in
the report and in some cases cause tools parsing the output to fail or
provide incomplete results.

Fixes #38179

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
