### PR TITLE
ITE: drivers/bbram: add magic number to compare in initial

### DIFF
--- a/drivers/bbram/Kconfig.it8xxx2
+++ b/drivers/bbram/Kconfig.it8xxx2
@@ -1,12 +1,12 @@
 # Copyright (c) 2021 Google Inc
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_ST_BBRAM_IT8XXX2 := ite,it8xxx2-bbram
+DT_COMPAT_ITE_IT8XXX2_BBRAM := ite,it8xxx2-bbram
 
 config BBRAM_IT8XXX2
 	bool "ITE IT81202 Battery-backed RAM drivers"
 	depends on SOC_FAMILY_RISCV_ITE
-	default $(dt_compat_enabled,${DT_COMPAT_ST_BBRAM_IT8XXX2})
+	default $(dt_compat_enabled,$(DT_COMPAT_ITE_IT8XXX2_BBRAM))
 	help
 	  This option enables the BBRAM driver for RISCV_ITE family of
 	  processors.

--- a/drivers/bbram/bbram_it8xxx2.c
+++ b/drivers/bbram/bbram_it8xxx2.c
@@ -13,6 +13,12 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(bbram, CONFIG_BBRAM_LOG_LEVEL);
 
+#define BRAM_VALID_MAGIC        0x4252414D  /* "BRAM" */
+#define BRAM_VALID_MAGIC_FIELD0 (BRAM_VALID_MAGIC & 0xff)
+#define BRAM_VALID_MAGIC_FIELD1 ((BRAM_VALID_MAGIC >> 8) & 0xff)
+#define BRAM_VALID_MAGIC_FIELD2 ((BRAM_VALID_MAGIC >> 16) & 0xff)
+#define BRAM_VALID_MAGIC_FIELD3 ((BRAM_VALID_MAGIC >> 24) & 0xff)
+
 /** Device config */
 struct bbram_it8xxx2_config {
 	/** BBRAM base address */
@@ -53,7 +59,30 @@ static const struct bbram_driver_api bbram_it8xxx2_driver_api = {
 
 static int bbram_it8xxx2_init(const struct device *dev)
 {
-	ARG_UNUSED(dev);
+	const struct bbram_it8xxx2_config *config = dev->config;
+	uint8_t *base_addr = (uint8_t *)config->base_addr;
+	uint8_t *bram_valid_flag0 = base_addr + BRAM_IDX_VALID_FLAGS0;
+	uint8_t *bram_valid_flag1 = base_addr + BRAM_IDX_VALID_FLAGS1;
+	uint8_t *bram_valid_flag2 = base_addr + BRAM_IDX_VALID_FLAGS2;
+	uint8_t *bram_valid_flag3 = base_addr + BRAM_IDX_VALID_FLAGS3;
+
+	if ((*bram_valid_flag0 != BRAM_VALID_MAGIC_FIELD0) ||
+	    (*bram_valid_flag1 != BRAM_VALID_MAGIC_FIELD1) ||
+	    (*bram_valid_flag2 != BRAM_VALID_MAGIC_FIELD2) ||
+	    (*bram_valid_flag3 != BRAM_VALID_MAGIC_FIELD3)) {
+		/*
+		 * Magic does not match, so BRAM must be uninitialized. Clear
+		 * entire Bank0 BRAM, and set magic value.
+		 */
+		for (int i = 0; i < BRAM_IDX_VALID_FLAGS0; i++) {
+			*(base_addr + i) = 0;
+		}
+
+		*bram_valid_flag0 = BRAM_VALID_MAGIC_FIELD0;
+		*bram_valid_flag1 = BRAM_VALID_MAGIC_FIELD1;
+		*bram_valid_flag2 = BRAM_VALID_MAGIC_FIELD2;
+		*bram_valid_flag3 = BRAM_VALID_MAGIC_FIELD3;
+	}
 
 	return 0;
 }

--- a/soc/riscv/riscv-ite/common/chip_chipregs.h
+++ b/soc/riscv/riscv-ite/common/chip_chipregs.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2020 ITE Corporation. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -1868,6 +1868,24 @@ struct gctrl_it8xxx2_regs {
 #define IT8XXX2_GCTRL_HGRST		BIT(3)
 /* bit[2] = 1: Enable global reset. */
 #define IT8XXX2_GCTRL_GRST		BIT(2)
+
+/**
+ *
+ * (22xxh) Battery-backed SRAM (BRAM) registers
+ *
+ */
+#ifndef __ASSEMBLER__
+/* Battery backed RAM indices. */
+#define BRAM_MAGIC_FIELD_OFFSET 0xbc
+enum bram_indices {
+
+	/* This field is used to indicate BRAM is valid or not. */
+	BRAM_IDX_VALID_FLAGS0 = BRAM_MAGIC_FIELD_OFFSET,
+	BRAM_IDX_VALID_FLAGS1,
+	BRAM_IDX_VALID_FLAGS2,
+	BRAM_IDX_VALID_FLAGS3
+};
+#endif /* !__ASSEMBLER__ */
 
 #ifndef __ASSEMBLER__
 /*


### PR DESCRIPTION
BBRAM content should be cleared when boot from cutoff. Compare magic
number to decide whether to clear entire BBRAM.

Signed-off-by: Tim Lin <tim2.lin@ite.corp-partner.google.com>