### PR TITLE
hawkbit: add support for using Range HTTP header

### DIFF
--- a/samples/subsys/mgmt/hawkbit/sample.yaml
+++ b/samples/subsys/mgmt/hawkbit/sample.yaml
@@ -10,3 +10,12 @@ tests:
     depends_on: netif
     build_only: true
     platform_allow: frdm_k64f
+  samples.net.hawkbit.download_part:
+    harness: net
+    tags: net
+    extra_configs:
+      - CONFIG_HAWKBIT_DOWNLOAD_PART=y
+      - CONFIG_HAWKBIT_DOWNLOAD_PART_SIZE=1
+    depends_on: netif
+    build_only: true
+    platform_allow: frdm_k64f

--- a/subsys/mgmt/hawkbit/Kconfig
+++ b/subsys/mgmt/hawkbit/Kconfig
@@ -81,6 +81,30 @@ config HAWKBIT_DDI_SECURITY_TOKEN
 	  Authentication security token for the configured Hawkbit DDI
 	  authentication mode.
 
+choice
+	prompt "Download strategy"
+	default HAWKBIT_DOWNLOAD_FULL
+
+config HAWKBIT_DOWNLOAD_FULL
+	bool "Download using single request"
+	help
+	  Download the firmware update using a single HTTP request.
+
+config HAWKBIT_DOWNLOAD_PART
+	bool "Download using multiple requests"
+	help
+	  Download firmware using multiple requests. This uses the HTTP Range
+	  header to split up downloads into chunks.
+
+endchoice
+
+config HAWKBIT_DOWNLOAD_PART_SIZE
+	int "Size of downloaded part"
+	depends on HAWKBIT_DOWNLOAD_PART
+	default 1
+	help
+	  Size of downloaded part of the firmware, in kB.
+
 module = HAWKBIT
 module-str = Log Level for hawkbit
 module-help = Enables logging for Hawkbit code.

--- a/subsys/mgmt/hawkbit/hawkbit_priv.h
+++ b/subsys/mgmt/hawkbit/hawkbit_priv.h
@@ -24,6 +24,7 @@ enum hawkbit_http_request {
 	HAWKBIT_PROBE_DEPLOYMENT_BASE,
 	HAWKBIT_REPORT,
 	HAWKBIT_DOWNLOAD,
+	HAWKBIT_DOWNLOAD_PART,
 };
 
 enum hawkbit_status_fini {
@@ -162,6 +163,7 @@ struct entry http_request[] = {
 	{"HAWKBIT_PROBE_DEPLOYMENT_BASE", 3},
 	{"HAWKBIT_REPORT", 4},
 	{"HAWKBIT_DOWNLOAD", 5},
+	{"HAWKBIT_DOWNLOAD_PART", 6},
 };
 
 #endif /* __HAWKBIT_PRIV_H__ */


### PR DESCRIPTION
Downloading of firmware updates can now be performed using the Range
HTTP header. This is because some modems don't support downloading files
larger than some set amount when using TLS. For example the nrf9160
modem can only handle transfers of 2 kB when using TLS. Moreover this
also also provides a starting point for resumeable downloads for
hawkbit.

Signed-off-by: Joep Buruma <burumaj50@gmail.com>