### PR TITLE
samples: subsys: mcumgr: Remove deprecated <power/reboot.h> header

### DIFF
--- a/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/src/zephyr_os_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/src/zephyr_os_mgmt.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr.h>
-#include <power/reboot.h>
+#include <sys/reboot.h>
 #include <debug/object_tracing.h>
 #include <kernel_structs.h>
 #include <mgmt/mgmt.h>


### PR DESCRIPTION
MCUMgr sample was failing to build due to including a deprecated header.
Replace it with the new header file to fix the build.

Fixes #41050