### PR TITLE
drivers: can: mcan: remove unused NUM_TX_EVENT_FIFO_ELEMENTS macro

### DIFF
--- a/drivers/can/can_mcan.h
+++ b/drivers/can/can_mcan.h
@@ -19,10 +19,7 @@
 #define NUM_RX_FIFO0_ELEMENTS   DT_PROP(MCAN_DT_PATH, rx_fifo0_elements)
 #define NUM_RX_FIFO1_ELEMENTS   DT_PROP(MCAN_DT_PATH, rx_fifo0_elements)
 #define NUM_RX_BUF_ELEMENTS     DT_PROP(MCAN_DT_PATH, rx_buffer_elements)
-#define NUM_TX_EVENT_FIFO_ELEMENTS \
-				DT_PROP(MCAN_DT_PATH, tx_event_fifo_elements)
 #define NUM_TX_BUF_ELEMENTS     DT_PROP(MCAN_DT_PATH, tx_buffer_elements)
-
 
 #ifdef CONFIG_CAN_STM32FD
 #define NUM_STD_FILTER_DATA CONFIG_CAN_MAX_STD_ID_FILTER


### PR DESCRIPTION
Remove the unused `NUM_TX_EVENT_FIFO_ELEMENTS` helper macro. There is no dts property for setting the TX event FIFO size.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>