### PR TITLE
Add functions to properly truncate and copy UTF-8 strings

### DIFF
--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -389,6 +389,20 @@ uint8_t u8_to_dec(char *buf, uint8_t buflen, uint8_t value);
  */
 char *utf8_trunc(char *utf8_str);
 
+/**
+ * @brief Copies a UTF-8 encoded string from @p src to @p dst
+ *
+ * The resulting @p dst will always be NULL terminated, and the @p dst string
+ * will always be properly UTF-8 truncated.
+ *
+ * @param dst The destination of the UTF-8 string.
+ * @param src The source string
+ * @param n   The size of the @p dst buffer. Shall not be 0.
+ *
+ * return Pointer to the @p dst
+ */
+char *utf8_lcpy(char *dst, const char *src, size_t n);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -363,6 +363,32 @@ static inline uint8_t bin2bcd(uint8_t bin)
  */
 uint8_t u8_to_dec(char *buf, uint8_t buflen, uint8_t value);
 
+/**
+ * @brief Properly truncate a NULL-terminated UTF-8 string
+ *
+ * Take a NULL-terminated UTF-8 string and ensure that if the string has been
+ * truncated (by setting the NULL terminator) earlier by other means, that
+ * the string ends with a properly formatted UTF-8 character (1-4 bytes).
+ *
+ * @htmlonly
+ * Example:
+ *      char test_str[] = "€€€";
+ *      char trunc_utf8[8];
+ *
+ *      printf("Original : %s\n", test_str); // €€€
+ *      strncpy(trunc_utf8, test_str, sizeof(trunc_utf8));
+ *      trunc_utf8[sizeof(trunc_utf8) - 1] = '\0';
+ *      printf("Bad      : %s\n", trunc_utf8); // €€�
+ *      utf8_trunc(trunc_utf8);
+ *      printf("Truncated: %s\n", trunc_utf8); // €€
+ * @endhtmlonly
+ *
+ * @param utf8_str NULL-terminated string
+ *
+ *  @return Pointer to the @p utf8_str
+ */
+char *utf8_trunc(char *utf8_str);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/os/CMakeLists.txt
+++ b/lib/os/CMakeLists.txt
@@ -24,7 +24,6 @@ zephyr_sources(
   heap-validate.c
   bitarray.c
   multi_heap.c
-  utf8.c
   )
 
 zephyr_sources_ifdef(CONFIG_CBPRINTF_COMPLETE cbprintf_complete.c)
@@ -47,6 +46,8 @@ zephyr_sources_ifdef(CONFIG_REBOOT reboot.c)
 zephyr_sources_ifdef(CONFIG_SHARED_MULTI_HEAP shared_multi_heap.c)
 
 zephyr_sources_ifdef(CONFIG_HEAP_LISTENER heap_listener.c)
+
+zephyr_sources_ifdef(CONFIG_UTF8 utf8.c)
 
 zephyr_library_include_directories(
   ${ZEPHYR_BASE}/kernel/include

--- a/lib/os/CMakeLists.txt
+++ b/lib/os/CMakeLists.txt
@@ -24,6 +24,7 @@ zephyr_sources(
   heap-validate.c
   bitarray.c
   multi_heap.c
+  utf8.c
   )
 
 zephyr_sources_ifdef(CONFIG_CBPRINTF_COMPLETE cbprintf_complete.c)

--- a/lib/os/Kconfig
+++ b/lib/os/Kconfig
@@ -143,6 +143,12 @@ config REBOOT
 	  needed to perform a "safe" reboot (e.g. to stop the system clock before
 	  issuing a reset).
 
+config UTF8
+	bool "UTF-8 string operation supported"
+	help
+	  Enable the utf8 API. The API implements functions to specifically
+	  handle UTF-8 encoded strings.
+
 rsource "Kconfig.cbprintf"
 
 endmenu

--- a/lib/os/utf8.c
+++ b/lib/os/utf8.c
@@ -6,6 +6,7 @@
 
 #include <stdint.h>
 #include <string.h>
+#include <sys/__assert.h>
 
 #define ASCII_CHAR 0x7F
 #define SEQUENCE_FIRST_MASK 0xC0
@@ -56,4 +57,18 @@ char *utf8_trunc(char *utf8_str)
 	*last_byte_p = '\0';
 
 	return utf8_str;
+}
+
+char *utf8_lcpy(char *dst, const char *src, size_t n)
+{
+	__ASSERT(n > 0, "n shall not be 0");
+
+	strncpy(dst, src, n - 1);
+	dst[n - 1] = '\0';
+
+	if (n != 1) {
+		utf8_trunc(dst);
+	}
+
+	return dst;
 }

--- a/lib/os/utf8.c
+++ b/lib/os/utf8.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+#include <string.h>
+
+#define ASCII_CHAR 0x7F
+#define SEQUENCE_FIRST_MASK 0xC0
+#define SEQUENCE_LEN_2_BYTE 0xC0
+#define SEQUENCE_LEN_3_BYTE 0xE0
+#define SEQUENCE_LEN_4_BYTE 0xF0
+
+char *utf8_trunc(char *utf8_str)
+{
+	char *last_byte_p = utf8_str + strlen(utf8_str) - 1;
+	uint8_t bytes_truncated;
+	char seq_start_byte;
+
+	if ((*last_byte_p & ASCII_CHAR) == *last_byte_p) {
+		/* Not part of an UTF8 sequence, return */
+		return utf8_str;
+	}
+
+	/* Find the starting byte and NULL-terminate other bytes */
+	bytes_truncated = 0;
+	while ((*last_byte_p & SEQUENCE_FIRST_MASK) != SEQUENCE_FIRST_MASK &&
+	       last_byte_p > utf8_str) {
+		last_byte_p--;
+		bytes_truncated++;
+	}
+	bytes_truncated++; /* include the starting byte */
+
+	/* Verify if the the last character actually need to be truncated
+	 * Handles the case where the number of bytes in the last UTF8-char
+	 * matches the number of bytes we searched for the starting byte
+	 */
+	seq_start_byte = *last_byte_p;
+	if ((seq_start_byte & SEQUENCE_LEN_4_BYTE) == SEQUENCE_LEN_4_BYTE) {
+		if (bytes_truncated == 4) {
+			return utf8_str;
+		}
+	} else if ((seq_start_byte & SEQUENCE_LEN_3_BYTE) == SEQUENCE_LEN_3_BYTE) {
+		if (bytes_truncated == 3) {
+			return utf8_str;
+		}
+	} else if ((seq_start_byte & SEQUENCE_LEN_2_BYTE) == SEQUENCE_LEN_2_BYTE) {
+		if (bytes_truncated == 2) {
+			return utf8_str;
+		}
+	}
+
+	/* NULL-terminate the unterminated starting byte */
+	*last_byte_p = '\0';
+
+	return utf8_str;
+}


### PR DESCRIPTION
Add functions that can properly truncate and copy UTF-8 strings
without leaving unterminated started characters,
as UTF-8 characters can be 1-4 bytes long.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/34159