### PR TITLE
Boards: ARC: QEMU: Enable  networking SLIP networking

### DIFF
--- a/boards/arc/qemu_arc/Kconfig.defconfig
+++ b/boards/arc/qemu_arc/Kconfig.defconfig
@@ -1,9 +1,30 @@
-# Copyright (c) 2020 Synopsys, Inc. All rights reserved.
+# Copyright (c) 2020,2021 Synopsys, Inc. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 if BOARD_QEMU_ARC
 
 config BOARD
 	default "qemu_arc"
+
+if NETWORKING
+
+	config NET_L2_ETHERNET
+	default y
+
+	# Required to satisfy dependency of networking stack on RNG
+	config TEST_RANDOM_GENERATOR
+	default y
+
+endif # NETWORKING
+
+if UART_PIPE
+
+	# By fefault "UART_0" is selected, while we'd like
+	# to keep using "UART_0" as a normal serial port for
+	# debug prints and possibly interaction with the board.
+	config UART_PIPE_ON_DEV_NAME
+	default "UART_1"
+
+endif # UART_PIPE
 
 endif

--- a/boards/arc/qemu_arc/qemu_arc.dtsi
+++ b/boards/arc/qemu_arc/qemu_arc.dtsi
@@ -45,6 +45,16 @@
 		interrupts = <24 1>;
 	};
 
+	uart@f0002000 {
+		compatible = "ns16550";
+		clock-frequency = <10000000>;
+		reg = <0xf0002000 0x400>;
+		current-speed = <115200>;
+		label = "UART_1";
+		interrupt-parent = <&intc>;
+		interrupts = <25 1>;
+	};
+
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/soc/arc/snps_qemu/Kconfig.defconfig
+++ b/soc/arc/snps_qemu/Kconfig.defconfig
@@ -21,7 +21,7 @@ config NUM_IRQ_PRIO_LEVELS
 	default 15
 
 config NUM_IRQS
-	default 25
+	default 26
 
 # Technically ARC HS supports MPUv3, but not v2. But given MPUv3
 # is the same as v2 but with minimal region size of 32 bytes, we


### PR DESCRIPTION
This enables networking-related samples on ARC's QEMU platform.

Note, it requires updated QEMU which supports the second UART (which is used exactly for SLIP-based networking interface, see https://github.com/zephyrproject-rtos/sdk-ng/pull/422).

As it is (with updated SDK-ng whenever it gets published) this gets us Civetweb web-server working on `qemu_arc_hs` only because:
* For ARC EM-based `qemu_arc_em` we need https://github.com/zephyrproject-rtos/civetweb/pull/8 fix for Civetweb so that C-implemnted atomics are used. Otherwise linker errors-out on missing `__atomic_xxx` symbols.
* For ARC HS68-based `qemu_arc_hs6x` we need to increase `ISR_STACK_SIZE` of the sample itself, i.e. revert (at least partially) https://github.com/zephyrproject-rtos/zephyr/pull/28376 so that ISR stack size is not smaller than exception stack size (which we set as a 4Kib for 64-bit ARC platform). 