### PR TITLE
drivers: use instance based DT macros where possible

### DIFF
--- a/drivers/counter/counter_ll_stm32_timer.c
+++ b/drivers/counter/counter_ll_stm32_timer.c
@@ -580,7 +580,7 @@ void counter_stm32_irq_handler(const struct device *dev)
 		IRQ_CONNECT(DT_IRQN(TIMER(idx)),				  \
 			    DT_IRQ(TIMER(idx), priority),			  \
 			    counter_stm32_irq_handler,				  \
-			    DEVICE_DT_GET(DT_DRV_INST(idx)),			  \
+			    DEVICE_DT_INST_GET(idx),				  \
 			    0);							  \
 		irq_enable(DT_IRQN(TIMER(idx)));				  \
 	}									  \

--- a/drivers/counter/counter_mcux_pit.c
+++ b/drivers/counter/counter_mcux_pit.c
@@ -143,7 +143,7 @@ static int mcux_pit_set_alarm(const struct device *dev, uint8_t chan_id,
 
 	uint32_t ticks = alarm_cfg->ticks;
 
-	if (chan_id != DT_PROP(DT_DRV_INST(0), pit_channel)) {
+	if (chan_id != DT_INST_PROP(0, pit_channel)) {
 		LOG_ERR("Invalid channel id");
 		return -EINVAL;
 	}
@@ -167,7 +167,7 @@ static int mcux_pit_cancel_alarm(const struct device *dev, uint8_t chan_id)
 	const struct mcux_pit_config *config = dev->config;
 	struct mcux_pit_data *data = dev->data;
 
-	if (chan_id != DT_PROP(DT_DRV_INST(0), pit_channel)) {
+	if (chan_id != DT_INST_PROP(0, pit_channel)) {
 		LOG_ERR("Invalid channel id");
 		return -EINVAL;
 	}
@@ -193,7 +193,7 @@ static int mcux_pit_init(const struct device *dev)
 	config->irq_config_func(dev);
 
 	PIT_SetTimerPeriod(config->base, config->pit_channel,
-			   USEC_TO_COUNT(DT_PROP(DT_DRV_INST(0), pit_period),
+			   USEC_TO_COUNT(DT_INST_PROP(0, pit_period),
 					 CLOCK_GetFreq(kCLOCK_BusClk)));
 
 	return 0;
@@ -225,10 +225,10 @@ static const struct mcux_pit_config mcux_pit_config_0 = {
 	.info = {
 		.max_top_value = UINT32_MAX,
 		.channels = 1,
-		.freq = DT_PROP(DT_DRV_INST(0), clock_frequency),
+		.freq = DT_INST_PROP(0, clock_frequency),
 	},
 	.base = (PIT_Type *)DT_INST_REG_ADDR(0),
-	.pit_channel = DT_PROP(DT_DRV_INST(0), pit_channel),
+	.pit_channel = DT_INST_PROP(0, pit_channel),
 	.irq_config_func = mcux_pit_irq_config_0,
 };
 

--- a/drivers/counter/counter_sam_tc.c
+++ b/drivers/counter/counter_sam_tc.c
@@ -359,7 +359,7 @@ static const struct counter_driver_api counter_sam_driver_api = {
 		DT_INST_PROP_OR(n, reg_cmr, COUNTER_SAM_TC_CMR(n))
 
 #define COUNTER_SAM_TC_INPUT_FREQUENCY(n)	\
-		COND_CODE_1(DT_PROP(DT_DRV_INST(n), nodivclk), \
+		COND_CODE_1(DT_INST_PROP(n, nodivclk), \
 			    (SOC_ATMEL_SAM_MCK_FREQ_HZ), \
 			    (sam_tc_input_freq_table[COUNTER_SAM_TC_REG_CMR(n) \
 						     & TC_CMR_TCCLKS_Msk]))

--- a/drivers/counter/rtc_mcp7940n.c
+++ b/drivers/counter/rtc_mcp7940n.c
@@ -758,7 +758,7 @@ static const struct counter_driver_api mcp7940n_api = {
 		},									\
 		.i2c_dev = DEVICE_DT_GET(DT_INST_BUS(index)),				\
 		.addr = DT_INST_REG_ADDR(index),					\
-		.int_gpios =  GPIO_DT_SPEC_GET_OR(DT_DRV_INST(index), int_gpios, {0}),	\
+		.int_gpios = GPIO_DT_SPEC_INST_GET_OR(index, int_gpios, {0}),		\
 	};										\
 											\
 	DEVICE_DT_INST_DEFINE(index, mcp7940n_init, NULL,				\

--- a/drivers/display/display_st7735r.c
+++ b/drivers/display/display_st7735r.c
@@ -541,13 +541,13 @@ static const struct display_driver_api st7735r_api = {
 		.cmd_data.pin = DT_INST_GPIO_PIN(inst, cmd_data_gpios),		\
 		.cmd_data.flags = DT_INST_GPIO_FLAGS(inst, cmd_data_gpios),	\
 		.reset.name = UTIL_AND(						\
-			DT_INST_HAS_PROP(inst, reset_gpios),			\
+			DT_INST_NODE_HAS_PROP(inst, reset_gpios),		\
 			DT_INST_GPIO_LABEL(inst, reset_gpios)),			\
 		.reset.pin = UTIL_AND(						\
-			DT_INST_HAS_PROP(inst, reset_gpios),			\
+			DT_INST_NODE_HAS_PROP(inst, reset_gpios),		\
 			DT_INST_GPIO_PIN(inst, reset_gpios)),			\
 		.reset.flags = UTIL_AND(					\
-			DT_INST_HAS_PROP(inst, reset_gpios),			\
+			DT_INST_NODE_HAS_PROP(inst, reset_gpios),		\
 			DT_INST_GPIO_FLAGS(inst, reset_gpios)),			\
 		.width = DT_INST_PROP(inst, width),				\
 		.height = DT_INST_PROP(inst, height),				\

--- a/drivers/dma/dma_mcux_edma.c
+++ b/drivers/dma/dma_mcux_edma.c
@@ -441,13 +441,13 @@ static int dma_mcux_edma_init(const struct device *dev)
 	return 0;
 }
 
-#define IRQ_CONFIG(node_id, idx, fn)					\
-	IF_ENABLED(DT_IRQ_HAS_IDX(node_id, idx), (			\
-		IRQ_CONNECT(DT_IRQ_BY_IDX(node_id, idx, irq),		\
-		DT_IRQ_BY_IDX(node_id, idx, priority),			\
+#define IRQ_CONFIG(n, idx, fn)						\
+	IF_ENABLED(DT_INST_IRQ_HAS_IDX(n, idx), (			\
+		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(n, idx, irq),		\
+		DT_INST_IRQ_BY_IDX(n, idx, priority),			\
 		fn,							\
-		DEVICE_DT_GET(node_id), 0);				\
-		irq_enable(DT_IRQ_BY_IDX(node_id, idx, irq));		\
+		DEVICE_DT_INST_GET(n), 0);				\
+		irq_enable(DT_INST_IRQ_BY_IDX(n, idx, irq));		\
 		))
 
 #define DMA_MCUX_EDMA_CONFIG_FUNC(n)					\
@@ -455,41 +455,24 @@ static int dma_mcux_edma_init(const struct device *dev)
 	{								\
 		ARG_UNUSED(dev);					\
 									\
-		IRQ_CONFIG(DT_DRV_INST(n), 0,				\
-			dma_mcux_edma_irq_handler);			\
-		IRQ_CONFIG(DT_DRV_INST(n), 1,				\
-			dma_mcux_edma_irq_handler);			\
-		IRQ_CONFIG(DT_DRV_INST(n), 2,				\
-			dma_mcux_edma_irq_handler);			\
-		IRQ_CONFIG(DT_DRV_INST(n), 3,				\
-			dma_mcux_edma_irq_handler);			\
-		IRQ_CONFIG(DT_DRV_INST(n), 4,				\
-			dma_mcux_edma_irq_handler);			\
-		IRQ_CONFIG(DT_DRV_INST(n), 5,				\
-			dma_mcux_edma_irq_handler);			\
-		IRQ_CONFIG(DT_DRV_INST(n), 6,				\
-			dma_mcux_edma_irq_handler);			\
-		IRQ_CONFIG(DT_DRV_INST(n), 7,				\
-			dma_mcux_edma_irq_handler);			\
-		IRQ_CONFIG(DT_DRV_INST(n), 8,				\
-			dma_mcux_edma_irq_handler);			\
-		IRQ_CONFIG(DT_DRV_INST(n), 9,				\
-			dma_mcux_edma_irq_handler);			\
-		IRQ_CONFIG(DT_DRV_INST(n), 10,				\
-			dma_mcux_edma_irq_handler);			\
-		IRQ_CONFIG(DT_DRV_INST(n), 11,				\
-			dma_mcux_edma_irq_handler);			\
-		IRQ_CONFIG(DT_DRV_INST(n), 12,				\
-			dma_mcux_edma_irq_handler);			\
-		IRQ_CONFIG(DT_DRV_INST(n), 13,				\
-			dma_mcux_edma_irq_handler);			\
-		IRQ_CONFIG(DT_DRV_INST(n), 14,				\
-			dma_mcux_edma_irq_handler);			\
-		IRQ_CONFIG(DT_DRV_INST(n), 15,				\
-			dma_mcux_edma_irq_handler);			\
+		IRQ_CONFIG(n, 0, dma_mcux_edma_irq_handler);		\
+		IRQ_CONFIG(n, 1, dma_mcux_edma_irq_handler);		\
+		IRQ_CONFIG(n, 2, dma_mcux_edma_irq_handler);		\
+		IRQ_CONFIG(n, 3, dma_mcux_edma_irq_handler);		\
+		IRQ_CONFIG(n, 4, dma_mcux_edma_irq_handler);		\
+		IRQ_CONFIG(n, 5, dma_mcux_edma_irq_handler);		\
+		IRQ_CONFIG(n, 6, dma_mcux_edma_irq_handler);		\
+		IRQ_CONFIG(n, 7, dma_mcux_edma_irq_handler);		\
+		IRQ_CONFIG(n, 8, dma_mcux_edma_irq_handler);		\
+		IRQ_CONFIG(n, 9, dma_mcux_edma_irq_handler);		\
+		IRQ_CONFIG(n, 10, dma_mcux_edma_irq_handler);		\
+		IRQ_CONFIG(n, 11, dma_mcux_edma_irq_handler);		\
+		IRQ_CONFIG(n, 12, dma_mcux_edma_irq_handler);		\
+		IRQ_CONFIG(n, 13, dma_mcux_edma_irq_handler);		\
+		IRQ_CONFIG(n, 14, dma_mcux_edma_irq_handler);		\
+		IRQ_CONFIG(n, 15, dma_mcux_edma_irq_handler);		\
 									\
-		IRQ_CONFIG(DT_DRV_INST(n), 16,				\
-			dma_mcux_edma_error_irq_handler);		\
+		IRQ_CONFIG(n, 16, dma_mcux_edma_error_irq_handler);	\
 									\
 		LOG_DBG("install irq done");				\
 	}

--- a/drivers/eeprom/eeprom_emulator.c
+++ b/drivers/eeprom/eeprom_emulator.c
@@ -729,7 +729,7 @@ static const struct eeprom_driver_api eeprom_emu_api = {
 	.size = eeprom_emu_size,
 };
 
-#define EEPROM_PARTITION(n) DT_PHANDLE_BY_IDX(DT_DRV_INST(n), partition, 0)
+#define EEPROM_PARTITION(n) DT_INST_PHANDLE_BY_IDX(n, partition, 0)
 
 #define PART_WBS(part) \
 	DT_PROP(COND_CODE_1(DT_NODE_HAS_COMPAT(DT_GPARENT(part), soc_nv_flash),\

--- a/drivers/ethernet/phy/phy_mii.c
+++ b/drivers/ethernet/phy/phy_mii.c
@@ -389,7 +389,7 @@ static int phy_mii_initialize(const struct device *dev)
 	return 0;
 }
 
-#define IS_FIXED_LINK(n)	DT_NODE_HAS_PROP(DT_DRV_INST(n), fixed_link)
+#define IS_FIXED_LINK(n)	DT_INST_NODE_HAS_PROP(n, fixed_link)
 
 static const struct ethphy_driver_api phy_mii_driver_api = {
 	.get_link = phy_mii_get_link_state,
@@ -401,11 +401,11 @@ static const struct ethphy_driver_api phy_mii_driver_api = {
 
 #define PHY_MII_CONFIG(n)						 \
 static const struct phy_mii_dev_config phy_mii_dev_config_##n = {	 \
-	.phy_addr = DT_PROP(DT_DRV_INST(n), address),			 \
+	.phy_addr = DT_INST_PROP(n, address),				 \
 	.fixed = IS_FIXED_LINK(n),					 \
 	.fixed_speed = DT_INST_ENUM_IDX_OR(n, fixed_link, 0),		 \
 	.mdio = UTIL_AND(UTIL_NOT(IS_FIXED_LINK(n)),			 \
-			 DEVICE_DT_GET(DT_PHANDLE(DT_DRV_INST(n), mdio)))\
+			 DEVICE_DT_GET(DT_INST_PHANDLE(n, mdio)))	 \
 };
 
 #define PHY_MII_DEVICE(n)						\

--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -67,7 +67,7 @@ BUILD_ASSERT(DT_INST_PROP(0, cpol) == DT_INST_PROP(0, cpha),
 	     "Invalid combination of \"cpol\" and \"cpha\" properties.");
 
 /* for accessing devicetree properties of the bus node */
-#define QSPI_NODE DT_BUS(DT_DRV_INST(0))
+#define QSPI_NODE DT_INST_BUS(0)
 #define QSPI_PROP_AT(prop, idx) DT_PROP_BY_IDX(QSPI_NODE, prop, idx)
 #define QSPI_PROP_LEN(prop) DT_PROP_LEN(QSPI_NODE, prop)
 

--- a/drivers/flash/spi_flash_at45.c
+++ b/drivers/flash/spi_flash_at45.c
@@ -641,20 +641,20 @@ static const struct flash_driver_api spi_flash_at45_api = {
 };
 
 #define INST_HAS_RESET_GPIO(idx) \
-	DT_NODE_HAS_PROP(DT_DRV_INST(idx), reset_gpios)
+	DT_INST_NODE_HAS_PROP(idx, reset_gpios)
 
 #define INST_RESET_GPIO_SPEC(idx)					\
 	IF_ENABLED(INST_HAS_RESET_GPIO(idx),				\
 		(static const struct gpio_dt_spec reset_##idx =	\
-		GPIO_DT_SPEC_GET(DT_DRV_INST(idx), reset_gpios);))
+		GPIO_DT_SPEC_INST_GET(idx, reset_gpios);))
 
 #define INST_HAS_WP_GPIO(idx) \
-	DT_NODE_HAS_PROP(DT_DRV_INST(idx), wp_gpios)
+	DT_INST_NODE_HAS_PROP(idx, wp_gpios)
 
 #define INST_WP_GPIO_SPEC(idx)						\
 	IF_ENABLED(INST_HAS_WP_GPIO(idx),				\
 		(static const struct gpio_dt_spec wp_##idx =		\
-		GPIO_DT_SPEC_GET(DT_DRV_INST(idx), wp_gpios);))
+		GPIO_DT_SPEC_INST_GET(idx, wp_gpios);))
 
 #define SPI_FLASH_AT45_INST(idx)					     \
 	enum {								     \

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -57,9 +57,9 @@ LOG_MODULE_REGISTER(spi_nor, CONFIG_FLASH_LOG_LEVEL);
 #define T_RES1_MS ceiling_fraction(DT_INST_PROP(0, t_exit_dpd), NSEC_PER_MSEC)
 #endif /* T_EXIT_DPD */
 #if DT_INST_NODE_HAS_PROP(0, dpd_wakeup_sequence)
-#define T_DPDD_MS ceiling_fraction(DT_PROP_BY_IDX(DT_DRV_INST(0), dpd_wakeup_sequence, 0), NSEC_PER_MSEC)
-#define T_CRDP_MS ceiling_fraction(DT_PROP_BY_IDX(DT_DRV_INST(0), dpd_wakeup_sequence, 1), NSEC_PER_MSEC)
-#define T_RDP_MS ceiling_fraction(DT_PROP_BY_IDX(DT_DRV_INST(0), dpd_wakeup_sequence, 2), NSEC_PER_MSEC)
+#define T_DPDD_MS ceiling_fraction(DT_INST_PROP_BY_IDX(0, dpd_wakeup_sequence, 0), NSEC_PER_MSEC)
+#define T_CRDP_MS ceiling_fraction(DT_INST_PROP_BY_IDX(0, dpd_wakeup_sequence, 1), NSEC_PER_MSEC)
+#define T_RDP_MS ceiling_fraction(DT_INST_PROP_BY_IDX(0, dpd_wakeup_sequence, 2), NSEC_PER_MSEC)
 #else /* DPD_WAKEUP_SEQUENCE */
 #define T_DPDD_MS 0
 #endif /* DPD_WAKEUP_SEQUENCE */

--- a/drivers/gpio/gpio_mchp_xec_v2.c
+++ b/drivers/gpio/gpio_mchp_xec_v2.c
@@ -380,12 +380,12 @@ static const struct gpio_driver_api gpio_xec_driver_api = {
 };
 
 #define XEC_GPIO_PORT_FLAGS(n)						\
-	((DT_IRQ_HAS_CELL(DT_DRV_INST(n), irq)) ? GPIO_INT_ENABLE : 0)
+	((DT_INST_IRQ_HAS_CELL(n, irq)) ? GPIO_INT_ENABLE : 0)
 
 #define XEC_GPIO_PORT(n)						\
 	static int gpio_xec_port_init_##n(const struct device *dev)	\
 	{								\
-		if (!(DT_IRQ_HAS_CELL(DT_DRV_INST(n), irq))) {		\
+		if (!(DT_INST_IRQ_HAS_CELL(n, irq))) {			\
 			return 0;					\
 		}							\
 									\

--- a/drivers/gpio/gpio_mcp230xx.c
+++ b/drivers/gpio/gpio_mcp230xx.c
@@ -85,13 +85,13 @@ static int mcp230xx_bus_is_ready(const struct device *dev)
 	static struct mcp23xxx_config mcp230xx_##inst##_config = {     \
 		.config = {					       \
 			.port_pin_mask =			       \
-				GPIO_PORT_PIN_MASK_FROM_DT_NODE(DT_DRV_INST(n)), \
+				GPIO_PORT_PIN_MASK_FROM_DT_INST(n),    \
 		},						       \
 		.bus =  \
 	{                                                                                          \
-		.i2c = I2C_DT_SPEC_GET(DT_DRV_INST(n))                                  \
+		.i2c = I2C_DT_SPEC_INST_GET(n)                                          \
 	}, \
-		.ngpios =  DT_PROP(DT_DRV_INST(n), ngpios),		       \
+		.ngpios =  DT_INST_PROP(n, ngpios),			       \
 		.read_fn = mcp230xx_read_port_regs,              \
 		.write_fn = mcp230xx_write_port_regs,              \
 		.bus_fn = mcp230xx_bus_is_ready              \

--- a/drivers/gpio/gpio_mcp23sxx.c
+++ b/drivers/gpio/gpio_mcp23sxx.c
@@ -122,8 +122,7 @@ static int mcp23sxx_bus_is_ready(const struct device *dev)
 	};                                                                                    \
 	static struct mcp23xxx_config mcp23sxx_##inst##_config = {                            \
 		.config = {					                              \
-			.port_pin_mask =			                              \
-				GPIO_PORT_PIN_MASK_FROM_DT_NODE(DT_DRV_INST(n)),              \
+			.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(n),                  \
 		},						                              \
 		.bus = {                                                                      \
 			.spi = SPI_DT_SPEC_INST_GET(n,                                        \

--- a/drivers/gpio/gpio_nct38xx_alert.c
+++ b/drivers/gpio/gpio_nct38xx_alert.c
@@ -140,7 +140,7 @@ BUILD_ASSERT(CONFIG_GPIO_NCT38XX_ALERT_INIT_PRIORITY > CONFIG_GPIO_NCT38XX_INIT_
 		.nct38xx_num = DT_INST_PROP_LEN(inst, nct38xx_dev),                                \
 	};                                                                                         \
 	static struct nct38xx_alert_data nct38xx_alert_data_##inst = {                             \
-		.alert_dev = DEVICE_DT_GET(DT_DRV_INST(inst)),                                     \
+		.alert_dev = DEVICE_DT_INST_GET(inst),                                             \
 	};                                                                                         \
 	DEVICE_DT_INST_DEFINE(inst, nct38xx_alert_init, NULL, &nct38xx_alert_data_##inst,          \
 			      &nct38xx_alert_cfg_##inst, POST_KERNEL,                              \

--- a/drivers/i2s/i2s_mcux_sai.c
+++ b/drivers/i2s/i2s_mcux_sai.c
@@ -1097,40 +1097,29 @@ static const struct i2s_driver_api i2s_mcux_driver_api = {
 									\
 	static const struct i2s_mcux_config i2s_##i2s_id##_config = {	\
 		.base = (I2S_Type *)DT_INST_REG_ADDR(i2s_id),		\
-		.clk_src =						\
-			DT_CLOCKS_CELL_BY_IDX(DT_DRV_INST(i2s_id),	\
-				0, bits),				\
+		.clk_src = DT_INST_CLOCKS_CELL_BY_IDX(i2s_id, 0, bits),	\
 		.clk_pre_div = DT_INST_PROP(i2s_id, pre_div);		\
 		.clk_src_div = DT_INST_PROP(i2s_id, podf);		\
-		.pll_src =						\
-			DT_PHA_BY_NAME(DT_DRV_INST(i2s_id),		\
-				pll_clocks, src, value),		\
-		.pll_lp =						\
-			DT_PHA_BY_NAME(DT_DRV_INST(i2s_id),		\
-				pll_clocks, lp, value),			\
-		.pll_pd =						\
-			DT_PHA_BY_NAME(DT_DRV_INST(i2s_id),		\
-				pll_clocks, pd, value),			\
-		.pll_num =						\
-			DT_PHA_BY_NAME(DT_DRV_INST(i2s_id),		\
-				pll_clocks, num, value),		\
-		.pll_den =						\
-			DT_PHA_BY_NAME(DT_DRV_INST(i2s_id),		\
-				pll_clocks, den, value),		\
-		.mclk_pin_mask =					\
-			DT_PHA_BY_IDX(DT_DRV_INST(i2s_id),		\
-				pinmuxes, 0, function),			\
-		.mclk_pin_offset =					\
-			DT_PHA_BY_IDX(DT_DRV_INST(i2s_id),		\
-				pinmuxs, 0, pin),			\
+		.pll_src = DT_INST_PHA_BY_NAME(i2s_id, pll_clocks, src, \
+					       value),			\
+		.pll_lp = DT_INST_PHA_BY_NAME(i2s_id, pll_clocks, lp,	\
+					      value),			\
+		.pll_pd = DT_INST_PHA_BY_NAME(i2s_id, pll_clocks, pd,	\
+					      value),			\
+		.pll_num = DT_INST_PHA_BY_NAME(i2s_id, pll_clocks, num, \
+					       value),			\
+		.pll_den = DT_INST_PHA_BY_NAME(i2s_id, pll_clocks, den, \
+					       value),			\
+		.mclk_pin_mask = DT_INST_PHA_BY_IDX(i2s_id, pinmuxes,	\
+						     0, function),	\
+		.mclk_pin_offset = DT_INST_PHA_BY_IDX(i2s_id, pinmuxs,	\
+						       0, pin),		\
 		.clk_sub_sys =	(clock_control_subsys_t)		\
-			DT_CLOCKS_CELL_BY_IDX(DT_DRV_INST(i2s_id),	\
-				0, name),				\
-		.ccm_dev = DEVICE_DT_GET(				\
-				DT_CLOCKS_CTLR(DT_DRV_INST(i2s_id))),	\
+			DT_INST_CLOCKS_CELL_BY_IDX(i2s_id, 0, name),	\
+		.ccm_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(i2s_id)),	\
 		.pinmux_dev = DEVICE_DT_GET(				\
-				DT_PHANDLE_BY_IDX(DT_DRV_INST(i2s_id),	\
-				pinmuxes, 0)),				\
+				DT_INST_PHANDLE_BY_IDX(i2s_id, pinmuxes,\
+						       0)),		\
 		.irq_connect = i2s_irq_connect_##i2s_id,		\
 		.tx_sync_mode =						\
 			   DT_INST_PROP(i2s_id, nxp_tx_sync_mode),	\

--- a/drivers/kscan/kscan_ite_it8xxx2.c
+++ b/drivers/kscan/kscan_ite_it8xxx2.c
@@ -556,7 +556,7 @@ static const struct kscan_it8xxx2_config kscan_it8xxx2_cfg_0 = {
 	.reg_wuesr3 = DT_INST_REG_ADDR_BY_IDX(0, 2),
 	.reg_wuenr3 = DT_INST_REG_ADDR_BY_IDX(0, 3),
 	.irq = DT_INST_IRQN(0),
-	.gpio_dev = DEVICE_DT_GET(DT_PHANDLE_BY_IDX(DT_DRV_INST(0), gpio_dev, 0)),
+	.gpio_dev = DEVICE_DT_GET(DT_INST_PHANDLE_BY_IDX(0, gpio_dev, 0)),
 	.alt_list = kscan_alt_0,
 };
 

--- a/drivers/pwm/pwm_nrf5_sw.c
+++ b/drivers/pwm/pwm_nrf5_sw.c
@@ -18,7 +18,7 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(pwm_nrf5_sw);
 
-#define GENERATOR_NODE	DT_PHANDLE(DT_DRV_INST(0), generator)
+#define GENERATOR_NODE	DT_INST_PHANDLE(0, generator)
 #define GENERATOR_CC_NUM	DT_PROP(GENERATOR_NODE, cc_num)
 
 #if DT_NODE_HAS_COMPAT(GENERATOR_NODE, nordic_nrf_rtc)

--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -668,7 +668,7 @@ replaced by 'st,prescaler' property in parent node, aka timers"
 		.timer = (TIM_TypeDef *)DT_REG_ADDR(DT_INST_PARENT(index)),    \
 		/* For compatibility reason, use pwm st_prescaler property  */ \
 		/* if exist, otherwise use parent (timers) property         */ \
-		.prescaler = DT_PROP_OR(DT_DRV_INST(index), st_prescaler,      \
+		.prescaler = DT_INST_PROP_OR(index, st_prescaler,              \
 			(DT_PROP(DT_INST_PARENT(index), st_prescaler))),       \
 		.pclken = DT_INST_CLK(index, timer),                           \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),		       \

--- a/drivers/sensor/max17262/max17262.c
+++ b/drivers/sensor/max17262/max17262.c
@@ -321,7 +321,7 @@ static const struct sensor_driver_api max17262_battery_driver_api = {
 	static struct max17262_data max17262_data_##n;			\
 									\
 	static const struct max17262_config max17262_config_##n = {	\
-		.i2c = DEVICE_DT_GET(DT_BUS(DT_DRV_INST(n))),		\
+		.i2c = DEVICE_DT_GET(DT_INST_BUS(n)),			\
 		.i2c_addr = DT_INST_REG_ADDR(n),			\
 		.design_voltage = DT_INST_PROP(n, design_voltage),	\
 		.desired_voltage = DT_INST_PROP(n, desired_voltage),	\

--- a/drivers/sensor/tmp112/tmp112.c
+++ b/drivers/sensor/tmp112/tmp112.c
@@ -202,7 +202,7 @@ int tmp112_init(const struct device *dev)
 	static struct tmp112_data tmp112_data_##inst;			    \
 	static const struct tmp112_config tmp112_config_##inst = {	    \
 		.bus = I2C_DT_SPEC_INST_GET(inst),			    \
-		.cr = DT_ENUM_IDX(DT_DRV_INST(inst), conversion_rate),	    \
+		.cr = DT_INST_ENUM_IDX(inst, conversion_rate),		    \
 		.extended_mode = DT_INST_PROP(inst, extended_mode),	    \
 	};								    \
 									    \

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -820,7 +820,7 @@ void uart_nrfx_isr(const struct device *uart)
 
 static void rx_timeout(struct k_timer *timer)
 {
-	rx_rdy_evt(DEVICE_DT_GET(DT_DRV_INST(0)));
+	rx_rdy_evt(DEVICE_DT_INST_GET(0));
 }
 
 #if HW_FLOW_CONTROL_AVAILABLE
@@ -837,7 +837,7 @@ static void tx_timeout(struct k_timer *timer)
 	evt.data.tx.len = uart0_cb.tx_buffer_length;
 	uart0_cb.tx_buffer_length = 0;
 	uart0_cb.tx_counter = 0;
-	user_callback(DEVICE_DT_GET(DT_DRV_INST(0)), &evt);
+	user_callback(DEVICE_DT_INST_GET(0), &evt);
 }
 #endif
 
@@ -1093,7 +1093,7 @@ static int uart_nrfx_init(const struct device *dev)
 	IRQ_CONNECT(IRQN,
 		    IRQ_PRIO,
 		    uart_nrfx_isr,
-		    DEVICE_DT_GET(DT_DRV_INST(0)),
+		    DEVICE_DT_INST_GET(0),
 		    0);
 	irq_enable(IRQN);
 #endif

--- a/drivers/serial/usart_gd32.c
+++ b/drivers/serial/usart_gd32.c
@@ -317,8 +317,7 @@ static const struct uart_driver_api usart_gd32_driver_api = {
 		.reg = DT_INST_REG_ADDR(n),					\
 		.rcu_periph_clock = DT_INST_PROP(n, rcu_periph_clock),		\
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),			\
-		.parity = DT_ENUM_IDX_OR(DT_DRV_INST(n), parity,		\
-					 UART_CFG_PARITY_NONE),			\
+		.parity = DT_INST_ENUM_IDX_OR(n, parity, UART_CFG_PARITY_NONE),	\
 		 GD32_USART_IRQ_HANDLER_FUNC_INIT(n)				\
 	};									\
 	DEVICE_DT_INST_DEFINE(n, &usart_gd32_init,				\

--- a/drivers/syscon/syscon.c
+++ b/drivers/syscon/syscon.c
@@ -138,7 +138,7 @@ static int syscon_generic_init(const struct device *dev)
 		.reg_width = DT_INST_PROP_OR(inst, reg_io_width, 4),                               \
 	};                                                                                         \
 	static struct syscon_generic_data syscon_generic_data_##inst = {                           \
-		.size = DT_REG_SIZE(DT_DRV_INST(inst)),                                            \
+		.size = DT_INST_REG_SIZE(inst),                                                    \
 	};                                                                                         \
 	DEVICE_DT_INST_DEFINE(inst, syscon_generic_init, NULL, &syscon_generic_data_##inst,        \
 			      &syscon_generic_config_##inst, PRE_KERNEL_1,                         \

--- a/drivers/wifi/esp_at/esp.h
+++ b/drivers/wifi/esp_at/esp.h
@@ -59,7 +59,7 @@ extern "C" {
 #define ESP_PROTO_PASSIVE(proto) 0
 #endif /* CONFIG_WIFI_ESP_AT_PASSIVE_MODE */
 
-#define ESP_BUS DT_BUS(DT_DRV_INST(0))
+#define ESP_BUS DT_INST_BUS(0)
 
 #if DT_PROP(ESP_BUS, hw_flow_control) == 1
 #define _FLOW_CONTROL "3"


### PR DESCRIPTION
Replace usage of node based macros combined with `DT_DRV_INST(n)` with the instance based macros when available.
074a5a9 fixes usage of a non-existing macro.

Note: if preferred I can squash all commits together.