### PR TITLE
dts: arm: stm32l5.dtsi: declare i2c2 peripheral

### DIFF
--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -334,6 +334,19 @@
 			label= "I2C_1";
 		};
 
+		i2c2: i2c@40005800 {
+			compatible = "st,stm32-i2c-v2";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			reg = <0x40005800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00400000>;
+			interrupts = <57 0>, <58 0>;
+			interrupt-names = "event", "error";
+			status = "disabled";
+			label = "I2C_2";
+		};
+
 		spi1: spi@40013000 {
 			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
 			#address-cells = <1>;


### PR DESCRIPTION
The peripheral i2c2 declaration was missing in dts/arm/st/l5/stm32l5.dtsi.

