### PR TITLE
static_vrings_mi: Fix list of integration platforms

### DIFF
--- a/samples/subsys/ipc/ipc_service/static_vrings_mi/sample.yaml
+++ b/samples/subsys/ipc/ipc_service/static_vrings_mi/sample.yaml
@@ -6,6 +6,7 @@ tests:
     sample.ipc.static_vrings_mi.nrf:
         platform_allow: nrf5340dk_nrf5340_cpuapp bl5340_dvk_cpuapp
         integration_platforms:
-          - nrf5340dk_nrf5340_cpuapp bl5340_dvk_cpuapp
+          - nrf5340dk_nrf5340_cpuapp
+          - bl5340_dvk_cpuapp
         tags: ipc
         build_only: true


### PR DESCRIPTION
Use list of dashes for the list of integration platforms.

as requested in #41222 by @gopiotr 