### PR TITLE
[Backport v2.7-branch] boards: nucleo_h745zi_q: enable POWER_SUPPLY_DIRECT_SMPS

### DIFF
--- a/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m7_defconfig
+++ b/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m7_defconfig
@@ -6,6 +6,9 @@ CONFIG_SOC_STM32H745XX=y
 # Board config should be specified since there are 2 possible targets
 CONFIG_BOARD_NUCLEO_H745ZI_Q_M7=y
 
+# Enable the internal SMPS regulator
+CONFIG_POWER_SUPPLY_DIRECT_SMPS=y
+
 # Enable MPU
 CONFIG_ARM_MPU=y
 


### PR DESCRIPTION
The board is fitted with the SMPS components and have no path from
VDD_MCU to VDD_LDO.

The stm32h7_init code used to default to SMPS on supported SoC but has
been changed in 22186c7c51 to only use SMPS if explicitly configured to
do so. This is causing the board to become unresponsive after a power
cycle when flashed with the current defconfig, and needs to be started
pulling BOOT0 high to be recovered.

Setting CONFIG_POWER_SUPPLY_DIRECT_SMPS restores the intended behavior.

Signed-off-by: Fabio Baltieri <fabio.baltieri@gmail.com>

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/41536