### PR TITLE
boards: arm: pinetime_devkit0: Documenation update

### DIFF
--- a/boards/arm/pinetime_devkit0/doc/index.rst
+++ b/boards/arm/pinetime_devkit0/doc/index.rst
@@ -30,15 +30,15 @@ Hardware
 
 The PineTime is based on a Nordic NRF52832 chip and features:
 
-- 64 MHz Cortex-M4 with FPU
-- 64KB SRAM
-- 512KB on board Flash
-- 1.3 inches (33mm), 240x240 pixels display with ST7789 driver
-- 170-180mAh LiPo battery
-- XT25F32B 32Mb (4MB) SPI NOR Flash
-- CST816S Capacitive Touch
+- CPU: 64 MHz Cortex-M4 with FPU
+- RAM: 64KB SRAM
+- Flash: 512KB on board flash with additional 4MB SPI NOR XT25F32B
+- Display: 1.3 inches (33mm), 240x240 pixels display with ST7789 driver
+- Touchscreen: CST816S Capacitive Touch
+- Battery: 170-180mAh 3.8V LiPo
 - BMA421 Triaxial Acceleration Sensor
 - HRS3300 PPG Heart Rate Sensor
+- Vibration motor
 
 PineTime schematics
 ========================

--- a/boards/arm/pinetime_devkit0/doc/index.rst
+++ b/boards/arm/pinetime_devkit0/doc/index.rst
@@ -164,6 +164,8 @@ Unlocking the device is a one-time action that is needed to enable to debug
 port and provide full access to the device. This will erase all existing
 software from the internal flash.
 
+**Note: PineTime watches shipped after 20 Sep 2020 do not require unlocking. They are shipped unlocked.**
+
 .. code-block:: console
 
    $ nrfjprog -f NRF52 --recover

--- a/boards/arm/pinetime_devkit0/doc/index.rst
+++ b/boards/arm/pinetime_devkit0/doc/index.rst
@@ -40,10 +40,12 @@ The PineTime is based on a Nordic NRF52832 chip and features:
 - BMA421 Triaxial Acceleration Sensor
 - HRS3300 PPG Heart Rate Sensor
 
-PineTime Port Assignment
+PineTime schematics
 ========================
 
-See `PineTime schematics`_
+The `PineTime schematics`_ are available on the pine64 website. Below
+is an overview of the NRF52 port assignment.
+
 +----------------------+---------------------------------+-----------+
 | NRF52 pins           | Function                        | Direction |
 +======================+=================================+===========+


### PR DESCRIPTION
Primary reason for this PR is that the table on the documentation page is not displayed correctly. It contains the following changes:
- Fix port assignment table
- Reorder hardware features
- Add unlock notice
- Reword schematics section