### PR TITLE
doc: drop single quote references

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -98,13 +98,6 @@ if not west_found:
 else:
     exclude_patterns.append("**/*west-not-found*")
 
-# This change will allow us to use bare back-tick notation to let
-# Sphinx hunt for a reference, starting with normal "document"
-# references such as :ref:, but also including :c: and :cpp: domains
-# (potentially) helping with API (doxygen) references simply by using
-# `name`
-default_role = "any"
-
 pygments_style = "sphinx"
 
 todo_include_todos = False

--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -195,8 +195,8 @@ bundled in the :ref:`Zephyr SDK <zephyr_sdk>` by installing it.
 Python
 ======
 
-A `modern Python 3 version <install-required-tools>` is required. Check what
-version you have by using ``python3 --version``.
+A :ref:`modern Python 3 version <install-required-tools>` is required. Check
+what version you have by using ``python3 --version``.
 
 If you have an older version, you will need to install a more recent Python 3.
 You can build from source, or use a backport from your distribution's package

--- a/doc/guides/debug_tools/coredump.rst
+++ b/doc/guides/debug_tools/coredump.rst
@@ -58,7 +58,7 @@ Example
 -------
 
 This example uses the log module backend tied to serial console.
-This was done on `qemu_x86` where a null pointer was dereferenced.
+This was done on :ref:`qemu_x86` where a null pointer was dereferenced.
 
 This is the core dump log from the serial console, and is stored
 in :file:`coredump.log`:

--- a/doc/guides/debug_tools/tracing/index.rst
+++ b/doc/guides/debug_tools/tracing/index.rst
@@ -205,8 +205,8 @@ Using RAM backend
 
 For devices that do not have available I/O for tracing such as USB or UART but have
 enough RAM to collect trace datas, the ram backend can be enabled with configuration
-`CONFIG_TRACING_BACKEND_RAM`.
-Adjust `CONFIG_RAM_TRACING_BUFFER_SIZE` to be able to record enough traces for your needs.
+:kconfig:`CONFIG_TRACING_BACKEND_RAM`.
+Adjust :kconfig:`CONFIG_RAM_TRACING_BUFFER_SIZE` to be able to record enough traces for your needs.
 Then thanks to a runtime debugger such as gdb this buffer can be fetched from the target
 to an host computer::
 

--- a/doc/guides/dts/api-usage.rst
+++ b/doc/guides/dts/api-usage.rst
@@ -379,7 +379,7 @@ generated C header which is put into every application build directory:
 :ref:`devicetree_unfixed.h <dt-outputs>`. This file contains macros with
 devicetree data.
 
-These macros have tricky naming conventions which the `devicetree_api` API
+These macros have tricky naming conventions which the :ref:`devicetree_api` API
 abstracts away. They should be considered an implementation detail, but it's
 useful to understand them since they will frequently be seen in compiler error
 messages.

--- a/doc/guides/test/twister.rst
+++ b/doc/guides/test/twister.rst
@@ -611,7 +611,7 @@ Fixtures are defined in the hardware map file as a list::
         runner: pyocd
         serial: /dev/ttyACM9
 
-When running `twister` with ``--device-testing``, the configured fixture
+When running ``twister`` with ``--device-testing``, the configured fixture
 in the hardware map file will be matched to testcases requesting the same fixtures
 and these tests will be executed on the boards that provide this fixture.
 

--- a/doc/guides/west/west-apis.rst
+++ b/doc/guides/west/west-apis.rst
@@ -226,9 +226,10 @@ west.manifest
 
 .. automodule:: west.manifest
 
-The main classes are `Manifest` and `Project`. These represent the contents of
-a :ref:`manifest file <west-manifests>`. The recommended methods for parsing
-west manifests are `Manifest.from_file` and `Manifest.from_data`.
+The main classes are :py:class:`Manifest` and :py:class:`Project`. These
+represent the contents of a :ref:`manifest file <west-manifests>`. The
+recommended methods for parsing west manifests are
+:py:meth:`Manifest.from_file` and :py:meth:`Manifest.from_data`.
 
 Constants and functions
 =======================

--- a/doc/reference/modbus/index.rst
+++ b/doc/reference/modbus/index.rst
@@ -25,13 +25,13 @@ More information about Modbus and Modbus RTU can be found on the website
 Samples
 *******
 
