### PR TITLE
pm: policy: more cleanups

### DIFF
--- a/boards/posix/native_posix/native_posix.dts
+++ b/boards/posix/native_posix/native_posix.dts
@@ -40,6 +40,16 @@
 		};
 	};
 
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu0: cpu@0 {
+			compatible = "zephyr,native-posix-cpu";
+			reg = <0>;
+		};
+	};
+
 	flashcontroller0: flash-controller@0 {
 		compatible = "zephyr,sim-flash";
 		reg = <0x00000000 DT_SIZE_K(2048)>;

--- a/dts/bindings/cpu/gaisler,leon3.yaml
+++ b/dts/bindings/cpu/gaisler,leon3.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: A representation for Gaisler LEON3 CPU.
+
+compatible: "gaisler,leon3"
+
+include: cpu.yaml

--- a/dts/bindings/cpu/zephyr,native-posix-cpu.yaml
+++ b/dts/bindings/cpu/zephyr,native-posix-cpu.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: A representation for native_posix CPU.
+
+compatible: "zephyr,native-posix-cpu"
+
+include: cpu.yaml

--- a/dts/sparc/gr716a.dtsi
+++ b/dts/sparc/gr716a.dtsi
@@ -7,6 +7,16 @@
 #include "skeleton.dtsi"
 
 / {
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu0: cpu@0 {
+			compatible = "gaisler,leon3";
+			reg = <0>;
+		};
+	};
+
 	dram: ram@30000000 {
 		/* tightly coupled data RAM */
 		reg = <0x30000000 0x00010000>;

--- a/dts/sparc/leon3soc.dtsi
+++ b/dts/sparc/leon3soc.dtsi
@@ -7,6 +7,16 @@
 #include "skeleton.dtsi"
 
 / {
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu0: cpu@0 {
+			compatible = "gaisler,leon3";
+			reg = <0>;
+		};
+	};
+
 	ram0: memory@40000000 {
 		compatible = "mmio-sram";
 		reg = <0x40000000 0x40000000>;

--- a/include/pm/policy.h
+++ b/include/pm/policy.h
@@ -26,9 +26,10 @@ extern "C" {
  * @param cpu CPU index.
  * @param ticks The number of ticks to the next scheduled event.
  *
- * @return The power state the system should use for the given cpu.
+ * @return The power state the system should use for the given cpu. The function
+ * will return NULL if system should remain into PM_STATE_ACTIVE.
  */
-struct pm_state_info pm_policy_next_state(uint8_t cpu, int32_t ticks);
+const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks);
 
 /** @endcond */
 

--- a/include/pm/state.h
+++ b/include/pm/state.h
@@ -310,6 +310,17 @@ struct pm_state_info {
 			     Z_PM_STATE_FROM_DT_CPU, node_id)		       \
 	}
 
+
+/**
+ * Obtain information about all supported states by a CPU.
+ *
+ * @param cpu CPU index.
+ * @param states Where to store the list of supported states.
+ *
+ * @return Number of supported states.
+ */
+uint8_t pm_state_cpu_get_all(uint8_t cpu, const struct pm_state_info **states);
+
 /**
  * @}
  */

--- a/include/sys/time_units.h
+++ b/include/sys/time_units.h
@@ -7,6 +7,8 @@
 #ifndef ZEPHYR_INCLUDE_TIME_UNITS_H_
 #define ZEPHYR_INCLUDE_TIME_UNITS_H_
 
+#include <toolchain.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/subsys/pm/CMakeLists.txt
+++ b/subsys/pm/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_PM)
-  zephyr_sources(pm.c constraint.c)
+  zephyr_sources(pm.c constraint.c state.c)
   zephyr_sources_ifdef(CONFIG_PM_STATS pm_stats.c)
 endif()
 

--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -194,7 +194,12 @@ bool pm_system_suspend(int32_t ticks)
 	SYS_PORT_TRACING_FUNC_ENTER(pm, system_suspend, ticks);
 
 	if (!atomic_test_and_set_bit(z_power_states_forced, id)) {
-		z_power_states[id] = pm_policy_next_state(id, ticks);
+		const struct pm_state_info *info;
+
+		info = pm_policy_next_state(id, ticks);
+		if (info != NULL) {
+			z_power_states[id] = *info;
+		}
 	}
 
 	if (z_power_states[id].state == PM_STATE_ACTIVE) {

--- a/subsys/pm/policy/residency.c
+++ b/subsys/pm/policy/residency.c
@@ -32,14 +32,9 @@ const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks)
 
 		if ((ticks == K_TICKS_FOREVER) ||
 		    (ticks >= (min_residency + exit_latency))) {
-			LOG_DBG("Selected power state %d "
-				"(ticks: %d, min_residency: %u) to cpu %d",
-				state->state, ticks, state->min_residency_us,
-				cpu);
 			return state;
 		}
 	}
 
