### PR TITLE
stmemsc: make use of i2c/spi dt APIs

### DIFF
--- a/drivers/sensor/stmemsc/stmemsc_i2c.c
+++ b/drivers/sensor/stmemsc/stmemsc_i2c.c
@@ -12,13 +12,11 @@
 int stmemsc_i2c_read(const struct i2c_dt_spec *stmemsc,
 			     uint8_t reg_addr, uint8_t *value, uint8_t len)
 {
-	return i2c_burst_read(stmemsc->bus, stmemsc->addr,
-			      reg_addr, value, len);
+	return i2c_burst_read_dt(stmemsc, reg_addr, value, len);
 }
 
 int stmemsc_i2c_write(const struct i2c_dt_spec *stmemsc,
 			      uint8_t reg_addr, uint8_t *value, uint8_t len)
 {
-	return i2c_burst_write(stmemsc->bus, stmemsc->addr,
-			       reg_addr, value, len);
+	return i2c_burst_write_dt(stmemsc, reg_addr, value, len);
 }

--- a/drivers/sensor/stmemsc/stmemsc_spi.c
+++ b/drivers/sensor/stmemsc/stmemsc_spi.c
@@ -17,7 +17,6 @@
 int stmemsc_spi_read(const struct spi_dt_spec *stmemsc,
 		     uint8_t reg_addr, uint8_t *value, uint8_t len)
 {
-	const struct spi_config *spi_cfg = &stmemsc->config;
 	uint8_t buffer_tx[2] = { reg_addr | SPI_READ, 0 };
 
 	/*  write 1 byte with reg addr (msb at 1) + 1 dummy byte */
@@ -34,7 +33,7 @@ int stmemsc_spi_read(const struct spi_dt_spec *stmemsc,
 	};
 	const struct spi_buf_set rx = { .buffers = rx_buf, .count = 2 };
 
-	return spi_transceive(stmemsc->bus, spi_cfg, &tx, &rx);
+	return spi_transceive_dt(stmemsc, &tx, &rx);
 }
 
 /*
@@ -43,7 +42,6 @@ int stmemsc_spi_read(const struct spi_dt_spec *stmemsc,
 int stmemsc_spi_write(const struct spi_dt_spec *stmemsc,
 		      uint8_t reg_addr, uint8_t *value, uint8_t len)
 {
-	const struct spi_config *spi_cfg = &stmemsc->config;
 	uint8_t buffer_tx[1] = { reg_addr & ~SPI_READ };
 
 	/*
@@ -56,5 +54,5 @@ int stmemsc_spi_write(const struct spi_dt_spec *stmemsc,
 	};
 	const struct spi_buf_set tx = { .buffers = tx_buf, .count = 2 };
 
-	return spi_write(stmemsc->bus, spi_cfg, &tx);
+	return spi_write_dt(stmemsc, &tx);
 }


### PR DESCRIPTION
Make use in STMEMSC common i2c/spi routines of the DT APIs introduced in 2946a535 and c894ad12, which takes i2c_dt_spec and spi_dt_spec as input arguments.                                                                           
