### PR TITLE
cmake: Update messages mode using INFO to the correct mode STATUS

### DIFF
--- a/samples/drivers/ipm/ipm_mcux/CMakeLists.txt
+++ b/samples/drivers/ipm/ipm_mcux/CMakeLists.txt
@@ -14,7 +14,7 @@ else()
   message(FATAL_ERROR "${BOARD} was not supported for this sample")
 endif()
 
-message(INFO " ${BOARD} compile as Master in this sample")
+message(STATUS "${BOARD} compile as Master in this sample")
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(ipm_mcux)

--- a/samples/drivers/ipm/ipm_mcux/remote/CMakeLists.txt
+++ b/samples/drivers/ipm/ipm_mcux/remote/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.20.0)
 
 if(("${BOARD}" STREQUAL "lpcxpresso54114_m0")
 	OR "${BOARD}" STREQUAL "lpcxpresso55s69_cpu1")
-	message(INFO " ${BOARD} compiles as remote in this sample")
+	message(STATUS "${BOARD} compiles as remote in this sample")
 else()
 	message(FATAL_ERROR "${BOARD} was not supported for this sample")
 endif()

--- a/samples/drivers/mbox/CMakeLists.txt
+++ b/samples/drivers/mbox/CMakeLists.txt
@@ -14,7 +14,7 @@ else()
   message(FATAL_ERROR "${BOARD} is not supported for this sample")
 endif()
 
-message(INFO " ${BOARD} compile as Main in this sample")
+message(STATUS "${BOARD} compile as Main in this sample")
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mbox_ipc)

--- a/samples/drivers/mbox/remote/CMakeLists.txt
+++ b/samples/drivers/mbox/remote/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 if("${BOARD}" STREQUAL "nrf5340dk_nrf5340_cpunet")
-  message(INFO " ${BOARD} compile as remote in this sample")
+  message(STATUS "${BOARD} compile as remote in this sample")
 else()
   message(FATAL_ERROR "${BOARD} is not supported for this sample")
 endif()

--- a/samples/subsys/ipc/ipc_service/static_vrings_mi/CMakeLists.txt
+++ b/samples/subsys/ipc/ipc_service/static_vrings_mi/CMakeLists.txt
@@ -15,7 +15,7 @@ else()
   message(FATAL_ERROR "${BOARD} is not supported for this sample")
 endif()
 
-message(INFO " ${BOARD} compile as Master in this sample")
+message(STATUS "${BOARD} compile as Master in this sample")
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(ipc_service)

--- a/samples/subsys/ipc/ipc_service/static_vrings_mi/remote/CMakeLists.txt
+++ b/samples/subsys/ipc/ipc_service/static_vrings_mi/remote/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required(VERSION 3.20.0)
 
 if("${BOARD}" STREQUAL "nrf5340dk_nrf5340_cpunet"
        OR "${BOARD}" STREQUAL "bl5340_dvk_cpunet")
-	message(INFO " ${BOARD} compile as slave in this sample")
+	message(STATUS "${BOARD} compile as slave in this sample")
 else()
 	message(FATAL_ERROR "${BOARD} is not supported for this sample")
 endif()

--- a/samples/subsys/ipc/openamp/CMakeLists.txt
+++ b/samples/subsys/ipc/openamp/CMakeLists.txt
@@ -20,7 +20,7 @@ else()
   message(FATAL_ERROR "${BOARD} was not supported for this sample")
 endif()
 
-message(INFO " ${BOARD} compile as Master in this sample")
+message(STATUS "${BOARD} compile as Master in this sample")
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(openamp)

--- a/samples/subsys/ipc/openamp/remote/CMakeLists.txt
+++ b/samples/subsys/ipc/openamp/remote/CMakeLists.txt
@@ -9,7 +9,7 @@ if(("${BOARD}" STREQUAL "lpcxpresso54114_m0")
 	OR "${BOARD}" STREQUAL "lpcxpresso55s69_cpu1"
 	OR "${BOARD}" STREQUAL "mps2_an521_remote"
 	OR "${BOARD}" STREQUAL "v2m_musca_b1_ns")
-	message(INFO " ${BOARD} compiles as remote in this sample")
+	message(STATUS "${BOARD} compiles as remote in this sample")
 else()
 	message(FATAL_ERROR "${BOARD} was not supported for this sample")
 endif()

--- a/samples/subsys/ipc/rpmsg_service/CMakeLists.txt
+++ b/samples/subsys/ipc/rpmsg_service/CMakeLists.txt
@@ -22,7 +22,7 @@ else()
   message(FATAL_ERROR "${BOARD} was not supported for this sample")
 endif()
 
-message(INFO " ${BOARD} compile as Master in this sample")
+message(STATUS "${BOARD} compile as Master in this sample")
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(rpmsg_service)

--- a/samples/subsys/ipc/rpmsg_service/remote/CMakeLists.txt
+++ b/samples/subsys/ipc/rpmsg_service/remote/CMakeLists.txt
@@ -10,7 +10,7 @@ if("${BOARD}" STREQUAL "nrf5340dk_nrf5340_cpunet"
 	OR "${BOARD}" STREQUAL "lpcxpresso54114_m0"
 	OR "${BOARD}" STREQUAL "mps2_an521_remote"
 	OR "${BOARD}" STREQUAL "v2m_musca_b1_ns")
-	message(INFO " ${BOARD} compile as slave in this sample")
+	message(STATUS "${BOARD} compile as slave in this sample")
 else()
 	message(FATAL_ERROR "${BOARD} was not supported for this sample")
 endif()


### PR DESCRIPTION
Search and replace `message(INFO " ` with `message(STATUS "`.
This would otherwise print "INFO <message"

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>