### PR TITLE
kernel: Add "per thread" timeslice mechanism

### DIFF
--- a/include/kernel/thread.h
+++ b/include/kernel/thread.h
@@ -117,6 +117,12 @@ struct _thread_base {
 	struct _timeout timeout;
 #endif
 
+#ifdef CONFIG_TIMESLICE_PER_THREAD
+	int32_t slice_ticks;
+	k_thread_timeslice_fn_t slice_expired;
+	void *slice_data;
+#endif
+
 #ifdef CONFIG_SCHED_THREAD_USAGE
 	struct k_cycle_stats  usage;   /* Track thread usage statistics */
 #endif

--- a/include/kernel_structs.h
+++ b/include/kernel_structs.h
@@ -243,6 +243,8 @@ struct _timeout {
 #endif
 };
 
+typedef void (*k_thread_timeslice_fn_t)(struct k_thread *thread, void *data);
+
 #ifdef __cplusplus
 }
 #endif

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -500,6 +500,14 @@ config TIMESLICE_PRIORITY
 	  takes effect; threads having a higher priority than this ceiling are
 	  not subject to time slicing.
 
+config TIMESLICE_PER_THREAD
+	bool "Support per-thread timeslice values"
+	depends on TIMESLICING
+	help
+	  When set, this enables an API for setting timeslice values on
+	  a per-thread basis, with an application callback invoked when
+	  a thread reaches the end of its timeslice.
+
 config POLL
 	bool "Async I/O Framework"
 	help

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -56,7 +56,7 @@ bool z_set_prio(struct k_thread *thread, int prio);
 void *z_get_next_switch_handle(void *interrupted);
 void idle(void *unused1, void *unused2, void *unused3);
 void z_time_slice(int ticks);
-void z_reset_time_slice(void);
+void z_reset_time_slice(struct k_thread *curr);
 void z_sched_abort(struct k_thread *thread);
 void z_sched_ipi(void);
 void z_sched_start(struct k_thread *thread);

--- a/kernel/include/kswap.h
+++ b/kernel/include/kswap.h
@@ -106,9 +106,6 @@ static ALWAYS_INLINE unsigned int do_swap(unsigned int key,
 	new_thread = z_swap_next_thread();
 
 	if (new_thread != old_thread) {
-#ifdef CONFIG_TIMESLICING
-		z_reset_time_slice();
-#endif
 		z_sched_usage_switch(new_thread);
 
 #ifdef CONFIG_SMP
@@ -122,6 +119,10 @@ static ALWAYS_INLINE unsigned int do_swap(unsigned int key,
 		z_thread_mark_switched_out();
 		wait_for_switch(new_thread);
 		_current_cpu->current = new_thread;
+
+#ifdef CONFIG_TIMESLICING
+		z_reset_time_slice(new_thread);
+#endif
 
 #ifdef CONFIG_SPIN_VALIDATE
 		z_spin_lock_set_owner(&sched_spinlock);

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -779,6 +779,11 @@ void z_init_thread_base(struct _thread_base *thread_base, int priority,
 	thread_base->is_idle = 0;
 #endif
 
+#ifdef CONFIG_TIMESLICE_PER_THREAD
+	thread_base->slice_ticks = 0;
+	thread_base->slice_expired = NULL;
+#endif
+
 	/* swap_data does not need to be initialized */
 
 	z_init_thread_timeout(thread_base);

--- a/tests/kernel/sched/schedule_api/src/main.c
+++ b/tests/kernel/sched/schedule_api/src/main.c
@@ -73,7 +73,8 @@ void test_main(void)
 			 ztest_user_unit_test(test_k_thread_priority_set_init_null),
 			 ztest_user_unit_test(test_k_thread_priority_set_overmax),
 			 ztest_user_unit_test(test_k_thread_priority_set_upgrade),
-			 ztest_user_unit_test(test_k_wakeup_init_null)
+			 ztest_user_unit_test(test_k_wakeup_init_null),
+			 ztest_unit_test(test_slice_perthread)
 			 );
 	ztest_run_test_suite(threads_scheduling);
 }

--- a/tests/kernel/sched/schedule_api/src/test_sched.h
+++ b/tests/kernel/sched/schedule_api/src/test_sched.h
@@ -54,5 +54,6 @@ void test_k_thread_priority_set_init_null(void);
 void test_k_thread_priority_set_overmax(void);
 void test_k_thread_priority_set_upgrade(void);
 void test_k_wakeup_init_null(void);
+void test_slice_perthread(void);
 
 #endif /* __TEST_SCHED_H__ */

--- a/tests/kernel/sched/schedule_api/testcase.yaml
+++ b/tests/kernel/sched/schedule_api/testcase.yaml
@@ -12,6 +12,12 @@ tests:
     extra_configs:
       - CONFIG_TIMESLICING=n
     tags: kernel threads sched userspace ignore_faults
+  kernel.scheduler.slice_perthread:
+    filter: not CONFIG_SCHED_MULTIQ
+    extra_configs:
+      - CONFIG_TIMESLICING=y
+      - CONFIG_TIMESLICE_PER_THREAD=y
+    tags: kernel threads sched userspace ignore_faults
   kernel.scheduler.multiq:
     extra_args: CONF_FILE=prj_multiq.conf
     extra_configs:


### PR DESCRIPTION
Zephyr's timeslice implementation has always been somewhat primitive.
You get a global timeslice that applies broadly to the whole bottom of
the priority space, with no ability (beyond that one priority
threshold) to tune it to work on certain threads, etc...

This adds an (optionally configurable) API that allows timeslicing to
be controlled on a per-thread basis: any thread at any priority can be
set to timeslice, for a configurable per-thread slice time, and at the
end of its slice a callback can be provided that can take action.
This allows the application to implement things like responsiveness
heuristics, "fair" scheduling algorithms, etc... without requiring
that facility in the core kernel.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>