### PR TITLE
drivers: serial: nrfx_uart: fix pin disconnect in suspend when !PINCTRL

### DIFF
--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -1184,7 +1184,7 @@ static int uart_nrfx_pm_action(const struct device *dev,
 				return ret;
 			}
 #else
-			uart_nrfx_pins_configure(dev, false);
+			uart_nrfx_pins_configure(dev, true);
 #endif /* CONFIG_PINCTRL */
 		}
 		break;


### PR DESCRIPTION
Fix pin disconnection when COFNIG_PINCTRL=n, so that less power is used
in suspended state. This seems to be a copy-paste kind of bug, since
when both resuming and suspending the same configuration was applied.

Fixes: 5567d7ae072b ("drivers: serial: nrfx_uart: add support for pinctrl")