### PR TITLE
cmake: fix multiple shield parsing

### DIFF
--- a/cmake/kconfig.cmake
+++ b/cmake/kconfig.cmake
@@ -90,6 +90,8 @@ endforeach()
 # A list of common environment settings used when invoking Kconfig during CMake
 # configure time or menuconfig and related build target.
 string(REPLACE ";" "\\\;" SHIELD_AS_LIST_ESCAPED "${SHIELD_AS_LIST}")
+# cmake commands are escaped differently
+string(REPLACE ";" "\\;" SHIELD_AS_LIST_ESCAPED_COMMAND "${SHIELD_AS_LIST}")
 
 set(COMMON_KCONFIG_ENV_SETTINGS
   PYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}
@@ -251,7 +253,7 @@ endif()
 execute_process(
   COMMAND ${CMAKE_COMMAND} -E env
   ${COMMON_KCONFIG_ENV_SETTINGS}
-  SHIELD_AS_LIST=${SHIELD_AS_LIST_ESCAPED}
+  SHIELD_AS_LIST=${SHIELD_AS_LIST_ESCAPED_COMMAND}
   ${PYTHON_EXECUTABLE}
   ${ZEPHYR_BASE}/scripts/kconfig/kconfig.py
   --zephyr-base=${ZEPHYR_BASE}


### PR DESCRIPTION
When multiple shields are defined, only the shield last in the -DSHIELD
list gets defined in `.config`. This is due to too many backslashes
used defining it for an env setting.

To test this out, you can run the command `west build -b stm32f723e_disco samples/hello_world -DSHIELD="x_nucleo_idb05a1 x_nucleo_iks01a1"` from a clean environment and take a look at the `build/zephyr/.config` file. You noticed that there will only be `CONFIG_SHIELD_X_NUCLEO_IKS01A1=y` without this fix.

With this fix you'll see both `CONFIG_SHIELD_X_NUCLEO_IKS01A1=y` and `CONFIG_SHIELD_X_NUCLEO_IDB05A1=y`

Signed-off-by: Ryan McClelland <ryanmcclelland@fb.com>