### PR TITLE
qemu.cmake: Enable host serial ports

### DIFF
--- a/boards/arm/mps2_an521/board.cmake
+++ b/boards/arm/mps2_an521/board.cmake
@@ -12,6 +12,10 @@ set(QEMU_FLAGS_${ARCH}
   )
 board_set_debugger_ifnset(qemu)
 
+ # To enable a host tty switch between serial and pty
+ #  -chardev serial,path=/dev/ttyS0,id=hostS0
+list(APPEND QEMU_EXTRA_FLAGS -chardev pty,id=hostS0 -serial chardev:hostS0)
+
 if (CONFIG_BUILD_WITH_TFM)
   # Override the binary used by qemu, to use the combined
   # TF-M (Secure) & Zephyr (Non Secure) image (when running
@@ -21,5 +25,5 @@ if (CONFIG_BUILD_WITH_TFM)
 elseif (CONFIG_SOC_MPS2_AN521_CPU1)
   set(CPU0_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/zephyr/boards/arm/mps2_an521/empty_cpu0-prefix/src/empty_cpu0-build/zephyr)
   set(QEMU_KERNEL_OPTION "-device;loader,file=${CPU0_BINARY_DIR}/zephyr.elf")
-  set(QEMU_EXTRA_FLAGS "-device;loader,file=${CMAKE_CURRENT_BINARY_DIR}/zephyr/zephyr.elf")
+  list(APPEND QEMU_EXTRA_FLAGS "-device;loader,file=${PROJECT_BINARY_DIR}/${KERNEL_ELF_NAME}")
 endif()

--- a/boards/arm/mps2_an521/mps2_an521.dts
+++ b/boards/arm/mps2_an521/mps2_an521.dts
@@ -20,6 +20,7 @@
 		led1 = &led_1;
 		sw0 = &user_button_0;
 		sw1 = &user_button_1;
+		uart-1 = &uart1;
 		watchdog0 = &wdog0;
 	};
 
@@ -109,4 +110,8 @@
 
 &nvic {
 	arm,num-irq-priority-bits = <3>;
+};
+
+&uart1 {
+	status = "okay";
 };


### PR DESCRIPTION
Add cmake variable to allow configure host serial ports. It can be useful to send stimulus to hardware under test. As an example of use, configure and connect host /dev/pts/N to arm qemu uart-1 for mps2_an521 board. It can use a real devices like /dev/ttyS0. by just switching between serial and pty chardev options.

