### PR TITLE
adc: add io-channel-cells to use io-channels

### DIFF
--- a/dts/bindings/adc/ite,it8xxx2-adc.yaml
+++ b/dts/bindings/adc/ite,it8xxx2-adc.yaml
@@ -14,3 +14,6 @@ properties:
     pinctrl-0:
       type: phandles
       required: true
+
+io-channel-cells:
+    - input

--- a/dts/bindings/adc/zephyr,adc-emul.yaml
+++ b/dts/bindings/adc/zephyr,adc-emul.yaml
@@ -44,3 +44,6 @@ properties:
         description:
           External 1 reference voltage in mV. If not provided or set to zero,
           channel setup with ADC_REF_EXTERNAL1 will fail.
+
+io-channel-cells:
+    - input


### PR DESCRIPTION
Add fragment:
io-channel-cells:
    - input
to binding of the "ite,it8xxx2-adc" and "zephyr,adc-emul" compatible.
It is necessary to use io-channels property.

Signed-off-by: Dawid Niedzwiecki <dn@semihalf.com>