### PR TITLE
device: deprecate SYS_DEVICE_DEFINE 

### DIFF
--- a/doc/reference/drivers/index.rst
+++ b/doc/reference/drivers/index.rst
@@ -382,21 +382,10 @@ function.
 System Drivers
 **************
 
-In some cases you may just need to run a function at boot. Special ``SYS_*``
-macros exist that map to ``DEVICE_DEFINE()`` calls.
-For ``SYS_INIT()`` there are no config or runtime data structures and there
-isn't a way
-to later get a device pointer by name. The same policies for initialization
-level and priority apply.
-
-For ``SYS_DEVICE_DEFINE()`` you can obtain pointers by name.
-
-:c:func:`SYS_INIT()`
-   Run an initialization function at boot at specified priority.
-
-:c:func:`SYS_DEVICE_DEFINE()`
-   Like :c:func:`DEVICE_DEFINE` without an API table and constructing
-   the device name from the init function name.
+In some cases you may just need to run a function at boot. For such cases, the
+:c:macro:`SYS_INIT` can be used. This macro does not take any config or runtime
+data structures and there isn't a way to later get a device pointer by name. The
+same device policies for initialization level and priority apply.
 
 Error handling
 **************

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -730,6 +730,6 @@ static int gpio_stm32_afio_init(const struct device *dev)
 	return 0;
 }
 
-SYS_DEVICE_DEFINE("gpio_stm32_afio", gpio_stm32_afio_init, PRE_KERNEL_1, 0);
+SYS_INIT(gpio_stm32_afio_init, PRE_KERNEL_1, 0);
 
 #endif /* CONFIG_SOC_SERIES_STM32F1X && !CONFIG_GPIO_STM32_SWJ_ENABLE */

--- a/include/device.h
+++ b/include/device.h
@@ -100,20 +100,15 @@ typedef int16_t device_handle_t;
  *
  * @brief Run an initialization function at boot at specified priority.
  *
- * @details This macro allows you to use the device infrastructure to
- * run a function at boot time. It is equivalent to
- * <tt>DEVICE_DEFINE(dev_name, drv_name, init_fn, NULL, NULL, NULL,
- * level, prio, NULL)</tt>, where @p dev_name is derived from @p init_fn.
+ * @deprecated Use SYS_INIT() instead.
  *
- * @param drv_name A string name for the pseudo-device.
+ * @param drv_name A string name for the pseudo-device (unused).
  * @param init_fn Pointer to the function which should run at boot time.
  * @param level Initialization level to run the function in.
  * @param prio Function's priority within its initialization level.
- * @see DEVICE_DEFINE()
  */
 #define SYS_DEVICE_DEFINE(drv_name, init_fn, level, prio)		\
-	DEVICE_DEFINE(Z_SYS_NAME(init_fn), drv_name, init_fn, NULL,	\
-		      NULL, NULL, level, prio, NULL)
+	__DEPRECATED_MACRO SYS_INIT(init_fn, level, prio)
 
 /* Node paths can exceed the maximum size supported by device_get_binding() in user mode,
  * so synthesize a unique dev_name from the devicetree node.

--- a/samples/bluetooth/hci_spi/src/main.c
+++ b/samples/bluetooth/hci_spi/src/main.c
@@ -279,8 +279,7 @@ static int hci_spi_init(const struct device *unused)
 	return 0;
 }
 
-SYS_DEVICE_DEFINE("hci_spi", hci_spi_init,
-		  APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+SYS_INIT(hci_spi_init, APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
 
 void main(void)
 {

--- a/samples/bluetooth/hci_uart/src/main.c
+++ b/samples/bluetooth/hci_uart/src/main.c
@@ -343,8 +343,7 @@ static int hci_uart_init(const struct device *unused)
 	return 0;
 }
 
-SYS_DEVICE_DEFINE("hci_uart", hci_uart_init,
-		  APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+SYS_INIT(hci_uart_init, APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
 
 void main(void)
 {


### PR DESCRIPTION
As of today, it seems that `SYS_DEVICE_DEFINE` is basically used as `SYS_INIT`, so move all of its uses to `SYS_INIT` and deprecate it.