### PR TITLE
Bluetooth: controller: LLCP: Rejection logic for handling non-supported features

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -352,6 +352,9 @@ struct proc_ctx *llcp_create_remote_procedure(enum llcp_proc proc)
 	}
 
 	switch (ctx->proc) {
+	case PROC_UNKNOWN:
+		/* Nothing to do */
+		break;
 #if defined(CONFIG_BT_CTLR_LE_PING)
 	case PROC_LE_PING:
 		llcp_rp_comm_init_proc(ctx);

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -223,12 +223,18 @@ static void run_test_functions(struct unit_test *test)
 #define FAIL_FAST 0
 
 static jmp_buf test_fail;
+static jmp_buf test_skip;
 static jmp_buf test_pass;
 static jmp_buf stack_fail;
 
 void ztest_test_fail(void)
 {
 	raise(SIGABRT);
+}
+
+void ztest_test_skip(void)
+{
+	longjmp(test_skip, 1);
 }
 
 void ztest_test_pass(void)
@@ -271,11 +277,17 @@ static void init_testing(void)
 static int run_test(struct unit_test *test)
 {
 	int ret = TC_PASS;
+	int skip = 0;
 
 	TC_START(test->name);
 
 	if (setjmp(test_fail)) {
 		ret = TC_FAIL;
+		goto out;
+	}
+
+	if (setjmp(test_skip)) {
+		skip = 1;
 		goto out;
 	}
 
@@ -287,7 +299,12 @@ static int run_test(struct unit_test *test)
 	run_test_functions(test);
 out:
 	ret |= cleanup_test(test);
-	Z_TC_END_RESULT(ret, test->name);
+
+	if (skip) {
+		Z_TC_END_RESULT(TC_SKIP, test->name);
+	} else {
+		Z_TC_END_RESULT(ret, test->name);
+	}
 
 	return ret;
 }

--- a/tests/bluetooth/controller/common/include/helper_util.h
+++ b/tests/bluetooth/controller/common/include/helper_util.h
@@ -15,6 +15,8 @@ void event_done(struct ll_conn *conn);
 uint16_t event_counter(struct ll_conn *conn);
 
 #define lt_tx(_opcode, _conn, _param) lt_tx_real(__FILE__, __LINE__, _opcode, _conn, _param)
+#define lt_tx_no_encode(_pdu, _conn, _param)                                                       \
+	lt_tx_real_no_encode(__FILE__, __LINE__, _pdu, _conn, _param)
 #define lt_rx(_opcode, _conn, _tx_ref, _param)                                                     \
 	lt_rx_real(__FILE__, __LINE__, _opcode, _conn, _tx_ref, _param)
 #define lt_rx_q_is_empty(_conn) lt_rx_q_is_empty_real(__FILE__, __LINE__, _conn)
@@ -27,6 +29,8 @@ uint16_t event_counter(struct ll_conn *conn);
 
 void lt_tx_real(const char *file, uint32_t line, enum helper_pdu_opcode opcode,
 		struct ll_conn *conn, void *param);
+void lt_tx_real_no_encode(const char *file, uint32_t line, struct pdu_data *pdu,
+			  struct ll_conn *conn, void *param);
 void lt_rx_real(const char *file, uint32_t line, enum helper_pdu_opcode opcode,
 		struct ll_conn *conn, struct node_tx **tx_ref, void *param);
 void lt_rx_q_is_empty_real(const char *file, uint32_t line, struct ll_conn *conn);
@@ -35,3 +39,5 @@ void ut_rx_pdu_real(const char *file, uint32_t line, enum helper_pdu_opcode opco
 void ut_rx_node_real(const char *file, uint32_t line, enum helper_node_opcode opcode,
 		     struct node_rx_pdu **ntf_ref, void *param);
 void ut_rx_q_is_empty_real(const char *file, uint32_t line);
+
+void encode_pdu(enum helper_pdu_opcode opcode, struct pdu_data *pdu, void *param);

--- a/tests/bluetooth/controller/common/src/helper_pdu.c
+++ b/tests/bluetooth/controller/common/src/helper_pdu.c
@@ -7,7 +7,6 @@
 
 #include "zephyr/types.h"
 #include "ztest.h"
-#include "kconfig.h"
 
 #include <bluetooth/hci.h>
 #include <sys/byteorder.h>

--- a/tests/bluetooth/controller/ctrl_unsupported/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_unsupported/CMakeLists.txt
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20)
+
+if (NOT BOARD STREQUAL unit_testing)
+  message(FATAL_ERROR "This project can only be used with '-DBOARD=unit_testing'.")
+endif()
+
+FILE(GLOB SOURCES
+  src/*.c
+)
+
+project(bluetooth_ull_llcp_unsupported)
+find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})
+include(${ZEPHYR_BASE}/tests/bluetooth/controller/common/defaults_cmake.txt)
+
+target_sources(testbinary PRIVATE ${ll_sw_sources} ${mock_sources} ${common_sources})

--- a/tests/bluetooth/controller/ctrl_unsupported/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_unsupported/CMakeLists.txt
@@ -10,8 +10,38 @@ FILE(GLOB SOURCES
   src/*.c
 )
 
+# Propagate NO_ENC to compile
+if(NO_ENC)
+  add_compile_definitions(NO_ENC)
+endif()
+
+# Propagate NO_PER_FEAT_EXCH to compile
+if(NO_PER_FEAT_EXCH)
+  add_compile_definitions(NO_PER_FEAT_EXCH)
+endif()
+
+# Propagate NO_CPR to compile
+if(NO_CPR)
+  add_compile_definitions(NO_CPR)
+endif()
+
+# Propagate NO_PHY to compile
+if(NO_PHY)
+  add_compile_definitions(NO_PHY)
+endif()
+
 project(bluetooth_ull_llcp_unsupported)
 find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})
 include(${ZEPHYR_BASE}/tests/bluetooth/controller/common/defaults_cmake.txt)
+
+# Remove ull_llcp_enc.c from compile
+if(NO_ENC)
+  list(REMOVE_ITEM ll_sw_sources ${ZEPHYR_BASE}/subsys/bluetooth/controller/ll_sw/ull_llcp_enc.c)
+endif()
+
+# Remove ull_llcp_phy.c from compile
+if(NO_PHY)
+  list(REMOVE_ITEM ll_sw_sources ${ZEPHYR_BASE}/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c)
+endif()
 
 target_sources(testbinary PRIVATE ${ll_sw_sources} ${mock_sources} ${common_sources})

--- a/tests/bluetooth/controller/ctrl_unsupported/src/kconfig_override.h
+++ b/tests/bluetooth/controller/ctrl_unsupported/src/kconfig_override.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2021 Demant
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#if defined(NO_ENC)
+#undef CONFIG_BT_CTLR_LE_ENC
+#endif /* NO_ENC */
+
+#if defined(NO_PER_FEAT_EXCH)
+#undef CONFIG_BT_CTLR_PER_INIT_FEAT_XCHG
+#endif /* NO_PER_FEAT_EXCH */
+
+#if defined(NO_CPR)
+#undef CONFIG_BT_CTLR_CONN_PARAM_REQ
+#endif /* NO_CPR */
+
+#if defined(NO_PHY)
+#undef CONFIG_BT_CTLR_PHY
+#endif /* NO_PHY */

--- a/tests/bluetooth/controller/ctrl_unsupported/src/main.c
+++ b/tests/bluetooth/controller/ctrl_unsupported/src/main.c
@@ -241,6 +241,144 @@ void test_undefined_cen_rem(void)
 	}
 }
 
