### PR TITLE
drivers: watchdog: Add support for the GD32 watchdog timers

### DIFF
--- a/boards/arm/gd32e103v_eval/gd32e103v_eval.dts
+++ b/boards/arm/gd32e103v_eval/gd32e103v_eval.dts
@@ -71,6 +71,7 @@
 		sw0 = &user_key;
 		pwm-led0 = &pwm_led;
 		eeprom-0 = &eeprom0;
+		watchdog0 = &fwdgt;
 	};
 };
 
@@ -132,4 +133,8 @@
 	status = "okay";
 	pinctrl-0 = <&dac_default>;
 	pinctrl-names = "default";
+};
+
+&fwdgt {
+	status = "okay";
 };

--- a/boards/arm/gd32e103v_eval/gd32e103v_eval.yaml
+++ b/boards/arm/gd32e103v_eval/gd32e103v_eval.yaml
@@ -11,3 +11,5 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
+supported:
+  - watchdog

--- a/boards/arm/gd32e507v_start/gd32e507v_start.dts
+++ b/boards/arm/gd32e507v_start/gd32e507v_start.dts
@@ -47,6 +47,7 @@
 		led0 = &led1;
 		sw0 = &user_key;
 		pwm-led0 = &pwm_led;
+		watchdog0 = &fwdgt;
 	};
 };
 
@@ -74,4 +75,8 @@
 		pinctrl-0 = <&pwm2_default>;
 		pinctrl-names = "default";
 	};
+};
+
+&fwdgt {
+	status = "okay";
 };

--- a/boards/arm/gd32e507v_start/gd32e507v_start.yaml
+++ b/boards/arm/gd32e507v_start/gd32e507v_start.yaml
@@ -14,3 +14,4 @@ toolchain:
 supported:
   - pwm
   - gpio
+  - watchdog

--- a/boards/arm/gd32f350r_eval/gd32f350r_eval.dts
+++ b/boards/arm/gd32f350r_eval/gd32f350r_eval.dts
@@ -19,6 +19,10 @@
 		zephyr,shell-uart = &usart0;
 		zephyr,flash-controller = &fmc;
 	};
+
+	aliases {
+		watchdog0 = &fwdgt;
+	};
 };
 
 &usart0 {
@@ -34,4 +38,8 @@
 	rcu-clock-source = <4>;
 	pinctrl-0 = <&adc0_default>;
 	pinctrl-names = "default";
+};
+
+&fwdgt {
+	status = "okay";
 };

--- a/boards/arm/gd32f350r_eval/gd32f350r_eval.yaml
+++ b/boards/arm/gd32f350r_eval/gd32f350r_eval.yaml
@@ -11,3 +11,5 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
+supported:
+  - watchdog

--- a/boards/arm/gd32f403z_eval/gd32f403z_eval.dts
+++ b/boards/arm/gd32f403z_eval/gd32f403z_eval.dts
@@ -74,6 +74,7 @@
 		led1 = &led3;
 		sw0 = &user_key1;
 		pwm-led0 = &pwm_led;
+		watchdog0 = &fwdgt;
 	};
 };
 
@@ -111,4 +112,8 @@
 		pinctrl-0 = <&pwm0_default>;
 		pinctrl-names = "default";
 	};
+};
+
+&fwdgt {
+	status = "okay";
 };

--- a/boards/arm/gd32f403z_eval/gd32f403z_eval.yaml
+++ b/boards/arm/gd32f403z_eval/gd32f403z_eval.yaml
@@ -13,3 +13,4 @@ toolchain:
   - xtools
 supported:
   - pwm
+  - watchdog

--- a/boards/arm/gd32f450i_eval/gd32f450i_eval.dts
+++ b/boards/arm/gd32f450i_eval/gd32f450i_eval.dts
@@ -68,6 +68,7 @@
 		pwm-led0 = &pwm_led;
 		eeprom-0 = &eeprom0;
 		spi-flash0 = &nor_flash;
+		watchdog0 = &fwdgt;
 	};
 };
 
@@ -158,4 +159,8 @@
 		status = "okay";
 		jedec-id = [c8 40 15];
 	};
+};
+
+&fwdgt {
+	status = "okay";
 };

--- a/boards/arm/gd32f450i_eval/gd32f450i_eval.yaml
+++ b/boards/arm/gd32f450i_eval/gd32f450i_eval.yaml
@@ -13,3 +13,4 @@ toolchain:
   - xtools
 supported:
   - pwm
+  - watchdog

--- a/boards/arm/gd32f450z_eval/gd32f450z_eval.dts
+++ b/boards/arm/gd32f450z_eval/gd32f450z_eval.dts
@@ -68,6 +68,7 @@
 		pwm-led0 = &pwm_led;
 		eeprom-0 = &eeprom0;
 		spi-flash0 = &nor_flash;
+		watchdog0 = &fwdgt;
 	};
 };
 
@@ -144,4 +145,8 @@
 		status = "okay";
 		jedec-id = [c8 40 15];
 	};
+};
+
+&fwdgt {
+	status = "okay";
 };

--- a/boards/arm/gd32f450z_eval/gd32f450z_eval.yaml
+++ b/boards/arm/gd32f450z_eval/gd32f450z_eval.yaml
@@ -18,3 +18,4 @@ supported:
   - pwm
   - spi
   - uart
+  - watchdog

--- a/boards/arm/gd32f470i_eval/gd32f470i_eval.dts
+++ b/boards/arm/gd32f470i_eval/gd32f470i_eval.dts
@@ -68,6 +68,7 @@
 		pwm-led0 = &pwm_led;
 		eeprom-0 = &eeprom0;
 		spi-flash0 = &nor_flash;
+		watchdog0 = &fwdgt;
 	};
 };
 
@@ -148,4 +149,8 @@
 		status = "okay";
 		jedec-id = [c8 40 15];
 	};
