### PR TITLE
board: nucleo_h745zi_q: enable POWER_SUPPLY_DIRECT_SMPS

### DIFF
--- a/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m7_defconfig
+++ b/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m7_defconfig
@@ -6,6 +6,9 @@ CONFIG_SOC_STM32H745XX=y
 # Board config should be specified since there are 2 possible targets
 CONFIG_BOARD_NUCLEO_H745ZI_Q_M7=y
 
+# Enable the internal SMPS regulator
+CONFIG_POWER_SUPPLY_DIRECT_SMPS=y
+
 # Enable MPU
 CONFIG_ARM_MPU=y
 


### PR DESCRIPTION
Hi, just bumped into this while messing around with my Nucleo H755ZI-Q (same as the 745). The board becomes unresponsive after a power cycle and needs to be started in reset or pulling BOOT0 high to be reflashed, bisected down to 22186c7c51 changing the SMPS behavior.

The board is not fitted for using the LDO in the stock configuration:

![h755zi-q sch](https://user-images.githubusercontent.com/891546/145679948-8235be33-dbe7-4255-8126-6994dcfb8455.png)

Don't think other Nucleo boards are affected so this just changes nucleo_h745zi_q.