### PR TITLE
arch: riscv: ARCH_EXCEPT macro

### DIFF
--- a/arch/riscv/core/fatal.c
+++ b/arch/riscv/core/fatal.c
@@ -119,7 +119,15 @@ void _Fault(z_arch_esf_t *esf)
 	LOG_ERR("  mtval: %lx", mtval);
 #endif
 
-	z_riscv_fatal_error(K_ERR_CPU_EXCEPTION, esf);
+	unsigned int reason = K_ERR_CPU_EXCEPTION;
+
+#if !defined(CONFIG_USERSPACE)
+	if (esf->t5 == ARCH_EXCEPT_MARKER) {
+		reason = esf->t6;
+	}
+#endif
+
+	z_riscv_fatal_error(reason, esf);
 }
 
 #ifdef CONFIG_USERSPACE

--- a/include/arch/riscv/arch.h
+++ b/include/arch/riscv/arch.h
@@ -368,9 +368,7 @@ static inline uint64_t arch_k_cycle_get_64(void)
 	return sys_clock_cycle_get_64();
 }
 
-#ifdef CONFIG_USERSPACE
 #include <arch/riscv/error.h>
-#endif /* CONFIG_USERSPACE */
 
 #ifdef __cplusplus
 }

--- a/tests/subsys/debug/coredump/src/main.c
+++ b/tests/subsys/debug/coredump/src/main.c
@@ -15,11 +15,8 @@ void func_3(uint32_t *addr)
 	defined(CONFIG_BOARD_LONGAN_NANO) || \
 	defined(CONFIG_BOARD_LONGAN_NANO_LITE)
 	ARG_UNUSED(addr);
-	/* Call coredump() directly so Renode doesn't pause execution */
-	z_arch_esf_t esf;
-	struct k_thread kthread;
-
-	coredump(1, &esf, &kthread);
+	/* Call k_panic() directly so Renode doesn't pause execution */
+	k_panic();
 #elif !defined(CONFIG_CPU_CORTEX_M)
 	/* For null pointer reference */
 	*addr = 0;


### PR DESCRIPTION
Enable ARCH_EXCEPT macro for non-usermode scenario for RISC-V
Macro will now raise an illegal instruction exception so that mepc will hold expected value in exception handler, and generated coredump can reconstruct the failing stack

Coredump tests running on renode (for RISC-V) can now utilize fatal error path through k_panic

Signed-off-by: Mark Holden mholden@fb.com