### PR TITLE
doc: fix kconfig usage issues

### DIFF
--- a/doc/guides/porting/arch.rst
+++ b/doc/guides/porting/arch.rst
@@ -494,8 +494,8 @@ Two types of thread stacks exist:
 - "thread" stacks which typically use more memory, but are capable of hosting
   thread running in user mode, as well as any use-cases for kernel stacks.
 
-If :c:kconfig:`CONFIG_USERSPACE` is not enabled, "thread" and "kernel" stacks
-are equivalent.
+If :kconfig:`CONFIG_USERSPACE` is not enabled, "thread" and "kernel" stacks are
+equivalent.
 
 Additional macros may be defined in the architecture layer to specify
 the alignment of the base of stack objects, any reserved data inside the

--- a/doc/reference/kernel/memory/heap.rst
+++ b/doc/reference/kernel/memory/heap.rst
@@ -92,7 +92,7 @@ complete within 1-200 cycles.  One complexity is that the search of
 the minimum bucket size for an allocation (the set of free blocks that
 "might fit") has a compile-time upper bound of iterations to prevent
 unbounded list searches, at the expense of some fragmentation
-resistance.  This :c:kconfig:`CONFIG_SYS_HEAP_ALLOC_LOOPS` value may be
+resistance.  This :kconfig:`CONFIG_SYS_HEAP_ALLOC_LOOPS` value may be
 chosen by the user at build time, and defaults to a value of 3.
 
 Multi-Heap Wrapper Utility

--- a/doc/reference/kernel/timing/clocks.rst
+++ b/doc/reference/kernel/timing/clocks.rst
@@ -36,7 +36,7 @@ For asynchronous timekeeping, the kernel defines a "ticks" concept.  A
 uptime and timeout bookkeeping.  Interrupts are expected to be
 delivered on tick boundaries to the extent practical, and no
 fractional ticks are tracked.  The choice of tick rate is configurable
-via :c:kconfig:`CONFIG_SYS_CLOCK_TICKS_PER_SEC`.  Defaults on most
+via :kconfig:`CONFIG_SYS_CLOCK_TICKS_PER_SEC`.  Defaults on most
 hardware platforms (ones that support setting arbitrary interrupt
 timeouts) are expected to be in the range of 10 kHz, with software
 emulation platforms and legacy drivers using a more traditional 100 Hz

--- a/doc/releases/release-notes-2.1.rst
+++ b/doc/releases/release-notes-2.1.rst
@@ -320,7 +320,7 @@ Networking
 
 * Added new TCP stack implementation. The new TCP stack is still experimental
   and is turned off by default. Users wanting to experiment with it can set
-  :kconfig:`CONFIG_NET_TCP2` Kconfig option.
+  ``CONFIG_NET_TCP2`` Kconfig option.
 * Added support for running MQTT protocol on top of a Websocket connection.
 * Added support for enabling DNS in LWM2M.
 * Added support for resetting network statistics in net-shell.

--- a/doc/releases/release-notes-2.4.rst
+++ b/doc/releases/release-notes-2.4.rst
@@ -580,7 +580,7 @@ Drivers and Sensors
     * :kconfig:`CONFIG_USB_DEVICE_NETWORK_EEM`
     * :kconfig:`CONFIG_USB_DEVICE_NETWORK_RNDIS`
     * :kconfig:`CONFIG_TRACING_BACKEND_USB`
-    * :kconfig:`CONFIG_USB_UART_CONSOLE`
+    * ``CONFIG_USB_UART_CONSOLE``
 
   * USB device support has got its own work queue
     which is used by CDC ACM class by default.


### PR DESCRIPTION
- Fix some syntax errors, e.g. :c:kconfig:`...`
- Remove references to missing symbols (replaced with literals)

Issues found as part of https://github.com/zephyrproject-rtos/zephyr/pull/41753