### PR TITLE
Bluetooth: shell: Register callbacks dynamically

### DIFF
--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -415,7 +415,7 @@ void le_phy_updated(struct bt_conn *conn,
 }
 #endif
 
-BT_CONN_CB_DEFINE(conn_callbacks) = {
+static struct bt_conn_cb conn_callbacks = {
 	.connected = connected,
 	.disconnected = disconnected,
 	.le_param_req = le_param_req,
@@ -573,6 +573,8 @@ static void bt_ready(int err)
 
 #if defined(CONFIG_BT_CONN)
 	default_conn = NULL;
+
+	bt_conn_cb_register(&conn_callbacks);
 #endif /* CONFIG_BT_CONN */
 
 #if defined(CONFIG_BT_PER_ADV_SYNC)


### PR DESCRIPTION
Bluetooth callbacks are now registered dynamically again. When Bluetooth
callbacks were registered statically, they could be invoked before the
Bluetooth shell (ctx_shell) is initialized. The callbacks try to
shell_print(ctx_shell, ...), which results in a fatal error if ctx_shell
is undefined.

Fixes #40881.

Signed-off-by: Andreas Rudolf <andreas.rudolf@husqvarnagroup.com>