### PR TITLE
pm: device_runtime: Use pm flags for runtime state

### DIFF
--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -37,6 +37,8 @@ enum pm_device_flag {
 	PM_DEVICE_FLAG_WS_CAPABLE,
 	/** Indicates if the device is being used as wakeup source. */
 	PM_DEVICE_FLAG_WS_ENABLED,
+	/** Indicates if device runtime is enabled  */
+	PM_DEVICE_FLAG_RUNTIME_ENABLED,
 };
 
 /** @endcond */
@@ -99,8 +101,6 @@ struct pm_device {
 	const struct device *dev;
 	/** Lock to synchronize the get/put operations */
 	struct k_mutex lock;
-	/** Device pm enable flag */
-	bool enable : 1;
 	/** Device usage count */
 	uint32_t usage;
 	/** Work object for asynchronous calls */


### PR DESCRIPTION
Although we are declaring `pm->enable`as bitfield, it ends up using
more memory due memory alignment.

Since we already have an atomic variable for device flags, this commit
adds a new flag to indicates whether or not device runtime is enabled.
Doing it we are saving some extra bits and avoiding need to lock the
mutex in several situations since we can atomically check if pm
runtime is enabled on a given device.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>