### PR TITLE
Add GD32F405xx series SoCs

### DIFF
--- a/boards/arm/gd32f450i_eval/board.cmake
+++ b/boards/arm/gd32f450i_eval/board.cmake
@@ -1,4 +1,8 @@
 # Copyright (c) 2021, Teslabs Engineering S.L.
+# Copyright (c) 2021, BrainCo Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=GD32F450IK" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/dts/arm/gigadevice/gd32f4xx/gd32f405.dtsi
+++ b/dts/arm/gigadevice/gd32f4xx/gd32f405.dtsi
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2021, BrainCo Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gigadevice/gd32f4xx/gd32f4xx.dtsi>
+
+&cpu0 {
+	clock-frequency = <168000000>;
+};

--- a/dts/arm/gigadevice/gd32f4xx/gd32f405vg.dtsi
+++ b/dts/arm/gigadevice/gd32f4xx/gd32f405vg.dtsi
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2021 BrainCo Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <gigadevice/gd32f4xx/gd32f405.dtsi>
+
+/ {
+	soc {
+		flash-controller@40023c00 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_K(1024)>;
+			};
+		};
+
+		sram1: memory@2001c000 {
+			compatible = "mmio-sram";
+			reg = <0x2001c000 DT_SIZE_K(16)>;
+		};
+	};
+};

--- a/soc/arm/gigadevice/gd32f4xx/Kconfig.deconfig.gd32f405
+++ b/soc/arm/gigadevice/gd32f4xx/Kconfig.deconfig.gd32f405
@@ -1,0 +1,11 @@
+# Copyright (c) 2021 BrainCo Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC
+	default "gd32f405"
+
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
+
+config NUM_IRQS
+	default 82

--- a/soc/arm/gigadevice/gd32f4xx/Kconfig.soc
+++ b/soc/arm/gigadevice/gd32f4xx/Kconfig.soc
@@ -5,6 +5,9 @@ choice
 	prompt "GigaDevice GD32F4XX MCU Selection"
 	depends on SOC_SERIES_GD32F4XX
 
+	config SOC_GD32F405
+		bool "gd32f405"
+
 	config SOC_GD32F450
 		bool "gd32f450"
 

--- a/west.yml
+++ b/west.yml
@@ -73,7 +73,7 @@ manifest:
       groups:
         - hal
     - name: hal_gigadevice
-      revision: 2eafc9d95b623757df0027dd08ed1b693d3bb770
+      revision: 05de2b5229cf0267c73595c2454284059f48b27e
       path: modules/hal/gigadevice
       groups:
         - hal


### PR DESCRIPTION
Add GD32F405xx related definition to dts and soc.

Since there doesn't have GigaDevice official evaluation board for gd32f405 series SoCs, no reference board added in this PR. But gd32f405 is highly similar with gd32f450, maybe you can find some useful example on gd32f450i_eval board.
 
Also add a jlink runner for gd32f450i_eval board.

More GD32 support progress? #38657