### PR TITLE
logging: Cleanup in log_instance

### DIFF
--- a/include/logging/log.h
+++ b/include/logging/log.h
@@ -316,13 +316,13 @@ static inline char *log_strdup(const char *str)
 /* Return first argument */
 #define _LOG_ARG1(arg1, ...) arg1
 
-#define _LOG_MODULE_CONST_DATA_CREATE(_name, _level)			     \
-	IF_ENABLED(LOG_IN_CPLUSPLUS, (extern))				     \
-	const struct log_source_const_data LOG_ITEM_CONST_DATA(_name)	     \
-	__attribute__ ((section("." STRINGIFY(LOG_ITEM_CONST_DATA(_name))))) \
-	__attribute__((used)) = {					     \
-		.name = STRINGIFY(_name),				     \
-		.level = _level						     \
+#define _LOG_MODULE_CONST_DATA_CREATE(_name, _level)			       \
+	IF_ENABLED(LOG_IN_CPLUSPLUS, (extern))				       \
+	const struct log_source_const_data Z_LOG_ITEM_CONST_DATA(_name)	       \
+	__attribute__ ((section("." STRINGIFY(Z_LOG_ITEM_CONST_DATA(_name))))) \
+	__attribute__((used)) = {					       \
+		.name = STRINGIFY(_name),				       \
+		.level = _level						       \
 	}
 
 #define _LOG_MODULE_DYNAMIC_DATA_CREATE(_name)				\
@@ -409,14 +409,14 @@ static inline char *log_strdup(const char *str)
  */
 #define LOG_MODULE_DECLARE(...)						      \
 	extern const struct log_source_const_data			      \
-			LOG_ITEM_CONST_DATA(GET_ARG_N(1, __VA_ARGS__));	      \
+			Z_LOG_ITEM_CONST_DATA(GET_ARG_N(1, __VA_ARGS__));     \
 	extern struct log_source_dynamic_data				      \
 			LOG_ITEM_DYNAMIC_DATA(GET_ARG_N(1, __VA_ARGS__));     \
 									      \
 	static const struct log_source_const_data *			      \
 		__log_current_const_data __unused =			      \
 			_LOG_LEVEL_RESOLVE(__VA_ARGS__) ?		      \
-			&LOG_ITEM_CONST_DATA(GET_ARG_N(1, __VA_ARGS__)) :     \
+			&Z_LOG_ITEM_CONST_DATA(GET_ARG_N(1, __VA_ARGS__)) :   \
 			NULL;						      \
 									      \
 	static struct log_source_dynamic_data *				      \

--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -563,7 +563,7 @@ extern struct log_source_dynamic_data __log_dynamic_end[];
 #define LOG_ITEM_DYNAMIC_DATA(_name) UTIL_CAT(log_dynamic_, _name)
 
 #define LOG_INSTANCE_DYNAMIC_DATA(_module_name, _inst) \
-	LOG_ITEM_DYNAMIC_DATA(LOG_INSTANCE_FULL_NAME(_module_name, _inst))
+	LOG_ITEM_DYNAMIC_DATA(Z_LOG_INSTANCE_FULL_NAME(_module_name, _inst))
 
 /** @brief Get index of the log source based on the address of the dynamic data
  *         associated with the source.

--- a/include/logging/log_instance.h
+++ b/include/logging/log_instance.h
@@ -41,82 +41,134 @@ struct log_source_dynamic_data {
 #endif
 };
 
-/** @brief Creates name of variable and section for constant log data.
+/** @internal
+ *
+ * Creates name of variable and section for constant log data.
  *
  *  @param _name Name.
  */
-#define LOG_ITEM_CONST_DATA(_name) UTIL_CAT(log_const_, _name)
+#define Z_LOG_ITEM_CONST_DATA(_name) UTIL_CAT(log_const_, _name)
 
-#define Z_LOG_CONST_ITEM_REGISTER(_name, _str_name, _level)		     \
-	const struct log_source_const_data LOG_ITEM_CONST_DATA(_name)	     \
-	__attribute__ ((section("." STRINGIFY(LOG_ITEM_CONST_DATA(_name))))) \
-	__attribute__((used)) = {					     \
-		.name = _str_name,					     \
-		.level  = (_level),					     \
+/** @internal
+ *
+ * Create static logging instance in read only memory.
+ *
+ * @param _name name of the module. With added prefix forms name of variable and
+ * memory section.
+ *
+ * @param _str_name Name of the module that will be used when message is formatted.
+ *
+ * @param _level Messages up to this level are compiled in.
+ */
+#define Z_LOG_CONST_ITEM_REGISTER(_name, _str_name, _level)		       \
+	const struct log_source_const_data Z_LOG_ITEM_CONST_DATA(_name)	       \
+	__attribute__ ((section("." STRINGIFY(Z_LOG_ITEM_CONST_DATA(_name))))) \
+	__attribute__((used)) = {					       \
+		.name = _str_name,					       \
+		.level  = (_level),					       \
 	}
 
-/** @def LOG_INSTANCE_PTR_DECLARE
- * @brief Macro for declaring a logger instance pointer in the module structure.
+/** @brief Initialize pointer to logger instance with explicitly provided object.
+ *
+ * Macro can be used to initialized a pointer with object that is not unique to
+ * the given instance, thus not created with @ref LOG_INSTANCE_REGISTER.
+ *
+ * @param _name Name of the structure element for holding logging object.
+ * @param _object Pointer to a logging instance object.
  */
+#define LOG_OBJECT_PTR_INIT(_name, _object) \
+	IF_ENABLED(CONFIG_LOG, (._name = _object,))
 
-/** @def LOG_INSTANCE_REGISTER
+/** @internal
+ *
+ * Create a name for which contains module and instance names.
+ */
+#define Z_LOG_INSTANCE_FULL_NAME(_module_name, _inst_name) \
+	UTIL_CAT(_module_name, UTIL_CAT(_, _inst_name))
+
+/** @internal
+ *
+ * Returns a pointer associated with given logging instance. When runtime filtering
+ * is enabled then dynamic instance is returned.
+ *
+ * @param _name Name of the instance.
+ *
+ * @return Pointer to the instance object (static or dynamic).
+ */
+#define Z_LOG_OBJECT_PTR(_name) \
+		COND_CODE_1(CONFIG_LOG_RUNTIME_FILTERING, \
+			(&LOG_ITEM_DYNAMIC_DATA(_name)), \
+			(&Z_LOG_ITEM_CONST_DATA(_name))) \
+
+/** @brief Get pointer to a logging instance.
+ *
+ * Instance is identified by @p _module_name and @p _inst_name.
+ *
+ * @param _module_name Module name.
+ * @param _inst_name Instance name.
+ *
+ * @return Pointer to a logging instance.
+ */
+#define LOG_INSTANCE_PTR(_module_name, _inst_name) \
+	Z_LOG_OBJECT_PTR(Z_LOG_INSTANCE_FULL_NAME(_module_name, _inst_name))
+
+/** @brief Macro for initializing a pointer to the logger instance.
+ *
+ * @p _module_name and @p _inst_name are concatenated to form a name of the object.
+ *
+ * Macro is intended to be used in user structure initializer to initialize a field
+ * in the structure that holds pointer to the logging instance. Structure field
+ * should be declared using @p LOG_INSTANCE_PTR_DECLARE.
+ *
+ * @param _name Name of a structure element that have a pointer to logging instance object.
+ * @param _module_name Module name.
+ * @param _inst_name Instance name.
+ */
+#define LOG_INSTANCE_PTR_INIT(_name, _module_name, _inst_name)	   \
+	LOG_OBJECT_PTR_INIT(_name, LOG_INSTANCE_PTR(_module_name, _inst_name))
+
+#define Z_LOG_INSTANCE_STRUCT \
+	COND_CODE_1(CONFIG_LOG_RUNTIME_FILTERING, \
+		    (struct log_source_dynamic_data), \
+		    (const struct log_source_const_data))
+
+/**
+ * @brief Declare a logger instance pointer in the module structure.
+ *
+ * @param _name Name of a structure element that will have a pointer to logging
+ * instance object.
+ */
+#define LOG_INSTANCE_PTR_DECLARE(_name)	\
+	IF_ENABLED(CONFIG_LOG, (Z_LOG_INSTANCE_STRUCT * _name))
+
+#define Z_LOG_RUNTIME_INSTANCE_REGISTER(_module_name, _inst_name) \
+	struct log_source_dynamic_data LOG_INSTANCE_DYNAMIC_DATA(_module_name, _inst_name) \
+		__attribute__ ((section("." STRINGIFY( \
+				LOG_INSTANCE_DYNAMIC_DATA(_module_name, _inst_name) \
+				) \
+		))) __attribute__((used))
+
+#define Z_LOG_INSTANCE_REGISTER(_module_name, _inst_name, _level) \
+	Z_LOG_CONST_ITEM_REGISTER( \
+		Z_LOG_INSTANCE_FULL_NAME(_module_name, _inst_name), \
+		STRINGIFY(_module_name._inst_name), \
+		_level); \
+	IF_ENABLED(CONFIG_LOG_RUNTIME_FILTERING, \
+		   (Z_LOG_RUNTIME_INSTANCE_REGISTER(_module_name, _inst_name)))
+
+/**
  * @brief Macro for registering instance for logging with independent filtering.
  *
  * Module instance provides filtering of logs on instance level instead of
- * module level.
+ * module level. Instance create using this macro can later on be used with
+ * @ref LOG_INSTANCE_PTR_INIT or referenced by @ref LOG_INSTANCE_PTR.
+ *
+ * @param _module_name Module name.
+ * @param _inst_name Instance name.
+ * @param _level Initial static filtering.
  */
-
-/** @def LOG_INSTANCE_PTR_INIT
- * @brief Macro for initializing a pointer to the logger instance.
- */
-
-#ifdef CONFIG_LOG
-
-#define LOG_INSTANCE_FULL_NAME(_module_name, _inst_name) \
-	UTIL_CAT(_module_name, UTIL_CAT(_, _inst_name))
-
-#if defined(CONFIG_LOG_RUNTIME_FILTERING)
-#define LOG_INSTANCE_PTR_DECLARE(_name)	\
-	struct log_source_dynamic_data *_name
-
-#define LOG_INSTANCE_REGISTER(_module_name, _inst_name, _level)		   \
-	Z_LOG_CONST_ITEM_REGISTER(					   \
-		LOG_INSTANCE_FULL_NAME(_module_name, _inst_name),	   \
-		STRINGIFY(_module_name._inst_name),			   \
-		_level);						   \
-	struct log_source_dynamic_data LOG_INSTANCE_DYNAMIC_DATA(	   \
-						_module_name, _inst_name)  \
-		__attribute__ ((section("." STRINGIFY(			   \
-				LOG_INSTANCE_DYNAMIC_DATA(_module_name,	   \
-						       _inst_name)	   \
-				)					   \
-		))) __attribute__((used))
-
-#define LOG_INSTANCE_PTR_INIT(_name, _module_name, _inst_name)	   \
-	._name = &LOG_ITEM_DYNAMIC_DATA(			   \
-		LOG_INSTANCE_FULL_NAME(_module_name, _inst_name)),
-
-#else /* CONFIG_LOG_RUNTIME_FILTERING */
-#define LOG_INSTANCE_PTR_DECLARE(_name)	\
-	const struct log_source_const_data *_name
-
-#define LOG_INSTANCE_REGISTER(_module_name, _inst_name, _level)	  \
-	Z_LOG_CONST_ITEM_REGISTER(				  \
-		LOG_INSTANCE_FULL_NAME(_module_name, _inst_name), \
-		STRINGIFY(_module_name._inst_name),		  \
-		_level)
-
-
-#define LOG_INSTANCE_PTR_INIT(_name, _module_name, _inst_name) \
-	._name = &LOG_ITEM_CONST_DATA(			       \
-		LOG_INSTANCE_FULL_NAME(_module_name, _inst_name)),
-
-#endif /* CONFIG_LOG_RUNTIME_FILTERING */
-#else /* CONFIG_LOG */
-#define LOG_INSTANCE_PTR_DECLARE(_name) /* empty */
-#define LOG_INSTANCE_REGISTER(_module_name, _inst_name,  _level)    /* empty */
-#define LOG_INSTANCE_PTR_INIT(_name, _module_name, _inst_name)      /* empty */
-#endif
+#define LOG_INSTANCE_REGISTER(_module_name, _inst_name, _level) \
+	IF_ENABLED(CONFIG_LOG, (Z_LOG_INSTANCE_REGISTER(_module_name, _inst_name, _level)))
 
 #ifdef __cplusplus
 }

--- a/subsys/logging/Kconfig.processing
+++ b/subsys/logging/Kconfig.processing
@@ -91,7 +91,7 @@ config LOG_PROCESS_THREAD_STACK_SIZE
 	default 2048 if (RISCV && 64BIT)
 	default 2048 if LOG_BACKEND_FS
 	default 1152 if LOG_BACKEND_NET
-	default 1024 if NO_OPTIMIZATIONS
+	default 4096 if NO_OPTIMIZATIONS
 	default 1024 if XTENSA
 	default 768
 	help

--- a/tests/subsys/logging/log_output/src/log_output_test.c
+++ b/tests/subsys/logging/log_output/src/log_output_test.c
@@ -108,7 +108,7 @@ void test_log_output_string(void)
 	struct log_msg_ids src_level = {
 		.level = LOG_LEVEL_DBG,
 		.source_id = log_const_source_id(
-				&LOG_ITEM_CONST_DATA(LOG_MODULE_NAME)),
+				&Z_LOG_ITEM_CONST_DATA(LOG_MODULE_NAME)),
 		.domain_id = CONFIG_LOG_DOMAIN_ID,
 	};
 


### PR DESCRIPTION
Cleanup in log_instance.h (with no functional changes):
  - prefixing internal macros with Z_
  - adding doxygen documentation
  - using COND_CODE_1 instead of ifdefs
    
Additionally, added LOG_INSTANCE_PTR macro which allows to get
pointer to instance. It can be used to reuse single instance
for multiple module layers when doing instance logging.

It's partially driven by #19497

Additionally, increase default logging thread stack size when `NO_OPTIMIZATIONS=y`