### PR TITLE
runners: pyocd: Enable semihosting in pyOCD

### DIFF
--- a/boards/common/pyocd.board.cmake
+++ b/boards/common/pyocd.board.cmake
@@ -2,4 +2,7 @@
 
 board_set_flasher_ifnset(pyocd)
 board_set_debugger_ifnset(pyocd)
+if(CONFIG_SEMIHOST_CONSOLE)
+    board_runner_args(pyocd "--tool-opt=-S")
+endif()
 board_finalize_runner_args(pyocd "--dt-flash=y")


### PR DESCRIPTION
If ARM semihosting is selected, automatically enable the pyOCD feature.
This way the console output is directly available on the telnet port.

Signed-off-by: Casper Meijn <casper@meijn.net>