### PR TITLE
lib/os: Add sys_winstream lockless shared memory byte stream IPC

### DIFF
--- a/boards/xtensa/intel_adsp_cavs15/tools/adsplog.py
+++ b/boards/xtensa/intel_adsp_cavs15/tools/adsplog.py
@@ -1,12 +1,12 @@
 #!/usr/bin/python3
-#
-# Copyright (c) 2020 Intel Corporation
+# Copyright (c) 2021 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 import os
 import sys
 import time
 import mmap
+import struct
 
 # Log reader for the trace output buffer on a ADSP device.
 #
@@ -22,18 +22,8 @@ import mmap
 # "windows" starting at 512kb in the BAR which the DSP firmware can
 # map to 4k-aligned locations within its own address space.  By
 # protocol convention log output is an 8k region at window index 3.
-#
-# The 8k window is treated as an array of 64-byte "slots", each of
-# which is prefixed by a magic number, which should be 0x55aa for log
-# data, followed a 16 bit "ID" number, followed by a null-terminated
-# string in the final 60 bytes (or 60 non-null bytes of log data).
-# The DSP firmware will write sequential IDs into the buffer starting
-# from an ID of '1' in the 0th slot, and wrapping at the end.
 
 MAP_SIZE = 8192
-SLOT_SIZE = 64
-NUM_SLOTS = int(MAP_SIZE / SLOT_SIZE)
-SLOT_MAGIC = 0x55aa
 WIN_OFFSET = 0x80000
 WIN_IDX = 3
 WIN_SIZE = 0x20000
@@ -41,8 +31,6 @@ LOG_OFFSET = WIN_OFFSET + WIN_IDX * WIN_SIZE
 
 mem = None
 sys_devices = "/sys/bus/pci/devices"
-
-reset_logged = False
 
 for dev_addr in os.listdir(sys_devices):
     class_file = sys_devices + "/" + dev_addr + "/class"
@@ -75,163 +63,42 @@ if mem is None:
     sys.stderr.write("ERROR: No ADSP device found.\n")
     sys.exit(1)
 
-# Returns a tuple of (id, msg) if the slot is valid, or (-1, "") if
-# the slot does not contain firmware trace data
-def read_slot(slot, mem):
-    off = slot * SLOT_SIZE
+# This SHOULD be just "mem[start:start+length]", but slicing an mmap
+# array seems to be unreliable on one of my machines (python 3.6.9 on
+# Ubuntu 18.04).  Read out bytes individually.
+def read_mem(start, length):
+    return b''.join(mem[x].to_bytes(1, 'little') for x in range(start, start + length))
 
-    magic = (mem[off + 1] << 8) | mem[off]
-    sid = (mem[off + 3] << 8) | mem[off + 2]
+def read_hdr():
+    return struct.unpack("<IIII", read_mem(0, 16))
 
