### PR TITLE
Adds LOG_*_ONCE macros

### DIFF
--- a/include/logging/log.h
+++ b/include/logging/log.h
@@ -40,6 +40,18 @@ extern "C" {
 #define LOG_ERR(...)    Z_LOG(LOG_LEVEL_ERR, __VA_ARGS__)
 
 /**
+ * @brief Write an ERROR level message to the log, but only the first @p n times
+ *
+ * @details It's meant to report severe errors, such as those from which it's
+ * not possible to recover.
+ *
+ * @param n The number of times this log will be executed before it is silenced.
+ * @param ... A string optionally containing printk valid conversion specifier,
+ * followed by as many values as specifiers.
+ */
+#define LOG_ERR_N(n, ...)    Z_LOG_N(n, LOG_LEVEL_ERR, __VA_ARGS__)
+
+/**
  * @brief Write a WARNING level message to the log.
  *
  * @details It's meant to register messages related to unusual situations that
@@ -51,14 +63,38 @@ extern "C" {
 #define LOG_WRN(...)   Z_LOG(LOG_LEVEL_WRN, __VA_ARGS__)
 
 /**
+ * @brief Write a WARNING level message to the log, but only the first @p n times
+ *
+ * @details It's meant to register messages related to unusual situations that
+ * are not necessarily errors.
+ *
+ * @param n The number of times this log will be executed before it is silenced.
+ * @param ... A string optionally containing printk valid conversion specifier,
+ * followed by as many values as specifiers.
+ */
+#define LOG_WRN_N(n, ...)   Z_LOG_N(n, LOG_LEVEL_WRN, __VA_ARGS__)
+
+/**
  * @brief Write an INFO level message to the log.
  *
  * @details It's meant to write generic user oriented messages.
  *
+ * @param n The number of times this log will be executed before it is silenced.
  * @param ... A string optionally containing printk valid conversion specifier,
  * followed by as many values as specifiers.
  */
 #define LOG_INF(...)   Z_LOG(LOG_LEVEL_INF, __VA_ARGS__)
+
+/**
+ * @brief Write an INFO level message to the log, but only the first @p n times.
+ *
+ * @details It's meant to write generic user oriented messages.
+ *
+ * @param n The number of times this log will be executed before it is silenced.
+ * @param ... A string optionally containing printk valid conversion specifier,
+ * followed by as many values as specifiers.
+ */
+#define LOG_INF_N(n, ...)   Z_LOG_N(n, LOG_LEVEL_INF, __VA_ARGS__)
 
 /**
  * @brief Write a DEBUG level message to the log.
@@ -71,6 +107,17 @@ extern "C" {
 #define LOG_DBG(...)    Z_LOG(LOG_LEVEL_DBG, __VA_ARGS__)
 
 /**
+ * @brief Write a DEBUG level message to the log, but only the first @p n times.
+ *
+ * @details It's meant to write developer oriented information.
+ *
+ * @param n The number of times this log will be executed before it is silenced.
+ * @param ... A string optionally containing printk valid conversion specifier,
+ * followed by as many values as specifiers.
+ */
+#define LOG_DBG_N(n, ...)    Z_LOG_N(n, LOG_LEVEL_DBG, __VA_ARGS__)
+
+/**
  * @brief Unconditionally print raw log message.
  *
  * The result is same as if printk was used but it goes through logging
@@ -80,6 +127,18 @@ extern "C" {
  * followed by as many values as specifiers.
  */
 #define LOG_PRINTK(...) Z_LOG_PRINTK(__VA_ARGS__)
+
+/**
+ * @brief Unconditionally print raw log message, but only the first @p n times.
+ *
+ * The result is same as if printk was used but it goes through logging
+ * infrastructure thus utilizes logging mode, e.g. deferred mode.
+ *
+ * @param n The number of times this log will be executed before it is silenced.
+ * @param ... A string optionally containing printk valid conversion specifier,
+ * followed by as many values as specifiers.
+ */
+#define LOG_PRINTK_N(n, ...) Z_LOG_PRINTK_N(n, __VA_ARGS__)
 
 /**
  * @brief Write an ERROR level message associated with the instance to the log.
@@ -95,6 +154,23 @@ extern "C" {
  */
 #define LOG_INST_ERR(_log_inst, ...) \
 	Z_LOG_INSTANCE(LOG_LEVEL_ERR, _log_inst, __VA_ARGS__)
+
+/**
+ * @brief Write an ERROR level message associated with the instance to the log.
+ * but but only the first @p n times.
+ *
+ * Message is associated with specific instance of the module which has
+ * independent filtering settings (if runtime filtering is enabled) and
+ * message prefix (\<module_name\>.\<instance_name\>). It's meant to report
+ * severe errors, such as those from which it's not possible to recover.
+ *
+ * @param n The number of times this log will be executed before it is silenced.
+ * @param _log_inst Pointer to the log structure associated with the instance.
+ * @param ... A string optionally containing printk valid conversion specifier,
+ * followed by as many values as specifiers.
+ */
+#define LOG_INST_ERR_N(n, _log_inst, ...) \
+	Z_LOG_INSTANCE_N(n, LOG_LEVEL_ERR, _log_inst, __VA_ARGS__)
 
 /**
  * @brief Write a WARNING level message associated with the instance to the
@@ -113,6 +189,23 @@ extern "C" {
 	Z_LOG_INSTANCE(LOG_LEVEL_WRN, _log_inst, __VA_ARGS__)
 
 /**
+ * @brief Write a WARNING level message associated with the instance to the
+ *        log, but but only the first @p n times.
+ *
+ * Message is associated with specific instance of the module which has
+ * independent filtering settings (if runtime filtering is enabled) and
+ * message prefix (\<module_name\>.\<instance_name\>). It's meant to register
+ * messages related to unusual situations that are not necessarily errors.
+ *
+ * @param n         The number of times this log will be executed before it is silenced.
+ * @param _log_inst Pointer to the log structure associated with the instance.
+ * @param ...       A string optionally containing printk valid conversion
+ *                  specifier, followed by as many values as specifiers.
+ */
+#define LOG_INST_WRN_N(n, _log_inst, ...) \
+	Z_LOG_INSTANCE_N(n, LOG_LEVEL_WRN, _log_inst, __VA_ARGS__)
+
+/**
  * @brief Write an INFO level message associated with the instance to the log.
  *
  * Message is associated with specific instance of the module which has
@@ -126,6 +219,22 @@ extern "C" {
  */
 #define LOG_INST_INF(_log_inst, ...) \
 	Z_LOG_INSTANCE(LOG_LEVEL_INF, _log_inst, __VA_ARGS__)
+
+/**
+ * @brief Write an INFO level message associated with the instance to the log,
+ * but but only the first @p n times.
+ * Message is associated with specific instance of the module which has
+ * independent filtering settings (if runtime filtering is enabled) and
+ * message prefix (\<module_name\>.\<instance_name\>). It's meant to write
+ * generic user oriented messages.
+ *
+ * @param n The number of times this log will be executed before it is silenced.
+ * @param _log_inst Pointer to the log structure associated with the instance.
+ * @param ... A string optionally containing printk valid conversion specifier,
+ * followed by as many values as specifiers.
+ */
+#define LOG_INST_INF_N(n, _log_inst, ...) \
+	Z_LOG_INSTANCE_N(n, LOG_LEVEL_INF, _log_inst, __VA_ARGS__)
 
 /**
  * @brief Write a DEBUG level message associated with the instance to the log.
@@ -143,6 +252,23 @@ extern "C" {
 	Z_LOG_INSTANCE(LOG_LEVEL_DBG, _log_inst, __VA_ARGS__)
 
 /**
+ * @brief Write a DEBUG level message associated with the instance to the log,
+ * but but only the first @p n times.
+ *
+ * Message is associated with specific instance of the module which has
+ * independent filtering settings (if runtime filtering is enabled) and
+ * message prefix (\<module_name\>.\<instance_name\>). It's meant to write
+ * developer oriented information.
+ *
+ * @param n The number of times this log will be executed before it is silenced.
+ * @param _log_inst Pointer to the log structure associated with the instance.
+ * @param ... A string optionally containing printk valid conversion specifier,
+ * followed by as many values as specifiers.
+ */
+#define LOG_INST_DBG_N(n, _log_inst, ...) \
+	Z_LOG_INSTANCE_N(n, LOG_LEVEL_DBG, _log_inst, __VA_ARGS__)
+
+/**
  * @brief Write an ERROR level hexdump message to the log.
  *
  * @details It's meant to report severe errors, such as those from which it's
@@ -154,6 +280,20 @@ extern "C" {
  */
 #define LOG_HEXDUMP_ERR(_data, _length, _str) \
 	Z_LOG_HEXDUMP(LOG_LEVEL_ERR, _data, _length, _str)
+
+/**
+ * @brief Write an ERROR level hexdump message to the log, but but only the first @p n times.
+ *
+ * @details It's meant to report severe errors, such as those from which it's
+ * not possible to recover.
+ *
+ * @param n       The number of times this log will be executed before it is silenced.
+ * @param _data   Pointer to the data to be logged.
+ * @param _length Length of data (in bytes).
+ * @param _str    Persistent, raw string.
+ */
+#define LOG_HEXDUMP_ERR_N(n, _data, _length, _str) \
+	Z_LOG_HEXDUMP_N(n, LOG_LEVEL_ERR, _data, _length, _str)
 
 /**
  * @brief Write a WARNING level message to the log.
@@ -169,6 +309,20 @@ extern "C" {
 	Z_LOG_HEXDUMP(LOG_LEVEL_WRN, _data, _length, _str)
 
 /**
+ * @brief Write a WARNING level message to the log, but but only the first @p n times.
+ *
+ * @details It's meant to register messages related to unusual situations that
+ * are not necessarily errors.
+ *
+ * @param n       The number of times this log will be executed before it is silenced.
+ * @param _data   Pointer to the data to be logged.
+ * @param _length Length of data (in bytes).
+ * @param _str    Persistent, raw string.
+ */
+#define LOG_HEXDUMP_WRN_N(n, _data, _length, _str) \
+	Z_LOG_HEXDUMP_N(n, LOG_LEVEL_WRN, _data, _length, _str)
+
+/**
  * @brief Write an INFO level message to the log.
  *
  * @details It's meant to write generic user oriented messages.
@@ -181,6 +335,19 @@ extern "C" {
 	Z_LOG_HEXDUMP(LOG_LEVEL_INF, _data, _length, _str)
 
 /**
+ * @brief Write an INFO level message to the log.
+ *
+ * @details It's meant to write generic user oriented messages.
+ *
+ * @param n       The number of times this log will be executed before it is silenced.
+ * @param _data   Pointer to the data to be logged.
+ * @param _length Length of data (in bytes).
+ * @param _str    Persistent, raw string.
+ */
+#define LOG_HEXDUMP_INF_N(n, _data, _length, _str) \
+	Z_LOG_HEXDUMP_N(n, LOG_LEVEL_INF, _data, _length, _str)
+
+/**
  * @brief Write a DEBUG level message to the log.
  *
  * @details It's meant to write developer oriented information.
@@ -191,6 +358,19 @@ extern "C" {
  */
 #define LOG_HEXDUMP_DBG(_data, _length, _str) \
 	Z_LOG_HEXDUMP(LOG_LEVEL_DBG, _data, _length, _str)
+
+/**
+ * @brief Write a DEBUG level message to the log.
+ *
+ * @details It's meant to write developer oriented information.
+ *
+ * @param n       The number of times this log will be executed before it is silenced.
+ * @param _data   Pointer to the data to be logged.
+ * @param _length Length of data (in bytes).
+ * @param _str    Persistent, raw string.
+ */
+#define LOG_HEXDUMP_DBG_N(n, _data, _length, _str) \
+	Z_LOG_HEXDUMP_N(n, LOG_LEVEL_DBG, _data, _length, _str)
 
 /**
  * @brief Write an ERROR hexdump message associated with the instance to the
@@ -210,6 +390,25 @@ extern "C" {
 	Z_LOG_HEXDUMP_INSTANCE(LOG_LEVEL_ERR, _log_inst, _data, _length, _str)
 
 /**
+ * @brief Write an ERROR hexdump message associated with the instance to the
+ *        log, but but only the first @p n times.
+ *
+ * @param n The number of times this log will be executed before it is silenced.
+ * Message is associated with specific instance of the module which has
+ * independent filtering settings (if runtime filtering is enabled) and
+ * message prefix (\<module_name\>.\<instance_name\>). It's meant to report
+ * severe errors, such as those from which it's not possible to recover.
+ *
+ * @param n           The number of times this log will be executed before it is silenced.
+ * @param _log_inst   Pointer to the log structure associated with the instance.
+ * @param _data       Pointer to the data to be logged.
+ * @param _length     Length of data (in bytes).
+ * @param _str        Persistent, raw string.
+ */
+#define LOG_INST_HEXDUMP_ERR_N(n, _log_inst, _data, _length, _str) \
+	Z_LOG_HEXDUMP_INSTANCE_N(n, LOG_LEVEL_ERR, _log_inst, _data, _length, _str)
+
+/**
  * @brief Write a WARNING level hexdump message associated with the instance to
  *        the log.
  *
@@ -223,6 +422,23 @@ extern "C" {
  */
 #define LOG_INST_HEXDUMP_WRN(_log_inst, _data, _length, _str) \
 	Z_LOG_HEXDUMP_INSTANCE(LOG_LEVEL_WRN, _log_inst, _data, _length, _str)
+
+/**
+ * @brief Write a WARNING level hexdump message associated with the instance to
+ *        the log, but but only the first @p n times.
+ *
+ * @param n The number of times this log will be executed before it is silenced.
+ * @details It's meant to register messages related to unusual situations that
+ * are not necessarily errors.
+ *
+ * @param n           The number of times this log will be executed before it is silenced.
+ * @param _log_inst   Pointer to the log structure associated with the instance.
+ * @param _data       Pointer to the data to be logged.
+ * @param _length     Length of data (in bytes).
+ * @param _str        Persistent, raw string.
+ */
+#define LOG_INST_HEXDUMP_WRN_N(n, _log_inst, _data, _length, _str) \
+	Z_LOG_HEXDUMP_INSTANCE_N(n, LOG_LEVEL_WRN, _log_inst, _data, _length, _str)
 
 /**
  * @brief Write an INFO level hexdump message associated with the instance to
@@ -239,6 +455,21 @@ extern "C" {
 	Z_LOG_HEXDUMP_INSTANCE(LOG_LEVEL_INF, _log_inst, _data, _length, _str)
 
 /**
+ * @brief Write an INFO level hexdump message associated with the instance to
+ *        the log.
+ *
+ * @details It's meant to write generic user oriented messages.
+ *
+ * @param n           The number of times this log will be executed before it is silenced.
+ * @param _log_inst   Pointer to the log structure associated with the instance.
+ * @param _data       Pointer to the data to be logged.
+ * @param _length     Length of data (in bytes).
+ * @param _str        Persistent, raw string.
+ */
+#define LOG_INST_HEXDUMP_INF_N(n, _log_inst, _data, _length, _str) \
+	Z_LOG_HEXDUMP_INSTANCE_N(n, LOG_LEVEL_INF, _log_inst, _data, _length, _str)
+
+/**
  * @brief Write a DEBUG level hexdump message associated with the instance to
  *        the log.
  *
@@ -251,6 +482,21 @@ extern "C" {
  */
 #define LOG_INST_HEXDUMP_DBG(_log_inst, _data, _length, _str)	\
 	Z_LOG_HEXDUMP_INSTANCE(LOG_LEVEL_DBG, _log_inst, _data, _length, _str)
+
+/**
+ * @brief Write a DEBUG level hexdump message associated with the instance to
+ *        the log.
+ *
+ * @details It's meant to write developer oriented information.
+ *
+ * @param n           The number of times this log will be executed before it is silenced.
+ * @param _log_inst   Pointer to the log structure associated with the instance.
+ * @param _data       Pointer to the data to be logged.
+ * @param _length     Length of data (in bytes).
+ * @param _str        Persistent, raw string.
+ */
+#define LOG_INST_HEXDUMP_DBG_N(n, _log_inst, _data, _length, _str)	\
+	Z_LOG_HEXDUMP_INSTANCE_N(n, LOG_LEVEL_DBG, _log_inst, _data, _length, _str)
 
 /**
  * @brief Write an formatted string to the log.

--- a/include/logging/log.h
+++ b/include/logging/log.h
@@ -79,7 +79,6 @@ extern "C" {
  *
  * @details It's meant to write generic user oriented messages.
  *
- * @param n The number of times this log will be executed before it is silenced.
  * @param ... A string optionally containing printk valid conversion specifier,
  * followed by as many values as specifiers.
  */
@@ -393,7 +392,6 @@ extern "C" {
  * @brief Write an ERROR hexdump message associated with the instance to the
  *        log, but but only the first @p n times.
  *
- * @param n The number of times this log will be executed before it is silenced.
  * Message is associated with specific instance of the module which has
  * independent filtering settings (if runtime filtering is enabled) and
  * message prefix (\<module_name\>.\<instance_name\>). It's meant to report
@@ -427,7 +425,6 @@ extern "C" {
  * @brief Write a WARNING level hexdump message associated with the instance to
  *        the log, but but only the first @p n times.
  *
- * @param n The number of times this log will be executed before it is silenced.
  * @details It's meant to register messages related to unusual situations that
  * are not necessarily errors.
  *

--- a/include/logging/log.h
+++ b/include/logging/log.h
@@ -29,7 +29,7 @@ extern "C" {
  */
 
 /**
- * @brief Writes an ERROR level message to the log.
+ * @brief Write an ERROR level message to the log.
  *
  * @details It's meant to report severe errors, such as those from which it's
  * not possible to recover.
@@ -40,7 +40,7 @@ extern "C" {
 #define LOG_ERR(...)    Z_LOG(LOG_LEVEL_ERR, __VA_ARGS__)
 
 /**
- * @brief Writes a WARNING level message to the log.
+ * @brief Write a WARNING level message to the log.
  *
  * @details It's meant to register messages related to unusual situations that
  * are not necessarily errors.
@@ -51,7 +51,7 @@ extern "C" {
 #define LOG_WRN(...)   Z_LOG(LOG_LEVEL_WRN, __VA_ARGS__)
 
 /**
- * @brief Writes an INFO level message to the log.
+ * @brief Write an INFO level message to the log.
  *
  * @details It's meant to write generic user oriented messages.
  *
@@ -61,7 +61,7 @@ extern "C" {
 #define LOG_INF(...)   Z_LOG(LOG_LEVEL_INF, __VA_ARGS__)
 
 /**
- * @brief Writes a DEBUG level message to the log.
+ * @brief Write a DEBUG level message to the log.
  *
  * @details It's meant to write developer oriented information.
  *
@@ -82,7 +82,7 @@ extern "C" {
 #define LOG_PRINTK(...) Z_LOG_PRINTK(__VA_ARGS__)
 
 /**
- * @brief Writes an ERROR level message associated with the instance to the log.
+ * @brief Write an ERROR level message associated with the instance to the log.
  *
  * Message is associated with specific instance of the module which has
  * independent filtering settings (if runtime filtering is enabled) and
@@ -97,7 +97,7 @@ extern "C" {
 	Z_LOG_INSTANCE(LOG_LEVEL_ERR, _log_inst, __VA_ARGS__)
 
 /**
- * @brief Writes a WARNING level message associated with the instance to the
+ * @brief Write a WARNING level message associated with the instance to the
  *        log.
  *
  * Message is associated with specific instance of the module which has
@@ -113,7 +113,7 @@ extern "C" {
 	Z_LOG_INSTANCE(LOG_LEVEL_WRN, _log_inst, __VA_ARGS__)
 
 /**
- * @brief Writes an INFO level message associated with the instance to the log.
+ * @brief Write an INFO level message associated with the instance to the log.
  *
  * Message is associated with specific instance of the module which has
  * independent filtering settings (if runtime filtering is enabled) and
@@ -128,7 +128,7 @@ extern "C" {
 	Z_LOG_INSTANCE(LOG_LEVEL_INF, _log_inst, __VA_ARGS__)
 
 /**
- * @brief Writes a DEBUG level message associated with the instance to the log.
+ * @brief Write a DEBUG level message associated with the instance to the log.
  *
  * Message is associated with specific instance of the module which has
  * independent filtering settings (if runtime filtering is enabled) and
@@ -143,7 +143,7 @@ extern "C" {
 	Z_LOG_INSTANCE(LOG_LEVEL_DBG, _log_inst, __VA_ARGS__)
 
 /**
- * @brief Writes an ERROR level hexdump message to the log.
+ * @brief Write an ERROR level hexdump message to the log.
  *
  * @details It's meant to report severe errors, such as those from which it's
  * not possible to recover.
@@ -156,7 +156,7 @@ extern "C" {
 	Z_LOG_HEXDUMP(LOG_LEVEL_ERR, _data, _length, _str)
 
 /**
- * @brief Writes a WARNING level message to the log.
+ * @brief Write a WARNING level message to the log.
  *
  * @details It's meant to register messages related to unusual situations that
  * are not necessarily errors.
@@ -169,7 +169,7 @@ extern "C" {
 	Z_LOG_HEXDUMP(LOG_LEVEL_WRN, _data, _length, _str)
 
 /**
- * @brief Writes an INFO level message to the log.
+ * @brief Write an INFO level message to the log.
  *
  * @details It's meant to write generic user oriented messages.
  *
@@ -181,7 +181,7 @@ extern "C" {
 	Z_LOG_HEXDUMP(LOG_LEVEL_INF, _data, _length, _str)
 
 /**
- * @brief Writes a DEBUG level message to the log.
+ * @brief Write a DEBUG level message to the log.
  *
  * @details It's meant to write developer oriented information.
  *
@@ -193,7 +193,7 @@ extern "C" {
 	Z_LOG_HEXDUMP(LOG_LEVEL_DBG, _data, _length, _str)
 
 /**
- * @brief Writes an ERROR hexdump message associated with the instance to the
+ * @brief Write an ERROR hexdump message associated with the instance to the
  *        log.
  *
  * Message is associated with specific instance of the module which has
@@ -210,7 +210,7 @@ extern "C" {
 	Z_LOG_HEXDUMP_INSTANCE(LOG_LEVEL_ERR, _log_inst, _data, _length, _str)
 
 /**
- * @brief Writes a WARNING level hexdump message associated with the instance to
+ * @brief Write a WARNING level hexdump message associated with the instance to
  *        the log.
  *
  * @details It's meant to register messages related to unusual situations that
@@ -225,7 +225,7 @@ extern "C" {
 	Z_LOG_HEXDUMP_INSTANCE(LOG_LEVEL_WRN, _log_inst, _data, _length, _str)
 
 /**
- * @brief Writes an INFO level hexdump message associated with the instance to
+ * @brief Write an INFO level hexdump message associated with the instance to
  *        the log.
  *
  * @details It's meant to write generic user oriented messages.
@@ -239,7 +239,7 @@ extern "C" {
 	Z_LOG_HEXDUMP_INSTANCE(LOG_LEVEL_INF, _log_inst, _data, _length, _str)
 
 /**
- * @brief Writes a DEBUG level hexdump message associated with the instance to
+ * @brief Write a DEBUG level hexdump message associated with the instance to
  *        the log.
  *
  * @details It's meant to write developer oriented information.
@@ -253,7 +253,7 @@ extern "C" {
 	Z_LOG_HEXDUMP_INSTANCE(LOG_LEVEL_DBG, _log_inst, _data, _length, _str)
 
 /**
- * @brief Writes an formatted string to the log.
+ * @brief Write an formatted string to the log.
  *
  * @details Conditionally compiled (see CONFIG_LOG_PRINTK). Function provides
  * printk functionality.

--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -360,6 +360,9 @@ static inline char z_log_minimal_level_to_char(int level)
 #define Z_LOG(_level, ...) \
 	Z_LOG2(_level, 0, __log_current_const_data, __log_current_dynamic_data, __VA_ARGS__)
 
+#define Z_LOG_N(n, _level, ...) \
+	DO_FIRST_N(n, Z_LOG(_level, __VA_ARGS__))
+
 #define Z_LOG_INSTANCE(_level, _inst, ...) \
 	Z_LOG2(_level, 1, \
 		COND_CODE_1(CONFIG_LOG_RUNTIME_FILTERING, (NULL), (Z_LOG_INST(_inst))), \
@@ -367,6 +370,9 @@ static inline char z_log_minimal_level_to_char(int level)
 						CONFIG_LOG_RUNTIME_FILTERING, \
 						(Z_LOG_INST(_inst)), (NULL)), \
 		__VA_ARGS__)
+
+#define Z_LOG_INSTANCE_N(n, _level, _inst, ...) \
+	DO_FIRST_N(n, Z_LOG_INSTANCE(_level, _inst, __VA_ARGS__))
 
 /*****************************************************************************/
 /****************** Macros for hexdump logging *******************************/
@@ -455,6 +461,9 @@ static inline char z_log_minimal_level_to_char(int level)
 		      __log_current_dynamic_data, \
 		      _data, _length, __VA_ARGS__)
 
+#define Z_LOG_HEXDUMP_N(n, _level, _data, _length, ...) \
+	DO_FIRST_N(n, Z_LOG_HEXDUMP(_level, _data, _length, __VA_ARGS__))
+
 #define Z_LOG_HEXDUMP_INSTANCE(_level, _inst, _data, _length, _str) \
 	Z_LOG_HEXDUMP2(_level, 1, \
 		COND_CODE_1(CONFIG_LOG_RUNTIME_FILTERING, (NULL), (Z_LOG_INST(_inst))), \
@@ -462,6 +471,9 @@ static inline char z_log_minimal_level_to_char(int level)
 						CONFIG_LOG_RUNTIME_FILTERING, \
 						(Z_LOG_INST(_inst)), (NULL)), \
 		_data, _length, _str)
+
+#define Z_LOG_HEXDUMP_INSTANCE_N(n, _level, _inst, _data, _length, _str) \
+	DO_FIRST_N(n, Z_LOG_HEXDUMP_INSTANCE(_level, _inst, _data, _length, _str))
 
 /*****************************************************************************/
 /****************** Filtering macros *****************************************/
@@ -538,6 +550,9 @@ enum log_strdup_action {
 			  CONFIG_LOG_DOMAIN_ID, NULL, \
 			  LOG_LEVEL_INTERNAL_RAW_STRING, NULL, 0, __VA_ARGS__);\
 } while (0)
+
+#define Z_LOG_PRINTK_N(n, ...) \
+	DO_FIRST_N(n, Z_LOG_PRINTK(__VA_ARGS__))
 
 /** @brief Get index of the log source based on the address of the constant data
  *         associated with the source.

--- a/include/sys/util_macro.h
+++ b/include/sys/util_macro.h
@@ -591,6 +591,21 @@ extern "C" {
 #define MACRO_MAP_CAT_N(N, ...) MACRO_MAP_CAT_N_(N, __VA_ARGS__)
 
 /**
+ * @brief Silences a piece of code after a given number of executions.
+ *
+ * @param n    Number of times @p is executed before it is silenced
+ * @param code The code to execute and then silence
+ * @return The results of expanding the macro on each argument, all pasted
+ *         together
+ */
+#define DO_FIRST_N(n, code) \
+	static unsigned int UTIL_CAT(_do_n_cnt_, __LINE__); \
+	if (UTIL_CAT(_do_n_cnt_, __LINE__) < n) { \
+		UTIL_CAT(_do_n_cnt_, __LINE__)++; \
+		code; \
+	}
+
+/**
  * @}
  */
 

--- a/tests/subsys/logging/log_api/src/test.inc
+++ b/tests/subsys/logging/log_api/src/test.inc
@@ -666,6 +666,197 @@ static void test_log_printk(void)
 	process_and_validate(false, true);
 }
 
