### PR TITLE
ipc_service: ipc_rpmsg_static_vrings: Fix MBOX initialization

### DIFF
--- a/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
+++ b/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
@@ -276,12 +276,12 @@ static int mbox_init(const struct device *instance)
 
 	k_work_init(&data->mbox_work, mbox_callback_process);
 
-	err = mbox_register_callback(&conf->mbox_rx, mbox_callback, data);
+	err = mbox_set_enabled(&conf->mbox_rx, true);
 	if (err != 0) {
 		return err;
 	}
 
-	return mbox_set_enabled(&conf->mbox_rx, 1);
+	return mbox_register_callback(&conf->mbox_rx, mbox_callback, data);
 }
 
 static struct ipc_rpmsg_ept *register_ept_on_host(struct ipc_rpmsg_instance *rpmsg_inst,


### PR DESCRIPTION
Enable the MBOX channel before installing the handler, not the
viceversa.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>