### PR TITLE
Correct instruction caching on cAVS 2.5 non-primary cores

### DIFF
--- a/soc/xtensa/intel_adsp/common/include/cpu_init.h
+++ b/soc/xtensa/intel_adsp/common/include/cpu_init.h
@@ -1,0 +1,94 @@
+/* Copyright (c) 2021 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef __INTEL_ADSP_CPU_INIT_H
+#define __INTEL_ADSP_CPU_INIT_H
+
+#define CxL1CCAP (*(volatile uint32_t *)0x9F080080)
+#define CxL1CCFG (*(volatile uint32_t *)0x9F080084)
+#define CxL1PCFG (*(volatile uint32_t *)0x9F080088)
+
+/* "Data/Instruction Cache Memory Way Count" fields */
+#define CxL1CCAP_DCMWC ((CxL1CCAP >> 16) & 7)
+#define CxL1CCAP_ICMWC ((CxL1CCAP >> 20) & 7)
+
+/* Low-level CPU initialization.  Call this immediately after entering
+ * C code to initialize the cache, protection and synchronization
+ * features.
+ */
+static ALWAYS_INLINE void cpu_early_init(void)
+{
+	uint32_t reg;
+
+	if (IS_ENABLED(CONFIG_SOC_SERIES_INTEL_CAVS_V25)) {
+		/* First, on cAVS 2.5 we need to power the cache SRAM banks
+		 * on!  Write a bit for each cache way in the bottom half of
+		 * the L1CCFG register and poll the top half for them to turn
+		 * on.
+		 */
+		uint32_t dmask = BIT(CxL1CCAP_DCMWC) - 1;
+		uint32_t imask = BIT(CxL1CCAP_ICMWC) - 1;
+		uint32_t waymask = (imask << 8) | dmask;
+
+		CxL1CCFG = waymask;
+		while (((CxL1CCFG >> 16) & waymask) != waymask) {
+		}
+
+		/* Prefetcher also power gates, same interface */
+		CxL1PCFG = 1;
+		while ((CxL1PCFG & 0x10000) == 0) {
+		}
+	}
+
+	/* Now set up the Xtensa CPU to enable the cache logic.  The
+	 * details of the fields are somewhat complicated, but per the
+	 * ISA ref: "Turning on caches at power-up usually consists of
+	 * writing a constant with bits[31:8] all 1’s to MEMCTL.".
+	 * Also set bit 0 to enable the LOOP extension instruction
+	 * fetch buffer.
+	 */
+#ifdef XCHAL_HAVE_ICACHE_DYN_ENABLE
+	reg = 0xffffff01;
+	__asm__ volatile("wsr %0, MEMCTL; rsync" :: "r"(reg));
+#endif
+
+	/* Likewise enable prefetching.  Sadly these values are not
+	 * architecturally defined by Xtensa (they're just documented
+	 * as priority hints), so this constant is just copied from
+	 * SOF for now.  If we care about prefetch priority tuning
+	 * we're supposed to ask Cadence I guess.
+	 */
+	reg = IS_ENABLED(CONFIG_SOC_SERIES_INTEL_CAVS_V25) ? 0x1038 : 0;
+	__asm__ volatile("wsr %0, PREFCTL; rsync" :: "r"(reg));
+
+	/* Finally we need to enable the cache in the Region
+	 * Protection Option "TLB" entries.  The hardware defaults
+	 * have this set to RW/uncached (2) everywhere.  We want
+	 * writeback caching (4) in the sixth mapping (the second of
+	 * two RAM mappings) and to mark all unused regions
+	 * inaccessible (15) for safety.  Note that there is a HAL
+	 * routine that does this (by emulating the older "cacheattr"
+	 * hardware register), but it generates significantly larger
+	 * code.
+	 */
+	if (IS_ENABLED(CONFIG_SOC_SERIES_INTEL_CAVS_V25)) {
+		/* Already set up by the ROM on older hardware. */
+		const uint8_t attribs[] = { 2, 15, 15, 15, 2, 4, 15, 15 };
+
+		for (int region = 0; region < 8; region++) {
+			reg = 0x20000000 * region;
+			__asm__ volatile("wdtlb %0, %1"
+					 :: "r"(attribs[region]), "r"(reg));
+		}
+	}
+
+	/* Initialize ATOMCTL: Hardware defaults for S32C1I use
+	 * "internal" operations, meaning they are atomic only WRT the
+	 * local CPU!  We need external transactions on the shared
+	 * bus.
+	 */
+	reg = 0x15;
+	__asm__ volatile("wsr %0, ATOMCTL" :: "r"(reg));
+}
+
+#endif /* __INTEL_ADSP_CPU_INIT_H */

--- a/soc/xtensa/intel_adsp/common/soc_mp.c
+++ b/soc/xtensa/intel_adsp/common/soc_mp.c
@@ -23,6 +23,7 @@ LOG_MODULE_REGISTER(soc_mp, CONFIG_SOC_LOG_LEVEL);
 #include <adsp/io.h>
 #include <cavs-shim.h>
 #include <cavs-mem.h>
