### PR TITLE
intel_adsp: adds soc_mp_init symbol in non-mp case

### DIFF
--- a/soc/xtensa/intel_adsp/common/soc.c
+++ b/soc/xtensa/intel_adsp/common/soc.c
@@ -103,7 +103,7 @@ static __imr void power_init(void)
 }
 
 #if !DT_NODE_EXISTS(DT_NODELABEL(cavs0)) || CONFIG_MP_NUM_CPUS == 1
-void soc_idc_init(void) {}
+void soc_mp_init(void) {}
 void arch_sched_ipi(void) {}
 #endif
 


### PR DESCRIPTION
Tests showed a missing soc_mp_init symbol when building some tests.

This fixes the missing symbol build issue by renaming an empty function
definition that was missed in a previous commit.

Signee-off-by: Tom Burdick <thomas.burdick@intel.com>