### PR TITLE
drivers: spi: fix stm32 DMA channel numbering

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -73,10 +73,10 @@ static void dma_callback(const struct device *dev, void *arg,
 		data->status_flags |= SPI_STM32_DMA_ERROR_FLAG;
 	} else {
 		/* identify the origin of this callback */
-		if (channel == data->dma_tx.channel) {
+		if (channel + 1 == data->dma_tx.channel) {
 			/* this part of the transfer ends */
 			data->status_flags |= SPI_STM32_DMA_TX_DONE_FLAG;
-		} else if (channel == data->dma_rx.channel) {
+		} else if (channel + 1 == data->dma_rx.channel) {
 			/* this part of the transfer ends */
 			data->status_flags |= SPI_STM32_DMA_RX_DONE_FLAG;
 		} else {


### PR DESCRIPTION
In file spi_ll_stm32.c, function dma_callback(),
The DMA channel numbering was invalid (missing +1 offset).