### PR TITLE
boards: arm: pinetime: Enable ST7789v driver

### DIFF
--- a/boards/arm/pinetime_devkit0/Kconfig.defconfig
+++ b/boards/arm/pinetime_devkit0/Kconfig.defconfig
@@ -11,4 +11,14 @@ config BOARD
 config BT_CTLR
 	default BT
 
+if DISPLAY
+
+config SPI
+	default y
+
+config ST7789V
+	default y
+
+endif # DISPLAY
+
 endif # BOARD_PINETIME_DEVKIT0


### PR DESCRIPTION
When the application requests `CONFIG_DISPLAY`, then automatically
enable the display driver using `CONFIG_ST7789V`.

Signed-off-by: Casper Meijn <casper@meijn.net>