### PR TITLE
Support board aliases for configuration file include fragments

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -2256,6 +2256,14 @@ Relative paths are only allowed with `-D${ARGV1}=<path>`")
                         BUILD ${FILE_BUILD}
     )
     list(APPEND filename_list ${filename})
+
+    if(DEFINED BOARD_ALIAS)
+      zephyr_build_string(filename
+                          BOARD ${BOARD_ALIAS}
+                          BUILD ${FILE_BUILD}
+      )
+      list(APPEND filename_list ${filename})
+    endif()
     list(REMOVE_DUPLICATES filename_list)
 
     if(FILE_DTS)


### PR DESCRIPTION
In project where I create a board alias, e.g.:
```
set(LPCXpresso55S69_BOARD_ALIAS lpcxpresso55s69_cpu0)
```

If I want to have a configuration file include fragment, I need to use the real board in the file name:
```
Loaded configuration '[...]/zephyr/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu0_defconfig'
Merged configuration '[...]/app/prj.conf'
Merged configuration '[...]/app/boards/lpcxpresso55s69_cpu0.conf'
```

With this patch the board alias can be used:
```
Loaded configuration '[...]/zephyr/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu0_defconfig'
Merged configuration '[...]/app/prj.conf'
Merged configuration '[...]/app/boards/LPCXpresso55S69.conf'
```
