### PR TITLE
fs/fat_fs: Allow configuration of number of root entries

### DIFF
--- a/subsys/fs/Kconfig.fatfs
+++ b/subsys/fs/Kconfig.fatfs
@@ -43,6 +43,19 @@ config FS_FATFS_MOUNT_MKFS
 	  If formatting is not needed, disabling this flag will slightly
 	  reduce application size.
 
+if FS_FATFS_MOUNT_MKFS
+
+config FS_FATFS_MAX_ROOT_ENTRIES
+	int "Max number of entries in FAT FS root directory"
+	default 512
+	range 1 32768
+	help
+	  Sets how many root directory entries will be allocated when
+	  formatting new FAT system to a device.
+	  Note that this should be multiply of FS_FATFS_MAX_SS / 32.
+
+endif # FS_FATFS_MOUNT_MKFS
+
 config FS_FATFS_EXFAT
 	bool "Enable exFAT support"
 	select FS_FATFS_LFN

--- a/subsys/fs/fat_fs.c
+++ b/subsys/fs/fat_fs.c
@@ -429,7 +429,7 @@ static int fatfs_mount(struct fs_mount_t *mountp)
 			.fmt = FM_FAT | FM_SFD,	/* Any suitable FAT */
 			.n_fat = 1,		/* One FAT fs table */
 			.align = 0,		/* Get sector size via diskio query */
-			.n_root = 512,		/* Max 512 root directory entries */
+			.n_root = CONFIG_FS_FATFS_MAX_ROOT_ENTRIES,
 			.au_size = 0		/* Auto calculate cluster size */
 		};
 


### PR DESCRIPTION
The commit adds FS_FATFS_MAX_ROOT_ENTRIES Kconfig option that allows
to select number of root node entries that will be allocated while
creating FAT file system on a device.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>