### PR TITLE
soc: remove unnecessary devicetree.h header inclusion

### DIFF
--- a/include/arch/arm/aarch32/cortex_m/nvic.h
+++ b/include/arch/arm/aarch32/cortex_m/nvic.h
@@ -7,6 +7,8 @@
 #ifndef ZEPHYR_INCLUDE_ARCH_ARM_AARCH32_CORTEX_M_NVIC_H_
 #define ZEPHYR_INCLUDE_ARCH_ARM_AARCH32_CORTEX_M_NVIC_H_
 
+#include <devicetree.h>
+
 #if defined(CONFIG_ARMV8_1_M_MAINLINE)
 /* The order here is on purpose since ARMv8.1-M SoCs may define
  * CONFIG_ARMV6_M_ARMV8_M_BASELINE, CONFIG_ARMV7_M_ARMV8_M_MAINLINE or

--- a/soc/arm/arm/beetle/soc.h
+++ b/soc/arm/arm/beetle/soc.h
@@ -95,8 +95,6 @@
 
 #ifndef _ASMLANGUAGE
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
 
 #include "soc_pins.h"
 #include "soc_power.h"

--- a/soc/arm/arm/designstart/soc.h
+++ b/soc/arm/arm/designstart/soc.h
@@ -7,7 +7,6 @@
 #ifndef _SOC_H_
 #define _SOC_H_
 
-#include <devicetree.h>
 
 #define __MPU_PRESENT CONFIG_CPU_HAS_ARM_MPU
 

--- a/soc/arm/arm/mps2/soc.h
+++ b/soc/arm/arm/mps2/soc.h
@@ -16,7 +16,6 @@
 
 #endif
 
-#include <devicetree.h>
 #include <soc_registers.h>
 
 extern void wakeup_cpu1(void);

--- a/soc/arm/arm/mps3/soc.h
+++ b/soc/arm/arm/mps3/soc.h
@@ -17,6 +17,5 @@
 #define __MVE_FP                  1U        /* MVE floating point present */
 #endif
 
-#include <devicetree.h>
 
 #endif /* _SOC_H_ */

--- a/soc/arm/arm/musca_b1/soc.h
+++ b/soc/arm/arm/musca_b1/soc.h
@@ -9,7 +9,6 @@
 
 #ifndef _ASMLANGUAGE
 #include "system_cmsdk_musca_b1.h"
-#include <devicetree.h>
 #include <sys/util.h>
 #endif
 

--- a/soc/arm/arm/musca_s1/soc.h
+++ b/soc/arm/arm/musca_s1/soc.h
@@ -9,7 +9,6 @@
 
 #ifndef _ASMLANGUAGE
 #include "system_cmsdk_musca_s1.h"
-#include <devicetree.h>
 #include <sys/util.h>
 #endif
 

--- a/soc/arm/atmel_sam/sam3x/soc.h
+++ b/soc/arm/atmel_sam/sam3x/soc.h
@@ -17,8 +17,6 @@
 
 #ifndef _ASMLANGUAGE
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
 
 #define DONT_USE_CMSIS_INIT
 #define DONT_USE_PREDEFINED_CORE_HANDLERS

--- a/soc/arm/atmel_sam/sam4e/soc.h
+++ b/soc/arm/atmel_sam/sam4e/soc.h
@@ -19,8 +19,6 @@
 
 #ifndef _ASMLANGUAGE
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
 
 #define DONT_USE_CMSIS_INIT
 #define DONT_USE_PREDEFINED_CORE_HANDLERS

--- a/soc/arm/atmel_sam/sam4s/soc.h
+++ b/soc/arm/atmel_sam/sam4s/soc.h
@@ -19,8 +19,6 @@
 
 #ifndef _ASMLANGUAGE
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
 
 #define DONT_USE_CMSIS_INIT
 #define DONT_USE_PREDEFINED_CORE_HANDLERS

--- a/soc/arm/atmel_sam/same70/soc.h
+++ b/soc/arm/atmel_sam/same70/soc.h
@@ -17,8 +17,6 @@
 
 #ifndef _ASMLANGUAGE
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
 
 #define DONT_USE_CMSIS_INIT
 #define DONT_USE_PREDEFINED_CORE_HANDLERS

