### PR TITLE
docs: Adds syscall tracing to tracing docs

### DIFF
--- a/doc/guides/debug_tools/tracing/index.rst
+++ b/doc/guides/debug_tools/tracing/index.rst
@@ -471,3 +471,8 @@ Object tracking
 ===============
 
 .. doxygengroup:: subsys_tracing_object_tracking
+
+Syscalls
+========
+
+.. doxygengroup:: subsys_tracing_apis_syscall

--- a/include/tracing/tracing_syscall.h
+++ b/include/tracing/tracing_syscall.h
@@ -32,8 +32,8 @@
  * @brief Trace syscall exit
  * @param id Syscall ID (as defined in the generated syscall_list.h)
  * @param name Syscall name as a token (ex: k_thread_create)
- * @param ... Other parameters passed to the syscall, if the syscall has a return, the return value
- *            is the last parameter in the list
+ * @param ... Other parameters passed to the syscall, if the syscall has a
+ *            return, the return value is the last parameter in the list
  */
 #define sys_port_trace_syscall_exit(id, name, ...)
 


### PR DESCRIPTION
Adds missing syscall tracing reference docs to the tracing guide