+#ifdef CONFIG_BT_CTLR_LE_ENC
+void test_no_enc_per_rem(void)
+{
+	/* Skip test;
+	 * LE Encryption support is available
+	 */
+	ztest_test_skip();
+}
+#else
+void test_no_enc_per_rem(void)
+{
+	/* Role */
+	test_set_role(&test_conn, BT_HCI_ROLE_PERIPHERAL);
+
+	lt_tx_pdu_and_rx_unknown_rsp(LL_ENC_REQ);
+}
+#endif /* CONFIG_BT_CTLR_LE_ENC */
+
+void test_no_enc_cen_rem(void)
+{
+	/* Role */
+	test_set_role(&test_conn, BT_HCI_ROLE_CENTRAL);
+
+	lt_tx_pdu_and_rx_unknown_rsp(LL_ENC_REQ);
+}
+
+#if defined(CONFIG_BT_CTLR_PER_INIT_FEAT_XCHG)
+void test_no_per_feat_exch_per_rem(void)
+{
+	/* Skip test;
+	 * Peripheral-initiated Features Exchange support is available
+	 */
+	ztest_test_skip();
+}
+#else
+void test_no_per_feat_exch_per_rem(void)
+{
+	/* Role */
+	test_set_role(&test_conn, BT_HCI_ROLE_PERIPHERAL);
+
+	lt_tx_pdu_and_rx_unknown_rsp(LL_PERIPH_FEAT_XCHG);
+}
+#endif /* CONFIG_BT_CTLR_PER_INIT_FEAT_XCHG */
+
+#if defined(CONFIG_BT_CTLR_PER_INIT_FEAT_XCHG)
+void test_no_per_feat_exch_cen_rem(void)
+{
+	/* Skip test;
+	 * Peripheral-initiated Features Exchange support is available
+	 */
+	ztest_test_skip();
+}
+#else
+void test_no_per_feat_exch_cen_rem(void)
+{
+	/* Role */
+	test_set_role(&test_conn, BT_HCI_ROLE_CENTRAL);
+
+	lt_tx_pdu_and_rx_unknown_rsp(LL_PERIPH_FEAT_XCHG);
+}
+#endif /* CONFIG_BT_CTLR_PER_INIT_FEAT_XCHG */
+
+
+#if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
+void test_no_cpr_per_rem(void)
+{
+	/* Skip test;
+	 * Connection Parameters Request procedure support is available
+	 */
+	ztest_test_skip();
+}
+#else
+void test_no_cpr_per_rem(void)
+{
+	/* Role */
+	test_set_role(&test_conn, BT_HCI_ROLE_PERIPHERAL);
+
+	lt_tx_pdu_and_rx_unknown_rsp(LL_CONNECTION_PARAM_REQ);
+}
+#endif /* CONFIG_BT_CTLR_CONN_PARAM_REQ */
+
+#if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
+void test_no_cpr_cen_rem(void)
+{
+	/* Skip test;
+	 * Connection Parameters Request procedure support is available
+	 */
+	ztest_test_skip();
+}
+#else
+void test_no_cpr_cen_rem(void)
+{
+	/* Role */
+	test_set_role(&test_conn, BT_HCI_ROLE_CENTRAL);
+
+	lt_tx_pdu_and_rx_unknown_rsp(LL_CONNECTION_PARAM_REQ);
+}
+#endif /* CONFIG_BT_CTLR_CONN_PARAM_REQ */
+
+
+#if defined(CONFIG_BT_CTLR_PHY)
+void test_no_phy_per_rem(void)
+{
+	/* Skip test;
+	 * LE 2M PHY support is available
+	 */
+	ztest_test_skip();
+}
+#else
+void test_no_phy_per_rem(void)
+{
+	/* Role */
+	test_set_role(&test_conn, BT_HCI_ROLE_PERIPHERAL);
+
+	lt_tx_pdu_and_rx_unknown_rsp(LL_PHY_REQ);
+}
+#endif /* CONFIG_BT_CTLR_PHY */
+
+#if defined(CONFIG_BT_CTLR_PHY)
+void test_no_phy_cen_rem(void)
+{
+	/* Skip test;
+	 * LE 2M PHY support is available
+	 */
+	ztest_test_skip();
+}
+#else
+void test_no_phy_cen_rem(void)
+{
+	/* Role */
+	test_set_role(&test_conn, BT_HCI_ROLE_CENTRAL);
+
+	lt_tx_pdu_and_rx_unknown_rsp(LL_PHY_REQ);
+}
+#endif /* CONFIG_BT_CTLR_PHY */
+
+
+
 void test_main(void)
 {
 	ztest_test_suite(invalid,
@@ -255,6 +393,26 @@ void test_main(void)
 			 ztest_unit_test_setup_teardown(test_undefined_cen_rem, setup,
 							unit_test_noop));
 
+	ztest_test_suite(unsupported,
+			 ztest_unit_test_setup_teardown(test_no_enc_per_rem, setup,
+							unit_test_noop),
+			 ztest_unit_test_setup_teardown(test_no_enc_cen_rem, setup,
+							unit_test_noop),
+			 ztest_unit_test_setup_teardown(test_no_per_feat_exch_per_rem, setup,
+							unit_test_noop),
+			 ztest_unit_test_setup_teardown(test_no_per_feat_exch_cen_rem, setup,
+							unit_test_noop),
+			 ztest_unit_test_setup_teardown(test_no_cpr_per_rem, setup,
+							unit_test_noop),
+			 ztest_unit_test_setup_teardown(test_no_cpr_cen_rem, setup,
+							unit_test_noop),
+			 ztest_unit_test_setup_teardown(test_no_phy_per_rem, setup,
+							unit_test_noop),
+			 ztest_unit_test_setup_teardown(test_no_phy_cen_rem, setup,
+							unit_test_noop)
+			 );
+
 	ztest_run_test_suite(invalid);
 	ztest_run_test_suite(undefined);
+	ztest_run_test_suite(unsupported);
 }

