### PR TITLE
soc: xtensa: cavs-link.ld: add *(.trace_ctx) sections

### DIFF
--- a/soc/xtensa/intel_s1000/linker.ld
+++ b/soc/xtensa/intel_s1000/linker.ld
@@ -412,6 +412,9 @@ SECTIONS
     *(.sdata2.*)
     *(.gnu.linkonce.s2.*)
     KEEP(*(.jcr))
+    _trace_ctx_start = ABSOLUTE(.);
+    *(.trace_ctx)
+    _trace_ctx_end = ABSOLUTE(.);
     . = ALIGN(4096);
     *(.gna_model)
     _data_end = ABSOLUTE(.);

--- a/soc/xtensa/nxp_adsp/imx8/linker.ld
+++ b/soc/xtensa/nxp_adsp/imx8/linker.ld
@@ -390,6 +390,9 @@ SECTIONS
     *(.sdata2.*)
     *(.gnu.linkonce.s2.*)
     KEEP(*(.jcr))
+    _trace_ctx_start = ABSOLUTE(.);
+    *(.trace_ctx)
+    _trace_ctx_end = ABSOLUTE(.);
     . = ALIGN(4);
     *(.gna_model)
     _data_end = ABSOLUTE(.);

--- a/soc/xtensa/nxp_adsp/imx8m/linker.ld
+++ b/soc/xtensa/nxp_adsp/imx8m/linker.ld
@@ -390,6 +390,9 @@ SECTIONS
     *(.sdata2.*)
     *(.gnu.linkonce.s2.*)
     KEEP(*(.jcr))
+    _trace_ctx_start = ABSOLUTE(.);
+    *(.trace_ctx)
+    _trace_ctx_end = ABSOLUTE(.);
     . = ALIGN(4);
     *(.gna_model)
     _data_end = ABSOLUTE(.);


### PR DESCRIPTION
Copy/paste/diverge struck again; I should have known better.

Fixes very recent and incomplete commit 9a1c5ec78eac ("soc/intel_adsp:
cavs-link.ld: add *(.trace_ctx) sections"), see that commit for details.

Part of the fix for thesofproject/sof/issues/5032

This commit does not change `soc/xtensa/sample_controller/linker.ld`

Signed-off-by: Marc Herbert <marc.herbert@intel.com>