### PR TITLE
Enable Power Management on RT1064 SOC

### DIFF
--- a/boards/arm/mimxrt1064_evk/doc/index.rst
+++ b/boards/arm/mimxrt1064_evk/doc/index.rst
@@ -297,6 +297,11 @@ Build and flash applications as usual (see :ref:`build_an_application` and
 Configuring a Debug Probe
 =========================
 
+.. note::
+	When the device transitions into low power states, the debugger may be
+	unable to access the chip. Use caution when enabling ``CONFIG_PM``, and
+	if the debugger cannot flash the part, see :ref:`Troubleshooting RT1064`
+
 A debug probe is used for both flashing and debugging the board. This board is
 configured by default to use the :ref:`opensda-daplink-onboard-debug-probe`,
 however the :ref:`pyocd-debug-host-tools` do not yet support programming the
@@ -369,6 +374,9 @@ should see the following message in the terminal:
 
    ***** Booting Zephyr OS v1.14.0-rc1 *****
    Hello World! mimxrt1064_evk
+
+
+.. _Troubleshooting RT1064:
 
 Troubleshooting
 ===============

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -100,6 +100,25 @@
 			};
 		};
 	};
+
+	power-states {
+		idle: idle {
+			compatible = "zephyr,power-state";
+			power-state-name = "runtime-idle";
+			exit-latency-us = <4000>;
+			min-residency-us = <5000>;
+		};
+		suspend: suspend {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-idle";
+			exit-latency-us = <5000>;
+			min-residency-us = <10000>;
+		};
+	};
+};
+
+&cpu0 {
+	cpu-power-states = <&idle &suspend>;
 };
 
 arduino_i2c: &lpi2c1 {};

--- a/drivers/timer/mcux_gpt_timer.c
+++ b/drivers/timer/mcux_gpt_timer.c
@@ -133,14 +133,11 @@ static uint32_t elapsed(void)
 /* Interrupt fires every time GPT timer reaches set value.
  * GPT timer will reset to 0x0.
  *
- * Note: we use a direct ISR for latency concerns.
  */
-ISR_DIRECT_DECLARE(mcux_imx_gpt_isr)
+void mcux_imx_gpt_isr(const void *arg)
 {
-	/* Note: we do not call PM hooks in this function,
-	 * GPT timer does not need PM
-	 */
-	ISR_DIRECT_HEADER();
+	ARG_UNUSED(arg);
+
 	/* Update the value of 'wrapped_cycles' */
 	elapsed();
 
@@ -167,8 +164,6 @@ ISR_DIRECT_DECLARE(mcux_imx_gpt_isr)
 	/* If system is tickful, interrupt will fire again at next tick */
 	sys_clock_announce(1);
 #endif
-	ISR_DIRECT_FOOTER(1);
-	return 1;
 }
 
 /* Next needed call to sys_clock_announce will not be until the specified number
@@ -318,8 +313,8 @@ int sys_clock_driver_init(const struct device *dev)
 
 	ARG_UNUSED(dev);
 	/* Configure ISR. Use instance 0 of the GPT timer */
-	IRQ_DIRECT_CONNECT(DT_IRQN(GPT_INST), DT_IRQ(GPT_INST, priority),
-		    mcux_imx_gpt_isr, 0);
+	IRQ_CONNECT(DT_IRQN(GPT_INST), DT_IRQ(GPT_INST, priority),
+		    mcux_imx_gpt_isr, NULL, 0);
 
 	base = (GPT_Type *)DT_REG_ADDR(GPT_INST);
 

