### PR TITLE
net: ip: route: Fix log_strdup misuse

### DIFF
--- a/subsys/net/ip/route.c
+++ b/subsys/net/ip/route.c
@@ -238,7 +238,7 @@ static struct net_nbr *nbr_nexthop_get(struct net_if *iface,
 
 	NET_ASSERT(nbr->idx != NET_NBR_LLADDR_UNKNOWN,
 		   "Nexthop %s not in neighbor cache!",
-		   log_strdup(net_sprint_ipv6_addr(addr)));
+		   net_sprint_ipv6_addr(addr));
 
 	net_nbr_ref(nbr);
 


### PR DESCRIPTION
Log_strdup was used in NET_ASSERT macro which is not logging.
As a result linking fails when logging is disabled but asserts
are enabled.

Reason for failing test on main: https://github.com/zephyrproject-rtos/zephyr/pull/41387#issuecomment-999309430

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>