### PR TITLE
lib: os: mpsc_pbuf: Use flag for buffer full indication

### DIFF
--- a/include/sys/mpsc_pbuf.h
+++ b/include/sys/mpsc_pbuf.h
@@ -58,6 +58,9 @@ extern "C" {
  */
 #define MPSC_PBUF_MODE_OVERWRITE BIT(1)
 
+/** @brief Flag indicated that buffer is currently full. */
+#define MPSC_PBUF_FULL BIT(2)
+
 /**@} */
 
 /* Forward declaration */

--- a/lib/os/mpsc_pbuf.c
+++ b/lib/os/mpsc_pbuf.c
@@ -46,33 +46,50 @@ void mpsc_pbuf_init(struct mpsc_pbuf_buffer *buffer,
 	__ASSERT_NO_MSG(err == 0);
 }
 
+/* Calculate free space available or till end of buffer.
+ *
+ * @param buffer Buffer.
+ * @param[out] res Destination where free space is written.
+ *
+ * @retval true when space was calculated until end of buffer (and there might
+ * be more space available after wrapping.
+ * @retval false When result is total free space.
+ */
 static inline bool free_space(struct mpsc_pbuf_buffer *buffer, uint32_t *res)
 {
-	if (buffer->rd_idx > buffer->tmp_wr_idx) {
-		*res =  buffer->rd_idx - buffer->tmp_wr_idx - 1;
-
-		return false;
-	} else if (!buffer->rd_idx) {
-		*res = buffer->size - buffer->tmp_wr_idx - 1;
+	if (buffer->flags & MPSC_PBUF_FULL) {
+		*res = 0;
 		return false;
 	}
 
+	if (buffer->rd_idx > buffer->tmp_wr_idx) {
+		*res =  buffer->rd_idx - buffer->tmp_wr_idx;
+		return false;
+	}
 	*res = buffer->size - buffer->tmp_wr_idx;
 
 	return true;
 }
 
+/* Get amount of valid data.
+ *
+ * @param buffer Buffer.
+ * @param[out] res Destination where available space is written.
+ *
+ * @retval true when space was calculated until end of buffer (and there might
+ * be more space available after wrapping.
+ * @retval false When result is total free space.
+ */
 static inline bool available(struct mpsc_pbuf_buffer *buffer, uint32_t *res)
 {
-	if (buffer->tmp_rd_idx <= buffer->wr_idx) {
-		*res = (buffer->wr_idx - buffer->tmp_rd_idx);
-
-		return false;
+	if (buffer->flags & MPSC_PBUF_FULL || buffer->tmp_rd_idx > buffer->wr_idx) {
+		*res = buffer->size - buffer->tmp_rd_idx;
+		return true;
 	}
 
-	*res = buffer->size - buffer->tmp_rd_idx;
+	*res = (buffer->wr_idx - buffer->tmp_rd_idx);
 
-	return true;
+	return false;
 }
 
 static inline bool is_valid(union mpsc_pbuf_generic *item)
@@ -106,6 +123,21 @@ static inline uint32_t get_skip(union mpsc_pbuf_generic *item)
 	return 0;
 }
 
+
+static ALWAYS_INLINE void tmp_wr_idx_inc(struct mpsc_pbuf_buffer *buffer, uint32_t wlen)
+{
+	buffer->tmp_wr_idx = idx_inc(buffer, buffer->tmp_wr_idx, wlen);
+	if (buffer->tmp_wr_idx == buffer->rd_idx) {
+		buffer->flags |= MPSC_PBUF_FULL;
+	}
+}
+
+static void rd_idx_inc(struct mpsc_pbuf_buffer *buffer, uint32_t wlen)
+{
+	buffer->rd_idx = idx_inc(buffer, buffer->rd_idx, wlen);
+	buffer->flags &= ~MPSC_PBUF_FULL;
+}
+
 static void add_skip_item(struct mpsc_pbuf_buffer *buffer, uint32_t wlen)
 {
 	union mpsc_pbuf_generic skip = {
@@ -113,7 +145,7 @@ static void add_skip_item(struct mpsc_pbuf_buffer *buffer, uint32_t wlen)
 	};
 
 	buffer->buf[buffer->tmp_wr_idx] = skip.raw;
-	buffer->tmp_wr_idx = idx_inc(buffer, buffer->tmp_wr_idx, wlen);
+	tmp_wr_idx_inc(buffer, wlen);
 	buffer->wr_idx = idx_inc(buffer, buffer->wr_idx, wlen);
 }
 
@@ -139,13 +171,17 @@ static union mpsc_pbuf_generic *drop_item_locked(struct mpsc_pbuf_buffer *buffer
 
 	rd_wlen = skip_wlen ? skip_wlen : buffer->get_wlen(item);
 	if (skip_wlen) {
+		MPSC_PBUF_DBG(NULL, "Skip packet found (len: %u)", skip_wlen);
 		allow_drop = true;
 	} else if (allow_drop) {
 		if (item->hdr.busy) {
+			MPSC_PBUF_DBG(NULL, "Busy user packet found");
 			/* item is currently processed and cannot be overwritten. */
-			add_skip_item(buffer, free_wlen + 1);
+			if (free_wlen) {
+				add_skip_item(buffer, free_wlen);
+			}
 			buffer->wr_idx = idx_inc(buffer, buffer->wr_idx, rd_wlen);
-			buffer->tmp_wr_idx = idx_inc(buffer, buffer->tmp_wr_idx, rd_wlen);
+			tmp_wr_idx_inc(buffer, rd_wlen);
 
 			/* Get next itme followed the busy one. */
 			uint32_t next_rd_idx = idx_inc(buffer, buffer->rd_idx, rd_wlen);
@@ -159,6 +195,7 @@ static union mpsc_pbuf_generic *drop_item_locked(struct mpsc_pbuf_buffer *buffer
 				*user_packet = true;
 			}
 		} else {
+			MPSC_PBUF_DBG(NULL, "User packet to drop (len %u)", rd_wlen);
 			*user_packet = true;
 		}
 	} else {
@@ -166,8 +203,9 @@ static union mpsc_pbuf_generic *drop_item_locked(struct mpsc_pbuf_buffer *buffer
 	}
 
 	if (allow_drop) {
-		buffer->rd_idx = idx_inc(buffer, buffer->rd_idx, rd_wlen);
+		rd_idx_inc(buffer, rd_wlen);
 		buffer->tmp_rd_idx = buffer->rd_idx;
+		MPSC_PBUF_DBG(buffer, "Incremented rd indexes after drop");
 	}
 
 	return item;
@@ -186,10 +224,12 @@ void mpsc_pbuf_put_word(struct mpsc_pbuf_buffer *buffer,
 		cont = false;
 		key = k_spin_lock(&buffer->lock);
 		(void)free_space(buffer, &free_wlen);
+
+		MPSC_PBUF_DBG(buffer, "put_word (%d free space)", (int)free_wlen);
+
 		if (free_wlen) {
 			buffer->buf[buffer->tmp_wr_idx] = item.raw;
-			buffer->tmp_wr_idx = idx_inc(buffer,
-						     buffer->tmp_wr_idx, 1);
+			tmp_wr_idx_inc(buffer, 1);
 			buffer->wr_idx = idx_inc(buffer, buffer->wr_idx, 1);
 		} else {
 			bool user_drop = buffer->flags & MPSC_PBUF_MODE_OVERWRITE;
@@ -220,8 +260,8 @@ union mpsc_pbuf_generic *mpsc_pbuf_alloc(struct mpsc_pbuf_buffer *buffer,
 
 	MPSC_PBUF_DBG(buffer, "alloc %d words", (int)wlen);
 
-	if (wlen > (buffer->size - 1)) {
-		MPSC_PBUF_DBG(buffer, "Failed to alloc, ");
+	if (wlen > (buffer->size)) {
+		MPSC_PBUF_DBG(buffer, "Failed to alloc");
 		return NULL;
 	}
 
@@ -238,8 +278,7 @@ union mpsc_pbuf_generic *mpsc_pbuf_alloc(struct mpsc_pbuf_buffer *buffer,
 			    (union mpsc_pbuf_generic *)&buffer->buf[buffer->tmp_wr_idx];
 			item->hdr.valid = 0;
 			item->hdr.busy = 0;
-			buffer->tmp_wr_idx = idx_inc(buffer,
-						     buffer->tmp_wr_idx, wlen);
+			tmp_wr_idx_inc(buffer, wlen);
 		} else if (wrap) {
 			add_skip_item(buffer, free_wlen);
 			cont = true;
@@ -318,8 +357,7 @@ void mpsc_pbuf_put_word_ext(struct mpsc_pbuf_buffer *buffer,
 				(void **)&buffer->buf[buffer->tmp_wr_idx + 1];
 
 			*p = (void *)data;
-			buffer->tmp_wr_idx =
-				idx_inc(buffer, buffer->tmp_wr_idx, l);
+			tmp_wr_idx_inc(buffer, l);
 			buffer->wr_idx = idx_inc(buffer, buffer->wr_idx, l);
 		} else if (wrap) {
 			add_skip_item(buffer, free_wlen);
@@ -361,9 +399,8 @@ void mpsc_pbuf_put_data(struct mpsc_pbuf_buffer *buffer, const uint32_t *data,
 		if (free_wlen >= wlen) {
 			memcpy(&buffer->buf[buffer->tmp_wr_idx], data,
 				wlen * sizeof(uint32_t));
-			buffer->tmp_wr_idx =
-				idx_inc(buffer, buffer->tmp_wr_idx, wlen);
 			buffer->wr_idx = idx_inc(buffer, buffer->wr_idx, wlen);
+			tmp_wr_idx_inc(buffer, wlen);
 		} else if (wrap) {
 			add_skip_item(buffer, free_wlen);
 			cont = true;
@@ -412,8 +449,7 @@ const union mpsc_pbuf_generic *mpsc_pbuf_claim(struct mpsc_pbuf_buffer *buffer)
 
 				buffer->tmp_rd_idx =
 				      idx_inc(buffer, buffer->tmp_rd_idx, inc);
-				buffer->rd_idx =
-					idx_inc(buffer, buffer->rd_idx, inc);
+				rd_idx_inc(buffer, inc);
 				cont = true;
 			} else {
 				item->hdr.busy = 1;
@@ -442,8 +478,9 @@ void mpsc_pbuf_free(struct mpsc_pbuf_buffer *buffer,
 	if (!(buffer->flags & MPSC_PBUF_MODE_OVERWRITE) ||
 		 ((uint32_t *)item == &buffer->buf[buffer->rd_idx])) {
 		item->hdr.busy = 0;
-		buffer->rd_idx = idx_inc(buffer, buffer->rd_idx, wlen);
+		rd_idx_inc(buffer, wlen);
 	} else {
+		MPSC_PBUF_DBG(buffer, "Allocation occurred during claim");
 		item->skip.len = wlen;
 	}
 	MPSC_PBUF_DBG(buffer, "freed: %p", item);

--- a/lib/os/mpsc_pbuf.c
+++ b/lib/os/mpsc_pbuf.c
@@ -5,6 +5,7 @@
  */
 #include <sys/mpsc_pbuf.h>
 
+/* Cannot use logging as mpsc_pbuf is part of it. */
 #define MPSC_PBUF_DEBUG 0
 
 #define MPSC_PBUF_DBG(buffer, ...) do { \
@@ -19,7 +20,7 @@
 static inline void mpsc_state_print(struct mpsc_pbuf_buffer *buffer)
 {
 	if (MPSC_PBUF_DEBUG) {
-		printk("wr:%d/%d, rd:%d/%d\n",
+		printk(", wr:%d/%d, rd:%d/%d\n",
 			buffer->wr_idx, buffer->tmp_wr_idx,
 			buffer->rd_idx, buffer->tmp_rd_idx);
 	}
@@ -217,7 +218,7 @@ union mpsc_pbuf_generic *mpsc_pbuf_alloc(struct mpsc_pbuf_buffer *buffer,
 	uint32_t free_wlen;
 	bool valid_drop;
 
-	MPSC_PBUF_DBG(buffer, "alloc %d words, ", (int)wlen);
+	MPSC_PBUF_DBG(buffer, "alloc %d words", (int)wlen);
 
 	if (wlen > (buffer->size - 1)) {
 		MPSC_PBUF_DBG(buffer, "Failed to alloc, ");
@@ -269,7 +270,7 @@ union mpsc_pbuf_generic *mpsc_pbuf_alloc(struct mpsc_pbuf_buffer *buffer,
 		}
 	} while (cont);
 
-	MPSC_PBUF_DBG(buffer, "allocated %p ", item);
+	MPSC_PBUF_DBG(buffer, "allocated %p", item);
 
 	if (IS_ENABLED(CONFIG_MPSC_CLEAR_ALLOCATED) && item) {
 		/* During test fill with 0's to simplify message comparison */
@@ -289,7 +290,7 @@ void mpsc_pbuf_commit(struct mpsc_pbuf_buffer *buffer,
 	item->hdr.valid = 1;
 	buffer->wr_idx = idx_inc(buffer, buffer->wr_idx, wlen);
 	k_spin_unlock(&buffer->lock, key);
-	MPSC_PBUF_DBG(buffer, "committed %p ", item);
+	MPSC_PBUF_DBG(buffer, "committed %p", item);
 }
 
 void mpsc_pbuf_put_word_ext(struct mpsc_pbuf_buffer *buffer,
@@ -423,7 +424,7 @@ const union mpsc_pbuf_generic *mpsc_pbuf_claim(struct mpsc_pbuf_buffer *buffer)
 		}
 
 		if (!cont) {
-			MPSC_PBUF_DBG(buffer, "claimed: %p ", item);
+			MPSC_PBUF_DBG(buffer, "claimed: %p", item);
 		}
 		k_spin_unlock(&buffer->lock, key);
 	} while (cont);
@@ -445,7 +446,7 @@ void mpsc_pbuf_free(struct mpsc_pbuf_buffer *buffer,
 	} else {
 		item->skip.len = wlen;
 	}
-	MPSC_PBUF_DBG(buffer, "freed: %p ", item);
+	MPSC_PBUF_DBG(buffer, "freed: %p", item);
 
 	k_spin_unlock(&buffer->lock, key);
 	k_sem_give(&buffer->sem);

--- a/tests/lib/mpsc_pbuf/src/main.c
+++ b/tests/lib/mpsc_pbuf/src/main.c
@@ -52,6 +52,7 @@ static uint32_t get_wlen(const union mpsc_pbuf_generic *item)
 }
 
 static uint32_t drop_cnt;
+static uint32_t exp_drop_cnt;
 static uintptr_t exp_dropped_data[10];
 static uint32_t exp_dropped_len[10];
 
@@ -59,8 +60,13 @@ static void drop(const struct mpsc_pbuf_buffer *buffer, const union mpsc_pbuf_ge
 {
 	struct test_data_var *packet = (struct test_data_var *)item;
 
-	zassert_equal(packet->hdr.data, exp_dropped_data[drop_cnt], NULL);
-	zassert_equal(packet->hdr.len, exp_dropped_len[drop_cnt], NULL);
+	zassert_true(drop_cnt < exp_drop_cnt, NULL);
+	zassert_equal(packet->hdr.len, exp_dropped_len[drop_cnt],
+			"(%d) Got:%08x, Expected: %08x",
+			drop_cnt, packet->hdr.len, exp_dropped_len[drop_cnt]);
+	zassert_equal(packet->hdr.data, exp_dropped_data[drop_cnt],
+			"(%d) Got:%08x, Expected: %08x",
+			drop_cnt, packet->hdr.data, exp_dropped_data[drop_cnt]);
 	for (int i = 0; i < exp_dropped_len[drop_cnt] - 1; i++) {
 		int err = memcmp(packet->data, &exp_dropped_data[drop_cnt],
 				 sizeof(uint32_t));
@@ -80,11 +86,12 @@ static struct mpsc_pbuf_buffer_config cfg = {
 	.get_wlen = get_wlen
 };
 
-static void init(struct mpsc_pbuf_buffer *buffer, bool overwrite, bool pow2)
+static void init(struct mpsc_pbuf_buffer *buffer, uint32_t wlen, bool overwrite)
 {
 	drop_cnt = 0;
+	exp_drop_cnt = 0;
 	cfg.flags = overwrite ? MPSC_PBUF_MODE_OVERWRITE : 0;
-	cfg.size = ARRAY_SIZE(buf32) - (pow2 ? 0 : 1);
+	cfg.size = wlen;
 	mpsc_pbuf_init(buffer, &cfg);
 
 #if CONFIG_SOC_SERIES_NRF52X
@@ -107,7 +114,7 @@ void item_put_no_overwrite(bool pow2)
 {
 	struct mpsc_pbuf_buffer buffer;
 
-	init(&buffer, false, pow2);
+	init(&buffer, 4 - !pow2, false);
 
 	int repeat = buffer.size*2;
 	union test_item test_1word = {.data = {.valid = 1, .len = 1 }};
@@ -138,19 +145,20 @@ void item_put_overwrite(bool pow2)
 {
 	struct mpsc_pbuf_buffer buffer;
 
-	init(&buffer, true, pow2);
+	init(&buffer, 4 - !pow2, true);
 
 	union test_item test_1word = {.data = {.valid = 1, .len = 1 }};
 
 	exp_dropped_data[0] = 0;
 	exp_dropped_len[0] = 1;
+	exp_drop_cnt = 1;
 
-	for (int i = 0; i < buffer.size; i++) {
+	for (int i = 0; i < buffer.size + 1; i++) {
 		test_1word.data.data = i;
 		mpsc_pbuf_put_word(&buffer, test_1word.item);
 	}
 
-	zassert_equal(drop_cnt, 1,
+	zassert_equal(drop_cnt, exp_drop_cnt,
 			"Unexpected number of dropped messages: %d", drop_cnt);
 }
 
@@ -164,7 +172,7 @@ void item_put_saturate(bool pow2)
 {
 	struct mpsc_pbuf_buffer buffer;
 
-	init(&buffer, false, pow2);
+	init(&buffer, 4 - !pow2, false);
 
 	int repeat = buffer.size;
 	union test_item test_1word = {.data = {.valid = 1, .len = 1 }};
@@ -172,7 +180,7 @@ void item_put_saturate(bool pow2)
 
 	zassert_false(mpsc_pbuf_is_pending(&buffer), NULL);
 
-	for (int i = 0; i < repeat/2; i++) {
+	for (int i = 0; i < repeat / 2; i++) {
 		test_1word.data.data = i;
 		mpsc_pbuf_put_word(&buffer, test_1word.item);
 
@@ -184,12 +192,12 @@ void item_put_saturate(bool pow2)
 		mpsc_pbuf_free(&buffer, &t->item);
 	}
 
-	for (int i = 0; i < repeat; i++) {
+	for (int i = 0; i < repeat + 1; i++) {
 		test_1word.data.data = i;
 		mpsc_pbuf_put_word(&buffer, test_1word.item);
 	}
 
-	for (int i = 0; i < (repeat-1); i++) {
+	for (int i = 0; i < repeat; i++) {
 		t = (union test_item *)mpsc_pbuf_claim(&buffer);
 		zassert_true(t, NULL);
 		zassert_equal(t->data.data, i, NULL);
@@ -209,7 +217,7 @@ void benchmark_item_put(bool pow2)
 {
 	struct mpsc_pbuf_buffer buffer;
 
-	init(&buffer, true, pow2);
+	init(&buffer, ARRAY_SIZE(buf32) - !pow2, true);
 
 	int repeat = buffer.size - 1;
 	union test_item test_1word = {.data = {.valid = 1, .len = 1 }};
@@ -250,7 +258,7 @@ void item_put_ext_no_overwrite(bool pow2)
 {
 	struct mpsc_pbuf_buffer buffer;
 
-	init(&buffer, false, pow2);
+	init(&buffer, 8 - !pow2, false);
 
 	int repeat = buffer.size * 2;
 	union test_item test_ext_item = {
@@ -288,10 +296,10 @@ void item_put_word_ext_overwrite(bool pow2)
 {
 	struct mpsc_pbuf_buffer buffer;
 
-	init(&buffer, true, pow2);
+	init(&buffer, 8 - !pow2, true);
 
 	size_t w = (sizeof(uint32_t) + sizeof(void *)) / sizeof(uint32_t);
-	int repeat = 1 + (buffer.size - 1) / w;
+	int repeat = 1 + buffer.size / w;
 	union test_item test_ext_item = {
 		.data = {
 			.valid = 1,
@@ -301,19 +309,16 @@ void item_put_word_ext_overwrite(bool pow2)
 
 	exp_dropped_data[0] = 0;
 	exp_dropped_len[0] = w;
-	exp_dropped_data[1] = 1;
-	exp_dropped_len[1] = w;
+	exp_drop_cnt = 1;
 
 	for (uintptr_t i = 0; i < repeat; i++) {
 		test_ext_item.data.data = i;
 		mpsc_pbuf_put_word_ext(&buffer, test_ext_item.item, (void *)i);
 	}
 
-	uint32_t exp_drop_cnt = (sizeof(void *) == sizeof(uint32_t)) ?
-				(pow2 ? 1 : 2) : 2;
-
 	zassert_equal(drop_cnt, exp_drop_cnt,
-			"Unexpected number of dropped messages: %d", drop_cnt);
+			"Unexpected number of dropped messages: %d (exp: %d)",
+			drop_cnt, exp_drop_cnt);
 }
 
 void test_item_put_word_ext_overwrite(void)
@@ -326,7 +331,7 @@ void item_put_ext_saturate(bool pow2)
 {
 	struct mpsc_pbuf_buffer buffer;
 
-	init(&buffer, false, pow2);
+	init(&buffer, 8 - !pow2, false);
 
 	int repeat = buffer.size / PUT_EXT_LEN;
 	union test_item test_ext_item = {
@@ -355,7 +360,7 @@ void item_put_ext_saturate(bool pow2)
 		mpsc_pbuf_put_word_ext(&buffer, test_ext_item.item, data);
 	}
 
-	for (uintptr_t i = 0; i < (repeat-1); i++) {
+	for (uintptr_t i = 0; i < repeat; i++) {
 		t = (union test_item *)mpsc_pbuf_claim(&buffer);
 		zassert_true(t, NULL);
 		zassert_equal(t->data_ext.data, (void *)i, NULL);
@@ -376,7 +381,7 @@ void benchmark_item_put_ext(bool pow2)
 {
 	struct mpsc_pbuf_buffer buffer;
 
-	init(&buffer, false, pow2);
+	init(&buffer, ARRAY_SIZE(buf32) - !pow2, false);
 
 	int repeat = (buffer.size - 1) / PUT_EXT_LEN;
 	union test_item test_ext_item = {
@@ -423,7 +428,7 @@ void benchmark_item_put_data(bool pow2)
 {
 	struct mpsc_pbuf_buffer buffer;
 
-	init(&buffer, false, pow2);
+	init(&buffer, ARRAY_SIZE(buf32) - !pow2, false);
 
 	int repeat = (buffer.size - 1) / PUT_EXT_LEN;
 	union test_item test_ext_item = {
@@ -474,10 +479,10 @@ void item_put_data_overwrite(bool pow2)
 {
 	struct mpsc_pbuf_buffer buffer;
 
-	init(&buffer, true, pow2);
+	init(&buffer, 8 - !pow2, true);
 
 	size_t w = (sizeof(uint32_t) + sizeof(void *)) / sizeof(uint32_t);
-	int repeat = 1 + (buffer.size - 1) / w;
+	int repeat = 1 + buffer.size / w;
 	static const int len = sizeof(struct test_data_ext) / sizeof(uint32_t);
 	struct test_data_ext item = {
 		.hdr = {
@@ -488,8 +493,7 @@ void item_put_data_overwrite(bool pow2)
 
 	exp_dropped_data[0] = 0;
 	exp_dropped_len[0] = w;
-	exp_dropped_data[1] = 1;
-	exp_dropped_len[1] = w;
+	exp_drop_cnt = 1;
 
 	for (uintptr_t i = 0; i < repeat; i++) {
 		void *vitem;
@@ -499,9 +503,6 @@ void item_put_data_overwrite(bool pow2)
 		zassert_true(IS_PTR_ALIGNED(vitem, uint32_t), "unaligned ptr");
 		mpsc_pbuf_put_data(&buffer, (uint32_t *)vitem, len);
 	}
-
-	uint32_t exp_drop_cnt = (sizeof(void *) == sizeof(uint32_t)) ?
-				(pow2 ? 1 : 2) : 2;
 
 	zassert_equal(drop_cnt, exp_drop_cnt,
 			"Unexpected number of dropped messages: %d", drop_cnt);
@@ -517,7 +518,7 @@ void item_alloc_commit(bool pow2)
 {
 	struct mpsc_pbuf_buffer buffer;
 
-	init(&buffer, false, pow2);
+	init(&buffer, 16 - !pow2, false);
 
 	struct test_data_var *packet;
 	uint32_t len = 5;
@@ -556,15 +557,15 @@ void item_max_alloc(bool overwrite)
 	struct mpsc_pbuf_buffer buffer;
 	struct test_data_var *packet;
 
-	init(&buffer, overwrite, true);
+	init(&buffer, 8, overwrite);
 
 	/* First try to allocate the biggest possible packet. */
 	for (int i = 0; i < 2; i++) {
 		packet = (struct test_data_var *)mpsc_pbuf_alloc(&buffer,
-								 buffer.size - 1,
+								 buffer.size,
 								 K_NO_WAIT);
 		zassert_true(packet != NULL, NULL);
-		packet->hdr.len = buffer.size - 1;
+		packet->hdr.len = buffer.size;
 		mpsc_pbuf_commit(&buffer, (union mpsc_pbuf_generic *)packet);
 
 		packet = (struct test_data_var *)mpsc_pbuf_claim(&buffer);
@@ -573,7 +574,7 @@ void item_max_alloc(bool overwrite)
 
 	/* Too big packet cannot be allocated. */
 	packet = (struct test_data_var *)mpsc_pbuf_alloc(&buffer,
-							 buffer.size,
+							 buffer.size + 1,
 							 K_NO_WAIT);
 	zassert_true(packet == NULL, NULL);
 }
@@ -588,10 +589,10 @@ static uint32_t saturate_buffer_uneven(struct mpsc_pbuf_buffer *buffer,
 					uint32_t len)
 {
 	struct test_data_var *packet;
-	uint32_t uneven = 5;
+	uint32_t uneven = 3;
 	uint32_t cnt = 0;
 	int repeat =
-		uneven - 1 + ((buffer->size - (uneven * len)) / len);
+		uneven + ((buffer->size - (uneven * len)) / len);
 
 	/* Put some data to include wrapping */
 	for (int i = 0; i < uneven; i++) {
@@ -626,7 +627,7 @@ void item_alloc_commit_saturate(bool pow2)
 {
 	struct mpsc_pbuf_buffer buffer;
 
-	init(&buffer, false, pow2);
+	init(&buffer, 32 - !pow2, false);
 
 	saturate_buffer_uneven(&buffer, 5);
 
@@ -658,7 +659,7 @@ void item_alloc_preemption(bool pow2)
 {
 	struct mpsc_pbuf_buffer buffer;
 
-	init(&buffer, false, pow2);
+	init(&buffer, ARRAY_SIZE(buf32) - !pow2, false);
 
 	struct test_data_var *p0;
 	struct test_data_var *p1;
@@ -717,17 +718,24 @@ void overwrite(bool pow2)
 	uint32_t len0, len1;
 	struct mpsc_pbuf_buffer buffer;
 
-	init(&buffer, true, pow2);
+	init(&buffer, 32 - !pow2, true);
 	uint32_t packet_cnt = saturate_buffer_uneven(&buffer, fill_len);
+
+	zassert_equal(drop_cnt, exp_drop_cnt, NULL);
 
 	exp_dropped_data[0] = 0;
 	exp_dropped_len[0] = fill_len;
+	exp_drop_cnt++;
+	exp_dropped_data[1] = 1;
+	exp_dropped_len[1] = fill_len;
+	exp_drop_cnt++;
+
 	len0 = 6;
 	p = (struct test_data_var *)mpsc_pbuf_alloc(&buffer, len0, K_NO_WAIT);
 
 	p->hdr.len = len0;
 	mpsc_pbuf_commit(&buffer, (union mpsc_pbuf_generic *)p);
-	zassert_equal(drop_cnt, 1, NULL);
+	zassert_equal(drop_cnt, exp_drop_cnt, NULL);
 
 	/* Request allocation which will require dropping 2 packets. */
 	len1 = 9;
@@ -735,12 +743,13 @@ void overwrite(bool pow2)
 	exp_dropped_len[1] = fill_len;
 	exp_dropped_data[2] = 2;
 	exp_dropped_len[2] = fill_len;
+	exp_drop_cnt = 3;
 
 	p = (struct test_data_var *)mpsc_pbuf_alloc(&buffer, len1, K_NO_WAIT);
 
 	p->hdr.len = len1;
 	mpsc_pbuf_commit(&buffer, (union mpsc_pbuf_generic *)p);
-	zassert_equal(drop_cnt, 3, NULL);
+	zassert_equal(drop_cnt, exp_drop_cnt, NULL);
 
 	for (int i = 0; i < (packet_cnt - drop_cnt); i++) {
 		p = (struct test_data_var *)mpsc_pbuf_claim(&buffer);
@@ -780,7 +789,7 @@ void overwrite_while_claimed(bool pow2)
 	struct test_data_var *p1;
 	struct mpsc_pbuf_buffer buffer;
 
-	init(&buffer, true, pow2);
+	init(&buffer, 32 - !pow2, true);
 
 	uint32_t fill_len = 5;
 	uint32_t len = 6;
@@ -797,9 +806,10 @@ void overwrite_while_claimed(bool pow2)
 	exp_dropped_len[0] = fill_len;
 	exp_dropped_data[1] = p0->hdr.data + 2; /* next packet is dropped */
 	exp_dropped_len[1] = fill_len;
+	exp_drop_cnt = 2;
 	p1 = (struct test_data_var *)mpsc_pbuf_alloc(&buffer, 6, K_NO_WAIT);
 
-	zassert_equal(drop_cnt, 2, NULL);
+	zassert_equal(drop_cnt, exp_drop_cnt, NULL);
 	p1->hdr.len = len;
 	mpsc_pbuf_commit(&buffer, (union mpsc_pbuf_generic *)p1);
 
@@ -833,7 +843,7 @@ void overwrite_while_claimed2(bool pow2)
 	struct test_data_var *p1;
 	struct mpsc_pbuf_buffer buffer;
 
-	init(&buffer, true, pow2);
+	init(&buffer, 32 - !pow2, true);
 
 	uint32_t fill_len = 1;
 	uint32_t len = 3;
@@ -852,11 +862,10 @@ void overwrite_while_claimed2(bool pow2)
 	exp_dropped_len[1] = fill_len;
 	exp_dropped_data[2] = p0->hdr.data + 3; /* next packet is dropped */
 	exp_dropped_len[2] = fill_len;
-	exp_dropped_data[3] = p0->hdr.data + 4; /* next packet is dropped */
-	exp_dropped_len[3] = fill_len;
+	exp_drop_cnt = 3;
 	p1 = (struct test_data_var *)mpsc_pbuf_alloc(&buffer, len, K_NO_WAIT);
 
-	zassert_equal(drop_cnt, 4, NULL);
+	zassert_equal(drop_cnt, exp_drop_cnt, NULL);
 	p1->hdr.len = len;
 	mpsc_pbuf_commit(&buffer, (union mpsc_pbuf_generic *)p1);
 
@@ -880,8 +889,8 @@ void overwrite_while_claimed2(bool pow2)
 
 void test_overwrite_while_claimed2(void)
 {
-		overwrite_while_claimed2(true);
-		overwrite_while_claimed2(false);
+	overwrite_while_claimed2(true);
+	overwrite_while_claimed2(false);
 }
 
 static uintptr_t current_rd_idx;
@@ -934,7 +943,7 @@ void test_overwrite_consistency(void)
 			}
 		}
 
-		uint32_t wr_cnt = rand_get(1, 200);
+		uint32_t wr_cnt = rand_get(1, 15);
 
 		for (int i = 0; i < wr_cnt; i++) {
 			uint32_t wlen = rand_get(1, 15);
@@ -1021,7 +1030,7 @@ void start_threads(struct mpsc_pbuf_buffer *buffer)
 		k_ticks_t exp_wait = k_ms_to_ticks_ceil32(wait_ms);
 
 		/* Threads shall be blocked, waiting for available space. */
-		zassert_within(t, exp_wait, k_ms_to_ticks_ceil32(2), NULL);
+		zassert_within(t, exp_wait, k_ms_to_ticks_ceil32(20), NULL);
 	}
 }
 
@@ -1037,7 +1046,7 @@ void test_pending_alloc(void)
 
 	k_thread_priority_set(k_current_get(), 3);
 
-	init(&buffer, true, false);
+	init(&buffer, ARRAY_SIZE(buf32) - 1, true);
 
 	uint32_t fill_len = 1;
 	uint32_t packet_cnt = saturate_buffer_uneven(&buffer, fill_len);

--- a/tests/subsys/logging/log_api/src/test.inc
+++ b/tests/subsys/logging/log_api/src/test.inc
@@ -306,7 +306,7 @@ static size_t get_long_hexdump(void)
 	if (IS_ENABLED(CONFIG_LOG2)) {
 		return CONFIG_LOG_BUFFER_SIZE -
 			/* First message */
-			ROUND_UP(LOG2_SIMPLE_MSG_LEN + 2 * sizeof(int) + STR_SIZE("test %d"),
+			ROUND_UP(LOG2_SIMPLE_MSG_LEN + sizeof(int) + STR_SIZE("test %d"),
 				 sizeof(long long)) -
 			/* Hexdump message excluding data */
 			ROUND_UP(LOG2_SIMPLE_MSG_LEN + STR_SIZE("hexdump"),
@@ -531,10 +531,9 @@ static void test_log_from_declared_module(void)
 static size_t get_short_msg_capacity(bool *remainder)
 {
 	if (IS_ENABLED(CONFIG_LOG2)) {
-		*remainder = (CONFIG_LOG_BUFFER_SIZE % LOG2_SIMPLE_MSG_LEN) ?
-				true : false;
+		*remainder = false;
 
-		return (CONFIG_LOG_BUFFER_SIZE - sizeof(int)) / LOG2_SIMPLE_MSG_LEN;
+		return CONFIG_LOG_BUFFER_SIZE / LOG2_SIMPLE_MSG_LEN;
 	}
 
 	*remainder = (CONFIG_LOG_BUFFER_SIZE % sizeof(struct log_msg)) ?


### PR DESCRIPTION
Use flag instead of word in the buffer. Using this method allows to dedicate full buffer capacity for data.

Changed driven by request in https://github.com/zephyrproject-rtos/zephyr/issues/38268#issuecomment-917130719

It is extracted from #38777 to split changes into smaller pieces as original PR got stuck with no reviews for much too long.