### PR TITLE
tracing_user: Add ISR nest level parameter

### DIFF
--- a/doc/guides/debug_tools/tracing/index.rst
+++ b/doc/guides/debug_tools/tracing/index.rst
@@ -156,8 +156,8 @@ not be supported by the other tracing systems
 The following functions can be defined by the user:
 - ``void sys_trace_thread_switched_in_user(struct k_thread *thread)``
 - ``void sys_trace_thread_switched_out_user(struct k_thread *thread)``
-- ``void sys_trace_isr_enter_user()``
-- ``void sys_trace_isr_exit_user()``
+- ``void sys_trace_isr_enter_user(int nested_interrupts)``
+- ``void sys_trace_isr_exit_user(int nested_interrupts)``
 - ``void sys_trace_idle_user()``
 
 Enable this format with the :kconfig:`CONFIG_TRACING_USER` option.

--- a/samples/subsys/tracing/src/tracing_user.c
+++ b/samples/subsys/tracing/src/tracing_user.c
@@ -16,14 +16,14 @@ void sys_trace_thread_switched_out_user(struct k_thread *thread)
 	printk("%s: %p\n", __func__, thread);
 }
 
-void sys_trace_isr_enter_user(void)
+void sys_trace_isr_enter_user(int nested_interrupts)
 {
-	printk("%s\n", __func__);
+	printk("%s: %d\n", __func__, nested_interrupts);
 }
 
-void sys_trace_isr_exit_user(void)
+void sys_trace_isr_exit_user(int nested_interrupts)
 {
-	printk("%s\n", __func__);
+	printk("%s: %d\n", __func__, nested_interrupts);
 }
 
 void sys_trace_idle_user(void)

--- a/subsys/tracing/user/tracing_user.c
+++ b/subsys/tracing/user/tracing_user.c
@@ -6,22 +6,22 @@
 
 #include <tracing_user.h>
 #include <kernel_internal.h>
+#include <kernel_structs.h>
 #include <ksched.h>
 
-static int nested_interrupts;
+static int nested_interrupts[CONFIG_MP_NUM_CPUS];
 
 void __weak sys_trace_thread_switched_in_user(struct k_thread *thread) {}
 void __weak sys_trace_thread_switched_out_user(struct k_thread *thread) {}
-void __weak sys_trace_isr_enter_user(void) {}
-void __weak sys_trace_isr_exit_user(void) {}
+void __weak sys_trace_isr_enter_user(int nested_interrupts) {}
+void __weak sys_trace_isr_exit_user(int nested_interrupts) {}
 void __weak sys_trace_idle_user(void) {}
 
 void sys_trace_k_thread_switched_in(void)
 {
 	int key = irq_lock();
 
-	__ASSERT_NO_MSG(nested_interrupts == 0);
-
+	__ASSERT_NO_MSG(nested_interrupts[_current_cpu->id] == 0);
 	sys_trace_thread_switched_in_user(k_current_get());
 
 	irq_unlock(key);
@@ -31,8 +31,7 @@ void sys_trace_k_thread_switched_out(void)
 {
 	int key = irq_lock();
 
-	__ASSERT_NO_MSG(nested_interrupts == 0);
-
+	__ASSERT_NO_MSG(nested_interrupts[_current_cpu->id] == 0);
 	sys_trace_thread_switched_out_user(k_current_get());
 
 	irq_unlock(key);
@@ -41,22 +40,22 @@ void sys_trace_k_thread_switched_out(void)
 void sys_trace_isr_enter(void)
 {
 	int key = irq_lock();
+	_cpu_t *curr_cpu = _current_cpu;
 
-	if (nested_interrupts == 0) {
-		sys_trace_isr_enter_user();
-	}
-	nested_interrupts++;
+	sys_trace_isr_enter_user(nested_interrupts[curr_cpu->id]);
+	nested_interrupts[curr_cpu->id]++;
+
 	irq_unlock(key);
 }
 
 void sys_trace_isr_exit(void)
 {
 	int key = irq_lock();
+	_cpu_t *curr_cpu = _current_cpu;
 
-	nested_interrupts--;
-	if (nested_interrupts == 0) {
-		sys_trace_isr_exit_user();
-	}
+	nested_interrupts[curr_cpu->id]--;
+	sys_trace_isr_exit_user(nested_interrupts[curr_cpu->id]);
+
 	irq_unlock(key);
 }
 

--- a/subsys/tracing/user/tracing_user.h
+++ b/subsys/tracing/user/tracing_user.h
@@ -16,8 +16,8 @@ extern "C" {
 
 void sys_trace_thread_switched_in_user(struct k_thread *thread);
 void sys_trace_thread_switched_out_user(struct k_thread *thread);
-void sys_trace_isr_enter_user(void);
-void sys_trace_isr_exit_user(void);
+void sys_trace_isr_enter_user(int nested_interrupts);
+void sys_trace_isr_exit_user(int nested_interrupts);
 void sys_trace_idle_user(void);
 
 void sys_trace_k_thread_switched_in(void);


### PR DESCRIPTION
For tracing_user, the sys_trace_isr_enter() & sys_trace_isr_exit() block any nest interrupts & most SMP interrupts for the user. It is
hard to analyze the IRQ preemption(e.g., each IRQ counter and execution time). This commit adds ISR nest level for each CPU to the user instead of blocking user call back when nest interrupts.
