### PR TITLE
boards: mimxrt1170_evk_cm7: Enable watchdog

### DIFF
--- a/boards/arm/mimxrt1170_evk/doc/index.rst
+++ b/boards/arm/mimxrt1170_evk/doc/index.rst
@@ -115,6 +115,8 @@ features:
 +-----------+------------+-------------------------------------+
 | GPT       | on-chip    | gpt                                 |
 +-----------+------------+-------------------------------------+
+| WATCHDOG  | on-chip    | watchdog                            |
++-----------+------------+-------------------------------------+
 
 The default configuration can be found in the defconfig file:
 ``boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm7_defconfig``

--- a/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm7.dts
+++ b/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm7.dts
@@ -117,3 +117,7 @@
 &gpt_hw_timer {
 	status = "okay";
 };
+
+&wdog1 {
+	status = "okay";
+};

--- a/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm7.yaml
+++ b/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm7.yaml
@@ -23,3 +23,4 @@ supported:
   - i2c
   - pwm
   - dma
+  - watchdog


### PR DESCRIPTION
Enable watchdog for RT1170 EVK. Tested using
test/drivers/watchdog/wdt_basic_api.