### PR TITLE
Bluetooth: Samples: Add controller Kconfig requirement for ISO samples

### DIFF
--- a/samples/bluetooth/central_iso/README.rst
+++ b/samples/bluetooth/central_iso/README.rst
@@ -18,6 +18,8 @@ Requirements
 
 * BlueZ running on the host, or
 * A board with Bluetooth Low Energy 5.2 support
+* A Bluetooth Controller and board that supports setting
+  CONFIG_BT_CTLR_CENTRAL_ISO=y
 
 Building and Running
 ********************

--- a/samples/bluetooth/iso_broadcast/README.rst
+++ b/samples/bluetooth/iso_broadcast/README.rst
@@ -12,7 +12,10 @@ Broadcaster functionality.
 Requirements
 ************
 
-* A board with Bluetooth Low Energy support
+* BlueZ running on the host, or
+* A board with Bluetooth Low Energy 5.2 support
+* A Bluetooth Controller and board that supports setting
+  CONFIG_BT_CTLR_ADV_ISO=y
 
 Building and Running
 ********************

--- a/samples/bluetooth/iso_broadcast_benchmark/README.rst
+++ b/samples/bluetooth/iso_broadcast_benchmark/README.rst
@@ -19,9 +19,12 @@ can easily be changed.
 Requirements
 ************
 
-* A board with Bluetooth Low Energy 5.2 and Broadcast Isochronous Channel
-  support
-* A remote board running the same sample as the reversed role
+* BlueZ running on the host, or
+* A board with Bluetooth Low Energy 5.2 support
+* A Bluetooth Controller and board that supports setting
+  CONFIG_BT_CTLR_ADV_ISO=y
+* A remote board running the same sample as the reversed role that supports
+  setting CONFIG_BT_CTLR_SYNC_ISO
 
 Building and running
 ********************

--- a/samples/bluetooth/iso_connected_benchmark/README.rst
+++ b/samples/bluetooth/iso_connected_benchmark/README.rst
@@ -19,9 +19,12 @@ can easily be changed.
 Requirements
 ************
 
-* A board with Bluetooth Low Energy 5.2 and Connected Isochronous Channel
-  support
-* A remote board running the same sample as the reversed role
+* BlueZ running on the host, or
+* A board with Bluetooth Low Energy 5.2 support
+* A Bluetooth Controller and board that supports setting
+  CONFIG_BT_CTLR_CENTRAL_ISO=y
+* A remote board running the same sample as the reversed role that supports
+  setting CONFIG_BT_CTLR_PERIPHERAL_ISO=y
 
 Building and running
 ********************

--- a/samples/bluetooth/iso_receive/README.rst
+++ b/samples/bluetooth/iso_receive/README.rst
@@ -12,7 +12,10 @@ Receiver functionality.
 Requirements
 ************
 
-* A board with Bluetooth Low Energy support
+* BlueZ running on the host, or
+* A board with Bluetooth Low Energy 5.2 support
+* A Bluetooth Controller and board that supports setting
+  CONFIG_BT_CTLR_SYNC_ISO=y
 
 Building and Running
 ********************

--- a/samples/bluetooth/peripheral_iso/README.rst
+++ b/samples/bluetooth/peripheral_iso/README.rst
@@ -15,6 +15,8 @@ Requirements
 
 * BlueZ running on the host, or
 * A board with Bluetooth Low Energy 5.2 support
+* A Bluetooth Controller and board that supports setting
+  CONFIG_BT_CTLR_PERIPHERAL_ISO=y
 
 Building and Running
 ********************


### PR DESCRIPTION
Add reference to specific CONFIG_BT_CTLR_ Kconfig options
for the ISO samples. This is due to the fact that ISO
isn't fully supported in the Zephyr controller yet, and
won't be enabled by default for a while yet.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

fixes https://github.com/zephyrproject-rtos/zephyr/issues/41635