### PR TITLE
Revert "soc: cavs_v25: increase core count default to 4"

### DIFF
--- a/soc/xtensa/intel_adsp/cavs_v25/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/cavs_v25/Kconfig.defconfig.series
@@ -15,8 +15,9 @@ config SOC
 	string
 	default "intel_cavs_25"
 
+# Hardware has four cores, limited to two pending test fixes
 config MP_NUM_CPUS
-	default 4
+	default 2
 
 config SMP
        default y


### PR DESCRIPTION
This reverts commit af79664da3debec8d168e01dac6098dac88841cf.

The patch caused regression on TGL-H systems where only 2 DSP
cores are available. The Kconfig override used by existing SOF
application does not work with Zephyr. A quick fix using
Zephyr board revisions was considered, but review feedback
was that core count difference should be reflected in SoC-level
device tree. This will take more time to develop, so the revert
is needed to fix the immediate regression.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>