### PR TITLE
drivers: adc: Add threshold irq support

### DIFF
--- a/drivers/adc/Kconfig
+++ b/drivers/adc/Kconfig
@@ -40,6 +40,11 @@ config ADC_INIT_PRIORITY
 	help
 	  ADC driver device initialization priority.
 
+config ADC_THRESHOLD_IRQ
+	bool "Enable threshold interruption support"
+	help
+	  This option enables the threshold interruption API calls.
+
 module = ADC
 module-str = ADC
 source "subsys/logging/Kconfig.template.log_config"

--- a/dts/arm/nuvoton/npcx7.dtsi
+++ b/dts/arm/nuvoton/npcx7.dtsi
@@ -197,6 +197,7 @@
 				     &altf_adc7_sl   /* ADC7 - PINE1 */
 				     &altf_adc8_sl   /* ADC8 - PINF1 */
 				     &altf_adc9_sl>; /* ADC9 - PINF0 */
+			threshold-count = <3>;
 		};
 	};
 

--- a/dts/arm/nuvoton/npcx9.dtsi
+++ b/dts/arm/nuvoton/npcx9.dtsi
@@ -223,6 +223,7 @@
 				     &altf_adc9_sl    /* ADC9 - PINF0 */
 				     &altf_adc10_sl   /* ADC10 - PINE0 */
 				     &altf_adc11_sl>; /* ADC11 - PINC7 */
+			threshold-count = <6>;
 		};
 	};
 

--- a/dts/bindings/iio/adc/nuvoton,npcx-adc.yaml
+++ b/dts/bindings/iio/adc/nuvoton,npcx-adc.yaml
@@ -18,6 +18,10 @@ properties:
         type: phandles
         required: true
         description: configurations of pinmux controllers
+    threshold-count:
+        type: int
+        required: true
+        description: the number of adc threshold detector
 
 io-channel-cells:
     - input


### PR DESCRIPTION
Exporting and implementing API's to enable ADC threshold
interruption for NPCX chip.

Signed-off-by: Bernardo Perez Priego <bernardo.perez.priego@intel.com>