### PR TITLE
enable edma on mimxrt11xx series board

### DIFF
--- a/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm4.dts
+++ b/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm4.dts
@@ -36,3 +36,7 @@
 &lpi2c1 {
 	status = "okay";
 };
+
+&edma_lpsr0 {
+	status = "okay";
+};

--- a/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm7.dts
+++ b/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm7.dts
@@ -66,3 +66,7 @@
 &wdog1 {
 	status = "okay";
 };
+
+&edma0 {
+	status = "okay";
+};

--- a/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm4.dts
+++ b/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm4.dts
@@ -36,3 +36,7 @@
 &lpi2c1 {
 	status = "okay";
 };
+
+&edma_lpsr0 {
+	status = "okay";
+};

--- a/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm7.dts
+++ b/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm7.dts
@@ -62,3 +62,7 @@
 &lpadc0 {
 	status = "okay";
 };
+
+&edma0 {
+	status = "okay";
+};

--- a/drivers/clock_control/clock_control_mcux_ccm_rev2.c
+++ b/drivers/clock_control/clock_control_mcux_ccm_rev2.c
@@ -63,7 +63,10 @@ static int mcux_ccm_get_subsys_rate(const struct device *dev,
 
 #ifdef CONFIG_DMA_MCUX_EDMA
 	case IMX_CCM_EDMA_CLK:
-		clock_root = kCLOCK_Root_Edma + instance;
+		clock_root = kCLOCK_Root_Bus;
+		break;
+	case IMX_CCM_EDMA_LPSR_CLK:
+		clock_root = kCLOCK_Root_Bus_Lpsr;
 		break;
 #endif
 
@@ -78,6 +81,7 @@ static int mcux_ccm_get_subsys_rate(const struct device *dev,
 		clock_root = kCLOCK_Root_Gpt1 + instance;
 		break;
 #endif
+
 	default:
 		return -EINVAL;
 	}

--- a/drivers/dma/dma_mcux_edma.c
+++ b/drivers/dma/dma_mcux_edma.c
@@ -441,114 +441,80 @@ static int dma_mcux_edma_init(const struct device *dev)
 	return 0;
 }
 
-static void dma_imx_config_func_0(const struct device *dev);
+#define IRQ_CONFIG(node_id, idx, fn)					\
+	IF_ENABLED(DT_IRQ_HAS_IDX(node_id, idx), (			\
+		IRQ_CONNECT(DT_IRQ_BY_IDX(node_id, idx, irq),		\
+		DT_IRQ_BY_IDX(node_id, idx, priority),			\
+		fn,							\
+		DEVICE_DT_GET(node_id), 0);				\
+		irq_enable(DT_IRQ_BY_IDX(node_id, idx, irq));		\
+		))
 
-static const struct dma_mcux_edma_config dma_config_0 = {
-	.base = (DMA_Type *)DT_INST_REG_ADDR(0),
-	.dmamux_base = (DMAMUX_Type *)DT_INST_REG_ADDR_BY_IDX(0, 1),
-	.dma_channels = DT_INST_PROP(0, dma_channels),
-	.irq_config_func = dma_imx_config_func_0,
-};
+#define DMA_MCUX_EDMA_CONFIG_FUNC(n)					\
+	static void dma_imx_config_func_##n(const struct device *dev)	\
+	{								\
+		ARG_UNUSED(dev);					\
+									\
+		IRQ_CONFIG(DT_DRV_INST(n), 0,				\
+			dma_mcux_edma_irq_handler);			\
+		IRQ_CONFIG(DT_DRV_INST(n), 1,				\
+			dma_mcux_edma_irq_handler);			\
+		IRQ_CONFIG(DT_DRV_INST(n), 2,				\
+			dma_mcux_edma_irq_handler);			\
+		IRQ_CONFIG(DT_DRV_INST(n), 3,				\
+			dma_mcux_edma_irq_handler);			\
+		IRQ_CONFIG(DT_DRV_INST(n), 4,				\
+			dma_mcux_edma_irq_handler);			\
+		IRQ_CONFIG(DT_DRV_INST(n), 5,				\
+			dma_mcux_edma_irq_handler);			\
+		IRQ_CONFIG(DT_DRV_INST(n), 6,				\
+			dma_mcux_edma_irq_handler);			\
+		IRQ_CONFIG(DT_DRV_INST(n), 7,				\
+			dma_mcux_edma_irq_handler);			\
+		IRQ_CONFIG(DT_DRV_INST(n), 8,				\
+			dma_mcux_edma_irq_handler);			\
+		IRQ_CONFIG(DT_DRV_INST(n), 9,				\
+			dma_mcux_edma_irq_handler);			\
+		IRQ_CONFIG(DT_DRV_INST(n), 10,				\
+			dma_mcux_edma_irq_handler);			\
+		IRQ_CONFIG(DT_DRV_INST(n), 11,				\
+			dma_mcux_edma_irq_handler);			\
+		IRQ_CONFIG(DT_DRV_INST(n), 12,				\
+			dma_mcux_edma_irq_handler);			\
+		IRQ_CONFIG(DT_DRV_INST(n), 13,				\
+			dma_mcux_edma_irq_handler);			\
+		IRQ_CONFIG(DT_DRV_INST(n), 14,				\
+			dma_mcux_edma_irq_handler);			\
+		IRQ_CONFIG(DT_DRV_INST(n), 15,				\
+			dma_mcux_edma_irq_handler);			\
+									\
+		IRQ_CONFIG(DT_DRV_INST(n), 16,				\
+			dma_mcux_edma_error_irq_handler);		\
+									\
+		LOG_DBG("install irq done");				\
+	}
 
