### PR TITLE
spi: Grab relevant properties from DTS into the operation bitfield

### DIFF
--- a/dts/bindings/spi/spi-device.yaml
+++ b/dts/bindings/spi/spi-device.yaml
@@ -18,6 +18,7 @@ properties:
       required: true
     duplex:
       type: int
+      default: 0
       required: false
       description: |
         Duplex mode, full or half. By default it's always full duplex thus 0

--- a/include/drivers/spi.h
+++ b/include/drivers/spi.h
@@ -297,7 +297,9 @@ struct spi_config {
 #define SPI_CONFIG_DT(node_id, operation_, delay_)			\
 	{								\
 		.frequency = DT_PROP(node_id, spi_max_frequency),	\
-		.operation = (operation_),				\
+		.operation = (operation_) |				\
+			DT_PROP(node_id, duplex) |			\
+			DT_PROP(node_id, frame_format),			\
 		.slave = DT_REG_ADDR(node_id),				\
 		.cs = COND_CODE_1(					\
 			DT_SPI_DEV_HAS_CS_GPIOS(node_id),		\


### PR DESCRIPTION
duplex and frame_format where recently added and obviously need to be
grabbed from DTS relevantly.

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>