### PR TITLE
logging: output/syst: don't use raw output for hexdump

### DIFF
--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -55,6 +55,7 @@ extern void log_output_string_syst_process(const struct log_output *output,
 				const char *fmt, va_list ap, uint32_t flag);
 extern void log_output_hexdump_syst_process(const struct log_output *output,
 				struct log_msg_ids src_level,
+				const char *metadata,
 				const uint8_t *data, uint32_t length, uint32_t flag);
 
 /* The RFC 5424 allows very flexible mapping and suggest the value 0 being the
@@ -701,7 +702,8 @@ void log_output_hexdump(const struct log_output *output,
 	if (IS_ENABLED(CONFIG_LOG_MIPI_SYST_ENABLE) &&
 	    flags & LOG_OUTPUT_FLAG_FORMAT_SYST) {
 		log_output_hexdump_syst_process(output,
-				src_level, data, length, flags);
+				src_level, metadata,
+				data, length, flags);
 		return;
 	}
 


### PR DESCRIPTION
Hexdump via logging is supposed to be human-readable for
debug information. Therefore, it should actually print
in human-readable form (well... after some magical decoder
has processed the raw MIPI Sys-T output).

Signed-off-by: Daniel Leung <daniel.leung@intel.com>