### PR TITLE
boards: doc: Clarify a generic statement

### DIFF
--- a/boards/arm/96b_nitrogen/doc/index.rst
+++ b/boards/arm/96b_nitrogen/doc/index.rst
@@ -72,7 +72,7 @@ features:
 | RTT       | on-chip    | console                              |
 +-----------+------------+--------------------------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 See `Nordic Semiconductor Infocenter`_ for a complete list of nRF52-based
 board hardware features.
 

--- a/boards/arm/adafruit_feather_nrf52840/doc/index.rst
+++ b/boards/arm/adafruit_feather_nrf52840/doc/index.rst
@@ -81,7 +81,7 @@ following hardware features:
 | WDT       | on-chip    | watchdog             |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 
 Connections and IOs
 ===================

--- a/boards/arm/adafruit_feather_stm32f405/doc/index.rst
+++ b/boards/arm/adafruit_feather_stm32f405/doc/index.rst
@@ -56,7 +56,7 @@ following hardware features:
 | USB       | on-chip    | USB device           |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 
 Connections and IOs
 ===================

--- a/boards/arm/arduino_nano_33_ble/doc/index.rst
+++ b/boards/arm/arduino_nano_33_ble/doc/index.rst
@@ -61,7 +61,7 @@ The package is configured to support the following hardware:
 | WDT       | on-chip    | watchdog             |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 
 Notably, this includes the PDM (microphone) interface.
 

--- a/boards/arm/bcm958401m2/doc/index.rst
+++ b/boards/arm/bcm958401m2/doc/index.rst
@@ -29,7 +29,7 @@ features:
 | UART      | on-chip    | serial port                          |
 +-----------+------------+--------------------------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 
 The default configuration can be found in the defconfig file:
 

--- a/boards/arm/bcm958402m2_m7/doc/index.rst
+++ b/boards/arm/bcm958402m2_m7/doc/index.rst
@@ -29,7 +29,7 @@ hardware features:
 | UART      | on-chip    | Compatible with UART NS16550         |
 +-----------+------------+--------------------------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 
 The default configuration can be found in the defconfig file:
 

--- a/boards/arm/bl5340_dvk/doc/index.rst
+++ b/boards/arm/bl5340_dvk/doc/index.rst
@@ -137,7 +137,7 @@ hardware features:
 | WDT       | on-chip    | watchdog             |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 See `Nordic Semiconductor Infocenter`_
 for a complete list of hardware features.
 

--- a/boards/arm/bl652_dvk/doc/bl652_dvk.rst
+++ b/boards/arm/bl652_dvk/doc/bl652_dvk.rst
@@ -89,7 +89,7 @@ hardware features:
 | WDT       | on-chip    | watchdog             |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 See `BL652 Module Website`_.
 
 Connections and IOs

--- a/boards/arm/bl653_dvk/doc/bl653_dvk.rst
+++ b/boards/arm/bl653_dvk/doc/bl653_dvk.rst
@@ -81,7 +81,7 @@ hardware features:
 | WDT       | on-chip    | watchdog             |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 See `BL653 website`_
 for a complete list of BL653 Development Kit board hardware features.
 

--- a/boards/arm/bl654_dvk/doc/bl654_dvk.rst
+++ b/boards/arm/bl654_dvk/doc/bl654_dvk.rst
@@ -88,7 +88,7 @@ hardware features:
 | WDT       | on-chip    | watchdog             |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 See `BL654 website`_
 for a complete list of BL654 Development Kit board hardware features.
 

--- a/boards/arm/bl654_sensor_board/doc/bl654_sensor_board.rst
+++ b/boards/arm/bl654_sensor_board/doc/bl654_sensor_board.rst
@@ -86,7 +86,7 @@ The BL654 Sensor Board configuration supports the following hardware features:
 | WDT       | on-chip    | watchdog             |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 See the `BL654 website`_ for a complete list of BL654 module hardware features.
 
 Connections and IOs

--- a/boards/arm/bl654_usb/doc/bl654_usb.rst
+++ b/boards/arm/bl654_usb/doc/bl654_usb.rst
@@ -75,7 +75,7 @@ hardware features:
 | WDT       | on-chip    | watchdog             |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 See `BL654 website`_
 for a complete list of BL654 USB adapter hardware features.
 

