### PR TITLE
cmake: remove CMake policy CMP0000 and CMP0002

### DIFF
--- a/subsys/testsuite/unittest.cmake
+++ b/subsys/testsuite/unittest.cmake
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20.0)
-cmake_policy(SET CMP0000 OLD)
-cmake_policy(SET CMP0002 NEW)
 
 enable_language(C CXX ASM)
 

--- a/tests/unit/base64/CMakeLists.txt
+++ b/tests/unit/base64/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+cmake_minimum_required(VERSION 3.20.0)
+
 project(base64)
 set(SOURCES main.c)
 find_package(ZephyrUnittest REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/tests/unit/cbprintf/CMakeLists.txt
+++ b/tests/unit/cbprintf/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+cmake_minimum_required(VERSION 3.20.0)
+
 project(lib_os_cbprintf)
 set(SOURCES main.c)
 find_package(ZephyrUnittest REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/tests/unit/crc/CMakeLists.txt
+++ b/tests/unit/crc/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+cmake_minimum_required(VERSION 3.20.0)
+
 project(crc)
 set(SOURCES main.c)
 find_package(ZephyrUnittest REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/tests/unit/intmath/CMakeLists.txt
+++ b/tests/unit/intmath/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+cmake_minimum_required(VERSION 3.20.0)
+
 project(base64)
 set(SOURCES
   main.c

--- a/tests/unit/list/CMakeLists.txt
+++ b/tests/unit/list/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+cmake_minimum_required(VERSION 3.20.0)
+
 project(list)
 set(SOURCES
   main.c

--- a/tests/unit/math_extras/CMakeLists.txt
+++ b/tests/unit/math_extras/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+cmake_minimum_required(VERSION 3.20.0)
+
 project(math_extras)
 set(SOURCES main.c portable.c)
 find_package(ZephyrUnittest REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/tests/unit/net_timeout/CMakeLists.txt
+++ b/tests/unit/net_timeout/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+cmake_minimum_required(VERSION 3.20.0)
+
 project(lib_net_timeout)
 set(SOURCES main.c)
 find_package(ZephyrUnittest REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/tests/unit/rbtree/CMakeLists.txt
+++ b/tests/unit/rbtree/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+cmake_minimum_required(VERSION 3.20.0)
+
 project(rbtree)
 set(SOURCES main.c)
 find_package(ZephyrUnittest REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/tests/unit/timeutil/CMakeLists.txt
+++ b/tests/unit/timeutil/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Copyright 2019-2020 Peter Bigot Consulting
 # SPDX-License-Identifier: Apache-2.0
 
+cmake_minimum_required(VERSION 3.20.0)
+
 project(timeutil)
 set(SOURCES main.c test_gmtime.c test_s32.c test_s64.c test_sync.c)
 find_package(ZephyrUnittest REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/tests/unit/util/CMakeLists.txt
+++ b/tests/unit/util/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+cmake_minimum_required(VERSION 3.20.0)
+
 project(util)
 set(SOURCES main.c maincxx.cxx ../../../lib/os/dec.c)
 find_package(ZephyrUnittest REQUIRED HINTS $ENV{ZEPHYR_BASE})


### PR DESCRIPTION
This PR add `cmake_minimum_required()` to test cases missing this function call.
This removes the printing of the warning when CMake is invoked.

Also it allows us to remove two CMake policies.