### PR TITLE
pm: device: fix comment reference to DT_INVALID_NODE

### DIFF
--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -172,7 +172,7 @@ struct pm_device {
 /**
  * Define device PM resources for the given node identifier.
  *
- * @param node_id Node identifier (DT_NODE_INVALID if not a DT device).
+ * @param node_id Node identifier (DT_INVALID_NODE if not a DT device).
  * @param dev_name Device name.
  * @param pm_action_cb PM control callback.
  */


### PR DESCRIPTION
Comment block for Z_PM_DEVICE_DEFINE had an incorrect
reference to DT_INVALID_NODE. Using DT_NODE_INVALID
which isn't defined.

Signed-off-by: David Leach <david.leach@nxp.com>