### PR TITLE
tests: coredump: skip acrn_ehl_crb

### DIFF
--- a/tests/subsys/debug/coredump/testcase.yaml
+++ b/tests/subsys/debug/coredump/testcase.yaml
@@ -2,6 +2,7 @@ tests:
   coredump.logging_backend:
     tags: ignore_faults ignore_qemu_crash
     filter: CONFIG_ARCH_SUPPORTS_COREDUMP
+    platform_exclude: acrn_ehl_crb
     harness: console
     harness_config:
       type: multi_line

--- a/tests/subsys/debug/coredump_backends/testcase.yaml
+++ b/tests/subsys/debug/coredump_backends/testcase.yaml
@@ -2,6 +2,7 @@ tests:
   coredump.backends.logging:
     tags: ignore_faults ignore_qemu_crash
     filter: CONFIG_ARCH_SUPPORTS_COREDUMP
+    platform_exclude: acrn_ehl_crb
     harness: console
     harness_config:
       type: multi_line


### PR DESCRIPTION
The coredump tests output quite a large amount of data into
the console. However, the ACRN console only has very limited
history (comparatively), such that twister is unable to
match the necessary strings to consider the tests passed.
So skip those tests on acrn_ehl_crb.

Fixes #40887

Signed-off-by: Daniel Leung <daniel.leung@intel.com>