### PR TITLE
dts: nordic: Set default binding for all multi mode buses

### DIFF
--- a/dts/arm/nordic/nrf51822.dtsi
+++ b/dts/arm/nordic/nrf51822.dtsi
@@ -88,6 +88,7 @@
 			 * compatible = "nordic,nrf-spi" or
 			 *              "nordic,nrf-spis".
 			 */
+			compatible = "nordic,nrf-spi";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;

--- a/dts/arm/nordic/nrf52805.dtsi
+++ b/dts/arm/nordic/nrf52805.dtsi
@@ -59,6 +59,7 @@
 		uart0: uart@40002000 {
 			/* uart can be either UART or UARTE, for the user to pick */
 			/* compatible = "nordic,nrf-uarte" or "nordic,nrf-uart"; */
+			compatible = "nordic,nrf-uarte";
 			reg = <0x40002000 0x1000>;
 			interrupts = <2 NRF_DEFAULT_IRQ_PRIORITY>;
 			status = "disabled";
@@ -73,6 +74,7 @@
 			 *              "nordic,nrf-twim" or
 			 *              "nordic,nrf-twis".
 			 */
+			compatible = "nordic,nrf-twim";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
@@ -90,6 +92,7 @@
 			 *              "nordic,nrf-spim" or
 			 *              "nordic,nrf-spis".
 			 */
+			compatible = "nordic,nrf-spim";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;

--- a/dts/arm/nordic/nrf52810.dtsi
+++ b/dts/arm/nordic/nrf52810.dtsi
@@ -56,6 +56,7 @@
 		uart0: uart@40002000 {
 			/* uart can be either UART or UARTE, for the user to pick */
 			/* compatible = "nordic,nrf-uarte" or "nordic,nrf-uart"; */
+			compatible = "nordic,nrf-uarte";
 			reg = <0x40002000 0x1000>;
 			interrupts = <2 NRF_DEFAULT_IRQ_PRIORITY>;
 			status = "disabled";
@@ -70,6 +71,7 @@
 			 *              "nordic,nrf-twim" or
 			 *              "nordic,nrf-twis".
 			 */
+			compatible = "nordic,nrf-twim";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
@@ -87,6 +89,7 @@
 			 *              "nordic,nrf-spim" or
 			 *              "nordic,nrf-spis".
 			 */
+			compatible = "nordic,nrf-spim";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;

--- a/dts/arm/nordic/nrf52811.dtsi
+++ b/dts/arm/nordic/nrf52811.dtsi
@@ -61,6 +61,7 @@
 		uart0: uart@40002000 {
 			/* uart can be either UART or UARTE, for the user to pick */
 			/* compatible = "nordic,nrf-uarte" or "nordic,nrf-uart"; */
+			compatible = "nordic,nrf-uarte";
 			reg = <0x40002000 0x1000>;
 			interrupts = <2 NRF_DEFAULT_IRQ_PRIORITY>;
 			status = "disabled";
@@ -75,6 +76,7 @@
 			 *              "nordic,nrf-twim" or
 			 *              "nordic,nrf-twis".
 			 */
+			compatible = "nordic,nrf-twim";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
@@ -93,6 +95,7 @@
 			 *              "nordic,nrf-spim" or
 			 *              "nordic,nrf-spis".
 			 */
+			compatible = "nordic,nrf-spim";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
@@ -109,6 +112,7 @@
 			 *              "nordic,nrf-spim" or
 			 *              "nordic,nrf-spis".
 			 */
+			compatible = "nordic,nrf-spim";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;

--- a/dts/arm/nordic/nrf52820.dtsi
+++ b/dts/arm/nordic/nrf52820.dtsi
@@ -62,6 +62,7 @@
 		uart0: uart@40002000 {
 			/* uart can be either UART or UARTE, for the user to pick */
 			/* compatible = "nordic,nrf-uarte" or "nordic,nrf-uart"; */
+			compatible = "nordic,nrf-uarte";
 			reg = <0x40002000 0x1000>;
 			interrupts = <2 NRF_DEFAULT_IRQ_PRIORITY>;
 			status = "disabled";
@@ -76,6 +77,7 @@
 			 *              "nordic,nrf-twim" or
 			 *              "nordic,nrf-twis".
 			 */
+			compatible = "nordic,nrf-twim";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
@@ -93,6 +95,7 @@
 			 *              "nordic,nrf-spim" or
 			 *              "nordic,nrf-spis".
 			 */
+			compatible = "nordic,nrf-spim";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
@@ -109,6 +112,7 @@
 			 *              "nordic,nrf-twim" or
 			 *              "nordic,nrf-twis".
 			 */
+			compatible = "nordic,nrf-twim";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
@@ -126,6 +130,7 @@
 			 *              "nordic,nrf-spim" or
 			 *              "nordic,nrf-spis".
 			 */
+			compatible = "nordic,nrf-spim";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -56,6 +56,7 @@
 		uart0: uart@40002000 {
 			/* uart can be either UART or UARTE, for the user to pick */
 			/* compatible = "nordic,nrf-uarte" or "nordic,nrf-uart"; */
+			compatible = "nordic,nrf-uarte";
 			reg = <0x40002000 0x1000>;
 			interrupts = <2 NRF_DEFAULT_IRQ_PRIORITY>;
 			status = "disabled";
@@ -70,6 +71,7 @@
 			 *              "nordic,nrf-twim" or
 			 *              "nordic,nrf-twis".
 			 */
+			compatible = "nordic,nrf-twim";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
@@ -87,6 +89,7 @@
 			 *              "nordic,nrf-spim" or
 			 *              "nordic,nrf-spis".
 			 */
+			compatible = "nordic,nrf-spi";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
@@ -103,6 +106,7 @@
 			 *              "nordic,nrf-twim" or
 			 *              "nordic,nrf-twis".
 			 */
+			compatible = "nordic,nrf-twim";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
@@ -120,6 +124,7 @@
 			 *              "nordic,nrf-spim" or
 			 *              "nordic,nrf-spis".
 			 */
+			compatible = "nordic,nrf-spi";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
@@ -359,6 +364,7 @@
 			 *              "nordic,nrf-spim" or
 			 *              "nordic,nrf-spis".
 			 */
+			compatible = "nordic,nrf-spi";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40023000 0x1000>;

--- a/dts/arm/nordic/nrf52833.dtsi
+++ b/dts/arm/nordic/nrf52833.dtsi
@@ -61,6 +61,7 @@
 		uart0: uart@40002000 {
 			/* uart can be either UART or UARTE, for the user to pick */
 			/* compatible = "nordic,nrf-uarte" or "nordic,nrf-uart"; */
+			compatible = "nordic,nrf-uarte";
 			reg = <0x40002000 0x1000>;
 			interrupts = <2 NRF_DEFAULT_IRQ_PRIORITY>;
 			status = "disabled";
@@ -75,6 +76,7 @@
 			 *              "nordic,nrf-twim" or
 			 *              "nordic,nrf-twis".
 			 */
+			compatible = "nordic,nrf-twim";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
@@ -92,6 +94,7 @@
 			 *              "nordic,nrf-spim" or
 			 *              "nordic,nrf-spis".
 			 */
+			compatible = "nordic,nrf-spim";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
@@ -108,6 +111,7 @@
 			 *              "nordic,nrf-twim" or
 			 *              "nordic,nrf-twis".
 			 */
+			compatible = "nordic,nrf-twim";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
@@ -125,6 +129,7 @@
 			 *              "nordic,nrf-spim" or
 			 *              "nordic,nrf-spis".
 			 */
+			compatible = "nordic,nrf-spim";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
@@ -364,6 +369,7 @@
 			 *              "nordic,nrf-spim" or
 			 *              "nordic,nrf-spis".
 			 */
+			compatible = "nordic,nrf-spim";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40023000 0x1000>;

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -56,6 +56,7 @@
 		uart0: uart@40002000 {
 			/* uart can be either UART or UARTE, for the user to pick */
 			/* compatible = "nordic,nrf-uarte" or "nordic,nrf-uart"; */
+			compatible = "nordic,nrf-uarte";
 			reg = <0x40002000 0x1000>;
 			interrupts = <2 NRF_DEFAULT_IRQ_PRIORITY>;
 			status = "disabled";
@@ -70,6 +71,7 @@
 			 *              "nordic,nrf-twim" or
 			 *              "nordic,nrf-twis".
 			 */
+			compatible = "nordic,nrf-twim";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
@@ -87,6 +89,7 @@
 			 *              "nordic,nrf-spim" or
 			 *              "nordic,nrf-spis".
 			 */
+			compatible = "nordic,nrf-spim";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
@@ -103,6 +106,7 @@
 			 *              "nordic,nrf-twim" or
 			 *              "nordic,nrf-twis".
 			 */
+			compatible = "nordic,nrf-twim";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
@@ -120,6 +124,7 @@
 			 *              "nordic,nrf-spim" or
 			 *              "nordic,nrf-spis".
 			 */
+			compatible = "nordic,nrf-spim";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
@@ -359,6 +364,7 @@
 			 *              "nordic,nrf-spim" or
 			 *              "nordic,nrf-spis".
 			 */
+			compatible = "nordic,nrf-spim";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40023000 0x1000>;

--- a/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
@@ -31,6 +31,7 @@ i2c0: i2c@8000 {
 	 * compatible = "nordic,nrf-twim" or
 	 *              "nordic,nrf-twis".
 	 */
+	compatible = "nordic,nrf-twim";
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0x8000 0x1000>;
@@ -47,6 +48,7 @@ spi0: spi@8000 {
 	 * compatible = "nordic,nrf-spim" or
 	 *              "nordic,nrf-spis".
 	 */
+	compatible = "nordic,nrf-spim";
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0x8000 0x1000>;
@@ -70,6 +72,7 @@ i2c1: i2c@9000 {
 	 * compatible = "nordic,nrf-twim" or
 	 *              "nordic,nrf-twis".
 	 */
+	compatible = "nordic,nrf-twim";
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0x9000 0x1000>;
@@ -86,6 +89,7 @@ spi1: spi@9000 {
 	 * compatible = "nordic,nrf-spim" or
 	 *              "nordic,nrf-spis".
 	 */
+	compatible = "nordic,nrf-spim";
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0x9000 0x1000>;
@@ -119,6 +123,7 @@ i2c2: i2c@b000 {
 	 * compatible = "nordic,nrf-twim" or
 	 *              "nordic,nrf-twis".
 	 */
+	compatible = "nordic,nrf-twim";
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0xb000 0x1000>;
@@ -135,6 +140,7 @@ spi2: spi@b000 {
 	 * compatible = "nordic,nrf-spim" or
 	 *              "nordic,nrf-spis".
 	 */
+	compatible = "nordic,nrf-spim";
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0xb000 0x1000>;
@@ -158,6 +164,7 @@ i2c3: i2c@c000 {
 	 * compatible = "nordic,nrf-twim" or
 	 *              "nordic,nrf-twis".
 	 */
+	compatible = "nordic,nrf-twim";
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0xc000 0x1000>;
@@ -174,6 +181,7 @@ spi3: spi@c000 {
 	 * compatible = "nordic,nrf-spim" or
 	 *              "nordic,nrf-spis".
 	 */
+	compatible = "nordic,nrf-spim";
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0xc000 0x1000>;

--- a/dts/arm/nordic/nrf5340_cpunet.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet.dtsi
@@ -157,6 +157,7 @@
 			 * compatible = "nordic,nrf-twim" or
 			 *              "nordic,nrf-twis".
 			 */
+			compatible = "nordic,nrf-twim";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x41013000 0x1000>;
@@ -173,6 +174,7 @@
 			 * compatible = "nordic,nrf-spim" or
 			 *              "nordic,nrf-spis".
 			 */
+			compatible = "nordic,nrf-spim";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x41013000 0x1000>;

--- a/dts/arm/nordic/nrf9160_common.dtsi
+++ b/dts/arm/nordic/nrf9160_common.dtsi
@@ -154,6 +154,7 @@ i2c0: i2c@8000 {
 	 * compatible = "nordic,nrf-twim" or
 	 *              "nordic,nrf-twis".
 	 */
+	compatible = "nordic,nrf-twim";
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0x8000 0x1000>;
@@ -169,6 +170,7 @@ i2c1: i2c@9000 {
 	 * compatible = "nordic,nrf-twim" or
 	 *              "nordic,nrf-twis".
 	 */
+	compatible = "nordic,nrf-twim";
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0x9000 0x1000>;
@@ -184,6 +186,7 @@ i2c2: i2c@a000 {
 	 * compatible = "nordic,nrf-twim" or
 	 *              "nordic,nrf-twis".
 	 */
+	compatible = "nordic,nrf-twim";
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0xa000 0x1000>;
@@ -199,6 +202,7 @@ i2c3: i2c@b000 {
 	 * compatible = "nordic,nrf-twim" or
 	 *              "nordic,nrf-twis".
 	 */
+	compatible = "nordic,nrf-twim";
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0xb000 0x1000>;
@@ -214,6 +218,7 @@ spi0: spi@8000 {
 	 * compatible = "nordic,nrf-spim" or
 	 *              "nordic,nrf-spis".
 	 */
+	compatible = "nordic,nrf-spim";
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0x8000 0x1000>;
@@ -228,6 +233,7 @@ spi1: spi@9000 {
 	 * compatible = "nordic,nrf-spim" or
 	 *              "nordic,nrf-spis".
 	 */
+	compatible = "nordic,nrf-spim";
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0x9000 0x1000>;
@@ -242,6 +248,7 @@ spi2: spi@a000 {
 	 * compatible = "nordic,nrf-spim" or
 	 *              "nordic,nrf-spis".
 	 */
+	compatible = "nordic,nrf-spim";
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0xa000 0x1000>;
@@ -256,6 +263,7 @@ spi3: spi@b000 {
 	 * compatible = "nordic,nrf-spim" or
 	 *              "nordic,nrf-spis".
 	 */
+	compatible = "nordic,nrf-spim";
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0xb000 0x1000>;


### PR DESCRIPTION
As Nordic SPI, I2C and UART buses can act as both slave and master,
these nodes can have different compatible properties, and are annotated
with a comment, instead of a compatible property. This forces boards to
put compatible properties in their definitions, which is unnecessary
boilerplate for most boards, as most boards acts as masters on these
buses.

Set master mode by default for these buses, to reduce boilerplate and
potential errors in board definitions. Boards that need to act as slave
nodes will just continue to override the compatible properties.
Likewise, existing boards that override this compatible property with a
master binding will not be affected by this change.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>