-    if magic != SLOT_MAGIC:
-        return (-1, "")
-
-    # This dance because indexing large variable-length slices of
-    # the mmap() array seems to produce garbage....
-    msgbytes = []
-    for i in range(4, SLOT_SIZE):
-        b = mem[off+i]
-        if b == 0:
-            break
-        msgbytes.append(b)
-    msg = bytearray(len(msgbytes))
-    for i, elem in enumerate(msgbytes):
-        msg[i] = elem
-
-    return (sid, msg.decode(encoding="utf-8", errors="ignore"))
-
-def read_hist(start_slot):
-    global reset_logged
-    id0, msg = read_slot(start_slot, mem)
-
-    # An invalid slot zero means no data has ever been placed in the
-    # trace buffer, which is likely a system reset condition.  Back
-    # off for one second, because continuing to read the buffer has
-    # been observed to hang the flash process (which I think can only
-    # be a hardware bug).
-    if start_slot == 0 and id0 < 0:
-        if not reset_logged:
-            sys.stdout.write("===\n=== [Invalid slot 0; ADSP Device Reset?]\n===\n")
-            sys.stdout.flush()
-        reset_logged = True
-        time.sleep(1)
-        return (0, 0, "")
-
-    reset_logged = False
-
-    # Start at zero and read forward to get the last data in the
-    # buffer.  We are always guaranteed that slot zero will contain
-    # valid data if any slot contains valid data.
-    last_id = id0
-    final_slot = start_slot
-    for i in range(start_slot + 1, NUM_SLOTS):
-        id, s = read_slot(i, mem)
-        if id != ((last_id + 1) & 0xffff):
-            break
-        msg += s
-        final_slot = i
-        last_id = id
-
-    final_id = last_id
-
-    # Now read backwards from the end to get the prefix blocks from
-    # the last wraparound
-    last_id = id0
-    for i in range(NUM_SLOTS - 1, final_slot, -1):
-        id, s = read_slot(i, mem)
-        if id < 0:
-            break
-
-        # Race protection: the other side might have clobbered the
-        # data after we read the ID, make sure it hasn't changed.
-        id_check = read_slot(i, mem)[0]
-        if id_check != id:
-            break
-
-        if ((id + 1) & 0xffff) == last_id:
-            msg = s + msg
-        last_id = id
-
-    # If we were unable to read forward from slot zero, but could read
-    # backward, then this is a wrapped buffer being currently updated
-    # into slot zero.  See comment below.
-    if final_slot == start_slot and last_id != id0:
-        return None
-
-    return ((final_slot + 1) % NUM_SLOTS, (final_id + 1) & 0xffff, msg)
-
-# Returns a tuple containing the next slot to expect data in, the ID
-# that slot should hold, and the full string history of trace data
-# from the buffer.  Start with slot zero (which is always part of the
-# current string if there is any data at all) and scan forward and
-# back to find the maximum extent.
-def trace_history():
-    # This loop is a race protection for the situation where the
-    # buffer has wrapped and new data is currently being placed into
-    # slot zero.  In those circumstances, slot zero will have a valid
-    # magic number but its sequence ID will not correlate with the
-    # previous and next slots.
-    ret = None
-    while ret is None:
-        ret = read_hist(0)
-        if ret is None:
-            ret = read_hist(1)
-    return ret
-
-
-# Loop, reading the next slot if it has new data.  Otherwise check the
-# full buffer and see if history is discontiguous (i.e. what is in the
-# buffer should be a proper suffix of what we have stored).  If it
-# doesn't match, then just print it (it's a reboot or a ring buffer
-# overrun).  If nothing has changed, then sleep a bit and keep
-# polling.
-def main():
-    next_slot, next_id, last_hist = trace_history()
-
-    # We only have one command line argument, to suppress the history
-    # dump at the start (so CI runs don't see e.g. a previous device
-    # state containing logs from another test, and get confused)
-    if len(sys.argv) < 2 or sys.argv[1] != "--no-history":
-        sys.stdout.write(last_hist)
-
+# Python implementation of the same algorithm in sys_winstream_read(),
+# see there for details.
+def winstream_read(last_seq):
     while True:
-        id, smsg = read_slot(next_slot, mem)
+        (wlen, start, end, seq) = read_hdr()
+        if seq == last_seq or start == end:
+            return (seq, "")
+        behind = seq - last_seq
+        if behind > ((end - start) % wlen):
+            return (seq, "")
+        copy = (end - behind) % wlen
+        suffix = min(behind, wlen - copy)
+        result = read_mem(16 + copy, suffix)
+        if suffix < behind:
+            result += read_mem(16, behind - suffix)
+        (wlen, start1, end, seq1) = read_hdr()
+        if start1 == start and seq1 == seq:
+            return (seq, result.decode("utf-8"))
 
-        if id == next_id:
-            next_slot = int((next_slot + 1) % NUM_SLOTS)
-            next_id = (id + 1) & 0xffff
-            last_hist += smsg
-            sys.stdout.write(smsg)
-        else:
-            slot2, id2, msg2 = trace_history()
+# Choose our last_seq based on whether to dump the pre-existing buffer
+(wlen, start, end, seq) = read_hdr()
+last_seq = seq
+if len(sys.argv) < 2 or sys.argv[1] != "--no-history":
+    last_seq -= (end - start) % wlen
 