+};
+
+&fwdgt {
+	status = "okay";
 };

--- a/boards/arm/gd32f470i_eval/gd32f470i_eval.yaml
+++ b/boards/arm/gd32f470i_eval/gd32f470i_eval.yaml
@@ -18,3 +18,4 @@ supported:
   - pwm
   - spi
   - uart
+  - watchdog

--- a/boards/riscv/gd32vf103c_starter/gd32vf103c_starter.dts
+++ b/boards/riscv/gd32vf103c_starter/gd32vf103c_starter.dts
@@ -50,6 +50,7 @@
 		led0 = &led1;
 		sw0 = &key_a;
 		pwm-led0 = &pwm_led;
+		watchdog0 = &fwdgt;
 	};
 };
 
@@ -85,4 +86,8 @@
 		pinctrl-0 = <&pwm2_default>;
 		pinctrl-names = "default";
 	};
+};
+
+&fwdgt {
+	status = "okay";
 };

--- a/boards/riscv/gd32vf103c_starter/gd32vf103c_starter.yaml
+++ b/boards/riscv/gd32vf103c_starter/gd32vf103c_starter.yaml
@@ -13,3 +13,4 @@ supported:
   - uart
   - gpio
   - pwm
+  - watchdog

--- a/boards/riscv/gd32vf103v_eval/gd32vf103v_eval.dts
+++ b/boards/riscv/gd32vf103v_eval/gd32vf103v_eval.dts
@@ -79,6 +79,7 @@
 		sw0 = &key_cet;
 		pwm-led0 = &pwm_led;
 		spi-flash0 = &nor_flash;
+		watchdog0 = &fwdgt;
 	};
 };
 
@@ -143,4 +144,8 @@
 	status = "okay";
 	pinctrl-0 = <&adc0_default>;
 	pinctrl-names = "default";
+};
+
+&fwdgt {
+	status = "okay";
 };

--- a/boards/riscv/gd32vf103v_eval/gd32vf103v_eval.yaml
+++ b/boards/riscv/gd32vf103v_eval/gd32vf103v_eval.yaml
@@ -13,3 +13,4 @@ supported:
   - uart
   - gpio
   - pwm
+  - watchdog

--- a/boards/riscv/longan_nano/longan_nano-common.dtsi
+++ b/boards/riscv/longan_nano/longan_nano-common.dtsi
@@ -59,6 +59,7 @@
 		pwm-led0 = &pwm_led_green;
 		pwm-led1 = &pwm_led_blue;
 		sw0 = &button_boot0;
+		watchdog0 = &fwdgt;
 	};
 };
 
@@ -115,4 +116,8 @@
 			status = "okay";
 		};
 	};
+};
+
+&fwdgt {
+	status = "okay";
 };

--- a/boards/riscv/longan_nano/longan_nano.yaml
+++ b/boards/riscv/longan_nano/longan_nano.yaml
@@ -7,3 +7,5 @@ toolchain:
   - xtools
 flash: 128
 ram: 32
+supported:
+  - watchdog

--- a/boards/riscv/longan_nano/longan_nano_lite.yaml
+++ b/boards/riscv/longan_nano/longan_nano_lite.yaml
@@ -7,3 +7,5 @@ toolchain:
   - xtools
 flash: 64
 ram: 20
+supported:
+  - watchdog

--- a/drivers/watchdog/CMakeLists.txt
+++ b/drivers/watchdog/CMakeLists.txt
@@ -6,6 +6,7 @@ zephyr_library_sources_ifdef(CONFIG_IWDG_STM32 wdt_iwdg_stm32.c)
 zephyr_library_sources_ifdef(CONFIG_WWDG_STM32 wdt_wwdg_stm32.c)
 
 zephyr_library_sources_ifdef(CONFIG_FWDGT_GD32 wdt_fwdgt_gd32.c)
+zephyr_library_sources_ifdef(CONFIG_WWDGT_GD32 wdt_wwdgt_gd32.c)
 
 zephyr_library_sources_ifdef(CONFIG_WDOG_CMSDK_APB wdt_cmsdk_apb.c)
 

--- a/drivers/watchdog/CMakeLists.txt
+++ b/drivers/watchdog/CMakeLists.txt
@@ -5,6 +5,8 @@ zephyr_library()
 zephyr_library_sources_ifdef(CONFIG_IWDG_STM32 wdt_iwdg_stm32.c)
 zephyr_library_sources_ifdef(CONFIG_WWDG_STM32 wdt_wwdg_stm32.c)
 
+zephyr_library_sources_ifdef(CONFIG_FWDGT_GD32 wdt_fwdgt_gd32.c)
+
 zephyr_library_sources_ifdef(CONFIG_WDOG_CMSDK_APB wdt_cmsdk_apb.c)
 
 zephyr_library_sources_ifdef(CONFIG_WDT_CC32XX wdt_cc32xx.c)

--- a/drivers/watchdog/Kconfig
+++ b/drivers/watchdog/Kconfig
@@ -86,4 +86,6 @@ source "drivers/watchdog/Kconfig.it8xxx2"
 
 source "drivers/watchdog/Kconfig.rpi_pico"
 
+source "drivers/watchdog/Kconfig.gd32"
+
 endif

--- a/drivers/watchdog/Kconfig.gd32
+++ b/drivers/watchdog/Kconfig.gd32
@@ -8,3 +8,11 @@ config FWDGT_GD32
 	select USE_GD32_FWDGT
 	help
 	  Enable the Free watchdog timer (FWDGT) driver for GD32 SoCs.
+
+config WWDGT_GD32
+	bool "GD32 Window watchdog timer (WWDGT) Driver"
+	default y
+	depends on DT_HAS_GD_GD32_WWDGT_ENABLED
+	select USE_GD32_WWDGT
+	help
+	  Enable the Window watchdog timer (WWDGT) driver for GD32 SoCs.

