### PR TITLE
drivers: esp32: fix display driver not working

### DIFF
--- a/drivers/i2c/i2c_esp32.c
+++ b/drivers/i2c/i2c_esp32.c
@@ -123,6 +123,7 @@ static int i2c_esp32_config_pin(const struct device *dev)
 {
 	const struct i2c_esp32_config *config = dev->config;
 	struct i2c_esp32_data *data = (struct i2c_esp32_data *const)(dev)->data;
+	int ret = 0;
 
 	if (config->index >= SOC_I2C_NUM) {
 		LOG_ERR("Invalid I2C peripheral number");
@@ -130,18 +131,18 @@ static int i2c_esp32_config_pin(const struct device *dev)
 	}
 
 	gpio_pin_set(data->sda_gpio, config->sda.pin, 1);
-	gpio_pin_configure(data->sda_gpio, config->sda.pin,
+	ret = gpio_pin_configure(data->sda_gpio, config->sda.pin,
 			GPIO_PULL_UP | GPIO_OPEN_DRAIN | GPIO_OUTPUT | GPIO_INPUT);
 	esp_rom_gpio_matrix_out(config->sda.pin, config->sda.sig_out, 0, 0);
 	esp_rom_gpio_matrix_in(config->sda.pin, config->sda.sig_in, 0);
 
 	gpio_pin_set(data->scl_gpio, config->scl.pin, 1);
-	gpio_pin_configure(data->scl_gpio, config->scl.pin,
+	ret |= gpio_pin_configure(data->scl_gpio, config->scl.pin,
 			GPIO_PULL_UP | GPIO_OPEN_DRAIN | GPIO_OUTPUT | GPIO_INPUT);
 	esp_rom_gpio_matrix_out(config->scl.pin, config->scl.sig_out, 0, 0);
 	esp_rom_gpio_matrix_in(config->scl.pin, config->scl.sig_in, 0);
 
-	return 0;
+	return ret;
 }
 
 /* Some slave device will die by accident and keep the SDA in low level,
@@ -274,8 +275,6 @@ static int i2c_esp32_configure(const struct device *dev, uint32_t dev_config)
 
 	i2c_hal_set_bus_timing(&data->hal, config->bitrate, i2c_get_clk_src(config->bitrate));
 	i2c_hal_update_config(&data->hal);
-
-	irq_enable(data->irq_line);
 
 	return 0;
 }
@@ -473,6 +472,7 @@ static int IRAM_ATTR i2c_esp32_write_msg(const struct device *dev,
 		if (wr_filled > 0) {
 			i2c_hal_write_txfifo(&data->hal, write_pr, wr_filled);
 			i2c_hal_write_cmd_reg(&data->hal, cmd, data->cmd_idx++);
+			i2c_hal_write_cmd_reg(&data->hal, hw_end_cmd, data->cmd_idx++);
 		}
 
 		if (msg->len == 0 && (msg->flags & I2C_MSG_STOP)) {
@@ -482,8 +482,6 @@ static int IRAM_ATTR i2c_esp32_write_msg(const struct device *dev,
 				.byte_num = 0
 			};
 			i2c_hal_write_cmd_reg(&data->hal, cmd, data->cmd_idx++);
-		} else {
-			i2c_hal_write_cmd_reg(&data->hal, hw_end_cmd, data->cmd_idx++);
 		}
 
 		i2c_hal_enable_master_tx_it(&data->hal);
@@ -651,7 +649,7 @@ static int IRAM_ATTR i2c_esp32_init(const struct device *dev)
 
 	clock_control_on(config->clock_dev, config->clock_subsys);
 
-	data->irq_line = esp_intr_alloc(config->irq_source, 0, i2c_esp32_isr, (void *)dev, NULL);
+	esp_intr_alloc(config->irq_source, 0, i2c_esp32_isr, (void *)dev, NULL);
 
 	return i2c_esp32_configure(dev, config->default_config);
 }

--- a/drivers/pinmux/pinmux_esp32.c
+++ b/drivers/pinmux/pinmux_esp32.c
@@ -11,10 +11,24 @@
 #include <soc/soc.h>
 #include <hal/gpio_types.h>
 #include <hal/gpio_ll.h>
+#include <hal/rtc_io_hal.h>
 #include <soc.h>
 
 #include <errno.h>
 #include <drivers/pinmux.h>
+
+#ifndef SOC_GPIO_SUPPORT_RTC_INDEPENDENT
+#define SOC_GPIO_SUPPORT_RTC_INDEPENDENT 0
+#endif
+
+static inline bool rtc_gpio_is_valid_gpio(uint32_t gpio_num)
+{
+#if SOC_RTCIO_INPUT_OUTPUT_SUPPORTED
+	return (gpio_num < SOC_GPIO_PIN_COUNT && rtc_io_num_map[gpio_num] >= 0);
+#else
+	return false;
+#endif
+}
 
 static int pinmux_set(const struct device *dev, uint32_t pin, uint32_t func)
 {
@@ -48,11 +62,26 @@ static int pinmux_pullup(const struct device *dev, uint32_t pin, uint8_t func)
 
 	switch (func) {
 	case PINMUX_PULLUP_DISABLE:
-		gpio_ll_pullup_dis(&GPIO, pin);
+		if (!rtc_gpio_is_valid_gpio(pin) || SOC_GPIO_SUPPORT_RTC_INDEPENDENT) {
+			gpio_ll_pullup_dis(&GPIO, pin);
+			gpio_ll_pulldown_en(&GPIO, pin);
+		} else {
+#if SOC_RTCIO_INPUT_OUTPUT_SUPPORTED
+			rtcio_hal_pullup_disable(rtc_io_num_map[pin]);
+			rtcio_hal_pulldown_enable(rtc_io_num_map[pin]);
+#endif
+		}
 		break;
 	case PINMUX_PULLUP_ENABLE:
-		gpio_ll_pulldown_dis(&GPIO, pin);
-		gpio_ll_pullup_en(&GPIO, pin);
+		if (!rtc_gpio_is_valid_gpio(pin) || SOC_GPIO_SUPPORT_RTC_INDEPENDENT) {
+			gpio_ll_pulldown_dis(&GPIO, pin);
+			gpio_ll_pullup_en(&GPIO, pin);
+		} else {
+#if SOC_RTCIO_INPUT_OUTPUT_SUPPORTED
+			rtcio_hal_pulldown_disable(rtc_io_num_map[pin]);
+			rtcio_hal_pullup_enable(rtc_io_num_map[pin]);
+#endif
+		}
 		break;
 	default:
 		return -EINVAL;
@@ -67,11 +96,9 @@ static int pinmux_input(const struct device *dev, uint32_t pin, uint8_t func)
 
 	switch (func) {
 	case PINMUX_INPUT_ENABLED:
-		gpio_ll_output_disable(&GPIO, pin);
 		gpio_ll_input_enable(&GPIO, pin);
 		break;
 	case PINMUX_OUTPUT_ENABLED:
-		gpio_ll_input_disable(&GPIO, pin);
 		gpio_ll_output_enable(&GPIO, pin);
 		esp_rom_gpio_matrix_out(pin, SIG_GPIO_OUT_IDX, false, false);
 		break;

--- a/west.yml
+++ b/west.yml
@@ -67,7 +67,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: c4a591c35385be59a41cde7efc85fe7660172979
+      revision: bd2e2d8dcdc19defdb1bf6e07fb94f62bc99c925
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
This PR enables I2C display or any other peripheral to work by fixing I2C end packet
and gpio/pinmux configuration. Some pins in ESP32 are controlled over RTC registers. For example, pin 4
can only be pull-up when enabled by rtc_io register and not directly over gpio pull up register.