### PR TITLE
lib/posix/fs: fix end-of-dir in readdir

### DIFF
--- a/lib/posix/fs.c
+++ b/lib/posix/fs.c
@@ -290,6 +290,11 @@ struct dirent *readdir(DIR *dirp)
 		return NULL;
 	}
 
+	if (fdirent.name[0] == 0) {
+		/* assume end-of-dir, leave errno untouched */
+		return NULL;
+	}
+
 	rc = strlen(fdirent.name);
 	rc = (rc < MAX_FILE_NAME) ? rc : (MAX_FILE_NAME - 1);
 	(void)memcpy(pdirent.d_name, fdirent.name, rc);

--- a/tests/posix/fs/src/test_fs_dir.c
+++ b/tests/posix/fs/src/test_fs_dir.c
@@ -54,6 +54,7 @@ static int test_mkdir(void)
 static int test_lsdir(const char *path)
 {
 	DIR *dirp;
+	int res = 0;
 	struct dirent *entry;
 
 	TC_PRINT("\nreaddir test:\n");
@@ -67,20 +68,24 @@ static int test_lsdir(const char *path)
 
 	TC_PRINT("\nListing dir %s:\n", path);
 	/* Verify fs_readdir() */
-	entry = readdir(dirp);
+	errno = 0;
+	while ((entry = readdir(dirp)) != NULL) {
+		if (entry->d_name[0] == 0) {
+			res = -EIO;
+			break;
+		}
 
-	/* entry.name[0] == 0 means end-of-dir */
-	if (entry == NULL) {
-		closedir(dirp);
-		return -EIO;
-	} else {
 		TC_PRINT("[FILE] %s\n", entry->d_name);
+	}
+
+	if (errno) {
+		res = -EIO;
 	}
 
 	/* Verify fs_closedir() */
 	closedir(dirp);
 
-	return 0;
+	return res;
 }
 
 /**


### PR DESCRIPTION
POSIX readdir should return NULL if end of dir is reached and
leave errno untouched.

Signed-off-by: Rico Ganahl <rico.ganahl@bytesatwork.ch>