### PR TITLE
devicetree: add DT_INST_PARENT helper

### DIFF
--- a/drivers/counter/counter_ll_stm32_timer.c
+++ b/drivers/counter/counter_ll_stm32_timer.c
@@ -561,7 +561,7 @@ void counter_stm32_irq_handler(const struct device *dev)
 	}
 }
 
-#define TIMER(idx)              DT_PARENT(DT_DRV_INST(idx))
+#define TIMER(idx)              DT_INST_PARENT(idx)
 
 /** TIMx instance from DT */
 #define TIM(idx) ((TIM_TypeDef *)DT_REG_ADDR(TIMER(idx)))

--- a/drivers/counter/counter_mcux_snvs.c
+++ b/drivers/counter/counter_mcux_snvs.c
@@ -322,7 +322,7 @@ static struct mcux_snvs_config mcux_snvs_config_0 = {
 		.channels = MCUX_SNVS_NUM_CHANNELS,
 		.flags = COUNTER_CONFIG_INFO_COUNT_UP,
 	},
-	.base = (SNVS_Type *)DT_REG_ADDR(DT_PARENT(DT_DRV_INST(0))),
+	.base = (SNVS_Type *)DT_REG_ADDR(DT_INST_PARENT(0)),
 	.irq_config_func = mcux_snvs_irq_config_0,
 };
 

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -31,7 +31,7 @@ LOG_MODULE_REGISTER(flash_stm32_qspi, CONFIG_FLASH_LOG_LEVEL);
 #define STM32_QSPI_FIFO_THRESHOLD         8
 #define STM32_QSPI_CLOCK_PRESCALER_MAX  255
 
-#define STM32_QSPI_USE_DMA DT_NODE_HAS_PROP(DT_PARENT(DT_DRV_INST(0)), dmas)
+#define STM32_QSPI_USE_DMA DT_NODE_HAS_PROP(DT_INST_PARENT(0), dmas)
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_qspi_nor)
 
@@ -857,7 +857,7 @@ static int flash_stm32_qspi_init(const struct device *dev)
 
 static void flash_stm32_qspi_irq_config_func(const struct device *dev);
 
-#define STM32_QSPI_NODE DT_PARENT(DT_DRV_INST(0))
+#define STM32_QSPI_NODE DT_INST_PARENT(0)
 
 PINCTRL_DT_DEFINE(STM32_QSPI_NODE)
 

--- a/drivers/gpio/gpio_nct38xx_port.c
+++ b/drivers/gpio/gpio_nct38xx_port.c
@@ -465,7 +465,7 @@ BUILD_ASSERT(CONFIG_GPIO_NCT38XX_PORT_INIT_PRIORITY > CONFIG_GPIO_NCT38XX_INIT_P
 	static const struct gpio_nct38xx_port_config gpio_nct38xx_port_cfg_##inst = {              \
 		.common = { .port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(inst) &               \
 					     DT_INST_PROP(inst, pin_mask) },                       \
-		.nct38xx_dev = DEVICE_DT_GET(DT_PARENT(DT_DRV_INST(inst))),                        \
+		.nct38xx_dev = DEVICE_DT_GET(DT_INST_PARENT(inst)),                                \
 		.gpio_port = DT_INST_REG_ADDR(inst),                                               \
 		.pinmux_mask = COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, pinmux_mask),               \
 					   (DT_INST_PROP(inst, pinmux_mask)), (0)),                \

--- a/drivers/mdio/mdio_sam.c
+++ b/drivers/mdio/mdio_sam.c
@@ -130,7 +130,7 @@ static const struct mdio_driver_api mdio_sam_driver_api = {
 
 #define MDIO_SAM_CONFIG(n)						\
 static const struct mdio_sam_dev_config mdio_sam_dev_config_##n = {	\
-	.regs = (Gmac *)DT_REG_ADDR(DT_PARENT(DT_DRV_INST(n))),		\
+	.regs = (Gmac *)DT_REG_ADDR(DT_INST_PARENT(n)),			\
 	.protocol = DT_INST_ENUM_IDX(n, protocol),			\
 };
 

