### PR TITLE
boards: pinetime_devkit0: add compatible for generic spi nor flash

### DIFF
--- a/boards/arm/pinetime_devkit0/pinetime_devkit0.dts
+++ b/boards/arm/pinetime_devkit0/pinetime_devkit0.dts
@@ -125,12 +125,13 @@
 
 	cs-gpios = <&gpio0 5 GPIO_ACTIVE_LOW>, <&gpio0 25 GPIO_ACTIVE_LOW>;
 
-	/* Macronix MX25L CMOS Flash Memory */
-	mx25l: mx25l@0 {
-		compatible = "mxicy,cmos-mx25l";
+	xt25fb32: xt25fb32@0 {
+		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <8000000>; /* 8MHz */
-		label = "CMOS MX25L";
+		label = "XT25FB32";
+		jedec-id = [0b 40 16];
+		size = <DT_SIZE_M(32)>;
 	};
 
 	/* Sitronix ST7789V LCD */


### PR DESCRIPTION
using the correct datasheet download from official site: http://www.xtxtech.com/download/?AId=154

Signed-off-by: Qingsong Gou <gouqs@hotmail.com>