### PR TITLE
dts: riscv: gigadevice: Add GD32VF103 DAC configuration

### DIFF
--- a/boards/riscv/longan_nano/longan_nano-pinctrl.dtsi
+++ b/boards/riscv/longan_nano/longan_nano-pinctrl.dtsi
@@ -11,4 +11,10 @@
 			pinmux = <USART0_TX_PA9_NORMP>, <USART0_RX_PA10_NORMP>;
 		};
 	};
+
+	dac_default: dac_default {
+		group1 {
+			pinmux = <DAC_OUT0_PA4>;
+		};
+	};
 };

--- a/boards/riscv/longan_nano/longan_nano.dts
+++ b/boards/riscv/longan_nano/longan_nano.dts
@@ -26,3 +26,9 @@
 	pinctrl-0 = <&usart0_default>;
 	pinctrl-names = "default";
 };
+
+&dac {
+	status = "okay";
+	pinctrl-0 = <&dac_default>;
+	pinctrl-names = "default";
+};

--- a/boards/riscv/longan_nano/longan_nano_lite.dts
+++ b/boards/riscv/longan_nano/longan_nano_lite.dts
@@ -26,3 +26,9 @@
 	pinctrl-0 = <&usart0_default>;
 	pinctrl-names = "default";
 };
+
+&dac {
+	status = "okay";
+	pinctrl-0 = <&dac_default>;
+	pinctrl-names = "default";
+};

--- a/drivers/dac/Kconfig.gd32
+++ b/drivers/dac/Kconfig.gd32
@@ -9,7 +9,7 @@ DT_COMPAT_GD_GD32_DAC := gd,gd32-dac
 
 config DAC_GD32
 	bool "GD32 DAC driver"
-	depends on SOC_FAMILY_GD32
+	depends on (SOC_FAMILY_GD32 || SOC_SERIES_GD32VF103)
 	default $(dt_compat_enabled,$(DT_COMPAT_GD_GD32_DAC))
 	help
 	  Enable GigaDevice GD32 DAC driver

--- a/dts/riscv/gigadevice/gd32vf103.dtsi
+++ b/dts/riscv/gigadevice/gd32vf103.dtsi
@@ -95,6 +95,16 @@
 			label = "UART_2";
 		};
 
+		dac: dac@40007400 {
+			compatible = "gd,gd32-dac";
+			reg = <0x40007400 0x400>;
+			rcu-periph-clock = <0x71d>;
+			num-channels = <2>;
+			label = "DAC";
+			status = "disabled";
+			#io-channel-cells = <1>;
+		};
+
 		afio: afio@40010000 {
 			compatible = "gd,gd32-afio";
 			reg = <0x40010000 0x400>;

--- a/samples/drivers/dac/README.rst
+++ b/samples/drivers/dac/README.rst
@@ -189,6 +189,26 @@ The sample can be built and executed for the
 
 Bridge the JP23 to DAC with the jumper cap, then DAC output will available on JP7.
 
+Building and Running for Longan Nano and Longan Nano Lite
+=========================================================
+The sample can be built and executed for the
+:ref:`longan_nano` as follows:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/drivers/dac
+   :board: longan_nano
+   :goals: build flash
+   :compact:
+
+also can run for the
+:ref: `longan_nano_lite` as follows:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/drivers/dac
+   :board: longan_nano_lite
+   :goals: build flash
+   :compact:
+
 Sample output
 =============
 

--- a/samples/drivers/dac/boards/longan_nano.overlay
+++ b/samples/drivers/dac/boards/longan_nano.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2021 TOKITA Hiroshi
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		dac = <&dac>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
+	};
+};

--- a/samples/drivers/dac/boards/longan_nano_lite.overlay
+++ b/samples/drivers/dac/boards/longan_nano_lite.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2021 TOKITA Hiroshi
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		dac = <&dac>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
+	};
+};

--- a/samples/drivers/dac/sample.yaml
+++ b/samples/drivers/dac/sample.yaml
@@ -7,7 +7,7 @@ tests:
       arduino_zero frdm_k22f frdm_k64f nucleo_f091rc nucleo_g071rb nucleo_g431rb
       nucleo_l073rz nucleo_l152re twr_ke18f nucleo_f767zi nucleo_f429zi bl652_dvk
       bl653_dvk bl654_dvk bl5340_dvk_cpuapp stm32f3_disco stm32l562e_dk nucleo_l552ze_q
-      gd32f450i_eval
+      gd32f450i_eval longan_nano longan_nano_lite
     depends_on: dac
     harness: console
     harness_config:


### PR DESCRIPTION
This PR enables the DAC driver introduced in #41152 also with the GD32VF103.

Add configuration for the longan nano board, and modify the DAC sample to work with it.

GD32VF103 has a 2ch/12bit resolution DAC.
It is the same configuration as the GD32450i-EVAL board's one.
This PR is referring to that.