### PR TITLE
GH Action 2.7 backports

### DIFF
--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -85,7 +85,7 @@ jobs:
 
       - name: ccache stats initial
         run: |
-          test -d github/home/.ccache && mv github/home/.ccache /github/home/.ccache
+          test -d github/home/.ccache && rm -rf /github/home/.ccache && mv github/home/.ccache /github/home/.ccache
           ccache -M 10G -s
 
       - name: Run Tests with Twister

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -16,6 +16,8 @@ jobs:
     container:
       image: zephyrprojectrtos/ci:v0.18.4
       options: '--entrypoint /bin/bash'
+      volumes:
+        - /home/runners/zephyrproject:/github/cache/zephyrproject
     strategy:
       fail-fast: false
       matrix:
@@ -53,7 +55,7 @@ jobs:
           # So first retry to update, if that does not work, remove all modules
           # and start over. (Workaround until we implement more robust module
           # west caching).
-          west update 2>&1 1> west.log || west update 2>&1 1> west2.log || ( rm -rf ../modules && west update)
+          west update --path-cache /github/cache/zephyrproject 2>&1 1> west.log || west update --path-cache /github/cache/zephyrproject 2>&1 1> west2.log || ( rm -rf ../modules && west update --path-cache /github/cache/zephyrproject)
 
       - name: Check Environment
         run: |

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -22,6 +22,8 @@ jobs:
     container:
       image: zephyrprojectrtos/ci:v0.18.4
       options: '--entrypoint /bin/bash'
+      volumes:
+        - /home/runners/zephyrproject:/github/cache/zephyrproject
     outputs:
       subset: ${{ steps.output-services.outputs.subset }}
       size: ${{ steps.output-services.outputs.size }}
@@ -120,6 +122,8 @@ jobs:
     container:
       image: zephyrprojectrtos/ci:v0.18.4
       options: '--entrypoint /bin/bash'
+      volumes:
+        - /home/runners/zephyrproject:/github/cache/zephyrproject
     strategy:
       fail-fast: false
       matrix:
@@ -158,7 +162,7 @@ jobs:
 
           west init -l . || true
           west config --global update.narrow true
-          west update 2>&1 1> west.update.log || west update 2>&1 1> west.update.log
+          west update --path-cache /github/cache/zephyrproject 2>&1 1> west.update.log || west update --path-cache /github/cache/zephyrproject 2>&1 1> west.update.log || ( rm -rf ../modules && west update --path-cache /github/cache/zephyrproject)
           west forall -c 'git reset --hard HEAD'
 
       - name: Check Environment

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -72,39 +72,26 @@ jobs:
             echo "Your branch is not up to date, you need to rebase on top of latest HEAD of main branch"
             exit 1
           )
-          python3 ./scripts/ci/test_plan.py -c origin/${BASE_REF}.. --pull-request
+          python3 ./scripts/ci/test_plan.py -c origin/${BASE_REF}.. --pull-request -t $TESTS_PER_BUILDER
+          if [ -s .testplan ]; then
+            cat .testplan >> $GITHUB_ENV
+          else
+            echo "TWISTER_NODES=${MATRIX_SIZE}" >> $GITHUB_ENV
+          fi
 
-          # get number of tests
-          if [ -s testplan.csv ]; then
-            lines=$(wc -l < testplan.csv)
-          else
-            lines=1
-          fi
-          if [ "$lines" = 1 ]; then
-            # no tests, so we need 0 nodes
-            nodes=0
-          else
-            nodes=$(( ${lines} / ${TESTS_PER_BUILDER}))
-            if [ ${nodes} -gt 4 -a ${nodes} -lt 10 ]; then
-              nodes=${MATRIX_SIZE}
-            elif [ "${nodes}" = 0 ]; then
-              # for less than TESTS_PER_BUILDER, we take at least 1 node
-              nodes=1
-            fi
-          fi
-          echo "::set-output name=calculated_matrix_size::${nodes}";
-          rm -f testplan.csv
+
+          rm -f testplan.csv .testplan
 
       - name: Determine matrix size
         id: output-services
         run: |
           if [ "${{github.event_name}}" = "pull_request_target" ]; then
