### PR TITLE
boards: riscv: longan_nano: Add LED and button configuration

### DIFF
--- a/boards/riscv/longan_nano/longan_nano-common.dtsi
+++ b/boards/riscv/longan_nano/longan_nano-common.dtsi
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2021 Tokita, Hiroshi <tokita.hiroshi@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,console = &usart0;
+		zephyr,shell-uart = &usart0;
+		zephyr,sram = &sram0;
+		zephyr,flash = &flash0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		led_red: led_red {
+			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
+			label = "LED_R";
+		};
+		led_green: led_green {
+			gpios = <&gpioa 1 GPIO_ACTIVE_LOW>;
+			label = "LED_G";
+		};
+		led_blue: led_blue {
+			gpios = <&gpioa 2 GPIO_ACTIVE_LOW>;
+			label = "LED_B";
+		};
+	};
+
+	gpio_keys {
+		compatible = "gpio-keys";
+		button_boot0: button_boot0 {
+			label = "BUTTON_BOOT0";
+			gpios = <&gpioa 8 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+
+		/* NOTE: bridge TIMER1_CH1 and LED_GREEN (PA1) */
+		pwm_led_green: pwm_led_green {
+			pwms = <&pwm1 1 PWM_POLARITY_NORMAL>;
+			label = "PWM_LED_G";
+		};
+		/* NOTE: bridge TIMER1_CH2 and LED_BLUE (PA2) */
+		pwm_led_blue: pwm_led_blue {
+			pwms = <&pwm1 2 PWM_POLARITY_NORMAL>;
+			label = "PWM_LED_B";
+		};
+	};
+
+	aliases {
+		led0 = &led_red;
+		led1 = &led_green;
+		led2 = &led_blue;
+		pwm-led0 = &pwm_led_green;
+		pwm-led1 = &pwm_led_blue;
+		sw0 = &button_boot0;
+	};
+};
+
+&gpioa {
+	status = "okay";
+};
+
+&gpiob {
+	status = "okay";
+};
+
+&gpioc {
+	status = "okay";
+};
+
+&usart0 {
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&usart0_default>;
+	pinctrl-names = "default";
+};
+
+&timer1 {
+	status = "okay";
+	prescaler = <4096>;
+
+	pwm1: pwm {
+		status = "okay";
+		pinctrl-0 = <&pwm1_default>;
+		pinctrl-names = "default";
+	};
+};
+
+&dac {
+	status = "okay";
+	pinctrl-0 = <&dac_default>;
+	pinctrl-names = "default";
+};

--- a/boards/riscv/longan_nano/longan_nano-pinctrl.dtsi
+++ b/boards/riscv/longan_nano/longan_nano-pinctrl.dtsi
@@ -12,6 +12,12 @@
 		};
 	};
 
+	pwm1_default: pwm1_default {
+		group1 {
+			pinmux = <TIMER1_CH1_PA1_OUT_NORMP>, <TIMER1_CH2_PA2_OUT_NORMP>;
+		};
+	};
+
 	dac_default: dac_default {
 		group1 {
 			pinmux = <DAC_OUT0_PA4>;

--- a/boards/riscv/longan_nano/longan_nano.dts
+++ b/boards/riscv/longan_nano/longan_nano.dts
@@ -7,28 +7,9 @@
 /dts-v1/;
 #include <gigadevice/gd32vf103Xb.dtsi>
 #include "longan_nano-pinctrl.dtsi"
+#include "longan_nano-common.dtsi"
 
 / {
 	model = "Sipeed Longan Nano";
 	compatible = "sipeed,longan_nano";
-
-	chosen {
-		zephyr,console = &usart0;
-		zephyr,shell-uart = &usart0;
-		zephyr,sram = &sram0;
-		zephyr,flash = &flash0;
-	};
-};
-
-&usart0 {
-	status = "okay";
-	current-speed = <115200>;
-	pinctrl-0 = <&usart0_default>;
-	pinctrl-names = "default";
-};
-
-&dac {
-	status = "okay";
-	pinctrl-0 = <&dac_default>;
-	pinctrl-names = "default";
 };

--- a/boards/riscv/longan_nano/longan_nano_lite.dts
+++ b/boards/riscv/longan_nano/longan_nano_lite.dts
@@ -7,28 +7,9 @@
 /dts-v1/;
 #include <gigadevice/gd32vf103X8.dtsi>
 #include "longan_nano-pinctrl.dtsi"
+#include "longan_nano-common.dtsi"
 
 / {
 	model = "Sipeed Longan Nano Lite";
 	compatible = "sipeed,longan_nano_lite";
-
-	chosen {
-		zephyr,console = &usart0;
-		zephyr,shell-uart = &usart0;
-		zephyr,sram = &sram0;
-		zephyr,flash = &flash0;
-	};
-};
-
-&usart0 {
-	status = "okay";
-	current-speed = <115200>;
-	pinctrl-0 = <&usart0_default>;
-	pinctrl-names = "default";
-};
-
-&dac {
-	status = "okay";
-	pinctrl-0 = <&dac_default>;
-	pinctrl-names = "default";
 };


### PR DESCRIPTION
Add configuration to support onboard LED and button.

- LED_R: PC13 (active low/output)
- LED_G: PA1  (active low/output)
- LED_B: PA2  (active low/output)
- BOOT0: PA8  (active high/input)

And enable timer1 to control LED_G and LED_B with PWM.

Signed-off-by: TOKITA Hiroshi <tokita.hiroshi@gmail.com>