### PR TITLE
fs: Use fs_mount_t.node to check if system is mounted 

### DIFF
--- a/subsys/fs/fs.c
+++ b/subsys/fs/fs.c
@@ -653,6 +653,11 @@ int fs_mount(struct fs_mount_t *mp)
 		return -EINVAL;
 	}
 
+	if (sys_dnode_is_linked(&mp->node)) {
+		LOG_ERR("file system already mounted!!");
+		return -EBUSY;
+	}
+
 	len = strlen(mp->mnt_point);
 
 	if ((len <= 1) || (mp->mnt_point[0] != '/')) {
@@ -725,7 +730,7 @@ int fs_unmount(struct fs_mount_t *mp)
 
 	k_mutex_lock(&mutex, K_FOREVER);
 
-	if (mp->fs == NULL) {
+	if (!sys_dnode_is_linked(&mp->node)) {
 		LOG_ERR("fs not mounted (mp == %p)", mp);
 		goto unmount_err;
 	}


### PR DESCRIPTION
 fs: Use fs_mount_t.node to check if system is mounted

The commit changes fs_mount and fs_unmount to use node fs_mount_t
member to decide whether file system described by given fs_mount_t
object has already been mounted.
Previously there was no such check in case of fs_mount, which
would allow to remount the same object as long as mount path
has been changed.
The fs_unmount has been checking whether API pointer (fs) has been
filled now it checks whether fs_mount_t is linked anywhere,
which is sign that the object is used.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>