### PR TITLE
CODEOWNERS: Add myself for mgmt/mcumgr/lib

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -692,6 +692,7 @@
 /subsys/lorawan/                          @Mani-Sadhasivam
 /subsys/mgmt/ec_host_cmd/                 @jettr
 /subsys/mgmt/mcumgr/                      @carlescufi @nvlsianpu
+/subsys/mgmt/mcumgr/lib/                  @de-nordic
 /subsys/mgmt/hawkbit/                     @Navin-Sankar
 /subsys/mgmt/mcumgr/smp_udp.c             @aunsbjerg
 /subsys/mgmt/updatehub/                   @nandojve @otavio


### PR DESCRIPTION
Add myself as codeowner for the mcumgr library.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>