### PR TITLE
drivers: modem: Adding SMS messaging support

### DIFF
--- a/drivers/modem/Kconfig
+++ b/drivers/modem/Kconfig
@@ -139,6 +139,24 @@ config MODEM_CELL_INFO
 	help
 	  Query for numerical operator id, location area code and cell id.
 
+config MODEM_SMS_IN_MSG_MAX_LEN
+        int "Maximum length of inbound SMS messages"
+        default 160
+        help
+          This is the maximum length of inbound (received) SMS messages.
+          Inbound SMS messages longer than this will be truncated.
+          The absolute maximum value may be network- and/or modem-dependent,
+          but a smaller value may be preferred in order to conserve memory.
+
+config MODEM_SMS_OUT_MSG_MAX_LEN
+        int "Maximum length of outbound SMS messages"
+        default 160
+        help
+          This is the maximum length of outbound SMS messages (being sent).
+          SMS message send requests longer than this are not possible.
+          The absolute maximum value may be network- and/or modem-dependent,
+          but a smaller value may be preferred in order to conserve memory.
+
 source "drivers/modem/Kconfig.ublox-sara-r4"
 source "drivers/modem/Kconfig.quectel-bg9x"
 source "drivers/modem/Kconfig.wncm14a2a"

--- a/drivers/modem/modem_context.h
+++ b/drivers/modem/modem_context.h
@@ -7,6 +7,7 @@
 
 /*
  * Copyright (c) 2019 Foundries.io
+ * Copyright (c) 2021 John Lange <john@y2038.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -25,9 +26,9 @@ extern "C" {
 #endif
 
 #define MODEM_PIN(name_, pin_, flags_) { \
-	.dev_name = name_, \
-	.pin = pin_, \
-	.init_flags = flags_ \
+		.dev_name = name_,	 \
+		.pin = pin_,		 \
+		.init_flags = flags_	 \
 }
 
 struct modem_iface {
@@ -67,12 +68,12 @@ struct modem_context {
 	char *data_iccid;
 #endif
 #if defined(CONFIG_MODEM_CELL_INFO)
-	int   data_operator;
-	int   data_lac;
-	int   data_cellid;
+	int data_operator;
+	int data_lac;
+	int data_cellid;
 #endif
 	int   *data_rssi;
-	bool  is_automatic_oper;
+	bool is_automatic_oper;
 	/* pin config */
 	struct modem_pin *pins;
 	size_t pins_len;

--- a/drivers/modem/modem_context.h
+++ b/drivers/modem/modem_context.h
@@ -20,6 +20,7 @@
 #include <net/net_ip.h>
 #include <sys/ring_buffer.h>
 #include <drivers/gpio.h>
+#include "modem_sms.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -83,6 +84,10 @@ struct modem_context {
 
 	/* command handler config */
 	struct modem_cmd_handler cmd_handler;
+
+	/* SMS functions */
+	send_sms_func_t send_sms;
+	recv_sms_func_t recv_sms;
 
 	/* driver data */
 	void *driver_data;

--- a/drivers/modem/modem_sms.h
+++ b/drivers/modem/modem_sms.h
@@ -1,0 +1,50 @@
+/** @file
+ * @brief Modem SMS for SMS common structure.
+ *
+ * Modem SMS handling for modem driver.
+ */
+
+/*
+ * Copyright (c) 2021 John Lange <john@y2038.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_MODEM_MODEM_SMS_H_
+#define ZEPHYR_INCLUDE_DRIVERS_MODEM_MODEM_SMS_H_
+
+#define SMS_PHONE_MAX_LEN          16
+#define SMS_TIME_MAX_LEN           26
+
+#ifndef CONFIG_SMS_IN_MSG_MAX_LEN
+#define CONFIG_SMS_IN_MSG_MAX_LEN  168
+#endif
+
+#ifndef CONFIG_SMS_OUT_MSG_MAX_LEN
+#define CONFIG_SMS_OUT_MSG_MAX_LEN 168
+#endif
+
+/*
+ * All fields in sms_out and sms_in are NULL terminated
+ */
+
+struct sms_out {
+        char phone[SMS_PHONE_MAX_LEN];
+        char msg  [CONFIG_SMS_OUT_MSG_MAX_LEN];
+};
+
+struct sms_in {
+        char phone[SMS_PHONE_MAX_LEN];
+        char time [SMS_TIME_MAX_LEN];
+        char msg  [CONFIG_SMS_IN_MSG_MAX_LEN];
+};
+
+typedef int (*send_sms_func_t)(void *obj, const struct sms_out *sms);
+typedef int (*recv_sms_func_t)(void *obj,       struct sms_in  *sms, k_timeout_t timeout);
+
+enum io_ctl {
+	SMS_SEND,
+	SMS_RECV,
+};
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_MODEM_MODEM_SMS_H_ */

--- a/drivers/modem/modem_sms.h
+++ b/drivers/modem/modem_sms.h
@@ -1,0 +1,42 @@
+/** @file
+ * @brief Modem SMS for SMS common structure.
+ *
+ * Modem SMS handling for modem driver.
+ */
+
+/*
+ * Copyright (c) 2021 John Lange <john@y2038.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_MODEM_MODEM_SMS_H_
+#define ZEPHYR_INCLUDE_DRIVERS_MODEM_MODEM_SMS_H_
+
+#define SMS_PHONE_MAX_LEN          16
+#define SMS_TIME_MAX_LEN           26
+
+/*
+ * All fields in sms_out and sms_in are NULL terminated
+ */
+
+struct sms_out {
+        char phone[SMS_PHONE_MAX_LEN];
+        char msg  [CONFIG_MODEM_SMS_OUT_MSG_MAX_LEN + 2];
+};
+
+struct sms_in {
+        char phone[SMS_PHONE_MAX_LEN];
+        char time [SMS_TIME_MAX_LEN];
+        char msg  [CONFIG_MODEM_SMS_IN_MSG_MAX_LEN + 2];
+};
+
+typedef int (*send_sms_func_t)(void *obj, const struct sms_out *sms);
+typedef int (*recv_sms_func_t)(void *obj,       struct sms_in  *sms, k_timeout_t timeout);
+
+enum io_ctl {
+	SMS_SEND,
+	SMS_RECV,
+};
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_MODEM_MODEM_SMS_H_ */


### PR DESCRIPTION
Adding function pointers for sending and receiving SMS messages
to the modem context. The receive SMS function may be blocking.

Signed-off-by: John Lange <John.Lange2@T-Mobile.com>