### PR TITLE
actions: compliance: Quotes arround undefined var

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -95,6 +95,6 @@ jobs:
           fi
         done
 
-        if [ ${exit} == 1 ]; then
+        if [ "${exit}" == "1" ]; then
           exit 1;
         fi


### PR DESCRIPTION
I noticed that the `check-warns` step of the `Compliance Checks` action display an error because the variable `exit` is not defined in the nominal case:
```
/home/runner/work/_temp/307ae227-cc24-4191-ac11-34d934fcda96.sh: line 16: [: ==: unary operator expected
```
The step finishes with success and if there was a compliance error the variable would be properly defined and this error would not be there.