### PR TITLE
twister: add -Werror to CMAKE_AFLAGS 

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -2149,9 +2149,9 @@ class CMake():
         cmake_args = [
             f'-B{self.build_dir}',
             f'-S{self.source_dir}',
-            f'-DEXTRA_CFLAGS="{cflags}"',
-            f'-DEXTRA_AFLAGS="{aflags}',
-            f'-DEXTRA_LDFLAGS="{ldflags}"',
+            f'-DEXTRA_CFLAGS={cflags}',
+            f'-DEXTRA_AFLAGS={aflags}',
+            f'-DEXTRA_LDFLAGS={ldflags}',
             f'-DEXTRA_GEN_DEFINES_ARGS={gen_defines_args}',
             f'-G{self.generator}'
         ]

--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -2139,7 +2139,7 @@ class CMake():
         if self.warnings_as_errors:
             ldflags = "-Wl,--fatal-warnings"
             cflags = "-Werror"
-            aflags = "-Wa,--fatal-warnings"
+            aflags = "-Werror -Wa,--fatal-warnings"
             gen_defines_args = "--edtlib-Werror"
         else:
             ldflags = cflags = aflags = ""


### PR DESCRIPTION
This reports the warning fixed in commit 61fe69d ("sys:
device_mmio.h replace <toolchain/common.h> with <toolchain.h>")

Signed-off-by: Marc Herbert <marc.herbert@intel.com>