### PR TITLE
sensors: STM32: Add support for L5 die temp sensor

### DIFF
--- a/drivers/sensor/stm32_temp/stm32_temp.c
+++ b/drivers/sensor/stm32_temp/stm32_temp.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Eug Krashtan
+ * Copyright (c) 2022 Wouter Cappelle
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,7 +12,15 @@
 
 LOG_MODULE_REGISTER(stm32_temp, CONFIG_SENSOR_LOG_LEVEL);
 
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_temp)
 #define DT_DRV_COMPAT st_stm32_temp
+#define HAS_CALIBRATION 0
+#elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_temp_cal)
+#define DT_DRV_COMPAT st_stm32_temp_cal
+#define HAS_CALIBRATION 1
+#else
+#error "No compatible devicetree node found"
+#endif
 
 struct stm32_temp_data {
 	const struct device *adc;
@@ -24,10 +33,19 @@ struct stm32_temp_data {
 };
 
 struct stm32_temp_config {
+	int tsv_mv;
+#if HAS_CALIBRATION
+	uint16_t *cal1_addr;
+	uint16_t *cal2_addr;
+	int cal1_temp;
+	int cal2_temp;
+	int cal_vrefanalog;
+	int cal_offset;
+#else
 	int avgslope;
 	int v25_mv;
-	int tsv_mv;
 	bool is_ntc;
+#endif
 };
 
 static int stm32_temp_sample_fetch(const struct device *dev, enum sensor_channel chan)
@@ -64,6 +82,13 @@ static int stm32_temp_channel_get(const struct device *dev, enum sensor_channel 
 		return -ENOTSUP;
 	}
 
+#if HAS_CALIBRATION
+	temp = ((float)data->raw * cfg->tsv_mv) / cfg->cal_vrefanalog;
+	temp -= *cfg->cal1_addr;
+	temp *= (cfg->cal2_temp - cfg->cal1_temp);
+	temp /= (*cfg->cal2_addr - *cfg->cal1_addr);
+	temp += cfg->cal_offset;
+#else
 	int32_t mv = data->raw * cfg->tsv_mv / 0x0FFF; /* Sensor value in millivolts */
 
 	if (cfg->is_ntc) {
@@ -73,6 +98,8 @@ static int stm32_temp_channel_get(const struct device *dev, enum sensor_channel 
 	}
 	temp = (temp / cfg->avgslope) * 10;
 	temp += 25;
+#endif
+
 	sensor_value_from_double(val, temp);
 
 	return 0;
@@ -116,19 +143,26 @@ static int stm32_temp_init(const struct device *dev)
 	return 0;
 }
 
-#define STM32_TEMP_INST(idx)                                                                       \
-	static struct stm32_temp_data inst_##idx##_data = {                                        \
-		.adc = DEVICE_DT_GET(DT_IO_CHANNELS_CTLR(DT_INST(idx, st_stm32_temp))),            \
-		.channel = DT_IO_CHANNELS_INPUT(DT_INST(idx, st_stm32_temp))                       \
-	};                                                                                         \
-	static const struct stm32_temp_config inst_##idx##_config = {                              \
-		.avgslope = DT_INST_PROP(idx, avgslope),                                           \
-		.v25_mv = DT_INST_PROP(idx, v25),                                                  \
-		.tsv_mv = DT_INST_PROP(idx, ts_voltage_mv),                                        \
-		.is_ntc = DT_INST_PROP(idx, ntc)                                                   \
-	};                                                                                         \
-	DEVICE_DT_INST_DEFINE(idx, stm32_temp_init, NULL, &inst_##idx##_data,                      \
-			      &inst_##idx##_config, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,      \
-			      &stm32_temp_driver_api);
+static const struct stm32_temp_config stm32_temp_dev_config = {
+	.tsv_mv = DT_INST_PROP(0, ts_voltage_mv),
+#if HAS_CALIBRATION
+	.cal1_addr = (uint16_t *)DT_INST_PROP(0, ts_cal1_addr),
+	.cal2_addr = (uint16_t *)DT_INST_PROP(0, ts_cal2_addr),
+	.cal1_temp = DT_INST_PROP(0, ts_cal1_temp),
+	.cal2_temp = DT_INST_PROP(0, ts_cal2_temp),
+	.cal_vrefanalog = DT_INST_PROP(0, ts_cal_vrefanalog),
+	.cal_offset = DT_INST_PROP(0, ts_cal_offset)
+#else
+	.avgslope = DT_INST_PROP(0, avgslope),
+	.v25_mv = DT_INST_PROP(0, v25),
+	.is_ntc = DT_INST_PROP(0, ntc)
+#endif
+};
 
