### PR TITLE
CODEOWNERS: Add kentjhall for STM32 counter driver

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -215,6 +215,7 @@
 /drivers/console/ipm_console.c            @finikorg
 /drivers/console/semihost_console.c       @luozhongyao
 /drivers/counter/counter_cmos.c           @dcpleung
+/drivers/counter/counter_ll_stm32_timer.c @kentjhall
 /drivers/crypto/*nrf_ecb*                 @maciekfabia @anangl
 /drivers/display/                         @vanwinkeljan
 /drivers/display/display_framebuf.c       @dcpleung


### PR DESCRIPTION
Add myself as codeowner for the STM32 counter driver.