### PR TITLE
Bluetooth: Mesh: Fix array parameter declarations for beacon_auth and app_key_resolve

### DIFF
--- a/subsys/bluetooth/mesh/app_keys.c
+++ b/subsys/bluetooth/mesh/app_keys.c
@@ -445,7 +445,7 @@ ssize_t bt_mesh_app_keys_get(uint16_t net_idx, uint16_t app_idxs[], size_t max,
 
 int bt_mesh_keys_resolve(struct bt_mesh_msg_ctx *ctx,
 			 struct bt_mesh_subnet **sub,
-			 const uint8_t *app_key[16], uint8_t *aid)
+			 const uint8_t **app_key, uint8_t *aid)
 {
 	struct app_key *app = NULL;
 

--- a/subsys/bluetooth/mesh/app_keys.h
+++ b/subsys/bluetooth/mesh/app_keys.h
@@ -41,7 +41,7 @@ int bt_mesh_app_key_set(uint16_t app_idx, uint16_t net_idx,
  */
 int bt_mesh_keys_resolve(struct bt_mesh_msg_ctx *ctx,
 			 struct bt_mesh_subnet **sub,
-			 const uint8_t *app_key[16], uint8_t *aid);
+			 const uint8_t **app_key, uint8_t *aid);
 
 /** @brief Iterate through all matching application keys and call @c cb on each.
  *

--- a/subsys/bluetooth/mesh/crypto.h
+++ b/subsys/bluetooth/mesh/crypto.h
@@ -64,7 +64,7 @@ static inline int bt_mesh_beacon_key(const uint8_t net_key[16],
 }
 
 int bt_mesh_beacon_auth(const uint8_t beacon_key[16], uint8_t flags,
-			const uint8_t net_id[16], uint32_t iv_index,
+			const uint8_t net_id[8], uint32_t iv_index,
 			uint8_t auth[8]);
 
 static inline int bt_mesh_app_id(const uint8_t app_key[16], uint8_t app_id[1])


### PR DESCRIPTION
The crypto.h declaration of the bt_mesh_beacon_auth function declares
the net_id parameter to be a 16 byte array, but the function definition
says 8 bytes. This breaks compilation in GCC 11, which feeds an 8 byte
array into this API, triggering a warning. Change the header declaration
to 8 bytes, which is the right size.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>