### PR TITLE
Bluetooth: Mesh: Return a boolean from subnet_find callback

### DIFF
--- a/subsys/bluetooth/mesh/cfg.c
+++ b/subsys/bluetooth/mesh/cfg.c
@@ -82,7 +82,7 @@ static enum bt_mesh_feat_state feature_get(int feature_flag)
 		       BT_MESH_FEATURE_DISABLED;
 }
 
-static int node_id_is_running(struct bt_mesh_subnet *sub, void *cb_data)
+static bool node_id_is_running(struct bt_mesh_subnet *sub, void *cb_data)
 {
 	return sub->node_id == BT_MESH_NODE_IDENTITY_RUNNING;
 }

--- a/subsys/bluetooth/mesh/proxy_srv.c
+++ b/subsys/bluetooth/mesh/proxy_srv.c
@@ -319,11 +319,11 @@ static int beacon_send(struct bt_mesh_proxy_client *client,
 				      &buf, NULL, NULL);
 }
 
-static int send_beacon_cb(struct bt_mesh_subnet *sub, void *cb_data)
+static bool send_beacon_cb(struct bt_mesh_subnet *sub, void *cb_data)
 {
 	struct bt_mesh_proxy_client *client = cb_data;
 
-	return beacon_send(client, sub);
+	return beacon_send(client, sub) != 0;
 }
 
 static void proxy_send_beacons(struct k_work *work)
@@ -528,7 +528,7 @@ static struct bt_mesh_subnet *next_sub(void)
 	return NULL;
 }
 
-static int sub_count_cb(struct bt_mesh_subnet *sub, void *cb_data)
+static bool sub_count_cb(struct bt_mesh_subnet *sub, void *cb_data)
 {
 	int *count = cb_data;
 
@@ -536,7 +536,10 @@ static int sub_count_cb(struct bt_mesh_subnet *sub, void *cb_data)
 		(*count)++;
 	}
 
-	return 0;
+	/* Don't stop until we've visited all subnets.
+	 * We're only using the "find" variant of the subnet iteration to get a context parameter.
+	 */
+	return false;
 }
 
 static int sub_count(void)

--- a/subsys/bluetooth/mesh/subnet.c
+++ b/subsys/bluetooth/mesh/subnet.c
@@ -638,8 +638,7 @@ int bt_mesh_subnet_set(uint16_t net_idx, uint8_t kr_phase,
 	return 0;
 }
 
-struct bt_mesh_subnet *bt_mesh_subnet_find(int (*cb)(struct bt_mesh_subnet *sub,
-						     void *cb_data),
+struct bt_mesh_subnet *bt_mesh_subnet_find(bool (*cb)(struct bt_mesh_subnet *sub, void *cb_data),
 					   void *cb_data)
 {
 	for (int i = 0; i < ARRAY_SIZE(subnets); i++) {

--- a/subsys/bluetooth/mesh/subnet.h
+++ b/subsys/bluetooth/mesh/subnet.h
@@ -87,13 +87,13 @@ void bt_mesh_net_keys_reset(void);
 
 /** @brief Call cb on every valid Subnet until it returns a non-zero value.
  *
- *  @param cb Callback to call, or NULL to return first valid subnet.
+ *  @param cb Callback to call, or NULL to return first valid subnet. If the callback returns true,
+ *            iteration stops, and the passed subnet is returned.
  *  @param cb_data Callback data to pass to callback.
  *
  *  @return Subnet that returned non-zero value.
  */
-struct bt_mesh_subnet *bt_mesh_subnet_find(int (*cb)(struct bt_mesh_subnet *sub,
-						     void *cb_data),
+struct bt_mesh_subnet *bt_mesh_subnet_find(bool (*cb)(struct bt_mesh_subnet *sub, void *cb_data),
 					   void *cb_data);
 
 /** @brief Iterate through all valid Subnets.


### PR DESCRIPTION
bt_mesh_subnet_find calls a callback for every subnet, and returns the
subnet that got a non-zero return code from the callback. As pointed out
in #41693, the callback should return a boolean, not an int.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>