### PR TITLE
boards: arm: pinetime: Add chosen display

### DIFF
--- a/boards/arm/pinetime_devkit0/pinetime_devkit0.dts
+++ b/boards/arm/pinetime_devkit0/pinetime_devkit0.dts
@@ -23,6 +23,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,display = &st7789v;
 	};
 
 	aliases {


### PR DESCRIPTION
The recent MR #40765 added a chosen display property. This was missing
for the pinetime board.

Signed-off-by: Casper Meijn <casper@meijn.net>