### PR TITLE
dts: aarch32: Fix Zynq-7000 On-Chip Memory

### DIFF
--- a/dts/arm/xilinx/zynq7000.dtsi
+++ b/dts/arm/xilinx/zynq7000.dtsi
@@ -26,12 +26,13 @@
 		ocm_low: memory@1000 {
 			compatible = "xlnx,zynq-ocm";
 			reg = <0x00001000 DT_SIZE_K(188)>;
-			zephyr,memory-region = "OCM";
+			zephyr,memory-region = "OCM_LOW";
 		};
 
 		ocm_high: memory@fffc0000 {
 			compatible = "xlnx,zynq-ocm";
 			reg = <0xFFFC0000 DT_SIZE_K(256)>;
+			zephyr,memory-region = "OCM_HIGH";
 		};
 
 		arch_timer: timer@f8f00200 {

--- a/dts/bindings/arm/xlnx,zynq-ocm.yaml
+++ b/dts/bindings/arm/xlnx,zynq-ocm.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+
+description: Xilinx Zynq OCM (On-Chip Memory)
+
+compatible: "xlnx,zynq-ocm"
+
+include: [base.yaml, mem-region.yaml]
+
+properties:
+    reg:
+      required: true

--- a/include/arch/arm/aarch32/cortex_a_r/scripts/linker.ld
+++ b/include/arch/arm/aarch32/cortex_a_r/scripts/linker.ld
@@ -352,7 +352,7 @@ GROUP_START(OCM)
 		*(.ocm_bss)
 		*(".ocm_bss.*")
 		__ocm_bss_end = .;
-	} GROUP_LINK_IN(OCM)
+	} GROUP_LINK_IN(LINKER_DT_NODE_REGION_NAME(DT_CHOSEN(zephyr_ocm)))
 
 	SECTION_PROLOGUE(_OCM_DATA_SECTION_NAME,,SUBALIGN(4))
 	{
@@ -360,7 +360,7 @@ GROUP_START(OCM)
 		*(.ocm_data)
 		*(".ocm_data.*")
 		__ocm_data_end = .;
-	} GROUP_LINK_IN(OCM)
+	} GROUP_LINK_IN(LINKER_DT_NODE_REGION_NAME(DT_CHOSEN(zephyr_ocm)))
 
   __ocm_end = .;
   __ocm_size = __ocm_end - __ocm_start;


### PR DESCRIPTION
Proper data section mapping to the OCM region of the Zynq-7000 (board qemu_cortex_a9) no longer works since the introduction of the zephyr,memory-region attributes. Fix this issue by:

- adding the missing YAML file which provides a binding for the memory type "xlnx,zynq-ocm",
- assigning unique memory-region identifiers to the two alternate locations of the OCM, one of which is activated at the board level using a 'chosen' entry,
- modifying the linker command file used by the corresponding arch so that the OCM region is assigned the memory-region identifier of the currently chosen OCM region.
