### PR TITLE
MAINTAINERS: Update NXP platform collaborators

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1493,6 +1493,7 @@ NXP Platforms:
     - dleach02
   collaborators:
     - mmahadevan108
+    - danieldegrasse
   files:
     - boards/arm/mimx*/
     - boards/arm/frdm_k*/


### PR DESCRIPTION
Add danieldegrasse to the NXP platform collaborators list.

Signed-off-by: David Leach <david.leach@nxp.com>