### PR TITLE
arch: arm: aarch32: USE_SWITCH support for Cortex-A/-R

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -34,8 +34,10 @@ config ARM
 	# is really only necessary for Cortex-M with ARM MPU!
 	select GEN_PRIV_STACKS
 	select ARCH_HAS_THREAD_LOCAL_STORAGE if CPU_CORTEX_R || CPU_CORTEX_M
+	select USE_SWITCH_SUPPORTED if CPU_AARCH32_CORTEX_A
+	select SWAP_NONATOMIC if USE_SWITCH
 	help
-	  ARM architecture
+	  ARM (AArch32) architecture
 
 config ARM64
 	bool

--- a/arch/arm/core/aarch32/cortex_a_r/exc_exit.S
+++ b/arch/arm/core/aarch32/cortex_a_r/exc_exit.S
@@ -93,10 +93,25 @@ SECTION_SUBSEC_FUNC(TEXT, _HandlerModeExit, z_arm_int_exit)
 	cmp r0, #1
 	bhi __EXIT_INT
 
+#if defined(CONFIG_USE_SWITCH)
+	sub sp, sp, #0x4
+	mov r0, sp
+	bl z_arch_get_next_switch_handle
+	ldr r1, [sp]
+	add sp, sp, #0x4
+	cmp r0, r1
+	beq __EXIT_INT
+
+	push {r0-r1}
+	bl z_arm_pendsv
+	pop {r0-r1}
+#else
 	ldr r1, [r3, #_kernel_offset_to_current]
 	ldr r0, [r3, #_kernel_offset_to_ready_q_cache]
 	cmp r0, r1
 	blne z_arm_pendsv
+#endif /* CONFIG_USE_SWITCH */
+
 __EXIT_INT:
 #endif /* CONFIG_PREEMPT_ENABLED */
 
@@ -183,7 +198,19 @@ SECTION_SUBSEC_FUNC(TEXT, _HandlerModeExit, z_arm_exc_exit)
 	 * caller using lr_svc.
 	 */
 	cps #MODE_SVC
+#if defined(CONFIG_USE_SWITCH)
+	sub sp, sp, #0x4
+	mov r0, sp
+	bl z_arch_get_next_switch_handle
+	ldr r1, [sp]
+	add sp, sp, #0x4
+
+	push {r0-r1}
 	bl z_arm_pendsv
+	pop {r0-r1}
+#else
+	bl z_arm_pendsv
+#endif
 
 	/* Decrement exception nesting count */
 	ldr r3, =_kernel

--- a/arch/arm/core/aarch32/swap.c
+++ b/arch/arm/core/aarch32/swap.c
@@ -30,6 +30,7 @@ extern const int _k_neg_eagain;
  * On ARMv6-M, the intlock key is represented by the PRIMASK register,
  * as BASEPRI is not available.
  */
+#if !defined(CONFIG_USE_SWITCH)
 int arch_swap(unsigned int key)
 {
 	/* store off key and return value */
@@ -52,3 +53,4 @@ int arch_swap(unsigned int key)
 	 */
 	return _current->arch.swap_return_value;
 }
+#endif /* !CONFIG_USE_SWITCH */

--- a/arch/arm/core/aarch32/swap_helper.S
+++ b/arch/arm/core/aarch32/swap_helper.S
@@ -71,9 +71,21 @@ SECTION_FUNC(TEXT, z_arm_pendsv)
 #endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
 #endif /* CONFIG_INSTRUMENT_THREAD_SWITCHING */
 
-    /* load _kernel into r1 and current k_thread into r2 */
+    /*
+     * load _kernel into r1 and current k_thread into r2
+     * Source of the current thread info:
+     * - from the top of the stack if CONFIG_USE_SWITCH is set
+     *   (value provided to arch_switch before triggering SVC) or
+     * - _kernel->current otherwise.
+     */
+
     ldr r1, =_kernel
+#if defined(CONFIG_USE_SWITCH)
+    /* Thread to switch out of is at [sp, #0x4] */
+    ldr r2, [sp, #0x4]
+#else
     ldr r2, [r1, #_kernel_offset_to_current]
+#endif
 
 #if defined(CONFIG_ARM_STORE_EXC_RETURN)
     /* Store LSB of LR (EXC_RETURN) to the thread's 'mode' word. */
@@ -159,10 +171,15 @@ out_fp_endif:
 
     /* _kernel is still in r1 */
 
+#if defined(CONFIG_USE_SWITCH)
+    /* Thread to switch to is at [sp] */
+    /* _current has already been updated by caller */
+    ldr r2, [sp]
+#else
     /* fetch the thread to run from the ready queue cache */
     ldr r2, [r1, #_kernel_offset_to_ready_q_cache]
-
     str r2, [r1, #_kernel_offset_to_current]
+#endif
 
     /*
      * Clear PendSV so that if another interrupt comes in and
@@ -346,9 +363,11 @@ in_fp_endif:
     ldmia r0, {v1-v8, ip}
 #elif defined(CONFIG_ARMV7_R) || defined(CONFIG_ARMV7_A)
 _thread_irq_disabled:
+#if !defined(CONFIG_USE_SWITCH)
     /* load _kernel into r1 and current k_thread into r2 */
     ldr r1, =_kernel
     ldr r2, [r1, #_kernel_offset_to_current]
+#endif /* _kernel already in r1, current already in r2 with USE_SWITCH set */
 
     /* addr of callee-saved regs in thread in r0 */
     ldr r0, =_thread_offset_to_callee_saved
@@ -706,9 +725,22 @@ demux:
 #endif
 
 _context_switch:
+#if defined(CONFIG_USE_SWITCH)
+    cps #MODE_SYS
+    /*
+     * The two parameters of arch_switch are the last two words that
+     * have been pushed onto the SYS mode's stack.
+     */
+    ldr r0, [sp]       /* switch_to */
+    ldr r1, [sp, #0x4] /* switch_from* */
+    cps #MODE_SVC
+    push {r0-r1}
+#endif
     /* handler mode exit, to PendSV */
     bl z_arm_pendsv
-
+#if defined(CONFIG_USE_SWITCH)
+    pop {r0-r1}
+#endif
     b z_arm_int_exit
 
 _oops:

--- a/arch/arm/core/aarch32/thread.c
+++ b/arch/arm/core/aarch32/thread.c
@@ -129,11 +129,23 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	thread->arch.priv_stack_start = 0;
 #endif
 #endif
+
+#if defined(CONFIG_USE_SWITCH)
+	thread->switch_handle = (void *)thread;
+#endif
 	/*
 	 * initial values in all other registers/thread entries are
 	 * irrelevant.
 	 */
 }
+
+#if defined(CONFIG_USE_SWITCH)
+void *z_arch_get_next_switch_handle(struct k_thread **old_thread)
+{
+	*old_thread = _current;
+	return z_get_next_switch_handle(*old_thread);
+}
+#endif
 
 #if defined(CONFIG_MPU_STACK_GUARD) && defined(CONFIG_FPU) \
 	&& defined(CONFIG_FPU_SHARING)

--- a/arch/arm/include/aarch32/cortex_a_r/exc.h
+++ b/arch/arm/include/aarch32/cortex_a_r/exc.h
@@ -76,7 +76,11 @@ static ALWAYS_INLINE void z_arm_clear_faults(void)
 {
 }
 
+#if !defined(CONFIG_USE_SWITCH)
 extern void z_arm_cortex_r_svc(void);
+#else
+extern void z_arm_cortex_r_svc(void *switch_to, void **switched_from);
+#endif /* !CONFIG_USE_SWITCH */
 
 #ifdef __cplusplus
 }

--- a/arch/arm/include/aarch32/kernel_arch_func.h
+++ b/arch/arm/include/aarch32/kernel_arch_func.h
@@ -61,11 +61,28 @@ static ALWAYS_INLINE void arch_kernel_init(void)
 #endif /* CONFIG_ARM_AARCH32_MMU */
 }
 
+#if !defined(CONFIG_USE_SWITCH)
+/*
+ * When CONFIG_USE_SWITCH is set, this function is already provided in
+ * kernel/include/kernel_internal.h.
+ */
 static ALWAYS_INLINE void
 arch_thread_return_value_set(struct k_thread *thread, unsigned int value)
 {
 	thread->arch.swap_return_value = value;
 }
+#endif
+
+#if defined(CONFIG_USE_SWITCH) \
+	&& (defined(CONFIG_CPU_CORTEX_R) || defined(CONFIG_CPU_AARCH32_CORTEX_A))
+static inline void arch_switch(void *switch_to, void **switched_from)
+{
+	void *switched_from_thread = CONTAINER_OF(switched_from, struct k_thread,
+						  switch_handle);
+
+	z_arm_cortex_r_svc(switch_to, switched_from_thread);
+}
+#endif
 
 #if !defined(CONFIG_MULTITHREADING) && defined(CONFIG_CPU_CORTEX_M)
 extern FUNC_NORETURN void z_arm_switch_to_main_no_multithreading(

--- a/boards/arm/qemu_cortex_a9/Kconfig.defconfig
+++ b/boards/arm/qemu_cortex_a9/Kconfig.defconfig
@@ -20,6 +20,9 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config SYS_CLOCK_TICKS_PER_SEC
 	default 1000
 
+config USE_SWITCH
+	default y
+
 if CONSOLE
 
 	config UART_CONSOLE

--- a/kernel/idle.c
+++ b/kernel/idle.c
@@ -87,7 +87,7 @@ void idle(void *unused1, void *unused2, void *unused3)
 #endif
 
 #if !defined(CONFIG_PREEMPT_ENABLED)
-# if !defined(CONFIG_USE_SWITCH) || defined(CONFIG_SPARC)
+# if !defined(CONFIG_USE_SWITCH) || defined(CONFIG_SPARC) || defined(CONFIG_ARM)
 		/* A legacy mess: the idle thread is by definition
 		 * preemptible as far as the modern scheduler is
 		 * concerned, but older platforms use


### PR DESCRIPTION
This PR introduces support for CONFIG_USE_SWITCH on non-Cortex-M aarch32 CPUs as a pre-condition for SMP support.

Tested on actual Zynq hardware targets and with the twister kernel testsuite on qemu_cortex_a9.
At the time being, USE_SWITCH_SUPPORTED is only set for Cortex-A CPUs as this is the type of CPU I could best test this implementation on. CPU-related ifdefs in the code always consider Cortex-R as well.