### PR TITLE
canbus: switch to DEVICE_DT_GET()

### DIFF
--- a/dts/bindings/can/can-controller.yaml
+++ b/dts/bindings/can/can-controller.yaml
@@ -5,8 +5,6 @@ include: base.yaml
 bus: can
 
 properties:
-    label:
-      required: true
     bus-speed:
       type: int
       required: true

--- a/tests/drivers/can/api/src/main.c
+++ b/tests/drivers/can/api/src/main.c
@@ -44,12 +44,10 @@
 #define TEST_CAN_EXT_MASK_ID_2 0x1555556A
 #define TEST_CAN_EXT_MASK      0x1FFFFFF0
 
-#define CAN_DEVICE_NAME DT_LABEL(DT_CHOSEN(zephyr_canbus))
-
 CAN_MSGQ_DEFINE(can_msgq, 5);
 struct k_sem rx_isr_sem;
 struct k_sem tx_cb_sem;
-const struct device *can_dev;
+const struct device *can_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
 
 const struct zcan_frame test_std_msg_1 = {
 	.id_type = CAN_STANDARD_IDENTIFIER,
@@ -605,8 +603,7 @@ void test_main(void)
 {
 	k_sem_init(&rx_isr_sem, 0, 2);
 	k_sem_init(&tx_cb_sem, 0, 2);
-	can_dev = device_get_binding(CAN_DEVICE_NAME);
-	zassert_not_null(can_dev, "Device not found");
+	zassert_true(device_is_ready(can_dev), "CAN device not ready");
 
 	ztest_test_suite(can_driver,
 			 ztest_unit_test(test_set_loopback),

--- a/tests/drivers/can/canfd/src/main.c
+++ b/tests/drivers/can/canfd/src/main.c
@@ -28,13 +28,11 @@
 #define TEST_CAN_STD_ID_1      0x555
 #define TEST_CAN_STD_ID_2      0x556
 
-#define CAN_DEVICE_NAME DT_LABEL(DT_CHOSEN(zephyr_canbus))
-
 CAN_MSGQ_DEFINE(can_msgq, 5);
 struct k_sem rx_isr_sem;
 struct k_sem rx_cb_sem;
 struct k_sem tx_cb_sem;
-const struct device *can_dev;
+const struct device *can_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
 
 const struct zcan_frame test_std_msg_1 = {
 	.id_type = CAN_STANDARD_IDENTIFIER,
@@ -311,8 +309,7 @@ void test_main(void)
 	k_sem_init(&rx_isr_sem, 0, 2);
 	k_sem_init(&rx_cb_sem, 0, INT_MAX);
 	k_sem_init(&tx_cb_sem, 0, 2);
-	can_dev = device_get_binding(CAN_DEVICE_NAME);
-	zassert_not_null(can_dev, "Device not found");
+	zassert_true(device_is_ready(can_dev), "CAN device not ready");
 
 	ztest_test_suite(canfd_driver,
 			 ztest_unit_test(test_set_loopback),

--- a/tests/drivers/can/timing/src/main.c
+++ b/tests/drivers/can/timing/src/main.c
@@ -22,9 +22,7 @@
  * @}
  */
 
-#define CAN_DEVICE_NAME DT_LABEL(DT_CHOSEN(zephyr_canbus))
-
-const struct device *can_dev;
+const struct device *can_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
 
 struct timing_samples {
 	uint32_t bitrate;
@@ -124,8 +122,7 @@ static void test_verify_algo(void)
 
 void test_main(void)
 {
-	can_dev = device_get_binding(CAN_DEVICE_NAME);
-	zassert_not_null(can_dev, "Device not found");
+	zassert_true(device_is_ready(can_dev), "CAN device not ready");
 
 	ztest_test_suite(can_timing,
 			 ztest_unit_test(test_verify_algo));

--- a/tests/subsys/canbus/isotp/conformance/src/main.c
+++ b/tests/subsys/canbus/isotp/conformance/src/main.c
@@ -49,8 +49,6 @@
 #define BS_TIMEOUT_UPPER_MS   1100
 #define BS_TIMEOUT_LOWER_MS   1000
 
-#define CAN_DEVICE_NAME DT_LABEL(DT_CHOSEN(zephyr_canbus))
-
 /*
  * @addtogroup t_can
  * @{
@@ -120,7 +118,7 @@ const struct isotp_msg_id tx_addr_fixed = {
 	.use_fixed_addr = 1
 };
 
-const struct device *can_dev;
+const struct device *can_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
 struct isotp_recv_ctx recv_ctx;
 struct isotp_send_ctx send_ctx;
 uint8_t data_buf[128];
@@ -969,8 +967,7 @@ void test_main(void)
 	zassert_true(sizeof(random_data) >= sizeof(data_buf) * 2 + 10,
 		     "Test data size to small");
 
-	can_dev = device_get_binding(CAN_DEVICE_NAME);
-	zassert_not_null(can_dev, "CAN device not not found");
+	zassert_true(device_is_ready(can_dev), "CAN device not ready");
 
 	ret = can_set_mode(can_dev, CAN_LOOPBACK_MODE);
 	zassert_equal(ret, 0, "Failed to set loopback mode [%d]", ret);

--- a/tests/subsys/canbus/isotp/implementation/src/main.c
+++ b/tests/subsys/canbus/isotp/implementation/src/main.c
@@ -12,8 +12,6 @@
 #define NUMBER_OF_REPETITIONS 5
 #define DATA_SIZE_SF          7
 
-#define CAN_DEVICE_NAME DT_LABEL(DT_CHOSEN(zephyr_canbus))
-
 /*
  * @addtogroup t_can
  * @{
@@ -27,7 +25,7 @@
  * @}
  */
 
-const struct device *can_dev;
+const struct device *can_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
 
 const struct isotp_fc_opts fc_opts = {
 	.bs = 8,
@@ -417,8 +415,8 @@ void test_main(void)
 	zassert_true(sizeof(random_data) >= sizeof(data_buf) * 2 + 10,
 		     "Test data size to small");
 
-	can_dev = device_get_binding(CAN_DEVICE_NAME);
-	zassert_not_null(can_dev, "CAN device not not found");
+	zassert_true(device_is_ready(can_dev), "CAN device not ready");
+
 	ret = can_set_mode(can_dev, CAN_LOOPBACK_MODE);
 	zassert_equal(ret, 0, "Configuring loopback mode failed (%d)", ret);
 


### PR DESCRIPTION
Switch CAN samples and test code from using device_get_binding() to DEVICE_DT_GET().