--- a/soc/arm/atmel_sam/samv71/soc.h
+++ b/soc/arm/atmel_sam/samv71/soc.h
@@ -18,8 +18,6 @@
 
 #ifndef _ASMLANGUAGE
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
 
 #define DONT_USE_CMSIS_INIT
 #define DONT_USE_PREDEFINED_CORE_HANDLERS

--- a/soc/arm/atmel_sam0/common/soc_port.c
+++ b/soc/arm/atmel_sam0/common/soc_port.c
@@ -9,6 +9,8 @@
  * @brief Atmel SAM0 MCU family I/O Pin Controller (PORT)
  */
 
+#include <stdbool.h>
+
 #include "soc_port.h"
 
 int soc_port_pinmux_set(PortGroup *pg, uint32_t pin, uint32_t func)

--- a/soc/arm/atmel_sam0/samd20/soc.h
+++ b/soc/arm/atmel_sam0/samd20/soc.h
@@ -13,8 +13,6 @@
 
 #include <zephyr/types.h>
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
 
 #if defined(CONFIG_SOC_PART_NUMBER_SAMD20E14)
 #include <samd20e14.h>

--- a/soc/arm/atmel_sam0/samd21/soc.h
+++ b/soc/arm/atmel_sam0/samd21/soc.h
@@ -13,8 +13,6 @@
 
 #include <zephyr/types.h>
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
 
 #if defined(CONFIG_SOC_PART_NUMBER_SAMD21E15A)
 #include <samd21e15a.h>

--- a/soc/arm/atmel_sam0/samd51/soc.h
+++ b/soc/arm/atmel_sam0/samd51/soc.h
@@ -13,8 +13,6 @@
 
 #include <zephyr/types.h>
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
 
 #if defined(CONFIG_SOC_PART_NUMBER_SAMD51G18A)
 #include <samd51g18a.h>

--- a/soc/arm/atmel_sam0/same51/soc.h
+++ b/soc/arm/atmel_sam0/same51/soc.h
@@ -13,8 +13,6 @@
 
 #include <zephyr/types.h>
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
 
 #if defined(CONFIG_SOC_PART_NUMBER_SAME51J18A)
 #include <same51j18a.h>

--- a/soc/arm/atmel_sam0/same53/soc.h
+++ b/soc/arm/atmel_sam0/same53/soc.h
@@ -13,8 +13,6 @@
 
 #include <zephyr/types.h>
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
 
 #if defined(CONFIG_SOC_PART_NUMBER_SAME53J18A)
 #include <same53j18a.h>

--- a/soc/arm/atmel_sam0/same54/soc.h
+++ b/soc/arm/atmel_sam0/same54/soc.h
@@ -13,8 +13,6 @@
 
 #include <zephyr/types.h>
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
 
 #if defined(CONFIG_SOC_PART_NUMBER_SAME54N19A)
 #include <same54n19a.h>

--- a/soc/arm/atmel_sam0/samr21/soc.h
+++ b/soc/arm/atmel_sam0/samr21/soc.h
@@ -13,8 +13,6 @@
 
 #include <zephyr/types.h>
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
 
 #if defined(CONFIG_SOC_PART_NUMBER_SAMR21E16A)
 #include <samr21e16a.h>

--- a/soc/arm/bcm_vk/valkyrie/soc.h
+++ b/soc/arm/bcm_vk/valkyrie/soc.h
@@ -11,7 +11,6 @@
 
 #ifndef _ASMLANGUAGE
 
