### PR TITLE
pwm: nucleo: Change the TIM2 out pin for PWM loopback test

### DIFF
--- a/tests/drivers/pwm/pwm_loopback/boards/nucleo_h743zi.overlay
+++ b/tests/drivers/pwm/pwm_loopback/boards/nucleo_h743zi.overlay
@@ -10,7 +10,7 @@
 	pwm_loopback_0 {
 		compatible = "test-pwm-loopback";
 		/* first index must be a 32-Bit timer */
-		pwms = <&pwm2 2 0 PWM_POLARITY_NORMAL>,
+		pwms = <&pwm2 4 0 PWM_POLARITY_NORMAL>,
 			<&pwm5 1 0 PWM_POLARITY_NORMAL>;
 	};
 };
@@ -20,7 +20,7 @@
 	status = "okay";
 	pwm2: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim2_ch2_pa1>; /* CN11 PIN30 */
+		pinctrl-0 = <&tim2_ch4_pa3>; /* CN12 PIN37 */
 		pinctrl-names = "default";
 	};
 };


### PR DESCRIPTION
The TIM2 output pin (i.e. PA1 - TIM2 ch2) on the NUCLEO-H743ZI2 devel
board by default is connected to (RMI_REF_CLOCK) of ETH phy IC
(LAN8742).

In the LAN8742 (LED2->nINTSEL is connected to GND), so the nINT/REFCLKO
(RMI_REF_CLOCK net) is the  50MHz clock signal output.

This disturbs the signal generated by TIM2, which afterwards is used as
input one for the PWM/Capture feature testing.

The solution (found and proposed by Alexandre Bourdiol) is to change the
TIM2 output pin to PA3, which is not connected in this NUCLEO board.

Suggested-by: Alexandre Bourdiol <alexandre.bourdiol@st.com>
Signed-off-by: Lukasz Majewski <lukma@denx.de>