### PR TITLE
driver: uart_npcx: Fix uart to use PM constrain

### DIFF
--- a/soc/arm/nuvoton_npcx/common/reg/reg_def.h
+++ b/soc/arm/nuvoton_npcx/common/reg/reg_def.h
@@ -329,7 +329,7 @@ struct uart_reg {
 #define NPCX_UFTCTL_TEMPTY_LVL_SEL            FIELD(0, 5)
 #define NPCX_UFTCTL_TEMPTY_LVL_EN             5
 #define NPCX_UFTCTL_TEMPTY_EN                 6
-#define NPCX_UFTCTL_NXMIPEN                   7
+#define NPCX_UFTCTL_NXMIP_EN                  7
 #define NPCX_UFRCTL_RFULL_LVL_SEL             FIELD(0, 5)
 #define NPCX_UFRCTL_RFULL_LVL_EN              5
 #define NPCX_UFRCTL_RNEMPTY_EN                6


### PR DESCRIPTION
The device PM callback needs to be used only to suspend/resume devices.
If the system cannot be suspended because UART is in a particular
state, the pm_constraint_set/release API should be used. For NPCX UART,
the chip can't enter low power idle state until UART completes the data
transmission.
This commit changes NPCX UART to use pm_constraint_set/release & fixes
UART lost data from low power idle.

Fix #40621
