### PR TITLE
cbprintf_packaged: remove undefined pointer subtraction

### DIFF
--- a/lib/os/cbprintf_packaged.c
+++ b/lib/os/cbprintf_packaged.c
@@ -504,7 +504,7 @@ process_string:
 	 * then we have it now.
 	 */
 	if (!buf0) {
-		return len + buf - buf0;
+		return len + (uintptr_t)buf;
 	}
 
 	/* Clear our buffer header. We made room for it initially. */


### PR DESCRIPTION
Subtracting NULL from a pointer is apparently undefined.

Normally we don't know if `buf0` is NULL, but in this very case
we do due to the enclosing if, and static analysis may get unhappy.

Fixes #40866.
