### PR TITLE
drivers/uart: stm32: don't call k_yield on poll_out

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -543,10 +543,6 @@ static void uart_stm32_poll_out(const struct device *dev,
 			}
 			irq_unlock(key);
 		}
-		if (!k_is_in_isr()) {
-			/* yield execution to another thread of the same or higher priority. */
-			k_yield();
-		}
 	}
 
 #ifdef CONFIG_PM


### PR DESCRIPTION
Some tests like:
    tests/kernel/sched/metairq/kernel.scheduler.metairq
    tests/kernel/profiling/profiling_api/kernel.common.profiling
    tests/kernel/sched/schedule_api/kernel.scheduler
    tests/kernel/sched/schedule_api/kernel.scheduler.multiq
    tests/kernel/profiling/profiling_api/kernel.common.profiling
    tests/kernel/workq/work_queue/kernel.workqueue

don't support that the current thread change when writing a message with
printk (which uses poll_out). So, we remove the call to k_yield which is
useful only for optimizing cpu usage by forcing a thread change if the
usart send stack is full.

Fix #40775