### PR TITLE
net: socket: packet: Add EtherCAT protocol support

### DIFF
--- a/include/net/ethernet.h
+++ b/include/net/ethernet.h
@@ -65,6 +65,7 @@ struct net_eth_addr {
 #define NET_ETH_PTYPE_PTP		0x88f7
 #define NET_ETH_PTYPE_LLDP		0x88cc
 #define NET_ETH_PTYPE_ALL               0x0003 /* from linux/if_ether.h */
+#define NET_ETH_PTYPE_ECAT		0x88a4
 
 #if !defined(ETH_P_ALL)
 #define ETH_P_ALL	NET_ETH_PTYPE_ALL
@@ -83,6 +84,9 @@ struct net_eth_addr {
 #endif
 #if !defined(ETH_P_TSN)
 #define ETH_P_TSN	NET_ETH_PTYPE_TSN
+#endif
+#if !defined(ETH_P_ECAT)
+#define  ETH_P_ECAT	NET_ETH_PTYPE_ECAT
 #endif
 
 #define NET_ETH_MINIMAL_FRAME_SIZE	60

--- a/subsys/net/lib/sockets/sockets_packet.c
+++ b/subsys/net/lib/sockets/sockets_packet.c
@@ -386,7 +386,8 @@ static const struct socket_op_vtable packet_sock_fd_op_vtable = {
 static bool packet_is_supported(int family, int type, int proto)
 {
 	if (((type == SOCK_RAW) && (proto == ETH_P_ALL)) ||
-		((type == SOCK_RAW) && (proto == IPPROTO_RAW)) ||
+	    ((type == SOCK_RAW) && (proto == IPPROTO_RAW)) ||
+	    ((type == SOCK_RAW) && (proto == ETH_P_ECAT)) ||
 	    ((type == SOCK_DGRAM) && (proto > 0))) {
 		return true;
 	}


### PR DESCRIPTION
Add EtherCAT protocol support, now applications can
transmit/receive EtherCAT packets via RAW socket.

Signed-off-by: Hou Zhiqiang <Zhiqiang.Hou@nxp.com>