### PR TITLE
kernel/swap: Initialize dummy thread's resource pool

### DIFF
--- a/kernel/include/kswap.h
+++ b/kernel/include/kswap.h
@@ -225,6 +225,11 @@ static inline void z_dummy_thread_init(struct k_thread *dummy_thread)
 #ifdef CONFIG_USERSPACE
 	dummy_thread->mem_domain_info.mem_domain = &k_mem_domain_default;
 #endif
+#if (CONFIG_HEAP_MEM_POOL_SIZE > 0)
+	k_thread_system_pool_assign(dummy_thread);
+#else
+	dummy_thread->resource_pool = NULL;
+#endif
 
 	_current_cpu->current = dummy_thread;
 }


### PR DESCRIPTION
This PR addresses the issue related to the dummy thread's uninitialized resource pool described in #41482.

Fixes #41482