### PR TITLE
queue: maybe unused condition need to be removed.

### DIFF
--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -255,9 +255,7 @@ int k_queue_append_list(struct k_queue *queue, void *head, void *tail)
 	k_spinlock_key_t key = k_spin_lock(&queue->lock);
 	struct k_thread *thread = NULL;
 
-	if (head != NULL) {
-		thread = z_unpend_first_thread(&queue->wait_q);
-	}
+	thread = z_unpend_first_thread(&queue->wait_q);
 
 	while ((head != NULL) && (thread != NULL)) {
 		prepare_thread_to_run(thread, head);


### PR DESCRIPTION
In function k_qeueu_append_list, the head of the list will be checked in the
function entry by CHECK IF macro, and before using the list, the spinlock
will be locked. So the list will not be changed by other threads. Thus,
remove the next IF condition.

Signed-off-by: NingX Zhao <ningx.zhao@intel.com>