### PR TITLE
fat_fs: Add support for the "win" variable alignment in FATFS struct

### DIFF
--- a/subsys/fs/Kconfig.fatfs
+++ b/subsys/fs/Kconfig.fatfs
@@ -129,6 +129,19 @@ config FS_FATFS_MAX_SS
 	range 512 4096
 	default 512
 
+config FS_FATFS_WINDOW_ALIGNMENT
+	int "Memory alignment for the member \"win\" in FATFS"
+	default 1
+	help
+	  Specifies alignment, in bytes of FAT FS window buffer that is
+	  used for device's read/write operations. MMC controllers may
+	  require read/write buffer to start at memory address with
+	  specific alignment, for example 16 or 512 bytes, the value
+	  provided here is used as such alignment. Note that the window
+	  buffer is internal element of FATFS structure, which means
+	  that, in worst scenario, value provided here may cause FATFS
+	  structure to have size of twice the value
+
 endmenu
 
 endif # FAT_FILESYSTEM_ELM

--- a/west.yml
+++ b/west.yml
@@ -42,7 +42,7 @@ manifest:
       groups:
         - tools
     - name: fatfs
-      revision: 09a9d913c61dccbb8ff92d8943b452c614ac5292
+      revision: 9237454a30bcf6e14a89db174e8dbeb8f31831d2
       path: modules/fs/fatfs
       groups:
         - fs


### PR DESCRIPTION
This is to support Sypnosys Designware SDMMC controller read and write
operation where the buffer address is needed to be 16bytes and 512bytes
aligned. Adding macro FS_FATFS_WINDOW_ALIGNMENT to align the "win" variable
address in FATFS struct.

Signed-off-by: Boon Khai Ng <boon.khai.ng@intel.com>