### PR TITLE
CODEOWNERS: Add LingaoM for bbc_microbit_v2 board

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -90,6 +90,7 @@
 /boards/arm/96b_stm32_sensor_mez/         @Mani-Sadhasivam
 /boards/arm/96b_wistrio/                  @Mani-Sadhasivam
 /boards/arm/arduino_due/                  @ioannisg
+/boards/arm/bbc_microbit_v2/              @LingaoM
 /boards/arm/blackpill_f401ce/             @coderkalyan
 /boards/arm/blackpill_f411ce/             @coderkalyan
 /boards/arm/cc1352r1_launchxl/            @bwitherspoon


### PR DESCRIPTION
Add myself as codeowner for the bbc_microbit_v2 driver

https://github.com/zephyrproject-rtos/zephyr/pull/31000

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>