### PR TITLE
drivers: sensor: max6675: convert to spi_dt_spec

### DIFF
--- a/drivers/sensor/max6675/max6675.c
+++ b/drivers/sensor/max6675/max6675.c
@@ -21,16 +21,10 @@ LOG_MODULE_REGISTER(max6675, CONFIG_SENSOR_LOG_LEVEL);
 #define TEMPERATURE_RES 25U
 
 struct max6675_config {
-	const char *spi_label;
-	struct spi_config spi_config;
-	const char *spi_cs_label;
-	gpio_pin_t spi_cs_pin;
-	gpio_dt_flags_t spi_cs_flags;
+	struct spi_dt_spec spi;
 };
 
 struct max6675_data {
-	const struct device *spi;
-	struct spi_cs_control cs_ctrl;
 	uint16_t sample;
 };
 
@@ -55,7 +49,7 @@ static int max6675_sample_fetch(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	ret = spi_read(data->spi, &config->spi_config, &rx_bufs);
+	ret = spi_read_dt(&config->spi, &rx_bufs);
 	if (ret < 0) {
 		return ret;
 	}
@@ -95,50 +89,27 @@ static const struct sensor_driver_api max6675_api = {
 
 static int max6675_init(const struct device *dev)
 {
-	struct max6675_data *data = dev->data;
 	const struct max6675_config *config = dev->config;
 
-	data->spi = device_get_binding(config->spi_label);
-	if (data->spi == NULL) {
-		LOG_ERR("Could not get SPI device %s", config->spi_label);
+	if (!spi_is_ready(&config->spi)) {
+		LOG_ERR("SPI bus is not ready");
 		return -ENODEV;
-	}
-
-	data->cs_ctrl.gpio_dev = device_get_binding(config->spi_cs_label);
-	if (data->cs_ctrl.gpio_dev != NULL) {
-		data->cs_ctrl.gpio_pin = config->spi_cs_pin;
-		data->cs_ctrl.gpio_dt_flags = config->spi_cs_flags;
-		data->cs_ctrl.delay = 0U;
 	}
 
 	return 0;
 }
 
-#define MAX6675_INIT(n)							       \
-	static struct max6675_data max6675_data_##n;			       \
-									       \
-	static const struct max6675_config max6675_config_##n = {	       \
-		.spi_label = DT_INST_BUS_LABEL(n),			       \
-		.spi_config = {						       \
-			.frequency = DT_INST_PROP_OR(n, spi_max_frequency, 0U),\
-			.operation = SPI_OP_MODE_MASTER | SPI_WORD_SET(8U),    \
-			.slave = DT_INST_REG_ADDR(n),			       \
-			.cs = &max6675_data_##n.cs_ctrl,		       \
-		},							       \
-		.spi_cs_label = UTIL_AND(				       \
-			DT_INST_SPI_DEV_HAS_CS_GPIOS(n),		       \
-			DT_INST_SPI_DEV_CS_GPIOS_LABEL(n)),		       \
-		.spi_cs_pin = UTIL_AND(					       \
-			DT_INST_SPI_DEV_HAS_CS_GPIOS(n),		       \
-			DT_INST_SPI_DEV_CS_GPIOS_PIN(n)),		       \
-		.spi_cs_flags = UTIL_AND(				       \
-			DT_INST_SPI_DEV_HAS_CS_GPIOS(n),		       \
-			DT_INST_SPI_DEV_CS_GPIOS_FLAGS(n)),		       \
-	};								       \
-									       \
-	DEVICE_DT_INST_DEFINE(n, &max6675_init, NULL,			       \
-			      &max6675_data_##n, &max6675_config_##n,	       \
-			      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,	       \
+#define MAX6675_INIT(n)							\
+	static struct max6675_data max6675_data_##n;			\
+	static const struct max6675_config max6675_config_##n = {	\
+		.spi = SPI_DT_SPEC_INST_GET(n,				\
+					    SPI_OP_MODE_MASTER |	\
+					    SPI_WORD_SET(8U),		\
+					    0U),			\
+	};								\
+	DEVICE_DT_INST_DEFINE(n, &max6675_init, NULL,			\
+			      &max6675_data_##n, &max6675_config_##n,	\
+			      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,	\
 			      &max6675_api);
 
 DT_INST_FOREACH_STATUS_OKAY(MAX6675_INIT)


### PR DESCRIPTION
Convert max6675 driver to use `spi_dt_spec` helpers.

Signed-off-by: Bartosz Bilas <bartosz.bilas@hotmail.com>