### PR TITLE
dts/bindings: lps22hh: Fix the odr property description

### DIFF
--- a/dts/bindings/sensor/st,lps22hh-common.yaml
+++ b/dts/bindings/sensor/st,lps22hh-common.yaml
@@ -18,7 +18,7 @@ properties:
       default: 0
       description: |
           Specify the default output data rate expressed in samples per second (Hz).
-          Default is power-down mode
+          The default is the power-on reset value.
       enum:
         - 0  # Power-Down
         - 1  # 1Hz


### PR DESCRIPTION
The dts properties description policy states that the default
value should be justified (e.g. configuration at power-up).
Addresses comment in #41143

Signed-off-by: Armando Visconti <armando.visconti@st.com>