### PR TITLE
net: shell: Fix parser error on net ping command

### DIFF
--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -4114,6 +4114,7 @@ static int parse_arg(size_t *i, size_t argc, char *argv[])
 		str = argv[*i];
 	}
 
+	errno = 0;
 	res = strtol(str, &endptr, 10);
 
 	if (errno || (endptr == str)) {


### PR DESCRIPTION
The strtol() function use errno to return error code.
However, it is not being initialized in the parser_arg()
function before calling the strtol(). Thus, hitting error
when performing net ping command with -c / -i parameters.

Signed-off-by: Kweh Hock Leong <hock.leong.kweh@intel.com>