### PR TITLE
drivers: clock_control: stm32h7: do not enable systick in clock control initialization

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -755,8 +755,6 @@ static int stm32_clock_control_init(const struct device *dev)
 	}
 #endif /* STM32_PLL3_ENABLE */
 
-	/* Set systick to 1ms */
-	SysTick_Config(CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC / 1000);
 	/* Update CMSIS variable */
 	SystemCoreClock = CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC;
 


### PR DESCRIPTION
Do not enable systick in the clock control initialization.

Fixes #41691