### PR TITLE
kernel: mem_domain: remove extra slash in Z_PROGBITS_SYM

### DIFF
--- a/include/app_memory/app_memdomain.h
+++ b/include/app_memory/app_memdomain.h
@@ -81,7 +81,7 @@ struct z_app_region {
 /* ARM has a quirk in that '@' denotes a comment, so we have to send
  * %progbits to the assembler instead.
  */
-#define Z_PROGBITS_SYM	"\%"
+#define Z_PROGBITS_SYM	"%"
 #else
 #define Z_PROGBITS_SYM "@"
 #endif


### PR DESCRIPTION
The macro Z_PROGBITS_SYM has "\%" but this is not correct
usage to escape "%". So remove the extra slash. Note that
this macro is used directly to generate assembly code
so it cannot be "%%" as in escaping "%" in printf().

Fixes #40439

Signed-off-by: Daniel Leung <daniel.leung@intel.com>