### PR TITLE
Sam0 adc fix

### DIFF
--- a/drivers/adc/adc_sam0.c
+++ b/drivers/adc/adc_sam0.c
@@ -392,7 +392,8 @@ static int start_read(const struct device *dev,
 
 	wait_synchronization(adc);
 
-	if (sequence->channels != 1U) {
+	if ((sequence->channels == 0) ||
+		((sequence->channels & (sequence->channels - 1)) != 0)) {
 		LOG_ERR("Channel scanning is not supported");
 		return -ENOTSUP;
 	}

--- a/samples/drivers/adc/boards/arduino_zero.overlay
+++ b/samples/drivers/adc/boards/arduino_zero.overlay
@@ -1,0 +1,16 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2022 Kim Bøndergaard <kim@fam-boendergaard.dk>
+ */
+
+/ {
+	zephyr,user {
+		/* J106.6 (A5) aka D21G18, pin PB02_AIN10 */
+		io-channels = <&adc 10>;
+	};
+};
+
+&adc {
+	status = "okay";
+};

--- a/samples/drivers/adc/src/main.c
+++ b/samples/drivers/adc/src/main.c
@@ -49,7 +49,11 @@ struct adc_channel_cfg channel_cfg = {
 	.acquisition_time = ADC_ACQUISITION_TIME,
 	/* channel ID will be overwritten below */
 	.channel_id = 0,
-	.differential = 0
+	.differential = 0,
+#ifdef CONFIG_ADC_CONFIGURABLE_INPUTS
+	.input_negative = 0,
+	.input_positive = 0,
+#endif
 };
 
 struct adc_sequence sequence = {
@@ -79,6 +83,9 @@ void main(void)
 #ifdef CONFIG_ADC_NRFX_SAADC
 		channel_cfg.input_positive = SAADC_CH_PSELP_PSELP_AnalogInput0
 					     + channel_ids[i];
+#endif
+#ifdef CONFIG_ADC_CONFIGURABLE_INPUTS
+		channel_cfg.input_positive = channel_ids[i];
 #endif
 
 		adc_channel_setup(dev_adc, &channel_cfg);


### PR DESCRIPTION
Make support for all samd21 adc channels. Before only channel 0 was supported.

example project drivers/adc enriched with overlay for arduino_zero.
Unfortunately I don't have access to this board and can't verify it my self.
I'm currently working on another board on which the fix has been verified, but it would be nice if someone could test it at arduino_zero