### PR TITLE
drivers: pwm: add GD32 PWM driver

### DIFF
--- a/boards/arm/gd32f403z_eval/doc/index.rst
+++ b/boards/arm/gd32f403z_eval/doc/index.rst
@@ -66,6 +66,8 @@ The board configuration supports the following hardware features:
 | NVIC      | on-chip    | nested vectored       |
 |           |            | interrupt controller  |
 +-----------+------------+-----------------------+
+| PWM       | on-chip    | PWM                   |
++-----------+------------+-----------------------+
 | SYSTICK   | on-chip    | system clock          |
 +-----------+------------+-----------------------+
 | UART      | on-chip    | serial port-polling   |

--- a/boards/arm/gd32f403z_eval/gd32f403z_eval-pinctrl.dtsi
+++ b/boards/arm/gd32f403z_eval/gd32f403z_eval-pinctrl.dtsi
@@ -11,4 +11,10 @@
 			pinmux = <USART0_TX_PA9_NORMP>, <USART0_RX_PA10_NORMP>;
 		};
 	};
+
+	pwm0_default: pwm0_default {
+		group1 {
+			pinmux = <TIMER0_CH0_PA8_OUT_NORMP>;
+		};
+	};
 };

--- a/boards/arm/gd32f403z_eval/gd32f403z_eval.dts
+++ b/boards/arm/gd32f403z_eval/gd32f403z_eval.dts
@@ -59,10 +59,20 @@
 		};
 	};
 
+	pwmleds {
+		compatible = "pwm-leds";
+
+		/* NOTE: bridge TIMER0_CH0 (PA8) and LED2 (PF0) */
+		pwm_led: pwm_led {
+			pwms = <&pwm0 0 PWM_POLARITY_NORMAL>;
+		};
+	};
+
 	aliases {
 		led0 = &led2;
 		led1 = &led3;
 		sw0 = &user_key1;
+		pwm-led0 = &pwm_led;
 	};
 };
 
@@ -83,4 +93,15 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart0_default>;
 	pinctrl-names = "default";
+};
+
+&timer0 {
+	status = "okay";
+	prescaler = <256>;
+
+	pwm0: pwm {
+		status = "okay";
+		pinctrl-0 = <&pwm0_default>;
+		pinctrl-names = "default";
+	};
 };

--- a/boards/arm/gd32f403z_eval/gd32f403z_eval.yaml
+++ b/boards/arm/gd32f403z_eval/gd32f403z_eval.yaml
@@ -11,3 +11,5 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
+supported:
+  - pwm

--- a/boards/arm/gd32f450i_eval/doc/index.rst
+++ b/boards/arm/gd32f450i_eval/doc/index.rst
@@ -68,6 +68,9 @@ The board configuration supports the following hardware features:
    * - NVIC
      - N/A
      - :dtcompatible:`arm,v7m-nvic`
+   * - PWM
+     - :kconfig:`CONFIG_PWM`
+     - :dtcompatible:`gd,gd32-pwm`
    * - SYSTICK
      - N/A
      - N/A

--- a/boards/arm/gd32f450i_eval/gd32f450i_eval-pinctrl.dtsi
+++ b/boards/arm/gd32f450i_eval/gd32f450i_eval-pinctrl.dtsi
@@ -17,4 +17,10 @@
 			pinmux = <DAC_OUT0_PA4>;
 		};
 	};
+
+	pwm1_default: pwm1_default {
+		group1 {
+			pinmux = <TIMER1_CH2_PB10>;
+		};
+	};
 };

--- a/boards/arm/gd32f450i_eval/gd32f450i_eval.dts
+++ b/boards/arm/gd32f450i_eval/gd32f450i_eval.dts
@@ -51,10 +51,20 @@
 		};
 	};
 
+	pwmleds {
+		compatible = "pwm-leds";
+
+		/* NOTE: bridge TIMER1_CH2 (PB10) and LED1 (PE2) */
+		pwm_led: pwm_led {
+			pwms = <&pwm1 2 PWM_POLARITY_NORMAL>;
+		};
+	};
+
 	aliases {
 		led0 = &led1;
 		led1 = &led2;
 		sw0 = &user_key;
+		pwm-led0 = &pwm_led;
 	};
 };
 
@@ -89,4 +99,14 @@
 	status = "okay";
 	pinctrl-0 = <&dac_default>;
 	pinctrl-names = "default";
