### PR TITLE
drivers: gpio: test device

### DIFF
--- a/drivers/gpio/CMakeLists.txt
+++ b/drivers/gpio/CMakeLists.txt
@@ -52,6 +52,7 @@ zephyr_library_sources_ifdef(CONFIG_GPIO_NEORV32    gpio_neorv32.c)
 zephyr_library_sources_ifdef(CONFIG_GPIO_NCT38XX    gpio_nct38xx.c)
 zephyr_library_sources_ifdef(CONFIG_GPIO_NCT38XX    gpio_nct38xx_port.c)
 zephyr_library_sources_ifdef(CONFIG_GPIO_NCT38XX_INTERRUPT gpio_nct38xx_alert.c)
+zephyr_library_sources_ifdef(CONFIG_GPIO_TEST       gpio_test.c)
 
 
 zephyr_library_sources_ifdef(CONFIG_GPIO_SHELL      gpio_shell.c)

--- a/drivers/gpio/Kconfig
+++ b/drivers/gpio/Kconfig
@@ -115,4 +115,6 @@ source "drivers/gpio/Kconfig.neorv32"
 
 source "drivers/gpio/Kconfig.nct38xx"
 
+source "drivers/gpio/Kconfig.test"
+
 endif # GPIO

--- a/drivers/gpio/Kconfig.test
+++ b/drivers/gpio/Kconfig.test
@@ -1,0 +1,10 @@
+# Copyright (c) 2021, Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+# SPDX-License-Identifier: Apache-2.0
+
+DT_COMPAT_VND_GPIO := vnd,gpio
+
+# Hidden option for turning on the dummy driver for vnd,gpio devices
+# used in testing.
+config GPIO_TEST
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_VND_GPIO))

--- a/drivers/gpio/gpio_test.c
+++ b/drivers/gpio/gpio_test.c
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2021, Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * This is not a real GPIO driver. It is used to instantiate struct
+ * devices for the "vnd,gpio" devicetree compatible used in test code.
+ */
+
+#define DT_DRV_COMPAT vnd_gpio
+
+#include <drivers/gpio.h>
+
+static int vnd_gpio_pin_configure(const struct device *port,
+				  gpio_pin_t pin,
+				  gpio_flags_t flags)
+{
+	return -ENOTSUP;
+}
+
+static int vnd_gpio_port_get_raw(const struct device *port,
+				 gpio_port_value_t *value)
+{
+	return -ENOTSUP;
+}
+
+static int vnd_gpio_port_set_masked_raw(const struct device *port,
+					gpio_port_pins_t mask,
+					gpio_port_value_t value)
+{
+	return -ENOTSUP;
+}
+
+static int vnd_gpio_port_set_bits_raw(const struct device *port,
+				      gpio_port_pins_t pins)
+{
+	return -ENOTSUP;
+}
+
+static int vnd_gpio_port_clear_bits_raw(const struct device *port,
+					gpio_port_pins_t pins)
+{
+	return -ENOTSUP;
+}
+
+static int vnd_gpio_port_toggle_bits(const struct device *port,
+				     gpio_port_pins_t pins)
+{
+	return -ENOTSUP;
+}
+
+static int vnd_gpio_pin_interrupt_configure(const struct device *port,
+					    gpio_pin_t pin,
+					    enum gpio_int_mode mode,
+					    enum gpio_int_trig trig)
+{
+	return -ENOTSUP;
+}
+
+static int vnd_gpio_manage_callback(const struct device *port,
+				    struct gpio_callback *cb,
+				    bool set)
+{
+	return -ENOTSUP;
+}
+
+static uint32_t vnd_gpio_get_pending_int(const struct device *dev)
+{
+	return 0;
+}
+
+static const struct gpio_driver_api vnd_gpio_api = {
+	.pin_configure = vnd_gpio_pin_configure,
+	.port_get_raw = vnd_gpio_port_get_raw,
+	.port_set_masked_raw = vnd_gpio_port_set_masked_raw,
+	.port_set_bits_raw = vnd_gpio_port_set_bits_raw,
+	.port_clear_bits_raw = vnd_gpio_port_clear_bits_raw,
+	.port_toggle_bits = vnd_gpio_port_toggle_bits,
+	.pin_interrupt_configure = vnd_gpio_pin_interrupt_configure,
+	.manage_callback = vnd_gpio_manage_callback,
+	.get_pending_int = vnd_gpio_get_pending_int
+};
+
+static int vnd_gpio_init(const struct device *dev)
+{
+	return 0;
+}
+
+#define VND_GPIO_INIT(n)					  \
+	DEVICE_DT_INST_DEFINE(n, &vnd_gpio_init, NULL,		  \
+			      NULL, NULL, POST_KERNEL,		  \
+			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
+			      &vnd_gpio_api);
+
+DT_INST_FOREACH_STATUS_OKAY(VND_GPIO_INIT)

