### PR TITLE
boards: arm: mps2_an521: Add Ethernet support

### DIFF
--- a/boards/arm/mps2_an521/mps2_an521-common.dtsi
+++ b/boards/arm/mps2_an521/mps2_an521-common.dtsi
@@ -203,3 +203,12 @@ gpio_misc: mps2_fpgaio@30204c {
 	ngpios = <10>;
 	label = "FPGA_MISC";
 };
+
+eth0: eth@2000000 {
+	/* Linux has "smsc,lan9115" */
+	compatible = "smsc,lan9220";
+	/* Actual reg range is ~0x200 */
+	reg = <0x2000000 0x100000>;
+	label = "eth0";
+	interrupts = <48 3>;
+};


### PR DESCRIPTION
The only thing missing was the devicetree info.
Note that the address and irq are different for each ANxxx.

QEMU in the zephyr sdk 0.13.1 or better has the needed configuration for
mps2_an385, mps2_an521, and mps3_an547.
mps2_an385 and mps3_an547 worked even before this addition.

This can be tested following the general instructions in the
Zephyr documentation for "Networking with QEMU Ethernet"
https://docs.zephyrproject.org/latest/guides/networking/qemu_eth_setup.html

The specific command to use for mps2_an521 is:
$ west build -b mps2_an521 zephyr/samples/net/sockets/echo_server -- \
 -DOVERLAY_CONFIG=overlay-smsc911x.conf

Signed-off-by: Bill Mills <bill.mills@linaro.org>