### PR TITLE
tests: logging: log_api: Fix test suite setup

### DIFF
--- a/subsys/testsuite/ztest/include/ztest_test_new.h
+++ b/subsys/testsuite/ztest/include/ztest_test_new.h
@@ -103,14 +103,14 @@ extern struct ztest_suite_node _ztest_suite_node_list_end[];
  * @param after_fn The function to call after each unit test in this suite
  * @param teardown_fn The function to call after running all the tests in this suite
  */
-#define ZTEST_SUITE(SUITE_NAME, PREDICATE, setup_fn, before_fn, after_fn, teardown_fn)             \
-	static STRUCT_SECTION_ITERABLE(ztest_suite_node, z_ztest_test_node_##SUITE_NAME) = {       \
-		.name = #SUITE_NAME,                                                               \
-		.setup = (setup_fn),                                                               \
-		.before = (before_fn),                                                             \
-		.after = (after_fn),                                                               \
-		.teardown = (teardown_fn),                                                         \
-		.predicate = PREDICATE,                                                            \
+#define ZTEST_SUITE(SUITE_NAME, PREDICATE, setup_fn, before_fn, after_fn, teardown_fn)		\
+	static STRUCT_SECTION_ITERABLE(ztest_suite_node, z_ztest_test_node_ ## SUITE_NAME) = {	\
+		.name = STRINGIFY(SUITE_NAME),							\
+		.setup = (setup_fn),								\
+		.before = (before_fn),								\
+		.after = (after_fn),								\
+		.teardown = (teardown_fn),							\
+		.predicate = PREDICATE,								\
 	}
 
 /**

--- a/tests/subsys/logging/log_api/src/test.inc
+++ b/tests/subsys/logging/log_api/src/test.inc
@@ -660,7 +660,7 @@ static void log_api_suite_before(void *data)
 }
 
 #define WRAP_TEST(test_name, suffix)                       \
-	ZTEST(test_log_api_##suffix, test_name##_##suffix) \
+	ZTEST(UTIL_CAT(test_log_api_, suffix), UTIL_CAT(test_name, UTIL_CAT(_,suffix))) \
 	{                                                  \
 		test_name();                               \
 	}
@@ -670,7 +670,7 @@ static void log_api_suite_before(void *data)
 #else
 #define TEST_SUFFIX cc
 #endif
-#define TEST_SUITE_NAME test_log_api_ ## TEST_SUFFIX
+#define TEST_SUITE_NAME UTIL_CAT(test_log_api_, TEST_SUFFIX)
 
 ZTEST_SUITE(TEST_SUITE_NAME, NULL, log_api_suite_setup,
 	    log_api_suite_before, NULL, log_api_suite_teardown);


### PR DESCRIPTION
After switching to new ztest suite was wrongly setup and
no tests were run. Replaced ## with macro that resolves
and concatenates.

Additionally, used `STRINGIFY` in `ZTEST_SUITE`. That was also needed to fix test suite.

Introduced by #39714.