+#include <cpu_init.h>
 
 extern void z_sched_ipi(void);
 extern void z_smp_start_cpu(int id);
@@ -94,93 +95,11 @@ __asm__(".align 4                   \n\t"
 	"  call4 z_mp_entry         \n\t");
 BUILD_ASSERT(XCHAL_EXCM_LEVEL == 5);
 
-#define CxL1CCAP (*(volatile uint32_t *)0x9F080080)
-#define CxL1CCFG (*(volatile uint32_t *)0x9F080084)
-#define CxL1PCFG (*(volatile uint32_t *)0x9F080088)
-
-/* "Data/Instruction Cache Memory Way Count" fields */
-#define CxL1CCAP_DCMWC ((CxL1CCAP >> 16) & 7)
-#define CxL1CCAP_ICMWC ((CxL1CCAP >> 20) & 7)
-
-static ALWAYS_INLINE void enable_l1_cache(void)
-{
-	uint32_t reg;
-
-#ifdef CONFIG_SOC_SERIES_INTEL_CAVS_V25
-	/* First, on cAVS 2.5 we need to power the cache SRAM banks
-	 * on!  Write a bit for each cache way in the bottom half of
-	 * the L1CCFG register and poll the top half for them to turn
-	 * on.
-	 */
-	uint32_t dmask = BIT(CxL1CCAP_DCMWC) - 1;
-	uint32_t imask = BIT(CxL1CCAP_ICMWC) - 1;
-	uint32_t waymask = (imask << 8) | dmask;
-
-	CxL1CCFG = waymask;
-	while (((CxL1CCFG >> 16) & waymask) != waymask) {
-	}
-
-	/* Prefetcher also power gates, same interface */
-	CxL1PCFG = 1;
-	while ((CxL1PCFG & 0x10000) == 0) {
-	}
-#endif
-
-	/* Now set up the Xtensa CPU to enable the cache logic.  The
-	 * details of the fields are somewhat complicated, but per the
-	 * ISA ref: "Turning on caches at power-up usually consists of
-	 * writing a constant with bits[31:8] all 1’s to MEMCTL.".
-	 * Also set bit 0 to enable the LOOP extension instruction
-	 * fetch buffer.
-	 */
-#ifdef XCHAL_HAVE_ICACHE_DYN_ENABLE
-	reg = 0xffffff01;
-	__asm__ volatile("wsr %0, MEMCTL; rsync" :: "r"(reg));
-#endif
-
-	/* Likewise enable prefetching.  Sadly these values are not
-	 * architecturally defined by Xtensa (they're just documented
-	 * as priority hints), so this constant is just copied from
-	 * SOF for now.  If we care about prefetch priority tuning
-	 * we're supposed to ask Cadence I guess.
-	 */
-	reg = IS_ENABLED(CONFIG_SOC_SERIES_INTEL_CAVS_V25) ? 0x1038 : 0;
-	__asm__ volatile("wsr %0, PREFCTL; rsync" :: "r"(reg));
-
-	/* Finally we need to enable the cache in the Region
-	 * Protection Option "TLB" entries.  The hardware defaults
-	 * have this set to RW/uncached (2) everywhere.  We want
-	 * writeback caching (4) in the sixth mapping (the second of
-	 * two RAM mappings) and to mark all unused regions
-	 * inaccessible (15) for safety.  Note that there is a HAL
-	 * routine that does this (by emulating the older "cacheattr"
-	 * hardware register), but it generates significantly larger
-	 * code.
-	 */
-#ifdef CONFIG_SOC_SERIES_INTEL_CAVS_V25
-	/* Already set up by the ROM on older hardware. */
-	const uint8_t attribs[] = { 2, 15, 15, 15, 2, 4, 15, 15 };
-
-	for (int region = 0; region < 8; region++) {
-		reg = 0x20000000 * region;
-		__asm__ volatile("wdtlb %0, %1" :: "r"(attribs[region]), "r"(reg));
-	}
-#endif
-}
-
 void z_mp_entry(void)
 {
 	uint32_t reg;
 
-	enable_l1_cache();
-
-	/* Fix ATOMCTL to match CPU0.  Hardware defaults for S32C1I
-	 * use internal operations (and are thus presumably atomic
-	 * only WRT the local CPU!).  We need external transactions on
-	 * the shared bus.
-	 */
-	reg = 0x15;
-	__asm__ volatile("wsr %0, ATOMCTL" :: "r"(reg));
+	cpu_early_init();
 
 	/* We don't know what the boot ROM (on pre-2.5 DSPs) might
 	 * have touched and we don't care.  Make sure it's not in our


### PR DESCRIPTION
The MP startup path on cAVS 2.5 was setting up the data caching behavior for the Xtensa region protection option, but forgetting the instruction cache.  This is clearly incorrect, and per the SOF team visible in some performance regressions that have been visible in Zephyr builds.

Pull request also includes a bit of refactoring to enable this (code coming right behind this finishes a big rework of the bootloader layer which unifies CPU initialization and code entry to a single path across all the platforms and for all cores).  The last patch contains the meat of the issue.