### PR TITLE
tests: ztress: fix dependency on SMP

### DIFF
--- a/subsys/testsuite/ztest/Kconfig
+++ b/subsys/testsuite/ztest/Kconfig
@@ -110,7 +110,6 @@ config ZTEST_PARAMETER_COUNT
 
 config ZTRESS
 	bool "Stress test framework"
-	depends on !SMP
 	select THREAD_RUNTIME_STATS
 	select THREAD_MONITOR
 	select TEST_RANDOM_GENERATOR if !ENTROPY_HAS_DRIVER

--- a/tests/lib/ringbuffer/testcase.yaml
+++ b/tests/lib/ringbuffer/testcase.yaml
@@ -5,10 +5,13 @@ tests:
   libraries.ring_buffer:
     integration_platforms:
       - native_posix
+    extra_configs:
+      - CONFIG_MP_NUM_CPUS=1
 
   libraries.ring_buffer_concurrent:
     platform_allow: qemu_x86
     extra_configs:
       - CONFIG_SYS_CLOCK_TICKS_PER_SEC=100000
+      - CONFIG_MP_NUM_CPUS=1
     integration_platforms:
       - qemu_x86

--- a/tests/ztest/ztress/testcase.yaml
+++ b/tests/ztest/ztress/testcase.yaml
@@ -1,8 +1,10 @@
 common:
   tags: test_framework
-  filter: CONFIG_QEMU_TARGET and not CONFIG_SMP
+  filter: CONFIG_QEMU_TARGET
 tests:
   testing.ztest.ztress:
+    extra_configs:
+      - CONFIG_MP_NUM_CPUS=1
     integration_platforms:
       - qemu_x86
     #FIXME Fails for unknown reason #41710


### PR DESCRIPTION
Use CONFIG_MP_NUM_CPUS=1 with ztress and do not disable SMP completely.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
