### PR TITLE
tests: drivers: pwm_loopback: nucleo_h743zi: change PWM output pin

### DIFF
--- a/tests/drivers/pwm/pwm_loopback/boards/nucleo_h743zi.overlay
+++ b/tests/drivers/pwm/pwm_loopback/boards/nucleo_h743zi.overlay
@@ -10,7 +10,7 @@
 	pwm_loopback_0 {
 		compatible = "test-pwm-loopback";
 		/* first index must be a 32-Bit timer */
-		pwms = <&pwm2 2 0 PWM_POLARITY_NORMAL>,
+		pwms = <&pwm2 4 0 PWM_POLARITY_NORMAL>,
 			<&pwm5 1 0 PWM_POLARITY_NORMAL>;
 	};
 };
@@ -20,7 +20,7 @@
 	status = "okay";
 	pwm2: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim2_ch2_pa1>; /* CN11 PIN30 */
+		pinctrl-0 = <&tim2_ch4_pa3>; /* CN9 PIN1 A0 */
 		pinctrl-names = "default";
 	};
 };


### PR DESCRIPTION
tests: drivers: pwm_loopback: nucleo_h743zi: change PWM output pin

PA1 is connected to ethernet RMII Reference Clock signal
and it impacts the TIMER signal.
Change to PA3 on Arduino A0 connector
