### PR TITLE
boards: mimxrt10xx: Add missing edma0 node to evaluation boards

### DIFF
--- a/boards/arm/mimxrt1010_evk/mimxrt1010_evk.dts
+++ b/boards/arm/mimxrt1010_evk/mimxrt1010_evk.dts
@@ -79,3 +79,7 @@ zephyr_udc0: &usb1 {
 &adc1 {
 	status = "okay";
 };
+
+&edma0 {
+	status = "okay";
+};

--- a/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
+++ b/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
@@ -108,3 +108,7 @@ zephyr_udc0: &usb1 {
 &adc1 {
 	status = "okay";
 };
+
+&edma0 {
+	status = "okay";
+};

--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -165,3 +165,7 @@ zephyr_udc0: &usb1 {
 &adc1 {
 	status = "okay";
 };
+
+&edma0 {
+	status = "okay";
+};

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -227,3 +227,7 @@ zephyr_udc0: &usb1 {
 &wdog0 {
 	status = "okay";
 };
+
+&edma0 {
+	status = "okay";
+};


### PR DESCRIPTION
EDMA0 node was missing from some RT10xx series evaluation boards,
causing SPI loopback test to fail to build. Add the node to the board
DTS files.

Fixes #41024

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>