### PR TITLE
drivers: flash: Refactor drivers to use shared init priority

### DIFF
--- a/drivers/flash/Kconfig
+++ b/drivers/flash/Kconfig
@@ -58,6 +58,14 @@ config FLASH_PAGE_LAYOUT
 	help
 	  Enables API for retrieving the layout of flash memory pages.
 
+config FLASH_INIT_PRIORITY
+	int "Flash init priority"
+	default KERNEL_INIT_PRIORITY_DEVICE
+	help
+	  Flash driver device initialization priority. This initialization
+	  priority is used unless the driver implementation has its own
+	  initialization priority
+
 source "drivers/flash/Kconfig.b91"
 
 source "drivers/flash/Kconfig.at45"

--- a/drivers/flash/flash_esp32.c
+++ b/drivers/flash/flash_esp32.c
@@ -835,5 +835,5 @@ static const struct flash_esp32_dev_config flash_esp32_config = {
 DEVICE_DT_INST_DEFINE(0, flash_esp32_init,
 		      NULL,
 		      &flash_esp32_data, &flash_esp32_config,
-		      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		      POST_KERNEL, CONFIG_FLASH_INIT_PRIORITY,
 		      &flash_esp32_driver_api);

--- a/drivers/flash/flash_gecko.c
+++ b/drivers/flash/flash_gecko.c
@@ -225,4 +225,4 @@ static struct flash_gecko_data flash_gecko_0_data;
 
 DEVICE_DT_INST_DEFINE(0, flash_gecko_init, NULL,
 		    &flash_gecko_0_data, NULL, POST_KERNEL,
-		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &flash_gecko_driver_api);
+		    CONFIG_FLASH_INIT_PRIORITY, &flash_gecko_driver_api);

--- a/drivers/flash/flash_ite_it8xxx2.c
+++ b/drivers/flash/flash_ite_it8xxx2.c
@@ -607,5 +607,5 @@ static struct flash_it8xxx2_dev_data flash_it8xxx2_data;
 DEVICE_DT_INST_DEFINE(0, flash_it8xxx2_init, NULL,
 		      &flash_it8xxx2_data, NULL,
 		      PRE_KERNEL_1,
-		      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+		      CONFIG_FLASH_INIT_PRIORITY,
 		      &flash_it8xxx2_api);

--- a/drivers/flash/flash_mcux_flexspi_hyperflash.c
+++ b/drivers/flash/flash_mcux_flexspi_hyperflash.c
@@ -677,7 +677,7 @@ static const struct flash_driver_api flash_flexspi_hyperflash_api = {
 			      &flash_flexspi_hyperflash_data_##n,	\
 			      &flash_flexspi_hyperflash_config_##n,	\
 			      POST_KERNEL,				\
-			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\
+			      CONFIG_FLASH_INIT_PRIORITY,		\
 			      &flash_flexspi_hyperflash_api);
 
 DT_INST_FOREACH_STATUS_OKAY(FLASH_FLEXSPI_HYPERFLASH)

--- a/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
+++ b/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
@@ -560,7 +560,7 @@ static const struct flash_driver_api flash_flexspi_nor_api = {
 			      &flash_flexspi_nor_data_##n,		\
 			      &flash_flexspi_nor_config_##n,		\
 			      POST_KERNEL,				\
-			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\
+			      CONFIG_FLASH_INIT_PRIORITY,		\
 			      &flash_flexspi_nor_api);
 
 DT_INST_FOREACH_STATUS_OKAY(FLASH_FLEXSPI_NOR)

--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -574,7 +574,7 @@ static const struct flash_driver_api flash_flexspi_nor_api = {
 			      &flash_flexspi_nor_data_##n,		\
 			      &flash_flexspi_nor_config_##n,		\
 			      POST_KERNEL,				\
-			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\
+			      CONFIG_FLASH_INIT_PRIORITY,		\
 			      &flash_flexspi_nor_api);
 
 DT_INST_FOREACH_STATUS_OKAY(FLASH_FLEXSPI_NOR)

--- a/drivers/flash/flash_sam.c
+++ b/drivers/flash/flash_sam.c
@@ -385,5 +385,5 @@ static struct flash_sam_dev_data flash_sam_data;
 
 DEVICE_DT_INST_DEFINE(0, flash_sam_init, NULL,
 		    &flash_sam_data, &flash_sam_cfg,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    POST_KERNEL, CONFIG_FLASH_INIT_PRIORITY,
 		    &flash_sam_api);

--- a/drivers/flash/flash_sam0.c
+++ b/drivers/flash/flash_sam0.c
@@ -468,4 +468,4 @@ static struct flash_sam0_data flash_sam0_data_0;
 
 DEVICE_DT_INST_DEFINE(0, flash_sam0_init, NULL,
 		    &flash_sam0_data_0, NULL, POST_KERNEL,
-		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &flash_sam0_api);
+		    CONFIG_FLASH_INIT_PRIORITY, &flash_sam0_api);

--- a/drivers/flash/flash_simulator.c
+++ b/drivers/flash/flash_simulator.c
@@ -436,7 +436,7 @@ static int flash_init(const struct device *dev)
 }
 
 DEVICE_DT_INST_DEFINE(0, flash_init, NULL,
-		    NULL, NULL, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    NULL, NULL, POST_KERNEL, CONFIG_FLASH_INIT_PRIORITY,
 		    &flash_sim_api);
 
 #ifdef CONFIG_ARCH_POSIX

