### PR TITLE
west.yml: Update hal_stm32 with recent cube packages

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -124,7 +124,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 5ca535df5874d1f9ab931265a2b1f691b76df9ce
+      revision: 91531028be0bfa554ae1dd9e2b5d3ed6fd7287c3
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
STM32Cube updates:
   stm32cube: update stm32wb and its lib to version V1.12.1
   stm32cube: update stm32mp1 to version V1.5.0
   stm32cube: update stm32u5 to version V1.0.2

  update stm32cube/common_ll

Signed-off-by: Francois Ramu <francois.ramu@st.com>