### PR TITLE
net: l2: ppp: fix MRU when CONFIG_NET_L2_PPP_OPTION_MRU=n

### DIFF
--- a/subsys/net/l2/ppp/lcp.c
+++ b/subsys/net/l2/ppp/lcp.c
@@ -308,8 +308,9 @@ static void lcp_init(struct ppp_context *ctx)
 
 	ppp_fsm_name_set(&ctx->lcp.fsm, ppp_proto2str(PPP_LCP));
 
-#if defined(CONFIG_NET_L2_PPP_OPTION_MRU)
 	ctx->lcp.my_options.mru = net_if_get_mtu(ctx->iface);
+
+#if defined(CONFIG_NET_L2_PPP_OPTION_MRU)
 	ctx->lcp.fsm.my_options.info = lcp_my_options;
 	ctx->lcp.fsm.my_options.data = ctx->lcp.my_options_data;
 	ctx->lcp.fsm.my_options.count = ARRAY_SIZE(lcp_my_options);


### PR DESCRIPTION
When support for custom MRU/MTU was added with
CONFIG_NET_L2_PPP_OPTION_MRU=y, code flow with
CONFIG_NET_L2_PPP_OPTION_MRU=n has been broken due to lack of valid
'ctx->lcp.my_options.mru' initialization and its use (with value 0) in
the implementation.

Initialize 'ctx->lcp.my_options.mru' unconditionally in lcp_init(), so
that PPP works fine with CONFIG_NET_L2_PPP_OPTION_MRU=n.

Fixes: 8a51a79d8925 ("net: l2: ppp: possibility to have a custom MRU/MTU")