--- a/drivers/watchdog/Kconfig.gd32
+++ b/drivers/watchdog/Kconfig.gd32
@@ -1,0 +1,10 @@
+# Copyright (c) 2021 TOKITA Hiroshi <tokita.hiroshi@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+config FWDGT_GD32
+	bool "GD32 Free watchdog timer (FWDGT) driver"
+	default y
+	depends on DT_HAS_GD_GD32_FWDGT_ENABLED
+	select USE_GD32_FWDGT
+	help
+	  Enable the Free watchdog timer (FWDGT) driver for GD32 SoCs.

--- a/drivers/watchdog/wdt_fwdgt_gd32.c
+++ b/drivers/watchdog/wdt_fwdgt_gd32.c
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2022 TOKITA Hiroshi
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT gd_gd32_fwdgt
+
+#include <zephyr/drivers/watchdog.h>
+#include <zephyr/logging/log.h>
+
+#include <gd32_fwdgt.h>
+
+LOG_MODULE_REGISTER(wdt_fwdgt_gd32, CONFIG_WDT_LOG_LEVEL);
+
+#define FWDGT_RELOAD_MAX    (0xFFFU)
+#define FWDGT_PRESCALER_MAX (256U)
+
+#if defined(CONFIG_GD32_HAS_IRC_32K)
+#define RCU_IRC_LOW_SPEED RCU_IRC32K
+#elif defined(CONFIG_GD32_HAS_IRC_40K)
+#define RCU_IRC_LOW_SPEED RCU_IRC40K
+#else
+#error IRC frequency was not configured
+#endif
+
+#define IS_VALID_FWDGT_PRESCALER(psc)                                          \
+	(((psc) == FWDGT_PSC_DIV4) || ((psc) == FWDGT_PSC_DIV8) ||             \
+	 ((psc) == FWDGT_PSC_DIV16) || ((psc) == FWDGT_PSC_DIV32) ||           \
+	 ((psc) == FWDGT_PSC_DIV64) || ((psc) == FWDGT_PSC_DIV128) ||          \
+	 ((psc) == FWDGT_PSC_DIV256))
+
+#define FWDGT_INITIAL_TIMEOUT DT_INST_PROP(0, initial_timeout_ms)
+
+#if (FWDGT_INITIAL_TIMEOUT <= 0)
+#error Must be initial-timeout > 0
+#elif (FWDGT_INITIAL_TIMEOUT >                                                 \
+	(FWDGT_PRESCALER_MAX * FWDGT_RELOAD_MAX * MSEC_PER_SEC /               \
+	CONFIG_GD32_LOW_SPEED_IRC_FREQUENCY))
+#error Must be initial-timeout <= (256 * 4095 * 1000 / GD32_LOW_SPEED_IRC_FREQUENCY)
+#endif
+
+/**
+ * @brief Calculates FWDGT config value from timeout.
+ *
+ * @param timeout Timeout value in milliseconds.
+ * @param prescaler Pointer to the storage of prescaler value.
+ * @param reload Pointer to the storage of reload value.
+ *
+ * @return 0 on success, -EINVAL if the timeout is out of range
+ */
+static int gd32_fwdgt_calc_timeout(uint32_t timeout, uint32_t *prescaler,
+				   uint32_t *reload)
+{
+	uint16_t divider = 4U;
+	uint8_t shift = 0U;
+	uint32_t ticks = (uint64_t)CONFIG_GD32_LOW_SPEED_IRC_FREQUENCY *
+			 timeout / MSEC_PER_SEC;
+
+	while ((ticks / divider) > FWDGT_RELOAD_MAX) {
+		shift++;
+		divider = 4U << shift;
+	}
+
+	if (!IS_VALID_FWDGT_PRESCALER(PSC_PSC(shift)) || timeout == 0U) {
+		return -EINVAL;
+	}
+
+	/* convert the 'shift' to prescaler value */
+	*prescaler = PSC_PSC(shift);
+	*reload = (ticks / divider) - 1U;
+
+	return 0;
+}
+
+static int gd32_fwdgt_setup(const struct device *dev, uint8_t options)
+{
+	ARG_UNUSED(dev);
+
+	if ((options & WDT_OPT_PAUSE_HALTED_BY_DBG) != 0U) {
+#if CONFIG_GD32_DBG_SUPPORT
+		dbg_periph_enable(DBG_FWDGT_HOLD);
+#else
+		LOG_ERR("Debug support not enabled");
+		return -ENOTSUP;
+#endif
+	}
+
+	if ((options & WDT_OPT_PAUSE_IN_SLEEP) != 0U) {
+		LOG_ERR("WDT_OPT_PAUSE_IN_SLEEP not supported");
+		return -ENOTSUP;
+	}
+
+	fwdgt_enable();
+
+	return 0;
+}
+
+static int gd32_fwdgt_disable(const struct device *dev)
+{
+	/* watchdog cannot be stopped once started */
+	ARG_UNUSED(dev);
+
+	return -EPERM;
+}
+
+static int gd32_fwdgt_install_timeout(const struct device *dev,
+				      const struct wdt_timeout_cfg *config)
+{
+	uint32_t prescaler = 0U;
+	uint32_t reload = 0U;
+	ErrStatus errstat = ERROR;
+
+	/* Callback is not supported by FWDGT */
+	if (config->callback != NULL) {
+		LOG_ERR("callback not supported by FWDGT");
+		return -ENOTSUP;
+	}
+
+	/* Calculate prescaler and reload value from timeout value */
+	if (gd32_fwdgt_calc_timeout(config->window.max, &prescaler,
+				    &reload) != 0) {
+		LOG_ERR("window max is out of range");
+		return -EINVAL;
+	}
+
+	/* Configure and run FWDGT */
+	fwdgt_write_enable();
+	errstat = fwdgt_config(reload, prescaler);
+	if (errstat != SUCCESS) {
+		LOG_ERR("fwdgt_config() failed: %d", errstat);
+		return -EINVAL;
+	}
+	fwdgt_write_disable();
+
+	return 0;
+}
+
+static int gd32_fwdgt_feed(const struct device *dev, int channel_id)
+{
+	ARG_UNUSED(channel_id);
+
+	fwdgt_counter_reload();
+
+	return 0;
+}
+
+static const struct wdt_driver_api fwdgt_gd32_api = {
+	.setup = gd32_fwdgt_setup,
+	.disable = gd32_fwdgt_disable,
+	.install_timeout = gd32_fwdgt_install_timeout,
+	.feed = gd32_fwdgt_feed,
+};
+
+static int gd32_fwdgt_init(const struct device *dev)
+{
+	int ret = 0;
+
+	/* Turn on and wait stabilize system clock oscillator. */
+	rcu_osci_on(RCU_IRC_LOW_SPEED);
+	while (!rcu_osci_stab_wait(RCU_IRC_LOW_SPEED)) {
+	}
+
+#if !defined(CONFIG_WDT_DISABLE_AT_BOOT)
+	const struct wdt_timeout_cfg config = {
+		.window.max = FWDGT_INITIAL_TIMEOUT
+	};
+
+	ret = gd32_fwdgt_install_timeout(dev, &config);
+#endif
+
+	return ret;
+}
+
+DEVICE_DT_INST_DEFINE(0, gd32_fwdgt_init, NULL, NULL, NULL, POST_KERNEL,
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &fwdgt_gd32_api);