--- a/tests/bluetooth/controller/ctrl_unsupported/src/main.c
+++ b/tests/bluetooth/controller/ctrl_unsupported/src/main.c
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2022 Demant
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/types.h>
+#include <ztest.h>
+
+#include <bluetooth/hci.h>
+#include <sys/byteorder.h>
+#include <sys/slist.h>
+#include <sys/util.h>
+#include "hal/ccm.h"
+
+#include "util/util.h"
+#include "util/mem.h"
+#include "util/memq.h"
+#include "util/dbuf.h"
+
+#include "pdu.h"
+#include "ll.h"
+#include "ll_settings.h"
+#include "ll_feat.h"
+
+#include "lll.h"
+#include "lll_df_types.h"
+#include "lll_conn.h"
+#include "ull_tx_queue.h"
+
+#include "ull_conn_types.h"
+#include "ull_llcp.h"
+#include "ull_llcp_internal.h"
+
+#include "helper_pdu.h"
+#include "helper_util.h"
+
+struct ll_conn test_conn;
+
+static void setup(void)
+{
+	test_setup(&test_conn);
+}
+
+#define LLCTRL_PDU_SIZE (offsetof(struct pdu_data, llctrl) + sizeof(struct pdu_data_llctrl))
+
+/* +-----+ +-------+            +-----+
+ * | UT  | | LL_A  |            | LT  |
+ * +-----+ +-------+            +-----+
+ *    |        |                   |
+ *    |        |             <PDU> |
+ *    |        |<------------------|
+ *    |        |                   |
+ *    |        | LL_UNKNOWN_RSP    |
+ *    |        |------------------>|
+ *    |        |                   |
+ */
+static void lt_tx_pdu_and_rx_unknown_rsp(enum helper_pdu_opcode opcode)
+{
+	struct node_tx *tx;
+	struct pdu_data pdu;
+	/* PDU contents does not matter when testing for invalid PDU opcodes */
+	uint8_t data[LLCTRL_PDU_SIZE] = { 0 };
+
+	/* Encode a PDU for the opcode */
+	encode_pdu(opcode, &pdu, &data);
+
+	/* Setup the LL_UNKNOWN_RSP expected for the PDU */
+	struct pdu_data_llctrl_unknown_rsp unknown_rsp = {
+		.type = pdu.llctrl.opcode
+	};
+
+	/* Connect */
+	ull_cp_state_set(&test_conn, ULL_CP_CONNECTED);
+
+	/* Prepare */
+	event_prepare(&test_conn);
+
+	/* Rx */
+	lt_tx(opcode, &test_conn, &pdu.llctrl.unknown_rsp);
+
+	/* Done */
+	event_done(&test_conn);
+
+	/* Prepare */
+	event_prepare(&test_conn);
+
+	/* Tx Queue should have one LL Control PDU */
+	lt_rx(LL_UNKNOWN_RSP, &test_conn, &tx, &unknown_rsp);
+	lt_rx_q_is_empty(&test_conn);
+
+	/* Done */
+	event_done(&test_conn);
+
+	/* Release Tx */
+	ull_cp_release_tx(&test_conn, tx);
+
+	/* There should not be a host notifications */
+	ut_rx_q_is_empty();
+
+	zassert_equal(ctx_buffers_free(), CONFIG_BT_CTLR_LLCP_PROC_CTX_BUF_NUM,
+		      "Free CTX buffers %d", ctx_buffers_free());
+}
+
+static void lt_tx_undef_opcode_and_rx_unknown_rsp(uint8_t opcode)
+{
+	struct node_tx *tx;
+	struct pdu_data pdu;
+	/* PDU contents does not matter when testing for invalid PDU opcodes */
+	uint8_t data[LLCTRL_PDU_SIZE] = { 0 };
+
+	/* Undefined opcodes cannot be encoded, so encode a LL_UNKNOWN_RSP as
+	 * a placeholder and override the opcode
+	 */
+	encode_pdu(LL_UNKNOWN_RSP, &pdu, &data);
+	pdu.llctrl.opcode = opcode;
+
+	/* Setup the LL_UNKNOWN_RSP expected for the PDU */
+	struct pdu_data_llctrl_unknown_rsp unknown_rsp = {
+		.type = pdu.llctrl.opcode
+	};
+
+	/* Connect */
+	ull_cp_state_set(&test_conn, ULL_CP_CONNECTED);
+
+	/* Prepare */
+	event_prepare(&test_conn);
+
+	/* Rx */
+	lt_tx_no_encode(&pdu, &test_conn, &pdu.llctrl.unknown_rsp);
+
+	/* Done */
+	event_done(&test_conn);
+
+	/* Prepare */
+	event_prepare(&test_conn);
+
+	/* Tx Queue should have one LL Control PDU */
+	lt_rx(LL_UNKNOWN_RSP, &test_conn, &tx, &unknown_rsp);
+	lt_rx_q_is_empty(&test_conn);
+
+	/* Done */
+	event_done(&test_conn);
+
+	/* Release Tx */
+	ull_cp_release_tx(&test_conn, tx);
+
+	/* There should not be a host notifications */
+	ut_rx_q_is_empty();
+
+	zassert_equal(ctx_buffers_free(), CONFIG_BT_CTLR_LLCP_PROC_CTX_BUF_NUM,
+		      "Free CTX buffers %d", ctx_buffers_free());
+}
+
+void test_invalid_per_rem(void)
+{
+	/* Role */
+	test_set_role(&test_conn, BT_HCI_ROLE_PERIPHERAL);
+
+	/* Test opcodes that cannot initiate a remote procedure */
+	lt_tx_pdu_and_rx_unknown_rsp(LL_ENC_RSP);
+	lt_tx_pdu_and_rx_unknown_rsp(LL_START_ENC_REQ);
+	lt_tx_pdu_and_rx_unknown_rsp(LL_START_ENC_RSP);
+	lt_tx_pdu_and_rx_unknown_rsp(LL_UNKNOWN_RSP);
+	lt_tx_pdu_and_rx_unknown_rsp(LL_FEATURE_RSP);
+	lt_tx_pdu_and_rx_unknown_rsp(LL_PAUSE_ENC_RSP);
+	lt_tx_pdu_and_rx_unknown_rsp(LL_REJECT_IND);
+	lt_tx_pdu_and_rx_unknown_rsp(LL_CONNECTION_PARAM_RSP);
+	lt_tx_pdu_and_rx_unknown_rsp(LL_REJECT_EXT_IND);
+	lt_tx_pdu_and_rx_unknown_rsp(LL_LE_PING_RSP);
+	lt_tx_pdu_and_rx_unknown_rsp(LL_LENGTH_RSP);
+	lt_tx_pdu_and_rx_unknown_rsp(LL_PHY_RSP);
+	lt_tx_pdu_and_rx_unknown_rsp(LL_PHY_UPDATE_IND);
+	lt_tx_pdu_and_rx_unknown_rsp(LL_CTE_RSP);
+
+	/* Test opcodes that can initiate a remote procedure but use the wrong
+	 * role
+	 */
+	lt_tx_pdu_and_rx_unknown_rsp(LL_PERIPH_FEAT_XCHG);
+	lt_tx_pdu_and_rx_unknown_rsp(LL_MIN_USED_CHANS_IND);
+}
+
+void test_invalid_cen_rem(void)
+{
+	/* Role */
+	test_set_role(&test_conn, BT_HCI_ROLE_CENTRAL);
+
+	/* Test opcodes that cannot initiate a remote procedure */
+	lt_tx_pdu_and_rx_unknown_rsp(LL_ENC_RSP);
+	lt_tx_pdu_and_rx_unknown_rsp(LL_START_ENC_REQ);
+	lt_tx_pdu_and_rx_unknown_rsp(LL_START_ENC_RSP);
+	lt_tx_pdu_and_rx_unknown_rsp(LL_UNKNOWN_RSP);
+	lt_tx_pdu_and_rx_unknown_rsp(LL_FEATURE_RSP);
+	lt_tx_pdu_and_rx_unknown_rsp(LL_PAUSE_ENC_RSP);
+	lt_tx_pdu_and_rx_unknown_rsp(LL_REJECT_IND);
+	lt_tx_pdu_and_rx_unknown_rsp(LL_CONNECTION_PARAM_RSP);
+	lt_tx_pdu_and_rx_unknown_rsp(LL_REJECT_EXT_IND);
+	lt_tx_pdu_and_rx_unknown_rsp(LL_LE_PING_RSP);
+	lt_tx_pdu_and_rx_unknown_rsp(LL_LENGTH_RSP);
+	lt_tx_pdu_and_rx_unknown_rsp(LL_PHY_RSP);
+	lt_tx_pdu_and_rx_unknown_rsp(LL_PHY_UPDATE_IND);
+	lt_tx_pdu_and_rx_unknown_rsp(LL_CTE_RSP);
+
+	/* Test opcodes that can initiate a remote procedure but use the wrong
+	 * role
+	 */
+	lt_tx_pdu_and_rx_unknown_rsp(LL_CONNECTION_UPDATE_IND);
+	lt_tx_pdu_and_rx_unknown_rsp(LL_CHAN_MAP_UPDATE_IND);
+	lt_tx_pdu_and_rx_unknown_rsp(LL_ENC_REQ);
+	lt_tx_pdu_and_rx_unknown_rsp(LL_FEATURE_REQ);
+	lt_tx_pdu_and_rx_unknown_rsp(LL_PAUSE_ENC_REQ);
+}
+
+void test_undefined_per_rem(void)
+{
+	/* Role */
+	test_set_role(&test_conn, BT_HCI_ROLE_PERIPHERAL);
+
+	/* Test undefined opcodes that cannot initiate a remote procedure */
+
+	/* BLUETOOTH CORE SPECIFICATION Version 5.3 | Vol 6, Part B, Table 2.18:
+	 * LL Control PDU opcodes
+	 */
+	for (uint16_t opcode = 0x30; opcode < 0x100; opcode++) {
+		lt_tx_undef_opcode_and_rx_unknown_rsp(opcode);
+	}
+}
+
+void test_undefined_cen_rem(void)
+{
+	/* Role */
+	test_set_role(&test_conn, BT_HCI_ROLE_CENTRAL);
+
+	/* Test undefined opcodes that cannot initiate a remote procedure */
+
+	/* BLUETOOTH CORE SPECIFICATION Version 5.3 | Vol 6, Part B, Table 2.18:
+	 * LL Control PDU opcodes
+	 */
+	for (uint16_t opcode = 0x30; opcode < 0x100; opcode++) {
+		lt_tx_undef_opcode_and_rx_unknown_rsp(opcode);
+	}
+}
+
+void test_main(void)
+{
+	ztest_test_suite(invalid,
+			 ztest_unit_test_setup_teardown(test_invalid_per_rem, setup,
+							unit_test_noop),
+			 ztest_unit_test_setup_teardown(test_invalid_cen_rem, setup,
+							unit_test_noop));
+
+	ztest_test_suite(undefined,
+			 ztest_unit_test_setup_teardown(test_undefined_per_rem, setup,
+							unit_test_noop),
+			 ztest_unit_test_setup_teardown(test_undefined_cen_rem, setup,
+							unit_test_noop));
+
+	ztest_run_test_suite(invalid);
+	ztest_run_test_suite(undefined);
+}