-struct dma_mcux_edma_data dma_data;
 /*
  * define the dma
  */
-DEVICE_DT_INST_DEFINE(0, &dma_mcux_edma_init, NULL,
-		    &dma_data, &dma_config_0, POST_KERNEL,
-		    CONFIG_DMA_INIT_PRIORITY, &dma_mcux_edma_api);
+#define DMA_INIT(n)							\
+	static void dma_imx_config_func_##n(const struct device *dev);	\
+	static const struct dma_mcux_edma_config dma_config_##n = {	\
+		.base = (DMA_Type *)DT_INST_REG_ADDR(n),		\
+		.dmamux_base =						\
+			(DMAMUX_Type *)DT_INST_REG_ADDR_BY_IDX(n, 1),	\
+		.dma_channels = DT_INST_PROP(n, dma_channels),		\
+		.irq_config_func = dma_imx_config_func_##n,		\
+	};								\
+									\
+	struct dma_mcux_edma_data dma_data_##n;				\
+									\
+	DEVICE_DT_INST_DEFINE(n,					\
+			    &dma_mcux_edma_init, NULL,			\
+			    &dma_data_##n, &dma_config_##n,		\
+			    POST_KERNEL, CONFIG_DMA_INIT_PRIORITY,	\
+			    &dma_mcux_edma_api);			\
+									\
+	DMA_MCUX_EDMA_CONFIG_FUNC(n);
 
