### PR TITLE
STM32: ADC: Fix Calibration on L5 series

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -592,7 +592,16 @@ static int start_read(const struct device *dev,
 	!defined(CONFIG_SOC_SERIES_STM32F1X) && \
 	!defined(STM32F3X_ADC_V2_5) && \
 	!defined(CONFIG_SOC_SERIES_STM32L1X)
+#if defined(CONFIG_SOC_SERIES_STM32L5X)
+		/* Calibration can only be initiated when the ADC is disabled */
+		LL_ADC_Disable(adc);
+		while (LL_ADC_IsEnabled(adc) == 1UL) {
+		}
+#endif
 		adc_stm32_calib(dev);
+#if defined(CONFIG_SOC_SERIES_STM32L5X)
+		LL_ADC_Enable(adc);
+#endif
 #else
 		LOG_ERR("Calibration not supported");
 		return -ENOTSUP;


### PR DESCRIPTION
When calibration is done with a STM32L5 ADC, you can get in an
endless loop in adc_stm32_calib:LL_ADC_IsCalibrationOnGoing(adc)
which is waiting for calibration to finish. This bug happens when the
adc sequence requests an calibration. According to the datasheet
of the L5 series, the ADC needs to be disabled before calibration
can be started. This commit is fixing it for the L5 series.

This has been tested with the
stm32_temp sensor, which requests a calibration the first time.

Signed-off-by: Wouter Cappelle <wouter.cappelle@crodeon.com>