### PR TITLE
boards: nrf9160dk: enable external_flash_pins_routing by default

### DIFF
--- a/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840_0_14_0.overlay
+++ b/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840_0_14_0.overlay
@@ -21,7 +21,7 @@
 		external_flash_pins_routing: switch-ext-mem-ctrl {
 			compatible = "nordic,nrf9160dk-optional-routing";
 			control-gpios = <&gpio0 19 GPIO_ACTIVE_HIGH>;
-			status = "disabled";
+			status = "okay";
 		};
 	};
 };


### PR DESCRIPTION
It is not possible to connect to an external flash if this is not
enabled, causing a bad user experience.

Also, the official board controller firmware enables this use case by
default.

Hence we enable the required pin by default to improve the user
experience and to align with the official board controller firmware.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>