### PR TITLE
modules: Use posix paths in Kconfig module prompts

### DIFF
--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -193,7 +193,7 @@ def kconfig_snippet(meta, path, kconfig_file=None):
     name = meta['name']
     name_sanitized = meta['name-sanitized']
 
-    snippet = (f'menu "{name} ({path})"',
+    snippet = (f'menu "{name} ({path.as_posix()})"',
                f'osource "{kconfig_file.resolve().as_posix()}"' if kconfig_file
                else f'osource "$(ZEPHYR_{name_sanitized.upper()}_KCONFIG)"',
                f'config ZEPHYR_{name_sanitized.upper()}_MODULE',


### PR DESCRIPTION
kconfiglib doesn't render backslashes in menu strings, and the prompts
in the module menu will be unintelligible on Windows. Print these
menus as posix paths on Windows as well, so they don't look broken in
menuconfig.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>

Current module menu on Windows:
![image](https://user-images.githubusercontent.com/7857838/144447625-1e71fbf6-2f09-4c7e-b428-800281f8a344.png)

After this change:
![image](https://user-images.githubusercontent.com/7857838/144447518-11a13514-d4e1-49b3-86a9-6f86dfeea453.png)
