### PR TITLE
cmake: remove CMake policy CMP0002 and CMP0116

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -28,16 +28,6 @@
 # invocation in every toplevel CMakeLists.txt.
 cmake_minimum_required(VERSION 3.20.0)
 
-# CMP0002: "Logical target names must be globally unique"
-cmake_policy(SET CMP0002 NEW)
-
-# Use the old CMake behaviour until we are updating the CMake 3.20 as minimum
-# required. This ensure that CMake >=3.20 will be consistent with older CMakes.
-# CMP0116: Ninja generators transform DEPFILE s from add_custom_command().
-if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.20)
-  cmake_policy(SET CMP0116 OLD)
-endif()
-
 define_property(GLOBAL PROPERTY ZEPHYR_LIBS
     BRIEF_DOCS "Global list of all Zephyr CMake libs that should be linked in"
     FULL_DOCS  "Global list of all Zephyr CMake libs that should be linked in.


### PR DESCRIPTION
The CMake policies CMP0002 and CMP0116 can now safely be removed.

Setting CMake minimum version to 3.20 ensures that policies are set to
NEW per default for those two policies:
> The cmake_minimum_required() command does more than report an error
> if a too-old version of CMake is used to build a project. It also sets
> all policies introduced in that CMake version or earlier to NEW
> behavior.

CMP0002 was introduced in CMake 2.6 and was set to NEW.

CMP0116 was introduced in CMake 3.20 and set to OLD because of:
> Use the old CMake behaviour until we are updating the CMake 3.20 as
> minimum required. This ensure that CMake >=3.20 will be consistent
> with older CMakes.

and can thus be removed as we are now having 3.20 as minimum required.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>