### PR TITLE
coding guidelines: partially comply with MISRA C:2012 Rule 20.7

### DIFF
--- a/arch/x86/core/early_serial.c
+++ b/arch/x86/core/early_serial.c
@@ -21,8 +21,8 @@
  * together.
  */
 static mm_reg_t mmio;
-#define IN(reg)       (sys_read32(mmio + reg * 4) & 0xff)
-#define OUT(reg, val) sys_write32((val) & 0xff, mmio + reg * 4)
+#define IN(reg)       (sys_read32(mmio + (reg) * 4) & 0xff)
+#define OUT(reg, val) sys_write32((val) & 0xff, mmio + (reg) * 4)
 #elif defined(X86_SOC_EARLY_SERIAL_MMIO8_ADDR)
 /* Still other devices use a MMIO region containing packed byte
  * registers

--- a/arch/x86/include/x86_mmu.h
+++ b/arch/x86/include/x86_mmu.h
@@ -209,7 +209,7 @@ extern pentry_t z_x86_kernel_ptables[];
 static inline pentry_t *z_x86_thread_page_tables_get(struct k_thread *thread)
 {
 #if defined(CONFIG_USERSPACE) && !defined(CONFIG_X86_COMMON_PAGE_TABLE)
-	if (!IS_ENABLED(CONFIG_X86_KPTI) ||
+	if (!(IS_ENABLED(CONFIG_X86_KPTI)) ||
 	    (thread->base.user_options & K_USER) != 0U) {
 		/* If KPTI is enabled, supervisor threads always use
 		 * the kernel's page tables and not the page tables associated

--- a/drivers/interrupt_controller/intc_system_apic.c
+++ b/drivers/interrupt_controller/intc_system_apic.c
@@ -19,7 +19,7 @@
 #include <irq.h>
 #include <linker/sections.h>
 
-#define IS_IOAPIC_IRQ(irq)  (irq < z_loapic_irq_base())
+#define IS_IOAPIC_IRQ(irq)  ((irq) < z_loapic_irq_base())
 #define HARDWARE_IRQ_LIMIT ((z_loapic_irq_base() + LOAPIC_IRQ_COUNT) - 1)
 
 /**

--- a/drivers/pcie/host/msi.c
+++ b/drivers/pcie/host/msi.c
@@ -285,7 +285,7 @@ bool pcie_msi_enable(pcie_bdf_t bdf,
 		return false;
 	}
 
-	if (!msi && IS_ENABLED(CONFIG_PCIE_MSI_X)) {
+	if (!msi && (IS_ENABLED(CONFIG_PCIE_MSI_X))) {
 		enable_msix(bdf, vectors, n_vector, base, irq);
 	} else {
 		enable_msi(bdf, vectors, n_vector, base, irq);

--- a/drivers/pcie/host/pcie.c
+++ b/drivers/pcie/host/pcie.c
@@ -123,7 +123,7 @@ bool pcie_get_mbar(pcie_bdf_t bdf,
 	size = pcie_conf_read(bdf, reg);
 	pcie_conf_write(bdf, reg, (uint32_t)phys_addr);
 
-	if (IS_ENABLED(CONFIG_64BIT) && PCIE_CONF_BAR_64(phys_addr)) {
+	if ((IS_ENABLED(CONFIG_64BIT)) && PCIE_CONF_BAR_64(phys_addr)) {
 		reg++;
 		phys_addr |= ((uint64_t)pcie_conf_read(bdf, reg)) << 32;
 

--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -220,8 +220,8 @@ BUILD_ASSERT(IS_ENABLED(CONFIG_PCIE), "NS16550(s) in DT need CONFIG_PCIE");
 #else
 #define INBYTE(x) sys_read8(x)
 #define INWORD(x) sys_read32(x)
-#define OUTBYTE(x, d) sys_write8(d, x)
-#define OUTWORD(x, d) sys_write32(d, x)
+#define OUTBYTE(x, d) sys_write8((d), (x))
+#define OUTWORD(x, d) sys_write32((d), (x))
 #endif /* UART_NS16550_ACCESS_IOPORT */
 
 #ifdef CONFIG_UART_NS16550_ACCESS_WORD_ONLY

--- a/drivers/timer/apic_tsc.c
+++ b/drivers/timer/apic_tsc.c
@@ -43,7 +43,7 @@ static void isr(const void *arg)
 	k_spin_unlock(&lock, key);
 	sys_clock_announce(ticks);
 
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+	if (!(IS_ENABLED(CONFIG_TICKLESS_KERNEL))) {
 		sys_clock_set_timeout(1, false);
 	}
 }
@@ -189,7 +189,7 @@ int sys_clock_driver_init(const struct device *dev)
 	last_announce = rdtsc();
 	irq_enable(timer_irq());
 
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+	if (!(IS_ENABLED(CONFIG_TICKLESS_KERNEL))) {
 		sys_clock_set_timeout(1, false);
 	}
 

