### PR TITLE
arch: arm: aarch32: fix section alignment behind rodata start marker

### DIFF
--- a/include/arch/arm/aarch32/cortex_a_r/scripts/linker.ld
+++ b/include/arch/arm/aarch32/cortex_a_r/scripts/linker.ld
@@ -62,7 +62,7 @@ _region_min_align = CONFIG_ARM_MPU_REGION_MIN_ALIGN_AND_SIZE;
 #elif defined(CONFIG_ARM_AARCH32_MMU)
 _region_min_align = CONFIG_MMU_PAGE_SIZE;
 #else
-/* If building without MPU support, use default 4-byte alignment. */
+/* If building without MPU/MMU support, use default 4-byte alignment. */
 _region_min_align = 4;
 #endif
 
@@ -151,10 +151,9 @@ SECTIONS
          */
         *(.glue_7t) *(.glue_7) *(.vfp11_veneer) *(.v4_bx)
 
+        __text_region_end = .;
+        . = ALIGN(_region_min_align);
     } GROUP_LINK_IN(ROMABLE_REGION)
-
-    __text_region_end = .;
-    . = ALIGN(_region_min_align);
 
 #if defined (CONFIG_CPLUSPLUS)
     SECTION_PROLOGUE(.ARM.extab,,)
@@ -181,8 +180,11 @@ SECTIONS
         __exidx_end = .;
     } GROUP_LINK_IN(ROMABLE_REGION)
 
-    . = ALIGN(_region_min_align);
-    __rodata_region_start = .;
+    SECTION_PROLOGUE(rodata_start,,)
+    {
+        . = ALIGN(_region_min_align);
+        __rodata_region_start = .;
+    } GROUP_LINK_IN(ROMABLE_REGION)
 
 #include <linker/common-rom.ld>
 #include <linker/thread-local-storage.ld>

--- a/tests/subsys/logging/log_api/testcase.yaml
+++ b/tests/subsys/logging/log_api/testcase.yaml
@@ -45,45 +45,45 @@ tests:
       - CONFIG_SAMPLE_MODULE_LOG_LEVEL_DBG=y
 
   logging.log2_api_deferred_overflow_rt_filter:
-    # FIXME:see #38041, #39978
-    platform_exclude: qemu_arc_hs6x qemu_cortex_a9
+    # FIXME:see #38041
+    platform_exclude: qemu_arc_hs6x
     extra_configs:
       - CONFIG_LOG2_MODE_DEFERRED=y
       - CONFIG_LOG_MODE_OVERFLOW=y
       - CONFIG_LOG_RUNTIME_FILTERING=y
 
   logging.log2_api_deferred_overflow:
-    # FIXME:see #38041, #39978
-    platform_exclude: qemu_arc_hs6x qemu_cortex_a9
+    # FIXME:see #38041
+    platform_exclude: qemu_arc_hs6x
     extra_configs:
       - CONFIG_LOG2_MODE_DEFERRED=y
       - CONFIG_LOG_MODE_OVERFLOW=y
 
   logging.log2_api_deferred_no_overflow:
-    # FIXME:see #38041, #39978
-    platform_exclude: qemu_arc_hs6x qemu_cortex_a9
+    # FIXME:see #38041
+    platform_exclude: qemu_arc_hs6x
     extra_configs:
       - CONFIG_LOG2_MODE_DEFERRED=y
       - CONFIG_LOG_MODE_OVERFLOW=n
 
   logging.log2_api_deferred_static_filter:
-    # FIXME:see #38041, #39978
-    platform_exclude: qemu_arc_hs6x qemu_cortex_a9
+    # FIXME:see #38041
+    platform_exclude: qemu_arc_hs6x
     extra_configs:
       - CONFIG_LOG2_MODE_DEFERRED=y
       - CONFIG_SAMPLE_MODULE_LOG_LEVEL_DBG=y
 
   logging.log2_api_deferred_func_prefix:
-    # FIXME:see #38041, #39978
-    platform_exclude: qemu_arc_hs6x qemu_cortex_a9
+    # FIXME:see #38041
+    platform_exclude: qemu_arc_hs6x
     extra_configs:
       - CONFIG_LOG2_MODE_DEFERRED=y
       - CONFIG_SAMPLE_MODULE_LOG_LEVEL_DBG=y
       - CONFIG_LOG_FUNC_NAME_PREFIX_DBG=y
 
   logging.log2_api_deferred_64b_timestamp:
-    # FIXME:see #38041, #39978
-    platform_exclude: qemu_arc_hs6x qemu_cortex_a9
+    # FIXME:see #38041
+    platform_exclude: qemu_arc_hs6x
     extra_configs:
       - CONFIG_LOG2_MODE_DEFERRED=y
       - CONFIG_LOG_TIMESTAMP_64BIT=y

--- a/tests/subsys/logging/log_msg2/testcase.yaml
+++ b/tests/subsys/logging/log_msg2/testcase.yaml
@@ -15,8 +15,6 @@ tests:
       - CONFIG_LOG_MODE_OVERFLOW=n
 
   logging.log_msg2_64b_timestamp:
-    # FIXME: see #39978
-    platform_exclude: qemu_cortex_a9
     extra_configs:
       - CONFIG_CBPRINTF_COMPLETE=y
       - CONFIG_LOG_TIMESTAMP_64BIT=y
@@ -27,8 +25,6 @@ tests:
       - CONFIG_CBPRINTF_FP_SUPPORT=y
 
   logging.log_msg2_fp_64b_timestamp:
-    # FIXME: see #39978
-    platform_exclude: qemu_cortex_a9
     extra_configs:
       - CONFIG_CBPRINTF_COMPLETE=y
       - CONFIG_CBPRINTF_FP_SUPPORT=y


### PR DESCRIPTION
Fixes #39978.

This commit assigns the __rodata_region_start marker to the ROMABLE region
prior to the inclusion of linker/common-rom.ld, linker/thread-local-storage.ld and
linker/cplusplus-rom.ld. Prior to this fix, the __rodata_region_start marker was
properly aligned and indicated the expected memory location for the start of the
rodata section and similar sections, but it was disconnected from the ROMABLE
region into which the subsequent sections are being integrated, resulting in place-
ment of those sections right behind the previous section in the ROMABLE region
and therefore at addresses below the __rodata_region_start marker.

For the sake of consistent behaviour, the end marker of the text region
has been modified accordingly.

Signed-off-by: Immo Birnbaum <Immo.Birnbaum@weidmueller.com>