### PR TITLE
ITE drivers/kscan: support tests/driver/kscan/kscan_api

### DIFF
--- a/boards/riscv/it8xxx2_evb/it8xxx2_evb.dts
+++ b/boards/riscv/it8xxx2_evb/it8xxx2_evb.dts
@@ -26,6 +26,7 @@
 
 	aliases {
 		led0 = &led0;
+		kscan0 = &kscan0;
 	};
 
 	leds {

--- a/drivers/kscan/kscan_ite_it8xxx2.c
+++ b/drivers/kscan/kscan_ite_it8xxx2.c
@@ -492,16 +492,16 @@ static int kscan_it8xxx2_init(const struct device *dev)
 	/* Enable keyboard scan loop */
 	atomic_set(&data->enable_scan, 1);
 
+	irq_connect_dynamic(DT_INST_IRQN(0), 0,
+			    (void (*)(const void *))keyboard_raw_interrupt,
+			    (const void *)dev, 0);
+
 	/* Create keyboard scan task */
 	k_thread_create(&data->thread, data->thread_stack,
 			TASK_STACK_SIZE,
 			(void (*)(void *, void *, void *))polling_task,
 			(void *)dev, NULL, NULL,
 			K_PRIO_COOP(4), 0, K_NO_WAIT);
-
-	irq_connect_dynamic(DT_INST_IRQN(0), 0,
-			    (void (*)(const void *))keyboard_raw_interrupt,
-			    (const void *)dev, 0);
 
 	return 0;
 }


### PR DESCRIPTION
Add kscan0 to support tests/driver/kscan/kscan_api.

When running the tests code on it8xxx2_evb, it shows fatal
error: IRQ is enabled. We found that once polling_task() is
created and executed, the KSI interrupt will be enabled and
before we call irq_connect_dynamic(), so we switch both
function sequence.

Signed-off-by: Ruibin Chang <Ruibin.Chang@ite.com.tw>