### PR TITLE
[Backport v2.7-branch] drivers: can: change can_tx_callback_t function signature

### DIFF
--- a/doc/reference/networking/can_api.rst
+++ b/doc/reference/networking/can_api.rst
@@ -177,12 +177,12 @@ occurred. It does not block until the message is sent like the example above.
 
 .. code-block:: C
 
-  void tx_irq_callback(uint32_t error_flags, void *arg)
+  void tx_irq_callback(int error, void *arg)
   {
           char *sender = (char *)arg;
 
-          if (error_flags) {
-                  LOG_ERR("Sendig failed [%d]\nSender: %s\n", error_flags, sender);
+          if (error != 0) {
+                  LOG_ERR("Sendig failed [%d]\nSender: %s\n", error, sender);
           }
   }
 

--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -56,7 +56,7 @@ static const uint8_t reg_demand[] = {2, 1, 4, 2};
 static void can_stm32_signal_tx_complete(struct can_mailbox *mb)
 {
 	if (mb->tx_callback) {
-		mb->tx_callback(mb->error_flags, mb->callback_arg);
+		mb->tx_callback(mb->error, mb->callback_arg);
 	} else  {
 		k_sem_give(&mb->tx_int_sem);
 	}
@@ -151,7 +151,7 @@ void can_stm32_tx_isr_handler(CAN_TypeDef *can, struct can_stm32_data *data)
 	bus_off = can->ESR & CAN_ESR_BOFF;
 
 	if ((can->TSR & CAN_TSR_RQCP0) | bus_off) {
-		data->mb0.error_flags =
+		data->mb0.error =
 				can->TSR & CAN_TSR_TXOK0 ? CAN_TX_OK  :
 				can->TSR & CAN_TSR_TERR0 ? CAN_TX_ERR :
 				can->TSR & CAN_TSR_ALST0 ? CAN_TX_ARB_LOST :
@@ -163,7 +163,7 @@ void can_stm32_tx_isr_handler(CAN_TypeDef *can, struct can_stm32_data *data)
 	}
 
 	if ((can->TSR & CAN_TSR_RQCP1) | bus_off) {
-		data->mb1.error_flags =
+		data->mb1.error =
 				can->TSR & CAN_TSR_TXOK1 ? CAN_TX_OK  :
 				can->TSR & CAN_TSR_TERR1 ? CAN_TX_ERR :
 				can->TSR & CAN_TSR_ALST1 ? CAN_TX_ARB_LOST :
@@ -175,7 +175,7 @@ void can_stm32_tx_isr_handler(CAN_TypeDef *can, struct can_stm32_data *data)
 	}
 
 	if ((can->TSR & CAN_TSR_RQCP2) | bus_off) {
-		data->mb2.error_flags =
+		data->mb2.error =
 				can->TSR & CAN_TSR_TXOK2 ? CAN_TX_OK  :
 				can->TSR & CAN_TSR_TERR2 ? CAN_TX_ERR :
 				can->TSR & CAN_TSR_ALST2 ? CAN_TX_ARB_LOST :
@@ -688,7 +688,7 @@ int can_stm32_send(const struct device *dev, const struct zcan_frame *msg,
 
 	if (callback == NULL) {
 		k_sem_take(&mb->tx_int_sem, K_FOREVER);
-		return mb->error_flags;
+		return mb->error;
 	}
 
 	return 0;

--- a/drivers/can/can_stm32.h
+++ b/drivers/can/can_stm32.h
@@ -43,7 +43,7 @@ struct can_mailbox {
 	can_tx_callback_t tx_callback;
 	void *callback_arg;
 	struct k_sem tx_int_sem;
-	uint32_t error_flags;
+	int error;
 };
 
 

--- a/drivers/can/socket_can_generic.h
+++ b/drivers/can/socket_can_generic.h
@@ -45,12 +45,12 @@ static inline void socket_can_iface_init(struct net_if *iface)
 	LOG_DBG("Init CAN interface %p dev %p", iface, dev);
 }
 
-static inline void tx_irq_callback(uint32_t error_flags, void *arg)
+static inline void tx_irq_callback(int error, void *arg)
 {
 	char *caller_str = (char *)arg;
-	if (error_flags) {
+	if (error != 0) {
 		LOG_DBG("TX error from %s! error-code: %d",
-			caller_str, error_flags);
+			caller_str, error);
 	}
 }
 

--- a/include/drivers/can.h
+++ b/include/drivers/can.h
@@ -302,10 +302,10 @@ struct can_timing {
  * @typedef can_tx_callback_t
  * @brief Define the application callback handler function signature
  *
- * @param error_flags status of the performed send operation
+ * @param error status of the performed send operation
  * @param arg argument that was passed when the message was sent
  */
-typedef void (*can_tx_callback_t)(uint32_t error_flags, void *arg);
+typedef void (*can_tx_callback_t)(int error, void *arg);
 
 /**
  * @typedef can_rx_callback_t

--- a/modules/canopennode/CO_driver.c
+++ b/modules/canopennode/CO_driver.c
@@ -94,7 +94,7 @@ static void canopen_rx_isr_callback(struct zcan_frame *msg, void *arg)
 	buffer->pFunct(buffer->object, &rxMsg);
 }
 
-static void canopen_tx_isr_callback(uint32_t error_flags, void *arg)
+static void canopen_tx_isr_callback(int error, void *arg)
 {
 	CO_CANmodule_t *CANmodule = arg;
 
@@ -103,7 +103,7 @@ static void canopen_tx_isr_callback(uint32_t error_flags, void *arg)
 		return;
 	}
 
-	if (error_flags == CAN_TX_OK) {
+	if (error == CAN_TX_OK) {
 		CANmodule->first_tx_msg = false;
 	}
 

--- a/samples/drivers/can/src/main.c
+++ b/samples/drivers/can/src/main.c
@@ -37,13 +37,13 @@ struct can_bus_err_cnt current_err_cnt;
 
 CAN_DEFINE_MSGQ(counter_msgq, 2);
 
-void tx_irq_callback(uint32_t error_flags, void *arg)
+void tx_irq_callback(int error, void *arg)
 {
 	char *sender = (char *)arg;
 
-	if (error_flags) {
+	if (error != 0) {
 		printk("Callback! error-code: %d\nSender: %s\n",
-		       error_flags, sender);
+		       error, sender);
 	}
 }
 

--- a/subsys/canbus/isotp/isotp.c
+++ b/subsys/canbus/isotp/isotp.c
@@ -87,12 +87,12 @@ static inline void receive_report_error(struct isotp_recv_ctx *ctx, int err)
 	ctx->error_nr = err;
 }
 
-void receive_can_tx_isr(uint32_t err_flags, void *arg)
+void receive_can_tx_isr(int error, void *arg)
 {
 	struct isotp_recv_ctx *ctx = (struct isotp_recv_ctx *)arg;
 
-	if (err_flags) {
-		LOG_ERR("Error sending FC frame (%d)", err_flags);
+	if (error != 0) {
+		LOG_ERR("Error sending FC frame (%d)", error);
 		receive_report_error(ctx, ISOTP_N_ERROR);
 		k_work_submit(&ctx->work);
 	}
@@ -756,7 +756,7 @@ static inline void send_report_error(struct isotp_send_ctx *ctx, uint32_t err)
 	ctx->error_nr = err;
 }
 
-static void send_can_tx_isr(uint32_t err_flags, void *arg)
+static void send_can_tx_isr(int error, void *arg)
 {
 	struct isotp_send_ctx *ctx = (struct isotp_send_ctx *)arg;
 

--- a/subsys/net/l2/canbus/6locan.c
+++ b/subsys/net/l2/canbus/6locan.c
@@ -430,10 +430,10 @@ static void canbus_set_frame_addr_pkt(struct zcan_frame *frame,
 	canbus_set_frame_addr(frame, dest_addr, &src_addr, mcast);
 }
 
-static void canbus_fc_send_cb(uint32_t err_flags, void *arg)
+static void canbus_fc_send_cb(int error, void *arg)
 {
-	if (err_flags) {
-		NET_ERR("Sending FC frame failed: %d", err_flags);
+	if (error != 0) {
+		NET_ERR("Sending FC frame failed: %d", error);
 	}
 }
 
@@ -688,7 +688,7 @@ static enum net_verdict canbus_process_sf(struct net_pkt *pkt)
 	return canbus_finish_pkt(pkt);
 }
 
-static void canbus_tx_frame_isr(uint32_t err_flags, void *arg)
+static void canbus_tx_frame_isr(int error, void *arg)
 {
 	struct net_pkt *pkt = (struct net_pkt *)arg;
 	struct canbus_isotp_tx_ctx *ctx = pkt->canbus_tx_ctx;
@@ -1528,14 +1528,14 @@ static inline int canbus_send_dad_request(const struct device *net_can_dev,
 	return 0;
 }
 
-static void canbus_send_dad_resp_cb(uint32_t err_flags, void *cb_arg)
+static void canbus_send_dad_resp_cb(int error, void *cb_arg)
 {
 	static uint8_t fail_cnt;
 	struct k_work *work = (struct k_work *)cb_arg;
 
-	if (err_flags) {
-		NET_ERR("Failed to send dad response [%u]", err_flags);
-		if (err_flags != CAN_TX_BUS_OFF &&
+	if (error != 0) {
+		NET_ERR("Failed to send dad response [%u]", error);
+		if (error != CAN_TX_BUS_OFF &&
 		    fail_cnt < NET_CAN_DAD_SEND_RETRY) {
 			k_work_submit_to_queue(&net_canbus_workq, work);
 		}

--- a/tests/drivers/can/api/src/main.c
+++ b/tests/drivers/can/api/src/main.c
@@ -185,7 +185,7 @@ static inline void check_msg(const struct zcan_frame *msg1,
 	zassert_equal(cmp_res, 0, "Received data differ");
 }
 
-static void tx_std_isr_1(uint32_t error_flags, void *arg)
+static void tx_std_isr_1(int error, void *arg)
 {
 	const struct zcan_frame *msg = (const struct zcan_frame *)arg;
 
@@ -194,7 +194,7 @@ static void tx_std_isr_1(uint32_t error_flags, void *arg)
 	zassert_equal(msg->id, TEST_CAN_STD_ID_1, "Arg does not match");
 }
 
-static void tx_std_isr_2(uint32_t error_flags, void *arg)
+static void tx_std_isr_2(int error, void *arg)
 {
 	const struct zcan_frame *msg = (const struct zcan_frame *)arg;
 
@@ -203,7 +203,7 @@ static void tx_std_isr_2(uint32_t error_flags, void *arg)
 	zassert_equal(msg->id, TEST_CAN_STD_ID_2, "Arg does not match");
 }
 
-static void tx_ext_isr_1(uint32_t error_flags, void *arg)
+static void tx_ext_isr_1(int error, void *arg)
 {
 	const struct zcan_frame *msg = (const struct zcan_frame *)arg;
 
@@ -212,7 +212,7 @@ static void tx_ext_isr_1(uint32_t error_flags, void *arg)
 	zassert_equal(msg->id, TEST_CAN_EXT_ID_1, "Arg does not match");
 }
 
-static void tx_ext_isr_2(uint32_t error_flags, void *arg)
+static void tx_ext_isr_2(int error, void *arg)
 {
 	const struct zcan_frame *msg = (const struct zcan_frame *)arg;
 

--- a/tests/drivers/can/canfd/src/main.c
+++ b/tests/drivers/can/canfd/src/main.c
@@ -123,7 +123,7 @@ static inline void check_msg(const struct zcan_frame *msg1,
 	zassert_equal(cmp_res, 0, "Received data differ");
 }
 
-static void tx_std_isr_1(uint32_t error_flags, void *arg)
+static void tx_std_isr_1(int error, void *arg)
 {
 	const struct zcan_frame *msg = (const struct zcan_frame *)arg;
 
@@ -132,7 +132,7 @@ static void tx_std_isr_1(uint32_t error_flags, void *arg)
 	zassert_equal(msg->id, TEST_CAN_STD_ID_1, "Arg does not match");
 }
 
-static void tx_std_isr_2(uint32_t error_flags, void *arg)
+static void tx_std_isr_2(int error, void *arg)
 {
 	const struct zcan_frame *msg = (const struct zcan_frame *)arg;
 


### PR DESCRIPTION
Backport b1b77c177404b53537a284b1dc1606d1fc8da8be from #41481 

Fixes: #41522 