### PR TITLE
testsuite: ztress: multi-cpu case fixed

### DIFF
--- a/subsys/testsuite/ztest/src/ztress.c
+++ b/subsys/testsuite/ztest/src/ztress.c
@@ -353,15 +353,16 @@ int ztress_execute(struct ztress_context_data *timer_data,
 		tids[i] = k_thread_create(&threads[i], stacks[i], CONFIG_ZTRESS_STACK_SIZE,
 					  ztress_thread,
 					  &thread_data[i], (void *)(uintptr_t)ztress_prio, NULL,
-					  priority, 0, K_NO_WAIT);
+					  priority, 0, K_MSEC(10));
 		(void)k_thread_name_set(tids[i], thread_names[i]);
 		priority++;
 		ztress_prio++;
 	}
 
 	if (timer_data != NULL) {
-		k_timer_start(&ztress_timer, backoff[0], K_NO_WAIT);
+		k_timer_start(&ztress_timer, K_MSEC(10), K_NO_WAIT);
 	}
+
 
 	/* Wait until all threads complete. */
 	for (int i = 0; i < cnt; i++) {

--- a/tests/lib/ringbuffer/testcase.yaml
+++ b/tests/lib/ringbuffer/testcase.yaml
@@ -7,13 +7,10 @@ tests:
     integration_platforms:
       - native_posix
       - native_posix_64
-    extra_configs:
-      - CONFIG_MP_NUM_CPUS=1
 
   libraries.ring_buffer_concurrent:
     platform_allow: qemu_x86
     extra_configs:
       - CONFIG_SYS_CLOCK_TICKS_PER_SEC=100000
-      - CONFIG_MP_NUM_CPUS=1
     integration_platforms:
       - qemu_x86

--- a/tests/ztest/ztress/src/main.c
+++ b/tests/ztest/ztress/src/main.c
@@ -29,8 +29,9 @@ static void test_timeout(void)
 	uint32_t repeat = 1000000;
 	k_timeout_t t = Z_TIMEOUT_TICKS(20);
 	int err;
+	int timeout = 1000;
 
-	ztress_set_timeout(K_MSEC(1000));
+	ztress_set_timeout(K_MSEC(timeout));
 
 	d = k_uptime_get();
 
@@ -52,7 +53,7 @@ static void test_timeout(void)
 	d = k_uptime_get();
 	err = ztress_execute(&timer_data, thread_data, ARRAY_SIZE(thread_data));
 	d = k_uptime_get() - d;
-	zassert_within(d, 1000, 200, NULL);
+	zassert_within(d, timeout + 500, 500, NULL);
 
 	ztress_set_timeout(K_NO_WAIT);
 }

--- a/tests/ztest/ztress/testcase.yaml
+++ b/tests/ztest/ztress/testcase.yaml
@@ -3,9 +3,5 @@ common:
   filter: CONFIG_QEMU_TARGET
 tests:
   testing.ztest.ztress:
-    extra_configs:
-      - CONFIG_MP_NUM_CPUS=1
     integration_platforms:
       - qemu_x86
-    #FIXME Fails for unknown reason #41710
-    platform_exclude: qemu_cortex_a9


### PR DESCRIPTION
testsuite: ztress: Make cpu load calculation multi-cpu ready
    
Use idle threads on all cores for cpu load calculation.

Additionally, minor tweaks which fixes tests for multi-cpu and qemu_cortex_a9. Removing limitations from tests.

Fixes #41710.