### PR TITLE
tests/kernel/queue: Coherence fixes for tests/kernel/queue

### DIFF
--- a/tests/kernel/queue/src/test_queue_fail.c
+++ b/tests/kernel/queue/src/test_queue_fail.c
@@ -58,9 +58,9 @@ static void tThread_entry(void *p1, void *p2, void *p3)
  */
 void test_queue_append_list_error(void)
 {
-	qdata_t data_l[2];
+	static qdata_t data_l[2];
 	static struct k_queue queue;
-	qdata_t *head = NULL, *tail = &data_l[1];
+	static qdata_t *head = NULL, *tail = &data_l[1];
 
 	k_queue_init(&queue);
 	memset(data_l, 0, sizeof(data_l));


### PR DESCRIPTION
When CONFIG_KERNEL_COHERENCE=y, it's not legal to place shared data
(like the queue elements in this test case) on the stack, because that
memory is incoherent with respect to other CPUs in the system.

Make them static (another option would have been to mark the test case
1cpu).

Fixes #41860

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>