### PR TITLE
scripts: runners: esp32: remove print() call

### DIFF
--- a/scripts/west_commands/runners/esp32.py
+++ b/scripts/west_commands/runners/esp32.py
@@ -116,5 +116,4 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
 
         self.logger.info("Flashing esp32 chip on {} ({}bps)".
                          format(self.device, self.baud))
-        print(cmd_flash)
         self.check_call(cmd_flash)


### PR DESCRIPTION
This print() call was introduced as part of commit 16571db029ed ("soc:
esp32: add support to mcuboot build") probably as a leftover from
debugging stage. Remove that, so flash command is not printed by
default. Those commmands can be easily printed by passing -v flag to
`west -v flash ...` command.