### PR TITLE
pinctrl: some minor updates

### DIFF
--- a/doc/guides/pinctrl/index.rst
+++ b/doc/guides/pinctrl/index.rst
@@ -473,7 +473,7 @@ The example below contains a complete example of a device driver that uses the
 
     #define MYDEV_DEFINE(i)                                                    \
         /* Define all pinctrl configuration for instance "i" */                \
-        PINCTRL_DT_INST_DEFINE(i)                                              \
+        PINCTRL_DT_INST_DEFINE(i);                                             \
         ...                                                                    \
         static const struct mydev_config mydev_config_##i = {                  \
             ...                                                                \
@@ -484,7 +484,7 @@ The example below contains a complete example of a device driver that uses the
         ...                                                                    \
                                                                                \
         DEVICE_DT_INST_DEFINE(i, mydev_init, NULL, &mydev_data##i,             \
-                              &mydev_config##i, ...)
+                              &mydev_config##i, ...);
 
     DT_INST_FOREACH_STATUS_OKAY(MYDEV_DEFINE)
 

--- a/doc/guides/pinctrl/index.rst
+++ b/doc/guides/pinctrl/index.rst
@@ -272,14 +272,14 @@ particular state are enclosed in a single Devicetree node.
     &pinctrl {
         /* Node with pin configuration for default state */
         periph0_default: periph0_default {
-            pins1 {
+            group1 {
                 /* Mappings: PERIPH0_SIGA -> PX0, PERIPH0_SIGC -> PZ1 */
                 pinmux = <PERIPH0_SIGA_PX0>, <PERIPH0_SIGC_PZ1>;
                 /* Pins PX0 and PZ1 have pull-up enabled */
                 bias-pull-up;
             };
             ...
-            pinsN {
+            groupN {
                 /* Mappings: PERIPH0_SIGB -> PY7 */
                 pinmux = <PERIPH0_SIGB_PY7>;
             };

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -1050,7 +1050,7 @@ static const struct adc_driver_api api_stm32_driver_api = {
 									\
 static void adc_stm32_cfg_func_##index(void);				\
 									\
-PINCTRL_DT_INST_DEFINE(index)						\
+PINCTRL_DT_INST_DEFINE(index);						\
 									\
 static const struct adc_stm32_cfg adc_stm32_cfg_##index = {		\
 	.base = (ADC_TypeDef *)DT_INST_REG_ADDR(index),			\

--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -1131,7 +1131,7 @@ static const struct can_driver_api can_api_funcs = {
 
 static void config_can_1_irq(CAN_TypeDef *can);
 
-PINCTRL_DT_DEFINE(DT_NODELABEL(can1))
+PINCTRL_DT_DEFINE(DT_NODELABEL(can1));
 
 static const struct can_stm32_config can_stm32_cfg_1 = {
 	.can = (CAN_TypeDef *)DT_REG_ADDR(DT_NODELABEL(can1)),
@@ -1227,7 +1227,7 @@ NET_DEVICE_INIT(socket_can_stm32_1, SOCKET_CAN_NAME_1, socket_can_init_1,
 
 static void config_can_2_irq(CAN_TypeDef *can);
 
-PINCTRL_DT_DEFINE(DT_NODELABEL(can2))
+PINCTRL_DT_DEFINE(DT_NODELABEL(can2));
 
 static const struct can_stm32_config can_stm32_cfg_2 = {
 	.can = (CAN_TypeDef *)DT_REG_ADDR(DT_NODELABEL(can2)),

--- a/drivers/can/can_stm32fd.c
+++ b/drivers/can/can_stm32fd.c
@@ -234,7 +234,7 @@ static void config_can_##inst##_irq(void)                                      \
 
 #define CAN_STM32FD_CFG_INST(inst)                                             \
 									       \
-PINCTRL_DT_INST_DEFINE(inst)						       \
+PINCTRL_DT_INST_DEFINE(inst);						       \
 									       \
 static const struct can_stm32fd_config can_stm32fd_cfg_##inst = {              \
 	.msg_sram = (struct can_mcan_msg_sram *)                               \
@@ -266,7 +266,7 @@ static const struct can_stm32fd_config can_stm32fd_cfg_##inst = {              \
 
 #define CAN_STM32FD_CFG_INST(inst)                                             \
 									       \
-PINCTRL_DT_INST_DEFINE(inst)						       \
+PINCTRL_DT_INST_DEFINE(inst);						       \
 									       \
 static const struct can_stm32fd_config can_stm32fd_cfg_##inst = {              \
 	.msg_sram = (struct can_mcan_msg_sram *)                               \

--- a/drivers/dac/dac_gd32.c
+++ b/drivers/dac/dac_gd32.c
@@ -150,7 +150,7 @@ static int dac_gd32_init(const struct device *dev)
 	return 0;
 }
 
-PINCTRL_DT_INST_DEFINE(0)
+PINCTRL_DT_INST_DEFINE(0);
 
 static struct dac_gd32_data dac_gd32_data_0;
 

--- a/drivers/dac/dac_stm32.c
+++ b/drivers/dac/dac_stm32.c
@@ -144,7 +144,7 @@ static const struct dac_driver_api api_stm32_driver_api = {
 
 #define STM32_DAC_INIT(index)						\
 									\
-PINCTRL_DT_INST_DEFINE(index)						\
+PINCTRL_DT_INST_DEFINE(index);						\
 									\
 static const struct dac_stm32_cfg dac_stm32_cfg_##index = {		\
 	.base = (DAC_TypeDef *)DT_INST_REG_ADDR(index),			\

--- a/drivers/disk/sdmmc_stm32.c
+++ b/drivers/disk/sdmmc_stm32.c
@@ -484,7 +484,7 @@ err_card_detect:
 
 #if DT_NODE_HAS_STATUS(DT_DRV_INST(0), okay)
 
-PINCTRL_DT_INST_DEFINE(0)
+PINCTRL_DT_INST_DEFINE(0);
 
 static void stm32_sdmmc_irq_config_func(const struct device *dev)
 {

--- a/drivers/ethernet/eth_dwmac_stm32h7x.c
+++ b/drivers/ethernet/eth_dwmac_stm32h7x.c
@@ -27,7 +27,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include "eth_dwmac_priv.h"
 
-PINCTRL_DT_INST_DEFINE(0)
+PINCTRL_DT_INST_DEFINE(0);
 static const struct pinctrl_dev_config *eth0_pcfg =
 	PINCTRL_DT_INST_DEV_CONFIG_GET(0);
 

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -1085,7 +1085,7 @@ static void eth0_irq_config(void)
 	irq_enable(DT_INST_IRQN(0));
 }
 
-PINCTRL_DT_INST_DEFINE(0)
+PINCTRL_DT_INST_DEFINE(0);
 
 static const struct eth_stm32_hal_dev_cfg eth0_config = {
 	.config_func = eth0_irq_config,

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -859,7 +859,7 @@ static void flash_stm32_qspi_irq_config_func(const struct device *dev);
 
 #define STM32_QSPI_NODE DT_INST_PARENT(0)
 
-PINCTRL_DT_DEFINE(STM32_QSPI_NODE)
+PINCTRL_DT_DEFINE(STM32_QSPI_NODE);
 
 static const struct flash_stm32_qspi_config flash_stm32_qspi_cfg = {
 	.regs = (QUADSPI_TypeDef *)DT_REG_ADDR(STM32_QSPI_NODE),

--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -327,7 +327,7 @@ STM32_I2C_IRQ_HANDLER_DECL(name);					\
 									\
 DEFINE_TIMINGS(name)							\
 									\
-PINCTRL_DT_DEFINE(DT_NODELABEL(name))					\
+PINCTRL_DT_DEFINE(DT_NODELABEL(name));					\
 									\
 static const struct i2c_stm32_config i2c_stm32_cfg_##name = {		\
 	.i2c = (I2C_TypeDef *)DT_REG_ADDR(DT_NODELABEL(name)),		\

--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -894,7 +894,7 @@ static const struct device *get_dev_from_tx_dma_channel(uint32_t dma_channel)
 									\
 static void i2s_stm32_irq_config_func_##index(const struct device *dev);\
 									\
-PINCTRL_DT_DEFINE(DT_NODELABEL(i2s##index))				\
+PINCTRL_DT_DEFINE(DT_NODELABEL(i2s##index));				\
 									\
 static const struct i2s_stm32_cfg i2s_stm32_config_##index = {		\
 	.i2s = (SPI_TypeDef *) DT_REG_ADDR(DT_NODELABEL(i2s##index)),	\

--- a/drivers/memc/memc_stm32.c
+++ b/drivers/memc/memc_stm32.c
@@ -46,7 +46,7 @@ static int memc_stm32_init(const struct device *dev)
 	return 0;
 }
 
-PINCTRL_DT_INST_DEFINE(0)
+PINCTRL_DT_INST_DEFINE(0);
 
 static const struct memc_stm32_config config = {
 	.fmc = DT_INST_REG_ADDR(0),

--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -662,7 +662,7 @@ replaced by 'st,prescaler' property in parent node, aka timers"
 	static struct pwm_stm32_data pwm_stm32_data_##index;                   \
 	IRQ_CONFIG_FUNC(index)						       \
 									       \
-	PINCTRL_DT_INST_DEFINE(index)					       \
+	PINCTRL_DT_INST_DEFINE(index);					       \
 									       \
 	static const struct pwm_stm32_config pwm_stm32_config_##index = {      \
 		.timer = (TIM_TypeDef *)DT_REG_ADDR(DT_INST_PARENT(index)),    \

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1983,7 +1983,7 @@ static int uarte_nrfx_pm_action(const struct device *dev,
 #define UART_NRF_UARTE_DEVICE(idx)					       \
 	UARTE_INT_DRIVEN(idx);						       \
 	UARTE_ASYNC(idx);						       \
-	IF_ENABLED(CONFIG_PINCTRL, (PINCTRL_DT_DEFINE(UARTE(idx))))	       \
+	IF_ENABLED(CONFIG_PINCTRL, (PINCTRL_DT_DEFINE(UARTE(idx));))	       \
 	static struct uarte_nrfx_data uarte_##idx##_data = {		       \
 		UARTE_CONFIG(idx),					       \
 		IF_ENABLED(CONFIG_UART_##idx##_ASYNC,			       \

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1688,7 +1688,7 @@ static void uart_stm32_irq_config_func_##index(const struct device *dev)	\
 #define STM32_UART_INIT(index)						\
 STM32_UART_IRQ_HANDLER_DECL(index)					\
 									\
-PINCTRL_DT_INST_DEFINE(index)						\
+PINCTRL_DT_INST_DEFINE(index);						\
 									\
 static const struct uart_stm32_config uart_stm32_cfg_##index = {	\
 	.uconf = {							\

--- a/drivers/serial/usart_gd32.c
+++ b/drivers/serial/usart_gd32.c
@@ -308,7 +308,7 @@ static const struct uart_driver_api usart_gd32_driver_api = {
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 
 #define GD32_USART_INIT(n)							\
-	PINCTRL_DT_INST_DEFINE(n)						\
+	PINCTRL_DT_INST_DEFINE(n);						\
 	GD32_USART_IRQ_HANDLER(n)						\
 	static struct gd32_usart_data usart_gd32_data_##n = {			\
 		.baud_rate = DT_INST_PROP(n, current_speed),			\

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -941,7 +941,7 @@ static void spi_stm32_irq_config_func_##id(const struct device *dev)		\
 #define STM32_SPI_INIT(id)						\
 STM32_SPI_IRQ_HANDLER_DECL(id);						\
 									\
-PINCTRL_DT_INST_DEFINE(id)						\
+PINCTRL_DT_INST_DEFINE(id);						\
 									\
 static const struct spi_stm32_config spi_stm32_cfg_##id = {		\
 	.spi = (SPI_TypeDef *) DT_INST_REG_ADDR(id),			\

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -61,7 +61,7 @@ LOG_MODULE_REGISTER(usb_dc_stm32);
 #define USB_MAXIMUM_SPEED	DT_INST_PROP(0, maximum_speed)
 #endif
 
-PINCTRL_DT_INST_DEFINE(0)
+PINCTRL_DT_INST_DEFINE(0);
 static const struct pinctrl_dev_config *usb_pcfg =
 					PINCTRL_DT_INST_DEV_CONFIG_GET(0);
 

--- a/dts/bindings/test/vnd,pinctrl-test.yaml
+++ b/dts/bindings/test/vnd,pinctrl-test.yaml
@@ -28,7 +28,7 @@ child-binding:
       /* node representing default state for test_device0 */
       test_device0_default: test_device0_default {
         /* group 1 (name is arbitrary) */
-        pins1 {
+        group1 {
           /* configure pins 0 and 1 */
           pins = <0>, <1>;
           /* both pins 0 and 1 have pull-up enabled */
@@ -36,7 +36,7 @@ child-binding:
         };
         ...
         /* group N (name is arbitrary) */
-        pinsN {
+        groupN {
           /* configure pin M */
           pins = <M>;
           /* pin M has pull-down enabled */

--- a/include/drivers/pinctrl.h
+++ b/include/drivers/pinctrl.h
@@ -240,7 +240,7 @@ struct pinctrl_dev_config {
 	Z_PINCTRL_STATES_DEFINE(node_id)				       \
 	Z_PINCTRL_DEV_CONFIG_CONST Z_PINCTRL_DEV_CONFIG_STATIC		       \
 	struct pinctrl_dev_config Z_PINCTRL_DEV_CONFIG_NAME(node_id) =	       \
-	Z_PINCTRL_DEV_CONFIG_INIT(node_id);
+	Z_PINCTRL_DEV_CONFIG_INIT(node_id)
 
 /**
  * @brief Define all pin control information for the given compatible index.

--- a/tests/drivers/pinctrl/api/app.overlay
+++ b/tests/drivers/pinctrl/api/app.overlay
@@ -10,11 +10,11 @@
 
 		/* default state for device 0 */
 		test_device0_default: test_device0_default {
-			pins1 {
+			group1 {
 				pins = <0>;
 				bias-pull-up;
 			};
-			pins2 {
+			group2 {
 				pins = <1>;
 				bias-pull-down;
 			};
@@ -22,18 +22,18 @@
 
 		/* sleep state for device 0 */
 		test_device0_sleep: test_device0_sleep {
-			pins1 {
+			group1 {
 				pins = <0>, <1>;
 			};
 		};
 
 		/* alternative default state for device 0 */
 		test_device0_alt_default: test_device0_alt_default {
-			pins1 {
+			group1 {
 				pins = <2>;
 				bias-pull-down;
 			};
-			pins2 {
+			group2 {
 				pins = <3>;
 				bias-pull-up;
 			};
@@ -41,28 +41,28 @@
 
 		/* alternative sleep state for device 0 */
 		test_device0_alt_sleep: test_device0_alt_sleep {
-			pins1 {
+			group1 {
 				pins = <2>, <3>;
 			};
 		};
 
 		/* default state for device 1 */
 		test_device1_default: test_device1_default {
-			pins1 {
+			group1 {
 				pins = <10>, <11>, <12>;
 			};
 		};
 
 		/* custom state "mystate" for device 1 */
 		test_device1_mystate: test_device1_mystate {
-			pins1 {
+			group1 {
 				pins = <10>;
 			};
-			pins2 {
+			group2 {
 				pins = <11>;
 				bias-pull-up;
 			};
-			pins3 {
+			group3 {
 				pins = <12>;
 				bias-pull-down;
 			};

--- a/tests/drivers/pinctrl/common/test_device.c
+++ b/tests/drivers/pinctrl/common/test_device.c
@@ -19,7 +19,7 @@ int test_device_init(const struct device *dev)
 }
 
 #define PINCTRL_DEVICE_INIT(inst)					\
-	PINCTRL_DT_INST_DEFINE(inst)					\
+	PINCTRL_DT_INST_DEFINE(inst);					\
 									\
 	DEVICE_DT_INST_DEFINE(inst, test_device_init, NULL, NULL, NULL,	\
 			      POST_KERNEL,				\

--- a/tests/drivers/pinctrl/gd32/boards/gd32f403z_eval.overlay
+++ b/tests/drivers/pinctrl/gd32/boards/gd32f403z_eval.overlay
@@ -18,48 +18,48 @@
 		/* Note: the groups are just meant for testing if properties and
 		   pins are parsed correctly, but do not necessarily represent a
 		   feasible combination */
-		pins1 {
+		group1 {
 			pinmux = <GD32_PINMUX_AFIO('A', 0, ANALOG, NORMP)>,
 				 <GD32_PINMUX_AFIO('B', 1, ALTERNATE, NORMP)>,
 				 <GD32_PINMUX_AFIO('C', 2, GPIO_IN, NORMP)>;
 		};
-		pins2 {
+		group2 {
 			pinmux = <GD32_PINMUX_AFIO('A', 3, GPIO_IN, TEST_DEVICE_RMP)>,
 				 <GD32_PINMUX_AFIO('B', 4, ALTERNATE, TEST_DEVICE_RMP)>;
 		};
-		pins3 {
+		group3 {
 			pinmux = <GD32_PINMUX_AFIO('C', 5, GPIO_IN, NORMP)>;
 			drive-push-pull;
 		};
-		pins4 {
+		group4 {
 			pinmux = <GD32_PINMUX_AFIO('A', 6, GPIO_IN, NORMP)>;
 			drive-open-drain;
 		};
-		pins5 {
+		group5 {
 			pinmux = <GD32_PINMUX_AFIO('B', 7, GPIO_IN, NORMP)>;
 			bias-disable;
 		};
-		pins6 {
+		group6 {
 			pinmux = <GD32_PINMUX_AFIO('C', 8, GPIO_IN, NORMP)>;
 			bias-pull-up;
 		};
-		pins7 {
+		group7 {
 			pinmux = <GD32_PINMUX_AFIO('A', 9, GPIO_IN, NORMP)>;
 			bias-pull-down;
 		};
-		pins8 {
+		group8 {
 			pinmux = <GD32_PINMUX_AFIO('B', 10, ALTERNATE, NORMP)>;
 			slew-rate = "max-speed-2mhz";
 		};
-		pins9 {
+		group9 {
 			pinmux = <GD32_PINMUX_AFIO('C', 11, ALTERNATE, NORMP)>;
 			slew-rate = "max-speed-10mhz";
 		};
-		pins10 {
+		group10 {
 			pinmux = <GD32_PINMUX_AFIO('A', 12, ALTERNATE, NORMP)>;
 			slew-rate = "max-speed-50mhz";
 		};
-		pins11 {
+		group11 {
 			pinmux = <GD32_PINMUX_AFIO('B', 13, ALTERNATE, NORMP)>;
 			slew-rate = "max-speed-highest";
 		};

--- a/tests/drivers/pinctrl/gd32/boards/gd32f450i_eval.overlay
+++ b/tests/drivers/pinctrl/gd32/boards/gd32f450i_eval.overlay
@@ -16,47 +16,47 @@
 		/* Note: the groups are just meant for testing if properties and
 		   pins are parsed correctly, but do not necessarily represent a
 		   feasible combination */
-		pins1 {
+		group1 {
 			pinmux = <GD32_PINMUX_AF('A', 0, AF0)>,
 				 <GD32_PINMUX_AF('B', 1, AF1)>;
 		};
-		pins2 {
+		group2 {
 			pinmux = <GD32_PINMUX_AF('C', 2, AF2)>;
 			drive-push-pull;
 		};
-		pins3 {
+		group3 {
 			pinmux = <GD32_PINMUX_AF('A', 3, AF3)>;
 			drive-open-drain;
 		};
-		pins4 {
+		group4 {
 			pinmux = <GD32_PINMUX_AF('B', 4, AF4)>;
 			bias-disable;
 		};
-		pins5 {
+		group5 {
 			pinmux = <GD32_PINMUX_AF('C', 5, AF5)>;
 			bias-pull-up;
 		};
-		pins6 {
+		group6 {
 			pinmux = <GD32_PINMUX_AF('A', 6, AF6)>;
 			bias-pull-down;
 		};
-		pins7 {
+		group7 {
 			pinmux = <GD32_PINMUX_AF('B', 7, AF7)>;
 			slew-rate = "max-speed-2mhz";
 		};
-		pins8 {
+		group8 {
 			pinmux = <GD32_PINMUX_AF('C', 8, AF8)>;
 			slew-rate = "max-speed-25mhz";
 		};
-		pins9 {
+		group9 {
 			pinmux = <GD32_PINMUX_AF('A', 9, AF9)>;
 			slew-rate = "max-speed-50mhz";
 		};
-		pins10 {
+		group10 {
 			pinmux = <GD32_PINMUX_AF('B', 10, AF10)>;
 			slew-rate = "max-speed-200mhz";
 		};
-		pins11 {
+		group11 {
 			pinmux = <GD32_PINMUX_AF('C', 11, ANALOG)>;
 		};
 	};


### PR DESCRIPTION
- pinctrl: require ; after PINCTRL_DT_(INST_)DEFINE macros
  The PINCTRL_DT_(INST_)DEFINE macros already defined the trailing ;,
  making its usage inconsistent with other macros such as DEVICE_DT_DEFINE.
- pinctrl: use groupN instead of pinsN for groups
  The pinsN group name can be a confusing in some circumstances, so change
  it to groupN. Some platforms (e.g. nrf or gd32) are already using
  groupN. Documentation and API tests have been updated.