### PR TITLE
timer: hpet: make legacy interrupt routing optional

### DIFF
--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -435,14 +435,19 @@ static int sys_clock_driver_init(const struct device *dev)
 	cyc_per_tick = hz / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
 #endif
 
+	reg = hpet_gconf_get();
+	reg |= GCONF_ENABLE;
+
+#if (DT_INST_PROP(0, no_legacy_irq) == 0)
 	/* Note: we set the legacy routing bit, because otherwise
 	 * nothing in Zephyr disables the PIT which then fires
 	 * interrupts into the same IRQ.  But that means we're then
 	 * forced to use IRQ2 contra the way the kconfig IRQ selection
 	 * is supposed to work.  Should fix this.
 	 */
-	reg = hpet_gconf_get();
-	reg |= GCONF_LR | GCONF_ENABLE;
+	reg |= GCONF_LR;
+#endif
+
 	hpet_gconf_set(reg);
 
 	last_count = hpet_counter_get();

--- a/dts/bindings/timer/intel,hpet.yaml
+++ b/dts/bindings/timer/intel,hpet.yaml
@@ -13,3 +13,8 @@ properties:
 
     interrupts:
       required: true
+
+    no-legacy-irq:
+      type: boolean
+      required: false
+      description: Do not set legacy IRQ bit


### PR DESCRIPTION
On some platforms, HPET is not wired to trigger IRQ 2.
This would make HPET non-functional if the legacy
interrupt routing bit is set in the global config
register. This adds a DTS flag so the driver won't
set the bit to enable legacy interrupt.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>