### PR TITLE
soc/intel_adsp: flush output data after writing to stdout

### DIFF
--- a/boards/xtensa/intel_adsp_cavs15/tools/adsplog.py
+++ b/boards/xtensa/intel_adsp_cavs15/tools/adsplog.py
@@ -102,3 +102,4 @@ while True:
     (last_seq, output) = winstream_read(last_seq)
     if output:
         sys.stdout.write(output)
+        sys.stdout.flush()


### PR DESCRIPTION
twister waits for the output of adsplog.py, test cases will be
labled "timeout" if there is no output received.

Signed-off-by: Meng xianglin <xianglinx.meng@intel.com>