### PR TITLE
I2C Bus idle fixes for SAM0

### DIFF
--- a/drivers/i2c/i2c_sam0.c
+++ b/drivers/i2c/i2c_sam0.c
@@ -481,6 +481,9 @@ static int i2c_sam0_transfer(const struct device *dev, struct i2c_msg *msgs,
 		k_sem_take(&data->sem, K_FOREVER);
 
 		if (data->msg.status) {
+			/* return the bus to idle */
+			i2c->CTRLB.bit.CMD = 3;
+
 			if (data->msg.status & SERCOM_I2CM_STATUS_ARBLOST) {
 				LOG_DBG("Arbitration lost on %s",
 					DEV_NAME(dev));


### PR DESCRIPTION
When working with a SAML21, I observed unexpected behaviour for the SAM0 I2C driver:

- The bus fails to return to idle after a read
- The bus fails to return to idle after an unacknowledged write
- The bus fails to return to idle after an error (e.g: unacknowledged address)

These patches resolve these issues. Confirmation that this also affects (and resolves the issue) for other SOCs would be appreciated.