### PR TITLE
soc: arm: stm32: implement VOS switch for H7 series

### DIFF
--- a/soc/arm/st_stm32/stm32h7/CMakeLists.txt
+++ b/soc/arm/st_stm32/stm32h7/CMakeLists.txt
@@ -3,6 +3,7 @@
 zephyr_include_directories(${ZEPHYR_BASE}/drivers)
 
 zephyr_sources_ifdef(CONFIG_CPU_CORTEX_M7 soc_m7.c)
+zephyr_sources_ifdef(CONFIG_CPU_CORTEX_M7 power_m7.c)
 zephyr_sources_ifdef(CONFIG_CPU_CORTEX_M4 soc_m4.c)
 
 zephyr_sources(mpu_regions.c)

--- a/soc/arm/st_stm32/stm32h7/Kconfig.defconfig.stm32h723xx
+++ b/soc/arm/st_stm32/stm32h7/Kconfig.defconfig.stm32h723xx
@@ -1,6 +1,7 @@
 # ST STM32H723X MCU configuration options
 
 # Copyright (c) 2020 Alexander Kozhinov <AlexanderKozhinov@yandex.com>
+# Copyright (c) 2022 SILA Embedded Solutions GmbH <office@embedded-solutions.at>
 # SPDX-License-Identifier: Apache-2.0
 
 if SOC_STM32H723XX
@@ -10,5 +11,10 @@ config SOC
 
 config NUM_IRQS
 	default 163
+
+choice VOS0_SWITCH_METHOD_CHOICE
+	default VOS0_SWITCH_METHOD_DIRECT
+
+endchoice
 
 endif # SOC_STM32H723XX

--- a/soc/arm/st_stm32/stm32h7/Kconfig.defconfig.stm32h735xx
+++ b/soc/arm/st_stm32/stm32h7/Kconfig.defconfig.stm32h735xx
@@ -11,4 +11,9 @@ config SOC
 config NUM_IRQS
 	default 163
 
+choice VOS0_SWITCH_METHOD_CHOICE
+	default VOS0_SWITCH_METHOD_DIRECT
+
+endchoice
+
 endif # SOC_STM32H735XX

--- a/soc/arm/st_stm32/stm32h7/Kconfig.defconfig.stm32h743xx
+++ b/soc/arm/st_stm32/stm32h7/Kconfig.defconfig.stm32h743xx
@@ -1,6 +1,7 @@
 # ST STM32H743X MCU configuration options
 
 # Copyright (c) 2020 Teslabs Engineering S.L.
+# Copyright (c) 2022 SILA Embedded Solutions GmbH <office@embedded-solutions.at>
 # SPDX-License-Identifier: Apache-2.0
 
 if SOC_STM32H743XX
@@ -10,5 +11,10 @@ config SOC
 
 config NUM_IRQS
 	default 150
+
+choice VOS0_SWITCH_METHOD_CHOICE
+	default VOS0_SWITCH_METHOD_ODEN
+
+endchoice
 
 endif # SOC_STM32H743XX

--- a/soc/arm/st_stm32/stm32h7/Kconfig.defconfig.stm32h745xx
+++ b/soc/arm/st_stm32/stm32h7/Kconfig.defconfig.stm32h745xx
@@ -1,6 +1,7 @@
 # ST STM32H745X MCU configuration options
 
 # Copyright (c) 2020 Alexander Kozhinov <AlexanderKozhinov@yandex.com>
+# Copyright (c) 2022 SILA Embedded Solutions GmbH <office@embedded-solutions.at>
 # SPDX-License-Identifier: Apache-2.0
 
 if SOC_STM32H745XX
@@ -10,5 +11,10 @@ config SOC
 
 config NUM_IRQS
 	default 150
+
+choice VOS0_SWITCH_METHOD_CHOICE
+	default VOS0_SWITCH_METHOD_ODEN
+
+endchoice
 
 endif # SOC_STM32H745XX

--- a/soc/arm/st_stm32/stm32h7/Kconfig.defconfig.stm32h747xx
+++ b/soc/arm/st_stm32/stm32h7/Kconfig.defconfig.stm32h747xx
@@ -1,6 +1,7 @@
 # ST STM32H747X MCU configuration options
 
 # Copyright (c) 2019 Linaro Limited
