### PR TITLE
doc: doxygen: generate and expose Doxygen tag file

### DIFF
--- a/doc/guides/docs/index.rst
+++ b/doc/guides/docs/index.rst
@@ -261,7 +261,21 @@ or invoke make with the following target::
    # To generate HTML output without detailed Kconfig
    make html-fast
 
+Linking external Doxygen projects against Zephyr
+************************************************
+
+External projects that build upon Zephyr functionality and wish to refer to
+Zephyr documentation in Doxygen (through the use of @ref), can utilize the
+tag file exported at `zephyr.tag </doxygen/html/zephyr.tag>`_
+
+Once downloaded, the tag file can be used in a custom ``doxyfile.in`` as follows::
+
+   TAGFILES = "/path/to/zephyr.tag=https://docs.zephyrproject.org/latest/doxygen/html/"
+
+For additional information refer to `Doxygen External Documentation`_.
+
 
 .. _reStructuredText: http://sphinx-doc.org/rest.html
 .. _Sphinx: http://sphinx-doc.org/
 .. _Windows Python Path: https://docs.python.org/3/using/windows.html#finding-the-python-executable
+.. _Doxygen External Documentation: https://www.doxygen.nl/manual/external.html

--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -2348,7 +2348,7 @@ TAGFILES               =
 # tag file that is based on the input files it reads. See section "Linking to
 # external documentation" for more information about the usage of tag files.
 
-GENERATE_TAGFILE       =
+GENERATE_TAGFILE       = @DOXY_OUT@/html/zephyr.tag
 
 # If the ALLEXTERNALS tag is set to YES, all external class will be listed in
 # the class index. If set to NO, only the inherited external classes will be


### PR DESCRIPTION
Generate the doxygen tag file when building documentation and expose it on the website for external projects to link against.
See https://www.doxygen.nl/manual/external.html

Implements #41529