### PR TITLE
Bluetooth: host: Add API to run conn CTE response HCI command

### DIFF
--- a/include/bluetooth/direction.h
+++ b/include/bluetooth/direction.h
@@ -142,6 +142,7 @@ struct bt_df_conn_iq_samples_report {
 	/** Pinter to IQ samples data. */
 	struct bt_hci_le_iq_sample const *sample;
 };
+
 /**
  * @brief Set or update the Constant Tone Extension parameters for periodic advertising set.
  *
@@ -216,5 +217,27 @@ int bt_df_conn_cte_rx_enable(struct bt_conn *conn, const struct bt_df_conn_cte_r
  * @return Zero in case of success, other value in case of failure.
  */
 int bt_df_conn_cte_rx_disable(struct bt_conn *conn);
+
+/**
+ * @brief Enable Constant Tone Extension response procedure for a connection.
+ *
+ * The function is available if @kconfig{CONFIG_BT_DF_CONNECTION_CTE_RSP} is enabled.
+ *
+ * @param conn   Connection object.
+ *
+ * @return Zero in case of success, other value in case of failure.
+ */
+int bt_df_conn_cte_rsp_enable(struct bt_conn *conn);
+
+/**
+ * @brief Disable Constant Tone Extension response procedure for a connection.
+ *
+ * The function is available if @kconfig{CONFIG_BT_DF_CONNECTION_CTE_RSP} is enabled.
+ *
+ * @param conn   Connection object.
+ *
+ * @return Zero in case of success, other value in case of failure.
+ */
+int bt_df_conn_cte_rsp_disable(struct bt_conn *conn);
 
 #endif /* ZEPHYR_INCLUDE_BLUETOOTH_DF_H_ */

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -546,26 +546,39 @@ config BT_DF
 	  It will allow to: get information about antennae, configure
 	  Constant Tone Extension, transmit CTE and sample incoming CTE.
 
+if BT_DF
+
 config BT_DF_CONNECTIONLESS_CTE_RX
 	bool "Enable support for receive of CTE in connectionless mode"
-	depends on BT_DF
 	help
 	  Enable support for reception and sampling of Constant Tone Extension
 	  in connectionless mode.
 
 config BT_DF_CONNECTION_CTE_RX
 	bool "Enable support for receive of CTE in connection mode"
-	depends on BT_DF
 	help
 	  Enable support for reception and sampling of Constant Tone Extension
 	  in connection mode.
 
+config BT_DF_CONNECTION_CTE_TX
+	bool "Enable support for transmission of CTE in connection mode"
+	help
+	  Enable support for transmission of Constant Tone Extension in
+	  connection mode.
+
+config BT_DF_CONNECTION_CTE_RSP
+	bool "Enable support for CTE request procedure in connection mode"
+	depends on BT_DF_CONNECTION_CTE_TX
+	help
+	  Enable support for request of Constant Tone Extension in connection
+	  mode.
+
 config BT_DEBUG_DF
 	bool "Bluetooth Direction Finding debug"
-	depends on BT_DF
 	help
 	  This option enables debug support for Bluetooth Direction Finding
 
+endif # BT_DF
 endif # BT_HCI_HOST
 
 config BT_ECC

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -44,6 +44,8 @@ enum {
 	BT_CONN_AUTO_DATA_LEN_COMPLETE,
 
 	BT_CONN_CTE_RX_ENABLED,          /* CTE receive and sampling is enabled */
+	BT_CONN_CTE_TX_PARAMS_SET,       /* CTE transmission parameters are set */
+	BT_CONN_CTE_RSP_ENABLED,         /* CTE response procedure is enabled */
 
 	/* Total number of flags - must be at the end of the enum */
 	BT_CONN_NUM_FLAGS,

--- a/subsys/bluetooth/host/direction.c
+++ b/subsys/bluetooth/host/direction.c
@@ -791,12 +791,11 @@ static int bt_df_set_conn_cte_rx_enable(struct bt_conn *conn, bool enable,
 
 int bt_df_conn_cte_rx_enable(struct bt_conn *conn, const struct bt_df_conn_cte_rx_param *params)
 {
-	CHECKIF(!conn)
-	{
+	CHECKIF(!conn) {
 		return -EINVAL;
 	}
-	CHECKIF(!params)
-	{
+
+	CHECKIF(!params) {
 		return -EINVAL;
 	}
 
@@ -805,8 +804,7 @@ int bt_df_conn_cte_rx_enable(struct bt_conn *conn, const struct bt_df_conn_cte_r
 
 int bt_df_conn_cte_rx_disable(struct bt_conn *conn)
 {
-	CHECKIF(!conn)
-	{
+	CHECKIF(!conn) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Add host API to allow execution of HCI_LE_Connection_CTE_Response_-
Enable HCI command.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>