### PR TITLE
boards: Fix arduino_nano_33_ble PCB initialization problem

### DIFF
--- a/boards/arm/arduino_nano_33_ble/src/init_sensors.c
+++ b/boards/arm/arduino_nano_33_ble/src/init_sensors.c
@@ -7,6 +7,8 @@
 #include <init.h>
 #include <arduino_nano_33_ble.h>
 
+#define ARDUINO_SENSOR_INIT_PRIORITY 50
+
 /*
  * this method roughly follows the steps here:
  * https://github.com/arduino/ArduinoCore-nRF528x-mbedos/blob/6216632cc70271619ad43547c804dabb4afa4a00/variants/ARDUINO_NANO33BLE/variant.cpp#L136
@@ -51,4 +53,4 @@ static int board_internal_sensors_init(const struct device *dev)
 	arduino_gpio_digitalWrite(&gpios, ARDUINO_INTERNAL_I2C_PULLUP, 1);
 	return 0;
 }
-SYS_INIT(board_internal_sensors_init, PRE_KERNEL_1, 32);
+SYS_INIT(board_internal_sensors_init, POST_KERNEL, ARDUINO_SENSOR_INIT_PRIORITY);


### PR DESCRIPTION
The board_internal_sensors_init function was called erlier than the GPIO
driver was initialized. This commit fixes the issue.

Signed-off-by: Przemyslaw Bida <przemyslaw.bida@nordicsemi.no>