### PR TITLE
boards: nrf: clean up DK board buttons in DTS

### DIFF
--- a/boards/arm/nrf52dk_nrf52805/nrf52dk_nrf52805.dts
+++ b/boards/arm/nrf52dk_nrf52805/nrf52dk_nrf52805.dts
@@ -42,7 +42,7 @@
 		};
 	};
 
-	gpio_keys {
+	buttons {
 		compatible = "gpio-keys";
 		button0: button_0 {
 			label = "Push button switch 0";

--- a/boards/arm/nrf52dk_nrf52810/nrf52dk_nrf52810.dts
+++ b/boards/arm/nrf52dk_nrf52810/nrf52dk_nrf52810.dts
@@ -44,7 +44,7 @@
 		};
 	};
 
-	gpio_keys {
+	buttons {
 		compatible = "gpio-keys";
 		button0: button_0 {
 			label = "Push button switch 0";

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
@@ -42,22 +42,29 @@
 	};
 
 	buttons {
+		/*
+		 * Unlike most DK boards, we do not actually have 4 buttons
+		 * on nRF9160 DK. Instead, we have 2 buttons and 2 switches.
+		 * Treat the switches as buttons anyway, for convenience.
+		 * This makes life easier for software that wants to deal with
+		 * the usual "4 buttons per DK board" convention.
+		 */
 		compatible = "gpio-keys";
 		button0: button_0 {
-			gpios = <&gpio0 8 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
-			label = "Switch 1";
-		};
-		button1: button_1 {
-			gpios = <&gpio0 9 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
-			label = "Switch 2";
-		};
-		button2: button_2 {
 			gpios = <&gpio0 6 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "Push button 1";
 		};
-		button3: button_3 {
+		button1: button_1 {
 			gpios = <&gpio0 7 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "Push button 2";
+		};
+		button2: button_2 {
+			gpios = <&gpio0 8 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Switch 1";
+		};
+		button3: button_3 {
+			gpios = <&gpio0 9 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Switch 2";
 		};
 	};
 
@@ -134,10 +141,10 @@
 		led2 = &led2;
 		led3 = &led3;
 		pwm-led0 = &pwm_led0;
-		sw0 = &button2;
-		sw1 = &button3;
-		sw2 = &button0;
-		sw3 = &button1;
+		sw0 = &button0;
+		sw1 = &button1;
+		sw2 = &button2;
+		sw3 = &button3;
 		bootloader-led0 = &led0;
 	};
 };

--- a/samples/drivers/spi_flash_at45/src/main.c
+++ b/samples/drivers/spi_flash_at45/src/main.c
@@ -7,6 +7,7 @@
 #include <zephyr.h>
 #include <drivers/flash.h>
 #include <logging/log_ctrl.h>
+#include <pm/device.h>
 
 #define FLASH_DEVICE        DT_LABEL(DT_INST(0, atmel_at45))
 


### PR DESCRIPTION
Our boards generally follow the following devicetree conventions:

- buttons are defined in the node with path /buttons
- alias sw0 is button 0, sw1 is button 1, and so on

Not all boards follow the convention, though. Align the oddballs for
consistency. This is useful for writing helper libraries that depend
on these conventions. Add a comment describing the odd situation for
nRF9160 DK while we are here.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>