### PR TITLE
[Backport v2.7-branch] drivers: ssd16xx: fix driver initialization

### DIFF
--- a/drivers/display/ssd16xx.c
+++ b/drivers/display/ssd16xx.c
@@ -636,8 +636,8 @@ static int ssd16xx_controller_init(const struct device *dev)
 
 static int ssd16xx_init(const struct device *dev)
 {
-	const struct ssd16xx_config *config = dev->config;
 	struct ssd16xx_data *driver = dev->data;
+	const struct ssd16xx_config *config = driver->config;
 
 	LOG_DBG("");
 


### PR DESCRIPTION
backport 5e722c436842068c3ac1d75b440ea505035dfaf6

ssd16xx driver is not well designed and does not pass configuration
via device->config but via struct ssd16xx_data, this was not taken
into account in the commit 4d6d50e2bc60
("display: ssd16xx: convert to spi_dt_spec").

Fixes: #40925 