### PR TITLE
doc: development_process: splitting up commits is justified

### DIFF
--- a/doc/development_process/dev_env_and_tools.rst
+++ b/doc/development_process/dev_env_and_tools.rst
@@ -177,7 +177,6 @@ dismissed following the criteria below:
   structural changes such as:
 
   - Split the PR
-  - Split the commits
   - Can you fix this unrelated code that happens to appear in the diff
   - Can you fix unrelated issues
   - Etc.


### PR DESCRIPTION
Asking that a pull request restructure its commits is not
automatically an unjustified structural change. Remove it from the
list of unjustified changes. Commit structure is important for
maintaining bisectability.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>