### PR TITLE
runners: openocd: Default to an actual executable when not configured

### DIFF
--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -58,7 +58,7 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
         if cfg.openocd_search is not None:
             for p in cfg.openocd_search:
                 search_args.extend(['-s', p])
-        self.openocd_cmd = [cfg.openocd] + search_args
+        self.openocd_cmd = [cfg.openocd or 'openocd'] + search_args
         # openocd doesn't cope with Windows path names, so convert
         # them to POSIX style just to be sure.
         self.elf_name = Path(cfg.elf_file).as_posix()


### PR DESCRIPTION
Whenever build/zephyr/runners.yaml does not specify the location of the
openocd executable we seemd to be leaving the executable variable as
None. Instead, use its executable name.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>