### PR TITLE
tests: logging: Disable log2 deferred tests on qemu_cortex_a9

### DIFF
--- a/tests/subsys/logging/log_api/testcase.yaml
+++ b/tests/subsys/logging/log_api/testcase.yaml
@@ -45,45 +45,45 @@ tests:
       - CONFIG_SAMPLE_MODULE_LOG_LEVEL_DBG=y
 
   logging.log2_api_deferred_overflow_rt_filter:
-    # FIXME: qemu_arc_hs6x excluded, see #38041
-    platform_exclude: qemu_arc_hs6x
+    # FIXME:see #38041, #39978
+    platform_exclude: qemu_arc_hs6x qemu_cortex_a9
     extra_configs:
       - CONFIG_LOG2_MODE_DEFERRED=y
       - CONFIG_LOG_MODE_OVERFLOW=y
       - CONFIG_LOG_RUNTIME_FILTERING=y
 
   logging.log2_api_deferred_overflow:
-    # FIXME: qemu_arc_hs6x excluded, see #38041
-    platform_exclude: qemu_arc_hs6x
+    # FIXME:see #38041, #39978
+    platform_exclude: qemu_arc_hs6x qemu_cortex_a9
     extra_configs:
       - CONFIG_LOG2_MODE_DEFERRED=y
       - CONFIG_LOG_MODE_OVERFLOW=y
 
   logging.log2_api_deferred_no_overflow:
-    # FIXME: qemu_arc_hs6x excluded, see #38041
-    platform_exclude: qemu_arc_hs6x
+    # FIXME:see #38041, #39978
+    platform_exclude: qemu_arc_hs6x qemu_cortex_a9
     extra_configs:
       - CONFIG_LOG2_MODE_DEFERRED=y
       - CONFIG_LOG_MODE_OVERFLOW=n
 
   logging.log2_api_deferred_static_filter:
-    # FIXME: qemu_arc_hs6x excluded, see #38041
-    platform_exclude: qemu_arc_hs6x
+    # FIXME:see #38041, #39978
+    platform_exclude: qemu_arc_hs6x qemu_cortex_a9
     extra_configs:
       - CONFIG_LOG2_MODE_DEFERRED=y
       - CONFIG_SAMPLE_MODULE_LOG_LEVEL_DBG=y
 
   logging.log2_api_deferred_func_prefix:
-    # FIXME: qemu_arc_hs6x excluded, see #38041
-    platform_exclude: qemu_arc_hs6x
+    # FIXME:see #38041, #39978
+    platform_exclude: qemu_arc_hs6x qemu_cortex_a9
     extra_configs:
       - CONFIG_LOG2_MODE_DEFERRED=y
       - CONFIG_SAMPLE_MODULE_LOG_LEVEL_DBG=y
       - CONFIG_LOG_FUNC_NAME_PREFIX_DBG=y
 
   logging.log2_api_deferred_64b_timestamp:
-    # FIXME: qemu_arc_hs6x excluded, see #38041
-    platform_exclude: qemu_arc_hs6x
+    # FIXME:see #38041, #39978
+    platform_exclude: qemu_arc_hs6x qemu_cortex_a9
     extra_configs:
       - CONFIG_LOG2_MODE_DEFERRED=y
       - CONFIG_LOG_TIMESTAMP_64BIT=y


### PR DESCRIPTION
As described in #39978, an issue is currently preventing those tests
from executing correctly. Disable them until a fix is found.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>