### PR TITLE
tests: improve the testcases of queue

### DIFF
--- a/tests/kernel/queue/src/test_queue_fail.c
+++ b/tests/kernel/queue/src/test_queue_fail.c
@@ -12,6 +12,7 @@
 
 static K_THREAD_STACK_DEFINE(tstack, STACK_SIZE);
 static struct k_thread tdata;
+K_SEM_DEFINE(sem, 0, 1);
 
 /*test cases*/
 /**
@@ -32,8 +33,12 @@ void test_queue_get_fail(void)
 /* The sub-thread entry */
 static void tThread_entry(void *p1, void *p2, void *p3)
 {
+	k_sem_give(&sem);
+
 	/* wait the queue for data */
-	k_queue_get((struct k_queue *)p1, K_FOREVER);
+	qdata_t *p = k_queue_get((struct k_queue *)p1, K_FOREVER);
+
+	zassert_equal(p, p2, "Failed to append a unnormal list");
 }
 
 /**
@@ -72,16 +77,19 @@ void test_queue_append_list_error(void)
 			"failed to CHECKIF tail == NULL");
 	/* Initializing the queue for re-using below */
 	k_queue_init(&queue);
-	k_thread_create(&tdata, tstack, STACK_SIZE, tThread_entry, &queue,
-			NULL, NULL, K_PRIO_PREEMPT(0), 0, K_NO_WAIT);
-	/* Delay for thread initializing */
-	k_sleep(K_MSEC(500));
-	/* Append list into the queue for sub-thread */
+
+	/* Append unnormal list(just one node)into the queue for sub-thread */
 	head = &data_l[0];
-	tail = &data_l[1];
-	head->snode.next = (sys_snode_t *)tail;
-	tail->snode.next = NULL;
-	k_queue_append_list(&queue, (uint32_t *)head, (uint32_t *)tail);
+	head->snode.next = NULL;
+
+	k_thread_create(&tdata, tstack, STACK_SIZE, tThread_entry, &queue,
+			head, NULL, K_PRIO_PREEMPT(0), 0, K_NO_WAIT);
+	/* Delay for thread initializing */
+	k_sem_take(&sem, K_FOREVER);
+
+	k_queue_append_list(&queue, (uint32_t *)head, (uint32_t *)head);
+
+	k_thread_join(&tdata, K_FOREVER);
 }
 
 /**


### PR DESCRIPTION
In test_queue_append_list_error function, try to append an unnormal
list to check if the data is successful to append, and improve the
coverage for queue.c

Signed-off-by: NingX Zhao <ningx.zhao@intel.com>