-	LOG_DBG("No suitable power state found for cpu: %d!", cpu);
 	return NULL;
 }

--- a/subsys/pm/policy/residency.c
+++ b/subsys/pm/policy/residency.c
@@ -12,7 +12,7 @@
 #include <logging/log.h>
 LOG_MODULE_DECLARE(pm, CONFIG_PM_LOG_LEVEL);
 
-struct pm_state_info pm_policy_next_state(uint8_t cpu, int32_t ticks)
+const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks)
 {
 	uint8_t num_cpu_states;
 	const struct pm_state_info *cpu_states;
@@ -36,10 +36,10 @@ struct pm_state_info pm_policy_next_state(uint8_t cpu, int32_t ticks)
 				"(ticks: %d, min_residency: %u) to cpu %d",
 				state->state, ticks, state->min_residency_us,
 				cpu);
-			return *state;
+			return state;
 		}
 	}
 
 	LOG_DBG("No suitable power state found for cpu: %d!", cpu);
-	return (struct pm_state_info){PM_STATE_ACTIVE, 0, 0};
+	return NULL;
 }

--- a/subsys/pm/policy/residency.c
+++ b/subsys/pm/policy/residency.c
@@ -4,72 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <devicetree.h>
 #include <pm/pm.h>
 #include <pm/policy.h>
 #include <sys_clock.h>
-#include <sys/check.h>
 #include <sys/time_units.h>
-#include <sys/util.h>
 
 #include <logging/log.h>
 LOG_MODULE_DECLARE(pm, CONFIG_PM_LOG_LEVEL);
 
