### PR TITLE
storage/flash_map: Use larger type for alignment

### DIFF
--- a/include/storage/flash_map.h
+++ b/include/storage/flash_map.h
@@ -191,7 +191,7 @@ int flash_area_erase(const struct flash_area *fa, off_t off, size_t len);
  *
  * @return Alignment restriction for flash writes in [B].
  */
-uint8_t flash_area_align(const struct flash_area *fa);
+uint32_t flash_area_align(const struct flash_area *fa);
 
 /**
  * Retrieve info about sectors within the area.

--- a/subsys/storage/flash_map/flash_map.c
+++ b/subsys/storage/flash_map/flash_map.c
@@ -93,7 +93,7 @@ int flash_area_erase(const struct flash_area *fa, off_t off, size_t len)
 	return rc;
 }
 
-uint8_t flash_area_align(const struct flash_area *fa)
+uint32_t flash_area_align(const struct flash_area *fa)
 {
 	const struct device *dev;
 


### PR DESCRIPTION
In MCUboot:
    commit 4aa286d2db2d02a8f0ff29cdc3304f3185dbe261
    Author: Gustavo Henrique Nihei <gustavo.nihei@espressif.com>
    Date:   Wed Nov 24 14:54:56 2021 -0300

        flash_map: Increase minimum supported write align via flash_area_align

MCUboot changed the type of the alignment value in flash from a uint8_t
to a uint32_t.  Indeed, Zephyr contains flash devices that have a larger
alignment than will fit in an 8-bit value.  This generally means that
`flash_area_align` will just return 0 on these platforms.

Change call in Zephyr as well.

This shouldn't cause any observable behavior changes in Zephyr, other
than making some cases that don't work currently begin to work.  If a
client is storing these results in a u8, it will be truncated, the same
as things were previously.  If, however, the caller is prepared to
handle a larger type, this will result in having correct information,
instead of the truncated value.

Signed-off-by: David Brown <david.brown@linaro.org>