### PR TITLE
Bluetooth: Controller: Fix to restrict Extended Adv Report to max data length

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -490,6 +490,13 @@ config BT_CTLR_ADV_EXT_RX_PDU_LEN_MAX
 	help
 	  Maximum Advertising Extensions Receive PDU Length.
 
+config BT_CTLR_SCAN_DATA_LEN_MAX
+	int "Maximum Extended Scanning Data Length"
+	depends on BT_OBSERVER
+	range 31 1650
+	help
+	  Maximum Extended Scanning Data Length.
+
 config BT_CTLR_ADV_PERIODIC
 	bool "LE Periodic Advertising in Advertising State" if !BT_LL_SW_SPLIT
 	depends on BT_BROADCASTER && BT_CTLR_ADV_PERIODIC_SUPPORT

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -5570,6 +5570,7 @@ static void ext_adv_pdu_frag(uint8_t evt_type, uint8_t phy, uint8_t sec_phy,
 	const uint8_t data_len_frag = MIN(*data_len, data_len_max);
 
 	do {
+		/* Prepare a fragment of PDU data in a HCI event */
 		ext_adv_info_fill(evt_type, phy, sec_phy, adv_addr_type,
 				  adv_addr, direct_addr_type, direct_addr,
 				  rl_idx, tx_pwr, rssi, interval_le16, adi,
@@ -5581,6 +5582,10 @@ static void ext_adv_pdu_frag(uint8_t evt_type, uint8_t phy, uint8_t sec_phy,
 
 		*evt_buf = bt_buf_get_rx(BT_BUF_EVT, K_FOREVER);
 		net_buf_frag_add(buf, *evt_buf);
+
+		/* Continue to fragment until last partial PDU data fragment,
+		 * remainder PDU data's HCI event will be prepare by caller.
+		 */
 	} while (*data_len > data_len_max);
 }
 
@@ -5600,15 +5605,24 @@ static void ext_adv_data_frag(const struct node_rx_pdu *node_rx_data,
 	evt_type |= (BT_HCI_LE_ADV_EVT_TYPE_DATA_STATUS_PARTIAL << 5);
 
 	do {
+		/* Fragment the PDU data */
 		ext_adv_pdu_frag(evt_type, phy, *sec_phy, adv_addr_type,
 				 adv_addr, direct_addr_type, direct_addr,
 				 rl_idx, tx_pwr, rssi, interval_le16, adi,
 				 data_len_max, &data_len_total, data_len,
 				 data, buf, evt_buf);
 
+		/* Check if more PDUs in the list */
 		node_rx_data = node_rx_data->hdr.rx_ftr.extra;
 		if (node_rx_data) {
-			if (*data_len) {
+			if (*data_len >= data_len_total) {
+				/* Last fragment restricted to maximum scan
+				 * data length, caller will prepare the last
+				 * HCI fragment event.
+				 */
+				break;
+			} else if (*data_len) {
+				/* Last fragment of current PDU data */
 				ext_adv_pdu_frag(evt_type, phy, *sec_phy,
 						 adv_addr_type, adv_addr,
 						 direct_addr_type, direct_addr,
@@ -5618,9 +5632,20 @@ static void ext_adv_data_frag(const struct node_rx_pdu *node_rx_data,
 						 data_len, data, buf, evt_buf);
 			}
 
+			/* Get next PDU data in list */
 			*data_len = ext_adv_data_get(node_rx_data, sec_phy,
 						     data);
+
+			/* Restrict PDU data to maximum scan data length */
+			if (*data_len > data_len_total) {
+				*data_len = data_len_total;
+			}
 		}
+
+		/* Continue to fragment if current PDU data length less than
+		 * total data length or current PDU data length greater than
+		 * HCI event max length.
+		 */
 	} while ((*data_len < data_len_total) || (*data_len > data_len_max));
 }
 
@@ -5968,6 +5993,16 @@ no_ext_hdr:
 		}
 	}
 
+	/* Restrict data length to maximum scan data length */
+	if (data_len_total > CONFIG_BT_CTLR_SCAN_DATA_LEN_MAX) {
+		data_len_total = CONFIG_BT_CTLR_SCAN_DATA_LEN_MAX;
+		if (data_len > data_len_total) {
+			data_len = data_len_total;
+		}
+
+		data_status = BT_HCI_LE_ADV_EVT_TYPE_DATA_STATUS_INCOMPLETE;
+	}
+
 	/* Set directed advertising bit */
 	if (direct_addr) {
 		evt_type |= BT_HCI_LE_ADV_EVT_TYPE_DIRECT;
@@ -5980,6 +6015,9 @@ no_ext_hdr:
 		       sizeof(struct bt_hci_evt_le_ext_advertising_report) -
 		       sizeof(struct bt_hci_evt_le_ext_advertising_info);
 
+	/* If PDU data length less than total data length or PDU data length
+	 * greater than maximum HCI event data length, then fragment.
+	 */
 	if ((data_len < data_len_total) || (data_len > data_len_max)) {
 		ext_adv_data_frag(node_rx_data, evt_type, phy, &sec_phy,
 				  adv_addr_type, adv_addr, direct_addr_type,
@@ -5992,7 +6030,7 @@ no_ext_hdr:
 	/* Set data status bits */
 	evt_type |= (data_status << 5);
 
-	/* Start constructing the adv event */
+	/* Start constructing the adv event for remainder of the PDU data */
 	ext_adv_info_fill(evt_type, phy, sec_phy, adv_addr_type, adv_addr,
 			  direct_addr_type, direct_addr, rl_idx, tx_pwr, rssi,
 			  interval_le16, adi, data_len, data, evt_buf);
@@ -6002,6 +6040,16 @@ no_ext_hdr:
 		node_rx_extra_list_release(node_rx->hdr.rx_ftr.extra);
 
 		return;
+	}
+
+	/* Restrict scan response data length to maximum scan data length */
+	if (scan_data_len_total > CONFIG_BT_CTLR_SCAN_DATA_LEN_MAX) {
+		scan_data_len_total = CONFIG_BT_CTLR_SCAN_DATA_LEN_MAX;
+		if (scan_data_len > scan_data_len_total) {
+			scan_data_len = scan_data_len_total;
+		}
+
+		scan_data_status = BT_HCI_LE_ADV_EVT_TYPE_DATA_STATUS_INCOMPLETE;
 	}
 
 	/* Set scan response bit */
@@ -6016,6 +6064,9 @@ no_ext_hdr:
 	evt_buf = bt_buf_get_rx(BT_BUF_EVT, K_FOREVER);
 	net_buf_frag_add(buf, evt_buf);
 
+	/* If PDU data length less than total data length or PDU data length
+	 * greater than maximum HCI event data length, then fragment.
+	 */
 	if ((scan_data_len < scan_data_len_total) ||
 	    (scan_data_len > data_len_max)) {
 		ext_adv_data_frag(node_rx_scan_data, evt_type, phy,
@@ -6029,7 +6080,7 @@ no_ext_hdr:
 	/* set scan data status bits */
 	evt_type |= (scan_data_status << 5);
 
-	/* Start constructing the event */
+	/* Start constructing the event for remainder of the PDU data */
 	ext_adv_info_fill(evt_type, phy, sec_phy_scan, adv_addr_type, adv_addr,
 			  direct_addr_type, direct_addr, rl_idx, tx_pwr, rssi,
 			  interval_le16, adi, scan_data_len, scan_data,


### PR DESCRIPTION
Fix implementation to limit Extended Scanned data to a
configurable maximum length when generating HCI reports.

Fixes #41653.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>