### PR TITLE
drivers: watchdog_stm32: Freeze watchdog when MCU is halted

### DIFF
--- a/drivers/watchdog/wdt_iwdg_stm32.c
+++ b/drivers/watchdog/wdt_iwdg_stm32.c
@@ -179,6 +179,13 @@ static int iwdg_stm32_init(const struct device *dev)
 	iwdg_stm32_install_timeout(dev, &config);
 #endif
 
+#ifdef CONFIG_DEBUG
+	/* Freeze the IWDG when MCU is halt in debug mode */
+	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_DBGMCU);
+	LL_DBGMCU_APB1_GRP1_FreezePeriph(LL_DBGMCU_APB1_GRP1_IWDG_STOP);
+	LL_APB1_GRP1_DisableClock(LL_APB1_GRP1_PERIPH_DBGMCU);
+#endif /* CONFIG_DEBUG */
+
 	/*
 	 * The ST production value for the option bytes where WDG_SW bit is
 	 * present is 0x00FF55AA, namely the Software watchdog mode is

--- a/drivers/watchdog/wdt_wwdg_stm32.c
+++ b/drivers/watchdog/wdt_wwdg_stm32.c
@@ -282,6 +282,13 @@ static int wwdg_stm32_init(const struct device *dev)
 
 	wwdg_stm32_irq_config(dev);
 
+#ifdef CONFIG_DEBUG
+	/* Freeze the IWDG when MCU is halt in debug mode */
+	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_DBGMCU);
+	LL_DBGMCU_APB1_GRP1_FreezePeriph(LL_DBGMCU_APB1_GRP1_WWDG_STOP);
+	LL_APB1_GRP1_DisableClock(LL_APB1_GRP1_PERIPH_DBGMCU);
+#endif /* CONFIG_DEBUG */
+
 	return clock_control_on(clk, (clock_control_subsys_t *) &cfg->pclken);
 }
 


### PR DESCRIPTION
Freeze watchdog when MCU is halted in debug mode.

**Only tested on iWDG, patched wwdg driver together as I think they should be similar.**