### PR TITLE
kernel: Reset the switch_handler only in the arch code

### DIFF
--- a/arch/arm64/core/isr_wrapper.S
+++ b/arch/arm64/core/isr_wrapper.S
@@ -119,9 +119,28 @@ spurious_continue:
 	 * x0: 1st thread in the ready queue
 	 * x1: _current thread
 	 */
+
+#ifdef CONFIG_SMP
+	/*
+	 * 2 possibilities here:
+	 *  - x0 != NULL (implies x0 != x1): we need to context switch and set
+	 *    the switch_handle in the context switch code
+	 *  - x0 == NULL: no context switch
+	 */
+	cmp	x0, #0x0
+	bne	switch
+
+	/*
+	 * No context switch. Restore x0 from x1 (they are the same thread).
+	 * See also comments to z_arch_get_next_switch_handle()
+	 */
+	mov	x0, x1
+	b	exit
+switch:
+#else
 	cmp	x0, x1
 	beq	exit
-
+#endif
 	/* Switch thread */
 	bl	z_arm64_context_switch
 


### PR DESCRIPTION
This PR follows the discussion at #40795 and is an ARM64-specific alternative to #41840

For details refer to that ticket and issue, but bottom line is that for ARM64 we do not set the `switch_handler` when exiting from `z_get_next_switch_handle()` but only in the context switching code when the context has been already fully saved to avoid races on multiple cores.

Fixes: #40795 