-/**
- * Check CPU power state consistency.
- *
- * @param i Power state index.
- * @param node_id CPU node identifier.
- */
-#define CHECK_POWER_STATE_CONSISTENCY(i, node_id)			       \
-	BUILD_ASSERT(							       \
-		DT_PROP_BY_PHANDLE_IDX_OR(node_id, cpu_power_states, i,	       \
-					  min_residency_us, 0U) >=	       \
-		DT_PROP_BY_PHANDLE_IDX_OR(node_id, cpu_power_states, i,	       \
-					  exit_latency_us, 0U),		       \
-		"Found CPU power state with min_residency < exit_latency");
-
-/**
- * @brief Check CPU power states consistency
- *
- * All states should have a minimum residency >= than the exit latency.
- *
- * @param node_id A CPU node identifier.
- */
-#define CHECK_POWER_STATES_CONSISTENCY(node_id)				       \
-	UTIL_LISTIFY(DT_NUM_CPU_POWER_STATES(node_id),			       \
-		     CHECK_POWER_STATE_CONSISTENCY, node_id)		       \
-
-/* Check that all power states are consistent */
-COND_CODE_1(DT_NODE_EXISTS(DT_PATH(cpus)),
-	    (DT_FOREACH_CHILD(DT_PATH(cpus), CHECK_POWER_STATES_CONSISTENCY)),
-	    ())
-
-#define NUM_CPU_STATES(n) DT_NUM_CPU_POWER_STATES(n),
-#define CPU_STATES(n) (struct pm_state_info[])PM_STATE_INFO_LIST_FROM_DT_CPU(n),
-
-/** CPU power states information for each CPU */
-static const struct pm_state_info *cpus_states[] = {
-	COND_CODE_1(DT_NODE_EXISTS(DT_PATH(cpus)),
-		    (DT_FOREACH_CHILD(DT_PATH(cpus), CPU_STATES)),
-		    ())
-};
-
-/** Number of states for each CPU */
-static const uint8_t states_per_cpu[] = {
-	COND_CODE_1(DT_NODE_EXISTS(DT_PATH(cpus)),
-		    (DT_FOREACH_CHILD(DT_PATH(cpus), NUM_CPU_STATES)),
-		    ())
-};
-
 struct pm_state_info pm_policy_next_state(uint8_t cpu, int32_t ticks)
 {
-	CHECKIF(cpu >= ARRAY_SIZE(states_per_cpu)) {
-		goto error;
-	}
+	uint8_t num_cpu_states;
+	const struct pm_state_info *cpu_states;
 
-	for (int16_t i = (int16_t)states_per_cpu[cpu] - 1; i >= 0; i--) {
-		const struct pm_state_info *state = &((cpus_states[cpu])[i]);
+	num_cpu_states = pm_state_cpu_get_all(cpu, &cpu_states);
+
+	for (int16_t i = (int16_t)num_cpu_states - 1; i >= 0; i--) {
+		const struct pm_state_info *state = &cpu_states[i];
 		uint32_t min_residency, exit_latency;
 
 		if (!pm_constraint_get(state->state)) {
@@ -89,7 +40,6 @@ struct pm_state_info pm_policy_next_state(uint8_t cpu, int32_t ticks)
 		}
 	}
 
-error:
 	LOG_DBG("No suitable power state found for cpu: %d!", cpu);
 	return (struct pm_state_info){PM_STATE_ACTIVE, 0, 0};
 }

--- a/subsys/pm/state.c
+++ b/subsys/pm/state.c
@@ -8,6 +8,9 @@
 #include <pm/state.h>
 #include <toolchain.h>
 
+BUILD_ASSERT(DT_NODE_EXISTS(DT_PATH(cpus)),
+	     "cpus node not defined in Devicetree");
+
 /**
  * Check CPU power state consistency.
  *
@@ -34,25 +37,19 @@
 		     CHECK_POWER_STATE_CONSISTENCY, node_id)		       \
 
 /* Check that all power states are consistent */
-COND_CODE_1(DT_NODE_EXISTS(DT_PATH(cpus)),
-	    (DT_FOREACH_CHILD(DT_PATH(cpus), CHECK_POWER_STATES_CONSISTENCY)),
-	    ())
+DT_FOREACH_CHILD(DT_PATH(cpus), CHECK_POWER_STATES_CONSISTENCY)
 
 #define NUM_CPU_STATES(n) DT_NUM_CPU_POWER_STATES(n),
 #define CPU_STATES(n) (struct pm_state_info[])PM_STATE_INFO_LIST_FROM_DT_CPU(n),
 
 /** CPU power states information for each CPU */
 static const struct pm_state_info *cpus_states[] = {
-	COND_CODE_1(DT_NODE_EXISTS(DT_PATH(cpus)),
-		    (DT_FOREACH_CHILD(DT_PATH(cpus), CPU_STATES)),
-		    ())
+	DT_FOREACH_CHILD(DT_PATH(cpus), CPU_STATES)
 };
 
 /** Number of states for each CPU */
 static const uint8_t states_per_cpu[] = {
-	COND_CODE_1(DT_NODE_EXISTS(DT_PATH(cpus)),
-		    (DT_FOREACH_CHILD(DT_PATH(cpus), NUM_CPU_STATES)),
-		    ())
+	DT_FOREACH_CHILD(DT_PATH(cpus), NUM_CPU_STATES)
 };
 
 uint8_t pm_state_cpu_get_all(uint8_t cpu, const struct pm_state_info **states)

--- a/subsys/pm/state.c
+++ b/subsys/pm/state.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2018 Intel Corporation.
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <pm/state.h>
+#include <toolchain.h>
+
+/**
+ * Check CPU power state consistency.
+ *
+ * @param i Power state index.
+ * @param node_id CPU node identifier.
+ */
+#define CHECK_POWER_STATE_CONSISTENCY(i, node_id)			       \
+	BUILD_ASSERT(							       \
+		DT_PROP_BY_PHANDLE_IDX_OR(node_id, cpu_power_states, i,	       \
+					  min_residency_us, 0U) >=	       \
+		DT_PROP_BY_PHANDLE_IDX_OR(node_id, cpu_power_states, i,	       \
+					  exit_latency_us, 0U),		       \
+		"Found CPU power state with min_residency < exit_latency");
+
+/**
+ * @brief Check CPU power states consistency
+ *
+ * All states should have a minimum residency >= than the exit latency.
+ *
+ * @param node_id A CPU node identifier.
+ */
+#define CHECK_POWER_STATES_CONSISTENCY(node_id)				       \
+	UTIL_LISTIFY(DT_NUM_CPU_POWER_STATES(node_id),			       \
+		     CHECK_POWER_STATE_CONSISTENCY, node_id)		       \
+
+/* Check that all power states are consistent */
+COND_CODE_1(DT_NODE_EXISTS(DT_PATH(cpus)),
+	    (DT_FOREACH_CHILD(DT_PATH(cpus), CHECK_POWER_STATES_CONSISTENCY)),
+	    ())
+
+#define NUM_CPU_STATES(n) DT_NUM_CPU_POWER_STATES(n),
+#define CPU_STATES(n) (struct pm_state_info[])PM_STATE_INFO_LIST_FROM_DT_CPU(n),
+
+/** CPU power states information for each CPU */
+static const struct pm_state_info *cpus_states[] = {
+	COND_CODE_1(DT_NODE_EXISTS(DT_PATH(cpus)),
+		    (DT_FOREACH_CHILD(DT_PATH(cpus), CPU_STATES)),
+		    ())
+};
+
+/** Number of states for each CPU */
+static const uint8_t states_per_cpu[] = {
+	COND_CODE_1(DT_NODE_EXISTS(DT_PATH(cpus)),
+		    (DT_FOREACH_CHILD(DT_PATH(cpus), NUM_CPU_STATES)),
+		    ())
+};
+
+uint8_t pm_state_cpu_get_all(uint8_t cpu, const struct pm_state_info **states)
+{
+	if (cpu >= ARRAY_SIZE(cpus_states)) {
+		return 0;
+	}
+
+	*states = cpus_states[cpu];
+
+	return states_per_cpu[cpu];
+}

--- a/tests/kernel/profiling/profiling_api/src/main.c
+++ b/tests/kernel/profiling/profiling_api/src/main.c
@@ -23,7 +23,7 @@ static void tdata_dump_callback(const struct k_thread *thread, void *user_data)
 }
 
 /* Our PM policy handler */
