### PR TITLE
samples: userspace: skip syscall_perf test

### DIFF
--- a/samples/userspace/syscall_perf/sample.yaml
+++ b/samples/userspace/syscall_perf/sample.yaml
@@ -11,4 +11,4 @@ common:
 tests:
   sample.syscall_performances:
     filter: CONFIG_ARCH_HAS_USERSPACE
-    platform_allow: riscv32
+    skip: true


### PR DESCRIPTION
This test was never performed in CI due to the incorrect platform name in `platform_allow` list. I do not know which platform from RISCV architecture the author of this test had in mind. If it be taken into consideration `CONFIG_ARCH_HAS_USERSPACE` filter in this testcase, only platforms from the E31 family fulfill this assumption: `qemu_riscv32_xip` and `hifive1_revb`. I tried to build this sample for those platforms by `west` command but it fails. I decided to remove wrong `riscv32` platform name from `platform_allow` list and mark this test as skip. I know that it is not the best solution, but it seems to have no sense to keep in repository tests, which cannot be evaluated. Perhaps all test should be removed from samples or it should be clarify how this sample should be run. 

I'm open for propositions what can be done with this sample.

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>