### PR TITLE
pm: device_runtime: Fix reference count when action fails

### DIFF
--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -86,7 +86,10 @@ static void runtime_suspend_work(struct k_work *work)
 	ret = pm->action_cb(pm->dev, PM_DEVICE_ACTION_SUSPEND);
 
 	(void)k_mutex_lock(&pm->lock, K_FOREVER);
-	if (ret == 0) {
+	if (ret < 0) {
+		pm->usage++;
+		pm->state = PM_DEVICE_STATE_ACTIVE;
+	} else {
 		pm->state = PM_DEVICE_STATE_SUSPENDED;
 	}
 	k_condvar_broadcast(&pm->condvar);


### PR DESCRIPTION
The usage count and device power state has to be restored when the
device action callback fails in the async operation. Otherwise it will
lead to an inconsistent state.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>