### PR TITLE
lib: os: Code guideline fixes

### DIFF
--- a/include/sys/sys_heap.h
+++ b/include/sys/sys_heap.h
@@ -198,7 +198,7 @@ void sys_heap_stress(void *(*alloc_fn)(void *arg, size_t bytes),
 		     void *arg, size_t total_bytes,
 		     uint32_t op_count,
 		     void *scratch_mem, size_t scratch_bytes,
-		     int target_percent,
+		     uint32_t target_percent,
 		     struct z_heap_stress_result *result);
 
 /** @brief Print heap internal structure information to the console

--- a/lib/os/fdtable.c
+++ b/lib/os/fdtable.c
@@ -94,8 +94,8 @@ static int _find_fd_entry(void)
 {
 	int fd;
 
-	for (fd = 0; fd < ARRAY_SIZE(fdtable); fd++) {
-		if (!atomic_get(&fdtable[fd].refcount)) {
+	for (fd = 0; fd < (int)ARRAY_SIZE(fdtable); fd++) {
+		if (atomic_get(&fdtable[fd].refcount) == 0) {
 			return fd;
 		}
 	}
@@ -106,12 +106,13 @@ static int _find_fd_entry(void)
 
 static int _check_fd(int fd)
 {
-	if (fd < 0 || fd >= ARRAY_SIZE(fdtable)) {
+	if (fd < 0 || fd >= (int)ARRAY_SIZE(fdtable)) {
 		errno = EBADF;
 		return -1;
 	}
+	uint32_t ufd = (uint32_t)fd;
 
-	fd = k_array_index_sanitize(fd, ARRAY_SIZE(fdtable));
+	ufd = k_array_index_sanitize(ufd, (uint32_t)ARRAY_SIZE(fdtable));
 
 	if (atomic_get(&fdtable[ufd].refcount) == 0) {
 		errno = EBADF;

--- a/lib/os/hex.c
+++ b/lib/os/hex.c
@@ -12,11 +12,11 @@
 int char2hex(char c, uint8_t *x)
 {
 	if (c >= '0' && c <= '9') {
-		*x = c - '0';
+		*x = (uint8_t)(int)(c - '0');
 	} else if (c >= 'a' && c <= 'f') {
-		*x = c - 'a' + 10;
+		*x = (uint8_t)(int)(c - 'a' + 10);
 	} else if (c >= 'A' && c <= 'F') {
-		*x = c - 'A' + 10;
+		*x = (uint8_t)(int)(c - 'A' + 10);
 	} else {
 		return -EINVAL;
 	}
@@ -47,7 +47,7 @@ size_t bin2hex(const uint8_t *buf, size_t buflen, char *hex, size_t hexlen)
 		if (hex2char(buf[i] >> 4, &hex[2 * i]) < 0) {
 			return 0;
 		}
-		if (hex2char(buf[i] & 0xf, &hex[2 * i + 1]) < 0) {
+		if (hex2char(buf[i] & 0x0FU, &hex[2 * i + 1]) < 0) {
 			return 0;
 		}
 	}

--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -97,7 +97,7 @@ static int buf_char_out(int c, void *ctx_p)
 	struct buf_out_context *ctx = ctx_p;
 
 	ctx->count++;
-	ctx->buf[ctx->buf_count++] = c;
+	ctx->buf[ctx->buf_count++] = (char)c;
 	if (ctx->buf_count == CONFIG_PRINTK_BUFFER_SIZE) {
 		buf_flush(ctx);
 	}
@@ -166,7 +166,7 @@ void z_impl_k_str_out(char *c, size_t n)
 #endif
 
 	for (i = 0; i < n; i++) {
-		_char_out(c[i]);
+		_char_out((int)c[i]);
 	}
 
 #ifdef CONFIG_PRINTK_SYNC
@@ -225,8 +225,8 @@ void printk(const char *fmt, ...)
 
 struct str_context {
 	char *str;
-	int max;
-	int count;
+	size_t max;
+	size_t count;
 };
 
 static int str_out(int c, struct str_context *ctx)
@@ -239,7 +239,7 @@ static int str_out(int c, struct str_context *ctx)
 	if (ctx->count == ctx->max - 1) {
 		ctx->str[ctx->count++] = '\0';
 	} else {
-		ctx->str[ctx->count++] = c;
+		ctx->str[ctx->count++] = (char)c;
 	}
 
 	return c;
@@ -267,5 +267,5 @@ int vsnprintk(char *str, size_t size, const char *fmt, va_list ap)
 		str[ctx.count] = '\0';
 	}
 
-	return ctx.count;
+	return (int)ctx.count;
 }

--- a/lib/os/sem.c
+++ b/lib/os/sem.c
@@ -22,7 +22,7 @@ static inline atomic_t bounded_dec(atomic_t *val, atomic_t minimum)
 		}
 
 		new_value = old_value - 1;
-	} while (atomic_cas(val, old_value, new_value) == 0);
+	} while (!atomic_cas(val, old_value, new_value));
 
 	return old_value;
 }
@@ -40,7 +40,7 @@ static inline atomic_t bounded_inc(atomic_t *val, atomic_t minimum,
 
 		new_value = old_value < minimum ?
 			    minimum + 1 : old_value + 1;
-	} while (atomic_cas(val, old_value, new_value) == 0U);
+	} while (!atomic_cas(val, old_value, new_value));
 
 	return old_value;
 }

--- a/lib/os/sem.c
+++ b/lib/os/sem.c
@@ -48,13 +48,13 @@ static inline atomic_t bounded_inc(atomic_t *val, atomic_t minimum,
 int sys_sem_init(struct sys_sem *sem, unsigned int initial_count,
 		 unsigned int limit)
 {
-	if (sem == NULL || limit == SYS_SEM_MINIMUM ||
-	    initial_count > limit || limit > INT_MAX) {
+	if (sem == NULL || limit == (unsigned int)SYS_SEM_MINIMUM ||
+	    initial_count > limit || limit > (unsigned int)INT_MAX) {
 		return -EINVAL;
 	}
 
-	atomic_set(&sem->futex.val, initial_count);
-	sem->limit = limit;
+	atomic_set(&sem->futex.val, (int)initial_count);
+	sem->limit = (int)limit;
 
 	return 0;
 }
@@ -103,7 +103,7 @@ unsigned int sys_sem_count_get(struct sys_sem *sem)
 {
 	int value = atomic_get(&sem->futex.val);
 
-	return value > SYS_SEM_MINIMUM ? value : SYS_SEM_MINIMUM;
+	return (unsigned int)(value > SYS_SEM_MINIMUM ? value : SYS_SEM_MINIMUM);
 }
 #else
 int sys_sem_init(struct sys_sem *sem, unsigned int initial_count,

--- a/lib/os/timeutil.c
+++ b/lib/os/timeutil.c
@@ -31,7 +31,9 @@ static int64_t time_days_from_civil(int64_t y,
 				    unsigned int m,
 				    unsigned int d)
 {
-	y -= m <= 2;
+	if (m <= 2) {
+		--y;
+	}
 
 	int64_t era = (y >= 0 ? y : y - 399) / 400;
 	unsigned int yoe = y - era * 400;


### PR DESCRIPTION
- Ensure computations are done in the destination precision
- Avoid mixing characters with integers
- Avoid mixing signed and unsigned integers in computations and
  comparisons


Original PR: https://github.com/zephyrproject-rtos/zephyr/pull/41227