### PR TITLE
intel_adsp: Remove unused soc_idc_init reference

### DIFF
--- a/soc/xtensa/intel_adsp/common/soc.c
+++ b/soc/xtensa/intel_adsp/common/soc.c
@@ -105,7 +105,6 @@ static __imr void power_init(void)
 }
 
 #if !DT_NODE_EXISTS(DT_NODELABEL(cavs0)) || CONFIG_MP_NUM_CPUS == 1
-void soc_idc_init(void) {}
 void arch_sched_ipi(void) {}
 #endif
 


### PR DESCRIPTION
Unused as it was renamed to soc_mp_init, this is a stray left over.

Signed-off-by: Tom Burdick <thomas.burdick@intel.com>