### PR TITLE
dts: bindings: timer: Correct compatible name of riscv,machine-timer

### DIFF
--- a/dts/bindings/timer/riscv,machine-timer.yaml
+++ b/dts/bindings/timer/riscv,machine-timer.yaml
@@ -3,7 +3,7 @@
 
 description: RISC-V Machine timer
 
-compatible: "nuclei,machine-timer"
+compatible: "riscv,machine-timer"
 
 include: base.yaml
 


### PR DESCRIPTION
dts/bindings/timer/riscv,machine-timer must have compatible name  riscv,machine-timer. nuclei,machine-timer is wrong, correct it.

Due to the wrong compatible name, the properties defined in riscv,machine-timer not applied.
At this time, only affect GD32VF103 SoC using this dts node.