### PR TITLE
samples: fix wrong extra_args definitions

### DIFF
--- a/samples/philosophers/sample.yaml
+++ b/samples/philosophers/sample.yaml
@@ -18,17 +18,17 @@ tests:
   sample.kernel.philosopher:
     tags: introduction
   sample.kernel.philosopher.same_prio:
-    extra_args: "-DSAME_PRIO=1"
+    extra_args: SAME_PRIO=1
   sample.kernel.philosopher.static:
-    extra_args: "-DSTATIC_OBJS=1"
+    extra_args: STATIC_OBJS=1
   sample.kernel.philosopher.semaphores:
-    extra_args: "-DFORKS=SEMAPHORES"
+    extra_args: FORKS=SEMAPHORES
   sample.kernel.philosopher.stacks:
-    extra_args: "-DFORKS=STACKS"
+    extra_args: FORKS=STACKS
   sample.kernel.philosopher.fifos:
-    extra_args: "-DFORKS=FIFOS"
+    extra_args: FORKS=FIFOS
   sample.kernel.philosopher.lifos:
-    extra_args: "-DFORKS=LIFOS"
+    extra_args: FORKS=LIFOS
   sample.kernel.philosopher.preempt_only:
     extra_configs:
       - CONFIG_NUM_PREEMPT_PRIORITIES=6

--- a/samples/subsys/portability/cmsis_rtos_v1/philosophers/sample.yaml
+++ b/samples/subsys/portability/cmsis_rtos_v1/philosophers/sample.yaml
@@ -20,6 +20,6 @@ tests:
   sample.portability.cmsis_rtos_v1.philosopher:
     tags: cmsis_rtos
   sample.portability.cmsis_rtos_v1.philosopher.same_prio:
-    extra_args: "-DSAME_PRIO=1"
+    extra_args: SAME_PRIO=1
   sample.portability.cmsis_rtos_v1.philosopher.semaphores:
-    extra_args: "-DFORKS=SEMAPHORES"
+    extra_args: FORKS=SEMAPHORES

--- a/samples/subsys/portability/cmsis_rtos_v2/philosophers/sample.yaml
+++ b/samples/subsys/portability/cmsis_rtos_v2/philosophers/sample.yaml
@@ -21,6 +21,6 @@ tests:
   sample.portability.cmsis_rtos_v2.philosopher:
     tags: cmsis_rtos
   sample.portability.cmsis_rtos_v2.philosopher.same_prio:
-    extra_args: "-DSAME_PRIO=1"
+    extra_args: SAME_PRIO=1
   sample.portability.cmsis_rtos_v2.philosopher.semaphores:
-    extra_args: "-DFORKS=SEMAPHORES"
+    extra_args: FORKS=SEMAPHORES

--- a/samples/subsys/usb/cdc_acm/sample.yaml
+++ b/samples/subsys/usb/cdc_acm/sample.yaml
@@ -14,7 +14,7 @@ tests:
     depends_on: usb_device
     tags: usb
     platform_exclude: native_posix native_posix_64
-    extra_args: "-DOVERLAY_CONFIG=overlay-composite-cdc-msc.conf"
+    extra_args: OVERLAY_CONFIG=overlay-composite-cdc-msc.conf
     harness: console
     harness_config:
       type: one_line


### PR DESCRIPTION
Fix wrong extra_args definitions wich cause that this args were not used
by CMake during building this samples via Twister in CI.

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>