### PR TITLE
Bluetooth: host: ifdef sc_reset on CONFIG_BT_GATT_SERVICE_CHANGED

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -2488,15 +2488,13 @@ static void sc_restore_rsp(struct bt_conn *conn,
 	}
 #endif
 
-#if defined(CONFIG_BT_GATT_SERVICE_CHANGED)
-	if (!err) {
+	if (!err && IS_ENABLED(CONFIG_BT_GATT_SERVICE_CHANGED)) {
 		struct gatt_sc_cfg *sc_cfg = find_sc_cfg(conn->id, &conn->le.dst);
 
 		if (sc_cfg) {
 			sc_reset(sc_cfg);
 		}
 	}
-#endif
 }
 
 static struct bt_gatt_indicate_params sc_restore_params[CONFIG_BT_MAX_CONN];


### PR DESCRIPTION
Only define sc_reset when CONFIG_BT_GATT_SERVICE_CHANGED is
defined. Otherwise we get an unused function warning.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>