-struct pm_state_info pm_policy_next_state(uint8_t cpu, int32_t ticks)
+const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks)
 {
 	static bool test_flag;
 
@@ -37,7 +37,7 @@ struct pm_state_info pm_policy_next_state(uint8_t cpu, int32_t ticks)
 		test_flag = true;
 	}
 
-	return (struct pm_state_info){PM_STATE_ACTIVE, 0, 0};
+	return NULL;
 }
 
 /*work handler*/

--- a/tests/subsys/pm/device_wakeup_api/src/main.c
+++ b/tests/subsys/pm/device_wakeup_api/src/main.c
@@ -57,16 +57,20 @@ void pm_power_state_exit_post_ops(struct pm_state_info info)
 	irq_unlock(0);
 }
 
-struct pm_state_info pm_policy_next_state(uint8_t cpu, int32_t ticks)
+const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks)
 {
+	static const struct pm_state_info state = {
+		.state = PM_STATE_SUSPEND_TO_RAM
+	};
+
 	ARG_UNUSED(cpu);
 
 	while (sleep_count < 3) {
 		sleep_count++;
-		return (struct pm_state_info){PM_STATE_SUSPEND_TO_RAM, 0, 0, 0};
+		return &state;
 	}
 
-	return (struct pm_state_info){PM_STATE_ACTIVE, 0, 0, 0};
+	return NULL;
 }
 
 void test_wakeup_device_api(void)

