### PR TITLE
modules: hal_nordic: Update nrfx to version 2.7.0

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -88,7 +88,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 077031bf6eaac5352e304ad0f1a0c5b16b4dd115
+      revision: f6b23344f6bdfb490ac7d038344174a99fa75d45
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Update the hal_nordic module revision, to switch to nrfx v2.7.0.

nrfx 2.7.0 includes the option to skip GPIO and PSEL register
configuration which is needed for aligning shims with pinctrl.

Signed-off-by: Nikodem Kastelik <nikodem.kastelik@nordicsemi.no>