### PR TITLE
tests: subsys: logging: log_msg2: disable some tests on qemu_cortex_a9

### DIFF
--- a/tests/subsys/logging/log_msg2/testcase.yaml
+++ b/tests/subsys/logging/log_msg2/testcase.yaml
@@ -15,6 +15,8 @@ tests:
       - CONFIG_LOG_MODE_OVERFLOW=n
 
   logging.log_msg2_64b_timestamp:
+    # FIXME: see #39978
+    platform_exclude: qemu_cortex_a9
     extra_configs:
       - CONFIG_CBPRINTF_COMPLETE=y
       - CONFIG_LOG_TIMESTAMP_64BIT=y
@@ -25,6 +27,8 @@ tests:
       - CONFIG_CBPRINTF_FP_SUPPORT=y
 
   logging.log_msg2_fp_64b_timestamp:
+    # FIXME: see #39978
+    platform_exclude: qemu_cortex_a9
     extra_configs:
       - CONFIG_CBPRINTF_COMPLETE=y
       - CONFIG_CBPRINTF_FP_SUPPORT=y


### PR DESCRIPTION
logging.log_msg2_64b_timestamp and logging.log_msg2_fp_64b_timestamp are
currently failing on qemu_cortex_a9 due to #39978. Disable them on that
platform until the issue is fixed.