### PR TITLE
drivers: gpio: set all on-chip gpios to PRE_KERNEL_1/2 init

### DIFF
--- a/drivers/gpio/gpio_andes_atcgpio100.c
+++ b/drivers/gpio/gpio_andes_atcgpio100.c
@@ -352,7 +352,7 @@ static int gpio_atcgpio100_init(const struct device *port)
 		NULL,							\
 		&gpio_atcgpio100_data_##n,				\
 		&gpio_atcgpio100_config_##n,				\
-		POST_KERNEL,						\
+		PRE_KERNEL_1,						\
 		CONFIG_GPIO_INIT_PRIORITY,				\
 		&gpio_atcgpio100_api);					\
 									\

--- a/drivers/gpio/gpio_b91.c
+++ b/drivers/gpio/gpio_b91.c
@@ -561,7 +561,7 @@ static void gpio_b91_irq_connect_4(void)
 			      NULL,					    \
 			      &gpio_b91_data_##n,			    \
 			      &gpio_b91_config_##n,			    \
-			      POST_KERNEL,				    \
+			      PRE_KERNEL_1,				    \
 			      CONFIG_GPIO_INIT_PRIORITY,		    \
 			      &gpio_b91_driver_api);
 

--- a/drivers/gpio/gpio_cc13xx_cc26xx.c
+++ b/drivers/gpio/gpio_cc13xx_cc26xx.c
@@ -283,5 +283,5 @@ static const struct gpio_driver_api gpio_cc13xx_cc26xx_driver_api = {
 DEVICE_DT_INST_DEFINE(0, gpio_cc13xx_cc26xx_init,
 		    NULL, &gpio_cc13xx_cc26xx_data_0,
 		    &gpio_cc13xx_cc26xx_cfg_0,
-		    POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
+		    PRE_KERNEL_1, CONFIG_GPIO_INIT_PRIORITY,
 		    &gpio_cc13xx_cc26xx_driver_api);

--- a/drivers/gpio/gpio_cmsdk_ahb.c
+++ b/drivers/gpio/gpio_cmsdk_ahb.c
@@ -277,7 +277,7 @@ static int gpio_cmsdk_ahb_init(const struct device *dev)
 			    NULL,						\
 			    &gpio_cmsdk_port_##n##_data,			\
 			    &gpio_cmsdk_port_## n ##_config,			\
-			    POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,		\
+			    PRE_KERNEL_1, CONFIG_GPIO_INIT_PRIORITY,	\
 			    &gpio_cmsdk_ahb_drv_api_funcs);			\
 										\
 	static void gpio_cmsdk_port_##n##_config_func(const struct device *dev)	\

--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -539,7 +539,7 @@ PM_DEVICE_DT_INST_DEFINE(0, gpio_dw_device_pm_action);
 
 DEVICE_DT_INST_DEFINE(0,
 	      gpio_dw_initialize, PM_DEVICE_DT_INST_REF(0), &gpio_0_runtime,
-	      &gpio_config_0, POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
+	      &gpio_config_0, PRE_KERNEL_1, CONFIG_GPIO_INIT_PRIORITY,
 	      &api_funcs);
 
 #if DT_INST_IRQ_HAS_CELL(0, flags)
@@ -603,7 +603,7 @@ PM_DEVICE_DT_INST_DEFINE(1, gpio_dw_device_pm_action);
 
 DEVICE_DT_INST_DEFINE(1,
 	      gpio_dw_initialize, PM_DEVICE_DT_INST_REF(1), &gpio_1_runtime,
-	      &gpio_dw_config_1, POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
+	      &gpio_dw_config_1, PRE_KERNEL_1, CONFIG_GPIO_INIT_PRIORITY,
 	      &api_funcs);
 
 #if DT_INST_IRQ_HAS_CELL(1, flags)
@@ -666,7 +666,7 @@ PM_DEVICE_DT_INST_DEFINE(2, gpio_dw_device_pm_action);
 
 DEVICE_DT_INST_DEFINE(2,
 	      gpio_dw_initialize, PM_DEVICE_DT_INST_REF(2), &gpio_2_runtime,
-	      &gpio_dw_config_2, POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
+	      &gpio_dw_config_2, PRE_KERNEL_1, CONFIG_GPIO_INIT_PRIORITY,
 	      &api_funcs);
 
 #if DT_INST_IRQ_HAS_CELL(2, flags)
