### PR TITLE
ci: doc-build: disable parallel build

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -74,7 +74,7 @@ jobs:
           DOC_TAG="development"
         fi
 
-        DOC_TAG=${DOC_TAG} SPHINXOPTS="-q -W -j auto -t publish" make -C doc html
+        DOC_TAG=${DOC_TAG} SPHINXOPTS="-q -W -t publish" make -C doc html
 
     - name: compress-docs
       run: |


### PR DESCRIPTION
When an error happens during the Sphinx build (e.g. due to a broken
reference), the process hangs on CI when run with both `-j auto`
(parallel build) and `-W` (warnings as errors) options. The root cause
of the issue is unknown, and does not seem to happen locally. Parallel
builds are experimental on Sphinx, so they have been disabled on CI for
now.  Because CI runner is a single core machine, the build time should
remain equal or similar. The option is still left as default, so local
builds will continue to benefit from parallelization.

Fixes #40633 