### PR TITLE
[Backport v2.7-branch] include: usb: add alignment attribute to macro USBD_CFG_DATA_DEFINE

### DIFF
--- a/include/usb/usb_device.h
+++ b/include/usb/usb_device.h
@@ -68,7 +68,7 @@ extern "C" {
  * inside usb data section in the RAM.
  */
 #define USBD_CFG_DATA_DEFINE(p, name) \
-	static __in_section(usb, data_##p, name) __used
+	static __in_section(usb, data_##p, name) __used __aligned(4)
 
 /*************************************************************************
  *  USB configuration


### PR DESCRIPTION
backport dfb7a5952fee8a83663a6feddf0770f3e22ca7aa, see #40640

It could be observed on native_posix_64 platform that
without alignment attribute the usb_cfg_data structures
are placed with a gap or padding in specified RAM section.
This breaks the possibility to iterate over the structures.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/40640