### PR TITLE
drivers: flash: Refactor boundary checking

### DIFF
--- a/drivers/flash/soc_flash_nrf.c
+++ b/drivers/flash/soc_flash_nrf.c
@@ -94,32 +94,23 @@ static inline bool is_aligned_32(uint32_t data)
 	return (data & 0x3) ? false : true;
 }
 
-static inline bool is_regular_addr_valid(off_t addr, size_t len)
+static inline bool is_within_bounds(off_t addr, size_t len, off_t boundary_start,
+				    size_t boundary_size)
 {
-	size_t flash_size = nrfx_nvmc_flash_size_get();
-
-	if (addr >= flash_size ||
-	    addr < 0 ||
-	    len > flash_size ||
-	    (addr) + len > flash_size) {
-		return false;
-	}
-
-	return true;
+	return (addr >= boundary_start &&
+			(addr < (boundary_start + boundary_size)) &&
+			(len <= (boundary_start + boundary_size - addr)));
 }
 
+static inline bool is_regular_addr_valid(off_t addr, size_t len)
+{
+	return is_within_bounds(addr, len, 0, nrfx_nvmc_flash_size_get());
+}
 
 static inline bool is_uicr_addr_valid(off_t addr, size_t len)
 {
 #ifdef CONFIG_SOC_FLASH_NRF_UICR
-	if (addr >= (off_t)NRF_UICR + sizeof(*NRF_UICR) ||
-	    addr < (off_t)NRF_UICR ||
-	    len > sizeof(*NRF_UICR) ||
-	    addr + len > (off_t)NRF_UICR + sizeof(*NRF_UICR)) {
-		return false;
-	}
-
-	return true;
+	return is_within_bounds(addr, len, (off_t)NRF_UICR, sizeof(*NRF_UICR));
 #else
 	return false;
 #endif /* CONFIG_SOC_FLASH_NRF_UICR */


### PR DESCRIPTION
We will soon need to do more boundary checking to test whether we are
reading secure or non-secure memory.

Refactor the boundary checking in preparation for this.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>