### PR TITLE
tests: fix typos and misnamed platforms

### DIFF
--- a/samples/boards/arc_secure_services/sample.yaml
+++ b/samples/boards/arc_secure_services/sample.yaml
@@ -6,7 +6,7 @@ tests:
   sample.board.arc_secure_services:
     # Requires multiple kernels in an AMP config. See README.rst
     build_only: true
-    platform_allow: nsim_sem em_starterkit_em7d_secure
+    platform_allow: nsim_sem em_starterkit_em7d
     tags: secure
     harness: console
     harness_config:

--- a/samples/drivers/counter/maxim_ds3231/sample.yaml
+++ b/samples/drivers/counter/maxim_ds3231/sample.yaml
@@ -5,4 +5,4 @@ sample:
 tests:
   sample.basic.maxim_ds3231:
     build_only: true
-    platform_allow: efr32mg_sltb004a frdm_k64f nrf51_pca10028 nucleo_l476rg particle_xenon
+    platform_allow: efr32mg_sltb004a frdm_k64f nrf51dk_nrf51422 nucleo_l476rg particle_xenon

--- a/samples/subsys/ipc/ipc_service/static_vrings_mi/sample.yaml
+++ b/samples/subsys/ipc/ipc_service/static_vrings_mi/sample.yaml
@@ -6,6 +6,7 @@ tests:
     sample.ipc.static_vrings_mi.nrf:
         platform_allow: nrf5340dk_nrf5340_cpuapp bl5340_dvk_cpuapp
         integration_platforms:
-          - nrf5340dk_nrf5340_cpuapp bl5340_dvk_cpuapp
+          - nrf5340dk_nrf5340_cpuapp
+          - bl5340_dvk_cpuapp
         tags: ipc
         build_only: true

--- a/samples/subsys/ipc/openamp/sample.yaml
+++ b/samples/subsys/ipc/openamp/sample.yaml
@@ -4,7 +4,7 @@ sample:
     name: OpenAMP example integration
 tests:
     sample.ipc.openamp:
-        platform_allow: lpcxpresso54114_m4 lpcxpresso55s69_cpu0 mps2_an521 v2m_musca v2m_musca_b1
+        platform_allow: lpcxpresso54114_m4 lpcxpresso55s69_cpu0 mps2_an521 v2m_musca_b1
         tags: ipm
         harness: console
         harness_config:

--- a/samples/subsys/ipc/rpmsg_service/sample.yaml
+++ b/samples/subsys/ipc/rpmsg_service/sample.yaml
@@ -16,6 +16,7 @@ tests:
     sample.ipc.rpmsg_service.nrf:
         platform_allow: nrf5340dk_nrf5340_cpuapp bl5340_dvk_cpuapp
         integration_platforms:
-          - nrf5340dk_nrf5340_cpuapp bl5340_dvk_cpuapp
+          - nrf5340dk_nrf5340_cpuapp
+          - bl5340_dvk_cpuapp
         tags: ipm
         build_only: true

--- a/samples/tfm_integration/tfm_secure_partition/sample.yaml
+++ b/samples/tfm_integration/tfm_secure_partition/sample.yaml
@@ -1,7 +1,7 @@
 common:
     tags: tfm
-    platform_allow: mps2_an521_nonsecure v2m_musca_s1_nonsecure
-                    nrf5340dk_nrf5340_cpuappns nrf9160dk_nrf9160ns
+    platform_allow: mps2_an521_ns v2m_musca_s1_ns
+                    nrf5340dk_nrf5340_cpuapp_ns nrf9160dk_nrf9160_ns
     harness: console
     harness_config:
       type: multi_line

--- a/tests/drivers/build_all/ieee802154/testcase.yaml
+++ b/tests/drivers/build_all/ieee802154/testcase.yaml
@@ -6,7 +6,7 @@ tests:
     platform_allow: native_posix
     extra_args: OVERLAY_CONFIG=external.conf
   ieee802154.build.cc12xx_cc2520:
-    platform_allow: cc1352_sensortag
+    platform_allow: cc1352r_sensortag
     extra_configs:
       - CONFIG_IEEE802154_CC13XX_CC26XX=y
       - CONFIG_IEEE802154_CC13XX_CC26XX_SUB_GHZ=y

