### PR TITLE
boards: thing52_nrf52832: enable segger rtt in the default config

### DIFF
--- a/boards/arm/thingy52_nrf52832/thingy52_nrf52832_defconfig
+++ b/boards/arm/thingy52_nrf52832/thingy52_nrf52832_defconfig
@@ -13,6 +13,9 @@ CONFIG_ARM_MPU=y
 # Enable hardware stack protection
 CONFIG_HW_STACK_PROTECTION=y
 
+# Enable RTT
+CONFIG_USE_SEGGER_RTT=y
+
 # enable GPIO
 CONFIG_GPIO=y
 


### PR DESCRIPTION
Enabled Segger RTT in the default configuration of Thingy52.

Signed-off-by: Kamil Piszczek <Kamil.Piszczek@nordicsemi.no>