### PR TITLE
shields: mikroe_eth_click: Fix CS pins for LPC55S69

### DIFF
--- a/boards/shields/mikroe_eth_click/boards/lpcxpresso55s69_cpu0.overlay
+++ b/boards/shields/mikroe_eth_click/boards/lpcxpresso55s69_cpu0.overlay
@@ -9,6 +9,11 @@
 &mikrobus_spi {
 	status = "okay";
 
+	cs-gpios = <&gpio0 20 GPIO_ACTIVE_LOW>,
+		   <&gpio1 1 GPIO_ACTIVE_LOW>,
+		   <&gpio1 12 GPIO_ACTIVE_LOW>,
+		   <&gpio1 26 GPIO_ACTIVE_LOW>;
+
     /* LPCXpresso55xxx boards all use SSEL1. */
 	eth_click: eth_click@1 {
 		compatible = "microchip,enc28j60";

--- a/boards/shields/mikroe_eth_click/boards/lpcxpresso55s69_ns.overlay
+++ b/boards/shields/mikroe_eth_click/boards/lpcxpresso55s69_ns.overlay
@@ -9,6 +9,11 @@
 &mikrobus_spi {
 	status = "okay";
 
+	cs-gpios = <&gpio0 20 GPIO_ACTIVE_LOW>,
+		   <&gpio1 1 GPIO_ACTIVE_LOW>,
+		   <&gpio1 12 GPIO_ACTIVE_LOW>,
+		   <&gpio1 26 GPIO_ACTIVE_LOW>;
+
     /* LPCXpresso55xxx boards all use SSEL1. */
 	eth_click: eth_click@1 {
 		compatible = "microchip,enc28j60";


### PR DESCRIPTION
Fix CS pins for Mikroe Click Ethernet shield overlay on LPC55S69's. Should resolve #31748. 