### PR TITLE
Add conn check for GATT notify handlers for LE audio implementations

### DIFF
--- a/subsys/bluetooth/audio/aics_client.c
+++ b/subsys/bluetooth/audio/aics_client.c
@@ -51,9 +51,15 @@ uint8_t aics_client_notify_handler(struct bt_conn *conn, struct bt_gatt_subscrib
 				   const void *data, uint16_t length)
 {
 	uint16_t handle = params->value_handle;
-	struct bt_aics *inst = lookup_aics_by_handle(conn, handle);
+	struct bt_aics *inst;
 	struct bt_aics_state *state;
 	uint8_t *status;
+
+	if (conn == NULL) {
+		return BT_GATT_ITER_CONTINUE;
+	}
+
+	inst = lookup_aics_by_handle(conn, handle);
 
 	if (!inst) {
 		BT_DBG("Instance not found");

--- a/subsys/bluetooth/audio/csis_client.c
+++ b/subsys/bluetooth/audio/csis_client.c
@@ -186,6 +186,10 @@ static uint8_t sirk_notify_func(struct bt_conn *conn,
 		return BT_GATT_ITER_STOP;
 	}
 
+	if (conn == NULL) {
+		return BT_GATT_ITER_CONTINUE;
+	}
+
 	csis_inst = lookup_instance_by_handle(conn, handle);
 
 	if (csis_inst != NULL) {
@@ -254,6 +258,10 @@ static uint8_t size_notify_func(struct bt_conn *conn,
 		return BT_GATT_ITER_STOP;
 	}
 
+	if (conn == NULL) {
+		return BT_GATT_ITER_CONTINUE;
+	}
+
 	csis_inst = lookup_instance_by_handle(conn, handle);
 
 	if (csis_inst != NULL) {
@@ -295,6 +303,10 @@ static uint8_t lock_notify_func(struct bt_conn *conn,
 		params->value_handle = 0U;
 
 		return BT_GATT_ITER_STOP;
+	}
+
+	if (conn == NULL) {
+		return BT_GATT_ITER_CONTINUE;
 	}
 
 	csis_inst = lookup_instance_by_handle(conn, handle);

--- a/subsys/bluetooth/audio/mcc.c
+++ b/subsys/bluetooth/audio/mcc.c
@@ -911,6 +911,10 @@ static uint8_t mcs_notify_handler(struct bt_conn *conn,
 {
 	uint16_t handle = params->value_handle;
 
+	if (conn == NULL) {
+		return BT_GATT_ITER_CONTINUE;
+	}
+
 	BT_DBG("Notification, handle: %d", handle);
 
 	if (data) {

--- a/subsys/bluetooth/audio/mics_client.c
+++ b/subsys/bluetooth/audio/mics_client.c
@@ -60,7 +60,13 @@ static uint8_t mute_notify_handler(struct bt_conn *conn,
 				   const void *data, uint16_t length)
 {
 	uint8_t *mute_val;
-	struct bt_mics *mics_inst = &mics_insts[bt_conn_index(conn)];
+	struct bt_mics *mics_inst;
+
+	if (conn == NULL) {
+		return BT_GATT_ITER_CONTINUE;
+	}
+
+	mics_inst = &mics_insts[bt_conn_index(conn)];
 
 	if (data != NULL) {
 		if (length == sizeof(*mute_val)) {

--- a/subsys/bluetooth/audio/vocs_client.c
+++ b/subsys/bluetooth/audio/vocs_client.c
@@ -49,7 +49,13 @@ uint8_t vocs_client_notify_handler(struct bt_conn *conn, struct bt_gatt_subscrib
 				   const void *data, uint16_t length)
 {
 	uint16_t handle = params->value_handle;
-	struct bt_vocs *inst = lookup_vocs_by_handle(conn, handle);
+	struct bt_vocs *inst;
+
+	if (conn == NULL) {
+		return BT_GATT_ITER_CONTINUE;
+	}
+
+	inst = lookup_vocs_by_handle(conn, handle);
 
 	if (!inst) {
 		BT_DBG("Instance not found");

--- a/subsys/bluetooth/services/ots/ots_client.c
+++ b/subsys/bluetooth/services/ots/ots_client.c
@@ -349,8 +349,13 @@ uint8_t bt_ots_client_indicate_handler(struct bt_conn *conn,
 				       const void *data, uint16_t length)
 {
 	uint16_t handle = params->value_handle;
-	struct bt_otc_internal_instance_t *inst =
-		lookup_inst_by_handle(handle);
+	struct bt_otc_internal_instance_t *inst;
+
+	if (conn == NULL) {
+		return BT_GATT_ITER_CONTINUE;
+	}
+
+	inst = lookup_inst_by_handle(handle);
 
 	/* TODO: Can we somehow avoid exposing this
 	 * callback via the public API?


### PR DESCRIPTION
Most of the implementations used the `conn` pointer in one way or another, but the pointer may be NULL, which was not accounted for. 