### PR TITLE
boards: stm32: fix power supply for STM32H735 Discovery Kit

### DIFF
--- a/boards/arm/stm32h735g_disco/stm32h735g_disco_defconfig
+++ b/boards/arm/stm32h735g_disco/stm32h735g_disco_defconfig
@@ -26,3 +26,6 @@ CONFIG_CLOCK_CONTROL=y
 
 # enable pin controller
 CONFIG_PINCTRL=y
+
+# select power supply
+CONFIG_POWER_SUPPLY_DIRECT_SMPS=y


### PR DESCRIPTION
Use power supply direct SMPS on STM32H735
Discovery Kit.

Signed-off-by: Benedikt Schmidt <benedikt.schmidt@embedded-solutions.at>

Fixes #41873