### PR TITLE
twister: fix skip marked as pass in json report

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -3830,11 +3830,13 @@ class TestSuite(DisablePyTestCollectionMixin):
                     if rom_size:
                         testcase["rom_size"] = rom_size
 
-                    if instance.results[k] in ["PASS"] or instance.status == 'passed':
+                    if instance.results[k] in ["SKIP"] or instance.status == 'skipped':
+                        testcase["status"] = "skipped"
+                        testcase["reason"] = instance.reason
+                    elif instance.results[k] in ["PASS"] or instance.status == 'passed':
                         testcase["status"] = "passed"
                         if instance.handler:
                             testcase["execution_time"] =  handler_time
-
                     elif instance.results[k] in ['FAIL', 'BLOCK'] or instance.status in ["error", "failed", "timeout", "flash_error"]:
                         testcase["status"] = "failed"
                         testcase["reason"] = instance.reason
@@ -3845,9 +3847,6 @@ class TestSuite(DisablePyTestCollectionMixin):
                             testcase["device_log"] = self.process_log(device_log)
                         else:
                             testcase["build_log"] = self.process_log(build_log)
-                    elif instance.status == 'skipped':
-                        testcase["status"] = "skipped"
-                        testcase["reason"] = instance.reason
                     testcases.append(testcase)
 
         suites = [ {"testcases": testcases} ]


### PR DESCRIPTION
When some testcase is skip in their source code by ztest_test_skip()
function in final json report it is marked as pass what is wrong. Due to
the changes in this commit those skips can be marked properly.

Those changes do not impact in situation, when tests or samples are
performed as build only.

Fixes: #41440

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>