### PR TITLE
libc: newlibc: Fix recursive gettimeofday() calls on non-Posix systems

### DIFF
--- a/lib/libc/newlib/libc-hooks.c
+++ b/lib/libc/newlib/libc-hooks.c
@@ -552,5 +552,12 @@ void *_sbrk_r(struct _reent *r, int count)
 
 int _gettimeofday(struct timeval *__tp, void *__tzp)
 {
+#ifdef CONFIG_POSIX_API
 	return gettimeofday(__tp, __tzp);
+#else
+	/* Non-posix systems should not call gettimeofday() here as it will
+	 * result in a recursive call loop and result in a stack overflow.
+	 */
+	return -1;
+#endif
 }


### PR DESCRIPTION
Calling gettimeofday() from _gettimeofday() in a non-Posix build
environment can result in a recursive call loop, causing a stack
overflow. Modify _gettimeofday() to return -1 for non-posix systems
(the previous behaviour that was added in #22508).

Fixes #41095

Signed-off-by: Binu Jacob <bjj@planetinnovation.com.au>