### PR TITLE
drivers: gpio: nrfx: Use mask to determine if sense is used

### DIFF
--- a/drivers/gpio/Kconfig.nrfx
+++ b/drivers/gpio/Kconfig.nrfx
@@ -1,42 +1,10 @@
 # Copyright (c) 2018 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig GPIO_NRFX
+config GPIO_NRFX
 	bool "nRF GPIO driver"
 	default y
 	depends on SOC_FAMILY_NRF
 	select NRFX_GPIOTE
 	help
 	  Enable GPIO driver for nRF line of MCUs.
-
-if GPIO_NRFX
-
-choice
-	prompt "nRF GPIO edge interrupts mechanism"
-	default GPIO_NRF_INT_EDGE_USING_GPIOTE
-
-config GPIO_NRF_INT_EDGE_USING_GPIOTE
-	bool "Edge interrupts using GPIOTE"
-	help
-	  Enable GPIO edge interrupts implementation using GPIOTE events.
-
-config GPIO_NRF_INT_EDGE_USING_SENSE
-	bool "Edge interrupts using SENSE"
-	help
-	  Enable GPIO edge interrupts implementation using GPIO SENSE, which is
-	  a level interrupt mechanism. Conversion from level to edge interrupts
-	  notification happens in GPIO driver, so it is transparent to GPIO
-	  consumers after switching from GPIOTE mechanism.
-
-	  Use this option as an alternative to GPIOTE event mechanism. According
-	  to product specifications and erratas to some nRF MCUs, using GPIOTE
-	  results in increased current consumption in System ON Idle and in
-	  conjunction with SPI/TWI peripherals. Selecting this option allows to
-	  reduce current for those cases.
-
-	  Using this option additionally allows detecting state changes of pins
-	  configured as output, which might be handy for some applications.
-
-endchoice
-
-endif # GPIO_NRFX

--- a/dts/bindings/gpio/nordic,nrf-gpio.yaml
+++ b/dts/bindings/gpio/nordic,nrf-gpio.yaml
@@ -17,6 +17,13 @@ properties:
     "#gpio-cells":
       const: 2
 
+    sense-edge-mask:
+      required: false
+      type: int
+      description: |
+        Mask of pins that use the GPIO sense mechanism for edge detection.
+        Pins not included in the mask use GPIOTE channels in the event mode.
+
     port:
       type: int
       required: true

--- a/tests/drivers/gpio/gpio_basic_api/boards/nrf52840dk_nrf52840_sense_edge.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nrf52840dk_nrf52840_sense_edge.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&gpio1 {
+	sense-edge-mask = <0x6>;
+};

--- a/tests/drivers/gpio/gpio_basic_api/testcase.yaml
+++ b/tests/drivers/gpio/gpio_basic_api/testcase.yaml
@@ -1,9 +1,16 @@
-tests:
-  drivers.gpio.2pin:
+common:
     tags: drivers gpio
     depends_on: gpio
-    min_flash: 34
-    filter: dt_compat_enabled("test-gpio-basic-api")
     harness: ztest
     harness_config:
       fixture: gpio_loopback
+
+tests:
+  drivers.gpio.2pin:
+    min_flash: 34
+    filter: dt_compat_enabled("test-gpio-basic-api")
+
+  drivers.gpio.nrf_sense_edge:
+    platform_allow: nrf52840dk_nrf52840
+    extra_args: "DTC_OVERLAY_FILE=boards/nrf52840dk_nrf52840.overlay;\
+                 boards/nrf52840dk_nrf52840_sense_edge.overlay"


### PR DESCRIPTION
#31823 added configuration to use sense mechanism for edge interrupts but solution that was used back then was for all or none. It was already raised back then that per-pin solution is needed (https://github.com/zephyrproject-rtos/zephyr/pull/31823#pullrequestreview-608657733).

This PR do this by adding device tree mask which can be used to configure which pins will use sensing for edge interrupts. Added test configuration to validate that.

Maybe there is a way to have it more user friendly by allowing per-pin configuration in device tree instead of mask. Any device tree experts suggestions are welcomed.