### PR TITLE
bluetooth: ots: notify application prior to object name change

### DIFF
--- a/include/bluetooth/services/ots.h
+++ b/include/bluetooth/services/ots.h
@@ -634,15 +634,16 @@ struct bt_ots_cb {
 	 *
 	 *  This callback is called when the object name is written.
 	 *  This is a notification to the application that the object name
-	 *  has been updated by the OTS service implementation.
+	 *  will be updated by the OTS service implementation.
 	 *
-	 *  @param ots    OTS instance.
-	 *  @param conn   The connection that wrote object name.
-	 *  @param id     Object ID.
-	 *  @param name   Object name.
+	 *  @param ots        OTS instance.
+	 *  @param conn       The connection that wrote object name.
+	 *  @param id         Object ID.
+	 *  @param cur_name   Current object name.
+	 *  @param new_name   New object name.
 	 */
 	void (*obj_name_written)(struct bt_ots *ots, struct bt_conn *conn,
-			     uint64_t id, const char *name);
+				 uint64_t id, const char *cur_name, const char *new_name);
 };
 
 /** @brief Descriptor for OTS initialization. */

--- a/samples/bluetooth/peripheral_ots/src/main.c
+++ b/samples/bluetooth/peripheral_ots/src/main.c
@@ -182,13 +182,15 @@ static ssize_t ots_obj_write(struct bt_ots *ots, struct bt_conn *conn,
 	return len;
 }
 
-void ots_obj_name_written(struct bt_ots *ots, struct bt_conn *conn, uint64_t id, const char *name)
+static void ots_obj_name_written(struct bt_ots *ots, struct bt_conn *conn,
+				 uint64_t id, const char *cur_name, const char *new_name)
 {
 	char id_str[BT_OTS_OBJ_ID_STR_LEN];
 
 	bt_ots_obj_id_to_str(id, id_str, sizeof(id_str));
 
-	printk("Name for object with %s ID has been written\n", id_str);
+	printk("Name for object with %s ID is being changed from '%s' to '%s'\n",
+		id_str, cur_name, new_name);
 }
 
 static struct bt_ots_cb ots_callbacks = {

--- a/subsys/bluetooth/services/ots/ots.c
+++ b/subsys/bluetooth/services/ots/ots.c
@@ -187,13 +187,13 @@ ssize_t ots_obj_name_write(struct bt_conn *conn,
 		rc = bt_gatt_ots_obj_manager_next_obj_get(ots->obj_manager, obj, &obj);
 	}
 
-	/* Update real object name after no duplicate detected */
-	strcpy(ots->cur_obj->metadata.name, name);
-
+	/* No duplicate detected, notify application and update real object name */
 	if (ots->cb->obj_name_written) {
 		ots->cb->obj_name_written(ots, conn, ots->cur_obj->id,
-					  ots->cur_obj->metadata.name);
+					  ots->cur_obj->metadata.name, name);
 	}
+
+	strcpy(ots->cur_obj->metadata.name, name);
 
 	return len;
 }


### PR DESCRIPTION
This change augments the application object name change notification to
occur prior to the actual name change done by the OTS layer.

Notifying prior to the actual name change makes it possible to inform the
application of the current name of the object as well as the new name.

Signed-off-by: Abe Kohandel <abe.kohandel@gmail.com>