### PR TITLE
Bluetooth: Mesh: Fix Config/Health Client async API

### DIFF
--- a/include/bluetooth/mesh/cfg_cli.h
+++ b/include/bluetooth/mesh/cfg_cli.h
@@ -56,6 +56,10 @@ int bt_mesh_cfg_node_reset(uint16_t net_idx, uint16_t addr, bool *status);
  *  return the largest page number it supports that is less than the requested
  *  page index. The actual page the device responds with is returned in @c rsp.
  *
+ *  This method can be used asynchronously by setting @p rsp and @p comp
+ *  as NULL. This way the method will not wait for response and will return
+ *  immediately after sending the command.
+ *
  *  @param net_idx Network index to encrypt with.
  *  @param addr    Target node address.
  *  @param page    Composition data page, or 0xff to request the first available
@@ -70,6 +74,10 @@ int bt_mesh_cfg_comp_data_get(uint16_t net_idx, uint16_t addr, uint8_t page,
 
 /** @brief Get the target node's network beacon state.
  *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
  *  @param net_idx Network index to encrypt with.
  *  @param addr    Target node address.
  *  @param status  Status response parameter, returns one of
@@ -81,6 +89,11 @@ int bt_mesh_cfg_comp_data_get(uint16_t net_idx, uint16_t addr, uint8_t page,
 int bt_mesh_cfg_beacon_get(uint16_t net_idx, uint16_t addr, uint8_t *status);
 
 /** @brief             Get the target node's network key refresh phase state.
+ *
+ *  This method can be used asynchronously by setting @p status and @p phase
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
  *  @param net_idx     Network index to encrypt with.
  *  @param addr        Target node address.
  *  @param key_net_idx Network key index.
@@ -93,6 +106,11 @@ int bt_mesh_cfg_krp_get(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
 			uint8_t *status, uint8_t *phase);
 
 /** @brief             Set the target node's network key refresh phase parameters.
+ *
+ *  This method can be used asynchronously by setting @p status and @p phase
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
  *  @param net_idx     Network index to encrypt with.
  *  @param addr        Target node address.
  *  @param key_net_idx Network key index.
@@ -108,6 +126,10 @@ int bt_mesh_cfg_krp_set(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
 
 /** @brief Set the target node's network beacon state.
  *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
  *  @param net_idx Network index to encrypt with.
  *  @param addr    Target node address.
  *  @param val     New network beacon state, should be one of
@@ -122,6 +144,10 @@ int bt_mesh_cfg_beacon_set(uint16_t net_idx, uint16_t addr, uint8_t val, uint8_t
 
 /** @brief Get the target node's Time To Live value.
  *
+ *  This method can be used asynchronously by setting @p ttl
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
  *  @param net_idx Network index to encrypt with.
  *  @param addr    Target node address.
  *  @param ttl     TTL response buffer.
@@ -131,6 +157,10 @@ int bt_mesh_cfg_beacon_set(uint16_t net_idx, uint16_t addr, uint8_t val, uint8_t
 int bt_mesh_cfg_ttl_get(uint16_t net_idx, uint16_t addr, uint8_t *ttl);
 
 /** @brief Set the target node's Time To Live value.
+ *
+ *  This method can be used asynchronously by setting @p ttl
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
  *
  *  @param net_idx Network index to encrypt with.
  *  @param addr    Target node address.
@@ -143,6 +173,10 @@ int bt_mesh_cfg_ttl_set(uint16_t net_idx, uint16_t addr, uint8_t val, uint8_t *t
 
 /** @brief Get the target node's Friend feature status.
  *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
  *  @param net_idx Network index to encrypt with.
  *  @param addr    Target node address.
  *  @param status  Status response parameter. Returns one of
@@ -154,6 +188,10 @@ int bt_mesh_cfg_ttl_set(uint16_t net_idx, uint16_t addr, uint8_t val, uint8_t *t
 int bt_mesh_cfg_friend_get(uint16_t net_idx, uint16_t addr, uint8_t *status);
 
 /** @brief Set the target node's Friend feature state.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
  *
  *  @param net_idx Network index to encrypt with.
  *  @param addr    Target node address.
@@ -170,6 +208,10 @@ int bt_mesh_cfg_friend_set(uint16_t net_idx, uint16_t addr, uint8_t val, uint8_t
 
 /** @brief Get the target node's Proxy feature state.
  *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
  *  @param net_idx Network index to encrypt with.
  *  @param addr    Target node address.
  *  @param status  Status response parameter. Returns one of
@@ -182,6 +224,10 @@ int bt_mesh_cfg_friend_set(uint16_t net_idx, uint16_t addr, uint8_t val, uint8_t
 int bt_mesh_cfg_gatt_proxy_get(uint16_t net_idx, uint16_t addr, uint8_t *status);
 
 /** @brief Set the target node's Proxy feature state.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
  *
  *  @param net_idx Network index to encrypt with.
  *  @param addr    Target node address.
@@ -200,6 +246,10 @@ int bt_mesh_cfg_gatt_proxy_set(uint16_t net_idx, uint16_t addr, uint8_t val,
 
 /** @brief Get the target node's network_transmit state.
  *
+ *  This method can be used asynchronously by setting @p transmit
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
  *  @param net_idx  Network index to encrypt with.
  *  @param addr     Target node address.
  *  @param transmit Network transmit response parameter. Returns the encoded
@@ -212,6 +262,10 @@ int bt_mesh_cfg_net_transmit_get(uint16_t net_idx, uint16_t addr,
 			  uint8_t *transmit);
 
 /** @brief Set the target node's network transmit parameters.
+ *
+ *  This method can be used asynchronously by setting @p transmit
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
  *
  *  @param net_idx    Network index to encrypt with.
  *  @param addr       Target node address.
@@ -226,6 +280,10 @@ int bt_mesh_cfg_net_transmit_set(uint16_t net_idx, uint16_t addr,
 		uint8_t val, uint8_t *transmit);
 
 /** @brief Get the target node's Relay feature state.
+ *
+ *  This method can be used asynchronously by setting @p status and @p transmit
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
  *
  *  @param net_idx  Network index to encrypt with.
  *  @param addr     Target node address.
@@ -242,6 +300,10 @@ int bt_mesh_cfg_relay_get(uint16_t net_idx, uint16_t addr, uint8_t *status,
 			  uint8_t *transmit);
 
 /** @brief Set the target node's Relay parameters.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  and @p transmit as NULL. This way the method will not wait for
+ *  response and will return immediately after sending the command.
  *
  *  @param net_idx      Network index to encrypt with.
  *  @param addr         Target node address.
@@ -265,6 +327,10 @@ int bt_mesh_cfg_relay_set(uint16_t net_idx, uint16_t addr, uint8_t new_relay,
 
 /** @brief Add a network key to the target node.
  *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
  *  @param net_idx     Network index to encrypt with.
  *  @param addr        Target node address.
  *  @param key_net_idx Network key index.
@@ -277,6 +343,10 @@ int bt_mesh_cfg_net_key_add(uint16_t net_idx, uint16_t addr, uint16_t key_net_id
 			    const uint8_t net_key[16], uint8_t *status);
 
 /** @brief Get a list of the target node's network key indexes.
+ *
+ *  This method can be used asynchronously by setting @p keys
+ *  or @p key_cnt as NULL. This way the method will not wait
+ *  for response and will return immediately after sending the command.
  *
  *  @param net_idx Network index to encrypt with.
  *  @param addr    Target node address.
@@ -293,6 +363,10 @@ int bt_mesh_cfg_net_key_get(uint16_t net_idx, uint16_t addr, uint16_t *keys,
 
 /** @brief Delete a network key from the target node.
  *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
  *  @param net_idx     Network index to encrypt with.
  *  @param addr        Target node address.
  *  @param key_net_idx Network key index.
@@ -304,6 +378,10 @@ int bt_mesh_cfg_net_key_del(uint16_t net_idx, uint16_t addr,
 			    uint16_t key_net_idx, uint8_t *status);
 
 /** @brief Add an application key to the target node.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
  *
  *  @param net_idx     Network index to encrypt with.
  *  @param addr        Target node address.
@@ -320,6 +398,10 @@ int bt_mesh_cfg_app_key_add(uint16_t net_idx, uint16_t addr, uint16_t key_net_id
 
 /** @brief Get a list of the target node's application key indexes for a
  *         specific network key.
+ *
+ *  This method can be used asynchronously by setting @p status and
+ *  ( @p keys or @p key_cnt ) as NULL. This way the method will not wait
+ *  for response and will return immediately after sending the command.
  *
  *  @param net_idx     Network index to encrypt with.
  *  @param addr        Target node address.
@@ -341,6 +423,10 @@ int bt_mesh_cfg_app_key_get(uint16_t net_idx, uint16_t addr, uint16_t key_net_id
 
 /** @brief Delete an application key from the target node.
  *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
  *  @param net_idx     Network index to encrypt with.
  *  @param addr        Target node address.
  *  @param key_net_idx Network key index the application key belongs to.
@@ -353,6 +439,10 @@ int bt_mesh_cfg_app_key_del(uint16_t net_idx, uint16_t addr,
 		uint16_t key_net_idx, uint16_t key_app_idx, uint8_t *status);
 
 /** @brief Bind an application to a SIG model on the target node.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
  *
  *  @param net_idx     Network index to encrypt with.
  *  @param addr        Target node address.
@@ -368,6 +458,10 @@ int bt_mesh_cfg_mod_app_bind(uint16_t net_idx, uint16_t addr, uint16_t elem_addr
 
 /** @brief Unbind an application from a SIG model on the target node.
  *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
  *  @param net_idx     Network index to encrypt with.
  *  @param addr        Target node address.
  *  @param elem_addr   Element address the model is in.
@@ -382,6 +476,10 @@ int bt_mesh_cfg_mod_app_unbind(uint16_t net_idx, uint16_t addr,
 	uint16_t mod_id, uint8_t *status);
 
 /** @brief Bind an application to a vendor model on the target node.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
  *
  *  @param net_idx     Network index to encrypt with.
  *  @param addr        Target node address.
@@ -399,6 +497,10 @@ int bt_mesh_cfg_mod_app_bind_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_
 
 /** @brief Unbind an application from a vendor model on the target node.
  *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
  *  @param net_idx     Network index to encrypt with.
  *  @param addr        Target node address.
  *  @param elem_addr   Element address the model is in.
@@ -415,6 +517,10 @@ int bt_mesh_cfg_mod_app_unbind_vnd(uint16_t net_idx, uint16_t addr,
 
 /** @brief Get a list of all applications bound to a SIG model on the target
  *         node.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  and ( @p apps or @p app_cnt ) as NULL. This way the method will
+ *  not wait for response and will return immediately after sending the command.
  *
  *  @param net_idx   Network index to encrypt with.
  *  @param addr      Target node address.
@@ -436,6 +542,10 @@ int bt_mesh_cfg_mod_app_get(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
 
 /** @brief Get a list of all applications bound to a vendor model on the target
  *         node.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  and ( @p apps or @p app_cnt ) as NULL. This way the method will
+ *  not wait for response and will return immediately after sending the command.
  *
  *  @param net_idx   Network index to encrypt with.
  *  @param addr      Target node address.
@@ -525,6 +635,10 @@ struct bt_mesh_cfg_mod_pub {
 
 /** @brief Get publish parameters for a SIG model on the target node.
  *
+ *  This method can be used asynchronously by setting @p status and
+ *  @p pub as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
+ *
  *  @param net_idx   Network index to encrypt with.
  *  @param addr      Target node address.
  *  @param elem_addr Element address the model is in.
@@ -539,6 +653,10 @@ int bt_mesh_cfg_mod_pub_get(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
 			    uint8_t *status);
 
 /** @brief Get publish parameters for a vendor model on the target node.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  and @p pub as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
  *
  *  @param net_idx   Network index to encrypt with.
  *  @param addr      Target node address.
@@ -556,6 +674,12 @@ int bt_mesh_cfg_mod_pub_get_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_a
 
 /** @brief Set publish parameters for a SIG model on the target node.
  *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
+ *
+ *  @p pub shall not be NULL.
+ *
  *  @param net_idx   Network index to encrypt with.
  *  @param addr      Target node address.
  *  @param elem_addr Element address the model is in.
@@ -570,6 +694,12 @@ int bt_mesh_cfg_mod_pub_set(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
 			    uint8_t *status);
 
 /** @brief Set publish parameters for a vendor model on the target node.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
+ *
+ *  @p pub shall not be NULL.
  *
  *  @param net_idx   Network index to encrypt with.
  *  @param addr      Target node address.
@@ -587,6 +717,10 @@ int bt_mesh_cfg_mod_pub_set_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_a
 
 /** @brief Add a group address to a SIG model's subscription list.
  *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
+ *
  *  @param net_idx   Network index to encrypt with.
  *  @param addr      Target node address.
  *  @param elem_addr Element address the model is in.
@@ -600,6 +734,10 @@ int bt_mesh_cfg_mod_sub_add(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
 			    uint16_t sub_addr, uint16_t mod_id, uint8_t *status);
 
 /** @brief Add a group address to a vendor model's subscription list.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
  *
  *  @param net_idx   Network index to encrypt with.
  *  @param addr      Target node address.
@@ -617,6 +755,10 @@ int bt_mesh_cfg_mod_sub_add_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_a
 
 /** @brief Delete a group address in a SIG model's subscription list.
  *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
+ *
  *  @param net_idx   Network index to encrypt with.
  *  @param addr      Target node address.
  *  @param elem_addr Element address the model is in.
@@ -630,6 +772,10 @@ int bt_mesh_cfg_mod_sub_del(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
 			    uint16_t sub_addr, uint16_t mod_id, uint8_t *status);
 
 /** @brief Delete a group address in a vendor model's subscription list.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
  *
  *  @param net_idx   Network index to encrypt with.
  *  @param addr      Target node address.
@@ -651,6 +797,10 @@ int bt_mesh_cfg_mod_sub_del_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_a
  * Deletes all subscriptions in the model's subscription list, and adds a
  * single group address instead.
  *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
+ *
  *  @param net_idx   Network index to encrypt with.
  *  @param addr      Target node address.
  *  @param elem_addr Element address the model is in.
@@ -669,6 +819,10 @@ int bt_mesh_cfg_mod_sub_overwrite(uint16_t net_idx, uint16_t addr, uint16_t elem
  * Deletes all subscriptions in the model's subscription list, and adds a
  * single group address instead.
  *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
+ *
  *  @param net_idx   Network index to encrypt with.
  *  @param addr      Target node address.
  *  @param elem_addr Element address the model is in.
@@ -685,6 +839,10 @@ int bt_mesh_cfg_mod_sub_overwrite_vnd(uint16_t net_idx, uint16_t addr,
 
 /** @brief Add a virtual address to a SIG model's subscription list.
  *
+ *  This method can be used asynchronously by setting @p status
+ *  and @p virt_addr as NULL. This way the method will not wait
+ *  for response and will return immediately after sending the command.
+ *
  *  @param net_idx   Network index to encrypt with.
  *  @param addr      Target node address.
  *  @param elem_addr Element address the model is in.
@@ -700,6 +858,10 @@ int bt_mesh_cfg_mod_sub_va_add(uint16_t net_idx, uint16_t addr, uint16_t elem_ad
 			       uint16_t *virt_addr, uint8_t *status);
 
 /** @brief Add a virtual address to a vendor model's subscription list.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  and @p virt_addr as NULL. This way the method will not wait
+ *  for response and will return immediately after sending the command.
  *
  *  @param net_idx   Network index to encrypt with.
  *  @param addr      Target node address.
@@ -718,6 +880,10 @@ int bt_mesh_cfg_mod_sub_va_add_vnd(uint16_t net_idx, uint16_t addr, uint16_t ele
 
 /** @brief Delete a virtual address in a SIG model's subscription list.
  *
+ *  This method can be used asynchronously by setting @p status
+ *  and @p virt_addr as NULL. This way the method will not wait
+ *  for response and will return immediately after sending the command.
+ *
  *  @param net_idx   Network index to encrypt with.
  *  @param addr      Target node address.
  *  @param elem_addr Element address the model is in.
@@ -733,6 +899,10 @@ int bt_mesh_cfg_mod_sub_va_del(uint16_t net_idx, uint16_t addr, uint16_t elem_ad
 			       uint16_t *virt_addr, uint8_t *status);
 
 /** @brief Delete a virtual address in a vendor model's subscription list.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  and @p virt_addr as NULL. This way the method will not wait
+ *  for response and will return immediately after sending the command.
  *
  *  @param net_idx   Network index to encrypt with.
  *  @param addr      Target node address.
@@ -750,10 +920,14 @@ int bt_mesh_cfg_mod_sub_va_del_vnd(uint16_t net_idx, uint16_t addr, uint16_t ele
 				   uint16_t cid, uint16_t *virt_addr, uint8_t *status);
 
 /** @brief Overwrite all addresses in a SIG model's subscription list with a
- * virtual address.
+ *  virtual address.
  *
- * Deletes all subscriptions in the model's subscription list, and adds a
- * single group address instead.
+ *  Deletes all subscriptions in the model's subscription list, and adds a
+ *  single group address instead.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  and @p virt_addr as NULL. This way the method will not wait
+ *  for response and will return immediately after sending the command.
  *
  *  @param net_idx   Network index to encrypt with.
  *  @param addr      Target node address.
@@ -771,10 +945,14 @@ int bt_mesh_cfg_mod_sub_va_overwrite(uint16_t net_idx, uint16_t addr,
 				     uint8_t *status);
 
 /** @brief Overwrite all addresses in a vendor model's subscription list with a
- * virtual address.
+ *  virtual address.
  *
- * Deletes all subscriptions in the model's subscription list, and adds a
- * single group address instead.
+ *  Deletes all subscriptions in the model's subscription list, and adds a
+ *  single group address instead.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  and @p virt_addr as NULL. This way the method will not wait
+ *  for response and will return immediately after sending the command.
  *
  *  @param net_idx   Network index to encrypt with.
  *  @param addr      Target node address.
@@ -794,6 +972,10 @@ int bt_mesh_cfg_mod_sub_va_overwrite_vnd(uint16_t net_idx, uint16_t addr,
 
 /** @brief Get the subscription list of a SIG model on the target node.
  *
+ *  This method can be used asynchronously by setting @p status and
+ *  ( @p subs or @p sub_cnt ) as NULL. This way the method will
+ *  not wait for response and will return immediately after sending the command.
+ *
  *  @param net_idx   Network index to encrypt with.
  *  @param addr      Target node address.
  *  @param elem_addr Element address the model is in.
@@ -812,6 +994,10 @@ int bt_mesh_cfg_mod_sub_get(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
 			    size_t *sub_cnt);
 
 /** @brief Get the subscription list of a vendor model on the target node.
+ *
+ *  This method can be used asynchronously by setting @p status and
+ *  ( @p subs or @p sub_cnt ) as NULL. This way the method will
+ *  not wait for response and will return immediately after sending the command.
  *
  *  @param net_idx   Network index to encrypt with.
  *  @param addr      Target node address.
@@ -871,6 +1057,12 @@ struct bt_mesh_cfg_hb_sub {
 
 /** @brief Set the target node's Heartbeat subscription parameters.
  *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
+ *
+ *  @p sub shall not be null.
+ *
  *  @param net_idx Network index to encrypt with.
  *  @param addr    Target node address.
  *  @param sub     New Heartbeat subscription parameters.
@@ -882,6 +1074,10 @@ int bt_mesh_cfg_hb_sub_set(uint16_t net_idx, uint16_t addr,
 			   struct bt_mesh_cfg_hb_sub *sub, uint8_t *status);
 
 /** @brief Get the target node's Heartbeta subscription parameters.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  and @p sub as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
  *
  *  @param net_idx Network index to encrypt with.
  *  @param addr    Target node address.
@@ -932,6 +1128,12 @@ struct bt_mesh_cfg_hb_pub {
  *
  *  @note The target node must already have received the specified network key.
  *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
+ *
+ *  @p pub shall not be NULL;
+ *
  *  @param net_idx Network index to encrypt with.
  *  @param addr    Target node address.
  *  @param pub     New Heartbeat publication parameters.
@@ -944,6 +1146,10 @@ int bt_mesh_cfg_hb_pub_set(uint16_t net_idx, uint16_t addr,
 
 /** @brief Get the target node's Heartbeat publication parameters.
  *
+ *  This method can be used asynchronously by setting @p status
+ *  and @p pub as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
+ *
  *  @param net_idx Network index to encrypt with.
  *  @param addr    Target node address.
  *  @param pub     Heartbeat publication parameter return buffer.
@@ -955,6 +1161,10 @@ int bt_mesh_cfg_hb_pub_get(uint16_t net_idx, uint16_t addr,
 			   struct bt_mesh_cfg_hb_pub *pub, uint8_t *status);
 
 /** @brief Delete all group addresses in a SIG model's subscription list.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
  *
  *  @param net_idx   Network index to encrypt with.
  *  @param addr      Target node address.
@@ -969,6 +1179,10 @@ int bt_mesh_cfg_mod_sub_del_all(uint16_t net_idx, uint16_t addr,
 				uint8_t *status);
 
 /** @brief Delete all group addresses in a vendor model's subscription list.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
  *
  *  @param net_idx   Network index to encrypt with.
  *  @param addr      Target node address.
@@ -985,6 +1199,10 @@ int bt_mesh_cfg_mod_sub_del_all_vnd(uint16_t net_idx, uint16_t addr,
 
 /** @brief Update a network key to the target node.
  *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
+ *
  *  @param net_idx     Network index to encrypt with.
  *  @param addr        Target node address.
  *  @param key_net_idx Network key index.
@@ -998,6 +1216,10 @@ int bt_mesh_cfg_net_key_update(uint16_t net_idx, uint16_t addr,
 			       uint8_t *status);
 
 /** @brief Update an application key to the target node.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
  *
  *  @param net_idx     Network index to encrypt with.
  *  @param addr        Target node address.
@@ -1013,6 +1235,10 @@ int bt_mesh_cfg_app_key_update(uint16_t net_idx, uint16_t addr,
 			       const uint8_t app_key[16], uint8_t *status);
 
 /** @brief Set the Node Identity parameters.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  and @p identity as NULL. This way the method will not wait
+ *  for response and will return immediately after sending the command.
  *
  *  @param net_idx Network index to encrypt with.
  *  @param addr    Target node address.
@@ -1031,6 +1257,10 @@ int bt_mesh_cfg_node_identity_set(uint16_t net_idx, uint16_t addr,
 
 /** @brief Get the Node Identity parameters.
  *
+ *  This method can be used asynchronously by setting @p status
+ *  and @p identity as NULL. This way the method will not wait
+ *  for response and will return immediately after sending the command.
+ *
  *  @param net_idx Network index to encrypt with.
  *  @param addr    Target node address.
  *  @param key_net_idx Network key index the application key belongs to.
@@ -1046,6 +1276,10 @@ int bt_mesh_cfg_node_identity_get(uint16_t net_idx, uint16_t addr,
 				  uint8_t *identity);
 
 /** @brief Get the Low Power Node Polltimeout parameters.
+ *
+ *  This method can be used asynchronously by setting @p polltimeout
+ *  as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
  *
  *  @param net_idx Network index to encrypt with.
  *  @param addr    Target node address.

--- a/include/bluetooth/mesh/health_cli.h
+++ b/include/bluetooth/mesh/health_cli.h
@@ -112,6 +112,14 @@ int bt_mesh_health_cli_set(struct bt_mesh_model *model);
 
 /** @brief Get the registered fault state for the given Company ID.
  *
+ *  This method can be used asynchronously by setting @p test_id
+ *  and ( @p faults or @p fault_count ) as NULL This way the method
+ *  will not wait for response and will return immediately after
+ *  sending the command.
+ *
+ *  To process the response arguments of an async method, register
+ *  the @c fault_status callback in @c bt_mesh_health_cli struct.
+ *
  *  @see bt_mesh_health_faults
  *
  *  @param addr        Target node element address.
@@ -128,6 +136,14 @@ int bt_mesh_health_fault_get(uint16_t addr, uint16_t app_idx, uint16_t cid,
 			     size_t *fault_count);
 
 /** @brief Clear the registered faults for the given Company ID.
+ *
+ *  This method can be used asynchronously by setting @p test_id
+ *  and ( @p faults or @p fault_count ) as NULL This way the method
+ *  will not wait for response and will return immediately after
+ *  sending the command.
+ *
+ *  To process the response arguments of an async method, register
+ *  the @c fault_status callback in @c bt_mesh_health_cli struct.
  *
  *  @see bt_mesh_health_faults
  *
@@ -158,6 +174,13 @@ int bt_mesh_health_fault_clear_unack(uint16_t addr, uint16_t app_idx,
 				     uint16_t cid);
 
 /** @brief Invoke a self-test procedure for the given Company ID.
+ *
+ *  This method can be used asynchronously by setting @p faults
+ *  or @p fault_count as NULL This way the method will not wait
+ *  for response and will return immediately after sending the command.
+ *
+ *  To process the response arguments of an async method, register
+ *  the @c fault_status callback in @c bt_mesh_health_cli struct.
  *
  *  @param addr        Target node element address.
  *  @param app_idx     Application index to encrypt with.
@@ -194,6 +217,13 @@ int bt_mesh_health_fault_test_unack(uint16_t addr, uint16_t app_idx,
  *  Health fast period divisor is 5, the Health server will publish with an
  *  interval of 500 ms when a fault is registered.
  *
+ *  This method can be used asynchronously by setting @p divisor
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
+ *  To process the response arguments of an async method, register
+ *  the @c period_status callback in @c bt_mesh_health_cli struct.
+ *
  *  @param addr    Target node element address.
  *  @param app_idx Application index to encrypt with.
  *  @param divisor Health period divisor response buffer.
@@ -212,6 +242,13 @@ int bt_mesh_health_period_get(uint16_t addr, uint16_t app_idx,
  *  Health server is configured to publish with a period of 16 seconds, and the
  *  Health fast period divisor is 5, the Health server will publish with an
  *  interval of 500 ms when a fault is registered.
+ *
+ *  This method can be used asynchronously by setting @p updated_divisor
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
+ *  To process the response arguments of an async method, register
+ *  the @c period_status callback in @c bt_mesh_health_cli struct.
  *
  *  @param addr            Target node element address.
  *  @param app_idx         Application index to encrypt with.
@@ -238,6 +275,13 @@ int bt_mesh_health_period_set_unack(uint16_t addr, uint16_t app_idx,
 
 /** @brief Get the current attention timer value.
  *
+ *  This method can be used asynchronously by setting @p attention
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
+ *  To process the response arguments of an async method, register
+ *  the @c attention_status callback in @c bt_mesh_health_cli struct.
+ *
  *  @param addr      Target node element address.
  *  @param app_idx   Application index to encrypt with.
  *  @param attention Attention timer response buffer, measured in seconds.
@@ -248,6 +292,13 @@ int bt_mesh_health_attention_get(uint16_t addr, uint16_t app_idx,
 				 uint8_t *attention);
 
 /** @brief Set the attention timer.
+ *
+ *  This method can be used asynchronously by setting @p updated_attention
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
+ *  To process the response arguments of an async method, register
+ *  the @c attention_status callback in @c bt_mesh_health_cli struct.
  *
  *  @param addr              Target node element address.
  *  @param app_idx           Application index to encrypt with.

--- a/subsys/bluetooth/mesh/cfg_cli.c
+++ b/subsys/bluetooth/mesh/cfg_cli.c
@@ -953,6 +953,11 @@ int bt_mesh_cfg_comp_data_get(uint16_t net_idx, uint16_t addr, uint8_t page,
 		return err;
 	}
 
+	if (!rsp && !comp) {
+		bt_mesh_msg_ack_ctx_clear(&cli->ack_ctx);
+		return 0;
+	}
+
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
 }
 
@@ -980,6 +985,11 @@ static int get_state_u8(uint16_t net_idx, uint16_t addr, uint32_t op, uint32_t r
 		BT_ERR("model_send() failed (err %d)", err);
 		bt_mesh_msg_ack_ctx_clear(&cli->ack_ctx);
 		return err;
+	}
+
+	if (!val) {
+		bt_mesh_msg_ack_ctx_clear(&cli->ack_ctx);
+		return 0;
 	}
 
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
@@ -1010,6 +1020,11 @@ static int set_state_u8(uint16_t net_idx, uint16_t addr, uint32_t op, uint32_t r
 		BT_ERR("model_send() failed (err %d)", err);
 		bt_mesh_msg_ack_ctx_clear(&cli->ack_ctx);
 		return err;
+	}
+
+	if (!val) {
+		bt_mesh_msg_ack_ctx_clear(&cli->ack_ctx);
+		return 0;
 	}
 
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
@@ -1052,6 +1067,11 @@ int bt_mesh_cfg_krp_get(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
 		return err;
 	}
 
+	if (!status && !phase) {
+		bt_mesh_msg_ack_ctx_clear(&cli->ack_ctx);
+		return 0;
+	}
+
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
 }
 
@@ -1085,6 +1105,11 @@ int bt_mesh_cfg_krp_set(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
 		BT_ERR("model_send() failed (err %d)", err);
 		bt_mesh_msg_ack_ctx_clear(&cli->ack_ctx);
 		return err;
+	}
+
+	if (!status && !phase) {
+		bt_mesh_msg_ack_ctx_clear(&cli->ack_ctx);
+		return 0;
 	}
 
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
@@ -1164,10 +1189,6 @@ int bt_mesh_cfg_relay_get(uint16_t net_idx, uint16_t addr, uint8_t *status,
 	};
 	int err;
 
-	if (!status || !transmit) {
-		return -EINVAL;
-	}
-
 	err = cli_prepare(&param, OP_RELAY_STATUS, addr);
 	if (err) {
 		return err;
@@ -1180,6 +1201,11 @@ int bt_mesh_cfg_relay_get(uint16_t net_idx, uint16_t addr, uint8_t *status,
 		BT_ERR("model_send() failed (err %d)", err);
 		bt_mesh_msg_ack_ctx_clear(&cli->ack_ctx);
 		return err;
+	}
+
+	if (!status && !transmit) {
+		bt_mesh_msg_ack_ctx_clear(&cli->ack_ctx);
+		return 0;
 	}
 
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
@@ -1215,6 +1241,11 @@ int bt_mesh_cfg_relay_set(uint16_t net_idx, uint16_t addr, uint8_t new_relay,
 		BT_ERR("model_send() failed (err %d)", err);
 		bt_mesh_msg_ack_ctx_clear(&cli->ack_ctx);
 		return err;
+	}
+
+	if (!status && !transmit) {
+		bt_mesh_msg_ack_ctx_clear(&cli->ack_ctx);
+		return 0;
 	}
 
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
@@ -1329,6 +1360,11 @@ int bt_mesh_cfg_net_key_get(uint16_t net_idx, uint16_t addr, uint16_t *keys,
 		BT_ERR("model_send() failed (err %d)", err);
 		bt_mesh_msg_ack_ctx_clear(&cli->ack_ctx);
 		return err;
+	}
+
+	if (!keys || !key_cnt) {
+		bt_mesh_msg_ack_ctx_clear(&cli->ack_ctx);
+		return 0;
 	}
 
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
@@ -1526,6 +1562,11 @@ int bt_mesh_cfg_app_key_get(uint16_t net_idx, uint16_t addr, uint16_t key_net_id
 		BT_ERR("model_send() failed (err %d)", err);
 		bt_mesh_msg_ack_ctx_clear(&cli->ack_ctx);
 		return err;
+	}
+
+	if (!status && (!keys || !key_cnt)) {
+		bt_mesh_msg_ack_ctx_clear(&cli->ack_ctx);
+		return 0;
 	}
 
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
@@ -1757,6 +1798,11 @@ static int mod_member_list_get(uint32_t op, uint32_t expect_op, uint16_t net_idx
 		return err;
 	}
 
+	if (!status && (!apps || !app_cnt)) {
+		bt_mesh_msg_ack_ctx_clear(&cli->ack_ctx);
+		return 0;
+	}
+
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
 }
 
@@ -1969,7 +2015,7 @@ static int mod_sub_va(uint32_t op, uint16_t net_idx, uint16_t addr, uint16_t ele
 		return err;
 	}
 
-	if (!status) {
+	if (!status && !virt_addr) {
 		bt_mesh_msg_ack_ctx_clear(&cli->ack_ctx);
 		return 0;
 	}
@@ -2103,7 +2149,7 @@ static int mod_pub_get(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
 		return err;
 	}
 
-	if (!status) {
+	if (!status && !pub) {
 		bt_mesh_msg_ack_ctx_clear(&cli->ack_ctx);
 		return 0;
 	}
@@ -2244,6 +2290,10 @@ int bt_mesh_cfg_mod_pub_set(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
 			    uint16_t mod_id, struct bt_mesh_cfg_mod_pub *pub,
 			    uint8_t *status)
 {
+	if (!pub) {
+		return -EINVAL;
+	}
+
 	if (pub->uuid) {
 		return mod_pub_va_set(net_idx, addr, elem_addr, mod_id, CID_NVAL, pub, status);
 	} else {
@@ -2255,6 +2305,10 @@ int bt_mesh_cfg_mod_pub_set_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_a
 				uint16_t mod_id, uint16_t cid, struct bt_mesh_cfg_mod_pub *pub,
 				uint8_t *status)
 {
+	if (!pub) {
+		return -EINVAL;
+	}
+
 	if (cid == CID_NVAL) {
 		return -EINVAL;
 	}
@@ -2281,6 +2335,10 @@ int bt_mesh_cfg_hb_sub_set(uint16_t net_idx, uint16_t addr,
 		.sub = sub,
 	};
 	int err;
+
+	if (!sub) {
+		return -EINVAL;
+	}
 
 	err = cli_prepare(&param, OP_HEARTBEAT_SUB_STATUS, addr);
 	if (err) {
@@ -2337,7 +2395,7 @@ int bt_mesh_cfg_hb_sub_get(uint16_t net_idx, uint16_t addr,
 		return err;
 	}
 
-	if (!status) {
+	if (!status && !sub) {
 		bt_mesh_msg_ack_ctx_clear(&cli->ack_ctx);
 		return 0;
 	}
@@ -2359,6 +2417,10 @@ int bt_mesh_cfg_hb_pub_set(uint16_t net_idx, uint16_t addr,
 		.status = status,
 	};
 	int err;
+
+	if (!pub) {
+		return -EINVAL;
+	}
 
 	err = cli_prepare(&param, OP_HEARTBEAT_PUB_STATUS, addr);
 	if (err) {
@@ -2418,7 +2480,7 @@ int bt_mesh_cfg_hb_pub_get(uint16_t net_idx, uint16_t addr,
 		return err;
 	}
 
-	if (!status) {
+	if (!status && !pub) {
 		bt_mesh_msg_ack_ctx_clear(&cli->ack_ctx);
 		return 0;
 	}
@@ -2460,7 +2522,7 @@ int bt_mesh_cfg_node_identity_set(uint16_t net_idx, uint16_t addr,
 		return err;
 	}
 
-	if (!status) {
+	if (!status && !identity) {
 		bt_mesh_msg_ack_ctx_clear(&cli->ack_ctx);
 		return 0;
 	}
@@ -2501,7 +2563,7 @@ int bt_mesh_cfg_node_identity_get(uint16_t net_idx, uint16_t addr,
 		return err;
 	}
 
-	if (!status) {
+	if (!status && !identity) {
 		bt_mesh_msg_ack_ctx_clear(&cli->ack_ctx);
 		return 0;
 	}
@@ -2538,6 +2600,11 @@ int bt_mesh_cfg_lpn_timeout_get(uint16_t net_idx, uint16_t addr,
 		BT_ERR("model_send() failed (err %d)", err);
 		bt_mesh_msg_ack_ctx_clear(&cli->ack_ctx);
 		return err;
+	}
+
+	if (!polltimeout) {
+		bt_mesh_msg_ack_ctx_clear(&cli->ack_ctx);
+		return 0;
 	}
 
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));

--- a/subsys/bluetooth/mesh/shell.c
+++ b/subsys/bluetooth/mesh/shell.c
@@ -2393,8 +2393,7 @@ static int cmd_fault_clear_unack(const struct shell *shell, size_t argc,
 
 	cid = strtoul(argv[1], NULL, 0);
 
-	err = bt_mesh_health_fault_clear(net.dst, net.app_idx, cid,
-					 NULL, NULL, NULL);
+	err = bt_mesh_health_fault_clear_unack(net.dst, net.app_idx, cid);
 	if (err) {
 		shell_error(shell, "Health Fault Clear Unacknowledged failed "
 			    "(err %d)", err);
@@ -2445,8 +2444,7 @@ static int cmd_fault_test_unack(const struct shell *shell, size_t argc,
 	cid = strtoul(argv[1], NULL, 0);
 	test_id = strtoul(argv[2], NULL, 0);
 
-	err = bt_mesh_health_fault_test(net.dst, net.app_idx, cid,
-				 test_id, NULL, NULL);
+	err = bt_mesh_health_fault_test_unack(net.dst, net.app_idx, cid, test_id);
 	if (err) {
 		shell_error(shell, "Health Fault Test Unacknowledged failed "
 			    "(err %d)", err);
@@ -2507,7 +2505,7 @@ static int cmd_period_set_unack(const struct shell *shell, size_t argc,
 
 	divisor = strtoul(argv[1], NULL, 0);
 
-	err = bt_mesh_health_period_set(net.dst, net.app_idx, divisor, NULL);
+	err = bt_mesh_health_period_set_unack(net.dst, net.app_idx, divisor);
 	if (err) {
 		shell_print(shell, "Failed to send Health Period Set (err %d)",
 			    err);
@@ -2571,8 +2569,7 @@ static int cmd_attention_set_unack(const struct shell *shell, size_t argc,
 
 	attention = strtoul(argv[1], NULL, 0);
 
-	err = bt_mesh_health_attention_set(net.dst, net.app_idx, attention,
-				 NULL);
+	err = bt_mesh_health_attention_set_unack(net.dst, net.app_idx, attention);
 	if (err) {
 		shell_error(shell, "Failed to send Health Attention Set "
 			    "(err %d)", err);

--- a/tests/bluetooth/tester/src/mesh.c
+++ b/tests/bluetooth/tester/src/mesh.c
@@ -2177,9 +2177,7 @@ static void health_fault_clear(uint8_t *data, uint16_t len)
 						 cmd->cid, &test_id, faults,
 						 &fault_count);
 	} else {
-		err = bt_mesh_health_fault_clear(cmd->address, cmd->app_idx,
-						 cmd->cid, NULL, faults,
-						 &fault_count);
+		err = bt_mesh_health_fault_clear_unack(cmd->address, cmd->app_idx, cmd->cid);
 	}
 
 	if (err) {
@@ -2219,9 +2217,8 @@ static void health_fault_test(uint8_t *data, uint16_t len)
 						cid, test_id, faults,
 						&fault_count);
 	} else {
-		err = bt_mesh_health_fault_test(cmd->address, cmd->app_idx,
-						cid, test_id, NULL,
-						&fault_count);
+		err = bt_mesh_health_fault_test_unack(cmd->address, cmd->app_idx,
+						cid, test_id);
 	}
 
 	if (err) {
@@ -2279,8 +2276,7 @@ static void health_period_set(uint8_t *data, uint16_t len)
 		err = bt_mesh_health_period_set(cmd->address, cmd->app_idx,
 						cmd->divisor, &updated_divisor);
 	} else {
-		err = bt_mesh_health_period_set(cmd->address, cmd->app_idx,
-						cmd->divisor, NULL);
+		err = bt_mesh_health_period_set_unack(cmd->address, cmd->app_idx, cmd->divisor);
 	}
 
 	if (err) {
@@ -2336,8 +2332,8 @@ static void health_attention_set(uint8_t *data, uint16_t len)
 						   cmd->attention,
 						   &updated_attention);
 	} else {
-		err = bt_mesh_health_attention_set(cmd->address, cmd->app_idx,
-						   cmd->attention, NULL);
+		err = bt_mesh_health_attention_set_unack(cmd->address, cmd->app_idx,
+							 cmd->attention);
 	}
 
 	if (err) {


### PR DESCRIPTION
The previous PR was not fully baked, so this PR fixes issues by:
- Adding checks when dereferncing pointers stored in params.
- Clearing ack context if a return argument is NULL to not block and
wait for response.
- Updating Health Client Unack API use in mesh shell and tester

Signed-off-by: Michał Narajowski <michal.narajowski@codecoup.pl>