### PR TITLE
drivers: display: st7789v: Move params to `struct config`

### DIFF
--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -419,37 +419,43 @@ static const struct display_driver_api st7789v_api = {
 	.set_orientation = st7789v_set_orientation,
 };
 
-static const struct st7789v_config st7789v_config = {
-	.bus = SPI_DT_SPEC_INST_GET(0, SPI_OP_MODE_MASTER | SPI_WORD_SET(8), 0),
-	.cmd_data_gpio = GPIO_DT_SPEC_INST_GET(0, cmd_data_gpios),
-	.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(0, reset_gpios, {}),	\
-	.vcom = DT_INST_PROP(0, vcom),
-	.gctrl = DT_INST_PROP(0, gctrl),
-	.vdv_vrh_enable = (DT_INST_NODE_HAS_PROP(0, vrhs) && DT_INST_NODE_HAS_PROP(0, vdvs)),
-	.vrh_value = DT_INST_PROP_OR(0, vrhs, 0),
-	.vdv_value = DT_INST_PROP_OR(0, vdvs, 0),
-	.mdac = DT_INST_PROP(0, mdac),
-	.gamma = DT_INST_PROP(0, gamma),
-	.colmod = DT_INST_PROP(0, colmod),
-	.lcm = DT_INST_PROP(0, lcm),
-	.porch_param = DT_INST_PROP(0, porch_param),
-	.cmd2en_param = DT_INST_PROP(0, cmd2en_param),
-	.pwctrl1_param = DT_INST_PROP(0, pwctrl1_param),
-	.pvgam_param = DT_INST_PROP(0, pvgam_param),
-	.nvgam_param = DT_INST_PROP(0, nvgam_param),
-	.ram_param = DT_INST_PROP(0, ram_param),
-	.rgb_param = DT_INST_PROP(0, rgb_param),
-	.width = DT_INST_PROP(0, width),
-	.height = DT_INST_PROP(0, height),
-};
+#define ST7789V_INIT(inst)							\
+	static const struct st7789v_config st7789v_config_ ## inst = {		\
+		.bus = SPI_DT_SPEC_INST_GET(inst, SPI_OP_MODE_MASTER |          \
+							  SPI_WORD_SET(8), 0),	\
+		.cmd_data_gpio = GPIO_DT_SPEC_INST_GET(inst, cmd_data_gpios),	\
+		.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, reset_gpios, {}),	\
+		.vcom = DT_INST_PROP(inst, vcom),				\
+		.gctrl = DT_INST_PROP(inst, gctrl),				\
+		.vdv_vrh_enable = (DT_INST_NODE_HAS_PROP(inst, vrhs)            \
+					&& DT_INST_NODE_HAS_PROP(inst, vdvs)),	\
+		.vrh_value = DT_INST_PROP_OR(inst, vrhs, 0),			\
+		.vdv_value = DT_INST_PROP_OR(inst, vdvs, 0),			\
+		.mdac = DT_INST_PROP(inst, mdac),				\
+		.gamma = DT_INST_PROP(inst, gamma),				\
+		.colmod = DT_INST_PROP(inst, colmod),				\
+		.lcm = DT_INST_PROP(inst, lcm),					\
+		.porch_param = DT_INST_PROP(inst, porch_param),			\
+		.cmd2en_param = DT_INST_PROP(inst, cmd2en_param),		\
+		.pwctrl1_param = DT_INST_PROP(inst, pwctrl1_param),		\
+		.pvgam_param = DT_INST_PROP(inst, pvgam_param),			\
+		.nvgam_param = DT_INST_PROP(inst, nvgam_param),			\
+		.ram_param = DT_INST_PROP(inst, ram_param),			\
+		.rgb_param = DT_INST_PROP(inst, rgb_param),			\
+		.width = DT_INST_PROP(inst, width),				\
+		.height = DT_INST_PROP(inst, height),				\
+	};									\
+										\
+	static struct st7789v_data st7789v_data_ ## inst = {			\
+		.x_offset = DT_INST_PROP(inst, x_offset),			\
+		.y_offset = DT_INST_PROP(inst, y_offset),			\
+	};									\
+										\
+	PM_DEVICE_DT_INST_DEFINE(inst, st7789v_pm_action);			\
+										\
+	DEVICE_DT_INST_DEFINE(inst, &st7789v_init, PM_DEVICE_DT_INST_GET(inst), \
+			&st7789v_data_ ## inst, &st7789v_config_ ## inst,	\
+			POST_KERNEL, CONFIG_DISPLAY_INIT_PRIORITY,		\
+			&st7789v_api);
 
-static struct st7789v_data st7789v_data = {
-	.x_offset = DT_INST_PROP(0, x_offset),
-	.y_offset = DT_INST_PROP(0, y_offset),
-};
-
-PM_DEVICE_DT_INST_DEFINE(0, st7789v_pm_action);
-
-DEVICE_DT_INST_DEFINE(0, &st7789v_init, PM_DEVICE_DT_INST_GET(0), &st7789v_data,
-		      &st7789v_config, POST_KERNEL,
-		      CONFIG_DISPLAY_INIT_PRIORITY, &st7789v_api);
+DT_INST_FOREACH_STATUS_OKAY(ST7789V_INIT)


### PR DESCRIPTION
Move the const configuration parameters to `struct st7789v_config`.

Signed-off-by: Casper Meijn <casper@meijn.net>