### PR TITLE
kernel: Fix typo in macro name

### DIFF
--- a/include/arch/x86/ia32/arch.h
+++ b/include/arch/x86/ia32/arch.h
@@ -427,13 +427,13 @@ extern struct task_state_segment _main_tss;
  */
 #if defined(CONFIG_EAGER_FPU_SHARING) || defined(CONFIG_LAZY_FPU_SHARING)
 #ifdef CONFIG_SSE
-#define ARCH_DYMANIC_OBJ_K_THREAD_ALIGNMENT	16
+#define ARCH_DYNAMIC_OBJ_K_THREAD_ALIGNMENT	16
 #else
-#define ARCH_DYMANIC_OBJ_K_THREAD_ALIGNMENT	(sizeof(void *))
+#define ARCH_DYNAMIC_OBJ_K_THREAD_ALIGNMENT	(sizeof(void *))
 #endif
 #else
 /* No special alignment requirements, simply align on pointer size. */
-#define ARCH_DYMANIC_OBJ_K_THREAD_ALIGNMENT	(sizeof(void *))
+#define ARCH_DYNAMIC_OBJ_K_THREAD_ALIGNMENT	(sizeof(void *))
 #endif /* CONFIG_*_FP_SHARING */
 
 

--- a/include/arch/x86/intel64/arch.h
+++ b/include/arch/x86/intel64/arch.h
@@ -136,6 +136,6 @@ struct x86_ssf {
 /*
  * Thread object needs to be 16-byte aligned.
  */
-#define ARCH_DYMANIC_OBJ_K_THREAD_ALIGNMENT	16
+#define ARCH_DYNAMIC_OBJ_K_THREAD_ALIGNMENT	16
 
 #endif /* ZEPHYR_INCLUDE_ARCH_X86_INTEL64_ARCH_H_ */

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -124,8 +124,8 @@ uint8_t *z_priv_stack_find(k_thread_stack_t *stack)
  * the maximum alignment needed for all kernel objects
  * (hence the following DYN_OBJ_DATA_ALIGN).
  */
-#ifdef ARCH_DYMANIC_OBJ_K_THREAD_ALIGNMENT
-#define DYN_OBJ_DATA_ALIGN_K_THREAD	(ARCH_DYMANIC_OBJ_K_THREAD_ALIGNMENT)
+#ifdef ARCH_DYNAMIC_OBJ_K_THREAD_ALIGNMENT
+#define DYN_OBJ_DATA_ALIGN_K_THREAD	(ARCH_DYNAMIC_OBJ_K_THREAD_ALIGNMENT)
 #else
 #define DYN_OBJ_DATA_ALIGN_K_THREAD	(sizeof(void *))
 #endif
@@ -187,8 +187,8 @@ static size_t obj_align_get(enum k_objects otype)
 
 	switch (otype) {
 	case K_OBJ_THREAD:
-#ifdef ARCH_DYMANIC_OBJ_K_THREAD_ALIGNMENT
-		ret = ARCH_DYMANIC_OBJ_K_THREAD_ALIGNMENT;
+#ifdef ARCH_DYNAMIC_OBJ_K_THREAD_ALIGNMENT
+		ret = ARCH_DYNAMIC_OBJ_K_THREAD_ALIGNMENT;
 #else
 		ret = __alignof(struct dyn_obj);
 #endif


### PR DESCRIPTION
Fixes a typo in the macro ARCH_DYMANIC_OBJ_K_THREAD_ALIGNMENT
so that DYMANIC becomes DYNAMIC.

Fixes: #41253 