### PR TITLE
dts: arm: npcx: Fix GPIOE3 low voltage control map

### DIFF
--- a/dts/arm/nuvoton/npcx/npcx-lvol-ctrl-map.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx-lvol-ctrl-map.dtsi
@@ -113,8 +113,8 @@
 		lvol_ioe4: lvol46 {
 			lvols = <&scfg 0x0e 4 4 6>;
 		};
-		lvol_ioe6: lvol47 {
-			lvols = <&scfg 0x0e 6 4 7>;
+		lvol_ioe3: lvol47 {
+			lvols = <&scfg 0x0e 3 4 7>;
 		};
 
 		/* Low-Voltage IO Control 5 */


### PR DESCRIPTION
NPCX series used npcx-lvol-ctrl-map to record the GPIO & low voltage
control register map. However, GPIOE3 was configured as GPIOE6, which
is a non-existed pin. This commit fixes the GPIOE3 low voltage control
map.

Signed-off-by: Wealian Liao <WHLIAO@nuvoton.com>