### PR TITLE
net: offer update state callbacks

### DIFF
--- a/include/net/lwm2m.h
+++ b/include/net/lwm2m.h
@@ -102,6 +102,10 @@ enum lwm2m_observe_event {
 typedef void (*lwm2m_observe_cb_t)(enum lwm2m_observe_event event, struct lwm2m_obj_path *path,
 				   void *user_data);
 
+#if defined(CONFIG_LWM2M_FIRMWARE_UPDATE_OBJ_SUPPORT)
+typedef void (*lwm2m_engine_update_state_cb)(uint8_t update_state);
+#endif
+
 /**
  * @brief LwM2M context structure to maintain information for a single
  * LwM2M connection.
@@ -370,6 +374,16 @@ void lwm2m_firmware_set_write_cb(lwm2m_engine_set_data_cb_t cb);
  * @return A registered callback function to receive the block transfer data
  */
 lwm2m_engine_set_data_cb_t lwm2m_firmware_get_write_cb(void);
+
+/**
+ * @brief Set callback to get update state changed.
+ *
+ * LwM2M clients use this function to know the state of a firmware update
+ * process.
+ *
+ * @param[in] cb A callback function to receive the update state changes
+ */
+void lwm2m_register_update_state_callback(lwm2m_engine_update_state_cb cb);
 
 #if defined(CONFIG_LWM2M_FIRMWARE_UPDATE_PULL_SUPPORT)
 /**

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
@@ -72,6 +72,7 @@ static struct lwm2m_engine_res_inst res_inst[RESOURCE_INSTANCE_COUNT];
 
 static lwm2m_engine_set_data_cb_t write_cb;
 static lwm2m_engine_execute_cb_t update_cb;
+static lwm2m_engine_update_state_cb update_state_cb;
 
 #ifdef CONFIG_LWM2M_FIRMWARE_UPDATE_PULL_SUPPORT
 extern int lwm2m_firmware_start_transfer(char *package_uri);
@@ -114,6 +115,10 @@ void lwm2m_firmware_set_update_state(uint8_t state)
 	if (error) {
 		LOG_ERR("Invalid state transition: %u -> %u",
 			update_state, state);
+	}
+
+	if (update_state_cb) {
+		update_state_cb(state);
 	}
 
 	update_state = state;
@@ -283,6 +288,11 @@ void lwm2m_firmware_set_update_cb(lwm2m_engine_execute_cb_t cb)
 lwm2m_engine_execute_cb_t lwm2m_firmware_get_update_cb(void)
 {
 	return update_cb;
+}
+
+void lwm2m_register_update_state_callback(lwm2m_engine_update_state_cb cb)
+{
+	update_state_cb = cb;
 }
 
 static int firmware_update_cb(uint16_t obj_inst_id,


### PR DESCRIPTION
Add the possibility to register callback to receive update state
changes. The intention behind this patch is to know in the application
code whenever the firmware update process is in one of following
states:
- STATE_IDLE (0)
- STATE_DOWNLOADING (1)
- STATE_DOWNLOADED (2)
- STATE_UPDATING (3)

Signed-off-by: Andreas Chmielewski <andreas.chmielewski@grandcentrix.net>