### PR TITLE
drivers: can: deprecate the use of CAN-specific error return values

### DIFF
--- a/doc/reference/networking/can_api.rst
+++ b/doc/reference/networking/can_api.rst
@@ -164,7 +164,7 @@ a mailbox. When a transmitting mailbox is assigned, sending cannot be canceled.
   can_dev = device_get_binding("CAN_0");
 
   ret = can_send(can_dev, &frame, K_MSEC(100), NULL, NULL);
-  if (ret != CAN_TX_OK) {
+  if (ret != 0) {
           LOG_ERR("Sending failed [%d]", ret);
   }
 

--- a/drivers/can/can_loopback.c
+++ b/drivers/can/can_loopback.c
@@ -73,7 +73,7 @@ void tx_thread(void *data_arg, void *arg2, void *arg3)
 		if (!frame.cb) {
 			k_sem_give(frame.tx_compl);
 		} else {
-			frame.cb(CAN_TX_OK, frame.cb_arg);
+			frame.cb(0, frame.cb_arg);
 		}
 	}
 }
@@ -96,7 +96,7 @@ int can_loopback_send(const struct device *dev,
 
 	if (frame->dlc > CAN_MAX_DLC) {
 		LOG_ERR("DLC of %d exceeds maximum (%d)", frame->dlc, CAN_MAX_DLC);
-		return CAN_TX_EINVAL;
+		return -EINVAL;
 	}
 
 	if (!data->loopback) {
@@ -118,7 +118,7 @@ int can_loopback_send(const struct device *dev,
 		k_sem_take(&tx_sem, K_FOREVER);
 	}
 
-	return  ret ? CAN_TIMEOUT : CAN_TX_OK;
+	return  ret ? -EAGAIN : 0;
 }
 
 
@@ -130,7 +130,7 @@ static inline int get_free_filter(struct can_loopback_filter *filters)
 		}
 	}
 
-	return CAN_NO_FREE_FILTER;
+	return -ENOSPC;
 }
 
 int can_loopback_attach_isr(const struct device *dev, can_rx_callback_t isr,

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -34,7 +34,7 @@ static int can_exit_sleep_mode(struct can_mcan_reg *can)
 		if (k_cycle_get_32() - start_time >
 			k_ms_to_cyc_ceil32(CAN_INIT_TIMEOUT)) {
 			can->cccr |= CAN_MCAN_CCCR_CSR;
-			return CAN_TIMEOUT;
+			return -EAGAIN;
 		}
 	}
 
@@ -51,7 +51,7 @@ static int can_enter_init_mode(struct can_mcan_reg  *can, k_timeout_t timeout)
 	while ((can->cccr & CAN_MCAN_CCCR_INIT) == 0U) {
 		if (k_uptime_ticks() - start_time > timeout.ticks) {
 			can->cccr &= ~CAN_MCAN_CCCR_INIT;
-			return CAN_TIMEOUT;
+			return -EAGAIN;
 		}
 	}
 
@@ -67,7 +67,7 @@ static int can_leave_init_mode(struct can_mcan_reg  *can, k_timeout_t timeout)
 
 	while ((can->cccr & CAN_MCAN_CCCR_INIT) != 0U) {
 		if (k_uptime_ticks() - start_time > timeout.ticks) {
-			return CAN_TIMEOUT;
+			return -EAGAIN;
 		}
 	}
 
@@ -431,7 +431,7 @@ static void can_mcan_tc_event_handler(struct can_mcan_reg *can,
 		if (tx_cb == NULL) {
 			k_sem_give(&data->tx_fin_sem[tx_idx]);
 		} else {
-			tx_cb(CAN_TX_OK, data->tx_fin_cb_arg[tx_idx]);
+			tx_cb(0, data->tx_fin_cb_arg[tx_idx]);
 		}
 	}
 }
@@ -658,21 +658,21 @@ int can_mcan_send(const struct can_mcan_config *cfg,
 	if (data_length > sizeof(frame->data)) {
 		LOG_ERR("data length (%zu) > max frame data length (%zu)",
 			data_length, sizeof(frame->data));
-		return CAN_TX_EINVAL;
+		return -EINVAL;
 	}
 
 	if (frame->fd != 1 && frame->dlc > MCAN_MAX_DLC) {
 		LOG_ERR("DLC of %d without fd flag set.", frame->dlc);
-		return CAN_TX_EINVAL;
+		return -EINVAL;
 	}
 
 	if (can->psr & CAN_MCAN_PSR_BO) {
-		return CAN_TX_BUS_OFF;
+		return -ENETDOWN;
 	}
 
 	ret = k_sem_take(&data->tx_sem, timeout);
 	if (ret != 0) {
-		return CAN_TIMEOUT;
+		return -EAGAIN;
 	}
 
 	__ASSERT_NO_MSG((can->txfqs & CAN_MCAN_TXFQS_TFQF) !=
@@ -715,7 +715,7 @@ int can_mcan_send(const struct can_mcan_config *cfg,
 		k_sem_take(&data->tx_fin_sem[put_idx], K_FOREVER);
 	}
 
-	return CAN_TX_OK;
+	return 0;
 }
 
 static int can_mcan_get_free_std(volatile struct can_mcan_std_filter *filters)
@@ -726,7 +726,7 @@ static int can_mcan_get_free_std(volatile struct can_mcan_std_filter *filters)
 		}
 	}
 
