### PR TITLE
dts: arm: Fix warning on STM32L010XB boards

### DIFF
--- a/dts/arm/st/l0/stm32l010Xb.dtsi
+++ b/dts/arm/st/l0/stm32l010Xb.dtsi
@@ -31,7 +31,6 @@
 			pwm {
 				compatible = "st,stm32-pwm";
 				status = "disabled";
-				st,prescaler = <0>;
 				label = "PWM_22";
 				#pwm-cells = <3>;
 			};


### PR DESCRIPTION
When building for an STM32K010xB MCU, there is a deprecated properties warning, which should be fixed by this PR.

Signed-off-by: Wouter Cappelle <wouter.cappelle@crodeon.com>