### PR TITLE
kernel: add 'static' keyword to select routines

### DIFF
--- a/include/kernel/sched_priq.h
+++ b/include/kernel/sched_priq.h
@@ -33,7 +33,6 @@ struct k_thread;
 
 struct k_thread *z_priq_dumb_best(sys_dlist_t *pq);
 void z_priq_dumb_remove(sys_dlist_t *pq, struct k_thread *thread);
-void z_priq_dumb_add(sys_dlist_t *pq, struct k_thread *thread);
 
 struct _priq_rb {
 	struct rbtree tree;
@@ -56,8 +55,6 @@ struct _priq_mq {
 	unsigned int bitmask; /* bit 1<<i set if queues[i] is non-empty */
 };
 
-void z_priq_mq_add(struct _priq_mq *pq, struct k_thread *thread);
-void z_priq_mq_remove(struct _priq_mq *pq, struct k_thread *thread);
 struct k_thread *z_priq_mq_best(struct _priq_mq *pq);
 
 #endif /* ZEPHYR_INCLUDE_SCHED_PRIQ_H_ */

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -54,6 +54,11 @@ struct k_spinlock sched_spinlock;
 static void update_cache(int preempt_ok);
 static void end_thread(struct k_thread *thread);
 
+static ALWAYS_INLINE void z_priq_mq_add(struct _priq_mq *pq,
+					struct k_thread *thread);
+static ALWAYS_INLINE void z_priq_mq_remove(struct _priq_mq *pq,
+					   struct k_thread *thread);
+
 static inline int is_preempt(struct k_thread *thread)
 {
 	/* explanation in kernel_struct.h */
@@ -173,7 +178,8 @@ static ALWAYS_INLINE struct k_thread *_priq_dumb_mask_best(sys_dlist_t *pq)
 }
 #endif
 
-ALWAYS_INLINE void z_priq_dumb_add(sys_dlist_t *pq, struct k_thread *thread)
+static ALWAYS_INLINE void z_priq_dumb_add(sys_dlist_t *pq,
+					  struct k_thread *thread)
 {
 	struct k_thread *t;
 
@@ -1077,7 +1083,8 @@ struct k_thread *z_priq_rb_best(struct _priq_rb *pq)
 # endif
 #endif
 
-ALWAYS_INLINE void z_priq_mq_add(struct _priq_mq *pq, struct k_thread *thread)
+static ALWAYS_INLINE void z_priq_mq_add(struct _priq_mq *pq,
+					struct k_thread *thread)
 {
 	int priority_bit = thread->base.prio - K_HIGHEST_THREAD_PRIO;
 
@@ -1085,7 +1092,8 @@ ALWAYS_INLINE void z_priq_mq_add(struct _priq_mq *pq, struct k_thread *thread)
 	pq->bitmask |= BIT(priority_bit);
 }
 
-ALWAYS_INLINE void z_priq_mq_remove(struct _priq_mq *pq, struct k_thread *thread)
+static ALWAYS_INLINE void z_priq_mq_remove(struct _priq_mq *pq,
+					   struct k_thread *thread)
 {
 	int priority_bit = thread->base.prio - K_HIGHEST_THREAD_PRIO;
 


### PR DESCRIPTION
This work was originally done for the v2.7-auditable-branch (see PR 41003). However, there was a request to submit this against the main branch as well.

Applies the 'static' keyword to the following inlined routines:
    z_priq_dumb_add()
    z_priq_mq_add()
    z_priq_mq_remove()
As those routines are only used in one place, they no longer have
externally visible declarations.

Signed-off-by: Peter Mitsis <peter.mitsis@intel.com>