### PR TITLE
entropy: Bluetooth HCI entropy source added

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -248,6 +248,7 @@
 /drivers/eeprom/                          @henrikbrixandersen
 /drivers/eeprom/eeprom_stm32.c            @KwonTae-young
 /drivers/entropy/*b91*                    @yurvyn
+/drivers/entropy/*bt_hci*                 @JordanYates
 /drivers/entropy/*rv32m1*                 @dleach02
 /drivers/entropy/*gecko*                  @chrta
 /drivers/entropy/*litex*                  @mateusz-holenko @kgugala @pgielda

--- a/boards/arm/nrf5340dk_nrf5340/Kconfig.defconfig
+++ b/boards/arm/nrf5340dk_nrf5340/Kconfig.defconfig
@@ -8,6 +8,10 @@ if  BOARD_NRF5340DK_NRF5340_CPUAPP || BOARD_NRF5340DK_NRF5340_CPUAPP_NS
 config BOARD
 	default "nrf5340dk_nrf5340_cpuapp" if BOARD_NRF5340DK_NRF5340_CPUAPP || BOARD_NRF5340DK_NRF5340_CPUAPP_NS
 
+config ENTROPY_BT_HCI
+	default y if BT_HCI
+	depends on ENTROPY_GENERATOR
+
 # By default, if we build for a Non-Secure version of the board,
 # force building with TF-M as the Secure Execution Environment.
 

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
@@ -13,6 +13,7 @@
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;
 		zephyr,bt-c2h-uart = &uart0;
+		zephyr,entropy = &rng_hci;
 	};
 
 	leds {
@@ -60,6 +61,12 @@
 			gpios = <&gpio0 9 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "Push button 4";
 		};
+	};
+
+	rng_hci: entropy_bt_hci {
+		compatible = "zephyr,bt-hci-entropy";
+		label = "bt_hci_entropy";
+		status = "okay";
 	};
 
 	arduino_header: connector {

--- a/drivers/entropy/CMakeLists.txt
+++ b/drivers/entropy/CMakeLists.txt
@@ -17,3 +17,4 @@ zephyr_library_sources_ifdef(CONFIG_USERSPACE                  entropy_handlers.
 zephyr_library_sources_ifdef(CONFIG_ENTROPY_RV32M1_TRNG        entropy_rv32m1_trng.c)
 zephyr_library_sources_ifdef(CONFIG_ENTROPY_GECKO_TRNG         entropy_gecko_trng.c)
 zephyr_library_sources_ifdef(CONFIG_ENTROPY_NEORV32_TRNG       entropy_neorv32_trng.c)
+zephyr_library_sources_ifdef(CONFIG_ENTROPY_BT_HCI             entropy_bt_hci.c)

--- a/drivers/entropy/Kconfig
+++ b/drivers/entropy/Kconfig
@@ -32,6 +32,7 @@ source "drivers/entropy/Kconfig.rv32m1"
 source "drivers/entropy/Kconfig.litex"
 source "drivers/entropy/Kconfig.gecko"
 source "drivers/entropy/Kconfig.neorv32"
+source "drivers/entropy/Kconfig.bt_hci"
 
 config ENTROPY_HAS_DRIVER
 	bool

--- a/drivers/entropy/Kconfig.bt_hci
+++ b/drivers/entropy/Kconfig.bt_hci
@@ -1,0 +1,16 @@
+# Copyright (c) 2022, Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+# SPDX-License-Identifier: Apache-2.0
+
+config ENTROPY_BT_HCI
+	bool "Bluetooth HCI RNG driver"
+	depends on BT_HCI
+	select ENTROPY_HAS_DRIVER
+	help
+	  Enable Random Number Generator from a Bluetooth HCI device.
+
+# Don't use use Bluetooth HCI as a random source since it will be slow.
+# Instead, use the software implemented xoshiro RNG.
+choice RNG_GENERATOR_CHOICE
+	default XOSHIRO_RANDOM_GENERATOR if ENTROPY_BT_HCI
+endchoice

--- a/drivers/entropy/entropy_bt_hci.c
+++ b/drivers/entropy/entropy_bt_hci.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2022, Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT zephyr_bt_hci_entropy
+
+#include <drivers/entropy.h>
+#include <bluetooth/hci.h>
+#include <string.h>
+
+static int entropy_bt_init(const struct device *dev)
+{
+	/* Nothing to do */
+	return 0;
+}
+
+static int entropy_bt_get_entropy(const struct device *dev,
+				  uint8_t *buffer, uint16_t length)
+{
+	struct bt_hci_rp_le_rand *rp;
+	struct net_buf *rsp;
+	int req, ret;
+
+	if (!bt_is_ready()) {
+		return -EAGAIN;
+	}
+
+	while (length > 0) {
+		/* Number of bytes to fill on this iteration */
+		req = MIN(length, sizeof(rp->rand));
+		/* Request the next 8 bytes over HCI */
+		ret = bt_hci_cmd_send_sync(BT_HCI_OP_LE_RAND, NULL, &rsp);
+		if (ret) {
+			return ret;
+		}
+		/* Copy random data into buffer */
+		rp = (void *)rsp->data;
+		memcpy(buffer, rp->rand, req);
+		buffer += req;
+		length -= req;
+	}
+	return 0;
+}
+
+/* HCI commands cannot be run from an interrupt context */
+static const struct entropy_driver_api entropy_bt_api = {
+	.get_entropy = entropy_bt_get_entropy,
+	.get_entropy_isr = NULL
+};
+
+#define ENTROPY_BT_HCI_INIT(inst)				  \
+	DEVICE_DT_INST_DEFINE(inst, entropy_bt_init,		  \
+			      NULL, NULL, NULL,			  \
+			      PRE_KERNEL_1,			  \
+			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
+			      &entropy_bt_api);
+
+DT_INST_FOREACH_STATUS_OKAY(ENTROPY_BT_HCI_INIT)

