### PR TITLE
tests: thread_apis: fix cast to smaller integer type

### DIFF
--- a/tests/kernel/threads/thread_apis/src/main.c
+++ b/tests/kernel/threads/thread_apis/src/main.c
@@ -307,7 +307,7 @@ enum control_method {
 
 void join_entry(void *p1, void *p2, void *p3)
 {
-	enum control_method m = (enum control_method)p1;
+	enum control_method m = (enum control_method)(intptr_t)p1;
 
 	switch (m) {
 	case TIMEOUT:


### PR DESCRIPTION
Clang 12.0.0 complains about
"cast to smaller integer type 'enum control_method' from 'void *'
[-Werror,-Wvoid-pointer-to-enum-cast]".
Cast it to intptr_t type first.

Fixes "Build with Clang/LLVM / clang-build (native_posix) (pull_request_target)", for example https://github.com/zephyrproject-rtos/zephyr/pull/40765