### PR TITLE
boards: b_u585i_iot02a: Leds are active low

### DIFF
--- a/boards/arm/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
+++ b/boards/arm/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
@@ -12,11 +12,11 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led_1: led_1 {
-			gpios = <&gpioh 7 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpioh 7 GPIO_ACTIVE_LOW>;
 			label = "User LD7";
 		};
 		red_led_1: led_3 {
-			gpios = <&gpioh 6 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpioh 6 GPIO_ACTIVE_LOW>;
 			label = "User LD6";
 		};
 	};


### PR DESCRIPTION
Fix dts leds configuration for this board as they actually light up
active when pin is set to 0.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>