### PR TITLE
drivers: ieee802154_nrf5: fix sleep call for csl

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -625,12 +625,12 @@ static int nrf5_stop(const struct device *dev)
 	}
 #else
 	ARG_UNUSED(dev);
-#endif
 
 	if (!nrf_802154_sleep()) {
 		LOG_ERR("Error while stopping radio");
 		return -EIO;
 	}
+#endif
 
 	LOG_DBG("nRF5 802154 radio stopped");
 


### PR DESCRIPTION
When the csl is active the nrf_802154_sleep() is called unnecessary.
This commit fixes it.