### PR TITLE
shell: bt: set shell for commands

### DIFF
--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -2558,6 +2558,8 @@ static int cmd_bonds(const struct shell *sh, size_t argc, char *argv[])
 {
 	int bond_count = 0;
 
+	ctx_shell = sh;
+
 	shell_print(sh, "Bonded devices:");
 	bt_foreach_bond(selected_id, bond_info, &bond_count);
 	shell_print(sh, "Total %d", bond_count);
@@ -2617,6 +2619,8 @@ static void connection_info(struct bt_conn *conn, void *user_data)
 static int cmd_connections(const struct shell *sh, size_t argc, char *argv[])
 {
 	int conn_count = 0;
+
+	ctx_shell = sh;
 
 	shell_print(sh, "Connected devices:");
 	bt_conn_foreach(BT_CONN_TYPE_ALL, connection_info, &conn_count);


### PR DESCRIPTION
bt shell uses a global pointer to a shell. That pointer becomes
valid after running cmd_init (bt init). That's a problem for
bt bonds and bt connections which depend on that global pointer
to be set. Without setting it these commands crash the MCU.

Maybe a bigger overhaul of this module is necessary to avoid problems like this one.

More about how this bug works was described here: https://github.com/zephyrproject-rtos/zephyr/issues/41796