### PR TITLE
drivers: ieee802154_nrf5: fix condition for mac keys and frame counter

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -544,7 +544,7 @@ static int nrf5_tx(const struct device *dev,
 
 	LOG_DBG("Result: %d", nrf5_data.tx_result);
 
-#if NRF_802154_ENCRYPTION_ENABLED
+#if defined(CONFIG_IEEE802154_2015)
 	/*
 	 * When frame encryption by the radio driver is enabled, the frame stored in
 	 * the tx_psdu buffer is:
@@ -698,7 +698,7 @@ static void nrf5_iface_init(struct net_if *iface)
 	ieee802154_init(iface);
 }
 
-#if defined(CONFIG_NRF_802154_ENCRYPTION)
+#if defined(CONFIG_IEEE802154_2015)
 static void nrf5_config_mac_keys(struct ieee802154_key *mac_keys)
 {
 	static nrf_802154_key_id_t stored_key_ids[NRF_802154_SECURITY_KEY_STORAGE_SIZE];
@@ -733,7 +733,7 @@ static void nrf5_config_mac_keys(struct ieee802154_key *mac_keys)
 		i++;
 	};
 }
-#endif /* CONFIG_NRF_802154_ENCRYPTION */
+#endif /* CONFIG_IEEE802154_2015 */
 
 #if defined(CONFIG_IEEE802154_CSL_ENDPOINT)
 static void nrf5_receive_at(uint32_t start, uint32_t duration, uint8_t channel, uint32_t id)
@@ -831,7 +831,7 @@ static int nrf5_configure(const struct device *dev,
 		nrf5_data.event_handler = config->event_handler;
 		break;
 
-#if defined(CONFIG_NRF_802154_ENCRYPTION)
+#if defined(CONFIG_IEEE802154_2015)
 	case IEEE802154_CONFIG_MAC_KEYS:
 		nrf5_config_mac_keys(config->mac_keys);
 		break;
@@ -839,7 +839,7 @@ static int nrf5_configure(const struct device *dev,
 	case IEEE802154_CONFIG_FRAME_COUNTER:
 		nrf_802154_security_global_frame_counter_set(config->frame_counter);
 		break;
-#endif /* CONFIG_NRF_802154_ENCRYPTION */
+#endif /* CONFIG_IEEE802154_2015 */
 
 	case IEEE802154_CONFIG_ENH_ACK_HEADER_IE: {
 		uint8_t short_addr_le[SHORT_ADDRESS_SIZE];


### PR DESCRIPTION
For multicore devices like nRF53, shim layer part of setting mac keys and frame counters is called on application core where
CONFIG_NRF_802154_ENCRYPTION is disabled (the define concerns radio driver for net core).
This commit replaces CONFIG_NRF_802154_ENCRYPTION with CONFIG_IEEE802154_2015.