--- a/tests/subsys/pm/policy_api/CMakeLists.txt
+++ b/tests/subsys/pm/policy_api/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Copyright (c) 2021 Nordic Semiconductor ASA.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(policy_api)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/subsys/pm/policy_api/app.overlay
+++ b/tests/subsys/pm/policy_api/app.overlay
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	cpus {
+		cpu1: cpu@1 {
+			compatible = "zephyr,native-posix-cpu";
+			reg = <1>;
+			cpu-power-states = <&state2>;
+		};
+	};
+
+	power-states {
+		state0: state0 {
+			compatible = "zephyr,power-state";
+			power-state-name = "runtime-idle";
+			min-residency-us = <100000>;
+			exit-latency-us = <10000>;
+		};
+
+		state1: state1 {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-ram";
+			min-residency-us = <1000000>;
+			exit-latency-us = <100000>;
+		};
+
+		state2: state2 {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-ram";
+			min-residency-us = <500000>;
+			exit-latency-us = <50000>;
+		};
+	};
+};
+
+&cpu0 {
+	cpu-power-states = <&state0 &state1>;
+};

--- a/tests/subsys/pm/policy_api/prj.conf
+++ b/tests/subsys/pm/policy_api/prj.conf
@@ -1,0 +1,5 @@
+# Copyright (c) 2021 Nordic Semiconductor ASA.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y
+CONFIG_PM=y

--- a/tests/subsys/pm/policy_api/src/main.c
+++ b/tests/subsys/pm/policy_api/src/main.c
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <pm/policy.h>
+#include <sys/time_units.h>
+#include <sys_clock.h>
+#include <ztest.h>
+
+#ifdef CONFIG_PM_POLICY_RESIDENCY
+/**
+ * @brief Test the behavior of pm_policy_next_state() when
+ * CONFIG_PM_POLICY_RESIDENCY=y.
+ */
+static void test_pm_policy_next_state_residency(void)
+{
+	const struct pm_state_info *next;
+
+	/* cpu 0 */
+	next = pm_policy_next_state(0U, 0);
+	zassert_equal(next, NULL, NULL);
+
+	next = pm_policy_next_state(0U, k_us_to_ticks_floor32(10999));
+	zassert_equal(next, NULL, NULL);
+
+	next = pm_policy_next_state(0U, k_us_to_ticks_floor32(110000));
+	zassert_equal(next->state, PM_STATE_RUNTIME_IDLE, NULL);
+	zassert_equal(next->min_residency_us, 100000, NULL);
+	zassert_equal(next->exit_latency_us, 10000, NULL);
+
+	next = pm_policy_next_state(0U, k_us_to_ticks_floor32(1099999));
+	zassert_equal(next->state, PM_STATE_RUNTIME_IDLE, NULL);
+
+	next = pm_policy_next_state(0U, k_us_to_ticks_floor32(1100000));
+	zassert_equal(next->state, PM_STATE_SUSPEND_TO_RAM, NULL);
+	zassert_equal(next->min_residency_us, 1000000, NULL);
+	zassert_equal(next->exit_latency_us, 100000, NULL);
+
+	next = pm_policy_next_state(0U, K_TICKS_FOREVER);
+	zassert_equal(next->state, PM_STATE_SUSPEND_TO_RAM, NULL);
+
+	/* cpu 1 */
+	next = pm_policy_next_state(1U, 0);
+	zassert_equal(next, NULL, NULL);
+
+	next = pm_policy_next_state(1U, k_us_to_ticks_floor32(549999));
+	zassert_equal(next, NULL, NULL);
+
+	next = pm_policy_next_state(1U, k_us_to_ticks_floor32(550000));
+	zassert_equal(next->state, PM_STATE_SUSPEND_TO_RAM, NULL);
+	zassert_equal(next->min_residency_us, 500000, NULL);
+	zassert_equal(next->exit_latency_us, 50000, NULL);
+
+	next = pm_policy_next_state(1U, K_TICKS_FOREVER);
+	zassert_equal(next->state, PM_STATE_SUSPEND_TO_RAM, NULL);
+}
+#else
+static void test_pm_policy_next_state_residency(void)
+{
+	ztest_test_skip();
+}
+#endif /* CONFIG_PM_POLICY_RESIDENCY */
+
+#ifdef CONFIG_PM_POLICY_APP
+const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks)
+{
+	static const struct pm_state_info state = {.state = PM_STATE_SOFT_OFF};
+
+	ARG_UNUSED(cpu);
+	ARG_UNUSED(ticks);
+
+	return &state;
+}
+
+/**
+ * @brief Test that a custom policy can be implemented when
+ * CONFIG_PM_POLICY_APP=y.
+ */
+static void test_pm_policy_next_state_app(void)
+{
+	const struct pm_state_info *next;
+
+	next = pm_policy_next_state(0U, 0);
+	zassert_equal(next->state, PM_STATE_SOFT_OFF, NULL);
+}
+#else
+static void test_pm_policy_next_state_app(void)
+{
+	ztest_test_skip();
+}
+#endif /* CONFIG_PM_POLICY_APP */
+
+void test_main(void)
+{
+	ztest_test_suite(policy_api,
+			 ztest_unit_test(test_pm_policy_next_state_residency),
+			 ztest_unit_test(test_pm_policy_next_state_app));
+	ztest_run_test_suite(policy_api);
+}