--- a/drivers/watchdog/wdt_wwdgt_gd32.c
+++ b/drivers/watchdog/wdt_wwdgt_gd32.c
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2022 TOKITA Hiroshi
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT gd_gd32_wwdgt
+
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/clock_control/gd32.h>
+#include <zephyr/drivers/reset.h>
+#include <zephyr/drivers/watchdog.h>
+#include <zephyr/logging/log.h>
+
+#include <gd32_wwdgt.h>
+
+LOG_MODULE_REGISTER(wdt_wwdgt_gd32, CONFIG_WDT_LOG_LEVEL);
+
+#define WWDGT_PRESCALER_EXP_MAX (3U)
+#define WWDGT_COUNTER_MIN	(0x40U)
+#define WWDGT_COUNTER_MAX	(0x7fU)
+#define WWDGT_INTERNAL_DIVIDER	(4096ULL)
+
+struct gd32_wwdgt_config {
+	uint16_t clkid;
+	struct reset_dt_spec reset;
+};
+
+/* mutable driver data */
+struct gd32_wwdgt_data {
+	/* counter update value*/
+	uint8_t counter;
+	/* user defined callback */
+	wdt_callback_t callback;
+};
+
+static void gd32_wwdgt_irq_config(const struct device *dev);
+
+/**
+ * @param timeout Timeout value in milliseconds.
+ * @param exp exponent part of prescaler
+ *
+ * @return ticks count calculated by this formula.
+ *
+ *  timeout = pclk * INTERNAL_DIVIDER * (2^prescaler_exp) * (count + 1)
+ *  transform as
+ *  count = (timeout * pclk / INTERNAL_DIVIDER * (2^prescaler_exp) ) - 1
+ *
+ *  and add WWDGT_COUNTER_MIN to this as a offset value.
+ */
+static inline uint32_t gd32_wwdgt_calc_ticks(const struct device *dev,
+					    uint32_t timeout, uint32_t exp)
+{
+	const struct gd32_wwdgt_config *config = dev->config;
+	uint32_t pclk;
+
+	(void)clock_control_get_rate(GD32_CLOCK_CONTROLLER,
+				       (clock_control_subsys_t *)&config->clkid,
+				       &pclk);
+
+	return ((timeout * pclk)
+		/ (WWDGT_INTERNAL_DIVIDER * (1 << exp) * MSEC_PER_SEC) - 1)
+		+ WWDGT_COUNTER_MIN;
+}
+
+/**
+ * @brief Calculates WWDGT config value from timeout window.
+ *
+ * @param win Pointer to timeout window struct.
+ * @param counter Pointer to the storage of counter value.
+ * @param wval Pointer to the storage of window value.
+ * @param prescaler Pointer to the storage of prescaler value.
+ *
+ * @return 0 on success, -EINVAL if the window-max is out of range
+ */
+static int gd32_wwdgt_calc_window(const struct device *dev,
+				  const struct wdt_window *win,
+				  uint32_t *counter, uint32_t *wval,
+				  uint32_t *prescaler)
+{
+	for (uint32_t shift = 0U; shift <= WWDGT_PRESCALER_EXP_MAX; shift++) {
+		uint32_t max_count = gd32_wwdgt_calc_ticks(dev, win->max, shift);
+
+		if (max_count <= WWDGT_COUNTER_MAX) {
+			*counter = max_count;
+			*prescaler = CFG_PSC(shift);
+			if (win->min == 0U) {
+				*wval = max_count;
+			} else {
+				*wval = gd32_wwdgt_calc_ticks(dev, win->min, shift);
+			}
+
+			return 0;
+		}
+	}
+
+	return -EINVAL;
+}
+
+static int gd32_wwdgt_setup(const struct device *dev, uint8_t options)
+{
+	ARG_UNUSED(dev);
+
+	if (options & WDT_OPT_PAUSE_HALTED_BY_DBG) {
+#if CONFIG_GD32_DBG_SUPPORT
+		dbg_periph_enable(DBG_WWDGT_HOLD);
+#else
+		LOG_ERR("Debug support not enabled");
+		return -ENOTSUP;
+#endif
+	}
+
+	if (options & WDT_OPT_PAUSE_IN_SLEEP) {
+		LOG_ERR("WDT_OPT_PAUSE_IN_SLEEP not supported");
+		return -ENOTSUP;
+	}
+
+	wwdgt_enable();
+	wwdgt_flag_clear();
+	wwdgt_interrupt_enable();
+
+	return 0;
+}
+
+static int gd32_wwdgt_disable(const struct device *dev)
+{
+	/* watchdog cannot be stopped once started */
+	ARG_UNUSED(dev);
+
+	return -EPERM;
+}
+
+static int gd32_wwdgt_install_timeout(const struct device *dev,
+				      const struct wdt_timeout_cfg *config)
+{
+	uint32_t prescaler = 0U;
+	uint32_t counter = 0U;
+	uint32_t window = 0U;
+	struct gd32_wwdgt_data *data = dev->data;
+
+	if (config->window.max == 0U) {
+		LOG_ERR("window.max must be non-zero");
+		return -EINVAL;
+	}
+
+	if (gd32_wwdgt_calc_window(dev, &config->window, &counter, &window,
+				   &prescaler) != 0) {
+		LOG_ERR("window.max in out of range");
+		return -EINVAL;
+	}
+
+	data->callback = config->callback;
+	data->counter = counter;
+
+	wwdgt_config(counter, window, prescaler);
+
+	return 0;
+}
+
+static int gd32_wwdgt_feed(const struct device *dev, int channel_id)
+{
+	struct gd32_wwdgt_data *data = dev->data;
+
+	ARG_UNUSED(channel_id);
+
+	wwdgt_counter_update(data->counter);
+
+	return 0;
+}
+
+static void gd32_wwdgt_isr(const struct device *dev)
+{
+	struct gd32_wwdgt_data *data = dev->data;
+
+	if (wwdgt_flag_get() != 0) {
+		wwdgt_flag_clear();
+
+		if (data->callback != NULL) {
+			data->callback(dev, 0);
+		}
+	}
+}
+
+static void gd32_wwdgt_irq_config(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority), gd32_wwdgt_isr,
+		    DEVICE_DT_INST_GET(0), 0);
+	irq_enable(DT_INST_IRQN(0));
+}
+
+static const struct wdt_driver_api wwdgt_gd32_api = {
+	.setup = gd32_wwdgt_setup,
+	.disable = gd32_wwdgt_disable,
+	.install_timeout = gd32_wwdgt_install_timeout,
+	.feed = gd32_wwdgt_feed,
+};
+
+static int gd32_wwdgt_init(const struct device *dev)
+{
+	const struct gd32_wwdgt_config *config = dev->config;
+
+	(void)clock_control_on(GD32_CLOCK_CONTROLLER,
+			       (clock_control_subsys_t *)&config->clkid);
+	(void)reset_line_toggle_dt(&config->reset);
+	gd32_wwdgt_irq_config(dev);
+
+	return 0;
+}
+
+static const struct gd32_wwdgt_config wwdgt_cfg = {
+	.clkid = DT_INST_CLOCKS_CELL(0, id),
+	.reset = RESET_DT_SPEC_INST_GET(0),
+};
+
+static struct gd32_wwdgt_data wwdgt_data = {
+	.counter = WWDGT_COUNTER_MIN,
+	.callback = NULL
+};
+
+DEVICE_DT_INST_DEFINE(0, gd32_wwdgt_init, NULL, &wwdgt_data, &wwdgt_cfg, POST_KERNEL,
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &wwdgt_gd32_api);

