### PR TITLE
drivers: nrf5: kconfig: add missing dependency for TEMP_NRF5

### DIFF
--- a/drivers/sensor/nrf5/Kconfig
+++ b/drivers/sensor/nrf5/Kconfig
@@ -13,5 +13,6 @@ config TEMP_NRF5_FORCE_ALT
 config TEMP_NRF5
 	bool "nRF5 Temperature Sensor"
 	depends on HAS_HW_NRF_TEMP
+	depends on MULTITHREADING || TEMP_NRF5_FORCE_ALT
 	help
 	  Enable driver for nRF5 temperature sensor.


### PR DESCRIPTION
Fixes: #40538

The TEMP_NRF5 setting requires MULTITHREADING, therefore add this
dependency to Kconfig.

The TEMP_NRF5 supports an alternative driver implementation using the
TEMP_NRF5_FORCE_ALT setting.
Because it cannot be known whether an alternative implementation has
the same dependency, then the MULTITHREADING is OR'ed with
TEMP_NRF5_FORCE_ALT, as to allow enabling of TEMP_NRF5 if an alternative
driver is provided.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>