### PR TITLE
tests: disk: Add fixture for sdcard test

### DIFF
--- a/tests/drivers/disk/testcase.yaml
+++ b/tests/drivers/disk/testcase.yaml
@@ -1,5 +1,8 @@
 tests:
   drivers.disk.usdhc:
+    harness: ztest
+    harness_config:
+      fixture: fixture_sdhc
     filter: CONFIG_SDMMC_USDHC
     tags: disk mcux
     integration_platforms:


### PR DESCRIPTION
Add fixture disk_sdcard for the sdcard test, since the test requires an
SD card to be present on the board.

Fixes #41331 

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>