### PR TITLE
doc: reference: api: overview: note that the CAN API was changed in v3.0

### DIFF
--- a/doc/reference/api/overview.rst
+++ b/doc/reference/api/overview.rst
@@ -50,7 +50,7 @@ current :ref:`stability level <api_lifecycle>`.
    * - :ref:`can_api`
      - Unstable
      - 1.14
-     - 2.6
+     - 3.0
 
    * - :ref:`counter_api`
      - Unstable


### PR DESCRIPTION
Update the API overview documentation to note that the CAN API was changed for the upcoming Zephyr v3.0 release.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>