### PR TITLE
soc: arm: nuvoton_npcx: add missing include

### DIFF
--- a/soc/arm/nuvoton_npcx/common/reg/reg_def.h
+++ b/soc/arm/nuvoton_npcx/common/reg/reg_def.h
@@ -9,6 +9,7 @@
 
 #include <stdint.h>
 
+#include <devicetree.h>
 #include <sys/__assert.h>
 #include <sys/util_macro.h>
 #include <toolchain.h>


### PR DESCRIPTION
The reg_def.h was not self-contained: it uses DT API but doesn't
include <devicetree.h>.