--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -395,4 +395,4 @@ static int stm32_flash_init(const struct device *dev)
 
 DEVICE_DT_INST_DEFINE(0, stm32_flash_init, NULL,
 		    &flash_data, NULL, POST_KERNEL,
-		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &flash_stm32_api);
+		    CONFIG_FLASH_INIT_PRIORITY, &flash_stm32_api);

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -888,7 +888,7 @@ static struct flash_stm32_qspi_data flash_stm32_qspi_dev_data = {
 
 DEVICE_DT_INST_DEFINE(0, &flash_stm32_qspi_init, NULL,
 		      &flash_stm32_qspi_dev_data, &flash_stm32_qspi_cfg,
-		      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		      POST_KERNEL, CONFIG_FLASH_INIT_PRIORITY,
 		      &flash_stm32_qspi_driver_api);
 
 static void flash_stm32_qspi_irq_config_func(const struct device *dev)

--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -694,4 +694,4 @@ static int stm32h7_flash_init(const struct device *dev)
 
 DEVICE_DT_INST_DEFINE(0, stm32h7_flash_init, NULL,
 		    &flash_data, NULL, POST_KERNEL,
-		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &flash_stm32h7_api);
+		    CONFIG_FLASH_INIT_PRIORITY, &flash_stm32h7_api);

--- a/drivers/flash/soc_flash_b91.c
+++ b/drivers/flash/soc_flash_b91.c
@@ -180,4 +180,4 @@ static const struct flash_driver_api flash_b91_api = {
 /* Driver registration */
 DEVICE_DT_INST_DEFINE(0, flash_b91_init,
 		      NULL, &flash_data, NULL, POST_KERNEL,
-		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &flash_b91_api);
+		      CONFIG_FLASH_INIT_PRIORITY, &flash_b91_api);

--- a/drivers/flash/soc_flash_lpc.c
+++ b/drivers/flash/soc_flash_lpc.c
@@ -172,4 +172,4 @@ static int flash_lpc_init(const struct device *dev)
 
 DEVICE_DT_INST_DEFINE(0, flash_lpc_init, NULL,
 			&flash_data, NULL, POST_KERNEL,
-			CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &flash_lpc_api);
+			CONFIG_FLASH_INIT_PRIORITY, &flash_lpc_api);

--- a/drivers/flash/soc_flash_mcux.c
+++ b/drivers/flash/soc_flash_mcux.c
@@ -284,4 +284,4 @@ static int flash_mcux_init(const struct device *dev)
 
 DEVICE_DT_INST_DEFINE(0, flash_mcux_init, NULL,
 			&flash_data, NULL, POST_KERNEL,
-			CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &flash_mcux_api);
+			CONFIG_FLASH_INIT_PRIORITY, &flash_mcux_api);

--- a/drivers/flash/soc_flash_nios2_qspi.c
+++ b/drivers/flash/soc_flash_nios2_qspi.c
@@ -523,5 +523,5 @@ struct flash_nios2_qspi_config flash_cfg = {
 DEVICE_DEFINE(flash_nios2_qspi,
 		CONFIG_SOC_FLASH_NIOS2_QSPI_DEV_NAME,
 		flash_nios2_qspi_init, NULL, &flash_cfg, NULL,
-		POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		POST_KERNEL, CONFIG_FLASH_INIT_PRIORITY,
 		&flash_nios2_qspi_api);

--- a/drivers/flash/soc_flash_nrf.c
+++ b/drivers/flash/soc_flash_nrf.c
@@ -289,7 +289,7 @@ static int nrf_flash_init(const struct device *dev)
 
 DEVICE_DT_INST_DEFINE(0, nrf_flash_init, NULL,
 		 NULL, NULL,
-		 POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		 POST_KERNEL, CONFIG_FLASH_INIT_PRIORITY,
 		 &flash_nrf_api);
 
 #ifndef CONFIG_SOC_FLASH_NRF_RADIO_SYNC_NONE

--- a/drivers/flash/soc_flash_rv32m1.c
+++ b/drivers/flash/soc_flash_rv32m1.c
@@ -163,4 +163,4 @@ static int flash_mcux_init(const struct device *dev)
 
 DEVICE_DT_INST_DEFINE(0, flash_mcux_init, NULL,
 			&flash_data, NULL, POST_KERNEL,
-			CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &flash_mcux_api);
+			CONFIG_FLASH_INIT_PRIORITY, &flash_mcux_api);


### PR DESCRIPTION
Refactors all of the on-chip flash drivers to use a shared driver class
initialization priority configuration, CONFIG_FLASH_INIT_PRIORITY, to
allow configuring flash drivers separately from other devices. This is
similar to other driver classes like I2C and SPI.

The default is set to CONFIG_KERNEL_INIT_PRIORITY_DEVICE to preserve the
existing default initialization priority for most drivers.

Driver-specific options for SPI-based flash drivers are left intact
because they need to be initialized at a different priority than on-chip
flash drivers.

Signed-off-by: Maureen Helm <maureen.helm@intel.com>