### PR TITLE
doc: extensions: link-roles: hide stderr for git describe

### DIFF
--- a/doc/_extensions/zephyr/link-roles.py
+++ b/doc/_extensions/zephyr/link-roles.py
@@ -21,7 +21,8 @@ except ImportError:
 
 def get_github_rev():
     try:
-        output = subprocess.check_output('git describe --exact-match', shell=True)
+        output = subprocess.check_output('git describe --exact-match',
+                                         shell=True, stderr=subprocess.DEVNULL)
     except subprocess.CalledProcessError:
         return 'main'
 


### PR DESCRIPTION
Redirect stderr to DEVNULL when running `git describe --exact-match`.
This prevents messages like "fatal: No names found, cannot describe
anything." to be shown.