### PR TITLE
net: sockets_tls: Reset mbedtls session on handshake errors

### DIFF
--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -918,7 +918,9 @@ static int tls_mbedtls_handshake(struct tls_context *context, bool block)
 
 	while ((ret = mbedtls_ssl_handshake(&context->ssl)) != 0) {
 		if (ret == MBEDTLS_ERR_SSL_WANT_READ ||
-		    ret == MBEDTLS_ERR_SSL_WANT_WRITE) {
+		    ret == MBEDTLS_ERR_SSL_WANT_WRITE ||
+		    ret == MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS ||
+		    ret == MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS) {
 			if (block) {
 				continue;
 			}
@@ -945,9 +947,20 @@ static int tls_mbedtls_handshake(struct tls_context *context, bool block)
 				ret = -ETIMEDOUT;
 				break;
 			}
+		} else {
+			/* MbedTLS API documentation requires session to
+			 * be reset in other error cases
+			 */
+			NET_ERR("TLS handshake error: -%x", -ret);
+			ret = tls_mbedtls_reset(context);
+			if (ret == 0) {
+				ret = -ECONNABORTED;
+				break;
+			}
 		}
 
-		NET_ERR("TLS handshake error: -%x", -ret);
+		/* Avoid constant loop if tls_mbedtls_reset fails */
+		NET_ERR("TLS reset error: -%x", -ret);
 		ret = -ECONNABORTED;
 		break;
 	}


### PR DESCRIPTION
According to MbedTLS API documentation, its session must be reset if mbedtls_ssl_handshake returns something other than:
 - 0
 - MBEDTLS_ERR_SSL_WANT_READ
 - MBEDTLS_ERR_SSL_WANT_WRITE
 - MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS
 - MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS

In MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS and MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS cases the function must be called
again when operation is ready. These cases now return -EAGIN or continue to retry if it's a blocking call.

From mbedtls_ssl_handshake function in [documentation](https://tls.mbed.org/api/ssl_8h.html):
> Warning
> If this function returns something other than 0, MBEDTLS_ERR_SSL_WANT_READ, MBEDTLS_ERR_SSL_WANT_WRITE, MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS or MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS, you must stop using the SSL context for reading or writing, and either free it or call mbedtls_ssl_session_reset() on it before re-using it for a new connection; the current connection must be closed.