### PR TITLE
samples/drivers: led_pca9633: Convert to build_only

### DIFF
--- a/samples/drivers/led_pca9633/sample.yaml
+++ b/samples/drivers/led_pca9633/sample.yaml
@@ -4,4 +4,5 @@ sample:
 tests:
   sample.drivers.led.pca9633:
     depends_on: arduino_i2c
+    build_only: true
     tags: LED


### PR DESCRIPTION
Sample should only be run if led is present on board.
Since, this is not the case on any of the in tree boards,
set the sample as build-only.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>