### PR TITLE
net: lwm2m: Update connectivity monitor object

### DIFF
--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -246,6 +246,22 @@ config LWM2M_CONN_MON_OBJ_SUPPORT
 	help
 	  Include support for LWM2M Connectivity Monitoring Object (ID 4)
 
+choice
+	prompt "LwM2M Connectivity Monitor object version"
+	default LWM2M_CONNMON_OBJECT_VERSION_1_0
+	depends on LWM2M_CONN_MON_OBJ_SUPPORT
+	help
+	  Select Which version of the Connectivity Monitor object should be used.
+
+config LWM2M_CONNMON_OBJECT_VERSION_1_0
+	bool "Connectivity monitor object version 1.0"
+
+config LWM2M_CONNMON_OBJECT_VERSION_1_2
+	bool "Connectivity monitor object version 1.2 [EXPERIMENTAL]"
+	select EXPERIMENTAL
+
+endchoice
+
 config LWM2M_CONN_MON_BEARER_MAX
 	int "Maximum # of available network bearer resource instances"
 	depends on LWM2M_CONN_MON_OBJ_SUPPORT

--- a/subsys/net/lib/lwm2m/lwm2m_obj_connmon.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_connmon.c
@@ -19,7 +19,13 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include "lwm2m_engine.h"
 
 #define CONNMON_VERSION_MAJOR 1
+#if defined(CONFIG_LWM2M_CONNMON_OBJECT_VERSION_1_2)
+#define CONNMON_VERSION_MINOR 2
+#define CONNMON_MAX_ID 13
+#else
 #define CONNMON_VERSION_MINOR 0
+#define CONNMON_MAX_ID 11
+#endif /* CONFIG_LWM2M_CONNMON_OBJECT_VERSION_1_2 */
 
 /* Connectivity Monitoring resource IDs */
 #define CONNMON_NETWORK_BEARER_ID		0
@@ -33,8 +39,10 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define CONNMON_CELLID				8
 #define CONNMON_SMNC				9
 #define CONNMON_SMCC				10
-
-#define CONNMON_MAX_ID				11
+#if defined(CONFIG_LWM2M_CONNMON_OBJECT_VERSION_1_2)
+#define CONNMON_SIGNAL_SNR			11
+#define CONNMON_LAC				12
+#endif
 
 #define CONNMON_STRING_SHORT			8
 
@@ -81,6 +89,10 @@ static uint8_t link_quality;
 static uint32_t cellid;
 static uint16_t mnc;
 static uint16_t mcc;
+#if defined(CONFIG_LWM2M_CONNMON_OBJECT_VERSION_1_2)
+static int32_t snr;
+static uint16_t lac;
+#endif
 
 /* only 1 instance of Connection Monitoring object exists */
 static struct lwm2m_engine_obj connmon;
@@ -95,7 +107,11 @@ static struct lwm2m_engine_obj_field fields[] = {
 	OBJ_FIELD_DATA(CONNMON_APN, R_OPT, STRING),
 	OBJ_FIELD_DATA(CONNMON_CELLID, R_OPT, U32),
 	OBJ_FIELD_DATA(CONNMON_SMNC, R_OPT, U16),
-	OBJ_FIELD_DATA(CONNMON_SMCC, R_OPT, U16)
+	OBJ_FIELD_DATA(CONNMON_SMCC, R_OPT, U16),
+#if defined(CONFIG_LWM2M_CONNMON_OBJECT_VERSION_1_2)
+	OBJ_FIELD_DATA(CONNMON_SIGNAL_SNR, R_OPT, S32),
+	OBJ_FIELD_DATA(CONNMON_LAC, R_OPT, U16),
+#endif
 };
 
 static struct lwm2m_engine_obj_inst inst;
@@ -136,6 +152,10 @@ static struct lwm2m_engine_obj_inst *connmon_create(uint16_t obj_inst_id)
 			  sizeof(cellid));
 	INIT_OBJ_RES_DATA(CONNMON_SMNC, res, i, res_inst, j, &mnc, sizeof(mnc));
 	INIT_OBJ_RES_DATA(CONNMON_SMCC, res, i, res_inst, j, &mcc, sizeof(mcc));
+#if defined(CONFIG_LWM2M_CONNMON_OBJECT_VERSION_1_2)
+	INIT_OBJ_RES_DATA(CONNMON_SIGNAL_SNR, res, i, res_inst, j, &snr, sizeof(snr));
+	INIT_OBJ_RES_DATA(CONNMON_LAC, res, i, res_inst, j, &lac, sizeof(lac));
+#endif
 
 	inst.resources = res;
 	inst.resource_count = i;


### PR DESCRIPTION
Update the connectivity monitor object to version 1.2.
Added also a Kconfig option to switch between object versions 1.0 and 1.2.

The OMA specification for LwM2M version 1.1 uses the object version 1.2 of the connectivity monitor object.

Signed-off-by: Jarno Lamsa <jarno.lamsa@nordicsemi.no>