--- a/dts/bindings/bluetooth/zephyr,bt-hci-entropy.yaml
+++ b/dts/bindings/bluetooth/zephyr,bt-hci-entropy.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2018, I-SENSE group of ICCS
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    Bluetooth module that uses Zephyr's Bluetooth Host Controller Interface as
+    an entropy source
+
+compatible: "zephyr,bt-hci-entropy"
+
+include: base.yaml

--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -157,6 +157,13 @@ int bt_enable(bt_ready_cb_t cb);
 int bt_disable(void);
 
 /**
+ * @brief Check if Bluetooth is ready
+ *
+ * @return true when Bluetooth is ready, false otherwise
+ */
+bool bt_is_ready(void);
+
+/**
  * @brief Set Bluetooth Device Name
  *
  * Set Bluetooth GAP Device Name.

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3682,6 +3682,10 @@ int bt_disable(void)
 	return 0;
 }
 
+bool bt_is_ready(void)
+{
+	return atomic_test_bit(bt_dev.flags, BT_DEV_READY);
+}
 
 #define DEVICE_NAME_LEN (sizeof(CONFIG_BT_DEVICE_NAME) - 1)
 #if defined(CONFIG_BT_DEVICE_NAME_DYNAMIC)

--- a/subsys/random/rand32_ctr_drbg.c
+++ b/subsys/random/rand32_ctr_drbg.c
@@ -30,6 +30,7 @@ static K_SEM_DEFINE(state_sem, 1, 1);
 
 static const struct device *entropy_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
 static const unsigned char drbg_seed[] = CONFIG_CS_CTR_DRBG_PERSONALIZATION;
+static bool ctr_initialised;
 
 #if defined(CONFIG_MBEDTLS)
 
@@ -92,7 +93,7 @@ static int ctr_drbg_initialize(void)
 	}
 
 #endif
-
+	ctr_initialised = true;
 	return 0;
 }
 
@@ -102,7 +103,7 @@ int z_impl_sys_csrand_get(void *dst, uint32_t outlen)
 	int ret;
 	unsigned int key = irq_lock();
 
-	if (unlikely(!entropy_dev)) {
+	if (unlikely(!ctr_initialised)) {
 		ret = ctr_drbg_initialize();
 		if (ret != 0) {
 			ret = -EIO;

--- a/subsys/random/rand32_xoshiro128.c
+++ b/subsys/random/rand32_xoshiro128.c
@@ -60,6 +60,16 @@ static void xoshiro128_init_state(void)
 	rc = entropy_get_entropy(entropy_driver, (uint8_t *)&state, sizeof(state));
 	if (rc == 0) {
 		initialized = true;
+	} else {
+		/* Entropy device failed or is not yet ready.
+		 * Reseed the PRNG state with pseudo-random data until it can
+		 * be properly seeded. This may be needed if random numbers are
+		 * requested before the backing entropy device has been enabled.
+		 */
+		state[0] = k_cycle_get_32();
+		state[1] = k_cycle_get_32() ^ 0x9b64c2b0;
+		state[2] = k_cycle_get_32() ^ 0x86d3d2d4;
+		state[3] = k_cycle_get_32() ^ 0xa00ae278;
 	}
 }
 

