### PR TITLE
soc: cavs_v25: increase core count default to 4

### DIFF
--- a/soc/xtensa/intel_adsp/cavs_v25/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/cavs_v25/Kconfig.defconfig.series
@@ -15,9 +15,8 @@ config SOC
 	string
 	default "intel_cavs_25"
 
-# Hardware has four cores, limited to two pending test fixes
 config MP_NUM_CPUS
-	default 2
+	default 4
 
 config SMP
        default y


### PR DESCRIPTION
The default config for cavs25 should be a 4 core config. Variants that
have less cores, need to override the config option to a smaller value.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>