### PR TITLE
drivers: spi: stm32: Skip pinctrl setup for subghzspi

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -823,6 +823,18 @@ static const struct spi_driver_api api_funcs = {
 	.release = spi_stm32_release,
 };
 
+static inline bool spi_stm32_is_subghzspi(const struct device *dev)
+{
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_subghz)
+	const struct spi_stm32_config *cfg = dev->config;
+
+	return cfg->use_subghzspi_nss;
+#else
+	ARG_UNUSED(dev);
+	return false;
+#endif
+}
+
 static int spi_stm32_init(const struct device *dev)
 {
 	struct spi_stm32_data *data __attribute__((unused)) = dev->data;
@@ -835,11 +847,13 @@ static int spi_stm32_init(const struct device *dev)
 		return -EIO;
 	}
 
-	/* Configure dt provided device signals when available */
-	err = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
-	if (err < 0) {
-		LOG_ERR("SPI pinctrl setup failed (%d)", err);
-		return err;
+	if (!spi_stm32_is_subghzspi(dev)) {
+		/* Configure dt provided device signals when available */
+		err = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
+		if (err < 0) {
+			LOG_ERR("SPI pinctrl setup failed (%d)", err);
+			return err;
+		}
 	}
 
 #ifdef CONFIG_SPI_STM32_INTERRUPT


### PR DESCRIPTION
Subghzspi instances cannot have any pinctrl configs,
they are blacklisted by the dts binding. This caused an
initialization failure of the spi_ll_stm32 driver for
subghzspi instance because no "default" pinctrl was found.
    
This commit solves the problem by skipping the pinctrl setup
for subghzpi devices. The use_subghzpi_nss property is used
to identify a subghzspi device, as this is a required boolean
property only available in the subghzspi binding this is a
perfect indicator for such instances.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/41581