### PR TITLE
boards: nucleo_wb55rg: Add stm32cubeprogrammer runner

### DIFF
--- a/boards/arm/nucleo_wb55rg/board.cmake
+++ b/boards/arm/nucleo_wb55rg/board.cmake
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 board_runner_args(pyocd "--target=stm32wb55rgvx")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset=hw")
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)


### PR DESCRIPTION
Use of stm32cubeprogrammer runner makes life easier
on test bench for this device.
Though, keep openocd as default.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>