### PR TITLE
Add CAN nodes for STM32H7 series

### DIFF
--- a/drivers/can/can_stm32fd.c
+++ b/drivers/can/can_stm32fd.c
@@ -49,10 +49,18 @@ int can_stm32fd_get_max_filters(const struct device *dev, enum can_ide id_type)
 
 void can_stm32fd_clock_enable(void)
 {
+/* There are different naming for clock source RCC_CCIPR_FDCANSEL_1
+ * in files stm32h7xx_ll_rcc.h and stm32g4xx_ll_rcc.h
+ */
+#if defined(LL_RCC_FDCAN_CLKSOURCE_PLL2Q)
+	LL_RCC_SetFDCANClockSource(LL_RCC_FDCAN_CLKSOURCE_PLL2Q);
+	__HAL_RCC_FDCAN_CLK_ENABLE();
+#else
 	LL_RCC_SetFDCANClockSource(LL_RCC_FDCAN_CLKSOURCE_PCLK1);
 	__HAL_RCC_FDCAN_CLK_ENABLE();
 
 	FDCAN_CONFIG->CKDIV = CONFIG_CAN_STM32_CLOCK_DIVISOR >> 1;
+#endif
 }
 
 void can_stm32fd_register_state_change_isr(const struct device *dev,

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -444,6 +444,42 @@
 			label = "SPI_6";
 		};
 
+		can {
+			compatible = "bosch,m-can-base";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			std-filter-elements = <28>;
+			ext-filter-elements = <8>;
+			rx-fifo0-elements = <3>;
+			rx-fifo1-elements = <3>;
+			rx-buffer-elements = <0>;
+			tx-buffer-elements = <3>;
+
+			can1: can@40006400 {
+				compatible = "st,stm32-fdcan";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				reg = <0x40006400 0x400>, <0x4000A400 0x350>;
+				reg-names = "m_can", "message_ram";
+				interrupts = <21 0>, <22 0>;
+				interrupt-names = "LINE_0", "LINE_1";
+				status = "disabled";
+				label = "CAN_1";
+			};
+
+			can2: can@40006800 {
+				compatible = "st,stm32-fdcan";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				reg = <0x40006800 0x400>, <0x4000A750 0x350>;
+				reg-names = "m_can", "message_ram";
+				interrupts = <86 0>, <87 0>;
+				interrupt-names = "LINE_0", "LINE_1";
+				status = "disabled";
+				label = "CAN_2";
+			};
+		};
+
 		timers1: timers@40010000 {
 			compatible = "st,stm32-timers";
 			reg = <0x40010000 0x400>;


### PR DESCRIPTION
Each STM32H7 Series chip contains 2 or 3 FDCAN controllers.
(https://www.st.com/en/microcontrollers-microprocessors/
stm32h7-series.html)