### PR TITLE
drivers: can: deprecate can_configure()

### DIFF
--- a/include/drivers/can.h
+++ b/include/drivers/can.h
@@ -856,8 +856,8 @@ static inline int can_set_bitrate(const struct device *dev,
  * @retval 0 If successful.
  * @retval -EIO General input / output error, failed to configure device.
  */
-static inline int can_configure(const struct device *dev, enum can_mode mode,
-				uint32_t bitrate)
+__deprecated static inline int can_configure(const struct device *dev, enum can_mode mode,
+					     uint32_t bitrate)
 {
 	if (bitrate > 0) {
 		int err = can_set_bitrate(dev, bitrate, 0);

--- a/modules/canopennode/CO_driver.c
+++ b/modules/canopennode/CO_driver.c
@@ -244,7 +244,7 @@ void CO_CANmodule_disable(CO_CANmodule_t *CANmodule)
 
 	canopen_detach_all_rx_filters(CANmodule);
 
-	err = can_configure(CANmodule->dev, CAN_SILENT_MODE, 0);
+	err = can_set_mode(CANmodule->dev, CAN_SILENT_MODE);
 	if (err) {
 		LOG_ERR("failed to disable CAN interface (err %d)", err);
 	}


### PR DESCRIPTION
The can_configure() API call does not handle CAN-FD bitrates. Deprecate the can_configure() API wrapper function in favour of the newer can_set_bitrate() and can_set_mode() functions.
    
Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>
