### PR TITLE
drivers: lora: sx126: convert to spi_dt_spec

### DIFF
--- a/drivers/lora/sx126x_common.h
+++ b/drivers/lora/sx126x_common.h
@@ -29,15 +29,11 @@
 #error No SX126x instance in device tree.
 #endif
 
-#define HAVE_GPIO_CS		DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 #define HAVE_GPIO_ANTENNA_ENABLE			\
 	DT_INST_NODE_HAS_PROP(0, antenna_enable_gpios)
 #define HAVE_GPIO_TX_ENABLE	DT_INST_NODE_HAS_PROP(0, tx_enable_gpios)
 #define HAVE_GPIO_RX_ENABLE	DT_INST_NODE_HAS_PROP(0, rx_enable_gpios)
 
-#define GPIO_CS_LABEL		DT_INST_SPI_DEV_CS_GPIOS_LABEL(0)
-#define GPIO_CS_PIN		DT_INST_SPI_DEV_CS_GPIOS_PIN(0)
-#define GPIO_CS_FLAGS		DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0)
 
 #define GPIO_ANTENNA_ENABLE_PIN	DT_INST_GPIO_PIN(0, antenna_enable_gpios)
 #define GPIO_TX_ENABLE_PIN	DT_INST_GPIO_PIN(0, tx_enable_gpios)
@@ -56,11 +52,7 @@ struct sx126x_data {
 #if HAVE_GPIO_RX_ENABLE
 	const struct device *rx_enable;
 #endif
-	const struct device *spi;
-	struct spi_config spi_cfg;
-#if HAVE_GPIO_CS
-	struct spi_cs_control spi_cs;
-#endif
+	struct spi_dt_spec spi;
 	RadioOperatingModes_t mode;
 };
 


### PR DESCRIPTION
Convert sx126 driver to use `spi_dt_spec` helpers.

Signed-off-by: Bartosz Bilas <bartosz.bilas@hotmail.com>