### PR TITLE
tests: lib: ring_buffer: Increase timeot

### DIFF
--- a/tests/lib/ringbuffer/testcase.yaml
+++ b/tests/lib/ringbuffer/testcase.yaml
@@ -1,5 +1,6 @@
 common:
     tags: ring_buffer circular_buffer
+    timeout: 90
 
 tests:
   libraries.ring_buffer:


### PR DESCRIPTION
The tests from tests/lib/ringbuffer fails on all nrf platforms due
to a timeout. Increasing the timeout value solves the issue.

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>