### PR TITLE
drivers: avoid i2c_burst_write where possible

### DIFF
--- a/drivers/gpio/gpio_mcp230xx.c
+++ b/drivers/gpio/gpio_mcp230xx.c
@@ -48,10 +48,13 @@ static int mcp230xx_write_port_regs(const struct device *dev, uint8_t reg, uint1
 	const struct mcp23xxx_config *config = dev->config;
 	int ret;
 
-	uint8_t nwrite = (config->ngpios == 8) ? 1 : 2;
-	uint16_t port_data = sys_cpu_to_le16(value);
+	uint8_t nwrite = (config->ngpios == 8) ? 2 : 3;
+	uint8_t buf[3];
 
-	ret = i2c_burst_write_dt(&config->bus.i2c, reg, (uint8_t *)&port_data, nwrite);
+	buf[0] = reg;
+	sys_put_le16(value, &buf[1]);
+
+	ret = i2c_write_dt(&config->bus.i2c, buf, nwrite);
 	if (ret < 0) {
 		LOG_ERR("i2c_write failed!");
 		return ret;

--- a/drivers/gpio/gpio_pca95xx.c
+++ b/drivers/gpio/gpio_pca95xx.c
@@ -181,17 +181,17 @@ static int write_port_regs(const struct device *dev, uint8_t reg,
 		(struct gpio_pca95xx_drv_data * const)dev->data;
 	const struct device *i2c_master = drv_data->i2c_master;
 	uint16_t i2c_addr = config->i2c_slave_addr;
-	uint16_t port_data;
+	uint8_t buf[3];
 	int ret;
 
 	LOG_DBG("PCA95XX[0x%X]: Write: REG[0x%X] = 0x%X, REG[0x%X] = "
 		"0x%X", i2c_addr, reg, (value & 0xFF),
 		(reg + 1), (value >> 8));
 
-	port_data = sys_cpu_to_le16(value);
+	buf[0] = reg;
+	sys_put_le16(value, &buf[1]);
 
-	ret = i2c_burst_write(i2c_master, i2c_addr, reg,
-			      (uint8_t *)&port_data, sizeof(port_data));
+	ret = i2c_write(i2c_master, buf, sizeof(buf), i2c_addr);
 	if (ret == 0) {
 		*cache = value;
 	} else {

--- a/drivers/gpio/gpio_stmpe1600.c
+++ b/drivers/gpio/gpio_stmpe1600.c
@@ -71,14 +71,16 @@ struct stmpe1600_drvdata {
 
 static int write_reg16(const struct stmpe1600_config * const config, uint8_t reg, uint16_t value)
 {
-	uint16_t transfer_data = sys_cpu_to_le16(value);
+	uint8_t buf[3];
 	int ret;
 
 	LOG_DBG("STMPE1600[0x%02X]: write REG[0x%02X..0x%02X] = %04x",
 		config->i2c_slave_addr, reg, reg + 1, value);
 
-	ret = i2c_burst_write(config->i2c_bus, config->i2c_slave_addr, reg,
-			      (uint8_t *)&transfer_data, sizeof(transfer_data));
+	buf[0] = reg;
+	sys_put_le16(value, &buf[1]);
+
+	ret = i2c_write(config->i2c_bus, buf, sizeof(buf), config->i2c_slave_addr);
 
 	if (ret != 0) {
 		LOG_ERR("STMPE1600[0x%02X]: write error REG[0x%02X..0x%02X]: %d",

--- a/drivers/sensor/max17055/max17055.c
+++ b/drivers/sensor/max17055/max17055.c
@@ -44,11 +44,12 @@ static int max17055_reg_read(struct max17055_data *priv, int reg_addr,
 static int max17055_reg_write(struct max17055_data *priv, int reg_addr,
 			      uint16_t val)
 {
-	uint8_t i2c_data[2];
+	uint8_t buf[3];
 
-	sys_put_le16(val, i2c_data);
+	buf[0] = (uint8_t)reg_addr;
+	sys_put_le16(val, &buf[1]);
 
-	return i2c_burst_write(priv->i2c, DT_INST_REG_ADDR(0), reg_addr, i2c_data, 2);
+	return i2c_write(priv->i2c, buf, sizeof(buf), DT_INST_REG_ADDR(0));
 }
 
 /**

--- a/drivers/sensor/tmp112/tmp112.c
+++ b/drivers/sensor/tmp112/tmp112.c
@@ -33,9 +33,12 @@ static int tmp112_reg_read(const struct tmp112_config *cfg,
 static int tmp112_reg_write(const struct tmp112_config *cfg,
 			    uint8_t reg, uint16_t val)
 {
-	uint16_t val_be = sys_cpu_to_be16(val);
+	uint8_t buf[3];
 
-	return i2c_burst_write_dt(&cfg->bus, reg, (uint8_t *)&val_be, 2);
+	buf[0] = reg;
+	sys_put_be16(val, &buf[1]);
+
+	return i2c_write_dt(&cfg->bus, buf, sizeof(buf));
 }
 
 static uint16_t set_config_flags(struct tmp112_data *data, uint16_t mask,


### PR DESCRIPTION
i2c_burst_write can have portability issues with certain i2c
peripherals that can fail when this api is called. This fixes the case
where this can be easily replaced with i2c_write in mcp230xx,
pca95xx, stmpe1600, max17055, and tmp112.

Signed-off-by: Ryan McClelland <ryanmcclelland@fb.com>