### PR TITLE
soc/intel_adsp: fix icache initialization

### DIFF
--- a/soc/xtensa/intel_adsp/common/include/cpu_init.h
+++ b/soc/xtensa/intel_adsp/common/include/cpu_init.h
@@ -82,7 +82,7 @@ static ALWAYS_INLINE void cpu_early_init(void)
 	 * Also set bit 0 to enable the LOOP extension instruction
 	 * fetch buffer.
 	 */
-#ifdef XCHAL_HAVE_ICACHE_DYN_ENABLE
+#if XCHAL_USE_MEMCTL
 	reg = 0xffffff01;
 	__asm__ volatile("wsr %0, MEMCTL; rsync" :: "r"(reg));
 #endif


### PR DESCRIPTION
XCHAL_HAVE_ICACHE_DYN_ENABLE is not set for any Intel cAVS
hardware, so MEMCTL configuration is not done properly leaving
icache disabled. This can be seen as ~10X slowness when running
code on non-primary cores. Fix the issue by using XCHAL_USE_MEMCTL
to check for MEMCTL usage.

Fixes: https://github.com/thesofproject/sof/issues/5050

Also explain the performance delta seen with test case https://github.com/zephyrproject-rtos/zephyr/pull/41496


Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>