### PR TITLE
drivers: lora: shell: fix 'long' specifier in shell_error()

### DIFF
--- a/drivers/lora/shell.c
+++ b/drivers/lora/shell.c
@@ -176,7 +176,7 @@ static int lora_conf_set(const struct shell *shell, const char *param,
 			modem_config.bandwidth = BW_500_KHZ;
 			break;
 		default:
-			shell_error(shell, "Invalid bandwidth: %s", lval);
+			shell_error(shell, "Invalid bandwidth: %ld", lval);
 			return -EINVAL;
 		}
 	} else if (!strcmp("sf", param)) {


### PR DESCRIPTION
Replace '%s' with '%ld', so that 'long' value is properly printed with
shell_error(). This suppresses following warning:

```
  zephyr/drivers/lora/shell.c:181:23: warning: format '%s' expects \
      argument of type 'char *', but argument 4 has type 'long int' \
      [-Wformat=]
    181 |    shell_error(shell, "Invalid bandwidth: %s", lval);
        |                       ^~~~~~~~~~~~~~~~~~~~~~~  ~~~~
        |                                                |
        |                                                long int
```