### PR TITLE
pm: device: Account state locked in action_run

### DIFF
--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -330,6 +330,7 @@ int pm_device_state_get(const struct device *dev,
  * @retval -EALREADY If device is already at the requested state.
  * @retval -EBUSY If device is changing its state.
  * @retval -ENOSYS If device does not support PM.
+ * @retval -EPERM If device has power state locked.
  * @retval Errno Other negative errno on failure.
  */
 int pm_device_action_run(const struct device *dev,

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -89,6 +89,10 @@ int pm_device_action_run(const struct device *dev,
 		return -ENOSYS;
 	}
 
+	if (pm_device_state_is_locked(dev)) {
+		return -EPERM;
+	}
+
 	switch (action) {
 	case PM_DEVICE_ACTION_FORCE_SUSPEND:
 		__fallthrough;


### PR DESCRIPTION
Similar what is done in pm_device_state_set, checking if the power
state for a given device in pm_device_action_run is locked.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>