-DT_INST_FOREACH_STATUS_OKAY(STM32_TEMP_INST)
+static struct stm32_temp_data stm32_temp_dev_data = {
+	.adc = DEVICE_DT_GET(DT_INST_IO_CHANNELS_CTLR(0)),
+	.channel = DT_INST_IO_CHANNELS_INPUT(0),
+};
+
+DEVICE_DT_INST_DEFINE(0, stm32_temp_init, NULL, &stm32_temp_dev_data, &stm32_temp_dev_config,
+		      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &stm32_temp_driver_api);

--- a/drivers/sensor/stm32_temp/stm32_temp.c
+++ b/drivers/sensor/stm32_temp/stm32_temp.c
@@ -30,8 +30,7 @@ struct stm32_temp_config {
 	bool is_ntc;
 };
 
-static int stm32_temp_sample_fetch(const struct device *dev,
-				  enum sensor_channel chan)
+static int stm32_temp_sample_fetch(const struct device *dev, enum sensor_channel chan)
 {
 	struct stm32_temp_data *data = dev->data;
 	struct adc_sequence *sp = &data->adc_seq;
@@ -54,9 +53,8 @@ static int stm32_temp_sample_fetch(const struct device *dev,
 	return 0;
 }
 
-static int stm32_temp_channel_get(const struct device *dev,
-				 enum sensor_channel chan,
-				 struct sensor_value *val)
+static int stm32_temp_channel_get(const struct device *dev, enum sensor_channel chan,
+				  struct sensor_value *val)
 {
 	struct stm32_temp_data *data = dev->data;
 	const struct stm32_temp_config *cfg = dev->config;
@@ -73,7 +71,7 @@ static int stm32_temp_channel_get(const struct device *dev,
 	} else {
 		temp = (float)(mv - cfg->v25_mv);
 	}
-	temp = (temp/cfg->avgslope)*10;
+	temp = (temp / cfg->avgslope) * 10;
 	temp += 25;
 	sensor_value_from_double(val, temp);
 
@@ -99,13 +97,11 @@ static int stm32_temp_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	*accp = (struct adc_channel_cfg){
-		.gain = ADC_GAIN_1,
-		.reference = ADC_REF_INTERNAL,
-		.acquisition_time = ADC_ACQ_TIME_MAX,
-		.channel_id = data->channel,
-		.differential = 0
-	};
+	*accp = (struct adc_channel_cfg){ .gain = ADC_GAIN_1,
+					  .reference = ADC_REF_INTERNAL,
+					  .acquisition_time = ADC_ACQ_TIME_MAX,
+					  .channel_id = data->channel,
+					  .differential = 0 };
 	rc = adc_channel_setup(data->adc, accp);
 	LOG_DBG("Setup AIN%u got %d", data->channel, rc);
 
@@ -120,26 +116,19 @@ static int stm32_temp_init(const struct device *dev)
 	return 0;
 }
 
-#define STM32_TEMP_INST(idx)    \
-	static struct stm32_temp_data inst_##idx##_data = {  \
-		.adc = DEVICE_DT_GET(DT_IO_CHANNELS_CTLR(  \
-						DT_INST(idx, st_stm32_temp))), \
-		.channel = DT_IO_CHANNELS_INPUT( \
-						DT_INST(idx, st_stm32_temp)) \
-	};  \
-	static const struct stm32_temp_config inst_##idx##_config = { \
-		.avgslope = DT_INST_PROP(idx, avgslope),  \
-		.v25_mv = DT_INST_PROP(idx, v25),  \
-		.tsv_mv = DT_INST_PROP(idx, ts_voltage_mv),  \
-		.is_ntc = DT_INST_PROP(idx, ntc)  \
-	};  \
-	DEVICE_DT_INST_DEFINE(idx,  \
-		    stm32_temp_init,    \
-		    NULL,               \
-		    &inst_##idx##_data, \
-			&inst_##idx##_config,  \
-		    POST_KERNEL,           \
-		    CONFIG_SENSOR_INIT_PRIORITY, \
-		    &stm32_temp_driver_api);
+#define STM32_TEMP_INST(idx)                                                                       \
+	static struct stm32_temp_data inst_##idx##_data = {                                        \
+		.adc = DEVICE_DT_GET(DT_IO_CHANNELS_CTLR(DT_INST(idx, st_stm32_temp))),            \
+		.channel = DT_IO_CHANNELS_INPUT(DT_INST(idx, st_stm32_temp))                       \
+	};                                                                                         \
+	static const struct stm32_temp_config inst_##idx##_config = {                              \
+		.avgslope = DT_INST_PROP(idx, avgslope),                                           \
+		.v25_mv = DT_INST_PROP(idx, v25),                                                  \
+		.tsv_mv = DT_INST_PROP(idx, ts_voltage_mv),                                        \
+		.is_ntc = DT_INST_PROP(idx, ntc)                                                   \
+	};                                                                                         \
+	DEVICE_DT_INST_DEFINE(idx, stm32_temp_init, NULL, &inst_##idx##_data,                      \
+			      &inst_##idx##_config, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,      \
+			      &stm32_temp_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(STM32_TEMP_INST)

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -594,6 +594,19 @@
 		#phy-cells = <0>;
 		label = "USB_FS_PHY";
 	};
