### PR TITLE
drivers: ethernet: dsa_ksz8xxx: convert to spi_dt_spec

### DIFF
--- a/drivers/ethernet/dsa_ksz8xxx.c
+++ b/drivers/ethernet/dsa_ksz8xxx.c
@@ -13,10 +13,8 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME, CONFIG_ETHERNET_LOG_LEVEL);
 #include <kernel.h>
 #include <errno.h>
 #include <sys/util.h>
-#include <drivers/spi.h>
 #include <net/ethernet.h>
 #include <linker/sections.h>
-#include <drivers/spi.h>
 
 #if defined(CONFIG_DSA_SPI)
 #include <drivers/spi.h>


### PR DESCRIPTION
Convert dsa_ksz8xxx driver to use `spi_dt_spec` helpers.

Signed-off-by: Bartosz Bilas bartosz.bilas@hotmail.com