-            if [ -n "${{steps.test-plan.outputs.calculated_matrix_size}}" ]; then
-              subset="[$(seq -s',' 1 ${{steps.test-plan.outputs.calculated_matrix_size}})]"
+            if [ -n "${TWISTER_NODES}" ]; then
+              subset="[$(seq -s',' 1 ${TWISTER_NODES})]"
             else
               subset="[$(seq -s',' 1 ${MATRIX_SIZE})]"
             fi
-            size=${{ steps.test-plan.outputs.calculated_matrix_size }}
+            size=${TWISTER_NODES}
           elif [ "${{github.event_name}}" = "push" ]; then
             subset="[$(seq -s',' 1 ${PUSH_MATRIX_SIZE})]"
             size=${MATRIX_SIZE}

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -26,7 +26,8 @@ jobs:
       subset: ${{ steps.output-services.outputs.subset }}
       size: ${{ steps.output-services.outputs.size }}
     env:
-      MATRIX_SIZE: 15
+      MATRIX_SIZE: 10
+      PUSH_MATRIX_SIZE: 15
       DAILY_MATRIX_SIZE: 120
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.13.1
       CLANG_ROOT_DIR: /usr/lib/llvm-12
@@ -81,7 +82,9 @@ jobs:
             nodes=0
           else
             nodes=$(( ${lines} / ${TESTS_PER_BUILDER}))
-            if [ "${nodes}" = 0 ]; then
+            if [ ${nodes} -gt 4 -a ${nodes} -lt 10 ]; then
+              nodes=${MATRIX_SIZE}
+            elif [ "${nodes}" = 0 ]; then
               # for less than TESTS_PER_BUILDER, we take at least 1 node
               nodes=1
             fi
@@ -100,7 +103,7 @@ jobs:
             fi
             size=${{ steps.test-plan.outputs.calculated_matrix_size }}
           elif [ "${{github.event_name}}" = "push" ]; then
-            subset="[$(seq -s',' 1 ${MATRIX_SIZE})]"
+            subset="[$(seq -s',' 1 ${PUSH_MATRIX_SIZE})]"
             size=${MATRIX_SIZE}
           elif [ "${{github.event_name}}" = "schedule" ]; then
             subset="[$(seq -s',' 1 ${DAILY_MATRIX_SIZE})]"

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -186,7 +186,7 @@ jobs:
 
       - name: ccache stats initial
         run: |
-          test -d github/home/.ccache && mv github/home/.ccache /github/home/.ccache
+          test -d github/home/.ccache && rm -rf /github/home/.ccache && mv github/home/.ccache /github/home/.ccache
           ccache -M 10G -s
 
       - if: github.event_name == 'push'

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -17,6 +17,7 @@ jobs:
           access_token: ${{ github.token }}
 
   twister-build-prep:
+
     runs-on: zephyr_runner
     needs: twister-build-cleanup
     container:
@@ -30,7 +31,7 @@ jobs:
     env:
       MATRIX_SIZE: 10
       PUSH_MATRIX_SIZE: 15
-      DAILY_MATRIX_SIZE: 120
+      DAILY_MATRIX_SIZE: 80
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.13.1
       CLANG_ROOT_DIR: /usr/lib/llvm-12
       TESTS_PER_BUILDER: 700

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -114,7 +114,6 @@ jobs:
           echo "::set-output name=subset::${subset}";
           echo "::set-output name=size::${size}";
 
-
   twister-build:
     runs-on: zephyr_runner
     needs: twister-build-prep
@@ -210,6 +209,7 @@ jobs:
       - if: github.event_name == 'pull_request_target'
         name: Run Tests with Twister (Pull Request)
         run: |
+          rm -f testplan.csv
           export ZEPHYR_BASE=${PWD}
           export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
           python3 ./scripts/ci/test_plan.py -c origin/${BASE_REF}.. --pull-request
