### PR TITLE
soc: arm: stm32: activate LPTIM1 for STM32 H7 series

### DIFF
--- a/boards/arm/nucleo_h723zg/Kconfig.defconfig
+++ b/boards/arm/nucleo_h723zg/Kconfig.defconfig
@@ -15,4 +15,9 @@ config NET_L2_ETHERNET
 
 endif # NETWORKING
 
+choice STM32_LPTIM_CLOCK
+	default STM32_LPTIM_CLOCK_LSE
+	depends on STM32_LPTIM_TIMER
+endchoice
+
 endif # BOARD_NUCLEO_H723ZG

--- a/boards/arm/nucleo_h723zg/nucleo_h723zg.dts
+++ b/boards/arm/nucleo_h723zg/nucleo_h723zg.dts
@@ -72,6 +72,10 @@
 	status = "okay";
 };
 
+&lptim1 {
+	status = "okay";
+};
+
 &pll {
 	div-m = <4>;
 	mul-n = <275>;

--- a/boards/arm/nucleo_h723zg/nucleo_h723zg.dts
+++ b/boards/arm/nucleo_h723zg/nucleo_h723zg.dts
@@ -68,6 +68,10 @@
 	status = "okay";
 };
 
+&clk_lse {
+	status = "okay";
+};
+
 &pll {
 	div-m = <4>;
 	mul-n = <275>;

--- a/boards/arm/stm32h735g_disco/Kconfig.defconfig
+++ b/boards/arm/stm32h735g_disco/Kconfig.defconfig
@@ -12,5 +12,9 @@ config SPI_STM32_INTERRUPT
 	default y
 	depends on SPI
 
+choice STM32_LPTIM_CLOCK
+	default STM32_LPTIM_CLOCK_LSE
+	depends on STM32_LPTIM_TIMER
+endchoice
 
 endif # BOARD_STM32H735G_DISCO

--- a/boards/arm/stm32h735g_disco/stm32h735g_disco.dts
+++ b/boards/arm/stm32h735g_disco/stm32h735g_disco.dts
@@ -51,6 +51,10 @@
 	status = "okay";
 };
 
+&clk_lse {
+	status = "okay";
+};
+
 &pll {
 	div-m = <5>;
 	mul-n = <110>;

--- a/boards/arm/stm32h735g_disco/stm32h735g_disco.dts
+++ b/boards/arm/stm32h735g_disco/stm32h735g_disco.dts
@@ -113,3 +113,7 @@
 	pinctrl-names = "default";
 	cd-gpios = <&gpiof 5 GPIO_ACTIVE_LOW>;
 };
+
+&lptim1 {
+	status = "okay";
+};

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -679,6 +679,18 @@
 			};
 		};
 
+		lptim1: timers@40002400 {
+			compatible = "st,stm32-lptim";
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000200>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40002400 0x400>;
+			interrupts = <93 1>;
+			interrupt-names = "wakeup";
+			status = "disabled";
+			label = "LPTIM_1";
+		};
+
 		adc1: adc@40022000 {
 			compatible = "st,stm32-adc";
 			reg = <0x40022000 0x400>;

--- a/soc/arm/st_stm32/stm32h7/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32h7/Kconfig.defconfig.series
@@ -1,6 +1,7 @@
 # ST Microelectronics STM32H7 MCU line
 
 # Copyright (c) 2019 Linaro  Limited
+# Copyright (c) 2022 SILA Embedded Solutions GmbH <office@embedded-solutions.at>
 # SPDX-License-Identifier: Apache-2.0
 
 # Kconfig symbols common to STM32H7 series
@@ -15,6 +16,9 @@ config SOC_SERIES
 config ROM_START_OFFSET
 	default 0x400 if BOOTLOADER_MCUBOOT
 	default 0x0   if !BOOTLOADER_MCUBOOT
+
+config STM32_LPTIM_TIMER
+	default y if PM
 
 if ENTROPY_GENERATOR
 


### PR DESCRIPTION
Activate LPTIM1 for STM32 H7 series.