--- a/tests/bluetooth/controller/ctrl_unsupported/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_unsupported/testcase.yaml
@@ -3,3 +3,15 @@ common:
 tests:
   bluetooth.controller.ctrl_unsupported.default.test:
      type: unit
+  bluetooth.controller.ctrl_unsupported.no_enc.test:
+     type: unit
+     extra_args: NO_ENC=y KCONFIG_OVERRIDE_FILE="kconfig_override.h"
+  bluetooth.controller.ctrl_unsupported.no_per_feat_exch.test:
+     type: unit
+     extra_args: NO_PER_FEAT_EXCH=y KCONFIG_OVERRIDE_FILE="kconfig_override.h"
+  bluetooth.controller.ctrl_unsupported.no_cpr.test:
+     type: unit
+     extra_args: NO_CPR=y KCONFIG_OVERRIDE_FILE="kconfig_override.h"
+  bluetooth.controller.ctrl_unsupported.no_phy.test:
+     type: unit
+     extra_args: NO_PHY=y KCONFIG_OVERRIDE_FILE="kconfig_override.h"

--- a/tests/bluetooth/controller/ctrl_unsupported/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_unsupported/testcase.yaml
@@ -1,0 +1,5 @@
+common:
+    tags: test_framework bluetooth bt_unsupported bt_ull_llcp
+tests:
+  bluetooth.controller.ctrl_unsupported.default.test:
+     type: unit


### PR DESCRIPTION
Implement rejection logic for handling non-supported features and unit tests for:

- Invalid opcodes based on controller role
- No LE Encryption support
- No Connection Parameters Request procedure support
- No Peripheral-initiated Features Exchange support
- No LE 2M PHY/LE Coded PHY support

Update ztest for non-kernel test to support skipping via `ztest_test_skip()`.