### PR TITLE
[Backport v2.7-branch] drivers: can: fix can_configure() when CAN-FD is enabled

### DIFF
--- a/include/drivers/can.h
+++ b/include/drivers/can.h
@@ -817,7 +817,7 @@ static inline int can_configure(const struct device *dev, enum can_mode mode,
 				uint32_t bitrate)
 {
 	if (bitrate > 0) {
-		int err = can_set_bitrate(dev, bitrate, 0);
+		int err = can_set_bitrate(dev, bitrate, bitrate);
 		if (err != 0) {
 			return err;
 		}
@@ -825,7 +825,6 @@ static inline int can_configure(const struct device *dev, enum can_mode mode,
 
 	return can_set_mode(dev, mode);
 }
-
 
 /**
  * @brief Get current state


### PR DESCRIPTION
Backport 8d5a0664d29ae43a71325bb0b2aa9834dba3c473 from #40813