### PR TITLE
Update CPU runtime stats of non-idle time

### DIFF
--- a/kernel/usage.c
+++ b/kernel/usage.c
@@ -47,7 +47,9 @@ static void sched_cpu_update_usage(struct _cpu *cpu, uint32_t cycles)
 	}
 #endif
 
-	cpu->usage.total += cycles;
+	if (cpu->current != cpu->idle_thread) {
+		cpu->usage.total += cycles;
+	}
 }
 #else
 #define sched_cpu_update_usage(cpu, cycles)   do { } while (0)


### PR DESCRIPTION
Updates sched_cpu_update_usage() such that the CPU runtime stats
only update the its non-idle time when the current thread is not the
idle thread. This is necessary as otherwise the CPUs idle-time will
be double counted in k_thread_runtime_stats.execution_cycles.

Fixes: #41792

Signed-off-by: Peter Mitsis <peter.mitsis@intel.com>