### PR TITLE
cmake: fix out of tree hal build fail

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -404,6 +404,9 @@ macro(zephyr_library_get_current_dir_lib_name base lib_name)
   # Replace / with __ (driver/serial => driver__serial)
   string(REGEX REPLACE "/" "__" name ${name})
 
+  # Replace : with __ (C:/zephyrproject => C____zephyrproject)
+  string(REGEX REPLACE ":" "__" name ${name})
+
   set(${lib_name} ${name})
 endmacro()
 


### PR DESCRIPTION
Fix out of tree building hal fail with different drive on windows environment, due to ':' is invalid character as a lib_name.

Signed-off-by: Jim Tan <KuoChun.Tan@ite.com.tw>