### PR TITLE
manifest: mcuboot update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -168,7 +168,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 33906b472a6c0ed4e2ca3520eb4eed1db40c6018
+      revision: 399720d1cabd26c4356445d351f263b31e942961
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Synch up to upstream:
https://github.com/mcu-tools/mcuboot/commit/1eedec3e7936f74872aca43f3962246e7abe6439

- fixed the build issue caused by removal of CONFIG_SYSTEM_CLOCK_DISABLE
property (within drivers: timer: implementation cleanups #37435)
- always call sys_clock_disable() in main since the empty
sys_clock_disable() callback is provided if the platform doesn't
support system clock disable capability.
- bootutil: Close flash_area after failure to read swap status information
- fixed status offset calculation in case of scratch area

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>