### PR TITLE
device: deprecate device_usable_check

### DIFF
--- a/include/device.h
+++ b/include/device.h
@@ -739,7 +739,7 @@ size_t z_device_get_all_static(const struct device * *devices);
  *
  * @return true if and only if the device is available for use.
  */
-bool z_device_ready(const struct device *dev);
+bool z_device_is_ready(const struct device *dev);
 
 /** @brief Determine whether a device is ready for use
  *
@@ -752,7 +752,7 @@ bool z_device_ready(const struct device *dev);
  */
 static inline int z_device_usable_check(const struct device *dev)
 {
-	return z_device_ready(dev) ? 0 : -ENODEV;
+	return z_device_is_ready(dev) ? 0 : -ENODEV;
 }
 
 /** @brief Determine whether a device is ready for use.

--- a/include/device.h
+++ b/include/device.h
@@ -741,38 +741,6 @@ size_t z_device_get_all_static(const struct device * *devices);
  */
 bool z_device_is_ready(const struct device *dev);
 
-/** @brief Determine whether a device is ready for use
- *
- * This is the implementation underlying `device_usable_check()`, without the
- * overhead of a syscall wrapper.
- *
- * @param dev pointer to the device in question.
- *
- * @return a non-positive integer as documented in device_usable_check().
- */
-static inline int z_device_usable_check(const struct device *dev)
-{
-	return z_device_is_ready(dev) ? 0 : -ENODEV;
-}
-
-/** @brief Determine whether a device is ready for use.
- *
- * This checks whether a device can be used, returning 0 if it can, and
- * distinct error values that identify the reason if it cannot.
- *
- * @retval 0 if the device is usable.
- * @retval -ENODEV if the device has not been initialized, the device pointer
- * is NULL or the initialization failed.
- * @retval other negative error codes to indicate additional conditions that
- * make the device unusable.
- */
-__syscall int device_usable_check(const struct device *dev);
-
-static inline int z_impl_device_usable_check(const struct device *dev)
-{
-	return z_device_usable_check(dev);
-}
-
 /** @brief Verify that a device is ready for use.
  *
  * Indicates whether the provided device pointer is for a device known to be
@@ -794,6 +762,39 @@ __syscall bool device_is_ready(const struct device *dev);
 static inline bool z_impl_device_is_ready(const struct device *dev)
 {
 	return z_device_is_ready(dev);
+}
+
+/**
+ * @brief Determine whether a device is ready for use
+ *
+ * This is equivalent to device_usable_check(), without the overhead of a
+ * syscall wrapper.
+ *
+ * @deprecated Use z_device_is_ready() instead.
+ *
+ * @param dev Device instance.
+ *
+ * @retval 0 If device is usable.
+ * @retval -ENODEV If device is not usable.
+ */
+__deprecated static inline int z_device_usable_check(const struct device *dev)
+{
+	return z_device_is_ready(dev) ? 0 : -ENODEV;
+}
+
+/**
+ * @brief Determine whether a device is ready for use
+ *
+ * @deprecated Use device_is_ready() instead.
+ *
+ * @param dev Device instance.
+ *
+ * @retval 0 If device is usable.
+ * @retval -ENODEV If device is not usable.
+ */
+__deprecated static inline int device_usable_check(const struct device *dev)
+{
+	return device_is_ready(dev) ? 0 : -ENODEV;
 }
 
 /**

--- a/include/device.h
+++ b/include/device.h
@@ -789,9 +789,11 @@ static inline int z_impl_device_usable_check(const struct device *dev)
  * @retval false if the device is not ready for use or if a NULL device pointer
  * is passed as argument.
  */
-static inline bool device_is_ready(const struct device *dev)
+__syscall bool device_is_ready(const struct device *dev);
+
+static inline bool z_impl_device_is_ready(const struct device *dev)
 {
-	return device_usable_check(dev) == 0;
+	return z_device_is_ready(dev);
 }
 
 /**

--- a/include/device.h
+++ b/include/device.h
@@ -733,11 +733,19 @@ __syscall const struct device *device_get_binding(const char *name);
  */
 size_t z_device_get_all_static(const struct device * *devices);
 
-/** @brief Determine whether a device has been successfully initialized.
+/**
+ * @brief Verify that a device is ready for use.
+ *
+ * This is the implementation underlying device_is_ready(), without the overhead
+ * of a syscall wrapper.
  *
  * @param dev pointer to the device in question.
  *
- * @return true if and only if the device is available for use.
+ * @retval true If the device is ready for use.
+ * @retval false If the device is not ready for use or if a NULL device pointer
+ * is passed as argument.
+ *
+ * @see device_is_ready()
  */
 bool z_device_is_ready(const struct device *dev);
 
@@ -748,13 +756,12 @@ bool z_device_is_ready(const struct device *dev);
  *
  * This can be used with device pointers captured from DEVICE_DT_GET(), which
  * does not include the readiness checks of device_get_binding(). At minimum
- * this means that the device has been successfully initialized, but it may
- * take on further conditions (e.g. is not powered down).
+ * this means that the device has been successfully initialized.
  *
  * @param dev pointer to the device in question.
  *
