### PR TITLE
soc: silabs_exx32: Add support for ARM ETM on gecko Series 2 SoCs

### DIFF
--- a/soc/arm/Kconfig
+++ b/soc/arm/Kconfig
@@ -56,6 +56,11 @@ config NRF_SPU_RAM_REGION_SIZE
 	  RAM region size for the NRF_SPU peripheral
 endif
 
+config HAS_ARM_ETM
+	bool
+	help
+	  When enabled, indicates that SoC supports Embedded Trace Macrocell (ETM)
+
 config HAS_SWO
 	bool
 	help

--- a/soc/arm/silabs_exx32/efr32mg21/Kconfig.series
+++ b/soc/arm/silabs_exx32/efr32mg21/Kconfig.series
@@ -14,6 +14,7 @@ config SOC_SERIES_EFR32MG21
 	select SOC_FAMILY_EXX32
 	select HAS_SILABS_GECKO
 	select HAS_SWO
+	select HAS_ARM_ETM
 	select SOC_GECKO_CMU
 	select SOC_GECKO_EMU
 	select SOC_GECKO_GPIO

--- a/soc/arm/silabs_exx32/efr32mg21/soc_pinmap.h
+++ b/soc/arm/silabs_exx32/efr32mg21/soc_pinmap.h
@@ -19,4 +19,9 @@
 #define PIN_SWO { gpioPortA, 3, gpioModePushPull, 1 }
 #endif  /* CONFIG_LOG_BACKEND_SWO */
 
+#ifdef CONFIG_TRACING_ETM
+#define PIN_TRACEDATA0 {gpioPortA, 3, gpioModePushPull, 0}
+#define PIN_TRACECLK {gpioPortA, 4, gpioModePushPull, 0}
+#endif /* CONFIG_TRACING_ETM */
+
 #endif  /* ZEPHYR_SOC_ARM_SILABS_EXX32_EFR32MG21_SOC_PINMAP_H_ */

--- a/subsys/tracing/Kconfig
+++ b/subsys/tracing/Kconfig
@@ -17,6 +17,34 @@ config TRACING
 
 if TRACING
 
+choice
+	prompt "Tracing mode"
+	default SOFTWARE_TRACING
+
+config HARDWARE_TRACING
+	bool "Hardware Tracing"
+	help
+		Enable tracing using the hardware capabilities
+
+config SOFTWARE_TRACING
+	bool "Software Tracing"
+	help
+		Enable tracing using the software capabilities
+
+endchoice # Tracing Mode
+
+if HARDWARE_TRACING
+
+config TRACING_ETM
+	bool "Tracing via ARM Embedded Trace Macrocell"
+	depends on HAS_ARM_ETM
+	help
+	  Enable the ARM Embedded Trace Macrocell.
+
+endif # Hardware Tracing
+
+if SOFTWARE_TRACING
+
 config TRACING_CORE
 	bool
 	help
@@ -52,11 +80,6 @@ config TRACING_CTF
 	select TRACING_CORE
 	help
 	  Enable tracing to a Common Trace Format stream.
-
-config TRACING_ETM
-	bool "Tracing via ARM Embedded Trace Macrocell"
-	help
-	  Enable the ARM Embedded Trace Macrocell.
 
 config TRACING_TEST
 	bool "Tracing for test usage"
@@ -320,6 +343,8 @@ config TRACING_EVENT
 
 endmenu  # Tracing Configuration
 
-endif
+endif  # Software Tracing
+
+endif  # Tracing Support
 
 source "subsys/tracing/sysview/Kconfig"

--- a/subsys/tracing/Kconfig
+++ b/subsys/tracing/Kconfig
@@ -53,6 +53,11 @@ config TRACING_CTF
 	help
 	  Enable tracing to a Common Trace Format stream.
 
+config TRACING_ETM
+	bool "Tracing via ARM Embedded Trace Macrocell"
+	help
+	  Enable the ARM Embedded Trace Macrocell.
+
 config TRACING_TEST
 	bool "Tracing for test usage"
 	select TRACING_CORE


### PR DESCRIPTION
This commit adds support for ARM ETM tracing feature on Silicon Labs
Gecko Series 2. It required some pins and clocks to be set.

Add TRACING_ETM as new tracing format in the subsys/tracing/Kconfig.

It was tested on the EFR32MG21 SoC using the `samples/synchronization` and Segger Ozone tool.

Signed-off-by: Steven Lemaire <steven.lemaire@zii.aero>