### PR TITLE
logging: Add MIPI sys-t support for v2 logging subsystem.

### DIFF
--- a/samples/subsys/logging/syst/sample.yaml
+++ b/samples/subsys/logging/syst/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: syst sample
 tests:
-  sample.logger.syst:
+  sample.logger.syst.v1:
     platform_allow: mps2_an385 sam_e70_xplained
     tags: logging
     harness: console
@@ -9,3 +9,13 @@ tests:
       type: one_line
       regex:
         - "SYS-T RAW DATA: "
+  sample.logger.syst.v2.deferred:
+    platform_allow: mps2_an385 sam_e70_xplained
+    tags: logging
+    harness: console
+    harness_config:
+      type: one_line
+      regex:
+        - "SYS-T RAW DATA: "
+    extra_configs:
+      - CONFIG_LOG2_MODE_DEFERRED=y

--- a/samples/subsys/logging/syst/src/main.c
+++ b/samples/subsys/logging/syst/src/main.c
@@ -34,12 +34,13 @@ void main(void)
 	struct test_frame frame = { 0 };
 	const uint8_t data[DATA_MAX_DLEN] = { 0x01, 0x02, 0x03, 0x04,
 					0x05, 0x06, 0x07, 0x08 };
+#ifndef CONFIG_LOG2
 	struct log_msg_ids src_level = {
 		.level = LOG_LEVEL_INTERNAL_RAW_STRING,
 		.source_id = 0, /* not used as level indicates raw string. */
 		.domain_id = 0, /* not used as level indicates raw string. */
 	};
-
+#endif
 
 	/* standard print */
 	LOG_ERR("Error message example.");
@@ -51,6 +52,10 @@ void main(void)
 	LOG_DBG("Debug message example, %d, %d", 1, 2);
 	LOG_DBG("Debug message example, %d, %d, %d", 1, 2, 3);
 	LOG_DBG("Debug message example, %d, %d, %d, 0x%x", 1, 2, 3, 4);
+
+#ifdef CONFIG_LOG2
+	LOG_DBG("Debug message example, %f", 3.14159265359);
+#endif
 
 	/* hexdump */
 	frame.rtr = 1U;
@@ -67,6 +72,9 @@ void main(void)
 	/* raw string */
 	printk("hello sys-t on board %s\n", CONFIG_BOARD);
 
+#ifndef CONFIG_LOG2
 	/* log output string */
 	log_string_sync(src_level, "%s", "log string sync");
+#endif
+
 }

