### PR TITLE
drivers: can: add error-warning state

### DIFF
--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -673,6 +673,10 @@ enum can_state can_mcan_get_state(const struct can_mcan_config *cfg,
 		return CAN_ERROR_PASSIVE;
 	}
 
+	if (can->psr & CAN_MCAN_PSR_EW) {
+		return CAN_ERROR_WARNING;
+	}
+
 	return CAN_ERROR_ACTIVE;
 }
 

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -668,6 +668,10 @@ static enum can_state mcp2515_get_state(const struct device *dev,
 		return CAN_ERROR_PASSIVE;
 	}
 
+	if (eflg & MCP2515_EFLG_EWARN) {
+		return CAN_ERROR_WARNING;
+	}
+
 	return CAN_ERROR_ACTIVE;
 }
 

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -337,6 +337,10 @@ static enum can_state mcux_flexcan_get_state(const struct device *dev,
 		return CAN_ERROR_PASSIVE;
 	}
 
+	if ((status_flags & (kFLEXCAN_TxErrorWarningFlag | kFLEXCAN_RxErrorWarningFlag)) != 0) {
+		return CAN_ERROR_WARNING;
+	}
+
 	return CAN_ERROR_ACTIVE;
 }
 

--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -327,6 +327,7 @@ static void can_rcar_error(const struct device *dev)
 		/* Clear interrupt condition */
 		sys_write8((uint8_t)~RCAR_CAN_EIFR_EWIF,
 			   config->reg_addr + RCAR_CAN_EIFR);
+		can_rcar_state_change(dev, CAN_ERROR_WARNING);
 	}
 	if (eifr & RCAR_CAN_EIFR_EPIF) {
 		LOG_DBG("Error passive interrupt\n");

--- a/include/drivers/can.h
+++ b/include/drivers/can.h
@@ -96,11 +96,13 @@ enum can_mode {
  * @brief Defines the state of the CAN bus
  */
 enum can_state {
-	/** Error-active state. */
+	/** Error-active state (RX/TX error count < 96). */
 	CAN_ERROR_ACTIVE,
-	/** Error-passive state. */
+	/** Error-warning state (RX/TX error count < 128). */
+	CAN_ERROR_WARNING,
+	/** Error-passive state (RX/TX error count < 256). */
 	CAN_ERROR_PASSIVE,
-	/** Bus-off state. */
+	/** Bus-off state (RX/TX error count >= 256). */
 	CAN_BUS_OFF,
 	/** Bus state unknown. */
 	CAN_BUS_UNKNOWN

--- a/samples/drivers/can/src/main.c
+++ b/samples/drivers/can/src/main.c
@@ -110,6 +110,8 @@ char *state_to_str(enum can_state state)
 	switch (state) {
 	case CAN_ERROR_ACTIVE:
 		return "error-active";
+	case CAN_ERROR_WARNING:
+		return "error-warning";
 	case CAN_ERROR_PASSIVE:
 		return "error-passive";
 	case CAN_BUS_OFF:


### PR DESCRIPTION
Add CAN controller error-warning state and document the relationship between CAN controller states and CAN controller RX/TX error counter values. This new state corresponds to `CAN_STATE_ERROR_WARNING` in the Linux kernel (see https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/can/netlink.h#L71).

Implement support for CAN controller error-warning state in the following drivers:
- NXP FlexCAN
- ST STM32 bxCAN
- Bosch M_CAN
- Microchip MCP2515
- Renesas RCAR (thanks to @julien-massot)

~I have not added support for error-warning to the Renesas RCAN driver as I do not have access to the hardware for verification and testing.~

Fixes: #21010