### PR TITLE
scripts: checkpatch: typedefsfile: add pinctrl_soc_pin_t

### DIFF
--- a/scripts/checkpatch/typedefsfile
+++ b/scripts/checkpatch/typedefsfile
@@ -2,3 +2,4 @@ _cpu_arch_t
 k_mem_partition_attr_t
 mbedtls_pk_context
 z_arch_esf_t
+pinctrl_soc_pin_t


### PR DESCRIPTION
The pinctrl_soc_pin_t is used as an opaque type in pinctrl to store pin
configurations which are SoC-dependent.