### PR TITLE
boards: bbc_microbit: Fix usage of GPIOTE channels

### DIFF
--- a/boards/arm/bbc_microbit/bbc_microbit.dts
+++ b/boards/arm/bbc_microbit/bbc_microbit.dts
@@ -76,6 +76,15 @@
 
 &gpio0 {
 	status = "okay";
+	/*
+	 * Use the sensing mechanism for all pins by default, as GPIOTE channels
+	 * are needed for the LED matrix and the SW PWM.
+	 */
+	sense-edge-mask = <0xffffffff>;
+};
+
+&sw_pwm {
+	channel-count = <1>;
 };
 
 &uart0 {


### PR DESCRIPTION
There are only 4 GPIOTE channels available in the nRF51 SoC that is
used in the bbc_microbit board. After the display driver for the board
has been reworked to use the nRF LED matrix display driver underneath
(see commit 44585b7fc5d3f0132fdc53838903019575a49824), 3 of those are
used for handling the display, so only 1 remains for other uses. This
causes problems with handling of buttons (as it needs GPIO interrupts
and by default the GPIO shim driver uses GPIOTE channels for their
generation) and also the SW PWM driver fails to initialize in its
default configuration (as it requires 3 GPIOTE channels for providing
3 PWM channels). And because of these problems, for example, the pong
sample does not work.

This commit addresses the problems by changing two things:
- it configures the GPIO shim driver to use the sensing mechanism
  instead of GPIOTE channels for interrupt generation for all pins
- it limits the number of available SW PWM channels to 1 (instead of
  the default 3)

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>