### PR TITLE
cmake: Fix fallback quoting

### DIFF
--- a/cmake/linker/ld/ld_script.cmake
+++ b/cmake/linker/ld/ld_script.cmake
@@ -33,7 +33,7 @@ function(system_to_string)
     if(DEFINED size)
       set(size ", LENGTH = (${size})")
     endif()
-    set(memory_region "  ${name} ${flags} ${start}${size}")
+    set(memory_region "  \"${name}\" ${flags} ${start}${size}")
 
     set(${STRING_STRING} "${${STRING_STRING}}${memory_region}\n")
   endforeach()


### PR DESCRIPTION
When no 'zephyr,memory-region' property is present, the region name
generation falls back to the node path. The problem is that the node
path contains the '@' character that must be quoted in the linker script
to not hit the error:

  linker_zephyr_pre0.cmd:7: ignoring invalid character `@' in expression
  linker_zephyr_pre0.cmd:7: syntax error

Add the missing quotes.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>