-            # Device reset:
-            if slot2 == 0 and id2 == 0 and msg2 == "":
-                next_id = 1
-                next_slot = slot2
-                last_hist = ""
-
-            if not last_hist.endswith(msg2):
-                # On a mismatch, go back and check one last time to
-                # address the race where a new slot wasn't present
-                # just JUST THEN but is NOW.
-                id3, s3 = read_slot(next_slot, mem)
-                if id3 == next_id:
-                    next_slot = int((next_slot + 1) % NUM_SLOTS)
-                    next_id = (next_id + 1) & 0xffff
-                    last_hist += s3
-                    sys.stdout.write(s3)
-                    continue
-
-                # Otherwise it represents discontiguous data, either a
-                # reset of an overrun, just dump what we have and
-                # start over.
-                next_slot = slot2
-                last_hist = msg2
-                sys.stdout.write(msg2)
-            else:
-                sys.stdout.flush()
-                time.sleep(0.10)
-
-if __name__ == "__main__":
-    main()
+while True:
+    time.sleep(0.1)
+    (last_seq, output) = winstream_read(last_seq)
+    if output:
+        sys.stdout.write(output)

--- a/include/sys/winstream.h
+++ b/include/sys/winstream.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2021 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_SYS_WINSTREAM_H_
+#define ZEPHYR_INCLUDE_SYS_WINSTREAM_H_
+
+#include <stdint.h>
+
+/** @brief Lockless shared memory byte stream IPC
+ *
+ * The sys_winstream utility implements a unidirectional byte stream
+ * with simple read/write semantics on top of a memory region shared
+ * by the writer and reader.  It requires no locking or
+ * synchronization mechanisms beyond reliable ordering of memory
+ * operations, and so is a good fit for use with heterogenous shared
+ * memory environments (for example, where Zephyr needs to talk to
+ * other CPUs in the system running their own software).
+ */
+struct sys_winstream {
+	uint32_t len;   /* Length of data[] in bytes */
+	uint32_t start; /* Index of first valid byte in data[] */
+	uint32_t end;   /* Index of next byte in data[] to write */
+	uint32_t seq;   /* Mod-2^32 index of end since stream init */
+	uint8_t data[];
+};
+
+/** @brief Construct a sys_winstream from a region of memory
+ *
+ * This function initializes a sys_winstream in an arbitrarily-sized
+ * region of memory, returning the resulting object (which is
+ * guaranteed to be at the same address as the buffer).  The memory
+ * must (obviously) be shared between the reader and writer, and all
+ * operations to it must be coherent and consistently ordered.
+ *
+ * @param buf Pointer to a region of memory to contain the stream
+ * @param buflen Length of the buffer, must be large enough to contain
+ *               the struct sys_winstream and at least one byte of
+ *               data.
+ * @return A pointer to an initialized sys_winstream (same address as
+ *         the buf parameter).
+ */
+static inline struct sys_winstream *sys_winstream_init(void *buf, int buflen)
+{
+	struct sys_winstream *ws = buf, tmp = { .len = buflen - sizeof(*ws) };
+
+	*ws = tmp;
+	return ws;
+}
+
+/** @brief Write bytes to a sys_winstream
+ *
+ * This function writes the specified number of bytes into the stream.
+ * It will always return synchronously, it does not block or engage in
+ * any kind of synchronization beyond memory write ordering.  Any
+ * bytes passed beyond what can be stored in the buffer will be
+ * silently dropped, but readers can detect their presence via the
+ * sequence number.
+ *
+ * @param ws A sys_winstream to which to write
+ * @param data Pointer to bytes to be written
+ * @param len Number of bytes to write
+ */
+void sys_winstream_write(struct sys_winstream *ws,
+			 const char *data, uint32_t len);
+
+/** @brief Read bytes from a sys_winstream
+ *
+ * This function will read bytes from a sys_winstream into a specified
+ * buffer.  It will always return in constant time, it does not block
+ * or engage in any kind of synchronization beyond memory ordering.
+ * The number of bytes read into the buffer will be returned, but note
+ * that it is possible that an underflow can occur if the writer gets
+ * ahead of our context.  That situation can be detected via the
+ * sequence number returned via a pointer (i.e. if "*seq != old_seq +
+ * return_value", an underflow occurred and bytes were dropped).
+ *
+ * @param ws A sys_winstream from which to read
+ * @param seq A pointer to an integer containing the last sequence
+ *            number read from the stream, or zero to indicate "start
+ *            of stream".  The current state of the stream will be
+ *            returned in the pointer for use in future calls.
+ * @param buf A buffer into which to store the data read
+ * @param buflen The length of buf in bytes
+ * @return The number of bytes written into the buffer
+ */
+uint32_t sys_winstream_read(struct sys_winstream *ws,
+			    uint32_t *seq, char *buf, uint32_t buflen);
+
+#endif /* ZEPHYR_INCLUDE_SYS_WINSTREAM_H_ */

