### PR TITLE
drivers: display_nrf_led_matrix: Add option to light LEDs in groups

### DIFF
--- a/boards/arm/bbc_microbit/bbc_microbit.dts
+++ b/boards/arm/bbc_microbit/bbc_microbit.dts
@@ -65,6 +65,7 @@
 			    <&gpio0 12 GPIO_ACTIVE_LOW>;
 		refresh-frequency = <50>;
 		timer = <&timer2>;
+		pixel-group-size = <3>;
 	};
 };
 

--- a/boards/arm/bbc_microbit_v2/bbc_microbit_v2.dts
+++ b/boards/arm/bbc_microbit_v2/bbc_microbit_v2.dts
@@ -64,6 +64,7 @@
 		refresh-frequency = <50>;
 		timer = <&timer4>;
 		pwm = <&pwm0>;
+		pixel-group-size = <4>;
 	};
 
 	edge_connector: connector {

--- a/drivers/display/Kconfig.nrf_led_matrix
+++ b/drivers/display/Kconfig.nrf_led_matrix
@@ -8,12 +8,12 @@ config DISPLAY_NRF_LED_MATRIX
 	select NRFX_PPI if HAS_HW_NRF_PPI
 	help
 	  Enable driver for a LED matrix with rows and columns driven by
-	  GPIOs. The matrix is refreshed pixel by pixel (only one LED is
-	  turned on in particular time slots) and each pixel can have one
-	  of 256 levels of brightness (0 means off completely).
+	  GPIOs. The driver allows setting one of 256 levels of brightness
+	  (where 0 means off completely) for each of the LEDs independently.
 	  Assignment of GPIOs to rows and columns and the mapping of those
 	  to pixels are specified in properties of a "nordic,nrf-led-matrix"
 	  compatible node in devicetree.
-	  The driver uses one TIMER instance and, depending on what is set
-	  in devicetree, one PWM instance or one PPI channel and one GPIOTE
-	  channel.
+	  The driver uses one TIMER instance and, depending on what is set in
+	  devicetree, one PWM instance or one or more GPIOTE and PPI channels
+	  (the latter value depends on the chosen pixel group size - the number
+	  of LEDs in one row that can be lit simultaneously).

--- a/dts/bindings/display/nordic,nrf-led-matrix.yaml
+++ b/dts/bindings/display/nordic,nrf-led-matrix.yaml
@@ -61,5 +61,22 @@ properties:
       required: false
       description: |
         Reference to a PWM instance for generating pulse signals on column
-        GPIOs. If not provided, one PPI and one GPIOTE channel are allocated
-        and used instead for generating those pulses.
+        GPIOs. If not provided, GPIOTE and PPI channels are allocated and
+        used instead for generating those pulses.
+
+    pixel-group-size:
+      type: int
+      required: true
+      description: |
+        This value specifies the maximum number of LEDs in one row that can
+        be lit simultaneously.
+        If set to 1, only a single LED is turned on in a particular time slot.
+        Bigger values increase the maximum achievable brightness of the LEDs
+        and lower the CPU load by decreasing the frequency of execution of
+        the timer interrupt handler.
+        In case GPIOTE and PPI channels are used for generating the pixel pulse
+        signals, the number of channels that need to be allocated is equal to
+        this value.
+        If GPIOTE and PPI channels are used, the upper limit for the value is
+        defined by the number of CC channels in the used timer minus one.
+        If PWM is used, the upper limit is the number of PWM channels.


### PR DESCRIPTION
Add a new DT property named "pixel-group-size" that allows users to
configure the driver to refresh the matrix by illuminating multiple
LEDs in particular rows simultaneously. This way the maximum possible
brightness of the LEDs can be increased (as they can be lit longer)
and the timer interrupt handler is executed less frequently, what
results in decreased CPU load, but more GPIOTE/PPI channels needs to
be allocated if the PWM peripheral cannot be used. Thus, it is left
to users to select the configuration that suits them best.

Update definitions of both the bbc_microbit boards with this new
property, using the maximum available group size (to achieve maximum
possible brightness). For v2, no new resources are used (only all
channels in the already used PWM peripheral are now utilized).
For v1, two more GPIOTE and PPI channels are allocated.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>