### PR TITLE
tests/lib/devicetree/devices: Exclude thingy52_nrf52832 platform

### DIFF
--- a/tests/lib/devicetree/devices/testcase.yaml
+++ b/tests/lib/devicetree/devices/testcase.yaml
@@ -5,4 +5,4 @@ tests:
     # will mostly likely be the fastest.
     integration_platforms:
       - native_posix
-    platform_exclude: hsdk hsdk_2cores
+    platform_exclude: hsdk hsdk_2cores thingy52_nrf52832


### PR DESCRIPTION
This test cannot be built for thingy52_nrf52832, as this board uses
regulator devices that need the SX1509B GPIO expander driver that
in turn depends on I2C which needs to be disabled in this test.
Commit b579c12714a452ddcb436615d218d39f9f0cd5bd addressed a similar
problem for hsdk platforms by excluding those. Use the same solution.

Fixes #41418.