### PR TITLE
pwm: test: Add Nucleo board to test loopback and fix polarity setting

### DIFF
--- a/tests/drivers/pwm/pwm_loopback/boards/nucleo_h743zi.overlay
+++ b/tests/drivers/pwm/pwm_loopback/boards/nucleo_h743zi.overlay
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021 Denx Software Enginerring GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <dt-bindings/pwm/pwm.h>
+
+/ {
+	pwm_loopback_0 {
+		compatible = "test-pwm-loopback";
+		/* first index must be a 32-Bit timer */
+		pwms = <&pwm2 2 0 PWM_POLARITY_NORMAL>,
+			<&pwm5 1 0 PWM_POLARITY_NORMAL>;
+	};
+};
+
+/* 32-Bit timers */
+&timers2 {
+	status = "okay";
+	pwm2: pwm {
+		status = "okay";
+		pinctrl-0 = <&tim2_ch2_pa1>; /* CN11 PIN30 */
+		pinctrl-names = "default";
+	};
+};
+
+&timers5 {
+	status = "okay";
+	pwm5: pwm {
+		status = "okay";
+		pinctrl-0 = <&tim5_ch1_pa0>; /* CN11 PIN28 */
+		pinctrl-names = "default";
+	};
+};

--- a/tests/drivers/pwm/pwm_loopback/src/test_pwm_loopback.c
+++ b/tests/drivers/pwm/pwm_loopback/src/test_pwm_loopback.c
@@ -51,14 +51,16 @@ void test_capture(uint32_t period, uint32_t pulse, enum test_pwm_unit unit,
 		TC_PRINT("Testing PWM capture @ %u/%u nsec\n",
 			 pulse, period);
 		err = pwm_pin_set_nsec(out.dev, out.pwm, period,
-				       pulse, out.flags);
+				       pulse, out.flags ^=
+				       (flags & PWM_POLARITY_MASK));
 		break;
 
 	case TEST_PWM_UNIT_USEC:
 		TC_PRINT("Testing PWM capture @ %u/%u usec\n",
 			 pulse, period);
 		err = pwm_pin_set_usec(out.dev, out.pwm, period,
-				       pulse, out.flags);
+				       pulse, out.flags ^=
+				       (flags & PWM_POLARITY_MASK));
 		break;
 
 	default:

--- a/tests/drivers/pwm/pwm_loopback/src/test_pwm_loopback.c
+++ b/tests/drivers/pwm/pwm_loopback/src/test_pwm_loopback.c
@@ -101,14 +101,8 @@ void test_capture(uint32_t period, uint32_t pulse, enum test_pwm_unit unit,
 	}
 
 	if (flags & PWM_CAPTURE_TYPE_PULSE) {
-		if (flags & PWM_POLARITY_INVERTED) {
-			zassert_within(pulse_capture, period - pulse,
-				       (period - pulse) / 100,
-				       "pulse capture off by more than 1%");
-		} else {
-			zassert_within(pulse_capture, pulse, pulse / 100,
-				       "pulse capture off by more than 1%");
-		}
+		zassert_within(pulse_capture, pulse, pulse / 100,
+			       "pulse capture off by more than 1%");
 	}
 }
 


### PR DESCRIPTION
This patch series provides:

1. Possibility to run PWM test loopback on Nucleo board (`nucleo_h743zi`)
`west build -p always -b nucleo_h743zi ./zephyr/tests/drivers/pwm/pwm_loopback/`
`west debug --gdb /home/lukma/.local/opt/zephyr-sdk-0.13.1/arm-zephyr-eabi/bin/arm-zephyr-eabi-gdb-no-py`

2. The fix for polarity setting for the test - to rely on the HW signal inversion, not on software.
Without this fix the "inversion" of the signal is checked with not using the polarity inversion in HW, and measuring
the duration of the (period - pulse) time. This is abusing of the `PWM_POLARITY_INVERTED` flag, which is 
used to enable signal polarity inversion in the PWM/Timer hardware.
