### PR TITLE
drivers: sensors: tmp112 fix config register updating

### DIFF
--- a/drivers/sensor/tmp112/tmp112.c
+++ b/drivers/sensor/tmp112/tmp112.c
@@ -53,7 +53,7 @@ static int tmp112_update_config(const struct device *dev, uint16_t mask,
 
 	rc = tmp112_reg_write(dev->config, TMP112_REG_CONFIG, new_val);
 	if (rc == 0) {
-		data->config_reg = val;
+		data->config_reg = new_val;
 	}
 
 	return rc;


### PR DESCRIPTION
The function that sets the driver's state of the sensor's
config register has a bug. This commit fixes that.

Signed-off-by: Pete Dietl <petedietl@gmail.com>