### PR TITLE
[Backport v2.7-branch] Fix for: mcumgr over serial does not add CRC to length of packet len

### DIFF
--- a/include/mgmt/mcumgr/serial.h
+++ b/include/mgmt/mcumgr/serial.h
@@ -35,7 +35,8 @@
  * | -------------- | ------------------------------------------------------- |
  * | 0x06 0x09      | Byte pair indicating the start of a packet.             |
  * | 0x04 0x14      | Byte pair indicating the start of a continuation frame. |
- * | Packet length  | The combined total length of the *unencoded* body.      |
+ * | Packet length  | The combined total length of the *unencoded* body plus  |
+ * |                | the final CRC (2 bytes). Length is in Big-Endian format.|
  * | Body           | The actual SMP data (i.e., 8-byte header and CBOR       |
  * |                | key-value map).                                         |
  * | CRC16          | A CRC16 of the *unencoded* body of the entire packet.   |

--- a/subsys/mgmt/mcumgr/serial_util.c
+++ b/subsys/mgmt/mcumgr/serial_util.c
@@ -218,7 +218,8 @@ int mcumgr_serial_tx_frame(const uint8_t *data, bool first, int len,
 
 	/* Only the first fragment contains the packet length. */
 	if (first) {
-		u16 = sys_cpu_to_be16(len);
+		/* The size of the CRC16 should be added to packet length */
+		u16 = sys_cpu_to_be16(len + 2);
 		memcpy(raw, &u16, sizeof(u16));
 		raw[2] = data[0];
 


### PR DESCRIPTION
Backport of https://github.com/zephyrproject-rtos/zephyr/pull/40127

Fixes #41004