### PR TITLE
net: openthread: resolve platform entropy dependency

### DIFF
--- a/subsys/net/lib/openthread/platform/CMakeLists.txt
+++ b/subsys/net/lib/openthread/platform/CMakeLists.txt
@@ -3,7 +3,6 @@
 zephyr_library_named(openthread_platform)
 zephyr_library_sources(
   alarm.c
-  entropy.c
   misc.c
   platform.c
   radio.c
@@ -16,6 +15,7 @@ zephyr_library_sources_ifdef(CONFIG_OPENTHREAD_COPROCESSOR uart.c)
 zephyr_library_sources_ifdef(CONFIG_OPENTHREAD_CRYPTO_PSA crypto_psa.c)
 zephyr_library_sources_ifdef(CONFIG_OPENTHREAD_SHELL shell.c)
 zephyr_library_sources_ifdef(CONFIG_OPENTHREAD_EXTERNAL_HEAP memory.c)
+zephyr_library_sources_ifdef(CONFIG_OPENTHREAD_COPROCESSOR_RCP entropy.c)
 zephyr_library_sources_ifndef(CONFIG_LOG_BACKEND_SPINEL logging.c)
 
 zephyr_include_directories(.)


### PR DESCRIPTION
The platform implementation of function otPlatEntropyGet is needed only for RCP. For rest variants OpenThread gets entropy from mbedtls.