- * @retval true if the device is ready for use.
- * @retval false if the device is not ready for use or if a NULL device pointer
+ * @retval true If the device is ready for use.
+ * @retval false If the device is not ready for use or if a NULL device pointer
  * is passed as argument.
  */
 __syscall bool device_is_ready(const struct device *dev);

--- a/include/drivers/clock_control.h
+++ b/include/drivers/clock_control.h
@@ -117,10 +117,8 @@ struct clock_control_driver_api {
 static inline int clock_control_on(const struct device *dev,
 				   clock_control_subsys_t sys)
 {
-	int ret = device_usable_check(dev);
-
-	if (ret != 0) {
-		return ret;
+	if (!device_is_ready(dev)) {
+		return -ENODEV;
 	}
 
 	const struct clock_control_driver_api *api =
@@ -142,10 +140,8 @@ static inline int clock_control_on(const struct device *dev,
 static inline int clock_control_off(const struct device *dev,
 				    clock_control_subsys_t sys)
 {
-	int ret = device_usable_check(dev);
-
-	if (ret != 0) {
-		return ret;
+	if (!device_is_ready(dev)) {
+		return -ENODEV;
 	}
 
 	const struct clock_control_driver_api *api =
@@ -183,10 +179,8 @@ static inline int clock_control_async_on(const struct device *dev,
 		return -ENOSYS;
 	}
 
-	int ret = device_usable_check(dev);
-
-	if (ret != 0) {
-		return ret;
+	if (!device_is_ready(dev)) {
+		return -ENODEV;
 	}
 
 	return api->async_on(dev, sys, cb, user_data);
@@ -228,10 +222,8 @@ static inline int clock_control_get_rate(const struct device *dev,
 					 clock_control_subsys_t sys,
 					 uint32_t *rate)
 {
-	int ret = device_usable_check(dev);
-
-	if (ret != 0) {
-		return ret;
+	if (!device_is_ready(dev)) {
+		return -ENODEV;
 	}
 
 	const struct clock_control_driver_api *api =
@@ -264,10 +256,8 @@ static inline int clock_control_set_rate(const struct device *dev,
 		clock_control_subsys_t sys,
 		clock_control_subsys_rate_t rate)
 {
-	int ret = device_usable_check(dev);
-
-	if (ret != 0) {
-		return ret;
+	if (!device_is_ready(dev)) {
+		return -ENODEV;
 	}
 
 	const struct clock_control_driver_api *api =

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -106,13 +106,13 @@ const struct device *z_impl_device_get_binding(const char *name)
 	 * performed. Reserve string comparisons for a fallback.
 	 */
 	for (dev = __device_start; dev != __device_end; dev++) {
-		if (z_device_ready(dev) && (dev->name == name)) {
+		if (z_device_is_ready(dev) && (dev->name == name)) {
 			return dev;
 		}
 	}
 
 	for (dev = __device_start; dev != __device_end; dev++) {
-		if (z_device_ready(dev) && (strcmp(name, dev->name) == 0)) {
+		if (z_device_is_ready(dev) && (strcmp(name, dev->name) == 0)) {
 			return dev;
 		}
 	}
@@ -149,7 +149,7 @@ size_t z_device_get_all_static(struct device const **devices)
 	return __device_end - __device_start;
 }
 
-bool z_device_ready(const struct device *dev)
+bool z_device_is_ready(const struct device *dev)
 {
 	/*
 	 * if an invalid device pointer is passed as argument, this call

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -134,14 +134,6 @@ static inline const struct device *z_vrfy_device_get_binding(const char *name)
 }
 #include <syscalls/device_get_binding_mrsh.c>
 
-static inline int z_vrfy_device_usable_check(const struct device *dev)
-{
-	Z_OOPS(Z_SYSCALL_OBJ_INIT(dev, K_OBJ_ANY));
-
-	return z_impl_device_usable_check(dev);
-}
-#include <syscalls/device_usable_check_mrsh.c>
-
 static inline bool z_vrfy_device_is_ready(const struct device *dev)
 {
 	Z_OOPS(Z_SYSCALL_OBJ_INIT(dev, K_OBJ_ANY));

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -141,6 +141,14 @@ static inline int z_vrfy_device_usable_check(const struct device *dev)
 	return z_impl_device_usable_check(dev);
 }
 #include <syscalls/device_usable_check_mrsh.c>
+
+static inline bool z_vrfy_device_is_ready(const struct device *dev)
+{
+	Z_OOPS(Z_SYSCALL_OBJ_INIT(dev, K_OBJ_ANY));
+
+	return z_impl_device_is_ready(dev);
+}
+#include <syscalls/device_is_ready_mrsh.c>
 #endif /* CONFIG_USERSPACE */
 
 size_t z_device_get_all_static(struct device const **devices)


### PR DESCRIPTION
It looks like the functionality offered by `device_usable_check()` is equivalent to `device_is_ready()`. The possible error codes provided by `device_usable_check()` are a binary set: 0 (usable) or -ENODEV (not usable). This means that `device_usable_check()` is effectively a function returning a boolean encoded as an integer. It seems that `device_usable_check()` has rarely been used, there was just a single use case in-tree that has been replaced with `device_is_ready()` keeping the same old behavior.