### PR TITLE
ci: doc-build: run apt-get update before install

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -47,6 +47,7 @@ jobs:
 
     - name: install-pkgs
       run: |
+        sudo apt-get update
         sudo apt-get install -y ninja-build graphviz libclang1-9 libclang-cpp9
         wget -q https://www.doxygen.nl/files/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz
         tar xf doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz


### PR DESCRIPTION
Make sure the package index is always up-to-date before installing.