### PR TITLE
boards: stm32f769i_disc0: add touchscreen support

### DIFF
--- a/boards/arm/stm32f769i_disco/Kconfig.defconfig
+++ b/boards/arm/stm32f769i_disco/Kconfig.defconfig
@@ -12,6 +12,12 @@ config SPI_STM32_INTERRUPT
 	default y
 	depends on SPI
 
+config I2C
+	default y if KSCAN
+
+config KSCAN_FT5336
+	default y if KSCAN
+
 if NETWORKING
 
 config NET_L2_ETHERNET

--- a/boards/arm/stm32f769i_disco/doc/index.rst
+++ b/boards/arm/stm32f769i_disco/doc/index.rst
@@ -118,6 +118,10 @@ The Zephyr stm32f769i_disco board configuration supports the following hardware 
 +-----------+------------+-------------------------------------+
 | QSPI NOR  | on-chip    | flash                               |
 +-----------+------------+-------------------------------------+
+| FMC       | on-chip    | memc (SDRAM)                        |
++-----------+------------+-------------------------------------+
+| TOUCH     | off-chip   | ft5336(FT6202)                      |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on Zephyr porting.
 
@@ -138,6 +142,7 @@ Default Zephyr Peripheral Mapping:
 - UART_1 TX/RX : PA9/PA10 (ST-Link Virtual Port Com)
 - UART_6 TX/RX : PC6/PC7 (Arduino Serial)
 - I2C1 SCL/SDA : PB8/PB9 (Arduino I2C)
+- I2C4 SCL/SDA : PD12/PB7 (Touchscreen FT6202, PI13 Interrupt Pin)
 - SPI2 SCK/MISO/MOSI : PA12/PB14/PB15 (Arduino SPI)
 - ETH : PA1, PA2, PA7, PC1, PC4, PC5, PG11, PG13, PG14
 - LD1 : PJ13

--- a/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
+++ b/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
@@ -63,6 +63,7 @@
 		led2 = &green_led_3;
 		led3 = &red_led_4;
 		sw0 = &user_button;
+		kscan0 = &touch_controller;
 	};
 };
 
@@ -111,6 +112,20 @@ arduino_serial: &usart6 {};
 	pinctrl-names = "default";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+};
+
+&i2c4 {
+	pinctrl-0 = <&i2c4_scl_pd12 &i2c4_sda_pb7>;
+	pinctrl-names = "default";
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_FAST>;
+
+	touch_controller: ft6202@2a {
+		compatible = "focaltech,ft5336";
+		reg = <0x2a>;
+		label = "FT6202";
+		int-gpios = <&gpioi 13 0>;
+	};
 };
 
 &spi2 {

--- a/boards/arm/stm32f769i_disco/stm32f769i_disco.yaml
+++ b/boards/arm/stm32f769i_disco/stm32f769i_disco.yaml
@@ -17,3 +17,4 @@ supported:
   - arduino_gpio
   - netif:eth
   - memc
+  - kscan:touch


### PR DESCRIPTION
Add support for the touchscreen controller on STM32F769I-DISC0(MB1166).
The touchscreen uses Focaltech FT6202 which is compatible with FT5336.
Tested with kscan_touch sample application.

Signed-off-by: Konstantinos Papadopoulos <kostas.papadopulos@gmail.com>