### PR TITLE
kernel: smp: change back the order of SMP thread and timer initialization

### DIFF
--- a/kernel/smp.c
+++ b/kernel/smp.c
@@ -84,9 +84,9 @@ static inline FUNC_NORETURN void smp_init_top(void *arg)
 {
 	struct k_thread dummy_thread;
 
-	smp_timer_init();
 	(void)atomic_set(&ready_flag, 1);
 	z_smp_thread_init(arg, &dummy_thread);
+	smp_timer_init();
 	z_swap_unlocked();
 
 	CODE_UNREACHABLE; /* LCOV_EXCL_LINE */


### PR DESCRIPTION
Commit 3457118 changed the sequence of z_smp_thread_init() and
smp_timer_init() in smp_init_top() subroutine, which initializes
other BPs. In some boards (up_squared, acrn_ehl_crb) it will fail to
work while SMP enabling. If the timer interrupt is enabled before the
first thread was initialized. Now change back to its original order.

Fixes #41835

Signed-off-by: Enjia Mai <enjia.mai@intel.com>