### PR TITLE
lib: os: mpsc_pbuf: Add const to mpsc_pbuf_free argument

### DIFF
--- a/include/sys/mpsc_pbuf.h
+++ b/include/sys/mpsc_pbuf.h
@@ -226,7 +226,7 @@ const union mpsc_pbuf_generic *mpsc_pbuf_claim(struct mpsc_pbuf_buffer *buffer);
  * @param packet Packet.
  */
 void mpsc_pbuf_free(struct mpsc_pbuf_buffer *buffer,
-		    union mpsc_pbuf_generic *packet);
+		    const union mpsc_pbuf_generic *packet);
 
 /** @brief Check if there are any message pending.
  *

--- a/lib/os/mpsc_pbuf.c
+++ b/lib/os/mpsc_pbuf.c
@@ -432,18 +432,19 @@ const union mpsc_pbuf_generic *mpsc_pbuf_claim(struct mpsc_pbuf_buffer *buffer)
 }
 
 void mpsc_pbuf_free(struct mpsc_pbuf_buffer *buffer,
-		     union mpsc_pbuf_generic *item)
+		     const union mpsc_pbuf_generic *item)
 {
 	uint32_t wlen = buffer->get_wlen(item);
 	k_spinlock_key_t key = k_spin_lock(&buffer->lock);
+	union mpsc_pbuf_generic *witem = (union mpsc_pbuf_generic *)item;
 
-	item->hdr.valid = 0;
+	witem->hdr.valid = 0;
 	if (!(buffer->flags & MPSC_PBUF_MODE_OVERWRITE) ||
 		 ((uint32_t *)item == &buffer->buf[buffer->rd_idx])) {
-		item->hdr.busy = 0;
+		witem->hdr.busy = 0;
 		buffer->rd_idx = idx_inc(buffer, buffer->rd_idx, wlen);
 	} else {
-		item->skip.len = wlen;
+		witem->skip.len = wlen;
 	}
 	MPSC_PBUF_DBG(buffer, "freed: %p ", item);
 


### PR DESCRIPTION
#38779 added const qualifiers to mpsc_pbuf api. After this change `mpsc_pbuf_claim` returns const variable which is later on freed using `mpsc_pbuf_free` which was missing const qualifier. Added const qualifier to argument in a function.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>