### PR TITLE
drivers: spi: stm32 spi driver using ll_func as defined in the header

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -757,11 +757,11 @@ static int transceive_dma(const struct device *dev,
 #endif
 
 		/* wait until TX buffer is really empty */
-		while (LL_SPI_IsActiveFlag_TXE(spi) == 0) {
+		while (ll_func_tx_is_empty(spi) == 0) {
 		}
 
 		/* wait until hardware is really ready */
-		while (LL_SPI_IsActiveFlag_BSY(spi) == 1) {
+		while (ll_func_spi_is_busy(spi) == 1) {
 		}
 
 		LL_SPI_DisableDMAReq_TX(spi);


### PR DESCRIPTION
Instead of checking the SPI register flags, the spi_ll_stm32.h
has dedicated functions for that purpose.
They are abstracting the STM32 registers of SPI instance.

Signed-off-by: Francois Ramu <francois.ramu@st.com>