### PR TITLE
manifest: Update hal_nordic revision to fix nrfx_pwm driver

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -88,7 +88,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: f6b23344f6bdfb490ac7d038344174a99fa75d45
+      revision: a42b016d7c7610489f5f8c79773fedc05ba352ee
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Update the hal_nordic module revision to fix a copy-paste bug in
the nrfx_pwm driver that prevents PWM pins from being configured.

Fixes #41413.