### PR TITLE
CODEOWNERS: Add myself for ESP32 BT HCI driver

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -205,6 +205,7 @@
 /drivers/audio/*nrfx*                     @anangl
 /drivers/bbram/*                          @yperess @sjg20 @jackrosenthal
 /drivers/bluetooth/                       @alwa-nordic @jhedberg @Vudentz
+/drivers/bluetooth/hci/hci_esp32.c        @sylvioalves
 /drivers/cache/                           @carlocaione
 /drivers/syscon/                          @carlocaione @yperess
 /drivers/can/                             @alexanderwachter


### PR DESCRIPTION
Add myself as codeowner for the ESP32 bluetooth HCI driver

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>