### PR TITLE
Bluetooth: Controller: Support for Periodic Sync Receive enable 

### DIFF
--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -1650,6 +1650,9 @@ struct bt_hci_rp_le_read_ant_info {
 	uint8_t max_cte_len;
 };
 
+#define BT_HCI_LE_SET_PER_ADV_RECV_ENABLE_ENABLE           BIT(0)
+#define BT_HCI_LE_SET_PER_ADV_RECV_ENABLE_FILTER_DUPLICATE BIT(1)
+
 #define BT_HCI_OP_LE_SET_PER_ADV_RECV_ENABLE     BT_OP(BT_OGF_LE, 0x0059)
 struct bt_hci_cp_le_set_per_adv_recv_enable {
 	uint16_t handle;

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -3551,6 +3551,22 @@ static void le_per_adv_recv_enable(struct net_buf *buf, struct net_buf **evt)
 
 	status = ll_sync_recv_enable(handle, cmd->enable);
 
+#if CONFIG_BT_CTLR_DUP_FILTER_LEN > 0
+	if (!status) {
+		if (cmd->enable &
+		    BT_HCI_LE_SET_PER_ADV_RECV_ENABLE_FILTER_DUPLICATE) {
+			if (!dup_scan || (dup_count < 0)) {
+				dup_count = 0;
+				dup_curr = 0U;
+			} else {
+				/* FIXME: Invalidate dup_ext_adv_mode array entries */
+			}
+		} else if (!dup_scan) {
+			dup_count = DUP_FILTER_DISABLED;
+		}
+	}
+#endif
+
 	ccst = hci_cmd_complete(evt, sizeof(*ccst));
 	ccst->status = status;
 }

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -1679,7 +1679,7 @@ static void le_set_scan_enable(struct net_buf *buf, struct net_buf **evt)
 		if (0) {
 
 #if defined(CONFIG_BT_CTLR_SYNC_PERIODIC_ADI_SUPPORT)
-		} else if (dup_count <= DUP_FILTER_DISABLED) {
+		} else if (dup_count == DUP_FILTER_DISABLED) {
 			dup_scan = true;
 
 			/* All entries reset */
@@ -3396,7 +3396,7 @@ static void le_set_ext_scan_enable(struct net_buf *buf, struct net_buf **evt)
 		if (0) {
 
 #if defined(CONFIG_BT_CTLR_SYNC_PERIODIC_ADI_SUPPORT)
-		} else if (dup_count < 0) {
+		} else if (dup_count == DUP_FILTER_DISABLED) {
 			dup_scan = true;
 
 			/* All entries reset */
@@ -3473,7 +3473,7 @@ static void le_per_adv_create_sync(struct net_buf *buf, struct net_buf **evt)
 #if CONFIG_BT_CTLR_DUP_FILTER_LEN > 0
 	/* Initialize duplicate filtering */
 	if (cmd->options & BT_HCI_LE_PER_ADV_CREATE_SYNC_FP_FILTER_DUPLICATE) {
-		if (!dup_scan || (dup_count < 0)) {
+		if (!dup_scan || (dup_count == DUP_FILTER_DISABLED)) {
 			dup_count = 0;
 			dup_curr = 0U;
 		} else {
@@ -3555,7 +3555,7 @@ static void le_per_adv_recv_enable(struct net_buf *buf, struct net_buf **evt)
 	if (!status) {
 		if (cmd->enable &
 		    BT_HCI_LE_SET_PER_ADV_RECV_ENABLE_FILTER_DUPLICATE) {
-			if (!dup_scan || (dup_count < 0)) {
+			if (!dup_scan || (dup_count == DUP_FILTER_DISABLED)) {
 				dup_count = 0;
 				dup_curr = 0U;
 			} else {

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -6153,7 +6153,7 @@ static void le_per_adv_sync_report(struct pdu_data *pdu_data,
 	uint8_t hdr_len;
 	uint8_t *ptr;
 	int8_t rssi;
-	bool drop;
+	bool accept;
 
 	if (!(event_mask & BT_EVT_MASK_LE_META_EVENT) ||
 	    (!(le_event_mask & BT_EVT_MASK_LE_PER_ADVERTISING_REPORT) &&
@@ -6294,17 +6294,18 @@ no_ext_hdr:
 		/* FIXME: Use correct data status else chain PDU report will
 		 *        be filtered out.
 		 */
-		drop = !ftr->sync_rx_enabled ||
-		       (sync->nodups && dup_found(PDU_ADV_TYPE_EXT_IND,
-						  sync->peer_id_addr_type,
-						  sync->peer_id_addr,
-						  DUP_EXT_ADV_MODE_PERIODIC,
-						  adi, 0U));
+		accept = ftr->sync_rx_enabled &&
+			 (!sync->nodups ||
+			  !dup_found(PDU_ADV_TYPE_EXT_IND,
+				     sync->peer_id_addr_type,
+				     sync->peer_id_addr,
+				     DUP_EXT_ADV_MODE_PERIODIC,
+				     adi, 0U));
 #endif /* CONFIG_BT_CTLR_DUP_FILTER_LEN > 0 &&
 	* CONFIG_BT_CTLR_SYNC_PERIODIC_ADI_SUPPORT
 	*/
 	} else {
-		drop = !ftr->sync_rx_enabled;
+		accept = ftr->sync_rx_enabled;
 	}
 
 	data_len_max = ADV_REPORT_EVT_MAX_LEN -
@@ -6313,7 +6314,7 @@ no_ext_hdr:
 
 	evt_buf = buf;
 
-	if ((le_event_mask & BT_EVT_MASK_LE_PER_ADVERTISING_REPORT) && !drop) {
+	if ((le_event_mask & BT_EVT_MASK_LE_PER_ADVERTISING_REPORT) && accept) {
 		do {
 			struct bt_hci_evt_le_per_advertising_report *sep;
 			uint8_t data_len_frag;

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -6150,10 +6150,10 @@ static void le_per_adv_sync_report(struct pdu_data *pdu_data,
 	uint8_t data_len_max;
 	uint8_t *acad = NULL;
 	uint8_t hdr_buf_len;
-	bool dup = false;
 	uint8_t hdr_len;
 	uint8_t *ptr;
 	int8_t rssi;
+	bool drop;
 
 	if (!(event_mask & BT_EVT_MASK_LE_META_EVENT) ||
 	    (!(le_event_mask & BT_EVT_MASK_LE_PER_ADVERTISING_REPORT) &&
@@ -6283,23 +6283,29 @@ no_ext_hdr:
 		BT_DBG("    AD Data (%u): <todo>", data_len);
 	}
 
+	if (0) {
+
 #if (CONFIG_BT_CTLR_DUP_FILTER_LEN > 0) && \
 	defined(CONFIG_BT_CTLR_SYNC_PERIODIC_ADI_SUPPORT)
-	if (IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC_ADI_SUPPORT) && adi) {
+	} else if (IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC_ADI_SUPPORT) &&
+		   adi) {
 		const struct ll_sync_set *sync = HDR_LLL2ULL(ftr->param);
 
 		/* FIXME: Use correct data status else chain PDU report will
 		 *        be filtered out.
 		 */
-		dup = sync->nodups && dup_found(PDU_ADV_TYPE_EXT_IND,
-						sync->peer_id_addr_type,
-						sync->peer_id_addr,
-						DUP_EXT_ADV_MODE_PERIODIC,
-						adi, 0U);
-	}
+		drop = !ftr->sync_rx_enabled ||
+		       (sync->nodups && dup_found(PDU_ADV_TYPE_EXT_IND,
+						  sync->peer_id_addr_type,
+						  sync->peer_id_addr,
+						  DUP_EXT_ADV_MODE_PERIODIC,
+						  adi, 0U));
 #endif /* CONFIG_BT_CTLR_DUP_FILTER_LEN > 0 &&
 	* CONFIG_BT_CTLR_SYNC_PERIODIC_ADI_SUPPORT
 	*/
+	} else {
+		drop = !ftr->sync_rx_enabled;
+	}
 
 	data_len_max = ADV_REPORT_EVT_MAX_LEN -
 		       sizeof(struct bt_hci_evt_le_meta_event) -
@@ -6307,7 +6313,7 @@ no_ext_hdr:
 
 	evt_buf = buf;
 
-	if (!dup && (le_event_mask & BT_EVT_MASK_LE_PER_ADVERTISING_REPORT)) {
+	if ((le_event_mask & BT_EVT_MASK_LE_PER_ADVERTISING_REPORT) && !drop) {
 		do {
 			struct bt_hci_evt_le_per_advertising_report *sep;
 			uint8_t data_len_frag;

--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -335,7 +335,8 @@ struct node_rx_ftr {
 	uint8_t  aux_w4next:1;
 	uint8_t  aux_failed:1;
 #if defined(CONFIG_BT_CTLR_SYNC_PERIODIC)
-	uint8_t sync_status:2;
+	uint8_t  sync_status:2;
+	uint8_t  sync_rx_enabled:1;
 #endif /* CONFIG_BT_CTLR_SYNC_PERIODIC */
 
 	uint8_t  phy_flags:1;

--- a/subsys/bluetooth/controller/ll_sw/lll_sync.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_sync.h
@@ -18,13 +18,13 @@ struct lll_sync {
 	uint8_t crc_init[3];
 
 	uint8_t phy:3;
-	uint8_t is_rx_enabled:1;
 	/* Bitmask providing not allowed types of CTE. */
 	uint8_t cte_type:5;
 	/* The member is required for filtering by CTE type. If filtering policy is disabled then
 	 * synchronization is terminated for periodic advertisements with wrong CTE type.
 	 */
 	uint8_t filter_policy:1;
+	uint8_t is_rx_enabled:1;
 	uint8_t is_aux_sched:1;
 
 #if defined(CONFIG_BT_CTLR_SYNC_ISO)

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -616,7 +616,7 @@ static void isr_aux_setup(void *param)
 static int isr_rx(struct lll_sync *lll, uint8_t node_type, uint8_t crc_ok, uint8_t rssi_ready,
 		  enum sync_status status)
 {
-	uint8_t sched = 0U;
+	bool sched = false;
 	int err;
 
 	/* Check CRC and generate Periodic Advertising Report */
@@ -659,21 +659,21 @@ static int isr_rx(struct lll_sync *lll, uint8_t node_type, uint8_t crc_ok, uint8
 
 			ull_rx_put(node_rx->hdr.link, node_rx);
 
-			sched = 1U;
+			sched = true;
 		} else {
 			err = 0;
 		}
 
 #if defined(CONFIG_BT_CTLR_DF_SCAN_CTE_RX)
 		(void)create_iq_report(lll, rssi_ready, BT_HCI_LE_CTE_CRC_OK);
-		sched = 1U;
+		sched = true;
 #endif /* CONFIG_BT_CTLR_DF_SCAN_CTE_RX */
 
 	} else {
 #if defined(CONFIG_BT_CTLR_DF_SAMPLE_CTE_FOR_PDU_WITH_BAD_CRC)
 		err = create_iq_report(lll, rssi_ready, BT_HCI_LE_CTE_CRC_ERR_CTE_BASED_TIME);
 		if (!err) {
-			sched = 1U;
+			sched = true;
 		}
 #endif /* CONFIG_BT_CTLR_DF_SAMPLE_CTE_FOR_PDU_WITH_BAD_CRC */
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -616,6 +616,7 @@ static void isr_aux_setup(void *param)
 static int isr_rx(struct lll_sync *lll, uint8_t node_type, uint8_t crc_ok, uint8_t rssi_ready,
 		  enum sync_status status)
 {
+	uint8_t sched = 0U;
 	int err;
 
 	/* Check CRC and generate Periodic Advertising Report */
@@ -623,7 +624,8 @@ static int isr_rx(struct lll_sync *lll, uint8_t node_type, uint8_t crc_ok, uint8
 		struct node_rx_pdu *node_rx;
 
 		node_rx = ull_pdu_rx_alloc_peek(3);
-		if (node_rx) {
+		if (node_rx &&
+		    (lll->is_rx_enabled || (node_type == NODE_RX_TYPE_SYNC))) {
 			struct node_rx_ftr *ftr;
 			struct pdu_adv *pdu;
 
@@ -657,23 +659,29 @@ static int isr_rx(struct lll_sync *lll, uint8_t node_type, uint8_t crc_ok, uint8
 
 			ull_rx_put(node_rx->hdr.link, node_rx);
 
-#if defined(CONFIG_BT_CTLR_DF_SCAN_CTE_RX)
-			(void)create_iq_report(lll, rssi_ready,
-					       BT_HCI_LE_CTE_CRC_OK);
-#endif /* CONFIG_BT_CTLR_DF_SCAN_CTE_RX */
-
-			ull_rx_sched();
+			sched = 1U;
 		} else {
 			err = 0;
 		}
+
+#if defined(CONFIG_BT_CTLR_DF_SCAN_CTE_RX)
+		(void)create_iq_report(lll, rssi_ready, BT_HCI_LE_CTE_CRC_OK);
+		sched = 1U;
+#endif /* CONFIG_BT_CTLR_DF_SCAN_CTE_RX */
+
 	} else {
 #if defined(CONFIG_BT_CTLR_DF_SAMPLE_CTE_FOR_PDU_WITH_BAD_CRC)
 		err = create_iq_report(lll, rssi_ready, BT_HCI_LE_CTE_CRC_ERR_CTE_BASED_TIME);
 		if (!err) {
-			ull_rx_sched();
+			sched = 1U;
 		}
 #endif /* CONFIG_BT_CTLR_DF_SAMPLE_CTE_FOR_PDU_WITH_BAD_CRC */
+
 		err = 0;
+	}
+
+	if (sched) {
+		ull_rx_sched();
 	}
 
 	return err;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -624,8 +624,7 @@ static int isr_rx(struct lll_sync *lll, uint8_t node_type, uint8_t crc_ok, uint8
 		struct node_rx_pdu *node_rx;
 
 		node_rx = ull_pdu_rx_alloc_peek(3);
-		if (node_rx &&
-		    (lll->is_rx_enabled || (node_type == NODE_RX_TYPE_SYNC))) {
+		if (node_rx) {
 			struct node_rx_ftr *ftr;
 			struct pdu_adv *pdu;
 
@@ -643,6 +642,7 @@ static int isr_rx(struct lll_sync *lll, uint8_t node_type, uint8_t crc_ok, uint8
 					    radio_rx_chain_delay_get(lll->phy,
 								     1);
 			ftr->sync_status = status;
+			ftr->sync_rx_enabled = lll->is_rx_enabled;
 
 			pdu = (void *)node_rx->pdu;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -348,6 +348,17 @@ uint8_t ll_sync_terminate(uint16_t handle)
 	return 0;
 }
 
+/* @brief Link Layer interface function corresponding to HCI LE Set Periodic
+ *        Advertising Receive Enable command.
+ *
+ * @param[in] handle Sync_Handle identifying the periodic advertising
+ *                   train. Range: 0x0000 to 0x0EFF.
+ * @param[in] enable Bit number 0 - Reporting Enabled.
+ *                   Bit number 1 - Duplicate filtering enabled.
+ *                   All other bits - Reserved for future use.
+ *
+ * @return HCI error codes as documented in Bluetooth Core Specification v5.3.
+ */
 uint8_t ll_sync_recv_enable(uint16_t handle, uint8_t enable)
 {
 	struct ll_sync_set *sync;

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -227,7 +227,7 @@ uint8_t ll_sync_create(uint8_t options, uint8_t sid, uint8_t adv_addr_type,
 	lll_sync->filter_policy = scan->per_scan.filter_policy;
 #endif /* CONFIG_BT_CTLR_SYNC_PERIODIC_CTE_TYPE_FILTERING */
 
-	/* TODO: Add support for reporting initially enabled/disabled */
+	/* Reporting initially enabled/disabled */
 	lll_sync->is_rx_enabled =
 		!(options & BT_HCI_LE_PER_ADV_CREATE_SYNC_FP_REPORTS_DISABLED);
 
@@ -349,8 +349,27 @@ uint8_t ll_sync_terminate(uint16_t handle)
 
 uint8_t ll_sync_recv_enable(uint16_t handle, uint8_t enable)
 {
-	/* TODO: Add support for reporting enable/disable */
-	return BT_HCI_ERR_CMD_DISALLOWED;
+	struct ll_sync_set *sync;
+	struct lll_sync *lll;
+
+	sync = ull_sync_is_enabled_get(handle);
+	if (!sync) {
+		return BT_HCI_ERR_UNKNOWN_ADV_IDENTIFIER;
+	}
+
+	/* Reporting enabled/disabled */
+	lll = &sync->lll;
+	lll->is_rx_enabled = (enable &
+			      BT_HCI_LE_SET_PER_ADV_RECV_ENABLE_ENABLE) ?
+			      1U : 0U;
+
+#if defined(CONFIG_BT_CTLR_SYNC_PERIODIC_ADI_SUPPORT)
+	sync->nodups = (enable &
+			BT_HCI_LE_SET_PER_ADV_RECV_ENABLE_FILTER_DUPLICATE) ?
+		       1U : 0U;
+#endif
+
+	return 0;
 }
 
 int ull_sync_init(void)
@@ -694,6 +713,7 @@ void ull_sync_established_report(memq_link_t *link, struct node_rx_hdr *rx)
 	struct lll_sync *lll;
 
 	ftr = &rx->rx_ftr;
+	lll = ftr->param;
 
 #if defined(CONFIG_BT_CTLR_SYNC_PERIODIC_CTE_TYPE_FILTERING)
 	enum sync_status sync_status;
@@ -702,8 +722,6 @@ void ull_sync_established_report(memq_link_t *link, struct node_rx_hdr *rx)
 	sync_status = ftr->sync_status;
 #else
 	struct pdu_cte_info *rx_cte_info;
-
-	lll = ftr->param;
 
 	rx_cte_info = pdu_cte_info_get((struct pdu_adv *)((struct node_rx_pdu *)rx)->pdu);
 	if (rx_cte_info != NULL) {
@@ -719,14 +737,14 @@ void ull_sync_established_report(memq_link_t *link, struct node_rx_hdr *rx)
 	 * or the CTE type is incorrect and filter policy doesn't allow to continue scanning.
 	 */
 	if (sync_status != SYNC_STAT_READY_OR_CONT_SCAN) {
-#else
+#else /* !CONFIG_BT_CTLR_SYNC_PERIODIC_CTE_TYPE_FILTERING */
+
 	if (1) {
-#endif /* CONFIG_BT_CTLR_SYNC_PERIODIC_CTE_TYPE_FILTERING */
+#endif /* !CONFIG_BT_CTLR_SYNC_PERIODIC_CTE_TYPE_FILTERING */
 
 		/* Set the sync handle corresponding to the LLL context passed in the node rx
 		 * footer field.
 		 */
-		lll = ftr->param;
 		ull_sync = HDR_LLL2ULL(lll);
 
 		/* Prepare and dispatch sync notification */
@@ -761,15 +779,20 @@ void ull_sync_established_report(memq_link_t *link, struct node_rx_hdr *rx)
 	 * scanning is terminated due to wrong CTE type.
 	 */
 	if (sync_status != SYNC_STAT_TERM) {
-#else
+#else /* !CONFIG_BT_CTLR_SYNC_PERIODIC_CTE_TYPE_FILTERING */
+
 	if (1) {
-#endif /* CONFIG_BT_CTLR_SYNC_PERIODIC_CTE_TYPE_FILTERING */
+#endif /* !CONFIG_BT_CTLR_SYNC_PERIODIC_CTE_TYPE_FILTERING */
 		/* Switch sync event prepare function to one reposnsible for regular PDUs receive */
 		mfy_lll_prepare.fp = lll_sync_prepare;
 
-		/* Change node type to appropriately handle periodic advertising PDU report */
-		rx->type = NODE_RX_TYPE_SYNC_REPORT;
-		ull_scan_aux_setup(link, rx);
+		if (lll->is_rx_enabled) {
+			/* Change node type to appropriately handle periodic
+			 * advertising PDU report.
+			 */
+			rx->type = NODE_RX_TYPE_SYNC_REPORT;
+			ull_scan_aux_setup(link, rx);
+		}
 	}
 }
 

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -179,6 +179,10 @@ uint8_t ll_sync_create(uint8_t options, uint8_t sid, uint8_t adv_addr_type,
 	sync->node_rx_sync_estab = node_rx;
 	sync->node_rx_lost.hdr.link = link_sync_lost;
 
+	/* Reporting initially enabled/disabled */
+	sync->rx_enable =
+		!(options & BT_HCI_LE_PER_ADV_CREATE_SYNC_FP_REPORTS_DISABLED);
+
 #if defined(CONFIG_BT_CTLR_SYNC_PERIODIC_ADI_SUPPORT)
 	sync->nodups = (options &
 			BT_HCI_LE_PER_ADV_CREATE_SYNC_FP_FILTER_DUPLICATE) ?
@@ -218,6 +222,7 @@ uint8_t ll_sync_create(uint8_t options, uint8_t sid, uint8_t adv_addr_type,
 
 	/* Initialize sync LLL context */
 	lll_sync = &sync->lll;
+	lll_sync->is_rx_enabled = sync->rx_enable;
 	lll_sync->skip_prepare = 0U;
 	lll_sync->skip_event = 0U;
 	lll_sync->window_widening_prepare_us = 0U;
@@ -226,10 +231,6 @@ uint8_t ll_sync_create(uint8_t options, uint8_t sid, uint8_t adv_addr_type,
 	lll_sync->cte_type = sync_cte_type;
 	lll_sync->filter_policy = scan->per_scan.filter_policy;
 #endif /* CONFIG_BT_CTLR_SYNC_PERIODIC_CTE_TYPE_FILTERING */
-
-	/* Reporting initially enabled/disabled */
-	lll_sync->is_rx_enabled =
-		!(options & BT_HCI_LE_PER_ADV_CREATE_SYNC_FP_REPORTS_DISABLED);
 
 #if defined(CONFIG_BT_CTLR_DF_SCAN_CTE_RX)
 	ull_df_sync_cfg_init(&lll_sync->df_cfg);
@@ -350,7 +351,6 @@ uint8_t ll_sync_terminate(uint16_t handle)
 uint8_t ll_sync_recv_enable(uint16_t handle, uint8_t enable)
 {
 	struct ll_sync_set *sync;
-	struct lll_sync *lll;
 
 	sync = ull_sync_is_enabled_get(handle);
 	if (!sync) {
@@ -358,10 +358,8 @@ uint8_t ll_sync_recv_enable(uint16_t handle, uint8_t enable)
 	}
 
 	/* Reporting enabled/disabled */
-	lll = &sync->lll;
-	lll->is_rx_enabled = (enable &
-			      BT_HCI_LE_SET_PER_ADV_RECV_ENABLE_ENABLE) ?
-			      1U : 0U;
+	sync->rx_enable = (enable & BT_HCI_LE_SET_PER_ADV_RECV_ENABLE_ENABLE) ?
+			  1U : 0U;
 
 #if defined(CONFIG_BT_CTLR_SYNC_PERIODIC_ADI_SUPPORT)
 	sync->nodups = (enable &
@@ -713,7 +711,6 @@ void ull_sync_established_report(memq_link_t *link, struct node_rx_hdr *rx)
 	struct lll_sync *lll;
 
 	ftr = &rx->rx_ftr;
-	lll = ftr->param;
 
 #if defined(CONFIG_BT_CTLR_SYNC_PERIODIC_CTE_TYPE_FILTERING)
 	enum sync_status sync_status;
@@ -722,6 +719,8 @@ void ull_sync_established_report(memq_link_t *link, struct node_rx_hdr *rx)
 	sync_status = ftr->sync_status;
 #else
 	struct pdu_cte_info *rx_cte_info;
+
+	lll = ftr->param;
 
 	rx_cte_info = pdu_cte_info_get((struct pdu_adv *)((struct node_rx_pdu *)rx)->pdu);
 	if (rx_cte_info != NULL) {
@@ -745,6 +744,7 @@ void ull_sync_established_report(memq_link_t *link, struct node_rx_hdr *rx)
 		/* Set the sync handle corresponding to the LLL context passed in the node rx
 		 * footer field.
 		 */
+		lll = ftr->param;
 		ull_sync = HDR_LLL2ULL(lll);
 
 		/* Prepare and dispatch sync notification */
@@ -786,13 +786,11 @@ void ull_sync_established_report(memq_link_t *link, struct node_rx_hdr *rx)
 		/* Switch sync event prepare function to one reposnsible for regular PDUs receive */
 		mfy_lll_prepare.fp = lll_sync_prepare;
 
-		if (lll->is_rx_enabled) {
-			/* Change node type to appropriately handle periodic
-			 * advertising PDU report.
-			 */
-			rx->type = NODE_RX_TYPE_SYNC_REPORT;
-			ull_scan_aux_setup(link, rx);
-		}
+		/* Change node type to appropriately handle periodic
+		 * advertising PDU report.
+		 */
+		rx->type = NODE_RX_TYPE_SYNC_REPORT;
+		ull_scan_aux_setup(link, rx);
 	}
 }
 
@@ -1079,6 +1077,9 @@ static void ticker_cb(uint32_t ticks_at_expire, uint32_t ticks_drift,
 	DEBUG_RADIO_PREPARE_O(1);
 
 	lll = &sync->lll;
+
+	/* Commit receive enable changed value */
+	lll->is_rx_enabled = sync->rx_enable;
 
 	/* Increment prepare reference count */
 	ref = ull_ref_inc(&sync->ull);

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -362,8 +362,7 @@ uint8_t ll_sync_recv_enable(uint16_t handle, uint8_t enable)
 			  1U : 0U;
 
 #if defined(CONFIG_BT_CTLR_SYNC_PERIODIC_ADI_SUPPORT)
-	sync->nodups = (enable &
-			BT_HCI_LE_SET_PER_ADV_RECV_ENABLE_FILTER_DUPLICATE) ?
+	sync->nodups = (enable & BT_HCI_LE_SET_PER_ADV_RECV_ENABLE_FILTER_DUPLICATE) ?
 		       1U : 0U;
 #endif
 

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_types.h
@@ -29,6 +29,8 @@ struct ll_sync_set {
 	* CONFIG_BT_CTLR_SYNC_PERIODIC_ADI_SUPPORT
 	*/
 
+	uint8_t rx_enable:1;
+
 #if defined(CONFIG_BT_CTLR_SYNC_PERIODIC_ADI_SUPPORT)
 	uint8_t nodups:1;
 #endif


### PR DESCRIPTION
Initial support for Periodic Advertising Synchronization
Receive Enable command.

Update support for Periodic Advertising Synchronization
Receive Enable command, so that PDUs are received so that
contents of Extended Common Payload Format is parsed and
process for information like Channel Map Update and BIGInfo.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>