### PR TITLE
ci: doc-build: skip Kconfig docs build on pull requests

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -77,7 +77,13 @@ jobs:
           DOC_TAG="development"
         fi
 
-        DOC_TAG=${DOC_TAG} SPHINXOPTS="-q -W -t publish" make -C doc html
+        if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          DOC_TARGET="html-fast"
+        else
+          DOC_TARGET="html"
+        fi
+
+        DOC_TAG=${DOC_TAG} SPHINXOPTS="-q -W -t publish" make -C doc ${DOC_TARGET}
 
     - name: compress-docs
       run: |


### PR DESCRIPTION
The documentation supports a special target named "html-fast" that skips
generation of all Kconfig pages. Instead, it creates a single dummy page
where a reference to all existing Kconfig options is placed. This means
that references are resolved, but content is not rendered. Since Kconfig
help is rendered as a literal, chances of breaking documentation
build due to Kconfig changes should be low. The change proposed in this
patch should speed up documentation build on pull requests while a
proper solution is found for the Kconfig docs.