--- a/include/arch/x86/arch.h
+++ b/include/arch/x86/arch.h
@@ -219,7 +219,7 @@ static ALWAYS_INLINE int sys_test_and_clear_bit(mem_addr_t addr,
 extern unsigned char _irq_to_interrupt_vector[];
 
 #define Z_IRQ_TO_INTERRUPT_VECTOR(irq) \
-	((unsigned int) _irq_to_interrupt_vector[irq])
+	((unsigned int) _irq_to_interrupt_vector[(irq)])
 
 
 #endif /* _ASMLANGUAGE */

--- a/include/device.h
+++ b/include/device.h
@@ -791,7 +791,7 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 		const Z_DECL_ALIGN(struct device)			\
 		DEVICE_NAME_GET(dev_name) __used			\
 	__attribute__((__section__(".z_device_" #level STRINGIFY(prio)"_"))) = { \
-		.name = drv_name,					\
+		.name = (drv_name),					\
 		.config = (cfg_ptr),					\
 		.api = (api_ptr),					\
 		.state = &Z_DEVICE_STATE_NAME(dev_name),		\

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -324,7 +324,7 @@ extern FUNC_NORETURN void k_thread_user_mode_enter(k_thread_entry_t entry,
  * @param ... list of kernel object pointers
  */
 #define k_thread_access_grant(thread, ...) \
-	FOR_EACH_FIXED_ARG(k_object_access_grant, (;), thread, __VA_ARGS__)
+	FOR_EACH_FIXED_ARG((k_object_access_grant), (;), (thread), __VA_ARGS__)
 
 /**
  * @brief Assign a resource memory pool to a thread
@@ -2398,10 +2398,10 @@ struct k_stack {
 
 #define Z_STACK_INITIALIZER(obj, stack_buffer, stack_num_entries) \
 	{ \
-	.wait_q = Z_WAIT_Q_INIT(&obj.wait_q),	\
-	.base = stack_buffer, \
-	.next = stack_buffer, \
-	.top = stack_buffer + stack_num_entries, \
+	.wait_q = Z_WAIT_Q_INIT(&(obj).wait_q),	\
+	.base = (stack_buffer), \
+	.next = (stack_buffer), \
+	.top = (stack_buffer) + (stack_num_entries), \
 	}
 
 /**
@@ -2509,7 +2509,7 @@ __syscall int k_stack_pop(struct k_stack *stack, stack_data_t *data,
  */
 #define K_STACK_DEFINE(name, stack_num_entries)                \
 	stack_data_t __noinit                                  \
-		_k_stack_buf_##name[stack_num_entries];        \
+		_k_stack_buf_##name[(stack_num_entries)];        \
 	STRUCT_SECTION_ITERABLE(k_stack, name) =               \
 		Z_STACK_INITIALIZER(name, _k_stack_buf_##name, \
 				    stack_num_entries)
@@ -2558,7 +2558,7 @@ struct k_mutex {
  */
 #define Z_MUTEX_INITIALIZER(obj) \
 	{ \
-	.wait_q = Z_WAIT_Q_INIT(&obj.wait_q), \
+	.wait_q = Z_WAIT_Q_INIT(&(obj).wait_q), \
 	.owner = NULL, \
 	.lock_count = 0, \
 	.owner_orig_prio = K_LOWEST_APPLICATION_THREAD_PRIO, \
@@ -2738,9 +2738,9 @@ struct k_sem {
 
 #define Z_SEM_INITIALIZER(obj, initial_count, count_limit) \
 	{ \
-	.wait_q = Z_WAIT_Q_INIT(&obj.wait_q), \
-	.count = initial_count, \
-	.limit = count_limit, \
+	.wait_q = Z_WAIT_Q_INIT(&(obj).wait_q), \
+	.count = (initial_count), \
+	.limit = (count_limit), \
 	_POLL_EVENT_OBJ_INIT(obj) \
 	}
 
@@ -3507,7 +3507,7 @@ struct k_work {
 };
 
 #define Z_WORK_INITIALIZER(work_handler) { \
-	.handler = work_handler, \
+	.handler = (work_handler), \
 }
 
 /** @brief A structure used to submit work after a delay. */
@@ -3524,7 +3524,7 @@ struct k_work_delayable {
 
 #define Z_WORK_DELAYABLE_INITIALIZER(work_handler) { \
 	.work = { \
-		.handler = work_handler, \
+		.handler = (work_handler), \
 		.flags = K_WORK_DELAYABLE, \
 	}, \
 }
@@ -3858,7 +3858,7 @@ struct k_work_user {
 #define Z_WORK_USER_INITIALIZER(work_handler) \
 	{ \
 	._reserved = NULL, \
-	.handler = work_handler, \
+	.handler = (work_handler), \
 	.flags = 0 \
 	}
 

--- a/include/kernel/thread_stack.h
+++ b/include/kernel/thread_stack.h
@@ -150,7 +150,7 @@ static inline char *z_stack_ptr_align(char *ptr)
  */
 #define K_KERNEL_PINNED_STACK_ARRAY_EXTERN(sym, nmemb, size) \
 	extern struct z_thread_stack_element \
-		sym[nmemb][Z_KERNEL_STACK_LEN(size)]
+		sym[(nmemb)][Z_KERNEL_STACK_LEN(size)]
 
 /**
  * @def Z_KERNEL_STACK_DEFINE_IN
@@ -189,7 +189,7 @@ static inline char *z_stack_ptr_align(char *ptr)
 #define Z_KERNEL_STACK_ARRAY_DEFINE_IN(sym, nmemb, size, lsect) \
 	struct z_thread_stack_element lsect \
 		__aligned(Z_KERNEL_STACK_OBJ_ALIGN) \
-		sym[nmemb][Z_KERNEL_STACK_LEN(size)]
+		sym[(nmemb)][Z_KERNEL_STACK_LEN(size)]
 
 /**
  * @def K_KERNEL_STACK_DEFINE

--- a/include/logging/log.h
+++ b/include/logging/log.h
@@ -153,7 +153,7 @@ extern "C" {
  * @param _str    Persistent, raw string.
  */
 #define LOG_HEXDUMP_ERR(_data, _length, _str) \
-	Z_LOG_HEXDUMP(LOG_LEVEL_ERR, _data, _length, _str)
+	Z_LOG_HEXDUMP(LOG_LEVEL_ERR, _data, _length, (_str))
 
 /**
  * @brief Writes a WARNING level message to the log.
@@ -166,7 +166,7 @@ extern "C" {
  * @param _str    Persistent, raw string.
  */
 #define LOG_HEXDUMP_WRN(_data, _length, _str) \
-	Z_LOG_HEXDUMP(LOG_LEVEL_WRN, _data, _length, _str)
+	Z_LOG_HEXDUMP(LOG_LEVEL_WRN, _data, _length, (_str))
 
 /**
  * @brief Writes an INFO level message to the log.
@@ -178,7 +178,7 @@ extern "C" {
  * @param _str    Persistent, raw string.
  */
 #define LOG_HEXDUMP_INF(_data, _length, _str) \
-	Z_LOG_HEXDUMP(LOG_LEVEL_INF, _data, _length, _str)
+	Z_LOG_HEXDUMP(LOG_LEVEL_INF, _data, _length, (_str))
 
 /**
  * @brief Writes a DEBUG level message to the log.
@@ -190,7 +190,7 @@ extern "C" {
  * @param _str    Persistent, raw string.
  */
 #define LOG_HEXDUMP_DBG(_data, _length, _str) \
-	Z_LOG_HEXDUMP(LOG_LEVEL_DBG, _data, _length, _str)
+	Z_LOG_HEXDUMP(LOG_LEVEL_DBG, _data, _length, (_str))
 
 /**
  * @brief Writes an ERROR hexdump message associated with the instance to the
@@ -289,7 +289,7 @@ static inline void log_printk(const char *fmt, va_list ap)
 char *z_log_strdup(const char *str);
 static inline char *log_strdup(const char *str)
 {
-	if (IS_ENABLED(CONFIG_LOG_MINIMAL) || IS_ENABLED(CONFIG_LOG2)) {
+	if ((IS_ENABLED(CONFIG_LOG_MINIMAL)) || (IS_ENABLED(CONFIG_LOG2))) {
 		return (char *)str;
 	}
 
@@ -322,7 +322,7 @@ static inline char *log_strdup(const char *str)
 	__attribute__ ((section("." STRINGIFY(LOG_ITEM_CONST_DATA(_name))))) \
 	__attribute__((used)) = {					     \
 		.name = STRINGIFY(_name),				     \
-		.level = _level						     \
+		.level = (_level)						     \
 	}
 
 #define _LOG_MODULE_DYNAMIC_DATA_CREATE(_name)				\
@@ -415,19 +415,19 @@ static inline char *log_strdup(const char *str)
 									      \
 	static const struct log_source_const_data *			      \
 		__log_current_const_data __unused =			      \
-			_LOG_LEVEL_RESOLVE(__VA_ARGS__) ?		      \
+			(_LOG_LEVEL_RESOLVE(__VA_ARGS__)) != 0 ?		      \
 			&LOG_ITEM_CONST_DATA(GET_ARG_N(1, __VA_ARGS__)) :     \
 			NULL;						      \
 									      \
 	static struct log_source_dynamic_data *				      \
 		__log_current_dynamic_data __unused =			      \
-			(_LOG_LEVEL_RESOLVE(__VA_ARGS__) &&		      \
-			IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING)) ?	      \
+			(((_LOG_LEVEL_RESOLVE(__VA_ARGS__)) != 0) &&		      \
+			(IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING))) ?	      \
 			&LOG_ITEM_DYNAMIC_DATA(GET_ARG_N(1, __VA_ARGS__)) :   \
 			NULL;						      \
 									      \
 	static const uint32_t __log_level __unused =			      \
-					_LOG_LEVEL_RESOLVE(__VA_ARGS__)
+					(_LOG_LEVEL_RESOLVE(__VA_ARGS__))
 
 /**
  * @brief Macro for setting log level in the file or function where instance

--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -35,13 +35,13 @@ extern "C" {
 #endif
 
 #define LOG_FUNCTION_PREFIX_MASK \
-	(((uint32_t)IS_ENABLED(CONFIG_LOG_FUNC_NAME_PREFIX_ERR) << \
+	(((uint32_t)(IS_ENABLED(CONFIG_LOG_FUNC_NAME_PREFIX_ERR)) << \
 	  LOG_LEVEL_ERR) | \
-	 ((uint32_t)IS_ENABLED(CONFIG_LOG_FUNC_NAME_PREFIX_WRN) << \
+	 ((uint32_t)(IS_ENABLED(CONFIG_LOG_FUNC_NAME_PREFIX_WRN)) << \
 	  LOG_LEVEL_WRN) | \
-	 ((uint32_t)IS_ENABLED(CONFIG_LOG_FUNC_NAME_PREFIX_INF) << \
+	 ((uint32_t)(IS_ENABLED(CONFIG_LOG_FUNC_NAME_PREFIX_INF)) << \
 	  LOG_LEVEL_INF) | \
-	 ((uint32_t)IS_ENABLED(CONFIG_LOG_FUNC_NAME_PREFIX_DBG) << LOG_LEVEL_DBG))
+	 ((uint32_t)(IS_ENABLED(CONFIG_LOG_FUNC_NAME_PREFIX_DBG)) << LOG_LEVEL_DBG))
 
 /** @brief Macro for returning local level value if defined or default.
  *
@@ -51,7 +51,7 @@ extern "C" {
 	Z_LOG_RESOLVED_LEVEL1(_level, _default)
 
 #define Z_LOG_RESOLVED_LEVEL1(_level, _default) \
-	__COND_CODE(_LOG_XXXX##_level, (_level), (_default))
+	__COND_CODE(_LOG_XXXX##_level, ((_level)), ((_default)))
 
 #define _LOG_XXXX0  _LOG_YYYY,
 #define _LOG_XXXX0U _LOG_YYYY,
@@ -195,9 +195,9 @@ extern "C" {
 
 #define Z_LOG_INTERNAL2(is_user_context, _src_level, ...) do { \
 	if (is_user_context) { \
-		log_from_user(_src_level, __VA_ARGS__); \
+		log_from_user((_src_level), __VA_ARGS__); \
 	} else if (IS_ENABLED(CONFIG_LOG_IMMEDIATE)) { \
-		log_string_sync(_src_level, __VA_ARGS__); \
+		log_string_sync((_src_level), __VA_ARGS__); \
 	} else { \
 		Z_LOG_INTERNAL_X(Z_LOG_NARGS_POSTFIX(__VA_ARGS__), \
 					_src_level, __VA_ARGS__); \
@@ -206,10 +206,10 @@ extern "C" {
 
 #define Z_LOG_INTERNAL(is_user_context, _level, _source, _dsource, ...) do { \
 	uint16_t src_id = \
-		IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
+		(IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING)) ? \
 		LOG_DYNAMIC_ID_GET(_dsource) : LOG_CONST_ID_GET(_source); \
 	struct log_msg_ids src_level = { \
-		.level = _level, \
+		.level = (_level), \
 		.domain_id = CONFIG_LOG_DOMAIN_ID, \
 		.source_id = src_id \
 	}; \
@@ -218,16 +218,16 @@ extern "C" {
 } while (false)
 
 #define _LOG_INTERNAL_0(_src_level, _str) \
-	log_0(_str, _src_level)
+	log_0((_str), (_src_level))
 
 #define _LOG_INTERNAL_1(_src_level, _str, _arg0) \
-	log_1(_str, (log_arg_t)(_arg0), _src_level)
+	log_1((_str), (log_arg_t)(_arg0), (_src_level))
 
 #define _LOG_INTERNAL_2(_src_level, _str, _arg0, _arg1)	\
-	log_2(_str, (log_arg_t)(_arg0), (log_arg_t)(_arg1), _src_level)
+	log_2((_str), (log_arg_t)(_arg0), (log_arg_t)(_arg1), (_src_level))
 
 #define _LOG_INTERNAL_3(_src_level, _str, _arg0, _arg1, _arg2) \
-	log_3(_str, (log_arg_t)(_arg0), (log_arg_t)(_arg1), (log_arg_t)(_arg2), _src_level)
+	log_3((_str), (log_arg_t)(_arg0), (log_arg_t)(_arg1), (log_arg_t)(_arg2), (_src_level))
 
 #define __LOG_ARG_CAST(_x) (log_arg_t)(_x)
 
@@ -236,19 +236,19 @@ extern "C" {
 #define _LOG_INTERNAL_LONG(_src_level, _str, ...)		  \
 	do {							  \
 		log_arg_t args[] = {__LOG_ARGUMENTS(__VA_ARGS__)};\
-		log_n(_str, args, ARRAY_SIZE(args), _src_level);  \
+		log_n((_str), args, ARRAY_SIZE(args), (_src_level));  \
 	} while (false)
 
 #define Z_LOG_LEVEL_CHECK(_level, _check_level, _default_level) \
-	(_level <= Z_LOG_RESOLVED_LEVEL(_check_level, _default_level))
+	((_level) <= Z_LOG_RESOLVED_LEVEL(_check_level, _default_level))
 
 #define Z_LOG_CONST_LEVEL_CHECK(_level)					    \
-	(IS_ENABLED(CONFIG_LOG) &&					    \
+	((IS_ENABLED(CONFIG_LOG)) &&					    \
 	(Z_LOG_LEVEL_CHECK(_level, CONFIG_LOG_OVERRIDE_LEVEL, LOG_LEVEL_NONE) \
 	||								    \
-	((IS_ENABLED(CONFIG_LOG_OVERRIDE_LEVEL) == false) &&		    \
-	(_level <= __log_level) &&					    \
-	(_level <= CONFIG_LOG_MAX_LEVEL)				    \
+	(!(IS_ENABLED(CONFIG_LOG_OVERRIDE_LEVEL)) &&		    \
+	((_level) <= __log_level) &&					    \
+	((_level) <= CONFIG_LOG_MAX_LEVEL)				    \
 	)								    \
 	))
 
@@ -302,16 +302,16 @@ static inline char z_log_minimal_level_to_char(int level)
 	} \
 	\
 	bool is_user_context = k_is_user_context(); \
-	uint32_t filters = IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
+	uint32_t filters = (IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING)) ? \
 						(_dsource)->filters : 0;\
-	if (IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) && !is_user_context && \
-	    _level > Z_LOG_RUNTIME_FILTER(filters)) { \
+	if ((IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING)) && !is_user_context && \
+	    (_level) > Z_LOG_RUNTIME_FILTER(filters)) { \
 		break; \
 	} \
 	if (IS_ENABLED(CONFIG_LOG2)) { \
 		int _mode; \
-		void *_src = IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
-			(void *)_dsource : (void *)_source; \
+		void *_src = (IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING)) ? \
+			(void *)(_dsource) : (void *)(_source); \
 		Z_LOG_MSG2_CREATE(UTIL_NOT(IS_ENABLED(CONFIG_USERSPACE)), _mode, \
 				  CONFIG_LOG_DOMAIN_ID, _src, _level, NULL,\
 				  0, __VA_ARGS__); \
@@ -342,28 +342,28 @@ static inline char z_log_minimal_level_to_char(int level)
 /****************** Macros for hexdump logging *******************************/
 /*****************************************************************************/
 #define Z_LOG_HEXDUMP2(_level, _source, _dsource, _data, _len, ...) do { \
-	const char *_str = GET_ARG_N(1, __VA_ARGS__); \
+	const char *_str = (GET_ARG_N(1, __VA_ARGS__)); \
 	if (!Z_LOG_CONST_LEVEL_CHECK(_level)) {	\
 		break; \
 	} \
 	bool is_user_context = k_is_user_context(); \
-	uint32_t filters = IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
+	uint32_t filters = (IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING)) ? \
 						(_dsource)->filters : 0;\
 	\
 	if (IS_ENABLED(CONFIG_LOG_MINIMAL)) { \
 		Z_LOG_TO_PRINTK(_level, "%s", _str); \
-		z_log_minimal_hexdump_print(_level, \
-					    (const char *)_data, _len);\
+		z_log_minimal_hexdump_print((_level), \
+					    (const char *)(_data), (_len));\
 		break; \
 	} \
-	if (IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) && !is_user_context && \
-	    _level > Z_LOG_RUNTIME_FILTER(filters)) { \
+	if ((IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING)) && !is_user_context && \
+	    (_level) > Z_LOG_RUNTIME_FILTER(filters)) { \
 		break; \
 	} \
 	if (IS_ENABLED(CONFIG_LOG2)) { \
 		int mode; \
-		void *_src = IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
-			(void *)_dsource : (void *)_source; \
+		void *_src = (IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING)) ? \
+			(void *)(_dsource) : (void *)(_source); \
 		Z_LOG_MSG2_CREATE(UTIL_NOT(IS_ENABLED(CONFIG_USERSPACE)), mode, \
 				  CONFIG_LOG_DOMAIN_ID, _src, _level, \
 				  _data, _len, \
@@ -374,20 +374,20 @@ static inline char z_log_minimal_level_to_char(int level)
 		break; \
 	} \
 	uint16_t src_id = \
-		IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
+		(IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING)) ? \
 		LOG_DYNAMIC_ID_GET(_dsource) : LOG_CONST_ID_GET(_source);\
 	struct log_msg_ids src_level = { \
-		.level = _level, \
+		.level = (_level), \
 		.domain_id = CONFIG_LOG_DOMAIN_ID, \
 		.source_id = src_id, \
 	}; \
 	if (is_user_context) { \
 		log_hexdump_from_user(src_level, _str, \
-				      (const char *)_data, _len); \
+				      (const char *)(_data), (_len)); \
 	} else if (IS_ENABLED(CONFIG_LOG_IMMEDIATE)) { \
-		log_hexdump_sync(src_level, _str, (const char *)_data, _len); \
+		log_hexdump_sync(src_level, _str, (const char *)(_data), (_len)); \
 	} else { \
-		log_hexdump(_str, (const char *)_data, _len, src_level); \
+		log_hexdump(_str, (const char *)(_data), (_len), src_level); \
 	} \
 } while (false)
 
@@ -450,7 +450,7 @@ static inline char z_log_minimal_level_to_char(int level)
  * two other backends are set for ERR, returned level is INF.
  */
 #define Z_LOG_RUNTIME_FILTER(_filter) \
-	LOG_FILTER_SLOT_GET(&_filter, LOG_FILTER_AGGR_SLOT_IDX)
+	LOG_FILTER_SLOT_GET(&(_filter), LOG_FILTER_AGGR_SLOT_IDX)
 
 /** @brief Log level value used to indicate log entry that should not be
  *	   formatted (raw string).
@@ -468,7 +468,7 @@ enum log_strdup_action {
 };
 
 #define Z_LOG_PRINTK(...) do { \
-	if (IS_ENABLED(CONFIG_LOG_MINIMAL) || !IS_ENABLED(CONFIG_LOG2)) { \
+	if ((IS_ENABLED(CONFIG_LOG_MINIMAL)) || !(IS_ENABLED(CONFIG_LOG2))) { \
 		z_log_minimal_printk(__VA_ARGS__); \
 		break; \
 	} \
@@ -476,7 +476,7 @@ enum log_strdup_action {
 	if (0) {\
 		z_log_printf_arg_checker(__VA_ARGS__); \
 	} \
-	Z_LOG_MSG2_CREATE(!IS_ENABLED(CONFIG_USERSPACE), _mode, \
+	Z_LOG_MSG2_CREATE(!(IS_ENABLED(CONFIG_USERSPACE)), _mode, \
 			  CONFIG_LOG_DOMAIN_ID, NULL, \
 			  LOG_LEVEL_INTERNAL_RAW_STRING, NULL, 0, __VA_ARGS__);\
 } while (false)
@@ -821,9 +821,9 @@ __syscall void z_log_hexdump_from_user(uint32_t src_level_val,
 	} \
 	\
 	bool is_user_context = k_is_user_context(); \
-	uint32_t filters = IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
+	uint32_t filters = (IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING)) ? \
 						_dsource->filters : 0;\
-	if (IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) && !is_user_context && \
+	if ((IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING)) && !is_user_context && \
 	    _level > Z_LOG_RUNTIME_FILTER(filters)) { \
 		break; \
 	} \
@@ -833,7 +833,7 @@ __syscall void z_log_hexdump_from_user(uint32_t src_level_val,
 		break; \
 	} \
 	uint16_t _id = \
-		IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
+		(IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING)) ? \
 		LOG_DYNAMIC_ID_GET(_dsource) : LOG_CONST_ID_GET(_source);\
 	struct log_msg_ids src_level = { \
 		.level = _level, \

--- a/include/logging/log_msg2.h
+++ b/include/logging/log_msg2.h
@@ -127,10 +127,10 @@ enum z_log_msg2_mode {
 	.valid = 0, \
 	.busy = 0, \
 	.type = Z_LOG_MSG2_LOG, \
-	.domain = _domain_id, \
-	.level = _level, \
-	.package_len = _plen, \
-	.data_len = _dlen, \
+	.domain = (_domain_id), \
+	.level = (_level), \
+	.package_len = (_plen), \
+	.data_len = (_dlen), \
 	.reserved = 0, \
 }
 
@@ -141,11 +141,11 @@ enum z_log_msg2_mode {
 #define Z_LOG_MSG2_ON_STACK_ALLOC(ptr, len) \
 	long long _ll_buf[ceiling_fraction(len, sizeof(long long))]; \
 	long double _ld_buf[ceiling_fraction(len, sizeof(long double))]; \
-	ptr = (sizeof(long double) == Z_LOG_MSG2_ALIGNMENT) ? \
+	(ptr) = (sizeof(long double) == Z_LOG_MSG2_ALIGNMENT) ? \
 			(struct log_msg2 *)_ld_buf : (struct log_msg2 *)_ll_buf; \
 	if (IS_ENABLED(CONFIG_LOG_TEST_CLEAR_MESSAGE_SPACE)) { \
 		/* During test fill with 0's to simplify message comparison */ \
-		memset(ptr, 0, len); \
+		memset((ptr), 0, (len)); \
 	}
 #else /* Z_LOG_MSG2_USE_VLA */
 /* When VLA cannot be used we need to trick compiler a bit and create multiple
@@ -187,7 +187,7 @@ enum z_log_msg2_mode {
 	sizeof(struct log_msg2_hdr)
 
 #define Z_LOG_MSG2_LEN(pkg_len, data_len) \
-	(sizeof(struct log_msg2_hdr) + pkg_len + (data_len))
+	(sizeof(struct log_msg2_hdr) + (pkg_len) + (data_len))
 
 #define Z_LOG_MSG2_ALIGNED_WLEN(pkg_len, data_len) \
 	ceiling_fraction(ROUND_UP(Z_LOG_MSG2_LEN(pkg_len, data_len), \
@@ -214,7 +214,7 @@ enum z_log_msg2_mode {
 #define Z_LOG_MSG2_STACK_CREATE(_domain_id, _source, _level, _data, _dlen, ...)\
 do { \
 	int _plen; \
-	if (GET_ARG_N(1, __VA_ARGS__) == NULL) { \
+	if ((GET_ARG_N(1, __VA_ARGS__)) == NULL) { \
 		_plen = 0; \
 	} else { \
 		CBPRINTF_STATIC_PACKAGE(NULL, 0, _plen, Z_LOG_MSG2_ALIGN_OFFSET, \
@@ -232,7 +232,7 @@ do { \
 					   (uint32_t)_plen, _dlen); \
 	LOG_MSG2_DBG("creating message on stack: package len: %d, data len: %d\n", \
 			_plen, (int)(_dlen)); \
-	z_log_msg2_static_create((void *)_source, _desc, _msg->data, _data); \
+	z_log_msg2_static_create((void *)(_source), _desc, _msg->data, (_data)); \
 } while (false)
 
 #if CONFIG_LOG_SPEED
@@ -377,22 +377,22 @@ do { \
 	Z_LOG_MSG2_STR_VAR(_fmt, ##__VA_ARGS__); \
 	if (CBPRINTF_MUST_RUNTIME_PACKAGE(_cstr_cnt, __VA_ARGS__)) { \
 		LOG_MSG2_DBG("create runtime message\n");\
-		z_log_msg2_runtime_create(_domain_id, (void *)_source, \
-					  _level, (uint8_t *)_data, _dlen,\
+		z_log_msg2_runtime_create((_domain_id), (void *)(_source), \
+					  (_level), (uint8_t *)(_data), (_dlen),\
 					  Z_LOG_FMT_ARGS(_fmt, ##__VA_ARGS__));\
-		_mode = Z_LOG_MSG2_MODE_RUNTIME; \
-	} else if (IS_ENABLED(CONFIG_LOG_SPEED) && _try_0cpy && ((_dlen) == 0)) {\
+		(_mode) = Z_LOG_MSG2_MODE_RUNTIME; \
+	} else if ((IS_ENABLED(CONFIG_LOG_SPEED)) && (_try_0cpy) && ((_dlen) == 0)) {\
 		LOG_MSG2_DBG("create zero-copy message\n");\
 		Z_LOG_MSG2_SIMPLE_CREATE(_domain_id, _source, \
 					_level, Z_LOG_FMT_ARGS(_fmt, ##__VA_ARGS__)); \
-		_mode = Z_LOG_MSG2_MODE_ZERO_COPY; \
+		(_mode) = Z_LOG_MSG2_MODE_ZERO_COPY; \
 	} else { \
 		LOG_MSG2_DBG("create on stack message\n");\
 		Z_LOG_MSG2_STACK_CREATE(_domain_id, _source, _level, _data, \
 					_dlen, Z_LOG_FMT_ARGS(_fmt, ##__VA_ARGS__)); \
-		_mode = Z_LOG_MSG2_MODE_FROM_STACK; \
+		(_mode) = Z_LOG_MSG2_MODE_FROM_STACK; \
 	} \
-	(void)_mode; \
+	(void)(_mode); \
 } while (false)
 #endif /* CONFIG_LOG2_ALWAYS_RUNTIME */
 

--- a/include/sys/bitarray.h
+++ b/include/sys/bitarray.h
@@ -42,11 +42,11 @@ typedef struct sys_bitarray sys_bitarray_t;
  */
 #define SYS_BITARRAY_DEFINE(name, total_bits)				\
 	uint32_t _sys_bitarray_bundles_##name				\
-		[(((total_bits + 8 - 1) / 8) + sizeof(uint32_t) - 1)	\
+		[((((total_bits) + 8 - 1) / 8) + sizeof(uint32_t) - 1)	\
 		 / sizeof(uint32_t)] = {0};				\
 	sys_bitarray_t name = {						\
-		.num_bits = total_bits,					\
-		.num_bundles = (((total_bits + 8 - 1) / 8)		\
+		.num_bits = (total_bits),					\
+		.num_bundles = ((((total_bits) + 8 - 1) / 8)		\
 				+ sizeof(uint32_t) - 1)			\
 			       / sizeof(uint32_t),			\
 		.bundles = _sys_bitarray_bundles_##name,		\

--- a/include/sys/cbprintf.h
+++ b/include/sys/cbprintf.h
@@ -55,11 +55,11 @@ extern "C" {
  * So set it manually.
  */
 #define CBPRINTF_PACKAGE_ALIGNMENT \
-	(IS_ENABLED(CONFIG_CBPRINTF_PACKAGE_LONGDOUBLE) ? \
+	((IS_ENABLED(CONFIG_CBPRINTF_PACKAGE_LONGDOUBLE)) ? \
 		16 : MAX(sizeof(double), sizeof(long long)))
 #else
 #define CBPRINTF_PACKAGE_ALIGNMENT \
-	(IS_ENABLED(CONFIG_CBPRINTF_PACKAGE_LONGDOUBLE) ? \
+	(((IS_ENABLED(CONFIG_CBPRINTF_PACKAGE_LONGDOUBLE))) ? \
 		sizeof(long double) : MAX(sizeof(double), sizeof(long long)))
 #endif
 

--- a/include/sys/cbprintf_internal.h
+++ b/include/sys/cbprintf_internal.h
@@ -129,7 +129,7 @@ extern "C" {
 	_Pragma("GCC diagnostic ignored \"-Wpointer-arith\"") \
 	int _rv = COND_CODE_0(NUM_VA_ARGS_LESS_1(__VA_ARGS__), \
 			(0), \
-			(((Z_CBPRINTF_HAS_PCHAR_ARGS(__VA_ARGS__) - skip) > 0))); \
+			(((Z_CBPRINTF_HAS_PCHAR_ARGS(__VA_ARGS__) - (skip)) > 0))); \
 	_Pragma("GCC diagnostic pop")\
 	_rv; \
 })
@@ -179,26 +179,26 @@ extern "C" {
 					0.0); \
 		size_t arg_size = Z_CBPRINTF_ARG_SIZE(arg); \
 		size_t _wsize = arg_size / sizeof(int); \
-		z_cbprintf_wcpy((int *)buf, \
+		z_cbprintf_wcpy((int *)(buf), \
 			      (int *) _Generic((arg) + 0, float : &_d, default : &_v), \
 			      _wsize); \
 	} else { \
 		*_Generic((arg) + 0, \
-			char : (int *)buf, \
-			unsigned char: (int *)buf, \
-			short : (int *)buf, \
-			unsigned short : (int *)buf, \
-			int : (int *)buf, \
-			unsigned int : (unsigned int *)buf, \
-			long : (long *)buf, \
-			unsigned long : (unsigned long *)buf, \
-			long long : (long long *)buf, \
-			unsigned long long : (unsigned long long *)buf, \
-			float : (double *)buf, \
-			double : (double *)buf, \
-			long double : (long double *)buf, \
+			char : (int *)(buf), \
+			unsigned char: (int *)(buf), \
+			short : (int *)(buf), \
+			unsigned short : (int *)(buf), \
+			int : (int *)(buf), \
+			unsigned int : (unsigned int *)(buf), \
+			long : (long *)(buf), \
+			unsigned long : (unsigned long *)(buf), \
+			long long : (long long *)(buf), \
+			unsigned long long : (unsigned long long *)(buf), \
+			float : (double *)(buf), \
+			double : (double *)(buf), \
+			long double : (long double *)(buf), \
 			default : \
-				(const void **)buf) = arg; \
+				(const void **)(buf)) = (arg); \
 	} \
 } while (false)
 #endif
@@ -264,21 +264,21 @@ extern "C" {
 do { \
 	BUILD_ASSERT(!((sizeof(double) < VA_STACK_ALIGN(long double)) && \
 			Z_CBPRINTF_IS_LONGDOUBLE(_arg) && \
-			!IS_ENABLED(CONFIG_CBPRINTF_PACKAGE_LONGDOUBLE)),\
+			!(IS_ENABLED(CONFIG_CBPRINTF_PACKAGE_LONGDOUBLE))),\
 			"Packaging of long double not enabled in Kconfig."); \
-	while (_align_offset % Z_CBPRINTF_ALIGNMENT(_arg) != 0UL) { \
-		_idx += sizeof(int); \
-		_align_offset += sizeof(int); \
+	while ((_align_offset) % Z_CBPRINTF_ALIGNMENT(_arg) != 0UL) { \
+		(_idx) += sizeof(int); \
+		(_align_offset) += sizeof(int); \
 	} \
 	uint32_t _arg_size = Z_CBPRINTF_ARG_SIZE(_arg); \
-	if (Z_CBPRINTF_IS_PCHAR(_arg)) { \
-		_s_buf[_s_idx++] = _idx / sizeof(int); \
+	if (Z_CBPRINTF_IS_PCHAR(_arg) != 0) { \
+		(_s_buf)[(_s_idx)++] = (_idx) / sizeof(int); \
 	} \
-	if (_buf && _idx < (int)_max) { \
-		Z_CBPRINTF_STORE_ARG(&_buf[_idx], _arg); \
+	if ((_buf) != NULL && (_idx) < (int)(_max)) { \
+		Z_CBPRINTF_STORE_ARG(&(_buf)[(_idx)], _arg); \
 	} \
-	_idx += _arg_size; \
-	_align_offset += _arg_size; \
+	(_idx) += (_arg_size); \
+	(_align_offset) += (_arg_size); \
 } while (false)
 
 /** @brief Package single argument.
@@ -342,27 +342,27 @@ do { \
 	_Pragma("GCC diagnostic push") \
 	_Pragma("GCC diagnostic ignored \"-Wpointer-arith\"") \
 	Z_CBPRINTF_SUPPRESS_SIZEOF_ARRAY_DECAY \
-	BUILD_ASSERT(!IS_ENABLED(CONFIG_XTENSA) || \
-		     (IS_ENABLED(CONFIG_XTENSA) && \
-		      !(_align_offset % CBPRINTF_PACKAGE_ALIGNMENT)), \
+	BUILD_ASSERT(!(IS_ENABLED(CONFIG_XTENSA)) || \
+		     ((IS_ENABLED(CONFIG_XTENSA)) && \
+		      ((_align_offset) % CBPRINTF_PACKAGE_ALIGNMENT) == 0U), \
 			"Xtensa requires aligned package."); \
-	BUILD_ASSERT((_align_offset % sizeof(int)) == 0, \
+	BUILD_ASSERT(((_align_offset) % sizeof(int)) == 0, \
 			"Alignment offset must be multiply of a word."); \
 	IF_ENABLED(CONFIG_CBPRINTF_STATIC_PACKAGE_CHECK_ALIGNMENT, \
 		(__ASSERT(!((uintptr_t)buf & (CBPRINTF_PACKAGE_ALIGNMENT - 1)), \
 			  "Buffer must be aligned.");)) \
-	bool str_idxs = _flags & CBPRINTF_PACKAGE_ADD_STRING_IDXS; \
-	uint8_t *_pbuf = buf; \
+	bool str_idxs = (_flags) & CBPRINTF_PACKAGE_ADD_STRING_IDXS; \
+	uint8_t *_pbuf = (buf); \
 	uint8_t _s_cnt = 0; \
 	uint16_t _s_buffer[16]; \
-	size_t _pmax = (buf != NULL) ? _inlen : INT32_MAX; \
+	size_t _pmax = ((buf) != NULL) ? (_inlen) : INT32_MAX; \
 	int _pkg_len = 0; \
 	int _total_len = 0; \
-	int _pkg_offset = _align_offset; \
+	int _pkg_offset = (_align_offset); \
 	union z_cbprintf_hdr *_len_loc; \
 	/* package starts with string address and field with length */ \
 	if (_pmax < sizeof(union z_cbprintf_hdr)) { \
-		_outlen = -ENOSPC; \
+		(_outlen) = -ENOSPC; \
 		break; \
 	} \
 	_len_loc = (union z_cbprintf_hdr *)_pbuf; \
@@ -380,7 +380,7 @@ do { \
 		} \
 	} \
 	/* Store length */ \
-	_outlen = (_total_len > (int)_pmax) ? -ENOSPC : _total_len; \
+	(_outlen) = (_total_len > (int)_pmax) ? -ENOSPC : _total_len; \
 	/* Store length in the header, set number of dumped strings to 0 */ \
 	if (_pbuf != NULL) { \
 		union z_cbprintf_hdr hdr = { \

--- a/include/sys/device_mmio.h
+++ b/include/sys/device_mmio.h
@@ -652,7 +652,7 @@ struct z_device_mmio_rom {
 #define DEVICE_MMIO_TOPLEVEL_MAP(name, flags) \
 	device_map(&Z_TOPLEVEL_RAM_NAME(name), \
 		   Z_TOPLEVEL_ROM_NAME(name).phys_addr, \
-		   Z_TOPLEVEL_ROM_NAME(name).size, flags)
+		   Z_TOPLEVEL_ROM_NAME(name).size, (flags))
 #else
 #define DEVICE_MMIO_TOPLEVEL_MAP(name, flags) do { } while (false)
 #endif

--- a/include/sys/dlist.h
+++ b/include/sys/dlist.h
@@ -111,10 +111,10 @@ typedef struct _dnode sys_dnode_t;
  * @param __dns A sys_dnode_t pointer for the loop to run safely
  */
 #define SYS_DLIST_FOR_EACH_NODE_SAFE(__dl, __dn, __dns)			\
-	for (__dn = sys_dlist_peek_head(__dl),				\
-		     __dns = sys_dlist_peek_next(__dl, __dn);		\
-	     __dn != NULL; __dn = __dns,				\
-		     __dns = sys_dlist_peek_next(__dl, __dn))
+	for ((__dn) = sys_dlist_peek_head(__dl),				\
+		     (__dns) = sys_dlist_peek_next((__dl), (__dn));		\
+	     (__dn) != NULL; (__dn) = (__dns),				\
+		     (__dns) = sys_dlist_peek_next(__dl, __dn))
 
 /*
  * @brief Provide the primitive to resolve the container of a list node
@@ -125,7 +125,7 @@ typedef struct _dnode sys_dnode_t;
  * @param __n The field name of sys_dnode_t within the container struct
  */
 #define SYS_DLIST_CONTAINER(__dn, __cn, __n) \
-	((__dn != NULL) ? CONTAINER_OF(__dn, __typeof__(*__cn), __n) : NULL)
+	(((__dn) != NULL) ? CONTAINER_OF(__dn, __typeof__(*(__cn)), __n) : NULL)
 /*
  * @brief Provide the primitive to peek container of the list head
  *
@@ -144,8 +144,8 @@ typedef struct _dnode sys_dnode_t;
  * @param __n The field name of sys_dnode_t within the container struct
  */
 #define SYS_DLIST_PEEK_NEXT_CONTAINER(__dl, __cn, __n) \
-	((__cn != NULL) ? \
-	 SYS_DLIST_CONTAINER(sys_dlist_peek_next(__dl, &(__cn->__n)),	\
+	(((__cn) != NULL) ? \
+	 SYS_DLIST_CONTAINER(sys_dlist_peek_next((__dl), &((__cn)->__n)),	\
 				      __cn, __n) : NULL)
 
 /**
@@ -163,9 +163,9 @@ typedef struct _dnode sys_dnode_t;
  * @param __n The field name of sys_dnode_t within the container struct
  */
 #define SYS_DLIST_FOR_EACH_CONTAINER(__dl, __cn, __n)			\
-	for (__cn = SYS_DLIST_PEEK_HEAD_CONTAINER(__dl, __cn, __n);     \
-	     __cn != NULL;                                              \
-	     __cn = SYS_DLIST_PEEK_NEXT_CONTAINER(__dl, __cn, __n))
+	for ((__cn) = SYS_DLIST_PEEK_HEAD_CONTAINER(__dl, __cn, __n);     \
+	     (__cn) != NULL;                                              \
+	     (__cn) = SYS_DLIST_PEEK_NEXT_CONTAINER(__dl, __cn, __n))
 
 /**
  * @brief Provide the primitive to safely iterate on a list under a container
@@ -183,10 +183,10 @@ typedef struct _dnode sys_dnode_t;
  * @param __n The field name of sys_dnode_t within the container struct
  */
 #define SYS_DLIST_FOR_EACH_CONTAINER_SAFE(__dl, __cn, __cns, __n)	\
-	for (__cn = SYS_DLIST_PEEK_HEAD_CONTAINER(__dl, __cn, __n),	\
-	     __cns = SYS_DLIST_PEEK_NEXT_CONTAINER(__dl, __cn, __n);    \
-	     __cn != NULL; __cn = __cns,				\
-	     __cns = SYS_DLIST_PEEK_NEXT_CONTAINER(__dl, __cn, __n))
+	for ((__cn) = SYS_DLIST_PEEK_HEAD_CONTAINER(__dl, __cn, __n),	\
+	     (__cns) = SYS_DLIST_PEEK_NEXT_CONTAINER(__dl, __cn, __n);    \
+	     (__cn) != NULL; (__cn) = (__cns),				\
+	     (__cns) = SYS_DLIST_PEEK_NEXT_CONTAINER(__dl, __cn, __n))
 
 /**
  * @brief initialize list to its empty state

--- a/include/sys/list_gen.h
+++ b/include/sys/list_gen.h
@@ -12,21 +12,21 @@
 #include <sys/util.h>
 
 #define Z_GENLIST_FOR_EACH_NODE(__lname, __l, __sn)			\
-	for (__sn = sys_ ## __lname ## _peek_head(__l); __sn != NULL;	\
-	     __sn = sys_ ## __lname ## _peek_next(__sn))
+	for ((__sn) = sys_ ## __lname ## _peek_head(__l); (__sn) != NULL;	\
+	     (__sn) = sys_ ## __lname ## _peek_next(__sn))
 
 
 #define Z_GENLIST_ITERATE_FROM_NODE(__lname, __l, __sn)			\
-	for (__sn = __sn ? sys_ ## __lname ## _peek_next_no_check(__sn)	\
+	for ((__sn) = (__sn) ? sys_ ## __lname ## _peek_next_no_check(__sn)	\
 			 : sys_ ## __lname ## _peek_head(__l);		\
-	     __sn != NULL;						\
-	     __sn = sys_ ## __lname ## _peek_next(__sn))
+	     (__sn) != NULL;						\
+	     (__sn) = sys_ ## __lname ## _peek_next(__sn))
 
 #define Z_GENLIST_FOR_EACH_NODE_SAFE(__lname, __l, __sn, __sns)		\
-	for (__sn = sys_ ## __lname ## _peek_head(__l),			\
-		     __sns = sys_ ## __lname ## _peek_next(__sn);	\
-	     __sn != NULL ; __sn = __sns,				\
-		     __sns = sys_ ## __lname ## _peek_next(__sn))
+	for ((__sn) = sys_ ## __lname ## _peek_head(__l),			\
+		     (__sns) = sys_ ## __lname ## _peek_next(__sn);	\
+	     (__sn) != NULL ; (__sn) = (__sns),				\
+		     (__sns) = sys_ ## __lname ## _peek_next(__sn))
 
 #define Z_GENLIST_CONTAINER(__ln, __cn, __n)				\
 	((__ln) ? CONTAINER_OF((__ln), __typeof__(*(__cn)), __n) : NULL)
@@ -43,16 +43,16 @@
 			__cn, __n) : NULL)
 
 #define Z_GENLIST_FOR_EACH_CONTAINER(__lname, __l, __cn, __n)		\
-	for (__cn = Z_GENLIST_PEEK_HEAD_CONTAINER(__lname, __l, __cn,	\
+	for ((__cn) = Z_GENLIST_PEEK_HEAD_CONTAINER(__lname, __l, __cn,	\
 						  __n);			\
-	     __cn != NULL;						\
-	     __cn = Z_GENLIST_PEEK_NEXT_CONTAINER(__lname, __cn, __n))
+	     (__cn) != NULL;						\
+	     (__cn) = Z_GENLIST_PEEK_NEXT_CONTAINER(__lname, __cn, __n))
 
 #define Z_GENLIST_FOR_EACH_CONTAINER_SAFE(__lname, __l, __cn, __cns, __n)     \
-	for (__cn = Z_GENLIST_PEEK_HEAD_CONTAINER(__lname, __l, __cn, __n),   \
-	     __cns = Z_GENLIST_PEEK_NEXT_CONTAINER(__lname, __cn, __n); \
-	     __cn != NULL; __cn = __cns,				\
-	     __cns = Z_GENLIST_PEEK_NEXT_CONTAINER(__lname, __cn, __n))
+	for ((__cn) = Z_GENLIST_PEEK_HEAD_CONTAINER(__lname, __l, __cn, __n),   \
+	     (__cns) = Z_GENLIST_PEEK_NEXT_CONTAINER(__lname, __cn, __n); \
+	     (__cn) != NULL; (__cn) = (__cns),				\
+	     (__cns) = Z_GENLIST_PEEK_NEXT_CONTAINER(__lname, __cn, __n))
 
 #define Z_GENLIST_IS_EMPTY(__lname)					\
 	static inline bool						\

--- a/include/sys/onoff.h
+++ b/include/sys/onoff.h
@@ -188,14 +188,14 @@ struct onoff_manager {
  * to an off state. Can be null.
  */
 #define ONOFF_TRANSITIONS_INITIALIZER(_start, _stop, _reset) { \
-		.start = _start,			       \
-		.stop = _stop,				       \
-		.reset = _reset,			       \
+		.start = (_start),			       \
+		.stop = (_stop),				       \
+		.reset = (_reset),			       \
 }
 
 /** @internal */
 #define ONOFF_MANAGER_INITIALIZER(_transitions) { \
-		.transitions = _transitions,	  \
+		.transitions = (_transitions),	  \
 }
 
 /**

--- a/include/sys/rb.h
+++ b/include/sys/rb.h
@@ -198,7 +198,7 @@ struct rbnode *z_rb_foreach_next(struct rbtree *tree, struct _rb_foreach *f);
  */
 #define RB_FOR_EACH(tree, node) \
 	for (struct _rb_foreach __f = _RB_FOREACH_INIT(tree, node);	\
-	     (node = z_rb_foreach_next(tree, &__f));			\
+	     ((node) = z_rb_foreach_next((tree), &__f));			\
 	     /**/)
 
 /**
@@ -213,8 +213,8 @@ struct rbnode *z_rb_foreach_next(struct rbtree *tree, struct _rb_foreach *f);
  */
 #define RB_FOR_EACH_CONTAINER(tree, node, field)		           \
 	for (struct _rb_foreach __f = _RB_FOREACH_INIT(tree, node);	   \
-			({struct rbnode *n = z_rb_foreach_next(tree, &__f); \
-			 node = n ? CONTAINER_OF(n, __typeof__(*(node)),   \
+			({struct rbnode *n = z_rb_foreach_next((tree), &__f); \
+			 (node) = (n != NULL) ? CONTAINER_OF(n, __typeof__(*(node)),   \
 					 field) : NULL; }) != NULL;        \
 			 /**/)
 

--- a/include/sys/time_units.h
+++ b/include/sys/time_units.h
@@ -202,7 +202,7 @@ static TIME_CONSTEXPR ALWAYS_INLINE uint64_t z_tmcvt(uint64_t t, uint32_t from_h
 #define Z_HZ_ns 1000000000
 #define Z_HZ_cyc sys_clock_hw_cycles_per_sec()
 #define Z_HZ_ticks CONFIG_SYS_CLOCK_TICKS_PER_SEC
-#define Z_CCYC (!IS_ENABLED(CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME))
+#define Z_CCYC (!(IS_ENABLED(CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME)))
 
 /** @brief Convert milliseconds to hardware cycles
  *

--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -335,7 +335,7 @@ uint8_t u8_to_dec(char *buf, uint8_t buflen, uint8_t value);
 /* This is used in linker scripts so need to avoid type casting there */
 #define KB(x) ((x) << 10)
 #else
-#define KB(x) (((size_t)x) << 10)
+#define KB(x) (((size_t)(x)) << 10)
 #endif
 /** @brief Number of bytes in @p x mebibytes */
 #define MB(x) (KB(x) << 10)

--- a/include/syscall_handler.h
+++ b/include/syscall_handler.h
@@ -346,11 +346,11 @@ extern int z_user_string_copy(char *dst, const char *src, size_t maxlen);
  * @return 0 on success, nonzero on failure
  */
 #define Z_SYSCALL_MEMORY(ptr, size, write) \
-	Z_SYSCALL_VERIFY_MSG(arch_buffer_validate((void *)ptr, size, write) \
+	Z_SYSCALL_VERIFY_MSG(arch_buffer_validate((void *)(ptr), (size), (write)) \
 			     == 0, \
 			     "Memory region %p (size %zu) %s access denied", \
 			     (void *)(ptr), (size_t)(size), \
-			     write ? "write" : "read")
+			     (write) ? "write" : "read")
 
 /**
  * @brief Runtime check that a user thread has read permission to a memory area
@@ -447,9 +447,9 @@ static inline int z_obj_validation_check(struct z_object *ko,
 
 #define Z_SYSCALL_IS_OBJ(ptr, type, init) \
 	Z_SYSCALL_VERIFY_MSG(z_obj_validation_check(			\
-				     z_object_find((const void *)ptr),	\
-				     (const void *)ptr,			\
-				     type, init) == 0, "access denied")
+				     z_object_find((const void *)(ptr)),	\
+				     (const void *)(ptr),			\
+				     (type), (init)) == 0, "access denied")
 
 /**
  * @brief Runtime check driver object pointer for presence of operation
@@ -464,7 +464,7 @@ static inline int z_obj_validation_check(struct z_object *ko,
 #define Z_SYSCALL_DRIVER_OP(ptr, api_name, op) \
 	({ \
 		struct api_name *__device__ = (struct api_name *) \
-			((const struct device *)ptr)->api; \
+			((const struct device *)(ptr))->api; \
 		Z_SYSCALL_VERIFY_MSG(__device__->op != NULL, \
 				    "Operation %s not defined for driver " \
 				    "instance %p", \

--- a/include/toolchain/common.h
+++ b/include/toolchain/common.h
@@ -231,9 +231,12 @@
  * ITERABLE_SECTION_ROM() or ITERABLE_SECTION_RAM() in the linker script.
  */
 #define STRUCT_SECTION_FOREACH(struct_type, iterator) \
+	STRUCT_SECTION_FOREACH_(struct_type, iterator, (iterator))
+
+#define STRUCT_SECTION_FOREACH_(struct_type, iterator_name, iterator) \
 	extern struct struct_type _CONCAT(_##struct_type, _list_start)[]; \
 	extern struct struct_type _CONCAT(_##struct_type, _list_end)[]; \
-	for (struct struct_type *iterator = \
+	for (struct struct_type *iterator_name = \
 			_CONCAT(_##struct_type, _list_start); \
 	     ({ __ASSERT(iterator <= _CONCAT(_##struct_type, _list_end), \
 			 "unexpected list end location"); \

--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -58,7 +58,7 @@
  */
 #elif (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)) || \
 	(__STDC_VERSION__) >= 201100
-#define BUILD_ASSERT(EXPR, MSG...) _Static_assert(EXPR, "" MSG)
+#define BUILD_ASSERT(EXPR, MSG...) _Static_assert((EXPR), "" MSG)
 #else
 #define BUILD_ASSERT(EXPR, MSG...)
 #endif

--- a/kernel/banner.c
+++ b/kernel/banner.c
@@ -27,7 +27,7 @@ void boot_banner(void)
 	static const unsigned int boot_delay;
 #endif
 
-	if (boot_delay > 0 && IS_ENABLED(CONFIG_MULTITHREADING)) {
+	if (boot_delay > 0 && (IS_ENABLED(CONFIG_MULTITHREADING))) {
 		printk("***** delaying boot " STRINGIFY(
 			CONFIG_BOOT_DELAY) "ms (per build configuration) *****\n");
 		k_busy_wait(CONFIG_BOOT_DELAY * USEC_PER_MSEC);

--- a/kernel/fatal.c
+++ b/kernel/fatal.c
@@ -98,7 +98,7 @@ void z_fatal_error(unsigned int reason, const z_arch_esf_t *esf)
 	 * appropriate.
 	 */
 	unsigned int key = arch_irq_lock();
-	struct k_thread *thread = IS_ENABLED(CONFIG_MULTITHREADING) ?
+	struct k_thread *thread = (IS_ENABLED(CONFIG_MULTITHREADING)) ?
 			k_current_get() : NULL;
 
 	/* twister looks for the "ZEPHYR FATAL ERROR" string, don't
@@ -139,7 +139,7 @@ void z_fatal_error(unsigned int reason, const z_arch_esf_t *esf)
 	 * Note that k_thread_abort() returns on some architectures but
 	 * not others; e.g. on ARC, x86_64, Xtensa with ASM2, ARM
 	 */
-	if (!IS_ENABLED(CONFIG_TEST)) {
+	if (!(IS_ENABLED(CONFIG_TEST))) {
 		__ASSERT(reason != K_ERR_KERNEL_PANIC,
 			 "Attempted to recover from a kernel panic condition");
 		/* FIXME: #17656 */

--- a/kernel/idle.c
+++ b/kernel/idle.c
@@ -78,8 +78,8 @@ void idle(void *unused1, void *unused2, void *unused3)
 		 * a fallback configuration for new platform
 		 * bringup.
 		 */
-		if (IS_ENABLED(CONFIG_SMP) &&
-		    !IS_ENABLED(CONFIG_SCHED_IPI_SUPPORTED)) {
+		if ((IS_ENABLED(CONFIG_SMP)) &&
+		    !(IS_ENABLED(CONFIG_SCHED_IPI_SUPPORTED))) {
 			k_busy_wait(100);
 			k_yield();
 			continue;

--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -221,8 +221,8 @@ void z_mem_manage_boot_finish(void);
 
 #define LOCKED(lck) for (k_spinlock_key_t __i = {},			\
 					  __key = k_spin_lock(lck);	\
-			!__i.key;					\
-			k_spin_unlock(lck, __key), __i.key = 1)
+			__i.key == 0;					\
+			k_spin_unlock((lck), __key), __i.key = 1)
 
 #ifdef CONFIG_PM
 

--- a/kernel/include/mmu.h
+++ b/kernel/include/mmu.h
@@ -47,8 +47,8 @@
  * been remapped or paged out. Never use this unless you know exactly what you
  * are doing.
  */
-#define Z_BOOT_VIRT_TO_PHYS(virt) ((uintptr_t)(((uint8_t *)virt) - Z_VM_OFFSET))
-#define Z_BOOT_PHYS_TO_VIRT(phys) ((uint8_t *)(((uintptr_t)phys) + Z_VM_OFFSET))
+#define Z_BOOT_VIRT_TO_PHYS(virt) ((uintptr_t)(((uint8_t *)(virt)) - Z_VM_OFFSET))
+#define Z_BOOT_PHYS_TO_VIRT(phys) ((uint8_t *)(((uintptr_t)(phys)) + Z_VM_OFFSET))
 
 #ifdef CONFIG_ARCH_MAPS_ALL_RAM
 #define Z_FREE_VM_START	Z_BOOT_PHYS_TO_VIRT(Z_PHYS_RAM_END)
@@ -213,9 +213,9 @@ extern size_t z_free_page_count;
 
 /* Convenience macro for iterating over all page frames */
 #define Z_PAGE_FRAME_FOREACH(_phys, _pageframe) \
-	for (_phys = Z_PHYS_RAM_START, _pageframe = z_page_frames; \
-	     _phys < Z_PHYS_RAM_END; \
-	     _phys += CONFIG_MMU_PAGE_SIZE, _pageframe++)
+	for ((_phys) = Z_PHYS_RAM_START, (_pageframe) = z_page_frames; \
+	     (_phys) < Z_PHYS_RAM_END; \
+	     (_phys) += CONFIG_MMU_PAGE_SIZE, (_pageframe)++)
 
 #ifdef CONFIG_DEMAND_PAGING
 /* We reserve a virtual page as a scratch area for page-ins/outs at the end

--- a/kernel/kheap.c
+++ b/kernel/kheap.c
@@ -78,7 +78,7 @@ void *k_heap_aligned_alloc(struct k_heap *h, size_t align, size_t bytes,
 		ret = sys_heap_aligned_alloc(&h->heap, align, bytes);
 
 		now = sys_clock_tick_get();
-		if (!IS_ENABLED(CONFIG_MULTITHREADING) ||
+		if (!(IS_ENABLED(CONFIG_MULTITHREADING)) ||
 		    (ret != NULL) || ((end - now) <= 0)) {
 			break;
 		}
@@ -122,7 +122,7 @@ void k_heap_free(struct k_heap *h, void *mem)
 	sys_heap_free(&h->heap, mem);
 
 	SYS_PORT_TRACING_OBJ_FUNC(k_heap, free, h);
-	if (IS_ENABLED(CONFIG_MULTITHREADING) && z_unpend_all(&h->wait_q) != 0) {
+	if ((IS_ENABLED(CONFIG_MULTITHREADING)) && z_unpend_all(&h->wait_q) != 0) {
 		z_reschedule(&h->lock, key);
 	} else {
 		k_spin_unlock(&h->lock, key);

--- a/kernel/mem_slab.c
+++ b/kernel/mem_slab.c
@@ -119,7 +119,7 @@ int k_mem_slab_alloc(struct k_mem_slab *slab, void **mem, k_timeout_t timeout)
 
 		result = 0;
 	} else if (K_TIMEOUT_EQ(timeout, K_NO_WAIT) ||
-		   !IS_ENABLED(CONFIG_MULTITHREADING)) {
+		   !(IS_ENABLED(CONFIG_MULTITHREADING))) {
 		/* don't wait for a free block to become available */
 		*mem = NULL;
 		result = -ENOMEM;
@@ -149,7 +149,7 @@ void k_mem_slab_free(struct k_mem_slab *slab, void **mem)
 	k_spinlock_key_t key = k_spin_lock(&slab->lock);
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_mem_slab, free, slab);
-	if (slab->free_list == NULL && IS_ENABLED(CONFIG_MULTITHREADING)) {
+	if (slab->free_list == NULL && (IS_ENABLED(CONFIG_MULTITHREADING))) {
 		struct k_thread *pending_thread = z_unpend_first_thread(&slab->wait_q);
 
 		if (pending_thread != NULL) {

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -122,12 +122,12 @@ void z_page_frames_dump(void)
 }
 
 #define VIRT_FOREACH(_base, _size, _pos) \
-	for (_pos = _base; \
-	     _pos < ((uint8_t *)_base + _size); _pos += CONFIG_MMU_PAGE_SIZE)
+	for ((_pos) = (_base); \
+	     (_pos) < ((uint8_t *)(_base) + (_size)); (_pos) += CONFIG_MMU_PAGE_SIZE)
 
 #define PHYS_FOREACH(_base, _size, _pos) \
-	for (_pos = _base; \
-	     _pos < ((uintptr_t)_base + _size); _pos += CONFIG_MMU_PAGE_SIZE)
+	for ((_pos) = (_base); \
+	     (_pos) < ((uintptr_t)(_base) + (_size)); (_pos) += CONFIG_MMU_PAGE_SIZE)
 
 
 /*

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -138,7 +138,7 @@ static ALWAYS_INLINE bool should_preempt(struct k_thread *thread,
 	 * context switching.  Platforms with atomic swap can never
 	 * hit this.
 	 */
-	if (IS_ENABLED(CONFIG_SWAP_NONATOMIC)
+	if ((IS_ENABLED(CONFIG_SWAP_NONATOMIC))
 	    && z_is_thread_timeout_active(thread)) {
 		return true;
 	}
@@ -192,7 +192,7 @@ ALWAYS_INLINE void z_priq_dumb_add(sys_dlist_t *pq, struct k_thread *thread)
  */
 static inline bool should_queue_thread(struct k_thread *th)
 {
-	return !IS_ENABLED(CONFIG_SMP) || th != _current;
+	return !(IS_ENABLED(CONFIG_SMP)) || th != _current;
 }
 
 static ALWAYS_INLINE void queue_thread(void *pq,
@@ -362,7 +362,7 @@ void k_sched_time_slice_set(int32_t slice, int prio)
 	LOCKED(&sched_spinlock) {
 		_current_cpu->slice_ticks = 0;
 		slice_time = k_ms_to_ticks_ceil32(slice);
-		if (IS_ENABLED(CONFIG_TICKLESS_KERNEL) && slice > 0) {
+		if ((IS_ENABLED(CONFIG_TICKLESS_KERNEL)) && slice > 0) {
 			/* It's not possible to reliably set a 1-tick
 			 * timeout if ticks aren't regular.
 			 */
@@ -762,7 +762,7 @@ bool z_set_prio(struct k_thread *thread, int prio)
 
 		if (need_sched) {
 			/* Don't requeue on SMP if it's the running thread */
-			if (!IS_ENABLED(CONFIG_SMP) || z_is_thread_queued(thread)) {
+			if (!(IS_ENABLED(CONFIG_SMP)) || z_is_thread_queued(thread)) {
 				dequeue_thread(&_kernel.ready_q.runq, thread);
 				thread->base.prio = prio;
 				queue_thread(&_kernel.ready_q.runq, thread);
@@ -892,7 +892,7 @@ void *z_get_next_switch_handle(void *interrupted)
 	LOCKED(&sched_spinlock) {
 		struct k_thread *old_thread = _current, *new_thread;
 
-		if (IS_ENABLED(CONFIG_SMP)) {
+		if ((IS_ENABLED(CONFIG_SMP))) {
 			old_thread->switch_handle = NULL;
 		}
 		new_thread = next_up();
@@ -930,7 +930,7 @@ void *z_get_next_switch_handle(void *interrupted)
 		}
 		old_thread->switch_handle = interrupted;
 		ret = new_thread->switch_handle;
-		if (IS_ENABLED(CONFIG_SMP)) {
+		if ((IS_ENABLED(CONFIG_SMP))) {
 			/* Active threads MUST have a null here */
 			new_thread->switch_handle = NULL;
 		}
@@ -1188,7 +1188,7 @@ void z_impl_k_yield(void)
 
 	k_spinlock_key_t key = k_spin_lock(&sched_spinlock);
 
-	if (!IS_ENABLED(CONFIG_SMP) ||
+	if (!(IS_ENABLED(CONFIG_SMP)) ||
 	    z_is_thread_queued(_current)) {
 		dequeue_thread(&_kernel.ready_q.runq,
 			       _current);

--- a/kernel/system_work_q.c
+++ b/kernel/system_work_q.c
@@ -24,7 +24,7 @@ static int k_sys_work_q_init(const struct device *dev)
 	ARG_UNUSED(dev);
 	struct k_work_queue_config cfg = {
 		.name = "sysworkq",
-		.no_yield = IS_ENABLED(CONFIG_SYSTEM_WORKQUEUE_NO_YIELD),
+		.no_yield = (IS_ENABLED(CONFIG_SYSTEM_WORKQUEUE_NO_YIELD)),
 	};
 
 	k_work_queue_start(&k_sys_work_q,

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -18,7 +18,7 @@ static sys_dlist_t timeout_list = SYS_DLIST_STATIC_INIT(&timeout_list);
 
 static struct k_spinlock timeout_lock;
 
-#define MAX_WAIT (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) \
+#define MAX_WAIT ((IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE)) \
 		  ? K_TICKS_FOREVER : INT_MAX)
 
 /* Cycles left to process in the currently-executing sys_clock_announce() */
@@ -96,7 +96,7 @@ void z_add_timeout(struct _timeout *to, _timeout_func_t fn,
 	LOCKED(&timeout_lock) {
 		struct _timeout *t;
 
-		if (IS_ENABLED(CONFIG_TIMEOUT_64BIT) &&
+		if ((IS_ENABLED(CONFIG_TIMEOUT_64BIT)) &&
 		    Z_TICK_ABS(timeout.ticks) >= 0) {
 			k_ticks_t ticks = Z_TICK_ABS(timeout.ticks) - curr_tick;
 
@@ -224,7 +224,7 @@ void z_set_timeout_expiry(int32_t ticks, bool is_idle)
 		 * exit and so can't get the timeslicing clamp folded
 		 * in.
 		 */
-		if (!imminent && (sooner || IS_ENABLED(CONFIG_SMP))) {
+		if (!imminent && (sooner || (IS_ENABLED(CONFIG_SMP)))) {
 			sys_clock_set_timeout(MIN(ticks, next_to), is_idle);
 		}
 	}
@@ -355,7 +355,7 @@ uint64_t sys_clock_timeout_end_calc(k_timeout_t timeout)
 
 		dt = timeout.ticks;
 
-		if (IS_ENABLED(CONFIG_TIMEOUT_64BIT) && Z_TICK_ABS(dt) >= 0) {
+		if ((IS_ENABLED(CONFIG_TIMEOUT_64BIT)) && Z_TICK_ABS(dt) >= 0) {
 			return Z_TICK_ABS(dt);
 		}
 		return sys_clock_tick_get() + MAX(1, dt);

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -46,7 +46,7 @@ void z_timer_expiration_handler(struct _timeout *t)
 		timer->expiry_fn(timer);
 	}
 
-	if (!IS_ENABLED(CONFIG_MULTITHREADING)) {
+	if (!(IS_ENABLED(CONFIG_MULTITHREADING))) {
 		k_spin_unlock(&lock, key);
 		return;
 	}
@@ -76,7 +76,7 @@ void k_timer_init(struct k_timer *timer,
 	timer->stop_fn = stop_fn;
 	timer->status = 0U;
 
-	if (IS_ENABLED(CONFIG_MULTITHREADING)) {
+	if ((IS_ENABLED(CONFIG_MULTITHREADING))) {
 		z_waitq_init(&timer->wait_q);
 	}
 
@@ -153,7 +153,7 @@ void z_impl_k_timer_stop(struct k_timer *timer)
 		timer->stop_fn(timer);
 	}
 
-	if (IS_ENABLED(CONFIG_MULTITHREADING)) {
+	if ((IS_ENABLED(CONFIG_MULTITHREADING))) {
 		struct k_thread *pending_thread = z_unpend1_no_timeout(&timer->wait_q);
 
 		if (pending_thread != NULL) {
@@ -197,7 +197,7 @@ uint32_t z_impl_k_timer_status_sync(struct k_timer *timer)
 	__ASSERT(!arch_is_in_isr(), "");
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_timer, status_sync, timer);
 
-	if (!IS_ENABLED(CONFIG_MULTITHREADING)) {
+	if (!(IS_ENABLED(CONFIG_MULTITHREADING))) {
 		uint32_t result;
 
 		do {

--- a/lib/libc/minimal/source/stdout/fprintf.c
+++ b/lib/libc/minimal/source/stdout/fprintf.c
@@ -10,7 +10,7 @@
 #include <stdio.h>
 #include <sys/cbprintf.h>
 
-#define DESC(d) ((void *)d)
+#define DESC(d) ((void *)(d))
 
 int fprintf(FILE *_MLIBC_RESTRICT stream, const char *_MLIBC_RESTRICT format, ...)
 {

--- a/lib/os/bitarray.c
+++ b/lib/os/bitarray.c
@@ -13,7 +13,7 @@
 #include <sys/sys_io.h>
 
 /* Number of bits represented by one bundle */
-#define bundle_bitness(ba)	(sizeof(ba->bundles[0]) * 8)
+#define bundle_bitness(ba)	(sizeof((ba)->bundles[0]) * 8)
 
 struct bundle_data {
 	 /* Start and end index of bundles */

--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -534,7 +534,7 @@ int_conv:
 		 */
 		if (conv->specifier == 'c') {
 			unsupported = (conv->length_mod != LENGTH_NONE);
-		} else if (!IS_ENABLED(CONFIG_CBPRINTF_FULL_INTEGRAL)) {
+		} else if (!(IS_ENABLED(CONFIG_CBPRINTF_FULL_INTEGRAL))) {
 			/* Disable conversion that might produce truncated
 			 * results with buffers sized for 32 bits.
 			 */
@@ -570,7 +570,7 @@ int_conv:
 		conv->specifier_cat = SPECIFIER_FP;
 
 		/* Don't support if disabled */
-		if (!IS_ENABLED(CONFIG_CBPRINTF_FP_SUPPORT)) {
+		if (!(IS_ENABLED(CONFIG_CBPRINTF_FP_SUPPORT))) {
 			unsupported = true;
 			break;
 		}
@@ -579,7 +579,7 @@ int_conv:
 		conv->specifier_a = (conv->specifier == 'a')
 			|| (conv->specifier == 'A');
 		if (conv->specifier_a
-		    && !IS_ENABLED(CONFIG_CBPRINTF_FP_A_SUPPORT)) {
+		    && !(IS_ENABLED(CONFIG_CBPRINTF_FP_A_SUPPORT))) {
 			unsupported = true;
 			break;
 		}
@@ -939,8 +939,8 @@ static char *encode_float(double value,
 	}
 
 	/* Handle converting to the hex representation. */
-	if (IS_ENABLED(CONFIG_CBPRINTF_FP_A_SUPPORT)
-	    && (IS_ENABLED(CONFIG_CBPRINTF_FP_ALWAYS_A)
+	if ((IS_ENABLED(CONFIG_CBPRINTF_FP_A_SUPPORT))
+	    && ((IS_ENABLED(CONFIG_CBPRINTF_FP_ALWAYS_A))
 		|| conv->specifier_a)) {
 		*buf++ = '0';
 		*buf++ = 'x';
@@ -1360,7 +1360,7 @@ int cbvprintf(cbprintf_cb out, void *ctx, const char *fp, va_list ap)
  */
 
 #define OUTS(_sp, _ep) do { \
-	int rc = outs(out, ctx, _sp, _ep); \
+	int rc = outs(out, ctx, (_sp), (_ep)); \
 	\
 	if (rc < 0) {	    \
 		return rc; \
@@ -1437,7 +1437,7 @@ int cbvprintf(cbprintf_cb out, void *ctx, const char *fp, va_list ap)
 		conv->pad0_pre_exp = 0;
 
 		/* FP conversion requires knowing the precision. */
-		if (IS_ENABLED(CONFIG_CBPRINTF_FP_SUPPORT)
+		if ((IS_ENABLED(CONFIG_CBPRINTF_FP_SUPPORT))
 		    && (conv->specifier_cat == SPECIFIER_FP)
 		    && !conv->prec_present) {
 			if (conv->specifier_a) {
@@ -1762,7 +1762,7 @@ int cbvprintf(cbprintf_cb out, void *ctx, const char *fp, va_list ap)
 			OUTC(sign);
 		}
 
-		if (IS_ENABLED(CONFIG_CBPRINTF_FP_SUPPORT) && conv->pad_fp) {
+		if ((IS_ENABLED(CONFIG_CBPRINTF_FP_SUPPORT)) && conv->pad_fp) {
 			const char *cp = bps;
 
 			if (conv->specifier_a) {

--- a/lib/os/notify.c
+++ b/lib/os/notify.c
@@ -76,7 +76,7 @@ sys_notify_generic_callback sys_notify_finalize(struct sys_notify *notify,
 	compiler_barrier();
 	notify->flags = SYS_NOTIFY_METHOD_COMPLETED;
 
-	if (IS_ENABLED(CONFIG_POLL) && (sig != NULL)) {
+	if ((IS_ENABLED(CONFIG_POLL)) && (sig != NULL)) {
 		k_poll_signal_raise(sig, res);
 	}
 

--- a/tests/benchmarks/footprints/src/timer.c
+++ b/tests/benchmarks/footprints/src/timer.c
@@ -97,7 +97,7 @@ void run_timer(void)
 
 	k_mem_domain_add_thread(&footprint_mem_domain, tid);
 
-	k_thread_access_grant(tid, &timer0);
+	k_thread_access_grant(tid, (&timer0));
 	k_thread_start(tid);
 
 	k_thread_join(tid, K_FOREVER);

--- a/tests/benchmarks/footprints/src/userspace.c
+++ b/tests/benchmarks/footprints/src/userspace.c
@@ -106,7 +106,7 @@ void validation_overhead_user_thread(void *p1, void *p2, void *p3)
 
 void validation_overhead(void)
 {
-	k_thread_access_grant(k_current_get(), &test_sema);
+	k_thread_access_grant(k_current_get(), (&test_sema));
 
 	k_thread_create(&my_thread_user, my_stack_area, STACK_SIZE,
 			validation_overhead_user_thread,

--- a/tests/benchmarks/footprints/src/workq.c
+++ b/tests/benchmarks/footprints/src/workq.c
@@ -116,15 +116,15 @@ void run_workq(void)
 	 * to it.
 	 */
 	k_mem_domain_add_thread(&footprint_mem_domain, &user_workq.thread);
-	k_thread_access_grant(&user_workq.thread, &sync_sema);
+	k_thread_access_grant(&user_workq.thread, (&sync_sema));
 
 	tid = k_thread_create(&my_thread, my_stack_area, STACK_SIZE,
 			      simple_user_workq_thread, NULL, NULL, NULL,
 			      0, K_USER, K_FOREVER);
 
-	k_thread_access_grant(tid, &sync_sema,
-			      &user_workq.thread, &user_workq.queue,
-			      &user_workq_stack);
+	k_thread_access_grant(tid, (&sync_sema),
+			      (&user_workq.thread), (&user_workq.queue),
+			      (&user_workq_stack));
 
 	k_mem_domain_add_thread(&footprint_mem_domain, tid);
 


### PR DESCRIPTION
MISRA C:2012 Rule 20.7 (Expressions resulting from the expansion of
macro parameters shall be enclosed in parentheses.)

Where possible, change, e.g.,

`#define EXAMPLE1(h, k) (h + k)`
 
to

`#define EXAMPLE1(h, k) ((h) + (k))`

Where this is not possible and we have a macro we cannot change, e.g.,

`#define EXAMPLE2(h, k) (h * k)`

change, e.g.,

`EXAMPLE2(x - y, a - b)`

to

`EXAMPLE2((x - y), (a - b))`

Signed-off-by: Abramo Bagnara <abramo.bagnara@bugseng.com>