### PR TITLE
Bluetooth: Controller: Fix wrong variable passed to isr_done

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
@@ -353,7 +353,7 @@ static void isr_tx(void *param)
 		radio_isr_set(isr_tx, lll_sync);
 		switch_radio_complete_and_b2b_tx(lll_sync, lll->phy_s);
 	} else {
-		radio_isr_set(isr_done, lll);
+		radio_isr_set(isr_done, lll_sync);
 		switch_radio_complete_and_phy_end_disable(lll_sync);
 	}
 


### PR DESCRIPTION
Wrong variable was passed when isr_done was registered. It lead to
memory faults and exceptions. It should be a pointer to lll_adv_sync
instance instead of lll_adv.

The commit fixes the issue.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>