### PR TITLE
drivers: lora: sx127: convert to spi_dt_spec

### DIFF
--- a/drivers/lora/sx127x.c
+++ b/drivers/lora/sx127x.c
@@ -98,8 +98,6 @@ BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(semtech_sx1272) +
 	     "Multiple SX127x instances in DT");
 
 #define GPIO_RESET_PIN		DT_INST_GPIO_PIN(0, reset_gpios)
-#define GPIO_CS_PIN		DT_INST_SPI_DEV_CS_GPIOS_PIN(0)
-#define GPIO_CS_FLAGS		DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0)
 
 #define GPIO_ANTENNA_ENABLE_PIN				\
 	DT_INST_GPIO_PIN(0, antenna_enable_gpios)
@@ -201,8 +199,7 @@ static struct sx127x_data {
 	const struct device *tcxo_power;
 	bool tcxo_power_enabled;
 #endif
-	const struct device *spi;
-	struct spi_config spi_cfg;
+	struct spi_dt_spec spi;
 	const struct device *dio_dev[SX127X_MAX_DIO];
 	struct k_work dio_work[SX127X_MAX_DIO];
 } dev_data;
@@ -416,10 +413,10 @@ static int sx127x_transceive(uint8_t reg, bool write, void *data, size_t length)
 			.count = ARRAY_SIZE(buf)
 		};
 
-		return spi_transceive(dev_data.spi, &dev_data.spi_cfg, &tx, &rx);
+		return spi_transceive_dt(&dev_data.spi, &tx, &rx);
 	}
 
-	return spi_write(dev_data.spi, &dev_data.spi_cfg, &tx);
+	return spi_write_dt(&dev_data.spi, &tx);
 }
 
 int sx127x_read(uint8_t reg_addr, uint8_t *data, uint8_t len)
@@ -585,37 +582,18 @@ static int sx127x_antenna_configure(void)
 
 static int sx127x_lora_init(const struct device *dev)
 {
-#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
-	static struct spi_cs_control spi_cs;
-#endif
 	int ret;
 	uint8_t regval;
 
-	dev_data.spi = device_get_binding(DT_INST_BUS_LABEL(0));
-	if (!dev_data.spi) {
-		LOG_ERR("Cannot get pointer to %s device",
-			DT_INST_BUS_LABEL(0));
-		return -EINVAL;
+	dev_data.spi = (struct spi_dt_spec) SPI_DT_SPEC_INST_GET(0,
+					SPI_WORD_SET(8) | SPI_TRANSFER_MSB,
+					0U);
+
+	if (!spi_is_ready(&dev_data.spi)) {
+		LOG_ERR("SPI bus %s is not ready",
+			dev_data.spi.bus->name);
+		return -ENODEV;
 	}
-
-	dev_data.spi_cfg.operation = SPI_WORD_SET(8) | SPI_TRANSFER_MSB;
-	dev_data.spi_cfg.frequency = DT_INST_PROP(0, spi_max_frequency);
-	dev_data.spi_cfg.slave = DT_INST_REG_ADDR(0);
-
-#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
-	spi_cs.gpio_dev = device_get_binding(DT_INST_SPI_DEV_CS_GPIOS_LABEL(0));
-	if (!spi_cs.gpio_dev) {
-		LOG_ERR("Cannot get pointer to %s device",
-			DT_INST_SPI_DEV_CS_GPIOS_LABEL(0));
-		return -EIO;
-	}
-
-	spi_cs.gpio_pin = GPIO_CS_PIN;
-	spi_cs.gpio_dt_flags = GPIO_CS_FLAGS;
-	spi_cs.delay = 0U;
-
-	dev_data.spi_cfg.cs = &spi_cs;
-#endif
 
 	ret = sx12xx_configure_pin(tcxo_power, GPIO_OUTPUT_INACTIVE);
 	if (ret) {


### PR DESCRIPTION
Convert sx127 driver to use `spi_dt_spec` helpers.

Signed-off-by: Bartosz Bilas <bartosz.bilas@hotmail.com>