### PR TITLE
actions: clang: do not test all boards when --platform is given

### DIFF
--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -98,7 +98,7 @@ class Filters:
         self.find_tests()
         if not self.platforms:
             self.find_archs()
-        self.find_boards()
+            self.find_boards()
 
     def get_plan(self, options, integration=False):
         fname = "_test_plan_partial.csv"


### PR DESCRIPTION
If we are invoking testplan for only one board, do not bother with other
board related changes, just generate plan for the specified platform.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
