### PR TITLE
Update RT10xx clock init

### DIFF
--- a/boards/arm/mimxrt1010_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1010_evk/CMakeLists.txt
@@ -5,4 +5,5 @@
 #
 
 zephyr_library()
-zephyr_library_sources(pinmux.c)
+zephyr_library_sources(pinmux.c clock_config.c)
+zephyr_include_directories(.)

--- a/boards/arm/mimxrt1010_evk/clock_config.c
+++ b/boards/arm/mimxrt1010_evk/clock_config.c
@@ -1,0 +1,367 @@
+/*
+ * Copyright (c) 2021, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * How to setup clock using clock driver functions:
+ *
+ * 1. Call CLOCK_InitXXXPLL() to configure corresponding PLL clock.
+ *
+ * 2. Call CLOCK_InitXXXpfd() to configure corresponding PLL pfd clock.
+ *
+ * 3. Call CLOCK_SetMux() to configure corresponding clock source for target clock out.
+ *
+ * 4. Call CLOCK_SetDiv() to configure corresponding clock divider for target clock out.
+ *
+ * 5. Call CLOCK_SetXtalFreq() to set XTAL frequency based on board settings.
+ *
+ */
+
+/* TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
+ * !!GlobalInfo
+ * product: Clocks v8.0
+ * processor: MIMXRT1011xxxxx
+ * package_id: MIMXRT1011DAE5A
+ * mcu_data: ksdk2_0
+ * processor_version: 10.0.0
+ * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS **********/
+
+#include "clock_config.h"
+#include "fsl_iomuxc.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+/* System clock frequency. */
+extern uint32_t SystemCoreClock;
+
+/*******************************************************************************
+ ************************ BOARD_InitBootClocks function ************************
+ ******************************************************************************/
+void BOARD_InitBootClocks(void)
+{
+	clock_init();
+}
+
+/*******************************************************************************
+ ************************** Configuration clock_init ***************************
+ ******************************************************************************/
+/* TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
+ * !!Configuration
+ * name: clock_init
+ * called_from_default_init: true
+ * outputs:
+ * - {id: ADC_ALT_CLK.outFreq, value: 40 MHz}
+ * - {id: CKIL_SYNC_CLK_ROOT.outFreq, value: 32.768 kHz}
+ * - {id: CLK_1M.outFreq, value: 1 MHz}
+ * - {id: CLK_24M.outFreq, value: 24 MHz}
+ * - {id: CORE_CLK_ROOT.outFreq, value: 500 MHz}
+ * - {id: ENET_500M_REF_CLK.outFreq, value: 500 MHz}
+ * - {id: FLEXIO1_CLK_ROOT.outFreq, value: 30 MHz}
+ * - {id: FLEXSPI_CLK_ROOT.outFreq, value: 90 MHz}
+ * - {id: GPT1_ipg_clk_highfreq.outFreq, value: 62.5 MHz}
+ * - {id: GPT2_ipg_clk_highfreq.outFreq, value: 62.5 MHz}
+ * - {id: IPG_CLK_ROOT.outFreq, value: 125 MHz}
+ * - {id: LPI2C_CLK_ROOT.outFreq, value: 10 MHz}
+ * - {id: LPSPI_CLK_ROOT.outFreq, value: 90 MHz}
+ * - {id: MQS_MCLK.outFreq, value: 540/13 MHz}
+ * - {id: PERCLK_CLK_ROOT.outFreq, value: 62.5 MHz}
+ * - {id: SAI1_CLK_ROOT.outFreq, value: 540/13 MHz}
+ * - {id: SAI1_MCLK1.outFreq, value: 540/13 MHz}
+ * - {id: SAI1_MCLK2.outFreq, value: 540/13 MHz}
+ * - {id: SAI1_MCLK3.outFreq, value: 30 MHz}
+ * - {id: SAI3_CLK_ROOT.outFreq, value: 540/13 MHz}
+ * - {id: SAI3_MCLK1.outFreq, value: 540/13 MHz}
+ * - {id: SAI3_MCLK3.outFreq, value: 30 MHz}
+ * - {id: SPDIF0_CLK_ROOT.outFreq, value: 30 MHz}
+ * - {id: TRACE_CLK_ROOT.outFreq, value: 99 MHz}
+ * - {id: UART_CLK_ROOT.outFreq, value: 80 MHz}
+ * - {id: USBPHY_CLK.outFreq, value: 480 MHz}
+ * settings:
+ * - {id: CCM.ADC_ACLK_PODF.scale, value: '12', locked: true}
+ * - {id: CCM.AHB_PODF.scale, value: '1', locked: true}
+ * - {id: CCM.CLKO2_DIV.scale, value: '1', locked: true}
+ * - {id: CCM.CLKO2_SEL.sel, value: XTALOSC24M.OSC_CLK}
+ * - {id: CCM.FLEXSPI_PODF.scale, value: '8', locked: true}
+ * - {id: CCM.FLEXSPI_SEL.sel, value: CCM_ANALOG.PLL3_PFD0_CLK}
+ * - {id: CCM.IPG_PODF.scale, value: '4', locked: true}
+ * - {id: CCM.LPI2C_CLK_PODF.scale, value: '6', locked: true}
+ * - {id: CCM.LPSPI_CLK_SEL.sel, value: CCM_ANALOG.PLL3_PFD0_CLK}
+ * - {id: CCM.LPSPI_PODF.scale, value: '8', locked: true}
+ * - {id: CCM.PERCLK_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.PERIPH_CLK2_SEL.sel, value: XTALOSC24M.OSC_CLK}
+ * - {id: CCM.PRE_PERIPH_CLK_SEL.sel, value: CCM_ANALOG.ENET_500M_REF_CLK}
+ * - {id: CCM.SAI1_CLK_SEL.sel, value: CCM_ANALOG.PLL3_PFD2_CLK}
+ * - {id: CCM.SAI3_CLK_SEL.sel, value: CCM_ANALOG.PLL3_PFD2_CLK}
+ * - {id: CCM.TRACE_PODF.scale, value: '4', locked: true}
+ * - {id: CCM_ANALOG.PLL2.denom, value: '1', locked: true}
+ * - {id: CCM_ANALOG.PLL2.num, value: '0', locked: true}
+ * - {id: CCM_ANALOG.PLL2_BYPASS.sel, value: CCM_ANALOG.PLL2_OUT_CLK}
+ * - {id: CCM_ANALOG.PLL2_PFD0_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD0}
+ * - {id: CCM_ANALOG.PLL2_PFD0_DIV.scale, value: '24', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD0_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD1_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD1}
+ * - {id: CCM_ANALOG.PLL2_PFD2_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD2}
+ * - {id: CCM_ANALOG.PLL2_PFD2_DIV.scale, value: '29', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD2_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD3_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD3}
+ * - {id: CCM_ANALOG.PLL2_PFD3_DIV.scale, value: '35', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD3_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_BYPASS.sel, value: CCM_ANALOG.PLL3}
+ * - {id: CCM_ANALOG.PLL3_PFD0_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD0}
+ * - {id: CCM_ANALOG.PLL3_PFD0_DIV.scale, value: '12', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD0_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD1_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD1}
+ * - {id: CCM_ANALOG.PLL3_PFD1_DIV.scale, value: '35', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD1_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD2_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD2}
+ * - {id: CCM_ANALOG.PLL3_PFD2_DIV.scale, value: '26', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD2_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD3_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD3}
+ * - {id: CCM_ANALOG.PLL3_PFD3_DIV.scale, value: '31', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD3_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL4.denom, value: '50'}
+ * - {id: CCM_ANALOG.PLL4.div, value: '27', locked: true}
+ * - {id: CCM_ANALOG.PLL4_POST_DIV.scale, value: '4', locked: true}
+ * - {id: CCM_ANALOG.PLL6_BYPASS.sel, value: CCM_ANALOG.PLL6}
+ * - {id: CCM_ANALOG_PLL_USB1_EN_USB_CLKS_CFG, value: Enabled}
+ * - {id: CCM_ANALOG_PLL_USB1_EN_USB_CLKS_OUT_CFG, value: Enabled}
+ * - {id: CCM_ANALOG_PLL_USB1_POWER_CFG, value: 'Yes'}
+ * sources:
+ * - {id: XTALOSC24M.RTC_OSC.outFreq, value: 32.768 kHz, enabled: true}
+ * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS **********/
+
+/*******************************************************************************
+ * Variables for clock_init configuration
+ ******************************************************************************/
+const clock_sys_pll_config_t sysPllConfig_clock_init = {
+	/* PLL loop divider, Fout = Fin * ( 20 + loopDivider*2 + numerator / denominator ) */
+	.loopDivider = 1,
+	/* 30 bit numerator of fractional loop divider */
+	.numerator = 0,
+	/* 30 bit denominator of fractional loop divider */
+	.denominator = 1,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+const clock_usb_pll_config_t usb1PllConfig_clock_init = {
+	/* PLL loop divider, Fout = Fin * 20 */
+	.loopDivider = 0,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+const clock_enet_pll_config_t enetPllConfig_clock_init = {
+	/* Enable the PLL providing the ENET 500MHz reference clock */
+	.enableClkOutput500M = true,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+/*******************************************************************************
+ * Code for clock_init configuration
+ ******************************************************************************/
+void clock_init(void)
+{
+	/* Init RTC OSC clock frequency. */
+	CLOCK_SetRtcXtalFreq(32768U);
+	/* Enable 1MHz clock output. */
+	XTALOSC24M->OSC_CONFIG2 |= XTALOSC24M_OSC_CONFIG2_ENABLE_1M_MASK;
+	/* Use free 1MHz clock output. */
+	XTALOSC24M->OSC_CONFIG2 &= ~XTALOSC24M_OSC_CONFIG2_MUX_1M_MASK;
+	/* Set XTAL 24MHz clock frequency. */
+	CLOCK_SetXtalFreq(24000000U);
+	/* Enable XTAL 24MHz clock source. */
+	CLOCK_InitExternalClk(0);
+	/* Enable internal RC. */
+	CLOCK_InitRcOsc24M();
+	/* Switch clock source to external OSC. */
+	CLOCK_SwitchOsc(kCLOCK_XtalOsc);
+	/* Set Oscillator ready counter value. */
+	CCM->CCR = (CCM->CCR & (~CCM_CCR_OSCNT_MASK)) | CCM_CCR_OSCNT(127);
+	/* Setting the VDD_SOC to 1.25V. It is necessary to config CORE to 500Mhz. */
+	DCDC->REG3 = (DCDC->REG3 & (~DCDC_REG3_TRG_MASK)) | DCDC_REG3_TRG(0x12);
+	/* Waiting for DCDC_STS_DC_OK bit is asserted */
+	while (DCDC_REG0_STS_DC_OK_MASK != (DCDC_REG0_STS_DC_OK_MASK & DCDC->REG0)) {
+	}
+	/* Set AHB_PODF. */
+	CLOCK_SetDiv(kCLOCK_AhbDiv, 0);
+	/* Disable IPG clock gate. */
+	CLOCK_DisableClock(kCLOCK_Adc1);
+	CLOCK_DisableClock(kCLOCK_Xbar1);
+	/* Set IPG_PODF. */
+	CLOCK_SetDiv(kCLOCK_IpgDiv, 3);
+	/* Init Enet PLL. */
+	CLOCK_InitEnetPll(&enetPllConfig_clock_init);
+	/* Set preperiph clock source. */
+	CLOCK_SetMux(kCLOCK_PrePeriphMux, 3);
+	/* Set periph clock source. */
+	CLOCK_SetMux(kCLOCK_PeriphMux, 0);
+	/* Set periph clock2 clock source. */
+	CLOCK_SetMux(kCLOCK_PeriphClk2Mux, 1);
+	/* Set per clock source. */
+	CLOCK_SetMux(kCLOCK_PerclkMux, 0);
+	/* Disable PERCLK clock gate. */
+	CLOCK_DisableClock(kCLOCK_Gpt1);
+	CLOCK_DisableClock(kCLOCK_Gpt1S);
+	CLOCK_DisableClock(kCLOCK_Gpt2);
+	CLOCK_DisableClock(kCLOCK_Gpt2S);
+	CLOCK_DisableClock(kCLOCK_Pit);
+	/* Set PERCLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_PerclkDiv, 1);
+	/*
+	 * In SDK projects, external flash (configured by FLEXSPI) will be initialized by dcd.
+	 * With this macro XIP_EXTERNAL_FLASH, usb1 pll (selected to be FLEXSPI clock source in
+	 * SDK projects) will be left unchanged.
+	 * Note: If another clock source is selected for FLEXSPI, user may want to avoid changing
+	 * that clock as well.
+	 */
+#if !(defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1))
+	/* Disable Flexspi clock gate. */
+	CLOCK_DisableClock(kCLOCK_FlexSpi);
+	/* Set FLEXSPI_PODF. */
+	CLOCK_SetDiv(kCLOCK_FlexspiDiv, 7);
+	/* Set Flexspi clock source. */
+	CLOCK_SetMux(kCLOCK_FlexspiMux, 3);
+	CLOCK_SetMux(kCLOCK_FlexspiSrcMux, 0);
+#endif
+	/* Disable ADC_ACLK_EN clock gate. */
+	CCM->CSCMR2 &= ~CCM_CSCMR2_ADC_ACLK_EN_MASK;
+	/* Set ADC_ACLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_AdcDiv, 11);
+	/* Disable LPSPI clock gate. */
+	CLOCK_DisableClock(kCLOCK_Lpspi1);
+	CLOCK_DisableClock(kCLOCK_Lpspi2);
+	/* Set LPSPI_PODF. */
+	CLOCK_SetDiv(kCLOCK_LpspiDiv, 7);
+	/* Set Lpspi clock source. */
+	CLOCK_SetMux(kCLOCK_LpspiMux, 1);
+	/* Disable TRACE clock gate. */
+	CLOCK_DisableClock(kCLOCK_Trace);
+	/* Set TRACE_PODF. */
+	CLOCK_SetDiv(kCLOCK_TraceDiv, 3);
+	/* Set Trace clock source. */
+	CLOCK_SetMux(kCLOCK_TraceMux, 2);
+	/* Disable SAI1 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Sai1);
+	/* Set SAI1_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Sai1PreDiv, 3);
+	/* Set SAI1_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Sai1Div, 1);
+	/* Set Sai1 clock source. */
+	CLOCK_SetMux(kCLOCK_Sai1Mux, 0);
+	/* Disable SAI3 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Sai3);
+	/* Set SAI3_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Sai3PreDiv, 3);
+	/* Set SAI3_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Sai3Div, 1);
+	/* Set Sai3 clock source. */
+	CLOCK_SetMux(kCLOCK_Sai3Mux, 0);
+	/* Disable Lpi2c clock gate. */
+	CLOCK_DisableClock(kCLOCK_Lpi2c1);
+	CLOCK_DisableClock(kCLOCK_Lpi2c2);
+	/* Set LPI2C_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Lpi2cDiv, 5);
+	/* Set Lpi2c clock source. */
+	CLOCK_SetMux(kCLOCK_Lpi2cMux, 0);
+	/* Disable UART clock gate. */
+	CLOCK_DisableClock(kCLOCK_Lpuart1);
+	CLOCK_DisableClock(kCLOCK_Lpuart2);
+	CLOCK_DisableClock(kCLOCK_Lpuart3);
+	CLOCK_DisableClock(kCLOCK_Lpuart4);
+	/* Set UART_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_UartDiv, 0);
+	/* Set Uart clock source. */
+	CLOCK_SetMux(kCLOCK_UartMux, 0);
+	/* Disable SPDIF clock gate. */
+	CLOCK_DisableClock(kCLOCK_Spdif);
+	/* Set SPDIF0_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Spdif0PreDiv, 1);
+	/* Set SPDIF0_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Spdif0Div, 7);
+	/* Set Spdif clock source. */
+	CLOCK_SetMux(kCLOCK_SpdifMux, 3);
+	/* Disable Flexio1 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Flexio1);
+	/* Set FLEXIO1_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Flexio1PreDiv, 1);
+	/* Set FLEXIO1_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Flexio1Div, 7);
+	/* Set Flexio1 clock source. */
+	CLOCK_SetMux(kCLOCK_Flexio1Mux, 3);
+	/* Set Pll3 sw clock source. */
+	CLOCK_SetMux(kCLOCK_Pll3SwMux, 0);
+	/* Init System PLL. */
+	CLOCK_InitSysPll(&sysPllConfig_clock_init);
+	/* Init System pfd0. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd0, 24);
+	/* Init System pfd1. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd1, 16);
+	/* Init System pfd2. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd2, 29);
+	/* Init System pfd3. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd3, 35);
+	/*
+	 * In SDK projects, external flash (configured by FLEXSPI) will be initialized by dcd.
+	 * With this macro XIP_EXTERNAL_FLASH, usb1 pll (selected to be FLEXSPI clock source in
+	 * SDK projects) will be left unchanged.
+	 * Note: If another clock source is selected for FLEXSPI, user may want to avoid changing
+	 * that clock as well.
+	 */
+#if !(defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1))
+	/* Init Usb1 PLL. */
+	CLOCK_InitUsb1Pll(&usb1PllConfig_clock_init);
+	/* Init Usb1 pfd0. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd0, 12);
+	/* Init Usb1 pfd1. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd1, 35);
+	/* Init Usb1 pfd2. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd2, 26);
+	/* Init Usb1 pfd3. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd3, 31);
+#endif
+	/* DeInit Audio PLL. */
+	CLOCK_DeinitAudioPll();
+	/* Bypass Audio PLL. */
+	CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllAudio, 1);
+	/* Set divider for Audio PLL. */
+	CCM_ANALOG->MISC2 &= ~CCM_ANALOG_MISC2_AUDIO_DIV_LSB_MASK;
+	CCM_ANALOG->MISC2 &= ~CCM_ANALOG_MISC2_AUDIO_DIV_MSB_MASK;
+	/* Enable Audio PLL output. */
+	CCM_ANALOG->PLL_AUDIO |= CCM_ANALOG_PLL_AUDIO_ENABLE_MASK;
+	/* Set clock out1 divider. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO1_DIV_MASK)) | CCM_CCOSR_CLKO1_DIV(0);
+	/* Set clock out1 source. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO1_SEL_MASK)) | CCM_CCOSR_CLKO1_SEL(1);
+	/* Set clock out2 divider. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO2_DIV_MASK)) | CCM_CCOSR_CLKO2_DIV(0);
+	/* Set clock out2 source. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO2_SEL_MASK)) | CCM_CCOSR_CLKO2_SEL(14);
+	/* Set clock out1 drives clock out1. */
+	CCM->CCOSR &= ~CCM_CCOSR_CLK_OUT_SEL_MASK;
+	/* Disable clock out1. */
+	CCM->CCOSR &= ~CCM_CCOSR_CLKO1_EN_MASK;
+	/* Disable clock out2. */
+	CCM->CCOSR &= ~CCM_CCOSR_CLKO2_EN_MASK;
+	/* Set SAI1 MCLK1 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk1Sel, 0);
+	/* Set SAI1 MCLK2 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk2Sel, 0);
+	/* Set SAI1 MCLK3 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk3Sel, 0);
+	/* Set SAI3 MCLK3 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI3MClk3Sel, 0);
+	/* Set MQS configuration. */
+	IOMUXC_MQSConfig(IOMUXC_GPR, kIOMUXC_MqsPwmOverSampleRate32, 0);
+	/* Set GPT1 High frequency reference clock source. */
+	IOMUXC_GPR->GPR5 &= ~IOMUXC_GPR_GPR5_VREF_1M_CLK_GPT1_MASK;
+	/* Set GPT2 High frequency reference clock source. */
+	IOMUXC_GPR->GPR5 &= ~IOMUXC_GPR_GPR5_VREF_1M_CLK_GPT2_MASK;
+	/* Set SystemCoreClock variable. */
+	SystemCoreClock = CLOCK_INIT_CORE_CLOCK;
+}

--- a/boards/arm/mimxrt1010_evk/clock_config.h
+++ b/boards/arm/mimxrt1010_evk/clock_config.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2021, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _CLOCK_CONFIG_H_
+#define _CLOCK_CONFIG_H_
+
+#include "fsl_common.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+/*!< Board xtal0 frequency in Hz */
+#define BOARD_XTAL0_CLK_HZ                         24000000U
+
+/*!< Board xtal32k frequency in Hz */
+#define BOARD_XTAL32K_CLK_HZ                          32768U
+/*******************************************************************************
+ ************************ BOARD_InitBootClocks function ************************
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus*/
+
+/*!
+ * @brief This function executes default configuration of clocks.
+ *
+ */
+void BOARD_InitBootClocks(void);
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus*/
+
+/*******************************************************************************
+ ************************** Configuration clock_init ***************************
+ ******************************************************************************/
+/*******************************************************************************
+ * Definitions for clock_init configuration
+ ******************************************************************************/
+/*!< Core clock frequency: 500000000Hz */
+#define CLOCK_INIT_CORE_CLOCK                     500000000U
+
+/* Clock outputs (values are in Hz): */
+#define CLOCK_INIT_ADC_ALT_CLK                        40000000UL
+#define CLOCK_INIT_CKIL_SYNC_CLK_ROOT                 32768UL
+#define CLOCK_INIT_CLKO1_CLK                          0UL
+#define CLOCK_INIT_CLKO2_CLK                          0UL
+#define CLOCK_INIT_CLK_1M                             1000000UL
+#define CLOCK_INIT_CLK_24M                            24000000UL
+#define CLOCK_INIT_CORE_CLK_ROOT                      500000000UL
+#define CLOCK_INIT_ENET_500M_REF_CLK                  500000000UL
+#define CLOCK_INIT_FLEXIO1_CLK_ROOT                   30000000UL
+#define CLOCK_INIT_FLEXSPI_CLK_ROOT                   90000000UL
+#define CLOCK_INIT_GPT1_IPG_CLK_HIGHFREQ              62500000UL
+#define CLOCK_INIT_GPT2_IPG_CLK_HIGHFREQ              62500000UL
+#define CLOCK_INIT_IPG_CLK_ROOT                       125000000UL
+#define CLOCK_INIT_LPI2C_CLK_ROOT                     10000000UL
+#define CLOCK_INIT_LPSPI_CLK_ROOT                     90000000UL
+#define CLOCK_INIT_MQS_MCLK                           41538461UL
+#define CLOCK_INIT_PERCLK_CLK_ROOT                    62500000UL
+#define CLOCK_INIT_SAI1_CLK_ROOT                      41538461UL
+#define CLOCK_INIT_SAI1_MCLK1                         41538461UL
+#define CLOCK_INIT_SAI1_MCLK2                         41538461UL
+#define CLOCK_INIT_SAI1_MCLK3                         30000000UL
+#define CLOCK_INIT_SAI3_CLK_ROOT                      41538461UL
+#define CLOCK_INIT_SAI3_MCLK1                         41538461UL
+#define CLOCK_INIT_SAI3_MCLK2                         0UL
+#define CLOCK_INIT_SAI3_MCLK3                         30000000UL
+#define CLOCK_INIT_SPDIF0_CLK_ROOT                    30000000UL
+#define CLOCK_INIT_SPDIF0_EXTCLK_OUT                  0UL
+#define CLOCK_INIT_TRACE_CLK_ROOT                     99000000UL
+#define CLOCK_INIT_UART_CLK_ROOT                      80000000UL
+#define CLOCK_INIT_USBPHY_CLK                         480000000UL
+
+/*! @brief Usb1 PLL set for clock_init configuration.
+ */
+extern const clock_usb_pll_config_t usb1PllConfig_clock_init;
+/*! @brief Sys PLL for clock_init configuration.
+ */
+extern const clock_sys_pll_config_t sysPllConfig_clock_init;
+/*! @brief Enet PLL set for clock_init configuration.
+ */
+extern const clock_enet_pll_config_t enetPllConfig_clock_init;
+
+/*******************************************************************************
+ * API for clock_init configuration
+ ******************************************************************************/
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus*/
+
+/*!
+ * @brief This function executes configuration of clocks.
+ *
+ */
+void clock_init(void);
+
+#if defined(__cplusplus)
+}
+#endif  /* __cplusplus*/
+
+#endif  /* _CLOCK_CONFIG_H_ */

--- a/boards/arm/mimxrt1010_evk/doc/index.rst
+++ b/boards/arm/mimxrt1010_evk/doc/index.rst
@@ -191,6 +191,110 @@ see the following message in the terminal:
 
     Hello World! mimxrt1010_evk
 
+MCUXpresso Config Tool
+======================
+
+A ``mimxrt1010_evk.mex`` file is included. This file was used to generate the clock
+initialization code and can be used as a starting point to tweak the clock configuration.
+This could be useful for different boards that are based on i.MX RT1010.
+
+NOTE: The MCUXpresso Config Tool currently generates a ``.c`` file with the clock configuration.
+Considering options on leveraging this tool in the future to generate a devicetree compatible file.
+
+Clock Configuration at Platform Initialization
+==============================================
+
+Below is the clock configuration at platform initialization.
+
+- On-chip 24MHz oscillator is enabled
+
+- Clock sources
+
++----------------------------+-----------------+
+| Name                       | Frequency       |
++============================+=================+
+| RTC Oscillator             | 32.768 kHz      |
++----------------------------+-----------------+
+| 24MHz clock source         | 24 MHz          |
++----------------------------+-----------------+
+| 1MHz clock                 | 1 MHz           |
++----------------------------+-----------------+
+| SAI1 MCLK                  | Inactive        |
++----------------------------+-----------------+
+| SAI3 MCLK                  | Inactive        |
++----------------------------+-----------------+
+| SPDIF_CLK_EXT              | Inactive        |
++----------------------------+-----------------+
+| SPDIF_SRCLK                | 1 MHz           |
++----------------------------+-----------------+
+| SPDIF_OUTCLK               | 1 MHz           |
++----------------------------+-----------------+
+
+- Clock outputs
+
++----------------------------+-----------------+
+| Name                       | Frequency       |
++============================+=================+
+| CORE_CLK_ROOT              | 500 MHz         |
++----------------------------+-----------------+
+| IPG_CLK_ROOT               | 125 MHz         |
++----------------------------+-----------------+
+| PERCLK_CLK_ROOT            | 62.5 MHz        |
++----------------------------+-----------------+
+| FLEXSPI_CLK_ROOT           | 90 MHz          |
++----------------------------+-----------------+
+| SPDIF0_CLK_ROOT            | 30 MHz          |
++----------------------------+-----------------+
+| FLEXIO1_CLK_ROOT           | 30 MHz          |
++----------------------------+-----------------+
+| SAI1_CLK_ROOT              | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI3_CLK_ROOT              | 41.53 MHz       |
++----------------------------+-----------------+
+| LPI2C_CLK_ROOT             | 10 MHz          |
++----------------------------+-----------------+
+| UART_CLK_ROOT              | 80 MHz          |
++----------------------------+-----------------+
+| ADC_ALT_CLK                | 40 MHz          |
++----------------------------+-----------------+
+| LPSPI_CLK_ROOT             | 90 MHz          |
++----------------------------+-----------------+
+| TRACE_CLK_ROOT             | 99 MHz          |
++----------------------------+-----------------+
+| CKIL_SYNC_CLK_ROOT         | 32.768 kHz      |
++----------------------------+-----------------+
+| Clock 1M output            | 1 MHz           |
++----------------------------+-----------------+
+| Clock 24MHz output         | 24 MHz          |
++----------------------------+-----------------+
+| CLKO1_CLK                  | Inactive        |
++----------------------------+-----------------+
+| CLKO2_CLK                  | Inactive        |
++----------------------------+-----------------+
+| ENET_500M_CLK              | 500 MHz         |
++----------------------------+-----------------+
+| USBPHY PLL clock           | 480 MHz         |
++----------------------------+-----------------+
+| GPT1 high frequency clock  | 62.5 MHz        |
++----------------------------+-----------------+
+| GPT2 high frequency clock  | 62.5 MHz        |
++----------------------------+-----------------+
+| SAI1 MCLK 1                | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI1 MCLK 2                | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI1 MCLK 3                | 30 MHz          |
++----------------------------+-----------------+
+| SAI3 MCLK 1                | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI3 MCLK 2                | Inactive        |
++----------------------------+-----------------+
+| SAI3 MCLK 3                | 30 MHz          |
++----------------------------+-----------------+
+| SPDIF0_EXTCLK              | Inactive        |
++----------------------------+-----------------+
+| MQS MCLK                   | 41.53 MHz       |
++----------------------------+-----------------+
 
 .. _MIMXRT1010-EVK Website:
    https://www.nxp.com/MIMXRT1010-EVK

--- a/boards/arm/mimxrt1010_evk/mimxrt1010_evk.mex
+++ b/boards/arm/mimxrt1010_evk/mimxrt1010_evk.mex
@@ -1,0 +1,1060 @@
+<?xml version="1.0" encoding= "UTF-8" ?>
+<configuration name="MIMXRT1011xxxxx" xsi:schemaLocation="http://mcuxpresso.nxp.com/XSD/mex_configuration_10 http://mcuxpresso.nxp.com/XSD/mex_configuration_10.xsd" uuid="de3bdbe5-65cf-482d-b1be-cd17b780459b" version="10" xmlns="http://mcuxpresso.nxp.com/XSD/mex_configuration_10" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+   <common>
+      <processor>MIMXRT1011xxxxx</processor>
+      <package>MIMXRT1011DAE5A</package>
+      <mcu_data>ksdk2_0</mcu_data>
+      <cores selected="core0">
+         <core name="Cortex-M7F" id="core0" description="M7 core"/>
+      </cores>
+      <description></description>
+   </common>
+   <preferences>
+      <validate_boot_init_only>true</validate_boot_init_only>
+      <generate_extended_information>false</generate_extended_information>
+      <generate_code_modified_registers_only>false</generate_code_modified_registers_only>
+      <update_include_paths>true</update_include_paths>
+   </preferences>
+   <tools>
+      <pins name="Pins" version="10.0" enabled="true" update_project_code="false">
+         <generated_project_files>
+            <file path="board/pin_mux.c" update_enabled="true"/>
+            <file path="board/pin_mux.h" update_enabled="true"/>
+         </generated_project_files>
+         <pins_profile>
+            <processor_version>10.0.0</processor_version>
+            <power_domains/>
+            <pin_labels>
+               <pin_label pin_num="78" pin_signal="VSS_4" label="LPI2C1_SCL" identifier="LPI2C1_SCL"/>
+               <pin_label pin_num="77" pin_signal="VDD_SOC_IN_3" label="LPI2C1_SDA" identifier="LPI2C1_SDA"/>
+               <pin_label pin_num="76" pin_signal="GPIO_SD_00" label="LCD_RESET" identifier="LCD_RESET"/>
+               <pin_label pin_num="66" pin_signal="GPIO_SD_09" label="JTAG_TDI/J21[5]/ENET_RST/J22[5]" identifier="ENET_RST"/>
+               <pin_label pin_num="64" pin_signal="GPIO_SD_11" label="LCD_TOUCH_INT" identifier="INT2_COMBO"/>
+            </pin_labels>
+         </pins_profile>
+         <functions_list>
+            <function name="pinmux_ENET">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="ENET" description="Peripheral ENET is not initialized" problem_level="1" source="Pins:pinmux_ENET">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_ENET">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="ENET" signal="enet_rx_data, 0" pin_num="" pin_signal="GPIO_B1_04">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_rx_data, 1" pin_num="" pin_signal="GPIO_B1_05">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_rx_en" pin_num="" pin_signal="GPIO_B1_06">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_tx_data, 0" pin_num="" pin_signal="GPIO_B1_07">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_tx_data, 1" pin_num="" pin_signal="GPIO_B1_08">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_tx_en" pin_num="" pin_signal="GPIO_B1_09">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_ref_clk" pin_num="" pin_signal="GPIO_B1_10">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="software_input_on" value="Enable"/>
+                        <pin_feature name="speed" value="MHZ_50"/>
+                        <pin_feature name="drive_strength" value="R0_6"/>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                        <pin_feature name="pull_keeper_enable" value="Disable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_rx_er" pin_num="" pin_signal="GPIO_B1_11">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_mdc" pin_num="" pin_signal="GPIO_EMC_40">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_mdio" pin_num="" pin_signal="GPIO_EMC_41">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="GPIO1" signal="gpio_io, 10" pin_num="" pin_signal="GPIO_EMC_18">
+                     <pin_features>
+                        <pin_feature name="speed" value="MHZ_100"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_ENET_RST">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_ENET_RST">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="GPIO1" signal="gpio_io, 09" pin_num="" pin_signal="GPIO_EMC_17">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_100"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_LPI2C1">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="LPI2C1" description="Peripheral LPI2C1 is not initialized" problem_level="1" source="Pins:pinmux_LPI2C1">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_LPI2C1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="LPI2C1" signal="SDA" pin_num="" pin_signal="VDD_SOC_IN_5"/>
+                  <pin peripheral="LPI2C1" signal="SCL" pin_num="" pin_signal="VSS_8"/>
+               </pins>
+            </function>
+            <function name="pinmux_LCDIF">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="LCDIF" description="Peripheral LCDIF is not initialized" problem_level="1" source="Pins:pinmux_LCDIF">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_LCDIF">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="LCDIF" signal="lcdif_clk" pin_num="" pin_signal="GPIO_B0_00">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_enable" pin_num="" pin_signal="GPIO_B0_01">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_hsync" pin_num="" pin_signal="GPIO_B0_02">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_vsync" pin_num="" pin_signal="GPIO_B0_03">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 00" pin_num="" pin_signal="GPIO_B0_04">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 01" pin_num="" pin_signal="GPIO_B0_05">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 02" pin_num="" pin_signal="GPIO_B0_06">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 03" pin_num="" pin_signal="GPIO_B0_07">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 04" pin_num="" pin_signal="GPIO_B0_08">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 05" pin_num="" pin_signal="GPIO_B0_09">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 06" pin_num="" pin_signal="GPIO_B0_10">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 07" pin_num="" pin_signal="GPIO_B0_11">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 08" pin_num="" pin_signal="GPIO_B0_12">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 09" pin_num="" pin_signal="GPIO_B0_13">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 10" pin_num="" pin_signal="GPIO_B0_14">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 11" pin_num="" pin_signal="GPIO_B0_15">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 12" pin_num="" pin_signal="GPIO_B1_00">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 13" pin_num="" pin_signal="GPIO_B1_01">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 14" pin_num="" pin_signal="GPIO_B1_02">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 15" pin_num="" pin_signal="GPIO_B1_03">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="GPIO1" signal="gpio_io, 02" pin_num="76" pin_signal="GPIO_SD_00"/>
+                  <pin peripheral="GPIO2" signal="gpio_io, 31" pin_num="" pin_signal="GPIO_B1_15"/>
+               </pins>
+            </function>
+            <function name="pinmux_LPUART1">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="LPUART1" description="Peripheral LPUART1 is not initialized" problem_level="1" source="Pins:pinmux_LPUART1">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_LPUART1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="LPUART1" signal="RX" pin_num="" pin_signal="NVCC_GPIO_6"/>
+                  <pin peripheral="LPUART1" signal="TX" pin_num="" pin_signal="GPIO_EMC_20">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Slow"/>
+                        <pin_feature name="software_input_on" value="Disable"/>
+                        <pin_feature name="open_drain" value="Disable"/>
+                        <pin_feature name="speed" value="MHZ_100"/>
+                        <pin_feature name="drive_strength" value="R0_6"/>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                        <pin_feature name="pull_keeper_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Disable"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_FT5336_int">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_FT5336_int">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="GPIO1" signal="gpio_io, 11" pin_num="" pin_signal="GPIO_EMC_19">
+                     <pin_features>
+                        <pin_feature name="drive_strength" value="R0_6"/>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_FlexSPIA">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="FLEXSPI" description="Peripheral FLEXSPI is not initialized" problem_level="1" source="Pins:pinmux_FlexSPIA">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_FlexSPIA">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_FlexSPIA">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_DQS" pin_num="26" pin_signal="VDD_SNVS_CAP"/>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_SS0_B" pin_num="25" pin_signal="VDD_SNVS_IN"/>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_SCLK" pin_num="24" pin_signal="PMIC_ON_REQ"/>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_DATA0" pin_num="23" pin_signal="TEST_MODE"/>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_DATA1" pin_num="22" pin_signal="POR_B">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_DATA2" pin_num="21" pin_signal="ONOFF">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_DATA3" pin_num="19" pin_signal="DCDC_LP"/>
+               </pins>
+            </function>
+            <function name="pinmux_FlexCAN3">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="CAN3" description="Peripheral CAN3 is not initialized" problem_level="1" source="Pins:pinmux_FlexCAN3">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_FlexCAN3">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="CAN3" signal="TX" pin_num="" pin_signal="GPIO_EMC_36"/>
+                  <pin peripheral="CAN3" signal="RX" pin_num="" pin_signal="GPIO_EMC_37"/>
+               </pins>
+            </function>
+            <function name="pinmux_FlexCAN2">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="CAN2" description="Peripheral CAN2 is not initialized" problem_level="1" source="Pins:pinmux_FlexCAN2">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_FlexCAN2">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="CAN2" signal="TX" pin_num="" pin_signal="GPIO_EMC_21"/>
+                  <pin peripheral="CAN2" signal="RX" pin_num="" pin_signal="GPIO_EMC_22"/>
+               </pins>
+            </function>
+            <function name="pinmux_FlexCAN1">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="CAN1" description="Peripheral CAN1 is not initialized" problem_level="1" source="Pins:pinmux_FlexCAN1">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_FlexCAN1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="CAN1" signal="TX" pin_num="" pin_signal="GPIO_EMC_35"/>
+                  <pin peripheral="CAN1" signal="RX" pin_num="" pin_signal="VDD_SOC_IN_4"/>
+               </pins>
+            </function>
+            <function name="pinmux_CSI">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="CSI" description="Peripheral CSI is not initialized" problem_level="1" source="Pins:pinmux_CSI">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_CSI">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="GPIO1" signal="gpio_io, 04" pin_num="74" pin_signal="GPIO_SD_02"/>
+                  <pin peripheral="CSI" signal="csi_pixclk" pin_num="" pin_signal="GPIO_EMC_25"/>
+                  <pin peripheral="CSI" signal="csi_mclk" pin_num="" pin_signal="GPIO_EMC_26"/>
+                  <pin peripheral="CSI" signal="csi_vsync" pin_num="" pin_signal="GPIO_EMC_33"/>
+                  <pin peripheral="CSI" signal="csi_hsync" pin_num="" pin_signal="GPIO_EMC_34"/>
+                  <pin peripheral="CSI" signal="csi_data, 09" pin_num="" pin_signal="GPIO_EMC_35"/>
+                  <pin peripheral="CSI" signal="csi_data, 08" pin_num="" pin_signal="VDD_SOC_IN_4"/>
+                  <pin peripheral="CSI" signal="csi_data, 07" pin_num="80" pin_signal="GPIO_12"/>
+                  <pin peripheral="CSI" signal="csi_data, 06" pin_num="79" pin_signal="GPIO_13"/>
+                  <pin peripheral="CSI" signal="csi_data, 05" pin_num="78" pin_signal="VSS_4"/>
+                  <pin peripheral="CSI" signal="csi_data, 04" pin_num="76" pin_signal="GPIO_SD_00"/>
+                  <pin peripheral="CSI" signal="csi_data, 03" pin_num="75" pin_signal="GPIO_SD_01"/>
+                  <pin peripheral="CSI" signal="csi_data, 02" pin_num="74" pin_signal="GPIO_SD_02"/>
+               </pins>
+            </function>
+            <function name="pinmux_FlexPWM2_pwm3">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="PWM2" description="Peripheral PWM2 is not initialized" problem_level="1" source="Pins:pinmux_FlexPWM2_pwm3">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_FlexPWM2_pwm3">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="PWM2" signal="A, 3" pin_num="" pin_signal="GPIO_EMC_17"/>
+               </pins>
+            </function>
+            <function name="pinmux_LPUART3">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="LPUART3" description="Peripheral LPUART3 is not initialized" problem_level="1" source="Pins:pinmux_LPUART3">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_LPUART3">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="LPUART3" signal="TX" pin_num="" pin_signal="GPIO_EMC_33"/>
+                  <pin peripheral="LPUART3" signal="RX" pin_num="" pin_signal="GPIO_EMC_34"/>
+               </pins>
+            </function>
+            <function name="pinmux_USER_LED_SW0">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_USER_LED_SW0">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="GPIO1" signal="gpio_io, 09" pin_num="" pin_signal="GPIO_EMC_17">
+                     <pin_features>
+                        <pin_feature name="drive_strength" value="R0_6"/>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="GPIO5" signal="gpio_io, 00" pin_num="52" pin_signal="GPIO_AD_06"/>
+               </pins>
+            </function>
+            <function name="pinmux_SDHC1">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="USDHC1" description="Peripheral USDHC1 is not initialized" problem_level="1" source="Pins:pinmux_SDHC1">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_SDHC1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_SDHC1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="GPIO1" signal="gpio_io, 05" pin_num="73" pin_signal="GPIO_SD_03">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="GPIO2" signal="gpio_io, 28" pin_num="" pin_signal="GPIO_B1_12">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="drive_strength" value="R0"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_vselect" pin_num="" pin_signal="GPIO_B1_14">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="drive_strength" value="R0_4"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_cmd" pin_num="48" pin_signal="GPIO_AD_09"/>
+                  <pin peripheral="USDHC1" signal="usdhc_clk" pin_num="47" pin_signal="GPIO_AD_10"/>
+                  <pin peripheral="USDHC1" signal="usdhc_data, 0" pin_num="46" pin_signal="GPIO_AD_11"/>
+                  <pin peripheral="USDHC1" signal="usdhc_data, 1" pin_num="45" pin_signal="GPIO_AD_12"/>
+                  <pin peripheral="USDHC1" signal="usdhc_data, 2" pin_num="43" pin_signal="GPIO_AD_14"/>
+                  <pin peripheral="USDHC1" signal="usdhc_data, 3" pin_num="42" pin_signal="VDDA_ADC_3P3/ADC_VREFH"/>
+               </pins>
+            </function>
+         </functions_list>
+      </pins>
+      <clocks name="Clocks" version="8.0" enabled="true" update_project_code="true">
+         <generated_project_files>
+            <file path="board/clock_config.c" update_enabled="true"/>
+            <file path="board/clock_config.h" update_enabled="true"/>
+         </generated_project_files>
+         <clocks_profile>
+            <processor_version>10.0.0</processor_version>
+         </clocks_profile>
+         <clock_configurations>
+            <clock_configuration name="clock_init">
+               <description></description>
+               <options/>
+               <dependencies>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.rtc_xtali" description="&apos;RTC_XTALI&apos; (Pins tool id: XTALOSC24M.rtc_xtali, Clocks tool id: XTALOSC24M.RTC_XTALI) needs to be routed" problem_level="1" source="Clocks:clock_init">
+                     <feature name="routed" evaluation="">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.rtc_xtali" description="&apos;RTC_XTALI&apos; (Pins tool id: XTALOSC24M.rtc_xtali, Clocks tool id: XTALOSC24M.RTC_XTALI) needs to have &apos;INPUT&apos; direction" problem_level="1" source="Clocks:clock_init">
+                     <feature name="direction" evaluation="">
+                        <data>INPUT</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.rtc_xtalo" description="&apos;RTC_XTALO&apos; (Pins tool id: XTALOSC24M.rtc_xtalo, Clocks tool id: XTALOSC24M.RTC_XTALO) needs to be routed" problem_level="1" source="Clocks:clock_init">
+                     <feature name="routed" evaluation="">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.rtc_xtalo" description="&apos;RTC_XTALO&apos; (Pins tool id: XTALOSC24M.rtc_xtalo, Clocks tool id: XTALOSC24M.RTC_XTALO) needs to have &apos;OUTPUT&apos; direction" problem_level="1" source="Clocks:clock_init">
+                     <feature name="direction" evaluation="">
+                        <data>OUTPUT</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.xtali" description="&apos;XTALI&apos; (Pins tool id: XTALOSC24M.xtali, Clocks tool id: XTALOSC24M.XTALI) needs to be routed" problem_level="1" source="Clocks:clock_init">
+                     <feature name="routed" evaluation="">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.xtali" description="&apos;XTALI&apos; (Pins tool id: XTALOSC24M.xtali, Clocks tool id: XTALOSC24M.XTALI) needs to have &apos;INPUT&apos; direction" problem_level="1" source="Clocks:clock_init">
+                     <feature name="direction" evaluation="">
+                        <data>INPUT</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.xtalo" description="&apos;XTALO&apos; (Pins tool id: XTALOSC24M.xtalo, Clocks tool id: XTALOSC24M.XTALO) needs to be routed" problem_level="1" source="Clocks:clock_init">
+                     <feature name="routed" evaluation="">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.xtalo" description="&apos;XTALO&apos; (Pins tool id: XTALOSC24M.xtalo, Clocks tool id: XTALOSC24M.XTALO) needs to have &apos;OUTPUT&apos; direction" problem_level="1" source="Clocks:clock_init">
+                     <feature name="direction" evaluation="">
+                        <data>OUTPUT</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Clocks initialization requires the COMMON Driver in the project." problem_level="2" source="Clocks:clock_init">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Clocks initialization requires the IOMUXC Driver in the project." problem_level="2" source="Clocks:clock_init">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <clock_sources>
+                  <clock_source id="XTALOSC24M.RTC_OSC.outFreq" value="32.768 kHz" locked="false" enabled="true"/>
+               </clock_sources>
+               <clock_outputs>
+                  <clock_output id="ADC_ALT_CLK.outFreq" value="40 MHz" locked="false" accuracy=""/>
+                  <clock_output id="CKIL_SYNC_CLK_ROOT.outFreq" value="32.768 kHz" locked="false" accuracy=""/>
+                  <clock_output id="CLK_1M.outFreq" value="1 MHz" locked="false" accuracy=""/>
+                  <clock_output id="CLK_24M.outFreq" value="24 MHz" locked="false" accuracy=""/>
+                  <clock_output id="CORE_CLK_ROOT.outFreq" value="500 MHz" locked="false" accuracy=""/>
+                  <clock_output id="ENET_500M_REF_CLK.outFreq" value="500 MHz" locked="false" accuracy=""/>
+                  <clock_output id="FLEXIO1_CLK_ROOT.outFreq" value="30 MHz" locked="false" accuracy=""/>
+                  <clock_output id="FLEXSPI_CLK_ROOT.outFreq" value="90 MHz" locked="false" accuracy=""/>
+                  <clock_output id="GPT1_ipg_clk_highfreq.outFreq" value="62.5 MHz" locked="false" accuracy=""/>
+                  <clock_output id="GPT2_ipg_clk_highfreq.outFreq" value="62.5 MHz" locked="false" accuracy=""/>
+                  <clock_output id="IPG_CLK_ROOT.outFreq" value="125 MHz" locked="false" accuracy=""/>
+                  <clock_output id="LPI2C_CLK_ROOT.outFreq" value="10 MHz" locked="false" accuracy=""/>
+                  <clock_output id="LPSPI_CLK_ROOT.outFreq" value="90 MHz" locked="false" accuracy=""/>
+                  <clock_output id="MQS_MCLK.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="PERCLK_CLK_ROOT.outFreq" value="62.5 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI1_CLK_ROOT.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI1_MCLK1.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI1_MCLK2.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI1_MCLK3.outFreq" value="30 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI3_CLK_ROOT.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI3_MCLK1.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI3_MCLK3.outFreq" value="30 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SPDIF0_CLK_ROOT.outFreq" value="30 MHz" locked="false" accuracy=""/>
+                  <clock_output id="TRACE_CLK_ROOT.outFreq" value="99 MHz" locked="false" accuracy=""/>
+                  <clock_output id="UART_CLK_ROOT.outFreq" value="80 MHz" locked="false" accuracy=""/>
+                  <clock_output id="USBPHY_CLK.outFreq" value="480 MHz" locked="false" accuracy=""/>
+               </clock_outputs>
+               <clock_settings>
+                  <setting id="CCM.ADC_ACLK_PODF.scale" value="12" locked="true"/>
+                  <setting id="CCM.AHB_PODF.scale" value="1" locked="true"/>
+                  <setting id="CCM.CLKO2_DIV.scale" value="1" locked="true"/>
+                  <setting id="CCM.CLKO2_SEL.sel" value="XTALOSC24M.OSC_CLK" locked="false"/>
+                  <setting id="CCM.FLEXSPI_PODF.scale" value="8" locked="true"/>
+                  <setting id="CCM.FLEXSPI_SEL.sel" value="CCM_ANALOG.PLL3_PFD0_CLK" locked="false"/>
+                  <setting id="CCM.IPG_PODF.scale" value="4" locked="true"/>
+                  <setting id="CCM.LPI2C_CLK_PODF.scale" value="6" locked="true"/>
+                  <setting id="CCM.LPSPI_CLK_SEL.sel" value="CCM_ANALOG.PLL3_PFD0_CLK" locked="false"/>
+                  <setting id="CCM.LPSPI_PODF.scale" value="8" locked="true"/>
+                  <setting id="CCM.PERCLK_PODF.scale" value="2" locked="true"/>
+                  <setting id="CCM.PERIPH_CLK2_SEL.sel" value="XTALOSC24M.OSC_CLK" locked="false"/>
+                  <setting id="CCM.PRE_PERIPH_CLK_SEL.sel" value="CCM_ANALOG.ENET_500M_REF_CLK" locked="false"/>
+                  <setting id="CCM.SAI1_CLK_SEL.sel" value="CCM_ANALOG.PLL3_PFD2_CLK" locked="false"/>
+                  <setting id="CCM.SAI3_CLK_SEL.sel" value="CCM_ANALOG.PLL3_PFD2_CLK" locked="false"/>
+                  <setting id="CCM.TRACE_PODF.scale" value="4" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2.denom" value="1" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2.num" value="0" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_BYPASS.sel" value="CCM_ANALOG.PLL2_OUT_CLK" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD0_BYPASS.sel" value="CCM_ANALOG.PLL2_PFD0" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD0_DIV.scale" value="24" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD0_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD1_BYPASS.sel" value="CCM_ANALOG.PLL2_PFD1" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD2_BYPASS.sel" value="CCM_ANALOG.PLL2_PFD2" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD2_DIV.scale" value="29" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD2_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD3_BYPASS.sel" value="CCM_ANALOG.PLL2_PFD3" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD3_DIV.scale" value="35" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD3_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_BYPASS.sel" value="CCM_ANALOG.PLL3" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD0_BYPASS.sel" value="CCM_ANALOG.PLL3_PFD0" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD0_DIV.scale" value="12" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD0_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD1_BYPASS.sel" value="CCM_ANALOG.PLL3_PFD1" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD1_DIV.scale" value="35" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD1_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD2_BYPASS.sel" value="CCM_ANALOG.PLL3_PFD2" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD2_DIV.scale" value="26" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD2_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD3_BYPASS.sel" value="CCM_ANALOG.PLL3_PFD3" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD3_DIV.scale" value="31" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD3_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL4.denom" value="50" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL4.div" value="27" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL4_POST_DIV.scale" value="4" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL6_BYPASS.sel" value="CCM_ANALOG.PLL6" locked="false"/>
+                  <setting id="CCM_ANALOG_PLL_USB1_EN_USB_CLKS_CFG" value="Enabled" locked="false"/>
+                  <setting id="CCM_ANALOG_PLL_USB1_EN_USB_CLKS_OUT_CFG" value="Enabled" locked="false"/>
+                  <setting id="CCM_ANALOG_PLL_USB1_POWER_CFG" value="Yes" locked="false"/>
+               </clock_settings>
+               <called_from_default_init>true</called_from_default_init>
+            </clock_configuration>
+         </clock_configurations>
+      </clocks>
+      <dcdx name="DCDx" version="3.0" enabled="true" update_project_code="true">
+         <generated_project_files/>
+         <dcdx_profile>
+            <processor_version>10.0.0</processor_version>
+            <output_format>c_array</output_format>
+         </dcdx_profile>
+         <dcdx_configurations>
+            <dcdx_configuration name="Device_configuration">
+               <description></description>
+               <options/>
+               <command_groups>
+                  <command_group name="Imported Commands" enabled="true">
+                     <commands>
+                        <command type="write_value" address="CCM_CCGR0" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR1" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR2" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR3" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR4" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR5" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR6" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_ANALOG_PLL_SYS" value="0x2001" value_width="4"/>
+                        <command type="write_value" address="CCM_ANALOG_PFD_528" value="0x1D0000" value_width="4"/>
+                        <command type="write_value" address="CCM_CBCDR" value="0x10D40" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_00" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_01" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_02" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_03" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_04" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_05" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_06" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_07" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_08" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_09" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_10" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_11" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_12" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_13" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_14" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_15" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_16" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_17" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_18" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_19" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_20" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_21" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_22" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_23" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_24" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_25" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_26" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_27" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_28" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_29" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_30" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_31" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_32" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_33" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_34" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_35" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_36" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_37" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_38" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_39" value="0x10" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_00" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_01" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_02" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_03" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_04" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_05" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_06" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_07" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_08" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_09" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_10" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_11" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_12" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_13" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_14" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_15" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_16" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_17" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_18" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_19" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_20" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_21" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_22" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_23" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_24" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_25" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_26" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_27" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_28" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_29" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_30" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_31" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_32" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_33" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_34" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_35" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_36" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_37" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_38" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_39" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="SEMC_MCR" value="0x10000004" value_width="4"/>
+                        <command type="write_value" address="SEMC_BMCR0" value="0x81" value_width="4"/>
+                        <command type="write_value" address="SEMC_BMCR1" value="0x81" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR0" value="0x8000001B" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR1" value="0x8200001B" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR2" value="0x8400001B" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR3" value="0x8600001B" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR4" value="0x90000021" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR5" value="0xA0000019" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR6" value="0xA8000017" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR7" value="0xA900001B" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR8" value="0x21" value_width="4"/>
+                        <command type="write_value" address="SEMC_IOCR" value="0x79A8" value_width="4"/>
+                        <command type="write_value" address="SEMC_SDRAMCR0" value="0xF31" value_width="4"/>
+                        <command type="write_value" address="SEMC_SDRAMCR1" value="0x652922" value_width="4"/>
+                        <command type="write_value" address="SEMC_SDRAMCR2" value="0x10920" value_width="4"/>
+                        <command type="write_value" address="SEMC_SDRAMCR3" value="0x50210A08" value_width="4"/>
+                        <command type="write_value" address="SEMC_DBICR0" value="0x21" value_width="4"/>
+                        <command type="write_value" address="SEMC_DBICR1" value="0x888888" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR1" value="0x02" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR2" value="0x00" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR0" value="0x80000000" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCMD" value="0xA55A000F" value_width="4"/>
+                        <command type="check_any_bit_set" address="SEMC_INTR" value="0x01" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR0" value="0x80000000" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCMD" value="0xA55A000C" value_width="4"/>
+                        <command type="check_any_bit_set" address="SEMC_INTR" value="0x01" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR0" value="0x80000000" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCMD" value="0xA55A000C" value_width="4"/>
+                        <command type="check_any_bit_set" address="SEMC_INTR" value="0x01" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPTXDAT" value="0x33" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR0" value="0x80000000" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCMD" value="0xA55A000A" value_width="4"/>
+                        <command type="check_any_bit_set" address="SEMC_INTR" value="0x01" value_width="4"/>
+                        <command type="write_value" address="SEMC_SDRAMCR3" value="0x50210A09" value_width="4"/>
+                     </commands>
+                  </command_group>
+               </command_groups>
+            </dcdx_configuration>
+         </dcdx_configurations>
+      </dcdx>
+      <periphs name="Peripherals" version="10.0" enabled="true" update_project_code="false">
+         <generated_project_files>
+            <file path="board/peripherals.c" update_enabled="true"/>
+            <file path="board/peripherals.h" update_enabled="true"/>
+         </generated_project_files>
+         <peripherals_profile>
+            <processor_version>10.0.0</processor_version>
+         </peripherals_profile>
+         <functional_groups>
+            <functional_group name="BOARD_InitPeripherals" uuid="1c6563a6-c68b-40e5-8828-2853c99f95fa" called_from_default_init="true" id_prefix="BOARD_" core="core0">
+               <description></description>
+               <options/>
+               <dependencies/>
+               <instances>
+                  <instance name="NVIC" uuid="2c253e89-508d-4544-9d44-c226931d8f3f" type="nvic" type_id="nvic_57b5eef3774cc60acaede6f5b8bddc67" mode="general" peripheral="NVIC" enabled="true" comment="" custom_name_enabled="false" editing_lock="false">
+                     <config_set name="nvic">
+                        <array name="interrupt_table"/>
+                        <array name="interrupts"/>
+                     </config_set>
+                  </instance>
+               </instances>
+            </functional_group>
+         </functional_groups>
+         <components>
+            <component name="system" uuid="18e298ee-cc10-47f7-b950-440409a94f94" type_id="system_54b53072540eeeb8f8e9343e71f28176">
+               <config_set_global name="global_system_definitions">
+                  <setting name="user_definitions" value=""/>
+                  <setting name="user_includes" value=""/>
+               </config_set_global>
+            </component>
+            <component name="msg" uuid="078a031a-1304-48e4-934c-de6b7bd41d37" type_id="msg_6e2baaf3b97dbeef01c0043275f9a0e7">
+               <config_set_global name="global_messages"/>
+            </component>
+            <component name="generic_uart" uuid="0e122da2-c994-4d5a-a7b8-5a63103fc1d2" type_id="generic_uart_8cae00565451cf2346eb1b8c624e73a6">
+               <config_set_global name="global_uart"/>
+            </component>
+            <component name="generic_can" uuid="51762fc1-cf05-4bb3-a3ca-5da5c50ea072" type_id="generic_can_1bfdd78b1af214566c1f23cf6a582d80">
+               <config_set_global name="global_can"/>
+            </component>
+            <component name="uart_cmsis_common" uuid="d4182366-28a3-4b72-9e22-d29aa447729c" type_id="uart_cmsis_common_9cb8e302497aa696fdbb5a4fd622c2a8">
+               <config_set_global name="global_USART_CMSIS_common" quick_selection="default"/>
+            </component>
+            <component name="generic_enet" uuid="c9d3d8ac-0dc9-40de-aea5-dd11df3d996b" type_id="generic_enet_74db5c914f0ddbe47d86af40cb77a619">
+               <config_set_global name="global_enet"/>
+            </component>
+         </components>
+      </periphs>
+      <tee name="TEE" version="2.0" enabled="false" update_project_code="true">
+         <generated_project_files/>
+         <tee_profile>
+            <processor_version>N/A</processor_version>
+         </tee_profile>
+      </tee>
+   </tools>
+</configuration>

--- a/boards/arm/mimxrt1015_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1015_evk/CMakeLists.txt
@@ -5,4 +5,5 @@
 #
 
 zephyr_library()
-zephyr_library_sources(pinmux.c)
+zephyr_library_sources(pinmux.c clock_config.c)
+zephyr_include_directories(.)

--- a/boards/arm/mimxrt1015_evk/clock_config.c
+++ b/boards/arm/mimxrt1015_evk/clock_config.c
@@ -1,0 +1,389 @@
+/*
+ * Copyright (c) 2021, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * How to setup clock using clock driver functions:
+ *
+ * 1. Call CLOCK_InitXXXPLL() to configure corresponding PLL clock.
+ *
+ * 2. Call CLOCK_InitXXXpfd() to configure corresponding PLL pfd clock.
+ *
+ * 3. Call CLOCK_SetMux() to configure corresponding clock source for target clock out.
+ *
+ * 4. Call CLOCK_SetDiv() to configure corresponding clock divider for target clock out.
+ *
+ * 5. Call CLOCK_SetXtalFreq() to set XTAL frequency based on board settings.
+ *
+ */
+
+/* TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
+ * !!GlobalInfo
+ * product: Clocks v8.0
+ * processor: MIMXRT1015xxxxx
+ * package_id: MIMXRT1015DAF5A
+ * mcu_data: ksdk2_0
+ * processor_version: 10.0.0
+ * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS **********/
+
+#include "clock_config.h"
+#include "fsl_iomuxc.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+/* System clock frequency. */
+extern uint32_t SystemCoreClock;
+
+/*******************************************************************************
+ ************************ BOARD_InitBootClocks function ************************
+ ******************************************************************************/
+void BOARD_InitBootClocks(void)
+{
+	clock_init();
+}
+
+/*******************************************************************************
+ ************************** Configuration clock_init ***************************
+ ******************************************************************************/
+/* TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
+ * !!Configuration
+ * name: clock_init
+ * called_from_default_init: true
+ * outputs:
+ * - {id: AHB_CLK_ROOT.outFreq, value: 500 MHz}
+ * - {id: CKIL_SYNC_CLK_ROOT.outFreq, value: 32.768 kHz}
+ * - {id: CLK_1M.outFreq, value: 1 MHz}
+ * - {id: CLK_24M.outFreq, value: 24 MHz}
+ * - {id: ENET_500M_REF_CLK.outFreq, value: 500 MHz}
+ * - {id: FLEXIO1_CLK_ROOT.outFreq, value: 30 MHz}
+ * - {id: FLEXSPI_CLK_ROOT.outFreq, value: 90 MHz}
+ * - {id: GPT1_ipg_clk_highfreq.outFreq, value: 62.5 MHz}
+ * - {id: GPT2_ipg_clk_highfreq.outFreq, value: 62.5 MHz}
+ * - {id: IPG_CLK_ROOT.outFreq, value: 125 MHz}
+ * - {id: LPI2C_CLK_ROOT.outFreq, value: 10 MHz}
+ * - {id: LPSPI_CLK_ROOT.outFreq, value: 90 MHz}
+ * - {id: MQS_MCLK.outFreq, value: 540/13 MHz}
+ * - {id: PERCLK_CLK_ROOT.outFreq, value: 62.5 MHz}
+ * - {id: SAI1_CLK_ROOT.outFreq, value: 540/13 MHz}
+ * - {id: SAI1_MCLK1.outFreq, value: 540/13 MHz}
+ * - {id: SAI1_MCLK2.outFreq, value: 540/13 MHz}
+ * - {id: SAI1_MCLK3.outFreq, value: 30 MHz}
+ * - {id: SAI2_CLK_ROOT.outFreq, value: 540/13 MHz}
+ * - {id: SAI2_MCLK1.outFreq, value: 540/13 MHz}
+ * - {id: SAI2_MCLK3.outFreq, value: 30 MHz}
+ * - {id: SAI3_CLK_ROOT.outFreq, value: 540/13 MHz}
+ * - {id: SAI3_MCLK1.outFreq, value: 540/13 MHz}
+ * - {id: SAI3_MCLK3.outFreq, value: 30 MHz}
+ * - {id: SPDIF0_CLK_ROOT.outFreq, value: 30 MHz}
+ * - {id: TRACE_CLK_ROOT.outFreq, value: 99 MHz}
+ * - {id: UART_CLK_ROOT.outFreq, value: 80 MHz}
+ * - {id: USBPHY1_CLK.outFreq, value: 480 MHz}
+ * settings:
+ * - {id: CCM.AHB_PODF.scale, value: '1', locked: true}
+ * - {id: CCM.ARM_PODF.scale, value: '1', locked: true}
+ * - {id: CCM.CLKO2_DIV.scale, value: '1', locked: true}
+ * - {id: CCM.CLKO2_SEL.sel, value: XTALOSC24M.OSC_CLK}
+ * - {id: CCM.FLEXSPI_PODF.scale, value: '8', locked: true}
+ * - {id: CCM.FLEXSPI_SEL.sel, value: CCM_ANALOG.PLL3_PFD0_CLK}
+ * - {id: CCM.IPG_PODF.scale, value: '4', locked: true}
+ * - {id: CCM.LPI2C_CLK_PODF.scale, value: '6', locked: true}
+ * - {id: CCM.LPSPI_CLK_SEL.sel, value: CCM_ANALOG.PLL3_PFD0_CLK}
+ * - {id: CCM.LPSPI_PODF.scale, value: '8', locked: true}
+ * - {id: CCM.PERCLK_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.PERIPH_CLK2_SEL.sel, value: XTALOSC24M.OSC_CLK}
+ * - {id: CCM.PRE_PERIPH_CLK_SEL.sel, value: CCM.ARM_PODF}
+ * - {id: CCM.SAI2_CLK_PRED.scale, value: '4', locked: true}
+ * - {id: CCM.SEMC_CLK_SEL.sel, value: CCM.SEMC_ALT_CLK_SEL}
+ * - {id: CCM.SEMC_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.TRACE_PODF.scale, value: '4', locked: true}
+ * - {id: CCM_ANALOG.PLL2.denom, value: '1', locked: true}
+ * - {id: CCM_ANALOG.PLL2.num, value: '0', locked: true}
+ * - {id: CCM_ANALOG.PLL2_BYPASS.sel, value: CCM_ANALOG.PLL2_OUT_CLK}
+ * - {id: CCM_ANALOG.PLL2_PFD0_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD0}
+ * - {id: CCM_ANALOG.PLL2_PFD0_DIV.scale, value: '24', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD0_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD1_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD1}
+ * - {id: CCM_ANALOG.PLL2_PFD2_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD2}
+ * - {id: CCM_ANALOG.PLL2_PFD2_DIV.scale, value: '29', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD2_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD3_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD3}
+ * - {id: CCM_ANALOG.PLL2_PFD3_DIV.scale, value: '35', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD3_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_BYPASS.sel, value: CCM_ANALOG.PLL3}
+ * - {id: CCM_ANALOG.PLL3_PFD0_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD0}
+ * - {id: CCM_ANALOG.PLL3_PFD0_DIV.scale, value: '12', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD0_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD1_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD1}
+ * - {id: CCM_ANALOG.PLL3_PFD1_DIV.scale, value: '35', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD1_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD2_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD2}
+ * - {id: CCM_ANALOG.PLL3_PFD2_DIV.scale, value: '26', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD2_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD3_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD3}
+ * - {id: CCM_ANALOG.PLL3_PFD3_DIV.scale, value: '31', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD3_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL4.denom, value: '50'}
+ * - {id: CCM_ANALOG.PLL4.div, value: '27', locked: true}
+ * - {id: CCM_ANALOG.PLL4_POST_DIV.scale, value: '4', locked: true}
+ * - {id: CCM_ANALOG.PLL6_BYPASS.sel, value: CCM_ANALOG.PLL6}
+ * - {id: CCM_ANALOG_PLL_USB1_EN_USB_CLKS_CFG, value: Enabled}
+ * - {id: CCM_ANALOG_PLL_USB1_EN_USB_CLKS_OUT_CFG, value: Enabled}
+ * - {id: CCM_ANALOG_PLL_USB1_POWER_CFG, value: 'Yes'}
+ * sources:
+ * - {id: XTALOSC24M.RTC_OSC.outFreq, value: 32.768 kHz, enabled: true}
+ * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS **********/
+
+/*******************************************************************************
+ * Variables for clock_init configuration
+ ******************************************************************************/
+const clock_sys_pll_config_t sysPllConfig_clock_init = {
+	/* PLL loop divider, Fout = Fin * ( 20 + loopDivider*2 + numerator / denominator ) */
+	.loopDivider = 1,
+	/* 30 bit numerator of fractional loop divider */
+	.numerator = 0,
+	/* 30 bit denominator of fractional loop divider */
+	.denominator = 1,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+const clock_usb_pll_config_t usb1PllConfig_clock_init = {
+	/* PLL loop divider, Fout = Fin * 20 */
+	.loopDivider = 0,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+const clock_enet_pll_config_t enetPllConfig_clock_init = {
+	/* Enable the PLL providing the ENET 500MHz reference clock */
+	.enableClkOutput500M = true,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+/*******************************************************************************
+ * Code for clock_init configuration
+ ******************************************************************************/
+void clock_init(void)
+{
+	/* Init RTC OSC clock frequency. */
+	CLOCK_SetRtcXtalFreq(32768U);
+	/* Enable 1MHz clock output. */
+	XTALOSC24M->OSC_CONFIG2 |= XTALOSC24M_OSC_CONFIG2_ENABLE_1M_MASK;
+	/* Use free 1MHz clock output. */
+	XTALOSC24M->OSC_CONFIG2 &= ~XTALOSC24M_OSC_CONFIG2_MUX_1M_MASK;
+	/* Set XTAL 24MHz clock frequency. */
+	CLOCK_SetXtalFreq(24000000U);
+	/* Enable XTAL 24MHz clock source. */
+	CLOCK_InitExternalClk(0);
+	/* Enable internal RC. */
+	CLOCK_InitRcOsc24M();
+	/* Switch clock source to external OSC. */
+	CLOCK_SwitchOsc(kCLOCK_XtalOsc);
+	/* Set Oscillator ready counter value. */
+	CCM->CCR = (CCM->CCR & (~CCM_CCR_OSCNT_MASK)) | CCM_CCR_OSCNT(127);
+	/* Setting PeriphClk2Mux and PeriphMux to provide stable clock before PLLs are initialed */
+	CLOCK_SetMux(kCLOCK_PeriphClk2Mux, 1);  /* Set PERIPH_CLK2 MUX to OSC */
+	CLOCK_SetMux(kCLOCK_PeriphMux, 1);      /* Set PERIPH_CLK MUX to PERIPH_CLK2 */
+	/* Setting the VDD_SOC to 1.25V. It is necessary to config AHB to 500Mhz. */
+	DCDC->REG3 = (DCDC->REG3 & (~DCDC_REG3_TRG_MASK)) | DCDC_REG3_TRG(0x12);
+	/* Waiting for DCDC_STS_DC_OK bit is asserted */
+	while (DCDC_REG0_STS_DC_OK_MASK != (DCDC_REG0_STS_DC_OK_MASK & DCDC->REG0)) {
+	}
+	/* Set AHB_PODF. */
+	CLOCK_SetDiv(kCLOCK_AhbDiv, 0);
+	/* Disable IPG clock gate. */
+	CLOCK_DisableClock(kCLOCK_Adc1);
+	CLOCK_DisableClock(kCLOCK_Xbar1);
+	CLOCK_DisableClock(kCLOCK_Xbar2);
+	/* Set IPG_PODF. */
+	CLOCK_SetDiv(kCLOCK_IpgDiv, 3);
+	/* Set ARM_PODF. */
+	CLOCK_SetDiv(kCLOCK_ArmDiv, 0);
+	/* Set PERIPH_CLK2_PODF. */
+	CLOCK_SetDiv(kCLOCK_PeriphClk2Div, 0);
+	/* Disable PERCLK clock gate. */
+	CLOCK_DisableClock(kCLOCK_Gpt1);
+	CLOCK_DisableClock(kCLOCK_Gpt1S);
+	CLOCK_DisableClock(kCLOCK_Gpt2);
+	CLOCK_DisableClock(kCLOCK_Gpt2S);
+	CLOCK_DisableClock(kCLOCK_Pit);
+	/* Set PERCLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_PerclkDiv, 1);
+	/* Set SEMC_PODF. */
+	CLOCK_SetDiv(kCLOCK_SemcDiv, 1);
+	/* Set Semc alt clock source. */
+	CLOCK_SetMux(kCLOCK_SemcAltMux, 0);
+	/* Set Semc clock source. */
+	CLOCK_SetMux(kCLOCK_SemcMux, 1);
+	/*
+	 * In SDK projects, external flash (configured by FLEXSPI) will be initialized by dcd.
+	 * With this macro XIP_EXTERNAL_FLASH, usb1 pll (selected to be FLEXSPI clock source
+	 * in SDK projects) will be left unchanged.
+	 * Note: If another clock source is selected for FLEXSPI, user may want to avoid
+	 * changing that clock as well.
+	 */
+#if !(defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1))
+	/* Disable Flexspi clock gate. */
+	CLOCK_DisableClock(kCLOCK_FlexSpi);
+	/* Set FLEXSPI_PODF. */
+	CLOCK_SetDiv(kCLOCK_FlexspiDiv, 7);
+	/* Set Flexspi clock source. */
+	CLOCK_SetMux(kCLOCK_FlexspiMux, 3);
+#endif
+	/* Disable LPSPI clock gate. */
+	CLOCK_DisableClock(kCLOCK_Lpspi1);
+	CLOCK_DisableClock(kCLOCK_Lpspi2);
+	/* Set LPSPI_PODF. */
+	CLOCK_SetDiv(kCLOCK_LpspiDiv, 7);
+	/* Set Lpspi clock source. */
+	CLOCK_SetMux(kCLOCK_LpspiMux, 1);
+	/* Disable TRACE clock gate. */
+	CLOCK_DisableClock(kCLOCK_Trace);
+	/* Set TRACE_PODF. */
+	CLOCK_SetDiv(kCLOCK_TraceDiv, 3);
+	/* Set Trace clock source. */
+	CLOCK_SetMux(kCLOCK_TraceMux, 2);
+	/* Disable SAI1 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Sai1);
+	/* Set SAI1_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Sai1PreDiv, 3);
+	/* Set SAI1_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Sai1Div, 1);
+	/* Set Sai1 clock source. */
+	CLOCK_SetMux(kCLOCK_Sai1Mux, 0);
+	/* Disable SAI2 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Sai2);
+	/* Set SAI2_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Sai2PreDiv, 3);
+	/* Set SAI2_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Sai2Div, 1);
+	/* Set Sai2 clock source. */
+	CLOCK_SetMux(kCLOCK_Sai2Mux, 0);
+	/* Disable SAI3 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Sai3);
+	/* Set SAI3_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Sai3PreDiv, 3);
+	/* Set SAI3_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Sai3Div, 1);
+	/* Set Sai3 clock source. */
+	CLOCK_SetMux(kCLOCK_Sai3Mux, 0);
+	/* Disable Lpi2c clock gate. */
+	CLOCK_DisableClock(kCLOCK_Lpi2c1);
+	CLOCK_DisableClock(kCLOCK_Lpi2c2);
+	/* Set LPI2C_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Lpi2cDiv, 5);
+	/* Set Lpi2c clock source. */
+	CLOCK_SetMux(kCLOCK_Lpi2cMux, 0);
+	/* Disable UART clock gate. */
+	CLOCK_DisableClock(kCLOCK_Lpuart1);
+	CLOCK_DisableClock(kCLOCK_Lpuart2);
+	CLOCK_DisableClock(kCLOCK_Lpuart3);
+	CLOCK_DisableClock(kCLOCK_Lpuart4);
+	/* Set UART_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_UartDiv, 0);
+	/* Set Uart clock source. */
+	CLOCK_SetMux(kCLOCK_UartMux, 0);
+	/* Disable SPDIF clock gate. */
+	CLOCK_DisableClock(kCLOCK_Spdif);
+	/* Set SPDIF0_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Spdif0PreDiv, 1);
+	/* Set SPDIF0_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Spdif0Div, 7);
+	/* Set Spdif clock source. */
+	CLOCK_SetMux(kCLOCK_SpdifMux, 3);
+	/* Disable Flexio1 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Flexio1);
+	/* Set FLEXIO1_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Flexio1PreDiv, 1);
+	/* Set FLEXIO1_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Flexio1Div, 7);
+	/* Set Flexio1 clock source. */
+	CLOCK_SetMux(kCLOCK_Flexio1Mux, 3);
+	/* Set Pll3 sw clock source. */
+	CLOCK_SetMux(kCLOCK_Pll3SwMux, 0);
+	/* Init System PLL. */
+	CLOCK_InitSysPll(&sysPllConfig_clock_init);
+	/* Init System pfd0. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd0, 24);
+	/* Init System pfd1. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd1, 16);
+	/* Init System pfd2. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd2, 29);
+	/* Init System pfd3. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd3, 35);
+	/*
+	 * In SDK projects, external flash (configured by FLEXSPI) will be initialized by dcd.
+	 * With this macro XIP_EXTERNAL_FLASH, usb1 pll (selected to be FLEXSPI clock source
+	 * in SDK projects) will be left unchanged.
+	 * Note: If another clock source is selected for FLEXSPI, user may want to avoid
+	 * changing that clock as well.
+	 */
+#if !(defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1))
+	/* Init Usb1 PLL. */
+	CLOCK_InitUsb1Pll(&usb1PllConfig_clock_init);
+	/* Init Usb1 pfd0. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd0, 12);
+	/* Init Usb1 pfd1. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd1, 35);
+	/* Init Usb1 pfd2. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd2, 26);
+	/* Init Usb1 pfd3. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd3, 31);
+#endif
+	/* DeInit Audio PLL. */
+	CLOCK_DeinitAudioPll();
+	/* Bypass Audio PLL. */
+	CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllAudio, 1);
+	/* Set divider for Audio PLL. */
+	CCM_ANALOG->MISC2 &= ~CCM_ANALOG_MISC2_AUDIO_DIV_LSB_MASK;
+	CCM_ANALOG->MISC2 &= ~CCM_ANALOG_MISC2_AUDIO_DIV_MSB_MASK;
+	/* Enable Audio PLL output. */
+	CCM_ANALOG->PLL_AUDIO |= CCM_ANALOG_PLL_AUDIO_ENABLE_MASK;
+	/* Init Enet PLL. */
+	CLOCK_InitEnetPll(&enetPllConfig_clock_init);
+	/* Set preperiph clock source. */
+	CLOCK_SetMux(kCLOCK_PrePeriphMux, 3);
+	/* Set periph clock source. */
+	CLOCK_SetMux(kCLOCK_PeriphMux, 0);
+	/* Set periph clock2 clock source. */
+	CLOCK_SetMux(kCLOCK_PeriphClk2Mux, 1);
+	/* Set per clock source. */
+	CLOCK_SetMux(kCLOCK_PerclkMux, 0);
+	/* Set clock out1 divider. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO1_DIV_MASK)) | CCM_CCOSR_CLKO1_DIV(0);
+	/* Set clock out1 source. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO1_SEL_MASK)) | CCM_CCOSR_CLKO1_SEL(1);
+	/* Set clock out2 divider. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO2_DIV_MASK)) | CCM_CCOSR_CLKO2_DIV(0);
+	/* Set clock out2 source. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO2_SEL_MASK)) | CCM_CCOSR_CLKO2_SEL(14);
+	/* Set clock out1 drives clock out1. */
+	CCM->CCOSR &= ~CCM_CCOSR_CLK_OUT_SEL_MASK;
+	/* Disable clock out1. */
+	CCM->CCOSR &= ~CCM_CCOSR_CLKO1_EN_MASK;
+	/* Disable clock out2. */
+	CCM->CCOSR &= ~CCM_CCOSR_CLKO2_EN_MASK;
+	/* Set SAI1 MCLK1 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk1Sel, 0);
+	/* Set SAI1 MCLK2 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk2Sel, 0);
+	/* Set SAI1 MCLK3 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk3Sel, 0);
+	/* Set SAI2 MCLK3 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI2MClk3Sel, 0);
+	/* Set SAI3 MCLK3 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI3MClk3Sel, 0);
+	/* Set MQS configuration. */
+	IOMUXC_MQSConfig(IOMUXC_GPR, kIOMUXC_MqsPwmOverSampleRate32, 0);
+	/* Set GPT1 High frequency reference clock source. */
+	IOMUXC_GPR->GPR5 &= ~IOMUXC_GPR_GPR5_VREF_1M_CLK_GPT1_MASK;
+	/* Set GPT2 High frequency reference clock source. */
+	IOMUXC_GPR->GPR5 &= ~IOMUXC_GPR_GPR5_VREF_1M_CLK_GPT2_MASK;
+	/* Set SystemCoreClock variable. */
+	SystemCoreClock = CLOCK_INIT_CORE_CLOCK;
+}

--- a/boards/arm/mimxrt1015_evk/clock_config.h
+++ b/boards/arm/mimxrt1015_evk/clock_config.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2021, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _CLOCK_CONFIG_H_
+#define _CLOCK_CONFIG_H_
+
+#include "fsl_common.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+/*!< Board xtal0 frequency in Hz */
+#define BOARD_XTAL0_CLK_HZ                         24000000U
+
+/*!< Board xtal32k frequency in Hz */
+#define BOARD_XTAL32K_CLK_HZ                          32768U
+/*******************************************************************************
+ ************************ BOARD_InitBootClocks function ************************
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus*/
+
+/*!
+ * @brief This function executes default configuration of clocks.
+ *
+ */
+void BOARD_InitBootClocks(void);
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus*/
+
+/*******************************************************************************
+ ************************** Configuration clock_init ***************************
+ ******************************************************************************/
+/*******************************************************************************
+ * Definitions for clock_init configuration
+ ******************************************************************************/
+/*!< Core clock frequency: 500000000Hz */
+#define CLOCK_INIT_CORE_CLOCK                     500000000U
+
+/* Clock outputs (values are in Hz): */
+#define CLOCK_INIT_AHB_CLK_ROOT                       500000000UL
+#define CLOCK_INIT_CKIL_SYNC_CLK_ROOT                 32768UL
+#define CLOCK_INIT_CLKO1_CLK                          0UL
+#define CLOCK_INIT_CLKO2_CLK                          0UL
+#define CLOCK_INIT_CLK_1M                             1000000UL
+#define CLOCK_INIT_CLK_24M                            24000000UL
+#define CLOCK_INIT_ENET_500M_REF_CLK                  500000000UL
+#define CLOCK_INIT_FLEXIO1_CLK_ROOT                   30000000UL
+#define CLOCK_INIT_FLEXSPI_CLK_ROOT                   90000000UL
+#define CLOCK_INIT_GPT1_IPG_CLK_HIGHFREQ              62500000UL
+#define CLOCK_INIT_GPT2_IPG_CLK_HIGHFREQ              62500000UL
+#define CLOCK_INIT_IPG_CLK_ROOT                       125000000UL
+#define CLOCK_INIT_LPI2C_CLK_ROOT                     10000000UL
+#define CLOCK_INIT_LPSPI_CLK_ROOT                     90000000UL
+#define CLOCK_INIT_MQS_MCLK                           41538461UL
+#define CLOCK_INIT_PERCLK_CLK_ROOT                    62500000UL
+#define CLOCK_INIT_SAI1_CLK_ROOT                      41538461UL
+#define CLOCK_INIT_SAI1_MCLK1                         41538461UL
+#define CLOCK_INIT_SAI1_MCLK2                         41538461UL
+#define CLOCK_INIT_SAI1_MCLK3                         30000000UL
+#define CLOCK_INIT_SAI2_CLK_ROOT                      41538461UL
+#define CLOCK_INIT_SAI2_MCLK1                         41538461UL
+#define CLOCK_INIT_SAI2_MCLK2                         0UL
+#define CLOCK_INIT_SAI2_MCLK3                         30000000UL
+#define CLOCK_INIT_SAI3_CLK_ROOT                      41538461UL
+#define CLOCK_INIT_SAI3_MCLK1                         41538461UL
+#define CLOCK_INIT_SAI3_MCLK2                         0UL
+#define CLOCK_INIT_SAI3_MCLK3                         30000000UL
+#define CLOCK_INIT_SPDIF0_CLK_ROOT                    30000000UL
+#define CLOCK_INIT_SPDIF0_EXTCLK_OUT                  0UL
+#define CLOCK_INIT_TRACE_CLK_ROOT                     99000000UL
+#define CLOCK_INIT_UART_CLK_ROOT                      80000000UL
+#define CLOCK_INIT_USBPHY1_CLK                        480000000UL
+
+/*! @brief Usb1 PLL set for clock_init configuration.
+ */
+extern const clock_usb_pll_config_t usb1PllConfig_clock_init;
+/*! @brief Sys PLL for clock_init configuration.
+ */
+extern const clock_sys_pll_config_t sysPllConfig_clock_init;
+/*! @brief Enet PLL set for clock_init configuration.
+ */
+extern const clock_enet_pll_config_t enetPllConfig_clock_init;
+
+/*******************************************************************************
+ * API for clock_init configuration
+ ******************************************************************************/
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus*/
+
+/*!
+ * @brief This function executes configuration of clocks.
+ *
+ */
+void clock_init(void);
+
+#if defined(__cplusplus)
+}
+#endif  /* __cplusplus*/
+
+#endif  /* _CLOCK_CONFIG_H_ */

--- a/boards/arm/mimxrt1015_evk/doc/index.rst
+++ b/boards/arm/mimxrt1015_evk/doc/index.rst
@@ -196,6 +196,118 @@ see the following message in the terminal:
     ***** Booting Zephyr OS v1.14.0-rc1-1297-g312d75f2459e *****
     Hello World! mimxrt1015_evk
 
+MCUXpresso Config Tool
+======================
+
+A ``mimxrt1015_evk.mex`` file is included. This file was used to generate the clock
+initialization code and can be used as a starting point to tweak the clock configuration.
+This could be useful for different boards that are based on i.MX RT1015.
+
+NOTE: The MCUXpresso Config Tool currently generates a ``.c`` file with the clock configuration.
+Considering options on leveraging this tool in the future to generate a devicetree compatible file.
+
+Clock Configuration at Platform Initialization
+==============================================
+
+Below is the clock configuration at platform initialization.
+
+- On-chip 24MHz oscillator is enabled
+
+- Clock sources
+
++----------------------------+-----------------+
+| Name                       | Frequency       |
++============================+=================+
+| RTC Oscillator             | 32.768 kHz      |
++----------------------------+-----------------+
+| 24MHz clock source         | 24 MHz          |
++----------------------------+-----------------+
+| 1MHz clock                 | 1 MHz           |
++----------------------------+-----------------+
+| SAI1 MCLK                  | Inactive        |
++----------------------------+-----------------+
+| SAI2 MCLK                  | Inactive        |
++----------------------------+-----------------+
+| SAI3 MCLK                  | Inactive        |
++----------------------------+-----------------+
+| SPDIF_CLK_EXT              | Inactive        |
++----------------------------+-----------------+
+| SPDIF_SRCLK                | 1 MHz           |
++----------------------------+-----------------+
+| SPDIF_OUTCLK               | 1 MHz           |
++----------------------------+-----------------+
+
+- Clock outputs
+
++============================+=================+
+| Name                       | Frequency       |
++============================+=================+
+| AHB_CLK_ROOT               | 500 MHz         |
++----------------------------+-----------------+
+| IPG_CLK_ROOT               | 125 MHz         |
++----------------------------+-----------------+
+| PERCLK_CLK_ROOT            | 62.5 MHz        |
++----------------------------+-----------------+
+| FLEXSPI_CLK_ROOT           | 90 MHz          |
++----------------------------+-----------------+
+| SPDIF0_CLK_ROOT            | 30 MHz          |
++----------------------------+-----------------+
+| FLEXIO1_CLK_ROOT           | 30 MHz          |
++----------------------------+-----------------+
+| SAI1_CLK_ROOT              | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI2_CLK_ROOT              | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI3_CLK_ROOT              | 41.53 MHz       |
++----------------------------+-----------------+
+| LPI2C_CLK_ROOT             | 10 MHz          |
++----------------------------+-----------------+
+| UART_CLK_ROOT              | 80 MHz          |
++----------------------------+-----------------+
+| LPSPI_CLK_ROOT             | 90 MHz          |
++----------------------------+-----------------+
+| TRACE_CLK_ROOT             | 99 MHz          |
++----------------------------+-----------------+
+| CKIL_SYNC_CLK_ROOT         | 32.768 kHz      |
++----------------------------+-----------------+
+| Clock 1M output            | 1 MHz           |
++----------------------------+-----------------+
+| Clock 24MHz output         | 24 MHz          |
++----------------------------+-----------------+
+| CLKO1_CLK                  | Inactive        |
++----------------------------+-----------------+
+| CLKO2_CLK                  | Inactive        |
++----------------------------+-----------------+
+| ENET_500M_CLK              | 500 MHz         |
++----------------------------+-----------------+
+| USBPHY1 PLL clock          | 480 MHz         |
++----------------------------+-----------------+
+| GPT1 high frequency clock  | 62.5 MHz        |
++----------------------------+-----------------+
+| GPT2 high frequency clock  | 62.5 MHz        |
++----------------------------+-----------------+
+| SAI1 MCLK 1                | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI1 MCLK 2                | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI1 MCLK 3                | 30 MHz          |
++----------------------------+-----------------+
+| SAI2 MCLK 1                | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI2 MCLK 2                | Inactive        |
++----------------------------+-----------------+
+| SAI2 MCLK 3                | 30 MHz          |
++----------------------------+-----------------+
+| SAI3 MCLK 1                | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI3 MCLK 2                | Inactive        |
++----------------------------+-----------------+
+| SAI3 MCLK 3                | 30 MHz          |
++----------------------------+-----------------+
+| SPDIF0_EXTCLK              | Inactive        |
++----------------------------+-----------------+
+| MQS MCLK                   | 41.53 MHz       |
++----------------------------+-----------------+
 
 .. _MIMXRT1015-EVK Website:
    https://www.nxp.com/support/developer-resources/run-time-software/i.mx-developer-resources/i.mx-rt1015-evaluation-kit:MIMXRT1015-EVK

--- a/boards/arm/mimxrt1015_evk/mimxrt1015_evk.mex
+++ b/boards/arm/mimxrt1015_evk/mimxrt1015_evk.mex
@@ -1,0 +1,902 @@
+<?xml version="1.0" encoding= "UTF-8" ?>
+<configuration name="MIMXRT1015xxxxx" xsi:schemaLocation="http://mcuxpresso.nxp.com/XSD/mex_configuration_10 http://mcuxpresso.nxp.com/XSD/mex_configuration_10.xsd" uuid="de3bdbe5-65cf-482d-b1be-cd17b780459b" version="10" xmlns="http://mcuxpresso.nxp.com/XSD/mex_configuration_10" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+   <common>
+      <processor>MIMXRT1015xxxxx</processor>
+      <package>MIMXRT1015DAF5A</package>
+      <mcu_data>ksdk2_0</mcu_data>
+      <cores selected="core0">
+         <core name="Cortex-M7F" id="core0" description="M7 core"/>
+      </cores>
+      <description></description>
+   </common>
+   <preferences>
+      <validate_boot_init_only>true</validate_boot_init_only>
+      <generate_extended_information>false</generate_extended_information>
+      <generate_code_modified_registers_only>false</generate_code_modified_registers_only>
+      <update_include_paths>true</update_include_paths>
+   </preferences>
+   <tools>
+      <pins name="Pins" version="10.0" enabled="true" update_project_code="false">
+         <generated_project_files/>
+         <pins_profile>
+            <processor_version>10.0.0</processor_version>
+            <power_domains/>
+            <pin_labels>
+               <pin_label pin_num="78" pin_signal="GPIO_AD_B0_00" label="LPI2C1_SCL" identifier="LPI2C1_SCL"/>
+               <pin_label pin_num="77" pin_signal="GPIO_AD_B0_01" label="LPI2C1_SDA" identifier="LPI2C1_SDA"/>
+               <pin_label pin_num="76" pin_signal="GPIO_AD_B0_02" label="LCD_RESET" identifier="LCD_RESET"/>
+               <pin_label pin_num="66" pin_signal="GPIO_AD_B0_09" label="JTAG_TDI/J21[5]/ENET_RST/J22[5]" identifier="ENET_RST"/>
+               <pin_label pin_num="64" pin_signal="GPIO_AD_B0_11" label="LCD_TOUCH_INT" identifier="INT2_COMBO"/>
+            </pin_labels>
+         </pins_profile>
+         <functions_list>
+            <function name="pinmux_ENET">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies/>
+               <pins>
+                  <pin peripheral="ENET" signal="enet_rx_data, 0" pin_num="" pin_signal="GPIO_B1_04">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_rx_data, 1" pin_num="" pin_signal="GPIO_B1_05">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_rx_en" pin_num="" pin_signal="GPIO_B1_06">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_tx_data, 0" pin_num="" pin_signal="GPIO_B1_07">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_tx_data, 1" pin_num="" pin_signal="GPIO_B1_08">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_tx_en" pin_num="" pin_signal="GPIO_B1_09">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_ref_clk" pin_num="" pin_signal="GPIO_B1_10">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="software_input_on" value="Enable"/>
+                        <pin_feature name="speed" value="MHZ_50"/>
+                        <pin_feature name="drive_strength" value="R0_6"/>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                        <pin_feature name="pull_keeper_enable" value="Disable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_rx_er" pin_num="" pin_signal="GPIO_B1_11">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_mdc" pin_num="" pin_signal="GPIO_EMC_40">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_mdio" pin_num="" pin_signal="GPIO_EMC_41">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="GPIO1" signal="gpio_io, 10" pin_num="98" pin_signal="GPIO_EMC_18">
+                     <pin_features>
+                        <pin_feature name="speed" value="MHZ_100"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_ENET_RST">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies/>
+               <pins>
+                  <pin peripheral="GPIO1" signal="gpio_io, 09" pin_num="99" pin_signal="GPIO_EMC_17">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_100"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_LPI2C1">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies/>
+               <pins>
+                  <pin peripheral="LPI2C1" signal="SDA" pin_num="91" pin_signal="VDD_SOC_IN_5"/>
+                  <pin peripheral="LPI2C1" signal="SCL" pin_num="92" pin_signal="VSS_8"/>
+               </pins>
+            </function>
+            <function name="pinmux_LCDIF">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies/>
+               <pins>
+                  <pin peripheral="LCDIF" signal="lcdif_clk" pin_num="" pin_signal="GPIO_B0_00">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_enable" pin_num="" pin_signal="GPIO_B0_01">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_hsync" pin_num="" pin_signal="GPIO_B0_02">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_vsync" pin_num="" pin_signal="GPIO_B0_03">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 00" pin_num="" pin_signal="GPIO_B0_04">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 01" pin_num="" pin_signal="GPIO_B0_05">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 02" pin_num="" pin_signal="GPIO_B0_06">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 03" pin_num="" pin_signal="GPIO_B0_07">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 04" pin_num="" pin_signal="GPIO_B0_08">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 05" pin_num="" pin_signal="GPIO_B0_09">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 06" pin_num="" pin_signal="GPIO_B0_10">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 07" pin_num="" pin_signal="GPIO_B0_11">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 08" pin_num="" pin_signal="GPIO_B0_12">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 09" pin_num="" pin_signal="GPIO_B0_13">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 10" pin_num="" pin_signal="GPIO_B0_14">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 11" pin_num="" pin_signal="GPIO_B0_15">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 12" pin_num="" pin_signal="GPIO_B1_00">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 13" pin_num="" pin_signal="GPIO_B1_01">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 14" pin_num="" pin_signal="GPIO_B1_02">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 15" pin_num="" pin_signal="GPIO_B1_03">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="GPIO1" signal="gpio_io, 02" pin_num="76" pin_signal="GPIO_AD_B0_02"/>
+                  <pin peripheral="GPIO2" signal="gpio_io, 31" pin_num="" pin_signal="GPIO_B1_15"/>
+               </pins>
+            </function>
+            <function name="pinmux_LPUART1">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies/>
+               <pins>
+                  <pin peripheral="LPUART1" signal="RX" pin_num="95" pin_signal="NVCC_GPIO_6"/>
+                  <pin peripheral="LPUART1" signal="TX" pin_num="96" pin_signal="GPIO_EMC_20">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Slow"/>
+                        <pin_feature name="software_input_on" value="Disable"/>
+                        <pin_feature name="open_drain" value="Disable"/>
+                        <pin_feature name="speed" value="MHZ_100"/>
+                        <pin_feature name="drive_strength" value="R0_6"/>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                        <pin_feature name="pull_keeper_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Disable"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_FT5336_int">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies/>
+               <pins>
+                  <pin peripheral="GPIO1" signal="gpio_io, 11" pin_num="97" pin_signal="GPIO_EMC_19">
+                     <pin_features>
+                        <pin_feature name="drive_strength" value="R0_6"/>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_FlexSPIA">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies/>
+               <pins>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_DQS" pin_num="26" pin_signal="DCDC_PSWITCH"/>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_SS0_B" pin_num="25" pin_signal="DCDC_LP"/>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_SCLK" pin_num="24" pin_signal="DCDC_GND"/>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_DATA0" pin_num="23" pin_signal="DCDC_IN"/>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_DATA1" pin_num="22" pin_signal="GPIO_SD_B1_00">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_DATA2" pin_num="21" pin_signal="GPIO_SD_B1_01">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_DATA3" pin_num="19" pin_signal="VSS_1"/>
+               </pins>
+            </function>
+            <function name="pinmux_FlexCAN3">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies/>
+               <pins>
+                  <pin peripheral="CAN3" signal="TX" pin_num="" pin_signal="GPIO_EMC_36"/>
+                  <pin peripheral="CAN3" signal="RX" pin_num="" pin_signal="GPIO_EMC_37"/>
+               </pins>
+            </function>
+            <function name="pinmux_FlexCAN2">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies/>
+               <pins>
+                  <pin peripheral="CAN2" signal="TX" pin_num="94" pin_signal="GPIO_EMC_21"/>
+                  <pin peripheral="CAN2" signal="RX" pin_num="93" pin_signal="GPIO_EMC_22"/>
+               </pins>
+            </function>
+            <function name="pinmux_FlexCAN1">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies/>
+               <pins>
+                  <pin peripheral="CAN1" signal="TX" pin_num="82" pin_signal="GPIO_EMC_35"/>
+                  <pin peripheral="CAN1" signal="RX" pin_num="81" pin_signal="VDD_SOC_IN_4"/>
+               </pins>
+            </function>
+            <function name="pinmux_CSI">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies/>
+               <pins>
+                  <pin peripheral="GPIO1" signal="gpio_io, 04" pin_num="74" pin_signal="GPIO_AD_B0_04"/>
+                  <pin peripheral="CSI" signal="csi_pixclk" pin_num="88" pin_signal="GPIO_EMC_25"/>
+                  <pin peripheral="CSI" signal="csi_mclk" pin_num="87" pin_signal="GPIO_EMC_26"/>
+                  <pin peripheral="CSI" signal="csi_vsync" pin_num="84" pin_signal="GPIO_EMC_33"/>
+                  <pin peripheral="CSI" signal="csi_hsync" pin_num="83" pin_signal="GPIO_EMC_34"/>
+                  <pin peripheral="CSI" signal="csi_data, 09" pin_num="82" pin_signal="GPIO_EMC_35"/>
+                  <pin peripheral="CSI" signal="csi_data, 08" pin_num="81" pin_signal="VDD_SOC_IN_4"/>
+                  <pin peripheral="CSI" signal="csi_data, 07" pin_num="80" pin_signal="NVCC_GPIO_5"/>
+                  <pin peripheral="CSI" signal="csi_data, 06" pin_num="79" pin_signal="VSS_7"/>
+                  <pin peripheral="CSI" signal="csi_data, 05" pin_num="78" pin_signal="GPIO_AD_B0_00"/>
+                  <pin peripheral="CSI" signal="csi_data, 04" pin_num="76" pin_signal="GPIO_AD_B0_02"/>
+                  <pin peripheral="CSI" signal="csi_data, 03" pin_num="75" pin_signal="GPIO_AD_B0_03"/>
+                  <pin peripheral="CSI" signal="csi_data, 02" pin_num="74" pin_signal="GPIO_AD_B0_04"/>
+               </pins>
+            </function>
+            <function name="pinmux_FlexPWM2_pwm3">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies/>
+               <pins>
+                  <pin peripheral="PWM2" signal="A, 3" pin_num="99" pin_signal="GPIO_EMC_17"/>
+               </pins>
+            </function>
+            <function name="pinmux_LPUART3">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies/>
+               <pins>
+                  <pin peripheral="LPUART3" signal="TX" pin_num="84" pin_signal="GPIO_EMC_33"/>
+                  <pin peripheral="LPUART3" signal="RX" pin_num="83" pin_signal="GPIO_EMC_34"/>
+               </pins>
+            </function>
+            <function name="pinmux_USER_LED_SW0">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies/>
+               <pins>
+                  <pin peripheral="GPIO1" signal="gpio_io, 09" pin_num="99" pin_signal="GPIO_EMC_17">
+                     <pin_features>
+                        <pin_feature name="drive_strength" value="R0_6"/>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="GPIO5" signal="gpio_io, 00" pin_num="52" pin_signal="GPIO_AD_B1_15"/>
+               </pins>
+            </function>
+            <function name="pinmux_SDHC1">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies/>
+               <pins>
+                  <pin peripheral="GPIO1" signal="gpio_io, 05" pin_num="73" pin_signal="GPIO_AD_B0_05">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="GPIO2" signal="gpio_io, 28" pin_num="" pin_signal="GPIO_B1_12">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="drive_strength" value="R0"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_vselect" pin_num="" pin_signal="GPIO_B1_14">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="drive_strength" value="R0_4"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_cmd" pin_num="48" pin_signal="VDD_HIGH_IN"/>
+                  <pin peripheral="USDHC1" signal="usdhc_clk" pin_num="47" pin_signal="XTALO"/>
+                  <pin peripheral="USDHC1" signal="usdhc_data, 0" pin_num="46" pin_signal="XTALI"/>
+                  <pin peripheral="USDHC1" signal="usdhc_data, 1" pin_num="45" pin_signal="USB_OTG1_CHD_B"/>
+                  <pin peripheral="USDHC1" signal="usdhc_data, 2" pin_num="43" pin_signal="NGND_KEL0"/>
+                  <pin peripheral="USDHC1" signal="usdhc_data, 3" pin_num="42" pin_signal="USB_OTG1_DP"/>
+               </pins>
+            </function>
+         </functions_list>
+      </pins>
+      <clocks name="Clocks" version="8.0" enabled="true" update_project_code="true">
+         <generated_project_files>
+            <file path="board/clock_config.c" update_enabled="true"/>
+            <file path="board/clock_config.h" update_enabled="true"/>
+         </generated_project_files>
+         <clocks_profile>
+            <processor_version>10.0.0</processor_version>
+         </clocks_profile>
+         <clock_configurations>
+            <clock_configuration name="clock_init">
+               <description></description>
+               <options/>
+               <dependencies>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.rtc_xtali" description="&apos;RTC_XTALI&apos; (Pins tool id: XTALOSC24M.rtc_xtali, Clocks tool id: XTALOSC24M.RTC_XTALI) needs to be routed" problem_level="1" source="Clocks:clock_init">
+                     <feature name="routed" evaluation="">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.rtc_xtali" description="&apos;RTC_XTALI&apos; (Pins tool id: XTALOSC24M.rtc_xtali, Clocks tool id: XTALOSC24M.RTC_XTALI) needs to have &apos;INPUT&apos; direction" problem_level="1" source="Clocks:clock_init">
+                     <feature name="direction" evaluation="">
+                        <data>INPUT</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.rtc_xtalo" description="&apos;RTC_XTALO&apos; (Pins tool id: XTALOSC24M.rtc_xtalo, Clocks tool id: XTALOSC24M.RTC_XTALO) needs to be routed" problem_level="1" source="Clocks:clock_init">
+                     <feature name="routed" evaluation="">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.rtc_xtalo" description="&apos;RTC_XTALO&apos; (Pins tool id: XTALOSC24M.rtc_xtalo, Clocks tool id: XTALOSC24M.RTC_XTALO) needs to have &apos;OUTPUT&apos; direction" problem_level="1" source="Clocks:clock_init">
+                     <feature name="direction" evaluation="">
+                        <data>OUTPUT</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.xtali" description="&apos;XTALI&apos; (Pins tool id: XTALOSC24M.xtali, Clocks tool id: XTALOSC24M.XTALI) needs to be routed" problem_level="1" source="Clocks:clock_init">
+                     <feature name="routed" evaluation="">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.xtali" description="&apos;XTALI&apos; (Pins tool id: XTALOSC24M.xtali, Clocks tool id: XTALOSC24M.XTALI) needs to have &apos;INPUT&apos; direction" problem_level="1" source="Clocks:clock_init">
+                     <feature name="direction" evaluation="">
+                        <data>INPUT</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.xtalo" description="&apos;XTALO&apos; (Pins tool id: XTALOSC24M.xtalo, Clocks tool id: XTALOSC24M.XTALO) needs to be routed" problem_level="1" source="Clocks:clock_init">
+                     <feature name="routed" evaluation="">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.xtalo" description="&apos;XTALO&apos; (Pins tool id: XTALOSC24M.xtalo, Clocks tool id: XTALOSC24M.XTALO) needs to have &apos;OUTPUT&apos; direction" problem_level="1" source="Clocks:clock_init">
+                     <feature name="direction" evaluation="">
+                        <data>OUTPUT</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Clocks initialization requires the COMMON Driver in the project." problem_level="2" source="Clocks:clock_init">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Clocks initialization requires the IOMUXC Driver in the project." problem_level="2" source="Clocks:clock_init">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <clock_sources>
+                  <clock_source id="XTALOSC24M.RTC_OSC.outFreq" value="32.768 kHz" locked="false" enabled="true"/>
+               </clock_sources>
+               <clock_outputs>
+                  <clock_output id="AHB_CLK_ROOT.outFreq" value="500 MHz" locked="false" accuracy=""/>
+                  <clock_output id="CKIL_SYNC_CLK_ROOT.outFreq" value="32.768 kHz" locked="false" accuracy=""/>
+                  <clock_output id="CLK_1M.outFreq" value="1 MHz" locked="false" accuracy=""/>
+                  <clock_output id="CLK_24M.outFreq" value="24 MHz" locked="false" accuracy=""/>
+                  <clock_output id="ENET_500M_REF_CLK.outFreq" value="500 MHz" locked="false" accuracy=""/>
+                  <clock_output id="FLEXIO1_CLK_ROOT.outFreq" value="30 MHz" locked="false" accuracy=""/>
+                  <clock_output id="FLEXSPI_CLK_ROOT.outFreq" value="90 MHz" locked="false" accuracy=""/>
+                  <clock_output id="GPT1_ipg_clk_highfreq.outFreq" value="62.5 MHz" locked="false" accuracy=""/>
+                  <clock_output id="GPT2_ipg_clk_highfreq.outFreq" value="62.5 MHz" locked="false" accuracy=""/>
+                  <clock_output id="IPG_CLK_ROOT.outFreq" value="125 MHz" locked="false" accuracy=""/>
+                  <clock_output id="LPI2C_CLK_ROOT.outFreq" value="10 MHz" locked="false" accuracy=""/>
+                  <clock_output id="LPSPI_CLK_ROOT.outFreq" value="90 MHz" locked="false" accuracy=""/>
+                  <clock_output id="MQS_MCLK.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="PERCLK_CLK_ROOT.outFreq" value="62.5 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI1_CLK_ROOT.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI1_MCLK1.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI1_MCLK2.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI1_MCLK3.outFreq" value="30 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI2_CLK_ROOT.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI2_MCLK1.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI2_MCLK3.outFreq" value="30 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI3_CLK_ROOT.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI3_MCLK1.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI3_MCLK3.outFreq" value="30 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SPDIF0_CLK_ROOT.outFreq" value="30 MHz" locked="false" accuracy=""/>
+                  <clock_output id="TRACE_CLK_ROOT.outFreq" value="99 MHz" locked="false" accuracy=""/>
+                  <clock_output id="UART_CLK_ROOT.outFreq" value="80 MHz" locked="false" accuracy=""/>
+                  <clock_output id="USBPHY1_CLK.outFreq" value="480 MHz" locked="false" accuracy=""/>
+               </clock_outputs>
+               <clock_settings>
+                  <setting id="CCM.AHB_PODF.scale" value="1" locked="true"/>
+                  <setting id="CCM.ARM_PODF.scale" value="1" locked="true"/>
+                  <setting id="CCM.CLKO2_DIV.scale" value="1" locked="true"/>
+                  <setting id="CCM.CLKO2_SEL.sel" value="XTALOSC24M.OSC_CLK" locked="false"/>
+                  <setting id="CCM.FLEXSPI_PODF.scale" value="8" locked="true"/>
+                  <setting id="CCM.FLEXSPI_SEL.sel" value="CCM_ANALOG.PLL3_PFD0_CLK" locked="false"/>
+                  <setting id="CCM.IPG_PODF.scale" value="4" locked="true"/>
+                  <setting id="CCM.LPI2C_CLK_PODF.scale" value="6" locked="true"/>
+                  <setting id="CCM.LPSPI_CLK_SEL.sel" value="CCM_ANALOG.PLL3_PFD0_CLK" locked="false"/>
+                  <setting id="CCM.LPSPI_PODF.scale" value="8" locked="true"/>
+                  <setting id="CCM.PERCLK_PODF.scale" value="2" locked="true"/>
+                  <setting id="CCM.PERIPH_CLK2_SEL.sel" value="XTALOSC24M.OSC_CLK" locked="false"/>
+                  <setting id="CCM.PRE_PERIPH_CLK_SEL.sel" value="CCM.ARM_PODF" locked="false"/>
+                  <setting id="CCM.SAI2_CLK_PRED.scale" value="4" locked="true"/>
+                  <setting id="CCM.SEMC_CLK_SEL.sel" value="CCM.SEMC_ALT_CLK_SEL" locked="false"/>
+                  <setting id="CCM.SEMC_PODF.scale" value="2" locked="true"/>
+                  <setting id="CCM.TRACE_PODF.scale" value="4" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2.denom" value="1" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2.num" value="0" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_BYPASS.sel" value="CCM_ANALOG.PLL2_OUT_CLK" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD0_BYPASS.sel" value="CCM_ANALOG.PLL2_PFD0" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD0_DIV.scale" value="24" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD0_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD1_BYPASS.sel" value="CCM_ANALOG.PLL2_PFD1" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD2_BYPASS.sel" value="CCM_ANALOG.PLL2_PFD2" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD2_DIV.scale" value="29" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD2_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD3_BYPASS.sel" value="CCM_ANALOG.PLL2_PFD3" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD3_DIV.scale" value="35" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD3_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_BYPASS.sel" value="CCM_ANALOG.PLL3" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD0_BYPASS.sel" value="CCM_ANALOG.PLL3_PFD0" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD0_DIV.scale" value="12" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD0_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD1_BYPASS.sel" value="CCM_ANALOG.PLL3_PFD1" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD1_DIV.scale" value="35" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD1_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD2_BYPASS.sel" value="CCM_ANALOG.PLL3_PFD2" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD2_DIV.scale" value="26" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD2_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD3_BYPASS.sel" value="CCM_ANALOG.PLL3_PFD3" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD3_DIV.scale" value="31" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD3_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL4.denom" value="50" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL4.div" value="27" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL4_POST_DIV.scale" value="4" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL6_BYPASS.sel" value="CCM_ANALOG.PLL6" locked="false"/>
+                  <setting id="CCM_ANALOG_PLL_USB1_EN_USB_CLKS_CFG" value="Enabled" locked="false"/>
+                  <setting id="CCM_ANALOG_PLL_USB1_EN_USB_CLKS_OUT_CFG" value="Enabled" locked="false"/>
+                  <setting id="CCM_ANALOG_PLL_USB1_POWER_CFG" value="Yes" locked="false"/>
+               </clock_settings>
+               <called_from_default_init>true</called_from_default_init>
+            </clock_configuration>
+         </clock_configurations>
+      </clocks>
+      <dcdx name="DCDx" version="3.0" enabled="true" update_project_code="true">
+         <generated_project_files/>
+         <dcdx_profile>
+            <processor_version>10.0.0</processor_version>
+            <output_format>c_array</output_format>
+         </dcdx_profile>
+         <dcdx_configurations>
+            <dcdx_configuration name="Device_configuration">
+               <description></description>
+               <options/>
+               <command_groups>
+                  <command_group name="Imported Commands" enabled="true">
+                     <commands>
+                        <command type="write_value" address="CCM_CCGR0" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR1" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR2" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR3" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR4" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR5" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR6" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_ANALOG_PLL_SYS" value="0x2001" value_width="4"/>
+                        <command type="write_value" address="CCM_ANALOG_PFD_528" value="0x1D0000" value_width="4"/>
+                        <command type="write_value" address="CCM_CBCDR" value="0x10D40" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_00" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_01" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_02" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_03" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_04" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_05" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_06" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_07" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_08" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_09" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_10" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_11" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_12" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_13" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_14" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_15" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_16" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_17" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_18" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_19" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_20" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_21" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_22" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_23" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_24" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_25" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_26" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_27" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_28" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_29" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_30" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_31" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_32" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_33" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_34" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_35" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_36" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_37" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_38" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_39" value="0x10" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_00" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_01" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_02" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_03" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_04" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_05" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_06" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_07" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_08" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_09" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_10" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_11" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_12" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_13" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_14" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_15" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_16" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_17" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_18" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_19" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_20" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_21" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_22" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_23" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_24" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_25" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_26" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_27" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_28" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_29" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_30" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_31" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_32" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_33" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_34" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_35" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_36" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_37" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_38" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_39" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="SEMC_MCR" value="0x10000004" value_width="4"/>
+                        <command type="write_value" address="SEMC_BMCR0" value="0x81" value_width="4"/>
+                        <command type="write_value" address="SEMC_BMCR1" value="0x81" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR0" value="0x8000001B" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR1" value="0x8200001B" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR2" value="0x8400001B" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR3" value="0x8600001B" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR4" value="0x90000021" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR5" value="0xA0000019" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR6" value="0xA8000017" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR7" value="0xA900001B" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR8" value="0x21" value_width="4"/>
+                        <command type="write_value" address="SEMC_IOCR" value="0x79A8" value_width="4"/>
+                        <command type="write_value" address="SEMC_SDRAMCR0" value="0xF31" value_width="4"/>
+                        <command type="write_value" address="SEMC_SDRAMCR1" value="0x652922" value_width="4"/>
+                        <command type="write_value" address="SEMC_SDRAMCR2" value="0x10920" value_width="4"/>
+                        <command type="write_value" address="SEMC_SDRAMCR3" value="0x50210A08" value_width="4"/>
+                        <command type="write_value" address="SEMC_DBICR0" value="0x21" value_width="4"/>
+                        <command type="write_value" address="SEMC_DBICR1" value="0x888888" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR1" value="0x02" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR2" value="0x00" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR0" value="0x80000000" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCMD" value="0xA55A000F" value_width="4"/>
+                        <command type="check_any_bit_set" address="SEMC_INTR" value="0x01" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR0" value="0x80000000" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCMD" value="0xA55A000C" value_width="4"/>
+                        <command type="check_any_bit_set" address="SEMC_INTR" value="0x01" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR0" value="0x80000000" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCMD" value="0xA55A000C" value_width="4"/>
+                        <command type="check_any_bit_set" address="SEMC_INTR" value="0x01" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPTXDAT" value="0x33" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR0" value="0x80000000" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCMD" value="0xA55A000A" value_width="4"/>
+                        <command type="check_any_bit_set" address="SEMC_INTR" value="0x01" value_width="4"/>
+                        <command type="write_value" address="SEMC_SDRAMCR3" value="0x50210A09" value_width="4"/>
+                     </commands>
+                  </command_group>
+               </command_groups>
+            </dcdx_configuration>
+         </dcdx_configurations>
+      </dcdx>
+      <periphs name="Peripherals" version="10.0" enabled="true" update_project_code="false">
+         <generated_project_files>
+            <file path="board/peripherals.c" update_enabled="true"/>
+            <file path="board/peripherals.h" update_enabled="true"/>
+         </generated_project_files>
+         <peripherals_profile>
+            <processor_version>10.0.0</processor_version>
+         </peripherals_profile>
+         <functional_groups>
+            <functional_group name="BOARD_InitPeripherals" uuid="1c6563a6-c68b-40e5-8828-2853c99f95fa" called_from_default_init="true" id_prefix="BOARD_" core="core0">
+               <description></description>
+               <options/>
+               <dependencies/>
+               <instances>
+                  <instance name="NVIC" uuid="2c253e89-508d-4544-9d44-c226931d8f3f" type="nvic" type_id="nvic_57b5eef3774cc60acaede6f5b8bddc67" mode="general" peripheral="NVIC" enabled="true" comment="" custom_name_enabled="false" editing_lock="false">
+                     <config_set name="nvic">
+                        <array name="interrupt_table"/>
+                        <array name="interrupts"/>
+                     </config_set>
+                  </instance>
+               </instances>
+            </functional_group>
+         </functional_groups>
+         <components>
+            <component name="system" uuid="18e298ee-cc10-47f7-b950-440409a94f94" type_id="system_54b53072540eeeb8f8e9343e71f28176">
+               <config_set_global name="global_system_definitions">
+                  <setting name="user_definitions" value=""/>
+                  <setting name="user_includes" value=""/>
+               </config_set_global>
+            </component>
+            <component name="msg" uuid="078a031a-1304-48e4-934c-de6b7bd41d37" type_id="msg_6e2baaf3b97dbeef01c0043275f9a0e7">
+               <config_set_global name="global_messages"/>
+            </component>
+            <component name="generic_uart" uuid="0e122da2-c994-4d5a-a7b8-5a63103fc1d2" type_id="generic_uart_8cae00565451cf2346eb1b8c624e73a6">
+               <config_set_global name="global_uart"/>
+            </component>
+            <component name="generic_can" uuid="51762fc1-cf05-4bb3-a3ca-5da5c50ea072" type_id="generic_can_1bfdd78b1af214566c1f23cf6a582d80">
+               <config_set_global name="global_can"/>
+            </component>
+            <component name="uart_cmsis_common" uuid="d4182366-28a3-4b72-9e22-d29aa447729c" type_id="uart_cmsis_common_9cb8e302497aa696fdbb5a4fd622c2a8">
+               <config_set_global name="global_USART_CMSIS_common" quick_selection="default"/>
+            </component>
+            <component name="generic_enet" uuid="c9d3d8ac-0dc9-40de-aea5-dd11df3d996b" type_id="generic_enet_74db5c914f0ddbe47d86af40cb77a619">
+               <config_set_global name="global_enet"/>
+            </component>
+         </components>
+      </periphs>
+      <tee name="TEE" version="2.0" enabled="false" update_project_code="true">
+         <generated_project_files/>
+         <tee_profile>
+            <processor_version>N/A</processor_version>
+         </tee_profile>
+      </tee>
+   </tools>
+</configuration>

--- a/boards/arm/mimxrt1020_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1020_evk/CMakeLists.txt
@@ -5,4 +5,5 @@
 #
 
 zephyr_library()
-zephyr_library_sources(pinmux.c)
+zephyr_library_sources(pinmux.c clock_config.c)
+zephyr_include_directories(.)

--- a/boards/arm/mimxrt1020_evk/clock_config.c
+++ b/boards/arm/mimxrt1020_evk/clock_config.c
@@ -1,0 +1,468 @@
+/*
+ * Copyright (c) 2021, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * How to setup clock using clock driver functions:
+ *
+ * 1. Call CLOCK_InitXXXPLL() to configure corresponding PLL clock.
+ *
+ * 2. Call CLOCK_InitXXXpfd() to configure corresponding PLL pfd clock.
+ *
+ * 3. Call CLOCK_SetMux() to configure corresponding clock source for target clock out.
+ *
+ * 4. Call CLOCK_SetDiv() to configure corresponding clock divider for target clock out.
+ *
+ * 5. Call CLOCK_SetXtalFreq() to set XTAL frequency based on board settings.
+ *
+ */
+
+/* TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
+ * !!GlobalInfo
+ * product: Clocks v8.0
+ * processor: MIMXRT1021xxxxx
+ * package_id: MIMXRT1021DAG5A
+ * mcu_data: ksdk2_0
+ * processor_version: 10.0.0
+ * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS **********/
+
+#include "clock_config.h"
+#include "fsl_iomuxc.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+/* System clock frequency. */
+extern uint32_t SystemCoreClock;
+
+/*******************************************************************************
+ ************************ BOARD_InitBootClocks function ************************
+ ******************************************************************************/
+void BOARD_InitBootClocks(void)
+{
+	clock_init();
+}
+
+/*******************************************************************************
+ ************************** Configuration clock_init ***************************
+ ******************************************************************************/
+/* TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
+ * !!Configuration
+ * name: clock_init
+ * called_from_default_init: true
+ * outputs:
+ * - {id: AHB_CLK_ROOT.outFreq, value: 500 MHz}
+ * - {id: CAN_CLK_ROOT.outFreq, value: 40 MHz}
+ * - {id: CKIL_SYNC_CLK_ROOT.outFreq, value: 32.768 kHz}
+ * - {id: CLK_1M.outFreq, value: 1 MHz}
+ * - {id: CLK_24M.outFreq, value: 24 MHz}
+ * - {id: ENET_125M_CLK.outFreq, value: 50 MHz}
+ * - {id: ENET_25M_REF_CLK.outFreq, value: 25 MHz}
+ * - {id: ENET_500M_REF_CLK.outFreq, value: 500 MHz}
+ * - {id: FLEXIO1_CLK_ROOT.outFreq, value: 30 MHz}
+ * - {id: FLEXSPI_CLK_ROOT.outFreq, value: 90 MHz}
+ * - {id: GPT1_ipg_clk_highfreq.outFreq, value: 62.5 MHz}
+ * - {id: GPT2_ipg_clk_highfreq.outFreq, value: 62.5 MHz}
+ * - {id: IPG_CLK_ROOT.outFreq, value: 125 MHz}
+ * - {id: LPI2C_CLK_ROOT.outFreq, value: 10 MHz}
+ * - {id: LPSPI_CLK_ROOT.outFreq, value: 90 MHz}
+ * - {id: MQS_MCLK.outFreq, value: 540/13 MHz}
+ * - {id: PERCLK_CLK_ROOT.outFreq, value: 62.5 MHz}
+ * - {id: SAI1_CLK_ROOT.outFreq, value: 540/13 MHz}
+ * - {id: SAI1_MCLK1.outFreq, value: 540/13 MHz}
+ * - {id: SAI1_MCLK2.outFreq, value: 540/13 MHz}
+ * - {id: SAI1_MCLK3.outFreq, value: 30 MHz}
+ * - {id: SAI2_CLK_ROOT.outFreq, value: 540/13 MHz}
+ * - {id: SAI2_MCLK1.outFreq, value: 540/13 MHz}
+ * - {id: SAI2_MCLK3.outFreq, value: 30 MHz}
+ * - {id: SAI3_CLK_ROOT.outFreq, value: 540/13 MHz}
+ * - {id: SAI3_MCLK1.outFreq, value: 540/13 MHz}
+ * - {id: SAI3_MCLK3.outFreq, value: 30 MHz}
+ * - {id: SEMC_CLK_ROOT.outFreq, value: 4752/29 MHz}
+ * - {id: SPDIF0_CLK_ROOT.outFreq, value: 30 MHz}
+ * - {id: TRACE_CLK_ROOT.outFreq, value: 99 MHz}
+ * - {id: UART_CLK_ROOT.outFreq, value: 80 MHz}
+ * - {id: USBPHY1_CLK.outFreq, value: 480 MHz}
+ * - {id: USDHC1_CLK_ROOT.outFreq, value: 198 MHz}
+ * - {id: USDHC2_CLK_ROOT.outFreq, value: 198 MHz}
+ * settings:
+ * - {id: CCM.AHB_PODF.scale, value: '1', locked: true}
+ * - {id: CCM.ARM_PODF.scale, value: '1', locked: true}
+ * - {id: CCM.CLKO2_DIV.scale, value: '1', locked: true}
+ * - {id: CCM.CLKO2_SEL.sel, value: XTALOSC24M.OSC_CLK}
+ * - {id: CCM.FLEXSPI_PODF.scale, value: '8', locked: true}
+ * - {id: CCM.FLEXSPI_SEL.sel, value: CCM_ANALOG.PLL3_PFD0_CLK}
+ * - {id: CCM.IPG_PODF.scale, value: '4', locked: true}
+ * - {id: CCM.LPI2C_CLK_PODF.scale, value: '6', locked: true}
+ * - {id: CCM.LPSPI_CLK_SEL.sel, value: CCM_ANALOG.PLL3_PFD0_CLK}
+ * - {id: CCM.LPSPI_PODF.scale, value: '8', locked: true}
+ * - {id: CCM.PERCLK_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.PERIPH_CLK2_SEL.sel, value: XTALOSC24M.OSC_CLK}
+ * - {id: CCM.PRE_PERIPH_CLK_SEL.sel, value: CCM.ARM_PODF}
+ * - {id: CCM.SAI2_CLK_PRED.scale, value: '4', locked: true}
+ * - {id: CCM.SEMC_CLK_SEL.sel, value: CCM.SEMC_ALT_CLK_SEL}
+ * - {id: CCM.SEMC_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.TRACE_PODF.scale, value: '4', locked: true}
+ * - {id: CCM.USDHC1_CLK_SEL.sel, value: CCM_ANALOG.PLL2_PFD0_CLK}
+ * - {id: CCM.USDHC1_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.USDHC2_CLK_SEL.sel, value: CCM_ANALOG.PLL2_PFD0_CLK}
+ * - {id: CCM.USDHC2_PODF.scale, value: '2', locked: true}
+ * - {id: CCM_ANALOG.PLL2.denom, value: '1', locked: true}
+ * - {id: CCM_ANALOG.PLL2.num, value: '0', locked: true}
+ * - {id: CCM_ANALOG.PLL2_BYPASS.sel, value: CCM_ANALOG.PLL2_OUT_CLK}
+ * - {id: CCM_ANALOG.PLL2_PFD0_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD0}
+ * - {id: CCM_ANALOG.PLL2_PFD0_DIV.scale, value: '24', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD0_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD1_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD1}
+ * - {id: CCM_ANALOG.PLL2_PFD2_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD2}
+ * - {id: CCM_ANALOG.PLL2_PFD2_DIV.scale, value: '29', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD2_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD3_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD3}
+ * - {id: CCM_ANALOG.PLL2_PFD3_DIV.scale, value: '35', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD3_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_BYPASS.sel, value: CCM_ANALOG.PLL3}
+ * - {id: CCM_ANALOG.PLL3_PFD0_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD0}
+ * - {id: CCM_ANALOG.PLL3_PFD0_DIV.scale, value: '12', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD0_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD1_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD1}
+ * - {id: CCM_ANALOG.PLL3_PFD1_DIV.scale, value: '35', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD1_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD2_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD2}
+ * - {id: CCM_ANALOG.PLL3_PFD2_DIV.scale, value: '26', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD2_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD3_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD3}
+ * - {id: CCM_ANALOG.PLL3_PFD3_DIV.scale, value: '31', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD3_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL4.denom, value: '50'}
+ * - {id: CCM_ANALOG.PLL4.div, value: '27', locked: true}
+ * - {id: CCM_ANALOG.PLL4_POST_DIV.scale, value: '4', locked: true}
+ * - {id: CCM_ANALOG.PLL6_BYPASS.sel, value: CCM_ANALOG.PLL6}
+ * - {id: CCM_ANALOG_PLL_USB1_EN_USB_CLKS_CFG, value: Enabled}
+ * - {id: CCM_ANALOG_PLL_USB1_EN_USB_CLKS_OUT_CFG, value: Enabled}
+ * - {id: CCM_ANALOG_PLL_USB1_POWER_CFG, value: 'Yes'}
+ * sources:
+ * - {id: XTALOSC24M.RTC_OSC.outFreq, value: 32.768 kHz, enabled: true}
+ * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS **********/
+
+/*******************************************************************************
+ * Variables for clock_init configuration
+ ******************************************************************************/
+const clock_sys_pll_config_t sysPllConfig_clock_init = {
+	/* PLL loop divider, Fout = Fin * ( 20 + loopDivider*2 + numerator / denominator ) */
+	.loopDivider = 1,
+	/* 30 bit numerator of fractional loop divider */
+	.numerator = 0,
+	/* 30 bit denominator of fractional loop divider */
+	.denominator = 1,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+const clock_usb_pll_config_t usb1PllConfig_clock_init = {
+	/* PLL loop divider, Fout = Fin * 20 */
+	.loopDivider = 0,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+const clock_enet_pll_config_t enetPllConfig_clock_init = {
+	/* Enable the PLL providing the ENET 125MHz reference clock */
+	.enableClkOutput = true,
+	/* Enable the PLL providing the ENET 500MHz reference clock */
+	.enableClkOutput500M = true,
+	/* Enable the PLL providing the ENET 25MHz reference clock */
+	.enableClkOutput25M = true,
+	/* Set frequency of ethernet reference clock to 50 MHz */
+	.loopDivider = 1,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+/*******************************************************************************
+ * Code for clock_init configuration
+ ******************************************************************************/
+void clock_init(void)
+{
+	/* Init RTC OSC clock frequency. */
+	CLOCK_SetRtcXtalFreq(32768U);
+	/* Enable 1MHz clock output. */
+	XTALOSC24M->OSC_CONFIG2 |= XTALOSC24M_OSC_CONFIG2_ENABLE_1M_MASK;
+	/* Use free 1MHz clock output. */
+	XTALOSC24M->OSC_CONFIG2 &= ~XTALOSC24M_OSC_CONFIG2_MUX_1M_MASK;
+	/* Set XTAL 24MHz clock frequency. */
+	CLOCK_SetXtalFreq(24000000U);
+	/* Enable XTAL 24MHz clock source. */
+	CLOCK_InitExternalClk(0);
+	/* Enable internal RC. */
+	CLOCK_InitRcOsc24M();
+	/* Switch clock source to external OSC. */
+	CLOCK_SwitchOsc(kCLOCK_XtalOsc);
+	/* Set Oscillator ready counter value. */
+	CCM->CCR = (CCM->CCR & (~CCM_CCR_OSCNT_MASK)) | CCM_CCR_OSCNT(127);
+	/* Setting PeriphClk2Mux and PeriphMux to provide stable clock before PLLs are initialed */
+	CLOCK_SetMux(kCLOCK_PeriphClk2Mux, 1);  /* Set PERIPH_CLK2 MUX to OSC */
+	CLOCK_SetMux(kCLOCK_PeriphMux, 1);      /* Set PERIPH_CLK MUX to PERIPH_CLK2 */
+	/* Setting the VDD_SOC to 1.25V. It is necessary to config AHB to 500Mhz. */
+	DCDC->REG3 = (DCDC->REG3 & (~DCDC_REG3_TRG_MASK)) | DCDC_REG3_TRG(0x12);
+	/* Waiting for DCDC_STS_DC_OK bit is asserted */
+	while (DCDC_REG0_STS_DC_OK_MASK != (DCDC_REG0_STS_DC_OK_MASK & DCDC->REG0)) {
+	}
+	/* Set AHB_PODF. */
+	CLOCK_SetDiv(kCLOCK_AhbDiv, 0);
+	/* Disable IPG clock gate. */
+	CLOCK_DisableClock(kCLOCK_Adc1);
+	CLOCK_DisableClock(kCLOCK_Adc2);
+	CLOCK_DisableClock(kCLOCK_Xbar1);
+	CLOCK_DisableClock(kCLOCK_Xbar2);
+	/* Set IPG_PODF. */
+	CLOCK_SetDiv(kCLOCK_IpgDiv, 3);
+	/* Set ARM_PODF. */
+	CLOCK_SetDiv(kCLOCK_ArmDiv, 0);
+	/* Set PERIPH_CLK2_PODF. */
+	CLOCK_SetDiv(kCLOCK_PeriphClk2Div, 0);
+	/* Disable PERCLK clock gate. */
+	CLOCK_DisableClock(kCLOCK_Gpt1);
+	CLOCK_DisableClock(kCLOCK_Gpt1S);
+	CLOCK_DisableClock(kCLOCK_Gpt2);
+	CLOCK_DisableClock(kCLOCK_Gpt2S);
+	CLOCK_DisableClock(kCLOCK_Pit);
+	/* Set PERCLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_PerclkDiv, 1);
+	/* Disable USDHC1 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Usdhc1);
+	/* Set USDHC1_PODF. */
+	CLOCK_SetDiv(kCLOCK_Usdhc1Div, 1);
+	/* Set Usdhc1 clock source. */
+	CLOCK_SetMux(kCLOCK_Usdhc1Mux, 1);
+	/* Disable USDHC2 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Usdhc2);
+	/* Set USDHC2_PODF. */
+	CLOCK_SetDiv(kCLOCK_Usdhc2Div, 1);
+	/* Set Usdhc2 clock source. */
+	CLOCK_SetMux(kCLOCK_Usdhc2Mux, 1);
+	/*
+	 * In SDK projects, SDRAM (configured by SEMC) will be initialized in either debug script
+	 * or dcd. With this macro SKIP_SYSCLK_INIT, system pll (selected to be SEMC source clock
+	 * in SDK projects) will be left unchanged.
+	 * Note: If another clock source is selected for SEMC, user may want to avoid changing that
+	 * clock as well.
+	 */
+#ifndef SKIP_SYSCLK_INIT
+	/* Disable Semc clock gate. */
+	CLOCK_DisableClock(kCLOCK_Semc);
+	/* Set SEMC_PODF. */
+	CLOCK_SetDiv(kCLOCK_SemcDiv, 1);
+	/* Set Semc alt clock source. */
+	CLOCK_SetMux(kCLOCK_SemcAltMux, 0);
+	/* Set Semc clock source. */
+	CLOCK_SetMux(kCLOCK_SemcMux, 1);
+#endif
+	/*
+	 * In SDK projects, external flash (configured by FLEXSPI) will be initialized by dcd.
+	 * With this macro XIP_EXTERNAL_FLASH, usb1 pll (selected to be FLEXSPI clock source in
+	 * SDK projects) will be left unchanged.
+	 * Note: If another clock source is selected for FLEXSPI, user may want to avoid changing
+	 * that clock as well.
+	 */
+#if !(defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1))
+	/* Disable Flexspi clock gate. */
+	CLOCK_DisableClock(kCLOCK_FlexSpi);
+	/* Set FLEXSPI_PODF. */
+	CLOCK_SetDiv(kCLOCK_FlexspiDiv, 7);
+	/* Set Flexspi clock source. */
+	CLOCK_SetMux(kCLOCK_FlexspiMux, 3);
+#endif
+	/* Disable LPSPI clock gate. */
+	CLOCK_DisableClock(kCLOCK_Lpspi1);
+	CLOCK_DisableClock(kCLOCK_Lpspi2);
+	CLOCK_DisableClock(kCLOCK_Lpspi3);
+	CLOCK_DisableClock(kCLOCK_Lpspi4);
+	/* Set LPSPI_PODF. */
+	CLOCK_SetDiv(kCLOCK_LpspiDiv, 7);
+	/* Set Lpspi clock source. */
+	CLOCK_SetMux(kCLOCK_LpspiMux, 1);
+	/* Disable TRACE clock gate. */
+	CLOCK_DisableClock(kCLOCK_Trace);
+	/* Set TRACE_PODF. */
+	CLOCK_SetDiv(kCLOCK_TraceDiv, 3);
+	/* Set Trace clock source. */
+	CLOCK_SetMux(kCLOCK_TraceMux, 2);
+	/* Disable SAI1 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Sai1);
+	/* Set SAI1_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Sai1PreDiv, 3);
+	/* Set SAI1_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Sai1Div, 1);
+	/* Set Sai1 clock source. */
+	CLOCK_SetMux(kCLOCK_Sai1Mux, 0);
+	/* Disable SAI2 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Sai2);
+	/* Set SAI2_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Sai2PreDiv, 3);
+	/* Set SAI2_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Sai2Div, 1);
+	/* Set Sai2 clock source. */
+	CLOCK_SetMux(kCLOCK_Sai2Mux, 0);
+	/* Disable SAI3 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Sai3);
+	/* Set SAI3_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Sai3PreDiv, 3);
+	/* Set SAI3_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Sai3Div, 1);
+	/* Set Sai3 clock source. */
+	CLOCK_SetMux(kCLOCK_Sai3Mux, 0);
+	/* Disable Lpi2c clock gate. */
+	CLOCK_DisableClock(kCLOCK_Lpi2c1);
+	CLOCK_DisableClock(kCLOCK_Lpi2c2);
+	CLOCK_DisableClock(kCLOCK_Lpi2c3);
+	/* Set LPI2C_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Lpi2cDiv, 5);
+	/* Set Lpi2c clock source. */
+	CLOCK_SetMux(kCLOCK_Lpi2cMux, 0);
+	/* Disable CAN clock gate. */
+	CLOCK_DisableClock(kCLOCK_Can1);
+	CLOCK_DisableClock(kCLOCK_Can2);
+	CLOCK_DisableClock(kCLOCK_Can1S);
+	CLOCK_DisableClock(kCLOCK_Can2S);
+	/* Set CAN_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_CanDiv, 1);
+	/* Set Can clock source. */
+	CLOCK_SetMux(kCLOCK_CanMux, 2);
+	/* Disable UART clock gate. */
+	CLOCK_DisableClock(kCLOCK_Lpuart1);
+	CLOCK_DisableClock(kCLOCK_Lpuart2);
+	CLOCK_DisableClock(kCLOCK_Lpuart3);
+	CLOCK_DisableClock(kCLOCK_Lpuart4);
+	CLOCK_DisableClock(kCLOCK_Lpuart5);
+	CLOCK_DisableClock(kCLOCK_Lpuart6);
+	CLOCK_DisableClock(kCLOCK_Lpuart7);
+	CLOCK_DisableClock(kCLOCK_Lpuart8);
+	/* Set UART_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_UartDiv, 0);
+	/* Set Uart clock source. */
+	CLOCK_SetMux(kCLOCK_UartMux, 0);
+	/* Disable SPDIF clock gate. */
+	CLOCK_DisableClock(kCLOCK_Spdif);
+	/* Set SPDIF0_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Spdif0PreDiv, 1);
+	/* Set SPDIF0_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Spdif0Div, 7);
+	/* Set Spdif clock source. */
+	CLOCK_SetMux(kCLOCK_SpdifMux, 3);
+	/* Disable Flexio1 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Flexio1);
+	/* Set FLEXIO1_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Flexio1PreDiv, 1);
+	/* Set FLEXIO1_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Flexio1Div, 7);
+	/* Set Flexio1 clock source. */
+	CLOCK_SetMux(kCLOCK_Flexio1Mux, 3);
+	/* Set Pll3 sw clock source. */
+	CLOCK_SetMux(kCLOCK_Pll3SwMux, 0);
+	/*
+	 * In SDK projects, SDRAM (configured by SEMC) will be initialized in either debug script or
+	 * dcd. With this macro SKIP_SYSCLK_INIT, system pll (selected to be SEMC source clock in
+	 * SDK projects) will be left unchanged.
+	 * Note: If another clock source is selected for SEMC, user may want to avoid changing that
+	 * clock as well.
+	 */
+#ifndef SKIP_SYSCLK_INIT
+#if defined(XIP_BOOT_HEADER_DCD_ENABLE) && (XIP_BOOT_HEADER_DCD_ENABLE == 1)
+    #warning "SKIP_SYSCLK_INIT should be defined to keep system pll (selected to be SEMC source \
+	      clock in SDK projects) unchanged."
+#endif
+	/* Init System PLL. */
+	CLOCK_InitSysPll(&sysPllConfig_clock_init);
+	/* Init System pfd0. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd0, 24);
+	/* Init System pfd1. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd1, 16);
+	/* Init System pfd2. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd2, 29);
+	/* Init System pfd3. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd3, 35);
+#endif
+	/*
+	 * In SDK projects, external flash (configured by FLEXSPI) will be initialized by dcd.
+	 * With this macro XIP_EXTERNAL_FLASH, usb1 pll (selected to be FLEXSPI clock source in
+	 * SDK projects) will be left unchanged.
+	 * Note: If another clock source is selected for FLEXSPI, user may want to avoid changing
+	 * that clock as well.
+	 */
+#if !(defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1))
+	/* Init Usb1 PLL. */
+	CLOCK_InitUsb1Pll(&usb1PllConfig_clock_init);
+	/* Init Usb1 pfd0. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd0, 12);
+	/* Init Usb1 pfd1. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd1, 35);
+	/* Init Usb1 pfd2. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd2, 26);
+	/* Init Usb1 pfd3. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd3, 31);
+#endif
+	/* DeInit Audio PLL. */
+	CLOCK_DeinitAudioPll();
+	/* Bypass Audio PLL. */
+	CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllAudio, 1);
+	/* Set divider for Audio PLL. */
+	CCM_ANALOG->MISC2 &= ~CCM_ANALOG_MISC2_AUDIO_DIV_LSB_MASK;
+	CCM_ANALOG->MISC2 &= ~CCM_ANALOG_MISC2_AUDIO_DIV_MSB_MASK;
+	/* Enable Audio PLL output. */
+	CCM_ANALOG->PLL_AUDIO |= CCM_ANALOG_PLL_AUDIO_ENABLE_MASK;
+	/* Init Enet PLL. */
+	CLOCK_InitEnetPll(&enetPllConfig_clock_init);
+	/* Set preperiph clock source. */
+	CLOCK_SetMux(kCLOCK_PrePeriphMux, 3);
+	/* Set periph clock source. */
+	CLOCK_SetMux(kCLOCK_PeriphMux, 0);
+	/* Set periph clock2 clock source. */
+	CLOCK_SetMux(kCLOCK_PeriphClk2Mux, 1);
+	/* Set per clock source. */
+	CLOCK_SetMux(kCLOCK_PerclkMux, 0);
+	/* Set clock out1 divider. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO1_DIV_MASK)) | CCM_CCOSR_CLKO1_DIV(0);
+	/* Set clock out1 source. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO1_SEL_MASK)) | CCM_CCOSR_CLKO1_SEL(1);
+	/* Set clock out2 divider. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO2_DIV_MASK)) | CCM_CCOSR_CLKO2_DIV(0);
+	/* Set clock out2 source. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO2_SEL_MASK)) | CCM_CCOSR_CLKO2_SEL(14);
+	/* Set clock out1 drives clock out1. */
+	CCM->CCOSR &= ~CCM_CCOSR_CLK_OUT_SEL_MASK;
+	/* Disable clock out1. */
+	CCM->CCOSR &= ~CCM_CCOSR_CLKO1_EN_MASK;
+	/* Disable clock out2. */
+	CCM->CCOSR &= ~CCM_CCOSR_CLKO2_EN_MASK;
+	/* Set SAI1 MCLK1 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk1Sel, 0);
+	/* Set SAI1 MCLK2 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk2Sel, 0);
+	/* Set SAI1 MCLK3 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk3Sel, 0);
+	/* Set SAI2 MCLK3 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI2MClk3Sel, 0);
+	/* Set SAI3 MCLK3 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI3MClk3Sel, 0);
+	/* Set MQS configuration. */
+	IOMUXC_MQSConfig(IOMUXC_GPR, kIOMUXC_MqsPwmOverSampleRate32, 0);
+	/* Set ENET Ref clock source. */
+#if defined(IOMUXC_GPR_GPR1_ENET_REF_CLK_DIR_MASK)
+	IOMUXC_GPR->GPR1 &= ~IOMUXC_GPR_GPR1_ENET_REF_CLK_DIR_MASK;
+#elif defined(IOMUXC_GPR_GPR1_ENET1_TX_CLK_DIR_MASK)
+	/* Backward compatibility for original bitfield name */
+	IOMUXC_GPR->GPR1 &= ~IOMUXC_GPR_GPR1_ENET1_TX_CLK_DIR_MASK;
+#else
+#error "Neither IOMUXC_GPR_GPR1_ENET_REF_CLK_DIR_MASK nor IOMUXC_GPR_GPR1_ENET1_TX_CLK_DIR_MASK \
+	is defined."
+#endif /* defined(IOMUXC_GPR_GPR1_ENET_REF_CLK_DIR_MASK) */
+	/* Set GPT1 High frequency reference clock source. */
+	IOMUXC_GPR->GPR5 &= ~IOMUXC_GPR_GPR5_VREF_1M_CLK_GPT1_MASK;
+	/* Set GPT2 High frequency reference clock source. */
+	IOMUXC_GPR->GPR5 &= ~IOMUXC_GPR_GPR5_VREF_1M_CLK_GPT2_MASK;
+	/* Set SystemCoreClock variable. */
+	SystemCoreClock = CLOCK_INIT_CORE_CLOCK;
+}

--- a/boards/arm/mimxrt1020_evk/clock_config.h
+++ b/boards/arm/mimxrt1020_evk/clock_config.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2021, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _CLOCK_CONFIG_H_
+#define _CLOCK_CONFIG_H_
+
+#include "fsl_common.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+/*!< Board xtal0 frequency in Hz */
+#define BOARD_XTAL0_CLK_HZ                         24000000U
+
+/*!< Board xtal32k frequency in Hz */
+#define BOARD_XTAL32K_CLK_HZ                          32768U
+/*******************************************************************************
+ ************************ BOARD_InitBootClocks function ************************
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus*/
+
+/*!
+ * @brief This function executes default configuration of clocks.
+ *
+ */
+void BOARD_InitBootClocks(void);
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus*/
+
+/*******************************************************************************
+ ************************** Configuration clock_init ***************************
+ ******************************************************************************/
+/*******************************************************************************
+ * Definitions for clock_init configuration
+ ******************************************************************************/
+/*!< Core clock frequency: 500000000Hz */
+#define CLOCK_INIT_CORE_CLOCK                     500000000U
+
+/* Clock outputs (values are in Hz): */
+#define CLOCK_INIT_AHB_CLK_ROOT                       500000000UL
+#define CLOCK_INIT_CAN_CLK_ROOT                       40000000UL
+#define CLOCK_INIT_CKIL_SYNC_CLK_ROOT                 32768UL
+#define CLOCK_INIT_CLKO1_CLK                          0UL
+#define CLOCK_INIT_CLKO2_CLK                          0UL
+#define CLOCK_INIT_CLK_1M                             1000000UL
+#define CLOCK_INIT_CLK_24M                            24000000UL
+#define CLOCK_INIT_ENET_125M_CLK                      50000000UL
+#define CLOCK_INIT_ENET_25M_REF_CLK                   25000000UL
+#define CLOCK_INIT_ENET_500M_REF_CLK                  500000000UL
+#define CLOCK_INIT_ENET_REF_CLK                       0UL
+#define CLOCK_INIT_ENET_TX_CLK                        0UL
+#define CLOCK_INIT_FLEXIO1_CLK_ROOT                   30000000UL
+#define CLOCK_INIT_FLEXSPI_CLK_ROOT                   90000000UL
+#define CLOCK_INIT_GPT1_IPG_CLK_HIGHFREQ              62500000UL
+#define CLOCK_INIT_GPT2_IPG_CLK_HIGHFREQ              62500000UL
+#define CLOCK_INIT_IPG_CLK_ROOT                       125000000UL
+#define CLOCK_INIT_LPI2C_CLK_ROOT                     10000000UL
+#define CLOCK_INIT_LPSPI_CLK_ROOT                     90000000UL
+#define CLOCK_INIT_MQS_MCLK                           41538461UL
+#define CLOCK_INIT_PERCLK_CLK_ROOT                    62500000UL
+#define CLOCK_INIT_SAI1_CLK_ROOT                      41538461UL
+#define CLOCK_INIT_SAI1_MCLK1                         41538461UL
+#define CLOCK_INIT_SAI1_MCLK2                         41538461UL
+#define CLOCK_INIT_SAI1_MCLK3                         30000000UL
+#define CLOCK_INIT_SAI2_CLK_ROOT                      41538461UL
+#define CLOCK_INIT_SAI2_MCLK1                         41538461UL
+#define CLOCK_INIT_SAI2_MCLK2                         0UL
+#define CLOCK_INIT_SAI2_MCLK3                         30000000UL
+#define CLOCK_INIT_SAI3_CLK_ROOT                      41538461UL
+#define CLOCK_INIT_SAI3_MCLK1                         41538461UL
+#define CLOCK_INIT_SAI3_MCLK2                         0UL
+#define CLOCK_INIT_SAI3_MCLK3                         30000000UL
+#define CLOCK_INIT_SEMC_CLK_ROOT                      163862068UL
+#define CLOCK_INIT_SPDIF0_CLK_ROOT                    30000000UL
+#define CLOCK_INIT_SPDIF0_EXTCLK_OUT                  0UL
+#define CLOCK_INIT_TRACE_CLK_ROOT                     99000000UL
+#define CLOCK_INIT_UART_CLK_ROOT                      80000000UL
+#define CLOCK_INIT_USBPHY1_CLK                        480000000UL
+#define CLOCK_INIT_USDHC1_CLK_ROOT                    198000000UL
+#define CLOCK_INIT_USDHC2_CLK_ROOT                    198000000UL
+
+/*! @brief Usb1 PLL set for clock_init configuration.
+ */
+extern const clock_usb_pll_config_t usb1PllConfig_clock_init;
+/*! @brief Sys PLL for clock_init configuration.
+ */
+extern const clock_sys_pll_config_t sysPllConfig_clock_init;
+/*! @brief Enet PLL set for clock_init configuration.
+ */
+extern const clock_enet_pll_config_t enetPllConfig_clock_init;
+
+/*******************************************************************************
+ * API for clock_init configuration
+ ******************************************************************************/
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus*/
+
+/*!
+ * @brief This function executes configuration of clocks.
+ *
+ */
+void clock_init(void);
+
+#if defined(__cplusplus)
+}
+#endif  /* __cplusplus*/
+
+#endif  /* _CLOCK_CONFIG_H_ */

--- a/boards/arm/mimxrt1020_evk/doc/index.rst
+++ b/boards/arm/mimxrt1020_evk/doc/index.rst
@@ -276,6 +276,139 @@ should see the following message in the terminal:
    ***** Booting Zephyr OS v1.14.0-rc1 *****
    Hello World! mimxrt1020_evk
 
+MCUXpresso Config Tool
+======================
+
+A ``mimxrt1020_evk.mex`` file is included. This file was used to generate the clock
+initialization code and can be used as a starting point to tweak the clock configuration.
+This could be useful for different boards that are based on i.MX RT1020.
+
+NOTE: The MCUXpresso Config Tool currently generates a ``.c`` file with the clock configuration.
+Considering options on leveraging this tool in the future to generate a devicetree compatible file.
+
+Clock Configuration at Platform Initialization
+==============================================
+
+Below is the clock configuration at platform initialization.
+
+- On-chip 24MHz oscillator is enabled
+
+- Clock sources
+
++----------------------------+-----------------+
+| Name                       | Frequency       |
++============================+=================+
+| RTC Oscillator             | 32.768 kHz      |
++----------------------------+-----------------+
+| 24MHz clock source         | 24 MHz          |
++----------------------------+-----------------+
+| 1MHz clock                 | 1 MHz           |
++----------------------------+-----------------+
+| SAI1 MCLK                  | Inactive        |
++----------------------------+-----------------+
+| SAI2 MCLK                  | Inactive        |
++----------------------------+-----------------+
+| SAI3 MCLK                  | Inactive        |
++----------------------------+-----------------+
+| SPDIF_CLK_EXT              | Inactive        |
++----------------------------+-----------------+
+| SPDIF_SRCLK                | 1 MHz           |
++----------------------------+-----------------+
+| SPDIF_OUTCLK               | 1 MHz           |
++----------------------------+-----------------+
+| ENET_TX_CLK_EXT            | Inactive        |
++----------------------------+-----------------+
+| ENET_REF_CLK_EXT           | Inactive        |
++----------------------------+-----------------+
+
+- Clock outputs
+
++============================+=================+
+| Name                       | Frequency       |
++============================+=================+
+| AHB_CLK_ROOT               | 500 MHz         |
++----------------------------+-----------------+
+| IPG_CLK_ROOT               | 125 MHz         |
++----------------------------+-----------------+
+| SEMC_CLK_ROOT              | 163.86 MHz      |
++----------------------------+-----------------+
+| PERCLK_CLK_ROOT            | 62.5 MHz        |
++----------------------------+-----------------+
+| USDHC1_CLK_ROOT            | 198 MHz         |
++----------------------------+-----------------+
+| USDHC2_CLK_ROOT            | 198 MHz         |
++----------------------------+-----------------+
+| FLEXSPI_CLK_ROOT           | 90 MHz          |
++----------------------------+-----------------+
+| SPDIF0_CLK_ROOT            | 30 MHz          |
++----------------------------+-----------------+
+| FLEXIO1_CLK_ROOT           | 30 MHz          |
++----------------------------+-----------------+
+| SAI1_CLK_ROOT              | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI2_CLK_ROOT              | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI3_CLK_ROOT              | 41.53 MHz       |
++----------------------------+-----------------+
+| LPI2C_CLK_ROOT             | 10 MHz          |
++----------------------------+-----------------+
+| CAN_CLK_ROOT               | 40 MHz          |
++----------------------------+-----------------+
+| UART_CLK_ROOT              | 80 MHz          |
++----------------------------+-----------------+
+| LPSPI_CLK_ROOT             | 90 MHz          |
++----------------------------+-----------------+
+| TRACE_CLK_ROOT             | 99 MHz          |
++----------------------------+-----------------+
+| CKIL_SYNC_CLK_ROOT         | 32.768 kHz      |
++----------------------------+-----------------+
+| Clock 1M output            | 1 MHz           |
++----------------------------+-----------------+
+| Clock 24MHz output         | 24 MHz          |
++----------------------------+-----------------+
+| CLKO1_CLK                  | Inactive        |
++----------------------------+-----------------+
+| CLKO2_CLK                  | Inactive        |
++----------------------------+-----------------+
+| ENET_125M_CLK              | 50 MHz          |
++----------------------------+-----------------+
+| ENET_25M_REF_CLK           | 25 MHz          |
++----------------------------+-----------------+
+| ENET_500M_CLK              | 500 MHz         |
++----------------------------+-----------------+
+| USBPHY1 PLL clock          | 480 MHz         |
++----------------------------+-----------------+
+| GPT1 high frequency clock  | 62.5 MHz        |
++----------------------------+-----------------+
+| GPT2 high frequency clock  | 62.5 MHz        |
++----------------------------+-----------------+
+| SAI1 MCLK 1                | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI1 MCLK 2                | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI1 MCLK 3                | 30 MHz          |
++----------------------------+-----------------+
+| SAI2 MCLK 1                | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI2 MCLK 2                | Inactive        |
++----------------------------+-----------------+
+| SAI2 MCLK 3                | 30 MHz          |
++----------------------------+-----------------+
+| SAI3 MCLK 1                | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI3 MCLK 2                | Inactive        |
++----------------------------+-----------------+
+| SAI3 MCLK 3                | 30 MHz          |
++----------------------------+-----------------+
+| SPDIF0_EXTCLK              | Inactive        |
++----------------------------+-----------------+
+| MQS MCLK                   | 41.53... MHz    |
++----------------------------+-----------------+
+| ENET_TX_CLK                | Inactive        |
++----------------------------+-----------------+
+| ENET_REF_CLK               | Inactive        |
++----------------------------+-----------------+
+
 .. _MIMXRT1020-EVK Website:
    https://www.nxp.com/support/developer-resources/run-time-software/i.mx-developer-resources/i.mx-rt1020-evaluation-kit:MIMXRT1020-EVK
 

--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.mex
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.mex
@@ -1,0 +1,1220 @@
+<?xml version="1.0" encoding= "UTF-8" ?>
+<configuration name="MIMXRT1021xxxxx" xsi:schemaLocation="http://mcuxpresso.nxp.com/XSD/mex_configuration_10 http://mcuxpresso.nxp.com/XSD/mex_configuration_10.xsd" uuid="de3bdbe5-65cf-482d-b1be-cd17b780459b" version="10" xmlns="http://mcuxpresso.nxp.com/XSD/mex_configuration_10" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+   <common>
+      <processor>MIMXRT1021xxxxx</processor>
+      <package>MIMXRT1021DAG5A</package>
+      <mcu_data>ksdk2_0</mcu_data>
+      <cores selected="core0">
+         <core name="Cortex-M7F" id="core0" description="M7 core"/>
+      </cores>
+      <description></description>
+   </common>
+   <preferences>
+      <validate_boot_init_only>true</validate_boot_init_only>
+      <generate_extended_information>false</generate_extended_information>
+      <generate_code_modified_registers_only>false</generate_code_modified_registers_only>
+      <update_include_paths>true</update_include_paths>
+   </preferences>
+   <tools>
+      <pins name="Pins" version="10.0" enabled="true" update_project_code="false">
+         <generated_project_files>
+            <file path="board/pin_mux.c" update_enabled="true"/>
+            <file path="board/pin_mux.h" update_enabled="true"/>
+         </generated_project_files>
+         <pins_profile>
+            <processor_version>10.0.0</processor_version>
+            <power_domains/>
+            <pin_labels>
+               <pin_label pin_num="111" pin_signal="GPIO_AD_B0_00" label="LPI2C1_SCL" identifier="LPI2C1_SCL"/>
+               <pin_label pin_num="110" pin_signal="GPIO_AD_B0_01" label="LPI2C1_SDA" identifier="LPI2C1_SDA"/>
+               <pin_label pin_num="109" pin_signal="GPIO_AD_B0_02" label="LCD_RESET" identifier="LCD_RESET"/>
+               <pin_label pin_num="99" pin_signal="GPIO_AD_B0_09" label="JTAG_TDI/J21[5]/ENET_RST/J22[5]" identifier="ENET_RST"/>
+               <pin_label pin_num="97" pin_signal="GPIO_AD_B0_11" label="LCD_TOUCH_INT" identifier="INT2_COMBO"/>
+            </pin_labels>
+         </pins_profile>
+         <functions_list>
+            <function name="pinmux_ENET">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="ENET" description="Peripheral ENET is not initialized" problem_level="1" source="Pins:pinmux_ENET">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_ENET">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_ENET">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="ENET" signal="enet_rx_data, 0" pin_num="" pin_signal="GPIO_B1_04">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_rx_data, 1" pin_num="" pin_signal="GPIO_B1_05">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_rx_en" pin_num="" pin_signal="GPIO_B1_06">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_tx_data, 0" pin_num="" pin_signal="GPIO_B1_07">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_tx_data, 1" pin_num="" pin_signal="GPIO_B1_08">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_tx_en" pin_num="" pin_signal="GPIO_B1_09">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_ref_clk" pin_num="" pin_signal="GPIO_B1_10">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="software_input_on" value="Enable"/>
+                        <pin_feature name="speed" value="MHZ_50"/>
+                        <pin_feature name="drive_strength" value="R0_6"/>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                        <pin_feature name="pull_keeper_enable" value="Disable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_rx_er" pin_num="" pin_signal="GPIO_B1_11">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_mdc" pin_num="116" pin_signal="GPIO_EMC_40">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_mdio" pin_num="115" pin_signal="GPIO_EMC_41">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="GPIO1" signal="gpio_io, 10" pin_num="98" pin_signal="GPIO_AD_B0_10">
+                     <pin_features>
+                        <pin_feature name="speed" value="MHZ_100"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_ENET_RST">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_ENET_RST">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_ENET_RST">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="GPIO1" signal="gpio_io, 09" pin_num="99" pin_signal="GPIO_AD_B0_09">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_100"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_LPI2C1">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="LPI2C1" description="Peripheral LPI2C1 is not initialized" problem_level="1" source="Pins:pinmux_LPI2C1">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_LPI2C1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_LPI2C1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="LPI2C1" signal="SDA" pin_num="91" pin_signal="GPIO_AD_B1_01">
+                     <pin_features>
+                        <pin_feature name="software_input_on" value="Enable"/>
+                        <pin_feature name="open_drain" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_22K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LPI2C1" signal="SCL" pin_num="92" pin_signal="GPIO_AD_B1_00">
+                     <pin_features>
+                        <pin_feature name="software_input_on" value="Enable"/>
+                        <pin_feature name="open_drain" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_22K_Ohm"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_LCDIF">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="LCDIF" description="Peripheral LCDIF is not initialized" problem_level="1" source="Pins:pinmux_LCDIF">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_LCDIF">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_LCDIF">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="LCDIF" signal="lcdif_clk" pin_num="" pin_signal="GPIO_B0_00">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_enable" pin_num="" pin_signal="GPIO_B0_01">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_hsync" pin_num="" pin_signal="GPIO_B0_02">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_vsync" pin_num="" pin_signal="GPIO_B0_03">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 00" pin_num="" pin_signal="GPIO_B0_04">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 01" pin_num="" pin_signal="GPIO_B0_05">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 02" pin_num="" pin_signal="GPIO_B0_06">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 03" pin_num="" pin_signal="GPIO_B0_07">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 04" pin_num="" pin_signal="GPIO_B0_08">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 05" pin_num="" pin_signal="GPIO_B0_09">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 06" pin_num="" pin_signal="GPIO_B0_10">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 07" pin_num="" pin_signal="GPIO_B0_11">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 08" pin_num="" pin_signal="GPIO_B0_12">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 09" pin_num="" pin_signal="GPIO_B0_13">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 10" pin_num="" pin_signal="GPIO_B0_14">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 11" pin_num="" pin_signal="GPIO_B0_15">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 12" pin_num="" pin_signal="GPIO_B1_00">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 13" pin_num="" pin_signal="GPIO_B1_01">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 14" pin_num="" pin_signal="GPIO_B1_02">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 15" pin_num="" pin_signal="GPIO_B1_03">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="GPIO1" signal="gpio_io, 02" pin_num="109" pin_signal="GPIO_AD_B0_02"/>
+                  <pin peripheral="GPIO2" signal="gpio_io, 31" pin_num="" pin_signal="GPIO_B1_15"/>
+               </pins>
+            </function>
+            <function name="pinmux_LPUART1">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="LPUART1" description="Peripheral LPUART1 is not initialized" problem_level="1" source="Pins:pinmux_LPUART1">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_LPUART1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_LPUART1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="LPUART1" signal="RX" pin_num="95" pin_signal="GPIO_AD_B0_13">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Slow"/>
+                        <pin_feature name="software_input_on" value="Disable"/>
+                        <pin_feature name="open_drain" value="Disable"/>
+                        <pin_feature name="speed" value="MHZ_100"/>
+                        <pin_feature name="drive_strength" value="R0_6"/>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                        <pin_feature name="pull_keeper_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Disable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LPUART1" signal="TX" pin_num="96" pin_signal="GPIO_AD_B0_12">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Slow"/>
+                        <pin_feature name="software_input_on" value="Disable"/>
+                        <pin_feature name="open_drain" value="Disable"/>
+                        <pin_feature name="speed" value="MHZ_100"/>
+                        <pin_feature name="drive_strength" value="R0_6"/>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                        <pin_feature name="pull_keeper_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Disable"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_FT5336_int">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_FT5336_int">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_FT5336_int">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="GPIO1" signal="gpio_io, 11" pin_num="97" pin_signal="GPIO_AD_B0_11">
+                     <pin_features>
+                        <pin_feature name="drive_strength" value="R0_6"/>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_FlexSPIA">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="FLEXSPI" description="Peripheral FLEXSPI is not initialized" problem_level="1" source="Pins:pinmux_FlexSPIA">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_FlexSPIA">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_FlexSPIA">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_DQS" pin_num="26" pin_signal="GPIO_SD_B1_05">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_SS0_B" pin_num="25" pin_signal="GPIO_SD_B1_06">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_SCLK" pin_num="24" pin_signal="GPIO_SD_B1_07">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_DATA0" pin_num="23" pin_signal="GPIO_SD_B1_08">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_DATA1" pin_num="22" pin_signal="GPIO_SD_B1_09">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_DATA2" pin_num="21" pin_signal="GPIO_SD_B1_10">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_DATA3" pin_num="19" pin_signal="GPIO_SD_B1_11">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_FlexCAN3">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="CAN3" description="Peripheral CAN3 is not initialized" problem_level="1" source="Pins:pinmux_FlexCAN3">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_FlexCAN3">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="CAN3" signal="TX" pin_num="120" pin_signal="GPIO_EMC_36"/>
+                  <pin peripheral="CAN3" signal="RX" pin_num="119" pin_signal="GPIO_EMC_37"/>
+               </pins>
+            </function>
+            <function name="pinmux_FlexCAN2">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="CAN2" description="Peripheral CAN2 is not initialized" problem_level="1" source="Pins:pinmux_FlexCAN2">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_FlexCAN2">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_FlexCAN2">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="CAN2" signal="TX" pin_num="94" pin_signal="GPIO_AD_B0_14"/>
+                  <pin peripheral="CAN2" signal="RX" pin_num="93" pin_signal="GPIO_AD_B0_15"/>
+               </pins>
+            </function>
+            <function name="pinmux_FlexCAN1">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="CAN1" description="Peripheral CAN1 is not initialized" problem_level="1" source="Pins:pinmux_FlexCAN1">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_FlexCAN1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="CAN1" signal="TX" pin_num="82" pin_signal="GPIO_AD_B1_08"/>
+                  <pin peripheral="CAN1" signal="RX" pin_num="81" pin_signal="GPIO_AD_B1_09"/>
+               </pins>
+            </function>
+            <function name="pinmux_CSI">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="CSI" description="Peripheral CSI is not initialized" problem_level="1" source="Pins:pinmux_CSI">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_CSI">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_CSI">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="GPIO1" signal="gpio_io, 04" pin_num="107" pin_signal="GPIO_AD_B0_04"/>
+                  <pin peripheral="CSI" signal="csi_pixclk" pin_num="88" pin_signal="GPIO_AD_B1_04"/>
+                  <pin peripheral="CSI" signal="csi_mclk" pin_num="87" pin_signal="GPIO_AD_B1_05"/>
+                  <pin peripheral="CSI" signal="csi_vsync" pin_num="84" pin_signal="GPIO_AD_B1_06"/>
+                  <pin peripheral="CSI" signal="csi_hsync" pin_num="83" pin_signal="GPIO_AD_B1_07"/>
+                  <pin peripheral="CSI" signal="csi_data, 09" pin_num="82" pin_signal="GPIO_AD_B1_08"/>
+                  <pin peripheral="CSI" signal="csi_data, 08" pin_num="81" pin_signal="GPIO_AD_B1_09"/>
+                  <pin peripheral="CSI" signal="csi_data, 07" pin_num="80" pin_signal="GPIO_AD_B1_10"/>
+                  <pin peripheral="CSI" signal="csi_data, 06" pin_num="79" pin_signal="GPIO_AD_B1_11"/>
+                  <pin peripheral="CSI" signal="csi_data, 05" pin_num="78" pin_signal="GPIO_AD_B1_12"/>
+                  <pin peripheral="CSI" signal="csi_data, 04" pin_num="76" pin_signal="GPIO_AD_B1_13"/>
+                  <pin peripheral="CSI" signal="csi_data, 03" pin_num="75" pin_signal="GPIO_AD_B1_14"/>
+                  <pin peripheral="CSI" signal="csi_data, 02" pin_num="74" pin_signal="GPIO_AD_B1_15"/>
+               </pins>
+            </function>
+            <function name="pinmux_FlexPWM2_pwm3">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="PWM2" description="Peripheral PWM2 is not initialized" problem_level="1" source="Pins:pinmux_FlexPWM2_pwm3">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_FlexPWM2_pwm3">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="PWM2" signal="A, 3" pin_num="99" pin_signal="GPIO_AD_B0_09"/>
+               </pins>
+            </function>
+            <function name="pinmux_LPUART3">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="LPUART3" description="Peripheral LPUART3 is not initialized" problem_level="1" source="Pins:pinmux_LPUART3">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_LPUART3">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="LPUART3" signal="TX" pin_num="84" pin_signal="GPIO_AD_B1_06"/>
+                  <pin peripheral="LPUART3" signal="RX" pin_num="83" pin_signal="GPIO_AD_B1_07"/>
+               </pins>
+            </function>
+            <function name="pinmux_USER_LED_SW0">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_USER_LED_SW0">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_USER_LED_SW0">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="GPIO1" signal="gpio_io, 09" pin_num="99" pin_signal="GPIO_AD_B0_09">
+                     <pin_features>
+                        <pin_feature name="drive_strength" value="R0_6"/>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="GPIO5" signal="gpio_io, 00" pin_num="52" pin_signal="WAKEUP"/>
+               </pins>
+            </function>
+            <function name="pinmux_SDHC1">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="USDHC1" description="Peripheral USDHC1 is not initialized" problem_level="1" source="Pins:pinmux_SDHC1">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_SDHC1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_SDHC1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="GPIO1" signal="gpio_io, 05" pin_num="106" pin_signal="GPIO_AD_B0_05">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="GPIO2" signal="gpio_io, 28" pin_num="" pin_signal="GPIO_B1_12">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="drive_strength" value="R0"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_vselect" pin_num="" pin_signal="GPIO_B1_14">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="drive_strength" value="R0_4"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_cmd" pin_num="48" pin_signal="GPIO_SD_B0_00">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_100"/>
+                        <pin_feature name="drive_strength" value="R0"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_clk" pin_num="47" pin_signal="GPIO_SD_B0_01">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="drive_strength" value="R0"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_data, 0" pin_num="46" pin_signal="GPIO_SD_B0_02">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="drive_strength" value="R0"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_data, 1" pin_num="45" pin_signal="GPIO_SD_B0_03">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="drive_strength" value="R0"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_data, 2" pin_num="43" pin_signal="GPIO_SD_B0_04">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="drive_strength" value="R0"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_data, 3" pin_num="42" pin_signal="GPIO_SD_B0_05">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="drive_strength" value="R0"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+         </functions_list>
+      </pins>
+      <clocks name="Clocks" version="8.0" enabled="true" update_project_code="true">
+         <generated_project_files>
+            <file path="board/clock_config.c" update_enabled="true"/>
+            <file path="board/clock_config.h" update_enabled="true"/>
+         </generated_project_files>
+         <clocks_profile>
+            <processor_version>10.0.0</processor_version>
+         </clocks_profile>
+         <clock_configurations>
+            <clock_configuration name="clock_init">
+               <description></description>
+               <options/>
+               <dependencies>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.rtc_xtali" description="&apos;RTC_XTALI&apos; (Pins tool id: XTALOSC24M.rtc_xtali, Clocks tool id: XTALOSC24M.RTC_XTALI) needs to be routed" problem_level="1" source="Clocks:clock_init">
+                     <feature name="routed" evaluation="">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.rtc_xtali" description="&apos;RTC_XTALI&apos; (Pins tool id: XTALOSC24M.rtc_xtali, Clocks tool id: XTALOSC24M.RTC_XTALI) needs to have &apos;INPUT&apos; direction" problem_level="1" source="Clocks:clock_init">
+                     <feature name="direction" evaluation="">
+                        <data>INPUT</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.rtc_xtalo" description="&apos;RTC_XTALO&apos; (Pins tool id: XTALOSC24M.rtc_xtalo, Clocks tool id: XTALOSC24M.RTC_XTALO) needs to be routed" problem_level="1" source="Clocks:clock_init">
+                     <feature name="routed" evaluation="">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.rtc_xtalo" description="&apos;RTC_XTALO&apos; (Pins tool id: XTALOSC24M.rtc_xtalo, Clocks tool id: XTALOSC24M.RTC_XTALO) needs to have &apos;OUTPUT&apos; direction" problem_level="1" source="Clocks:clock_init">
+                     <feature name="direction" evaluation="">
+                        <data>OUTPUT</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.xtali" description="&apos;XTALI&apos; (Pins tool id: XTALOSC24M.xtali, Clocks tool id: XTALOSC24M.XTALI) needs to be routed" problem_level="1" source="Clocks:clock_init">
+                     <feature name="routed" evaluation="">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.xtali" description="&apos;XTALI&apos; (Pins tool id: XTALOSC24M.xtali, Clocks tool id: XTALOSC24M.XTALI) needs to have &apos;INPUT&apos; direction" problem_level="1" source="Clocks:clock_init">
+                     <feature name="direction" evaluation="">
+                        <data>INPUT</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.xtalo" description="&apos;XTALO&apos; (Pins tool id: XTALOSC24M.xtalo, Clocks tool id: XTALOSC24M.XTALO) needs to be routed" problem_level="1" source="Clocks:clock_init">
+                     <feature name="routed" evaluation="">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.xtalo" description="&apos;XTALO&apos; (Pins tool id: XTALOSC24M.xtalo, Clocks tool id: XTALOSC24M.XTALO) needs to have &apos;OUTPUT&apos; direction" problem_level="1" source="Clocks:clock_init">
+                     <feature name="direction" evaluation="">
+                        <data>OUTPUT</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Clocks initialization requires the COMMON Driver in the project." problem_level="2" source="Clocks:clock_init">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Clocks initialization requires the IOMUXC Driver in the project." problem_level="2" source="Clocks:clock_init">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <clock_sources>
+                  <clock_source id="XTALOSC24M.RTC_OSC.outFreq" value="32.768 kHz" locked="false" enabled="true"/>
+               </clock_sources>
+               <clock_outputs>
+                  <clock_output id="AHB_CLK_ROOT.outFreq" value="500 MHz" locked="false" accuracy=""/>
+                  <clock_output id="CAN_CLK_ROOT.outFreq" value="40 MHz" locked="false" accuracy=""/>
+                  <clock_output id="CKIL_SYNC_CLK_ROOT.outFreq" value="32.768 kHz" locked="false" accuracy=""/>
+                  <clock_output id="CLK_1M.outFreq" value="1 MHz" locked="false" accuracy=""/>
+                  <clock_output id="CLK_24M.outFreq" value="24 MHz" locked="false" accuracy=""/>
+                  <clock_output id="ENET_125M_CLK.outFreq" value="50 MHz" locked="false" accuracy=""/>
+                  <clock_output id="ENET_25M_REF_CLK.outFreq" value="25 MHz" locked="false" accuracy=""/>
+                  <clock_output id="ENET_500M_REF_CLK.outFreq" value="500 MHz" locked="false" accuracy=""/>
+                  <clock_output id="FLEXIO1_CLK_ROOT.outFreq" value="30 MHz" locked="false" accuracy=""/>
+                  <clock_output id="FLEXSPI_CLK_ROOT.outFreq" value="90 MHz" locked="false" accuracy=""/>
+                  <clock_output id="GPT1_ipg_clk_highfreq.outFreq" value="62.5 MHz" locked="false" accuracy=""/>
+                  <clock_output id="GPT2_ipg_clk_highfreq.outFreq" value="62.5 MHz" locked="false" accuracy=""/>
+                  <clock_output id="IPG_CLK_ROOT.outFreq" value="125 MHz" locked="false" accuracy=""/>
+                  <clock_output id="LPI2C_CLK_ROOT.outFreq" value="10 MHz" locked="false" accuracy=""/>
+                  <clock_output id="LPSPI_CLK_ROOT.outFreq" value="90 MHz" locked="false" accuracy=""/>
+                  <clock_output id="MQS_MCLK.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="PERCLK_CLK_ROOT.outFreq" value="62.5 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI1_CLK_ROOT.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI1_MCLK1.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI1_MCLK2.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI1_MCLK3.outFreq" value="30 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI2_CLK_ROOT.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI2_MCLK1.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI2_MCLK3.outFreq" value="30 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI3_CLK_ROOT.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI3_MCLK1.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI3_MCLK3.outFreq" value="30 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SEMC_CLK_ROOT.outFreq" value="4752/29 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SPDIF0_CLK_ROOT.outFreq" value="30 MHz" locked="false" accuracy=""/>
+                  <clock_output id="TRACE_CLK_ROOT.outFreq" value="99 MHz" locked="false" accuracy=""/>
+                  <clock_output id="UART_CLK_ROOT.outFreq" value="80 MHz" locked="false" accuracy=""/>
+                  <clock_output id="USBPHY1_CLK.outFreq" value="480 MHz" locked="false" accuracy=""/>
+                  <clock_output id="USDHC1_CLK_ROOT.outFreq" value="198 MHz" locked="false" accuracy=""/>
+                  <clock_output id="USDHC2_CLK_ROOT.outFreq" value="198 MHz" locked="false" accuracy=""/>
+               </clock_outputs>
+               <clock_settings>
+                  <setting id="CCM.AHB_PODF.scale" value="1" locked="true"/>
+                  <setting id="CCM.ARM_PODF.scale" value="1" locked="true"/>
+                  <setting id="CCM.CLKO2_DIV.scale" value="1" locked="true"/>
+                  <setting id="CCM.CLKO2_SEL.sel" value="XTALOSC24M.OSC_CLK" locked="false"/>
+                  <setting id="CCM.FLEXSPI_PODF.scale" value="8" locked="true"/>
+                  <setting id="CCM.FLEXSPI_SEL.sel" value="CCM_ANALOG.PLL3_PFD0_CLK" locked="false"/>
+                  <setting id="CCM.IPG_PODF.scale" value="4" locked="true"/>
+                  <setting id="CCM.LPI2C_CLK_PODF.scale" value="6" locked="true"/>
+                  <setting id="CCM.LPSPI_CLK_SEL.sel" value="CCM_ANALOG.PLL3_PFD0_CLK" locked="false"/>
+                  <setting id="CCM.LPSPI_PODF.scale" value="8" locked="true"/>
+                  <setting id="CCM.PERCLK_PODF.scale" value="2" locked="true"/>
+                  <setting id="CCM.PERIPH_CLK2_SEL.sel" value="XTALOSC24M.OSC_CLK" locked="false"/>
+                  <setting id="CCM.PRE_PERIPH_CLK_SEL.sel" value="CCM.ARM_PODF" locked="false"/>
+                  <setting id="CCM.SAI2_CLK_PRED.scale" value="4" locked="true"/>
+                  <setting id="CCM.SEMC_CLK_SEL.sel" value="CCM.SEMC_ALT_CLK_SEL" locked="false"/>
+                  <setting id="CCM.SEMC_PODF.scale" value="2" locked="true"/>
+                  <setting id="CCM.TRACE_PODF.scale" value="4" locked="true"/>
+                  <setting id="CCM.USDHC1_CLK_SEL.sel" value="CCM_ANALOG.PLL2_PFD0_CLK" locked="false"/>
+                  <setting id="CCM.USDHC1_PODF.scale" value="2" locked="true"/>
+                  <setting id="CCM.USDHC2_CLK_SEL.sel" value="CCM_ANALOG.PLL2_PFD0_CLK" locked="false"/>
+                  <setting id="CCM.USDHC2_PODF.scale" value="2" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2.denom" value="1" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2.num" value="0" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_BYPASS.sel" value="CCM_ANALOG.PLL2_OUT_CLK" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD0_BYPASS.sel" value="CCM_ANALOG.PLL2_PFD0" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD0_DIV.scale" value="24" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD0_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD1_BYPASS.sel" value="CCM_ANALOG.PLL2_PFD1" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD2_BYPASS.sel" value="CCM_ANALOG.PLL2_PFD2" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD2_DIV.scale" value="29" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD2_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD3_BYPASS.sel" value="CCM_ANALOG.PLL2_PFD3" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD3_DIV.scale" value="35" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD3_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_BYPASS.sel" value="CCM_ANALOG.PLL3" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD0_BYPASS.sel" value="CCM_ANALOG.PLL3_PFD0" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD0_DIV.scale" value="12" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD0_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD1_BYPASS.sel" value="CCM_ANALOG.PLL3_PFD1" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD1_DIV.scale" value="35" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD1_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD2_BYPASS.sel" value="CCM_ANALOG.PLL3_PFD2" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD2_DIV.scale" value="26" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD2_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD3_BYPASS.sel" value="CCM_ANALOG.PLL3_PFD3" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD3_DIV.scale" value="31" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD3_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL4.denom" value="50" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL4.div" value="27" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL4_POST_DIV.scale" value="4" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL6_BYPASS.sel" value="CCM_ANALOG.PLL6" locked="false"/>
+                  <setting id="CCM_ANALOG_PLL_USB1_EN_USB_CLKS_CFG" value="Enabled" locked="false"/>
+                  <setting id="CCM_ANALOG_PLL_USB1_EN_USB_CLKS_OUT_CFG" value="Enabled" locked="false"/>
+                  <setting id="CCM_ANALOG_PLL_USB1_POWER_CFG" value="Yes" locked="false"/>
+               </clock_settings>
+               <called_from_default_init>true</called_from_default_init>
+            </clock_configuration>
+         </clock_configurations>
+      </clocks>
+      <dcdx name="DCDx" version="3.0" enabled="true" update_project_code="false">
+         <generated_project_files>
+            <file path="board/dcd.c" update_enabled="true"/>
+            <file path="board/dcd.h" update_enabled="true"/>
+         </generated_project_files>
+         <dcdx_profile>
+            <processor_version>10.0.0</processor_version>
+            <output_format>c_array</output_format>
+         </dcdx_profile>
+         <dcdx_configurations>
+            <dcdx_configuration name="Device_configuration">
+               <description></description>
+               <options/>
+               <command_groups>
+                  <command_group name="Imported Commands" enabled="true">
+                     <commands>
+                        <command type="write_value" address="CCM_CCGR0" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR1" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR2" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR3" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR4" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR5" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR6" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_ANALOG_PLL_SYS" value="0x2001" value_width="4"/>
+                        <command type="write_value" address="CCM_ANALOG_PFD_528" value="0x1D0000" value_width="4"/>
+                        <command type="write_value" address="CCM_CBCDR" value="0x10D40" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_00" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_01" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_02" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_03" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_04" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_05" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_06" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_07" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_08" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_09" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_10" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_11" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_12" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_13" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_14" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_15" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_16" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_17" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_18" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_19" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_20" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_21" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_22" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_23" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_24" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_25" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_26" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_27" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_28" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_29" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_30" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_31" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_32" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_33" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_34" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_35" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_36" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_37" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_38" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_39" value="0x10" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_00" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_01" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_02" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_03" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_04" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_05" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_06" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_07" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_08" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_09" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_10" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_11" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_12" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_13" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_14" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_15" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_16" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_17" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_18" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_19" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_20" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_21" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_22" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_23" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_24" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_25" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_26" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_27" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_28" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_29" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_30" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_31" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_32" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_33" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_34" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_35" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_36" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_37" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_38" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_39" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="SEMC_MCR" value="0x10000004" value_width="4"/>
+                        <command type="write_value" address="SEMC_BMCR0" value="0x81" value_width="4"/>
+                        <command type="write_value" address="SEMC_BMCR1" value="0x81" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR0" value="0x8000001B" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR1" value="0x8200001B" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR2" value="0x8400001B" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR3" value="0x8600001B" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR4" value="0x90000021" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR5" value="0xA0000019" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR6" value="0xA8000017" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR7" value="0xA900001B" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR8" value="0x21" value_width="4"/>
+                        <command type="write_value" address="SEMC_IOCR" value="0x79A8" value_width="4"/>
+                        <command type="write_value" address="SEMC_SDRAMCR0" value="0xF31" value_width="4"/>
+                        <command type="write_value" address="SEMC_SDRAMCR1" value="0x652922" value_width="4"/>
+                        <command type="write_value" address="SEMC_SDRAMCR2" value="0x10920" value_width="4"/>
+                        <command type="write_value" address="SEMC_SDRAMCR3" value="0x50210A08" value_width="4"/>
+                        <command type="write_value" address="SEMC_DBICR0" value="0x21" value_width="4"/>
+                        <command type="write_value" address="SEMC_DBICR1" value="0x888888" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR1" value="0x02" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR2" value="0x00" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR0" value="0x80000000" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCMD" value="0xA55A000F" value_width="4"/>
+                        <command type="check_any_bit_set" address="SEMC_INTR" value="0x01" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR0" value="0x80000000" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCMD" value="0xA55A000C" value_width="4"/>
+                        <command type="check_any_bit_set" address="SEMC_INTR" value="0x01" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR0" value="0x80000000" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCMD" value="0xA55A000C" value_width="4"/>
+                        <command type="check_any_bit_set" address="SEMC_INTR" value="0x01" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPTXDAT" value="0x33" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR0" value="0x80000000" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCMD" value="0xA55A000A" value_width="4"/>
+                        <command type="check_any_bit_set" address="SEMC_INTR" value="0x01" value_width="4"/>
+                        <command type="write_value" address="SEMC_SDRAMCR3" value="0x50210A09" value_width="4"/>
+                     </commands>
+                  </command_group>
+               </command_groups>
+            </dcdx_configuration>
+         </dcdx_configurations>
+      </dcdx>
+      <periphs name="Peripherals" version="10.0" enabled="true" update_project_code="false">
+         <generated_project_files>
+            <file path="board/peripherals.c" update_enabled="true"/>
+            <file path="board/peripherals.h" update_enabled="true"/>
+         </generated_project_files>
+         <peripherals_profile>
+            <processor_version>10.0.0</processor_version>
+         </peripherals_profile>
+         <functional_groups>
+            <functional_group name="BOARD_InitPeripherals" uuid="1c6563a6-c68b-40e5-8828-2853c99f95fa" called_from_default_init="true" id_prefix="BOARD_" core="core0">
+               <description></description>
+               <options/>
+               <dependencies/>
+               <instances>
+                  <instance name="NVIC" uuid="2c253e89-508d-4544-9d44-c226931d8f3f" type="nvic" type_id="nvic_57b5eef3774cc60acaede6f5b8bddc67" mode="general" peripheral="NVIC" enabled="true" comment="" custom_name_enabled="false" editing_lock="false">
+                     <config_set name="nvic">
+                        <array name="interrupt_table"/>
+                        <array name="interrupts"/>
+                     </config_set>
+                  </instance>
+               </instances>
+            </functional_group>
+         </functional_groups>
+         <components>
+            <component name="system" uuid="18e298ee-cc10-47f7-b950-440409a94f94" type_id="system_54b53072540eeeb8f8e9343e71f28176">
+               <config_set_global name="global_system_definitions">
+                  <setting name="user_definitions" value=""/>
+                  <setting name="user_includes" value=""/>
+               </config_set_global>
+            </component>
+            <component name="msg" uuid="078a031a-1304-48e4-934c-de6b7bd41d37" type_id="msg_6e2baaf3b97dbeef01c0043275f9a0e7">
+               <config_set_global name="global_messages"/>
+            </component>
+            <component name="generic_uart" uuid="0e122da2-c994-4d5a-a7b8-5a63103fc1d2" type_id="generic_uart_8cae00565451cf2346eb1b8c624e73a6">
+               <config_set_global name="global_uart"/>
+            </component>
+            <component name="generic_can" uuid="51762fc1-cf05-4bb3-a3ca-5da5c50ea072" type_id="generic_can_1bfdd78b1af214566c1f23cf6a582d80">
+               <config_set_global name="global_can"/>
+            </component>
+            <component name="uart_cmsis_common" uuid="d4182366-28a3-4b72-9e22-d29aa447729c" type_id="uart_cmsis_common_9cb8e302497aa696fdbb5a4fd622c2a8">
+               <config_set_global name="global_USART_CMSIS_common" quick_selection="default"/>
+            </component>
+            <component name="generic_enet" uuid="c9d3d8ac-0dc9-40de-aea5-dd11df3d996b" type_id="generic_enet_74db5c914f0ddbe47d86af40cb77a619">
+               <config_set_global name="global_enet"/>
+            </component>
+         </components>
+      </periphs>
+      <tee name="TEE" version="2.0" enabled="false" update_project_code="true">
+         <generated_project_files/>
+         <tee_profile>
+            <processor_version>N/A</processor_version>
+         </tee_profile>
+      </tee>
+   </tools>
+</configuration>

--- a/boards/arm/mimxrt1024_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1024_evk/CMakeLists.txt
@@ -5,4 +5,5 @@
 #
 
 zephyr_library()
-zephyr_library_sources(pinmux.c)
+zephyr_library_sources(pinmux.c clock_config.c)
+zephyr_include_directories(.)

--- a/boards/arm/mimxrt1024_evk/clock_config.c
+++ b/boards/arm/mimxrt1024_evk/clock_config.c
@@ -1,0 +1,468 @@
+/*
+ * Copyright (c) 2021, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * How to setup clock using clock driver functions:
+ *
+ * 1. Call CLOCK_InitXXXPLL() to configure corresponding PLL clock.
+ *
+ * 2. Call CLOCK_InitXXXpfd() to configure corresponding PLL pfd clock.
+ *
+ * 3. Call CLOCK_SetMux() to configure corresponding clock source for target clock out.
+ *
+ * 4. Call CLOCK_SetDiv() to configure corresponding clock divider for target clock out.
+ *
+ * 5. Call CLOCK_SetXtalFreq() to set XTAL frequency based on board settings.
+ *
+ */
+
+/* TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
+ * !!GlobalInfo
+ * product: Clocks v8.0
+ * processor: MIMXRT1024xxxxx
+ * package_id: MIMXRT1024DAG5A
+ * mcu_data: ksdk2_0
+ * processor_version: 10.0.0
+ * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS **********/
+
+#include "clock_config.h"
+#include "fsl_iomuxc.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+/* System clock frequency. */
+extern uint32_t SystemCoreClock;
+
+/*******************************************************************************
+ ************************ BOARD_InitBootClocks function ************************
+ ******************************************************************************/
+void BOARD_InitBootClocks(void)
+{
+	clock_init();
+}
+
+/*******************************************************************************
+ ************************** Configuration clock_init ***************************
+ ******************************************************************************/
+/* TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
+ * !!Configuration
+ * name: clock_init
+ * called_from_default_init: true
+ * outputs:
+ * - {id: AHB_CLK_ROOT.outFreq, value: 500 MHz}
+ * - {id: CAN_CLK_ROOT.outFreq, value: 40 MHz}
+ * - {id: CKIL_SYNC_CLK_ROOT.outFreq, value: 32.768 kHz}
+ * - {id: CLK_1M.outFreq, value: 1 MHz}
+ * - {id: CLK_24M.outFreq, value: 24 MHz}
+ * - {id: ENET_125M_CLK.outFreq, value: 50 MHz}
+ * - {id: ENET_25M_REF_CLK.outFreq, value: 25 MHz}
+ * - {id: ENET_500M_REF_CLK.outFreq, value: 500 MHz}
+ * - {id: FLEXIO1_CLK_ROOT.outFreq, value: 30 MHz}
+ * - {id: FLEXSPI_CLK_ROOT.outFreq, value: 90 MHz}
+ * - {id: GPT1_ipg_clk_highfreq.outFreq, value: 62.5 MHz}
+ * - {id: GPT2_ipg_clk_highfreq.outFreq, value: 62.5 MHz}
+ * - {id: IPG_CLK_ROOT.outFreq, value: 125 MHz}
+ * - {id: LPI2C_CLK_ROOT.outFreq, value: 10 MHz}
+ * - {id: LPSPI_CLK_ROOT.outFreq, value: 90 MHz}
+ * - {id: MQS_MCLK.outFreq, value: 540/13 MHz}
+ * - {id: PERCLK_CLK_ROOT.outFreq, value: 62.5 MHz}
+ * - {id: SAI1_CLK_ROOT.outFreq, value: 540/13 MHz}
+ * - {id: SAI1_MCLK1.outFreq, value: 540/13 MHz}
+ * - {id: SAI1_MCLK2.outFreq, value: 540/13 MHz}
+ * - {id: SAI1_MCLK3.outFreq, value: 30 MHz}
+ * - {id: SAI2_CLK_ROOT.outFreq, value: 540/13 MHz}
+ * - {id: SAI2_MCLK1.outFreq, value: 540/13 MHz}
+ * - {id: SAI2_MCLK3.outFreq, value: 30 MHz}
+ * - {id: SAI3_CLK_ROOT.outFreq, value: 540/13 MHz}
+ * - {id: SAI3_MCLK1.outFreq, value: 540/13 MHz}
+ * - {id: SAI3_MCLK3.outFreq, value: 30 MHz}
+ * - {id: SEMC_CLK_ROOT.outFreq, value: 4752/29 MHz}
+ * - {id: SPDIF0_CLK_ROOT.outFreq, value: 30 MHz}
+ * - {id: TRACE_CLK_ROOT.outFreq, value: 99 MHz}
+ * - {id: UART_CLK_ROOT.outFreq, value: 80 MHz}
+ * - {id: USBPHY1_CLK.outFreq, value: 480 MHz}
+ * - {id: USDHC1_CLK_ROOT.outFreq, value: 198 MHz}
+ * - {id: USDHC2_CLK_ROOT.outFreq, value: 198 MHz}
+ * settings:
+ * - {id: CCM.AHB_PODF.scale, value: '1', locked: true}
+ * - {id: CCM.ARM_PODF.scale, value: '1', locked: true}
+ * - {id: CCM.CLKO2_DIV.scale, value: '1', locked: true}
+ * - {id: CCM.CLKO2_SEL.sel, value: XTALOSC24M.OSC_CLK}
+ * - {id: CCM.FLEXSPI_PODF.scale, value: '8', locked: true}
+ * - {id: CCM.FLEXSPI_SEL.sel, value: CCM_ANALOG.PLL3_PFD0_CLK}
+ * - {id: CCM.IPG_PODF.scale, value: '4', locked: true}
+ * - {id: CCM.LPI2C_CLK_PODF.scale, value: '6', locked: true}
+ * - {id: CCM.LPSPI_CLK_SEL.sel, value: CCM_ANALOG.PLL3_PFD0_CLK}
+ * - {id: CCM.LPSPI_PODF.scale, value: '8', locked: true}
+ * - {id: CCM.PERCLK_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.PERIPH_CLK2_SEL.sel, value: XTALOSC24M.OSC_CLK}
+ * - {id: CCM.PRE_PERIPH_CLK_SEL.sel, value: CCM.ARM_PODF}
+ * - {id: CCM.SAI2_CLK_PRED.scale, value: '4', locked: true}
+ * - {id: CCM.SEMC_CLK_SEL.sel, value: CCM.SEMC_ALT_CLK_SEL}
+ * - {id: CCM.SEMC_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.TRACE_PODF.scale, value: '4', locked: true}
+ * - {id: CCM.USDHC1_CLK_SEL.sel, value: CCM_ANALOG.PLL2_PFD0_CLK}
+ * - {id: CCM.USDHC1_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.USDHC2_CLK_SEL.sel, value: CCM_ANALOG.PLL2_PFD0_CLK}
+ * - {id: CCM.USDHC2_PODF.scale, value: '2', locked: true}
+ * - {id: CCM_ANALOG.PLL2.denom, value: '1', locked: true}
+ * - {id: CCM_ANALOG.PLL2.num, value: '0', locked: true}
+ * - {id: CCM_ANALOG.PLL2_BYPASS.sel, value: CCM_ANALOG.PLL2_OUT_CLK}
+ * - {id: CCM_ANALOG.PLL2_PFD0_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD0}
+ * - {id: CCM_ANALOG.PLL2_PFD0_DIV.scale, value: '24', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD0_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD1_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD1}
+ * - {id: CCM_ANALOG.PLL2_PFD2_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD2}
+ * - {id: CCM_ANALOG.PLL2_PFD2_DIV.scale, value: '29', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD2_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD3_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD3}
+ * - {id: CCM_ANALOG.PLL2_PFD3_DIV.scale, value: '35', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD3_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_BYPASS.sel, value: CCM_ANALOG.PLL3}
+ * - {id: CCM_ANALOG.PLL3_PFD0_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD0}
+ * - {id: CCM_ANALOG.PLL3_PFD0_DIV.scale, value: '12', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD0_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD1_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD1}
+ * - {id: CCM_ANALOG.PLL3_PFD1_DIV.scale, value: '35', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD1_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD2_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD2}
+ * - {id: CCM_ANALOG.PLL3_PFD2_DIV.scale, value: '26', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD2_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD3_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD3}
+ * - {id: CCM_ANALOG.PLL3_PFD3_DIV.scale, value: '31', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD3_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL4.denom, value: '50'}
+ * - {id: CCM_ANALOG.PLL4.div, value: '27', locked: true}
+ * - {id: CCM_ANALOG.PLL4_POST_DIV.scale, value: '4', locked: true}
+ * - {id: CCM_ANALOG.PLL6_BYPASS.sel, value: CCM_ANALOG.PLL6}
+ * - {id: CCM_ANALOG_PLL_USB1_EN_USB_CLKS_CFG, value: Enabled}
+ * - {id: CCM_ANALOG_PLL_USB1_EN_USB_CLKS_OUT_CFG, value: Enabled}
+ * - {id: CCM_ANALOG_PLL_USB1_POWER_CFG, value: 'Yes'}
+ * sources:
+ * - {id: XTALOSC24M.RTC_OSC.outFreq, value: 32.768 kHz, enabled: true}
+ * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS **********/
+
+/*******************************************************************************
+ * Variables for clock_init configuration
+ ******************************************************************************/
+const clock_sys_pll_config_t sysPllConfig_clock_init = {
+	/* PLL loop divider, Fout = Fin * ( 20 + loopDivider*2 + numerator / denominator ) */
+	.loopDivider = 1,
+	/* 30 bit numerator of fractional loop divider */
+	.numerator = 0,
+	/* 30 bit denominator of fractional loop divider */
+	.denominator = 1,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+const clock_usb_pll_config_t usb1PllConfig_clock_init = {
+	/* PLL loop divider, Fout = Fin * 20 */
+	.loopDivider = 0,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+const clock_enet_pll_config_t enetPllConfig_clock_init = {
+	/* Enable the PLL providing the ENET 125MHz reference clock */
+	.enableClkOutput = true,
+	/* Enable the PLL providing the ENET 500MHz reference clock */
+	.enableClkOutput500M = true,
+	/* Enable the PLL providing the ENET 25MHz reference clock */
+	.enableClkOutput25M = true,
+	/* Set frequency of ethernet reference clock to 50 MHz */
+	.loopDivider = 1,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+/*******************************************************************************
+ * Code for clock_init configuration
+ ******************************************************************************/
+void clock_init(void)
+{
+	/* Init RTC OSC clock frequency. */
+	CLOCK_SetRtcXtalFreq(32768U);
+	/* Enable 1MHz clock output. */
+	XTALOSC24M->OSC_CONFIG2 |= XTALOSC24M_OSC_CONFIG2_ENABLE_1M_MASK;
+	/* Use free 1MHz clock output. */
+	XTALOSC24M->OSC_CONFIG2 &= ~XTALOSC24M_OSC_CONFIG2_MUX_1M_MASK;
+	/* Set XTAL 24MHz clock frequency. */
+	CLOCK_SetXtalFreq(24000000U);
+	/* Enable XTAL 24MHz clock source. */
+	CLOCK_InitExternalClk(0);
+	/* Enable internal RC. */
+	CLOCK_InitRcOsc24M();
+	/* Switch clock source to external OSC. */
+	CLOCK_SwitchOsc(kCLOCK_XtalOsc);
+	/* Set Oscillator ready counter value. */
+	CCM->CCR = (CCM->CCR & (~CCM_CCR_OSCNT_MASK)) | CCM_CCR_OSCNT(127);
+	/* Setting PeriphClk2Mux and PeriphMux to provide stable clock before PLLs are initialed */
+	CLOCK_SetMux(kCLOCK_PeriphClk2Mux, 1);  /* Set PERIPH_CLK2 MUX to OSC */
+	CLOCK_SetMux(kCLOCK_PeriphMux, 1);      /* Set PERIPH_CLK MUX to PERIPH_CLK2 */
+	/* Setting the VDD_SOC to 1.25V. It is necessary to config AHB to 500Mhz. */
+	DCDC->REG3 = (DCDC->REG3 & (~DCDC_REG3_TRG_MASK)) | DCDC_REG3_TRG(0x12);
+	/* Waiting for DCDC_STS_DC_OK bit is asserted */
+	while (DCDC_REG0_STS_DC_OK_MASK != (DCDC_REG0_STS_DC_OK_MASK & DCDC->REG0)) {
+	}
+	/* Set AHB_PODF. */
+	CLOCK_SetDiv(kCLOCK_AhbDiv, 0);
+	/* Disable IPG clock gate. */
+	CLOCK_DisableClock(kCLOCK_Adc1);
+	CLOCK_DisableClock(kCLOCK_Adc2);
+	CLOCK_DisableClock(kCLOCK_Xbar1);
+	CLOCK_DisableClock(kCLOCK_Xbar2);
+	/* Set IPG_PODF. */
+	CLOCK_SetDiv(kCLOCK_IpgDiv, 3);
+	/* Set ARM_PODF. */
+	CLOCK_SetDiv(kCLOCK_ArmDiv, 0);
+	/* Set PERIPH_CLK2_PODF. */
+	CLOCK_SetDiv(kCLOCK_PeriphClk2Div, 0);
+	/* Disable PERCLK clock gate. */
+	CLOCK_DisableClock(kCLOCK_Gpt1);
+	CLOCK_DisableClock(kCLOCK_Gpt1S);
+	CLOCK_DisableClock(kCLOCK_Gpt2);
+	CLOCK_DisableClock(kCLOCK_Gpt2S);
+	CLOCK_DisableClock(kCLOCK_Pit);
+	/* Set PERCLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_PerclkDiv, 1);
+	/* Disable USDHC1 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Usdhc1);
+	/* Set USDHC1_PODF. */
+	CLOCK_SetDiv(kCLOCK_Usdhc1Div, 1);
+	/* Set Usdhc1 clock source. */
+	CLOCK_SetMux(kCLOCK_Usdhc1Mux, 1);
+	/* Disable USDHC2 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Usdhc2);
+	/* Set USDHC2_PODF. */
+	CLOCK_SetDiv(kCLOCK_Usdhc2Div, 1);
+	/* Set Usdhc2 clock source. */
+	CLOCK_SetMux(kCLOCK_Usdhc2Mux, 1);
+	/*
+	 * In SDK projects, SDRAM (configured by SEMC) will be initialized in either debug script
+	 * or dcd. With this macro SKIP_SYSCLK_INIT, system pll (selected to be SEMC source clock
+	 * in SDK projects) will be left unchanged.
+	 * Note: If another clock source is selected for SEMC, user may want to avoid changing that
+	 * clock as well.
+	 */
+#ifndef SKIP_SYSCLK_INIT
+	/* Disable Semc clock gate. */
+	CLOCK_DisableClock(kCLOCK_Semc);
+	/* Set SEMC_PODF. */
+	CLOCK_SetDiv(kCLOCK_SemcDiv, 1);
+	/* Set Semc alt clock source. */
+	CLOCK_SetMux(kCLOCK_SemcAltMux, 0);
+	/* Set Semc clock source. */
+	CLOCK_SetMux(kCLOCK_SemcMux, 1);
+#endif
+	/*
+	 * In SDK projects, external flash (configured by FLEXSPI) will be initialized by dcd.
+	 * With this macro XIP_EXTERNAL_FLASH, usb1 pll (selected to be FLEXSPI clock source in
+	 * SDK projects) will be left unchanged.
+	 * Note: If another clock source is selected for FLEXSPI, user may want to avoid changing
+	 * that clock as well.
+	 */
+#if !(defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1))
+	/* Disable Flexspi clock gate. */
+	CLOCK_DisableClock(kCLOCK_FlexSpi);
+	/* Set FLEXSPI_PODF. */
+	CLOCK_SetDiv(kCLOCK_FlexspiDiv, 7);
+	/* Set Flexspi clock source. */
+	CLOCK_SetMux(kCLOCK_FlexspiMux, 3);
+#endif
+	/* Disable LPSPI clock gate. */
+	CLOCK_DisableClock(kCLOCK_Lpspi1);
+	CLOCK_DisableClock(kCLOCK_Lpspi2);
+	CLOCK_DisableClock(kCLOCK_Lpspi3);
+	CLOCK_DisableClock(kCLOCK_Lpspi4);
+	/* Set LPSPI_PODF. */
+	CLOCK_SetDiv(kCLOCK_LpspiDiv, 7);
+	/* Set Lpspi clock source. */
+	CLOCK_SetMux(kCLOCK_LpspiMux, 1);
+	/* Disable TRACE clock gate. */
+	CLOCK_DisableClock(kCLOCK_Trace);
+	/* Set TRACE_PODF. */
+	CLOCK_SetDiv(kCLOCK_TraceDiv, 3);
+	/* Set Trace clock source. */
+	CLOCK_SetMux(kCLOCK_TraceMux, 2);
+	/* Disable SAI1 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Sai1);
+	/* Set SAI1_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Sai1PreDiv, 3);
+	/* Set SAI1_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Sai1Div, 1);
+	/* Set Sai1 clock source. */
+	CLOCK_SetMux(kCLOCK_Sai1Mux, 0);
+	/* Disable SAI2 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Sai2);
+	/* Set SAI2_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Sai2PreDiv, 3);
+	/* Set SAI2_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Sai2Div, 1);
+	/* Set Sai2 clock source. */
+	CLOCK_SetMux(kCLOCK_Sai2Mux, 0);
+	/* Disable SAI3 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Sai3);
+	/* Set SAI3_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Sai3PreDiv, 3);
+	/* Set SAI3_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Sai3Div, 1);
+	/* Set Sai3 clock source. */
+	CLOCK_SetMux(kCLOCK_Sai3Mux, 0);
+	/* Disable Lpi2c clock gate. */
+	CLOCK_DisableClock(kCLOCK_Lpi2c1);
+	CLOCK_DisableClock(kCLOCK_Lpi2c2);
+	CLOCK_DisableClock(kCLOCK_Lpi2c3);
+	/* Set LPI2C_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Lpi2cDiv, 5);
+	/* Set Lpi2c clock source. */
+	CLOCK_SetMux(kCLOCK_Lpi2cMux, 0);
+	/* Disable CAN clock gate. */
+	CLOCK_DisableClock(kCLOCK_Can1);
+	CLOCK_DisableClock(kCLOCK_Can2);
+	CLOCK_DisableClock(kCLOCK_Can1S);
+	CLOCK_DisableClock(kCLOCK_Can2S);
+	/* Set CAN_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_CanDiv, 1);
+	/* Set Can clock source. */
+	CLOCK_SetMux(kCLOCK_CanMux, 2);
+	/* Disable UART clock gate. */
+	CLOCK_DisableClock(kCLOCK_Lpuart1);
+	CLOCK_DisableClock(kCLOCK_Lpuart2);
+	CLOCK_DisableClock(kCLOCK_Lpuart3);
+	CLOCK_DisableClock(kCLOCK_Lpuart4);
+	CLOCK_DisableClock(kCLOCK_Lpuart5);
+	CLOCK_DisableClock(kCLOCK_Lpuart6);
+	CLOCK_DisableClock(kCLOCK_Lpuart7);
+	CLOCK_DisableClock(kCLOCK_Lpuart8);
+	/* Set UART_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_UartDiv, 0);
+	/* Set Uart clock source. */
+	CLOCK_SetMux(kCLOCK_UartMux, 0);
+	/* Disable SPDIF clock gate. */
+	CLOCK_DisableClock(kCLOCK_Spdif);
+	/* Set SPDIF0_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Spdif0PreDiv, 1);
+	/* Set SPDIF0_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Spdif0Div, 7);
+	/* Set Spdif clock source. */
+	CLOCK_SetMux(kCLOCK_SpdifMux, 3);
+	/* Disable Flexio1 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Flexio1);
+	/* Set FLEXIO1_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Flexio1PreDiv, 1);
+	/* Set FLEXIO1_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Flexio1Div, 7);
+	/* Set Flexio1 clock source. */
+	CLOCK_SetMux(kCLOCK_Flexio1Mux, 3);
+	/* Set Pll3 sw clock source. */
+	CLOCK_SetMux(kCLOCK_Pll3SwMux, 0);
+	/*
+	 * In SDK projects, SDRAM (configured by SEMC) will be initialized in either debug script
+	 * or dcd. With this macro SKIP_SYSCLK_INIT, system pll (selected to be SEMC source clock
+	 * in SDK projects) will be left unchanged.
+	 * Note: If another clock source is selected for SEMC, user may want to avoid changing that
+	 * clock as well.
+	 */
+#ifndef SKIP_SYSCLK_INIT
+#if defined(XIP_BOOT_HEADER_DCD_ENABLE) && (XIP_BOOT_HEADER_DCD_ENABLE == 1)
+    #warning "SKIP_SYSCLK_INIT should be defined to keep system pll (selected to be SEMC source \
+	      clock in SDK projects) unchanged."
+#endif
+	/* Init System PLL. */
+	CLOCK_InitSysPll(&sysPllConfig_clock_init);
+	/* Init System pfd0. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd0, 24);
+	/* Init System pfd1. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd1, 16);
+	/* Init System pfd2. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd2, 29);
+	/* Init System pfd3. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd3, 35);
+#endif
+	/*
+	 * In SDK projects, external flash (configured by FLEXSPI) will be initialized by dcd.
+	 * With this macro XIP_EXTERNAL_FLASH, usb1 pll (selected to be FLEXSPI clock source in SDK
+	 * projects) will be left unchanged.
+	 * Note: If another clock source is selected for FLEXSPI, user may want to avoid changing
+	 * that clock as well.
+	 */
+#if !(defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1))
+	/* Init Usb1 PLL. */
+	CLOCK_InitUsb1Pll(&usb1PllConfig_clock_init);
+	/* Init Usb1 pfd0. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd0, 12);
+	/* Init Usb1 pfd1. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd1, 35);
+	/* Init Usb1 pfd2. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd2, 26);
+	/* Init Usb1 pfd3. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd3, 31);
+#endif
+	/* DeInit Audio PLL. */
+	CLOCK_DeinitAudioPll();
+	/* Bypass Audio PLL. */
+	CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllAudio, 1);
+	/* Set divider for Audio PLL. */
+	CCM_ANALOG->MISC2 &= ~CCM_ANALOG_MISC2_AUDIO_DIV_LSB_MASK;
+	CCM_ANALOG->MISC2 &= ~CCM_ANALOG_MISC2_AUDIO_DIV_MSB_MASK;
+	/* Enable Audio PLL output. */
+	CCM_ANALOG->PLL_AUDIO |= CCM_ANALOG_PLL_AUDIO_ENABLE_MASK;
+	/* Init Enet PLL. */
+	CLOCK_InitEnetPll(&enetPllConfig_clock_init);
+	/* Set preperiph clock source. */
+	CLOCK_SetMux(kCLOCK_PrePeriphMux, 3);
+	/* Set periph clock source. */
+	CLOCK_SetMux(kCLOCK_PeriphMux, 0);
+	/* Set periph clock2 clock source. */
+	CLOCK_SetMux(kCLOCK_PeriphClk2Mux, 1);
+	/* Set per clock source. */
+	CLOCK_SetMux(kCLOCK_PerclkMux, 0);
+	/* Set clock out1 divider. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO1_DIV_MASK)) | CCM_CCOSR_CLKO1_DIV(0);
+	/* Set clock out1 source. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO1_SEL_MASK)) | CCM_CCOSR_CLKO1_SEL(1);
+	/* Set clock out2 divider. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO2_DIV_MASK)) | CCM_CCOSR_CLKO2_DIV(0);
+	/* Set clock out2 source. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO2_SEL_MASK)) | CCM_CCOSR_CLKO2_SEL(14);
+	/* Set clock out1 drives clock out1. */
+	CCM->CCOSR &= ~CCM_CCOSR_CLK_OUT_SEL_MASK;
+	/* Disable clock out1. */
+	CCM->CCOSR &= ~CCM_CCOSR_CLKO1_EN_MASK;
+	/* Disable clock out2. */
+	CCM->CCOSR &= ~CCM_CCOSR_CLKO2_EN_MASK;
+	/* Set SAI1 MCLK1 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk1Sel, 0);
+	/* Set SAI1 MCLK2 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk2Sel, 0);
+	/* Set SAI1 MCLK3 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk3Sel, 0);
+	/* Set SAI2 MCLK3 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI2MClk3Sel, 0);
+	/* Set SAI3 MCLK3 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI3MClk3Sel, 0);
+	/* Set MQS configuration. */
+	IOMUXC_MQSConfig(IOMUXC_GPR, kIOMUXC_MqsPwmOverSampleRate32, 0);
+	/* Set ENET Ref clock source. */
+#if defined(IOMUXC_GPR_GPR1_ENET_REF_CLK_DIR_MASK)
+	IOMUXC_GPR->GPR1 &= ~IOMUXC_GPR_GPR1_ENET_REF_CLK_DIR_MASK;
+#elif defined(IOMUXC_GPR_GPR1_ENET1_TX_CLK_DIR_MASK)
+	/* Backward compatibility for original bitfield name */
+	IOMUXC_GPR->GPR1 &= ~IOMUXC_GPR_GPR1_ENET1_TX_CLK_DIR_MASK;
+#else
+#error "Neither IOMUXC_GPR_GPR1_ENET_REF_CLK_DIR_MASK nor IOMUXC_GPR_GPR1_ENET1_TX_CLK_DIR_MASK \
+	is defined."
+#endif /* defined(IOMUXC_GPR_GPR1_ENET_REF_CLK_DIR_MASK) */
+	/* Set GPT1 High frequency reference clock source. */
+	IOMUXC_GPR->GPR5 &= ~IOMUXC_GPR_GPR5_VREF_1M_CLK_GPT1_MASK;
+	/* Set GPT2 High frequency reference clock source. */
+	IOMUXC_GPR->GPR5 &= ~IOMUXC_GPR_GPR5_VREF_1M_CLK_GPT2_MASK;
+	/* Set SystemCoreClock variable. */
+	SystemCoreClock = CLOCK_INIT_CORE_CLOCK;
+}

--- a/boards/arm/mimxrt1024_evk/clock_config.h
+++ b/boards/arm/mimxrt1024_evk/clock_config.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2021, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _CLOCK_CONFIG_H_
+#define _CLOCK_CONFIG_H_
+
+#include "fsl_common.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+/*!< Board xtal0 frequency in Hz */
+#define BOARD_XTAL0_CLK_HZ                         24000000U
+
+/*!< Board xtal32k frequency in Hz */
+#define BOARD_XTAL32K_CLK_HZ                          32768U
+/*******************************************************************************
+ ************************ BOARD_InitBootClocks function ************************
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus*/
+
+/*!
+ * @brief This function executes default configuration of clocks.
+ *
+ */
+void BOARD_InitBootClocks(void);
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus*/
+
+/*******************************************************************************
+ ************************** Configuration clock_init ***************************
+ ******************************************************************************/
+/*******************************************************************************
+ * Definitions for clock_init configuration
+ ******************************************************************************/
+/*!< Core clock frequency: 500000000Hz */
+#define CLOCK_INIT_CORE_CLOCK                     500000000U
+
+/* Clock outputs (values are in Hz): */
+#define CLOCK_INIT_AHB_CLK_ROOT                       500000000UL
+#define CLOCK_INIT_CAN_CLK_ROOT                       40000000UL
+#define CLOCK_INIT_CKIL_SYNC_CLK_ROOT                 32768UL
+#define CLOCK_INIT_CLKO1_CLK                          0UL
+#define CLOCK_INIT_CLKO2_CLK                          0UL
+#define CLOCK_INIT_CLK_1M                             1000000UL
+#define CLOCK_INIT_CLK_24M                            24000000UL
+#define CLOCK_INIT_ENET_125M_CLK                      50000000UL
+#define CLOCK_INIT_ENET_25M_REF_CLK                   25000000UL
+#define CLOCK_INIT_ENET_500M_REF_CLK                  500000000UL
+#define CLOCK_INIT_ENET_REF_CLK                       0UL
+#define CLOCK_INIT_ENET_TX_CLK                        0UL
+#define CLOCK_INIT_FLEXIO1_CLK_ROOT                   30000000UL
+#define CLOCK_INIT_FLEXSPI_CLK_ROOT                   90000000UL
+#define CLOCK_INIT_GPT1_IPG_CLK_HIGHFREQ              62500000UL
+#define CLOCK_INIT_GPT2_IPG_CLK_HIGHFREQ              62500000UL
+#define CLOCK_INIT_IPG_CLK_ROOT                       125000000UL
+#define CLOCK_INIT_LPI2C_CLK_ROOT                     10000000UL
+#define CLOCK_INIT_LPSPI_CLK_ROOT                     90000000UL
+#define CLOCK_INIT_MQS_MCLK                           41538461UL
+#define CLOCK_INIT_PERCLK_CLK_ROOT                    62500000UL
+#define CLOCK_INIT_SAI1_CLK_ROOT                      41538461UL
+#define CLOCK_INIT_SAI1_MCLK1                         41538461UL
+#define CLOCK_INIT_SAI1_MCLK2                         41538461UL
+#define CLOCK_INIT_SAI1_MCLK3                         30000000UL
+#define CLOCK_INIT_SAI2_CLK_ROOT                      41538461UL
+#define CLOCK_INIT_SAI2_MCLK1                         41538461UL
+#define CLOCK_INIT_SAI2_MCLK2                         0UL
+#define CLOCK_INIT_SAI2_MCLK3                         30000000UL
+#define CLOCK_INIT_SAI3_CLK_ROOT                      41538461UL
+#define CLOCK_INIT_SAI3_MCLK1                         41538461UL
+#define CLOCK_INIT_SAI3_MCLK2                         0UL
+#define CLOCK_INIT_SAI3_MCLK3                         30000000UL
+#define CLOCK_INIT_SEMC_CLK_ROOT                      163862068UL
+#define CLOCK_INIT_SPDIF0_CLK_ROOT                    30000000UL
+#define CLOCK_INIT_SPDIF0_EXTCLK_OUT                  0UL
+#define CLOCK_INIT_TRACE_CLK_ROOT                     99000000UL
+#define CLOCK_INIT_UART_CLK_ROOT                      80000000UL
+#define CLOCK_INIT_USBPHY1_CLK                        480000000UL
+#define CLOCK_INIT_USDHC1_CLK_ROOT                    198000000UL
+#define CLOCK_INIT_USDHC2_CLK_ROOT                    198000000UL
+
+/*! @brief Usb1 PLL set for clock_init configuration.
+ */
+extern const clock_usb_pll_config_t usb1PllConfig_clock_init;
+/*! @brief Sys PLL for clock_init configuration.
+ */
+extern const clock_sys_pll_config_t sysPllConfig_clock_init;
+/*! @brief Enet PLL set for clock_init configuration.
+ */
+extern const clock_enet_pll_config_t enetPllConfig_clock_init;
+
+/*******************************************************************************
+ * API for clock_init configuration
+ ******************************************************************************/
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus*/
+
+/*!
+ * @brief This function executes configuration of clocks.
+ *
+ */
+void clock_init(void);
+
+#if defined(__cplusplus)
+}
+#endif  /* __cplusplus*/
+
+#endif  /* _CLOCK_CONFIG_H_ */

--- a/boards/arm/mimxrt1024_evk/doc/index.rst
+++ b/boards/arm/mimxrt1024_evk/doc/index.rst
@@ -251,6 +251,139 @@ should see the following message in the terminal:
    ***** Booting Zephyr OS v2.4.0-rc1 *****
    Hello World! mimxrt1024_evk
 
+MCUXpresso Config Tool
+======================
+
+A ``mimxrt1024_evk.mex`` file is included. This file was used to generate the clock
+initialization code and can be used as a starting point to tweak the clock configuration.
+This could be useful for different boards that are based on i.MX RT1024.
+
+NOTE: The MCUXpresso Config Tool currently generates a ``.c`` file with the clock configuration.
+Considering options on leveraging this tool in the future to generate a devicetree compatible file.
+
+Clock Configuration at Platform Initialization
+==============================================
+
+Below is the clock configuration at platform initialization.
+
+- On-chip 24MHz oscillator is enabled
+
+- Clock sources
+
++----------------------------+-----------------+
+| Name                       | Frequency       |
++============================+=================+
+| RTC Oscillator             | 32.768 kHz      |
++----------------------------+-----------------+
+| 24MHz clock source         | 24 MHz          |
++----------------------------+-----------------+
+| 1MHz clock                 | 1 MHz           |
++----------------------------+-----------------+
+| SAI1 MCLK                  | Inactive        |
++----------------------------+-----------------+
+| SAI2 MCLK                  | Inactive        |
++----------------------------+-----------------+
+| SAI3 MCLK                  | Inactive        |
++----------------------------+-----------------+
+| SPDIF_CLK_EXT              | Inactive        |
++----------------------------+-----------------+
+| SPDIF_SRCLK                | 1 MHz           |
++----------------------------+-----------------+
+| SPDIF_OUTCLK               | 1 MHz           |
++----------------------------+-----------------+
+| ENET_TX_CLK_EXT            | Inactive        |
++----------------------------+-----------------+
+| ENET_REF_CLK_EXT           | Inactive        |
++----------------------------+-----------------+
+
+- Clock outputs
+
++============================+=================+
+| Name                       | Frequency       |
++============================+=================+
+| AHB_CLK_ROOT               | 500 MHz         |
++----------------------------+-----------------+
+| IPG_CLK_ROOT               | 125 MHz         |
++----------------------------+-----------------+
+| SEMC_CLK_ROOT              | 163.86 MHz      |
++----------------------------+-----------------+
+| PERCLK_CLK_ROOT            | 62.5 MHz        |
++----------------------------+-----------------+
+| USDHC1_CLK_ROOT            | 198 MHz         |
++----------------------------+-----------------+
+| USDHC2_CLK_ROOT            | 198 MHz         |
++----------------------------+-----------------+
+| FLEXSPI_CLK_ROOT           | 90 MHz          |
++----------------------------+-----------------+
+| SPDIF0_CLK_ROOT            | 30 MHz          |
++----------------------------+-----------------+
+| FLEXIO1_CLK_ROOT           | 30 MHz          |
++----------------------------+-----------------+
+| SAI1_CLK_ROOT              | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI2_CLK_ROOT              | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI3_CLK_ROOT              | 41.53 MHz       |
++----------------------------+-----------------+
+| LPI2C_CLK_ROOT             | 10 MHz          |
++----------------------------+-----------------+
+| CAN_CLK_ROOT               | 40 MHz          |
++----------------------------+-----------------+
+| UART_CLK_ROOT              | 80 MHz          |
++----------------------------+-----------------+
+| LPSPI_CLK_ROOT             | 90 MHz          |
++----------------------------+-----------------+
+| TRACE_CLK_ROOT             | 99 MHz          |
++----------------------------+-----------------+
+| CKIL_SYNC_CLK_ROOT         | 32.768 kHz      |
++----------------------------+-----------------+
+| Clock 1M output            | 1 MHz           |
++----------------------------+-----------------+
+| Clock 24MHz output         | 24 MHz          |
++----------------------------+-----------------+
+| CLKO1_CLK                  | Inactive        |
++----------------------------+-----------------+
+| CLKO2_CLK                  | Inactive        |
++----------------------------+-----------------+
+| ENET_125M_CLK              | 50 MHz          |
++----------------------------+-----------------+
+| ENET_25M_REF_CLK           | 25 MHz          |
++----------------------------+-----------------+
+| ENET_500M_CLK              | 500 MHz         |
++----------------------------+-----------------+
+| USBPHY1 PLL clock          | 480 MHz         |
++----------------------------+-----------------+
+| GPT1 high frequency clock  | 62.5 MHz        |
++----------------------------+-----------------+
+| GPT2 high frequency clock  | 62.5 MHz        |
++----------------------------+-----------------+
+| SAI1 MCLK 1                | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI1 MCLK 2                | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI1 MCLK 3                | 30 MHz          |
++----------------------------+-----------------+
+| SAI2 MCLK 1                | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI2 MCLK 2                | Inactive        |
++----------------------------+-----------------+
+| SAI2 MCLK 3                | 30 MHz          |
++----------------------------+-----------------+
+| SAI3 MCLK 1                | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI3 MCLK 2                | Inactive        |
++----------------------------+-----------------+
+| SAI3 MCLK 3                | 30 MHz          |
++----------------------------+-----------------+
+| SPDIF0_EXTCLK              | Inactive        |
++----------------------------+-----------------+
+| MQS MCLK                   | 41.53 MHz       |
++----------------------------+-----------------+
+| ENET_TX_CLK                | Inactive        |
++----------------------------+-----------------+
+| ENET_REF_CLK               | Inactive        |
++----------------------------+-----------------+
+
 .. _MIMXRT1024-EVK Website:
    https://www.nxp.com/design/development-boards/i-mx-evaluation-and-development-boards/i-mx-rt1024-evaluation-kit:MIMXRT1024-EVK
 

--- a/boards/arm/mimxrt1024_evk/mimxrt1024_evk.mex
+++ b/boards/arm/mimxrt1024_evk/mimxrt1024_evk.mex
@@ -1,0 +1,1215 @@
+<?xml version="1.0" encoding= "UTF-8" ?>
+<configuration name="MIMXRT1024xxxxx" xsi:schemaLocation="http://mcuxpresso.nxp.com/XSD/mex_configuration_10 http://mcuxpresso.nxp.com/XSD/mex_configuration_10.xsd" uuid="de3bdbe5-65cf-482d-b1be-cd17b780459b" version="10" xmlns="http://mcuxpresso.nxp.com/XSD/mex_configuration_10" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+   <common>
+      <processor>MIMXRT1024xxxxx</processor>
+      <package>MIMXRT1024DAG5A</package>
+      <mcu_data>ksdk2_0</mcu_data>
+      <cores selected="core0">
+         <core name="Cortex-M7F" id="core0" description="M7 core"/>
+      </cores>
+      <description></description>
+   </common>
+   <preferences>
+      <validate_boot_init_only>true</validate_boot_init_only>
+      <generate_extended_information>false</generate_extended_information>
+      <generate_code_modified_registers_only>false</generate_code_modified_registers_only>
+      <update_include_paths>true</update_include_paths>
+   </preferences>
+   <tools>
+      <pins name="Pins" version="10.0" enabled="true" update_project_code="false">
+         <generated_project_files>
+            <file path="board/pin_mux.c" update_enabled="true"/>
+            <file path="board/pin_mux.h" update_enabled="true"/>
+         </generated_project_files>
+         <pins_profile>
+            <processor_version>10.0.0</processor_version>
+            <power_domains/>
+            <pin_labels>
+               <pin_label pin_num="111" pin_signal="GPIO_AD_B0_00" label="LPI2C1_SCL" identifier="LPI2C1_SCL"/>
+               <pin_label pin_num="110" pin_signal="GPIO_AD_B0_01" label="LPI2C1_SDA" identifier="LPI2C1_SDA"/>
+               <pin_label pin_num="109" pin_signal="GPIO_AD_B0_02" label="LCD_RESET" identifier="LCD_RESET"/>
+               <pin_label pin_num="99" pin_signal="GPIO_AD_B0_09" label="JTAG_TDI/J21[5]/ENET_RST/J22[5]" identifier="ENET_RST"/>
+               <pin_label pin_num="97" pin_signal="GPIO_AD_B0_11" label="LCD_TOUCH_INT" identifier="INT2_COMBO"/>
+            </pin_labels>
+         </pins_profile>
+         <functions_list>
+            <function name="pinmux_ENET">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="ENET" description="Peripheral ENET is not initialized" problem_level="1" source="Pins:pinmux_ENET">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_ENET">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_ENET">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="ENET" signal="enet_rx_data, 0" pin_num="" pin_signal="GPIO_B1_04">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_rx_data, 1" pin_num="" pin_signal="GPIO_B1_05">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_rx_en" pin_num="" pin_signal="GPIO_B1_06">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_tx_data, 0" pin_num="" pin_signal="GPIO_B1_07">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_tx_data, 1" pin_num="" pin_signal="GPIO_B1_08">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_tx_en" pin_num="" pin_signal="GPIO_B1_09">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_ref_clk" pin_num="" pin_signal="GPIO_B1_10">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="software_input_on" value="Enable"/>
+                        <pin_feature name="speed" value="MHZ_50"/>
+                        <pin_feature name="drive_strength" value="R0_6"/>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                        <pin_feature name="pull_keeper_enable" value="Disable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_rx_er" pin_num="" pin_signal="GPIO_B1_11">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_mdc" pin_num="116" pin_signal="GPIO_EMC_40">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_mdio" pin_num="115" pin_signal="GPIO_EMC_41">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="GPIO1" signal="gpio_io, 10" pin_num="98" pin_signal="GPIO_AD_B0_10">
+                     <pin_features>
+                        <pin_feature name="speed" value="MHZ_100"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_ENET_RST">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_ENET_RST">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_ENET_RST">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="GPIO1" signal="gpio_io, 09" pin_num="99" pin_signal="GPIO_AD_B0_09">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_100"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_LPI2C1">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="LPI2C1" description="Peripheral LPI2C1 is not initialized" problem_level="1" source="Pins:pinmux_LPI2C1">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_LPI2C1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="LPI2C1" signal="SDA" pin_num="" pin_signal="GPIO_AD_B1_01">
+                     <pin_features>
+                        <pin_feature name="software_input_on" value="Enable"/>
+                        <pin_feature name="open_drain" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_22K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LPI2C1" signal="SCL" pin_num="" pin_signal="GPIO_AD_B1_00">
+                     <pin_features>
+                        <pin_feature name="software_input_on" value="Enable"/>
+                        <pin_feature name="open_drain" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_22K_Ohm"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_LCDIF">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="LCDIF" description="Peripheral LCDIF is not initialized" problem_level="1" source="Pins:pinmux_LCDIF">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_LCDIF">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_LCDIF">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="LCDIF" signal="lcdif_clk" pin_num="" pin_signal="GPIO_B0_00">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_enable" pin_num="" pin_signal="GPIO_B0_01">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_hsync" pin_num="" pin_signal="GPIO_B0_02">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_vsync" pin_num="" pin_signal="GPIO_B0_03">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 00" pin_num="" pin_signal="GPIO_B0_04">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 01" pin_num="" pin_signal="GPIO_B0_05">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 02" pin_num="" pin_signal="GPIO_B0_06">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 03" pin_num="" pin_signal="GPIO_B0_07">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 04" pin_num="" pin_signal="GPIO_B0_08">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 05" pin_num="" pin_signal="GPIO_B0_09">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 06" pin_num="" pin_signal="GPIO_B0_10">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 07" pin_num="" pin_signal="GPIO_B0_11">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 08" pin_num="" pin_signal="GPIO_B0_12">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 09" pin_num="" pin_signal="GPIO_B0_13">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 10" pin_num="" pin_signal="GPIO_B0_14">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 11" pin_num="" pin_signal="GPIO_B0_15">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 12" pin_num="" pin_signal="GPIO_B1_00">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 13" pin_num="" pin_signal="GPIO_B1_01">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 14" pin_num="" pin_signal="GPIO_B1_02">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 15" pin_num="" pin_signal="GPIO_B1_03">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="GPIO1" signal="gpio_io, 02" pin_num="109" pin_signal="GPIO_AD_B0_02"/>
+                  <pin peripheral="GPIO2" signal="gpio_io, 31" pin_num="" pin_signal="GPIO_B1_15"/>
+               </pins>
+            </function>
+            <function name="pinmux_LPUART1">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="LPUART1" description="Peripheral LPUART1 is not initialized" problem_level="1" source="Pins:pinmux_LPUART1">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_LPUART1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_LPUART1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="LPUART1" signal="RX" pin_num="95" pin_signal="GPIO_AD_B0_13">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Slow"/>
+                        <pin_feature name="software_input_on" value="Disable"/>
+                        <pin_feature name="open_drain" value="Disable"/>
+                        <pin_feature name="speed" value="MHZ_100"/>
+                        <pin_feature name="drive_strength" value="R0_6"/>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                        <pin_feature name="pull_keeper_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Disable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LPUART1" signal="TX" pin_num="96" pin_signal="GPIO_AD_B0_12">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Slow"/>
+                        <pin_feature name="software_input_on" value="Disable"/>
+                        <pin_feature name="open_drain" value="Disable"/>
+                        <pin_feature name="speed" value="MHZ_100"/>
+                        <pin_feature name="drive_strength" value="R0_6"/>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                        <pin_feature name="pull_keeper_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Disable"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_FT5336_int">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_FT5336_int">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_FT5336_int">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="GPIO1" signal="gpio_io, 11" pin_num="97" pin_signal="GPIO_AD_B0_11">
+                     <pin_features>
+                        <pin_feature name="drive_strength" value="R0_6"/>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_FlexSPIA">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="FLEXSPI" description="Peripheral FLEXSPI is not initialized" problem_level="1" source="Pins:pinmux_FlexSPIA">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_FlexSPIA">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_FlexSPIA">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_DQS" pin_num="26" pin_signal="GPIO_SD_B1_05">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_SS0_B" pin_num="25" pin_signal="GPIO_SD_B1_06">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_SCLK" pin_num="24" pin_signal="GPIO_SD_B1_07">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_DATA0" pin_num="23" pin_signal="GPIO_SD_B1_08">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_DATA1" pin_num="22" pin_signal="GPIO_SD_B1_09">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_DATA2" pin_num="21" pin_signal="GPIO_SD_B1_10">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_DATA3" pin_num="19" pin_signal="GPIO_SD_B1_11">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_FlexCAN3">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="CAN3" description="Peripheral CAN3 is not initialized" problem_level="1" source="Pins:pinmux_FlexCAN3">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_FlexCAN3">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="CAN3" signal="TX" pin_num="120" pin_signal="GPIO_EMC_36"/>
+                  <pin peripheral="CAN3" signal="RX" pin_num="119" pin_signal="GPIO_EMC_37"/>
+               </pins>
+            </function>
+            <function name="pinmux_FlexCAN2">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="CAN2" description="Peripheral CAN2 is not initialized" problem_level="1" source="Pins:pinmux_FlexCAN2">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_FlexCAN2">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_FlexCAN2">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="CAN2" signal="TX" pin_num="94" pin_signal="GPIO_AD_B0_14"/>
+                  <pin peripheral="CAN2" signal="RX" pin_num="93" pin_signal="GPIO_AD_B0_15"/>
+               </pins>
+            </function>
+            <function name="pinmux_FlexCAN1">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="CAN1" description="Peripheral CAN1 is not initialized" problem_level="1" source="Pins:pinmux_FlexCAN1">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_FlexCAN1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="CAN1" signal="TX" pin_num="82" pin_signal="GPIO_AD_B1_08"/>
+                  <pin peripheral="CAN1" signal="RX" pin_num="81" pin_signal="GPIO_AD_B1_09"/>
+               </pins>
+            </function>
+            <function name="pinmux_CSI">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="CSI" description="Peripheral CSI is not initialized" problem_level="1" source="Pins:pinmux_CSI">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_CSI">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_CSI">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="GPIO1" signal="gpio_io, 04" pin_num="107" pin_signal="GPIO_AD_B0_04"/>
+                  <pin peripheral="CSI" signal="csi_pixclk" pin_num="" pin_signal="GPIO_AD_B1_04"/>
+                  <pin peripheral="CSI" signal="csi_mclk" pin_num="" pin_signal="GPIO_AD_B1_05"/>
+                  <pin peripheral="CSI" signal="csi_vsync" pin_num="84" pin_signal="GPIO_AD_B1_06"/>
+                  <pin peripheral="CSI" signal="csi_hsync" pin_num="83" pin_signal="GPIO_AD_B1_07"/>
+                  <pin peripheral="CSI" signal="csi_data, 09" pin_num="82" pin_signal="GPIO_AD_B1_08"/>
+                  <pin peripheral="CSI" signal="csi_data, 08" pin_num="81" pin_signal="GPIO_AD_B1_09"/>
+                  <pin peripheral="CSI" signal="csi_data, 07" pin_num="80" pin_signal="GPIO_AD_B1_10"/>
+                  <pin peripheral="CSI" signal="csi_data, 06" pin_num="79" pin_signal="GPIO_AD_B1_11"/>
+                  <pin peripheral="CSI" signal="csi_data, 05" pin_num="78" pin_signal="GPIO_AD_B1_12"/>
+                  <pin peripheral="CSI" signal="csi_data, 04" pin_num="76" pin_signal="GPIO_AD_B1_13"/>
+                  <pin peripheral="CSI" signal="csi_data, 03" pin_num="75" pin_signal="GPIO_AD_B1_14"/>
+                  <pin peripheral="CSI" signal="csi_data, 02" pin_num="74" pin_signal="GPIO_AD_B1_15"/>
+               </pins>
+            </function>
+            <function name="pinmux_FlexPWM2_pwm3">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="PWM2" description="Peripheral PWM2 is not initialized" problem_level="1" source="Pins:pinmux_FlexPWM2_pwm3">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_FlexPWM2_pwm3">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="PWM2" signal="A, 3" pin_num="99" pin_signal="GPIO_AD_B0_09"/>
+               </pins>
+            </function>
+            <function name="pinmux_LPUART3">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="LPUART3" description="Peripheral LPUART3 is not initialized" problem_level="1" source="Pins:pinmux_LPUART3">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_LPUART3">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="LPUART3" signal="TX" pin_num="84" pin_signal="GPIO_AD_B1_06"/>
+                  <pin peripheral="LPUART3" signal="RX" pin_num="83" pin_signal="GPIO_AD_B1_07"/>
+               </pins>
+            </function>
+            <function name="pinmux_USER_LED_SW0">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_USER_LED_SW0">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_USER_LED_SW0">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="GPIO1" signal="gpio_io, 09" pin_num="99" pin_signal="GPIO_AD_B0_09">
+                     <pin_features>
+                        <pin_feature name="drive_strength" value="R0_6"/>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="GPIO5" signal="gpio_io, 00" pin_num="52" pin_signal="WAKEUP"/>
+               </pins>
+            </function>
+            <function name="pinmux_SDHC1">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="USDHC1" description="Peripheral USDHC1 is not initialized" problem_level="1" source="Pins:pinmux_SDHC1">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_SDHC1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_SDHC1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="GPIO1" signal="gpio_io, 05" pin_num="106" pin_signal="GPIO_AD_B0_05">
+                     <pin_features>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="GPIO2" signal="gpio_io, 28" pin_num="" pin_signal="GPIO_B1_12">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="drive_strength" value="R0"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_vselect" pin_num="" pin_signal="GPIO_B1_14">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="drive_strength" value="R0_4"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_cmd" pin_num="48" pin_signal="GPIO_SD_B0_00">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="speed" value="MHZ_100"/>
+                        <pin_feature name="drive_strength" value="R0"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_clk" pin_num="47" pin_signal="GPIO_SD_B0_01">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="drive_strength" value="R0"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_data, 0" pin_num="46" pin_signal="GPIO_SD_B0_02">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="drive_strength" value="R0"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_data, 1" pin_num="45" pin_signal="GPIO_SD_B0_03">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="drive_strength" value="R0"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_data, 2" pin_num="43" pin_signal="GPIO_SD_B0_04">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="drive_strength" value="R0"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_data, 3" pin_num="42" pin_signal="GPIO_SD_B0_05">
+                     <pin_features>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                        <pin_feature name="drive_strength" value="R0"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+         </functions_list>
+      </pins>
+      <clocks name="Clocks" version="8.0" enabled="true" update_project_code="true">
+         <generated_project_files>
+            <file path="board/clock_config.c" update_enabled="true"/>
+            <file path="board/clock_config.h" update_enabled="true"/>
+         </generated_project_files>
+         <clocks_profile>
+            <processor_version>10.0.0</processor_version>
+         </clocks_profile>
+         <clock_configurations>
+            <clock_configuration name="clock_init">
+               <description></description>
+               <options/>
+               <dependencies>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.rtc_xtali" description="&apos;RTC_XTALI&apos; (Pins tool id: XTALOSC24M.rtc_xtali, Clocks tool id: XTALOSC24M.RTC_XTALI) needs to be routed" problem_level="1" source="Clocks:clock_init">
+                     <feature name="routed" evaluation="">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.rtc_xtali" description="&apos;RTC_XTALI&apos; (Pins tool id: XTALOSC24M.rtc_xtali, Clocks tool id: XTALOSC24M.RTC_XTALI) needs to have &apos;INPUT&apos; direction" problem_level="1" source="Clocks:clock_init">
+                     <feature name="direction" evaluation="">
+                        <data>INPUT</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.rtc_xtalo" description="&apos;RTC_XTALO&apos; (Pins tool id: XTALOSC24M.rtc_xtalo, Clocks tool id: XTALOSC24M.RTC_XTALO) needs to be routed" problem_level="1" source="Clocks:clock_init">
+                     <feature name="routed" evaluation="">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.rtc_xtalo" description="&apos;RTC_XTALO&apos; (Pins tool id: XTALOSC24M.rtc_xtalo, Clocks tool id: XTALOSC24M.RTC_XTALO) needs to have &apos;OUTPUT&apos; direction" problem_level="1" source="Clocks:clock_init">
+                     <feature name="direction" evaluation="">
+                        <data>OUTPUT</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.xtali" description="&apos;XTALI&apos; (Pins tool id: XTALOSC24M.xtali, Clocks tool id: XTALOSC24M.XTALI) needs to be routed" problem_level="1" source="Clocks:clock_init">
+                     <feature name="routed" evaluation="">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.xtali" description="&apos;XTALI&apos; (Pins tool id: XTALOSC24M.xtali, Clocks tool id: XTALOSC24M.XTALI) needs to have &apos;INPUT&apos; direction" problem_level="1" source="Clocks:clock_init">
+                     <feature name="direction" evaluation="">
+                        <data>INPUT</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.xtalo" description="&apos;XTALO&apos; (Pins tool id: XTALOSC24M.xtalo, Clocks tool id: XTALOSC24M.XTALO) needs to be routed" problem_level="1" source="Clocks:clock_init">
+                     <feature name="routed" evaluation="">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.xtalo" description="&apos;XTALO&apos; (Pins tool id: XTALOSC24M.xtalo, Clocks tool id: XTALOSC24M.XTALO) needs to have &apos;OUTPUT&apos; direction" problem_level="1" source="Clocks:clock_init">
+                     <feature name="direction" evaluation="">
+                        <data>OUTPUT</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Clocks initialization requires the COMMON Driver in the project." problem_level="2" source="Clocks:clock_init">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Clocks initialization requires the IOMUXC Driver in the project." problem_level="2" source="Clocks:clock_init">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <clock_sources>
+                  <clock_source id="XTALOSC24M.RTC_OSC.outFreq" value="32.768 kHz" locked="false" enabled="true"/>
+               </clock_sources>
+               <clock_outputs>
+                  <clock_output id="AHB_CLK_ROOT.outFreq" value="500 MHz" locked="false" accuracy=""/>
+                  <clock_output id="CAN_CLK_ROOT.outFreq" value="40 MHz" locked="false" accuracy=""/>
+                  <clock_output id="CKIL_SYNC_CLK_ROOT.outFreq" value="32.768 kHz" locked="false" accuracy=""/>
+                  <clock_output id="CLK_1M.outFreq" value="1 MHz" locked="false" accuracy=""/>
+                  <clock_output id="CLK_24M.outFreq" value="24 MHz" locked="false" accuracy=""/>
+                  <clock_output id="ENET_125M_CLK.outFreq" value="50 MHz" locked="false" accuracy=""/>
+                  <clock_output id="ENET_25M_REF_CLK.outFreq" value="25 MHz" locked="false" accuracy=""/>
+                  <clock_output id="ENET_500M_REF_CLK.outFreq" value="500 MHz" locked="false" accuracy=""/>
+                  <clock_output id="FLEXIO1_CLK_ROOT.outFreq" value="30 MHz" locked="false" accuracy=""/>
+                  <clock_output id="FLEXSPI_CLK_ROOT.outFreq" value="90 MHz" locked="false" accuracy=""/>
+                  <clock_output id="GPT1_ipg_clk_highfreq.outFreq" value="62.5 MHz" locked="false" accuracy=""/>
+                  <clock_output id="GPT2_ipg_clk_highfreq.outFreq" value="62.5 MHz" locked="false" accuracy=""/>
+                  <clock_output id="IPG_CLK_ROOT.outFreq" value="125 MHz" locked="false" accuracy=""/>
+                  <clock_output id="LPI2C_CLK_ROOT.outFreq" value="10 MHz" locked="false" accuracy=""/>
+                  <clock_output id="LPSPI_CLK_ROOT.outFreq" value="90 MHz" locked="false" accuracy=""/>
+                  <clock_output id="MQS_MCLK.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="PERCLK_CLK_ROOT.outFreq" value="62.5 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI1_CLK_ROOT.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI1_MCLK1.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI1_MCLK2.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI1_MCLK3.outFreq" value="30 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI2_CLK_ROOT.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI2_MCLK1.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI2_MCLK3.outFreq" value="30 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI3_CLK_ROOT.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI3_MCLK1.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI3_MCLK3.outFreq" value="30 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SEMC_CLK_ROOT.outFreq" value="4752/29 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SPDIF0_CLK_ROOT.outFreq" value="30 MHz" locked="false" accuracy=""/>
+                  <clock_output id="TRACE_CLK_ROOT.outFreq" value="99 MHz" locked="false" accuracy=""/>
+                  <clock_output id="UART_CLK_ROOT.outFreq" value="80 MHz" locked="false" accuracy=""/>
+                  <clock_output id="USBPHY1_CLK.outFreq" value="480 MHz" locked="false" accuracy=""/>
+                  <clock_output id="USDHC1_CLK_ROOT.outFreq" value="198 MHz" locked="false" accuracy=""/>
+                  <clock_output id="USDHC2_CLK_ROOT.outFreq" value="198 MHz" locked="false" accuracy=""/>
+               </clock_outputs>
+               <clock_settings>
+                  <setting id="CCM.AHB_PODF.scale" value="1" locked="true"/>
+                  <setting id="CCM.ARM_PODF.scale" value="1" locked="true"/>
+                  <setting id="CCM.CLKO2_DIV.scale" value="1" locked="true"/>
+                  <setting id="CCM.CLKO2_SEL.sel" value="XTALOSC24M.OSC_CLK" locked="false"/>
+                  <setting id="CCM.FLEXSPI_PODF.scale" value="8" locked="true"/>
+                  <setting id="CCM.FLEXSPI_SEL.sel" value="CCM_ANALOG.PLL3_PFD0_CLK" locked="false"/>
+                  <setting id="CCM.IPG_PODF.scale" value="4" locked="true"/>
+                  <setting id="CCM.LPI2C_CLK_PODF.scale" value="6" locked="true"/>
+                  <setting id="CCM.LPSPI_CLK_SEL.sel" value="CCM_ANALOG.PLL3_PFD0_CLK" locked="false"/>
+                  <setting id="CCM.LPSPI_PODF.scale" value="8" locked="true"/>
+                  <setting id="CCM.PERCLK_PODF.scale" value="2" locked="true"/>
+                  <setting id="CCM.PERIPH_CLK2_SEL.sel" value="XTALOSC24M.OSC_CLK" locked="false"/>
+                  <setting id="CCM.PRE_PERIPH_CLK_SEL.sel" value="CCM.ARM_PODF" locked="false"/>
+                  <setting id="CCM.SAI2_CLK_PRED.scale" value="4" locked="true"/>
+                  <setting id="CCM.SEMC_CLK_SEL.sel" value="CCM.SEMC_ALT_CLK_SEL" locked="false"/>
+                  <setting id="CCM.SEMC_PODF.scale" value="2" locked="true"/>
+                  <setting id="CCM.TRACE_PODF.scale" value="4" locked="true"/>
+                  <setting id="CCM.USDHC1_CLK_SEL.sel" value="CCM_ANALOG.PLL2_PFD0_CLK" locked="false"/>
+                  <setting id="CCM.USDHC1_PODF.scale" value="2" locked="true"/>
+                  <setting id="CCM.USDHC2_CLK_SEL.sel" value="CCM_ANALOG.PLL2_PFD0_CLK" locked="false"/>
+                  <setting id="CCM.USDHC2_PODF.scale" value="2" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2.denom" value="1" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2.num" value="0" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_BYPASS.sel" value="CCM_ANALOG.PLL2_OUT_CLK" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD0_BYPASS.sel" value="CCM_ANALOG.PLL2_PFD0" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD0_DIV.scale" value="24" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD0_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD1_BYPASS.sel" value="CCM_ANALOG.PLL2_PFD1" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD2_BYPASS.sel" value="CCM_ANALOG.PLL2_PFD2" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD2_DIV.scale" value="29" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD2_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD3_BYPASS.sel" value="CCM_ANALOG.PLL2_PFD3" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD3_DIV.scale" value="35" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD3_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_BYPASS.sel" value="CCM_ANALOG.PLL3" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD0_BYPASS.sel" value="CCM_ANALOG.PLL3_PFD0" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD0_DIV.scale" value="12" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD0_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD1_BYPASS.sel" value="CCM_ANALOG.PLL3_PFD1" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD1_DIV.scale" value="35" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD1_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD2_BYPASS.sel" value="CCM_ANALOG.PLL3_PFD2" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD2_DIV.scale" value="26" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD2_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD3_BYPASS.sel" value="CCM_ANALOG.PLL3_PFD3" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD3_DIV.scale" value="31" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD3_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL4.denom" value="50" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL4.div" value="27" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL4_POST_DIV.scale" value="4" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL6_BYPASS.sel" value="CCM_ANALOG.PLL6" locked="false"/>
+                  <setting id="CCM_ANALOG_PLL_USB1_EN_USB_CLKS_CFG" value="Enabled" locked="false"/>
+                  <setting id="CCM_ANALOG_PLL_USB1_EN_USB_CLKS_OUT_CFG" value="Enabled" locked="false"/>
+                  <setting id="CCM_ANALOG_PLL_USB1_POWER_CFG" value="Yes" locked="false"/>
+               </clock_settings>
+               <called_from_default_init>true</called_from_default_init>
+            </clock_configuration>
+         </clock_configurations>
+      </clocks>
+      <dcdx name="DCDx" version="3.0" enabled="true" update_project_code="false">
+         <generated_project_files>
+            <file path="board/dcd.c" update_enabled="true"/>
+            <file path="board/dcd.h" update_enabled="true"/>
+         </generated_project_files>
+         <dcdx_profile>
+            <processor_version>10.0.0</processor_version>
+            <output_format>c_array</output_format>
+         </dcdx_profile>
+         <dcdx_configurations>
+            <dcdx_configuration name="Device_configuration">
+               <description></description>
+               <options/>
+               <command_groups>
+                  <command_group name="Imported Commands" enabled="true">
+                     <commands>
+                        <command type="write_value" address="CCM_CCGR0" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR1" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR2" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR3" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR4" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR5" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR6" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_ANALOG_PLL_SYS" value="0x2001" value_width="4"/>
+                        <command type="write_value" address="CCM_ANALOG_PFD_528" value="0x1D0000" value_width="4"/>
+                        <command type="write_value" address="CCM_CBCDR" value="0x10D40" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_00" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_01" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_02" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_03" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_04" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_05" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_06" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_07" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_08" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_09" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_10" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_11" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_12" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_13" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_14" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_15" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_16" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_17" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_18" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_19" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_20" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_21" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_22" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_23" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_24" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_25" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_26" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_27" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_28" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_29" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_30" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_31" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_32" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_33" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_34" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_35" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_36" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_37" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_38" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_39" value="0x10" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_00" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_01" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_02" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_03" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_04" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_05" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_06" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_07" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_08" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_09" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_10" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_11" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_12" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_13" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_14" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_15" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_16" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_17" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_18" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_19" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_20" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_21" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_22" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_23" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_24" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_25" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_26" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_27" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_28" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_29" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_30" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_31" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_32" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_33" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_34" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_35" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_36" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_37" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_38" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_39" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="SEMC_MCR" value="0x10000004" value_width="4"/>
+                        <command type="write_value" address="SEMC_BMCR0" value="0x81" value_width="4"/>
+                        <command type="write_value" address="SEMC_BMCR1" value="0x81" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR0" value="0x8000001B" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR1" value="0x8200001B" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR2" value="0x8400001B" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR3" value="0x8600001B" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR4" value="0x90000021" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR5" value="0xA0000019" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR6" value="0xA8000017" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR7" value="0xA900001B" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR8" value="0x21" value_width="4"/>
+                        <command type="write_value" address="SEMC_IOCR" value="0x79A8" value_width="4"/>
+                        <command type="write_value" address="SEMC_SDRAMCR0" value="0xF31" value_width="4"/>
+                        <command type="write_value" address="SEMC_SDRAMCR1" value="0x652922" value_width="4"/>
+                        <command type="write_value" address="SEMC_SDRAMCR2" value="0x10920" value_width="4"/>
+                        <command type="write_value" address="SEMC_SDRAMCR3" value="0x50210A08" value_width="4"/>
+                        <command type="write_value" address="SEMC_DBICR0" value="0x21" value_width="4"/>
+                        <command type="write_value" address="SEMC_DBICR1" value="0x888888" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR1" value="0x02" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR2" value="0x00" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR0" value="0x80000000" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCMD" value="0xA55A000F" value_width="4"/>
+                        <command type="check_any_bit_set" address="SEMC_INTR" value="0x01" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR0" value="0x80000000" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCMD" value="0xA55A000C" value_width="4"/>
+                        <command type="check_any_bit_set" address="SEMC_INTR" value="0x01" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR0" value="0x80000000" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCMD" value="0xA55A000C" value_width="4"/>
+                        <command type="check_any_bit_set" address="SEMC_INTR" value="0x01" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPTXDAT" value="0x33" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR0" value="0x80000000" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCMD" value="0xA55A000A" value_width="4"/>
+                        <command type="check_any_bit_set" address="SEMC_INTR" value="0x01" value_width="4"/>
+                        <command type="write_value" address="SEMC_SDRAMCR3" value="0x50210A09" value_width="4"/>
+                     </commands>
+                  </command_group>
+               </command_groups>
+            </dcdx_configuration>
+         </dcdx_configurations>
+      </dcdx>
+      <periphs name="Peripherals" version="10.0" enabled="true" update_project_code="false">
+         <generated_project_files>
+            <file path="board/peripherals.c" update_enabled="true"/>
+            <file path="board/peripherals.h" update_enabled="true"/>
+         </generated_project_files>
+         <peripherals_profile>
+            <processor_version>10.0.0</processor_version>
+         </peripherals_profile>
+         <functional_groups>
+            <functional_group name="BOARD_InitPeripherals" uuid="1c6563a6-c68b-40e5-8828-2853c99f95fa" called_from_default_init="true" id_prefix="BOARD_" core="core0">
+               <description></description>
+               <options/>
+               <dependencies/>
+               <instances>
+                  <instance name="NVIC" uuid="2c253e89-508d-4544-9d44-c226931d8f3f" type="nvic" type_id="nvic_57b5eef3774cc60acaede6f5b8bddc67" mode="general" peripheral="NVIC" enabled="true" comment="" custom_name_enabled="false" editing_lock="false">
+                     <config_set name="nvic">
+                        <array name="interrupt_table"/>
+                        <array name="interrupts"/>
+                     </config_set>
+                  </instance>
+               </instances>
+            </functional_group>
+         </functional_groups>
+         <components>
+            <component name="system" uuid="18e298ee-cc10-47f7-b950-440409a94f94" type_id="system_54b53072540eeeb8f8e9343e71f28176">
+               <config_set_global name="global_system_definitions">
+                  <setting name="user_definitions" value=""/>
+                  <setting name="user_includes" value=""/>
+               </config_set_global>
+            </component>
+            <component name="msg" uuid="078a031a-1304-48e4-934c-de6b7bd41d37" type_id="msg_6e2baaf3b97dbeef01c0043275f9a0e7">
+               <config_set_global name="global_messages"/>
+            </component>
+            <component name="generic_uart" uuid="0e122da2-c994-4d5a-a7b8-5a63103fc1d2" type_id="generic_uart_8cae00565451cf2346eb1b8c624e73a6">
+               <config_set_global name="global_uart"/>
+            </component>
+            <component name="generic_can" uuid="51762fc1-cf05-4bb3-a3ca-5da5c50ea072" type_id="generic_can_1bfdd78b1af214566c1f23cf6a582d80">
+               <config_set_global name="global_can"/>
+            </component>
+            <component name="uart_cmsis_common" uuid="d4182366-28a3-4b72-9e22-d29aa447729c" type_id="uart_cmsis_common_9cb8e302497aa696fdbb5a4fd622c2a8">
+               <config_set_global name="global_USART_CMSIS_common" quick_selection="default"/>
+            </component>
+            <component name="generic_enet" uuid="c9d3d8ac-0dc9-40de-aea5-dd11df3d996b" type_id="generic_enet_74db5c914f0ddbe47d86af40cb77a619">
+               <config_set_global name="global_enet"/>
+            </component>
+         </components>
+      </periphs>
+      <tee name="TEE" version="2.0" enabled="false" update_project_code="true">
+         <generated_project_files/>
+         <tee_profile>
+            <processor_version>N/A</processor_version>
+         </tee_profile>
+      </tee>
+   </tools>
+</configuration>

--- a/boards/arm/mimxrt1050_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1050_evk/CMakeLists.txt
@@ -5,7 +5,8 @@
 #
 
 zephyr_library()
-zephyr_library_sources(pinmux.c)
+zephyr_library_sources(pinmux.c clock_config.c)
+zephyr_include_directories(.)
 
 if (CONFIG_DISPLAY)
 message(WARNING "

--- a/boards/arm/mimxrt1050_evk/clock_config.c
+++ b/boards/arm/mimxrt1050_evk/clock_config.c
@@ -1,0 +1,561 @@
+/*
+ * Copyright (c) 2021, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * How to setup clock using clock driver functions:
+ *
+ * 1. Call CLOCK_InitXXXPLL() to configure corresponding PLL clock.
+ *
+ * 2. Call CLOCK_InitXXXpfd() to configure corresponding PLL pfd clock.
+ *
+ * 3. Call CLOCK_SetMux() to configure corresponding clock source for target clock out.
+ *
+ * 4. Call CLOCK_SetDiv() to configure corresponding clock divider for target clock out.
+ *
+ * 5. Call CLOCK_SetXtalFreq() to set XTAL frequency based on board settings.
+ *
+ */
+
+/* TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
+ * !!GlobalInfo
+ * product: Clocks v8.0
+ * processor: MIMXRT1052xxxxB
+ * package_id: MIMXRT1052DVL6B
+ * mcu_data: ksdk2_0
+ * processor_version: 10.0.0
+ * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS **********/
+
+#include "clock_config.h"
+#include "fsl_iomuxc.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+/* System clock frequency. */
+extern uint32_t SystemCoreClock;
+
+/*******************************************************************************
+ ************************ BOARD_InitBootClocks function ************************
+ ******************************************************************************/
+void BOARD_InitBootClocks(void)
+{
+	clock_init();
+}
+
+/*******************************************************************************
+ ************************** Configuration clock_init ***************************
+ ******************************************************************************/
+/* TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
+ * !!Configuration
+ * name: clock_init
+ * called_from_default_init: true
+ * outputs:
+ * - {id: AHB_CLK_ROOT.outFreq, value: 600 MHz}
+ * - {id: CAN_CLK_ROOT.outFreq, value: 40 MHz}
+ * - {id: CKIL_SYNC_CLK_ROOT.outFreq, value: 32.768 kHz}
+ * - {id: CLK_1M.outFreq, value: 1 MHz}
+ * - {id: CLK_24M.outFreq, value: 24 MHz}
+ * - {id: CSI_CLK_ROOT.outFreq, value: 24 MHz}
+ * - {id: ENET_125M_CLK.outFreq, value: 50 MHz}
+ * - {id: ENET_25M_REF_CLK.outFreq, value: 25 MHz}
+ * - {id: FLEXIO1_CLK_ROOT.outFreq, value: 30 MHz}
+ * - {id: FLEXIO2_CLK_ROOT.outFreq, value: 30 MHz}
+ * - {id: FLEXSPI_CLK_ROOT.outFreq, value: 90 MHz}
+ * - {id: GPT1_ipg_clk_highfreq.outFreq, value: 75 MHz}
+ * - {id: GPT2_ipg_clk_highfreq.outFreq, value: 75 MHz}
+ * - {id: IPG_CLK_ROOT.outFreq, value: 150 MHz}
+ * - {id: LCDIF_CLK_ROOT.outFreq, value: 9.3 MHz}
+ * - {id: LPI2C_CLK_ROOT.outFreq, value: 10 MHz}
+ * - {id: LPSPI_CLK_ROOT.outFreq, value: 90 MHz}
+ * - {id: LVDS1_CLK.outFreq, value: 1.2 GHz}
+ * - {id: MQS_MCLK.outFreq, value: 540/13 MHz}
+ * - {id: PERCLK_CLK_ROOT.outFreq, value: 75 MHz}
+ * - {id: PLL7_MAIN_CLK.outFreq, value: 24 MHz}
+ * - {id: SAI1_CLK_ROOT.outFreq, value: 540/13 MHz}
+ * - {id: SAI1_MCLK1.outFreq, value: 540/13 MHz}
+ * - {id: SAI1_MCLK2.outFreq, value: 540/13 MHz}
+ * - {id: SAI1_MCLK3.outFreq, value: 30 MHz}
+ * - {id: SAI2_CLK_ROOT.outFreq, value: 540/13 MHz}
+ * - {id: SAI2_MCLK1.outFreq, value: 540/13 MHz}
+ * - {id: SAI2_MCLK3.outFreq, value: 30 MHz}
+ * - {id: SAI3_CLK_ROOT.outFreq, value: 540/13 MHz}
+ * - {id: SAI3_MCLK1.outFreq, value: 540/13 MHz}
+ * - {id: SAI3_MCLK3.outFreq, value: 30 MHz}
+ * - {id: SEMC_CLK_ROOT.outFreq, value: 4752/29 MHz}
+ * - {id: SPDIF0_CLK_ROOT.outFreq, value: 30 MHz}
+ * - {id: TRACE_CLK_ROOT.outFreq, value: 99 MHz}
+ * - {id: UART_CLK_ROOT.outFreq, value: 80 MHz}
+ * - {id: USBPHY1_CLK.outFreq, value: 480 MHz}
+ * - {id: USDHC1_CLK_ROOT.outFreq, value: 198 MHz}
+ * - {id: USDHC2_CLK_ROOT.outFreq, value: 198 MHz}
+ * settings:
+ * - {id: CCM.AHB_PODF.scale, value: '1', locked: true}
+ * - {id: CCM.ARM_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.CLKO2_DIV.scale, value: '1', locked: true}
+ * - {id: CCM.CLKO2_SEL.sel, value: XTALOSC24M.OSC_CLK}
+ * - {id: CCM.CSI_PODF.scale, value: '1', locked: true}
+ * - {id: CCM.FLEXSPI_PODF.scale, value: '8', locked: true}
+ * - {id: CCM.FLEXSPI_SEL.sel, value: CCM_ANALOG.PLL3_PFD0_CLK}
+ * - {id: CCM.LCDIF_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.LCDIF_PRED.scale, value: '5', locked: true}
+ * - {id: CCM.LCDIF_PRE_CLK_SEL.sel, value: CCM_ANALOG.PLL5_MAIN_CLK}
+ * - {id: CCM.LPI2C_CLK_PODF.scale, value: '6', locked: true}
+ * - {id: CCM.LPSPI_CLK_SEL.sel, value: CCM_ANALOG.PLL3_PFD0_CLK}
+ * - {id: CCM.LPSPI_PODF.scale, value: '8', locked: true}
+ * - {id: CCM.PERCLK_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.PERIPH_CLK2_SEL.sel, value: XTALOSC24M.OSC_CLK}
+ * - {id: CCM.SAI2_CLK_PRED.scale, value: '4', locked: true}
+ * - {id: CCM.SEMC_CLK_SEL.sel, value: CCM.SEMC_ALT_CLK_SEL}
+ * - {id: CCM.SEMC_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.TRACE_PODF.scale, value: '4', locked: true}
+ * - {id: CCM.USDHC1_CLK_SEL.sel, value: CCM_ANALOG.PLL2_PFD0_CLK}
+ * - {id: CCM.USDHC1_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.USDHC2_CLK_SEL.sel, value: CCM_ANALOG.PLL2_PFD0_CLK}
+ * - {id: CCM.USDHC2_PODF.scale, value: '2', locked: true}
+ * - {id: CCM_ANALOG.PLL1_BYPASS.sel, value: CCM_ANALOG.PLL1}
+ * - {id: CCM_ANALOG.PLL1_PREDIV.scale, value: '1', locked: true}
+ * - {id: CCM_ANALOG.PLL1_VDIV.scale, value: '50', locked: true}
+ * - {id: CCM_ANALOG.PLL2.denom, value: '1', locked: true}
+ * - {id: CCM_ANALOG.PLL2.num, value: '0', locked: true}
+ * - {id: CCM_ANALOG.PLL2_BYPASS.sel, value: CCM_ANALOG.PLL2_OUT_CLK}
+ * - {id: CCM_ANALOG.PLL2_PFD0_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD0}
+ * - {id: CCM_ANALOG.PLL2_PFD0_DIV.scale, value: '24', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD0_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD1_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD1}
+ * - {id: CCM_ANALOG.PLL2_PFD2_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD2}
+ * - {id: CCM_ANALOG.PLL2_PFD2_DIV.scale, value: '29', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD2_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD3_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD3}
+ * - {id: CCM_ANALOG.PLL2_PFD3_DIV.scale, value: '35', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD3_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_BYPASS.sel, value: CCM_ANALOG.PLL3}
+ * - {id: CCM_ANALOG.PLL3_PFD0_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD0}
+ * - {id: CCM_ANALOG.PLL3_PFD0_DIV.scale, value: '12', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD0_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD1_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD1}
+ * - {id: CCM_ANALOG.PLL3_PFD1_DIV.scale, value: '35', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD1_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD2_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD2}
+ * - {id: CCM_ANALOG.PLL3_PFD2_DIV.scale, value: '26', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD2_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD3_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD3}
+ * - {id: CCM_ANALOG.PLL3_PFD3_DIV.scale, value: '31', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD3_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL4.denom, value: '50'}
+ * - {id: CCM_ANALOG.PLL4.div, value: '27', locked: true}
+ * - {id: CCM_ANALOG.PLL4_POST_DIV.scale, value: '4', locked: true}
+ * - {id: CCM_ANALOG.PLL5.denom, value: '1'}
+ * - {id: CCM_ANALOG.PLL5.div, value: '31', locked: true}
+ * - {id: CCM_ANALOG.PLL5.num, value: '0'}
+ * - {id: CCM_ANALOG.PLL5_BYPASS.sel, value: CCM_ANALOG.PLL5_POST_DIV}
+ * - {id: CCM_ANALOG.PLL5_POST_DIV.scale, value: '2', locked: true}
+ * - {id: CCM_ANALOG.PLL6_BYPASS.sel, value: CCM_ANALOG.PLL6}
+ * - {id: CCM_ANALOG.VIDEO_DIV.scale, value: '4', locked: true}
+ * - {id: CCM_ANALOG_PLL_USB1_EN_USB_CLKS_CFG, value: Enabled}
+ * - {id: CCM_ANALOG_PLL_USB1_EN_USB_CLKS_OUT_CFG, value: Enabled}
+ * - {id: CCM_ANALOG_PLL_USB1_POWER_CFG, value: 'Yes'}
+ * - {id: CCM_ANALOG_PLL_VIDEO_POWERDOWN_CFG, value: 'No'}
+ * sources:
+ * - {id: XTALOSC24M.RTC_OSC.outFreq, value: 32.768 kHz, enabled: true}
+ * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS **********/
+
+/*******************************************************************************
+ * Variables for clock_init configuration
+ ******************************************************************************/
+const clock_arm_pll_config_t armPllConfig_clock_init = {
+	/* PLL loop divider, Fout = Fin * 50 */
+	.loopDivider = 100,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+const clock_sys_pll_config_t sysPllConfig_clock_init = {
+	/* PLL loop divider, Fout = Fin * ( 20 + loopDivider*2 + numerator / denominator ) */
+	.loopDivider = 1,
+	/* 30 bit numerator of fractional loop divider */
+	.numerator = 0,
+	/* 30 bit denominator of fractional loop divider */
+	.denominator = 1,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+const clock_usb_pll_config_t usb1PllConfig_clock_init = {
+	/* PLL loop divider, Fout = Fin * 20 */
+	.loopDivider = 0,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+const clock_video_pll_config_t videoPllConfig_clock_init = {
+	/* PLL loop divider, Fout = Fin * ( loopDivider + numerator / denominator ) */
+	.loopDivider = 31,
+	/* Divider after PLL */
+	.postDivider = 8,
+	/*
+	 * 30 bit numerator of fractional loop divider,
+	 * Fout = Fin * ( loopDivider + numerator / denominator )
+	 */
+	.numerator = 0,
+	/*
+	 * 30 bit denominator of fractional loop divider,
+	 * Fout = Fin * ( loopDivider + numerator / denominator )
+	 */
+	.denominator = 1,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+const clock_enet_pll_config_t enetPllConfig_clock_init = {
+	/* Enable the PLL providing the ENET 125MHz reference clock */
+	.enableClkOutput = true,
+	/* Enable the PLL providing the ENET 25MHz reference clock */
+	.enableClkOutput25M = true,
+	/* Set frequency of ethernet reference clock to 50 MHz */
+	.loopDivider = 1,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+/*******************************************************************************
+ * Code for clock_init configuration
+ ******************************************************************************/
+void clock_init(void)
+{
+	/* Init RTC OSC clock frequency. */
+	CLOCK_SetRtcXtalFreq(32768U);
+	/* Enable 1MHz clock output. */
+	XTALOSC24M->OSC_CONFIG2 |= XTALOSC24M_OSC_CONFIG2_ENABLE_1M_MASK;
+	/* Use free 1MHz clock output. */
+	XTALOSC24M->OSC_CONFIG2 &= ~XTALOSC24M_OSC_CONFIG2_MUX_1M_MASK;
+	/* Set XTAL 24MHz clock frequency. */
+	CLOCK_SetXtalFreq(24000000U);
+	/* Enable XTAL 24MHz clock source. */
+	CLOCK_InitExternalClk(0);
+	/* Enable internal RC. */
+	CLOCK_InitRcOsc24M();
+	/* Switch clock source to external OSC. */
+	CLOCK_SwitchOsc(kCLOCK_XtalOsc);
+	/* Set Oscillator ready counter value. */
+	CCM->CCR = (CCM->CCR & (~CCM_CCR_OSCNT_MASK)) | CCM_CCR_OSCNT(127);
+	/* Setting PeriphClk2Mux and PeriphMux to provide stable clock before PLLs are initialed */
+	CLOCK_SetMux(kCLOCK_PeriphClk2Mux, 1);  /* Set PERIPH_CLK2 MUX to OSC */
+	CLOCK_SetMux(kCLOCK_PeriphMux, 1);      /* Set PERIPH_CLK MUX to PERIPH_CLK2 */
+	/* Setting the VDD_SOC to 1.275V. It is necessary to config AHB to 600Mhz. */
+	DCDC->REG3 = (DCDC->REG3 & (~DCDC_REG3_TRG_MASK)) | DCDC_REG3_TRG(0x13);
+	/* Waiting for DCDC_STS_DC_OK bit is asserted */
+	while (DCDC_REG0_STS_DC_OK_MASK != (DCDC_REG0_STS_DC_OK_MASK & DCDC->REG0)) {
+	}
+	/* Set AHB_PODF. */
+	CLOCK_SetDiv(kCLOCK_AhbDiv, 0);
+	/* Disable IPG clock gate. */
+	CLOCK_DisableClock(kCLOCK_Adc1);
+	CLOCK_DisableClock(kCLOCK_Adc2);
+	CLOCK_DisableClock(kCLOCK_Xbar1);
+	CLOCK_DisableClock(kCLOCK_Xbar2);
+	CLOCK_DisableClock(kCLOCK_Xbar3);
+	/* Set IPG_PODF. */
+	CLOCK_SetDiv(kCLOCK_IpgDiv, 3);
+	/* Set ARM_PODF. */
+	CLOCK_SetDiv(kCLOCK_ArmDiv, 1);
+	/* Set PERIPH_CLK2_PODF. */
+	CLOCK_SetDiv(kCLOCK_PeriphClk2Div, 0);
+	/* Disable PERCLK clock gate. */
+	CLOCK_DisableClock(kCLOCK_Gpt1);
+	CLOCK_DisableClock(kCLOCK_Gpt1S);
+	CLOCK_DisableClock(kCLOCK_Gpt2);
+	CLOCK_DisableClock(kCLOCK_Gpt2S);
+	CLOCK_DisableClock(kCLOCK_Pit);
+	/* Set PERCLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_PerclkDiv, 1);
+	/* Disable USDHC1 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Usdhc1);
+	/* Set USDHC1_PODF. */
+	CLOCK_SetDiv(kCLOCK_Usdhc1Div, 1);
+	/* Set Usdhc1 clock source. */
+	CLOCK_SetMux(kCLOCK_Usdhc1Mux, 1);
+	/* Disable USDHC2 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Usdhc2);
+	/* Set USDHC2_PODF. */
+	CLOCK_SetDiv(kCLOCK_Usdhc2Div, 1);
+	/* Set Usdhc2 clock source. */
+	CLOCK_SetMux(kCLOCK_Usdhc2Mux, 1);
+	/*
+	 * In SDK projects, SDRAM (configured by SEMC) will be initialized in either debug script or
+	 * dcd. With this macro SKIP_SYSCLK_INIT, system pll (selected to be SEMC source clock in
+	 * SDK projects) will be left unchanged.
+	 * Note: If another clock source is selected for SEMC, user may want to avoid changing that
+	 * clock as well.
+	 */
+#ifndef SKIP_SYSCLK_INIT
+	/* Disable Semc clock gate. */
+	CLOCK_DisableClock(kCLOCK_Semc);
+	/* Set SEMC_PODF. */
+	CLOCK_SetDiv(kCLOCK_SemcDiv, 1);
+	/* Set Semc alt clock source. */
+	CLOCK_SetMux(kCLOCK_SemcAltMux, 0);
+	/* Set Semc clock source. */
+	CLOCK_SetMux(kCLOCK_SemcMux, 1);
+#endif
+	/*
+	 * In SDK projects, external flash (configured by FLEXSPI) will be initialized by dcd.
+	 * With this macro XIP_EXTERNAL_FLASH, usb1 pll (selected to be FLEXSPI clock source in SDK
+	 * projects) will be left unchanged.
+	 * Note: If another clock source is selected for FLEXSPI, user may want to avoid changing
+	 * that clock as well.
+	 */
+#if !(defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1))
+	/* Disable Flexspi clock gate. */
+	CLOCK_DisableClock(kCLOCK_FlexSpi);
+	/* Set FLEXSPI_PODF. */
+	CLOCK_SetDiv(kCLOCK_FlexspiDiv, 7);
+	/* Set Flexspi clock source. */
+	CLOCK_SetMux(kCLOCK_FlexspiMux, 3);
+#endif
+	/* Disable CSI clock gate. */
+	CLOCK_DisableClock(kCLOCK_Csi);
+	/* Set CSI_PODF. */
+	CLOCK_SetDiv(kCLOCK_CsiDiv, 0);
+	/* Set Csi clock source. */
+	CLOCK_SetMux(kCLOCK_CsiMux, 0);
+	/* Disable LPSPI clock gate. */
+	CLOCK_DisableClock(kCLOCK_Lpspi1);
+	CLOCK_DisableClock(kCLOCK_Lpspi2);
+	CLOCK_DisableClock(kCLOCK_Lpspi3);
+	CLOCK_DisableClock(kCLOCK_Lpspi4);
+	/* Set LPSPI_PODF. */
+	CLOCK_SetDiv(kCLOCK_LpspiDiv, 7);
+	/* Set Lpspi clock source. */
+	CLOCK_SetMux(kCLOCK_LpspiMux, 1);
+	/* Disable TRACE clock gate. */
+	CLOCK_DisableClock(kCLOCK_Trace);
+	/* Set TRACE_PODF. */
+	CLOCK_SetDiv(kCLOCK_TraceDiv, 3);
+	/* Set Trace clock source. */
+	CLOCK_SetMux(kCLOCK_TraceMux, 2);
+	/* Disable SAI1 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Sai1);
+	/* Set SAI1_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Sai1PreDiv, 3);
+	/* Set SAI1_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Sai1Div, 1);
+	/* Set Sai1 clock source. */
+	CLOCK_SetMux(kCLOCK_Sai1Mux, 0);
+	/* Disable SAI2 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Sai2);
+	/* Set SAI2_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Sai2PreDiv, 3);
+	/* Set SAI2_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Sai2Div, 1);
+	/* Set Sai2 clock source. */
+	CLOCK_SetMux(kCLOCK_Sai2Mux, 0);
+	/* Disable SAI3 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Sai3);
+	/* Set SAI3_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Sai3PreDiv, 3);
+	/* Set SAI3_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Sai3Div, 1);
+	/* Set Sai3 clock source. */
+	CLOCK_SetMux(kCLOCK_Sai3Mux, 0);
+	/* Disable Lpi2c clock gate. */
+	CLOCK_DisableClock(kCLOCK_Lpi2c1);
+	CLOCK_DisableClock(kCLOCK_Lpi2c2);
+	CLOCK_DisableClock(kCLOCK_Lpi2c3);
+	/* Set LPI2C_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Lpi2cDiv, 5);
+	/* Set Lpi2c clock source. */
+	CLOCK_SetMux(kCLOCK_Lpi2cMux, 0);
+	/* Disable CAN clock gate. */
+	CLOCK_DisableClock(kCLOCK_Can1);
+	CLOCK_DisableClock(kCLOCK_Can2);
+	CLOCK_DisableClock(kCLOCK_Can1S);
+	CLOCK_DisableClock(kCLOCK_Can2S);
+	/* Set CAN_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_CanDiv, 1);
+	/* Set Can clock source. */
+	CLOCK_SetMux(kCLOCK_CanMux, 2);
+	/* Disable UART clock gate. */
+	CLOCK_DisableClock(kCLOCK_Lpuart1);
+	CLOCK_DisableClock(kCLOCK_Lpuart2);
+	CLOCK_DisableClock(kCLOCK_Lpuart3);
+	CLOCK_DisableClock(kCLOCK_Lpuart4);
+	CLOCK_DisableClock(kCLOCK_Lpuart5);
+	CLOCK_DisableClock(kCLOCK_Lpuart6);
+	CLOCK_DisableClock(kCLOCK_Lpuart7);
+	CLOCK_DisableClock(kCLOCK_Lpuart8);
+	/* Set UART_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_UartDiv, 0);
+	/* Set Uart clock source. */
+	CLOCK_SetMux(kCLOCK_UartMux, 0);
+	/* Disable LCDIF clock gate. */
+	CLOCK_DisableClock(kCLOCK_LcdPixel);
+	/* Set LCDIF_PRED. */
+	CLOCK_SetDiv(kCLOCK_LcdifPreDiv, 4);
+	/* Set LCDIF_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_LcdifDiv, 1);
+	/* Set Lcdif pre clock source. */
+	CLOCK_SetMux(kCLOCK_LcdifPreMux, 2);
+	/* Disable SPDIF clock gate. */
+	CLOCK_DisableClock(kCLOCK_Spdif);
+	/* Set SPDIF0_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Spdif0PreDiv, 1);
+	/* Set SPDIF0_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Spdif0Div, 7);
+	/* Set Spdif clock source. */
+	CLOCK_SetMux(kCLOCK_SpdifMux, 3);
+	/* Disable Flexio1 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Flexio1);
+	/* Set FLEXIO1_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Flexio1PreDiv, 1);
+	/* Set FLEXIO1_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Flexio1Div, 7);
+	/* Set Flexio1 clock source. */
+	CLOCK_SetMux(kCLOCK_Flexio1Mux, 3);
+	/* Disable Flexio2 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Flexio2);
+	/* Set FLEXIO2_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Flexio2PreDiv, 1);
+	/* Set FLEXIO2_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Flexio2Div, 7);
+	/* Set Flexio2 clock source. */
+	CLOCK_SetMux(kCLOCK_Flexio2Mux, 3);
+	/* Set Pll3 sw clock source. */
+	CLOCK_SetMux(kCLOCK_Pll3SwMux, 0);
+	/* Init ARM PLL. */
+	CLOCK_InitArmPll(&armPllConfig_clock_init);
+	/*
+	 * In SDK projects, SDRAM (configured by SEMC) will be initialized in either debug script or
+	 * dcd. With this macro SKIP_SYSCLK_INIT, system pll (selected to be SEMC source clock in
+	 * SDK projects) will be left unchanged.
+	 * Note: If another clock source is selected for SEMC, user may want to avoid changing that
+	 * clock as well.
+	 */
+#ifndef SKIP_SYSCLK_INIT
+#if defined(XIP_BOOT_HEADER_DCD_ENABLE) && (XIP_BOOT_HEADER_DCD_ENABLE == 1)
+    #warning "SKIP_SYSCLK_INIT should be defined to keep system pll (selected to be SEMC source \
+	clock in SDK projects) unchanged."
+#endif
+	/* Init System PLL. */
+	CLOCK_InitSysPll(&sysPllConfig_clock_init);
+	/* Init System pfd0. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd0, 24);
+	/* Init System pfd1. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd1, 16);
+	/* Init System pfd2. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd2, 29);
+	/* Init System pfd3. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd3, 35);
+	/* Disable pfd offset. */
+	CCM_ANALOG->PLL_SYS &= ~CCM_ANALOG_PLL_SYS_PFD_OFFSET_EN_MASK;
+#endif
+	/*
+	 * In SDK projects, external flash (configured by FLEXSPI) will be initialized by dcd.
+	 * With this macro XIP_EXTERNAL_FLASH, usb1 pll (selected to be FLEXSPI clock source in
+	 * SDK projects) will be left unchanged.
+	 * Note: If another clock source is selected for FLEXSPI, user may want to avoid changing
+	 * that clock as well.
+	 */
+#if !(defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1))
+	/* Init Usb1 PLL. */
+	CLOCK_InitUsb1Pll(&usb1PllConfig_clock_init);
+	/* Init Usb1 pfd0. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd0, 12);
+	/* Init Usb1 pfd1. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd1, 35);
+	/* Init Usb1 pfd2. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd2, 26);
+	/* Init Usb1 pfd3. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd3, 31);
+#endif
+	/* DeInit Audio PLL. */
+	CLOCK_DeinitAudioPll();
+	/* Bypass Audio PLL. */
+	CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllAudio, 1);
+	/* Set divider for Audio PLL. */
+	CCM_ANALOG->MISC2 &= ~CCM_ANALOG_MISC2_AUDIO_DIV_LSB_MASK;
+	CCM_ANALOG->MISC2 &= ~CCM_ANALOG_MISC2_AUDIO_DIV_MSB_MASK;
+	/* Enable Audio PLL output. */
+	CCM_ANALOG->PLL_AUDIO |= CCM_ANALOG_PLL_AUDIO_ENABLE_MASK;
+	/* Init Video PLL. */
+	uint32_t pllVideo;
+	/* Disable Video PLL output before initial Video PLL. */
+	CCM_ANALOG->PLL_VIDEO &= ~CCM_ANALOG_PLL_VIDEO_ENABLE_MASK;
+	/* Bypass PLL first */
+	CCM_ANALOG->PLL_VIDEO = (CCM_ANALOG->PLL_VIDEO &
+				(~CCM_ANALOG_PLL_VIDEO_BYPASS_CLK_SRC_MASK)) |
+				CCM_ANALOG_PLL_VIDEO_BYPASS_MASK |
+				CCM_ANALOG_PLL_VIDEO_BYPASS_CLK_SRC(0);
+	CCM_ANALOG->PLL_VIDEO_NUM = CCM_ANALOG_PLL_VIDEO_NUM_A(0);
+	CCM_ANALOG->PLL_VIDEO_DENOM = CCM_ANALOG_PLL_VIDEO_DENOM_B(1);
+	pllVideo = (CCM_ANALOG->PLL_VIDEO & (~(CCM_ANALOG_PLL_VIDEO_DIV_SELECT_MASK |
+		   CCM_ANALOG_PLL_VIDEO_POWERDOWN_MASK))) |
+		   CCM_ANALOG_PLL_VIDEO_ENABLE_MASK |
+		   CCM_ANALOG_PLL_VIDEO_DIV_SELECT(31);
+	pllVideo |= CCM_ANALOG_PLL_VIDEO_POST_DIV_SELECT(1);
+	CCM_ANALOG->MISC2 = (CCM_ANALOG->MISC2 & (~CCM_ANALOG_MISC2_VIDEO_DIV_MASK)) |
+			     CCM_ANALOG_MISC2_VIDEO_DIV(3);
+	CCM_ANALOG->PLL_VIDEO = pllVideo;
+	while ((CCM_ANALOG->PLL_VIDEO & CCM_ANALOG_PLL_VIDEO_LOCK_MASK) == 0) {
+	}
+	/* Disable pfd offset. */
+	CCM_ANALOG->PLL_VIDEO &= ~CCM_ANALOG_PLL_VIDEO_PFD_OFFSET_EN_MASK;
+	/* Disable bypass for Video PLL. */
+	CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllVideo, 0);
+	/* Init Enet PLL. */
+	CLOCK_InitEnetPll(&enetPllConfig_clock_init);
+	/* Disable pfd offset. */
+	CCM_ANALOG->PLL_ENET &= ~CCM_ANALOG_PLL_ENET_PFD_OFFSET_EN_MASK;
+	/* DeInit Usb2 PLL. */
+	CLOCK_DeinitUsb2Pll();
+	/* Bypass Usb2 PLL. */
+	CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllUsb2, 1);
+	/* Enable Usb2 PLL output. */
+	CCM_ANALOG->PLL_USB2 |= CCM_ANALOG_PLL_USB2_ENABLE_MASK;
+	/* Set preperiph clock source. */
+	CLOCK_SetMux(kCLOCK_PrePeriphMux, 3);
+	/* Set periph clock source. */
+	CLOCK_SetMux(kCLOCK_PeriphMux, 0);
+	/* Set periph clock2 clock source. */
+	CLOCK_SetMux(kCLOCK_PeriphClk2Mux, 1);
+	/* Set per clock source. */
+	CLOCK_SetMux(kCLOCK_PerclkMux, 0);
+	/* Set lvds1 clock source. */
+	CCM_ANALOG->MISC1 = (CCM_ANALOG->MISC1 & (~CCM_ANALOG_MISC1_LVDS1_CLK_SEL_MASK)) |
+			     CCM_ANALOG_MISC1_LVDS1_CLK_SEL(0);
+	/* Set clock out1 divider. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO1_DIV_MASK)) | CCM_CCOSR_CLKO1_DIV(0);
+	/* Set clock out1 source. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO1_SEL_MASK)) | CCM_CCOSR_CLKO1_SEL(1);
+	/* Set clock out2 divider. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO2_DIV_MASK)) | CCM_CCOSR_CLKO2_DIV(0);
+	/* Set clock out2 source. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO2_SEL_MASK)) | CCM_CCOSR_CLKO2_SEL(14);
+	/* Set clock out1 drives clock out1. */
+	CCM->CCOSR &= ~CCM_CCOSR_CLK_OUT_SEL_MASK;
+	/* Disable clock out1. */
+	CCM->CCOSR &= ~CCM_CCOSR_CLKO1_EN_MASK;
+	/* Disable clock out2. */
+	CCM->CCOSR &= ~CCM_CCOSR_CLKO2_EN_MASK;
+	/* Set SAI1 MCLK1 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk1Sel, 0);
+	/* Set SAI1 MCLK2 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk2Sel, 0);
+	/* Set SAI1 MCLK3 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk3Sel, 0);
+	/* Set SAI2 MCLK3 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI2MClk3Sel, 0);
+	/* Set SAI3 MCLK3 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI3MClk3Sel, 0);
+	/* Set MQS configuration. */
+	IOMUXC_MQSConfig(IOMUXC_GPR, kIOMUXC_MqsPwmOverSampleRate32, 0);
+	/* Set ENET Ref clock source. */
+	IOMUXC_GPR->GPR1 &= ~IOMUXC_GPR_GPR1_ENET1_TX_CLK_DIR_MASK;
+	/* Set GPT1 High frequency reference clock source. */
+	IOMUXC_GPR->GPR5 &= ~IOMUXC_GPR_GPR5_VREF_1M_CLK_GPT1_MASK;
+	/* Set GPT2 High frequency reference clock source. */
+	IOMUXC_GPR->GPR5 &= ~IOMUXC_GPR_GPR5_VREF_1M_CLK_GPT2_MASK;
+	/* Set SystemCoreClock variable. */
+	SystemCoreClock = CLOCK_INIT_CORE_CLOCK;
+}

--- a/boards/arm/mimxrt1050_evk/clock_config.h
+++ b/boards/arm/mimxrt1050_evk/clock_config.h
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2021, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _CLOCK_CONFIG_H_
+#define _CLOCK_CONFIG_H_
+
+#include "fsl_common.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+/*!< Board xtal0 frequency in Hz */
+#define BOARD_XTAL0_CLK_HZ                         24000000U
+
+/*!< Board xtal32k frequency in Hz */
+#define BOARD_XTAL32K_CLK_HZ                          32768U
+/*******************************************************************************
+ ************************ BOARD_InitBootClocks function ************************
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus*/
+
+/*!
+ * @brief This function executes default configuration of clocks.
+ *
+ */
+void BOARD_InitBootClocks(void);
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus*/
+
+/*******************************************************************************
+ ************************** Configuration clock_init ***************************
+ ******************************************************************************/
+/*******************************************************************************
+ * Definitions for clock_init configuration
+ ******************************************************************************/
+/*!< Core clock frequency: 600000000Hz */
+#define CLOCK_INIT_CORE_CLOCK                     600000000U
+
+/* Clock outputs (values are in Hz): */
+#define CLOCK_INIT_AHB_CLK_ROOT                       600000000UL
+#define CLOCK_INIT_CAN_CLK_ROOT                       40000000UL
+#define CLOCK_INIT_CKIL_SYNC_CLK_ROOT                 32768UL
+#define CLOCK_INIT_CLKO1_CLK                          0UL
+#define CLOCK_INIT_CLKO2_CLK                          0UL
+#define CLOCK_INIT_CLK_1M                             1000000UL
+#define CLOCK_INIT_CLK_24M                            24000000UL
+#define CLOCK_INIT_CSI_CLK_ROOT                       24000000UL
+#define CLOCK_INIT_ENET_125M_CLK                      50000000UL
+#define CLOCK_INIT_ENET_25M_REF_CLK                   25000000UL
+#define CLOCK_INIT_ENET_REF_CLK                       0UL
+#define CLOCK_INIT_ENET_TX_CLK                        0UL
+#define CLOCK_INIT_FLEXIO1_CLK_ROOT                   30000000UL
+#define CLOCK_INIT_FLEXIO2_CLK_ROOT                   30000000UL
+#define CLOCK_INIT_FLEXSPI_CLK_ROOT                   90000000UL
+#define CLOCK_INIT_GPT1_IPG_CLK_HIGHFREQ              75000000UL
+#define CLOCK_INIT_GPT2_IPG_CLK_HIGHFREQ              75000000UL
+#define CLOCK_INIT_IPG_CLK_ROOT                       150000000UL
+#define CLOCK_INIT_LCDIF_CLK_ROOT                     9300000UL
+#define CLOCK_INIT_LPI2C_CLK_ROOT                     10000000UL
+#define CLOCK_INIT_LPSPI_CLK_ROOT                     90000000UL
+#define CLOCK_INIT_LVDS1_CLK                          1200000000UL
+#define CLOCK_INIT_MQS_MCLK                           41538461UL
+#define CLOCK_INIT_PERCLK_CLK_ROOT                    75000000UL
+#define CLOCK_INIT_PLL7_MAIN_CLK                      24000000UL
+#define CLOCK_INIT_SAI1_CLK_ROOT                      41538461UL
+#define CLOCK_INIT_SAI1_MCLK1                         41538461UL
+#define CLOCK_INIT_SAI1_MCLK2                         41538461UL
+#define CLOCK_INIT_SAI1_MCLK3                         30000000UL
+#define CLOCK_INIT_SAI2_CLK_ROOT                      41538461UL
+#define CLOCK_INIT_SAI2_MCLK1                         41538461UL
+#define CLOCK_INIT_SAI2_MCLK2                         0UL
+#define CLOCK_INIT_SAI2_MCLK3                         30000000UL
+#define CLOCK_INIT_SAI3_CLK_ROOT                      41538461UL
+#define CLOCK_INIT_SAI3_MCLK1                         41538461UL
+#define CLOCK_INIT_SAI3_MCLK2                         0UL
+#define CLOCK_INIT_SAI3_MCLK3                         30000000UL
+#define CLOCK_INIT_SEMC_CLK_ROOT                      163862068UL
+#define CLOCK_INIT_SPDIF0_CLK_ROOT                    30000000UL
+#define CLOCK_INIT_SPDIF0_EXTCLK_OUT                  0UL
+#define CLOCK_INIT_TRACE_CLK_ROOT                     99000000UL
+#define CLOCK_INIT_UART_CLK_ROOT                      80000000UL
+#define CLOCK_INIT_USBPHY1_CLK                        480000000UL
+#define CLOCK_INIT_USBPHY2_CLK                        0UL
+#define CLOCK_INIT_USDHC1_CLK_ROOT                    198000000UL
+#define CLOCK_INIT_USDHC2_CLK_ROOT                    198000000UL
+
+/*! @brief Arm PLL set for clock_init configuration.
+ */
+extern const clock_arm_pll_config_t armPllConfig_clock_init;
+/*! @brief Usb1 PLL set for clock_init configuration.
+ */
+extern const clock_usb_pll_config_t usb1PllConfig_clock_init;
+/*! @brief Sys PLL for clock_init configuration.
+ */
+extern const clock_sys_pll_config_t sysPllConfig_clock_init;
+/*! @brief Video PLL set for clock_init configuration.
+ */
+extern const clock_video_pll_config_t videoPllConfig_clock_init;
+/*! @brief Enet PLL set for clock_init configuration.
+ */
+extern const clock_enet_pll_config_t enetPllConfig_clock_init;
+
+/*******************************************************************************
+ * API for clock_init configuration
+ ******************************************************************************/
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus*/
+
+/*!
+ * @brief This function executes configuration of clocks.
+ *
+ */
+void clock_init(void);
+
+#if defined(__cplusplus)
+}
+#endif  /* __cplusplus*/
+
+#endif  /* _CLOCK_CONFIG_H_ */

--- a/boards/arm/mimxrt1050_evk/doc/index.rst
+++ b/boards/arm/mimxrt1050_evk/doc/index.rst
@@ -409,6 +409,151 @@ For more details, please see the following `NXP i.MXRT1050 A0 to A1 Migration Gu
 
 Current Zephyr build supports the new MIMXRT1050-EVKB
 
+MCUXpresso Config Tool
+======================
+
+A ``mimxrt1050_evk.mex`` file is included. This file was used to generate the clock
+initialization code and can be used as a starting point to tweak the clock configuration.
+This could be useful for different boards that are based on i.MX RT1050.
+
+NOTE: The MCUXpresso Config Tool currently generates a ``.c`` file with the clock configuration.
+Considering options on leveraging this tool in the future to generate a devicetree compatible file.
+
+Clock Configuration at Platform Initialization
+==============================================
+
+Below is the clock configuration at platform initialization.
+
+- On-chip 24MHz oscillator is enabled
+
+- Clock sources
+
++----------------------------+-----------------+
+| Name                       | Frequency       |
++============================+=================+
+| RTC Oscillator             | 32.768 kHz      |
++----------------------------+-----------------+
+| 24MHz clock source         | 24 MHz          |
++----------------------------+-----------------+
+| 1MHz clock                 | 1 MHz           |
++----------------------------+-----------------+
+| CLK1 external clock source | Inactive        |
++----------------------------+-----------------+
+| SAI1 MCLK                  | Inactive        |
++----------------------------+-----------------+
+| SAI2 MCLK                  | Inactive        |
++----------------------------+-----------------+
+| SAI3 MCLK                  | Inactive        |
++----------------------------+-----------------+
+| SPDIF_CLK_EXT              | Inactive        |
++----------------------------+-----------------+
+| SPDIF_SRCLK                | 1 MHz           |
++----------------------------+-----------------+
+| SPDIF_OUTCLK               | 1 MHz           |
++----------------------------+-----------------+
+| ENET_TX_CLK_EXT            | Inactive        |
++----------------------------+-----------------+
+| ENET_REF_CLK_EXT           | Inactive        |
++----------------------------+-----------------+
+
+- Clock outputs
+
++============================+=================+
+| Name                       | Frequency       |
++============================+=================+
+| AHB_CLK_ROOT               | 600 MHz         |
++----------------------------+-----------------+
+| IPG_CLK_ROOT               | 150 MHz         |
++----------------------------+-----------------+
+| SEMC_CLK_ROOT              | 163.86 MHz      |
++----------------------------+-----------------+
+| PERCLK_CLK_ROOT            | 75 MHz          |
++----------------------------+-----------------+
+| LCDIF_CLK_ROOT             | 9.3 MHz         |
++----------------------------+-----------------+
+| CSI_CLK_ROOT               | 24 MHz          |
++----------------------------+-----------------+
+| USDHC1_CLK_ROOT            | 198 MHz         |
++----------------------------+-----------------+
+| USDHC2_CLK_ROOT            | 198 MHz         |
++----------------------------+-----------------+
+| FLEXSPI_CLK_ROOT           | 90 MHz          |
++----------------------------+-----------------+
+| SPDIF0_CLK_ROOT            | 30 MHz          |
++----------------------------+-----------------+
+| FLEXIO1_CLK_ROOT           | 30 MHz          |
++----------------------------+-----------------+
+| FLEXIO2_CLK_ROOT           | 30 MHz          |
++----------------------------+-----------------+
+| SAI1_CLK_ROOT              | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI2_CLK_ROOT              | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI3_CLK_ROOT              | 41.53 MHz       |
++----------------------------+-----------------+
+| LPI2C_CLK_ROOT             | 10 MHz          |
++----------------------------+-----------------+
+| CAN_CLK_ROOT               | 40 MHz          |
++----------------------------+-----------------+
+| UART_CLK_ROOT              | 80 MHz          |
++----------------------------+-----------------+
+| LPSPI_CLK_ROOT             | 90 MHz          |
++----------------------------+-----------------+
+| TRACE_CLK_ROOT             | 99 MHz          |
++----------------------------+-----------------+
+| CKIL_SYNC_CLK_ROOT         | 32.768 kHz      |
++----------------------------+-----------------+
+| Clock 1M output            | 1 MHz           |
++----------------------------+-----------------+
+| Clock 24MHz output         | 24 MHz          |
++----------------------------+-----------------+
+| CLKO1_CLK                  | Inactive        |
++----------------------------+-----------------+
+| CLKO2_CLK                  | Inactive        |
++----------------------------+-----------------+
+| ENET_125M_CLK              | 50 MHz          |
++----------------------------+-----------------+
+| ENET_25M_REF_CLK           | 25 MHz          |
++----------------------------+-----------------+
+| LVDS1_CLK                  | 1.2 GHz         |
++----------------------------+-----------------+
+| USB2 PLL clock             | 24 MHz          |
++----------------------------+-----------------+
+| USBPHY1 PLL clock          | 480 MHz         |
++----------------------------+-----------------+
+| USBPHY2 PLL clock          | Inactive        |
++----------------------------+-----------------+
+| GPT1 high frequency clock  | 75 MHz          |
++----------------------------+-----------------+
+| GPT2 high frequency clock  | 75 MHz          |
++----------------------------+-----------------+
+| SAI1 MCLK 1                | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI1 MCLK 2                | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI1 MCLK 3                | 30 MHz          |
++----------------------------+-----------------+
+| SAI2 MCLK 1                | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI2 MCLK 2                | Inactive        |
++----------------------------+-----------------+
+| SAI2 MCLK 3                | 30 MHz          |
++----------------------------+-----------------+
+| SAI3 MCLK 1                | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI3 MCLK 2                | Inactive        |
++----------------------------+-----------------+
+| SAI3 MCLK 3                | 30 MHz          |
++----------------------------+-----------------+
+| SPDIF0_EXTCLK              | Inactive        |
++----------------------------+-----------------+
+| MQS MCLK                   | 41.53 MHz       |
++----------------------------+-----------------+
+| ENET_TX_CLK                | Inactive        |
++----------------------------+-----------------+
+| ENET_REF_CLK               | Inactive        |
++----------------------------+-----------------+
+
 .. _MIMXRT1050-EVK Website:
    https://www.nxp.com/products/microcontrollers-and-processors/arm-based-processors-and-mcus/i.mx-applications-processors/i.mx-rt-series/i.mx-rt1050-evaluation-kit:MIMXRT1050-EVK
 

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.mex
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.mex
@@ -1,0 +1,1251 @@
+<?xml version="1.0" encoding= "UTF-8" ?>
+<configuration name="MIMXRT1052xxxxB" xsi:schemaLocation="http://mcuxpresso.nxp.com/XSD/mex_configuration_10 http://mcuxpresso.nxp.com/XSD/mex_configuration_10.xsd" uuid="de3bdbe5-65cf-482d-b1be-cd17b780459b" version="10" xmlns="http://mcuxpresso.nxp.com/XSD/mex_configuration_10" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+   <common>
+      <processor>MIMXRT1052xxxxB</processor>
+      <package>MIMXRT1052DVL6B</package>
+      <mcu_data>ksdk2_0</mcu_data>
+      <cores selected="core0">
+         <core name="Cortex-M7F" id="core0" description="M7 core"/>
+      </cores>
+      <description></description>
+   </common>
+   <preferences>
+      <validate_boot_init_only>true</validate_boot_init_only>
+      <generate_extended_information>false</generate_extended_information>
+      <generate_code_modified_registers_only>false</generate_code_modified_registers_only>
+      <update_include_paths>true</update_include_paths>
+   </preferences>
+   <tools>
+      <pins name="Pins" version="10.0" enabled="true" update_project_code="false">
+         <generated_project_files>
+            <file path="board/pin_mux.c" update_enabled="true"/>
+            <file path="board/pin_mux.h" update_enabled="true"/>
+         </generated_project_files>
+         <pins_profile>
+            <processor_version>10.0.0</processor_version>
+            <power_domains/>
+            <pin_labels>
+               <pin_label pin_num="M14" pin_signal="GPIO_AD_B0_00" label="LPI2C1_SCL" identifier="LPI2C1_SCL"/>
+               <pin_label pin_num="H10" pin_signal="GPIO_AD_B0_01" label="LPI2C1_SDA" identifier="LPI2C1_SDA"/>
+               <pin_label pin_num="M11" pin_signal="GPIO_AD_B0_02" label="LCD_RESET" identifier="LCD_RESET"/>
+               <pin_label pin_num="F14" pin_signal="GPIO_AD_B0_09" label="JTAG_TDI/J21[5]/ENET_RST/J22[5]" identifier="ENET_RST"/>
+               <pin_label pin_num="G10" pin_signal="GPIO_AD_B0_11" label="LCD_TOUCH_INT" identifier="INT2_COMBO"/>
+            </pin_labels>
+         </pins_profile>
+         <functions_list>
+            <function name="pinmux_ENET">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="ENET" description="Peripheral ENET is not initialized" problem_level="1" source="Pins:pinmux_ENET">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_ENET">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_ENET">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="ENET" signal="enet_rx_data, 0" pin_num="E12" pin_signal="GPIO_B1_04">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_rx_data, 1" pin_num="D12" pin_signal="GPIO_B1_05">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_rx_en" pin_num="C12" pin_signal="GPIO_B1_06">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_tx_data, 0" pin_num="B12" pin_signal="GPIO_B1_07">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_tx_data, 1" pin_num="A12" pin_signal="GPIO_B1_08">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_tx_en" pin_num="A13" pin_signal="GPIO_B1_09">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_ref_clk" pin_num="B13" pin_signal="GPIO_B1_10">
+                     <pin_features>
+                        <pin_feature name="software_input_on" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                        <pin_feature name="pull_keeper_enable" value="Disable"/>
+                        <pin_feature name="speed" value="MHZ_50"/>
+                        <pin_feature name="drive_strength" value="R0_6"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_rx_er" pin_num="C13" pin_signal="GPIO_B1_11">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_mdc" pin_num="A7" pin_signal="GPIO_EMC_40">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_mdio" pin_num="C7" pin_signal="GPIO_EMC_41">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="GPIO1" signal="gpio_io, 10" pin_num="G13" pin_signal="GPIO_AD_B0_10">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="speed" value="MHZ_100"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_ENET_RST">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_ENET_RST">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_ENET_RST">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="GPIO1" signal="gpio_io, 09" pin_num="F14" pin_signal="GPIO_AD_B0_09">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="speed" value="MHZ_100"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_LPI2C1">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="LPI2C1" description="Peripheral LPI2C1 is not initialized" problem_level="1" source="Pins:pinmux_LPI2C1">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_LPI2C1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_LPI2C1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="LPI2C1" signal="SDA" pin_num="K11" pin_signal="GPIO_AD_B1_01">
+                     <pin_features>
+                        <pin_feature name="software_input_on" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_22K_Ohm"/>
+                        <pin_feature name="open_drain" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LPI2C1" signal="SCL" pin_num="J11" pin_signal="GPIO_AD_B1_00">
+                     <pin_features>
+                        <pin_feature name="software_input_on" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_22K_Ohm"/>
+                        <pin_feature name="open_drain" value="Enable"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_LCDIF">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="LCDIF" description="Peripheral LCDIF is not initialized" problem_level="1" source="Pins:pinmux_LCDIF">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_LCDIF">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_LCDIF">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="LCDIF" signal="lcdif_clk" pin_num="D7" pin_signal="GPIO_B0_00">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_enable" pin_num="E7" pin_signal="GPIO_B0_01">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_hsync" pin_num="E8" pin_signal="GPIO_B0_02">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_vsync" pin_num="D8" pin_signal="GPIO_B0_03">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 00" pin_num="C8" pin_signal="GPIO_B0_04">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 01" pin_num="B8" pin_signal="GPIO_B0_05">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 02" pin_num="A8" pin_signal="GPIO_B0_06">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 03" pin_num="A9" pin_signal="GPIO_B0_07">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 04" pin_num="B9" pin_signal="GPIO_B0_08">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 05" pin_num="C9" pin_signal="GPIO_B0_09">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 06" pin_num="D9" pin_signal="GPIO_B0_10">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 07" pin_num="A10" pin_signal="GPIO_B0_11">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 08" pin_num="C10" pin_signal="GPIO_B0_12">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 09" pin_num="D10" pin_signal="GPIO_B0_13">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 10" pin_num="E10" pin_signal="GPIO_B0_14">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 11" pin_num="E11" pin_signal="GPIO_B0_15">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 12" pin_num="A11" pin_signal="GPIO_B1_00">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 13" pin_num="B11" pin_signal="GPIO_B1_01">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 14" pin_num="C11" pin_signal="GPIO_B1_02">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 15" pin_num="D11" pin_signal="GPIO_B1_03">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="GPIO1" signal="gpio_io, 02" pin_num="M11" pin_signal="GPIO_AD_B0_02"/>
+                  <pin peripheral="GPIO2" signal="gpio_io, 31" pin_num="B14" pin_signal="GPIO_B1_15"/>
+               </pins>
+            </function>
+            <function name="pinmux_LPUART1">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="LPUART1" description="Peripheral LPUART1 is not initialized" problem_level="1" source="Pins:pinmux_LPUART1">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_LPUART1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_LPUART1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="LPUART1" signal="RX" pin_num="L14" pin_signal="GPIO_AD_B0_13">
+                     <pin_features>
+                        <pin_feature name="software_input_on" value="Disable"/>
+                        <pin_feature name="hysteresis_enable" value="Disable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                        <pin_feature name="pull_keeper_enable" value="Enable"/>
+                        <pin_feature name="open_drain" value="Disable"/>
+                        <pin_feature name="speed" value="MHZ_100"/>
+                        <pin_feature name="drive_strength" value="R0_6"/>
+                        <pin_feature name="slew_rate" value="Slow"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LPUART1" signal="TX" pin_num="K14" pin_signal="GPIO_AD_B0_12">
+                     <pin_features>
+                        <pin_feature name="software_input_on" value="Disable"/>
+                        <pin_feature name="hysteresis_enable" value="Disable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                        <pin_feature name="pull_keeper_enable" value="Enable"/>
+                        <pin_feature name="open_drain" value="Disable"/>
+                        <pin_feature name="speed" value="MHZ_100"/>
+                        <pin_feature name="drive_strength" value="R0_6"/>
+                        <pin_feature name="slew_rate" value="Slow"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_FT5336_int">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_FT5336_int">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_FT5336_int">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="GPIO1" signal="gpio_io, 11" pin_num="G10" pin_signal="GPIO_AD_B0_11">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                        <pin_feature name="drive_strength" value="R0_6"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_FlexSPIA">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="FLEXSPI" description="Peripheral FLEXSPI is not initialized" problem_level="1" source="Pins:pinmux_FlexSPIA">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_FlexSPIA">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_FlexSPIA">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_DQS" pin_num="N3" pin_signal="GPIO_SD_B1_05">
+                     <pin_features>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_SS0_B" pin_num="L3" pin_signal="GPIO_SD_B1_06">
+                     <pin_features>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_SCLK" pin_num="L4" pin_signal="GPIO_SD_B1_07">
+                     <pin_features>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_DATA0" pin_num="P3" pin_signal="GPIO_SD_B1_08">
+                     <pin_features>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_DATA1" pin_num="N4" pin_signal="GPIO_SD_B1_09">
+                     <pin_features>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_DATA2" pin_num="P4" pin_signal="GPIO_SD_B1_10">
+                     <pin_features>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_DATA3" pin_num="P5" pin_signal="GPIO_SD_B1_11">
+                     <pin_features>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_FlexCAN3">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="CAN3" description="Peripheral CAN3 is not initialized" problem_level="1" source="Pins:pinmux_FlexCAN3">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_FlexCAN3">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="CAN3" signal="TX" pin_num="C3" pin_signal="GPIO_EMC_36"/>
+                  <pin peripheral="CAN3" signal="RX" pin_num="E4" pin_signal="GPIO_EMC_37"/>
+               </pins>
+            </function>
+            <function name="pinmux_FlexCAN2">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="CAN2" description="Peripheral CAN2 is not initialized" problem_level="1" source="Pins:pinmux_FlexCAN2">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_FlexCAN2">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_FlexCAN2">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="CAN2" signal="TX" pin_num="H14" pin_signal="GPIO_AD_B0_14"/>
+                  <pin peripheral="CAN2" signal="RX" pin_num="L10" pin_signal="GPIO_AD_B0_15"/>
+               </pins>
+            </function>
+            <function name="pinmux_FlexCAN1">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="CAN1" description="Peripheral CAN1 is not initialized" problem_level="1" source="Pins:pinmux_FlexCAN1">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_FlexCAN1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_FlexCAN1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="CAN1" signal="TX" pin_num="H13" pin_signal="GPIO_AD_B1_08"/>
+                  <pin peripheral="CAN1" signal="RX" pin_num="M13" pin_signal="GPIO_AD_B1_09"/>
+               </pins>
+            </function>
+            <function name="pinmux_CSI">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="CSI" description="Peripheral CSI is not initialized" problem_level="1" source="Pins:pinmux_CSI">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_CSI">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_CSI">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="GPIO1" signal="gpio_io, 04" pin_num="F11" pin_signal="GPIO_AD_B0_04"/>
+                  <pin peripheral="CSI" signal="csi_pixclk" pin_num="L12" pin_signal="GPIO_AD_B1_04"/>
+                  <pin peripheral="CSI" signal="csi_mclk" pin_num="K12" pin_signal="GPIO_AD_B1_05"/>
+                  <pin peripheral="CSI" signal="csi_vsync" pin_num="J12" pin_signal="GPIO_AD_B1_06"/>
+                  <pin peripheral="CSI" signal="csi_hsync" pin_num="K10" pin_signal="GPIO_AD_B1_07"/>
+                  <pin peripheral="CSI" signal="csi_data, 09" pin_num="H13" pin_signal="GPIO_AD_B1_08"/>
+                  <pin peripheral="CSI" signal="csi_data, 08" pin_num="M13" pin_signal="GPIO_AD_B1_09"/>
+                  <pin peripheral="CSI" signal="csi_data, 07" pin_num="L13" pin_signal="GPIO_AD_B1_10"/>
+                  <pin peripheral="CSI" signal="csi_data, 06" pin_num="J13" pin_signal="GPIO_AD_B1_11"/>
+                  <pin peripheral="CSI" signal="csi_data, 05" pin_num="H12" pin_signal="GPIO_AD_B1_12"/>
+                  <pin peripheral="CSI" signal="csi_data, 04" pin_num="H11" pin_signal="GPIO_AD_B1_13"/>
+                  <pin peripheral="CSI" signal="csi_data, 03" pin_num="G12" pin_signal="GPIO_AD_B1_14"/>
+                  <pin peripheral="CSI" signal="csi_data, 02" pin_num="J14" pin_signal="GPIO_AD_B1_15"/>
+               </pins>
+            </function>
+            <function name="pinmux_FlexPWM2_pwm3">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="PWM2" description="Peripheral PWM2 is not initialized" problem_level="1" source="Pins:pinmux_FlexPWM2_pwm3">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_FlexPWM2_pwm3">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_FlexPWM2_pwm3">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="PWM2" signal="A, 3" pin_num="F14" pin_signal="GPIO_AD_B0_09"/>
+               </pins>
+            </function>
+            <function name="pinmux_LPUART3">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="LPUART3" description="Peripheral LPUART3 is not initialized" problem_level="1" source="Pins:pinmux_LPUART3">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_LPUART3">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_LPUART3">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="LPUART3" signal="TX" pin_num="J12" pin_signal="GPIO_AD_B1_06"/>
+                  <pin peripheral="LPUART3" signal="RX" pin_num="K10" pin_signal="GPIO_AD_B1_07"/>
+               </pins>
+            </function>
+            <function name="pinmux_USER_LED_SW0">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_USER_LED_SW0">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_USER_LED_SW0">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="GPIO1" signal="gpio_io, 09" pin_num="F14" pin_signal="GPIO_AD_B0_09">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                        <pin_feature name="drive_strength" value="R0_6"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="GPIO5" signal="gpio_io, 00" pin_num="L6" pin_signal="WAKEUP"/>
+               </pins>
+            </function>
+            <function name="pinmux_SDHC1">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="USDHC1" description="Peripheral USDHC1 is not initialized" problem_level="1" source="Pins:pinmux_SDHC1">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_SDHC1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_SDHC1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="GPIO1" signal="gpio_io, 05" pin_num="G14" pin_signal="GPIO_AD_B0_05">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="GPIO2" signal="gpio_io, 28" pin_num="D13" pin_signal="GPIO_B1_12">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="drive_strength" value="R0"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_vselect" pin_num="C14" pin_signal="GPIO_B1_14">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="drive_strength" value="R0_4"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_cmd" pin_num="J4" pin_signal="GPIO_SD_B0_00">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="speed" value="MHZ_100"/>
+                        <pin_feature name="drive_strength" value="R0"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_clk" pin_num="J3" pin_signal="GPIO_SD_B0_01">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                        <pin_feature name="drive_strength" value="R0"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_data, 0" pin_num="J1" pin_signal="GPIO_SD_B0_02">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="drive_strength" value="R0"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_data, 1" pin_num="K1" pin_signal="GPIO_SD_B0_03">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="drive_strength" value="R0"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_data, 2" pin_num="H2" pin_signal="GPIO_SD_B0_04">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="drive_strength" value="R0"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_data, 3" pin_num="J2" pin_signal="GPIO_SD_B0_05">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="drive_strength" value="R0"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+         </functions_list>
+      </pins>
+      <clocks name="Clocks" version="8.0" enabled="true" update_project_code="true">
+         <generated_project_files>
+            <file path="board/clock_config.c" update_enabled="true"/>
+            <file path="board/clock_config.h" update_enabled="true"/>
+         </generated_project_files>
+         <clocks_profile>
+            <processor_version>10.0.0</processor_version>
+         </clocks_profile>
+         <clock_configurations>
+            <clock_configuration name="clock_init">
+               <description></description>
+               <options/>
+               <dependencies>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.rtc_xtali" description="&apos;RTC_XTALI&apos; (Pins tool id: XTALOSC24M.rtc_xtali, Clocks tool id: XTALOSC24M.RTC_XTALI) needs to be routed" problem_level="1" source="Clocks:clock_init">
+                     <feature name="routed" evaluation="">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.rtc_xtali" description="&apos;RTC_XTALI&apos; (Pins tool id: XTALOSC24M.rtc_xtali, Clocks tool id: XTALOSC24M.RTC_XTALI) needs to have &apos;INPUT&apos; direction" problem_level="1" source="Clocks:clock_init">
+                     <feature name="direction" evaluation="">
+                        <data>INPUT</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.rtc_xtalo" description="&apos;RTC_XTALO&apos; (Pins tool id: XTALOSC24M.rtc_xtalo, Clocks tool id: XTALOSC24M.RTC_XTALO) needs to be routed" problem_level="1" source="Clocks:clock_init">
+                     <feature name="routed" evaluation="">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.rtc_xtalo" description="&apos;RTC_XTALO&apos; (Pins tool id: XTALOSC24M.rtc_xtalo, Clocks tool id: XTALOSC24M.RTC_XTALO) needs to have &apos;OUTPUT&apos; direction" problem_level="1" source="Clocks:clock_init">
+                     <feature name="direction" evaluation="">
+                        <data>OUTPUT</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.xtali" description="&apos;XTALI&apos; (Pins tool id: XTALOSC24M.xtali, Clocks tool id: XTALOSC24M.XTALI) needs to be routed" problem_level="1" source="Clocks:clock_init">
+                     <feature name="routed" evaluation="">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.xtali" description="&apos;XTALI&apos; (Pins tool id: XTALOSC24M.xtali, Clocks tool id: XTALOSC24M.XTALI) needs to have &apos;INPUT&apos; direction" problem_level="1" source="Clocks:clock_init">
+                     <feature name="direction" evaluation="">
+                        <data>INPUT</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.xtalo" description="&apos;XTALO&apos; (Pins tool id: XTALOSC24M.xtalo, Clocks tool id: XTALOSC24M.XTALO) needs to be routed" problem_level="1" source="Clocks:clock_init">
+                     <feature name="routed" evaluation="">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.xtalo" description="&apos;XTALO&apos; (Pins tool id: XTALOSC24M.xtalo, Clocks tool id: XTALOSC24M.XTALO) needs to have &apos;OUTPUT&apos; direction" problem_level="1" source="Clocks:clock_init">
+                     <feature name="direction" evaluation="">
+                        <data>OUTPUT</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Clocks initialization requires the COMMON Driver in the project." problem_level="2" source="Clocks:clock_init">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Clocks initialization requires the IOMUXC Driver in the project." problem_level="2" source="Clocks:clock_init">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <clock_sources>
+                  <clock_source id="XTALOSC24M.RTC_OSC.outFreq" value="32.768 kHz" locked="false" enabled="true"/>
+               </clock_sources>
+               <clock_outputs>
+                  <clock_output id="AHB_CLK_ROOT.outFreq" value="600 MHz" locked="false" accuracy=""/>
+                  <clock_output id="CAN_CLK_ROOT.outFreq" value="40 MHz" locked="false" accuracy=""/>
+                  <clock_output id="CKIL_SYNC_CLK_ROOT.outFreq" value="32.768 kHz" locked="false" accuracy=""/>
+                  <clock_output id="CLK_1M.outFreq" value="1 MHz" locked="false" accuracy=""/>
+                  <clock_output id="CLK_24M.outFreq" value="24 MHz" locked="false" accuracy=""/>
+                  <clock_output id="CSI_CLK_ROOT.outFreq" value="24 MHz" locked="false" accuracy=""/>
+                  <clock_output id="ENET_125M_CLK.outFreq" value="50 MHz" locked="false" accuracy=""/>
+                  <clock_output id="ENET_25M_REF_CLK.outFreq" value="25 MHz" locked="false" accuracy=""/>
+                  <clock_output id="FLEXIO1_CLK_ROOT.outFreq" value="30 MHz" locked="false" accuracy=""/>
+                  <clock_output id="FLEXIO2_CLK_ROOT.outFreq" value="30 MHz" locked="false" accuracy=""/>
+                  <clock_output id="FLEXSPI_CLK_ROOT.outFreq" value="90 MHz" locked="false" accuracy=""/>
+                  <clock_output id="GPT1_ipg_clk_highfreq.outFreq" value="75 MHz" locked="false" accuracy=""/>
+                  <clock_output id="GPT2_ipg_clk_highfreq.outFreq" value="75 MHz" locked="false" accuracy=""/>
+                  <clock_output id="IPG_CLK_ROOT.outFreq" value="150 MHz" locked="false" accuracy=""/>
+                  <clock_output id="LCDIF_CLK_ROOT.outFreq" value="9.3 MHz" locked="false" accuracy=""/>
+                  <clock_output id="LPI2C_CLK_ROOT.outFreq" value="10 MHz" locked="false" accuracy=""/>
+                  <clock_output id="LPSPI_CLK_ROOT.outFreq" value="90 MHz" locked="false" accuracy=""/>
+                  <clock_output id="LVDS1_CLK.outFreq" value="1.2 GHz" locked="false" accuracy=""/>
+                  <clock_output id="MQS_MCLK.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="PERCLK_CLK_ROOT.outFreq" value="75 MHz" locked="false" accuracy=""/>
+                  <clock_output id="PLL7_MAIN_CLK.outFreq" value="24 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI1_CLK_ROOT.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI1_MCLK1.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI1_MCLK2.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI1_MCLK3.outFreq" value="30 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI2_CLK_ROOT.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI2_MCLK1.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI2_MCLK3.outFreq" value="30 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI3_CLK_ROOT.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI3_MCLK1.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI3_MCLK3.outFreq" value="30 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SEMC_CLK_ROOT.outFreq" value="4752/29 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SPDIF0_CLK_ROOT.outFreq" value="30 MHz" locked="false" accuracy=""/>
+                  <clock_output id="TRACE_CLK_ROOT.outFreq" value="99 MHz" locked="false" accuracy=""/>
+                  <clock_output id="UART_CLK_ROOT.outFreq" value="80 MHz" locked="false" accuracy=""/>
+                  <clock_output id="USBPHY1_CLK.outFreq" value="480 MHz" locked="false" accuracy=""/>
+                  <clock_output id="USDHC1_CLK_ROOT.outFreq" value="198 MHz" locked="false" accuracy=""/>
+                  <clock_output id="USDHC2_CLK_ROOT.outFreq" value="198 MHz" locked="false" accuracy=""/>
+               </clock_outputs>
+               <clock_settings>
+                  <setting id="CCM.AHB_PODF.scale" value="1" locked="true"/>
+                  <setting id="CCM.ARM_PODF.scale" value="2" locked="true"/>
+                  <setting id="CCM.CLKO2_DIV.scale" value="1" locked="true"/>
+                  <setting id="CCM.CLKO2_SEL.sel" value="XTALOSC24M.OSC_CLK" locked="false"/>
+                  <setting id="CCM.CSI_PODF.scale" value="1" locked="true"/>
+                  <setting id="CCM.FLEXSPI_PODF.scale" value="8" locked="true"/>
+                  <setting id="CCM.FLEXSPI_SEL.sel" value="CCM_ANALOG.PLL3_PFD0_CLK" locked="false"/>
+                  <setting id="CCM.LCDIF_PODF.scale" value="2" locked="true"/>
+                  <setting id="CCM.LCDIF_PRED.scale" value="5" locked="true"/>
+                  <setting id="CCM.LCDIF_PRE_CLK_SEL.sel" value="CCM_ANALOG.PLL5_MAIN_CLK" locked="false"/>
+                  <setting id="CCM.LPI2C_CLK_PODF.scale" value="6" locked="true"/>
+                  <setting id="CCM.LPSPI_CLK_SEL.sel" value="CCM_ANALOG.PLL3_PFD0_CLK" locked="false"/>
+                  <setting id="CCM.LPSPI_PODF.scale" value="8" locked="true"/>
+                  <setting id="CCM.PERCLK_PODF.scale" value="2" locked="true"/>
+                  <setting id="CCM.PERIPH_CLK2_SEL.sel" value="XTALOSC24M.OSC_CLK" locked="false"/>
+                  <setting id="CCM.SAI2_CLK_PRED.scale" value="4" locked="true"/>
+                  <setting id="CCM.SEMC_CLK_SEL.sel" value="CCM.SEMC_ALT_CLK_SEL" locked="false"/>
+                  <setting id="CCM.SEMC_PODF.scale" value="2" locked="true"/>
+                  <setting id="CCM.TRACE_PODF.scale" value="4" locked="true"/>
+                  <setting id="CCM.USDHC1_CLK_SEL.sel" value="CCM_ANALOG.PLL2_PFD0_CLK" locked="false"/>
+                  <setting id="CCM.USDHC1_PODF.scale" value="2" locked="true"/>
+                  <setting id="CCM.USDHC2_CLK_SEL.sel" value="CCM_ANALOG.PLL2_PFD0_CLK" locked="false"/>
+                  <setting id="CCM.USDHC2_PODF.scale" value="2" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL1_BYPASS.sel" value="CCM_ANALOG.PLL1" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL1_PREDIV.scale" value="1" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL1_VDIV.scale" value="50" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2.denom" value="1" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2.num" value="0" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_BYPASS.sel" value="CCM_ANALOG.PLL2_OUT_CLK" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD0_BYPASS.sel" value="CCM_ANALOG.PLL2_PFD0" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD0_DIV.scale" value="24" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD0_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD1_BYPASS.sel" value="CCM_ANALOG.PLL2_PFD1" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD2_BYPASS.sel" value="CCM_ANALOG.PLL2_PFD2" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD2_DIV.scale" value="29" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD2_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD3_BYPASS.sel" value="CCM_ANALOG.PLL2_PFD3" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD3_DIV.scale" value="35" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD3_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_BYPASS.sel" value="CCM_ANALOG.PLL3" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD0_BYPASS.sel" value="CCM_ANALOG.PLL3_PFD0" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD0_DIV.scale" value="12" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD0_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD1_BYPASS.sel" value="CCM_ANALOG.PLL3_PFD1" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD1_DIV.scale" value="35" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD1_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD2_BYPASS.sel" value="CCM_ANALOG.PLL3_PFD2" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD2_DIV.scale" value="26" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD2_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD3_BYPASS.sel" value="CCM_ANALOG.PLL3_PFD3" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD3_DIV.scale" value="31" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD3_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL4.denom" value="50" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL4.div" value="27" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL4_POST_DIV.scale" value="4" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL5.denom" value="1" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL5.div" value="31" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL5.num" value="0" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL5_BYPASS.sel" value="CCM_ANALOG.PLL5_POST_DIV" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL5_POST_DIV.scale" value="2" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL6_BYPASS.sel" value="CCM_ANALOG.PLL6" locked="false"/>
+                  <setting id="CCM_ANALOG.VIDEO_DIV.scale" value="4" locked="true"/>
+                  <setting id="CCM_ANALOG_PLL_USB1_EN_USB_CLKS_CFG" value="Enabled" locked="false"/>
+                  <setting id="CCM_ANALOG_PLL_USB1_EN_USB_CLKS_OUT_CFG" value="Enabled" locked="false"/>
+                  <setting id="CCM_ANALOG_PLL_USB1_POWER_CFG" value="Yes" locked="false"/>
+                  <setting id="CCM_ANALOG_PLL_VIDEO_POWERDOWN_CFG" value="No" locked="false"/>
+               </clock_settings>
+               <called_from_default_init>true</called_from_default_init>
+            </clock_configuration>
+         </clock_configurations>
+      </clocks>
+      <dcdx name="DCDx" version="3.0" enabled="true" update_project_code="false">
+         <generated_project_files>
+            <file path="board/dcd.c" update_enabled="true"/>
+            <file path="board/dcd.h" update_enabled="true"/>
+         </generated_project_files>
+         <dcdx_profile>
+            <processor_version>10.0.0</processor_version>
+            <output_format>c_array</output_format>
+         </dcdx_profile>
+         <dcdx_configurations>
+            <dcdx_configuration name="Device_configuration">
+               <description></description>
+               <options/>
+               <command_groups>
+                  <command_group name="Imported Commands" enabled="true">
+                     <commands>
+                        <command type="write_value" address="CCM_CCGR0" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR1" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR2" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR3" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR4" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR5" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR6" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_ANALOG_PLL_SYS" value="0x2001" value_width="4"/>
+                        <command type="write_value" address="CCM_ANALOG_PFD_528" value="0x1D0000" value_width="4"/>
+                        <command type="write_value" address="CCM_CBCDR" value="0x10D40" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_00" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_01" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_02" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_03" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_04" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_05" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_06" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_07" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_08" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_09" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_10" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_11" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_12" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_13" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_14" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_15" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_16" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_17" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_18" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_19" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_20" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_21" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_22" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_23" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_24" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_25" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_26" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_27" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_28" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_29" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_30" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_31" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_32" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_33" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_34" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_35" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_36" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_37" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_38" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_39" value="0x10" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_00" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_01" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_02" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_03" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_04" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_05" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_06" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_07" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_08" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_09" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_10" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_11" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_12" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_13" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_14" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_15" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_16" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_17" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_18" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_19" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_20" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_21" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_22" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_23" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_24" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_25" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_26" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_27" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_28" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_29" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_30" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_31" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_32" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_33" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_34" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_35" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_36" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_37" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_38" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_39" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="SEMC_MCR" value="0x10000004" value_width="4"/>
+                        <command type="write_value" address="SEMC_BMCR0" value="0x81" value_width="4"/>
+                        <command type="write_value" address="SEMC_BMCR1" value="0x81" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR0" value="0x8000001B" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR1" value="0x8200001B" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR2" value="0x8400001B" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR3" value="0x8600001B" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR4" value="0x90000021" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR5" value="0xA0000019" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR6" value="0xA8000017" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR7" value="0xA900001B" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR8" value="0x21" value_width="4"/>
+                        <command type="write_value" address="SEMC_IOCR" value="0x79A8" value_width="4"/>
+                        <command type="write_value" address="SEMC_SDRAMCR0" value="0xF31" value_width="4"/>
+                        <command type="write_value" address="SEMC_SDRAMCR1" value="0x652922" value_width="4"/>
+                        <command type="write_value" address="SEMC_SDRAMCR2" value="0x10920" value_width="4"/>
+                        <command type="write_value" address="SEMC_SDRAMCR3" value="0x50210A08" value_width="4"/>
+                        <command type="write_value" address="SEMC_DBICR0" value="0x21" value_width="4"/>
+                        <command type="write_value" address="SEMC_DBICR1" value="0x888888" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR1" value="0x02" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR2" value="0x00" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR0" value="0x80000000" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCMD" value="0xA55A000F" value_width="4"/>
+                        <command type="check_any_bit_set" address="SEMC_INTR" value="0x01" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR0" value="0x80000000" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCMD" value="0xA55A000C" value_width="4"/>
+                        <command type="check_any_bit_set" address="SEMC_INTR" value="0x01" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR0" value="0x80000000" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCMD" value="0xA55A000C" value_width="4"/>
+                        <command type="check_any_bit_set" address="SEMC_INTR" value="0x01" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPTXDAT" value="0x33" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR0" value="0x80000000" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCMD" value="0xA55A000A" value_width="4"/>
+                        <command type="check_any_bit_set" address="SEMC_INTR" value="0x01" value_width="4"/>
+                        <command type="write_value" address="SEMC_SDRAMCR3" value="0x50210A09" value_width="4"/>
+                     </commands>
+                  </command_group>
+               </command_groups>
+            </dcdx_configuration>
+         </dcdx_configurations>
+      </dcdx>
+      <periphs name="Peripherals" version="10.0" enabled="true" update_project_code="false">
+         <generated_project_files>
+            <file path="board/peripherals.c" update_enabled="true"/>
+            <file path="board/peripherals.h" update_enabled="true"/>
+         </generated_project_files>
+         <peripherals_profile>
+            <processor_version>10.0.0</processor_version>
+         </peripherals_profile>
+         <functional_groups>
+            <functional_group name="BOARD_InitPeripherals" uuid="1c6563a6-c68b-40e5-8828-2853c99f95fa" called_from_default_init="true" id_prefix="BOARD_" core="core0">
+               <description></description>
+               <options/>
+               <dependencies/>
+               <instances>
+                  <instance name="NVIC" uuid="2c253e89-508d-4544-9d44-c226931d8f3f" type="nvic" type_id="nvic_57b5eef3774cc60acaede6f5b8bddc67" mode="general" peripheral="NVIC" enabled="true" comment="" custom_name_enabled="false" editing_lock="false">
+                     <config_set name="nvic">
+                        <array name="interrupt_table"/>
+                        <array name="interrupts"/>
+                     </config_set>
+                  </instance>
+               </instances>
+            </functional_group>
+         </functional_groups>
+         <components>
+            <component name="system" uuid="18e298ee-cc10-47f7-b950-440409a94f94" type_id="system_54b53072540eeeb8f8e9343e71f28176">
+               <config_set_global name="global_system_definitions">
+                  <setting name="user_definitions" value=""/>
+                  <setting name="user_includes" value=""/>
+               </config_set_global>
+            </component>
+            <component name="msg" uuid="078a031a-1304-48e4-934c-de6b7bd41d37" type_id="msg_6e2baaf3b97dbeef01c0043275f9a0e7">
+               <config_set_global name="global_messages"/>
+            </component>
+            <component name="generic_uart" uuid="0e122da2-c994-4d5a-a7b8-5a63103fc1d2" type_id="generic_uart_8cae00565451cf2346eb1b8c624e73a6">
+               <config_set_global name="global_uart"/>
+            </component>
+            <component name="generic_can" uuid="51762fc1-cf05-4bb3-a3ca-5da5c50ea072" type_id="generic_can_1bfdd78b1af214566c1f23cf6a582d80">
+               <config_set_global name="global_can"/>
+            </component>
+            <component name="uart_cmsis_common" uuid="d4182366-28a3-4b72-9e22-d29aa447729c" type_id="uart_cmsis_common_9cb8e302497aa696fdbb5a4fd622c2a8">
+               <config_set_global name="global_USART_CMSIS_common" quick_selection="default"/>
+            </component>
+            <component name="generic_enet" uuid="c9d3d8ac-0dc9-40de-aea5-dd11df3d996b" type_id="generic_enet_74db5c914f0ddbe47d86af40cb77a619">
+               <config_set_global name="global_enet"/>
+            </component>
+         </components>
+      </periphs>
+      <tee name="TEE" version="2.0" enabled="false" update_project_code="true">
+         <generated_project_files/>
+         <tee_profile>
+            <processor_version>N/A</processor_version>
+         </tee_profile>
+      </tee>
+   </tools>
+</configuration>

--- a/boards/arm/mimxrt1060_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1060_evk/CMakeLists.txt
@@ -5,7 +5,8 @@
 #
 
 zephyr_library()
-zephyr_library_sources(pinmux.c)
+zephyr_library_sources(pinmux.c clock_config.c)
+zephyr_include_directories(.)
 
 if (CONFIG_DISPLAY)
 message(WARNING "

--- a/boards/arm/mimxrt1060_evk/clock_config.c
+++ b/boards/arm/mimxrt1060_evk/clock_config.c
@@ -1,0 +1,573 @@
+/*
+ * Copyright (c) 2021, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * How to setup clock using clock driver functions:
+ *
+ * 1. Call CLOCK_InitXXXPLL() to configure corresponding PLL clock.
+ *
+ * 2. Call CLOCK_InitXXXpfd() to configure corresponding PLL pfd clock.
+ *
+ * 3. Call CLOCK_SetMux() to configure corresponding clock source for target clock out.
+ *
+ * 4. Call CLOCK_SetDiv() to configure corresponding clock divider for target clock out.
+ *
+ * 5. Call CLOCK_SetXtalFreq() to set XTAL frequency based on board settings.
+ *
+ */
+
+/* TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
+ * !!GlobalInfo
+ * product: Clocks v8.0
+ * processor: MIMXRT1062xxxxA
+ * package_id: MIMXRT1062DVL6A
+ * mcu_data: ksdk2_0
+ * processor_version: 10.0.0
+ * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS **********/
+
+#include "clock_config.h"
+#include "fsl_iomuxc.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+/* System clock frequency. */
+extern uint32_t SystemCoreClock;
+
+/*******************************************************************************
+ ************************ BOARD_InitBootClocks function ************************
+ ******************************************************************************/
+void BOARD_InitBootClocks(void)
+{
+	clock_init();
+}
+
+/*******************************************************************************
+ ************************** Configuration clock_init ***************************
+ ******************************************************************************/
+/* TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
+ * !!Configuration
+ * name: clock_init
+ * called_from_default_init: true
+ * outputs:
+ * - {id: AHB_CLK_ROOT.outFreq, value: 600 MHz}
+ * - {id: CAN_CLK_ROOT.outFreq, value: 40 MHz}
+ * - {id: CKIL_SYNC_CLK_ROOT.outFreq, value: 32.768 kHz}
+ * - {id: CLK_1M.outFreq, value: 1 MHz}
+ * - {id: CLK_24M.outFreq, value: 24 MHz}
+ * - {id: CSI_CLK_ROOT.outFreq, value: 24 MHz}
+ * - {id: ENET_125M_CLK.outFreq, value: 50 MHz}
+ * - {id: ENET_25M_REF_CLK.outFreq, value: 25 MHz}
+ * - {id: FLEXIO1_CLK_ROOT.outFreq, value: 30 MHz}
+ * - {id: FLEXIO2_CLK_ROOT.outFreq, value: 30 MHz}
+ * - {id: FLEXSPI2_CLK_ROOT.outFreq, value: 720/7 MHz}
+ * - {id: FLEXSPI_CLK_ROOT.outFreq, value: 90 MHz}
+ * - {id: GPT1_ipg_clk_highfreq.outFreq, value: 75 MHz}
+ * - {id: GPT2_ipg_clk_highfreq.outFreq, value: 75 MHz}
+ * - {id: IPG_CLK_ROOT.outFreq, value: 150 MHz}
+ * - {id: LCDIF_CLK_ROOT.outFreq, value: 9.3 MHz}
+ * - {id: LPI2C_CLK_ROOT.outFreq, value: 10 MHz}
+ * - {id: LPSPI_CLK_ROOT.outFreq, value: 90 MHz}
+ * - {id: LVDS1_CLK.outFreq, value: 1.2 GHz}
+ * - {id: MQS_MCLK.outFreq, value: 540/13 MHz}
+ * - {id: PERCLK_CLK_ROOT.outFreq, value: 75 MHz}
+ * - {id: PLL7_MAIN_CLK.outFreq, value: 24 MHz}
+ * - {id: SAI1_CLK_ROOT.outFreq, value: 540/13 MHz}
+ * - {id: SAI1_MCLK1.outFreq, value: 540/13 MHz}
+ * - {id: SAI1_MCLK2.outFreq, value: 540/13 MHz}
+ * - {id: SAI1_MCLK3.outFreq, value: 30 MHz}
+ * - {id: SAI2_CLK_ROOT.outFreq, value: 540/13 MHz}
+ * - {id: SAI2_MCLK1.outFreq, value: 540/13 MHz}
+ * - {id: SAI2_MCLK3.outFreq, value: 30 MHz}
+ * - {id: SAI3_CLK_ROOT.outFreq, value: 540/13 MHz}
+ * - {id: SAI3_MCLK1.outFreq, value: 540/13 MHz}
+ * - {id: SAI3_MCLK3.outFreq, value: 30 MHz}
+ * - {id: SEMC_CLK_ROOT.outFreq, value: 4752/29 MHz}
+ * - {id: SPDIF0_CLK_ROOT.outFreq, value: 30 MHz}
+ * - {id: TRACE_CLK_ROOT.outFreq, value: 99 MHz}
+ * - {id: UART_CLK_ROOT.outFreq, value: 80 MHz}
+ * - {id: USBPHY1_CLK.outFreq, value: 480 MHz}
+ * - {id: USDHC1_CLK_ROOT.outFreq, value: 198 MHz}
+ * - {id: USDHC2_CLK_ROOT.outFreq, value: 198 MHz}
+ * settings:
+ * - {id: CCM.AHB_PODF.scale, value: '1', locked: true}
+ * - {id: CCM.ARM_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.CLKO2_DIV.scale, value: '1', locked: true}
+ * - {id: CCM.CLKO2_SEL.sel, value: XTALOSC24M.OSC_CLK}
+ * - {id: CCM.CSI_PODF.scale, value: '1', locked: true}
+ * - {id: CCM.FLEXSPI2_PODF.scale, value: '7', locked: true}
+ * - {id: CCM.FLEXSPI2_SEL.sel, value: CCM_ANALOG.PLL3_PFD0_CLK}
+ * - {id: CCM.FLEXSPI_PODF.scale, value: '8', locked: true}
+ * - {id: CCM.FLEXSPI_SEL.sel, value: CCM_ANALOG.PLL3_PFD0_CLK}
+ * - {id: CCM.LCDIF_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.LCDIF_PRED.scale, value: '5', locked: true}
+ * - {id: CCM.LCDIF_PRE_CLK_SEL.sel, value: CCM_ANALOG.PLL5_MAIN_CLK}
+ * - {id: CCM.LPI2C_CLK_PODF.scale, value: '6', locked: true}
+ * - {id: CCM.LPSPI_CLK_SEL.sel, value: CCM_ANALOG.PLL3_PFD0_CLK}
+ * - {id: CCM.LPSPI_PODF.scale, value: '8', locked: true}
+ * - {id: CCM.PERCLK_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.PERIPH_CLK2_SEL.sel, value: XTALOSC24M.OSC_CLK}
+ * - {id: CCM.SAI2_CLK_PRED.scale, value: '4', locked: true}
+ * - {id: CCM.SEMC_CLK_SEL.sel, value: CCM.SEMC_ALT_CLK_SEL}
+ * - {id: CCM.SEMC_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.TRACE_PODF.scale, value: '4', locked: true}
+ * - {id: CCM.USDHC1_CLK_SEL.sel, value: CCM_ANALOG.PLL2_PFD0_CLK}
+ * - {id: CCM.USDHC1_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.USDHC2_CLK_SEL.sel, value: CCM_ANALOG.PLL2_PFD0_CLK}
+ * - {id: CCM.USDHC2_PODF.scale, value: '2', locked: true}
+ * - {id: CCM_ANALOG.PLL1_BYPASS.sel, value: CCM_ANALOG.PLL1}
+ * - {id: CCM_ANALOG.PLL1_PREDIV.scale, value: '1', locked: true}
+ * - {id: CCM_ANALOG.PLL1_VDIV.scale, value: '50', locked: true}
+ * - {id: CCM_ANALOG.PLL2.denom, value: '1', locked: true}
+ * - {id: CCM_ANALOG.PLL2.num, value: '0', locked: true}
+ * - {id: CCM_ANALOG.PLL2_BYPASS.sel, value: CCM_ANALOG.PLL2_OUT_CLK}
+ * - {id: CCM_ANALOG.PLL2_PFD0_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD0}
+ * - {id: CCM_ANALOG.PLL2_PFD0_DIV.scale, value: '24', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD0_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD1_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD1}
+ * - {id: CCM_ANALOG.PLL2_PFD2_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD2}
+ * - {id: CCM_ANALOG.PLL2_PFD2_DIV.scale, value: '29', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD2_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD3_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD3}
+ * - {id: CCM_ANALOG.PLL2_PFD3_DIV.scale, value: '35', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD3_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_BYPASS.sel, value: CCM_ANALOG.PLL3}
+ * - {id: CCM_ANALOG.PLL3_PFD0_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD0}
+ * - {id: CCM_ANALOG.PLL3_PFD0_DIV.scale, value: '12', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD0_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD1_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD1}
+ * - {id: CCM_ANALOG.PLL3_PFD1_DIV.scale, value: '35', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD1_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD2_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD2}
+ * - {id: CCM_ANALOG.PLL3_PFD2_DIV.scale, value: '26', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD2_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD3_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD3}
+ * - {id: CCM_ANALOG.PLL3_PFD3_DIV.scale, value: '31', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD3_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL4.denom, value: '50'}
+ * - {id: CCM_ANALOG.PLL4.div, value: '27', locked: true}
+ * - {id: CCM_ANALOG.PLL4_POST_DIV.scale, value: '4', locked: true}
+ * - {id: CCM_ANALOG.PLL5.denom, value: '1'}
+ * - {id: CCM_ANALOG.PLL5.div, value: '31', locked: true}
+ * - {id: CCM_ANALOG.PLL5.num, value: '0'}
+ * - {id: CCM_ANALOG.PLL5_BYPASS.sel, value: CCM_ANALOG.PLL5_POST_DIV}
+ * - {id: CCM_ANALOG.PLL5_POST_DIV.scale, value: '2', locked: true}
+ * - {id: CCM_ANALOG.PLL6_BYPASS.sel, value: CCM_ANALOG.PLL6}
+ * - {id: CCM_ANALOG.VIDEO_DIV.scale, value: '4', locked: true}
+ * - {id: CCM_ANALOG_PLL_ENET_ENET2_REF_EN_CFG, value: Disabled}
+ * - {id: CCM_ANALOG_PLL_USB1_EN_USB_CLKS_CFG, value: Enabled}
+ * - {id: CCM_ANALOG_PLL_USB1_EN_USB_CLKS_OUT_CFG, value: Enabled}
+ * - {id: CCM_ANALOG_PLL_USB1_POWER_CFG, value: 'Yes'}
+ * - {id: CCM_ANALOG_PLL_VIDEO_POWERDOWN_CFG, value: 'No'}
+ * sources:
+ * - {id: XTALOSC24M.RTC_OSC.outFreq, value: 32.768 kHz, enabled: true}
+ * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS **********/
+
+/*******************************************************************************
+ * Variables for clock_init configuration
+ ******************************************************************************/
+const clock_arm_pll_config_t armPllConfig_clock_init = {
+	/* PLL loop divider, Fout = Fin * 50 */
+	.loopDivider = 100,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+const clock_sys_pll_config_t sysPllConfig_clock_init = {
+	/* PLL loop divider, Fout = Fin * ( 20 + loopDivider*2 + numerator / denominator ) */
+	.loopDivider = 1,
+	/* 30 bit numerator of fractional loop divider */
+	.numerator = 0,
+	/* 30 bit denominator of fractional loop divider */
+	.denominator = 1,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+const clock_usb_pll_config_t usb1PllConfig_clock_init = {
+	/* PLL loop divider, Fout = Fin * 20 */
+	.loopDivider = 0,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+const clock_video_pll_config_t videoPllConfig_clock_init = {
+	/* PLL loop divider, Fout = Fin * ( loopDivider + numerator / denominator ) */
+	.loopDivider = 31,
+	.postDivider = 8,                               /* Divider after PLL */
+	/*
+	 * 30 bit numerator of fractional loop divider,
+	 * Fout = Fin * ( loopDivider + numerator / denominator )
+	 */
+	.numerator = 0,
+	/*
+	 * 30 bit denominator of fractional loop divider,
+	 * Fout = Fin * ( loopDivider + numerator / denominator )
+	 */
+	.denominator = 1,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+const clock_enet_pll_config_t enetPllConfig_clock_init = {
+	/* Enable the PLL providing the ENET 125MHz reference clock */
+	.enableClkOutput = true,
+	/* Disable the PLL providing the ENET2 125MHz reference clock */
+	.enableClkOutput1 = false,
+	/* Enable the PLL providing the ENET 25MHz reference clock */
+	.enableClkOutput25M = true,
+	/* Set frequency of ethernet reference clock to 50 MHz */
+	.loopDivider = 1,
+	/* Set frequency of ethernet reference clock to 25 MHz */
+	.loopDivider1 = 0,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+/*******************************************************************************
+ * Code for clock_init configuration
+ ******************************************************************************/
+void clock_init(void)
+{
+	/* Init RTC OSC clock frequency. */
+	CLOCK_SetRtcXtalFreq(32768U);
+	/* Enable 1MHz clock output. */
+	XTALOSC24M->OSC_CONFIG2 |= XTALOSC24M_OSC_CONFIG2_ENABLE_1M_MASK;
+	/* Use free 1MHz clock output. */
+	XTALOSC24M->OSC_CONFIG2 &= ~XTALOSC24M_OSC_CONFIG2_MUX_1M_MASK;
+	/* Set XTAL 24MHz clock frequency. */
+	CLOCK_SetXtalFreq(24000000U);
+	/* Enable XTAL 24MHz clock source. */
+	CLOCK_InitExternalClk(0);
+	/* Enable internal RC. */
+	CLOCK_InitRcOsc24M();
+	/* Switch clock source to external OSC. */
+	CLOCK_SwitchOsc(kCLOCK_XtalOsc);
+	/* Set Oscillator ready counter value. */
+	CCM->CCR = (CCM->CCR & (~CCM_CCR_OSCNT_MASK)) | CCM_CCR_OSCNT(127);
+	/* Setting PeriphClk2Mux and PeriphMux to provide stable clock before PLLs are initialed */
+	CLOCK_SetMux(kCLOCK_PeriphClk2Mux, 1);  /* Set PERIPH_CLK2 MUX to OSC */
+	CLOCK_SetMux(kCLOCK_PeriphMux, 1);      /* Set PERIPH_CLK MUX to PERIPH_CLK2 */
+	/* Setting the VDD_SOC to 1.275V. It is necessary to config AHB to 600Mhz. */
+	DCDC->REG3 = (DCDC->REG3 & (~DCDC_REG3_TRG_MASK)) | DCDC_REG3_TRG(0x13);
+	/* Waiting for DCDC_STS_DC_OK bit is asserted */
+	while (DCDC_REG0_STS_DC_OK_MASK != (DCDC_REG0_STS_DC_OK_MASK & DCDC->REG0)) {
+	}
+	/* Set AHB_PODF. */
+	CLOCK_SetDiv(kCLOCK_AhbDiv, 0);
+	/* Disable IPG clock gate. */
+	CLOCK_DisableClock(kCLOCK_Adc1);
+	CLOCK_DisableClock(kCLOCK_Adc2);
+	CLOCK_DisableClock(kCLOCK_Xbar1);
+	CLOCK_DisableClock(kCLOCK_Xbar2);
+	CLOCK_DisableClock(kCLOCK_Xbar3);
+	/* Set IPG_PODF. */
+	CLOCK_SetDiv(kCLOCK_IpgDiv, 3);
+	/* Set ARM_PODF. */
+	CLOCK_SetDiv(kCLOCK_ArmDiv, 1);
+	/* Set PERIPH_CLK2_PODF. */
+	CLOCK_SetDiv(kCLOCK_PeriphClk2Div, 0);
+	/* Disable PERCLK clock gate. */
+	CLOCK_DisableClock(kCLOCK_Gpt1);
+	CLOCK_DisableClock(kCLOCK_Gpt1S);
+	CLOCK_DisableClock(kCLOCK_Gpt2);
+	CLOCK_DisableClock(kCLOCK_Gpt2S);
+	CLOCK_DisableClock(kCLOCK_Pit);
+	/* Set PERCLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_PerclkDiv, 1);
+	/* Disable USDHC1 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Usdhc1);
+	/* Set USDHC1_PODF. */
+	CLOCK_SetDiv(kCLOCK_Usdhc1Div, 1);
+	/* Set Usdhc1 clock source. */
+	CLOCK_SetMux(kCLOCK_Usdhc1Mux, 1);
+	/* Disable USDHC2 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Usdhc2);
+	/* Set USDHC2_PODF. */
+	CLOCK_SetDiv(kCLOCK_Usdhc2Div, 1);
+	/* Set Usdhc2 clock source. */
+	CLOCK_SetMux(kCLOCK_Usdhc2Mux, 1);
+	/*
+	 * In SDK projects, SDRAM (configured by SEMC) will be initialized in either debug script
+	 * or dcd. With this macro SKIP_SYSCLK_INIT, system pll (selected to be SEMC source clock
+	 * in SDK projects) will be left unchanged.
+	 * Note: If another clock source is selected for SEMC, user may want to avoid changing
+	 * that clock as well.
+	 */
+#ifndef SKIP_SYSCLK_INIT
+	/* Disable Semc clock gate. */
+	CLOCK_DisableClock(kCLOCK_Semc);
+	/* Set SEMC_PODF. */
+	CLOCK_SetDiv(kCLOCK_SemcDiv, 1);
+	/* Set Semc alt clock source. */
+	CLOCK_SetMux(kCLOCK_SemcAltMux, 0);
+	/* Set Semc clock source. */
+	CLOCK_SetMux(kCLOCK_SemcMux, 1);
+#endif
+	/*
+	 * In SDK projects, external flash (configured by FLEXSPI) will be initialized by dcd.
+	 * With this macro XIP_EXTERNAL_FLASH, usb1 pll (selected to be FLEXSPI clock source in
+	 * SDK projects) will be left unchanged.
+	 * Note: If another clock source is selected for FLEXSPI, user may want to avoid changing
+	 * that clock as well.
+	 */
+#if !(defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1))
+	/* Disable Flexspi clock gate. */
+	CLOCK_DisableClock(kCLOCK_FlexSpi);
+	/* Set FLEXSPI_PODF. */
+	CLOCK_SetDiv(kCLOCK_FlexspiDiv, 7);
+	/* Set Flexspi clock source. */
+	CLOCK_SetMux(kCLOCK_FlexspiMux, 3);
+#endif
+	/* Disable Flexspi2 clock gate. */
+	CLOCK_DisableClock(kCLOCK_FlexSpi2);
+	/* Set FLEXSPI2_PODF. */
+	CLOCK_SetDiv(kCLOCK_Flexspi2Div, 6);
+	/* Set Flexspi2 clock source. */
+	CLOCK_SetMux(kCLOCK_Flexspi2Mux, 1);
+	/* Disable CSI clock gate. */
+	CLOCK_DisableClock(kCLOCK_Csi);
+	/* Set CSI_PODF. */
+	CLOCK_SetDiv(kCLOCK_CsiDiv, 0);
+	/* Set Csi clock source. */
+	CLOCK_SetMux(kCLOCK_CsiMux, 0);
+	/* Disable LPSPI clock gate. */
+	CLOCK_DisableClock(kCLOCK_Lpspi1);
+	CLOCK_DisableClock(kCLOCK_Lpspi2);
+	CLOCK_DisableClock(kCLOCK_Lpspi3);
+	CLOCK_DisableClock(kCLOCK_Lpspi4);
+	/* Set LPSPI_PODF. */
+	CLOCK_SetDiv(kCLOCK_LpspiDiv, 7);
+	/* Set Lpspi clock source. */
+	CLOCK_SetMux(kCLOCK_LpspiMux, 1);
+	/* Disable TRACE clock gate. */
+	CLOCK_DisableClock(kCLOCK_Trace);
+	/* Set TRACE_PODF. */
+	CLOCK_SetDiv(kCLOCK_TraceDiv, 3);
+	/* Set Trace clock source. */
+	CLOCK_SetMux(kCLOCK_TraceMux, 2);
+	/* Disable SAI1 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Sai1);
+	/* Set SAI1_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Sai1PreDiv, 3);
+	/* Set SAI1_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Sai1Div, 1);
+	/* Set Sai1 clock source. */
+	CLOCK_SetMux(kCLOCK_Sai1Mux, 0);
+	/* Disable SAI2 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Sai2);
+	/* Set SAI2_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Sai2PreDiv, 3);
+	/* Set SAI2_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Sai2Div, 1);
+	/* Set Sai2 clock source. */
+	CLOCK_SetMux(kCLOCK_Sai2Mux, 0);
+	/* Disable SAI3 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Sai3);
+	/* Set SAI3_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Sai3PreDiv, 3);
+	/* Set SAI3_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Sai3Div, 1);
+	/* Set Sai3 clock source. */
+	CLOCK_SetMux(kCLOCK_Sai3Mux, 0);
+	/* Disable Lpi2c clock gate. */
+	CLOCK_DisableClock(kCLOCK_Lpi2c1);
+	CLOCK_DisableClock(kCLOCK_Lpi2c2);
+	CLOCK_DisableClock(kCLOCK_Lpi2c3);
+	/* Set LPI2C_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Lpi2cDiv, 5);
+	/* Set Lpi2c clock source. */
+	CLOCK_SetMux(kCLOCK_Lpi2cMux, 0);
+	/* Disable CAN clock gate. */
+	CLOCK_DisableClock(kCLOCK_Can1);
+	CLOCK_DisableClock(kCLOCK_Can2);
+	CLOCK_DisableClock(kCLOCK_Can3);
+	CLOCK_DisableClock(kCLOCK_Can1S);
+	CLOCK_DisableClock(kCLOCK_Can2S);
+	CLOCK_DisableClock(kCLOCK_Can3S);
+	/* Set CAN_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_CanDiv, 1);
+	/* Set Can clock source. */
+	CLOCK_SetMux(kCLOCK_CanMux, 2);
+	/* Disable UART clock gate. */
+	CLOCK_DisableClock(kCLOCK_Lpuart1);
+	CLOCK_DisableClock(kCLOCK_Lpuart2);
+	CLOCK_DisableClock(kCLOCK_Lpuart3);
+	CLOCK_DisableClock(kCLOCK_Lpuart4);
+	CLOCK_DisableClock(kCLOCK_Lpuart5);
+	CLOCK_DisableClock(kCLOCK_Lpuart6);
+	CLOCK_DisableClock(kCLOCK_Lpuart7);
+	CLOCK_DisableClock(kCLOCK_Lpuart8);
+	/* Set UART_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_UartDiv, 0);
+	/* Set Uart clock source. */
+	CLOCK_SetMux(kCLOCK_UartMux, 0);
+	/* Disable LCDIF clock gate. */
+	CLOCK_DisableClock(kCLOCK_LcdPixel);
+	/* Set LCDIF_PRED. */
+	CLOCK_SetDiv(kCLOCK_LcdifPreDiv, 4);
+	/* Set LCDIF_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_LcdifDiv, 1);
+	/* Set Lcdif pre clock source. */
+	CLOCK_SetMux(kCLOCK_LcdifPreMux, 2);
+	/* Disable SPDIF clock gate. */
+	CLOCK_DisableClock(kCLOCK_Spdif);
+	/* Set SPDIF0_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Spdif0PreDiv, 1);
+	/* Set SPDIF0_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Spdif0Div, 7);
+	/* Set Spdif clock source. */
+	CLOCK_SetMux(kCLOCK_SpdifMux, 3);
+	/* Disable Flexio1 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Flexio1);
+	/* Set FLEXIO1_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Flexio1PreDiv, 1);
+	/* Set FLEXIO1_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Flexio1Div, 7);
+	/* Set Flexio1 clock source. */
+	CLOCK_SetMux(kCLOCK_Flexio1Mux, 3);
+	/* Disable Flexio2 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Flexio2);
+	/* Set FLEXIO2_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Flexio2PreDiv, 1);
+	/* Set FLEXIO2_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Flexio2Div, 7);
+	/* Set Flexio2 clock source. */
+	CLOCK_SetMux(kCLOCK_Flexio2Mux, 3);
+	/* Set Pll3 sw clock source. */
+	CLOCK_SetMux(kCLOCK_Pll3SwMux, 0);
+	/* Init ARM PLL. */
+	CLOCK_InitArmPll(&armPllConfig_clock_init);
+	/*
+	 * In SDK projects, SDRAM (configured by SEMC) will be initialized in either debug script
+	 * or dcd. With this macro SKIP_SYSCLK_INIT, system pll (selected to be SEMC source clock
+	 * in SDK projects) will be left unchanged.
+	 * Note: If another clock source is selected for SEMC, user may want to avoid changing that
+	 * clock as well.
+	 */
+#ifndef SKIP_SYSCLK_INIT
+#if defined(XIP_BOOT_HEADER_DCD_ENABLE) && (XIP_BOOT_HEADER_DCD_ENABLE == 1)
+    #warning "SKIP_SYSCLK_INIT should be defined to keep system pll (selected to be SEMC source \
+	clock in SDK projects) unchanged."
+#endif
+	/* Init System PLL. */
+	CLOCK_InitSysPll(&sysPllConfig_clock_init);
+	/* Init System pfd0. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd0, 24);
+	/* Init System pfd1. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd1, 16);
+	/* Init System pfd2. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd2, 29);
+	/* Init System pfd3. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd3, 35);
+#endif
+	/*
+	 * In SDK projects, external flash (configured by FLEXSPI) will be initialized by dcd.
+	 * With this macro XIP_EXTERNAL_FLASH, usb1 pll (selected to be FLEXSPI clock source in
+	 * SDK projects) will be left unchanged.
+	 * Note: If another clock source is selected for FLEXSPI, user may want to avoid changing
+	 * that clock as well.
+	 */
+#if !(defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1))
+	/* Init Usb1 PLL. */
+	CLOCK_InitUsb1Pll(&usb1PllConfig_clock_init);
+	/* Init Usb1 pfd0. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd0, 12);
+	/* Init Usb1 pfd1. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd1, 35);
+	/* Init Usb1 pfd2. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd2, 26);
+	/* Init Usb1 pfd3. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd3, 31);
+#endif
+	/* DeInit Audio PLL. */
+	CLOCK_DeinitAudioPll();
+	/* Bypass Audio PLL. */
+	CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllAudio, 1);
+	/* Set divider for Audio PLL. */
+	CCM_ANALOG->MISC2 &= ~CCM_ANALOG_MISC2_AUDIO_DIV_LSB_MASK;
+	CCM_ANALOG->MISC2 &= ~CCM_ANALOG_MISC2_AUDIO_DIV_MSB_MASK;
+	/* Enable Audio PLL output. */
+	CCM_ANALOG->PLL_AUDIO |= CCM_ANALOG_PLL_AUDIO_ENABLE_MASK;
+	/* Init Video PLL. */
+	uint32_t pllVideo;
+	/* Disable Video PLL output before initial Video PLL. */
+	CCM_ANALOG->PLL_VIDEO &= ~CCM_ANALOG_PLL_VIDEO_ENABLE_MASK;
+	/* Bypass PLL first */
+	CCM_ANALOG->PLL_VIDEO = (CCM_ANALOG->PLL_VIDEO &
+				(~CCM_ANALOG_PLL_VIDEO_BYPASS_CLK_SRC_MASK)) |
+				CCM_ANALOG_PLL_VIDEO_BYPASS_MASK |
+				CCM_ANALOG_PLL_VIDEO_BYPASS_CLK_SRC(0);
+	CCM_ANALOG->PLL_VIDEO_NUM = CCM_ANALOG_PLL_VIDEO_NUM_A(0);
+	CCM_ANALOG->PLL_VIDEO_DENOM = CCM_ANALOG_PLL_VIDEO_DENOM_B(1);
+	pllVideo = (CCM_ANALOG->PLL_VIDEO &
+		    (~(CCM_ANALOG_PLL_VIDEO_DIV_SELECT_MASK |
+		       CCM_ANALOG_PLL_VIDEO_POWERDOWN_MASK))) |
+		   CCM_ANALOG_PLL_VIDEO_ENABLE_MASK |
+		   CCM_ANALOG_PLL_VIDEO_DIV_SELECT(31);
+	pllVideo |= CCM_ANALOG_PLL_VIDEO_POST_DIV_SELECT(1);
+	CCM_ANALOG->MISC2 = (CCM_ANALOG->MISC2 & (~CCM_ANALOG_MISC2_VIDEO_DIV_MASK)) |
+			     CCM_ANALOG_MISC2_VIDEO_DIV(3);
+	CCM_ANALOG->PLL_VIDEO = pllVideo;
+	while ((CCM_ANALOG->PLL_VIDEO & CCM_ANALOG_PLL_VIDEO_LOCK_MASK) == 0) {
+	}
+	/* Disable bypass for Video PLL. */
+	CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllVideo, 0);
+	/* Init Enet PLL. */
+	CLOCK_InitEnetPll(&enetPllConfig_clock_init);
+	/* DeInit Usb2 PLL. */
+	CLOCK_DeinitUsb2Pll();
+	/* Bypass Usb2 PLL. */
+	CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllUsb2, 1);
+	/* Enable Usb2 PLL output. */
+	CCM_ANALOG->PLL_USB2 |= CCM_ANALOG_PLL_USB2_ENABLE_MASK;
+	/* Set preperiph clock source. */
+	CLOCK_SetMux(kCLOCK_PrePeriphMux, 3);
+	/* Set periph clock source. */
+	CLOCK_SetMux(kCLOCK_PeriphMux, 0);
+	/* Set periph clock2 clock source. */
+	CLOCK_SetMux(kCLOCK_PeriphClk2Mux, 1);
+	/* Set per clock source. */
+	CLOCK_SetMux(kCLOCK_PerclkMux, 0);
+	/* Set lvds1 clock source. */
+	CCM_ANALOG->MISC1 = (CCM_ANALOG->MISC1 & (~CCM_ANALOG_MISC1_LVDS1_CLK_SEL_MASK)) |
+			     CCM_ANALOG_MISC1_LVDS1_CLK_SEL(0);
+	/* Set clock out1 divider. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO1_DIV_MASK)) | CCM_CCOSR_CLKO1_DIV(0);
+	/* Set clock out1 source. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO1_SEL_MASK)) | CCM_CCOSR_CLKO1_SEL(1);
+	/* Set clock out2 divider. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO2_DIV_MASK)) | CCM_CCOSR_CLKO2_DIV(0);
+	/* Set clock out2 source. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO2_SEL_MASK)) | CCM_CCOSR_CLKO2_SEL(14);
+	/* Set clock out1 drives clock out1. */
+	CCM->CCOSR &= ~CCM_CCOSR_CLK_OUT_SEL_MASK;
+	/* Disable clock out1. */
+	CCM->CCOSR &= ~CCM_CCOSR_CLKO1_EN_MASK;
+	/* Disable clock out2. */
+	CCM->CCOSR &= ~CCM_CCOSR_CLKO2_EN_MASK;
+	/* Set SAI1 MCLK1 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk1Sel, 0);
+	/* Set SAI1 MCLK2 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk2Sel, 0);
+	/* Set SAI1 MCLK3 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk3Sel, 0);
+	/* Set SAI2 MCLK3 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI2MClk3Sel, 0);
+	/* Set SAI3 MCLK3 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI3MClk3Sel, 0);
+	/* Set MQS configuration. */
+	IOMUXC_MQSConfig(IOMUXC_GPR, kIOMUXC_MqsPwmOverSampleRate32, 0);
+	/* Set ENET Ref clock source. */
+	IOMUXC_GPR->GPR1 &= ~IOMUXC_GPR_GPR1_ENET1_TX_CLK_DIR_MASK;
+	/* Set ENET2 Ref clock source. */
+	IOMUXC_GPR->GPR1 &= ~IOMUXC_GPR_GPR1_ENET2_TX_CLK_DIR_MASK;
+	/* Set GPT1 High frequency reference clock source. */
+	IOMUXC_GPR->GPR5 &= ~IOMUXC_GPR_GPR5_VREF_1M_CLK_GPT1_MASK;
+	/* Set GPT2 High frequency reference clock source. */
+	IOMUXC_GPR->GPR5 &= ~IOMUXC_GPR_GPR5_VREF_1M_CLK_GPT2_MASK;
+	/* Set SystemCoreClock variable. */
+	SystemCoreClock = CLOCK_INIT_CORE_CLOCK;
+}

--- a/boards/arm/mimxrt1060_evk/clock_config.h
+++ b/boards/arm/mimxrt1060_evk/clock_config.h
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2021, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _CLOCK_CONFIG_H_
+#define _CLOCK_CONFIG_H_
+
+#include "fsl_common.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+/*!< Board xtal0 frequency in Hz */
+#define BOARD_XTAL0_CLK_HZ                         24000000U
+
+/*!< Board xtal32k frequency in Hz */
+#define BOARD_XTAL32K_CLK_HZ                          32768U
+/*******************************************************************************
+ ************************ BOARD_InitBootClocks function ************************
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus*/
+
+/*!
+ * @brief This function executes default configuration of clocks.
+ *
+ */
+void BOARD_InitBootClocks(void);
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus*/
+
+/*******************************************************************************
+ ************************** Configuration clock_init ***************************
+ ******************************************************************************/
+/*******************************************************************************
+ * Definitions for clock_init configuration
+ ******************************************************************************/
+/*!< Core clock frequency: 600000000Hz */
+#define CLOCK_INIT_CORE_CLOCK                     600000000U
+
+/* Clock outputs (values are in Hz): */
+#define CLOCK_INIT_AHB_CLK_ROOT                       600000000UL
+#define CLOCK_INIT_CAN_CLK_ROOT                       40000000UL
+#define CLOCK_INIT_CKIL_SYNC_CLK_ROOT                 32768UL
+#define CLOCK_INIT_CLKO1_CLK                          0UL
+#define CLOCK_INIT_CLKO2_CLK                          0UL
+#define CLOCK_INIT_CLK_1M                             1000000UL
+#define CLOCK_INIT_CLK_24M                            24000000UL
+#define CLOCK_INIT_CSI_CLK_ROOT                       24000000UL
+#define CLOCK_INIT_ENET2_125M_CLK                     0UL
+#define CLOCK_INIT_ENET2_REF_CLK                      0UL
+#define CLOCK_INIT_ENET2_TX_CLK                       0UL
+#define CLOCK_INIT_ENET_125M_CLK                      50000000UL
+#define CLOCK_INIT_ENET_25M_REF_CLK                   25000000UL
+#define CLOCK_INIT_ENET_REF_CLK                       0UL
+#define CLOCK_INIT_ENET_TX_CLK                        0UL
+#define CLOCK_INIT_FLEXIO1_CLK_ROOT                   30000000UL
+#define CLOCK_INIT_FLEXIO2_CLK_ROOT                   30000000UL
+#define CLOCK_INIT_FLEXSPI2_CLK_ROOT                  102857142UL
+#define CLOCK_INIT_FLEXSPI_CLK_ROOT                   90000000UL
+#define CLOCK_INIT_GPT1_IPG_CLK_HIGHFREQ              75000000UL
+#define CLOCK_INIT_GPT2_IPG_CLK_HIGHFREQ              75000000UL
+#define CLOCK_INIT_IPG_CLK_ROOT                       150000000UL
+#define CLOCK_INIT_LCDIF_CLK_ROOT                     9300000UL
+#define CLOCK_INIT_LPI2C_CLK_ROOT                     10000000UL
+#define CLOCK_INIT_LPSPI_CLK_ROOT                     90000000UL
+#define CLOCK_INIT_LVDS1_CLK                          1200000000UL
+#define CLOCK_INIT_MQS_MCLK                           41538461UL
+#define CLOCK_INIT_PERCLK_CLK_ROOT                    75000000UL
+#define CLOCK_INIT_PLL7_MAIN_CLK                      24000000UL
+#define CLOCK_INIT_SAI1_CLK_ROOT                      41538461UL
+#define CLOCK_INIT_SAI1_MCLK1                         41538461UL
+#define CLOCK_INIT_SAI1_MCLK2                         41538461UL
+#define CLOCK_INIT_SAI1_MCLK3                         30000000UL
+#define CLOCK_INIT_SAI2_CLK_ROOT                      41538461UL
+#define CLOCK_INIT_SAI2_MCLK1                         41538461UL
+#define CLOCK_INIT_SAI2_MCLK2                         0UL
+#define CLOCK_INIT_SAI2_MCLK3                         30000000UL
+#define CLOCK_INIT_SAI3_CLK_ROOT                      41538461UL
+#define CLOCK_INIT_SAI3_MCLK1                         41538461UL
+#define CLOCK_INIT_SAI3_MCLK2                         0UL
+#define CLOCK_INIT_SAI3_MCLK3                         30000000UL
+#define CLOCK_INIT_SEMC_CLK_ROOT                      163862068UL
+#define CLOCK_INIT_SPDIF0_CLK_ROOT                    30000000UL
+#define CLOCK_INIT_SPDIF0_EXTCLK_OUT                  0UL
+#define CLOCK_INIT_TRACE_CLK_ROOT                     99000000UL
+#define CLOCK_INIT_UART_CLK_ROOT                      80000000UL
+#define CLOCK_INIT_USBPHY1_CLK                        480000000UL
+#define CLOCK_INIT_USBPHY2_CLK                        0UL
+#define CLOCK_INIT_USDHC1_CLK_ROOT                    198000000UL
+#define CLOCK_INIT_USDHC2_CLK_ROOT                    198000000UL
+
+/*! @brief Arm PLL set for clock_init configuration.
+ */
+extern const clock_arm_pll_config_t armPllConfig_clock_init;
+/*! @brief Usb1 PLL set for clock_init configuration.
+ */
+extern const clock_usb_pll_config_t usb1PllConfig_clock_init;
+/*! @brief Sys PLL for clock_init configuration.
+ */
+extern const clock_sys_pll_config_t sysPllConfig_clock_init;
+/*! @brief Video PLL set for clock_init configuration.
+ */
+extern const clock_video_pll_config_t videoPllConfig_clock_init;
+/*! @brief Enet PLL set for clock_init configuration.
+ */
+extern const clock_enet_pll_config_t enetPllConfig_clock_init;
+
+/*******************************************************************************
+ * API for clock_init configuration
+ ******************************************************************************/
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus*/
+
+/*!
+ * @brief This function executes configuration of clocks.
+ *
+ */
+void clock_init(void);
+
+#if defined(__cplusplus)
+}
+#endif  /* __cplusplus*/
+
+#endif  /* _CLOCK_CONFIG_H_ */

--- a/boards/arm/mimxrt1060_evk/doc/index.rst
+++ b/boards/arm/mimxrt1060_evk/doc/index.rst
@@ -400,6 +400,163 @@ If the west flash or debug commands fail, and the command hangs while executing
 runners.jlink, confirm the J-Link debug probe is configured, powered, and
 connected to the EVK properly. See :ref:`Using J-Link RT1060` for more details.
 
+MCUXpresso Config Tool
+======================
+
+A ``mimxrt1060_evk.mex`` file is included. This file was used to generate the clock
+initialization code and can be used as a starting point to tweak the clock configuration.
+This could be useful for different boards that are based on i.MX RT1060.
+
+NOTE: The MCUXpresso Config Tool currently generates a ``.c`` file with the clock configuration.
+Considering options on leveraging this tool in the future to generate a devicetree compatible file.
+
+Clock Configuration at Platform Initialization
+==============================================
+
+Below is the clock configuration at platform initialization.
+
+- On-chip 24MHz oscillator is enabled
+
+- Clock sources
+
++----------------------------+-----------------+
+| Name                       | Frequency       |
++============================+=================+
+| RTC Oscillator             | 32.768 kHz      |
++----------------------------+-----------------+
+| 24MHz clock source         | 24 MHz          |
++----------------------------+-----------------+
+| 1MHz clock                 | 1 MHz           |
++----------------------------+-----------------+
+| CLK1 external clock source | Inactive        |
++----------------------------+-----------------+
+| SAI1 MCLK                  | Inactive        |
++----------------------------+-----------------+
+| SAI2 MCLK                  | Inactive        |
++----------------------------+-----------------+
+| SAI3 MCLK                  | Inactive        |
++----------------------------+-----------------+
+| SPDIF_CLK_EXT              | Inactive        |
++----------------------------+-----------------+
+| SPDIF_SRCLK                | 1 MHz           |
++----------------------------+-----------------+
+| SPDIF_OUTCLK               | 1 MHz           |
++----------------------------+-----------------+
+| ENET_TX_CLK_EXT            | Inactive        |
++----------------------------+-----------------+
+| ENET_REF_CLK_EXT           | Inactive        |
++----------------------------+-----------------+
+| ENET2_TX_CLK_EXT           | Inactive        |
++----------------------------+-----------------+
+| ENET2_REF_CLK_EXT          | Inactive        |
++----------------------------+-----------------+
+
+- Clock outputs
+
++============================+=================+
+| Name                       | Frequency       |
++============================+=================+
+| AHB_CLK_ROOT               | 600 MHz         |
++----------------------------+-----------------+
+| IPG_CLK_ROOT               | 150 MHz         |
++----------------------------+-----------------+
+| SEMC_CLK_ROOT              | 163.86 MHz      |
++----------------------------+-----------------+
+| PERCLK_CLK_ROOT            | 75 MHz          |
++----------------------------+-----------------+
+| LCDIF_CLK_ROOT             | 9.3 MHz         |
++----------------------------+-----------------+
+| CSI_CLK_ROOT               | 24 MHz          |
++----------------------------+-----------------+
+| USDHC1_CLK_ROOT            | 198 MHz         |
++----------------------------+-----------------+
+| USDHC2_CLK_ROOT            | 198 MHz         |
++----------------------------+-----------------+
+| FLEXSPI_CLK_ROOT           | 90 MHz          |
++----------------------------+-----------------+
+| FLEXSPI2_CLK_ROOT          | 102.85 MHz      |
++----------------------------+-----------------+
+| SPDIF0_CLK_ROOT            | 30 MHz          |
++----------------------------+-----------------+
+| FLEXIO1_CLK_ROOT           | 30 MHz          |
++----------------------------+-----------------+
+| FLEXIO2_CLK_ROOT           | 30 MHz          |
++----------------------------+-----------------+
+| SAI1_CLK_ROOT              | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI2_CLK_ROOT              | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI3_CLK_ROOT              | 41.53 MHz       |
++----------------------------+-----------------+
+| LPI2C_CLK_ROOT             | 10 MHz          |
++----------------------------+-----------------+
+| CAN_CLK_ROOT               | 40 MHz          |
++----------------------------+-----------------+
+| UART_CLK_ROOT              | 80 MHz          |
++----------------------------+-----------------+
+| LPSPI_CLK_ROOT             | 90 MHz          |
++----------------------------+-----------------+
+| TRACE_CLK_ROOT             | 99 MHz          |
++----------------------------+-----------------+
+| CKIL_SYNC_CLK_ROOT         | 32.768 kHz      |
++----------------------------+-----------------+
+| Clock 1M output            | 1 MHz           |
++----------------------------+-----------------+
+| Clock 24MHz output         | 24 MHz          |
++----------------------------+-----------------+
+| CLKO1_CLK                  | Inactive        |
++----------------------------+-----------------+
+| CLKO2_CLK                  | Inactive        |
++----------------------------+-----------------+
+| ENET_125M_CLK              | 50 MHz          |
++----------------------------+-----------------+
+| ENET2_125M_CLK             | Inactive        |
++----------------------------+-----------------+
+| ENET_25M_REF_CLK           | 25 MHz          |
++----------------------------+-----------------+
+| LVDS1_CLK                  | 1.2 GHz         |
++----------------------------+-----------------+
+| USB2 PLL clock             | 24 MHz          |
++----------------------------+-----------------+
+| USBPHY1 PLL clock          | 480 MHz         |
++----------------------------+-----------------+
+| USBPHY2 PLL clock          | Inactive        |
++----------------------------+-----------------+
+| GPT1 high frequency clock  | 75 MHz          |
++----------------------------+-----------------+
+| GPT2 high frequency clock  | 75 MHz          |
++----------------------------+-----------------+
+| SAI1 MCLK 1                | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI1 MCLK 2                | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI1 MCLK 3                | 30 MHz          |
++----------------------------+-----------------+
+| SAI2 MCLK 1                | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI2 MCLK 2                | Inactive        |
++----------------------------+-----------------+
+| SAI2 MCLK 3                | 30 MHz          |
++----------------------------+-----------------+
+| SAI3 MCLK 1                | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI3 MCLK 2                | Inactive        |
++----------------------------+-----------------+
+| SAI3 MCLK 3                | 30 MHz          |
++----------------------------+-----------------+
+| SPDIF0_EXTCLK              | Inactive        |
++----------------------------+-----------------+
+| MQS MCLK                   | 41.53 MHz       |
++----------------------------+-----------------+
+| ENET_TX_CLK                | Inactive        |
++----------------------------+-----------------+
+| ENET2_TX_CLK               | Inactive        |
++----------------------------+-----------------+
+| ENET_REF_CLK               | Inactive        |
++----------------------------+-----------------+
+| ENET2_REF_CLK              | Inactive        |
++----------------------------+-----------------+
+
 .. _MIMXRT1060-EVK Website:
    https://www.nxp.com/support/developer-resources/software-development-tools/mcuxpresso-software-and-tools/mimxrt1060-evk-i.mx-rt1060-evaluation-kit:MIMXRT1060-EVK
 

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.mex
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.mex
@@ -1,0 +1,1260 @@
+<?xml version="1.0" encoding= "UTF-8" ?>
+<configuration name="MIMXRT1062xxxxA" xsi:schemaLocation="http://mcuxpresso.nxp.com/XSD/mex_configuration_10 http://mcuxpresso.nxp.com/XSD/mex_configuration_10.xsd" uuid="de3bdbe5-65cf-482d-b1be-cd17b780459b" version="10" xmlns="http://mcuxpresso.nxp.com/XSD/mex_configuration_10" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+   <common>
+      <processor>MIMXRT1062xxxxA</processor>
+      <package>MIMXRT1062DVL6A</package>
+      <mcu_data>ksdk2_0</mcu_data>
+      <cores selected="core0">
+         <core name="Cortex-M7F" id="core0" description="M7 core"/>
+      </cores>
+      <description></description>
+   </common>
+   <preferences>
+      <validate_boot_init_only>true</validate_boot_init_only>
+      <generate_extended_information>false</generate_extended_information>
+      <generate_code_modified_registers_only>false</generate_code_modified_registers_only>
+      <update_include_paths>true</update_include_paths>
+   </preferences>
+   <tools>
+      <pins name="Pins" version="10.0" enabled="true" update_project_code="false">
+         <generated_project_files>
+            <file path="board/pin_mux.c" update_enabled="true"/>
+            <file path="board/pin_mux.h" update_enabled="true"/>
+         </generated_project_files>
+         <pins_profile>
+            <processor_version>10.0.0</processor_version>
+            <power_domains/>
+            <pin_labels>
+               <pin_label pin_num="M14" pin_signal="GPIO_AD_B0_00" label="LPI2C1_SCL" identifier="LPI2C1_SCL"/>
+               <pin_label pin_num="H10" pin_signal="GPIO_AD_B0_01" label="LPI2C1_SDA" identifier="LPI2C1_SDA"/>
+               <pin_label pin_num="M11" pin_signal="GPIO_AD_B0_02" label="LCD_RESET" identifier="LCD_RESET"/>
+               <pin_label pin_num="F14" pin_signal="GPIO_AD_B0_09" label="JTAG_TDI/J21[5]/ENET_RST/J22[5]" identifier="ENET_RST"/>
+               <pin_label pin_num="G10" pin_signal="GPIO_AD_B0_11" label="LCD_TOUCH_INT" identifier="INT2_COMBO"/>
+            </pin_labels>
+         </pins_profile>
+         <functions_list>
+            <function name="pinmux_ENET">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="ENET" description="Peripheral ENET is not initialized" problem_level="1" source="Pins:pinmux_ENET">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_ENET">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_ENET">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="ENET" signal="enet_rx_data, 0" pin_num="E12" pin_signal="GPIO_B1_04">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_rx_data, 1" pin_num="D12" pin_signal="GPIO_B1_05">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_rx_en" pin_num="C12" pin_signal="GPIO_B1_06">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_tx_data, 0" pin_num="B12" pin_signal="GPIO_B1_07">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_tx_data, 1" pin_num="A12" pin_signal="GPIO_B1_08">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_tx_en" pin_num="A13" pin_signal="GPIO_B1_09">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_ref_clk" pin_num="B13" pin_signal="GPIO_B1_10">
+                     <pin_features>
+                        <pin_feature name="software_input_on" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                        <pin_feature name="pull_keeper_enable" value="Disable"/>
+                        <pin_feature name="speed" value="MHZ_50"/>
+                        <pin_feature name="drive_strength" value="R0_6"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_rx_er" pin_num="C13" pin_signal="GPIO_B1_11">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_mdc" pin_num="A7" pin_signal="GPIO_EMC_40">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_mdio" pin_num="C7" pin_signal="GPIO_EMC_41">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="GPIO1" signal="gpio_io, 10" pin_num="G13" pin_signal="GPIO_AD_B0_10">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="speed" value="MHZ_100"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_ENET_RST">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_ENET_RST">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_ENET_RST">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="GPIO1" signal="gpio_io, 09" pin_num="F14" pin_signal="GPIO_AD_B0_09">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="speed" value="MHZ_100"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_LPI2C1">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="LPI2C1" description="Peripheral LPI2C1 is not initialized" problem_level="1" source="Pins:pinmux_LPI2C1">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_LPI2C1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_LPI2C1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="LPI2C1" signal="SDA" pin_num="K11" pin_signal="GPIO_AD_B1_01">
+                     <pin_features>
+                        <pin_feature name="software_input_on" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_22K_Ohm"/>
+                        <pin_feature name="open_drain" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LPI2C1" signal="SCL" pin_num="J11" pin_signal="GPIO_AD_B1_00">
+                     <pin_features>
+                        <pin_feature name="software_input_on" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_22K_Ohm"/>
+                        <pin_feature name="open_drain" value="Enable"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_LCDIF">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="LCDIF" description="Peripheral LCDIF is not initialized" problem_level="1" source="Pins:pinmux_LCDIF">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_LCDIF">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_LCDIF">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="LCDIF" signal="lcdif_clk" pin_num="D7" pin_signal="GPIO_B0_00">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_enable" pin_num="E7" pin_signal="GPIO_B0_01">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_hsync" pin_num="E8" pin_signal="GPIO_B0_02">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_vsync" pin_num="D8" pin_signal="GPIO_B0_03">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 00" pin_num="C8" pin_signal="GPIO_B0_04">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 01" pin_num="B8" pin_signal="GPIO_B0_05">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 02" pin_num="A8" pin_signal="GPIO_B0_06">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 03" pin_num="A9" pin_signal="GPIO_B0_07">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 04" pin_num="B9" pin_signal="GPIO_B0_08">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 05" pin_num="C9" pin_signal="GPIO_B0_09">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 06" pin_num="D9" pin_signal="GPIO_B0_10">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 07" pin_num="A10" pin_signal="GPIO_B0_11">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 08" pin_num="C10" pin_signal="GPIO_B0_12">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 09" pin_num="D10" pin_signal="GPIO_B0_13">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 10" pin_num="E10" pin_signal="GPIO_B0_14">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 11" pin_num="E11" pin_signal="GPIO_B0_15">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 12" pin_num="A11" pin_signal="GPIO_B1_00">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 13" pin_num="B11" pin_signal="GPIO_B1_01">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 14" pin_num="C11" pin_signal="GPIO_B1_02">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 15" pin_num="D11" pin_signal="GPIO_B1_03">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="GPIO1" signal="gpio_io, 02" pin_num="M11" pin_signal="GPIO_AD_B0_02"/>
+                  <pin peripheral="GPIO2" signal="gpio_io, 31" pin_num="B14" pin_signal="GPIO_B1_15"/>
+               </pins>
+            </function>
+            <function name="pinmux_LPUART1">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="LPUART1" description="Peripheral LPUART1 is not initialized" problem_level="1" source="Pins:pinmux_LPUART1">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_LPUART1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_LPUART1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="LPUART1" signal="RX" pin_num="L14" pin_signal="GPIO_AD_B0_13">
+                     <pin_features>
+                        <pin_feature name="software_input_on" value="Disable"/>
+                        <pin_feature name="hysteresis_enable" value="Disable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                        <pin_feature name="pull_keeper_enable" value="Enable"/>
+                        <pin_feature name="open_drain" value="Disable"/>
+                        <pin_feature name="speed" value="MHZ_100"/>
+                        <pin_feature name="drive_strength" value="R0_6"/>
+                        <pin_feature name="slew_rate" value="Slow"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LPUART1" signal="TX" pin_num="K14" pin_signal="GPIO_AD_B0_12">
+                     <pin_features>
+                        <pin_feature name="software_input_on" value="Disable"/>
+                        <pin_feature name="hysteresis_enable" value="Disable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                        <pin_feature name="pull_keeper_enable" value="Enable"/>
+                        <pin_feature name="open_drain" value="Disable"/>
+                        <pin_feature name="speed" value="MHZ_100"/>
+                        <pin_feature name="drive_strength" value="R0_6"/>
+                        <pin_feature name="slew_rate" value="Slow"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_FT5336_int">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_FT5336_int">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_FT5336_int">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="GPIO1" signal="gpio_io, 11" pin_num="G10" pin_signal="GPIO_AD_B0_11">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                        <pin_feature name="drive_strength" value="R0_6"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_FlexSPIA">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="FLEXSPI" description="Peripheral FLEXSPI is not initialized" problem_level="1" source="Pins:pinmux_FlexSPIA">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_FlexSPIA">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_FlexSPIA">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_DQS" pin_num="N3" pin_signal="GPIO_SD_B1_05">
+                     <pin_features>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_SS0_B" pin_num="L3" pin_signal="GPIO_SD_B1_06">
+                     <pin_features>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_SCLK" pin_num="L4" pin_signal="GPIO_SD_B1_07">
+                     <pin_features>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_DATA0" pin_num="P3" pin_signal="GPIO_SD_B1_08">
+                     <pin_features>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_DATA1" pin_num="N4" pin_signal="GPIO_SD_B1_09">
+                     <pin_features>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_DATA2" pin_num="P4" pin_signal="GPIO_SD_B1_10">
+                     <pin_features>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_DATA3" pin_num="P5" pin_signal="GPIO_SD_B1_11">
+                     <pin_features>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_FlexCAN3">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="CAN3" description="Peripheral CAN3 is not initialized" problem_level="1" source="Pins:pinmux_FlexCAN3">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_FlexCAN3">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_FlexCAN3">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="CAN3" signal="TX" pin_num="C3" pin_signal="GPIO_EMC_36"/>
+                  <pin peripheral="CAN3" signal="RX" pin_num="E4" pin_signal="GPIO_EMC_37"/>
+               </pins>
+            </function>
+            <function name="pinmux_FlexCAN2">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="CAN2" description="Peripheral CAN2 is not initialized" problem_level="1" source="Pins:pinmux_FlexCAN2">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_FlexCAN2">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_FlexCAN2">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="CAN2" signal="TX" pin_num="H14" pin_signal="GPIO_AD_B0_14"/>
+                  <pin peripheral="CAN2" signal="RX" pin_num="L10" pin_signal="GPIO_AD_B0_15"/>
+               </pins>
+            </function>
+            <function name="pinmux_FlexCAN1">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="CAN1" description="Peripheral CAN1 is not initialized" problem_level="1" source="Pins:pinmux_FlexCAN1">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_FlexCAN1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_FlexCAN1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="CAN1" signal="TX" pin_num="H13" pin_signal="GPIO_AD_B1_08"/>
+                  <pin peripheral="CAN1" signal="RX" pin_num="M13" pin_signal="GPIO_AD_B1_09"/>
+               </pins>
+            </function>
+            <function name="pinmux_CSI">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="CSI" description="Peripheral CSI is not initialized" problem_level="1" source="Pins:pinmux_CSI">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_CSI">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_CSI">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="GPIO1" signal="gpio_io, 04" pin_num="F11" pin_signal="GPIO_AD_B0_04"/>
+                  <pin peripheral="CSI" signal="csi_pixclk" pin_num="L12" pin_signal="GPIO_AD_B1_04"/>
+                  <pin peripheral="CSI" signal="csi_mclk" pin_num="K12" pin_signal="GPIO_AD_B1_05"/>
+                  <pin peripheral="CSI" signal="csi_vsync" pin_num="J12" pin_signal="GPIO_AD_B1_06"/>
+                  <pin peripheral="CSI" signal="csi_hsync" pin_num="K10" pin_signal="GPIO_AD_B1_07"/>
+                  <pin peripheral="CSI" signal="csi_data, 09" pin_num="H13" pin_signal="GPIO_AD_B1_08"/>
+                  <pin peripheral="CSI" signal="csi_data, 08" pin_num="M13" pin_signal="GPIO_AD_B1_09"/>
+                  <pin peripheral="CSI" signal="csi_data, 07" pin_num="L13" pin_signal="GPIO_AD_B1_10"/>
+                  <pin peripheral="CSI" signal="csi_data, 06" pin_num="J13" pin_signal="GPIO_AD_B1_11"/>
+                  <pin peripheral="CSI" signal="csi_data, 05" pin_num="H12" pin_signal="GPIO_AD_B1_12"/>
+                  <pin peripheral="CSI" signal="csi_data, 04" pin_num="H11" pin_signal="GPIO_AD_B1_13"/>
+                  <pin peripheral="CSI" signal="csi_data, 03" pin_num="G12" pin_signal="GPIO_AD_B1_14"/>
+                  <pin peripheral="CSI" signal="csi_data, 02" pin_num="J14" pin_signal="GPIO_AD_B1_15"/>
+               </pins>
+            </function>
+            <function name="pinmux_FlexPWM2_pwm3">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="PWM2" description="Peripheral PWM2 is not initialized" problem_level="1" source="Pins:pinmux_FlexPWM2_pwm3">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_FlexPWM2_pwm3">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_FlexPWM2_pwm3">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="PWM2" signal="A, 3" pin_num="F14" pin_signal="GPIO_AD_B0_09"/>
+               </pins>
+            </function>
+            <function name="pinmux_LPUART3">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="LPUART3" description="Peripheral LPUART3 is not initialized" problem_level="1" source="Pins:pinmux_LPUART3">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_LPUART3">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_LPUART3">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="LPUART3" signal="TX" pin_num="J12" pin_signal="GPIO_AD_B1_06"/>
+                  <pin peripheral="LPUART3" signal="RX" pin_num="K10" pin_signal="GPIO_AD_B1_07"/>
+               </pins>
+            </function>
+            <function name="pinmux_USER_LED_SW0">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_USER_LED_SW0">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_USER_LED_SW0">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="GPIO1" signal="gpio_io, 09" pin_num="F14" pin_signal="GPIO_AD_B0_09">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                        <pin_feature name="drive_strength" value="R0_6"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="GPIO5" signal="gpio_io, 00" pin_num="L6" pin_signal="WAKEUP"/>
+               </pins>
+            </function>
+            <function name="pinmux_SDHC1">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="USDHC1" description="Peripheral USDHC1 is not initialized" problem_level="1" source="Pins:pinmux_SDHC1">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_SDHC1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_SDHC1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="GPIO1" signal="gpio_io, 05" pin_num="G14" pin_signal="GPIO_AD_B0_05">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="GPIO2" signal="gpio_io, 28" pin_num="D13" pin_signal="GPIO_B1_12">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="drive_strength" value="R0"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_vselect" pin_num="C14" pin_signal="GPIO_B1_14">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="drive_strength" value="R0_4"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_cmd" pin_num="J4" pin_signal="GPIO_SD_B0_00">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="speed" value="MHZ_100"/>
+                        <pin_feature name="drive_strength" value="R0"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_clk" pin_num="J3" pin_signal="GPIO_SD_B0_01">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                        <pin_feature name="drive_strength" value="R0"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_data, 0" pin_num="J1" pin_signal="GPIO_SD_B0_02">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="drive_strength" value="R0"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_data, 1" pin_num="K1" pin_signal="GPIO_SD_B0_03">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="drive_strength" value="R0"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_data, 2" pin_num="H2" pin_signal="GPIO_SD_B0_04">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="drive_strength" value="R0"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_data, 3" pin_num="J2" pin_signal="GPIO_SD_B0_05">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="drive_strength" value="R0"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+         </functions_list>
+      </pins>
+      <clocks name="Clocks" version="8.0" enabled="true" update_project_code="true">
+         <generated_project_files>
+            <file path="board/clock_config.c" update_enabled="true"/>
+            <file path="board/clock_config.h" update_enabled="true"/>
+         </generated_project_files>
+         <clocks_profile>
+            <processor_version>10.0.0</processor_version>
+         </clocks_profile>
+         <clock_configurations>
+            <clock_configuration name="clock_init">
+               <description></description>
+               <options/>
+               <dependencies>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.rtc_xtali" description="&apos;RTC_XTALI&apos; (Pins tool id: XTALOSC24M.rtc_xtali, Clocks tool id: XTALOSC24M.RTC_XTALI) needs to be routed" problem_level="1" source="Clocks:clock_init">
+                     <feature name="routed" evaluation="">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.rtc_xtali" description="&apos;RTC_XTALI&apos; (Pins tool id: XTALOSC24M.rtc_xtali, Clocks tool id: XTALOSC24M.RTC_XTALI) needs to have &apos;INPUT&apos; direction" problem_level="1" source="Clocks:clock_init">
+                     <feature name="direction" evaluation="">
+                        <data>INPUT</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.rtc_xtalo" description="&apos;RTC_XTALO&apos; (Pins tool id: XTALOSC24M.rtc_xtalo, Clocks tool id: XTALOSC24M.RTC_XTALO) needs to be routed" problem_level="1" source="Clocks:clock_init">
+                     <feature name="routed" evaluation="">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.rtc_xtalo" description="&apos;RTC_XTALO&apos; (Pins tool id: XTALOSC24M.rtc_xtalo, Clocks tool id: XTALOSC24M.RTC_XTALO) needs to have &apos;OUTPUT&apos; direction" problem_level="1" source="Clocks:clock_init">
+                     <feature name="direction" evaluation="">
+                        <data>OUTPUT</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.xtali" description="&apos;XTALI&apos; (Pins tool id: XTALOSC24M.xtali, Clocks tool id: XTALOSC24M.XTALI) needs to be routed" problem_level="1" source="Clocks:clock_init">
+                     <feature name="routed" evaluation="">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.xtali" description="&apos;XTALI&apos; (Pins tool id: XTALOSC24M.xtali, Clocks tool id: XTALOSC24M.XTALI) needs to have &apos;INPUT&apos; direction" problem_level="1" source="Clocks:clock_init">
+                     <feature name="direction" evaluation="">
+                        <data>INPUT</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.xtalo" description="&apos;XTALO&apos; (Pins tool id: XTALOSC24M.xtalo, Clocks tool id: XTALOSC24M.XTALO) needs to be routed" problem_level="1" source="Clocks:clock_init">
+                     <feature name="routed" evaluation="">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.xtalo" description="&apos;XTALO&apos; (Pins tool id: XTALOSC24M.xtalo, Clocks tool id: XTALOSC24M.XTALO) needs to have &apos;OUTPUT&apos; direction" problem_level="1" source="Clocks:clock_init">
+                     <feature name="direction" evaluation="">
+                        <data>OUTPUT</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Clocks initialization requires the COMMON Driver in the project." problem_level="2" source="Clocks:clock_init">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Clocks initialization requires the IOMUXC Driver in the project." problem_level="2" source="Clocks:clock_init">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <clock_sources>
+                  <clock_source id="XTALOSC24M.RTC_OSC.outFreq" value="32.768 kHz" locked="false" enabled="true"/>
+               </clock_sources>
+               <clock_outputs>
+                  <clock_output id="AHB_CLK_ROOT.outFreq" value="600 MHz" locked="false" accuracy=""/>
+                  <clock_output id="CAN_CLK_ROOT.outFreq" value="40 MHz" locked="false" accuracy=""/>
+                  <clock_output id="CKIL_SYNC_CLK_ROOT.outFreq" value="32.768 kHz" locked="false" accuracy=""/>
+                  <clock_output id="CLK_1M.outFreq" value="1 MHz" locked="false" accuracy=""/>
+                  <clock_output id="CLK_24M.outFreq" value="24 MHz" locked="false" accuracy=""/>
+                  <clock_output id="CSI_CLK_ROOT.outFreq" value="24 MHz" locked="false" accuracy=""/>
+                  <clock_output id="ENET_125M_CLK.outFreq" value="50 MHz" locked="false" accuracy=""/>
+                  <clock_output id="ENET_25M_REF_CLK.outFreq" value="25 MHz" locked="false" accuracy=""/>
+                  <clock_output id="FLEXIO1_CLK_ROOT.outFreq" value="30 MHz" locked="false" accuracy=""/>
+                  <clock_output id="FLEXIO2_CLK_ROOT.outFreq" value="30 MHz" locked="false" accuracy=""/>
+                  <clock_output id="FLEXSPI2_CLK_ROOT.outFreq" value="720/7 MHz" locked="false" accuracy=""/>
+                  <clock_output id="FLEXSPI_CLK_ROOT.outFreq" value="90 MHz" locked="false" accuracy=""/>
+                  <clock_output id="GPT1_ipg_clk_highfreq.outFreq" value="75 MHz" locked="false" accuracy=""/>
+                  <clock_output id="GPT2_ipg_clk_highfreq.outFreq" value="75 MHz" locked="false" accuracy=""/>
+                  <clock_output id="IPG_CLK_ROOT.outFreq" value="150 MHz" locked="false" accuracy=""/>
+                  <clock_output id="LCDIF_CLK_ROOT.outFreq" value="9.3 MHz" locked="false" accuracy=""/>
+                  <clock_output id="LPI2C_CLK_ROOT.outFreq" value="10 MHz" locked="false" accuracy=""/>
+                  <clock_output id="LPSPI_CLK_ROOT.outFreq" value="90 MHz" locked="false" accuracy=""/>
+                  <clock_output id="LVDS1_CLK.outFreq" value="1.2 GHz" locked="false" accuracy=""/>
+                  <clock_output id="MQS_MCLK.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="PERCLK_CLK_ROOT.outFreq" value="75 MHz" locked="false" accuracy=""/>
+                  <clock_output id="PLL7_MAIN_CLK.outFreq" value="24 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI1_CLK_ROOT.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI1_MCLK1.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI1_MCLK2.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI1_MCLK3.outFreq" value="30 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI2_CLK_ROOT.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI2_MCLK1.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI2_MCLK3.outFreq" value="30 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI3_CLK_ROOT.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI3_MCLK1.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI3_MCLK3.outFreq" value="30 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SEMC_CLK_ROOT.outFreq" value="4752/29 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SPDIF0_CLK_ROOT.outFreq" value="30 MHz" locked="false" accuracy=""/>
+                  <clock_output id="TRACE_CLK_ROOT.outFreq" value="99 MHz" locked="false" accuracy=""/>
+                  <clock_output id="UART_CLK_ROOT.outFreq" value="80 MHz" locked="false" accuracy=""/>
+                  <clock_output id="USBPHY1_CLK.outFreq" value="480 MHz" locked="false" accuracy=""/>
+                  <clock_output id="USDHC1_CLK_ROOT.outFreq" value="198 MHz" locked="false" accuracy=""/>
+                  <clock_output id="USDHC2_CLK_ROOT.outFreq" value="198 MHz" locked="false" accuracy=""/>
+               </clock_outputs>
+               <clock_settings>
+                  <setting id="CCM.AHB_PODF.scale" value="1" locked="true"/>
+                  <setting id="CCM.ARM_PODF.scale" value="2" locked="true"/>
+                  <setting id="CCM.CLKO2_DIV.scale" value="1" locked="true"/>
+                  <setting id="CCM.CLKO2_SEL.sel" value="XTALOSC24M.OSC_CLK" locked="false"/>
+                  <setting id="CCM.CSI_PODF.scale" value="1" locked="true"/>
+                  <setting id="CCM.FLEXSPI2_PODF.scale" value="7" locked="true"/>
+                  <setting id="CCM.FLEXSPI2_SEL.sel" value="CCM_ANALOG.PLL3_PFD0_CLK" locked="false"/>
+                  <setting id="CCM.FLEXSPI_PODF.scale" value="8" locked="true"/>
+                  <setting id="CCM.FLEXSPI_SEL.sel" value="CCM_ANALOG.PLL3_PFD0_CLK" locked="false"/>
+                  <setting id="CCM.LCDIF_PODF.scale" value="2" locked="true"/>
+                  <setting id="CCM.LCDIF_PRED.scale" value="5" locked="true"/>
+                  <setting id="CCM.LCDIF_PRE_CLK_SEL.sel" value="CCM_ANALOG.PLL5_MAIN_CLK" locked="false"/>
+                  <setting id="CCM.LPI2C_CLK_PODF.scale" value="6" locked="true"/>
+                  <setting id="CCM.LPSPI_CLK_SEL.sel" value="CCM_ANALOG.PLL3_PFD0_CLK" locked="false"/>
+                  <setting id="CCM.LPSPI_PODF.scale" value="8" locked="true"/>
+                  <setting id="CCM.PERCLK_PODF.scale" value="2" locked="true"/>
+                  <setting id="CCM.PERIPH_CLK2_SEL.sel" value="XTALOSC24M.OSC_CLK" locked="false"/>
+                  <setting id="CCM.SAI2_CLK_PRED.scale" value="4" locked="true"/>
+                  <setting id="CCM.SEMC_CLK_SEL.sel" value="CCM.SEMC_ALT_CLK_SEL" locked="false"/>
+                  <setting id="CCM.SEMC_PODF.scale" value="2" locked="true"/>
+                  <setting id="CCM.TRACE_PODF.scale" value="4" locked="true"/>
+                  <setting id="CCM.USDHC1_CLK_SEL.sel" value="CCM_ANALOG.PLL2_PFD0_CLK" locked="false"/>
+                  <setting id="CCM.USDHC1_PODF.scale" value="2" locked="true"/>
+                  <setting id="CCM.USDHC2_CLK_SEL.sel" value="CCM_ANALOG.PLL2_PFD0_CLK" locked="false"/>
+                  <setting id="CCM.USDHC2_PODF.scale" value="2" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL1_BYPASS.sel" value="CCM_ANALOG.PLL1" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL1_PREDIV.scale" value="1" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL1_VDIV.scale" value="50" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2.denom" value="1" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2.num" value="0" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_BYPASS.sel" value="CCM_ANALOG.PLL2_OUT_CLK" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD0_BYPASS.sel" value="CCM_ANALOG.PLL2_PFD0" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD0_DIV.scale" value="24" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD0_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD1_BYPASS.sel" value="CCM_ANALOG.PLL2_PFD1" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD2_BYPASS.sel" value="CCM_ANALOG.PLL2_PFD2" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD2_DIV.scale" value="29" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD2_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD3_BYPASS.sel" value="CCM_ANALOG.PLL2_PFD3" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD3_DIV.scale" value="35" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD3_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_BYPASS.sel" value="CCM_ANALOG.PLL3" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD0_BYPASS.sel" value="CCM_ANALOG.PLL3_PFD0" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD0_DIV.scale" value="12" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD0_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD1_BYPASS.sel" value="CCM_ANALOG.PLL3_PFD1" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD1_DIV.scale" value="35" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD1_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD2_BYPASS.sel" value="CCM_ANALOG.PLL3_PFD2" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD2_DIV.scale" value="26" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD2_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD3_BYPASS.sel" value="CCM_ANALOG.PLL3_PFD3" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD3_DIV.scale" value="31" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD3_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL4.denom" value="50" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL4.div" value="27" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL4_POST_DIV.scale" value="4" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL5.denom" value="1" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL5.div" value="31" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL5.num" value="0" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL5_BYPASS.sel" value="CCM_ANALOG.PLL5_POST_DIV" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL5_POST_DIV.scale" value="2" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL6_BYPASS.sel" value="CCM_ANALOG.PLL6" locked="false"/>
+                  <setting id="CCM_ANALOG.VIDEO_DIV.scale" value="4" locked="true"/>
+                  <setting id="CCM_ANALOG_PLL_ENET_ENET2_REF_EN_CFG" value="Disabled" locked="false"/>
+                  <setting id="CCM_ANALOG_PLL_USB1_EN_USB_CLKS_CFG" value="Enabled" locked="false"/>
+                  <setting id="CCM_ANALOG_PLL_USB1_EN_USB_CLKS_OUT_CFG" value="Enabled" locked="false"/>
+                  <setting id="CCM_ANALOG_PLL_USB1_POWER_CFG" value="Yes" locked="false"/>
+                  <setting id="CCM_ANALOG_PLL_VIDEO_POWERDOWN_CFG" value="No" locked="false"/>
+               </clock_settings>
+               <called_from_default_init>true</called_from_default_init>
+            </clock_configuration>
+         </clock_configurations>
+      </clocks>
+      <dcdx name="DCDx" version="3.0" enabled="true" update_project_code="false">
+         <generated_project_files>
+            <file path="board/dcd.c" update_enabled="true"/>
+            <file path="board/dcd.h" update_enabled="true"/>
+         </generated_project_files>
+         <dcdx_profile>
+            <processor_version>10.0.0</processor_version>
+            <output_format>c_array</output_format>
+         </dcdx_profile>
+         <dcdx_configurations>
+            <dcdx_configuration name="Device_configuration">
+               <description></description>
+               <options/>
+               <command_groups>
+                  <command_group name="Imported Commands" enabled="true">
+                     <commands>
+                        <command type="write_value" address="CCM_CCGR0" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR1" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR2" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR3" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR4" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR5" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR6" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_ANALOG_PLL_SYS" value="0x2001" value_width="4"/>
+                        <command type="write_value" address="CCM_ANALOG_PFD_528" value="0x1D0000" value_width="4"/>
+                        <command type="write_value" address="CCM_CBCDR" value="0x10D40" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_00" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_01" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_02" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_03" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_04" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_05" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_06" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_07" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_08" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_09" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_10" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_11" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_12" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_13" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_14" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_15" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_16" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_17" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_18" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_19" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_20" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_21" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_22" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_23" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_24" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_25" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_26" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_27" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_28" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_29" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_30" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_31" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_32" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_33" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_34" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_35" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_36" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_37" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_38" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_39" value="0x10" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_00" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_01" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_02" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_03" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_04" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_05" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_06" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_07" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_08" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_09" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_10" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_11" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_12" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_13" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_14" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_15" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_16" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_17" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_18" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_19" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_20" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_21" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_22" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_23" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_24" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_25" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_26" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_27" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_28" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_29" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_30" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_31" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_32" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_33" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_34" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_35" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_36" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_37" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_38" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_39" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="SEMC_MCR" value="0x10000004" value_width="4"/>
+                        <command type="write_value" address="SEMC_BMCR0" value="0x81" value_width="4"/>
+                        <command type="write_value" address="SEMC_BMCR1" value="0x81" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR0" value="0x8000001B" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR1" value="0x8200001B" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR2" value="0x8400001B" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR3" value="0x8600001B" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR4" value="0x90000021" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR5" value="0xA0000019" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR6" value="0xA8000017" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR7" value="0xA900001B" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR8" value="0x21" value_width="4"/>
+                        <command type="write_value" address="SEMC_IOCR" value="0x79A8" value_width="4"/>
+                        <command type="write_value" address="SEMC_SDRAMCR0" value="0xF31" value_width="4"/>
+                        <command type="write_value" address="SEMC_SDRAMCR1" value="0x652922" value_width="4"/>
+                        <command type="write_value" address="SEMC_SDRAMCR2" value="0x10920" value_width="4"/>
+                        <command type="write_value" address="SEMC_SDRAMCR3" value="0x50210A08" value_width="4"/>
+                        <command type="write_value" address="SEMC_DBICR0" value="0x21" value_width="4"/>
+                        <command type="write_value" address="SEMC_DBICR1" value="0x888888" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR1" value="0x02" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR2" value="0x00" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR0" value="0x80000000" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCMD" value="0xA55A000F" value_width="4"/>
+                        <command type="check_any_bit_set" address="SEMC_INTR" value="0x01" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR0" value="0x80000000" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCMD" value="0xA55A000C" value_width="4"/>
+                        <command type="check_any_bit_set" address="SEMC_INTR" value="0x01" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR0" value="0x80000000" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCMD" value="0xA55A000C" value_width="4"/>
+                        <command type="check_any_bit_set" address="SEMC_INTR" value="0x01" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPTXDAT" value="0x33" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR0" value="0x80000000" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCMD" value="0xA55A000A" value_width="4"/>
+                        <command type="check_any_bit_set" address="SEMC_INTR" value="0x01" value_width="4"/>
+                        <command type="write_value" address="SEMC_SDRAMCR3" value="0x50210A09" value_width="4"/>
+                     </commands>
+                  </command_group>
+               </command_groups>
+            </dcdx_configuration>
+         </dcdx_configurations>
+      </dcdx>
+      <periphs name="Peripherals" version="10.0" enabled="true" update_project_code="false">
+         <generated_project_files>
+            <file path="board/peripherals.c" update_enabled="true"/>
+            <file path="board/peripherals.h" update_enabled="true"/>
+         </generated_project_files>
+         <peripherals_profile>
+            <processor_version>10.0.0</processor_version>
+         </peripherals_profile>
+         <functional_groups>
+            <functional_group name="BOARD_InitPeripherals" uuid="1c6563a6-c68b-40e5-8828-2853c99f95fa" called_from_default_init="true" id_prefix="BOARD_" core="core0">
+               <description></description>
+               <options/>
+               <dependencies/>
+               <instances>
+                  <instance name="NVIC" uuid="2c253e89-508d-4544-9d44-c226931d8f3f" type="nvic" type_id="nvic_57b5eef3774cc60acaede6f5b8bddc67" mode="general" peripheral="NVIC" enabled="true" comment="" custom_name_enabled="false" editing_lock="false">
+                     <config_set name="nvic">
+                        <array name="interrupt_table"/>
+                        <array name="interrupts"/>
+                     </config_set>
+                  </instance>
+               </instances>
+            </functional_group>
+         </functional_groups>
+         <components>
+            <component name="system" uuid="18e298ee-cc10-47f7-b950-440409a94f94" type_id="system_54b53072540eeeb8f8e9343e71f28176">
+               <config_set_global name="global_system_definitions">
+                  <setting name="user_definitions" value=""/>
+                  <setting name="user_includes" value=""/>
+               </config_set_global>
+            </component>
+            <component name="msg" uuid="078a031a-1304-48e4-934c-de6b7bd41d37" type_id="msg_6e2baaf3b97dbeef01c0043275f9a0e7">
+               <config_set_global name="global_messages"/>
+            </component>
+            <component name="generic_uart" uuid="0e122da2-c994-4d5a-a7b8-5a63103fc1d2" type_id="generic_uart_8cae00565451cf2346eb1b8c624e73a6">
+               <config_set_global name="global_uart"/>
+            </component>
+            <component name="generic_can" uuid="51762fc1-cf05-4bb3-a3ca-5da5c50ea072" type_id="generic_can_1bfdd78b1af214566c1f23cf6a582d80">
+               <config_set_global name="global_can"/>
+            </component>
+            <component name="uart_cmsis_common" uuid="d4182366-28a3-4b72-9e22-d29aa447729c" type_id="uart_cmsis_common_9cb8e302497aa696fdbb5a4fd622c2a8">
+               <config_set_global name="global_USART_CMSIS_common" quick_selection="default"/>
+            </component>
+            <component name="generic_enet" uuid="c9d3d8ac-0dc9-40de-aea5-dd11df3d996b" type_id="generic_enet_74db5c914f0ddbe47d86af40cb77a619">
+               <config_set_global name="global_enet"/>
+            </component>
+         </components>
+      </periphs>
+      <tee name="TEE" version="2.0" enabled="false" update_project_code="true">
+         <generated_project_files/>
+         <tee_profile>
+            <processor_version>N/A</processor_version>
+         </tee_profile>
+      </tee>
+   </tools>
+</configuration>

--- a/boards/arm/mimxrt1064_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1064_evk/CMakeLists.txt
@@ -5,7 +5,8 @@
 #
 
 zephyr_library()
-zephyr_library_sources(pinmux.c)
+zephyr_library_sources(pinmux.c clock_config.c)
+zephyr_include_directories(.)
 
 if (CONFIG_DISPLAY)
 message(WARNING "

--- a/boards/arm/mimxrt1064_evk/clock_config.c
+++ b/boards/arm/mimxrt1064_evk/clock_config.c
@@ -1,0 +1,576 @@
+/*
+ * Copyright (c) 2021, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * How to setup clock using clock driver functions:
+ *
+ * 1. Call CLOCK_InitXXXPLL() to configure corresponding PLL clock.
+ *
+ * 2. Call CLOCK_InitXXXpfd() to configure corresponding PLL pfd clock.
+ *
+ * 3. Call CLOCK_SetMux() to configure corresponding clock source for target clock out.
+ *
+ * 4. Call CLOCK_SetDiv() to configure corresponding clock divider for target clock out.
+ *
+ * 5. Call CLOCK_SetXtalFreq() to set XTAL frequency based on board settings.
+ *
+ */
+
+/* TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
+ * !!GlobalInfo
+ * product: Clocks v8.0
+ * processor: MIMXRT1064xxxxA
+ * package_id: MIMXRT1064DVL6A
+ * mcu_data: ksdk2_0
+ * processor_version: 10.0.0
+ * board: MIMXRT1064-EVK
+ * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS **********/
+
+#include "clock_config.h"
+#include "fsl_iomuxc.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+/* System clock frequency. */
+extern uint32_t SystemCoreClock;
+
+/*******************************************************************************
+ ************************ BOARD_InitBootClocks function ************************
+ ******************************************************************************/
+void BOARD_InitBootClocks(void)
+{
+	clock_init();
+}
+
+/*******************************************************************************
+ ************************** Configuration clock_init ***************************
+ ******************************************************************************/
+/* TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
+ * !!Configuration
+ * name: clock_init
+ * called_from_default_init: true
+ * outputs:
+ * - {id: AHB_CLK_ROOT.outFreq, value: 600 MHz}
+ * - {id: CAN_CLK_ROOT.outFreq, value: 40 MHz}
+ * - {id: CKIL_SYNC_CLK_ROOT.outFreq, value: 32.768 kHz}
+ * - {id: CLK_1M.outFreq, value: 1 MHz}
+ * - {id: CLK_24M.outFreq, value: 24 MHz}
+ * - {id: CSI_CLK_ROOT.outFreq, value: 24 MHz}
+ * - {id: ENET_125M_CLK.outFreq, value: 50 MHz}
+ * - {id: ENET_25M_REF_CLK.outFreq, value: 25 MHz}
+ * - {id: FLEXIO1_CLK_ROOT.outFreq, value: 30 MHz}
+ * - {id: FLEXIO2_CLK_ROOT.outFreq, value: 30 MHz}
+ * - {id: FLEXSPI2_CLK_ROOT.outFreq, value: 720/7 MHz}
+ * - {id: FLEXSPI_CLK_ROOT.outFreq, value: 90 MHz}
+ * - {id: GPT1_ipg_clk_highfreq.outFreq, value: 75 MHz}
+ * - {id: GPT2_ipg_clk_highfreq.outFreq, value: 75 MHz}
+ * - {id: IPG_CLK_ROOT.outFreq, value: 150 MHz}
+ * - {id: LCDIF_CLK_ROOT.outFreq, value: 9.3 MHz}
+ * - {id: LPI2C_CLK_ROOT.outFreq, value: 10 MHz}
+ * - {id: LPSPI_CLK_ROOT.outFreq, value: 90 MHz}
+ * - {id: LVDS1_CLK.outFreq, value: 1.2 GHz}
+ * - {id: MQS_MCLK.outFreq, value: 540/13 MHz}
+ * - {id: PERCLK_CLK_ROOT.outFreq, value: 75 MHz}
+ * - {id: PLL7_MAIN_CLK.outFreq, value: 24 MHz}
+ * - {id: SAI1_CLK_ROOT.outFreq, value: 540/13 MHz}
+ * - {id: SAI1_MCLK1.outFreq, value: 540/13 MHz}
+ * - {id: SAI1_MCLK2.outFreq, value: 540/13 MHz}
+ * - {id: SAI1_MCLK3.outFreq, value: 30 MHz}
+ * - {id: SAI2_CLK_ROOT.outFreq, value: 540/13 MHz}
+ * - {id: SAI2_MCLK1.outFreq, value: 540/13 MHz}
+ * - {id: SAI2_MCLK3.outFreq, value: 30 MHz}
+ * - {id: SAI3_CLK_ROOT.outFreq, value: 540/13 MHz}
+ * - {id: SAI3_MCLK1.outFreq, value: 540/13 MHz}
+ * - {id: SAI3_MCLK3.outFreq, value: 30 MHz}
+ * - {id: SEMC_CLK_ROOT.outFreq, value: 4752/29 MHz}
+ * - {id: SPDIF0_CLK_ROOT.outFreq, value: 30 MHz}
+ * - {id: TRACE_CLK_ROOT.outFreq, value: 99 MHz}
+ * - {id: UART_CLK_ROOT.outFreq, value: 80 MHz}
+ * - {id: USBPHY1_CLK.outFreq, value: 480 MHz}
+ * - {id: USDHC1_CLK_ROOT.outFreq, value: 198 MHz}
+ * - {id: USDHC2_CLK_ROOT.outFreq, value: 198 MHz}
+ * settings:
+ * - {id: CCM.AHB_PODF.scale, value: '1', locked: true}
+ * - {id: CCM.ARM_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.CLKO2_DIV.scale, value: '1', locked: true}
+ * - {id: CCM.CLKO2_SEL.sel, value: XTALOSC24M.OSC_CLK}
+ * - {id: CCM.CSI_PODF.scale, value: '1', locked: true}
+ * - {id: CCM.FLEXSPI2_PODF.scale, value: '7', locked: true}
+ * - {id: CCM.FLEXSPI2_SEL.sel, value: CCM_ANALOG.PLL3_PFD0_CLK}
+ * - {id: CCM.FLEXSPI_PODF.scale, value: '8', locked: true}
+ * - {id: CCM.FLEXSPI_SEL.sel, value: CCM_ANALOG.PLL3_PFD0_CLK}
+ * - {id: CCM.LCDIF_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.LCDIF_PRED.scale, value: '5', locked: true}
+ * - {id: CCM.LCDIF_PRE_CLK_SEL.sel, value: CCM_ANALOG.PLL5_MAIN_CLK}
+ * - {id: CCM.LPI2C_CLK_PODF.scale, value: '6', locked: true}
+ * - {id: CCM.LPSPI_CLK_SEL.sel, value: CCM_ANALOG.PLL3_PFD0_CLK}
+ * - {id: CCM.LPSPI_PODF.scale, value: '8', locked: true}
+ * - {id: CCM.PERCLK_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.PERIPH_CLK2_SEL.sel, value: XTALOSC24M.OSC_CLK}
+ * - {id: CCM.SAI2_CLK_PRED.scale, value: '4', locked: true}
+ * - {id: CCM.SEMC_CLK_SEL.sel, value: CCM.SEMC_ALT_CLK_SEL}
+ * - {id: CCM.SEMC_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.TRACE_PODF.scale, value: '4', locked: true}
+ * - {id: CCM.USDHC1_CLK_SEL.sel, value: CCM_ANALOG.PLL2_PFD0_CLK}
+ * - {id: CCM.USDHC1_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.USDHC2_CLK_SEL.sel, value: CCM_ANALOG.PLL2_PFD0_CLK}
+ * - {id: CCM.USDHC2_PODF.scale, value: '2', locked: true}
+ * - {id: CCM_ANALOG.PLL1_BYPASS.sel, value: CCM_ANALOG.PLL1}
+ * - {id: CCM_ANALOG.PLL1_PREDIV.scale, value: '1', locked: true}
+ * - {id: CCM_ANALOG.PLL1_VDIV.scale, value: '50', locked: true}
+ * - {id: CCM_ANALOG.PLL2.denom, value: '1', locked: true}
+ * - {id: CCM_ANALOG.PLL2.num, value: '0', locked: true}
+ * - {id: CCM_ANALOG.PLL2_BYPASS.sel, value: CCM_ANALOG.PLL2_OUT_CLK}
+ * - {id: CCM_ANALOG.PLL2_PFD0_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD0}
+ * - {id: CCM_ANALOG.PLL2_PFD0_DIV.scale, value: '24', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD0_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD1_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD1}
+ * - {id: CCM_ANALOG.PLL2_PFD2_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD2}
+ * - {id: CCM_ANALOG.PLL2_PFD2_DIV.scale, value: '29', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD2_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD3_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD3}
+ * - {id: CCM_ANALOG.PLL2_PFD3_DIV.scale, value: '35', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD3_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_BYPASS.sel, value: CCM_ANALOG.PLL3}
+ * - {id: CCM_ANALOG.PLL3_PFD0_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD0}
+ * - {id: CCM_ANALOG.PLL3_PFD0_DIV.scale, value: '12', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD0_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD1_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD1}
+ * - {id: CCM_ANALOG.PLL3_PFD1_DIV.scale, value: '35', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD1_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD2_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD2}
+ * - {id: CCM_ANALOG.PLL3_PFD2_DIV.scale, value: '26', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD2_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD3_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD3}
+ * - {id: CCM_ANALOG.PLL3_PFD3_DIV.scale, value: '31', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD3_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL4.denom, value: '50'}
+ * - {id: CCM_ANALOG.PLL4.div, value: '27', locked: true}
+ * - {id: CCM_ANALOG.PLL4_POST_DIV.scale, value: '4', locked: true}
+ * - {id: CCM_ANALOG.PLL5.denom, value: '1'}
+ * - {id: CCM_ANALOG.PLL5.div, value: '31', locked: true}
+ * - {id: CCM_ANALOG.PLL5.num, value: '0'}
+ * - {id: CCM_ANALOG.PLL5_BYPASS.sel, value: CCM_ANALOG.PLL5_POST_DIV}
+ * - {id: CCM_ANALOG.PLL5_POST_DIV.scale, value: '2', locked: true}
+ * - {id: CCM_ANALOG.PLL6_BYPASS.sel, value: CCM_ANALOG.PLL6}
+ * - {id: CCM_ANALOG.VIDEO_DIV.scale, value: '4', locked: true}
+ * - {id: CCM_ANALOG_PLL_ENET_ENET2_REF_EN_CFG, value: Disabled}
+ * - {id: CCM_ANALOG_PLL_USB1_EN_USB_CLKS_CFG, value: Enabled}
+ * - {id: CCM_ANALOG_PLL_USB1_EN_USB_CLKS_OUT_CFG, value: Enabled}
+ * - {id: CCM_ANALOG_PLL_USB1_POWER_CFG, value: 'Yes'}
+ * - {id: CCM_ANALOG_PLL_VIDEO_POWERDOWN_CFG, value: 'No'}
+ * sources:
+ * - {id: XTALOSC24M.RTC_OSC.outFreq, value: 32.768 kHz, enabled: true}
+ * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS **********/
+
+/*******************************************************************************
+ * Variables for clock_init configuration
+ ******************************************************************************/
+const clock_arm_pll_config_t armPllConfig_clock_init = {
+	/* PLL loop divider, Fout = Fin * 50 */
+	.loopDivider = 100,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+const clock_sys_pll_config_t sysPllConfig_clock_init = {
+	/* PLL loop divider, Fout = Fin * ( 20 + loopDivider*2 + numerator / denominator ) */
+	.loopDivider = 1,
+	/* 30 bit numerator of fractional loop divider */
+	.numerator = 0,
+	/* 30 bit denominator of fractional loop divider */
+	.denominator = 1,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+const clock_usb_pll_config_t usb1PllConfig_clock_init = {
+	/* PLL loop divider, Fout = Fin * 20 */
+	.loopDivider = 0,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+const clock_video_pll_config_t videoPllConfig_clock_init = {
+	/* PLL loop divider, Fout = Fin * ( loopDivider + numerator / denominator ) */
+	.loopDivider = 31,
+	/* Divider after PLL */
+	.postDivider = 8,
+	/*
+	 * 30 bit numerator of fractional loop divider,
+	 * Fout = Fin * ( loopDivider + numerator / denominator )
+	 */
+	.numerator = 0,
+	/*
+	 * 30 bit denominator of fractional loop divider,
+	 * Fout = Fin * ( loopDivider + numerator / denominator )
+	 */
+	.denominator = 1,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+const clock_enet_pll_config_t enetPllConfig_clock_init = {
+	/* Enable the PLL providing the ENET 125MHz reference clock */
+	.enableClkOutput = true,
+	/* Disable the PLL providing the ENET2 125MHz reference clock */
+	.enableClkOutput1 = false,
+	/* Enable the PLL providing the ENET 25MHz reference clock */
+	.enableClkOutput25M = true,
+	/* Set frequency of ethernet reference clock to 50 MHz */
+	.loopDivider = 1,
+	/* Set frequency of ethernet reference clock to 25 MHz */
+	.loopDivider1 = 0,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+/*******************************************************************************
+ * Code for clock_init configuration
+ ******************************************************************************/
+void clock_init(void)
+{
+	/* Init RTC OSC clock frequency. */
+	CLOCK_SetRtcXtalFreq(32768U);
+	/* Enable 1MHz clock output. */
+	XTALOSC24M->OSC_CONFIG2 |= XTALOSC24M_OSC_CONFIG2_ENABLE_1M_MASK;
+	/* Use free 1MHz clock output. */
+	XTALOSC24M->OSC_CONFIG2 &= ~XTALOSC24M_OSC_CONFIG2_MUX_1M_MASK;
+	/* Set XTAL 24MHz clock frequency. */
+	CLOCK_SetXtalFreq(24000000U);
+	/* Enable XTAL 24MHz clock source. */
+	CLOCK_InitExternalClk(0);
+	/* Enable internal RC. */
+	CLOCK_InitRcOsc24M();
+	/* Switch clock source to external OSC. */
+	CLOCK_SwitchOsc(kCLOCK_XtalOsc);
+	/* Set Oscillator ready counter value. */
+	CCM->CCR = (CCM->CCR & (~CCM_CCR_OSCNT_MASK)) | CCM_CCR_OSCNT(127);
+	/* Setting PeriphClk2Mux and PeriphMux to provide stable clock before PLLs are initialed */
+	CLOCK_SetMux(kCLOCK_PeriphClk2Mux, 1);  /* Set PERIPH_CLK2 MUX to OSC */
+	CLOCK_SetMux(kCLOCK_PeriphMux, 1);      /* Set PERIPH_CLK MUX to PERIPH_CLK2 */
+	/* Setting the VDD_SOC to 1.275V. It is necessary to config AHB to 600Mhz. */
+	DCDC->REG3 = (DCDC->REG3 & (~DCDC_REG3_TRG_MASK)) | DCDC_REG3_TRG(0x13);
+	/* Waiting for DCDC_STS_DC_OK bit is asserted */
+	while (DCDC_REG0_STS_DC_OK_MASK != (DCDC_REG0_STS_DC_OK_MASK & DCDC->REG0)) {
+	}
+	/* Set AHB_PODF. */
+	CLOCK_SetDiv(kCLOCK_AhbDiv, 0);
+	/* Disable IPG clock gate. */
+	CLOCK_DisableClock(kCLOCK_Adc1);
+	CLOCK_DisableClock(kCLOCK_Adc2);
+	CLOCK_DisableClock(kCLOCK_Xbar1);
+	CLOCK_DisableClock(kCLOCK_Xbar2);
+	CLOCK_DisableClock(kCLOCK_Xbar3);
+	/* Set IPG_PODF. */
+	CLOCK_SetDiv(kCLOCK_IpgDiv, 3);
+	/* Set ARM_PODF. */
+	CLOCK_SetDiv(kCLOCK_ArmDiv, 1);
+	/* Set PERIPH_CLK2_PODF. */
+	CLOCK_SetDiv(kCLOCK_PeriphClk2Div, 0);
+	/* Disable PERCLK clock gate. */
+	CLOCK_DisableClock(kCLOCK_Gpt1);
+	CLOCK_DisableClock(kCLOCK_Gpt1S);
+	CLOCK_DisableClock(kCLOCK_Gpt2);
+	CLOCK_DisableClock(kCLOCK_Gpt2S);
+	CLOCK_DisableClock(kCLOCK_Pit);
+	/* Set PERCLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_PerclkDiv, 1);
+	/* Disable USDHC1 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Usdhc1);
+	/* Set USDHC1_PODF. */
+	CLOCK_SetDiv(kCLOCK_Usdhc1Div, 1);
+	/* Set Usdhc1 clock source. */
+	CLOCK_SetMux(kCLOCK_Usdhc1Mux, 1);
+	/* Disable USDHC2 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Usdhc2);
+	/* Set USDHC2_PODF. */
+	CLOCK_SetDiv(kCLOCK_Usdhc2Div, 1);
+	/* Set Usdhc2 clock source. */
+	CLOCK_SetMux(kCLOCK_Usdhc2Mux, 1);
+	/*
+	 * In SDK projects, SDRAM (configured by SEMC) will be initialized in either debug script
+	 * or dcd. With this macro SKIP_SYSCLK_INIT, system pll (selected to be SEMC source clock
+	 * in SDK projects) will be left unchanged.
+	 * Note: If another clock source is selected for SEMC, user may want to avoid changing that
+	 * clock as well.
+	 */
+#ifndef SKIP_SYSCLK_INIT
+	/* Disable Semc clock gate. */
+	CLOCK_DisableClock(kCLOCK_Semc);
+	/* Set SEMC_PODF. */
+	CLOCK_SetDiv(kCLOCK_SemcDiv, 1);
+	/* Set Semc alt clock source. */
+	CLOCK_SetMux(kCLOCK_SemcAltMux, 0);
+	/* Set Semc clock source. */
+	CLOCK_SetMux(kCLOCK_SemcMux, 1);
+#endif
+	/* Disable Flexspi clock gate. */
+	CLOCK_DisableClock(kCLOCK_FlexSpi);
+	/* Set FLEXSPI_PODF. */
+	CLOCK_SetDiv(kCLOCK_FlexspiDiv, 7);
+	/* Set Flexspi clock source. */
+	CLOCK_SetMux(kCLOCK_FlexspiMux, 3);
+	/*
+	 * In SDK projects, external flash (configured by FLEXSPI2) will be initialized by dcd.
+	 * With this macro XIP_EXTERNAL_FLASH, usb1 pll (selected to be FLEXSPI2 clock source in
+	 * SDK projects) will be left unchanged.
+	 * Note: If another clock source is selected for FLEXSPI2, user may want to avoid changing
+	 * that clock as well.
+	 */
+#if !(defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1))
+	/* Disable Flexspi2 clock gate. */
+	CLOCK_DisableClock(kCLOCK_FlexSpi2);
+	/* Set FLEXSPI2_PODF. */
+	CLOCK_SetDiv(kCLOCK_Flexspi2Div, 6);
+	/* Set Flexspi2 clock source. */
+	CLOCK_SetMux(kCLOCK_Flexspi2Mux, 1);
+#endif
+	/* Disable CSI clock gate. */
+	CLOCK_DisableClock(kCLOCK_Csi);
+	/* Set CSI_PODF. */
+	CLOCK_SetDiv(kCLOCK_CsiDiv, 0);
+	/* Set Csi clock source. */
+	CLOCK_SetMux(kCLOCK_CsiMux, 0);
+	/* Disable LPSPI clock gate. */
+	CLOCK_DisableClock(kCLOCK_Lpspi1);
+	CLOCK_DisableClock(kCLOCK_Lpspi2);
+	CLOCK_DisableClock(kCLOCK_Lpspi3);
+	CLOCK_DisableClock(kCLOCK_Lpspi4);
+	/* Set LPSPI_PODF. */
+	CLOCK_SetDiv(kCLOCK_LpspiDiv, 7);
+	/* Set Lpspi clock source. */
+	CLOCK_SetMux(kCLOCK_LpspiMux, 1);
+	/* Disable TRACE clock gate. */
+	CLOCK_DisableClock(kCLOCK_Trace);
+	/* Set TRACE_PODF. */
+	CLOCK_SetDiv(kCLOCK_TraceDiv, 3);
+	/* Set Trace clock source. */
+	CLOCK_SetMux(kCLOCK_TraceMux, 2);
+	/* Disable SAI1 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Sai1);
+	/* Set SAI1_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Sai1PreDiv, 3);
+	/* Set SAI1_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Sai1Div, 1);
+	/* Set Sai1 clock source. */
+	CLOCK_SetMux(kCLOCK_Sai1Mux, 0);
+	/* Disable SAI2 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Sai2);
+	/* Set SAI2_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Sai2PreDiv, 3);
+	/* Set SAI2_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Sai2Div, 1);
+	/* Set Sai2 clock source. */
+	CLOCK_SetMux(kCLOCK_Sai2Mux, 0);
+	/* Disable SAI3 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Sai3);
+	/* Set SAI3_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Sai3PreDiv, 3);
+	/* Set SAI3_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Sai3Div, 1);
+	/* Set Sai3 clock source. */
+	CLOCK_SetMux(kCLOCK_Sai3Mux, 0);
+	/* Disable Lpi2c clock gate. */
+	CLOCK_DisableClock(kCLOCK_Lpi2c1);
+	CLOCK_DisableClock(kCLOCK_Lpi2c2);
+	CLOCK_DisableClock(kCLOCK_Lpi2c3);
+	/* Set LPI2C_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Lpi2cDiv, 5);
+	/* Set Lpi2c clock source. */
+	CLOCK_SetMux(kCLOCK_Lpi2cMux, 0);
+	/* Disable CAN clock gate. */
+	CLOCK_DisableClock(kCLOCK_Can1);
+	CLOCK_DisableClock(kCLOCK_Can2);
+	CLOCK_DisableClock(kCLOCK_Can3);
+	CLOCK_DisableClock(kCLOCK_Can1S);
+	CLOCK_DisableClock(kCLOCK_Can2S);
+	CLOCK_DisableClock(kCLOCK_Can3S);
+	/* Set CAN_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_CanDiv, 1);
+	/* Set Can clock source. */
+	CLOCK_SetMux(kCLOCK_CanMux, 2);
+	/* Disable UART clock gate. */
+	CLOCK_DisableClock(kCLOCK_Lpuart1);
+	CLOCK_DisableClock(kCLOCK_Lpuart2);
+	CLOCK_DisableClock(kCLOCK_Lpuart3);
+	CLOCK_DisableClock(kCLOCK_Lpuart4);
+	CLOCK_DisableClock(kCLOCK_Lpuart5);
+	CLOCK_DisableClock(kCLOCK_Lpuart6);
+	CLOCK_DisableClock(kCLOCK_Lpuart7);
+	CLOCK_DisableClock(kCLOCK_Lpuart8);
+	/* Set UART_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_UartDiv, 0);
+	/* Set Uart clock source. */
+	CLOCK_SetMux(kCLOCK_UartMux, 0);
+	/* Disable LCDIF clock gate. */
+	CLOCK_DisableClock(kCLOCK_LcdPixel);
+	/* Set LCDIF_PRED. */
+	CLOCK_SetDiv(kCLOCK_LcdifPreDiv, 4);
+	/* Set LCDIF_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_LcdifDiv, 1);
+	/* Set Lcdif pre clock source. */
+	CLOCK_SetMux(kCLOCK_LcdifPreMux, 2);
+	/* Disable SPDIF clock gate. */
+	CLOCK_DisableClock(kCLOCK_Spdif);
+	/* Set SPDIF0_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Spdif0PreDiv, 1);
+	/* Set SPDIF0_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Spdif0Div, 7);
+	/* Set Spdif clock source. */
+	CLOCK_SetMux(kCLOCK_SpdifMux, 3);
+	/* Disable Flexio1 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Flexio1);
+	/* Set FLEXIO1_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Flexio1PreDiv, 1);
+	/* Set FLEXIO1_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Flexio1Div, 7);
+	/* Set Flexio1 clock source. */
+	CLOCK_SetMux(kCLOCK_Flexio1Mux, 3);
+	/* Disable Flexio2 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Flexio2);
+	/* Set FLEXIO2_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Flexio2PreDiv, 1);
+	/* Set FLEXIO2_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Flexio2Div, 7);
+	/* Set Flexio2 clock source. */
+	CLOCK_SetMux(kCLOCK_Flexio2Mux, 3);
+	/* Set Pll3 sw clock source. */
+	CLOCK_SetMux(kCLOCK_Pll3SwMux, 0);
+	/* Init ARM PLL. */
+	CLOCK_InitArmPll(&armPllConfig_clock_init);
+	/*
+	 * In SDK projects, SDRAM (configured by SEMC) will be initialized in either debug script
+	 * or dcd. With this macro SKIP_SYSCLK_INIT, system pll (selected to be SEMC source clock
+	 * in SDK projects) will be left unchanged.
+	 * Note: If another clock source is selected for SEMC, user may want to avoid changing that
+	 * clock as well.
+	 */
+#ifndef SKIP_SYSCLK_INIT
+#if defined(XIP_BOOT_HEADER_DCD_ENABLE) && (XIP_BOOT_HEADER_DCD_ENABLE == 1)
+    #warning "SKIP_SYSCLK_INIT should be defined to keep system pll (selected to be SEMC source \
+	clock in SDK projects) unchanged."
+#endif
+	/* Init System PLL. */
+	CLOCK_InitSysPll(&sysPllConfig_clock_init);
+	/* Init System pfd0. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd0, 24);
+	/* Init System pfd1. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd1, 16);
+	/* Init System pfd2. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd2, 29);
+	/* Init System pfd3. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd3, 35);
+#endif
+	/*
+	 * In SDK projects, external flash (configured by FLEXSPI2) will be initialized by dcd.
+	 * With this macro XIP_EXTERNAL_FLASH, usb1 pll (selected to be FLEXSPI2 clock source in
+	 * SDK projects) will be left unchanged.
+	 * Note: If another clock source is selected for FLEXSPI2, user may want to avoid changing
+	 * that clock as well.
+	 */
+#if !(defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1))
+	/* Init Usb1 PLL. */
+	CLOCK_InitUsb1Pll(&usb1PllConfig_clock_init);
+	/* Init Usb1 pfd0. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd0, 12);
+	/* Init Usb1 pfd1. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd1, 35);
+	/* Init Usb1 pfd2. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd2, 26);
+	/* Init Usb1 pfd3. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd3, 31);
+#endif
+	/* DeInit Audio PLL. */
+	CLOCK_DeinitAudioPll();
+	/* Bypass Audio PLL. */
+	CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllAudio, 1);
+	/* Set divider for Audio PLL. */
+	CCM_ANALOG->MISC2 &= ~CCM_ANALOG_MISC2_AUDIO_DIV_LSB_MASK;
+	CCM_ANALOG->MISC2 &= ~CCM_ANALOG_MISC2_AUDIO_DIV_MSB_MASK;
+	/* Enable Audio PLL output. */
+	CCM_ANALOG->PLL_AUDIO |= CCM_ANALOG_PLL_AUDIO_ENABLE_MASK;
+	/* Init Video PLL. */
+	uint32_t pllVideo;
+	/* Disable Video PLL output before initial Video PLL. */
+	CCM_ANALOG->PLL_VIDEO &= ~CCM_ANALOG_PLL_VIDEO_ENABLE_MASK;
+	/* Bypass PLL first */
+	CCM_ANALOG->PLL_VIDEO = (CCM_ANALOG->PLL_VIDEO &
+				(~CCM_ANALOG_PLL_VIDEO_BYPASS_CLK_SRC_MASK)) |
+				CCM_ANALOG_PLL_VIDEO_BYPASS_MASK |
+				CCM_ANALOG_PLL_VIDEO_BYPASS_CLK_SRC(0);
+	CCM_ANALOG->PLL_VIDEO_NUM = CCM_ANALOG_PLL_VIDEO_NUM_A(0);
+	CCM_ANALOG->PLL_VIDEO_DENOM = CCM_ANALOG_PLL_VIDEO_DENOM_B(1);
+	pllVideo = (CCM_ANALOG->PLL_VIDEO &
+		    (~(CCM_ANALOG_PLL_VIDEO_DIV_SELECT_MASK |
+		       CCM_ANALOG_PLL_VIDEO_POWERDOWN_MASK))) |
+		   CCM_ANALOG_PLL_VIDEO_ENABLE_MASK |
+		   CCM_ANALOG_PLL_VIDEO_DIV_SELECT(31);
+	pllVideo |= CCM_ANALOG_PLL_VIDEO_POST_DIV_SELECT(1);
+	CCM_ANALOG->MISC2 = (CCM_ANALOG->MISC2 & (~CCM_ANALOG_MISC2_VIDEO_DIV_MASK)) |
+			     CCM_ANALOG_MISC2_VIDEO_DIV(3);
+	CCM_ANALOG->PLL_VIDEO = pllVideo;
+	while ((CCM_ANALOG->PLL_VIDEO & CCM_ANALOG_PLL_VIDEO_LOCK_MASK) == 0) {
+	}
+	/* Disable bypass for Video PLL. */
+	CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllVideo, 0);
+	/* Init Enet PLL. */
+	CLOCK_InitEnetPll(&enetPllConfig_clock_init);
+	/* DeInit Usb2 PLL. */
+	CLOCK_DeinitUsb2Pll();
+	/* Bypass Usb2 PLL. */
+	CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllUsb2, 1);
+	/* Enable Usb2 PLL output. */
+	CCM_ANALOG->PLL_USB2 |= CCM_ANALOG_PLL_USB2_ENABLE_MASK;
+	/* Set preperiph clock source. */
+	CLOCK_SetMux(kCLOCK_PrePeriphMux, 3);
+	/* Set periph clock source. */
+	CLOCK_SetMux(kCLOCK_PeriphMux, 0);
+	/* Set periph clock2 clock source. */
+	CLOCK_SetMux(kCLOCK_PeriphClk2Mux, 1);
+	/* Set per clock source. */
+	CLOCK_SetMux(kCLOCK_PerclkMux, 0);
+	/* Set lvds1 clock source. */
+	CCM_ANALOG->MISC1 = (CCM_ANALOG->MISC1 &
+			     (~CCM_ANALOG_MISC1_LVDS1_CLK_SEL_MASK)) |
+			     CCM_ANALOG_MISC1_LVDS1_CLK_SEL(0);
+	/* Set clock out1 divider. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO1_DIV_MASK)) | CCM_CCOSR_CLKO1_DIV(0);
+	/* Set clock out1 source. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO1_SEL_MASK)) | CCM_CCOSR_CLKO1_SEL(1);
+	/* Set clock out2 divider. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO2_DIV_MASK)) | CCM_CCOSR_CLKO2_DIV(0);
+	/* Set clock out2 source. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO2_SEL_MASK)) | CCM_CCOSR_CLKO2_SEL(14);
+	/* Set clock out1 drives clock out1. */
+	CCM->CCOSR &= ~CCM_CCOSR_CLK_OUT_SEL_MASK;
+	/* Disable clock out1. */
+	CCM->CCOSR &= ~CCM_CCOSR_CLKO1_EN_MASK;
+	/* Disable clock out2. */
+	CCM->CCOSR &= ~CCM_CCOSR_CLKO2_EN_MASK;
+	/* Set SAI1 MCLK1 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk1Sel, 0);
+	/* Set SAI1 MCLK2 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk2Sel, 0);
+	/* Set SAI1 MCLK3 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk3Sel, 0);
+	/* Set SAI2 MCLK3 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI2MClk3Sel, 0);
+	/* Set SAI3 MCLK3 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI3MClk3Sel, 0);
+	/* Set MQS configuration. */
+	IOMUXC_MQSConfig(IOMUXC_GPR, kIOMUXC_MqsPwmOverSampleRate32, 0);
+	/* Set ENET Ref clock source. */
+	IOMUXC_GPR->GPR1 &= ~IOMUXC_GPR_GPR1_ENET1_TX_CLK_DIR_MASK;
+	/* Set ENET2 Ref clock source. */
+	IOMUXC_GPR->GPR1 &= ~IOMUXC_GPR_GPR1_ENET2_TX_CLK_DIR_MASK;
+	/* Set GPT1 High frequency reference clock source. */
+	IOMUXC_GPR->GPR5 &= ~IOMUXC_GPR_GPR5_VREF_1M_CLK_GPT1_MASK;
+	/* Set GPT2 High frequency reference clock source. */
+	IOMUXC_GPR->GPR5 &= ~IOMUXC_GPR_GPR5_VREF_1M_CLK_GPT2_MASK;
+	/* Set SystemCoreClock variable. */
+	SystemCoreClock = CLOCK_INIT_CORE_CLOCK;
+}

--- a/boards/arm/mimxrt1064_evk/clock_config.h
+++ b/boards/arm/mimxrt1064_evk/clock_config.h
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2021, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _CLOCK_CONFIG_H_
+#define _CLOCK_CONFIG_H_
+
+#include "fsl_common.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+/*!< Board xtal0 frequency in Hz */
+#define BOARD_XTAL0_CLK_HZ                         24000000U
+
+/*!< Board xtal32k frequency in Hz */
+#define BOARD_XTAL32K_CLK_HZ                          32768U
+/*******************************************************************************
+ ************************ BOARD_InitBootClocks function ************************
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus*/
+
+/*!
+ * @brief This function executes default configuration of clocks.
+ *
+ */
+void BOARD_InitBootClocks(void);
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus*/
+
+/*******************************************************************************
+ ************************** Configuration clock_init ***************************
+ ******************************************************************************/
+/*******************************************************************************
+ * Definitions for clock_init configuration
+ ******************************************************************************/
+/*!< Core clock frequency: 600000000Hz */
+#define CLOCK_INIT_CORE_CLOCK                     600000000U
+
+/* Clock outputs (values are in Hz): */
+#define CLOCK_INIT_AHB_CLK_ROOT                       600000000UL
+#define CLOCK_INIT_CAN_CLK_ROOT                       40000000UL
+#define CLOCK_INIT_CKIL_SYNC_CLK_ROOT                 32768UL
+#define CLOCK_INIT_CLKO1_CLK                          0UL
+#define CLOCK_INIT_CLKO2_CLK                          0UL
+#define CLOCK_INIT_CLK_1M                             1000000UL
+#define CLOCK_INIT_CLK_24M                            24000000UL
+#define CLOCK_INIT_CSI_CLK_ROOT                       24000000UL
+#define CLOCK_INIT_ENET2_125M_CLK                     0UL
+#define CLOCK_INIT_ENET2_REF_CLK                      0UL
+#define CLOCK_INIT_ENET2_TX_CLK                       0UL
+#define CLOCK_INIT_ENET_125M_CLK                      50000000UL
+#define CLOCK_INIT_ENET_25M_REF_CLK                   25000000UL
+#define CLOCK_INIT_ENET_REF_CLK                       0UL
+#define CLOCK_INIT_ENET_TX_CLK                        0UL
+#define CLOCK_INIT_FLEXIO1_CLK_ROOT                   30000000UL
+#define CLOCK_INIT_FLEXIO2_CLK_ROOT                   30000000UL
+#define CLOCK_INIT_FLEXSPI2_CLK_ROOT                  102857142UL
+#define CLOCK_INIT_FLEXSPI_CLK_ROOT                   90000000UL
+#define CLOCK_INIT_GPT1_IPG_CLK_HIGHFREQ              75000000UL
+#define CLOCK_INIT_GPT2_IPG_CLK_HIGHFREQ              75000000UL
+#define CLOCK_INIT_IPG_CLK_ROOT                       150000000UL
+#define CLOCK_INIT_LCDIF_CLK_ROOT                     9300000UL
+#define CLOCK_INIT_LPI2C_CLK_ROOT                     10000000UL
+#define CLOCK_INIT_LPSPI_CLK_ROOT                     90000000UL
+#define CLOCK_INIT_LVDS1_CLK                          1200000000UL
+#define CLOCK_INIT_MQS_MCLK                           41538461UL
+#define CLOCK_INIT_PERCLK_CLK_ROOT                    75000000UL
+#define CLOCK_INIT_PLL7_MAIN_CLK                      24000000UL
+#define CLOCK_INIT_SAI1_CLK_ROOT                      41538461UL
+#define CLOCK_INIT_SAI1_MCLK1                         41538461UL
+#define CLOCK_INIT_SAI1_MCLK2                         41538461UL
+#define CLOCK_INIT_SAI1_MCLK3                         30000000UL
+#define CLOCK_INIT_SAI2_CLK_ROOT                      41538461UL
+#define CLOCK_INIT_SAI2_MCLK1                         41538461UL
+#define CLOCK_INIT_SAI2_MCLK2                         0UL
+#define CLOCK_INIT_SAI2_MCLK3                         30000000UL
+#define CLOCK_INIT_SAI3_CLK_ROOT                      41538461UL
+#define CLOCK_INIT_SAI3_MCLK1                         41538461UL
+#define CLOCK_INIT_SAI3_MCLK2                         0UL
+#define CLOCK_INIT_SAI3_MCLK3                         30000000UL
+#define CLOCK_INIT_SEMC_CLK_ROOT                      163862068UL
+#define CLOCK_INIT_SPDIF0_CLK_ROOT                    30000000UL
+#define CLOCK_INIT_SPDIF0_EXTCLK_OUT                  0UL
+#define CLOCK_INIT_TRACE_CLK_ROOT                     99000000UL
+#define CLOCK_INIT_UART_CLK_ROOT                      80000000UL
+#define CLOCK_INIT_USBPHY1_CLK                        480000000UL
+#define CLOCK_INIT_USBPHY2_CLK                        0UL
+#define CLOCK_INIT_USDHC1_CLK_ROOT                    198000000UL
+#define CLOCK_INIT_USDHC2_CLK_ROOT                    198000000UL
+
+/*! @brief Arm PLL set for clock_init configuration.
+ */
+extern const clock_arm_pll_config_t armPllConfig_clock_init;
+/*! @brief Usb1 PLL set for clock_init configuration.
+ */
+extern const clock_usb_pll_config_t usb1PllConfig_clock_init;
+/*! @brief Sys PLL for clock_init configuration.
+ */
+extern const clock_sys_pll_config_t sysPllConfig_clock_init;
+/*! @brief Video PLL set for clock_init configuration.
+ */
+extern const clock_video_pll_config_t videoPllConfig_clock_init;
+/*! @brief Enet PLL set for clock_init configuration.
+ */
+extern const clock_enet_pll_config_t enetPllConfig_clock_init;
+
+/*******************************************************************************
+ * API for clock_init configuration
+ ******************************************************************************/
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus*/
+
+/*!
+ * @brief This function executes configuration of clocks.
+ *
+ */
+void clock_init(void);
+
+#if defined(__cplusplus)
+}
+#endif  /* __cplusplus*/
+
+#endif  /* _CLOCK_CONFIG_H_ */

--- a/boards/arm/mimxrt1064_evk/doc/index.rst
+++ b/boards/arm/mimxrt1064_evk/doc/index.rst
@@ -406,6 +406,163 @@ runners.jlink, confirm the J-Link debug probe is configured, powered, and
 connected to the EVK properly.  See :ref:`Using J-Link RT1064` for more
 details.
 
+MCUXpresso Config Tool
+======================
+
+A ``mimxrt1064_evk.mex`` file is included. This file was used to generate the clock
+initialization code and can be used as a starting point to tweak the clock configuration.
+This could be useful for different boards that are based on i.MX RT1064.
+
+NOTE: The MCUXpresso Config Tool currently generates a ``.c`` file with the clock configuration.
+Considering options on leveraging this tool in the future to generate a devicetree compatible file.
+
+Clock Configuration at Platform Initialization
+==============================================
+
+Below is the clock configuration at platform initialization.
+
+- On-chip 24MHz oscillator is enabled
+
+- Clock sources
+
++----------------------------+-----------------+
+| Name                       | Frequency       |
++============================+=================+
+| RTC Oscillator             | 32.768 kHz      |
++----------------------------+-----------------+
+| 24MHz clock source         | 24 MHz          |
++----------------------------+-----------------+
+| 1MHz clock                 | 1 MHz           |
++----------------------------+-----------------+
+| CLK1 external clock source | Inactive        |
++----------------------------+-----------------+
+| SAI1 MCLK                  | Inactive        |
++----------------------------+-----------------+
+| SAI2 MCLK                  | Inactive        |
++----------------------------+-----------------+
+| SAI3 MCLK                  | Inactive        |
++----------------------------+-----------------+
+| SPDIF_CLK_EXT              | Inactive        |
++----------------------------+-----------------+
+| SPDIF_SRCLK                | 1 MHz           |
++----------------------------+-----------------+
+| SPDIF_OUTCLK               | 1 MHz           |
++----------------------------+-----------------+
+| ENET_TX_CLK_EXT            | Inactive        |
++----------------------------+-----------------+
+| ENET_REF_CLK_EXT           | Inactive        |
++----------------------------+-----------------+
+| ENET2_TX_CLK_EXT           | Inactive        |
++----------------------------+-----------------+
+| ENET2_REF_CLK_EXT          | Inactive        |
++----------------------------+-----------------+
+
+- Clock outputs
+
++============================+=================+
+| Name                       | Frequency       |
++============================+=================+
+| AHB_CLK_ROOT               | 600 MHz         |
++----------------------------+-----------------+
+| IPG_CLK_ROOT               | 150 MHz         |
++----------------------------+-----------------+
+| SEMC_CLK_ROOT              | 163.86 MHz      |
++----------------------------+-----------------+
+| PERCLK_CLK_ROOT            | 75 MHz          |
++----------------------------+-----------------+
+| LCDIF_CLK_ROOT             | 9.3 MHz         |
++----------------------------+-----------------+
+| CSI_CLK_ROOT               | 24 MHz          |
++----------------------------+-----------------+
+| USDHC1_CLK_ROOT            | 198 MHz         |
++----------------------------+-----------------+
+| USDHC2_CLK_ROOT            | 198 MHz         |
++----------------------------+-----------------+
+| FLEXSPI_CLK_ROOT           | 90 MHz          |
++----------------------------+-----------------+
+| FLEXSPI2_CLK_ROOT          | 102.85 MHz      |
++----------------------------+-----------------+
+| SPDIF0_CLK_ROOT            | 30 MHz          |
++----------------------------+-----------------+
+| FLEXIO1_CLK_ROOT           | 30 MHz          |
++----------------------------+-----------------+
+| FLEXIO2_CLK_ROOT           | 30 MHz          |
++----------------------------+-----------------+
+| SAI1_CLK_ROOT              | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI2_CLK_ROOT              | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI3_CLK_ROOT              | 41.53 MHz       |
++----------------------------+-----------------+
+| LPI2C_CLK_ROOT             | 10 MHz          |
++----------------------------+-----------------+
+| CAN_CLK_ROOT               | 40 MHz          |
++----------------------------+-----------------+
+| UART_CLK_ROOT              | 80 MHz          |
++----------------------------+-----------------+
+| LPSPI_CLK_ROOT             | 90 MHz          |
++----------------------------+-----------------+
+| TRACE_CLK_ROOT             | 99 MHz          |
++----------------------------+-----------------+
+| CKIL_SYNC_CLK_ROOT         | 32.768 kHz      |
++----------------------------+-----------------+
+| Clock 1M output            | 1 MHz           |
++----------------------------+-----------------+
+| Clock 24MHz output         | 24 MHz          |
++----------------------------+-----------------+
+| CLKO1_CLK                  | Inactive        |
++----------------------------+-----------------+
+| CLKO2_CLK                  | Inactive        |
++----------------------------+-----------------+
+| ENET_125M_CLK              | 50 MHz          |
++----------------------------+-----------------+
+| ENET2_125M_CLK             | Inactive        |
++----------------------------+-----------------+
+| ENET_25M_REF_CLK           | 25 MHz          |
++----------------------------+-----------------+
+| LVDS1_CLK                  | 1.2 GHz         |
++----------------------------+-----------------+
+| USB2 PLL clock             | 24 MHz          |
++----------------------------+-----------------+
+| USBPHY1 PLL clock          | 480 MHz         |
++----------------------------+-----------------+
+| USBPHY2 PLL clock          | Inactive        |
++----------------------------+-----------------+
+| GPT1 high frequency clock  | 75 MHz          |
++----------------------------+-----------------+
+| GPT2 high frequency clock  | 75 MHz          |
++----------------------------+-----------------+
+| SAI1 MCLK 1                | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI1 MCLK 2                | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI1 MCLK 3                | 30 MHz          |
++----------------------------+-----------------+
+| SAI2 MCLK 1                | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI2 MCLK 2                | Inactive        |
++----------------------------+-----------------+
+| SAI2 MCLK 3                | 30 MHz          |
++----------------------------+-----------------+
+| SAI3 MCLK 1                | 41.53 MHz       |
++----------------------------+-----------------+
+| SAI3 MCLK 2                | Inactive        |
++----------------------------+-----------------+
+| SAI3 MCLK 3                | 30 MHz          |
++----------------------------+-----------------+
+| SPDIF0_EXTCLK              | Inactive        |
++----------------------------+-----------------+
+| MQS MCLK                   | 41.53 MHz       |
++----------------------------+-----------------+
+| ENET_TX_CLK                | Inactive        |
++----------------------------+-----------------+
+| ENET2_TX_CLK               | Inactive        |
++----------------------------+-----------------+
+| ENET_REF_CLK               | Inactive        |
++----------------------------+-----------------+
+| ENET2_REF_CLK              | Inactive        |
++----------------------------+-----------------+
+
 .. _MIMXRT1064-EVK Website:
    https://www.nxp.com/support/developer-resources/run-time-software/i.mx-developer-resources/mimxrt1064-evk-i.mx-rt1064-evaluation-kit:MIMXRT1064-EVK
 

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.mex
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.mex
@@ -1,0 +1,1261 @@
+<?xml version="1.0" encoding= "UTF-8" ?>
+<configuration name="MIMXRT1064xxxxA" xsi:schemaLocation="http://mcuxpresso.nxp.com/XSD/mex_configuration_10 http://mcuxpresso.nxp.com/XSD/mex_configuration_10.xsd" uuid="de3bdbe5-65cf-482d-b1be-cd17b780459b" version="10" xmlns="http://mcuxpresso.nxp.com/XSD/mex_configuration_10" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+   <common>
+      <processor>MIMXRT1064xxxxA</processor>
+      <package>MIMXRT1064DVL6A</package>
+      <board>MIMXRT1064-EVK</board>
+      <mcu_data>ksdk2_0</mcu_data>
+      <cores selected="core0">
+         <core name="Cortex-M7F" id="core0" description="M7 core"/>
+      </cores>
+      <description></description>
+   </common>
+   <preferences>
+      <validate_boot_init_only>true</validate_boot_init_only>
+      <generate_extended_information>false</generate_extended_information>
+      <generate_code_modified_registers_only>false</generate_code_modified_registers_only>
+      <update_include_paths>true</update_include_paths>
+   </preferences>
+   <tools>
+      <pins name="Pins" version="10.0" enabled="true" update_project_code="false">
+         <generated_project_files>
+            <file path="board/pin_mux.c" update_enabled="true"/>
+            <file path="board/pin_mux.h" update_enabled="true"/>
+         </generated_project_files>
+         <pins_profile>
+            <processor_version>10.0.0</processor_version>
+            <power_domains/>
+            <pin_labels>
+               <pin_label pin_num="M14" pin_signal="GPIO_AD_B0_00" label="LPI2C1_SCL" identifier="LPI2C1_SCL"/>
+               <pin_label pin_num="H10" pin_signal="GPIO_AD_B0_01" label="LPI2C1_SDA" identifier="LPI2C1_SDA"/>
+               <pin_label pin_num="M11" pin_signal="GPIO_AD_B0_02" label="LCD_RESET" identifier="LCD_RESET"/>
+               <pin_label pin_num="F14" pin_signal="GPIO_AD_B0_09" label="JTAG_TDI/J21[5]/ENET_RST/J22[5]" identifier="ENET_RST"/>
+               <pin_label pin_num="G10" pin_signal="GPIO_AD_B0_11" label="LCD_TOUCH_INT" identifier="INT2_COMBO"/>
+            </pin_labels>
+         </pins_profile>
+         <functions_list>
+            <function name="pinmux_ENET">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="ENET" description="Peripheral ENET is not initialized" problem_level="1" source="Pins:pinmux_ENET">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_ENET">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_ENET">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="ENET" signal="enet_rx_data, 0" pin_num="E12" pin_signal="GPIO_B1_04">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_rx_data, 1" pin_num="D12" pin_signal="GPIO_B1_05">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_rx_en" pin_num="C12" pin_signal="GPIO_B1_06">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_tx_data, 0" pin_num="B12" pin_signal="GPIO_B1_07">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_tx_data, 1" pin_num="A12" pin_signal="GPIO_B1_08">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_tx_en" pin_num="A13" pin_signal="GPIO_B1_09">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_ref_clk" pin_num="B13" pin_signal="GPIO_B1_10">
+                     <pin_features>
+                        <pin_feature name="software_input_on" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                        <pin_feature name="pull_keeper_enable" value="Disable"/>
+                        <pin_feature name="speed" value="MHZ_50"/>
+                        <pin_feature name="drive_strength" value="R0_6"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_rx_er" pin_num="C13" pin_signal="GPIO_B1_11">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_mdc" pin_num="A7" pin_signal="GPIO_EMC_40">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="ENET" signal="enet_mdio" pin_num="C7" pin_signal="GPIO_EMC_41">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="GPIO1" signal="gpio_io, 10" pin_num="G13" pin_signal="GPIO_AD_B0_10">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="speed" value="MHZ_100"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_ENET_RST">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_ENET_RST">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_ENET_RST">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="GPIO1" signal="gpio_io, 09" pin_num="F14" pin_signal="GPIO_AD_B0_09">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="speed" value="MHZ_100"/>
+                        <pin_feature name="drive_strength" value="R0_5"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_LPI2C1">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="LPI2C1" description="Peripheral LPI2C1 is not initialized" problem_level="1" source="Pins:pinmux_LPI2C1">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_LPI2C1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_LPI2C1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="LPI2C1" signal="SDA" pin_num="K11" pin_signal="GPIO_AD_B1_01">
+                     <pin_features>
+                        <pin_feature name="software_input_on" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_22K_Ohm"/>
+                        <pin_feature name="open_drain" value="Enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LPI2C1" signal="SCL" pin_num="J11" pin_signal="GPIO_AD_B1_00">
+                     <pin_features>
+                        <pin_feature name="software_input_on" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_22K_Ohm"/>
+                        <pin_feature name="open_drain" value="Enable"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_LCDIF">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="LCDIF" description="Peripheral LCDIF is not initialized" problem_level="1" source="Pins:pinmux_LCDIF">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_LCDIF">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_LCDIF">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="LCDIF" signal="lcdif_clk" pin_num="D7" pin_signal="GPIO_B0_00">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_enable" pin_num="E7" pin_signal="GPIO_B0_01">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_hsync" pin_num="E8" pin_signal="GPIO_B0_02">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_vsync" pin_num="D8" pin_signal="GPIO_B0_03">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 00" pin_num="C8" pin_signal="GPIO_B0_04">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 01" pin_num="B8" pin_signal="GPIO_B0_05">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 02" pin_num="A8" pin_signal="GPIO_B0_06">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 03" pin_num="A9" pin_signal="GPIO_B0_07">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 04" pin_num="B9" pin_signal="GPIO_B0_08">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 05" pin_num="C9" pin_signal="GPIO_B0_09">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 06" pin_num="D9" pin_signal="GPIO_B0_10">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 07" pin_num="A10" pin_signal="GPIO_B0_11">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 08" pin_num="C10" pin_signal="GPIO_B0_12">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 09" pin_num="D10" pin_signal="GPIO_B0_13">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 10" pin_num="E10" pin_signal="GPIO_B0_14">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 11" pin_num="E11" pin_signal="GPIO_B0_15">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 12" pin_num="A11" pin_signal="GPIO_B1_00">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 13" pin_num="B11" pin_signal="GPIO_B1_01">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 14" pin_num="C11" pin_signal="GPIO_B1_02">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LCDIF" signal="lcdif_data, 15" pin_num="D11" pin_signal="GPIO_B1_03">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="GPIO1" signal="gpio_io, 02" pin_num="M11" pin_signal="GPIO_AD_B0_02"/>
+                  <pin peripheral="GPIO2" signal="gpio_io, 31" pin_num="B14" pin_signal="GPIO_B1_15"/>
+               </pins>
+            </function>
+            <function name="pinmux_LPUART1">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="LPUART1" description="Peripheral LPUART1 is not initialized" problem_level="1" source="Pins:pinmux_LPUART1">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_LPUART1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_LPUART1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="LPUART1" signal="RX" pin_num="L14" pin_signal="GPIO_AD_B0_13">
+                     <pin_features>
+                        <pin_feature name="software_input_on" value="Disable"/>
+                        <pin_feature name="hysteresis_enable" value="Disable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                        <pin_feature name="pull_keeper_enable" value="Enable"/>
+                        <pin_feature name="open_drain" value="Disable"/>
+                        <pin_feature name="speed" value="MHZ_100"/>
+                        <pin_feature name="drive_strength" value="R0_6"/>
+                        <pin_feature name="slew_rate" value="Slow"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="LPUART1" signal="TX" pin_num="K14" pin_signal="GPIO_AD_B0_12">
+                     <pin_features>
+                        <pin_feature name="software_input_on" value="Disable"/>
+                        <pin_feature name="hysteresis_enable" value="Disable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                        <pin_feature name="pull_keeper_enable" value="Enable"/>
+                        <pin_feature name="open_drain" value="Disable"/>
+                        <pin_feature name="speed" value="MHZ_100"/>
+                        <pin_feature name="drive_strength" value="R0_6"/>
+                        <pin_feature name="slew_rate" value="Slow"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_FT5336_int">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_FT5336_int">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_FT5336_int">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="GPIO1" signal="gpio_io, 11" pin_num="G10" pin_signal="GPIO_AD_B0_11">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                        <pin_feature name="drive_strength" value="R0_6"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_FlexSPIA">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="FLEXSPI" description="Peripheral FLEXSPI is not initialized" problem_level="1" source="Pins:pinmux_FlexSPIA">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_FlexSPIA">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_FlexSPIA">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_DQS" pin_num="N3" pin_signal="GPIO_SD_B1_05">
+                     <pin_features>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_SS0_B" pin_num="L3" pin_signal="GPIO_SD_B1_06">
+                     <pin_features>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_SCLK" pin_num="L4" pin_signal="GPIO_SD_B1_07">
+                     <pin_features>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_DATA0" pin_num="P3" pin_signal="GPIO_SD_B1_08">
+                     <pin_features>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_DATA1" pin_num="N4" pin_signal="GPIO_SD_B1_09">
+                     <pin_features>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_DATA2" pin_num="P4" pin_signal="GPIO_SD_B1_10">
+                     <pin_features>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="FLEXSPI" signal="FLEXSPI_A_DATA3" pin_num="P5" pin_signal="GPIO_SD_B1_11">
+                     <pin_features>
+                        <pin_feature name="speed" value="MHZ_200"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+            <function name="pinmux_FlexCAN3">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="CAN3" description="Peripheral CAN3 is not initialized" problem_level="1" source="Pins:pinmux_FlexCAN3">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_FlexCAN3">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_FlexCAN3">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="CAN3" signal="TX" pin_num="C3" pin_signal="GPIO_EMC_36"/>
+                  <pin peripheral="CAN3" signal="RX" pin_num="E4" pin_signal="GPIO_EMC_37"/>
+               </pins>
+            </function>
+            <function name="pinmux_FlexCAN2">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="CAN2" description="Peripheral CAN2 is not initialized" problem_level="1" source="Pins:pinmux_FlexCAN2">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_FlexCAN2">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_FlexCAN2">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="CAN2" signal="TX" pin_num="H14" pin_signal="GPIO_AD_B0_14"/>
+                  <pin peripheral="CAN2" signal="RX" pin_num="L10" pin_signal="GPIO_AD_B0_15"/>
+               </pins>
+            </function>
+            <function name="pinmux_FlexCAN1">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="CAN1" description="Peripheral CAN1 is not initialized" problem_level="1" source="Pins:pinmux_FlexCAN1">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_FlexCAN1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_FlexCAN1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="CAN1" signal="TX" pin_num="H13" pin_signal="GPIO_AD_B1_08"/>
+                  <pin peripheral="CAN1" signal="RX" pin_num="M13" pin_signal="GPIO_AD_B1_09"/>
+               </pins>
+            </function>
+            <function name="pinmux_CSI">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="CSI" description="Peripheral CSI is not initialized" problem_level="1" source="Pins:pinmux_CSI">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_CSI">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_CSI">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="GPIO1" signal="gpio_io, 04" pin_num="F11" pin_signal="GPIO_AD_B0_04"/>
+                  <pin peripheral="CSI" signal="csi_pixclk" pin_num="L12" pin_signal="GPIO_AD_B1_04"/>
+                  <pin peripheral="CSI" signal="csi_mclk" pin_num="K12" pin_signal="GPIO_AD_B1_05"/>
+                  <pin peripheral="CSI" signal="csi_vsync" pin_num="J12" pin_signal="GPIO_AD_B1_06"/>
+                  <pin peripheral="CSI" signal="csi_hsync" pin_num="K10" pin_signal="GPIO_AD_B1_07"/>
+                  <pin peripheral="CSI" signal="csi_data, 09" pin_num="H13" pin_signal="GPIO_AD_B1_08"/>
+                  <pin peripheral="CSI" signal="csi_data, 08" pin_num="M13" pin_signal="GPIO_AD_B1_09"/>
+                  <pin peripheral="CSI" signal="csi_data, 07" pin_num="L13" pin_signal="GPIO_AD_B1_10"/>
+                  <pin peripheral="CSI" signal="csi_data, 06" pin_num="J13" pin_signal="GPIO_AD_B1_11"/>
+                  <pin peripheral="CSI" signal="csi_data, 05" pin_num="H12" pin_signal="GPIO_AD_B1_12"/>
+                  <pin peripheral="CSI" signal="csi_data, 04" pin_num="H11" pin_signal="GPIO_AD_B1_13"/>
+                  <pin peripheral="CSI" signal="csi_data, 03" pin_num="G12" pin_signal="GPIO_AD_B1_14"/>
+                  <pin peripheral="CSI" signal="csi_data, 02" pin_num="J14" pin_signal="GPIO_AD_B1_15"/>
+               </pins>
+            </function>
+            <function name="pinmux_FlexPWM2_pwm3">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="PWM2" description="Peripheral PWM2 is not initialized" problem_level="1" source="Pins:pinmux_FlexPWM2_pwm3">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_FlexPWM2_pwm3">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_FlexPWM2_pwm3">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="PWM2" signal="A, 3" pin_num="F14" pin_signal="GPIO_AD_B0_09"/>
+               </pins>
+            </function>
+            <function name="pinmux_LPUART3">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="LPUART3" description="Peripheral LPUART3 is not initialized" problem_level="1" source="Pins:pinmux_LPUART3">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_LPUART3">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_LPUART3">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="LPUART3" signal="TX" pin_num="J12" pin_signal="GPIO_AD_B1_06"/>
+                  <pin peripheral="LPUART3" signal="RX" pin_num="K10" pin_signal="GPIO_AD_B1_07"/>
+               </pins>
+            </function>
+            <function name="pinmux_USER_LED_SW0">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_USER_LED_SW0">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_USER_LED_SW0">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="GPIO1" signal="gpio_io, 09" pin_num="F14" pin_signal="GPIO_AD_B0_09">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                        <pin_feature name="drive_strength" value="R0_6"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="GPIO5" signal="gpio_io, 00" pin_num="L6" pin_signal="WAKEUP"/>
+               </pins>
+            </function>
+            <function name="pinmux_SDHC1">
+               <description>Configures pin routing and optionally pin electrical features.</description>
+               <options>
+                  <callFromInitBoot>false</callFromInitBoot>
+                  <coreID>core0</coreID>
+                  <enableClock>false</enableClock>
+               </options>
+               <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="USDHC1" description="Peripheral USDHC1 is not initialized" problem_level="1" source="Pins:pinmux_SDHC1">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:pinmux_SDHC1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Pins initialization requires the IOMUXC Driver in the project." problem_level="2" source="Pins:pinmux_SDHC1">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <pins>
+                  <pin peripheral="GPIO1" signal="gpio_io, 05" pin_num="G14" pin_signal="GPIO_AD_B0_05">
+                     <pin_features>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Keeper"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="GPIO2" signal="gpio_io, 28" pin_num="D13" pin_signal="GPIO_B1_12">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="drive_strength" value="R0"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_vselect" pin_num="C14" pin_signal="GPIO_B1_14">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="drive_strength" value="R0_4"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_cmd" pin_num="J4" pin_signal="GPIO_SD_B0_00">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="speed" value="MHZ_100"/>
+                        <pin_feature name="drive_strength" value="R0"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_clk" pin_num="J3" pin_signal="GPIO_SD_B0_01">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
+                        <pin_feature name="drive_strength" value="R0"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_data, 0" pin_num="J1" pin_signal="GPIO_SD_B0_02">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="drive_strength" value="R0"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_data, 1" pin_num="K1" pin_signal="GPIO_SD_B0_03">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="drive_strength" value="R0"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_data, 2" pin_num="H2" pin_signal="GPIO_SD_B0_04">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="drive_strength" value="R0"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="USDHC1" signal="usdhc_data, 3" pin_num="J2" pin_signal="GPIO_SD_B0_05">
+                     <pin_features>
+                        <pin_feature name="hysteresis_enable" value="Enable"/>
+                        <pin_feature name="pull_up_down_config" value="Pull_Up_47K_Ohm"/>
+                        <pin_feature name="pull_keeper_select" value="Pull"/>
+                        <pin_feature name="drive_strength" value="R0"/>
+                        <pin_feature name="slew_rate" value="Fast"/>
+                     </pin_features>
+                  </pin>
+               </pins>
+            </function>
+         </functions_list>
+      </pins>
+      <clocks name="Clocks" version="8.0" enabled="true" update_project_code="true">
+         <generated_project_files>
+            <file path="board/clock_config.c" update_enabled="true"/>
+            <file path="board/clock_config.h" update_enabled="true"/>
+         </generated_project_files>
+         <clocks_profile>
+            <processor_version>10.0.0</processor_version>
+         </clocks_profile>
+         <clock_configurations>
+            <clock_configuration name="clock_init">
+               <description></description>
+               <options/>
+               <dependencies>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.rtc_xtali" description="&apos;RTC_XTALI&apos; (Pins tool id: XTALOSC24M.rtc_xtali, Clocks tool id: XTALOSC24M.RTC_XTALI) needs to be routed" problem_level="1" source="Clocks:clock_init">
+                     <feature name="routed" evaluation="">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.rtc_xtali" description="&apos;RTC_XTALI&apos; (Pins tool id: XTALOSC24M.rtc_xtali, Clocks tool id: XTALOSC24M.RTC_XTALI) needs to have &apos;INPUT&apos; direction" problem_level="1" source="Clocks:clock_init">
+                     <feature name="direction" evaluation="">
+                        <data>INPUT</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.rtc_xtalo" description="&apos;RTC_XTALO&apos; (Pins tool id: XTALOSC24M.rtc_xtalo, Clocks tool id: XTALOSC24M.RTC_XTALO) needs to be routed" problem_level="1" source="Clocks:clock_init">
+                     <feature name="routed" evaluation="">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.rtc_xtalo" description="&apos;RTC_XTALO&apos; (Pins tool id: XTALOSC24M.rtc_xtalo, Clocks tool id: XTALOSC24M.RTC_XTALO) needs to have &apos;OUTPUT&apos; direction" problem_level="1" source="Clocks:clock_init">
+                     <feature name="direction" evaluation="">
+                        <data>OUTPUT</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.xtali" description="&apos;XTALI&apos; (Pins tool id: XTALOSC24M.xtali, Clocks tool id: XTALOSC24M.XTALI) needs to be routed" problem_level="1" source="Clocks:clock_init">
+                     <feature name="routed" evaluation="">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.xtali" description="&apos;XTALI&apos; (Pins tool id: XTALOSC24M.xtali, Clocks tool id: XTALOSC24M.XTALI) needs to have &apos;INPUT&apos; direction" problem_level="1" source="Clocks:clock_init">
+                     <feature name="direction" evaluation="">
+                        <data>INPUT</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.xtalo" description="&apos;XTALO&apos; (Pins tool id: XTALOSC24M.xtalo, Clocks tool id: XTALOSC24M.XTALO) needs to be routed" problem_level="1" source="Clocks:clock_init">
+                     <feature name="routed" evaluation="">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PinSignal" resourceId="XTALOSC24M.xtalo" description="&apos;XTALO&apos; (Pins tool id: XTALOSC24M.xtalo, Clocks tool id: XTALOSC24M.XTALO) needs to have &apos;OUTPUT&apos; direction" problem_level="1" source="Clocks:clock_init">
+                     <feature name="direction" evaluation="">
+                        <data>OUTPUT</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Clocks initialization requires the COMMON Driver in the project." problem_level="2" source="Clocks:clock_init">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="SWComponent" resourceId="platform.drivers.iomuxc" description="Clocks initialization requires the IOMUXC Driver in the project." problem_level="2" source="Clocks:clock_init">
+                     <feature name="enabled" evaluation="equal" configuration="core0">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <clock_sources>
+                  <clock_source id="XTALOSC24M.RTC_OSC.outFreq" value="32.768 kHz" locked="false" enabled="true"/>
+               </clock_sources>
+               <clock_outputs>
+                  <clock_output id="AHB_CLK_ROOT.outFreq" value="600 MHz" locked="false" accuracy=""/>
+                  <clock_output id="CAN_CLK_ROOT.outFreq" value="40 MHz" locked="false" accuracy=""/>
+                  <clock_output id="CKIL_SYNC_CLK_ROOT.outFreq" value="32.768 kHz" locked="false" accuracy=""/>
+                  <clock_output id="CLK_1M.outFreq" value="1 MHz" locked="false" accuracy=""/>
+                  <clock_output id="CLK_24M.outFreq" value="24 MHz" locked="false" accuracy=""/>
+                  <clock_output id="CSI_CLK_ROOT.outFreq" value="24 MHz" locked="false" accuracy=""/>
+                  <clock_output id="ENET_125M_CLK.outFreq" value="50 MHz" locked="false" accuracy=""/>
+                  <clock_output id="ENET_25M_REF_CLK.outFreq" value="25 MHz" locked="false" accuracy=""/>
+                  <clock_output id="FLEXIO1_CLK_ROOT.outFreq" value="30 MHz" locked="false" accuracy=""/>
+                  <clock_output id="FLEXIO2_CLK_ROOT.outFreq" value="30 MHz" locked="false" accuracy=""/>
+                  <clock_output id="FLEXSPI2_CLK_ROOT.outFreq" value="720/7 MHz" locked="false" accuracy=""/>
+                  <clock_output id="FLEXSPI_CLK_ROOT.outFreq" value="90 MHz" locked="false" accuracy=""/>
+                  <clock_output id="GPT1_ipg_clk_highfreq.outFreq" value="75 MHz" locked="false" accuracy=""/>
+                  <clock_output id="GPT2_ipg_clk_highfreq.outFreq" value="75 MHz" locked="false" accuracy=""/>
+                  <clock_output id="IPG_CLK_ROOT.outFreq" value="150 MHz" locked="false" accuracy=""/>
+                  <clock_output id="LCDIF_CLK_ROOT.outFreq" value="9.3 MHz" locked="false" accuracy=""/>
+                  <clock_output id="LPI2C_CLK_ROOT.outFreq" value="10 MHz" locked="false" accuracy=""/>
+                  <clock_output id="LPSPI_CLK_ROOT.outFreq" value="90 MHz" locked="false" accuracy=""/>
+                  <clock_output id="LVDS1_CLK.outFreq" value="1.2 GHz" locked="false" accuracy=""/>
+                  <clock_output id="MQS_MCLK.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="PERCLK_CLK_ROOT.outFreq" value="75 MHz" locked="false" accuracy=""/>
+                  <clock_output id="PLL7_MAIN_CLK.outFreq" value="24 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI1_CLK_ROOT.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI1_MCLK1.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI1_MCLK2.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI1_MCLK3.outFreq" value="30 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI2_CLK_ROOT.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI2_MCLK1.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI2_MCLK3.outFreq" value="30 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI3_CLK_ROOT.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI3_MCLK1.outFreq" value="540/13 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SAI3_MCLK3.outFreq" value="30 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SEMC_CLK_ROOT.outFreq" value="4752/29 MHz" locked="false" accuracy=""/>
+                  <clock_output id="SPDIF0_CLK_ROOT.outFreq" value="30 MHz" locked="false" accuracy=""/>
+                  <clock_output id="TRACE_CLK_ROOT.outFreq" value="99 MHz" locked="false" accuracy=""/>
+                  <clock_output id="UART_CLK_ROOT.outFreq" value="80 MHz" locked="false" accuracy=""/>
+                  <clock_output id="USBPHY1_CLK.outFreq" value="480 MHz" locked="false" accuracy=""/>
+                  <clock_output id="USDHC1_CLK_ROOT.outFreq" value="198 MHz" locked="false" accuracy=""/>
+                  <clock_output id="USDHC2_CLK_ROOT.outFreq" value="198 MHz" locked="false" accuracy=""/>
+               </clock_outputs>
+               <clock_settings>
+                  <setting id="CCM.AHB_PODF.scale" value="1" locked="true"/>
+                  <setting id="CCM.ARM_PODF.scale" value="2" locked="true"/>
+                  <setting id="CCM.CLKO2_DIV.scale" value="1" locked="true"/>
+                  <setting id="CCM.CLKO2_SEL.sel" value="XTALOSC24M.OSC_CLK" locked="false"/>
+                  <setting id="CCM.CSI_PODF.scale" value="1" locked="true"/>
+                  <setting id="CCM.FLEXSPI2_PODF.scale" value="7" locked="true"/>
+                  <setting id="CCM.FLEXSPI2_SEL.sel" value="CCM_ANALOG.PLL3_PFD0_CLK" locked="false"/>
+                  <setting id="CCM.FLEXSPI_PODF.scale" value="8" locked="true"/>
+                  <setting id="CCM.FLEXSPI_SEL.sel" value="CCM_ANALOG.PLL3_PFD0_CLK" locked="false"/>
+                  <setting id="CCM.LCDIF_PODF.scale" value="2" locked="true"/>
+                  <setting id="CCM.LCDIF_PRED.scale" value="5" locked="true"/>
+                  <setting id="CCM.LCDIF_PRE_CLK_SEL.sel" value="CCM_ANALOG.PLL5_MAIN_CLK" locked="false"/>
+                  <setting id="CCM.LPI2C_CLK_PODF.scale" value="6" locked="true"/>
+                  <setting id="CCM.LPSPI_CLK_SEL.sel" value="CCM_ANALOG.PLL3_PFD0_CLK" locked="false"/>
+                  <setting id="CCM.LPSPI_PODF.scale" value="8" locked="true"/>
+                  <setting id="CCM.PERCLK_PODF.scale" value="2" locked="true"/>
+                  <setting id="CCM.PERIPH_CLK2_SEL.sel" value="XTALOSC24M.OSC_CLK" locked="false"/>
+                  <setting id="CCM.SAI2_CLK_PRED.scale" value="4" locked="true"/>
+                  <setting id="CCM.SEMC_CLK_SEL.sel" value="CCM.SEMC_ALT_CLK_SEL" locked="false"/>
+                  <setting id="CCM.SEMC_PODF.scale" value="2" locked="true"/>
+                  <setting id="CCM.TRACE_PODF.scale" value="4" locked="true"/>
+                  <setting id="CCM.USDHC1_CLK_SEL.sel" value="CCM_ANALOG.PLL2_PFD0_CLK" locked="false"/>
+                  <setting id="CCM.USDHC1_PODF.scale" value="2" locked="true"/>
+                  <setting id="CCM.USDHC2_CLK_SEL.sel" value="CCM_ANALOG.PLL2_PFD0_CLK" locked="false"/>
+                  <setting id="CCM.USDHC2_PODF.scale" value="2" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL1_BYPASS.sel" value="CCM_ANALOG.PLL1" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL1_PREDIV.scale" value="1" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL1_VDIV.scale" value="50" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2.denom" value="1" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2.num" value="0" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_BYPASS.sel" value="CCM_ANALOG.PLL2_OUT_CLK" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD0_BYPASS.sel" value="CCM_ANALOG.PLL2_PFD0" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD0_DIV.scale" value="24" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD0_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD1_BYPASS.sel" value="CCM_ANALOG.PLL2_PFD1" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD2_BYPASS.sel" value="CCM_ANALOG.PLL2_PFD2" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD2_DIV.scale" value="29" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD2_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD3_BYPASS.sel" value="CCM_ANALOG.PLL2_PFD3" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD3_DIV.scale" value="35" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL2_PFD3_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_BYPASS.sel" value="CCM_ANALOG.PLL3" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD0_BYPASS.sel" value="CCM_ANALOG.PLL3_PFD0" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD0_DIV.scale" value="12" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD0_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD1_BYPASS.sel" value="CCM_ANALOG.PLL3_PFD1" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD1_DIV.scale" value="35" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD1_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD2_BYPASS.sel" value="CCM_ANALOG.PLL3_PFD2" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD2_DIV.scale" value="26" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD2_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD3_BYPASS.sel" value="CCM_ANALOG.PLL3_PFD3" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD3_DIV.scale" value="31" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL3_PFD3_MUL.scale" value="18" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL4.denom" value="50" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL4.div" value="27" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL4_POST_DIV.scale" value="4" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL5.denom" value="1" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL5.div" value="31" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL5.num" value="0" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL5_BYPASS.sel" value="CCM_ANALOG.PLL5_POST_DIV" locked="false"/>
+                  <setting id="CCM_ANALOG.PLL5_POST_DIV.scale" value="2" locked="true"/>
+                  <setting id="CCM_ANALOG.PLL6_BYPASS.sel" value="CCM_ANALOG.PLL6" locked="false"/>
+                  <setting id="CCM_ANALOG.VIDEO_DIV.scale" value="4" locked="true"/>
+                  <setting id="CCM_ANALOG_PLL_ENET_ENET2_REF_EN_CFG" value="Disabled" locked="false"/>
+                  <setting id="CCM_ANALOG_PLL_USB1_EN_USB_CLKS_CFG" value="Enabled" locked="false"/>
+                  <setting id="CCM_ANALOG_PLL_USB1_EN_USB_CLKS_OUT_CFG" value="Enabled" locked="false"/>
+                  <setting id="CCM_ANALOG_PLL_USB1_POWER_CFG" value="Yes" locked="false"/>
+                  <setting id="CCM_ANALOG_PLL_VIDEO_POWERDOWN_CFG" value="No" locked="false"/>
+               </clock_settings>
+               <called_from_default_init>true</called_from_default_init>
+            </clock_configuration>
+         </clock_configurations>
+      </clocks>
+      <dcdx name="DCDx" version="3.0" enabled="true" update_project_code="false">
+         <generated_project_files>
+            <file path="board/dcd.c" update_enabled="true"/>
+            <file path="board/dcd.h" update_enabled="true"/>
+         </generated_project_files>
+         <dcdx_profile>
+            <processor_version>10.0.0</processor_version>
+            <output_format>c_array</output_format>
+         </dcdx_profile>
+         <dcdx_configurations>
+            <dcdx_configuration name="Device_configuration">
+               <description></description>
+               <options/>
+               <command_groups>
+                  <command_group name="Imported Commands" enabled="true">
+                     <commands>
+                        <command type="write_value" address="CCM_CCGR0" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR1" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR2" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR3" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR4" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR5" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_CCGR6" value="0xFFFFFFFF" value_width="4"/>
+                        <command type="write_value" address="CCM_ANALOG_PLL_SYS" value="0x2001" value_width="4"/>
+                        <command type="write_value" address="CCM_ANALOG_PFD_528" value="0x1D0000" value_width="4"/>
+                        <command type="write_value" address="CCM_CBCDR" value="0x10D40" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_00" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_01" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_02" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_03" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_04" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_05" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_06" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_07" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_08" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_09" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_10" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_11" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_12" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_13" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_14" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_15" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_16" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_17" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_18" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_19" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_20" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_21" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_22" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_23" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_24" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_25" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_26" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_27" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_28" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_29" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_30" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_31" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_32" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_33" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_34" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_35" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_36" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_37" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_38" value="0x00" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_39" value="0x10" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_00" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_01" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_02" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_03" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_04" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_05" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_06" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_07" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_08" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_09" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_10" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_11" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_12" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_13" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_14" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_15" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_16" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_17" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_18" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_19" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_20" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_21" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_22" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_23" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_24" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_25" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_26" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_27" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_28" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_29" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_30" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_31" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_32" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_33" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_34" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_35" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_36" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_37" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_38" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="IOMUXC_SW_PAD_CTL_PAD_GPIO_EMC_39" value="0x110F9" value_width="4"/>
+                        <command type="write_value" address="SEMC_MCR" value="0x10000004" value_width="4"/>
+                        <command type="write_value" address="SEMC_BMCR0" value="0x81" value_width="4"/>
+                        <command type="write_value" address="SEMC_BMCR1" value="0x81" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR0" value="0x8000001B" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR1" value="0x8200001B" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR2" value="0x8400001B" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR3" value="0x8600001B" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR4" value="0x90000021" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR5" value="0xA0000019" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR6" value="0xA8000017" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR7" value="0xA900001B" value_width="4"/>
+                        <command type="write_value" address="SEMC_BR8" value="0x21" value_width="4"/>
+                        <command type="write_value" address="SEMC_IOCR" value="0x79A8" value_width="4"/>
+                        <command type="write_value" address="SEMC_SDRAMCR0" value="0xF31" value_width="4"/>
+                        <command type="write_value" address="SEMC_SDRAMCR1" value="0x652922" value_width="4"/>
+                        <command type="write_value" address="SEMC_SDRAMCR2" value="0x10920" value_width="4"/>
+                        <command type="write_value" address="SEMC_SDRAMCR3" value="0x50210A08" value_width="4"/>
+                        <command type="write_value" address="SEMC_DBICR0" value="0x21" value_width="4"/>
+                        <command type="write_value" address="SEMC_DBICR1" value="0x888888" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR1" value="0x02" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR2" value="0x00" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR0" value="0x80000000" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCMD" value="0xA55A000F" value_width="4"/>
+                        <command type="check_any_bit_set" address="SEMC_INTR" value="0x01" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR0" value="0x80000000" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCMD" value="0xA55A000C" value_width="4"/>
+                        <command type="check_any_bit_set" address="SEMC_INTR" value="0x01" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR0" value="0x80000000" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCMD" value="0xA55A000C" value_width="4"/>
+                        <command type="check_any_bit_set" address="SEMC_INTR" value="0x01" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPTXDAT" value="0x33" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCR0" value="0x80000000" value_width="4"/>
+                        <command type="write_value" address="SEMC_IPCMD" value="0xA55A000A" value_width="4"/>
+                        <command type="check_any_bit_set" address="SEMC_INTR" value="0x01" value_width="4"/>
+                        <command type="write_value" address="SEMC_SDRAMCR3" value="0x50210A09" value_width="4"/>
+                     </commands>
+                  </command_group>
+               </command_groups>
+            </dcdx_configuration>
+         </dcdx_configurations>
+      </dcdx>
+      <periphs name="Peripherals" version="10.0" enabled="true" update_project_code="false">
+         <generated_project_files>
+            <file path="board/peripherals.c" update_enabled="true"/>
+            <file path="board/peripherals.h" update_enabled="true"/>
+         </generated_project_files>
+         <peripherals_profile>
+            <processor_version>10.0.0</processor_version>
+         </peripherals_profile>
+         <functional_groups>
+            <functional_group name="BOARD_InitPeripherals" uuid="1c6563a6-c68b-40e5-8828-2853c99f95fa" called_from_default_init="true" id_prefix="BOARD_" core="core0">
+               <description></description>
+               <options/>
+               <dependencies/>
+               <instances>
+                  <instance name="NVIC" uuid="2c253e89-508d-4544-9d44-c226931d8f3f" type="nvic" type_id="nvic_57b5eef3774cc60acaede6f5b8bddc67" mode="general" peripheral="NVIC" enabled="true" comment="" custom_name_enabled="false" editing_lock="false">
+                     <config_set name="nvic">
+                        <array name="interrupt_table"/>
+                        <array name="interrupts"/>
+                     </config_set>
+                  </instance>
+               </instances>
+            </functional_group>
+         </functional_groups>
+         <components>
+            <component name="system" uuid="18e298ee-cc10-47f7-b950-440409a94f94" type_id="system_54b53072540eeeb8f8e9343e71f28176">
+               <config_set_global name="global_system_definitions">
+                  <setting name="user_definitions" value=""/>
+                  <setting name="user_includes" value=""/>
+               </config_set_global>
+            </component>
+            <component name="msg" uuid="078a031a-1304-48e4-934c-de6b7bd41d37" type_id="msg_6e2baaf3b97dbeef01c0043275f9a0e7">
+               <config_set_global name="global_messages"/>
+            </component>
+            <component name="generic_uart" uuid="0e122da2-c994-4d5a-a7b8-5a63103fc1d2" type_id="generic_uart_8cae00565451cf2346eb1b8c624e73a6">
+               <config_set_global name="global_uart"/>
+            </component>
+            <component name="generic_can" uuid="51762fc1-cf05-4bb3-a3ca-5da5c50ea072" type_id="generic_can_1bfdd78b1af214566c1f23cf6a582d80">
+               <config_set_global name="global_can"/>
+            </component>
+            <component name="uart_cmsis_common" uuid="d4182366-28a3-4b72-9e22-d29aa447729c" type_id="uart_cmsis_common_9cb8e302497aa696fdbb5a4fd622c2a8">
+               <config_set_global name="global_USART_CMSIS_common" quick_selection="default"/>
+            </component>
+            <component name="generic_enet" uuid="c9d3d8ac-0dc9-40de-aea5-dd11df3d996b" type_id="generic_enet_74db5c914f0ddbe47d86af40cb77a619">
+               <config_set_global name="global_enet"/>
+            </component>
+         </components>
+      </periphs>
+      <tee name="TEE" version="2.0" enabled="false" update_project_code="true">
+         <generated_project_files/>
+         <tee_profile>
+            <processor_version>N/A</processor_version>
+         </tee_profile>
+      </tee>
+   </tools>
+</configuration>

--- a/boards/arm/mm_feather/CMakeLists.txt
+++ b/boards/arm/mm_feather/CMakeLists.txt
@@ -5,6 +5,7 @@
 #
 
 zephyr_library()
-zephyr_library_sources(pinmux.c)
+zephyr_library_sources(pinmux.c clock_config.c)
 zephyr_sources_ifdef(CONFIG_BOOT_FLEXSPI_NOR flexspi_nor_config.c)
 zephyr_sources_ifdef(CONFIG_DEVICE_CONFIGURATION_DATA mmfeather_sdram_ini_dcd.c)
+zephyr_include_directories(.)

--- a/boards/arm/mm_feather/clock_config.c
+++ b/boards/arm/mm_feather/clock_config.c
@@ -1,0 +1,573 @@
+/*
+ * Copyright (c) 2021, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * How to setup clock using clock driver functions:
+ *
+ * 1. Call CLOCK_InitXXXPLL() to configure corresponding PLL clock.
+ *
+ * 2. Call CLOCK_InitXXXpfd() to configure corresponding PLL pfd clock.
+ *
+ * 3. Call CLOCK_SetMux() to configure corresponding clock source for target clock out.
+ *
+ * 4. Call CLOCK_SetDiv() to configure corresponding clock divider for target clock out.
+ *
+ * 5. Call CLOCK_SetXtalFreq() to set XTAL frequency based on board settings.
+ *
+ */
+
+/* TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
+ * !!GlobalInfo
+ * product: Clocks v8.0
+ * processor: MIMXRT1062xxxxA
+ * package_id: MIMXRT1062DVL6A
+ * mcu_data: ksdk2_0
+ * processor_version: 10.0.0
+ * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS **********/
+
+#include "clock_config.h"
+#include "fsl_iomuxc.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+/* System clock frequency. */
+extern uint32_t SystemCoreClock;
+
+/*******************************************************************************
+ ************************ BOARD_InitBootClocks function ************************
+ ******************************************************************************/
+void BOARD_InitBootClocks(void)
+{
+	clock_init();
+}
+
+/*******************************************************************************
+ ************************** Configuration clock_init ***************************
+ ******************************************************************************/
+/* TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
+ * !!Configuration
+ * name: clock_init
+ * called_from_default_init: true
+ * outputs:
+ * - {id: AHB_CLK_ROOT.outFreq, value: 600 MHz}
+ * - {id: CAN_CLK_ROOT.outFreq, value: 40 MHz}
+ * - {id: CKIL_SYNC_CLK_ROOT.outFreq, value: 32.768 kHz}
+ * - {id: CLK_1M.outFreq, value: 1 MHz}
+ * - {id: CLK_24M.outFreq, value: 24 MHz}
+ * - {id: CSI_CLK_ROOT.outFreq, value: 24 MHz}
+ * - {id: ENET_125M_CLK.outFreq, value: 50 MHz}
+ * - {id: ENET_25M_REF_CLK.outFreq, value: 25 MHz}
+ * - {id: FLEXIO1_CLK_ROOT.outFreq, value: 30 MHz}
+ * - {id: FLEXIO2_CLK_ROOT.outFreq, value: 30 MHz}
+ * - {id: FLEXSPI2_CLK_ROOT.outFreq, value: 720/7 MHz}
+ * - {id: FLEXSPI_CLK_ROOT.outFreq, value: 90 MHz}
+ * - {id: GPT1_ipg_clk_highfreq.outFreq, value: 75 MHz}
+ * - {id: GPT2_ipg_clk_highfreq.outFreq, value: 75 MHz}
+ * - {id: IPG_CLK_ROOT.outFreq, value: 150 MHz}
+ * - {id: LCDIF_CLK_ROOT.outFreq, value: 9.3 MHz}
+ * - {id: LPI2C_CLK_ROOT.outFreq, value: 10 MHz}
+ * - {id: LPSPI_CLK_ROOT.outFreq, value: 90 MHz}
+ * - {id: LVDS1_CLK.outFreq, value: 1.2 GHz}
+ * - {id: MQS_MCLK.outFreq, value: 540/13 MHz}
+ * - {id: PERCLK_CLK_ROOT.outFreq, value: 75 MHz}
+ * - {id: PLL7_MAIN_CLK.outFreq, value: 24 MHz}
+ * - {id: SAI1_CLK_ROOT.outFreq, value: 540/13 MHz}
+ * - {id: SAI1_MCLK1.outFreq, value: 540/13 MHz}
+ * - {id: SAI1_MCLK2.outFreq, value: 540/13 MHz}
+ * - {id: SAI1_MCLK3.outFreq, value: 30 MHz}
+ * - {id: SAI2_CLK_ROOT.outFreq, value: 540/13 MHz}
+ * - {id: SAI2_MCLK1.outFreq, value: 540/13 MHz}
+ * - {id: SAI2_MCLK3.outFreq, value: 30 MHz}
+ * - {id: SAI3_CLK_ROOT.outFreq, value: 540/13 MHz}
+ * - {id: SAI3_MCLK1.outFreq, value: 540/13 MHz}
+ * - {id: SAI3_MCLK3.outFreq, value: 30 MHz}
+ * - {id: SEMC_CLK_ROOT.outFreq, value: 4752/29 MHz}
+ * - {id: SPDIF0_CLK_ROOT.outFreq, value: 30 MHz}
+ * - {id: TRACE_CLK_ROOT.outFreq, value: 99 MHz}
+ * - {id: UART_CLK_ROOT.outFreq, value: 80 MHz}
+ * - {id: USBPHY1_CLK.outFreq, value: 480 MHz}
+ * - {id: USDHC1_CLK_ROOT.outFreq, value: 198 MHz}
+ * - {id: USDHC2_CLK_ROOT.outFreq, value: 198 MHz}
+ * settings:
+ * - {id: CCM.AHB_PODF.scale, value: '1', locked: true}
+ * - {id: CCM.ARM_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.CLKO2_DIV.scale, value: '1', locked: true}
+ * - {id: CCM.CLKO2_SEL.sel, value: XTALOSC24M.OSC_CLK}
+ * - {id: CCM.CSI_PODF.scale, value: '1', locked: true}
+ * - {id: CCM.FLEXSPI2_PODF.scale, value: '7', locked: true}
+ * - {id: CCM.FLEXSPI2_SEL.sel, value: CCM_ANALOG.PLL3_PFD0_CLK}
+ * - {id: CCM.FLEXSPI_PODF.scale, value: '8', locked: true}
+ * - {id: CCM.FLEXSPI_SEL.sel, value: CCM_ANALOG.PLL3_PFD0_CLK}
+ * - {id: CCM.LCDIF_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.LCDIF_PRED.scale, value: '5', locked: true}
+ * - {id: CCM.LCDIF_PRE_CLK_SEL.sel, value: CCM_ANALOG.PLL5_MAIN_CLK}
+ * - {id: CCM.LPI2C_CLK_PODF.scale, value: '6', locked: true}
+ * - {id: CCM.LPSPI_CLK_SEL.sel, value: CCM_ANALOG.PLL3_PFD0_CLK}
+ * - {id: CCM.LPSPI_PODF.scale, value: '8', locked: true}
+ * - {id: CCM.PERCLK_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.PERIPH_CLK2_SEL.sel, value: XTALOSC24M.OSC_CLK}
+ * - {id: CCM.SAI2_CLK_PRED.scale, value: '4', locked: true}
+ * - {id: CCM.SEMC_CLK_SEL.sel, value: CCM.SEMC_ALT_CLK_SEL}
+ * - {id: CCM.SEMC_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.TRACE_PODF.scale, value: '4', locked: true}
+ * - {id: CCM.USDHC1_CLK_SEL.sel, value: CCM_ANALOG.PLL2_PFD0_CLK}
+ * - {id: CCM.USDHC1_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.USDHC2_CLK_SEL.sel, value: CCM_ANALOG.PLL2_PFD0_CLK}
+ * - {id: CCM.USDHC2_PODF.scale, value: '2', locked: true}
+ * - {id: CCM_ANALOG.PLL1_BYPASS.sel, value: CCM_ANALOG.PLL1}
+ * - {id: CCM_ANALOG.PLL1_PREDIV.scale, value: '1', locked: true}
+ * - {id: CCM_ANALOG.PLL1_VDIV.scale, value: '50', locked: true}
+ * - {id: CCM_ANALOG.PLL2.denom, value: '1', locked: true}
+ * - {id: CCM_ANALOG.PLL2.num, value: '0', locked: true}
+ * - {id: CCM_ANALOG.PLL2_BYPASS.sel, value: CCM_ANALOG.PLL2_OUT_CLK}
+ * - {id: CCM_ANALOG.PLL2_PFD0_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD0}
+ * - {id: CCM_ANALOG.PLL2_PFD0_DIV.scale, value: '24', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD0_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD1_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD1}
+ * - {id: CCM_ANALOG.PLL2_PFD2_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD2}
+ * - {id: CCM_ANALOG.PLL2_PFD2_DIV.scale, value: '29', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD2_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD3_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD3}
+ * - {id: CCM_ANALOG.PLL2_PFD3_DIV.scale, value: '35', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD3_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_BYPASS.sel, value: CCM_ANALOG.PLL3}
+ * - {id: CCM_ANALOG.PLL3_PFD0_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD0}
+ * - {id: CCM_ANALOG.PLL3_PFD0_DIV.scale, value: '12', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD0_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD1_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD1}
+ * - {id: CCM_ANALOG.PLL3_PFD1_DIV.scale, value: '35', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD1_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD2_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD2}
+ * - {id: CCM_ANALOG.PLL3_PFD2_DIV.scale, value: '26', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD2_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD3_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD3}
+ * - {id: CCM_ANALOG.PLL3_PFD3_DIV.scale, value: '31', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD3_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL4.denom, value: '50'}
+ * - {id: CCM_ANALOG.PLL4.div, value: '27', locked: true}
+ * - {id: CCM_ANALOG.PLL4_POST_DIV.scale, value: '4', locked: true}
+ * - {id: CCM_ANALOG.PLL5.denom, value: '1'}
+ * - {id: CCM_ANALOG.PLL5.div, value: '31', locked: true}
+ * - {id: CCM_ANALOG.PLL5.num, value: '0'}
+ * - {id: CCM_ANALOG.PLL5_BYPASS.sel, value: CCM_ANALOG.PLL5_POST_DIV}
+ * - {id: CCM_ANALOG.PLL5_POST_DIV.scale, value: '2', locked: true}
+ * - {id: CCM_ANALOG.PLL6_BYPASS.sel, value: CCM_ANALOG.PLL6}
+ * - {id: CCM_ANALOG.VIDEO_DIV.scale, value: '4', locked: true}
+ * - {id: CCM_ANALOG_PLL_ENET_ENET2_REF_EN_CFG, value: Disabled}
+ * - {id: CCM_ANALOG_PLL_USB1_EN_USB_CLKS_CFG, value: Enabled}
+ * - {id: CCM_ANALOG_PLL_USB1_EN_USB_CLKS_OUT_CFG, value: Enabled}
+ * - {id: CCM_ANALOG_PLL_USB1_POWER_CFG, value: 'Yes'}
+ * - {id: CCM_ANALOG_PLL_VIDEO_POWERDOWN_CFG, value: 'No'}
+ * sources:
+ * - {id: XTALOSC24M.RTC_OSC.outFreq, value: 32.768 kHz, enabled: true}
+ * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS **********/
+
+/*******************************************************************************
+ * Variables for clock_init configuration
+ ******************************************************************************/
+const clock_arm_pll_config_t armPllConfig_clock_init = {
+	/* PLL loop divider, Fout = Fin * 50 */
+	.loopDivider = 100,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+const clock_sys_pll_config_t sysPllConfig_clock_init = {
+	/* PLL loop divider, Fout = Fin * ( 20 + loopDivider*2 + numerator / denominator ) */
+	.loopDivider = 1,
+	/* 30 bit numerator of fractional loop divider */
+	.numerator = 0,
+	/* 30 bit denominator of fractional loop divider */
+	.denominator = 1,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+const clock_usb_pll_config_t usb1PllConfig_clock_init = {
+	/* PLL loop divider, Fout = Fin * 20 */
+	.loopDivider = 0,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+const clock_video_pll_config_t videoPllConfig_clock_init = {
+	/* PLL loop divider, Fout = Fin * ( loopDivider + numerator / denominator ) */
+	.loopDivider = 31,
+	.postDivider = 8,                               /* Divider after PLL */
+	/*
+	 * 30 bit numerator of fractional loop divider,
+	 * Fout = Fin * ( loopDivider + numerator / denominator )
+	 */
+	.numerator = 0,
+	/*
+	 * 30 bit denominator of fractional loop divider,
+	 * Fout = Fin * ( loopDivider + numerator / denominator )
+	 */
+	.denominator = 1,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+const clock_enet_pll_config_t enetPllConfig_clock_init = {
+	/* Enable the PLL providing the ENET 125MHz reference clock */
+	.enableClkOutput = true,
+	/* Disable the PLL providing the ENET2 125MHz reference clock */
+	.enableClkOutput1 = false,
+	/* Enable the PLL providing the ENET 25MHz reference clock */
+	.enableClkOutput25M = true,
+	/* Set frequency of ethernet reference clock to 50 MHz */
+	.loopDivider = 1,
+	/* Set frequency of ethernet reference clock to 25 MHz */
+	.loopDivider1 = 0,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+/*******************************************************************************
+ * Code for clock_init configuration
+ ******************************************************************************/
+void clock_init(void)
+{
+	/* Init RTC OSC clock frequency. */
+	CLOCK_SetRtcXtalFreq(32768U);
+	/* Enable 1MHz clock output. */
+	XTALOSC24M->OSC_CONFIG2 |= XTALOSC24M_OSC_CONFIG2_ENABLE_1M_MASK;
+	/* Use free 1MHz clock output. */
+	XTALOSC24M->OSC_CONFIG2 &= ~XTALOSC24M_OSC_CONFIG2_MUX_1M_MASK;
+	/* Set XTAL 24MHz clock frequency. */
+	CLOCK_SetXtalFreq(24000000U);
+	/* Enable XTAL 24MHz clock source. */
+	CLOCK_InitExternalClk(0);
+	/* Enable internal RC. */
+	CLOCK_InitRcOsc24M();
+	/* Switch clock source to external OSC. */
+	CLOCK_SwitchOsc(kCLOCK_XtalOsc);
+	/* Set Oscillator ready counter value. */
+	CCM->CCR = (CCM->CCR & (~CCM_CCR_OSCNT_MASK)) | CCM_CCR_OSCNT(127);
+	/* Setting PeriphClk2Mux and PeriphMux to provide stable clock before PLLs are initialed */
+	CLOCK_SetMux(kCLOCK_PeriphClk2Mux, 1);  /* Set PERIPH_CLK2 MUX to OSC */
+	CLOCK_SetMux(kCLOCK_PeriphMux, 1);      /* Set PERIPH_CLK MUX to PERIPH_CLK2 */
+	/* Setting the VDD_SOC to 1.275V. It is necessary to config AHB to 600Mhz. */
+	DCDC->REG3 = (DCDC->REG3 & (~DCDC_REG3_TRG_MASK)) | DCDC_REG3_TRG(0x13);
+	/* Waiting for DCDC_STS_DC_OK bit is asserted */
+	while (DCDC_REG0_STS_DC_OK_MASK != (DCDC_REG0_STS_DC_OK_MASK & DCDC->REG0)) {
+	}
+	/* Set AHB_PODF. */
+	CLOCK_SetDiv(kCLOCK_AhbDiv, 0);
+	/* Disable IPG clock gate. */
+	CLOCK_DisableClock(kCLOCK_Adc1);
+	CLOCK_DisableClock(kCLOCK_Adc2);
+	CLOCK_DisableClock(kCLOCK_Xbar1);
+	CLOCK_DisableClock(kCLOCK_Xbar2);
+	CLOCK_DisableClock(kCLOCK_Xbar3);
+	/* Set IPG_PODF. */
+	CLOCK_SetDiv(kCLOCK_IpgDiv, 3);
+	/* Set ARM_PODF. */
+	CLOCK_SetDiv(kCLOCK_ArmDiv, 1);
+	/* Set PERIPH_CLK2_PODF. */
+	CLOCK_SetDiv(kCLOCK_PeriphClk2Div, 0);
+	/* Disable PERCLK clock gate. */
+	CLOCK_DisableClock(kCLOCK_Gpt1);
+	CLOCK_DisableClock(kCLOCK_Gpt1S);
+	CLOCK_DisableClock(kCLOCK_Gpt2);
+	CLOCK_DisableClock(kCLOCK_Gpt2S);
+	CLOCK_DisableClock(kCLOCK_Pit);
+	/* Set PERCLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_PerclkDiv, 1);
+	/* Disable USDHC1 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Usdhc1);
+	/* Set USDHC1_PODF. */
+	CLOCK_SetDiv(kCLOCK_Usdhc1Div, 1);
+	/* Set Usdhc1 clock source. */
+	CLOCK_SetMux(kCLOCK_Usdhc1Mux, 1);
+	/* Disable USDHC2 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Usdhc2);
+	/* Set USDHC2_PODF. */
+	CLOCK_SetDiv(kCLOCK_Usdhc2Div, 1);
+	/* Set Usdhc2 clock source. */
+	CLOCK_SetMux(kCLOCK_Usdhc2Mux, 1);
+	/*
+	 * In SDK projects, SDRAM (configured by SEMC) will be initialized in either debug script
+	 * or dcd. With this macro SKIP_SYSCLK_INIT, system pll (selected to be SEMC source clock
+	 * in SDK projects) will be left unchanged.
+	 * Note: If another clock source is selected for SEMC, user may want to avoid changing
+	 * that clock as well.
+	 */
+#ifndef SKIP_SYSCLK_INIT
+	/* Disable Semc clock gate. */
+	CLOCK_DisableClock(kCLOCK_Semc);
+	/* Set SEMC_PODF. */
+	CLOCK_SetDiv(kCLOCK_SemcDiv, 1);
+	/* Set Semc alt clock source. */
+	CLOCK_SetMux(kCLOCK_SemcAltMux, 0);
+	/* Set Semc clock source. */
+	CLOCK_SetMux(kCLOCK_SemcMux, 1);
+#endif
+	/*
+	 * In SDK projects, external flash (configured by FLEXSPI) will be initialized by dcd.
+	 * With this macro XIP_EXTERNAL_FLASH, usb1 pll (selected to be FLEXSPI clock source in
+	 * SDK projects) will be left unchanged.
+	 * Note: If another clock source is selected for FLEXSPI, user may want to avoid changing
+	 * that clock as well.
+	 */
+#if !(defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1))
+	/* Disable Flexspi clock gate. */
+	CLOCK_DisableClock(kCLOCK_FlexSpi);
+	/* Set FLEXSPI_PODF. */
+	CLOCK_SetDiv(kCLOCK_FlexspiDiv, 7);
+	/* Set Flexspi clock source. */
+	CLOCK_SetMux(kCLOCK_FlexspiMux, 3);
+#endif
+	/* Disable Flexspi2 clock gate. */
+	CLOCK_DisableClock(kCLOCK_FlexSpi2);
+	/* Set FLEXSPI2_PODF. */
+	CLOCK_SetDiv(kCLOCK_Flexspi2Div, 6);
+	/* Set Flexspi2 clock source. */
+	CLOCK_SetMux(kCLOCK_Flexspi2Mux, 1);
+	/* Disable CSI clock gate. */
+	CLOCK_DisableClock(kCLOCK_Csi);
+	/* Set CSI_PODF. */
+	CLOCK_SetDiv(kCLOCK_CsiDiv, 0);
+	/* Set Csi clock source. */
+	CLOCK_SetMux(kCLOCK_CsiMux, 0);
+	/* Disable LPSPI clock gate. */
+	CLOCK_DisableClock(kCLOCK_Lpspi1);
+	CLOCK_DisableClock(kCLOCK_Lpspi2);
+	CLOCK_DisableClock(kCLOCK_Lpspi3);
+	CLOCK_DisableClock(kCLOCK_Lpspi4);
+	/* Set LPSPI_PODF. */
+	CLOCK_SetDiv(kCLOCK_LpspiDiv, 7);
+	/* Set Lpspi clock source. */
+	CLOCK_SetMux(kCLOCK_LpspiMux, 1);
+	/* Disable TRACE clock gate. */
+	CLOCK_DisableClock(kCLOCK_Trace);
+	/* Set TRACE_PODF. */
+	CLOCK_SetDiv(kCLOCK_TraceDiv, 3);
+	/* Set Trace clock source. */
+	CLOCK_SetMux(kCLOCK_TraceMux, 2);
+	/* Disable SAI1 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Sai1);
+	/* Set SAI1_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Sai1PreDiv, 3);
+	/* Set SAI1_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Sai1Div, 1);
+	/* Set Sai1 clock source. */
+	CLOCK_SetMux(kCLOCK_Sai1Mux, 0);
+	/* Disable SAI2 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Sai2);
+	/* Set SAI2_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Sai2PreDiv, 3);
+	/* Set SAI2_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Sai2Div, 1);
+	/* Set Sai2 clock source. */
+	CLOCK_SetMux(kCLOCK_Sai2Mux, 0);
+	/* Disable SAI3 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Sai3);
+	/* Set SAI3_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Sai3PreDiv, 3);
+	/* Set SAI3_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Sai3Div, 1);
+	/* Set Sai3 clock source. */
+	CLOCK_SetMux(kCLOCK_Sai3Mux, 0);
+	/* Disable Lpi2c clock gate. */
+	CLOCK_DisableClock(kCLOCK_Lpi2c1);
+	CLOCK_DisableClock(kCLOCK_Lpi2c2);
+	CLOCK_DisableClock(kCLOCK_Lpi2c3);
+	/* Set LPI2C_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Lpi2cDiv, 5);
+	/* Set Lpi2c clock source. */
+	CLOCK_SetMux(kCLOCK_Lpi2cMux, 0);
+	/* Disable CAN clock gate. */
+	CLOCK_DisableClock(kCLOCK_Can1);
+	CLOCK_DisableClock(kCLOCK_Can2);
+	CLOCK_DisableClock(kCLOCK_Can3);
+	CLOCK_DisableClock(kCLOCK_Can1S);
+	CLOCK_DisableClock(kCLOCK_Can2S);
+	CLOCK_DisableClock(kCLOCK_Can3S);
+	/* Set CAN_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_CanDiv, 1);
+	/* Set Can clock source. */
+	CLOCK_SetMux(kCLOCK_CanMux, 2);
+	/* Disable UART clock gate. */
+	CLOCK_DisableClock(kCLOCK_Lpuart1);
+	CLOCK_DisableClock(kCLOCK_Lpuart2);
+	CLOCK_DisableClock(kCLOCK_Lpuart3);
+	CLOCK_DisableClock(kCLOCK_Lpuart4);
+	CLOCK_DisableClock(kCLOCK_Lpuart5);
+	CLOCK_DisableClock(kCLOCK_Lpuart6);
+	CLOCK_DisableClock(kCLOCK_Lpuart7);
+	CLOCK_DisableClock(kCLOCK_Lpuart8);
+	/* Set UART_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_UartDiv, 0);
+	/* Set Uart clock source. */
+	CLOCK_SetMux(kCLOCK_UartMux, 0);
+	/* Disable LCDIF clock gate. */
+	CLOCK_DisableClock(kCLOCK_LcdPixel);
+	/* Set LCDIF_PRED. */
+	CLOCK_SetDiv(kCLOCK_LcdifPreDiv, 4);
+	/* Set LCDIF_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_LcdifDiv, 1);
+	/* Set Lcdif pre clock source. */
+	CLOCK_SetMux(kCLOCK_LcdifPreMux, 2);
+	/* Disable SPDIF clock gate. */
+	CLOCK_DisableClock(kCLOCK_Spdif);
+	/* Set SPDIF0_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Spdif0PreDiv, 1);
+	/* Set SPDIF0_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Spdif0Div, 7);
+	/* Set Spdif clock source. */
+	CLOCK_SetMux(kCLOCK_SpdifMux, 3);
+	/* Disable Flexio1 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Flexio1);
+	/* Set FLEXIO1_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Flexio1PreDiv, 1);
+	/* Set FLEXIO1_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Flexio1Div, 7);
+	/* Set Flexio1 clock source. */
+	CLOCK_SetMux(kCLOCK_Flexio1Mux, 3);
+	/* Disable Flexio2 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Flexio2);
+	/* Set FLEXIO2_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Flexio2PreDiv, 1);
+	/* Set FLEXIO2_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Flexio2Div, 7);
+	/* Set Flexio2 clock source. */
+	CLOCK_SetMux(kCLOCK_Flexio2Mux, 3);
+	/* Set Pll3 sw clock source. */
+	CLOCK_SetMux(kCLOCK_Pll3SwMux, 0);
+	/* Init ARM PLL. */
+	CLOCK_InitArmPll(&armPllConfig_clock_init);
+	/*
+	 * In SDK projects, SDRAM (configured by SEMC) will be initialized in either debug script
+	 * or dcd. With this macro SKIP_SYSCLK_INIT, system pll (selected to be SEMC source clock
+	 * in SDK projects) will be left unchanged.
+	 * Note: If another clock source is selected for SEMC, user may want to avoid changing that
+	 * clock as well.
+	 */
+#ifndef SKIP_SYSCLK_INIT
+#if defined(XIP_BOOT_HEADER_DCD_ENABLE) && (XIP_BOOT_HEADER_DCD_ENABLE == 1)
+    #warning "SKIP_SYSCLK_INIT should be defined to keep system pll (selected to be SEMC source \
+	clock in SDK projects) unchanged."
+#endif
+	/* Init System PLL. */
+	CLOCK_InitSysPll(&sysPllConfig_clock_init);
+	/* Init System pfd0. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd0, 24);
+	/* Init System pfd1. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd1, 16);
+	/* Init System pfd2. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd2, 29);
+	/* Init System pfd3. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd3, 35);
+#endif
+	/*
+	 * In SDK projects, external flash (configured by FLEXSPI) will be initialized by dcd.
+	 * With this macro XIP_EXTERNAL_FLASH, usb1 pll (selected to be FLEXSPI clock source in
+	 * SDK projects) will be left unchanged.
+	 * Note: If another clock source is selected for FLEXSPI, user may want to avoid changing
+	 * that clock as well.
+	 */
+#if !(defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1))
+	/* Init Usb1 PLL. */
+	CLOCK_InitUsb1Pll(&usb1PllConfig_clock_init);
+	/* Init Usb1 pfd0. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd0, 12);
+	/* Init Usb1 pfd1. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd1, 35);
+	/* Init Usb1 pfd2. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd2, 26);
+	/* Init Usb1 pfd3. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd3, 31);
+#endif
+	/* DeInit Audio PLL. */
+	CLOCK_DeinitAudioPll();
+	/* Bypass Audio PLL. */
+	CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllAudio, 1);
+	/* Set divider for Audio PLL. */
+	CCM_ANALOG->MISC2 &= ~CCM_ANALOG_MISC2_AUDIO_DIV_LSB_MASK;
+	CCM_ANALOG->MISC2 &= ~CCM_ANALOG_MISC2_AUDIO_DIV_MSB_MASK;
+	/* Enable Audio PLL output. */
+	CCM_ANALOG->PLL_AUDIO |= CCM_ANALOG_PLL_AUDIO_ENABLE_MASK;
+	/* Init Video PLL. */
+	uint32_t pllVideo;
+	/* Disable Video PLL output before initial Video PLL. */
+	CCM_ANALOG->PLL_VIDEO &= ~CCM_ANALOG_PLL_VIDEO_ENABLE_MASK;
+	/* Bypass PLL first */
+	CCM_ANALOG->PLL_VIDEO = (CCM_ANALOG->PLL_VIDEO &
+				(~CCM_ANALOG_PLL_VIDEO_BYPASS_CLK_SRC_MASK)) |
+				CCM_ANALOG_PLL_VIDEO_BYPASS_MASK |
+				CCM_ANALOG_PLL_VIDEO_BYPASS_CLK_SRC(0);
+	CCM_ANALOG->PLL_VIDEO_NUM = CCM_ANALOG_PLL_VIDEO_NUM_A(0);
+	CCM_ANALOG->PLL_VIDEO_DENOM = CCM_ANALOG_PLL_VIDEO_DENOM_B(1);
+	pllVideo = (CCM_ANALOG->PLL_VIDEO &
+		    (~(CCM_ANALOG_PLL_VIDEO_DIV_SELECT_MASK |
+		       CCM_ANALOG_PLL_VIDEO_POWERDOWN_MASK))) |
+		   CCM_ANALOG_PLL_VIDEO_ENABLE_MASK |
+		   CCM_ANALOG_PLL_VIDEO_DIV_SELECT(31);
+	pllVideo |= CCM_ANALOG_PLL_VIDEO_POST_DIV_SELECT(1);
+	CCM_ANALOG->MISC2 = (CCM_ANALOG->MISC2 & (~CCM_ANALOG_MISC2_VIDEO_DIV_MASK)) |
+			     CCM_ANALOG_MISC2_VIDEO_DIV(3);
+	CCM_ANALOG->PLL_VIDEO = pllVideo;
+	while ((CCM_ANALOG->PLL_VIDEO & CCM_ANALOG_PLL_VIDEO_LOCK_MASK) == 0) {
+	}
+	/* Disable bypass for Video PLL. */
+	CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllVideo, 0);
+	/* Init Enet PLL. */
+	CLOCK_InitEnetPll(&enetPllConfig_clock_init);
+	/* DeInit Usb2 PLL. */
+	CLOCK_DeinitUsb2Pll();
+	/* Bypass Usb2 PLL. */
+	CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllUsb2, 1);
+	/* Enable Usb2 PLL output. */
+	CCM_ANALOG->PLL_USB2 |= CCM_ANALOG_PLL_USB2_ENABLE_MASK;
+	/* Set preperiph clock source. */
+	CLOCK_SetMux(kCLOCK_PrePeriphMux, 3);
+	/* Set periph clock source. */
+	CLOCK_SetMux(kCLOCK_PeriphMux, 0);
+	/* Set periph clock2 clock source. */
+	CLOCK_SetMux(kCLOCK_PeriphClk2Mux, 1);
+	/* Set per clock source. */
+	CLOCK_SetMux(kCLOCK_PerclkMux, 0);
+	/* Set lvds1 clock source. */
+	CCM_ANALOG->MISC1 = (CCM_ANALOG->MISC1 & (~CCM_ANALOG_MISC1_LVDS1_CLK_SEL_MASK)) |
+			     CCM_ANALOG_MISC1_LVDS1_CLK_SEL(0);
+	/* Set clock out1 divider. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO1_DIV_MASK)) | CCM_CCOSR_CLKO1_DIV(0);
+	/* Set clock out1 source. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO1_SEL_MASK)) | CCM_CCOSR_CLKO1_SEL(1);
+	/* Set clock out2 divider. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO2_DIV_MASK)) | CCM_CCOSR_CLKO2_DIV(0);
+	/* Set clock out2 source. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO2_SEL_MASK)) | CCM_CCOSR_CLKO2_SEL(14);
+	/* Set clock out1 drives clock out1. */
+	CCM->CCOSR &= ~CCM_CCOSR_CLK_OUT_SEL_MASK;
+	/* Disable clock out1. */
+	CCM->CCOSR &= ~CCM_CCOSR_CLKO1_EN_MASK;
+	/* Disable clock out2. */
+	CCM->CCOSR &= ~CCM_CCOSR_CLKO2_EN_MASK;
+	/* Set SAI1 MCLK1 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk1Sel, 0);
+	/* Set SAI1 MCLK2 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk2Sel, 0);
+	/* Set SAI1 MCLK3 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk3Sel, 0);
+	/* Set SAI2 MCLK3 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI2MClk3Sel, 0);
+	/* Set SAI3 MCLK3 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI3MClk3Sel, 0);
+	/* Set MQS configuration. */
+	IOMUXC_MQSConfig(IOMUXC_GPR, kIOMUXC_MqsPwmOverSampleRate32, 0);
+	/* Set ENET Ref clock source. */
+	IOMUXC_GPR->GPR1 &= ~IOMUXC_GPR_GPR1_ENET1_TX_CLK_DIR_MASK;
+	/* Set ENET2 Ref clock source. */
+	IOMUXC_GPR->GPR1 &= ~IOMUXC_GPR_GPR1_ENET2_TX_CLK_DIR_MASK;
+	/* Set GPT1 High frequency reference clock source. */
+	IOMUXC_GPR->GPR5 &= ~IOMUXC_GPR_GPR5_VREF_1M_CLK_GPT1_MASK;
+	/* Set GPT2 High frequency reference clock source. */
+	IOMUXC_GPR->GPR5 &= ~IOMUXC_GPR_GPR5_VREF_1M_CLK_GPT2_MASK;
+	/* Set SystemCoreClock variable. */
+	SystemCoreClock = CLOCK_INIT_CORE_CLOCK;
+}

--- a/boards/arm/mm_feather/clock_config.h
+++ b/boards/arm/mm_feather/clock_config.h
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2021, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _CLOCK_CONFIG_H_
+#define _CLOCK_CONFIG_H_
+
+#include "fsl_common.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+/*!< Board xtal0 frequency in Hz */
+#define BOARD_XTAL0_CLK_HZ                         24000000U
+
+/*!< Board xtal32k frequency in Hz */
+#define BOARD_XTAL32K_CLK_HZ                          32768U
+/*******************************************************************************
+ ************************ BOARD_InitBootClocks function ************************
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus*/
+
+/*!
+ * @brief This function executes default configuration of clocks.
+ *
+ */
+void BOARD_InitBootClocks(void);
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus*/
+
+/*******************************************************************************
+ ************************** Configuration clock_init ***************************
+ ******************************************************************************/
+/*******************************************************************************
+ * Definitions for clock_init configuration
+ ******************************************************************************/
+/*!< Core clock frequency: 600000000Hz */
+#define CLOCK_INIT_CORE_CLOCK                     600000000U
+
+/* Clock outputs (values are in Hz): */
+#define CLOCK_INIT_AHB_CLK_ROOT                       600000000UL
+#define CLOCK_INIT_CAN_CLK_ROOT                       40000000UL
+#define CLOCK_INIT_CKIL_SYNC_CLK_ROOT                 32768UL
+#define CLOCK_INIT_CLKO1_CLK                          0UL
+#define CLOCK_INIT_CLKO2_CLK                          0UL
+#define CLOCK_INIT_CLK_1M                             1000000UL
+#define CLOCK_INIT_CLK_24M                            24000000UL
+#define CLOCK_INIT_CSI_CLK_ROOT                       24000000UL
+#define CLOCK_INIT_ENET2_125M_CLK                     0UL
+#define CLOCK_INIT_ENET2_REF_CLK                      0UL
+#define CLOCK_INIT_ENET2_TX_CLK                       0UL
+#define CLOCK_INIT_ENET_125M_CLK                      50000000UL
+#define CLOCK_INIT_ENET_25M_REF_CLK                   25000000UL
+#define CLOCK_INIT_ENET_REF_CLK                       0UL
+#define CLOCK_INIT_ENET_TX_CLK                        0UL
+#define CLOCK_INIT_FLEXIO1_CLK_ROOT                   30000000UL
+#define CLOCK_INIT_FLEXIO2_CLK_ROOT                   30000000UL
+#define CLOCK_INIT_FLEXSPI2_CLK_ROOT                  102857142UL
+#define CLOCK_INIT_FLEXSPI_CLK_ROOT                   90000000UL
+#define CLOCK_INIT_GPT1_IPG_CLK_HIGHFREQ              75000000UL
+#define CLOCK_INIT_GPT2_IPG_CLK_HIGHFREQ              75000000UL
+#define CLOCK_INIT_IPG_CLK_ROOT                       150000000UL
+#define CLOCK_INIT_LCDIF_CLK_ROOT                     9300000UL
+#define CLOCK_INIT_LPI2C_CLK_ROOT                     10000000UL
+#define CLOCK_INIT_LPSPI_CLK_ROOT                     90000000UL
+#define CLOCK_INIT_LVDS1_CLK                          1200000000UL
+#define CLOCK_INIT_MQS_MCLK                           41538461UL
+#define CLOCK_INIT_PERCLK_CLK_ROOT                    75000000UL
+#define CLOCK_INIT_PLL7_MAIN_CLK                      24000000UL
+#define CLOCK_INIT_SAI1_CLK_ROOT                      41538461UL
+#define CLOCK_INIT_SAI1_MCLK1                         41538461UL
+#define CLOCK_INIT_SAI1_MCLK2                         41538461UL
+#define CLOCK_INIT_SAI1_MCLK3                         30000000UL
+#define CLOCK_INIT_SAI2_CLK_ROOT                      41538461UL
+#define CLOCK_INIT_SAI2_MCLK1                         41538461UL
+#define CLOCK_INIT_SAI2_MCLK2                         0UL
+#define CLOCK_INIT_SAI2_MCLK3                         30000000UL
+#define CLOCK_INIT_SAI3_CLK_ROOT                      41538461UL
+#define CLOCK_INIT_SAI3_MCLK1                         41538461UL
+#define CLOCK_INIT_SAI3_MCLK2                         0UL
+#define CLOCK_INIT_SAI3_MCLK3                         30000000UL
+#define CLOCK_INIT_SEMC_CLK_ROOT                      163862068UL
+#define CLOCK_INIT_SPDIF0_CLK_ROOT                    30000000UL
+#define CLOCK_INIT_SPDIF0_EXTCLK_OUT                  0UL
+#define CLOCK_INIT_TRACE_CLK_ROOT                     99000000UL
+#define CLOCK_INIT_UART_CLK_ROOT                      80000000UL
+#define CLOCK_INIT_USBPHY1_CLK                        480000000UL
+#define CLOCK_INIT_USBPHY2_CLK                        0UL
+#define CLOCK_INIT_USDHC1_CLK_ROOT                    198000000UL
+#define CLOCK_INIT_USDHC2_CLK_ROOT                    198000000UL
+
+/*! @brief Arm PLL set for clock_init configuration.
+ */
+extern const clock_arm_pll_config_t armPllConfig_clock_init;
+/*! @brief Usb1 PLL set for clock_init configuration.
+ */
+extern const clock_usb_pll_config_t usb1PllConfig_clock_init;
+/*! @brief Sys PLL for clock_init configuration.
+ */
+extern const clock_sys_pll_config_t sysPllConfig_clock_init;
+/*! @brief Video PLL set for clock_init configuration.
+ */
+extern const clock_video_pll_config_t videoPllConfig_clock_init;
+/*! @brief Enet PLL set for clock_init configuration.
+ */
+extern const clock_enet_pll_config_t enetPllConfig_clock_init;
+
+/*******************************************************************************
+ * API for clock_init configuration
+ ******************************************************************************/
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus*/
+
+/*!
+ * @brief This function executes configuration of clocks.
+ *
+ */
+void clock_init(void);
+
+#if defined(__cplusplus)
+}
+#endif  /* __cplusplus*/
+
+#endif  /* _CLOCK_CONFIG_H_ */

--- a/boards/arm/mm_feather/mm_feather.yaml
+++ b/boards/arm/mm_feather/mm_feather.yaml
@@ -19,7 +19,6 @@ supported:
   - sdhc
   - gpio
   - i2c
-  - dma
   - uart
   - pwm
   - spi

--- a/boards/arm/mm_swiftio/CMakeLists.txt
+++ b/boards/arm/mm_swiftio/CMakeLists.txt
@@ -5,6 +5,7 @@
 #
 
 zephyr_library()
-zephyr_library_sources(pinmux.c)
+zephyr_library_sources(pinmux.c clock_config.c)
 zephyr_sources_ifdef(CONFIG_BOOT_FLEXSPI_NOR flexspi_nor_config.c)
 zephyr_sources_ifdef(CONFIG_DEVICE_CONFIGURATION_DATA mmswiftio_sdram_ini_dcd.c)
+zephyr_include_directories(.)

--- a/boards/arm/mm_swiftio/clock_config.c
+++ b/boards/arm/mm_swiftio/clock_config.c
@@ -1,0 +1,561 @@
+/*
+ * Copyright (c) 2021, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * How to setup clock using clock driver functions:
+ *
+ * 1. Call CLOCK_InitXXXPLL() to configure corresponding PLL clock.
+ *
+ * 2. Call CLOCK_InitXXXpfd() to configure corresponding PLL pfd clock.
+ *
+ * 3. Call CLOCK_SetMux() to configure corresponding clock source for target clock out.
+ *
+ * 4. Call CLOCK_SetDiv() to configure corresponding clock divider for target clock out.
+ *
+ * 5. Call CLOCK_SetXtalFreq() to set XTAL frequency based on board settings.
+ *
+ */
+
+/* TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
+ * !!GlobalInfo
+ * product: Clocks v8.0
+ * processor: MIMXRT1052xxxxB
+ * package_id: MIMXRT1052DVL6B
+ * mcu_data: ksdk2_0
+ * processor_version: 10.0.0
+ * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS **********/
+
+#include "clock_config.h"
+#include "fsl_iomuxc.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+/* System clock frequency. */
+extern uint32_t SystemCoreClock;
+
+/*******************************************************************************
+ ************************ BOARD_InitBootClocks function ************************
+ ******************************************************************************/
+void BOARD_InitBootClocks(void)
+{
+	clock_init();
+}
+
+/*******************************************************************************
+ ************************** Configuration clock_init ***************************
+ ******************************************************************************/
+/* TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
+ * !!Configuration
+ * name: clock_init
+ * called_from_default_init: true
+ * outputs:
+ * - {id: AHB_CLK_ROOT.outFreq, value: 600 MHz}
+ * - {id: CAN_CLK_ROOT.outFreq, value: 40 MHz}
+ * - {id: CKIL_SYNC_CLK_ROOT.outFreq, value: 32.768 kHz}
+ * - {id: CLK_1M.outFreq, value: 1 MHz}
+ * - {id: CLK_24M.outFreq, value: 24 MHz}
+ * - {id: CSI_CLK_ROOT.outFreq, value: 24 MHz}
+ * - {id: ENET_125M_CLK.outFreq, value: 50 MHz}
+ * - {id: ENET_25M_REF_CLK.outFreq, value: 25 MHz}
+ * - {id: FLEXIO1_CLK_ROOT.outFreq, value: 30 MHz}
+ * - {id: FLEXIO2_CLK_ROOT.outFreq, value: 30 MHz}
+ * - {id: FLEXSPI_CLK_ROOT.outFreq, value: 90 MHz}
+ * - {id: GPT1_ipg_clk_highfreq.outFreq, value: 75 MHz}
+ * - {id: GPT2_ipg_clk_highfreq.outFreq, value: 75 MHz}
+ * - {id: IPG_CLK_ROOT.outFreq, value: 150 MHz}
+ * - {id: LCDIF_CLK_ROOT.outFreq, value: 9.3 MHz}
+ * - {id: LPI2C_CLK_ROOT.outFreq, value: 10 MHz}
+ * - {id: LPSPI_CLK_ROOT.outFreq, value: 90 MHz}
+ * - {id: LVDS1_CLK.outFreq, value: 1.2 GHz}
+ * - {id: MQS_MCLK.outFreq, value: 540/13 MHz}
+ * - {id: PERCLK_CLK_ROOT.outFreq, value: 75 MHz}
+ * - {id: PLL7_MAIN_CLK.outFreq, value: 24 MHz}
+ * - {id: SAI1_CLK_ROOT.outFreq, value: 540/13 MHz}
+ * - {id: SAI1_MCLK1.outFreq, value: 540/13 MHz}
+ * - {id: SAI1_MCLK2.outFreq, value: 540/13 MHz}
+ * - {id: SAI1_MCLK3.outFreq, value: 30 MHz}
+ * - {id: SAI2_CLK_ROOT.outFreq, value: 540/13 MHz}
+ * - {id: SAI2_MCLK1.outFreq, value: 540/13 MHz}
+ * - {id: SAI2_MCLK3.outFreq, value: 30 MHz}
+ * - {id: SAI3_CLK_ROOT.outFreq, value: 540/13 MHz}
+ * - {id: SAI3_MCLK1.outFreq, value: 540/13 MHz}
+ * - {id: SAI3_MCLK3.outFreq, value: 30 MHz}
+ * - {id: SEMC_CLK_ROOT.outFreq, value: 4752/29 MHz}
+ * - {id: SPDIF0_CLK_ROOT.outFreq, value: 30 MHz}
+ * - {id: TRACE_CLK_ROOT.outFreq, value: 99 MHz}
+ * - {id: UART_CLK_ROOT.outFreq, value: 80 MHz}
+ * - {id: USBPHY1_CLK.outFreq, value: 480 MHz}
+ * - {id: USDHC1_CLK_ROOT.outFreq, value: 198 MHz}
+ * - {id: USDHC2_CLK_ROOT.outFreq, value: 198 MHz}
+ * settings:
+ * - {id: CCM.AHB_PODF.scale, value: '1', locked: true}
+ * - {id: CCM.ARM_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.CLKO2_DIV.scale, value: '1', locked: true}
+ * - {id: CCM.CLKO2_SEL.sel, value: XTALOSC24M.OSC_CLK}
+ * - {id: CCM.CSI_PODF.scale, value: '1', locked: true}
+ * - {id: CCM.FLEXSPI_PODF.scale, value: '8', locked: true}
+ * - {id: CCM.FLEXSPI_SEL.sel, value: CCM_ANALOG.PLL3_PFD0_CLK}
+ * - {id: CCM.LCDIF_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.LCDIF_PRED.scale, value: '5', locked: true}
+ * - {id: CCM.LCDIF_PRE_CLK_SEL.sel, value: CCM_ANALOG.PLL5_MAIN_CLK}
+ * - {id: CCM.LPI2C_CLK_PODF.scale, value: '6', locked: true}
+ * - {id: CCM.LPSPI_CLK_SEL.sel, value: CCM_ANALOG.PLL3_PFD0_CLK}
+ * - {id: CCM.LPSPI_PODF.scale, value: '8', locked: true}
+ * - {id: CCM.PERCLK_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.PERIPH_CLK2_SEL.sel, value: XTALOSC24M.OSC_CLK}
+ * - {id: CCM.SAI2_CLK_PRED.scale, value: '4', locked: true}
+ * - {id: CCM.SEMC_CLK_SEL.sel, value: CCM.SEMC_ALT_CLK_SEL}
+ * - {id: CCM.SEMC_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.TRACE_PODF.scale, value: '4', locked: true}
+ * - {id: CCM.USDHC1_CLK_SEL.sel, value: CCM_ANALOG.PLL2_PFD0_CLK}
+ * - {id: CCM.USDHC1_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.USDHC2_CLK_SEL.sel, value: CCM_ANALOG.PLL2_PFD0_CLK}
+ * - {id: CCM.USDHC2_PODF.scale, value: '2', locked: true}
+ * - {id: CCM_ANALOG.PLL1_BYPASS.sel, value: CCM_ANALOG.PLL1}
+ * - {id: CCM_ANALOG.PLL1_PREDIV.scale, value: '1', locked: true}
+ * - {id: CCM_ANALOG.PLL1_VDIV.scale, value: '50', locked: true}
+ * - {id: CCM_ANALOG.PLL2.denom, value: '1', locked: true}
+ * - {id: CCM_ANALOG.PLL2.num, value: '0', locked: true}
+ * - {id: CCM_ANALOG.PLL2_BYPASS.sel, value: CCM_ANALOG.PLL2_OUT_CLK}
+ * - {id: CCM_ANALOG.PLL2_PFD0_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD0}
+ * - {id: CCM_ANALOG.PLL2_PFD0_DIV.scale, value: '24', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD0_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD1_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD1}
+ * - {id: CCM_ANALOG.PLL2_PFD2_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD2}
+ * - {id: CCM_ANALOG.PLL2_PFD2_DIV.scale, value: '29', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD2_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD3_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD3}
+ * - {id: CCM_ANALOG.PLL2_PFD3_DIV.scale, value: '35', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD3_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_BYPASS.sel, value: CCM_ANALOG.PLL3}
+ * - {id: CCM_ANALOG.PLL3_PFD0_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD0}
+ * - {id: CCM_ANALOG.PLL3_PFD0_DIV.scale, value: '12', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD0_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD1_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD1}
+ * - {id: CCM_ANALOG.PLL3_PFD1_DIV.scale, value: '35', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD1_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD2_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD2}
+ * - {id: CCM_ANALOG.PLL3_PFD2_DIV.scale, value: '26', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD2_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD3_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD3}
+ * - {id: CCM_ANALOG.PLL3_PFD3_DIV.scale, value: '31', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD3_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL4.denom, value: '50'}
+ * - {id: CCM_ANALOG.PLL4.div, value: '27', locked: true}
+ * - {id: CCM_ANALOG.PLL4_POST_DIV.scale, value: '4', locked: true}
+ * - {id: CCM_ANALOG.PLL5.denom, value: '1'}
+ * - {id: CCM_ANALOG.PLL5.div, value: '31', locked: true}
+ * - {id: CCM_ANALOG.PLL5.num, value: '0'}
+ * - {id: CCM_ANALOG.PLL5_BYPASS.sel, value: CCM_ANALOG.PLL5_POST_DIV}
+ * - {id: CCM_ANALOG.PLL5_POST_DIV.scale, value: '2', locked: true}
+ * - {id: CCM_ANALOG.PLL6_BYPASS.sel, value: CCM_ANALOG.PLL6}
+ * - {id: CCM_ANALOG.VIDEO_DIV.scale, value: '4', locked: true}
+ * - {id: CCM_ANALOG_PLL_USB1_EN_USB_CLKS_CFG, value: Enabled}
+ * - {id: CCM_ANALOG_PLL_USB1_EN_USB_CLKS_OUT_CFG, value: Enabled}
+ * - {id: CCM_ANALOG_PLL_USB1_POWER_CFG, value: 'Yes'}
+ * - {id: CCM_ANALOG_PLL_VIDEO_POWERDOWN_CFG, value: 'No'}
+ * sources:
+ * - {id: XTALOSC24M.RTC_OSC.outFreq, value: 32.768 kHz, enabled: true}
+ * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS **********/
+
+/*******************************************************************************
+ * Variables for clock_init configuration
+ ******************************************************************************/
+const clock_arm_pll_config_t armPllConfig_clock_init = {
+	/* PLL loop divider, Fout = Fin * 50 */
+	.loopDivider = 100,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+const clock_sys_pll_config_t sysPllConfig_clock_init = {
+	/* PLL loop divider, Fout = Fin * ( 20 + loopDivider*2 + numerator / denominator ) */
+	.loopDivider = 1,
+	/* 30 bit numerator of fractional loop divider */
+	.numerator = 0,
+	/* 30 bit denominator of fractional loop divider */
+	.denominator = 1,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+const clock_usb_pll_config_t usb1PllConfig_clock_init = {
+	/* PLL loop divider, Fout = Fin * 20 */
+	.loopDivider = 0,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+const clock_video_pll_config_t videoPllConfig_clock_init = {
+	/* PLL loop divider, Fout = Fin * ( loopDivider + numerator / denominator ) */
+	.loopDivider = 31,
+	/* Divider after PLL */
+	.postDivider = 8,
+	/*
+	 * 30 bit numerator of fractional loop divider,
+	 * Fout = Fin * ( loopDivider + numerator / denominator )
+	 */
+	.numerator = 0,
+	/*
+	 * 30 bit denominator of fractional loop divider,
+	 * Fout = Fin * ( loopDivider + numerator / denominator )
+	 */
+	.denominator = 1,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+const clock_enet_pll_config_t enetPllConfig_clock_init = {
+	/* Enable the PLL providing the ENET 125MHz reference clock */
+	.enableClkOutput = true,
+	/* Enable the PLL providing the ENET 25MHz reference clock */
+	.enableClkOutput25M = true,
+	/* Set frequency of ethernet reference clock to 50 MHz */
+	.loopDivider = 1,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+/*******************************************************************************
+ * Code for clock_init configuration
+ ******************************************************************************/
+void clock_init(void)
+{
+	/* Init RTC OSC clock frequency. */
+	CLOCK_SetRtcXtalFreq(32768U);
+	/* Enable 1MHz clock output. */
+	XTALOSC24M->OSC_CONFIG2 |= XTALOSC24M_OSC_CONFIG2_ENABLE_1M_MASK;
+	/* Use free 1MHz clock output. */
+	XTALOSC24M->OSC_CONFIG2 &= ~XTALOSC24M_OSC_CONFIG2_MUX_1M_MASK;
+	/* Set XTAL 24MHz clock frequency. */
+	CLOCK_SetXtalFreq(24000000U);
+	/* Enable XTAL 24MHz clock source. */
+	CLOCK_InitExternalClk(0);
+	/* Enable internal RC. */
+	CLOCK_InitRcOsc24M();
+	/* Switch clock source to external OSC. */
+	CLOCK_SwitchOsc(kCLOCK_XtalOsc);
+	/* Set Oscillator ready counter value. */
+	CCM->CCR = (CCM->CCR & (~CCM_CCR_OSCNT_MASK)) | CCM_CCR_OSCNT(127);
+	/* Setting PeriphClk2Mux and PeriphMux to provide stable clock before PLLs are initialed */
+	CLOCK_SetMux(kCLOCK_PeriphClk2Mux, 1);  /* Set PERIPH_CLK2 MUX to OSC */
+	CLOCK_SetMux(kCLOCK_PeriphMux, 1);      /* Set PERIPH_CLK MUX to PERIPH_CLK2 */
+	/* Setting the VDD_SOC to 1.275V. It is necessary to config AHB to 600Mhz. */
+	DCDC->REG3 = (DCDC->REG3 & (~DCDC_REG3_TRG_MASK)) | DCDC_REG3_TRG(0x13);
+	/* Waiting for DCDC_STS_DC_OK bit is asserted */
+	while (DCDC_REG0_STS_DC_OK_MASK != (DCDC_REG0_STS_DC_OK_MASK & DCDC->REG0)) {
+	}
+	/* Set AHB_PODF. */
+	CLOCK_SetDiv(kCLOCK_AhbDiv, 0);
+	/* Disable IPG clock gate. */
+	CLOCK_DisableClock(kCLOCK_Adc1);
+	CLOCK_DisableClock(kCLOCK_Adc2);
+	CLOCK_DisableClock(kCLOCK_Xbar1);
+	CLOCK_DisableClock(kCLOCK_Xbar2);
+	CLOCK_DisableClock(kCLOCK_Xbar3);
+	/* Set IPG_PODF. */
+	CLOCK_SetDiv(kCLOCK_IpgDiv, 3);
+	/* Set ARM_PODF. */
+	CLOCK_SetDiv(kCLOCK_ArmDiv, 1);
+	/* Set PERIPH_CLK2_PODF. */
+	CLOCK_SetDiv(kCLOCK_PeriphClk2Div, 0);
+	/* Disable PERCLK clock gate. */
+	CLOCK_DisableClock(kCLOCK_Gpt1);
+	CLOCK_DisableClock(kCLOCK_Gpt1S);
+	CLOCK_DisableClock(kCLOCK_Gpt2);
+	CLOCK_DisableClock(kCLOCK_Gpt2S);
+	CLOCK_DisableClock(kCLOCK_Pit);
+	/* Set PERCLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_PerclkDiv, 1);
+	/* Disable USDHC1 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Usdhc1);
+	/* Set USDHC1_PODF. */
+	CLOCK_SetDiv(kCLOCK_Usdhc1Div, 1);
+	/* Set Usdhc1 clock source. */
+	CLOCK_SetMux(kCLOCK_Usdhc1Mux, 1);
+	/* Disable USDHC2 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Usdhc2);
+	/* Set USDHC2_PODF. */
+	CLOCK_SetDiv(kCLOCK_Usdhc2Div, 1);
+	/* Set Usdhc2 clock source. */
+	CLOCK_SetMux(kCLOCK_Usdhc2Mux, 1);
+	/*
+	 * In SDK projects, SDRAM (configured by SEMC) will be initialized in either debug script or
+	 * dcd. With this macro SKIP_SYSCLK_INIT, system pll (selected to be SEMC source clock in
+	 * SDK projects) will be left unchanged.
+	 * Note: If another clock source is selected for SEMC, user may want to avoid changing that
+	 * clock as well.
+	 */
+#ifndef SKIP_SYSCLK_INIT
+	/* Disable Semc clock gate. */
+	CLOCK_DisableClock(kCLOCK_Semc);
+	/* Set SEMC_PODF. */
+	CLOCK_SetDiv(kCLOCK_SemcDiv, 1);
+	/* Set Semc alt clock source. */
+	CLOCK_SetMux(kCLOCK_SemcAltMux, 0);
+	/* Set Semc clock source. */
+	CLOCK_SetMux(kCLOCK_SemcMux, 1);
+#endif
+	/*
+	 * In SDK projects, external flash (configured by FLEXSPI) will be initialized by dcd.
+	 * With this macro XIP_EXTERNAL_FLASH, usb1 pll (selected to be FLEXSPI clock source in SDK
+	 * projects) will be left unchanged.
+	 * Note: If another clock source is selected for FLEXSPI, user may want to avoid changing
+	 * that clock as well.
+	 */
+#if !(defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1))
+	/* Disable Flexspi clock gate. */
+	CLOCK_DisableClock(kCLOCK_FlexSpi);
+	/* Set FLEXSPI_PODF. */
+	CLOCK_SetDiv(kCLOCK_FlexspiDiv, 7);
+	/* Set Flexspi clock source. */
+	CLOCK_SetMux(kCLOCK_FlexspiMux, 3);
+#endif
+	/* Disable CSI clock gate. */
+	CLOCK_DisableClock(kCLOCK_Csi);
+	/* Set CSI_PODF. */
+	CLOCK_SetDiv(kCLOCK_CsiDiv, 0);
+	/* Set Csi clock source. */
+	CLOCK_SetMux(kCLOCK_CsiMux, 0);
+	/* Disable LPSPI clock gate. */
+	CLOCK_DisableClock(kCLOCK_Lpspi1);
+	CLOCK_DisableClock(kCLOCK_Lpspi2);
+	CLOCK_DisableClock(kCLOCK_Lpspi3);
+	CLOCK_DisableClock(kCLOCK_Lpspi4);
+	/* Set LPSPI_PODF. */
+	CLOCK_SetDiv(kCLOCK_LpspiDiv, 7);
+	/* Set Lpspi clock source. */
+	CLOCK_SetMux(kCLOCK_LpspiMux, 1);
+	/* Disable TRACE clock gate. */
+	CLOCK_DisableClock(kCLOCK_Trace);
+	/* Set TRACE_PODF. */
+	CLOCK_SetDiv(kCLOCK_TraceDiv, 3);
+	/* Set Trace clock source. */
+	CLOCK_SetMux(kCLOCK_TraceMux, 2);
+	/* Disable SAI1 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Sai1);
+	/* Set SAI1_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Sai1PreDiv, 3);
+	/* Set SAI1_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Sai1Div, 1);
+	/* Set Sai1 clock source. */
+	CLOCK_SetMux(kCLOCK_Sai1Mux, 0);
+	/* Disable SAI2 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Sai2);
+	/* Set SAI2_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Sai2PreDiv, 3);
+	/* Set SAI2_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Sai2Div, 1);
+	/* Set Sai2 clock source. */
+	CLOCK_SetMux(kCLOCK_Sai2Mux, 0);
+	/* Disable SAI3 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Sai3);
+	/* Set SAI3_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Sai3PreDiv, 3);
+	/* Set SAI3_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Sai3Div, 1);
+	/* Set Sai3 clock source. */
+	CLOCK_SetMux(kCLOCK_Sai3Mux, 0);
+	/* Disable Lpi2c clock gate. */
+	CLOCK_DisableClock(kCLOCK_Lpi2c1);
+	CLOCK_DisableClock(kCLOCK_Lpi2c2);
+	CLOCK_DisableClock(kCLOCK_Lpi2c3);
+	/* Set LPI2C_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Lpi2cDiv, 5);
+	/* Set Lpi2c clock source. */
+	CLOCK_SetMux(kCLOCK_Lpi2cMux, 0);
+	/* Disable CAN clock gate. */
+	CLOCK_DisableClock(kCLOCK_Can1);
+	CLOCK_DisableClock(kCLOCK_Can2);
+	CLOCK_DisableClock(kCLOCK_Can1S);
+	CLOCK_DisableClock(kCLOCK_Can2S);
+	/* Set CAN_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_CanDiv, 1);
+	/* Set Can clock source. */
+	CLOCK_SetMux(kCLOCK_CanMux, 2);
+	/* Disable UART clock gate. */
+	CLOCK_DisableClock(kCLOCK_Lpuart1);
+	CLOCK_DisableClock(kCLOCK_Lpuart2);
+	CLOCK_DisableClock(kCLOCK_Lpuart3);
+	CLOCK_DisableClock(kCLOCK_Lpuart4);
+	CLOCK_DisableClock(kCLOCK_Lpuart5);
+	CLOCK_DisableClock(kCLOCK_Lpuart6);
+	CLOCK_DisableClock(kCLOCK_Lpuart7);
+	CLOCK_DisableClock(kCLOCK_Lpuart8);
+	/* Set UART_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_UartDiv, 0);
+	/* Set Uart clock source. */
+	CLOCK_SetMux(kCLOCK_UartMux, 0);
+	/* Disable LCDIF clock gate. */
+	CLOCK_DisableClock(kCLOCK_LcdPixel);
+	/* Set LCDIF_PRED. */
+	CLOCK_SetDiv(kCLOCK_LcdifPreDiv, 4);
+	/* Set LCDIF_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_LcdifDiv, 1);
+	/* Set Lcdif pre clock source. */
+	CLOCK_SetMux(kCLOCK_LcdifPreMux, 2);
+	/* Disable SPDIF clock gate. */
+	CLOCK_DisableClock(kCLOCK_Spdif);
+	/* Set SPDIF0_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Spdif0PreDiv, 1);
+	/* Set SPDIF0_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Spdif0Div, 7);
+	/* Set Spdif clock source. */
+	CLOCK_SetMux(kCLOCK_SpdifMux, 3);
+	/* Disable Flexio1 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Flexio1);
+	/* Set FLEXIO1_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Flexio1PreDiv, 1);
+	/* Set FLEXIO1_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Flexio1Div, 7);
+	/* Set Flexio1 clock source. */
+	CLOCK_SetMux(kCLOCK_Flexio1Mux, 3);
+	/* Disable Flexio2 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Flexio2);
+	/* Set FLEXIO2_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Flexio2PreDiv, 1);
+	/* Set FLEXIO2_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Flexio2Div, 7);
+	/* Set Flexio2 clock source. */
+	CLOCK_SetMux(kCLOCK_Flexio2Mux, 3);
+	/* Set Pll3 sw clock source. */
+	CLOCK_SetMux(kCLOCK_Pll3SwMux, 0);
+	/* Init ARM PLL. */
+	CLOCK_InitArmPll(&armPllConfig_clock_init);
+	/*
+	 * In SDK projects, SDRAM (configured by SEMC) will be initialized in either debug script or
+	 * dcd. With this macro SKIP_SYSCLK_INIT, system pll (selected to be SEMC source clock in
+	 * SDK projects) will be left unchanged.
+	 * Note: If another clock source is selected for SEMC, user may want to avoid changing that
+	 * clock as well.
+	 */
+#ifndef SKIP_SYSCLK_INIT
+#if defined(XIP_BOOT_HEADER_DCD_ENABLE) && (XIP_BOOT_HEADER_DCD_ENABLE == 1)
+    #warning "SKIP_SYSCLK_INIT should be defined to keep system pll (selected to be SEMC source \
+	clock in SDK projects) unchanged."
+#endif
+	/* Init System PLL. */
+	CLOCK_InitSysPll(&sysPllConfig_clock_init);
+	/* Init System pfd0. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd0, 24);
+	/* Init System pfd1. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd1, 16);
+	/* Init System pfd2. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd2, 29);
+	/* Init System pfd3. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd3, 35);
+	/* Disable pfd offset. */
+	CCM_ANALOG->PLL_SYS &= ~CCM_ANALOG_PLL_SYS_PFD_OFFSET_EN_MASK;
+#endif
+	/*
+	 * In SDK projects, external flash (configured by FLEXSPI) will be initialized by dcd.
+	 * With this macro XIP_EXTERNAL_FLASH, usb1 pll (selected to be FLEXSPI clock source in
+	 * SDK projects) will be left unchanged.
+	 * Note: If another clock source is selected for FLEXSPI, user may want to avoid changing
+	 * that clock as well.
+	 */
+#if !(defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1))
+	/* Init Usb1 PLL. */
+	CLOCK_InitUsb1Pll(&usb1PllConfig_clock_init);
+	/* Init Usb1 pfd0. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd0, 12);
+	/* Init Usb1 pfd1. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd1, 35);
+	/* Init Usb1 pfd2. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd2, 26);
+	/* Init Usb1 pfd3. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd3, 31);
+#endif
+	/* DeInit Audio PLL. */
+	CLOCK_DeinitAudioPll();
+	/* Bypass Audio PLL. */
+	CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllAudio, 1);
+	/* Set divider for Audio PLL. */
+	CCM_ANALOG->MISC2 &= ~CCM_ANALOG_MISC2_AUDIO_DIV_LSB_MASK;
+	CCM_ANALOG->MISC2 &= ~CCM_ANALOG_MISC2_AUDIO_DIV_MSB_MASK;
+	/* Enable Audio PLL output. */
+	CCM_ANALOG->PLL_AUDIO |= CCM_ANALOG_PLL_AUDIO_ENABLE_MASK;
+	/* Init Video PLL. */
+	uint32_t pllVideo;
+	/* Disable Video PLL output before initial Video PLL. */
+	CCM_ANALOG->PLL_VIDEO &= ~CCM_ANALOG_PLL_VIDEO_ENABLE_MASK;
+	/* Bypass PLL first */
+	CCM_ANALOG->PLL_VIDEO = (CCM_ANALOG->PLL_VIDEO &
+				(~CCM_ANALOG_PLL_VIDEO_BYPASS_CLK_SRC_MASK)) |
+				CCM_ANALOG_PLL_VIDEO_BYPASS_MASK |
+				CCM_ANALOG_PLL_VIDEO_BYPASS_CLK_SRC(0);
+	CCM_ANALOG->PLL_VIDEO_NUM = CCM_ANALOG_PLL_VIDEO_NUM_A(0);
+	CCM_ANALOG->PLL_VIDEO_DENOM = CCM_ANALOG_PLL_VIDEO_DENOM_B(1);
+	pllVideo = (CCM_ANALOG->PLL_VIDEO & (~(CCM_ANALOG_PLL_VIDEO_DIV_SELECT_MASK |
+		   CCM_ANALOG_PLL_VIDEO_POWERDOWN_MASK))) |
+		   CCM_ANALOG_PLL_VIDEO_ENABLE_MASK |
+		   CCM_ANALOG_PLL_VIDEO_DIV_SELECT(31);
+	pllVideo |= CCM_ANALOG_PLL_VIDEO_POST_DIV_SELECT(1);
+	CCM_ANALOG->MISC2 = (CCM_ANALOG->MISC2 & (~CCM_ANALOG_MISC2_VIDEO_DIV_MASK)) |
+			     CCM_ANALOG_MISC2_VIDEO_DIV(3);
+	CCM_ANALOG->PLL_VIDEO = pllVideo;
+	while ((CCM_ANALOG->PLL_VIDEO & CCM_ANALOG_PLL_VIDEO_LOCK_MASK) == 0) {
+	}
+	/* Disable pfd offset. */
+	CCM_ANALOG->PLL_VIDEO &= ~CCM_ANALOG_PLL_VIDEO_PFD_OFFSET_EN_MASK;
+	/* Disable bypass for Video PLL. */
+	CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllVideo, 0);
+	/* Init Enet PLL. */
+	CLOCK_InitEnetPll(&enetPllConfig_clock_init);
+	/* Disable pfd offset. */
+	CCM_ANALOG->PLL_ENET &= ~CCM_ANALOG_PLL_ENET_PFD_OFFSET_EN_MASK;
+	/* DeInit Usb2 PLL. */
+	CLOCK_DeinitUsb2Pll();
+	/* Bypass Usb2 PLL. */
+	CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllUsb2, 1);
+	/* Enable Usb2 PLL output. */
+	CCM_ANALOG->PLL_USB2 |= CCM_ANALOG_PLL_USB2_ENABLE_MASK;
+	/* Set preperiph clock source. */
+	CLOCK_SetMux(kCLOCK_PrePeriphMux, 3);
+	/* Set periph clock source. */
+	CLOCK_SetMux(kCLOCK_PeriphMux, 0);
+	/* Set periph clock2 clock source. */
+	CLOCK_SetMux(kCLOCK_PeriphClk2Mux, 1);
+	/* Set per clock source. */
+	CLOCK_SetMux(kCLOCK_PerclkMux, 0);
+	/* Set lvds1 clock source. */
+	CCM_ANALOG->MISC1 = (CCM_ANALOG->MISC1 & (~CCM_ANALOG_MISC1_LVDS1_CLK_SEL_MASK)) |
+			     CCM_ANALOG_MISC1_LVDS1_CLK_SEL(0);
+	/* Set clock out1 divider. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO1_DIV_MASK)) | CCM_CCOSR_CLKO1_DIV(0);
+	/* Set clock out1 source. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO1_SEL_MASK)) | CCM_CCOSR_CLKO1_SEL(1);
+	/* Set clock out2 divider. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO2_DIV_MASK)) | CCM_CCOSR_CLKO2_DIV(0);
+	/* Set clock out2 source. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO2_SEL_MASK)) | CCM_CCOSR_CLKO2_SEL(14);
+	/* Set clock out1 drives clock out1. */
+	CCM->CCOSR &= ~CCM_CCOSR_CLK_OUT_SEL_MASK;
+	/* Disable clock out1. */
+	CCM->CCOSR &= ~CCM_CCOSR_CLKO1_EN_MASK;
+	/* Disable clock out2. */
+	CCM->CCOSR &= ~CCM_CCOSR_CLKO2_EN_MASK;
+	/* Set SAI1 MCLK1 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk1Sel, 0);
+	/* Set SAI1 MCLK2 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk2Sel, 0);
+	/* Set SAI1 MCLK3 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk3Sel, 0);
+	/* Set SAI2 MCLK3 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI2MClk3Sel, 0);
+	/* Set SAI3 MCLK3 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI3MClk3Sel, 0);
+	/* Set MQS configuration. */
+	IOMUXC_MQSConfig(IOMUXC_GPR, kIOMUXC_MqsPwmOverSampleRate32, 0);
+	/* Set ENET Ref clock source. */
+	IOMUXC_GPR->GPR1 &= ~IOMUXC_GPR_GPR1_ENET1_TX_CLK_DIR_MASK;
+	/* Set GPT1 High frequency reference clock source. */
+	IOMUXC_GPR->GPR5 &= ~IOMUXC_GPR_GPR5_VREF_1M_CLK_GPT1_MASK;
+	/* Set GPT2 High frequency reference clock source. */
+	IOMUXC_GPR->GPR5 &= ~IOMUXC_GPR_GPR5_VREF_1M_CLK_GPT2_MASK;
+	/* Set SystemCoreClock variable. */
+	SystemCoreClock = CLOCK_INIT_CORE_CLOCK;
+}

--- a/boards/arm/mm_swiftio/clock_config.h
+++ b/boards/arm/mm_swiftio/clock_config.h
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2021, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _CLOCK_CONFIG_H_
+#define _CLOCK_CONFIG_H_
+
+#include "fsl_common.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+/*!< Board xtal0 frequency in Hz */
+#define BOARD_XTAL0_CLK_HZ                         24000000U
+
+/*!< Board xtal32k frequency in Hz */
+#define BOARD_XTAL32K_CLK_HZ                          32768U
+/*******************************************************************************
+ ************************ BOARD_InitBootClocks function ************************
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus*/
+
+/*!
+ * @brief This function executes default configuration of clocks.
+ *
+ */
+void BOARD_InitBootClocks(void);
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus*/
+
+/*******************************************************************************
+ ************************** Configuration clock_init ***************************
+ ******************************************************************************/
+/*******************************************************************************
+ * Definitions for clock_init configuration
+ ******************************************************************************/
+/*!< Core clock frequency: 600000000Hz */
+#define CLOCK_INIT_CORE_CLOCK                     600000000U
+
+/* Clock outputs (values are in Hz): */
+#define CLOCK_INIT_AHB_CLK_ROOT                       600000000UL
+#define CLOCK_INIT_CAN_CLK_ROOT                       40000000UL
+#define CLOCK_INIT_CKIL_SYNC_CLK_ROOT                 32768UL
+#define CLOCK_INIT_CLKO1_CLK                          0UL
+#define CLOCK_INIT_CLKO2_CLK                          0UL
+#define CLOCK_INIT_CLK_1M                             1000000UL
+#define CLOCK_INIT_CLK_24M                            24000000UL
+#define CLOCK_INIT_CSI_CLK_ROOT                       24000000UL
+#define CLOCK_INIT_ENET_125M_CLK                      50000000UL
+#define CLOCK_INIT_ENET_25M_REF_CLK                   25000000UL
+#define CLOCK_INIT_ENET_REF_CLK                       0UL
+#define CLOCK_INIT_ENET_TX_CLK                        0UL
+#define CLOCK_INIT_FLEXIO1_CLK_ROOT                   30000000UL
+#define CLOCK_INIT_FLEXIO2_CLK_ROOT                   30000000UL
+#define CLOCK_INIT_FLEXSPI_CLK_ROOT                   90000000UL
+#define CLOCK_INIT_GPT1_IPG_CLK_HIGHFREQ              75000000UL
+#define CLOCK_INIT_GPT2_IPG_CLK_HIGHFREQ              75000000UL
+#define CLOCK_INIT_IPG_CLK_ROOT                       150000000UL
+#define CLOCK_INIT_LCDIF_CLK_ROOT                     9300000UL
+#define CLOCK_INIT_LPI2C_CLK_ROOT                     10000000UL
+#define CLOCK_INIT_LPSPI_CLK_ROOT                     90000000UL
+#define CLOCK_INIT_LVDS1_CLK                          1200000000UL
+#define CLOCK_INIT_MQS_MCLK                           41538461UL
+#define CLOCK_INIT_PERCLK_CLK_ROOT                    75000000UL
+#define CLOCK_INIT_PLL7_MAIN_CLK                      24000000UL
+#define CLOCK_INIT_SAI1_CLK_ROOT                      41538461UL
+#define CLOCK_INIT_SAI1_MCLK1                         41538461UL
+#define CLOCK_INIT_SAI1_MCLK2                         41538461UL
+#define CLOCK_INIT_SAI1_MCLK3                         30000000UL
+#define CLOCK_INIT_SAI2_CLK_ROOT                      41538461UL
+#define CLOCK_INIT_SAI2_MCLK1                         41538461UL
+#define CLOCK_INIT_SAI2_MCLK2                         0UL
+#define CLOCK_INIT_SAI2_MCLK3                         30000000UL
+#define CLOCK_INIT_SAI3_CLK_ROOT                      41538461UL
+#define CLOCK_INIT_SAI3_MCLK1                         41538461UL
+#define CLOCK_INIT_SAI3_MCLK2                         0UL
+#define CLOCK_INIT_SAI3_MCLK3                         30000000UL
+#define CLOCK_INIT_SEMC_CLK_ROOT                      163862068UL
+#define CLOCK_INIT_SPDIF0_CLK_ROOT                    30000000UL
+#define CLOCK_INIT_SPDIF0_EXTCLK_OUT                  0UL
+#define CLOCK_INIT_TRACE_CLK_ROOT                     99000000UL
+#define CLOCK_INIT_UART_CLK_ROOT                      80000000UL
+#define CLOCK_INIT_USBPHY1_CLK                        480000000UL
+#define CLOCK_INIT_USBPHY2_CLK                        0UL
+#define CLOCK_INIT_USDHC1_CLK_ROOT                    198000000UL
+#define CLOCK_INIT_USDHC2_CLK_ROOT                    198000000UL
+
+/*! @brief Arm PLL set for clock_init configuration.
+ */
+extern const clock_arm_pll_config_t armPllConfig_clock_init;
+/*! @brief Usb1 PLL set for clock_init configuration.
+ */
+extern const clock_usb_pll_config_t usb1PllConfig_clock_init;
+/*! @brief Sys PLL for clock_init configuration.
+ */
+extern const clock_sys_pll_config_t sysPllConfig_clock_init;
+/*! @brief Video PLL set for clock_init configuration.
+ */
+extern const clock_video_pll_config_t videoPllConfig_clock_init;
+/*! @brief Enet PLL set for clock_init configuration.
+ */
+extern const clock_enet_pll_config_t enetPllConfig_clock_init;
+
+/*******************************************************************************
+ * API for clock_init configuration
+ ******************************************************************************/
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus*/
+
+/*!
+ * @brief This function executes configuration of clocks.
+ *
+ */
+void clock_init(void);
+
+#if defined(__cplusplus)
+}
+#endif  /* __cplusplus*/
+
+#endif  /* _CLOCK_CONFIG_H_ */

--- a/boards/arm/teensy4/CMakeLists.txt
+++ b/boards/arm/teensy4/CMakeLists.txt
@@ -10,5 +10,6 @@ if(CONFIG_PINMUX)
     zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 endif()
 
-zephyr_library_sources(flexspi_nor_config.c)
+zephyr_library_sources(flexspi_nor_config.c clock_config.c)
 zephyr_library_sources_ifdef(CONFIG_DEVICE_CONFIGURATION_DATA teensy4_sdram_ini_dcd.c)
+zephyr_include_directories(.)

--- a/boards/arm/teensy4/clock_config.c
+++ b/boards/arm/teensy4/clock_config.c
@@ -1,0 +1,573 @@
+/*
+ * Copyright (c) 2021, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * How to setup clock using clock driver functions:
+ *
+ * 1. Call CLOCK_InitXXXPLL() to configure corresponding PLL clock.
+ *
+ * 2. Call CLOCK_InitXXXpfd() to configure corresponding PLL pfd clock.
+ *
+ * 3. Call CLOCK_SetMux() to configure corresponding clock source for target clock out.
+ *
+ * 4. Call CLOCK_SetDiv() to configure corresponding clock divider for target clock out.
+ *
+ * 5. Call CLOCK_SetXtalFreq() to set XTAL frequency based on board settings.
+ *
+ */
+
+/* TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
+ * !!GlobalInfo
+ * product: Clocks v8.0
+ * processor: MIMXRT1062xxxxA
+ * package_id: MIMXRT1062DVL6A
+ * mcu_data: ksdk2_0
+ * processor_version: 10.0.0
+ * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS **********/
+
+#include "clock_config.h"
+#include "fsl_iomuxc.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+/* System clock frequency. */
+extern uint32_t SystemCoreClock;
+
+/*******************************************************************************
+ ************************ BOARD_InitBootClocks function ************************
+ ******************************************************************************/
+void BOARD_InitBootClocks(void)
+{
+	clock_init();
+}
+
+/*******************************************************************************
+ ************************** Configuration clock_init ***************************
+ ******************************************************************************/
+/* TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
+ * !!Configuration
+ * name: clock_init
+ * called_from_default_init: true
+ * outputs:
+ * - {id: AHB_CLK_ROOT.outFreq, value: 600 MHz}
+ * - {id: CAN_CLK_ROOT.outFreq, value: 40 MHz}
+ * - {id: CKIL_SYNC_CLK_ROOT.outFreq, value: 32.768 kHz}
+ * - {id: CLK_1M.outFreq, value: 1 MHz}
+ * - {id: CLK_24M.outFreq, value: 24 MHz}
+ * - {id: CSI_CLK_ROOT.outFreq, value: 24 MHz}
+ * - {id: ENET_125M_CLK.outFreq, value: 50 MHz}
+ * - {id: ENET_25M_REF_CLK.outFreq, value: 25 MHz}
+ * - {id: FLEXIO1_CLK_ROOT.outFreq, value: 30 MHz}
+ * - {id: FLEXIO2_CLK_ROOT.outFreq, value: 30 MHz}
+ * - {id: FLEXSPI2_CLK_ROOT.outFreq, value: 720/7 MHz}
+ * - {id: FLEXSPI_CLK_ROOT.outFreq, value: 90 MHz}
+ * - {id: GPT1_ipg_clk_highfreq.outFreq, value: 75 MHz}
+ * - {id: GPT2_ipg_clk_highfreq.outFreq, value: 75 MHz}
+ * - {id: IPG_CLK_ROOT.outFreq, value: 150 MHz}
+ * - {id: LCDIF_CLK_ROOT.outFreq, value: 9.3 MHz}
+ * - {id: LPI2C_CLK_ROOT.outFreq, value: 10 MHz}
+ * - {id: LPSPI_CLK_ROOT.outFreq, value: 90 MHz}
+ * - {id: LVDS1_CLK.outFreq, value: 1.2 GHz}
+ * - {id: MQS_MCLK.outFreq, value: 540/13 MHz}
+ * - {id: PERCLK_CLK_ROOT.outFreq, value: 75 MHz}
+ * - {id: PLL7_MAIN_CLK.outFreq, value: 24 MHz}
+ * - {id: SAI1_CLK_ROOT.outFreq, value: 540/13 MHz}
+ * - {id: SAI1_MCLK1.outFreq, value: 540/13 MHz}
+ * - {id: SAI1_MCLK2.outFreq, value: 540/13 MHz}
+ * - {id: SAI1_MCLK3.outFreq, value: 30 MHz}
+ * - {id: SAI2_CLK_ROOT.outFreq, value: 540/13 MHz}
+ * - {id: SAI2_MCLK1.outFreq, value: 540/13 MHz}
+ * - {id: SAI2_MCLK3.outFreq, value: 30 MHz}
+ * - {id: SAI3_CLK_ROOT.outFreq, value: 540/13 MHz}
+ * - {id: SAI3_MCLK1.outFreq, value: 540/13 MHz}
+ * - {id: SAI3_MCLK3.outFreq, value: 30 MHz}
+ * - {id: SEMC_CLK_ROOT.outFreq, value: 4752/29 MHz}
+ * - {id: SPDIF0_CLK_ROOT.outFreq, value: 30 MHz}
+ * - {id: TRACE_CLK_ROOT.outFreq, value: 99 MHz}
+ * - {id: UART_CLK_ROOT.outFreq, value: 80 MHz}
+ * - {id: USBPHY1_CLK.outFreq, value: 480 MHz}
+ * - {id: USDHC1_CLK_ROOT.outFreq, value: 198 MHz}
+ * - {id: USDHC2_CLK_ROOT.outFreq, value: 198 MHz}
+ * settings:
+ * - {id: CCM.AHB_PODF.scale, value: '1', locked: true}
+ * - {id: CCM.ARM_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.CLKO2_DIV.scale, value: '1', locked: true}
+ * - {id: CCM.CLKO2_SEL.sel, value: XTALOSC24M.OSC_CLK}
+ * - {id: CCM.CSI_PODF.scale, value: '1', locked: true}
+ * - {id: CCM.FLEXSPI2_PODF.scale, value: '7', locked: true}
+ * - {id: CCM.FLEXSPI2_SEL.sel, value: CCM_ANALOG.PLL3_PFD0_CLK}
+ * - {id: CCM.FLEXSPI_PODF.scale, value: '8', locked: true}
+ * - {id: CCM.FLEXSPI_SEL.sel, value: CCM_ANALOG.PLL3_PFD0_CLK}
+ * - {id: CCM.LCDIF_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.LCDIF_PRED.scale, value: '5', locked: true}
+ * - {id: CCM.LCDIF_PRE_CLK_SEL.sel, value: CCM_ANALOG.PLL5_MAIN_CLK}
+ * - {id: CCM.LPI2C_CLK_PODF.scale, value: '6', locked: true}
+ * - {id: CCM.LPSPI_CLK_SEL.sel, value: CCM_ANALOG.PLL3_PFD0_CLK}
+ * - {id: CCM.LPSPI_PODF.scale, value: '8', locked: true}
+ * - {id: CCM.PERCLK_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.PERIPH_CLK2_SEL.sel, value: XTALOSC24M.OSC_CLK}
+ * - {id: CCM.SAI2_CLK_PRED.scale, value: '4', locked: true}
+ * - {id: CCM.SEMC_CLK_SEL.sel, value: CCM.SEMC_ALT_CLK_SEL}
+ * - {id: CCM.SEMC_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.TRACE_PODF.scale, value: '4', locked: true}
+ * - {id: CCM.USDHC1_CLK_SEL.sel, value: CCM_ANALOG.PLL2_PFD0_CLK}
+ * - {id: CCM.USDHC1_PODF.scale, value: '2', locked: true}
+ * - {id: CCM.USDHC2_CLK_SEL.sel, value: CCM_ANALOG.PLL2_PFD0_CLK}
+ * - {id: CCM.USDHC2_PODF.scale, value: '2', locked: true}
+ * - {id: CCM_ANALOG.PLL1_BYPASS.sel, value: CCM_ANALOG.PLL1}
+ * - {id: CCM_ANALOG.PLL1_PREDIV.scale, value: '1', locked: true}
+ * - {id: CCM_ANALOG.PLL1_VDIV.scale, value: '50', locked: true}
+ * - {id: CCM_ANALOG.PLL2.denom, value: '1', locked: true}
+ * - {id: CCM_ANALOG.PLL2.num, value: '0', locked: true}
+ * - {id: CCM_ANALOG.PLL2_BYPASS.sel, value: CCM_ANALOG.PLL2_OUT_CLK}
+ * - {id: CCM_ANALOG.PLL2_PFD0_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD0}
+ * - {id: CCM_ANALOG.PLL2_PFD0_DIV.scale, value: '24', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD0_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD1_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD1}
+ * - {id: CCM_ANALOG.PLL2_PFD2_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD2}
+ * - {id: CCM_ANALOG.PLL2_PFD2_DIV.scale, value: '29', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD2_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD3_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD3}
+ * - {id: CCM_ANALOG.PLL2_PFD3_DIV.scale, value: '35', locked: true}
+ * - {id: CCM_ANALOG.PLL2_PFD3_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_BYPASS.sel, value: CCM_ANALOG.PLL3}
+ * - {id: CCM_ANALOG.PLL3_PFD0_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD0}
+ * - {id: CCM_ANALOG.PLL3_PFD0_DIV.scale, value: '12', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD0_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD1_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD1}
+ * - {id: CCM_ANALOG.PLL3_PFD1_DIV.scale, value: '35', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD1_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD2_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD2}
+ * - {id: CCM_ANALOG.PLL3_PFD2_DIV.scale, value: '26', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD2_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD3_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD3}
+ * - {id: CCM_ANALOG.PLL3_PFD3_DIV.scale, value: '31', locked: true}
+ * - {id: CCM_ANALOG.PLL3_PFD3_MUL.scale, value: '18', locked: true}
+ * - {id: CCM_ANALOG.PLL4.denom, value: '50'}
+ * - {id: CCM_ANALOG.PLL4.div, value: '27', locked: true}
+ * - {id: CCM_ANALOG.PLL4_POST_DIV.scale, value: '4', locked: true}
+ * - {id: CCM_ANALOG.PLL5.denom, value: '1'}
+ * - {id: CCM_ANALOG.PLL5.div, value: '31', locked: true}
+ * - {id: CCM_ANALOG.PLL5.num, value: '0'}
+ * - {id: CCM_ANALOG.PLL5_BYPASS.sel, value: CCM_ANALOG.PLL5_POST_DIV}
+ * - {id: CCM_ANALOG.PLL5_POST_DIV.scale, value: '2', locked: true}
+ * - {id: CCM_ANALOG.PLL6_BYPASS.sel, value: CCM_ANALOG.PLL6}
+ * - {id: CCM_ANALOG.VIDEO_DIV.scale, value: '4', locked: true}
+ * - {id: CCM_ANALOG_PLL_ENET_ENET2_REF_EN_CFG, value: Disabled}
+ * - {id: CCM_ANALOG_PLL_USB1_EN_USB_CLKS_CFG, value: Enabled}
+ * - {id: CCM_ANALOG_PLL_USB1_EN_USB_CLKS_OUT_CFG, value: Enabled}
+ * - {id: CCM_ANALOG_PLL_USB1_POWER_CFG, value: 'Yes'}
+ * - {id: CCM_ANALOG_PLL_VIDEO_POWERDOWN_CFG, value: 'No'}
+ * sources:
+ * - {id: XTALOSC24M.RTC_OSC.outFreq, value: 32.768 kHz, enabled: true}
+ * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS **********/
+
+/*******************************************************************************
+ * Variables for clock_init configuration
+ ******************************************************************************/
+const clock_arm_pll_config_t armPllConfig_clock_init = {
+	/* PLL loop divider, Fout = Fin * 50 */
+	.loopDivider = 100,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+const clock_sys_pll_config_t sysPllConfig_clock_init = {
+	/* PLL loop divider, Fout = Fin * ( 20 + loopDivider*2 + numerator / denominator ) */
+	.loopDivider = 1,
+	/* 30 bit numerator of fractional loop divider */
+	.numerator = 0,
+	/* 30 bit denominator of fractional loop divider */
+	.denominator = 1,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+const clock_usb_pll_config_t usb1PllConfig_clock_init = {
+	/* PLL loop divider, Fout = Fin * 20 */
+	.loopDivider = 0,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+const clock_video_pll_config_t videoPllConfig_clock_init = {
+	/* PLL loop divider, Fout = Fin * ( loopDivider + numerator / denominator ) */
+	.loopDivider = 31,
+	.postDivider = 8,                               /* Divider after PLL */
+	/*
+	 * 30 bit numerator of fractional loop divider,
+	 * Fout = Fin * ( loopDivider + numerator / denominator )
+	 */
+	.numerator = 0,
+	/*
+	 * 30 bit denominator of fractional loop divider,
+	 * Fout = Fin * ( loopDivider + numerator / denominator )
+	 */
+	.denominator = 1,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+const clock_enet_pll_config_t enetPllConfig_clock_init = {
+	/* Enable the PLL providing the ENET 125MHz reference clock */
+	.enableClkOutput = true,
+	/* Disable the PLL providing the ENET2 125MHz reference clock */
+	.enableClkOutput1 = false,
+	/* Enable the PLL providing the ENET 25MHz reference clock */
+	.enableClkOutput25M = true,
+	/* Set frequency of ethernet reference clock to 50 MHz */
+	.loopDivider = 1,
+	/* Set frequency of ethernet reference clock to 25 MHz */
+	.loopDivider1 = 0,
+	/* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+	.src = 0,
+};
+/*******************************************************************************
+ * Code for clock_init configuration
+ ******************************************************************************/
+void clock_init(void)
+{
+	/* Init RTC OSC clock frequency. */
+	CLOCK_SetRtcXtalFreq(32768U);
+	/* Enable 1MHz clock output. */
+	XTALOSC24M->OSC_CONFIG2 |= XTALOSC24M_OSC_CONFIG2_ENABLE_1M_MASK;
+	/* Use free 1MHz clock output. */
+	XTALOSC24M->OSC_CONFIG2 &= ~XTALOSC24M_OSC_CONFIG2_MUX_1M_MASK;
+	/* Set XTAL 24MHz clock frequency. */
+	CLOCK_SetXtalFreq(24000000U);
+	/* Enable XTAL 24MHz clock source. */
+	CLOCK_InitExternalClk(0);
+	/* Enable internal RC. */
+	CLOCK_InitRcOsc24M();
+	/* Switch clock source to external OSC. */
+	CLOCK_SwitchOsc(kCLOCK_XtalOsc);
+	/* Set Oscillator ready counter value. */
+	CCM->CCR = (CCM->CCR & (~CCM_CCR_OSCNT_MASK)) | CCM_CCR_OSCNT(127);
+	/* Setting PeriphClk2Mux and PeriphMux to provide stable clock before PLLs are initialed */
+	CLOCK_SetMux(kCLOCK_PeriphClk2Mux, 1);  /* Set PERIPH_CLK2 MUX to OSC */
+	CLOCK_SetMux(kCLOCK_PeriphMux, 1);      /* Set PERIPH_CLK MUX to PERIPH_CLK2 */
+	/* Setting the VDD_SOC to 1.275V. It is necessary to config AHB to 600Mhz. */
+	DCDC->REG3 = (DCDC->REG3 & (~DCDC_REG3_TRG_MASK)) | DCDC_REG3_TRG(0x13);
+	/* Waiting for DCDC_STS_DC_OK bit is asserted */
+	while (DCDC_REG0_STS_DC_OK_MASK != (DCDC_REG0_STS_DC_OK_MASK & DCDC->REG0)) {
+	}
+	/* Set AHB_PODF. */
+	CLOCK_SetDiv(kCLOCK_AhbDiv, 0);
+	/* Disable IPG clock gate. */
+	CLOCK_DisableClock(kCLOCK_Adc1);
+	CLOCK_DisableClock(kCLOCK_Adc2);
+	CLOCK_DisableClock(kCLOCK_Xbar1);
+	CLOCK_DisableClock(kCLOCK_Xbar2);
+	CLOCK_DisableClock(kCLOCK_Xbar3);
+	/* Set IPG_PODF. */
+	CLOCK_SetDiv(kCLOCK_IpgDiv, 3);
+	/* Set ARM_PODF. */
+	CLOCK_SetDiv(kCLOCK_ArmDiv, 1);
+	/* Set PERIPH_CLK2_PODF. */
+	CLOCK_SetDiv(kCLOCK_PeriphClk2Div, 0);
+	/* Disable PERCLK clock gate. */
+	CLOCK_DisableClock(kCLOCK_Gpt1);
+	CLOCK_DisableClock(kCLOCK_Gpt1S);
+	CLOCK_DisableClock(kCLOCK_Gpt2);
+	CLOCK_DisableClock(kCLOCK_Gpt2S);
+	CLOCK_DisableClock(kCLOCK_Pit);
+	/* Set PERCLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_PerclkDiv, 1);
+	/* Disable USDHC1 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Usdhc1);
+	/* Set USDHC1_PODF. */
+	CLOCK_SetDiv(kCLOCK_Usdhc1Div, 1);
+	/* Set Usdhc1 clock source. */
+	CLOCK_SetMux(kCLOCK_Usdhc1Mux, 1);
+	/* Disable USDHC2 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Usdhc2);
+	/* Set USDHC2_PODF. */
+	CLOCK_SetDiv(kCLOCK_Usdhc2Div, 1);
+	/* Set Usdhc2 clock source. */
+	CLOCK_SetMux(kCLOCK_Usdhc2Mux, 1);
+	/*
+	 * In SDK projects, SDRAM (configured by SEMC) will be initialized in either debug script
+	 * or dcd. With this macro SKIP_SYSCLK_INIT, system pll (selected to be SEMC source clock
+	 * in SDK projects) will be left unchanged.
+	 * Note: If another clock source is selected for SEMC, user may want to avoid changing
+	 * that clock as well.
+	 */
+#ifndef SKIP_SYSCLK_INIT
+	/* Disable Semc clock gate. */
+	CLOCK_DisableClock(kCLOCK_Semc);
+	/* Set SEMC_PODF. */
+	CLOCK_SetDiv(kCLOCK_SemcDiv, 1);
+	/* Set Semc alt clock source. */
+	CLOCK_SetMux(kCLOCK_SemcAltMux, 0);
+	/* Set Semc clock source. */
+	CLOCK_SetMux(kCLOCK_SemcMux, 1);
+#endif
+	/*
+	 * In SDK projects, external flash (configured by FLEXSPI) will be initialized by dcd.
+	 * With this macro XIP_EXTERNAL_FLASH, usb1 pll (selected to be FLEXSPI clock source in
+	 * SDK projects) will be left unchanged.
+	 * Note: If another clock source is selected for FLEXSPI, user may want to avoid changing
+	 * that clock as well.
+	 */
+#if !(defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1))
+	/* Disable Flexspi clock gate. */
+	CLOCK_DisableClock(kCLOCK_FlexSpi);
+	/* Set FLEXSPI_PODF. */
+	CLOCK_SetDiv(kCLOCK_FlexspiDiv, 7);
+	/* Set Flexspi clock source. */
+	CLOCK_SetMux(kCLOCK_FlexspiMux, 3);
+#endif
+	/* Disable Flexspi2 clock gate. */
+	CLOCK_DisableClock(kCLOCK_FlexSpi2);
+	/* Set FLEXSPI2_PODF. */
+	CLOCK_SetDiv(kCLOCK_Flexspi2Div, 6);
+	/* Set Flexspi2 clock source. */
+	CLOCK_SetMux(kCLOCK_Flexspi2Mux, 1);
+	/* Disable CSI clock gate. */
+	CLOCK_DisableClock(kCLOCK_Csi);
+	/* Set CSI_PODF. */
+	CLOCK_SetDiv(kCLOCK_CsiDiv, 0);
+	/* Set Csi clock source. */
+	CLOCK_SetMux(kCLOCK_CsiMux, 0);
+	/* Disable LPSPI clock gate. */
+	CLOCK_DisableClock(kCLOCK_Lpspi1);
+	CLOCK_DisableClock(kCLOCK_Lpspi2);
+	CLOCK_DisableClock(kCLOCK_Lpspi3);
+	CLOCK_DisableClock(kCLOCK_Lpspi4);
+	/* Set LPSPI_PODF. */
+	CLOCK_SetDiv(kCLOCK_LpspiDiv, 7);
+	/* Set Lpspi clock source. */
+	CLOCK_SetMux(kCLOCK_LpspiMux, 1);
+	/* Disable TRACE clock gate. */
+	CLOCK_DisableClock(kCLOCK_Trace);
+	/* Set TRACE_PODF. */
+	CLOCK_SetDiv(kCLOCK_TraceDiv, 3);
+	/* Set Trace clock source. */
+	CLOCK_SetMux(kCLOCK_TraceMux, 2);
+	/* Disable SAI1 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Sai1);
+	/* Set SAI1_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Sai1PreDiv, 3);
+	/* Set SAI1_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Sai1Div, 1);
+	/* Set Sai1 clock source. */
+	CLOCK_SetMux(kCLOCK_Sai1Mux, 0);
+	/* Disable SAI2 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Sai2);
+	/* Set SAI2_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Sai2PreDiv, 3);
+	/* Set SAI2_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Sai2Div, 1);
+	/* Set Sai2 clock source. */
+	CLOCK_SetMux(kCLOCK_Sai2Mux, 0);
+	/* Disable SAI3 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Sai3);
+	/* Set SAI3_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Sai3PreDiv, 3);
+	/* Set SAI3_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Sai3Div, 1);
+	/* Set Sai3 clock source. */
+	CLOCK_SetMux(kCLOCK_Sai3Mux, 0);
+	/* Disable Lpi2c clock gate. */
+	CLOCK_DisableClock(kCLOCK_Lpi2c1);
+	CLOCK_DisableClock(kCLOCK_Lpi2c2);
+	CLOCK_DisableClock(kCLOCK_Lpi2c3);
+	/* Set LPI2C_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Lpi2cDiv, 5);
+	/* Set Lpi2c clock source. */
+	CLOCK_SetMux(kCLOCK_Lpi2cMux, 0);
+	/* Disable CAN clock gate. */
+	CLOCK_DisableClock(kCLOCK_Can1);
+	CLOCK_DisableClock(kCLOCK_Can2);
+	CLOCK_DisableClock(kCLOCK_Can3);
+	CLOCK_DisableClock(kCLOCK_Can1S);
+	CLOCK_DisableClock(kCLOCK_Can2S);
+	CLOCK_DisableClock(kCLOCK_Can3S);
+	/* Set CAN_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_CanDiv, 1);
+	/* Set Can clock source. */
+	CLOCK_SetMux(kCLOCK_CanMux, 2);
+	/* Disable UART clock gate. */
+	CLOCK_DisableClock(kCLOCK_Lpuart1);
+	CLOCK_DisableClock(kCLOCK_Lpuart2);
+	CLOCK_DisableClock(kCLOCK_Lpuart3);
+	CLOCK_DisableClock(kCLOCK_Lpuart4);
+	CLOCK_DisableClock(kCLOCK_Lpuart5);
+	CLOCK_DisableClock(kCLOCK_Lpuart6);
+	CLOCK_DisableClock(kCLOCK_Lpuart7);
+	CLOCK_DisableClock(kCLOCK_Lpuart8);
+	/* Set UART_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_UartDiv, 0);
+	/* Set Uart clock source. */
+	CLOCK_SetMux(kCLOCK_UartMux, 0);
+	/* Disable LCDIF clock gate. */
+	CLOCK_DisableClock(kCLOCK_LcdPixel);
+	/* Set LCDIF_PRED. */
+	CLOCK_SetDiv(kCLOCK_LcdifPreDiv, 4);
+	/* Set LCDIF_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_LcdifDiv, 1);
+	/* Set Lcdif pre clock source. */
+	CLOCK_SetMux(kCLOCK_LcdifPreMux, 2);
+	/* Disable SPDIF clock gate. */
+	CLOCK_DisableClock(kCLOCK_Spdif);
+	/* Set SPDIF0_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Spdif0PreDiv, 1);
+	/* Set SPDIF0_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Spdif0Div, 7);
+	/* Set Spdif clock source. */
+	CLOCK_SetMux(kCLOCK_SpdifMux, 3);
+	/* Disable Flexio1 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Flexio1);
+	/* Set FLEXIO1_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Flexio1PreDiv, 1);
+	/* Set FLEXIO1_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Flexio1Div, 7);
+	/* Set Flexio1 clock source. */
+	CLOCK_SetMux(kCLOCK_Flexio1Mux, 3);
+	/* Disable Flexio2 clock gate. */
+	CLOCK_DisableClock(kCLOCK_Flexio2);
+	/* Set FLEXIO2_CLK_PRED. */
+	CLOCK_SetDiv(kCLOCK_Flexio2PreDiv, 1);
+	/* Set FLEXIO2_CLK_PODF. */
+	CLOCK_SetDiv(kCLOCK_Flexio2Div, 7);
+	/* Set Flexio2 clock source. */
+	CLOCK_SetMux(kCLOCK_Flexio2Mux, 3);
+	/* Set Pll3 sw clock source. */
+	CLOCK_SetMux(kCLOCK_Pll3SwMux, 0);
+	/* Init ARM PLL. */
+	CLOCK_InitArmPll(&armPllConfig_clock_init);
+	/*
+	 * In SDK projects, SDRAM (configured by SEMC) will be initialized in either debug script
+	 * or dcd. With this macro SKIP_SYSCLK_INIT, system pll (selected to be SEMC source clock
+	 * in SDK projects) will be left unchanged.
+	 * Note: If another clock source is selected for SEMC, user may want to avoid changing that
+	 * clock as well.
+	 */
+#ifndef SKIP_SYSCLK_INIT
+#if defined(XIP_BOOT_HEADER_DCD_ENABLE) && (XIP_BOOT_HEADER_DCD_ENABLE == 1)
+    #warning "SKIP_SYSCLK_INIT should be defined to keep system pll (selected to be SEMC source \
+	clock in SDK projects) unchanged."
+#endif
+	/* Init System PLL. */
+	CLOCK_InitSysPll(&sysPllConfig_clock_init);
+	/* Init System pfd0. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd0, 24);
+	/* Init System pfd1. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd1, 16);
+	/* Init System pfd2. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd2, 29);
+	/* Init System pfd3. */
+	CLOCK_InitSysPfd(kCLOCK_Pfd3, 35);
+#endif
+	/*
+	 * In SDK projects, external flash (configured by FLEXSPI) will be initialized by dcd.
+	 * With this macro XIP_EXTERNAL_FLASH, usb1 pll (selected to be FLEXSPI clock source in
+	 * SDK projects) will be left unchanged.
+	 * Note: If another clock source is selected for FLEXSPI, user may want to avoid changing
+	 * that clock as well.
+	 */
+#if !(defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1))
+	/* Init Usb1 PLL. */
+	CLOCK_InitUsb1Pll(&usb1PllConfig_clock_init);
+	/* Init Usb1 pfd0. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd0, 12);
+	/* Init Usb1 pfd1. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd1, 35);
+	/* Init Usb1 pfd2. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd2, 26);
+	/* Init Usb1 pfd3. */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd3, 31);
+#endif
+	/* DeInit Audio PLL. */
+	CLOCK_DeinitAudioPll();
+	/* Bypass Audio PLL. */
+	CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllAudio, 1);
+	/* Set divider for Audio PLL. */
+	CCM_ANALOG->MISC2 &= ~CCM_ANALOG_MISC2_AUDIO_DIV_LSB_MASK;
+	CCM_ANALOG->MISC2 &= ~CCM_ANALOG_MISC2_AUDIO_DIV_MSB_MASK;
+	/* Enable Audio PLL output. */
+	CCM_ANALOG->PLL_AUDIO |= CCM_ANALOG_PLL_AUDIO_ENABLE_MASK;
+	/* Init Video PLL. */
+	uint32_t pllVideo;
+	/* Disable Video PLL output before initial Video PLL. */
+	CCM_ANALOG->PLL_VIDEO &= ~CCM_ANALOG_PLL_VIDEO_ENABLE_MASK;
+	/* Bypass PLL first */
+	CCM_ANALOG->PLL_VIDEO = (CCM_ANALOG->PLL_VIDEO &
+				(~CCM_ANALOG_PLL_VIDEO_BYPASS_CLK_SRC_MASK)) |
+				CCM_ANALOG_PLL_VIDEO_BYPASS_MASK |
+				CCM_ANALOG_PLL_VIDEO_BYPASS_CLK_SRC(0);
+	CCM_ANALOG->PLL_VIDEO_NUM = CCM_ANALOG_PLL_VIDEO_NUM_A(0);
+	CCM_ANALOG->PLL_VIDEO_DENOM = CCM_ANALOG_PLL_VIDEO_DENOM_B(1);
+	pllVideo = (CCM_ANALOG->PLL_VIDEO &
+		    (~(CCM_ANALOG_PLL_VIDEO_DIV_SELECT_MASK |
+		       CCM_ANALOG_PLL_VIDEO_POWERDOWN_MASK))) |
+		   CCM_ANALOG_PLL_VIDEO_ENABLE_MASK |
+		   CCM_ANALOG_PLL_VIDEO_DIV_SELECT(31);
+	pllVideo |= CCM_ANALOG_PLL_VIDEO_POST_DIV_SELECT(1);
+	CCM_ANALOG->MISC2 = (CCM_ANALOG->MISC2 & (~CCM_ANALOG_MISC2_VIDEO_DIV_MASK)) |
+			     CCM_ANALOG_MISC2_VIDEO_DIV(3);
+	CCM_ANALOG->PLL_VIDEO = pllVideo;
+	while ((CCM_ANALOG->PLL_VIDEO & CCM_ANALOG_PLL_VIDEO_LOCK_MASK) == 0) {
+	}
+	/* Disable bypass for Video PLL. */
+	CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllVideo, 0);
+	/* Init Enet PLL. */
+	CLOCK_InitEnetPll(&enetPllConfig_clock_init);
+	/* DeInit Usb2 PLL. */
+	CLOCK_DeinitUsb2Pll();
+	/* Bypass Usb2 PLL. */
+	CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllUsb2, 1);
+	/* Enable Usb2 PLL output. */
+	CCM_ANALOG->PLL_USB2 |= CCM_ANALOG_PLL_USB2_ENABLE_MASK;
+	/* Set preperiph clock source. */
+	CLOCK_SetMux(kCLOCK_PrePeriphMux, 3);
+	/* Set periph clock source. */
+	CLOCK_SetMux(kCLOCK_PeriphMux, 0);
+	/* Set periph clock2 clock source. */
+	CLOCK_SetMux(kCLOCK_PeriphClk2Mux, 1);
+	/* Set per clock source. */
+	CLOCK_SetMux(kCLOCK_PerclkMux, 0);
+	/* Set lvds1 clock source. */
+	CCM_ANALOG->MISC1 = (CCM_ANALOG->MISC1 & (~CCM_ANALOG_MISC1_LVDS1_CLK_SEL_MASK)) |
+			     CCM_ANALOG_MISC1_LVDS1_CLK_SEL(0);
+	/* Set clock out1 divider. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO1_DIV_MASK)) | CCM_CCOSR_CLKO1_DIV(0);
+	/* Set clock out1 source. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO1_SEL_MASK)) | CCM_CCOSR_CLKO1_SEL(1);
+	/* Set clock out2 divider. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO2_DIV_MASK)) | CCM_CCOSR_CLKO2_DIV(0);
+	/* Set clock out2 source. */
+	CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO2_SEL_MASK)) | CCM_CCOSR_CLKO2_SEL(14);
+	/* Set clock out1 drives clock out1. */
+	CCM->CCOSR &= ~CCM_CCOSR_CLK_OUT_SEL_MASK;
+	/* Disable clock out1. */
+	CCM->CCOSR &= ~CCM_CCOSR_CLKO1_EN_MASK;
+	/* Disable clock out2. */
+	CCM->CCOSR &= ~CCM_CCOSR_CLKO2_EN_MASK;
+	/* Set SAI1 MCLK1 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk1Sel, 0);
+	/* Set SAI1 MCLK2 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk2Sel, 0);
+	/* Set SAI1 MCLK3 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk3Sel, 0);
+	/* Set SAI2 MCLK3 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI2MClk3Sel, 0);
+	/* Set SAI3 MCLK3 clock source. */
+	IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI3MClk3Sel, 0);
+	/* Set MQS configuration. */
+	IOMUXC_MQSConfig(IOMUXC_GPR, kIOMUXC_MqsPwmOverSampleRate32, 0);
+	/* Set ENET Ref clock source. */
+	IOMUXC_GPR->GPR1 &= ~IOMUXC_GPR_GPR1_ENET1_TX_CLK_DIR_MASK;
+	/* Set ENET2 Ref clock source. */
+	IOMUXC_GPR->GPR1 &= ~IOMUXC_GPR_GPR1_ENET2_TX_CLK_DIR_MASK;
+	/* Set GPT1 High frequency reference clock source. */
+	IOMUXC_GPR->GPR5 &= ~IOMUXC_GPR_GPR5_VREF_1M_CLK_GPT1_MASK;
+	/* Set GPT2 High frequency reference clock source. */
+	IOMUXC_GPR->GPR5 &= ~IOMUXC_GPR_GPR5_VREF_1M_CLK_GPT2_MASK;
+	/* Set SystemCoreClock variable. */
+	SystemCoreClock = CLOCK_INIT_CORE_CLOCK;
+}

--- a/boards/arm/teensy4/clock_config.h
+++ b/boards/arm/teensy4/clock_config.h
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2021, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _CLOCK_CONFIG_H_
+#define _CLOCK_CONFIG_H_
+
+#include "fsl_common.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+/*!< Board xtal0 frequency in Hz */
+#define BOARD_XTAL0_CLK_HZ                         24000000U
+
+/*!< Board xtal32k frequency in Hz */
+#define BOARD_XTAL32K_CLK_HZ                          32768U
+/*******************************************************************************
+ ************************ BOARD_InitBootClocks function ************************
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus*/
+
+/*!
+ * @brief This function executes default configuration of clocks.
+ *
+ */
+void BOARD_InitBootClocks(void);
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus*/
+
+/*******************************************************************************
+ ************************** Configuration clock_init ***************************
+ ******************************************************************************/
+/*******************************************************************************
+ * Definitions for clock_init configuration
+ ******************************************************************************/
+/*!< Core clock frequency: 600000000Hz */
+#define CLOCK_INIT_CORE_CLOCK                     600000000U
+
+/* Clock outputs (values are in Hz): */
+#define CLOCK_INIT_AHB_CLK_ROOT                       600000000UL
+#define CLOCK_INIT_CAN_CLK_ROOT                       40000000UL
+#define CLOCK_INIT_CKIL_SYNC_CLK_ROOT                 32768UL
+#define CLOCK_INIT_CLKO1_CLK                          0UL
+#define CLOCK_INIT_CLKO2_CLK                          0UL
+#define CLOCK_INIT_CLK_1M                             1000000UL
+#define CLOCK_INIT_CLK_24M                            24000000UL
+#define CLOCK_INIT_CSI_CLK_ROOT                       24000000UL
+#define CLOCK_INIT_ENET2_125M_CLK                     0UL
+#define CLOCK_INIT_ENET2_REF_CLK                      0UL
+#define CLOCK_INIT_ENET2_TX_CLK                       0UL
+#define CLOCK_INIT_ENET_125M_CLK                      50000000UL
+#define CLOCK_INIT_ENET_25M_REF_CLK                   25000000UL
+#define CLOCK_INIT_ENET_REF_CLK                       0UL
+#define CLOCK_INIT_ENET_TX_CLK                        0UL
+#define CLOCK_INIT_FLEXIO1_CLK_ROOT                   30000000UL
+#define CLOCK_INIT_FLEXIO2_CLK_ROOT                   30000000UL
+#define CLOCK_INIT_FLEXSPI2_CLK_ROOT                  102857142UL
+#define CLOCK_INIT_FLEXSPI_CLK_ROOT                   90000000UL
+#define CLOCK_INIT_GPT1_IPG_CLK_HIGHFREQ              75000000UL
+#define CLOCK_INIT_GPT2_IPG_CLK_HIGHFREQ              75000000UL
+#define CLOCK_INIT_IPG_CLK_ROOT                       150000000UL
+#define CLOCK_INIT_LCDIF_CLK_ROOT                     9300000UL
+#define CLOCK_INIT_LPI2C_CLK_ROOT                     10000000UL
+#define CLOCK_INIT_LPSPI_CLK_ROOT                     90000000UL
+#define CLOCK_INIT_LVDS1_CLK                          1200000000UL
+#define CLOCK_INIT_MQS_MCLK                           41538461UL
+#define CLOCK_INIT_PERCLK_CLK_ROOT                    75000000UL
+#define CLOCK_INIT_PLL7_MAIN_CLK                      24000000UL
+#define CLOCK_INIT_SAI1_CLK_ROOT                      41538461UL
+#define CLOCK_INIT_SAI1_MCLK1                         41538461UL
+#define CLOCK_INIT_SAI1_MCLK2                         41538461UL
+#define CLOCK_INIT_SAI1_MCLK3                         30000000UL
+#define CLOCK_INIT_SAI2_CLK_ROOT                      41538461UL
+#define CLOCK_INIT_SAI2_MCLK1                         41538461UL
+#define CLOCK_INIT_SAI2_MCLK2                         0UL
+#define CLOCK_INIT_SAI2_MCLK3                         30000000UL
+#define CLOCK_INIT_SAI3_CLK_ROOT                      41538461UL
+#define CLOCK_INIT_SAI3_MCLK1                         41538461UL
+#define CLOCK_INIT_SAI3_MCLK2                         0UL
+#define CLOCK_INIT_SAI3_MCLK3                         30000000UL
+#define CLOCK_INIT_SEMC_CLK_ROOT                      163862068UL
+#define CLOCK_INIT_SPDIF0_CLK_ROOT                    30000000UL
+#define CLOCK_INIT_SPDIF0_EXTCLK_OUT                  0UL
+#define CLOCK_INIT_TRACE_CLK_ROOT                     99000000UL
+#define CLOCK_INIT_UART_CLK_ROOT                      80000000UL
+#define CLOCK_INIT_USBPHY1_CLK                        480000000UL
+#define CLOCK_INIT_USBPHY2_CLK                        0UL
+#define CLOCK_INIT_USDHC1_CLK_ROOT                    198000000UL
+#define CLOCK_INIT_USDHC2_CLK_ROOT                    198000000UL
+
+/*! @brief Arm PLL set for clock_init configuration.
+ */
+extern const clock_arm_pll_config_t armPllConfig_clock_init;
+/*! @brief Usb1 PLL set for clock_init configuration.
+ */
+extern const clock_usb_pll_config_t usb1PllConfig_clock_init;
+/*! @brief Sys PLL for clock_init configuration.
+ */
+extern const clock_sys_pll_config_t sysPllConfig_clock_init;
+/*! @brief Video PLL set for clock_init configuration.
+ */
+extern const clock_video_pll_config_t videoPllConfig_clock_init;
+/*! @brief Enet PLL set for clock_init configuration.
+ */
+extern const clock_enet_pll_config_t enetPllConfig_clock_init;
+
+/*******************************************************************************
+ * API for clock_init configuration
+ ******************************************************************************/
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus*/
+
+/*!
+ * @brief This function executes configuration of clocks.
+ *
+ */
+void clock_init(void);
+
+#if defined(__cplusplus)
+}
+#endif  /* __cplusplus*/
+
+#endif  /* _CLOCK_CONFIG_H_ */

--- a/soc/arm/nxp_imx/rt/CMakeLists.txt
+++ b/soc/arm/nxp_imx/rt/CMakeLists.txt
@@ -3,6 +3,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
+zephyr_compile_definitions(
+  XIP_EXTERNAL_FLASH
+  SKIP_SYSCLK_INIT
+)
+
 zephyr_sources_ifdef(CONFIG_SOC_SERIES_IMX_RT11XX soc_rt11xx.c)
 zephyr_sources_ifdef(CONFIG_SOC_SERIES_IMX_RT10XX soc_rt10xx.c)
 

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1010
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1010
@@ -9,20 +9,8 @@ config SOC
 	string
 	default "mimxrt1011"
 
-config HAS_ARM_DIV
-	default n
-
 config NUM_IRQS
 	default 80
-
-config ARM_DIV
-	default 0
-
-config AHB_DIV
-	default 0
-
-config IPG_DIV
-	default 3
 
 config GPIO
 	default y

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1015
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1015
@@ -11,15 +11,6 @@ config SOC
 config NUM_IRQS
 	default 142
 
-config ARM_DIV
-	default 0
-
-config AHB_DIV
-	default 0
-
-config IPG_DIV
-	default 3
-
 config GPIO
 	default y
 

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1021
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1021
@@ -11,15 +11,6 @@ config SOC
 config NUM_IRQS
 	default 142
 
-config ARM_DIV
-	default 0
-
-config AHB_DIV
-	default 0
-
-config IPG_DIV
-	default 3
-
 config GPIO
 	default y
 

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1024
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1024
@@ -11,15 +11,6 @@ config SOC
 config NUM_IRQS
 	default 142
 
-config ARM_DIV
-	default 0
-
-config AHB_DIV
-	default 0
-
-config IPG_DIV
-	default 3
-
 config GPIO
 	default y
 

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1052
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1052
@@ -11,15 +11,6 @@ config SOC
 config NUM_IRQS
 	default 160
 
-config ARM_DIV
-	default 1
-
-config AHB_DIV
-	default 0
-
-config IPG_DIV
-	default 3
-
 config GPIO
 	default y
 

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1062
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1062
@@ -11,15 +11,6 @@ config SOC
 config NUM_IRQS
 	default 160
 
-config ARM_DIV
-	default 1
-
-config AHB_DIV
-	default 0
-
-config IPG_DIV
-	default 3
-
 config GPIO
 	default y
 

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1064
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1064
@@ -11,15 +11,6 @@ config SOC
 config NUM_IRQS
 	default 160
 
-config ARM_DIV
-	default 1
-
-config AHB_DIV
-	default 0
-
-config IPG_DIV
-	default 3
-
 config GPIO
 	default y
 

--- a/soc/arm/nxp_imx/rt/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt/Kconfig.soc
@@ -22,9 +22,8 @@ config SOC_MIMXRT1011
 	select HAS_MCUX_GPT
 	select HAS_MCUX_TRNG
 	select CPU_HAS_ARM_MPU
-	select INIT_SYS_PLL
-	select INIT_USB1_PLL
-	select INIT_ENET_PLL
+	select HAS_ENET_PLL
+	select USE_ENET_PLL_AS_ARM_CLK
 	select HAS_MCUX_USB_EHCI
 	select HAS_MCUX_USDHC1
 	select HAS_MCUX_USDHC2
@@ -46,9 +45,8 @@ config SOC_MIMXRT1015
 	select HAS_MCUX_TRNG
 	select CPU_HAS_FPU_DOUBLE_PRECISION
 	select CPU_HAS_ARM_MPU
-	select INIT_SYS_PLL
-	select INIT_USB1_PLL
-	select INIT_ENET_PLL
+	select HAS_ENET_PLL
+	select USE_ENET_PLL_AS_ARM_CLK
 	select HAS_MCUX_USB_EHCI
 	select HAS_MCUX_USDHC1
 	select HAS_MCUX_USDHC2
@@ -72,9 +70,8 @@ config SOC_MIMXRT1021
 	select HAS_MCUX_TRNG
 	select CPU_HAS_FPU_DOUBLE_PRECISION
 	select CPU_HAS_ARM_MPU
-	select INIT_SYS_PLL
-	select INIT_USB1_PLL
-	select INIT_ENET_PLL
+	select HAS_ENET_PLL
+	select USE_ENET_PLL_AS_ARM_CLK
 	select HAS_MCUX_USB_EHCI
 	select HAS_MCUX_USDHC1
 	select HAS_MCUX_USDHC2
@@ -100,9 +97,8 @@ config SOC_MIMXRT1024
 	select HAS_MCUX_TRNG
 	select CPU_HAS_FPU_DOUBLE_PRECISION
 	select CPU_HAS_ARM_MPU
-	select INIT_SYS_PLL
-	select INIT_USB1_PLL
-	select INIT_ENET_PLL
+	select HAS_ENET_PLL
+	select USE_ENET_PLL_AS_ARM_CLK
 	select HAS_MCUX_USB_EHCI
 	select HAS_MCUX_USDHC1
 	select HAS_MCUX_USDHC2
@@ -128,9 +124,6 @@ config SOC_MIMXRT1051
 	select HAS_MCUX_TRNG
 	select CPU_HAS_FPU_DOUBLE_PRECISION
 	select CPU_HAS_ARM_MPU
-	select INIT_ARM_PLL
-	select INIT_SYS_PLL
-	select INIT_USB1_PLL
 	select HAS_MCUX_USB_EHCI
 	select HAS_MCUX_USDHC1
 	select HAS_MCUX_USDHC2
@@ -157,11 +150,8 @@ config SOC_MIMXRT1052
 	select HAS_MCUX_TRNG
 	select CPU_HAS_FPU_DOUBLE_PRECISION
 	select CPU_HAS_ARM_MPU
-	select INIT_ARM_PLL
-	select INIT_SYS_PLL
-	select INIT_USB1_PLL
-	select INIT_VIDEO_PLL if DISPLAY_MCUX_ELCDIF
-	select INIT_ENET_PLL if NET_L2_ETHERNET
+	select HAS_VIDEO_PLL
+	select HAS_ENET_PLL
 	select HAS_MCUX_USB_EHCI
 	select HAS_MCUX_USDHC1
 	select HAS_MCUX_USDHC2
@@ -188,9 +178,6 @@ config SOC_MIMXRT1061
 	select HAS_MCUX_TRNG
 	select CPU_HAS_FPU_DOUBLE_PRECISION
 	select CPU_HAS_ARM_MPU
-	select INIT_ARM_PLL
-	select INIT_SYS_PLL
-	select INIT_USB1_PLL
 	select HAS_MCUX_USB_EHCI
 	select HAS_MCUX_USDHC1
 	select HAS_MCUX_USDHC2
@@ -218,11 +205,8 @@ config SOC_MIMXRT1062
 	select HAS_MCUX_TRNG
 	select CPU_HAS_FPU_DOUBLE_PRECISION
 	select CPU_HAS_ARM_MPU
-	select INIT_ARM_PLL
-	select INIT_SYS_PLL
-	select INIT_USB1_PLL
-	select INIT_VIDEO_PLL if DISPLAY_MCUX_ELCDIF
-	select INIT_ENET_PLL if NET_L2_ETHERNET
+	select HAS_VIDEO_PLL
+	select HAS_ENET_PLL
 	select HAS_MCUX_USB_EHCI
 	select HAS_MCUX_USDHC1
 	select HAS_MCUX_USDHC2
@@ -253,11 +237,8 @@ config SOC_MIMXRT1064
 	select HAS_MCUX_TRNG
 	select CPU_HAS_FPU_DOUBLE_PRECISION
 	select CPU_HAS_ARM_MPU
-	select INIT_ARM_PLL
-	select INIT_SYS_PLL
-	select INIT_USB1_PLL
-	select INIT_VIDEO_PLL if DISPLAY_MCUX_ELCDIF
-	select INIT_ENET_PLL if NET_L2_ETHERNET
+	select HAS_VIDEO_PLL
+	select HAS_ENET_PLL
 	select HAS_MCUX_USB_EHCI
 	select HAS_MCUX_USDHC1
 	select HAS_MCUX_USDHC2
@@ -283,9 +264,8 @@ config SOC_MIMXRT1176_CM7
 	select HAS_MCUX_FLEXSPI
 	select HAS_MCUX_FLEXCAN
 	select CPU_HAS_ARM_MPU
-	select INIT_ARM_PLL
-	select INIT_ENET_PLL if NET_L2_ETHERNET
-	select INIT_VIDEO_PLL
+	select HAS_ENET_PLL
+	select HAS_VIDEO_PLL
 	select HAS_MCUX_EDMA
 	select CPU_HAS_FPU_DOUBLE_PRECISION
 	select ADJUST_DCDC
@@ -310,9 +290,8 @@ config SOC_MIMXRT1176_CM4
 	select HAS_MCUX_LPUART
 	select HAS_MCUX_GPT
 	select CPU_HAS_ARM_MPU
-	select INIT_ARM_PLL
-	select INIT_ENET_PLL if NET_L2_ETHERNET
-	select INIT_VIDEO_PLL
+	select HAS_ENET_PLL
+	select HAS_VIDEO_PLL
 	select HAS_MCUX_EDMA
 	select HAS_MCUX_PWM
 	select HAS_MCUX_USDHC1
@@ -336,9 +315,8 @@ config SOC_MIMXRT1166_CM7
 	select HAS_MCUX_GPT
 	select HAS_MCUX_FLEXCAN
 	select CPU_HAS_ARM_MPU
-	select INIT_ARM_PLL
-	select INIT_ENET_PLL if NET_L2_ETHERNET
-	select INIT_VIDEO_PLL
+	select HAS_ENET_PLL
+	select HAS_VIDEO_PLL
 	select HAS_MCUX_EDMA
 	select CPU_HAS_FPU_DOUBLE_PRECISION
 	select ADJUST_DCDC
@@ -347,7 +325,6 @@ config SOC_MIMXRT1166_CM7
 	select HAS_MCUX_PWM
 	select HAS_MCUX_USDHC1
 	select HAS_MCUX_USDHC2
-
 
 config SOC_MIMXRT1166_CM4
 	bool "SOC_MIMXRT1166_CM4"
@@ -364,9 +341,8 @@ config SOC_MIMXRT1166_CM4
 	select HAS_MCUX_FLEXSPI
 	select HAS_MCUX_GPT
 	select CPU_HAS_ARM_MPU
-	select INIT_ARM_PLL
-	select INIT_ENET_PLL if NET_L2_ETHERNET
-	select INIT_VIDEO_PLL
+	select HAS_ENET_PLL
+	select HAS_VIDEO_PLL
 	select HAS_MCUX_EDMA
 	select HAS_MCUX_PWM
 	select HAS_MCUX_USDHC1
@@ -566,24 +542,14 @@ config INIT_ENET_PLL
 	  MIMXRT1021 - see commit 17f4d6bec7 ("soc: nxp_imx: fix ENET_PLL selection
 	  for MIMXRT1021").
 
-config HAS_ARM_DIV
-	bool "Has the divider for ARM"
-	default y
+config HAS_VIDEO_PLL
+	bool "SoC has a dedicated Video PLL"
 
-config ARM_DIV
-	int "ARM clock divider"
-	range 0 7
-	default 0
+config HAS_ENET_PLL
+	bool "SoC has a dedicated Ethernet PLL"
 
-config AHB_DIV
-	int "AHB clock divider"
-	range 0 7
-	default 0
-
-config IPG_DIV
-	int "IPG clock divider"
-	range 0 3
-	default 0
+config USE_ENET_PLL_AS_ARM_CLK
+	bool "On some RT10XX SoC's the ENET PLL is used as ARM Reference clock"
 
 config ADJUST_DCDC
 	bool "Adjust internal DCDC output"

--- a/soc/arm/nxp_imx/rt/soc_rt10xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt10xx.c
@@ -14,30 +14,10 @@
 #include <arch/cpu.h>
 #include <arch/arm/aarch32/cortex_m/cmsis.h>
 #include <fsl_flexspi_nor_boot.h>
+#include <clock_config.h>
 #if CONFIG_USB_DC_NXP_EHCI
 #include "usb_phy.h"
 #include "usb_dc_mcux.h"
-#endif
-
-#ifdef CONFIG_INIT_ARM_PLL
-/* ARM PLL configuration for RUN mode */
-const clock_arm_pll_config_t armPllConfig = {
-	.loopDivider = 100U
-};
-#endif
-
-#ifdef CONFIG_INIT_SYS_PLL
-/* SYS PLL configuration for RUN mode */
-const clock_sys_pll_config_t sysPllConfig = {
-	.loopDivider = 1U
-};
-#endif
-
-#ifdef CONFIG_INIT_USB1_PLL
-/* USB1 PLL configuration for RUN mode */
-const clock_usb_pll_config_t usb1PllConfig = {
-	.loopDivider = 0U
-};
 #endif
 
 #if CONFIG_USB_DC_NXP_EHCI
@@ -47,40 +27,10 @@ const clock_usb_pll_config_t usb1PllConfig = {
 #define BOARD_USB_PHY_TXCAL45DM (0x06U)
 #endif
 
-#ifdef CONFIG_INIT_ENET_PLL
-/* ENET PLL configuration for RUN mode */
-const clock_enet_pll_config_t ethPllConfig = {
-#if defined(CONFIG_SOC_MIMXRT1011) || \
-	defined(CONFIG_SOC_MIMXRT1015) || \
-	defined(CONFIG_SOC_MIMXRT1021) || \
-	defined(CONFIG_SOC_MIMXRT1024)
-	.enableClkOutput500M = true,
-#endif
-#ifdef CONFIG_ETH_MCUX
-	.enableClkOutput = true,
-#endif
-#if defined(CONFIG_PTP_CLOCK_MCUX)
-	.enableClkOutput25M = true,
-#else
-	.enableClkOutput25M = false,
-#endif
-	.loopDivider = 1,
-};
-#endif
-
 #if CONFIG_USB_DC_NXP_EHCI
 	usb_phy_config_struct_t usbPhyConfig = {
 		BOARD_USB_PHY_D_CAL, BOARD_USB_PHY_TXCAL45DP, BOARD_USB_PHY_TXCAL45DM,
 	};
-#endif
-
-#ifdef CONFIG_INIT_VIDEO_PLL
-const clock_video_pll_config_t videoPllConfig = {
-	.loopDivider = 31,
-	.postDivider = 8,
-	.numerator = 0,
-	.denominator = 0,
-};
 #endif
 
 #ifdef CONFIG_NXP_IMX_RT_BOOT_HEADER
@@ -110,77 +60,20 @@ const __imx_boot_ivt_section ivt image_vector_table = {
 /**
  * @brief Initialize the system clock
  */
-static ALWAYS_INLINE void clock_init(void)
+static ALWAYS_INLINE void clock_post_init(void)
 {
-	/* Boot ROM did initialize the XTAL, here we only sets external XTAL
-	 * OSC freq
-	 */
-	CLOCK_SetXtalFreq(24000000U);
-	CLOCK_SetRtcXtalFreq(32768U);
-
-	/* Set PERIPH_CLK2 MUX to OSC */
-	CLOCK_SetMux(kCLOCK_PeriphClk2Mux, 0x1);
-
-	/* Set PERIPH_CLK MUX to PERIPH_CLK2 */
-	CLOCK_SetMux(kCLOCK_PeriphMux, 0x1);
-
-	/* Setting the VDD_SOC to 1.5V. It is necessary to config AHB to 600Mhz
-	 */
-	DCDC->REG3 = (DCDC->REG3 & (~DCDC_REG3_TRG_MASK)) | DCDC_REG3_TRG(0x12);
-	/* Waiting for DCDC_STS_DC_OK bit is asserted */
-	while (DCDC_REG0_STS_DC_OK_MASK !=
-			(DCDC_REG0_STS_DC_OK_MASK & DCDC->REG0)) {
-		;
-	}
-
-#ifdef CONFIG_INIT_ARM_PLL
-	CLOCK_InitArmPll(&armPllConfig); /* Configure ARM PLL to 1200M */
+#if defined(CONFIG_HAS_ENET_PLL) && !defined(CONFIG_USE_ENET_PLL_AS_ARM_CLK)
+#ifndef CONFIG_ETH_MCUX
+	/* Turn off the ENET PLL as Ethernet is not used */
+	CLOCK_DeinitEnetPll();
 #endif
-#ifdef CONFIG_INIT_SYS_PLL
-	CLOCK_InitSysPll(&sysPllConfig); /* Configure SYS PLL to 528M */
-#endif
-#ifdef CONFIG_INIT_USB1_PLL
-	CLOCK_InitUsb1Pll(&usb1PllConfig); /* Configure USB1 PLL to 480M */
-#endif
-#ifdef CONFIG_INIT_ENET_PLL
-	CLOCK_InitEnetPll(&ethPllConfig);
-#endif
-#ifdef CONFIG_INIT_VIDEO_PLL
-	CLOCK_InitVideoPll(&videoPllConfig);
 #endif
 
-#ifdef CONFIG_HAS_ARM_DIV
-	CLOCK_SetDiv(kCLOCK_ArmDiv, CONFIG_ARM_DIV); /* Set ARM PODF */
+#ifdef CONFIG_HAS_VIDEO_PLL
+#ifndef CONFIG_DISPLAY
+	/* Turn off the Video PLL as Display is not used */
+	CLOCK_DeinitVideoPll();
 #endif
-	CLOCK_SetDiv(kCLOCK_AhbDiv, CONFIG_AHB_DIV); /* Set AHB PODF */
-	CLOCK_SetDiv(kCLOCK_IpgDiv, CONFIG_IPG_DIV); /* Set IPG PODF */
-
-	/* Set PRE_PERIPH_CLK to PLL1, 1200M */
-	CLOCK_SetMux(kCLOCK_PrePeriphMux, 0x3);
-
-	/* Set PERIPH_CLK MUX to PRE_PERIPH_CLK */
-	CLOCK_SetMux(kCLOCK_PeriphMux, 0x0);
-
-#ifdef CONFIG_UART_MCUX_LPUART
-	/* Configure UART divider to default */
-	CLOCK_SetMux(kCLOCK_UartMux, 0); /* Set UART source to PLL3 80M */
-	CLOCK_SetDiv(kCLOCK_UartDiv, 0); /* Set UART divider to 1 */
-#endif
-
-#ifdef CONFIG_I2C_MCUX_LPI2C
-	CLOCK_SetMux(kCLOCK_Lpi2cMux, 0); /* Set I2C source as USB1 PLL 480M */
-	CLOCK_SetDiv(kCLOCK_Lpi2cDiv, 5); /* Set I2C divider to 6 */
-#endif
-
-#ifdef CONFIG_SPI_MCUX_LPSPI
-	CLOCK_SetMux(kCLOCK_LpspiMux, 1); /* Set SPI source to USB1 PFD0 720M */
-	CLOCK_SetDiv(kCLOCK_LpspiDiv, 7); /* Set SPI divider to 8 */
-#endif
-
-#ifdef CONFIG_DISPLAY_MCUX_ELCDIF
-	CLOCK_SetMux(kCLOCK_LcdifPreMux, 2);
-	CLOCK_SetDiv(kCLOCK_LcdifPreDiv, 4);
-	CLOCK_SetDiv(kCLOCK_LcdifDiv, 1);
 #endif
 
 #if CONFIG_USB_DC_NXP_EHCI
@@ -189,47 +82,25 @@ static ALWAYS_INLINE void clock_init(void)
 	CLOCK_EnableUsbhs0Clock(kCLOCK_Usb480M,
 		DT_PROP_BY_PHANDLE(DT_INST(0, nxp_mcux_usbd), clocks, clock_frequency));
 	USB_EhciPhyInit(kUSB_ControllerEhci0, CPU_XTAL_CLK_HZ, &usbPhyConfig);
-#endif
+#else /* CONFIG_USB_DC_NXP_EHCI */
+	CLOCK_DisableUsbhs0PhyPllClock();
+#endif /* CONFIG_USB_DC_NXP_EHCI */
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(usdhc1), okay) && CONFIG_DISK_DRIVER_SDMMC
-	/* Configure USDHC clock source and divider */
-	CLOCK_InitSysPfd(kCLOCK_Pfd0, 0x12U);
-	CLOCK_SetDiv(kCLOCK_Usdhc1Div, 0U);
-	CLOCK_SetMux(kCLOCK_Usdhc1Mux, 1U);
 	CLOCK_EnableClock(kCLOCK_Usdhc1);
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(usdhc2), okay) && CONFIG_DISK_DRIVER_SDMMC
-	/* Configure USDHC clock source and divider */
-	CLOCK_InitSysPfd(kCLOCK_Pfd0, 0x12U);
-	CLOCK_SetDiv(kCLOCK_Usdhc2Div, 0U);
-	CLOCK_SetMux(kCLOCK_Usdhc2Mux, 1U);
 	CLOCK_EnableClock(kCLOCK_Usdhc2);
 #endif
 
 #ifdef CONFIG_VIDEO_MCUX_CSI
 	CLOCK_EnableClock(kCLOCK_Csi); /* Disable CSI clock gate */
-	CLOCK_SetDiv(kCLOCK_CsiDiv, 0); /* Set CSI divider to 1 */
-	CLOCK_SetMux(kCLOCK_CsiMux, 0); /* Set CSI source to OSC 24M */
-#endif
-#ifdef CONFIG_CAN_MCUX_FLEXCAN
-	CLOCK_SetDiv(kCLOCK_CanDiv, 1); /* Set CAN_CLK_PODF. */
-	CLOCK_SetMux(kCLOCK_CanMux, 2); /* Set Can clock source. */
-#endif
-
-#if !(defined(CONFIG_CODE_FLEXSPI) || defined(CONFIG_CODE_FLEXSPI2)) && \
-	defined(CONFIG_MEMC_MCUX_FLEXSPI) && \
-	DT_NODE_HAS_STATUS(DT_NODELABEL(flexspi), okay)
-	CLOCK_DisableClock(kCLOCK_FlexSpi);
-	CLOCK_InitUsb1Pfd(kCLOCK_Pfd0, 24);
-	CLOCK_SetMux(kCLOCK_FlexspiMux, 3);
-	CLOCK_SetDiv(kCLOCK_FlexspiDiv, 2);
 #endif
 
 	/* Keep the system clock running so SYSTICK can wake up the system from
 	 * wfi.
 	 */
 	CLOCK_SetMode(kCLOCK_ModeRun);
-
 }
 
 #if (DT_NODE_HAS_STATUS(DT_NODELABEL(usdhc1), okay) && CONFIG_DISK_DRIVER_SDMMC)
@@ -321,8 +192,10 @@ static int imxrt_init(const struct device *arg)
 		SCB_EnableDCache();
 	}
 
-	/* Initialize system clock */
+	/* Initialize clocks with tool generated code */
 	clock_init();
+	/* Additional clock init after generated code */
+	clock_post_init();
 
 	/*
 	 * install default handler that simply resets the CPU

--- a/west.yml
+++ b/west.yml
@@ -98,7 +98,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 66db7c2a57ec1adfd3574169346ed3af9bf17c0b
+      revision: 55daf0af92e0524c0f51f8a9f8985f2d23e145c6
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
The clock initialization code is moved out of the soc.c file to the boards folder. The MCUXpresso Config Tool was used to generate clock init code. This change allows customizing the clock initialization code for each MXRT10xx board. 
A MCUXpresso Config Tool file is also provided, this can be used a s starting point when updating the clock configuration.

`clock_config.c` was generated by the tool. This matches what was originally present inside `soc_rt10xx.c`.