### PR TITLE
doc: Fix typo for links to MAINTAINERS.yml

### DIFF
--- a/doc/contribute/external.rst
+++ b/doc/contribute/external.rst
@@ -103,7 +103,7 @@ Regardless of the mode of integration, external source code that is integrated
 in Zephyr requires regular ongoing maintenance. The submitter of the proposal to
 integrate external source code must therefore commit to maintain the integration
 of such code for the foreseeable future.
-This may require adding an entry in the :file:`MAINTAINERS.yaml` as part of the
+This may require adding an entry in the :file:`MAINTAINERS.yml` as part of the
 process.
 
 .. _external-src-process:

--- a/doc/development_process/project_roles.rst
+++ b/doc/development_process/project_roles.rst
@@ -248,7 +248,7 @@ MAINTAINERS File
 
 Generic guidelines for deciding and filling in the Maintainers' list
 
-* The :zephyr_file:`MAINTAINERS.yaml` file shall replace the
+* The :zephyr_file:`MAINTAINERS.yml` file shall replace the
   :zephyr_file:`CODEOWNERS` file and will be used for both setting assignees and
   reviewers.
 * We should keep the granularity of code maintainership at a manageable level


### PR DESCRIPTION
The file was referenced as MAINTAINERS.yaml instead of
MAINTAINERS.yml given invalid links.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>