### PR TITLE
ITE: cleanup: it8xxx2: drivers/intc rename the function

### DIFF
--- a/drivers/interrupt_controller/intc_ite_it8xxx2.c
+++ b/drivers/interrupt_controller/intc_ite_it8xxx2.c
@@ -136,8 +136,7 @@ void ite_intc_irq_disable(unsigned int irq)
 	irq_unlock(key);
 }
 
-void ite_intc_irq_priority_set(unsigned int irq,
-		unsigned int prio, unsigned int flags)
+void ite_intc_irq_polarity_set(unsigned int irq, unsigned int flags)
 {
 	uint32_t g, i;
 	volatile uint8_t *tri;

--- a/drivers/timer/ite_it8xxx2_timer.c
+++ b/drivers/timer/ite_it8xxx2_timer.c
@@ -101,7 +101,7 @@ void timer_5ms_one_shot(void)
 			ONE_SHOT_TIMER_FLAG);
 
 	/* Set rising edge triggered of one shot timer */
-	ite_intc_irq_priority_set(ONE_SHOT_TIMER_IRQ, 0, ONE_SHOT_TIMER_FLAG);
+	ite_intc_irq_polarity_set(ONE_SHOT_TIMER_IRQ, ONE_SHOT_TIMER_FLAG);
 
 	/* Clear interrupt status of one shot timer */
 	ite_intc_isr_clear(ONE_SHOT_TIMER_IRQ);
@@ -306,7 +306,7 @@ static int timer_init(enum ext_timer_idx ext_timer,
 	}
 
 	/* Set rising edge triggered of external timer x */
-	ite_intc_irq_priority_set(irq_num, 0, irq_flag);
+	ite_intc_irq_polarity_set(irq_num, irq_flag);
 
 	/* Clear interrupt status of external timer x */
 	ite_intc_isr_clear(irq_num);

--- a/soc/riscv/riscv-ite/common/soc_common.h
+++ b/soc/riscv/riscv-ite/common/soc_common.h
@@ -43,8 +43,7 @@ extern void ite_intc_irq_enable(unsigned int irq);
 extern void ite_intc_irq_disable(unsigned int irq);
 extern uint8_t ite_intc_get_irq_num(void);
 extern int ite_intc_irq_is_enable(unsigned int irq);
-extern void ite_intc_irq_priority_set(unsigned int irq,
-			unsigned int prio, unsigned int flags);
+extern void ite_intc_irq_polarity_set(unsigned int irq, unsigned int flags);
 extern void ite_intc_isr_clear(unsigned int irq);
 #endif /* CONFIG_ITE_IT8XXX2_INTC */
 


### PR DESCRIPTION
The function should be renamed ite_intc_irq_polarity_set.

Signed-off-by: Tim Lin <tim2.lin@ite.corp-partner.google.com>