### PR TITLE
gpio: mcp23s17: use gpio_driver_data not config

### DIFF
--- a/drivers/gpio/gpio_mcp23s17.h
+++ b/drivers/gpio/gpio_mcp23s17.h
@@ -47,7 +47,7 @@ extern "C" {
 
 /** Configuration data */
 struct mcp23s17_config {
-	/* gpio_driver_data needs to be first */
+	/* gpio_driver_config needs to be first */
 	struct gpio_driver_config common;
 
 	struct spi_dt_spec bus;
@@ -56,7 +56,7 @@ struct mcp23s17_config {
 /** Runtime driver data */
 struct mcp23s17_drv_data {
 	/* gpio_driver_data needs to be first */
-	struct gpio_driver_config data;
+	struct gpio_driver_data data;
 
 	struct k_sem lock;
 


### PR DESCRIPTION
fix incorrect gpio driver struct used in driver data.
This should not have caused any issue as currently
sizeof(gpio_driver_data) == sizeof(gpio_driver_config).

Signed-off-by: Simon Frank <simon.frank@lohmega.com>