### PR TITLE
doc: guides: tfm: fix documentation build

### DIFF
--- a/doc/guides/tfm/requirements.rst
+++ b/doc/guides/tfm/requirements.rst
@@ -10,8 +10,8 @@ The following are some of the boards that can be used with TF-M:
      - NSPE board name
    * - :ref:`mps2_an521_board`
      - ``mps2_an521_ns`` (qemu supported)
-   * - :ref:`mps2_an547_board`
-     - ``mps2_an547_ns`` (qemu supported)
+   * - :ref:`mps3_an547_board`
+     - ``mps3_an547_ns`` (qemu supported)
    * - :ref:`bl5340_dvk`
      - ``bl5340_dvk_cpuapp_ns``
    * - :ref:`lpcxpresso55s69`


### PR DESCRIPTION
Fix the TF-M requirements documentation build.

Fixes: ee001fa4bbb59f1949ac760f37bd74246868e9dd

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>