--- a/subsys/logging/log_backend_rtt.c
+++ b/subsys/logging/log_backend_rtt.c
@@ -320,6 +320,8 @@ static void process(const struct log_backend *const backend,
 {
 	uint32_t flags = log_backend_std_get_flags();
 
+	flags |= IS_ENABLED(CONFIG_LOG_BACKEND_RTT_SYST_ENABLE) ? LOG_OUTPUT_FLAG_FORMAT_SYST : 0;
+
 	log_output_msg2_process(&log_output_rtt, &msg->log, flags);
 }
 

--- a/subsys/logging/log_backend_swo.c
+++ b/subsys/logging/log_backend_swo.c
@@ -87,6 +87,8 @@ static void log_backend_swo_process(const struct log_backend *const backend,
 {
 	uint32_t flags = log_backend_std_get_flags();
 
+	flags |= IS_ENABLED(CONFIG_LOG_BACKEND_SWO_SYST_ENABLE) ? LOG_OUTPUT_FLAG_FORMAT_SYST : 0;
+
 	log_output_msg2_process(&log_output_swo, &msg->log, flags);
 }
 

--- a/subsys/logging/log_backend_uart.c
+++ b/subsys/logging/log_backend_uart.c
@@ -103,6 +103,8 @@ static void process(const struct log_backend *const backend,
 {
 	uint32_t flags = log_backend_std_get_flags();
 
+	flags |= IS_ENABLED(CONFIG_LOG_BACKEND_UART_SYST_ENABLE) ? LOG_OUTPUT_FLAG_FORMAT_SYST : 0;
+
 	if (IS_ENABLED(CONFIG_LOG_BACKEND_UART_OUTPUT_DICTIONARY)) {
 		log_dict_output_msg2_process(&log_output_uart,
 					     &msg->log, flags);

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -48,6 +48,8 @@ static uint32_t timestamp_div;
 
 extern void log_output_msg_syst_process(const struct log_output *output,
 				struct log_msg *msg, uint32_t flag);
+extern void log_output_msg2_syst_process(const struct log_output *output,
+				struct log_msg2 *msg, uint32_t flag);
 extern void log_output_string_syst_process(const struct log_output *output,
 				struct log_msg_ids src_level,
 				const char *fmt, va_list ap, uint32_t flag);
@@ -589,10 +591,7 @@ void log_output_msg2_process(const struct log_output *output,
 
 	if (IS_ENABLED(CONFIG_LOG_MIPI_SYST_ENABLE) &&
 	    flags & LOG_OUTPUT_FLAG_FORMAT_SYST) {
-		__ASSERT_NO_MSG(0);
-		/* todo not supported
-		 * log_output_msg_syst_process(output, msg, flags);
-		 */
+		log_output_msg2_syst_process(output, msg, flags);
 		return;
 	}
 

--- a/west.yml
+++ b/west.yml
@@ -174,7 +174,7 @@ manifest:
       path: modules/debug/mipi-sys-t
       groups:
         - debug
-      revision: 75e671550ac1acb502f315fe4952514dc73f7bfb
+      revision: d9da086b11cda494d85f4d8a9829f505c2d5e380
     - name: nanopb
       revision: d148bd26718e4c10414f07a7eb1bd24c62e56c5d
       path: modules/lib/nanopb


### PR DESCRIPTION
Adding functions log_output_msg2_syst_process and hexdump2_print
to support v2 logging subsystem.

Updates west.yml to pick up a new version of the MIPI sys-t library that
supports vprintf.

Signed-off-by: Aastha Grover <aastha.grover@intel.com>
Signed-off-by: Maureen Helm <maureen.helm@intel.com>

Based on #39975 with the following changes:
- Rebased to latest main
- Added vprintf support to the MIPI sys-t library
- Replaced hardcoded printf calls up to 15 arguments with a single call to vprintf
- Updated the sample to print a floating point value when v2 logging is enabled

Tested on `mps2_an385`


```diff
diff --git a/subsys/logging/log_output_syst.c b/subsys/logging/log_output_syst.c
index fedb0e3543..957c4cad5d 100644
--- a/subsys/logging/log_output_syst.c
+++ b/subsys/logging/log_output_syst.c
@@ -712,14 +712,10 @@ void log_output_msg2_syst_process(const struct log_output *output,
        if (len && !hexdump_len) {
 
                char *buf = data, *fmt;
-               unsigned int args_size;
 
                fmt = ((char **)buf)[1];
-               args_size = ((((uint8_t *)buf)[0] * sizeof(int))/4)-2;
                buf += sizeof(char *) * 2;
 
-               uint32_t *args = args_size ? alloca(sizeof(uint32_t)*args_size) : NULL;
-
                union {
                        va_list ap;
                        void *ptr;
@@ -727,92 +723,7 @@ void log_output_msg2_syst_process(const struct log_output *output,
 
                u.ptr = buf;
 
-               for (uint8_t i = 0; i < args_size; i++) {
-                       args[i] = va_arg(u.ap, int);
-               }
-
-               switch (args_size) {
-               case 0:
-                       MIPI_SYST_PRINTF(&log_syst_handle, severity, fmt);
-                       break;
-               case 1:
-                       MIPI_SYST_PRINTF(&log_syst_handle, severity, fmt, args[0]);
-                       break;
-               case 2:
-                       MIPI_SYST_PRINTF(&log_syst_handle, severity, fmt, args[0],
-                                       args[1]);
-                       break;
-               case 3:
-                       MIPI_SYST_PRINTF(&log_syst_handle, severity, fmt, args[0],
-                                       args[1], args[2]);
-                       break;
-               case 4:
-                       MIPI_SYST_PRINTF(&log_syst_handle, severity, fmt, args[0],
-                                       args[1], args[2], args[3]);
-                       break;
-               case 5:
-                       MIPI_SYST_PRINTF(&log_syst_handle, severity, fmt, args[0],
-                                       args[1], args[2], args[3], args[4]);
-                       break;
-               case 6:
-                       MIPI_SYST_PRINTF(&log_syst_handle, severity, fmt, args[0],
-                               args[1], args[2], args[3], args[4], args[5]);
-                       break;
-               case 7:
-                       MIPI_SYST_PRINTF(&log_syst_handle, severity, fmt, args[0],
-                                       args[1], args[2], args[3], args[4], args[5],
-                                       args[6]);
-                       break;
-               case 8:
-                       MIPI_SYST_PRINTF(&log_syst_handle, severity, fmt, args[0],
-                                       args[1], args[2], args[3], args[4], args[5],
-                                       args[6], args[7]);
-                       break;
-               case 9:
-                       MIPI_SYST_PRINTF(&log_syst_handle, severity, fmt, args[0],
-                                       args[1], args[2], args[3], args[4], args[5],
-                                       args[6], args[7], args[8]);
-                       break;
-               case 10:
-                       MIPI_SYST_PRINTF(&log_syst_handle, severity, fmt, args[0],
-                                       args[1], args[2], args[3], args[4], args[5],
-                                       args[6], args[7], args[8], args[9]);
-                       break;
-               case 11:
-                       MIPI_SYST_PRINTF(&log_syst_handle, severity, fmt, args[0],
-                                       args[1], args[2], args[3], args[4], args[5],
-                                       args[6], args[7], args[8], args[9], args[10]);
-                       break;
-               case 12:
-                       MIPI_SYST_PRINTF(&log_syst_handle, severity, fmt, args[0],
-                                       args[1], args[2], args[3], args[4], args[5],
-                                       args[6], args[7], args[8], args[9], args[10],
-                                       args[11]);
-                       break;
-               case 13:
-                       MIPI_SYST_PRINTF(&log_syst_handle, severity, fmt, args[0],
-                                       args[1], args[2], args[3], args[4], args[5],
-                                       args[6], args[7], args[8], args[9], args[10],
-                                       args[11], args[12]);
-                       break;
-               case 14:
-                       MIPI_SYST_PRINTF(&log_syst_handle, severity, fmt, args[0],
-                                       args[1], args[2], args[3], args[4], args[5],
-                                       args[6], args[7], args[8], args[9], args[10],
-                                       args[11], args[12], args[13]);
-                       break;
-               case 15:
-                       MIPI_SYST_PRINTF(&log_syst_handle, severity, fmt, args[0],
-                                       args[1], args[2], args[3], args[4], args[5],
-                                       args[6], args[7], args[8], args[9], args[10],
-                                       args[11], args[12], args[13], args[14]);
-                       break;
-               default:
-                       /* Unsupported number of arguments. */
-                       __ASSERT_NO_MSG(true);
-                       break;
-               }
-
+               MIPI_SYST_VPRINTF(&log_syst_handle, severity, fmt, u.ap);
        }
 
        if (hexdump_len) {
```