### PR TITLE
drivers: adc: atmel_sam: Add DMA support

### DIFF
--- a/drivers/adc/Kconfig.sam_afec
+++ b/drivers/adc/Kconfig.sam_afec
@@ -1,6 +1,7 @@
 # ADC configuration options
 
 # Copyright (c) 2017 comsuisse AG
+# Copyright (c) 2022 RIC Electronics
 # SPDX-License-Identifier: Apache-2.0
 
 config ADC_SAM_AFEC
@@ -9,3 +10,30 @@ config ADC_SAM_AFEC
 	help
 	  Enable Atmel SAM MCU Family Analog-to-Digital Converter (ADC) driver
 	  based on AFEC module.
+if ADC_SAM_AFEC
+
+config ADC_SAM_AFEC_DMA
+	bool "Use DMA for the transfer"
+	depends on DMA
+	help
+	  When enabled DMA will be used for the transfer. Note that
+	  currently DMA requires a hardware trigger to be configured.
+	  Please refer to the driver binding file and the datasheet
+	  for more information on how to configure a hardware trigger.
+
+config ADC_SAM_AFEC_TAG_CHANNEL
+	bool "When using DMA include a channel tag"
+	depends on ADC_SAM_AFEC_DMA
+	help
+	  When DMA is enabled optionally change the data width to 32-bits
+	  and include a channel tag. This makes it easy to validate which
+	  channel a sample came from.
+
+	  Note that data caching is enabled by default so the cache must
+	  be invalidated after reading to get the correct results.
+	  For example:
+
+	  adc_read_async(adc0, &seq, &signal);
+	  SCB_InvalidateDCache_by_Addr(buffer, sizeof(buffer));
+
+endif

--- a/dts/bindings/adc/atmel,sam-afec.yaml
+++ b/dts/bindings/adc/atmel,sam-afec.yaml
@@ -31,5 +31,53 @@ properties:
         For example the I2C on SAME7x would be
            pinctrl-0 = <&pa8b_afec0_adtrg>;
 
+    dmas:
+      required: false
+      description: |
+        DMA specifiers.  Each specifier will have a phandle
+        reference to the dma controller, the channel number, and peripheral
+        trigger source.
+
+        For example dmas for ADC0 channel 0:
+          dmas = <&xdmac 0 DMA_PERID_AFEC0_RX>;
+
+    trigger-source:
+      type: int
+      required: false
+      default: 0
+      enum:
+        - 0 # Software driven
+        - 1 # TIOA output of Timer Counter channel 0 for AFEC0
+            # TIOA output of Timer Counter channel 3 for AFEC1
+        - 2 # TIOA output of Timer Counter channel 1 for AFEC0
+            # TIOA output of Timer Counter channel 4 for AFEC1
+        - 3 # TIOA output of Timer Counter channel 2 for AFEC0
+            # TIOA output of Timer Counter channel 5 for AFEC1
+        - 4 # PWM0 event line 0 for AFEC0
+            # PWM1 event line 0 for AFEC1
+        - 5 # PWM0 event line 1 for AFEC0
+            # PWM1 event line 1 for AFEC1
+        - 6 # Analog Comparator
+      description: |
+        The trigger source of the ADC conversions. If a hardware
+        source is selected, the hardware pheripheral will need
+        to be setup separately to generate the event. This driver
+        only configures the AFEC side. Please refer to the
+        datasheet for more information. Also note that only the
+        timer has been tested as a trigger source. Ther TC channels
+        0-2 are on TC0, 3-5 are on TC1. So those timers have to be
+        used.
+
+    tc:
+      type: phandle
+      required: false
+      description: |
+        When trigger-source 1, 2 or 3 is configured then this
+        is the phandle of the timer used for triggering. The timer
+        needs to be separately configured to trigger the conversion.
+        For details how to do that refer to the timer driver and
+        datasheet.
+        e.g tc = <&tc0>;
+
 io-channel-cells:
     - input


### PR DESCRIPTION
This patch adds DMA support for the atmel sam s70/e70/v70/v71.
This patch requires that a hardware ADC trigger be configured.
The only hardware trigger that was tested was the timer counter.

Tested on a custom sams70 board.

Signed-off-by: Marius Scholtz <mariuss@ricelectronics.com>