### PR TITLE
doc: reference: include two levels of titles in the toc

### DIFF
--- a/doc/reference/api/index.rst
+++ b/doc/reference/api/index.rst
@@ -1,7 +1,7 @@
 .. _api_status_and_guidelines:
 
-API Status / Guidelines
-#######################
+API Status and Guidelines
+#########################
 
 .. toctree::
    :maxdepth: 1

--- a/doc/reference/canbus/controller.rst
+++ b/doc/reference/canbus/controller.rst
@@ -1,7 +1,7 @@
 .. _can_api:
 
-CAN Controller API
-##################
+CAN Controller
+##############
 
 .. contents::
     :local:

--- a/doc/reference/edac/index.rst
+++ b/doc/reference/edac/index.rst
@@ -1,7 +1,7 @@
 .. _edac_api:
 
-Error Detection And Correction (EDAC) API
-#########################################
+Error Detection And Correction (EDAC)
+#####################################
 
 API Reference
 *************

--- a/doc/reference/index.rst
+++ b/doc/reference/index.rst
@@ -4,7 +4,8 @@ API Reference
 #############
 
 .. toctree::
-   :maxdepth: 1
+   :titlesonly:
+   :maxdepth: 2
 
    api/index.rst
    audio/index.rst

--- a/doc/reference/misc/index.rst
+++ b/doc/reference/misc/index.rst
@@ -1,7 +1,7 @@
 .. _misc_api:
 
-Miscellaneous APIs
-##################
+Miscellaneous
+#############
 
 .. comment
    not documenting

--- a/doc/reference/misc/notify.rst
+++ b/doc/reference/misc/notify.rst
@@ -1,7 +1,7 @@
 .. _async_notification:
 
-Asynchronous Notification APIs
-##############################
+Asynchronous Notifications
+##########################
 
 Zephyr APIs often include :ref:`api_term_async` functions where an
 operation is initiated and the application needs to be informed when it

--- a/doc/reference/modbus/index.rst
+++ b/doc/reference/modbus/index.rst
@@ -1,6 +1,6 @@
 .. _modbus:
 
-MODBUS
+Modbus
 ######
 
 Modbus is an industrial messaging protocol. The protocol is specified

--- a/doc/reference/usb/udc.rst
+++ b/doc/reference/usb/udc.rst
@@ -1,7 +1,7 @@
 .. _udc_api:
 
-USB device controller driver API
-################################
+USB device controller driver
+############################
 
 The USB Device Controller Driver Layer implements the low level control routines
 to deal directly with the hardware. All device controller drivers should


### PR DESCRIPTION
The Zephyr API grouping can be a bit difficult to maneuver. Ease this up a bit by expanding the table of contents to contain two levels of titles.
    
Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>