### PR TITLE
tracing: Fix k_fifo_put_list tracing for CONFIG_TRACING_NONE=yes

### DIFF
--- a/include/tracing/tracing.h
+++ b/include/tracing/tracing.h
@@ -1153,7 +1153,7 @@ void sys_trace_idle(void);
  * @param head First ll-node
  * @param tail Last ll-node
  */
-#define sys_port_trace_k_fifo_alloc_put_list_enter(fifo, head, tail)
+#define sys_port_trace_k_fifo_put_list_enter(fifo, head, tail)
 
 /**
  * @brief Trace FIFO Queue put list exit
@@ -1161,7 +1161,7 @@ void sys_trace_idle(void);
  * @param head First ll-node
  * @param tail Last ll-node
  */
-#define sys_port_trace_k_fifo_alloc_put_list_exit(fifo, head, tail)
+#define sys_port_trace_k_fifo_put_list_exit(fifo, head, tail)
 
 /**
  * @brief Trace FIFO Queue put slist entry


### PR DESCRIPTION
k_fifo_put_list() tracing entry points are called
sys_port_trace_k_fifo_put_list_enter and sys_port_trace_k_fifo_put_list_exit,
however, they were misnamed in "tracing.h". So anyone using tracing and
CONFIG_TRACING_NONE=yes would see compilation errors if they tried to
use k_fifo_put_list().

Signed-off-by: Ederson de Souza <ederson.desouza@intel.com>