### PR TITLE
ci: doc-build: use concurrency group to cancel in progress builds

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -37,6 +37,9 @@ jobs:
     name: "Documentation Build (HTML)"
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    concurrency:
+      group: doc-build-html-${{ github.ref }}
+      cancel-in-progress: true
 
     steps:
     - name: checkout
@@ -91,6 +94,9 @@ jobs:
     runs-on: ubuntu-latest
     container: texlive/texlive:latest
     timeout-minutes: 30
+    concurrency:
+      group: doc-build-pdf-${{ github.ref }}
+      cancel-in-progress: true
 
     steps:
     - name: checkout


### PR DESCRIPTION
Add the documentation build jobs to a concurrency group so that branch
force pushes will automatically cancel in progress jobs.