### PR TITLE
tests: footprints: Code guideline fixes

### DIFF
--- a/tests/benchmarks/footprints/src/libc.c
+++ b/tests/benchmarks/footprints/src/libc.c
@@ -15,7 +15,7 @@ static char new_string[32];
 
 void run_libc(void)
 {
-	int len;
+	size_t len;
 
 	len = strlen(const_string);
 	len = strnlen(const_string, len);

--- a/tests/benchmarks/footprints/src/main.c
+++ b/tests/benchmarks/footprints/src/main.c
@@ -46,7 +46,7 @@ void main(void)
 	};
 
 	k_mem_domain_init(&footprint_mem_domain,
-			  ARRAY_SIZE(mem_parts), mem_parts);
+			  (uint8_t)ARRAY_SIZE(mem_parts), mem_parts);
 #endif /* CONFIG_USERSPACE */
 
 	run_thread_system();

--- a/tests/benchmarks/footprints/src/timer.c
+++ b/tests/benchmarks/footprints/src/timer.c
@@ -10,9 +10,9 @@
 
 #include "footprint.h"
 
-#define DURATION	100
-#define PERIOD		50
-#define EXPIRE_TIMES	4
+#define DURATION	100U
+#define PERIOD		50U
+#define EXPIRE_TIMES	4U
 
 struct timer_data {
 	uint32_t expire_cnt;
@@ -46,7 +46,7 @@ static void timer_expire(struct k_timer *timer)
 	tdata.expire_cnt++;
 }
 
-static void busy_wait_ms(int32_t ms)
+static void busy_wait_ms(uint32_t ms)
 {
 	k_busy_wait(ms*1000);
 }

--- a/tests/benchmarks/footprints/src/userspace.c
+++ b/tests/benchmarks/footprints/src/userspace.c
@@ -46,7 +46,7 @@ static inline int z_vrfy_validation_overhead_syscall(void)
 
 	bool status_1 = Z_SYSCALL_OBJ(&test_sema, K_OBJ_SEM);
 
-	return status_0 || status_1;
+	return (status_0 || status_1) ? 1 : 0;
 }
 #include <syscalls/validation_overhead_syscall_mrsh.c>
 


### PR DESCRIPTION
- avoid mixing signed and unsigned integers in computations and
  comparisons;

- ensure computations are done in the destination precision;

- Use proper types;