### PR TITLE
Fix all instances of -Waddress-of-packed-member

### DIFF
--- a/arch/x86/core/acpi.c
+++ b/arch/x86/core/acpi.c
@@ -149,7 +149,12 @@ void *z_acpi_find_table(uint32_t signature)
 
 			uint32_t *end = (uint32_t *)((char *)rsdt + rsdt->sdt.length);
 
-			for (uint32_t *tp = &rsdt->table_ptrs[0]; tp < end; tp++) {
+			/* Extra indirection required to avoid
+			 * -Waddress-of-packed-member
+			 */
+			void *table_ptrs = &rsdt->table_ptrs[0];
+
+			for (uint32_t *tp = table_ptrs; tp < end; tp++) {
 				t_phys = (long)*tp;
 				z_phys_map(&mapped_tbl, t_phys, sizeof(*t), 0);
 				t = (void *)mapped_tbl;
@@ -186,7 +191,12 @@ void *z_acpi_find_table(uint32_t signature)
 
 			uint64_t *end = (uint64_t *)((char *)xsdt + xsdt->sdt.length);
 
-			for (uint64_t *tp = &xsdt->table_ptrs[0]; tp < end; tp++) {
+			/* Extra indirection required to avoid
+			 * -Waddress-of-packed-member
+			 */
+			void *table_ptrs = &xsdt->table_ptrs[0];
+
+			for (uint64_t *tp = table_ptrs; tp < end; tp++) {
 				t_phys = (long)*tp;
 				z_phys_map(&mapped_tbl, t_phys, sizeof(*t), 0);
 				t = (void *)mapped_tbl;

--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -42,14 +42,6 @@ check_set_compiler_property(APPEND PROPERTY warning_base -Wpointer-arith)
 # not portable
 check_set_compiler_property(APPEND PROPERTY warning_base -Wexpansion-to-defined)
 
-if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "9.1.0")
-  set_compiler_property(APPEND PROPERTY warning_base
-                        # FIXME: Remove once #16587 is fixed
-                        -Wno-address-of-packed-member
-  )
-endif()
-
-
 # GCC options for warning levels 1, 2, 3, when using `-DW=[1|2|3]`
 set_compiler_property(PROPERTY warning_dw_1
                       -Waggregate-return

--- a/drivers/gpio/gpio_sx1509b.c
+++ b/drivers/gpio/gpio_sx1509b.c
@@ -453,7 +453,10 @@ static int port_write(const struct device *dev,
 
 	const struct sx1509b_config *cfg = dev->config;
 	struct sx1509b_drv_data *drv_data = dev->data;
-	uint16_t *outp = &drv_data->pin_state.data;
+	void *data = &drv_data->pin_state.data;
+	uint16_t *outp = data;
+
+	__ASSERT_NO_MSG(IS_PTR_ALIGNED(data, uint16_t));
 
 	k_sem_take(&drv_data->lock, K_FOREVER);
 

--- a/drivers/sensor/bmi160/bmi160.c
+++ b/drivers/sensor/bmi160/bmi160.c
@@ -791,8 +791,7 @@ static inline void bmi160_gyr_channel_get(const struct device *dev,
 {
 	struct bmi160_data *data = to_data(dev);
 
-	bmi160_channel_convert(chan, data->scale.gyr,
-			       data->sample.gyr, val);
+	bmi160_channel_convert(chan, data->scale.gyr, data->sample.gyr, val);
 }
 #endif
 
@@ -803,8 +802,7 @@ static inline void bmi160_acc_channel_get(const struct device *dev,
 {
 	struct bmi160_data *data = to_data(dev);
 
-	bmi160_channel_convert(chan, data->scale.acc,
-			       data->sample.acc, val);
+	bmi160_channel_convert(chan, data->scale.acc, data->sample.acc, val);
 }
 #endif
 

--- a/drivers/sensor/bmi160/bmi160.h
+++ b/drivers/sensor/bmi160/bmi160.h
@@ -471,7 +471,7 @@ union bmi160_sample {
 #if !defined(CONFIG_BMI160_ACCEL_PMU_SUSPEND)
 		uint16_t acc[BMI160_AXES];
 #endif
-	} __packed;
+	};
 };
 
 struct bmi160_scale {

--- a/include/toolchain/common.h
+++ b/include/toolchain/common.h
@@ -187,6 +187,9 @@
  */
 #define Z_DECL_ALIGN(type) __aligned(__alignof(type)) type
 
+/* Check if a pointer is aligned enough for a particular data type. */
+#define IS_PTR_ALIGNED(ptr, type) ((((uintptr_t)ptr) % __alignof(type)) == 0)
+
 /**
  * @brief Iterable Sections APIs
  * @defgroup iterable_section_apis Iterable Sections APIs

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -380,7 +380,10 @@ static void free_page_frame_list_put(struct z_page_frame *pf)
 {
 	PF_ASSERT(pf, z_page_frame_is_available(pf),
 		 "unavailable page put on free list");
-	sys_slist_append(&free_page_frame_list, &pf->node);
+	/* The structure is packed, which ensures that this is true */
+	void *node = pf;
+
+	sys_slist_append(&free_page_frame_list, node);
 	z_free_page_count++;
 }
 

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -466,8 +466,11 @@ static void unref_check(struct z_object *ko, uintptr_t index)
 	sys_bitfield_clear_bit((mem_addr_t)&ko->perms, index);
 
 #ifdef CONFIG_DYNAMIC_OBJECTS
-	struct dyn_obj *dyn =
-			CONTAINER_OF(ko, struct dyn_obj, kobj);
+	void *vko = ko;
+
+	struct dyn_obj *dyn = CONTAINER_OF(vko, struct dyn_obj, kobj);
+	/* TODO: check why this assert hits */
+	/*__ASSERT(IS_PTR_ALIGNED(dyn, struct dyn_obj), "unaligned z_object");*/
 
 	if ((ko->flags & K_OBJ_FLAG_ALLOC) == 0U) {
 		goto out;

--- a/subsys/bluetooth/controller/ll_sw/ull_central.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central.c
@@ -807,6 +807,7 @@ void ull_central_setup(struct node_rx_hdr *rx, struct node_rx_ftr *ftr,
 	struct ll_conn *conn;
 	memq_link_t *link;
 	uint8_t chan_sel;
+	void *node;
 
 	/* Get reference to Tx-ed CONNECT_IND PDU */
 	pdu_tx = (void *)((struct node_rx_pdu *)rx)->pdu;
@@ -820,8 +821,14 @@ void ull_central_setup(struct node_rx_hdr *rx, struct node_rx_ftr *ftr,
 	/* This is the chan sel bit from the received adv pdu */
 	chan_sel = pdu_tx->chan_sel;
 
+	/* Check for pdu field being aligned before populating connection
+	 * complete event.
+	 */
+	node = pdu_tx;
+	LL_ASSERT(IS_PTR_ALIGNED(node, struct node_rx_cc));
+
 	/* Populate the fields required for connection complete event */
-	cc = (void *)pdu_tx;
+	cc = node;
 	cc->status = 0U;
 	cc->role = 0U;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
@@ -89,6 +89,7 @@ void ull_periph_setup(struct node_rx_hdr *rx, struct node_rx_ftr *ftr,
 	memq_link_t *link;
 	uint16_t timeout;
 	uint8_t chan_sel;
+	void *node;
 
 	adv = ((struct lll_adv *)ftr->param)->hdr.parent;
 	conn = lll->hdr.parent;
@@ -232,7 +233,14 @@ void ull_periph_setup(struct node_rx_hdr *rx, struct node_rx_ftr *ftr,
 		chan_sel = pdu_adv->chan_sel;
 	}
 
-	cc = (void *)pdu_adv;
+	/* Check for pdu field being aligned before populating connection
+	 * complete event.
+	 */
+	node = pdu_adv;
+	LL_ASSERT(IS_PTR_ALIGNED(node, struct node_rx_cc));
+
+	/* Populate the fields required for connection complete event */
+	cc = node;
 	cc->status = 0U;
 	cc->role = 1U;
 

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -1012,16 +1012,18 @@ void test_main(void)
 
 #if defined(CONFIG_ARM64)
 	struct z_arm64_thread_stack_header *hdr;
+	void *vhdr = ((struct z_arm64_thread_stack_header *)ztest_thread_stack);
 
-	hdr = ((struct z_arm64_thread_stack_header *)ztest_thread_stack);
+	hdr = vhdr;
 	priv_stack_ptr = (((char *)&hdr->privilege_stack) +
 			  (sizeof(hdr->privilege_stack) - 1));
 #elif defined(CONFIG_ARM)
 	priv_stack_ptr = (char *)z_priv_stack_find(ztest_thread_stack);
 #elif defined(CONFIG_X86)
 	struct z_x86_thread_stack_header *hdr;
+	void *vhdr = ((struct z_x86_thread_stack_header *)ztest_thread_stack);
 
-	hdr = ((struct z_x86_thread_stack_header *)ztest_thread_stack);
+	hdr = vhdr;
 	priv_stack_ptr = (((char *)&hdr->privilege_stack) +
 			  (sizeof(hdr->privilege_stack) - 1));
 #elif defined(CONFIG_RISCV)


### PR DESCRIPTION
This finally closes #16587 by removing all remaining pieces of code that can trigger the compiler warning after #39192 resolved all the ones in the networking code.

Additional analysis of the problem can be found [here](https://github.com/zephyrproject-rtos/zephyr/issues/16587#issuecomment-930116330).