### PR TITLE
scripts: generate image info header file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1577,6 +1577,19 @@ if(CONFIG_BUILD_OUTPUT_EXE)
     )
 endif()
 
+if(CONFIG_BUILD_OUTPUT_INFO_HEADER)
+  list(APPEND
+    post_build_commands
+    COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/gen_image_info.py
+    --elf-file=${KERNEL_ELF_NAME}
+    --header-file=${PROJECT_BINARY_DIR}/include/public/zephyr_image_info.h
+    )
+  list(APPEND
+    post_build_byproducts
+    ${PROJECT_BINARY_DIR}/include/public/zephyr_image_info.h
+    )
+endif()
+
 # Generate and use MCUboot related artifacts as needed.
 if(CONFIG_BOOTLOADER_MCUBOOT)
   include(${CMAKE_CURRENT_LIST_DIR}/cmake/mcuboot.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1394,6 +1394,18 @@ if(CONFIG_OUTPUT_PRINT_MEMORY_USAGE)
   endif()
 endif()
 
+if(CONFIG_BUILD_OUTPUT_ADJUST_LMA)
+  math(EXPR adjustment "${CONFIG_BUILD_OUTPUT_ADJUST_LMA}" OUTPUT_FORMAT DECIMAL)
+  list(APPEND
+    post_build_commands
+    COMMAND $<TARGET_PROPERTY:bintools,elfconvert_command>
+            $<TARGET_PROPERTY:bintools,elfconvert_flag_final>
+            $<TARGET_PROPERTY:bintools,elfconvert_flag_lma_adjust>${adjustment}
+            $<TARGET_PROPERTY:bintools,elfconvert_flag_infile>${KERNEL_ELF_NAME}
+            $<TARGET_PROPERTY:bintools,elfconvert_flag_outfile>${KERNEL_ELF_NAME}
+    )
+endif()
+
 if(CONFIG_BUILD_OUTPUT_HEX OR BOARD_FLASH_RUNNER STREQUAL openocd)
   get_property(elfconvert_formats TARGET bintools PROPERTY elfconvert_formats)
   if(ihex IN_LIST elfconvert_formats)
@@ -1583,6 +1595,7 @@ if(CONFIG_BUILD_OUTPUT_INFO_HEADER)
     COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/gen_image_info.py
     --elf-file=${KERNEL_ELF_NAME}
     --header-file=${PROJECT_BINARY_DIR}/include/public/zephyr_image_info.h
+    $<$<BOOL:${adjustment}>:--adjusted-lma=${adjustment}>
     )
   list(APPEND
     post_build_byproducts

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -650,6 +650,7 @@
 /scripts/pylib/twister/expr_parser.py     @nashif
 /scripts/schemas/twister/                 @nashif
 /scripts/gen_app_partitions.py            @dcpleung @nashif
+scripts/gen_image_info.py                 @tejlmand
 /scripts/get_maintainer.py                @nashif
 /scripts/dts/                             @mbolivar-nordic @galak
 /scripts/release/                         @nashif

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -494,6 +494,30 @@ config BUILD_OUTPUT_STRIPPED
 	  Build a stripped binary zephyr/zephyr.strip in the build directory.
 	  The name of this file can be customized with CONFIG_KERNEL_BIN_NAME.
 
+config BUILD_OUTPUT_ADJUST_LMA
+	string
+	help
+	  This will adjust the LMA address in the final ELF and hex files with
+	  the value provided.
+	  This will not affect the internal address symbols inside the image but
+	  can be useful when adjusting the LMA address for flash tools or multi
+	  stage loaders where a pre-loader may copy image to a second location
+	  before booting a second core.
+	  The value will be evaluated as a math expression, this means that
+	  following are valid expression
+	  - 1024
+	  - 0x1000
+	  - -0x1000
+	  - 0x20000000 - 0x10000000
+	  Note: negative numbers are valid.
+	  To adjust according to a chosen flash partition one can specify a
+	  default as:
+	  DT_CHOSEN_IMAGE_<name> := <name>,<name>-partition
+	  DT_CHOSEN_Z_FLASH := zephyr,flash
+	  config BUILD_OUTPUT_ADJUST_LMA
+	    default "$(dt_chosen_reg_addr_hex,$(DT_CHOSEN_IMAGE_M4))-\
+	             $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))"
+
 config BUILD_OUTPUT_INFO_HEADER
 	bool "Create a image information header"
 	help

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -494,6 +494,17 @@ config BUILD_OUTPUT_STRIPPED
 	  Build a stripped binary zephyr/zephyr.strip in the build directory.
 	  The name of this file can be customized with CONFIG_KERNEL_BIN_NAME.
 
+config BUILD_OUTPUT_INFO_HEADER
+	bool "Create a image information header"
+	help
+	  Create an image information header which will contain image
+	  information from the Zephyr binary.
+	  Example of information contained in the header file:
+	  - Number of segments in the image
+	  - LMA address of each segment
+	  - VMA address of each segment
+	  - Size of each segment
+
 config APPLICATION_DEFINED_SYSCALL
 	bool "Scan application folder for any syscall definition"
 	help

--- a/cmake/bintools/gnu/target_bintools.cmake
+++ b/cmake/bintools/gnu/target_bintools.cmake
@@ -41,6 +41,8 @@ set_property(TARGET bintools PROPERTY elfconvert_flag_section_remove "--remove-s
 set_property(TARGET bintools PROPERTY elfconvert_flag_section_only "--only-section=")
 set_property(TARGET bintools PROPERTY elfconvert_flag_section_rename "--rename-section;")
 
+set_property(TARGET bintools PROPERTY elfconvert_flag_lma_adjust "--change-section-lma;*+")
+
 # Note, placing a ';' at the end results in the following param  to be a list,
 # and hence space separated.
 # Thus the command line argument becomes:

--- a/scripts/gen_image_info.py
+++ b/scripts/gen_image_info.py
@@ -16,6 +16,7 @@ Information included in the image information header:
 - Number of segments in the image
 - LMA address of each segment
 - VMA address of each segment
+- LMA adjusted of each segment if the LMA addresses has been adjusted after linking
 - Size of each segment
 '''
 
@@ -23,7 +24,7 @@ import argparse
 from elftools.elf.elffile import ELFFile
 
 
-def write_header(filename, segments):
+def write_header(filename, segments, adjusted_lma):
     content = []
 
     filename_we = filename.split('.h')[0].upper()
@@ -31,6 +32,7 @@ def write_header(filename, segments):
     content.append(f'#define {filename_we}_H')
     content.append(f'')
     content.append(f'#define SEGMENT_NUM {len(segments)}')
+    content.append(f'#define ADJUSTED_LMA {adjusted_lma}')
 
     for idx, segment in enumerate(segments):
         segment_header = segment['segment'].header
@@ -69,10 +71,12 @@ def main():
                         help="""Header file to write with image data.""")
     parser.add_argument('--elf-file', required=True,
                         help="""ELF File to process.""")
+    parser.add_argument('--adjusted-lma', required=False, default=0,
+                        help="""Adjusted LMA address value.""")
     args = parser.parse_args()
 
     segments = read_segments(args.elf_file)
-    write_header(args.header_file, segments)
+    write_header(args.header_file, segments, args.adjusted_lma)
 
 
 if __name__ == "__main__":

--- a/scripts/gen_image_info.py
+++ b/scripts/gen_image_info.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2022, Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+'''
+Script to generate image information files.
+
+This script creates a image information header which can be included by a
+second build system.
+This allows a second stage build system to use image information from a Zephyr
+build by including the generated header.
+
+Information included in the image information header:
+- Number of segments in the image
+- LMA address of each segment
+- VMA address of each segment
+- Size of each segment
+'''
+
+import argparse
+from elftools.elf.elffile import ELFFile
+
+
+def write_header(filename, segments):
+    content = []
+
+    filename_we = filename.split('.h')[0].upper()
+    content.append(f'#ifndef {filename_we}_H')
+    content.append(f'#define {filename_we}_H')
+    content.append(f'')
+    content.append(f'#define SEGMENT_NUM {len(segments)}')
+
+    for idx, segment in enumerate(segments):
+        segment_header = segment['segment'].header
+        hex_lma_addr = hex(segment_header.p_paddr)
+        hex_vma_addr = hex(segment_header.p_vaddr)
+        hex_size = hex(segment_header.p_filesz)
+
+        content.append(f'')
+        content.append(f'#define SEGMENT_LMA_ADDRESS_{idx} {hex_lma_addr}')
+        content.append(f'#define SEGMENT_VMA_ADDRESS_{idx} {hex_vma_addr}')
+        content.append(f'#define SEGMENT_SIZE_{idx} {hex_size}')
+
+    content.append(f'')
+    content.append(f'#endif /* {filename_we}_H */')
+
+    with open(filename, 'w') as out_file:
+        out_file.write('\n'.join(content))
+
+
+def read_segments(filename):
+    elffile = ELFFile(open(filename, 'rb'))
+    segments = list()
+    for segment_idx in range(elffile.num_segments()):
+        segments.insert(segment_idx, dict())
+        segments[segment_idx]['segment'] = elffile.get_segment(segment_idx)
+    return segments
+
+
+def main():
+    parser = argparse.ArgumentParser(description='''
+    Process ELF file and extract image information.
+    Create header file with extracted image information which can be included
+    in other build systems.''')
+
+    parser.add_argument('--header-file', required=True,
+                        help="""Header file to write with image data.""")
+    parser.add_argument('--elf-file', required=True,
+                        help="""ELF File to process.""")
+    args = parser.parse_args()
+
+    segments = read_segments(args.elf_file)
+    write_header(args.header_file, segments)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR is inspired by the discussion at dev-review, 2022-01-06 and #41579

The #41579 embeds a binary Zephyr image inside the current Zephyr image in order to load it to second core through RAM.
This works, but the two images are independent of each other.
One disadvantage of converting the elf file to binary image and embed it directly is that any gaps between segments will be padded, and this padding will then also be copied.
By providing the ability to generate a header with segment information, then the image can be flashed independently, and it can be copied without padding data as the LMA address and segment size is available.

-------

This commit adds the `gen_image_info.py` script which supports creation
of a header file with image information from the EFL file.

This version populates the header file with:
- Number of segments in the image
- LMA address of each segment
- VMA address of each segment
- Size of each segment

The header file can be used by a secondary build system which needs this
information.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>