### PR TITLE
ci: doc-build: run apt-get update before install

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -30,7 +30,7 @@ env:
   # The latest CMake available directly with apt is 3.18, but we need >=3.20
   # so we fetch that through pip.
   CMAKE_VERSION: 3.20.5
-  DOXYGEN_VERSION: 1.9.1
+  DOXYGEN_VERSION: 1.9.2
 
 jobs:
   doc-build-html:

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -44,6 +44,7 @@ jobs:
     - name: install-pkgs
       run: |
         sudo apt-get update
+        sudo apt-get upgrade
         sudo apt-get install -y ninja-build graphviz libclang1-9 libclang-cpp9
         wget -q https://www.doxygen.nl/files/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz
         tar xf doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -43,6 +43,7 @@ jobs:
 
     - name: install-pkgs
       run: |
+        sudo apt-get update
         sudo apt-get install -y ninja-build graphviz libclang1-9 libclang-cpp9
         wget -q https://www.doxygen.nl/files/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz
         tar xf doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz


### PR DESCRIPTION
Make sure the package index is always up-to-date before installing.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>