### PR TITLE
modbus: keep transaction and protocol IDs in gateway mode

### DIFF
--- a/samples/subsys/modbus/tcp_gateway/boards/frdm_k64f.overlay
+++ b/samples/subsys/modbus/tcp_gateway/boards/frdm_k64f.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&uart2 {
+&arduino_serial {
 	status = "okay";
 	current-speed = <115200>;
 

--- a/subsys/modbus/modbus_raw.c
+++ b/subsys/modbus/modbus_raw.c
@@ -147,7 +147,17 @@ int modbus_raw_backend_txn(const int iface, struct modbus_adu *adu)
 	err = modbus_tx_wait_rx_adu(ctx);
 
 	if (err == 0) {
+		/*
+		 * Serial line does not use transaction and protocol IDs.
+		 * Temporarily store transaction and protocol IDs, and write it
+		 * back if the transfer was successful.
+		 */
+		uint16_t trans_id = adu->trans_id;
+		uint16_t proto_id = adu->proto_id;
+
 		memcpy(adu, &ctx->rx_adu, sizeof(struct modbus_adu));
+		adu->trans_id = trans_id;
+		adu->proto_id = proto_id;
 	} else {
 		modbus_set_exception(adu, MODBUS_EXC_GW_TARGET_FAILED_TO_RESP);
 	}


### PR DESCRIPTION
Serial line interface does not use transaction and protocol
IDs. Continue to use memcpy() for the whole frame as it is safer
and more efficient but temporarily store transaction and protocol
IDs, and write it back if the transfer was successful.

Fixes: #41637 