### PR TITLE
driver: i2c: npcx: adjust parameters for better I2C timing at 100 KHz

### DIFF
--- a/drivers/i2c/i2c_npcx_controller.c
+++ b/drivers/i2c/i2c_npcx_controller.c
@@ -161,13 +161,13 @@ struct i2c_ctrl_data {
 
 /* Recommended I2C timing values are based on 15 MHz */
 static const struct npcx_i2c_timing_cfg npcx_15m_speed_confs[] = {
-	[NPCX_I2C_BUS_SPEED_100KHZ] = {.HLDT = 0, .k1 = 75, .k2 = 0},
+	[NPCX_I2C_BUS_SPEED_100KHZ] = {.HLDT = 15, .k1 = 76, .k2 = 0},
 	[NPCX_I2C_BUS_SPEED_400KHZ] = {.HLDT = 7, .k1 = 24, .k2 = 18,},
 	[NPCX_I2C_BUS_SPEED_1MHZ] = {.HLDT  = 7, .k1 = 14, .k2 = 10,},
 };
 
 static const struct npcx_i2c_timing_cfg npcx_20m_speed_confs[] = {
-	[NPCX_I2C_BUS_SPEED_100KHZ] = {.HLDT = 0, .k1 = 100, .k2 = 0},
+	[NPCX_I2C_BUS_SPEED_100KHZ] = {.HLDT = 15, .k1 = 102, .k2 = 0},
 	[NPCX_I2C_BUS_SPEED_400KHZ] = {.HLDT = 7, .k1 = 32, .k2 = 22},
 	[NPCX_I2C_BUS_SPEED_1MHZ] = {.HLDT  = 7, .k1 = 16, .k2 = 10},
 };
@@ -349,11 +349,13 @@ static void i2c_ctrl_config_bus_freq(const struct device *dev,
 	if (bus_freq == NPCX_I2C_BUS_SPEED_100KHZ) {
 		/* Enable 'Normal' Mode */
 		inst->SMBCTL3 &= ~(BIT(NPCX_SMBCTL3_400K));
-		/* Set freq of SCL */
+		/* Set freq of SCL. For 100KHz, only k1 is used.  */
 		SET_FIELD(inst->SMBCTL2, NPCX_SMBCTL2_SCLFRQ0_6_FIELD,
 				bus_cfg.k1/2 & 0x7f);
 		SET_FIELD(inst->SMBCTL3, NPCX_SMBCTL3_SCLFRQ7_8_FIELD,
-				bus_cfg.k2/2 >> 7);
+				bus_cfg.k1/2 >> 7);
+		SET_FIELD(inst->SMBCTL4, NPCX_SMBCTL4_HLDT_FIELD,
+				bus_cfg.HLDT);
 	} else {
 		/* Enable 'Fast' Mode for 400K or higher freq. */
 		inst->SMBCTL3 |= BIT(NPCX_SMBCTL3_400K);


### PR DESCRIPTION
The original parameter (k1) setting may let the I2C frequency be a
little bit higher than 100k Hz, which causes the timing Tsu:sta (set-up
time for a repeated START) to violate the spec. This change fixes the k1
parameter and also changes the HLDT to the suggested value in the
datasheet.

Signed-off-by: Jun Lin <CHLin56@nuvoton.com>