### PR TITLE
Add ISO central and peripheral security handling

### DIFF
--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -121,6 +121,7 @@ struct bt_iso_chan {
 	/** Channel QoS reference */
 	struct bt_iso_chan_qos		*qos;
 	enum bt_iso_state		state;
+#if defined(CONFIG_BT_SMP)
 	/** @brief The required security level of the channel
 	 *
 	 * This value can be set as the central before connecting a CIS
@@ -129,6 +130,7 @@ struct bt_iso_chan {
 	 * peripheral once a channel has been accepted.
 	 */
 	bt_security_t			required_sec_level;
+#endif /* CONFIG_BT_SMP */
 	/** Node used internally by the stack */
 	sys_snode_t node;
 };
@@ -503,8 +505,10 @@ struct bt_iso_accept_info {
 
 /** @brief ISO Server structure. */
 struct bt_iso_server {
+#if defined(CONFIG_BT_SMP)
 	/** Required minimum security level */
 	bt_security_t		sec_level;
+#endif /* CONFIG_BT_SMP */
 
 	/** @brief Server accept callback
 	 *

--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -94,6 +94,8 @@ extern "C" {
 enum bt_iso_state {
 	/** Channel disconnected */
 	BT_ISO_STATE_DISCONNECTED,
+	/** Channel is pending ACL encryption before connecting */
+	BT_ISO_STATE_ENCRYPT_PENDING,
 	/** Channel in connecting state */
 	BT_ISO_STATE_CONNECTING,
 	/** Channel ready for upper layer traffic on it */
@@ -119,6 +121,13 @@ struct bt_iso_chan {
 	/** Channel QoS reference */
 	struct bt_iso_chan_qos		*qos;
 	enum bt_iso_state		state;
+	/** @brief The required security level of the channel
+	 *
+	 * This value can be set as the central before connecting a CIS
+	 * with bt_iso_chan_connect().
+	 * The value is overwritten to @ref bt_iso_server::sec_level for the
+	 * peripheral once a channel has been accepted.
+	 */
 	bt_security_t			required_sec_level;
 	/** Node used internally by the stack */
 	sys_snode_t node;
@@ -435,7 +444,7 @@ struct bt_iso_chan_ops {
 	 *
 	 *  If this callback is provided it will be called whenever the
 	 *  channel is disconnected, including when a connection gets
-	 *  rejected.
+	 *  rejected or when setting security fails.
 	 *
 	 *  @param chan   The channel that has been Disconnected
 	 *  @param reason BT_HCI_ERR_* reason for the disconnection.

--- a/samples/bluetooth/iso_connected_benchmark/src/main.c
+++ b/samples/bluetooth/iso_connected_benchmark/src/main.c
@@ -338,7 +338,9 @@ static int iso_accept(const struct bt_iso_accept_info *info,
 }
 
 static struct bt_iso_server iso_server = {
+#if defined(CONFIG_BT_SMP)
 	.sec_level = DEFAULT_CIS_SEC_LEVEL,
+#endif /* CONFIG_BT_SMP */
 	.accept = iso_accept,
 };
 

--- a/samples/bluetooth/peripheral_iso/src/main.c
+++ b/samples/bluetooth/peripheral_iso/src/main.c
@@ -141,7 +141,9 @@ static int iso_accept(const struct bt_iso_accept_info *info,
 }
 
 static struct bt_iso_server iso_server = {
+#if defined(CONFIG_BT_SMP)
 	.sec_level = BT_SECURITY_L1,
+#endif /* CONFIG_BT_SMP */
 	.accept = iso_accept,
 };
 

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1986,6 +1986,9 @@ void bt_conn_security_changed(struct bt_conn *conn, uint8_t hci_err,
 
 	reset_pairing(conn);
 	bt_l2cap_security_changed(conn, hci_err);
+	if (IS_ENABLED(CONFIG_BT_ISO_CENTRAL)) {
+		bt_iso_security_changed(conn, hci_err);
+	}
 
 	for (cb = callback_list; cb; cb = cb->_next) {
 		if (cb->security_changed) {

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -927,12 +927,14 @@ int bt_iso_server_register(struct bt_iso_server *server)
 		return -EINVAL;
 	}
 
+#if defined(CONFIG_BT_SMP)
 	if (server->sec_level > BT_SECURITY_L3) {
 		return -EINVAL;
 	} else if (server->sec_level < BT_SECURITY_L1) {
 		/* Level 0 is only applicable for BR/EDR */
 		server->sec_level = BT_SECURITY_L1;
 	}
+#endif /* CONFIG_BT_SMP */
 
 	BT_DBG("%p", server);
 
@@ -969,7 +971,9 @@ static int iso_accept(struct bt_conn *acl, struct bt_conn *iso)
 		return err;
 	}
 
+#if defined(CONFIG_BT_SMP)
 	chan->required_sec_level = iso_server->sec_level;
+#endif /* CONFIG_BT_SMP */
 
 	bt_iso_chan_add(iso, chan);
 	bt_iso_chan_set_state(chan, BT_ISO_STATE_CONNECTING);
@@ -1028,11 +1032,15 @@ static uint8_t iso_server_check_security(struct bt_conn *conn)
 		return BT_HCI_ERR_SUCCESS;
 	}
 
+#if defined(CONFIG_BT_SMP)
 	if (conn->sec_level >= iso_server->sec_level) {
 		return BT_HCI_ERR_SUCCESS;
 	}
 
 	return BT_HCI_ERR_INSUFFICIENT_SECURITY;
+#else
+	return BT_HCI_ERR_SUCCESS;
+#endif /* CONFIG_BT_SMP */
 }
 
 void hci_le_cis_req(struct net_buf *buf)
@@ -1815,6 +1823,7 @@ static int hci_le_create_cis(const struct bt_iso_connect_param *param,
 	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_CREATE_CIS, buf, NULL);
 }
 
+#if defined(CONFIG_BT_SMP)
 static int iso_chan_connect_security(const struct bt_iso_connect_param *param,
 				     size_t count)
 {
@@ -1863,6 +1872,7 @@ static int iso_chan_connect_security(const struct bt_iso_connect_param *param,
 
 	return 0;
 }
+#endif /* CONFIG_BT_SMP */
 
 int bt_iso_chan_connect(const struct bt_iso_connect_param *param, size_t count)
 {
@@ -1913,6 +1923,7 @@ int bt_iso_chan_connect(const struct bt_iso_connect_param *param, size_t count)
 		}
 	}
 
+#if defined(CONFIG_BT_SMP)
 	/* Check for and initiate security for all channels that have
 	 * requested encryption if the ACL link is not already secured
 	 */
@@ -1921,6 +1932,7 @@ int bt_iso_chan_connect(const struct bt_iso_connect_param *param, size_t count)
 		BT_DBG("Failed to initate security for all CIS: %d", err);
 		return err;
 	}
+#endif /* CONFIG_BT_SMP */
 
 	err = hci_le_create_cis(param, count);
 	if (err == -ECANCELED) {

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -957,10 +957,6 @@ static int iso_accept(struct bt_conn *acl, struct bt_conn *iso)
 
 	BT_DBG("%p", iso);
 
-	if (!iso_server) {
-		return -ENOMEM;
-	}
-
 	accept_info.acl = acl;
 	accept_info.cig_id = iso->iso.cig_id;
 	accept_info.cis_id = iso->iso.cis_id;
@@ -1054,6 +1050,12 @@ void hci_le_cis_req(struct net_buf *buf)
 
 	BT_DBG("acl_handle %u cis_handle %u cig_id %u cis %u",
 		acl_handle, cis_handle, evt->cig_id, evt->cis_id);
+
+	if (iso_server == NULL) {
+		BT_DBG("No ISO server registered");
+		hci_le_reject_cis(cis_handle, BT_HCI_ERR_UNSPECIFIED);
+		return;
+	}
 
 	/* Lookup existing connection with same handle */
 	iso = bt_conn_lookup_handle(cis_handle);

--- a/subsys/bluetooth/host/iso_internal.h
+++ b/subsys/bluetooth/host/iso_internal.h
@@ -106,6 +106,9 @@ void bt_iso_connected(struct bt_conn *iso);
 /* Notify ISO channels of a disconnect event */
 void bt_iso_disconnected(struct bt_conn *iso);
 
+/* Notify ISO connected channels of security changed */
+void bt_iso_security_changed(struct bt_conn *acl, uint8_t hci_status);
+
 /* Allocate ISO PDU */
 #if defined(CONFIG_NET_BUF_LOG)
 struct net_buf *bt_iso_create_pdu_timeout_debug(struct net_buf_pool *pool,

--- a/subsys/bluetooth/shell/iso.c
+++ b/subsys/bluetooth/shell/iso.c
@@ -547,12 +547,16 @@ SHELL_STATIC_SUBCMD_SET_CREATE(iso_cmds,
 	SHELL_CMD_ARG(cig_create, NULL, "[dir=tx,rx,txrx] [interval] [packing] [framing] "
 		      "[latency] [sdu] [phy] [rtn]", cmd_cig_create, 1, 8),
 	SHELL_CMD_ARG(cig_term, NULL, "Terminate the CIG", cmd_cig_term, 1, 0),
+#if defined(CONFIG_BT_SMP)
+	SHELL_CMD_ARG(connect, NULL, "Connect ISO Channel [security level]", cmd_connect, 1, 1),
+#else /* !CONFIG_BT_SMP */
 	SHELL_CMD_ARG(connect, NULL, "Connect ISO Channel", cmd_connect, 1, 0),
+#endif /* CONFIG_BT_SMP */
 #endif /* CONFIG_BT_ISO_CENTRAL */
 #if defined(CONFIG_BT_ISO_PERIPHERAL)
 #if defined(CONFIG_BT_SMP)
 	SHELL_CMD_ARG(listen, NULL, "<dir=tx,rx,txrx> [security level]", cmd_listen, 2, 1),
-#else
+#else /* !CONFIG_BT_SMP */
 	SHELL_CMD_ARG(listen, NULL, "<dir=tx,rx,txrx>", cmd_listen, 2, 0),
 #endif /* CONFIG_BT_SMP */
 #endif /* CONFIG_BT_ISO_PERIPHERAL */

--- a/subsys/bluetooth/shell/iso.c
+++ b/subsys/bluetooth/shell/iso.c
@@ -206,6 +206,12 @@ static int cmd_connect(const struct shell *sh, size_t argc, char *argv[])
 		return 0;
 	}
 
+#if defined(CONFIG_BT_SMP)
+	if (argc > 1) {
+		iso_chan.required_sec_level = *argv[1] - '0';
+	}
+#endif /* CONFIG_BT_SMP */
+
 	err = bt_iso_chan_connect(&connect_param, 1);
 	if (err) {
 		shell_error(sh, "Unable to connect (err %d)", err);
@@ -237,7 +243,9 @@ static int iso_accept(const struct bt_iso_accept_info *info,
 }
 
 struct bt_iso_server iso_server = {
+#if defined(CONFIG_BT_SMP)
 	.sec_level = BT_SECURITY_L1,
+#endif /* CONFIG_BT_SMP */
 	.accept = iso_accept,
 };
 
@@ -260,9 +268,11 @@ static int cmd_listen(const struct shell *sh, size_t argc, char *argv[])
 		return -ENOEXEC;
 	}
 
+#if defined(CONFIG_BT_SMP)
 	if (argc > 2) {
 		iso_server.sec_level = *argv[2] - '0';
 	}
+#endif /* CONFIG_BT_SMP */
 
 	err = bt_iso_server_register(&iso_server);
 	if (err) {
@@ -540,7 +550,11 @@ SHELL_STATIC_SUBCMD_SET_CREATE(iso_cmds,
 	SHELL_CMD_ARG(connect, NULL, "Connect ISO Channel", cmd_connect, 1, 0),
 #endif /* CONFIG_BT_ISO_CENTRAL */
 #if defined(CONFIG_BT_ISO_PERIPHERAL)
+#if defined(CONFIG_BT_SMP)
 	SHELL_CMD_ARG(listen, NULL, "<dir=tx,rx,txrx> [security level]", cmd_listen, 2, 1),
+#else
+	SHELL_CMD_ARG(listen, NULL, "<dir=tx,rx,txrx>", cmd_listen, 2, 0),
+#endif /* CONFIG_BT_SMP */
 #endif /* CONFIG_BT_ISO_PERIPHERAL */
 	SHELL_CMD_ARG(send, NULL, "Send to ISO Channel [count]",
 		      cmd_send, 1, 1),


### PR DESCRIPTION
The `required_sec_level` from `struct bt_iso_chan` and the `sec_level` from `struct bt_iso_server` was added to the API long time ago, but was never implemented properly. This PR updates the ISO implementation to properly use these values. 

fixes #33865 