### PR TITLE
spi: npcx_fiu: Update the SPI context

### DIFF
--- a/drivers/spi/spi_npcx_fiu.c
+++ b/drivers/spi/spi_npcx_fiu.c
@@ -77,6 +77,7 @@ static int spi_npcx_fiu_transceive(const struct device *dev,
 	int error = 0;
 
 	spi_context_lock(ctx, false, NULL, spi_cfg);
+	ctx->config = spi_cfg;
 
 	/*
 	 * Configure UMA lock/unlock only if tx buffer set and rx buffer set


### PR DESCRIPTION
Update the SPI context during all transceive functions. This fixes a
deadlock where SPI transactions failed to give back the semaphore.

Verified on NPCX9 based Chromebook.

Signed-off-by: Keith Short <keithshort@google.com>