### PR TITLE
soc: esp32: use SoC name as IDF target instead of board name

### DIFF
--- a/soc/xtensa/esp32/CMakeLists.txt
+++ b/soc/xtensa/esp32/CMakeLists.txt
@@ -25,7 +25,7 @@ if(CONFIG_BOOTLOADER_ESP_IDF)
     ${CMAKE_COMMAND} -G${CMAKE_GENERATOR}
     -S ${espidf_components_dir}/bootloader/subproject
     -B ${espidf_build_dir}/bootloader -DSDKCONFIG=${espidf_build_dir}/sdkconfig
-    -DIDF_PATH=${ESP_IDF_PATH} -DIDF_TARGET=${CONFIG_BOARD}
+    -DIDF_PATH=${ESP_IDF_PATH} -DIDF_TARGET=${CONFIG_SOC}
     -DPYTHON_DEPS_CHECKED=1
     -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
     -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}


### PR DESCRIPTION
So far board name was used as IDF target. This worked, as the only board
in tree that is based on 'esp32' SoC is actually 'esp32'.

Use CONFIG_SOC instead of CONFIG_BOARD, so that new boards based on
'esp32' SoC can be successfully introduced both downstream or upstream.