### PR TITLE
timer: update riscv minimum delay in timer

### DIFF
--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -13,7 +13,16 @@
 			      / (uint64_t)CONFIG_SYS_CLOCK_TICKS_PER_SEC))
 #define MAX_CYC INT_MAX
 #define MAX_TICKS ((MAX_CYC - CYC_PER_TICK) / CYC_PER_TICK)
-#define MIN_DELAY 1000
+
+/*
+ * Calculates the minimum delay to be about 1/8th of a tick down to a minimum
+ * of two cycles. According to the spec, this minimum delay *should* not be
+ * needed as the timer comparator is supposed to trigger the interrupt if the
+ * comparison register is less than the timer register; however, what hardware
+ * implements is a different matter.
+ */
+
+#define MIN_DELAY ((CYC_PER_TICK + 15) >> 3)
 
 #define TICKLESS IS_ENABLED(CONFIG_TICKLESS_KERNEL)
 


### PR DESCRIPTION
Although the minimum delay in the RISCV timer should not technically
be necessary (according to the specs), it is also acknowledged that
historically hardware has not always 100% conformed to documentation.
To that end, the minimum delay in the RISCV timer has been kept, but
shortened from a fixed length of 1000 cycles to one that varies
between 2 cycles for the highest system tick rates to about 1/8th of
a tick for slower tick rates.

Signed-off-by: Peter Mitsis <peter.mitsis@intel.com>