### PR TITLE
Microchip ADC driver fix

### DIFF
--- a/drivers/adc/adc_mchp_xec.c
+++ b/drivers/adc/adc_mchp_xec.c
@@ -278,10 +278,17 @@ struct adc_driver_api adc_xec_api = {
 	.ref_internal = XEC_ADC_VREF_ANALOG,
 };
 
+/* ADC Config Register */
+#define XEC_ADC_CFG_CLK_VAL(clk_time)	(		\
+	(clk_time << MCHP_ADC_CFG_CLK_LO_TIME_POS) |	\
+	(clk_time << MCHP_ADC_CFG_CLK_HI_TIME_POS))
+
 static int adc_xec_init(const struct device *dev)
 {
 	struct adc_xec_regs *adc_regs = ADC_XEC_REG_BASE;
 	struct adc_xec_data *data = dev->data;
+
+	adc_regs->config_reg = XEC_ADC_CFG_CLK_VAL(DT_INST_PROP(0, clktime));
 
 	adc_regs->control_reg =  XEC_ADC_CTRL_ACTIVATE
 		| XEC_ADC_CTRL_POWER_SAVER_DIS

--- a/dts/arm/microchip/mec1501hsz.dtsi
+++ b/dts/arm/microchip/mec1501hsz.dtsi
@@ -400,6 +400,7 @@
 			label = "ADC_0";
 			status = "disabled";
 			#io-channel-cells = <1>;
+			clktime = <32>;
 		};
 		kscan0: kscan@40009c00 {
 			compatible = "microchip,xec-kscan";

--- a/dts/bindings/adc/microchip,xec-adc.yaml
+++ b/dts/bindings/adc/microchip,xec-adc.yaml
@@ -17,5 +17,10 @@ properties:
     "#io-channel-cells":
       const: 1
 
+    clktime:
+      type: int
+      required: true
+      description: ADC clock high & low time count value <1:255>
+
 io-channel-cells:
     - input


### PR DESCRIPTION
ADC readings with current microchip ADC driver aren't accurate. 
ADC configuration register need to be programmed with appropriate values for high & low clock time values. 