--- a/tests/subsys/pm/policy_api/testcase.yaml
+++ b/tests/subsys/pm/policy_api/testcase.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) 2021 Nordic Semiconductor ASA.
+# SPDX-License-Identifier: Apache-2.0
+
+common:
+  tags: pm
+  platform_allow: native_posix native_posix_64
+tests:
+  subsys.pm.policy_api: {}
+  subsys.pm.policy_api_app:
+    extra_configs:
+      - CONFIG_PM_POLICY_APP=y

--- a/tests/subsys/pm/power_mgmt/src/main.c
+++ b/tests/subsys/pm/power_mgmt/src/main.c
@@ -198,9 +198,9 @@ void pm_power_state_exit_post_ops(struct pm_state_info info)
 }
 
 /* Our PM policy handler */
-struct pm_state_info pm_policy_next_state(uint8_t cpu, int ticks)
+const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks)
 {
-	struct pm_state_info info = {};
+	static struct pm_state_info info;
 
 	ARG_UNUSED(cpu);
 
@@ -219,7 +219,7 @@ struct pm_state_info pm_policy_next_state(uint8_t cpu, int ticks)
 		 */
 		info.state = PM_STATE_ACTIVE;
 	}
-	return info;
+	return &info;
 }
 
 /* implement in application, called by idle thread */

--- a/tests/subsys/pm/power_mgmt_multicore/src/main.c
+++ b/tests/subsys/pm/power_mgmt_multicore/src/main.c
@@ -60,9 +60,9 @@ void pm_power_state_exit_post_ops(struct pm_state_info info)
 	irq_unlock(0);
 }
 
-struct pm_state_info pm_policy_next_state(uint8_t cpu, int ticks)
+const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int ticks)
 {
-	struct pm_state_info info = {};
+	static struct pm_state_info info = {};
 	int32_t msecs = k_ticks_to_ms_floor64(ticks);
 
 	if (msecs < ACTIVE_MSEC) {
@@ -81,7 +81,7 @@ struct pm_state_info pm_policy_next_state(uint8_t cpu, int ticks)
 
 	state_testing[_current_cpu->id] = info.state;
 
-	return info;
+	return &info;
 }
 
 /*


### PR DESCRIPTION
Principal changes in this PR:

- Add `pm_state_cpu_get_all` API to obtain CPU power states information.
- Simplify residency policy by using this new API
- Policy returns now a reference to the next state instead of a struct copy
- Add new tests that cover the behavior of the policy API

Others:
- Added `cpus` node to native_posix and leon3 (was missing), this simplifies PM code as we can assume `cpus` exists
- Fixed some include issues (sys/time_units.h)