### PR TITLE
test: bsim: Fix missed bsim warnings

### DIFF
--- a/tests/bluetooth/bsim_bt/compile.source
+++ b/tests/bluetooth/bsim_bt/compile.source
@@ -11,6 +11,7 @@ function compile(){
   local cmake_args="${cmake_args:-"-DCONFIG_COVERAGE=y \
     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON"}"
   local ninja_args="${ninja_args:-""}"
+  local cc_flags="${cc_flags:-"-Werror"}"
 
   local exe_name="${exe_name:-bs_${BOARD}_${app}_${conf_file}}"
   local exe_name=${exe_name//\//_}
@@ -27,7 +28,8 @@ function compile(){
       [ -d "${this_dir}" ] && rm ${this_dir} -rf
       mkdir -p ${this_dir} && cd ${this_dir}
       cmake -GNinja -DBOARD_ROOT=${BOARD_ROOT} -DBOARD=${BOARD} \
-            -DCONF_FILE=${conf_file} -DOVERLAY_CONFIG=${conf_overlay} ${cmake_args} ${app_root}/${app} \
+            -DCONF_FILE=${conf_file} -DOVERLAY_CONFIG=${conf_overlay} \
+            ${cmake_args} -DCMAKE_C_FLAGS="${cc_flags}" ${app_root}/${app} \
             &> cmake.out || { cat cmake.out && return 0; }
   else
       cd ${this_dir}

--- a/west.yml
+++ b/west.yml
@@ -184,7 +184,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: a47e326ca772ddd14cc3b9d4ca30a9ab44ecca16
+      revision: 42645e87ade210c1cac201ff4b2bffb23cd6e331
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: cfd050ff38a9d028dc211690b2ec35971128e45e


### PR DESCRIPTION
PR fixes https://github.com/zephyrproject-rtos/zephyr/issues/38303
It adds a lost compiler option to prohibit warnings
It fixes warnings in BabbleSim hw repo. (need to be merged first.)