### PR TITLE
twister: add extra binary args option

### DIFF
--- a/scripts/schemas/twister/testcase-schema.yaml
+++ b/scripts/schemas/twister/testcase-schema.yaml
@@ -155,6 +155,9 @@ mapping:
           "extra_args":
             type: str
             required: false
+          "extra_bin_args":
+            type: str
+            required: false
           "extra_configs":
             type: seq
             required: false

--- a/scripts/tests/twister/test_reporting_testsuite.py
+++ b/scripts/tests/twister/test_reporting_testsuite.py
@@ -51,8 +51,8 @@ def test_csv_report(class_testsuite, instances_fixture, tmpdir):
     assert os.stat(filename).st_size != 0
 
     mydict = {'test': [], 'arch' : [], 'platform' : [], 'status': [],
-              'extra_args': [], 'handler': [], 'handler_time': [],
-              'ram_size': [], 'rom_size': []}
+              'extra_args': [], 'extra_bin_args': [], 'handler': [],
+              'handler_time': [], 'ram_size': [], 'rom_size': []}
 
     with open(filename, "r") as file:
         csv_reader = csv.reader(file)
@@ -66,6 +66,8 @@ def test_csv_report(class_testsuite, instances_fixture, tmpdir):
         mydict["status"].append(instance_status)
         args = " ".join(instance.testcase.extra_args)
         mydict["extra_args"].append(args)
+        bin_args = " ".join(instance.testcase.extra_bin_args)
+        mydict["extra_bin_args"].append(bin_args)
         mydict["handler"].append(instance.platform.simulation)
         mydict["handler_time"].append(instance.metrics.get("handler_time", ""))
         mydict["ram_size"].append(instance.metrics.get("ram_size", '0'))

--- a/scripts/twister
+++ b/scripts/twister
@@ -40,6 +40,9 @@ pairs:
     Extra cache entries to pass to CMake when building or running the
     test case.
 
+  extra_bin_args: <list of extra arguments for the test binary>
+    Extra arguments to pass to the test binary.
+
   extra_configs: <list of extra configurations>
     Extra configuration options to be merged with a master prj.conf
     when building or running the test case.
@@ -551,6 +554,10 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
         help="""Force testing on selected platforms,
         even if they are excluded in the test configuration (testcase.yaml)."""
     )
+    parser.add_argument(
+        "--extra-bin-args", action="append", default=[],
+        help="Extra arguments to pass to the test binary."
+    )
 
     parser.add_argument(
         "-l", "--all", action="store_true",
@@ -914,6 +921,7 @@ def main():
     suite.inline_logs = options.inline_logs
     suite.enable_size_report = options.enable_size_report
     suite.extra_args = options.extra_args
+    suite.extra_bin_args = options.extra_bin_args
     suite.west_flash = options.west_flash
     suite.west_runner = options.west_runner
     suite.verbose = VERBOSE


### PR DESCRIPTION
This is useful when eg. testing HCI/BT on native posix, as you then
might have to provide "--bt-hci" argument to the binary.

Fixes issue #41073 