### PR TITLE
lorawan: adding settings NVM for LoRaWAN

### DIFF
--- a/subsys/lorawan/CMakeLists.txt
+++ b/subsys/lorawan/CMakeLists.txt
@@ -22,3 +22,4 @@ zephyr_compile_definitions_ifdef(CONFIG_LORAMAC_REGION_RU864 REGION_RU864)
 
 zephyr_library_sources_ifdef(CONFIG_LORAWAN lorawan.c)
 zephyr_library_sources_ifdef(CONFIG_LORAWAN lw_priv.c)
+add_subdirectory(nvm)

--- a/subsys/lorawan/Kconfig
+++ b/subsys/lorawan/Kconfig
@@ -66,4 +66,6 @@ config LORAMAC_REGION_RU864
 
 endchoice
 
+rsource "nvm/Kconfig"
+
 endif # LORAWAN

--- a/subsys/lorawan/nvm/CMakeLists.txt
+++ b/subsys/lorawan/nvm/CMakeLists.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library_sources_ifdef(CONFIG_LORAWAN_NVM_SETTINGS lorawan_nvm_settings.c)

--- a/subsys/lorawan/nvm/Kconfig
+++ b/subsys/lorawan/nvm/Kconfig
@@ -1,0 +1,23 @@
+# LoRaWAN Non Volatile Memory configuration options
+
+# Copyright (c) 2022 Intellinium <giuliano.franchetto@intellinium.com>
+# SPDX-License-Identifier: Apache-2.0
+
+choice LORAWAN_NVM
+	bool "LoRaWAN NVM backend"
+	default LORAWAN_NVM_SETTINGS if SETTINGS
+	default LORAWAN_NVM_NONE
+
+config LORAWAN_NVM_NONE
+	bool "No NVM backend for LoRaWAN"
+	help
+	  If this configuration is used, it is the responsibility of the
+	  application to store and restore the DevNonce value each time
+	  a OTAA join request is sent. This value should be used in the
+	  join configuration directly.
+
+config LORAWAN_NVM_SETTINGS
+	bool "Settings based NVM"
+	depends on SETTINGS
+
+endchoice

--- a/subsys/lorawan/nvm/lorawan_nvm.h
+++ b/subsys/lorawan/nvm/lorawan_nvm.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022 Intellinium <giuliano.franchetto@intellinium.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_SUBSYS_LORAWAN_NVM_H_
+#define ZEPHYR_SUBSYS_LORAWAN_NVM_H_
+
+#include <stdint.h>
+
+/**
+ * @brief Hook function called when an interrupt related to NVM
+ * is received from the LoRaWAN stack.
+ *
+ * @note This function should not be called directly by the application
+ *
+ * @param flags OR'ed flags received with the interrupt
+ *
+ * @see LORAMAC_NVM_NOTIFY_FLAG_NONE
+ * @see LORAMAC_NVM_NOTIFY_FLAG_CRYPTO
+ * @see LORAMAC_NVM_NOTIFY_FLAG_MAC_GROUP1
+ * @see LORAMAC_NVM_NOTIFY_FLAG_MAC_GROUP2
+ * @see LORAMAC_NVM_NOTIFY_FLAG_SECURE_ELEMENT
+ * @see LORAMAC_NVM_NOTIFY_FLAG_REGION_GROUP1
+ * @see LORAMAC_NVM_NOTIFY_FLAG_REGION_GROUP2
+ * @see LORAMAC_NVM_NOTIFY_FLAG_CLASS_B
+ */
+void lorawan_nvm_data_mgmt_event(uint16_t flags);
+
+/**
+ * @brief Restores all the relevant LoRaWAN data from the Non-Volatile Memory.
+ *
+ * @note This function should only be called if a NVM has been enabled, and
+ * not directly by the application.
+ *
+ * @return 0 on success, or a negative error code otherwise
+ */
+int lorawan_nvm_data_restore(void);
+
+/**
+ * @brief Initializes the NVM backend
+ *
+ * @note This function shall be called before any other
+ * NVM back functions.
+ *
+ * @return 0 on success, or a negative error code otherwise
+ */
+int lorawan_nvm_init(void);
+
+#endif /* ZEPHYR_SUBSYS_LORAWAN_NVM_H_ */

