### PR TITLE
tests: coverage: fix the blocking on mps2_an385 coverage report

### DIFF
--- a/subsys/testsuite/coverage/coverage.c
+++ b/subsys/testsuite/coverage/coverage.c
@@ -11,7 +11,7 @@
 #include "coverage.h"
 
 
-#ifdef CONFIG_X86
+#if defined(CONFIG_X86) || defined(CONFIG_SOC_SERIES_MPS2)
 #define MALLOC_MAX_HEAP_SIZE 32768
 #define MALLOC_MIN_BLOCK_SIZE 128
 #else


### PR DESCRIPTION
The overall code coverage report of mps2_an385 was blocked by the
tests/net/lib/coap, the error message shows "No Mem available to
continue dump". So we enlarge the gcov heap size to prevent this
situation, try to make the report can be generated at least.

PS. Run "twister -T tests/ -p mps2_an385 --coverage" 
There are several code coverage reports failed in tests/net/ need to be fixed (but they did not block the report)

Fixes #41388

Signed-off-by: Enjia Mai <enjia.mai@intel.com>