### PR TITLE
arch: cortex_m: Fix dwt cyccnt assert

### DIFF
--- a/arch/arm/include/aarch32/cortex_m/dwt.h
+++ b/arch/arm/include/aarch32/cortex_m/dwt.h
@@ -99,8 +99,10 @@ static inline int z_arm_dwt_init_cycle_counter(void)
 	DWT->CYCCNT = 0;
 	DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
 
-	/* Assert that the cycle counter is indeed implemented. */
-	__ASSERT((DWT->CTRL & DWT_CTRL_NOCYCCNT_Msk) != 0,
+	/* Assert that the cycle counter is indeed implemented.
+	 * The field is called NOCYCCNT. So 1 means there is no cycle counter.
+	 */
+	__ASSERT((DWT->CTRL & DWT_CTRL_NOCYCCNT_Msk) == 0,
 		"DWT implements no cycle counter. "
 		"Cannot be used for cycle counting\n");
 


### PR DESCRIPTION
Fix the assert that checks for existence of a cycle counter.

The field is named NO CYCCNT, so when it is 1, there is no cycle
counter. But we are asserting the opposite.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>