### PR TITLE
tests: drivers: can: stm32: filter out boards without st,stm32-can

### DIFF
--- a/tests/drivers/can/stm32/testcase.yaml
+++ b/tests/drivers/can/stm32/testcase.yaml
@@ -2,3 +2,4 @@ tests:
   drivers.can.stm32:
     tags: driver can
     depends_on: can
+    filter: dt_compat_enabled("st,stm32-can")


### PR DESCRIPTION
Filter out boards without st,stm32-can compatibles enabled in their devicetree in the stm32-specific CAN driver test.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>