### PR TITLE
Bluetooth: Drivers: Fix bad return for bt_esp_evt_recv

### DIFF
--- a/drivers/bluetooth/hci/hci_esp32.c
+++ b/drivers/bluetooth/hci/hci_esp32.c
@@ -93,7 +93,7 @@ static struct net_buf *bt_esp_evt_recv(uint8_t *data, size_t remaining)
 		BT_ERR("Not enough space in buffer %zu/%zu",
 		       remaining, buf_tailroom);
 		net_buf_unref(buf);
-		continue;
+		return NULL;
 	}
 
 	net_buf_add_mem(buf, data, remaining);


### PR DESCRIPTION
Instead of returning NULL, the function had a `continue`.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

Fixes issue introduced by https://github.com/zephyrproject-rtos/zephyr/pull/41011