### PR TITLE
mgmt: mcumgr: fix inclusion of missing header

### DIFF
--- a/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/src/zephyr_os_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/src/zephyr_os_mgmt.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr.h>
-#include <power/reboot.h>
+#include <sys/reboot.h>
 #include <debug/object_tracing.h>
 #include <kernel_structs.h>
 #include <mgmt/mgmt.h>


### PR DESCRIPTION
<power/reboot.h> was recently removed, this usage was missed.