+};
+
+&timer1 {
+	status = "okay";
+
+	pwm1: pwm {
+		status = "okay";
+		pinctrl-0 = <&pwm1_default>;
+		pinctrl-names = "default";
+	};
 };

--- a/boards/arm/gd32f450i_eval/gd32f450i_eval.yaml
+++ b/boards/arm/gd32f450i_eval/gd32f450i_eval.yaml
@@ -11,3 +11,5 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
+supported:
+  - pwm

--- a/drivers/pwm/CMakeLists.txt
+++ b/drivers/pwm/CMakeLists.txt
@@ -23,6 +23,7 @@ zephyr_library_sources_ifdef(CONFIG_PWM_NPCX		pwm_npcx.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_XLNX_AXI_TIMER	pwm_xlnx_axi_timer.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_MCUX_PWT 	pwm_mcux_pwt.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_GECKO   pwm_gecko.c)
+zephyr_library_sources_ifdef(CONFIG_PWM_GD32 pwm_gd32.c)
 
 zephyr_library_sources_ifdef(CONFIG_USERSPACE   pwm_handlers.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_CAPTURE pwm_capture.c)

--- a/drivers/pwm/Kconfig
+++ b/drivers/pwm/Kconfig
@@ -69,4 +69,6 @@ source "drivers/pwm/Kconfig.mcux_pwt"
 
 source "drivers/pwm/Kconfig.gecko"
 
+source "drivers/pwm/Kconfig.gd32"
+
 endif # PWM

--- a/drivers/pwm/Kconfig.gd32
+++ b/drivers/pwm/Kconfig.gd32
@@ -1,0 +1,11 @@
+# Copyright (c) 2021 Teslabs Engineering S.L.
+# SPDX-License-Identifier: Apache-2.0
+
+DT_COMPAT_GD_GD32_PWM := gd,gd32-pwm
+
+config PWM_GD32
+	bool "GigaDevice GD32 PWM driver"
+	depends on SOC_FAMILY_GD32
+	default $(dt_compat_enabled,$(DT_COMPAT_GD_GD32_PWM))
+	help
+	  Enable the GigaDevice GD32 PWM driver.

