### PR TITLE
drivers: adc: stm32: Disable ADC before calibration

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -592,7 +592,14 @@ static int start_read(const struct device *dev,
 	!defined(CONFIG_SOC_SERIES_STM32F1X) && \
 	!defined(STM32F3X_ADC_V2_5) && \
 	!defined(CONFIG_SOC_SERIES_STM32L1X)
+
+		/* we cannot calibrate the ADC while the ADC is enabled */
+		LL_ADC_Disable(adc);
+		while (LL_ADC_IsEnabled(adc) == 1UL) {
+		}
 		adc_stm32_calib(dev);
+		/* re-enable ADC after calibration */
+		LL_ADC_Enable(adc);
 #else
 		LOG_ERR("Calibration not supported");
 		return -ENOTSUP;


### PR DESCRIPTION
The STM32 docs state that the ADC may not be calibrated unless
the ADC is disabled (ADEN=0). This commit implements this constraint

Fixes #40936

Signed-off-by: Pete Dietl <petedietl@gmail.com>