### PR TITLE
Multi instance lwm2m object 5 [Experimental]

### DIFF
--- a/include/net/lwm2m.h
+++ b/include/net/lwm2m.h
@@ -371,6 +371,25 @@ void lwm2m_firmware_set_write_cb(lwm2m_engine_set_data_cb_t cb);
  */
 lwm2m_engine_set_data_cb_t lwm2m_firmware_get_write_cb(void);
 
+/**
+ * @brief Set data callback for firmware block transfer.
+ *
+ * LwM2M clients use this function to register a callback for receiving the
+ * block transfer data when performing a firmware update.
+ *
+ * @param[in] obj_inst_id Object instance ID
+ * @param[in] cb A callback function to receive the block transfer data
+ */
+void lwm2m_firmware_set_write_cb_inst(uint16_t obj_inst_id, lwm2m_engine_set_data_cb_t cb);
+
+/**
+ * @brief Get the data callback for firmware block transfer writes.
+ *
+ * @param[in] obj_inst_id Object instance ID
+ * @return A registered callback function to receive the block transfer data
+ */
+lwm2m_engine_set_data_cb_t lwm2m_firmware_get_write_cb_inst(uint16_t obj_inst_id);
+
 #if defined(CONFIG_LWM2M_FIRMWARE_UPDATE_PULL_SUPPORT)
 /**
  * @brief Set data callback to handle firmware update execute events.
@@ -388,6 +407,25 @@ void lwm2m_firmware_set_update_cb(lwm2m_engine_execute_cb_t cb);
  * @return A registered callback function to receive the execute event.
  */
 lwm2m_engine_execute_cb_t lwm2m_firmware_get_update_cb(void);
+
+/**
+ * @brief Set data callback to handle firmware update execute events.
+ *
+ * LwM2M clients use this function to register a callback for receiving the
+ * update resource "execute" operation on the LwM2M Firmware Update object.
+ *
+ * @param[in] obj_inst_id Object instance ID
+ * @param[in] cb A callback function to receive the execute event.
+ */
+void lwm2m_firmware_set_update_cb_inst(uint16_t obj_inst_id, lwm2m_engine_execute_cb_t cb);
+
+/**
+ * @brief Get the event callback for firmware update execute events.
+ *
+ * @param[in] obj_inst_id Object instance ID
+ * @return A registered callback function to receive the execute event.
+ */
+lwm2m_engine_execute_cb_t lwm2m_firmware_get_update_cb_inst(uint16_t obj_inst_id);
 #endif
 #endif
 

--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -310,6 +310,21 @@ config LWM2M_FIRMWARE_UPDATE_OBJ_SUPPORT
 	help
 	  Include support for LWM2M Firmware Update Object (ID 5)
 
+config LWM2M_FIRMWARE_UPDATE_OBJ_SUPPORT_MULTIPLE
+	bool "Support multiple firmware update objects [EXPERIMENTAL]"
+	depends on LWM2M_FIRMWARE_UPDATE_OBJ_SUPPORT
+	select EXPERIMENTAL
+	help
+	  Support multiple instances of LWM2M Firwmare Update Object (ID 5)
+
+config LWM2M_FIRMWARE_UPDATE_OBJ_INSTANCE_COUNT
+	int "Maximum # of LWM2M Firmware update object instances"
+	default 1
+	depends on LWM2M_FIRMWARE_UPDATE_OBJ_SUPPORT_MULTIPLE
+	help
+	  This setting establishes the total count of LWM2M Firmware update
+	  object instances available to the client.
+
 config LWM2M_FIRMWARE_UPDATE_PULL_SUPPORT
 	bool "Firmware Update object pull support"
 	default y

--- a/subsys/net/lib/lwm2m/lwm2m_engine.h
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.h
@@ -128,10 +128,8 @@ int32_t lwm2m_server_get_pmax(uint16_t obj_inst_id);
 int lwm2m_server_short_id_to_inst(uint16_t short_id);
 
 #if defined(CONFIG_LWM2M_FIRMWARE_UPDATE_OBJ_SUPPORT)
-uint8_t lwm2m_firmware_get_update_state(void);
-void lwm2m_firmware_set_update_state(uint8_t state);
-void lwm2m_firmware_set_update_result(uint8_t result);
-uint8_t lwm2m_firmware_get_update_result(void);
+void lwm2m_firmware_set_update_state(uint16_t obj_inst_id, uint8_t state);
+void lwm2m_firmware_set_update_result(uint16_t obj_inst_id, uint8_t result);
 #endif
 
 /* Attribute handling. */

--- a/subsys/net/lib/lwm2m/lwm2m_engine.h
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.h
@@ -128,8 +128,10 @@ int32_t lwm2m_server_get_pmax(uint16_t obj_inst_id);
 int lwm2m_server_short_id_to_inst(uint16_t short_id);
 
 #if defined(CONFIG_LWM2M_FIRMWARE_UPDATE_OBJ_SUPPORT)
-void lwm2m_firmware_set_update_state(uint16_t obj_inst_id, uint8_t state);
-void lwm2m_firmware_set_update_result(uint16_t obj_inst_id, uint8_t result);
+void lwm2m_firmware_set_update_state_inst(uint16_t obj_inst_id, uint8_t state);
+void lwm2m_firmware_set_update_result_inst(uint16_t obj_inst_id, uint8_t result);
+void lwm2m_firmware_set_update_state(uint8_t state);
+void lwm2m_firmware_set_update_result(uint8_t result);
 #endif
 
 /* Attribute handling. */

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
@@ -65,7 +65,7 @@ int lwm2m_firmware_cancel_transfer(void)
 	return 0;
 }
 
-int lwm2m_firmware_start_transfer(char *package_uri)
+int lwm2m_firmware_start_transfer(uint16_t obj_inst_id, char *package_uri)
 {
 	int error_code;
 

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
@@ -21,7 +21,7 @@ static void set_update_result(uint16_t obj_inst_id, int error_code)
 	int result;
 
 	if (!error_code) {
-		lwm2m_firmware_set_update_state(STATE_DOWNLOADED);
+		lwm2m_firmware_set_update_state_inst(obj_inst_id, STATE_DOWNLOADED);
 		return;
 	}
 
@@ -78,7 +78,7 @@ int lwm2m_firmware_start_transfer(uint16_t obj_inst_id, char *package_uri)
 		return error_code;
 	}
 
-	lwm2m_firmware_set_update_state(STATE_DOWNLOADING);
+	lwm2m_firmware_set_update_state_inst(obj_inst_id, STATE_DOWNLOADING);
 
 	return 0;
 }


### PR DESCRIPTION
Adding a possibility to create multiple instances of the firmware update object.
This gives a possibility to update multiple parts of the firmware at once and follow the status.
Currently this isn't included in the OMA LWM2M specification, thus it is considered experimental.