### PR TITLE
kernel: Reset switch_handler as late as possible

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -976,8 +976,17 @@ void *z_get_next_switch_handle(void *interrupted)
 			if (z_is_thread_queued(old_thread)) {
 				runq_add(old_thread);
 			}
+		} else {
+			/* Re-set the switch_handle here if we don't have to
+			 * context switch later (because old_thread ==
+			 * new_thread).
+			 *
+			 * In case of context switching the switch_handle will
+			 * be set later after the context is being swapped out
+			 * to unblock the wait_for_switch().
+			 */
+			old_thread->switch_handle = interrupted;
 		}
-		old_thread->switch_handle = interrupted;
 		ret = new_thread->switch_handle;
 		if (IS_ENABLED(CONFIG_SMP)) {
 			/* Active threads MUST have a null here */


### PR DESCRIPTION
This was a tentative fix for #40795 with the reproducer in https://github.com/carlocaione/zephyr/commit/c6cecbeee6c23b3183b5319e06afbafdc33de739.

### Very big note (DNM)
This is breaking `qemu_x86_64` (!!!) but at the same time all the tests for `qemu_cortex_a53_smp` (including the issue reproducer) are passing so I think there is a very fundamental difference in how the context switch is managed between the two architectures, even though they both use the `USE_SWITCH` flag.

So, I'm opening this issue to try to braindump some reasoning around the switching code and maybe trying to understand (hopefully with @andyross help) why this change is fixing something for A53 SMP but totally breaking the `qemu_x86_64`.

### The problem
When running the reproducer on the ARM64 + SMP the execution stops after a few seconds with random errors. What's happening is that when exiting from the exception handler (usually triggered by an IPI) the value for `SPSR` popped out from the saved context in https://github.com/zephyrproject-rtos/zephyr/blob/44462723f59ddcc0786af0b5406122476c2addf9/arch/arm64/core/vector_table.S#L223 contains rubbish, so upon return (`ERET`) we are jumping at a random place triggering the fault.

My theory is that the old thread being swapped out on a core after `z_get_next_switch_handle()` is being swapped in on a different core before the context has been correctly saved, causing the issue (my assumption, still to be proved, is that while the thread is being swapped out on one core, it is being picked up on a different core by `do_swap()` before the context is fully saved).

The condition used to synchronize the cores and mark a thread as being ready to be picked up on a different core is the `switch_handle != 0`. This is usually done, after the context has been fully saved, in the arch switch code, for example:

https://github.com/zephyrproject-rtos/zephyr/blob/44462723f59ddcc0786af0b5406122476c2addf9/arch/arm64/core/switch.S#L58-L63

But the `switch_handle` is also set in `z_get_next_switch_handle()` though in:

https://github.com/zephyrproject-rtos/zephyr/blob/44462723f59ddcc0786af0b5406122476c2addf9/kernel/sched.c#L980

this is probably done because when no other thread is ready to be swapped in (that is `old_thread` == `new_thread`) the `switch_handle` must be reset (because it is not going to be set in the context switching code). Please note that when `old_thread != new_thread`, the `switch_handle` is going to be set in both places: in `z_get_next_switch_handle()` but also in the arch context switching code.

This also means that at the end of the `z_get_next_switch_handle()` function https://github.com/zephyrproject-rtos/zephyr/blob/44462723f59ddcc0786af0b5406122476c2addf9/kernel/sched.c#L980-L987

the `old_thread` is in the ready queue and marked as being ready to be picked up by other cores waiting on `wait_for_switch()` even though the context has not swapped out and saved yet.

### The fix

The proposed fix is to leave only the arch-specific switching code to actually set the `switch_handle`, while leaving the set in `z_get_next_switch_handle()` only when the thread is not actually swapped out. This is done to be sure that when the `switch_handle` is set in the assembly switching code, we are 100% sure that all the context has been saved and the thread can be scheduled safely on a different core.

### Closing note

While this PR looks reasonable to me (I'm not a scheduler expert, so I'm pretty sure I'm missing something here) and this is apparently fixing the problem in #40795, this is breaking `qemu_x86_64`, so something is definitely wrong with this fix but I'm failing to see what.