-void dma_imx_config_func_0(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	/*install the dma error handle*/
-
-	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 0, irq),
-		    DT_INST_IRQ_BY_IDX(0, 0, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
-	irq_enable(DT_INST_IRQ_BY_IDX(0, 0, irq));
-
-	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 1, irq),
-		    DT_INST_IRQ_BY_IDX(0, 1, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
-	irq_enable(DT_INST_IRQ_BY_IDX(0, 1, irq));
-
-	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 2, irq),
-		    DT_INST_IRQ_BY_IDX(0, 2, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
-	irq_enable(DT_INST_IRQ_BY_IDX(0, 2, irq));
-
-	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 3, irq),
-		    DT_INST_IRQ_BY_IDX(0, 3, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
-	irq_enable(DT_INST_IRQ_BY_IDX(0, 3, irq));
-
-	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 4, irq),
-		    DT_INST_IRQ_BY_IDX(0, 4, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
-	irq_enable(DT_INST_IRQ_BY_IDX(0, 4, irq));
-
-	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 5, irq),
-		    DT_INST_IRQ_BY_IDX(0, 5, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
-	irq_enable(DT_INST_IRQ_BY_IDX(0, 5, irq));
-
-	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 6, irq),
-		    DT_INST_IRQ_BY_IDX(0, 6, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
-	irq_enable(DT_INST_IRQ_BY_IDX(0, 6, irq));
-
-	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 7, irq),
-		    DT_INST_IRQ_BY_IDX(0, 7, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
-	irq_enable(DT_INST_IRQ_BY_IDX(0, 7, irq));
-
-	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 8, irq),
-		    DT_INST_IRQ_BY_IDX(0, 8, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
-	irq_enable(DT_INST_IRQ_BY_IDX(0, 8, irq));
-
-	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 9, irq),
-		    DT_INST_IRQ_BY_IDX(0, 9, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
-	irq_enable(DT_INST_IRQ_BY_IDX(0, 9, irq));
-
-	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 10, irq),
-		    DT_INST_IRQ_BY_IDX(0, 10, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
-	irq_enable(DT_INST_IRQ_BY_IDX(0, 10, irq));
-
-	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 11, irq),
-		    DT_INST_IRQ_BY_IDX(0, 11, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
-	irq_enable(DT_INST_IRQ_BY_IDX(0, 11, irq));
-
-	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 12, irq),
-		    DT_INST_IRQ_BY_IDX(0, 12, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
-	irq_enable(DT_INST_IRQ_BY_IDX(0, 12, irq));
-
-	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 13, irq),
-		    DT_INST_IRQ_BY_IDX(0, 13, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
-	irq_enable(DT_INST_IRQ_BY_IDX(0, 13, irq));
-
-	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 14, irq),
-		    DT_INST_IRQ_BY_IDX(0, 14, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
-	irq_enable(DT_INST_IRQ_BY_IDX(0, 14, irq));
-
-	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 15, irq),
-		    DT_INST_IRQ_BY_IDX(0, 15, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
-	irq_enable(DT_INST_IRQ_BY_IDX(0, 15, irq));
-
-	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 16, irq),
-		    DT_INST_IRQ_BY_IDX(0, 16, priority),
-		    dma_mcux_edma_error_irq_handler,
-		    DEVICE_DT_INST_GET(0), 0);
-	irq_enable(DT_INST_IRQ_BY_IDX(0, 16, irq));
-
-	LOG_DBG("install irq done");
-}
+DT_INST_FOREACH_STATUS_OKAY(DMA_INIT)

--- a/dts/arm/nxp/nxp_rt1160_cm4.dtsi
+++ b/dts/arm/nxp/nxp_rt1160_cm4.dtsi
@@ -52,23 +52,23 @@
 			#gpio-cells = <2>;
 		};
 
-		edma1: dma-controller@40c14000 {
+		edma_lpsr0: dma-controller@40c14000 {
 			#dma-cells = <2>;
 			compatible = "nxp,mcux-edma";
 			dma-channels = <32>;
-			dma-requests = <128>;
+			dma-requests = <208>;
 			nxp,mem2mem;
 			nxp,a_on;
 			reg = <0x40c14000 0x4000>,
-				<0x400c1800 0x4000>;
-			clocks = <&ccm IMX_CCM_EDMA_CLK 0x7C 0x000000C0>;
-			status = "disabled";
-			label = "EDMA1";
+				<0x40c18000 0x4000>;
 			interrupts = <0 0>, <1 0>, <2 0>, <3 0>,
 				<4 0>, <5 0>, <6 0>, <7 0>,
 				<8 0>, <9 0>, <10 0>, <11 0>,
 				<12 0>, <13 0>, <14 0>, <15 0>,
 				<16 0>;
+			clocks = <&ccm IMX_CCM_EDMA_LPSR_CLK 0 0>;
+			status = "disabled";
+			label = "DMA_0";
 		};
 
 	};

--- a/dts/arm/nxp/nxp_rt1160_cm7.dtsi
+++ b/dts/arm/nxp/nxp_rt1160_cm7.dtsi
@@ -63,19 +63,19 @@
 			#dma-cells = <2>;
 			compatible = "nxp,mcux-edma";
 			dma-channels = <32>;
-			dma-requests = <128>;
+			dma-requests = <208>;
 			nxp,mem2mem;
 			nxp,a_on;
 			reg = <0x40070000 0x4000>,
 				<0x40074000 0x4000>;
-			clocks = <&ccm IMX_CCM_EDMA_CLK 0x7C 0x000000C0>;
-				status = "disabled";
-			label = "EDMA0";
 			interrupts = <0 0>, <1 0>, <2 0>, <3 0>,
 				<4 0>, <5 0>, <6 0>, <7 0>,
 				<8 0>, <9 0>, <10 0>, <11 0>,
 				<12 0>, <13 0>, <14 0>, <15 0>,
 				<16 0>;
