### PR TITLE
samples: net: gsm_modem: Fix gsm_ppp.h path

### DIFF
--- a/samples/net/gsm_modem/src/main.c
+++ b/samples/net/gsm_modem/src/main.c
@@ -11,7 +11,7 @@
 #include <net/net_mgmt.h>
 #include <net/net_event.h>
 #include <net/net_conn_mgr.h>
-#include <drivers/gsm_ppp.h>
+#include <drivers/modem/gsm_ppp.h>
 
 #include <logging/log.h>
 LOG_MODULE_REGISTER(sample_gsm_ppp, LOG_LEVEL_DBG);


### PR DESCRIPTION
The gsm_ppp.h is currently in include/drivers/modem directory
so change the path accordingly.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>