### PR TITLE
RD: soc/intel_adsp: measure a simple dummy DSP load at core start

### DIFF
--- a/soc/xtensa/intel_adsp/common/soc_mp.c
+++ b/soc/xtensa/intel_adsp/common/soc_mp.c
@@ -141,6 +141,8 @@ __imr void z_mp_entry(void)
 
 	cpus_active[start_rec.cpu] = true;
 
+	dummy_dspload();
+
 	start_rec.fn(start_rec.arg);
 	__ASSERT(false, "arch_start_cpu() handler should never return");
 }


### PR DESCRIPTION
Upon starting a core, run a simple DSP workload, measure and print
its execution time.