### PR TITLE
test: Bluetooth: Mesh: fix racing between bsim devices in provisioning test

### DIFF
--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_provision.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_provision.c
@@ -9,6 +9,7 @@
 #include "mesh/net.h"
 #include "argparse.h"
 #include <bs_pc_backchannel.h>
+#include <time_machine.h>
 
 #include <tinycrypt/constants.h>
 #include <tinycrypt/ecc.h>
@@ -87,6 +88,11 @@ static bool is_oob_auth;
 
 static void test_device_init(void)
 {
+	/* Ensure those test devices will not drift more than
+	 * 100ms for each other in emulated time
+	 */
+	tm_set_phy_max_resync_offset(100000);
+
 	/* Ensure that the UUID is unique: */
 	dev_uuid[6] = '0' + get_device_nbr();
 
@@ -96,6 +102,11 @@ static void test_device_init(void)
 
 static void test_provisioner_init(void)
 {
+	/* Ensure those test devices will not drift more than
+	 * 100ms for each other in emulated time
+	 */
+	tm_set_phy_max_resync_offset(100000);
+
 	atomic_set_bit(flags, IS_PROVISIONER);
 	bt_mesh_test_cfg_set(NULL, WAIT_TIME);
 	k_work_init_delayable(&oob_timer, delayed_input);
@@ -346,6 +357,8 @@ static void oob_provisioner(bool read_oob_pk, bool use_oob_pk)
 		 */
 		k_sleep(K_SECONDS(1));
 	}
+
+	bt_mesh_reset();
 }
 
 /** @brief Verify that this device pb-adv provision.


### PR DESCRIPTION
Bsim devices work asynchronously before access to Phy.
Interprocess OOB communication might be broken because of this.
PR adds synchronization for devices. Drift is 100ms between them.

Signed-off-by: Aleksandr Khromykh <aleksandr.khromykh@nordicsemi.no>