### PR TITLE
mcuboot: synchronize 8-XII-2021

### DIFF
--- a/doc/releases/release-notes-3.0.rst
+++ b/doc/releases/release-notes-3.0.rst
@@ -348,6 +348,21 @@ Libraries / Subsystems
 HALs
 ****
 
+MCUboot
+*******
+
+* Fixed serial recovery skipping on nrf5340.
+* Fixed issue which caused that progressive's erase feature was off although was selected by Kconfig (introduced by #42c985cead).
+* Added check of reset address in incoming image validation phase, see ``CONFIG_MCUBOOT_VERIFY_IMG_ADDRESS``.
+* Allow image header bigger than 1 KB for encrypted images.
+* Support Mbed TLS 3.0.
+* stm32: watchdog support.
+* many documentation improvements.
+* Fixed deadlock on cryptolib selectors in Kconfig.
+* Fixed support for single application slot with serial recovery.
+* Added various hooks to be able to change how image data is accessed, see ``CONFIG_BOOT_IMAGE_ACCESS_HOOKS``.
+* Added custom commands support in serila recovery (PERUSER_MGMT_GROUP): storage erase ``CONFIG_BOOT_MGMT_CUSTOM_STORAGE_ERASE``, custo image status ``CONFIG_BOOT_MGMT_CUSTOM_IMG_LIST``.
+* Added support for direct image upload, see ``CONFIG_MCUBOOT_SERIAL_DIRECT_IMAGE_UPLOAD`` in serial recovery.
 
 Trusted Firmware-m
 ******************

--- a/west.yml
+++ b/west.yml
@@ -168,7 +168,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 225b02468bf77806bdd5f503725256cb345970d2
+      revision: 33906b472a6c0ed4e2ca3520eb4eed1db40c6018
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Mcuboot was synchronized with its upstream project to:
mcu-tools/mcuboot@05143ce

- Fixed serial recovery skipping on nrf5340
- Fixed issue which caused that progressive's erase feature
was off although was selected by Kconfig (introduced by #42c985cead)
- Added check of reset address in incoming image validation phase,
see CONFIG_MCUBOOT_VERIFY_IMG_ADDRESS
- Allow image header bigger than 1 KB for encrypted images
- Fixed build with image encryption using RSA
(issue introduced by migration to mbedTLS 3.0.0)
- stm32: watchdog support
- many documentation improvements