### PR TITLE
drivers: can: fix can_configure() when CAN-FD is enabled

### DIFF
--- a/include/drivers/can.h
+++ b/include/drivers/can.h
@@ -860,7 +860,7 @@ static inline int can_configure(const struct device *dev, enum can_mode mode,
 				uint32_t bitrate)
 {
 	if (bitrate > 0) {
-		int err = can_set_bitrate(dev, bitrate, 0);
+		int err = can_set_bitrate(dev, bitrate, bitrate);
 		if (err != 0) {
 			return err;
 		}
@@ -868,7 +868,6 @@ static inline int can_configure(const struct device *dev, enum can_mode mode,
 
 	return can_set_mode(dev, mode);
 }
-
 
 /**
  * @brief Get current state


### PR DESCRIPTION
Currently, can_configure() pass a hard-coded 0 for the data bitrate (which is only used for CAN-FD), breaking this API for CAN-FD enabled applications.

Instead pass in the provided bitrate for both arbitration phase and data phase.

Fixes: #34375

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>