-`modbus-rtu-server-sample` and `modbus-rtu-client-sample` give
+:ref:`modbus-rtu-server-sample` and :ref:`modbus-rtu-client-sample` give
 the possibility to try out RTU server and RTU client implementation with
 an evaluation board.
 
-`modbus-tcp-server-sample` is a simple Modbus TCP server.
+:ref:`modbus-tcp-server-sample` is a simple Modbus TCP server.
 
-`modbus-gateway-sample` is an example how to build a TCP to serial line
+:ref:`modbus-gateway-sample` is an example how to build a TCP to serial line
 gateway with Zephyr OS.
 
 API Reference

--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -1004,7 +1004,7 @@ release:
 * :github:`31944` - flashing not working with openocd runner
 * :github:`31938` - Invalid SPDX license identifier used in file
 * :github:`31937` - sample.bluetooth.peripheral_hr_rv32m1_vega_ri5cy does not build
-* :github:`31930` - uart_nrfx_uarte: `CONFIG_UART_ASYNC_API` with `CONFIG_PM_DEVICE` breaks
+* :github:`31930` - uart_nrfx_uarte: ``CONFIG_UART_ASYNC_API`` with ``CONFIG_PM_DEVICE`` breaks
 * :github:`31928` - usb loopback not work on nrf52840
 * :github:`31924` - IVSHMEM with ACRN not working
 * :github:`31921` - west flash not working with pyocd
@@ -1632,7 +1632,7 @@ release:
 * :github:`28870` - Peripheral initiated connection parameter update is ignored
 * :github:`28867` - ARM Cortex-M4: Semaphores could not be used in ISRs with priority 0?
 * :github:`28865` - Doc: Generate documentation using dts bindings
-* :github:`28854` - `CONFIG_STACK_POINTER_RANDOM` may be undefined
+* :github:`28854` - ``CONFIG_STACK_POINTER_RANDOM`` may be undefined
 * :github:`28847` - code_relocation sample does not work on windows
 * :github:`28844` - Double quote prepended when exporting CMAKE compile option using zephyr_get_compile_options_for_lang()
 * :github:`28833` - STM32: SPI DMA Driver - HW CS handling not compatible with spi_nor (Winbond W25Q)

--- a/samples/boards/esp32/wifi_station/README.rst
+++ b/samples/boards/esp32/wifi_station/README.rst
@@ -33,7 +33,7 @@ The sample can be built and flashed as follows:
    west flash
 
 If using another supported Espressif board, replace the board argument in the above
-command with your own board (e.g., `esp32s2_saola` board).
+command with your own board (e.g., :ref:`esp32s2_saola` board).
 
 Sample Output
 =============

--- a/samples/net/dsa/README.rst
+++ b/samples/net/dsa/README.rst
@@ -19,7 +19,7 @@ Requirements
 Building and Running
 ********************
 
-Host machine with `ip_k66f` board from Segger.
+Host machine with :ref:`ip_k66f` board from Segger.
 
 Follow these steps to build the DSA sample application:
 

--- a/samples/subsys/mgmt/hawkbit/README.rst
+++ b/samples/subsys/mgmt/hawkbit/README.rst
@@ -23,7 +23,7 @@ Caveats
 *******
 
 * The Zephyr port of ``Hawkbit`` is configured to run on a
-  :ref: `Freedom-K64F <frdm_k64f>` MCU by default. The application should
+  :ref:`Freedom-K64F <frdm_k64f>` MCU by default. The application should
   build and run for other platforms with support internet connection. Some
   platforms need some modification. Overlay files would be needed to support
   BLE 6lowpan, 802.15.4 or OpenThread configurations as well as the


### PR DESCRIPTION
```
doc: drop single quote references 

Many documents relied on single quotes to create references, e.g.
`my_reference`. This is possible because `default_role = "any"` is
enabled in Sphinx conf.py. However, this method comes with its problems:

- It mixes all domains together, so it's not clear to what are you
  referencing: a document? a Kconfig option? a C function?...
- It creates inconsistencies: in some places explicit roles are used
  (e.g. :ref:`my_page`) while in some others not.
- _Conflicts_ with markdown. Single quotes are used for literals in
  Markdown, so people tend to use the same syntax in Sphinx, even though
  it has a different purpose.

Usages have been found using `git grep '`[^`]*` ' -- **/*.rst`.
```
```
doc: do not use any as default role 

References should be aded using the appropriate role, e.g. :ref:,
:c:func:, :kconfig:, etc.
```