### PR TITLE
lora: sx126x: don't re-enable interrupt in sleep

### DIFF
--- a/drivers/lora/sx126x.c
+++ b/drivers/lora/sx126x.c
@@ -410,7 +410,10 @@ static void sx126x_dio1_irq_work_handler(struct k_work *work)
 		Radio.IrqProcess();
 	}
 
-	sx126x_dio1_irq_enable(&dev_data);
+	/* Re-enable the interrupt if we are not in sleep mode */
+	if (dev_data.mode != MODE_SLEEP) {
+		sx126x_dio1_irq_enable(&dev_data);
+	}
 }
 
 static int sx126x_lora_init(const struct device *dev)


### PR DESCRIPTION
Don't re-enable the DIO1 interrupt when the modem is in sleep mode. This
fixes the power regression introduced in Zephyr v2.7.0.

Fixes #41026

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>