### PR TITLE
[Backport v2.7-branch] drivers: mcux_flexspi: Default logging to disabled when XIP is used

### DIFF
--- a/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
+++ b/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
@@ -23,6 +23,17 @@
 static uint8_t nor_write_buf[SPI_NOR_PAGE_SIZE];
 #endif
 
+/*
+ * NOTE: If CONFIG_FLASH_MCUX_FLEXSPI_XIP is selected, Any external functions
+ * called while interacting with the flexspi MUST be relocated to SRAM or ITCM
+ * at runtime, so that the chip does not access the flexspi to read program
+ * instructions while it is being written to
+ */
+#if defined(CONFIG_FLASH_MCUX_FLEXSPI_XIP) && (CONFIG_FLASH_LOG_LEVEL > 0)
+#warning "Enabling flash driver logging and XIP mode simultaneously can cause \
+	read-while-write hazards. This configuration is not recommended."
+#endif
+
 LOG_MODULE_REGISTER(flash_flexspi_nor, CONFIG_FLASH_LOG_LEVEL);
 
 enum {

--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -23,6 +23,17 @@
 static uint8_t nor_write_buf[SPI_NOR_PAGE_SIZE];
 #endif
 
+/*
+ * NOTE: If CONFIG_FLASH_MCUX_FLEXSPI_XIP is selected, Any external functions
+ * called while interacting with the flexspi MUST be relocated to SRAM or ITCM
+ * at runtime, so that the chip does not access the flexspi to read program
+ * instructions while it is being written to
+ */
+#if defined(CONFIG_FLASH_MCUX_FLEXSPI_XIP) && (CONFIG_FLASH_LOG_LEVEL > 0)
+#warning "Enabling flash driver logging and XIP mode simultaneously can cause \
+	read-while-write hazards. This configuration is not recommended."
+#endif
+
 LOG_MODULE_REGISTER(flash_flexspi_nor, CONFIG_FLASH_LOG_LEVEL);
 
 enum {

--- a/drivers/memc/memc_mcux_flexspi.c
+++ b/drivers/memc/memc_mcux_flexspi.c
@@ -11,6 +11,18 @@
 
 #include "memc_mcux_flexspi.h"
 
+
+/*
+ * NOTE: If CONFIG_FLASH_MCUX_FLEXSPI_XIP is selected, Any external functions
+ * called while interacting with the flexspi MUST be relocated to SRAM or ITCM
+ * at runtime, so that the chip does not access the flexspi to read program
+ * instructions while it is being written to
+ */
+#if defined(CONFIG_FLASH_MCUX_FLEXSPI_XIP) && (CONFIG_MEMC_LOG_LEVEL > 0)
+#warning "Enabling memc driver logging and XIP mode simultaneously can cause \
+	read-while-write hazards. This configuration is not recommended."
+#endif
+
 LOG_MODULE_REGISTER(memc_flexspi, CONFIG_MEMC_LOG_LEVEL);
 
 struct memc_flexspi_config {

--- a/drivers/memc/memc_mcux_flexspi_hyperram.c
+++ b/drivers/memc/memc_mcux_flexspi_hyperram.c
@@ -11,7 +11,19 @@
 
 #include "memc_mcux_flexspi.h"
 
-LOG_MODULE_DECLARE(memc_flexspi, CONFIG_MEMC_LOG_LEVEL);
+
+/*
+ * NOTE: If CONFIG_FLASH_MCUX_FLEXSPI_XIP is selected, Any external functions
+ * called while interacting with the flexspi MUST be relocated to SRAM or ITCM
+ * at runtime, so that the chip does not access the flexspi to read program
+ * instructions while it is being written to
+ */
+#if defined(CONFIG_FLASH_MCUX_FLEXSPI_XIP) && (CONFIG_MEMC_LOG_LEVEL > 0)
+#warning "Enabling memc driver logging and XIP mode simultaneously can cause \
+	read-while-write hazards. This configuration is not recommended."
+#endif
+
+LOG_MODULE_REGISTER(memc_flexspi, CONFIG_MEMC_LOG_LEVEL);
 
 enum {
 	READ_DATA,

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
@@ -52,6 +52,19 @@ config UART_MCUX_LPUART
 	default y if HAS_MCUX_LPUART
 	depends on SERIAL
 
+if FLASH_MCUX_FLEXSPI_XIP
+
+# Avoid RWW hazards by defaulting logging to disabled
+choice FLASH_LOG_LEVEL_CHOICE
+	default FLASH_LOG_LEVEL_OFF
+endchoice
+
+choice MEMC_LOG_LEVEL_CHOICE
+	default MEMC_LOG_LEVEL_OFF
+endchoice
+
+endif
+
 if COUNTER
 
 config COUNTER_MCUX_GPT


### PR DESCRIPTION
Program flow will behave incorrectly (memory and instruction fetches
return invalid data) if Flexspi is accessed by the Flexspi driver while
being used as XIP memory by the Cortex M7.

Set logging to disabled by when XIP mode is used in the memc and
flexspi drivers, and warn the user if they attempt to enable it.

Fixes #40133

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>