### PR TITLE
soc: mimxrt11xx: Fix CAN peripheral for RT11xx

### DIFF
--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -723,7 +723,7 @@
 			interrupts = <44 0>, <45 0>;
 			interrupt-names = "common", "error";
 			clocks = <&ccm IMX_CCM_CAN1_CLK 0x68 14>;
-			clk-source = <2>;
+			clk-source = <0>;
 			label = "CAN_1";
 			sjw = <1>;
 			sample-point = <875>;
@@ -738,7 +738,7 @@
 			interrupts = <46 0>, <47 0>;
 			interrupt-names = "common", "error";
 			clocks = <&ccm IMX_CCM_CAN2_CLK 0x68 18>;
-			clk-source = <2>;
+			clk-source = <0>;
 			label = "CAN_2";
 			sjw = <1>;
 			sample-point = <875>;
@@ -753,7 +753,7 @@
 			interrupts = <48 0>, <49 0>;
 			interrupt-names = "common", "error";
 			clocks = <&ccm IMX_CCM_CAN3_CLK 0x84 6>;
-			clk-source = <2>;
+			clk-source = <0>;
 			label = "CAN_3";
 			sjw = <1>;
 			sample-point = <875>;

--- a/soc/arm/nxp_imx/rt/soc_rt11xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt11xx.c
@@ -367,10 +367,18 @@ static ALWAYS_INLINE void clock_init(void)
 #endif
 
 #ifdef CONFIG_CAN_MCUX_FLEXCAN
-	/* Configure CAN3 using OSC_RC_400M */
-	rootCfg.mux = kCLOCK_CAN3_ClockRoot_MuxOscRc400M;
-	rootCfg.div = 5;
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(flexcan1), okay)
+	/* Configure CAN1 using Osc48MDiv2 */
+	rootCfg.mux = kCLOCK_CAN1_ClockRoot_MuxOscRc48MDiv2;
+	rootCfg.div = 1;
+	CLOCK_SetRootClock(kCLOCK_Root_Can1, &rootCfg);
+#endif
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(flexcan3), okay)
+	/* Configure CAN1 using Osc48MDiv2 */
+	rootCfg.mux = kCLOCK_CAN3_ClockRoot_MuxOscRc48MDiv2;
+	rootCfg.div = 1;
 	CLOCK_SetRootClock(kCLOCK_Root_Can3, &rootCfg);
+#endif
 #endif
 
 #ifdef CONFIG_COUNTER_MCUX_GPT


### PR DESCRIPTION
RT11xx CAN peripheral had incorrect clocking configuration in SOC clock
init code and DTS. Fix peripheral to run at 24MHz clock, and provide the correct clock source setting to the FLEXCAN driver

This PR also enables FLEXCAN1, provided that the user sets `status="okay"`, and selects the output pins in `pinmux.c` for their custom board

Fixes #41251

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>