--- a/tests/drivers/entropy/api/entropy_bt_hci.conf
+++ b/tests/drivers/entropy/api/entropy_bt_hci.conf
@@ -1,0 +1,1 @@
+CONFIG_BT=y

--- a/tests/drivers/entropy/api/entropy_bt_hci.overlay
+++ b/tests/drivers/entropy/api/entropy_bt_hci.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2021, Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,entropy = &rng_hci;
+	};
+
+	rng_hci: entropy_bt_hci {
+		compatible = "zephyr,bt-hci-entropy";
+		label = "bt_hci_entropy";
+		status = "okay";
+	};
+};

--- a/tests/drivers/entropy/api/src/main.c
+++ b/tests/drivers/entropy/api/src/main.c
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <bluetooth/bluetooth.h>
 #include <drivers/entropy.h>
 #include <ztest.h>
 
@@ -21,8 +22,8 @@
  * @}
  */
 
-#define BUFFER_LENGTH 10
-#define RECHECK_RANDOM_ENTROPY 0x10
+#define BUFFER_LENGTH           10
+#define RECHECK_RANDOM_ENTROPY  0x10
 
 static int random_entropy(const struct device *dev, char *buffer, char num)
 {
@@ -104,6 +105,10 @@ static void test_entropy_get_entropy(void)
 
 void test_main(void)
 {
+#ifdef CONFIG_BT
+	bt_enable(NULL);
+#endif /* CONFIG_BT */
+
 	ztest_test_suite(entropy_api,
 			 ztest_unit_test(test_entropy_get_entropy));
 	ztest_run_test_suite(entropy_api);

--- a/tests/drivers/entropy/api/testcase.yaml
+++ b/tests/drivers/entropy/api/testcase.yaml
@@ -2,3 +2,7 @@ tests:
   drivers.entropy:
     filter: CONFIG_ENTROPY_HAS_DRIVER
     tags: drivers entropy
+  drivers.entropy.bt_hci:
+    platform_allow: nrf52_bsim
+    extra_args: DTC_OVERLAY_FILE=./entropy_bt_hci.overlay OVERLAY_CONFIG=./entropy_bt_hci.conf
+    tags: driver entropy bluetooth


### PR DESCRIPTION
Implements an entropy source that utilizes the Bluetooth HCI command `LE_RAND` as its randomness source.

Changes to the xoshiro128 driver are required as the HCI interface is not available until after the application calls `bt_enable`, which is unlikely to be before `PRE_KERNEL_2`, where the random drivers are initialized.

Implements #37186