### PR TITLE
Fix: Add the doxygen group of heap listener

### DIFF
--- a/doc/reference/kernel/memory/heap.rst
+++ b/doc/reference/kernel/memory/heap.rst
@@ -218,3 +218,8 @@ API Reference
 =============
 
 .. doxygengroup:: heap_apis
+
+Heap listener
+*************
+
+.. doxygengroup:: heap_listener_apis


### PR DESCRIPTION
Add the doxygen contents of heap listener which is missed.
We already have some apis of heap listener, but cannot be display
in our documents. So add the group to show in the doc.

After [#40370 ](https://github.com/zephyrproject-rtos/zephyr/pull/40370) was merged, the heap listener APIs not show in
our zephyr document.
Submit this PR for it.

Signed-off-by: Jian Kang <jianx.kang@intel.com>