### PR TITLE
samples: modules: canopennode: add stm32f3_disco support

### DIFF
--- a/modules/canopennode/Kconfig
+++ b/modules/canopennode/Kconfig
@@ -33,7 +33,7 @@ config CANOPENNODE_TRACE_BUFFER_SIZE
 
 config CANOPENNODE_TX_WORKQUEUE_STACK_SIZE
 	int "Stack size for the CANopen transmit workqueue"
-	default 320
+	default 512
 	help
 	  Size of the stack used for the internal CANopen transmit
 	  workqueue.
@@ -86,7 +86,7 @@ config CANOPENNODE_SYNC_THREAD
 config CANOPENNODE_SYNC_THREAD_STACK_SIZE
 	int "Stack size for the CANopen SYNC thread"
 	depends on CANOPENNODE_SYNC_THREAD
-	default 256
+	default 512
 	help
 	  Size of the stack used for the internal thread which
 	  processes CANopen SYNC RPDOs and TPDOs.

--- a/samples/modules/canopennode/README.rst
+++ b/samples/modules/canopennode/README.rst
@@ -61,6 +61,25 @@ The sample can be built and executed for the FRDM-K64F as follows:
 Pressing the button labelled ``SW3`` will increment the button press
 counter object at index ``0x2102`` in the object dictionary.
 
+Building and Running for STM32F3 Discovery
+==========================================
+The :ref:`stm32f3_disco_board` board does not come with an onboard CAN
+transceiver. In order to use the CAN bus on the STM32F3 Discovery board, an
+external CAN bus tranceiver must be connected to ``PD1`` (``CAN_TX``) and
+``PD0`` (``CAN_RX``). This board supports CANopen LED indicators (red and green
+LEDs)
+
+The sample can be built and executed for the STM32F3 Discovery as follows:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/modules/canopennode
+   :board: stm32f3_disco
+   :goals: build flash
+   :compact:
+
+Pressing the button labelled ``USER`` will increment the button press counter
+object at index ``0x2102`` in the object dictionary.
+
 Building and Running for boards without storage partition
 =========================================================
 The sample can be built for boards without a flash storage partition by using a different configuration file:

--- a/samples/modules/canopennode/boards/stm32f3_disco.overlay
+++ b/samples/modules/canopennode/boards/stm32f3_disco.overlay
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2021 Vestas Wind Systems A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		green-led = &green_led_6;
+		red-led = &red_led_3;
+	};
+};

--- a/samples/modules/canopennode/sample.yaml
+++ b/samples/modules/canopennode/sample.yaml
@@ -3,7 +3,7 @@ sample:
 common:
   tags: can canopen
   depends_on: can
-  platform_allow: twr_ke18f frdm_k64f
+  platform_allow: twr_ke18f frdm_k64f stm32f3_disco
   harness: console
   harness_config:
     type: one_line
@@ -14,6 +14,7 @@ tests:
     tags: introduction
   sample.modules.canopennode.program_download:
     build_only: true
+    platform_exclude: stm32f3_disco
     extra_configs:
       - CONFIG_BOOTLOADER_MCUBOOT=y
   sample.modules.canopennode.no_storage:


### PR DESCRIPTION
Add support for the ST STM32F3 Discovery development board.
    
Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>
