### PR TITLE
soc/intel_adsp: cavs-link.ld: add *(.trace_ctx) sections

### DIFF
--- a/soc/xtensa/intel_adsp/common/include/cavs-link.ld
+++ b/soc/xtensa/intel_adsp/common/include/cavs-link.ld
@@ -359,6 +359,9 @@ SECTIONS {
     *(.sdata2.*)
     *(.gnu.linkonce.s2.*)
     KEEP(*(.jcr))
+    _trace_ctx_start = ABSOLUTE(.);
+    *(.trace_ctx)
+    _trace_ctx_end = ABSOLUTE(.);
     *(.gna_model)
     _data_end = .;
   } >ucram


### PR DESCRIPTION
The CAVS linker scripts in Zephyr and "plain" (XTOS) SOF seem to share
the same origin and they mostly duplicate each other so they naturally
keep diverging from each other. This commit catches up with the SOF
commit ef43899c580f (thesofproject/sof/pull/2996) which added
the *(.trace_ctx) sections as part of the runtime log filtering
implementation (feature request thesofproject/sof/issues/2172)

Paraphrasing that commit, the goal is to create at link time a C-like
array by regrouping scattered trace contexts so they can be iterated on.

Together with some other changes in SOF, these 3 additional lines are
enough change in Zephyr to fix SOF bug thesofproject/sof/issues/5032

Signed-off-by: Marc Herbert <marc.herbert@intel.com>