@@ -231,7 +231,10 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Unit Test Results (Subset ${{ matrix.subset }})
-          path: twister-out/twister.xml
+          if-no-files-found: ignore
+          path: |
+            twister-out/twister.xml
+            testplan.csv
 
   twister-test-results:
     name: "Publish Unit Tests Results"

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -107,9 +107,11 @@ jobs:
           elif [ "${{github.event_name}}" = "push" ]; then
             subset="[$(seq -s',' 1 ${PUSH_MATRIX_SIZE})]"
             size=${MATRIX_SIZE}
-          elif [ "${{github.event_name}}" = "schedule" ]; then
+          elif [ "${{github.event_name}}" = "schedule" && "${{github.repository}}" = "zephyrproject-rtos/zephyr" ]; then
             subset="[$(seq -s',' 1 ${DAILY_MATRIX_SIZE})]"
             size=${DAILY_MATRIX_SIZE}
+          else
+            size=0
           fi
           echo "::set-output name=subset::${subset}";
           echo "::set-output name=size::${size}";

--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -284,6 +284,10 @@ def parse_args():
             help="This is a pull request")
     parser.add_argument('-p', '--platform', action="append",
             help="Limit this for a platform or a list of platforms.")
+    parser.add_argument('-t', '--tests_per_builder', default=700, type=int,
+            help="Number of tests per builder")
+    parser.add_argument('-n', '--default-matrix', default=10, type=int,
+            help="Number of tests per builder")
 
     return parser.parse_args()
 
@@ -317,6 +321,18 @@ if __name__ == "__main__":
             dup_free_set.add(tuple(x))
 
     logging.info(f'Total tests to be run: {len(dup_free)}')
+    with open(".testplan", "w") as tp:
+        total_tests = len(dup_free)
+        nodes = round(total_tests / args.tests_per_builder)
+        if total_tests % args.tests_per_builder != total_tests:
+            nodes = nodes + 1
+
+        if nodes > 5:
+            nodes = args.default_matrix
+
+        tp.write(f"TWISTER_TESTS={total_tests}\n")
+        tp.write(f"TWISTER_NODES={nodes}\n")
+
     header = ['test', 'arch', 'platform', 'status', 'extra_args', 'handler',
             'handler_time', 'ram_size', 'rom_size']
 

--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -96,7 +96,8 @@ class Filters:
         self.find_tags()
         self.find_excludes()
         self.find_tests()
-        self.find_archs()
+        if not self.platforms:
+            self.find_archs()
         self.find_boards()
 
     def get_plan(self, options, integration=False):
@@ -105,6 +106,7 @@ class Filters:
         if integration:
             cmd.append("--integration")
 
+        logging.info(" ".join(cmd))
         _ = subprocess.call(cmd)
         with open(fname, newline='') as csvfile:
             csv_reader = csv.reader(csvfile, delimiter=',')
@@ -138,7 +140,13 @@ class Filters:
 
         if _options:
             logging.info(f'Potential architecture filters...')
-            self.get_plan(_options, True)
+            if self.platforms:
+                for platform in self.platforms:
+                    _options.extend(["-p", platform])
+
+                self.get_plan(_options, True)
+            else:
+                self.get_plan(_options, False)
 
     def find_boards(self):
         boards = set()
@@ -255,8 +263,11 @@ class Filters:
                 for platform in self.platforms:
                     _options.extend(["-p", platform])
 
-            _options.extend(self.tag_options)
-            self.get_plan(_options, True)
+                _options.extend(self.tag_options)
+                self.get_plan(_options)
+            else:
+                _options.extend(self.tag_options)
+                self.get_plan(_options, True)
         else:
             logging.info(f'No twister needed or partial twister run only...')
 

--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -100,10 +100,10 @@ class Filters:
         self.find_archs()
         self.find_boards()
 
