### PR TITLE
shell: Fix immediate logging case

### DIFF
--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -649,7 +649,7 @@ struct shell_backend_ctx_flags {
 	uint32_t last_nl      :8; /*!< Last received new line character */
 	uint32_t cmd_ctx      :1; /*!< Shell is executing command */
 	uint32_t print_noinit :1; /*!< Print request from not initialized shell */
-	uint32_t panic_mode   :1; /*!< Shell in panic mode */
+	uint32_t sync_mode    :1; /*!< Shell in synchronous mode */
 };
 
 BUILD_ASSERT((sizeof(struct shell_backend_ctx_flags) == sizeof(uint32_t)),

--- a/subsys/shell/shell_log_backend.c
+++ b/subsys/shell/shell_log_backend.c
@@ -56,6 +56,7 @@ void z_shell_log_backend_enable(const struct shell_log_backend *backend,
 
 		shell = (const struct shell *)ctx;
 
+		z_flag_sync_mode_set(shell, true);
 		/* Reenable transport in blocking mode */
 		err = shell->iface->api->enable(shell->iface, true);
 	}
@@ -289,7 +290,7 @@ static void panic(const struct log_backend *const backend)
 	if (err == 0) {
 		shell->log_backend->control_block->state =
 						SHELL_LOG_BACKEND_PANIC;
-		z_flag_panic_mode_set(shell, true);
+		z_flag_sync_mode_set(shell, true);
 
 		/* Move to the start of next line. */
 		z_shell_multiline_data_calc(&shell->ctx->vt100_ctx.cons,

--- a/subsys/shell/shell_ops.c
+++ b/subsys/shell/shell_ops.c
@@ -510,7 +510,7 @@ void z_shell_fprintf(const struct shell *sh,
 	__ASSERT_NO_MSG(sh->ctx);
 	__ASSERT_NO_MSG(sh->fprintf_ctx);
 	__ASSERT_NO_MSG(fmt);
-	__ASSERT(z_flag_panic_mode_get(sh) || !k_is_in_isr(),
+	__ASSERT(z_flag_sync_mode_get(sh) || !k_is_in_isr(),
 		 "Thread context required.");
 
 	va_list args;

--- a/subsys/shell/shell_ops.h
+++ b/subsys/shell/shell_ops.h
@@ -203,16 +203,16 @@ static inline bool z_flag_print_noinit_set(const struct shell *sh, bool val)
 	return ret;
 }
 
-static inline bool z_flag_panic_mode_get(const struct shell *sh)
+static inline bool z_flag_sync_mode_get(const struct shell *sh)
 {
-	return sh->ctx->ctx.flags.panic_mode == 1;
+	return sh->ctx->ctx.flags.sync_mode == 1;
 }
 
-static inline bool z_flag_panic_mode_set(const struct shell *sh, bool val)
+static inline bool z_flag_sync_mode_set(const struct shell *sh, bool val)
 {
 	bool ret;
 
-	Z_SHELL_SET_FLAG_ATOMIC(sh, ctx, panic_mode, val, ret);
+	Z_SHELL_SET_FLAG_ATOMIC(sh, ctx, sync_mode, val, ret);
 	return ret;
 }
 


### PR DESCRIPTION
When logging is using immediate mode then logging messages
can be processed from any context, including interrupt context.
z_shell_fprintf was asserting in that case since it allowed to
be called from interrupt context only when logging was in panic
mode. However, shell works in the same way when logging is in
immediate mode as in panic mode.

Renamed internal shell flag from panic_mode to sync_mode. Flag
is also set when shell log backend is started in synchronous
mode (immediate logging) which prevents assertion.

Fixes #41289.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>