### PR TITLE
pm: s/PM_DEVICE_(DT_(INST))_REF/PM_DEVICE_(DT_(INST))_GET

### DIFF
--- a/drivers/display/display_st7735r.c
+++ b/drivers/display/display_st7735r.c
@@ -577,7 +577,7 @@ static const struct display_driver_api st7735r_api = {
 										\
 	PM_DEVICE_DT_INST_DEFINE(inst, st7735r_pm_action);			\
 										\
-	DEVICE_DT_INST_DEFINE(inst, st7735r_init, PM_DEVICE_DT_INST_REF(inst),	\
+	DEVICE_DT_INST_DEFINE(inst, st7735r_init, PM_DEVICE_DT_INST_GET(inst),	\
 			      &st7735r_data_ ## inst, &st7735r_config_ ## inst,	\
 			      POST_KERNEL, CONFIG_DISPLAY_INIT_PRIORITY,	\
 			      &st7735r_api);

--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -447,5 +447,5 @@ static struct st7789v_data st7789v_data = {
 PM_DEVICE_DT_INST_DEFINE(0, st7789v_pm_action);
 
 DEVICE_DT_INST_DEFINE(0, &st7789v_init,
-	      PM_DEVICE_DT_INST_REF(0), &st7789v_data, NULL, POST_KERNEL,
+	      PM_DEVICE_DT_INST_GET(0), &st7789v_data, NULL, POST_KERNEL,
 	      CONFIG_DISPLAY_INIT_PRIORITY, &st7789v_api);

--- a/drivers/entropy/entropy_cc13xx_cc26xx.c
+++ b/drivers/entropy/entropy_cc13xx_cc26xx.c
@@ -353,7 +353,7 @@ PM_DEVICE_DT_INST_DEFINE(0, entropy_cc13xx_cc26xx_pm_action);
 
 DEVICE_DT_INST_DEFINE(0,
 		entropy_cc13xx_cc26xx_init,
-		PM_DEVICE_DT_INST_REF(0),
+		PM_DEVICE_DT_INST_GET(0),
 		&entropy_cc13xx_cc26xx_data, NULL,
 		PRE_KERNEL_1, CONFIG_ENTROPY_INIT_PRIORITY,
 		&entropy_cc13xx_cc26xx_driver_api);

--- a/drivers/entropy/entropy_neorv32_trng.c
+++ b/drivers/entropy/entropy_neorv32_trng.c
@@ -139,7 +139,7 @@ static const struct entropy_driver_api neorv32_trng_driver_api = {
 	PM_DEVICE_DT_INST_DEFINE(n, neorv32_trng_pm_action);		\
 									\
 	DEVICE_DT_INST_DEFINE(n, &neorv32_trng_init,			\
-			 PM_DEVICE_DT_INST_REF(n),			\
+			 PM_DEVICE_DT_INST_GET(n),			\
 			 NULL,						\
 			 &neorv32_trng_##n##_config,			\
 			 PRE_KERNEL_1,					\

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -1436,7 +1436,7 @@ static void eth_mcux_err_isr(const struct device *dev)
 									\
 	ETH_NET_DEVICE_DT_INST_DEFINE(n,				\
 			    eth_init,					\
-			    PM_DEVICE_DT_INST_REF(n),			\
+			    PM_DEVICE_DT_INST_GET(n),			\
 			    &eth##n##_context,				\
 			    &eth##n##_buffer_config,			\
 			    CONFIG_ETH_INIT_PRIORITY,			\

--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -1197,7 +1197,7 @@ static const struct qspi_nor_config qspi_nor_dev_config = {
 
 PM_DEVICE_DT_INST_DEFINE(0, qspi_nor_pm_action);
 
-DEVICE_DT_INST_DEFINE(0, qspi_nor_init, PM_DEVICE_DT_INST_REF(0),
+DEVICE_DT_INST_DEFINE(0, qspi_nor_init, PM_DEVICE_DT_INST_GET(0),
 		      &qspi_nor_dev_data, &qspi_nor_dev_config,
 		      POST_KERNEL, CONFIG_NORDIC_QSPI_NOR_INIT_PRIORITY,
 		      &qspi_nor_api);

--- a/drivers/flash/spi_flash_at45.c
+++ b/drivers/flash/spi_flash_at45.c
@@ -704,7 +704,7 @@ static const struct flash_driver_api spi_flash_at45_api = {
 	PM_DEVICE_DT_INST_DEFINE(idx, spi_flash_at45_pm_action);	     \
 									     \
 	DEVICE_DT_INST_DEFINE(idx,					     \
-		      spi_flash_at45_init, PM_DEVICE_DT_INST_REF(idx),	     \
+		      spi_flash_at45_init, PM_DEVICE_DT_INST_GET(idx),	     \
 		      &inst_##idx##_data, &inst_##idx##_config,		     \
 		      POST_KERNEL, CONFIG_SPI_FLASH_AT45_INIT_PRIORITY,      \
 		      &spi_flash_at45_api);

--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -538,7 +538,7 @@ static struct gpio_dw_runtime gpio_0_runtime = {
 PM_DEVICE_DT_INST_DEFINE(0, gpio_dw_device_pm_action);
 
 DEVICE_DT_INST_DEFINE(0,
-	      gpio_dw_initialize, PM_DEVICE_DT_INST_REF(0), &gpio_0_runtime,
+	      gpio_dw_initialize, PM_DEVICE_DT_INST_GET(0), &gpio_0_runtime,
 	      &gpio_config_0, PRE_KERNEL_1, CONFIG_GPIO_INIT_PRIORITY,
 	      &api_funcs);
 
@@ -602,7 +602,7 @@ static struct gpio_dw_runtime gpio_1_runtime = {
 PM_DEVICE_DT_INST_DEFINE(1, gpio_dw_device_pm_action);
 
 DEVICE_DT_INST_DEFINE(1,
-	      gpio_dw_initialize, PM_DEVICE_DT_INST_REF(1), &gpio_1_runtime,
+	      gpio_dw_initialize, PM_DEVICE_DT_INST_GET(1), &gpio_1_runtime,
 	      &gpio_dw_config_1, PRE_KERNEL_1, CONFIG_GPIO_INIT_PRIORITY,
 	      &api_funcs);
 
@@ -665,7 +665,7 @@ static struct gpio_dw_runtime gpio_2_runtime = {
 PM_DEVICE_DT_INST_DEFINE(2, gpio_dw_device_pm_action);
 
 DEVICE_DT_INST_DEFINE(2,
-	      gpio_dw_initialize, PM_DEVICE_DT_INST_REF(2), &gpio_2_runtime,
+	      gpio_dw_initialize, PM_DEVICE_DT_INST_GET(2), &gpio_2_runtime,
 	      &gpio_dw_config_2, PRE_KERNEL_1, CONFIG_GPIO_INIT_PRIORITY,
 	      &api_funcs);
 
@@ -728,7 +728,7 @@ static struct gpio_dw_runtime gpio_3_runtime = {
 PM_DEVICE_DT_INST_DEFINE(3, gpio_dw_device_pm_action);
 
 DEVICE_DT_INST_DEFINE(3,
-	      gpio_dw_initialize, PM_DEVICE_DT_INST_REF(3), &gpio_3_runtime,
+	      gpio_dw_initialize, PM_DEVICE_DT_INST_GET(3), &gpio_3_runtime,
 	      &gpio_dw_config_3, PRE_KERNEL_1, CONFIG_GPIO_INIT_PRIORITY,
 	      &api_funcs);
 

--- a/drivers/gpio/gpio_emul.c
+++ b/drivers/gpio/gpio_emul.c
@@ -734,7 +734,7 @@ static int gpio_emul_pm_device_pm_action(const struct device *dev,
 	PM_DEVICE_DT_INST_DEFINE(_num, gpio_emul_pm_device_pm_action);	\
 									\
 	DEVICE_DT_INST_DEFINE(_num, gpio_emul_init,			\
-			    PM_DEVICE_DT_INST_REF(_num),		\
+			    PM_DEVICE_DT_INST_GET(_num),		\
 			    &gpio_emul_data_##_num,			\
 			    &gpio_emul_config_##_num, POST_KERNEL,	\
 			    CONFIG_GPIO_INIT_PRIORITY,			\

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -645,7 +645,7 @@ static int gpio_stm32_init(const struct device *dev)
 	PM_DEVICE_DT_DEFINE(__node, gpio_stm32_pm_action);		       \
 	DEVICE_DT_DEFINE(__node,					       \
 			    gpio_stm32_init,				       \
-			    PM_DEVICE_DT_REF(__node),			       \
+			    PM_DEVICE_DT_GET(__node),			       \
 			    &gpio_stm32_data_## __suffix,		       \
 			    &gpio_stm32_cfg_## __suffix,		       \
 			    PRE_KERNEL_1,				       \

--- a/drivers/i2c/i2c_cc13xx_cc26xx.c
+++ b/drivers/i2c/i2c_cc13xx_cc26xx.c
@@ -439,7 +439,7 @@ PM_DEVICE_DT_INST_DEFINE(0, i2c_cc13xx_cc26xx_pm_action);
 
 I2C_DEVICE_DT_INST_DEFINE(0,
 		i2c_cc13xx_cc26xx_init,
-		PM_DEVICE_DT_INST_REF(0),
+		PM_DEVICE_DT_INST_GET(0),
 		&i2c_cc13xx_cc26xx_data, &i2c_cc13xx_cc26xx_config,
 		POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,
 		&i2c_cc13xx_cc26xx_driver_api);

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -289,7 +289,7 @@ static int twi_nrfx_pm_action(const struct device *dev,
 	PM_DEVICE_DT_DEFINE(I2C(idx), twi_nrfx_pm_action);		       \
 	I2C_DEVICE_DT_DEFINE(I2C(idx),					       \
 		      twi_##idx##_init,					       \
-		      PM_DEVICE_DT_REF(I2C(idx)),			       \
+		      PM_DEVICE_DT_GET(I2C(idx)),			       \
 		      &twi_##idx##_data,				       \
 		      &twi_##idx##z_config,				       \
 		      POST_KERNEL,					       \

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -374,7 +374,7 @@ static int twim_nrfx_pm_action(const struct device *dev,
 	PM_DEVICE_DT_DEFINE(I2C(idx), twim_nrfx_pm_action);		       \
 	I2C_DEVICE_DT_DEFINE(I2C(idx),					       \
 		      twim_##idx##_init,				       \
-		      PM_DEVICE_DT_REF(I2C(idx)),			       \
+		      PM_DEVICE_DT_GET(I2C(idx)),			       \
 		      &twim_##idx##_data,				       \
 		      &twim_##idx##z_config,				       \
 		      POST_KERNEL,					       \

--- a/drivers/interrupt_controller/intc_ioapic.c
+++ b/drivers/interrupt_controller/intc_ioapic.c
@@ -544,5 +544,5 @@ static void IoApicRedUpdateLo(unsigned int irq,
 
 PM_DEVICE_DEFINE(ioapic, ioapic_pm_action);
 
-DEVICE_DEFINE(ioapic, "ioapic", ioapic_init, PM_DEVICE_REF(ioapic), NULL, NULL,
+DEVICE_DEFINE(ioapic, "ioapic", ioapic_init, PM_DEVICE_GET(ioapic), NULL, NULL,
 	      PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);

--- a/drivers/interrupt_controller/intc_loapic.c
+++ b/drivers/interrupt_controller/intc_loapic.c
@@ -421,7 +421,7 @@ static int loapic_pm_action(const struct device *dev,
 
 PM_DEVICE_DEFINE(loapic, loapic_pm_action);
 
-DEVICE_DEFINE(loapic, "loapic", loapic_init, PM_DEVICE_REF(loapic), NULL, NULL,
+DEVICE_DEFINE(loapic, "loapic", loapic_init, PM_DEVICE_GET(loapic), NULL, NULL,
 	      PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
 
 #if CONFIG_LOAPIC_SPURIOUS_VECTOR

--- a/drivers/led/led_pwm.c
+++ b/drivers/led/led_pwm.c
@@ -168,7 +168,7 @@ static const struct led_pwm_config led_pwm_config_##id = {	\
 PM_DEVICE_DT_INST_DEFINE(id, led_pwm_pm_action);		\
 								\
 DEVICE_DT_INST_DEFINE(id, &led_pwm_init,			\
-		      PM_DEVICE_DT_INST_REF(id), NULL,		\
+		      PM_DEVICE_DT_INST_GET(id), NULL,		\
 		      &led_pwm_config_##id, POST_KERNEL,	\
 		      CONFIG_LED_INIT_PRIORITY, &led_pwm_api);
 

--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -368,7 +368,7 @@ static int pwm_nrfx_pm_action(const struct device *dev,
 	};								      \
 	PM_DEVICE_DT_DEFINE(PWM(idx), pwm_nrfx_pm_action);		      \
 	DEVICE_DT_DEFINE(PWM(idx),					      \
-		      pwm_nrfx_init, PM_DEVICE_DT_REF(PWM(idx)),	      \
+		      pwm_nrfx_init, PM_DEVICE_DT_GET(PWM(idx)),	      \
 		      &pwm_nrfx_##idx##_data,				      \
 		      &pwm_nrfx_##idx##config,				      \
 		      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	      \

--- a/drivers/sensor/apds9960/apds9960.c
+++ b/drivers/sensor/apds9960/apds9960.c
@@ -538,5 +538,5 @@ static struct apds9960_data apds9960_data;
 PM_DEVICE_DT_INST_DEFINE(0, apds9960_pm_action);
 
 DEVICE_DT_INST_DEFINE(0, apds9960_init,
-	      PM_DEVICE_DT_INST_REF(0), &apds9960_data, &apds9960_config,
+	      PM_DEVICE_DT_INST_GET(0), &apds9960_data, &apds9960_config,
 	      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &apds9960_driver_api);

--- a/drivers/sensor/bme280/bme280.c
+++ b/drivers/sensor/bme280/bme280.c
@@ -453,7 +453,7 @@ static int bme280_pm_action(const struct device *dev,
 									\
 	DEVICE_DT_INST_DEFINE(inst,					\
 			 bme280_chip_init,				\
-			 PM_DEVICE_DT_INST_REF(inst),			\
+			 PM_DEVICE_DT_INST_GET(inst),			\
 			 &bme280_data_##inst,				\
 			 &bme280_config_##inst,				\
 			 POST_KERNEL,					\

--- a/drivers/sensor/bmp388/bmp388.c
+++ b/drivers/sensor/bmp388/bmp388.c
@@ -725,7 +725,7 @@ static int bmp388_init(const struct device *dev)
 	DEVICE_DT_INST_DEFINE(						   \
 		inst,							   \
 		bmp388_init,						   \
-		PM_DEVICE_DT_INST_REF(inst),				   \
+		PM_DEVICE_DT_INST_GET(inst),				   \
 		&bmp388_data_##inst,					   \
 		&bmp388_config_##inst,					   \
 		POST_KERNEL,						   \

--- a/drivers/sensor/bq274xx/bq274xx.c
+++ b/drivers/sensor/bq274xx/bq274xx.c
@@ -777,7 +777,7 @@ static const struct sensor_driver_api bq274xx_battery_driver_api = {
 	PM_DEVICE_DT_INST_DEFINE(index, bq274xx_pm_action);		       \
 									       \
 	DEVICE_DT_INST_DEFINE(index, &bq274xx_gauge_init,		       \
-			    PM_DEVICE_DT_INST_REF(index),		       \
+			    PM_DEVICE_DT_INST_GET(index),		       \
 			    &bq274xx_driver_##index,                           \
 			    &bq274xx_config_##index, POST_KERNEL,              \
 			    CONFIG_SENSOR_INIT_PRIORITY,                       \

--- a/drivers/sensor/fdc2x1x/fdc2x1x.c
+++ b/drivers/sensor/fdc2x1x/fdc2x1x.c
@@ -1030,7 +1030,7 @@ static int fdc2x1x_init(const struct device *dev)
 									   \
 	DEVICE_DT_INST_DEFINE(n,					   \
 			      fdc2x1x_init,				   \
-			      PM_DEVICE_DT_INST_REF(n),			   \
+			      PM_DEVICE_DT_INST_GET(n),			   \
 			      &fdc2x1x_data_##n,			   \
 			      &fdc2x1x_config_##n,			   \
 			      POST_KERNEL,				   \

--- a/drivers/sensor/ina219/ina219.c
+++ b/drivers/sensor/ina219/ina219.c
@@ -307,7 +307,7 @@ static const struct sensor_driver_api ina219_api = {
 								\
 	DEVICE_DT_INST_DEFINE(n,				\
 			      ina219_init,			\
-			      PM_DEVICE_DT_INST_REF(n),		\
+			      PM_DEVICE_DT_INST_GET(n),		\
 			      &ina219_data_##n,			\
 			      &ina219_config_##n,		\
 			      POST_KERNEL,			\

--- a/drivers/sensor/lis2mdl/lis2mdl.c
+++ b/drivers/sensor/lis2mdl/lis2mdl.c
@@ -493,7 +493,7 @@ static int lis2mdl_pm_action(const struct device *dev,
 									\
 	DEVICE_DT_INST_DEFINE(inst,					\
 			    lis2mdl_init,				\
-			    PM_DEVICE_DT_INST_REF(inst),		\
+			    PM_DEVICE_DT_INST_GET(inst),		\
 			    &lis2mdl_data_##inst,			\
 			    &lis2mdl_config_##inst,			\
 			    POST_KERNEL,				\

--- a/drivers/sensor/lm77/lm77.c
+++ b/drivers/sensor/lm77/lm77.c
@@ -415,7 +415,7 @@ static int lm77_pm_action(const struct device *dev,
 	PM_DEVICE_DT_INST_DEFINE(n, lm77_pm_action);			\
 									\
 	DEVICE_DT_INST_DEFINE(n, lm77_init,				\
-			      PM_DEVICE_DT_INST_REF(n),			\
+			      PM_DEVICE_DT_INST_GET(n),			\
 			      &lm77_data_##n,				\
 			      &lm77_config_##n, POST_KERNEL,		\
 			      CONFIG_SENSOR_INIT_PRIORITY,		\

--- a/drivers/sensor/qdec_nrfx/qdec_nrfx.c
+++ b/drivers/sensor/qdec_nrfx/qdec_nrfx.c
@@ -245,5 +245,5 @@ static const struct sensor_driver_api qdec_nrfx_driver_api = {
 PM_DEVICE_DT_INST_DEFINE(0, qdec_nrfx_pm_action);
 
 DEVICE_DT_INST_DEFINE(0, qdec_nrfx_init,
-		PM_DEVICE_DT_INST_REF(0), NULL, NULL, POST_KERNEL,
+		PM_DEVICE_DT_INST_GET(0), NULL, NULL, POST_KERNEL,
 		CONFIG_SENSOR_INIT_PRIORITY, &qdec_nrfx_driver_api);

--- a/drivers/sensor/sgp40/sgp40.c
+++ b/drivers/sensor/sgp40/sgp40.c
@@ -260,7 +260,7 @@ static const struct sensor_driver_api sgp40_api = {
 								\
 	DEVICE_DT_INST_DEFINE(n,				\
 			      sgp40_init,			\
-			      PM_DEVICE_DT_INST_REF(n),	\
+			      PM_DEVICE_DT_INST_GET(n),	\
 			      &sgp40_data_##n,			\
 			      &sgp40_config_##n,		\
 			      POST_KERNEL,			\

--- a/drivers/sensor/si7210/si7210.c
+++ b/drivers/sensor/si7210/si7210.c
@@ -539,7 +539,7 @@ static int si7210_init(const struct device *dev)
 		.bus = I2C_DT_SPEC_INST_GET(inst), \
 	}; \
 	PM_DEVICE_DT_INST_DEFINE(inst, si7210_pm_action); \
-	DEVICE_DT_INST_DEFINE(inst, si7210_init, PM_DEVICE_DT_INST_REF(inst), \
+	DEVICE_DT_INST_DEFINE(inst, si7210_init, PM_DEVICE_DT_INST_GET(inst), \
 		&si7210_data_##inst, &si7210_config_##inst, POST_KERNEL, \
 		CONFIG_SENSOR_INIT_PRIORITY, &si7210_api_funcs);
 

--- a/drivers/sensor/vcnl4040/vcnl4040.c
+++ b/drivers/sensor/vcnl4040/vcnl4040.c
@@ -367,5 +367,5 @@ static struct vcnl4040_data vcnl4040_data;
 PM_DEVICE_DT_INST_DEFINE(0, vcnl4040_pm_action);
 
 DEVICE_DT_INST_DEFINE(0, vcnl4040_init,
-	      PM_DEVICE_DT_INST_REF(0), &vcnl4040_data, &vcnl4040_config,
+	      PM_DEVICE_DT_INST_GET(0), &vcnl4040_data, &vcnl4040_config,
 	      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &vcnl4040_driver_api);

--- a/drivers/serial/uart_cc13xx_cc26xx.c
+++ b/drivers/serial/uart_cc13xx_cc26xx.c
@@ -539,7 +539,7 @@ static const struct uart_driver_api uart_cc13xx_cc26xx_driver_api = {
 									     \
 	DEVICE_DT_INST_DEFINE(n,					     \
 		uart_cc13xx_cc26xx_init_##n,				     \
-		PM_DEVICE_DT_INST_REF(n),				     \
+		PM_DEVICE_DT_INST_GET(n),				     \
 		&uart_cc13xx_cc26xx_data_##n, &uart_cc13xx_cc26xx_config_##n,\
 		PRE_KERNEL_1, CONFIG_SERIAL_INIT_PRIORITY,		     \
 		&uart_cc13xx_cc26xx_driver_api)

--- a/drivers/serial/uart_ite_it8xxx2.c
+++ b/drivers/serial/uart_ite_it8xxx2.c
@@ -186,7 +186,7 @@ static int uart_it8xxx2_init(const struct device *dev)
 									       \
 	PM_DEVICE_DT_INST_DEFINE(inst, uart_it8xxx2_pm_action);                \
 	DEVICE_DT_INST_DEFINE(inst, &uart_it8xxx2_init,                        \
-			      PM_DEVICE_DT_INST_REF(inst),                     \
+			      PM_DEVICE_DT_INST_GET(inst),                     \
 			      &uart_it8xxx2_data_##inst,                       \
 			      &uart_it8xxx2_cfg_##inst,                        \
 			      PRE_KERNEL_1,                                    \

--- a/drivers/serial/uart_neorv32.c
+++ b/drivers/serial/uart_neorv32.c
@@ -534,7 +534,7 @@ static const struct uart_driver_api neorv32_uart_driver_api = {
 	PM_DEVICE_DT_DEFINE(node_id, neorv32_uart_pm_action);		\
 									\
 	DEVICE_DT_DEFINE(node_id, &neorv32_uart_init,			\
-			 PM_DEVICE_DT_REF(node_id),			\
+			 PM_DEVICE_DT_GET(node_id),			\
 			 &neorv32_uart_##n##_data,			\
 			 &neorv32_uart_##n##_config,			\
 			 PRE_KERNEL_1,					\

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -1231,7 +1231,7 @@ PM_DEVICE_DT_INST_DEFINE(0, uart_nrfx_pm_action);
 
 DEVICE_DT_INST_DEFINE(0,
 	      uart_nrfx_init,
-	      PM_DEVICE_DT_INST_REF(0),
+	      PM_DEVICE_DT_INST_GET(0),
 	      &uart_nrfx_uart0_data,
 	      &uart_nrfx_uart0_config,
 	      /* Initialize UART device before UART console. */

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -2028,7 +2028,7 @@ static int uarte_nrfx_pm_action(const struct device *dev,
 									       \
 	DEVICE_DT_DEFINE(UARTE(idx),					       \
 		      uarte_##idx##_init,				       \
-		      PM_DEVICE_DT_REF(UARTE(idx)),			       \
+		      PM_DEVICE_DT_GET(UARTE(idx)),			       \
 		      &uarte_##idx##_data,				       \
 		      &uarte_##idx##z_config,				       \
 		      PRE_KERNEL_1,					       \

--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -298,7 +298,7 @@ static const struct spi_driver_api spi_cc13xx_cc26xx_driver_api = {
 									    \
 	DEVICE_DT_INST_DEFINE(n,					    \
 		spi_cc13xx_cc26xx_init_##n,				    \
-		PM_DEVICE_DT_INST_REF(n),				    \
+		PM_DEVICE_DT_INST_GET(n),				    \
 		&spi_cc13xx_cc26xx_data_##n, &spi_cc13xx_cc26xx_config_##n, \
 		POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,			    \
 		&spi_cc13xx_cc26xx_driver_api)

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -364,7 +364,7 @@ static int spi_nrfx_pm_action(const struct device *dev,
 	PM_DEVICE_DT_DEFINE(SPI(idx), spi_nrfx_pm_action);		       \
 	DEVICE_DT_DEFINE(SPI(idx),					       \
 		      spi_##idx##_init,					       \
-		      PM_DEVICE_DT_REF(SPI(idx)),			       \
+		      PM_DEVICE_DT_GET(SPI(idx)),			       \
 		      &spi_##idx##_data,				       \
 		      &spi_##idx##z_config,				       \
 		      POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,		       \

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -541,7 +541,7 @@ static int spim_nrfx_pm_action(const struct device *dev,
 	PM_DEVICE_DT_DEFINE(SPIM(idx), spim_nrfx_pm_action);		       \
 	DEVICE_DT_DEFINE(SPIM(idx),					       \
 		      spi_##idx##_init,					       \
-		      PM_DEVICE_DT_REF(SPIM(idx)),			       \
+		      PM_DEVICE_DT_GET(SPIM(idx)),			       \
 		      &spi_##idx##_data,				       \
 		      &spi_##idx##z_config,				       \
 		      POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,		       \

--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -189,11 +189,11 @@ struct pm_device {
  *
  * @param dev_name Device name.
  */
-#define Z_PM_DEVICE_REF(dev_name) &Z_PM_DEVICE_NAME(dev_name)
+#define Z_PM_DEVICE_GET(dev_name) &Z_PM_DEVICE_NAME(dev_name)
 
 #else
 #define Z_PM_DEVICE_DEFINE(node_id, dev_name, pm_action_cb)
-#define Z_PM_DEVICE_REF(dev_name) NULL
+#define Z_PM_DEVICE_GET(dev_name) NULL
 #endif /* CONFIG_PM_DEVICE */
 
 /** @endcond */
@@ -248,8 +248,8 @@ struct pm_device {
  * @return Reference to the device PM resources (NULL if device
  * @kconfig{CONFIG_PM_DEVICE} is disabled).
  */
-#define PM_DEVICE_REF(dev_name) \
-	Z_PM_DEVICE_REF(dev_name)
+#define PM_DEVICE_GET(dev_name) \
+	Z_PM_DEVICE_GET(dev_name)
 
 /**
  * @brief Obtain a reference to the device PM resources for the given node.
@@ -259,8 +259,8 @@ struct pm_device {
  * @return Reference to the device PM resources (NULL if device
  * @kconfig{CONFIG_PM_DEVICE} is disabled).
  */
-#define PM_DEVICE_DT_REF(node_id) \
-	PM_DEVICE_REF(Z_DEVICE_DT_DEV_NAME(node_id))
+#define PM_DEVICE_DT_GET(node_id) \
+	PM_DEVICE_GET(Z_DEVICE_DT_DEV_NAME(node_id))
 
 /**
  * @brief Obtain a reference to the device PM resources for the given instance.
@@ -270,8 +270,8 @@ struct pm_device {
  * @return Reference to the device PM resources (NULL if device
  * @kconfig{CONFIG_PM_DEVICE} is disabled).
  */
-#define PM_DEVICE_DT_INST_REF(idx) \
-	PM_DEVICE_DT_REF(DT_DRV_INST(idx))
+#define PM_DEVICE_DT_INST_GET(idx) \
+	PM_DEVICE_DT_GET(DT_DRV_INST(idx))
 
 /**
  * @brief Get name of device PM state

--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -189,7 +189,7 @@ struct pm_device {
  *
  * @param dev_name Device name.
  */
-#define Z_PM_DEVICE_GET(dev_name) &Z_PM_DEVICE_NAME(dev_name)
+#define Z_PM_DEVICE_GET(dev_name) (&Z_PM_DEVICE_NAME(dev_name))
 
 #else
 #define Z_PM_DEVICE_DEFINE(node_id, dev_name, pm_action_cb)

--- a/samples/subsys/pm/device_pm/src/dummy_driver.c
+++ b/samples/subsys/pm/device_pm/src/dummy_driver.c
@@ -115,5 +115,5 @@ int dummy_init(const struct device *dev)
 PM_DEVICE_DEFINE(dummy_driver, dummy_device_pm_action);
 
 DEVICE_DEFINE(dummy_driver, DUMMY_DRIVER_NAME, &dummy_init,
-		    PM_DEVICE_REF(dummy_driver), NULL, NULL, APPLICATION,
+		    PM_DEVICE_GET(dummy_driver), NULL, NULL, APPLICATION,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &funcs);

--- a/samples/subsys/pm/device_pm/src/dummy_parent.c
+++ b/samples/subsys/pm/device_pm/src/dummy_parent.c
@@ -54,5 +54,5 @@ int dummy_parent_init(const struct device *dev)
 PM_DEVICE_DEFINE(dummy_parent, dummy_parent_pm_action);
 
 DEVICE_DEFINE(dummy_parent, DUMMY_PARENT_NAME, &dummy_parent_init,
-		    PM_DEVICE_REF(dummy_parent), NULL, NULL, POST_KERNEL,
+		    PM_DEVICE_GET(dummy_parent), NULL, NULL, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &funcs);

--- a/tests/benchmarks/footprints/src/pm_device.c
+++ b/tests/benchmarks/footprints/src/pm_device.c
@@ -31,7 +31,7 @@ static int dummy_device_pm_action(const struct device *dev,
 PM_DEVICE_DEFINE(dummy_pm_driver, dummy_device_pm_action);
 
 DEVICE_DEFINE(dummy_pm_driver, DUMMY_PM_DRIVER_NAME, &dummy_init,
-		    PM_DEVICE_REF(dummy_pm_driver), NULL, NULL, APPLICATION,
+		    PM_DEVICE_GET(dummy_pm_driver), NULL, NULL, APPLICATION,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
 
 DEVICE_DEFINE(dummy_driver, DUMMY_DRIVER_NAME, &dummy_init,

--- a/tests/net/pm/src/main.c
+++ b/tests/net/pm/src/main.c
@@ -103,7 +103,7 @@ static struct dummy_api fake_dev_if_api = {
 PM_DEVICE_DEFINE(fake_dev, fake_dev_pm_action);
 
 NET_DEVICE_INIT(fake_dev, "fake_dev",
-		fake_dev_init, PM_DEVICE_REF(fake_dev),
+		fake_dev_init, PM_DEVICE_GET(fake_dev),
 		&fake_dev_context_data, NULL,
 		CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		&fake_dev_if_api, _ETH_L2_LAYER, _ETH_L2_CTX_TYPE, 127);

--- a/tests/subsys/pm/device_runtime_api/src/test_driver.c
+++ b/tests/subsys/pm/device_runtime_api/src/test_driver.c
@@ -67,5 +67,5 @@ PM_DEVICE_DEFINE(test_driver, test_driver_action);
 static struct test_driver_data data;
 
 DEVICE_DEFINE(test_driver, "test_driver", &test_driver_init,
-	      PM_DEVICE_REF(test_driver), &data, NULL, POST_KERNEL,
+	      PM_DEVICE_GET(test_driver), &data, NULL, POST_KERNEL,
 	      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, NULL);

--- a/tests/subsys/pm/power_mgmt/src/dummy_driver.c
+++ b/tests/subsys/pm/power_mgmt/src/dummy_driver.c
@@ -39,5 +39,5 @@ int dummy_init(const struct device *dev)
 PM_DEVICE_DEFINE(dummy_driver, dummy_device_pm_action);
 
 DEVICE_DEFINE(dummy_driver, DUMMY_DRIVER_NAME, &dummy_init,
-	      PM_DEVICE_REF(dummy_driver), NULL, NULL, APPLICATION,
+	      PM_DEVICE_GET(dummy_driver), NULL, NULL, APPLICATION,
 	      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &funcs);

--- a/tests/subsys/pm/power_mgmt/src/main.c
+++ b/tests/subsys/pm/power_mgmt/src/main.c
@@ -74,7 +74,7 @@ static int device_a_pm_action(const struct device *dev,
 PM_DEVICE_DT_DEFINE(DT_INST(0, test_device_pm), device_a_pm_action);
 
 DEVICE_DT_DEFINE(DT_INST(0, test_device_pm), device_init,
-		PM_DEVICE_DT_REF(DT_INST(0, test_device_pm)), NULL, NULL,
+		PM_DEVICE_DT_GET(DT_INST(0, test_device_pm)), NULL, NULL,
 		PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		NULL);
 
@@ -119,7 +119,7 @@ static int device_b_pm_action(const struct device *dev,
 PM_DEVICE_DT_DEFINE(DT_INST(1, test_device_pm), device_b_pm_action);
 
 DEVICE_DT_DEFINE(DT_INST(1, test_device_pm), device_init,
-		PM_DEVICE_DT_REF(DT_INST(1, test_device_pm)), NULL, NULL,
+		PM_DEVICE_DT_GET(DT_INST(1, test_device_pm)), NULL, NULL,
 		PRE_KERNEL_2, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		NULL);
 
@@ -135,7 +135,7 @@ static int device_c_pm_action(const struct device *dev,
 PM_DEVICE_DT_DEFINE(DT_INST(2, test_device_pm), device_c_pm_action);
 
 DEVICE_DT_DEFINE(DT_INST(2, test_device_pm), device_init,
-		PM_DEVICE_DT_REF(DT_INST(2, test_device_pm)), NULL, NULL,
+		PM_DEVICE_DT_GET(DT_INST(2, test_device_pm)), NULL, NULL,
 		POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		NULL);
 


### PR DESCRIPTION
To align with macros used to obtain a device reference (e.g.
`DEVICE_DT_GET`), align the PM macros to use "GET" instead of "REF". This
change should have low impact since no official release has gone out yet
with the "REF" macros.