### PR TITLE
boards: arm: pinetime: Add battery voltage divider

### DIFF
--- a/boards/arm/pinetime_devkit0/pinetime_devkit0.dts
+++ b/boards/arm/pinetime_devkit0/pinetime_devkit0.dts
@@ -66,6 +66,17 @@
 		gpios = <&gpio0 15 GPIO_ACTIVE_HIGH>;
 		label = "Key out";
 	};
+
+	vbatt {
+		compatible = "voltage-divider";
+		io-channels = <&adc 7>;
+		output-ohms = <1000000>;
+		full-ohms = <(1000000 + 1000000)>;
+	};
+};
+
+&adc {
+	status = "okay";
 };
 
 &gpiote {


### PR DESCRIPTION
PineTime hardware can measure the battery voltage via an ADC pin. Define
this as a `voltage-divider` in the board dts. This enables the sample
`boards/nrf/battery`.

Signed-off-by: Casper Meijn <casper@meijn.net>