--- a/subsys/lorawan/nvm/lorawan_nvm_settings.c
+++ b/subsys/lorawan/nvm/lorawan_nvm_settings.c
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2022 Intellinium <giuliano.franchetto@intellinium.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <LoRaMac.h>
+#include <kernel.h>
+#include <settings/settings.h>
+#include "lorawan_nvm.h"
+#include <logging/log.h>
+
+LOG_MODULE_REGISTER(lorawan_nvm, CONFIG_LORAWAN_LOG_LEVEL);
+
+#define LORAWAN_SETTINGS_BASE                "lorawan/nvm"
+
+struct lorawan_nvm_setting_descr {
+	const char *name;
+	const char *setting_name;
+	size_t size;
+	off_t offset;
+	uint16_t flag;
+};
+
+#define NVM_SETTING_DESCR(_flag, _member) \
+	{									\
+		.flag = _flag,							\
+		.name = STRINGIFY(_member),					\
+		.setting_name =						\
+			LORAWAN_SETTINGS_BASE "/" STRINGIFY(_member),		\
+		.offset = offsetof(LoRaMacNvmData_t, _member),		\
+		.size = sizeof(((LoRaMacNvmData_t *)0)->_member),		\
+	}
+
+static const struct lorawan_nvm_setting_descr nvm_setting_descriptors[] = {
+	NVM_SETTING_DESCR(LORAMAC_NVM_NOTIFY_FLAG_CRYPTO, Crypto),
+	NVM_SETTING_DESCR(LORAMAC_NVM_NOTIFY_FLAG_MAC_GROUP1, MacGroup1),
+	NVM_SETTING_DESCR(LORAMAC_NVM_NOTIFY_FLAG_MAC_GROUP2, MacGroup2),
+	NVM_SETTING_DESCR(LORAMAC_NVM_NOTIFY_FLAG_SECURE_ELEMENT, SecureElement),
+	NVM_SETTING_DESCR(LORAMAC_NVM_NOTIFY_FLAG_REGION_GROUP1, RegionGroup1),
+	NVM_SETTING_DESCR(LORAMAC_NVM_NOTIFY_FLAG_REGION_GROUP2, RegionGroup2),
+	NVM_SETTING_DESCR(LORAMAC_NVM_NOTIFY_FLAG_CLASS_B, ClassB),
+};
+
+static void lorawan_nvm_save_settings(uint16_t nvm_notify_flag)
+{
+	MibRequestConfirm_t mib_req;
+
+	LOG_DBG("Saving LoRaWAN settings");
+
+	/* Retrieve the actual context */
+	mib_req.Type = MIB_NVM_CTXS;
+	if (LoRaMacMibGetRequestConfirm(&mib_req) != LORAMAC_STATUS_OK) {
+		LOG_ERR("Could not get NVM context");
+		return;
+	}
+
+	LoRaMacNvmData_t *nvm = mib_req.Param.Contexts;
+
+	LOG_DBG("Crypto version: %"PRIu32", DevNonce: %d, JoinNonce: %"PRIu32,
+		mib_req.Param.Contexts->Crypto.LrWanVersion.Value,
+		mib_req.Param.Contexts->Crypto.DevNonce,
+		mib_req.Param.Contexts->Crypto.JoinNonce);
+
+	for (uint32_t i = 0; i < ARRAY_SIZE(nvm_setting_descriptors); i++) {
+		const struct lorawan_nvm_setting_descr *descr =
+			&nvm_setting_descriptors[i];
+
+		if ((nvm_notify_flag & descr->flag) == descr->flag) {
+			LOG_DBG("Saving configuration %s", descr->setting_name);
+			int err = settings_save_one(descr->setting_name,
+						(char *)nvm + descr->offset,
+						descr->size);
+			if (err) {
+				LOG_ERR("Could not save settings %s, error %d",
+					descr->name, err);
+			}
+		}
+	}
+
+	settings_save();
+}
+
+void lorawan_nvm_data_mgmt_event(uint16_t flags)
+{
+	if (flags != LORAMAC_NVM_NOTIFY_FLAG_NONE) {
+		lorawan_nvm_save_settings(flags);
+	}
+}
+
+static int load_setting(void *tgt, size_t tgt_size,
+			const char *key, size_t len,
+			settings_read_cb read_cb, void *cb_arg)
+{
+	if (len != tgt_size) {
+		LOG_ERR("Can't load '%s' state, size mismatch.",
+			log_strdup(key));
+		return -EINVAL;
+	}
+
+	if (!tgt) {
+		LOG_ERR("Can't load '%s' state, no target.",
+			log_strdup(key));
+		return -EINVAL;
+	}
+
+	if (read_cb(cb_arg, tgt, len) != len) {
+		LOG_ERR("Can't load '%s' state, short read.",
+			log_strdup(key));
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int on_setting_loaded(const char *key, size_t len,
+			   settings_read_cb read_cb,
+			   void *cb_arg, void *param)
+{
+	int err;
+	LoRaMacNvmData_t *nvm = param;
+
+	LOG_DBG("Key: %s", log_strdup(key));
+
+	for (uint32_t i = 0; i < ARRAY_SIZE(nvm_setting_descriptors); i++) {
+		const struct lorawan_nvm_setting_descr *descr =
+			&nvm_setting_descriptors[i];
+
+		if (strcmp(descr->name, key) == 0) {
+			err = load_setting((char *)nvm + descr->offset,
+				descr->size, key, len, read_cb, cb_arg);
+			if (err) {
+				LOG_ERR("Could not read setting %s", descr->name);
+			}
+			return err;
+		}
+	}
+
+	LOG_WRN("Unknown LoRaWAN setting: %s", log_strdup(key));
+	return 0;
+}
+
+int lorawan_nvm_data_restore(void)
+{
+	int err;
+	LoRaMacStatus_t status;
+	MibRequestConfirm_t mib_req;
+
+	LOG_DBG("Restoring LoRaWAN settings");
+
+	/* Retrieve the actual context */
+	mib_req.Type = MIB_NVM_CTXS;
+	if (LoRaMacMibGetRequestConfirm(&mib_req) != LORAMAC_STATUS_OK) {
+		LOG_ERR("Could not get NVM context");
+		return -EINVAL;
+	}
+
+	err = settings_load_subtree_direct(LORAWAN_SETTINGS_BASE,
+					   on_setting_loaded,
+					   mib_req.Param.Contexts);
+	if (err) {
+		LOG_ERR("Could not load LoRaWAN settings, error %d", err);
+		return err;
+	}
+
+	LOG_DBG("Crypto version: %"PRIu32", DevNonce: %d, JoinNonce: %"PRIu32,
+		mib_req.Param.Contexts->Crypto.LrWanVersion.Value,
+		mib_req.Param.Contexts->Crypto.DevNonce,
+		mib_req.Param.Contexts->Crypto.JoinNonce);
+
+	mib_req.Type = MIB_NVM_CTXS;
+	status = LoRaMacMibSetRequestConfirm(&mib_req);
+	if (status != LORAMAC_STATUS_OK) {
+		LOG_ERR("Could not set the NVM context, error %d", status);
+		return -EINVAL;
+	}
+
+	LOG_DBG("LoRaWAN context restored");
+
+	return 0;
+}
+
+int lorawan_nvm_init(void)
+{
+	return settings_subsys_init();
+}


### PR DESCRIPTION
Adding a reference implementation of the Non-Volatile Memory module
needed to join any LoRaWAN network.

This NVM is based on the SETTINGS subsys to store all the required
key to join and communicate on a LoRaWAN network.

Without proper NVM, one may experience errors when using OTAA
to join the network, as the device may violate anti-replay
protection (depending on the version of LoRaWAN).

Fixes: #41773

Signed-off-by: Giuliano Franchetto <giuliano.franchetto@intellinium.com>