--- a/boards/arm/cc1352r1_launchxl/doc/index.rst
+++ b/boards/arm/cc1352r1_launchxl/doc/index.rst
@@ -53,7 +53,7 @@ features:
 | SPI       | on-chip    | spi                  |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 
 Connections and IOs
 ===================

--- a/boards/arm/cc1352r_sensortag/doc/index.rst
+++ b/boards/arm/cc1352r_sensortag/doc/index.rst
@@ -61,7 +61,7 @@ features:
 | SPI       | off-chip   | ADXL362          |
 +-----------+------------+------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 
 Connections and IOs
 ===================

--- a/boards/arm/cc26x2r1_launchxl/doc/index.rst
+++ b/boards/arm/cc26x2r1_launchxl/doc/index.rst
@@ -53,7 +53,7 @@ features:
 | SPI       | on-chip    | spi                  |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 
 Connections and IOs
 ===================

--- a/boards/arm/contextualelectronics_abc/doc/index.rst
+++ b/boards/arm/contextualelectronics_abc/doc/index.rst
@@ -76,7 +76,7 @@ hardware features:
 | Modem     | on-board   | quectel_bg9x         |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 See `ABC Board website`_ for more details on this board, and
 `Nordic Semiconductor Infocenter`_ for a complete list of SoC
 features.

--- a/boards/arm/holyiot_yj16019/doc/index.rst
+++ b/boards/arm/holyiot_yj16019/doc/index.rst
@@ -67,7 +67,7 @@ hardware features:
 | WDT       | on-chip    | watchdog             |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 
 Connections and IOs
 ===================

--- a/boards/arm/mikroe_clicker_2/doc/mikroe_clicker_2.rst
+++ b/boards/arm/mikroe_clicker_2/doc/mikroe_clicker_2.rst
@@ -52,7 +52,7 @@ The Zephyr MikroE Clicker 2 configuration supports the following hardware featur
 | USB       | on-chip    | usb                                 |
 +-----------+------------+-------------------------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 
 The default configuration can be found in the defconfig file:
 

--- a/boards/arm/mikroe_mini_m4_for_stm32/doc/mikroe_mini_m4_for_stm32.rst
+++ b/boards/arm/mikroe_mini_m4_for_stm32/doc/mikroe_mini_m4_for_stm32.rst
@@ -84,7 +84,7 @@ features:
 +-----------+------------+----------------------+
 
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 
 The default configuration can be found in the defconfig file:
 

--- a/boards/arm/nrf21540dk_nrf52840/doc/index.rst
+++ b/boards/arm/nrf21540dk_nrf52840/doc/index.rst
@@ -83,7 +83,7 @@ hardware features:
 | WDT       | on-chip    | watchdog             |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 See `nRF52840 Product Specification`_ and `Nordic Semiconductor Infocenter`_
 for a complete list of nRF21540 Development Kit board hardware features.
 

--- a/boards/arm/nrf51dk_nrf51422/doc/index.rst
+++ b/boards/arm/nrf51dk_nrf51422/doc/index.rst
@@ -75,7 +75,7 @@ hardware features:
 | WDT       | on-chip    | watchdog             |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 See `nRF51 DK website`_ and `Nordic Semiconductor Infocenter`_
 for a complete list of nRF51 Development Kit board hardware features.
 

--- a/boards/arm/nrf51dongle_nrf51422/doc/index.rst
+++ b/boards/arm/nrf51dongle_nrf51422/doc/index.rst
@@ -75,7 +75,7 @@ hardware features:
 | WDT       | on-chip    | watchdog             |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 See `nRF51 Dongle website`_ and `Nordic Semiconductor Infocenter`_
 for a complete list of nRF51 Dongle hardware features.
 

--- a/boards/arm/nrf52833dk_nrf52833/doc/index.rst
+++ b/boards/arm/nrf52833dk_nrf52833/doc/index.rst
@@ -79,7 +79,7 @@ hardware features:
 | WDT       | on-chip    | watchdog             |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 See `nRF52833 DK website`_ and `Nordic Semiconductor Infocenter`_
 for a complete list of nRF52833 Development Kit board hardware features.
 

