### PR TITLE
usb: add iterable section in ram for usb_cfg_data 

### DIFF
--- a/doc/releases/release-notes-3.0.rst
+++ b/doc/releases/release-notes-3.0.rst
@@ -75,6 +75,11 @@ Removed APIs in this release:
   is changed so that it more closely mimics the real UART controller,
   option is no longer necessary.
 
+Deprecated in this release:
+
+* :c:macro:`USBD_CFG_DATA_DEFINE` is deprecated in favor of utilizing
+  :c:macro:`USBD_DEFINE_CFG_DATA`
+
 Stable API changes in this release
 ==================================
 

--- a/include/linker/common-ram.ld
+++ b/include/linker/common-ram.ld
@@ -122,13 +122,6 @@
 		__usb_descriptor_end = .;
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
-	SECTION_DATA_PROLOGUE(usb_data,,SUBALIGN(1))
-	{
-		__usb_data_start = .;
-		*(".usb.data")
-		KEEP(*(SORT_BY_NAME(".usb.data*")))
-		__usb_data_end = .;
-	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 	ITERABLE_SECTION_RAM(usb_cfg_data, 4)
 #endif /* CONFIG_USB_DEVICE_STACK */
 

--- a/include/linker/common-ram.ld
+++ b/include/linker/common-ram.ld
@@ -129,6 +129,7 @@
 		KEEP(*(SORT_BY_NAME(".usb.data*")))
 		__usb_data_end = .;
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+	ITERABLE_SECTION_RAM(usb_cfg_data, 4)
 #endif /* CONFIG_USB_DEVICE_STACK */
 
 #if defined(CONFIG_USB_DEVICE_BOS)

--- a/include/usb/usb_device.h
+++ b/include/usb/usb_device.h
@@ -68,7 +68,7 @@ extern "C" {
  * inside usb data section in the RAM.
  */
 #define USBD_CFG_DATA_DEFINE(p, name) \
-	static __in_section(usb, data_##p, name) __used
+	static __in_section(usb, data_##p, name) __used __aligned(4)
 
 /*************************************************************************
  *  USB configuration

--- a/include/usb/usb_device.h
+++ b/include/usb/usb_device.h
@@ -67,8 +67,11 @@ extern "C" {
  * This macro should be used to place the struct usb_cfg_data
  * inside usb data section in the RAM.
  */
-#define USBD_CFG_DATA_DEFINE(p, name) \
-	static __in_section(usb, data_##p, name) __used __aligned(4)
+#define USBD_DEFINE_CFG_DATA(name) \
+	static STRUCT_SECTION_ITERABLE(usb_cfg_data, name)
+
+#define USBD_CFG_DATA_DEFINE(p, name) __DEPRECATED_MACRO \
+	static __in_section(_usb_cfg_data, static, p##_name) __used __aligned(4)
 
 /*************************************************************************
  *  USB configuration

--- a/samples/net/wpanusb/src/wpanusb.c
+++ b/samples/net/wpanusb/src/wpanusb.c
@@ -163,7 +163,7 @@ static int wpanusb_vendor_handler(struct usb_setup_packet *setup,
 	return 0;
 }
 
-USBD_CFG_DATA_DEFINE(primary, wpanusb) struct usb_cfg_data wpanusb_config = {
+USBD_DEFINE_CFG_DATA(wpanusb_config) = {
 	.usb_device_description = NULL,
 	.interface_descriptor = &wpanusb_desc.if0,
 	.cb_usb_status = wpanusb_status_cb,

--- a/samples/subsys/usb/webusb/src/webusb.c
+++ b/samples/subsys/usb/webusb/src/webusb.c
@@ -215,7 +215,7 @@ static struct usb_ep_cfg_data webusb_ep_data[] = {
 	}
 };
 
-USBD_CFG_DATA_DEFINE(primary, webusb) struct usb_cfg_data webusb_config = {
+USBD_DEFINE_CFG_DATA(webusb_config) = {
 	.usb_device_description = NULL,
 	.interface_descriptor = &webusb_desc.if0,
 	.cb_usb_status = webusb_dev_status_cb,

--- a/subsys/tracing/tracing_backend_usb.c
+++ b/subsys/tracing/tracing_backend_usb.c
@@ -127,8 +127,7 @@ static struct usb_ep_cfg_data ep_cfg[] = {
 	},
 };
 
-USBD_CFG_DATA_DEFINE(primary, tracing_backend_usb)
-struct usb_cfg_data tracing_backend_usb_config = {
+USBD_DEFINE_CFG_DATA(tracing_backend_usb_config) = {
 	.usb_device_description = NULL,
 	.interface_descriptor = &dev_desc.if0,
 	.cb_usb_status = dev_status_cb,

--- a/subsys/usb/class/audio/audio.c
+++ b/subsys/usb/class/audio/audio.c
@@ -917,8 +917,7 @@ void usb_audio_register(const struct device *dev,
 }
 
 #define DEFINE_AUDIO_DEVICE(dev, i)					  \
-	USBD_CFG_DATA_DEFINE(primary, audio)				  \
-	struct usb_cfg_data dev##_audio_config_##i = {			  \
+	USBD_DEFINE_CFG_DATA(dev##_audio_config_##i) = {		  \
 		.usb_device_description	= NULL,				  \
 		.interface_config = audio_interface_config,		  \
 		.interface_descriptor = &dev##_desc_##i.std_ac_interface, \

--- a/subsys/usb/class/bluetooth.c
+++ b/subsys/usb/class/bluetooth.c
@@ -404,7 +404,7 @@ static void bluetooth_interface_config(struct usb_desc_header *head,
 	bluetooth_cfg.if0.bInterfaceNumber = bInterfaceNumber;
 }
 
-USBD_CFG_DATA_DEFINE(primary, hci) struct usb_cfg_data bluetooth_config = {
+USBD_DEFINE_CFG_DATA(bluetooth_config) = {
 	.usb_device_description = NULL,
 	.interface_config = bluetooth_interface_config,
 	.interface_descriptor = &bluetooth_cfg.if0,

--- a/subsys/usb/class/bt_h4.c
+++ b/subsys/usb/class/bt_h4.c
@@ -213,7 +213,7 @@ static void bt_h4_interface_config(struct usb_desc_header *head,
 	bt_h4_cfg.if0.bInterfaceNumber = bInterfaceNumber;
 }
 
-USBD_CFG_DATA_DEFINE(primary, hci_h4) struct usb_cfg_data bt_h4_config = {
+USBD_DEFINE_CFG_DATA(bt_h4_config) = {
 	.usb_device_description = NULL,
 	.interface_config = bt_h4_interface_config,
 	.interface_descriptor = &bt_h4_cfg.if0,

--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -1070,8 +1070,7 @@ static const struct uart_driver_api cdc_acm_driver_api = {
 		},							\
 	};								\
 									\
-	USBD_CFG_DATA_DEFINE(primary, cdc_acm)				\
-	struct usb_cfg_data cdc_acm_config_##x = {			\
+	USBD_DEFINE_CFG_DATA(cdc_acm_config_##x) = {			\
 		.usb_device_description = NULL,				\
 		.interface_config = cdc_interface_config,		\
 		.interface_descriptor = &cdc_acm_cfg_##x.if0,		\

--- a/subsys/usb/class/dfu/usb_dfu.c
+++ b/subsys/usb/class/dfu/usb_dfu.c
@@ -761,7 +761,7 @@ static void dfu_interface_config(struct usb_desc_header *head,
 }
 
 /* Configuration of the DFU Device send to the USB Driver */
-USBD_CFG_DATA_DEFINE(primary, dfu) struct usb_cfg_data dfu_config = {
+USBD_DEFINE_CFG_DATA(dfu_config) = {
 	.usb_device_description = NULL,
 	.interface_config = dfu_interface_config,
 	.interface_descriptor = &dfu_cfg.if0,
@@ -777,7 +777,7 @@ USBD_CFG_DATA_DEFINE(primary, dfu) struct usb_cfg_data dfu_config = {
  * Dummy configuration, this is necessary to configure DFU mode descriptor
  * which is an alternative (secondary) device descriptor.
  */
-USBD_CFG_DATA_DEFINE(secondary, dfu) struct usb_cfg_data dfu_mode_config = {
+USBD_DEFINE_CFG_DATA(dfu_mode_config) = {
 	.usb_device_description = NULL,
 	.interface_config = NULL,
 	.interface_descriptor = &dfu_mode_desc.sec_dfu_cfg.if0,

--- a/subsys/usb/class/hid/core.c
+++ b/subsys/usb/class/hid/core.c
@@ -623,8 +623,7 @@ static void hid_interface_config(struct usb_desc_header *head,
 }
 
 #define DEFINE_HID_CFG_DATA(x, _)					\
-	USBD_CFG_DATA_DEFINE(primary, hid)				\
-	struct usb_cfg_data hid_config_##x = {				\
+	USBD_DEFINE_CFG_DATA(hid_config_##x) = {			\
 		.usb_device_description = NULL,				\
 		.interface_config = hid_interface_config,		\
 		.interface_descriptor = &hid_cfg_##x.if0,		\

--- a/subsys/usb/class/loopback.c
+++ b/subsys/usb/class/loopback.c
@@ -167,7 +167,7 @@ static void loopback_interface_config(struct usb_desc_header *head,
 }
 
 /* usb.rst device config data start */
-USBD_CFG_DATA_DEFINE(primary, loopback) struct usb_cfg_data loopback_config = {
+USBD_DEFINE_CFG_DATA(loopback_config) = {
 	.usb_device_description = NULL,
 	.interface_config = loopback_interface_config,
 	.interface_descriptor = &loopback_cfg.if0,

--- a/subsys/usb/class/msc.c
+++ b/subsys/usb/class/msc.c
@@ -895,7 +895,7 @@ static void mass_interface_config(struct usb_desc_header *head,
 }
 
 /* Configuration of the Mass Storage Device send to the USB Driver */
-USBD_CFG_DATA_DEFINE(primary, msd) struct usb_cfg_data mass_storage_config = {
+USBD_DEFINE_CFG_DATA(mass_storage_config) = {
 	.usb_device_description = NULL,
 	.interface_config = mass_interface_config,
 	.interface_descriptor = &mass_cfg.if0,

--- a/subsys/usb/class/netusb/function_ecm.c
+++ b/subsys/usb/class/netusb/function_ecm.c
@@ -428,7 +428,7 @@ static void ecm_interface_config(struct usb_desc_header *head,
 #endif
 }
 
-USBD_CFG_DATA_DEFINE(primary, netusb) struct usb_cfg_data netusb_config = {
+USBD_DEFINE_CFG_DATA(cdc_ecm_config) = {
 	.usb_device_description = NULL,
 	.interface_config = ecm_interface_config,
 	.interface_descriptor = &cdc_ecm_cfg.if0,

--- a/subsys/usb/class/netusb/function_eem.c
+++ b/subsys/usb/class/netusb/function_eem.c
@@ -279,7 +279,7 @@ static void eem_interface_config(struct usb_desc_header *head,
 	cdc_eem_cfg.if0.bInterfaceNumber = bInterfaceNumber;
 }
 
-USBD_CFG_DATA_DEFINE(primary, netusb) struct usb_cfg_data netusb_config = {
+USBD_DEFINE_CFG_DATA(cdc_eem_config) = {
 	.usb_device_description = NULL,
 	.interface_config = eem_interface_config,
 	.interface_descriptor = &cdc_eem_cfg.if0,

--- a/subsys/usb/class/netusb/function_rndis.c
+++ b/subsys/usb/class/netusb/function_rndis.c
@@ -1158,7 +1158,7 @@ static void netusb_interface_config(struct usb_desc_header *head,
 	rndis_cfg.iad.bFirstInterface = bInterfaceNumber;
 }
 
-USBD_CFG_DATA_DEFINE(primary, netusb) struct usb_cfg_data netusb_config = {
+USBD_DEFINE_CFG_DATA(rndis_config) = {
 	.usb_device_description = NULL,
 	.interface_config = netusb_interface_config,
 	.interface_descriptor = &rndis_cfg.if0,

--- a/subsys/usb/usb_descriptor.c
+++ b/subsys/usb/usb_descriptor.c
@@ -36,8 +36,6 @@ LOG_MODULE_REGISTER(usb_descriptor);
 /* Linker-defined symbols bound the USB descriptor structs */
 extern struct usb_desc_header __usb_descriptor_start[];
 extern struct usb_desc_header __usb_descriptor_end[];
-extern struct usb_cfg_data __usb_data_start[];
-extern struct usb_cfg_data __usb_data_end[];
 
 /* Structure representing the global USB description */
 struct common_descriptor {
@@ -286,11 +284,9 @@ static int usb_validate_ep_cfg_data(struct usb_ep_descriptor * const ep_descr,
  */
 static struct usb_cfg_data *usb_get_cfg_data(struct usb_if_descriptor *iface)
 {
-	size_t length = (__usb_data_end - __usb_data_start);
-
-	for (size_t i = 0; i < length; i++) {
-		if (__usb_data_start[i].interface_descriptor == iface) {
-			return &__usb_data_start[i];
+	STRUCT_SECTION_FOREACH(usb_cfg_data, cfg_data) {
+		if (cfg_data->interface_descriptor == iface) {
+			return cfg_data;
 		}
 	}
 

--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -99,10 +99,6 @@ LOG_MODULE_REGISTER(usb_device);
 #define MAX_NUM_REQ_HANDLERS        4U
 #define MAX_STD_REQ_MSG_SIZE        8U
 
-/* Linker-defined symbols bound the USB descriptor structs */
-extern struct usb_cfg_data __usb_data_start[];
-extern struct usb_cfg_data __usb_data_end[];
-
 K_MUTEX_DEFINE(usb_enable_lock);
 
 static struct usb_dev_priv {
@@ -954,20 +950,17 @@ static bool usb_handle_std_interface_req(struct usb_setup_packet *setup,
  */
 static bool is_ep_valid(uint8_t ep)
 {
-	size_t size = (__usb_data_end - __usb_data_start);
 	const struct usb_ep_cfg_data *ep_data;
-	const struct usb_cfg_data *cfg;
 
 	/* Check if its Endpoint 0 */
 	if (USB_EP_GET_IDX(ep) == 0) {
 		return true;
 	}
 
-	for (size_t i = 0; i < size; i++) {
-		cfg = &__usb_data_start[i];
-		ep_data = cfg->endpoint;
+	STRUCT_SECTION_FOREACH(usb_cfg_data, cfg_data) {
+		ep_data = cfg_data->endpoint;
 
-		for (uint8_t n = 0; n < cfg->num_endpoints; n++) {
+		for (uint8_t n = 0; n < cfg_data->num_endpoints; n++) {
 			if (ep_data[n].ep_addr == ep) {
 				return true;
 			}
@@ -1168,13 +1161,12 @@ static void usb_register_status_callback(usb_dc_status_callback cb)
 
 static int foreach_ep(int (* endpoint_callback)(const struct usb_ep_cfg_data *))
 {
-	size_t size = (__usb_data_end - __usb_data_start);
+	struct usb_ep_cfg_data *ep_data;
 
-	for (size_t i = 0; i < size; i++) {
-		struct usb_cfg_data *cfg = &__usb_data_start[i];
-		struct usb_ep_cfg_data *ep_data = cfg->endpoint;
+	STRUCT_SECTION_FOREACH(usb_cfg_data, cfg_data) {
+		ep_data = cfg_data->endpoint;
 
-		for (uint8_t n = 0; n < cfg->num_endpoints; n++) {
+		for (uint8_t n = 0; n < cfg_data->num_endpoints; n++) {
 			int ret;
 
 			ret = endpoint_callback(&ep_data[n]);
@@ -1194,8 +1186,6 @@ static int disable_interface_ep(const struct usb_ep_cfg_data *ep_data)
 
 static void forward_status_cb(enum usb_dc_status_code status, const uint8_t *param)
 {
-	size_t size = (__usb_data_end - __usb_data_start);
-
 	if (status == USB_DC_DISCONNECTED) {
 		usb_reset_alt_setting();
 	}
@@ -1210,11 +1200,9 @@ static void forward_status_cb(enum usb_dc_status_code status, const uint8_t *par
 		}
 	}
 
-	for (size_t i = 0; i < size; i++) {
-		struct usb_cfg_data *cfg = &__usb_data_start[i];
-
-		if (cfg->cb_usb_status) {
-			cfg->cb_usb_status(cfg, status, param);
+	STRUCT_SECTION_FOREACH(usb_cfg_data, cfg_data) {
+		if (cfg_data->cb_usb_status) {
+			cfg_data->cb_usb_status(cfg_data, status, param);
 		}
 	}
 
@@ -1401,16 +1389,15 @@ int usb_wakeup_request(void)
 static int class_handler(struct usb_setup_packet *pSetup,
 			 int32_t *len, uint8_t **data)
 {
-	size_t size = (__usb_data_end - __usb_data_start);
 	const struct usb_if_descriptor *if_descr;
 	struct usb_interface_cfg_data *iface;
 
 	LOG_DBG("bRequest 0x%02x, wIndex 0x%04x",
 		pSetup->bRequest, pSetup->wIndex);
 
-	for (size_t i = 0; i < size; i++) {
-		iface = &(__usb_data_start[i].interface);
-		if_descr = __usb_data_start[i].interface_descriptor;
+	STRUCT_SECTION_FOREACH(usb_cfg_data, cfg_data) {
+		iface = &cfg_data->interface;
+		if_descr = cfg_data->interface_descriptor;
 		/*
 		 * Wind forward until it is within the range
 		 * of the current descriptor.
@@ -1431,16 +1418,15 @@ static int class_handler(struct usb_setup_packet *pSetup,
 static int custom_handler(struct usb_setup_packet *pSetup,
 			  int32_t *len, uint8_t **data)
 {
-	size_t size = (__usb_data_end - __usb_data_start);
 	const struct usb_if_descriptor *if_descr;
 	struct usb_interface_cfg_data *iface;
 
 	LOG_DBG("bRequest 0x%02x, wIndex 0x%04x",
 		pSetup->bRequest, pSetup->wIndex);
 
-	for (size_t i = 0; i < size; i++) {
-		iface = &(__usb_data_start[i].interface);
-		if_descr = __usb_data_start[i].interface_descriptor;
+	STRUCT_SECTION_FOREACH(usb_cfg_data, cfg_data) {
+		iface = &cfg_data->interface;
+		if_descr = cfg_data->interface_descriptor;
 		/*
 		 * Wind forward until it is within the range
 		 * of the current descriptor.
@@ -1475,7 +1461,6 @@ static int custom_handler(struct usb_setup_packet *pSetup,
 static int vendor_handler(struct usb_setup_packet *pSetup,
 			  int32_t *len, uint8_t **data)
 {
-	size_t size = (__usb_data_end - __usb_data_start);
 	struct usb_interface_cfg_data *iface;
 
 	LOG_DBG("bRequest 0x%02x, wIndex 0x%04x",
@@ -1487,8 +1472,8 @@ static int vendor_handler(struct usb_setup_packet *pSetup,
 		}
 	}
 
-	for (size_t i = 0; i < size; i++) {
-		iface = &(__usb_data_start[i].interface);
+	STRUCT_SECTION_FOREACH(usb_cfg_data, cfg_data) {
+		iface = &cfg_data->interface;
 		if (iface->vendor_handler) {
 			if (!iface->vendor_handler(pSetup, len, data)) {
 				return 0;
@@ -1501,12 +1486,11 @@ static int vendor_handler(struct usb_setup_packet *pSetup,
 
 static int composite_setup_ep_cb(void)
 {
-	size_t size = (__usb_data_end - __usb_data_start);
 	struct usb_ep_cfg_data *ep_data;
 
-	for (size_t i = 0; i < size; i++) {
-		ep_data = __usb_data_start[i].endpoint;
-		for (uint8_t n = 0; n < __usb_data_start[i].num_endpoints; n++) {
+	STRUCT_SECTION_FOREACH(usb_cfg_data, cfg_data) {
+		ep_data = cfg_data->endpoint;
+		for (uint8_t n = 0; n < cfg_data->num_endpoints; n++) {
 			LOG_DBG("set cb, ep: 0x%x", ep_data[n].ep_addr);
 			if (usb_dc_ep_set_callback(ep_data[n].ep_addr,
 						   ep_data[n].ep_cb)) {

--- a/tests/subsys/usb/desc_sections/src/desc_sections.c
+++ b/tests/subsys/usb/desc_sections/src/desc_sections.c
@@ -21,8 +21,8 @@ LOG_MODULE_REGISTER(test_main, LOG_LEVEL_DBG);
 /* Linker-defined symbols bound the USB descriptor structs */
 extern struct usb_desc_header __usb_descriptor_start[];
 extern struct usb_desc_header __usb_descriptor_end[];
-extern struct usb_cfg_data __usb_data_start[];
-extern struct usb_cfg_data __usb_data_end[];
+extern struct usb_cfg_data _usb_cfg_data_list_start[];
+extern struct usb_cfg_data _usb_cfg_data_list_end[];
 
 uint8_t *usb_get_device_descriptor(void);
 
@@ -94,8 +94,7 @@ struct usb_test_config {
 	};
 
 #define DEFINE_TEST_CFG_DATA(x, _)				\
-	USBD_CFG_DATA_DEFINE(primary, test_##x)			\
-	struct usb_cfg_data test_config_##x = {			\
+	USBD_DEFINE_CFG_DATA(test_config_##x) = {		\
 	.usb_device_description = NULL,				\
 	.interface_config = interface_config,			\
 	.interface_descriptor = &test_cfg_##x.if0,		\
@@ -127,11 +126,9 @@ UTIL_LISTIFY(NUM_INSTANCES, DEFINE_TEST_CFG_DATA, _)
 
 static struct usb_cfg_data *usb_get_cfg_data(struct usb_if_descriptor *iface)
 {
-	size_t length = (__usb_data_end - __usb_data_start);
-
-	for (size_t i = 0; i < length; i++) {
-		if (__usb_data_start[i].interface_descriptor == iface) {
-			return &__usb_data_start[i];
+	STRUCT_SECTION_FOREACH(usb_cfg_data, cfg_data) {
+		if (cfg_data->interface_descriptor == iface) {
+			return cfg_data;
 		}
 	}
 
@@ -215,10 +212,10 @@ static void test_desc_sections(void)
 	TC_PRINT("USB Descriptor table span %d\n",
 		 SYMBOL_SPAN(__usb_descriptor_end, __usb_descriptor_start));
 
-	TC_PRINT("__usb_data_start %p\n", __usb_data_start);
-	TC_PRINT("__usb_data_end %p\n", __usb_data_end);
+	TC_PRINT("_usb_cfg_data_list_start %p\n", _usb_cfg_data_list_start);
+	TC_PRINT("_usb_cfg_data_list_end %p\n", _usb_cfg_data_list_end);
 	TC_PRINT("USB Configuration data span %d\n",
-		 SYMBOL_SPAN(__usb_data_end, __usb_data_start));
+		 SYMBOL_SPAN(_usb_cfg_data_list_end, _usb_cfg_data_list_start));
 
 	TC_PRINT("sizeof usb_cfg_data %zu\n", sizeof(struct usb_cfg_data));
 
@@ -228,8 +225,8 @@ static void test_desc_sections(void)
 			SYMBOL_SPAN(__usb_descriptor_end, __usb_descriptor_start),
 			"USB Descriptor table section");
 
-	LOG_HEXDUMP_DBG((uint8_t *)__usb_data_start,
-			SYMBOL_SPAN(__usb_data_end, __usb_data_start),
+	LOG_HEXDUMP_DBG((uint8_t *)_usb_cfg_data_list_start,
+			SYMBOL_SPAN(_usb_cfg_data_list_end, _usb_cfg_data_list_start),
 			"USB Configuratio structures section");
 
 	head = (struct usb_desc_header *)__usb_descriptor_start;
@@ -239,8 +236,9 @@ static void test_desc_sections(void)
 		      TEST_DESCRIPTOR_TABLE_SPAN, NULL);
 
 	/* Calculate number of structures */
-	zassert_equal(__usb_data_end - __usb_data_start, NUM_INSTANCES, NULL);
-	zassert_equal(SYMBOL_SPAN(__usb_data_end, __usb_data_start),
+	zassert_equal(_usb_cfg_data_list_end - _usb_cfg_data_list_start,
+		      NUM_INSTANCES, NULL);
+	zassert_equal(SYMBOL_SPAN(_usb_cfg_data_list_end, _usb_cfg_data_list_start),
 		      NUM_INSTANCES * sizeof(struct usb_cfg_data), NULL);
 
 	check_endpoint_allocation(head);

--- a/tests/subsys/usb/device/src/main.c
+++ b/tests/subsys/usb/device/src/main.c
@@ -78,7 +78,7 @@ static struct usb_ep_cfg_data device_ep[] = {
 	},
 };
 
-USBD_CFG_DATA_DEFINE(primary, device) struct usb_cfg_data device_config = {
+USBD_DEFINE_CFG_DATA(device_config) = {
 	.usb_device_description = NULL,
 	.interface_descriptor = &dev_desc.if0,
 	.cb_usb_status = status_cb,


### PR DESCRIPTION
Add iterable section in ram for struct usb_cfg_data and
new makro USBD_DEFINE_CFG_DATA which should be used to
define usb_cfg_date structures.
Rework USB device support to use macro STRUCT_SECTION_FOREACH.

Fixes: #40640 