### PR TITLE
Bluetooth: host: Add API to HCI CTE conn request enable procedure

### DIFF
--- a/include/bluetooth/direction.h
+++ b/include/bluetooth/direction.h
@@ -61,7 +61,12 @@ enum bt_df_packet_status {
 struct bt_df_adv_cte_tx_param {
 	/** Length of CTE in 8us units. */
 	uint8_t  cte_len;
-	/** CTE Type: AoA, AoD 1us slots, AoD 2us slots. */
+	/**
+	 * @brief CTE type.
+	 *
+	 * Allowed values are defined by @ref bt_df_cte_type, except BT_DF_CTE_TYPE_NONE and
+	 * BT_DF_CTE_TYPE_ALL.
+	 */
 	uint8_t  cte_type;
 	/** Number of CTE to transmit in each periodic adv interval. */
 	uint8_t  cte_count;
@@ -80,8 +85,12 @@ struct bt_df_adv_cte_tx_param {
  * for correctness.
  */
 struct bt_df_per_adv_sync_cte_rx_param {
-	/* Bitmap with allowed CTE types (@ref bt_df_cte_type). */
-	uint8_t cte_type;
+	/**
+	 * @brief Bitfield with allowed CTE types.
+	 *
+	 *  Allowed values are defined by @ref bt_df_cte_type, except BT_DF_CTE_TYPE_NONE.
+	 */
+	uint8_t cte_types;
 	/** Antenna switching slots (@ref bt_df_antenna_switching_slot). */
 	uint8_t slot_durations;
 	/** Max number of CTEs to receive. Min is 1, max is 10, 0 means receive continuously. */
@@ -114,8 +123,12 @@ struct bt_df_per_adv_sync_iq_samples_report {
 };
 
 struct bt_df_conn_cte_rx_param {
-	/* Bitmap with allowed CTE types (@ref bt_df_cte_type). */
-	uint8_t cte_type;
+	/**
+	 * @brief Bitfield with allowed CTE types.
+	 *
+	 *  Allowed values are defined by @ref bt_df_cte_type, except BT_DF_CTE_TYPE_NONE.
+	 */
+	uint8_t cte_types;
 	/** Antenna switching slots (@ref bt_df_antenna_switching_slot). */
 	uint8_t slot_durations;
 	/** Length of antenna switch pattern. */

--- a/include/bluetooth/direction.h
+++ b/include/bluetooth/direction.h
@@ -13,12 +13,16 @@ enum bt_df_cte_type {
 	BT_DF_CTE_TYPE_NONE = 0,
 	/** Angle of Arrival mode. Antenna switching done on receiver site. */
 	BT_DF_CTE_TYPE_AOA = BIT(0),
-	/** Angle of Departure mode with 1 us antenna switching slots.
-	 *  Antenna switching done on transmitter site.
+	/**
+	 * @brief Angle of Departure mode with 1 us antenna switching slots.
+	 *
+	 * Antenna switching done on transmitter site.
 	 */
 	BT_DF_CTE_TYPE_AOD_1US = BIT(1),
-	/** Angle of Departure mode with 2 us antenna switching slots.
-	 *  Antenna switching done on transmitter site.
+	/**
+	 * @brief Angle of Departure mode with 2 us antenna switching slots.
+	 *
+	 * Antenna switching done on transmitter site.
 	 */
 	BT_DF_CTE_TYPE_AOD_2US = BIT(2),
 	/** Convenience value that collects all possible CTE types in one entry. */
@@ -155,6 +159,25 @@ struct bt_df_conn_cte_tx_param {
 	const uint8_t *ant_ids;
 };
 
+struct bt_df_conn_cte_req_params {
+	/**
+	 * @brief Requested interval for initiating the CTE Request procedure.
+	 *
+	 * Value 0x0 means, run the procedure once. Other values are intervals in number of
+	 * connection events, to run the command periodically.
+	 */
+	uint8_t interval;
+	/** Requested length of the CTE in 8 us units. */
+	uint8_t cte_length;
+	/**
+	 * @brief Requested type of the CTE.
+	 *
+	 * Allowed values are defined by @ref bt_df_cte_type, except BT_DF_CTE_TYPE_NONE and
+	 * BT_DF_CTE_TYPE_ALL.
+	 */
+	uint8_t cte_type;
+};
+
 /**
  * @brief Set or update the Constant Tone Extension parameters for periodic advertising set.
  *
@@ -245,6 +268,29 @@ int bt_df_conn_cte_rx_disable(struct bt_conn *conn);
  * @return Zero in case of success, other value in case of failure.
  */
 int bt_df_set_conn_cte_tx_param(struct bt_conn *conn, const struct bt_df_conn_cte_tx_param *params);
+
+/**
+ * @brief Enable Constant Tone Extension request procedure for a connection.
+ *
+ * The function is available if @kconfig{CONFIG_BT_DF_CONNECTION_CTE_REQ} is enabled.
+ *
+ * @param conn   Connection object.
+ * @param params CTE receive and sampling parameters.
+ *
+ * @return Zero in case of success, other value in case of failure.
+ */
+int bt_df_conn_cte_req_enable(struct bt_conn *conn, const struct bt_df_conn_cte_req_params *params);
+
+/**
+ * @brief Disable Constant Tone Extension request procedure for a connection.
+ *
+ * The function is available if @kconfig{CONFIG_BT_DF_CONNECTION_CTE_REQ} is enabled.
+ *
+ * @param conn   Connection object.
+ *
+ * @return Zero in case of success, other value in case of failure.
+ */
+int bt_df_conn_cte_req_disable(struct bt_conn *conn);
 
 /**
  * @brief Enable Constant Tone Extension response procedure for a connection.

--- a/samples/bluetooth/direction_finding_connectionless_rx/src/main.c
+++ b/samples/bluetooth/direction_finding_connectionless_rx/src/main.c
@@ -13,7 +13,6 @@
 #include <sys/util.h>
 
 #include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
 #include <bluetooth/direction.h>
 
 #define DEVICE_NAME     CONFIG_BT_DEVICE_NAME
@@ -244,12 +243,12 @@ static void enable_cte_rx(void)
 	const struct bt_df_per_adv_sync_cte_rx_param cte_rx_params = {
 		.max_cte_count = 5,
 #if defined(CONFIG_BT_CTLR_DF_ANT_SWITCH_RX)
-		.cte_type = BT_DF_CTE_TYPE_ALL,
+		.cte_types = BT_DF_CTE_TYPE_ALL,
 		.slot_durations = 0x2,
 		.num_ant_ids = ARRAY_SIZE(ant_patterns),
 		.ant_ids = ant_patterns,
 #else
-		.cte_type = BT_DF_CTE_TYPE_AOD_1US | BT_DF_CTE_TYPE_AOD_2US,
+		.cte_types = BT_DF_CTE_TYPE_AOD_1US | BT_DF_CTE_TYPE_AOD_2US,
 #endif /* CONFIG_BT_CTLR_DF_ANT_SWITCH_RX */
 	};
 

--- a/samples/bluetooth/direction_finding_connectionless_tx/src/main.c
+++ b/samples/bluetooth/direction_finding_connectionless_tx/src/main.c
@@ -11,7 +11,6 @@
 #include <sys/printk.h>
 
 #include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
 #include <bluetooth/direction.h>
 #include <sys/byteorder.h>
 #include <sys/util.h>
@@ -55,11 +54,11 @@ static uint8_t ant_patterns[] = {0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0x
 struct bt_df_adv_cte_tx_param cte_params = { .cte_len = CTE_LEN,
 					     .cte_count = PER_ADV_EVENT_CTE_COUNT,
 #if defined(CONFIG_BT_CTLR_DF_ANT_SWITCH_TX)
-					     .cte_type = BT_HCI_LE_AOD_CTE_2US,
+					     .cte_type = BT_DF_CTE_TYPE_AOD_2US,
 					     .num_ant_ids = ARRAY_SIZE(ant_patterns),
 					     .ant_ids = ant_patterns
 #else
-					     .cte_type = BT_HCI_LE_AOA_CTE,
+					     .cte_type = BT_DF_CTE_TYPE_AOA,
 					     .num_ant_ids = 0,
 					     .ant_ids = NULL
 #endif /* CONFIG_BT_CTLR_DF_ANT_SWITCH_TX */

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -566,6 +566,13 @@ config BT_DF_CONNECTION_CTE_TX
 	  Enable support for transmission of Constant Tone Extension in
 	  connection mode.
 
+config BT_DF_CONNECTION_CTE_REQ
+	bool "Enable support for CTE request procedure in connection mode"
+	depends on BT_DF_CONNECTION_CTE_RX
+	help
+	  Enable support for request of Constant Tone Extension in connection
+	  mode.
+
 config BT_DF_CONNECTION_CTE_RSP
 	bool "Enable support for CTE request procedure in connection mode"
 	depends on BT_DF_CONNECTION_CTE_TX

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -44,7 +44,9 @@ enum {
 	BT_CONN_AUTO_DATA_LEN_COMPLETE,
 
 	BT_CONN_CTE_RX_ENABLED,          /* CTE receive and sampling is enabled */
+	BT_CONN_CTE_RX_PARAMS_SET,       /* CTE parameters are set */
 	BT_CONN_CTE_TX_PARAMS_SET,       /* CTE transmission parameters are set */
+	BT_CONN_CTE_REQ_ENABLED,         /* CTE request procedure is enabled */
 	BT_CONN_CTE_RSP_ENABLED,         /* CTE response procedure is enabled */
 
 	/* Total number of flags - must be at the end of the enum */

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -169,8 +169,12 @@ struct bt_conn {
 #endif /* CONFIG_BT_SMP || CONFIG_BT_BREDR */
 
 #if defined(CONFIG_BT_DF_CONNECTION_CTE_RX)
-	/** Accepted CTE type */
-	uint8_t cte_type;
+	/**
+	 * @brief Bitfield with allowed CTE types.
+	 *
+	 *  Allowed values are defined by @ref bt_df_cte_type, except BT_DF_CTE_TYPE_NONE.
+	 */
+	uint8_t cte_types;
 #endif /* CONFIG_BT_DF_CONNECTION_CTE_RX */
 
 	/* Connection error or reason for disconnect */

--- a/subsys/bluetooth/host/direction.c
+++ b/subsys/bluetooth/host/direction.c
@@ -47,12 +47,12 @@ const static uint8_t df_dummy_switch_pattern[BT_HCI_LE_SWITCH_PATTERN_LEN_MIN] =
 #define DF_SAMPLING_ANTENNA_NUMBER_MIN 0x2
 
 #if defined(CONFIG_BT_DF_CONNECTIONLESS_CTE_RX) || defined(CONFIG_BT_DF_CONNECTION_CTE_RX)
-static bool validate_cte_rx_common_params(uint8_t cte_types, uint8_t slot_durations,
-					  uint8_t num_ant_ids, const uint8_t *ant_ids);
+static bool valid_cte_rx_common_params(uint8_t cte_types, uint8_t slot_durations,
+				       uint8_t num_ant_ids, const uint8_t *ant_ids);
 #endif /* CONFIG_BT_DF_CONNECTIONLESS_CTE_RX || CONFIG_BT_DF_CONNECTION_CTE_RX */
 
 #if defined(CONFIG_BT_DF_CONNECTIONLESS_CTE_RX)
-static bool validate_cl_cte_rx_params(const struct bt_df_per_adv_sync_cte_rx_param *params);
+static bool valid_cl_cte_rx_params(const struct bt_df_per_adv_sync_cte_rx_param *params);
 static void
 prepare_cl_cte_rx_enable_cmd_params(struct net_buf *buf, struct bt_le_per_adv_sync *sync,
 				    const struct bt_df_per_adv_sync_cte_rx_param *params,
@@ -229,8 +229,8 @@ static int hci_df_set_adv_cte_tx_enable(struct bt_le_ext_adv *adv,
 }
 
 #if defined(CONFIG_BT_DF_CONNECTIONLESS_CTE_RX) || defined(CONFIG_BT_DF_CONNECTION_CTE_RX)
-static bool validate_cte_rx_common_params(uint8_t cte_types, uint8_t slot_durations,
-					  uint8_t num_ant_ids, const uint8_t *ant_ids)
+static bool valid_cte_rx_common_params(uint8_t cte_types, uint8_t slot_durations,
+				       uint8_t num_ant_ids, const uint8_t *ant_ids)
 {
 	if (!(cte_types & BT_DF_CTE_TYPE_ALL)) {
 		return false;
@@ -259,15 +259,15 @@ static bool validate_cte_rx_common_params(uint8_t cte_types, uint8_t slot_durati
 #endif /* CONFIG_BT_DF_CONNECTIONLESS_CTE_RX || CONFIG_BT_DF_CONNECTION_CTE_RX */
 
 #if defined(CONFIG_BT_DF_CONNECTIONLESS_CTE_RX)
-static bool validate_cl_cte_rx_params(const struct bt_df_per_adv_sync_cte_rx_param *params)
+static bool valid_cl_cte_rx_params(const struct bt_df_per_adv_sync_cte_rx_param *params)
 {
 	if (params->max_cte_count > BT_HCI_LE_SAMPLE_CTE_COUNT_MAX) {
 		return false;
 	}
 
 	if (params->cte_types & BT_DF_CTE_TYPE_AOA) {
-		return validate_cte_rx_common_params(params->cte_types, params->slot_durations,
-						     params->num_ant_ids, params->ant_ids);
+		return valid_cte_rx_common_params(params->cte_types, params->slot_durations,
+						  params->num_ant_ids, params->ant_ids);
 	}
 
 	return true;
@@ -321,7 +321,7 @@ static int hci_df_set_cl_cte_rx_enable(struct bt_le_per_adv_sync *sync, bool ena
 	int err;
 
 	if (enable) {
-		if (!validate_cl_cte_rx_params(params)) {
+		if (!valid_cl_cte_rx_params(params)) {
 			return -EINVAL;
 		}
 	}
@@ -404,7 +404,7 @@ void hci_df_prepare_connectionless_iq_report(struct net_buf *buf,
 #endif /* CONFIG_BT_DF_CONNECTIONLESS_CTE_RX */
 
 #if defined(CONFIG_BT_DF_CONNECTION_CTE_TX)
-static bool validate_conn_cte_tx_params(const struct bt_df_conn_cte_tx_param *params)
+static bool valid_conn_cte_tx_params(const struct bt_df_conn_cte_tx_param *params)
 {
 	if (!(params->cte_types & BT_DF_CTE_TYPE_ALL)) {
 		return false;
@@ -466,7 +466,7 @@ static int hci_df_set_conn_cte_tx_param(struct bt_conn *conn,
 	/* If AoD is not enabled, ant_ids are ignored by controller:
 	 * BT Core spec 5.2 Vol 4, Part E sec. 7.8.84.
 	 */
-	if (!validate_conn_cte_tx_params(params)) {
+	if (!valid_conn_cte_tx_params(params)) {
 		return -EINVAL;
 	}
 
@@ -548,8 +548,8 @@ static int hci_df_set_conn_cte_rx_enable(struct bt_conn *conn, bool enable,
 	int err;
 
 	if (enable) {
-		if (!validate_cte_rx_common_params(params->cte_types, params->slot_durations,
-						   params->num_ant_ids, params->ant_ids)) {
+		if (!valid_cte_rx_common_params(params->cte_types, params->slot_durations,
+						params->num_ant_ids, params->ant_ids)) {
 			return -EINVAL;
 		}
 	}

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -198,8 +198,12 @@ struct bt_le_per_adv_sync {
 	uint8_t phy;
 
 #if defined(CONFIG_BT_DF_CONNECTIONLESS_CTE_RX)
-	/** Accepted CTE type */
-	uint8_t cte_type;
+	/**
+	 * @brief Bitfield with allowed CTE types.
+	 *
+	 *  Allowed values are defined by @ref bt_df_cte_type, except BT_DF_CTE_TYPE_NONE.
+	 */
+	uint8_t cte_types;
 #endif /* CONFIG_BT_DF_CONNECTIONLESS_CTE_RX */
 
 #if CONFIG_BT_PER_ADV_SYNC_BUF_SIZE > 0


### PR DESCRIPTION
There were no implementation for HCI_LE_Connection_CTE_Request_Enable
command from BT 5.3 Core specification.

The PR adds implementation and API to be used by applications.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>