### PR TITLE
Fixing up a few issues in the new LLCP implementation

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
@@ -472,8 +472,16 @@ struct ll_conn {
  * and/or needs to be properly integrated in the control procedures
  */
 	union {
+		struct {
+#if defined(CONFIG_BT_CTLR_CONN_META)
+			uint8_t  is_must_expire:1;
+#endif /* CONFIG_BT_CTLR_CONN_META */
+		} common;
 #if defined(CONFIG_BT_PERIPHERAL)
 		struct {
+#if defined(CONFIG_BT_CTLR_CONN_META)
+			uint8_t  is_must_expire:1;
+#endif /* CONFIG_BT_CTLR_CONN_META */
 			uint8_t  latency_cancel:1;
 			uint8_t  sca:3;
 			uint32_t force;
@@ -483,6 +491,9 @@ struct ll_conn {
 
 #if defined(CONFIG_BT_CENTRAL)
 		struct {
+#if defined(CONFIG_BT_CTLR_CONN_META)
+			uint8_t  is_must_expire:1;
+#endif /* CONFIG_BT_CTLR_CONN_META */
 			uint8_t terminate_ack:1;
 		} central;
 #endif /* CONFIG_BT_CENTRAL */

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_chmu.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_chmu.c
@@ -113,7 +113,7 @@ static void lp_chmu_complete(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t
 static void lp_chmu_send_channel_map_update_ind(struct ll_conn *conn, struct proc_ctx *ctx,
 						uint8_t evt, void *param)
 {
-	if (llcp_rr_get_collision(conn) || !llcp_tx_alloc_peek(conn, ctx)) {
+	if (ctx->pause || llcp_rr_get_collision(conn) || !llcp_tx_alloc_peek(conn, ctx)) {
 		ctx->state = LP_CHMU_STATE_WAIT_TX_CHAN_MAP_IND;
 	} else {
 		llcp_rr_set_incompat(conn, INCOMPAT_RESOLVABLE);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
@@ -415,7 +415,7 @@ static void lp_comm_send_req(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t
 		}
 		break;
 	case PROC_TERMINATE:
-		if (ctx->pause || !llcp_tx_alloc_peek(conn, ctx)) {
+		if (!llcp_tx_alloc_peek(conn, ctx)) {
 			ctx->state = LP_COMMON_STATE_WAIT_TX;
 		} else {
 			lp_comm_tx(conn, ctx);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_conn_upd.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_conn_upd.c
@@ -216,7 +216,7 @@ static void lp_cu_complete(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t e
 static void lp_cu_send_conn_param_req(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt,
 				      void *param)
 {
-	if (llcp_rr_get_collision(conn) || !llcp_tx_alloc_peek(conn, ctx)) {
+	if (ctx->pause || llcp_rr_get_collision(conn) || !llcp_tx_alloc_peek(conn, ctx)) {
 		ctx->state = LP_CU_STATE_WAIT_TX_CONN_PARAM_REQ;
 	} else {
 		uint16_t event_counter = ull_conn_event_counter(conn);
@@ -260,7 +260,7 @@ static void lp_cu_send_conn_param_req(struct ll_conn *conn, struct proc_ctx *ctx
 static void lp_cu_send_conn_update_ind(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt,
 				       void *param)
 {
-	if (!llcp_tx_alloc_peek(conn, ctx)) {
+	if (ctx->pause || !llcp_tx_alloc_peek(conn, ctx)) {
 		ctx->state = LP_CU_STATE_WAIT_TX_CONN_UPDATE_IND;
 	} else {
 		ctx->data.cu.win_size = 1U;
@@ -625,7 +625,7 @@ static void rp_cu_complete(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t e
 static void rp_cu_send_conn_update_ind(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt,
 				       void *param)
 {
-	if (!llcp_tx_alloc_peek(conn, ctx)) {
+	if (ctx->pause || !llcp_tx_alloc_peek(conn, ctx)) {
 		ctx->state = RP_CU_STATE_WAIT_TX_CONN_UPDATE_IND;
 	} else {
 		ctx->data.cu.win_size = 1U;
@@ -642,7 +642,7 @@ static void rp_cu_send_conn_update_ind(struct ll_conn *conn, struct proc_ctx *ct
 static void rp_cu_send_reject_ext_ind(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt,
 				      void *param)
 {
-	if (!llcp_tx_alloc_peek(conn, ctx)) {
+	if (ctx->pause || !llcp_tx_alloc_peek(conn, ctx)) {
 		ctx->state = RP_CU_STATE_WAIT_TX_REJECT_EXT_IND;
 	} else {
 		rp_cu_tx(conn, ctx, PDU_DATA_LLCTRL_TYPE_REJECT_EXT_IND);
@@ -654,7 +654,7 @@ static void rp_cu_send_reject_ext_ind(struct ll_conn *conn, struct proc_ctx *ctx
 static void rp_cu_send_conn_param_rsp(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt,
 				      void *param)
 {
-	if (!llcp_tx_alloc_peek(conn, ctx)) {
+	if (ctx->pause || !llcp_tx_alloc_peek(conn, ctx)) {
 		ctx->state = RP_CU_STATE_WAIT_TX_CONN_PARAM_RSP;
 	} else {
 		rp_cu_tx(conn, ctx, PDU_DATA_LLCTRL_TYPE_CONN_PARAM_RSP);
@@ -678,7 +678,7 @@ static void rp_cu_send_conn_param_req_ntf(struct ll_conn *conn, struct proc_ctx 
 static void rp_cu_send_unknown_rsp(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt,
 				   void *param)
 {
-	if (!llcp_tx_alloc_peek(conn, ctx)) {
+	if (ctx->pause || !llcp_tx_alloc_peek(conn, ctx)) {
 		ctx->state = RP_CU_STATE_WAIT_TX_UNKNOWN_RSP;
 	} else {
 		rp_cu_tx(conn, ctx, PDU_DATA_LLCTRL_TYPE_UNKNOWN_RSP);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_enc.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_enc.c
@@ -249,6 +249,10 @@ static void lp_enc_send_enc_req(struct ll_conn *conn, struct proc_ctx *ctx, uint
 		/* Wait for the LL_ENC_RSP */
 		ctx->rx_opcode = PDU_DATA_LLCTRL_TYPE_ENC_RSP;
 		ctx->state = LP_ENC_STATE_WAIT_RX_ENC_RSP;
+
+		/* Pause possibly ongoing remote procedure */
+		llcp_rr_pause(conn);
+
 	}
 }
 
@@ -409,6 +413,9 @@ static void lp_enc_st_wait_rx_start_enc_req(struct ll_conn *conn, struct proc_ct
 		ctx->data.enc.error = (pdu->llctrl.opcode == PDU_DATA_LLCTRL_TYPE_REJECT_IND) ?
 						    pdu->llctrl.reject_ind.error_code :
 						    pdu->llctrl.reject_ext_ind.error_code;
+		/* Resume possibly paused remote procedure */
+		llcp_rr_resume(conn);
+
 		lp_enc_complete(conn, ctx, evt, param);
 		break;
 	default:
@@ -440,6 +447,10 @@ static void lp_enc_st_wait_rx_start_enc_rsp(struct ll_conn *conn, struct proc_ct
 		/* Resume Rx data */
 		ull_conn_resume_rx_data(conn);
 		ctx->data.enc.error = BT_HCI_ERR_SUCCESS;
+
+		/* Resume possibly paused remote procedure */
+		llcp_rr_resume(conn);
+
 		lp_enc_complete(conn, ctx, evt, param);
 		break;
 	default:
@@ -816,6 +827,8 @@ static void rp_enc_send_reject_ind(struct ll_conn *conn, struct proc_ctx *ctx, u
 		llcp_tx_resume_data(conn);
 		/* Resume Rx data */
 		ull_conn_resume_rx_data(conn);
+		/* Resume possibly paused local procedure */
+		llcp_lr_resume(conn);
 	}
 }
 
@@ -833,6 +846,9 @@ static void rp_enc_send_start_enc_rsp(struct ll_conn *conn, struct proc_ctx *ctx
 		llcp_tx_resume_data(conn);
 		/* Resume Rx data */
 		ull_conn_resume_rx_data(conn);
+
+		/* Resume possibly paused local procedure */
+		llcp_lr_resume(conn);
 
 		/* Tx Encryption enabled */
 		conn->lll.enc_tx = 1U;
@@ -897,6 +913,10 @@ static void rp_enc_state_wait_rx_enc_req(struct ll_conn *conn, struct proc_ctx *
 		llcp_tx_flush(conn);
 		/* Pause Rx data */
 		ull_conn_pause_rx_data(conn);
+
+		/* Pause possibly paused local procedure */
+		llcp_lr_pause(conn);
+
 		rp_enc_store_m(conn, ctx, param);
 		rp_enc_send_enc_rsp(conn, ctx, evt, param);
 		break;

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
@@ -415,6 +415,8 @@ void llcp_pdu_decode_terminate_ind(struct proc_ctx *ctx, struct pdu_data *pdu);
  * LLCP Local Request
  */
 struct proc_ctx *llcp_lr_peek(struct ll_conn *conn);
+void llcp_lr_pause(struct ll_conn *conn);
+void llcp_lr_resume(struct ll_conn *conn);
 void llcp_lr_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, struct node_tx *tx);
 void llcp_lr_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx);
 void llcp_lr_enqueue(struct ll_conn *conn, struct proc_ctx *ctx);
@@ -431,6 +433,8 @@ void llcp_lr_abort(struct ll_conn *conn);
 void llcp_rr_set_incompat(struct ll_conn *conn, enum proc_incompat incompat);
 bool llcp_rr_get_collision(struct ll_conn *conn);
 struct proc_ctx *llcp_rr_peek(struct ll_conn *conn);
+void llcp_rr_pause(struct ll_conn *conn);
+void llcp_rr_resume(struct ll_conn *conn);
 void llcp_rr_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, struct node_tx *tx);
 void llcp_rr_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx);
 void llcp_rr_init(struct ll_conn *conn);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
@@ -111,6 +111,26 @@ struct proc_ctx *llcp_lr_peek(struct ll_conn *conn)
 	return ctx;
 }
 
+void llcp_lr_pause(struct ll_conn *conn)
+{
+	struct proc_ctx *ctx;
+
+	ctx = (struct proc_ctx *)sys_slist_peek_head(&conn->llcp.local.pend_proc_list);
+	if (ctx) {
+		ctx->pause = 1;
+	}
+}
+
+void llcp_lr_resume(struct ll_conn *conn)
+{
+	struct proc_ctx *ctx;
+
+	ctx = (struct proc_ctx *)sys_slist_peek_head(&conn->llcp.local.pend_proc_list);
+	if (ctx) {
+		ctx->pause = 0;
+	}
+}
+
 void llcp_lr_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx)
 {
 	switch (ctx->proc) {

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
@@ -439,7 +439,7 @@ static void lp_pu_complete(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t e
 
 static void lp_pu_send_phy_req(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
-	if (llcp_rr_get_collision(conn) || !llcp_tx_alloc_peek(conn, ctx)) {
+	if (ctx->pause || llcp_rr_get_collision(conn) || !llcp_tx_alloc_peek(conn, ctx)) {
 		ctx->state = LP_PU_STATE_WAIT_TX_PHY_REQ;
 	} else {
 		llcp_rr_set_incompat(conn, INCOMPAT_RESOLVABLE);
@@ -453,7 +453,7 @@ static void lp_pu_send_phy_req(struct ll_conn *conn, struct proc_ctx *ctx, uint8
 static void lp_pu_send_phy_update_ind(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt,
 				      void *param)
 {
-	if (!llcp_tx_alloc_peek(conn, ctx)) {
+	if (ctx->pause || !llcp_tx_alloc_peek(conn, ctx)) {
 		ctx->state = LP_PU_STATE_WAIT_TX_PHY_UPDATE_IND;
 	} else {
 		ctx->data.pu.instant = pu_event_counter(conn) + PHY_UPDATE_INSTANT_DELTA;
@@ -840,7 +840,7 @@ static void rp_pu_complete(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t e
 static void rp_pu_send_phy_update_ind(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt,
 				      void *param)
 {
-	if (!llcp_tx_alloc_peek(conn, ctx)) {
+	if (ctx->pause || !llcp_tx_alloc_peek(conn, ctx)) {
 		ctx->state = RP_PU_STATE_WAIT_TX_PHY_UPDATE_IND;
 	} else {
 		ctx->data.pu.instant = pu_event_counter(conn) + PHY_UPDATE_INSTANT_DELTA;
@@ -854,7 +854,7 @@ static void rp_pu_send_phy_update_ind(struct ll_conn *conn, struct proc_ctx *ctx
 #if defined(CONFIG_BT_PERIPHERAL)
 static void rp_pu_send_phy_rsp(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
-	if (!llcp_tx_alloc_peek(conn, ctx)) {
+	if (ctx->pause || !llcp_tx_alloc_peek(conn, ctx)) {
 		ctx->state = RP_PU_STATE_WAIT_TX_PHY_RSP;
 	} else {
 		rp_pu_tx(conn, ctx, PDU_DATA_LLCTRL_TYPE_PHY_RSP);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
@@ -171,6 +171,27 @@ struct proc_ctx *llcp_rr_peek(struct ll_conn *conn)
 	return ctx;
 }
 
+void llcp_rr_pause(struct ll_conn *conn)
+{
+	struct proc_ctx *ctx;
+
+	ctx = (struct proc_ctx *)sys_slist_peek_head(&conn->llcp.remote.pend_proc_list);
+	if (ctx) {
+		ctx->pause = 1;
+	}
+}
+
+void llcp_rr_resume(struct ll_conn *conn)
+{
+	struct proc_ctx *ctx;
+
+	ctx = (struct proc_ctx *)sys_slist_peek_head(&conn->llcp.remote.pend_proc_list);
+	if (ctx) {
+		ctx->pause = 0;
+	}
+}
+
+
 void llcp_rr_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx)
 {
 	switch (ctx->proc) {
@@ -351,7 +372,7 @@ static void rr_act_reject(struct ll_conn *conn)
 
 	LL_ASSERT(ctx != NULL);
 
-	if (!llcp_tx_alloc_peek(conn, ctx)) {
+	if (ctx->pause || !llcp_tx_alloc_peek(conn, ctx)) {
 		rr_set_state(conn, RR_STATE_REJECT);
 	} else {
 		rr_tx(conn, ctx, PDU_DATA_LLCTRL_TYPE_REJECT_IND);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
@@ -449,7 +449,7 @@ static void rr_st_idle(struct ll_conn *conn, uint8_t evt, void *param)
 				/* Run remote procedure */
 				rr_act_run(conn);
 				rr_set_state(conn, RR_STATE_TERMINATE);
-			} else if (incompat == INCOMPAT_NO_COLLISION) {
+			} else if (!with_instant || incompat == INCOMPAT_NO_COLLISION) {
 				/* No collision
 				 * => Run procedure
 				 *

--- a/subsys/bluetooth/controller/ll_sw/ull_tx_queue.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_tx_queue.c
@@ -15,15 +15,19 @@ void ull_tx_q_init(struct ull_tx_q *queue)
 
 void ull_tx_q_pause_data(struct ull_tx_q *queue)
 {
-	queue->pause_data = 1U;
+	queue->pause_data++;
 }
 
 void ull_tx_q_resume_data(struct ull_tx_q *queue)
 {
-	queue->pause_data = 0U;
+	if (queue->pause_data > 0) {
+		queue->pause_data--;
+	}
 
-	/* move all paused data to the tail of tx list */
-	sys_slist_merge_slist(&queue->tx_list, &queue->data_list);
+	/* move all paused data to the tail of tx list, only if not empty and no longer paused */
+	if (!queue->pause_data &&  !sys_slist_is_empty(&queue->data_list)) {
+		sys_slist_merge_slist(&queue->tx_list, &queue->data_list);
+	}
 }
 
 void ull_tx_q_enqueue_data(struct ull_tx_q *queue, struct node_tx *tx)


### PR DESCRIPTION
It was found that procedure pause handling was incomplete, so this is completed.
There was a slip in modification to struct llcp - missing member 'is_must_expire'
Finally it has turned out that the tx data pause/resume had a race condition, so the pause flag is changed into a counter, however without changing the API.