### PR TITLE
Bluetooth: Controller: llcp: Fix issues related with LLCP context allocation and release

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -534,8 +534,9 @@ config BT_CTLR_LLCP_COMMON_TX_CTRL_BUF_NUM
 
 config BT_CTLR_LLCP_PROC_CTX_BUF_NUM
 	int "Number of control procedure contexts to be available across all connections"
-	default BT_CTLR_LLCP_CONN
-	range 1 255
+	default 2 if BT_CTLR_LLCP_CONN = 1
+	default BT_CTLR_LLCP_CONN if BT_CTLR_LLCP_CONN > 1
+	range 2 255
 	help
 	  Set the number control procedure contexts that is to be available.
 	  This defines the size of the pool of control procedure contexts available

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -2303,6 +2303,7 @@ static void conn_cleanup_finalize(struct ll_conn *conn)
 	}
 #else /* CONFIG_BT_LL_SW_LLCP_LEGACY */
 	ARG_UNUSED(rx);
+	ull_cp_state_set(conn, ULL_CP_DISCONNECTED);
 #endif /* CONFIG_BT_LL_SW_LLCP_LEGACY */
 
 	/* flush demux-ed Tx buffer still in ULL context */


### PR DESCRIPTION
There were two issues related with LLCP context:
1) Not enough memory reserved for LLCP context allocation.
2) Missing release of LLCP contexts when connection is lost.

Default number of LLCP context that were possible to be allocated was a max number of possible connections.
In case of a single connection there were high risk that remote procedure will be acknowledged but never handled by a local device.
As a temporary solution number of contexts was increased to two for single connection.
There should be added queueing mechanism for remote control procedures.

There were missing release of control procedures context when connection was lost.
That lead to exhaustion of contexts and new control procedures were not possible to be executed.
Added code responsible for release of control procedures context when connection is lost.