### PR TITLE
soc: arm: atmel_sam: samv71: Fix SPI build dependency

### DIFF
--- a/drivers/gpio/Kconfig.sam
+++ b/drivers/gpio/Kconfig.sam
@@ -4,16 +4,21 @@
 # Copyright (c) 2020 Gerson Fernando Budke <nandojve@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
+# Workaround for not being able to have commas in macro arguments
+DT_COMPAT_ATMEL_SAM_GPIO := atmel,sam-gpio
+
 config GPIO_SAM
 	bool "Atmel SAM GPIO (PORT) driver"
-	default y
+	default y if $(dt_compat_enabled,$(DT_COMPAT_ATMEL_SAM_GPIO))
 	depends on SOC_FAMILY_SAM && !SOC_SERIES_SAM4L
+	depends on GPIO
 	help
 	  Enable support for the Atmel SAM 'PORT' GPIO controllers.
 
 config GPIO_SAM4L
 	bool "Atmel SAM4L GPIO (PORT) driver"
-	default y
+	default y if $(dt_compat_enabled,$(DT_COMPAT_ATMEL_SAM_GPIO))
 	depends on SOC_SERIES_SAM4L
+	depends on GPIO
 	help
 	  Enable support for the Atmel SAM4L 'PORT' GPIO controllers.

--- a/drivers/spi/Kconfig.sam
+++ b/drivers/spi/Kconfig.sam
@@ -4,9 +4,14 @@
 # Copyright (c) 2018 qianfan Zhao
 # SPDX-License-Identifier: Apache-2.0
 
+# Workaround for not being able to have commas in macro arguments
+DT_COMPAT_ATMEL_SAM_SPI := atmel,sam-spi
+
 config SPI_SAM
 	bool "Atmel SAM series SPI driver"
-	default y
+	default $(dt_compat_enabled,$(DT_COMPAT_ATMEL_SAM_SPI))
 	depends on SOC_FAMILY_SAM
+	depends on SPI
+	select GPIO
 	help
 	  Enable support for the SAM SPI driver.

--- a/soc/arm/atmel_sam/samv71/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam/samv71/Kconfig.defconfig.series
@@ -46,10 +46,6 @@ config DMA_SAM_XDMAC
 	default y
 	depends on DMA
 
-config GPIO_SAM
-	default y
-	depends on GPIO
-
 config ADC_SAM_AFEC
 	default y
 	depends on ADC
@@ -61,10 +57,6 @@ config I2C_SAM_TWIHS
 config I2S_SAM_SSC
 	default y
 	depends on I2S
-
-config SPI_SAM
-	default y
-	depends on SPI
 
 config USB_DC_SAM_USBHS
 	default y

--- a/tests/drivers/spi/spi_loopback/boards/sam_v71_xult.conf
+++ b/tests/drivers/spi/spi_loopback/boards/sam_v71_xult.conf
@@ -1,1 +1,0 @@
-CONFIG_GPIO=y

--- a/tests/drivers/spi/spi_loopback/boards/sam_v71b_xult.conf
+++ b/tests/drivers/spi/spi_loopback/boards/sam_v71b_xult.conf
@@ -1,1 +1,0 @@
-CONFIG_GPIO=y


### PR DESCRIPTION
The SAM spi driver depends on GPIO driver to work. It seems that this dependency chain it is not handled. This select GPIO driver when SPI driver is enabled. It rework GPIO and SPI Kconfig to select driver by devicetree and drop entries at Kconfig.defconfig.series file.

Fixes #41525

Signed-off-by: Gerson Fernando Budke <nandojve@gmail.com>