### PR TITLE
net: socket: Extending POSIX compatability SO_<options>

### DIFF
--- a/drivers/wifi/simplelink/simplelink_sockets.c
+++ b/drivers/wifi/simplelink/simplelink_sockets.c
@@ -679,13 +679,6 @@ static int map_credentials(int sd, const void *optval, socklen_t optlen)
 }
 #endif  /* CONFIG_NET_SOCKETS_SOCKOPT_TLS */
 
-/* Excerpted from SimpleLink's socket.h:
- * "Unsupported: these are only placeholders to not break BSD code."
- *  Remove once Zephyr has POSIX socket options defined.
- */
-#define SO_BROADCAST  (200)
-#define SO_SNDBUF     (202)
-
 /* Needed to keep line lengths < 80: */
 #define _SEC_DOMAIN_VERIF SL_SO_SECURE_DOMAIN_NAME_VERIFICATION
 

--- a/include/net/socket.h
+++ b/include/net/socket.h
@@ -838,12 +838,29 @@ struct ifreq {
 #define SOL_SOCKET 1
 
 /* Socket options for SOL_SOCKET level */
-/** sockopt: Enable server address reuse (ignored, for compatibility) */
+
+/** sockopt: Recording debugging information (ignored, for compatibility) */
+#define SO_DEBUG 1
+/** sockopt: address reuse (ignored, for compatibility) */
 #define SO_REUSEADDR 2
 /** sockopt: Type of the socket */
 #define SO_TYPE 3
 /** sockopt: Async error (ignored, for compatibility) */
 #define SO_ERROR 4
+/** sockopt: Bypass normal routing and send directly to host (ignored, for compatibility) */
+#define SO_DONTROUTE 5
+/** sockopt: Transmission of broadcast messages is supported (ignored, for compatibility) */
+#define SO_BROADCAST 6
+
+/** sockopt: Size of socket socket send buffer (ignored, for compatibility) */
+#define SO_SNDBUF 7
+
+/** sockopt: Enable sending keep-alive messages on connections (ignored, for compatibility) */
+#define SO_KEEPALIVE 9
+/** sockopt: Place out-of-band data into receive stream (ignored, for compatibility) */
+#define SO_OOBINLINE 10
+/** sockopt: Allow multiple sockets to reuse a single port (ignored, for compatibility) */
+#define SO_REUSEPORT 15
 
 /**
  * sockopt: Receive timeout
@@ -856,10 +873,18 @@ struct ifreq {
 /** sockopt: Bind a socket to an interface */
 #define SO_BINDTODEVICE	25
 
+/** sockopt: Socket accepts incoming connections (ignored, for compatibility) */
+#define SO_ACCEPTCONN 30
+
 /** sockopt: Timestamp TX packets */
 #define SO_TIMESTAMPING 37
 /** sockopt: Protocol used with the socket */
 #define SO_PROTOCOL 38
+
+/** sockopt: Domain used with SOCKET (ignored, for compatibility) */
+#define SO_DOMAIN 39
+
+/** End Socket options for SOL_SOCKET level */
 
 /* Socket options for IPPROTO_TCP level */
 /** sockopt: Disable TCP buffering (ignored, for compatibility) */


### PR DESCRIPTION
Adding these definitions help ease of porting POSIX applications.

They currently do nothing in the core network stack and will return an error if used. However, they help port some POSIX without changing these. In particular, this enables using the Nim programming language's standard library with Zephyr.

The values copy those from Linux amd64, similar to the other SO_OPTIONS.
