### PR TITLE
drivers: serial: RCar add pinctrl support

### DIFF
--- a/boards/arm/rcar_h3ulcb/rcar_h3ulcb_cr7.dts
+++ b/boards/arm/rcar_h3ulcb/rcar_h3ulcb_cr7.dts
@@ -58,6 +58,8 @@
 };
 
 &scif1 {
+	pinctrl-0 = <&scif1_data_a_tx_default &scif1_data_a_rx_default>;
+	pinctrl-names = "default";
 	status = "okay";
 };
 

--- a/drivers/serial/uart_rcar.c
+++ b/drivers/serial/uart_rcar.c
@@ -12,6 +12,7 @@
 #include <drivers/uart.h>
 #include <drivers/clock_control.h>
 #include <drivers/clock_control/rcar_clock_control.h>
+#include <drivers/pinctrl.h>
 #include <spinlock.h>
 
 struct uart_rcar_cfg {
@@ -19,6 +20,7 @@ struct uart_rcar_cfg {
 	const struct device *clock_dev;
 	struct rcar_cpg_clk mod_clk;
 	struct rcar_cpg_clk bus_clk;
+	const struct pinctrl_dev_config *pcfg;
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	void (*irq_config_func)(const struct device *dev);
 #endif
@@ -270,6 +272,12 @@ static int uart_rcar_init(const struct device *dev)
 	const struct uart_rcar_cfg *config = DEV_UART_CFG(dev);
 	struct uart_rcar_data *data = DEV_UART_DATA(dev);
 	int ret;
+
+	/* Configure dt provided device signals when available */
+	ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+	if (ret < 0) {
+		return ret;
+	}
 
 	ret = clock_control_on(config->clock_dev,
 			       (clock_control_subsys_t *)&config->mod_clk);
@@ -527,6 +535,7 @@ static const struct uart_driver_api uart_rcar_driver_api = {
 
 /* Device Instantiation */
 #define UART_RCAR_DECLARE_CFG(n, IRQ_FUNC_INIT)			    \
+	PINCTRL_DT_INST_DEFINE(n);				    \
 	static const struct uart_rcar_cfg uart_rcar_cfg_##n = {	    \
 		.reg_addr = DT_INST_REG_ADDR(n),		    \
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)), \
@@ -538,6 +547,7 @@ static const struct uart_driver_api uart_rcar_driver_api = {
 			DT_INST_CLOCKS_CELL_BY_IDX(n, 1, module),   \
 		.bus_clk.domain =				    \
 			DT_INST_CLOCKS_CELL_BY_IDX(n, 1, domain),   \
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),	    \
 		IRQ_FUNC_INIT					    \
 	}
 

--- a/dts/bindings/serial/renesas,rcar-scif.yaml
+++ b/dts/bindings/serial/renesas,rcar-scif.yaml
@@ -5,7 +5,7 @@ description: Renesas R-Car UART controller
 
 compatible: "renesas,rcar-scif"
 
-include: uart-controller.yaml
+include: [uart-controller.yaml, pinctrl-device.yaml]
 
 properties:
     reg:


### PR DESCRIPTION
Hi,

This Pull request follows #40550 that introduced new Renesas RCar Pinctrl driver.

This PR then :
- Add Pinctrl support in Renesas RCar scif driver.
- Add pins definitions for SCIF1 for Renesas RCar H3ULCB board.

It has been tested and validated on board.