### PR TITLE
drivers: spi: nrfx: release regardless of config

### DIFF
--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -256,10 +256,6 @@ static int spi_nrfx_release(const struct device *dev,
 {
 	struct spi_nrfx_data *dev_data = get_dev_data(dev);
 
-	if (!spi_context_configured(&dev_data->ctx, spi_cfg)) {
-		return -EINVAL;
-	}
-
 	if (dev_data->busy) {
 		return -EBUSY;
 	}

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -416,10 +416,6 @@ static int spi_nrfx_release(const struct device *dev,
 {
 	struct spi_nrfx_data *dev_data = get_dev_data(dev);
 
-	if (!spi_context_configured(&dev_data->ctx, spi_cfg)) {
-		return -EINVAL;
-	}
-
 	if (dev_data->busy) {
 		return -EBUSY;
 	}

--- a/drivers/spi/spi_nrfx_spis.c
+++ b/drivers/spi/spi_nrfx_spis.c
@@ -201,10 +201,6 @@ static int spi_nrfx_release(const struct device *dev,
 {
 	struct spi_nrfx_data *dev_data = get_dev_data(dev);
 
-	if (!spi_context_configured(&dev_data->ctx, spi_cfg)) {
-		return -EINVAL;
-	}
-
 	spi_context_unlock_unconditionally(&dev_data->ctx);
 
 	return 0;


### PR DESCRIPTION
Removed pointer compare on config parameter. SPI should always be
released regardless of config address. This also seems to be the
behavior in other SPI drivers.

Related issue: #28093

Signed-off-by: Simon Frank simon.frank@lohmega.com