### PR TITLE
drivers: uart: esp32: fix poll in return value

### DIFF
--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -103,7 +103,8 @@ static int uart_esp32_poll_in(const struct device *dev, unsigned char *p_char)
 	}
 
 	uart_hal_read_rxfifo(&DEV_CFG(dev)->hal, p_char, &inout_rd_len);
-	return inout_rd_len;
+
+	return 0;
 }
 
 static void uart_esp32_poll_out(const struct device *dev, unsigned char c)
@@ -354,6 +355,10 @@ static int uart_esp32_fifo_fill(const struct device *dev,
 				const uint8_t *tx_data, int len)
 {
 	uint32_t written = 0;
+
+	if (len < 0) {
+		return 0;
+	}
 
 	uart_hal_write_txfifo(&DEV_CFG(dev)->hal, tx_data, len, &written);
 	return written;


### PR DESCRIPTION
uart_poll_in should return 0 on success and not
the total amount of data read.

This also adds a check in fifo_fill call to
avoid negative values, otherwise it would send garbage
to uart

Closes #41352

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>