### PR TITLE
ITE: drivers/i2c: add the compatibility of GPIO F2/F3 for i2c3

### DIFF
--- a/drivers/pinmux/pinmux_ite_it8xxx2.c
+++ b/drivers/pinmux/pinmux_ite_it8xxx2.c
@@ -162,10 +162,18 @@ static int pinmux_it8xxx2_init(const struct device *dev)
 	IT8XXX2_GPIO_GCR &= ~(BIT(1) | BIT(2));
 
 	/*
-	 * TODO: If SMBUS3 swaps from H group to F group, we have to
+	 * If SMBUS3 swaps from H group to F group, we have to
 	 * set SMB3PSEL = 1 in PMER3 register.
 	 */
+	if (DEVICE_DT_GET(DT_PHANDLE(DT_NODELABEL(i2c3), gpio_dev)) ==
+	    DEVICE_DT_GET(DT_NODELABEL(gpiof))) {
 
+		struct gctrl_it8xxx2_regs *const gctrl_base =
+			(struct gctrl_it8xxx2_regs *)
+				DT_REG_ADDR(DT_NODELABEL(gctrl));
+
+			gctrl_base->GCTRL_PMER3 |= IT8XXX2_GCTRL_SMB3PSEL;
+	}
 	/*
 	 * TODO: If UART2 swaps from bit2:1 to bit6:5 in H group, we
 	 * have to set UART1PSEL = 1 in UART1PMR register.

--- a/dts/riscv/it8xxx2-alts-map.dtsi
+++ b/dts/riscv/it8xxx2-alts-map.dtsi
@@ -95,11 +95,17 @@
 		pinctrl_i2c_data2: i2c_data2 {
 			pinctrls = <&pinmuxf 7 IT8XXX2_PINMUX_FUNC_1>;
 		};
-		pinctrl_i2c_clk3: i2c_clk3 {
+		pinctrl_i2c_clk3_gph1: i2c_clk3_gph1 {
 			pinctrls = <&pinmuxh 1 IT8XXX2_PINMUX_FUNC_3>;
 		};
-		pinctrl_i2c_data3: i2c_data3 {
+		pinctrl_i2c_data3_gph2: i2c_data3_gph2 {
 			pinctrls = <&pinmuxh 2 IT8XXX2_PINMUX_FUNC_3>;
+		};
+		pinctrl_i2c_clk3_gpf2: i2c_clk3_gpf2 {
+			pinctrls = <&pinmuxf 2 IT8XXX2_PINMUX_FUNC_4>;
+		};
+		pinctrl_i2c_data3_gpf3: i2c_data3_gpf3 {
+			pinctrls = <&pinmuxf 3 IT8XXX2_PINMUX_FUNC_4>;
 		};
 		pinctrl_i2c_clk4: i2c_clk4 {
 			pinctrls = <&pinmuxe 0 IT8XXX2_PINMUX_FUNC_3>;

--- a/dts/riscv/it8xxx2.dtsi
+++ b/dts/riscv/it8xxx2.dtsi
@@ -707,8 +707,8 @@
 			label = "I2C_3";
 			port-num = <3>;
 			gpio-dev = <&gpioh>;
-			pinctrl-0 = <&pinctrl_i2c_clk3    /* GPH1 */
-				     &pinctrl_i2c_data3>; /* GPH2 */
+			pinctrl-0 = <&pinctrl_i2c_clk3_gph1    /* GPH1 */
+				     &pinctrl_i2c_data3_gph2>; /* GPH2 */
 		};
 		i2c4: i2c@f03500 {
 			compatible = "ite,it8xxx2-i2c";

--- a/soc/riscv/riscv-ite/common/chip_chipregs.h
+++ b/soc/riscv/riscv-ite/common/chip_chipregs.h
@@ -1652,6 +1652,11 @@ enum chip_pll_mode {
 #define IT83XX_I2C_RAMH2A(base)		ECREG(base+0x50)
 #define IT83XX_I2C_CMD_ADDH2(base)	ECREG(base+0x52)
 
+/* SMBus/I2C register fields */
+/* 0x07: Time Out Status */
+#define IT8XXX2_I2C_SCL_IN		BIT(2)
+#define IT8XXX2_I2C_SDA_IN		BIT(0)
+
 /* --- General Control (GCTRL) --- */
 #define IT83XX_GCTRL_BASE 0x00F02000
 
@@ -1847,6 +1852,8 @@ struct gctrl_it8xxx2_regs {
 #define IT8XXX2_GCTRL_LRSIWR		BIT(2)
 #define IT8XXX2_GCTRL_LRSIPWRSWTR	BIT(1)
 #define IT8XXX2_GCTRL_LRSIPGWR		BIT(0)
+/* 0x46: Pin Multi-function Enable 3 */
+#define IT8XXX2_GCTRL_SMB3PSEL		BIT(6)
 /* 0x4B: ETWD and UART Control */
 #define IT8XXX2_GCTRL_ETWD_HW_RST_EN	BIT(0)
 /* Accept Port 80h Cycle */


### PR DESCRIPTION
The default I2C channel 3 is used by alternate function of GPIO H1/H2
Krabby uses GPIO F2/F3 as I2C channel 3, so we need to add the
compatibility of the GPIO F2/F3.

TEST=test on it8xxx2_evb:
zmake configure -b zephyr/projects/it8xxx2_evb/

Signed-off-by: Tim Lin <tim2.lin@ite.corp-partner.google.com>