### PR TITLE
gitlint: Make commit message line size be compatible with checkpatch.pl

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -39,7 +39,7 @@ words=wip
 
 [max-line-length-with-exceptions]
 # B1 = body-max-line-length
-line-length=72
+line-length=75
 
 [body-min-length]
 min-length=3


### PR DESCRIPTION
checkpatch.pl recommends that commit messages line size should not go over
75 characters, howerver .gitlint was enforcing 72 characters instead, which
is inconsistent. This patch changes .gitlint so that both are compatible.

Signed-off-by: Ederson de Souza <ederson.desouza@intel.com>