### PR TITLE
drivers: uart: fix esp32 TX checks

### DIFF
--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -391,7 +391,8 @@ static void uart_esp32_irq_tx_disable(const struct device *dev)
 
 static int uart_esp32_irq_tx_ready(const struct device *dev)
 {
-	return (uart_hal_get_txfifo_len(&DEV_CFG(dev)->hal) > 0);
+	return (uart_hal_get_txfifo_len(&DEV_CFG(dev)->hal) > 0 &&
+			uart_hal_get_intr_ena_status(&DEV_CFG(dev)->hal) & UART_INTR_TXFIFO_EMPTY);
 }
 
 static void uart_esp32_irq_rx_enable(const struct device *dev)
@@ -410,8 +411,7 @@ static void uart_esp32_irq_rx_disable(const struct device *dev)
 
 static int uart_esp32_irq_tx_complete(const struct device *dev)
 {
-	/* check if TX FIFO is empty */
-	return (uart_hal_get_txfifo_len(&DEV_CFG(dev)->hal) == UART_LL_FIFO_DEF_LEN ? 1 : 0);
+	return uart_hal_is_tx_idle(&DEV_CFG(dev)->hal);
 }
 
 static int uart_esp32_irq_rx_ready(const struct device *dev)


### PR DESCRIPTION
This fixes both TX ready and TX completed UART
calls to meet valid condition.

Closes #41526
Closes #41624

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>