### PR TITLE
[RFC] Bluetooth: BT_BUF_RX_SIZE  to include discardable size

### DIFF
--- a/include/bluetooth/buf.h
+++ b/include/bluetooth/buf.h
@@ -79,6 +79,13 @@ struct bt_buf_data {
 /** Data size needed for HCI Event RX buffers */
 #define BT_BUF_EVT_RX_SIZE BT_BUF_EVT_SIZE(CONFIG_BT_BUF_EVT_RX_SIZE)
 
+/** Data size needed for discardable HCI Event RX buffers */
+#if defined(CONFIG_BT_BUF_EVT_DISCARDABLE_COUNT)
+#define BT_BUF_DISCARDABLE_EVT_RX_SIZE BT_BUF_EVT_SIZE(CONFIG_BT_BUF_EVT_DISCARDABLE_SIZE)
+#else
+#define BT_BUF_DISCARDABLE_EVT_RX_SIZE 0
+#endif /* CONFIG_BT_BUF_EVT_DISCARDABLE_COUNT */
+
 #if defined(CONFIG_BT_ISO)
 #define BT_BUF_ISO_RX_SIZE BT_BUF_ISO_SIZE(CONFIG_BT_ISO_RX_MTU)
 #define BT_BUF_ISO_RX_COUNT CONFIG_BT_ISO_RX_BUF_COUNT
@@ -88,7 +95,9 @@ struct bt_buf_data {
 #endif /* CONFIG_BT_ISO */
 
 /** Data size needed for HCI ACL, HCI ISO or Event RX buffers */
-#define BT_BUF_RX_SIZE (MAX(MAX(BT_BUF_ACL_RX_SIZE, BT_BUF_EVT_RX_SIZE), \
+#define BT_BUF_RX_SIZE (MAX(MAX(MAX(BT_BUF_ACL_RX_SIZE), \
+			    BT_BUF_EVT_RX_SIZE), \
+			    BT_BUF_DISCARDABLE_EVT_RX_SIZE), \
 			    BT_BUF_ISO_RX_SIZE))
 
 /** Buffer count needed for HCI ACL, HCI ISO or Event RX buffers */

--- a/samples/bluetooth/hci_spi/src/main.c
+++ b/samples/bluetooth/hci_spi/src/main.c
@@ -65,9 +65,6 @@ const static struct spi_buf_set tx_bufs = {
 	.count = 1,
 };
 
-/* HCI buffer pools */
-#define CMD_BUF_SIZE BT_BUF_RX_SIZE
-
 /*
  * This finds an arbitrary node with compatible
  * "zephyr,bt-hci-spi-slave". There should just be one in the

--- a/subsys/bluetooth/host/buf.c
+++ b/subsys/bluetooth/host/buf.c
@@ -40,7 +40,7 @@ NET_BUF_POOL_FIXED_DEFINE(num_complete_pool, 1, NUM_COMLETE_EVENT_SIZE, 8, NULL)
 
 #if defined(CONFIG_BT_BUF_EVT_DISCARDABLE_COUNT)
 NET_BUF_POOL_FIXED_DEFINE(discardable_pool, CONFIG_BT_BUF_EVT_DISCARDABLE_COUNT,
-			  BT_BUF_EVT_SIZE(CONFIG_BT_BUF_EVT_DISCARDABLE_SIZE), 8,
+			  BT_BUF_DISCARDABLE_EVT_RX_SIZE, 8,
 			  NULL);
 #endif /* CONFIG_BT_BUF_EVT_DISCARDABLE_COUNT */
 
@@ -48,15 +48,11 @@ NET_BUF_POOL_FIXED_DEFINE(discardable_pool, CONFIG_BT_BUF_EVT_DISCARDABLE_COUNT,
 NET_BUF_POOL_DEFINE(acl_in_pool, CONFIG_BT_BUF_ACL_RX_COUNT,
 		    BT_BUF_ACL_SIZE(CONFIG_BT_BUF_ACL_RX_SIZE),
 		    sizeof(struct acl_data), bt_hci_host_num_completed_packets);
+#endif /* CONFIG_BT_HCI_ACL_FLOW_CONTROL */
 
 NET_BUF_POOL_FIXED_DEFINE(evt_pool, CONFIG_BT_BUF_EVT_RX_COUNT,
 			  BT_BUF_EVT_RX_SIZE, 8,
 			  NULL);
-#else
-NET_BUF_POOL_FIXED_DEFINE(hci_rx_pool, BT_BUF_RX_COUNT,
-			  BT_BUF_RX_SIZE, 8,
-			  NULL);
-#endif /* CONFIG_BT_HCI_ACL_FLOW_CONTROL */
 
 struct net_buf *bt_buf_get_rx(enum bt_buf_type type, k_timeout_t timeout)
 {
@@ -78,7 +74,7 @@ struct net_buf *bt_buf_get_rx(enum bt_buf_type type, k_timeout_t timeout)
 		buf = net_buf_alloc(&acl_in_pool, timeout);
 	}
 #else
-	buf = net_buf_alloc(&hci_rx_pool, timeout);
+	buf = net_buf_alloc(&evt_pool, timeout);
 #endif
 
 	if (buf) {


### PR DESCRIPTION
This prevents the application from using this value for creating buffers that would also contain discardable events.

Semantically this makes more sense to me.

For applications compiled with HCI_RAW this has no implications as those have no discardable buffers.