### PR TITLE
drivers: dma_stm32: init DMA struct in dma_stm32_configure

### DIFF
--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -265,8 +265,10 @@ DMA_STM32_EXPORT_API int dma_stm32_configure(const struct device *dev,
 	struct dma_stm32_stream *stream =
 				&dev_config->streams[id - STREAM_OFFSET];
 	DMA_TypeDef *dma = (DMA_TypeDef *)dev_config->base;
-	LL_DMA_InitTypeDef DMA_InitStruct = {0};
+	LL_DMA_InitTypeDef DMA_InitStruct;
 	int ret;
+
+	LL_DMA_StructInit(&DMA_InitStruct);
 
 	/* give channel from index 0 */
 	id = id - STREAM_OFFSET;


### PR DESCRIPTION
The init struct for DMA peripheral is allocated in stack
and must be initialized (e.g. with LL_DMA_StructInit here)
to avoid loading undefined values in the DMA peripheral
registers.