### PR TITLE
tests: lib: ringbuffer: Disable test for SMP

### DIFF
--- a/tests/lib/ringbuffer/testcase.yaml
+++ b/tests/lib/ringbuffer/testcase.yaml
@@ -1,6 +1,6 @@
 common:
     tags: ring_buffer circular_buffer
-
+    filter: not CONFIG_SMP
 tests:
   libraries.ring_buffer:
     integration_platforms:


### PR DESCRIPTION
Ring buffer test is using ztress which does not work with SMP.
Filter out for now.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>