--- a/dts/arm/gigadevice/gd32e10x/gd32e10x.dtsi
+++ b/dts/arm/gigadevice/gd32e10x/gd32e10x.dtsi
@@ -164,6 +164,21 @@
 			status = "okay";
 		};
 
+		fwdgt: watchdog@40003000 {
+			compatible = "gd,gd32-fwdgt";
+			reg = <0x40003000 0x400>;
+			status = "disabled";
+		};
+
+		wwdgt: watchdog@40002c00 {
+			compatible = "gd,gd32-wwdgt";
+			reg = <0x40002C00 0x400>;
+			clocks = <&cctl GD32_CLOCK_WWDGT>;
+			resets = <&rctl GD32_RESET_WWDGT>;
+			interrupts = <0 0>;
+			status = "disabled";
+		};
+
 		pinctrl: pin-controller@40010800 {
 			compatible = "gd,gd32-pinctrl-afio";
 			reg = <0x40010800 0x1c00>;

--- a/dts/arm/gigadevice/gd32e50x/gd32e50x.dtsi
+++ b/dts/arm/gigadevice/gd32e50x/gd32e50x.dtsi
@@ -201,6 +201,21 @@
 			status = "okay";
 		};
 
+		fwdgt: watchdog@40003000 {
+			compatible = "gd,gd32-fwdgt";
+			reg = <0x40003000 0x400>;
+			status = "disabled";
+		};
+
+		wwdgt: watchdog@40002c00 {
+			compatible = "gd,gd32-wwdgt";
+			reg = <0x40002C00 0x400>;
+			clocks = <&cctl GD32_CLOCK_WWDGT>;
+			resets = <&rctl GD32_RESET_WWDGT>;
+			interrupts = <0 0>;
+			status = "disabled";
+		};
+
 		pinctrl: pin-controller@40010800 {
 			compatible = "gd,gd32-pinctrl-afio";
 			reg = <0x40010800 0x2400>;

--- a/dts/arm/gigadevice/gd32f3x0/gd32f3x0.dtsi
+++ b/dts/arm/gigadevice/gd32f3x0/gd32f3x0.dtsi
@@ -101,6 +101,21 @@
 			status = "disabled";
 		};
 