--- a/tests/drivers/flash/testcase.yaml
+++ b/tests/drivers/flash/testcase.yaml
@@ -19,7 +19,7 @@ tests:
   drivers.flash.stm32:
     integration_platforms:
       - nucleo_f091rc
-      - nucleo_f103rc
+      - nucleo_f103rb
       - nucleo_f207zg
       - stm32f3_disco
       - nucleo_f429zi

--- a/tests/kernel/workq/critical/testcase.yaml
+++ b/tests/kernel/workq/critical/testcase.yaml
@@ -3,14 +3,14 @@ common:
 
 tests:
   kernel.workqueue:
-    platform_exclude: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard
+    platform_exclude: nsim_sem_mpu_stack_guard
     filter: not CONFIG_WDT_SAM
   kernel.workqueue.sam:
     filter: CONFIG_WDT_SAM
     extra_configs:
      - CONFIG_WDT_DISABLE_AT_BOOT=y
   kernel.workqueue.nsim:
-    platform_allow: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard
+    platform_allow: nsim_sem_mpu_stack_guard
     extra_configs:
       - CONFIG_TEST_HW_STACK_PROTECTION=n
   kernel.workqueue.linker_generator:

--- a/tests/posix/common/testcase.yaml
+++ b/tests/posix/common/testcase.yaml
@@ -6,11 +6,11 @@ common:
 
 tests:
   portability.posix.common:
-    platform_exclude: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard ehl_crb
+    platform_exclude: nsim_sem_mpu_stack_guard ehl_crb
     extra_configs:
       - CONFIG_NEWLIB_LIBC=n
   portability.posix.common.newlib:
-    platform_exclude: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard ehl_crb
+    platform_exclude: nsim_sem_mpu_stack_guard ehl_crb
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
@@ -19,26 +19,26 @@ tests:
     extra_configs:
       - CONFIG_ARCMWDT_LIBC=y
   portability.posix.common.tls:
-    platform_exclude: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard ehl_crb
+    platform_exclude: nsim_sem_mpu_stack_guard ehl_crb
     filter: CONFIG_ARCH_HAS_THREAD_LOCAL_STORAGE and CONFIG_TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE
     extra_configs:
       - CONFIG_NEWLIB_LIBC=n
       - CONFIG_THREAD_LOCAL_STORAGE=y
       - CONFIG_MAIN_STACK_SIZE=1152
   portability.posix.common.tls.newlib:
-    platform_exclude: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard ehl_crb
+    platform_exclude: nsim_sem_mpu_stack_guard ehl_crb
     filter: TOOLCHAIN_HAS_NEWLIB == 1 and CONFIG_ARCH_HAS_THREAD_LOCAL_STORAGE and CONFIG_TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
       - CONFIG_THREAD_LOCAL_STORAGE=y
       - CONFIG_MAIN_STACK_SIZE=1152
   portability.posix.common.nsim:
-    platform_allow: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard
+    platform_allow: nsim_sem_mpu_stack_guard
     extra_configs:
       - CONFIG_NEWLIB_LIBC=n
       - CONFIG_TEST_HW_STACK_PROTECTION=n
   portability.posix.common.newlib.nsim:
-    platform_allow: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard
+    platform_allow: nsim_sem_mpu_stack_guard
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y

--- a/tests/subsys/jwt/testcase.yaml
+++ b/tests/subsys/jwt/testcase.yaml
@@ -8,4 +8,4 @@ tests:
     tags: jwt
     filter: CONFIG_ENTROPY_HAS_DRIVER
     integration_platforms:
-      - frdm_k64
+      - frdm_k64f

--- a/tests/subsys/storage/stream/stream_flash/testcase.yaml
+++ b/tests/subsys/storage/stream/stream_flash/testcase.yaml
@@ -12,5 +12,5 @@ tests:
     tags: stream_flash
   storage.stream_flash.mpu_allow_flash_write:
     extra_args: OVERLAY_CONFIG=mpu_allow_flash_write.overlay
-    platform_allow:  nrf52840_pca10056
+    platform_allow: nrf52840dk_nrf52840
     tags: stream_flash


### PR DESCRIPTION
Various obsolote and misnamed platfomrs in test filters theat went
undetected for a while.

Fixes #41222

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
