### PR TITLE
[RFC] fs/littlefs: allow own partition

### DIFF
--- a/samples/subsys/fs/littlefs/src/main.c
+++ b/samples/subsys/fs/littlefs/src/main.c
@@ -26,7 +26,9 @@ FS_LITTLEFS_DECLARE_DEFAULT_CONFIG(storage);
 static struct fs_mount_t lfs_storage_mnt = {
 	.type = FS_LITTLEFS,
 	.fs_data = &storage,
-	.storage_dev = (void *)FLASH_AREA_ID(storage),
+	.storage_dev = (void *) COND_CODE_1(FLASH_AREA_LABEL_EXISTS(littlefs_storage),
+					    (FLASH_AREA_ID(littlefs_storage)),
+					    (FLASH_AREA_ID(storage))),
 	.mnt_point = "/lfs",
 };
 #endif /* PARTITION_NODE */

--- a/subsys/fs/shell.c
+++ b/subsys/fs/shell.c
@@ -36,7 +36,9 @@ FS_LITTLEFS_DECLARE_DEFAULT_CONFIG(lfs_data);
 static struct fs_mount_t littlefs_mnt = {
 	.type = FS_LITTLEFS,
 	.fs_data = &lfs_data,
-	.storage_dev = (void *)FLASH_AREA_ID(storage),
+	.storage_dev = (void *) COND_CODE_1(FLASH_AREA_LABEL_EXISTS(littlefs_storage),
+					    (FLASH_AREA_ID(littlefs_storage)),
+					    (FLASH_AREA_ID(storage))),
 };
 #endif
 


### PR DESCRIPTION
This patch introduce preference for usage littlefs' dedicated partittion while application declares the FS instance explicitly.
So `littlefs_storage` partition will be used if it is defined while the fstab DTS node for littlefs is not provided.

Objective for this patch is providing out of the box capability to simultaneous usage of littlefs, NVS and FCB

I want to add similar patches for NVS and FCB, but firs I'm request for comments.