### PR TITLE
drivers: counter: sam expose RC reg to DT

### DIFF
--- a/drivers/counter/counter_sam_tc.c
+++ b/drivers/counter/counter_sam_tc.c
@@ -47,6 +47,7 @@ struct counter_sam_dev_cfg {
 	struct counter_config_info info;
 	Tc *regs;
 	uint32_t reg_cmr;
+	uint32_t reg_rc;
 	void (*irq_config_func)(const struct device *dev);
 	const struct soc_gpio_pin *pin_list;
 	uint8_t pin_list_size;
@@ -326,6 +327,7 @@ static int counter_sam_initialize(const struct device *dev)
 
 	/* Clock and Mode Selection */
 	tc_ch->TC_CMR = dev_cfg->reg_cmr;
+	tc_ch->TC_RC = dev_cfg->reg_rc;
 
 #ifdef TC_EMR_NODIVCLK
 	if (dev_cfg->nodivclk) {
@@ -378,6 +380,7 @@ static const struct counter_sam_dev_cfg counter_##n##_sam_config = { \
 	},							\
 	.regs = (Tc *)DT_INST_REG_ADDR(n),			\
 	.reg_cmr = COUNTER_SAM_TC_REG_CMR(n),			\
+	.reg_rc = DT_INST_PROP_OR(n, reg_rc, 0),		\
 	.irq_config_func = &counter_##n##_sam_config_func,	\
 	.pin_list = pins_tc##n,					\
 	.pin_list_size = ARRAY_SIZE(pins_tc##n),		\

--- a/dts/bindings/timer/atmel,sam-tc.yaml
+++ b/dts/bindings/timer/atmel,sam-tc.yaml
@@ -55,6 +55,17 @@ properties:
         the driver to count events generated on the TIOA, TIOB signal connected
         to the external pin.
 
+    reg-rc:
+      type: int
+      required: false
+      description: |
+        Register C compare/match value. RC can be used as compare/match unit
+        for an specific timer unit. Their use depends on how timer channel
+        is configured,see reg-cmr. It can be used as trigger for both input
+        capture or counter mode, or even as event source. The RC register
+        behavior is SoC dependent. For more information and use cases,
+        check SoC datasheet and application notes.
+
     pinctrl-0:
       type: phandles
       required: false


### PR DESCRIPTION
Exposes the RC register so that the initial value can be set in
the device tree. This is useful in the case where the timer
generates an event but an interrupt is not required.
e.g generate event to sample adc on RC register match.

Tested on Atmel SMART SAM E70 Xplained Ultra board

Signed-off-by: Marius Scholtz <mariuss@ricelectronics.com>