### PR TITLE
dts: nrf_qspi_nor: add option for specifying size in bytes

### DIFF
--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -55,7 +55,18 @@ struct qspi_nor_config {
 #define QSPI_BLOCK_SIZE SPI_NOR_BLOCK_SIZE
 
 /* instance 0 flash size in bytes */
+#if DT_INST_NODE_HAS_PROP(0, size_in_bytes)
+#define INST_0_BYTES (DT_INST_PROP(0, size_in_bytes))
+#elif DT_INST_NODE_HAS_PROP(0, size)
 #define INST_0_BYTES (DT_INST_PROP(0, size) / 8)
+#else
+#error "No size specified. 'size' or 'size-in-bytes' must be set"
+#endif
+
+BUILD_ASSERT(!(DT_INST_NODE_HAS_PROP(0, size_in_bytes) && DT_INST_NODE_HAS_PROP(0, size)),
+	     "Node " DT_NODE_PATH(DT_DRV_INST(0)) " has both size and size-in-bytes "
+	     "properties; use exactly one");
+
 
 #define INST_0_SCK_FREQUENCY DT_INST_PROP(0, sck_frequency)
 BUILD_ASSERT(INST_0_SCK_FREQUENCY >= (NRF_QSPI_BASE_CLOCK_FREQ / 16),

--- a/dts/bindings/mtd/nordic,qspi-nor.yaml
+++ b/dts/bindings/mtd/nordic,qspi-nor.yaml
@@ -21,7 +21,16 @@ properties:
     required: true
 
   size:
-    required: true
+    type: int
+    required: false
+    description: |
+      The size in bits. Set this or size-in-bytes, but not both.
+
+  size-in-bytes:
+    type: int
+    required: false
+    description: |
+      The size in bytes. Set this or size, but not both.
 
   # Match original driver NORDIC_QSPI_NOR_QE_BIT Kconfig default.
   quad-enable-requirements:

--- a/tests/drivers/flash/boards/nrf52840_size_in_bytes.overlay
+++ b/tests/drivers/flash/boards/nrf52840_size_in_bytes.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2022, Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&mx25r64 {
+        /delete-property/ size;
+        size-in-bytes = <8388608>;
+};

--- a/tests/drivers/flash/src/main.c
+++ b/tests/drivers/flash/src/main.c
@@ -11,9 +11,15 @@
 #include <storage/flash_map.h>
 
 #if (CONFIG_NORDIC_QSPI_NOR - 0)
-#define FLASH_DEVICE DT_LABEL(DT_INST(0, nordic_qspi_nor))
+#define NORDIC_QSPI_NOR_NODE DT_INST(0, nordic_qspi_nor)
+#define FLASH_DEVICE DT_LABEL(NORDIC_QSPI_NOR_NODE)
 #define FLASH_TEST_REGION_OFFSET 0xff000
-#define TEST_AREA_MAX DT_PROP(DT_INST(0, nordic_qspi_nor), size)
+
+#if DT_NODE_HAS_PROP(NORDIC_QSPI_NOR_NODE, size_in_bytes)
+#define TEST_AREA_MAX (DT_PROP(DT_INST(0, nordic_qspi_nor), size_in_bytes))
+#else
+#define TEST_AREA_MAX DT_PROP(DT_INST(0, nordic_qspi_nor), size * 8)
+#endif
 
 #elif defined(CONFIG_FLASH_MCUX_FLEXSPI_NOR)
 

--- a/tests/drivers/flash/testcase.yaml
+++ b/tests/drivers/flash/testcase.yaml
@@ -5,6 +5,14 @@ tests:
     extra_args: OVERLAY_CONFIG=boards/nrf52840_flash_qspi.conf
     integration_platforms:
       - nrf52840dk_nrf52840
+  drivers.flash.nrf_qspi_nor.size_in_bytes:
+    platform_allow: nrf52840dk_nrf52840
+    tags: flash nrf52 nrf_qspi_fash
+    extra_args:
+      OVERLAY_CONFIG=boards/nrf52840_flash_qspi.conf
+      DTC_OVERLAY_FILE=boards/nrf52840_size_in_bytes.overlay
+    integration_platforms:
+      - nrf52840dk_nrf52840
   drivers.flash.soc_flash_nrf:
     platform_allow: nrf52840dk_nrf52840
     tags: nrf52 soc_flash_nrf


### PR DESCRIPTION
If a user has a 1GB external flash it is currently not possible
to configure this through DTS. To allow for such a configuration
we add an option which specifies that the size is in bytes not bits.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>