### PR TITLE
uart_stm32: fix a dead lock on poll_out if it's called in interrupt

### DIFF
--- a/drivers/serial/uart_stm32.h
+++ b/drivers/serial/uart_stm32.h
@@ -57,7 +57,6 @@ struct uart_stm32_data {
 	uint32_t baud_rate;
 	/* clock device */
 	const struct device *clock;
-	atomic_t tx_lock;
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	uart_irq_callback_user_data_t user_cb;
 	void *user_data;
@@ -74,6 +73,7 @@ struct uart_stm32_data {
 #endif
 #ifdef CONFIG_PM
 	bool tx_poll_stream_on;
+	bool tx_int_stream_on;
 	bool pm_constraint_on;
 #endif
 };


### PR DESCRIPTION
If the function poll_out is called in an interrupt with a higher
priority than the usart priority, the function could lock forever. In
fact, the lock variable is never unset if the usart interrupt is no
longer called. So now, we don't use the lock variable if poll_out is
called in interrupt.

Fixes #40775

Signed-off-by: Julien D'ascenzio <julien.dascenzio@paratronic.fr>