### PR TITLE
drivers: can: unify TX behaviour

### DIFF
--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -316,6 +316,30 @@ static int mcux_get_tx_alloc(struct mcux_flexcan_data *data)
 	return alloc >= MCUX_FLEXCAN_MAX_TX ? -1 : alloc;
 }
 
+static enum can_state mcux_flexcan_get_state(const struct device *dev,
+					     struct can_bus_err_cnt *err_cnt)
+{
+	const struct mcux_flexcan_config *config = dev->config;
+	uint64_t status_flags;
+
+	if (err_cnt != NULL) {
+		FLEXCAN_GetBusErrCount(config->base, &err_cnt->tx_err_cnt,
+				       &err_cnt->rx_err_cnt);
+	}
+
+	status_flags = FLEXCAN_GetStatusFlags(config->base);
+
+	if ((status_flags & CAN_ESR1_FLTCONF(2)) != 0U) {
+		return CAN_BUS_OFF;
+	}
+
+	if ((status_flags & CAN_ESR1_FLTCONF(1)) != 0U) {
+		return CAN_ERROR_PASSIVE;
+	}
+
+	return CAN_ERROR_ACTIVE;
+}
+
 static int mcux_flexcan_send(const struct device *dev,
 			     const struct zcan_frame *frame,
 			     k_timeout_t timeout,
@@ -330,6 +354,11 @@ static int mcux_flexcan_send(const struct device *dev,
 	if (frame->dlc > CAN_MAX_DLC) {
 		LOG_ERR("DLC of %d exceeds maximum (%d)", frame->dlc, CAN_MAX_DLC);
 		return -EINVAL;
+	}
+
+	if (mcux_flexcan_get_state(dev, NULL) == CAN_BUS_OFF) {
+		LOG_DBG("Transmit failed, bus-off");
+		return -ENETDOWN;
 	}
 
 	while (true) {
@@ -433,31 +462,6 @@ static void mcux_flexcan_set_state_change_callback(const struct device *dev,
 	data->state_change_cb_data = user_data;
 }
 
-static enum can_state mcux_flexcan_get_state(const struct device *dev,
-					     struct can_bus_err_cnt *err_cnt)
-{
-	const struct mcux_flexcan_config *config = dev->config;
-	uint32_t status_flags;
-
-	if (err_cnt) {
-		FLEXCAN_GetBusErrCount(config->base, &err_cnt->tx_err_cnt,
-				       &err_cnt->rx_err_cnt);
-	}
-
-	status_flags = (FLEXCAN_GetStatusFlags(config->base) &
-			CAN_ESR1_FLTCONF_MASK) << CAN_ESR1_FLTCONF_SHIFT;
-
-	if (status_flags & 0x02) {
-		return CAN_BUS_OFF;
-	}
-
-	if (status_flags & 0x01) {
-		return CAN_ERROR_PASSIVE;
-	}
-
-	return CAN_ERROR_ACTIVE;
-}
-
 #ifndef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY
 int mcux_flexcan_recover(const struct device *dev, k_timeout_t timeout)
 {
@@ -522,76 +526,60 @@ static inline void mcux_flexcan_transfer_error_status(const struct device *dev,
 	struct mcux_flexcan_data *data = dev->data;
 	const can_state_change_callback_t cb = data->state_change_cb;
 	void *cb_data = data->state_change_cb_data;
-
 	can_tx_callback_t function;
-	int status = 0;
 	void *arg;
 	int alloc;
 	enum can_state state;
 	struct can_bus_err_cnt err_cnt;
 
-	if (error & CAN_ESR1_FLTCONF(2)) {
-		LOG_DBG("Tx bus off (error 0x%08llx)", error);
-		status = -ENETDOWN;
-	} else if ((error & kFLEXCAN_Bit0Error) ||
-		   (error & kFLEXCAN_Bit1Error)) {
-		LOG_DBG("TX arbitration lost (error 0x%08llx)", error);
-		status = -EBUSY;
-	} else if (error & kFLEXCAN_AckError) {
-		LOG_DBG("TX no ACK received (error 0x%08llx)", error);
-		status = -EIO;
-	} else if (error & kFLEXCAN_StuffingError) {
-		LOG_DBG("RX stuffing error (error 0x%08llx)", error);
-	} else if (error & kFLEXCAN_FormError) {
-		LOG_DBG("RX form error (error 0x%08llx)", error);
-	} else if (error & kFLEXCAN_CrcError) {
-		LOG_DBG("RX CRC error (error 0x%08llx)", error);
-	} else {
-		LOG_DBG("Unhandled error (error 0x%08llx)", error);
+	if ((error & (kFLEXCAN_Bit0Error & kFLEXCAN_Bit1Error)) != 0U) {
+		LOG_DBG("TX arbitration lost (error 0x%016llx)", error);
+	}
+
+	if ((error & kFLEXCAN_AckError) != 0U) {
+		LOG_DBG("TX no ACK received (error 0x%016llx)", error);
+	}
+
+	if ((error & kFLEXCAN_StuffingError) != 0U) {
+		LOG_DBG("RX stuffing error (error 0x%016llx)", error);
+	}
+
+	if ((error & kFLEXCAN_FormError) != 0U) {
+		LOG_DBG("RX form error (error 0x%016llx)", error);
+	}
+
+	if ((error & kFLEXCAN_CrcError) != 0U) {
+		LOG_DBG("RX CRC error (error 0x%016llx)", error);
 	}
 
 	state = mcux_flexcan_get_state(dev, &err_cnt);
 	if (data->state != state) {
 		data->state = state;
 
-		if (cb) {
+		if (cb != NULL) {
 			cb(state, err_cnt, cb_data);
 		}
 	}
 
-	if (status == 0) {
-		/*
-		 * Error/status is not TX related. No further action
-		 * required.
-		 */
-		return;
-	}
+	if (state == CAN_BUS_OFF) {
+		/* Abort any pending TX frames in case of bus-off */
+		for (alloc = 0; alloc < MCUX_FLEXCAN_MAX_TX; alloc++) {
+			/* Copy callback function and argument before clearing bit */
+			function = data->tx_cbs[alloc].function;
+			arg = data->tx_cbs[alloc].arg;
 
-	/*
-	 * Since the FlexCAN module ESR1 register accumulates errors
-	 * and warnings across multiple transmitted frames (until the
-	 * CPU reads the register) it is not possible to find out
-	 * which transfer caused the error/warning.
-	 *
-	 * We therefore propagate the error/warning to all currently
-	 * active transmitters.
-	 */
-	for (alloc = 0; alloc < MCUX_FLEXCAN_MAX_TX; alloc++) {
-		/* Copy callback function and argument before clearing bit */
-		function = data->tx_cbs[alloc].function;
-		arg = data->tx_cbs[alloc].arg;
+			if (atomic_test_and_clear_bit(data->tx_allocs, alloc)) {
+				FLEXCAN_TransferAbortSend(config->base, &data->handle,
+							  ALLOC_IDX_TO_TXMB_IDX(alloc));
+				if (function != NULL) {
+					function(-ENETDOWN, arg);
+				} else {
+					data->tx_cbs[alloc].status = -ENETDOWN;
+					k_sem_give(&data->tx_cbs[alloc].done);
+				}
 
-		if (atomic_test_and_clear_bit(data->tx_allocs, alloc)) {
-			FLEXCAN_TransferAbortSend(config->base, &data->handle,
-						  ALLOC_IDX_TO_TXMB_IDX(alloc));
-			if (function != NULL) {
-				function(status, arg);
-			} else {
-				data->tx_cbs[alloc].status = status;
-				k_sem_give(&data->tx_cbs[alloc].done);
+				k_sem_give(&data->tx_allocs_sem);
 			}
-
-			k_sem_give(&data->tx_allocs_sem);
 		}
 	}
 }
@@ -660,28 +648,37 @@ static inline void mcux_flexcan_transfer_rx_idle(const struct device *dev,
 static FLEXCAN_CALLBACK(mcux_flexcan_transfer_callback)
 {
 	struct mcux_flexcan_data *data = (struct mcux_flexcan_data *)userData;
+	/*
+	 * The result field can either be a MB index (which is limited to 32 bit
+	 * value) or a status flags value, which is 32 bit on some platforms but
+	 * 64 on others. To decouple the remaining functions from this, the
+	 * result field is always promoted to uint64_t.
+	 */
+	uint32_t mb = (uint32_t)result;
+	uint64_t status_flags = result;
+
+	ARG_UNUSED(base);
 
 	switch (status) {
 	case kStatus_FLEXCAN_UnHandled:
+		/* Not all fault confinement state changes are handled by the HAL */
 		__fallthrough;
 	case kStatus_FLEXCAN_ErrorStatus:
-		mcux_flexcan_transfer_error_status(data->dev, (uint64_t)result);
+		mcux_flexcan_transfer_error_status(data->dev, status_flags);
 		break;
 	case kStatus_FLEXCAN_TxSwitchToRx:
 		__fallthrough;
 	case kStatus_FLEXCAN_TxIdle:
-		/* The result field is a MB value which is limited to 32bit value */
-		mcux_flexcan_transfer_tx_idle(data->dev, (uint32_t)result);
+		mcux_flexcan_transfer_tx_idle(data->dev, mb);
 		break;
 	case kStatus_FLEXCAN_RxOverflow:
 		__fallthrough;
 	case kStatus_FLEXCAN_RxIdle:
-		/* The result field is a MB value which is limited to 32bit value */
-		mcux_flexcan_transfer_rx_idle(data->dev, (uint32_t)result);
+		mcux_flexcan_transfer_rx_idle(data->dev, mb);
 		break;
 	default:
-		LOG_WRN("Unhandled error/status (status 0x%08x, "
-			 "result = 0x%08llx", status, (uint64_t)result);
+		LOG_WRN("Unhandled status 0x%08x (result = 0x%016llx)",
+			status, status_flags);
 	}
 }
 

--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -489,6 +489,10 @@ static int can_stm32_init(const struct device *dev)
 #ifdef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY
 	can->MCR |= CAN_MCR_ABOM;
 #endif
+	if (cfg->one_shot) {
+		can->MCR |= CAN_MCR_NART;
+	}
+
 	timing.sjw = cfg->sjw;
 	if (cfg->sample_point && USE_SP_ALGO) {
 		ret = can_calc_timing(dev, &timing, cfg->bus_speed,
@@ -1148,6 +1152,7 @@ static const struct can_stm32_config can_stm32_cfg_1 = {
 	.prop_ts1 = DT_PROP_OR(DT_NODELABEL(can1), prop_seg, 0) +
 		    DT_PROP_OR(DT_NODELABEL(can1), phase_seg1, 0),
 	.ts2 = DT_PROP_OR(DT_NODELABEL(can1), phase_seg2, 0),
+	.one_shot = DT_PROP(DT_NODELABEL(can1), one_shot),
 	.pclken = {
 		.enr = DT_CLOCKS_CELL(DT_NODELABEL(can1), bits),
 		.bus = DT_CLOCKS_CELL(DT_NODELABEL(can1), bus),
@@ -1245,6 +1250,7 @@ static const struct can_stm32_config can_stm32_cfg_2 = {
 	.prop_ts1 = DT_PROP_OR(DT_NODELABEL(can2), prop_seg, 0) +
 		    DT_PROP_OR(DT_NODELABEL(can2), phase_seg1, 0),
 	.ts2 = DT_PROP_OR(DT_NODELABEL(can2), phase_seg2, 0),
+	.one_shot = DT_PROP(DT_NODELABEL(can2), one_shot),
 	.pclken = {
 		.enr = DT_CLOCKS_CELL(DT_NODELABEL(can2), bits),
 		.bus = DT_CLOCKS_CELL(DT_NODELABEL(can2), bus),

--- a/drivers/can/can_stm32.h
+++ b/drivers/can/can_stm32.h
@@ -76,6 +76,7 @@ struct can_stm32_config {
 	uint8_t sjw;
 	uint8_t prop_ts1;
 	uint8_t ts2;
+	bool one_shot;
 	struct stm32_pclken pclken;
 	void (*config_irq)(CAN_TypeDef *can);
 	const struct pinctrl_dev_config *pcfg;

--- a/dts/bindings/can/st,stm32-can.yaml
+++ b/dts/bindings/can/st,stm32-can.yaml
@@ -20,6 +20,14 @@ properties:
     pinctrl-names:
       required: true
 
+    one-shot:
+      type: boolean
+      required: false
+      description: |
+        Disable automatic retransmissions. A CAN frame will only be transmitted
+        once, independently of the transmission result (successful, error, or
+        arbitration lost).
+
     master-can-reg:
       type: int
       required: false

--- a/include/drivers/can.h
+++ b/include/drivers/can.h
@@ -599,8 +599,13 @@ static inline int can_set_bitrate(const struct device *dev,
 /**
  * @brief Transmit a CAN frame on the CAN bus
  *
- * Transmit a CAN fram on the CAN bus with optional timeout and completion
+ * Transmit a CAN frame on the CAN bus with optional timeout and completion
  * callback function.
+ *
+ * By default, the CAN controller will automatically retry transmission in case
+ * of lost bus arbitration or missing acknowledge. Some CAN controllers support
+ * disabling automatic retransmissions ("one-shot" mode) via a devicetree
+ * property.
  *
  * @see can_write() for a simplified API wrapper.
  *
@@ -616,8 +621,10 @@ static inline int can_set_bitrate(const struct device *dev,
  * @retval 0 if successful.
  * @retval -EINVAL if an invalid parameter was passed to the function.
  * @retval -ENETDOWN if the CAN controller is in bus-off state.
- * @retval -EBUSY if CAN bus arbitration was lost.
- * @retval -EIO if a general transmit error occurred.
+ * @retval -EBUSY if CAN bus arbitration was lost (only applicable if automatic
+ *                retransmissions are disabled).
+ * @retval -EIO if a general transmit error occurred (e.g. missing ACK if
+ *              automatic retransmissions are disabled).
  * @retval -EAGAIN on timeout.
  */
 __syscall int can_send(const struct device *dev, const struct zcan_frame *frame,
@@ -640,6 +647,11 @@ static inline int z_impl_can_send(const struct device *dev, const struct zcan_fr
  * @a zcan_frame struct. This function blocks until the data is sent or a
  * timeout occurs.
  *
+ * By default, the CAN controller will automatically retry transmission in case
+ * of lost bus arbitration or missing acknowledge. Some CAN controllers support
+ * disabling automatic retransmissions ("one-shot" mode) via a devicetree
+ * property.
+ *
  * @param dev     Pointer to the device structure for the driver instance.
  * @param data    Pointer to the data to write.
  * @param length  Number of bytes to write (max. 8).
@@ -650,8 +662,10 @@ static inline int z_impl_can_send(const struct device *dev, const struct zcan_fr
  * @retval 0 if successful.
  * @retval -EINVAL if an invalid parameter was passed to the function.
  * @retval -ENETDOWN if the CAN controller is in bus-off state.
- * @retval -EBUSY if CAN bus arbitration was lost.
- * @retval -EIO if a general transmit error occurred.
+ * @retval -EBUSY if CAN bus arbitration was lost (only applicable if automatic
+ *                retransmissions are disabled).
+ * @retval -EIO if a general transmit error occurred (e.g. missing ACK if
+ *              automatic retransmissions are disabled).
  * @retval -EAGAIN on timeout.
  */
 static inline int can_write(const struct device *dev, const uint8_t *data, uint8_t length,


### PR DESCRIPTION
Unify the TX behaviour of the current CAN drivers:
- Document the expected driver behavior for can_send()/can_write() when loosing bus arbitration or when a frame is not acknowledged.
- Add support for disabling automatic retransmission of CAN frames in the STM32 CAN driver (similar to CAN "one-shot" mode in the Linux kernel. This is added mostly to have an in-tree example of how this feature can be enabled on some CAN controllers. In the Linux kernel, one-shot mode also requires hardware support)
- Rework the transmit error handling in the NXP MCUX FlexCAN driver:
    - Frame transmission must be automatically retried in case of lost arbitration or missing acknowledge.
    - Abort any pending TX frames when bus-off state is entered.
    - Fail early in can_send() if in bus-off state.

These changes were verified on the `twr_ke18f`, `mimxrt1024_evk`, and `stm32f3_disco` boards.

Fixes: #19502