### PR TITLE
Add memc support for STM32F7 series

### DIFF
--- a/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
+++ b/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
@@ -22,6 +22,11 @@
 		zephyr,flash-controller = &mx25l51245g;
 	};
 
+	sdram1: sdram@c0000000 {
+		device_type = "memory";
+		reg = <0xc0000000 DT_SIZE_M(16)>;
+	};
+
 	leds {
 		compatible = "gpio-leds";
 		red_led_1:led_1 {
@@ -164,6 +169,49 @@ arduino_serial: &usart6 {};
 				label = "storage";
 				reg = <0x001a0000 DT_SIZE_M(62)>;
 			};
+		};
+	};
+};
+
+&fmc {
+	status = "okay";
+	pinctrl-0 = <&fmc_nbl0_pe0 &fmc_nbl1_pe1 &fmc_nbl2_pi4 &fmc_nbl3_pi5
+		     &fmc_sdclk_pg8 &fmc_sdnwe_ph5 &fmc_sdcke0_ph2 &fmc_sdne0_ph3
+		     &fmc_sdnras_pf11 &fmc_sdncas_pg15
+		     &fmc_a0_pf0 &fmc_a1_pf1 &fmc_a2_pf2 &fmc_a3_pf3
+		     &fmc_a4_pf4 &fmc_a5_pf5 &fmc_a6_pf12 &fmc_a7_pf13
+		     &fmc_a8_pf14 &fmc_a9_pf15 &fmc_a10_pg0 &fmc_a11_pg1
+		     &fmc_a12_pg2 &fmc_a14_pg4 &fmc_a15_pg5
+		     &fmc_d0_pd14 &fmc_d1_pd15 &fmc_d2_pd0 &fmc_d3_pd1
+		     &fmc_d4_pe7 &fmc_d5_pe8 &fmc_d6_pe9 &fmc_d7_pe10
+		     &fmc_d8_pe11 &fmc_d9_pe12 &fmc_d10_pe13 &fmc_d11_pe14
+		     &fmc_d12_pe15 &fmc_d13_pd8 &fmc_d14_pd9 &fmc_d15_pd10
+		     &fmc_d16_ph8 &fmc_d17_ph9 &fmc_d18_ph10 &fmc_d19_ph11
+		     &fmc_d20_ph12 &fmc_d21_ph13 &fmc_d22_ph14 &fmc_d23_ph15
+		     &fmc_d24_pi0 &fmc_d25_pi1 &fmc_d26_pi2 &fmc_d27_pi3
+		     &fmc_d28_pi6 &fmc_d29_pi7 &fmc_d30_pi9 &fmc_d31_pi10>;
+	pinctrl-names = "default";
+
+	sdram {
+		status = "okay";
+
+		power-up-delay = <100>;
+		num-auto-refresh = <8>;
+		mode-register = <0x230>;
+		refresh-rate = <603>;
+
+		bank@0 {
+			reg = <0>;
+
+			st,sdram-control = <STM32_FMC_SDRAM_NC_8
+					    STM32_FMC_SDRAM_NR_12
+					    STM32_FMC_SDRAM_MWID_32
+					    STM32_FMC_SDRAM_NB_4
+					    STM32_FMC_SDRAM_CAS_3
+					    STM32_FMC_SDRAM_SDCLK_PERIOD_2
+					    STM32_FMC_SDRAM_RBURST_ENABLE
+					    STM32_FMC_SDRAM_RPIPE_0>;
+			st,sdram-timing = <2 6 4 6 2 2 2>;
 		};
 	};
 };

--- a/boards/arm/stm32f769i_disco/stm32f769i_disco.yaml
+++ b/boards/arm/stm32f769i_disco/stm32f769i_disco.yaml
@@ -16,3 +16,4 @@ supported:
   - gpio
   - arduino_gpio
   - netif:eth
+  - memc

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -10,6 +10,7 @@
 #include <dt-bindings/i2c/i2c.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/pwm/pwm.h>
+#include <dt-bindings/memory-controller/stm32-fmc-sdram.h>
 #include <freq.h>
 
 / {
@@ -73,6 +74,22 @@
 	};
 
 	soc {
+		fmc: memory-controller@a0000000 {
+			compatible = "st,stm32-fmc";
+			reg = <0xa0000000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x00000001>;
+			label = "STM32_FMC";
+			status = "disabled";
+
+			sdram: sdram {
+				compatible = "st,stm32-fmc-sdram";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				label = "STM32_FMC_SDRAM";
+				status = "disabled";
+			};
+		};
+
 		flash: flash-controller@40023c00 {
 			compatible = "st,stm32-flash-controller", "st,stm32f7-flash-controller";
 			label = "FLASH_CTRL";


### PR DESCRIPTION
As per #36204 and #29686, adding support for STM32F7 and board STM32F769I-DISC0.