--- a/drivers/pwm/pwm_gd32.c
+++ b/drivers/pwm/pwm_gd32.c
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) 2021 Teslabs Engineering S.L.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT gd_gd32_pwm
+
+#include <errno.h>
+
+#include <drivers/pwm.h>
+#include <drivers/pinctrl.h>
+#include <soc.h>
+#include <sys/util_macro.h>
+
+#include <logging/log.h>
+LOG_MODULE_REGISTER(pwm_gd32, CONFIG_PWM_LOG_LEVEL);
+
+/** PWM data. */
+struct pwm_gd32_data {
+	/** Timer clock (Hz). */
+	uint32_t tim_clk;
+};
+
+/** PWM configuration. */
+struct pwm_gd32_config {
+	/** Timer register. */
+	uint32_t reg;
+	/** Number of channels */
+	uint8_t channels;
+	/** Flag to indicate if timer has 32-bit counter */
+	bool is_32bit;
+	/** Flag to indicate if timer is advanced */
+	bool is_advanced;
+	/** Prescaler. */
+	uint16_t prescaler;
+	/** RCU peripheral clock. */
+	uint32_t rcu_periph_clock;
+	/** RCU peripheral reset. */
+	uint32_t rcu_periph_reset;
+	/** pinctrl configurations. */
+	const struct pinctrl_dev_config *pcfg;
+};
+
+/** Obtain channel enable bit for the given channel */
+#define TIMER_CHCTL2_CHXEN(ch) BIT(4U * (ch))
+/** Obtain polarity bit for the given channel */
+#define TIMER_CHCTL2_CHXP(ch) BIT(1U + (4U * (ch)))
+/** Obtain CHCTL0/1 mask for the given channel (0 or 1) */
+#define TIMER_CHCTLX_MSK(ch) (0xFU << (8U * (ch)))
+
+/** Obtain RCU register offset from RCU clock value */
+#define RCU_CLOCK_OFFSET(rcu_clock) ((rcu_clock) >> 6U)
+
+/**
+ * Obtain the timer clock.
+ *
+ * @param dev Device instance.
+ *
+ * @return Timer clock (Hz).
+ */
+static uint32_t pwm_gd32_get_tim_clk(const struct device *dev)
+{
+	const struct pwm_gd32_config *config = dev->config;
+	uint32_t apb_psc, apb_clk;
+
+	/* obtain APB prescaler value */
+	if (RCU_CLOCK_OFFSET(config->rcu_periph_clock) == APB1EN_REG_OFFSET) {
+		apb_psc = RCU_CFG0 & RCU_CFG0_APB1PSC;
+	} else {
+		apb_psc = RCU_CFG0 & RCU_CFG0_APB2PSC;
+	}
+
+	switch (apb_psc) {
+	case RCU_APB1_CKAHB_DIV2:
+		apb_psc = 2U;
+		break;
+	case RCU_APB1_CKAHB_DIV4:
+		apb_psc = 4U;
+		break;
+	case RCU_APB1_CKAHB_DIV8:
+		apb_psc = 8U;
+		break;
+	case RCU_APB1_CKAHB_DIV16:
+		apb_psc = 16U;
+		break;
+	default:
+		apb_psc = 1U;
+		break;
+	}
+
+	apb_clk = CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC / apb_psc;
+
+#ifdef RCU_CFG1_TIMERSEL
+	/*
+	 * The TIMERSEL bit in RCU_CFG1 controls the clock frequency of all the
+	 * timers connected to the APB1 and APB2 domains.
+	 *
+	 * Up to a certain threshold value of APB{1,2} prescaler, timer clock
+	 * equals to CK_AHB. This threshold value depends on TIMERSEL setting
+	 * (2 if TIMERSEL=0, 4 if TIMERSEL=1). Above threshold, timer clock is
+	 * set to a multiple of the APB domain clock CK_APB{1,2} (2 if
+	 * TIMERSEL=0, 4 if TIMERSEL=1).
+	 */
+
+	/* TIMERSEL = 0 */
+	if ((RCU_CFG1 & RCU_CFG1_TIMERSEL) == 0U) {
+		if (apb_psc <= 2U) {
+			return CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC;
+		}
+
+		return apb_clk * 2U;
+	}
+
+	/* TIMERSEL = 1 */
+	if (apb_psc <= 4U) {
+		return CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC;
+	}
+
+	return apb_clk * 4U;
+#else
+	/*
+	 * If the APB prescaler equals 1, the timer clock frequencies are set to
+	 * the same frequency as that of the APB domain. Otherwise, they are set
+	 * to twice the frequency of the APB domain.
+	 */
+	if (apb_psc == 1U) {
+		return apb_clk;
+	}
+
+	return apb_clk * 2U;
+#endif /* RCU_CFG1_TIMERSEL */
+}
+
+static int pwm_gd32_pin_set(const struct device *dev, uint32_t pwm,
+			    uint32_t period_cycles, uint32_t pulse_cycles,
+			    pwm_flags_t flags)
+{
+	const struct pwm_gd32_config *config = dev->config;
+
+	if (pwm >= config->channels) {
+		return -EINVAL;
+	}
+
+	if (pulse_cycles > period_cycles) {
+		return -EINVAL;
+	}
+
+	/* 16-bit timers can count up to UINT16_MAX */
+	if (!config->is_32bit && (period_cycles > UINT16_MAX)) {
+		return -ENOTSUP;
+	}
+
+	/* disable channel output if period is zero */
+	if (period_cycles == 0U) {
+		TIMER_CHCTL2(config->reg) &= ~TIMER_CHCTL2_CHXEN(pwm);
+		return 0;
+	}
+
+	/* update polarity */
+	if ((flags & PWM_POLARITY_INVERTED) != 0U) {
+		TIMER_CHCTL2(config->reg) |= TIMER_CHCTL2_CHXP(pwm);
+	} else {
+		TIMER_CHCTL2(config->reg) &= ~TIMER_CHCTL2_CHXP(pwm);
+	}
+
+	/* update pulse */
+	switch (pwm) {
+	case 0U:
+		TIMER_CH0CV(config->reg) = pulse_cycles;
+		break;
+	case 1U:
+		TIMER_CH1CV(config->reg) = pulse_cycles;
+		break;
+	case 2U:
+		TIMER_CH2CV(config->reg) = pulse_cycles;
+		break;
+	case 3U:
+		TIMER_CH3CV(config->reg) = pulse_cycles;
+		break;
+	default:
+		__ASSERT_NO_MSG(NULL);
+		break;
+	}
+
+	/* update period */
+	TIMER_CAR(config->reg) = period_cycles;
+
+	/* channel not enabled: configure it */
+	if ((TIMER_CHCTL2(config->reg) & TIMER_CHCTL2_CHXEN(pwm)) == 0U) {
+		volatile uint32_t *chctl;
+
+		/* select PWM1 mode, enable OC shadowing */
+		if (pwm < 2U) {
+			chctl = &TIMER_CHCTL0(config->reg);
+		} else {
+			chctl = &TIMER_CHCTL1(config->reg);
+		}
+
+		*chctl &= ~TIMER_CHCTLX_MSK(pwm);
+		*chctl |= (TIMER_OC_MODE_PWM1 | TIMER_OC_SHADOW_ENABLE) <<
+			  (8U * (pwm % 2U));
+
+		/* enable channel output */
+		TIMER_CHCTL2(config->reg) |= TIMER_CHCTL2_CHXEN(pwm);
+
+		/* generate update event (to load shadow values) */
+		TIMER_SWEVG(config->reg) |= TIMER_SWEVG_UPG;
+	}
+
+	return 0;
+}
+
+static int pwm_gd32_get_cycles_per_sec(const struct device *dev, uint32_t pwm,
+				       uint64_t *cycles)
+{
+	struct pwm_gd32_data *data = dev->data;
+	const struct pwm_gd32_config *config = dev->config;
+
+	*cycles = (uint64_t)(data->tim_clk / (config->prescaler + 1U));
+
+	return 0;
+}
+
+static const struct pwm_driver_api pwm_gd32_driver_api = {
+	.pin_set = pwm_gd32_pin_set,
+	.get_cycles_per_sec = pwm_gd32_get_cycles_per_sec,
+};
+
+static int pwm_gd32_init(const struct device *dev)
+{
+	const struct pwm_gd32_config *config = dev->config;
+	struct pwm_gd32_data *data = dev->data;
+	int ret;
+
+	rcu_periph_clock_enable(config->rcu_periph_clock);
+
+	/* reset timer to its default state */
+	rcu_periph_reset_enable(config->rcu_periph_reset);
+	rcu_periph_reset_disable(config->rcu_periph_reset);
+
+	/* apply pin configuration */
+	ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* cache timer clock value */
+	data->tim_clk = pwm_gd32_get_tim_clk(dev);
+
+	/* basic timer operation: edge aligned, up counting, shadowed CAR */
+	TIMER_CTL0(config->reg) = TIMER_CKDIV_DIV1 | TIMER_COUNTER_EDGE |
+				  TIMER_COUNTER_UP | TIMER_CTL0_ARSE;
+	TIMER_PSC(config->reg) = config->prescaler;
+
+	/* enable primary output for advanced timers */
+	if (config->is_advanced) {
+		TIMER_CCHP(config->reg) |= TIMER_CCHP_POEN;
+	}
+
+	/* enable timer counter */
+	TIMER_CTL0(config->reg) |= TIMER_CTL0_CEN;
+
+	return 0;
+}
+
+#define PWM_GD32_DEFINE(i)						       \
+	static struct pwm_gd32_data pwm_gd32_data_##i;			       \
+									       \
+	PINCTRL_DT_INST_DEFINE(i);					       \
+									       \
+	static const struct pwm_gd32_config pwm_gd32_config_##i = {	       \
+		.reg = DT_REG_ADDR(DT_INST_PARENT(i)),			       \
+		.rcu_periph_clock = DT_PROP(DT_INST_PARENT(i),		       \
+					    rcu_periph_clock),		       \
+		.rcu_periph_reset = DT_PROP(DT_INST_PARENT(i),		       \
+					    rcu_periph_reset),		       \
+		.prescaler = DT_PROP(DT_INST_PARENT(i), prescaler),	       \
+		.channels = DT_PROP(DT_INST_PARENT(i), channels),	       \
+		.is_32bit = DT_PROP(DT_INST_PARENT(i), is_32bit),	       \
+		.is_advanced = DT_PROP(DT_INST_PARENT(i), is_advanced),	       \
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(i),		       \
+	};								       \
+									       \
+	DEVICE_DT_INST_DEFINE(i, &pwm_gd32_init, NULL, &pwm_gd32_data_##i,     \
+			      &pwm_gd32_config_##i, POST_KERNEL,	       \
+			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	       \
+			      &pwm_gd32_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(PWM_GD32_DEFINE)

--- a/dts/arm/gigadevice/gd32f403/gd32f403.dtsi
+++ b/dts/arm/gigadevice/gd32f403/gd32f403.dtsi
@@ -1,11 +1,14 @@
 /*
  * Copyright (c) 2021, ATL Electronics
+ * Copyright (c) 2021, Teslabs Engineering S.L.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <arm/armv7-m.dtsi>
 #include <dt-bindings/gpio/gpio.h>
+
+#include <dt-bindings/pwm/pwm.h>
 
 / {
 	cpus {
@@ -194,6 +197,221 @@
 			};
 		};
 
+		timer0: timer@40012c00 {
+			compatible = "gd,gd32-timer";
+			reg = <0x40012c00 0x400>;
+			interrupts = <24 0>, <25 0>, <26 0>, <27 0>;
+			interrupt-names = "brk", "up", "trgcom", "cc";
+			rcu-periph-clock = <0x60b>;
+			rcu-periph-reset = <0x30b>;
+			is-advanced;
+			channels = <4>;
+			status = "disabled";
+			label = "TIMER_0";
+
+			pwm {
+				compatible = "gd,gd32-pwm";
+				status = "disabled";
+				label = "PWM_0";
+				#pwm-cells = <2>;
+			};
+		};
+
+		timer2: timer@40000400 {
+			compatible = "gd,gd32-timer";
+			reg = <0x40000400 0x400>;
+			interrupts = <29 0>;
+			interrupt-names = "global";
+			rcu-periph-clock = <0x701>;
+			rcu-periph-reset = <0x401>;
+			channels = <4>;
+			status = "disabled";
+			label = "TIMER_2";
+
+			pwm {
+				compatible = "gd,gd32-pwm";
+				status = "disabled";
+				label = "PWM_2";
+				#pwm-cells = <2>;
+			};
+		};
+
+		timer3: timer@40000800 {
+			compatible = "gd,gd32-timer";
+			reg = <0x40000800 0x400>;
+			interrupts = <30 0>;
+			interrupt-names = "global";
+			rcu-periph-clock = <0x702>;
+			rcu-periph-reset = <0x402>;
+			channels = <4>;
+			status = "disabled";
+			label = "TIMER_3";
+
+			pwm {
+				compatible = "gd,gd32-pwm";
+				status = "disabled";
+				label = "PWM_3";
+				#pwm-cells = <2>;
+			};
+		};
+
+		timer5: timer@40001000 {
+			compatible = "gd,gd32-timer";
+			reg = <0x40001000 0x400>;
+			interrupts = <54 0>;
+			interrupt-names = "global";
+			rcu-periph-clock = <0x704>;
+			rcu-periph-reset = <0x404>;
+			channels = <0>;
+			status = "disabled";
+			label = "TIMER_5";
+		};
+
+		timer6: timer@40001400 {
+			compatible = "gd,gd32-timer";
+			reg = <0x40001400 0x400>;
+			interrupts = <55 0>;
+			interrupt-names = "global";
+			rcu-periph-clock = <0x705>;
+			rcu-periph-reset = <0x405>;
+			channels = <0>;
+			status = "disabled";
+			label = "TIMER_6";
+		};
+
+		timer7: timer@40013400 {
+			compatible = "gd,gd32-timer";
+			reg = <0x40013400 0x400>;
+			interrupts = <43 0>, <44 0>, <45 0>, <46 0>;
+			interrupt-names = "brk", "up", "trgcom", "cc";
+			rcu-periph-clock = <0x60d>;
+			rcu-periph-reset = <0x30d>;
+			is-advanced;
+			channels = <4>;
+			status = "disabled";
+			label = "TIMER_7";
+
+			pwm {
+				compatible = "gd,gd32-pwm";
+				status = "disabled";
+				label = "PWM_7";
+				#pwm-cells = <2>;
+			};
+		};
+
+		timer8: timer@40014c00 {
+			compatible = "gd,gd32-timer";
+			reg = <0x40014c00 0x400>;
+			interrupts = <24 0>;
+			interrupt-names = "global";
+			rcu-periph-clock = <0x613>;
+			rcu-periph-reset = <0x313>;
+			channels = <2>;
+			status = "disabled";
+			label = "TIMER_8";
+
+			pwm {
+				compatible = "gd,gd32-pwm";
+				status = "disabled";
+				label = "PWM_8";
+				#pwm-cells = <2>;
+			};
+		};
+
+		timer9: timer@40015000 {
+			compatible = "gd,gd32-timer";
+			reg = <0x40015000 0x400>;
+			interrupts = <25 0>;
+			interrupt-names = "global";
+			rcu-periph-clock = <0x614>;
+			rcu-periph-reset = <0x314>;
+			channels = <1>;
+			status = "disabled";
+			label = "TIMER_9";
+
+			pwm {
+				compatible = "gd,gd32-pwm";
+				status = "disabled";
+				label = "PWM_9";
+				#pwm-cells = <2>;
+			};
+		};
+
+		timer10: timer@40015400 {
+			compatible = "gd,gd32-timer";
+			reg = <0x40015400 0x400>;
+			interrupts = <26 0>;
+			interrupt-names = "global";
+			rcu-periph-clock = <0x615>;
+			rcu-periph-reset = <0x315>;
+			channels = <1>;
+			status = "disabled";
+			label = "TIMER_10";
+
+			pwm {
+				compatible = "gd,gd32-pwm";
+				status = "disabled";
+				label = "PWM_10";
+				#pwm-cells = <2>;
+			};
+		};
+
+		timer11: timer@40001800 {
+			compatible = "gd,gd32-timer";
+			reg = <0x40001800 0x400>;
+			interrupts = <43 0>;
+			interrupt-names = "global";
+			rcu-periph-clock = <0x706>;
+			rcu-periph-reset = <0x406>;
+			channels = <2>;
+			status = "disabled";
+			label = "TIMER_11";
+
+			pwm {
+				compatible = "gd,gd32-pwm";
+				status = "disabled";
+				label = "PWM_11";
+				#pwm-cells = <2>;
+			};
+		};
+
+		timer12: timer@40001c00 {
+			compatible = "gd,gd32-timer";
+			reg = <0x40001c00 0x400>;
+			interrupts = <44 0>;
+			interrupt-names = "global";
+			rcu-periph-clock = <0x707>;
+			rcu-periph-reset = <0x402>;
+			channels = <1>;
+			status = "disabled";
+			label = "TIMER_12";
+
+			pwm {
+				compatible = "gd,gd32-pwm";
+				status = "disabled";
+				label = "PWM_12";
+				#pwm-cells = <2>;
+			};
+		};
+
+		timer13: timer@40002000 {
+			compatible = "gd,gd32-timer";
+			reg = <0x40002000 0x400>;
+			interrupts = <45 0>;
+			interrupt-names = "global";
+			rcu-periph-clock = <0x708>;
+			rcu-periph-reset = <0x408>;
+			channels = <1>;
+			status = "disabled";
+			label = "TIMER_13";
+
+			pwm {
+				compatible = "gd,gd32-pwm";
+				status = "disabled";
+				label = "PWM_13";
+				#pwm-cells = <2>;
+			};
+		};
 	};
 };
 

--- a/dts/arm/gigadevice/gd32f4xx/gd32f4xx.dtsi
+++ b/dts/arm/gigadevice/gd32f4xx/gd32f4xx.dtsi
@@ -7,6 +7,8 @@
 #include <arm/armv7-m.dtsi>
 #include <dt-bindings/gpio/gpio.h>
 
+#include <dt-bindings/pwm/pwm.h>
+
 / {
 	cpus {
 		#address-cells = <1>;
@@ -246,6 +248,262 @@
 				rcu-periph-clock = <0xc08>;
 				status = "disabled";
 				label = "GPIOI";
+			};
+		};
+
+		timer0: timer@40010000 {
+			compatible = "gd,gd32-timer";
+			reg = <0x40010000 0x400>;
+			interrupts = <24 0>, <25 0>, <26 0>, <27 0>;
+			interrupt-names = "brk", "up", "trgcom", "cc";
+			rcu-periph-clock = <0x1100>;
+			rcu-periph-reset = <0x900>;
+			is-advanced;
+			channels = <4>;
+			status = "disabled";
+			label = "TIMER_0";
+
+			pwm {
+				compatible = "gd,gd32-pwm";
+				status = "disabled";
+				label = "PWM_0";
+				#pwm-cells = <2>;
+			};
+		};
+
+		timer1: timer@40000000 {
+			compatible = "gd,gd32-timer";
+			reg = <0x40000000 0x400>;
+			interrupts = <28 0>;
+			interrupt-names = "global";
+			rcu-periph-clock = <0x1000>;
+			rcu-periph-reset = <0x800>;
+			is-32bit;
+			channels = <4>;
+			status = "disabled";
+			label = "TIMER_1";
+
+			pwm {
+				compatible = "gd,gd32-pwm";
+				status = "disabled";
+				label = "PWM_1";
+				#pwm-cells = <2>;
+			};
+		};
+
+		timer2: timer@40000400 {
+			compatible = "gd,gd32-timer";
+			reg = <0x40000400 0x400>;
+			interrupts = <29 0>;
+			interrupt-names = "global";
+			rcu-periph-clock = <0x1001>;
+			rcu-periph-reset = <0x801>;
+			channels = <4>;
+			status = "disabled";
+			label = "TIMER_2";
+
+			pwm {
+				compatible = "gd,gd32-pwm";
+				status = "disabled";
+				label = "PWM_2";
+				#pwm-cells = <2>;
+			};
+		};
+
+		timer3: timer@40000800 {
+			compatible = "gd,gd32-timer";
+			reg = <0x40000800 0x400>;
+			interrupts = <30 0>;
+			interrupt-names = "global";
+			rcu-periph-clock = <0x1002>;
+			rcu-periph-reset = <0x802>;
+			channels = <4>;
+			status = "disabled";
+			label = "TIMER_3";
+
+			pwm {
+				compatible = "gd,gd32-pwm";
+				status = "disabled";
+				label = "PWM_3";
+				#pwm-cells = <2>;
+			};
+		};
+
+		timer4: timer@40000c00 {
+			compatible = "gd,gd32-timer";
+			reg = <0x40000c00 0x400>;
+			interrupts = <50 0>;
+			interrupt-names = "global";
+			rcu-periph-clock = <0x1003>;
+			rcu-periph-reset = <0x803>;
+			is-32bit;
+			channels = <4>;
+			status = "disabled";
+			label = "TIMER_4";
+
+			pwm {
+				compatible = "gd,gd32-pwm";
+				status = "disabled";
+				label = "PWM_4";
+				#pwm-cells = <2>;
+			};
+		};
+
+		timer5: timer@40001000 {
+			compatible = "gd,gd32-timer";
+			reg = <0x40001000 0x400>;
+			interrupts = <54 0>;
+			interrupt-names = "global";
+			rcu-periph-clock = <0x1004>;
+			rcu-periph-reset = <0x804>;
+			channels = <0>;
+			status = "disabled";
+			label = "TIMER_5";
+		};
+
+		timer6: timer@40001400 {
+			compatible = "gd,gd32-timer";
+			reg = <0x40001400 0x400>;
+			interrupts = <55 0>;
+			interrupt-names = "global";
+			rcu-periph-clock = <0x1005>;
+			rcu-periph-reset = <0x805>;
+			channels = <0>;
+			status = "disabled";
+			label = "TIMER_6";
+		};
+
+		timer7: timer@40010400 {
+			compatible = "gd,gd32-timer";
+			reg = <0x40010400 0x400>;
+			interrupts = <43 0>, <44 0>, <45 0>, <46 0>;
+			interrupt-names = "brk", "up", "trgcom", "cc";
+			rcu-periph-clock = <0x1101>;
+			rcu-periph-reset = <0x901>;
+			is-advanced;
+			channels = <4>;
+			status = "disabled";
+			label = "TIMER_7";
+
+			pwm {
+				compatible = "gd,gd32-pwm";
+				status = "disabled";
+				label = "PWM_7";
+				#pwm-cells = <2>;
+			};
+		};
+
+		timer8: timer@40014000 {
+			compatible = "gd,gd32-timer";
+			reg = <0x40014000 0x400>;
+			interrupts = <24 0>;
+			interrupt-names = "global";
+			rcu-periph-clock = <0x1110>;
+			rcu-periph-reset = <0x910>;
+			channels = <2>;
+			status = "disabled";
+			label = "TIMER_8";
+
+			pwm {
+				compatible = "gd,gd32-pwm";
+				status = "disabled";
+				label = "PWM_8";
+				#pwm-cells = <2>;
+			};
+		};
+
+		timer9: timer@40014400 {
+			compatible = "gd,gd32-timer";
+			reg = <0x40014400 0x400>;
+			interrupts = <25 0>;
+			interrupt-names = "global";
+			rcu-periph-clock = <0x1111>;
+			rcu-periph-reset = <0x911>;
+			channels = <1>;
+			status = "disabled";
+			label = "TIMER_9";
+
+			pwm {
+				compatible = "gd,gd32-pwm";
+				status = "disabled";
+				label = "PWM_9";
+				#pwm-cells = <2>;
+			};
+		};
+
+		timer10: timer@40014800 {
+			compatible = "gd,gd32-timer";
+			reg = <0x40014800 0x400>;
+			interrupts = <26 0>;
+			interrupt-names = "global";
+			rcu-periph-clock = <0x1112>;
+			rcu-periph-reset = <0x912>;
+			channels = <1>;
+			status = "disabled";
+			label = "TIMER_10";
+
+			pwm {
+				compatible = "gd,gd32-pwm";
+				status = "disabled";
+				label = "PWM_10";
+				#pwm-cells = <2>;
+			};
+		};
+
+		timer11: timer@40001800 {
+			compatible = "gd,gd32-timer";
+			reg = <0x40001800 0x400>;
+			interrupts = <43 0>;
+			interrupt-names = "global";
+			rcu-periph-clock = <0x1006>;
+			rcu-periph-reset = <0x806>;
+			channels = <2>;
+			status = "disabled";
+			label = "TIMER_11";
+
+			pwm {
+				compatible = "gd,gd32-pwm";
+				status = "disabled";
+				label = "PWM_11";
+				#pwm-cells = <2>;
+			};
+		};
+
+		timer12: timer@40001c00 {
+			compatible = "gd,gd32-timer";
+			reg = <0x40001c00 0x400>;
+			interrupts = <44 0>;
+			interrupt-names = "global";
+			rcu-periph-clock = <0x1007>;
+			rcu-periph-reset = <0x802>;
+			channels = <1>;
+			status = "disabled";
+			label = "TIMER_12";
+
+			pwm {
+				compatible = "gd,gd32-pwm";
+				status = "disabled";
+				label = "PWM_12";
+				#pwm-cells = <2>;
+			};
+		};
+
+		timer13: timer@40002000 {
+			compatible = "gd,gd32-timer";
+			reg = <0x40002000 0x400>;
+			interrupts = <45 0>;
+			interrupt-names = "global";
+			rcu-periph-clock = <0x1008>;
+			rcu-periph-reset = <0x808>;
+			channels = <1>;
+			status = "disabled";
+			label = "TIMER_13";
+
+			pwm {
+				compatible = "gd,gd32-pwm";
+				status = "disabled";
+				label = "PWM_13";
+				#pwm-cells = <2>;
 			};
 		};
 	};

--- a/dts/bindings/pwm/gd,gd32-pwm.yaml
+++ b/dts/bindings/pwm/gd,gd32-pwm.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) 2021 Teslabs Engineering S.L.
+# SPDX-License-Identifier: Apache-2.0
+
+description: GigaDevice GD32 PWM
+
+compatible: "gd,gd32-pwm"
+
+include: [base.yaml, pwm-controller.yaml, pinctrl-device.yaml]
+
+properties:
+  pinctrl-0:
+    required: true
+
+  pinctrl-names:
+    required: true
+
+  "#pwm-cells":
+    const: 2
+
+pwm-cells:
+  - channel
+  - flags

--- a/dts/bindings/timer/gd,gd32-timer.yaml
+++ b/dts/bindings/timer/gd,gd32-timer.yaml
@@ -1,0 +1,45 @@
+# Copyright (c) 2021 Teslabs Engineering S.L.
+# SPDX-License-Identifier: Apache-2.0
+
+description: GigaDevice GD32 timer
+
+compatible: "gd,gd32-timer"
+
+include: base.yaml
+
+properties:
+  label:
+    required: true
+
+  reg:
+    required: true
+
+  channels:
+    type: int
+    required: true
+    description: Number of timer channels.
+
+  prescaler:
+    type: int
+    default: 0
+    description: Timer prescaler. Defaults to 0 (SoC default).
+
+  is-32bit:
+    type: boolean
+    description: Indicates if timer has a 32-bit counter.
+
+  is-advanced:
+    type: boolean
+    description: |
+      Indicates if timer has advanced features. Such features include break
+      inputs, dead-time insertion, etc.
+
+  rcu-periph-clock:
+    type: int
+    description: Reset Control Unit Peripheral Clock ID
+    required: true
+
+  rcu-periph-reset:
+    type: int
+    description: Reset Control Unit Peripheral Reset ID
+    required: true


### PR DESCRIPTION
This PR introduces an initial version of a PWM driver for GD32 SoCs. No PWM capture support for now.

Tested on GD32F450I-EVAL using:

- samples/basic/blinky_pwm
- samples/basic/fade_led

Also tested on GD32VF103V-EVAL board (not part of this PR yet) https://github.com/teslabs/zephyr/tree/pwm-gd32-vf103.

Confirmed generated waveform periods are correct using scope.