### PR TITLE
Bluetooth: drivers: Add length checks before net_buf_add_mem

### DIFF
--- a/drivers/bluetooth/hci/h4.c
+++ b/drivers/bluetooth/hci/h4.c
@@ -281,6 +281,8 @@ static inline void read_payload(void)
 	int read;
 
 	if (!rx.buf) {
+		size_t buf_tailroom;
+
 		rx.buf = get_rx(K_NO_WAIT);
 		if (!rx.buf) {
 			if (rx.discardable) {
@@ -297,8 +299,10 @@ static inline void read_payload(void)
 
 		BT_DBG("Allocated rx.buf %p", rx.buf);
 
-		if (rx.remaining > net_buf_tailroom(rx.buf)) {
-			BT_ERR("Not enough space in buffer");
+		buf_tailroom = net_buf_tailroom(rx.buf);
+		if (buf_tailroom < rx.remaining) {
+			BT_ERR("Not enough space in buffer %u/%zu",
+			       rx.remaining, buf_tailroom);
 			rx.discard = rx.remaining;
 			reset_rx();
 			return;

--- a/drivers/bluetooth/hci/h5.c
+++ b/drivers/bluetooth/hci/h5.c
@@ -415,6 +415,7 @@ static void bt_uart_isr(const struct device *unused, void *user_data)
 	uint8_t byte;
 	int ret;
 	static uint8_t hdr[4];
+	size_t buf_tailroom;
 
 	ARG_UNUSED(unused);
 	ARG_UNUSED(user_data);
@@ -533,6 +534,14 @@ static void bt_uart_isr(const struct device *unused, void *user_data)
 					h5_reset_rx();
 					continue;
 				}
+			}
+
+			buf_tailroom = net_buf_tailroom(h5.rx_buf);
+			if (buf_tailroom < sizeof(byte)) {
+				BT_ERR("Not enough space in buffer %zu/%zu",
+				       sizeof(byte), buf_tailroom);
+				h5_reset_rx();
+				break;
 			}
 
 			net_buf_add_mem(h5.rx_buf, &byte, sizeof(byte));

--- a/drivers/bluetooth/hci/rpmsg.c
+++ b/drivers/bluetooth/hci/rpmsg.c
@@ -57,6 +57,7 @@ static struct net_buf *bt_rpmsg_evt_recv(uint8_t *data, size_t remaining)
 	bool discardable;
 	struct bt_hci_evt_hdr hdr;
 	struct net_buf *buf;
+	size_t buf_tailroom;
 
 	if (remaining < sizeof(hdr)) {
 		BT_ERR("Not enough data for event header");
@@ -86,6 +87,15 @@ static struct net_buf *bt_rpmsg_evt_recv(uint8_t *data, size_t remaining)
 	}
 
 	net_buf_add_mem(buf, &hdr, sizeof(hdr));
+
+	buf_tailroom = net_buf_tailroom(buf);
+	if (buf_tailroom < remaining) {
+		BT_ERR("Not enough space in buffer %zu/%zu",
+		       remaining, buf_tailroom);
+		net_buf_unref(buf);
+		return NULL;
+	}
+
 	net_buf_add_mem(buf, data, remaining);
 
 	return buf;
@@ -95,6 +105,7 @@ static struct net_buf *bt_rpmsg_acl_recv(uint8_t *data, size_t remaining)
 {
 	struct bt_hci_acl_hdr hdr;
 	struct net_buf *buf;
+	size_t buf_tailroom;
 
 	if (remaining < sizeof(hdr)) {
 		BT_ERR("Not enough data for ACL header");
@@ -119,6 +130,14 @@ static struct net_buf *bt_rpmsg_acl_recv(uint8_t *data, size_t remaining)
 		return NULL;
 	}
 
+	buf_tailroom = net_buf_tailroom(buf);
+	if (buf_tailroom < remaining) {
+		BT_ERR("Not enough space in buffer %zu/%zu",
+		       remaining, buf_tailroom);
+		net_buf_unref(buf);
+		return NULL;
+	}
+
 	BT_DBG("len %u", remaining);
 	net_buf_add_mem(buf, data, remaining);
 
@@ -129,6 +148,7 @@ static struct net_buf *bt_rpmsg_iso_recv(uint8_t *data, size_t remaining)
 {
 	struct bt_hci_iso_hdr hdr;
 	struct net_buf *buf;
+	size_t buf_tailroom;
 
 	if (remaining < sizeof(hdr)) {
 		BT_ERR("Not enough data for ISO header");
@@ -149,6 +169,14 @@ static struct net_buf *bt_rpmsg_iso_recv(uint8_t *data, size_t remaining)
 
 	if (remaining != bt_iso_hdr_len(sys_le16_to_cpu(hdr.len))) {
 		BT_ERR("ISO payload length is not correct");
+		net_buf_unref(buf);
+		return NULL;
+	}
+
+	buf_tailroom = net_buf_tailroom(buf);
+	if (buf_tailroom < remaining) {
+		BT_ERR("Not enough space in buffer %zu/%zu",
+		       remaining, buf_tailroom);
 		net_buf_unref(buf);
 		return NULL;
 	}


### PR DESCRIPTION
Add length checks before calls to net_buf_add_mem
for dynamically sized data.

This should give a better error response than hitting
the __ASSERT in net_buf_simple_add.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>