--- a/lib/os/CMakeLists.txt
+++ b/lib/os/CMakeLists.txt
@@ -51,6 +51,8 @@ zephyr_sources_ifdef(CONFIG_UTF8 utf8.c)
 
 zephyr_sources_ifdef(CONFIG_SYS_MEM_BLOCKS mem_blocks.c)
 
+zephyr_sources_ifdef(CONFIG_WINSTREAM winstream.c)
+
 zephyr_library_include_directories(
   ${ZEPHYR_BASE}/kernel/include
   ${ZEPHYR_BASE}/arch/${ARCH}/include

--- a/lib/os/Kconfig
+++ b/lib/os/Kconfig
@@ -38,6 +38,31 @@ config MPSC_PBUF
 	  storing variable length packets in a circular way and operate directly
 	  on the buffer memory.
 
+config SHARED_MULTI_HEAP
+	bool "Shared multi-heap manager"
+	help
+	  Enable support for a shared multi-heap manager that uses the
+	  multi-heap allocator to manage a set of reserved memory regions with
+	  different capabilities / attributes (cacheable, non-cacheable,
+	  etc...) defined in the DT.
+
+config WINSTREAM
+	bool "Lockless shared memory window byte stream"
+	help
+	  Winstream is a byte stream IPC for use in shared memory
+	  "windows", generally for transmit to non-Zephyr contexts that
+	  can't share Zephyr APIs or data structures.
+
+if WINSTREAM
+config WINSTREAM_STDLIB_MEMCOPY
+	bool "Use standard memcpy() in winstream"
+	help
+	  The sys_winstream utility is sometimes used in early boot
+	  environments before the standard library is usable.  By
+	  default it uses a simple internal bytewise memcpy().  Set
+	  this to use the one from the standard library.
+endif
+
 if MPSC_PBUF
 config MPSC_CLEAR_ALLOCATED
 	bool "Clear allocated packet"

--- a/lib/os/winstream.c
+++ b/lib/os/winstream.c
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2021 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <sys/util.h>
+#include <sys/winstream.h>
+
+/* This code may be used (e.g. for trace/logging) in very early
+ * environments where the standard library isn't available yet.
+ * Implement a simple memcpy() as an option.
+ */
+#ifndef CONFIG_WINSTREAM_STDLIB_MEMCOPY
+# define MEMCPY(dst, src, n) \
+	do { for (int i = 0; i < (n); i++) { (dst)[i] = (src)[i]; } } while (0)
+#else
+# define MEMCPY memcpy
+#endif
+
+/* These are just compiler barriers now.  Zephyr doesn't currently
+ * have a framework for hardware memory ordering, and all our targets
+ * (arm64 excepted) either promise firm ordering (x86) or are in-order
+ * cores (everything else).  But these are marked for future
+ * enhancement.
+ */
+#define READ_BARRIER()  __asm__ volatile("" ::: "memory")
+#define WRITE_BARRIER() __asm__ volatile("")
+
+static uint32_t idx_mod(struct sys_winstream *ws, uint32_t idx)
+{
+	return idx >= ws->len ? idx - ws->len : idx;
+}
+
+/* Computes modular a - b, assuming a and b are in [0:len) */
+static uint32_t idx_sub(struct sys_winstream *ws, uint32_t a, uint32_t b)
+{
+	return idx_mod(ws, a + (ws->len - b));
+}
+
+void sys_winstream_write(struct sys_winstream *ws,
+			 const char *data, uint32_t len)
+{
+	uint32_t len0 = len, suffix;
+	uint32_t start = ws->start, end = ws->end, seq = ws->seq;
+
+	/* Overflow: if we're truncating then just reset the buffer.
+	 * (Max bytes buffered is actually len-1 because start==end is
+	 * reserved to mean "empty")
+	 */
+	if (len > ws->len - 1) {
+		start = end;
+		len = ws->len - 1;
+	}
+
+	/* Make room in the buffer by advancing start first (note same
+	 * len-1 from above)
+	 */
+	len = MIN(len, ws->len);
+	if (seq != 0) {
+		uint32_t avail = (ws->len - 1) - idx_sub(ws, end, start);
+
+		if (len > avail) {
+			ws->start = idx_mod(ws, start + (len - avail));
+			WRITE_BARRIER();
+		}
+	}
+
+	/* Had to truncate? */
+	if (len < len0) {
+		ws->start = end;
+		data += len0 - len;
+	}
+
+	suffix = MIN(len, ws->len - end);
+	MEMCPY(&ws->data[end], data, suffix);
+	if (len > suffix) {
+		MEMCPY(&ws->data[0], data + suffix, len - suffix);
+	}
+
+	ws->end = idx_mod(ws, end + len);
+	ws->seq += len0; /* seq represents dropped bytes too! */
+	WRITE_BARRIER();
+}
+
+uint32_t sys_winstream_read(struct sys_winstream *ws,
+			    uint32_t *seq, char *buf, uint32_t buflen)
+{
+	uint32_t seq0 = *seq, start, end, wseq, len, behind, copy, suffix;
+
+	do {
+		start = ws->start; end = ws->end; wseq = ws->seq;
+		READ_BARRIER();
+
+		/* No change in buffer state or empty initial stream are easy */
+		if (*seq == wseq || start == end) {
+			*seq = wseq;
+			return 0;
+		}
+
+		/* Underflow: we're trying to read from a spot farther
+		 * back than start.  We dropped some bytes, so cheat
+		 * and just drop them all to catch up.
+		 */
+		behind = wseq - *seq;
+		if (behind > idx_sub(ws, ws->end, ws->start)) {
+			*seq = wseq;
+			return 0;
+		}
+
+		/* Copy data */
+		copy = idx_sub(ws, ws->end, behind);
+		len = MIN(buflen, behind);
+		suffix = MIN(len, ws->len - copy);
+		MEMCPY(buf, &ws->data[copy], suffix);
+		if (len > suffix) {
+			MEMCPY(buf + suffix, &ws->data[0], len - suffix);
+		}
+		*seq = seq0 + len;
+
+		/* Check vs. the state we initially read and repeat if
+		 * needed.  This can't loop forever even if the other
+		 * side is stuck spamming writes: we'll run out of
+		 * buffer space and exit via the underflow condition.
+		 */
+		READ_BARRIER();
+	} while (start != ws->start || wseq != ws->seq);
+
+	return len;
+}

--- a/soc/xtensa/intel_adsp/Kconfig
+++ b/soc/xtensa/intel_adsp/Kconfig
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config SOC_FAMILY_INTEL_ADSP
+	select WINSTREAM
 	bool
 
 if SOC_FAMILY_INTEL_ADSP

--- a/soc/xtensa/intel_adsp/common/boot.c
+++ b/soc/xtensa/intel_adsp/common/boot.c
@@ -66,6 +66,8 @@
 
 #define MANIFEST_SEGMENT_COUNT 3
 
+extern void soc_trace_init(void);
+
 /* Initial/true entry point.  Does nothing but jump to
  * z_boot_asm_entry (which cannot be here, because it needs to be able
  * to reference immediates which must link before it)
@@ -324,6 +326,7 @@ __imr void boot_core0(void)
 	win_setup();
 	lp_sram_init();
 	parse_manifest();
+	soc_trace_init();
 	z_xtensa_cache_flush_all();
 
 	/* Zephyr! */

--- a/soc/xtensa/intel_adsp/common/include/soc.h
+++ b/soc/xtensa/intel_adsp/common/include/soc.h
@@ -70,6 +70,7 @@
 #define __imr __in_section_unique(imr)
 #define __imrdata __in_section_unique(imrdata)
 
+extern void soc_trace_init(void);
 extern void z_soc_irq_enable(uint32_t irq);
 extern void z_soc_irq_disable(uint32_t irq);
 extern int z_soc_irq_is_enabled(unsigned int irq);

--- a/soc/xtensa/intel_adsp/common/trace_out.c
+++ b/soc/xtensa/intel_adsp/common/trace_out.c
@@ -1,72 +1,14 @@
-/*
- * Copyright (c) 2020 Intel Corporation
- *
+/* Copyright (c) 2021 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <zephyr.h>
 #include <soc.h>
 #include <cavs-mem.h>
+#include <sys/winstream.h>
 
-/* Simple output driver for the trace window of an ADSP device used
- * for communication with the host processor as a shared memory
- * region.  The protocol uses an array of 64-byte "slots", each of
- * which is prefixed by a 16 bit magic number followed by a sequential
- * ID number starting from 1.  The remaining bytes are a (potentially
- * nul-terminated) string containing output data.
- *
- * IMPORTANT NOTE on cache coherence: the shared memory window is in
- * HP-SRAM.  Each DSP core has an L1 cache that is incoherent (!) from
- * the perspective of the other cores.  To handle this, we take care
- * to access all memory through the uncached window into HP-SRAM at
- * 0x9xxxxxxx and not the L1-cached mapping of the same memory at
- * 0xBxxxxxxx.
- */
+struct k_spinlock trace_lock;
 
-#define SRAM_TRACE_BASE HP_SRAM_WIN3_BASE
-#define SRAM_TRACE_SIZE HP_SRAM_WIN3_SIZE
-
-#define SLOT_SIZE 64
-#define SLOT_MAGIC 0x55aa
-
-#define NSLOTS (SRAM_TRACE_SIZE / SLOT_SIZE)
-#define MSGSZ (SLOT_SIZE - sizeof(struct slot_hdr))
-
-struct slot_hdr {
-	uint16_t magic;
-	uint16_t id;
-};
-
-struct slot {
-	struct slot_hdr hdr;
-	char msg[MSGSZ];
-};
-
-struct metadata {
-	struct k_spinlock lock;
-	bool initialized;
-	uint32_t curr_slot;   /* To which slot are we writing? */
-	uint32_t n_bytes;     /* How many bytes buffered in curr_slot */
-};
-
-/* Give it a cache line all its own! */
-static __aligned(64) union {
-	struct metadata meta;
-	uint32_t cache_pad[16];
-} data_rec;
-
-#define data ((volatile struct metadata *)z_soc_uncached_ptr(&data_rec.meta))
-
-static inline struct slot *slot(int i)
-{
-	struct slot *slots = z_soc_uncached_ptr((void *)SRAM_TRACE_BASE);
-
-	return &slots[i];
-}
-
-static int slot_incr(int s)
-{
-	return (s + 1) % NSLOTS;
-}
+static struct sys_winstream *winstream;
 
 void intel_adsp_trace_out(int8_t *str, size_t len)
 {
@@ -84,62 +26,10 @@ void intel_adsp_trace_out(int8_t *str, size_t len)
 			 : "r"(a4), "r"(a5)  : "memory");
 #endif
 
-	k_spinlock_key_t key = k_spin_lock((void *)&data->lock);
+	k_spinlock_key_t key = k_spin_lock(&trace_lock);
 
-	if (!data->initialized) {
-		slot(0)->hdr.magic = 0;
-		slot(0)->hdr.id = 0;
-		data->curr_slot = data->n_bytes = 0;
-		data->initialized = 1;
-	}
-
-	/* We work with a local copy of the global data for
-	 * performance reasons (The memory behind the "data" pointer
-	 * is uncached and volatile!) and put it back at the end.
-	 */
-	uint32_t curr_slot = data->curr_slot;
-	uint32_t n_bytes = data->n_bytes;
-
-	for (size_t i = 0; i < len; i++) {
-		int8_t c = str[i];
-		struct slot *s = slot(curr_slot);
-
-		s->msg[n_bytes++] = c;
-
-		/* Are we done with this slot?  Terminate it and flag
-		 * it for consumption on the other side
-		 */
-		if (c == '\n' || n_bytes >= MSGSZ) {
-			if (n_bytes < MSGSZ) {
-				s->msg[n_bytes] = 0;
-			}
-
-			/* Make sure the next slot has a magic number
-			 * (so the reader can distinguish between
-			 * no-new-data and system-reset), but does NOT
-			 * have the correct successor ID (so can never
-			 * be picked up as valid data).  We'll
-			 * increment it later when we terminate that
-			 * slot.
-			 */
-			int next_slot = slot_incr(curr_slot);
-			uint16_t new_id = s->hdr.id + 1;
-
-			slot(next_slot)->hdr.id = new_id;
-			slot(next_slot)->hdr.magic = SLOT_MAGIC;
-			slot(next_slot)->msg[0] = 0;
-
-			s->hdr.id = new_id;
-			s->hdr.magic = SLOT_MAGIC;
-
-			curr_slot = next_slot;
-			n_bytes = 0;
-		}
-	}
-
-	data->curr_slot = curr_slot;
-	data->n_bytes = n_bytes;
-	k_spin_unlock((void *)&data->lock, key);
+	sys_winstream_write(winstream, str, len);
+	k_spin_unlock(&trace_lock, key);
 }
 
 int arch_printk_char_out(int c)