@@ -729,7 +729,7 @@ PM_DEVICE_DT_INST_DEFINE(3, gpio_dw_device_pm_action);
 
 DEVICE_DT_INST_DEFINE(3,
 	      gpio_dw_initialize, PM_DEVICE_DT_INST_REF(3), &gpio_3_runtime,
-	      &gpio_dw_config_3, POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
+	      &gpio_dw_config_3, PRE_KERNEL_1, CONFIG_GPIO_INIT_PRIORITY,
 	      &api_funcs);
 
 #if DT_INST_IRQ_HAS_CELL(3, flags)

--- a/drivers/gpio/gpio_eos_s3.c
+++ b/drivers/gpio/gpio_eos_s3.c
@@ -403,6 +403,6 @@ DEVICE_DT_INST_DEFINE(0,
 		    NULL,
 		    &gpio_eos_s3_data,
 		    &gpio_eos_s3_config,
-		    POST_KERNEL,
+		    PRE_KERNEL_1,
 		    CONFIG_GPIO_INIT_PRIORITY,
 		    &gpio_eos_s3_driver_api);

--- a/drivers/gpio/gpio_imx.c
+++ b/drivers/gpio/gpio_imx.c
@@ -225,7 +225,7 @@ static const struct gpio_driver_api imx_gpio_driver_api = {
 			    NULL,					\
 			    &imx_gpio_##n##_data,			\
 			    &imx_gpio_##n##_config,			\
-			    POST_KERNEL,				\
+			    PRE_KERNEL_1,				\
 			    CONFIG_GPIO_INIT_PRIORITY,			\
 			    &imx_gpio_driver_api);			\
 									\

--- a/drivers/gpio/gpio_ite_it8xxx2.c
+++ b/drivers/gpio/gpio_ite_it8xxx2.c
@@ -596,7 +596,7 @@ DEVICE_DT_INST_DEFINE(inst,                                        \
 		NULL,                                              \
 		&gpio_ite_data_##inst,                             \
 		&gpio_ite_cfg_##inst,                              \
-		POST_KERNEL,                                       \
+		PRE_KERNEL_1,                                       \
 		CONFIG_GPIO_INIT_PRIORITY,                         \
 		&gpio_ite_driver_api);
 
@@ -624,4 +624,4 @@ static int gpio_it8xxx2_init_set(const struct device *arg)
 
 	return 0;
 }
-SYS_INIT(gpio_it8xxx2_init_set, POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY);
+SYS_INIT(gpio_it8xxx2_init_set, PRE_KERNEL_1, CONFIG_GPIO_INIT_PRIORITY);

--- a/drivers/gpio/gpio_lpc11u6x.c
+++ b/drivers/gpio/gpio_lpc11u6x.c
@@ -593,7 +593,7 @@ DEVICE_DT_DEFINE(DT_NODELABEL(gpio##id),				\
 		    NULL,						\
 		    &gpio_lpc11u6x_data_##id,				\
 		    &gpio_lpc11u6x_config_##id,				\
-		    POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,		\
+		    PRE_KERNEL_2, CONFIG_GPIO_INIT_PRIORITY,		\
 		    &gpio_lpc11u6x_driver_api)
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(gpio0), okay)

--- a/drivers/gpio/gpio_mchp_xec.c
+++ b/drivers/gpio/gpio_mchp_xec.c
@@ -355,7 +355,7 @@ DEVICE_DT_DEFINE(DT_NODELABEL(gpio_000_036),
 		    gpio_xec_port000_036_init,
 		    NULL,
 		    &gpio_xec_port000_036_data, &gpio_xec_port000_036_config,
-		    POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
+		    PRE_KERNEL_1, CONFIG_GPIO_INIT_PRIORITY,
 		    &gpio_xec_driver_api);
 
 static int gpio_xec_port000_036_init(const struct device *dev)
