### PR TITLE
logging: Extend support for compilation with up to 31 arguments

### DIFF
--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -180,7 +180,8 @@ extern "C" {
 #define Z_LOG_NARGS_POSTFIX_IMPL(				\
 	_ignored,						\
 	_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10,		\
-	_11, _12, _13, _14, N, ...) N
+	_11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21,  \
+	_22, _23, _24, _25, _26, _27, _28, _29, _30, _31, N, ...) N
 
 /**@brief Macro to get the postfix for further log message processing.
  *
@@ -192,7 +193,9 @@ extern "C" {
  */
 #define Z_LOG_NARGS_POSTFIX(...) \
 	Z_LOG_NARGS_POSTFIX_IMPL(__VA_ARGS__, LONG, LONG, LONG, LONG, LONG, \
-			LONG, LONG, LONG, LONG, LONG, LONG, LONG, 3, 2, 1, 0, ~)
+			LONG, LONG, LONG, LONG, LONG, LONG, LONG, LONG, LONG, \
+			LONG, LONG, LONG, LONG, LONG, LONG, LONG, LONG, LONG, \
+			LONG, LONG, LONG, LONG, LONG, LONG, 3, 2, 1, 0, ~)
 
 #define Z_LOG_INTERNAL_X(N, ...)  UTIL_CAT(_LOG_INTERNAL_, N)(__VA_ARGS__)
 


### PR DESCRIPTION
Logging v2 supports 255 arguments but since logging v1 was supporting
only 15, and it is still compiled, more than 15 could not be used.
Extending logging v1 macro to accept up to 31 arguments. It will fail
during processing in case of v1 but will work with v2 enabled. It is
a temporary solution since v1 will be removed at some point.

Fixes #40883.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>