+		fwdgt: watchdog@40003000 {
+			compatible = "gd,gd32-fwdgt";
+			reg = <0x40003000 0x400>;
+			status = "disabled";
+		};
+
+		wwdgt: watchdog@40002c00 {
+			compatible = "gd,gd32-wwdgt";
+			reg = <0x40002C00 0x400>;
+			clocks = <&cctl GD32_CLOCK_WWDGT>;
+			resets = <&rctl GD32_RESET_WWDGT>;
+			interrupts = <0 0>;
+			status = "disabled";
+		};
+
 		pinctrl: pin-controller@48000000 {
 			compatible = "gd,gd32-pinctrl-af";
 			reg = <0x48000000 0x1800>;

--- a/dts/arm/gigadevice/gd32f403/gd32f403.dtsi
+++ b/dts/arm/gigadevice/gd32f403/gd32f403.dtsi
@@ -202,6 +202,21 @@
 			status = "okay";
 		};
 
+		fwdgt: watchdog@40003000 {
+			compatible = "gd,gd32-fwdgt";
+			reg = <0x40003000 0x400>;
+			status = "disabled";
+		};
+
+		wwdgt: watchdog@40002c00 {
+			compatible = "gd,gd32-wwdgt";
+			reg = <0x40002C00 0x400>;
+			clocks = <&cctl GD32_CLOCK_WWDGT>;
+			resets = <&rctl GD32_RESET_WWDGT>;
+			interrupts = <0 0>;
+			status = "disabled";
+		};
+
 		pinctrl: pin-controller@40010800 {
 			compatible = "gd,gd32-pinctrl-afio";
 			reg = <0x40010800 0x1c00>;

--- a/dts/arm/gigadevice/gd32f4xx/gd32f4xx.dtsi
+++ b/dts/arm/gigadevice/gd32f4xx/gd32f4xx.dtsi
@@ -274,6 +274,21 @@
 			status = "okay";
 		};
 
+		fwdgt: watchdog@40003000 {
+			compatible = "gd,gd32-fwdgt";
+			reg = <0x40003000 0x400>;
+			status = "disabled";
+		};
+
+		wwdgt: watchdog@40002c00 {
+			compatible = "gd,gd32-wwdgt";
+			reg = <0x40002C00 0x400>;
+			clocks = <&cctl GD32_CLOCK_WWDGT>;
+			resets = <&rctl GD32_RESET_WWDGT>;
+			interrupts = <0 0>;
+			status = "disabled";
+		};
+
 		pinctrl: pin-controller@40020000 {
 			compatible = "gd,gd32-pinctrl-af";
 			reg = <0x40020000 0x2400>;

--- a/dts/bindings/watchdog/gd,gd32-fwdgt.yaml
+++ b/dts/bindings/watchdog/gd,gd32-fwdgt.yaml
@@ -1,0 +1,33 @@
+# Copyright (c) 2021, TOKITA Hiroshi
+# SPDX-License-Identifier: Apache-2.0
+
+description: GD32 free watchdog timer
+
+compatible: "gd,gd32-fwdgt"
+
+include: base.yaml
+
+properties:
+    reg:
+      required: true
+
+    initial-timeout-ms:
+      type: int
+      default: 250
+      description: |
+        Set timeout value in milliseconds.
+        The following equation gives the maximum timeout value
+
+          timeout = (reload + 1) / (peripheral_freqency / prescaler).
+
+        where the maximum prescaler = 256 and the maximum reload = 4096.
+        The peripheral_frequency uses GD32_LOW_SPEED_IRC_FREQUENCY
+        that defined in modules/hal_gigadevice/Kconfig.
+        Validate the value is within a capable range at the compile time.
+
+        The default value defined is close to the register reset value
+        from values that don't cause calculation errors in both cases of
+        the low-speed internal RC oscillator frequency is 32kHz or 40kHz.
+
+        0.25 [timeout in sec] = (1999 [reload] + 1) / (32000 [freq] / 4 [prescaler])
+        0.25 [timeout in sec] = (2499 [reload] + 1) / (40000 [freq] / 4 [prescaler])

--- a/dts/bindings/watchdog/gd,gd32-wwdgt.yaml
+++ b/dts/bindings/watchdog/gd,gd32-wwdgt.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2021 TOKITA Hiroshi
+# SPDX-License-Identifier: Apache-2.0
+
+description: GD32 window watchdog timer
+
+compatible: "gd,gd32-wwdgt"
+
+include: [base.yaml, reset-device.yaml]
+
+properties:
+    reg:
+      required: true
+
+    clocks:
+      required: true
+
+    resets:
+      required: true

--- a/dts/riscv/gigadevice/gd32vf103.dtsi
+++ b/dts/riscv/gigadevice/gd32vf103.dtsi
@@ -204,6 +204,21 @@
 			status = "okay";
 		};
 
