### PR TITLE
gitlint: Stop ignoring merge, revert, fixup and squash commits

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -4,7 +4,10 @@ ignore=title-trailing-punctuation, T3, title-max-length, T1, body-hard-tab, B3, 
 # verbosity should be a value between 1 and 3, the commandline -v flags take precedence over this
 verbosity = 3
 # By default gitlint will ignore merge commits. Set to 'false' to disable.
-ignore-merge-commits=true
+ignore-merge-commits=false
+ignore-revert-commits=false
+ignore-fixup-commits=false
+ignore-squash-commits=false
 # Enable debug mode (prints more output). Disabled by default
 debug = false
 


### PR DESCRIPTION
Some special commit types were being ignored by Gitlint, allowing
commits that did not abide by our formatting rules to slip through the
checks. Instead, enforce them on all commit types.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>