### PR TITLE
Fix few missing memory region names on stm32 boards

### DIFF
--- a/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
+++ b/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
@@ -21,6 +21,7 @@
 	};
 
 	sdram2: sdram@d0000000 {
+		compatible = "mmio-sram";
 		device_type = "memory";
 		reg = <0xd0000000 DT_SIZE_M(8)>;
 		zephyr,memory-region = "SDRAM2";

--- a/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
+++ b/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
@@ -23,8 +23,10 @@
 	};
 
 	sdram1: sdram@c0000000 {
+		compatible = "mmio-sram";
 		device_type = "memory";
 		reg = <0xc0000000 DT_SIZE_M(16)>;
+		zephyr,memory-region = "SDRAM1";
 	};
 
 	leds {

--- a/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.dts
+++ b/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.dts
@@ -22,6 +22,7 @@
 	};
 
 	sdram2: sdram@d0000000 {
+		compatible = "mmio-sram";
 		device_type = "memory";
 		reg = <0xd0000000 DT_SIZE_M(32)>;
 		zephyr,memory-region = "SDRAM2";

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -3376,7 +3376,7 @@ function(zephyr_linker_dts_memory)
 
   dt_reg_addr(addr PATH ${DTS_MEMORY_PATH})
   dt_reg_size(size PATH ${DTS_MEMORY_PATH})
-  dt_prop(name PATH ${DTS_MEMORY_PATH} PROPERTY "memory-region")
+  dt_prop(name PATH ${DTS_MEMORY_PATH} PROPERTY "zephyr,memory-region")
   if (NOT DEFINED name)
     # Fallback to the node path
     set(name ${DTS_MEMORY_PATH})

--- a/dts/arm/st/f3/stm32f303X8.dtsi
+++ b/dts/arm/st/f3/stm32f303X8.dtsi
@@ -11,6 +11,7 @@
 	ccm0: memory@10000000 {
 		compatible = "st,stm32-ccm";
 		reg = <0x10000000 DT_SIZE_K(8)>;
+		zephyr,memory-region = "CCM";
 	};
 
 	sram0: memory@20000000 {

--- a/dts/arm/st/f3/stm32f303Xc.dtsi
+++ b/dts/arm/st/f3/stm32f303Xc.dtsi
@@ -11,6 +11,7 @@
 	ccm0: memory@10000000 {
 		compatible = "st,stm32-ccm";
 		reg = <0x10000000 DT_SIZE_K(8)>;
+		zephyr,memory-region = "CCM";
 	};
 
 	sram0: memory@20000000 {

--- a/dts/arm/st/f3/stm32f303Xe.dtsi
+++ b/dts/arm/st/f3/stm32f303Xe.dtsi
@@ -11,6 +11,7 @@
 	ccm0: memory@10000000 {
 		compatible = "st,stm32-ccm";
 		reg = <0x10000000 DT_SIZE_K(16)>;
+		zephyr,memory-region = "CCM";
 	};
 
 	sram0: memory@20000000 {

--- a/dts/arm/st/f3/stm32f334X8.dtsi
+++ b/dts/arm/st/f3/stm32f334X8.dtsi
@@ -11,6 +11,7 @@
 	ccm0: memory@10000000 {
 		compatible = "st,stm32-ccm";
 		reg = <0x10000000 DT_SIZE_K(4)>;
+		zephyr,memory-region = "CCM";
 	};
 
 	sram0: memory@20000000 {

--- a/dts/arm/st/f4/stm32f405Xg.dtsi
+++ b/dts/arm/st/f4/stm32f405Xg.dtsi
@@ -11,6 +11,7 @@
 	ccm0: memory@10000000 {
 		compatible = "st,stm32-ccm";
 		reg = <0x10000000 DT_SIZE_K(64)>;
+		zephyr,memory-region = "CCM";
 	};
 
 	sram0: memory@20000000 {

--- a/dts/arm/st/f4/stm32f407Xe.dtsi
+++ b/dts/arm/st/f4/stm32f407Xe.dtsi
@@ -11,6 +11,7 @@
 	ccm0: memory@10000000 {
 		compatible = "st,stm32-ccm";
 		reg = <0x10000000 DT_SIZE_K(64)>;
+		zephyr,memory-region = "CCM";
 	};
 
 	sram0: memory@20000000 {

--- a/dts/arm/st/f4/stm32f407Xg.dtsi
+++ b/dts/arm/st/f4/stm32f407Xg.dtsi
@@ -11,6 +11,7 @@
 	ccm0: memory@10000000 {
 		compatible = "st,stm32-ccm";
 		reg = <0x10000000 DT_SIZE_K(64)>;
+		zephyr,memory-region = "CCM";
 	};
 
 	sram0: memory@20000000 {

--- a/dts/arm/st/f4/stm32f415Rg.dtsi
+++ b/dts/arm/st/f4/stm32f415Rg.dtsi
@@ -11,6 +11,7 @@
 	ccm0: memory@10000000 {
 		compatible = "st,stm32-ccm";
 		reg = <0x10000000 DT_SIZE_K(64)>;
+		zephyr,memory-region = "CCM";
 	};
 
 	sram0: memory@20000000 {

--- a/dts/arm/st/f4/stm32f417Xe.dtsi
+++ b/dts/arm/st/f4/stm32f417Xe.dtsi
@@ -11,6 +11,7 @@
 	ccm0: memory@10000000 {
 		compatible = "st,stm32-ccm";
 		reg = <0x10000000 DT_SIZE_K(64)>;
+		zephyr,memory-region = "CCM";
 	};
 
 	sram0: memory@20000000 {

--- a/dts/arm/st/f4/stm32f417Xg.dtsi
+++ b/dts/arm/st/f4/stm32f417Xg.dtsi
@@ -11,6 +11,7 @@
 	ccm0: memory@10000000 {
 		compatible = "st,stm32-ccm";
 		reg = <0x10000000 DT_SIZE_K(64)>;
+		zephyr,memory-region = "CCM";
 	};
 
 	sram0: memory@20000000 {

--- a/dts/arm/st/f4/stm32f427Xi.dtsi
+++ b/dts/arm/st/f4/stm32f427Xi.dtsi
@@ -11,6 +11,7 @@
 	ccm0: memory@10000000 {
 		compatible = "st,stm32-ccm";
 		reg = <0x10000000 DT_SIZE_K(64)>;
+		zephyr,memory-region = "CCM";
 	};
 
 	sram0: memory@20000000 {

--- a/dts/arm/st/f4/stm32f427vi.dtsi
+++ b/dts/arm/st/f4/stm32f427vi.dtsi
@@ -11,6 +11,7 @@
 	ccm0: memory@10000000 {
 		compatible = "st,stm32-ccm";
 		reg = <0x10000000 DT_SIZE_K(64)>;
+		zephyr,memory-region = "CCM";
 	};
 
 	sram0: memory@20000000 {

--- a/dts/arm/st/f4/stm32f429Xi.dtsi
+++ b/dts/arm/st/f4/stm32f429Xi.dtsi
@@ -11,6 +11,7 @@
 	ccm0: memory@10000000 {
 		compatible = "st,stm32-ccm";
 		reg = <0x10000000 DT_SIZE_K(64)>;
+		zephyr,memory-region = "CCM";
 	};
 
 	sram0: memory@20000000 {

--- a/dts/arm/st/f4/stm32f429vi.dtsi
+++ b/dts/arm/st/f4/stm32f429vi.dtsi
@@ -11,6 +11,7 @@
 	ccm0: memory@10000000 {
 		compatible = "st,stm32-ccm";
 		reg = <0x10000000 DT_SIZE_K(64)>;
+		zephyr,memory-region = "CCM";
 	};
 
 	sram0: memory@20000000 {

--- a/dts/arm/st/f4/stm32f437Xi.dtsi
+++ b/dts/arm/st/f4/stm32f437Xi.dtsi
@@ -11,6 +11,7 @@
 	ccm0: memory@10000000 {
 		compatible = "st,stm32-ccm";
 		reg = <0x10000000 DT_SIZE_K(64)>;
+		zephyr,memory-region = "CCM";
 	};
 
 	sram0: memory@20000000 {

--- a/dts/arm/st/f4/stm32f469Xi.dtsi
+++ b/dts/arm/st/f4/stm32f469Xi.dtsi
@@ -11,6 +11,7 @@
 	ccm0: memory@10000000 {
 		compatible = "st,stm32-ccm";
 		reg = <0x10000000 DT_SIZE_K(64)>;
+		zephyr,memory-region = "CCM";
 	};
 
 	sram0: memory@20000000 {

--- a/dts/bindings/arm/st,stm32-ccm.yaml
+++ b/dts/bindings/arm/st,stm32-ccm.yaml
@@ -4,7 +4,7 @@ description: STM32 CCM (Core Coupled Memory)
 
 compatible: "st,stm32-ccm"
 
-include: base.yaml
+include: [base.yaml, mem-region.yaml]
 
 properties:
     reg:

--- a/dts/bindings/memory-controllers/st,stm32-fmc-sdram.yaml
+++ b/dts/bindings/memory-controllers/st,stm32-fmc-sdram.yaml
@@ -56,13 +56,17 @@ description: |
   memory device/s in DeviceTree:
 
   sdram1: sdram@c0000000 {
+      compatible = "mmio-sram";
       device_type = "memory";
       reg = <0xc000000 DT_SIZE_M(X)>;
+      zephyr,memory-region = "SDRAM1";
   };
 
   sdram2: sdram@d0000000 {
+      compatible = "mmio-sram";
       device_type = "memory";
       reg = <0xd000000 DT_SIZE_M(X)>;
+      zephyr,memory-region = "SDRAM2";
   };
 
   It is important to use sdram1 and sdram2 node labels for bank 1 and bank 2


### PR DESCRIPTION
Hey hi, found few missing region names after https://github.com/zephyrproject-rtos/zephyr/pull/37279 on SDRAM and CCM nodes for some stm32 boards. One had no compatible, the other missed the binding, tested with `west build -p -b stm32f429i_disc1 samples/basic/blinky`.

Before:

```
Memory region         Used Size  Region Size  %age Used
           FLASH:       14988 B         2 MB      0.71%
            SRAM:        4320 B       192 KB      2.20%
/memory@10000000:          0 GB        64 KB      0.00%
 /sdram@d0000000:          0 GB         8 MB      0.00%
        IDT_LIST:          0 GB         2 KB      0.00%
```

after:

```
Memory region         Used Size  Region Size  %age Used
           FLASH:       14988 B         2 MB      0.71%
            SRAM:        4320 B       192 KB      2.20%
             CCM:          0 GB        64 KB      0.00%
          SDRAM2:          0 GB         8 MB      0.00%
        IDT_LIST:          0 GB         2 KB      0.00%
```

Also fix the property name used in `zephyr_linker_dts_memory`, right now it's always using the fallback.

@JordanYates 