### PR TITLE
tests: pm_multicore: Avoid possible race condition

### DIFF
--- a/tests/subsys/pm/power_mgmt_multicore/src/main.c
+++ b/tests/subsys/pm/power_mgmt_multicore/src/main.c
@@ -79,7 +79,7 @@ const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int ticks)
 		}
 	}
 
-	state_testing[_current_cpu->id] = info.state;
+	state_testing[cpu] = info.state;
 
 	return &info;
 }


### PR DESCRIPTION
Use the given cpu argument in the policy callback to
avoid possible race condition.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>