+
+	die_temp: dietemp {
+		compatible = "st,stm32-temp-cal";
+		ts-cal1-addr = <0x0BFA05A8>;
+		ts-cal2-addr = <0x0BFA05CA>;
+		ts-cal1-temp = <30>;
+		ts-cal2-temp = <110>;
+		ts-cal-vrefanalog = <3000>;
+		ts-cal-offset = <30>;
+		io-channels = <&adc1 17>;
+		status = "disabled";
+		label = "DIE_TEMP";
+	};
 };
 
 &nvic {

--- a/dts/bindings/sensor/st,stm32-temp-cal.yaml
+++ b/dts/bindings/sensor/st,stm32-temp-cal.yaml
@@ -1,0 +1,45 @@
+# Copyright (c) 2022, Wouter Cappelle
+# SPDX-License-Identifier: Apache-2.0
+
+description: STM32 family TEMP node for production calibrated sensors like L5/U5
+
+compatible: "st,stm32-temp-cal"
+
+include: [base.yaml, "st,stm32-temp-common.yaml"]
+
+properties:
+    ts-cal1-addr:
+      type: int
+      required: true
+      description: address of parameter TS_CAL1
+
+    ts-cal2-addr:
+      type: int
+      required: true
+      description: address of parameter TS_CAL2
+
+    ts-cal1-temp:
+      type: int
+      required: true
+      description: |
+        temperature at which temperature sensor has been
+        calibrated in production for data into ts-cal1-addr
+
+    ts-cal2-temp:
+      type: int
+      required: true
+      description: |
+        temperature at which temperature sensor has been
+        calibrated in production for data into ts-cal2-addr
+
+    ts-cal-vrefanalog:
+      type: int
+      required: true
+      description: |
+        Analog voltage reference (Vref+) voltage with which
+        temperature sensor has been calibrated in production
+
+    ts-cal-offset:
+      type: int
+      required: true
+      description: Temperature offset in Celcius

--- a/dts/bindings/sensor/st,stm32-temp-common.yaml
+++ b/dts/bindings/sensor/st,stm32-temp-common.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2022, Wouter Cappelle
+# SPDX-License-Identifier: Apache-2.0
+
+properties:
+    label:
+      required: true
+
+    io-channels:
+      required: true
+      description: ADC channel for temperature sensor
+
+    ts-voltage-mv:
+      type: int
+      default: 3300
+      description: Temperature sensor voltage in millivolts

--- a/dts/bindings/sensor/st,stm32-temp.yaml
+++ b/dts/bindings/sensor/st,stm32-temp.yaml
@@ -5,21 +5,9 @@ description: STM32 family TEMP node
 
 compatible: "st,stm32-temp"
 
-include: base.yaml
+include: [base.yaml, "st,stm32-temp-common.yaml"]
 
 properties:
-    label:
-      required: true
-
-    io-channels:
-      required: true
-      description: ADC channel for temperature sensor
-
-    ts-voltage-mv:
-      type: int
-      default: 3300
-      description: Temperature sensor voltage in millivolts
-
     avgslope:
       type: int
       default: 25

--- a/samples/sensor/stm32_temp_sensor/boards/stm32l562e_dk.overlay
+++ b/samples/sensor/stm32_temp_sensor/boards/stm32l562e_dk.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2022 Wouter Cappelle
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Application overlay for creating temperature sensor device instance
+ */
+
+&die_temp {
+    status = "okay";
+};
+
+&adc1 {
+    status = "okay";
+};

--- a/samples/sensor/stm32_temp_sensor/sample.yaml
+++ b/samples/sensor/stm32_temp_sensor/sample.yaml
@@ -6,4 +6,4 @@ tests:
     depends_on: adc
     tags: sensors
     build_only: true
-    platform_allow: nucleo_f401re stm32f103_mini
+    platform_allow: nucleo_f401re stm32f103_mini stm32l562e_dk

--- a/samples/sensor/stm32_temp_sensor/src/main.c
+++ b/samples/sensor/stm32_temp_sensor/src/main.c
@@ -9,11 +9,19 @@
 #include <drivers/sensor.h>
 #include <sys/printk.h>
 
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_temp)
+#define TEMP_NODE DT_INST(0, st_stm32_temp)
+#elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_temp_cal)
+#define TEMP_NODE DT_INST(0, st_stm32_temp_cal)
+#else
+#error "Could not find a compatible temperature sensor"
+#endif
+
 void main(void)
 {
 	struct sensor_value val;
 	int rc;
-	const struct device *dev = DEVICE_DT_GET(DT_INST(0, st_stm32_temp));
+	const struct device *dev = DEVICE_DT_GET(TEMP_NODE);
 
 	if (!device_is_ready(dev)) {
 		printk("Temperature sensor is not ready\n");

--- a/samples/sensor/stm32_temp_sensor/src/main.c
+++ b/samples/sensor/stm32_temp_sensor/src/main.c
@@ -9,13 +9,11 @@
 #include <drivers/sensor.h>
 #include <sys/printk.h>
 
-
 void main(void)
 {
 	struct sensor_value val;
 	int rc;
-	const struct device *dev =
-		DEVICE_DT_GET(DT_INST(0, st_stm32_temp));
+	const struct device *dev = DEVICE_DT_GET(DT_INST(0, st_stm32_temp));
 
 	if (!device_is_ready(dev)) {
 		printk("Temperature sensor is not ready\n");
@@ -40,7 +38,6 @@ void main(void)
 			continue;
 		}
 
-		printk("Current temperature: %.1f °C\n",
-					sensor_value_to_double(&val));
+		printk("Current temperature: %.1f °C\n", sensor_value_to_double(&val));
 	}
 }


### PR DESCRIPTION
This PR adds the different handling of temperature sensor for the
STM32L5 soc. In this soc, there are some calibration settings which
need to be applied for temperature conversion which seem different than other seriers.

Afaik this is the only soc which needs this different handling.

Datasheet snippet for reviewers:
![image](https://user-images.githubusercontent.com/10128093/146527083-3c7bef38-b182-422f-995f-5c081f3cf35f.png)
