### PR TITLE
Fix non-standard pseudo-instructions of RISC-V

### DIFF
--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -733,7 +733,7 @@ call_irq:
 	RV_OP_LOADREG t1, RV_REGSIZE(t0)
 
 	/* Call ISR function */
-	jalr ra, t1
+	jalr ra, t1, 0
 
 on_thread_stack:
 	/* Get reference to _kernel */

--- a/arch/riscv/core/swap.S
+++ b/arch/riscv/core/swap.S
@@ -54,7 +54,7 @@ SECTION_FUNC(exception.other, arch_swap)
 	addi a0, t2, 0
 
 	/* Return */
-	jalr x0, ra
+	ret
 
 
 /*

--- a/soc/riscv/esp32c3/soc_irq.S
+++ b/soc/riscv/esp32c3/soc_irq.S
@@ -20,7 +20,7 @@ SECTION_FUNC(exception.other, __soc_handle_irq)
 	addi sp, sp,-4
 	sw  ra, 0x00(sp)
 	la t1, soc_intr_get_next_source
-	jalr ra, t1
+	jalr ra, t1, 0
 	lw  ra, 0x00(sp)
 	addi sp, sp, 4
 	ret

--- a/soc/riscv/riscv-ite/common/soc_irq.S
+++ b/soc/riscv/riscv-ite/common/soc_irq.S
@@ -57,4 +57,4 @@ SECTION_FUNC(exception.other, __soc_is_irq)
 
 not_interrupt:
 	/* return */
-	jalr x0, ra
+	ret

--- a/soc/riscv/riscv-privilege/common/soc_irq.S
+++ b/soc/riscv/riscv-privilege/common/soc_irq.S
@@ -31,7 +31,7 @@ SECTION_FUNC(exception.other, __soc_handle_irq)
 	csrrc t1, mip, t0
 
 	/* Return */
-	jalr x0, ra
+	ret
 
 /*
  * __soc_is_irq is defined as .weak to allow re-implementation by
@@ -58,4 +58,4 @@ SECTION_FUNC(exception.other, __soc_is_irq)
 
 not_interrupt:
 	/* return */
-	jalr x0, ra
+	ret

--- a/soc/riscv/riscv-privilege/neorv32/soc_irq.S
+++ b/soc/riscv/riscv-privilege/neorv32/soc_irq.S
@@ -25,4 +25,4 @@ SECTION_FUNC(exception.other, __soc_handle_irq)
 	csrrs t2, mie, t1
 
 	/* Return */
-	jalr x0, ra
+	ret


### PR DESCRIPTION
Fixes #41100.