### PR TITLE
boards: arm: stm32: fix user led configuration

### DIFF
--- a/boards/arm/stm32h735g_disco/stm32h735g_disco.dts
+++ b/boards/arm/stm32h735g_disco/stm32h735g_disco.dts
@@ -22,11 +22,11 @@
 	leds {
 		compatible = "gpio-leds";
 		red_led: led_1 {
-			gpios = <&gpioc 2 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpioc 2 GPIO_ACTIVE_LOW>;
 			label = "User LD2";
 		};
 		green_led: led_2 {
-			gpios = <&gpioc 3 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpioc 3 GPIO_ACTIVE_LOW>;
 			label = "User LD1";
 		};
 	};


### PR DESCRIPTION
User LEDs are active low.

Signed-off-by: Benedikt Schmidt <benedikt.schmidt@embedded-solutions.at>

Fixes #41745