### PR TITLE
cmake: improve the check of optimization level against CMAKE_BUILD_TYPE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1714,8 +1714,11 @@ set(build_types None Debug Release RelWithDebInfo MinSizeRel)
 
 if((CMAKE_BUILD_TYPE IN_LIST build_types) AND (NOT NO_BUILD_TYPE_WARNING))
   string(TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE_uppercase)
-
-  if(NOT (${OPTIMIZATION_FLAG} IN_LIST CMAKE_C_FLAGS_${CMAKE_BUILD_TYPE_uppercase}))
+  # The CMAKE_C_FLAGS_<build_type> is a string, so we do a regex to see if the
+  # optimization flag is present in that string.
+  # To avoid false-positive matches, the flag must either be matched first
+  # or last in string, or come after / followed by minimum a space.
+  if(NOT (CMAKE_C_FLAGS_${CMAKE_BUILD_TYPE_uppercase} MATCHES "(^| )${OPTIMIZATION_FLAG}($| )"))
     message(WARNING "
       The CMake build type was set to '${CMAKE_BUILD_TYPE}', but the optimization flag was set to '${OPTIMIZATION_FLAG}'.
       This may be intentional and the warning can be turned off by setting the CMake variable 'NO_BUILD_TYPE_WARNING'"


### PR DESCRIPTION
Fixes: #39626

The CMAKE_C_FLAGS_<build_type> is a string with arguments separated by
spaces and not a list, for example "-O3 -DNDEBUG".

Therefore update the `if()` check to do a regex match to determine if
the optimization level specified through Kconfig matches the
optimization level that would be defined by the CMAKE_BUILD_TYPE
setting.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>