+			clocks = <&ccm IMX_CCM_EDMA_CLK 0 0>;
+			status = "disabled";
+			label = "DMA_0";
 		};
 	};
 };

--- a/dts/arm/nxp/nxp_rt1170_cm4.dtsi
+++ b/dts/arm/nxp/nxp_rt1170_cm4.dtsi
@@ -52,23 +52,23 @@
 			#gpio-cells = <2>;
 		};
 
-		edma1: dma-controller@40c14000 {
+		edma_lpsr0: dma-controller@40c14000 {
 			#dma-cells = <2>;
 			compatible = "nxp,mcux-edma";
 			dma-channels = <32>;
-			dma-requests = <128>;
+			dma-requests = <208>;
 			nxp,mem2mem;
 			nxp,a_on;
 			reg = <0x40c14000 0x4000>,
-				<0x400c1800 0x4000>;
-			clocks = <&ccm IMX_CCM_EDMA_CLK 0x7C 0x000000C0>;
-			status = "disabled";
-			label = "EDMA1";
+				<0x40c18000 0x4000>;
 			interrupts = <0 0>, <1 0>, <2 0>, <3 0>,
 				<4 0>, <5 0>, <6 0>, <7 0>,
 				<8 0>, <9 0>, <10 0>, <11 0>,
 				<12 0>, <13 0>, <14 0>, <15 0>,
 				<16 0>;
+			clocks = <&ccm IMX_CCM_EDMA_LPSR_CLK 0 0>;
+			status = "disabled";
+			label = "DMA_0";
 		};
 	};
 };

--- a/dts/arm/nxp/nxp_rt1170_cm7.dtsi
+++ b/dts/arm/nxp/nxp_rt1170_cm7.dtsi
@@ -63,19 +63,19 @@
 			#dma-cells = <2>;
 			compatible = "nxp,mcux-edma";
 			dma-channels = <32>;
-			dma-requests = <128>;
+			dma-requests = <208>;
 			nxp,mem2mem;
 			nxp,a_on;
 			reg = <0x40070000 0x4000>,
 				<0x40074000 0x4000>;
-			clocks = <&ccm IMX_CCM_EDMA_CLK 0x7C 0x000000C0>;
-				status = "disabled";
-			label = "EDMA0";
 			interrupts = <0 0>, <1 0>, <2 0>, <3 0>,
 				<4 0>, <5 0>, <6 0>, <7 0>,
 				<8 0>, <9 0>, <10 0>, <11 0>,
 				<12 0>, <13 0>, <14 0>, <15 0>,
 				<16 0>;
+			clocks = <&ccm IMX_CCM_EDMA_CLK 0 0>;
+			status = "disabled";
+			label = "DMA_0";
 		};
 	};
 };


### PR DESCRIPTION
enable edma on mimxrt11xx series board

tested on mimxrt1160_evk_cm7, and build pass for mximxrt1160_evk_cm4

```
*** Booting Zephyr OS build v2.7.99-2040-g1aa4c3f4c2d6  ***
Running test suite dma_m2m_link_test
===================================================================
START - test_dma_m2m_chan0_1_major_link
Preparing DMA Controller: Chan_ID=1, BURST_LEN=1
Starting the transfer
DMA transfer done ch 0
It is harder to be kind than to be wise........
It is harder to
 PASS - test_dma_m2m_chan0_1_major_link in 2.15 seconds
===================================================================
START - test_dma_m2m_chan0_1_minor_link
Preparing DMA Controller: Chan_ID=1, BURST_LEN=1
Starting the transfer
DMA transfer done ch 0
It is harder to be kind than to be wise........
It is harder to be kind than to
 PASS - test_dma_m2m_chan0_1_minor_link in 2.14 seconds
===================================================================
START - test_dma_m2m_chan0_1_minor_major_link
Preparing DMA Controller: Chan_ID=1, BURST_LEN=1
Starting the transfer
DMA transfer done ch 0
DMA transfer done ch 1
It is harder to be kind than to be wise........
It is harder to be kind than to be wise........
 PASS - test_dma_m2m_chan0_1_minor_major_link in 2.15 seconds
===================================================================
Test suite dma_m2m_link_test succeeded
===================================================================
PROJECT EXECUTION SUCCESSFUL
```
