### PR TITLE
Icmp4 fixes

### DIFF
--- a/subsys/net/ip/icmpv4.c
+++ b/subsys/net/ip/icmpv4.c
@@ -600,6 +600,17 @@ int net_icmpv4_send_error(struct net_pkt *orig, uint8_t type, uint8_t code)
 		}
 	}
 
+	if (net_ipv4_is_addr_bcast(net_pkt_iface(orig),
+				   (struct in_addr *)ip_hdr->dst)) {
+		/* We should not send an error to packet that
+		 * were sent to broadcast
+		 */
+		NET_DBG("Not sending error to bcast pkt from %s on proto %s",
+			log_strdup(net_sprint_ipv4_addr(&ip_hdr->src)),
+			net_proto2str(AF_INET, ip_hdr->proto));
+		goto drop_no_pkt;
+	}
+
 	if (ip_hdr->proto == IPPROTO_UDP) {
 		copy_len = sizeof(struct net_ipv4_hdr) +
 			sizeof(struct net_udp_hdr);

--- a/subsys/net/ip/icmpv4.c
+++ b/subsys/net/ip/icmpv4.c
@@ -635,8 +635,8 @@ int net_icmpv4_send_error(struct net_pkt *orig, uint8_t type, uint8_t code)
 
 	NET_DBG("Sending ICMPv4 Error Message type %d code %d from %s to %s",
 		type, code,
-		log_strdup(net_sprint_ipv4_addr(&ip_hdr->src)),
-		log_strdup(net_sprint_ipv4_addr(&ip_hdr->dst)));
+		log_strdup(net_sprint_ipv4_addr(&ip_hdr->dst)),
+		log_strdup(net_sprint_ipv4_addr(&ip_hdr->src)));
 
 	if (net_send_data(pkt) >= 0) {
 		net_stats_update_icmp_sent(net_pkt_iface(orig));


### PR DESCRIPTION
I could not find a reference in the ICMPv4 rfc about not sending an error to bcasted packet. But that sounds right, or else it would be an easy way for a client to get ddos itself.