### PR TITLE
soc: arm: mps3: Only enable MVE if not QEMU

### DIFF
--- a/soc/arm/arm/mps3/Kconfig.soc
+++ b/soc/arm/arm/mps3/Kconfig.soc
@@ -12,7 +12,7 @@ config SOC_MPS3_AN547
 	select CPU_HAS_ARM_MPU
 	select CPU_HAS_FPU
 	select ARMV8_M_DSP
-	select ARMV8_1_M_MVEI
-	select ARMV8_1_M_MVEF
+	select ARMV8_1_M_MVEI if !QEMU_TARGET
+	select ARMV8_1_M_MVEF if !QEMU_TARGET
 
 endchoice


### PR DESCRIPTION
QEMU doesn't currently support MVE until the QEMU 6.2 release is out.
So for now only enable MVE support if we are NOT targetting QEMU.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>