--- a/boards/arm/nrf52840dk_nrf52840/doc/index.rst
+++ b/boards/arm/nrf52840dk_nrf52840/doc/index.rst
@@ -84,7 +84,7 @@ hardware features:
 | WDT       | on-chip    | watchdog             |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 See `nRF52840 DK website`_ and `Nordic Semiconductor Infocenter`_
 for a complete list of nRF52840 Development Kit board hardware features.
 

--- a/boards/arm/nrf52840dongle_nrf52840/doc/index.rst
+++ b/boards/arm/nrf52840dongle_nrf52840/doc/index.rst
@@ -82,7 +82,7 @@ hardware features:
 | WDT       | on-chip    | watchdog             |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 See `nRF52840 Dongle website`_ and `Nordic Semiconductor Infocenter`_
 for a complete list of nRF52840 Dongle board hardware features.
 

--- a/boards/arm/nrf52_adafruit_feather/doc/index.rst
+++ b/boards/arm/nrf52_adafruit_feather/doc/index.rst
@@ -67,7 +67,7 @@ hardware features:
 | RTT       | on-chip    | console              |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 
 Connections and IOs
 ===================

--- a/boards/arm/nrf52_vbluno52/doc/index.rst
+++ b/boards/arm/nrf52_vbluno52/doc/index.rst
@@ -58,7 +58,7 @@ hardware features:
 | SPI       | on-chip    | spi                  |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 
 Connections and IOs
 ===================

--- a/boards/arm/nrf52dk_nrf52832/doc/index.rst
+++ b/boards/arm/nrf52dk_nrf52832/doc/index.rst
@@ -82,7 +82,7 @@ hardware features:
 | WDT       | on-chip    | watchdog             |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 See `nRF52 DK website`_ and `Nordic Semiconductor Infocenter`_
 for a complete list of nRF52 Development Kit board hardware features.
 

--- a/boards/arm/nrf5340dk_nrf5340/doc/index.rst
+++ b/boards/arm/nrf5340dk_nrf5340/doc/index.rst
@@ -132,7 +132,7 @@ hardware features:
 | WDT       | on-chip    | watchdog             |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 See `Nordic Semiconductor Infocenter`_
 for a complete list of nRF5340 DK board hardware features.
 

