### PR TITLE
drivers: flash: Eliminate warning when compiling with GCC

### DIFF
--- a/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
+++ b/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
@@ -236,7 +236,7 @@ static int flash_flexspi_nor_erase_sector(const struct device *dev,
 		.dataSize = 0,
 	};
 
-	LOG_DBG("Erasing sector at 0x%08x", offset);
+	LOG_DBG("Erasing sector at 0x%08zx", (ssize_t) offset);
 
 	return memc_flexspi_transfer(data->controller, &transfer);
 }
@@ -277,7 +277,7 @@ static int flash_flexspi_nor_page_program(const struct device *dev,
 		.dataSize = len,
 	};
 
-	LOG_DBG("Page programming %d bytes to 0x%08x", len, offset);
+	LOG_DBG("Page programming %d bytes to 0x%08zx", len, (ssize_t) offset);
 
 	return memc_flexspi_transfer(data->controller, &transfer);
 }


### PR DESCRIPTION
Address the issue mentioned in zephyrproject-rtos#7412

Using `printf()` with `"%x"` to print an `off_t` value produces the following warning:
```
format '%x' expects 'unsigned int', argument has type 'long int'
  228 |  LOG_DBG("Erasing sector at 0x%08x", offset);
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~
      |                                      |
      |                                      off_t {aka long int}
```
In newlib `off_t` is `long`. Even though both `int` and `long` are 4 bytes wide in the architecture in use, GCC wants to see `"%lx"` to `printf()` a `long`. Using `"%"PRIx32` still produces the same warning because `PRIx32` (from inttypes.h) still expands to simply an `"x"` and not `"lx"`.

PR zephyrproject-rtos#40004 has solved this by casting offset to `ssize_t`. The same solution is emulated here.


Signed-off-by: [Milind Paranjpe](mailto:milind@whisper.ai)