+# Copyright (c) 2022 SILA Embedded Solutions GmbH <office@embedded-solutions.at>
 # SPDX-License-Identifier: Apache-2.0
 
 if SOC_STM32H747XX
@@ -10,5 +11,10 @@ config SOC
 
 config NUM_IRQS
 	default 150
+
+choice VOS0_SWITCH_METHOD_CHOICE
+	default VOS0_SWITCH_METHOD_ODEN
+
+endchoice
 
 endif # SOC_STM32H747XX

--- a/soc/arm/st_stm32/stm32h7/Kconfig.defconfig.stm32h750xx
+++ b/soc/arm/st_stm32/stm32h7/Kconfig.defconfig.stm32h750xx
@@ -1,6 +1,7 @@
 # ST STM32H750XX MCU configuration options
 
 # Copyright (c) 2020 Teslabs Engineering S.L.
+# Copyright (c) 2022 SILA Embedded Solutions GmbH <office@embedded-solutions.at>
 # SPDX-License-Identifier: Apache-2.0
 
 if SOC_STM32H750XX
@@ -10,5 +11,10 @@ config SOC
 
 config NUM_IRQS
 	default 150
+
+choice VOS0_SWITCH_METHOD_CHOICE
+	default VOS0_SWITCH_METHOD_ODEN
+
+endchoice
 
 endif # SOC_STM32H750XX

--- a/soc/arm/st_stm32/stm32h7/Kconfig.defconfig.stm32h753xx
+++ b/soc/arm/st_stm32/stm32h7/Kconfig.defconfig.stm32h753xx
@@ -1,6 +1,7 @@
 # ST STM32H753X MCU configuration options
 
 # Copyright (c) 2020 Petri Oksanen <petri@iote.ai>
+# Copyright (c) 2022 SILA Embedded Solutions GmbH <office@embedded-solutions.at>
 # SPDX-License-Identifier: Apache-2.0
 
 if SOC_STM32H753XX
@@ -10,5 +11,10 @@ config SOC
 
 config NUM_IRQS
 	default 150
+
+choice VOS0_SWITCH_METHOD_CHOICE
+	default VOS0_SWITCH_METHOD_ODEN
+
+endchoice
 
 endif # SOC_STM32H753XX

--- a/soc/arm/st_stm32/stm32h7/Kconfig.soc
+++ b/soc/arm/st_stm32/stm32h7/Kconfig.soc
@@ -2,6 +2,7 @@
 
 # Copyright (c) 2019 Linaro Limited
 # Copyright (c) 2020 Teslabs Engineering S.L.
+# Copyright (c) 2022 SILA Embedded Solutions GmbH <office@embedded-solutions.at>
 # SPDX-License-Identifier: Apache-2.0
 
 choice
@@ -40,5 +41,17 @@ config SOC_STM32H753XX
 	bool "STM32H753XX"
 	select CPU_CORTEX_M7
 	select CPU_HAS_FPU_DOUBLE_PRECISION
+
+endchoice
+
+choice VOS0_SWITCH_METHOD_CHOICE
+	prompt "STM32H7 method to switch into VOS0"
+	depends on SOC_SERIES_STM32H7X
+
+config VOS0_SWITCH_METHOD_ODEN
+	bool "switch into VOS0 via VOS1 and ODEN bit"
+
+config VOS0_SWITCH_METHOD_DIRECT
+	bool "direct switch into VOS0"
 
 endchoice

