### PR TITLE
Various twister bug fixes

### DIFF
--- a/doc/guides/test/twister.rst
+++ b/doc/guides/test/twister.rst
@@ -561,14 +561,14 @@ this example we are using a reel_board and an nrf52840dk_nrf52840::
     product: DAPLink CMSIS-DAP
     runner: pyocd
     serial: /dev/cu.usbmodem146114202
-    baud: '9600'
+    baud: 9600
   - connected: true
     id: 000683759358
     platform: nrf52840dk_nrf52840
     product: J-Link
     runner: nrfjprog
     serial: /dev/cu.usbmodem0006837593581
-    baud: '9600'
+    baud: 9600
 
 The baud entry is only needed if not running at 115200.
 

--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -767,7 +767,7 @@ class DeviceHandler(Handler):
                         command_extra_args.append("--board-id")
                         command_extra_args.append(board_id)
                     elif runner == "nrfjprog":
-                        command_extra_args.append("--snr")
+                        command_extra_args.append("--dev-id")
                         command_extra_args.append(board_id)
                     elif runner == "openocd" and product == "STM32 STLink":
                         command_extra_args.append("--cmd-pre-init")

--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -740,7 +740,7 @@ class DeviceHandler(Handler):
         else:
             serial_device = hardware.serial
 
-        logger.debug("Using serial device {} @ {} baud".format(serial_device, hardware.serial_baud))
+        logger.debug(f"Using serial device {serial_device} @ {hardware.baud} baud")
 
         if (self.suite.west_flash is not None) or runner:
             command = ["west", "flash", "--skip-rebuild", "-d", self.build_dir]
@@ -799,7 +799,7 @@ class DeviceHandler(Handler):
         try:
             ser = serial.Serial(
                 serial_device,
-                baudrate=hardware.serial_baud,
+                baudrate=hardware.baud,
                 parity=serial.PARITY_NONE,
                 stopbits=serial.STOPBITS_ONE,
                 bytesize=serial.EIGHTBITS,
@@ -4068,9 +4068,7 @@ class DUT(object):
                  runner=None):
 
         self.serial = serial
-        self.serial_baud = 115200
-        if serial_baud:
-            self.serial_baud = serial_baud
+        self.baud = serial_baud or 115200
         self.platform = platform
         self.serial_pty = serial_pty
         self._counter = Value("i", 0)

--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -4252,6 +4252,7 @@ class HardwareMap:
                             s_dev.runner = runner
 
                 s_dev.connected = True
+                s_dev.lock = None
                 self.detected.append(s_dev)
             else:
                 logger.warning("Unsupported device (%s): %s" % (d.manufacturer, d))


### PR DESCRIPTION
- twister: remove lock from generated hardware map
- twister: fix baud setting for detected devices
- twister: fix documentation of baud setting
- twister: do not use deprecated arguments to nrfprog


Fixes #40449 
Fixes #40450
Fixes #39179
