### PR TITLE
pwm: stm32: Modify digital filter for timer capture driver

### DIFF
--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -311,7 +311,7 @@ static int init_capture_channel(const struct device *dev, uint32_t pwm,
 
 	LL_TIM_IC_StructInit(&ic);
 	ic.ICPrescaler = TIM_ICPSC_DIV1;
-	ic.ICFilter = LL_TIM_IC_FILTER_FDIV1;
+	ic.ICFilter = LL_TIM_IC_FILTER_FDIV1_N8;
 
 	if (channel == LL_TIM_CHANNEL_CH1) {
 		if (pwm == 1u) {


### PR DESCRIPTION
With the current code there is no digital filtering applied to the
stm32 PWM/capture driver (in init_capture_channel() function).

It turns out that for stm32h743 (nucleo_h743zi) board the filter
needs to be enabled to allow correct operation - this change
follows recommendation from point 39.3.5 "Input Capture Mode"
 -   point 3 (from Reference Manual "RM0433 Rev 7").

This problem has been discovered when the PWM loopback test was
run (./zephyr/tests/drivers/pwm/pwm_loopback/).

Signed-off-by: Lukasz Majewski <lukma@denx.de>