@@ -148,4 +38,11 @@ int arch_printk_char_out(int c)
 
 	intel_adsp_trace_out(&s, 1);
 	return 0;
+}
+
+void soc_trace_init(void)
+{
+	void *buf = z_soc_uncached_ptr((void *)HP_SRAM_WIN3_BASE);
+
+	winstream = sys_winstream_init(buf, HP_SRAM_WIN3_SIZE);
 }

--- a/tests/unit/winstream/CMakeLists.txt
+++ b/tests/unit/winstream/CMakeLists.txt
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+project(winstream)
+cmake_minimum_required(VERSION 3.20.0)
+set(SOURCES main.c)
+find_package(ZephyrUnittest REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/tests/unit/winstream/main.c
+++ b/tests/unit/winstream/main.c
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2021 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <ztest.h>
+#include <sys/winstream.h>
+
+/* This, uh, seems to be the standard way to unit test library code.
+ * Or so I gather from tests/unit/rbtree ...
+ */
+#include "../../../lib/os/winstream.c"
+
+#define BUFLEN 64
+
+const char *msg = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+char wsmem[BUFLEN + 1]; /* Extra 1 to have a null for easier debugging */
+
+void test_winstream(void)
+{
+	struct sys_winstream *ws = sys_winstream_init(wsmem, BUFLEN);
+
+	/* Write one byte */
+	sys_winstream_write(ws, "a", 1);
+
+	uint32_t seq = 0;
+	char c;
+
+	/* Read the byte back */
+	uint32_t bytes = sys_winstream_read(ws, &seq, &c, 1);
+
+	zassert_true(bytes == 1, "");
+	zassert_true(seq == 1, "");
+	zassert_true(c == 'a', "");
+
+	/* Read from an empty buffer */
+	bytes = sys_winstream_read(ws, &seq, &c, 1);
+	zassert_true(bytes == 0, "");
+	zassert_true(seq == 1, "");
+
+	/* Write an overflowing string */
+	sys_winstream_write(ws, msg, strlen(msg));
+	zassert_true(ws->seq == 1 + strlen(msg), "");
+	zassert_true(ws->start == 1, "");
+	zassert_true(ws->end == 0, "");
+
+	/* Read after underflow, verify empty string comes back with the
+	 * correct sequence number
+	 */
+	char readback[BUFLEN + 1];
+
+	memset(readback, 0, sizeof(readback));
+	bytes = sys_winstream_read(ws, &seq, readback, sizeof(readback));
+	zassert_true(seq == ws->seq, "");
+	zassert_true(bytes == 0, "");
+
+	/* Read back from empty buffer */
+	uint32_t seq0 = seq;
+
+	bytes = sys_winstream_read(ws, &seq, readback, sizeof(readback));
+	zassert_true(seq == seq0, "");
+	zassert_true(bytes == 0, "");
+
+	/* Write a "short-enough" string that fits in before the wrap,
+	 * then read it out
+	 */
+	seq0 = seq;
+	sys_winstream_write(ws, msg, ws->len / 2);
+	bytes = sys_winstream_read(ws, &seq, readback, sizeof(readback));
+	zassert_true(bytes == ws->len / 2, "");
+	zassert_true(seq == seq0 + ws->len / 2, "");
+	zassert_true(strncmp(readback, msg, ws->len / 2) == 0, "");
+
+	/* Do it again, this time it will need to wrap around the buffer */
+	memset(readback, 0, sizeof(readback));
+	seq0 = seq;
+	sys_winstream_write(ws, msg, ws->len / 2);
+	bytes = sys_winstream_read(ws, &seq, readback, sizeof(readback));
+	zassert_true(bytes == ws->len / 2, "");
+	zassert_true(seq == seq0 + ws->len / 2, "");
+	zassert_true(strncmp(readback, msg, ws->len / 2) == 0, "");
+
+	/* Finally loop with a relatively prime (actually prime prime)
+	 * buffer size to stress for edges.
+	 */
+	int n = 13;
+	char msg2[13];
+
+	for (int i = 0; i < (n + 1) * (ws->len + 1); i++) {
+		memset(msg2, 'A' + (i % 26), n);
+		seq0 = seq;
+		memset(readback, 0, sizeof(readback));
+		sys_winstream_write(ws, msg2, n);
+		bytes = sys_winstream_read(ws, &seq, readback, sizeof(readback));
+		zassert_true(bytes == n, "");
+		zassert_true(seq == seq0 + n, "");
+		zassert_true(strncmp(readback, msg2, n) == 0, "");
+	}
+}
+
+void test_main(void)
+{
+	ztest_test_suite(test_winstream,
+			 ztest_unit_test(test_winstream)
+			 );
+	ztest_run_test_suite(test_winstream);
+}

--- a/tests/unit/winstream/testcase.yaml
+++ b/tests/unit/winstream/testcase.yaml
@@ -1,0 +1,4 @@
+tests:
+  utilities.winstream:
+    tags: winstream
+    type: unit


### PR DESCRIPTION
[Pull request adds the IPC mechanism, and also support for it as the default trace output in cAVS platforms]

It's not uncommon to have Zephyr running in environments where it shares a memory bus with a foreign/non-Zephyr system (both the older Intel Quark and cAVS audio DSP systems share this property).  In those circumstances, it would be nice to have a utility that allows an arbitrary-sized chunk of that memory to be used as a unidirectional buffered byte stream without requiring complicated driver support. sys_winstream is one such abstraction.

This code is lockless, it makes no synchronization demands of the OS or hardware beyond memory ordering[1].  It implements a simple file/socket-style read/write API.  It produces small code and is high performance (e.g. a read or write on Xtensa is about 60 cycles plus one per byte copied).  It's bidirectional, with no internal Zephyr dependencies (allowing it to be easily ported to the foreign system). And it's quite a bit simpler (especially for the reader) than the older cAVS trace protocol it's designed to replace.

[1] Which means that right now it won't work reliably on arm64 until we add a memory barrier framework to Zephyr!  See notes in the code; the locations for the barriers are present, but there's no utility to call. 