### PR TITLE
Yet more ongoing cAVS cleanup & futureproofing

### DIFF
--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -89,4 +89,21 @@ config XTENSA_SMALL_VECTOR_TABLE_ENTRY
 	  handlers to the end of vector table, renaming them to
 	  _Level\LVL\()VectorHelper.
 
+config XTENSA_CACHED_REGION
+	int "Cached RPO mapping"
+	range 0 7
+	help
+	  A design trick on multi-core hardware is to map memory twice
+	  so that it can be seen in both (incoherent) cached mappings
+	  and a coherent "shared" area.  This specifies which 512M
+	  region (0-7, as defined by the Xtensa Region Protection
+	  Option) contains the "cached" mapping.
+
+config XTENSA_UNCACHED_REGION
+	int "Uncached RPO mapping"
+	range 0 7
+	help
+	  As for XTENSA_CACHED_REGION, this specifies which 512M
+	  region (0-7) contains the "uncached" mapping.
+
 endmenu

--- a/arch/xtensa/include/kernel_arch_func.h
+++ b/arch/xtensa/include/kernel_arch_func.h
@@ -58,18 +58,6 @@ static inline void arch_switch(void *switch_to, void **switched_from)
 	return xtensa_switch(switch_to, switched_from);
 }
 
-/* FIXME: we don't have a framework for including this from the SoC
- * layer, so we define it in the arch code here.
- */
-#if defined(CONFIG_SOC_FAMILY_INTEL_ADSP) && defined(CONFIG_KERNEL_COHERENCE)
-static inline bool arch_mem_coherent(void *ptr)
-{
-	size_t addr = (size_t) ptr;
-
-	return addr >= 0x80000000 && addr < 0xa0000000;
-}
-#endif
-
 #ifdef CONFIG_KERNEL_COHERENCE
 static ALWAYS_INLINE void arch_cohere_stacks(struct k_thread *old_thread,
 					     void *old_switch_handle,

--- a/include/arch/xtensa/cache.h
+++ b/include/arch/xtensa/cache.h
@@ -15,8 +15,9 @@ extern "C" {
 
 #define Z_DCACHE_MAX (XCHAL_DCACHE_SIZE / XCHAL_DCACHE_WAYS)
 
-#if XCHAL_DCACHE_SIZE
 #define Z_IS_POW2(x) (((x) != 0) && (((x) & ((x)-1)) == 0))
+
+#if XCHAL_DCACHE_SIZE
 BUILD_ASSERT(Z_IS_POW2(XCHAL_DCACHE_LINESIZE));
 BUILD_ASSERT(Z_IS_POW2(Z_DCACHE_MAX));
 #endif
@@ -77,6 +78,139 @@ static ALWAYS_INLINE void z_xtensa_cache_flush_inv_all(void)
 {
 	z_xtensa_cache_flush_inv(NULL, Z_DCACHE_MAX);
 }
+
+#ifdef CONFIG_ARCH_HAS_COHERENCE
+static inline bool arch_mem_coherent(void *ptr)
+{
+	size_t addr = (size_t) ptr;
+
+	return (addr >> 29) == CONFIG_XTENSA_UNCACHED_REGION;
+}
+#endif
+
+static ALWAYS_INLINE uint32_t z_xtrpoflip(uint32_t addr, uint32_t rto, uint32_t rfrom)
+{
+	/* The math here is all compile-time: when the two regions
+	 * differ by a power of two, we can convert between them by
+	 * setting or clearing just one bit.  Otherwise it needs two
+	 * operations.
+	 */
+	uint32_t rxor = (rto ^ rfrom) << 29;
+
+	rto <<= 29;
+	if (Z_IS_POW2(rxor)) {
+		if ((rxor & rto) == 0) {
+			return addr & ~rxor;
+		} else {
+			return addr | rxor;
+		}
+	} else {
+		return (addr & ~(7U << 29)) | rto;
+	}
+}
+
+/**
+ * @brief Return cached pointer to a RAM address
+ *
+ * The Xtensa coherence architecture maps addressable RAM twice, in
+ * two different 512MB regions whose L1 cache settings can be
+ * controlled independently.  So for any given pointer, it is possible
+ * to convert it to and from a cached version.
+ *
+ * This function takes a pointer to any addressible object (either in
+ * cacheable memory or not) and returns a pointer that can be used to
+ * refer to the same memory through the L1 data cache.  Data read
+ * through the resulting pointer will reflect locally cached values on
+ * the current CPU if they exist, and writes will go first into the
+ * cache and be written back later.
+ *
+ * @see arch_xtensa_uncached_ptr()
+ *
+ * @param ptr A pointer to a valid C object
+ * @return A pointer to the same object via the L1 dcache
+ */
+static inline void *arch_xtensa_cached_ptr(void *ptr)
+{
+	return (void *)z_xtrpoflip((uint32_t) ptr,
+				   CONFIG_XTENSA_CACHED_REGION,
+				   CONFIG_XTENSA_UNCACHED_REGION);
+}
+
+/**
+ * @brief Return uncached pointer to a RAM address
+ *
+ * The Xtensa coherence architecture maps addressable RAM twice, in
+ * two different 512MB regions whose L1 cache settings can be
+ * controlled independently.  So for any given pointer, it is possible
+ * to convert it to and from a cached version.
+ *
+ * This function takes a pointer to any addressible object (either in
+ * cacheable memory or not) and returns a pointer that can be used to
+ * refer to the same memory while bypassing the L1 data cache.  Data
+ * in the L1 cache will not be inspected nor modified by the access.
+ *
+ * @see arch_xtensa_cached_ptr()
+ *
+ * @param ptr A pointer to a valid C object
+ * @return A pointer to the same object bypassing the L1 dcache
+ */
+static inline void *arch_xtensa_uncached_ptr(void *ptr)
+{
+	return (void *)z_xtrpoflip((uint32_t) ptr,
+				   CONFIG_XTENSA_UNCACHED_REGION,
+				   CONFIG_XTENSA_CACHED_REGION);
+}
+
+/* Utility to generate an unrolled and optimal[1] code sequence to set
+ * the RPO TLB registers (contra the HAL cacheattr macros, which
+ * generate larger code and can't be called from C), based on the
+ * KERNEL_COHERENCE configuration in use.  Selects RPO attribute "2"
+ * for regions (including MMIO registers in region zero) which want to
+ * bypass L1, "4" for the cached region which wants writeback, and
+ * "15" (invalid) elsewhere.
+ *
+ * Note that on cores that have the "translation" option set, we need
+ * to put an identity mapping in the high bits.  Also per spec
+ * changing the current code region (by definition cached) requires
+ * that WITLB be followed by an ISYNC and that both instructions live
+ * in the same cache line (two 3-byte instructions fit in an 8-byte
+ * aligned region, so that's guaranteed not to cross a cache line
+ * boundary).
+ *
+ * [1] With the sole exception of gcc's infuriating insistence on
+ * emitting a precomputed literal for addr + addrincr instead of
+ * computing it with a single ADD instruction from values it already
+ * has in registers.  Explicitly assigning the variables to registers
+ * via an attribute works, but then emits needless MOV instructions
+ * instead.  I tell myself it's just 32 bytes of .text, but... Sigh.
+ */
+#define _REGION_ATTR(r)						\
+	((r) == 0 ? 2 :						\
+	 ((r) == CONFIG_XTENSA_CACHED_REGION ? 4 :		\
+	  ((r) == CONFIG_XTENSA_UNCACHED_REGION ? 2 : 15)))
+
+#define _SET_ONE_TLB(region) do {				\
+	uint32_t attr = _REGION_ATTR(region);			\
+	if (XCHAL_HAVE_XLT_CACHEATTR) {				\
+		attr |= addr; /* RPO with translation */	\
+	}							\
+	if (region != CONFIG_XTENSA_CACHED_REGION) {		\
+		__asm__ volatile("wdtlb %0, %1; witlb %0, %1"	\
+				 :: "r"(attr), "r"(addr));	\
+	} else {						\
+		__asm__ volatile("wdtlb %0, %1"			\
+				 :: "r"(attr), "r"(addr));	\
+		__asm__ volatile("j 1f; .align 8; 1:");		\
+		__asm__ volatile("witlb %0, %1; isync"		\
+				 :: "r"(attr), "r"(addr));	\
+	}							\
+	addr += addrincr;					\
+} while (0)
+
+#define ARCH_XTENSA_SET_RPO_TLB() do {				\
+	register uint32_t addr = 0, addrincr = 0x20000000;	\
+	FOR_EACH(_SET_ONE_TLB, (;), 0, 1, 2, 3, 4, 5, 6, 7);	\
+} while (0)
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/kernel/smp.c
+++ b/kernel/smp.c
@@ -13,6 +13,10 @@
 static atomic_t global_lock;
 static atomic_t start_flag;
 
