### PR TITLE
samples/subsys/audio/sof: tune compiler options for audio DSP code

### DIFF
--- a/samples/subsys/audio/sof/prj.conf
+++ b/samples/subsys/audio/sof/prj.conf
@@ -5,6 +5,9 @@ CONFIG_BUILD_OUTPUT_BIN=n
 # Requires heap_info() be implemented, but no Zephyr wrapper
 CONFIG_DEBUG_MEMORY_USAGE_SCAN=n
 
+# Ensure -O2 (or similar) is used for optimization
+CONFIG_SPEED_OPTIMIZATIONS=y
+
 CONFIG_SCHED_DEADLINE=y
 CONFIG_SCHED_CPU_MASK=y
 CONFIG_SMP_BOOT_DELAY=y

--- a/samples/subsys/audio/sof/prj.conf
+++ b/samples/subsys/audio/sof/prj.conf
@@ -8,6 +8,10 @@ CONFIG_DEBUG_MEMORY_USAGE_SCAN=n
 # Ensure -O2 (or similar) is used for optimization
 CONFIG_SPEED_OPTIMIZATIONS=y
 
+# Zephyr top-level default of -fno-strict-overflow is
+# not a good fit for audio DSP code
+CONFIG_COMPILER_OPT="-fstrict-overflow"
+
 CONFIG_SCHED_DEADLINE=y
 CONFIG_SCHED_CPU_MASK=y
 CONFIG_SMP_BOOT_DELAY=y


### PR DESCRIPTION
A series to improve performance of SOF DSP code in Zephyr builds:

samples/subsys/audio/sof: use -fstrict-overflow for SOF
samples/subsys/audio/sof: build with CONFIG_SPEED_OPTIMIZATIONS
