### PR TITLE
subsys: l2: Properly terminate LCP state at modem side when closing down

### DIFF
--- a/subsys/net/l2/ppp/lcp.c
+++ b/subsys/net/l2/ppp/lcp.c
@@ -206,6 +206,11 @@ static void lcp_finished(struct ppp_fsm *fsm)
 					       lcp.fsm);
 
 	ppp_link_terminated(ctx);
+
+	/* take the remainder down */
+	ppp_mgmt_raise_carrier_off_event(ctx->iface);
+
+	net_if_carrier_down(ctx->iface);
 }
 
 #if defined(CONFIG_NET_L2_PPP_OPTION_MRU)


### PR DESCRIPTION
Takes the modem state machine by calling lcp_close instead of lcp_down
Using this method the LCP layer sends a TERMINATE_REQ to the modem and the
network interface is only taken down when the LCP layer has properly finished.
Moved the ppp_mgmt_raise_carrier_off_event and net_if_carrier_down
to lcp.c to avoid breaking the interface.
Tested on a real modem.

Fixes: zephyrproject-rtos#41627

Signed-off-by: Sjors Hettinga <s.a.hettinga@gmail.com>