### PR TITLE
Bluetooth: Add reference to BT_HCI_ERR_* for disconnect reason

### DIFF
--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -811,7 +811,7 @@ struct bt_conn_cb {
 	 *  increase @kconfig{CONFIG_BT_MAX_CONN}.
 	 *
 	 *  @param conn Connection object.
-	 *  @param reason HCI reason for the disconnection.
+	 *  @param reason BT_HCI_ERR_* reason for the disconnection.
 	 */
 	void (*disconnected)(struct bt_conn *conn, uint8_t reason);
 

--- a/include/bluetooth/iso.h
+++ b/include/bluetooth/iso.h
@@ -416,7 +416,7 @@ struct bt_iso_chan_ops {
 	 *  rejected.
 	 *
 	 *  @param chan   The channel that has been Disconnected
-	 *  @param reason HCI reason for the disconnection.
+	 *  @param reason BT_HCI_ERR_* reason for the disconnection.
 	 */
 	void (*disconnected)(struct bt_iso_chan *chan, uint8_t reason);
 


### PR DESCRIPTION
Add reference to BT_HCI_ERR_* for ACL and ISO disconnect
reason.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

fixes https://github.com/zephyrproject-rtos/zephyr/issues/41749