### PR TITLE
Bluetooth: Mesh: LPN terminate CB establish clause

### DIFF
--- a/subsys/bluetooth/mesh/lpn.c
+++ b/subsys/bluetooth/mesh/lpn.c
@@ -240,9 +240,11 @@ static void clear_friendship(bool force, bool disable)
 		lpn->old_friend = lpn->frnd;
 	}
 
-	STRUCT_SECTION_FOREACH(bt_mesh_lpn_cb, cb) {
-		if (cb->terminated && lpn->frnd != BT_MESH_ADDR_UNASSIGNED) {
-			cb->terminated(lpn->sub->net_idx, lpn->frnd);
+	if (lpn->established) {
+		STRUCT_SECTION_FOREACH(bt_mesh_lpn_cb, cb) {
+			if (cb->terminated) {
+				cb->terminated(lpn->sub->net_idx, lpn->frnd);
+			}
 		}
 	}
 

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_friendship.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_friendship.c
@@ -850,11 +850,33 @@ static void test_lpn_disable(void)
 	PASS();
 }
 
-#define TEST_CASE(role, name, description)                                                         \
-	{                                                                                          \
-		.test_id = "friendship_" #role "_" #name, .test_descr = description,               \
-		.test_post_init_f = test_##role##_init, .test_tick_f = bt_mesh_test_timeout,       \
-		.test_main_f = test_##role##_##name,                                               \
+/** LPN terminate cb test.
+ *
+ * Check that terminate cb is not triggered when there is no established
+ * connection.
+ */
+static void test_lpn_term_cb_check(void)
+{
+	bt_mesh_test_setup();
+
+	bt_mesh_lpn_set(true);
+	ASSERT_OK(evt_wait(LPN_POLLED, K_MSEC(1000)), "Friend never polled");
+	bt_mesh_lpn_set(false);
+
+	if (!evt_wait(LPN_TERMINATED, K_SECONDS(30))) {
+		FAIL("LPN terminate CB triggered unexpectedly");
+	}
+
+	PASS();
+}
+
+#define TEST_CASE(role, name, description)                  \
+	{                                                   \
+		.test_id = "friendship_" #role "_" #name,   \
+		.test_descr = description,                  \
+		.test_post_init_f = test_##role##_init,     \
+		.test_tick_f = bt_mesh_test_timeout,        \
+		.test_main_f = test_##role##_##name,        \
 	}
 
 static const struct bst_test_instance test_connect[] = {
@@ -874,6 +896,7 @@ static const struct bst_test_instance test_connect[] = {
 	TEST_CASE(lpn,    group,            "LPN: receive on group addrs"),
 	TEST_CASE(lpn,    loopback,         "LPN: send to loopback addrs"),
 	TEST_CASE(lpn,    disable,          "LPN: disable LPN"),
+	TEST_CASE(lpn,    term_cb_check,    "LPN: no terminate cb trigger"),
 
 	TEST_CASE(other,  msg,              "Other mesh device: message exchange"),
 	TEST_CASE(other,  group,            "Other mesh device: send to group addrs"),

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/tests_scripts/friendship/lpn_terminate_cb.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/tests_scripts/friendship/lpn_terminate_cb.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Copyright 2022 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
+
+# Check that the LPN terminate callback does not trigger when there is no established
+# connection.
+#
+# This covers a corner case scenario where the LPN has received a friend offer, but has
+# not yet established a connection. In this case the LPN terminate callback should not
+# be triggered if the LPN is disabled, which is monitored by this test.
+RunTest mesh_lpn_terminate_cb_check \
+	friendship_friend_est \
+	friendship_lpn_term_cb_check


### PR DESCRIPTION
Adds clause so that the LPN must have a established friend
connection for the connection terminate callback to trigger
upon clearing a friendship.

Also adds BabbleSim test covering this particular corner case.

Signed-off-by: Anders Storrø <anders.storro@nordicsemi.no>