+		fwdgt: watchdog@40003000 {
+			compatible = "gd,gd32-fwdgt";
+			reg = <0x40003000 0x400>;
+			status = "disabled";
+		};
+
+		wwdgt: watchdog@40002c00 {
+			compatible = "gd,gd32-wwdgt";
+			reg = <0x40002C00 0x400>;
+			clocks = <&cctl GD32_CLOCK_WWDGT>;
+			resets = <&rctl GD32_RESET_WWDGT>;
+			interrupts = <0 0>;
+			status = "disabled";
+		};
+
 		pinctrl: pin-controller@40010800 {
 			compatible = "gd,gd32-pinctrl-afio";
 			reg = <0x40010800 0x1c00>;

--- a/modules/hal_gigadevice/CMakeLists.txt
+++ b/modules/hal_gigadevice/CMakeLists.txt
@@ -30,6 +30,14 @@ elseif(${CONFIG_GD32_HXTAL_25MHZ})
   zephyr_compile_definitions(HXTAL_VALUE=25000000 HXTAL_VALUE_8M=25000000)
 endif()
 
+if(CONFIG_GD32_HAS_IRC_32K)
+  zephyr_compile_definitions(IRC32K_VALUE=${CONFIG_GD32_LOW_SPEED_IRC_FREQUENCY})
+endif()
+
+if(CONFIG_GD32_HAS_IRC_40K)
+  zephyr_compile_definitions(IRC40K_VALUE=${CONFIG_GD32_LOW_SPEED_IRC_FREQUENCY})
+endif()
+
 # GD32E50X series HAL public headers require extra definitions
 if(${CONFIG_SOC_SERIES_GD32E50X})
   zephyr_compile_definitions(GD32E50X)

--- a/modules/hal_gigadevice/Kconfig
+++ b/modules/hal_gigadevice/Kconfig
@@ -70,6 +70,15 @@ config GD32_LOW_SPEED_IRC_FREQUENCY
 	help
 	  Define value of low speed internal RC oscillator (IRC) in Hz
 
+config GD32_DBG_SUPPORT
+	bool "Use GD32 Debug features"
+	select USE_GD32_DBG
+	default y
+	help
+	  Enable GD32 Debug features.
+	  This option makes allows using functions that access to
+	  DBG_CTL register such as dbg_periph_enable().
+
 config USE_GD32_ADC
 	bool
 	help

--- a/modules/hal_gigadevice/Kconfig
+++ b/modules/hal_gigadevice/Kconfig
@@ -53,6 +53,23 @@ config GD32_HXTAL_25MHZ
 
 endchoice
 
+config GD32_HAS_IRC_32K
+	bool
+	help
+	  Use 32KHz oscillator for low speed internal RC Oscillator
+
+config GD32_HAS_IRC_40K
+	bool
+	help
+	  Use 40KHz oscillator for low speed internal RC Oscillator
+
+config GD32_LOW_SPEED_IRC_FREQUENCY
+	int
+	default 32000 if GD32_HAS_IRC_32K
+	default 40000 if GD32_HAS_IRC_40K
+	help
+	  Define value of low speed internal RC oscillator (IRC) in Hz
+
 config USE_GD32_ADC
 	bool
 	help

--- a/samples/drivers/watchdog/boards/gd32_fwdgt.overlay
+++ b/samples/drivers/watchdog/boards/gd32_fwdgt.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022 Tokita, Hiroshi <tokita.hiroshi@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		watchdog0 = &fwdgt;
+	};
+};
+
+&fwdgt {
+	status = "okay";
+};
+
+&wwdgt {
+	status = "disabled";
+};

--- a/samples/drivers/watchdog/boards/gd32_wwdgt.overlay
+++ b/samples/drivers/watchdog/boards/gd32_wwdgt.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022 Tokita, Hiroshi <tokita.hiroshi@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		watchdog0 = &wwdgt;
+	};
+};
+
+&fwdgt {
+	status = "disabled";
+};
+
+&wwdgt {
+	status = "okay";
+};

--- a/samples/drivers/watchdog/sample.yaml
+++ b/samples/drivers/watchdog/sample.yaml
@@ -14,7 +14,7 @@ common:
   depends_on: watchdog
 tests:
   sample.drivers.watchdog:
-    filter: not CONFIG_SOC_FAMILY_STM32
+    filter: not (CONFIG_SOC_FAMILY_STM32 or CONFIG_SOC_FAMILY_GD32 or SOC_SERIES_GD32VF103)
   sample.drivers.watchdog.stm32_wwdg:
     extra_args: DTC_OVERLAY_FILE=boards/stm32_wwdg.overlay
     filter: dt_compat_enabled("st,stm32-window-watchdog")
@@ -27,3 +27,15 @@ tests:
     platform_allow: b_u585i_iot02a nucleo_f091rc nucleo_f103rb nucleo_f207zg nucleo_f429zi
         nucleo_f746zg nucleo_g071rb nucleo_g474re nucleo_h743zi nucleo_l073rz nucleo_l152re
         nucleo_wb55rg nucleo_wl55jc stm32f3_disco stm32l562e_dk disco_l475_iot1
+  sample.drivers.watchdog.gd32_fwdgt:
+    filter: dt_has_compat("gd,gd32-fwdgt")
+    extra_args: DTC_OVERLAY_FILE=boards/gd32_fwdgt.overlay
+    platform_allow: gd32e103v_eval gd32e507v_start gd32f350r_eval gd32f403z_eval
+        gd32f450i_eval gd32f450z_eval gd32f470i_eval gd32vf103c_starter gd32vf103v_eval
+        longan_nano
+  sample.drivers.watchdog.gd32_wwdgt:
+    filter: dt_has_compat("gd,gd32-wwdgt")
+    extra_args: DTC_OVERLAY_FILE=boards/gd32_wwdgt.overlay
+    platform_allow: gd32e103v_eval gd32e507v_start gd32f350r_eval gd32f403z_eval
+        gd32f450i_eval gd32f450z_eval gd32f470i_eval gd32vf103c_starter gd32vf103v_eval
+        longan_nano

--- a/soc/arm/gigadevice/gd32e10x/Kconfig.series
+++ b/soc/arm/gigadevice/gd32e10x/Kconfig.series
@@ -10,5 +10,6 @@ config SOC_SERIES_GD32E10X
 	select CPU_CORTEX_M_HAS_VTOR
 	select SOC_FAMILY_GD32_ARM
 	select GD32_HAS_AFIO_PINMUX
+	select GD32_HAS_IRC_40K
 	help
 	  Enable support for GigaDevice GD32E10X MCU series

--- a/soc/arm/gigadevice/gd32e50x/Kconfig.series
+++ b/soc/arm/gigadevice/gd32e50x/Kconfig.series
@@ -9,5 +9,6 @@ config SOC_SERIES_GD32E50X
 	select CPU_CORTEX_M33
 	select SOC_FAMILY_GD32_ARM
 	select GD32_HAS_AFIO_PINMUX
+	select GD32_HAS_IRC_40K
 	help
 	  Enable support for GigaDevice GD32E50X MCU series

