### PR TITLE
samples/tfm_integration: nucleo_l552ze_q: Update flash partition

### DIFF
--- a/samples/tfm_integration/psa_crypto/boards/nucleo_l552ze_q_ns.overlay
+++ b/samples/tfm_integration/psa_crypto/boards/nucleo_l552ze_q_ns.overlay
@@ -28,18 +28,18 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x00013000>;
+			reg = <0x00000000 0x00014000>;
 			read-only;
 		};
 		/* Secure image primary slot */
-		slot0_partition: partition@13000 {
+		slot0_partition: partition@14000 {
 			label = "image-0";
-			reg = <0x00013000 0x0002D000>;
+			reg = <0x00014000 0x0002D000>;
 		};
 		/* Non-secure image primary slot */
-		slot1_partition: partition@40000 {
+		slot1_partition: partition@41000 {
 			label = "image-1";
-			reg = <0x00040000 0x00009000>;
+			reg = <0x00041000 0x00009000>;
 		};
 		/*
 		 * The flash starting at 0x7F000 and ending at

--- a/samples/tfm_integration/tfm_ipc/boards/nucleo_l552ze_q_ns.overlay
+++ b/samples/tfm_integration/tfm_ipc/boards/nucleo_l552ze_q_ns.overlay
@@ -29,18 +29,18 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x00013000>;
+			reg = <0x00000000 0x00014000>;
 			read-only;
 		};
 		/* Secure image primary slot */
-		slot0_partition: partition@13000 {
+		slot0_partition: partition@14000 {
 			label = "image-0";
-			reg = <0x00013000 0x0002D000>;
+			reg = <0x00014000 0x0002D000>;
 		};
 		/* Non-secure image primary slot */
-		slot1_partition: partition@40000 {
+		slot1_partition: partition@41000 {
 			label = "image-1";
-			reg = <0x00040000 0x00009000>;
+			reg = <0x00041000 0x00009000>;
 		};
 		/*
 		 * The flash starting at 0x7F000 and ending at


### PR DESCRIPTION
Due to a recent change in TFM, some more space should be allocated
to mcuboot flash partition (some space should be allocate for OTP)
(Cf commit db07170a34f ("Platform: Allocate space in flash for OTP")
in trusted-firmware-m repo)
Take this into account and increase mcuboot flash partition for
nucleo_l552ze_q_ns target.

EDIT:  checkpatch will likely complain about this commit message due to unknown SHA1 for current repo. I propose to put a waiver on this false positive.