### PR TITLE
Bluetooth: controller: Fixed BSIM ISO compile error

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_sync_iso.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_sync_iso.h
@@ -78,3 +78,5 @@ void lll_sync_iso_create_prepare(void *param);
 void lll_sync_iso_prepare(void *param);
 
 extern uint8_t ull_sync_iso_lll_handle_get(struct lll_sync_iso *lll);
+extern void ll_iso_rx_put(memq_link_t *link, void *rx);
+extern void ll_rx_sched(void);


### PR DESCRIPTION
Added missing #includes for access to ULL functions.

Signed-off-by: Morten Priess <mtpr@oticon.com>