### PR TITLE
samples: big_http_download: make num_iterations unsigned

### DIFF
--- a/samples/net/sockets/big_http_download/src/big_http_download.c
+++ b/samples/net/sockets/big_http_download/src/big_http_download.c
@@ -244,7 +244,7 @@ void main(void)
 	unsigned int total_bytes = 0U;
 	int resolve_attempts = 10;
 	bool is_tls = false;
-	int num_iterations = CONFIG_SAMPLE_BIG_HTTP_DL_NUM_ITER;
+	unsigned int num_iterations = CONFIG_SAMPLE_BIG_HTTP_DL_NUM_ITER;
 
 #if defined(CONFIG_NET_SOCKETS_SOCKOPT_TLS)
 	tls_credential_add(CA_CERTIFICATE_TAG, TLS_CREDENTIAL_CA_CERTIFICATE,


### PR DESCRIPTION
It is documented as unsigned in
samples/net/sockets/big_http_download/Kconfig

Signed overflow is undefined behavior, unsigned is not. This fixes the
following warning:
```
   -Wstrict-overflow=1

samples/net/sockets/big_http_download/src/big_http_download.c:346:2:
In function 'main':
error: iteration 2147483648 invokes undefined behavior
                           [-Werror=aggressive-loop-optimizations]
  346 |  } while (--num_iterations != 0);
```
Signed-off-by: Marc Herbert <marc.herbert@intel.com>