--- a/boards/arm/nrf9160dk_nrf9160/doc/index.rst
+++ b/boards/arm/nrf9160dk_nrf9160/doc/index.rst
@@ -108,7 +108,7 @@ should be used when building your application (for more information, see
 Remember to also enable routing for this additional hardware in the firmware for
 :ref:`nrf9160dk_nrf52840` (see :ref:`nrf9160dk_board_controller_firmware`).
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 See `nRF9160 DK website`_ and `Nordic Semiconductor Infocenter`_
 for a complete list of nRF9160 DK board hardware features.
 

--- a/boards/arm/olimex_stm32_e407/doc/index.rst
+++ b/boards/arm/olimex_stm32_e407/doc/index.rst
@@ -48,7 +48,7 @@ hardware features:
 | USB OTG HS | on-chip    | USB device           |
 +------------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 
 Pin Mapping
 ===========

--- a/boards/arm/olimex_stm32_h103/doc/index.rst
+++ b/boards/arm/olimex_stm32_h103/doc/index.rst
@@ -60,7 +60,7 @@ The OLIMEX STM32-H103 supports the following hardware features:
 | ADC       | on-chip    | adc                  |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 
 Connections and IOs
 ===================

--- a/boards/arm/olimex_stm32_h407/doc/index.rst
+++ b/boards/arm/olimex_stm32_h407/doc/index.rst
@@ -44,7 +44,7 @@ hardware features:
 | GPIO      | on-chip    | gpio                 |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 
 Pin Mapping
 ===========

--- a/boards/arm/olimex_stm32_p405/doc/index.rst
+++ b/boards/arm/olimex_stm32_p405/doc/index.rst
@@ -44,7 +44,7 @@ hardware features:
 | GPIO      | on-chip    | gpio                 |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 
 Pin Mapping
 ===========

--- a/boards/arm/olimexino_stm32/doc/index.rst
+++ b/boards/arm/olimexino_stm32/doc/index.rst
@@ -51,7 +51,7 @@ hardware features:
 | CAN       | on-chip    | Controller Area Network |
 +-----------+------------+-------------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 
 Pin Mapping
 ===========

--- a/boards/arm/particle_argon/doc/index.rst
+++ b/boards/arm/particle_argon/doc/index.rst
@@ -71,7 +71,7 @@ hardware features:
 | RADIO     | on-chip    | Bluetooth            |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 
 Connections and IOs
 ===================

--- a/boards/arm/particle_boron/doc/index.rst
+++ b/boards/arm/particle_boron/doc/index.rst
@@ -71,7 +71,7 @@ hardware features:
 | RADIO     | on-chip    | Bluetooth            |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 
 Connections and IOs
 ===================

--- a/boards/arm/particle_xenon/doc/index.rst
+++ b/boards/arm/particle_xenon/doc/index.rst
@@ -70,7 +70,7 @@ hardware features:
 | RADIO     | on-chip    | Bluetooth            |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 
 Connections and IOs
 ===================

--- a/boards/arm/rak5010_nrf52840/doc/index.rst
+++ b/boards/arm/rak5010_nrf52840/doc/index.rst
@@ -84,7 +84,7 @@ The rak5010_nrf52840 board configuration supports the following hardware feature
 | WDT       | on-chip    | watchdog             |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 
 Connections and IOs
 ===================

--- a/boards/arm/reel_board/doc/index.rst
+++ b/boards/arm/reel_board/doc/index.rst
@@ -146,7 +146,7 @@ hardware features:
 |           |            | HDC1010 polling      |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 
 Connections and IOs
 ===================

--- a/boards/arm/rm1xx_dvk/doc/index.rst
+++ b/boards/arm/rm1xx_dvk/doc/index.rst
@@ -92,7 +92,7 @@ hardware features:
 | WDT       | on-chip    | watchdog             |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 See `Nordic Semiconductor Infocenter`_
 for a complete list of hardware features.
 

--- a/boards/arm/segger_trb_stm32f407/doc/index.rst
+++ b/boards/arm/segger_trb_stm32f407/doc/index.rst
@@ -51,7 +51,7 @@ hardware features:
 +------------+------------+------------------------------+
 
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 
 Pin Mapping
 ===========

--- a/boards/arm/stm32_min_dev/doc/index.rst
+++ b/boards/arm/stm32_min_dev/doc/index.rst
@@ -119,7 +119,7 @@ The stm32_min_dev board configuration supports the following hardware features:
 | ADC       | on-chip    | adc                  |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 
 Connections and IOs
 ===================

--- a/boards/arm/ubx_bmd300eval_nrf52832/doc/index.rst
+++ b/boards/arm/ubx_bmd300eval_nrf52832/doc/index.rst
@@ -96,7 +96,7 @@ hardware features:
 | WDT       | on-chip    | watchdog             |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 See the `u-blox website`_ for a complete list of
 BMD-300/301/350-EVAL hardware features.
 

--- a/boards/arm/ubx_bmd330eval_nrf52810/doc/index.rst
+++ b/boards/arm/ubx_bmd330eval_nrf52810/doc/index.rst
@@ -93,7 +93,7 @@ hardware features:
 | WDT       | on-chip    | watchdog             |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 See the `u-blox website`_ for a complete list of
 BMD-330-EVAL hardware features.
 

--- a/boards/arm/ubx_bmd340eval_nrf52840/doc/index.rst
+++ b/boards/arm/ubx_bmd340eval_nrf52840/doc/index.rst
@@ -102,7 +102,7 @@ the following hardware features:
 | WDT       | on-chip    | watchdog             |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 See the `u-blox website`_ for a complete list of BMD-340-EVAL
 and BMD-341-EVAL hardware features.
 

--- a/boards/arm/ubx_bmd345eval_nrf52840/doc/index.rst
+++ b/boards/arm/ubx_bmd345eval_nrf52840/doc/index.rst
@@ -115,7 +115,7 @@ hardware features:
 | WDT       | on-chip    | watchdog             |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 See the `u-blox website`_ for a complete list of BMD-345-EVAL
 hardware features.
 

--- a/boards/arm/ubx_bmd360eval_nrf52811/doc/index.rst
+++ b/boards/arm/ubx_bmd360eval_nrf52811/doc/index.rst
@@ -91,7 +91,7 @@ hardware features:
 | WDT       | on-chip    | watchdog             |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 See the `u-blox website`_ for a complete list of
 BMD-360-EVAL hardware features.
 

--- a/boards/arm/ubx_bmd380eval_nrf52840/doc/index.rst
+++ b/boards/arm/ubx_bmd380eval_nrf52840/doc/index.rst
@@ -99,7 +99,7 @@ hardware features:
 | WDT       | on-chip    | watchdog             |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 See the `u-blox website`_ for a complete list of BMD-380-EVAL
 hardware features.
 

--- a/boards/arm/ubx_evkannab1_nrf52832/doc/index.rst
+++ b/boards/arm/ubx_evkannab1_nrf52832/doc/index.rst
@@ -71,7 +71,7 @@ following hardware features:
 | WDT       | on-chip    | watchdog             |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 See `EVK-ANNA-B1 product page`_ and `ANNA-B1 Data Sheet`_
 for a complete list of EVK ANNA-B1 hardware features.
 

--- a/boards/arm/ubx_evkninab1_nrf52832/doc/index.rst
+++ b/boards/arm/ubx_evkninab1_nrf52832/doc/index.rst
@@ -77,7 +77,7 @@ following hardware features:
 	disabled. On the EVK-NINA-B1, these pins are
 	assigned to SWDIO and SWDCLK, respectively.
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 See `EVK-NINA-B1 product page`_ and `NINA-B1 Data Sheet`_
 for a complete list of EVK NINA-B1 hardware features.
 

--- a/boards/arm/ubx_evkninab3_nrf52840/doc/index.rst
+++ b/boards/arm/ubx_evkninab3_nrf52840/doc/index.rst
@@ -85,7 +85,7 @@ hardware features:
 | WDT       | on-chip    | watchdog             |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 See the `u-blox website`_ for a complete list of EVK-NINA-B30x
 hardware features.
 

--- a/boards/arm/ubx_evkninab4_nrf52833/doc/index.rst
+++ b/boards/arm/ubx_evkninab4_nrf52833/doc/index.rst
@@ -73,7 +73,7 @@ hardware features:
 | WDT       | on-chip    | watchdog             |
 +-----------+------------+----------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 See `EVK-NINA-B4 product page`_ and `NINA-B40 Data Sheet`_
 for a complete list of EVK NINA-B4 hardware features.
 

--- a/boards/arm64/bcm958402m2_a72/doc/index.rst
+++ b/boards/arm64/bcm958402m2_a72/doc/index.rst
@@ -29,7 +29,7 @@ hardware features:
 | UART      | on-chip    | NS16550 compatible serial port       |
 +-----------+------------+--------------------------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 
 The default configuration can be found in the defconfig file:
 

--- a/boards/arm64/intel_socfpga_agilex_socdk/doc/index.rst
+++ b/boards/arm64/intel_socfpga_agilex_socdk/doc/index.rst
@@ -38,7 +38,7 @@ hardware features:
 | UART      | on-chip    | NS16550 compatible serial port       |
 +-----------+------------+--------------------------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 
 The default configuration can be found in the defconfig file:
 

--- a/boards/arm64/nxp_ls1046ardb/doc/index.rst
+++ b/boards/arm64/nxp_ls1046ardb/doc/index.rst
@@ -63,7 +63,7 @@ hardware features:
 | UART      | on-chip    | NS16550 compatible serial port       |
 +-----------+------------+--------------------------------------+
 
-Other hardware features are not supported by the Zephyr kernel.
+Other hardware features have not been enabled yet for this board.
 
 The default configuration can be found in the defconfig file for NON-SMP:
 


### PR DESCRIPTION
This sentence ("Other hardware features are not supported by the
Zephyr kernel."), which could be found in a high number of boards
documentation, is misleading on two levels:
- peripheral support is not a kernel business
- in most of cases, features are actually supported but not enabled.

Fix this.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>