### PR TITLE
dts: arm: npcx: Add PSL_IN3/4 for initial pin config

### DIFF
--- a/dts/arm/nuvoton/npcx7.dtsi
+++ b/dts/arm/nuvoton/npcx7.dtsi
@@ -29,6 +29,8 @@
 			   &alta_no_peci_en
 			   &altd_npsl_in1_sl
 			   &altd_npsl_in2_sl
+			   &altd_psl_in3_sl
+			   &altd_psl_in4_sl
 			   &alt7_no_ksi0_sl
 			   &alt7_no_ksi1_sl
 			   &alt7_no_ksi2_sl

--- a/dts/arm/nuvoton/npcx9.dtsi
+++ b/dts/arm/nuvoton/npcx9.dtsi
@@ -29,6 +29,8 @@
 			   &alta_no_peci_en
 			   &altd_npsl_in1_sl
 			   &altd_npsl_in2_sl
+			   &altd_psl_in3_sl
+			   &altd_psl_in4_sl
 			   &alt7_no_ksi0_sl
 			   &alt7_no_ksi1_sl
 			   &alt7_no_ksi2_sl


### PR DESCRIPTION
PSL_IN pin select register is Vsby power-up reset. When the other
core-domain-reset reset the chip, PSL_IN3/4 don't set to GPIO. This
commit adds PSL_IN3/4 to the pin select list in NPCX devicetree. So
these pins can be set to GPIO when the other core-domain-reset.

Signed-off-by: Wealian Liao <WHLIAO@nuvoton.com>