### PR TITLE
soc: xtensa/intel_adsp: don't call soc_mp_init if MP_NUM_CPUS==1

### DIFF
--- a/soc/xtensa/intel_adsp/common/soc.c
+++ b/soc/xtensa/intel_adsp/common/soc.c
@@ -37,7 +37,9 @@ LOG_MODULE_REGISTER(soc);
 # define GENO_DIOPTOSEL           BIT(2)
 #endif
 
+#if CONFIG_MP_NUM_CPUS > 1
 extern void soc_mp_init(void);
+#endif
 
 static __imr void power_init_v15(void)
 {
@@ -116,7 +118,9 @@ static __imr int soc_init(const struct device *dev)
 		power_init();
 	}
 
+#if CONFIG_MP_NUM_CPUS > 1
 	soc_mp_init();
+#endif
 
 	return 0;
 }


### PR DESCRIPTION
There is no need to call soc_mp_init() if CONFIG_MP_NUM_CPUS
indicates only 1 CPU is being used. This also fixes an undefined
reference to soc_mp_init() since mp_cavs.c is not compiled
unless the build is targeting more than 1 CPU.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>