### PR TITLE
drivers: wifi: eswifi: fix socket poll timeout

### DIFF
--- a/drivers/wifi/eswifi/eswifi_socket_offload.c
+++ b/drivers/wifi/eswifi/eswifi_socket_offload.c
@@ -458,7 +458,7 @@ static int eswifi_socket_poll(struct zsock_pollfd *fds, int nfds, int msecs)
 		return -1;
 	}
 
-	ret = k_sem_take(&socket->read_sem, K_MSEC(msecs*10));
+	ret = k_sem_take(&socket->read_sem, K_MSEC(msecs));
 	if (ret) {
 		errno = ETIMEDOUT;
 		return -1;


### PR DESCRIPTION
This is a trivial fix for an issue introduced in https://github.com/zephyrproject-rtos/zephyr/commit/6ea54db33489d10b873137d4239294225aa81fa6, which causes all `poll()` operation to take 10x more time than requested.

Tested experimentally on an STMicro B-L475E-IOT01A2C (`disco_l475_iot1`) board. The timeouts are correct after this fix.