### PR TITLE
boards: qemu_x86_tiny: pin logging subsys code and data

### DIFF
--- a/boards/x86/qemu_x86/qemu_x86_tiny.ld
+++ b/boards/x86/qemu_x86/qemu_x86_tiny.ld
@@ -228,6 +228,13 @@ MEMORY
 	*(.text.sys_memcpy_swap)					\
 	*(.text.z_*)
 
+/* For logging subsys */
+#define LIB_SUBSYS_LOGGING_IN_SECT(lsect)				\
+	*log_*.c.obj(.##lsect)						\
+	*log_*.c.obj(.##lsect.*)					\
+	*mpsc_pbuf.c.obj(.##lsect)					\
+	*mpsc_pbuf.c.obj(.##lsect.*)
+
 epoint = Z_MEM_PHYS_ADDR(CONFIG_KERNEL_ENTRY);
 ENTRY(epoint)
 
@@ -363,6 +370,7 @@ SECTIONS
 		LIB_ZEPHYR_IN_SECT(text)
 		LIB_C_IN_SECT(text)
 		LIB_DRIVERS_IN_SECT(text)
+		LIB_SUBSYS_LOGGING_IN_SECT(text)
 
 		*_divdi3.o(.text)
 		*_udivdi3.o(.text)
@@ -409,6 +417,7 @@ SECTIONS
 		LIB_ZEPHYR_IN_SECT(rodata)
 		LIB_C_IN_SECT(rodata)
 		LIB_DRIVERS_IN_SECT(rodata)
+		LIB_SUBSYS_LOGGING_IN_SECT(rodata)
 
 		/* Static strings */
 		*(.rodata.str*.*)
@@ -448,6 +457,7 @@ SECTIONS
 		LIB_ZEPHYR_IN_SECT(data)
 		LIB_C_IN_SECT(data)
 		LIB_DRIVERS_IN_SECT(data)
+		LIB_SUBSYS_LOGGING_IN_SECT(data)
 
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
@@ -472,6 +482,7 @@ SECTIONS
 		LIB_ZEPHYR_IN_SECT(bss)
 		LIB_C_IN_SECT(bss)
 		LIB_DRIVERS_IN_SECT(bss)
+		LIB_SUBSYS_LOGGING_IN_SECT(bss)
 
 		lnkr_pinned_bss_end = .;
 	} GROUP_NOLOAD_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
@@ -499,6 +510,7 @@ SECTIONS
 		LIB_ZEPHYR_IN_SECT(noinit)
 		LIB_C_IN_SECT(noinit)
 		LIB_DRIVERS_IN_SECT(noinit)
+		LIB_SUBSYS_LOGGING_IN_SECT(noinit)
 
 #ifdef CONFIG_ZTEST
 		/* For tests/kernel/mem_slab/ tests */

--- a/scripts/logging/dictionary/database_gen.py
+++ b/scripts/logging/dictionary/database_gen.py
@@ -32,7 +32,12 @@ logger = logging.getLogger(os.path.basename(sys.argv[0]))
 
 
 # Sections that contains static strings
-STATIC_STRING_SECTIONS = ['rodata', '.rodata', 'log_strings_sections']
+STATIC_STRING_SECTIONS = [
+    'rodata',
+    '.rodata',
+    'pinned.rodata',
+    'log_strings_sections'
+]
 
 
 def parse_args():

--- a/scripts/logging/dictionary/dictionary_parser/log_parser_v1.py
+++ b/scripts/logging/dictionary/dictionary_parser/log_parser_v1.py
@@ -195,7 +195,10 @@ class LogParserV1(LogParser):
             str_idx = arg_offset + self.data_types.get_sizeof(DataTypes.PTR) * 2
             str_idx /= self.data_types.get_sizeof(DataTypes.INT)
 
-            ret = string_tbl[int(str_idx)]
+            if int(str_idx) not in string_tbl:
+                ret = "<string@0x{0:x}>".format(arg)
+            else:
+                ret = string_tbl[int(str_idx)]
 
         return ret
 


### PR DESCRIPTION
This pins the logging subsys code and data so logging can be
used with demand paging.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>