@@ -401,7 +401,7 @@ DEVICE_DT_DEFINE(DT_NODELABEL(gpio_040_076),
 		    gpio_xec_port040_076_init,
 		    NULL,
 		    &gpio_xec_port040_076_data, &gpio_xec_port040_076_config,
-		    POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
+		    PRE_KERNEL_1, CONFIG_GPIO_INIT_PRIORITY,
 		    &gpio_xec_driver_api);
 
 static int gpio_xec_port040_076_init(const struct device *dev)
@@ -447,7 +447,7 @@ DEVICE_DT_DEFINE(DT_NODELABEL(gpio_100_136),
 		    gpio_xec_port100_136_init,
 		    NULL,
 		    &gpio_xec_port100_136_data, &gpio_xec_port100_136_config,
-		    POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
+		    PRE_KERNEL_1, CONFIG_GPIO_INIT_PRIORITY,
 		    &gpio_xec_driver_api);
 
 static int gpio_xec_port100_136_init(const struct device *dev)
@@ -493,7 +493,7 @@ DEVICE_DT_DEFINE(DT_NODELABEL(gpio_140_176),
 		    gpio_xec_port140_176_init,
 		    NULL,
 		    &gpio_xec_port140_176_data, &gpio_xec_port140_176_config,
-		    POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
+		    PRE_KERNEL_1, CONFIG_GPIO_INIT_PRIORITY,
 		    &gpio_xec_driver_api);
 
 static int gpio_xec_port140_176_init(const struct device *dev)
@@ -539,7 +539,7 @@ DEVICE_DT_DEFINE(DT_NODELABEL(gpio_200_236),
 		    gpio_xec_port200_236_init,
 		    NULL,
 		    &gpio_xec_port200_236_data, &gpio_xec_port200_236_config,
-		    POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
+		    PRE_KERNEL_1, CONFIG_GPIO_INIT_PRIORITY,
 		    &gpio_xec_driver_api);
 
 static int gpio_xec_port200_236_init(const struct device *dev)
@@ -585,7 +585,7 @@ DEVICE_DT_DEFINE(DT_NODELABEL(gpio_240_276),
 		    gpio_xec_port240_276_init,
 		    NULL,
 		    &gpio_xec_port240_276_data, &gpio_xec_port240_276_config,
-		    POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
+		    PRE_KERNEL_1, CONFIG_GPIO_INIT_PRIORITY,
 		    &gpio_xec_driver_api);
 
 static int gpio_xec_port240_276_init(const struct device *dev)

