### PR TITLE
soc: mxrt10xx: Update the clock init code

### DIFF
--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1010
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1010
@@ -24,6 +24,9 @@ config AHB_DIV
 config IPG_DIV
 	default 3
 
+config DCDC_VALUE
+	default 0x12
+
 config GPIO
 	default y
 

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1015
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1015
@@ -20,6 +20,9 @@ config AHB_DIV
 config IPG_DIV
 	default 3
 
+config DCDC_VALUE
+	default 0x12
+
 config GPIO
 	default y
 

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1021
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1021
@@ -20,6 +20,9 @@ config AHB_DIV
 config IPG_DIV
 	default 3
 
+config DCDC_VALUE
+	default 0x12
+
 config GPIO
 	default y
 

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1024
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1024
@@ -20,6 +20,9 @@ config AHB_DIV
 config IPG_DIV
 	default 3
 
+config DCDC_VALUE
+	default 0x12
+
 config GPIO
 	default y
 

--- a/soc/arm/nxp_imx/rt/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt/Kconfig.soc
@@ -22,8 +22,6 @@ config SOC_MIMXRT1011
 	select HAS_MCUX_GPT
 	select HAS_MCUX_TRNG
 	select CPU_HAS_ARM_MPU
-	select INIT_SYS_PLL
-	select INIT_USB1_PLL
 	select INIT_ENET_PLL
 	select HAS_MCUX_USB_EHCI
 	select HAS_MCUX_USDHC1
@@ -46,8 +44,6 @@ config SOC_MIMXRT1015
 	select HAS_MCUX_TRNG
 	select CPU_HAS_FPU_DOUBLE_PRECISION
 	select CPU_HAS_ARM_MPU
-	select INIT_SYS_PLL
-	select INIT_USB1_PLL
 	select INIT_ENET_PLL
 	select HAS_MCUX_USB_EHCI
 	select HAS_MCUX_USDHC1
@@ -72,8 +68,6 @@ config SOC_MIMXRT1021
 	select HAS_MCUX_TRNG
 	select CPU_HAS_FPU_DOUBLE_PRECISION
 	select CPU_HAS_ARM_MPU
-	select INIT_SYS_PLL
-	select INIT_USB1_PLL
 	select INIT_ENET_PLL
 	select HAS_MCUX_USB_EHCI
 	select HAS_MCUX_USDHC1
@@ -100,8 +94,6 @@ config SOC_MIMXRT1024
 	select HAS_MCUX_TRNG
 	select CPU_HAS_FPU_DOUBLE_PRECISION
 	select CPU_HAS_ARM_MPU
-	select INIT_SYS_PLL
-	select INIT_USB1_PLL
 	select INIT_ENET_PLL
 	select HAS_MCUX_USB_EHCI
 	select HAS_MCUX_USDHC1
@@ -129,8 +121,6 @@ config SOC_MIMXRT1051
 	select CPU_HAS_FPU_DOUBLE_PRECISION
 	select CPU_HAS_ARM_MPU
 	select INIT_ARM_PLL
-	select INIT_SYS_PLL
-	select INIT_USB1_PLL
 	select HAS_MCUX_USB_EHCI
 	select HAS_MCUX_USDHC1
 	select HAS_MCUX_USDHC2
@@ -158,8 +148,6 @@ config SOC_MIMXRT1052
 	select CPU_HAS_FPU_DOUBLE_PRECISION
 	select CPU_HAS_ARM_MPU
 	select INIT_ARM_PLL
-	select INIT_SYS_PLL
-	select INIT_USB1_PLL
 	select INIT_VIDEO_PLL if DISPLAY_MCUX_ELCDIF
 	select INIT_ENET_PLL if NET_L2_ETHERNET
 	select HAS_MCUX_USB_EHCI
@@ -189,8 +177,6 @@ config SOC_MIMXRT1061
 	select CPU_HAS_FPU_DOUBLE_PRECISION
 	select CPU_HAS_ARM_MPU
 	select INIT_ARM_PLL
-	select INIT_SYS_PLL
-	select INIT_USB1_PLL
 	select HAS_MCUX_USB_EHCI
 	select HAS_MCUX_USDHC1
 	select HAS_MCUX_USDHC2
@@ -219,8 +205,6 @@ config SOC_MIMXRT1062
 	select CPU_HAS_FPU_DOUBLE_PRECISION
 	select CPU_HAS_ARM_MPU
 	select INIT_ARM_PLL
-	select INIT_SYS_PLL
-	select INIT_USB1_PLL
 	select INIT_VIDEO_PLL if DISPLAY_MCUX_ELCDIF
 	select INIT_ENET_PLL if NET_L2_ETHERNET
 	select HAS_MCUX_USB_EHCI
@@ -254,8 +238,6 @@ config SOC_MIMXRT1064
 	select CPU_HAS_FPU_DOUBLE_PRECISION
 	select CPU_HAS_ARM_MPU
 	select INIT_ARM_PLL
-	select INIT_SYS_PLL
-	select INIT_USB1_PLL
 	select INIT_VIDEO_PLL if DISPLAY_MCUX_ELCDIF
 	select INIT_ENET_PLL if NET_L2_ETHERNET
 	select HAS_MCUX_USB_EHCI
@@ -550,12 +532,6 @@ config SOC_SERIES_IMX_RT11XX
 config INIT_ARM_PLL
 	bool "Initialize ARM PLL"
 
-config INIT_SYS_PLL
-	bool "Initialize SYS PLL"
-
-config INIT_USB1_PLL
-	bool "Initialize USB1 PLL"
-
 config INIT_VIDEO_PLL
 	bool "Initialize Video PLL"
 
@@ -584,6 +560,10 @@ config IPG_DIV
 	int "IPG clock divider"
 	range 0 3
 	default 0
+
+config DCDC_VALUE
+	hex "DCDC value for VDD_SOC"
+	default 0x13
 
 config ADJUST_DCDC
 	bool "Adjust internal DCDC output"


### PR DESCRIPTION
1. Setup VDD_SOC with the appropriate setting depending on the SoC
2. Do not configure PLL_SYS and PLL_USB. These are already configured by the ROM code using the DCD
3. Fix setting for USDHC clock

Fixes #41890