### PR TITLE
Linker script generator fixes for Windows host.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -802,6 +802,7 @@ if(CONFIG_HAS_DTS)
     --kernel $<TARGET_FILE:${ZEPHYR_LINK_STAGE_EXECUTABLE}>
     --zephyr-base ${ZEPHYR_BASE}
     --start-symbol "$<TARGET_PROPERTY:linker,devices_start_symbol>"
+    VERBATIM
     DEPENDS ${ZEPHYR_LINK_STAGE_EXECUTABLE}
     )
   set_property(GLOBAL APPEND PROPERTY GENERATED_APP_SOURCE_FILES dev_handles.c)

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -3859,13 +3859,13 @@ endfunction()
 # EXPR <expr>  : Expression that defines the symbol. Due to linker limitations
 #                all expressions should only contain simple math, such as
 #                `+, -, *` and similar. The expression will go directly into the
-#                linker, and all `%<symbol>%` will be replaced with the referred
+#                linker, and all `@<symbol>@` will be replaced with the referred
 #                symbol.
 #
 # Example:
 #   To create a new symbol `bar` pointing to the start VMA address of section
 #   `foo` + 1024, one can write:
-#     zephyr_linker_symbol(SYMBOL bar EXPR "(%foo% + 1024)")
+#     zephyr_linker_symbol(SYMBOL bar EXPR "(@foo@ + 1024)")
 #
 function(zephyr_linker_symbol)
   set(single_args "EXPR;SYMBOL")

--- a/cmake/linker/armlink/scatter_script.cmake
+++ b/cmake/linker/armlink/scatter_script.cmake
@@ -394,12 +394,12 @@ function(symbol_to_string)
   get_property(subalign GLOBAL PROPERTY ${STRING_SYMBOL}_SUBALIGN)
 
   string(REPLACE "\\" "" expr "${expr}")
-  string(REGEX MATCHALL "%([^%]*)%" match_res ${expr})
+  string(REGEX MATCHALL "@([^@]*)@" match_res ${expr})
 
   foreach(match ${match_res})
-    string(REPLACE "%" "" match ${match})
+    string(REPLACE "@" "" match ${match})
     get_property(symbol_val GLOBAL PROPERTY SYMBOL_TABLE_${match})
-    string(REPLACE "%${match}%" "ImageBase(${symbol_val})" expr ${expr})
+    string(REPLACE "@${match}@" "ImageBase(${symbol_val})" expr ${expr})
   endforeach()
 
   if(DEFINED subalign)

--- a/cmake/linker/armlink/target.cmake
+++ b/cmake/linker/armlink/target.cmake
@@ -1,13 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# In order to ensure that the armlink symbol name is correctly passed to
-# gen_handles.py, we must first ensure that it is properly escaped.
-# For Python to work, the `$` must be passed as `\$` on command line.
-# In order to pass a single `\` to command line it must first be escaped, that is `\\`.
-# In ninja build files, a `$` is not accepted but must be passed as `$$`.
-# CMake, Python and Ninja combined results in `\\$$` in order to pass a sing `\$` to Python,
-# so `$$` thus becomes: `\\$$\\$$`.
-set_property(TARGET linker PROPERTY devices_start_symbol "Image\\$$\\$$device\\$$\\$$Base")
+set_property(TARGET linker PROPERTY devices_start_symbol "Image$$device$$Base")
 
 find_program(CMAKE_LINKER ${CROSS_COMPILE}armlink PATH ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
 

--- a/cmake/linker/ld/ld_script.cmake
+++ b/cmake/linker/ld/ld_script.cmake
@@ -74,11 +74,11 @@ function(symbol_to_string)
   get_property(subalign GLOBAL PROPERTY ${STRING_SYMBOL}_SUBALIGN)
 
   string(REPLACE "\\" "" expr "${expr}")
-  string(REGEX MATCHALL "%([^%]*)%" match_res ${expr})
+  string(REGEX MATCHALL "@([^@]*)@" match_res ${expr})
 
   foreach(match ${match_res})
-    string(REPLACE "%" "" match ${match})
-    string(REPLACE "%${match}%" "${match}" expr ${expr})
+    string(REPLACE "@" "" match ${match})
+    string(REPLACE "@${match}@" "${match}" expr ${expr})
   endforeach()
 
   set(${STRING_STRING} "${${STRING_STRING}}\n${symbol} = ${expr};\n" PARENT_SCOPE)

--- a/cmake/linker_script/arm/linker.cmake
+++ b/cmake/linker_script/arm/linker.cmake
@@ -144,9 +144,9 @@ if(NOT CONFIG_USERSPACE)
   zephyr_linker_section_configure(SECTION .noinit INPUT ".kernel_noinit.*")
 endif()
 
-zephyr_linker_symbol(SYMBOL __kernel_ram_start EXPR "(%__bss_start%)")
+zephyr_linker_symbol(SYMBOL __kernel_ram_start EXPR "(@__bss_start@)")
 zephyr_linker_symbol(SYMBOL __kernel_ram_end  EXPR "(${RAM_ADDR} + ${RAM_SIZE})")
-zephyr_linker_symbol(SYMBOL __kernel_ram_size EXPR "(%__kernel_ram_end% - %__bss_start%)")
+zephyr_linker_symbol(SYMBOL __kernel_ram_size EXPR "(@__kernel_ram_end@ - @__bss_start@)")
 zephyr_linker_symbol(SYMBOL _image_ram_start  EXPR "(${RAM_ADDR})" SUBALIGN 32) # ToDo calculate 32 correctly
 zephyr_linker_symbol(SYMBOL ARM_LIB_STACKHEAP EXPR "(${RAM_ADDR} + ${RAM_SIZE})" SIZE -0x1000)
 


### PR DESCRIPTION
Fixes: #41435

This PR contains two commits fixing issues on Windows hosts for the linker script generator:
- cmake: linker generator replace % with @ for symbol referencing
- cmake: remove platform / build file specific escaping and use `VERBATIM` flag for `add_custom_command()` instead.
