### PR TITLE
twister: Protect hardware-map file accesses

### DIFF
--- a/doc/guides/test/twister.rst
+++ b/doc/guides/test/twister.rst
@@ -585,12 +585,6 @@ The above command will result in twister building tests for the platforms
 defined in the hardware map and subsequently flashing and running the tests
 on those platforms.
 
-.. note::
-
-  Currently only boards with support for both pyocd and nrfjprog are supported
-  with the hardware map features. Boards that require other runners to flash the
-  Zephyr binary are still work in progress.
-
 Fixtures
 +++++++++
 


### PR DESCRIPTION
Attempt to fix https://github.com/zephyrproject-rtos/zephyr/issues/39179.

First step is to add exception on file accesses in order to detected potential issues earlier and provide meaningful error message.

Note: I can't reproduce the issue I'm often seeing with this first step.
This being said I don't consider this could fix all cases.