### PR TITLE
drivers: can: rename API functions for better consistency

### DIFF
--- a/doc/reference/canbus/controller.rst
+++ b/doc/reference/canbus/controller.rst
@@ -205,24 +205,24 @@ Receiving
 *********
 
 Frames are only received when they match a filter.
-The following code snippets show how to receive frames by attaching filters.
+The following code snippets show how to receive frames by adding filters.
 
 Here we have an example for a receiving callback as used for
-:c:func:`can_attach_isr`. The argument arg is passed when the filter is
-attached.
+:c:func:`can_add_rx_filter`. The user data argument is passed when the filter is
+added.
 
 .. code-block:: C
 
-  void rx_callback_function(struct zcan_frame *frame, void *arg)
+  void rx_callback_function(struct zcan_frame *frame, void *user_data)
   {
           ... do something with the frame ...
   }
 
-The following snippet shows how to attach a filter with an interrupt callback.
+The following snippet shows how to add a filter with a callback function.
 It is the most efficient but also the most critical way to receive messages.
 The callback function is called from an interrupt context, which means that the
 callback function should be as short as possible and must not block.
-Attaching ISRs is not allowed from userspace context.
+Adding callback functions is not allowed from userspace context.
 
 The filter for this example is configured to match the identifier 0x123 exactly.
 
@@ -240,15 +240,15 @@ The filter for this example is configured to match the identifier 0x123 exactly.
 
   can_dev = device_get_binding("CAN_0");
 
-  filter_id = can_attach_isr(can_dev, rx_callback_function, callback_arg, &my_filter);
+  filter_id = can_add_rx_filter(can_dev, rx_callback_function, callback_arg, &my_filter);
   if (filter_id < 0) {
-    LOG_ERR("Unable to attach isr [%d]", filter_id);
+    LOG_ERR("Unable to add rx filter [%d]", filter_id);
   }
 
-Here an example for :c:func:`can_attach_msgq` is shown. With this function, it
-is possible to receive frames synchronously. This function can be called from
-userspace context.
-The size of the message queue should be as big as the expected backlog.
+Here an example for :c:func:`can_add_rx_filter_msgq` is shown. With this
+function, it is possible to receive frames synchronously. This function can be
+called from userspace context.  The size of the message queue should be as big
+as the expected backlog.
 
 The filter for this example is configured to match the extended identifier
 0x1234567 exactly.
@@ -262,16 +262,16 @@ The filter for this example is configured to match the extended identifier
           .rtr_mask = 1,
           .id_mask = CAN_EXT_ID_MASK
   };
-  CAN_DEFINE_MSGQ(my_can_msgq, 2);
+  CAN_MSGQ_DEFINE(my_can_msgq, 2);
   struct zcan_frame rx_frame;
   int filter_id;
   const struct device *can_dev;
 
   can_dev = device_get_binding("CAN_0");
 
-  filter_id = can_attach_msgq(can_dev, &my_can_msgq, &my_filter);
+  filter_id = can_add_rx_filter_msgq(can_dev, &my_can_msgq, &my_filter);
   if (filter_id < 0) {
-    LOG_ERR("Unable to attach isr [%d]", filter_id);
+    LOG_ERR("Unable to add rx msgq [%d]", filter_id);
     return;
   }
 
@@ -280,11 +280,11 @@ The filter for this example is configured to match the extended identifier
     ... do something with the frame ...
   }
 
-:c:func:`can_detach` removes the given filter.
+:c:func:`can_remove_rx_filter` removes the given filter.
 
 .. code-block:: C
 
-  can_detach(can_dev, filter_id);
+  can_remove_rx_filter(can_dev, filter_id);
 
 Setting the bitrate
 *******************

--- a/drivers/can/can_common.c
+++ b/drivers/can/can_common.c
@@ -40,12 +40,12 @@ static void can_msgq_put(struct zcan_frame *frame, void *arg)
 	}
 }
 
-int z_impl_can_attach_msgq(const struct device *dev, struct k_msgq *msg_q,
-			   const struct zcan_filter *filter)
+int z_impl_can_add_rx_filter_msgq(const struct device *dev, struct k_msgq *msgq,
+				  const struct zcan_filter *filter)
 {
 	const struct can_driver_api *api = dev->api;
 
-	return api->attach_isr(dev, can_msgq_put, msg_q, filter);
+	return api->add_rx_filter(dev, can_msgq_put, msgq, filter);
 }
 
 static inline void can_work_buffer_init(struct can_frame_buffer *buffer)
@@ -140,7 +140,7 @@ int can_attach_workq(const struct device *dev, struct k_work_q *work_q,
 	work->cb_arg = user_data;
 	can_work_buffer_init(&work->buf);
 
-	return api->attach_isr(dev, can_work_isr_put, work, filter);
+	return api->add_rx_filter(dev, can_work_isr_put, work, filter);
 }
 
 

--- a/drivers/can/can_handlers.c
+++ b/drivers/can/can_handlers.c
@@ -55,9 +55,9 @@ static inline int z_vrfy_can_send(const struct device *dev,
 }
 #include <syscalls/can_send_mrsh.c>
 
-static inline int z_vrfy_can_attach_msgq(const struct device *dev,
-					 struct k_msgq *msgq,
-					 const struct zcan_filter *filter)
+static inline int z_vrfy_can_add_rx_filter_msgq(const struct device *dev,
+						struct k_msgq *msgq,
+						const struct zcan_filter *filter)
 {
 	Z_OOPS(Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_CAN));
 
@@ -65,20 +65,20 @@ static inline int z_vrfy_can_attach_msgq(const struct device *dev,
 				     sizeof(struct zcan_filter)));
 	Z_OOPS(Z_SYSCALL_OBJ(msgq, K_OBJ_MSGQ));
 
-	return z_impl_can_attach_msgq((const struct device *)dev,
-				      (struct k_msgq *)msgq,
-				      (const struct zcan_filter *) filter);
+	return z_impl_can_add_rx_filter_msgq((const struct device *)dev,
+					     (struct k_msgq *)msgq,
+					     (const struct zcan_filter *)filter);
 }
-#include <syscalls/can_attach_msgq_mrsh.c>
+#include <syscalls/can_add_rx_filter_msgq_mrsh.c>
 
-static inline void z_vrfy_can_detach(const struct device *dev, int filter_id)
+static inline void z_vrfy_can_remove_rx_filter(const struct device *dev, int filter_id)
 {
 
-	Z_OOPS(Z_SYSCALL_DRIVER_CAN(dev, detach));
+	Z_OOPS(Z_SYSCALL_DRIVER_CAN(dev, remove_rx_filter));
 
-	z_impl_can_detach((const struct device *)dev, (int)filter_id);
+	z_impl_can_remove_rx_filter((const struct device *)dev, (int)filter_id);
 }
