### PR TITLE
samples, modules: tflite-micro: reduce sample test case noise

### DIFF
--- a/samples/modules/tflite-micro/hello_world/src/main.c
+++ b/samples/modules/tflite-micro/hello_world/src/main.c
@@ -16,7 +16,8 @@
 
 #include "main_functions.h"
 
-#define NUM_LOOPS 50
+/* Increase number of loops to see full period of the sine curve */
+#define NUM_LOOPS 10
 
 /* This is the default main used on systems that have the standard C entry
  * point. Other devices (for example FreeRTOS or ESP32) that have different


### PR DESCRIPTION
Reduces noise of sample test case in CI by reducing number of output lines from 50 to 10.

Signed-off-by: Lauren Murphy <lauren.murphy@intel.com>