--- a/tests/drivers/build_all/adc/src/main.c
+++ b/tests/drivers/build_all/adc/src/main.c
@@ -4,16 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-
 void main(void)
 {
 }
-
-#if DT_NODE_EXISTS(DT_INST(0, vnd_gpio))
-/* Fake GPIO device, needed for building drivers that use DEVICE_DT_GET()
- * to access GPIO controllers.
- */
-DEVICE_DT_DEFINE(DT_INST(0, vnd_gpio), NULL, NULL, NULL, NULL,
-		 POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
-#endif

--- a/tests/drivers/build_all/adc/testcase.yaml
+++ b/tests/drivers/build_all/adc/testcase.yaml
@@ -5,7 +5,7 @@ tests:
   drivers.adc.spi.build:
     platform_allow: native_posix
     tags: adc_mcp302x adc_lmp90xxx
-    extra_args: "CONFIG_SPI=y CONFIG_ADC_MCP320X=y CONFIG_ADC_LMP90XXX=y"
+    extra_args: "CONFIG_GPIO=y CONFIG_SPI=y CONFIG_ADC_MCP320X=y CONFIG_ADC_LMP90XXX=y"
   drivers.adc.emul.build:
     platform_allow: native_posix
     tags: adc_emul

--- a/tests/drivers/build_all/counter/src/main.c
+++ b/tests/drivers/build_all/counter/src/main.c
@@ -4,16 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-
 void main(void)
 {
 }
-
-#if DT_NODE_EXISTS(DT_INST(0, vnd_gpio))
-/* Fake GPIO device, needed for building drivers that use DEVICE_DT_GET()
- * to access GPIO controllers.
- */
-DEVICE_DT_DEFINE(DT_INST(0, vnd_gpio), NULL, NULL, NULL, NULL,
-		 POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
-#endif

--- a/tests/drivers/build_all/dac/src/main.c
+++ b/tests/drivers/build_all/dac/src/main.c
@@ -4,16 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-
 void main(void)
 {
 }
-
-#if DT_NODE_EXISTS(DT_INST(0, vnd_gpio))
-/* Fake GPIO device, needed for building drivers that use DEVICE_DT_GET()
- * to access GPIO controllers.
- */
-DEVICE_DT_DEFINE(DT_INST(0, vnd_gpio), NULL, NULL, NULL, NULL,
-		 POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
-#endif

--- a/tests/drivers/build_all/dac/testcase.yaml
+++ b/tests/drivers/build_all/dac/testcase.yaml
@@ -5,7 +5,7 @@ tests:
   drivers.dac.spi.build:
     platform_allow: native_posix
     tags: dac_dacx0508
-    extra_args: "CONFIG_SPI=y CONFIG_DAC_DACX0508=y"
+    extra_args: "CONFIG_GPIO=y CONFIG_SPI=y CONFIG_DAC_DACX0508=y"
   drivers.dac.i2c.build:
     platform_allow: native_posix
     tags: dac_dacx3608 dac_mcp4725

--- a/tests/drivers/build_all/eeprom/src/main.c
+++ b/tests/drivers/build_all/eeprom/src/main.c
@@ -4,16 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-
 void main(void)
 {
 }
-
-#if DT_NODE_EXISTS(DT_INST(0, vnd_gpio))
-/* Fake GPIO device, needed for building drivers that use DEVICE_DT_GET()
- * to access GPIO controllers.
- */
-DEVICE_DT_DEFINE(DT_INST(0, vnd_gpio), NULL, NULL, NULL, NULL,
-		 POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
-#endif

--- a/tests/drivers/build_all/ethernet/prj.conf
+++ b/tests/drivers/build_all/ethernet/prj.conf
@@ -8,6 +8,7 @@ CONFIG_TEST_USERSPACE=y
 
 # No board will enable the generic SPI hosted enc28j60 driver by
 # default, force it on:
+CONFIG_GPIO=y
 CONFIG_SPI=y
 CONFIG_ETH_ENC28J60=y
 CONFIG_ETH_ENC28J60_0=y

--- a/tests/drivers/build_all/ethernet/src/main.c
+++ b/tests/drivers/build_all/ethernet/src/main.c
@@ -4,16 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-
 void main(void)
 {
 }
-
-#if DT_NODE_EXISTS(DT_INST(0, vnd_gpio))
-/* Fake GPIO device, needed for building drivers that use DEVICE_DT_GET()
- * to access GPIO controllers.
- */
-DEVICE_DT_DEFINE(DT_INST(0, vnd_gpio), NULL, NULL, NULL, NULL,
-		 POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
-#endif

--- a/tests/drivers/build_all/gpio/src/main.c
+++ b/tests/drivers/build_all/gpio/src/main.c
@@ -4,16 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-
 void main(void)
 {
 }
-
-#if DT_NODE_EXISTS(DT_INST(0, vnd_gpio))
-/* Fake GPIO device, needed for building drivers that use DEVICE_DT_GET()
- * to access GPIO controllers.
- */
-DEVICE_DT_DEFINE(DT_INST(0, vnd_gpio), NULL, NULL, NULL, NULL,
-		 POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
-#endif

--- a/tests/drivers/build_all/ieee802154/src/main.c
+++ b/tests/drivers/build_all/ieee802154/src/main.c
@@ -5,16 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-
 void main(void)
 {
 }
-
-#if DT_NODE_EXISTS(DT_INST(0, vnd_gpio))
-/* Fake GPIO device, needed for building drivers that use DEVICE_DT_GET()
- * to access GPIO controllers.
- */
-DEVICE_DT_DEFINE(DT_INST(0, vnd_gpio), NULL, NULL, NULL, NULL,
-		 POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
-#endif

--- a/tests/drivers/build_all/led/src/main.c
+++ b/tests/drivers/build_all/led/src/main.c
@@ -4,16 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-
 void main(void)
 {
 }
-
-#if DT_NODE_EXISTS(DT_INST(0, vnd_gpio))
-/* Fake GPIO device, needed for building drivers that use DEVICE_DT_GET()
- * to access GPIO controllers.
- */
-DEVICE_DT_DEFINE(DT_INST(0, vnd_gpio), NULL, NULL, NULL, NULL,
-		 POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
-#endif

--- a/tests/drivers/build_all/modem/src/main.c
+++ b/tests/drivers/build_all/modem/src/main.c
@@ -4,16 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-
 void main(void)
 {
 }
-
-#if DT_NODE_EXISTS(DT_INST(0, vnd_gpio))
-/* Fake GPIO device, needed for building drivers that use DEVICE_DT_GET()
- * to access GPIO controllers.
- */
-DEVICE_DT_DEFINE(DT_INST(0, vnd_gpio), NULL, NULL, NULL, NULL,
-		 POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
-#endif

--- a/tests/drivers/build_all/pwm/src/main.c
+++ b/tests/drivers/build_all/pwm/src/main.c
@@ -4,16 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-
 void main(void)
 {
 }
-
-#if DT_NODE_EXISTS(DT_INST(0, vnd_gpio))
-/* Fake GPIO device, needed for building drivers that use DEVICE_DT_GET()
- * to access GPIO controllers.
- */
-DEVICE_DT_DEFINE(DT_INST(0, vnd_gpio), NULL, NULL, NULL, NULL,
-		 POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
-#endif

--- a/tests/drivers/build_all/sensor/src/main.c
+++ b/tests/drivers/build_all/sensor/src/main.c
@@ -4,16 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-
 void main(void)
 {
 }
-
-#if DT_NODE_EXISTS(DT_INST(0, vnd_gpio))
-/* Fake GPIO device, needed for building drivers that use DEVICE_DT_GET()
- * to access GPIO controllers.
- */
-DEVICE_DT_DEFINE(DT_INST(0, vnd_gpio), NULL, NULL, NULL, NULL,
-		 POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
-#endif


### PR DESCRIPTION
Implements a dummy GPIO driver for the vnd,gpio compatible to allow drivers that use GPIO to be compiled for generic platforms in build_all tests.

This driver follows the conventions of spi_test.c and i2c_test.c, and allows the manually device creation in each "build_all" test to be removed.