### PR TITLE
scripts/pylib/twister: Add sn option to stm32cubeprogrgammer runner

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -780,6 +780,8 @@ class DeviceHandler(Handler):
                         command_extra_args.append("cmsis_dap_serial %s" % (board_id))
                     elif runner == "jlink":
                         command.append("--tool-opt=-SelectEmuBySN  %s" % (board_id))
+                    elif runner == "stm32cubeprogrammer":
+                        command.append("--tool-opt=sn=%s" % (board_id))
 
             if command_extra_args != []:
                 command.append('--')


### PR DESCRIPTION
In order to enable use of stm32cubeprogrammer runner with twister,
add "sn" tool specific option which allows to provide target serial
number and hence select the target to flash when multiple ones are
connected to the host.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>