### PR TITLE
littlefs : Add LFS_READONLY and CUSTOM_LFS_CONFIG_FILE to Kconfig

### DIFF
--- a/subsys/fs/Kconfig.littlefs
+++ b/subsys/fs/Kconfig.littlefs
@@ -104,4 +104,24 @@ config FS_LITTLEFS_HEAP_PER_ALLOC_OVERHEAD_SIZE
 
 endif # FS_LITTLEFS_FC_HEAP_SIZE <= 0
 
+config LFS_READONLY
+	bool "Enable readonly little fs"
+	default 0
+	help
+	  Enable readonly littlefs
+
+config LFS_CFG
+	bool "Enable little fs custom config"
+	default 0
+	help
+	  Enable lfs custom config file. This flag will allow CUSTOM_LFS_CONFIG_FILE.
+
+config CUSTOM_LFS_CONFIG_FILE
+	string "Custom LFS configuration file" if LFS_CFG
+	default "littlefs_util.h"
+	help
+	  Allow user defined input file for the LFS_CONFIG setting. The default config
+	  file can be tweaked with Kconfig to optimize resources with lfs library.
+	  You can specify the actual configuration file using the LFS_CONFIG.
+
 endif # FILE_SYSTEM_LITTLEFS

--- a/subsys/fs/littlefs_fs.c
+++ b/subsys/fs/littlefs_fs.c
@@ -203,16 +203,17 @@ static void release_file_data(struct fs_file_t *fp)
 
 static int lfs_flags_from_zephyr(unsigned int zflags)
 {
-	int flags = (zflags & FS_O_CREATE) ? LFS_O_CREAT : 0;
+	int flags = 0;
 
 	/* LFS_O_READONLY and LFS_O_WRONLY can be selected at the same time,
 	 * this is not a mistake, together they create RDWR access.
 	 */
 	flags |= (zflags & FS_O_READ) ? LFS_O_RDONLY : 0;
-	flags |= (zflags & FS_O_WRITE) ? LFS_O_WRONLY : 0;
-
+#if !IS_ENABLED(CONFIG_LFS_READONLY)
+	flags = (zflags & FS_O_CREATE) ? LFS_O_CREAT : 0;
+	flags |= (zflags & FS_O_WRITE)	 ? LFS_O_WRONLY : 0;
 	flags |= (zflags & FS_O_APPEND) ? LFS_O_APPEND : 0;
-
+#endif
 	return flags;
 }
 
@@ -270,6 +271,7 @@ static int littlefs_close(struct fs_file_t *fp)
 	return lfs_to_errno(ret);
 }
 
+#if !IS_ENABLED(CONFIG_LFS_READONLY)
 static int littlefs_unlink(struct fs_mount_t *mountp, const char *path)
 {
 	struct fs_littlefs *fs = mountp->fs_data;
@@ -299,6 +301,7 @@ static int littlefs_rename(struct fs_mount_t *mountp, const char *from,
 	fs_unlock(fs);
 	return lfs_to_errno(ret);
 }
+#endif
 
 static ssize_t littlefs_read(struct fs_file_t *fp, void *ptr, size_t len)
 {
@@ -312,6 +315,7 @@ static ssize_t littlefs_read(struct fs_file_t *fp, void *ptr, size_t len)
 	return lfs_to_errno(ret);
 }
 
+#if !IS_ENABLED(CONFIG_LFS_READONLY)
 static ssize_t littlefs_write(struct fs_file_t *fp, const void *ptr, size_t len)
 {
 	struct fs_littlefs *fs = fp->mp->fs_data;
@@ -323,6 +327,7 @@ static ssize_t littlefs_write(struct fs_file_t *fp, const void *ptr, size_t len)
 	fs_unlock(fs);
 	return lfs_to_errno(ret);
 }
+#endif
 
 BUILD_ASSERT((FS_SEEK_SET == LFS_SEEK_SET)
 	     && (FS_SEEK_CUR == LFS_SEEK_CUR)
@@ -357,6 +362,7 @@ static off_t littlefs_tell(struct fs_file_t *fp)
 	return ret;
 }
 
+#if !IS_ENABLED(CONFIG_LFS_READONLY)
 static int littlefs_truncate(struct fs_file_t *fp, off_t length)
 {
 	struct fs_littlefs *fs = fp->mp->fs_data;
@@ -393,6 +399,7 @@ static int littlefs_mkdir(struct fs_mount_t *mountp, const char *path)
 	fs_unlock(fs);
 	return lfs_to_errno(ret);
 }
+#endif
 
 static int littlefs_opendir(struct fs_dir_t *dp, const char *path)
 {
@@ -700,8 +707,8 @@ static int littlefs_mount(struct fs_mount_t *mountp)
 
 	/* Mount it, formatting if needed. */
 	ret = lfs_mount(&fs->lfs, &fs->cfg);
-	if (ret < 0 &&
-	    (mountp->flags & FS_MOUNT_FLAG_NO_FORMAT) == 0) {
+	if (ret < 0 && (mountp->flags & FS_MOUNT_FLAG_NO_FORMAT) == 0) {
+#if !IS_ENABLED(CONFIG_LFS_READONLY)
 		LOG_WRN("can't mount (LFS %d); formatting", ret);
 		if ((mountp->flags & FS_MOUNT_FLAG_READ_ONLY) == 0) {
 			ret = lfs_format(&fs->lfs, &fs->cfg);
@@ -715,7 +722,7 @@ static int littlefs_mount(struct fs_mount_t *mountp)
 			ret = -EROFS;
 			goto out;
 		}
-
+#endif
 		ret = lfs_mount(&fs->lfs, &fs->cfg);
 		if (ret < 0) {
 			LOG_ERR("remount after format failed (LFS %d)", ret);
@@ -758,19 +765,21 @@ static const struct fs_file_system_t littlefs_fs = {
 	.open = littlefs_open,
 	.close = littlefs_close,
 	.read = littlefs_read,
-	.write = littlefs_write,
 	.lseek = littlefs_seek,
 	.tell = littlefs_tell,
-	.truncate = littlefs_truncate,
-	.sync = littlefs_sync,
 	.opendir = littlefs_opendir,
 	.readdir = littlefs_readdir,
 	.closedir = littlefs_closedir,
 	.mount = littlefs_mount,
 	.unmount = littlefs_unmount,
+#if !IS_ENABLED(CONFIG_LFS_READONLY)
+	.sync = littlefs_sync,
+	.write = littlefs_write,
+	.truncate = littlefs_truncate,
 	.unlink = littlefs_unlink,
 	.rename = littlefs_rename,
 	.mkdir = littlefs_mkdir,
+#endif
 	.stat = littlefs_stat,
 	.statvfs = littlefs_statvfs,
 };


### PR DESCRIPTION
Add littlefs config file and add lfs readonly flags to kconfig

Signed-off-by: Pooja Ganesh <poojamg@amperecomputing.com>