### PR TITLE
Bluetooth: Fix build error for printing LTK

### DIFF
--- a/subsys/bluetooth/host/keys.c
+++ b/subsys/bluetooth/host/keys.c
@@ -494,11 +494,13 @@ void bt_keys_show_sniffer_info(struct bt_keys *keys, void *data)
 		BT_INFO("SC LTK: 0x%s", bt_hex(ltk, keys->enc_size));
 	}
 
+#if !defined(CONFIG_BT_SMP_SC_PAIR_ONLY)
 	if (keys->keys & BT_KEYS_PERIPH_LTK) {
 		sys_memcpy_swap(ltk, keys->periph_ltk.val, keys->enc_size);
 		BT_INFO("Legacy LTK: 0x%s (peripheral)",
 			bt_hex(ltk, keys->enc_size));
 	}
+#endif /* !CONFIG_BT_SMP_SC_PAIR_ONLY */
 
 	if (keys->keys & BT_KEYS_LTK) {
 		sys_memcpy_swap(ltk, keys->ltk.val, keys->enc_size);


### PR DESCRIPTION
CONFIG_BT_LOG_SNIFFER_INFO allows print of LTK for debugging.
If CONFIG_BT_SMP_SC_PAIR_ONLY is set a non-existing struct
entry was printes, which caused a compile-time error.

Signed-off-by: Casper Bonde <casper_bonde@bose.com>