### PR TITLE
usb: bluetooth: do not start transfers when USB bus is suspended 

### DIFF
--- a/drivers/usb/device/Kconfig
+++ b/drivers/usb/device/Kconfig
@@ -16,7 +16,7 @@ config USB_DC_HAS_HS_SUPPORT
 	  USB device controller supports high speed.
 
 config USB_DEVICE_REMOTE_WAKEUP
-	bool
+	bool "Enable remote wakeup support"
 	help
 	  USB device controller supports remote wakeup feature.
 
@@ -81,7 +81,7 @@ config USB_NRFX
 	depends on HAS_HW_NRF_USBD
 	select NRFX_USBD
 	select NRFX_POWER
-	select USB_DEVICE_REMOTE_WAKEUP
+	imply USB_DEVICE_REMOTE_WAKEUP
 	help
 	  nRF USB Device Controller Driver
 

--- a/subsys/usb/class/bluetooth.c
+++ b/subsys/usb/class/bluetooth.c
@@ -19,6 +19,7 @@
 #include <bluetooth/l2cap.h>
 #include <bluetooth/hci_vs.h>
 #include <drivers/bluetooth/hci_driver.h>
+#include <sys/atomic.h>
 
 #define LOG_LEVEL CONFIG_USB_DEVICE_LOG_LEVEL
 #include <logging/log.h>
@@ -42,7 +43,11 @@ static struct k_thread tx_thread_data;
 
 /* HCI USB state flags */
 static bool configured;
-static bool suspended;
+/*
+ * Shared variable between bluetooth_status_cb() and hci_tx_thread(),
+ * where hci_tx_thread() has read-only access to it.
+ */
+static atomic_t suspended;
 
 static uint8_t ep_out_buf[USB_MAX_FS_BULK_MPS];
 
@@ -131,6 +136,21 @@ static void hci_tx_thread(void)
 		    bt_hci_raw_get_mode() == BT_HCI_RAW_MODE_H4) {
 			/* Force to sent over bulk if H4 is selected */
 			bt_buf_set_type(buf, BT_BUF_ACL_IN);
+		}
+
+		if (atomic_get(&suspended)) {
+			if (usb_wakeup_request()) {
+				LOG_DBG("Remote wakeup not enabled/supported");
+			}
+			/*
+			 * Let's wait until operation is resumed.
+			 * This is independent of usb_wakeup_request() result,
+			 * as long as device is suspended it should not start
+			 * any transfers.
+			 */
+			while (atomic_get(&suspended)) {
+				k_sleep(K_MSEC(1));
+			}
 		}
 
 		switch (bt_buf_get_type(buf)) {
@@ -269,13 +289,14 @@ static void bluetooth_status_cb(struct usb_cfg_data *cfg,
 				const uint8_t *param)
 {
 	ARG_UNUSED(cfg);
+	atomic_val_t tmp;
 
 	/* Check the USB status and do needed action if required */
 	switch (status) {
 	case USB_DC_RESET:
 		LOG_DBG("Device reset detected");
 		configured = false;
-		suspended = false;
+		atomic_clear(&suspended);
 		break;
 	case USB_DC_CONFIGURED:
 		LOG_DBG("Device configured");
@@ -293,17 +314,16 @@ static void bluetooth_status_cb(struct usb_cfg_data *cfg,
 		usb_cancel_transfer(bluetooth_ep_data[HCI_IN_EP_IDX].ep_addr);
 		usb_cancel_transfer(bluetooth_ep_data[HCI_OUT_EP_IDX].ep_addr);
 		configured = false;
-		suspended = false;
+		atomic_clear(&suspended);
 		break;
 	case USB_DC_SUSPEND:
 		LOG_DBG("Device suspended");
-		suspended = true;
+		atomic_set(&suspended, 1);
 		break;
 	case USB_DC_RESUME:
-		LOG_DBG("Device resumed");
-		if (suspended) {
-			LOG_DBG("from suspend");
-			suspended = false;
+		tmp = atomic_clear(&suspended);
+		if (tmp) {
+			LOG_DBG("Device resumed from suspend");
 			if (configured) {
 				/* Start reading */
 				acl_read_cb(bluetooth_ep_data[HCI_OUT_EP_IDX].ep_addr,


### PR DESCRIPTION
Do not start transfers when USB bus is suspended.
If the bus is suspended, initiate remote-wakeup and
wait until the bus is operational.

Allow to disable option USB_DEVICE_REMOTE_WAKEUP.

Fixes: #40776