--- a/drivers/gpio/gpio_mchp_xec_v2.c
+++ b/drivers/gpio/gpio_mchp_xec_v2.c
@@ -420,7 +420,7 @@ static const struct gpio_driver_api gpio_xec_driver_api = {
 									\
 	DEVICE_DT_INST_DEFINE(n, gpio_xec_port_init_##n, NULL,		\
 		&gpio_xec_port_data_##n, &xec_gpio_config_##n,		\
-		POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,			\
+		PRE_KERNEL_1, CONFIG_GPIO_INIT_PRIORITY,			\
 		&gpio_xec_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(XEC_GPIO_PORT)

--- a/drivers/gpio/gpio_mcux_lpc.c
+++ b/drivers/gpio/gpio_mcux_lpc.c
@@ -394,7 +394,7 @@ static const clock_ip_name_t gpio_clock_names[] = GPIO_CLOCKS;
 											\
 	DEVICE_DT_INST_DEFINE(n, lpc_gpio_init_##n, NULL,				\
 		    &gpio_mcux_lpc_data_##n,						\
-		    &gpio_mcux_lpc_config_##n, POST_KERNEL,				\
+		    &gpio_mcux_lpc_config_##n, PRE_KERNEL_1,				\
 		    CONFIG_GPIO_INIT_PRIORITY,						\
 		    &gpio_mcux_lpc_driver_api);						\
 											\

--- a/drivers/gpio/gpio_neorv32.c
+++ b/drivers/gpio/gpio_neorv32.c
@@ -234,7 +234,7 @@ static const struct gpio_driver_api neorv32_gpio_driver_api = {
 			NULL,						\
 			&neorv32_gpio_##n##_data,			\
 			&neorv32_gpio_##n##_config,			\
-			POST_KERNEL,					\
+			PRE_KERNEL_2,					\
 			CONFIG_GPIO_INIT_PRIORITY,			\
 			&neorv32_gpio_driver_api);
 

--- a/drivers/gpio/gpio_npcx.c
+++ b/drivers/gpio/gpio_npcx.c
@@ -335,7 +335,7 @@ int gpio_npcx_init(const struct device *dev)
 			    NULL,					       \
 			    &gpio_npcx_data_##inst,                            \
 			    &gpio_npcx_cfg_##inst,                             \
-			    POST_KERNEL,                                       \
+			    PRE_KERNEL_1,                                       \
 			    CONFIG_GPIO_INIT_PRIORITY,                         \
 			    &gpio_npcx_driver);
 

--- a/drivers/gpio/gpio_psoc6.c
+++ b/drivers/gpio/gpio_psoc6.c
@@ -268,7 +268,7 @@ int gpio_psoc6_init(const struct device *dev)
 									\
 	DEVICE_DT_INST_DEFINE(n, gpio_psoc6_init, NULL,			\
 			    &port_##n##_psoc6_runtime,			\
-			    &port_##n##_psoc6_config, POST_KERNEL,	\
+			    &port_##n##_psoc6_config, PRE_KERNEL_1,	\
 			    CONFIG_GPIO_INIT_PRIORITY,			\
 			    &gpio_psoc6_api);				\
 									\

--- a/drivers/gpio/gpio_rcar.c
+++ b/drivers/gpio/gpio_rcar.c
@@ -309,7 +309,7 @@ static const struct gpio_driver_api gpio_rcar_driver_api = {
 			      NULL,				    \
 			      &gpio_rcar_data_##n,		    \
 			      &gpio_rcar_cfg_##n,		    \
-			      POST_KERNEL,			    \
+			      PRE_KERNEL_1,			    \
 			      CONFIG_GPIO_INIT_PRIORITY,	    \
 			      &gpio_rcar_driver_api		    \
 			      );				    \

--- a/drivers/gpio/gpio_rv32m1.c
+++ b/drivers/gpio/gpio_rv32m1.c
@@ -317,7 +317,7 @@ static const struct gpio_driver_api gpio_rv32m1_driver_api = {
 			    NULL,					\
 			    &gpio_rv32m1_##n##_data,			\
 			    &gpio_rv32m1_##n##_config,			\
-			    POST_KERNEL,				\
+			    PRE_KERNEL_1,				\
 			    CONFIG_GPIO_INIT_PRIORITY,			\
 			    &gpio_rv32m1_driver_api);			\
 									\

--- a/drivers/gpio/gpio_sam.c
+++ b/drivers/gpio/gpio_sam.c
@@ -324,7 +324,7 @@ int gpio_sam_init(const struct device *dev)
 									\
 	DEVICE_DT_INST_DEFINE(n, gpio_sam_init, NULL,			\
 			    &port_##n##_sam_runtime,			\
-			    &port_##n##_sam_config, POST_KERNEL,	\
+			    &port_##n##_sam_config, PRE_KERNEL_1,	\
 			    CONFIG_GPIO_INIT_PRIORITY,			\
 			    &gpio_sam_api);				\
 									\

--- a/drivers/gpio/gpio_sam0.c
+++ b/drivers/gpio/gpio_sam0.c
@@ -306,7 +306,7 @@ static struct gpio_sam0_data gpio_sam0_data_0;
 DEVICE_DT_DEFINE(DT_NODELABEL(porta),
 		    gpio_sam0_init, NULL,
 		    &gpio_sam0_data_0, &gpio_sam0_config_0,
-		    POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
+		    PRE_KERNEL_1, CONFIG_GPIO_INIT_PRIORITY,
 		    &gpio_sam0_api);
 #endif
 
@@ -328,7 +328,7 @@ static struct gpio_sam0_data gpio_sam0_data_1;
 DEVICE_DT_DEFINE(DT_NODELABEL(portb),
 		    gpio_sam0_init, NULL,
 		    &gpio_sam0_data_1, &gpio_sam0_config_1,
-		    POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
+		    PRE_KERNEL_1, CONFIG_GPIO_INIT_PRIORITY,
 		    &gpio_sam0_api);
 #endif
 
@@ -350,7 +350,7 @@ static struct gpio_sam0_data gpio_sam0_data_2;
 DEVICE_DT_DEFINE(DT_NODELABEL(portc),
 		    gpio_sam0_init, NULL,
 		    &gpio_sam0_data_2, &gpio_sam0_config_2,
-		    POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
+		    PRE_KERNEL_1, CONFIG_GPIO_INIT_PRIORITY,
 		    &gpio_sam0_api);
 #endif
 
@@ -372,6 +372,6 @@ static struct gpio_sam0_data gpio_sam0_data_3;
 DEVICE_DT_DEFINE(DT_NODELABEL(portd),
 		    gpio_sam0_init, NULL,
 		    &gpio_sam0_data_3, &gpio_sam0_config_3,
-		    POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
+		    PRE_KERNEL_1, CONFIG_GPIO_INIT_PRIORITY,
 		    &gpio_sam0_api);
 #endif

--- a/drivers/gpio/gpio_sam4l.c
+++ b/drivers/gpio/gpio_sam4l.c
@@ -266,7 +266,7 @@ int gpio_sam_init(const struct device *dev)
 									\
 	DEVICE_DT_INST_DEFINE(n, gpio_sam_init, NULL,			\
 			    &port_##n##_sam_runtime,			\
-			    &port_##n##_sam_config, POST_KERNEL,	\
+			    &port_##n##_sam_config, PRE_KERNEL_1,	\
 			    CONFIG_GPIO_INIT_PRIORITY,			\
 			    &gpio_sam_api);				\
 									\

--- a/drivers/gpio/gpio_sifive.c
+++ b/drivers/gpio/gpio_sifive.c
@@ -361,7 +361,7 @@ DEVICE_DT_INST_DEFINE(0,
 		    gpio_sifive_init,
 		    NULL,
 		    &gpio_sifive_data0, &gpio_sifive_config0,
-		    POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
+		    PRE_KERNEL_1, CONFIG_GPIO_INIT_PRIORITY,
 		    &gpio_sifive_driver);
 
 #define		IRQ_INIT(n)					\

--- a/drivers/gpio/gpio_xlnx_axi.c
+++ b/drivers/gpio/gpio_xlnx_axi.c
@@ -286,7 +286,7 @@ static const struct gpio_driver_api gpio_xlnx_axi_driver_api = {
 			NULL,						\
 			&gpio_xlnx_axi_##n##_2_data,			\
 			&gpio_xlnx_axi_##n##_2_config,			\
-			POST_KERNEL,					\
+			PRE_KERNEL_1,					\
 			CONFIG_GPIO_INIT_PRIORITY,			\
 			&gpio_xlnx_axi_driver_api);
 
@@ -314,7 +314,7 @@ static const struct gpio_driver_api gpio_xlnx_axi_driver_api = {
 			NULL,						\
 			&gpio_xlnx_axi_##n##_data,			\
 			&gpio_xlnx_axi_##n##_config,			\
-			POST_KERNEL,					\
+			PRE_KERNEL_1,					\
 			CONFIG_GPIO_INIT_PRIORITY,			\
 			&gpio_xlnx_axi_driver_api);			\
 	GPIO_XLNX_AXI_GPIO2_COND_INIT(n);


### PR DESCRIPTION
PRE_KERNEL_1 is to be used for devices that have no dependencies
and do not use kernel features, such as those that rely solely on
hardware present in the processor/SOC. This commit updates these
gpios to initialize during the PRE_KERNEL_1 rather than the
POST_KERNEL. Some SoC drivers are moved to PRE_KERNEL_2 due
to dependencies.

A lot of 'other' drivers can depend on GPIOs though phandles
(such as reset lines, data or command gpios, etc...). Most of these
drivers that would need this would come up on the POST_KERNEL,
and it's likely the driver may not be up yet as it should be defined.

Signed-off-by: Ryan McClelland <ryanmcclelland@fb.com>

reference: https://docs.zephyrproject.org/latest/reference/drivers/index.html#initialization-levels