### PR TITLE
cmake: Don't try to convert generator expressions

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -87,26 +87,12 @@ endfunction()
 
 # https://cmake.org/cmake/help/latest/command/target_include_directories.html
 function(zephyr_include_directories)
-  foreach(arg ${ARGV})
-    if(IS_ABSOLUTE ${arg})
-      set(path ${arg})
-    else()
-      set(path ${CMAKE_CURRENT_SOURCE_DIR}/${arg})
-    endif()
-    target_include_directories(zephyr_interface INTERFACE ${path})
-  endforeach()
+  target_include_directories(zephyr_interface INTERFACE ${ARGV})
 endfunction()
 
 # https://cmake.org/cmake/help/latest/command/target_include_directories.html
 function(zephyr_system_include_directories)
-  foreach(arg ${ARGV})
-    if(IS_ABSOLUTE ${arg})
-      set(path ${arg})
-    else()
-      set(path ${CMAKE_CURRENT_SOURCE_DIR}/${arg})
-    endif()
-    target_include_directories(zephyr_interface SYSTEM INTERFACE ${path})
-  endforeach()
+  target_include_directories(zephyr_interface SYSTEM INTERFACE ${ARGV})
 endfunction()
 
 # https://cmake.org/cmake/help/latest/command/target_compile_definitions.html


### PR DESCRIPTION
When generator expressions are passed to zephyr_include_directories it
tries to convert it to an absolute path, but this will result in the
wrong path.

With this change we skip the conversion when a generator expression is
detected and leave it to the user to only use generator expressions
with absolute paths.

This change allows generator expressions to be used.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>