### PR TITLE
Bluetooth: Mesh: GATT proxy enable fix for ext adv

### DIFF
--- a/subsys/bluetooth/mesh/cfg.c
+++ b/subsys/bluetooth/mesh/cfg.c
@@ -100,8 +100,9 @@ int bt_mesh_gatt_proxy_set(enum bt_mesh_feat_state gatt_proxy)
 		return err;
 	}
 
-	if (gatt_proxy == BT_MESH_FEATURE_DISABLED &&
-	    !bt_mesh_subnet_find(node_id_is_running, NULL)) {
+	if ((gatt_proxy == BT_MESH_FEATURE_ENABLED) ||
+	    (gatt_proxy == BT_MESH_FEATURE_DISABLED &&
+	     !bt_mesh_subnet_find(node_id_is_running, NULL))) {
 		bt_mesh_adv_gatt_update();
 	}
 


### PR DESCRIPTION
Adds fix so that a node running with extended adveriser is able to
enable GATT proxy correctly. This fixes a corner case issue where a
device with no other ongoing message sending is unable to advertise
the GATT proxy through
bt_mesh_gatt_proxy_set(BT_MESH_FEATURE_ENABLED) .

Signed-off-by: Anders Storrø <anders.storro@nordicsemi.no>