### PR TITLE
build: Remove unused functions

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -276,12 +276,12 @@ void z_requeue_current(struct k_thread *curr)
 		runq_add(curr);
 	}
 }
-#endif
 
 static inline bool is_aborting(struct k_thread *thread)
 {
 	return (thread->base.thread_state & _THREAD_ABORTING) != 0U;
 }
+#endif
 
 static ALWAYS_INLINE struct k_thread *next_up(void)
 {
@@ -916,6 +916,7 @@ struct k_thread *z_swap_next_thread(void)
 #endif
 }
 
+#ifdef CONFIG_USE_SWITCH
 /* Just a wrapper around _current = xxx with tracing */
 static inline void set_current(struct k_thread *new_thread)
 {
@@ -923,7 +924,6 @@ static inline void set_current(struct k_thread *new_thread)
 	_current_cpu->current = new_thread;
 }
 
-#ifdef CONFIG_USE_SWITCH
 void *z_get_next_switch_handle(void *interrupted)
 {
 	z_check_stack_sentinel();

--- a/lib/os/mpsc_pbuf.c
+++ b/lib/os/mpsc_pbuf.c
@@ -96,18 +96,6 @@ static inline uint32_t idx_inc(struct mpsc_pbuf_buffer *buffer,
 	return (i >= buffer->size) ? i - buffer->size : i;
 }
 
-static inline uint32_t idx_dec(struct mpsc_pbuf_buffer *buffer,
-				uint32_t idx, uint32_t val)
-{
-	uint32_t i = idx - val;
-
-	if (buffer->flags & MPSC_PBUF_SIZE_POW2) {
-		return idx & (buffer->size - 1);
-	}
-
-	return (i >= buffer->size) ? i + buffer->size : i;
-}
-
 static inline uint32_t get_skip(union mpsc_pbuf_generic *item)
 {
 	if (item->hdr.busy && !item->hdr.valid) {

--- a/lib/os/ring_buffer.c
+++ b/lib/os/ring_buffer.c
@@ -168,18 +168,6 @@ int ring_buf_item_get(struct ring_buf *buf, uint16_t *type, uint8_t *value,
 	return 0;
 }
 
-/** @brief Wraps index if it exceeds the limit.
- *
- * @param val  Value
- * @param max  Max.
- *
- * @return value % max.
- */
-static inline uint32_t wrap(uint32_t val, uint32_t max)
-{
-	return val >= max ? (val - max) : val;
-}
-
 uint32_t ring_buf_put_claim(struct ring_buf *buf, uint8_t **data, uint32_t size)
 {
 	uint32_t space, trail_size, allocated, tmp_trail_mod;


### PR DESCRIPTION
Removed unused functions, or moved inside #ifdefs.This allows using -Werror=unused-function on the clang compiler. Tested by building the ChromeOS EC on all supported platforms with-Werror=unused-functions.

Signed-off-by: Jeremy Bettis <jbettis@google.com>