### PR TITLE
boards: arm: frdm_k64f: add documentation for CAN pins

### DIFF
--- a/boards/arm/frdm_k64f/doc/index.rst
+++ b/boards/arm/frdm_k64f/doc/index.rst
@@ -135,6 +135,10 @@ The K64F SoC has five pairs of pinmux/gpio controllers.
 +-------+-----------------+---------------------------+
 | PTB17 | UART0_TX        | UART Console              |
 +-------+-----------------+---------------------------+
+| PTB18 | CAN0_TX         | CAN TX                    |
++-------+-----------------+---------------------------+
+| PTB19 | CAN0_RX         | CAN RX                    |
++-------+-----------------+---------------------------+
 | PTC8  | PWM             | PWM_3 channel 4           |
 +-------+-----------------+---------------------------+
 | PTC9  | PWM             | PWM_3 channel 5           |
@@ -206,6 +210,13 @@ USB
 The K64F SoC has a USB OTG (USBOTG) controller that supports both
 device and host functions through its micro USB connector (K64F USB).
 Only USB device function is supported in Zephyr at the moment.
+
+CAN
+===
+
+The FRDM-K64F board does not come with an onboard CAN transceiver. In order to
+use the CAN bus, an external CAN bus tranceiver must be connected to ``PTB18``
+(``CAN0_TX``) and ``PTB19`` (``CAN0_RX``).
 
 Programming and Debugging
 *************************


### PR DESCRIPTION
Add documentation to the CAN RX/TX pins of the NXP FRDM-K64F development board.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>