### PR TITLE
soc: esp32s2: fix: data cache setup

### DIFF
--- a/soc/xtensa/esp32s2/soc.c
+++ b/soc/xtensa/esp32s2/soc.c
@@ -68,8 +68,10 @@ void __attribute__((section(".iram1"))) __start(void)
 	 * line size.
 	 * Enable data cache, so if we don't use SPIRAM, it just works.
 	 */
+#if CONFIG_ESP_SPIRAM
 	esp_config_data_cache_mode();
 	esp_rom_Cache_Enable_DCache(0);
+#endif
 
 #if !CONFIG_BOOTLOADER_ESP_IDF
 	/* The watchdog timer is enabled in the 1st stage (ROM) bootloader.


### PR DESCRIPTION
Data cache mode setup and enabling should be done only when `CONFIG_ESP_SPIRAM` is enabled. Otherwise, the memory layout will conflict with defaults.