### PR TITLE
IBECC: Fixing issues with uninitialized device in tests

### DIFF
--- a/drivers/edac/edac_ibecc.c
+++ b/drivers/edac/edac_ibecc.c
@@ -334,6 +334,8 @@ static int edac_ibecc_init(const struct device *dev)
 	/* Enable Host Bridge generated SERR event */
 	ibecc_errcmd_setup(bdf, true);
 
+	LOG_INF("IBECC driver initialized");
+
 	return 0;
 }
 

--- a/tests/subsys/edac/ibecc/src/ibecc.c
+++ b/tests/subsys/edac/ibecc/src/ibecc.c
@@ -22,10 +22,10 @@
 #define DURATION		100
 #endif
 
-const struct device *dev;
-
 static void test_ibecc_initialized(void)
 {
+	const struct device *dev;
+
 	dev = device_get_binding(DEVICE_NAME);
 	zassert_not_null(dev, "Device not found");
 
@@ -52,10 +52,14 @@ static void callback(const struct device *d, void *data)
 
 static void test_ibecc_api(void)
 {
+	const struct device *dev;
 	uint64_t value;
 	int ret;
 
 	/* Error log API */
+
+	dev = device_get_binding(DEVICE_NAME);
+	zassert_not_null(dev, "Device not found");
 
 	ret = edac_ecc_error_log_get(dev, &value);
 	zassert_equal(ret, -ENODATA, "edac_ecc_error_log_get failed");
@@ -86,9 +90,13 @@ static void test_ibecc_api(void)
 #if defined(CONFIG_EDAC_ERROR_INJECT)
 static void test_ibecc_error_inject_api(void)
 {
+	const struct device *dev;
 	uint32_t test_value;
 	uint64_t val;
 	int ret;
+
+	dev = device_get_binding(DEVICE_NAME);
+	zassert_not_null(dev, "Device not found");
 
 	/* Verify default parameters */
 
@@ -154,7 +162,8 @@ static void test_ibecc_error_inject_api(void)
 #endif
 
 #if defined(CONFIG_EDAC_ERROR_INJECT)
-static void test_inject(uint64_t addr, uint64_t mask, uint8_t type)
+static void test_inject(const struct device *dev, uint64_t addr, uint64_t mask,
+			uint8_t type)
 {
 	unsigned int errors_cor, errors_uc;
 	uint64_t test_addr;
@@ -258,13 +267,17 @@ static int check_values(void *p1, void *p2, void *p3)
 
 static void ibecc_error_inject_test(uint64_t addr, uint64_t mask, uint64_t type)
 {
+	const struct device *dev;
 	int ret;
+
+	dev = device_get_binding(DEVICE_NAME);
+	zassert_not_null(dev, "Device not found");
 
 	ret = edac_notify_callback_set(dev, callback);
 	zassert_equal(ret, 0, "Error setting notification callback");
 
 	/* Test injecting correctable error at address TEST_ADDRESS1 */
-	test_inject(addr, mask, type);
+	test_inject(dev, addr, mask, type);
 
 #if defined(CONFIG_USERSPACE)
 	k_thread_user_mode_enter((k_thread_entry_t)check_values,

--- a/tests/subsys/edac/ibecc/src/ibecc.c
+++ b/tests/subsys/edac/ibecc/src/ibecc.c
@@ -256,7 +256,7 @@ static int check_values(void *p1, void *p2, void *p3)
 	return 0;
 }
 
-static void test_ibecc_error_inject_test_cor(void)
+static void ibecc_error_inject_test(uint64_t addr, uint64_t mask, uint64_t type)
 {
 	int ret;
 
@@ -264,40 +264,30 @@ static void test_ibecc_error_inject_test_cor(void)
 	zassert_equal(ret, 0, "Error setting notification callback");
 
 	/* Test injecting correctable error at address TEST_ADDRESS1 */
-	test_inject(TEST_ADDRESS1, TEST_ADDRESS_MASK, EDAC_ERROR_TYPE_DRAM_COR);
+	test_inject(addr, mask, type);
 
 #if defined(CONFIG_USERSPACE)
 	k_thread_user_mode_enter((k_thread_entry_t)check_values,
-				 (void *)TEST_ADDRESS1,
-				 (void *)EDAC_ERROR_TYPE_DRAM_COR,
+				 (void *)addr,
+				 (void *)type,
 				 NULL);
 #else
-	check_values((void *)TEST_ADDRESS1, (void *)EDAC_ERROR_TYPE_DRAM_COR,
-		     NULL);
+	check_values((void *)addr, (void *)type, NULL);
 #endif
+}
+
+static void test_ibecc_error_inject_test_cor(void)
+{
+	ibecc_error_inject_test(TEST_ADDRESS1, TEST_ADDRESS_MASK,
+				EDAC_ERROR_TYPE_DRAM_COR);
 }
 
 static void test_ibecc_error_inject_test_uc(void)
 {
-	int ret;
-
-	ret = edac_notify_callback_set(dev, callback);
-	zassert_equal(ret, 0, "Error setting notification callback");
-
-	/* Test injecting uncorrectable error at address TEST_ADDRESS2 */
-	test_inject(TEST_ADDRESS2, TEST_ADDRESS_MASK, EDAC_ERROR_TYPE_DRAM_UC);
-
-#if defined(CONFIG_USERSPACE)
-	k_thread_user_mode_enter((k_thread_entry_t)check_values,
-				 (void *)TEST_ADDRESS2,
-				 (void *)EDAC_ERROR_TYPE_DRAM_UC,
-				 NULL);
-#else
-	check_values((void *)TEST_ADDRESS2, (void *)EDAC_ERROR_TYPE_DRAM_UC,
-		     NULL);
-#endif
+	ibecc_error_inject_test(TEST_ADDRESS2, TEST_ADDRESS_MASK,
+				EDAC_ERROR_TYPE_DRAM_UC);
 }
-#else
+#else /* CONFIG_EDAC_ERROR_INJECT */
 static void test_ibecc_error_inject_test_cor(void)
 {
 	ztest_test_skip();


### PR DESCRIPTION
When disabling IBECC support in BIOS after first test failure to get device, other tests are still executing with NULL as a device pointer. 