### PR TITLE
boards: posix: nrf52_bsim: provide missing CMSIS functions

### DIFF
--- a/boards/posix/nrf52_bsim/cmsis.c
+++ b/boards/posix/nrf52_bsim/cmsis.c
@@ -67,3 +67,8 @@ uint32_t __get_PRIMASK(void)
 {
 	return hw_irq_ctrl_get_current_lock();
 }
+
+void __set_PRIMASK(uint32_t primask)
+{
+	hw_irq_ctrl_change_lock(primask != 0);
+}

--- a/boards/posix/nrf52_bsim/cmsis.h
+++ b/boards/posix/nrf52_bsim/cmsis.h
@@ -38,6 +38,14 @@ extern "C" {
 #define __NOP()
 #endif
 
+void __enable_irq(void);
+
+void __disable_irq(void);
+
+uint32_t __get_PRIMASK(void);
+
+void __set_PRIMASK(uint32_t primask);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This commit provides missing CMSIS functions for nRF52 babblesim board.

Signed-off-by: Jedrzej Ciupis <jedrzej.ciupis@nordicsemi.no>