+#define MOCK_LOG_BACKEND_RECORD_WITH_LEVEL(str, level) mock_log_backend_record( \
+	&backend1, LOG_CURRENT_MODULE_ID(), \
+	CONFIG_LOG_DOMAIN_ID, level, \
+	exp_timestamp++, \
+	str);
+
+static void test_log_n(void)
+{
+	log_timestamp_t exp_timestamp = TIMESTAMP_INIT_VAL;
+
+	log_setup(false);
+
+	/**
+	 * Test at least once at each level
+	 */
+	MOCK_LOG_BACKEND_RECORD_WITH_LEVEL("test 0", LOG_LEVEL_INF);
+	MOCK_LOG_BACKEND_RECORD_WITH_LEVEL("test 1", LOG_LEVEL_INF);
+	MOCK_LOG_BACKEND_RECORD_WITH_LEVEL("test 2", LOG_LEVEL_INF);
+	MOCK_LOG_BACKEND_RECORD_WITH_LEVEL("test 3", LOG_LEVEL_INF);
+	MOCK_LOG_BACKEND_RECORD_WITH_LEVEL("test 4", LOG_LEVEL_INF);
+	for (size_t i = 0; i < 10; i++) {
+		LOG_INF_N(5, "test %zu", i);
+	}
+
+	while (LOG_PROCESS()) {
+	}
+
+	MOCK_LOG_BACKEND_RECORD_WITH_LEVEL("test 0", LOG_LEVEL_ERR);
+	MOCK_LOG_BACKEND_RECORD_WITH_LEVEL("test 1", LOG_LEVEL_ERR);
+	MOCK_LOG_BACKEND_RECORD_WITH_LEVEL("test 2", LOG_LEVEL_ERR);
+	MOCK_LOG_BACKEND_RECORD_WITH_LEVEL("test 3", LOG_LEVEL_ERR);
+	MOCK_LOG_BACKEND_RECORD_WITH_LEVEL("test 4", LOG_LEVEL_ERR);
+	for (size_t i = 0; i < 10; i++) {
+		LOG_ERR_N(5, "test %zu", i);
+	}
+
+	while (LOG_PROCESS()) {
+	}
+
+	MOCK_LOG_BACKEND_RECORD_WITH_LEVEL("test 0", LOG_LEVEL_WRN);
+	MOCK_LOG_BACKEND_RECORD_WITH_LEVEL("test 1", LOG_LEVEL_WRN);
+	MOCK_LOG_BACKEND_RECORD_WITH_LEVEL("test 2", LOG_LEVEL_WRN);
+	MOCK_LOG_BACKEND_RECORD_WITH_LEVEL("test 3", LOG_LEVEL_WRN);
+	MOCK_LOG_BACKEND_RECORD_WITH_LEVEL("test 4", LOG_LEVEL_WRN);
+	for (size_t i = 0; i < 10; i++) {
+		LOG_WRN_N(5, "test %zu", i);
+	}
+
+	while (LOG_PROCESS()) {
+	}
+
+	/**
+	 * Debug level tests may be prefixed with the function name
+	 */
+	static char test_0_str[32];
+	static char test_1_str[32];
+	static char test_2_str[32];
+	static char test_3_str[32];
+	static char test_4_str[32];
+
+	if (IS_ENABLED(CONFIG_LOG_FUNC_NAME_PREFIX_DBG)) {
+		snprintk(test_0_str, sizeof(test_0_str), "%s: test 0", __func__);
+		snprintk(test_1_str, sizeof(test_1_str), "%s: test 1", __func__);
+		snprintk(test_2_str, sizeof(test_2_str), "%s: test 2", __func__);
+		snprintk(test_3_str, sizeof(test_3_str), "%s: test 3", __func__);
+		snprintk(test_4_str, sizeof(test_4_str), "%s: test 4", __func__);
+	} else {
+		snprintk(test_0_str, sizeof(test_0_str), "test 0");
+		snprintk(test_1_str, sizeof(test_1_str), "test 1");
+		snprintk(test_2_str, sizeof(test_2_str), "test 2");
+		snprintk(test_3_str, sizeof(test_3_str), "test 3");
+		snprintk(test_4_str, sizeof(test_4_str), "test 4");
+	}
+
+	if (IS_ENABLED(CONFIG_SAMPLE_MODULE_LOG_LEVEL_DBG)) {
+		MOCK_LOG_BACKEND_RECORD_WITH_LEVEL(test_0_str, LOG_LEVEL_DBG);
+		MOCK_LOG_BACKEND_RECORD_WITH_LEVEL(test_1_str, LOG_LEVEL_DBG);
+		MOCK_LOG_BACKEND_RECORD_WITH_LEVEL(test_2_str, LOG_LEVEL_DBG);
+		MOCK_LOG_BACKEND_RECORD_WITH_LEVEL(test_3_str, LOG_LEVEL_DBG);
+		MOCK_LOG_BACKEND_RECORD_WITH_LEVEL(test_4_str, LOG_LEVEL_DBG);
+		for (size_t i = 0; i < 10; i++) {
+			LOG_DBG_N(5, "test %zu", i);
+		}
+	}
+
+	while (LOG_PROCESS()) {
+	}
+
+	/**
+	 * Test zero (silenced log) and one (log once)
+	 */
+	for (size_t i = 0; i < 10; i++) {
+		LOG_INF_N(0, "test zero");
+	}
+	MOCK_LOG_BACKEND_RECORD_WITH_LEVEL("test one", LOG_LEVEL_INF);
+	for (size_t i = 0; i < 10; i++) {
+		LOG_INF_N(1, "test one");
+	}
+	while (LOG_PROCESS()) {
+	}
+
+	mock_log_backend_validate(&backend1, false);
+}
+
+#define MOCK_LOG_BACKEND_RECORD_HEXDUMP_WITH_LEVEL(data, str, level) \
+	mock_log_backend_generic_record(&backend1, LOG_CURRENT_MODULE_ID(), \
+					CONFIG_LOG_DOMAIN_ID, \
+					level, \
+					exp_timestamp++, str, \
+					data, sizeof(data));
+
+static void test_log_n_hexdump(void)
+{
+	log_timestamp_t exp_timestamp = TIMESTAMP_INIT_VAL;
+
+	log_setup(false);
+
+	static uint8_t data[] = {1, 2, 3, 4};
+	char *str = "hexdump";
+
+	/**
+	 * Test at least once at each level
+	 */
+	MOCK_LOG_BACKEND_RECORD_HEXDUMP_WITH_LEVEL(data, str, LOG_LEVEL_INF);
+	MOCK_LOG_BACKEND_RECORD_HEXDUMP_WITH_LEVEL(data, str, LOG_LEVEL_INF);
+	MOCK_LOG_BACKEND_RECORD_HEXDUMP_WITH_LEVEL(data, str, LOG_LEVEL_INF);
+	MOCK_LOG_BACKEND_RECORD_HEXDUMP_WITH_LEVEL(data, str, LOG_LEVEL_INF);
+	MOCK_LOG_BACKEND_RECORD_HEXDUMP_WITH_LEVEL(data, str, LOG_LEVEL_INF);
+	for (size_t i = 0; i < 10; i++) {
+		LOG_HEXDUMP_INF_N(5, data, sizeof(data), str);
+	}
+
+	while (LOG_PROCESS()) {
+	}
+
+	MOCK_LOG_BACKEND_RECORD_HEXDUMP_WITH_LEVEL(data, str, LOG_LEVEL_WRN);
+	MOCK_LOG_BACKEND_RECORD_HEXDUMP_WITH_LEVEL(data, str, LOG_LEVEL_WRN);
+	MOCK_LOG_BACKEND_RECORD_HEXDUMP_WITH_LEVEL(data, str, LOG_LEVEL_WRN);
+	MOCK_LOG_BACKEND_RECORD_HEXDUMP_WITH_LEVEL(data, str, LOG_LEVEL_WRN);
+	MOCK_LOG_BACKEND_RECORD_HEXDUMP_WITH_LEVEL(data, str, LOG_LEVEL_WRN);
+	for (size_t i = 0; i < 10; i++) {
+		LOG_HEXDUMP_WRN_N(5, data, sizeof(data), str);
+	}
+
+	while (LOG_PROCESS()) {
+	}
+
+	MOCK_LOG_BACKEND_RECORD_HEXDUMP_WITH_LEVEL(data, str, LOG_LEVEL_ERR);
+	MOCK_LOG_BACKEND_RECORD_HEXDUMP_WITH_LEVEL(data, str, LOG_LEVEL_ERR);
+	MOCK_LOG_BACKEND_RECORD_HEXDUMP_WITH_LEVEL(data, str, LOG_LEVEL_ERR);
+	MOCK_LOG_BACKEND_RECORD_HEXDUMP_WITH_LEVEL(data, str, LOG_LEVEL_ERR);
+	MOCK_LOG_BACKEND_RECORD_HEXDUMP_WITH_LEVEL(data, str, LOG_LEVEL_ERR);
+	for (size_t i = 0; i < 10; i++) {
+		LOG_HEXDUMP_ERR_N(5, data, sizeof(data), str);
+	}
+
+	while (LOG_PROCESS()) {
+	}
+
+	/**
+	 * Debug level tests may be prefixed with the function name
+	 */
+	static char test_str[256];
+
+	if (IS_ENABLED(CONFIG_LOG_FUNC_NAME_PREFIX_DBG)) {
+		snprintk(test_str, sizeof(test_str), "%s: hexdump", __func__);
+	} else {
+		snprintk(test_str, sizeof(test_str), "hexdump");
+	}
+	if (IS_ENABLED(CONFIG_SAMPLE_MODULE_LOG_LEVEL_DBG)) {
+		MOCK_LOG_BACKEND_RECORD_HEXDUMP_WITH_LEVEL(data, test_str, LOG_LEVEL_DBG);
+		MOCK_LOG_BACKEND_RECORD_HEXDUMP_WITH_LEVEL(data, test_str, LOG_LEVEL_DBG);
+		MOCK_LOG_BACKEND_RECORD_HEXDUMP_WITH_LEVEL(data, test_str, LOG_LEVEL_DBG);
+		MOCK_LOG_BACKEND_RECORD_HEXDUMP_WITH_LEVEL(data, test_str, LOG_LEVEL_DBG);
+		MOCK_LOG_BACKEND_RECORD_HEXDUMP_WITH_LEVEL(data, test_str, LOG_LEVEL_DBG);
+		for (size_t i = 0; i < 10; i++) {
+			if (IS_ENABLED(CONFIG_LOG1)) {
+				LOG_HEXDUMP_DBG_N(5, data, sizeof(data), test_str);
+			}
+			else {
+				LOG_HEXDUMP_DBG_N(5, data, sizeof(data), "hexdump");
+			}
+		}
+	}
+
+	while (LOG_PROCESS()) {
+	}
+
+	mock_log_backend_validate(&backend1, false);
+}
+
 /* Disable backends because same suite may be executed again but compiled by C++ */
 static void log_api_suite_teardown(void *data)
 {
@@ -737,3 +928,5 @@ WRAP_TEST(test_log_from_declared_module, TEST_SUFFIX)
 WRAP_TEST(test_log_msg_dropped_notification, TEST_SUFFIX)
 WRAP_TEST(test_log_panic, TEST_SUFFIX)
 WRAP_TEST(test_log_printk, TEST_SUFFIX)
+WRAP_TEST(test_log_n, TEST_SUFFIX)
+WRAP_TEST(test_log_n_hexdump, TEST_SUFFIX)

--- a/tests/unit/util/test.inc
+++ b/tests/unit/util/test.inc
@@ -303,6 +303,39 @@ static void test_FOR_EACH_FIXED_ARG(void)
 	zassert_equal(sum, 6, "Unexpected value %d", sum);
 }
 
