### PR TITLE
drivers: eth: stm32: remove dead CAN L2 translation code

### DIFF
--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -90,35 +90,6 @@ static uint8_t dma_tx_buffer[ETH_TXBUFNB][ETH_TX_BUF_SIZE] __eth_stm32_buf;
 static ETH_TxPacketConfig tx_config;
 #endif
 
-#if defined(CONFIG_NET_L2_CANBUS_ETH_TRANSLATOR)
-#include <net/can.h>
-
-static void set_mac_to_translator_addr(uint8_t *mac_addr)
-{
-	/* Set the last 14 bit to the translator  link layer address to avoid
-	 * address collissions with the 6LoCAN address range
-	 */
-	mac_addr[4] = (mac_addr[4] & 0xC0) | (NET_CAN_ETH_TRANSLATOR_ADDR >> 8);
-	mac_addr[5] = NET_CAN_ETH_TRANSLATOR_ADDR & 0xFF;
-}
-
-static void enable_canbus_eth_translator_filter(ETH_HandleTypeDef *heth,
-						uint8_t *mac_addr)
-{
-	heth->Instance->MACA1LR = (mac_addr[3] << 24U) | (mac_addr[2] << 16U) |
-				  (mac_addr[1] << 8U) | mac_addr[0];
-
-#if defined(CONFIG_SOC_SERIES_STM32H7X)
-	heth->Instance->MACA1HR = ETH_MACAHR_AE | ETH_MACAHR_MBC_HBITS15_8 |
-				  ETH_MACAHR_MBC_HBITS7_0;
-#else
-	/*enable filter 1 and ignore byte 5 and 6 for filtering*/
-	heth->Instance->MACA1HR = ETH_MACA1HR_AE |  ETH_MACA1HR_MBC_HBits15_8 |
-				  ETH_MACA1HR_MBC_HBits7_0;
-#endif  /* CONFIG_SOC_SERIES_STM32H7X */
-}
-#endif /*CONFIG_NET_L2_CANBUS_ETH_TRANSLATOR*/
-
 static HAL_StatusTypeDef read_eth_phy_register(ETH_HandleTypeDef *heth,
 						uint32_t PHYAddr,
 						uint32_t PHYReg,
@@ -669,10 +640,6 @@ static int eth_initialize(const struct device *dev)
 #if defined(CONFIG_ETH_STM32_HAL_RANDOM_MAC)
 	generate_mac(dev_data->mac_addr);
 #endif
-#if defined(CONFIG_NET_L2_CANBUS_ETH_TRANSLATOR)
-	set_mac_to_translator_addr(dev_data->mac_addr);
-#endif
-
 	heth->Init.MACAddr = dev_data->mac_addr;
 
 #if defined(CONFIG_SOC_SERIES_STM32H7X)
@@ -745,10 +712,6 @@ static int eth_initialize(const struct device *dev)
 	}
 
 	disable_mcast_filter(heth);
-
-#if defined(CONFIG_NET_L2_CANBUS_ETH_TRANSLATOR)
-	enable_canbus_eth_translator_filter(heth, dev_data->mac_addr);
-#endif
 
 #if defined(CONFIG_SOC_SERIES_STM32H7X)
 	/* Adjust MDC clock range depending on HCLK frequency: */


### PR DESCRIPTION
Remove dead Ethernet/CAN L2 translation code guarded by non-existent `CONFIG_NET_L2_CANBUS_ETH_TRANSLATOR`.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>