-#include <devicetree.h>
 
 /* Interrupt Number Definition */
 typedef enum IRQn {

--- a/soc/arm/bcm_vk/viper/soc.h
+++ b/soc/arm/bcm_vk/viper/soc.h
@@ -12,7 +12,6 @@
 
 #ifndef _ASMLANGUAGE
 
-#include <devicetree.h>
 
 /* Interrupt Number Definition */
 typedef enum IRQn {

--- a/soc/arm/cypress/psoc6/soc.h
+++ b/soc/arm/cypress/psoc6/soc.h
@@ -19,8 +19,6 @@
 
 #ifndef _ASMLANGUAGE
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
 
 #include <cy_device_headers.h>
 

--- a/soc/arm/gigadevice/gd32f3x0/soc.h
+++ b/soc/arm/gigadevice/gd32f3x0/soc.h
@@ -8,7 +8,6 @@
 
 #ifndef _ASMLANGUAGE
 
-#include <devicetree.h>
 #include <gd32f3x0.h>
 
 #endif /* _ASMLANGUAGE */

--- a/soc/arm/gigadevice/gd32f403/soc.h
+++ b/soc/arm/gigadevice/gd32f403/soc.h
@@ -13,7 +13,6 @@
 #include <sys/util.h>
 
 #ifndef _ASMLANGUAGE
-#include <devicetree.h>
 #include <gd32f403.h>
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/arm/gigadevice/gd32f4xx/soc.h
+++ b/soc/arm/gigadevice/gd32f4xx/soc.h
@@ -8,7 +8,6 @@
 
 #ifndef _ASMLANGUAGE
 
-#include <devicetree.h>
 #include <gd32f4xx.h>
 
 #endif /* _ASMLANGUAGE */

--- a/soc/arm/infineon_xmc/4xxx/soc.h
+++ b/soc/arm/infineon_xmc/4xxx/soc.h
@@ -6,7 +6,5 @@
  *
  */
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
 #include <system_XMC4500.h>
 #include <XMC4500.h>

--- a/soc/arm/nuvoton_npcx/common/reg/reg_def.h
+++ b/soc/arm/nuvoton_npcx/common/reg/reg_def.h
@@ -7,6 +7,12 @@
 #ifndef _NUVOTON_NPCX_REG_DEF_H
 #define _NUVOTON_NPCX_REG_DEF_H
 
+#include <stdint.h>
+
+#include <sys/__assert.h>
+#include <sys/util_macro.h>
+#include <toolchain.h>
+
 /*
  * NPCX register structure size/offset checking macro function to mitigate
  * the risk of unexpected compiling results. All addresses of NPCX registers

--- a/soc/arm/nuvoton_npcx/common/soc_clock.h
+++ b/soc/arm/nuvoton_npcx/common/soc_clock.h
@@ -7,6 +7,11 @@
 #ifndef _NUVOTON_NPCX_SOC_CLOCK_H_
 #define _NUVOTON_NPCX_SOC_CLOCK_H_
 
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <devicetree.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/soc/arm/nuvoton_npcx/common/soc_dt.h
+++ b/soc/arm/nuvoton_npcx/common/soc_dt.h
@@ -7,6 +7,10 @@
 #ifndef _NUVOTON_NPCX_SOC_DT_H_
 #define _NUVOTON_NPCX_SOC_DT_H_
 
+#include <devicetree.h>
+#include <irq.h>
+#include <sys/util_macro.h>
+
 /**
  * @brief Like DT_PROP(), but expand parameters with
  *        DT_ENUM_UPPER_TOKEN not DT_PROP

--- a/soc/arm/nuvoton_npcx/common/soc_espi.h
+++ b/soc/arm/nuvoton_npcx/common/soc_espi.h
@@ -8,7 +8,6 @@
 #define _NUVOTON_NPCX_SOC_ESPI_H_
 
 #include <device.h>
-#include <sys/util.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/soc/arm/nuvoton_npcx/common/soc_gpio.h
+++ b/soc/arm/nuvoton_npcx/common/soc_gpio.h
@@ -7,6 +7,8 @@
 #ifndef _NUVOTON_NPCX_SOC_GPIO_H_
 #define _NUVOTON_NPCX_SOC_GPIO_H_
 
+#include <device.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/soc/arm/nuvoton_npcx/common/soc_host.h
+++ b/soc/arm/nuvoton_npcx/common/soc_host.h
@@ -7,6 +7,12 @@
 #ifndef _NUVOTON_NPCX_SOC_HOST_H_
 #define _NUVOTON_NPCX_SOC_HOST_H_
 
+#include <stdint.h>
+
+#include <device.h>
+#include <drivers/espi.h>
+#include <sys/slist.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/soc/arm/nuvoton_npcx/common/soc_miwu.h
+++ b/soc/arm/nuvoton_npcx/common/soc_miwu.h
@@ -7,6 +7,11 @@
 #ifndef _NUVOTON_NPCX_SOC_MIWU_H_
 #define _NUVOTON_NPCX_SOC_MIWU_H_
 
+#include <stdint.h>
+
+#include <device.h>
+#include <drivers/gpio.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/soc/arm/nuvoton_npcx/common/soc_pins.h
+++ b/soc/arm/nuvoton_npcx/common/soc_pins.h
@@ -7,6 +7,10 @@
 #ifndef _NUVOTON_NPCX_SOC_PINS_H_
 #define _NUVOTON_NPCX_SOC_PINS_H_
 
+#include <stdint.h>
+
+#include "reg/reg_def.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/soc/arm/nuvoton_npcx/npcx7/soc.h
+++ b/soc/arm/nuvoton_npcx/npcx7/soc.h
@@ -11,8 +11,6 @@
 #define __FPU_PRESENT  CONFIG_CPU_HAS_FPU
 #define __MPU_PRESENT  CONFIG_CPU_HAS_ARM_MPU
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
 
 #include <reg/reg_access.h>
 #include <reg/reg_def.h>

--- a/soc/arm/nuvoton_npcx/npcx9/soc.h
+++ b/soc/arm/nuvoton_npcx/npcx9/soc.h
@@ -11,8 +11,6 @@
 #define __FPU_PRESENT  CONFIG_CPU_HAS_FPU
 #define __MPU_PRESENT  CONFIG_CPU_HAS_ARM_MPU
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
 
 #include <reg/reg_access.h>
 #include <reg/reg_def.h>

--- a/soc/arm/nuvoton_numicro/m48x/soc.h
+++ b/soc/arm/nuvoton_numicro/m48x/soc.h
@@ -9,7 +9,6 @@
 #define ZEPHYR_SOC_ARM_NUVOTON_M48X_SOC_H_
 
 #include <sys/util.h>
-#include <devicetree.h>
 #include <NuMicro.h>
 
 #endif /* ZEPHYR_SOC_ARM_NUVOTON_M48X_SOC_H_*/

--- a/soc/arm/nxp_imx/mimx8ml8_m7/soc.h
+++ b/soc/arm/nxp_imx/mimx8ml8_m7/soc.h
@@ -13,8 +13,6 @@ extern "C" {
 
 #ifndef _ASMLANGUAGE
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
 
 #include <fsl_device_registers.h>
 

--- a/soc/arm/nxp_kinetis/k6x/soc.h
+++ b/soc/arm/nxp_kinetis/k6x/soc.h
@@ -25,8 +25,6 @@
 
 #include <fsl_common.h>
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/arm/nxp_kinetis/k8x/soc.h
+++ b/soc/arm/nxp_kinetis/k8x/soc.h
@@ -17,8 +17,6 @@ extern "C" {
 
 #include <fsl_common.h>
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/arm/nxp_kinetis/ke1xf/soc.h
+++ b/soc/arm/nxp_kinetis/ke1xf/soc.h
@@ -13,8 +13,6 @@
 
 #include <fsl_common.h>
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/arm/nxp_kinetis/kl2x/soc.h
+++ b/soc/arm/nxp_kinetis/kl2x/soc.h
@@ -15,8 +15,6 @@
 
 #include <fsl_common.h>
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/arm/nxp_kinetis/kv5x/soc.h
+++ b/soc/arm/nxp_kinetis/kv5x/soc.h
@@ -17,8 +17,6 @@ extern "C" {
 
 #include <fsl_common.h>
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/arm/nxp_kinetis/kwx/soc.h
+++ b/soc/arm/nxp_kinetis/kwx/soc.h
@@ -26,8 +26,6 @@
 
 #include <fsl_common.h>
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/arm/nxp_lpc/lpc11u6x/soc.h
+++ b/soc/arm/nxp_lpc/lpc11u6x/soc.h
@@ -18,8 +18,6 @@
 #ifndef _ASMLANGUAGE
 #include <sys/util.h>
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/arm/nxp_lpc/lpc54xxx/soc.h
+++ b/soc/arm/nxp_lpc/lpc54xxx/soc.h
@@ -19,8 +19,6 @@
 #include <sys/util.h>
 #include <fsl_common.h>
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/arm/nxp_lpc/lpc55xxx/soc.h
+++ b/soc/arm/nxp_lpc/lpc55xxx/soc.h
@@ -19,8 +19,6 @@
 #include <sys/util.h>
 #include <fsl_common.h>
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/arm/quicklogic_eos_s3/soc.h
+++ b/soc/arm/quicklogic_eos_s3/soc.h
@@ -9,7 +9,6 @@
 
 #include <sys/util.h>
 #include <eoss3_dev.h>
-#include <devicetree.h>
 
 /* Available frequencies */
 #define HSOSC_1MHZ	1024000

--- a/soc/arm/silabs_exx32/efm32gg11b/soc.h
+++ b/soc/arm/silabs_exx32/efm32gg11b/soc.h
@@ -25,8 +25,6 @@ extern "C" {
 #include <em_bus.h>
 #include <em_common.h>
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
 
 #include "soc_pinmap.h"
 #include "../common/soc_gpio.h"

--- a/soc/arm/silabs_exx32/efm32gg11b/soc_pinmap.h
+++ b/soc/arm/silabs_exx32/efm32gg11b/soc_pinmap.h
@@ -15,6 +15,7 @@
 #ifndef _SILABS_EFM32GG11B_SOC_PINMAP_H_
 #define _SILABS_EFM32GG11B_SOC_PINMAP_H_
 
+#include <devicetree.h>
 #include <soc.h>
 #include <em_gpio.h>
 

--- a/soc/arm/silabs_exx32/efm32jg12b/soc.h
+++ b/soc/arm/silabs_exx32/efm32jg12b/soc.h
@@ -20,8 +20,6 @@
 #include <em_bus.h>
 #include <em_common.h>
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
 
 #include "soc_pinmap.h"
 #include "../common/soc_gpio.h"

--- a/soc/arm/silabs_exx32/efm32jg12b/soc_pinmap.h
+++ b/soc/arm/silabs_exx32/efm32jg12b/soc_pinmap.h
@@ -13,6 +13,7 @@
 #ifndef _SILABS_EFM32JG12B_SOC_PINMAP_H_
 #define _SILABS_EFM32JG12B_SOC_PINMAP_H_
 
+#include <devicetree.h>
 #include <soc.h>
 #include <em_gpio.h>
 

--- a/soc/arm/silabs_exx32/efm32pg12b/soc.h
+++ b/soc/arm/silabs_exx32/efm32pg12b/soc.h
@@ -20,8 +20,6 @@
 #include <em_bus.h>
 #include <em_common.h>
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
 
 #include "soc_pinmap.h"
 #include "../common/soc_gpio.h"

--- a/soc/arm/silabs_exx32/efm32pg12b/soc_pinmap.h
+++ b/soc/arm/silabs_exx32/efm32pg12b/soc_pinmap.h
@@ -13,6 +13,7 @@
 #ifndef _SILABS_EFM32PG12B_SOC_PINMAP_H_
 #define _SILABS_EFM32PG12B_SOC_PINMAP_H_
 
+#include <devicetree.h>
 #include <soc.h>
 #include <em_gpio.h>
 

--- a/soc/arm/silabs_exx32/efm32pg1b/soc.h
+++ b/soc/arm/silabs_exx32/efm32pg1b/soc.h
@@ -20,8 +20,6 @@
 #include <em_bus.h>
 #include <em_common.h>
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
 
 #include "soc_pinmap.h"
 #include "../common/soc_gpio.h"

--- a/soc/arm/silabs_exx32/efm32pg1b/soc_pinmap.h
+++ b/soc/arm/silabs_exx32/efm32pg1b/soc_pinmap.h
@@ -13,6 +13,7 @@
 #ifndef _SILABS_EFM32PG1B_SOC_PINMAP_H_
 #define _SILABS_EFM32PG1B_SOC_PINMAP_H_
 
+#include <devicetree.h>
 #include <soc.h>
 #include <em_gpio.h>
 

--- a/soc/arm/silabs_exx32/efm32wg/soc.h
+++ b/soc/arm/silabs_exx32/efm32wg/soc.h
@@ -20,8 +20,6 @@
 #include <em_bus.h>
 #include <em_common.h>
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
 
 #include "soc_pinmap.h"
 #include "../common/soc_gpio.h"

--- a/soc/arm/silabs_exx32/efr32bg13p/soc.h
+++ b/soc/arm/silabs_exx32/efr32bg13p/soc.h
@@ -22,8 +22,6 @@
 #include "soc_pinmap.h"
 #include "../common/soc_gpio.h"
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/arm/silabs_exx32/efr32fg13p/soc.h
+++ b/soc/arm/silabs_exx32/efr32fg13p/soc.h
@@ -20,8 +20,6 @@
 #include <em_bus.h>
 #include <em_common.h>
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
 
 #include "soc_pinmap.h"
 #include "../common/soc_gpio.h"

--- a/soc/arm/silabs_exx32/efr32fg13p/soc_pinmap.h
+++ b/soc/arm/silabs_exx32/efr32fg13p/soc_pinmap.h
@@ -13,6 +13,7 @@
 #ifndef _SILABS_EFR32FG13P_SOC_PINMAP_H_
 #define _SILABS_EFR32FG13P_SOC_PINMAP_H_
 
+#include <devicetree.h>
 #include <soc.h>
 #include <em_gpio.h>
 

--- a/soc/arm/silabs_exx32/efr32fg1p/soc.h
+++ b/soc/arm/silabs_exx32/efr32fg1p/soc.h
@@ -20,8 +20,6 @@
 #include <em_bus.h>
 #include <em_common.h>
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
 
 #include "soc_pinmap.h"
 #include "../common/soc_gpio.h"

--- a/soc/arm/silabs_exx32/efr32fg1p/soc_pinmap.h
+++ b/soc/arm/silabs_exx32/efr32fg1p/soc_pinmap.h
@@ -13,6 +13,7 @@
 #ifndef _SILABS_EFR32FG1P_SOC_PINMAP_H_
 #define _SILABS_EFR32FG1P_SOC_PINMAP_H_
 
+#include <devicetree.h>
 #include <soc.h>
 #include <em_gpio.h>
 

--- a/soc/arm/silabs_exx32/efr32mg12p/soc.h
+++ b/soc/arm/silabs_exx32/efr32mg12p/soc.h
@@ -19,8 +19,6 @@
 
 #include <em_common.h>
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
 
 #include "soc_pinmap.h"
 #include "../common/soc_gpio.h"

--- a/soc/arm/silabs_exx32/efr32mg12p/soc_pinmap.h
+++ b/soc/arm/silabs_exx32/efr32mg12p/soc_pinmap.h
@@ -13,6 +13,7 @@
 #ifndef _SOC_PINMAP_H_
 #define _SOC_PINMAP_H_
 
+#include <devicetree.h>
 #include <em_gpio.h>
 
 #define GPIO_NODE DT_INST(0, silabs_gecko_gpio)

--- a/soc/arm/silabs_exx32/efr32mg21/soc.h
+++ b/soc/arm/silabs_exx32/efr32mg21/soc.h
@@ -22,8 +22,6 @@
 #include "soc_pinmap.h"
 #include "../common/soc_gpio.h"
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
 
 #endif  /* !_ASMLANGUAGE */
 

--- a/soc/arm64/arm/fvp_aemv8r/soc.h
+++ b/soc/arm64/arm/fvp_aemv8r/soc.h
@@ -6,6 +6,5 @@
 #ifndef _SOC_H_
 #define _SOC_H_
 
-#include <devicetree.h>
 
 #endif /* _SOC_H_ */

--- a/soc/arm64/nxp_layerscape/ls1046a/soc.h
+++ b/soc/arm64/nxp_layerscape/ls1046a/soc.h
@@ -11,7 +11,6 @@
 #include <toolchain.h>
 
 #ifndef _ASMLANGUAGE
-#include <devicetree.h>
 #endif /* _ASMLANGUAGE */
 
 #define UART_REG_ADDR_INTERVAL 1

--- a/soc/riscv/riscv-ite/it8xxx2/soc.h
+++ b/soc/riscv/riscv-ite/it8xxx2/soc.h
@@ -7,7 +7,6 @@
  *
  */
 #include <soc_common.h>
-#include <devicetree.h>
 
 #define UART_REG_ADDR_INTERVAL 1
 

--- a/soc/riscv/riscv-privilege/andes_v5/ae350/soc.h
+++ b/soc/riscv/riscv-privilege/andes_v5/ae350/soc.h
@@ -12,7 +12,6 @@
 #define __RISCV_ANDES_AE350_SOC_H_
 
 #include <soc_common.h>
-#include <devicetree.h>
 
 /* Machine timer memory-mapped registers */
 #define RISCV_MTIME_BASE             0xE6000000

--- a/soc/riscv/riscv-privilege/andes_v5/smu.h
+++ b/soc/riscv/riscv-privilege/andes_v5/smu.h
@@ -11,6 +11,9 @@
 #ifndef SOC_RISCV_ANDES_V5_SMU_H_
 #define SOC_RISCV_ANDES_V5_SMU_H_
 
+#include <devicetree.h>
+#include <sys/util_macro.h>
+
 /*
  * SMU Register Base Address
  */

--- a/soc/riscv/riscv-privilege/miv/soc.h
+++ b/soc/riscv/riscv-privilege/miv/soc.h
@@ -5,7 +5,6 @@
 #define __RISCV32_MIV_SOC_H_
 
 #include <soc_common.h>
-#include <devicetree.h>
 
 /* GPIO Interrupts */
 #define MIV_GPIO_0_IRQ           (0)

--- a/soc/riscv/riscv-privilege/neorv32/soc.h
+++ b/soc/riscv/riscv-privilege/neorv32/soc.h
@@ -8,7 +8,6 @@
 #define RISCV_NEORV32_SOC_H
 
 #include <soc_common.h>
-#include <devicetree.h>
 
 /* Machine System Timer (MTIME) registers */
 #define RISCV_MTIME_BASE    0xffffff90U

--- a/soc/riscv/riscv-privilege/sifive-freedom/soc.h
+++ b/soc/riscv/riscv-privilege/sifive-freedom/soc.h
@@ -12,7 +12,6 @@
 #define __RISCV_SIFIVE_FREEDOM_SOC_H_
 
 #include <soc_common.h>
-#include <devicetree.h>
 
 #if defined(CONFIG_SOC_RISCV_SIFIVE_FREEDOM)
 

--- a/soc/riscv/riscv-privilege/starfive_jh71xx/soc.h
+++ b/soc/riscv/riscv-privilege/starfive_jh71xx/soc.h
@@ -8,7 +8,6 @@
 #define __RISCV_VIRT_SOC_H_
 
 #include <soc_common.h>
-#include <devicetree.h>
 
 #define RISCV_MTIME_BASE 0x0200BFF8
 #define RISCV_MTIMECMP_BASE 0x02004000

--- a/soc/riscv/riscv-privilege/telink_b91/linker.ld
+++ b/soc/riscv/riscv-privilege/telink_b91/linker.ld
@@ -8,8 +8,8 @@
  * @brief Linker script for the Telink B91 SoC
  */
 
-#include <soc.h>
 #include <autoconf.h>
+#include <devicetree.h>
 #include <linker/linker-tool.h>
 
 MEMORY

--- a/soc/riscv/riscv-privilege/telink_b91/soc.h
+++ b/soc/riscv/riscv-privilege/telink_b91/soc.h
@@ -8,7 +8,6 @@
 #define RISCV_TELINK_B91_SOC_H
 
 #include <soc_common.h>
-#include <devicetree.h>
 
 /* Machine timer memory-mapped registers */
 #define RISCV_MTIME_BASE             0xE6000000

--- a/soc/riscv/riscv-privilege/virt/soc.h
+++ b/soc/riscv/riscv-privilege/virt/soc.h
@@ -8,7 +8,6 @@
 #define __RISCV_VIRT_SOC_H_
 
 #include <soc_common.h>
-#include <devicetree.h>
 
 #define SIFIVE_SYSCON_TEST           0x00100000
 #define RISCV_MTIME_BASE             0x0200BFF8


### PR DESCRIPTION
Main commits:

```
arch: arm: aarch32: cortex_m: nvic: make header self-contained

The header contains macros that make use of the Devicetree API, however,
<devicetree.h> is not included. This was "mitigated" by most <soc.h>
including <devicetree.h>.
```

```
soc: remove unnecessary inclusions of devicetree.h 

Many ARM SoCs included <devicetree.h> likely due to:

1. nvic.h not being self-contained
2. As a result of copy-paste

Some RISC-V SoCs had the same problem, in this case likely due to
copy-paste from ARM. The <devicetree.h> header has been removed using
the following command:

sed -i ':a;N;$!ba;s/#include <devicetree\.h>\n//g' soc/**/soc.h

soc.h files that make a legitimate usage of the API have not been
changed.
```

Note: this change triggered some other issues that I have also fixed.

Related: https://github.com/zephyrproject-rtos/zephyr/issues/41543