### PR TITLE
Bluetooth: Controller: Reset dup filtering on Periodic Re-sync 

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -4959,6 +4959,13 @@ static inline bool is_dup_or_update(struct dup_entry *dup, uint8_t adv_type,
 			if (adv_set->adi.did != adi->did) {
 				/* report different DID */
 				adv_set->adi.did = adi->did;
+				/* set new data status */
+				if (data_status ==
+				    BT_HCI_LE_ADV_EVT_TYPE_DATA_STATUS_COMPLETE) {
+					adv_set->data_cmplt = 1U;
+				} else {
+					adv_set->data_cmplt = 0U;
+				}
 				return false;
 			} else if (!adv_set->data_cmplt &&
 				   (data_status ==

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -501,7 +501,6 @@ static void host_num_completed_packets(struct net_buf *buf,
 	struct bt_hci_cp_host_num_completed_packets *cmd = (void *)buf->data;
 	struct bt_hci_evt_cc_status *ccst;
 	uint32_t count = 0U;
-	int i;
 
 	/* special case, no event returned except for error conditions */
 	if (hci_hbuf_total <= 0) {
@@ -515,7 +514,7 @@ static void host_num_completed_packets(struct net_buf *buf,
 	}
 
 	/* leave *evt == NULL so no event is generated */
-	for (i = 0; i < cmd->num_handles; i++) {
+	for (uint8_t i = 0; i < cmd->num_handles; i++) {
 		uint16_t h = sys_le16_to_cpu(cmd->h[i].handle);
 		uint16_t c = sys_le16_to_cpu(cmd->h[i].count);
 
@@ -4913,9 +4912,7 @@ static void dup_ext_adv_mode_reset(struct dup_ext_adv_mode *dup_adv_mode)
 #if defined(CONFIG_BT_CTLR_SYNC_PERIODIC_ADI_SUPPORT)
 static void dup_ext_adv_reset(void)
 {
-	int i;
-
-	for (i = 0; i < dup_count; i++) {
+	for (int32_t i = 0; i < dup_count; i++) {
 		struct dup_entry *dup;
 
 		dup = &dup_filter[i];
@@ -4927,22 +4924,19 @@ static void dup_ext_adv_reset(void)
 static void dup_periodic_adv_reset(uint8_t addr_type, const uint8_t *addr,
 				   uint8_t sid)
 {
-	int addr_idx;
-
-	for (addr_idx = 0; addr_idx < dup_count; addr_idx++) {
+	for (int32_t addr_idx = 0; addr_idx < dup_count; addr_idx++) {
 		struct dup_ext_adv_mode *dup_mode;
 		struct dup_entry *dup;
-		int set_idx;
 
 		dup = &dup_filter[addr_idx];
-		if (memcmp(addr, &dup->addr.a.val[0],
-			   sizeof(bt_addr_t)) ||
+		if (memcmp(addr, dup->addr.a.val, sizeof(bt_addr_t)) ||
 		    (addr_type != dup->addr.type)) {
 			continue;
 		}
 
 		dup_mode = &dup->adv_mode[DUP_EXT_ADV_MODE_PERIODIC];
-		for (set_idx = 0; set_idx < dup_mode->set_count; set_idx++) {
+		for (uint16_t set_idx = 0; set_idx < dup_mode->set_count;
+		     set_idx++) {
 			struct dup_ext_adv_set *adv_set;
 
 			adv_set = &dup_mode->set[set_idx];
@@ -5001,12 +4995,12 @@ static inline bool is_dup_or_update(struct dup_entry *dup, uint8_t adv_type,
 				/* report different DID */
 				adv_set->adi.did = adi->did;
 				/* set new data status */
-				if (data_status ==
-				    BT_HCI_LE_ADV_EVT_TYPE_DATA_STATUS_COMPLETE) {
+				if (data_status == BT_HCI_LE_ADV_EVT_TYPE_DATA_STATUS_COMPLETE) {
 					adv_set->data_cmplt = 1U;
 				} else {
 					adv_set->data_cmplt = 0U;
 				}
+
 				return false;
 			} else if (!adv_set->data_cmplt &&
 				   (data_status ==
@@ -5039,7 +5033,6 @@ static bool dup_found(uint8_t adv_type, uint8_t addr_type, const uint8_t *addr,
 	/* check for duplicate filtering */
 	if (dup_count >= 0) {
 		struct dup_entry *dup;
-		int i;
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 		__ASSERT((adv_mode < ARRAY_SIZE(dup_filter[0].adv_mode)),
@@ -5047,7 +5040,7 @@ static bool dup_found(uint8_t adv_type, uint8_t addr_type, const uint8_t *addr,
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
 
 		/* find for existing entry and update if changed */
-		for (i = 0; i < dup_count; i++) {
+		for (int32_t i = 0; i < dup_count; i++) {
 			dup = &dup_filter[i];
 			if (memcmp(addr, &dup->addr.a.val[0],
 				   sizeof(bt_addr_t)) ||
@@ -5147,10 +5140,9 @@ static inline void le_dir_adv_report(struct pdu_adv *adv, struct net_buf *buf,
 static inline bool scan_filter_apply(uint8_t filter, uint8_t *data, uint8_t len)
 {
 	struct scan_filter *f = &scan_filters[filter];
-	int i;
 
 	/* No patterns means filter out all advertising packets */
-	for (i = 0; i < f->count; i++) {
+	for (uint8_t i = 0; i < f->count; i++) {
 		/* Require at least the length of the pattern */
 		if (len >= f->lengths[i] &&
 		    !memcmp(data, f->patterns[i], f->lengths[i])) {

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -6306,20 +6306,23 @@ no_ext_hdr:
 	} else if (IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC_ADI_SUPPORT) &&
 		   adi) {
 		const struct ll_sync_set *sync = HDR_LLL2ULL(ftr->param);
+		uint8_t data_status;
 
-		/* FIXME: Use correct data status else chain PDU report will
-		 *        be filtered out.
-		 */
+		data_status = (aux_ptr) ?
+			      BT_HCI_LE_ADV_EVT_TYPE_DATA_STATUS_PARTIAL :
+			      BT_HCI_LE_ADV_EVT_TYPE_DATA_STATUS_COMPLETE;
+
 		accept = ftr->sync_rx_enabled &&
 			 (!sync->nodups ||
 			  !dup_found(PDU_ADV_TYPE_EXT_IND,
 				     sync->peer_id_addr_type,
 				     sync->peer_id_addr,
 				     DUP_EXT_ADV_MODE_PERIODIC,
-				     adi, 0U));
+				     adi, data_status));
 #endif /* CONFIG_BT_CTLR_DUP_FILTER_LEN > 0 &&
 	* CONFIG_BT_CTLR_SYNC_PERIODIC_ADI_SUPPORT
 	*/
+
 	} else {
 		accept = ftr->sync_rx_enabled;
 	}

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -149,7 +149,7 @@ static uint32_t dup_curr;
 
 #if defined(CONFIG_BT_CTLR_SYNC_PERIODIC_ADI_SUPPORT)
 /* Helper function to reset non-periodic advertising entries in filter table */
-static void dup_ext_adv_reset(int count);
+static void dup_ext_adv_reset(void);
 /* Flag for advertising reports be filtered for duplicates. */
 static bool dup_scan;
 #else /* !CONFIG_BT_CTLR_SYNC_PERIODIC_ADI_SUPPORT */
@@ -1687,7 +1687,7 @@ static void le_set_scan_enable(struct net_buf *buf, struct net_buf **evt)
 			dup_curr = 0U;
 		} else if (!dup_scan) {
 			dup_scan = true;
-			dup_ext_adv_reset(dup_count);
+			dup_ext_adv_reset();
 #endif /* CONFIG_BT_CTLR_SYNC_PERIODIC_ADI_SUPPORT */
 
 		} else {
@@ -3404,7 +3404,7 @@ static void le_set_ext_scan_enable(struct net_buf *buf, struct net_buf **evt)
 			dup_curr = 0U;
 		} else if (!dup_scan) {
 			dup_scan = true;
-			dup_ext_adv_reset(dup_count);
+			dup_ext_adv_reset();
 #endif /* CONFIG_BT_CTLR_SYNC_PERIODIC_ADI_SUPPORT */
 
 		} else {
@@ -4906,11 +4906,11 @@ static void dup_ext_adv_mode_reset(struct dup_ext_adv_mode *dup_adv_mode)
 }
 
 #if defined(CONFIG_BT_CTLR_SYNC_PERIODIC_ADI_SUPPORT)
-static void dup_ext_adv_reset(int count)
+static void dup_ext_adv_reset(void)
 {
 	int i;
 
-	for (i = 0; i < count; i++) {
+	for (i = 0; i < dup_count; i++) {
 		struct dup_entry *dup;
 
 		dup = &dup_filter[i];

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -3477,7 +3477,9 @@ static void le_per_adv_create_sync(struct net_buf *buf, struct net_buf **evt)
 			dup_count = 0;
 			dup_curr = 0U;
 		} else {
-			/* FIXME: Invalidate dup_ext_adv_mode array entries */
+			/* NOTE: Invalidate dup_ext_adv_mode array entries is
+			 *       done when sync is established.
+			 */
 		}
 	} else if (!dup_scan) {
 		dup_count = DUP_FILTER_DISABLED;
@@ -3559,7 +3561,10 @@ static void le_per_adv_recv_enable(struct net_buf *buf, struct net_buf **evt)
 				dup_count = 0;
 				dup_curr = 0U;
 			} else {
-				/* FIXME: Invalidate dup_ext_adv_mode array entries */
+				/* NOTE: Invalidate dup_ext_adv_mode array
+				 *       entries is done when sync is
+				 *       established.
+				 */
 			}
 		} else if (!dup_scan) {
 			dup_count = DUP_FILTER_DISABLED;
@@ -4918,6 +4923,42 @@ static void dup_ext_adv_reset(void)
 		dup_ext_adv_mode_reset(dup->adv_mode);
 	}
 }
+
+static void dup_periodic_adv_reset(uint8_t addr_type, const uint8_t *addr,
+				   uint8_t sid)
+{
+	int addr_idx;
+
+	for (addr_idx = 0; addr_idx < dup_count; addr_idx++) {
+		struct dup_ext_adv_mode *dup_mode;
+		struct dup_entry *dup;
+		int set_idx;
+
+		dup = &dup_filter[addr_idx];
+		if (memcmp(addr, &dup->addr.a.val[0],
+			   sizeof(bt_addr_t)) ||
+		    (addr_type != dup->addr.type)) {
+			continue;
+		}
+
+		dup_mode = &dup->adv_mode[DUP_EXT_ADV_MODE_PERIODIC];
+		for (set_idx = 0; set_idx < dup_mode->set_count; set_idx++) {
+			struct dup_ext_adv_set *adv_set;
+
+			adv_set = &dup_mode->set[set_idx];
+			if (adv_set->adi.sid != sid) {
+				continue;
+			}
+
+			/* reset data complete state */
+			adv_set->data_cmplt = 0U;
+
+			return;
+		}
+
+		return;
+	}
+}
 #endif /* CONFIG_BT_CTLR_SYNC_PERIODIC_ADI_SUPPORT */
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
 
@@ -6137,9 +6178,13 @@ static void le_per_adv_sync_established(struct pdu_data *pdu_data,
 		return;
 	}
 
-	sep->handle = sys_cpu_to_le16(node_rx->hdr.handle);
-
 	scan = node_rx->hdr.rx_ftr.param;
+
+	dup_periodic_adv_reset(scan->per_scan.adv_addr_type,
+			       scan->per_scan.adv_addr,
+			       scan->per_scan.sid);
+
+	sep->handle = sys_cpu_to_le16(node_rx->hdr.handle);
 
 	/* Resolved address, if private, has been populated in ULL */
 	sep->adv_addr.type = scan->per_scan.adv_addr_type;


### PR DESCRIPTION
Reset duplicate filtering of Periodic Advertising Reports
when Periodic Advertising Sync is created again after a
terminate or sync lost.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>