### PR TITLE
tests: benchmark: fix code coverage incorrect for latency_measure

### DIFF
--- a/tests/benchmarks/latency_measure/src/main.c
+++ b/tests/benchmarks/latency_measure/src/main.c
@@ -67,4 +67,5 @@ K_THREAD_DEFINE(test_thread_id, STACK_SIZE, test_thread, NULL, NULL, NULL, K_PRI
 
 void main(void)
 {
+	k_thread_join(test_thread_id, K_FOREVER);
 }


### PR DESCRIPTION
Fixing code coverage data cannot be generated correctly when running
tests/benchmark/latency_measure test suite. This is because the gcov data
do not generate completely when the measuring thread stop. So our
solution is: In main(), just waiting for the measuring thread to complete
before the gcov data start to dump out, to make sure all the gcov data
can be output completely.

Signed-off-by: Enjia Mai <enjia.mai@intel.com>