### PR TITLE
cmake: Fix invalid warning related to rimage

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -826,8 +826,8 @@ function(board_finalize_runner_args runner)
 endfunction()
 
 function(board_set_rimage_target target)
-  zephyr_check_cache(RIMAGE_TARGET)
   set(RIMAGE_TARGET ${target} CACHE STRING "rimage target")
+  zephyr_check_cache(RIMAGE_TARGET)
 endfunction()
 
 # Zephyr board revision:


### PR DESCRIPTION
Fixes an issue on SOF-supported boards where the build system
incorrectly believed that the rimage target was changing when rerunning
CMake, even though the user did not change any configuration. This issue
was introduced in commit 525fa76f4dd13d42549261c9fc846a150ee291bc.

Create initial build dir:
$ west build --board intel_adsp_cavs18 samples/subsys/audio/sof

Re-run CMake with no arguments in that build dir:
$ cd build
$ cmake .

CMake Warning at /home/mhelm/zephyrproject/zephyr/cmake/extensions.cmake:2403 (message):
  The build directory must be cleaned pristinely when changing rimage target,

  Current value="", Ignored value="cnl"
Call Stack (most recent call first):
  /home/mhelm/zephyrproject/zephyr/cmake/extensions.cmake:829 (zephyr_check_cache)
  /home/mhelm/zephyrproject/zephyr/boards/xtensa/intel_adsp_cavs18/board.cmake:6 (board_set_rimage_target)
  /home/mhelm/zephyrproject/zephyr/cmake/app/boilerplate.cmake:635 (include)
  /home/mhelm/zephyrproject/zephyr/share/zephyr-package/cmake/ZephyrConfig.cmake:24 (include)
  /home/mhelm/zephyrproject/zephyr/share/zephyr-package/cmake/ZephyrConfig.cmake:40 (include_boilerplate)
  CMakeLists.txt:5 (find_package)

Signed-off-by: Maureen Helm <maureen.helm@intel.com>

Fixes #40808