### PR TITLE
drivers: modem: gsm: Fix NULL being passed to rssi_handler

### DIFF
--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -708,7 +708,7 @@ attaching:
 
 	if (!IS_ENABLED(CONFIG_GSM_MUX)) {
 		/* Read connection quality (RSSI) before PPP carrier is ON */
-		rssi_handler(NULL);
+		rssi_handler(&gsm->rssi_work_handle.work);
 
 		if (!(gsm->minfo.mdm_rssi && gsm->minfo.mdm_rssi != GSM_RSSI_INVALID &&
 			gsm->minfo.mdm_rssi < GSM_RSSI_MAXVAL)) {


### PR DESCRIPTION
Fix hard fault due to NULL being passed as argument into rssi_handler, which now derives the `gsm_modem` struct pointer from the argument.

See https://github.com/zephyrproject-rtos/zephyr/pull/41545#issuecomment-1005649021

This is caused by my recent PR #41545, specifically d9ea07b. I apologize for any inconvenience caused.