+static void test_DO_FIRST_N(void)
+{
+	uint32_t count = 0;
+
+	for (size_t i = 0; i < 10; i++) {
+		DO_FIRST_N(0, count++);
+	}
+	zassert_equal(count, 0, "Unexpected value %" PRIu32, count);
+
+	for (size_t i = 0; i < 10; i++) {
+		DO_FIRST_N(1, count++);
+	}
+	zassert_equal(count, 1, "Unexpected value %" PRIu32, count);
+
+	count = 0;
+	for (size_t i = 0; i < 10; i++) {
+		DO_FIRST_N(2, count++);
+	}
+	zassert_equal(count, 2, "Unexpected value %" PRIu32, count);
+
+	count = 0;
+	for (size_t i = 0; i < 10; i++) {
+		DO_FIRST_N(3, count++);
+	}
+	zassert_equal(count, 3, "Unexpected value %" PRIu32, count);
+
+	count = 0;
+	for (size_t i = 0; i < 10; i++) {
+		DO_FIRST_N(4, count++);
+	}
+	zassert_equal(count, 4, "Unexpected value %" PRIu32, count);
+}
+
 static void test_FOR_EACH_IDX(void)
 {
 	#define FOR_EACH_IDX_MACRO_TEST(n, arg) uint8_t a##n = arg
@@ -474,7 +507,8 @@ void test_cc(void)
 			 ztest_unit_test(test_nested_FOR_EACH),
 			 ztest_unit_test(test_GET_ARG_N),
 			 ztest_unit_test(test_GET_ARGS_LESS_N),
-			 ztest_unit_test(test_mixing_GET_ARG_and_FOR_EACH)
+			 ztest_unit_test(test_mixing_GET_ARG_and_FOR_EACH),
+			 ztest_unit_test(test_DO_FIRST_N)
 	);
 
 	ztest_run_test_suite(test_lib_sys_util_tests);


### PR DESCRIPTION
Sometimes it can be useful to execute a log statement only a fixed number of times. For instance, because logging it would produce a lot of spam and it's a fact that will stay constant during the whole runtime. This change adds macros to silence a single log statement after a given number of executions. 

Signed-off-by: Rafael Laya <rafaellaya@fb.com>