-	return CAN_NO_FREE_FILTER;
+	return -ENOSPC;
 }
 
 /* Use masked configuration only for simplicity. If someone needs more than
@@ -749,9 +749,9 @@ int can_mcan_attach_std(struct can_mcan_data *data,
 	k_mutex_lock(&data->inst_mutex, K_FOREVER);
 	filter_nr = can_mcan_get_free_std(msg_ram->std_filt);
 
-	if (filter_nr == CAN_NO_FREE_FILTER) {
+	if (filter_nr == -ENOSPC) {
 		LOG_INF("No free standard id filter left");
-		return CAN_NO_FREE_FILTER;
+		return -ENOSPC;
 	}
 
 	/* TODO propper fifo balancing */
@@ -790,7 +790,7 @@ static int can_mcan_get_free_ext(volatile struct can_mcan_ext_filter *filters)
 		}
 	}
 
-	return CAN_NO_FREE_FILTER;
+	return -ENOSPC;
 }
 
 static int can_mcan_attach_ext(struct can_mcan_data *data,
@@ -808,9 +808,9 @@ static int can_mcan_attach_ext(struct can_mcan_data *data,
 	k_mutex_lock(&data->inst_mutex, K_FOREVER);
 	filter_nr = can_mcan_get_free_ext(msg_ram->ext_filt);
 
-	if (filter_nr == CAN_NO_FREE_FILTER) {
+	if (filter_nr == -ENOSPC) {
 		LOG_INF("No free extender id filter left");
-		return CAN_NO_FREE_FILTER;
+		return -ENOSPC;
 	}
 
 	/* TODO propper fifo balancing */
@@ -861,7 +861,7 @@ int can_mcan_attach_isr(struct can_mcan_data *data,
 		filter_nr += NUM_STD_FILTER_DATA;
 	}
 
-	if (filter_nr == CAN_NO_FREE_FILTER) {
+	if (filter_nr == -ENOSPC) {
 		LOG_INF("No free filter left");
 	}
 

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -470,11 +470,11 @@ static int mcp2515_send(const struct device *dev,
 	if (frame->dlc > CAN_MAX_DLC) {
 		LOG_ERR("DLC of %d exceeds maximum (%d)",
 			frame->dlc, CAN_MAX_DLC);
-		return CAN_TX_EINVAL;
+		return -EINVAL;
 	}
 
 	if (k_sem_take(&dev_data->tx_sem, timeout) != 0) {
-		return CAN_TIMEOUT;
+		return -EAGAIN;
 	}
 
 	k_mutex_lock(&dev_data->mutex, K_FOREVER);
@@ -491,7 +491,7 @@ static int mcp2515_send(const struct device *dev,
 
 	if (tx_idx == MCP2515_TX_CNT) {
 		LOG_WRN("no free tx slot available");
-		return CAN_TX_ERR;
+		return -EIO;
 	}
 
 	dev_data->tx_cb[tx_idx].cb = callback;
@@ -545,7 +545,7 @@ static int mcp2515_attach_isr(const struct device *dev,
 		dev_data->cb_arg[filter_idx] = cb_arg;
 
 	} else {
-		filter_idx = CAN_NO_FREE_FILTER;
+		filter_idx = -ENOSPC;
 	}
 
 	k_mutex_unlock(&dev_data->mutex);

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -328,7 +328,7 @@ static int mcux_flexcan_send(const struct device *dev,
 
 	if (frame->dlc > CAN_MAX_DLC) {
 		LOG_ERR("DLC of %d exceeds maximum (%d)", frame->dlc, CAN_MAX_DLC);
-		return CAN_TX_EINVAL;
+		return -EINVAL;
 	}
 
 	while (true) {
@@ -342,7 +342,7 @@ static int mcux_flexcan_send(const struct device *dev,
 		}
 
 		if (k_sem_take(&data->tx_allocs_sem, timeout) != 0) {
-			return CAN_TIMEOUT;
+			return -EAGAIN;
 		}
 	}
 
@@ -355,7 +355,7 @@ static int mcux_flexcan_send(const struct device *dev,
 	status = FLEXCAN_TransferSendNonBlocking(config->base, &data->handle,
 						 &xfer);
 	if (status != kStatus_Success) {
-		return CAN_TX_ERR;
+		return -EIO;
 	}
 
 	if (callback == NULL) {
@@ -363,7 +363,7 @@ static int mcux_flexcan_send(const struct device *dev,
 		return data->tx_cbs[alloc].status;
 	}
 
-	return CAN_TX_OK;
+	return 0;
 }
 
 static int mcux_flexcan_attach_isr(const struct device *dev,
@@ -376,7 +376,7 @@ static int mcux_flexcan_attach_isr(const struct device *dev,
 	flexcan_mb_transfer_t xfer;
 	status_t status;
 	uint32_t mask;
-	int alloc = CAN_NO_FREE_FILTER;
+	int alloc = -ENOSPC;
 	int i;
 
 	__ASSERT_NO_MSG(isr);
@@ -391,7 +391,7 @@ static int mcux_flexcan_attach_isr(const struct device *dev,
 		}
 	}
 
-	if (alloc == CAN_NO_FREE_FILTER) {
+	if (alloc == -ENOSPC) {
 		return alloc;
 	}
 
@@ -414,7 +414,7 @@ static int mcux_flexcan_attach_isr(const struct device *dev,
 	if (status != kStatus_Success) {
 		LOG_ERR("Failed to start rx for filter id %d (err = %d)",
 			alloc, status);
-		alloc = CAN_NO_FREE_FILTER;
+		alloc = -ENOSPC;
 	}
 
 	k_mutex_unlock(&data->rx_mutex);
@@ -473,7 +473,7 @@ int mcux_flexcan_recover(const struct device *dev, k_timeout_t timeout)
 		while (mcux_flexcan_get_state(dev, NULL) == CAN_BUS_OFF) {
 			if (!K_TIMEOUT_EQ(timeout, K_FOREVER) &&
 			    k_uptime_ticks() - start_time >= timeout.ticks) {
-				ret = CAN_TIMEOUT;
+				ret = -EAGAIN;
 			}
 		}
 	}
@@ -518,7 +518,7 @@ static inline void mcux_flexcan_transfer_error_status(const struct device *dev,
 	const struct mcux_flexcan_config *config = dev->config;
 	struct mcux_flexcan_data *data = dev->data;
 	can_tx_callback_t function;
-	int status = CAN_TX_OK;
+	int status = 0;
 	void *arg;
 	int alloc;
 	enum can_state state;
@@ -526,14 +526,14 @@ static inline void mcux_flexcan_transfer_error_status(const struct device *dev,
 
 	if (error & CAN_ESR1_FLTCONF(2)) {
 		LOG_DBG("Tx bus off (error 0x%08llx)", error);
-		status = CAN_TX_BUS_OFF;
+		status = -ENETDOWN;
 	} else if ((error & kFLEXCAN_Bit0Error) ||
 		   (error & kFLEXCAN_Bit1Error)) {
 		LOG_DBG("TX arbitration lost (error 0x%08llx)", error);
-		status = CAN_TX_ARB_LOST;
+		status = -EBUSY;
 	} else if (error & kFLEXCAN_AckError) {
 		LOG_DBG("TX no ACK received (error 0x%08llx)", error);
-		status = CAN_TX_ERR;
+		status = -EIO;
 	} else if (error & kFLEXCAN_StuffingError) {
 		LOG_DBG("RX stuffing error (error 0x%08llx)", error);
 	} else if (error & kFLEXCAN_FormError) {
@@ -552,7 +552,7 @@ static inline void mcux_flexcan_transfer_error_status(const struct device *dev,
 		}
 	}
 
-	if (status == CAN_TX_OK) {
+	if (status == 0) {
 		/*
 		 * Error/status is not TX related. No further action
 		 * required.
@@ -605,9 +605,9 @@ static inline void mcux_flexcan_transfer_tx_idle(const struct device *dev,
 
 	if (atomic_test_and_clear_bit(data->tx_allocs, alloc)) {
 		if (function != NULL) {
-			function(CAN_TX_OK, arg);
+			function(0, arg);
 		} else {
-			data->tx_cbs[alloc].status = CAN_TX_OK;
+			data->tx_cbs[alloc].status = 0;
 			k_sem_give(&data->tx_cbs[alloc].done);
 		}
 		k_sem_give(&data->tx_allocs_sem);

--- a/drivers/can/can_shell.c
+++ b/drivers/can/can_shell.c
@@ -371,7 +371,7 @@ static int cmd_attach(const struct shell *shell, size_t argc, char **argv)
 	ret = can_attach_workq(can_dev, &k_sys_work_q, &work, print_frame,
 			       (void *)shell, &filter);
 	if (ret < 0) {
-		if (ret == CAN_NO_FREE_FILTER) {
+		if (ret == -ENOSPC) {
 			shell_error(shell, "Can't attach, no free filter left");
 		} else {
 			shell_error(shell, "Failed to attach filter [%d]", ret);

--- a/drivers/can/socket_can_generic.h
+++ b/drivers/can/socket_can_generic.h
@@ -95,7 +95,7 @@ static inline int socket_can_setsockopt(const struct device *dev, void *obj,
 
 	ret = can_attach_msgq(socket_context->can_dev, socket_context->msgq,
 			      optval);
-	if (ret == CAN_NO_FREE_FILTER) {
+	if (ret == -ENOSPC) {
 		errno = ENOSPC;
 		return -1;
 	}

--- a/include/drivers/can.h
+++ b/include/drivers/can.h
@@ -88,13 +88,13 @@ extern "C" {
  * @brief Defines the mode of the CAN controller
  */
 enum can_mode {
-	/* Normal mode. */
+	/** Normal mode. */
 	CAN_NORMAL_MODE,
-	/* Controller is not allowed to send dominant bits. */
+	/** Controller is not allowed to send dominant bits. */
 	CAN_SILENT_MODE,
-	/* Controller is in loopback mode (receives own frames). */
+	/** Controller is in loopback mode (receives own frames). */
 	CAN_LOOPBACK_MODE,
-	/* Combination of loopback and silent modes. */
+	/** Combination of loopback and silent modes. */
 	CAN_SILENT_LOOPBACK_MODE
 };
 

--- a/include/drivers/can.h
+++ b/include/drivers/can.h
@@ -85,40 +85,6 @@ extern "C" {
 /** @} */
 
 /**
- * @name CAN specific error codes
- *
- * The `CAN_TX_*` error codes are used for CAN specific error return codes from
- * @a can_send() and for `error_flags` values in @a can_tx_callback_t().
- *
- * `CAN_NO_FREE_FILTER` is returned by `can_attach_*()` if no free filters are
- * available. `CAN_TIMEOUT` indicates that @a can_recover() timed out.
- *
- * @warning These definitions are deprecated. Use the corresponding errno
- * definitions instead.
- *
- * @{
- */
-
-/** Transmitted successfully. */
-#define CAN_TX_OK          (0)          __DEPRECATED_MACRO
-/** General transmit error. */
-#define CAN_TX_ERR         (-EIO)       __DEPRECATED_MACRO
-/** Bus arbitration lost during transmission. */
-#define CAN_TX_ARB_LOST    (-EBUSY)     __DEPRECATED_MACRO
-/** CAN controller is in bus off state. */
-#define CAN_TX_BUS_OFF     (-ENETDOWN)  __DEPRECATED_MACRO
-/** Unknown error. */
-#define CAN_TX_UNKNOWN     (CAN_TX_ERR) __DEPRECATED_MACRO
-/** Invalid parameter. */
-#define CAN_TX_EINVAL      (-EINVAL)    __DEPRECATED_MACRO
-/** No free filters available. */
-#define CAN_NO_FREE_FILTER (-ENOSPC)    __DEPRECATED_MACRO
-/** Operation timed out. */
-#define CAN_TIMEOUT        (-EAGAIN)    __DEPRECATED_MACRO
-
-/** @} */
-
-/**
  * @brief Defines the mode of the CAN controller
  */
 enum can_mode {
@@ -648,34 +614,6 @@ static inline int can_set_bitrate(const struct device *dev,
 #endif /* !CONFIG_CAN_FD_MODE */
 }
 
-/**
- * @brief Configure operation of a host controller.
- *
- * @warning This function is deprecated. Use @a can_set_bitrate() and @a
- * can_set_mode() instead.
- *
- * @param dev Pointer to the device structure for the driver instance.
- * @param mode Operation mode.
- * @param bitrate bus-speed in Baud/s.
- *
- * @retval 0 If successful.
- * @retval -EIO General input/output error, failed to configure device.
- */
-__deprecated static inline int can_configure(const struct device *dev, enum can_mode mode,
-					     uint32_t bitrate)
-{
-	int err;
-
-	if (bitrate > 0) {
-		err = can_set_bitrate(dev, bitrate, bitrate);
-		if (err != 0) {
-			return err;
-		}
-	}
-
-	return can_set_mode(dev, mode);
-}
-
 /** @} */
 
 /**
@@ -1161,6 +1099,75 @@ static inline void can_copy_zfilter_to_filter(const struct zcan_filter *zfilter,
 }
 
 /** @} */
+
+/**
+ * @cond INTERNAL_HIDDEN
+ * Deprecated APIs
+ */
+
+/**
+ * @name CAN specific error codes
+ *
+ * The `CAN_TX_*` error codes are used for CAN specific error return codes from
+ * @a can_send() and for `error_flags` values in @a can_tx_callback_t().
+ *
+ * `CAN_NO_FREE_FILTER` is returned by `can_attach_*()` if no free filters are
+ * available. `CAN_TIMEOUT` indicates that @a can_recover() timed out.
+ *
+ * @warning These definitions are deprecated. Use the corresponding errno
+ * definitions instead.
+ *
+ * @{
+ */
+
+/** Transmitted successfully. */
+#define CAN_TX_OK          (0)          __DEPRECATED_MACRO
+/** General transmit error. */
+#define CAN_TX_ERR         (-EIO)       __DEPRECATED_MACRO
+/** Bus arbitration lost during transmission. */
+#define CAN_TX_ARB_LOST    (-EBUSY)     __DEPRECATED_MACRO
+/** CAN controller is in bus off state. */
+#define CAN_TX_BUS_OFF     (-ENETDOWN)  __DEPRECATED_MACRO
+/** Unknown error. */
+#define CAN_TX_UNKNOWN     (CAN_TX_ERR) __DEPRECATED_MACRO
+/** Invalid parameter. */
+#define CAN_TX_EINVAL      (-EINVAL)    __DEPRECATED_MACRO
+/** No free filters available. */
+#define CAN_NO_FREE_FILTER (-ENOSPC)    __DEPRECATED_MACRO
+/** Operation timed out. */
+#define CAN_TIMEOUT        (-EAGAIN)    __DEPRECATED_MACRO
+
+/** @} */
+
+/**
+ * @brief Configure operation of a host controller.
+ *
+ * @warning This function is deprecated. Use @a can_set_bitrate() and @a
+ * can_set_mode() instead.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param mode Operation mode.
+ * @param bitrate bus-speed in Baud/s.
+ *
+ * @retval 0 If successful.
+ * @retval -EIO General input/output error, failed to configure device.
+ */
+__deprecated static inline int can_configure(const struct device *dev, enum can_mode mode,
+					     uint32_t bitrate)
+{
+	int err;
+
+	if (bitrate > 0) {
+		err = can_set_bitrate(dev, bitrate, bitrate);
+		if (err != 0) {
+			return err;
+		}
+	}
+
+	return can_set_mode(dev, mode);
+}
+
+/** @endcond */
 
 /**
  * @}

--- a/include/drivers/can.h
+++ b/include/drivers/can.h
@@ -93,25 +93,28 @@ extern "C" {
  * `CAN_NO_FREE_FILTER` is returned by `can_attach_*()` if no free filters are
  * available. `CAN_TIMEOUT` indicates that @a can_recover() timed out.
  *
+ * @warning These definitions are deprecated. Use the corresponding errno
+ * definitions instead.
+ *
  * @{
  */
 
 /** Transmitted successfully. */
-#define CAN_TX_OK          (0)
+#define CAN_TX_OK          (0)          __DEPRECATED_MACRO
 /** General transmit error. */
-#define CAN_TX_ERR         (-2)
+#define CAN_TX_ERR         (-EIO)       __DEPRECATED_MACRO
 /** Bus arbitration lost during transmission. */
-#define CAN_TX_ARB_LOST    (-3)
+#define CAN_TX_ARB_LOST    (-EBUSY)     __DEPRECATED_MACRO
 /** CAN controller is in bus off state. */
-#define CAN_TX_BUS_OFF     (-4)
+#define CAN_TX_BUS_OFF     (-ENETDOWN)  __DEPRECATED_MACRO
 /** Unknown error. */
-#define CAN_TX_UNKNOWN     (-5)
+#define CAN_TX_UNKNOWN     (CAN_TX_ERR) __DEPRECATED_MACRO
 /** Invalid parameter. */
-#define CAN_TX_EINVAL      (-22)
+#define CAN_TX_EINVAL      (-EINVAL)    __DEPRECATED_MACRO
 /** No free filters available. */
-#define CAN_NO_FREE_FILTER (-1)
+#define CAN_NO_FREE_FILTER (-ENOSPC)    __DEPRECATED_MACRO
 /** Operation timed out. */
-#define CAN_TIMEOUT        (-1)
+#define CAN_TIMEOUT        (-EAGAIN)    __DEPRECATED_MACRO
 
 /** @} */
 
@@ -294,7 +297,8 @@ struct can_timing {
  * @typedef can_tx_callback_t
  * @brief Defines the application callback handler function signature
  *
- * @param error_flags Status of the performed send operation.
+ * @param error_flags Status of the performed send operation. See the list of
+ *                    return values for @a can_send() for value descriptions.
  * @param user_data   User data provided when the frame was sent.
  */
 typedef void (*can_tx_callback_t)(uint32_t error_flags, void *user_data);
@@ -697,8 +701,12 @@ __deprecated static inline int can_configure(const struct device *dev, enum can_
  *                  if called from user mode.
  * @param user_data User data to pass to callback function.
  *
- * @retval 0 If successful.
- * @retval CAN_TX_* on failure.
+ * @retval 0 if successful.
+ * @retval -EINVAL if an invalid parameter was passed to the function.
+ * @retval -ENETDOWN if the CAN controller is in bus-off state.
+ * @retval -EBUSY if CAN bus arbitration was lost.
+ * @retval -EIO if a general transmit error occurred.
+ * @retval -EAGAIN on timeout.
  */
 __syscall int can_send(const struct device *dev, const struct zcan_frame *frame,
 		       k_timeout_t timeout, can_tx_callback_t callback,
@@ -727,10 +735,12 @@ static inline int z_impl_can_send(const struct device *dev, const struct zcan_fr
  * @param rtr     Write as data frame or Remote Transmission Request (RTR) frame.
  * @param timeout Timeout waiting for an empty TX mailbox or ``K_FOREVER``.
  *
- * @retval 0 If successful.
- * @retval -EIO General input/output error.
- * @retval -EINVAL if length > 8.
- * @retval CAN_TX_* on failure.
+ * @retval 0 if successful.
+ * @retval -EINVAL if an invalid parameter was passed to the function.
+ * @retval -ENETDOWN if the CAN controller is in bus-off state.
+ * @retval -EBUSY if CAN bus arbitration was lost.
+ * @retval -EIO if a general transmit error occurred.
+ * @retval -EAGAIN on timeout.
  */
 static inline int can_write(const struct device *dev, const uint8_t *data, uint8_t length,
 			    uint32_t id, enum can_rtr rtr, k_timeout_t timeout)
@@ -783,7 +793,7 @@ static inline int can_write(const struct device *dev, const uint8_t *data, uint8
  * @param filter    Pointer to a @a zcan_filter structure defining the filter.
  *
  * @retval filter_id on success.
- * @retval CAN_NO_FREE_FILTER if there are no free filters.
+ * @retval -ENOSPC if there are no free filters.
  */
 static inline int can_attach_isr(const struct device *dev, can_rx_callback_t callback,
 				 void *user_data, const struct zcan_filter *filter)
@@ -818,7 +828,7 @@ static inline int can_attach_isr(const struct device *dev, can_rx_callback_t cal
  * @param filter    Pointer to a @a zcan_filter structure defining the filter.
  *
  * @retval filter_id on success.
- * @retval CAN_NO_FREE_FILTER if there are no free filters.
+ * @retval -ENOSPC if there are no free filters.
  */
 int can_attach_workq(const struct device *dev, struct k_work_q  *work_q,
 		     struct zcan_work *work, can_rx_callback_t callback, void *user_data,
@@ -855,7 +865,7 @@ int can_attach_workq(const struct device *dev, struct k_work_q  *work_q,
  * @param filter Pointer to a @a zcan_filter structure defining the filter.
  *
  * @retval filter_id on success.
- * @retval CAN_NO_FREE_FILTER if there are no free filters.
+ * @retval -ENOSPC if there are no free filters.
  */
 __syscall int can_attach_msgq(const struct device *dev, struct k_msgq *msg_q,
 			      const struct zcan_filter *filter);
@@ -945,7 +955,7 @@ static inline enum can_state z_impl_can_get_state(const struct device *dev,
  * @param timeout Timeout for waiting for the recovery or ``K_FOREVER``.
  *
  * @retval 0 on success.
- * @retval CAN_TIMEOUT on timeout.
+ * @retval -EAGAIN on timeout.
  */
 #if !defined(CONFIG_CAN_AUTO_BUS_OFF_RECOVERY) || defined(__DOXYGEN__)
 __syscall int can_recover(const struct device *dev, k_timeout_t timeout);

--- a/modules/canopennode/CO_driver.c
+++ b/modules/canopennode/CO_driver.c
@@ -70,10 +70,10 @@ static void canopen_detach_all_rx_filters(CO_CANmodule_t *CANmodule)
 	}
 
 	for (i = 0U; i < CANmodule->rx_size; i++) {
-		if (CANmodule->rx_array[i].filter_id != CAN_NO_FREE_FILTER) {
+		if (CANmodule->rx_array[i].filter_id != -ENOSPC) {
 			can_detach(CANmodule->dev,
 				   CANmodule->rx_array[i].filter_id);
-			CANmodule->rx_array[i].filter_id = CAN_NO_FREE_FILTER;
+			CANmodule->rx_array[i].filter_id = -ENOSPC;
 		}
 	}
 }
@@ -103,7 +103,7 @@ static void canopen_tx_isr_callback(uint32_t error_flags, void *arg)
 		return;
 	}
 
-	if (error_flags == CAN_TX_OK) {
+	if (error_flags == 0) {
 		CANmodule->first_tx_msg = false;
 	}
 
@@ -133,9 +133,9 @@ static void canopen_tx_retry(struct k_work *item)
 
 			err = can_send(CANmodule->dev, &msg, K_NO_WAIT,
 				       canopen_tx_isr_callback, CANmodule);
-			if (err == CAN_TIMEOUT) {
+			if (err == -EAGAIN) {
 				break;
-			} else if (err != CAN_TX_OK) {
+			} else if (err != 0) {
 				LOG_ERR("failed to send CAN frame (err %d)",
 					err);
 				CO_errorReport(CANmodule->em,
@@ -210,7 +210,7 @@ CO_ReturnError_t CO_CANmodule_init(CO_CANmodule_t *CANmodule,
 	for (i = 0U; i < rxSize; i++) {
 		rxArray[i].ident = 0U;
 		rxArray[i].pFunct = NULL;
-		rxArray[i].filter_id = CAN_NO_FREE_FILTER;
+		rxArray[i].filter_id = -ENOSPC;
 	}
 
 	for (i = 0U; i < txSize; i++) {
@@ -284,14 +284,14 @@ CO_ReturnError_t CO_CANrxBufferInit(CO_CANmodule_t *CANmodule, uint16_t index,
 	filter.rtr = (rtr ? 1 : 0);
 	filter.rtr_mask = 1;
 
-	if (buffer->filter_id != CAN_NO_FREE_FILTER) {
+	if (buffer->filter_id != -ENOSPC) {
 		can_detach(CANmodule->dev, buffer->filter_id);
 	}
 
 	buffer->filter_id = can_attach_isr(CANmodule->dev,
 					   canopen_rx_isr_callback,
 					   buffer, &filter);
-	if (buffer->filter_id == CAN_NO_FREE_FILTER) {
+	if (buffer->filter_id == -ENOSPC) {
 		LOG_ERR("failed to attach CAN rx isr, no free filter");
 		CO_errorReport(CANmodule->em, CO_EM_MEMORY_ALLOCATION_ERROR,
 			       CO_EMC_SOFTWARE_INTERNAL, 0);
@@ -357,9 +357,9 @@ CO_ReturnError_t CO_CANsend(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer)
 
 	err = can_send(CANmodule->dev, &msg, K_NO_WAIT, canopen_tx_isr_callback,
 		       CANmodule);
-	if (err == CAN_TIMEOUT) {
+	if (err == -EAGAIN) {
 		buffer->bufferFull = true;
-	} else if (err != CAN_TX_OK) {
+	} else if (err != 0) {
 		LOG_ERR("failed to send CAN frame (err %d)", err);
 		CO_errorReport(CANmodule->em, CO_EM_GENERIC_SOFTWARE_ERROR,
 			       CO_EMC_COMMUNICATION, 0);

--- a/samples/drivers/can/src/main.c
+++ b/samples/drivers/can/src/main.c
@@ -218,7 +218,7 @@ void main(void)
 
 	ret = can_attach_workq(can_dev, &k_sys_work_q, &rx_work, change_led,
 			       NULL, &change_led_filter);
-	if (ret == CAN_NO_FREE_FILTER) {
+	if (ret == -ENOSPC) {
 		printk("Error, no filter available!\n");
 		return;
 	}

--- a/subsys/canbus/isotp/isotp.c
+++ b/subsys/canbus/isotp/isotp.c
@@ -969,7 +969,7 @@ static inline int send_cf(struct isotp_send_ctx *ctx)
 
 	ret = can_send(ctx->can_dev, &frame, K_MSEC(ISOTP_A),
 		       send_can_tx_isr, ctx);
-	if (ret == CAN_TX_OK) {
+	if (ret == 0) {
 		ctx->sn++;
 		pull_data_ctx(ctx, len);
 		ctx->bs--;
@@ -1051,7 +1051,7 @@ static void send_state_machine(struct isotp_send_ctx *ctx)
 
 			if (ret < 0) {
 				LOG_ERR("Failed to send CF");
-				send_report_error(ctx, ret == CAN_TIMEOUT ?
+				send_report_error(ctx, ret == -EAGAIN ?
 						ISOTP_N_TIMEOUT_A :
 						ISOTP_N_ERROR);
 				break;
@@ -1181,7 +1181,7 @@ static int send(struct isotp_send_ctx *ctx, const struct device *can_dev,
 		ret = send_sf(ctx);
 		ctx->state = ISOTP_TX_WAIT_FIN;
 		if (ret) {
-			return ret == CAN_TIMEOUT ?
+			return ret == -EAGAIN ?
 			       ISOTP_N_TIMEOUT_A : ISOTP_N_ERROR;
 		}
 	}

--- a/tests/drivers/can/api/src/main.c
+++ b/tests/drivers/can/api/src/main.c
@@ -339,9 +339,9 @@ static void send_test_msg(const struct device *can_dev,
 	int ret;
 
 	ret = can_send(can_dev, msg, TEST_SEND_TIMEOUT, NULL, NULL);
-	zassert_not_equal(ret, CAN_TX_ARB_LOST,
+	zassert_not_equal(ret, -EBUSY,
 			  "Arbitration though in loopback mode");
-	zassert_equal(ret, CAN_TX_OK, "Can't send a message. Err: %d", ret);
+	zassert_equal(ret, 0, "Can't send a message. Err: %d", ret);
 }
 
 static void send_test_msg_nowait(const struct device *can_dev,
@@ -351,9 +351,9 @@ static void send_test_msg_nowait(const struct device *can_dev,
 	int ret;
 	ret = can_send(can_dev, msg, TEST_SEND_TIMEOUT, cb,
 			(struct zcan_frame *)msg);
-	zassert_not_equal(ret, CAN_TX_ARB_LOST,
+	zassert_not_equal(ret, -EBUSY,
 			  "Arbitration though in loopback mode");
-	zassert_equal(ret, CAN_TX_OK, "Can't send a message. Err: %d", ret);
+	zassert_equal(ret, 0, "Can't send a message. Err: %d", ret);
 }
 
 static inline int attach_msgq(const struct device *can_dev,
@@ -362,7 +362,7 @@ static inline int attach_msgq(const struct device *can_dev,
 	int filter_id;
 
 	filter_id = can_attach_msgq(can_dev, &can_msgq, filter);
-	zassert_not_equal(filter_id, CAN_NO_FREE_FILTER,
+	zassert_not_equal(filter_id, -ENOSPC,
 			  "Filter full even for a single one");
 	zassert_true((filter_id >= 0), "Negative filter number");
 
@@ -379,7 +379,7 @@ static inline int attach_workq(const struct device *can_dev,
 	filter_id  = can_attach_workq(can_dev, &k_sys_work_q, work, cb,
 				     (void *)filter, filter);
 
-	zassert_not_equal(filter_id, CAN_NO_FREE_FILTER,
+	zassert_not_equal(filter_id, -ENOSPC,
 			  "Filter full even for a single one");
 	zassert_true((filter_id >= 0), "Negative filter number");
 
@@ -395,7 +395,7 @@ static inline int attach_isr(const struct device *can_dev,
 	k_sem_reset(&rx_isr_sem);
 
 	filter_id = can_attach_isr(can_dev, isr, (void *)filter, filter);
-	zassert_not_equal(filter_id, CAN_NO_FREE_FILTER,
+	zassert_not_equal(filter_id, -ENOSPC,
 			  "Filter full even for a single one");
 	zassert_true((filter_id >= 0), "Negative filter number");
 
@@ -713,7 +713,7 @@ static void test_send_receive_wrong_id(void)
 }
 
 /*
- * Check if a call with dlc > CAN_MAX_DLC returns CAN_TX_EINVAL
+ * Check if a call with dlc > CAN_MAX_DLC returns -EINVAL
  */
 static void test_send_invalid_dlc(void)
 {
@@ -723,8 +723,8 @@ static void test_send_invalid_dlc(void)
 	frame.dlc = CAN_MAX_DLC + 1;
 
 	ret = can_send(can_dev, &frame, TEST_SEND_TIMEOUT, tx_std_isr_1, NULL);
-	zassert_equal(ret, CAN_TX_EINVAL,
-		      "ret [%d] not equal to %d", ret, CAN_TX_EINVAL);
+	zassert_equal(ret, -EINVAL,
+		      "ret [%d] not equal to %d", ret, -EINVAL);
 }
 
 void test_main(void)

--- a/tests/drivers/can/canfd/src/main.c
+++ b/tests/drivers/can/canfd/src/main.c
@@ -203,9 +203,9 @@ static void send_test_msg(const struct device *can_dev,
 	int ret;
 
 	ret = can_send(can_dev, msg, TEST_SEND_TIMEOUT, NULL, NULL);
-	zassert_not_equal(ret, CAN_TX_ARB_LOST,
+	zassert_not_equal(ret, -EBUSY,
 			  "Arbitration though in loopback mode");
-	zassert_equal(ret, CAN_TX_OK, "Can't send a message. Err: %d", ret);
+	zassert_equal(ret, 0, "Can't send a message. Err: %d", ret);
 }
 
 static void send_test_msg_nowait(const struct device *can_dev,
@@ -216,9 +216,9 @@ static void send_test_msg_nowait(const struct device *can_dev,
 
 	ret = can_send(can_dev, msg, TEST_SEND_TIMEOUT, cb,
 			(struct zcan_frame *)msg);
-	zassert_not_equal(ret, CAN_TX_ARB_LOST,
+	zassert_not_equal(ret, -EBUSY,
 			  "Arbitration though in loopback mode");
-	zassert_equal(ret, CAN_TX_OK, "Can't send a message. Err: %d", ret);
+	zassert_equal(ret, 0, "Can't send a message. Err: %d", ret);
 }
 
 static inline int attach_msgq(const struct device *can_dev,
@@ -227,7 +227,7 @@ static inline int attach_msgq(const struct device *can_dev,
 	int filter_id;
 
 	filter_id = can_attach_msgq(can_dev, &can_msgq, filter);
-	zassert_not_equal(filter_id, CAN_NO_FREE_FILTER,
+	zassert_not_equal(filter_id, -ENOSPC,
 			  "Filter full even for a single one");
 	zassert_true((filter_id >= 0), "Negative filter number");
 
@@ -244,7 +244,7 @@ static inline int attach_workq(const struct device *can_dev,
 	filter_id  = can_attach_workq(can_dev, &k_sys_work_q, work, cb,
 				     (void *)filter, filter);
 
-	zassert_not_equal(filter_id, CAN_NO_FREE_FILTER,
+	zassert_not_equal(filter_id, -ENOSPC,
 			  "Filter full even for a single one");
 	zassert_true((filter_id >= 0), "Negative filter number");
 
@@ -260,7 +260,7 @@ static inline int attach_isr(const struct device *can_dev,
 	k_sem_reset(&rx_isr_sem);
 
 	filter_id = can_attach_isr(can_dev, isr, (void *)filter, filter);
-	zassert_not_equal(filter_id, CAN_NO_FREE_FILTER,
+	zassert_not_equal(filter_id, -ENOSPC,
 			  "Filter full even for a single one");
 	zassert_true((filter_id >= 0), "Negative filter number");
 

--- a/tests/drivers/can/stm32/src/main.c
+++ b/tests/drivers/can/stm32/src/main.c
@@ -109,9 +109,9 @@ static void send_test_msg(const struct device *can_dev,
 	int ret;
 
 	ret = can_send(can_dev, msg, TEST_SEND_TIMEOUT, NULL, NULL);
-	zassert_not_equal(ret, CAN_TX_ARB_LOST,
+	zassert_not_equal(ret, -EBUSY,
 			  "Arbitration though in loopback mode");
-	zassert_equal(ret, CAN_TX_OK, "Can't send a message. Err: %d", ret);
+	zassert_equal(ret, 0, "Can't send a message. Err: %d", ret);
 }
 
 /*
@@ -131,18 +131,18 @@ static void test_filter_handling(void)
 	ret = can_set_mode(can_dev, CAN_LOOPBACK_MODE);
 
 	filter_id_1 = can_attach_msgq(can_dev, &can_msgq, &test_ext_masked_filter);
-	zassert_not_equal(filter_id_1, CAN_NO_FREE_FILTER,
+	zassert_not_equal(filter_id_1, -ENOSPC,
 			  "Filter full even for a single one");
 	zassert_true((filter_id_1 >= 0), "Negative filter number");
 
 	filter_id_2 = can_attach_msgq(can_dev, &can_msgq, &test_std_filter);
-	zassert_not_equal(filter_id_2, CAN_NO_FREE_FILTER,
+	zassert_not_equal(filter_id_2, -ENOSPC,
 			  "Filter full when attaching the second one");
 	zassert_true((filter_id_2 >= 0), "Negative filter number");
 
 	can_detach(can_dev, filter_id_1);
 	filter_id_1 = can_attach_msgq(can_dev, &can_msgq, &test_std_some_filter);
-	zassert_not_equal(filter_id_1, CAN_NO_FREE_FILTER,
+	zassert_not_equal(filter_id_1, -ENOSPC,
 			  "Filter full when overriding the first one");
 	zassert_true((filter_id_1 >= 0), "Negative filter number");
 
@@ -157,7 +157,7 @@ static void test_filter_handling(void)
 
 	can_detach(can_dev, filter_id_1);
 	filter_id_1 = can_attach_msgq(can_dev, &can_msgq, &test_ext_filter);
-	zassert_not_equal(filter_id_1, CAN_NO_FREE_FILTER,
+	zassert_not_equal(filter_id_1, -ENOSPC,
 			  "Filter full when overriding the first one");
 	zassert_true((filter_id_1 >= 0), "Negative filter number");
 

--- a/tests/subsys/canbus/isotp/conformance/src/main.c
+++ b/tests/subsys/canbus/isotp/conformance/src/main.c
@@ -250,7 +250,7 @@ static void send_frame_series(struct frame_desired *frames, size_t length,
 		frame.dlc = desired->length;
 		memcpy(frame.data, desired->data, desired->length);
 		ret = can_send(can_dev, &frame, K_MSEC(500), NULL, NULL);
-		zassert_equal(ret, CAN_TX_OK, "Sending msg %d failed.", i);
+		zassert_equal(ret, 0, "Sending msg %d failed.", i);
 		desired++;
 	}
 }
@@ -298,7 +298,7 @@ static int attach_msgq(uint32_t id, uint32_t mask)
 	};
 
 	filter_id = can_attach_msgq(can_dev, &frame_msgq, &filter);
-	zassert_not_equal(filter_id, CAN_NO_FREE_FILTER, "Filter full");
+	zassert_not_equal(filter_id, -ENOSPC, "Filter full");
 	zassert_true((filter_id >= 0), "Negative filter number [%d]",
 		     filter_id);
 


### PR DESCRIPTION
Deprecate the use of CAN-specific error return values and replace them with standard errno values.
    
Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>
