### PR TITLE
action: clang: set the name of checkout repo to zephyr

### DIFF
--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -39,8 +39,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          path: ./zephyr
 
       - name: Environment Setup
+        working-directory: ./zephyr
         run: |
           pip3 install GitPython
           echo "$HOME/.local/bin" >> $GITHUB_PATH
@@ -59,6 +61,7 @@ jobs:
           west update --path-cache /github/cache/zephyrproject 2>&1 1> west.log || west update --path-cache /github/cache/zephyrproject 2>&1 1> west2.log || ( rm -rf ../modules ../bootloader ../tools && west update --path-cache /github/cache/zephyrproject)
 
       - name: Check Environment
+        working-directory: ./zephyr
         run: |
           cmake --version
           ${CLANG_ROOT_DIR}/bin/clang --version
@@ -90,6 +93,7 @@ jobs:
           ccache -M 10G -s
 
       - name: Run Tests with Twister
+        working-directory: ./zephyr
         id: twister
         run: |
           export ZEPHYR_BASE=${PWD}
@@ -117,7 +121,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Unit Test Results (Subset ${{ matrix.platform }})
-          path: twister-out/twister.xml
+          path: zephyr/twister-out/twister.xml
 
   clang-build-results:
     name: "Publish Unit Tests Results"


### PR DESCRIPTION
Fixes isses with downstream forks, where repos names are not zephyr

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>