### PR TITLE
MAINTAINERS: Add files-exclude for Bluetooth sub-subsystems

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -185,6 +185,11 @@ Bluetooth:
         - subsys/bluetooth/shell/
         - subsys/bluetooth/audio/
         - tests/bluetooth/
+    files-exclude:
+        - include/bluetooth/mesh/
+        - subsys/bluetooth/controller/
+        - subsys/bluetooth/mesh/
+        - samples/bluetooth/mesh/
     labels:
         - "area: Bluetooth"
 
@@ -203,6 +208,7 @@ Bluetooth controller:
         - subsys/bluetooth/controller/
     labels:
         - "area: Bluetooth Controller"
+        - "area: Bluetooth"
 
 Bluetooth Mesh:
     status: maintained
@@ -219,6 +225,7 @@ Bluetooth Mesh:
         - tests/bluetooth/mesh*/
     labels:
         - "area: Bluetooth Mesh"
+        - "area: Bluetooth"
 
 Build system:
     status: maintained


### PR DESCRIPTION
The Bluetooth Controller and the Bluetooth Mesh have separate maintainer
entries, and should not be covered by the Bluetooth entry itself, as
this causes jhedberg to get assigned to all PRs for these directories,
instead of cvinayak and trond-snekvik.

Adds a files-exclude list for the Bluetooth section of MAINTAINERS.yml
to ensure that PRs that only change any of these folders stop matching
the Bluetooth entry. Also adds "area: Bluetooth" to these directories,
as we'd still like all controller and mesh PRs to be labeled Bluetooth.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>