### PR TITLE
doc: update requirements

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -124,64 +124,27 @@ hr,
     border-color: var(--admonition-attention-title-background-color) !important;
     color: var(--admonition-attention-color) !important;
 }
-.rst-content dl:not(.docutils).class dt,
-.rst-content dl:not(.docutils).function dt,
-.rst-content dl:not(.docutils).method dt,
-.rst-content dl:not(.docutils).attribute dt {
-    width: 100% !important;
-}
-.rst-content dl:not(.docutils).class > dt,
-.rst-content dl:not(.docutils).function > dt,
-.rst-content dl:not(.docutils).method > dt,
-.rst-content dl:not(.docutils).attribute > dt {
-    font-size: 100% !important;
-    font-weight: normal !important;
-    margin-bottom: 16px !important;
-    padding: 6px 8px !important;
-}
-.rst-content dl:not(.docutils) tt.descclassname,
-.rst-content dl:not(.docutils) code.descclassname {
-    color: var(--highlight-type2-color) !important;
-    font-weight: normal !important;
-}
-.rst-content dl:not(.docutils) tt.descname,
-.rst-content dl:not(.docutils) code.descname {
-    color: var(--highlight-function-color) !important;
-    font-weight: normal !important;
-}
-.rst-content dl:not(.docutils) .sig-paren,
-.rst-content dl:not(.docutils) .optional {
-    color: var(--highlight-operator-color) !important;
-    font-weight: normal !important;
-    padding: 0 2px !important;
-}
-.rst-content dl:not(.docutils) .optional {
-    font-style: italic !important;
-}
-.rst-content dl:not(.docutils) .sig-param,
-.rst-content dl:not(.docutils).class dt > em,
-.rst-content dl:not(.docutils).function dt > em,
-.rst-content dl:not(.docutils).method dt > em {
-    color: var(--code-literal-color) !important;
+
+.rst-content dt.sig .k {
+    color: var(--highlight-keyword2-color) !important;
     font-style: normal !important;
-    padding: 0 4px !important;
 }
-.rst-content dl:not(.docutils) .sig-param,
-.rst-content dl:not(.docutils).class dt > code,
-.rst-content dl:not(.docutils).function dt > code,
-.rst-content dl:not(.docutils).method dt > code {
-    padding: 0 4px !important;
-}
-.rst-content dl:not(.docutils) .sig-param,
-.rst-content dl:not(.docutils).class dt > .optional ~ em,
-.rst-content dl:not(.docutils).function dt > .optional ~ em,
-.rst-content dl:not(.docutils).method dt > .optional ~ em {
-    color: var(--highlight-number-color) !important;
-    font-style: italic !important;
-}
-.rst-content dl:not(.docutils).class dt > em.property {
+
+.rst-content dt.sig .kt {
     color: var(--highlight-keyword-color) !important;
+    font-style: normal !important;
 }
+
+.rst-content dt.sig .sig-name .n {
+    color: var(--highlight-function-color) !important;
+}
+
+.rst-content dt.sig .k,
+.rst-content dt.sig .kt,
+.rst-content dt.sig .n {
+    font-weight: normal !important;
+}
+
 .rst-content dl:not(.docutils) dt a.headerlink {
     color: var(--link-color) !important;
 }
@@ -880,16 +843,8 @@ kbd, .kbd {
 
 /* Breathe tweaks */
 
-.rst-content dl.group>dt, .rst-content dl.group>dd>p {
-    display:none !important;
-}
-
-.rst-content dl.group {
-    margin: 0 0 1rem 0;
-}
-
-.rst-content dl.group>dd {
-    margin-left: 0 !important;
+.rst-content .section > dl > dd {
+    margin-left: 0;
 }
 
 .rst-content p.breathe-sectiondef-title {
@@ -897,22 +852,10 @@ kbd, .kbd {
     color: var(--link-color);
 }
 
-.rst-content div.breathe-sectiondef {
-    padding-left: 0 !important;
-}
-
 .rst-content dl:not(.docutils) dl:not(.rst-other-versions) dt {
     background: var(--admonition-note-background-color) !important;
     border-top: none !important;
     border-left: none !important;
-}
-
-.rst-content dl:not(.docutils).c.var .pre {
-  padding-right: 4px;
-}
-
-.rst-content dl:not(.docutils).c.struct .property {
-  padding-right: 4px !important;
 }
 
 /* Misc tweaks */

--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -1,12 +1,12 @@
 # DOC: used to generate docs
 
-breathe~=4.23,!=4.29.0
-sphinx~=3.3
-sphinx_rtd_theme>=0.5.2,<1.0
+breathe>=4.30
+sphinx~=4.0
+sphinx_rtd_theme~=1.0
 sphinx-tabs
 sphinxcontrib-svg2pdfconverter
-pygments~=2.9
-sphinx-notfound-page>=0.6
+pygments>=2.9
+sphinx-notfound-page
 
 # YAML validation. Used by zephyr_module.
 PyYAML>=5.1


### PR DESCRIPTION
- breathe: for simplicity, require versions > 4.30 (lower versions have
known issues, so do not take risks).
- Sphinx: start requiring versions >=4.x. Keep with compatible versions,
since Sphinx major updates can easily break extensions, themes, etc.
- sphinx_rtd_theme: upgrade to >=1.x. Again, keep with compatible versions
since we have style customizations that can likely break on major
upgrades.
- pygments: Allow any version >=2.9 (version that introduced DT support).
We do not have strong compatibility requirements here.
- sphinx-notfound-page: Remove any requirements, we do not have strong
requirements for this one.

Some necessary stylesheet changes have also been done (note that style is similar to the current one, but with subtle differences since the HTML structure for code directives has changed).