### PR TITLE
doc: style admonitions

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -527,6 +527,7 @@ a.internal:visited code.literal {
 
 /* Admonition tweaks */
 
+.rst-content .admonition,
 .rst-content .admonition.note,
 .rst-content .admonition.seealso {
     background-color: var(--admonition-note-background-color);
@@ -534,6 +535,7 @@ a.internal:visited code.literal {
     overflow: auto;
 }
 
+.rst-content .admonition .admonition-title,
 .rst-content .admonition.note .admonition-title,
 .rst-content .admonition.seealso .admonition-title {
     background-color: var(--admonition-note-title-background-color);


### PR DESCRIPTION
Only certain type of admonitions were styled (e.g. notes, warnings,
etc.). This change also styles generic admonitions such as:

```rst
... admonition:: Rationale

    ...
```

Fixes #40622