### PR TITLE
Bluetooth: Fix default event size when periodic adv sync is enabled

### DIFF
--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -109,7 +109,7 @@ config BT_BUF_ACL_RX_COUNT
 
 config BT_BUF_EVT_RX_SIZE
 	int "Maximum supported HCI Event buffer length"
-	default 255 if (BT_EXT_ADV && !(BT_BUF_EVT_DISCARDABLE_COUNT > 0)) || BT_PER_ADV
+	default 255 if (BT_EXT_ADV && !(BT_BUF_EVT_DISCARDABLE_COUNT > 0)) || BT_PER_ADV_SYNC
 	# LE Read Supported Commands command complete event.
 	default 68
 	range 68 255


### PR DESCRIPTION
Periodic Advertising reports can be up to 255.

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>