+#if CONFIG_MP_NUM_CPUS > 1
+static atomic_t ready_flag;
+#endif
+
 unsigned int z_smp_global_lock(void)
 {
 	unsigned int key = arch_irq_lock();
@@ -48,6 +52,15 @@ void z_smp_release_global_lock(struct k_thread *thread)
 	}
 }
 
+/* Tiny delay that relaxes bus traffic to avoid spamming a shared
+ * memory bus looking at an atomic variable
+ */
+static inline void local_delay(void)
+{
+	for (volatile int i = 0; i < 1000; i++) {
+	}
+}
+
 #if CONFIG_MP_NUM_CPUS > 1
 
 void z_smp_thread_init(void *arg, struct k_thread *thread)
@@ -56,6 +69,7 @@ void z_smp_thread_init(void *arg, struct k_thread *thread)
 
 	/* Wait for the signal to begin scheduling */
 	while (!atomic_get(cpu_start_flag)) {
+		local_delay();
 	}
 
 	z_dummy_thread_init(thread);
@@ -70,9 +84,9 @@ static inline FUNC_NORETURN void smp_init_top(void *arg)
 {
 	struct k_thread dummy_thread;
 
-	z_smp_thread_init(arg, &dummy_thread);
 	smp_timer_init();
-
+	(void)atomic_set(&ready_flag, 1);
+	z_smp_thread_init(arg, &dummy_thread);
 	z_swap_unlocked();
 
 	CODE_UNREACHABLE; /* LCOV_EXCL_LINE */
@@ -92,10 +106,14 @@ void z_smp_init(void)
 {
 	(void)atomic_clear(&start_flag);
 
-#if CONFIG_MP_NUM_CPUS > 1 && !defined(CONFIG_SMP_BOOT_DELAY)
+#if !defined(CONFIG_SMP_BOOT_DELAY) && (CONFIG_MP_NUM_CPUS > 1)
 	for (int i = 1; i < CONFIG_MP_NUM_CPUS; i++) {
+		(void)atomic_clear(&ready_flag);
 		arch_start_cpu(i, z_interrupt_stacks[i], CONFIG_ISR_STACK_SIZE,
 			       smp_init_top, &start_flag);
+		while (!atomic_get(&ready_flag)) {
+			local_delay();
+		}
 	}
 #endif
 

--- a/soc/xtensa/intel_adsp/Kconfig.defconfig
+++ b/soc/xtensa/intel_adsp/Kconfig.defconfig
@@ -4,3 +4,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 source "soc/xtensa/intel_adsp/*/Kconfig.defconfig.series"
+
+# Lower priority defaults come AFTER the series-specific ones set above
+
+config XTENSA_CACHED_REGION
+	default 5
+
+config XTENSA_UNCACHED_REGION
+	default 4

--- a/soc/xtensa/intel_adsp/common/CMakeLists.txt
+++ b/soc/xtensa/intel_adsp/common/CMakeLists.txt
@@ -59,6 +59,7 @@ add_custom_target(
       copy ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_NAME}.elf ${KERNEL_REMAPPED}
 
   COMMAND ${ELF_FIX} ${CMAKE_OBJCOPY} ${KERNEL_REMAPPED}
+      ${CONFIG_XTENSA_CACHED_REGION} ${CONFIG_XTENSA_UNCACHED_REGION}
 
   # Extract modules for rimage
   COMMAND ${CMAKE_OBJCOPY}

--- a/soc/xtensa/intel_adsp/common/CMakeLists.txt
+++ b/soc/xtensa/intel_adsp/common/CMakeLists.txt
@@ -16,6 +16,7 @@ zephyr_library_sources(boot.c)
 
 if(CONFIG_MP_NUM_CPUS GREATER 1)
   zephyr_library_sources(soc_mp.c)
+  zephyr_library_sources(mp_cavs.c)
 endif()
 
 zephyr_library_sources_ifdef(CONFIG_CAVS_ICTL irq-cavs.c)

--- a/soc/xtensa/intel_adsp/common/fix_elf_addrs.py
+++ b/soc/xtensa/intel_adsp/common/fix_elf_addrs.py
@@ -3,13 +3,11 @@
 # Copyright (c) 2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-# ADSP devices have their RAM regions mapped twice, once in the 512MB
-# region from 0x80000000-0x9fffffff and again from
-# 0xa0000000-0xbfffffff.  The first mapping is set in the CPU to
-# bypass the L1 cache, and so access through pointers in that region
-# is coherent between CPUs (but slow).  The second region accesses the
-# same memory through the L1 cache and requires careful flushing when
-# used with shared data.
+# ADSP devices have their RAM regions mapped twice.  The first mapping
+# is set in the CPU to bypass the L1 cache, and so access through
+# pointers in that region is coherent between CPUs (but slow).  The
+# second region accesses the same memory through the L1 cache and
+# requires careful flushing when used with shared data.
 #
 # This distinction is exposed in the linker script, where some symbols
 # (e.g. stack regions) are linked into cached memory, but others
@@ -26,13 +24,19 @@ from elftools.elf.elffile import ELFFile
 
 objcopy_bin = sys.argv[1]
 elffile = sys.argv[2]
+cached_reg = int(sys.argv[3])
+uncached_reg = int(sys.argv[4])
+
+uc_min = uncached_reg << 29
+uc_max = uc_min | 0x1fffffff
+cache_off = "0x%x" % ((cached_reg - uncached_reg) << 29)
 
 fixup =[]
 with open(elffile, "rb") as fd:
     elf = ELFFile(fd)
     for s in elf.iter_sections():
         addr = s.header.sh_addr
-        if 0x80000000 <= addr < 0xa0000000:
+        if uc_min <= addr <= uc_max:
             print(f"fix_elf_addrs.py: Moving section {s.name} to cached SRAM region")
             fixup.append(s.name)
 
@@ -43,5 +47,5 @@ for s in fixup:
     # error (no --quiet option, no -Werror=no-whatever, nothing).
     # Just swallow the error stream for now pending rework to the
     # linker framework.
-    cmd = f"{objcopy_bin} --change-section-address {s}+0x20000000 {elffile} 2>/dev/null"
+    cmd = f"{objcopy_bin} --change-section-address {s}+{cache_off} {elffile} 2>/dev/null"
     os.system(cmd)

--- a/soc/xtensa/intel_adsp/common/include/cavs-link.ld
+++ b/soc/xtensa/intel_adsp/common/include/cavs-link.ld
@@ -25,31 +25,25 @@ OUTPUT_ARCH(xtensa)
 
 ENTRY(rom_entry);
 
-/* DSP RAM regions (all of them) are mapped twice on the DSP: once in
- * a 512MB region from 0x80000000-0x9fffffff and again from
- * 0xa0000000-0xbfffffff.  The first mapping is set up to bypass the
- * L1 cache, so it must be used when multiprocessor coherence is
- * desired, where the latter mapping is best used for processor-local
- * data (e.g. stacks) or shared data that is managed with explicit
- * cache flush/invalidate operations.
+/* DSP RAM regions (all of them) are mapped twice on the DSP.  One
+ * mapping is set up to bypass the L1 cache, so it must be used when
+ * multiprocessor coherence is desired, where the latter mapping is
+ * best used for processor-local data (e.g. stacks) or shared data
+ * that is managed with explicit cache flush/invalidate operations.
  *
  * These macros will set up a segment start address correctly,
  * including alignment to a cache line.  Be sure to also emit the
- * section to ">ram :ram_phdr" or ">ucram :ucram_phdr" as
- * appropriate. (Forgetting the correct PHDR will actually work, as
- * the output tooling ignores it, but it will cause the linker to emit
- * 512MB of unused data into the output file!)
- *
- * (Note clumsy syntax because XCC doesn't understand the "~" operator)
+ * section to ">ram" or ">ucram" as appropriate, to prevent the linker
+ * from filling in 512MB of sparse zeros.
  */
 #ifdef CONFIG_KERNEL_COHERENCE
-#define SEGSTART_CACHED   (ALIGN(64) | 0x20000000)
-#define SEGSTART_UNCACHED (ALIGN(64) & 0xdfffffff) /* == ~0x20000000 */
+#define RPO_SET(addr, reg) ((addr & 0x1fffffff) | (reg << 29))
+#define SEGSTART_CACHED   RPO_SET(ALIGN(64), CONFIG_XTENSA_CACHED_REGION)
+#define SEGSTART_UNCACHED RPO_SET(ALIGN(64), CONFIG_XTENSA_UNCACHED_REGION)
 #else
 #define SEGSTART_CACHED   .
 #define SEGSTART_UNCACHED .
 #define ucram ram
-#define ucram_phdr ram_phdr
 #endif
 
 /* intlist.ld needs an IDT_LIST memory region */
@@ -129,7 +123,7 @@ MEMORY {
 	len = RAM_SIZE
 #ifdef CONFIG_KERNEL_COHERENCE
   ucram :
-	org = RAM_BASE - 0x20000000,
+	org = RPO_SET(RAM_BASE, CONFIG_XTENSA_UNCACHED_REGION),
 	len = RAM_SIZE
 #endif
 #ifdef CONFIG_GEN_ISR_TABLES

--- a/soc/xtensa/intel_adsp/common/include/cpu_init.h
+++ b/soc/xtensa/intel_adsp/common/include/cpu_init.h
@@ -4,6 +4,7 @@
 #ifndef __INTEL_ADSP_CPU_INIT_H
 #define __INTEL_ADSP_CPU_INIT_H
 
+#include <arch/xtensa/cache.h>
 #include <xtensa/config/core-isa.h>
 
 #define CxL1CCAP (*(volatile uint32_t *)0x9F080080)
@@ -13,39 +14,6 @@
 /* "Data/Instruction Cache Memory Way Count" fields */
 #define CxL1CCAP_DCMWC ((CxL1CCAP >> 16) & 7)
 #define CxL1CCAP_ICMWC ((CxL1CCAP >> 20) & 7)
-
-/* Utilities to generate an unwrapped code sequence to set the RPO TLB
- * registers.  Pass the 8 region attributes as arguments, e.g.:
- *
- *     SET_RPO_TLB(2, 15, 15, 15, 2, 4, 15, 15);
- *
- * Note that cAVS 1.5 has the "translation" option that we don't use,
- * but still need to put an identity mapping in the high bits.  Also
- * per spec changing the current code region requires that WITLB be
- * followed by an ISYNC and that both instructions live in the same
- * cache line (two 3-byte instructions fit in an 8-byte aligned
- * region, so that's guaranteed not to cross a caceh line boundary).
- */
-#define SET_ONE_TLB(region, att) do {					\
-	uint32_t addr = region * 0x20000000U, attr = att;		\
-	if (XCHAL_HAVE_XLT_CACHEATTR) {					\
-		attr |= addr; /* RPO with translation */		\
-	}								\
-	if (region != (L2_SRAM_BASE >> 29)) {				\
-		__asm__ volatile("wdtlb %0, %1; witlb %0, %1"		\
-				 :: "r"(attr), "r"(addr));		\
-	} else {							\
-		__asm__ volatile("wdtlb %0, %1"				\
-				 :: "r"(attr), "r"(addr));		\
-		__asm__ volatile("j 1f; .align 8; 1:");			\
-		__asm__ volatile("witlb %0, %1; isync"			\
-				 :: "r"(attr), "r"(addr));		\
-	}								\
-} while (0)
-
-#define SET_RPO_TLB(...) do {				\
-	FOR_EACH_IDX(SET_ONE_TLB, (;), __VA_ARGS__);	\
-} while (0)
 
 /* Low-level CPU initialization.  Call this immediately after entering
  * C code to initialize the cache, protection and synchronization
@@ -98,15 +66,9 @@ static ALWAYS_INLINE void cpu_early_init(void)
 
 	/* Finally we need to enable the cache in the Region
 	 * Protection Option "TLB" entries.  The hardware defaults
-	 * have this set to RW/uncached (2) everywhere.  We want
-	 * writeback caching (4) in the sixth mapping (the second of
-	 * two RAM mappings) and to mark all unused regions
-	 * inaccessible (15) for safety.  Note that there is a HAL
-	 * routine that does this (by emulating the older "cacheattr"
-	 * hardware register), but it generates significantly larger
-	 * code.
+	 * have this set to RW/uncached everywhere.
 	 */
-	SET_RPO_TLB(2, 15, 15, 15, 2, 4, 15, 15);
+	ARCH_XTENSA_SET_RPO_TLB();
 
 	/* Initialize ATOMCTL: Hardware defaults for S32C1I use
 	 * "internal" operations, meaning they are atomic only WRT the

--- a/soc/xtensa/intel_adsp/common/include/soc.h
+++ b/soc/xtensa/intel_adsp/common/include/soc.h
@@ -74,6 +74,12 @@ extern void z_soc_irq_enable(uint32_t irq);
 extern void z_soc_irq_disable(uint32_t irq);
 extern int z_soc_irq_is_enabled(unsigned int irq);
 
+extern void z_soc_mp_asm_entry(void);
+extern void soc_mp_startup(uint32_t cpu);
+extern void soc_start_core(int cpu_num);
+
+extern bool soc_cpus_active[CONFIG_MP_NUM_CPUS];
+
 /* Legacy SOC-level API still used in a few drivers */
 #define SOC_DCACHE_FLUSH(addr, size)		\
 	z_xtensa_cache_flush((addr), (size))

--- a/soc/xtensa/intel_adsp/common/include/soc.h
+++ b/soc/xtensa/intel_adsp/common/include/soc.h
@@ -80,54 +80,12 @@ extern void soc_start_core(int cpu_num);
 
 extern bool soc_cpus_active[CONFIG_MP_NUM_CPUS];
 
-/* Legacy SOC-level API still used in a few drivers */
+/* Legacy cache APIs still used in a few places */
 #define SOC_DCACHE_FLUSH(addr, size)		\
 	z_xtensa_cache_flush((addr), (size))
 #define SOC_DCACHE_INVALIDATE(addr, size)	\
 	z_xtensa_cache_inv((addr), (size))
-
-/**
- * @brief Return uncached pointer to a RAM address
- *
- * The Intel ADSP architecture maps all addressable RAM (of all types)
- * twice, in two different 512MB segments regions whose L1 cache
- * settings can be controlled independently.  So for any given
- * pointer, it is possible to convert it to and from a cached version.
- *
- * This function takes a pointer to any addressible object (either in
- * cacheable memory or not) and returns a pointer that can be used to
- * refer to the same memory while bypassing the L1 data cache.  Data
- * in the L1 cache will not be inspected nor modified by the access.
- *
- * @see z_soc_cached_ptr()
- *
- * @param p A pointer to a valid C object
- * @return A pointer to the same object bypassing the L1 dcache
- */
-static inline void *z_soc_uncached_ptr(void *p)
-{
-	return ((void *)(((size_t)p) & ~0x20000000));
-}
-
-/**
- * @brief Return cached pointer to a RAM address
- *
- * This function takes a pointer to any addressible object (either in
- * cacheable memory or not) and returns a pointer that can be used to
- * refer to the same memory through the L1 data cache.  Data read
- * through the resulting pointer will reflect locally cached values on
- * the current CPU if they exist, and writes will go first into the
- * cache and be written back later.
- *
- * @see z_soc_uncached_ptr()
- *
- * @param p A pointer to a valid C object
- * @return A pointer to the same object via the L1 dcache
-
- */
-static inline void *z_soc_cached_ptr(void *p)
-{
-	return ((void *)(((size_t)p) | 0x20000000));
-}
+#define z_soc_cached_ptr(p) arch_xtensa_cached_ptr(p)
+#define z_soc_uncached_ptr(p) arch_xtensa_uncached_ptr(p)
 
 #endif /* __INC_SOC_H */

--- a/soc/xtensa/intel_adsp/common/mp_cavs.c
+++ b/soc/xtensa/intel_adsp/common/mp_cavs.c
@@ -1,0 +1,281 @@
+/* Copyright (c) 2021 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr.h>
+#include <cavs-idc.h>
+#include <cavs-mem.h>
+#include <cavs-shim.h>
+
+/* IDC power up message to the ROM firmware.  This isn't documented
+ * anywhere, it's basically just a magic number (except the high bit,
+ * which signals the hardware)
+ */
+#define IDC_MSG_POWER_UP				  \
+	(BIT(31) |     /* Latch interrupt in ITC write */ \
+	 (0x1 << 24) | /* "ROM control version" = 1 */	  \
+	 (0x2 << 0))   /* "Core wake version" = 2 */
+
+#define IDC_ALL_CORES (BIT(CONFIG_MP_NUM_CPUS) - 1)
+
+#define CAVS15_ROM_IDC_DELAY 500
+
+extern void z_sched_ipi(void);
+extern void z_reinit_idle_thread(int i);
+extern void z_smp_start_cpu(int id);
+
+static struct k_spinlock mplock;
+
+__imr void soc_mp_startup(uint32_t cpu)
+{
+	/* We got here via an IDC interrupt.  Clear the TFC high bit
+	 * (by writing a one!) to acknowledge and clear the latched
+	 * hardware interrupt (so we don't have to service it as a
+	 * spurious IPI when we enter user code).  Remember: this
+	 * could have come from any core, clear all of them.
+	 */
+	for (int i = 0; i < CONFIG_MP_NUM_CPUS; i++) {
+		IDC[cpu].core[i].tfc = BIT(31);
+	}
+
+	/* Interrupt must be enabled while running on current core */
+	irq_enable(DT_IRQN(DT_INST(0, intel_cavs_idc)));
+
+	/* Unfortunately the interrupt controller doesn't understand
+	 * that each CPU has its own mask register (the timer has a
+	 * similar hook).  Needed only on hardware with ROMs that
+	 * disable this; otherwise our own code in soc_idc_init()
+	 * already has it unmasked.
+	 */
+	if (!IS_ENABLED(CONFIG_SOC_SERIES_INTEL_CAVS_V25)) {
+		CAVS_INTCTRL[cpu].l2.clear = CAVS_L2_IDC;
+	}
+}
+
+static ALWAYS_INLINE uint32_t prid(void)
+{
+	uint32_t prid;
+
+	__asm__ volatile("rsr %0, PRID" : "=r"(prid));
+	return prid;
+}
+
+void soc_start_core(int cpu_num)
+{
+	uint32_t curr_cpu = prid();
+
+#ifdef CONFIG_SOC_SERIES_INTEL_CAVS_V15
+	/* On the older hardware, core power is managed by the host
+	 * and aren't able to poll for anything to know it's
+	 * available.  Need a delay here so that the hardware and ROM
+	 * firmware can complete initialization and be waiting for the
+	 * IDC we're about to send.
+	 */
+	k_busy_wait(CAVS15_ROM_IDC_DELAY);
+#endif
+
+#ifdef CONFIG_SOC_SERIES_INTEL_CAVS_V25
+	/* On cAVS v2.5, MP startup works differently.  The core has
+	 * no ROM, and starts running immediately upon receipt of an
+	 * IDC interrupt at the start of LPSRAM at 0xbe800000.  Note
+	 * that means we don't need to bother constructing a "message"
+	 * below, it will be ignored.  But it's left in place for
+	 * simplicity and compatibility.
+	 *
+	 * All we need to do is place a single jump at that address to
+	 * our existing MP entry point.  Unfortunately Xtensa makes
+	 * this difficult, as the region is beyond the range of a
+	 * relative jump instruction, so we need an immediate, which
+	 * can only be backwards-referenced.  So we hand-assemble a
+	 * tiny trampoline here ("jump over the immediate address,
+	 * load it, jump to it").
+	 *
+	 * Long term we want to have this in linkable LP-SRAM memory
+	 * such that the standard system bootstrap out of IMR can
+	 * place it there.  But this is fine for now.
+	 */
+	void **lpsram = z_soc_uncached_ptr((void *)LP_SRAM_BASE);
+	uint8_t tramp[] = {
+		0x06, 0x01, 0x00, /* J <PC+8>  (jump to L32R) */
+		0,                /* (padding to align entry_addr) */
+		0, 0, 0, 0,       /* (entry_addr goes here) */
+		0x01, 0xff, 0xff, /* L32R a0, <entry_addr> */
+		0xa0, 0x00, 0x00, /* JX a0 */
+	};
+
+	memcpy(lpsram, tramp, ARRAY_SIZE(tramp));
+	lpsram[1] = z_soc_mp_asm_entry;
+#endif
+
+	/* Disable automatic power and clock gating for that CPU, so
+	 * it won't just go back to sleep.  Note that after startup,
+	 * the cores are NOT power gated even if they're configured to
+	 * be, so by default a core will launch successfully but then
+	 * turn itself off when it gets to the WAITI instruction in
+	 * the idle thread.
+	 */
+	CAVS_SHIM.pwrctl |= CAVS_PWRCTL_TCPDSPPG(cpu_num);
+	if (!IS_ENABLED(CONFIG_SOC_SERIES_INTEL_CAVS_V15)) {
+		CAVS_SHIM.clkctl |= CAVS_CLKCTL_TCPLCG(cpu_num);
+	}
+
+	/* Workaround.  SOF seems to have some older code on pre-2.5
+	 * hardware that is remasking these interrupts (probably a
+	 * variant of the same code we inherited earlier to mask it
+	 * while the ROM handles the startup IDC?).  Unmask
+	 * unconditionally while we get this figured out, it's cheap
+	 * and safe.
+	 */
+	if (IS_ENABLED(CONFIG_SOF)) {
+		CAVS_INTCTRL[cpu_num].l2.clear = CAVS_L2_IDC;
+		for (int c = 0; c < CONFIG_MP_NUM_CPUS; c++) {
+			IDC[c].busy_int |= IDC_ALL_CORES;
+		}
+	}
+
+	/* Send power-up message to the other core.  Start address
+	 * gets passed via the IETC scratch register (only 30 bits
+	 * available, so it's sent shifted).  The write to ITC
+	 * triggers the interrupt, so that comes last.
+	 */
+	uint32_t ietc = ((long) z_soc_mp_asm_entry) >> 2;
+
+	IDC[curr_cpu].core[cpu_num].ietc = ietc;
+	IDC[curr_cpu].core[cpu_num].itc = IDC_MSG_POWER_UP;
+}
+
+void arch_sched_ipi(void)
+{
+	uint32_t curr = prid();
+
+	for (int c = 0; c < CONFIG_MP_NUM_CPUS; c++) {
+		if (c != curr && soc_cpus_active[c]) {
+			IDC[curr].core[c].itc = BIT(31);
+		}
+	}
+}
+
+void idc_isr(void *param)
+{
+	ARG_UNUSED(param);
+
+#ifdef CONFIG_SMP
+	/* Right now this interrupt is only used for IPIs */
+	z_sched_ipi();
+#endif
+
+	/* ACK the interrupt to all the possible sources.  This is a
+	 * level-sensitive interrupt triggered by a logical OR of each
+	 * of the ITC/TFC high bits, INCLUDING the one "from this
+	 * CPU".
+	 */
+	for (int i = 0; i < CONFIG_MP_NUM_CPUS; i++) {
+		IDC[prid()].core[i].tfc = BIT(31);
+	}
+}
+
+__imr void soc_mp_init(void)
+{
+	IRQ_CONNECT(DT_IRQN(DT_NODELABEL(idc)), 0, idc_isr, NULL, 0);
+
+	/* Every CPU should be able to receive an IDC interrupt from
+	 * every other CPU, but not to be back-interrupted when the
+	 * target core clears the busy bit.
+	 */
+	for (int core = 0; core < CONFIG_MP_NUM_CPUS; core++) {
+		IDC[core].busy_int |= IDC_ALL_CORES;
+		IDC[core].done_int &= ~IDC_ALL_CORES;
+
+		/* Also unmask the IDC interrupt for every core in the
+		 * L2 mask register.
+		 */
+		CAVS_INTCTRL[core].l2.clear = CAVS_L2_IDC;
+	}
+
+	/* Clear out any existing pending interrupts that might be present */
+	for (int i = 0; i < CONFIG_MP_NUM_CPUS; i++) {
+		for (int j = 0; j < CONFIG_MP_NUM_CPUS; j++) {
+			IDC[i].core[j].tfc = BIT(31);
+		}
+	}
+
+	soc_cpus_active[0] = true;
+}
+
+/**
+ * @brief Restart halted SMP CPU
+ *
+ * Relaunches a CPU that has entered an idle power state via
+ * soc_halt_cpu().  Returns -EINVAL if the CPU is not in a power-gated
+ * idle state.  Upon successful return, the CPU is online and
+ * available to run any Zephyr thread.
+ *
+ * @param id CPU to start, in the range [1:CONFIG_MP_NUM_CPUS)
+ */
+__imr int soc_relaunch_cpu(int id)
+{
+	int ret = 0;
+	k_spinlock_key_t k = k_spin_lock(&mplock);
+
+	if (id < 1 || id >= CONFIG_MP_NUM_CPUS) {
+		ret = -EINVAL;
+		goto out;
+	}
+
+	if (CAVS_SHIM.pwrsts & CAVS_PWRSTS_PDSPPGS(id)) {
+		ret = -EINVAL;
+		goto out;
+	}
+
+	__ASSERT_NO_MSG(!soc_cpus_active[id]);
+
+	CAVS_INTCTRL[id].l2.clear = CAVS_L2_IDC;
+	z_reinit_idle_thread(id);
+	z_smp_start_cpu(id);
+
+ out:
+	k_spin_unlock(&mplock, k);
+	return ret;
+}
+
+/**
+ * @brief Halts and offlines a running CPU
+ *
+ * Enables power gating on the specified CPU, which cannot be the
+ * current CPU or CPU 0.  The CPU must be idle; no application threads
+ * may be runnable on it when this function is called (or at least the
+ * CPU must be guaranteed to reach idle in finite time without
+ * deadlock).  Actual CPU shutdown can only happen in the context of
+ * the idle thread, and synchronization is an application
+ * responsibility.  This function will hang if the other CPU fails to
+ * reach idle.
+ *
+ * @param id CPU to halt, not current cpu or cpu 0
+ * @return 0 on success, -EINVAL on error
+ */
+__imr int soc_halt_cpu(int id)
+{
+	int ret = 0;
+	k_spinlock_key_t k = k_spin_lock(&mplock);
+
+	if (id == 0 || id == _current_cpu->id) {
+		ret = -EINVAL;
+		goto out;
+	}
+
+	/* Stop sending IPIs to this core */
+	soc_cpus_active[id] = false;
+
+	/* Turn off the "prevent power/clock gating" bits, enabling
+	 * low power idle
+	 */
+	CAVS_SHIM.pwrctl &= ~CAVS_PWRCTL_TCPDSPPG(id);
+	CAVS_SHIM.clkctl &= ~CAVS_CLKCTL_TCPLCG(id);
+
+	/* Wait for the CPU to reach an idle state before returing */
+	while (CAVS_SHIM.pwrsts & CAVS_PWRSTS_PDSPPGS(id)) {
+	}
+
+ out:
+	k_spin_unlock(&mplock, k);
+	return ret;
+}

--- a/soc/xtensa/intel_adsp/common/soc.c
+++ b/soc/xtensa/intel_adsp/common/soc.c
@@ -37,6 +37,8 @@ LOG_MODULE_REGISTER(soc);
 # define GENO_DIOPTOSEL           BIT(2)
 #endif
 
+extern void soc_mp_init(void);
+
 static __imr void power_init_v15(void)
 {
 	/* HP domain clocked by PLL
@@ -114,7 +116,7 @@ static __imr int soc_init(const struct device *dev)
 		power_init();
 	}
 
-	soc_idc_init();
+	soc_mp_init();
 
 	return 0;
 }

--- a/soc/xtensa/intel_adsp/common/soc_mp.c
+++ b/soc/xtensa/intel_adsp/common/soc_mp.c
@@ -24,23 +24,6 @@ LOG_MODULE_REGISTER(soc_mp, CONFIG_SOC_LOG_LEVEL);
 #include <cavs-mem.h>
 #include <cpu_init.h>
 
-extern void z_sched_ipi(void);
-extern void z_smp_start_cpu(int id);
-extern void z_reinit_idle_thread(int i);
-
-/* IDC power up message to the ROM firmware.  This isn't documented
- * anywhere, it's basically just a magic number (except the high bit,
- * which signals the hardware)
- */
-#define IDC_MSG_POWER_UP				  \
-	(BIT(31) |     /* Latch interrupt in ITC write */ \
-	 (0x1 << 24) | /* "ROM control version" = 1 */	  \
-	 (0x2 << 0))   /* "Core wake version" = 2 */
-
-#define IDC_ALL_CORES (BIT(CONFIG_MP_NUM_CPUS) - 1)
-
-#define CAVS15_ROM_IDC_DELAY 500
-
 struct cpustart_rec {
 	uint32_t        cpu;
 	arch_cpustart_t	fn;
@@ -48,8 +31,6 @@ struct cpustart_rec {
 };
 
 static struct cpustart_rec start_rec;
-
-static struct k_spinlock mplock;
 
 char *z_mp_stack_top;
 
@@ -67,7 +48,7 @@ uint32_t _loader_storage_manifest_start;
  * to be absolutely sure we don't try to IPI a CPU that isn't ready to
  * start, or else we'll launch it into garbage and crash the DSP.
  */
-static bool cpus_active[CONFIG_MP_NUM_CPUS];
+bool soc_cpus_active[CONFIG_MP_NUM_CPUS];
 
 /* Tiny assembly stub for calling z_mp_entry() on the auxiliary CPUs.
  * Mask interrupts, clear the register window state and set the stack
@@ -77,7 +58,6 @@ static bool cpus_active[CONFIG_MP_NUM_CPUS];
  * Note that alignment is absolutely required: the IDC protocol passes
  * only the upper 30 bits of the address to the second CPU.
  */
-void z_soc_mp_asm_entry(void);
 __asm__(".align 4                   \n\t"
 	".global z_soc_mp_asm_entry \n\t"
 	"z_soc_mp_asm_entry:        \n\t"
@@ -91,32 +71,6 @@ __asm__(".align 4                   \n\t"
 	"  movi  a1, z_mp_stack_top \n\t"
 	"  l32i  a1, a1, 0          \n\t"
 	"  call4 z_mp_entry         \n\t");
-
-static __imr void soc_mp_startup(void)
-{
-	/* We got here via an IDC interrupt.  Clear the TFC high bit
-	 * (by writing a one!) to acknowledge and clear the latched
-	 * hardware interrupt (so we don't have to service it as a
-	 * spurious IPI when we enter user code).  Remember: this
-	 * could have come from any core, clear all of them.
-	 */
-	for (int i = 0; i < CONFIG_MP_NUM_CPUS; i++) {
-		IDC[start_rec.cpu].core[i].tfc = BIT(31);
-	}
-
-	/* Interrupt must be enabled while running on current core */
-	irq_enable(DT_IRQN(DT_INST(0, intel_cavs_idc)));
-
-	/* Unfortunately the interrupt controller doesn't understand
-	 * that each CPU has its own mask register (the timer has a
-	 * similar hook).  Needed only on hardware with ROMs that
-	 * disable this; otherwise our own code in soc_idc_init()
-	 * already has it unmasked.
-	 */
-	if (!IS_ENABLED(CONFIG_SOC_SERIES_INTEL_CAVS_V25)) {
-		CAVS_INTCTRL[start_rec.cpu].l2.clear = CAVS_L2_IDC;
-	}
-}
 
 __imr void z_mp_entry(void)
 {
@@ -141,113 +95,21 @@ __imr void z_mp_entry(void)
 	__asm__ volatile(
 		"wsr." CONFIG_XTENSA_KERNEL_CPU_PTR_SR " %0" : : "r"(cpu));
 
-	soc_mp_startup();
-	cpus_active[start_rec.cpu] = true;
+	soc_mp_startup(start_rec.cpu);
+	soc_cpus_active[start_rec.cpu] = true;
 	start_rec.fn(start_rec.arg);
 	__ASSERT(false, "arch_start_cpu() handler should never return");
 }
 
 bool arch_cpu_active(int cpu_num)
 {
-	return cpus_active[cpu_num];
-}
-
-static ALWAYS_INLINE uint32_t prid(void)
-{
-	uint32_t prid;
-
-	__asm__ volatile("rsr %0, PRID" : "=r"(prid));
-	return prid;
-}
-
-void soc_start_core(int cpu_num)
-{
-	uint32_t curr_cpu = prid();
-
-#ifdef CONFIG_SOC_SERIES_INTEL_CAVS_V15
-	/* On the older hardware, core power is managed by the host
-	 * and aren't able to poll for anything to know it's
-	 * available.  Need a delay here so that the hardware and ROM
-	 * firmware can complete initialization and be waiting for the
-	 * IDC we're about to send.
-	 */
-	k_busy_wait(CAVS15_ROM_IDC_DELAY);
-#endif
-
-#ifdef CONFIG_SOC_SERIES_INTEL_CAVS_V25
-	/* On cAVS v2.5, MP startup works differently.  The core has
-	 * no ROM, and starts running immediately upon receipt of an
-	 * IDC interrupt at the start of LPSRAM at 0xbe800000.  Note
-	 * that means we don't need to bother constructing a "message"
-	 * below, it will be ignored.  But it's left in place for
-	 * simplicity and compatibility.
-	 *
-	 * All we need to do is place a single jump at that address to
-	 * our existing MP entry point.  Unfortunately Xtensa makes
-	 * this difficult, as the region is beyond the range of a
-	 * relative jump instruction, so we need an immediate, which
-	 * can only be backwards-referenced.  So we hand-assemble a
-	 * tiny trampoline here ("jump over the immediate address,
-	 * load it, jump to it").
-	 *
-	 * Long term we want to have this in linkable LP-SRAM memory
-	 * such that the standard system bootstrap out of IMR can
-	 * place it there.  But this is fine for now.
-	 */
-	void **lpsram = z_soc_uncached_ptr((void *)LP_SRAM_BASE);
-	uint8_t tramp[] = {
-		0x06, 0x01, 0x00, /* J <PC+8>  (jump to L32R) */
-		0,                /* (padding to align entry_addr) */
-		0, 0, 0, 0,       /* (entry_addr goes here) */
-		0x01, 0xff, 0xff, /* L32R a0, <entry_addr> */
-		0xa0, 0x00, 0x00, /* JX a0 */
-	};
-
-	memcpy(lpsram, tramp, ARRAY_SIZE(tramp));
-	lpsram[1] = z_soc_mp_asm_entry;
-#endif
-
-	/* Disable automatic power and clock gating for that CPU, so
-	 * it won't just go back to sleep.  Note that after startup,
-	 * the cores are NOT power gated even if they're configured to
-	 * be, so by default a core will launch successfully but then
-	 * turn itself off when it gets to the WAITI instruction in
-	 * the idle thread.
-	 */
-	CAVS_SHIM.pwrctl |= CAVS_PWRCTL_TCPDSPPG(cpu_num);
-	if (!IS_ENABLED(CONFIG_SOC_SERIES_INTEL_CAVS_V15)) {
-		CAVS_SHIM.clkctl |= CAVS_CLKCTL_TCPLCG(cpu_num);
-	}
-
-	/* Workaround.  SOF seems to have some older code on pre-2.5
-	 * hardware that is remasking these interrupts (probably a
-	 * variant of the same code we inherited earlier to mask it
-	 * while the ROM handles the startup IDC?).  Unmask
-	 * unconditionally while we get this figured out, it's cheap
-	 * and safe.
-	 */
-	if (IS_ENABLED(CONFIG_SOF)) {
-		CAVS_INTCTRL[cpu_num].l2.clear = CAVS_L2_IDC;
-		for (int c = 0; c < CONFIG_MP_NUM_CPUS; c++) {
-			IDC[c].busy_int |= IDC_ALL_CORES;
-		}
-	}
-
-	/* Send power-up message to the other core.  Start address
-	 * gets passed via the IETC scratch register (only 30 bits
-	 * available, so it's sent shifted).  The write to ITC
-	 * triggers the interrupt, so that comes last.
-	 */
-	uint32_t ietc = ((long) z_soc_mp_asm_entry) >> 2;
-
-	IDC[curr_cpu].core[cpu_num].ietc = ietc;
-	IDC[curr_cpu].core[cpu_num].itc = IDC_MSG_POWER_UP;
+	return soc_cpus_active[cpu_num];
 }
 
 void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
 		    arch_cpustart_t fn, void *arg)
 {
-	__ASSERT_NO_MSG(!cpus_active[cpu_num]);
+	__ASSERT_NO_MSG(!soc_cpus_active[cpu_num]);
 
 	start_rec.cpu = cpu_num;
 	start_rec.fn = fn;
@@ -258,146 +120,9 @@ void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
 	soc_start_core(cpu_num);
 }
 
-void arch_sched_ipi(void)
-{
-	uint32_t curr = prid();
-
-	for (int c = 0; c < CONFIG_MP_NUM_CPUS; c++) {
-		if (c != curr && cpus_active[c]) {
-			IDC[curr].core[c].itc = BIT(31);
-		}
-	}
-}
-
-void idc_isr(void *param)
-{
-	ARG_UNUSED(param);
-
-#ifdef CONFIG_SMP
-	/* Right now this interrupt is only used for IPIs */
-	z_sched_ipi();
-#endif
-
-	/* ACK the interrupt to all the possible sources.  This is a
-	 * level-sensitive interrupt triggered by a logical OR of each
-	 * of the ITC/TFC high bits, INCLUDING the one "from this
-	 * CPU".
-	 */
-	for (int i = 0; i < CONFIG_MP_NUM_CPUS; i++) {
-		IDC[prid()].core[i].tfc = BIT(31);
-	}
-}
-
 /* Fallback stub for external SOF code */
 __imr int cavs_idc_smp_init(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 	return 0;
-}
-
-__imr void soc_mp_init(void)
-{
-	IRQ_CONNECT(DT_IRQN(DT_NODELABEL(idc)), 0, idc_isr, NULL, 0);
-
-	/* Every CPU should be able to receive an IDC interrupt from
-	 * every other CPU, but not to be back-interrupted when the
-	 * target core clears the busy bit.
-	 */
-	for (int core = 0; core < CONFIG_MP_NUM_CPUS; core++) {
-		IDC[core].busy_int |= IDC_ALL_CORES;
-		IDC[core].done_int &= ~IDC_ALL_CORES;
-
-		/* Also unmask the IDC interrupt for every core in the
-		 * L2 mask register.
-		 */
-		CAVS_INTCTRL[core].l2.clear = CAVS_L2_IDC;
-	}
-
-	/* Clear out any existing pending interrupts that might be present */
-	for (int i = 0; i < CONFIG_MP_NUM_CPUS; i++) {
-		for (int j = 0; j < CONFIG_MP_NUM_CPUS; j++) {
-			IDC[i].core[j].tfc = BIT(31);
-		}
-	}
-
-	cpus_active[0] = true;
-}
-
-/**
- * @brief Restart halted SMP CPU
- *
- * Relaunches a CPU that has entered an idle power state via
- * soc_halt_cpu().  Returns -EINVAL if the CPU is not in a power-gated
- * idle state.  Upon successful return, the CPU is online and
- * available to run any Zephyr thread.
- *
- * @param id CPU to start, in the range [1:CONFIG_MP_NUM_CPUS)
- */
-__imr int soc_relaunch_cpu(int id)
-{
-	int ret = 0;
-	k_spinlock_key_t k = k_spin_lock(&mplock);
-
-	if (id < 1 || id >= CONFIG_MP_NUM_CPUS) {
-		ret = -EINVAL;
-		goto out;
-	}
-
-	if (CAVS_SHIM.pwrsts & CAVS_PWRSTS_PDSPPGS(id)) {
-		ret = -EINVAL;
-		goto out;
-	}
-
-	__ASSERT_NO_MSG(!cpus_active[id]);
-
-	CAVS_INTCTRL[id].l2.clear = CAVS_L2_IDC;
-	z_reinit_idle_thread(id);
-	z_smp_start_cpu(id);
-
- out:
-	k_spin_unlock(&mplock, k);
-	return ret;
-}
-
-/**
- * @brief Halts and offlines a running CPU
- *
- * Enables power gating on the specified CPU, which cannot be the
- * current CPU or CPU 0.  The CPU must be idle; no application threads
- * may be runnable on it when this function is called (or at least the
- * CPU must be guaranteed to reach idle in finite time without
- * deadlock).  Actual CPU shutdown can only happen in the context of
- * the idle thread, and synchronization is an application
- * responsibility.  This function will hang if the other CPU fails to
- * reach idle.
- *
- * @param id CPU to halt, not current cpu or cpu 0
- * @return 0 on success, -EINVAL on error
- */
-__imr int soc_halt_cpu(int id)
-{
-	int ret = 0;
-	k_spinlock_key_t k = k_spin_lock(&mplock);
-
-	if (id == 0 || id == _current_cpu->id) {
-		ret = -EINVAL;
-		goto out;
-	}
-
-	/* Stop sending IPIs to this core */
-	cpus_active[id] = false;
-
-	/* Turn off the "prevent power/clock gating" bits, enabling
-	 * low power idle
-	 */
-	CAVS_SHIM.pwrctl &= ~CAVS_PWRCTL_TCPDSPPG(id);
-	CAVS_SHIM.clkctl &= ~CAVS_CLKCTL_TCPLCG(id);
-
-	/* Wait for the CPU to reach an idle state before returing */
-	while (CAVS_SHIM.pwrsts & CAVS_PWRSTS_PDSPPGS(id)) {
-	}
-
- out:
-	k_spin_unlock(&mplock, k);
-	return ret;
 }


### PR DESCRIPTION
Another batch of changes.  The big one being that the Xtensa double-mapped memory trick which underlies KERNEL_COHERENCE has been generalized and moved from the SOC into the Xtensa architecture, since it's something any hardware vendor might do and involves nothing specific to the audio DSPs at all.  And this allows us to configure it with just two kconfigs.