### PR TITLE
sys: device_mmio.h remove #include <toolchain/common.h> 

### DIFF
--- a/include/sys/device_mmio.h
+++ b/include/sys/device_mmio.h
@@ -15,7 +15,7 @@
 #ifndef ZEPHYR_INCLUDE_SYS_DEVICE_MMIO_H
 #define ZEPHYR_INCLUDE_SYS_DEVICE_MMIO_H
 
-#include <toolchain/common.h>
+#include <toolchain.h>
 #include <linker/sections.h>
 
 /**


### PR DESCRIPTION
v1: re-order `#include <toolchain/common.h>`

v2: remove `#include <toolchain/common.h>`

v3: replace `#include <toolchain/common.h>` with `#include <toolchain.h>`

Any version fixes the following warning:
```
$ west build -b qemu_x86  tests/arch/x86/static_idt/

In file included from zephyr/include/toolchain.h:50,
             from zephyr/include/linker/section_tags.h:12,
             from zephyr/include/linker/sections.h:132,
             from zephyr/include/sys/device_mmio.h:19,
             from zephyr/include/drivers/interrupt_controller/loapic.h:14,
             from zephyr/include/drivers/interrupt_controller/sysapic.h:10,
             from zephyr/include/arch/x86/arch.h:231,
             from zephyr/include/arch/cpu.h:15,
             from zephyr/tests/arch/x86/static_idt/src/test_stubs.S:17:
zephyr/include/toolchain/gcc.h:61: error: BUILD_ASSERT redefined [-Werror]
   61 | #define BUILD_ASSERT(EXPR, MSG...) _Static_assert(EXPR, "" MSG)
      |
In file included from zephyr/include/sys/device_mmio.h:18,
             from zephyr/include/drivers/interrupt_controller/loapic.h:14,
             from zephyr/include/drivers/interrupt_controller/sysapic.h:10,
             from zephyr/include/arch/x86/arch.h:231,
             from zephyr/include/arch/cpu.h:15,
             from zephyr/tests/arch/x86/static_idt/src/test_stubs.S:17:
zephyr/include/toolchain/common.h:165: note: this is the location of the
  previous definition
  165 | #define BUILD_ASSERT(EXPR, MSG...) \
```

Thanks to Gerard Marull-Paretas for recommending v3

Related to commit af20208cd942 ("devices: mark device MMIO declarations to
boot/pinned sections") that added `#include <linker/sections.h>`

`#include <toolchain/common.h>` was here since the dawn of time (= commit db0ca08fb731)

Signed-off-by: Marc Herbert <marc.herbert@intel.com>