### PR TITLE
GATT long write improvement

### DIFF
--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -98,6 +98,14 @@ enum {
 	 * response) which doesn't generate any response.
 	 */
 	BT_GATT_WRITE_FLAG_CMD = BIT(1),
+
+	/** @brief Attribute write execute flag
+	 *
+	 * If set, indicates that write operation is a execute, which indicates
+	 * the end of a long write, and will come after 1 or more
+	 * @ref BT_GATT_WRITE_FLAG_PREPARE.
+	 */
+	BT_GATT_WRITE_FLAG_EXECUTE = BIT(2),
 };
 
 /** @brief GATT Attribute structure. */

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -1666,6 +1666,8 @@ static uint8_t write_cb(const struct bt_gatt_attr *attr, uint16_t handle,
 	/* Set command flag if not a request */
 	if (!data->req) {
 		flags |= BT_GATT_WRITE_FLAG_CMD;
+	} else if (data->req == BT_ATT_OP_EXEC_WRITE_REQ) {
+		flags |= BT_GATT_WRITE_FLAG_EXECUTE;
 	}
 
 	/* Write attribute value */


### PR DESCRIPTION
This PR improves how GATT long writes are handled on the server. 

The current implementation makes it near-impossible for an application to determine if the data provided to the GATT write callback is the last segment of a long write, which is needed to properly decode it (depending on the characteristic). 

fixes https://github.com/zephyrproject-rtos/zephyr/issues/34459

This solution requires a reassembly buffer to hold the maximum length writable to a GATT characteristic. 
An alternative, and less memory hungry, solution could be to instead of reassembling the data for the application, we only provide a flag for the last segment, and let the application do the reassembly. I'm open for changing the solution if reviewers so do desire. 

With the current solution (reassembly), the `BT_GATT_WRITE_FLAG_EXECUTE` could be considered optional, and the commit could be removed if reviewers desire. 