--- a/drivers/memc/memc_stm32_sdram.c
+++ b/drivers/memc/memc_stm32_sdram.c
@@ -119,7 +119,7 @@ static const struct memc_stm32_sdram_bank_config bank_config[] = {
 
 /** SDRAM configuration. */
 static const struct memc_stm32_sdram_config config = {
-	.sdram = (FMC_SDRAM_TypeDef *)(DT_REG_ADDR(DT_PARENT(DT_DRV_INST(0))) +
+	.sdram = (FMC_SDRAM_TypeDef *)(DT_REG_ADDR(DT_INST_PARENT(0)) +
 				       SDRAM_OFFSET),
 	.power_up_delay = DT_INST_PROP(0, power_up_delay),
 	.num_auto_refresh = DT_INST_PROP(0, num_auto_refresh),

--- a/drivers/ps2/ps2_npcx_channel.c
+++ b/drivers/ps2/ps2_npcx_channel.c
@@ -111,7 +111,7 @@ static const struct ps2_driver_api ps2_channel_npcx_driver_api = {
 		.channel_id = DT_INST_PROP(inst, channel),                     \
 		.alts_size = ARRAY_SIZE(ps2_channel_alts##inst),               \
 		.alts_list = ps2_channel_alts##inst,                           \
-		.ps2_ctrl = DEVICE_DT_GET(DT_PARENT(DT_DRV_INST(inst))),       \
+		.ps2_ctrl = DEVICE_DT_GET(DT_INST_PARENT(inst)),               \
 	};                                                                     \
 									       \
 	DEVICE_DT_INST_DEFINE(inst, ps2_npcx_channel_init, NULL, NULL,         \

--- a/drivers/pwm/pwm_gecko.c
+++ b/drivers/pwm/pwm_gecko.c
@@ -102,8 +102,7 @@ static int pwm_gecko_init(const struct device *dev)
 
 #define PWM_GECKO_INIT(index)							\
 	static const struct pwm_gecko_config pwm_gecko_config_##index = {	\
-		.timer = (TIMER_TypeDef *)DT_REG_ADDR(                          \
-			DT_PARENT(DT_DRV_INST(index))),				\
+		.timer = (TIMER_TypeDef *)DT_REG_ADDR(DT_INST_PARENT(index)),	\
 		.clock = CLOCK_TIMER(index),					\
 		.prescaler = DT_INST_PROP(index, prescaler),			\
 		.prescale_enum = (TIMER_Prescale_TypeDef)			\

--- a/drivers/pwm/pwm_mcux.c
+++ b/drivers/pwm/pwm_mcux.c
@@ -169,7 +169,7 @@ static const struct pwm_driver_api pwm_mcux_driver_api = {
 	static struct pwm_mcux_data pwm_mcux_data_ ## n;		  \
 									  \
 	static const struct pwm_mcux_config pwm_mcux_config_ ## n = {     \
-		.base = (void *)DT_REG_ADDR(DT_PARENT(DT_DRV_INST(n))),   \
+		.base = (void *)DT_REG_ADDR(DT_INST_PARENT(n)),		  \
 		.index = DT_INST_PROP(n, index),			  \
 		.mode = kPWM_EdgeAligned,				  \
 		.prescale = kPWM_Prescale_Divide_128,			  \

--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -633,10 +633,10 @@ static int pwm_stm32_init(const struct device *dev)
 #define IRQ_CONFIG_FUNC(index)                                                 \
 static void pwm_stm32_irq_config_func_##index(const struct device *dev)        \
 {                                                                              \
-	IRQ_CONNECT(DT_IRQN(DT_PARENT(DT_DRV_INST(index))),                    \
-			DT_IRQ(DT_PARENT(DT_DRV_INST(index)), priority),       \
+	IRQ_CONNECT(DT_IRQN(DT_INST_PARENT(index)),                            \
+			DT_IRQ(DT_INST_PARENT(index), priority),               \
 			pwm_stm32_isr, DEVICE_DT_INST_GET(index), 0);          \
-	irq_enable(DT_IRQN(DT_PARENT(DT_DRV_INST(index))));                    \
+	irq_enable(DT_IRQN(DT_INST_PARENT(index)));                            \
 }
 #define CAPTURE_INIT(index)                                                    \
 	.irq_config_func = pwm_stm32_irq_config_func_##index
@@ -647,8 +647,8 @@ static void pwm_stm32_irq_config_func_##index(const struct device *dev)        \
 
 #define DT_INST_CLK(index, inst)                                               \
 	{                                                                      \
-		.bus = DT_CLOCKS_CELL(DT_PARENT(DT_DRV_INST(index)), bus),     \
-		.enr = DT_CLOCKS_CELL(DT_PARENT(DT_DRV_INST(index)), bits)     \
+		.bus = DT_CLOCKS_CELL(DT_INST_PARENT(index), bus),             \
+		.enr = DT_CLOCKS_CELL(DT_INST_PARENT(index), bits)             \
 	}
 
 /* Print warning if any pwm node has 'st,prescaler' property */
@@ -665,13 +665,11 @@ replaced by 'st,prescaler' property in parent node, aka timers"
 	PINCTRL_DT_INST_DEFINE(index)					       \
 									       \
 	static const struct pwm_stm32_config pwm_stm32_config_##index = {      \
-		.timer = (TIM_TypeDef *)DT_REG_ADDR(                           \
-			DT_PARENT(DT_DRV_INST(index))),                        \
+		.timer = (TIM_TypeDef *)DT_REG_ADDR(DT_INST_PARENT(index)),    \
 		/* For compatibility reason, use pwm st_prescaler property  */ \
 		/* if exist, otherwise use parent (timers) property         */ \
 		.prescaler = DT_PROP_OR(DT_DRV_INST(index), st_prescaler,      \
-			(DT_PROP(DT_PARENT(DT_DRV_INST(index)),                \
-				 st_prescaler))),                              \
+			(DT_PROP(DT_INST_PARENT(index), st_prescaler))),       \
 		.pclken = DT_INST_CLK(index, timer),                           \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),		       \
 		CAPTURE_INIT(index)					       \

--- a/drivers/regulator/regulator_pmic.c
+++ b/drivers/regulator/regulator_pmic.c
@@ -324,8 +324,8 @@ static const struct regulator_driver_api api = {
 		.ilim_reg = DT_INST_PROP_OR(id, ilim_reg, 0),			\
 		.ilim_mask = DT_INST_PROP_OR(id, ilim_mask, 0),			\
 		.enable_inverted = DT_INST_PROP(id, enable_inverted),				\
-		.i2c_address = DT_REG_ADDR(DT_PARENT(DT_DRV_INST(id))),				\
-		.i2c_dev = DEVICE_DT_GET(DT_BUS(DT_PARENT(DT_DRV_INST(id)))),			\
+		.i2c_address = DT_REG_ADDR(DT_INST_PARENT(id)),					\
+		.i2c_dev = DEVICE_DT_GET(DT_BUS(DT_INST_PARENT(id))),				\
 		.voltage_array = pmic_reg_##id##_vol_range,					\
 		.current_array = pmic_reg_##id##_cur_limits,					\
 	};											\

--- a/include/devicetree.h
+++ b/include/devicetree.h
@@ -326,6 +326,13 @@
 #define DT_PARENT(node_id) UTIL_CAT(node_id, _PARENT)
 
 /**
+ * @brief Get a DT_DRV_COMPAT parent's node identifier
+ * @param inst instance number
+ * @return a node identifier for the instance's parent
+ */
+#define DT_INST_PARENT(inst) DT_PARENT(DT_DRV_INST(inst))
+
+/**
  * @brief Get a node identifier for a grandparent node
  *
  * Example devicetree fragment:

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -1639,11 +1639,20 @@ static void test_clocks(void)
 		      25000000, "");
 }
 
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT vnd_spi_device
 static void test_parent(void)
 {
 	/* The label of a child node's parent is the label of the parent. */
 	zassert_true(!strcmp(DT_LABEL(DT_PARENT(TEST_SPI_DEV_0)),
 			     DT_LABEL(TEST_SPI_BUS_0)), "");
+
+	/*
+	 * The parent's label for the first instance of vnd,spi-device,
+	 * child of TEST_SPI, is the same as TEST_SPI.
+	 */
+	zassert_true(!strcmp(DT_LABEL(DT_INST_PARENT(0)),
+			     DT_LABEL(TEST_SPI)), "");
 	/*
 	 * We should be able to use DT_PARENT() even with nodes, like /test,
 	 * that have no matching compatible.


### PR DESCRIPTION
- Provide the instance based version of the `DT_PARENT` macro.
- Replace usages of `DT_PARENT(DT_DRV_INST(idx))` with more idiomatic `DT_INST_PARENT(idx)`.