-    def get_plan(self, options):
+    def get_plan(self, options, integration=False):
         fname = "_test_plan_partial.csv"
         cmd = ["scripts/twister", "-c"] + options + ["--save-tests", fname ]
-        if self.pull_request:
+        if integration:
             cmd.append("--integration")
 
         p = subprocess.call(cmd)
@@ -139,7 +139,7 @@ class Filters:
 
         if _options:
             logging.info(f'Potential architecture filters...')
-            self.get_plan(_options)
+            self.get_plan(_options, True)
 
     def find_boards(self):
         boards = set()
@@ -257,7 +257,7 @@ class Filters:
                     _options.extend(["-p", platform])
 
             _options.extend(self.tag_options)
-            self.get_plan(_options)
+            self.get_plan(_options, True)
         else:
             logging.info(f'No twister needed or partial twister run only...')
 

--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -5,7 +5,6 @@
 # A script to generate twister options based on modified files.
 
 import re, os
-import sh
 import argparse
 import glob
 import yaml
@@ -14,7 +13,7 @@ import fnmatch
 import subprocess
 import csv
 import logging
-from git import Git, Repo
+from git import Repo
 
 if "ZEPHYR_BASE" not in os.environ:
     exit("$ZEPHYR_BASE environment variable undefined.")
@@ -106,10 +105,10 @@ class Filters:
         if integration:
             cmd.append("--integration")
 
-        p = subprocess.call(cmd)
+        _ = subprocess.call(cmd)
         with open(fname, newline='') as csvfile:
             csv_reader = csv.reader(csvfile, delimiter=',')
-            header = next(csv_reader)
+            _ = next(csv_reader)
             for e in csv_reader:
                 self.all_tests.append(e)
         if os.path.exists(fname):
@@ -191,7 +190,7 @@ class Filters:
                 for platform in self.platforms:
                     _options.extend(["-p", platform])
             else:
-                 _options.append("--all")
+                _options.append("--all")
             self.get_plan(_options)
 
     def find_tags(self):

--- a/scripts/gen_app_partitions.py
+++ b/scripts/gen_app_partitions.py
@@ -39,6 +39,7 @@ import re
 from collections import OrderedDict
 from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import SymbolTableSection
+import elftools.common.exceptions
 
 SZ = 'size'
 SRC = 'sources'
@@ -106,7 +107,11 @@ elf_part_size_regex = re.compile(r'z_data_smem_(.*)_part_size')
 
 def find_obj_file_partitions(filename, partitions):
     with open(filename, 'rb') as f:
-        full_lib = ELFFile(f)
+        try:
+            full_lib = ELFFile(f)
+        except elftools.common.exceptions.ELFError as e:
+            exit(f"Error: {filename}: {e}")
+
         if not full_lib:
             sys.exit("Error parsing file: " + filename)
 
@@ -136,12 +141,17 @@ def parse_obj_files(partitions):
         for filename in files:
             if re.match(r".*\.obj$", filename):
                 fullname = os.path.join(dirpath, filename)
-                find_obj_file_partitions(fullname, partitions)
+                fsize = os.path.getsize(fullname)
+                if fsize != 0:
+                    find_obj_file_partitions(fullname, partitions)
 
 
 def parse_elf_file(partitions):
     with open(args.elf, 'rb') as f:
-        elffile = ELFFile(f)
+        try:
+            elffile = ELFFile(f)
+        except elftools.common.exceptions.ELFError as e:
+            exit(f"Error: {args.elf}: {e}")
 
         symbol_tbls = [s for s in elffile.iter_sections()
                        if isinstance(s, SymbolTableSection)]


### PR DESCRIPTION
- actions: twister: apply a new strategy from smaller test plans
- actions: twister: run tests on all platforms when changed
- actions: twister: load modules from cache
- actions: twister: upload testplan as an artifact
- actions: twister: do not schedule on non main branches
- actions: twister: limit daily job to 60 builders
- ci: test_plan: fix pylint warnings
- actions: fix filtering for clang action
- actions: twister: determine nodes in python script
- actions: twister: remove existing ccache directory
