### PR TITLE
CODEOWNER: Add LingaoM for bluetooth mesh stack

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -668,7 +668,7 @@
 /subsys/bluetooth/                        @alwa-nordic @jhedberg @Vudentz
 /subsys/bluetooth/audio/                  @alwa-nordic @jhedberg @Vudentz @Thalley @asbjornsabo
 /subsys/bluetooth/controller/             @carlescufi @cvinayak @thoh-ot @kruithofa
-/subsys/bluetooth/mesh/                   @jhedberg @trond-snekvik @alwa-nordic @Vudentz
+/subsys/bluetooth/mesh/                   @jhedberg @trond-snekvik @alwa-nordic @Vudentz @LingaoM
 /subsys/canbus/                           @alexanderwachter
 /subsys/cpp/                              @vanwinkeljan
 /subsys/debug/                            @nashif


### PR DESCRIPTION
Add myself as codeowner for bluetooth mesh subsystem.

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>