### PR TITLE
Update H4 driver to execute vendor-specific commands for initialization BT Controller before BT Host executes Reset sequence.

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -131,3 +131,16 @@ config BT_DRIVER_QUIRK_NO_AUTO_DLE
 
 	  This has to be enabled when the BLE controller connected is Zephyr
 	  open source controller.
+
+config BT_HCI_SETUP
+	bool
+	help
+	  Enable the HCI vendor-specific Setup function.
+
+	  This option has to be enabled when the BT Controller requires execution
+	  of the vendor-specific commands sequence to initialize the BT Controller
+	  before the BT Host executes a Reset sequence.
+
+	  The user should generally avoid changing it via menuconfig or in
+	  configuration files. This option are enabled by the vendor-specific
+	  HCI extension, where the Setup function is implemented.

--- a/drivers/bluetooth/hci/h4.c
+++ b/drivers/bluetooth/hci/h4.c
@@ -525,11 +525,29 @@ static int h4_open(void)
 	return 0;
 }
 
+#if defined(CONFIG_BT_HCI_SETUP)
+static int h4_setup(void)
+{
+	/* Extern bt_h4_vnd_setup function.
+	 * This function executes vendor-specific commands sequence to
+	 * initialize BT Controller before BT Host executes Reset sequence.
+	 * bt_h4_vnd_setup function must be implemented in vendor-specific HCI
+	 * extansion module if CONFIG_BT_HCI_SETUP is enabled.
+	 */
+	extern int bt_h4_vnd_setup(const struct device *dev);
+
+	return bt_h4_vnd_setup(h4_dev);
+}
+#endif
+
 static const struct bt_hci_driver drv = {
 	.name		= "H:4",
 	.bus		= BT_HCI_DRIVER_BUS_UART,
 	.open		= h4_open,
 	.send		= h4_send,
+#if defined(CONFIG_BT_HCI_SETUP)
+	.setup		= h4_setup
+#endif
 };
 
 static int bt_uart_init(const struct device *unused)

--- a/include/drivers/bluetooth/hci_driver.h
+++ b/include/drivers/bluetooth/hci_driver.h
@@ -185,6 +185,21 @@ struct bt_hci_driver {
 	 * @return 0 on success or negative error number on failure.
 	 */
 	int (*send)(struct net_buf *buf);
+
+#if defined(CONFIG_BT_HCI_SETUP) || defined(__DOXYGEN__)
+	/**
+	 * @brief HCI vendor-specific setup
+	 *
+	 * Executes vendor-specific commands sequence to initialize
+	 * BT Controller before BT Host executes Reset sequence.
+	 *
+	 * @note @kconfig{CONFIG_BT_HCI_SETUP} must be selected for this
+	 * field to be available.
+	 *
+	 * @return 0 on success or negative error number on failure.
+	 */
+	int (*setup)(void);
+#endif /* defined(CONFIG_BT_HCI_SETUP) || defined(__DOXYGEN__)*/
 };
 
 /**

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3276,6 +3276,14 @@ static void hci_vs_init(void)
 static int hci_init(void)
 {
 	int err;
+#if defined(CONFIG_BT_HCI_SETUP)
+	if (bt_dev.drv->setup) {
+		err = bt_dev.drv->setup();
+		if (err) {
+			return err;
+		}
+	}
+#endif /* defined(CONFIG_BT_HCI_SETUP) */
 
 	err = common_init();
 	if (err) {


### PR DESCRIPTION
Update H4 driver to execute vendor-specific commands for initialization BT Controller before BT Host executes Reset sequence. Details in https://github.com/zephyrproject-rtos/zephyr/issues/41140.

The following changes was agreed with @carlescufi:
1. add one more field 'setup' in bt_hci_driver type as pointer to HCI vendor-specific setup function
2. add BT_HCI_H4_SETUP Config option in drivers/bluetooth/hci/Kconfig 
3. update hci_init function to call bt_dev.drv->setup() if it not null

