### PR TITLE
samples: exclude platform stm32f769i_disco

### DIFF
--- a/samples/drivers/display/sample.yaml
+++ b/samples/drivers/display/sample.yaml
@@ -4,7 +4,7 @@ sample:
 tests:
   sample.display.shield.adafruit_2_8_tft_touch_v2:
     depends_on: arduino_gpio arduino_i2c arduino_spi
-    platform_exclude: reel_board reel_board_v2 ubx_evkannab1_nrf52832
+    platform_exclude: reel_board reel_board_v2 ubx_evkannab1_nrf52832 stm32f769i_disco
     extra_args: SHIELD=adafruit_2_8_tft_touch_v2
     tags: display shield
     harness: console

--- a/samples/subsys/display/lvgl/sample.yaml
+++ b/samples/subsys/display/lvgl/sample.yaml
@@ -11,7 +11,7 @@ tests:
     # Default settings end up allocating an ~150KB sized buffer in lvgl.
     # This adds a bit of buffer to that for other data.
     min_ram: 175
-    platform_exclude: reel_board reel_board_v2 ubx_evkannab1_nrf52832
+    platform_exclude: reel_board reel_board_v2 ubx_evkannab1_nrf52832 stm32f769i_disco
     extra_args: SHIELD=adafruit_2_8_tft_touch_v2
     tags: shield
     harness: console

--- a/samples/subsys/fs/fat_fs/sample.yaml
+++ b/samples/subsys/fs/fat_fs/sample.yaml
@@ -12,6 +12,7 @@ tests:
     platform_allow: nrf52840_blip
   sample.filesystem.fat_fs.adafruit_2_8_tft_touch_v2:
     depends_on: arduino_spi arduino_gpio arduino_i2c
+    platform_exclude: stm32f769i_disco
     extra_args: SHIELD=adafruit_2_8_tft_touch_v2
     tags: shield
     harness: console


### PR DESCRIPTION
Excluded due to conflicts with adafruit_2_8_tft_touch_v2.
#41519
[Test results](https://github.com/zephyrproject-rtos/zephyr/pull/41519/checks?check_run_id=4693948594)