### PR TITLE
boards: arm: arduino_nano_33_ble: Add green and blue leds to the dts

### DIFF
--- a/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble.dts
+++ b/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble.dts
@@ -27,11 +27,21 @@
 			gpios = <&gpio0 24 0>;
 			label = "Red LED";
 		};
+		led1: led_1 {
+			gpios = <&gpio0 16 0>;
+			label = "Green LED";
+		};
+		led2: led_2 {
+			gpios = <&gpio0 6 0>;
+			label = "Blue LED";
+		};
 	};
 
 	/* These aliases are provided for compatibility with samples */
 	aliases {
 		led0 = &led0;
+		led1 = &led1;
+		led2 = &led2;
 		spi = &spi2;
 	};
 };


### PR DESCRIPTION
This adds the green and blue leds to the dts of the
Arduino Nano 33 BLE board.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>