--- a/dts/arm/nxp/nxp_rt.dtsi
+++ b/dts/arm/nxp/nxp_rt.dtsi
@@ -19,7 +19,7 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		cpu@0 {
+		cpu0: cpu@0 {
 			device_type = "cpu";
 			compatible = "arm,cortex-m7";
 			reg = <0>;

--- a/modules/Kconfig.mcux
+++ b/modules/Kconfig.mcux
@@ -141,6 +141,16 @@ config HAS_MCUX_GPC
 	help
 	  Set if the general power controller (GPC) module is present in the SoC.
 
+config HAS_MCUX_PMU
+	bool
+	help
+	  Set if the power management unit (PMU) module is present in the SoC.
+
+config HAS_MCUX_DCDC
+	bool
+	help
+	  Set if the DCDC converter module is present in the SoC.
+
 config HAS_MCUX_SNVS
 	bool
 	help

--- a/soc/arm/nxp_imx/rt/CMakeLists.txt
+++ b/soc/arm/nxp_imx/rt/CMakeLists.txt
@@ -28,7 +28,15 @@ endif()
 if (CONFIG_PM AND CONFIG_SOC_SERIES_IMX_RT10XX)
   zephyr_sources(power_rt10xx.c)
   zephyr_code_relocate(power_rt10xx.c ITCM_TEXT)
+  if (CONFIG_SOC_MIMXRT1064)
+    zephyr_sources(lpm_rt1064.c)
+    zephyr_code_relocate(lpm_rt1064.c ITCM_TEXT)
+  endif()
 endif()
+
+zephyr_compile_definitions(
+  XIP_EXTERNAL_FLASH
+)
 
 zephyr_linker_section_configure(
   SECTION .rom_start

--- a/soc/arm/nxp_imx/rt/CMakeLists.txt
+++ b/soc/arm/nxp_imx/rt/CMakeLists.txt
@@ -22,7 +22,12 @@ if(CONFIG_DEVICE_CONFIGURATION_DATA)
 endif()
 
 if(CONFIG_PM)
-zephyr_sources_ifdef(CONFIG_SOC_SERIES_IMX_RT11XX power_rt11xx.c)
+  zephyr_sources_ifdef(CONFIG_SOC_SERIES_IMX_RT11XX power_rt11xx.c)
+endif()
+
+if (CONFIG_PM AND CONFIG_SOC_SERIES_IMX_RT10XX)
+  zephyr_sources(power_rt10xx.c)
+  zephyr_code_relocate(power_rt10xx.c ITCM_TEXT)
 endif()
 
 zephyr_linker_section_configure(

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
@@ -104,6 +104,9 @@ config ZTEST_NO_YIELD
 
 if SOC_SERIES_IMX_RT10XX && PM
 
+config CODE_DATA_RELOCATION
+	default y
+
 config PM_MCUX_GPC
 	default y if HAS_MCUX_GPC
 

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
@@ -72,7 +72,6 @@ endif
 # set the tick per sec as a divider of the GPT clock source
 config SYS_CLOCK_TICKS_PER_SEC
 	default 4096 if MCUX_GPT_TIMER
-
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 32768 if MCUX_GPT_TIMER
 
@@ -98,6 +97,23 @@ config WDT_MCUX_IMX_WDOG
 config PM_MCUX_GPC
 	default y if HAS_MCUX_GPC
 	depends on SOC_SERIES_IMX_RT11XX && PM
+
+# Don't allow SOC to sleep after tests complete when PM is enabled
+config ZTEST_NO_YIELD
+	default y if (ZTEST && PM)
+
+if SOC_SERIES_IMX_RT10XX && PM
+
+config PM_MCUX_GPC
+	default y if HAS_MCUX_GPC
+
+config PM_MCUX_DCDC
+	default y if HAS_MCUX_DCDC
+
+config PM_MCUX_PMU
+	default y if HAS_MCUX_PMU
+
+endif # SOC_SERIES_IMX_RT10XX && PM
 
 if CODE_SEMC
 

--- a/soc/arm/nxp_imx/rt/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt/Kconfig.soc
@@ -27,6 +27,9 @@ config SOC_MIMXRT1011
 	select HAS_MCUX_USDHC1
 	select HAS_MCUX_USDHC2
 	select HAS_MCUX_EDMA
+	select HAS_MCUX_GPC
+	select HAS_MCUX_DCDC
+	select HAS_MCUX_PMU
 
 config SOC_MIMXRT1015
 	bool "SOC_MIMXRT1015"
@@ -49,6 +52,9 @@ config SOC_MIMXRT1015
 	select HAS_MCUX_USDHC1
 	select HAS_MCUX_USDHC2
 	select HAS_MCUX_EDMA
+	select HAS_MCUX_GPC
+	select HAS_MCUX_DCDC
+	select HAS_MCUX_PMU
 
 config SOC_MIMXRT1021
 	bool "SOC_MIMXRT1021"
@@ -75,6 +81,9 @@ config SOC_MIMXRT1021
 	select HAS_MCUX_EDMA
 	select HAS_MCUX_FLEXCAN
 	select HAS_MCUX_PWM
+	select HAS_MCUX_GPC
+	select HAS_MCUX_DCDC
+	select HAS_MCUX_PMU
 
 config SOC_MIMXRT1024
 	bool "SOC_MIMXRT1024"
@@ -101,6 +110,9 @@ config SOC_MIMXRT1024
 	select HAS_MCUX_EDMA
 	select HAS_MCUX_FLEXCAN
 	select HAS_MCUX_SRC
+	select HAS_MCUX_GPC
+	select HAS_MCUX_DCDC
+	select HAS_MCUX_PMU
 
 config SOC_MIMXRT1051
 	bool "SOC_MIMXRT1051"
@@ -127,6 +139,9 @@ config SOC_MIMXRT1051
 	select HAS_MCUX_CSI
 	select HAS_MCUX_EDMA
 	select HAS_MCUX_FLEXCAN
+	select HAS_MCUX_GPC
+	select HAS_MCUX_DCDC
+	select HAS_MCUX_PMU
 
 config SOC_MIMXRT1052
 	bool "SOC_MIMXRT1052"
@@ -157,6 +172,9 @@ config SOC_MIMXRT1052
 	select HAS_MCUX_EDMA
 	select HAS_MCUX_FLEXCAN
 	select HAS_MCUX_PWM
+	select HAS_MCUX_GPC
+	select HAS_MCUX_DCDC
+	select HAS_MCUX_PMU
 
 config SOC_MIMXRT1061
 	bool "SOC_MIMXRT1061"
@@ -183,6 +201,9 @@ config SOC_MIMXRT1061
 	select HAS_MCUX_CSI
 	select HAS_MCUX_EDMA
 	select HAS_MCUX_FLEXCAN
+	select HAS_MCUX_GPC
+	select HAS_MCUX_DCDC
+	select HAS_MCUX_PMU
 
 config SOC_MIMXRT1062
 	bool "SOC_MIMXRT1062"
@@ -214,6 +235,9 @@ config SOC_MIMXRT1062
 	select HAS_MCUX_EDMA
 	select HAS_MCUX_FLEXCAN
 	select HAS_MCUX_I2S
+	select HAS_MCUX_GPC
+	select HAS_MCUX_DCDC
+	select HAS_MCUX_PMU
 
 config SOC_MIMXRT1064
 	bool "SOC_MIMXRT1064"
@@ -246,6 +270,9 @@ config SOC_MIMXRT1064
 	select HAS_MCUX_CSI
 	select HAS_MCUX_EDMA
 	select HAS_MCUX_FLEXCAN
+	select HAS_MCUX_GPC
+	select HAS_MCUX_DCDC
+	select HAS_MCUX_PMU
 
 config SOC_MIMXRT1176_CM7
 	bool "SOC_MIMXRT1176_CM7"
@@ -586,6 +613,12 @@ config ADJUST_LDO
 
 config PM_MCUX_GPC
 	bool "MCUX general power controller driver"
+
+config PM_MCUX_DCDC
+	bool "MCUX dcdc converter module driver"
+
+config PM_MCUX_PMU
+	bool "MCUX power management unit driver"
 
 menuconfig NXP_IMX_RT_BOOT_HEADER
 	bool "Enable the boot header"

--- a/soc/arm/nxp_imx/rt/lpm_rt1064.c
+++ b/soc/arm/nxp_imx/rt/lpm_rt1064.c
@@ -1,0 +1,469 @@
+/*
+ * Copyright (c) 2021, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Note: this file is linked to RAM. Any functions called while changing clocks
+ * to the flexspi modules must be linked to RAM, or within this file
+ */
+
+#include <init.h>
+#include <power_rt10xx.h>
+#include <zephyr.h>
+#include "clock_config.h"
+
+
+/*
+ * Clock configuration structures populated at boot time. These structures are
+ * used to reinitialize the PLLs after exiting low power mode.
+ */
+#ifdef CONFIG_INIT_ARM_PLL
+static clock_arm_pll_config_t arm_pll_config;
+#endif
+#ifdef CONFIG_INIT_VIDEO_PLL
+static clock_video_pll_config_t video_pll_config;
+#endif
+#ifdef CONFIG_INIT_ENET_PLL
+static clock_enet_pll_config_t enet_pll_config;
+#endif
+static clock_sys_pll_config_t sys_pll_config;
+static clock_usb_pll_config_t usb1_pll_config;
+
+#define IMX_RT_SYS_PFD_FRAC(reg, pfd_num) \
+	(((reg) >> (8U * pfd_num)) &\
+	CCM_ANALOG_PFD_528_PFD0_FRAC_MASK)
+#define IMX_RT_USB1_PFD_FRAC(reg, pfd_num) \
+	(((reg) >> (8U * pfd_num)) &\
+	CCM_ANALOG_PFD_480_PFD0_FRAC_MASK)
+
+uint8_t sys_pll_pfd0_frac;
+uint8_t sys_pll_pfd1_frac;
+uint8_t sys_pll_pfd2_frac;
+uint8_t sys_pll_pfd3_frac;
+
+uint8_t usb1_pll_pfd1_frac;
+uint8_t usb1_pll_pfd2_frac;
+uint8_t usb1_pll_pfd3_frac;
+
+uint32_t flexspi_div;
+
+/*
+ * Duplicate implementation of CLOCK_SetMux() provided by SDK. This function
+ * must be linked to ITCM, as it will be used to change the clocks of the
+ * FLEXSPI and SEMC peripherals.
+ * Any function called from this function must also reside in ITCM
+ */
+static void clock_set_mux(clock_mux_t mux, uint32_t value)
+{
+	uint32_t busy_shift;
+
+	busy_shift = (uint32_t)CCM_TUPLE_BUSY_SHIFT(mux);
+	CCM_TUPLE_REG(CCM, mux) = (CCM_TUPLE_REG(CCM, mux) & (~CCM_TUPLE_MASK(mux))) |
+		  (((uint32_t)((value) << CCM_TUPLE_SHIFT(mux))) & CCM_TUPLE_MASK(mux));
+
+	/* Clock switch need Handshake? */
+	if (busy_shift != CCM_NO_BUSY_WAIT) {
+		/* Wait until CCM internal handshake finish. */
+		while ((CCM->CDHIPR & ((1UL << busy_shift))) != 0UL) {
+		}
+	}
+}
+
+/*
+ * Duplicate implementation of CLOCK_SetDiv() provided by SDK. This function
+ * must be linked to ITCM, as it will be used to change the clocks of the
+ * FLEXSPI and SEMC peripherals.
+ * Any function called from this function must also reside in ITCM
+ */
+static void clock_set_div(clock_div_t divider, uint32_t value)
+{
+	uint32_t busy_shift;
+
+	busy_shift = CCM_TUPLE_BUSY_SHIFT(divider);
+	CCM_TUPLE_REG(CCM, divider) = (CCM_TUPLE_REG(CCM, divider) & (~CCM_TUPLE_MASK(divider))) |
+		(((uint32_t)((value) << CCM_TUPLE_SHIFT(divider))) & CCM_TUPLE_MASK(divider));
+
+	/* Clock switch need Handshake? */
+	if (busy_shift != CCM_NO_BUSY_WAIT) {
+		/* Wait until CCM internal handshake finish. */
+		while ((CCM->CDHIPR & ((uint32_t)(1UL << busy_shift))) != 0UL) {
+		}
+	}
+}
+
+/*
+ * Duplicate implementation of CLOCK_InitUsb1Pll() provided by SDK. This function
+ * must be linked to ITCM, as it will be used to change the clocks of the
+ * FLEXSPI and SEMC peripherals.
+ * Any function called from this function must also reside in ITCM
+ */
+static void clock_init_usb1_pll(const clock_usb_pll_config_t *config)
+{
+	/* Bypass PLL first */
+	CCM_ANALOG->PLL_USB1 = (CCM_ANALOG->PLL_USB1 & (~CCM_ANALOG_PLL_USB1_BYPASS_CLK_SRC_MASK)) |
+		CCM_ANALOG_PLL_USB1_BYPASS_MASK | CCM_ANALOG_PLL_USB1_BYPASS_CLK_SRC(config->src);
+
+	CCM_ANALOG->PLL_USB1 = (CCM_ANALOG->PLL_USB1 & (~CCM_ANALOG_PLL_USB1_DIV_SELECT_MASK)) |
+		CCM_ANALOG_PLL_USB1_ENABLE_MASK | CCM_ANALOG_PLL_USB1_POWER_MASK |
+		CCM_ANALOG_PLL_USB1_EN_USB_CLKS_MASK |
+		CCM_ANALOG_PLL_USB1_DIV_SELECT(config->loopDivider);
+
+	while ((CCM_ANALOG->PLL_USB1 & CCM_ANALOG_PLL_USB1_LOCK_MASK) == 0UL) {
+		;
+	}
+
+	/* Disable Bypass */
+	CCM_ANALOG->PLL_USB1 &= ~CCM_ANALOG_PLL_USB1_BYPASS_MASK;
+}
+
+static void flexspi_enter_critical(void)
+{
+#if CONFIG_CODE_FLEXSPI2
+	/* Wait for flexspi to be inactive, and gate the clock */
+	while (!((FLEXSPI2->STS0 & FLEXSPI_STS0_ARBIDLE_MASK) &&
+			(FLEXSPI2->STS0 & FLEXSPI_STS0_SEQIDLE_MASK))) {
+	}
+	FLEXSPI2->MCR0 |= FLEXSPI_MCR0_MDIS_MASK;
+
+	/* Disable clock gate of flexspi2. */
+	CCM->CCGR7 &= (~CCM_CCGR7_CG1_MASK);
+#elif CONFIG_CODE_FLEXSPI
+	/* Wait for flexspi to be inactive, and gate the clock */
+	while (!((FLEXSPI->STS0 & FLEXSPI_STS0_ARBIDLE_MASK) &&
+			(FLEXSPI->STS0 & FLEXSPI_STS0_SEQIDLE_MASK))) {
+	}
+	FLEXSPI->MCR0 |= FLEXSPI_MCR0_MDIS_MASK;
+
+	/* Disable clock of flexspi. */
+	CCM->CCGR6 &= (~CCM_CCGR6_CG5_MASK);
+#endif
+}
+
+static void flexspi_exit_critical(void)
+{
+#if CONFIG_CODE_FLEXSPI2
+	/* Enable clock gate of flexspi2. */
+	CCM->CCGR7 |= (CCM_CCGR7_CG1_MASK);
+
+	FLEXSPI2->MCR0 &= ~FLEXSPI_MCR0_MDIS_MASK;
+	FLEXSPI2->MCR0 |= FLEXSPI_MCR0_SWRESET_MASK;
+	while (FLEXSPI2->MCR0 & FLEXSPI_MCR0_SWRESET_MASK) {
+	}
+	while (!((FLEXSPI2->STS0 & FLEXSPI_STS0_ARBIDLE_MASK) &&
+		(FLEXSPI2->STS0 & FLEXSPI_STS0_SEQIDLE_MASK))) {
+	}
+#elif CONFIG_CODE_FLEXSPI
+	/* Enable clock of flexspi. */
+	CCM->CCGR6 |= CCM_CCGR6_CG5_MASK;
+
+	FLEXSPI->MCR0 &= ~FLEXSPI_MCR0_MDIS_MASK;
+	FLEXSPI->MCR0 |= FLEXSPI_MCR0_SWRESET_MASK;
+	while (FLEXSPI->MCR0 & FLEXSPI_MCR0_SWRESET_MASK) {
+	}
+	while (!((FLEXSPI->STS0 & FLEXSPI_STS0_ARBIDLE_MASK) &&
+		(FLEXSPI->STS0 & FLEXSPI_STS0_SEQIDLE_MASK))) {
+	}
+#endif
+	/* Invalidate I-cache after flexspi clock changed. */
+	if (SCB_CCR_IC_Msk == (SCB_CCR_IC_Msk & SCB->CCR)) {
+		SCB_InvalidateICache();
+	}
+}
+
+
+void clock_full_power(void)
+{
+	/* Power up PLLS */
+	/* Set arm PLL div to divide by 2*/
+	clock_set_div(kCLOCK_ArmDiv, 1);
+#ifdef CONFIG_INIT_ARM_PLL
+	/* Reinit arm pll based on saved configuration */
+	CLOCK_InitArmPll(&arm_pll_config);
+#endif
+
+#ifdef CONFIG_INIT_VIDEO_PLL
+	/* Reinit video pll */
+	CLOCK_InitVideoPll(&video_pll_config);
+#endif
+
+#ifdef CONFIG_INIT_ENET_PLL
+	/* Reinit enet pll */
+	CLOCK_InitEnetPll(&enet_pll_config);
+#endif
+	/* Init SYS PLL */
+	CLOCK_InitSysPll(&sys_pll_config);
+
+	/* Enable USB PLL PFD 1 2 3 */
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd1, usb1_pll_pfd1_frac);
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd2, usb1_pll_pfd2_frac);
+	CLOCK_InitUsb1Pfd(kCLOCK_Pfd3, usb1_pll_pfd3_frac);
+
+	/* Enable SYS PLL PFD0 1 2 3 */
+	CLOCK_InitSysPfd(kCLOCK_Pfd0, sys_pll_pfd0_frac);
+	CLOCK_InitSysPfd(kCLOCK_Pfd1, sys_pll_pfd1_frac);
+	CLOCK_InitSysPfd(kCLOCK_Pfd2, sys_pll_pfd2_frac);
+	CLOCK_InitSysPfd(kCLOCK_Pfd3, sys_pll_pfd3_frac);
+
+	/* Switch to full speed clocks */
+#if (defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1))
+	flexspi_enter_critical();
+#endif
+
+	/* Set Flexspi divider before increasing frequency of PLL3 PDF0. */
+#if CONFIG_CODE_FLEXSPI
+	clock_set_div(kCLOCK_FlexspiDiv, flexspi_div);
+	clock_set_mux(kCLOCK_FlexspiMux, 3);
+#elif CONFIG_CODE_FLEXSPI2
+	clock_set_div(kCLOCK_Flexspi2Div, flexspi_div);
+	clock_set_mux(kCLOCK_Flexspi2Mux, 1);
+#endif
+	/* Init USB1 PLL. This will disable the PLL3 bypass. */
+	clock_init_usb1_pll(&usb1_pll_config);
+
+	/* Switch SEMC clock to PLL2_PFD2 clock */
+	clock_set_mux(kCLOCK_SemcMux, 1);
+
+	/* CORE CLK to 600MHz, AHB, IPG to 150MHz, PERCLK to 75MHz */
+	clock_set_div(kCLOCK_PerclkDiv, 1);
+	clock_set_div(kCLOCK_IpgDiv, 3);
+	clock_set_div(kCLOCK_AhbDiv, 0);
+	/* PERCLK mux to IPG CLK */
+	clock_set_mux(kCLOCK_PerclkMux, 0);
+	/* MUX to ENET_500M (RT1010-1024) / ARM_PODF (RT1050-1064) */
+	clock_set_mux(kCLOCK_PrePeriphMux, 3);
+	/* PERIPH mux to periph clock 2 output */
+	clock_set_mux(kCLOCK_PeriphMux, 0);
+
+#if (defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1))
+	flexspi_exit_critical();
+#endif
+
+}
+
+void clock_low_power(void)
+{
+#if (defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1))
+	flexspi_enter_critical();
+#endif
+	/* Switch to 24MHz core clock, so ARM PLL can power down */
+	clock_set_div(kCLOCK_PeriphClk2Div, 0);
+	/* Switch to OSC clock */
+	clock_set_mux(kCLOCK_PeriphClk2Mux, 1);
+	/* Switch peripheral mux to 24MHz source */
+	clock_set_mux(kCLOCK_PeriphMux, 1);
+	/* Set PLL3 to bypass mode, output 24M clock */
+	CCM_ANALOG->PLL_USB1_SET = CCM_ANALOG_PLL_USB1_BYPASS_MASK;
+	CCM_ANALOG->PLL_USB1_SET = CCM_ANALOG_PLL_USB1_ENABLE_MASK;
+	CCM_ANALOG->PFD_480_CLR = CCM_ANALOG_PFD_480_PFD0_CLKGATE_MASK;
+	/* Change flexspi to use PLL3 PFD0 with no divisor (24M flexspi clock) */
+#if CONFIG_CODE_FLEXSPI
+	clock_set_div(kCLOCK_FlexspiDiv, 0);
+	/* FLEXSPI1 mux to PLL3 PFD0 BYPASS */
+	clock_set_mux(kCLOCK_FlexspiMux, 3);
+#elif CONFIG_CODE_FLEXSPI2
+	clock_set_div(kCLOCK_Flexspi2Div, 0);
+	/* FLEXSPI2 mux to PLL3 PFD0 BYPASS */
+	clock_set_mux(kCLOCK_Flexspi2Mux, 1);
+#endif
+	/* CORE CLK to 24MHz and AHB, IPG, PERCLK to 12MHz */
+	clock_set_div(kCLOCK_PerclkDiv, 0);
+	clock_set_div(kCLOCK_IpgDiv, 1);
+	clock_set_div(kCLOCK_AhbDiv, 0);
+	/* PERCLK mux to IPG CLK */
+	clock_set_mux(kCLOCK_PerclkMux, 0);
+	/* Switch SEMC clock to peripheral clock */
+	clock_set_mux(kCLOCK_SemcMux, 0);
+#if (defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1))
+	flexspi_exit_critical();
+#endif
+	/* After switching clocks, it is safe to power down the PLLs */
+#ifdef CONFIG_INIT_ARM_PLL
+	/* Deinit ARM PLL */
+	CLOCK_DeinitArmPll();
+#endif
+	/* Deinit SYS PLL */
+	CLOCK_DeinitSysPll();
+
+	/* Deinit SYS PLL PFD 0 1 2 3 */
+	CLOCK_DeinitSysPfd(kCLOCK_Pfd0);
+	CLOCK_DeinitSysPfd(kCLOCK_Pfd1);
+	CLOCK_DeinitSysPfd(kCLOCK_Pfd2);
+	CLOCK_DeinitSysPfd(kCLOCK_Pfd3);
+
+
+	/* Deinit USB1 PLL PFD 1 2 3 */
+	CLOCK_DeinitUsb1Pfd(kCLOCK_Pfd1);
+	CLOCK_DeinitUsb1Pfd(kCLOCK_Pfd2);
+	CLOCK_DeinitUsb1Pfd(kCLOCK_Pfd3);
+
+	/* Deinit VIDEO PLL */
+	CLOCK_DeinitVideoPll();
+
+	/* Deinit ENET PLL */
+	CLOCK_DeinitEnetPll();
+}
+
+void clock_lpm_init(void)
+{
+	uint32_t tmp_reg = 0;
+
+	CLOCK_SetMode(kCLOCK_ModeRun);
+	/* Enable RC OSC. It needs at least 4ms to be stable, so self tuning need to be enabled. */
+	XTALOSC24M->LOWPWR_CTRL |= XTALOSC24M_LOWPWR_CTRL_RC_OSC_EN_MASK;
+	/* Configure RC OSC */
+	XTALOSC24M->OSC_CONFIG0 = XTALOSC24M_OSC_CONFIG0_RC_OSC_PROG_CUR(0x4) |
+					XTALOSC24M_OSC_CONFIG0_SET_HYST_MINUS(0x2) |
+					XTALOSC24M_OSC_CONFIG0_RC_OSC_PROG(0xA7) |
+					XTALOSC24M_OSC_CONFIG0_START_MASK |
+					XTALOSC24M_OSC_CONFIG0_ENABLE_MASK;
+	XTALOSC24M->OSC_CONFIG1 = XTALOSC24M_OSC_CONFIG1_COUNT_RC_CUR(0x40) |
+		XTALOSC24M_OSC_CONFIG1_COUNT_RC_TRG(0x2DC);
+	/* Take some delay */
+	SDK_DelayAtLeastUs(4000, SDK_DEVICE_MAXIMUM_CPU_CLOCK_FREQUENCY);
+	/* Add some hysteresis */
+	tmp_reg = XTALOSC24M->OSC_CONFIG0;
+	tmp_reg &= ~(XTALOSC24M_OSC_CONFIG0_HYST_PLUS_MASK |
+				XTALOSC24M_OSC_CONFIG0_HYST_MINUS_MASK);
+	tmp_reg |= XTALOSC24M_OSC_CONFIG0_HYST_PLUS(3) | XTALOSC24M_OSC_CONFIG0_HYST_MINUS(3);
+	XTALOSC24M->OSC_CONFIG0 = tmp_reg;
+	/* Set COUNT_1M_TRG */
+	tmp_reg = XTALOSC24M->OSC_CONFIG2;
+	tmp_reg &= ~XTALOSC24M_OSC_CONFIG2_COUNT_1M_TRG_MASK;
+	tmp_reg |= XTALOSC24M_OSC_CONFIG2_COUNT_1M_TRG(0x2d7);
+	XTALOSC24M->OSC_CONFIG2 = tmp_reg;
+	/* Hardware requires to read OSC_CONFIG0 or OSC_CONFIG1 to make OSC_CONFIG2 write work */
+	tmp_reg = XTALOSC24M->OSC_CONFIG1;
+	XTALOSC24M->OSC_CONFIG1 = tmp_reg;
+}
+
+static int imxrt_lpm_init(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	struct clock_callbacks callbacks;
+	uint32_t usb1_pll_pfd0_frac;
+
+	callbacks.clock_set_run = clock_full_power;
+	callbacks.clock_set_low_power = clock_low_power;
+	callbacks.clock_lpm_init = clock_lpm_init;
+
+	/*
+	 * Read the boot time configuration of all PLLs.
+	 * This is required because not all PLLs preserve register state
+	 * when powered down. Additionally, populating these configuration
+	 * structures enables the rest of the code to use the fsl_clock HAL api.
+	 */
+#ifdef CONFIG_INIT_ARM_PLL
+	/* Read configuration values for arm pll */
+	arm_pll_config.src = ((CCM_ANALOG->PLL_ARM &
+		CCM_ANALOG_PLL_ARM_BYPASS_CLK_SRC_MASK) >>
+		CCM_ANALOG_PLL_ARM_BYPASS_CLK_SRC_SHIFT);
+	arm_pll_config.loopDivider = ((CCM_ANALOG->PLL_ARM &
+		CCM_ANALOG_PLL_ARM_DIV_SELECT_MASK) >>
+		CCM_ANALOG_PLL_ARM_DIV_SELECT_SHIFT);
+#endif
+	/* Read configuration values for sys pll */
+	sys_pll_config.src = ((CCM_ANALOG->PLL_SYS &
+		CCM_ANALOG_PLL_SYS_BYPASS_CLK_SRC_MASK) >>
+		CCM_ANALOG_PLL_SYS_BYPASS_CLK_SRC_SHIFT);
+	sys_pll_config.loopDivider = ((CCM_ANALOG->PLL_SYS &
+		CCM_ANALOG_PLL_SYS_DIV_SELECT_MASK) >>
+		CCM_ANALOG_PLL_SYS_DIV_SELECT_SHIFT);
+	sys_pll_config.numerator = CCM_ANALOG->PLL_SYS_NUM;
+	sys_pll_config.denominator = CCM_ANALOG->PLL_SYS_DENOM;
+	sys_pll_config.ss_step = ((CCM_ANALOG->PLL_SYS_SS &
+			CCM_ANALOG_PLL_SYS_SS_STEP_MASK) >>
+			CCM_ANALOG_PLL_SYS_SS_STEP_SHIFT);
+	sys_pll_config.ss_enable = ((CCM_ANALOG->PLL_SYS_SS &
+			CCM_ANALOG_PLL_SYS_SS_ENABLE_MASK) >>
+			CCM_ANALOG_PLL_SYS_SS_ENABLE_SHIFT);
+	sys_pll_config.ss_stop = ((CCM_ANALOG->PLL_SYS_SS &
+			CCM_ANALOG_PLL_SYS_SS_STOP_MASK) >>
+			CCM_ANALOG_PLL_SYS_SS_STOP_SHIFT);
+
+	/* Read configuration values for usb1 pll */
+	usb1_pll_config.src = ((CCM_ANALOG->PLL_USB1 &
+		CCM_ANALOG_PLL_USB1_BYPASS_CLK_SRC_MASK) >>
+		CCM_ANALOG_PLL_USB1_BYPASS_CLK_SRC_SHIFT);
+	usb1_pll_config.loopDivider = ((CCM_ANALOG->PLL_USB1 &
+		CCM_ANALOG_PLL_USB1_DIV_SELECT_MASK) >>
+		CCM_ANALOG_PLL_USB1_DIV_SELECT_SHIFT);
+#ifdef CONFIG_INIT_VIDEO_PLL
+	/* Read configuration values for video pll */
+	video_pll_config.src = ((CCM_ANALOG->PLL_VIDEO &
+		CCM_ANALOG_PLL_VIDEO_BYPASS_CLK_SRC_MASK) >>
+		CCM_ANALOG_PLL_VIDEO_BYPASS_CLK_SRC_SHIFT);
+	video_pll_config.loopDivider = ((CCM_ANALOG->PLL_VIDEO &
+		CCM_ANALOG_PLL_VIDEO_DIV_SELECT_MASK) >>
+		CCM_ANALOG_PLL_VIDEO_DIV_SELECT_SHIFT);
+	video_pll_config.numerator = CCM_ANALOG->PLL_VIDEO_NUM
+	video_pll_config.denominator = CCM_ANALOG->PLL_VIDEO_DENOM;
+	switch ((CCM_ANALOG->PLL_VIDEO &
+		CCM_ANALOG_PLL_VIDEO_POST_DIV_SELECT_MASK) >>
+		CCM_ANALOG_PLL_VIDEO_POST_DIV_SELECT_SHIFT) {
+		case 0:
+			video_pll_config.postDivider = 16;
+			break;
+		case 1:
+			if (CCM_ANALOG->MISC2 & CCM_ANALOG_MISC2_VIDEO_DIV(3)) {
+				video_pll_config.postDivider = 8;
+			} else {
+				video_pll_config.postDivider = 2;
+			}
+			break;
+		case 2:
+			if (CCM_ANALOG->MISC2 & CCM_ANALOG_MISC2_VIDEO_DIV(3)) {
+				video_pll_config.postDivider = 4
+			} else {
+				video_pll_config.postDivider = 1;
+			}
+			break;
+		default:
+			video_pll_config.postDivider = 1;
+	}
+#endif
+#if CONFIG_INIT_ENET_PLL
+	enet_pll_config.src = ((CCM_ANALOG->PLL_ENET &
+		CCM_ANALOG_PLL_ENET_BYPASS_CLK_SRC_MASK) >>
+		CCM_ANALOG_PLL_ENET_BYPASS_CLK_SRC_SHIFT);
+	enet_pll_config.loopDivider = ((CCM_ANALOG->PLL_ENET &
+		CCM_ANALOG_PLL_ENET_DIV_SELECT_MASK) >>
+		CCM_ANALOG_PLL_ENET_DIV_SELECT_SHIFT);
+	enet_pll_config.loopDivider1 = ((CCM_ANALOG->PLL_ENET &
+		CCM_ANALOG_PLL_ENET_ENET2_DIV_SELECT_MASK) >>
+		CCM_ANALOG_PLL_ENET_ENET2_DIV_SELECT_SHIFT);
+	enet_pll_config.enableClkOutput = (CCM_ANALOG->PLL_ENET &
+		CCM_ANALOG_PLL_ENET_ENABLE_MASK);
+	enet_pll_config.enableClkOutput1 = (CCM_ANALOG->PLL_ENET &
+		CCM_ANALOG_PLL_ENET_ENET2_REF_EN_MASK);
+	enet_pll_config.enableClkOutput25M = (CCM_ANALOG->PLL_ENET &
+		CCM_ANALOG_PLL_ENET_ENET_25M_REF_EN_MASK);
+#endif
+
+	/* Record all pll PFD values that we intend to disable in low power mode */
+	sys_pll_pfd0_frac = IMX_RT_SYS_PFD_FRAC(CCM_ANALOG->PFD_528, kCLOCK_Pfd0);
+	sys_pll_pfd1_frac = IMX_RT_SYS_PFD_FRAC(CCM_ANALOG->PFD_528, kCLOCK_Pfd1);
+	sys_pll_pfd2_frac = IMX_RT_SYS_PFD_FRAC(CCM_ANALOG->PFD_528, kCLOCK_Pfd2);
+	sys_pll_pfd3_frac = IMX_RT_SYS_PFD_FRAC(CCM_ANALOG->PFD_528, kCLOCK_Pfd3);
+
+	usb1_pll_pfd0_frac = IMX_RT_USB1_PFD_FRAC(CCM_ANALOG->PFD_480, kCLOCK_Pfd0);
+	/* The target full power frequency for the flexspi clock is ~100MHz.
+	 * Use the PFD0 value currently set to calculate the div we should use for
+	 * the full power flexspi div
+	 * PFD output frequency formula = (480 * 18) / pfd0_frac
+	 * flexspi div formula = FLOOR((480*18) / (pfd0_frac * target_full_power_freq))
+	 */
+	flexspi_div = (480 * 18) / (usb1_pll_pfd0_frac * 100);
+
+
+	usb1_pll_pfd1_frac = IMX_RT_USB1_PFD_FRAC(CCM_ANALOG->PFD_480, kCLOCK_Pfd1);
+	usb1_pll_pfd2_frac = IMX_RT_USB1_PFD_FRAC(CCM_ANALOG->PFD_480, kCLOCK_Pfd2);
+	usb1_pll_pfd3_frac = IMX_RT_USB1_PFD_FRAC(CCM_ANALOG->PFD_480, kCLOCK_Pfd3);
+
+	/* Install LPM callbacks */
+	imxrt_clock_pm_callbacks_register(&callbacks);
+	return 0;
+}
+
+
+SYS_INIT(imxrt_lpm_init, PRE_KERNEL_1, 0);

--- a/soc/arm/nxp_imx/rt/power_rt10xx.c
+++ b/soc/arm/nxp_imx/rt/power_rt10xx.c
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2021 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Note: this file is linked to RAM. Any functions called while preparing for
+ * sleep mode must be defined within this file, or linked to RAM.
+ */
+#include <zephyr.h>
+#include <device.h>
+#include <pm/pm.h>
+#include <fsl_dcdc.h>
+#include <fsl_pmu.h>
+#include <fsl_gpc.h>
+#include <fsl_lpuart.h>
+#include <fsl_clock.h>
+#include <logging/log.h>
+
+#include "power_rt10xx.h"
+
+LOG_MODULE_REGISTER(soc_power, CONFIG_SOC_LOG_LEVEL);
+
+
+static struct clock_callbacks lpm_clock_hooks;
+
+/*
+ * Boards with RT10XX SOCs can register callbacks to set their clocks into
+ * normal/full speed mode, low speed mode, and low power mode.
+ * If callbacks are present, the low power subsystem will disable
+ * PLLs for power savings when entering low power states.
+ */
+void imxrt_clock_pm_callbacks_register(struct clock_callbacks *callbacks)
+{
+	/* If run callback is set, low power must be as well. */
+	__ASSERT_NO_MSG(callbacks && callbacks->clock_set_run && callbacks->clock_set_low_power);
+	lpm_clock_hooks.clock_set_run = callbacks->clock_set_run;
+	lpm_clock_hooks.clock_set_low_power = callbacks->clock_set_low_power;
+	if (callbacks->clock_lpm_init) {
+		lpm_clock_hooks.clock_lpm_init = callbacks->clock_lpm_init;
+	}
+}
+
+static void lpm_set_sleep_mode_config(clock_mode_t mode)
+{
+	uint32_t clpcr;
+
+	/* Set GPC wakeup config to GPT timer interrupt */
+	GPC_EnableIRQ(GPC, DT_IRQN(DT_INST(0, nxp_gpt_hw_timer)));
+	/*
+	 * ERR050143: CCM: When improper low-power sequence is used,
+	 * the SoC enters low power mode before the ARM core executes WFI.
+	 *
+	 * Software workaround:
+	 * 1) Software should trigger IRQ #41 (GPR_IRQ) to be always pending
+	 *      by setting IOMUXC_GPR_GPR1_GINT.
+	 * 2) Software should then unmask IRQ #41 in GPC before setting CCM
+	 *      Low-Power mode.
+	 * 3) Software should mask IRQ #41 right after CCM Low-Power mode
+	 *      is set (set bits 0-1 of CCM_CLPCR).
+	 */
+	GPC_EnableIRQ(GPC, GPR_IRQ_IRQn);
+	clpcr = CCM->CLPCR & (~(CCM_CLPCR_LPM_MASK | CCM_CLPCR_ARM_CLK_DIS_ON_LPM_MASK));
+	/* Note: if CCM_CLPCR_ARM_CLK_DIS_ON_LPM_MASK is set,
+	 * debugger will not connect in sleep mode
+	 */
+	/* Set clock control module to transfer system to idle mode */
+	clpcr |= CCM_CLPCR_LPM(mode) | CCM_CLPCR_MASK_SCU_IDLE_MASK |
+		     CCM_CLPCR_MASK_L2CC_IDLE_MASK |
+		     CCM_CLPCR_STBY_COUNT_MASK |
+		     CCM_CLPCR_ARM_CLK_DIS_ON_LPM_MASK;
+#ifndef CONFIG_SOC_MIMXRT1011
+	/* RT1011 does not include handshake bits */
+	clpcr |= CCM_CLPCR_BYPASS_LPM_HS0_MASK | CCM_CLPCR_BYPASS_LPM_HS1_MASK;
+#endif
+	CCM->CLPCR = clpcr;
+	GPC_DisableIRQ(GPC, GPR_IRQ_IRQn);
+}
+
+static void lpm_enter_sleep_mode(clock_mode_t mode)
+{
+	/* FIXME: When this function is entered the Kernel has disabled
+	 * interrupts using BASEPRI register. This is incorrect as it prevents
+	 * waking up from any interrupt which priority is not 0. Work around the
+	 * issue and disable interrupts using PRIMASK register as recommended
+	 * by ARM.
+	 */
+
+	/* Set PRIMASK */
+	__disable_irq();
+	/* Set BASEPRI to 0 */
+	irq_unlock(0);
+	__DSB();
+	__ISB();
+
+	if (mode == kCLOCK_ModeWait) {
+		/* Clear the SLEEPDEEP bit to go into sleep mode (WAIT) */
+		SCB->SCR &= ~SCB_SCR_SLEEPDEEP_Msk;
+	} else {
+		/* Set the SLEEPDEEP bit to enable deep sleep mode (STOP) */
+		SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+	}
+	/* WFI instruction will start entry into WAIT/STOP mode */
+	__WFI();
+
+}
+
+static void lpm_set_run_mode_config(void)
+{
+	/* Clear GPC wakeup source */
+	GPC_DisableIRQ(GPC, DT_IRQN(DT_INST(0, nxp_gpt_hw_timer)));
+	CCM->CLPCR &= ~(CCM_CLPCR_LPM_MASK | CCM_CLPCR_ARM_CLK_DIS_ON_LPM_MASK);
+}
+
+/* Toggle the analog bandgap reference circuitry on and off */
+static void bandgap_set(bool on)
+{
+	if (on) {
+		/* Enable bandgap in PMU */
+		PMU->MISC0_CLR = PMU_MISC0_REFTOP_PWD_MASK;
+		/* Wait for it to stabilize */
+		while ((PMU->MISC0 & PMU_MISC0_REFTOP_VBGUP_MASK) == 0) {
+
+		}
+		/* Disable low power bandgap */
+		XTALOSC24M->LOWPWR_CTRL_CLR = XTALOSC24M_LOWPWR_CTRL_LPBG_SEL_MASK;
+	} else {
+		/* Disable bandgap in PMU and switch to low power one */
+		XTALOSC24M->LOWPWR_CTRL_SET = XTALOSC24M_LOWPWR_CTRL_LPBG_SEL_MASK;
+		PMU->MISC0_SET = PMU_MISC0_REFTOP_PWD_MASK;
+	}
+}
+
+/* Should only be used if core clocks have been reduced- drops SOC voltage */
+static void lpm_drop_voltage(void)
+{
+	/* Move to the internal RC oscillator, since we are using low power clocks */
+	CLOCK_InitRcOsc24M();
+	/* Switch to internal RC oscillator */
+	CLOCK_SwitchOsc(kCLOCK_RcOsc);
+	CLOCK_DeinitExternalClk();
+	/*
+	 * Change to 1.075V SOC voltage. If you are experiencing issues with
+	 * low power mode stability, try raising this voltage value.
+	 */
+	DCDC_AdjustRunTargetVoltage(DCDC, 0xB);
+	/* Enable 2.5 and 1.1V weak regulators */
+	PMU_2P5EnableWeakRegulator(PMU, true);
+	PMU_1P1EnableWeakRegulator(PMU, true);
+	/* Disable normal regulators */
+	PMU_2P5EnableOutput(PMU, false);
+	PMU_1P1EnableOutput(PMU, false);
+	/* Disable analog bandgap */
+	bandgap_set(false);
+}
+
+/* Undo the changes made by lpm_drop_voltage so clocks can be raised */
+static void lpm_raise_voltage(void)
+{
+	/* Enable analog bandgap */
+	bandgap_set(true);
+	/* Enable regulator LDOs */
+	PMU_2P5EnableOutput(PMU, true);
+	PMU_1P1EnableOutput(PMU, true);
+	/* Disable weak LDOs */
+	PMU_2P5EnableWeakRegulator(PMU, false);
+	PMU_1P1EnableWeakRegulator(PMU, false);
+	/* Change to 1.275V SOC voltage */
+	DCDC_AdjustRunTargetVoltage(DCDC, 0x13);
+	/* Move to the external RC oscillator */
+	CLOCK_InitExternalClk(0);
+	/* Switch clock source to external OSC. */
+	CLOCK_SwitchOsc(kCLOCK_XtalOsc);
+}
+
+
+/* Sets device into low power mode */
+__weak void pm_power_state_set(struct pm_state_info info)
+{
+	switch (info.state) {
+	case PM_STATE_RUNTIME_IDLE:
+		LOG_DBG("entering PM state runtime idle");
+		lpm_set_sleep_mode_config(kCLOCK_ModeWait);
+		lpm_enter_sleep_mode(kCLOCK_ModeWait);
+		break;
+	case PM_STATE_SUSPEND_TO_IDLE:
+		LOG_DBG("entering PM state suspend to idle");
+		if (lpm_clock_hooks.clock_set_low_power) {
+			/* Drop the SOC clocks to low power mode, and decrease core voltage */
+			lpm_clock_hooks.clock_set_low_power();
+			lpm_drop_voltage();
+		}
+		lpm_set_sleep_mode_config(kCLOCK_ModeWait);
+		lpm_enter_sleep_mode(kCLOCK_ModeWait);
+		break;
+	default:
+		return;
+	}
+}
+
+/* Handle SOC specific activity after Low Power Mode Exit */
+__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
+{
+	/* Set run mode config after wakeup */
+	switch (info.state) {
+	case PM_STATE_RUNTIME_IDLE:
+		lpm_set_run_mode_config();
+		LOG_DBG("exited PM state runtime idle");
+		break;
+	case PM_STATE_SUSPEND_TO_IDLE:
+		lpm_set_run_mode_config();
+		if (lpm_clock_hooks.clock_set_run) {
+			/* Raise core voltage and restore SOC clocks */
+			lpm_raise_voltage();
+			lpm_clock_hooks.clock_set_run();
+		}
+		LOG_DBG("exited PM state suspend to idle");
+		break;
+	default:
+		break;
+	}
+	/* Clear PRIMASK after wakeup */
+	__enable_irq();
+}
+
+/* Initialize power system */
+static int rt10xx_power_init(const struct device *dev)
+{
+	dcdc_internal_regulator_config_t reg_config;
+
+	ARG_UNUSED(dev);
+
+	/* Ensure clocks to ARM core memory will not be gated in low power mode
+	 * if interrupt is pending
+	 */
+	CCM->CGPR |= CCM_CGPR_INT_MEM_CLK_LPM_MASK;
+
+	if (lpm_clock_hooks.clock_lpm_init) {
+		lpm_clock_hooks.clock_lpm_init();
+	}
+
+	/* Errata ERR050143 */
+	IOMUXC_GPR->GPR1 |= IOMUXC_GPR_GPR1_GINT_MASK;
+
+	/* Configure DCDC */
+	DCDC_BootIntoDCM(DCDC);
+	/* Set target voltage for low power mode to 0.925V*/
+	DCDC_AdjustLowPowerTargetVoltage(DCDC, 0x1);
+	/* Reconfigure DCDC to disable internal load resistor */
+	reg_config.enableLoadResistor = false;
+	reg_config.feedbackPoint = 0x1; /* 1.0V with 1.3V reference voltage */
+	DCDC_SetInternalRegulatorConfig(DCDC, &reg_config);
+
+	/* Enable high gate drive on power FETs to reduce leakage current */
+	PMU_CoreEnableIncreaseGateDrive(PMU, true);
+
+
+	return 0;
+}
+
+SYS_INIT(rt10xx_power_init, PRE_KERNEL_2, 0);

--- a/soc/arm/nxp_imx/rt/power_rt10xx.h
+++ b/soc/arm/nxp_imx/rt/power_rt10xx.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _SOC_ARM_NXP_IMX_RT_POWER_RT10XX_H_
+#define _SOC_ARM_NXP_IMX_RT_POWER_RT10XX_H_
+
+struct clock_callbacks {
+	/*
+	 * The clock_set_run function should switch all clocks to their
+	 * default running configuration, and power up required PLLs
+	 * The system will be transitioning out of sleep when calling this function.
+	 */
+	void (*clock_set_run)(void);
+	 /*
+	  * The clock_set_low_power function should switch all clocks to
+	  * the lowest power mode possible, and disable all possible PLLs.
+	  * Note that the function should, at minimum, switch the arm core to the
+	  * 24 MHz oscillator.
+	  * The system will transition to sleep after calling this function.
+	  */
+	void (*clock_set_low_power)(void);
+	/*
+	 * The clock_init function should perform any one time initialization that
+	 * clocks used in low power mode require.
+	 */
+	void (*clock_lpm_init)(void);
+};
+
+void imxrt_clock_pm_callbacks_register(struct clock_callbacks *callbacks);
+
+#endif /* _SOC_ARM_NXP_IMX_RT_POWER_RT10XX_H_ */

--- a/soc/arm/nxp_imx/rt5xx/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt5xx/Kconfig.defconfig.series
@@ -14,6 +14,9 @@ config ROM_START_OFFSET
 config NUM_IRQS
 	default 74
 
+config ZTEST_NO_YIELD
+	default y if (PM && ZTEST)
+
 #
 # The base address of the external flash comes from the FLEXSPI base
 # address. The size of the flash is defined by what is populated and

--- a/soc/arm/nxp_imx/rt6xx/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt6xx/Kconfig.defconfig.series
@@ -17,6 +17,9 @@ config NUM_IRQS
 config PM
 	select CODE_DATA_RELOCATION_SRAM
 
+config ZTEST_NO_YIELD
+	default y if (ZTEST && PM)
+
 #
 # The base address of the external flash comes from the FLEXSPI base
 # address. The size of the flash is defined by what is populated and

--- a/subsys/testsuite/ztest/Kconfig
+++ b/subsys/testsuite/ztest/Kconfig
@@ -79,6 +79,14 @@ config ZTEST_ASSERT_HOOK
 	  error test case. Remember to add ignore_fault tag in yaml file when
 	  using twister to run testing.
 
+config ZTEST_NO_YIELD
+	bool "Do not yield to the idle thread after tests complete"
+	help
+	  When the tests complete, do not yield to the idle thread and instead
+	  spin in a loop. This is useful for low power mode tests, where
+	  yielding to the idle thread may put the board into a low power state
+	  where a debugger cannot connect to it.
+
 if ZTEST_NEW_API
 
 menu "ztest provided rules"

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -562,5 +562,17 @@ void main(void)
 			state.boots = 0;
 		}
 	}
+#ifdef CONFIG_ZTEST_NO_YIELD
+	/*
+	 * Rather than yielding to idle thread, keep the part awake so debugger can
+	 * still access it, since some SOCs cannot be debugged in low power states.
+	 */
+	uint32_t key = irq_lock();
+
+	while (1) {
+		; /* Spin */
+	}
+	irq_unlock(key);
+#endif
 }
 #endif


### PR DESCRIPTION
This PR enables power management for the RT1064 SOC. The SOC level power management hooks will handle placing the core into WAIT mode, as well as reducing core voltage. The RT1064 EVK board folder contains `lpm.c`, which provides board specific hooks to reduce clock frequencies and disable PLLs, which is required to ensure that the core voltage can be reduced without issues.