--- a/soc/arm/gigadevice/gd32f3x0/Kconfig.series
+++ b/soc/arm/gigadevice/gd32f3x0/Kconfig.series
@@ -8,5 +8,6 @@ config SOC_SERIES_GD32F3X0
 	select CPU_CORTEX_M4
 	select SOC_FAMILY_GD32_ARM
 	select GD32_HAS_AF_PINMUX
+	select GD32_HAS_IRC_40K
 	help
 	  Enable support for GigaDevice GD32F3X0 MCU series

--- a/soc/arm/gigadevice/gd32f403/Kconfig.series
+++ b/soc/arm/gigadevice/gd32f403/Kconfig.series
@@ -11,5 +11,6 @@ config SOC_SERIES_GD32F403
 	select CPU_CORTEX_M_HAS_VTOR
 	select SOC_FAMILY_GD32_ARM
 	select GD32_HAS_AFIO_PINMUX
+	select GD32_HAS_IRC_40K
 	help
 	  Enable support for GigaDevice GD32F403 MCU series

--- a/soc/arm/gigadevice/gd32f4xx/Kconfig.series
+++ b/soc/arm/gigadevice/gd32f4xx/Kconfig.series
@@ -9,5 +9,6 @@ config SOC_SERIES_GD32F4XX
 	select CPU_CORTEX_M4
 	select SOC_FAMILY_GD32_ARM
 	select GD32_HAS_AF_PINMUX
+	select GD32_HAS_IRC_32K
 	help
 	  Enable support for GigaDevice GD32F4XX MCU series

--- a/soc/riscv/riscv-privilege/gd32vf103/Kconfig.series
+++ b/soc/riscv/riscv-privilege/gd32vf103/Kconfig.series
@@ -12,6 +12,7 @@ config SOC_SERIES_GD32VF103
 	select BUILD_OUTPUT_HEX
 	select XIP
 	select GD32_HAS_AFIO_PINMUX
+	select GD32_HAS_IRC_40K
 	select HAS_GD32_HAL
 	select RISCV_HAS_CLIC
 

--- a/tests/drivers/watchdog/wdt_basic_api/boards/gd32_fwdgt.overlay
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/gd32_fwdgt.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2022 Tokita, Hiroshi <tokita.hiroshi@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&fwdgt {
+	status = "okay";
+};

--- a/tests/drivers/watchdog/wdt_basic_api/boards/gd32_wwdgt.overlay
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/gd32_wwdgt.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2022 Tokita, Hiroshi <tokita.hiroshi@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&wwdgt {
+	status = "okay";
+};

--- a/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
+++ b/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
@@ -92,6 +92,10 @@
 #define WDT_NODE DT_INST(0, ti_cc32xx_watchdog)
 #elif DT_HAS_COMPAT_STATUS_OKAY(nxp_imx_wdog)
 #define WDT_NODE DT_INST(0, nxp_imx_wdog)
+#elif DT_HAS_COMPAT_STATUS_OKAY(gd_gd32_wwdgt)
+#define WDT_NODE DT_INST(0, gd_gd32_wwdgt)
+#elif DT_HAS_COMPAT_STATUS_OKAY(gd_gd32_fwdgt)
+#define WDT_NODE DT_INST(0, gd_gd32_fwdgt)
 #elif DT_HAS_COMPAT_STATUS_OKAY(zephyr_counter_watchdog)
 #define WDT_NODE DT_COMPAT_GET_ANY_STATUS_OKAY(zephyr_counter_watchdog)
 #endif

--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -6,7 +6,8 @@ tests:
     filter: >
       not (CONFIG_WDT_SAM or dt_compat_enabled("st,stm32-window-watchdog")
        or dt_compat_enabled("st,stm32-watchdog") or CONFIG_SOC_FAMILY_LPC or
-       CONFIG_SOC_SERIES_IMX_RT6XX or CONFIG_SOC_SERIES_IMX_RT5XX)
+       CONFIG_SOC_SERIES_IMX_RT6XX or CONFIG_SOC_SERIES_IMX_RT5XX or
+       CONFIG_SOC_FAMILY_GD32 or SOC_SERIES_GD32VF103)
     platform_exclude: mec15xxevb_assy6853
   drivers.watchdog.stm32wwdg:
     filter: dt_compat_enabled("st,stm32-window-watchdog") or dt_compat_enabled("st,stm32-watchdog")
@@ -33,3 +34,15 @@ tests:
     platform_allow: nrf52840dk_nrf52840
     extra_args: OVERLAY_CONFIG="boards/nrf52840dk_nrf52840_counter.conf"
       DTC_OVERLAY_FILE="boards/nrf52840dk_nrf52840_counter.overlay"
+  drivers.watchdog.gd32fwdgt:
+    filter: dt_compat_enabled("gd,gd32-fwdgt")
+    extra_args: DTC_OVERLAY_FILE="boards/gd32_fwdgt.overlay"
+    platform_allow: gd32e103v_eval gd32e507v_start gd32f350r_eval gd32f403z_eval
+        gd32f450i_eval gd32f450z_eval gd32f470i_eval gd32vf103c_starter gd32vf103v_eval
+        longan_nano
+  drivers.watchdog.gd32wwdgt:
+    filter: dt_compat_enabled("gd,gd32-wwdgt")
+    extra_args: DTC_OVERLAY_FILE="boards/gd32_wwdgt.overlay"
+    platform_allow: gd32e103v_eval gd32e507v_start gd32f350r_eval gd32f403z_eval
+        gd32f450i_eval gd32f450z_eval gd32f470i_eval gd32vf103c_starter
+        gd32vf103v_eval longan_nano


### PR DESCRIPTION
This PR adds watchdog drivers for GD32.
GD32 has two types of the watchdog timer, such as

- FWDGT free watchdog timer
- WWDGT Window watchdog timer

This PR adds support for both types of watchdogs.

I verified with  Longan Nano Board with GD32VF103.

More GD32 work #38657