### PR TITLE
soc: esp32: gpio: remove pin offset and moves UART pin definitions

### DIFF
--- a/boards/riscv/esp32c3_devkitm/esp32c3_devkitm.dts
+++ b/boards/riscv/esp32c3_devkitm/esp32c3_devkitm.dts
@@ -40,8 +40,8 @@
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;
-	tx-pin = <2>;
-	rx-pin = <3>;
+	tx-pin = <21>;
+	rx-pin = <20>;
 };
 
 &i2c0 {

--- a/boards/xtensa/esp32s2_saola/esp32s2_saola.dts
+++ b/boards/xtensa/esp32s2_saola/esp32s2_saola.dts
@@ -31,8 +31,8 @@
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;
-	rx-pin = <5>;
-	tx-pin = <6>;
+	tx-pin = <43>;
+	rx-pin = <44>;
 };
 
 &gpio0 {

--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -73,20 +73,13 @@ static inline bool gpio_pin_is_output_capable(uint32_t pin)
 	return ((BIT(pin) & SOC_GPIO_VALID_OUTPUT_GPIO_MASK) != 0);
 }
 
-static inline int gpio_get_pin_offset(const struct device *dev)
-{
-	struct gpio_esp32_config *const cfg = DEV_CFG(dev);
-
-	return ((cfg->gpio_port) ? 32 : 0);
-}
-
 static int gpio_esp32_config(const struct device *dev,
 			     gpio_pin_t pin,
 			     gpio_flags_t flags)
 {
 	struct gpio_esp32_config *const cfg = DEV_CFG(dev);
 	struct gpio_esp32_data *data = dev->data;
-	uint32_t io_pin = pin + gpio_get_pin_offset(dev);
+	uint32_t io_pin = (uint32_t) pin;
 	uint32_t key;
 	int ret = 0;
 
@@ -300,7 +293,7 @@ static int gpio_esp32_pin_interrupt_configure(const struct device *port,
 					      enum gpio_int_trig trig)
 {
 	struct gpio_esp32_config *const cfg = DEV_CFG(port);
-	uint32_t io_pin = pin + gpio_get_pin_offset(port);
+	uint32_t io_pin = (uint32_t) pin;
 	int intr_trig_mode = convert_int_type(mode, trig);
 	uint32_t key;
 

--- a/dts/riscv/espressif/esp32c3.dtsi
+++ b/dts/riscv/espressif/esp32c3.dtsi
@@ -116,13 +116,10 @@
 			compatible = "espressif,esp32-uart";
 			reg = <0x60000000 0x400>;
 			label = "UART_0";
+			status = "disabled";
 			interrupts = <UART0_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_UART0_MODULE>;
-			current-speed = <115200>;
-			status = "okay";
-			tx-pin = <21>;
-			rx-pin = <20>;
 		};
 
 		uart1: uart@60010000 {

--- a/dts/xtensa/espressif/esp32s2.dtsi
+++ b/dts/xtensa/espressif/esp32s2.dtsi
@@ -85,13 +85,10 @@
 			compatible = "espressif,esp32-uart";
 			reg = <0x3f400000 0x400>;
 			label = "UART_0";
+			status = "disabled";
 			interrupts = <UART0_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_UART0_MODULE>;
-			current-speed = <115200>;
-			status = "okay";
-			tx-pin = <43>;
-			rx-pin = <44>;
 		};
 
 		uart1: uart@3f410000 {


### PR DESCRIPTION
- Removes pin offset from GPIO driver since Espressif's SoC's pin counting does not wrap up on 32
- Moves UART's pinout definition to board's `.dts`