### PR TITLE
treewide: drop DEV_DATA/DEV_CFG usage

### DIFF
--- a/drivers/adc/adc_cc32xx.c
+++ b/drivers/adc/adc_cc32xx.c
@@ -229,7 +229,7 @@ static int adc_cc32xx_read_async(const struct device *dev,
 static void adc_cc32xx_isr(const struct device *dev, int no)
 {
 	const struct adc_cc32xx_cfg *config = dev->config;
-	struct adc_cc32xx_data *data = (struct adc_cc32xx_data *)dev->data;
+	struct adc_cc32xx_data *data = dev->data;
 	const int chan = s_channel[no];
 	unsigned long mask = MAP_ADCIntStatus(config->base, chan);
 	int cnt = 0;

--- a/drivers/adc/adc_ite_it8xxx2.c
+++ b/drivers/adc/adc_ite_it8xxx2.c
@@ -20,10 +20,6 @@ LOG_MODULE_REGISTER(adc_ite_it8xxx2);
 #define ADC_CONTEXT_USES_KERNEL_TIMER
 #include "adc_context.h"
 
-#define DEV_DATA(dev) ((struct adc_it8xxx2_data * const)(dev)->data)
-
-#define DEV_CFG(dev) ((struct adc_it8xxx2_cfg * const)(dev)->config)
-
 /* ADC internal reference voltage (Unit:mV) */
 #define IT8XXX2_ADC_VREF_VOL 3000
 /* ADC channels disabled */
@@ -74,7 +70,7 @@ struct adc_it8xxx2_cfg {
 static int adc_it8xxx2_channel_setup(const struct device *dev,
 				     const struct adc_channel_cfg *channel_cfg)
 {
-	struct adc_it8xxx2_cfg *config = DEV_CFG(dev);
+	struct adc_it8xxx2_cfg *config = dev->config;
 
 	if (channel_cfg->acquisition_time != ADC_ACQ_TIME_DEFAULT) {
 		LOG_ERR("Selected ADC acquisition time is not valid");
@@ -157,7 +153,7 @@ static int check_buffer_size(const struct adc_sequence *sequence,
 static int adc_it8xxx2_start_read(const struct device *dev,
 				  const struct adc_sequence *sequence)
 {
-	struct adc_it8xxx2_data *data = DEV_DATA(dev);
+	struct adc_it8xxx2_data *data = dev->data;
 	uint32_t channel_mask = sequence->channels;
 
 	if (!channel_mask || channel_mask & ~BIT_MASK(CHIP_ADC_COUNT)) {
@@ -189,7 +185,7 @@ static void adc_context_start_sampling(struct adc_context *ctx)
 static int adc_it8xxx2_read(const struct device *dev,
 			    const struct adc_sequence *sequence)
 {
-	struct adc_it8xxx2_data *data = DEV_DATA(dev);
+	struct adc_it8xxx2_data *data = dev->data;
 	uint32_t channel_mask = sequence->channels;
 	uint8_t channel_count = 0;
 	int err = 0;
@@ -229,7 +225,7 @@ static void adc_context_update_buffer_pointer(struct adc_context *ctx,
 /* Get result for each ADC selected channel. */
 static void adc_it8xxx2_get_sample(const struct device *dev)
 {
-	struct adc_it8xxx2_data *data = DEV_DATA(dev);
+	struct adc_it8xxx2_data *data = dev->data;
 	struct adc_it8xxx2_regs *const adc_regs = ADC_IT8XXX2_REG_BASE;
 	bool valid = false;
 
@@ -251,7 +247,7 @@ static void adc_it8xxx2_get_sample(const struct device *dev)
 static void adc_it8xxx2_isr(const void *arg)
 {
 	struct device *dev = (struct device *)arg;
-	struct adc_it8xxx2_data *data = DEV_DATA(dev);
+	struct adc_it8xxx2_data *data = dev->data;
 
 	LOG_DBG("ADC ISR triggered.");
 
@@ -288,7 +284,7 @@ static void adc_accuracy_initialization(void)
 
 static int adc_it8xxx2_init(const struct device *dev)
 {
-	struct adc_it8xxx2_data *data = DEV_DATA(dev);
+	struct adc_it8xxx2_data *data = dev->data;
 	struct adc_it8xxx2_regs *const adc_regs = ADC_IT8XXX2_REG_BASE;
 
 	/* ADC analog accuracy initialization */

--- a/drivers/adc/adc_ite_it8xxx2.c
+++ b/drivers/adc/adc_ite_it8xxx2.c
@@ -70,7 +70,7 @@ struct adc_it8xxx2_cfg {
 static int adc_it8xxx2_channel_setup(const struct device *dev,
 				     const struct adc_channel_cfg *channel_cfg)
 {
-	struct adc_it8xxx2_cfg *config = dev->config;
+	const struct adc_it8xxx2_cfg *config = dev->config;
 
 	if (channel_cfg->acquisition_time != ADC_ACQ_TIME_DEFAULT) {
 		LOG_ERR("Selected ADC acquisition time is not valid");

--- a/drivers/adc/adc_mcux_adc16.c
+++ b/drivers/adc/adc_mcux_adc16.c
@@ -67,10 +67,6 @@ struct mcux_adc16_data {
 	uint8_t channel_id;
 };
 
-#define DEV_CFG(dev) ((const struct mcux_adc16_config *const)dev->config)
-#define DEV_DATA(dev) ((struct mcux_adc16_data *)dev->data)
-#define DEV_BASE(dev) ((ADC_Type *)DEV_CFG(dev)->base)
-
 #ifdef CONFIG_ADC_MCUX_ADC16_HW_TRIGGER
 #define SIM_SOPT7_ADCSET(x, shifts, mask)                                      \
 	(((uint32_t)(((uint32_t)(x)) << shifts)) & mask)
@@ -81,7 +77,7 @@ static void adc_dma_callback(const struct device *dma_dev, void *callback_arg,
 			     uint32_t channel, int error_code)
 {
 	struct device *dev = (struct device *)callback_arg;
-	struct mcux_adc16_data *data = DEV_DATA(dev);
+	struct mcux_adc16_data *data = dev->data;
 
 	LOG_DBG("DMA done");
 	adc_context_on_sampling_done(&data->ctx, dev);

--- a/drivers/adc/adc_sam0.c
+++ b/drivers/adc/adc_sam0.c
@@ -58,11 +58,6 @@ struct adc_sam0_cfg {
 	void (*config_func)(const struct device *dev);
 };
 
-#define DEV_CFG(dev) \
-	((const struct adc_sam0_cfg *const)(dev)->config)
-#define DEV_DATA(dev) \
-	((struct adc_sam0_data *)(dev)->data)
-
 static void wait_synchronization(Adc *const adc)
 {
 #if defined(ADC_SYNCBUSY_MASK)
@@ -77,7 +72,7 @@ static void wait_synchronization(Adc *const adc)
 static int adc_sam0_acquisition_to_clocks(const struct device *dev,
 					  uint16_t acquisition_time)
 {
-	const struct adc_sam0_cfg *const cfg = DEV_CFG(dev);
+	const struct adc_sam0_cfg *const cfg = dev->config;
 	uint64_t scaled_acq;
 
 	switch (ADC_ACQ_TIME_UNIT(acquisition_time)) {
@@ -122,7 +117,7 @@ static int adc_sam0_acquisition_to_clocks(const struct device *dev,
 static int adc_sam0_channel_setup(const struct device *dev,
 				  const struct adc_channel_cfg *channel_cfg)
 {
-	const struct adc_sam0_cfg *const cfg = DEV_CFG(dev);
+	const struct adc_sam0_cfg *const cfg = dev->config;
 	Adc *const adc = cfg->regs;
 	int retval;
 	uint8_t SAMPCTRL = 0;
@@ -182,7 +177,7 @@ static int adc_sam0_channel_setup(const struct device *dev,
 		adc->REFCTRL.reg = REFCTRL;
 		wait_synchronization(adc);
 #ifdef ADC_SAM0_REFERENCE_GLITCH
-		struct adc_sam0_data *data = DEV_DATA(dev);
+		struct adc_sam0_data *data = dev->data;
 
 		data->reference_changed = 1;
 #endif
@@ -283,7 +278,7 @@ static int adc_sam0_channel_setup(const struct device *dev,
 
 static void adc_sam0_start_conversion(const struct device *dev)
 {
-	const struct adc_sam0_cfg *const cfg = DEV_CFG(dev);
+	const struct adc_sam0_cfg *const cfg = dev->config;
 	Adc *const adc = cfg->regs;
 
 	LOG_DBG("Starting conversion");
@@ -336,8 +331,8 @@ static int check_buffer_size(const struct adc_sequence *sequence,
 static int start_read(const struct device *dev,
 		      const struct adc_sequence *sequence)
 {
-	const struct adc_sam0_cfg *const cfg = DEV_CFG(dev);
-	struct adc_sam0_data *data = DEV_DATA(dev);
+	const struct adc_sam0_cfg *const cfg = dev->config;
+	struct adc_sam0_data *data = dev->data;
 	Adc *const adc = cfg->regs;
 	int error;
 
@@ -419,7 +414,7 @@ static int start_read(const struct device *dev,
 static int adc_sam0_read(const struct device *dev,
 			 const struct adc_sequence *sequence)
 {
-	struct adc_sam0_data *data = DEV_DATA(dev);
+	struct adc_sam0_data *data = dev->data;
 	int error;
 
 	adc_context_lock(&data->ctx, false, NULL);
@@ -431,8 +426,8 @@ static int adc_sam0_read(const struct device *dev,
 
 static void adc_sam0_isr(const struct device *dev)
 {
-	struct adc_sam0_data *data = DEV_DATA(dev);
-	const struct adc_sam0_cfg *const cfg = DEV_CFG(dev);
+	struct adc_sam0_data *data = dev->data;
+	const struct adc_sam0_cfg *const cfg = dev->config;
 	Adc *const adc = cfg->regs;
 	uint16_t result;
 
@@ -456,8 +451,8 @@ static void adc_sam0_isr(const struct device *dev)
 
 static int adc_sam0_init(const struct device *dev)
 {
-	const struct adc_sam0_cfg *const cfg = DEV_CFG(dev);
-	struct adc_sam0_data *data = DEV_DATA(dev);
+	const struct adc_sam0_cfg *const cfg = dev->config;
+	struct adc_sam0_data *data = dev->data;
 	Adc *const adc = cfg->regs;
 
 #ifdef MCLK
@@ -502,7 +497,7 @@ static int adc_sam0_read_async(const struct device *dev,
 			       const struct adc_sequence *sequence,
 			       struct k_poll_signal *async)
 {
-	struct adc_sam0_data *data = DEV_DATA(dev);
+	struct adc_sam0_data *data = dev->data;
 	int error;
 
 	adc_context_lock(&data->ctx, true, async);
@@ -549,7 +544,7 @@ static const struct adc_driver_api adc_sam0_api = {
 
 #define ADC_SAM0_CONFIGURE(n)						\
 do {									\
-	const struct adc_sam0_cfg *const cfg = DEV_CFG(dev);		\
+	const struct adc_sam0_cfg *const cfg = dev->config;		\
 	Adc * const adc = cfg->regs;					\
 	uint32_t comp = ADC_SAM0_BIASCOMP(n);				\
 	uint32_t r2r = ADC_SAM0_BIASR2R(n);				\
@@ -569,7 +564,7 @@ do {									\
 
 #define ADC_SAM0_CONFIGURE(n)						\
 do {									\
-	const struct adc_sam0_cfg *const cfg = DEV_CFG(dev);		\
+	const struct adc_sam0_cfg *const cfg = dev->config;		\
 	Adc * const adc = cfg->regs;					\
 	/* Linearity is split across two words */			\
 	uint32_t lin = ((*(uint32_t *)ADC_FUSES_LINEARITY_0_ADDR) &		\

--- a/drivers/adc/adc_sam_afec.c
+++ b/drivers/adc/adc_sam_afec.c
@@ -62,16 +62,10 @@ struct adc_sam_cfg {
 	struct soc_gpio_pin afec_trg_pin;
 };
 
-#define DEV_CFG(dev) \
-	((const struct adc_sam_cfg *const)(dev)->config)
-
-#define DEV_DATA(dev) \
-	((struct adc_sam_data *)(dev)->data)
-
 static int adc_sam_channel_setup(const struct device *dev,
 				 const struct adc_channel_cfg *channel_cfg)
 {
-	const struct adc_sam_cfg * const cfg = DEV_CFG(dev);
+	const struct adc_sam_cfg * const cfg = dev->config;
 	Afec *const afec = cfg->regs;
 
 	uint8_t channel_id = channel_cfg->channel_id;
@@ -120,8 +114,8 @@ static int adc_sam_channel_setup(const struct device *dev,
 
 static void adc_sam_start_conversion(const struct device *dev)
 {
-	const struct adc_sam_cfg *const cfg = DEV_CFG(dev);
-	struct adc_sam_data *data = DEV_DATA(dev);
+	const struct adc_sam_cfg *const cfg = dev->config;
+	struct adc_sam_data *data = dev->data;
 	Afec *const afec = cfg->regs;
 
 	data->channel_id = find_lsb_set(data->channels) - 1;
@@ -186,7 +180,7 @@ static int check_buffer_size(const struct adc_sequence *sequence,
 static int start_read(const struct device *dev,
 		      const struct adc_sequence *sequence)
 {
-	struct adc_sam_data *data = DEV_DATA(dev);
+	struct adc_sam_data *data = dev->data;
 	int error = 0;
 	uint32_t channels = sequence->channels;
 
@@ -251,7 +245,7 @@ static int start_read(const struct device *dev,
 static int adc_sam_read(const struct device *dev,
 			const struct adc_sequence *sequence)
 {
-	struct adc_sam_data *data = DEV_DATA(dev);
+	struct adc_sam_data *data = dev->data;
 	int error;
 
 	adc_context_lock(&data->ctx, false, NULL);
@@ -263,8 +257,8 @@ static int adc_sam_read(const struct device *dev,
 
 static int adc_sam_init(const struct device *dev)
 {
-	const struct adc_sam_cfg *const cfg = DEV_CFG(dev);
-	struct adc_sam_data *data = DEV_DATA(dev);
+	const struct adc_sam_cfg *const cfg = dev->config;
+	struct adc_sam_data *data = dev->data;
 	Afec *const afec = cfg->regs;
 
 	/* Reset the AFEC. */
@@ -306,7 +300,7 @@ static int adc_sam_read_async(const struct device *dev,
 			      const struct adc_sequence *sequence,
 			      struct k_poll_signal *async)
 {
-	struct adc_sam_data *data = DEV_DATA(dev);
+	struct adc_sam_data *data = dev->data;
 	int error;
 
 	adc_context_lock(&data->ctx, true, async);
@@ -327,8 +321,8 @@ static const struct adc_driver_api adc_sam_api = {
 
 static void adc_sam_isr(const struct device *dev)
 {
-	struct adc_sam_data *data = DEV_DATA(dev);
-	const struct adc_sam_cfg *const cfg = DEV_CFG(dev);
+	struct adc_sam_data *data = dev->data;
+	const struct adc_sam_cfg *const cfg = dev->config;
 	Afec *const afec = cfg->regs;
 	uint16_t result;
 

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -704,7 +704,7 @@ static void adc_context_update_buffer_pointer(struct adc_context *ctx,
 
 static void adc_stm32_isr(const struct device *dev)
 {
-	struct adc_stm32_data *data = (struct adc_stm32_data *)dev->data;
+	struct adc_stm32_data *data = dev->data;
 	const struct adc_stm32_cfg *config =
 		(const struct adc_stm32_cfg *)dev->config;
 	ADC_TypeDef *adc = config->base;

--- a/drivers/audio/mpxxdtyy-i2s.c
+++ b/drivers/audio/mpxxdtyy-i2s.c
@@ -24,7 +24,7 @@ int mpxxdtyy_i2s_read(const struct device *dev, uint8_t stream, void **buffer,
 		      size_t *size, int32_t timeout)
 {
 	int ret;
-	struct mpxxdtyy_data *const data = DEV_DATA(dev);
+	struct mpxxdtyy_data *const data = dev->data;
 	void *pdm_block, *pcm_block;
 	size_t pdm_size;
 	TPDMFilter_InitStruct *pdm_filter = &data->pdm_filter[0];
@@ -54,7 +54,7 @@ int mpxxdtyy_i2s_read(const struct device *dev, uint8_t stream, void **buffer,
 int mpxxdtyy_i2s_trigger(const struct device *dev, enum dmic_trigger cmd)
 {
 	int ret;
-	struct mpxxdtyy_data *const data = DEV_DATA(dev);
+	struct mpxxdtyy_data *const data = dev->data;
 	enum i2s_trigger_cmd i2s_cmd;
 	enum dmic_state tmp_state;
 
@@ -92,7 +92,7 @@ int mpxxdtyy_i2s_trigger(const struct device *dev, enum dmic_trigger cmd)
 int mpxxdtyy_i2s_configure(const struct device *dev, struct dmic_cfg *cfg)
 {
 	int ret;
-	struct mpxxdtyy_data *const data = DEV_DATA(dev);
+	struct mpxxdtyy_data *const data = dev->data;
 	uint8_t chan_size = cfg->streams->pcm_width;
 	uint32_t audio_freq = cfg->streams->pcm_rate;
 	uint16_t factor;

--- a/drivers/audio/mpxxdtyy.c
+++ b/drivers/audio/mpxxdtyy.c
@@ -47,7 +47,7 @@ static uint8_t right_channel(uint8_t a, uint8_t b)
 
 uint16_t sw_filter_lib_init(const struct device *dev, struct dmic_cfg *cfg)
 {
-	struct mpxxdtyy_data *const data = DEV_DATA(dev);
+	struct mpxxdtyy_data *const data = dev->data;
 	TPDMFilter_InitStruct *pdm_filter = &data->pdm_filter[0];
 	uint16_t factor;
 	uint32_t audio_freq = cfg->streams->pcm_rate;
@@ -150,7 +150,7 @@ static const struct _dmic_ops mpxxdtyy_driver_api = {
 
 static int mpxxdtyy_initialize(const struct device *dev)
 {
-	struct mpxxdtyy_data *const data = DEV_DATA(dev);
+	struct mpxxdtyy_data *const data = dev->data;
 
 	data->comm_master = device_get_binding(DT_INST_BUS_LABEL(0));
 

--- a/drivers/audio/mpxxdtyy.h
+++ b/drivers/audio/mpxxdtyy.h
@@ -19,11 +19,6 @@ extern "C" {
 #define MPXXDTYY_MIN_PDM_FREQ		1200000 /* 1.2MHz */
 #define MPXXDTYY_MAX_PDM_FREQ		3250000 /* 3.25MHz */
 
-#define DEV_CFG(dev) \
-	((const struct mpxxdtyy_config *const)(dev)->config)
-#define DEV_DATA(dev) \
-	((struct mpxxdtyy_data *const)(dev)->data)
-
 struct mpxxdtyy_data {
 	const struct device *comm_master;
 	enum dmic_state		state;

--- a/drivers/audio/tlv320dac310x.c
+++ b/drivers/audio/tlv320dac310x.c
@@ -50,11 +50,6 @@ static struct codec_driver_config codec_device_config = {
 
 static struct codec_driver_data codec_device_data;
 
-#define DEV_CFG(dev) \
-	((struct codec_driver_config *const)(dev)->config)
-#define DEV_DATA(dev) \
-	((struct codec_driver_data *const)(dev)->data)
-
 static void codec_write_reg(const struct device *dev, struct reg_addr reg,
 			    uint8_t val);
 static void codec_read_reg(const struct device *dev, struct reg_addr reg,
@@ -78,7 +73,8 @@ static void codec_read_all_regs(const struct device *dev);
 
 static int codec_initialize(const struct device *dev)
 {
-	struct codec_driver_config *const dev_cfg = DEV_CFG(dev);
+	struct codec_driver_config *const dev_cfg =
+		(struct codec_driver_config *)dev->config;
 
 	/* bind I2C */
 	dev_cfg->i2c_device = device_get_binding(dev_cfg->i2c_dev_name);
@@ -102,7 +98,8 @@ static int codec_initialize(const struct device *dev)
 static int codec_configure(const struct device *dev,
 			   struct audio_codec_cfg *cfg)
 {
-	struct codec_driver_config *const dev_cfg = DEV_CFG(dev);
+	struct codec_driver_config *const dev_cfg =
+		(struct codec_driver_config *)dev->config;
 	int ret;
 
 	if (cfg->dai_type != AUDIO_DAI_TYPE_I2S) {
@@ -202,8 +199,9 @@ static int codec_apply_properties(const struct device *dev)
 static void codec_write_reg(const struct device *dev, struct reg_addr reg,
 			    uint8_t val)
 {
-	struct codec_driver_data *const dev_data = DEV_DATA(dev);
-	struct codec_driver_config *const dev_cfg = DEV_CFG(dev);
+	struct codec_driver_data *const dev_data = dev->data;
+	struct codec_driver_config *const dev_cfg =
+		(struct codec_driver_config *)dev->config;
 
 	/* set page if different */
 	if (dev_data->reg_addr_cache.page != reg.page) {
@@ -221,8 +219,9 @@ static void codec_write_reg(const struct device *dev, struct reg_addr reg,
 static void codec_read_reg(const struct device *dev, struct reg_addr reg,
 			   uint8_t *val)
 {
-	struct codec_driver_data *const dev_data = DEV_DATA(dev);
-	struct codec_driver_config *const dev_cfg = DEV_CFG(dev);
+	struct codec_driver_data *const dev_data = dev->data;
+	struct codec_driver_config *const dev_cfg =
+		(struct codec_driver_config *)dev->config;
 
 	/* set page if different */
 	if (dev_data->reg_addr_cache.page != reg.page) {

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -37,6 +37,8 @@ LOG_MODULE_REGISTER(mcp2515_can);
 
 static int mcp2515_cmd_soft_reset(const struct device *dev)
 {
+	const struct mcp2515_config *dev_cfg = dev->config;
+
 	uint8_t cmd_buf[] = { MCP2515_OPCODE_RESET };
 
 	const struct spi_buf tx_buf = {
@@ -46,13 +48,15 @@ static int mcp2515_cmd_soft_reset(const struct device *dev)
 		.buffers = &tx_buf, .count = 1U
 	};
 
-	return spi_write_dt(&DEV_CFG(dev)->bus, &tx);
+	return spi_write_dt(&dev_cfg->bus, &tx);
 }
 
 static int mcp2515_cmd_bit_modify(const struct device *dev, uint8_t reg_addr,
 				  uint8_t mask,
 				  uint8_t data)
 {
+	const struct mcp2515_config *dev_cfg = dev->config;
+
 	uint8_t cmd_buf[] = { MCP2515_OPCODE_BIT_MODIFY, reg_addr, mask, data };
 
 	const struct spi_buf tx_buf = {
@@ -62,12 +66,14 @@ static int mcp2515_cmd_bit_modify(const struct device *dev, uint8_t reg_addr,
 		.buffers = &tx_buf, .count = 1U
 	};
 
-	return spi_write_dt(&DEV_CFG(dev)->bus, &tx);
+	return spi_write_dt(&dev_cfg->bus, &tx);
 }
 
 static int mcp2515_cmd_write_reg(const struct device *dev, uint8_t reg_addr,
 				 uint8_t *buf_data, uint8_t buf_len)
 {
+	const struct mcp2515_config *dev_cfg = dev->config;
+
 	uint8_t cmd_buf[] = { MCP2515_OPCODE_WRITE, reg_addr };
 
 	struct spi_buf tx_buf[] = {
@@ -78,7 +84,7 @@ static int mcp2515_cmd_write_reg(const struct device *dev, uint8_t reg_addr,
 		.buffers = tx_buf, .count = ARRAY_SIZE(tx_buf)
 	};
 
-	return spi_write_dt(&DEV_CFG(dev)->bus, &tx);
+	return spi_write_dt(&dev_cfg->bus, &tx);
 }
 
 /*
@@ -98,6 +104,8 @@ static int mcp2515_cmd_write_reg(const struct device *dev, uint8_t reg_addr,
 static int mcp2515_cmd_load_tx_buffer(const struct device *dev, uint8_t abc,
 				      uint8_t *buf_data, uint8_t buf_len)
 {
+	const struct mcp2515_config *dev_cfg = dev->config;
+
 	__ASSERT(abc <= 5, "abc <= 5");
 
 	uint8_t cmd_buf[] = { MCP2515_OPCODE_LOAD_TX_BUFFER | abc };
@@ -110,7 +118,7 @@ static int mcp2515_cmd_load_tx_buffer(const struct device *dev, uint8_t abc,
 		.buffers = tx_buf, .count = ARRAY_SIZE(tx_buf)
 	};
 
-	return spi_write_dt(&DEV_CFG(dev)->bus, &tx);
+	return spi_write_dt(&dev_cfg->bus, &tx);
 }
 
 /*
@@ -122,6 +130,8 @@ static int mcp2515_cmd_load_tx_buffer(const struct device *dev, uint8_t abc,
  */
 static int mcp2515_cmd_rts(const struct device *dev, uint8_t nnn)
 {
+	const struct mcp2515_config *dev_cfg = dev->config;
+
 	__ASSERT(nnn < BIT(MCP2515_TX_CNT), "nnn < BIT(MCP2515_TX_CNT)");
 
 	uint8_t cmd_buf[] = { MCP2515_OPCODE_RTS | nnn };
@@ -133,12 +143,14 @@ static int mcp2515_cmd_rts(const struct device *dev, uint8_t nnn)
 		.buffers = tx_buf, .count = ARRAY_SIZE(tx_buf)
 	};
 
-	return spi_write_dt(&DEV_CFG(dev)->bus, &tx);
+	return spi_write_dt(&dev_cfg->bus, &tx);
 }
 
 static int mcp2515_cmd_read_reg(const struct device *dev, uint8_t reg_addr,
 				uint8_t *buf_data, uint8_t buf_len)
 {
+	const struct mcp2515_config *dev_cfg = dev->config;
+
 	uint8_t cmd_buf[] = { MCP2515_OPCODE_READ, reg_addr };
 
 	struct spi_buf tx_buf[] = {
@@ -156,7 +168,7 @@ static int mcp2515_cmd_read_reg(const struct device *dev, uint8_t reg_addr,
 		.buffers = rx_buf, .count = ARRAY_SIZE(rx_buf)
 	};
 
-	return spi_transceive_dt(&DEV_CFG(dev)->bus, &tx, &rx);
+	return spi_transceive_dt(&dev_cfg->bus, &tx, &rx);
 }
 
 /*
@@ -173,6 +185,8 @@ static int mcp2515_cmd_read_reg(const struct device *dev, uint8_t reg_addr,
 static int mcp2515_cmd_read_rx_buffer(const struct device *dev, uint8_t nm,
 				      uint8_t *buf_data, uint8_t buf_len)
 {
+	const struct mcp2515_config *dev_cfg = dev->config;
+
 	__ASSERT(nm <= 0x03, "nm <= 0x03");
 
 	uint8_t cmd_buf[] = { MCP2515_OPCODE_READ_RX_BUFFER | (nm << 1) };
@@ -192,7 +206,7 @@ static int mcp2515_cmd_read_rx_buffer(const struct device *dev, uint8_t nm,
 		.buffers = rx_buf, .count = ARRAY_SIZE(rx_buf)
 	};
 
-	return spi_transceive_dt(&DEV_CFG(dev)->bus, &tx, &rx);
+	return spi_transceive_dt(&dev_cfg->bus, &tx, &rx);
 }
 
 static uint8_t mcp2515_convert_canmode_to_mcp2515mode(enum can_mode mode)
@@ -308,7 +322,7 @@ static int mcp2515_get_mode(const struct device *dev, uint8_t *mode)
 
 static int mcp2515_get_core_clock(const struct device *dev, uint32_t *rate)
 {
-	const struct mcp2515_config *dev_cfg = DEV_CFG(dev);
+	const struct mcp2515_config *dev_cfg = dev->config;
 
 	*rate = dev_cfg->osc_freq / 2;
 	return 0;
@@ -326,7 +340,7 @@ static int mcp2515_set_timing(const struct device *dev,
 			      const struct can_timing *timing_data)
 {
 	ARG_UNUSED(timing_data);
-	struct mcp2515_data *dev_data = DEV_DATA(dev);
+	struct mcp2515_data *dev_data = dev->data;
 	int ret;
 
 	if (!timing) {
@@ -439,7 +453,7 @@ done:
 
 static int mcp2515_set_mode(const struct device *dev, enum can_mode mode)
 {
-	struct mcp2515_data *dev_data = DEV_DATA(dev);
+	struct mcp2515_data *dev_data = dev->data;
 	int ret;
 
 	k_mutex_lock(&dev_data->mutex, K_FOREVER);
@@ -460,7 +474,7 @@ static int mcp2515_send(const struct device *dev,
 			k_timeout_t timeout, can_tx_callback_t callback,
 			void *user_data)
 {
-	struct mcp2515_data *dev_data = DEV_DATA(dev);
+	struct mcp2515_data *dev_data = dev->data;
 	uint8_t tx_idx = 0U;
 	uint8_t abc;
 	uint8_t nnn;
@@ -523,7 +537,7 @@ static int mcp2515_add_rx_filter(const struct device *dev,
 				 void *cb_arg,
 				 const struct zcan_filter *filter)
 {
-	struct mcp2515_data *dev_data = DEV_DATA(dev);
+	struct mcp2515_data *dev_data = dev->data;
 	int filter_id = 0;
 
 	__ASSERT(rx_cb != NULL, "response_ptr can not be null");
@@ -555,7 +569,7 @@ static int mcp2515_add_rx_filter(const struct device *dev,
 
 static void mcp2515_remove_rx_filter(const struct device *dev, int filter_id)
 {
-	struct mcp2515_data *dev_data = DEV_DATA(dev);
+	struct mcp2515_data *dev_data = dev->data;
 
 	k_mutex_lock(&dev_data->mutex, K_FOREVER);
 	dev_data->filter_usage &= ~BIT(filter_id);
@@ -566,7 +580,7 @@ static void mcp2515_set_state_change_callback(const struct device *dev,
 					      can_state_change_callback_t cb,
 					      void *user_data)
 {
-	struct mcp2515_data *dev_data = DEV_DATA(dev);
+	struct mcp2515_data *dev_data = dev->data;
 
 	dev_data->state_change_cb = cb;
 	dev_data->state_change_cb_data = user_data;
@@ -575,7 +589,7 @@ static void mcp2515_set_state_change_callback(const struct device *dev,
 static void mcp2515_rx_filter(const struct device *dev,
 			      struct zcan_frame *frame)
 {
-	struct mcp2515_data *dev_data = DEV_DATA(dev);
+	struct mcp2515_data *dev_data = dev->data;
 	uint8_t filter_id = 0U;
 	can_rx_callback_t callback;
 	struct zcan_frame tmp_frame;
@@ -621,7 +635,7 @@ static void mcp2515_rx(const struct device *dev, uint8_t rx_idx)
 
 static void mcp2515_tx_done(const struct device *dev, uint8_t tx_idx)
 {
-	struct mcp2515_data *dev_data = DEV_DATA(dev);
+	struct mcp2515_data *dev_data = dev->data;
 
 	if (dev_data->tx_cb[tx_idx].cb == NULL) {
 		k_sem_give(&dev_data->tx_cb[tx_idx].sem);
@@ -673,7 +687,7 @@ static enum can_state mcp2515_get_state(const struct device *dev,
 
 static void mcp2515_handle_errors(const struct device *dev)
 {
-	struct mcp2515_data *dev_data = DEV_DATA(dev);
+	struct mcp2515_data *dev_data = dev->data;
 	can_state_change_callback_t state_change_cb = dev_data->state_change_cb;
 	void *state_change_cb_data = dev_data->state_change_cb_data;
 	enum can_state state;
@@ -697,8 +711,8 @@ static void mcp2515_recover(const struct device *dev, k_timeout_t timeout)
 
 static void mcp2515_handle_interrupts(const struct device *dev)
 {
-	const struct mcp2515_config *dev_cfg = DEV_CFG(dev);
-	struct mcp2515_data *dev_data = DEV_DATA(dev);
+	const struct mcp2515_config *dev_cfg = dev->config;
+	struct mcp2515_data *dev_data = dev->data;
 	int ret;
 	uint8_t canintf;
 
@@ -765,7 +779,7 @@ static void mcp2515_handle_interrupts(const struct device *dev)
 
 static void mcp2515_int_thread(const struct device *dev)
 {
-	struct mcp2515_data *dev_data = DEV_DATA(dev);
+	struct mcp2515_data *dev_data = dev->data;
 
 	while (1) {
 		k_sem_take(&dev_data->int_sem, K_FOREVER);
@@ -814,8 +828,8 @@ static const struct can_driver_api can_api_funcs = {
 
 static int mcp2515_init(const struct device *dev)
 {
-	const struct mcp2515_config *dev_cfg = DEV_CFG(dev);
-	struct mcp2515_data *dev_data = DEV_DATA(dev);
+	const struct mcp2515_config *dev_cfg = dev->config;
+	struct mcp2515_data *dev_data = dev->data;
 	int ret;
 	struct can_timing timing;
 

--- a/drivers/can/can_mcp2515.h
+++ b/drivers/can/can_mcp2515.h
@@ -14,10 +14,6 @@
 #define MCP2515_TX_CNT                   3
 #define MCP2515_FRAME_LEN               13
 
-#define DEV_CFG(dev) \
-	((const struct mcp2515_config *const)(dev)->config)
-#define DEV_DATA(dev) ((struct mcp2515_data *const)(dev)->data)
-
 struct mcp2515_tx_cb {
 	struct k_sem sem;
 	can_tx_callback_t cb;

--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -201,8 +201,8 @@ static void can_stm32_isr(const struct device *dev)
 	const struct can_stm32_config *cfg;
 	CAN_TypeDef *can;
 
-	data = DEV_DATA(dev);
-	cfg = DEV_CFG(dev);
+	data = dev->data;
+	cfg = dev->config;
 	can = cfg->can;
 
 	can_stm32_tx_isr_handler(can, data);
@@ -221,8 +221,8 @@ static void can_stm32_rx_isr(const struct device *dev)
 	const struct can_stm32_config *cfg;
 	CAN_TypeDef *can;
 
-	data = DEV_DATA(dev);
-	cfg = DEV_CFG(dev);
+	data = dev->data;
+	cfg = dev->config;
 	can = cfg->can;
 
 	can_stm32_rx_isr_handler(can, data);
@@ -234,8 +234,8 @@ static void can_stm32_tx_isr(const struct device *dev)
 	const struct can_stm32_config *cfg;
 	CAN_TypeDef *can;
 
-	data = DEV_DATA(dev);
-	cfg = DEV_CFG(dev);
+	data = dev->data;
+	cfg = dev->config;
 	can = cfg->can;
 
 	can_stm32_tx_isr_handler(can, data);
@@ -247,8 +247,8 @@ static void can_stm32_state_change_isr(const struct device *dev)
 	const struct can_stm32_config *cfg;
 	CAN_TypeDef *can;
 
-	data = DEV_DATA(dev);
-	cfg = DEV_CFG(dev);
+	data = dev->data;
+	cfg = dev->config;
 	can = cfg->can;
 
 
@@ -313,9 +313,9 @@ static int can_leave_sleep_mode(CAN_TypeDef *can)
 
 int can_stm32_set_mode(const struct device *dev, enum can_mode mode)
 {
-	const struct can_stm32_config *cfg = DEV_CFG(dev);
+	const struct can_stm32_config *cfg = dev->config;
 	CAN_TypeDef *can = cfg->can;
-	struct can_stm32_data *data = DEV_DATA(dev);
+	struct can_stm32_data *data = dev->data;
 	int ret;
 
 	LOG_DBG("Set mode %d", mode);
@@ -359,9 +359,9 @@ int can_stm32_set_timing(const struct device *dev,
 			 const struct can_timing *timing,
 			 const struct can_timing *timing_data)
 {
-	const struct can_stm32_config *cfg = DEV_CFG(dev);
+	const struct can_stm32_config *cfg = dev->config;
 	CAN_TypeDef *can = cfg->can;
-	struct can_stm32_data *data = DEV_DATA(dev);
+	struct can_stm32_data *data = dev->data;
 	int ret = -EIO;
 
 	ARG_UNUSED(timing_data);
@@ -397,7 +397,7 @@ done:
 
 int can_stm32_get_core_clock(const struct device *dev, uint32_t *rate)
 {
-	const struct can_stm32_config *cfg = DEV_CFG(dev);
+	const struct can_stm32_config *cfg = dev->config;
 	const struct device *clock;
 	int ret;
 
@@ -423,8 +423,8 @@ int can_stm32_get_max_filters(const struct device *dev, enum can_ide id_type)
 
 static int can_stm32_init(const struct device *dev)
 {
-	const struct can_stm32_config *cfg = DEV_CFG(dev);
-	struct can_stm32_data *data = DEV_DATA(dev);
+	const struct can_stm32_config *cfg = dev->config;
+	struct can_stm32_data *data = dev->data;
 	CAN_TypeDef *can = cfg->can;
 	struct can_timing timing;
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(can2), okay)
@@ -534,8 +534,8 @@ static void can_stm32_set_state_change_callback(const struct device *dev,
 						can_state_change_callback_t cb,
 						void *user_data)
 {
-	struct can_stm32_data *data = DEV_DATA(dev);
-	const struct can_stm32_config *cfg = DEV_CFG(dev);
+	struct can_stm32_data *data = dev->data;
+	const struct can_stm32_config *cfg = dev->config;
 	CAN_TypeDef *can = cfg->can;
 
 	data->state_change_cb = cb;
@@ -551,7 +551,7 @@ static void can_stm32_set_state_change_callback(const struct device *dev,
 static enum can_state can_stm32_get_state(const struct device *dev,
 					  struct can_bus_err_cnt *err_cnt)
 {
-	const struct can_stm32_config *cfg = DEV_CFG(dev);
+	const struct can_stm32_config *cfg = dev->config;
 	CAN_TypeDef *can = cfg->can;
 
 	if (err_cnt) {
@@ -576,8 +576,8 @@ static enum can_state can_stm32_get_state(const struct device *dev,
 #ifndef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY
 int can_stm32_recover(const struct device *dev, k_timeout_t timeout)
 {
-	const struct can_stm32_config *cfg = DEV_CFG(dev);
-	struct can_stm32_data *data = DEV_DATA(dev);
+	const struct can_stm32_config *cfg = dev->config;
+	struct can_stm32_data *data = dev->data;
 	CAN_TypeDef *can = cfg->can;
 	int ret = -EAGAIN;
 	int64_t start_time;
@@ -619,8 +619,8 @@ int can_stm32_send(const struct device *dev, const struct zcan_frame *frame,
 		   k_timeout_t timeout, can_tx_callback_t callback,
 		   void *user_data)
 {
-	const struct can_stm32_config *cfg = DEV_CFG(dev);
-	struct can_stm32_data *data = DEV_DATA(dev);
+	const struct can_stm32_config *cfg = dev->config;
+	struct can_stm32_data *data = dev->data;
 	CAN_TypeDef *can = cfg->can;
 	uint32_t transmit_status_register = can->TSR;
 	CAN_TxMailBox_TypeDef *mailbox = NULL;
@@ -1029,8 +1029,8 @@ static inline int can_stm32_add_rx_filter_unlocked(const struct device *dev,
 						   void *cb_arg,
 						   const struct zcan_filter *filter)
 {
-	const struct can_stm32_config *cfg = DEV_CFG(dev);
-	struct can_stm32_data *data = DEV_DATA(dev);
+	const struct can_stm32_config *cfg = dev->config;
+	struct can_stm32_data *data = dev->data;
 	CAN_TypeDef *can = cfg->master_can;
 	int filter_index = 0;
 	int filter_id;
@@ -1048,7 +1048,7 @@ int can_stm32_add_rx_filter(const struct device *dev, can_rx_callback_t cb,
 			    void *cb_arg,
 			    const struct zcan_filter *filter)
 {
-	struct can_stm32_data *data = DEV_DATA(dev);
+	struct can_stm32_data *data = dev->data;
 	int filter_id;
 
 	k_mutex_lock(&data->inst_mutex, K_FOREVER);
@@ -1060,8 +1060,8 @@ int can_stm32_add_rx_filter(const struct device *dev, can_rx_callback_t cb,
 
 void can_stm32_remove_rx_filter(const struct device *dev, int filter_id)
 {
-	const struct can_stm32_config *cfg = DEV_CFG(dev);
-	struct can_stm32_data *data = DEV_DATA(dev);
+	const struct can_stm32_config *cfg = dev->config;
+	struct can_stm32_data *data = dev->data;
 	CAN_TypeDef *can = cfg->master_can;
 	int bank_nr;
 	int filter_index;

--- a/drivers/can/can_stm32.h
+++ b/drivers/can/can_stm32.h
@@ -10,10 +10,6 @@
 
 #include <drivers/can.h>
 
-#define DEV_DATA(dev) ((struct can_stm32_data *const)(dev)->data)
-#define DEV_CFG(dev) \
-	((const struct can_stm32_config *const)(dev)->config)
-
 #define BIT_SEG_LENGTH(cfg) ((cfg)->prop_ts1 + (cfg)->ts2 + 1)
 
 #define CAN_NUMBER_OF_FILTER_BANKS (14)

--- a/drivers/can/can_stm32fd.c
+++ b/drivers/can/can_stm32fd.c
@@ -57,7 +57,7 @@ void can_stm32fd_set_state_change_callback(const struct device *dev,
 					   can_state_change_callback_t cb,
 					   void *user_data)
 {
-	struct can_stm32fd_data *data = DEV_DATA(dev);
+	struct can_stm32fd_data *data = dev->data;
 
 	data->mcan_data.state_change_cb = cb;
 	data->mcan_data.state_change_cb_data = user_data;
@@ -65,9 +65,10 @@ void can_stm32fd_set_state_change_callback(const struct device *dev,
 
 static int can_stm32fd_init(const struct device *dev)
 {
-	const struct can_stm32fd_config *cfg = DEV_CFG(dev);
+	const struct can_stm32fd_config *cfg = dev->config;
+	struct can_stm32fd_data *data = dev->data;
 	const struct can_mcan_config *mcan_cfg = &cfg->mcan_cfg;
-	struct can_mcan_data *mcan_data = &DEV_DATA(dev)->mcan_data;
+	struct can_mcan_data *mcan_data = &data->mcan_data;
 	struct can_mcan_msg_sram *msg_ram = cfg->msg_sram;
 	int ret;
 
@@ -92,7 +93,7 @@ static int can_stm32fd_init(const struct device *dev)
 enum can_state can_stm32fd_get_state(const struct device *dev,
 				     struct can_bus_err_cnt *err_cnt)
 {
-	const struct can_stm32fd_config *cfg = DEV_CFG(dev);
+	const struct can_stm32fd_config *cfg = dev->config;
 	const struct can_mcan_config *mcan_cfg = &cfg->mcan_cfg;
 
 	return can_mcan_get_state(mcan_cfg, err_cnt);
@@ -102,9 +103,10 @@ int can_stm32fd_send(const struct device *dev, const struct zcan_frame *frame,
 		     k_timeout_t timeout, can_tx_callback_t callback,
 		     void *user_data)
 {
-	const struct can_stm32fd_config *cfg = DEV_CFG(dev);
+	const struct can_stm32fd_config *cfg = dev->config;
+	struct can_stm32fd_data *data = dev->data;
 	const struct can_mcan_config *mcan_cfg = &cfg->mcan_cfg;
-	struct can_mcan_data *mcan_data = &DEV_DATA(dev)->mcan_data;
+	struct can_mcan_data *mcan_data = &data->mcan_data;
 	struct can_mcan_msg_sram *msg_ram = cfg->msg_sram;
 
 	return can_mcan_send(mcan_cfg, mcan_data, msg_ram, frame, timeout,
@@ -114,8 +116,9 @@ int can_stm32fd_send(const struct device *dev, const struct zcan_frame *frame,
 int can_stm32fd_add_rx_filter(const struct device *dev, can_rx_callback_t callback,
 			      void *user_data, const struct zcan_filter *filter)
 {
-	const struct can_stm32fd_config *cfg = DEV_CFG(dev);
-	struct can_mcan_data *mcan_data = &DEV_DATA(dev)->mcan_data;
+	const struct can_stm32fd_config *cfg = dev->config;
+	struct can_stm32fd_data *data = dev->data;
+	struct can_mcan_data *mcan_data = &data->mcan_data;
 	struct can_mcan_msg_sram *msg_ram = cfg->msg_sram;
 
 	return can_mcan_add_rx_filter(mcan_data, msg_ram, callback, user_data, filter);
@@ -123,8 +126,9 @@ int can_stm32fd_add_rx_filter(const struct device *dev, can_rx_callback_t callba
 
 void can_stm32fd_remove_rx_filter(const struct device *dev, int filter_id)
 {
-	const struct can_stm32fd_config *cfg = DEV_CFG(dev);
-	struct can_mcan_data *mcan_data = &DEV_DATA(dev)->mcan_data;
+	const struct can_stm32fd_config *cfg = dev->config;
+	struct can_stm32fd_data *data = dev->data;
+	struct can_mcan_data *mcan_data = &data->mcan_data;
 	struct can_mcan_msg_sram *msg_ram = cfg->msg_sram;
 
 	can_mcan_remove_rx_filter(mcan_data, msg_ram, filter_id);
@@ -132,7 +136,7 @@ void can_stm32fd_remove_rx_filter(const struct device *dev, int filter_id)
 
 int can_stm32fd_set_mode(const struct device *dev, enum can_mode mode)
 {
-	const struct can_stm32fd_config *cfg = DEV_CFG(dev);
+	const struct can_stm32fd_config *cfg = dev->config;
 	const struct can_mcan_config *mcan_cfg = &cfg->mcan_cfg;
 
 	return can_mcan_set_mode(mcan_cfg, mode);
@@ -142,7 +146,7 @@ int can_stm32fd_set_timing(const struct device *dev,
 			   const struct can_timing *timing,
 			   const struct can_timing *timing_data)
 {
-	const struct can_stm32fd_config *cfg = DEV_CFG(dev);
+	const struct can_stm32fd_config *cfg = dev->config;
 	const struct can_mcan_config *mcan_cfg = &cfg->mcan_cfg;
 
 	return can_mcan_set_timing(mcan_cfg, timing, timing_data);
@@ -151,9 +155,9 @@ int can_stm32fd_set_timing(const struct device *dev,
 void can_stm32fd_line_0_isr(void *arg)
 {
 	struct device *dev = (struct device *)arg;
-	const struct can_stm32fd_config *cfg = DEV_CFG(dev);
+	const struct can_stm32fd_config *cfg = dev->config;
 	const struct can_mcan_config *mcan_cfg = &cfg->mcan_cfg;
-	struct can_stm32fd_data *data = DEV_DATA(dev);
+	struct can_stm32fd_data *data = dev->data;
 	struct can_mcan_data *mcan_data = &data->mcan_data;
 	struct can_mcan_msg_sram *msg_ram = cfg->msg_sram;
 
@@ -163,9 +167,10 @@ void can_stm32fd_line_0_isr(void *arg)
 void can_stm32fd_line_1_isr(void *arg)
 {
 	struct device *dev = (struct device *)arg;
-	const struct can_stm32fd_config *cfg = DEV_CFG(dev);
+	const struct can_stm32fd_config *cfg = dev->config;
+	struct can_stm32fd_data *data = dev->data;
 	const struct can_mcan_config *mcan_cfg = &cfg->mcan_cfg;
-	struct can_mcan_data *mcan_data = &DEV_DATA(dev)->mcan_data;
+	struct can_mcan_data *mcan_data = &data->mcan_data;
 	struct can_mcan_msg_sram *msg_ram = cfg->msg_sram;
 
 	can_mcan_line_1_isr(mcan_cfg, msg_ram, mcan_data);

--- a/drivers/can/can_stm32fd.h
+++ b/drivers/can/can_stm32fd.h
@@ -10,9 +10,6 @@
 
 #include "can_mcan.h"
 
-#define DEV_DATA(dev) ((struct can_stm32fd_data *)(dev)->data)
-#define DEV_CFG(dev) ((const struct can_stm32fd_config *)(dev)->config)
-
 struct can_stm32fd_config {
 	struct can_mcan_msg_sram *msg_sram;
 	void (*config_irq)(void);

--- a/drivers/clock_control/clock_control_esp32.c
+++ b/drivers/clock_control/clock_control_esp32.c
@@ -45,8 +45,6 @@ struct esp32_clock_config {
 	int xtal_div;
 };
 
-#define DEV_CFG(dev)                ((struct esp32_clock_config *)(dev->config))
-
 static uint8_t const xtal_freq[] = {
 #ifdef CONFIG_SOC_ESP32
 	[ESP32_CLK_XTAL_24M] = 24,
@@ -119,7 +117,7 @@ static int clock_control_esp32_get_rate(const struct device *dev,
 
 static int clock_control_esp32_init(const struct device *dev)
 {
-	struct esp32_clock_config *cfg = DEV_CFG(dev);
+	struct esp32_clock_config *cfg = dev->config;
 	rtc_cpu_freq_config_t old_config;
 	rtc_cpu_freq_config_t new_config;
 	bool res;

--- a/drivers/clock_control/clock_control_esp32.c
+++ b/drivers/clock_control/clock_control_esp32.c
@@ -117,7 +117,7 @@ static int clock_control_esp32_get_rate(const struct device *dev,
 
 static int clock_control_esp32_init(const struct device *dev)
 {
-	struct esp32_clock_config *cfg = dev->config;
+	const struct esp32_clock_config *cfg = dev->config;
 	rtc_cpu_freq_config_t old_config;
 	rtc_cpu_freq_config_t new_config;
 	bool res;

--- a/drivers/clock_control/clock_control_lpc11u6x.c
+++ b/drivers/clock_control/clock_control_lpc11u6x.c
@@ -14,12 +14,6 @@
 
 #include "clock_control_lpc11u6x.h"
 
-#define DEV_CFG(dev)  ((const struct lpc11u6x_syscon_config *) \
-		      ((dev)->config))
-
-#define DEV_DATA(dev) ((struct lpc11u6x_syscon_data *) \
-		      ((dev)->data))
-
 static void syscon_power_up(struct lpc11u6x_syscon_regs *syscon,
 			    uint32_t bit, bool enable)
 {
@@ -151,8 +145,8 @@ static void syscon_frg_deinit(struct lpc11u6x_syscon_regs *syscon)
 static int lpc11u6x_clock_control_on(const struct device *dev,
 				     clock_control_subsys_t sub_system)
 {
-	const struct lpc11u6x_syscon_config *cfg = DEV_CFG(dev);
-	struct lpc11u6x_syscon_data *data = DEV_DATA(dev);
+	const struct lpc11u6x_syscon_config *cfg = dev->config;
+	struct lpc11u6x_syscon_data *data = dev->data;
 	uint32_t clk_mask = 0, reset_mask = 0;
 	int ret = 0, init_frg = 0;
 
@@ -223,8 +217,8 @@ static int lpc11u6x_clock_control_on(const struct device *dev,
 static int lpc11u6x_clock_control_off(const struct device *dev,
 				      clock_control_subsys_t sub_system)
 {
-	const struct lpc11u6x_syscon_config *cfg = DEV_CFG(dev);
-	struct lpc11u6x_syscon_data *data = DEV_DATA(dev);
+	const struct lpc11u6x_syscon_config *cfg = dev->config;
+	struct lpc11u6x_syscon_data *data = dev->data;
 	uint32_t clk_mask = 0, reset_mask = 0;
 	int ret = 0, deinit_frg = 0;
 
@@ -319,8 +313,8 @@ static int lpc11u6x_clock_control_get_rate(const struct device *dev,
 
 static int lpc11u6x_syscon_init(const struct device *dev)
 {
-	const struct lpc11u6x_syscon_config *cfg = DEV_CFG(dev);
-	struct lpc11u6x_syscon_data *data = DEV_DATA(dev);
+	const struct lpc11u6x_syscon_config *cfg = dev->config;
+	struct lpc11u6x_syscon_data *data = dev->data;
 	uint32_t val;
 
 	k_mutex_init(&data->mutex);

--- a/drivers/clock_control/clock_control_mcux_pcc.c
+++ b/drivers/clock_control/clock_control_mcux_pcc.c
@@ -22,8 +22,7 @@ struct mcux_pcc_config {
 	uint32_t base_address;
 };
 
-#define DEV_CFG(dev)  ((struct mcux_pcc_config *)(dev->config))
-#define DEV_BASE(dev) (DEV_CFG(dev)->base_address)
+#define DEV_BASE(dev) (((struct mcux_pcc_config *)(dev->config))->base_address)
 #ifndef MAKE_PCC_REGADDR
 #define MAKE_PCC_REGADDR(base, offset) ((base) + (offset))
 #endif

--- a/drivers/clock_control/clock_control_rcar_cpg_mssr.c
+++ b/drivers/clock_control/clock_control_rcar_cpg_mssr.c
@@ -15,8 +15,6 @@ struct rcar_mssr_config {
 	uint32_t base_address;
 };
 
-#define DEV_CFG(dev)  ((struct rcar_mssr_config *)(dev->config))
-
 static const uint16_t rmstpsr[] = {
 	0x110, 0x114, 0x118, 0x11c,
 	0x120, 0x124, 0x128, 0x12c,
@@ -68,7 +66,7 @@ static void cpg_reset(const struct rcar_mssr_config *config,
 static int cpg_core_clock_endisable(const struct device *dev,
 				    uint32_t module, uint32_t rate, bool enable)
 {
-	const struct rcar_mssr_config *config = DEV_CFG(dev);
+	const struct rcar_mssr_config *config = dev->config;
 	uint32_t divider;
 	unsigned int key;
 	int ret;
@@ -107,7 +105,7 @@ unlock:
 static int cpg_rmstp_clock_endisable(const struct device *dev,
 				     uint32_t module, bool enable)
 {
-	const struct rcar_mssr_config *config = DEV_CFG(dev);
+	const struct rcar_mssr_config *config = dev->config;
 	uint32_t reg = module / 100;
 	uint32_t bit = module % 100;
 	uint32_t bitmask = BIT(bit);
@@ -170,7 +168,7 @@ static int cpg_get_rate(const struct device *dev,
 			clock_control_subsys_t sys,
 			uint32_t *rate)
 {
-	const struct rcar_mssr_config *config = DEV_CFG(dev);
+	const struct rcar_mssr_config *config = dev->config;
 	struct rcar_cpg_clk *clk = (struct rcar_cpg_clk *)sys;
 	uint32_t val;
 	int ret = 0;

--- a/drivers/clock_control/clock_control_rv32m1_pcc.c
+++ b/drivers/clock_control/clock_control_rv32m1_pcc.c
@@ -18,8 +18,8 @@ struct rv32m1_pcc_config {
 	uint32_t base_address;
 };
 
-#define DEV_CFG(dev)  ((struct rv32m1_pcc_config *)(dev->config))
-#define DEV_BASE(dev) (DEV_CFG(dev)->base_address)
+#define DEV_BASE(dev) \
+	(((struct rv32m1_pcc_config *)(dev->config))->base_address)
 
 static inline clock_ip_name_t clock_ip(const struct device *dev,
 				       clock_control_subsys_t sub_system)

--- a/drivers/console/uart_mux.c
+++ b/drivers/console/uart_mux.c
@@ -87,9 +87,6 @@ enum uart_mux_status_code {
 struct uart_mux_config {
 };
 
-#define DEV_DATA(dev) \
-	((struct uart_mux_dev_data *)(dev)->data)
-
 struct uart_mux_dev_data {
 	sys_snode_t node;
 
@@ -230,7 +227,7 @@ static void uart_mux_tx_work(struct k_work *work)
 
 static int uart_mux_init(const struct device *dev)
 {
-	struct uart_mux_dev_data *dev_data = DEV_DATA(dev);
+	struct uart_mux_dev_data *dev_data = dev->data;
 
 	gsm_mux_init();
 
@@ -290,7 +287,7 @@ static void uart_mux_flush_isr(const struct device *dev)
 
 void uart_mux_disable(const struct device *dev)
 {
-	struct uart_mux_dev_data *dev_data = DEV_DATA(dev);
+	struct uart_mux_dev_data *dev_data = dev->data;
 	const struct device *uart = dev_data->real_uart->uart;
 
 	uart_irq_rx_disable(uart);
@@ -302,7 +299,7 @@ void uart_mux_disable(const struct device *dev)
 
 void uart_mux_enable(const struct device *dev)
 {
-	struct uart_mux_dev_data *dev_data = DEV_DATA(dev);
+	struct uart_mux_dev_data *dev_data = dev->data;
 	struct uart_mux *real_uart = dev_data->real_uart;
 
 	LOG_DBG("Claiming uart for uart_mux");
@@ -467,7 +464,7 @@ static int uart_mux_poll_in(const struct device *dev, unsigned char *p_char)
 static void uart_mux_poll_out(const struct device *dev,
 			      unsigned char out_char)
 {
-	struct uart_mux_dev_data *dev_data = DEV_DATA(dev);
+	struct uart_mux_dev_data *dev_data = dev->data;
 
 	if (dev_data->dev == NULL) {
 		return;
@@ -511,7 +508,7 @@ static int uart_mux_fifo_fill(const struct device *dev,
 		return -EINVAL;
 	}
 
-	dev_data = DEV_DATA(dev);
+	dev_data = dev->data;
 	if (dev_data->dev == NULL) {
 		return -ENOENT;
 	}
@@ -555,7 +552,7 @@ static int uart_mux_fifo_read(const struct device *dev, uint8_t *rx_data,
 		return -EINVAL;
 	}
 
-	dev_data = DEV_DATA(dev);
+	dev_data = dev->data;
 	if (dev_data->dev == NULL) {
 		return -ENOENT;
 	}
@@ -575,7 +572,7 @@ static int uart_mux_fifo_read(const struct device *dev, uint8_t *rx_data,
 
 static void uart_mux_irq_tx_enable(const struct device *dev)
 {
-	struct uart_mux_dev_data *dev_data = DEV_DATA(dev);
+	struct uart_mux_dev_data *dev_data = dev->data;
 
 	if (dev_data == NULL || dev_data->dev == NULL) {
 		return;
@@ -590,7 +587,7 @@ static void uart_mux_irq_tx_enable(const struct device *dev)
 
 static void uart_mux_irq_tx_disable(const struct device *dev)
 {
-	struct uart_mux_dev_data *dev_data = DEV_DATA(dev);
+	struct uart_mux_dev_data *dev_data = dev->data;
 
 	if (dev_data == NULL || dev_data->dev == NULL) {
 		return;
@@ -601,7 +598,7 @@ static void uart_mux_irq_tx_disable(const struct device *dev)
 
 static int uart_mux_irq_tx_ready(const struct device *dev)
 {
-	struct uart_mux_dev_data *dev_data = DEV_DATA(dev);
+	struct uart_mux_dev_data *dev_data = dev->data;
 
 	if (dev_data == NULL) {
 		return -EINVAL;
@@ -616,7 +613,7 @@ static int uart_mux_irq_tx_ready(const struct device *dev)
 
 static void uart_mux_irq_rx_enable(const struct device *dev)
 {
-	struct uart_mux_dev_data *dev_data = DEV_DATA(dev);
+	struct uart_mux_dev_data *dev_data = dev->data;
 
 	if (dev_data == NULL || dev_data->dev == NULL) {
 		return;
@@ -631,7 +628,7 @@ static void uart_mux_irq_rx_enable(const struct device *dev)
 
 static void uart_mux_irq_rx_disable(const struct device *dev)
 {
-	struct uart_mux_dev_data *dev_data = DEV_DATA(dev);
+	struct uart_mux_dev_data *dev_data = dev->data;
 
 	if (dev_data == NULL || dev_data->dev == NULL) {
 		return;
@@ -649,7 +646,7 @@ static int uart_mux_irq_tx_complete(const struct device *dev)
 
 static int uart_mux_irq_rx_ready(const struct device *dev)
 {
-	struct uart_mux_dev_data *dev_data = DEV_DATA(dev);
+	struct uart_mux_dev_data *dev_data = dev->data;
 
 	if (dev_data == NULL) {
 		return -EINVAL;
@@ -674,7 +671,7 @@ static void uart_mux_irq_err_disable(const struct device *dev)
 
 static int uart_mux_irq_is_pending(const struct device *dev)
 {
-	struct uart_mux_dev_data *dev_data = DEV_DATA(dev);
+	struct uart_mux_dev_data *dev_data = dev->data;
 
 	if (dev_data == NULL || dev_data->dev == NULL) {
 		return 0;
@@ -702,7 +699,7 @@ static void uart_mux_irq_callback_set(const struct device *dev,
 				      uart_irq_callback_user_data_t cb,
 				      void *user_data)
 {
-	struct uart_mux_dev_data *dev_data = DEV_DATA(dev);
+	struct uart_mux_dev_data *dev_data = dev->data;
 
 	if (dev_data == NULL) {
 		return;
@@ -790,7 +787,7 @@ const struct device *z_impl_uart_mux_find(int dlci_address)
 
 int uart_mux_send(const struct device *uart, const uint8_t *buf, size_t size)
 {
-	struct uart_mux_dev_data *dev_data = DEV_DATA(uart);
+	struct uart_mux_dev_data *dev_data = uart->data;
 
 	if (size == 0) {
 		return 0;
@@ -823,7 +820,7 @@ int uart_mux_recv(const struct device *mux, struct gsm_dlci *dlci,
 		  uint8_t *data,
 		  size_t len)
 {
-	struct uart_mux_dev_data *dev_data = DEV_DATA(mux);
+	struct uart_mux_dev_data *dev_data = mux->data;
 	size_t wrote = 0;
 
 	LOG_DBG("%s: dlci %p data %p len %zd", mux->name, (void *)dlci,

--- a/drivers/counter/counter_gecko_rtcc.c
+++ b/drivers/counter/counter_gecko_rtcc.c
@@ -40,10 +40,6 @@ struct counter_gecko_data {
 };
 
 #define DEV_NAME(dev) ((dev)->name)
-#define DEV_CFG(dev) \
-	((const struct counter_gecko_config * const)(dev)->config)
-#define DEV_DATA(dev) \
-	((struct counter_gecko_data *const)(dev)->data)
 
 #ifdef CONFIG_SOC_GECKO_HAS_ERRATA_RTCC_E201
 #define ERRATA_RTCC_E201_MESSAGE \
@@ -96,13 +92,13 @@ static int counter_gecko_get_value(const struct device *dev, uint32_t *ticks)
 static int counter_gecko_set_top_value(const struct device *dev,
 				       const struct counter_top_cfg *cfg)
 {
-	struct counter_gecko_data *const dev_data = DEV_DATA(dev);
+	struct counter_gecko_data *const dev_data = dev->data;
 	uint32_t ticks;
 	uint32_t flags;
 	int err = 0;
 
 #ifdef CONFIG_SOC_GECKO_HAS_ERRATA_RTCC_E201
-	const struct counter_gecko_config *const dev_cfg = DEV_CFG(dev);
+	const struct counter_gecko_config *const dev_cfg = dev->config;
 
 	if (dev_cfg->prescaler != 1) {
 		LOG_ERR(ERRATA_RTCC_E201_MESSAGE);
@@ -157,7 +153,7 @@ static int counter_gecko_set_alarm(const struct device *dev, uint8_t chan_id,
 				   const struct counter_alarm_cfg *alarm_cfg)
 {
 	uint32_t count = RTCC_CounterGet();
-	struct counter_gecko_data *const dev_data = DEV_DATA(dev);
+	struct counter_gecko_data *const dev_data = dev->data;
 	uint32_t top_value = counter_gecko_get_top_value(dev);
 	uint32_t ccv;
 
@@ -200,7 +196,7 @@ static int counter_gecko_set_alarm(const struct device *dev, uint8_t chan_id,
 static int counter_gecko_cancel_alarm(const struct device *dev,
 				      uint8_t chan_id)
 {
-	struct counter_gecko_data *const dev_data = DEV_DATA(dev);
+	struct counter_gecko_data *const dev_data = dev->data;
 
 	uint8_t cc_idx = chan_id2cc_idx(chan_id);
 
@@ -227,7 +223,7 @@ static uint32_t counter_gecko_get_pending_int(const struct device *dev)
 
 static int counter_gecko_init(const struct device *dev)
 {
-	const struct counter_gecko_config *const dev_cfg = DEV_CFG(dev);
+	const struct counter_gecko_config *const dev_cfg = dev->config;
 
 	RTCC_Init_TypeDef rtcc_config = {
 		false,                /* Don't start counting */
@@ -327,7 +323,7 @@ static const struct counter_driver_api counter_gecko_driver_api = {
 ISR_DIRECT_DECLARE(counter_gecko_isr_0)
 {
 	const struct device *dev = DEVICE_DT_INST_GET(0);
-	struct counter_gecko_data *const dev_data = DEV_DATA(dev);
+	struct counter_gecko_data *const dev_data = dev->data;
 	counter_alarm_callback_t alarm_callback;
 	uint32_t count = RTCC_CounterGet();
 	uint32_t flags = RTCC_IntGetEnabled();

--- a/drivers/counter/counter_sam0_tc32.c
+++ b/drivers/counter/counter_sam0_tc32.c
@@ -41,12 +41,6 @@ struct counter_sam0_tc32_config {
 	void (*irq_config_func)(const struct device *dev);
 };
 
-#define DEV_CFG(dev) ((const struct counter_sam0_tc32_config *const) \
-		      (dev)->config)
-#define DEV_DATA(dev) ((struct counter_sam0_tc32_data *const) \
-		       (dev)->data)
-
-
 static void wait_synchronization(TcCount32 *regs)
 {
 #if defined(TC_SYNCBUSY_MASK)
@@ -78,7 +72,7 @@ static void read_synchronize_count(TcCount32 *regs)
 
 static int counter_sam0_tc32_start(const struct device *dev)
 {
-	const struct counter_sam0_tc32_config *const cfg = DEV_CFG(dev);
+	const struct counter_sam0_tc32_config *const cfg = dev->config;
 	TcCount32 *tc = cfg->regs;
 
 	/*
@@ -92,7 +86,7 @@ static int counter_sam0_tc32_start(const struct device *dev)
 
 static int counter_sam0_tc32_stop(const struct device *dev)
 {
-	const struct counter_sam0_tc32_config *const cfg = DEV_CFG(dev);
+	const struct counter_sam0_tc32_config *const cfg = dev->config;
 	TcCount32 *tc = cfg->regs;
 
 	/*
@@ -108,7 +102,7 @@ static int counter_sam0_tc32_stop(const struct device *dev)
 
 static uint32_t counter_sam0_tc32_read(const struct device *dev)
 {
-	const struct counter_sam0_tc32_config *const cfg = DEV_CFG(dev);
+	const struct counter_sam0_tc32_config *const cfg = dev->config;
 	TcCount32 *tc = cfg->regs;
 
 	read_synchronize_count(tc);
@@ -125,8 +119,8 @@ static int counter_sam0_tc32_get_value(const struct device *dev,
 static void counter_sam0_tc32_relative_alarm(const struct device *dev,
 					     uint32_t ticks)
 {
-	struct counter_sam0_tc32_data *data = DEV_DATA(dev);
-	const struct counter_sam0_tc32_config *const cfg = DEV_CFG(dev);
+	struct counter_sam0_tc32_data *data = dev->data;
+	const struct counter_sam0_tc32_config *const cfg = dev->config;
 	TcCount32 *tc = cfg->regs;
 	uint32_t before;
 	uint32_t target;
@@ -185,8 +179,8 @@ static int counter_sam0_tc32_set_alarm(const struct device *dev,
 				       uint8_t chan_id,
 				       const struct counter_alarm_cfg *alarm_cfg)
 {
-	struct counter_sam0_tc32_data *data = DEV_DATA(dev);
-	const struct counter_sam0_tc32_config *const cfg = DEV_CFG(dev);
+	struct counter_sam0_tc32_data *data = dev->data;
+	const struct counter_sam0_tc32_config *const cfg = dev->config;
 	TcCount32 *tc = cfg->regs;
 
 	ARG_UNUSED(chan_id);
@@ -222,8 +216,8 @@ static int counter_sam0_tc32_set_alarm(const struct device *dev,
 static int counter_sam0_tc32_cancel_alarm(const struct device *dev,
 					  uint8_t chan_id)
 {
-	struct counter_sam0_tc32_data *data = DEV_DATA(dev);
-	const struct counter_sam0_tc32_config *const cfg = DEV_CFG(dev);
+	struct counter_sam0_tc32_data *data = dev->data;
+	const struct counter_sam0_tc32_config *const cfg = dev->config;
 	TcCount32 *tc = cfg->regs;
 
 	int key = irq_lock();
@@ -241,8 +235,8 @@ static int counter_sam0_tc32_cancel_alarm(const struct device *dev,
 static int counter_sam0_tc32_set_top_value(const struct device *dev,
 					   const struct counter_top_cfg *top_cfg)
 {
-	struct counter_sam0_tc32_data *data = DEV_DATA(dev);
-	const struct counter_sam0_tc32_config *const cfg = DEV_CFG(dev);
+	struct counter_sam0_tc32_data *data = dev->data;
+	const struct counter_sam0_tc32_config *const cfg = dev->config;
 	TcCount32 *tc = cfg->regs;
 	int err = 0;
 	int key = irq_lock();
@@ -286,7 +280,7 @@ static int counter_sam0_tc32_set_top_value(const struct device *dev,
 
 static uint32_t counter_sam0_tc32_get_pending_int(const struct device *dev)
 {
-	const struct counter_sam0_tc32_config *const cfg = DEV_CFG(dev);
+	const struct counter_sam0_tc32_config *const cfg = dev->config;
 	TcCount32 *tc = cfg->regs;
 
 	return tc->INTFLAG.reg & (TC_INTFLAG_MC0 | TC_INTFLAG_MC1);
@@ -294,7 +288,7 @@ static uint32_t counter_sam0_tc32_get_pending_int(const struct device *dev)
 
 static uint32_t counter_sam0_tc32_get_top_value(const struct device *dev)
 {
-	const struct counter_sam0_tc32_config *const cfg = DEV_CFG(dev);
+	const struct counter_sam0_tc32_config *const cfg = dev->config;
 	TcCount32 *tc = cfg->regs;
 
 	/*
@@ -307,8 +301,8 @@ static uint32_t counter_sam0_tc32_get_top_value(const struct device *dev)
 
 static void counter_sam0_tc32_isr(const struct device *dev)
 {
-	struct counter_sam0_tc32_data *data = DEV_DATA(dev);
-	const struct counter_sam0_tc32_config *const cfg = DEV_CFG(dev);
+	struct counter_sam0_tc32_data *data = dev->data;
+	const struct counter_sam0_tc32_config *const cfg = dev->config;
 	TcCount32 *tc = cfg->regs;
 	uint8_t status = tc->INTFLAG.reg;
 
@@ -335,7 +329,7 @@ static void counter_sam0_tc32_isr(const struct device *dev)
 
 static int counter_sam0_tc32_initialize(const struct device *dev)
 {
-	const struct counter_sam0_tc32_config *const cfg = DEV_CFG(dev);
+	const struct counter_sam0_tc32_config *const cfg = dev->config;
 	TcCount32 *tc = cfg->regs;
 
 #ifdef MCLK

--- a/drivers/counter/counter_sam_tc.c
+++ b/drivers/counter/counter_sam_tc.c
@@ -70,10 +70,6 @@ struct counter_sam_dev_data {
 };
 
 #define DEV_NAME(dev) ((dev)->name)
-#define DEV_CFG(dev) \
-	((const struct counter_sam_dev_cfg *const)(dev)->config)
-#define DEV_DATA(dev) \
-	((struct counter_sam_dev_data *const)(dev)->data)
 
 static const uint32_t sam_tc_input_freq_table[] = {
 #if defined(CONFIG_SOC_SERIES_SAME70) || defined(CONFIG_SOC_SERIES_SAMV71)
@@ -100,7 +96,7 @@ static const uint32_t sam_tc_input_freq_table[] = {
 
 static int counter_sam_tc_start(const struct device *dev)
 {
-	const struct counter_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
+	const struct counter_sam_dev_cfg *const dev_cfg = dev->config;
 	Tc *tc = dev_cfg->regs;
 	TcChannel *tc_ch = &tc->TcChannel[dev_cfg->tc_chan_num];
 
@@ -111,7 +107,7 @@ static int counter_sam_tc_start(const struct device *dev)
 
 static int counter_sam_tc_stop(const struct device *dev)
 {
-	const struct counter_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
+	const struct counter_sam_dev_cfg *const dev_cfg = dev->config;
 	Tc *tc = dev_cfg->regs;
 	TcChannel *tc_ch = &tc->TcChannel[dev_cfg->tc_chan_num];
 
@@ -122,7 +118,7 @@ static int counter_sam_tc_stop(const struct device *dev)
 
 static int counter_sam_tc_get_value(const struct device *dev, uint32_t *ticks)
 {
-	const struct counter_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
+	const struct counter_sam_dev_cfg *const dev_cfg = dev->config;
 	Tc *tc = dev_cfg->regs;
 	TcChannel *tc_ch = &tc->TcChannel[dev_cfg->tc_chan_num];
 
@@ -134,8 +130,8 @@ static int counter_sam_tc_get_value(const struct device *dev, uint32_t *ticks)
 static int counter_sam_tc_set_alarm(const struct device *dev, uint8_t chan_id,
 				    const struct counter_alarm_cfg *alarm_cfg)
 {
-	struct counter_sam_dev_data *data = DEV_DATA(dev);
-	const struct counter_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
+	struct counter_sam_dev_data *data = dev->data;
+	const struct counter_sam_dev_cfg *const dev_cfg = dev->config;
 	Tc *tc = dev_cfg->regs;
 	TcChannel *tc_ch = &tc->TcChannel[dev_cfg->tc_chan_num];
 	uint32_t top_value;
@@ -196,8 +192,8 @@ static int counter_sam_tc_set_alarm(const struct device *dev, uint8_t chan_id,
 
 static int counter_sam_tc_cancel_alarm(const struct device *dev, uint8_t chan_id)
 {
-	struct counter_sam_dev_data *data = DEV_DATA(dev);
-	const struct counter_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
+	struct counter_sam_dev_data *data = dev->data;
+	const struct counter_sam_dev_cfg *const dev_cfg = dev->config;
 	Tc *tc = dev_cfg->regs;
 	TcChannel *tc_ch = &tc->TcChannel[dev_cfg->tc_chan_num];
 
@@ -220,8 +216,8 @@ static int counter_sam_tc_cancel_alarm(const struct device *dev, uint8_t chan_id
 static int counter_sam_tc_set_top_value(const struct device *dev,
 					const struct counter_top_cfg *top_cfg)
 {
-	struct counter_sam_dev_data *data = DEV_DATA(dev);
-	const struct counter_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
+	struct counter_sam_dev_data *data = dev->data;
+	const struct counter_sam_dev_cfg *const dev_cfg = dev->config;
 	Tc *tc = dev_cfg->regs;
 	TcChannel *tc_ch = &tc->TcChannel[dev_cfg->tc_chan_num];
 	int ret = 0;
@@ -259,7 +255,7 @@ static int counter_sam_tc_set_top_value(const struct device *dev,
 
 static uint32_t counter_sam_tc_get_top_value(const struct device *dev)
 {
-	const struct counter_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
+	const struct counter_sam_dev_cfg *const dev_cfg = dev->config;
 	Tc *tc = dev_cfg->regs;
 	TcChannel *tc_ch = &tc->TcChannel[dev_cfg->tc_chan_num];
 
@@ -268,7 +264,7 @@ static uint32_t counter_sam_tc_get_top_value(const struct device *dev)
 
 static uint32_t counter_sam_tc_get_pending_int(const struct device *dev)
 {
-	const struct counter_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
+	const struct counter_sam_dev_cfg *const dev_cfg = dev->config;
 	Tc *tc = dev_cfg->regs;
 	TcChannel *tc_ch = &tc->TcChannel[dev_cfg->tc_chan_num];
 
@@ -277,8 +273,8 @@ static uint32_t counter_sam_tc_get_pending_int(const struct device *dev)
 
 static void counter_sam_tc_isr(const struct device *dev)
 {
-	struct counter_sam_dev_data *data = DEV_DATA(dev);
-	const struct counter_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
+	struct counter_sam_dev_data *data = dev->data;
+	const struct counter_sam_dev_cfg *const dev_cfg = dev->config;
 	Tc *tc = dev_cfg->regs;
 	TcChannel *tc_ch = &tc->TcChannel[dev_cfg->tc_chan_num];
 	uint32_t status;
@@ -314,7 +310,7 @@ static void counter_sam_tc_isr(const struct device *dev)
 
 static int counter_sam_initialize(const struct device *dev)
 {
-	const struct counter_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
+	const struct counter_sam_dev_cfg *const dev_cfg = dev->config;
 	Tc *const tc = dev_cfg->regs;
 	TcChannel *tc_ch = &tc->TcChannel[dev_cfg->tc_chan_num];
 

--- a/drivers/dac/dac_mcp4725.c
+++ b/drivers/dac/dac_mcp4725.c
@@ -82,7 +82,7 @@ static int mcp4725_channel_setup(const struct device *dev,
 static int mcp4725_write_value(const struct device *dev, uint8_t channel,
 				uint32_t value)
 {
-	const struct mcp4725_config *config = (struct mcp4725_config *)dev->config;
+	const struct mcp4725_config *config = dev->config;
 	uint8_t tx_data[2];
 	int ret;
 

--- a/drivers/dac/dac_sam.c
+++ b/drivers/dac/dac_sam.c
@@ -47,16 +47,12 @@ struct dac_sam_dev_data {
 };
 
 #define DEV_NAME(dev) ((dev)->name)
-#define DEV_CFG(dev) \
-	((const struct dac_sam_dev_cfg *const)(dev)->config)
-#define DEV_DATA(dev) \
-	((struct dac_sam_dev_data *const)(dev)->data)
 
 static void dac_sam_isr(void *arg)
 {
 	const struct device *dev = (const struct device *)arg;
-	const struct dac_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
-	struct dac_sam_dev_data *const dev_data = DEV_DATA(dev);
+	const struct dac_sam_dev_cfg *const dev_cfg = dev->config;
+	struct dac_sam_dev_data *const dev_data = dev->data;
 	Dacc *const dac = dev_cfg->regs;
 	uint32_t int_stat;
 
@@ -78,7 +74,7 @@ static void dac_sam_isr(void *arg)
 static int dac_sam_channel_setup(const struct device *dev,
 				 const struct dac_channel_cfg *channel_cfg)
 {
-	const struct dac_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
+	const struct dac_sam_dev_cfg *const dev_cfg = dev->config;
 	Dacc *const dac = dev_cfg->regs;
 
 	if (channel_cfg->channel_id >= DAC_CHANNEL_NO) {
@@ -97,8 +93,8 @@ static int dac_sam_channel_setup(const struct device *dev,
 static int dac_sam_write_value(const struct device *dev, uint8_t channel,
 			       uint32_t value)
 {
-	struct dac_sam_dev_data *const dev_data = DEV_DATA(dev);
-	const struct dac_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
+	struct dac_sam_dev_data *const dev_data = dev->data;
+	const struct dac_sam_dev_cfg *const dev_cfg = dev->config;
 	Dacc *const dac = dev_cfg->regs;
 
 	if (channel >= DAC_CHANNEL_NO) {
@@ -123,8 +119,8 @@ static int dac_sam_write_value(const struct device *dev, uint8_t channel,
 
 static int dac_sam_init(const struct device *dev)
 {
-	const struct dac_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
-	struct dac_sam_dev_data *const dev_data = DEV_DATA(dev);
+	const struct dac_sam_dev_cfg *const dev_cfg = dev->config;
+	struct dac_sam_dev_data *const dev_data = dev->data;
 	Dacc *const dac = dev_cfg->regs;
 
 	/* Configure interrupts */

--- a/drivers/dac/dac_sam0.c
+++ b/drivers/dac/dac_sam0.c
@@ -28,13 +28,11 @@ struct dac_sam0_cfg {
 	uint8_t refsel;
 };
 
-#define DEV_CFG(dev) ((const struct dac_sam0_cfg *const)(dev)->config)
-
 /* Write to the DAC. */
 static int dac_sam0_write_value(const struct device *dev, uint8_t channel,
 				uint32_t value)
 {
-	const struct dac_sam0_cfg *const cfg = DEV_CFG(dev);
+	const struct dac_sam0_cfg *const cfg = dev->config;
 	Dac *regs = cfg->regs;
 
 	regs->DATA.reg = (uint16_t)value;
@@ -62,7 +60,7 @@ static int dac_sam0_channel_setup(const struct device *dev,
 /* Initialise and enable the DAC. */
 static int dac_sam0_init(const struct device *dev)
 {
-	const struct dac_sam0_cfg *const cfg = DEV_CFG(dev);
+	const struct dac_sam0_cfg *const cfg = dev->config;
 	Dac *regs = cfg->regs;
 
 	/* Enable the GCLK */

--- a/drivers/display/display_dummy.c
+++ b/drivers/display/display_dummy.c
@@ -22,8 +22,7 @@ struct dummy_display_data {
 
 static int dummy_display_init(const struct device *dev)
 {
-	struct dummy_display_data *disp_data =
-	    (struct dummy_display_data *)dev->data;
+	struct dummy_display_data *disp_data = dev->data;
 
 	disp_data->current_pixel_format = PIXEL_FORMAT_ARGB_8888;
 

--- a/drivers/display/display_st7735r.c
+++ b/drivers/display/display_st7735r.c
@@ -141,14 +141,14 @@ static int st7735r_reset_display(struct st7735r_data *data)
 
 static int st7735r_blanking_on(const struct device *dev)
 {
-	struct st7735r_data *data = (struct st7735r_data *)dev->data;
+	struct st7735r_data *data = dev->data;
 
 	return st7735r_transmit(data, ST7735R_CMD_DISP_OFF, NULL, 0);
 }
 
 static int st7735r_blanking_off(const struct device *dev)
 {
-	struct st7735r_data *data = (struct st7735r_data *)dev->data;
+	struct st7735r_data *data = dev->data;
 
 	return st7735r_transmit(data, ST7735R_CMD_DISP_ON, NULL, 0);
 }
@@ -196,7 +196,7 @@ static int st7735r_write(const struct device *dev,
 			 const struct display_buffer_descriptor *desc,
 			 const void *buf)
 {
-	struct st7735r_data *data = (struct st7735r_data *)dev->data;
+	struct st7735r_data *data = dev->data;
 	const uint8_t *write_data_start = (uint8_t *) buf;
 	struct spi_buf tx_buf;
 	struct spi_buf_set tx_bufs;
@@ -269,7 +269,7 @@ static int st7735r_set_contrast(const struct device *dev,
 static void st7735r_get_capabilities(const struct device *dev,
 				     struct display_capabilities *capabilities)
 {
-	const struct st7735r_config *config = (const struct st7735r_config *)dev->config;
+	const struct st7735r_config *config = dev->config;
 
 	memset(capabilities, 0, sizeof(struct display_capabilities));
 	capabilities->x_resolution = config->width;
@@ -288,7 +288,7 @@ static void st7735r_get_capabilities(const struct device *dev,
 static int st7735r_set_pixel_format(const struct device *dev,
 				    const enum display_pixel_format pixel_format)
 {
-	const struct st7735r_config *config = (const struct st7735r_config *)dev->config;
+	const struct st7735r_config *config = dev->config;
 
 	if ((pixel_format == PIXEL_FORMAT_RGB_565) &&
 	    (~config->madctl & ST7735R_MADCTL_BGR)) {
@@ -436,8 +436,8 @@ static int st7735r_lcd_init(struct st7735r_data *data)
 
 static int st7735r_init(const struct device *dev)
 {
-	struct st7735r_data *data = (struct st7735r_data *)dev->data;
-	const struct st7735r_config *config = (const struct st7735r_config *)dev->config;
+	struct st7735r_data *data = dev->data;
+	const struct st7735r_config *config = dev->config;
 	int ret;
 
 	if (!spi_is_ready(&config->bus)) {
@@ -499,7 +499,7 @@ static int st7735r_pm_action(const struct device *dev,
 			     enum pm_device_action action)
 {
 	int ret = 0;
-	struct st7735r_data *data = (struct st7735r_data *)dev->data;
+	struct st7735r_data *data = dev->data;
 
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:

--- a/drivers/display/display_st7735r.c
+++ b/drivers/display/display_st7735r.c
@@ -269,7 +269,7 @@ static int st7735r_set_contrast(const struct device *dev,
 static void st7735r_get_capabilities(const struct device *dev,
 				     struct display_capabilities *capabilities)
 {
-	struct st7735r_config *config = (struct st7735r_config *)dev->config;
+	const struct st7735r_config *config = (const struct st7735r_config *)dev->config;
 
 	memset(capabilities, 0, sizeof(struct display_capabilities));
 	capabilities->x_resolution = config->width;
@@ -288,7 +288,7 @@ static void st7735r_get_capabilities(const struct device *dev,
 static int st7735r_set_pixel_format(const struct device *dev,
 				    const enum display_pixel_format pixel_format)
 {
-	struct st7735r_config *config = (struct st7735r_config *)dev->config;
+	const struct st7735r_config *config = (const struct st7735r_config *)dev->config;
 
 	if ((pixel_format == PIXEL_FORMAT_RGB_565) &&
 	    (~config->madctl & ST7735R_MADCTL_BGR)) {
@@ -437,7 +437,7 @@ static int st7735r_lcd_init(struct st7735r_data *data)
 static int st7735r_init(const struct device *dev)
 {
 	struct st7735r_data *data = (struct st7735r_data *)dev->data;
-	struct st7735r_config *config = (struct st7735r_config *)dev->config;
+	const struct st7735r_config *config = (const struct st7735r_config *)dev->config;
 	int ret;
 
 	if (!spi_is_ready(&config->bus)) {

--- a/drivers/dma/dma_dw.c
+++ b/drivers/dma/dma_dw.c
@@ -35,9 +35,6 @@ LOG_MODULE_REGISTER(dma_dw);
 #define DW_CFG_LOW_DEF			0x0
 
 #define DEV_NAME(dev) ((dev)->name)
-#define DEV_DATA(dev) ((struct dw_dma_dev_data *const)(dev)->data)
-#define DEV_CFG(dev) \
-	((const struct dw_dma_dev_cfg *const)(dev)->config)
 
 /* number of tries to wait for reset */
 #define DW_DMA_CFG_TRIES	10000
@@ -55,8 +52,8 @@ static ALWAYS_INLINE uint32_t dw_read(uint32_t dma_base, uint32_t reg)
 
 static void dw_dma_isr(const struct device *dev)
 {
-	const struct dw_dma_dev_cfg *const dev_cfg = DEV_CFG(dev);
-	struct dw_dma_dev_data *const dev_data = DEV_DATA(dev);
+	const struct dw_dma_dev_cfg *const dev_cfg = dev->config;
+	struct dw_dma_dev_data *const dev_data = dev->data;
 	struct dma_chan_data *chan_data;
 
 	uint32_t status_tfr = 0U;
@@ -118,8 +115,8 @@ static void dw_dma_isr(const struct device *dev)
 static int dw_dma_config(const struct device *dev, uint32_t channel,
 			 struct dma_config *cfg)
 {
-	struct dw_dma_dev_data *const dev_data = DEV_DATA(dev);
-	const struct dw_dma_dev_cfg *const dev_cfg = DEV_CFG(dev);
+	struct dw_dma_dev_data *const dev_data = dev->data;
+	const struct dw_dma_dev_cfg *const dev_cfg = dev->config;
 	struct dma_chan_data *chan_data;
 	struct dma_block_config *cfg_blocks;
 	uint32_t m_size;
@@ -252,8 +249,8 @@ static int dw_dma_config(const struct device *dev, uint32_t channel,
 static int dw_dma_reload(const struct device *dev, uint32_t channel,
 			 uint32_t src, uint32_t dst, size_t size)
 {
-	struct dw_dma_dev_data *const dev_data = DEV_DATA(dev);
-	const struct dw_dma_dev_cfg *const dev_cfg = DEV_CFG(dev);
+	struct dw_dma_dev_data *const dev_data = dev->data;
+	const struct dw_dma_dev_cfg *const dev_cfg = dev->config;
 
 	if (channel >= DW_MAX_CHAN) {
 		return -EINVAL;
@@ -270,7 +267,7 @@ static int dw_dma_reload(const struct device *dev, uint32_t channel,
 
 static int dw_dma_transfer_start(const struct device *dev, uint32_t channel)
 {
-	const struct dw_dma_dev_cfg *const dev_cfg = DEV_CFG(dev);
+	const struct dw_dma_dev_cfg *const dev_cfg = dev->config;
 
 	if (channel >= DW_MAX_CHAN) {
 		return -EINVAL;
@@ -284,7 +281,7 @@ static int dw_dma_transfer_start(const struct device *dev, uint32_t channel)
 
 static int dw_dma_transfer_stop(const struct device *dev, uint32_t channel)
 {
-	const struct dw_dma_dev_cfg *const dev_cfg = DEV_CFG(dev);
+	const struct dw_dma_dev_cfg *const dev_cfg = dev->config;
 
 	if (channel >= DW_MAX_CHAN) {
 		return -EINVAL;
@@ -297,8 +294,8 @@ static int dw_dma_transfer_stop(const struct device *dev, uint32_t channel)
 
 static void dw_dma_setup(const struct device *dev)
 {
-	const struct dw_dma_dev_cfg *const dev_cfg = DEV_CFG(dev);
-	struct dw_dma_dev_data *const dev_data = DEV_DATA(dev);
+	const struct dw_dma_dev_cfg *const dev_cfg = dev->config;
+	struct dw_dma_dev_data *const dev_data = dev->data;
 	struct dw_drv_plat_data *dp = dev_data->channel_data;
 	int i;
 
@@ -340,7 +337,7 @@ found:
 
 static int dw_dma_init(const struct device *dev)
 {
-	const struct dw_dma_dev_cfg *const dev_cfg = DEV_CFG(dev);
+	const struct dw_dma_dev_cfg *const dev_cfg = dev->config;
 
 	/* Disable all channels and Channel interrupts */
 	dw_dma_setup(dev);

--- a/drivers/dma/dma_iproc_pax_v1.c
+++ b/drivers/dma/dma_iproc_pax_v1.c
@@ -423,7 +423,7 @@ err:
 static int poll_on_write_sync(const struct device *dev,
 			      struct dma_iproc_pax_ring_data *ring)
 {
-	struct dma_iproc_pax_cfg *cfg = dev->config;
+	const struct dma_iproc_pax_cfg *cfg = dev->config;
 	const struct device *pcidev;
 	struct dma_iproc_pax_write_sync_data sync_rd, *recv, *sent;
 	uint64_t pci_addr;
@@ -593,7 +593,7 @@ static void rm_isr(void *arg)
 
 static int dma_iproc_pax_init(const struct device *dev)
 {
-	struct dma_iproc_pax_cfg *cfg = dev->config;
+	const struct dma_iproc_pax_cfg *cfg = dev->config;
 	struct dma_iproc_pax_data *pd = dev->data;
 	int r;
 	uintptr_t mem_aligned;
@@ -744,7 +744,7 @@ static int dma_iproc_pax_do_xfer(const struct device *dev,
 				 uint32_t pl_len)
 {
 	struct dma_iproc_pax_data *pd = dev->data;
-	struct dma_iproc_pax_cfg *cfg = dev->config;
+	const struct dma_iproc_pax_cfg *cfg = dev->config;
 	int ret = 0, cnt;
 	struct dma_iproc_pax_ring_data *ring;
 	void *hdr;

--- a/drivers/dma/dma_iproc_pax_v1.c
+++ b/drivers/dma/dma_iproc_pax_v1.c
@@ -26,12 +26,6 @@ LOG_MODULE_REGISTER(dma_iproc_pax);
 
 #define PAX_DMA_DEV_NAME(dev) ((dev)->name)
 
-#define PAX_DMA_DEV_CFG(dev) \
-	((struct dma_iproc_pax_cfg *)(dev)->config)
-
-#define PAX_DMA_DEV_DATA(dev) \
-	((struct dma_iproc_pax_data *)(dev)->data)
-
 /* Driver runtime data for PAX DMA and RM */
 static struct dma_iproc_pax_data pax_dma_data;
 
@@ -429,7 +423,7 @@ err:
 static int poll_on_write_sync(const struct device *dev,
 			      struct dma_iproc_pax_ring_data *ring)
 {
-	struct dma_iproc_pax_cfg *cfg = PAX_DMA_DEV_CFG(dev);
+	struct dma_iproc_pax_cfg *cfg = dev->config;
 	const struct device *pcidev;
 	struct dma_iproc_pax_write_sync_data sync_rd, *recv, *sent;
 	uint64_t pci_addr;
@@ -479,7 +473,7 @@ static int poll_on_write_sync(const struct device *dev,
 static int process_cmpl_event(const struct device *dev,
 			      enum ring_idx idx, uint32_t pl_len)
 {
-	struct dma_iproc_pax_data *pd = PAX_DMA_DEV_DATA(dev);
+	struct dma_iproc_pax_data *pd = dev->data;
 	uint32_t wr_offs, rd_offs, ret = 0;
 	struct dma_iproc_pax_ring_data *ring = &(pd->ring[idx]);
 	struct cmpl_pkt *c;
@@ -538,7 +532,7 @@ static int process_cmpl_event(const struct device *dev,
 static int peek_ring_cmpl(const struct device *dev,
 			  enum ring_idx idx, uint32_t pl_len)
 {
-	struct dma_iproc_pax_data *pd = PAX_DMA_DEV_DATA(dev);
+	struct dma_iproc_pax_data *pd = dev->data;
 	uint32_t wr_offs, rd_offs, timeout = PAX_DMA_MAX_POLL_WAIT;
 	struct dma_iproc_pax_ring_data *ring = &(pd->ring[idx]);
 
@@ -569,7 +563,7 @@ static void rm_isr(void *arg)
 {
 	uint32_t status, err_stat, idx;
 	const struct device *dev = arg;
-	struct dma_iproc_pax_data *pd = PAX_DMA_DEV_DATA(dev);
+	struct dma_iproc_pax_data *pd = dev->data;
 
 	/* read and clear interrupt status */
 	status = sys_read32(RM_COMM_REG(pd, RM_COMM_MSI_INTR_INTERRUPT_STATUS));
@@ -599,8 +593,8 @@ static void rm_isr(void *arg)
 
 static int dma_iproc_pax_init(const struct device *dev)
 {
-	struct dma_iproc_pax_cfg *cfg = PAX_DMA_DEV_CFG(dev);
-	struct dma_iproc_pax_data *pd = PAX_DMA_DEV_DATA(dev);
+	struct dma_iproc_pax_cfg *cfg = dev->config;
+	struct dma_iproc_pax_data *pd = dev->data;
 	int r;
 	uintptr_t mem_aligned;
 
@@ -713,7 +707,7 @@ static void set_pkt_count(const struct device *dev,
 			  enum ring_idx idx,
 			  uint32_t pl_len)
 {
-	struct dma_iproc_pax_data *pd = PAX_DMA_DEV_DATA(dev);
+	struct dma_iproc_pax_data *pd = dev->data;
 	uint32_t val;
 
 	/* program packet count for interrupt assertion */
@@ -729,7 +723,7 @@ static int wait_for_pkt_completion(const struct device *dev,
 				   enum ring_idx idx,
 				   uint32_t pl_len)
 {
-	struct dma_iproc_pax_data *pd = PAX_DMA_DEV_DATA(dev);
+	struct dma_iproc_pax_data *pd = dev->data;
 	struct dma_iproc_pax_ring_data *ring;
 
 	ring = &(pd->ring[idx]);
@@ -749,8 +743,8 @@ static int dma_iproc_pax_do_xfer(const struct device *dev,
 				 struct dma_iproc_pax_payload *pl,
 				 uint32_t pl_len)
 {
-	struct dma_iproc_pax_data *pd = PAX_DMA_DEV_DATA(dev);
-	struct dma_iproc_pax_cfg *cfg = PAX_DMA_DEV_CFG(dev);
+	struct dma_iproc_pax_data *pd = dev->data;
+	struct dma_iproc_pax_cfg *cfg = dev->config;
 	int ret = 0, cnt;
 	struct dma_iproc_pax_ring_data *ring;
 	void *hdr;
@@ -854,7 +848,7 @@ err_ret:
 static int dma_iproc_pax_configure(const struct device *dev, uint32_t channel,
 				   struct dma_config *cfg)
 {
-	struct dma_iproc_pax_data *pd = PAX_DMA_DEV_DATA(dev);
+	struct dma_iproc_pax_data *pd = dev->data;
 	struct dma_iproc_pax_ring_data *ring;
 	uint32_t xfer_sz;
 	int ret = 0;
@@ -953,7 +947,7 @@ static int dma_iproc_pax_transfer_start(const struct device *dev,
 					uint32_t channel)
 {
 	int ret = 0;
-	struct dma_iproc_pax_data *pd = PAX_DMA_DEV_DATA(dev);
+	struct dma_iproc_pax_data *pd = dev->data;
 	struct dma_iproc_pax_ring_data *ring;
 
 	if (channel >= PAX_DMA_RINGS_MAX) {

--- a/drivers/dma/dma_iproc_pax_v2.c
+++ b/drivers/dma/dma_iproc_pax_v2.c
@@ -26,12 +26,6 @@ LOG_MODULE_REGISTER(dma_iproc_pax_v2);
 
 #define PAX_DMA_DEV_NAME(dev)	((dev)->name)
 
-#define PAX_DMA_DEV_CFG(dev)	\
-			((struct dma_iproc_pax_cfg *)(dev)->config)
-
-#define PAX_DMA_DEV_DATA(dev)	\
-			((struct dma_iproc_pax_data *)(dev)->data)
-
 /* Driver runtime data for PAX DMA and RM */
 static struct dma_iproc_pax_data pax_dma_data;
 
@@ -512,7 +506,7 @@ err:
 static int poll_on_write_sync(const struct device *dev,
 			      struct dma_iproc_pax_ring_data *ring)
 {
-	struct dma_iproc_pax_cfg *cfg = PAX_DMA_DEV_CFG(dev);
+	struct dma_iproc_pax_cfg *cfg = dev->config;
 	const struct device *pcidev;
 	struct dma_iproc_pax_write_sync_data sync_rd, *recv, *sent;
 	uint64_t pci_addr;
@@ -563,7 +557,7 @@ static int poll_on_write_sync(const struct device *dev,
 static int process_cmpl_event(const struct device *dev,
 			      enum ring_idx idx, uint32_t pl_len)
 {
-	struct dma_iproc_pax_data *pd = PAX_DMA_DEV_DATA(dev);
+	struct dma_iproc_pax_data *pd = dev->data;
 	uint32_t wr_offs, rd_offs, ret = 0;
 	struct dma_iproc_pax_ring_data *ring = &(pd->ring[idx]);
 	struct cmpl_pkt *c;
@@ -625,7 +619,7 @@ static int process_cmpl_event(const struct device *dev,
 static int peek_ring_cmpl(const struct device *dev,
 			  enum ring_idx idx, uint32_t pl_len)
 {
-	struct dma_iproc_pax_data *pd = PAX_DMA_DEV_DATA(dev);
+	struct dma_iproc_pax_data *pd = dev->data;
 	uint32_t wr_offs, rd_offs, timeout = PAX_DMA_MAX_POLL_WAIT;
 	struct dma_iproc_pax_ring_data *ring = &(pd->ring[idx]);
 
@@ -656,7 +650,7 @@ static void rm_isr(void *arg)
 {
 	uint32_t status, err_stat, idx;
 	const struct device *dev = arg;
-	struct dma_iproc_pax_data *pd = PAX_DMA_DEV_DATA(dev);
+	struct dma_iproc_pax_data *pd = dev->data;
 
 	err_stat =
 	sys_read32(RM_COMM_REG(pd,
@@ -682,8 +676,8 @@ static void rm_isr(void *arg)
 
 static int dma_iproc_pax_init(const struct device *dev)
 {
-	struct dma_iproc_pax_cfg *cfg = PAX_DMA_DEV_CFG(dev);
-	struct dma_iproc_pax_data *pd = PAX_DMA_DEV_DATA(dev);
+	struct dma_iproc_pax_cfg *cfg = dev->config;
+	struct dma_iproc_pax_data *pd = dev->data;
 	int r;
 	uintptr_t mem_aligned;
 
@@ -891,7 +885,7 @@ static void set_pkt_count(const struct device *dev,
 			  enum ring_idx idx,
 			  uint32_t pl_len)
 {
-	struct dma_iproc_pax_data *pd = PAX_DMA_DEV_DATA(dev);
+	struct dma_iproc_pax_data *pd = dev->data;
 	uint32_t val;
 
 	/* program packet count for interrupt assertion */
@@ -907,7 +901,7 @@ static int wait_for_pkt_completion(const struct device *dev,
 				   enum ring_idx idx,
 				   uint32_t pl_len)
 {
-	struct dma_iproc_pax_data *pd = PAX_DMA_DEV_DATA(dev);
+	struct dma_iproc_pax_data *pd = dev->data;
 	struct dma_iproc_pax_ring_data *ring;
 
 	ring = &(pd->ring[idx]);
@@ -925,8 +919,8 @@ static int dma_iproc_pax_process_dma_blocks(const struct device *dev,
 					    enum ring_idx idx,
 					    struct dma_config *config)
 {
-	struct dma_iproc_pax_data *pd = PAX_DMA_DEV_DATA(dev);
-	struct dma_iproc_pax_cfg *cfg = PAX_DMA_DEV_CFG(dev);
+	struct dma_iproc_pax_data *pd = dev->data;
+	struct dma_iproc_pax_cfg *cfg = dev->config;
 	int ret = 0;
 	struct dma_iproc_pax_ring_data *ring;
 	uint32_t toggle_bit, non_hdr_bd_count = 0;
@@ -1003,7 +997,7 @@ err:
 static int dma_iproc_pax_configure(const struct device *dev, uint32_t channel,
 				   struct dma_config *cfg)
 {
-	struct dma_iproc_pax_data *pd = PAX_DMA_DEV_DATA(dev);
+	struct dma_iproc_pax_data *pd = dev->data;
 	struct dma_iproc_pax_ring_data *ring;
 	int ret = 0;
 
@@ -1046,7 +1040,7 @@ static int dma_iproc_pax_transfer_start(const struct device *dev,
 					uint32_t channel)
 {
 	int ret = 0;
-	struct dma_iproc_pax_data *pd = PAX_DMA_DEV_DATA(dev);
+	struct dma_iproc_pax_data *pd = dev->data;
 	struct dma_iproc_pax_ring_data *ring;
 
 	if (channel >= PAX_DMA_RINGS_MAX) {

--- a/drivers/dma/dma_iproc_pax_v2.c
+++ b/drivers/dma/dma_iproc_pax_v2.c
@@ -506,7 +506,7 @@ err:
 static int poll_on_write_sync(const struct device *dev,
 			      struct dma_iproc_pax_ring_data *ring)
 {
-	struct dma_iproc_pax_cfg *cfg = dev->config;
+	const struct dma_iproc_pax_cfg *cfg = dev->config;
 	const struct device *pcidev;
 	struct dma_iproc_pax_write_sync_data sync_rd, *recv, *sent;
 	uint64_t pci_addr;
@@ -676,7 +676,7 @@ static void rm_isr(void *arg)
 
 static int dma_iproc_pax_init(const struct device *dev)
 {
-	struct dma_iproc_pax_cfg *cfg = dev->config;
+	const struct dma_iproc_pax_cfg *cfg = dev->config;
 	struct dma_iproc_pax_data *pd = dev->data;
 	int r;
 	uintptr_t mem_aligned;
@@ -920,7 +920,7 @@ static int dma_iproc_pax_process_dma_blocks(const struct device *dev,
 					    struct dma_config *config)
 {
 	struct dma_iproc_pax_data *pd = dev->data;
-	struct dma_iproc_pax_cfg *cfg = dev->config;
+	const struct dma_iproc_pax_cfg *cfg = dev->config;
 	int ret = 0;
 	struct dma_iproc_pax_ring_data *ring;
 	uint32_t toggle_bit, non_hdr_bd_count = 0;

--- a/drivers/dma/dma_nios2_msgdma.c
+++ b/drivers/dma/dma_nios2_msgdma.c
@@ -33,13 +33,11 @@ struct nios2_msgdma_dev_cfg {
 };
 
 #define DEV_NAME(dev) ((dev)->name)
-#define DEV_CFG(dev) \
-	((struct nios2_msgdma_dev_cfg *)(dev)->config)
 
 static void nios2_msgdma_isr(void *arg)
 {
 	const struct device *dev = (const struct device *)arg;
-	struct nios2_msgdma_dev_cfg *cfg = DEV_CFG(dev);
+	struct nios2_msgdma_dev_cfg *cfg = (struct nios2_msgdma_dev_cfg *)dev->config;
 
 	/* Call Altera HAL driver ISR */
 	alt_handle_irq(cfg->msgdma_dev, DT_INST_IRQN(0));
@@ -70,7 +68,7 @@ static void nios2_msgdma_callback(void *context)
 static int nios2_msgdma_config(const struct device *dev, uint32_t channel,
 			       struct dma_config *cfg)
 {
-	struct nios2_msgdma_dev_cfg *dev_cfg = DEV_CFG(dev);
+	struct nios2_msgdma_dev_cfg *dev_cfg = (struct nios2_msgdma_dev_cfg *)dev->config;
 	struct dma_block_config *dma_block;
 	int status;
 	uint32_t control;
@@ -155,7 +153,7 @@ static int nios2_msgdma_config(const struct device *dev, uint32_t channel,
 static int nios2_msgdma_transfer_start(const struct device *dev,
 				       uint32_t channel)
 {
-	struct nios2_msgdma_dev_cfg *cfg = DEV_CFG(dev);
+	struct nios2_msgdma_dev_cfg *cfg = (struct nios2_msgdma_dev_cfg *)dev->config;
 	int status;
 
 	/* Nios-II mSGDMA supports only one channel per DMA core */
@@ -179,7 +177,7 @@ static int nios2_msgdma_transfer_start(const struct device *dev,
 static int nios2_msgdma_transfer_stop(const struct device *dev,
 				      uint32_t channel)
 {
-	struct nios2_msgdma_dev_cfg *cfg = DEV_CFG(dev);
+	struct nios2_msgdma_dev_cfg *cfg = (struct nios2_msgdma_dev_cfg *)dev->config;
 	int ret = -EIO;
 	uint32_t status;
 
@@ -209,7 +207,7 @@ static const struct dma_driver_api nios2_msgdma_driver_api = {
 
 static int nios2_msgdma0_initialize(const struct device *dev)
 {
-	struct nios2_msgdma_dev_cfg *dev_cfg = DEV_CFG(dev);
+	struct nios2_msgdma_dev_cfg *dev_cfg = (struct nios2_msgdma_dev_cfg *)dev->config;
 
 	dev_cfg->dev = dev;
 

--- a/drivers/dma/dma_pl330.c
+++ b/drivers/dma/dma_pl330.c
@@ -18,11 +18,6 @@
 LOG_MODULE_REGISTER(dma_pl330);
 
 #define DEV_NAME(dev) ((dev)->name)
-#define DEV_CFG(dev) \
-	((const struct dma_pl330_config *const)(dev)->config)
-
-#define DEV_DATA(dev) \
-	((struct dma_pl330_dev_data *const)(dev)->data)
 
 #define BYTE_WIDTH(burst_size) (1 << (burst_size))
 
@@ -171,7 +166,7 @@ static int dma_pl330_setup_ch(const struct device *dev,
 	uint32_t loop_counter0 = 0, loop_counter1 = 0;
 	uint32_t srcbytewidth, dstbytewidth;
 	uint32_t loop_counter, residue;
-	struct dma_pl330_dev_data *const dev_data = DEV_DATA(dev);
+	struct dma_pl330_dev_data *const dev_data = dev->data;
 	struct dma_pl330_ch_config *channel_cfg;
 	int secure = ch_dat->nonsec_mode ? SRC_PRI_NONSEC_VALUE :
 				SRC_PRI_SEC_VALUE;
@@ -268,7 +263,7 @@ static int dma_pl330_setup_ch(const struct device *dev,
 static int dma_pl330_start_dma_ch(const struct device *dev,
 				  uint32_t reg_base, int ch, int secure)
 {
-	struct dma_pl330_dev_data *const dev_data = DEV_DATA(dev);
+	struct dma_pl330_dev_data *const dev_data = dev->data;
 	struct dma_pl330_ch_config *channel_cfg;
 	uint32_t count = 0U;
 	uint32_t data;
@@ -323,8 +318,8 @@ static int dma_pl330_xfer(const struct device *dev, uint64_t dst,
 			  uint64_t src, uint32_t size, uint32_t channel,
 			  uint32_t *xfer_size)
 {
-	struct dma_pl330_dev_data *const dev_data = DEV_DATA(dev);
-	const struct dma_pl330_config *const dev_cfg = DEV_CFG(dev);
+	struct dma_pl330_dev_data *const dev_data = dev->data;
+	const struct dma_pl330_config *const dev_cfg = dev->config;
 	struct dma_pl330_ch_config *channel_cfg;
 	struct dma_pl330_ch_internal *ch_handle;
 	int ret;
@@ -471,7 +466,7 @@ static int dma_pl330_submit(const struct device *dev, uint64_t dst,
 static int dma_pl330_configure(const struct device *dev, uint32_t channel,
 			       struct dma_config *cfg)
 {
-	struct dma_pl330_dev_data *const dev_data = DEV_DATA(dev);
+	struct dma_pl330_dev_data *const dev_data = dev->data;
 	struct dma_pl330_ch_config *channel_cfg;
 	struct dma_pl330_ch_internal *ch_handle;
 
@@ -525,7 +520,7 @@ static int dma_pl330_configure(const struct device *dev, uint32_t channel,
 static int dma_pl330_transfer_start(const struct device *dev,
 				    uint32_t channel)
 {
-	struct dma_pl330_dev_data *const dev_data = DEV_DATA(dev);
+	struct dma_pl330_dev_data *const dev_data = dev->data;
 	struct dma_pl330_ch_config *channel_cfg;
 	int ret;
 
@@ -557,8 +552,8 @@ static int dma_pl330_transfer_stop(const struct device *dev, uint32_t channel)
 
 static int dma_pl330_initialize(const struct device *dev)
 {
-	const struct dma_pl330_config *const dev_cfg = DEV_CFG(dev);
-	struct dma_pl330_dev_data *const dev_data = DEV_DATA(dev);
+	const struct dma_pl330_config *const dev_cfg = dev->config;
+	struct dma_pl330_dev_data *const dev_data = dev->data;
 	struct dma_pl330_ch_config *channel_cfg;
 
 	for (int channel = 0; channel < MAX_DMA_CHANNELS; channel++) {

--- a/drivers/dma/dma_sam0.c
+++ b/drivers/dma/dma_sam0.c
@@ -26,14 +26,10 @@ struct dma_sam0_data {
 	struct dma_sam0_channel channels[DMAC_CH_NUM];
 };
 
-#define DEV_DATA(dev) \
-	((struct dma_sam0_data *const)(dev)->data)
-
-
 /* Handles DMA interrupts and dispatches to the individual channel */
 static void dma_sam0_isr(const struct device *dev)
 {
-	struct dma_sam0_data *data = DEV_DATA(dev);
+	struct dma_sam0_data *data = dev->data;
 	struct dma_sam0_channel *chdata;
 	uint16_t pend = DMA_REGS->INTPEND.reg;
 	uint32_t channel;
@@ -65,7 +61,7 @@ static void dma_sam0_isr(const struct device *dev)
 static int dma_sam0_config(const struct device *dev, uint32_t channel,
 			   struct dma_config *config)
 {
-	struct dma_sam0_data *data = DEV_DATA(dev);
+	struct dma_sam0_data *data = dev->data;
 	DmacDescriptor *desc = &data->descriptors[channel];
 	struct dma_block_config *block = config->head_block;
 	struct dma_sam0_channel *channel_control;
@@ -318,7 +314,7 @@ static int dma_sam0_stop(const struct device *dev, uint32_t channel)
 static int dma_sam0_reload(const struct device *dev, uint32_t channel,
 			   uint32_t src, uint32_t dst, size_t size)
 {
-	struct dma_sam0_data *data = DEV_DATA(dev);
+	struct dma_sam0_data *data = dev->data;
 	DmacDescriptor *desc = &data->descriptors[channel];
 	int key = irq_lock();
 
@@ -362,7 +358,7 @@ inval:
 static int dma_sam0_get_status(const struct device *dev, uint32_t channel,
 			       struct dma_status *stat)
 {
-	struct dma_sam0_data *data = DEV_DATA(dev);
+	struct dma_sam0_data *data = dev->data;
 	uint32_t act;
 
 	if (channel >= DMAC_CH_NUM || stat == NULL) {
@@ -406,7 +402,7 @@ static int dma_sam0_get_status(const struct device *dev, uint32_t channel,
 
 static int dma_sam0_init(const struct device *dev)
 {
-	struct dma_sam0_data *data = DEV_DATA(dev);
+	struct dma_sam0_data *data = dev->data;
 
 	/* Enable clocks. */
 #ifdef MCLK

--- a/drivers/dma/dma_sam_xdmac.c
+++ b/drivers/dma/dma_sam_xdmac.c
@@ -47,15 +47,12 @@ struct sam_xdmac_dev_data {
 };
 
 #define DEV_NAME(dev) ((dev)->name)
-#define DEV_CFG(dev) \
-	((const struct sam_xdmac_dev_cfg *const)(dev)->config)
-#define DEV_DATA(dev) \
-	((struct sam_xdmac_dev_data *const)(dev)->data)
 
 static void sam_xdmac_isr(const struct device *dev)
 {
-	const struct sam_xdmac_dev_cfg *const dev_cfg = DEV_CFG(dev);
-	struct sam_xdmac_dev_data *const dev_data = DEV_DATA(dev);
+	const struct sam_xdmac_dev_cfg *const dev_cfg = dev->config;
+	struct sam_xdmac_dev_data *const dev_data = dev->data;
+
 	Xdmac *const xdmac = dev_cfg->regs;
 	struct sam_xdmac_channel_cfg *channel_cfg;
 	uint32_t isr_status;
@@ -85,7 +82,8 @@ static void sam_xdmac_isr(const struct device *dev)
 int sam_xdmac_channel_configure(const struct device *dev, uint32_t channel,
 				struct sam_xdmac_channel_config *param)
 {
-	const struct sam_xdmac_dev_cfg *const dev_cfg = DEV_CFG(dev);
+	const struct sam_xdmac_dev_cfg *const dev_cfg = dev->config;
+
 	Xdmac *const xdmac = dev_cfg->regs;
 
 	if (channel >= DMA_CHANNELS_NO) {
@@ -127,7 +125,8 @@ int sam_xdmac_channel_configure(const struct device *dev, uint32_t channel,
 int sam_xdmac_transfer_configure(const struct device *dev, uint32_t channel,
 				 struct sam_xdmac_transfer_config *param)
 {
-	const struct sam_xdmac_dev_cfg *const dev_cfg = DEV_CFG(dev);
+	const struct sam_xdmac_dev_cfg *const dev_cfg = dev->config;
+
 	Xdmac *const xdmac = dev_cfg->regs;
 
 	if (channel >= DMA_CHANNELS_NO) {
@@ -179,7 +178,7 @@ int sam_xdmac_transfer_configure(const struct device *dev, uint32_t channel,
 static int sam_xdmac_config(const struct device *dev, uint32_t channel,
 			    struct dma_config *cfg)
 {
-	struct sam_xdmac_dev_data *const dev_data = DEV_DATA(dev);
+	struct sam_xdmac_dev_data *const dev_data = dev->data;
 	struct sam_xdmac_channel_config channel_cfg;
 	struct sam_xdmac_transfer_config transfer_cfg;
 	uint32_t burst_size;
@@ -274,7 +273,7 @@ static int sam_xdmac_config(const struct device *dev, uint32_t channel,
 static int sam_xdmac_transfer_reload(const struct device *dev, uint32_t channel,
 				     uint32_t src, uint32_t dst, size_t size)
 {
-	struct sam_xdmac_dev_data *const dev_data = DEV_DATA(dev);
+	struct sam_xdmac_dev_data *const dev_data = dev->data;
 	struct sam_xdmac_transfer_config transfer_cfg = {
 		.sa = src,
 		.da = dst,
@@ -286,7 +285,9 @@ static int sam_xdmac_transfer_reload(const struct device *dev, uint32_t channel,
 
 int sam_xdmac_transfer_start(const struct device *dev, uint32_t channel)
 {
-	Xdmac *const xdmac = DEV_CFG(dev)->regs;
+	const struct sam_xdmac_dev_cfg *config = dev->config;
+
+	Xdmac *const xdmac = config->regs;
 
 	if (channel >= DMA_CHANNELS_NO) {
 		return -EINVAL;
@@ -307,7 +308,9 @@ int sam_xdmac_transfer_start(const struct device *dev, uint32_t channel)
 
 int sam_xdmac_transfer_stop(const struct device *dev, uint32_t channel)
 {
-	Xdmac *const xdmac = DEV_CFG(dev)->regs;
+	const struct sam_xdmac_dev_cfg *config = dev->config;
+
+	Xdmac *const xdmac = config->regs;
 
 	if (channel >= DMA_CHANNELS_NO) {
 		return -EINVAL;
@@ -332,7 +335,8 @@ int sam_xdmac_transfer_stop(const struct device *dev, uint32_t channel)
 
 static int sam_xdmac_initialize(const struct device *dev)
 {
-	const struct sam_xdmac_dev_cfg *const dev_cfg = DEV_CFG(dev);
+	const struct sam_xdmac_dev_cfg *const dev_cfg = dev->config;
+
 	Xdmac *const xdmac = dev_cfg->regs;
 
 	/* Configure interrupts */

--- a/drivers/dma/dma_sam_xdmac.c
+++ b/drivers/dma/dma_sam_xdmac.c
@@ -53,7 +53,7 @@ static void sam_xdmac_isr(const struct device *dev)
 	const struct sam_xdmac_dev_cfg *const dev_cfg = dev->config;
 	struct sam_xdmac_dev_data *const dev_data = dev->data;
 
-	Xdmac *const xdmac = dev_cfg->regs;
+	Xdmac * const xdmac = dev_cfg->regs;
 	struct sam_xdmac_channel_cfg *channel_cfg;
 	uint32_t isr_status;
 	uint32_t err;
@@ -84,7 +84,7 @@ int sam_xdmac_channel_configure(const struct device *dev, uint32_t channel,
 {
 	const struct sam_xdmac_dev_cfg *const dev_cfg = dev->config;
 
-	Xdmac *const xdmac = dev_cfg->regs;
+	Xdmac * const xdmac = dev_cfg->regs;
 
 	if (channel >= DMA_CHANNELS_NO) {
 		return -EINVAL;
@@ -127,7 +127,7 @@ int sam_xdmac_transfer_configure(const struct device *dev, uint32_t channel,
 {
 	const struct sam_xdmac_dev_cfg *const dev_cfg = dev->config;
 
-	Xdmac *const xdmac = dev_cfg->regs;
+	Xdmac * const xdmac = dev_cfg->regs;
 
 	if (channel >= DMA_CHANNELS_NO) {
 		return -EINVAL;
@@ -287,7 +287,7 @@ int sam_xdmac_transfer_start(const struct device *dev, uint32_t channel)
 {
 	const struct sam_xdmac_dev_cfg *config = dev->config;
 
-	Xdmac *const xdmac = config->regs;
+	Xdmac * const xdmac = config->regs;
 
 	if (channel >= DMA_CHANNELS_NO) {
 		return -EINVAL;
@@ -310,7 +310,7 @@ int sam_xdmac_transfer_stop(const struct device *dev, uint32_t channel)
 {
 	const struct sam_xdmac_dev_cfg *config = dev->config;
 
-	Xdmac *const xdmac = config->regs;
+	Xdmac * const xdmac = config->regs;
 
 	if (channel >= DMA_CHANNELS_NO) {
 		return -EINVAL;
@@ -337,7 +337,7 @@ static int sam_xdmac_initialize(const struct device *dev)
 {
 	const struct sam_xdmac_dev_cfg *const dev_cfg = dev->config;
 
-	Xdmac *const xdmac = dev_cfg->regs;
+	Xdmac * const xdmac = dev_cfg->regs;
 
 	/* Configure interrupts */
 	dev_cfg->irq_config();

--- a/drivers/eeprom/eeprom_emulator.c
+++ b/drivers/eeprom/eeprom_emulator.c
@@ -64,9 +64,6 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(eeprom_emulator);
 
-#define DEV_CONFIG(dev) ((dev)->config)
-#define DEV_DATA(dev) ((dev)->data)
-
 struct eeprom_emu_config {
 	/* EEPROM size */
 	size_t size;
@@ -112,7 +109,7 @@ struct eeprom_emu_ctx {
 static inline int eeprom_emu_flash_read(const struct device *dev, off_t offset,
 					uint8_t *blk, size_t len)
 {
-	const struct eeprom_emu_config *dev_config = DEV_CONFIG(dev);
+	const struct eeprom_emu_config *dev_config = dev->config;
 
 	return flash_read(dev_config->flash_dev, dev_config->flash_offset +
 			  offset, blk, len);
@@ -124,7 +121,7 @@ static inline int eeprom_emu_flash_read(const struct device *dev, off_t offset,
 static inline int eeprom_emu_flash_write(const struct device *dev, off_t offset,
 				   const uint8_t *blk, size_t len)
 {
-	const struct eeprom_emu_config *dev_config = DEV_CONFIG(dev);
+	const struct eeprom_emu_config *dev_config = dev->config;
 	int rc;
 
 	rc = flash_write(dev_config->flash_dev, dev_config->flash_offset +
@@ -139,7 +136,7 @@ static inline int eeprom_emu_flash_write(const struct device *dev, off_t offset,
 static inline int eeprom_emu_flash_erase(const struct device *dev, off_t offset,
 				   size_t len)
 {
-	const struct eeprom_emu_config *dev_config = DEV_CONFIG(dev);
+	const struct eeprom_emu_config *dev_config = dev->config;
 	int rc;
 
 	rc = flash_erase(dev_config->flash_dev, dev_config->flash_offset +
@@ -152,7 +149,7 @@ static inline int eeprom_emu_flash_erase(const struct device *dev, off_t offset,
  */
 static int eeprom_emu_page_invalidate(const struct device *dev, off_t offset)
 {
-	const struct eeprom_emu_config *dev_config = DEV_CONFIG(dev);
+	const struct eeprom_emu_config *dev_config = dev->config;
 	uint8_t buf[dev_config->flash_cbs];
 
 	LOG_DBG("Invalidating page at [0x%tx]", (ptrdiff_t)offset);
@@ -169,7 +166,7 @@ static int eeprom_emu_page_invalidate(const struct device *dev, off_t offset)
 static uint32_t eeprom_emu_get_address(const struct device *dev,
 				       const uint8_t *blk)
 {
-	const struct eeprom_emu_config *dev_config = DEV_CONFIG(dev);
+	const struct eeprom_emu_config *dev_config = dev->config;
 	uint32_t address = 0U;
 
 	blk += dev_config->flash_cbs / 2;
@@ -192,7 +189,7 @@ static void eeprom_emu_set_change(const struct device *dev,
 				  const uint32_t address, const uint8_t *data,
 				  uint8_t *blk)
 {
-	const struct eeprom_emu_config *dev_config = DEV_CONFIG(dev);
+	const struct eeprom_emu_config *dev_config = dev->config;
 
 	for (int i = 0; i < (dev_config->flash_cbs / 2); i++) {
 		(*blk++) = (*data++);
@@ -214,7 +211,7 @@ static void eeprom_emu_set_change(const struct device *dev,
  */
 static int eeprom_emu_is_word_used(const struct device *dev, const uint8_t *blk)
 {
-	const struct eeprom_emu_config *dev_config = DEV_CONFIG(dev);
+	const struct eeprom_emu_config *dev_config = dev->config;
 
 	for (int i = 0; i < dev_config->flash_cbs; i++) {
 		if ((*blk++) != 0xff) {
@@ -233,8 +230,8 @@ static int eeprom_emu_is_word_used(const struct device *dev, const uint8_t *blk)
 static int eeprom_emu_word_read(const struct device *dev, off_t address,
 				uint8_t *data)
 {
-	const struct eeprom_emu_config *dev_config = DEV_CONFIG(dev);
-	const struct eeprom_emu_data *dev_data = DEV_DATA(dev);
+	const struct eeprom_emu_config *dev_config = dev->config;
+	const struct eeprom_emu_data *dev_data = dev->data;
 	uint8_t buf[dev_config->flash_cbs];
 	off_t direct_address;
 	int rc;
@@ -282,7 +279,7 @@ static int eeprom_emu_word_read(const struct device *dev, off_t address,
 static int eeprom_emu_flash_get(const struct device *dev,
 				struct eeprom_emu_ctx *ctx)
 {
-	const struct eeprom_emu_config *dev_config = DEV_CONFIG(dev);
+	const struct eeprom_emu_config *dev_config = dev->config;
 	off_t address = ctx->address + ctx->len - ctx->rlen;
 	uint8_t *data8 = (uint8_t *)(ctx->data);
 	uint8_t buf[dev_config->flash_cbs];
@@ -311,8 +308,8 @@ static int eeprom_emu_flash_get(const struct device *dev,
 static int eeprom_emu_compactor(const struct device *dev,
 				struct eeprom_emu_ctx *ctx)
 {
-	const struct eeprom_emu_config *dev_config = DEV_CONFIG(dev);
-	struct eeprom_emu_data *dev_data = DEV_DATA(dev);
+	const struct eeprom_emu_config *dev_config = dev->config;
+	struct eeprom_emu_data *dev_data = dev->data;
 	off_t next_page_offset;
 	int rc = 0;
 
@@ -419,8 +416,8 @@ static int eeprom_emu_word_write(const struct device *dev, off_t address,
 				 const uint8_t *data,
 				 struct eeprom_emu_ctx *ctx)
 {
-	const struct eeprom_emu_config *dev_config = DEV_CONFIG(dev);
-	struct eeprom_emu_data *dev_data = DEV_DATA(dev);
+	const struct eeprom_emu_config *dev_config = dev->config;
+	struct eeprom_emu_data *dev_data = dev->data;
 	uint8_t buf[dev_config->flash_cbs], tmp[dev_config->flash_cbs];
 	off_t direct_address, wraddr;
 	int rc;
@@ -484,7 +481,7 @@ static int eeprom_emu_word_write(const struct device *dev, off_t address,
 static int eeprom_emu_flash_set(const struct device *dev,
 				struct eeprom_emu_ctx *ctx)
 {
-	const struct eeprom_emu_config *dev_config = DEV_CONFIG(dev);
+	const struct eeprom_emu_config *dev_config = dev->config;
 	off_t address = ctx->address + ctx->len - ctx->rlen;
 	uint8_t *data8 = (uint8_t *)(ctx->data);
 	uint8_t buf[dev_config->flash_cbs];
@@ -515,7 +512,7 @@ static int eeprom_emu_flash_set(const struct device *dev,
 static int eeprom_emu_range_is_valid(const struct device *dev, off_t address,
 				     size_t len)
 {
-	const struct eeprom_emu_config *dev_config = DEV_CONFIG(dev);
+	const struct eeprom_emu_config *dev_config = dev->config;
 
 	if ((address + len) <= dev_config->size) {
 		return 1;
@@ -527,8 +524,8 @@ static int eeprom_emu_range_is_valid(const struct device *dev, off_t address,
 static int eeprom_emu_read(const struct device *dev, off_t address, void *data,
 			   size_t len)
 {
-	const struct eeprom_emu_config *dev_config = DEV_CONFIG(dev);
-	struct eeprom_emu_data *dev_data = DEV_DATA(dev);
+	const struct eeprom_emu_config *dev_config = dev->config;
+	struct eeprom_emu_data *dev_data = dev->data;
 	struct eeprom_emu_ctx ctx = {
 		.data = data,
 		.len = len,
@@ -578,8 +575,8 @@ static int eeprom_emu_read(const struct device *dev, off_t address, void *data,
 static int eeprom_emu_write(const struct device *dev, off_t address,
 			    const void *data, size_t len)
 {
-	const struct eeprom_emu_config *dev_config = DEV_CONFIG(dev);
-	struct eeprom_emu_data *dev_data = DEV_DATA(dev);
+	const struct eeprom_emu_config *dev_config = dev->config;
+	struct eeprom_emu_data *dev_data = dev->data;
 	struct eeprom_emu_ctx ctx = {
 		.data = data,
 		.len = len,
@@ -634,15 +631,15 @@ static int eeprom_emu_write(const struct device *dev, off_t address,
 
 static size_t eeprom_emu_size(const struct device *dev)
 {
-	const struct eeprom_emu_config *dev_config = DEV_CONFIG(dev);
+	const struct eeprom_emu_config *dev_config = dev->config;
 
 	return dev_config->size;
 }
 
 static int eeprom_emu_init(const struct device *dev)
 {
-	const struct eeprom_emu_config *dev_config = DEV_CONFIG(dev);
-	struct eeprom_emu_data *dev_data = DEV_DATA(dev);
+	const struct eeprom_emu_config *dev_config = dev->config;
+	struct eeprom_emu_data *dev_data = dev->data;
 	off_t offset;
 	uint8_t buf[dev_config->flash_cbs];
 	int rc;

--- a/drivers/eeprom/eeprom_simulator.c
+++ b/drivers/eeprom/eeprom_simulator.c
@@ -36,7 +36,6 @@ struct eeprom_sim_config {
 };
 
 #define DEV_NAME(dev) ((dev)->name)
-#define DEV_CONFIG(dev) ((dev)->config)
 
 #define EEPROM(addr) (mock_eeprom + (addr))
 
@@ -96,7 +95,7 @@ static uint8_t mock_eeprom[DT_INST_PROP(0, size)];
 static int eeprom_range_is_valid(const struct device *dev, off_t offset,
 				 size_t len)
 {
-	const struct eeprom_sim_config *config = DEV_CONFIG(dev);
+	const struct eeprom_sim_config *config = dev->config;
 
 	if ((offset + len) <= config->size) {
 		return 1;
@@ -138,7 +137,7 @@ static int eeprom_sim_write(const struct device *dev, off_t offset,
 			    const void *data,
 			    size_t len)
 {
-	const struct eeprom_sim_config *config = DEV_CONFIG(dev);
+	const struct eeprom_sim_config *config = dev->config;
 
 	if (config->readonly) {
 		LOG_WRN("attempt to write to read-only device");
@@ -196,7 +195,7 @@ end:
 
 static size_t eeprom_sim_size(const struct device *dev)
 {
-	const struct eeprom_sim_config *config = DEV_CONFIG(dev);
+	const struct eeprom_sim_config *config = dev->config;
 
 	return config->size;
 }

--- a/drivers/entropy/entropy_cc13xx_cc26xx.c
+++ b/drivers/entropy/entropy_cc13xx_cc26xx.c
@@ -38,12 +38,6 @@ struct entropy_cc13xx_cc26xx_data {
 #endif
 };
 
-static inline struct entropy_cc13xx_cc26xx_data *
-get_dev_data(const struct device *dev)
-{
-	return dev->data;
-}
-
 static void start_trng(struct entropy_cc13xx_cc26xx_data *data)
 {
 	/* Initialization as described in TRM section 18.6.1.2 */
@@ -100,7 +94,7 @@ static int entropy_cc13xx_cc26xx_get_entropy(const struct device *dev,
 					     uint8_t *buf,
 					     uint16_t len)
 {
-	struct entropy_cc13xx_cc26xx_data *data = get_dev_data(dev);
+	struct entropy_cc13xx_cc26xx_data *data = dev->data;
 	uint32_t cnt;
 
 #ifdef CONFIG_PM
@@ -133,7 +127,8 @@ static int entropy_cc13xx_cc26xx_get_entropy(const struct device *dev,
 
 static void entropy_cc13xx_cc26xx_isr(const void *arg)
 {
-	struct entropy_cc13xx_cc26xx_data *data = get_dev_data(arg);
+	const struct device *dev = arg;
+	struct entropy_cc13xx_cc26xx_data *data = dev->data;
 	uint32_t src = 0;
 	uint32_t cnt;
 	uint32_t num[2];
@@ -175,7 +170,7 @@ static int entropy_cc13xx_cc26xx_get_entropy_isr(const struct device *dev,
 						 uint8_t *buf, uint16_t len,
 						 uint32_t flags)
 {
-	struct entropy_cc13xx_cc26xx_data *data = get_dev_data(dev);
+	struct entropy_cc13xx_cc26xx_data *data = dev->data;
 	uint16_t cnt;
 	uint16_t read = len;
 	uint32_t src;
@@ -255,7 +250,7 @@ static int post_notify_fxn(unsigned int eventType, uintptr_t eventArg,
 
 		if (Power_getDependencyCount(res_id) != 0) {
 			/* Reconfigure and enable TRNG only if powered */
-			start_trng(get_dev_data(dev));
+			start_trng(dev->data);
 		}
 	}
 
@@ -267,7 +262,7 @@ static int post_notify_fxn(unsigned int eventType, uintptr_t eventArg,
 static int entropy_cc13xx_cc26xx_pm_action(const struct device *dev,
 					   enum pm_device_action action)
 {
-	struct entropy_cc13xx_cc26xx_data *data = get_dev_data(dev);
+	struct entropy_cc13xx_cc26xx_data *data = dev->data;
 
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
@@ -288,7 +283,7 @@ static int entropy_cc13xx_cc26xx_pm_action(const struct device *dev,
 
 static int entropy_cc13xx_cc26xx_init(const struct device *dev)
 {
-	struct entropy_cc13xx_cc26xx_data *data = get_dev_data(dev);
+	struct entropy_cc13xx_cc26xx_data *data = dev->data;
 
 	/* Initialize driver data */
 	ring_buf_init(&data->pool, sizeof(data->data), data->data);

--- a/drivers/entropy/entropy_nrf5.c
+++ b/drivers/entropy/entropy_nrf5.c
@@ -97,9 +97,6 @@ struct entropy_nrf5_dev_data {
 
 static struct entropy_nrf5_dev_data entropy_nrf5_data;
 
-#define DEV_DATA(dev) \
-	((struct entropy_nrf5_dev_data *)(dev)->data)
-
 static int random_byte_get(void)
 {
 	int retval = -EAGAIN;
@@ -231,7 +228,7 @@ static int entropy_nrf5_get_entropy(const struct device *dev, uint8_t *buf,
 				    uint16_t len)
 {
 	/* Check if this API is called on correct driver instance. */
-	__ASSERT_NO_MSG(&entropy_nrf5_data == DEV_DATA(dev));
+	__ASSERT_NO_MSG(&entropy_nrf5_data == dev->data);
 
 	while (len) {
 		uint16_t bytes;
@@ -261,7 +258,7 @@ static int entropy_nrf5_get_entropy_isr(const struct device *dev,
 	uint16_t cnt = len;
 
 	/* Check if this API is called on correct driver instance. */
-	__ASSERT_NO_MSG(&entropy_nrf5_data == DEV_DATA(dev));
+	__ASSERT_NO_MSG(&entropy_nrf5_data == dev->data);
 
 	if (likely((flags & ENTROPY_BUSYWAIT) == 0U)) {
 		return rng_pool_get((struct rng_pool *)(entropy_nrf5_data.isr),
@@ -340,7 +337,7 @@ DEVICE_DT_INST_DEFINE(0,
 static int entropy_nrf5_init(const struct device *dev)
 {
 	/* Check if this API is called on correct driver instance. */
-	__ASSERT_NO_MSG(&entropy_nrf5_data == DEV_DATA(dev));
+	__ASSERT_NO_MSG(&entropy_nrf5_data == dev->data);
 
 	/* Locking semaphore initialized to 1 (unlocked) */
 	k_sem_init(&entropy_nrf5_data.sem_lock, 1, 1);

--- a/drivers/entropy/entropy_sam.c
+++ b/drivers/entropy/entropy_sam.c
@@ -17,9 +17,6 @@ struct trng_sam_dev_cfg {
 	Trng *regs;
 };
 
-#define DEV_CFG(dev) \
-	((const struct trng_sam_dev_cfg *const)(dev)->config)
-
 static inline bool _ready(Trng * const trng)
 {
 #ifdef TRNG_ISR_DATRDY
@@ -76,7 +73,8 @@ static int entropy_sam_get_entropy_internal(const struct device *dev,
 					    uint8_t *buffer,
 					    uint16_t length, uint32_t flags)
 {
-	Trng *const trng = DEV_CFG(dev)->regs;
+	const struct trng_sam_dev_cfg *config = dev->config;
+	Trng *const trng = config->regs;
 
 	while (length > 0) {
 		size_t to_copy;
@@ -113,10 +111,10 @@ static int entropy_sam_get_entropy_isr(const struct device *dev,
 
 
 	if ((flags & ENTROPY_BUSYWAIT) == 0U) {
-
+		const struct trng_sam_dev_cfg *config = dev->config;
 		/* No busy wait; return whatever data is available. */
 
-		Trng * const trng = DEV_CFG(dev)->regs;
+		Trng * const trng = config->regs;
 
 		do {
 			size_t to_copy;
@@ -156,7 +154,8 @@ static int entropy_sam_get_entropy_isr(const struct device *dev,
 
 static int entropy_sam_init(const struct device *dev)
 {
-	Trng *const trng = DEV_CFG(dev)->regs;
+	const struct trng_sam_dev_cfg *config = dev->config;
+	Trng *const trng = config->regs;
 
 #ifdef MCLK
 	/* Enable the MCLK */

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -87,13 +87,6 @@ struct entropy_stm32_rng_dev_data {
 	RNG_POOL_DEFINE(thr, CONFIG_ENTROPY_STM32_THR_POOL_SIZE);
 };
 
-#define DEV_DATA(dev) \
-	((struct entropy_stm32_rng_dev_data *)(dev)->data)
-
-#define DEV_CFG(dev) \
-	((const struct entropy_stm32_rng_dev_cfg *)(dev)->config)
-
-
 static const struct entropy_stm32_rng_dev_cfg entropy_stm32_rng_config = {
 	.pclken	= { .bus = DT_INST_CLOCKS_CELL(0, bus),
 		    .enr = DT_INST_CLOCKS_CELL(0, bits) },
@@ -315,7 +308,7 @@ static int entropy_stm32_rng_get_entropy(const struct device *dev,
 					 uint16_t len)
 {
 	/* Check if this API is called on correct driver instance. */
-	__ASSERT_NO_MSG(&entropy_stm32_rng_data == DEV_DATA(dev));
+	__ASSERT_NO_MSG(&entropy_stm32_rng_data == dev->data);
 
 	while (len) {
 		uint16_t bytes;
@@ -347,7 +340,7 @@ static int entropy_stm32_rng_get_entropy_isr(const struct device *dev,
 	uint16_t cnt = len;
 
 	/* Check if this API is called on correct driver instance. */
-	__ASSERT_NO_MSG(&entropy_stm32_rng_data == DEV_DATA(dev));
+	__ASSERT_NO_MSG(&entropy_stm32_rng_data == dev->data);
 
 	if (likely((flags & ENTROPY_BUSYWAIT) == 0U)) {
 		return rng_pool_get(
@@ -416,8 +409,8 @@ static int entropy_stm32_rng_init(const struct device *dev)
 
 	__ASSERT_NO_MSG(dev != NULL);
 
-	dev_data = DEV_DATA(dev);
-	dev_cfg = DEV_CFG(dev);
+	dev_data = dev->data;
+	dev_cfg = dev->config;
 
 	__ASSERT_NO_MSG(dev_data != NULL);
 	__ASSERT_NO_MSG(dev_cfg != NULL);

--- a/drivers/espi/espi_saf_mchp_xec.c
+++ b/drivers/espi/espi_saf_mchp_xec.c
@@ -62,10 +62,6 @@ struct espi_saf_xec_data {
 	uint32_t hwstatus;
 };
 
-/* convenience defines */
-#define DEV_CFG(dev) ((const struct espi_saf_xec_config *const)(dev)->config)
-#define DEV_DATA(dev) ((struct espi_saf_xec_data *const)(dev)->data)
-
 /* EC portal local flash r/w buffer */
 static uint32_t slave_mem[MAX_SAF_ECP_BUFFER_SIZE];
 
@@ -397,7 +393,7 @@ static void saf_flash_cfg(const struct device *dev,
 			  const struct espi_saf_flash_cfg *fcfg, uint8_t cs)
 {
 	uint32_t d, did;
-	const struct espi_saf_xec_config *xcfg = DEV_CFG(dev);
+	const struct espi_saf_xec_config *xcfg = dev->config;
 	MCHP_SAF_HW_REGS *regs = (MCHP_SAF_HW_REGS *)xcfg->saf_base_addr;
 	QMSPI_Type *qregs = (QMSPI_Type *)xcfg->qmspi_base_addr;
 
@@ -467,7 +463,7 @@ static int espi_saf_xec_configuration(const struct device *dev,
 		return -EINVAL;
 	}
 
-	const struct espi_saf_xec_config *xcfg = DEV_CFG(dev);
+	const struct espi_saf_xec_config *xcfg = dev->config;
 	MCHP_SAF_HW_REGS *regs = (MCHP_SAF_HW_REGS *)xcfg->saf_base_addr;
 	const struct espi_saf_flash_cfg *fcfg = cfg->flash_cfgs;
 
@@ -557,7 +553,7 @@ static int espi_saf_xec_set_pr(const struct device *dev,
 		return -EINVAL;
 	}
 
-	const struct espi_saf_xec_config *xcfg = DEV_CFG(dev);
+	const struct espi_saf_xec_config *xcfg = dev->config;
 	MCHP_SAF_HW_REGS *regs = (MCHP_SAF_HW_REGS *)xcfg->saf_base_addr;
 
 	if (regs->SAF_FL_CFG_MISC & MCHP_SAF_FL_CFG_MISC_SAF_EN) {
@@ -600,7 +596,7 @@ static int espi_saf_xec_set_pr(const struct device *dev,
 
 static bool espi_saf_xec_channel_ready(const struct device *dev)
 {
-	const struct espi_saf_xec_config *cfg = DEV_CFG(dev);
+	const struct espi_saf_xec_config *cfg = dev->config;
 	MCHP_SAF_HW_REGS *regs = (MCHP_SAF_HW_REGS *)cfg->saf_base_addr;
 
 	if (regs->SAF_FL_CFG_MISC & MCHP_SAF_FL_CFG_MISC_SAF_EN) {
@@ -673,8 +669,8 @@ static int saf_ecp_access(const struct device *dev,
 {
 	uint32_t err_mask, n;
 	int rc, counter;
-	struct espi_saf_xec_data *xdat = DEV_DATA(dev);
-	const struct espi_saf_xec_config *cfg = DEV_CFG(dev);
+	struct espi_saf_xec_data *xdat = dev->data;
+	const struct espi_saf_xec_config *cfg = dev->config;
 	MCHP_SAF_HW_REGS *regs = (MCHP_SAF_HW_REGS *)cfg->saf_base_addr;
 
 	counter = 0;
@@ -798,7 +794,7 @@ static int espi_saf_xec_manage_callback(const struct device *dev,
 					struct espi_callback *callback,
 					bool set)
 {
-	struct espi_saf_xec_data *data = DEV_DATA(dev);
+	struct espi_saf_xec_data *data = dev->data;
 
 	return espi_manage_callback(&data->callbacks, callback, set);
 }
@@ -812,7 +808,7 @@ static int espi_saf_xec_activate(const struct device *dev)
 		return -EINVAL;
 	}
 
-	cfg = DEV_CFG(dev);
+	cfg = dev->config;
 	regs = (MCHP_SAF_HW_REGS *)cfg->saf_base_addr;
 
 	regs->SAF_FL_CFG_MISC |= MCHP_SAF_FL_CFG_MISC_SAF_EN;
@@ -857,7 +853,7 @@ DEVICE_DT_INST_DEFINE(0, &espi_saf_xec_init, NULL,
 
 static int espi_saf_xec_init(const struct device *dev)
 {
-	struct espi_saf_xec_data *data = DEV_DATA(dev);
+	struct espi_saf_xec_data *data = dev->data;
 
 	/* ungate SAF clocks by disabling PCR sleep enable */
 	mchp_pcr_periph_slp_ctrl(PCR_ESPI_SAF, MCHP_PCR_SLEEP_DIS);

--- a/drivers/ethernet/dsa_ksz8xxx.c
+++ b/drivers/ethernet/dsa_ksz8xxx.c
@@ -44,7 +44,6 @@ struct ksz8xxx_data {
 #endif
 };
 
-#define DEV_DATA(dev) ((struct dsa_context *const)(dev)->data)
 #define PRV_DATA(ctx) ((struct ksz8xxx_data *const)(ctx)->prv_data)
 
 static void dsa_ksz8xxx_write_reg(const struct ksz8xxx_data *pdev,
@@ -779,7 +778,8 @@ static void dsa_delayed_work(struct k_work *item)
 
 int dsa_port_init(const struct device *dev)
 {
-	struct ksz8xxx_data *pdev = PRV_DATA(DEV_DATA(dev));
+	struct dsa_context *data = dev->data;
+	struct ksz8xxx_data *pdev = PRV_DATA(data);
 
 	dsa_hw_init(pdev);
 	return 0;
@@ -789,7 +789,8 @@ int dsa_port_init(const struct device *dev)
 static int dsa_ksz8xxx_sw_write_reg(const struct device *dev, uint16_t reg_addr,
 				    uint8_t value)
 {
-	struct ksz8xxx_data *pdev = PRV_DATA(DEV_DATA(dev));
+	struct dsa_context *data = dev->data;
+	struct ksz8xxx_data *pdev = PRV_DATA(data);
 
 	dsa_ksz8xxx_write_reg(pdev, reg_addr, value);
 	return 0;
@@ -799,7 +800,8 @@ static int dsa_ksz8xxx_sw_write_reg(const struct device *dev, uint16_t reg_addr,
 static int dsa_ksz8xxx_sw_read_reg(const struct device *dev, uint16_t reg_addr,
 				   uint8_t *value)
 {
-	struct ksz8xxx_data *pdev = PRV_DATA(DEV_DATA(dev));
+	struct dsa_context *data = dev->data;
+	struct ksz8xxx_data *pdev = PRV_DATA(data);
 
 	dsa_ksz8xxx_read_reg(pdev, reg_addr, value);
 	return 0;
@@ -822,7 +824,8 @@ static int dsa_ksz8xxx_set_mac_table_entry(const struct device *dev,
 						uint16_t tbl_entry_idx,
 						uint16_t flags)
 {
-	struct ksz8xxx_data *pdev = PRV_DATA(DEV_DATA(dev));
+	struct dsa_context *data = dev->data;
+	struct ksz8xxx_data *pdev = PRV_DATA(data);
 
 	if (flags != 0) {
 		return -EINVAL;
@@ -847,7 +850,8 @@ static int dsa_ksz8xxx_get_mac_table_entry(const struct device *dev,
 						uint8_t *buf,
 						uint16_t tbl_entry_idx)
 {
-	struct ksz8xxx_data *pdev = PRV_DATA(DEV_DATA(dev));
+	struct dsa_context *data = dev->data;
+	struct ksz8xxx_data *pdev = PRV_DATA(data);
 
 	dsa_ksz8xxx_read_static_mac_table(pdev, tbl_entry_idx, buf);
 

--- a/drivers/ethernet/eth_gecko.c
+++ b/drivers/ethernet/eth_gecko.c
@@ -65,7 +65,7 @@ static void link_configure(ETH_TypeDef *eth, uint32_t flags)
 
 static void eth_gecko_setup_mac(const struct device *dev)
 {
-	const struct eth_gecko_dev_cfg *const cfg = DEV_CFG(dev);
+	const struct eth_gecko_dev_cfg *const cfg = dev->config;
 	ETH_TypeDef *eth = cfg->regs;
 	uint32_t link_status;
 	int result;
@@ -136,8 +136,8 @@ static void rx_error_handler(ETH_TypeDef *eth)
 
 static struct net_pkt *frame_get(const struct device *dev)
 {
-	struct eth_gecko_dev_data *const dev_data = DEV_DATA(dev);
-	const struct eth_gecko_dev_cfg *const cfg = DEV_CFG(dev);
+	struct eth_gecko_dev_data *const dev_data = dev->data;
+	const struct eth_gecko_dev_cfg *const cfg = dev->config;
 	ETH_TypeDef *eth = cfg->regs;
 	struct net_pkt *rx_frame = NULL;
 	uint16_t frag_len, total_len;
@@ -236,7 +236,7 @@ static struct net_pkt *frame_get(const struct device *dev)
 
 static void eth_rx(const struct device *dev)
 {
-	struct eth_gecko_dev_data *const dev_data = DEV_DATA(dev);
+	struct eth_gecko_dev_data *const dev_data = dev->data;
 	struct net_pkt *rx_frame;
 	int res = 0;
 
@@ -262,8 +262,8 @@ static void eth_rx(const struct device *dev)
 
 static int eth_tx(const struct device *dev, struct net_pkt *pkt)
 {
-	struct eth_gecko_dev_data *const dev_data = DEV_DATA(dev);
-	const struct eth_gecko_dev_cfg *const cfg = DEV_CFG(dev);
+	struct eth_gecko_dev_data *const dev_data = dev->data;
+	const struct eth_gecko_dev_cfg *const cfg = dev->config;
 	ETH_TypeDef *eth = cfg->regs;
 	uint16_t total_len;
 	uint8_t *dma_buffer;
@@ -325,8 +325,8 @@ error:
 static void rx_thread(void *arg1, void *unused1, void *unused2)
 {
 	const struct device *dev = (const struct device *)arg1;
-	struct eth_gecko_dev_data *const dev_data = DEV_DATA(dev);
-	const struct eth_gecko_dev_cfg *const cfg = DEV_CFG(dev);
+	struct eth_gecko_dev_data *const dev_data = dev->data;
+	const struct eth_gecko_dev_cfg *const cfg = dev->config;
 	int res;
 
 	__ASSERT_NO_MSG(arg1 != NULL);
@@ -369,8 +369,8 @@ static void rx_thread(void *arg1, void *unused1, void *unused2)
 
 static void eth_isr(const struct device *dev)
 {
-	struct eth_gecko_dev_data *const dev_data = DEV_DATA(dev);
-	const struct eth_gecko_dev_cfg *const cfg = DEV_CFG(dev);
+	struct eth_gecko_dev_data *const dev_data = dev->data;
+	const struct eth_gecko_dev_cfg *const cfg = dev->config;
 	ETH_TypeDef *eth = cfg->regs;
 	uint32_t int_clr = 0;
 	uint32_t int_stat = eth->IFCR;
@@ -429,7 +429,7 @@ static void eth_init_clocks(const struct device *dev)
 
 static void eth_init_pins(const struct device *dev)
 {
-	const struct eth_gecko_dev_cfg *const cfg = DEV_CFG(dev);
+	const struct eth_gecko_dev_cfg *const cfg = dev->config;
 	ETH_TypeDef *eth = cfg->regs;
 	uint32_t idx;
 
@@ -461,7 +461,7 @@ static void eth_init_pins(const struct device *dev)
 
 static int eth_init(const struct device *dev)
 {
-	const struct eth_gecko_dev_cfg *const cfg = DEV_CFG(dev);
+	const struct eth_gecko_dev_cfg *const cfg = dev->config;
 	ETH_TypeDef *eth = cfg->regs;
 
 	__ASSERT_NO_MSG(dev != NULL);
@@ -503,8 +503,8 @@ static void generate_mac(uint8_t mac_addr[6])
 static void eth_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
-	struct eth_gecko_dev_data *const dev_data = DEV_DATA(dev);
-	const struct eth_gecko_dev_cfg *const cfg = DEV_CFG(dev);
+	struct eth_gecko_dev_data *const dev_data = dev->data;
+	const struct eth_gecko_dev_cfg *const cfg = dev->config;
 	ETH_TypeDef *eth = cfg->regs;
 	int result;
 

--- a/drivers/ethernet/eth_gecko_priv.h
+++ b/drivers/ethernet/eth_gecko_priv.h
@@ -95,10 +95,6 @@ struct eth_gecko_dev_data {
 };
 
 #define DEV_NAME(dev) ((dev)->name)
-#define DEV_CFG(dev) \
-	((const struct eth_gecko_dev_cfg *)(dev)->config)
-#define DEV_DATA(dev) \
-	((struct eth_gecko_dev_data *)(dev)->data)
 
 /* PHY Management pins */
 #define PIN_PHY_MDC {DT_INST_PROP_BY_IDX(0, location_phy_mdc, 1), \

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -218,7 +218,7 @@ void eth_mcux_phy_stop(struct eth_context *context);
 static int eth_mcux_device_pm_action(const struct device *dev,
 				     enum pm_device_action action)
 {
-	struct eth_context *eth_ctx = (struct eth_context *)dev->data;
+	struct eth_context *eth_ctx = dev->data;
 	int ret = 0;
 
 	if (!eth_ctx->clock_dev) {

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -1354,7 +1354,7 @@ static void eth_rx(struct gmac_queue *queue)
 	struct net_pkt *rx_frame;
 #if defined(CONFIG_NET_GPTP)
 	const struct device *const dev = net_if_get_device(dev_data->iface);
-	const struct eth_sam_dev_cfg *const cfg = DEV_CFG(dev);
+	const struct eth_sam_dev_cfg *const cfg = dev->config;
 	Gmac *gmac = cfg->regs;
 	struct gptp_hdr *hdr;
 #endif
@@ -1448,8 +1448,8 @@ static int priority2queue(enum net_priority priority)
 
 static int eth_tx(const struct device *dev, struct net_pkt *pkt)
 {
-	const struct eth_sam_dev_cfg *const cfg = DEV_CFG(dev);
-	struct eth_sam_dev_data *const dev_data = DEV_DATA(dev);
+	const struct eth_sam_dev_cfg *const cfg = dev->config;
+	struct eth_sam_dev_data *const dev_data = dev->data;
 	Gmac *gmac = cfg->regs;
 	struct gmac_queue *queue;
 	struct gmac_desc_list *tx_desc_list;
@@ -1631,8 +1631,8 @@ static int eth_tx(const struct device *dev, struct net_pkt *pkt)
 
 static void queue0_isr(const struct device *dev)
 {
-	const struct eth_sam_dev_cfg *const cfg = DEV_CFG(dev);
-	struct eth_sam_dev_data *const dev_data = DEV_DATA(dev);
+	const struct eth_sam_dev_cfg *const cfg = dev->config;
+	struct eth_sam_dev_data *const dev_data = dev->data;
 	Gmac *gmac = cfg->regs;
 	struct gmac_queue *queue;
 	struct gmac_desc_list *rx_desc_list;
@@ -1682,8 +1682,8 @@ static void queue0_isr(const struct device *dev)
 static inline void priority_queue_isr(const struct device *dev,
 				      unsigned int queue_idx)
 {
-	const struct eth_sam_dev_cfg *const cfg = DEV_CFG(dev);
-	struct eth_sam_dev_data *const dev_data = DEV_DATA(dev);
+	const struct eth_sam_dev_cfg *const cfg = dev->config;
+	struct eth_sam_dev_data *const dev_data = dev->data;
 	Gmac *gmac = cfg->regs;
 	struct gmac_queue *queue;
 	struct gmac_desc_list *rx_desc_list;
@@ -1766,7 +1766,7 @@ static void queue5_isr(const struct device *dev)
 
 static int eth_initialize(const struct device *dev)
 {
-	const struct eth_sam_dev_cfg *const cfg = DEV_CFG(dev);
+	const struct eth_sam_dev_cfg *const cfg = dev->config;
 
 	cfg->config_func();
 
@@ -1823,8 +1823,8 @@ static void phy_link_state_changed(const struct device *pdev,
 				   void *user_data)
 {
 	const struct device *dev = (struct device *) user_data;
-	struct eth_sam_dev_data *const dev_data = DEV_DATA(dev);
-	const struct eth_sam_dev_cfg *const cfg = DEV_CFG(dev);
+	struct eth_sam_dev_data *const dev_data = dev->data;
+	const struct eth_sam_dev_cfg *const cfg = dev->config;
 	bool is_up;
 
 	is_up = state->is_up;
@@ -1852,8 +1852,8 @@ static void phy_link_state_changed(const struct device *pdev,
 static void eth0_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
-	struct eth_sam_dev_data *const dev_data = DEV_DATA(dev);
-	const struct eth_sam_dev_cfg *const cfg = DEV_CFG(dev);
+	struct eth_sam_dev_data *const dev_data = dev->data;
+	const struct eth_sam_dev_cfg *const cfg = dev->config;
 	static bool init_done;
 	uint32_t gmac_ncfgr_val;
 	int result;
@@ -1988,7 +1988,7 @@ static int eth_sam_gmac_set_qav_param(const struct device *dev,
 				      enum ethernet_config_type type,
 				      const struct ethernet_config *config)
 {
-	const struct eth_sam_dev_cfg *const cfg = DEV_CFG(dev);
+	const struct eth_sam_dev_cfg *const cfg = dev->config;
 	Gmac *gmac = cfg->regs;
 	enum ethernet_qav_param_type qav_param_type;
 	unsigned int delta_bandwidth;
@@ -2037,8 +2037,8 @@ static int eth_sam_gmac_set_config(const struct device *dev,
 #endif
 	case ETHERNET_CONFIG_TYPE_MAC_ADDRESS:
 	{
-		struct eth_sam_dev_data *const dev_data = DEV_DATA(dev);
-		const struct eth_sam_dev_cfg *const cfg = DEV_CFG(dev);
+		struct eth_sam_dev_data *const dev_data = dev->data;
+		const struct eth_sam_dev_cfg *const cfg = dev->config;
 
 		memcpy(dev_data->mac_addr,
 		       config->mac_address.addr,
@@ -2070,7 +2070,7 @@ static int eth_sam_gmac_get_qav_param(const struct device *dev,
 				      enum ethernet_config_type type,
 				      struct ethernet_config *config)
 {
-	const struct eth_sam_dev_cfg *const cfg = DEV_CFG(dev);
+	const struct eth_sam_dev_cfg *const cfg = dev->config;
 	Gmac *gmac = cfg->regs;
 	enum ethernet_qav_param_type qav_param_type;
 	int queue_id;
@@ -2137,7 +2137,7 @@ static int eth_sam_gmac_get_config(const struct device *dev,
 #if defined(CONFIG_PTP_CLOCK_SAM_GMAC)
 static const struct device *eth_sam_gmac_get_ptp_clock(const struct device *dev)
 {
-	struct eth_sam_dev_data *const dev_data = DEV_DATA(dev);
+	struct eth_sam_dev_data *const dev_data = dev->data;
 
 	return dev_data->ptp_clock;
 }
@@ -2401,7 +2401,7 @@ static int ptp_clock_sam_gmac_set(const struct device *dev,
 				  struct net_ptp_time *tm)
 {
 	struct ptp_context *ptp_context = dev->data;
-	const struct eth_sam_dev_cfg *const cfg = DEV_CFG(ptp_context->eth_dev);
+	const struct eth_sam_dev_cfg *const cfg = ptp_context->eth_dev->config;
 	Gmac *gmac = cfg->regs;
 
 	gmac->GMAC_TSH = tm->_sec.high & 0xffff;
@@ -2415,7 +2415,7 @@ static int ptp_clock_sam_gmac_get(const struct device *dev,
 				  struct net_ptp_time *tm)
 {
 	struct ptp_context *ptp_context = dev->data;
-	const struct eth_sam_dev_cfg *const cfg = DEV_CFG(ptp_context->eth_dev);
+	const struct eth_sam_dev_cfg *const cfg = ptp_context->eth_dev->config;
 	Gmac *gmac = cfg->regs;
 
 	tm->second = ((uint64_t)(gmac->GMAC_TSH & 0xffff) << 32) | gmac->GMAC_TSL;
@@ -2427,7 +2427,7 @@ static int ptp_clock_sam_gmac_get(const struct device *dev,
 static int ptp_clock_sam_gmac_adjust(const struct device *dev, int increment)
 {
 	struct ptp_context *ptp_context = dev->data;
-	const struct eth_sam_dev_cfg *const cfg = DEV_CFG(ptp_context->eth_dev);
+	const struct eth_sam_dev_cfg *const cfg = ptp_context->eth_dev->config;
 	Gmac *gmac = cfg->regs;
 
 	if ((increment <= -NSEC_PER_SEC) || (increment >= NSEC_PER_SEC)) {

--- a/drivers/ethernet/eth_sam_gmac_priv.h
+++ b/drivers/ethernet/eth_sam_gmac_priv.h
@@ -281,9 +281,4 @@ struct eth_sam_dev_data {
 	struct gmac_queue queue_list[GMAC_QUEUE_NUM];
 };
 
-#define DEV_CFG(dev) \
-	((const struct eth_sam_dev_cfg *const)(dev)->config)
-#define DEV_DATA(dev) \
-	((struct eth_sam_dev_data *const)(dev)->data)
-
 #endif /* ZEPHYR_DRIVERS_ETHERNET_ETH_SAM_GMAC_PRIV_H_ */

--- a/drivers/ethernet/eth_stellaris.c
+++ b/drivers/ethernet/eth_stellaris.c
@@ -39,7 +39,7 @@ static void eth_stellaris_assign_mac(const struct device *dev)
 
 static void eth_stellaris_flush(const struct device *dev)
 {
-	struct eth_stellaris_runtime *dev_data = DEV_DATA(dev);
+	struct eth_stellaris_runtime *dev_data = dev->data;
 
 	if (dev_data->tx_pos != 0) {
 		sys_write32(dev_data->tx_word, REG_MACDATA);
@@ -50,7 +50,7 @@ static void eth_stellaris_flush(const struct device *dev)
 
 static void eth_stellaris_send_byte(const struct device *dev, uint8_t byte)
 {
-	struct eth_stellaris_runtime *dev_data = DEV_DATA(dev);
+	struct eth_stellaris_runtime *dev_data = dev->data;
 
 	dev_data->tx_word |= byte << (dev_data->tx_pos * 8);
 	dev_data->tx_pos++;
@@ -63,7 +63,7 @@ static void eth_stellaris_send_byte(const struct device *dev, uint8_t byte)
 
 static int eth_stellaris_send(const struct device *dev, struct net_pkt *pkt)
 {
-	struct eth_stellaris_runtime *dev_data = DEV_DATA(dev);
+	struct eth_stellaris_runtime *dev_data = dev->data;
 	struct net_buf *frag;
 	uint16_t i, data_len;
 
@@ -203,7 +203,7 @@ error:
 
 static void eth_stellaris_rx(const struct device *dev)
 {
-	struct eth_stellaris_runtime *dev_data = DEV_DATA(dev);
+	struct eth_stellaris_runtime *dev_data = dev->data;
 	struct net_if *iface = dev_data->iface;
 	struct net_pkt *pkt;
 
@@ -229,7 +229,7 @@ err_mem:
 
 static void eth_stellaris_isr(const struct device *dev)
 {
-	struct eth_stellaris_runtime *dev_data = DEV_DATA(dev);
+	struct eth_stellaris_runtime *dev_data = dev->data;
 	int isr_val = sys_read32(REG_MACRIS);
 	uint32_t lock;
 
@@ -270,8 +270,8 @@ static void eth_stellaris_isr(const struct device *dev)
 static void eth_stellaris_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
-	const struct eth_stellaris_config *dev_conf = DEV_CFG(dev);
-	struct eth_stellaris_runtime *dev_data = DEV_DATA(dev);
+	const struct eth_stellaris_config *dev_conf = dev->config;
+	struct eth_stellaris_runtime *dev_data = dev->data;
 
 	dev_data->iface = iface;
 
@@ -291,7 +291,9 @@ static void eth_stellaris_init(struct net_if *iface)
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
 static struct net_stats_eth *eth_stellaris_stats(const struct device *dev)
 {
-	return &(DEV_DATA(dev)->stats);
+	struct eth_stellaris_runtime *dev_data = dev->data;
+
+	return &data->stats;
 }
 #endif
 

--- a/drivers/ethernet/eth_stellaris_priv.h
+++ b/drivers/ethernet/eth_stellaris_priv.h
@@ -8,23 +8,21 @@
 #ifndef ETH_STELLARIS_PRIV_H_
 #define ETH_STELLARIS_PRIV_H_
 
-#define DEV_DATA(dev) \
-	((struct eth_stellaris_runtime *)(dev)->data)
-#define DEV_CFG(dev) \
-	((const struct eth_stellaris_config *const)(dev)->config)
+#define REG_BASE(dev) \
+	((const struct eth_stellaris_config *const)(dev)->config)->mac_base
 /*
  *  Register mapping
  */
 /* Registers for ethernet system, mac_base + offset */
-#define REG_MACRIS		((DEV_CFG(dev)->mac_base) + 0x000)
-#define REG_MACIM		((DEV_CFG(dev)->mac_base) + 0x004)
-#define REG_MACRCTL		((DEV_CFG(dev)->mac_base) + 0x008)
-#define REG_MACTCTL		((DEV_CFG(dev)->mac_base) + 0x00C)
-#define REG_MACDATA		((DEV_CFG(dev)->mac_base) + 0x010)
-#define REG_MACIA0		((DEV_CFG(dev)->mac_base) + 0x014)
-#define REG_MACIA1		((DEV_CFG(dev)->mac_base) + 0x018)
-#define REG_MACNP		((DEV_CFG(dev)->mac_base) + 0x034)
-#define REG_MACTR		((DEV_CFG(dev)->mac_base) + 0x038)
+#define REG_MACRIS		(REG_BASE(dev) + 0x000)
+#define REG_MACIM		(REG_BASE(dev) + 0x004)
+#define REG_MACRCTL		(REG_BASE(dev) + 0x008)
+#define REG_MACTCTL		(REG_BASE(dev) + 0x00C)
+#define REG_MACDATA		(REG_BASE(dev) + 0x010)
+#define REG_MACIA0		(REG_BASE(dev) + 0x014)
+#define REG_MACIA1		(REG_BASE(dev) + 0x018)
+#define REG_MACNP		(REG_BASE(dev) + 0x034)
+#define REG_MACTR		(REG_BASE(dev) + 0x038)
 
 /* ETH MAC Receive Control bit fields set value */
 #define BIT_MACRCTL_RSTFIFO	0x10

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -202,7 +202,7 @@ static bool eth_is_ptp_pkt(struct net_if *iface, struct net_pkt *pkt)
 
 static int eth_tx(const struct device *dev, struct net_pkt *pkt)
 {
-	struct eth_stm32_hal_dev_data *dev_data = DEV_DATA(dev);
+	struct eth_stm32_hal_dev_data *dev_data = dev->data;
 	ETH_HandleTypeDef *heth;
 	uint8_t *dma_buffer;
 	int res;
@@ -462,7 +462,7 @@ static struct net_pkt *eth_rx(const struct device *dev, uint16_t *vlan_tag)
 
 	__ASSERT_NO_MSG(dev != NULL);
 
-	dev_data = DEV_DATA(dev);
+	dev_data = dev->data;
 
 	__ASSERT_NO_MSG(dev_data != NULL);
 
@@ -646,7 +646,7 @@ static void rx_thread(void *arg1, void *unused1, void *unused2)
 	ARG_UNUSED(unused2);
 
 	dev = (const struct device *)arg1;
-	dev_data = DEV_DATA(dev);
+	dev_data = dev->data;
 
 	__ASSERT_NO_MSG(dev_data != NULL);
 
@@ -702,7 +702,7 @@ static void eth_isr(const struct device *dev)
 
 	__ASSERT_NO_MSG(dev != NULL);
 
-	dev_data = DEV_DATA(dev);
+	dev_data = dev->data;
 
 	__ASSERT_NO_MSG(dev_data != NULL);
 
@@ -802,8 +802,8 @@ static int eth_initialize(const struct device *dev)
 
 	__ASSERT_NO_MSG(dev != NULL);
 
-	dev_data = DEV_DATA(dev);
-	cfg = DEV_CFG(dev);
+	dev_data = dev->data;
+	cfg = dev->config;
 
 	__ASSERT_NO_MSG(dev_data != NULL);
 	__ASSERT_NO_MSG(cfg != NULL);
@@ -964,7 +964,7 @@ static void eth_iface_init(struct net_if *iface)
 	dev = net_if_get_device(iface);
 	__ASSERT_NO_MSG(dev != NULL);
 
-	dev_data = DEV_DATA(dev);
+	dev_data = dev->data;
 	__ASSERT_NO_MSG(dev_data != NULL);
 
 	/* For VLAN, this value is only used to get the correct L2 driver.
@@ -986,9 +986,10 @@ static void eth_iface_init(struct net_if *iface)
 	net_if_flag_set(iface, NET_IF_NO_AUTO_START);
 
 	if (is_first_init) {
+		const struct eth_stm32_hal_dev_cfg *cfg = dev->config;
 		/* Now that the iface is setup, we are safe to enable IRQs. */
-		__ASSERT_NO_MSG(DEV_CFG(dev)->config_func != NULL);
-		DEV_CFG(dev)->config_func();
+		__ASSERT_NO_MSG(cfg->config_func != NULL);
+		cfg->config_func();
 	}
 }
 
@@ -1017,7 +1018,7 @@ static int eth_stm32_hal_set_config(const struct device *dev,
 	struct eth_stm32_hal_dev_data *dev_data;
 	ETH_HandleTypeDef *heth;
 
-	dev_data = DEV_DATA(dev);
+	dev_data = dev->data;
 	heth = &dev_data->heth;
 
 	switch (type) {
@@ -1317,8 +1318,8 @@ static const struct ptp_clock_driver_api api = {
 static int ptp_stm32_init(const struct device *port)
 {
 	const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(mac));
-	struct eth_stm32_hal_dev_data *eth_dev_data = DEV_DATA(dev);
-	const struct eth_stm32_hal_dev_cfg *eth_cfg = DEV_CFG(dev);
+	struct eth_stm32_hal_dev_data *eth_dev_data = dev->data;
+	const struct eth_stm32_hal_dev_cfg *eth_cfg = dev->config;
 	struct ptp_context *ptp_context = port->data;
 	ETH_HandleTypeDef *heth = &eth_dev_data->heth;
 	int ret;

--- a/drivers/ethernet/eth_stm32_hal_priv.h
+++ b/drivers/ethernet/eth_stm32_hal_priv.h
@@ -55,9 +55,4 @@ struct eth_stm32_hal_dev_data {
 #endif /* CONFIG_PTP_CLOCK_STM32_HAL */
 };
 
-#define DEV_CFG(dev) \
-	((const struct eth_stm32_hal_dev_cfg *)(dev)->config)
-#define DEV_DATA(dev) \
-	((struct eth_stm32_hal_dev_data *)(dev)->data)
-
 #endif /* ZEPHYR_DRIVERS_ETHERNET_ETH_STM32_HAL_PRIV_H_ */

--- a/drivers/ethernet/eth_xlnx_gem.c
+++ b/drivers/ethernet/eth_xlnx_gem.c
@@ -90,7 +90,7 @@ DT_INST_FOREACH_STATUS_OKAY(ETH_XLNX_GEM_INITIALIZE)
  */
 static int eth_xlnx_gem_dev_init(const struct device *dev)
 {
-	const struct eth_xlnx_gem_dev_cfg *dev_conf = DEV_CFG(dev);
+	const struct eth_xlnx_gem_dev_cfg *dev_conf = dev->config;
 	uint32_t reg_val;
 
 	/* Precondition checks using assertions */
@@ -219,8 +219,8 @@ static int eth_xlnx_gem_dev_init(const struct device *dev)
 static void eth_xlnx_gem_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
-	const struct eth_xlnx_gem_dev_cfg *dev_conf = DEV_CFG(dev);
-	struct eth_xlnx_gem_dev_data *dev_data = DEV_DATA(dev);
+	const struct eth_xlnx_gem_dev_cfg *dev_conf = dev->config;
+	struct eth_xlnx_gem_dev_data *dev_data = dev->data;
 
 	/* Set the initial contents of the current instance's run-time data */
 	dev_data->iface = iface;
@@ -264,8 +264,8 @@ static void eth_xlnx_gem_iface_init(struct net_if *iface)
  */
 static void eth_xlnx_gem_isr(const struct device *dev)
 {
-	const struct eth_xlnx_gem_dev_cfg *dev_conf = DEV_CFG(dev);
-	struct eth_xlnx_gem_dev_data *dev_data = DEV_DATA(dev);
+	const struct eth_xlnx_gem_dev_cfg *dev_conf = dev->config;
+	struct eth_xlnx_gem_dev_data *dev_data = dev->data;
 	uint32_t reg_val;
 
 	/* Read the interrupt status register */
@@ -344,8 +344,8 @@ static void eth_xlnx_gem_isr(const struct device *dev)
  */
 static int eth_xlnx_gem_send(const struct device *dev, struct net_pkt *pkt)
 {
-	const struct eth_xlnx_gem_dev_cfg *dev_conf = DEV_CFG(dev);
-	struct eth_xlnx_gem_dev_data *dev_data = DEV_DATA(dev);
+	const struct eth_xlnx_gem_dev_cfg *dev_conf = dev->config;
+	struct eth_xlnx_gem_dev_data *dev_data = dev->data;
 
 	uint16_t tx_data_length;
 	uint16_t tx_data_remaining;
@@ -519,8 +519,8 @@ static int eth_xlnx_gem_send(const struct device *dev, struct net_pkt *pkt)
  */
 static int eth_xlnx_gem_start_device(const struct device *dev)
 {
-	const struct eth_xlnx_gem_dev_cfg *dev_conf = DEV_CFG(dev);
-	struct eth_xlnx_gem_dev_data *dev_data = DEV_DATA(dev);
+	const struct eth_xlnx_gem_dev_cfg *dev_conf = dev->config;
+	struct eth_xlnx_gem_dev_data *dev_data = dev->data;
 	uint32_t reg_val;
 
 	if (dev_data->started) {
@@ -568,8 +568,8 @@ static int eth_xlnx_gem_start_device(const struct device *dev)
  */
 static int eth_xlnx_gem_stop_device(const struct device *dev)
 {
-	const struct eth_xlnx_gem_dev_cfg *dev_conf = DEV_CFG(dev);
-	struct eth_xlnx_gem_dev_data *dev_data = DEV_DATA(dev);
+	const struct eth_xlnx_gem_dev_cfg *dev_conf = dev->config;
+	struct eth_xlnx_gem_dev_data *dev_data = dev->data;
 	uint32_t reg_val;
 
 	if (!dev_data->started) {
@@ -613,7 +613,7 @@ static int eth_xlnx_gem_stop_device(const struct device *dev)
 static enum ethernet_hw_caps eth_xlnx_gem_get_capabilities(
 	const struct device *dev)
 {
-	const struct eth_xlnx_gem_dev_cfg *dev_conf = DEV_CFG(dev);
+	const struct eth_xlnx_gem_dev_cfg *dev_conf = dev->config;
 	enum ethernet_hw_caps caps = (enum ethernet_hw_caps)0;
 
 	if (dev_conf->max_link_speed == LINK_1GBIT) {
@@ -664,7 +664,9 @@ static enum ethernet_hw_caps eth_xlnx_gem_get_capabilities(
  */
 static struct net_stats_eth *eth_xlnx_gem_stats(const struct device *dev)
 {
-	return &(DEV_DATA(dev)->stats);
+	struct eth_xlnx_gem_dev_data *dev_data = dev->data;
+
+	return &data->stats;
 }
 #endif
 
@@ -677,7 +679,7 @@ static struct net_stats_eth *eth_xlnx_gem_stats(const struct device *dev)
  */
 static void eth_xlnx_gem_reset_hw(const struct device *dev)
 {
-	const struct eth_xlnx_gem_dev_cfg *dev_conf = DEV_CFG(dev);
+	const struct eth_xlnx_gem_dev_cfg *dev_conf = dev->config;
 
 	/*
 	 * Controller reset sequence as described in the Zynq-7000 TRM,
@@ -726,8 +728,8 @@ static void eth_xlnx_gem_configure_clocks(const struct device *dev)
 	 * values for the respective GEM's TX clock are calculated here.
 	 */
 
-	const struct eth_xlnx_gem_dev_cfg *dev_conf = DEV_CFG(dev);
-	struct eth_xlnx_gem_dev_data *dev_data = DEV_DATA(dev);
+	const struct eth_xlnx_gem_dev_cfg *dev_conf = dev->config;
+	struct eth_xlnx_gem_dev_data *dev_data = dev->data;
 
 	uint32_t div0;
 	uint32_t div1;
@@ -853,7 +855,7 @@ static void eth_xlnx_gem_configure_clocks(const struct device *dev)
  */
 static void eth_xlnx_gem_set_initial_nwcfg(const struct device *dev)
 {
-	const struct eth_xlnx_gem_dev_cfg *dev_conf = DEV_CFG(dev);
+	const struct eth_xlnx_gem_dev_cfg *dev_conf = dev->config;
 	uint32_t reg_val = 0;
 
 	if (dev_conf->ignore_ipg_rxer) {
@@ -973,8 +975,8 @@ static void eth_xlnx_gem_set_initial_nwcfg(const struct device *dev)
  */
 static void eth_xlnx_gem_set_nwcfg_link_speed(const struct device *dev)
 {
-	const struct eth_xlnx_gem_dev_cfg *dev_conf = DEV_CFG(dev);
-	struct eth_xlnx_gem_dev_data *dev_data = DEV_DATA(dev);
+	const struct eth_xlnx_gem_dev_cfg *dev_conf = dev->config;
+	struct eth_xlnx_gem_dev_data *dev_data = dev->data;
 	uint32_t reg_val;
 
 	/*
@@ -1007,8 +1009,8 @@ static void eth_xlnx_gem_set_nwcfg_link_speed(const struct device *dev)
  */
 static void eth_xlnx_gem_set_mac_address(const struct device *dev)
 {
-	const struct eth_xlnx_gem_dev_cfg *dev_conf = DEV_CFG(dev);
-	struct eth_xlnx_gem_dev_data *dev_data = DEV_DATA(dev);
+	const struct eth_xlnx_gem_dev_cfg *dev_conf = dev->config;
+	struct eth_xlnx_gem_dev_data *dev_data = dev->data;
 	uint32_t regval_top;
 	uint32_t regval_bot;
 
@@ -1043,7 +1045,7 @@ static void eth_xlnx_gem_set_mac_address(const struct device *dev)
  */
 static void eth_xlnx_gem_set_initial_dmacr(const struct device *dev)
 {
-	const struct eth_xlnx_gem_dev_cfg *dev_conf = DEV_CFG(dev);
+	const struct eth_xlnx_gem_dev_cfg *dev_conf = dev->config;
 	uint32_t reg_val = 0;
 
 	/*
@@ -1110,7 +1112,7 @@ static void eth_xlnx_gem_set_initial_dmacr(const struct device *dev)
  */
 static void eth_xlnx_gem_init_phy(const struct device *dev)
 {
-	struct eth_xlnx_gem_dev_data *dev_data = DEV_DATA(dev);
+	struct eth_xlnx_gem_dev_data *dev_data = dev->data;
 	int detect_rc;
 
 	LOG_DBG("%s attempting to initialize associated PHY", dev->name);
@@ -1162,7 +1164,7 @@ static void eth_xlnx_gem_poll_phy(struct k_work *work)
 	struct eth_xlnx_gem_dev_data *dev_data = CONTAINER_OF(dwork,
 		struct eth_xlnx_gem_dev_data, phy_poll_delayed_work);
 	const struct device *dev = net_if_get_device(dev_data->iface);
-	const struct eth_xlnx_gem_dev_cfg *dev_conf = DEV_CFG(dev);
+	const struct eth_xlnx_gem_dev_cfg *dev_conf = dev->config;
 
 	uint16_t phy_status;
 	uint8_t link_status;
@@ -1257,8 +1259,8 @@ static void eth_xlnx_gem_poll_phy(struct k_work *work)
  */
 static void eth_xlnx_gem_configure_buffers(const struct device *dev)
 {
-	const struct eth_xlnx_gem_dev_cfg *dev_conf = DEV_CFG(dev);
-	struct eth_xlnx_gem_dev_data *dev_data = DEV_DATA(dev);
+	const struct eth_xlnx_gem_dev_cfg *dev_conf = dev->config;
+	struct eth_xlnx_gem_dev_data *dev_data = dev->data;
 	struct eth_xlnx_gem_bd *bdptr;
 	uint32_t buf_iter;
 
@@ -1372,8 +1374,8 @@ static void eth_xlnx_gem_rx_pending_work(struct k_work *item)
  */
 static void eth_xlnx_gem_handle_rx_pending(const struct device *dev)
 {
-	const struct eth_xlnx_gem_dev_cfg *dev_conf = DEV_CFG(dev);
-	struct eth_xlnx_gem_dev_data *dev_data = DEV_DATA(dev);
+	const struct eth_xlnx_gem_dev_cfg *dev_conf = dev->config;
+	struct eth_xlnx_gem_dev_data *dev_data = dev->data;
 	uint32_t reg_addr;
 	uint32_t reg_ctrl;
 	uint32_t reg_val;
@@ -1552,8 +1554,8 @@ static void eth_xlnx_gem_tx_done_work(struct k_work *item)
  */
 static void eth_xlnx_gem_handle_tx_done(const struct device *dev)
 {
-	const struct eth_xlnx_gem_dev_cfg *dev_conf = DEV_CFG(dev);
-	struct eth_xlnx_gem_dev_data *dev_data = DEV_DATA(dev);
+	const struct eth_xlnx_gem_dev_cfg *dev_conf = dev->config;
+	struct eth_xlnx_gem_dev_data *dev_data = dev->data;
 	uint32_t reg_ctrl;
 	uint32_t reg_val;
 	uint32_t reg_val_txsr;

--- a/drivers/ethernet/eth_xlnx_gem_priv.h
+++ b/drivers/ethernet/eth_xlnx_gem_priv.h
@@ -410,12 +410,6 @@
 #define ETH_XLNX_GEM_PHY_MAINT_REGISTER_ID_SHIFT	18
 #define ETH_XLNX_GEM_PHY_MAINT_DATA_MASK		0x0000FFFF
 
-/* Device configuration / run-time data resolver macros */
-#define DEV_CFG(dev) \
-	((const struct eth_xlnx_gem_dev_cfg * const)(dev->config))
-#define DEV_DATA(dev) \
-	((struct eth_xlnx_gem_dev_data *)(dev->data))
-
 /* Device initialization macro */
 #define ETH_XLNX_GEM_NET_DEV_INIT(port) \
 ETH_NET_DEVICE_DT_INST_DEFINE(port,\

--- a/drivers/ethernet/phy/phy_mii.c
+++ b/drivers/ethernet/phy/phy_mii.c
@@ -35,9 +35,6 @@ struct phy_mii_dev_data {
 };
 
 #define DEV_NAME(dev) ((dev)->name)
-#define DEV_DATA(dev) ((struct phy_mii_dev_data *const)(dev)->data)
-#define DEV_CFG(dev) \
-	((const struct phy_mii_dev_config *const)(dev)->config)
 
 static int phy_mii_get_link_state(const struct device *dev,
 				  struct phy_link_state *state);
@@ -45,7 +42,7 @@ static int phy_mii_get_link_state(const struct device *dev,
 static inline int reg_read(const struct device *dev, uint16_t reg_addr,
 			   uint16_t *value)
 {
-	const struct phy_mii_dev_config *const cfg = DEV_CFG(dev);
+	const struct phy_mii_dev_config *const cfg = dev->config;
 
 	return mdio_read(cfg->mdio, cfg->phy_addr, reg_addr, value);
 }
@@ -53,7 +50,7 @@ static inline int reg_read(const struct device *dev, uint16_t reg_addr,
 static inline int reg_write(const struct device *dev, uint16_t reg_addr,
 			    uint16_t value)
 {
-	const struct phy_mii_dev_config *const cfg = DEV_CFG(dev);
+	const struct phy_mii_dev_config *const cfg = dev->config;
 
 	return mdio_write(cfg->mdio, cfg->phy_addr, reg_addr, value);
 }
@@ -108,8 +105,8 @@ static int get_id(const struct device *dev, uint32_t *phy_id)
 
 static int update_link_state(const struct device *dev)
 {
-	const struct phy_mii_dev_config *const cfg = DEV_CFG(dev);
-	struct phy_mii_dev_data *const data = DEV_DATA(dev);
+	const struct phy_mii_dev_config *const cfg = dev->config;
+	struct phy_mii_dev_data *const data = dev->data;
 	bool link_up;
 
 	uint16_t anar_reg = 0;
@@ -203,7 +200,7 @@ static int update_link_state(const struct device *dev)
 
 static void invoke_link_cb(const struct device *dev)
 {
-	struct phy_mii_dev_data *const data = DEV_DATA(dev);
+	struct phy_mii_dev_data *const data = dev->data;
 	struct phy_link_state state;
 
 	if (data->cb == NULL) {
@@ -300,7 +297,7 @@ static int phy_mii_cfg_link(const struct device *dev,
 static int phy_mii_get_link_state(const struct device *dev,
 				  struct phy_link_state *state)
 {
-	struct phy_mii_dev_data *const data = DEV_DATA(dev);
+	struct phy_mii_dev_data *const data = dev->data;
 
 	k_sem_take(&data->sem, K_FOREVER);
 
@@ -314,7 +311,7 @@ static int phy_mii_get_link_state(const struct device *dev,
 static int phy_mii_link_cb_set(const struct device *dev, phy_callback_t cb,
 			       void *user_data)
 {
-	struct phy_mii_dev_data *const data = DEV_DATA(dev);
+	struct phy_mii_dev_data *const data = dev->data;
 
 	data->cb = cb;
 	data->cb_data = user_data;
@@ -330,8 +327,8 @@ static int phy_mii_link_cb_set(const struct device *dev, phy_callback_t cb,
 
 static int phy_mii_initialize(const struct device *dev)
 {
-	const struct phy_mii_dev_config *const cfg = DEV_CFG(dev);
-	struct phy_mii_dev_data *const data = DEV_DATA(dev);
+	const struct phy_mii_dev_config *const cfg = dev->config;
+	struct phy_mii_dev_data *const data = dev->data;
 	uint32_t phy_id;
 
 	k_sem_init(&data->sem, 1, 1);

--- a/drivers/ethernet/phy_xlnx_gem.c
+++ b/drivers/ethernet/phy_xlnx_gem.c
@@ -192,8 +192,8 @@ static void phy_xlnx_gem_mdio_write(
  */
 static void phy_xlnx_gem_marvell_alaska_reset(const struct device *dev)
 {
-	const struct eth_xlnx_gem_dev_cfg *dev_conf = DEV_CFG(dev);
-	struct eth_xlnx_gem_dev_data *dev_data = DEV_DATA(dev);
+	const struct eth_xlnx_gem_dev_cfg *dev_conf = dev->config;
+	struct eth_xlnx_gem_dev_data *dev_data = dev->data;
 	uint16_t phy_data;
 	uint32_t retries = 0;
 
@@ -227,8 +227,8 @@ static void phy_xlnx_gem_marvell_alaska_reset(const struct device *dev)
  */
 static void phy_xlnx_gem_marvell_alaska_cfg(const struct device *dev)
 {
-	const struct eth_xlnx_gem_dev_cfg *dev_conf = DEV_CFG(dev);
-	struct eth_xlnx_gem_dev_data *dev_data = DEV_DATA(dev);
+	const struct eth_xlnx_gem_dev_cfg *dev_conf = dev->config;
+	struct eth_xlnx_gem_dev_data *dev_data = dev->data;
 	uint16_t phy_data;
 	uint16_t phy_data_gbit;
 	uint32_t retries = 0;
@@ -482,8 +482,8 @@ static void phy_xlnx_gem_marvell_alaska_cfg(const struct device *dev)
  */
 static uint16_t phy_xlnx_gem_marvell_alaska_poll_sc(const struct device *dev)
 {
-	const struct eth_xlnx_gem_dev_cfg *dev_conf = DEV_CFG(dev);
-	struct eth_xlnx_gem_dev_data *dev_data = DEV_DATA(dev);
+	const struct eth_xlnx_gem_dev_cfg *dev_conf = dev->config;
+	struct eth_xlnx_gem_dev_data *dev_data = dev->data;
 	uint16_t phy_data;
 	uint16_t phy_status = 0;
 
@@ -530,8 +530,8 @@ static uint16_t phy_xlnx_gem_marvell_alaska_poll_sc(const struct device *dev)
  */
 static uint8_t phy_xlnx_gem_marvell_alaska_poll_lsts(const struct device *dev)
 {
-	const struct eth_xlnx_gem_dev_cfg *dev_conf = DEV_CFG(dev);
-	struct eth_xlnx_gem_dev_data *dev_data = DEV_DATA(dev);
+	const struct eth_xlnx_gem_dev_cfg *dev_conf = dev->config;
+	struct eth_xlnx_gem_dev_data *dev_data = dev->data;
 	uint16_t phy_data;
 
 	/*
@@ -555,8 +555,8 @@ static uint8_t phy_xlnx_gem_marvell_alaska_poll_lsts(const struct device *dev)
 static enum eth_xlnx_link_speed phy_xlnx_gem_marvell_alaska_poll_lspd(
 	const struct device *dev)
 {
-	const struct eth_xlnx_gem_dev_cfg *dev_conf = DEV_CFG(dev);
-	struct eth_xlnx_gem_dev_data *dev_data  = DEV_DATA(dev);
+	const struct eth_xlnx_gem_dev_cfg *dev_conf = dev->config;
+	struct eth_xlnx_gem_dev_data *dev_data  = dev->data;
 	enum eth_xlnx_link_speed link_speed;
 	uint16_t phy_data;
 
@@ -610,8 +610,8 @@ static enum eth_xlnx_link_speed phy_xlnx_gem_marvell_alaska_poll_lspd(
  */
 static void phy_xlnx_gem_ti_dp83822_reset(const struct device *dev)
 {
-	const struct eth_xlnx_gem_dev_cfg *dev_conf = DEV_CFG(dev);
-	struct eth_xlnx_gem_dev_data *dev_data = DEV_DATA(dev);
+	const struct eth_xlnx_gem_dev_cfg *dev_conf = dev->config;
+	struct eth_xlnx_gem_dev_data *dev_data = dev->data;
 	uint16_t phy_data;
 	uint32_t retries = 0;
 
@@ -639,8 +639,8 @@ static void phy_xlnx_gem_ti_dp83822_reset(const struct device *dev)
  */
 static void phy_xlnx_gem_ti_dp83822_cfg(const struct device *dev)
 {
-	const struct eth_xlnx_gem_dev_cfg *dev_conf = DEV_CFG(dev);
-	struct eth_xlnx_gem_dev_data *dev_data = DEV_DATA(dev);
+	const struct eth_xlnx_gem_dev_cfg *dev_conf = dev->config;
+	struct eth_xlnx_gem_dev_data *dev_data = dev->data;
 	uint16_t phy_data = PHY_TI_ADV_SELECTOR_802_3;
 
 	/* Configure link advertisement */
@@ -721,8 +721,8 @@ static void phy_xlnx_gem_ti_dp83822_cfg(const struct device *dev)
  */
 static uint16_t phy_xlnx_gem_ti_dp83822_poll_sc(const struct device *dev)
 {
-	const struct eth_xlnx_gem_dev_cfg *dev_conf = DEV_CFG(dev);
-	struct eth_xlnx_gem_dev_data *dev_data = DEV_DATA(dev);
+	const struct eth_xlnx_gem_dev_cfg *dev_conf = dev->config;
+	struct eth_xlnx_gem_dev_data *dev_data = dev->data;
 	uint16_t phy_data;
 	uint16_t phy_status = 0;
 
@@ -761,8 +761,8 @@ static uint16_t phy_xlnx_gem_ti_dp83822_poll_sc(const struct device *dev)
  */
 static uint8_t phy_xlnx_gem_ti_dp83822_poll_lsts(const struct device *dev)
 {
-	const struct eth_xlnx_gem_dev_cfg *dev_conf = DEV_CFG(dev);
-	struct eth_xlnx_gem_dev_data *dev_data = DEV_DATA(dev);
+	const struct eth_xlnx_gem_dev_cfg *dev_conf = dev->config;
+	struct eth_xlnx_gem_dev_data *dev_data = dev->data;
 	uint16_t phy_data;
 
 	/*
@@ -789,8 +789,8 @@ static uint8_t phy_xlnx_gem_ti_dp83822_poll_lsts(const struct device *dev)
 static enum eth_xlnx_link_speed phy_xlnx_gem_ti_dp83822_poll_lspd(
 	const struct device *dev)
 {
-	const struct eth_xlnx_gem_dev_cfg *dev_conf = DEV_CFG(dev);
-	struct eth_xlnx_gem_dev_data *dev_data = DEV_DATA(dev);
+	const struct eth_xlnx_gem_dev_cfg *dev_conf = dev->config;
+	struct eth_xlnx_gem_dev_data *dev_data = dev->data;
 	enum eth_xlnx_link_speed link_speed;
 	uint16_t phy_data;
 
@@ -893,8 +893,8 @@ static struct phy_xlnx_gem_supported_dev phy_xlnx_gem_supported_devs[] = {
  */
 int phy_xlnx_gem_detect(const struct device *dev)
 {
-	const struct eth_xlnx_gem_dev_cfg *dev_conf = DEV_CFG(dev);
-	struct eth_xlnx_gem_dev_data *dev_data = DEV_DATA(dev);
+	const struct eth_xlnx_gem_dev_cfg *dev_conf = dev->config;
+	struct eth_xlnx_gem_dev_data *dev_data = dev->data;
 
 	uint8_t phy_curr_addr;
 	uint8_t phy_first_addr = dev_conf->phy_mdio_addr_fix;

--- a/drivers/flash/flash_gecko.c
+++ b/drivers/flash/flash_gecko.c
@@ -31,8 +31,6 @@ static const struct flash_parameters flash_gecko_parameters = {
 };
 
 #define DEV_NAME(dev) ((dev)->name)
-#define DEV_DATA(dev) \
-	((struct flash_gecko_data *const)(dev)->data)
 
 static bool write_range_is_valid(off_t offset, uint32_t size);
 static bool read_range_is_valid(off_t offset, uint32_t size);
@@ -59,7 +57,7 @@ static int flash_gecko_read(const struct device *dev, off_t offset,
 static int flash_gecko_write(const struct device *dev, off_t offset,
 			     const void *data, size_t size)
 {
-	struct flash_gecko_data *const dev_data = DEV_DATA(dev);
+	struct flash_gecko_data *const dev_data = dev->data;
 	MSC_Status_TypeDef msc_ret;
 	void *address;
 	int ret = 0;
@@ -90,7 +88,7 @@ static int flash_gecko_write(const struct device *dev, off_t offset,
 static int flash_gecko_erase(const struct device *dev, off_t offset,
 			     size_t size)
 {
-	struct flash_gecko_data *const dev_data = DEV_DATA(dev);
+	struct flash_gecko_data *const dev_data = dev->data;
 	int ret;
 
 	if (!read_range_is_valid(offset, size)) {
@@ -197,7 +195,7 @@ flash_gecko_get_parameters(const struct device *dev)
 
 static int flash_gecko_init(const struct device *dev)
 {
-	struct flash_gecko_data *const dev_data = DEV_DATA(dev);
+	struct flash_gecko_data *const dev_data = dev->data;
 
 	k_sem_init(&dev_data->mutex, 1, 1);
 

--- a/drivers/flash/flash_ite_it8xxx2.c
+++ b/drivers/flash/flash_ite_it8xxx2.c
@@ -32,9 +32,6 @@ extern char _ram_code_start;
 #define FLASH_IT8XXX2_REG_BASE \
 		((struct flash_it8xxx2_regs *)DT_INST_REG_ADDR(0))
 
-#define DEV_DATA(dev) \
-	((struct flash_it8xxx2_dev_data *const)(dev)->data)
-
 struct flash_it8xxx2_dev_data {
 	struct k_sem sem;
 	int all_protected;
@@ -411,7 +408,7 @@ static int __ram_code flash_it8xxx2_read(const struct device *dev, off_t offset,
 static int __ram_code flash_it8xxx2_write(const struct device *dev, off_t offset,
 					  const void *src_data, size_t len)
 {
-	struct flash_it8xxx2_dev_data *data = DEV_DATA(dev);
+	struct flash_it8xxx2_dev_data *data = dev->data;
 	int ret = -EINVAL;
 	unsigned int key;
 
@@ -457,7 +454,7 @@ static int __ram_code flash_it8xxx2_write(const struct device *dev, off_t offset
 static int __ram_code flash_it8xxx2_erase(const struct device *dev,
 					  off_t offset, size_t len)
 {
-	struct flash_it8xxx2_dev_data *data = DEV_DATA(dev);
+	struct flash_it8xxx2_dev_data *data = dev->data;
 	int v_size = len, v_addr = offset, ret = -EINVAL;
 	unsigned int key;
 
@@ -507,7 +504,7 @@ static int __ram_code flash_it8xxx2_erase(const struct device *dev,
 static int flash_it8xxx2_write_protection(const struct device *dev,
 					  bool enable)
 {
-	struct flash_it8xxx2_dev_data *data = DEV_DATA(dev);
+	struct flash_it8xxx2_dev_data *data = dev->data;
 
 	if (enable) {
 		/* Protect the entire flash */
@@ -538,7 +535,7 @@ flash_it8xxx2_get_parameters(const struct device *dev)
 static void flash_code_static_cache(const struct device *dev)
 {
 	struct flash_it8xxx2_regs *const flash_regs = FLASH_IT8XXX2_REG_BASE;
-	struct flash_it8xxx2_dev_data *data = DEV_DATA(dev);
+	struct flash_it8xxx2_dev_data *data = dev->data;
 	unsigned int key;
 
 	/* Make sure no interrupt while enable static cache */
@@ -574,7 +571,7 @@ static void flash_code_static_cache(const struct device *dev)
 static int flash_it8xxx2_init(const struct device *dev)
 {
 	struct flash_it8xxx2_regs *const flash_regs = FLASH_IT8XXX2_REG_BASE;
-	struct flash_it8xxx2_dev_data *data = DEV_DATA(dev);
+	struct flash_it8xxx2_dev_data *data = dev->data;
 
 	/* By default, select internal flash for indirect fast read. */
 	flash_regs->SMFI_ECINDAR3 = EC_INDIRECT_READ_INTERNAL_FLASH;

--- a/drivers/flash/flash_sam.c
+++ b/drivers/flash/flash_sam.c
@@ -51,22 +51,20 @@ static const struct flash_parameters flash_sam_parameters = {
 	.erase_value = 0xff,
 };
 
-#define DEV_CFG(dev) \
-	((const struct flash_sam_dev_cfg *const)(dev)->config)
-
-#define DEV_DATA(dev) \
-	((struct flash_sam_dev_data *const)(dev)->data)
-
 static int flash_sam_write_protection(const struct device *dev, bool enable);
 
 static inline void flash_sam_sem_take(const struct device *dev)
 {
-	k_sem_take(&DEV_DATA(dev)->sem, K_FOREVER);
+	struct flash_sam_dev_data *data = dev->data;
+
+	k_sem_take(&data->sem, K_FOREVER);
 }
 
 static inline void flash_sam_sem_give(const struct device *dev)
 {
-	k_sem_give(&DEV_DATA(dev)->sem);
+	struct flash_sam_dev_data *data = dev->data;
+
+	k_sem_give(&data->sem);
 }
 
 /* Check that the offset is within the flash */
@@ -96,7 +94,9 @@ static off_t flash_sam_get_page(off_t offset)
  */
 static int flash_sam_wait_ready(const struct device *dev)
 {
-	Efc *const efc = DEV_CFG(dev)->regs;
+	const struct flash_sam_dev_cfg *config = dev->config;
+
+	Efc *const efc = config->regs;
 
 	uint64_t timeout_time = k_uptime_get() + SAM_FLASH_TIMEOUT_MS;
 	uint32_t fsr;
@@ -135,7 +135,9 @@ static int flash_sam_wait_ready(const struct device *dev)
 static int flash_sam_write_page(const struct device *dev, off_t offset,
 				const void *data, size_t len)
 {
-	Efc *const efc = DEV_CFG(dev)->regs;
+	const struct flash_sam_dev_cfg *config = dev->config;
+
+	Efc *const efc = config->regs;
 	const uint32_t *src = data;
 	uint32_t *dst = (uint32_t *)((uint8_t *)CONFIG_FLASH_BASE_ADDRESS + offset);
 
@@ -242,7 +244,9 @@ static int flash_sam_read(const struct device *dev, off_t offset, void *data,
 /* Erase a single 8KiB block */
 static int flash_sam_erase_block(const struct device *dev, off_t offset)
 {
-	Efc *const efc = DEV_CFG(dev)->regs;
+	const struct flash_sam_dev_cfg *config = dev->config;
+
+	Efc *const efc = config->regs;
 
 	LOG_DBG("offset = 0x%lx", (long)offset);
 
@@ -314,7 +318,9 @@ static int flash_sam_erase(const struct device *dev, off_t offset, size_t len)
 /* Enable or disable the write protection */
 static int flash_sam_write_protection(const struct device *dev, bool enable)
 {
-	Efc *const efc = DEV_CFG(dev)->regs;
+	const struct flash_sam_dev_cfg *config = dev->config;
+
+	Efc *const efc = config->regs;
 	int rc = 0;
 
 	if (enable) {
@@ -360,7 +366,7 @@ flash_sam_get_parameters(const struct device *dev)
 
 static int flash_sam_init(const struct device *dev)
 {
-	struct flash_sam_dev_data *const data = DEV_DATA(dev);
+	struct flash_sam_dev_data *const data = dev->data;
 
 	k_sem_init(&data->sem, 1, 1);
 

--- a/drivers/flash/flash_sam.c
+++ b/drivers/flash/flash_sam.c
@@ -96,7 +96,7 @@ static int flash_sam_wait_ready(const struct device *dev)
 {
 	const struct flash_sam_dev_cfg *config = dev->config;
 
-	Efc *const efc = config->regs;
+	Efc * const efc = config->regs;
 
 	uint64_t timeout_time = k_uptime_get() + SAM_FLASH_TIMEOUT_MS;
 	uint32_t fsr;
@@ -137,7 +137,7 @@ static int flash_sam_write_page(const struct device *dev, off_t offset,
 {
 	const struct flash_sam_dev_cfg *config = dev->config;
 
-	Efc *const efc = config->regs;
+	Efc * const efc = config->regs;
 	const uint32_t *src = data;
 	uint32_t *dst = (uint32_t *)((uint8_t *)CONFIG_FLASH_BASE_ADDRESS + offset);
 
@@ -246,7 +246,7 @@ static int flash_sam_erase_block(const struct device *dev, off_t offset)
 {
 	const struct flash_sam_dev_cfg *config = dev->config;
 
-	Efc *const efc = config->regs;
+	Efc * const efc = config->regs;
 
 	LOG_DBG("offset = 0x%lx", (long)offset);
 
@@ -320,7 +320,7 @@ static int flash_sam_write_protection(const struct device *dev, bool enable)
 {
 	const struct flash_sam_dev_cfg *config = dev->config;
 
-	Efc *const efc = config->regs;
+	Efc * const efc = config->regs;
 	int rc = 0;
 
 	if (enable) {

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -106,21 +106,17 @@ struct flash_stm32_qspi_data {
 };
 
 #define DEV_NAME(dev) ((dev)->name)
-#define DEV_CFG(dev) \
-	(const struct flash_stm32_qspi_config * const)(dev->config)
-#define DEV_DATA(dev) \
-	(struct flash_stm32_qspi_data * const)(dev->data)
 
 static inline void qspi_lock_thread(const struct device *dev)
 {
-	struct flash_stm32_qspi_data *dev_data = DEV_DATA(dev);
+	struct flash_stm32_qspi_data *dev_data = dev->data;
 
 	k_sem_take(&dev_data->sem, K_FOREVER);
 }
 
 static inline void qspi_unlock_thread(const struct device *dev)
 {
-	struct flash_stm32_qspi_data *dev_data = DEV_DATA(dev);
+	struct flash_stm32_qspi_data *dev_data = dev->data;
 
 	k_sem_give(&dev_data->sem);
 }
@@ -128,7 +124,7 @@ static inline void qspi_unlock_thread(const struct device *dev)
 static inline void qspi_set_address_size(const struct device *dev,
 					 QSPI_CommandTypeDef *cmd)
 {
-	struct flash_stm32_qspi_data *dev_data = DEV_DATA(dev);
+	struct flash_stm32_qspi_data *dev_data = dev->data;
 
 	if (dev_data->flag_access_32bit) {
 		cmd->AddressSize = QSPI_ADDRESS_32_BITS;
@@ -141,7 +137,7 @@ static inline void qspi_set_address_size(const struct device *dev,
 static inline void qspi_prepare_quad_read(const struct device *dev,
 					  QSPI_CommandTypeDef *cmd)
 {
-	struct flash_stm32_qspi_data *dev_data = DEV_DATA(dev);
+	struct flash_stm32_qspi_data *dev_data = dev->data;
 
 	if (IS_ENABLED(STM32_QSPI_USE_QUAD_IO) && dev_data->flag_quad_io_en) {
 		cmd->Instruction = dev_data->qspi_read_cmd;
@@ -154,7 +150,7 @@ static inline void qspi_prepare_quad_read(const struct device *dev,
 static inline void qspi_prepare_quad_program(const struct device *dev,
 					     QSPI_CommandTypeDef *cmd)
 {
-	struct flash_stm32_qspi_data *dev_data = DEV_DATA(dev);
+	struct flash_stm32_qspi_data *dev_data = dev->data;
 	/*
 	 * There is no info about PP/4PP command in the SFDP tables,
 	 * hence it has been assumed that NOR flash memory supporting
@@ -177,8 +173,8 @@ static inline void qspi_prepare_quad_program(const struct device *dev,
  */
 static int qspi_send_cmd(const struct device *dev, QSPI_CommandTypeDef *cmd)
 {
-	const struct flash_stm32_qspi_config *dev_cfg = DEV_CFG(dev);
-	struct flash_stm32_qspi_data *dev_data = DEV_DATA(dev);
+	const struct flash_stm32_qspi_config *dev_cfg = dev->config;
+	struct flash_stm32_qspi_data *dev_data = dev->data;
 	HAL_StatusTypeDef hal_ret;
 
 	ARG_UNUSED(dev_cfg);
@@ -205,8 +201,8 @@ static int qspi_send_cmd(const struct device *dev, QSPI_CommandTypeDef *cmd)
 static int qspi_read_access(const struct device *dev, QSPI_CommandTypeDef *cmd,
 			    uint8_t *data, size_t size)
 {
-	const struct flash_stm32_qspi_config *dev_cfg = DEV_CFG(dev);
-	struct flash_stm32_qspi_data *dev_data = DEV_DATA(dev);
+	const struct flash_stm32_qspi_config *dev_cfg = dev->config;
+	struct flash_stm32_qspi_data *dev_data = dev->data;
 	HAL_StatusTypeDef hal_ret;
 
 	ARG_UNUSED(dev_cfg);
@@ -242,8 +238,8 @@ static int qspi_read_access(const struct device *dev, QSPI_CommandTypeDef *cmd,
 static int qspi_write_access(const struct device *dev, QSPI_CommandTypeDef *cmd,
 			     const uint8_t *data, size_t size)
 {
-	const struct flash_stm32_qspi_config *dev_cfg = DEV_CFG(dev);
-	struct flash_stm32_qspi_data *dev_data = DEV_DATA(dev);
+	const struct flash_stm32_qspi_config *dev_cfg = dev->config;
+	struct flash_stm32_qspi_data *dev_data = dev->data;
 	HAL_StatusTypeDef hal_ret;
 
 	ARG_UNUSED(dev_cfg);
@@ -298,7 +294,7 @@ static int qspi_read_sfdp(const struct device *dev, off_t addr, uint8_t *data,
 static bool qspi_address_is_valid(const struct device *dev, off_t addr,
 				  size_t size)
 {
-	const struct flash_stm32_qspi_config *dev_cfg = DEV_CFG(dev);
+	const struct flash_stm32_qspi_config *dev_cfg = dev->config;
 	size_t flash_size = dev_cfg->flash_size;
 
 	return (addr >= 0) && ((uint64_t)addr + (uint64_t)size <= flash_size);
@@ -423,8 +419,8 @@ static int flash_stm32_qspi_write(const struct device *dev, off_t addr,
 static int flash_stm32_qspi_erase(const struct device *dev, off_t addr,
 				  size_t size)
 {
-	const struct flash_stm32_qspi_config *dev_cfg = DEV_CFG(dev);
-	struct flash_stm32_qspi_data *dev_data = DEV_DATA(dev);
+	const struct flash_stm32_qspi_config *dev_cfg = dev->config;
+	struct flash_stm32_qspi_data *dev_data = dev->data;
 	int ret = 0;
 
 	if (!qspi_address_is_valid(dev, addr, size)) {
@@ -509,7 +505,7 @@ flash_stm32_qspi_get_parameters(const struct device *dev)
 
 static void flash_stm32_qspi_isr(const struct device *dev)
 {
-	struct flash_stm32_qspi_data *dev_data = DEV_DATA(dev);
+	struct flash_stm32_qspi_data *dev_data = dev->data;
 
 	HAL_QSPI_IRQHandler(&dev_data->hqspi);
 }
@@ -614,7 +610,7 @@ static void flash_stm32_qspi_pages_layout(const struct device *dev,
 				const struct flash_pages_layout **layout,
 				size_t *layout_size)
 {
-	struct flash_stm32_qspi_data *dev_data = DEV_DATA(dev);
+	struct flash_stm32_qspi_data *dev_data = dev->data;
 
 	*layout = &dev_data->layout;
 	*layout_size = 1;
@@ -634,8 +630,8 @@ static const struct flash_driver_api flash_stm32_qspi_driver_api = {
 #if defined(CONFIG_FLASH_PAGE_LAYOUT)
 static int setup_pages_layout(const struct device *dev)
 {
-	const struct flash_stm32_qspi_config *dev_cfg = DEV_CFG(dev);
-	struct flash_stm32_qspi_data *data = DEV_DATA(dev);
+	const struct flash_stm32_qspi_config *dev_cfg = dev->config;
+	struct flash_stm32_qspi_data *data = dev->data;
 	const size_t flash_size = dev_cfg->flash_size;
 	uint32_t layout_page_size = data->page_size;
 	uint8_t exp = 0;
@@ -760,7 +756,7 @@ static int qspi_write_enable(const struct device *dev)
 
 static int qspi_program_quad_io(const struct device *dev)
 {
-	struct flash_stm32_qspi_data *data = DEV_DATA(dev);
+	struct flash_stm32_qspi_data *data = dev->data;
 	uint8_t reg;
 	int ret;
 
@@ -813,8 +809,8 @@ static int spi_nor_process_bfp(const struct device *dev,
 			       const struct jesd216_param_header *php,
 			       const struct jesd216_bfp *bfp)
 {
-	const struct flash_stm32_qspi_config *dev_cfg = DEV_CFG(dev);
-	struct flash_stm32_qspi_data *data = DEV_DATA(dev);
+	const struct flash_stm32_qspi_config *dev_cfg = dev->config;
+	struct flash_stm32_qspi_data *data = dev->data;
 	struct jesd216_erase_type *etp = data->erase_types;
 	const size_t flash_size = jesd216_bfp_density(bfp) / 8U;
 	uint8_t addr_mode;
@@ -902,7 +898,7 @@ static int spi_nor_process_bfp(const struct device *dev,
 #if STM32_QSPI_RESET_GPIO
 static void flash_stm32_qspi_gpio_reset(const struct device *dev)
 {
-	const struct flash_stm32_qspi_config *dev_cfg = DEV_CFG(dev);
+	const struct flash_stm32_qspi_config *dev_cfg = dev->config;
 
 	/* Generate RESETn pulse for the flash memory */
 	gpio_pin_configure_dt(&dev_cfg->reset, GPIO_OUTPUT_ACTIVE);
@@ -913,8 +909,8 @@ static void flash_stm32_qspi_gpio_reset(const struct device *dev)
 
 static int flash_stm32_qspi_init(const struct device *dev)
 {
-	const struct flash_stm32_qspi_config *dev_cfg = DEV_CFG(dev);
-	struct flash_stm32_qspi_data *dev_data = DEV_DATA(dev);
+	const struct flash_stm32_qspi_config *dev_cfg = dev->config;
+	struct flash_stm32_qspi_data *dev_data = dev->data;
 	uint32_t ahb_clock_freq;
 	uint32_t prescaler = 0;
 	int ret;

--- a/drivers/gpio/gpio_b91.c
+++ b/drivers/gpio/gpio_b91.c
@@ -18,9 +18,6 @@
 #define GET_GPIO(dev)           ((volatile struct gpio_b91_t *)	\
 				 ((const struct gpio_b91_config *)dev->config)->gpio_base)
 
-/* Get GPIO configuration */
-#define GET_CFG(dev)            ((const struct gpio_b91_config *)dev->config)
-
 /* Get GPIO IRQ number defined in dts */
 #define GET_IRQ_NUM(dev)        (((const struct gpio_b91_config *)dev->config)->irq_num)
 
@@ -298,7 +295,7 @@ static void gpio_b91_config_in_out(volatile struct gpio_b91_t *gpio,
 /* GPIO driver initialization */
 static int gpio_b91_init(const struct device *dev)
 {
-	const struct gpio_b91_config *cfg = GET_CFG(dev);
+	const struct gpio_b91_config *cfg = dev->config;
 
 	cfg->pirq_connect();
 

--- a/drivers/gpio/gpio_cc32xx.c
+++ b/drivers/gpio/gpio_cc32xx.c
@@ -59,11 +59,6 @@ struct gpio_cc32xx_data {
 	sys_slist_t callbacks;
 };
 
-#define DEV_CFG(dev) \
-	((const struct gpio_cc32xx_config *)(dev)->config)
-#define DEV_DATA(dev) \
-	((struct gpio_cc32xx_data *)(dev)->data)
-
 static int gpio_cc32xx_port_set_bits_raw(const struct device *port,
 					 uint32_t mask);
 static int gpio_cc32xx_port_clear_bits_raw(const struct device *port,
@@ -73,7 +68,7 @@ static inline int gpio_cc32xx_config(const struct device *port,
 				     gpio_pin_t pin,
 				     gpio_flags_t flags)
 {
-	const struct gpio_cc32xx_config *gpio_config = DEV_CFG(port);
+	const struct gpio_cc32xx_config *gpio_config = port->config;
 	unsigned long port_base = gpio_config->port_base;
 
 	if (((flags & GPIO_INPUT) != 0) && ((flags & GPIO_OUTPUT) != 0)) {
@@ -107,7 +102,7 @@ static inline int gpio_cc32xx_config(const struct device *port,
 static int gpio_cc32xx_port_get_raw(const struct device *port,
 				    uint32_t *value)
 {
-	const struct gpio_cc32xx_config *gpio_config = DEV_CFG(port);
+	const struct gpio_cc32xx_config *gpio_config = port->config;
 	unsigned long port_base = gpio_config->port_base;
 	unsigned char pin_packed = 0xFF;
 
@@ -120,7 +115,7 @@ static int gpio_cc32xx_port_set_masked_raw(const struct device *port,
 					   uint32_t mask,
 					   uint32_t value)
 {
-	const struct gpio_cc32xx_config *gpio_config = DEV_CFG(port);
+	const struct gpio_cc32xx_config *gpio_config = port->config;
 	unsigned long port_base = gpio_config->port_base;
 
 	MAP_GPIOPinWrite(port_base, (unsigned char)mask, (unsigned char)value);
@@ -131,7 +126,7 @@ static int gpio_cc32xx_port_set_masked_raw(const struct device *port,
 static int gpio_cc32xx_port_set_bits_raw(const struct device *port,
 					 uint32_t mask)
 {
-	const struct gpio_cc32xx_config *gpio_config = DEV_CFG(port);
+	const struct gpio_cc32xx_config *gpio_config = port->config;
 	unsigned long port_base = gpio_config->port_base;
 
 	MAP_GPIOPinWrite(port_base, (unsigned char)mask, (unsigned char)mask);
@@ -142,7 +137,7 @@ static int gpio_cc32xx_port_set_bits_raw(const struct device *port,
 static int gpio_cc32xx_port_clear_bits_raw(const struct device *port,
 					   uint32_t mask)
 {
-	const struct gpio_cc32xx_config *gpio_config = DEV_CFG(port);
+	const struct gpio_cc32xx_config *gpio_config = port->config;
 	unsigned long port_base = gpio_config->port_base;
 
 	MAP_GPIOPinWrite(port_base, (unsigned char)mask, (unsigned char)~mask);
@@ -153,7 +148,7 @@ static int gpio_cc32xx_port_clear_bits_raw(const struct device *port,
 static int gpio_cc32xx_port_toggle_bits(const struct device *port,
 					uint32_t mask)
 {
-	const struct gpio_cc32xx_config *gpio_config = DEV_CFG(port);
+	const struct gpio_cc32xx_config *gpio_config = port->config;
 	unsigned long port_base = gpio_config->port_base;
 	long value;
 
@@ -170,7 +165,7 @@ static int gpio_cc32xx_pin_interrupt_configure(const struct device *port,
 					       enum gpio_int_mode mode,
 					       enum gpio_int_trig trig)
 {
-	const struct gpio_cc32xx_config *gpio_config = DEV_CFG(port);
+	const struct gpio_cc32xx_config *gpio_config = port->config;
 	unsigned long port_base = gpio_config->port_base;
 	unsigned long int_type;
 
@@ -212,15 +207,15 @@ static int gpio_cc32xx_manage_callback(const struct device *dev,
 				       struct gpio_callback *callback,
 				       bool set)
 {
-	struct gpio_cc32xx_data *data = DEV_DATA(dev);
+	struct gpio_cc32xx_data *data = dev->data;
 
 	return gpio_manage_callback(&data->callbacks, callback, set);
 }
 
 static void gpio_cc32xx_port_isr(const struct device *dev)
 {
-	const struct gpio_cc32xx_config *config = DEV_CFG(dev);
-	struct gpio_cc32xx_data *data = DEV_DATA(dev);
+	const struct gpio_cc32xx_config *config = dev->config;
+	struct gpio_cc32xx_data *data = dev->data;
 	uint32_t int_status;
 
 	/* See which interrupts triggered: */

--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -33,8 +33,6 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(gpio_esp32, CONFIG_LOG_DEFAULT_LEVEL);
 
-#define DEV_CFG(_dev) ((struct gpio_esp32_config *const)(_dev)->config)
-
 #ifdef CONFIG_SOC_ESP32C3
 /* gpio structs in esp32c3 series are different from xtensa ones */
 #define out out.data
@@ -91,7 +89,7 @@ static int gpio_esp32_config(const struct device *dev,
 			     gpio_pin_t pin,
 			     gpio_flags_t flags)
 {
-	struct gpio_esp32_config *const cfg = DEV_CFG(dev);
+	struct gpio_esp32_config *const cfg = dev->config;
 	struct gpio_esp32_data *data = dev->data;
 	uint32_t io_pin = (uint32_t) pin;
 	uint32_t key;
@@ -208,7 +206,7 @@ end:
 
 static int gpio_esp32_port_get_raw(const struct device *port, uint32_t *value)
 {
-	struct gpio_esp32_config *const cfg = DEV_CFG(port);
+	struct gpio_esp32_config *const cfg = port->config;
 
 	if (cfg->gpio_port == 0) {
 		*value = cfg->gpio_dev->in;
@@ -224,7 +222,7 @@ static int gpio_esp32_port_get_raw(const struct device *port, uint32_t *value)
 static int gpio_esp32_port_set_masked_raw(const struct device *port,
 					  uint32_t mask, uint32_t value)
 {
-	struct gpio_esp32_config *const cfg = DEV_CFG(port);
+	struct gpio_esp32_config *const cfg = port->config;
 
 	uint32_t key = irq_lock();
 
@@ -244,7 +242,7 @@ static int gpio_esp32_port_set_masked_raw(const struct device *port,
 static int gpio_esp32_port_set_bits_raw(const struct device *port,
 					uint32_t pins)
 {
-	struct gpio_esp32_config *const cfg = DEV_CFG(port);
+	struct gpio_esp32_config *const cfg = port->config;
 
 	if (cfg->gpio_port == 0) {
 		cfg->gpio_dev->out_w1ts = pins;
@@ -260,7 +258,7 @@ static int gpio_esp32_port_set_bits_raw(const struct device *port,
 static int gpio_esp32_port_clear_bits_raw(const struct device *port,
 					  uint32_t pins)
 {
-	struct gpio_esp32_config *const cfg = DEV_CFG(port);
+	struct gpio_esp32_config *const cfg = port->config;
 
 	if (cfg->gpio_port == 0) {
 		cfg->gpio_dev->out_w1tc = pins;
@@ -276,7 +274,7 @@ static int gpio_esp32_port_clear_bits_raw(const struct device *port,
 static int gpio_esp32_port_toggle_bits(const struct device *port,
 				       uint32_t pins)
 {
-	struct gpio_esp32_config *const cfg = DEV_CFG(port);
+	struct gpio_esp32_config *const cfg = port->config;
 	uint32_t key = irq_lock();
 
 	if (cfg->gpio_port == 0) {
@@ -330,7 +328,7 @@ static int gpio_esp32_pin_interrupt_configure(const struct device *port,
 					      enum gpio_int_mode mode,
 					      enum gpio_int_trig trig)
 {
-	struct gpio_esp32_config *const cfg = DEV_CFG(port);
+	struct gpio_esp32_config *const cfg = port->config;
 	uint32_t io_pin = (uint32_t) pin;
 	int intr_trig_mode = convert_int_type(mode, trig);
 	uint32_t key;
@@ -358,7 +356,7 @@ static int gpio_esp32_manage_callback(const struct device *dev,
 
 static uint32_t gpio_esp32_get_pending_int(const struct device *dev)
 {
-	struct gpio_esp32_config *const cfg = DEV_CFG(dev);
+	struct gpio_esp32_config *const cfg = dev->config;
 	uint32_t irq_status;
 	uint32_t const core_id = CPU_ID();
 
@@ -373,7 +371,7 @@ static uint32_t gpio_esp32_get_pending_int(const struct device *dev)
 
 static void IRAM_ATTR gpio_esp32_fire_callbacks(const struct device *dev)
 {
-	struct gpio_esp32_config *const cfg = DEV_CFG(dev);
+	struct gpio_esp32_config *const cfg = dev->config;
 	struct gpio_esp32_data *data = dev->data;
 	uint32_t irq_status;
 	uint32_t const core_id = CPU_ID();

--- a/drivers/gpio/gpio_lpc11u6x.c
+++ b/drivers/gpio/gpio_lpc11u6x.c
@@ -23,11 +23,6 @@
 
 #include "gpio_utils.h"
 
-#define DEV_CFG(dev)  ((const struct gpio_lpc11u6x_config *) \
-		       ((dev)->config))
-#define DEV_DATA(dev) ((struct gpio_lpc11u6x_data *) \
-		       ((dev)->data))
-
 /* Offset from syscon base address. */
 #define LPC11U6X_PINTSEL_REGS	0x178
 
@@ -110,8 +105,8 @@ struct gpio_lpc11u6x_data {
 static int gpio_lpc11u6x_pin_configure(const struct device *port,
 				       gpio_pin_t pin, gpio_flags_t flags)
 {
-	const struct gpio_lpc11u6x_config *config = DEV_CFG(port);
-	struct gpio_lpc11u6x_data *data = DEV_DATA(port);
+	const struct gpio_lpc11u6x_config *config = port->config;
+	struct gpio_lpc11u6x_data *data = port->data;
 	struct lpc11u6x_gpio_regs *gpio_regs = (struct lpc11u6x_gpio_regs *)
 		(config->shared->gpio_base + LPC11U6X_GPIO_REGS);
 	uint8_t port_num = config->port_num;
@@ -187,7 +182,7 @@ static int gpio_lpc11u6x_pin_configure(const struct device *port,
 static int gpio_lpc11u6x_port_get_raw(const struct device *port,
 				      gpio_port_value_t *value)
 {
-	const struct gpio_lpc11u6x_config *config = DEV_CFG(port);
+	const struct gpio_lpc11u6x_config *config = port->config;
 	struct lpc11u6x_gpio_regs *gpio_regs = (struct lpc11u6x_gpio_regs *)
 		(config->shared->gpio_base + LPC11U6X_GPIO_REGS);
 
@@ -200,7 +195,7 @@ static int gpio_lpc11u6x_port_set_masked_raw(const struct device *port,
 					     gpio_port_pins_t mask,
 					     gpio_port_value_t value)
 {
-	const struct gpio_lpc11u6x_config *config = DEV_CFG(port);
+	const struct gpio_lpc11u6x_config *config = port->config;
 	struct lpc11u6x_gpio_regs *gpio_regs = (struct lpc11u6x_gpio_regs *)
 		(config->shared->gpio_base + LPC11U6X_GPIO_REGS);
 	uint8_t port_num = config->port_num;
@@ -223,7 +218,7 @@ static int gpio_lpc11u6x_port_set_masked_raw(const struct device *port,
 static int gpio_lpc11u6x_port_set_bits_raw(const struct device *port,
 					   gpio_port_pins_t pins)
 {
-	const struct gpio_lpc11u6x_config *config = DEV_CFG(port);
+	const struct gpio_lpc11u6x_config *config = port->config;
 	struct lpc11u6x_gpio_regs *gpio_regs = (struct lpc11u6x_gpio_regs *)
 		(config->shared->gpio_base + LPC11U6X_GPIO_REGS);
 
@@ -235,7 +230,7 @@ static int gpio_lpc11u6x_port_set_bits_raw(const struct device *port,
 static int gpio_lpc11u6x_port_clear_bits_raw(const struct device *port,
 					     gpio_port_pins_t pins)
 {
-	const struct gpio_lpc11u6x_config *config = DEV_CFG(port);
+	const struct gpio_lpc11u6x_config *config = port->config;
 	struct lpc11u6x_gpio_regs *gpio_regs = (struct lpc11u6x_gpio_regs *)
 		(config->shared->gpio_base + LPC11U6X_GPIO_REGS);
 
@@ -247,7 +242,7 @@ static int gpio_lpc11u6x_port_clear_bits_raw(const struct device *port,
 static int gpio_lpc11u6x_port_toggle_bits(const struct device *port,
 					  gpio_port_pins_t pins)
 {
-	const struct gpio_lpc11u6x_config *config = DEV_CFG(port);
+	const struct gpio_lpc11u6x_config *config = port->config;
 	struct lpc11u6x_gpio_regs *gpio_regs = (struct lpc11u6x_gpio_regs *)
 		(config->shared->gpio_base + LPC11U6X_GPIO_REGS);
 
@@ -323,7 +318,7 @@ static int gpio_lpc11u6x_pin_interrupt_configure(const struct device *port,
 						 enum gpio_int_mode mode,
 						 enum gpio_int_trig trig)
 {
-	const struct gpio_lpc11u6x_config *config = DEV_CFG(port);
+	const struct gpio_lpc11u6x_config *config = port->config;
 	struct lpc11u6x_pint_regs *pint_regs = (struct lpc11u6x_pint_regs *)
 		(config->shared->gpio_base + LPC11U6X_PINT_REGS);
 	uint8_t intpin;
@@ -406,7 +401,7 @@ static int gpio_lpc11u6x_pin_interrupt_configure(const struct device *port,
 static int gpio_lpc11u6x_manage_callback(const struct device *port,
 					 struct gpio_callback *cb, bool set)
 {
-	struct gpio_lpc11u6x_data *data = DEV_DATA(port);
+	struct gpio_lpc11u6x_data *data = port->data;
 
 	return gpio_manage_callback(&data->cb_list, cb, set);
 }
@@ -515,8 +510,8 @@ do {							                \
 
 static int gpio_lpc11u6x_init(const struct device *dev)
 {
-	const struct gpio_lpc11u6x_config *config = DEV_CFG(dev);
-	struct gpio_lpc11u6x_data *data = DEV_DATA(dev);
+	const struct gpio_lpc11u6x_config *config = dev->config;
+	struct gpio_lpc11u6x_data *data = dev->data;
 	const struct device *clock_dev;
 	int ret;
 	static bool gpio_ready;

--- a/drivers/gpio/gpio_mcp23xxx.c
+++ b/drivers/gpio/gpio_mcp23xxx.c
@@ -78,7 +78,7 @@ static int write_port_regs(const struct device *dev, uint8_t reg, uint16_t value
  */
 static int setup_pin_dir(const struct device *dev, uint32_t pin, int flags)
 {
-	struct mcp23xxx_drv_data *drv_data = (struct mcp23xxx_drv_data *)dev->data;
+	struct mcp23xxx_drv_data *drv_data = dev->data;
 	uint16_t dir = drv_data->reg_cache.iodir;
 	uint16_t output = drv_data->reg_cache.gpio;
 	int ret;
@@ -119,7 +119,7 @@ static int setup_pin_dir(const struct device *dev, uint32_t pin, int flags)
  */
 static int setup_pin_pull(const struct device *dev, uint32_t pin, int flags)
 {
-	struct mcp23xxx_drv_data *drv_data = (struct mcp23xxx_drv_data *)dev->data;
+	struct mcp23xxx_drv_data *drv_data = dev->data;
 	uint16_t port;
 	int ret;
 
@@ -141,7 +141,7 @@ static int setup_pin_pull(const struct device *dev, uint32_t pin, int flags)
 
 static int mcp23xxx_pin_cfg(const struct device *dev, gpio_pin_t pin, gpio_flags_t flags)
 {
-	struct mcp23xxx_drv_data *drv_data = (struct mcp23xxx_drv_data *)dev->data;
+	struct mcp23xxx_drv_data *drv_data = dev->data;
 	int ret;
 
 	if (k_is_in_isr()) {
@@ -174,7 +174,7 @@ done:
 
 static int mcp23xxx_port_get_raw(const struct device *dev, uint32_t *value)
 {
-	struct mcp23xxx_drv_data *drv_data = (struct mcp23xxx_drv_data *)dev->data;
+	struct mcp23xxx_drv_data *drv_data = dev->data;
 	uint16_t buf;
 	int ret;
 
@@ -195,7 +195,7 @@ static int mcp23xxx_port_get_raw(const struct device *dev, uint32_t *value)
 
 static int mcp23xxx_port_set_masked_raw(const struct device *dev, uint32_t mask, uint32_t value)
 {
-	struct mcp23xxx_drv_data *drv_data = (struct mcp23xxx_drv_data *)dev->data;
+	struct mcp23xxx_drv_data *drv_data = dev->data;
 	uint16_t buf;
 	int ret;
 
@@ -229,7 +229,7 @@ static int mcp23xxx_port_clear_bits_raw(const struct device *dev, uint32_t mask)
 
 static int mcp23xxx_port_toggle_bits(const struct device *dev, uint32_t mask)
 {
-	struct mcp23xxx_drv_data *drv_data = (struct mcp23xxx_drv_data *)dev->data;
+	struct mcp23xxx_drv_data *drv_data = dev->data;
 	uint16_t buf;
 	int ret;
 
@@ -277,7 +277,7 @@ const struct gpio_driver_api gpio_mcp23xxx_api_table = {
 int gpio_mcp23xxx_init(const struct device *dev)
 {
 	const struct mcp23xxx_config *config = dev->config;
-	struct mcp23xxx_drv_data *drv_data = (struct mcp23xxx_drv_data *)dev->data;
+	struct mcp23xxx_drv_data *drv_data = dev->data;
 	int err;
 
 	if (config->ngpios != 8U && config->ngpios != 16U) {

--- a/drivers/gpio/gpio_psoc6.c
+++ b/drivers/gpio/gpio_psoc6.c
@@ -37,16 +37,11 @@ struct gpio_psoc6_runtime {
 	sys_slist_t cb;
 };
 
-#define DEV_CFG(dev) \
-	((const struct gpio_psoc6_config * const)(dev)->config)
-#define DEV_DATA(dev) \
-	((struct gpio_psoc6_runtime * const)(dev)->data)
-
 static int gpio_psoc6_config(const struct device *dev,
 			     gpio_pin_t pin,
 			     gpio_flags_t flags)
 {
-	const struct gpio_psoc6_config * const cfg = DEV_CFG(dev);
+	const struct gpio_psoc6_config * const cfg = dev->config;
 	GPIO_PRT_Type * const port = cfg->regs;
 	uint32_t drv_mode;
 	uint32_t pin_val;
@@ -96,7 +91,7 @@ static int gpio_psoc6_config(const struct device *dev,
 static int gpio_psoc6_port_get_raw(const struct device *dev,
 				   uint32_t *value)
 {
-	const struct gpio_psoc6_config * const cfg = DEV_CFG(dev);
+	const struct gpio_psoc6_config * const cfg = dev->config;
 	GPIO_PRT_Type * const port = cfg->regs;
 
 	*value = GPIO_PRT_IN(port);
@@ -110,7 +105,7 @@ static int gpio_psoc6_port_set_masked_raw(const struct device *dev,
 					  uint32_t mask,
 					  uint32_t value)
 {
-	const struct gpio_psoc6_config * const cfg = DEV_CFG(dev);
+	const struct gpio_psoc6_config * const cfg = dev->config;
 	GPIO_PRT_Type * const port = cfg->regs;
 
 	GPIO_PRT_OUT(port) = (GPIO_PRT_IN(port) & ~mask) | (mask & value);
@@ -121,7 +116,7 @@ static int gpio_psoc6_port_set_masked_raw(const struct device *dev,
 static int gpio_psoc6_port_set_bits_raw(const struct device *dev,
 					uint32_t mask)
 {
-	const struct gpio_psoc6_config * const cfg = DEV_CFG(dev);
+	const struct gpio_psoc6_config * const cfg = dev->config;
 	GPIO_PRT_Type * const port = cfg->regs;
 
 	GPIO_PRT_OUT_SET(port) = mask;
@@ -132,7 +127,7 @@ static int gpio_psoc6_port_set_bits_raw(const struct device *dev,
 static int gpio_psoc6_port_clear_bits_raw(const struct device *dev,
 					  uint32_t mask)
 {
-	const struct gpio_psoc6_config * const cfg = DEV_CFG(dev);
+	const struct gpio_psoc6_config * const cfg = dev->config;
 	GPIO_PRT_Type * const port = cfg->regs;
 
 	GPIO_PRT_OUT_CLR(port) = mask;
@@ -143,7 +138,7 @@ static int gpio_psoc6_port_clear_bits_raw(const struct device *dev,
 static int gpio_psoc6_port_toggle_bits(const struct device *dev,
 				       uint32_t mask)
 {
-	const struct gpio_psoc6_config * const cfg = DEV_CFG(dev);
+	const struct gpio_psoc6_config * const cfg = dev->config;
 	GPIO_PRT_Type * const port = cfg->regs;
 
 	GPIO_PRT_OUT_INV(port) = mask;
@@ -156,7 +151,7 @@ static int gpio_psoc6_pin_interrupt_configure(const struct device *dev,
 					    enum gpio_int_mode mode,
 					    enum gpio_int_trig trig)
 {
-	const struct gpio_psoc6_config * const cfg = DEV_CFG(dev);
+	const struct gpio_psoc6_config * const cfg = dev->config;
 	GPIO_PRT_Type * const port = cfg->regs;
 	uint32_t is_enabled = ((mode == GPIO_INT_MODE_DISABLED) ? 0 : 1);
 	uint32_t lv_trg = CY_GPIO_INTR_DISABLE;
@@ -194,7 +189,7 @@ static int gpio_psoc6_pin_interrupt_configure(const struct device *dev,
 
 static void gpio_psoc6_isr(const struct device *dev)
 {
-	const struct gpio_psoc6_config * const cfg = DEV_CFG(dev);
+	const struct gpio_psoc6_config * const cfg = dev->config;
 	GPIO_PRT_Type * const port = cfg->regs;
 	struct gpio_psoc6_runtime *context = dev->data;
 	uint32_t int_stat;
@@ -224,7 +219,7 @@ static int gpio_psoc6_manage_callback(const struct device *port,
 
 static uint32_t gpio_psoc6_get_pending_int(const struct device *dev)
 {
-	const struct gpio_psoc6_config * const cfg = DEV_CFG(dev);
+	const struct gpio_psoc6_config * const cfg = dev->config;
 	GPIO_PRT_Type * const port = cfg->regs;
 
 	LOG_DBG("Pending: 0x%08x", GPIO_PRT_INTR_MASKED(port));
@@ -246,7 +241,7 @@ static const struct gpio_driver_api gpio_psoc6_api = {
 
 int gpio_psoc6_init(const struct device *dev)
 {
-	const struct gpio_psoc6_config * const cfg = DEV_CFG(dev);
+	const struct gpio_psoc6_config * const cfg = dev->config;
 
 	cfg->config_func(dev);
 

--- a/drivers/gpio/gpio_sam.c
+++ b/drivers/gpio/gpio_sam.c
@@ -31,17 +31,12 @@ struct gpio_sam_runtime {
 	sys_slist_t cb;
 };
 
-#define DEV_CFG(dev) \
-	((const struct gpio_sam_config * const)(dev)->config)
-#define DEV_DATA(dev) \
-	((struct gpio_sam_runtime * const)(dev)->data)
-
 #define GPIO_SAM_ALL_PINS    0xFFFFFFFF
 
 static int gpio_sam_port_configure(const struct device *dev, uint32_t mask,
 				   gpio_flags_t flags)
 {
-	const struct gpio_sam_config * const cfg = DEV_CFG(dev);
+	const struct gpio_sam_config * const cfg = dev->config;
 	Pio * const pio = cfg->regs;
 
 	if (flags & GPIO_SINGLE_ENDED) {
@@ -153,7 +148,7 @@ static int gpio_sam_config(const struct device *dev, gpio_pin_t pin,
 
 static int gpio_sam_port_get_raw(const struct device *dev, uint32_t *value)
 {
-	const struct gpio_sam_config * const cfg = DEV_CFG(dev);
+	const struct gpio_sam_config * const cfg = dev->config;
 	Pio * const pio = cfg->regs;
 
 	*value = pio->PIO_PDSR;
@@ -165,7 +160,7 @@ static int gpio_sam_port_set_masked_raw(const struct device *dev,
 					uint32_t mask,
 					uint32_t value)
 {
-	const struct gpio_sam_config * const cfg = DEV_CFG(dev);
+	const struct gpio_sam_config * const cfg = dev->config;
 	Pio * const pio = cfg->regs;
 
 	pio->PIO_ODSR = (pio->PIO_ODSR & ~mask) | (mask & value);
@@ -175,7 +170,7 @@ static int gpio_sam_port_set_masked_raw(const struct device *dev,
 
 static int gpio_sam_port_set_bits_raw(const struct device *dev, uint32_t mask)
 {
-	const struct gpio_sam_config * const cfg = DEV_CFG(dev);
+	const struct gpio_sam_config * const cfg = dev->config;
 	Pio * const pio = cfg->regs;
 
 	/* Set pins. */
@@ -187,7 +182,7 @@ static int gpio_sam_port_set_bits_raw(const struct device *dev, uint32_t mask)
 static int gpio_sam_port_clear_bits_raw(const struct device *dev,
 					uint32_t mask)
 {
-	const struct gpio_sam_config * const cfg = DEV_CFG(dev);
+	const struct gpio_sam_config * const cfg = dev->config;
 	Pio * const pio = cfg->regs;
 
 	/* Clear pins. */
@@ -198,7 +193,7 @@ static int gpio_sam_port_clear_bits_raw(const struct device *dev,
 
 static int gpio_sam_port_toggle_bits(const struct device *dev, uint32_t mask)
 {
-	const struct gpio_sam_config * const cfg = DEV_CFG(dev);
+	const struct gpio_sam_config * const cfg = dev->config;
 	Pio * const pio = cfg->regs;
 
 	/* Toggle pins. */
@@ -212,7 +207,7 @@ static int gpio_sam_port_interrupt_configure(const struct device *dev,
 					     enum gpio_int_mode mode,
 					     enum gpio_int_trig trig)
 {
-	const struct gpio_sam_config * const cfg = DEV_CFG(dev);
+	const struct gpio_sam_config * const cfg = dev->config;
 	Pio * const pio = cfg->regs;
 
 	/* Disable the interrupt. */
@@ -266,7 +261,7 @@ static int gpio_sam_pin_interrupt_configure(const struct device *dev,
 
 static void gpio_sam_isr(const struct device *dev)
 {
-	const struct gpio_sam_config * const cfg = DEV_CFG(dev);
+	const struct gpio_sam_config * const cfg = dev->config;
 	Pio * const pio = cfg->regs;
 	struct gpio_sam_runtime *context = dev->data;
 	uint32_t int_stat;
@@ -298,7 +293,7 @@ static const struct gpio_driver_api gpio_sam_api = {
 
 int gpio_sam_init(const struct device *dev)
 {
-	const struct gpio_sam_config * const cfg = DEV_CFG(dev);
+	const struct gpio_sam_config * const cfg = dev->config;
 
 	/* The peripheral clock must be enabled for the interrupts to work. */
 	soc_pmc_peripheral_enable(cfg->periph_id);

--- a/drivers/gpio/gpio_sam4l.c
+++ b/drivers/gpio/gpio_sam4l.c
@@ -32,18 +32,13 @@ struct gpio_sam_runtime {
 	sys_slist_t cb;
 };
 
-#define DEV_CFG(dev) \
-	((const struct gpio_sam_config * const)(dev)->config)
-#define DEV_DATA(dev) \
-	((struct gpio_sam_runtime * const)(dev)->data)
-
 #define GPIO_SAM_ALL_PINS    0xFFFFFFFF
 
 static int gpio_sam_port_configure(const struct device *dev,
 				   uint32_t mask,
 				   gpio_flags_t flags)
 {
-	const struct gpio_sam_config * const cfg = DEV_CFG(dev);
+	const struct gpio_sam_config * const cfg = dev->config;
 	Gpio * const gpio = cfg->regs;
 
 	/* No hardware support */
@@ -104,7 +99,7 @@ static int gpio_sam_config(const struct device *dev,
 static int gpio_sam_port_get_raw(const struct device *dev,
 				 uint32_t *value)
 {
-	const struct gpio_sam_config * const cfg = DEV_CFG(dev);
+	const struct gpio_sam_config * const cfg = dev->config;
 	Gpio * const gpio = cfg->regs;
 
 	*value = gpio->PVR;
@@ -116,7 +111,7 @@ static int gpio_sam_port_set_masked_raw(const struct device *dev,
 					uint32_t mask,
 					uint32_t value)
 {
-	const struct gpio_sam_config * const cfg = DEV_CFG(dev);
+	const struct gpio_sam_config * const cfg = dev->config;
 	Gpio * const gpio = cfg->regs;
 
 	gpio->OVR = (gpio->PVR & ~mask) | (mask & value);
@@ -127,7 +122,7 @@ static int gpio_sam_port_set_masked_raw(const struct device *dev,
 static int gpio_sam_port_set_bits_raw(const struct device *dev,
 				      uint32_t mask)
 {
-	const struct gpio_sam_config * const cfg = DEV_CFG(dev);
+	const struct gpio_sam_config * const cfg = dev->config;
 	Gpio * const gpio = cfg->regs;
 
 	gpio->OVRS = mask;
@@ -138,7 +133,7 @@ static int gpio_sam_port_set_bits_raw(const struct device *dev,
 static int gpio_sam_port_clear_bits_raw(const struct device *dev,
 					uint32_t mask)
 {
-	const struct gpio_sam_config * const cfg = DEV_CFG(dev);
+	const struct gpio_sam_config * const cfg = dev->config;
 	Gpio * const gpio = cfg->regs;
 
 	gpio->OVRC = mask;
@@ -149,7 +144,7 @@ static int gpio_sam_port_clear_bits_raw(const struct device *dev,
 static int gpio_sam_port_toggle_bits(const struct device *dev,
 				     uint32_t mask)
 {
-	const struct gpio_sam_config * const cfg = DEV_CFG(dev);
+	const struct gpio_sam_config * const cfg = dev->config;
 	Gpio * const gpio = cfg->regs;
 
 	gpio->OVRT = mask;
@@ -162,7 +157,7 @@ static int gpio_sam_port_interrupt_configure(const struct device *dev,
 					     enum gpio_int_mode mode,
 					     enum gpio_int_trig trig)
 {
-	const struct gpio_sam_config * const cfg = DEV_CFG(dev);
+	const struct gpio_sam_config * const cfg = dev->config;
 	Gpio * const gpio = cfg->regs;
 
 	if (mode == GPIO_INT_MODE_LEVEL) {
@@ -199,7 +194,7 @@ static int gpio_sam_pin_interrupt_configure(const struct device *dev,
 
 static void gpio_sam_isr(const struct device *dev)
 {
-	const struct gpio_sam_config * const cfg = DEV_CFG(dev);
+	const struct gpio_sam_config * const cfg = dev->config;
 	Gpio * const gpio = cfg->regs;
 	struct gpio_sam_runtime *context = dev->data;
 	uint32_t int_stat;
@@ -232,7 +227,7 @@ static const struct gpio_driver_api gpio_sam_api = {
 
 int gpio_sam_init(const struct device *dev)
 {
-	const struct gpio_sam_config * const cfg = DEV_CFG(dev);
+	const struct gpio_sam_config * const cfg = dev->config;
 
 	soc_pmc_peripheral_enable(cfg->periph_id);
 

--- a/drivers/gpio/gpio_stellaris.c
+++ b/drivers/gpio/gpio_stellaris.c
@@ -29,14 +29,6 @@ struct gpio_stellaris_runtime {
 	sys_slist_t cb;
 };
 
-#define DEV_CFG(dev)                                     \
-	((const struct gpio_stellaris_config *const)     \
-	(dev)->config)
-
-#define DEV_DATA(dev)					 \
-	((struct gpio_stellaris_runtime *const)          \
-	(dev)->data)
-
 #define GPIO_REG_ADDR(base, offset) (base + offset)
 
 #define GPIO_RW_ADDR(base, offset, p)			 \
@@ -59,8 +51,8 @@ enum gpio_regs {
 
 static void gpio_stellaris_isr(const struct device *dev)
 {
-	const struct gpio_stellaris_config * const cfg = DEV_CFG(dev);
-	struct gpio_stellaris_runtime *context = DEV_DATA(dev);
+	const struct gpio_stellaris_config * const cfg = dev->config;
+	struct gpio_stellaris_runtime *context = dev->data;
 	uint32_t base = cfg->base;
 	uint32_t int_stat = sys_read32(GPIO_REG_ADDR(base, GPIO_MIS_OFFSET));
 
@@ -72,7 +64,7 @@ static void gpio_stellaris_isr(const struct device *dev)
 static int gpio_stellaris_configure(const struct device *dev,
 				    gpio_pin_t pin, gpio_flags_t flags)
 {
-	const struct gpio_stellaris_config *cfg = DEV_CFG(dev);
+	const struct gpio_stellaris_config *cfg = dev->config;
 	uint32_t base = cfg->base;
 	uint32_t port_map = cfg->port_map;
 
@@ -116,7 +108,7 @@ static int gpio_stellaris_configure(const struct device *dev,
 static int gpio_stellaris_port_get_raw(const struct device *dev,
 				       uint32_t *value)
 {
-	const struct gpio_stellaris_config *cfg = DEV_CFG(dev);
+	const struct gpio_stellaris_config *cfg = dev->config;
 	uint32_t base = cfg->base;
 
 	*value = sys_read32(GPIO_RW_MASK_ADDR(base, GPIO_DATA_OFFSET, 0xff));
@@ -128,7 +120,7 @@ static int gpio_stellaris_port_set_masked_raw(const struct device *dev,
 					      uint32_t mask,
 					      uint32_t value)
 {
-	const struct gpio_stellaris_config *cfg = DEV_CFG(dev);
+	const struct gpio_stellaris_config *cfg = dev->config;
 	uint32_t base = cfg->base;
 
 	sys_write32(value, GPIO_RW_MASK_ADDR(base, GPIO_DATA_OFFSET, mask));
@@ -139,7 +131,7 @@ static int gpio_stellaris_port_set_masked_raw(const struct device *dev,
 static int gpio_stellaris_port_set_bits_raw(const struct device *dev,
 					    uint32_t mask)
 {
-	const struct gpio_stellaris_config *cfg = DEV_CFG(dev);
+	const struct gpio_stellaris_config *cfg = dev->config;
 	uint32_t base = cfg->base;
 
 	sys_write32(mask, GPIO_RW_MASK_ADDR(base, GPIO_DATA_OFFSET, mask));
@@ -150,7 +142,7 @@ static int gpio_stellaris_port_set_bits_raw(const struct device *dev,
 static int gpio_stellaris_port_clear_bits_raw(const struct device *dev,
 					      uint32_t mask)
 {
-	const struct gpio_stellaris_config *cfg = DEV_CFG(dev);
+	const struct gpio_stellaris_config *cfg = dev->config;
 	uint32_t base = cfg->base;
 
 	sys_write32(0, GPIO_RW_MASK_ADDR(base, GPIO_DATA_OFFSET, mask));
@@ -161,7 +153,7 @@ static int gpio_stellaris_port_clear_bits_raw(const struct device *dev,
 static int gpio_stellaris_port_toggle_bits(const struct device *dev,
 					   uint32_t mask)
 {
-	const struct gpio_stellaris_config *cfg = DEV_CFG(dev);
+	const struct gpio_stellaris_config *cfg = dev->config;
 	uint32_t base = cfg->base;
 	uint32_t value;
 
@@ -177,7 +169,7 @@ static int gpio_stellaris_pin_interrupt_configure(const struct device *dev,
 						  enum gpio_int_mode mode,
 						  enum gpio_int_trig trig)
 {
-	const struct gpio_stellaris_config *cfg = DEV_CFG(dev);
+	const struct gpio_stellaris_config *cfg = dev->config;
 	uint32_t base = cfg->base;
 
 	/* Check if GPIO port needs interrupt support */
@@ -208,7 +200,7 @@ static int gpio_stellaris_pin_interrupt_configure(const struct device *dev,
 
 static int gpio_stellaris_init(const struct device *dev)
 {
-	const struct gpio_stellaris_config *cfg = DEV_CFG(dev);
+	const struct gpio_stellaris_config *cfg = dev->config;
 
 	cfg->config_func(dev);
 	return 0;
@@ -218,7 +210,7 @@ static int gpio_stellaris_manage_callback(const struct device *dev,
 					  struct gpio_callback *callback,
 					  bool set)
 {
-	struct gpio_stellaris_runtime *context = DEV_DATA(dev);
+	struct gpio_stellaris_runtime *context = dev->data;
 
 	gpio_manage_callback(&context->cb, callback, set);
 

--- a/drivers/gpio/gpio_stmpe1600.c
+++ b/drivers/gpio/gpio_stmpe1600.c
@@ -204,7 +204,7 @@ static int stmpe1600_port_get_raw(const struct device *dev, uint32_t *value)
 static int stmpe1600_port_set_masked_raw(const struct device *dev,
 					 uint32_t mask, uint32_t value)
 {
-	struct stmpe1600_drvdata *const drvdata = (struct stmpe1600_drvdata *const)dev->data;
+	struct stmpe1600_drvdata *const drvdata = dev->data;
 	uint16_t GPSR;
 	int ret;
 
@@ -235,7 +235,7 @@ static int stmpe1600_port_clear_bits_raw(const struct device *dev, uint32_t mask
 
 static int stmpe1600_port_toggle_bits(const struct device *dev, uint32_t mask)
 {
-	struct stmpe1600_drvdata *const drvdata = (struct stmpe1600_drvdata *const)dev->data;
+	struct stmpe1600_drvdata *const drvdata = dev->data;
 	uint16_t GPSR;
 	int ret;
 

--- a/drivers/i2c/i2c_cc32xx.c
+++ b/drivers/i2c/i2c_cc32xx.c
@@ -38,12 +38,8 @@ LOG_MODULE_REGISTER(i2c_cc32xx);
 
 #define IS_I2C_MSG_WRITE(flags) ((flags & I2C_MSG_RW_MASK) == I2C_MSG_WRITE)
 
-#define DEV_CFG(dev) \
-	((const struct i2c_cc32xx_config *const)(dev)->config)
-#define DEV_DATA(dev) \
-	((struct i2c_cc32xx_data *const)(dev)->data)
 #define DEV_BASE(dev) \
-	((DEV_CFG(dev))->base)
+	(((const struct i2c_cc32xx_config *const)(dev)->config)->base)
 
 
 /* Since this driver does not explicitly enable the TX/RX FIFOs, there
@@ -116,7 +112,7 @@ static void i2c_cc32xx_prime_transfer(const struct device *dev,
 				      struct i2c_msg *msg,
 				      uint16_t addr)
 {
-	struct i2c_cc32xx_data *data = DEV_DATA(dev);
+	struct i2c_cc32xx_data *data = dev->data;
 	uint32_t base = DEV_BASE(dev);
 
 	/* Initialize internal counters and buf pointers: */
@@ -161,7 +157,7 @@ static void i2c_cc32xx_prime_transfer(const struct device *dev,
 static int i2c_cc32xx_transfer(const struct device *dev, struct i2c_msg *msgs,
 			       uint8_t num_msgs, uint16_t addr)
 {
-	struct i2c_cc32xx_data *data = DEV_DATA(dev);
+	struct i2c_cc32xx_data *data = dev->data;
 	int retval = 0;
 
 	/* Acquire the driver mutex */
@@ -264,7 +260,7 @@ static void i2c_cc32xx_isr_handle_read(uint32_t base,
 static void i2c_cc32xx_isr(const struct device *dev)
 {
 	uint32_t base = DEV_BASE(dev);
-	struct i2c_cc32xx_data *data = DEV_DATA(dev);
+	struct i2c_cc32xx_data *data = dev->data;
 	uint32_t err_status;
 	uint32_t int_status;
 
@@ -326,8 +322,8 @@ static void i2c_cc32xx_isr(const struct device *dev)
 static int i2c_cc32xx_init(const struct device *dev)
 {
 	uint32_t base = DEV_BASE(dev);
-	const struct i2c_cc32xx_config *config = DEV_CFG(dev);
-	struct i2c_cc32xx_data *data = DEV_DATA(dev);
+	const struct i2c_cc32xx_config *config = dev->config;
+	struct i2c_cc32xx_data *data = dev->data;
 	uint32_t bitrate_cfg;
 	int error;
 	uint32_t regval;

--- a/drivers/i2c/i2c_gecko.c
+++ b/drivers/i2c/i2c_gecko.c
@@ -20,12 +20,8 @@ LOG_MODULE_REGISTER(i2c_gecko);
 
 #include "i2c-priv.h"
 
-#define DEV_CFG(dev) \
-	((const struct i2c_gecko_config * const)(dev)->config)
-#define DEV_DATA(dev) \
-	((struct i2c_gecko_data * const)(dev)->data)
 #define DEV_BASE(dev) \
-	((I2C_TypeDef *)(DEV_CFG(dev))->base)
+	((I2C_TypeDef *)((const struct i2c_gecko_config * const)(dev)->config)->base)
 
 struct i2c_gecko_config {
 	I2C_TypeDef *base;
@@ -51,7 +47,7 @@ void i2c_gecko_config_pins(const struct device *dev,
 			   const struct soc_gpio_pin *pin_scl)
 {
 	I2C_TypeDef *base = DEV_BASE(dev);
-	const struct i2c_gecko_config *config = DEV_CFG(dev);
+	const struct i2c_gecko_config *config = dev->config;
 
 	soc_gpio_configure(pin_scl);
 	soc_gpio_configure(pin_sda);
@@ -78,7 +74,7 @@ static int i2c_gecko_configure(const struct device *dev,
 			       uint32_t dev_config_raw)
 {
 	I2C_TypeDef *base = DEV_BASE(dev);
-	struct i2c_gecko_data *data = DEV_DATA(dev);
+	struct i2c_gecko_data *data = dev->data;
 	I2C_Init_TypeDef i2cInit = I2C_INIT_DEFAULT;
 	uint32_t baudrate;
 
@@ -112,7 +108,7 @@ static int i2c_gecko_transfer(const struct device *dev, struct i2c_msg *msgs,
 			      uint8_t num_msgs, uint16_t addr)
 {
 	I2C_TypeDef *base = DEV_BASE(dev);
-	struct i2c_gecko_data *data = DEV_DATA(dev);
+	struct i2c_gecko_data *data = dev->data;
 	I2C_TransferSeq_TypeDef seq;
 	I2C_TransferReturn_TypeDef ret = -EIO;
 	uint32_t timeout = 300000U;
@@ -174,7 +170,7 @@ finish:
 
 static int i2c_gecko_init(const struct device *dev)
 {
-	const struct i2c_gecko_config *config = DEV_CFG(dev);
+	const struct i2c_gecko_config *config = dev->config;
 	uint32_t bitrate_cfg;
 	int error;
 

--- a/drivers/i2c/i2c_imx.c
+++ b/drivers/i2c/i2c_imx.c
@@ -17,12 +17,8 @@ LOG_MODULE_REGISTER(i2c_imx);
 
 #include "i2c-priv.h"
 
-#define DEV_CFG(dev) \
-	((const struct i2c_imx_config * const)(dev)->config)
-#define DEV_DATA(dev) \
-	((struct i2c_imx_data * const)(dev)->data)
 #define DEV_BASE(dev) \
-	((I2C_Type *)(DEV_CFG(dev))->base)
+	((I2C_Type *)((const struct i2c_imx_config * const)(dev)->config)->base)
 
 struct i2c_imx_config {
 	I2C_Type *base;
@@ -51,7 +47,7 @@ static bool i2c_imx_write(const struct device *dev, uint8_t *txBuffer,
 			  uint32_t txSize)
 {
 	I2C_Type *base = DEV_BASE(dev);
-	struct i2c_imx_data *data = DEV_DATA(dev);
+	struct i2c_imx_data *data = dev->data;
 	struct i2c_master_transfer *transfer = &data->transfer;
 
 	transfer->isBusy = true;
@@ -85,7 +81,7 @@ static void i2c_imx_read(const struct device *dev, uint8_t *rxBuffer,
 			 uint32_t rxSize)
 {
 	I2C_Type *base = DEV_BASE(dev);
-	struct i2c_imx_data *data = DEV_DATA(dev);
+	struct i2c_imx_data *data = dev->data;
 	struct i2c_master_transfer *transfer = &data->transfer;
 
 	transfer->isBusy = true;
@@ -125,7 +121,7 @@ static int i2c_imx_configure(const struct device *dev,
 			     uint32_t dev_config_raw)
 {
 	I2C_Type *base = DEV_BASE(dev);
-	struct i2c_imx_data *data = DEV_DATA(dev);
+	struct i2c_imx_data *data = dev->data;
 	struct i2c_master_transfer *transfer = &data->transfer;
 	uint32_t baudrate;
 
@@ -189,7 +185,7 @@ static int i2c_imx_transfer(const struct device *dev, struct i2c_msg *msgs,
 			    uint8_t num_msgs, uint16_t addr)
 {
 	I2C_Type *base = DEV_BASE(dev);
-	struct i2c_imx_data *data = DEV_DATA(dev);
+	struct i2c_imx_data *data = dev->data;
 	struct i2c_master_transfer *transfer = &data->transfer;
 	uint16_t timeout = UINT16_MAX;
 	int result = -EIO;
@@ -271,7 +267,7 @@ finish:
 static void i2c_imx_isr(const struct device *dev)
 {
 	I2C_Type *base = DEV_BASE(dev);
-	struct i2c_imx_data *data = DEV_DATA(dev);
+	struct i2c_imx_data *data = dev->data;
 	struct i2c_master_transfer *transfer = &data->transfer;
 
 	/* Clear interrupt flag. */
@@ -336,8 +332,8 @@ static void i2c_imx_isr(const struct device *dev)
 
 static int i2c_imx_init(const struct device *dev)
 {
-	const struct i2c_imx_config *config = DEV_CFG(dev);
-	struct i2c_imx_data *data = DEV_DATA(dev);
+	const struct i2c_imx_config *config = dev->config;
+	struct i2c_imx_data *data = dev->data;
 	uint32_t bitrate_cfg;
 	int error;
 

--- a/drivers/i2c/i2c_ite_it8xxx2.c
+++ b/drivers/i2c/i2c_ite_it8xxx2.c
@@ -17,11 +17,6 @@
 #include <soc_dt.h>
 #include <sys/util.h>
 
-#define DEV_CFG(dev) \
-		((const struct i2c_it8xxx2_config * const)(dev)->config)
-#define DEV_DATA(dev) \
-		((struct i2c_it8xxx2_data * const)(dev)->data)
-
 #define I2C_STANDARD_PORT_COUNT 3
 /* Default PLL frequency. */
 #define PLL_CLOCK 48000000
@@ -152,8 +147,8 @@ enum i2c_reset_cause {
 
 static int i2c_parsing_return_value(const struct device *dev)
 {
-	struct i2c_it8xxx2_data *data = DEV_DATA(dev);
-	const struct i2c_it8xxx2_config *config = DEV_CFG(dev);
+	struct i2c_it8xxx2_data *data = dev->data;
+	const struct i2c_it8xxx2_config *config = dev->config;
 
 	if (!data->err)
 		return 0;
@@ -179,7 +174,7 @@ static int i2c_parsing_return_value(const struct device *dev)
 
 static int i2c_get_line_levels(const struct device *dev)
 {
-	const struct i2c_it8xxx2_config *config = DEV_CFG(dev);
+	const struct i2c_it8xxx2_config *config = dev->config;
 	uint8_t *base = config->base;
 	int pin_sts = 0;
 
@@ -200,7 +195,7 @@ static int i2c_get_line_levels(const struct device *dev)
 
 static int i2c_is_busy(const struct device *dev)
 {
-	const struct i2c_it8xxx2_config *config = DEV_CFG(dev);
+	const struct i2c_it8xxx2_config *config = dev->config;
 	uint8_t *base = config->base;
 
 	if (config->port < I2C_STANDARD_PORT_COUNT) {
@@ -223,7 +218,7 @@ static int i2c_bus_not_available(const struct device *dev)
 
 static void i2c_reset(const struct device *dev)
 {
-	const struct i2c_it8xxx2_config *config = DEV_CFG(dev);
+	const struct i2c_it8xxx2_config *config = dev->config;
 	uint8_t *base = config->base;
 
 	if (config->port < I2C_STANDARD_PORT_COUNT) {
@@ -260,7 +255,7 @@ static void i2c_standard_port_timing_regs_400khz(uint8_t port)
 static void i2c_standard_port_set_frequency(const struct device *dev,
 					int freq_khz, int freq_set)
 {
-	const struct i2c_it8xxx2_config *config = DEV_CFG(dev);
+	const struct i2c_it8xxx2_config *config = dev->config;
 
 	/*
 	 * If port's clock frequency is 400kHz, we use timing registers
@@ -281,8 +276,8 @@ static void i2c_standard_port_set_frequency(const struct device *dev,
 static void i2c_enhanced_port_set_frequency(const struct device *dev,
 				int freq_khz)
 {
-	struct i2c_it8xxx2_data *data = DEV_DATA(dev);
-	const struct i2c_it8xxx2_config *config = DEV_CFG(dev);
+	struct i2c_it8xxx2_data *data = dev->data;
+	const struct i2c_it8xxx2_config *config = dev->config;
 	uint32_t clk_div, psr;
 	uint8_t *base = config->base;
 
@@ -319,7 +314,7 @@ static void i2c_enhanced_port_set_frequency(const struct device *dev,
 static int i2c_it8xxx2_configure(const struct device *dev,
 				uint32_t dev_config_raw)
 {
-	const struct i2c_it8xxx2_config *config = DEV_CFG(dev);
+	const struct i2c_it8xxx2_config *config = dev->config;
 	struct i2c_it8xxx2_data *const data = dev->data;
 	uint32_t freq, freq_set;
 
@@ -391,8 +386,8 @@ static int i2c_it8xxx2_get_config(const struct device *dev,
 
 static int enhanced_i2c_error(const struct device *dev)
 {
-	struct i2c_it8xxx2_data *data = DEV_DATA(dev);
-	const struct i2c_it8xxx2_config *config = DEV_CFG(dev);
+	struct i2c_it8xxx2_data *data = dev->data;
+	const struct i2c_it8xxx2_config *config = dev->config;
 	uint8_t *base = config->base;
 	uint32_t i2c_str = IT83XX_I2C_STR(base);
 
@@ -409,8 +404,8 @@ static int enhanced_i2c_error(const struct device *dev)
 
 static void enhanced_i2c_start(const struct device *dev)
 {
-	struct i2c_it8xxx2_data *data = DEV_DATA(dev);
-	const struct i2c_it8xxx2_config *config = DEV_CFG(dev);
+	struct i2c_it8xxx2_data *data = dev->data;
+	const struct i2c_it8xxx2_config *config = dev->config;
 	uint8_t *base = config->base;
 
 	/* State reset and hardware reset */
@@ -431,8 +426,8 @@ static void i2c_pio_trans_data(const struct device *dev,
 				enum enhanced_i2c_transfer_direct direct,
 				uint16_t trans_data, int first_byte)
 {
-	struct i2c_it8xxx2_data *data = DEV_DATA(dev);
-	const struct i2c_it8xxx2_config *config = DEV_CFG(dev);
+	struct i2c_it8xxx2_data *data = dev->data;
+	const struct i2c_it8xxx2_config *config = dev->config;
 	uint8_t *base = config->base;
 	uint32_t nack = 0;
 
@@ -464,8 +459,8 @@ static void i2c_pio_trans_data(const struct device *dev,
 
 static int enhanced_i2c_tran_read(const struct device *dev)
 {
-	struct i2c_it8xxx2_data *data = DEV_DATA(dev);
-	const struct i2c_it8xxx2_config *config = DEV_CFG(dev);
+	struct i2c_it8xxx2_data *data = dev->data;
+	const struct i2c_it8xxx2_config *config = dev->config;
 	uint8_t *base = config->base;
 	uint8_t in_data = 0;
 
@@ -523,8 +518,8 @@ static int enhanced_i2c_tran_read(const struct device *dev)
 
 static int enhanced_i2c_tran_write(const struct device *dev)
 {
-	struct i2c_it8xxx2_data *data = DEV_DATA(dev);
-	const struct i2c_it8xxx2_config *config = DEV_CFG(dev);
+	struct i2c_it8xxx2_data *data = dev->data;
+	const struct i2c_it8xxx2_config *config = dev->config;
 	uint8_t *base = config->base;
 	uint8_t out_data;
 
@@ -565,8 +560,8 @@ static int enhanced_i2c_tran_write(const struct device *dev)
 
 static void i2c_r_last_byte(const struct device *dev)
 {
-	struct i2c_it8xxx2_data *data = DEV_DATA(dev);
-	const struct i2c_it8xxx2_config *config = DEV_CFG(dev);
+	struct i2c_it8xxx2_data *data = dev->data;
+	const struct i2c_it8xxx2_config *config = dev->config;
 	uint8_t *base = config->base;
 
 	/*
@@ -581,7 +576,7 @@ static void i2c_r_last_byte(const struct device *dev)
 
 static void i2c_w2r_change_direction(const struct device *dev)
 {
-	const struct i2c_it8xxx2_config *config = DEV_CFG(dev);
+	const struct i2c_it8xxx2_config *config = dev->config;
 	uint8_t *base = config->base;
 
 	/* I2C switch direction */
@@ -602,8 +597,8 @@ static void i2c_w2r_change_direction(const struct device *dev)
 
 static int i2c_tran_read(const struct device *dev)
 {
-	struct i2c_it8xxx2_data *data = DEV_DATA(dev);
-	const struct i2c_it8xxx2_config *config = DEV_CFG(dev);
+	struct i2c_it8xxx2_data *data = dev->data;
+	const struct i2c_it8xxx2_config *config = dev->config;
 	uint8_t *base = config->base;
 
 	if (data->msgs->flags & I2C_MSG_START) {
@@ -677,8 +672,8 @@ static int i2c_tran_read(const struct device *dev)
 
 static int i2c_tran_write(const struct device *dev)
 {
-	struct i2c_it8xxx2_data *data = DEV_DATA(dev);
-	const struct i2c_it8xxx2_config *config = DEV_CFG(dev);
+	struct i2c_it8xxx2_data *data = dev->data;
+	const struct i2c_it8xxx2_config *config = dev->config;
 	uint8_t *base = config->base;
 
 	if (data->msgs->flags & I2C_MSG_START) {
@@ -740,8 +735,8 @@ static int i2c_tran_write(const struct device *dev)
 
 static int i2c_transaction(const struct device *dev)
 {
-	struct i2c_it8xxx2_data *data = DEV_DATA(dev);
-	const struct i2c_it8xxx2_config *config = DEV_CFG(dev);
+	struct i2c_it8xxx2_data *data = dev->data;
+	const struct i2c_it8xxx2_config *config = dev->config;
 	uint8_t *base = config->base;
 
 	if (config->port < I2C_STANDARD_PORT_COUNT) {
@@ -804,8 +799,8 @@ static int i2c_it8xxx2_transfer(const struct device *dev, struct i2c_msg *msgs,
 		return -EINVAL;
 	}
 
-	data = DEV_DATA(dev);
-	config = DEV_CFG(dev);
+	data = dev->data;
+	config = dev->config;
 
 	/* Lock mutex of i2c controller */
 	k_mutex_lock(&data->mutex, K_FOREVER);
@@ -889,8 +884,8 @@ static int i2c_it8xxx2_transfer(const struct device *dev, struct i2c_msg *msgs,
 static void i2c_it8xxx2_isr(void *arg)
 {
 	struct device *dev = (struct device *)arg;
-	struct i2c_it8xxx2_data *data = DEV_DATA(dev);
-	const struct i2c_it8xxx2_config *config = DEV_CFG(dev);
+	struct i2c_it8xxx2_data *data = dev->data;
+	const struct i2c_it8xxx2_config *config = dev->config;
 
 	/* If done doing work, wake up the task waiting for the transfer */
 	if (!i2c_transaction(dev)) {
@@ -901,8 +896,8 @@ static void i2c_it8xxx2_isr(void *arg)
 
 static int i2c_it8xxx2_init(const struct device *dev)
 {
-	struct i2c_it8xxx2_data *data = DEV_DATA(dev);
-	const struct i2c_it8xxx2_config *config = DEV_CFG(dev);
+	struct i2c_it8xxx2_data *data = dev->data;
+	const struct i2c_it8xxx2_config *config = dev->config;
 	uint8_t *base = config->base;
 	uint32_t bitrate_cfg, offset = 0;
 	int error;
@@ -996,7 +991,7 @@ static int i2c_it8xxx2_init(const struct device *dev)
 
 static int i2c_it8xxx2_recover_bus(const struct device *dev)
 {
-	const struct i2c_it8xxx2_config *config = DEV_CFG(dev);
+	const struct i2c_it8xxx2_config *config = dev->config;
 	int i;
 
 	/* Set SCL of I2C as GPIO pin */

--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -25,8 +25,8 @@ LOG_MODULE_REGISTER(i2c_ll_stm32);
 
 int i2c_stm32_runtime_configure(const struct device *dev, uint32_t config)
 {
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
-	struct i2c_stm32_data *data = DEV_DATA(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
+	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 	uint32_t clock = 0U;
 	int ret;
@@ -66,7 +66,7 @@ int i2c_stm32_runtime_configure(const struct device *dev, uint32_t config)
 static int i2c_stm32_transfer(const struct device *dev, struct i2c_msg *msg,
 			      uint8_t num_msgs, uint16_t slave)
 {
-	struct i2c_stm32_data *data = DEV_DATA(dev);
+	struct i2c_stm32_data *data = dev->data;
 	struct i2c_msg *current, *next;
 	int ret = 0;
 
@@ -180,10 +180,10 @@ static const struct i2c_driver_api api_funcs = {
 static int i2c_stm32_init(const struct device *dev)
 {
 	const struct device *clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
 	uint32_t bitrate_cfg;
 	int ret;
-	struct i2c_stm32_data *data = DEV_DATA(dev);
+	struct i2c_stm32_data *data = dev->data;
 #ifdef CONFIG_I2C_STM32_INTERRUPT
 	k_sem_init(&data->device_sync_sem, 0, K_SEM_MAX_LIMIT);
 	cfg->irq_config_func(dev);

--- a/drivers/i2c/i2c_ll_stm32.h
+++ b/drivers/i2c/i2c_ll_stm32.h
@@ -90,8 +90,4 @@ int i2c_stm32_slave_unregister(const struct device *dev,
 			       struct i2c_slave_config *config);
 #endif
 
-#define DEV_DATA(dev) ((struct i2c_stm32_data * const)(dev)->data)
-#define DEV_CFG(dev)	\
-((const struct i2c_stm32_config * const)(dev)->config)
-
 #endif	/* ZEPHYR_DRIVERS_I2C_I2C_LL_STM32_H_ */

--- a/drivers/i2c/i2c_ll_stm32_v1.c
+++ b/drivers/i2c/i2c_ll_stm32_v1.c
@@ -47,7 +47,7 @@ static void stm32_i2c_generate_start_condition(I2C_TypeDef *i2c)
 
 static void stm32_i2c_disable_transfer_interrupts(const struct device *dev)
 {
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
 	I2C_TypeDef *i2c = cfg->i2c;
 
 	LL_I2C_DisableIT_TX(i2c);
@@ -59,7 +59,7 @@ static void stm32_i2c_disable_transfer_interrupts(const struct device *dev)
 
 static void stm32_i2c_enable_transfer_interrupts(const struct device *dev)
 {
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
 	I2C_TypeDef *i2c = cfg->i2c;
 
 	LL_I2C_EnableIT_ERR(i2c);
@@ -71,7 +71,7 @@ static void stm32_i2c_enable_transfer_interrupts(const struct device *dev)
 
 static void stm32_i2c_reset(const struct device *dev)
 {
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
 	I2C_TypeDef *i2c = cfg->i2c;
 	uint16_t cr1, cr2, oar1, oar2, trise, ccr;
 #if defined(I2C_FLTR_ANOFF) && defined(I2C_FLTR_DNF)
@@ -117,7 +117,7 @@ static void stm32_i2c_reset(const struct device *dev)
 
 static void stm32_i2c_master_finish(const struct device *dev)
 {
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
 	I2C_TypeDef *i2c = cfg->i2c;
 
 #ifdef CONFIG_I2C_STM32_INTERRUPT
@@ -125,7 +125,7 @@ static void stm32_i2c_master_finish(const struct device *dev)
 #endif
 
 #if defined(CONFIG_I2C_SLAVE)
-	struct i2c_stm32_data *data = DEV_DATA(dev);
+	struct i2c_stm32_data *data = dev->data;
 	data->master_active = false;
 	if (!data->slave_attached) {
 		LL_I2C_Disable(i2c);
@@ -142,8 +142,8 @@ static inline void msg_init(const struct device *dev, struct i2c_msg *msg,
 			    uint8_t *next_msg_flags, uint16_t slave,
 			    uint32_t transfer)
 {
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
-	struct i2c_stm32_data *data = DEV_DATA(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
+	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 
 	ARG_UNUSED(next_msg_flags);
@@ -178,7 +178,7 @@ static inline void msg_init(const struct device *dev, struct i2c_msg *msg,
 static int32_t msg_end(const struct device *dev, uint8_t *next_msg_flags,
 		       const char *funcname)
 {
-	struct i2c_stm32_data *data = DEV_DATA(dev);
+	struct i2c_stm32_data *data = dev->data;
 
 	if (data->current.is_nack || data->current.is_err ||
 	    data->current.is_arlo) {
@@ -217,15 +217,15 @@ error:
 
 static void stm32_i2c_master_mode_end(const struct device *dev)
 {
-	struct i2c_stm32_data *data = DEV_DATA(dev);
+	struct i2c_stm32_data *data = dev->data;
 
 	k_sem_give(&data->device_sync_sem);
 }
 
 static inline void handle_sb(const struct device *dev)
 {
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
-	struct i2c_stm32_data *data = DEV_DATA(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
+	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 
 	uint16_t saddr = data->slave_address;
@@ -258,8 +258,8 @@ static inline void handle_sb(const struct device *dev)
 
 static inline void handle_addr(const struct device *dev)
 {
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
-	struct i2c_stm32_data *data = DEV_DATA(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
+	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 
 	if (I2C_ADDR_10_BITS & data->dev_config) {
@@ -302,8 +302,8 @@ static inline void handle_addr(const struct device *dev)
 
 static inline void handle_txe(const struct device *dev)
 {
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
-	struct i2c_stm32_data *data = DEV_DATA(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
+	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 
 	if (data->current.len) {
@@ -332,8 +332,8 @@ static inline void handle_txe(const struct device *dev)
 
 static inline void handle_rxne(const struct device *dev)
 {
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
-	struct i2c_stm32_data *data = DEV_DATA(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
+	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 
 	if (data->current.len > 0) {
@@ -380,8 +380,8 @@ static inline void handle_rxne(const struct device *dev)
 
 static inline void handle_btf(const struct device *dev)
 {
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
-	struct i2c_stm32_data *data = DEV_DATA(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
+	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 
 	if (data->current.is_write) {
@@ -423,8 +423,8 @@ static inline void handle_btf(const struct device *dev)
 #if defined(CONFIG_I2C_SLAVE)
 static void stm32_i2c_slave_event(const struct device *dev)
 {
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
-	struct i2c_stm32_data *data = DEV_DATA(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
+	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 	const struct i2c_slave_callbacks *slave_cb =
 		data->slave_cfg->callbacks;
@@ -475,8 +475,8 @@ static void stm32_i2c_slave_event(const struct device *dev)
 int i2c_stm32_slave_register(const struct device *dev,
 			     struct i2c_slave_config *config)
 {
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
-	struct i2c_stm32_data *data = DEV_DATA(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
+	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 	uint32_t bitrate_cfg;
 	int ret;
@@ -521,8 +521,8 @@ int i2c_stm32_slave_register(const struct device *dev,
 int i2c_stm32_slave_unregister(const struct device *dev,
 			       struct i2c_slave_config *config)
 {
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
-	struct i2c_stm32_data *data = DEV_DATA(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
+	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 
 	if (!data->slave_attached) {
@@ -552,8 +552,8 @@ int i2c_stm32_slave_unregister(const struct device *dev,
 void stm32_i2c_event_isr(void *arg)
 {
 	const struct device *dev = (const struct device *)arg;
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
-	struct i2c_stm32_data *data = DEV_DATA(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
+	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 
 #if defined(CONFIG_I2C_SLAVE)
@@ -581,8 +581,8 @@ void stm32_i2c_event_isr(void *arg)
 void stm32_i2c_error_isr(void *arg)
 {
 	const struct device *dev = (const struct device *)arg;
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
-	struct i2c_stm32_data *data = DEV_DATA(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
+	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 
 #if defined(CONFIG_I2C_SLAVE)
@@ -617,7 +617,7 @@ end:
 int32_t stm32_i2c_msg_write(const struct device *dev, struct i2c_msg *msg,
 			    uint8_t *next_msg_flags, uint16_t saddr)
 {
-	struct i2c_stm32_data *data = DEV_DATA(dev);
+	struct i2c_stm32_data *data = dev->data;
 
 	msg_init(dev, msg, next_msg_flags, saddr, I2C_REQUEST_WRITE);
 
@@ -636,8 +636,8 @@ int32_t stm32_i2c_msg_write(const struct device *dev, struct i2c_msg *msg,
 int32_t stm32_i2c_msg_read(const struct device *dev, struct i2c_msg *msg,
 			   uint8_t *next_msg_flags, uint16_t saddr)
 {
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
-	struct i2c_stm32_data *data = DEV_DATA(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
+	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 
 	msg_init(dev, msg, next_msg_flags, saddr, I2C_REQUEST_READ);
@@ -659,8 +659,8 @@ int32_t stm32_i2c_msg_read(const struct device *dev, struct i2c_msg *msg,
 
 static inline int check_errors(const struct device *dev, const char *funcname)
 {
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
-	struct i2c_stm32_data *data = DEV_DATA(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
+	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 
 	if (LL_I2C_IsActiveFlag_AF(i2c)) {
@@ -710,8 +710,8 @@ static int stm32_i2c_wait_timeout(uint16_t *timeout)
 int32_t stm32_i2c_msg_write(const struct device *dev, struct i2c_msg *msg,
 			    uint8_t *next_msg_flags, uint16_t saddr)
 {
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
-	struct i2c_stm32_data *data = DEV_DATA(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
+	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 	uint32_t len = msg->len;
 	uint16_t timeout;
@@ -808,8 +808,8 @@ end:
 int32_t stm32_i2c_msg_read(const struct device *dev, struct i2c_msg *msg,
 			   uint8_t *next_msg_flags, uint16_t saddr)
 {
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
-	struct i2c_stm32_data *data = DEV_DATA(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
+	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 	uint32_t len = msg->len;
 	uint16_t timeout;
@@ -970,8 +970,8 @@ end:
 
 int32_t stm32_i2c_configure_timing(const struct device *dev, uint32_t clock)
 {
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
-	struct i2c_stm32_data *data = DEV_DATA(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
+	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 
 	switch (I2C_SPEED_GET(data->dev_config)) {

--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -31,8 +31,8 @@ static inline void msg_init(const struct device *dev, struct i2c_msg *msg,
 			    uint8_t *next_msg_flags, uint16_t slave,
 			    uint32_t transfer)
 {
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
-	struct i2c_stm32_data *data = DEV_DATA(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
+	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 
 	if (LL_I2C_IsEnabledReloadMode(i2c)) {
@@ -71,7 +71,7 @@ static inline void msg_init(const struct device *dev, struct i2c_msg *msg,
 
 static void stm32_i2c_disable_transfer_interrupts(const struct device *dev)
 {
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
 	I2C_TypeDef *i2c = cfg->i2c;
 
 	LL_I2C_DisableIT_TX(i2c);
@@ -84,7 +84,7 @@ static void stm32_i2c_disable_transfer_interrupts(const struct device *dev)
 
 static void stm32_i2c_enable_transfer_interrupts(const struct device *dev)
 {
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
 	I2C_TypeDef *i2c = cfg->i2c;
 
 	LL_I2C_EnableIT_STOP(i2c);
@@ -95,8 +95,8 @@ static void stm32_i2c_enable_transfer_interrupts(const struct device *dev)
 
 static void stm32_i2c_master_mode_end(const struct device *dev)
 {
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
-	struct i2c_stm32_data *data = DEV_DATA(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
+	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 
 	stm32_i2c_disable_transfer_interrupts(dev);
@@ -115,8 +115,8 @@ static void stm32_i2c_master_mode_end(const struct device *dev)
 #if defined(CONFIG_I2C_SLAVE)
 static void stm32_i2c_slave_event(const struct device *dev)
 {
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
-	struct i2c_stm32_data *data = DEV_DATA(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
+	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 	const struct i2c_slave_callbacks *slave_cb =
 		data->slave_cfg->callbacks;
@@ -181,8 +181,8 @@ static void stm32_i2c_slave_event(const struct device *dev)
 int i2c_stm32_slave_register(const struct device *dev,
 			     struct i2c_slave_config *config)
 {
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
-	struct i2c_stm32_data *data = DEV_DATA(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
+	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 	uint32_t bitrate_cfg;
 	int ret;
@@ -227,8 +227,8 @@ int i2c_stm32_slave_register(const struct device *dev,
 int i2c_stm32_slave_unregister(const struct device *dev,
 			       struct i2c_slave_config *config)
 {
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
-	struct i2c_stm32_data *data = DEV_DATA(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
+	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 
 	if (!data->slave_attached) {
@@ -261,8 +261,8 @@ int i2c_stm32_slave_unregister(const struct device *dev,
 
 static void stm32_i2c_event(const struct device *dev)
 {
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
-	struct i2c_stm32_data *data = DEV_DATA(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
+	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 
 #if defined(CONFIG_I2C_SLAVE)
@@ -324,8 +324,8 @@ end:
 
 static int stm32_i2c_error(const struct device *dev)
 {
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
-	struct i2c_stm32_data *data = DEV_DATA(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
+	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 
 #if defined(CONFIG_I2C_SLAVE)
@@ -383,8 +383,8 @@ void stm32_i2c_error_isr(void *arg)
 int stm32_i2c_msg_write(const struct device *dev, struct i2c_msg *msg,
 			uint8_t *next_msg_flags, uint16_t slave)
 {
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
-	struct i2c_stm32_data *data = DEV_DATA(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
+	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 	bool is_timeout = false;
 
@@ -441,8 +441,8 @@ error:
 int stm32_i2c_msg_read(const struct device *dev, struct i2c_msg *msg,
 		       uint8_t *next_msg_flags, uint16_t slave)
 {
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
-	struct i2c_stm32_data *data = DEV_DATA(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
+	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 	bool is_timeout = false;
 
@@ -500,7 +500,7 @@ error:
 #else /* !CONFIG_I2C_STM32_INTERRUPT */
 static inline int check_errors(const struct device *dev, const char *funcname)
 {
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
 	I2C_TypeDef *i2c = cfg->i2c;
 
 	if (LL_I2C_IsActiveFlag_NACK(i2c)) {
@@ -538,7 +538,7 @@ error:
 static inline int msg_done(const struct device *dev,
 			   unsigned int current_msg_flags)
 {
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
 	I2C_TypeDef *i2c = cfg->i2c;
 
 	/* Wait for transfer to complete */
@@ -563,7 +563,7 @@ static inline int msg_done(const struct device *dev,
 int stm32_i2c_msg_write(const struct device *dev, struct i2c_msg *msg,
 			uint8_t *next_msg_flags, uint16_t slave)
 {
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
 	I2C_TypeDef *i2c = cfg->i2c;
 	unsigned int len = 0U;
 	uint8_t *buf = msg->buf;
@@ -593,7 +593,7 @@ int stm32_i2c_msg_write(const struct device *dev, struct i2c_msg *msg,
 int stm32_i2c_msg_read(const struct device *dev, struct i2c_msg *msg,
 		       uint8_t *next_msg_flags, uint16_t slave)
 {
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
 	I2C_TypeDef *i2c = cfg->i2c;
 	unsigned int len = 0U;
 	uint8_t *buf = msg->buf;
@@ -619,8 +619,8 @@ int stm32_i2c_msg_read(const struct device *dev, struct i2c_msg *msg,
 
 int stm32_i2c_configure_timing(const struct device *dev, uint32_t clock)
 {
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
-	struct i2c_stm32_data *data = DEV_DATA(dev);
+	const struct i2c_stm32_config *cfg = dev->config;
+	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 	uint32_t i2c_hold_time_min, i2c_setup_time_min;
 	uint32_t i2c_h_min_time, i2c_l_min_time;

--- a/drivers/i2c/i2c_lpc11u6x.c
+++ b/drivers/i2c/i2c_lpc11u6x.c
@@ -13,9 +13,7 @@
 #include <dt-bindings/pinctrl/lpc11u6x-pinctrl.h>
 #include "i2c_lpc11u6x.h"
 
-#define DEV_CFG(dev) ((dev)->config)
-#define DEV_BASE(dev) (((struct lpc11u6x_i2c_config *) DEV_CFG((dev)))->base)
-#define DEV_DATA(dev) ((dev)->data)
+#define DEV_BASE(dev) (((struct lpc11u6x_i2c_config *)(dev->config))->base)
 
 static void lpc11u6x_i2c_set_bus_speed(const struct lpc11u6x_i2c_config *cfg,
 				       const struct device *clk_dev,
@@ -34,8 +32,8 @@ static void lpc11u6x_i2c_set_bus_speed(const struct lpc11u6x_i2c_config *cfg,
 static int lpc11u6x_i2c_configure(const struct device *dev,
 				  uint32_t dev_config)
 {
-	const struct lpc11u6x_i2c_config *cfg = DEV_CFG(dev);
-	struct lpc11u6x_i2c_data *data = DEV_DATA(dev);
+	const struct lpc11u6x_i2c_config *cfg = dev->config;
+	struct lpc11u6x_i2c_data *data = dev->data;
 	const struct device *clk_dev, *pinmux_dev;
 	uint32_t speed, flags = 0;
 
@@ -97,8 +95,8 @@ static int lpc11u6x_i2c_transfer(const struct device *dev,
 				 struct i2c_msg *msgs,
 				 uint8_t num_msgs, uint16_t addr)
 {
-	const struct lpc11u6x_i2c_config *cfg = DEV_CFG(dev);
-	struct lpc11u6x_i2c_data *data = DEV_DATA(dev);
+	const struct lpc11u6x_i2c_config *cfg = dev->config;
+	struct lpc11u6x_i2c_data *data = dev->data;
 	int ret = 0;
 
 	if (!num_msgs) {
@@ -140,8 +138,8 @@ static int lpc11u6x_i2c_transfer(const struct device *dev,
 static int lpc11u6x_i2c_slave_register(const struct device *dev,
 				       struct i2c_slave_config *cfg)
 {
-	const struct lpc11u6x_i2c_config *dev_cfg = DEV_CFG(dev);
-	struct lpc11u6x_i2c_data *data = DEV_DATA(dev);
+	const struct lpc11u6x_i2c_config *dev_cfg = dev->config;
+	struct lpc11u6x_i2c_data *data = dev->data;
 	int ret = 0;
 
 	if (!cfg) {
@@ -174,8 +172,8 @@ exit:
 static int lpc11u6x_i2c_slave_unregister(const struct device *dev,
 					 struct i2c_slave_config *cfg)
 {
-	const struct lpc11u6x_i2c_config *dev_cfg = DEV_CFG(dev);
-	struct lpc11u6x_i2c_data *data = DEV_DATA(dev);
+	const struct lpc11u6x_i2c_config *dev_cfg = dev->config;
+	struct lpc11u6x_i2c_data *data = dev->data;
 
 	if (!cfg) {
 		return -EINVAL;
@@ -194,8 +192,9 @@ static int lpc11u6x_i2c_slave_unregister(const struct device *dev,
 
 static void lpc11u6x_i2c_isr(const void *arg)
 {
-	struct lpc11u6x_i2c_data *data = DEV_DATA((const struct device *)arg);
-	struct lpc11u6x_i2c_regs *i2c = DEV_BASE((const struct device *) arg);
+	const struct device *dev = arg;
+	struct lpc11u6x_i2c_data *data = dev->data;
+	struct lpc11u6x_i2c_regs *i2c = DEV_BASE(dev);
 	struct lpc11u6x_i2c_current_transfer *transfer = &data->transfer;
 	uint32_t clear = LPC11U6X_I2C_CONTROL_SI;
 	uint32_t set = 0;
@@ -328,8 +327,8 @@ static void lpc11u6x_i2c_isr(const void *arg)
 
 static int lpc11u6x_i2c_init(const struct device *dev)
 {
-	const struct lpc11u6x_i2c_config *cfg = DEV_CFG(dev);
-	struct lpc11u6x_i2c_data *data = DEV_DATA(dev);
+	const struct lpc11u6x_i2c_config *cfg = dev->config;
+	struct lpc11u6x_i2c_data *data = dev->data;
 	const struct device *pinmux_dev, *clk_dev;
 
 	/* Configure SCL and SDA pins */

--- a/drivers/i2c/i2c_mcux.c
+++ b/drivers/i2c/i2c_mcux.c
@@ -18,12 +18,8 @@ LOG_MODULE_REGISTER(i2c_mcux);
 
 #include "i2c-priv.h"
 
-#define DEV_CFG(dev) \
-	((const struct i2c_mcux_config * const)(dev)->config)
-#define DEV_DATA(dev) \
-	((struct i2c_mcux_data * const)(dev)->data)
 #define DEV_BASE(dev) \
-	((I2C_Type *)(DEV_CFG(dev))->base)
+	((I2C_Type *)((const struct i2c_mcux_config * const)(dev)->config)->base)
 
 struct i2c_mcux_config {
 	I2C_Type *base;
@@ -43,8 +39,8 @@ static int i2c_mcux_configure(const struct device *dev,
 			      uint32_t dev_config_raw)
 {
 	I2C_Type *base = DEV_BASE(dev);
-	struct i2c_mcux_data *data = DEV_DATA(dev);
-	const struct i2c_mcux_config *config = DEV_CFG(dev);
+	struct i2c_mcux_data *data = dev->data;
+	const struct i2c_mcux_config *config = dev->config;
 	uint32_t clock_freq;
 	uint32_t baudrate;
 
@@ -110,7 +106,7 @@ static int i2c_mcux_transfer(const struct device *dev, struct i2c_msg *msgs,
 			     uint8_t num_msgs, uint16_t addr)
 {
 	I2C_Type *base = DEV_BASE(dev);
-	struct i2c_mcux_data *data = DEV_DATA(dev);
+	struct i2c_mcux_data *data = dev->data;
 	i2c_master_transfer_t transfer;
 	status_t status;
 	int ret = 0;
@@ -178,7 +174,7 @@ static int i2c_mcux_transfer(const struct device *dev, struct i2c_msg *msgs,
 static void i2c_mcux_isr(const struct device *dev)
 {
 	I2C_Type *base = DEV_BASE(dev);
-	struct i2c_mcux_data *data = DEV_DATA(dev);
+	struct i2c_mcux_data *data = dev->data;
 
 	I2C_MasterTransferHandleIRQ(base, &data->handle);
 }
@@ -186,8 +182,8 @@ static void i2c_mcux_isr(const struct device *dev)
 static int i2c_mcux_init(const struct device *dev)
 {
 	I2C_Type *base = DEV_BASE(dev);
-	const struct i2c_mcux_config *config = DEV_CFG(dev);
-	struct i2c_mcux_data *data = DEV_DATA(dev);
+	const struct i2c_mcux_config *config = dev->config;
+	struct i2c_mcux_data *data = dev->data;
 	uint32_t clock_freq, bitrate_cfg;
 	i2c_master_config_t master_config;
 	int error;

--- a/drivers/i2c/i2c_nios2.c
+++ b/drivers/i2c/i2c_nios2.c
@@ -19,9 +19,6 @@ LOG_MODULE_REGISTER(i2c_nios2);
 
 #define NIOS2_I2C_TIMEOUT_USEC		1000
 
-#define DEV_CFG(dev) \
-	((struct i2c_nios2_config *)(dev)->config)
-
 struct i2c_nios2_config {
 	ALT_AVALON_I2C_DEV_t	i2c_dev;
 	IRQ_DATA_t		irq_data;
@@ -30,7 +27,7 @@ struct i2c_nios2_config {
 
 static int i2c_nios2_configure(const struct device *dev, uint32_t dev_config)
 {
-	struct i2c_nios2_config *config = DEV_CFG(dev);
+	struct i2c_nios2_config *config = (struct i2c_nios2_config *)dev->config;
 	int32_t rc = 0;
 
 	k_sem_take(&config->sem_lock, K_FOREVER);
@@ -62,7 +59,7 @@ i2c_cfg_err:
 static int i2c_nios2_transfer(const struct device *dev, struct i2c_msg *msgs,
 			      uint8_t num_msgs, uint16_t addr)
 {
-	struct i2c_nios2_config *config = DEV_CFG(dev);
+	struct i2c_nios2_config *config = (struct i2c_nios2_config *)dev->config;
 	ALT_AVALON_I2C_STATUS_CODE status;
 	uint32_t restart, stop;
 	int32_t i, timeout, rc = 0;
@@ -143,7 +140,7 @@ i2c_transfer_err:
 
 static void i2c_nios2_isr(const struct device *dev)
 {
-	struct i2c_nios2_config *config = DEV_CFG(dev);
+	struct i2c_nios2_config *config = (struct i2c_nios2_config *)dev->config;
 
 	/* Call Altera HAL driver ISR */
 	alt_handle_irq(&config->i2c_dev, DT_INST_IRQN(0));
@@ -172,7 +169,7 @@ I2C_DEVICE_DT_INST_DEFINE(0, i2c_nios2_init, NULL,
 
 static int i2c_nios2_init(const struct device *dev)
 {
-	struct i2c_nios2_config *config = DEV_CFG(dev);
+	struct i2c_nios2_config *config = (struct i2c_nios2_config *)dev->config;
 	int rc;
 
 	/* initialize semaphore */

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -27,29 +27,20 @@ struct i2c_nrfx_twi_config {
 	nrfx_twi_config_t config;
 };
 
-static inline struct i2c_nrfx_twi_data *get_dev_data(const struct device *dev)
-{
-	return dev->data;
-}
-
-static inline
-const struct i2c_nrfx_twi_config *get_dev_config(const struct device *dev)
-{
-	return dev->config;
-}
-
 static int i2c_nrfx_twi_transfer(const struct device *dev,
 				 struct i2c_msg *msgs,
 				 uint8_t num_msgs, uint16_t addr)
 {
+	const struct i2c_nrfx_twi_config *config = dev->config;
+	struct i2c_nrfx_twi_data *data = dev->data;
 	int ret = 0;
 
-	k_sem_take(&(get_dev_data(dev)->transfer_sync), K_FOREVER);
+	k_sem_take(&data->transfer_sync, K_FOREVER);
 
 	/* Dummy take on completion_sync sem to be sure that it is empty */
-	k_sem_take(&(get_dev_data(dev)->completion_sync), K_NO_WAIT);
+	k_sem_take(&data->completion_sync, K_NO_WAIT);
 
-	nrfx_twi_enable(&get_dev_config(dev)->twi);
+	nrfx_twi_enable(&config->twi);
 
 	for (size_t i = 0; i < num_msgs; i++) {
 		if (I2C_MSG_ADDR_10_BITS & msgs[i].flags) {
@@ -95,9 +86,7 @@ static int i2c_nrfx_twi_transfer(const struct device *dev,
 			}
 		}
 
-		res = nrfx_twi_xfer(&get_dev_config(dev)->twi,
-				    &cur_xfer,
-				    xfer_flags);
+		res = nrfx_twi_xfer(&config->twi, &cur_xfer, xfer_flags);
 		if (res != NRFX_SUCCESS) {
 			if (res == NRFX_ERROR_BUSY) {
 				ret = -EBUSY;
@@ -108,7 +97,7 @@ static int i2c_nrfx_twi_transfer(const struct device *dev,
 			}
 		}
 
-		ret = k_sem_take(&(get_dev_data(dev)->completion_sync),
+		ret = k_sem_take(&data->completion_sync,
 				 I2C_TRANSFER_TIMEOUT_MSEC);
 		if (ret != 0) {
 			/* Whatever the frequency, completion_sync should have
@@ -128,14 +117,14 @@ static int i2c_nrfx_twi_transfer(const struct device *dev,
 			 * bus from this error.
 			 */
 			LOG_ERR("Error on I2C line occurred for message %d", i);
-			nrfx_twi_disable(&get_dev_config(dev)->twi);
-			nrfx_twi_bus_recover(get_dev_config(dev)->config.scl,
-					     get_dev_config(dev)->config.sda);
+			nrfx_twi_disable(&config->twi);
+			nrfx_twi_bus_recover(config->config.scl,
+					     config->config.sda);
 			ret = -EIO;
 			break;
 		}
 
-		res = get_dev_data(dev)->res;
+		res = data->res;
 		if (res != NRFX_SUCCESS) {
 			LOG_ERR("Error 0x%08X occurred for message %d", res, i);
 			ret = -EIO;
@@ -143,8 +132,8 @@ static int i2c_nrfx_twi_transfer(const struct device *dev,
 		}
 	}
 
-	nrfx_twi_disable(&get_dev_config(dev)->twi);
-	k_sem_give(&(get_dev_data(dev)->transfer_sync));
+	nrfx_twi_disable(&config->twi);
+	k_sem_give(&data->transfer_sync);
 
 	return ret;
 }
@@ -174,7 +163,9 @@ static void event_handler(nrfx_twi_evt_t const *p_event, void *p_context)
 static int i2c_nrfx_twi_configure(const struct device *dev,
 				  uint32_t dev_config)
 {
-	nrfx_twi_t const *inst = &(get_dev_config(dev)->twi);
+	const struct i2c_nrfx_twi_config *config = dev->config;
+	struct i2c_nrfx_twi_data *data = dev->data;
+	nrfx_twi_t const *inst = &config->twi;
 
 	if (I2C_ADDR_10_BITS & dev_config) {
 		return -EINVAL;
@@ -191,15 +182,17 @@ static int i2c_nrfx_twi_configure(const struct device *dev,
 		LOG_ERR("unsupported speed");
 		return -EINVAL;
 	}
-	get_dev_data(dev)->dev_config = dev_config;
+	data->dev_config = dev_config;
 
 	return 0;
 }
 
 static int i2c_nrfx_twi_recover_bus(const struct device *dev)
 {
-	nrfx_err_t err = nrfx_twi_bus_recover(get_dev_config(dev)->config.scl,
-					      get_dev_config(dev)->config.sda);
+	const struct i2c_nrfx_twi_config *config = dev->config;
+
+	nrfx_err_t err = nrfx_twi_bus_recover(config->config.scl,
+					      config->config.sda);
 
 	return (err == NRFX_SUCCESS ? 0 : -EBUSY);
 }
@@ -212,9 +205,9 @@ static const struct i2c_driver_api i2c_nrfx_twi_driver_api = {
 
 static int init_twi(const struct device *dev)
 {
-	struct i2c_nrfx_twi_data *dev_data = get_dev_data(dev);
-	nrfx_err_t result = nrfx_twi_init(&get_dev_config(dev)->twi,
-					  &get_dev_config(dev)->config,
+	const struct i2c_nrfx_twi_config *config = dev->config;
+	struct i2c_nrfx_twi_data *dev_data = dev->data;
+	nrfx_err_t result = nrfx_twi_init(&config->twi, &config->config,
 					  event_handler, dev_data);
 	if (result != NRFX_SUCCESS) {
 		LOG_ERR("Failed to initialize device: %s",
@@ -229,19 +222,20 @@ static int init_twi(const struct device *dev)
 static int twi_nrfx_pm_action(const struct device *dev,
 			      enum pm_device_action action)
 {
+	const struct i2c_nrfx_twi_config *config = dev->config;
+	struct i2c_nrfx_twi_data *data = dev->data;
 	int ret = 0;
 
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
 		init_twi(dev);
-		if (get_dev_data(dev)->dev_config) {
-			i2c_nrfx_twi_configure(dev,
-					       get_dev_data(dev)->dev_config);
+		if (data->dev_config) {
+			i2c_nrfx_twi_configure(dev, data->dev_config);
 		}
 		break;
 
 	case PM_DEVICE_ACTION_SUSPEND:
-		nrfx_twi_uninit(&get_dev_config(dev)->twi);
+		nrfx_twi_uninit(&config->twi);
 		break;
 
 	default:

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -31,23 +31,12 @@ struct i2c_nrfx_twim_config {
 	uint16_t flash_buf_max_size;
 };
 
-static inline struct i2c_nrfx_twim_data *get_dev_data(const struct device *dev)
-{
-	return dev->data;
-}
-
-static inline
-const struct i2c_nrfx_twim_config *get_dev_config(const struct device *dev)
-{
-	return dev->config;
-}
-
 static int i2c_nrfx_twim_transfer(const struct device *dev,
 				  struct i2c_msg *msgs,
 				  uint8_t num_msgs, uint16_t addr)
 {
-	struct i2c_nrfx_twim_data *dev_data = get_dev_data(dev);
-	const struct i2c_nrfx_twim_config *dev_config = get_dev_config(dev);
+	struct i2c_nrfx_twim_data *dev_data = dev->data;
+	const struct i2c_nrfx_twim_config *dev_config = dev->config;
 	int ret = 0;
 	uint8_t *msg_buf = dev_data->msg_buf;
 	uint16_t msg_buf_used = 0;
@@ -238,7 +227,9 @@ static void event_handler(nrfx_twim_evt_t const *p_event, void *p_context)
 static int i2c_nrfx_twim_configure(const struct device *dev,
 				   uint32_t dev_config)
 {
-	nrfx_twim_t const *inst = &(get_dev_config(dev)->twim);
+	const struct i2c_nrfx_twim_config *config = dev->config;
+	struct i2c_nrfx_twim_data *data = dev->data;
+	nrfx_twim_t const *inst = &config->twim;
 
 	if (I2C_ADDR_10_BITS & dev_config) {
 		return -EINVAL;
@@ -255,15 +246,17 @@ static int i2c_nrfx_twim_configure(const struct device *dev,
 		LOG_ERR("unsupported speed");
 		return -EINVAL;
 	}
-	get_dev_data(dev)->dev_config = dev_config;
+	data->dev_config = dev_config;
 
 	return 0;
 }
 
 static int i2c_nrfx_twim_recover_bus(const struct device *dev)
 {
-	nrfx_err_t err = nrfx_twim_bus_recover(get_dev_config(dev)->config.scl,
-					       get_dev_config(dev)->config.sda);
+	const struct i2c_nrfx_twim_config *config = dev->config;
+
+	nrfx_err_t err = nrfx_twim_bus_recover(config->config.scl,
+					       config->config.sda);
 
 	return (err == NRFX_SUCCESS ? 0 : -EBUSY);
 }
@@ -276,11 +269,10 @@ static const struct i2c_driver_api i2c_nrfx_twim_driver_api = {
 
 static int init_twim(const struct device *dev)
 {
-	struct i2c_nrfx_twim_data *dev_data = get_dev_data(dev);
-	nrfx_err_t result = nrfx_twim_init(&get_dev_config(dev)->twim,
-					   &get_dev_config(dev)->config,
-					   event_handler,
-					   dev_data);
+	const struct i2c_nrfx_twim_config *config = dev->config;
+	struct i2c_nrfx_twim_data *dev_data = dev->data;
+	nrfx_err_t result = nrfx_twim_init(&config->twim, &config->config,
+					   event_handler, dev_data);
 	if (result != NRFX_SUCCESS) {
 		LOG_ERR("Failed to initialize device: %s",
 			dev->name);
@@ -294,19 +286,20 @@ static int init_twim(const struct device *dev)
 static int twim_nrfx_pm_action(const struct device *dev,
 			       enum pm_device_action action)
 {
+	const struct i2c_nrfx_twim_config *config = dev->config;
+	struct i2c_nrfx_twim_data *data = dev->data;
 	int ret = 0;
 
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
 		init_twim(dev);
-		if (get_dev_data(dev)->dev_config) {
-			i2c_nrfx_twim_configure(dev,
-						get_dev_data(dev)->dev_config);
+		if (data->dev_config) {
+			i2c_nrfx_twim_configure(dev, data->dev_config);
 		}
 		break;
 
 	case PM_DEVICE_ACTION_SUSPEND:
-		nrfx_twim_uninit(&get_dev_config(dev)->twim);
+		nrfx_twim_uninit(&config->twim);
 		break;
 
 	default:

--- a/drivers/i2c/i2c_sam0.c
+++ b/drivers/i2c/i2c_sam0.c
@@ -57,10 +57,6 @@ struct i2c_sam0_dev_data {
 };
 
 #define DEV_NAME(dev) ((dev)->name)
-#define DEV_CFG(dev) \
-	((const struct i2c_sam0_dev_config *const)(dev)->config)
-#define DEV_DATA(dev) \
-	((struct i2c_sam0_dev_data *const)(dev)->data)
 
 static void wait_synchronization(SercomI2cm *regs)
 {
@@ -79,8 +75,8 @@ static void wait_synchronization(SercomI2cm *regs)
 
 static bool i2c_sam0_terminate_on_error(const struct device *dev)
 {
-	struct i2c_sam0_dev_data *data = DEV_DATA(dev);
-	const struct i2c_sam0_dev_config *const cfg = DEV_CFG(dev);
+	struct i2c_sam0_dev_data *data = dev->data;
+	const struct i2c_sam0_dev_config *const cfg = dev->config;
 	SercomI2cm *i2c = cfg->regs;
 
 	if (!(i2c->STATUS.reg & (SERCOM_I2CM_STATUS_ARBLOST |
@@ -126,8 +122,8 @@ static bool i2c_sam0_terminate_on_error(const struct device *dev)
 
 static void i2c_sam0_isr(const struct device *dev)
 {
-	struct i2c_sam0_dev_data *data = DEV_DATA(dev);
-	const struct i2c_sam0_dev_config *const cfg = DEV_CFG(dev);
+	struct i2c_sam0_dev_data *data = dev->data;
+	const struct i2c_sam0_dev_config *const cfg = dev->config;
 	SercomI2cm *i2c = cfg->regs;
 
 	/* Get present interrupts and clear them */
@@ -198,8 +194,8 @@ static void i2c_sam0_dma_write_done(const struct device *dma_dev, void *arg,
 				    uint32_t id, int error_code)
 {
 	const struct device *dev = arg;
-	struct i2c_sam0_dev_data *data = DEV_DATA(dev);
-	const struct i2c_sam0_dev_config *const cfg = DEV_CFG(dev);
+	struct i2c_sam0_dev_data *data = dev->data;
+	const struct i2c_sam0_dev_config *const cfg = dev->config;
 	SercomI2cm *i2c = cfg->regs;
 
 	ARG_UNUSED(dma_dev);
@@ -235,8 +231,8 @@ static void i2c_sam0_dma_write_done(const struct device *dma_dev, void *arg,
 
 static bool i2c_sam0_dma_write_start(const struct device *dev)
 {
-	struct i2c_sam0_dev_data *data = DEV_DATA(dev);
-	const struct i2c_sam0_dev_config *const cfg = DEV_CFG(dev);
+	struct i2c_sam0_dev_data *data = dev->data;
+	const struct i2c_sam0_dev_config *const cfg = dev->config;
 	SercomI2cm *i2c = cfg->regs;
 	int retval;
 
@@ -289,8 +285,8 @@ static void i2c_sam0_dma_read_done(const struct device *dma_dev, void *arg,
 				   uint32_t id, int error_code)
 {
 	const struct device *dev = arg;
-	struct i2c_sam0_dev_data *data = DEV_DATA(dev);
-	const struct i2c_sam0_dev_config *const cfg = DEV_CFG(dev);
+	struct i2c_sam0_dev_data *data = dev->data;
+	const struct i2c_sam0_dev_config *const cfg = dev->config;
 	SercomI2cm *i2c = cfg->regs;
 
 	ARG_UNUSED(dma_dev);
@@ -327,8 +323,8 @@ static void i2c_sam0_dma_read_done(const struct device *dma_dev, void *arg,
 
 static bool i2c_sam0_dma_read_start(const struct device *dev)
 {
-	struct i2c_sam0_dev_data *data = DEV_DATA(dev);
-	const struct i2c_sam0_dev_config *const cfg = DEV_CFG(dev);
+	struct i2c_sam0_dev_data *data = dev->data;
+	const struct i2c_sam0_dev_config *const cfg = dev->config;
 	SercomI2cm *i2c = cfg->regs;
 	int retval;
 
@@ -383,8 +379,8 @@ static bool i2c_sam0_dma_read_start(const struct device *dev)
 static int i2c_sam0_transfer(const struct device *dev, struct i2c_msg *msgs,
 			     uint8_t num_msgs, uint16_t addr)
 {
-	struct i2c_sam0_dev_data *data = DEV_DATA(dev);
-	const struct i2c_sam0_dev_config *const cfg = DEV_CFG(dev);
+	struct i2c_sam0_dev_data *data = dev->data;
+	const struct i2c_sam0_dev_config *const cfg = dev->config;
 	SercomI2cm *i2c = cfg->regs;
 	uint32_t addr_reg;
 
@@ -522,7 +518,7 @@ static int i2c_sam0_transfer(const struct device *dev, struct i2c_msg *msgs,
 static int i2c_sam0_set_apply_bitrate(const struct device *dev,
 				      uint32_t config)
 {
-	const struct i2c_sam0_dev_config *const cfg = DEV_CFG(dev);
+	const struct i2c_sam0_dev_config *const cfg = dev->config;
 	SercomI2cm *i2c = cfg->regs;
 	uint32_t baud;
 	uint32_t baud_low;
@@ -656,7 +652,7 @@ static int i2c_sam0_set_apply_bitrate(const struct device *dev,
 
 static int i2c_sam0_configure(const struct device *dev, uint32_t config)
 {
-	const struct i2c_sam0_dev_config *const cfg = DEV_CFG(dev);
+	const struct i2c_sam0_dev_config *const cfg = dev->config;
 	SercomI2cm *i2c = cfg->regs;
 	int retval;
 
@@ -683,8 +679,8 @@ static int i2c_sam0_configure(const struct device *dev, uint32_t config)
 
 static int i2c_sam0_initialize(const struct device *dev)
 {
-	struct i2c_sam0_dev_data *data = DEV_DATA(dev);
-	const struct i2c_sam0_dev_config *const cfg = DEV_CFG(dev);
+	struct i2c_sam0_dev_data *data = dev->data;
+	const struct i2c_sam0_dev_config *const cfg = dev->config;
 	SercomI2cm *i2c = cfg->regs;
 	int retval;
 

--- a/drivers/i2c/i2c_sam4l_twim.c
+++ b/drivers/i2c/i2c_sam4l_twim.c
@@ -103,14 +103,10 @@ struct i2c_sam_twim_dev_data {
 };
 
 #define DEV_NAME(dev) ((dev)->name)
-#define DEV_CFG(dev) \
-	((const struct i2c_sam_twim_dev_cfg *const)(dev)->config)
-#define DEV_DATA(dev) \
-	((struct i2c_sam_twim_dev_data *const)(dev)->data)
 
 static int i2c_clk_set(const struct device *dev, uint32_t speed)
 {
-	const struct i2c_sam_twim_dev_cfg *const cfg = DEV_CFG(dev);
+	const struct i2c_sam_twim_dev_cfg *const cfg = dev->config;
 	Twim *const twim = cfg->regs;
 	uint32_t per_clk = SOC_ATMEL_SAM_MCK_FREQ_HZ;
 	uint32_t f_prescaled = (per_clk / speed / 2);
@@ -286,8 +282,8 @@ static uint32_t i2c_prepare_xfer_cmd(struct i2c_sam_twim_dev_data *data,
 
 static void i2c_start_xfer(const struct device *dev, uint16_t daddr)
 {
-	const struct i2c_sam_twim_dev_cfg *const cfg = DEV_CFG(dev);
-	struct i2c_sam_twim_dev_data *data = DEV_DATA(dev);
+	const struct i2c_sam_twim_dev_cfg *const cfg = dev->config;
+	struct i2c_sam_twim_dev_data *data = dev->data;
 	struct i2c_msg *msg = &data->msgs[0];
 	Twim *const twim = cfg->regs;
 	uint32_t cmdr_reg;
@@ -420,8 +416,8 @@ static void i2c_prepare_next(struct i2c_sam_twim_dev_data *data,
 
 static void i2c_sam_twim_isr(const struct device *dev)
 {
-	const struct i2c_sam_twim_dev_cfg *const cfg = DEV_CFG(dev);
-	struct i2c_sam_twim_dev_data *const data = DEV_DATA(dev);
+	const struct i2c_sam_twim_dev_cfg *const cfg = dev->config;
+	struct i2c_sam_twim_dev_data *const data = dev->data;
 	Twim *const twim = cfg->regs;
 	struct i2c_msg *msg = &data->msgs[data->msg_cur_idx];
 	uint32_t isr_status;
@@ -507,7 +503,7 @@ static int i2c_sam_twim_transfer(const struct device *dev,
 				 struct i2c_msg *msgs,
 				 uint8_t num_msgs, uint16_t addr)
 {
-	struct i2c_sam_twim_dev_data *data = DEV_DATA(dev);
+	struct i2c_sam_twim_dev_data *data = dev->data;
 	int ret = 0;
 
 	/* Send out messages */
@@ -538,8 +534,8 @@ static int i2c_sam_twim_transfer(const struct device *dev,
 
 static int i2c_sam_twim_initialize(const struct device *dev)
 {
-	const struct i2c_sam_twim_dev_cfg *const cfg = DEV_CFG(dev);
-	struct i2c_sam_twim_dev_data *data = DEV_DATA(dev);
+	const struct i2c_sam_twim_dev_cfg *const cfg = dev->config;
+	struct i2c_sam_twim_dev_data *data = dev->data;
 	Twim *const twim = cfg->regs;
 	uint32_t bitrate_cfg;
 	int ret;

--- a/drivers/i2c/i2c_sam_twi.c
+++ b/drivers/i2c/i2c_sam_twi.c
@@ -66,12 +66,6 @@ struct i2c_sam_twi_dev_data {
 	struct twi_msg msg;
 };
 
-#define DEV_NAME(dev) ((dev)->name)
-#define DEV_CFG(dev) \
-	((const struct i2c_sam_twi_dev_cfg *const)(dev)->config)
-#define DEV_DATA(dev) \
-	((struct i2c_sam_twi_dev_data *const)(dev)->data)
-
 static int i2c_clk_set(Twi *const twi, uint32_t speed)
 {
 	uint32_t ck_div = 0U;
@@ -106,7 +100,7 @@ static int i2c_clk_set(Twi *const twi, uint32_t speed)
 
 static int i2c_sam_twi_configure(const struct device *dev, uint32_t config)
 {
-	const struct i2c_sam_twi_dev_cfg *const dev_cfg = DEV_CFG(dev);
+	const struct i2c_sam_twi_dev_cfg *const dev_cfg = dev->config;
 	Twi *const twi = dev_cfg->regs;
 	uint32_t bitrate;
 	int ret;
@@ -182,8 +176,8 @@ static int i2c_sam_twi_transfer(const struct device *dev,
 				struct i2c_msg *msgs,
 				uint8_t num_msgs, uint16_t addr)
 {
-	const struct i2c_sam_twi_dev_cfg *const dev_cfg = DEV_CFG(dev);
-	struct i2c_sam_twi_dev_data *const dev_data = DEV_DATA(dev);
+	const struct i2c_sam_twi_dev_cfg *const dev_cfg = dev->config;
+	struct i2c_sam_twi_dev_data *const dev_data = dev->data;
 	Twi *const twi = dev_cfg->regs;
 
 	__ASSERT_NO_MSG(msgs);
@@ -237,8 +231,8 @@ static int i2c_sam_twi_transfer(const struct device *dev,
 
 static void i2c_sam_twi_isr(const struct device *dev)
 {
-	const struct i2c_sam_twi_dev_cfg *const dev_cfg = DEV_CFG(dev);
-	struct i2c_sam_twi_dev_data *const dev_data = DEV_DATA(dev);
+	const struct i2c_sam_twi_dev_cfg *const dev_cfg = dev->config;
+	struct i2c_sam_twi_dev_data *const dev_data = dev->data;
 	Twi *const twi = dev_cfg->regs;
 	struct twi_msg *msg = &dev_data->msg;
 	uint32_t isr_status;
@@ -296,8 +290,8 @@ tx_comp:
 
 static int i2c_sam_twi_initialize(const struct device *dev)
 {
-	const struct i2c_sam_twi_dev_cfg *const dev_cfg = DEV_CFG(dev);
-	struct i2c_sam_twi_dev_data *const dev_data = DEV_DATA(dev);
+	const struct i2c_sam_twi_dev_cfg *const dev_cfg = dev->config;
+	struct i2c_sam_twi_dev_data *const dev_data = dev->data;
 	Twi *const twi = dev_cfg->regs;
 	uint32_t bitrate_cfg;
 	int ret;

--- a/drivers/i2c/i2c_sam_twihs.c
+++ b/drivers/i2c/i2c_sam_twihs.c
@@ -67,10 +67,6 @@ struct i2c_sam_twihs_dev_data {
 };
 
 #define DEV_NAME(dev) ((dev)->name)
-#define DEV_CFG(dev) \
-	((const struct i2c_sam_twihs_dev_cfg *const)(dev)->config)
-#define DEV_DATA(dev) \
-	((struct i2c_sam_twihs_dev_data *const)(dev)->data)
 
 static int i2c_clk_set(Twihs *const twihs, uint32_t speed)
 {
@@ -106,7 +102,7 @@ static int i2c_clk_set(Twihs *const twihs, uint32_t speed)
 
 static int i2c_sam_twihs_configure(const struct device *dev, uint32_t config)
 {
-	const struct i2c_sam_twihs_dev_cfg *const dev_cfg = DEV_CFG(dev);
+	const struct i2c_sam_twihs_dev_cfg *const dev_cfg = dev->config;
 	Twihs *const twihs = dev_cfg->regs;
 	uint32_t bitrate;
 	int ret;
@@ -184,8 +180,8 @@ static int i2c_sam_twihs_transfer(const struct device *dev,
 				  struct i2c_msg *msgs,
 				  uint8_t num_msgs, uint16_t addr)
 {
-	const struct i2c_sam_twihs_dev_cfg *const dev_cfg = DEV_CFG(dev);
-	struct i2c_sam_twihs_dev_data *const dev_data = DEV_DATA(dev);
+	const struct i2c_sam_twihs_dev_cfg *const dev_cfg = dev->config;
+	struct i2c_sam_twihs_dev_data *const dev_data = dev->data;
 	Twihs *const twihs = dev_cfg->regs;
 
 	__ASSERT_NO_MSG(msgs);
@@ -224,8 +220,8 @@ static int i2c_sam_twihs_transfer(const struct device *dev,
 
 static void i2c_sam_twihs_isr(const struct device *dev)
 {
-	const struct i2c_sam_twihs_dev_cfg *const dev_cfg = DEV_CFG(dev);
-	struct i2c_sam_twihs_dev_data *const dev_data = DEV_DATA(dev);
+	const struct i2c_sam_twihs_dev_cfg *const dev_cfg = dev->config;
+	struct i2c_sam_twihs_dev_data *const dev_data = dev->data;
 	Twihs *const twihs = dev_cfg->regs;
 	struct twihs_msg *msg = &dev_data->msg;
 	uint32_t isr_status;
@@ -283,8 +279,8 @@ tx_comp:
 
 static int i2c_sam_twihs_initialize(const struct device *dev)
 {
-	const struct i2c_sam_twihs_dev_cfg *const dev_cfg = DEV_CFG(dev);
-	struct i2c_sam_twihs_dev_data *const dev_data = DEV_DATA(dev);
+	const struct i2c_sam_twihs_dev_cfg *const dev_cfg = dev->config;
+	struct i2c_sam_twihs_dev_data *const dev_data = dev->data;
 	Twihs *const twihs = dev_cfg->regs;
 	uint32_t bitrate_cfg;
 	int ret;

--- a/drivers/i2c/slave/eeprom_slave.c
+++ b/drivers/i2c/slave/eeprom_slave.c
@@ -33,13 +33,6 @@ struct i2c_eeprom_slave_config {
 	uint8_t *buffer;
 };
 
-/* convenience defines */
-#define DEV_CFG(dev)							\
-	((const struct i2c_eeprom_slave_config * const)			\
-		(dev)->config)
-#define DEV_DATA(dev)							\
-	((struct i2c_eeprom_slave_data * const)(dev)->data)
-
 int eeprom_slave_program(const struct device *dev, const uint8_t *eeprom_data,
 			 unsigned int length)
 {
@@ -186,8 +179,8 @@ static const struct i2c_slave_callbacks eeprom_callbacks = {
 
 static int i2c_eeprom_slave_init(const struct device *dev)
 {
-	struct i2c_eeprom_slave_data *data = DEV_DATA(dev);
-	const struct i2c_eeprom_slave_config *cfg = DEV_CFG(dev);
+	struct i2c_eeprom_slave_data *data = dev->data;
+	const struct i2c_eeprom_slave_config *cfg = dev->config;
 
 	data->i2c_controller =
 		device_get_binding(cfg->controller_dev_name);

--- a/drivers/i2s/i2s_cavs.c
+++ b/drivers/i2s/i2s_cavs.c
@@ -86,10 +86,6 @@ struct i2s_cavs_dev_data {
 };
 
 #define DEV_NAME(dev) ((dev)->name)
-#define DEV_CFG(dev) \
-	((const struct i2s_cavs_config *const)(dev)->config)
-#define DEV_DATA(dev) \
-	((struct i2s_cavs_dev_data *const)(dev)->data)
 
 static void i2s_dma_tx_callback(const struct device *, void *, uint32_t, int);
 static void i2s_tx_stream_disable(struct i2s_cavs_dev_data *,
@@ -115,8 +111,8 @@ static void i2s_dma_tx_callback(const struct device *dma_dev, void *arg,
 				uint32_t channel, int status)
 {
 	const struct device *dev = (const struct device *)arg;
-	const struct i2s_cavs_config *const dev_cfg = DEV_CFG(dev);
-	struct i2s_cavs_dev_data *const dev_data = DEV_DATA(dev);
+	const struct i2s_cavs_config *const dev_cfg = dev->config;
+	struct i2s_cavs_dev_data *const dev_data = dev->data;
 
 	volatile struct i2s_cavs_ssp *const ssp = dev_cfg->regs;
 	struct stream *strm = &dev_data->tx;
@@ -171,8 +167,8 @@ static void i2s_dma_rx_callback(const struct device *dma_dev, void *arg,
 				uint32_t channel, int status)
 {
 	const struct device *dev = (const struct device *)arg;
-	const struct i2s_cavs_config *const dev_cfg = DEV_CFG(dev);
-	struct i2s_cavs_dev_data *const dev_data = DEV_DATA(dev);
+	const struct i2s_cavs_config *const dev_cfg = dev->config;
+	struct i2s_cavs_dev_data *const dev_data = dev->data;
 	volatile struct i2s_cavs_ssp *const ssp = dev_cfg->regs;
 	struct stream *strm = &dev_data->rx;
 	void *buffer;
@@ -229,8 +225,8 @@ static void i2s_dma_rx_callback(const struct device *dma_dev, void *arg,
 static int i2s_cavs_configure(const struct device *dev, enum i2s_dir dir,
 			      const struct i2s_config *i2s_cfg)
 {
-	const struct i2s_cavs_config *const dev_cfg = DEV_CFG(dev);
-	struct i2s_cavs_dev_data *const dev_data = DEV_DATA(dev);
+	const struct i2s_cavs_config *const dev_cfg = dev->config;
+	struct i2s_cavs_dev_data *const dev_data = dev->data;
 	volatile struct i2s_cavs_ssp *const ssp = dev_cfg->regs;
 	volatile struct i2s_cavs_mn_div *const mn_div = dev_cfg->mn_regs;
 	struct dma_block_config *dma_block;
@@ -635,8 +631,8 @@ static void i2s_rx_stream_disable(struct i2s_cavs_dev_data *dev_data,
 static int i2s_cavs_trigger(const struct device *dev, enum i2s_dir dir,
 			    enum i2s_trigger_cmd cmd)
 {
-	const struct i2s_cavs_config *const dev_cfg = DEV_CFG(dev);
-	struct i2s_cavs_dev_data *const dev_data = DEV_DATA(dev);
+	const struct i2s_cavs_config *const dev_cfg = dev->config;
+	struct i2s_cavs_dev_data *const dev_data = dev->data;
 	volatile struct i2s_cavs_ssp *const ssp = dev_cfg->regs;
 	struct stream *strm;
 	unsigned int key;
@@ -699,7 +695,7 @@ static int i2s_cavs_trigger(const struct device *dev, enum i2s_dir dir,
 static int i2s_cavs_read(const struct device *dev, void **mem_block,
 			 size_t *size)
 {
-	struct i2s_cavs_dev_data *const dev_data = DEV_DATA(dev);
+	struct i2s_cavs_dev_data *const dev_data = dev->data;
 	struct stream *strm = &dev_data->rx;
 	void *buffer;
 	int ret = 0;
@@ -723,7 +719,7 @@ static int i2s_cavs_read(const struct device *dev, void **mem_block,
 static int i2s_cavs_write(const struct device *dev, void *mem_block,
 			  size_t size)
 {
-	struct i2s_cavs_dev_data *const dev_data = DEV_DATA(dev);
+	struct i2s_cavs_dev_data *const dev_data = dev->data;
 	struct stream *strm = &dev_data->tx;
 	int ret;
 
@@ -748,9 +744,9 @@ static int i2s_cavs_write(const struct device *dev, void *mem_block,
 /* clear IRQ sources atm */
 static void i2s_cavs_isr(const struct device *dev)
 {
-	const struct i2s_cavs_config *const dev_cfg = DEV_CFG(dev);
+	const struct i2s_cavs_config *const dev_cfg = dev->config;
 	volatile struct i2s_cavs_ssp *const ssp = dev_cfg->regs;
-	struct i2s_cavs_dev_data *const dev_data = DEV_DATA(dev);
+	struct i2s_cavs_dev_data *const dev_data = dev->data;
 	uint32_t status;
 
 	/* clear interrupts */
@@ -771,8 +767,8 @@ static void i2s_cavs_isr(const struct device *dev)
 
 static int i2s_cavs_initialize(const struct device *dev)
 {
-	const struct i2s_cavs_config *const dev_cfg = DEV_CFG(dev);
-	struct i2s_cavs_dev_data *const dev_data = DEV_DATA(dev);
+	const struct i2s_cavs_config *const dev_cfg = dev->config;
+	struct i2s_cavs_dev_data *const dev_data = dev->data;
 
 	if (!device_is_ready(dev_cfg->dev_dma)) {
 		LOG_ERR("%s device not ready", dev_cfg->dev_dma->name);

--- a/drivers/i2s/i2s_litex.c
+++ b/drivers/i2s/i2s_litex.c
@@ -306,7 +306,7 @@ static int queue_put(struct ring_buf *rb, void *mem_block, size_t size)
 
 static int i2s_litex_initialize(const struct device *dev)
 {
-	struct i2s_litex_cfg *cfg = dev->config;
+	const struct i2s_litex_cfg *cfg = dev->config;
 	struct i2s_litex_data *const dev_data = dev->data;
 
 	k_sem_init(&dev_data->rx.sem, 0, CONFIG_I2S_LITEX_RX_BLOCK_COUNT);

--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -96,7 +96,7 @@ static int queue_put(struct ring_buf *rb, void *mem_block, size_t size)
 
 static int i2s_stm32_enable_clock(const struct device *dev)
 {
-	const struct i2s_stm32_cfg *cfg = DEV_CFG(dev);
+	const struct i2s_stm32_cfg *cfg = dev->config;
 	const struct device *clk;
 	int ret;
 
@@ -122,7 +122,7 @@ static uint16_t plli2s_ms_count;
 static int i2s_stm32_set_clock(const struct device *dev,
 			       uint32_t bit_clk_freq)
 {
-	const struct i2s_stm32_cfg *cfg = DEV_CFG(dev);
+	const struct i2s_stm32_cfg *cfg = dev->config;
 	uint32_t pll_src = LL_RCC_PLL_GetMainSource();
 	int freq_in;
 	uint8_t i2s_div, i2s_odd;
@@ -183,8 +183,8 @@ static int i2s_stm32_set_clock(const struct device *dev,
 static int i2s_stm32_configure(const struct device *dev, enum i2s_dir dir,
 			       const struct i2s_config *i2s_cfg)
 {
-	const struct i2s_stm32_cfg *const cfg = DEV_CFG(dev);
-	struct i2s_stm32_data *const dev_data = DEV_DATA(dev);
+	const struct i2s_stm32_cfg *const cfg = dev->config;
+	struct i2s_stm32_data *const dev_data = dev->data;
 	struct stream *stream;
 	uint32_t bit_clk_freq;
 	int ret;
@@ -289,7 +289,7 @@ static int i2s_stm32_configure(const struct device *dev, enum i2s_dir dir,
 static int i2s_stm32_trigger(const struct device *dev, enum i2s_dir dir,
 			     enum i2s_trigger_cmd cmd)
 {
-	struct i2s_stm32_data *const dev_data = DEV_DATA(dev);
+	struct i2s_stm32_data *const dev_data = dev->data;
 	struct stream *stream;
 	unsigned int key;
 	int ret;
@@ -382,7 +382,7 @@ static int i2s_stm32_trigger(const struct device *dev, enum i2s_dir dir,
 static int i2s_stm32_read(const struct device *dev, void **mem_block,
 			  size_t *size)
 {
-	struct i2s_stm32_data *const dev_data = DEV_DATA(dev);
+	struct i2s_stm32_data *const dev_data = dev->data;
 	int ret;
 
 	if (dev_data->rx.state == I2S_STATE_NOT_READY) {
@@ -410,7 +410,7 @@ static int i2s_stm32_read(const struct device *dev, void **mem_block,
 static int i2s_stm32_write(const struct device *dev, void *mem_block,
 			   size_t size)
 {
-	struct i2s_stm32_data *const dev_data = DEV_DATA(dev);
+	struct i2s_stm32_data *const dev_data = dev->data;
 	int ret;
 
 	if (dev_data->tx.state != I2S_STATE_RUNNING &&
@@ -505,8 +505,8 @@ static void dma_rx_callback(const struct device *dma_dev, void *arg,
 			    uint32_t channel, int status)
 {
 	const struct device *dev = get_dev_from_rx_dma_channel(channel);
-	const struct i2s_stm32_cfg *cfg = DEV_CFG(dev);
-	struct i2s_stm32_data *const dev_data = DEV_DATA(dev);
+	const struct i2s_stm32_cfg *cfg = dev->config;
+	struct i2s_stm32_data *const dev_data = dev->data;
 	struct stream *stream = &dev_data->rx;
 	void *mblk_tmp;
 	int ret;
@@ -572,8 +572,8 @@ static void dma_tx_callback(const struct device *dma_dev, void *arg,
 			    uint32_t channel, int status)
 {
 	const struct device *dev = get_dev_from_tx_dma_channel(channel);
-	const struct i2s_stm32_cfg *cfg = DEV_CFG(dev);
-	struct i2s_stm32_data *const dev_data = DEV_DATA(dev);
+	const struct i2s_stm32_cfg *cfg = dev->config;
+	struct i2s_stm32_data *const dev_data = dev->data;
 	struct stream *stream = &dev_data->tx;
 	size_t mem_block_size;
 	int ret;
@@ -639,8 +639,8 @@ static uint32_t i2s_stm32_irq_ovr_count;
 
 static void i2s_stm32_isr(const struct device *dev)
 {
-	const struct i2s_stm32_cfg *cfg = DEV_CFG(dev);
-	struct i2s_stm32_data *const dev_data = DEV_DATA(dev);
+	const struct i2s_stm32_cfg *cfg = dev->config;
+	struct i2s_stm32_data *const dev_data = dev->data;
 	struct stream *stream = &dev_data->rx;
 
 	LOG_ERR("%s: err=%d", __func__, (int)LL_I2S_ReadReg(cfg->i2s, SR));
@@ -657,8 +657,8 @@ static void i2s_stm32_isr(const struct device *dev)
 
 static int i2s_stm32_initialize(const struct device *dev)
 {
-	const struct i2s_stm32_cfg *cfg = DEV_CFG(dev);
-	struct i2s_stm32_data *const dev_data = DEV_DATA(dev);
+	const struct i2s_stm32_cfg *cfg = dev->config;
+	struct i2s_stm32_data *const dev_data = dev->data;
 	int ret, i;
 
 	/* Enable I2S clock propagation */
@@ -703,7 +703,7 @@ static int i2s_stm32_initialize(const struct device *dev)
 
 static int rx_stream_start(struct stream *stream, const struct device *dev)
 {
-	const struct i2s_stm32_cfg *cfg = DEV_CFG(dev);
+	const struct i2s_stm32_cfg *cfg = dev->config;
 	int ret;
 
 	ret = k_mem_slab_alloc(stream->cfg.mem_slab, &stream->mem_block,
@@ -742,7 +742,7 @@ static int rx_stream_start(struct stream *stream, const struct device *dev)
 
 static int tx_stream_start(struct stream *stream, const struct device *dev)
 {
-	const struct i2s_stm32_cfg *cfg = DEV_CFG(dev);
+	const struct i2s_stm32_cfg *cfg = dev->config;
 	size_t mem_block_size;
 	int ret;
 
@@ -786,7 +786,7 @@ static int tx_stream_start(struct stream *stream, const struct device *dev)
 
 static void rx_stream_disable(struct stream *stream, const struct device *dev)
 {
-	const struct i2s_stm32_cfg *cfg = DEV_CFG(dev);
+	const struct i2s_stm32_cfg *cfg = dev->config;
 
 	LL_I2S_DisableDMAReq_RX(cfg->i2s);
 	LL_I2S_DisableIT_ERR(cfg->i2s);
@@ -804,7 +804,7 @@ static void rx_stream_disable(struct stream *stream, const struct device *dev)
 
 static void tx_stream_disable(struct stream *stream, const struct device *dev)
 {
-	const struct i2s_stm32_cfg *cfg = DEV_CFG(dev);
+	const struct i2s_stm32_cfg *cfg = dev->config;
 
 	LL_I2S_DisableDMAReq_TX(cfg->i2s);
 	LL_I2S_DisableIT_ERR(cfg->i2s);

--- a/drivers/i2s/i2s_ll_stm32.h
+++ b/drivers/i2s/i2s_ll_stm32.h
@@ -49,11 +49,6 @@
 
 #endif /* CONFIG_I2S_STM32_USE_PLLI2S_ENABLE */
 
-#define DEV_CFG(dev) \
-	(const struct i2s_stm32_cfg * const)((dev)->config)
-#define DEV_DATA(dev) \
-	((struct i2s_stm32_data *const)(dev)->data)
-
 struct queue_item {
 	void *mem_block;
 	size_t size;

--- a/drivers/i2s/i2s_mcux_sai.c
+++ b/drivers/i2s/i2s_mcux_sai.c
@@ -111,7 +111,7 @@ static inline void i2s_purge_stream_buffers(struct stream *strm,
 
 static void i2s_tx_stream_disable(const struct device *dev)
 {
-	struct i2s_dev_data *dev_data = (struct i2s_dev_data *)dev->data;
+	struct i2s_dev_data *dev_data = dev->data;
 	struct stream *strm = &dev_data->tx;
 	const struct device *dev_dma = dev_data->dev_dma;
 	const struct i2s_mcux_config *dev_cfg = dev->config;
@@ -144,7 +144,7 @@ static void i2s_tx_stream_disable(const struct device *dev)
 
 static void i2s_rx_stream_disable(const struct device *dev)
 {
-	struct i2s_dev_data *dev_data = (struct i2s_dev_data *)dev->data;
+	struct i2s_dev_data *dev_data = dev->data;
 	struct stream *strm = &dev_data->rx;
 	const struct device *dev_dma = dev_data->dev_dma;
 	const struct i2s_mcux_config *dev_cfg = dev->config;
@@ -184,7 +184,7 @@ static void i2s_dma_tx_callback(const struct device *dma_dev,
 	const struct device *dev = (struct device *)arg;
 	const struct i2s_mcux_config *dev_cfg = dev->config;
 	I2S_Type *base = (I2S_Type *)dev_cfg->base;
-	struct i2s_dev_data *dev_data = (struct i2s_dev_data *)dev->data;
+	struct i2s_dev_data *dev_data = dev->data;
 	struct stream *strm = &dev_data->tx;
 	void *buffer = NULL;
 	int ret;
@@ -255,7 +255,7 @@ static void i2s_dma_rx_callback(const struct device *dma_dev,
 	struct device *dev = (struct device *)arg;
 	const struct i2s_mcux_config *dev_cfg = dev->config;
 	I2S_Type *base = (I2S_Type *)dev_cfg->base;
-	struct i2s_dev_data *dev_data = (struct i2s_dev_data *)dev->data;
+	struct i2s_dev_data *dev_data = dev->data;
 	struct stream *strm = &dev_data->rx;
 	void *buffer;
 	int ret;
@@ -361,7 +361,7 @@ static int i2s_mcux_config(const struct device *dev, enum i2s_dir dir,
 {
 	const struct i2s_mcux_config *dev_cfg = dev->config;
 	I2S_Type *base = (I2S_Type *)dev_cfg->base;
-	struct i2s_dev_data *dev_data = (struct i2s_dev_data *)dev->data;
+	struct i2s_dev_data *dev_data = dev->data;
 	sai_transceiver_t config;
 	uint32_t mclk;
 	/*num_words is frame size*/
@@ -614,7 +614,7 @@ static int i2s_mcux_config(const struct device *dev, enum i2s_dir dir,
 const struct i2s_config *i2s_mcux_config_get(const struct device *dev,
 					     enum i2s_dir dir)
 {
-	struct i2s_dev_data *dev_data = (struct i2s_dev_data *)dev->data;
+	struct i2s_dev_data *dev_data = dev->data;
 
 	if (dir == I2S_DIR_RX)
 		return &dev_data->rx.cfg;
@@ -626,7 +626,7 @@ static int i2s_tx_stream_start(const struct device *dev)
 {
 	int ret = 0;
 	void *buffer;
-	struct i2s_dev_data *dev_data = (struct i2s_dev_data *)dev->data;
+	struct i2s_dev_data *dev_data = dev->data;
 	struct stream *strm = &dev_data->tx;
 	uint32_t data_path = strm->start_channel;
 	const struct device *dev_dma = dev_data->dev_dma;
@@ -680,7 +680,7 @@ static int i2s_rx_stream_start(const struct device *dev)
 {
 	int ret = 0;
 	void *buffer;
-	struct i2s_dev_data *dev_data = (struct i2s_dev_data *)dev->data;
+	struct i2s_dev_data *dev_data = dev->data;
 	struct stream *strm = &dev_data->rx;
 	const struct device *dev_dma = dev_data->dev_dma;
 	const struct i2s_mcux_config *dev_cfg = dev->config;
@@ -732,7 +732,7 @@ static int i2s_rx_stream_start(const struct device *dev)
 static int i2s_mcux_trigger(const struct device *dev, enum i2s_dir dir,
 			    enum i2s_trigger_cmd cmd)
 {
-	struct i2s_dev_data *dev_data = (struct i2s_dev_data *)dev->data;
+	struct i2s_dev_data *dev_data = dev->data;
 	struct stream *strm;
 	unsigned int key;
 	int ret = 0;
@@ -830,7 +830,7 @@ static int i2s_mcux_read(const struct device *dev, void **mem_block,
 			 size_t *size)
 {
 	const struct i2s_mcux_config *dev_cfg = dev->config;
-	struct i2s_dev_data *dev_data = (struct i2s_dev_data *)dev->data;
+	struct i2s_dev_data *dev_data = dev->data;
 	struct stream *strm = &dev_data->rx;
 	void *buffer;
 	int ret = 0;
@@ -869,7 +869,7 @@ static int i2s_mcux_read(const struct device *dev, void **mem_block,
 static int i2s_mcux_write(const struct device *dev, void *mem_block,
 			  size_t size)
 {
-	struct i2s_dev_data *dev_data = (struct i2s_dev_data *)dev->data;
+	struct i2s_dev_data *dev_data = dev->data;
 	struct stream *strm = &dev_data->tx;
 	int ret;
 
@@ -1013,7 +1013,7 @@ static int i2s_mcux_initialize(const struct device *dev)
 {
 	const struct i2s_mcux_config *dev_cfg = dev->config;
 	I2S_Type *base = (I2S_Type *)dev_cfg->base;
-	struct i2s_dev_data *dev_data = (struct i2s_dev_data *)dev->data;
+	struct i2s_dev_data *dev_data = dev->data;
 	uint32_t mclk;
 
 	if (!dev_data->dev_dma) {

--- a/drivers/i2s/i2s_sam_ssc.c
+++ b/drivers/i2s/i2s_sam_ssc.c
@@ -99,10 +99,6 @@ struct i2s_sam_dev_data {
 };
 
 #define DEV_NAME(dev) ((dev)->name)
-#define DEV_CFG(dev) \
-	((const struct i2s_sam_dev_cfg *const)(dev)->config)
-#define DEV_DATA(dev) \
-	((struct i2s_sam_dev_data *const)(dev)->data)
 
 #define MODULO_INC(val, max) { val = (++val < max) ? val : 0; }
 
@@ -210,8 +206,8 @@ static void dma_rx_callback(const struct device *dma_dev, void *user_data,
 			    uint32_t channel, int status)
 {
 	const struct device *dev = get_dev_from_dma_channel(channel);
-	const struct i2s_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
-	struct i2s_sam_dev_data *const dev_data = DEV_DATA(dev);
+	const struct i2s_sam_dev_cfg *const dev_cfg = dev->config;
+	struct i2s_sam_dev_data *const dev_data = dev->data;
 	Ssc *const ssc = dev_cfg->regs;
 	struct stream *stream = &dev_data->rx;
 	int ret;
@@ -270,8 +266,8 @@ static void dma_tx_callback(const struct device *dma_dev, void *user_data,
 			    uint32_t channel, int status)
 {
 	const struct device *dev = get_dev_from_dma_channel(channel);
-	const struct i2s_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
-	struct i2s_sam_dev_data *const dev_data = DEV_DATA(dev);
+	const struct i2s_sam_dev_cfg *const dev_cfg = dev->config;
+	struct i2s_sam_dev_data *const dev_data = dev->data;
 	Ssc *const ssc = dev_cfg->regs;
 	struct stream *stream = &dev_data->tx;
 	size_t mem_block_size;
@@ -534,7 +530,7 @@ static int bit_clock_set(Ssc *const ssc, uint32_t bit_clk_freq)
 static const struct i2s_config *i2s_sam_config_get(const struct device *dev,
 						   enum i2s_dir dir)
 {
-	struct i2s_sam_dev_data *const dev_data = DEV_DATA(dev);
+	struct i2s_sam_dev_data *const dev_data = dev->data;
 	struct stream *stream;
 
 	if (dir == I2S_DIR_RX) {
@@ -553,8 +549,8 @@ static const struct i2s_config *i2s_sam_config_get(const struct device *dev,
 static int i2s_sam_configure(const struct device *dev, enum i2s_dir dir,
 			     const struct i2s_config *i2s_cfg)
 {
-	const struct i2s_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
-	struct i2s_sam_dev_data *const dev_data = DEV_DATA(dev);
+	const struct i2s_sam_dev_cfg *const dev_cfg = dev->config;
+	struct i2s_sam_dev_data *const dev_data = dev->data;
 	Ssc *const ssc = dev_cfg->regs;
 	uint8_t num_words = i2s_cfg->channels;
 	uint8_t word_size_bits = i2s_cfg->word_size;
@@ -788,8 +784,8 @@ static void tx_queue_drop(struct stream *stream)
 static int i2s_sam_trigger(const struct device *dev, enum i2s_dir dir,
 			   enum i2s_trigger_cmd cmd)
 {
-	const struct i2s_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
-	struct i2s_sam_dev_data *const dev_data = DEV_DATA(dev);
+	const struct i2s_sam_dev_cfg *const dev_cfg = dev->config;
+	struct i2s_sam_dev_data *const dev_data = dev->data;
 	Ssc *const ssc = dev_cfg->regs;
 	struct stream *stream;
 	unsigned int key;
@@ -878,7 +874,7 @@ static int i2s_sam_trigger(const struct device *dev, enum i2s_dir dir,
 static int i2s_sam_read(const struct device *dev, void **mem_block,
 			size_t *size)
 {
-	struct i2s_sam_dev_data *const dev_data = DEV_DATA(dev);
+	struct i2s_sam_dev_data *const dev_data = dev->data;
 	int ret;
 
 	if (dev_data->rx.state == I2S_STATE_NOT_READY) {
@@ -906,7 +902,7 @@ static int i2s_sam_read(const struct device *dev, void **mem_block,
 static int i2s_sam_write(const struct device *dev, void *mem_block,
 			 size_t size)
 {
-	struct i2s_sam_dev_data *const dev_data = DEV_DATA(dev);
+	struct i2s_sam_dev_data *const dev_data = dev->data;
 	int ret;
 
 	if (dev_data->tx.state != I2S_STATE_RUNNING &&
@@ -929,8 +925,8 @@ static int i2s_sam_write(const struct device *dev, void *mem_block,
 
 static void i2s_sam_isr(const struct device *dev)
 {
-	const struct i2s_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
-	struct i2s_sam_dev_data *const dev_data = DEV_DATA(dev);
+	const struct i2s_sam_dev_cfg *const dev_cfg = dev->config;
+	struct i2s_sam_dev_data *const dev_data = dev->data;
 	Ssc *const ssc = dev_cfg->regs;
 	uint32_t isr_status;
 
@@ -955,8 +951,8 @@ static void i2s_sam_isr(const struct device *dev)
 
 static int i2s_sam_initialize(const struct device *dev)
 {
-	const struct i2s_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
-	struct i2s_sam_dev_data *const dev_data = DEV_DATA(dev);
+	const struct i2s_sam_dev_cfg *const dev_cfg = dev->config;
+	struct i2s_sam_dev_data *const dev_data = dev->data;
 	Ssc *const ssc = dev_cfg->regs;
 
 	/* Configure interrupts */

--- a/drivers/ieee802154/ieee802154_cc13xx_cc26xx.c
+++ b/drivers/ieee802154/ieee802154_cc13xx_cc26xx.c
@@ -59,12 +59,6 @@ static void ieee802154_cc13xx_cc26xx_rx_done(
 	struct ieee802154_cc13xx_cc26xx_data *drv_data);
 static int ieee802154_cc13xx_cc26xx_stop(const struct device *dev);
 
-static inline struct ieee802154_cc13xx_cc26xx_data *
-get_dev_data(const struct device *dev)
-{
-	return dev->data;
-}
-
 /* TODO remove when rf driver bugfix is pulled in */
 static void update_saved_cmdhandle(RF_CmdHandle ch, RF_CmdHandle *saved)
 {
@@ -77,7 +71,7 @@ static void cmd_ieee_csma_callback(RF_Handle h, RF_CmdHandle ch, RF_EventMask e)
 	ARG_UNUSED(h);
 
 	const struct device *dev = &DEVICE_NAME_GET(ieee802154_cc13xx_cc26xx);
-	struct ieee802154_cc13xx_cc26xx_data *drv_data = get_dev_data(dev);
+	struct ieee802154_cc13xx_cc26xx_data *drv_data = dev->data;
 
 	update_saved_cmdhandle(ch, (RF_CmdHandle *) &drv_data->saved_cmdhandle);
 
@@ -93,7 +87,7 @@ static void cmd_ieee_rx_callback(RF_Handle h, RF_CmdHandle ch, RF_EventMask e)
 	ARG_UNUSED(h);
 
 	const struct device *dev = &DEVICE_NAME_GET(ieee802154_cc13xx_cc26xx);
-	struct ieee802154_cc13xx_cc26xx_data *drv_data = get_dev_data(dev);
+	struct ieee802154_cc13xx_cc26xx_data *drv_data = dev->data;
 
 	update_saved_cmdhandle(ch, (RF_CmdHandle *) &drv_data->saved_cmdhandle);
 
@@ -135,7 +129,7 @@ ieee802154_cc13xx_cc26xx_get_capabilities(const struct device *dev)
 
 static int ieee802154_cc13xx_cc26xx_cca(const struct device *dev)
 {
-	struct ieee802154_cc13xx_cc26xx_data *drv_data = get_dev_data(dev);
+	struct ieee802154_cc13xx_cc26xx_data *drv_data = dev->data;
 	RF_Stat status;
 
 	status = RF_runImmediateCmd(drv_data->rf_handle,
@@ -161,7 +155,7 @@ static int ieee802154_cc13xx_cc26xx_set_channel(const struct device *dev,
 	int r;
 	RF_Stat status;
 	RF_CmdHandle cmd_handle;
-	struct ieee802154_cc13xx_cc26xx_data *drv_data = get_dev_data(dev);
+	struct ieee802154_cc13xx_cc26xx_data *drv_data = dev->data;
 
 	/* TODO Support sub-GHz for CC13xx */
 	if (channel < 11 || channel > 26) {
@@ -210,7 +204,7 @@ static int ieee802154_cc13xx_cc26xx_reset_channel(
 	const struct device *dev)
 {
 	uint8_t channel;
-	struct ieee802154_cc13xx_cc26xx_data *drv_data = get_dev_data(dev);
+	struct ieee802154_cc13xx_cc26xx_data *drv_data = dev->data;
 
 	/* extract the channel from cmd_ieee_rx */
 	channel = drv_data->cmd_ieee_rx.channel;
@@ -227,7 +221,7 @@ ieee802154_cc13xx_cc26xx_filter(const struct device *dev, bool set,
 				enum ieee802154_filter_type type,
 				const struct ieee802154_filter *filter)
 {
-	struct ieee802154_cc13xx_cc26xx_data *drv_data = get_dev_data(dev);
+	struct ieee802154_cc13xx_cc26xx_data *drv_data = dev->data;
 
 	if (!set) {
 		return -ENOTSUP;
@@ -253,7 +247,7 @@ static int ieee802154_cc13xx_cc26xx_set_txpower(const struct device *dev,
 {
 	RF_Stat status;
 	const RF_TxPowerTable_Entry *table;
-	struct ieee802154_cc13xx_cc26xx_data *drv_data = get_dev_data(dev);
+	struct ieee802154_cc13xx_cc26xx_data *drv_data = dev->data;
 
 	/* TODO Support sub-GHz for CC13xx */
 	table = txPowerTable_2_4;
@@ -285,7 +279,7 @@ static int ieee802154_cc13xx_cc26xx_tx(const struct device *dev,
 	RF_ScheduleCmdParams sched_params = {
 		.allowDelay = true,
 	};
-	struct ieee802154_cc13xx_cc26xx_data *drv_data = get_dev_data(dev);
+	struct ieee802154_cc13xx_cc26xx_data *drv_data = dev->data;
 	bool ack = ieee802154_is_ar_flag_set(frag);
 	int retry = CONFIG_IEEE802154_CC13XX_CC26XX_RADIO_TX_RETRIES;
 
@@ -453,7 +447,7 @@ static int ieee802154_cc13xx_cc26xx_start(const struct device *dev)
 
 static int ieee802154_cc13xx_cc26xx_stop(const struct device *dev)
 {
-	struct ieee802154_cc13xx_cc26xx_data *drv_data = get_dev_data(dev);
+	struct ieee802154_cc13xx_cc26xx_data *drv_data = dev->data;
 
 	RF_Stat status;
 
@@ -480,7 +474,7 @@ ieee802154_cc13xx_cc26xx_configure(const struct device *dev,
 
 static void ieee802154_cc13xx_cc26xx_data_init(const struct device *dev)
 {
-	struct ieee802154_cc13xx_cc26xx_data *drv_data = get_dev_data(dev);
+	struct ieee802154_cc13xx_cc26xx_data *drv_data = dev->data;
 	uint8_t *mac;
 
 	if (sys_read32(CCFG_BASE + CCFG_O_IEEE_MAC_0) != 0xFFFFFFFF &&
@@ -517,7 +511,7 @@ static void ieee802154_cc13xx_cc26xx_data_init(const struct device *dev)
 static void ieee802154_cc13xx_cc26xx_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
-	struct ieee802154_cc13xx_cc26xx_data *drv_data = get_dev_data(dev);
+	struct ieee802154_cc13xx_cc26xx_data *drv_data = dev->data;
 
 	net_if_set_link_addr(iface, drv_data->mac, sizeof(drv_data->mac),
 			     NET_LINK_IEEE802154);
@@ -549,7 +543,7 @@ static int ieee802154_cc13xx_cc26xx_init(const struct device *dev)
 		.rfMode      = RF_MODE_MULTIPLE,
 		.cpePatchFxn = &rf_patch_cpe_multi_protocol,
 	};
-	struct ieee802154_cc13xx_cc26xx_data *drv_data = get_dev_data(dev);
+	struct ieee802154_cc13xx_cc26xx_data *drv_data = dev->data;
 
 	/* Initialize driver data */
 	ieee802154_cc13xx_cc26xx_data_init(dev);

--- a/drivers/ieee802154/ieee802154_cc13xx_cc26xx_subg.c
+++ b/drivers/ieee802154/ieee802154_cc13xx_cc26xx_subg.c
@@ -132,19 +132,12 @@ static inline bool is_subghz(uint16_t channel)
 	return (channel <= IEEE802154_SUB_GHZ_CHANNEL_MAX);
 }
 
-static inline struct ieee802154_cc13xx_cc26xx_subg_data *
-get_dev_data(const struct device *dev)
-{
-	return dev->data;
-}
-
 static void cmd_prop_tx_adv_callback(RF_Handle h, RF_CmdHandle ch,
 	RF_EventMask e)
 {
 	const struct device *dev =
 		&DEVICE_NAME_GET(ieee802154_cc13xx_cc26xx_subg);
-	struct ieee802154_cc13xx_cc26xx_subg_data *drv_data =
-		get_dev_data(dev);
+	struct ieee802154_cc13xx_cc26xx_subg_data *drv_data = dev->data;
 	RF_Op *op = RF_getCmdOp(h, ch);
 
 	LOG_DBG("ch: %u cmd: %04x cs st: %04x tx st: %04x e: 0x%" PRIx64, ch,
@@ -156,8 +149,7 @@ static void cmd_prop_rx_adv_callback(RF_Handle h, RF_CmdHandle ch,
 {
 	const struct device *dev =
 		&DEVICE_NAME_GET(ieee802154_cc13xx_cc26xx_subg);
-	struct ieee802154_cc13xx_cc26xx_subg_data *drv_data =
-		get_dev_data(dev);
+	struct ieee802154_cc13xx_cc26xx_subg_data *drv_data = dev->data;
 	RF_Op *op = RF_getCmdOp(h, ch);
 
 	LOG_DBG("ch: %u cmd: %04x st: %04x e: 0x%" PRIx64, ch,
@@ -201,8 +193,7 @@ ieee802154_cc13xx_cc26xx_subg_get_capabilities(const struct device *dev)
 
 static int ieee802154_cc13xx_cc26xx_subg_cca(const struct device *dev)
 {
-	struct ieee802154_cc13xx_cc26xx_subg_data *drv_data =
-		get_dev_data(dev);
+	struct ieee802154_cc13xx_cc26xx_subg_data *drv_data = dev->data;
 	RF_Stat status;
 
 	drv_data->cmd_prop_cs.status = IDLE;
@@ -228,8 +219,7 @@ static int ieee802154_cc13xx_cc26xx_subg_cca(const struct device *dev)
 
 static int ieee802154_cc13xx_cc26xx_subg_rx(const struct device *dev)
 {
-	struct ieee802154_cc13xx_cc26xx_subg_data *drv_data =
-		get_dev_data(dev);
+	struct ieee802154_cc13xx_cc26xx_subg_data *drv_data = dev->data;
 	RF_CmdHandle cmd_handle;
 
 	/* Set all RX entries to empty */
@@ -250,8 +240,7 @@ static int ieee802154_cc13xx_cc26xx_subg_rx(const struct device *dev)
 static int ieee802154_cc13xx_cc26xx_subg_set_channel(
 	const struct device *dev, uint16_t channel)
 {
-	struct ieee802154_cc13xx_cc26xx_subg_data *drv_data =
-		get_dev_data(dev);
+	struct ieee802154_cc13xx_cc26xx_subg_data *drv_data = dev->data;
 	RF_EventMask reason;
 	uint16_t freq, fract;
 	int r;
@@ -309,7 +298,7 @@ ieee802154_cc13xx_cc26xx_subg_filter(const struct device *dev, bool set,
 static int ieee802154_cc13xx_cc26xx_subg_set_txpower(
 	const struct device *dev, int16_t dbm)
 {
-	struct ieee802154_cc13xx_cc26xx_subg_data *drv_data = get_dev_data(dev);
+	struct ieee802154_cc13xx_cc26xx_subg_data *drv_data = dev->data;
 	RF_Stat status;
 
 	RF_TxPowerTable_Value power_table_value = RF_TxPowerTable_findValue(
@@ -335,8 +324,7 @@ static int ieee802154_cc13xx_cc26xx_subg_tx(const struct device *dev,
 					    struct net_pkt *pkt,
 					    struct net_buf *frag)
 {
-	struct ieee802154_cc13xx_cc26xx_subg_data *drv_data =
-		get_dev_data(dev);
+	struct ieee802154_cc13xx_cc26xx_subg_data *drv_data = dev->data;
 	int retry = CONFIG_IEEE802154_CC13XX_CC26XX_SUB_GHZ_RADIO_TX_RETRIES;
 	RF_EventMask reason;
 	int r;
@@ -511,8 +499,7 @@ static int ieee802154_cc13xx_cc26xx_subg_start(const struct device *dev)
  */
 static int ieee802154_cc13xx_cc26xx_subg_stop(const struct device *dev)
 {
-	struct ieee802154_cc13xx_cc26xx_subg_data *drv_data =
-		get_dev_data(dev);
+	struct ieee802154_cc13xx_cc26xx_subg_data *drv_data = dev->data;
 	RF_Stat status;
 
 	status = RF_flushCmd(drv_data->rf_handle, RF_CMDHANDLE_FLUSH_ALL, 0);
@@ -533,8 +520,7 @@ static int ieee802154_cc13xx_cc26xx_subg_stop(const struct device *dev)
  */
 static int ieee802154_cc13xx_cc26xx_subg_stop_if(const struct device *dev)
 {
-	struct ieee802154_cc13xx_cc26xx_subg_data *drv_data =
-		get_dev_data(dev);
+	struct ieee802154_cc13xx_cc26xx_subg_data *drv_data = dev->data;
 	int ret;
 
 	ret = ieee802154_cc13xx_cc26xx_subg_stop(dev);
@@ -612,8 +598,7 @@ static void ieee802154_cc13xx_cc26xx_subg_data_init(
 static void ieee802154_cc13xx_cc26xx_subg_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
-	struct ieee802154_cc13xx_cc26xx_subg_data *drv_data =
-		get_dev_data(dev);
+	struct ieee802154_cc13xx_cc26xx_subg_data *drv_data = dev->data;
 
 	net_if_set_link_addr(iface, drv_data->mac, sizeof(drv_data->mac),
 			     NET_LINK_IEEE802154);
@@ -644,8 +629,7 @@ static int ieee802154_cc13xx_cc26xx_subg_init(const struct device *dev)
 {
 	RF_Params rf_params;
 	RF_EventMask reason;
-	struct ieee802154_cc13xx_cc26xx_subg_data *drv_data =
-		get_dev_data(dev);
+	struct ieee802154_cc13xx_cc26xx_subg_data *drv_data = dev->data;
 
 	/* Initialize driver data */
 	ieee802154_cc13xx_cc26xx_subg_data_init(drv_data);

--- a/drivers/interrupt_controller/intc_gicv3_its.c
+++ b/drivers/interrupt_controller/intc_gicv3_its.c
@@ -423,7 +423,7 @@ static int its_send_invall_cmd(struct gicv3_its_data *data, uint32_t icid)
 
 static int gicv3_its_send_int(const struct device *dev, uint32_t device_id, uint32_t event_id)
 {
-	struct gicv3_its_data *data = (struct gicv3_its_data *)dev->data;
+	struct gicv3_its_data *data = dev->data;
 
 	/* TOFIX check device_id & event_id bounds */
 
@@ -432,8 +432,8 @@ static int gicv3_its_send_int(const struct device *dev, uint32_t device_id, uint
 
 static void its_setup_cmd_queue(const struct device *dev)
 {
-	const struct gicv3_its_config *cfg = (const struct gicv3_its_config *)dev->config;
-	struct gicv3_its_data *data = (struct gicv3_its_data *)dev->data;
+	const struct gicv3_its_config *cfg = dev->config;
+	struct gicv3_its_data *data = dev->data;
 	uint64_t reg = 0;
 
 	/* Zero out cmd table */
@@ -458,7 +458,7 @@ static void its_setup_cmd_queue(const struct device *dev)
 
 static uintptr_t gicv3_rdist_get_rdbase(const struct device *dev, unsigned int cpuid)
 {
-	struct gicv3_its_data *data = (struct gicv3_its_data *)dev->data;
+	struct gicv3_its_data *data = dev->data;
 	uint64_t typer = sys_read64(data->base + GITS_TYPER);
 
 	if (GITS_TYPER_PTA_GET(typer)) {
@@ -471,7 +471,7 @@ static uintptr_t gicv3_rdist_get_rdbase(const struct device *dev, unsigned int c
 static int gicv3_its_map_intid(const struct device *dev, uint32_t device_id, uint32_t event_id,
 			       unsigned int intid)
 {
-	struct gicv3_its_data *data = (struct gicv3_its_data *)dev->data;
+	struct gicv3_its_data *data = dev->data;
 	int ret;
 
 	/* TOFIX check device_id, event_id & intid bounds */
@@ -494,7 +494,7 @@ static int gicv3_its_map_intid(const struct device *dev, uint32_t device_id, uin
 static int gicv3_its_init_device_id(const struct device *dev, uint32_t device_id,
 				    unsigned int nites)
 {
-	struct gicv3_its_data *data = (struct gicv3_its_data *)dev->data;
+	struct gicv3_its_data *data = dev->data;
 	size_t entry_size, alloc_size;
 	int nr_ites;
 	void *itt;
@@ -610,8 +610,8 @@ void its_rdist_invall(void)
 
 static int gicv3_its_init(const struct device *dev)
 {
-	const struct gicv3_its_config *cfg = (const struct gicv3_its_config *)dev->config;
-	struct gicv3_its_data *data = (struct gicv3_its_data *)dev->data;
+	const struct gicv3_its_config *cfg = dev->config;
+	struct gicv3_its_data *data = dev->data;
 	uint32_t reg;
 	int ret;
 

--- a/drivers/interrupt_controller/intc_rv32m1_intmux.c
+++ b/drivers/interrupt_controller/intc_rv32m1_intmux.c
@@ -45,10 +45,7 @@ struct rv32m1_intmux_config {
 	struct _isr_table_entry *isr_base;
 };
 
-#define DEV_CFG(dev) \
-	((struct rv32m1_intmux_config *)(dev->config))
-
-#define DEV_REGS(dev) (DEV_CFG(dev)->regs)
+#define DEV_REGS(dev) (((const struct rv32m1_intmux_config *)(dev->config))->regs)
 
 /*
  * <irq_nextlevel.h> API
@@ -110,10 +107,11 @@ static int rv32m1_intmux_get_line_state(const struct device *dev,
 static void rv32m1_intmux_isr(const void *arg)
 {
 	const struct device *dev = DEVICE_DT_INST_GET(0);
+	const struct rv32m1_intmux_config *config = dev->config;
 	INTMUX_Type *regs = DEV_REGS(dev);
 	uint32_t channel = POINTER_TO_UINT(arg);
 	uint32_t line = (regs->CHANNEL[channel].CHn_VEC >> 2);
-	struct _isr_table_entry *isr_base = DEV_CFG(dev)->isr_base;
+	struct _isr_table_entry *isr_base = config->isr_base;
 	struct _isr_table_entry *entry;
 
 	/*
@@ -152,7 +150,7 @@ static const struct rv32m1_intmux_config rv32m1_intmux_cfg = {
 
 static int rv32m1_intmux_init(const struct device *dev)
 {
-	const struct rv32m1_intmux_config *config = DEV_CFG(dev);
+	const struct rv32m1_intmux_config *config = dev->config;
 	INTMUX_Type *regs = DEV_REGS(dev);
 	size_t i;
 

--- a/drivers/interrupt_controller/intc_sam0_eic.c
+++ b/drivers/interrupt_controller/intc_sam0_eic.c
@@ -27,9 +27,6 @@ struct sam0_eic_data {
 	struct sam0_eic_line_assignment lines[EIC_EXTINT_NUM];
 };
 
-#define DEV_DATA(dev) \
-	((struct sam0_eic_data *const)(dev)->data)
-
 static void wait_synchronization(void)
 {
 #ifdef REG_EIC_SYNCBUSY
@@ -52,7 +49,7 @@ static inline void set_eic_enable(bool on)
 
 static void sam0_eic_isr(const struct device *dev)
 {
-	struct sam0_eic_data *const dev_data = DEV_DATA(dev);
+	struct sam0_eic_data *const dev_data = dev->data;
 	uint16_t bits = EIC->INTFLAG.reg;
 	uint32_t line_index;
 

--- a/drivers/ipm/ipm_mhu.c
+++ b/drivers/ipm/ipm_mhu.c
@@ -11,12 +11,9 @@
 #include <soc.h>
 #include "ipm_mhu.h"
 
-#define DEV_CFG(dev) \
-	((const struct ipm_mhu_device_config * const)(dev)->config)
-#define DEV_DATA(dev) \
-	((struct ipm_mhu_data *)(dev)->data)
 #define IPM_MHU_REGS(dev) \
-	((volatile struct ipm_mhu_reg_map_t *)(DEV_CFG(dev))->base)
+	((volatile struct ipm_mhu_reg_map_t *) \
+	 (((const struct ipm_mhu_device_config * const)(dev)->config)->base))
 
 static enum ipm_mhu_cpu_id_t ipm_mhu_get_cpu_id(const struct device *d)
 {
@@ -117,7 +114,7 @@ static uint32_t ipm_mhu_max_id_val_get(const struct device *d)
 
 static int ipm_mhu_init(const struct device *d)
 {
-	const struct ipm_mhu_device_config *config = DEV_CFG(d);
+	const struct ipm_mhu_device_config *config = d->config;
 
 	config->irq_config_func(d);
 
@@ -126,7 +123,7 @@ static int ipm_mhu_init(const struct device *d)
 
 static void ipm_mhu_isr(const struct device *d)
 {
-	struct ipm_mhu_data *driver_data = DEV_DATA(d);
+	struct ipm_mhu_data *driver_data = d->data;
 	enum ipm_mhu_cpu_id_t cpu_id;
 	uint32_t ipm_mhu_status;
 
@@ -159,7 +156,7 @@ static void ipm_mhu_register_cb(const struct device *d,
 				ipm_callback_t cb,
 				void *user_data)
 {
-	struct ipm_mhu_data *driver_data = DEV_DATA(d);
+	struct ipm_mhu_data *driver_data = d->data;
 
 	driver_data->callback = cb;
 	driver_data->user_data = user_data;

--- a/drivers/ipm/ipm_stm32_ipcc.c
+++ b/drivers/ipm/ipm_stm32_ipcc.c
@@ -18,13 +18,9 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(ipm_stm32_ipcc, CONFIG_IPM_LOG_LEVEL);
 
-/* convenience defines */
-#define DEV_CFG(dev)							\
-	((const struct stm32_ipcc_mailbox_config * const)(dev)->config)
-#define DEV_DATA(dev)							\
-	((struct stm32_ipcc_mbx_data * const)(dev)->data)
 #define MBX_STRUCT(dev)					\
-	((IPCC_TypeDef *)(DEV_CFG(dev))->uconf.base)
+	((IPCC_TypeDef *)				\
+	 ((const struct stm32_ipcc_mailbox_config * const)(dev)->config)->uconf.base)
 
 #define IPCC_ALL_MR_TXF_CH_MASK 0xFFFF0000
 #define IPCC_ALL_MR_RXO_CH_MASK 0x0000FFFF
@@ -104,8 +100,8 @@ static struct stm32_ipcc_mbx_data stm32_IPCC_data;
 
 static void stm32_ipcc_mailbox_rx_isr(const struct device *dev)
 {
-	struct stm32_ipcc_mbx_data *data = DEV_DATA(dev);
-	const struct stm32_ipcc_mailbox_config *cfg = DEV_CFG(dev);
+	struct stm32_ipcc_mbx_data *data = dev->data;
+	const struct stm32_ipcc_mailbox_config *cfg = dev->config;
 	unsigned int value = 0;
 	uint32_t mask, i;
 
@@ -132,8 +128,8 @@ static void stm32_ipcc_mailbox_rx_isr(const struct device *dev)
 
 static void stm32_ipcc_mailbox_tx_isr(const struct device *dev)
 {
-	struct stm32_ipcc_mbx_data *data = DEV_DATA(dev);
-	const struct stm32_ipcc_mailbox_config *cfg = DEV_CFG(dev);
+	struct stm32_ipcc_mbx_data *data = dev->data;
+	const struct stm32_ipcc_mailbox_config *cfg = dev->config;
 	uint32_t mask, i;
 
 	mask = (~IPCC_ReadReg(cfg->ipcc, MR)) & IPCC_ALL_MR_TXF_CH_MASK;
@@ -156,7 +152,7 @@ static int stm32_ipcc_mailbox_ipm_send(const struct device *dev, int wait,
 				       const void *buff, int size)
 {
 	struct stm32_ipcc_mbx_data *data = dev->data;
-	const struct stm32_ipcc_mailbox_config *cfg = DEV_CFG(dev);
+	const struct stm32_ipcc_mailbox_config *cfg = dev->config;
 
 	ARG_UNUSED(wait);
 	ARG_UNUSED(buff);
@@ -196,7 +192,7 @@ static int stm32_ipcc_mailbox_ipm_max_data_size_get(const struct device *dev)
 
 static uint32_t stm32_ipcc_mailbox_ipm_max_id_val_get(const struct device *d)
 {
-	struct stm32_ipcc_mbx_data *data = DEV_DATA(d);
+	struct stm32_ipcc_mbx_data *data = d->data;
 
 	return data->num_ch - 1;
 }
@@ -205,7 +201,7 @@ static void stm32_ipcc_mailbox_ipm_register_callback(const struct device *d,
 						     ipm_callback_t cb,
 						     void *user_data)
 {
-	struct stm32_ipcc_mbx_data *data = DEV_DATA(d);
+	struct stm32_ipcc_mbx_data *data = d->data;
 
 	data->callback = cb;
 	data->user_data = user_data;
@@ -214,8 +210,8 @@ static void stm32_ipcc_mailbox_ipm_register_callback(const struct device *d,
 static int stm32_ipcc_mailbox_ipm_set_enabled(const struct device *dev,
 					      int enable)
 {
-	struct stm32_ipcc_mbx_data *data = DEV_DATA(dev);
-	const struct stm32_ipcc_mailbox_config *cfg = DEV_CFG(dev);
+	struct stm32_ipcc_mbx_data *data = dev->data;
+	const struct stm32_ipcc_mailbox_config *cfg = dev->config;
 	uint32_t i;
 
 	/* For now: nothing to be done */
@@ -242,8 +238,8 @@ static int stm32_ipcc_mailbox_ipm_set_enabled(const struct device *dev,
 static int stm32_ipcc_mailbox_init(const struct device *dev)
 {
 
-	struct stm32_ipcc_mbx_data *data = DEV_DATA(dev);
-	const struct stm32_ipcc_mailbox_config *cfg = DEV_CFG(dev);
+	struct stm32_ipcc_mbx_data *data = dev->data;
+	const struct stm32_ipcc_mailbox_config *cfg = dev->config;
 	const struct device *clk;
 	uint32_t i;
 

--- a/drivers/led/led_pwm.c
+++ b/drivers/led/led_pwm.c
@@ -21,8 +21,6 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(led_pwm, CONFIG_LED_LOG_LEVEL);
 
-#define DEV_CFG(dev)	((const struct led_pwm_config *) ((dev)->config))
-
 struct led_pwm {
 	const struct device *dev;
 	uint32_t channel;
@@ -38,7 +36,7 @@ struct led_pwm_config {
 static int led_pwm_blink(const struct device *dev, uint32_t led,
 			 uint32_t delay_on, uint32_t delay_off)
 {
-	const struct led_pwm_config *config = DEV_CFG(dev);
+	const struct led_pwm_config *config = dev->config;
 	const struct led_pwm *led_pwm;
 	uint32_t period_usec, pulse_usec;
 
@@ -65,7 +63,7 @@ static int led_pwm_blink(const struct device *dev, uint32_t led,
 static int led_pwm_set_brightness(const struct device *dev,
 				  uint32_t led, uint8_t value)
 {
-	const struct led_pwm_config *config = DEV_CFG(dev);
+	const struct led_pwm_config *config = dev->config;
 	const struct led_pwm *led_pwm;
 	uint32_t pulse;
 
@@ -93,7 +91,7 @@ static int led_pwm_off(const struct device *dev, uint32_t led)
 
 static int led_pwm_init(const struct device *dev)
 {
-	const struct led_pwm_config *config = DEV_CFG(dev);
+	const struct led_pwm_config *config = dev->config;
 	int i;
 
 	if (!config->num_leds) {
@@ -118,7 +116,7 @@ static int led_pwm_init(const struct device *dev)
 static int led_pwm_pm_action(const struct device *dev,
 			     enum pm_device_action action)
 {
-	const struct led_pwm_config *config = DEV_CFG(dev);
+	const struct led_pwm_config *config = dev->config;
 
 	/* switch all underlying PWM devices to the new state */
 	for (size_t i = 0; i < config->num_leds; i++) {

--- a/drivers/led/lp503x.c
+++ b/drivers/led/lp503x.c
@@ -59,9 +59,6 @@ LOG_MODULE_REGISTER(lp503x);
 /* Expose channels starting from the bank registers. */
 #define LP503X_CHANNEL_BASE		LP503X_BANK_BRIGHTNESS
 
-#define DEV_CFG(dev)	((const struct lp503x_config *) ((dev)->config))
-#define DEV_DATA(dev)	((struct lp503x_data *) ((dev)->data))
-
 struct lp503x_config {
 	char *i2c_bus_label;
 	uint8_t i2c_addr;
@@ -92,7 +89,7 @@ lp503x_led_to_info(const struct lp503x_config *config, uint32_t led)
 static int lp503x_get_info(const struct device *dev, uint32_t led,
 			   const struct led_info **info)
 {
-	const struct lp503x_config *config = DEV_CFG(dev);
+	const struct lp503x_config *config = dev->config;
 	const struct led_info *led_info = lp503x_led_to_info(config, led);
 
 	if (!led_info) {
@@ -107,8 +104,8 @@ static int lp503x_get_info(const struct device *dev, uint32_t led,
 static int lp503x_set_brightness(const struct device *dev,
 				 uint32_t led, uint8_t value)
 {
-	const struct lp503x_config *config = DEV_CFG(dev);
-	struct lp503x_data *data = DEV_DATA(dev);
+	const struct lp503x_config *config = dev->config;
+	struct lp503x_data *data = dev->data;
 	const struct led_info *led_info = lp503x_led_to_info(config, led);
 	uint8_t buf[2];
 
@@ -135,8 +132,8 @@ static int lp503x_off(const struct device *dev, uint32_t led)
 static int lp503x_set_color(const struct device *dev, uint32_t led,
 			    uint8_t num_colors, const uint8_t *color)
 {
-	const struct lp503x_config *config = DEV_CFG(dev);
-	struct lp503x_data *data = DEV_DATA(dev);
+	const struct lp503x_config *config = dev->config;
+	struct lp503x_data *data = dev->data;
 	const struct led_info *led_info = lp503x_led_to_info(config, led);
 	uint8_t buf[4];
 
@@ -156,8 +153,8 @@ static int lp503x_write_channels(const struct device *dev,
 				 uint32_t start_channel,
 				 uint32_t num_channels, const uint8_t *buf)
 {
-	const struct lp503x_config *config = DEV_CFG(dev);
-	struct lp503x_data *data = DEV_DATA(dev);
+	const struct lp503x_config *config = dev->config;
+	struct lp503x_data *data = dev->data;
 
 	if (start_channel >= LP503X_NUM_CHANNELS ||
 	    start_channel + num_channels > LP503X_NUM_CHANNELS) {
@@ -177,8 +174,8 @@ static int lp503x_write_channels(const struct device *dev,
 
 static int lp503x_init(const struct device *dev)
 {
-	const struct lp503x_config *config = DEV_CFG(dev);
-	struct lp503x_data *data = DEV_DATA(dev);
+	const struct lp503x_config *config = dev->config;
+	struct lp503x_data *data = dev->data;
 	uint8_t buf[3];
 	int err;
 

--- a/drivers/mdio/mdio_sam.c
+++ b/drivers/mdio/mdio_sam.c
@@ -32,15 +32,12 @@ struct mdio_sam_dev_config {
 };
 
 #define DEV_NAME(dev) ((dev)->name)
-#define DEV_DATA(dev) ((struct mdio_sam_dev_data *const)(dev)->data)
-#define DEV_CFG(dev) \
-	((const struct mdio_sam_dev_config *const)(dev)->config)
 
 static int mdio_transfer(const struct device *dev, uint8_t prtad, uint8_t devad,
 			 uint8_t rw, uint16_t data_in, uint16_t *data_out)
 {
-	const struct mdio_sam_dev_config *const cfg = DEV_CFG(dev);
-	struct mdio_sam_dev_data *const data = DEV_DATA(dev);
+	const struct mdio_sam_dev_config *const cfg = dev->config;
+	struct mdio_sam_dev_data *const data = dev->data;
 	int timeout = 50;
 
 	k_sem_take(&data->sem, K_FOREVER);
@@ -100,21 +97,21 @@ static int mdio_sam_write(const struct device *dev, uint8_t prtad,
 
 static void mdio_sam_bus_enable(const struct device *dev)
 {
-	const struct mdio_sam_dev_config *const cfg = DEV_CFG(dev);
+	const struct mdio_sam_dev_config *const cfg = dev->config;
 
 	cfg->regs->GMAC_NCR |= GMAC_NCR_MPE;
 }
 
 static void mdio_sam_bus_disable(const struct device *dev)
 {
-	const struct mdio_sam_dev_config *const cfg = DEV_CFG(dev);
+	const struct mdio_sam_dev_config *const cfg = dev->config;
 
 	cfg->regs->GMAC_NCR &= ~GMAC_NCR_MPE;
 }
 
 static int mdio_sam_initialize(const struct device *dev)
 {
-	struct mdio_sam_dev_data *const data = DEV_DATA(dev);
+	struct mdio_sam_dev_data *const data = dev->data;
 
 	k_sem_init(&data->sem, 1, 1);
 

--- a/drivers/misc/ft8xx/ft8xx.c
+++ b/drivers/misc/ft8xx/ft8xx.c
@@ -96,7 +96,7 @@ static bool verify_chip(void)
 static int ft8xx_init(const struct device *dev)
 {
 	int ret;
-	struct ft8xx_config *config = (struct ft8xx_config *)dev->config;
+	const struct ft8xx_config *config = (const struct ft8xx_config *)dev->config;
 
 	ret = ft8xx_drv_init();
 	if (ret < 0) {

--- a/drivers/misc/ft8xx/ft8xx.c
+++ b/drivers/misc/ft8xx/ft8xx.c
@@ -96,7 +96,7 @@ static bool verify_chip(void)
 static int ft8xx_init(const struct device *dev)
 {
 	int ret;
-	const struct ft8xx_config *config = (const struct ft8xx_config *)dev->config;
+	const struct ft8xx_config *config = dev->config;
 
 	ret = ft8xx_drv_init();
 	if (ret < 0) {

--- a/drivers/neural_net/intel_gna.c
+++ b/drivers/neural_net/intel_gna.c
@@ -28,10 +28,6 @@
 LOG_MODULE_REGISTER(neural_net);
 
 #define DEV_NAME(dev) ((dev)->name)
-#define DEV_CFG(dev) \
-	((const struct intel_gna_config *const)(dev)->config)
-#define DEV_DATA(dev) \
-	((struct intel_gna_data *const)(dev)->data)
 
 #if LOG_LEVEL >= LOG_LEVEL_DBG
 static void intel_gna_regs_dump(const struct device *dev);
@@ -53,7 +49,7 @@ static struct intel_gna_page_table __aligned(GNA_PG_SIZE_IN_BYTES)
 
 static void intel_gna_interrupt_handler(const struct device *dev)
 {
-	struct intel_gna_data *const gna = DEV_DATA(dev);
+	struct intel_gna_data *const gna = dev->data;
 
 	volatile struct intel_gna_regs *regs = gna->regs;
 	struct intel_gna_pending_resp pending_resp;
@@ -170,7 +166,7 @@ static int intel_gna_setup_page_table(void *physical, size_t size,
 
 static int intel_gna_initialize(const struct device *dev)
 {
-	struct intel_gna_data *const gna = DEV_DATA(dev);
+	struct intel_gna_data *const gna = dev->data;
 	uint32_t page_dir_entry;
 
 	k_msgq_init(&gna->request_queue, (char *)gna->requests,
@@ -225,7 +221,7 @@ static int intel_gna_initialize(const struct device *dev)
 static int intel_gna_configure(const struct device *dev,
 			       struct gna_config *cfg)
 {
-	struct intel_gna_data *const gna = DEV_DATA(dev);
+	struct intel_gna_data *const gna = dev->data;
 	volatile struct intel_gna_regs *regs = gna->regs;
 
 	if (gna->state != GNA_STATE_INITIALIZED) {
@@ -282,7 +278,7 @@ static int intel_gna_register_model(const struct device *dev,
 				    struct gna_model_info *model,
 				    void **model_handle)
 {
-	struct intel_gna_data *const gna = DEV_DATA(dev);
+	struct intel_gna_data *const gna = dev->data;
 	struct intel_gna_model *gna_model;
 	struct gna_model_header *header;
 	uint32_t ro_size, rw_size = 0;
@@ -387,7 +383,7 @@ static int intel_gna_register_model(const struct device *dev,
 static int intel_gna_deregister_model(const struct device *dev,
 				      void *model_handle)
 {
-	struct intel_gna_data *const gna = DEV_DATA(dev);
+	struct intel_gna_data *const gna = dev->data;
 	struct intel_gna_model *gna_model;
 
 	if (model_handle == NULL) {
@@ -406,7 +402,7 @@ static int intel_gna_infer(const struct device *dev,
 			   struct gna_inference_req *req,
 			   gna_callback callback)
 {
-	struct intel_gna_data *const gna = DEV_DATA(dev);
+	struct intel_gna_data *const gna = dev->data;
 	volatile struct intel_gna_regs *regs = gna->regs;
 	struct intel_gna_pending_req pending_req;
 	struct gna_model_header *header;
@@ -483,7 +479,7 @@ static int intel_gna_infer(const struct device *dev,
 #if LOG_LEVEL >= LOG_LEVEL_DBG
 static void intel_gna_regs_dump(const struct device *dev)
 {
-	struct intel_gna_data *const gna = DEV_DATA(dev);
+	struct intel_gna_data *const gna = dev->data;
 	volatile struct intel_gna_regs *regs = gna->regs;
 
 	LOG_DBG("gnasts     :%08x", regs->gnasts);
@@ -504,7 +500,7 @@ static void intel_gna_regs_dump(const struct device *dev)
 
 static void intel_gna_config_desc_dump(const struct device *dev)
 {
-	struct intel_gna_data *const gna = DEV_DATA(dev);
+	struct intel_gna_data *const gna = dev->data;
 	volatile struct intel_gna_regs *regs = gna->regs;
 
 	LOG_DBG("gnadesbase :%08x", regs->gnadesbase);

--- a/drivers/pcie/host/pcie_ecam.c
+++ b/drivers/pcie/host/pcie_ecam.c
@@ -41,8 +41,8 @@ struct pcie_ecam_data {
 
 static int pcie_ecam_init(const struct device *dev)
 {
-	const struct pcie_ctrl_config *cfg = (const struct pcie_ctrl_config *)dev->config;
-	struct pcie_ecam_data *data = (struct pcie_ecam_data *)dev->data;
+	const struct pcie_ctrl_config *cfg = dev->config;
+	struct pcie_ecam_data *data = dev->data;
 	int i;
 
 	/*
@@ -172,7 +172,7 @@ static int pcie_ecam_init(const struct device *dev)
 
 static uint32_t pcie_ecam_ctrl_conf_read(const struct device *dev, pcie_bdf_t bdf, unsigned int reg)
 {
-	struct pcie_ecam_data *data = (struct pcie_ecam_data *)dev->data;
+	struct pcie_ecam_data *data = dev->data;
 
 	return generic_pcie_ctrl_conf_read(data->cfg_addr, bdf, reg);
 }
@@ -180,7 +180,7 @@ static uint32_t pcie_ecam_ctrl_conf_read(const struct device *dev, pcie_bdf_t bd
 static void pcie_ecam_ctrl_conf_write(const struct device *dev, pcie_bdf_t bdf, unsigned int reg,
 				      uint32_t reg_data)
 {
-	struct pcie_ecam_data *data = (struct pcie_ecam_data *)dev->data;
+	struct pcie_ecam_data *data = dev->data;
 
 	generic_pcie_ctrl_conf_write(data->cfg_addr, bdf, reg, reg_data);
 }
@@ -207,7 +207,7 @@ static bool pcie_ecam_region_allocate(const struct device *dev, pcie_bdf_t bdf,
 				      bool mem, bool mem64, size_t bar_size,
 				      uintptr_t *bar_bus_addr)
 {
-	struct pcie_ecam_data *data = (struct pcie_ecam_data *)dev->data;
+	struct pcie_ecam_data *data = dev->data;
 	enum pcie_region_type type;
 
 	if (mem && !data->regions[PCIE_REGION_MEM64].size &&
@@ -244,7 +244,7 @@ static bool pcie_ecam_region_xlate(const struct device *dev, pcie_bdf_t bdf,
 				   bool mem, bool mem64, uintptr_t bar_bus_addr,
 				   uintptr_t *bar_addr)
 {
-	struct pcie_ecam_data *data = (struct pcie_ecam_data *)dev->data;
+	struct pcie_ecam_data *data = dev->data;
 	enum pcie_region_type type;
 
 	/* Means it hasn't been allocated */

--- a/drivers/pinmux/pinmux_b91.c
+++ b/drivers/pinmux/pinmux_b91.c
@@ -69,10 +69,6 @@
 #define PINMUX_B91_PULLUP_DISABLE   ((uint8_t)0u)
 #define PINMUX_B91_PULLUP_10K       ((uint8_t)3u)
 
-/* Get PinMux configuration */
-#define GET_CFG(dev) ((const struct pinmux_b91_config *)dev->config)
-
-
 /* B91 PinMux config structure */
 struct pinmux_b91_config {
 	uint8_t pad_mul_sel;
@@ -139,7 +135,7 @@ static void pinmux_b91_set_pull_up(uint32_t pin, uint8_t val)
 /* API implementation: init */
 static int pinmux_b91_init(const struct device *dev)
 {
-	const struct pinmux_b91_config *cfg = GET_CFG(dev);
+	const struct pinmux_b91_config *cfg = dev->config;
 
 	reg_gpio_pad_mul_sel |= cfg->pad_mul_sel;
 

--- a/drivers/pinmux/pinmux_ite_it8xxx2.c
+++ b/drivers/pinmux/pinmux_ite_it8xxx2.c
@@ -32,14 +32,10 @@ struct pinmux_it8xxx2_config {
 	uint8_t func4_en_mask[8];
 };
 
-#define DEV_CFG(dev)					\
-	((const struct pinmux_it8xxx2_config * const)	\
-	 (dev)->config)
-
 static int pinmux_it8xxx2_set(const struct device *dev,
 			      uint32_t pin, uint32_t func)
 {
-	const struct pinmux_it8xxx2_config *pinmux_config = DEV_CFG(dev);
+	const struct pinmux_it8xxx2_config *pinmux_config = dev->config;
 
 	volatile uint8_t *reg_gpcr =
 		(uint8_t *)(pinmux_config->reg_gpcr + pin);
@@ -89,7 +85,7 @@ static int pinmux_it8xxx2_set(const struct device *dev,
 static int pinmux_it8xxx2_get(const struct device *dev,
 			      uint32_t pin, uint32_t *func)
 {
-	const struct pinmux_it8xxx2_config *pinmux_config = DEV_CFG(dev);
+	const struct pinmux_it8xxx2_config *pinmux_config = dev->config;
 
 	volatile uint8_t *reg_gpcr =
 		(uint8_t *)(pinmux_config->reg_gpcr + pin);
@@ -110,7 +106,7 @@ static int pinmux_it8xxx2_get(const struct device *dev,
 static int pinmux_it8xxx2_pullup(const struct device *dev,
 				 uint32_t pin, uint8_t func)
 {
-	const struct pinmux_it8xxx2_config *pinmux_config = DEV_CFG(dev);
+	const struct pinmux_it8xxx2_config *pinmux_config = dev->config;
 
 	volatile uint8_t *reg_gpcr =
 		(uint8_t *)(pinmux_config->reg_gpcr + pin);
@@ -131,7 +127,7 @@ static int pinmux_it8xxx2_pullup(const struct device *dev,
 static int pinmux_it8xxx2_input(const struct device *dev,
 				uint32_t pin, uint8_t func)
 {
-	const struct pinmux_it8xxx2_config *pinmux_config = DEV_CFG(dev);
+	const struct pinmux_it8xxx2_config *pinmux_config = dev->config;
 
 	volatile uint8_t *reg_gpcr =
 		(uint8_t *)(pinmux_config->reg_gpcr + pin);

--- a/drivers/pinmux/pinmux_lpc11u6x.c
+++ b/drivers/pinmux/pinmux_lpc11u6x.c
@@ -22,10 +22,6 @@
 
 #include <drivers/pinmux.h>
 
-
-#define DEV_CFG(dev)  ((const struct pinmux_lpc11u6x_config *) \
-		      ((dev)->config))
-
 struct pinmux_lpc11u6x_config {
 	uint8_t port;
 	volatile uint32_t *base;
@@ -35,7 +31,7 @@ struct pinmux_lpc11u6x_config {
 static int pinmux_lpc11u6x_set(const struct device *dev, uint32_t pin,
 			       uint32_t func)
 {
-	const struct pinmux_lpc11u6x_config *config = DEV_CFG(dev);
+	const struct pinmux_lpc11u6x_config *config = dev->config;
 	volatile uint32_t *base;
 
 	if (pin >= config->npins) {
@@ -57,7 +53,7 @@ static int pinmux_lpc11u6x_set(const struct device *dev, uint32_t pin,
 static int
 pinmux_lpc11u6x_get(const struct device *dev, uint32_t pin, uint32_t *func)
 {
-	const struct pinmux_lpc11u6x_config *config = DEV_CFG(dev);
+	const struct pinmux_lpc11u6x_config *config = dev->config;
 	volatile uint32_t *base;
 
 	if (pin >= config->npins) {

--- a/drivers/pinmux/pinmux_sifive.c
+++ b/drivers/pinmux/pinmux_sifive.c
@@ -24,12 +24,9 @@ struct pinmux_sifive_regs_t {
 	uint32_t iof_sel;
 };
 
-#define DEV_CFG(dev)					\
-	((const struct pinmux_sifive_config * const)	\
-	 (dev)->config)
-
 #define DEV_PINMUX(dev)						\
-	((struct pinmux_sifive_regs_t *)(DEV_CFG(dev))->base)
+	((struct pinmux_sifive_regs_t *)			\
+	 ((const struct pinmux_sifive_config * const)(dev->config))->base)
 
 static int pinmux_sifive_set(const struct device *dev, uint32_t pin,
 			     uint32_t func)

--- a/drivers/pwm/pwm_gecko.c
+++ b/drivers/pwm/pwm_gecko.c
@@ -23,15 +23,12 @@ struct pwm_gecko_config {
 	uint8_t pin;
 };
 
-#define DEV_CFG(dev) \
-	((const struct pwm_gecko_config * const)(dev)->config)
-
 static int pwm_gecko_pin_set(const struct device *dev, uint32_t pwm,
 			     uint32_t period_cycles, uint32_t pulse_cycles,
 			     pwm_flags_t flags)
 {
 	TIMER_InitCC_TypeDef compare_config = TIMER_INITCC_DEFAULT;
-	const struct pwm_gecko_config *cfg = DEV_CFG(dev);
+	const struct pwm_gecko_config *cfg = dev->config;
 
 	if (BUS_RegMaskedRead(&cfg->timer->CC[pwm].CTRL,
 		_TIMER_CC_CTRL_MODE_MASK) != timerCCModePWM) {
@@ -68,7 +65,7 @@ static int pwm_gecko_get_cycles_per_sec(const struct device *dev,
 					uint32_t pwm,
 					uint64_t *cycles)
 {
-	const struct pwm_gecko_config *cfg = DEV_CFG(dev);
+	const struct pwm_gecko_config *cfg = dev->config;
 
 	*cycles = CMU_ClockFreqGet(cfg->clock) / cfg->prescaler;
 
@@ -83,7 +80,7 @@ static const struct pwm_driver_api pwm_gecko_driver_api = {
 static int pwm_gecko_init(const struct device *dev)
 {
 	TIMER_Init_TypeDef timer = TIMER_INIT_DEFAULT;
-	const struct pwm_gecko_config *cfg = DEV_CFG(dev);
+	const struct pwm_gecko_config *cfg = dev->config;
 
 	CMU_ClockEnable(cfg->clock, true);
 

--- a/drivers/pwm/pwm_imx.c
+++ b/drivers/pwm/pwm_imx.c
@@ -18,12 +18,8 @@ LOG_MODULE_REGISTER(pwm_imx);
 #define PWM_PWMCR_SWR(x) (((uint32_t)(((uint32_t)(x)) \
 				<<PWM_PWMCR_SWR_SHIFT))&PWM_PWMCR_SWR_MASK)
 
-#define DEV_CFG(dev) \
-	((const struct imx_pwm_config * const)(dev)->config)
-#define DEV_DATA(dev) \
-	((struct imx_pwm_data * const)(dev)->data)
 #define DEV_BASE(dev) \
-	((PWM_Type *)(DEV_CFG(dev))->base)
+	((PWM_Type *)((const struct imx_pwm_config * const)(dev)->config)->base)
 
 struct imx_pwm_config {
 	PWM_Type *base;
@@ -44,7 +40,7 @@ static int imx_pwm_get_cycles_per_sec(const struct device *dev, uint32_t pwm,
 				       uint64_t *cycles)
 {
 	PWM_Type *base = DEV_BASE(dev);
-	const struct imx_pwm_config *config = DEV_CFG(dev);
+	const struct imx_pwm_config *config = dev->config;
 
 	*cycles = get_pwm_clock_freq(base) >> config->prescaler;
 
@@ -56,8 +52,8 @@ static int imx_pwm_pin_set(const struct device *dev, uint32_t pwm,
 			   pwm_flags_t flags)
 {
 	PWM_Type *base = DEV_BASE(dev);
-	const struct imx_pwm_config *config = DEV_CFG(dev);
-	struct imx_pwm_data *data = DEV_DATA(dev);
+	const struct imx_pwm_config *config = dev->config;
+	struct imx_pwm_data *data = dev->data;
 	unsigned int period_ms;
 	bool enabled = imx_pwm_is_enabled(base);
 	int wait_count = 0, fifoav;
@@ -145,7 +141,7 @@ static int imx_pwm_pin_set(const struct device *dev, uint32_t pwm,
 
 static int imx_pwm_init(const struct device *dev)
 {
-	struct imx_pwm_data *data = DEV_DATA(dev);
+	struct imx_pwm_data *data = dev->data;
 	PWM_Type *base = DEV_BASE(dev);
 
 	PWM_PWMPR_REG(base) = data->period_cycles;

--- a/drivers/pwm/pwm_sam.c
+++ b/drivers/pwm/pwm_sam.c
@@ -22,14 +22,12 @@ struct sam_pwm_config {
 	uint8_t divider;
 };
 
-#define DEV_CFG(dev) \
-	((const struct sam_pwm_config * const)(dev)->config)
-
 static int sam_pwm_get_cycles_per_sec(const struct device *dev, uint32_t pwm,
 				      uint64_t *cycles)
 {
-	uint8_t prescaler = DEV_CFG(dev)->prescaler;
-	uint8_t divider = DEV_CFG(dev)->divider;
+	const struct sam_pwm_config *config = dev->config;
+	uint8_t prescaler = config->prescaler;
+	uint8_t divider = config->divider;
 
 	*cycles = SOC_ATMEL_SAM_MCK_FREQ_HZ /
 		  ((1 << prescaler) * divider);
@@ -41,7 +39,9 @@ static int sam_pwm_pin_set(const struct device *dev, uint32_t ch,
 			   uint32_t period_cycles, uint32_t pulse_cycles,
 			   pwm_flags_t flags)
 {
-	Pwm *const pwm = DEV_CFG(dev)->regs;
+	const struct sam_pwm_config *config = dev->config;
+
+	Pwm *const pwm = config->regs;
 
 	if (ch >= PWMCHNUM_NUMBER) {
 		return -EINVAL;
@@ -77,10 +77,12 @@ static int sam_pwm_pin_set(const struct device *dev, uint32_t ch,
 
 static int sam_pwm_init(const struct device *dev)
 {
-	Pwm *const pwm = DEV_CFG(dev)->regs;
-	uint32_t id = DEV_CFG(dev)->id;
-	uint8_t prescaler = DEV_CFG(dev)->prescaler;
-	uint8_t divider = DEV_CFG(dev)->divider;
+	const struct sam_pwm_config *config = dev->config;
+
+	Pwm *const pwm = config->regs;
+	uint32_t id = config->id;
+	uint8_t prescaler = config->prescaler;
+	uint8_t divider = config->divider;
 
 	/* FIXME: way to validate prescaler & divider */
 

--- a/drivers/pwm/pwm_sam.c
+++ b/drivers/pwm/pwm_sam.c
@@ -41,7 +41,7 @@ static int sam_pwm_pin_set(const struct device *dev, uint32_t ch,
 {
 	const struct sam_pwm_config *config = dev->config;
 
-	Pwm *const pwm = config->regs;
+	Pwm * const pwm = config->regs;
 
 	if (ch >= PWMCHNUM_NUMBER) {
 		return -EINVAL;
@@ -79,7 +79,7 @@ static int sam_pwm_init(const struct device *dev)
 {
 	const struct sam_pwm_config *config = dev->config;
 
-	Pwm *const pwm = config->regs;
+	Pwm * const pwm = config->regs;
 	uint32_t id = config->id;
 	uint8_t prescaler = config->prescaler;
 	uint8_t divider = config->divider;

--- a/drivers/pwm/pwm_sam0_tcc.c
+++ b/drivers/pwm/pwm_sam0_tcc.c
@@ -34,8 +34,6 @@ struct pwm_sam0_config {
 #endif
 };
 
-#define DEV_CFG(dev) ((const struct pwm_sam0_config *const)(dev)->config)
-
 /* Wait for the peripheral to finish all commands */
 static void wait_synchronization(Tcc *regs)
 {
@@ -46,7 +44,7 @@ static void wait_synchronization(Tcc *regs)
 static int pwm_sam0_get_cycles_per_sec(const struct device *dev, uint32_t ch,
 				       uint64_t *cycles)
 {
-	const struct pwm_sam0_config *const cfg = DEV_CFG(dev);
+	const struct pwm_sam0_config *const cfg = dev->config;
 
 	if (ch >= cfg->channels) {
 		return -EINVAL;
@@ -60,7 +58,7 @@ static int pwm_sam0_pin_set(const struct device *dev, uint32_t ch,
 			    uint32_t period_cycles, uint32_t pulse_cycles,
 			    pwm_flags_t flags)
 {
-	const struct pwm_sam0_config *const cfg = DEV_CFG(dev);
+	const struct pwm_sam0_config *const cfg = dev->config;
 	Tcc *regs = cfg->regs;
 	uint32_t top = 1 << cfg->counter_size;
 	uint32_t invert_mask = 1 << ch;
@@ -102,7 +100,7 @@ static int pwm_sam0_pin_set(const struct device *dev, uint32_t ch,
 
 static int pwm_sam0_init(const struct device *dev)
 {
-	const struct pwm_sam0_config *const cfg = DEV_CFG(dev);
+	const struct pwm_sam0_config *const cfg = dev->config;
 	Tcc *regs = cfg->regs;
 
 	/* Enable the clocks */

--- a/drivers/regulator/regulator_pmic.c
+++ b/drivers/regulator/regulator_pmic.c
@@ -89,7 +89,9 @@ static int regulator_modify_register(const struct regulator_config *conf,
  */
 int regulator_count_voltages(const struct device *dev)
 {
-	return ((struct regulator_config *)dev->config)->num_voltages;
+	const struct regulator_config *config = dev->config;
+
+	return config->num_voltages;
 }
 
 /**

--- a/drivers/sensor/bme280/bme280.c
+++ b/drivers/sensor/bme280/bme280.c
@@ -63,11 +63,6 @@ struct bme280_config {
 	const struct bme280_bus_io *bus_io;
 };
 
-static inline struct bme280_data *to_data(const struct device *dev)
-{
-	return dev->data;
-}
-
 static inline int bme280_bus_check(const struct device *dev)
 {
 	const struct bme280_config *cfg = dev->config;
@@ -174,7 +169,7 @@ static int bme280_wait_until_ready(const struct device *dev)
 static int bme280_sample_fetch(const struct device *dev,
 			       enum sensor_channel chan)
 {
-	struct bme280_data *data = to_data(dev);
+	struct bme280_data *data = dev->data;
 	uint8_t buf[8];
 	int32_t adc_press, adc_temp, adc_humidity;
 	int size = 6;
@@ -228,7 +223,7 @@ static int bme280_channel_get(const struct device *dev,
 			      enum sensor_channel chan,
 			      struct sensor_value *val)
 {
-	struct bme280_data *data = to_data(dev);
+	struct bme280_data *data = dev->data;
 
 	switch (chan) {
 	case SENSOR_CHAN_AMBIENT_TEMP:
@@ -272,7 +267,7 @@ static const struct sensor_driver_api bme280_api_funcs = {
 
 static int bme280_read_compensation(const struct device *dev)
 {
-	struct bme280_data *data = to_data(dev);
+	struct bme280_data *data = dev->data;
 	uint16_t buf[12];
 	uint8_t hbuf[7];
 	int err = 0;
@@ -325,7 +320,7 @@ static int bme280_read_compensation(const struct device *dev)
 
 static int bme280_chip_init(const struct device *dev)
 {
-	struct bme280_data *data = to_data(dev);
+	struct bme280_data *data = dev->data;
 	int err;
 
 	err = bme280_bus_check(dev);

--- a/drivers/sensor/bme680/bme680.c
+++ b/drivers/sensor/bme680/bme680.c
@@ -344,7 +344,7 @@ static int bme680_read_compensation(const struct device *dev)
 
 static int bme680_chip_init(const struct device *dev)
 {
-	struct bme680_data *data = (struct bme680_data *)dev->data;
+	struct bme680_data *data = dev->data;
 	int err;
 
 	err = bme680_reg_read(dev, BME680_REG_CHIP_ID, &data->chip_id, 1);

--- a/drivers/sensor/bmi160/bmi160.h
+++ b/drivers/sensor/bmi160/bmi160.h
@@ -509,16 +509,6 @@ struct bmi160_data {
 #endif /* CONFIG_BMI160_TRIGGER */
 };
 
-static inline struct bmi160_data *to_data(const struct device *dev)
-{
-	return dev->data;
-}
-
-static inline const struct bmi160_cfg *to_config(const struct device *dev)
-{
-	return dev->config;
-}
-
 int bmi160_read(const struct device *dev, uint8_t reg_addr,
 		void *data, uint8_t len);
 int bmi160_byte_read(const struct device *dev, uint8_t reg_addr,

--- a/drivers/sensor/bmi160/bmi160_trigger.c
+++ b/drivers/sensor/bmi160/bmi160_trigger.c
@@ -16,7 +16,7 @@ LOG_MODULE_DECLARE(BMI160, CONFIG_SENSOR_LOG_LEVEL);
 
 static void bmi160_handle_anymotion(const struct device *dev)
 {
-	struct bmi160_data *data = to_data(dev);
+	struct bmi160_data *data = dev->data;
 	struct sensor_trigger anym_trigger = {
 		.type = SENSOR_TRIG_DELTA,
 		.chan = SENSOR_CHAN_ACCEL_XYZ,
@@ -29,7 +29,7 @@ static void bmi160_handle_anymotion(const struct device *dev)
 
 static void bmi160_handle_drdy(const struct device *dev, uint8_t status)
 {
-	struct bmi160_data *data = to_data(dev);
+	struct bmi160_data *data = dev->data;
 	struct sensor_trigger drdy_trigger = {
 		.type = SENSOR_TRIG_DATA_READY,
 	};
@@ -121,7 +121,7 @@ static int bmi160_trigger_drdy_set(const struct device *dev,
 				   enum sensor_channel chan,
 				   sensor_trigger_handler_t handler)
 {
-	struct bmi160_data *data = to_data(dev);
+	struct bmi160_data *data = dev->data;
 	uint8_t drdy_en = 0U;
 
 #if !defined(CONFIG_BMI160_ACCEL_PMU_SUSPEND)
@@ -156,7 +156,7 @@ static int bmi160_trigger_drdy_set(const struct device *dev,
 static int bmi160_trigger_anym_set(const struct device *dev,
 				   sensor_trigger_handler_t handler)
 {
-	struct bmi160_data *data = to_data(dev);
+	struct bmi160_data *data = dev->data;
 	uint8_t anym_en = 0U;
 
 	data->handler_anymotion = handler;
@@ -265,8 +265,8 @@ int bmi160_trigger_set(const struct device *dev,
 
 int bmi160_trigger_mode_init(const struct device *dev)
 {
-	struct bmi160_data *data = to_data(dev);
-	const struct bmi160_cfg *cfg = to_config(dev);
+	struct bmi160_data *data = dev->data;
+	const struct bmi160_cfg *cfg = dev->config;
 	int ret;
 
 	if (!device_is_ready(cfg->interrupt.port)) {

--- a/drivers/sensor/bmp388/bmp388.c
+++ b/drivers/sensor/bmp388/bmp388.c
@@ -49,7 +49,7 @@ static const struct {
 static int bmp388_transceive(const struct device *dev,
 			     void *data, size_t length)
 {
-	const struct bmp388_config *cfg = DEV_CFG(dev);
+	const struct bmp388_config *cfg = dev->config;
 	const struct spi_buf buf = { .buf = data, .len = length };
 	const struct spi_buf_set s = { .buffers = &buf, .count = 1 };
 
@@ -61,7 +61,7 @@ static int bmp388_read_spi(const struct device *dev,
 			   void *data,
 			   size_t length)
 {
-	const struct bmp388_config *cfg = DEV_CFG(dev);
+	const struct bmp388_config *cfg = dev->config;
 
 	/* Reads must clock out a dummy byte after sending the address. */
 	uint8_t reg_buf[2] = { reg | BIT(7), 0 };
@@ -127,7 +127,7 @@ static int bmp388_read_i2c(const struct device *dev,
 			   void *data,
 			   size_t length)
 {
-	const struct bmp388_config *cfg = DEV_CFG(dev);
+	const struct bmp388_config *cfg = dev->config;
 
 	return i2c_burst_read(cfg->bus, cfg->bus_addr, reg, data, length);
 }
@@ -136,7 +136,7 @@ static int bmp388_byte_read_i2c(const struct device *dev,
 				uint8_t reg,
 				uint8_t *byte)
 {
-	const struct bmp388_config *cfg = DEV_CFG(dev);
+	const struct bmp388_config *cfg = dev->config;
 
 	return i2c_reg_read_byte(cfg->bus, cfg->bus_addr, reg, byte);
 }
@@ -145,7 +145,7 @@ static int bmp388_byte_write_i2c(const struct device *dev,
 				 uint8_t reg,
 				 uint8_t byte)
 {
-	const struct bmp388_config *cfg = DEV_CFG(dev);
+	const struct bmp388_config *cfg = dev->config;
 
 	return i2c_reg_write_byte(cfg->bus, cfg->bus_addr, reg, byte);
 }
@@ -155,7 +155,7 @@ int bmp388_reg_field_update_i2c(const struct device *dev,
 				uint8_t mask,
 				uint8_t val)
 {
-	const struct bmp388_config *cfg = DEV_CFG(dev);
+	const struct bmp388_config *cfg = dev->config;
 
 	return i2c_reg_update_byte(cfg->bus, cfg->bus_addr, reg, mask, val);
 }
@@ -174,7 +174,7 @@ static int bmp388_read(const struct device *dev,
 		       void *data,
 		       size_t length)
 {
-	const struct bmp388_config *cfg = DEV_CFG(dev);
+	const struct bmp388_config *cfg = dev->config;
 
 	return cfg->ops->read(dev, reg, data, length);
 }
@@ -183,7 +183,7 @@ static int bmp388_byte_read(const struct device *dev,
 			    uint8_t reg,
 			    uint8_t *byte)
 {
-	const struct bmp388_config *cfg = DEV_CFG(dev);
+	const struct bmp388_config *cfg = dev->config;
 
 	return cfg->ops->byte_read(dev, reg, byte);
 }
@@ -192,7 +192,7 @@ static int bmp388_byte_write(const struct device *dev,
 			     uint8_t reg,
 			     uint8_t byte)
 {
-	const struct bmp388_config *cfg = DEV_CFG(dev);
+	const struct bmp388_config *cfg = dev->config;
 
 	return cfg->ops->byte_write(dev, reg, byte);
 }
@@ -202,7 +202,7 @@ int bmp388_reg_field_update(const struct device *dev,
 			    uint8_t mask,
 			    uint8_t val)
 {
-	const struct bmp388_config *cfg = DEV_CFG(dev);
+	const struct bmp388_config *cfg = dev->config;
 
 	return cfg->ops->reg_field_update(dev, reg, mask, val);
 }
@@ -233,7 +233,7 @@ static int bmp388_attr_set_odr(const struct device *dev,
 			       uint16_t freq_milli)
 {
 	int err;
-	struct bmp388_data *data = DEV_DATA(dev);
+	struct bmp388_data *data = dev->data;
 	int odr = bmp388_freq_to_odr_val(freq_int, freq_milli);
 
 	if (odr < 0) {
@@ -261,7 +261,7 @@ static int bmp388_attr_set_oversampling(const struct device *dev,
 	uint32_t pos, mask;
 	int err;
 
-	struct bmp388_data *data = DEV_DATA(dev);
+	struct bmp388_data *data = dev->data;
 
 	/* Value must be a positive power of 2 <= 32. */
 	if ((val <= 0) || (val > 32) || ((val & (val - 1)) != 0)) {
@@ -343,7 +343,7 @@ static int bmp388_attr_set(const struct device *dev,
 static int bmp388_sample_fetch(const struct device *dev,
 			       enum sensor_channel chan)
 {
-	struct bmp388_data *bmp388 = DEV_DATA(dev);
+	struct bmp388_data *bmp388 = dev->data;
 	uint8_t raw[BMP388_SAMPLE_BUFFER_SIZE];
 	int ret = 0;
 
@@ -418,7 +418,7 @@ static void bmp388_compensate_temp(struct bmp388_data *data)
 static int bmp388_temp_channel_get(const struct device *dev,
 				   struct sensor_value *val)
 {
-	struct bmp388_data *data = DEV_DATA(dev);
+	struct bmp388_data *data = dev->data;
 
 	if (data->sample.comp_temp == 0) {
 		bmp388_compensate_temp(data);
@@ -490,7 +490,7 @@ static uint64_t bmp388_compensate_press(struct bmp388_data *data)
 static int bmp388_press_channel_get(const struct device *dev,
 				    struct sensor_value *val)
 {
-	struct bmp388_data *data = DEV_DATA(dev);
+	struct bmp388_data *data = dev->data;
 
 	if (data->sample.comp_temp == 0) {
 		bmp388_compensate_temp(data);
@@ -531,7 +531,7 @@ static int bmp388_channel_get(const struct device *dev,
 
 static int bmp388_get_calibration_data(const struct device *dev)
 {
-	struct bmp388_data *data = DEV_DATA(dev);
+	struct bmp388_data *data = dev->data;
 	struct bmp388_cal_data *cal = &data->cal;
 
 	if (bmp388_read(dev, BMP388_REG_CALIB0, cal, sizeof(*cal)) < 0) {
@@ -589,8 +589,8 @@ static const struct sensor_driver_api bmp388_api = {
 
 static int bmp388_init(const struct device *dev)
 {
-	struct bmp388_data *bmp388 = DEV_DATA(dev);
-	const struct bmp388_config *cfg = DEV_CFG(dev);
+	struct bmp388_data *bmp388 = dev->data;
+	const struct bmp388_config *cfg = dev->config;
 	uint8_t val = 0U;
 
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)

--- a/drivers/sensor/bmp388/bmp388.h
+++ b/drivers/sensor/bmp388/bmp388.h
@@ -187,9 +187,6 @@ struct bmp388_data {
 #endif /* CONFIG_BMP388_TRIGGER */
 };
 
-#define DEV_DATA(dev) ((struct bmp388_data *)dev->data)
-#define DEV_CFG(dev)  ((const struct bmp388_config *)dev->config)
-
 int bmp388_trigger_mode_init(const struct device *dev);
 int bmp388_trigger_set(const struct device *dev,
 		       const struct sensor_trigger *trig,

--- a/drivers/sensor/bmp388/bmp388_trigger.c
+++ b/drivers/sensor/bmp388/bmp388_trigger.c
@@ -23,7 +23,7 @@ LOG_MODULE_DECLARE(BMP388, CONFIG_SENSOR_LOG_LEVEL);
 static void bmp388_handle_interrupts(const void *arg)
 {
 	const struct device *dev = (const struct device *)arg;
-	struct bmp388_data *data = DEV_DATA(dev);
+	struct bmp388_data *data = dev->data;
 
 	struct sensor_trigger drdy_trigger = {
 		.type = SENSOR_TRIG_DATA_READY,
@@ -45,7 +45,7 @@ static void bmp388_thread_main(void *arg1, void *unused1, void *unused2)
 	ARG_UNUSED(unused1);
 	ARG_UNUSED(unused2);
 	const struct device *dev = (const struct device *)arg1;
-	struct bmp388_data *data = DEV_DATA(dev);
+	struct bmp388_data *data = dev->data;
 
 	while (1) {
 		k_sem_take(&data->sem, K_FOREVER);
@@ -90,7 +90,7 @@ int bmp388_trigger_set(
 	const struct sensor_trigger *trig,
 	sensor_trigger_handler_t handler)
 {
-	struct bmp388_data *data = DEV_DATA(dev);
+	struct bmp388_data *data = dev->data;
 
 #ifdef CONFIG_PM_DEVICE
 	enum pm_device_state state;
@@ -121,8 +121,8 @@ int bmp388_trigger_set(
 
 int bmp388_trigger_mode_init(const struct device *dev)
 {
-	struct bmp388_data *data = DEV_DATA(dev);
-	const struct bmp388_config *cfg = DEV_CFG(dev);
+	struct bmp388_data *data = dev->data;
+	const struct bmp388_config *cfg = dev->config;
 	int ret;
 
 	if (!device_is_ready(cfg->gpio_int.port)) {

--- a/drivers/sensor/lm75/lm75.c
+++ b/drivers/sensor/lm75/lm75.c
@@ -29,13 +29,13 @@ struct lm75_config {
 	uint8_t i2c_addr;
 };
 
-static inline int lm75_reg_read(struct lm75_config *cfg, uint8_t reg,
+static inline int lm75_reg_read(const struct lm75_config *cfg, uint8_t reg,
 				uint8_t *buf, uint32_t size)
 {
 	return i2c_burst_read(cfg->i2c_dev, cfg->i2c_addr, reg, buf, size);
 }
 
-static inline int lm75_fetch_temp(struct lm75_config *cfg, struct lm75_data *data)
+static inline int lm75_fetch_temp(const struct lm75_config *cfg, struct lm75_data *data)
 {
 	int ret;
 	uint8_t temp_read[2];
@@ -62,7 +62,7 @@ static int lm75_sample_fetch(const struct device *dev,
 			     enum sensor_channel chan)
 {
 	struct lm75_data *data = (struct lm75_data *)dev->data;
-	struct lm75_config *cfg = (struct lm75_config *)dev->config;
+	const struct lm75_config *cfg = (const struct lm75_config *)dev->config;
 
 	switch (chan) {
 	case SENSOR_CHAN_ALL:
@@ -96,7 +96,7 @@ static const struct sensor_driver_api lm75_driver_api = {
 
 int lm75_init(const struct device *dev)
 {
-	struct lm75_config *cfg = (struct lm75_config *)dev->config;
+	const struct lm75_config *cfg = (const struct lm75_config *)dev->config;
 
 	if (device_is_ready(cfg->i2c_dev)) {
 		return 0;

--- a/drivers/sensor/lm75/lm75.c
+++ b/drivers/sensor/lm75/lm75.c
@@ -61,8 +61,8 @@ static inline int lm75_fetch_temp(const struct lm75_config *cfg, struct lm75_dat
 static int lm75_sample_fetch(const struct device *dev,
 			     enum sensor_channel chan)
 {
-	struct lm75_data *data = (struct lm75_data *)dev->data;
-	const struct lm75_config *cfg = (const struct lm75_config *)dev->config;
+	struct lm75_data *data = dev->data;
+	const struct lm75_config *cfg = dev->config;
 
 	switch (chan) {
 	case SENSOR_CHAN_ALL:
@@ -77,7 +77,7 @@ static int lm75_channel_get(const struct device *dev,
 			    enum sensor_channel chan,
 			    struct sensor_value *val)
 {
-	struct lm75_data *data = (struct lm75_data *)dev->data;
+	struct lm75_data *data = dev->data;
 
 	switch (chan) {
 	case SENSOR_CHAN_AMBIENT_TEMP:
@@ -96,7 +96,7 @@ static const struct sensor_driver_api lm75_driver_api = {
 
 int lm75_init(const struct device *dev)
 {
-	const struct lm75_config *cfg = (const struct lm75_config *)dev->config;
+	const struct lm75_config *cfg = dev->config;
 
 	if (device_is_ready(cfg->i2c_dev)) {
 		return 0;

--- a/drivers/sensor/qdec_sam/qdec_sam.c
+++ b/drivers/sensor/qdec_sam/qdec_sam.c
@@ -35,15 +35,11 @@ struct qdec_sam_dev_data {
 };
 
 #define DEV_NAME(dev) ((dev)->name)
-#define DEV_CFG(dev) \
-	((const struct qdec_sam_dev_cfg *const)(dev)->config)
-#define DEV_DATA(dev) \
-	((struct qdec_sam_dev_data *const)(dev)->data)
 
 static int qdec_sam_fetch(const struct device *dev, enum sensor_channel chan)
 {
-	const struct qdec_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
-	struct qdec_sam_dev_data *const dev_data = DEV_DATA(dev);
+	const struct qdec_sam_dev_cfg *const dev_cfg = dev->config;
+	struct qdec_sam_dev_data *const dev_data = dev->data;
 	Tc *const tc = dev_cfg->regs;
 	TcChannel *tc_ch0 = &tc->TcChannel[0];
 
@@ -56,7 +52,7 @@ static int qdec_sam_fetch(const struct device *dev, enum sensor_channel chan)
 static int qdec_sam_get(const struct device *dev, enum sensor_channel chan,
 			struct sensor_value *val)
 {
-	struct qdec_sam_dev_data *const dev_data = DEV_DATA(dev);
+	struct qdec_sam_dev_data *const dev_data = dev->data;
 
 	if (chan == SENSOR_CHAN_ROTATION) {
 		val->val1 = dev_data->position;
@@ -79,7 +75,7 @@ static void qdec_sam_start(Tc *const tc)
 
 static void qdec_sam_configure(const struct device *dev)
 {
-	const struct qdec_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
+	const struct qdec_sam_dev_cfg *const dev_cfg = dev->config;
 	Tc *const tc = dev_cfg->regs;
 	TcChannel *tc_ch0 = &tc->TcChannel[0];
 
@@ -100,7 +96,7 @@ static void qdec_sam_configure(const struct device *dev)
 static int qdec_sam_initialize(const struct device *dev)
 {
 	__ASSERT_NO_MSG(dev != NULL);
-	const struct qdec_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
+	const struct qdec_sam_dev_cfg *const dev_cfg = dev->config;
 
 	/* Connect pins to the peripheral */
 	soc_gpio_list_configure(dev_cfg->pin_list, dev_cfg->pin_list_size);

--- a/drivers/sensor/sbs_gauge/sbs_gauge.c
+++ b/drivers/sensor/sbs_gauge/sbs_gauge.c
@@ -260,7 +260,7 @@ static int sbs_gauge_sample_fetch(const struct device *dev,
  */
 static int sbs_gauge_init(const struct device *dev)
 {
-	struct sbs_gauge_config *cfg;
+	const struct sbs_gauge_config *cfg;
 
 	cfg = (struct sbs_gauge_config *)dev->config;
 

--- a/drivers/sensor/sbs_gauge/sbs_gauge.c
+++ b/drivers/sensor/sbs_gauge/sbs_gauge.c
@@ -23,7 +23,7 @@ static int sbs_cmd_reg_read(const struct device *dev,
 	uint8_t i2c_data[2];
 	int status;
 
-	cfg = (struct sbs_gauge_config *)dev->config;
+	cfg = dev->config;
 	status = i2c_burst_read(cfg->i2c_dev, cfg->i2c_addr, reg_addr,
 				i2c_data, ARRAY_SIZE(i2c_data));
 	if (status < 0) {
@@ -48,7 +48,7 @@ static int sbs_gauge_channel_get(const struct device *dev,
 	struct sbs_gauge_data *data;
 	int32_t int_temp;
 
-	data = (struct sbs_gauge_data *)dev->data;
+	data = dev->data;
 	val->val2 = 0;
 
 	switch (chan) {
@@ -128,7 +128,7 @@ static int sbs_gauge_sample_fetch(const struct device *dev,
 	struct sbs_gauge_data *data;
 	int status = 0;
 
-	data = (struct sbs_gauge_data *)dev->data;
+	data = dev->data;
 
 	switch (chan) {
 	case SENSOR_CHAN_GAUGE_VOLTAGE:
@@ -262,7 +262,7 @@ static int sbs_gauge_init(const struct device *dev)
 {
 	const struct sbs_gauge_config *cfg;
 
-	cfg = (struct sbs_gauge_config *)dev->config;
+	cfg = dev->config;
 
 	if (!device_is_ready(cfg->i2c_dev)) {
 		LOG_ERR("%s device is not ready", cfg->i2c_dev->name);

--- a/drivers/sensor/sht3xd/sht3xd_trigger.c
+++ b/drivers/sensor/sht3xd/sht3xd_trigger.c
@@ -84,7 +84,7 @@ int sht3xd_attr_set(const struct device *dev,
 static inline void setup_alert(const struct device *dev,
 			       bool enable)
 {
-	struct sht3xd_data *data = (struct sht3xd_data *)dev->data;
+	struct sht3xd_data *data = dev->data;
 	const struct sht3xd_config *cfg =
 		(const struct sht3xd_config *)dev->config;
 	unsigned int flags = enable
@@ -99,11 +99,11 @@ static inline void handle_alert(const struct device *dev)
 	setup_alert(dev, false);
 
 #if defined(CONFIG_SHT3XD_TRIGGER_OWN_THREAD)
-	struct sht3xd_data *data = (struct sht3xd_data *)dev->data;
+	struct sht3xd_data *data = dev->data;
 
 	k_sem_give(&data->gpio_sem);
 #elif defined(CONFIG_SHT3XD_TRIGGER_GLOBAL_THREAD)
-	struct sht3xd_data *data = (struct sht3xd_data *)dev->data;
+	struct sht3xd_data *data = dev->data;
 
 	k_work_submit(&data->work);
 #endif
@@ -113,7 +113,7 @@ int sht3xd_trigger_set(const struct device *dev,
 		       const struct sensor_trigger *trig,
 		       sensor_trigger_handler_t handler)
 {
-	struct sht3xd_data *data = (struct sht3xd_data *)dev->data;
+	struct sht3xd_data *data = dev->data;
 	const struct sht3xd_config *cfg =
 		(const struct sht3xd_config *)dev->config;
 
@@ -153,7 +153,7 @@ static void sht3xd_gpio_callback(const struct device *dev,
 
 static void sht3xd_thread_cb(const struct device *dev)
 {
-	struct sht3xd_data *data = (struct sht3xd_data *)dev->data;
+	struct sht3xd_data *data = dev->data;
 
 	if (data->handler != NULL) {
 		data->handler(dev, &data->trigger);

--- a/drivers/sensor/vl53l0x/vl53l0x.c
+++ b/drivers/sensor/vl53l0x/vl53l0x.c
@@ -70,7 +70,7 @@ static int vl53l0x_channel_get(const struct device *dev,
 			       enum sensor_channel chan,
 			       struct sensor_value *val)
 {
-	struct vl53l0x_data *drv_data = (struct vl53l0x_data *)dev->data;
+	struct vl53l0x_data *drv_data = dev->data;
 
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_DISTANCE
 			|| chan == SENSOR_CHAN_PROX);

--- a/drivers/serial/leuart_gecko.c
+++ b/drivers/serial/leuart_gecko.c
@@ -18,12 +18,9 @@
 #define CLOCK_ID_PRFX(prefix, suffix) CLOCK_ID_PRFX2(prefix, suffix)
 #define CLOCK_LEUART(id) CLOCK_ID_PRFX(LEUART_PREFIX, id)
 
-#define DEV_CFG(dev) \
-	((const struct leuart_gecko_config * const)(dev)->config)
-#define DEV_DATA(dev) \
-	((struct leuart_gecko_data * const)(dev)->data)
 #define DEV_BASE(dev) \
-	((LEUART_TypeDef *)(DEV_CFG(dev))->base)
+	((LEUART_TypeDef *) \
+	 ((const struct leuart_gecko_config * const)(dev)->config)->base)
 
 struct leuart_gecko_config {
 	LEUART_TypeDef *base;
@@ -244,7 +241,7 @@ static void leuart_gecko_isr(const struct device *dev)
 
 static void leuart_gecko_init_pins(const struct device *dev)
 {
-	const struct leuart_gecko_config *config = DEV_CFG(dev);
+	const struct leuart_gecko_config *config = dev->config;
 	LEUART_TypeDef *base = DEV_BASE(dev);
 
 	soc_gpio_configure(&config->pin_rx);
@@ -263,7 +260,7 @@ static void leuart_gecko_init_pins(const struct device *dev)
 
 static int leuart_gecko_init(const struct device *dev)
 {
-	const struct leuart_gecko_config *config = DEV_CFG(dev);
+	const struct leuart_gecko_config *config = dev->config;
 	LEUART_TypeDef *base = DEV_BASE(dev);
 	LEUART_Init_TypeDef leuartInit = LEUART_INIT_DEFAULT;
 

--- a/drivers/serial/uart_altera_jtag_hal.c
+++ b/drivers/serial/uart_altera_jtag_hal.c
@@ -18,9 +18,6 @@
 #define UART_ALTERA_JTAG_DATA_REG                  0
 #define UART_ALTERA_JTAG_CONTROL_REG               1
 
-#define DEV_CFG(dev) \
-	((const struct uart_device_config * const)(dev)->config)
-
 extern int altera_avalon_jtag_uart_read(altera_avalon_jtag_uart_state *sp,
 		char *buffer, int space, int flags);
 extern int altera_avalon_jtag_uart_write(altera_avalon_jtag_uart_state *sp,
@@ -32,7 +29,7 @@ static void uart_altera_jtag_poll_out(const struct device *dev,
 	const struct uart_device_config *config;
 	altera_avalon_jtag_uart_state ustate;
 
-	config = DEV_CFG(dev);
+	config = dev->config;
 
 	ustate.base = JTAG_UART_0_BASE;
 	altera_avalon_jtag_uart_write(&ustate, &c, 1, 0);

--- a/drivers/serial/uart_apbuart.c
+++ b/drivers/serial/uart_apbuart.c
@@ -134,20 +134,17 @@ struct apbuart_dev_data {
 #endif
 };
 
-#define DEV_CFG(dev) \
-	((const struct apbuart_dev_cfg *const)(dev)->config)
-#define DEV_DATA(dev) \
-	((struct apbuart_dev_data *const)(dev)->data)
-
 /*
  * This routine waits for the TX holding register or TX FIFO to be ready and
  * then it writes a character to the data register.
  */
 static void apbuart_poll_out(const struct device *dev, unsigned char x)
 {
-	volatile struct apbuart_regs *regs = (void *) DEV_CFG(dev)->regs;
+	const struct apbuart_dev_cfg *config = dev->config;
+	struct apbuart_dev_data *data = dev->data;
+	volatile struct apbuart_regs *regs = (void *) config->regs;
 
-	if (DEV_DATA(dev)->usefifo) {
+	if (data->usefifo) {
 		/* Transmitter FIFO full flag is available. */
 		while (regs->status & APBUART_STATUS_TF) {
 			;
@@ -167,7 +164,8 @@ static void apbuart_poll_out(const struct device *dev, unsigned char x)
 
 static int apbuart_poll_in(const struct device *dev, unsigned char *c)
 {
-	volatile struct apbuart_regs *regs = (void *) DEV_CFG(dev)->regs;
+	const struct apbuart_dev_cfg *config = dev->config;
+	volatile struct apbuart_regs *regs = (void *) config->regs;
 
 	if ((regs->status & APBUART_STATUS_DR) == 0) {
 		return -1;
@@ -179,7 +177,8 @@ static int apbuart_poll_in(const struct device *dev, unsigned char *c)
 
 static int apbuart_err_check(const struct device *dev)
 {
-	volatile struct apbuart_regs *regs = (void *) DEV_CFG(dev)->regs;
+	const struct apbuart_dev_cfg *config = dev->config;
+	volatile struct apbuart_regs *regs = (void *) config->regs;
 	const uint32_t status = regs->status;
 	int err = 0;
 
@@ -233,7 +232,8 @@ static void set_baud(volatile struct apbuart_regs *const regs, uint32_t baud)
 static int apbuart_configure(const struct device *dev,
 			     const struct uart_config *cfg)
 {
-	volatile struct apbuart_regs *regs = (void *) DEV_CFG(dev)->regs;
+	const struct apbuart_dev_cfg *config = dev->config;
+	volatile struct apbuart_regs *regs = (void *) config->regs;
 	uint32_t ctrl = 0;
 	uint32_t newctrl = 0;
 
@@ -279,7 +279,8 @@ static int apbuart_configure(const struct device *dev,
 
 static int apbuart_config_get(const struct device *dev, struct uart_config *cfg)
 {
-	volatile struct apbuart_regs *regs = (void *) DEV_CFG(dev)->regs;
+	const struct apbuart_dev_cfg *config = dev->config;
+	volatile struct apbuart_regs *regs = (void *) config->regs;
 	const uint32_t ctrl = regs->ctrl;
 
 	cfg->parity = UART_CFG_PARITY_NONE;
@@ -311,10 +312,12 @@ static void apbuart_isr(const struct device *dev);
 static int apbuart_fifo_fill(const struct device *dev, const uint8_t *tx_data,
 			     int size)
 {
-	volatile struct apbuart_regs *regs = (void *) DEV_CFG(dev)->regs;
+	const struct apbuart_dev_cfg *config = dev->config;
+	struct apbuart_dev_data *data = dev->data;
+	volatile struct apbuart_regs *regs = (void *) config->regs;
 	int i;
 
-	if (DEV_DATA(dev)->usefifo) {
+	if (data->usefifo) {
 		/* Transmitter FIFO full flag is available. */
 		for (
 			i = 0;
@@ -335,7 +338,8 @@ static int apbuart_fifo_fill(const struct device *dev, const uint8_t *tx_data,
 static int apbuart_fifo_read(const struct device *dev, uint8_t *rx_data,
 			     const int size)
 {
-	volatile struct apbuart_regs *regs = (void *) DEV_CFG(dev)->regs;
+	const struct apbuart_dev_cfg *config = dev->config;
+	volatile struct apbuart_regs *regs = (void *) config->regs;
 	int i;
 
 	for (i = 0; (i < size) && (regs->status & APBUART_STATUS_DR); i++) {
@@ -347,10 +351,12 @@ static int apbuart_fifo_read(const struct device *dev, uint8_t *rx_data,
 
 static void apbuart_irq_tx_enable(const struct device *dev)
 {
-	volatile struct apbuart_regs *regs = (void *) DEV_CFG(dev)->regs;
+	const struct apbuart_dev_cfg *config = dev->config;
+	struct apbuart_dev_data *data = dev->data;
+	volatile struct apbuart_regs *regs = (void *) config->regs;
 	unsigned int key;
 
-	if (DEV_DATA(dev)->usefifo) {
+	if (data->usefifo) {
 		/* Enable the FIFO level interrupt */
 		regs->ctrl |= APBUART_CTRL_TF;
 		return;
@@ -375,16 +381,19 @@ static void apbuart_irq_tx_enable(const struct device *dev)
 
 static void apbuart_irq_tx_disable(const struct device *dev)
 {
-	volatile struct apbuart_regs *regs = (void *) DEV_CFG(dev)->regs;
+	const struct apbuart_dev_cfg *config = dev->config;
+	volatile struct apbuart_regs *regs = (void *) config->regs;
 
 	regs->ctrl &= ~(APBUART_CTRL_TF | APBUART_CTRL_TI);
 }
 
 static int apbuart_irq_tx_ready(const struct device *dev)
 {
-	volatile struct apbuart_regs *regs = (void *) DEV_CFG(dev)->regs;
+	const struct apbuart_dev_cfg *config = dev->config;
+	struct apbuart_dev_data *data = dev->data;
+	volatile struct apbuart_regs *regs = (void *) config->regs;
 
-	if (DEV_DATA(dev)->usefifo) {
+	if (data->usefifo) {
 		return !(regs->status & APBUART_STATUS_TF);
 	}
 	return !!(regs->status & APBUART_STATUS_TE);
@@ -392,35 +401,41 @@ static int apbuart_irq_tx_ready(const struct device *dev)
 
 static int apbuart_irq_tx_complete(const struct device *dev)
 {
-	volatile struct apbuart_regs *regs = (void *) DEV_CFG(dev)->regs;
+	const struct apbuart_dev_cfg *config = dev->config;
+	volatile struct apbuart_regs *regs = (void *) config->regs;
 
 	return !!(regs->status & APBUART_STATUS_TS);
 }
 
 static void apbuart_irq_rx_enable(const struct device *dev)
 {
-	volatile struct apbuart_regs *regs = (void *) DEV_CFG(dev)->regs;
+	const struct apbuart_dev_cfg *config = dev->config;
+	volatile struct apbuart_regs *regs = (void *) config->regs;
 
 	regs->ctrl |= APBUART_CTRL_RI;
 }
 
 static void apbuart_irq_rx_disable(const struct device *dev)
 {
-	volatile struct apbuart_regs *regs = (void *) DEV_CFG(dev)->regs;
+	const struct apbuart_dev_cfg *config = dev->config;
+	volatile struct apbuart_regs *regs = (void *) config->regs;
 
 	regs->ctrl &= ~APBUART_CTRL_RI;
 }
 
 static int apbuart_irq_rx_ready(const struct device *dev)
 {
-	volatile struct apbuart_regs *regs = (void *) DEV_CFG(dev)->regs;
+	const struct apbuart_dev_cfg *config = dev->config;
+	volatile struct apbuart_regs *regs = (void *) config->regs;
 
 	return !!(regs->status & APBUART_STATUS_DR);
 }
 
 static int apbuart_irq_is_pending(const struct device *dev)
 {
-	volatile struct apbuart_regs *regs = (void *) DEV_CFG(dev)->regs;
+	const struct apbuart_dev_cfg *config = dev->config;
+	struct apbuart_dev_data *data = dev->data;
+	volatile struct apbuart_regs *regs = (void *) config->regs;
 	uint32_t status = regs->status;
 	uint32_t ctrl = regs->ctrl;
 
@@ -428,7 +443,7 @@ static int apbuart_irq_is_pending(const struct device *dev)
 		return 1;
 	}
 
-	if (DEV_DATA(dev)->usefifo) {
+	if (data->usefifo) {
 		/* TH is the TX FIFO half-empty flag */
 		if (status & APBUART_STATUS_TH) {
 			return 1;
@@ -451,7 +466,7 @@ static void apbuart_irq_callback_set(const struct device *dev,
 				     uart_irq_callback_user_data_t cb,
 				     void *cb_data)
 {
-	struct apbuart_dev_data *const dev_data = DEV_DATA(dev);
+	struct apbuart_dev_data *const dev_data = dev->data;
 
 	dev_data->cb = cb;
 	dev_data->cb_data = cb_data;
@@ -459,7 +474,7 @@ static void apbuart_irq_callback_set(const struct device *dev,
 
 static void apbuart_isr(const struct device *dev)
 {
-	struct apbuart_dev_data *const dev_data = DEV_DATA(dev);
+	struct apbuart_dev_data *const dev_data = dev->data;
 
 	if (dev_data->cb) {
 		dev_data->cb(dev, dev_data->cb_data);
@@ -469,13 +484,15 @@ static void apbuart_isr(const struct device *dev)
 
 static int apbuart_init(const struct device *dev)
 {
-	volatile struct apbuart_regs *regs = (void *) DEV_CFG(dev)->regs;
+	const struct apbuart_dev_cfg *config = dev->config;
+	struct apbuart_dev_data *data = dev->data;
+	volatile struct apbuart_regs *regs = (void *) config->regs;
 	const uint32_t APBUART_DEBUG_MASK = APBUART_CTRL_DB | APBUART_CTRL_FL;
 	uint32_t dm;
 	uint32_t ctrl;
 
 	ctrl = regs->ctrl;
-	DEV_DATA(dev)->usefifo = !!(ctrl & APBUART_CTRL_FA);
+	data->usefifo = !!(ctrl & APBUART_CTRL_FA);
 	/* NOTE: CTRL_FL has reset value 0. CTRL_DB has no reset value. */
 	dm = ctrl & APBUART_DEBUG_MASK;
 	if (dm == APBUART_DEBUG_MASK) {
@@ -488,9 +505,9 @@ static int apbuart_init(const struct device *dev)
 	regs->status = 0;
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	irq_connect_dynamic(DEV_CFG(dev)->interrupt,
+	irq_connect_dynamic(config->interrupt,
 			    0, (void (*)(const void *))apbuart_isr, dev, 0);
-	irq_enable(DEV_CFG(dev)->interrupt);
+	irq_enable(config->interrupt);
 #endif
 
 	return 0;

--- a/drivers/serial/uart_b91.c
+++ b/drivers/serial/uart_b91.c
@@ -20,12 +20,6 @@
 #define GET_UART(dev)      ((volatile struct uart_b91_t *) \
 			    ((const struct uart_b91_config *)dev->config)->uart_addr)
 
-/* Get UART configuration */
-#define GET_CFG(dev)       ((const struct uart_b91_config *)dev->config)
-
-/* Get instance data */
-#define DEV_DATA(dev)      ((struct uart_b91_data *const)dev->data)
-
 /* UART TX buffer count max value */
 #define UART_TX_BUF_CNT    ((uint8_t)8u)
 
@@ -236,7 +230,7 @@ static void uart_b91_irq_handler(const struct device *dev)
 #ifndef CONFIG_UART_INTERRUPT_DRIVEN
 	ARG_UNUSED(dev);
 #else
-	struct uart_b91_data *data = DEV_DATA(dev);
+	struct uart_b91_data *data = dev->data;
 
 	if (data->callback != NULL) {
 		data->callback(dev, data->cb_data);
@@ -248,6 +242,7 @@ static void uart_b91_irq_handler(const struct device *dev)
 static int uart_b91_configure(const struct device *dev,
 			      const struct uart_config *cfg)
 {
+	struct uart_b91_data *data = dev->data;
 	uint16_t divider;
 	uint8_t bwpc;
 	uint8_t parity;
@@ -287,7 +282,7 @@ static int uart_b91_configure(const struct device *dev,
 	uart_b91_init(uart, divider, bwpc, parity, stop_bits);
 
 	/* save configuration */
-	DEV_DATA(dev)->cfg = *cfg;
+	data->cfg = *cfg;
 
 	return 0;
 }
@@ -296,7 +291,8 @@ static int uart_b91_configure(const struct device *dev,
 static int uart_b91_config_get(const struct device *dev,
 			       struct uart_config *cfg)
 {
-	*cfg = DEV_DATA(dev)->cfg;
+	struct uart_b91_data *data = dev->data;
+	*cfg = data->cfg;
 
 	return 0;
 }
@@ -308,7 +304,7 @@ static int uart_b91_driver_init(const struct device *dev)
 	uint8_t bwpc = 0u;
 	const struct device *pinmux;
 	volatile struct uart_b91_t *uart = GET_UART(dev);
-	const struct uart_b91_config *cfg = GET_CFG(dev);
+	const struct uart_b91_config *cfg = dev->config;
 
 	pinmux = DEVICE_DT_GET(DT_NODELABEL(pinmux));
 	if (!device_is_ready(pinmux)) {
@@ -334,7 +330,7 @@ static int uart_b91_driver_init(const struct device *dev)
 static void uart_b91_poll_out(const struct device *dev, uint8_t c)
 {
 	volatile struct uart_b91_t *uart = GET_UART(dev);
-	struct uart_b91_data *data = DEV_DATA(dev);
+	struct uart_b91_data *data = dev->data;
 
 	while (uart_b91_get_tx_bufcnt(uart) >= UART_TX_BUF_CNT) {
 	};
@@ -347,7 +343,7 @@ static void uart_b91_poll_out(const struct device *dev, uint8_t c)
 static int uart_b91_poll_in(const struct device *dev, unsigned char *c)
 {
 	volatile struct uart_b91_t *uart = GET_UART(dev);
-	struct uart_b91_data *data = DEV_DATA(dev);
+	struct uart_b91_data *data = dev->data;
 
 	if (uart_b91_get_rx_bufcnt(uart) == 0) {
 		return -1;
@@ -510,7 +506,7 @@ static void uart_b91_irq_callback_set(const struct device *dev,
 				      uart_irq_callback_user_data_t cb,
 				      void *cb_data)
 {
-	struct uart_b91_data *data = DEV_DATA(dev);
+	struct uart_b91_data *data = dev->data;
 
 	data->callback = cb;
 	data->cb_data = cb_data;

--- a/drivers/serial/uart_cc13xx_cc26xx.c
+++ b/drivers/serial/uart_cc13xx_cc26xx.c
@@ -38,24 +38,16 @@ struct uart_cc13xx_cc26xx_data {
 #endif
 };
 
-static inline struct uart_cc13xx_cc26xx_data *get_dev_data(const struct device *dev)
-{
-	return dev->data;
-}
-
-static inline const struct uart_device_config *get_dev_conf(const struct device *dev)
-{
-	return dev->config;
-}
-
 static int uart_cc13xx_cc26xx_poll_in(const struct device *dev,
 				      unsigned char *c)
 {
-	if (!UARTCharsAvail(get_dev_conf(dev)->regs)) {
+	const struct uart_device_config *config = dev->config;
+
+	if (!UARTCharsAvail(config->regs)) {
 		return -1;
 	}
 
-	*c = UARTCharGetNonBlocking(get_dev_conf(dev)->regs);
+	*c = UARTCharGetNonBlocking(config->regs);
 
 	return 0;
 }
@@ -63,25 +55,29 @@ static int uart_cc13xx_cc26xx_poll_in(const struct device *dev,
 static void uart_cc13xx_cc26xx_poll_out(const struct device *dev,
 					unsigned char c)
 {
-	UARTCharPut(get_dev_conf(dev)->regs, c);
+	const struct uart_device_config *config = dev->config;
+
+	UARTCharPut(config->regs, c);
 	/*
 	 * Need to wait for character to be transmitted to ensure cpu does not
 	 * enter standby when uart is busy
 	 */
-	while (UARTBusy(get_dev_conf(dev)->regs) == true) {
+	while (UARTBusy(config->regs) == true) {
 	}
 }
 
 static int uart_cc13xx_cc26xx_err_check(const struct device *dev)
 {
-	uint32_t flags = UARTRxErrorGet(get_dev_conf(dev)->regs);
+	const struct uart_device_config *config = dev->config;
+
+	uint32_t flags = UARTRxErrorGet(config->regs);
 
 	int error = (flags & UART_RXERROR_FRAMING ? UART_ERROR_FRAMING : 0) |
 		    (flags & UART_RXERROR_PARITY ? UART_ERROR_PARITY : 0) |
 		    (flags & UART_RXERROR_BREAK ? UART_BREAK : 0) |
 		    (flags & UART_RXERROR_OVERRUN ? UART_ERROR_OVERRUN : 0);
 
-	UARTRxErrorClear(get_dev_conf(dev)->regs);
+	UARTRxErrorClear(config->regs);
 
 	return error;
 }
@@ -89,6 +85,8 @@ static int uart_cc13xx_cc26xx_err_check(const struct device *dev)
 static int uart_cc13xx_cc26xx_configure(const struct device *dev,
 					const struct uart_config *cfg)
 {
+	const struct uart_device_config *config = dev->config;
+	struct uart_cc13xx_cc26xx_data *data = dev->data;
 	uint32_t line_ctrl = 0;
 	bool flow_ctrl;
 
@@ -157,29 +155,29 @@ static int uart_cc13xx_cc26xx_configure(const struct device *dev,
 	}
 
 	/* Disables UART before setting control registers */
-	UARTConfigSetExpClk(get_dev_conf(dev)->regs,
-			    get_dev_conf(dev)->sys_clk_freq, cfg->baudrate,
+	UARTConfigSetExpClk(config->regs,
+			    config->sys_clk_freq, cfg->baudrate,
 			    line_ctrl);
 
 	/* Clear all UART interrupts */
-	UARTIntClear(get_dev_conf(dev)->regs,
+	UARTIntClear(config->regs,
 		UART_INT_OE | UART_INT_BE | UART_INT_PE |
 		UART_INT_FE | UART_INT_RT | UART_INT_TX |
 		UART_INT_RX | UART_INT_CTS);
 
 	if (flow_ctrl) {
-		UARTHwFlowControlEnable(get_dev_conf(dev)->regs);
+		UARTHwFlowControlEnable(config->regs);
 	} else {
-		UARTHwFlowControlDisable(get_dev_conf(dev)->regs);
+		UARTHwFlowControlDisable(config->regs);
 	}
 
 	/* Re-enable UART */
-	UARTEnable(get_dev_conf(dev)->regs);
+	UARTEnable(config->regs);
 
 	/* Disabled FIFOs act as 1-byte-deep holding registers (character mode) */
-	UARTFIFODisable(get_dev_conf(dev)->regs);
+	UARTFIFODisable(config->regs);
 
-	get_dev_data(dev)->uart_config = *cfg;
+	data->uart_config = *cfg;
 
 	return 0;
 }
@@ -188,7 +186,9 @@ static int uart_cc13xx_cc26xx_configure(const struct device *dev,
 static int uart_cc13xx_cc26xx_config_get(const struct device *dev,
 					 struct uart_config *cfg)
 {
-	*cfg = get_dev_data(dev)->uart_config;
+	struct uart_cc13xx_cc26xx_data *data = dev->data;
+
+	*cfg = data->uart_config;
 	return 0;
 }
 #endif /* CONFIG_UART_USE_RUNTIME_CONFIGURE */
@@ -199,10 +199,11 @@ static int uart_cc13xx_cc26xx_fifo_fill(const struct device *dev,
 					const uint8_t *buf,
 					int len)
 {
+	const struct uart_device_config *config = dev->config;
 	int n = 0;
 
 	while (n < len) {
-		if (!UARTCharPutNonBlocking(get_dev_conf(dev)->regs, buf[n])) {
+		if (!UARTCharPutNonBlocking(config->regs, buf[n])) {
 			break;
 		}
 		n++;
@@ -215,11 +216,12 @@ static int uart_cc13xx_cc26xx_fifo_read(const struct device *dev,
 					uint8_t *buf,
 					const int len)
 {
+	const struct uart_device_config *config = dev->config;
 	int c, n;
 
 	n = 0;
 	while (n < len) {
-		c = UARTCharGetNonBlocking(get_dev_conf(dev)->regs);
+		c = UARTCharGetNonBlocking(config->regs);
 		if (c == -1) {
 			break;
 		}
@@ -231,8 +233,12 @@ static int uart_cc13xx_cc26xx_fifo_read(const struct device *dev,
 
 static void uart_cc13xx_cc26xx_irq_tx_enable(const struct device *dev)
 {
+	const struct uart_device_config *config = dev->config;
+
 #ifdef CONFIG_PM
-	if (!get_dev_data(dev)->tx_constrained) {
+	struct uart_cc13xx_cc26xx_data *data = dev->data;
+
+	if (!data->tx_constrained) {
 		/*
 		 * When tx irq is enabled, it is implicit that we are expecting
 		 * to transmit using the uart, hence we should no longer go
@@ -244,86 +250,109 @@ static void uart_cc13xx_cc26xx_irq_tx_enable(const struct device *dev)
 		 * would interfere with a transfer.
 		 */
 		pm_constraint_set(PM_STATE_STANDBY);
-		get_dev_data(dev)->tx_constrained = true;
+		data->tx_constrained = true;
 	}
 #endif
 
-	UARTIntEnable(get_dev_conf(dev)->regs, UART_INT_TX);
+	UARTIntEnable(config->regs, UART_INT_TX);
 }
 
 static void uart_cc13xx_cc26xx_irq_tx_disable(const struct device *dev)
 {
-	UARTIntDisable(get_dev_conf(dev)->regs, UART_INT_TX);
+	const struct uart_device_config *config = dev->config;
+
+	UARTIntDisable(config->regs, UART_INT_TX);
 
 #ifdef CONFIG_PM
-	if (get_dev_data(dev)->tx_constrained) {
+	struct uart_cc13xx_cc26xx_data *data = dev->data;
+
+	if (data->tx_constrained) {
 		pm_constraint_release(PM_STATE_STANDBY);
-		get_dev_data(dev)->tx_constrained = false;
+		data->tx_constrained = false;
 	}
 #endif
 }
 
 static int uart_cc13xx_cc26xx_irq_tx_ready(const struct device *dev)
 {
-	return UARTSpaceAvail(get_dev_conf(dev)->regs) ? 1 : 0;
+	const struct uart_device_config *config = dev->config;
+
+	return UARTSpaceAvail(config->regs) ? 1 : 0;
 }
 
 static void uart_cc13xx_cc26xx_irq_rx_enable(const struct device *dev)
 {
+	const struct uart_device_config *config = dev->config;
+
 #ifdef CONFIG_PM
+	struct uart_cc13xx_cc26xx_data *data = dev->data;
+
 	/*
 	 * When rx is enabled, it is implicit that we are expecting
 	 * to receive from the uart, hence we can no longer go into
 	 * standby.
 	 */
-	if (!get_dev_data(dev)->rx_constrained) {
+	if (!data->rx_constrained) {
 		pm_constraint_set(PM_STATE_STANDBY);
-		get_dev_data(dev)->rx_constrained = true;
+		data->rx_constrained = true;
 	}
 #endif
 
-	UARTIntEnable(get_dev_conf(dev)->regs, UART_INT_RX);
+	UARTIntEnable(config->regs, UART_INT_RX);
 }
 
 static void uart_cc13xx_cc26xx_irq_rx_disable(const struct device *dev)
 {
+	const struct uart_device_config *config = dev->config;
+
 #ifdef CONFIG_PM
-	if (get_dev_data(dev)->rx_constrained) {
+	struct uart_cc13xx_cc26xx_data *data = dev->data;
+
+	if (data->rx_constrained) {
 		pm_constraint_release(PM_STATE_STANDBY);
-		get_dev_data(dev)->rx_constrained = false;
+		data->rx_constrained = false;
 	}
 #endif
 
-	UARTIntDisable(get_dev_conf(dev)->regs, UART_INT_RX);
+	UARTIntDisable(config->regs, UART_INT_RX);
 }
 
 static int uart_cc13xx_cc26xx_irq_tx_complete(const struct device *dev)
 {
-	return UARTBusy(get_dev_conf(dev)->regs) ? 0 : 1;
+	const struct uart_device_config *config = dev->config;
+
+	return UARTBusy(config->regs) ? 0 : 1;
 }
 
 static int uart_cc13xx_cc26xx_irq_rx_ready(const struct device *dev)
 {
-	return UARTCharsAvail(get_dev_conf(dev)->regs) ? 1 : 0;
+	const struct uart_device_config *config = dev->config;
+
+	return UARTCharsAvail(config->regs) ? 1 : 0;
 }
 
 static void uart_cc13xx_cc26xx_irq_err_enable(const struct device *dev)
 {
-	return UARTIntEnable(get_dev_conf(dev)->regs,
+	const struct uart_device_config *config = dev->config;
+
+	return UARTIntEnable(config->regs,
 			     UART_INT_OE | UART_INT_BE | UART_INT_PE |
 				     UART_INT_FE);
 }
 
 static void uart_cc13xx_cc26xx_irq_err_disable(const struct device *dev)
 {
-	return UARTIntDisable(get_dev_conf(dev)->regs,
+	const struct uart_device_config *config = dev->config;
+
+	return UARTIntDisable(config->regs,
 			      UART_INT_OE | UART_INT_BE | UART_INT_PE |
 				      UART_INT_FE);
 }
 
 static int uart_cc13xx_cc26xx_irq_is_pending(const struct device *dev)
 {
-	uint32_t status = UARTIntStatus(get_dev_conf(dev)->regs, true);
+	const struct uart_device_config *config = dev->config;
+	uint32_t status = UARTIntStatus(config->regs, true);
 
 	return status & (UART_INT_TX | UART_INT_RX) ? 1 : 0;
 }
@@ -338,7 +367,7 @@ static void uart_cc13xx_cc26xx_irq_callback_set(const struct device *dev,
 						uart_irq_callback_user_data_t cb,
 						void *user_data)
 {
-	struct uart_cc13xx_cc26xx_data *data = get_dev_data(dev);
+	struct uart_cc13xx_cc26xx_data *data = dev->data;
 
 	data->callback = cb;
 	data->user_data = user_data;
@@ -346,7 +375,7 @@ static void uart_cc13xx_cc26xx_irq_callback_set(const struct device *dev,
 
 static void uart_cc13xx_cc26xx_isr(const struct device *dev)
 {
-	struct uart_cc13xx_cc26xx_data *data = get_dev_data(dev);
+	struct uart_cc13xx_cc26xx_data *data = dev->data;
 
 	if (data->callback) {
 		data->callback(dev, data->user_data);
@@ -368,13 +397,14 @@ static int postNotifyFxn(unsigned int eventType, uintptr_t eventArg,
 	uintptr_t clientArg)
 {
 	const struct device *dev = (const struct device *)clientArg;
+	const struct uart_device_config *config = dev->config;
+	struct uart_cc13xx_cc26xx_data *data = dev->data;
 	int ret = Power_NOTIFYDONE;
 	int16_t res_id;
 
 	/* Reconfigure the hardware if returning from standby */
 	if (eventType == PowerCC26XX_AWAKE_STANDBY) {
-		if (get_dev_conf(dev)->regs ==
-			DT_INST_REG_ADDR(0)) {
+		if (config->regs == DT_INST_REG_ADDR(0)) {
 			res_id = PowerCC26XX_PERIPH_UART0;
 		} else { /* DT_INST_REG_ADDR(1) */
 			res_id = PowerCC26X2_PERIPH_UART1;
@@ -386,7 +416,7 @@ static int postNotifyFxn(unsigned int eventType, uintptr_t eventArg,
 			 * actively powered down
 			 */
 			if (uart_cc13xx_cc26xx_configure(dev,
-				&get_dev_data(dev)->uart_config) != 0) {
+				&data->uart_config) != 0) {
 				ret = Power_NOTIFYERROR;
 			}
 		}
@@ -400,27 +430,27 @@ static int postNotifyFxn(unsigned int eventType, uintptr_t eventArg,
 static int uart_cc13xx_cc26xx_pm_action(const struct device *dev,
 					enum pm_device_action action)
 {
+	const struct uart_device_config *config = dev->config;
+	struct uart_cc13xx_cc26xx_data *data = dev->data;
 	int ret = 0;
 
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
-		if (get_dev_conf(dev)->regs == DT_INST_REG_ADDR(0)) {
+		if (config->regs == DT_INST_REG_ADDR(0)) {
 			Power_setDependency(PowerCC26XX_PERIPH_UART0);
 		} else {
 			Power_setDependency(PowerCC26X2_PERIPH_UART1);
 		}
 		/* Configure and enable UART */
-		ret = uart_cc13xx_cc26xx_configure(dev,
-			&get_dev_data(dev)->uart_config);
+		ret = uart_cc13xx_cc26xx_configure(dev, &data->uart_config);
 		break;
 	case PM_DEVICE_ACTION_SUSPEND:
-		UARTDisable(get_dev_conf(dev)->regs);
+		UARTDisable(config->regs);
 		/*
 		 * Release power dependency - i.e. potentially power
 		 * down serial domain.
 		 */
-		if (get_dev_conf(dev)->regs ==
-			DT_INST_REG_ADDR(0)) {
+		if (config->regs == DT_INST_REG_ADDR(0)) {
 			Power_releaseDependency(PowerCC26XX_PERIPH_UART0);
 		} else {
 			Power_releaseDependency(PowerCC26X2_PERIPH_UART1);
@@ -463,8 +493,10 @@ static const struct uart_driver_api uart_cc13xx_cc26xx_driver_api = {
 #ifdef CONFIG_PM
 #define UART_CC13XX_CC26XX_POWER_UART(n)				\
 	do {								\
-		get_dev_data(dev)->rx_constrained = false;		\
-		get_dev_data(dev)->tx_constrained = false;		\
+		struct uart_cc13xx_cc26xx_data *data = dev->data;	\
+									\
+		data->rx_constrained = false;				\
+		data->tx_constrained = false;				\
 									\
 		/* Set Power dependencies */				\
 		if (DT_INST_REG_ADDR(n) == 0x40001000) {		\
@@ -474,7 +506,7 @@ static const struct uart_driver_api uart_cc13xx_cc26xx_driver_api = {
 		}							\
 									\
 		/* Register notification function */			\
-		Power_registerNotify(&get_dev_data(dev)->postNotify,	\
+		Power_registerNotify(&data->postNotify,			\
 			PowerCC26XX_AWAKE_STANDBY,			\
 			postNotifyFxn, (uintptr_t)dev);			\
 	} while (0)
@@ -514,7 +546,9 @@ static const struct uart_driver_api uart_cc13xx_cc26xx_driver_api = {
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 #define UART_CC13XX_CC26XX_IRQ_CFG(n)					\
 	do {								\
-		UARTIntClear(get_dev_conf(dev)->regs, UART_INT_RX);	\
+		const struct uart_device_config *config = dev->config;	\
+									\
+		UARTIntClear(config->regs, UART_INT_RX);		\
 									\
 		IRQ_CONNECT(DT_INST_IRQN(n),				\
 				DT_INST_IRQ(n, priority),		\
@@ -523,7 +557,7 @@ static const struct uart_driver_api uart_cc13xx_cc26xx_driver_api = {
 				0);					\
 		irq_enable(DT_INST_IRQN(n));				\
 		/* Causes an initial TX ready INT when TX INT enabled */\
-		UARTCharPutNonBlocking(get_dev_conf(dev)->regs, '\0');  \
+		UARTCharPutNonBlocking(config->regs, '\0');		\
 	} while (0)
 
 #define UART_CC13XX_CC26XX_INT_FIELDS					\
@@ -552,6 +586,7 @@ static const struct uart_driver_api uart_cc13xx_cc26xx_driver_api = {
 #define UART_CC13XX_CC26XX_INIT_FUNC(n)					    \
 	static int uart_cc13xx_cc26xx_init_##n(const struct device *dev)	    \
 	{								    \
+		struct uart_cc13xx_cc26xx_data *data = dev->data;	    \
 		int ret;						    \
 									    \
 		UART_CC13XX_CC26XX_POWER_UART(n);			    \
@@ -563,8 +598,7 @@ static const struct uart_driver_api uart_cc13xx_cc26xx_driver_api = {
 			IOC_STD_INPUT);					    \
 									    \
 		/* Configure and enable UART */				    \
-		ret = uart_cc13xx_cc26xx_configure(dev,			    \
-			&get_dev_data(dev)->uart_config);		    \
+		ret = uart_cc13xx_cc26xx_configure(dev, &data->uart_config);\
 									    \
 		/* Enable interrupts */					    \
 		UART_CC13XX_CC26XX_IRQ_CFG(n);				    \

--- a/drivers/serial/uart_cc32xx.c
+++ b/drivers/serial/uart_cc32xx.c
@@ -26,11 +26,6 @@ struct uart_cc32xx_dev_data_t {
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 };
 
-#define DEV_CFG(dev) \
-	((const struct uart_device_config * const)(dev)->config)
-#define DEV_DATA(dev) \
-	((struct uart_cc32xx_dev_data_t * const)(dev)->data)
-
 #define PRIME_CHAR '\r'
 
 /* Forward decls: */
@@ -47,8 +42,8 @@ static void uart_cc32xx_isr(const struct device *dev);
  */
 static int uart_cc32xx_init(const struct device *dev)
 {
-	const struct uart_device_config *config = DEV_CFG(dev);
-	const struct uart_cc32xx_dev_data_t *data = DEV_DATA(dev);
+	const struct uart_device_config *config = dev->config;
+	const struct uart_cc32xx_dev_data_t *data = dev->data;
 
 	MAP_PRCMPeripheralClkEnable(data->prcm,
 		    PRCM_RUN_MODE_CLK | PRCM_SLP_MODE_CLK);
@@ -83,7 +78,7 @@ static int uart_cc32xx_init(const struct device *dev)
 
 static int uart_cc32xx_poll_in(const struct device *dev, unsigned char *c)
 {
-	const struct uart_device_config *config = DEV_CFG(dev);
+	const struct uart_device_config *config = dev->config;
 
 	if (MAP_UARTCharsAvail((unsigned long)config->base)) {
 		*c = MAP_UARTCharGetNonBlocking((unsigned long)config->base);
@@ -95,14 +90,14 @@ static int uart_cc32xx_poll_in(const struct device *dev, unsigned char *c)
 
 static void uart_cc32xx_poll_out(const struct device *dev, unsigned char c)
 {
-	const struct uart_device_config *config = DEV_CFG(dev);
+	const struct uart_device_config *config = dev->config;
 
 	MAP_UARTCharPut((unsigned long)config->base, c);
 }
 
 static int uart_cc32xx_err_check(const struct device *dev)
 {
-	const struct uart_device_config *config = DEV_CFG(dev);
+	const struct uart_device_config *config = dev->config;
 	unsigned long cc32xx_errs = 0L;
 	unsigned int z_err = 0U;
 
@@ -126,7 +121,7 @@ static int uart_cc32xx_fifo_fill(const struct device *dev,
 				 const uint8_t *tx_data,
 				 int size)
 {
-	const struct uart_device_config *config = DEV_CFG(dev);
+	const struct uart_device_config *config = dev->config;
 	unsigned int num_tx = 0U;
 
 	while ((size - num_tx) > 0) {
@@ -145,7 +140,7 @@ static int uart_cc32xx_fifo_fill(const struct device *dev,
 static int uart_cc32xx_fifo_read(const struct device *dev, uint8_t *rx_data,
 				 const int size)
 {
-	const struct uart_device_config *config = DEV_CFG(dev);
+	const struct uart_device_config *config = dev->config;
 	unsigned int num_rx = 0U;
 
 	while (((size - num_rx) > 0) &&
@@ -161,21 +156,21 @@ static int uart_cc32xx_fifo_read(const struct device *dev, uint8_t *rx_data,
 
 static void uart_cc32xx_irq_tx_enable(const struct device *dev)
 {
-	const struct uart_device_config *config = DEV_CFG(dev);
+	const struct uart_device_config *config = dev->config;
 
 	MAP_UARTIntEnable((unsigned long)config->base, UART_INT_TX);
 }
 
 static void uart_cc32xx_irq_tx_disable(const struct device *dev)
 {
-	const struct uart_device_config *config = DEV_CFG(dev);
+	const struct uart_device_config *config = dev->config;
 
 	MAP_UARTIntDisable((unsigned long)config->base, UART_INT_TX);
 }
 
 static int uart_cc32xx_irq_tx_ready(const struct device *dev)
 {
-	const struct uart_device_config *config = DEV_CFG(dev);
+	const struct uart_device_config *config = dev->config;
 	unsigned int int_status;
 
 	int_status = MAP_UARTIntStatus((unsigned long)config->base, 1);
@@ -185,7 +180,7 @@ static int uart_cc32xx_irq_tx_ready(const struct device *dev)
 
 static void uart_cc32xx_irq_rx_enable(const struct device *dev)
 {
-	const struct uart_device_config *config = DEV_CFG(dev);
+	const struct uart_device_config *config = dev->config;
 
 	/* FIFOs are left disabled from reset, so UART_INT_RT flag not used. */
 	MAP_UARTIntEnable((unsigned long)config->base, UART_INT_RX);
@@ -193,21 +188,21 @@ static void uart_cc32xx_irq_rx_enable(const struct device *dev)
 
 static void uart_cc32xx_irq_rx_disable(const struct device *dev)
 {
-	const struct uart_device_config *config = DEV_CFG(dev);
+	const struct uart_device_config *config = dev->config;
 
 	MAP_UARTIntDisable((unsigned long)config->base, UART_INT_RX);
 }
 
 static int uart_cc32xx_irq_tx_complete(const struct device *dev)
 {
-	const struct uart_device_config *config = DEV_CFG(dev);
+	const struct uart_device_config *config = dev->config;
 
 	return (!MAP_UARTBusy((unsigned long)config->base));
 }
 
 static int uart_cc32xx_irq_rx_ready(const struct device *dev)
 {
-	const struct uart_device_config *config = DEV_CFG(dev);
+	const struct uart_device_config *config = dev->config;
 	unsigned int int_status;
 
 	int_status = MAP_UARTIntStatus((unsigned long)config->base, 1);
@@ -227,7 +222,7 @@ static void uart_cc32xx_irq_err_disable(const struct device *dev)
 
 static int uart_cc32xx_irq_is_pending(const struct device *dev)
 {
-	const struct uart_device_config *config = DEV_CFG(dev);
+	const struct uart_device_config *config = dev->config;
 	unsigned int int_status;
 
 	int_status = MAP_UARTIntStatus((unsigned long)config->base, 1);
@@ -244,7 +239,7 @@ static void uart_cc32xx_irq_callback_set(const struct device *dev,
 					 uart_irq_callback_user_data_t cb,
 					 void *cb_data)
 {
-	struct uart_cc32xx_dev_data_t * const dev_data = DEV_DATA(dev);
+	struct uart_cc32xx_dev_data_t * const dev_data = dev->data;
 
 	dev_data->cb = cb;
 	dev_data->cb_data = cb_data;
@@ -262,8 +257,8 @@ static void uart_cc32xx_irq_callback_set(const struct device *dev,
  */
 static void uart_cc32xx_isr(const struct device *dev)
 {
-	const struct uart_device_config *config = DEV_CFG(dev);
-	struct uart_cc32xx_dev_data_t * const dev_data = DEV_DATA(dev);
+	const struct uart_device_config *config = dev->config;
+	struct uart_cc32xx_dev_data_t * const dev_data = dev->data;
 
 	unsigned long intStatus = MAP_UARTIntStatus((unsigned long)config->base,
 						    1);

--- a/drivers/serial/uart_imx.c
+++ b/drivers/serial/uart_imx.c
@@ -21,10 +21,8 @@
 #include <drivers/uart.h>
 #include <uart_imx.h>
 
-#define DEV_CFG(dev) \
-	((const struct imx_uart_config *const)(dev)->config)
 #define UART_STRUCT(dev) \
-	((UART_Type *)(DEV_CFG(dev))->base)
+	((UART_Type *)((const struct imx_uart_config *const)(dev)->config)->base)
 
 struct imx_uart_config {
 	UART_Type *base;

--- a/drivers/serial/uart_liteuart.c
+++ b/drivers/serial/uart_liteuart.c
@@ -257,7 +257,7 @@ static void uart_liteuart_irq_callback_set(const struct device *dev,
 {
 	struct uart_liteuart_data *data;
 
-	data = (struct uart_liteuart_data *)dev->data;
+	data = dev->data;
 	data->callback = cb;
 	data->cb_data = cb_data;
 }

--- a/drivers/serial/uart_liteuart.c
+++ b/drivers/serial/uart_liteuart.c
@@ -264,7 +264,7 @@ static void uart_liteuart_irq_callback_set(const struct device *dev,
 
 static void liteuart_uart_irq_handler(const struct device *dev)
 {
-	struct uart_liteuart_data *data = DEV_DATA(dev);
+	struct uart_liteuart_data *data = dev->data;
 	int key = irq_lock();
 
 	if (data->callback) {

--- a/drivers/serial/uart_lpc11u6x.c
+++ b/drivers/serial/uart_lpc11u6x.c
@@ -13,13 +13,10 @@
 
 #include "uart_lpc11u6x.h"
 
-#define DEV_CFG(dev) ((dev)->config)
-#define DEV_DATA(dev) ((dev)->data)
-
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(uart0), okay)
 static int lpc11u6x_uart0_poll_in(const struct device *dev, unsigned char *c)
 {
-	const struct lpc11u6x_uart0_config *cfg = DEV_CFG(dev);
+	const struct lpc11u6x_uart0_config *cfg = dev->config;
 
 	if (!(cfg->uart0->lsr & LPC11U6X_UART0_LSR_RDR)) {
 		return -1;
@@ -31,7 +28,7 @@ static int lpc11u6x_uart0_poll_in(const struct device *dev, unsigned char *c)
 
 static void lpc11u6x_uart0_poll_out(const struct device *dev, unsigned char c)
 {
-	const struct lpc11u6x_uart0_config *cfg = DEV_CFG(dev);
+	const struct lpc11u6x_uart0_config *cfg = dev->config;
 
 	while (!(cfg->uart0->lsr & LPC11U6X_UART0_LSR_THRE)) {
 	}
@@ -40,7 +37,7 @@ static void lpc11u6x_uart0_poll_out(const struct device *dev, unsigned char c)
 
 static int lpc11u6x_uart0_err_check(const struct device *dev)
 {
-	const struct lpc11u6x_uart0_config *cfg = DEV_CFG(dev);
+	const struct lpc11u6x_uart0_config *cfg = dev->config;
 	uint32_t lsr;
 	int ret = 0;
 
@@ -104,8 +101,8 @@ static void lpc11u6x_uart0_config_baudrate(const struct device *clk_drv,
 static int lpc11u6x_uart0_configure(const struct device *dev,
 				    const struct uart_config *cfg)
 {
-	const struct  lpc11u6x_uart0_config *dev_cfg = DEV_CFG(dev);
-	struct lpc11u6x_uart0_data *data = DEV_DATA(dev);
+	const struct  lpc11u6x_uart0_config *dev_cfg = dev->config;
+	struct lpc11u6x_uart0_data *data = dev->data;
 	const struct device *clk_dev;
 	uint32_t flags = 0;
 
@@ -190,7 +187,7 @@ static int lpc11u6x_uart0_configure(const struct device *dev,
 static int lpc11u6x_uart0_config_get(const struct device *dev,
 				     struct uart_config *cfg)
 {
-	struct lpc11u6x_uart0_data *data = DEV_DATA(dev);
+	struct lpc11u6x_uart0_data *data = dev->data;
 
 	cfg->baudrate = data->baudrate;
 	cfg->parity = data->parity;
@@ -207,7 +204,7 @@ static int lpc11u6x_uart0_fifo_fill(const struct device *dev,
 				    const uint8_t *data,
 				    const int size)
 {
-	const struct lpc11u6x_uart0_config *cfg = DEV_CFG(dev);
+	const struct lpc11u6x_uart0_config *cfg = dev->config;
 	int nr_sent = 0;
 
 	while (nr_sent < size && (cfg->uart0->lsr & LPC11U6X_UART0_LSR_THRE)) {
@@ -220,7 +217,7 @@ static int lpc11u6x_uart0_fifo_fill(const struct device *dev,
 static int lpc11u6x_uart0_fifo_read(const struct device *dev, uint8_t *data,
 				    const int size)
 {
-	const struct lpc11u6x_uart0_config *cfg = DEV_CFG(dev);
+	const struct lpc11u6x_uart0_config *cfg = dev->config;
 	int nr_rx = 0;
 
 	while (nr_rx < size && (cfg->uart0->lsr & LPC11U6X_UART0_LSR_RDR)) {
@@ -232,7 +229,7 @@ static int lpc11u6x_uart0_fifo_read(const struct device *dev, uint8_t *data,
 
 static void lpc11u6x_uart0_irq_tx_enable(const struct device *dev)
 {
-	const struct lpc11u6x_uart0_config *cfg = DEV_CFG(dev);
+	const struct lpc11u6x_uart0_config *cfg = dev->config;
 
 	cfg->uart0->ier = (cfg->uart0->ier & LPC11U6X_UART0_IER_MASK) |
 		LPC11U6X_UART0_IER_THREINTEN;
@@ -245,7 +242,7 @@ static void lpc11u6x_uart0_irq_tx_enable(const struct device *dev)
 
 static void lpc11u6x_uart0_irq_tx_disable(const struct device *dev)
 {
-	const struct lpc11u6x_uart0_config *cfg = DEV_CFG(dev);
+	const struct lpc11u6x_uart0_config *cfg = dev->config;
 
 	cfg->uart0->ier = (cfg->uart0->ier & LPC11U6X_UART0_IER_MASK) &
 		~LPC11U6X_UART0_IER_THREINTEN;
@@ -253,14 +250,14 @@ static void lpc11u6x_uart0_irq_tx_disable(const struct device *dev)
 
 static int lpc11u6x_uart0_irq_tx_complete(const struct device *dev)
 {
-	const struct lpc11u6x_uart0_config *cfg = DEV_CFG(dev);
+	const struct lpc11u6x_uart0_config *cfg = dev->config;
 
 	return (cfg->uart0->lsr & LPC11U6X_UART0_LSR_TEMT) != 0;
 }
 
 static int lpc11u6x_uart0_irq_tx_ready(const struct device *dev)
 {
-	const struct lpc11u6x_uart0_config *cfg = DEV_CFG(dev);
+	const struct lpc11u6x_uart0_config *cfg = dev->config;
 
 	return (cfg->uart0->lsr & LPC11U6X_UART0_LSR_THRE) &&
 		(cfg->uart0->ier & LPC11U6X_UART0_IER_THREINTEN);
@@ -268,7 +265,7 @@ static int lpc11u6x_uart0_irq_tx_ready(const struct device *dev)
 
 static void lpc11u6x_uart0_irq_rx_enable(const struct device *dev)
 {
-	const struct lpc11u6x_uart0_config *cfg = DEV_CFG(dev);
+	const struct lpc11u6x_uart0_config *cfg = dev->config;
 
 	cfg->uart0->ier = (cfg->uart0->ier & LPC11U6X_UART0_IER_MASK) |
 		LPC11U6X_UART0_IER_RBRINTEN;
@@ -276,7 +273,7 @@ static void lpc11u6x_uart0_irq_rx_enable(const struct device *dev)
 
 static void lpc11u6x_uart0_irq_rx_disable(const struct device *dev)
 {
-	const struct lpc11u6x_uart0_config *cfg = DEV_CFG(dev);
+	const struct lpc11u6x_uart0_config *cfg = dev->config;
 
 	cfg->uart0->ier = (cfg->uart0->ier & LPC11U6X_UART0_IER_MASK) &
 		~LPC11U6X_UART0_IER_RBRINTEN;
@@ -284,7 +281,7 @@ static void lpc11u6x_uart0_irq_rx_disable(const struct device *dev)
 
 static int lpc11u6x_uart0_irq_rx_ready(const struct device *dev)
 {
-	struct lpc11u6x_uart0_data *data = DEV_DATA(dev);
+	struct lpc11u6x_uart0_data *data = dev->data;
 
 	return (LPC11U6X_UART0_IIR_INTID(data->cached_iir) ==
 		LPC11U6X_UART0_IIR_INTID_RDA) ||
@@ -294,7 +291,7 @@ static int lpc11u6x_uart0_irq_rx_ready(const struct device *dev)
 
 static void lpc11u6x_uart0_irq_err_enable(const struct device *dev)
 {
-	const struct lpc11u6x_uart0_config *cfg = DEV_CFG(dev);
+	const struct lpc11u6x_uart0_config *cfg = dev->config;
 
 	cfg->uart0->ier = (cfg->uart0->ier & LPC11U6X_UART0_IER_MASK) |
 		LPC11U6X_UART0_IER_RLSINTEN;
@@ -302,7 +299,7 @@ static void lpc11u6x_uart0_irq_err_enable(const struct device *dev)
 
 static void lpc11u6x_uart0_irq_err_disable(const struct device *dev)
 {
-	const struct lpc11u6x_uart0_config *cfg = DEV_CFG(dev);
+	const struct lpc11u6x_uart0_config *cfg = dev->config;
 
 	cfg->uart0->ier = (cfg->uart0->ier & LPC11U6X_UART0_IER_MASK) &
 		~LPC11U6X_UART0_IER_RLSINTEN;
@@ -310,15 +307,15 @@ static void lpc11u6x_uart0_irq_err_disable(const struct device *dev)
 
 static int lpc11u6x_uart0_irq_is_pending(const struct device *dev)
 {
-	struct lpc11u6x_uart0_data *data = DEV_DATA(dev);
+	struct lpc11u6x_uart0_data *data = dev->data;
 
 	return !(data->cached_iir & LPC11U6X_UART0_IIR_STATUS);
 }
 
 static int lpc11u6x_uart0_irq_update(const struct device *dev)
 {
-	const struct lpc11u6x_uart0_config *cfg = DEV_CFG(dev);
-	struct lpc11u6x_uart0_data *data = DEV_DATA(dev);
+	const struct lpc11u6x_uart0_config *cfg = dev->config;
+	struct lpc11u6x_uart0_data *data = dev->data;
 
 	data->cached_iir = cfg->uart0->iir;
 	return 1;
@@ -328,7 +325,7 @@ static void lpc11u6x_uart0_irq_callback_set(const struct device *dev,
 					    uart_irq_callback_user_data_t cb,
 					    void *user_data)
 {
-	struct lpc11u6x_uart0_data *data = DEV_DATA(dev);
+	struct lpc11u6x_uart0_data *data = dev->data;
 
 	data->cb = cb;
 	data->cb_data = user_data;
@@ -336,7 +333,7 @@ static void lpc11u6x_uart0_irq_callback_set(const struct device *dev,
 
 static void lpc11u6x_uart0_isr(const struct device *dev)
 {
-	struct lpc11u6x_uart0_data *data = DEV_DATA(dev);
+	struct lpc11u6x_uart0_data *data = dev->data;
 
 	if (data->cb) {
 		data->cb(dev, data->cb_data);
@@ -346,8 +343,8 @@ static void lpc11u6x_uart0_isr(const struct device *dev)
 
 static int lpc11u6x_uart0_init(const struct device *dev)
 {
-	const struct lpc11u6x_uart0_config *cfg = DEV_CFG(dev);
-	struct lpc11u6x_uart0_data *data = DEV_DATA(dev);
+	const struct lpc11u6x_uart0_config *cfg = dev->config;
+	struct lpc11u6x_uart0_data *data = dev->data;
 	const struct device *clk_drv, *rx_pinmux_drv, *tx_pinmux_drv;
 
 	/* Configure RX and TX pin via the pinmux driver */
@@ -469,7 +466,7 @@ static void lpc11u6x_uart0_isr_config(const struct device *dev)
 
 static int lpc11u6x_uartx_poll_in(const struct device *dev, unsigned char *c)
 {
-	const struct lpc11u6x_uartx_config *cfg = DEV_CFG(dev);
+	const struct lpc11u6x_uartx_config *cfg = dev->config;
 
 	if (!(cfg->base->stat & LPC11U6X_UARTX_STAT_RXRDY)) {
 		return -1;
@@ -480,7 +477,7 @@ static int lpc11u6x_uartx_poll_in(const struct device *dev, unsigned char *c)
 
 static void lpc11u6x_uartx_poll_out(const struct device *dev, unsigned char c)
 {
-	const struct lpc11u6x_uartx_config *cfg = DEV_CFG(dev);
+	const struct lpc11u6x_uartx_config *cfg = dev->config;
 
 	while (!(cfg->base->stat & LPC11U6X_UARTX_STAT_TXRDY)) {
 	}
@@ -489,7 +486,7 @@ static void lpc11u6x_uartx_poll_out(const struct device *dev, unsigned char c)
 
 static int lpc11u6x_uartx_err_check(const struct device *dev)
 {
-	const struct lpc11u6x_uartx_config *cfg = DEV_CFG(dev);
+	const struct lpc11u6x_uartx_config *cfg = dev->config;
 	int ret = 0;
 
 	if (cfg->base->stat & LPC11U6X_UARTX_STAT_OVERRUNINT) {
@@ -526,8 +523,8 @@ static void lpc11u6x_uartx_config_baud(const struct lpc11u6x_uartx_config *cfg,
 static int lpc11u6x_uartx_configure(const struct device *dev,
 				    const struct uart_config *cfg)
 {
-	const struct  lpc11u6x_uartx_config *dev_cfg = DEV_CFG(dev);
-	struct lpc11u6x_uartx_data *data = DEV_DATA(dev);
+	const struct  lpc11u6x_uartx_config *dev_cfg = dev->config;
+	struct lpc11u6x_uartx_data *data = dev->data;
 	const struct device *clk_dev;
 	uint32_t flags = 0;
 
@@ -617,7 +614,7 @@ static int lpc11u6x_uartx_configure(const struct device *dev,
 static int lpc11u6x_uartx_config_get(const struct device *dev,
 				     struct uart_config *cfg)
 {
-	const struct lpc11u6x_uartx_data *data = DEV_DATA(dev);
+	const struct lpc11u6x_uartx_data *data = dev->data;
 
 	cfg->baudrate = data->baudrate;
 	cfg->parity = data->parity;
@@ -634,7 +631,7 @@ static int lpc11u6x_uartx_fifo_fill(const struct device *dev,
 				    const uint8_t *data,
 				    int size)
 {
-	const struct lpc11u6x_uartx_config *cfg = DEV_CFG(dev);
+	const struct lpc11u6x_uartx_config *cfg = dev->config;
 	int tx_size = 0;
 
 	while (tx_size < size &&
@@ -647,7 +644,7 @@ static int lpc11u6x_uartx_fifo_fill(const struct device *dev,
 static int lpc11u6x_uartx_fifo_read(const struct device *dev, uint8_t *data,
 				    int size)
 {
-	const struct lpc11u6x_uartx_config *cfg = DEV_CFG(dev);
+	const struct lpc11u6x_uartx_config *cfg = dev->config;
 	int rx_size = 0;
 
 	while (rx_size < size &&
@@ -659,7 +656,7 @@ static int lpc11u6x_uartx_fifo_read(const struct device *dev, uint8_t *data,
 
 static void lpc11u6x_uartx_irq_tx_enable(const struct device *dev)
 {
-	const struct lpc11u6x_uartx_config *cfg = DEV_CFG(dev);
+	const struct lpc11u6x_uartx_config *cfg = dev->config;
 
 	cfg->base->int_en_set = (cfg->base->int_en_set &
 				 LPC11U6X_UARTX_INT_EN_SET_MASK) |
@@ -668,14 +665,14 @@ static void lpc11u6x_uartx_irq_tx_enable(const struct device *dev)
 
 static void lpc11u6x_uartx_irq_tx_disable(const struct device *dev)
 {
-	const struct lpc11u6x_uartx_config *cfg = DEV_CFG(dev);
+	const struct lpc11u6x_uartx_config *cfg = dev->config;
 
 	cfg->base->int_en_clr = LPC11U6X_UARTX_INT_EN_CLR_TXRDYCLR;
 }
 
 static int lpc11u6x_uartx_irq_tx_ready(const struct device *dev)
 {
-	const struct lpc11u6x_uartx_config *cfg = DEV_CFG(dev);
+	const struct lpc11u6x_uartx_config *cfg = dev->config;
 
 	return (cfg->base->stat & LPC11U6X_UARTX_STAT_TXRDY) &&
 		(cfg->base->int_en_set & LPC11U6X_UARTX_INT_EN_SET_TXRDYEN);
@@ -683,14 +680,14 @@ static int lpc11u6x_uartx_irq_tx_ready(const struct device *dev)
 
 static int lpc11u6x_uartx_irq_tx_complete(const struct device *dev)
 {
-	const struct lpc11u6x_uartx_config *cfg = DEV_CFG(dev);
+	const struct lpc11u6x_uartx_config *cfg = dev->config;
 
 	return (cfg->base->stat & LPC11U6X_UARTX_STAT_TXIDLE) != 0;
 }
 
 static void lpc11u6x_uartx_irq_rx_enable(const struct device *dev)
 {
-	const struct lpc11u6x_uartx_config *cfg = DEV_CFG(dev);
+	const struct lpc11u6x_uartx_config *cfg = dev->config;
 
 	cfg->base->int_en_set = (cfg->base->int_en_set &
 				 LPC11U6X_UARTX_INT_EN_SET_MASK) |
@@ -699,14 +696,14 @@ static void lpc11u6x_uartx_irq_rx_enable(const struct device *dev)
 
 static void lpc11u6x_uartx_irq_rx_disable(const struct device *dev)
 {
-	const struct lpc11u6x_uartx_config *cfg = DEV_CFG(dev);
+	const struct lpc11u6x_uartx_config *cfg = dev->config;
 
 	cfg->base->int_en_clr = LPC11U6X_UARTX_INT_EN_CLR_RXRDYCLR;
 }
 
 static int lpc11u6x_uartx_irq_rx_ready(const struct device *dev)
 {
-	const struct lpc11u6x_uartx_config *cfg = DEV_CFG(dev);
+	const struct lpc11u6x_uartx_config *cfg = dev->config;
 
 	return (cfg->base->stat & LPC11U6X_UARTX_STAT_RXRDY) &&
 		(cfg->base->int_en_set & LPC11U6X_UARTX_INT_EN_SET_RXRDYEN);
@@ -714,7 +711,7 @@ static int lpc11u6x_uartx_irq_rx_ready(const struct device *dev)
 
 static void lpc11u6x_uartx_irq_err_enable(const struct device *dev)
 {
-	const struct lpc11u6x_uartx_config *cfg = DEV_CFG(dev);
+	const struct lpc11u6x_uartx_config *cfg = dev->config;
 
 	cfg->base->int_en_set = (cfg->base->int_en_set &
 				 LPC11U6X_UARTX_INT_EN_SET_MASK) |
@@ -725,7 +722,7 @@ static void lpc11u6x_uartx_irq_err_enable(const struct device *dev)
 
 static void lpc11u6x_uartx_irq_err_disable(const struct device *dev)
 {
-	const struct lpc11u6x_uartx_config *cfg = DEV_CFG(dev);
+	const struct lpc11u6x_uartx_config *cfg = dev->config;
 
 	cfg->base->int_en_clr = LPC11U6X_UARTX_INT_EN_CLR_OVERRUNCLR |
 		LPC11U6X_UARTX_INT_EN_CLR_FRAMERRCLR |
@@ -734,7 +731,7 @@ static void lpc11u6x_uartx_irq_err_disable(const struct device *dev)
 
 static int lpc11u6x_uartx_irq_is_pending(const struct device *dev)
 {
-	const struct lpc11u6x_uartx_config *cfg = DEV_CFG(dev);
+	const struct lpc11u6x_uartx_config *cfg = dev->config;
 
 	if ((cfg->base->stat & LPC11U6X_UARTX_STAT_RXRDY) &&
 	    (cfg->base->int_stat & LPC11U6X_UARTX_INT_STAT_RXRDY)) {
@@ -761,7 +758,7 @@ static void lpc11u6x_uartx_irq_callback_set(const struct device *dev,
 					    uart_irq_callback_user_data_t cb,
 					    void *user_data)
 {
-	struct lpc11u6x_uartx_data *data = DEV_DATA(dev);
+	struct lpc11u6x_uartx_data *data = dev->data;
 
 	data->cb = cb;
 	data->cb_data = user_data;
@@ -769,7 +766,7 @@ static void lpc11u6x_uartx_irq_callback_set(const struct device *dev,
 
 static void lpc11u6x_uartx_isr(const struct device *dev)
 {
-	struct lpc11u6x_uartx_data *data = DEV_DATA(dev);
+	struct lpc11u6x_uartx_data *data = dev->data;
 
 	if (data->cb) {
 		data->cb(dev, data->cb_data);
@@ -792,8 +789,8 @@ static void lpc11u6x_uartx_shared_isr(const void *arg)
 
 static int lpc11u6x_uartx_init(const struct device *dev)
 {
-	const struct lpc11u6x_uartx_config *cfg = DEV_CFG(dev);
-	struct lpc11u6x_uartx_data *data = DEV_DATA(dev);
+	const struct lpc11u6x_uartx_config *cfg = dev->config;
+	struct lpc11u6x_uartx_data *data = dev->data;
 	const struct device *clk_drv, *rx_pinmux_drv, *tx_pinmux_drv;
 
 	/* Configure RX and TX pin via the pinmux driver */

--- a/drivers/serial/uart_mcux_iuart.c
+++ b/drivers/serial/uart_mcux_iuart.c
@@ -30,12 +30,9 @@ struct mcux_iuart_data {
 #endif
 };
 
-#define DEV_CFG(dev)						\
-	((const struct mcux_iuart_config * const)(dev)->config)
-
 static int mcux_iuart_poll_in(const struct device *dev, unsigned char *c)
 {
-	const struct mcux_iuart_config *config = DEV_CFG(dev);
+	const struct mcux_iuart_config *config = dev->config;
 	int ret = -1;
 
 	if (UART_GetStatusFlag(config->base, kUART_RxDataReadyFlag)) {
@@ -48,7 +45,7 @@ static int mcux_iuart_poll_in(const struct device *dev, unsigned char *c)
 
 static void mcux_iuart_poll_out(const struct device *dev, unsigned char c)
 {
-	const struct mcux_iuart_config *config = DEV_CFG(dev);
+	const struct mcux_iuart_config *config = dev->config;
 
 	while (!(UART_GetStatusFlag(config->base, kUART_TxReadyFlag))) {
 	}
@@ -58,7 +55,7 @@ static void mcux_iuart_poll_out(const struct device *dev, unsigned char c)
 
 static int mcux_iuart_err_check(const struct device *dev)
 {
-	const struct mcux_iuart_config *config = DEV_CFG(dev);
+	const struct mcux_iuart_config *config = dev->config;
 	int err = 0;
 
 	if (UART_GetStatusFlag(config->base, kUART_RxOverrunFlag)) {
@@ -84,7 +81,7 @@ static int mcux_iuart_fifo_fill(const struct device *dev,
 				const uint8_t *tx_data,
 				int len)
 {
-	const struct mcux_iuart_config *config = DEV_CFG(dev);
+	const struct mcux_iuart_config *config = dev->config;
 	uint8_t num_tx = 0U;
 
 	while ((len - num_tx > 0) &&
@@ -99,7 +96,7 @@ static int mcux_iuart_fifo_fill(const struct device *dev,
 static int mcux_iuart_fifo_read(const struct device *dev, uint8_t *rx_data,
 				const int len)
 {
-	const struct mcux_iuart_config *config = DEV_CFG(dev);
+	const struct mcux_iuart_config *config = dev->config;
 	uint8_t num_rx = 0U;
 
 	while ((len - num_rx > 0) &&
@@ -113,28 +110,28 @@ static int mcux_iuart_fifo_read(const struct device *dev, uint8_t *rx_data,
 
 static void mcux_iuart_irq_tx_enable(const struct device *dev)
 {
-	const struct mcux_iuart_config *config = DEV_CFG(dev);
+	const struct mcux_iuart_config *config = dev->config;
 
 	UART_EnableInterrupts(config->base, kUART_TxEmptyEnable);
 }
 
 static void mcux_iuart_irq_tx_disable(const struct device *dev)
 {
-	const struct mcux_iuart_config *config = DEV_CFG(dev);
+	const struct mcux_iuart_config *config = dev->config;
 
 	UART_DisableInterrupts(config->base, kUART_TxEmptyEnable);
 }
 
 static int mcux_iuart_irq_tx_complete(const struct device *dev)
 {
-	const struct mcux_iuart_config *config = DEV_CFG(dev);
+	const struct mcux_iuart_config *config = dev->config;
 
 	return (UART_GetStatusFlag(config->base, kUART_TxEmptyFlag)) != 0U;
 }
 
 static int mcux_iuart_irq_tx_ready(const struct device *dev)
 {
-	const struct mcux_iuart_config *config = DEV_CFG(dev);
+	const struct mcux_iuart_config *config = dev->config;
 	uint32_t mask = kUART_TxEmptyEnable;
 
 	return (UART_GetEnabledInterrupts(config->base) & mask)
@@ -143,7 +140,7 @@ static int mcux_iuart_irq_tx_ready(const struct device *dev)
 
 static void mcux_iuart_irq_rx_enable(const struct device *dev)
 {
-	const struct mcux_iuart_config *config = DEV_CFG(dev);
+	const struct mcux_iuart_config *config = dev->config;
 	uint32_t mask = kUART_RxDataReadyEnable;
 
 	UART_EnableInterrupts(config->base, mask);
@@ -151,7 +148,7 @@ static void mcux_iuart_irq_rx_enable(const struct device *dev)
 
 static void mcux_iuart_irq_rx_disable(const struct device *dev)
 {
-	const struct mcux_iuart_config *config = DEV_CFG(dev);
+	const struct mcux_iuart_config *config = dev->config;
 	uint32_t mask = kUART_RxDataReadyEnable;
 
 	UART_DisableInterrupts(config->base, mask);
@@ -159,14 +156,14 @@ static void mcux_iuart_irq_rx_disable(const struct device *dev)
 
 static int mcux_iuart_irq_rx_full(const struct device *dev)
 {
-	const struct mcux_iuart_config *config = DEV_CFG(dev);
+	const struct mcux_iuart_config *config = dev->config;
 
 	return (UART_GetStatusFlag(config->base, kUART_RxDataReadyFlag)) != 0U;
 }
 
 static int mcux_iuart_irq_rx_pending(const struct device *dev)
 {
-	const struct mcux_iuart_config *config = DEV_CFG(dev);
+	const struct mcux_iuart_config *config = dev->config;
 	uint32_t mask = kUART_RxDataReadyEnable;
 
 	return (UART_GetEnabledInterrupts(config->base) & mask)
@@ -175,7 +172,7 @@ static int mcux_iuart_irq_rx_pending(const struct device *dev)
 
 static void mcux_iuart_irq_err_enable(const struct device *dev)
 {
-	const struct mcux_iuart_config *config = DEV_CFG(dev);
+	const struct mcux_iuart_config *config = dev->config;
 	uint32_t mask = kUART_RxOverrunEnable | kUART_ParityErrorEnable |
 			kUART_FrameErrorEnable;
 
@@ -184,7 +181,7 @@ static void mcux_iuart_irq_err_enable(const struct device *dev)
 
 static void mcux_iuart_irq_err_disable(const struct device *dev)
 {
-	const struct mcux_iuart_config *config = DEV_CFG(dev);
+	const struct mcux_iuart_config *config = dev->config;
 	uint32_t mask = kUART_RxOverrunEnable | kUART_ParityErrorEnable |
 			kUART_FrameErrorEnable;
 
@@ -223,7 +220,7 @@ static void mcux_iuart_isr(const struct device *dev)
 
 static int mcux_iuart_init(const struct device *dev)
 {
-	const struct mcux_iuart_config *config = DEV_CFG(dev);
+	const struct mcux_iuart_config *config = dev->config;
 	uart_config_t uart_config;
 	uint32_t clock_freq;
 

--- a/drivers/serial/uart_miv.c
+++ b/drivers/serial/uart_miv.c
@@ -145,13 +145,9 @@ struct uart_miv_data {
 #endif
 };
 
-#define DEV_CFG(dev)						\
-	((const struct uart_miv_device_config * const)		\
-	 (dev)->config)
 #define DEV_UART(dev)						\
-	((struct uart_miv_regs_t *)(DEV_CFG(dev))->uart_addr)
-#define DEV_DATA(dev)						\
-	((struct uart_miv_data * const)(dev)->data)
+	((struct uart_miv_regs_t *)				\
+	 ((const struct uart_miv_device_config * const)(dev)->config)->uart_addr)
 
 static void uart_miv_poll_out(const struct device *dev,
 				       unsigned char c)
@@ -297,7 +293,7 @@ static int uart_miv_irq_update(const struct device *dev)
 
 static void uart_miv_irq_handler(const struct device *dev)
 {
-	struct uart_miv_data *data = DEV_DATA(dev);
+	struct uart_miv_data *data = dev->data;
 
 	if (data->callback) {
 		data->callback(dev, data->cb_data);
@@ -315,7 +311,7 @@ void uart_miv_rx_thread(void *arg1, void *arg2, void *arg3)
 	struct uart_miv_data *data = (struct uart_miv_data *)arg1;
 	const struct device *dev = data->dev;
 	volatile struct uart_miv_regs_t *uart = DEV_UART(dev);
-	const struct uart_miv_device_config *const cfg = DEV_CFG(dev);
+	const struct uart_miv_device_config *const cfg = dev->config;
 	/* Make it go to sleep for a period no longer than
 	 * time to receive next character.
 	 */
@@ -336,7 +332,7 @@ static void uart_miv_irq_callback_set(const struct device *dev,
 				      uart_irq_callback_user_data_t cb,
 				      void *cb_data)
 {
-	struct uart_miv_data *data = DEV_DATA(dev);
+	struct uart_miv_data *data = dev->data;
 
 	data->callback = cb;
 	data->cb_data = cb_data;
@@ -346,7 +342,7 @@ static void uart_miv_irq_callback_set(const struct device *dev,
 
 static int uart_miv_init(const struct device *dev)
 {
-	const struct uart_miv_device_config *const cfg = DEV_CFG(dev);
+	const struct uart_miv_device_config *const cfg = dev->config;
 	volatile struct uart_miv_regs_t *uart = DEV_UART(dev);
 	/* Calculate divider value to set baudrate */
 	uint16_t baud_value = (cfg->sys_clk_freq / (cfg->baud_rate * 16U)) - 1;
@@ -415,7 +411,7 @@ DEVICE_DT_INST_DEFINE(0, uart_miv_init, NULL,
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 static void uart_miv_irq_cfg_func_0(const struct device *dev)
 {
-	struct uart_miv_data *data = DEV_DATA(dev);
+	struct uart_miv_data *data = dev->data;
 
 	data->dev = dev;
 

--- a/drivers/serial/uart_msp432p4xx.c
+++ b/drivers/serial/uart_msp432p4xx.c
@@ -28,11 +28,6 @@ struct uart_msp432p4xx_dev_data_t {
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 };
 
-#define DEV_CFG(dev) \
-	((const struct uart_device_config * const)(dev)->config)
-#define DEV_DATA(dev) \
-	((struct uart_msp432p4xx_dev_data_t * const)(dev)->data)
-
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 static void uart_msp432p4xx_isr(const struct device *dev);
 #endif
@@ -118,7 +113,7 @@ static int baudrate_set(eUSCI_UART_Config *config, uint32_t baudrate)
 static int uart_msp432p4xx_init(const struct device *dev)
 {
 	int err;
-	const struct uart_device_config *config = DEV_CFG(dev);
+	const struct uart_device_config *config = dev->config;
 	eUSCI_UART_Config UartConfig;
 
 	/* Select P1.2 and P1.3 in UART mode */
@@ -156,7 +151,7 @@ static int uart_msp432p4xx_init(const struct device *dev)
 
 static int uart_msp432p4xx_poll_in(const struct device *dev, unsigned char *c)
 {
-	const struct uart_device_config *config = DEV_CFG(dev);
+	const struct uart_device_config *config = dev->config;
 
 	*c = MAP_UART_receiveData((unsigned long)config->base);
 
@@ -166,7 +161,7 @@ static int uart_msp432p4xx_poll_in(const struct device *dev, unsigned char *c)
 static void uart_msp432p4xx_poll_out(const struct device *dev,
 				     unsigned char c)
 {
-	const struct uart_device_config *config = DEV_CFG(dev);
+	const struct uart_device_config *config = dev->config;
 
 	MAP_UART_transmitData((unsigned long)config->base, c);
 }
@@ -175,7 +170,7 @@ static void uart_msp432p4xx_poll_out(const struct device *dev,
 static int uart_msp432p4xx_fifo_fill(const struct device *dev,
 						const uint8_t *tx_data, int size)
 {
-	const struct uart_device_config *config = DEV_CFG(dev);
+	const struct uart_device_config *config = dev->config;
 	unsigned int num_tx = 0U;
 
 	while ((size - num_tx) > 0) {
@@ -196,7 +191,7 @@ static int uart_msp432p4xx_fifo_read(const struct device *dev,
 							uint8_t *rx_data,
 							const int size)
 {
-	const struct uart_device_config *config = DEV_CFG(dev);
+	const struct uart_device_config *config = dev->config;
 	unsigned int num_rx = 0U;
 
 	while (((size - num_rx) > 0) &&
@@ -212,7 +207,7 @@ static int uart_msp432p4xx_fifo_read(const struct device *dev,
 
 static void uart_msp432p4xx_irq_tx_enable(const struct device *dev)
 {
-	const struct uart_device_config *config = DEV_CFG(dev);
+	const struct uart_device_config *config = dev->config;
 
 	MAP_UART_enableInterrupt((unsigned long)config->base,
 					EUSCI_A_UART_TRANSMIT_INTERRUPT);
@@ -220,7 +215,7 @@ static void uart_msp432p4xx_irq_tx_enable(const struct device *dev)
 
 static void uart_msp432p4xx_irq_tx_disable(const struct device *dev)
 {
-	const struct uart_device_config *config = DEV_CFG(dev);
+	const struct uart_device_config *config = dev->config;
 
 	MAP_UART_disableInterrupt((unsigned long)config->base,
 					EUSCI_A_UART_TRANSMIT_INTERRUPT);
@@ -228,7 +223,7 @@ static void uart_msp432p4xx_irq_tx_disable(const struct device *dev)
 
 static int uart_msp432p4xx_irq_tx_ready(const struct device *dev)
 {
-	const struct uart_device_config *config = DEV_CFG(dev);
+	const struct uart_device_config *config = dev->config;
 	unsigned int int_status;
 
 	int_status =  MAP_UART_getInterruptStatus((unsigned long)config->base,
@@ -239,7 +234,7 @@ static int uart_msp432p4xx_irq_tx_ready(const struct device *dev)
 
 static void uart_msp432p4xx_irq_rx_enable(const struct device *dev)
 {
-	const struct uart_device_config *config = DEV_CFG(dev);
+	const struct uart_device_config *config = dev->config;
 
 	MAP_UART_enableInterrupt((unsigned long)config->base,
 				EUSCI_A_UART_RECEIVE_INTERRUPT);
@@ -247,7 +242,7 @@ static void uart_msp432p4xx_irq_rx_enable(const struct device *dev)
 
 static void uart_msp432p4xx_irq_rx_disable(const struct device *dev)
 {
-	const struct uart_device_config *config = DEV_CFG(dev);
+	const struct uart_device_config *config = dev->config;
 
 	MAP_UART_disableInterrupt((unsigned long)config->base,
 				EUSCI_A_UART_RECEIVE_INTERRUPT);
@@ -255,7 +250,7 @@ static void uart_msp432p4xx_irq_rx_disable(const struct device *dev)
 
 static int uart_msp432p4xx_irq_tx_complete(const struct device *dev)
 {
-	const struct uart_device_config *config = DEV_CFG(dev);
+	const struct uart_device_config *config = dev->config;
 
 	return MAP_UART_getInterruptStatus((unsigned long)config->base,
 				EUSCI_A_UART_TRANSMIT_COMPLETE_INTERRUPT_FLAG);
@@ -263,7 +258,7 @@ static int uart_msp432p4xx_irq_tx_complete(const struct device *dev)
 
 static int uart_msp432p4xx_irq_rx_ready(const struct device *dev)
 {
-	const struct uart_device_config *config = DEV_CFG(dev);
+	const struct uart_device_config *config = dev->config;
 	unsigned int int_status;
 
 	int_status = MAP_UART_getInterruptStatus((unsigned long)config->base,
@@ -284,7 +279,7 @@ static void uart_msp432p4xx_irq_err_disable(const struct device *dev)
 
 static int uart_msp432p4xx_irq_is_pending(const struct device *dev)
 {
-	const struct uart_device_config *config = DEV_CFG(dev);
+	const struct uart_device_config *config = dev->config;
 	unsigned int int_status;
 
 	int_status = MAP_UART_getEnabledInterruptStatus(
@@ -302,7 +297,7 @@ static void uart_msp432p4xx_irq_callback_set(const struct device *dev,
 					     uart_irq_callback_user_data_t cb,
 					     void *cb_data)
 {
-	struct uart_msp432p4xx_dev_data_t * const dev_data = DEV_DATA(dev);
+	struct uart_msp432p4xx_dev_data_t * const dev_data = dev->data;
 
 	dev_data->cb = cb;
 	dev_data->cb_data = cb_data;
@@ -317,8 +312,8 @@ static void uart_msp432p4xx_irq_callback_set(const struct device *dev,
  */
 static void uart_msp432p4xx_isr(const struct device *dev)
 {
-	const struct uart_device_config *config = DEV_CFG(dev);
-	struct uart_msp432p4xx_dev_data_t * const dev_data = DEV_DATA(dev);
+	const struct uart_device_config *config = dev->config;
+	struct uart_msp432p4xx_dev_data_t * const dev_data = dev->data;
 	unsigned int int_status;
 
 	int_status = MAP_UART_getEnabledInterruptStatus(

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -171,19 +171,9 @@ struct uarte_nrfx_config {
 #endif
 };
 
-static inline struct uarte_nrfx_data *get_dev_data(const struct device *dev)
-{
-	return dev->data;
-}
-
-static inline const struct uarte_nrfx_config *get_dev_config(const struct device *dev)
-{
-	return dev->config;
-}
-
 static inline NRF_UARTE_Type *get_uarte_instance(const struct device *dev)
 {
-	const struct uarte_nrfx_config *config = get_dev_config(dev);
+	const struct uarte_nrfx_config *config = dev->config;
 
 	return config->uarte_regs;
 }
@@ -191,7 +181,7 @@ static inline NRF_UARTE_Type *get_uarte_instance(const struct device *dev)
 #ifndef CONFIG_PINCTRL
 static void uarte_nrfx_pins_configure(const struct device *dev, bool sleep)
 {
-	const struct uarte_nrfx_config *cfg = get_dev_config(dev);
+	const struct uarte_nrfx_config *cfg = dev->config;
 
 	if (!sleep) {
 		if (cfg->tx_pin != NRF_UARTE_PSEL_DISCONNECTED) {
@@ -266,6 +256,7 @@ static void endtx_isr(const struct device *dev)
 static void uarte_nrfx_isr_int(void *arg)
 {
 	const struct device *dev = arg;
+	const struct uarte_nrfx_config *config = dev->config;
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
 
 	/* If interrupt driven and asynchronous APIs are disabled then UART
@@ -276,7 +267,7 @@ static void uarte_nrfx_isr_int(void *arg)
 		endtx_isr(dev);
 	}
 
-	if (get_dev_config(dev)->flags & UARTE_CFG_FLAG_LOW_POWER) {
+	if (config->flags & UARTE_CFG_FLAG_LOW_POWER) {
 		int key = irq_lock();
 
 		if (nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_TXSTOPPED)) {
@@ -284,7 +275,7 @@ static void uarte_nrfx_isr_int(void *arg)
 		}
 
 #ifdef UARTE_INTERRUPT_DRIVEN
-		struct uarte_nrfx_data *data = get_dev_data(dev);
+		struct uarte_nrfx_data *data = dev->data;
 
 		if (!data->int_driven || data->int_driven->fifo_fill_lock == 0)
 #endif
@@ -297,7 +288,7 @@ static void uarte_nrfx_isr_int(void *arg)
 	}
 
 #ifdef UARTE_INTERRUPT_DRIVEN
-	struct uarte_nrfx_data *data = get_dev_data(dev);
+	struct uarte_nrfx_data *data = dev->data;
 
 	if (!data->int_driven) {
 		return;
@@ -416,6 +407,7 @@ static int baudrate_set(const struct device *dev, uint32_t baudrate)
 static int uarte_nrfx_configure(const struct device *dev,
 				const struct uart_config *cfg)
 {
+	struct uarte_nrfx_data *data = dev->data;
 	nrf_uarte_config_t uarte_cfg;
 
 #if defined(UARTE_CONFIG_STOP_Msk)
@@ -476,7 +468,7 @@ static int uarte_nrfx_configure(const struct device *dev,
 
 	nrf_uarte_configure(get_uarte_instance(dev), &uarte_cfg);
 
-	get_dev_data(dev)->uart_config = *cfg;
+	data->uart_config = *cfg;
 
 	return 0;
 }
@@ -485,7 +477,9 @@ static int uarte_nrfx_configure(const struct device *dev,
 static int uarte_nrfx_config_get(const struct device *dev,
 				 struct uart_config *cfg)
 {
-	*cfg = get_dev_data(dev)->uart_config;
+	struct uarte_nrfx_data *data = dev->data;
+
+	*cfg = data->uart_config;
 	return 0;
 }
 #endif /* CONFIG_UART_USE_RUNTIME_CONFIGURE */
@@ -504,8 +498,9 @@ static int uarte_nrfx_err_check(const struct device *dev)
  */
 static bool is_tx_ready(const struct device *dev)
 {
+	const struct uarte_nrfx_config *config = dev->config;
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
-	bool ppi_endtx = get_dev_config(dev)->flags & UARTE_CFG_FLAG_PPI_ENDTX;
+	bool ppi_endtx = config->flags & UARTE_CFG_FLAG_PPI_ENDTX;
 
 	return nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_TXSTOPPED) ||
 		(!ppi_endtx ?
@@ -556,14 +551,15 @@ static inline bool hw_rx_counting_enabled(struct uarte_nrfx_data *data)
 static void uarte_enable(const struct device *dev, uint32_t mask)
 {
 #ifdef CONFIG_UART_ASYNC_API
-	struct uarte_nrfx_data *data = get_dev_data(dev);
+	const struct uarte_nrfx_config *config = dev->config;
+	struct uarte_nrfx_data *data = dev->data;
 
 	if (data->async) {
 		bool disabled = data->async->low_power_mask == 0;
 
 		data->async->low_power_mask |= mask;
 		if (hw_rx_counting_enabled(data) && disabled) {
-			const nrfx_timer_t *timer = &get_dev_config(dev)->timer;
+			const nrfx_timer_t *timer = &config->timer;
 
 			nrfx_timer_enable(timer);
 
@@ -581,6 +577,7 @@ static void uarte_enable(const struct device *dev, uint32_t mask)
  */
 static void tx_start(const struct device *dev, const uint8_t *buf, size_t len)
 {
+	const struct uarte_nrfx_config *config = dev->config;
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
 
 #if CONFIG_PM_DEVICE
@@ -595,7 +592,7 @@ static void tx_start(const struct device *dev, const uint8_t *buf, size_t len)
 	nrf_uarte_event_clear(uarte, NRF_UARTE_EVENT_ENDTX);
 	nrf_uarte_event_clear(uarte, NRF_UARTE_EVENT_TXSTOPPED);
 
-	if (get_dev_config(dev)->flags & UARTE_CFG_FLAG_LOW_POWER) {
+	if (config->flags & UARTE_CFG_FLAG_LOW_POWER) {
 		uarte_enable(dev, UARTE_LOW_POWER_TX);
 		nrf_uarte_int_enable(uarte, NRF_UARTE_INT_TXSTOPPED_MASK);
 	}
@@ -607,10 +604,11 @@ static void tx_start(const struct device *dev, const uint8_t *buf, size_t len)
 static void uart_disable(const struct device *dev)
 {
 #ifdef CONFIG_UART_ASYNC_API
-	struct uarte_nrfx_data *data = get_dev_data(dev);
+	const struct uarte_nrfx_config *config = dev->config;
+	struct uarte_nrfx_data *data = dev->data;
 
 	if (data->async && hw_rx_counting_enabled(data)) {
-		nrfx_timer_disable(&get_dev_config(dev)->timer);
+		nrfx_timer_disable(&config->timer);
 		/* Timer/counter value is reset when disabled. */
 		data->async->rx_total_byte_cnt = 0;
 		data->async->rx_total_user_byte_cnt = 0;
@@ -629,8 +627,8 @@ static void tx_timeout(struct k_timer *timer);
 
 static int uarte_nrfx_rx_counting_init(const struct device *dev)
 {
-	struct uarte_nrfx_data *data = get_dev_data(dev);
-	const struct uarte_nrfx_config *cfg = get_dev_config(dev);
+	struct uarte_nrfx_data *data = dev->data;
+	const struct uarte_nrfx_config *cfg = dev->config;
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
 	int ret;
 
@@ -696,7 +694,7 @@ static int uarte_nrfx_rx_counting_init(const struct device *dev)
 
 static int uarte_nrfx_init(const struct device *dev)
 {
-	struct uarte_nrfx_data *data = get_dev_data(dev);
+	struct uarte_nrfx_data *data = dev->data;
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
 
 	int ret = uarte_nrfx_rx_counting_init(dev);
@@ -741,7 +739,7 @@ static int uarte_nrfx_tx(const struct device *dev, const uint8_t *buf,
 			 size_t len,
 			 int32_t timeout)
 {
-	struct uarte_nrfx_data *data = get_dev_data(dev);
+	struct uarte_nrfx_data *data = dev->data;
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
 
 	if (!nrfx_is_in_ram(buf)) {
@@ -779,7 +777,7 @@ static int uarte_nrfx_tx(const struct device *dev, const uint8_t *buf,
 
 static int uarte_nrfx_tx_abort(const struct device *dev)
 {
-	struct uarte_nrfx_data *data = get_dev_data(dev);
+	struct uarte_nrfx_data *data = dev->data;
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
 
 	if (data->async->tx_buf == NULL) {
@@ -793,7 +791,7 @@ static int uarte_nrfx_tx_abort(const struct device *dev)
 
 static void user_callback(const struct device *dev, struct uart_event *evt)
 {
-	struct uarte_nrfx_data *data = get_dev_data(dev);
+	struct uarte_nrfx_data *data = dev->data;
 
 	if (data->async->user_callback) {
 		data->async->user_callback(dev, evt, data->async->user_data);
@@ -802,7 +800,7 @@ static void user_callback(const struct device *dev, struct uart_event *evt)
 
 static void notify_uart_rx_rdy(const struct device *dev, size_t len)
 {
-	struct uarte_nrfx_data *data = get_dev_data(dev);
+	struct uarte_nrfx_data *data = dev->data;
 	struct uart_event evt = {
 		.type = UART_RX_RDY,
 		.data.rx.buf = data->async->rx_buf,
@@ -842,8 +840,8 @@ static int uarte_nrfx_rx_enable(const struct device *dev, uint8_t *buf,
 				size_t len,
 				int32_t timeout)
 {
-	struct uarte_nrfx_data *data = get_dev_data(dev);
-	const struct uarte_nrfx_config *cfg = get_dev_config(dev);
+	struct uarte_nrfx_data *data = dev->data;
+	const struct uarte_nrfx_config *cfg = dev->config;
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
 
 	if (cfg->disable_rx) {
@@ -872,7 +870,7 @@ static int uarte_nrfx_rx_enable(const struct device *dev, uint8_t *buf,
 	data->async->rx_next_buf = NULL;
 	data->async->rx_next_buf_len = 0;
 
-	if (get_dev_config(dev)->flags & UARTE_CFG_FLAG_LOW_POWER) {
+	if (cfg->flags & UARTE_CFG_FLAG_LOW_POWER) {
 		if (data->async->rx_flush_cnt) {
 			int cpy_len = MIN(len, data->async->rx_flush_cnt);
 
@@ -900,7 +898,7 @@ static int uarte_nrfx_rx_enable(const struct device *dev, uint8_t *buf,
 	nrf_uarte_event_clear(uarte, NRF_UARTE_EVENT_RXSTARTED);
 
 	data->async->rx_enabled = true;
-	if (get_dev_config(dev)->flags & UARTE_CFG_FLAG_LOW_POWER) {
+	if (cfg->flags & UARTE_CFG_FLAG_LOW_POWER) {
 		int key = irq_lock();
 
 		uarte_enable(dev, UARTE_LOW_POWER_RX);
@@ -915,7 +913,7 @@ static int uarte_nrfx_rx_enable(const struct device *dev, uint8_t *buf,
 static int uarte_nrfx_rx_buf_rsp(const struct device *dev, uint8_t *buf,
 				 size_t len)
 {
-	struct uarte_nrfx_data *data = get_dev_data(dev);
+	struct uarte_nrfx_data *data = dev->data;
 	int err;
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
 	int key = irq_lock();
@@ -941,7 +939,7 @@ static int uarte_nrfx_callback_set(const struct device *dev,
 				   uart_callback_t callback,
 				   void *user_data)
 {
-	struct uarte_nrfx_data *data = get_dev_data(dev);
+	struct uarte_nrfx_data *data = dev->data;
 
 	if (!data->async) {
 		return -ENOTSUP;
@@ -955,7 +953,7 @@ static int uarte_nrfx_callback_set(const struct device *dev,
 
 static int uarte_nrfx_rx_disable(const struct device *dev)
 {
-	struct uarte_nrfx_data *data = get_dev_data(dev);
+	struct uarte_nrfx_data *data = dev->data;
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
 
 	if (data->async->rx_buf == NULL) {
@@ -992,7 +990,7 @@ static void rx_timeout(struct k_timer *timer)
 {
 	struct uarte_nrfx_data *data = k_timer_user_data_get(timer);
 	const struct device *dev = data->dev;
-	const struct uarte_nrfx_config *cfg = get_dev_config(dev);
+	const struct uarte_nrfx_config *cfg = dev->config;
 	uint32_t read;
 
 	if (data->async->is_in_irq) {
@@ -1095,7 +1093,7 @@ static void error_isr(const struct device *dev)
 
 static void rxstarted_isr(const struct device *dev)
 {
-	struct uarte_nrfx_data *data = get_dev_data(dev);
+	struct uarte_nrfx_data *data = dev->data;
 	struct uart_event evt = {
 		.type = UART_RX_BUF_REQUEST,
 	};
@@ -1110,7 +1108,7 @@ static void rxstarted_isr(const struct device *dev)
 
 static void endrx_isr(const struct device *dev)
 {
-	struct uarte_nrfx_data *data = get_dev_data(dev);
+	struct uarte_nrfx_data *data = dev->data;
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
 
 	data->async->is_in_irq = true;
@@ -1261,7 +1259,7 @@ static uint8_t rx_flush(const struct device *dev, uint8_t *buf, uint32_t len)
 
 static void async_uart_release(const struct device *dev, uint32_t dir_mask)
 {
-	struct uarte_nrfx_data *data = get_dev_data(dev);
+	struct uarte_nrfx_data *data = dev->data;
 	int key = irq_lock();
 
 	data->async->low_power_mask &= ~dir_mask;
@@ -1283,7 +1281,8 @@ static void async_uart_release(const struct device *dev, uint32_t dir_mask)
  */
 static void rxto_isr(const struct device *dev)
 {
-	struct uarte_nrfx_data *data = get_dev_data(dev);
+	const struct uarte_nrfx_config *config = dev->config;
+	struct uarte_nrfx_data *data = dev->data;
 
 	notify_rx_buf_release(dev, &data->async->rx_buf, true);
 	notify_rx_buf_release(dev, &data->async->rx_next_buf, true);
@@ -1292,7 +1291,7 @@ static void rxto_isr(const struct device *dev)
 		(void)rx_flush(dev, NULL, 0);
 	}
 
-	if (get_dev_config(dev)->flags & UARTE_CFG_FLAG_LOW_POWER) {
+	if (config->flags & UARTE_CFG_FLAG_LOW_POWER) {
 		async_uart_release(dev, UARTE_LOW_POWER_RX);
 	}
 
@@ -1301,11 +1300,12 @@ static void rxto_isr(const struct device *dev)
 
 static void txstopped_isr(const struct device *dev)
 {
-	struct uarte_nrfx_data *data = get_dev_data(dev);
+	const struct uarte_nrfx_config *config = dev->config;
+	struct uarte_nrfx_data *data = dev->data;
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
 	int key;
 
-	if (get_dev_config(dev)->flags & UARTE_CFG_FLAG_LOW_POWER) {
+	if (config->flags & UARTE_CFG_FLAG_LOW_POWER) {
 		nrf_uarte_int_disable(uarte, NRF_UARTE_INT_TXSTOPPED_MASK);
 		async_uart_release(dev, UARTE_LOW_POWER_TX);
 
@@ -1364,7 +1364,7 @@ static void txstopped_isr(const struct device *dev)
 static void uarte_nrfx_isr_async(const struct device *dev)
 {
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
-	struct uarte_nrfx_data *data = get_dev_data(dev);
+	struct uarte_nrfx_data *data = dev->data;
 
 	if (!hw_rx_counting_enabled(data)
 	    && nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_RXDRDY)) {
@@ -1434,7 +1434,7 @@ static void uarte_nrfx_isr_async(const struct device *dev)
 static int uarte_nrfx_poll_in(const struct device *dev, unsigned char *c)
 {
 
-	const struct uarte_nrfx_data *data = get_dev_data(dev);
+	const struct uarte_nrfx_data *data = dev->data;
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
 
 #ifdef CONFIG_UART_ASYNC_API
@@ -1464,7 +1464,7 @@ static int uarte_nrfx_poll_in(const struct device *dev, unsigned char *c)
  */
 static void uarte_nrfx_poll_out(const struct device *dev, unsigned char c)
 {
-	struct uarte_nrfx_data *data = get_dev_data(dev);
+	struct uarte_nrfx_data *data = dev->data;
 	bool isr_mode = k_is_in_isr() || k_is_pre_kernel();
 	int key;
 
@@ -1502,7 +1502,7 @@ static int uarte_nrfx_fifo_fill(const struct device *dev,
 				const uint8_t *tx_data,
 				int len)
 {
-	struct uarte_nrfx_data *data = get_dev_data(dev);
+	struct uarte_nrfx_data *data = dev->data;
 
 	len = MIN(len, data->int_driven->tx_buff_size);
 	if (!atomic_cas(&data->int_driven->fifo_fill_lock, 0, 1)) {
@@ -1535,7 +1535,7 @@ static int uarte_nrfx_fifo_read(const struct device *dev,
 {
 	int num_rx = 0;
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
-	const struct uarte_nrfx_data *data = get_dev_data(dev);
+	const struct uarte_nrfx_data *data = dev->data;
 
 	if (size > 0 && nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_ENDRX)) {
 		/* Clear the interrupt */
@@ -1554,7 +1554,7 @@ static int uarte_nrfx_fifo_read(const struct device *dev,
 static void uarte_nrfx_irq_tx_enable(const struct device *dev)
 {
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
-	struct uarte_nrfx_data *data = get_dev_data(dev);
+	struct uarte_nrfx_data *data = dev->data;
 	int key = irq_lock();
 
 	data->int_driven->disable_tx_irq = false;
@@ -1566,7 +1566,7 @@ static void uarte_nrfx_irq_tx_enable(const struct device *dev)
 /** Interrupt driven transfer disabling function */
 static void uarte_nrfx_irq_tx_disable(const struct device *dev)
 {
-	struct uarte_nrfx_data *data = get_dev_data(dev);
+	struct uarte_nrfx_data *data = dev->data;
 	/* TX IRQ will be disabled after current transmission is finished */
 	data->int_driven->disable_tx_irq = true;
 }
@@ -1575,7 +1575,7 @@ static void uarte_nrfx_irq_tx_disable(const struct device *dev)
 static int uarte_nrfx_irq_tx_ready_complete(const struct device *dev)
 {
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
-	struct uarte_nrfx_data *data = get_dev_data(dev);
+	struct uarte_nrfx_data *data = dev->data;
 
 	/* ENDTX flag is always on so that ISR is called when we enable TX IRQ.
 	 * Because of that we have to explicitly check if ENDTX interrupt is
@@ -1658,7 +1658,7 @@ static void uarte_nrfx_irq_callback_set(const struct device *dev,
 					uart_irq_callback_user_data_t cb,
 					void *cb_data)
 {
-	struct uarte_nrfx_data *data = get_dev_data(dev);
+	struct uarte_nrfx_data *data = dev->data;
 
 	data->int_driven->cb = cb;
 	data->int_driven->cb_data = cb_data;
@@ -1723,8 +1723,8 @@ static int uarte_instance_init(const struct device *dev,
 {
 	int err;
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
-	struct uarte_nrfx_data *data = get_dev_data(dev);
-	const struct uarte_nrfx_config *cfg = get_dev_config(dev);
+	struct uarte_nrfx_data *data = dev->data;
+	const struct uarte_nrfx_config *cfg = dev->config;
 
 	nrf_uarte_disable(uarte);
 
@@ -1739,7 +1739,7 @@ static int uarte_instance_init(const struct device *dev,
 	uarte_nrfx_pins_configure(dev, false);
 #endif /* CONFIG_PINCTRL */
 
-	err = uarte_nrfx_configure(dev, &get_dev_data(dev)->uart_config);
+	err = uarte_nrfx_configure(dev, &data->uart_config);
 	if (err) {
 		return err;
 	}
@@ -1803,7 +1803,8 @@ static int uarte_instance_init(const struct device *dev,
  */
 static void wait_for_tx_stopped(const struct device *dev)
 {
-	bool ppi_endtx = get_dev_config(dev)->flags & UARTE_CFG_FLAG_PPI_ENDTX;
+	const struct uarte_nrfx_config *config = dev->config;
+	bool ppi_endtx = config->flags & UARTE_CFG_FLAG_PPI_ENDTX;
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
 	bool res;
 
@@ -1835,9 +1836,9 @@ static int uarte_nrfx_pm_action(const struct device *dev,
 {
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
 #if defined(CONFIG_UART_ASYNC_API) || defined(UARTE_INTERRUPT_DRIVEN)
-	struct uarte_nrfx_data *data = get_dev_data(dev);
+	struct uarte_nrfx_data *data = dev->data;
 #endif
-	const struct uarte_nrfx_config *cfg = get_dev_config(dev);
+	const struct uarte_nrfx_config *cfg = dev->config;
 #ifdef CONFIG_PINCTRL
 	int ret;
 #endif
@@ -1860,7 +1861,7 @@ static int uarte_nrfx_pm_action(const struct device *dev,
 
 #ifdef CONFIG_UART_ASYNC_API
 		if (hw_rx_counting_enabled(data)) {
-			nrfx_timer_enable(&get_dev_config(dev)->timer);
+			nrfx_timer_enable(&cfg->timer);
 		}
 		if (data->async) {
 			return 0;

--- a/drivers/serial/uart_numicro.c
+++ b/drivers/serial/uart_numicro.c
@@ -11,15 +11,9 @@
 
 #define DT_DRV_COMPAT nuvoton_numicro_uart
 
-/* Device data structure */
-#define DEV_CFG(dev)						\
-	((const struct uart_numicro_config * const)(dev)->config)
-
-#define DRV_DATA(dev)						\
-	((struct uart_numicro_data * const)(dev)->data)
-
 #define UART_STRUCT(dev)					\
-	((UART_T *)(DEV_CFG(dev))->devcfg.base)
+	((UART_T *)						\
+	 ((const struct uart_numicro_config * const)(dev)->config)->devcfg.base)
 
 struct uart_numicro_config {
 	struct uart_device_config devcfg;
@@ -105,7 +99,7 @@ static inline uint32_t uart_numicro_convert_parity(enum uart_config_parity parit
 static int uart_numicro_configure(const struct device *dev,
 				  const struct uart_config *cfg)
 {
-	struct uart_numicro_data *ddata = DRV_DATA(dev);
+	struct uart_numicro_data *ddata = dev->data;
 	int32_t databits, stopbits;
 	uint32_t parity;
 
@@ -140,7 +134,7 @@ static int uart_numicro_configure(const struct device *dev,
 static int uart_numicro_config_get(const struct device *dev,
 				   struct uart_config *cfg)
 {
-	struct uart_numicro_data *ddata = DRV_DATA(dev);
+	struct uart_numicro_data *ddata = dev->data;
 
 	memcpy(cfg, &ddata->ucfg, sizeof(*cfg));
 
@@ -150,8 +144,8 @@ static int uart_numicro_config_get(const struct device *dev,
 
 static int uart_numicro_init(const struct device *dev)
 {
-	const struct uart_numicro_config *config = DEV_CFG(dev);
-	struct uart_numicro_data *ddata = DRV_DATA(dev);
+	const struct uart_numicro_config *config = dev->config;
+	struct uart_numicro_data *ddata = dev->data;
 
 	SYS_ResetModule(config->id_rst);
 

--- a/drivers/serial/uart_pl011.c
+++ b/drivers/serial/uart_pl011.c
@@ -142,12 +142,9 @@ struct pl011_data {
 		PL011_IMSC_RXIM | PL011_IMSC_TXIM | \
 		PL011_IMSC_RTIM)
 
-#define DEV_CFG(dev) \
-	((const struct uart_device_config * const)(dev)->config)
-#define DEV_DATA(dev) \
-	((struct pl011_data *)(dev)->data)
 #define PL011_REGS(dev) \
-	((volatile struct pl011_regs  *)(DEV_CFG(dev))->base)
+	((volatile struct pl011_regs  *) \
+	 ((const struct uart_device_config * const)(dev)->config)->base)
 
 static void pl011_enable(const struct device *dev)
 {
@@ -201,7 +198,9 @@ static int pl011_set_baudrate(const struct device *dev,
 
 static bool pl011_is_readable(const struct device *dev)
 {
-	if (!DEV_DATA(dev)->sbsa &&
+	struct pl011_data *data = dev->data;
+
+	if (!data->sbsa &&
 	    (!(PL011_REGS(dev)->cr & PL011_CR_UARTEN) ||
 	     !(PL011_REGS(dev)->cr & PL011_CR_RXE)))
 		return false;
@@ -277,7 +276,9 @@ static int pl011_irq_tx_complete(const struct device *dev)
 
 static int pl011_irq_tx_ready(const struct device *dev)
 {
-	if (!DEV_DATA(dev)->sbsa && !(PL011_REGS(dev)->cr & PL011_CR_TXE))
+	struct pl011_data *data = dev->data;
+
+	if (!data->sbsa && !(PL011_REGS(dev)->cr & PL011_CR_TXE))
 		return false;
 
 	return ((PL011_REGS(dev)->imsc & PL011_IMSC_TXIM) &&
@@ -298,7 +299,9 @@ static void pl011_irq_rx_disable(const struct device *dev)
 
 static int pl011_irq_rx_ready(const struct device *dev)
 {
-	if (!DEV_DATA(dev)->sbsa && !(PL011_REGS(dev)->cr & PL011_CR_RXE))
+	struct pl011_data *data = dev->data;
+
+	if (!data->sbsa && !(PL011_REGS(dev)->cr & PL011_CR_RXE))
 		return false;
 
 	return ((PL011_REGS(dev)->imsc & PL011_IMSC_RXIM) &&
@@ -330,8 +333,10 @@ static void pl011_irq_callback_set(const struct device *dev,
 					    uart_irq_callback_user_data_t cb,
 					    void *cb_data)
 {
-	DEV_DATA(dev)->irq_cb = cb;
-	DEV_DATA(dev)->irq_cb_data = cb_data;
+	struct pl011_data *data = dev->data;
+
+	data->irq_cb = cb;
+	data->irq_cb_data = cb_data;
 }
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 
@@ -358,6 +363,8 @@ static const struct uart_driver_api pl011_driver_api = {
 
 static int pl011_init(const struct device *dev)
 {
+	const struct uart_device_config *config = dev->config;
+	struct pl011_data *data = dev->data;
 	int ret;
 	uint32_t lcrh;
 
@@ -366,14 +373,14 @@ static int pl011_init(const struct device *dev)
 	 * or does not require configuration at all (if UART is emulated by
 	 * virtualization software).
 	 */
-	if (!DEV_DATA(dev)->sbsa) {
+	if (!data->sbsa) {
 		/* disable the uart */
 		pl011_disable(dev);
 		pl011_disable_fifo(dev);
 
 		/* Set baud rate */
-		ret = pl011_set_baudrate(dev, DEV_CFG(dev)->sys_clk_freq,
-					 DEV_DATA(dev)->baud_rate);
+		ret = pl011_set_baudrate(dev, config->sys_clk_freq,
+					 data->baud_rate);
 		if (ret != 0) {
 			return ret;
 		}
@@ -391,7 +398,7 @@ static int pl011_init(const struct device *dev)
 	PL011_REGS(dev)->imsc = 0U;
 	PL011_REGS(dev)->icr = PL011_IMSC_MASK_ALL;
 
-	if (!DEV_DATA(dev)->sbsa) {
+	if (!data->sbsa) {
 		PL011_REGS(dev)->dmacr = 0U;
 		__ISB();
 		PL011_REGS(dev)->cr &= ~(BIT(14) | BIT(15) | BIT(1));
@@ -399,9 +406,9 @@ static int pl011_init(const struct device *dev)
 		__ISB();
 	}
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	DEV_CFG(dev)->irq_config_func(dev);
+	config->irq_config_func(dev);
 #endif
-	if (!DEV_DATA(dev)->sbsa)
+	if (!data->sbsa)
 		pl011_enable(dev);
 
 	return 0;
@@ -410,7 +417,7 @@ static int pl011_init(const struct device *dev)
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 void pl011_isr(const struct device *dev)
 {
-	struct pl011_data *data = DEV_DATA(dev);
+	struct pl011_data *data = dev->data;
 
 	/* Verify if the callback has been registered */
 	if (data->irq_cb) {

--- a/drivers/serial/uart_psoc6.c
+++ b/drivers/serial/uart_psoc6.c
@@ -60,9 +60,6 @@ struct cypress_psoc6_data {
 	void *irq_cb_data;			/* Interrupt Callback Arg */
 };
 
-#define DEV_DATA(dev) \
-	((struct cypress_psoc6_data *const)(dev)->data)
-
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 
 /* Populate configuration structure */
@@ -288,7 +285,7 @@ static void uart_psoc6_irq_callback_set(const struct device *dev,
 					uart_irq_callback_user_data_t cb,
 					void *cb_data)
 {
-	struct cypress_psoc6_data *const dev_data = DEV_DATA(dev);
+	struct cypress_psoc6_data *const dev_data = dev->data;
 
 	dev_data->irq_cb = cb;
 	dev_data->irq_cb_data = cb_data;
@@ -296,7 +293,7 @@ static void uart_psoc6_irq_callback_set(const struct device *dev,
 
 static void uart_psoc6_isr(const struct device *dev)
 {
-	struct cypress_psoc6_data *const dev_data = DEV_DATA(dev);
+	struct cypress_psoc6_data *const dev_data = dev->data;
 
 	if (dev_data->irq_cb) {
 		dev_data->irq_cb(dev, dev_data->irq_cb_data);

--- a/drivers/serial/uart_rtt.c
+++ b/drivers/serial/uart_rtt.c
@@ -24,18 +24,6 @@ struct uart_rtt_data {
 #endif /* CONFIG_UART_ASYNC_API */
 };
 
-static inline
-const struct uart_rtt_config *get_dev_config(const struct device *dev)
-{
-	return dev->config;
-}
-
-static inline
-struct uart_rtt_data *get_dev_data(const struct device *dev)
-{
-	return dev->data;
-}
-
 static int uart_rtt_init(const struct device *dev)
 {
 	/*
@@ -43,8 +31,8 @@ static int uart_rtt_init(const struct device *dev)
 	 * it is configured in correct, non-blocking mode. Other channels
 	 * need to be configured at run-time.
 	 */
-	if (get_dev_config(dev)) {
-		const struct uart_rtt_config *cfg = get_dev_config(dev);
+	if (dev->config) {
+		const struct uart_rtt_config *cfg = dev->config;
 
 		SEGGER_RTT_ConfigUpBuffer(cfg->channel, dev->name,
 					  cfg->up_buffer, cfg->up_size,
@@ -67,8 +55,8 @@ static int uart_rtt_init(const struct device *dev)
 
 static int uart_rtt_poll_in(const struct device *dev, unsigned char *c)
 {
-	unsigned int ch =
-		get_dev_config(dev) ? get_dev_config(dev)->channel : 0;
+	const struct uart_rtt_config *config = dev->config;
+	unsigned int ch = config ? config->channel : 0;
 	unsigned int ret = SEGGER_RTT_Read(ch, c, 1);
 
 	return ret ? 0 : -1;
@@ -82,8 +70,8 @@ static int uart_rtt_poll_in(const struct device *dev, unsigned char *c)
  */
 static void uart_rtt_poll_out(const struct device *dev, unsigned char c)
 {
-	unsigned int ch =
-		get_dev_config(dev) ? get_dev_config(dev)->channel : 0;
+	const struct uart_rtt_config *config = dev->config;
+	unsigned int ch = config ? config->channel : 0;
 
 	SEGGER_RTT_Write(ch, &c, 1);
 }
@@ -93,16 +81,18 @@ static void uart_rtt_poll_out(const struct device *dev, unsigned char c)
 static int uart_rtt_callback_set(const struct device *dev,
 				 uart_callback_t callback, void *user_data)
 {
-	get_dev_data(dev)->callback = callback;
-	get_dev_data(dev)->user_data = user_data;
+	struct uart_rtt_data *data = dev->data;
+
+	data->callback = callback;
+	data->user_data = user_data;
 	return 0;
 }
 
 static int uart_rtt_tx(const struct device *dev,
 		       const uint8_t *buf, size_t len, int32_t timeout)
 {
-	const struct uart_rtt_config *cfg = get_dev_config(dev);
-	struct uart_rtt_data *data = get_dev_data(dev);
+	const struct uart_rtt_config *cfg = dev->config;
+	struct uart_rtt_data *data = dev->data;
 	unsigned int ch = cfg ? cfg->channel : 0;
 
 	ARG_UNUSED(timeout);

--- a/drivers/serial/uart_sam.c
+++ b/drivers/serial/uart_sam.c
@@ -43,12 +43,6 @@ struct uart_sam_dev_data {
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 };
 
-#define DEV_CFG(dev) \
-	((const struct uart_sam_dev_cfg *const)(dev)->config)
-#define DEV_DATA(dev) \
-	((struct uart_sam_dev_data *const)(dev)->data)
-
-
 static int baudrate_set(Uart *const uart, uint32_t baudrate,
 			uint32_t mck_freq_hz);
 
@@ -56,8 +50,8 @@ static int baudrate_set(Uart *const uart, uint32_t baudrate,
 static int uart_sam_init(const struct device *dev)
 {
 	int retval;
-	const struct uart_sam_dev_cfg *const cfg = DEV_CFG(dev);
-	struct uart_sam_dev_data *const dev_data = DEV_DATA(dev);
+	const struct uart_sam_dev_cfg *const cfg = dev->config;
+	struct uart_sam_dev_data *const dev_data = dev->data;
 	Uart *const uart = cfg->regs;
 
 	/* Enable UART clock in PMC */
@@ -99,7 +93,9 @@ static int uart_sam_init(const struct device *dev)
 
 static int uart_sam_poll_in(const struct device *dev, unsigned char *c)
 {
-	Uart *const uart = DEV_CFG(dev)->regs;
+	const struct uart_sam_dev_cfg *const cfg = dev->config;
+
+	Uart *const uart = cfg->regs;
 
 	if (!(uart->UART_SR & UART_SR_RXRDY)) {
 		return -EBUSY;
@@ -113,7 +109,9 @@ static int uart_sam_poll_in(const struct device *dev, unsigned char *c)
 
 static void uart_sam_poll_out(const struct device *dev, unsigned char c)
 {
-	Uart *const uart = DEV_CFG(dev)->regs;
+	const struct uart_sam_dev_cfg *const cfg = dev->config;
+
+	Uart *const uart = cfg->regs;
 
 	/* Wait for transmitter to be ready */
 	while (!(uart->UART_SR & UART_SR_TXRDY)) {
@@ -125,7 +123,9 @@ static void uart_sam_poll_out(const struct device *dev, unsigned char c)
 
 static int uart_sam_err_check(const struct device *dev)
 {
-	volatile Uart * const uart = DEV_CFG(dev)->regs;
+	const struct uart_sam_dev_cfg *const cfg = dev->config;
+
+	volatile Uart * const uart = cfg->regs;
 	int errors = 0;
 
 	if (uart->UART_SR & UART_SR_OVRE) {
@@ -170,7 +170,9 @@ static int uart_sam_fifo_fill(const struct device *dev,
 			      const uint8_t *tx_data,
 			      int size)
 {
-	volatile Uart * const uart = DEV_CFG(dev)->regs;
+	const struct uart_sam_dev_cfg *const cfg = dev->config;
+
+	volatile Uart * const uart = cfg->regs;
 
 	/* Wait for transmitter to be ready. */
 	while ((uart->UART_SR & UART_SR_TXRDY) == 0) {
@@ -184,7 +186,9 @@ static int uart_sam_fifo_fill(const struct device *dev,
 static int uart_sam_fifo_read(const struct device *dev, uint8_t *rx_data,
 			      const int size)
 {
-	volatile Uart * const uart = DEV_CFG(dev)->regs;
+	const struct uart_sam_dev_cfg *const cfg = dev->config;
+
+	volatile Uart * const uart = cfg->regs;
 	int bytes_read;
 
 	bytes_read = 0;
@@ -203,70 +207,90 @@ static int uart_sam_fifo_read(const struct device *dev, uint8_t *rx_data,
 
 static void uart_sam_irq_tx_enable(const struct device *dev)
 {
-	volatile Uart * const uart = DEV_CFG(dev)->regs;
+	const struct uart_sam_dev_cfg *const cfg = dev->config;
+
+	volatile Uart * const uart = cfg->regs;
 
 	uart->UART_IER = UART_IER_TXRDY;
 }
 
 static void uart_sam_irq_tx_disable(const struct device *dev)
 {
-	volatile Uart * const uart = DEV_CFG(dev)->regs;
+	const struct uart_sam_dev_cfg *const cfg = dev->config;
+
+	volatile Uart * const uart = cfg->regs;
 
 	uart->UART_IDR = UART_IDR_TXRDY;
 }
 
 static int uart_sam_irq_tx_ready(const struct device *dev)
 {
-	volatile Uart * const uart = DEV_CFG(dev)->regs;
+	const struct uart_sam_dev_cfg *const cfg = dev->config;
+
+	volatile Uart * const uart = cfg->regs;
 
 	return (uart->UART_SR & UART_SR_TXRDY);
 }
 
 static void uart_sam_irq_rx_enable(const struct device *dev)
 {
-	volatile Uart * const uart = DEV_CFG(dev)->regs;
+	const struct uart_sam_dev_cfg *const cfg = dev->config;
+
+	volatile Uart * const uart = cfg->regs;
 
 	uart->UART_IER = UART_IER_RXRDY;
 }
 
 static void uart_sam_irq_rx_disable(const struct device *dev)
 {
-	volatile Uart * const uart = DEV_CFG(dev)->regs;
+	const struct uart_sam_dev_cfg *const cfg = dev->config;
+
+	volatile Uart * const uart = cfg->regs;
 
 	uart->UART_IDR = UART_IDR_RXRDY;
 }
 
 static int uart_sam_irq_tx_complete(const struct device *dev)
 {
-	volatile Uart * const uart = DEV_CFG(dev)->regs;
+	const struct uart_sam_dev_cfg *const cfg = dev->config;
+
+	volatile Uart * const uart = cfg->regs;
 
 	return !(uart->UART_SR & UART_SR_TXRDY);
 }
 
 static int uart_sam_irq_rx_ready(const struct device *dev)
 {
-	volatile Uart * const uart = DEV_CFG(dev)->regs;
+	const struct uart_sam_dev_cfg *const cfg = dev->config;
+
+	volatile Uart * const uart = cfg->regs;
 
 	return (uart->UART_SR & UART_SR_RXRDY);
 }
 
 static void uart_sam_irq_err_enable(const struct device *dev)
 {
-	volatile Uart * const uart = DEV_CFG(dev)->regs;
+	const struct uart_sam_dev_cfg *const cfg = dev->config;
+
+	volatile Uart * const uart = cfg->regs;
 
 	uart->UART_IER = UART_IER_OVRE | UART_IER_FRAME | UART_IER_PARE;
 }
 
 static void uart_sam_irq_err_disable(const struct device *dev)
 {
-	volatile Uart * const uart = DEV_CFG(dev)->regs;
+	const struct uart_sam_dev_cfg *const cfg = dev->config;
+
+	volatile Uart * const uart = cfg->regs;
 
 	uart->UART_IDR = UART_IDR_OVRE | UART_IDR_FRAME | UART_IDR_PARE;
 }
 
 static int uart_sam_irq_is_pending(const struct device *dev)
 {
-	volatile Uart * const uart = DEV_CFG(dev)->regs;
+	const struct uart_sam_dev_cfg *const cfg = dev->config;
+
+	volatile Uart * const uart = cfg->regs;
 
 	return (uart->UART_IMR & (UART_IMR_TXRDY | UART_IMR_RXRDY)) &
 		(uart->UART_SR & (UART_SR_TXRDY | UART_SR_RXRDY));
@@ -283,7 +307,7 @@ static void uart_sam_irq_callback_set(const struct device *dev,
 				      uart_irq_callback_user_data_t cb,
 				      void *cb_data)
 {
-	struct uart_sam_dev_data *const dev_data = DEV_DATA(dev);
+	struct uart_sam_dev_data *const dev_data = dev->data;
 
 	dev_data->irq_cb = cb;
 	dev_data->irq_cb_data = cb_data;
@@ -291,7 +315,7 @@ static void uart_sam_irq_callback_set(const struct device *dev,
 
 static void uart_sam_isr(const struct device *dev)
 {
-	struct uart_sam_dev_data *const dev_data = DEV_DATA(dev);
+	struct uart_sam_dev_data *const dev_data = dev->data;
 
 	if (dev_data->irq_cb) {
 		dev_data->irq_cb(dev, dev_data->irq_cb_data);

--- a/drivers/serial/uart_sam.c
+++ b/drivers/serial/uart_sam.c
@@ -95,7 +95,7 @@ static int uart_sam_poll_in(const struct device *dev, unsigned char *c)
 {
 	const struct uart_sam_dev_cfg *const cfg = dev->config;
 
-	Uart *const uart = cfg->regs;
+	Uart * const uart = cfg->regs;
 
 	if (!(uart->UART_SR & UART_SR_RXRDY)) {
 		return -EBUSY;
@@ -111,7 +111,7 @@ static void uart_sam_poll_out(const struct device *dev, unsigned char c)
 {
 	const struct uart_sam_dev_cfg *const cfg = dev->config;
 
-	Uart *const uart = cfg->regs;
+	Uart * const uart = cfg->regs;
 
 	/* Wait for transmitter to be ready */
 	while (!(uart->UART_SR & UART_SR_TXRDY)) {
@@ -385,7 +385,7 @@ static const struct uart_driver_api uart_sam_driver_api = {
 									\
 	static const struct uart_sam_dev_cfg uart##n##_sam_config;	\
 									\
-	DEVICE_DT_INST_DEFINE(n, &uart_sam_init, 			\
+	DEVICE_DT_INST_DEFINE(n, &uart_sam_init,			\
 			    NULL, &uart##n##_sam_data,			\
 			    &uart##n##_sam_config, PRE_KERNEL_1,	\
 			    CONFIG_SERIAL_INIT_PRIORITY,		\

--- a/drivers/serial/uart_sam0.c
+++ b/drivers/serial/uart_sam0.c
@@ -504,7 +504,7 @@ static int uart_sam0_init(const struct device *dev)
 	const struct uart_sam0_dev_cfg *const cfg = dev->config;
 	struct uart_sam0_dev_data *const dev_data = dev->data;
 
-	SercomUsart *const usart = cfg->regs;
+	SercomUsart * const usart = cfg->regs;
 
 #ifdef MCLK
 	/* Enable the GCLK */
@@ -633,7 +633,7 @@ static int uart_sam0_poll_in(const struct device *dev, unsigned char *c)
 {
 	const struct uart_sam0_dev_cfg *config = dev->config;
 
-	SercomUsart *const usart = config->regs;
+	SercomUsart * const usart = config->regs;
 
 	if (!usart->INTFLAG.bit.RXC) {
 		return -EBUSY;
@@ -647,7 +647,7 @@ static void uart_sam0_poll_out(const struct device *dev, unsigned char c)
 {
 	const struct uart_sam0_dev_cfg *config = dev->config;
 
-	SercomUsart *const usart = config->regs;
+	SercomUsart * const usart = config->regs;
 
 	while (!usart->INTFLAG.bit.DRE) {
 	}

--- a/drivers/serial/uart_sam0.c
+++ b/drivers/serial/uart_sam0.c
@@ -87,10 +87,6 @@ struct uart_sam0_dev_data {
 #endif
 };
 
-#define DEV_CFG(dev) \
-	((const struct uart_sam0_dev_cfg *const)(dev)->config)
-#define DEV_DATA(dev) ((struct uart_sam0_dev_data * const)(dev)->data)
-
 static void wait_synchronization(SercomUsart *const usart)
 {
 #if defined(SERCOM_USART_SYNCBUSY_MASK)
@@ -392,8 +388,8 @@ static int uart_sam0_configure(const struct device *dev,
 {
 	int retval;
 
-	const struct uart_sam0_dev_cfg *const cfg = DEV_CFG(dev);
-	struct uart_sam0_dev_data *const dev_data = DEV_DATA(dev);
+	const struct uart_sam0_dev_cfg *const cfg = dev->config;
+	struct uart_sam0_dev_data *const dev_data = dev->data;
 	SercomUsart * const usart = cfg->regs;
 
 	wait_synchronization(usart);
@@ -493,7 +489,8 @@ static int uart_sam0_configure(const struct device *dev,
 static int uart_sam0_config_get(const struct device *dev,
 				struct uart_config *out_cfg)
 {
-	struct uart_sam0_dev_data *const dev_data = DEV_DATA(dev);
+	struct uart_sam0_dev_data *const dev_data = dev->data;
+
 	memcpy(out_cfg, &(dev_data->config_cache),
 				sizeof(dev_data->config_cache));
 
@@ -504,8 +501,8 @@ static int uart_sam0_config_get(const struct device *dev,
 static int uart_sam0_init(const struct device *dev)
 {
 	int retval;
-	const struct uart_sam0_dev_cfg *const cfg = DEV_CFG(dev);
-	struct uart_sam0_dev_data *const dev_data = DEV_DATA(dev);
+	const struct uart_sam0_dev_cfg *const cfg = dev->config;
+	struct uart_sam0_dev_data *const dev_data = dev->data;
 
 	SercomUsart *const usart = cfg->regs;
 
@@ -634,7 +631,9 @@ static int uart_sam0_init(const struct device *dev)
 
 static int uart_sam0_poll_in(const struct device *dev, unsigned char *c)
 {
-	SercomUsart *const usart = DEV_CFG(dev)->regs;
+	const struct uart_sam0_dev_cfg *config = dev->config;
+
+	SercomUsart *const usart = config->regs;
 
 	if (!usart->INTFLAG.bit.RXC) {
 		return -EBUSY;
@@ -646,7 +645,9 @@ static int uart_sam0_poll_in(const struct device *dev, unsigned char *c)
 
 static void uart_sam0_poll_out(const struct device *dev, unsigned char c)
 {
-	SercomUsart *const usart = DEV_CFG(dev)->regs;
+	const struct uart_sam0_dev_cfg *config = dev->config;
+
+	SercomUsart *const usart = config->regs;
 
 	while (!usart->INTFLAG.bit.DRE) {
 	}
@@ -657,7 +658,9 @@ static void uart_sam0_poll_out(const struct device *dev, unsigned char c)
 
 static int uart_sam0_err_check(const struct device *dev)
 {
-	SercomUsart * const regs = DEV_CFG(dev)->regs;
+	const struct uart_sam0_dev_cfg *config = dev->config;
+
+	SercomUsart * const regs = config->regs;
 	uint32_t err = 0U;
 
 	if (regs->STATUS.reg & SERCOM_USART_STATUS_BUFOVF) {
@@ -700,7 +703,7 @@ static int uart_sam0_err_check(const struct device *dev)
 
 static void uart_sam0_isr(const struct device *dev)
 {
-	struct uart_sam0_dev_data *const dev_data = DEV_DATA(dev);
+	struct uart_sam0_dev_data *const dev_data = dev->data;
 
 #if CONFIG_UART_INTERRUPT_DRIVEN
 	if (dev_data->cb) {
@@ -709,7 +712,7 @@ static void uart_sam0_isr(const struct device *dev)
 #endif
 
 #if CONFIG_UART_ASYNC_API
-	const struct uart_sam0_dev_cfg *const cfg = DEV_CFG(dev);
+	const struct uart_sam0_dev_cfg *const cfg = dev->config;
 	SercomUsart * const regs = cfg->regs;
 
 	if (dev_data->tx_len && regs->INTFLAG.bit.TXC) {
@@ -775,7 +778,8 @@ static void uart_sam0_isr(const struct device *dev)
 static int uart_sam0_fifo_fill(const struct device *dev,
 			       const uint8_t *tx_data, int len)
 {
-	SercomUsart *regs = DEV_CFG(dev)->regs;
+	const struct uart_sam0_dev_cfg *config = dev->config;
+	SercomUsart *regs = config->regs;
 
 	if (regs->INTFLAG.bit.DRE && len >= 1) {
 		regs->DATA.reg = tx_data[0];
@@ -787,7 +791,8 @@ static int uart_sam0_fifo_fill(const struct device *dev,
 
 static void uart_sam0_irq_tx_enable(const struct device *dev)
 {
-	SercomUsart * const regs = DEV_CFG(dev)->regs;
+	const struct uart_sam0_dev_cfg *config = dev->config;
+	SercomUsart * const regs = config->regs;
 
 	regs->INTENSET.reg = SERCOM_USART_INTENSET_DRE
 			   | SERCOM_USART_INTENSET_TXC;
@@ -795,7 +800,8 @@ static void uart_sam0_irq_tx_enable(const struct device *dev)
 
 static void uart_sam0_irq_tx_disable(const struct device *dev)
 {
-	SercomUsart * const regs = DEV_CFG(dev)->regs;
+	const struct uart_sam0_dev_cfg *config = dev->config;
+	SercomUsart * const regs = config->regs;
 
 	regs->INTENCLR.reg = SERCOM_USART_INTENCLR_DRE
 			   | SERCOM_USART_INTENCLR_TXC;
@@ -803,35 +809,40 @@ static void uart_sam0_irq_tx_disable(const struct device *dev)
 
 static int uart_sam0_irq_tx_ready(const struct device *dev)
 {
-	SercomUsart * const regs = DEV_CFG(dev)->regs;
+	const struct uart_sam0_dev_cfg *config = dev->config;
+	SercomUsart * const regs = config->regs;
 
 	return (regs->INTFLAG.bit.DRE != 0) && (regs->INTENSET.bit.DRE != 0);
 }
 
 static int uart_sam0_irq_tx_complete(const struct device *dev)
 {
-	SercomUsart * const regs = DEV_CFG(dev)->regs;
+	const struct uart_sam0_dev_cfg *config = dev->config;
+	SercomUsart * const regs = config->regs;
 
 	return (regs->INTFLAG.bit.TXC != 0) && (regs->INTENSET.bit.TXC != 0);
 }
 
 static void uart_sam0_irq_rx_enable(const struct device *dev)
 {
-	SercomUsart * const regs = DEV_CFG(dev)->regs;
+	const struct uart_sam0_dev_cfg *config = dev->config;
+	SercomUsart * const regs = config->regs;
 
 	regs->INTENSET.reg = SERCOM_USART_INTENSET_RXC;
 }
 
 static void uart_sam0_irq_rx_disable(const struct device *dev)
 {
-	SercomUsart * const regs = DEV_CFG(dev)->regs;
+	const struct uart_sam0_dev_cfg *config = dev->config;
+	SercomUsart * const regs = config->regs;
 
 	regs->INTENCLR.reg = SERCOM_USART_INTENCLR_RXC;
 }
 
 static int uart_sam0_irq_rx_ready(const struct device *dev)
 {
-	SercomUsart * const regs = DEV_CFG(dev)->regs;
+	const struct uart_sam0_dev_cfg *config = dev->config;
+	SercomUsart * const regs = config->regs;
 
 	return regs->INTFLAG.bit.RXC != 0;
 }
@@ -839,7 +850,8 @@ static int uart_sam0_irq_rx_ready(const struct device *dev)
 static int uart_sam0_fifo_read(const struct device *dev, uint8_t *rx_data,
 			       const int size)
 {
-	SercomUsart * const regs = DEV_CFG(dev)->regs;
+	const struct uart_sam0_dev_cfg *config = dev->config;
+	SercomUsart * const regs = config->regs;
 
 	if (regs->INTFLAG.bit.RXC) {
 		uint8_t ch = regs->DATA.reg;
@@ -856,7 +868,8 @@ static int uart_sam0_fifo_read(const struct device *dev, uint8_t *rx_data,
 
 static int uart_sam0_irq_is_pending(const struct device *dev)
 {
-	SercomUsart * const regs = DEV_CFG(dev)->regs;
+	const struct uart_sam0_dev_cfg *config = dev->config;
+	SercomUsart * const regs = config->regs;
 
 	return (regs->INTENSET.reg & regs->INTFLAG.reg) != 0;
 }
@@ -864,7 +877,8 @@ static int uart_sam0_irq_is_pending(const struct device *dev)
 #if defined(SERCOM_REV500)
 static void uart_sam0_irq_err_enable(const struct device *dev)
 {
-	SercomUsart * const regs = DEV_CFG(dev)->regs;
+	const struct uart_sam0_dev_cfg *config = dev->config;
+	SercomUsart * const regs = config->regs;
 
 	regs->INTENSET.reg |= SERCOM_USART_INTENCLR_ERROR;
 	wait_synchronization(regs);
@@ -872,7 +886,8 @@ static void uart_sam0_irq_err_enable(const struct device *dev)
 
 static void uart_sam0_irq_err_disable(const struct device *dev)
 {
-	SercomUsart * const regs = DEV_CFG(dev)->regs;
+	const struct uart_sam0_dev_cfg *config = dev->config;
+	SercomUsart * const regs = config->regs;
 
 	regs->INTENCLR.reg |= SERCOM_USART_INTENSET_ERROR;
 	wait_synchronization(regs);
@@ -882,7 +897,8 @@ static void uart_sam0_irq_err_disable(const struct device *dev)
 static int uart_sam0_irq_update(const struct device *dev)
 {
 	/* Clear sticky interrupts */
-	SercomUsart * const regs = DEV_CFG(dev)->regs;
+	const struct uart_sam0_dev_cfg *config = dev->config;
+	SercomUsart * const regs = config->regs;
 #if defined(SERCOM_REV500)
 	regs->INTFLAG.reg |=	SERCOM_USART_INTENCLR_ERROR
 			   |	SERCOM_USART_INTENCLR_RXBRK
@@ -898,7 +914,7 @@ static void uart_sam0_irq_callback_set(const struct device *dev,
 				       uart_irq_callback_user_data_t cb,
 				       void *cb_data)
 {
-	struct uart_sam0_dev_data *const dev_data = DEV_DATA(dev);
+	struct uart_sam0_dev_data *const dev_data = dev->data;
 
 	dev_data->cb = cb;
 	dev_data->cb_data = cb_data;
@@ -911,7 +927,7 @@ static int uart_sam0_callback_set(const struct device *dev,
 				  uart_callback_t callback,
 				  void *user_data)
 {
-	struct uart_sam0_dev_data *const dev_data = DEV_DATA(dev);
+	struct uart_sam0_dev_data *const dev_data = dev->data;
 
 	dev_data->async_cb = callback;
 	dev_data->async_cb_data = user_data;
@@ -923,9 +939,9 @@ static int uart_sam0_tx(const struct device *dev, const uint8_t *buf,
 			size_t len,
 			int32_t timeout)
 {
-	struct uart_sam0_dev_data *const dev_data = DEV_DATA(dev);
-	const struct uart_sam0_dev_cfg *const cfg = DEV_CFG(dev);
-	SercomUsart *regs = DEV_CFG(dev)->regs;
+	struct uart_sam0_dev_data *const dev_data = dev->data;
+	const struct uart_sam0_dev_cfg *const cfg = dev->config;
+	SercomUsart *regs = cfg->regs;
 	int retval;
 
 	if (cfg->tx_dma_channel == 0xFFU) {
@@ -967,8 +983,8 @@ err:
 
 static int uart_sam0_tx_abort(const struct device *dev)
 {
-	struct uart_sam0_dev_data *const dev_data = DEV_DATA(dev);
-	const struct uart_sam0_dev_cfg *const cfg = DEV_CFG(dev);
+	struct uart_sam0_dev_data *const dev_data = dev->data;
+	const struct uart_sam0_dev_cfg *const cfg = dev->config;
 
 	if (cfg->tx_dma_channel == 0xFFU) {
 		return -ENOTSUP;
@@ -983,9 +999,9 @@ static int uart_sam0_rx_enable(const struct device *dev, uint8_t *buf,
 			       size_t len,
 			       int32_t timeout)
 {
-	struct uart_sam0_dev_data *const dev_data = DEV_DATA(dev);
-	const struct uart_sam0_dev_cfg *const cfg = DEV_CFG(dev);
-	SercomUsart *regs = DEV_CFG(dev)->regs;
+	struct uart_sam0_dev_data *const dev_data = dev->data;
+	const struct uart_sam0_dev_cfg *const cfg = dev->config;
+	SercomUsart *regs = cfg->regs;
 	int retval;
 
 	if (cfg->rx_dma_channel == 0xFFU) {
@@ -1042,7 +1058,7 @@ static int uart_sam0_rx_buf_rsp(const struct device *dev, uint8_t *buf,
 		return -EINVAL;
 	}
 
-	struct uart_sam0_dev_data *const dev_data = DEV_DATA(dev);
+	struct uart_sam0_dev_data *const dev_data = dev->data;
 	int key = irq_lock();
 	int retval = 0;
 
@@ -1069,8 +1085,8 @@ err:
 
 static int uart_sam0_rx_disable(const struct device *dev)
 {
-	struct uart_sam0_dev_data *const dev_data = DEV_DATA(dev);
-	const struct uart_sam0_dev_cfg *const cfg = DEV_CFG(dev);
+	struct uart_sam0_dev_data *const dev_data = dev->data;
+	const struct uart_sam0_dev_cfg *const cfg = dev->config;
 	SercomUsart * const regs = cfg->regs;
 	struct dma_status st;
 

--- a/drivers/serial/uart_sifive.c
+++ b/drivers/serial/uart_sifive.c
@@ -64,13 +64,9 @@ struct uart_sifive_data {
 #endif
 };
 
-#define DEV_CFG(dev)						\
-	((const struct uart_sifive_device_config * const)	\
-	 (dev)->config)
 #define DEV_UART(dev)						\
-	((struct uart_sifive_regs_t *)(DEV_CFG(dev))->port)
-#define DEV_DATA(dev)						\
-	((struct uart_sifive_data * const)(dev)->data)
+	((struct uart_sifive_regs_t *)				\
+	 ((const struct uart_sifive_device_config * const)(dev)->config)->port)
 
 /**
  * @brief Output a character in polled mode.
@@ -301,7 +297,7 @@ static void uart_sifive_irq_callback_set(const struct device *dev,
 					 uart_irq_callback_user_data_t cb,
 					 void *cb_data)
 {
-	struct uart_sifive_data *data = DEV_DATA(dev);
+	struct uart_sifive_data *data = dev->data;
 
 	data->callback = cb;
 	data->cb_data = cb_data;
@@ -309,7 +305,7 @@ static void uart_sifive_irq_callback_set(const struct device *dev,
 
 static void uart_sifive_irq_handler(const struct device *dev)
 {
-	struct uart_sifive_data *data = DEV_DATA(dev);
+	struct uart_sifive_data *data = dev->data;
 
 	if (data->callback)
 		data->callback(dev, data->cb_data);
@@ -320,7 +316,7 @@ static void uart_sifive_irq_handler(const struct device *dev)
 
 static int uart_sifive_init(const struct device *dev)
 {
-	const struct uart_sifive_device_config * const cfg = DEV_CFG(dev);
+	const struct uart_sifive_device_config * const cfg = dev->config;
 	volatile struct uart_sifive_regs_t *uart = DEV_UART(dev);
 
 	/* Enable TX and RX channels */

--- a/drivers/serial/uart_stellaris.c
+++ b/drivers/serial/uart_stellaris.c
@@ -77,44 +77,39 @@ struct uart_stellaris_dev_data_t {
 #endif
 };
 
-/* convenience defines */
-
-#define DEV_CFG(dev) \
-	((const struct uart_device_config * const)(dev)->config)
-#define DEV_DATA(dev) \
-	((struct uart_stellaris_dev_data_t * const)(dev)->data)
 #define UART_STRUCT(dev) \
-	((volatile struct _uart *)(DEV_CFG(dev))->base)
+	((volatile struct _uart *) \
+	 ((const struct uart_device_config * const)(dev)->config)->base)
 
 /* registers */
-#define UARTDR(dev) (*((volatile uint32_t *)(DEV_CFG(dev)->base + 0x000)))
-#define UARTSR(dev) (*((volatile uint32_t *)(DEV_CFG(dev)->base + 0x004)))
-#define UARTCR(dev) (*((volatile uint32_t *)(DEV_CFG(dev)->base + 0x004)))
-#define UARTFR(dev) (*((volatile uint32_t *)(DEV_CFG(dev)->base + 0x018)))
-#define UARTILPR(dev) (*((volatile uint32_t *)(DEV_CFG(dev)->base + 0x020)))
-#define UARTIBRD(dev) (*((volatile uint32_t *)(DEV_CFG(dev)->base + 0x024)))
-#define UARTFBRD(dev) (*((volatile uint32_t *)(DEV_CFG(dev)->base + 0x028)))
-#define UARTLCRH(dev) (*((volatile uint32_t *)(DEV_CFG(dev)->base + 0x02C)))
-#define UARTCTL(dev) (*((volatile uint32_t *)(DEV_CFG(dev)->base + 0x030)))
-#define UARTIFLS(dev) (*((volatile uint32_t *)(DEV_CFG(dev)->base + 0x034)))
-#define UARTIM(dev) (*((volatile uint32_t *)(DEV_CFG(dev)->base + 0x038)))
-#define UARTRIS(dev) (*((volatile uint32_t *)(DEV_CFG(dev)->base + 0x03C)))
-#define UARTMIS(dev) (*((volatile uint32_t *)(DEV_CFG(dev)->base + 0x040)))
-#define UARTICR(dev) (*((volatile uint32_t *)(DEV_CFG(dev)->base + 0x044)))
+#define UARTDR(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0x000)))
+#define UARTSR(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0x004)))
+#define UARTCR(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0x004)))
+#define UARTFR(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0x018)))
+#define UARTILPR(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0x020)))
+#define UARTIBRD(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0x024)))
+#define UARTFBRD(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0x028)))
+#define UARTLCRH(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0x02C)))
+#define UARTCTL(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0x030)))
+#define UARTIFLS(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0x034)))
+#define UARTIM(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0x038)))
+#define UARTRIS(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0x03C)))
+#define UARTMIS(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0x040)))
+#define UARTICR(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0x044)))
 
 /* ID registers: UARTPID = UARTPeriphID, UARTPCID = UARTPCellId */
-#define UARTPID4(dev) (*((volatile uint32_t *)(DEV_CFG(dev)->base + 0xFD0)))
-#define UARTPID5(dev) (*((volatile uint32_t *)(DEV_CFG(dev)->base + 0xFD4)))
-#define UARTPID6(dev) (*((volatile uint32_t *)(DEV_CFG(dev)->base + 0xFD8)))
-#define UARTPID7(dev) (*((volatile uint32_t *)(DEV_CFG(dev)->base + 0xFDC)))
-#define UARTPID0(dev) (*((volatile uint32_t *)(DEV_CFG(dev)->base + 0xFE0)))
-#define UARTPID1(dev) (*((volatile uint32_t *)(DEV_CFG(dev)->base + 0xFE4)))
-#define UARTPID2(dev) (*((volatile uint32_t *)(DEV_CFG(dev)->base + 0xFE8)))
-#define UARTPID3(dev) (*((volatile uint32_t *)(DEV_CFG(dev)->base + 0xFEC)))
-#define UARTPCID0(dev) (*((volatile uint32_t *)(DEV_CFG(dev)->base + 0xFF0)))
-#define UARTPCID1(dev) (*((volatile uint32_t *)(DEV_CFG(dev)->base + 0xFF4)))
-#define UARTPCID2(dev) (*((volatile uint32_t *)(DEV_CFG(dev)->base + 0xFF8)))
-#define UARTPCID3(dev) (*((volatile uint32_t *)(DEV_CFG(dev)->base + 0xFFC)))
+#define UARTPID4(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0xFD0)))
+#define UARTPID5(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0xFD4)))
+#define UARTPID6(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0xFD8)))
+#define UARTPID7(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0xFDC)))
+#define UARTPID0(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0xFE0)))
+#define UARTPID1(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0xFE4)))
+#define UARTPID2(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0xFE8)))
+#define UARTPID3(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0xFEC)))
+#define UARTPCID0(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0xFF0)))
+#define UARTPCID1(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0xFF4)))
+#define UARTPCID2(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0xFF8)))
+#define UARTPCID3(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0xFFC)))
 
 /* muxed UART registers */
 #define sr u1._sr /* Read: receive status */
@@ -256,14 +251,16 @@ static inline void line_control_defaults_set(const struct device *dev)
  */
 static int uart_stellaris_init(const struct device *dev)
 {
+	struct uart_stellaris_dev_data_t *data = dev->data;
+	const struct uart_device_config *config = dev->config;
 	disable(dev);
-	baudrate_set(dev, DEV_DATA(dev)->baud_rate,
-		     DEV_CFG(dev)->sys_clk_freq);
+	baudrate_set(dev, data->baud_rate,
+		     config->sys_clk_freq);
 	line_control_defaults_set(dev);
 	enable(dev);
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	DEV_CFG(dev)->irq_config_func(dev);
+	config->irq_config_func(dev);
 #endif
 
 	return 0;
@@ -556,7 +553,7 @@ static void uart_stellaris_irq_callback_set(const struct device *dev,
 					    uart_irq_callback_user_data_t cb,
 					    void *cb_data)
 {
-	struct uart_stellaris_dev_data_t * const dev_data = DEV_DATA(dev);
+	struct uart_stellaris_dev_data_t * const dev_data = dev->data;
 
 	dev_data->cb = cb;
 	dev_data->cb_data = cb_data;
@@ -571,7 +568,7 @@ static void uart_stellaris_irq_callback_set(const struct device *dev,
  */
 static void uart_stellaris_isr(const struct device *dev)
 {
-	struct uart_stellaris_dev_data_t * const dev_data = DEV_DATA(dev);
+	struct uart_stellaris_dev_data_t * const dev_data = dev->data;
 
 	if (dev_data->cb) {
 		dev_data->cb(dev, dev_data->cb_data);

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -41,13 +41,9 @@ LOG_MODULE_REGISTER(uart_stm32);
 #define HAS_LPUART_1 (DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(lpuart1), \
 					 st_stm32_lpuart, okay))
 
-/* convenience defines */
-#define DEV_CFG(dev)							\
-	((const struct uart_stm32_config *const)(dev)->config)
-#define DEV_DATA(dev)							\
-	((struct uart_stm32_data *const)(dev)->data)
 #define UART_STRUCT(dev)					\
-	((USART_TypeDef *)(DEV_CFG(dev))->uconf.base)
+	((USART_TypeDef *)					\
+	 ((const struct uart_stm32_config *const)(dev)->config)->uconf.base)
 
 #if HAS_LPUART_1
 #ifdef USART_PRESC_PRESCALER
@@ -82,7 +78,7 @@ uint32_t lpuartdiv_calc(const uint64_t clock_rate, const uint32_t baud_rate)
 #ifdef CONFIG_PM
 static void uart_stm32_pm_constraint_set(const struct device *dev)
 {
-	struct uart_stm32_data *data = DEV_DATA(dev);
+	struct uart_stm32_data *data = dev->data;
 
 	if (!data->pm_constraint_on) {
 		data->pm_constraint_on = true;
@@ -92,7 +88,7 @@ static void uart_stm32_pm_constraint_set(const struct device *dev)
 
 static void uart_stm32_pm_constraint_release(const struct device *dev)
 {
-	struct uart_stm32_data *data = DEV_DATA(dev);
+	struct uart_stm32_data *data = dev->data;
 
 	if (data->pm_constraint_on) {
 		data->pm_constraint_on = false;
@@ -104,8 +100,8 @@ static void uart_stm32_pm_constraint_release(const struct device *dev)
 static inline void uart_stm32_set_baudrate(const struct device *dev,
 					   uint32_t baud_rate)
 {
-	const struct uart_stm32_config *config = DEV_CFG(dev);
-	struct uart_stm32_data *data = DEV_DATA(dev);
+	const struct uart_stm32_config *config = dev->config;
+	struct uart_stm32_data *data = dev->data;
 	USART_TypeDef *UartInstance = UART_STRUCT(dev);
 
 	uint32_t clock_rate;
@@ -399,7 +395,7 @@ static inline enum uart_config_flow_control uart_stm32_ll2cfg_hwctrl(uint32_t fc
 static int uart_stm32_configure(const struct device *dev,
 				const struct uart_config *cfg)
 {
-	struct uart_stm32_data *data = DEV_DATA(dev);
+	struct uart_stm32_data *data = dev->data;
 	USART_TypeDef *UartInstance = UART_STRUCT(dev);
 	const uint32_t parity = uart_stm32_cfg2ll_parity(cfg->parity);
 	const uint32_t stopbits = uart_stm32_cfg2ll_stopbits(cfg->stop_bits);
@@ -489,7 +485,7 @@ static int uart_stm32_configure(const struct device *dev,
 static int uart_stm32_config_get(const struct device *dev,
 				 struct uart_config *cfg)
 {
-	struct uart_stm32_data *data = DEV_DATA(dev);
+	struct uart_stm32_data *data = dev->data;
 
 	cfg->baudrate = data->baud_rate;
 	cfg->parity = uart_stm32_ll2cfg_parity(uart_stm32_get_parity(dev));
@@ -526,7 +522,7 @@ static void uart_stm32_poll_out(const struct device *dev,
 {
 	USART_TypeDef *UartInstance = UART_STRUCT(dev);
 #ifdef CONFIG_PM
-	struct uart_stm32_data *data = DEV_DATA(dev);
+	struct uart_stm32_data *data = dev->data;
 #endif
 	int key;
 
@@ -612,7 +608,7 @@ static int uart_stm32_err_check(const struct device *dev)
 
 static inline void __uart_stm32_get_clock(const struct device *dev)
 {
-	struct uart_stm32_data *data = DEV_DATA(dev);
+	struct uart_stm32_data *data = dev->data;
 	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	data->clock = clk;
@@ -674,7 +670,7 @@ static void uart_stm32_irq_tx_enable(const struct device *dev)
 {
 	USART_TypeDef *UartInstance = UART_STRUCT(dev);
 #ifdef CONFIG_PM
-	struct uart_stm32_data *data = DEV_DATA(dev);
+	struct uart_stm32_data *data = dev->data;
 	int key;
 #endif
 
@@ -695,7 +691,7 @@ static void uart_stm32_irq_tx_disable(const struct device *dev)
 {
 	USART_TypeDef *UartInstance = UART_STRUCT(dev);
 #ifdef CONFIG_PM
-	struct uart_stm32_data *data = DEV_DATA(dev);
+	struct uart_stm32_data *data = dev->data;
 	int key;
 
 	key = irq_lock();
@@ -800,7 +796,7 @@ static void uart_stm32_irq_callback_set(const struct device *dev,
 					uart_irq_callback_user_data_t cb,
 					void *cb_data)
 {
-	struct uart_stm32_data *data = DEV_DATA(dev);
+	struct uart_stm32_data *data = dev->data;
 
 	data->user_cb = cb;
 	data->user_data = cb_data;
@@ -919,7 +915,7 @@ static inline void async_timer_start(struct k_work_delayable *work,
 static void uart_stm32_dma_rx_flush(const struct device *dev)
 {
 	struct dma_status stat;
-	struct uart_stm32_data *data = DEV_DATA(dev);
+	struct uart_stm32_data *data = dev->data;
 
 	if (dma_get_status(data->dma_rx.dma_dev,
 				data->dma_rx.dma_channel, &stat) == 0) {
@@ -941,7 +937,7 @@ static void uart_stm32_dma_rx_flush(const struct device *dev)
 
 static void uart_stm32_isr(const struct device *dev)
 {
-	struct uart_stm32_data *data = DEV_DATA(dev);
+	struct uart_stm32_data *data = dev->data;
 #if defined(CONFIG_PM) || defined(CONFIG_UART_ASYNC_API)
 	USART_TypeDef *UartInstance = UART_STRUCT(dev);
 #endif
@@ -1020,7 +1016,7 @@ static int uart_stm32_async_callback_set(const struct device *dev,
 					 uart_callback_t callback,
 					 void *user_data)
 {
-	struct uart_stm32_data *data = DEV_DATA(dev);
+	struct uart_stm32_data *data = dev->data;
 
 	data->async_cb = callback;
 	data->async_user_data = user_data;
@@ -1045,7 +1041,7 @@ static inline void uart_stm32_dma_tx_disable(const struct device *dev)
 static inline void uart_stm32_dma_rx_enable(const struct device *dev)
 {
 	USART_TypeDef *UartInstance = UART_STRUCT(dev);
-	struct uart_stm32_data *data = DEV_DATA(dev);
+	struct uart_stm32_data *data = dev->data;
 
 	LL_USART_EnableDMAReq_RX(UartInstance);
 
@@ -1054,14 +1050,14 @@ static inline void uart_stm32_dma_rx_enable(const struct device *dev)
 
 static inline void uart_stm32_dma_rx_disable(const struct device *dev)
 {
-	struct uart_stm32_data *data = DEV_DATA(dev);
+	struct uart_stm32_data *data = dev->data;
 
 	data->dma_rx.enabled = false;
 }
 
 static int uart_stm32_async_rx_disable(const struct device *dev)
 {
-	struct uart_stm32_data *data = DEV_DATA(dev);
+	struct uart_stm32_data *data = dev->data;
 	USART_TypeDef *UartInstance = UART_STRUCT(dev);
 	struct uart_event disabled_event = {
 		.type = UART_RX_DISABLED
@@ -1101,7 +1097,7 @@ void uart_stm32_dma_tx_cb(const struct device *dma_dev, void *user_data,
 			       uint32_t channel, int status)
 {
 	const struct device *uart_dev = user_data;
-	struct uart_stm32_data *data = DEV_DATA(uart_dev);
+	struct uart_stm32_data *data = uart_dev->data;
 	struct dma_status stat;
 	unsigned int key = irq_lock();
 
@@ -1123,7 +1119,7 @@ void uart_stm32_dma_tx_cb(const struct device *dma_dev, void *user_data,
 
 static void uart_stm32_dma_replace_buffer(const struct device *dev)
 {
-	struct uart_stm32_data *data = DEV_DATA(dev);
+	struct uart_stm32_data *data = dev->data;
 
 	/* Replace the buffer and relod the DMA */
 	LOG_DBG("Replacing RX buffer: %d", data->rx_next_buffer_len);
@@ -1157,7 +1153,7 @@ void uart_stm32_dma_rx_cb(const struct device *dma_dev, void *user_data,
 			       uint32_t channel, int status)
 {
 	const struct device *uart_dev = user_data;
-	struct uart_stm32_data *data = DEV_DATA(uart_dev);
+	struct uart_stm32_data *data = uart_dev->data;
 
 	if (status != 0) {
 		async_evt_rx_err(data, status);
@@ -1193,7 +1189,7 @@ void uart_stm32_dma_rx_cb(const struct device *dma_dev, void *user_data,
 static int uart_stm32_async_tx(const struct device *dev,
 		const uint8_t *tx_data, size_t buf_size, int32_t timeout)
 {
-	struct uart_stm32_data *data = DEV_DATA(dev);
+	struct uart_stm32_data *data = dev->data;
 	USART_TypeDef *UartInstance = UART_STRUCT(dev);
 	int ret;
 
@@ -1252,7 +1248,7 @@ static int uart_stm32_async_tx(const struct device *dev,
 static int uart_stm32_async_rx_enable(const struct device *dev,
 		uint8_t *rx_buf, size_t buf_size, int32_t timeout)
 {
-	struct uart_stm32_data *data = DEV_DATA(dev);
+	struct uart_stm32_data *data = dev->data;
 	USART_TypeDef *UartInstance = UART_STRUCT(dev);
 	int ret;
 
@@ -1311,7 +1307,7 @@ static int uart_stm32_async_rx_enable(const struct device *dev,
 
 static int uart_stm32_async_tx_abort(const struct device *dev)
 {
-	struct uart_stm32_data *data = DEV_DATA(dev);
+	struct uart_stm32_data *data = dev->data;
 	size_t tx_buffer_length = data->dma_tx.buffer_length;
 	struct dma_status stat;
 
@@ -1364,7 +1360,7 @@ static void uart_stm32_async_tx_timeout(struct k_work *work)
 static int uart_stm32_async_rx_buf_rsp(const struct device *dev, uint8_t *buf,
 				       size_t len)
 {
-	struct uart_stm32_data *data = DEV_DATA(dev);
+	struct uart_stm32_data *data = dev->data;
 
 	LOG_DBG("replace buffer (%d)", len);
 	data->rx_next_buffer = buf;
@@ -1375,7 +1371,7 @@ static int uart_stm32_async_rx_buf_rsp(const struct device *dev, uint8_t *buf,
 
 static int uart_stm32_async_init(const struct device *dev)
 {
-	struct uart_stm32_data *data = DEV_DATA(dev);
+	struct uart_stm32_data *data = dev->data;
 	USART_TypeDef *UartInstance = UART_STRUCT(dev);
 
 	data->uart_dev = dev;
@@ -1525,8 +1521,8 @@ static const struct uart_driver_api uart_stm32_driver_api = {
  */
 static int uart_stm32_init(const struct device *dev)
 {
-	const struct uart_stm32_config *config = DEV_CFG(dev);
-	struct uart_stm32_data *data = DEV_DATA(dev);
+	const struct uart_stm32_config *config = dev->config;
+	struct uart_stm32_data *data = dev->data;
 	USART_TypeDef *UartInstance = UART_STRUCT(dev);
 	uint32_t ll_parity;
 	uint32_t ll_datawidth;

--- a/drivers/serial/uart_xlnx_ps.c
+++ b/drivers/serial/uart_xlnx_ps.c
@@ -150,12 +150,6 @@ struct uart_xlnx_ps_dev_data_t {
 #endif
 };
 
-#define DEV_CFG(dev) \
-	((const struct uart_xlnx_ps_dev_config * const) \
-	 (dev)->config)
-#define DEV_DATA(dev) \
-	((struct uart_xlnx_ps_dev_data_t *)(dev)->data)
-
 static const struct uart_driver_api uart_xlnx_ps_driver_api;
 
 /**
@@ -224,7 +218,7 @@ static void xlnx_ps_enable_uart(uint32_t reg_base)
  */
 static void set_baudrate(const struct device *dev, uint32_t baud_rate)
 {
-	const struct uart_xlnx_ps_dev_config *dev_cfg = DEV_CFG(dev);
+	const struct uart_xlnx_ps_dev_config *dev_cfg = dev->config;
 	uint32_t divisor, generator;
 	uint32_t baud;
 	uint32_t clk_freq;
@@ -283,7 +277,7 @@ static void set_baudrate(const struct device *dev, uint32_t baud_rate)
  */
 static int uart_xlnx_ps_init(const struct device *dev)
 {
-	const struct uart_xlnx_ps_dev_config *dev_cfg = DEV_CFG(dev);
+	const struct uart_xlnx_ps_dev_config *dev_cfg = dev->config;
 	uint32_t reg_val;
 	uint32_t reg_base;
 
@@ -334,7 +328,7 @@ static int uart_xlnx_ps_init(const struct device *dev)
  */
 static int uart_xlnx_ps_poll_in(const struct device *dev, unsigned char *c)
 {
-	const struct uart_xlnx_ps_dev_config *dev_cfg = DEV_CFG(dev);
+	const struct uart_xlnx_ps_dev_config *dev_cfg = dev->config;
 	uint32_t reg_val;
 	uint32_t reg_base;
 
@@ -365,7 +359,7 @@ static int uart_xlnx_ps_poll_in(const struct device *dev, unsigned char *c)
  */
 static void uart_xlnx_ps_poll_out(const struct device *dev, unsigned char c)
 {
-	const struct uart_xlnx_ps_dev_config *dev_cfg = DEV_CFG(dev);
+	const struct uart_xlnx_ps_dev_config *dev_cfg = dev->config;
 	uint32_t reg_val;
 	uint32_t reg_base;
 
@@ -597,7 +591,7 @@ static int uart_xlnx_ps_configure(const struct device *dev,
 				  const struct uart_config *cfg)
 {
 	struct uart_xlnx_ps_dev_config *dev_cfg =
-	(struct uart_xlnx_ps_dev_config *)DEV_CFG(dev);
+	(struct uart_xlnx_ps_dev_config *)dev->config;
 
 	uint32_t reg_base    = dev_cfg->uconf.regs;
 	uint32_t mode_reg    = 0;
@@ -803,7 +797,7 @@ static inline enum uart_config_flow_control uart_xlnx_ps_ll2cfg_hwctrl(
 static int uart_xlnx_ps_config_get(const struct device *dev,
 				   struct uart_config *cfg)
 {
-	const struct uart_xlnx_ps_dev_config *dev_cfg = DEV_CFG(dev);
+	const struct uart_xlnx_ps_dev_config *dev_cfg = dev->config;
 
 	/*
 	 * Read the Mode & Modem control registers - they contain
@@ -841,7 +835,7 @@ static int uart_xlnx_ps_fifo_fill(const struct device *dev,
 				  const uint8_t *tx_data,
 				  int size)
 {
-	const struct uart_xlnx_ps_dev_config *dev_cfg = DEV_CFG(dev);
+	const struct uart_xlnx_ps_dev_config *dev_cfg = dev->config;
 	uint32_t reg_base = dev_cfg->uconf.regs;
 	uint32_t data_iter = 0;
 
@@ -868,7 +862,7 @@ static int uart_xlnx_ps_fifo_fill(const struct device *dev,
 static int uart_xlnx_ps_fifo_read(const struct device *dev, uint8_t *rx_data,
 				  const int size)
 {
-	const struct uart_xlnx_ps_dev_config *dev_cfg = DEV_CFG(dev);
+	const struct uart_xlnx_ps_dev_config *dev_cfg = dev->config;
 	uint32_t reg_val;
 	uint32_t reg_base;
 	int inum = 0;
@@ -893,7 +887,7 @@ static int uart_xlnx_ps_fifo_read(const struct device *dev, uint8_t *rx_data,
  */
 static void uart_xlnx_ps_irq_tx_enable(const struct device *dev)
 {
-	const struct uart_xlnx_ps_dev_config *dev_cfg = DEV_CFG(dev);
+	const struct uart_xlnx_ps_dev_config *dev_cfg = dev->config;
 	uint32_t reg_base;
 
 	reg_base = dev_cfg->uconf.regs;
@@ -909,7 +903,7 @@ static void uart_xlnx_ps_irq_tx_enable(const struct device *dev)
  */
 static void uart_xlnx_ps_irq_tx_disable(const struct device *dev)
 {
-	const struct uart_xlnx_ps_dev_config *dev_cfg = DEV_CFG(dev);
+	const struct uart_xlnx_ps_dev_config *dev_cfg = dev->config;
 	uint32_t reg_base;
 
 	reg_base = dev_cfg->uconf.regs;
@@ -927,7 +921,7 @@ static void uart_xlnx_ps_irq_tx_disable(const struct device *dev)
  */
 static int uart_xlnx_ps_irq_tx_ready(const struct device *dev)
 {
-	const struct uart_xlnx_ps_dev_config *dev_cfg = DEV_CFG(dev);
+	const struct uart_xlnx_ps_dev_config *dev_cfg = dev->config;
 	uint32_t reg_base = dev_cfg->uconf.regs;
 	uint32_t reg_val = sys_read32(reg_base + XUARTPS_SR_OFFSET);
 
@@ -947,7 +941,7 @@ static int uart_xlnx_ps_irq_tx_ready(const struct device *dev)
  */
 static int uart_xlnx_ps_irq_tx_complete(const struct device *dev)
 {
-	const struct uart_xlnx_ps_dev_config *dev_cfg = DEV_CFG(dev);
+	const struct uart_xlnx_ps_dev_config *dev_cfg = dev->config;
 	uint32_t reg_base;
 	uint32_t reg_val;
 
@@ -967,7 +961,7 @@ static int uart_xlnx_ps_irq_tx_complete(const struct device *dev)
  */
 static void uart_xlnx_ps_irq_rx_enable(const struct device *dev)
 {
-	const struct uart_xlnx_ps_dev_config *dev_cfg = DEV_CFG(dev);
+	const struct uart_xlnx_ps_dev_config *dev_cfg = dev->config;
 	uint32_t reg_base;
 
 	reg_base = dev_cfg->uconf.regs;
@@ -981,7 +975,7 @@ static void uart_xlnx_ps_irq_rx_enable(const struct device *dev)
  */
 static void uart_xlnx_ps_irq_rx_disable(const struct device *dev)
 {
-	const struct uart_xlnx_ps_dev_config *dev_cfg = DEV_CFG(dev);
+	const struct uart_xlnx_ps_dev_config *dev_cfg = dev->config;
 	uint32_t reg_base;
 
 	reg_base = dev_cfg->uconf.regs;
@@ -997,7 +991,7 @@ static void uart_xlnx_ps_irq_rx_disable(const struct device *dev)
  */
 static int uart_xlnx_ps_irq_rx_ready(const struct device *dev)
 {
-	const struct uart_xlnx_ps_dev_config *dev_cfg = DEV_CFG(dev);
+	const struct uart_xlnx_ps_dev_config *dev_cfg = dev->config;
 	uint32_t reg_base = dev_cfg->uconf.regs;
 	uint32_t reg_val = sys_read32(reg_base + XUARTPS_ISR_OFFSET);
 
@@ -1016,7 +1010,7 @@ static int uart_xlnx_ps_irq_rx_ready(const struct device *dev)
  */
 static void uart_xlnx_ps_irq_err_enable(const struct device *dev)
 {
-	const struct uart_xlnx_ps_dev_config *dev_cfg = DEV_CFG(dev);
+	const struct uart_xlnx_ps_dev_config *dev_cfg = dev->config;
 	uint32_t reg_base;
 
 	reg_base = dev_cfg->uconf.regs;
@@ -1038,7 +1032,7 @@ static void uart_xlnx_ps_irq_err_enable(const struct device *dev)
  */
 static void uart_xlnx_ps_irq_err_disable(const struct device *dev)
 {
-	const struct uart_xlnx_ps_dev_config *dev_cfg = DEV_CFG(dev);
+	const struct uart_xlnx_ps_dev_config *dev_cfg = dev->config;
 	uint32_t reg_base;
 
 	reg_base = dev_cfg->uconf.regs;
@@ -1060,7 +1054,7 @@ static void uart_xlnx_ps_irq_err_disable(const struct device *dev)
  */
 static int uart_xlnx_ps_irq_is_pending(const struct device *dev)
 {
-	const struct uart_xlnx_ps_dev_config *dev_cfg = DEV_CFG(dev);
+	const struct uart_xlnx_ps_dev_config *dev_cfg = dev->config;
 	uint32_t reg_base;
 	uint32_t reg_imr;
 	uint32_t reg_isr;
@@ -1099,7 +1093,7 @@ static void uart_xlnx_ps_irq_callback_set(const struct device *dev,
 					    uart_irq_callback_user_data_t cb,
 					    void *cb_data)
 {
-	struct uart_xlnx_ps_dev_data_t *dev_data = DEV_DATA(dev);
+	struct uart_xlnx_ps_dev_data_t *dev_data = dev->data;
 
 	dev_data->user_cb = cb;
 	dev_data->user_data = cb_data;
@@ -1114,7 +1108,7 @@ static void uart_xlnx_ps_irq_callback_set(const struct device *dev,
  */
 static void uart_xlnx_ps_isr(const struct device *dev)
 {
-	const struct uart_xlnx_ps_dev_data_t *data = DEV_DATA(dev);
+	const struct uart_xlnx_ps_dev_data_t *data = dev->data;
 
 	if (data->user_cb) {
 		data->user_cb(dev, data->user_data);

--- a/drivers/serial/uart_xmc4xxx.c
+++ b/drivers/serial/uart_xmc4xxx.c
@@ -15,14 +15,9 @@ struct uart_xmc4xxx_data {
 	XMC_UART_CH_CONFIG_t config;
 };
 
-#define DEV_CFG(dev) \
-	((const struct uart_device_config * const)(dev)->config)
-#define DEV_DATA(dev) \
-	((struct uart_xmc4xxx_data * const)(dev)->data)
-
 static int uart_xmc4xxx_poll_in(const struct device *dev, unsigned char *c)
 {
-	const struct uart_device_config *config = DEV_CFG(dev);
+	const struct uart_device_config *config = dev->config;
 
 	*(uint16_t *)c =
 		XMC_UART_CH_GetReceivedData((XMC_USIC_CH_t *)config->base);
@@ -32,15 +27,15 @@ static int uart_xmc4xxx_poll_in(const struct device *dev, unsigned char *c)
 
 static void uart_xmc4xxx_poll_out(const struct device *dev, unsigned char c)
 {
-	const struct uart_device_config *config = DEV_CFG(dev);
+	const struct uart_device_config *config = dev->config;
 
 	XMC_UART_CH_Transmit((XMC_USIC_CH_t *)config->base, (uint16_t)c);
 }
 
 static int uart_xmc4xxx_init(const struct device *dev)
 {
-	const struct uart_device_config *config = DEV_CFG(dev);
-	struct uart_xmc4xxx_data *data = DEV_DATA(dev);
+	const struct uart_device_config *config = dev->config;
+	struct uart_xmc4xxx_data *data = dev->data;
 	XMC_USIC_CH_t *uart = (XMC_USIC_CH_t *)config->base;
 
 	data->config.data_bits = 8U;

--- a/drivers/serial/usart_sam.c
+++ b/drivers/serial/usart_sam.c
@@ -95,7 +95,8 @@ static int usart_sam_init(const struct device *dev)
 static int usart_sam_poll_in(const struct device *dev, unsigned char *c)
 {
 	const struct usart_sam_dev_cfg *config = dev->config;
-	Usart *const usart = config->regs;
+
+	Usart * const usart = config->regs;
 
 	if (!(usart->US_CSR & US_CSR_RXRDY)) {
 		return -EBUSY;
@@ -111,7 +112,7 @@ static void usart_sam_poll_out(const struct device *dev, unsigned char c)
 {
 	const struct usart_sam_dev_cfg *config = dev->config;
 
-	Usart *const usart = config->regs;
+	Usart * const usart = config->regs;
 
 	/* Wait for transmitter to be ready */
 	while (!(usart->US_CSR & US_CSR_TXRDY)) {

--- a/drivers/serial/usart_sam.c
+++ b/drivers/serial/usart_sam.c
@@ -43,12 +43,6 @@ struct usart_sam_dev_data {
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 };
 
-#define DEV_CFG(dev) \
-	((const struct usart_sam_dev_cfg *const)(dev)->config)
-#define DEV_DATA(dev) \
-	((struct usart_sam_dev_data *const)(dev)->data)
-
-
 static int baudrate_set(Usart *const usart, uint32_t baudrate,
 			uint32_t mck_freq_hz);
 
@@ -56,8 +50,8 @@ static int baudrate_set(Usart *const usart, uint32_t baudrate,
 static int usart_sam_init(const struct device *dev)
 {
 	int retval;
-	const struct usart_sam_dev_cfg *const cfg = DEV_CFG(dev);
-	struct usart_sam_dev_data *const dev_data = DEV_DATA(dev);
+	const struct usart_sam_dev_cfg *const cfg = dev->config;
+	struct usart_sam_dev_data *const dev_data = dev->data;
 	Usart *const usart = cfg->regs;
 
 	/* Enable USART clock in PMC */
@@ -100,7 +94,8 @@ static int usart_sam_init(const struct device *dev)
 
 static int usart_sam_poll_in(const struct device *dev, unsigned char *c)
 {
-	Usart *const usart = DEV_CFG(dev)->regs;
+	const struct usart_sam_dev_cfg *config = dev->config;
+	Usart *const usart = config->regs;
 
 	if (!(usart->US_CSR & US_CSR_RXRDY)) {
 		return -EBUSY;
@@ -114,7 +109,9 @@ static int usart_sam_poll_in(const struct device *dev, unsigned char *c)
 
 static void usart_sam_poll_out(const struct device *dev, unsigned char c)
 {
-	Usart *const usart = DEV_CFG(dev)->regs;
+	const struct usart_sam_dev_cfg *config = dev->config;
+
+	Usart *const usart = config->regs;
 
 	/* Wait for transmitter to be ready */
 	while (!(usart->US_CSR & US_CSR_TXRDY)) {
@@ -126,7 +123,9 @@ static void usart_sam_poll_out(const struct device *dev, unsigned char c)
 
 static int usart_sam_err_check(const struct device *dev)
 {
-	volatile Usart * const usart = DEV_CFG(dev)->regs;
+	const struct usart_sam_dev_cfg *config = dev->config;
+
+	volatile Usart * const usart = config->regs;
 	int errors = 0;
 
 	if (usart->US_CSR & US_CSR_OVRE) {
@@ -171,7 +170,9 @@ static int usart_sam_fifo_fill(const struct device *dev,
 			       const uint8_t *tx_data,
 			       int size)
 {
-	volatile Usart * const usart = DEV_CFG(dev)->regs;
+	const struct usart_sam_dev_cfg *config = dev->config;
+
+	volatile Usart * const usart = config->regs;
 
 	/* Wait for transmitter to be ready. */
 	while ((usart->US_CSR & US_CSR_TXRDY) == 0) {
@@ -185,7 +186,9 @@ static int usart_sam_fifo_fill(const struct device *dev,
 static int usart_sam_fifo_read(const struct device *dev, uint8_t *rx_data,
 			       const int size)
 {
-	volatile Usart * const usart = DEV_CFG(dev)->regs;
+	const struct usart_sam_dev_cfg *config = dev->config;
+
+	volatile Usart * const usart = config->regs;
 	int bytes_read;
 
 	bytes_read = 0;
@@ -204,70 +207,90 @@ static int usart_sam_fifo_read(const struct device *dev, uint8_t *rx_data,
 
 static void usart_sam_irq_tx_enable(const struct device *dev)
 {
-	volatile Usart * const usart = DEV_CFG(dev)->regs;
+	const struct usart_sam_dev_cfg *config = dev->config;
+
+	volatile Usart * const usart = config->regs;
 
 	usart->US_IER = US_IER_TXRDY;
 }
 
 static void usart_sam_irq_tx_disable(const struct device *dev)
 {
-	volatile Usart * const usart = DEV_CFG(dev)->regs;
+	const struct usart_sam_dev_cfg *config = dev->config;
+
+	volatile Usart * const usart = config->regs;
 
 	usart->US_IDR = US_IDR_TXRDY;
 }
 
 static int usart_sam_irq_tx_ready(const struct device *dev)
 {
-	volatile Usart * const usart = DEV_CFG(dev)->regs;
+	const struct usart_sam_dev_cfg *config = dev->config;
+
+	volatile Usart * const usart = config->regs;
 
 	return (usart->US_CSR & US_CSR_TXRDY);
 }
 
 static void usart_sam_irq_rx_enable(const struct device *dev)
 {
-	volatile Usart * const usart = DEV_CFG(dev)->regs;
+	const struct usart_sam_dev_cfg *config = dev->config;
+
+	volatile Usart * const usart = config->regs;
 
 	usart->US_IER = US_IER_RXRDY;
 }
 
 static void usart_sam_irq_rx_disable(const struct device *dev)
 {
-	volatile Usart * const usart = DEV_CFG(dev)->regs;
+	const struct usart_sam_dev_cfg *config = dev->config;
+
+	volatile Usart * const usart = config->regs;
 
 	usart->US_IDR = US_IDR_RXRDY;
 }
 
 static int usart_sam_irq_tx_complete(const struct device *dev)
 {
-	volatile Usart * const usart = DEV_CFG(dev)->regs;
+	const struct usart_sam_dev_cfg *config = dev->config;
+
+	volatile Usart * const usart = config->regs;
 
 	return !(usart->US_CSR & US_CSR_TXRDY);
 }
 
 static int usart_sam_irq_rx_ready(const struct device *dev)
 {
-	volatile Usart * const usart = DEV_CFG(dev)->regs;
+	const struct usart_sam_dev_cfg *config = dev->config;
+
+	volatile Usart * const usart = config->regs;
 
 	return (usart->US_CSR & US_CSR_RXRDY);
 }
 
 static void usart_sam_irq_err_enable(const struct device *dev)
 {
-	volatile Usart * const usart = DEV_CFG(dev)->regs;
+	const struct usart_sam_dev_cfg *config = dev->config;
+
+	volatile Usart * const usart = config->regs;
 
 	usart->US_IER = US_IER_OVRE | US_IER_FRAME | US_IER_PARE;
 }
 
 static void usart_sam_irq_err_disable(const struct device *dev)
 {
-	volatile Usart * const usart = DEV_CFG(dev)->regs;
+	const struct usart_sam_dev_cfg *config = dev->config;
+
+	volatile Usart * const usart = config->regs;
 
 	usart->US_IDR = US_IDR_OVRE | US_IDR_FRAME | US_IDR_PARE;
 }
 
 static int usart_sam_irq_is_pending(const struct device *dev)
 {
-	volatile Usart * const usart = DEV_CFG(dev)->regs;
+	const struct usart_sam_dev_cfg *config = dev->config;
+
+	volatile Usart * const usart = config->regs;
 
 	return (usart->US_IMR & (US_IMR_TXRDY | US_IMR_RXRDY)) &
 		(usart->US_CSR & (US_CSR_TXRDY | US_CSR_RXRDY));
@@ -284,7 +307,7 @@ static void usart_sam_irq_callback_set(const struct device *dev,
 				       uart_irq_callback_user_data_t cb,
 				       void *cb_data)
 {
-	struct usart_sam_dev_data *const dev_data = DEV_DATA(dev);
+	struct usart_sam_dev_data *const dev_data = dev->data;
 
 	dev_data->irq_cb = cb;
 	dev_data->cb_data = cb_data;
@@ -292,7 +315,7 @@ static void usart_sam_irq_callback_set(const struct device *dev,
 
 static void usart_sam_isr(const struct device *dev)
 {
-	struct usart_sam_dev_data *const dev_data = DEV_DATA(dev);
+	struct usart_sam_dev_data *const dev_data = dev->data;
 
 	if (dev_data->irq_cb) {
 		dev_data->irq_cb(dev, dev_data->cb_data);

--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -37,22 +37,12 @@ struct spi_cc13xx_cc26xx_data {
 
 #define CPU_FREQ DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency)
 
-static inline struct spi_cc13xx_cc26xx_data *get_dev_data(const struct device *dev)
-{
-	return dev->data;
-}
-
-static inline const struct spi_cc13xx_cc26xx_config *
-get_dev_config(const struct device *dev)
-{
-	return dev->config;
-}
-
 static int spi_cc13xx_cc26xx_configure(const struct device *dev,
 				       const struct spi_config *config)
 {
-	const struct spi_cc13xx_cc26xx_config *cfg = get_dev_config(dev);
-	struct spi_context *ctx = &get_dev_data(dev)->ctx;
+	const struct spi_cc13xx_cc26xx_config *cfg = dev->config;
+	struct spi_cc13xx_cc26xx_data *data = dev->data;
+	struct spi_context *ctx = &data->ctx;
 	uint32_t prot;
 
 	if (spi_context_configured(ctx, config)) {
@@ -143,8 +133,9 @@ static int spi_cc13xx_cc26xx_transceive(const struct device *dev,
 					const struct spi_buf_set *tx_bufs,
 					const struct spi_buf_set *rx_bufs)
 {
-	const struct spi_cc13xx_cc26xx_config *cfg = get_dev_config(dev);
-	struct spi_context *ctx = &get_dev_data(dev)->ctx;
+	const struct spi_cc13xx_cc26xx_config *cfg = dev->config;
+	struct spi_cc13xx_cc26xx_data *data = dev->data;
+	struct spi_context *ctx = &data->ctx;
 	uint32_t txd, rxd;
 	int err;
 
@@ -196,13 +187,15 @@ done:
 static int spi_cc13xx_cc26xx_release(const struct device *dev,
 				     const struct spi_config *config)
 {
-	struct spi_context *ctx = &get_dev_data(dev)->ctx;
+	const struct spi_cc13xx_cc26xx_config *cfg = dev->config;
+	struct spi_cc13xx_cc26xx_data *data = dev->data;
+	struct spi_context *ctx = &data->ctx;
 
 	if (!spi_context_configured(ctx, config)) {
 		return -EINVAL;
 	}
 
-	if (SSIBusy(get_dev_config(dev)->base)) {
+	if (SSIBusy(cfg->base)) {
 		return -EBUSY;
 	}
 
@@ -215,20 +208,22 @@ static int spi_cc13xx_cc26xx_release(const struct device *dev,
 static int spi_cc13xx_cc26xx_pm_action(const struct device *dev,
 				       enum pm_device_action action)
 {
+	const struct spi_cc13xx_cc26xx_config *config = dev->config;
+
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
-		if (get_dev_config(dev)->base == DT_INST_REG_ADDR(0)) {
+		if (config->base == DT_INST_REG_ADDR(0)) {
 			Power_setDependency(PowerCC26XX_PERIPH_SSI0);
 		} else {
 			Power_setDependency(PowerCC26XX_PERIPH_SSI1);
 		}
 		break;
 	case PM_DEVICE_ACTION_SUSPEND:
-		SSIDisable(get_dev_config(dev)->base);
+		SSIDisable(config->base);
 		/*
 		 * Release power dependency
 		 */
-		if (get_dev_config(dev)->base == DT_INST_REG_ADDR(0)) {
+		if (config->base == DT_INST_REG_ADDR(0)) {
 			Power_releaseDependency(PowerCC26XX_PERIPH_SSI0);
 		} else {
 			Power_releaseDependency(PowerCC26XX_PERIPH_SSI1);
@@ -306,15 +301,16 @@ static const struct spi_driver_api spi_cc13xx_cc26xx_driver_api = {
 #define SPI_CC13XX_CC26XX_INIT_FUNC(n)						\
 	static int spi_cc13xx_cc26xx_init_##n(const struct device *dev)		\
 	{									\
+		struct spi_cc13xx_cc26xx_data *data = dev->data;		\
 		int err;							\
 		SPI_CC13XX_CC26XX_POWER_SPI(n);					\
 										\
-		err = spi_context_cs_configure_all(&get_dev_data(dev)->ctx);	\
+		err = spi_context_cs_configure_all(&data->ctx);			\
 		if (err < 0) {							\
 			return err;						\
 		}								\
 										\
-		spi_context_unlock_unconditionally(&get_dev_data(dev)->ctx);	\
+		spi_context_unlock_unconditionally(&data->ctx);			\
 										\
 		return 0;							\
 	}

--- a/drivers/spi/spi_gecko.c
+++ b/drivers/spi/spi_gecko.c
@@ -29,8 +29,6 @@ LOG_MODULE_REGISTER(spi_gecko);
 
 #define SPI_WORD_SIZE 8
 
-#define DEV_DATA(dev) ((struct spi_gecko_data *) ((dev)->data))
-
 /* Structure Declarations */
 
 struct spi_gecko_data {
@@ -55,7 +53,7 @@ static int spi_config(const struct device *dev,
 		      uint16_t *control)
 {
 	const struct spi_gecko_config *gecko_config = dev->config;
-	struct spi_gecko_data *data = DEV_DATA(dev);
+	struct spi_gecko_data *data = dev->data;
 
 	if (config->operation & SPI_HALF_DUPLEX) {
 		LOG_ERR("Half-duplex not supported");
@@ -172,9 +170,10 @@ static void spi_gecko_xfer(const struct device *dev,
 			   const struct spi_config *config)
 {
 	int ret;
-	struct spi_context *ctx = &DEV_DATA(dev)->ctx;
+	struct spi_gecko_data *data = dev->data;
+	struct spi_context *ctx = &data->ctx;
 	const struct spi_gecko_config *gecko_config = dev->config;
-	struct spi_gecko_data *data = DEV_DATA(dev);
+	struct spi_gecko_data *data = dev->data;
 
 	spi_context_cs_control(ctx, true);
 
@@ -259,10 +258,11 @@ static int spi_gecko_transceive(const struct device *dev,
 				const struct spi_buf_set *tx_bufs,
 				const struct spi_buf_set *rx_bufs)
 {
+	struct spi_gecko_data *data = dev->data;
 	uint16_t control = 0;
 
 	spi_config(dev, config, &control);
-	spi_context_buffers_setup(&DEV_DATA(dev)->ctx, tx_bufs, rx_bufs, 1);
+	spi_context_buffers_setup(&data->ctx, tx_bufs, rx_bufs, 1);
 	spi_gecko_xfer(dev, config);
 	return 0;
 }

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -27,12 +27,6 @@ LOG_MODULE_REGISTER(spi_ll_stm32);
 
 #include "spi_ll_stm32.h"
 
-#define DEV_CFG(dev)						\
-(const struct spi_stm32_config * const)(dev->config)
-
-#define DEV_DATA(dev)					\
-(struct spi_stm32_data * const)(dev->data)
-
 /*
  * Check for SPI_SR_FRE to determine support for TI mode frame format
  * error flag, because STM32F1 SoCs do not support it and  STM32CUBE
@@ -92,8 +86,8 @@ static void dma_callback(const struct device *dev, void *arg,
 static int spi_stm32_dma_tx_load(const struct device *dev, const uint8_t *buf,
 				 size_t len)
 {
-	const struct spi_stm32_config *cfg = DEV_CFG(dev);
-	struct spi_stm32_data *data = DEV_DATA(dev);
+	const struct spi_stm32_config *cfg = dev->config;
+	struct spi_stm32_data *data = dev->data;
 	struct dma_block_config *blk_cfg;
 	int ret;
 
@@ -151,8 +145,8 @@ static int spi_stm32_dma_tx_load(const struct device *dev, const uint8_t *buf,
 static int spi_stm32_dma_rx_load(const struct device *dev, uint8_t *buf,
 				 size_t len)
 {
-	const struct spi_stm32_config *cfg = DEV_CFG(dev);
-	struct spi_stm32_data *data = DEV_DATA(dev);
+	const struct spi_stm32_config *cfg = dev->config;
+	struct spi_stm32_data *data = dev->data;
 	struct dma_block_config *blk_cfg;
 	int ret;
 
@@ -209,7 +203,7 @@ static int spi_stm32_dma_rx_load(const struct device *dev, uint8_t *buf,
 
 static int spi_dma_move_buffers(const struct device *dev, size_t len)
 {
-	struct spi_stm32_data *data = DEV_DATA(dev);
+	struct spi_stm32_data *data = dev->data;
 	int ret;
 	size_t dma_segment_len;
 
@@ -454,8 +448,8 @@ static void spi_stm32_isr(const struct device *dev)
 static int spi_stm32_configure(const struct device *dev,
 			       const struct spi_config *config)
 {
-	const struct spi_stm32_config *cfg = DEV_CFG(dev);
-	struct spi_stm32_data *data = DEV_DATA(dev);
+	const struct spi_stm32_config *cfg = dev->config;
+	struct spi_stm32_data *data = dev->data;
 	const uint32_t scaler[] = {
 		LL_SPI_BAUDRATEPRESCALER_DIV2,
 		LL_SPI_BAUDRATEPRESCALER_DIV4,
@@ -593,7 +587,7 @@ static int spi_stm32_configure(const struct device *dev,
 static int spi_stm32_release(const struct device *dev,
 			     const struct spi_config *config)
 {
-	struct spi_stm32_data *data = DEV_DATA(dev);
+	struct spi_stm32_data *data = dev->data;
 
 	spi_context_unlock_unconditionally(&data->ctx);
 
@@ -606,8 +600,8 @@ static int transceive(const struct device *dev,
 		      const struct spi_buf_set *rx_bufs,
 		      bool asynchronous, struct k_poll_signal *signal)
 {
-	const struct spi_stm32_config *cfg = DEV_CFG(dev);
-	struct spi_stm32_data *data = DEV_DATA(dev);
+	const struct spi_stm32_config *cfg = dev->config;
+	struct spi_stm32_data *data = dev->data;
 	SPI_TypeDef *spi = cfg->spi;
 	int ret;
 
@@ -678,7 +672,7 @@ end:
 
 static int wait_dma_rx_tx_done(const struct device *dev)
 {
-	struct spi_stm32_data *data = DEV_DATA(dev);
+	struct spi_stm32_data *data = dev->data;
 	int res = -1;
 
 	while (1) {
@@ -705,8 +699,8 @@ static int transceive_dma(const struct device *dev,
 		      const struct spi_buf_set *rx_bufs,
 		      bool asynchronous, struct k_poll_signal *signal)
 {
-	const struct spi_stm32_config *cfg = DEV_CFG(dev);
-	struct spi_stm32_data *data = DEV_DATA(dev);
+	const struct spi_stm32_config *cfg = dev->config;
+	struct spi_stm32_data *data = dev->data;
 	SPI_TypeDef *spi = cfg->spi;
 	int ret;
 
@@ -818,7 +812,7 @@ static int spi_stm32_transceive(const struct device *dev,
 				const struct spi_buf_set *rx_bufs)
 {
 #ifdef CONFIG_SPI_STM32_DMA
-	struct spi_stm32_data *data = DEV_DATA(dev);
+	struct spi_stm32_data *data = dev->data;
 
 	if ((data->dma_tx.dma_dev != NULL)
 	 && (data->dma_rx.dma_dev != NULL)) {

--- a/drivers/spi/spi_mcux_dspi.c
+++ b/drivers/spi/spi_mcux_dspi.c
@@ -475,7 +475,7 @@ static void dma_callback(const struct device *dma_dev, void *callback_arg,
 	const struct device *dev = (struct device *)callback_arg;
 	const struct spi_mcux_config *config = dev->config;
 	SPI_Type *base = config->base;
-	struct spi_mcux_data *data = (struct spi_mcux_data *)dev->data;
+	struct spi_mcux_data *data = dev->data;
 
 	LOG_DBG("=dma call back @channel %d=", channel);
 

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -49,16 +49,6 @@ struct spi_nrfx_config {
 
 static void event_handler(const nrfx_spim_evt_t *p_event, void *p_context);
 
-static inline struct spi_nrfx_data *get_dev_data(const struct device *dev)
-{
-	return dev->data;
-}
-
-static inline const struct spi_nrfx_config *get_dev_config(const struct device *dev)
-{
-	return dev->config;
-}
-
 static inline nrf_spim_frequency_t get_nrf_spim_frequency(uint32_t frequency)
 {
 	/* Get the highest supported frequency not exceeding the requested one.
@@ -121,8 +111,8 @@ static inline nrf_spim_bit_order_t get_nrf_spim_bit_order(uint16_t operation)
 static int configure(const struct device *dev,
 		     const struct spi_config *spi_cfg)
 {
-	struct spi_nrfx_data *dev_data = get_dev_data(dev);
-	const struct spi_nrfx_config *dev_config = get_dev_config(dev);
+	struct spi_nrfx_data *dev_data = dev->data;
+	const struct spi_nrfx_config *dev_config = dev->config;
 	struct spi_context *ctx = &dev_data->ctx;
 	uint32_t max_freq = dev_config->max_freq;
 	nrfx_spim_config_t config;
@@ -217,8 +207,8 @@ static int configure(const struct device *dev,
  */
 static void anomaly_58_workaround_setup(const struct device *dev)
 {
-	struct spi_nrfx_data *dev_data = get_dev_data(dev);
-	const struct spi_nrfx_config *dev_config = get_dev_config(dev);
+	struct spi_nrfx_data *dev_data = dev->data;
+	const struct spi_nrfx_config *dev_config = dev->config;
 	NRF_SPIM_Type *spim = dev_config->spim.p_reg;
 	uint32_t ppi_ch = dev_data->ppi_ch;
 	uint32_t gpiote_ch = dev_data->gpiote_ch;
@@ -257,8 +247,8 @@ static void anomaly_58_workaround_clear(struct spi_nrfx_data *dev_data)
 
 static int anomaly_58_workaround_init(const struct device *dev)
 {
-	struct spi_nrfx_data *data = get_dev_data(dev);
-	const struct spi_nrfx_config *config = get_dev_config(dev);
+	struct spi_nrfx_data *data = dev->data;
+	const struct spi_nrfx_config *config = dev->config;
 	nrfx_err_t err_code;
 
 	data->anomaly_58_workaround_active = false;
@@ -285,8 +275,8 @@ static int anomaly_58_workaround_init(const struct device *dev)
 
 static void transfer_next_chunk(const struct device *dev)
 {
-	struct spi_nrfx_data *dev_data = get_dev_data(dev);
-	const struct spi_nrfx_config *dev_config = get_dev_config(dev);
+	struct spi_nrfx_data *dev_data = dev->data;
+	const struct spi_nrfx_config *dev_config = dev->config;
 	struct spi_context *ctx = &dev_data->ctx;
 	int error = 0;
 
@@ -370,7 +360,7 @@ static int transceive(const struct device *dev,
 		      bool asynchronous,
 		      struct k_poll_signal *signal)
 {
-	struct spi_nrfx_data *dev_data = get_dev_data(dev);
+	struct spi_nrfx_data *dev_data = dev->data;
 	int error;
 
 	spi_context_lock(&dev_data->ctx, asynchronous, signal, spi_cfg);
@@ -414,7 +404,7 @@ static int spi_nrfx_transceive_async(const struct device *dev,
 static int spi_nrfx_release(const struct device *dev,
 			    const struct spi_config *spi_cfg)
 {
-	struct spi_nrfx_data *dev_data = get_dev_data(dev);
+	struct spi_nrfx_data *dev_data = dev->data;
 
 	if (!spi_context_configured(&dev_data->ctx, spi_cfg)) {
 		return -EINVAL;
@@ -442,8 +432,8 @@ static int spim_nrfx_pm_action(const struct device *dev,
 			       enum pm_device_action action)
 {
 	int ret = 0;
-	struct spi_nrfx_data *data = get_dev_data(dev);
-	const struct spi_nrfx_config *config = get_dev_config(dev);
+	struct spi_nrfx_data *data = dev->data;
+	const struct spi_nrfx_config *config = dev->config;
 
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
@@ -500,15 +490,16 @@ static int spim_nrfx_pm_action(const struct device *dev,
 		": cannot enable both pull-up and pull-down on MISO line");    \
 	static int spi_##idx##_init(const struct device *dev)		       \
 	{								       \
+		struct spi_nrfx_data *data = dev->data;                        \
 		int err;                                                       \
 		IRQ_CONNECT(NRFX_IRQ_NUMBER_GET(NRF_SPIM##idx),		       \
 			    DT_IRQ(SPIM(idx), priority),		       \
 			    nrfx_isr, nrfx_spim_##idx##_irq_handler, 0);       \
-		err = spi_context_cs_configure_all(&get_dev_data(dev)->ctx);   \
+		err = spi_context_cs_configure_all(&data->ctx);                \
 		if (err < 0) {                                                 \
 			return err;                                            \
 		}                                                              \
-		spi_context_unlock_unconditionally(&get_dev_data(dev)->ctx);   \
+		spi_context_unlock_unconditionally(&data->ctx);                \
 		COND_CODE_1(CONFIG_SOC_NRF52832_ALLOW_SPIM_DESPITE_PAN_58,     \
 		(return anomaly_58_workaround_init(dev);),		       \
 		(return 0;))						       \

--- a/drivers/watchdog/wdt_gecko.c
+++ b/drivers/watchdog/wdt_gecko.c
@@ -41,10 +41,6 @@ struct wdt_gecko_data {
 };
 
 #define DEV_NAME(dev) ((dev)->name)
-#define DEV_DATA(dev) \
-	((struct wdt_gecko_data *)(dev)->data)
-#define DEV_CFG(dev) \
-	((const struct wdt_gecko_cfg *)(dev)->config)
 
 static uint32_t wdt_gecko_get_timeout_from_persel(int perSel)
 {
@@ -93,8 +89,8 @@ static int wdt_gecko_convert_window(uint32_t window, uint32_t period)
 
 static int wdt_gecko_setup(const struct device *dev, uint8_t options)
 {
-	const struct wdt_gecko_cfg *config = DEV_CFG(dev);
-	struct wdt_gecko_data *data = DEV_DATA(dev);
+	const struct wdt_gecko_cfg *config = dev->config;
+	struct wdt_gecko_data *data = dev->data;
 	WDOG_TypeDef *wdog = config->base;
 
 	if (!data->timeout_installed) {
@@ -130,8 +126,8 @@ static int wdt_gecko_setup(const struct device *dev, uint8_t options)
 
 static int wdt_gecko_disable(const struct device *dev)
 {
-	const struct wdt_gecko_cfg *config = DEV_CFG(dev);
-	struct wdt_gecko_data *data = DEV_DATA(dev);
+	const struct wdt_gecko_cfg *config = dev->config;
+	struct wdt_gecko_data *data = dev->data;
 	WDOG_TypeDef *wdog = config->base;
 
 	WDOGn_Enable(wdog, false);
@@ -144,7 +140,7 @@ static int wdt_gecko_disable(const struct device *dev)
 static int wdt_gecko_install_timeout(const struct device *dev,
 				     const struct wdt_timeout_cfg *cfg)
 {
-	struct wdt_gecko_data *data = DEV_DATA(dev);
+	struct wdt_gecko_data *data = dev->data;
 	data->wdog_config = (WDOG_Init_TypeDef)WDOG_INIT_DEFAULT;
 	uint32_t installed_timeout;
 
@@ -216,7 +212,7 @@ static int wdt_gecko_install_timeout(const struct device *dev,
 
 static int wdt_gecko_feed(const struct device *dev, int channel_id)
 {
-	const struct wdt_gecko_cfg *config = DEV_CFG(dev);
+	const struct wdt_gecko_cfg *config = dev->config;
 	WDOG_TypeDef *wdog = config->base;
 
 	if (channel_id != 0) {
@@ -232,8 +228,8 @@ static int wdt_gecko_feed(const struct device *dev, int channel_id)
 
 static void wdt_gecko_isr(const struct device *dev)
 {
-	const struct wdt_gecko_cfg *config = DEV_CFG(dev);
-	struct wdt_gecko_data *data = DEV_DATA(dev);
+	const struct wdt_gecko_cfg *config = dev->config;
+	struct wdt_gecko_data *data = dev->data;
 	WDOG_TypeDef *wdog = config->base;
 	uint32_t flags;
 
@@ -248,7 +244,7 @@ static void wdt_gecko_isr(const struct device *dev)
 
 static int wdt_gecko_init(const struct device *dev)
 {
-	const struct wdt_gecko_cfg *config = DEV_CFG(dev);
+	const struct wdt_gecko_cfg *config = dev->config;
 
 #ifdef CONFIG_WDT_DISABLE_AT_BOOT
 	/* Ignore any errors */

--- a/drivers/watchdog/wdt_nrfx.c
+++ b/drivers/watchdog/wdt_nrfx.c
@@ -22,19 +22,10 @@ struct wdt_nrfx_config {
 	nrfx_wdt_config_t config;
 };
 
-static inline struct wdt_nrfx_data *get_dev_data(const struct device *dev)
-{
-	return dev->data;
-}
-
-static inline const struct wdt_nrfx_config *get_dev_config(const struct device *dev)
-{
-	return dev->config;
-}
-
-
 static int wdt_nrf_setup(const struct device *dev, uint8_t options)
 {
+	const struct wdt_nrfx_config *config = dev->config;
+	struct wdt_nrfx_data *data = dev->data;
 	nrf_wdt_behaviour_t behaviour;
 
 	/* Activate all available options. Run in all cases. */
@@ -50,16 +41,16 @@ static int wdt_nrf_setup(const struct device *dev, uint8_t options)
 		behaviour &= ~NRF_WDT_BEHAVIOUR_RUN_HALT;
 	}
 
-	nrf_wdt_behaviour_set(get_dev_config(dev)->wdt.p_reg, behaviour);
+	nrf_wdt_behaviour_set(config->wdt.p_reg, behaviour);
 	/* The watchdog timer is driven by the LFCLK clock running at 32768 Hz.
 	 * The timeout value given in milliseconds needs to be converted here
 	 * to watchdog ticks.*/
 	nrf_wdt_reload_value_set(
-		get_dev_config(dev)->wdt.p_reg,
-		(uint32_t)(((uint64_t)get_dev_data(dev)->m_timeout * 32768U)
+		config->wdt.p_reg,
+		(uint32_t)(((uint64_t)data->m_timeout * 32768U)
 			   / 1000));
 
-	nrfx_wdt_enable(&get_dev_config(dev)->wdt);
+	nrfx_wdt_enable(&config->wdt);
 
 	return 0;
 }
@@ -74,6 +65,8 @@ static int wdt_nrf_disable(const struct device *dev)
 static int wdt_nrf_install_timeout(const struct device *dev,
 				   const struct wdt_timeout_cfg *cfg)
 {
+	const struct wdt_nrfx_config *config = dev->config;
+	struct wdt_nrfx_data *data = dev->data;
 	nrfx_err_t err_code;
 	nrfx_wdt_channel_id channel_id;
 
@@ -85,7 +78,7 @@ static int wdt_nrf_install_timeout(const struct device *dev,
 		return -EINVAL;
 	}
 
-	if (get_dev_data(dev)->m_allocated_channels == 0U) {
+	if (data->m_allocated_channels == 0U) {
 		/* According to relevant Product Specifications, watchdogs
 		 * in all nRF chips can use reload values (determining
 		 * the timeout) from range 0xF-0xFFFFFFFF given in 32768 Hz
@@ -97,12 +90,12 @@ static int wdt_nrf_install_timeout(const struct device *dev,
 		}
 
 		/* Save timeout value from first registered watchdog channel. */
-		get_dev_data(dev)->m_timeout = cfg->window.max;
-	} else if (cfg->window.max != get_dev_data(dev)->m_timeout) {
+		data->m_timeout = cfg->window.max;
+	} else if (cfg->window.max != data->m_timeout) {
 		return -EINVAL;
 	}
 
-	err_code = nrfx_wdt_channel_alloc(&get_dev_config(dev)->wdt,
+	err_code = nrfx_wdt_channel_alloc(&config->wdt,
 					  &channel_id);
 
 	if (err_code == NRFX_ERROR_NO_MEM) {
@@ -110,20 +103,23 @@ static int wdt_nrf_install_timeout(const struct device *dev,
 	}
 
 	if (cfg->callback != NULL) {
-		get_dev_data(dev)->m_callbacks[channel_id] = cfg->callback;
+		data->m_callbacks[channel_id] = cfg->callback;
 	}
 
-	get_dev_data(dev)->m_allocated_channels++;
+	data->m_allocated_channels++;
 	return channel_id;
 }
 
 static int wdt_nrf_feed(const struct device *dev, int channel_id)
 {
-	if (channel_id > get_dev_data(dev)->m_allocated_channels) {
+	const struct wdt_nrfx_config *config = dev->config;
+	struct wdt_nrfx_data *data = dev->data;
+
+	if (channel_id > data->m_allocated_channels) {
 		return -EINVAL;
 	}
 
-	nrfx_wdt_channel_feed(&get_dev_config(dev)->wdt,
+	nrfx_wdt_channel_feed(&config->wdt,
 			      (nrfx_wdt_channel_id)channel_id);
 
 	return 0;
@@ -138,13 +134,15 @@ static const struct wdt_driver_api wdt_nrfx_driver_api = {
 
 static void wdt_event_handler(const struct device *dev)
 {
+	const struct wdt_nrfx_config *config = dev->config;
+	struct wdt_nrfx_data *data = dev->data;
 	int i;
 
-	for (i = 0; i < get_dev_data(dev)->m_allocated_channels; ++i) {
-		if (nrf_wdt_request_status(get_dev_config(dev)->wdt.p_reg,
+	for (i = 0; i < data->m_allocated_channels; ++i) {
+		if (nrf_wdt_request_status(config->wdt.p_reg,
 					   (nrf_wdt_rr_register_t)i)) {
-			if (get_dev_data(dev)->m_callbacks[i]) {
-				get_dev_data(dev)->m_callbacks[i](dev, i);
+			if (data->m_callbacks[i]) {
+				data->m_callbacks[i](dev, i);
 			}
 		}
 	}
@@ -159,11 +157,12 @@ static void wdt_event_handler(const struct device *dev)
 	}								       \
 	static int wdt_##idx##_init(const struct device *dev)		       \
 	{								       \
+		const struct wdt_nrfx_config *config = dev->config;	       \
 		nrfx_err_t err_code;					       \
 		IRQ_CONNECT(DT_IRQN(WDT(idx)), DT_IRQ(WDT(idx), priority),     \
 			    nrfx_isr, nrfx_wdt_##idx##_irq_handler, 0);	       \
-		err_code = nrfx_wdt_init(&get_dev_config(dev)->wdt,	       \
-				 &get_dev_config(dev)->config,		       \
+		err_code = nrfx_wdt_init(&config->wdt,			       \
+				 &config->config,			       \
 				 wdt_##idx##_event_handler);		       \
 		if (err_code != NRFX_SUCCESS) {				       \
 			return -EBUSY;					       \

--- a/drivers/watchdog/wdt_sam.c
+++ b/drivers/watchdog/wdt_sam.c
@@ -43,13 +43,11 @@ struct wdt_sam_dev_data {
 
 static struct wdt_sam_dev_data wdt_sam_data = { 0 };
 
-#define DEV_CFG(dev) \
-	((const struct wdt_sam_dev_cfg *const)(dev)->config)
-
 static void wdt_sam_isr(const struct device *dev)
 {
+	const struct wdt_sam_dev_cfg *config = dev->config;
 	uint32_t wdt_sr;
-	Wdt *const wdt = DEV_CFG(dev)->regs;
+	Wdt *const wdt = config->regs;
 	struct wdt_sam_dev_data *data = dev->data;
 
 	/* Clear status bit to acknowledge interrupt by dummy read. */
@@ -83,7 +81,9 @@ int wdt_sam_convert_timeout(uint32_t timeout, uint32_t sclk)
 
 static int wdt_sam_disable(const struct device *dev)
 {
-	Wdt *const wdt = DEV_CFG(dev)->regs;
+	const struct wdt_sam_dev_cfg *config = dev->config;
+
+	Wdt *const wdt = config->regs;
 	struct wdt_sam_dev_data *data = dev->data;
 
 	/* since Watchdog mode register is 'write-once', we can't disable if
@@ -106,8 +106,9 @@ static int wdt_sam_disable(const struct device *dev)
 
 static int wdt_sam_setup(const struct device *dev, uint8_t options)
 {
+	const struct wdt_sam_dev_cfg *config = dev->config;
 
-	Wdt *const wdt = DEV_CFG(dev)->regs;
+	Wdt *const wdt = config->regs;
 	struct wdt_sam_dev_data *data = dev->data;
 
 	if (!data->timeout_valid) {
@@ -208,12 +209,14 @@ static int wdt_sam_install_timeout(const struct device *dev,
 
 static int wdt_sam_feed(const struct device *dev, int channel_id)
 {
+	const struct wdt_sam_dev_cfg *config = dev->config;
+
 	/*
 	 * On watchdog restart the Watchdog counter is immediately
 	 * reloaded/feeded with the 12-bit watchdog counter
 	 * value from WDT_MR and restarted
 	 */
-	Wdt *const wdt = DEV_CFG(dev)->regs;
+	Wdt *const wdt = config->regs;
 
 	wdt->WDT_CR |= WDT_CR_KEY_PASSWD | WDT_CR_WDRSTT;
 

--- a/drivers/watchdog/wdt_sam.c
+++ b/drivers/watchdog/wdt_sam.c
@@ -47,7 +47,7 @@ static void wdt_sam_isr(const struct device *dev)
 {
 	const struct wdt_sam_dev_cfg *config = dev->config;
 	uint32_t wdt_sr;
-	Wdt *const wdt = config->regs;
+	Wdt * const wdt = config->regs;
 	struct wdt_sam_dev_data *data = dev->data;
 
 	/* Clear status bit to acknowledge interrupt by dummy read. */
@@ -83,7 +83,7 @@ static int wdt_sam_disable(const struct device *dev)
 {
 	const struct wdt_sam_dev_cfg *config = dev->config;
 
-	Wdt *const wdt = config->regs;
+	Wdt * const wdt = config->regs;
 	struct wdt_sam_dev_data *data = dev->data;
 
 	/* since Watchdog mode register is 'write-once', we can't disable if
@@ -108,7 +108,7 @@ static int wdt_sam_setup(const struct device *dev, uint8_t options)
 {
 	const struct wdt_sam_dev_cfg *config = dev->config;
 
-	Wdt *const wdt = config->regs;
+	Wdt * const wdt = config->regs;
 	struct wdt_sam_dev_data *data = dev->data;
 
 	if (!data->timeout_valid) {
@@ -216,7 +216,7 @@ static int wdt_sam_feed(const struct device *dev, int channel_id)
 	 * reloaded/feeded with the 12-bit watchdog counter
 	 * value from WDT_MR and restarted
 	 */
-	Wdt *const wdt = config->regs;
+	Wdt * const wdt = config->regs;
 
 	wdt->WDT_CR |= WDT_CR_KEY_PASSWD | WDT_CR_WDRSTT;
 

--- a/drivers/watchdog/wdt_sifive.c
+++ b/drivers/watchdog/wdt_sifive.c
@@ -59,10 +59,9 @@ struct wdt_sifive_dev_data {
 	bool timeout_valid;
 };
 
-#define DEV_CFG(dev) \
-	((const struct wdt_sifive_device_config *const)(dev)->config)
 #define DEV_REG(dev) \
-	((struct wdt_sifive_reg *)(DEV_CFG(dev))->regs)
+	((struct wdt_sifive_reg *) \
+	 ((const struct wdt_sifive_device_config *const)(dev)->config)->regs)
 
 /**
  * @brief Set maximum length of timeout to watchdog

--- a/include/drivers/dma.h
+++ b/include/drivers/dma.h
@@ -450,7 +450,7 @@ static inline int z_impl_dma_request_channel(const struct device *dev,
 	const struct dma_driver_api *api =
 		(const struct dma_driver_api *)dev->api;
 	/* dma_context shall be the first one in dev data */
-	struct dma_context *dma_ctx = (struct dma_context *)dev->data;
+	struct dma_context *dma_ctx = dev->data;
 
 	if (dma_ctx->magic != DMA_MAGIC) {
 		return channel;
@@ -486,7 +486,7 @@ __syscall void dma_release_channel(const struct device *dev,
 static inline void z_impl_dma_release_channel(const struct device *dev,
 					      uint32_t channel)
 {
-	struct dma_context *dma_ctx = (struct dma_context *)dev->data;
+	struct dma_context *dma_ctx = dev->data;
 
 	if (dma_ctx->magic != DMA_MAGIC) {
 		return;

--- a/samples/userspace/prod_consumer/src/sample_driver_foo.c
+++ b/samples/userspace/prod_consumer/src/sample_driver_foo.c
@@ -20,9 +20,6 @@ LOG_MODULE_REGISTER(sample_driver);
  * The driver sets up a timer which is used to fake interrupts.
  */
 
-#define DEV_DATA(dev) \
-	((struct sample_driver_foo_dev_data *const)(dev)->data)
-
 struct sample_driver_foo_dev_data {
 	const struct device *dev;
 	sample_driver_callback_t cb;
@@ -42,7 +39,7 @@ static int sample_driver_foo_set_callback(const struct device *dev,
 					  sample_driver_callback_t cb,
 					  void *context)
 {
-	struct sample_driver_foo_dev_data *data = DEV_DATA(dev);
+	struct sample_driver_foo_dev_data *data = dev->data;
 	int key = irq_lock();
 
 	data->cb_context = context;
@@ -54,7 +51,7 @@ static int sample_driver_foo_set_callback(const struct device *dev,
 
 static int sample_driver_foo_state_set(const struct device *dev, bool active)
 {
-	struct sample_driver_foo_dev_data *data = DEV_DATA(dev);
+	struct sample_driver_foo_dev_data *data = dev->data;
 
 	LOG_DBG("%s(%p, %d)", __func__, dev, active);
 
@@ -98,7 +95,7 @@ static void sample_driver_timer_cb(struct k_timer *timer)
 
 static int sample_driver_foo_init(const struct device *dev)
 {
-	struct sample_driver_foo_dev_data *data = DEV_DATA(dev);
+	struct sample_driver_foo_dev_data *data = dev->data;
 
 	k_timer_init(&data->timer, sample_driver_timer_cb, NULL);
 

--- a/subsys/net/lib/capture/capture.c
+++ b/subsys/net/lib/capture/capture.c
@@ -33,9 +33,6 @@ LOG_MODULE_REGISTER(net_capture, CONFIG_NET_CAPTURE_LOG_LEVEL);
 #define DEBUG_TX 0
 #endif
 
-#define DEV_DATA(dev) \
-	((struct net_capture *)(dev)->data)
-
 static K_MUTEX_DEFINE(lock);
 
 NET_PKT_SLAB_DEFINE(capture_pkts, CONFIG_NET_CAPTURE_PKT_COUNT);
@@ -450,7 +447,7 @@ fail:
 
 static int capture_cleanup(const struct device *dev)
 {
-	struct net_capture *ctx = DEV_DATA(dev);
+	struct net_capture *ctx = dev->data;
 
 	(void)net_capture_disable(dev);
 	(void)net_virtual_interface_attach(ctx->tunnel_iface, NULL);
@@ -469,14 +466,14 @@ static int capture_cleanup(const struct device *dev)
 
 static bool capture_is_enabled(const struct device *dev)
 {
-	struct net_capture *ctx = DEV_DATA(dev);
+	struct net_capture *ctx = dev->data;
 
 	return ctx->is_enabled ? true : false;
 }
 
 static int capture_enable(const struct device *dev, struct net_if *iface)
 {
-	struct net_capture *ctx = DEV_DATA(dev);
+	struct net_capture *ctx = dev->data;
 
 	if (ctx->is_enabled) {
 		return -EALREADY;
@@ -499,7 +496,7 @@ static int capture_enable(const struct device *dev, struct net_if *iface)
 
 static int capture_disable(const struct device *dev)
 {
-	struct net_capture *ctx = DEV_DATA(dev);
+	struct net_capture *ctx = dev->data;
 
 	ctx->capture_iface = NULL;
 	ctx->is_enabled = false;
@@ -565,7 +562,7 @@ out:
 
 static int capture_dev_init(const struct device *dev)
 {
-	struct net_capture *ctx = DEV_DATA(dev);
+	struct net_capture *ctx = dev->data;
 
 	k_mutex_lock(&lock, K_FOREVER);
 
@@ -583,7 +580,7 @@ static int capture_dev_init(const struct device *dev)
 static int capture_send(const struct device *dev, struct net_if *iface,
 			struct net_pkt *pkt)
 {
-	struct net_capture *ctx = DEV_DATA(dev);
+	struct net_capture *ctx = dev->data;
 	enum net_verdict verdict;
 	struct net_pkt *ip;
 	int ret;

--- a/subsys/testsuite/busy_sim/busy_sim.c
+++ b/subsys/testsuite/busy_sim/busy_sim.c
@@ -48,21 +48,11 @@ static const struct busy_sim_config sim_config = {
 static struct busy_sim_data sim_data;
 static const struct device *busy_sim_dev = DEVICE_DT_GET_ONE(vnd_busy_sim);
 
-static inline struct busy_sim_data *get_dev_data(const struct device *dev)
-{
-	return dev->data;
-}
-
-static inline const struct busy_sim_config *get_dev_config(const struct device *dev)
-{
-	return dev->config;
-}
-
 static void rng_pool_work_handler(struct k_work *work)
 {
 	uint8_t *buf;
 	uint32_t len;
-	const struct busy_sim_config *config = get_dev_config(busy_sim_dev);
+	const struct busy_sim_config *config = busy_sim_dev->config;
 
 	len = ring_buf_put_claim(&rnd_rbuf, &buf, BUFFER_SIZE - 1);
 	if (len) {
@@ -80,7 +70,7 @@ static void rng_pool_work_handler(struct k_work *work)
 
 static uint32_t get_timeout(bool idle)
 {
-	struct busy_sim_data *data = get_dev_data(busy_sim_dev);
+	struct busy_sim_data *data = busy_sim_dev->data;
 	uint32_t avg = idle ? data->idle_avg : data->active_avg;
 	uint32_t delta = idle ? data->idle_delta : data->active_delta;
 	uint16_t rand_val;
@@ -109,8 +99,8 @@ static void counter_alarm_callback(const struct device *dev,
 				   void *user_data)
 {
 	int err;
-	const struct busy_sim_config *config = get_dev_config(busy_sim_dev);
-	struct busy_sim_data *data = get_dev_data(busy_sim_dev);
+	const struct busy_sim_config *config = busy_sim_dev->config;
+	struct busy_sim_data *data = busy_sim_dev->data;
 
 	data->alarm_cfg.ticks = get_timeout(true);
 
@@ -140,8 +130,8 @@ void busy_sim_start(uint32_t active_avg, uint32_t active_delta,
 		    uint32_t idle_avg, uint32_t idle_delta, busy_sim_cb_t cb)
 {
 	int err;
-	const struct busy_sim_config *config = get_dev_config(busy_sim_dev);
-	struct busy_sim_data *data = get_dev_data(busy_sim_dev);
+	const struct busy_sim_config *config = busy_sim_dev->config;
+	struct busy_sim_data *data = busy_sim_dev->data;
 
 	data->cb = cb;
 	data->active_avg = active_avg;
@@ -165,7 +155,7 @@ void busy_sim_start(uint32_t active_avg, uint32_t active_delta,
 void busy_sim_stop(void)
 {
 	int err;
-	const struct busy_sim_config *config = get_dev_config(busy_sim_dev);
+	const struct busy_sim_config *config = busy_sim_dev->config;
 
 	if (!IS_ENABLED(CONFIG_XOSHIRO_RANDOM_GENERATOR)) {
 		k_work_cancel(&work);
@@ -178,8 +168,8 @@ void busy_sim_stop(void)
 static int busy_sim_init(const struct device *dev)
 {
 	uint32_t freq;
-	const struct busy_sim_config *config = get_dev_config(dev);
-	struct busy_sim_data *data = get_dev_data(dev);
+	const struct busy_sim_config *config = dev->config;
+	struct busy_sim_data *data = dev->data;
 
 	if ((config->pin_spec.port && !device_is_ready(config->pin_spec.port)) ||
 	    !device_is_ready(config->counter) ||

--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -59,9 +59,6 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(usb_cdc_acm);
 
-#define DEV_DATA(dev)						\
-	((struct cdc_acm_dev_data_t * const)(dev)->data)
-
 /* 115200bps, no parity, 1 stop bit, 8bit char */
 #define CDC_ACM_DEFAULT_BAUDRATE {sys_cpu_to_le32(115200), 0, 0, 8}
 
@@ -462,7 +459,7 @@ static void cdc_acm_irq_callback_work_handler(struct k_work *work)
  */
 static int cdc_acm_init(const struct device *dev)
 {
-	struct cdc_acm_dev_data_t * const dev_data = DEV_DATA(dev);
+	struct cdc_acm_dev_data_t * const dev_data = dev->data;
 	int ret = 0;
 
 	dev_data->common.dev = dev;
@@ -489,7 +486,7 @@ static int cdc_acm_init(const struct device *dev)
 static int cdc_acm_fifo_fill(const struct device *dev,
 			     const uint8_t *tx_data, int len)
 {
-	struct cdc_acm_dev_data_t * const dev_data = DEV_DATA(dev);
+	struct cdc_acm_dev_data_t * const dev_data = dev->data;
 	size_t wrote;
 
 	LOG_DBG("dev_data %p len %d tx_ringbuf space %u",
@@ -526,7 +523,7 @@ static int cdc_acm_fifo_fill(const struct device *dev,
 static int cdc_acm_fifo_read(const struct device *dev, uint8_t *rx_data,
 			     const int size)
 {
-	struct cdc_acm_dev_data_t * const dev_data = DEV_DATA(dev);
+	struct cdc_acm_dev_data_t * const dev_data = dev->data;
 	uint32_t len;
 
 	LOG_DBG("dev %p size %d rx_ringbuf space %u",
@@ -548,7 +545,7 @@ static int cdc_acm_fifo_read(const struct device *dev, uint8_t *rx_data,
  */
 static void cdc_acm_irq_tx_enable(const struct device *dev)
 {
-	struct cdc_acm_dev_data_t * const dev_data = DEV_DATA(dev);
+	struct cdc_acm_dev_data_t * const dev_data = dev->data;
 
 	dev_data->tx_irq_ena = true;
 
@@ -564,7 +561,7 @@ static void cdc_acm_irq_tx_enable(const struct device *dev)
  */
 static void cdc_acm_irq_tx_disable(const struct device *dev)
 {
-	struct cdc_acm_dev_data_t * const dev_data = DEV_DATA(dev);
+	struct cdc_acm_dev_data_t * const dev_data = dev->data;
 
 	dev_data->tx_irq_ena = false;
 }
@@ -578,7 +575,7 @@ static void cdc_acm_irq_tx_disable(const struct device *dev)
  */
 static int cdc_acm_irq_tx_ready(const struct device *dev)
 {
-	struct cdc_acm_dev_data_t * const dev_data = DEV_DATA(dev);
+	struct cdc_acm_dev_data_t * const dev_data = dev->data;
 
 	if (dev_data->tx_irq_ena && dev_data->tx_ready) {
 		return 1;
@@ -594,7 +591,7 @@ static int cdc_acm_irq_tx_ready(const struct device *dev)
  */
 static void cdc_acm_irq_rx_enable(const struct device *dev)
 {
-	struct cdc_acm_dev_data_t * const dev_data = DEV_DATA(dev);
+	struct cdc_acm_dev_data_t * const dev_data = dev->data;
 
 	dev_data->rx_irq_ena = true;
 
@@ -610,7 +607,7 @@ static void cdc_acm_irq_rx_enable(const struct device *dev)
  */
 static void cdc_acm_irq_rx_disable(const struct device *dev)
 {
-	struct cdc_acm_dev_data_t * const dev_data = DEV_DATA(dev);
+	struct cdc_acm_dev_data_t * const dev_data = dev->data;
 
 	dev_data->rx_irq_ena = false;
 }
@@ -624,7 +621,7 @@ static void cdc_acm_irq_rx_disable(const struct device *dev)
  */
 static int cdc_acm_irq_rx_ready(const struct device *dev)
 {
-	struct cdc_acm_dev_data_t * const dev_data = DEV_DATA(dev);
+	struct cdc_acm_dev_data_t * const dev_data = dev->data;
 
 	if (dev_data->rx_ready) {
 		return 1;
@@ -642,7 +639,7 @@ static int cdc_acm_irq_rx_ready(const struct device *dev)
  */
 static int cdc_acm_irq_is_pending(const struct device *dev)
 {
-	struct cdc_acm_dev_data_t * const dev_data = DEV_DATA(dev);
+	struct cdc_acm_dev_data_t * const dev_data = dev->data;
 
 	if (dev_data->tx_ready && dev_data->tx_irq_ena) {
 		return 1;
@@ -677,7 +674,7 @@ static void cdc_acm_irq_callback_set(const struct device *dev,
 				     uart_irq_callback_user_data_t cb,
 				     void *cb_data)
 {
-	struct cdc_acm_dev_data_t * const dev_data = DEV_DATA(dev);
+	struct cdc_acm_dev_data_t * const dev_data = dev->data;
 
 	dev_data->cb = cb;
 	dev_data->cb_data = cb_data;
@@ -687,7 +684,7 @@ static void cdc_acm_irq_callback_set(const struct device *dev,
 int cdc_acm_dte_rate_callback_set(const struct device *dev,
 				  cdc_dte_rate_callback_t callback)
 {
-	struct cdc_acm_dev_data_t *const dev_data = DEV_DATA(dev);
+	struct cdc_acm_dev_data_t *const dev_data = dev->data;
 
 	if (dev->api != &cdc_acm_driver_api) {
 		return -EINVAL;
@@ -711,7 +708,7 @@ int cdc_acm_dte_rate_callback_set(const struct device *dev,
  */
 static void cdc_acm_baudrate_set(const struct device *dev, uint32_t baudrate)
 {
-	struct cdc_acm_dev_data_t * const dev_data = DEV_DATA(dev);
+	struct cdc_acm_dev_data_t * const dev_data = dev->data;
 
 	dev_data->line_coding.dwDTERate = sys_cpu_to_le32(baudrate);
 }
@@ -731,7 +728,7 @@ static void cdc_acm_baudrate_set(const struct device *dev, uint32_t baudrate)
 static int cdc_acm_send_notification(const struct device *dev,
 				     uint16_t serial_state)
 {
-	struct cdc_acm_dev_data_t * const dev_data = DEV_DATA(dev);
+	struct cdc_acm_dev_data_t * const dev_data = dev->data;
 	struct usb_cfg_data * const cfg = (void *)dev->config;
 	struct cdc_acm_notification notification;
 	uint32_t cnt = 0U;
@@ -773,7 +770,7 @@ static int cdc_acm_send_notification(const struct device *dev,
 static int cdc_acm_line_ctrl_set(const struct device *dev,
 				 uint32_t ctrl, uint32_t val)
 {
-	struct cdc_acm_dev_data_t * const dev_data = DEV_DATA(dev);
+	struct cdc_acm_dev_data_t * const dev_data = dev->data;
 
 	switch (ctrl) {
 	case USB_CDC_LINE_CTRL_BAUD_RATE:
@@ -854,7 +851,7 @@ static int cdc_acm_line_ctrl_set(const struct device *dev,
 static int cdc_acm_line_ctrl_get(const struct device *dev,
 				 uint32_t ctrl, uint32_t *val)
 {
-	struct cdc_acm_dev_data_t * const dev_data = DEV_DATA(dev);
+	struct cdc_acm_dev_data_t * const dev_data = dev->data;
 
 	switch (ctrl) {
 	case UART_LINE_CTRL_BAUD_RATE:

--- a/tests/drivers/i2c/i2c_slave_api/common/i2c_virtual.c
+++ b/tests/drivers/i2c/i2c_slave_api/common/i2c_virtual.c
@@ -15,8 +15,6 @@
 #include <logging/log.h>
 LOG_MODULE_DECLARE(main);
 
-#define DEV_DATA(dev) ((struct i2c_virtual_data * const)(dev)->data)
-
 struct i2c_virtual_data {
 	sys_slist_t slaves;
 };
@@ -50,7 +48,7 @@ static struct i2c_slave_config *find_address(struct i2c_virtual_data *data,
 int i2c_virtual_slave_register(const struct device *dev,
 			       struct i2c_slave_config *config)
 {
-	struct i2c_virtual_data *data = DEV_DATA(dev);
+	struct i2c_virtual_data *data = dev->data;
 
 	if (!config) {
 		return -EINVAL;
@@ -71,7 +69,7 @@ int i2c_virtual_slave_register(const struct device *dev,
 int i2c_virtual_slave_unregister(const struct device *dev,
 				 struct i2c_slave_config *config)
 {
-	struct i2c_virtual_data *data = DEV_DATA(dev);
+	struct i2c_virtual_data *data = dev->data;
 
 	if (!config) {
 		return -EINVAL;
@@ -151,7 +149,7 @@ static int i2c_virtual_msg_read(const struct device *dev, struct i2c_msg *msg,
 static int i2c_virtual_transfer(const struct device *dev, struct i2c_msg *msg,
 				uint8_t num_msgs, uint16_t slave)
 {
-	struct i2c_virtual_data *data = DEV_DATA(dev);
+	struct i2c_virtual_data *data = dev->data;
 	struct i2c_msg *current, *next;
 	struct i2c_slave_config *cfg;
 	bool is_write = false;
@@ -215,7 +213,7 @@ static const struct i2c_driver_api api_funcs = {
 
 static int i2c_virtual_init(const struct device *dev)
 {
-	struct i2c_virtual_data *data = DEV_DATA(dev);
+	struct i2c_virtual_data *data = dev->data;
 
 	sys_slist_init(&data->slaves);
 

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -1435,21 +1435,14 @@ static const struct gpio_driver_api test_api;
 
 DT_INST_FOREACH_STATUS_OKAY(TEST_GPIO_INIT)
 
-static inline struct test_gpio_data *to_data(const struct device *dev)
-{
-	return (struct test_gpio_data *)dev->data;
-}
-
-static inline const struct test_gpio_info *to_info(const struct device *dev)
-{
-	return (const struct test_gpio_info *)dev->config;
-}
-
 static void test_devices(void)
 {
 	const struct device *devs[3];
 	int i = 0;
 	const struct device *dev_abcd;
+	struct test_gpio_data *data_dev0;
+	struct test_gpio_data *data_dev1;
+	const struct test_gpio_info *config_abdc;
 
 	zassert_equal(DT_NUM_INST_STATUS_OKAY(vnd_gpio_device), 2, "");
 
@@ -1466,19 +1459,23 @@ static void test_devices(void)
 		i++;
 	}
 
+	data_dev0 = devs[0]->data;
+	data_dev1 = devs[1]->data;
+
 	zassert_not_null(devs[0], "");
 	zassert_not_null(devs[1], "");
 	zassert_true(devs[2] == NULL, "");
 
-	zassert_true(to_data(devs[0])->is_gpio_ctlr, "");
-	zassert_true(to_data(devs[1])->is_gpio_ctlr, "");
-	zassert_true(to_data(devs[0])->init_called, "");
-	zassert_true(to_data(devs[1])->init_called, "");
+	zassert_true(data_dev0->is_gpio_ctlr, "");
+	zassert_true(data_dev1->is_gpio_ctlr, "");
+	zassert_true(data_dev0->init_called, "");
+	zassert_true(data_dev1->init_called, "");
 
 	dev_abcd = device_get_binding(DT_LABEL(TEST_ABCD1234));
+	config_abdc = dev_abcd->config;
 	zassert_not_null(dev_abcd, "");
-	zassert_equal(to_info(dev_abcd)->reg_addr, 0xabcd1234, "");
-	zassert_equal(to_info(dev_abcd)->reg_len, 0x500, "");
+	zassert_equal(config_abdc->reg_addr, 0xabcd1234, "");
+	zassert_equal(config_abdc->reg_len, 0x500, "");
 }
 
 static void test_cs_gpios(void)


### PR DESCRIPTION
Make device driver data and configuration access more uniform accross drivers.

NOTE: a few other issues have been fixed as a result of the changes, e.g. many drivers dropping config `const` qualifier.

Fixes #37616