### PR TITLE
twister: set serial option as required

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -683,7 +683,7 @@ class DeviceHandler(Handler):
         for d in self.suite.duts:
             if fixture and fixture not in d.fixtures:
                 continue
-            if d.platform != device or not (d.serial or d.serial_pty):
+            if d.platform != device:
                 continue
             d.lock.acquire()
             avail = False

--- a/scripts/schemas/twister/hwmap-schema.yaml
+++ b/scripts/schemas/twister/hwmap-schema.yaml
@@ -29,7 +29,7 @@ sequence:
         required: true
       "serial":
         type: str
-        required: false
+        required: true
       "baud":
         type: int
         required: false


### PR DESCRIPTION
Set serial option in hardware map as required - it is necessary to
connect with hardware device. If this is achived - it seems to no sense
to check in device_is_available function if serial or serial_pty is not
set (some of them have to be set previously).

This solution help to detect and rise error in situation when passed 
serial option is empty string.

Fixes: #41169

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>