### PR TITLE
MAINTAINERS: Add pavelvpv as Bluetooth Mesh collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -212,6 +212,7 @@ Bluetooth Mesh:
         - jhedberg
         - LingaoM
         - alxelax
+        - pavelvpv
     files:
         - subsys/bluetooth/mesh/
         - include/bluetooth/mesh/


### PR DESCRIPTION
Add pavelvpv as Bluetooth Mesh collaborator.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>