### PR TITLE
Entropy: STM32: add health test configuration

### DIFF
--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -487,6 +487,18 @@ static int entropy_stm32_rng_init(const struct device *dev)
 		(clock_control_subsys_t *)&dev_cfg->pclken);
 	__ASSERT_NO_MSG(res == 0);
 
+
+#if DT_INST_NODE_HAS_PROP(0, health-test-config)
+#if DT_INST_NODE_HAS_PROP(0, health-test-magic)
+	/* Write Magic number before writing configuration
+	 * Not all stm32 series have a Magic number
+	 */
+	LL_RNG_SetHealthConfig(dev_data->rng, DT_INST_PROP(0, health-test-magic));
+#endif
+	/* Write RNG HTCR configuration */
+	LL_RNG_SetHealthConfig(dev_data->rng, DT_INST_PROP(0, health-test-config));
+#endif
+
 	LL_RNG_EnableIT(dev_data->rng);
 
 	LL_RNG_Enable(dev_data->rng);

--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -35,6 +35,11 @@
 		dmamux1: dmamux@40020800 {
 			dma-requests= <129>;
 		};
+
+		rng: rng@48021800 {
+			health-test-magic = <0x17590abc>;
+			health-test-config = <0xaa74>;
+		};
 	};
 
 	/* DTCM memory directly coppled to CPU */

--- a/dts/arm/st/h7/stm32h735.dtsi
+++ b/dts/arm/st/h7/stm32h735.dtsi
@@ -44,6 +44,11 @@
 			status = "disabled";
 			label = "CRYP";
 		};
+
+		rng: rng@48021800 {
+			health-test-magic = <0x17590abc>;
+			health-test-config = <0xaa74>;
+		};
 	};
 
 	/* System data RAM accessible over AXI bus: AXI SRAM in D1 domain */

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -380,6 +380,8 @@
 			reg = <0x420c0800 0x400>;
 			interrupts = <94 0>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00040000>;
+			health-test-magic = <0x17590abc>;
+			health-test-config = <0xa2b3>;
 			status = "disabled";
 			label = "RNG";
 		};

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -347,6 +347,7 @@
 			reg = <0x420c0800 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00040000>;
 			interrupts = <94 0>;
+			health-test-config = <0x9aae>;
 			status = "disabled";
 			label = "RNG";
 		};

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -407,6 +407,8 @@
 			reg = <0x58001000 0x400>;
 			interrupts = <52 0>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x00040000>;
+			health-test-magic = <0x17590abc>;
+			health-test-config = <0xaa74>;
 			status = "disabled";
 			label = "RNG";
 		};

--- a/dts/bindings/rng/st,stm32-rng.yaml
+++ b/dts/bindings/rng/st,stm32-rng.yaml
@@ -16,3 +16,17 @@ properties:
 
     clocks:
       required: true
+
+    health-test-magic:
+      type: int
+      required: false
+      description: |
+           Magic Number to be written to Health Test Configuration Register (HTCR)
+           prior to real configuration, if any.
+
+    health-test-config:
+      type: int
+      required: false
+      description: |
+           Heath Test Configuration, necessary to have proper RNG behavior,
+           when available.


### PR DESCRIPTION
Entropy: STM32: add RNG health test configuration

As identified in PR #36993, some STM32 series need to configure health test register
for proper RNG behavior.
In addition, some also require to write a Magic number before writing the configuration.
