### PR TITLE
boards/intel_adsp_cavs25: add rev2 for 2 DSP core variant

### DIFF
--- a/boards/xtensa/intel_adsp_cavs25/intel_adsp_cavs25_2.conf
+++ b/boards/xtensa/intel_adsp_cavs25/intel_adsp_cavs25_2.conf
@@ -1,0 +1,2 @@
+# board revision 2 -> only 2 DSP cores available
+CONFIG_MP_NUM_CPUS=2

--- a/boards/xtensa/intel_adsp_cavs25/intel_adsp_cavs25_4.conf
+++ b/boards/xtensa/intel_adsp_cavs25/intel_adsp_cavs25_4.conf
@@ -1,0 +1,2 @@
+# board revision 4 -> full 4 DSP cores available
+CONFIG_MP_NUM_CPUS=4

--- a/boards/xtensa/intel_adsp_cavs25/revision.cmake
+++ b/boards/xtensa/intel_adsp_cavs25/revision.cmake
@@ -1,0 +1,5 @@
+# Copyright (c) 2021 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+board_check_revision(FORMAT NUMBER DEFAULT_REVISION 4)


### PR DESCRIPTION
Define revision 2 of the board that has only two DSP cores.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>