### PR TITLE
ci: doc-build: use --no-verbose when using wget

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -48,7 +48,7 @@ jobs:
     - name: install-pkgs
       run: |
         sudo apt-get install -y ninja-build graphviz libclang1-9 libclang-cpp9
-        wget -q https://www.doxygen.nl/files/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz
+        wget --no-verbose https://www.doxygen.nl/files/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz
         tar xf doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz
         echo "${PWD}/doxygen-${DOXYGEN_VERSION}/bin" >> $GITHUB_PATH
 


### PR DESCRIPTION
The -q flag supresses all wget output, even when there is a failure.
This makes it difficult to diagnose CI failures when the download fails.
The --no-verbose flag is a better choice: it is silent enough but it
always shows the outcome.