### PR TITLE
twister: remove redundant required for generate-hardware-map

### DIFF
--- a/scripts/twister
+++ b/scripts/twister
@@ -345,7 +345,6 @@ Artificially long but functional example:
              "use with the --device-serial option.")
 
     run_group_option.add_argument("--generate-hardware-map",
-                        required="--generate-hardware-map" in sys.argv,
                         help="""Probe serial devices connected to this platform
                         and create a hardware map file to be used with
                         --device-testing


### PR DESCRIPTION
remove a redundate required for --generate-hardware-map

this fixing: #41066

Signed-off-by: Hake Huang <hake.huang@oss.nxp.com>