### PR TITLE
Cleanup depfile usage

### DIFF
--- a/cmake/linker/ld/target.cmake
+++ b/cmake/linker/ld/target.cmake
@@ -67,7 +67,6 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
     endif()
 
     zephyr_get_include_directories_for_lang(C current_includes)
-    get_filename_component(base_name ${CMAKE_CURRENT_BINARY_DIR} NAME)
     get_property(current_defines GLOBAL PROPERTY PROPERTY_LINKER_SCRIPT_DEFINES)
 
     add_custom_command(
@@ -81,7 +80,7 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
       COMMAND ${CMAKE_C_COMPILER}
       -x assembler-with-cpp
       ${NOSYSDEF_CFLAG}
-      -MD -MF ${linker_script_gen}.dep -MT ${base_name}/${linker_script_gen}
+      -MD -MF ${linker_script_gen}.dep -MT ${linker_script_gen}
       -D_LINKER
       -D_ASMLANGUAGE
       -imacros ${AUTOCONF_H}

--- a/cmake/linker/ld/target.cmake
+++ b/cmake/linker/ld/target.cmake
@@ -50,13 +50,10 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
     set(template_script_defines ${linker_pass_define})
     list(TRANSFORM template_script_defines PREPEND "-D")
 
-    # Different generators deal with depfiles differently.
-    if(CMAKE_GENERATOR STREQUAL "Unix Makefiles")
-      # Note that the IMPLICIT_DEPENDS option is currently supported only
-      # for Makefile generators and will be ignored by other generators.
-      set(linker_script_dep IMPLICIT_DEPENDS C ${LINKER_SCRIPT})
-    elseif(CMAKE_GENERATOR STREQUAL "Ninja")
-      # Using DEPFILE with other generators than Ninja is an error.
+    # Only Ninja and Makefile generators support DEPFILE.
+    if((CMAKE_GENERATOR STREQUAL "Ninja")
+       OR (CMAKE_GENERATOR MATCHES "Makefiles")
+    )
       set(linker_script_dep DEPFILE ${PROJECT_BINARY_DIR}/${linker_script_gen}.dep)
     else()
       # TODO: How would the linker script dependencies work for non-linker


### PR DESCRIPTION
This is a series of commits that cleans up our DEPFILE usage.

With CMake 3.20 relative paths inside DEPFILEs are treated relative to CMAKE_CURRENT_BINARY_DIR and CMake will transform the path internally, therefore we must remove `base_name`.

With CMake 3.20 Makefile Generators now supports DEPFILE, this mean we can align the CMake code to only use DEPFILE.