### PR TITLE
openthread: add an option to store settings in RAM

### DIFF
--- a/subsys/net/l2/openthread/Kconfig
+++ b/subsys/net/l2/openthread/Kconfig
@@ -14,13 +14,14 @@ menuconfig NET_L2_OPENTHREAD
 	depends on NETWORKING
 	select NET_L2_PHY_IEEE802154
 
-	select SETTINGS
-	select FLASH
-	select FLASH_PAGE_LAYOUT
-	select FLASH_MAP
-	select MPU_ALLOW_FLASH_WRITE
-	select NVS
+	imply FLASH
+	imply FLASH_PAGE_LAYOUT
+	imply FLASH_MAP
+	imply MPU_ALLOW_FLASH_WRITE
+	imply NVS
 
+	select SETTINGS if FLASH
+	select OPENTHREAD_SETTINGS_RAM if !FLASH
 	select CPLUSPLUS
 	select REBOOT
 	select ENTROPY_GENERATOR

--- a/subsys/net/lib/openthread/platform/CMakeLists.txt
+++ b/subsys/net/lib/openthread/platform/CMakeLists.txt
@@ -7,7 +7,6 @@ zephyr_library_sources(
   misc.c
   platform.c
   radio.c
-  settings.c
   spi.c
   )
 
@@ -16,6 +15,7 @@ zephyr_library_sources_ifdef(CONFIG_OPENTHREAD_COPROCESSOR uart.c)
 zephyr_library_sources_ifdef(CONFIG_OPENTHREAD_CRYPTO_PSA crypto_psa.c)
 zephyr_library_sources_ifdef(CONFIG_OPENTHREAD_SHELL shell.c)
 zephyr_library_sources_ifdef(CONFIG_OPENTHREAD_EXTERNAL_HEAP memory.c)
+zephyr_library_sources_ifdef(CONFIG_SETTINGS settings.c)
 zephyr_library_sources_ifndef(CONFIG_LOG_BACKEND_SPINEL logging.c)
 
 zephyr_include_directories(.)

--- a/west.yml
+++ b/west.yml
@@ -190,7 +190,7 @@ manifest:
       revision: cfd050ff38a9d028dc211690b2ec35971128e45e
       path: modules/lib/open-amp
     - name: openthread
-      revision: 69eb7030c5eb479e2d387408f7b3814c58963804
+      revision: 41bc49da49736fbdfdfa231f7b2311f29dcc4979
       path: modules/lib/openthread
     - name: segger
       revision: 3a52ab222133193802d3c3b4d21730b9b1f1d2f6


### PR DESCRIPTION
Add an option to store OpenThread settings in RAM for the case where the flash driver is not available. This can be useful
for testing openthread on new platforms which are still under development.