-#include <syscalls/can_detach_mrsh.c>
+#include <syscalls/can_remove_rx_filter_mrsh.c>
 
 static inline
 enum can_state z_vrfy_can_get_state(const struct device *dev,

--- a/drivers/can/can_mcan.h
+++ b/drivers/can/can_mcan.h
@@ -166,7 +166,7 @@ struct can_mcan_data {
 	can_rx_callback_t rx_cb_ext[NUM_EXT_FILTER_DATA];
 	void *cb_arg_std[NUM_STD_FILTER_DATA];
 	void *cb_arg_ext[NUM_EXT_FILTER_DATA];
-	can_state_change_isr_t state_change_isr;
+	can_state_change_callback_t state_change_cb;
 	uint32_t std_filt_rtr;
 	uint32_t std_filt_rtr_mask;
 	uint8_t ext_filt_rtr;
@@ -219,13 +219,13 @@ int can_mcan_send(const struct can_mcan_config *cfg, struct can_mcan_data *data,
 		  k_timeout_t timeout, can_tx_callback_t callback,
 		  void *user_data);
 
-int can_mcan_attach_isr(struct can_mcan_data *data,
-			struct can_mcan_msg_sram *msg_ram,
-			can_rx_callback_t isr, void *cb_arg,
-			const struct zcan_filter *filter);
+int can_mcan_add_rx_filter(struct can_mcan_data *data,
+			   struct can_mcan_msg_sram *msg_ram,
+			   can_rx_callback_t callback, void *user_data,
+			   const struct zcan_filter *filter);
 
-void can_mcan_detach(struct can_mcan_data *data,
-		     struct can_mcan_msg_sram *msg_ram, int filter_nr);
+void can_mcan_remove_rx_filter(struct can_mcan_data *data,
+			       struct can_mcan_msg_sram *msg_ram, int filter_id);
 
 enum can_state can_mcan_get_state(const struct can_mcan_config *cfg,
 				  struct can_bus_err_cnt *err_cnt);

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -518,83 +518,83 @@ static int mcp2515_send(const struct device *dev,
 	return 0;
 }
 
-static int mcp2515_attach_isr(const struct device *dev,
-			      can_rx_callback_t rx_cb,
-			      void *cb_arg,
-			      const struct zcan_filter *filter)
+static int mcp2515_add_rx_filter(const struct device *dev,
+				 can_rx_callback_t rx_cb,
+				 void *cb_arg,
+				 const struct zcan_filter *filter)
 {
 	struct mcp2515_data *dev_data = DEV_DATA(dev);
-	int filter_idx = 0;
+	int filter_id = 0;
 
 	__ASSERT(rx_cb != NULL, "response_ptr can not be null");
 
 	k_mutex_lock(&dev_data->mutex, K_FOREVER);
 
 	/* find free filter */
-	while ((BIT(filter_idx) & dev_data->filter_usage)
-	       && (filter_idx < CONFIG_CAN_MAX_FILTER)) {
-		filter_idx++;
+	while ((BIT(filter_id) & dev_data->filter_usage)
+	       && (filter_id < CONFIG_CAN_MAX_FILTER)) {
+		filter_id++;
 	}
 
 	/* setup filter */
-	if (filter_idx < CONFIG_CAN_MAX_FILTER) {
-		dev_data->filter_usage |= BIT(filter_idx);
+	if (filter_id < CONFIG_CAN_MAX_FILTER) {
+		dev_data->filter_usage |= BIT(filter_id);
 
-		dev_data->filter[filter_idx] = *filter;
-		dev_data->rx_cb[filter_idx] = rx_cb;
-		dev_data->cb_arg[filter_idx] = cb_arg;
+		dev_data->filter[filter_id] = *filter;
+		dev_data->rx_cb[filter_id] = rx_cb;
+		dev_data->cb_arg[filter_id] = cb_arg;
 
 	} else {
-		filter_idx = -ENOSPC;
+		filter_id = -ENOSPC;
 	}
 
 	k_mutex_unlock(&dev_data->mutex);
 
-	return filter_idx;
+	return filter_id;
 }
 
-static void mcp2515_detach(const struct device *dev, int filter_nr)
+static void mcp2515_remove_rx_filter(const struct device *dev, int filter_id)
 {
 	struct mcp2515_data *dev_data = DEV_DATA(dev);
 
 	k_mutex_lock(&dev_data->mutex, K_FOREVER);
-	dev_data->filter_usage &= ~BIT(filter_nr);
+	dev_data->filter_usage &= ~BIT(filter_id);
 	k_mutex_unlock(&dev_data->mutex);
 }
 
-static void mcp2515_register_state_change_isr(const struct device *dev,
-						can_state_change_isr_t isr)
+static void mcp2515_set_state_change_callback(const struct device *dev,
+					      can_state_change_callback_t cb)
 {
 	struct mcp2515_data *dev_data = DEV_DATA(dev);
 
-	dev_data->state_change_isr = isr;
+	dev_data->state_change_cb = cb;
 }
 
 static void mcp2515_rx_filter(const struct device *dev,
 			      struct zcan_frame *frame)
 {
 	struct mcp2515_data *dev_data = DEV_DATA(dev);
-	uint8_t filter_idx = 0U;
+	uint8_t filter_id = 0U;
 	can_rx_callback_t callback;
 	struct zcan_frame tmp_frame;
 
 	k_mutex_lock(&dev_data->mutex, K_FOREVER);
 
-	for (; filter_idx < CONFIG_CAN_MAX_FILTER; filter_idx++) {
-		if (!(BIT(filter_idx) & dev_data->filter_usage)) {
+	for (; filter_id < CONFIG_CAN_MAX_FILTER; filter_id++) {
+		if (!(BIT(filter_id) & dev_data->filter_usage)) {
 			continue; /* filter slot empty */
 		}
 
 		if (!can_utils_filter_match(frame,
-					    &dev_data->filter[filter_idx])) {
+					    &dev_data->filter[filter_id])) {
 			continue; /* filter did not match */
 		}
 
-		callback = dev_data->rx_cb[filter_idx];
+		callback = dev_data->rx_cb[filter_id];
 		/*Make a temporary copy in case the user modifies the message*/
 		tmp_frame = *frame;
 
-		callback(&tmp_frame, dev_data->cb_arg[filter_idx]);
+		callback(&tmp_frame, dev_data->cb_arg[filter_id]);
 	}
 
 	k_mutex_unlock(&dev_data->mutex);
@@ -672,15 +672,15 @@ static enum can_state mcp2515_get_state(const struct device *dev,
 static void mcp2515_handle_errors(const struct device *dev)
 {
 	struct mcp2515_data *dev_data = DEV_DATA(dev);
-	can_state_change_isr_t state_change_isr = dev_data->state_change_isr;
+	can_state_change_callback_t state_change_cb = dev_data->state_change_cb;
 	enum can_state state;
 	struct can_bus_err_cnt err_cnt;
 
-	state = mcp2515_get_state(dev, state_change_isr ? &err_cnt : NULL);
+	state = mcp2515_get_state(dev, state_change_cb ? &err_cnt : NULL);
 
-	if (state_change_isr && dev_data->old_state != state) {
+	if (state_change_cb && dev_data->old_state != state) {
 		dev_data->old_state = state;
-		state_change_isr(state, err_cnt);
+		state_change_cb(state, err_cnt);
 	}
 }
 
@@ -783,13 +783,13 @@ static const struct can_driver_api can_api_funcs = {
 	.set_timing = mcp2515_set_timing,
 	.set_mode = mcp2515_set_mode,
 	.send = mcp2515_send,
-	.attach_isr = mcp2515_attach_isr,
-	.detach = mcp2515_detach,
+	.add_rx_filter = mcp2515_add_rx_filter,
+	.remove_rx_filter = mcp2515_remove_rx_filter,
 	.get_state = mcp2515_get_state,
 #ifndef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY
 	.recover = mcp2515_recover,
 #endif
-	.register_state_change_isr = mcp2515_register_state_change_isr,
+	.set_state_change_callback = mcp2515_set_state_change_callback,
 	.get_core_clock = mcp2515_get_core_clock,
 	.get_max_filters = mcp2515_get_max_filters,
 	.timing_min = {

--- a/drivers/can/can_mcp2515.h
+++ b/drivers/can/can_mcp2515.h
@@ -42,7 +42,7 @@ struct mcp2515_data {
 	can_rx_callback_t rx_cb[CONFIG_CAN_MAX_FILTER];
 	void *cb_arg[CONFIG_CAN_MAX_FILTER];
 	struct zcan_filter filter[CONFIG_CAN_MAX_FILTER];
-	can_state_change_isr_t state_change_isr;
+	can_state_change_callback_t state_change_cb;
 
 	/* general data */
 	struct k_mutex mutex;

--- a/drivers/can/can_net.c
+++ b/drivers/can/can_net.c
@@ -140,8 +140,8 @@ drop:
 	}
 }
 
-static inline int attach_mcast_filter(struct net_can_context *ctx,
-				      const struct in6_addr *addr)
+static inline int add_mcast_filter(struct net_can_context *ctx,
+				   const struct in6_addr *addr)
 {
 	static struct zcan_filter filter = {
 		.id_type = CAN_EXTENDED_IDENTIFIER,
@@ -158,13 +158,13 @@ static inline int attach_mcast_filter(struct net_can_context *ctx,
 			((group & CAN_NET_IF_ADDR_MASK) <<
 			 CAN_NET_IF_ADDR_DEST_POS);
 
-	filter_id = can_attach_isr(ctx->can_dev, net_can_recv,
-				   ctx, &filter);
+	filter_id = can_add_rx_filter(ctx->can_dev, net_can_recv,
+				      ctx, &filter);
 	if (filter_id == CAN_NET_FILTER_NOT_SET) {
 		return CAN_NET_FILTER_NOT_SET;
 	}
 
-	NET_DBG("Attached mcast filter. Group 0x%04x. Filter:%d",
+	NET_DBG("Added mcast filter. Group 0x%04x. Filter:%d",
 		group, filter_id);
 
 	return filter_id;
@@ -188,9 +188,9 @@ static void mcast_cb(struct net_if *iface, const struct net_addr *addr,
 			NET_ERR("Can't get a free filter_mapping");
 		}
 
-		filter_id = attach_mcast_filter(ctx, &addr->in6_addr);
+		filter_id = add_mcast_filter(ctx, &addr->in6_addr);
 		if (filter_id < 0) {
-			NET_ERR("Can't attach mcast filter");
+			NET_ERR("Can't add mcast filter");
 			return;
 		}
 
@@ -203,7 +203,7 @@ static void mcast_cb(struct net_if *iface, const struct net_addr *addr,
 			return;
 		}
 
-		can_detach(ctx->can_dev, filter_mapping->filter_id);
+		can_remove_rx_filter(ctx->can_dev, filter_mapping->filter_id);
 		filter_mapping->addr = NULL;
 	}
 }
@@ -222,25 +222,24 @@ static void net_can_iface_init(struct net_if *iface)
 	net_if_mcast_mon_register(&mcast_monitor, iface, mcast_cb);
 }
 
-static int can_attach_filter(const struct device *dev, can_rx_callback_t cb,
-			     void *cb_arg,
-			     const struct zcan_filter *filter)
+static int net_can_add_rx_filter(const struct device *dev, can_rx_callback_t cb,
+				 void *cb_arg, const struct zcan_filter *filter)
 {
 	struct net_can_context *ctx = dev->data;
 
-	return can_attach_isr(ctx->can_dev, cb, cb_arg, filter);
+	return can_add_rx_filter(ctx->can_dev, cb, cb_arg, filter);
 }
 
-static void can_detach_filter(const struct device *dev, int filter_id)
+static void net_can_remove_rx_filter(const struct device *dev, int filter_id)
 {
 	struct net_can_context *ctx = dev->data;
 
 	if (filter_id >= 0) {
-		can_detach(ctx->can_dev, filter_id);
+		can_remove_rx_filter(ctx->can_dev, filter_id);
 	}
 }
 
-static inline int can_attach_unicast_filter(struct net_can_context *ctx)
+static inline int can_add_unicast_filter(struct net_can_context *ctx)
 {
 	struct zcan_filter filter = {
 		.id_type = CAN_EXTENDED_IDENTIFIER,
@@ -254,20 +253,20 @@ static inline int can_attach_unicast_filter(struct net_can_context *ctx)
 
 	filter.id = (dest << CAN_NET_IF_ADDR_DEST_POS);
 
-	filter_id = can_attach_isr(ctx->can_dev, net_can_recv,
-				   ctx, &filter);
+	filter_id = can_add_rx_filter(ctx->can_dev, net_can_recv,
+				      ctx, &filter);
 	if (filter_id == CAN_NET_FILTER_NOT_SET) {
-		NET_ERR("Can't attach FF filter");
+		NET_ERR("Can't add FF filter");
 		return CAN_NET_FILTER_NOT_SET;
 	}
 
-	NET_DBG("Attached FF filter %d", filter_id);
+	NET_DBG("Added FF filter %d", filter_id);
 
 	return filter_id;
 }
 
 #ifdef CONFIG_NET_L2_CANBUS_ETH_TRANSLATOR
-static inline int can_attach_eth_bridge_filter(struct net_can_context *ctx)
+static inline int can_add_eth_bridge_filter(struct net_can_context *ctx)
 {
 	const struct zcan_filter filter = {
 		.id_type = CAN_EXTENDED_IDENTIFIER,
@@ -280,19 +279,19 @@ static inline int can_attach_eth_bridge_filter(struct net_can_context *ctx)
 
 	int filter_id;
 
-	filter_id = can_attach_isr(ctx->can_dev, net_can_recv,
-				   ctx, &filter);
+	filter_id = can_add_rx_filter(ctx->can_dev, net_can_recv,
+				      ctx, &filter);
 	if (filter_id == CAN_NET_FILTER_NOT_SET) {
-		NET_ERR("Can't attach ETH bridge filter");
+		NET_ERR("Can't add ETH bridge filter");
 		return CAN_NET_FILTER_NOT_SET;
 	}
 
-	NET_DBG("Attached ETH bridge filter %d", filter_id);
+	NET_DBG("Added ETH bridge filter %d", filter_id);
 
 	return filter_id;
 }
 
-static inline int can_attach_all_mcast_filter(struct net_can_context *ctx)
+static inline int can_add_all_mcast_filter(struct net_can_context *ctx)
 {
 	const struct zcan_filter filter = {
 		.id_type = CAN_EXTENDED_IDENTIFIER,
@@ -304,14 +303,14 @@ static inline int can_attach_all_mcast_filter(struct net_can_context *ctx)
 
 	int filter_id;
 
-	filter_id = can_attach_isr(ctx->can_dev, net_can_recv,
-				   ctx, &filter);
+	filter_id = can_add_rx_filter(ctx->can_dev, net_can_recv,
+				      ctx, &filter);
 	if (filter_id == CAN_NET_FILTER_NOT_SET) {
-		NET_ERR("Can't attach all mcast filter");
+		NET_ERR("Can't add all mcast filter");
 		return CAN_NET_FILTER_NOT_SET;
 	}
 
-	NET_DBG("Attached all mcast filter %d", filter_id);
+	NET_DBG("Added all mcast filter %d", filter_id);
 
 	return filter_id;
 }
@@ -323,7 +322,7 @@ static int can_enable(const struct device *dev, bool enable)
 
 	if (enable) {
 		if (ctx->recv_filter_id == CAN_NET_FILTER_NOT_SET) {
-			ctx->recv_filter_id = can_attach_unicast_filter(ctx);
+			ctx->recv_filter_id = can_add_unicast_filter(ctx);
 			if (ctx->recv_filter_id < 0) {
 				return -EIO;
 			}
@@ -331,34 +330,34 @@ static int can_enable(const struct device *dev, bool enable)
 
 #ifdef CONFIG_NET_L2_CANBUS_ETH_TRANSLATOR
 		if (ctx->eth_bridge_filter_id == CAN_NET_FILTER_NOT_SET) {
-			ctx->eth_bridge_filter_id = can_attach_eth_bridge_filter(ctx);
+			ctx->eth_bridge_filter_id = can_add_eth_bridge_filter(ctx);
 			if (ctx->eth_bridge_filter_id < 0) {
-				can_detach(ctx->can_dev, ctx->recv_filter_id);
+				can_remove_rx_filter(ctx->can_dev, ctx->recv_filter_id);
 				return -EIO;
 			}
 		}
 
 		if (ctx->all_mcast_filter_id == CAN_NET_FILTER_NOT_SET) {
-			ctx->all_mcast_filter_id = can_attach_all_mcast_filter(ctx);
+			ctx->all_mcast_filter_id = can_add_all_mcast_filter(ctx);
 			if (ctx->all_mcast_filter_id < 0) {
-				can_detach(ctx->can_dev, ctx->recv_filter_id);
-				can_detach(ctx->can_dev, ctx->eth_bridge_filter_id);
+				can_remove_rx_filter(ctx->can_dev, ctx->recv_filter_id);
+				can_remove_rx_filter(ctx->can_dev, ctx->eth_bridge_filter_id);
 				return -EIO;
 			}
 		}
 #endif /*CONFIG_NET_L2_CANBUS_ETH_TRANSLATOR*/
 	} else {
 		if (ctx->recv_filter_id != CAN_NET_FILTER_NOT_SET) {
-			can_detach(ctx->can_dev, ctx->recv_filter_id);
+			can_remove_rx_filter(ctx->can_dev, ctx->recv_filter_id);
 		}
 
 #ifdef CONFIG_NET_L2_CANBUS_ETH_TRANSLATOR
 		if (ctx->eth_bridge_filter_id != CAN_NET_FILTER_NOT_SET) {
-			can_detach(ctx->can_dev, ctx->eth_bridge_filter_id);
+			can_remove_rx_filter(ctx->can_dev, ctx->eth_bridge_filter_id);
 		}
 
 		if (ctx->all_mcast_filter_id != CAN_NET_FILTER_NOT_SET) {
-			can_detach(ctx->can_dev, ctx->all_mcast_filter_id);
+			can_remove_rx_filter(ctx->can_dev, ctx->all_mcast_filter_id);
 		}
 #endif /*CONFIG_NET_L2_CANBUS_ETH_TRANSLATOR*/
 	}
@@ -370,8 +369,8 @@ static struct net_can_api net_can_api_inst = {
 	.iface_api.init = net_can_iface_init,
 
 	.send = net_can_send,
-	.attach_filter = can_attach_filter,
-	.detach_filter = can_detach_filter,
+	.add_rx_filter = net_can_add_rx_filter,
+	.remove_rx_filter = net_can_remove_rx_filter,
 	.enable = can_enable,
 };
 

--- a/drivers/can/can_shell.c
+++ b/drivers/can/can_shell.c
@@ -10,7 +10,7 @@
 #include <zephyr/types.h>
 #include <stdlib.h>
 
-CAN_DEFINE_MSGQ(msgq, 4);
+CAN_MSGQ_DEFINE(msgq, 4);
 const struct shell *msgq_shell;
 static struct k_work_poll msgq_work;
 static struct k_poll_event msgq_events[1] = {
@@ -389,7 +389,7 @@ static int cmd_attach(const struct shell *shell, size_t argc, char **argv)
 		    filter.id, ext ? "extended" : "standard", filter.id_mask,
 		    filter.rtr_mask);
 
-	ret = can_attach_msgq(can_dev, &msgq, &filter);
+	ret = can_add_rx_filter_msgq(can_dev, &msgq, &filter);
 	if (ret < 0) {
 		if (ret == -ENOSPC) {
 			shell_error(shell, "Can't attach, no free filter left");
@@ -439,7 +439,7 @@ static int cmd_detach(const struct shell *shell, size_t argc, char **argv)
 		shell_error(shell, "filter_id must not be negative");
 	}
 
-	can_detach(can_dev, (int)id);
+	can_remove_rx_filter(can_dev, (int)id);
 
 	return 0;
 }

--- a/drivers/can/can_stm32.h
+++ b/drivers/can/can_stm32.h
@@ -64,7 +64,7 @@ struct can_stm32_data {
 	uint64_t filter_usage;
 	can_rx_callback_t rx_cb[CONFIG_CAN_MAX_FILTER];
 	void *cb_arg[CONFIG_CAN_MAX_FILTER];
-	can_state_change_isr_t state_change_isr;
+	can_state_change_callback_t state_change_cb;
 };
 
 struct can_stm32_config {

--- a/drivers/can/socket_can_generic.h
+++ b/drivers/can/socket_can_generic.h
@@ -22,7 +22,7 @@
 #define BUF_ALLOC_TIMEOUT K_MSEC(50)
 
 /* TODO: make msgq size configurable */
-CAN_DEFINE_MSGQ(socket_can_msgq, 5);
+CAN_MSGQ_DEFINE(socket_can_msgq, 5);
 K_KERNEL_STACK_DEFINE(rx_thread_stack, RX_THREAD_STACK_SIZE);
 
 struct socket_can_context {
@@ -93,8 +93,8 @@ static inline int socket_can_setsockopt(const struct device *dev, void *obj,
 
 	__ASSERT_NO_MSG(optlen == sizeof(struct zcan_filter));
 
-	ret = can_attach_msgq(socket_context->can_dev, socket_context->msgq,
-			      optval);
+	ret = can_add_rx_filter_msgq(socket_context->can_dev, socket_context->msgq,
+				     optval);
 	if (ret == -ENOSPC) {
 		errno = ENOSPC;
 		return -1;
@@ -109,7 +109,7 @@ static inline void socket_can_close(const struct device *dev, int filter_id)
 {
 	struct socket_can_context *socket_context = dev->data;
 
-	can_detach(socket_context->can_dev, filter_id);
+	can_remove_rx_filter(socket_context->can_dev, filter_id);
 }
 
 static struct canbus_api socket_can_api = {

--- a/include/net/can.h
+++ b/include/net/can.h
@@ -101,11 +101,11 @@ struct net_can_api {
 	/** Send a single CAN frame */
 	int (*send)(const struct device *dev, const struct zcan_frame *frame,
 		    can_tx_callback_t cb, void *cb_arg, k_timeout_t timeout);
-	/** Attach a filter with it's callback */
-	int (*attach_filter)(const struct device *dev, can_rx_callback_t cb,
+	/** Add a filter with its callback */
+	int (*add_rx_filter)(const struct device *dev, can_rx_callback_t cb,
 			     void *cb_arg, const struct zcan_filter *filter);
-	/** Detach a filter */
-	void (*detach_filter)(const struct device *dev, int filter_id);
+	/** Remove a filter */
+	void (*remove_rx_filter)(const struct device *dev, int filter_id);
 	/** Enable or disable the reception of frames for net CAN */
 	int (*enable)(const struct device *dev, bool enable);
 };

--- a/modules/canopennode/CO_driver.c
+++ b/modules/canopennode/CO_driver.c
@@ -71,20 +71,20 @@ static void canopen_detach_all_rx_filters(CO_CANmodule_t *CANmodule)
 
 	for (i = 0U; i < CANmodule->rx_size; i++) {
 		if (CANmodule->rx_array[i].filter_id != -ENOSPC) {
-			can_detach(CANmodule->dev,
-				   CANmodule->rx_array[i].filter_id);
+			can_remove_rx_filter(CANmodule->dev,
+					     CANmodule->rx_array[i].filter_id);
 			CANmodule->rx_array[i].filter_id = -ENOSPC;
 		}
 	}
 }
 
-static void canopen_rx_isr_callback(struct zcan_frame *msg, void *arg)
+static void canopen_rx_callback(struct zcan_frame *msg, void *arg)
 {
 	CO_CANrx_t *buffer = (CO_CANrx_t *)arg;
 	CO_CANrxMsg_t rxMsg;
 
 	if (!buffer || !buffer->pFunct) {
-		LOG_ERR("failed to process CAN rx isr callback");
+		LOG_ERR("failed to process CAN rx callback");
 		return;
 	}
 
@@ -94,12 +94,12 @@ static void canopen_rx_isr_callback(struct zcan_frame *msg, void *arg)
 	buffer->pFunct(buffer->object, &rxMsg);
 }
 
-static void canopen_tx_isr_callback(int error, void *arg)
+static void canopen_tx_callback(int error, void *arg)
 {
 	CO_CANmodule_t *CANmodule = arg;
 
 	if (!CANmodule) {
-		LOG_ERR("failed to process CAN tx isr callback");
+		LOG_ERR("failed to process CAN tx callback");
 		return;
 	}
 
@@ -132,7 +132,7 @@ static void canopen_tx_retry(struct k_work *item)
 			memcpy(msg.data, buffer->data, buffer->DLC);
 
 			err = can_send(CANmodule->dev, &msg, K_NO_WAIT,
-				       canopen_tx_isr_callback, CANmodule);
+				       canopen_tx_callback, CANmodule);
 			if (err == -EAGAIN) {
 				break;
 			} else if (err != 0) {
@@ -285,14 +285,14 @@ CO_ReturnError_t CO_CANrxBufferInit(CO_CANmodule_t *CANmodule, uint16_t index,
 	filter.rtr_mask = 1;
 
 	if (buffer->filter_id != -ENOSPC) {
-		can_detach(CANmodule->dev, buffer->filter_id);
+		can_remove_rx_filter(CANmodule->dev, buffer->filter_id);
 	}
 
-	buffer->filter_id = can_attach_isr(CANmodule->dev,
-					   canopen_rx_isr_callback,
-					   buffer, &filter);
+	buffer->filter_id = can_add_rx_filter(CANmodule->dev,
+					      canopen_rx_callback,
+					      buffer, &filter);
 	if (buffer->filter_id == -ENOSPC) {
-		LOG_ERR("failed to attach CAN rx isr, no free filter");
+		LOG_ERR("failed to add CAN rx callback, no free filter");
 		CO_errorReport(CANmodule->em, CO_EM_MEMORY_ALLOCATION_ERROR,
 			       CO_EMC_SOFTWARE_INTERNAL, 0);
 		return CO_ERROR_OUT_OF_MEMORY;
@@ -355,7 +355,7 @@ CO_ReturnError_t CO_CANsend(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer)
 	msg.rtr = (buffer->rtr ? 1 : 0);
 	memcpy(msg.data, buffer->data, buffer->DLC);
 
-	err = can_send(CANmodule->dev, &msg, K_NO_WAIT, canopen_tx_isr_callback,
+	err = can_send(CANmodule->dev, &msg, K_NO_WAIT, canopen_tx_callback,
 		       CANmodule);
 	if (err == -EAGAIN) {
 		buffer->bufferFull = true;

--- a/subsys/canbus/isotp/isotp.c
+++ b/subsys/canbus/isotp/isotp.c
@@ -76,7 +76,7 @@ static inline void receive_report_error(struct isotp_recv_ctx *ctx, int err)
 	ctx->error_nr = err;
 }
 
-void receive_can_tx_isr(int error, void *arg)
+static void receive_can_tx(int error, void *arg)
 {
 	struct isotp_recv_ctx *ctx = (struct isotp_recv_ctx *)arg;
 
@@ -146,7 +146,7 @@ static void receive_send_fc(struct isotp_recv_ctx *ctx, uint8_t fs)
 #endif
 
 	ret = can_send(ctx->can_dev, &frame, K_MSEC(ISOTP_A),
-		       receive_can_tx_isr, ctx);
+		       receive_can_tx, ctx);
 	if (ret) {
 		LOG_ERR("Can't send FC, (%d)", ret);
 		receive_report_error(ctx, ISOTP_N_TIMEOUT_A);
@@ -525,7 +525,7 @@ static void process_cf(struct isotp_recv_ctx *ctx, struct zcan_frame *frame)
 	}
 }
 
-static void receive_can_rx_isr(struct zcan_frame *frame, void *arg)
+static void receive_can_rx(struct zcan_frame *frame, void *arg)
 {
 	struct isotp_recv_ctx *ctx = (struct isotp_recv_ctx *)arg;
 
@@ -574,8 +574,8 @@ static inline int attach_ff_filter(struct isotp_recv_ctx *ctx)
 		.id_mask = mask
 	};
 
-	ctx->filter_id = can_attach_isr(ctx->can_dev, receive_can_rx_isr, ctx,
-					&filter);
+	ctx->filter_id = can_add_rx_filter(ctx->can_dev, receive_can_rx, ctx,
+					   &filter);
 	if (ctx->filter_id < 0) {
 		LOG_ERR("Error attaching FF filter [%d]", ctx->filter_id);
 		return ISOTP_NO_FREE_FILTER;
@@ -637,7 +637,7 @@ void isotp_unbind(struct isotp_recv_ctx *ctx)
 	struct net_buf *buf;
 
 	if (ctx->filter_id >= 0 && ctx->can_dev) {
-		can_detach(ctx->can_dev, ctx->filter_id);
+		can_remove_rx_filter(ctx->can_dev, ctx->filter_id);
 	}
 
 	z_abort_timeout(&ctx->timeout);
@@ -723,7 +723,7 @@ static inline void send_report_error(struct isotp_send_ctx *ctx, uint32_t err)
 	ctx->error_nr = err;
 }
 
-static void send_can_tx_isr(int error, void *arg)
+static void send_can_tx_cb(int error, void *arg)
 {
 	struct isotp_send_ctx *ctx = (struct isotp_send_ctx *)arg;
 
@@ -814,7 +814,7 @@ static void send_process_fc(struct isotp_send_ctx *ctx,
 	}
 }
 
-static void send_can_rx_isr(struct zcan_frame *frame, void *arg)
+static void send_can_rx_cb(struct zcan_frame *frame, void *arg)
 {
 	struct isotp_send_ctx *ctx = (struct isotp_send_ctx *)arg;
 
@@ -887,7 +887,7 @@ static inline int send_sf(struct isotp_send_ctx *ctx)
 
 	ctx->state = ISOTP_TX_SEND_SF;
 	ret = can_send(ctx->can_dev, &frame, K_MSEC(ISOTP_A),
-		       send_can_tx_isr, ctx);
+		       send_can_tx_cb, ctx);
 	return ret;
 }
 
@@ -929,7 +929,7 @@ static inline int send_ff(struct isotp_send_ctx *ctx)
 	memcpy(&frame.data[index], data, ISOTP_CAN_DL - index);
 
 	ret = can_send(ctx->can_dev, &frame, K_MSEC(ISOTP_A),
-		       send_can_tx_isr, ctx);
+		       send_can_tx_cb, ctx);
 	return ret;
 }
 
@@ -968,7 +968,7 @@ static inline int send_cf(struct isotp_send_ctx *ctx)
 #endif
 
 	ret = can_send(ctx->can_dev, &frame, K_MSEC(ISOTP_A),
-		       send_can_tx_isr, ctx);
+		       send_can_tx_cb, ctx);
 	if (ret == 0) {
 		ctx->sn++;
 		pull_data_ctx(ctx, len);
@@ -1084,7 +1084,7 @@ static void send_state_machine(struct isotp_send_ctx *ctx)
 		__fallthrough;
 	case ISOTP_TX_WAIT_FIN:
 		if (ctx->filter_id >= 0) {
-			can_detach(ctx->can_dev, ctx->filter_id);
+			can_remove_rx_filter(ctx->can_dev, ctx->filter_id);
 		}
 
 		LOG_DBG("SM finish");
@@ -1123,8 +1123,8 @@ static inline int attach_fc_filter(struct isotp_send_ctx *ctx)
 		.id_mask = CAN_EXT_ID_MASK
 	};
 
-	ctx->filter_id = can_attach_isr(ctx->can_dev, send_can_rx_isr, ctx,
-					&filter);
+	ctx->filter_id = can_add_rx_filter(ctx->can_dev, send_can_rx_cb, ctx,
+					   &filter);
 	if (ctx->filter_id < 0) {
 		LOG_ERR("Error attaching FC filter [%d]", ctx->filter_id);
 		return ISOTP_NO_FREE_FILTER;

--- a/subsys/net/l2/canbus/6locan.c
+++ b/subsys/net/l2/canbus/6locan.c
@@ -1572,12 +1572,12 @@ static inline void canbus_send_dad_response(struct k_work *item)
 	}
 }
 
-static inline void canbus_detach_filter(const struct device *net_can_dev,
-					int filter_id)
+static inline void canbus_remove_rx_filter(const struct device *net_can_dev,
+					   int filter_id)
 {
 	const struct net_can_api *api = net_can_dev->api;
 
-	api->detach_filter(net_can_dev, filter_id);
+	api->remove_rx_filter(net_can_dev, filter_id);
 }
 
 static void canbus_dad_resp_cb(struct zcan_frame *frame, void *arg)
@@ -1588,9 +1588,9 @@ static void canbus_dad_resp_cb(struct zcan_frame *frame, void *arg)
 }
 
 static inline
-int canbus_attach_dad_resp_filter(const struct device *net_can_dev,
-				  struct net_canbus_lladdr *ll_addr,
-				  struct k_sem *dad_sem)
+int canbus_add_dad_resp_filter(const struct device *net_can_dev,
+			       struct net_canbus_lladdr *ll_addr,
+			       struct k_sem *dad_sem)
 {
 	const struct net_can_api *api = net_can_dev->api;
 	struct zcan_filter filter = {
@@ -1603,10 +1603,10 @@ int canbus_attach_dad_resp_filter(const struct device *net_can_dev,
 
 	filter.id = canbus_addr_to_id(NET_CAN_DAD_ADDR, ll_addr->addr);
 
-	filter_id = api->attach_filter(net_can_dev, canbus_dad_resp_cb,
+	filter_id = api->add_rx_filter(net_can_dev, canbus_dad_resp_cb,
 				       dad_sem, &filter);
 	if (filter_id == -ENOSPC) {
-		NET_ERR("Can't attach dad response filter");
+		NET_ERR("Can't add dad response filter");
 	}
 
 	return filter_id;
@@ -1619,9 +1619,9 @@ static void canbus_dad_request_cb(struct zcan_frame *frame, void *arg)
 	k_work_submit_to_queue(&net_canbus_workq, work);
 }
 
-static inline int canbus_attach_dad_filter(const struct device *net_can_dev,
-					   struct net_canbus_lladdr *ll_addr,
-					   struct k_work *dad_work)
+static inline int canbus_add_dad_filter(const struct device *net_can_dev,
+					struct net_canbus_lladdr *ll_addr,
+					struct k_work *dad_work)
 {
 	const struct net_can_api *api = net_can_dev->api;
 	struct zcan_filter filter = {
@@ -1634,10 +1634,10 @@ static inline int canbus_attach_dad_filter(const struct device *net_can_dev,
 
 	filter.id = canbus_addr_to_id(ll_addr->addr, 0);
 
-	filter_id = api->attach_filter(net_can_dev, canbus_dad_request_cb,
+	filter_id = api->add_rx_filter(net_can_dev, canbus_dad_request_cb,
 				       dad_work, &filter);
 	if (filter_id == -ENOSPC) {
-		NET_ERR("Can't attach dad filter");
+		NET_ERR("Can't add dad filter");
 	}
 
 	return filter_id;
@@ -1665,18 +1665,18 @@ static inline int canbus_init_ll_addr(struct net_if *iface)
 	net_if_set_link_addr(iface, (uint8_t *)&ctx->ll_addr, sizeof(ll_addr),
 			     NET_LINK_CANBUS);
 
-	dad_resp_filter_id = canbus_attach_dad_resp_filter(net_can_dev, &ll_addr,
-							   &dad_sem);
+	dad_resp_filter_id = canbus_add_dad_resp_filter(net_can_dev, &ll_addr,
+							&dad_sem);
 	if (dad_resp_filter_id < 0) {
 		return -EIO;
 	}
 	/*
-	 * Attach this filter now to defend this address instantly.
+	 * Add this filter now to defend this address instantly.
 	 * This filter is not called for own DAD because loopback is not
 	 * enabled.
 	 */
-	ctx->dad_filter_id = canbus_attach_dad_filter(net_can_dev, &ll_addr,
-						      &ctx->dad_work);
+	ctx->dad_filter_id = canbus_add_dad_filter(net_can_dev, &ll_addr,
+						   &ctx->dad_work);
 	if (ctx->dad_filter_id < 0) {
 		ret = -EIO;
 		goto dad_err;
@@ -1690,7 +1690,7 @@ static inline int canbus_init_ll_addr(struct net_if *iface)
 	}
 
 	ret = k_sem_take(&dad_sem, NET_CAN_DAD_TIMEOUT);
-	canbus_detach_filter(net_can_dev, dad_resp_filter_id);
+	canbus_remove_rx_filter(net_can_dev, dad_resp_filter_id);
 	dad_resp_filter_id = CAN_NET_FILTER_NOT_SET;
 
 	if (ret != -EAGAIN) {
@@ -1704,12 +1704,12 @@ static inline int canbus_init_ll_addr(struct net_if *iface)
 dad_err:
 	net_if_set_link_addr(iface, NULL, 0, NET_LINK_CANBUS);
 	if (ctx->dad_filter_id != CAN_NET_FILTER_NOT_SET) {
-		canbus_detach_filter(net_can_dev, ctx->dad_filter_id);
+		canbus_remove_rx_filter(net_can_dev, ctx->dad_filter_id);
 		ctx->dad_filter_id = CAN_NET_FILTER_NOT_SET;
 	}
 
 	if (dad_resp_filter_id != CAN_NET_FILTER_NOT_SET) {
-		canbus_detach_filter(net_can_dev, dad_resp_filter_id);
+		canbus_remove_rx_filter(net_can_dev, dad_resp_filter_id);
 	}
 
 	return ret;
@@ -1846,7 +1846,7 @@ static int canbus_enable(struct net_if *iface, bool state)
 
 	} else {
 		if (ctx->dad_filter_id != CAN_NET_FILTER_NOT_SET) {
-			canbus_detach_filter(net_can_dev, ctx->dad_filter_id);
+			canbus_remove_rx_filter(net_can_dev, ctx->dad_filter_id);
 		}
 	}
 

--- a/tests/drivers/can/api/src/main.c
+++ b/tests/drivers/can/api/src/main.c
@@ -16,7 +16,7 @@
  * - Test Steps
  *   -# Set driver to loopback mode
  *   -# Try to send a message.
- *   -# Attach a filter from every kind
+ *   -# Add a filter from every kind
  *   -# Test if message reception is really blocking
  *   -# Send and receive a message with standard id without masking
  *   -# Send and receive a message with extended id without masking
@@ -46,7 +46,7 @@
 
 #define CAN_DEVICE_NAME DT_LABEL(DT_CHOSEN(zephyr_canbus))
 
-CAN_DEFINE_MSGQ(can_msgq, 5);
+CAN_MSGQ_DEFINE(can_msgq, 5);
 struct k_sem rx_isr_sem;
 struct k_sem tx_cb_sem;
 const struct device *can_dev;
@@ -291,12 +291,12 @@ static void send_test_msg_nowait(const struct device *can_dev,
 	zassert_equal(ret, 0, "Can't send a message. Err: %d", ret);
 }
 
-static inline int attach_msgq(const struct device *can_dev,
+static inline int add_rx_msgq(const struct device *can_dev,
 			      const struct zcan_filter *filter)
 {
 	int filter_id;
 
-	filter_id = can_attach_msgq(can_dev, &can_msgq, filter);
+	filter_id = can_add_rx_filter_msgq(can_dev, &can_msgq, filter);
 	zassert_not_equal(filter_id, -ENOSPC,
 			  "Filter full even for a single one");
 	zassert_true((filter_id >= 0), "Negative filter number");
@@ -304,15 +304,15 @@ static inline int attach_msgq(const struct device *can_dev,
 	return filter_id;
 }
 
-static inline int attach_isr(const struct device *can_dev,
-			     const struct zcan_filter *filter,
-			     can_rx_callback_t isr)
+static inline int add_rx_filter(const struct device *can_dev,
+				const struct zcan_filter *filter,
+				can_rx_callback_t callback)
 {
 	int filter_id;
 
 	k_sem_reset(&rx_isr_sem);
 
-	filter_id = can_attach_isr(can_dev, isr, (void *)filter, filter);
+	filter_id = can_add_rx_filter(can_dev, callback, (void *)filter, filter);
 	zassert_not_equal(filter_id, -ENOSPC,
 			  "Filter full even for a single one");
 	zassert_true((filter_id >= 0), "Negative filter number");
@@ -331,7 +331,7 @@ static void send_receive(const struct zcan_filter *filter1,
 
 	zassert_not_null(can_dev, "Device not not found");
 
-	filter_id_1 = attach_msgq(can_dev, filter1);
+	filter_id_1 = add_rx_msgq(can_dev, filter1);
 	send_test_msg(can_dev, msg1);
 	ret = k_msgq_get(&can_msgq, &msg_buffer, TEST_RECEIVE_TIMEOUT);
 	zassert_equal(ret, 0, "Receiving timeout");
@@ -347,38 +347,38 @@ static void send_receive(const struct zcan_filter *filter1,
 	}
 
 	check_msg(&msg_buffer, msg1, mask);
-	can_detach(can_dev, filter_id_1);
+	can_remove_rx_filter(can_dev, filter_id_1);
 
 	k_sem_reset(&tx_cb_sem);
 	if (msg1->id_type == CAN_STANDARD_IDENTIFIER) {
 		if (filter1->id_mask == CAN_STD_ID_MASK) {
-			filter_id_1 = attach_isr(can_dev, filter1,
-						 rx_std_isr_1);
-			filter_id_2 = attach_isr(can_dev, filter2,
-						 rx_std_isr_2);
+			filter_id_1 = add_rx_filter(can_dev, filter1,
+						    rx_std_isr_1);
+			filter_id_2 = add_rx_filter(can_dev, filter2,
+						    rx_std_isr_2);
 			send_test_msg_nowait(can_dev, msg1, tx_std_isr_1);
 			send_test_msg_nowait(can_dev, msg2, tx_std_isr_2);
 		} else {
-			filter_id_1 = attach_isr(can_dev, filter1,
-						 rx_std_mask_isr_1);
-			filter_id_2 = attach_isr(can_dev, filter2,
-						 rx_std_mask_isr_2);
+			filter_id_1 = add_rx_filter(can_dev, filter1,
+						    rx_std_mask_isr_1);
+			filter_id_2 = add_rx_filter(can_dev, filter2,
+						    rx_std_mask_isr_2);
 			send_test_msg_nowait(can_dev, msg1, tx_std_isr_1);
 			send_test_msg_nowait(can_dev, msg2, tx_std_isr_2);
 		}
 	} else {
 		if (filter1->id_mask == CAN_EXT_ID_MASK) {
-			filter_id_1 = attach_isr(can_dev, filter1,
-						 rx_ext_isr_1);
-			filter_id_2 = attach_isr(can_dev, filter2,
-						 rx_ext_isr_2);
+			filter_id_1 = add_rx_filter(can_dev, filter1,
+						    rx_ext_isr_1);
+			filter_id_2 = add_rx_filter(can_dev, filter2,
+						    rx_ext_isr_2);
 			send_test_msg_nowait(can_dev, msg1, tx_ext_isr_1);
 			send_test_msg_nowait(can_dev, msg2, tx_ext_isr_2);
 		} else {
-			filter_id_1 = attach_isr(can_dev, filter1,
-						 rx_ext_mask_isr_1);
-			filter_id_2 = attach_isr(can_dev, filter2,
-						 rx_ext_mask_isr_2);
+			filter_id_1 = add_rx_filter(can_dev, filter1,
+						    rx_ext_mask_isr_1);
+			filter_id_2 = add_rx_filter(can_dev, filter2,
+						    rx_ext_mask_isr_2);
 			send_test_msg_nowait(can_dev, msg1, tx_ext_isr_1);
 			send_test_msg_nowait(can_dev, msg2, tx_ext_isr_2);
 		}
@@ -392,8 +392,8 @@ static void send_receive(const struct zcan_filter *filter1,
 	zassert_equal(ret, 0, "Missing TX callback");
 	ret = k_sem_take(&tx_cb_sem, TEST_SEND_TIMEOUT);
 	zassert_equal(ret, 0, "Missing TX callback");
-	can_detach(can_dev, filter_id_1);
-	can_detach(can_dev, filter_id_2);
+	can_remove_rx_filter(can_dev, filter_id_1);
+	can_remove_rx_filter(can_dev, filter_id_2);
 }
 
 /*
@@ -421,32 +421,32 @@ static void test_send_and_forget(void)
 }
 
 /*
- * Test very basic filter attachment
+ * Test adding a very basic filter
  * Test each type but only one filter at a time
  */
-static void test_filter_attach(void)
+static void test_add_filter(void)
 {
 	int filter_id;
 
-	filter_id = attach_isr(can_dev, &test_std_filter_1, rx_std_isr_1);
-	can_detach(can_dev, filter_id);
+	filter_id = add_rx_filter(can_dev, &test_std_filter_1, rx_std_isr_1);
+	can_remove_rx_filter(can_dev, filter_id);
 
-	filter_id = attach_isr(can_dev, &test_ext_filter_1, rx_ext_isr_1);
-	can_detach(can_dev, filter_id);
+	filter_id = add_rx_filter(can_dev, &test_ext_filter_1, rx_ext_isr_1);
+	can_remove_rx_filter(can_dev, filter_id);
 
-	filter_id = attach_msgq(can_dev, &test_std_filter_1);
-	can_detach(can_dev, filter_id);
+	filter_id = add_rx_msgq(can_dev, &test_std_filter_1);
+	can_remove_rx_filter(can_dev, filter_id);
 
-	filter_id = attach_msgq(can_dev, &test_ext_filter_1);
-	can_detach(can_dev, filter_id);
+	filter_id = add_rx_msgq(can_dev, &test_ext_filter_1);
+	can_remove_rx_filter(can_dev, filter_id);
 
-	filter_id = attach_isr(can_dev, &test_std_masked_filter_1,
-			       rx_std_mask_isr_1);
-	can_detach(can_dev, filter_id);
+	filter_id = add_rx_filter(can_dev, &test_std_masked_filter_1,
+				  rx_std_mask_isr_1);
+	can_remove_rx_filter(can_dev, filter_id);
 
-	filter_id = attach_isr(can_dev, &test_ext_masked_filter_1,
-			       rx_ext_mask_isr_1);
-	can_detach(can_dev, filter_id);
+	filter_id = add_rx_filter(can_dev, &test_ext_masked_filter_1,
+				  rx_ext_mask_isr_1);
+	can_remove_rx_filter(can_dev, filter_id);
 }
 
 /*
@@ -457,12 +457,12 @@ static void test_receive_timeout(void)
 	int ret, filter_id;
 	struct zcan_frame msg;
 
-	filter_id = attach_msgq(can_dev, &test_std_filter_1);
+	filter_id = add_rx_msgq(can_dev, &test_std_filter_1);
 
 	ret = k_msgq_get(&can_msgq, &msg, TEST_RECEIVE_TIMEOUT);
 	zassert_equal(ret, -EAGAIN, "Got a message without sending it");
 
-	can_detach(can_dev, filter_id);
+	can_remove_rx_filter(can_dev, filter_id);
 }
 
 /*
@@ -481,7 +481,7 @@ static void test_send_callback(void)
 }
 
 /*
- * Attach to a filter that should pass the message and send the message.
+ * Add a filter that should pass the message and send the message.
  * The massage should be received within a small timeout.
  * Standard identifier
  */
@@ -492,7 +492,7 @@ void test_send_receive_std(void)
 }
 
 /*
- * Attach to a filter that should pass the message and send the message.
+ * Add a filter that should pass the message and send the message.
  * The massage should be received within a small timeout
  * Extended identifier
  */
@@ -503,7 +503,7 @@ void test_send_receive_ext(void)
 }
 
 /*
- * Attach to a filter that should pass the message and send the message.
+ * Add a filter that should pass the message and send the message.
  * The massage should be received within a small timeout.
  * The message ID is slightly different to the filter but should still
  * because of the mask settind in the filter.
@@ -516,7 +516,7 @@ void test_send_receive_std_masked(void)
 }
 
 /*
- * Attach to a filter that should pass the message and send the message.
+ * Add a filter that should pass the message and send the message.
  * The massage should be received within a small timeout.
  * The message ID is slightly different to the filter but should still
  * because of the mask settind in the filter.
@@ -529,7 +529,7 @@ void test_send_receive_ext_masked(void)
 }
 
 /*
- * Attach to a filter that should pass the message and send multiple messages.
+ * Add a filter that should pass the message and send multiple messages.
  * The massage should be received and buffered within a small timeout.
  * Extended identifier
  */
@@ -539,7 +539,7 @@ void test_send_receive_buffer(void)
 	struct k_msgq_attrs attrs;
 	struct zcan_frame frame;
 
-	filter_id = attach_msgq(can_dev, &test_std_filter_1);
+	filter_id = add_rx_msgq(can_dev, &test_std_filter_1);
 
 	k_msgq_get_attrs(&can_msgq, &attrs);
 	nframes = attrs.max_msgs;
@@ -562,11 +562,11 @@ void test_send_receive_buffer(void)
 		zassert_equal(ret, 0, "Receiving timeout");
 	}
 
-	can_detach(can_dev, filter_id);
+	can_remove_rx_filter(can_dev, filter_id);
 }
 
 /*
- * Attach to a filter that should not pass the message and send a message
+ * Add a filter that should not pass the message and send a message
  * with a different id.
  * The massage should not be received.
  */
@@ -575,7 +575,7 @@ static void test_send_receive_wrong_id(void)
 	int ret, filter_id;
 	struct zcan_frame msg_buffer;
 
-	filter_id = attach_msgq(can_dev, &test_std_filter_1);
+	filter_id = add_rx_msgq(can_dev, &test_std_filter_1);
 
 	send_test_msg(can_dev, &test_std_msg_2);
 
@@ -583,7 +583,7 @@ static void test_send_receive_wrong_id(void)
 	zassert_equal(ret, -EAGAIN,
 		      "Got a message that should not pass the filter");
 
-	can_detach(can_dev, filter_id);
+	can_remove_rx_filter(can_dev, filter_id);
 }
 
 /*
@@ -611,7 +611,7 @@ void test_main(void)
 	ztest_test_suite(can_driver,
 			 ztest_unit_test(test_set_loopback),
 			 ztest_unit_test(test_send_and_forget),
-			 ztest_unit_test(test_filter_attach),
+			 ztest_unit_test(test_add_filter),
 			 ztest_unit_test(test_receive_timeout),
 			 ztest_unit_test(test_send_callback),
 			 ztest_unit_test(test_send_receive_std),

--- a/tests/subsys/canbus/isotp/conformance/src/main.c
+++ b/tests/subsys/canbus/isotp/conformance/src/main.c
@@ -124,7 +124,7 @@ const struct device *can_dev;
 struct isotp_recv_ctx recv_ctx;
 struct isotp_send_ctx send_ctx;
 uint8_t data_buf[128];
-CAN_DEFINE_MSGQ(frame_msgq, 10);
+CAN_MSGQ_DEFINE(frame_msgq, 10);
 struct k_sem send_compl_sem;
 
 void send_complette_cb(int error_nr, void *arg)
@@ -281,7 +281,7 @@ static void check_frame_series(struct frame_desired *frames, size_t length,
 	zassert_equal(ret, -EAGAIN, "Expected timeout, but received %d", ret);
 }
 
-static int attach_msgq(uint32_t id, uint32_t mask)
+static int add_rx_msgq(uint32_t id, uint32_t mask)
 {
 	int filter_id;
 	struct zcan_filter filter = {
@@ -293,7 +293,7 @@ static int attach_msgq(uint32_t id, uint32_t mask)
 		.id_mask = mask
 	};
 
-	filter_id = can_attach_msgq(can_dev, &frame_msgq, &filter);
+	filter_id = can_add_rx_filter_msgq(can_dev, &frame_msgq, &filter);
 	zassert_not_equal(filter_id, -ENOSPC, "Filter full");
 	zassert_true((filter_id >= 0), "Negative filter number [%d]",
 		     filter_id);
@@ -334,7 +334,7 @@ static void test_send_sf(void)
 	memcpy(&des_frame.data[1], random_data, DATA_SIZE_SF);
 	des_frame.length = DATA_SIZE_SF + 1;
 
-	filter_id = attach_msgq(rx_addr.std_id, CAN_STD_ID_MASK);
+	filter_id = add_rx_msgq(rx_addr.std_id, CAN_STD_ID_MASK);
 	zassert_true((filter_id >= 0), "Negative filter number [%d]",
 		     filter_id);
 
@@ -342,7 +342,7 @@ static void test_send_sf(void)
 
 	check_frame_series(&des_frame, 1, &frame_msgq);
 
-	can_detach(can_dev, filter_id);
+	can_remove_rx_filter(can_dev, filter_id);
 }
 
 static void test_receive_sf(void)
@@ -386,7 +386,7 @@ static void test_send_sf_ext(void)
 	memcpy(&des_frame.data[2], random_data, DATA_SIZE_SF_EXT);
 	des_frame.length = DATA_SIZE_SF_EXT + 2;
 
-	filter_id = attach_msgq(rx_addr_ext.std_id, CAN_STD_ID_MASK);
+	filter_id = add_rx_msgq(rx_addr_ext.std_id, CAN_STD_ID_MASK);
 	zassert_true((filter_id >= 0), "Negative filter number [%d]",
 		     filter_id);
 
@@ -397,7 +397,7 @@ static void test_send_sf_ext(void)
 
 	check_frame_series(&des_frame, 1, &frame_msgq);
 
-	can_detach(can_dev, filter_id);
+	can_remove_rx_filter(can_dev, filter_id);
 }
 
 static void test_receive_sf_ext(void)
@@ -442,7 +442,7 @@ static void test_send_sf_fixed(void)
 	des_frame.length = DATA_SIZE_SF + 1;
 
 	/* mask to allow any priority and source address (SA) */
-	filter_id = attach_msgq(rx_addr_fixed.ext_id, 0x03FFFF00);
+	filter_id = add_rx_msgq(rx_addr_fixed.ext_id, 0x03FFFF00);
 	zassert_true((filter_id >= 0), "Negative filter number [%d]",
 		     filter_id);
 
@@ -453,7 +453,7 @@ static void test_send_sf_fixed(void)
 
 	check_frame_series(&des_frame, 1, &frame_msgq);
 
-	can_detach(can_dev, filter_id);
+	can_remove_rx_filter(can_dev, filter_id);
 }
 
 static void test_receive_sf_fixed(void)
@@ -510,7 +510,7 @@ static void test_send_data(void)
 	prepare_cf_frames(des_frames, ARRAY_SIZE(des_frames), data_ptr,
 			  remaining_length);
 
-	filter_id = attach_msgq(rx_addr.std_id, CAN_STD_ID_MASK);
+	filter_id = add_rx_msgq(rx_addr.std_id, CAN_STD_ID_MASK);
 	zassert_true((filter_id >= 0), "Negative filter number [%d]",
 		     filter_id);
 
@@ -522,7 +522,7 @@ static void test_send_data(void)
 
 	check_frame_series(des_frames, ARRAY_SIZE(des_frames), &frame_msgq);
 
-	can_detach(can_dev, filter_id);
+	can_remove_rx_filter(can_dev, filter_id);
 }
 
 static void test_send_data_blocks(void)
@@ -551,7 +551,7 @@ static void test_send_data_blocks(void)
 
 	remaining_length = DATA_SEND_LENGTH;
 
-	filter_id = attach_msgq(rx_addr.std_id, CAN_STD_ID_MASK);
+	filter_id = add_rx_msgq(rx_addr.std_id, CAN_STD_ID_MASK);
 	zassert_true((filter_id >= 0), "Negative filter number [%d]",
 		     filter_id);
 
@@ -587,7 +587,7 @@ static void test_send_data_blocks(void)
 	ret = k_msgq_get(&frame_msgq, &dummy_frame, K_MSEC(50));
 	zassert_equal(ret, -EAGAIN, "Expected timeout but got %d", ret);
 
-	can_detach(can_dev, filter_id);
+	can_remove_rx_filter(can_dev, filter_id);
 }
 
 static void test_receive_data(void)
@@ -612,7 +612,7 @@ static void test_receive_data(void)
 	prepare_cf_frames(des_frames, ARRAY_SIZE(des_frames), data_ptr,
 			  remaining_length);
 
-	filter_id = attach_msgq(tx_addr.std_id, CAN_STD_ID_MASK);
+	filter_id = add_rx_msgq(tx_addr.std_id, CAN_STD_ID_MASK);
 
 	ret = isotp_bind(&recv_ctx, can_dev, &rx_addr, &tx_addr,
 			 &fc_opts_single, K_NO_WAIT);
@@ -626,7 +626,7 @@ static void test_receive_data(void)
 
 	receive_test_data(&recv_ctx, random_data, DATA_SEND_LENGTH, 0);
 
-	can_detach(can_dev, filter_id);
+	can_remove_rx_filter(can_dev, filter_id);
 	isotp_unbind(&recv_ctx);
 }
 
@@ -658,7 +658,7 @@ static void test_receive_data_blocks(void)
 
 	remaining_frames = CEIL(remaining_length, DATA_SIZE_CF);
 
-	filter_id = attach_msgq(tx_addr.std_id, CAN_STD_ID_MASK);
+	filter_id = add_rx_msgq(tx_addr.std_id, CAN_STD_ID_MASK);
 	zassert_true((filter_id >= 0), "Negative filter number [%d]",
 		     filter_id);
 
@@ -689,7 +689,7 @@ static void test_receive_data_blocks(void)
 
 	receive_test_data(&recv_ctx, random_data, DATA_SEND_LENGTH, 0);
 
-	can_detach(can_dev, filter_id);
+	can_remove_rx_filter(can_dev, filter_id);
 	isotp_unbind(&recv_ctx);
 }
 
@@ -805,7 +805,7 @@ static void test_stmin(void)
 	fc_frame.data[2] = FC_PCI_BYTE_3(STMIN_VAL_1);
 	fc_frame.length = DATA_SIZE_FC;
 
-	filter_id = attach_msgq(rx_addr.std_id, CAN_STD_ID_MASK);
+	filter_id = add_rx_msgq(rx_addr.std_id, CAN_STD_ID_MASK);
 	zassert_true((filter_id >= 0), "Negative filter number [%d]",
 		     filter_id);
 
@@ -842,7 +842,7 @@ static void test_stmin(void)
 	zassert_true(time_diff >= STMIN_VAL_2, "STmin too short (%dms)",
 		     time_diff);
 
-	can_detach(can_dev, filter_id);
+	can_remove_rx_filter(can_dev, filter_id);
 }
 
 void test_receiver_fc_errors(void)
@@ -860,7 +860,7 @@ void test_receiver_fc_errors(void)
 	fc_frame.data[2] = FC_PCI_BYTE_3(fc_opts.stmin);
 	fc_frame.length = DATA_SIZE_FC;
 
-	filter_id = attach_msgq(tx_addr.std_id, CAN_STD_ID_MASK);
+	filter_id = add_rx_msgq(tx_addr.std_id, CAN_STD_ID_MASK);
 	zassert_true((filter_id >= 0), "Negative filter number [%d]",
 		     filter_id);
 
@@ -885,7 +885,7 @@ void test_receiver_fc_errors(void)
 	zassert_equal(ret, ISOTP_N_WRONG_SN,
 		      "Expected wrong SN but got %d", ret);
 
-	can_detach(can_dev, filter_id);
+	can_remove_rx_filter(can_dev, filter_id);
 	k_msgq_cleanup(&frame_msgq);
 	isotp_unbind(&recv_ctx);
 }
@@ -900,7 +900,7 @@ void test_sender_fc_errors(void)
 	memcpy(&ff_frame.data[2], random_data, DATA_SIZE_FF);
 	ff_frame.length = DATA_SIZE_FF + 2;
 
-	filter_id = attach_msgq(tx_addr.std_id, CAN_STD_ID_MASK);
+	filter_id = add_rx_msgq(tx_addr.std_id, CAN_STD_ID_MASK);
 
 	/* invalid flow status */
 	fc_frame.data[0] = FC_PCI_BYTE_1(3);
@@ -920,7 +920,7 @@ void test_sender_fc_errors(void)
 	zassert_equal(ret, 0, "Send complete callback not called");
 
 	/* buffer overflow */
-	can_detach(can_dev, filter_id);
+	can_remove_rx_filter(can_dev, filter_id);
 	ret = isotp_bind(&recv_ctx, can_dev, &tx_addr, &rx_addr,
 			 &fc_opts_single, K_NO_WAIT);
 	zassert_equal(ret, ISOTP_N_OK, "Binding failed [%d]", ret);
@@ -930,7 +930,7 @@ void test_sender_fc_errors(void)
 	zassert_equal(ret, ISOTP_N_BUFFER_OVERFLW,
 		      "Expected overflow but got %d", ret);
 	isotp_unbind(&recv_ctx);
-	filter_id = attach_msgq(tx_addr.std_id, CAN_STD_ID_MASK);
+	filter_id = add_rx_msgq(tx_addr.std_id, CAN_STD_ID_MASK);
 
 	k_sem_reset(&send_compl_sem);
 	ret = isotp_send(&send_ctx, can_dev, random_data, DATA_SEND_LENGTH,
@@ -958,7 +958,7 @@ void test_sender_fc_errors(void)
 	ret = k_sem_take(&send_compl_sem, K_MSEC(200));
 	zassert_equal(ret, 0, "Send complete callback not called");
 	k_msgq_cleanup(&frame_msgq);
-	can_detach(can_dev, filter_id);
+	can_remove_rx_filter(can_dev, filter_id);
 }
 
 


### PR DESCRIPTION
Rename a few CAN API functions for clarity and consistency with other Zephyr RTOS APIs.

- `CAN_DEFINE_MSGQ()` becomes `CAN_MSGQ_DEFINE()` to match `K_MSGQ_DEFINE()`.
- `can_attach_isr()` becomes `can_add_rx_filter()` since a filter callback function is not an interrupt service routine (although it is called in isr context). The word "attach" is replaced with "add" since filters are added, not attached. This matches the terminology used is other Zephyr APIs better.
- `can_detach()` becomes `can_remove_rx_filter()` to pair with `can_add_rx_filter()`.
- `can_attach_msgq()` becomes `can_add_rx_filter_msgq()` and documentation is updated to mention its relationship with `can_add_rx_filter()`.
- `can_register_state_change_isr()` becomes `can_set_state_change_callback()` since a state change callback function is not an interrupt service routine (although it is called in isr context). The word "register" is replaced with "set" since only one state change callback can be in place.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>