### PR TITLE
drivers: gpio: revert kconfig init priority for off-chip gpios

### DIFF
--- a/drivers/gpio/Kconfig.lmp90xxx
+++ b/drivers/gpio/Kconfig.lmp90xxx
@@ -3,7 +3,7 @@
 # Copyright (c) 2019 Vestas Wind Systems A/S
 # SPDX-License-Identifier: Apache-2.0
 
-config GPIO_LMP90XXX
+menuconfig GPIO_LMP90XXX
 	bool "LMP90xxx GPIO driver"
 	depends on ADC_LMP90XXX_GPIO
 	help
@@ -14,3 +14,11 @@ config GPIO_LMP90XXX
 
 	  The GPIO port of the LMP90xxx (D6 to D0) is exposed as a
 	  GPIO controller driver with read/write support.
+
+config GPIO_LMP90XXX_INIT_PRIORITY
+	int "Driver init priority"
+	default 99
+	depends on GPIO_LMP90XXX
+	help
+	  Device driver initialization priority. This driver must be
+	  initialized after the LMP90xxx ADC driver.

--- a/drivers/gpio/Kconfig.sx1509b
+++ b/drivers/gpio/Kconfig.sx1509b
@@ -15,6 +15,12 @@ menuconfig GPIO_SX1509B
 
 if GPIO_SX1509B
 
+config GPIO_SX1509B_INIT_PRIORITY
+	int "Init priority"
+	default 70
+	help
+	  Device driver initialization priority.
+
 config GPIO_SX1509B_INTERRUPT
 	bool "Interrupt enable"
 	default n

--- a/drivers/gpio/gpio_lmp90xxx.c
+++ b/drivers/gpio/gpio_lmp90xxx.c
@@ -158,7 +158,7 @@ static const struct gpio_driver_api gpio_lmp90xxx_api = {
 	.port_get_raw = gpio_lmp90xxx_port_get_raw,
 };
 
-BUILD_ASSERT(CONFIG_GPIO_INIT_PRIORITY >
+BUILD_ASSERT(CONFIG_GPIO_LMP90XXX_INIT_PRIORITY >
 	     CONFIG_ADC_INIT_PRIORITY,
 	     "LMP90xxx GPIO driver must be initialized after LMP90xxx ADC "
 	     "driver");
@@ -179,7 +179,7 @@ BUILD_ASSERT(CONFIG_GPIO_INIT_PRIORITY >
 			    NULL,					\
 			    &gpio_lmp90xxx_##id##_data,			\
 			    &gpio_lmp90xxx_##id##_cfg, POST_KERNEL,	\
-			    CONFIG_GPIO_INIT_PRIORITY,			\
+			    CONFIG_GPIO_LMP90XXX_INIT_PRIORITY,		\
 			    &gpio_lmp90xxx_api);
 
 DT_INST_FOREACH_STATUS_OKAY(GPIO_LMP90XXX_DEVICE)

--- a/drivers/gpio/gpio_sx1509b.c
+++ b/drivers/gpio/gpio_sx1509b.c
@@ -786,5 +786,5 @@ static struct sx1509b_drv_data sx1509b_drvdata = {
 
 DEVICE_DT_INST_DEFINE(0, sx1509b_init, NULL,
 		 &sx1509b_drvdata, &sx1509b_cfg,
-		 POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
+		 POST_KERNEL, CONFIG_GPIO_SX1509B_INIT_PRIORITY,
 		 &api_table);


### PR DESCRIPTION
In #40140, all on-chip gpios where made to use `CONFIG_GPIO_INIT_PRIORITY`.
The lmp90xxx and sx1509b are off-chip gpios. This commit reverts those
changes for these two devices.

Signed-off-by: Ryan McClelland <ryanmcclelland@fb.com>