### PR TITLE
twister: raise error for non-existing platform call

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -3867,13 +3867,14 @@ class TestSuite(DisablePyTestCollectionMixin):
         """
         Verify if platform name (passed by --platform option, or in yaml file
         as platform_allow or integration_platforms options) is correct. If not -
-        log error.
+        log and raise error.
         """
         for platform in platform_names_to_verify:
             if platform in self.platform_names:
                 break
             else:
                 logger.error(f"{log_info} - unrecognized platform - {platform}")
+                sys.exit(2)
 
 
 class CoverageTool:

--- a/scripts/tests/twister/test_reporting_testsuite.py
+++ b/scripts/tests/twister/test_reporting_testsuite.py
@@ -25,6 +25,7 @@ def test_discard_report(class_testsuite, platforms_list, all_testcases_dict, cap
     Test 2: Test if the generated report is not empty
     Test 3: Test if the gerenrated report contains the expected columns"""
     class_testsuite.platforms = platforms_list
+    class_testsuite.platform_names = [p.name for p in platforms_list]
     class_testsuite.testcases = all_testcases_dict
     filename = tmpdir.mkdir("test_discard").join("discard_report.csv")
     with pytest.raises(SystemExit):
@@ -88,6 +89,7 @@ def test_xunit_report(class_testsuite, test_data,
     Test 2: Assert on fails, passes, skips, errors values
     Test 3: Assert on the tree structure of twister.xml file"""
     class_testsuite.platforms = platforms_list
+    class_testsuite.platform_names = [p.name for p in platforms_list]
     class_testsuite.testcases = all_testcases_dict
     kwargs = {"exclude_tag" : ['test_a'], "exclude_platform" : ['demo_board_1'],
               "platform" : ['demo_board_2']}

--- a/scripts/tests/twister/test_testsuite_class.py
+++ b/scripts/tests/twister/test_testsuite_class.py
@@ -164,6 +164,7 @@ def test_apply_filters_part1(class_testsuite, all_testcases_dict, platforms_list
         assert not discards
 
     class_testsuite.platforms = platforms_list
+    class_testsuite.platform_names = [p.name for p in platforms_list]
     class_testsuite.testcases = all_testcases_dict
     for plat in class_testsuite.platforms:
         if plat_attribute == "ignore_tags":
@@ -234,6 +235,7 @@ def test_apply_filters_part2(class_testsuite, all_testcases_dict,
     """
 
     class_testsuite.platforms = platforms_list
+    class_testsuite.platform_names = [p.name for p in platforms_list]
     class_testsuite.testcases = all_testcases_dict
     kwargs = {
         extra_filter : extra_filter_value,
@@ -264,6 +266,7 @@ def test_apply_filters_part3(class_testsuite, all_testcases_dict, platforms_list
     Part 3 : Testing edge cases for ram and flash values of platforms & testcases
     """
     class_testsuite.platforms = platforms_list
+    class_testsuite.platform_names = [p.name for p in platforms_list]
     class_testsuite.testcases = all_testcases_dict
 
     for plat in class_testsuite.platforms:


### PR DESCRIPTION
Last time I introduced log error when some non-existing platforms are 
detected - https://github.com/zephyrproject-rtos/zephyr/pull/41081.
After this there were performed some activities for fix or remove those 
platforms form current Zephyr repository in samples.yaml or testcase.yaml.
Now when there is no problem with those non-existing platforms, perhaps 
there should be introduced raise error activity (which break the whole 
program). This will help us to prevent from those mistakes for the future.

Changes will raise error and break program in following three situations:

1. Platform name pass in --platform option does not exist.
2. During using --all option, platform from platform_allow list does not
exist.
3. During using --integration option, platform from
integration_platforms list does not exist.

If this proposition is too rigorous I am open for discussion.

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>