### PR TITLE
Bluetooth: Audio: Add check conn in VCS client notify handler

### DIFF
--- a/subsys/bluetooth/audio/vcs_client.c
+++ b/subsys/bluetooth/audio/vcs_client.c
@@ -91,11 +91,13 @@ static uint8_t vcs_client_notify_handler(struct bt_conn *conn,
 					 const void *data, uint16_t length)
 {
 	uint16_t handle = params->value_handle;
-	struct bt_vcs *vcs_inst = &vcs_insts[bt_conn_index(conn)];
+	struct bt_vcs *vcs_inst;
 
-	if (data == NULL) {
+	if (data == NULL || conn == NULL) {
 		return BT_GATT_ITER_CONTINUE;
 	}
+
+	vcs_inst = &vcs_insts[bt_conn_index(conn)];
 
 	if (handle == vcs_inst->cli.state_handle &&
 	    length == sizeof(vcs_inst->cli.state)) {


### PR DESCRIPTION
As per the GATT documenation, the conn pointer may actually
be NULL in the notify callback, indicating that the connection
is being unpaired.

Add a check for conn == NULL to avoid calling bt_conn_index
on a NULL pointer.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>