--- a/soc/arm/st_stm32/stm32h7/power_m7.c
+++ b/soc/arm/st_stm32/stm32h7/power_m7.c
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2021 SILA Embedded Solutions GmbH <office@embedded-solutions.at>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr.h>
+#include <pm/pm.h>
+#include <soc.h>
+#include <init.h>
+
+#include <stm32h7xx_ll_pwr.h>
+#include <stm32h7xx_ll_cortex.h>
+
+#include <logging/log.h>
+LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
+
+#if !defined(SMPS) && \
+		(defined(CONFIG_POWER_SUPPLY_DIRECT_SMPS) || \
+		defined(CONFIG_POWER_SUPPLY_SMPS_1V8_SUPPLIES_LDO) || \
+		defined(CONFIG_POWER_SUPPLY_SMPS_2V5_SUPPLIES_LDO) || \
+		defined(CONFIG_POWER_SUPPLY_SMPS_1V8_SUPPLIES_EXT_AND_LDO) || \
+		defined(CONFIG_POWER_SUPPLY_SMPS_2V5_SUPPLIES_EXT_AND_LDO) || \
+		defined(CONFIG_POWER_SUPPLY_SMPS_1V8_SUPPLIES_EXT) || \
+		defined(CONFIG_POWER_SUPPLY_SMPS_2V5_SUPPLIES_EXT))
+#error Unsupported configuration: Selected SoC do not support SMPS
+#endif
+
+#if defined(CONFIG_VOS0_SWITCH_METHOD_DIRECT)
+static void activate_vos0(void)
+{
+	LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE0);
+
+	/*
+	 * We have to wait for ACTVOSRDY and VOSRDY at this point,
+	 * as voltage scaling was changed from VOS3 to VOS0.
+	 */
+	while (LL_PWR_IsActiveFlag_VOS() == 0) {
+	}
+	while (LL_PWR_IsActiveFlag_ACTVOS() == 0) {
+	}
+}
+#elif defined(CONFIG_VOS0_SWITCH_METHOD_ODEN)
+static void activate_vos0(void)
+{
+	LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE1);
+
+	while (LL_PWR_IsActiveFlag_VOS() == 0) {
+	}
+
+	SET_BIT(SYSCFG->PWRCR, SYSCFG_PWRCR_ODEN);
+
+	while (LL_PWR_IsActiveFlag_VOS() == 0) {
+	}
+}
+#else
+#error switch into VOS0 not implemented
+#endif /* CONFIG_VOS0_SWITCH_METHOD_* */
+
+static int stm32_power_init(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+#if defined(CONFIG_POWER_SUPPLY_DIRECT_SMPS)
+	LL_PWR_ConfigSupply(LL_PWR_DIRECT_SMPS_SUPPLY);
+#elif defined(CONFIG_POWER_SUPPLY_SMPS_1V8_SUPPLIES_LDO)
+	LL_PWR_ConfigSupply(LL_PWR_SMPS_1V8_SUPPLIES_LDO);
+#elif defined(CONFIG_POWER_SUPPLY_SMPS_2V5_SUPPLIES_LDO)
+	LL_PWR_ConfigSupply(LL_PWR_SMPS_2V5_SUPPLIES_LDO);
+#elif defined(CONFIG_POWER_SUPPLY_SMPS_1V8_SUPPLIES_EXT_AND_LDO)
+	LL_PWR_ConfigSupply(LL_PWR_SMPS_1V8_SUPPLIES_EXT_AND_LDO);
+#elif defined(CONFIG_POWER_SUPPLY_SMPS_2V5_SUPPLIES_EXT_AND_LDO)
+	LL_PWR_ConfigSupply(LL_PWR_SMPS_2V5_SUPPLIES_EXT_AND_LDO);
+#elif defined(CONFIG_POWER_SUPPLY_SMPS_1V8_SUPPLIES_EXT)
+	LL_PWR_ConfigSupply(LL_PWR_SMPS_1V8_SUPPLIES_EXT);
+#elif defined(CONFIG_POWER_SUPPLY_SMPS_2V5_SUPPLIES_EXT)
+	LL_PWR_ConfigSupply(LL_PWR_SMPS_2V5_SUPPLIES_EXT);
+#elif defined(CONFIG_POWER_SUPPLY_EXTERNAL_SOURCE)
+	LL_PWR_ConfigSupply(LL_PWR_EXTERNAL_SOURCE_SUPPLY);
+#else
+	LL_PWR_ConfigSupply(LL_PWR_LDO_SUPPLY);
+#endif /* CONFIG_POWER_SUPPLY_* */
+
+	activate_vos0();
+
+	return 0;
+}
+
+SYS_INIT(stm32_power_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/soc/arm/st_stm32/stm32h7/soc_m7.c
+++ b/soc/arm/st_stm32/stm32h7/soc_m7.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019 Linaro Limited
+ * Copyright (c) 2021 SILA Embedded Solutions GmbH <office@embedded-solutions.at>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -66,8 +67,8 @@ static int stm32h7_init(const struct device *arg)
 	if (!(SCB->CCR & SCB_CCR_DC_Msk)) {
 		SCB_EnableDCache();
 	}
-
 #endif /* CONFIG_NOCACHE_MEMORY */
+
 	/* Install default handler that simply resets the CPU
 	 * if configured in the kernel, NOP otherwise
 	 */
@@ -78,40 +79,6 @@ static int stm32h7_init(const struct device *arg)
 	/* Update CMSIS SystemCoreClock variable (HCLK) */
 	/* At reset, system core clock is set to 64 MHz from HSI */
 	SystemCoreClock = 64000000;
-
-	/* Power Configuration */
-#if !defined(SMPS) && \
-		(defined(CONFIG_POWER_SUPPLY_DIRECT_SMPS) || \
-		defined(CONFIG_POWER_SUPPLY_SMPS_1V8_SUPPLIES_LDO) || \
-		defined(CONFIG_POWER_SUPPLY_SMPS_2V5_SUPPLIES_LDO) || \
-		defined(CONFIG_POWER_SUPPLY_SMPS_1V8_SUPPLIES_EXT_AND_LDO) || \
-		defined(CONFIG_POWER_SUPPLY_SMPS_2V5_SUPPLIES_EXT_AND_LDO) || \
-		defined(CONFIG_POWER_SUPPLY_SMPS_1V8_SUPPLIES_EXT) || \
-		defined(CONFIG_POWER_SUPPLY_SMPS_2V5_SUPPLIES_EXT))
-#error Unsupported configuration: Selected SoC do not support SMPS
-#endif
-#if defined(CONFIG_POWER_SUPPLY_DIRECT_SMPS)
-	LL_PWR_ConfigSupply(LL_PWR_DIRECT_SMPS_SUPPLY);
-#elif defined(CONFIG_POWER_SUPPLY_SMPS_1V8_SUPPLIES_LDO)
-	LL_PWR_ConfigSupply(LL_PWR_SMPS_1V8_SUPPLIES_LDO);
-#elif defined(CONFIG_POWER_SUPPLY_SMPS_2V5_SUPPLIES_LDO)
-	LL_PWR_ConfigSupply(LL_PWR_SMPS_2V5_SUPPLIES_LDO);
-#elif defined(CONFIG_POWER_SUPPLY_SMPS_1V8_SUPPLIES_EXT_AND_LDO)
-	LL_PWR_ConfigSupply(LL_PWR_SMPS_1V8_SUPPLIES_EXT_AND_LDO);
-#elif defined(CONFIG_POWER_SUPPLY_SMPS_2V5_SUPPLIES_EXT_AND_LDO)
-	LL_PWR_ConfigSupply(LL_PWR_SMPS_2V5_SUPPLIES_EXT_AND_LDO);
-#elif defined(CONFIG_POWER_SUPPLY_SMPS_1V8_SUPPLIES_EXT)
-	LL_PWR_ConfigSupply(LL_PWR_SMPS_1V8_SUPPLIES_EXT);
-#elif defined(CONFIG_POWER_SUPPLY_SMPS_2V5_SUPPLIES_EXT)
-	LL_PWR_ConfigSupply(LL_PWR_SMPS_2V5_SUPPLIES_EXT);
-#elif defined(CONFIG_POWER_SUPPLY_EXTERNAL_SOURCE)
-	LL_PWR_ConfigSupply(LL_PWR_EXTERNAL_SOURCE_SUPPLY);
-#else
-	LL_PWR_ConfigSupply(LL_PWR_LDO_SUPPLY);
-#endif
-	LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE1);
-	while (LL_PWR_IsActiveFlag_VOS() == 0) {
-	}
 
 	/* Errata ES0392 Rev 8:
 	 * 2.2.9: Reading from AXI SRAM may lead to data read corruption


### PR DESCRIPTION
Implement correct VOS switch for H7 series.

Signed-off-by: Benedikt Schmidt <benedikt.schmidt@embedded-solutions.at>