### PR TITLE
kconfig: drivers: crypto: Remove EXPERIMENTAL

### DIFF
--- a/drivers/crypto/Kconfig
+++ b/drivers/crypto/Kconfig
@@ -7,8 +7,7 @@
 # CRYPTO options
 #
 menuconfig CRYPTO
-	bool "Crypto Drivers [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "Crypto Drivers"
 
 if CRYPTO
 


### PR DESCRIPTION
The crypto driver API is 6 years old, has 5 different implementations,
and is widely used.

Remove the EXPERIMENTAL marking from the API. Each implementation may
still choose to mark itself as EXPERIMENTAL.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>