### PR TITLE
drivers: can: fix can_set_state_change_callback() API function

### DIFF
--- a/include/drivers/can.h
+++ b/include/drivers/can.h
@@ -889,7 +889,7 @@ static inline void can_set_state_change_callback(const struct device *dev,
 {
 	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
 
-	return api->set_state_change_callback(dev, callback, user_data);
+	api->set_state_change_callback(dev, callback, user_data);
 }
 
 /** @} */


### PR DESCRIPTION
Remove "return" statement from can_set_state_change_callback() API wrappper function (which is a void function).

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>