### PR TITLE
drivers: sensor: icm42605: convert to spi_dt_spec

### DIFF
--- a/drivers/sensor/icm42605/icm42605.c
+++ b/drivers/sensor/icm42605/icm42605.c
@@ -125,12 +125,13 @@ int icm42605_tap_fetch(const struct device *dev)
 {
 	int result = 0;
 	struct icm42605_data *drv_data = dev->data;
+	const struct icm42605_config *cfg = dev->config;
 
 	if (drv_data->tap_en &&
 	    (drv_data->tap_handler || drv_data->double_tap_handler)) {
-		result = inv_spi_read(REG_INT_STATUS3, drv_data->fifo_data, 1);
+		result = inv_spi_read(&cfg->spi, REG_INT_STATUS3, drv_data->fifo_data, 1);
 		if (drv_data->fifo_data[0] & BIT_INT_STATUS_TAP_DET) {
-			result = inv_spi_read(REG_APEX_DATA4,
+			result = inv_spi_read(&cfg->spi, REG_APEX_DATA4,
 					      drv_data->fifo_data, 1);
 			if (drv_data->fifo_data[0] & APEX_TAP) {
 				if (drv_data->tap_trigger.type ==
@@ -169,14 +170,15 @@ static int icm42605_sample_fetch(const struct device *dev,
 	int result = 0;
 	uint16_t fifo_count = 0;
 	struct icm42605_data *drv_data = dev->data;
+	const struct icm42605_config *cfg = dev->config;
 
 	/* Read INT_STATUS (0x45) and FIFO_COUNTH(0x46), FIFO_COUNTL(0x47) */
-	result = inv_spi_read(REG_INT_STATUS, drv_data->fifo_data, 3);
+	result = inv_spi_read(&cfg->spi, REG_INT_STATUS, drv_data->fifo_data, 3);
 
 	if (drv_data->fifo_data[0] & BIT_INT_STATUS_DRDY) {
 		fifo_count = (drv_data->fifo_data[1] << 8)
 			+ (drv_data->fifo_data[2]);
-		result = inv_spi_read(REG_FIFO_DATA, drv_data->fifo_data,
+		result = inv_spi_read(&cfg->spi, REG_FIFO_DATA, drv_data->fifo_data,
 				      fifo_count);
 
 		/* FIFO Data structure
@@ -390,30 +392,11 @@ static int icm42605_init(const struct device *dev)
 	struct icm42605_data *drv_data = dev->data;
 	const struct icm42605_config *cfg = dev->config;
 
-	drv_data->spi = device_get_binding(cfg->spi_label);
-	if (!drv_data->spi) {
-		LOG_ERR("SPI device not exist");
+	if (!spi_is_ready(&cfg->spi)) {
+		LOG_ERR("SPI bus is not ready");
 		return -ENODEV;
 	}
 
-	drv_data->spi_cs.gpio_dev = device_get_binding(cfg->gpio_label);
-
-	if (!drv_data->spi_cs.gpio_dev) {
-		LOG_ERR("GPIO device not exist");
-		return -ENODEV;
-	}
-
-	drv_data->spi_cs.gpio_pin = cfg->gpio_pin;
-	drv_data->spi_cs.gpio_dt_flags = cfg->gpio_dt_flags;
-	drv_data->spi_cs.delay = 0U;
-
-	drv_data->spi_cfg.frequency = cfg->frequency;
-	drv_data->spi_cfg.slave = cfg->slave;
-	drv_data->spi_cfg.operation = (SPI_OP_MODE_MASTER | SPI_MODE_CPOL |
-			SPI_MODE_CPHA | SPI_WORD_SET(8) | SPI_TRANSFER_MSB);
-	drv_data->spi_cfg.cs = &drv_data->spi_cs;
-
-	icm42605_spi_init(drv_data->spi, &drv_data->spi_cfg);
 	icm42605_data_init(drv_data, cfg);
 	icm42605_sensor_init(dev);
 
@@ -444,16 +427,16 @@ static const struct sensor_driver_api icm42605_driver_api = {
 
 #define ICM42605_DEFINE_CONFIG(index)					\
 	static const struct icm42605_config icm42605_cfg_##index = {	\
-		.spi_label = DT_INST_BUS_LABEL(index),			\
-		.spi_addr = DT_INST_REG_ADDR(index),			\
-		.frequency = DT_INST_PROP(index, spi_max_frequency),	\
-		.slave = DT_INST_REG_ADDR(index),			\
+		.spi = SPI_DT_SPEC_INST_GET(index,			\
+					    SPI_OP_MODE_MASTER |	\
+					    SPI_MODE_CPOL |		\
+					    SPI_MODE_CPHA |		\
+					    SPI_WORD_SET(8) |		\
+					    SPI_TRANSFER_MSB,		\
+					    0U),			\
 		.int_label = DT_INST_GPIO_LABEL(index, int_gpios),	\
 		.int_pin =  DT_INST_GPIO_PIN(index, int_gpios),		\
 		.int_flags = DT_INST_GPIO_FLAGS(index, int_gpios),	\
-		.gpio_label = DT_INST_SPI_DEV_CS_GPIOS_LABEL(index),	\
-		.gpio_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(index),	\
-		.gpio_dt_flags = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(index),	\
 		.accel_hz = DT_INST_PROP(index, accel_hz),		\
 		.gyro_hz = DT_INST_PROP(index, gyro_hz),		\
 		.accel_fs = DT_INST_ENUM_IDX(index, accel_fs),		\

--- a/drivers/sensor/icm42605/icm42605.h
+++ b/drivers/sensor/icm42605/icm42605.h
@@ -19,8 +19,6 @@ typedef void (*tap_fetch_t)(const struct device *dev);
 int icm42605_tap_fetch(const struct device *dev);
 
 struct icm42605_data {
-	const struct device *spi;
-
 	uint8_t fifo_data[HARDWARE_FIFO_SIZE];
 
 	int16_t accel_x;
@@ -63,16 +61,10 @@ struct icm42605_data {
 	struct k_thread thread;
 	struct k_sem gpio_sem;
 #endif
-
-	struct spi_cs_control spi_cs;
-	struct spi_config spi_cfg;
 };
 
 struct icm42605_config {
-	const char *spi_label;
-	uint16_t spi_addr;
-	uint32_t frequency;
-	uint32_t slave;
+	struct spi_dt_spec spi;
 	uint8_t int_pin;
 	uint8_t int_flags;
 	const char *int_label;

--- a/drivers/sensor/icm42605/icm42605_setup.c
+++ b/drivers/sensor/icm42605/icm42605_setup.c
@@ -16,10 +16,11 @@ LOG_MODULE_DECLARE(ICM42605, CONFIG_SENSOR_LOG_LEVEL);
 
 int icm42605_set_fs(const struct device *dev, uint16_t a_sf, uint16_t g_sf)
 {
+	const struct icm42605_config *cfg = dev->config;
 	uint8_t databuf;
 	int result;
 
-	result = inv_spi_read(REG_ACCEL_CONFIG0, &databuf, 1);
+	result = inv_spi_read(&cfg->spi, REG_ACCEL_CONFIG0, &databuf, 1);
 	if (result) {
 		return result;
 	}
@@ -27,9 +28,9 @@ int icm42605_set_fs(const struct device *dev, uint16_t a_sf, uint16_t g_sf)
 
 	databuf |= a_sf;
 
-	result = inv_spi_single_write(REG_ACCEL_CONFIG0, &databuf);
+	result = inv_spi_single_write(&cfg->spi, REG_ACCEL_CONFIG0, &databuf);
 
-	result = inv_spi_read(REG_GYRO_CONFIG0, &databuf, 1);
+	result = inv_spi_read(&cfg->spi, REG_GYRO_CONFIG0, &databuf, 1);
 
 	if (result) {
 		return result;
@@ -38,7 +39,7 @@ int icm42605_set_fs(const struct device *dev, uint16_t a_sf, uint16_t g_sf)
 	databuf &= ~BIT_GYRO_FSR;
 	databuf |= g_sf;
 
-	result = inv_spi_single_write(REG_GYRO_CONFIG0, &databuf);
+	result = inv_spi_single_write(&cfg->spi, REG_GYRO_CONFIG0, &databuf);
 
 	if (result) {
 		return result;
@@ -49,6 +50,7 @@ int icm42605_set_fs(const struct device *dev, uint16_t a_sf, uint16_t g_sf)
 
 int icm42605_set_odr(const struct device *dev, uint16_t a_rate, uint16_t g_rate)
 {
+	const struct icm42605_config *cfg = dev->config;
 	uint8_t databuf;
 	int result;
 
@@ -58,7 +60,7 @@ int icm42605_set_odr(const struct device *dev, uint16_t a_rate, uint16_t g_rate)
 		return -ENOTSUP;
 	}
 
-	result = inv_spi_read(REG_ACCEL_CONFIG0, &databuf, 1);
+	result = inv_spi_read(&cfg->spi, REG_ACCEL_CONFIG0, &databuf, 1);
 
 	if (result) {
 		return result;
@@ -94,7 +96,7 @@ int icm42605_set_odr(const struct device *dev, uint16_t a_rate, uint16_t g_rate)
 		databuf |= BIT_ACCEL_ODR_1;
 	}
 
-	result = inv_spi_single_write(REG_ACCEL_CONFIG0, &databuf);
+	result = inv_spi_single_write(&cfg->spi, REG_ACCEL_CONFIG0, &databuf);
 
 	if (result) {
 		return result;
@@ -102,7 +104,7 @@ int icm42605_set_odr(const struct device *dev, uint16_t a_rate, uint16_t g_rate)
 
 	LOG_DBG("Write Accel ODR 0x%X", databuf);
 
-	result = inv_spi_read(REG_GYRO_CONFIG0, &databuf, 1);
+	result = inv_spi_read(&cfg->spi, REG_GYRO_CONFIG0, &databuf, 1);
 
 	if (result) {
 		return result;
@@ -134,7 +136,7 @@ int icm42605_set_odr(const struct device *dev, uint16_t a_rate, uint16_t g_rate)
 
 	LOG_DBG("Write GYRO ODR 0x%X", databuf);
 
-	result = inv_spi_single_write(REG_GYRO_CONFIG0, &databuf);
+	result = inv_spi_single_write(&cfg->spi, REG_GYRO_CONFIG0, &databuf);
 	if (result) {
 		return result;
 	}
@@ -144,10 +146,11 @@ int icm42605_set_odr(const struct device *dev, uint16_t a_rate, uint16_t g_rate)
 
 int icm42605_sensor_init(const struct device *dev)
 {
+	const struct icm42605_config *cfg = dev->config;
 	int result = 0;
 	uint8_t v;
 
-	result = inv_spi_read(REG_WHO_AM_I, &v, 1);
+	result = inv_spi_read(&cfg->spi, REG_WHO_AM_I, &v, 1);
 
 	if (result) {
 		return result;
@@ -155,7 +158,7 @@ int icm42605_sensor_init(const struct device *dev)
 
 	LOG_DBG("WHO AM I : 0x%X", v);
 
-	result = inv_spi_read(REG_DEVICE_CONFIG, &v, 1);
+	result = inv_spi_read(&cfg->spi, REG_DEVICE_CONFIG, &v, 1);
 
 	if (result) {
 		LOG_DBG("read REG_DEVICE_CONFIG_REG failed");
@@ -164,7 +167,7 @@ int icm42605_sensor_init(const struct device *dev)
 
 	v |= BIT_SOFT_RESET;
 
-	result = inv_spi_single_write(REG_DEVICE_CONFIG, &v);
+	result = inv_spi_single_write(&cfg->spi, REG_DEVICE_CONFIG, &v);
 
 	if (result) {
 		LOG_ERR("write REG_DEVICE_CONFIG failed");
@@ -176,7 +179,7 @@ int icm42605_sensor_init(const struct device *dev)
 
 	v = BIT_GYRO_AFSR_MODE_HFS | BIT_ACCEL_AFSR_MODE_HFS | BIT_CLK_SEL_PLL;
 
-	result = inv_spi_single_write(REG_INTF_CONFIG1, &v);
+	result = inv_spi_single_write(&cfg->spi, REG_INTF_CONFIG1, &v);
 
 	if (result) {
 		LOG_ERR("write REG_INTF_CONFIG1 failed");
@@ -187,14 +190,14 @@ int icm42605_sensor_init(const struct device *dev)
 	    BIT_TMST_TO_REGS_EN |
 	    BIT_TMST_EN;
 
-	result = inv_spi_single_write(REG_TMST_CONFIG, &v);
+	result = inv_spi_single_write(&cfg->spi, REG_TMST_CONFIG, &v);
 
 	if (result) {
 		LOG_ERR("Write REG_TMST_CONFIG failed");
 		return result;
 	}
 
-	result = inv_spi_read(REG_INTF_CONFIG0, &v, 1);
+	result = inv_spi_read(&cfg->spi, REG_INTF_CONFIG0, &v, 1);
 
 	if (result) {
 		LOG_ERR("Read REG_INTF_CONFIG0 failed");
@@ -205,7 +208,7 @@ int icm42605_sensor_init(const struct device *dev)
 
 	v |= BIT_UI_SIFS_DISABLE_I2C;
 
-	result = inv_spi_single_write(REG_INTF_CONFIG0, &v);
+	result = inv_spi_single_write(&cfg->spi, REG_INTF_CONFIG0, &v);
 
 	if (result) {
 		LOG_ERR("Write REG_INTF_CONFIG failed");
@@ -213,13 +216,13 @@ int icm42605_sensor_init(const struct device *dev)
 	}
 
 	v = 0;
-	result = inv_spi_single_write(REG_INT_CONFIG1, &v);
+	result = inv_spi_single_write(&cfg->spi, REG_INT_CONFIG1, &v);
 
 	if (result) {
 		return result;
 	}
 
-	result = inv_spi_single_write(REG_PWR_MGMT0, &v);
+	result = inv_spi_single_write(&cfg->spi, REG_PWR_MGMT0, &v);
 
 	if (result) {
 		return result;
@@ -231,6 +234,7 @@ int icm42605_sensor_init(const struct device *dev)
 int icm42605_turn_on_fifo(const struct device *dev)
 {
 	const struct icm42605_data *drv_data = dev->data;
+	const struct icm42605_config *cfg = dev->config;
 
 	uint8_t int0_en = BIT_INT_UI_DRDY_INT1_EN;
 	uint8_t fifo_en = BIT_FIFO_ACCEL_EN | BIT_FIFO_GYRO_EN | BIT_FIFO_WM_TH;
@@ -239,70 +243,70 @@ int icm42605_turn_on_fifo(const struct device *dev)
 	uint8_t v = 0;
 
 	v = BIT_FIFO_MODE_BYPASS;
-	result = inv_spi_single_write(REG_FIFO_CONFIG, &v);
+	result = inv_spi_single_write(&cfg->spi, REG_FIFO_CONFIG, &v);
 	if (result) {
 		return result;
 	}
 
 	v = 0;
-	result = inv_spi_single_write(REG_FIFO_CONFIG1, &v);
+	result = inv_spi_single_write(&cfg->spi, REG_FIFO_CONFIG1, &v);
 	if (result) {
 		return result;
 	}
 
-	result = inv_spi_read(REG_FIFO_COUNTH, burst_read, 2);
+	result = inv_spi_read(&cfg->spi, REG_FIFO_COUNTH, burst_read, 2);
 	if (result) {
 		return result;
 	}
 
-	result = inv_spi_read(REG_FIFO_DATA, burst_read, 3);
+	result = inv_spi_read(&cfg->spi, REG_FIFO_DATA, burst_read, 3);
 	if (result) {
 		return result;
 	}
 
 	v = BIT_FIFO_MODE_STREAM;
-	result = inv_spi_single_write(REG_FIFO_CONFIG, &v);
+	result = inv_spi_single_write(&cfg->spi, REG_FIFO_CONFIG, &v);
 	if (result) {
 		return result;
 	}
 
-	result = inv_spi_single_write(REG_FIFO_CONFIG1, &fifo_en);
+	result = inv_spi_single_write(&cfg->spi, REG_FIFO_CONFIG1, &fifo_en);
 	if (result) {
 		return result;
 	}
 
-	result = inv_spi_single_write(REG_INT_SOURCE0, &int0_en);
+	result = inv_spi_single_write(&cfg->spi, REG_INT_SOURCE0, &int0_en);
 	if (result) {
 		return result;
 	}
 
 	if (drv_data->tap_en) {
 		v = BIT_TAP_ENABLE;
-		result = inv_spi_single_write(REG_APEX_CONFIG0, &v);
+		result = inv_spi_single_write(&cfg->spi, REG_APEX_CONFIG0, &v);
 		if (result) {
 			return result;
 		}
 
 		v = BIT_DMP_INIT_EN;
-		result = inv_spi_single_write(REG_SIGNAL_PATH_RESET, &v);
+		result = inv_spi_single_write(&cfg->spi, REG_SIGNAL_PATH_RESET, &v);
 		if (result) {
 			return result;
 		}
 
 		v = BIT_BANK_SEL_4;
-		result = inv_spi_single_write(REG_BANK_SEL, &v);
+		result = inv_spi_single_write(&cfg->spi, REG_BANK_SEL, &v);
 		if (result) {
 			return result;
 		}
 
 		v = BIT_INT_STATUS_TAP_DET;
-		result = inv_spi_single_write(REG_INT_SOURCE6, &v);
+		result = inv_spi_single_write(&cfg->spi, REG_INT_SOURCE6, &v);
 		if (result) {
 			return result;
 		}
 
 		v = BIT_BANK_SEL_0;
-		result = inv_spi_single_write(REG_BANK_SEL, &v);
+		result = inv_spi_single_write(&cfg->spi, REG_BANK_SEL, &v);
 		if (result) {
 			return result;
 		}
@@ -315,65 +319,65 @@ int icm42605_turn_on_fifo(const struct device *dev)
 int icm42605_turn_off_fifo(const struct device *dev)
 {
 	const struct icm42605_data *drv_data = dev->data;
-
+	const struct icm42605_config *cfg = dev->config;
 	uint8_t int0_en = 0;
 	uint8_t burst_read[3];
 	int result;
 	uint8_t v = 0;
 
 	v = BIT_FIFO_MODE_BYPASS;
-	result = inv_spi_single_write(REG_FIFO_CONFIG, &v);
+	result = inv_spi_single_write(&cfg->spi, REG_FIFO_CONFIG, &v);
 	if (result) {
 		return result;
 	}
 
 	v = 0;
-	result = inv_spi_single_write(REG_FIFO_CONFIG1, &v);
+	result = inv_spi_single_write(&cfg->spi, REG_FIFO_CONFIG1, &v);
 	if (result) {
 		return result;
 	}
 
-	result = inv_spi_read(REG_FIFO_COUNTH, burst_read, 2);
+	result = inv_spi_read(&cfg->spi, REG_FIFO_COUNTH, burst_read, 2);
 	if (result) {
 		return result;
 	}
 
-	result = inv_spi_read(REG_FIFO_DATA, burst_read, 3);
+	result = inv_spi_read(&cfg->spi, REG_FIFO_DATA, burst_read, 3);
 	if (result) {
 		return result;
 	}
 
-	result = inv_spi_single_write(REG_INT_SOURCE0, &int0_en);
+	result = inv_spi_single_write(&cfg->spi, REG_INT_SOURCE0, &int0_en);
 	if (result) {
 		return result;
 	}
 
 	if (drv_data->tap_en) {
 		v = 0;
-		result = inv_spi_single_write(REG_APEX_CONFIG0, &v);
+		result = inv_spi_single_write(&cfg->spi, REG_APEX_CONFIG0, &v);
 		if (result) {
 			return result;
 		}
 
-		result = inv_spi_single_write(REG_SIGNAL_PATH_RESET, &v);
+		result = inv_spi_single_write(&cfg->spi, REG_SIGNAL_PATH_RESET, &v);
 		if (result) {
 			return result;
 		}
 
 		v = BIT_BANK_SEL_4;
-		result = inv_spi_single_write(REG_BANK_SEL, &v);
+		result = inv_spi_single_write(&cfg->spi, REG_BANK_SEL, &v);
 		if (result) {
 			return result;
 		}
 
 		v = 0;
-		result = inv_spi_single_write(REG_INT_SOURCE6, &v);
+		result = inv_spi_single_write(&cfg->spi, REG_INT_SOURCE6, &v);
 		if (result) {
 			return result;
 		}
 
 		v = BIT_BANK_SEL_0;
-		result = inv_spi_single_write(REG_BANK_SEL, &v);
+		result = inv_spi_single_write(&cfg->spi, REG_BANK_SEL, &v);
 		if (result) {
 			return result;
 		}
@@ -385,7 +389,7 @@ int icm42605_turn_off_fifo(const struct device *dev)
 int icm42605_turn_on_sensor(const struct device *dev)
 {
 	struct icm42605_data *drv_data = dev->data;
-
+	const struct icm42605_config *cfg = dev->config;
 	uint8_t v = 0;
 	int result = 0;
 
@@ -402,7 +406,7 @@ int icm42605_turn_on_sensor(const struct device *dev)
 	v |= BIT_ACCEL_MODE_LNM;
 	v |= BIT_GYRO_MODE_LNM;
 
-	result = inv_spi_single_write(REG_PWR_MGMT0, &v);
+	result = inv_spi_single_write(&cfg->spi, REG_PWR_MGMT0, &v);
 	if (result) {
 		return result;
 	}
@@ -421,15 +425,16 @@ int icm42605_turn_on_sensor(const struct device *dev)
 
 int icm42605_turn_off_sensor(const struct device *dev)
 {
+	const struct icm42605_config *cfg = dev->config;
 	uint8_t v = 0;
 	int result = 0;
 
-	result = inv_spi_read(REG_PWR_MGMT0, &v, 1);
+	result = inv_spi_read(&cfg->spi, REG_PWR_MGMT0, &v, 1);
 
 	v ^= BIT_ACCEL_MODE_LNM;
 	v ^= BIT_GYRO_MODE_LNM;
 
-	result = inv_spi_single_write(REG_PWR_MGMT0, &v);
+	result = inv_spi_single_write(&cfg->spi, REG_PWR_MGMT0, &v);
 	if (result) {
 		return result;
 	}

--- a/drivers/sensor/icm42605/icm42605_spi.c
+++ b/drivers/sensor/icm42605/icm42605_spi.c
@@ -4,17 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <drivers/spi.h>
 #include <logging/log.h>
 #include <sys/__assert.h>
+#include "icm42605_spi.h"
 
 LOG_MODULE_DECLARE(ICM42605, CONFIG_SENSOR_LOG_LEVEL);
 
-static const struct device *spi_dev;
-static const struct spi_config *spi_cfg;
-
-int inv_spi_single_write(uint8_t reg, uint8_t *data)
+int inv_spi_single_write(const struct spi_dt_spec *bus, uint8_t reg, uint8_t *data)
 {
 	int result;
 
@@ -33,7 +29,7 @@ int inv_spi_single_write(uint8_t reg, uint8_t *data)
 		.count = 2,
 	};
 
-	result = spi_write(spi_dev, spi_cfg, &tx);
+	result = spi_write_dt(bus, &tx);
 
 	if (result) {
 		return result;
@@ -42,7 +38,7 @@ int inv_spi_single_write(uint8_t reg, uint8_t *data)
 	return 0;
 }
 
-int inv_spi_read(uint8_t reg, uint8_t *data, size_t len)
+int inv_spi_read(const struct spi_dt_spec *bus, uint8_t reg, uint8_t *data, size_t len)
 {
 	int result;
 	unsigned char tx_buffer[2] = { 0, };
@@ -74,23 +70,11 @@ int inv_spi_read(uint8_t reg, uint8_t *data, size_t len)
 		.count = 2,
 	};
 
-	result = spi_transceive(spi_dev, spi_cfg, &tx, &rx);
+	result = spi_transceive_dt(bus, &tx, &rx);
 
 	if (result) {
 		return result;
 	}
-
-	return 0;
-}
-
-int icm42605_spi_init(const struct device *spi_device,
-		      const struct spi_config *spi_config)
-{
-	__ASSERT_NO_MSG(spi_device);
-	__ASSERT_NO_MSG(spi_config);
-
-	spi_dev = spi_device;
-	spi_cfg = spi_config;
 
 	return 0;
 }

--- a/drivers/sensor/icm42605/icm42605_spi.h
+++ b/drivers/sensor/icm42605/icm42605_spi.h
@@ -8,10 +8,9 @@
 #define ZEPHYR_DRIVERS_SENSOR_ICM42605_ICM42605_SPI_H_
 
 #include <device.h>
+#include <drivers/spi.h>
 
-int inv_spi_single_write(uint8_t reg, uint8_t *data);
-int inv_spi_read(uint8_t reg, uint8_t *data, size_t len);
-int icm42605_spi_init(const struct device *spi_device,
-		      const struct spi_config *spi_config);
+int inv_spi_single_write(const struct spi_dt_spec *bus, uint8_t reg, uint8_t *data);
+int inv_spi_read(const struct spi_dt_spec *bus, uint8_t reg, uint8_t *data, size_t len);
 
 #endif /* __SENSOR_ICM42605_ICM42605_SPI__ */


### PR DESCRIPTION
Convert icm42605 driver to use spi_dt_spec helpers.

Signed-off-by: Bartosz Bilas <bartosz.bilas@hotmail.com>