### PR TITLE
drivers: watchdog: STM32G0X: clock DBGMCU before configuring

### DIFF
--- a/drivers/watchdog/wdt_iwdg_stm32.c
+++ b/drivers/watchdog/wdt_iwdg_stm32.c
@@ -83,6 +83,8 @@ static int iwdg_stm32_setup(const struct device *dev, uint8_t options)
 	if (options & WDT_OPT_PAUSE_HALTED_BY_DBG) {
 #if defined(CONFIG_SOC_SERIES_STM32F0X)
 		LL_APB1_GRP2_EnableClock(LL_APB1_GRP2_PERIPH_DBGMCU);
+#elif defined(CONFIG_SOC_SERIES_STM32G0X)
+		LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_DBGMCU);
 #elif defined(CONFIG_SOC_SERIES_STM32L0X)
 		LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_DBGMCU);
 #endif


### PR DESCRIPTION
Enable the clock for the DBGMCU peripherals so that it can be configured.