### PR TITLE
usb: Add macro for user defined string descriptors

### DIFF
--- a/include/usb/usb_device.h
+++ b/include/usb/usb_device.h
@@ -60,8 +60,10 @@ extern "C" {
 	static __in_section(usb, descriptor_##p, 3) __used __aligned(1)
 #define USBD_STRING_DESCR_DEFINE(p) \
 	static __in_section(usb, descriptor_##p, 4) __used __aligned(1)
-#define USBD_TERM_DESCR_DEFINE(p) \
+#define USBD_STRING_DESCR_USER_DEFINE(p) \
 	static __in_section(usb, descriptor_##p, 5) __used __aligned(1)
+#define USBD_TERM_DESCR_DEFINE(p) \
+	static __in_section(usb, descriptor_##p, 6) __used __aligned(1)
 
 /*
  * This macro should be used to place the struct usb_cfg_data

--- a/subsys/usb/class/netusb/function_ecm.c
+++ b/subsys/usb/class/netusb/function_ecm.c
@@ -399,7 +399,7 @@ struct usb_cdc_ecm_mac_descr {
 	uint8_t bString[USB_BSTRING_LENGTH(CONFIG_USB_DEVICE_NETWORK_ECM_MAC)];
 } __packed;
 
-USBD_STRING_DESCR_DEFINE(primary) struct usb_cdc_ecm_mac_descr utf16le_mac = {
+USBD_STRING_DESCR_USER_DEFINE(primary) struct usb_cdc_ecm_mac_descr utf16le_mac = {
 	.bLength = USB_STRING_DESCRIPTOR_LENGTH(
 			CONFIG_USB_DEVICE_NETWORK_ECM_MAC),
 	.bDescriptorType = USB_DESC_STRING,


### PR DESCRIPTION
The new macro USBD_STRING_DESCR_USER_DEFINE works like
USBD_STRING_DESCR_DEFINE with the exception of being
ordered strictly after it. The new macro is needed to
ensures that user defined string descriptors can be added
without disturbing the order of string descriptors
defined by the usb subsystem.

Fixes  #41017