### PR TITLE
Bluetooth: Controller: Skip re-init of static initialized PDU fields

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -655,6 +655,11 @@ void lll_conn_pdu_tx_prep(struct lll_conn *lll, struct pdu_data **pdu_data_tx)
 			p->ll_id = PDU_DATA_LLID_DATA_CONTINUE;
 
 #if defined(CONFIG_BT_CTLR_DF_CONN_CTE_TX)
+			/* BT 5.3 Core Spec does not define handling of CP bit
+			 * for PDUs fragmented by Controller, hence the CP bit
+			 * is set to zero. The CTE should not be transmitted
+			 * with CONTINUE PDUs if fragmentation is performed.
+			 */
 			p->cp = 0U;
 			p->resv = 0U;
 #endif /* CONFIG_BT_CTLR_DF_CONN_CTE_TX */
@@ -934,6 +939,11 @@ static void empty_tx_init(void)
 
 	p = (void *)radio_pkt_empty_get();
 	p->ll_id = PDU_DATA_LLID_DATA_CONTINUE;
+
+	/* cp, rfu, and resv fields in the empty PDU buffer is statically
+	 * zero initialized at power up and these values in this buffer are
+	 * not modified at runtime.
+	 */
 }
 
 #if defined(CONFIG_BT_CTLR_DF_CONN_CTE_TX)

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -653,6 +653,11 @@ void lll_conn_pdu_tx_prep(struct lll_conn *lll, struct pdu_data **pdu_data_tx)
 
 		if (lll->packet_tx_head_offset) {
 			p->ll_id = PDU_DATA_LLID_DATA_CONTINUE;
+
+#if defined(CONFIG_BT_CTLR_DF_CONN_CTE_TX)
+			p->cp = 0U;
+			p->resv = 0U;
+#endif /* CONFIG_BT_CTLR_DF_CONN_CTE_TX */
 		}
 
 		p->len = lll->packet_tx_head_len - lll->packet_tx_head_offset;
@@ -670,6 +675,12 @@ void lll_conn_pdu_tx_prep(struct lll_conn *lll, struct pdu_data **pdu_data_tx)
 		}
 
 		p->rfu = 0U;
+
+#if !defined(CONFIG_BT_CTLR_DATA_LENGTH_CLEAR)
+#if !defined(CONFIG_BT_CTLR_DF_CONN_CTE_TX)
+		p->resv = 0U;
+#endif /* !CONFIG_BT_CTLR_DF_CONN_CTE_TX */
+#endif /* CONFIG_BT_CTLR_DATA_LENGTH_CLEAR */
 	}
 
 	*pdu_data_tx = p;
@@ -923,10 +934,6 @@ static void empty_tx_init(void)
 
 	p = (void *)radio_pkt_empty_get();
 	p->ll_id = PDU_DATA_LLID_DATA_CONTINUE;
-	p->cp = false;
-#if !defined(CONFIG_BT_CTLR_DATA_LENGTH_CLEAR)
-	p->resv = 0U;
-#endif /* CONFIG_BT_CTLR_DATA_LENGTH_CLEAR */
 }
 
 #if defined(CONFIG_BT_CTLR_DF_CONN_CTE_TX)

--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -809,11 +809,19 @@ struct pdu_data {
 	uint8_t nesn:1;
 	uint8_t sn:1;
 	uint8_t md:1;
+#if defined(CONFIG_BT_CTLR_DF_CONN_CTE_TX)
 	uint8_t cp:1;
 	uint8_t rfu:2;
+#else
+	uint8_t rfu:3;
+#endif
 #elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#if defined(CONFIG_BT_CTLR_DF_CONN_CTE_TX)
 	uint8_t rfu:2;
 	uint8_t cp:1;
+#else
+	uint8_t rfu:3;
+#endif
 	uint8_t md:1;
 	uint8_t sn:1;
 	uint8_t nesn:1;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -2051,20 +2051,17 @@ uint16_t ull_conn_lll_max_tx_octets_get(struct lll_conn *lll)
 
 /**
  * @brief Initialize pdu_data members that are read only in lower link layer.
+ *        Fields that are modified after static initialization are only
+ *        re-initialized.
  *
  * @param pdu_tx Pointer to pdu_data object to be initialized
  */
 void ull_pdu_data_init(struct pdu_data *pdu_tx)
 {
-	LL_ASSERT(pdu_tx);
-
-	pdu_tx->cp = false;
-	pdu_tx->rfu = 0U;
-#if !defined(CONFIG_SOC_OPENISA_RV32M1_RISCV32)
-#if !defined(CONFIG_BT_CTLR_DATA_LENGTH_CLEAR)
+#if defined(CONFIG_BT_CTLR_DF_CONN_CTE_TX)
+	pdu_tx->cp = 0U;
 	pdu_tx->resv = 0U;
-#endif /* CONFIG_BT_CTLR_DATA_LENGTH_CLEAR */
-#endif /* !CONFIG_SOC_OPENISA_RV32M1_RISCV32 */
+#endif /* CONFIG_BT_CTLR_DF_CONN_CTE_TX */
 }
 
 static int init_reset(void)

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -2051,8 +2051,6 @@ uint16_t ull_conn_lll_max_tx_octets_get(struct lll_conn *lll)
 
 /**
  * @brief Initialize pdu_data members that are read only in lower link layer.
- *        Fields that are modified after static initialization are only
- *        re-initialized.
  *
  * @param pdu_tx Pointer to pdu_data object to be initialized
  */


### PR DESCRIPTION
Skip re-initialization of statically initialized PDU struct
fields that are not modified at runtime.

When supporting connection oriented CTE, the cp bit and
resv field used for CTE info are modified, hence
re-initialized these and accordingly reset the values
when just-in-time HCI Tx Data fragmentation is performed
in the Lower Link Layer.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>