### PR TITLE
net: openthread: Add openthread CSL clock uncert

### DIFF
--- a/subsys/net/l2/openthread/Kconfig.thread
+++ b/subsys/net/l2/openthread/Kconfig.thread
@@ -100,6 +100,12 @@ config OPENTHREAD_CSL_MIN_RECEIVE_ON
 	help
 	  The minimum CSL receive window (in microseconds) required to receive a full IEEE 802.15.4 frame
 
+config OPENTHREAD_PLATFORM_CSL_UNCERT
+	int "CSL clock uncertainty"
+	default 255
+	help
+	  The Uncertainty of the scheduling CSL of transmission by the parent, in ±10 us units.
+
 config OPENTHREAD_MAC_SOFTWARE_TX_SECURITY_ENABLE
 	bool "Enable software transmission security logic"
 	default y if OPENTHREAD_THREAD_VERSION_1_2

--- a/subsys/net/lib/openthread/platform/openthread-core-zephyr-config.h
+++ b/subsys/net/lib/openthread/platform/openthread-core-zephyr-config.h
@@ -329,6 +329,16 @@
 #endif /* CONFIG_OPENTHREAD_CSL_MIN_RECEIVE_ON */
 
 /**
+ * @def OPENTHREAD_CONFIG_PLATFORM_CSL_UNCERT
+ *
+ * The Uncertainty of the scheduling CSL of transmission by the parent, in ±10 us units.
+ */
+
+#ifdef CONFIG_OPENTHREAD_PLATFORM_CSL_UNCERT
+#define OPENTHREAD_CONFIG_PLATFORM_CSL_UNCERT CONFIG_OPENTHREAD_PLATFORM_CSL_UNCERT
+#endif /* CONFIG_OPENTHREAD_PLATFORM_CSL_UNCERT */
+
+/**
  * @def OPENTHREAD_CONFIG_MAC_SOFTWARE_TX_SECURITY_ENABLE
  *
  * Set to 1 to enable software transmission security logic.


### PR DESCRIPTION
This commit adds OPENTHREAD_PLATFORM_CSL_UNCERToption to Kconfig.
This option will allow user to configure openthreads CSL clock
uncertianity during build time.

Signed-off-by: Przemyslaw Bida <przemyslaw.bida@nordicsemi.no>