### PR TITLE
boards: arm: pinetime: Add display backlight to dts 

### DIFF
--- a/boards/arm/pinetime_devkit0/Kconfig.defconfig
+++ b/boards/arm/pinetime_devkit0/Kconfig.defconfig
@@ -19,7 +19,17 @@ config SPI
 config ST7789V
 	default y
 
+config LED
+	default y
+
 endif # DISPLAY
+
+if LED
+
+config LED_GPIO
+	default y
+
+endif # LED
 
 if FLASH
 

--- a/boards/arm/pinetime_devkit0/pinetime_devkit0.dts
+++ b/boards/arm/pinetime_devkit0/pinetime_devkit0.dts
@@ -176,6 +176,7 @@
 		nvgam-param = [D0 04 0C 11 13 2C 3F 44 51 2F 1F 1F 20 23];
 		ram-param = [00 F0];
 		rgb-param = [CD 08 14];
+		backlight-led = <&blled2>;
 	};
 };
 

--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -427,3 +427,8 @@ PM_DEVICE_DT_INST_DEFINE(0, st7789v_pm_action);
 DEVICE_DT_INST_DEFINE(0, &st7789v_init, PM_DEVICE_DT_INST_GET(0), &st7789v_data,
 		      &st7789v_config, POST_KERNEL,
 		      CONFIG_DISPLAY_INIT_PRIORITY, &st7789v_api);
+
+#if CONFIG_LED
+BUILD_ASSERT(CONFIG_DISPLAY_INIT_PRIORITY > CONFIG_LED_INIT_PRIORITY,
+	     "ST7789v driver must be initialized after LED driver");
+#endif

--- a/drivers/led/Kconfig
+++ b/drivers/led/Kconfig
@@ -16,7 +16,7 @@ source "subsys/logging/Kconfig.template.log_config"
 
 config LED_INIT_PRIORITY
 	int "LED initialization priority"
-	default 90
+	default 80
 	help
 	  System initialization priority for LED drivers.
 

--- a/dts/bindings/display/sitronix,st7789v.yaml
+++ b/dts/bindings/display/sitronix,st7789v.yaml
@@ -113,3 +113,11 @@ properties:
       type: uint8-array
       required: true
       description: RGB Interface Control Parameter
+
+    backlight-led:
+      type: phandle
+      required: false
+      description: |
+        For panels whose backlight is controlled by an external backlight
+        LED, this property contains a phandle that references the
+        LED.


### PR DESCRIPTION
Fixes #41047. Define the display backlight hardware relation in the PineTime dts and enable the backlight in the st7789v driver.

1. Add a backlight-led attribute to the display-controller binding. This is for panels with an external backlight led.
2. Add the backlight reference from the st7789v display to the bl led.
3. Make sure led driver is initialized before the display
4. Extend st7789v driver with backlight
5. Enable led driver for pinetime

