### PR TITLE
twister: log error for non-existing platform call

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -2768,6 +2768,7 @@ class TestSuite(DisablePyTestCollectionMixin):
         self.testcases = {}
         self.quarantine = {}
         self.platforms = []
+        self.platform_names = []
         self.selected_platforms = []
         self.filtered_platforms = []
         self.default_platforms = []
@@ -3010,6 +3011,8 @@ class TestSuite(DisablePyTestCollectionMixin):
                     logger.error("E: %s: can't load: %s" % (file, e))
                     self.load_errors += 1
 
+        self.platform_names = [p.name for p in self.platforms]
+
     def get_all_tests(self):
         tests = []
         for _, tc in self.testcases.items():
@@ -3129,7 +3132,7 @@ class TestSuite(DisablePyTestCollectionMixin):
         quarantine_list = []
         for quar_dict in quarantine_yaml:
             if quar_dict['platforms'][0] == "all":
-                plat = [p.name for p in self.platforms]
+                plat = self.platform_names
             else:
                 plat = quar_dict['platforms']
             comment = quar_dict.get('comment', "NA")
@@ -3215,6 +3218,7 @@ class TestSuite(DisablePyTestCollectionMixin):
             emulation_platforms = True
 
         if platform_filter:
+            self.verify_platforms_existence(platform_filter, f"platform_filter")
             platforms = list(filter(lambda p: p.name in platform_filter, self.platforms))
         elif emu_filter:
             platforms = list(filter(lambda p: p.simulation != 'na', self.platforms))
@@ -3232,6 +3236,8 @@ class TestSuite(DisablePyTestCollectionMixin):
             if tc.build_on_all and not platform_filter:
                 platform_scope = self.platforms
             elif tc.integration_platforms and self.integration:
+                self.verify_platforms_existence(
+                    tc.integration_platforms, f"{tc_name} - integration_platforms")
                 platform_scope = list(filter(lambda item: item.name in tc.integration_platforms, \
                                          self.platforms))
             else:
@@ -3242,6 +3248,8 @@ class TestSuite(DisablePyTestCollectionMixin):
             # If there isn't any overlap between the platform_allow list and the platform_scope
             # we set the scope to the platform_allow list
             if tc.platform_allow and not platform_filter and not integration:
+                self.verify_platforms_existence(
+                    tc.platform_allow, f"{tc_name} - platform_allow")
                 a = set(platform_scope)
                 b = set(filter(lambda item: item.name in tc.platform_allow, self.platforms))
                 c = a.intersection(b)
@@ -3853,6 +3861,19 @@ class TestSuite(DisablePyTestCollectionMixin):
                 if case == identifier:
                     results.append(tc)
         return results
+
+    def verify_platforms_existence(self, platform_names_to_verify, log_info=""):
+        """
+        Verify if platform name (passed by --platform option, or in yaml file
+        as platform_allow or integration_platforms options) is correct. If not -
+        log error.
+        """
+        for platform in platform_names_to_verify:
+            if platform in self.platform_names:
+                break
+            else:
+                logger.error(f"{log_info} - unrecognized platform - {platform}")
+
 
 class CoverageTool:
     """ Base class for every supported coverage tool


### PR DESCRIPTION
Changes will log error message in following three situations:

1. Platform name pass in `--platform` option does not exist. For example following command will log error message.
`scripts/twister -p xyz -T samples/hello_world/ `

> INFO    - Zephyr version: v2.7.99-2228-gee8a46ee2d9c
> INFO    - JOBS: 4
> INFO    - Using 'zephyr' toolchain.
> ERROR   - platform_filter - unrecognized platform - xyz

2. During using `--all` option, platform from `platform_allow` list does not exist. For example if in `samples/sensor/adxl362/sample.yaml` file will be a typo in `platform_allow` list:

> sample:
>   name: adxl362 sample
>   description: ADXL362 accelerometer sample application
> tests:
>   sample.sensor.adxl362:
>     harness: sensor
>     tags: sensors
>     depends_on: spi
>     integration_platforms:
>       - nrf52dk_nrf52832
>     platform_allow: nrf52dk_nrf52832_typo_bug

 the following command will log error message:
`scripts/twister --all -T samples/sensor/adxl362/`

> INFO    - Zephyr version: v2.7.99-2228-gee8a46ee2d9c
> INFO    - JOBS: 4
> INFO    - Using 'zephyr' toolchain.
> INFO    - Selecting all possible platforms per test case
> INFO    - Building initial testcase list...
> ERROR   - samples/sensor/adxl362/sample.sensor.adxl362 - platform_allow - unrecognized platform - nrf52dk_nrf52832_typo_bug

3. During using `--integration` option, platform from `integration_platforms` list does not exist. For example if in `samples/sensor/adxl362/sample.yaml` file will be a typo in `integration_platforms` list:

> sample:
>   name: adxl362 sample
>   description: ADXL362 accelerometer sample application
> tests:
>   sample.sensor.adxl362:
>     harness: sensor
>     tags: sensors
>     depends_on: spi
>     integration_platforms:
>       - nrf52dk_nrf52832_typo_bug
>     platform_allow: nrf52dk_nrf52832

 the following command will log error message:
`scripts/twister --integration -T samples/sensor/adxl362/`

> INFO    - Zephyr version: v2.7.99-2228-gee8a46ee2d9c
> INFO    - JOBS: 4
> INFO    - Using 'zephyr' toolchain.
> INFO    - Selecting default platforms per test case
> INFO    - Building initial testcase list...
> ERROR   - samples/sensor/adxl362/sample.sensor.adxl362 - integration_platforms - unrecognized platform - nrf52dk_nrf52832_typo_bug

Fixes #31868

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>