### PR TITLE
cmake: bintools: gnu: Suppress GDB check console outputs

### DIFF
--- a/cmake/bintools/gnu/target.cmake
+++ b/cmake/bintools/gnu/target.cmake
@@ -16,9 +16,9 @@ find_program(CMAKE_GDB     ${CROSS_COMPILE}gdb     PATHS ${TOOLCHAIN_HOME} NO_DE
 if(CMAKE_GDB)
   execute_process(
     COMMAND ${CMAKE_GDB} --configuration
-    OUTPUT_VARIABLE GDB_PY_NO_PY
-    OUTPUT_STRIP_TRAILING_WHITESPACE
     RESULTS_VARIABLE GDB_CFG_ERR
+    OUTPUT_QUIET
+    ERROR_QUIET
     )
   if (${GDB_CFG_ERR})
     # Failed to execute GDB, likely because of Python deps


### PR DESCRIPTION
The GDB check routine added in the PR #38749 does not suppress the
console outputs (stdout and stderr) and may print out a misleading
error message during a CMake configuration when the required version
of Python is not available on the system:

  arm-zephyr-eabi-gdb: error while loading shared libraries:
  libpython3.8.so.1.0: cannot open shared object file: No such file or
  directory

This commit adds the `OUTPUT_QUIET` and `ERROR_QUIET` options when
executing the GDB process so that the console outputs during the GDB
executable validation are not displayed to the user.

In addition, this commit removes the unused `GDB_PY_NO_PY` standard
output redirection variable since it is unnecessary.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>