### PR TITLE
edac: Do not enable edac shell by default

### DIFF
--- a/drivers/edac/Kconfig
+++ b/drivers/edac/Kconfig
@@ -19,7 +19,6 @@ config EDAC_ERROR_INJECT
 config EDAC_SHELL
 	bool "Enable EDAC Shell"
 	depends on SHELL
-	default y if SHELL
 	help
 	  Enable EDAC shell for debugging EDAC.
 


### PR DESCRIPTION
Do not enable edac shell if SHELL and EDAC are enabled.
