### PR TITLE
stm32g4: adc: Add DTS for ADC345

### DIFF
--- a/dts/arm/st/g4/stm32g473.dtsi
+++ b/dts/arm/st/g4/stm32g473.dtsi
@@ -58,5 +58,35 @@
 		dmamux1: dmamux@40020800 {
 			dma-channels = <16>;
 		};
+
+		adc3: adc@50000400 {
+			compatible = "st,stm32-adc";
+			reg = <0x50000400 0x100>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00004000>;
+			interrupts = <47 0>;
+			status = "disabled";
+			label = "ADC_3";
+			#io-channel-cells = <1>;
+		};
+
+		adc4: adc@50000500 {
+			compatible = "st,stm32-adc";
+			reg = <0x50000500 0x100>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00004000>;
+			interrupts = <61 0>;
+			status = "disabled";
+			label = "ADC_4";
+			#io-channel-cells = <1>;
+		};
+
+		adc5: adc@50000600 {
+			compatible = "st,stm32-adc";
+			reg = <0x50000600 0x100>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00004000>;
+			interrupts = <62 0>;
+			status = "disabled";
+			label = "ADC_5";
+			#io-channel-cells = <1>;
+		};
 	};
 };

--- a/dts/arm/st/g4/stm32g474.dtsi
+++ b/dts/arm/st/g4/stm32g474.dtsi
@@ -122,5 +122,35 @@
 			status = "disabled";
 			label = "SPI_4";
 		};
+
+		adc3: adc@50000400 {
+			compatible = "st,stm32-adc";
+			reg = <0x50000400 0x100>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00004000>;
+			interrupts = <47 0>;
+			status = "disabled";
+			label = "ADC_3";
+			#io-channel-cells = <1>;
+		};
+
+		adc4: adc@50000500 {
+			compatible = "st,stm32-adc";
+			reg = <0x50000500 0x100>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00004000>;
+			interrupts = <61 0>;
+			status = "disabled";
+			label = "ADC_4";
+			#io-channel-cells = <1>;
+		};
+
+		adc5: adc@50000600 {
+			compatible = "st,stm32-adc";
+			reg = <0x50000600 0x100>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00004000>;
+			interrupts = <62 0>;
+			status = "disabled";
+			label = "ADC_5";
+			#io-channel-cells = <1>;
+		};
 	};
 };

--- a/dts/arm/st/g4/stm32g483.dtsi
+++ b/dts/arm/st/g4/stm32g483.dtsi
@@ -58,5 +58,35 @@
 		dmamux1: dmamux@40020800 {
 			dma-channels = <16>;
 		};
+
+		adc3: adc@50000400 {
+			compatible = "st,stm32-adc";
+			reg = <0x50000400 0x100>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00004000>;
+			interrupts = <47 0>;
+			status = "disabled";
+			label = "ADC_3";
+			#io-channel-cells = <1>;
+		};
+
+		adc4: adc@50000500 {
+			compatible = "st,stm32-adc";
+			reg = <0x50000500 0x100>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00004000>;
+			interrupts = <61 0>;
+			status = "disabled";
+			label = "ADC_4";
+			#io-channel-cells = <1>;
+		};
+
+		adc5: adc@50000600 {
+			compatible = "st,stm32-adc";
+			reg = <0x50000600 0x100>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00004000>;
+			interrupts = <62 0>;
+			status = "disabled";
+			label = "ADC_5";
+			#io-channel-cells = <1>;
+		};
 	};
 };

--- a/dts/arm/st/g4/stm32g484.dtsi
+++ b/dts/arm/st/g4/stm32g484.dtsi
@@ -58,5 +58,35 @@
 		dmamux1: dmamux@40020800 {
 			dma-channels = <16>;
 		};
+
+		adc3: adc@50000400 {
+			compatible = "st,stm32-adc";
+			reg = <0x50000400 0x100>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00004000>;
+			interrupts = <47 0>;
+			status = "disabled";
+			label = "ADC_3";
+			#io-channel-cells = <1>;
+		};
+
+		adc4: adc@50000500 {
+			compatible = "st,stm32-adc";
+			reg = <0x50000500 0x100>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00004000>;
+			interrupts = <61 0>;
+			status = "disabled";
+			label = "ADC_4";
+			#io-channel-cells = <1>;
+		};
+
+		adc5: adc@50000600 {
+			compatible = "st,stm32-adc";
+			reg = <0x50000600 0x100>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00004000>;
+			interrupts = <62 0>;
+			status = "disabled";
+			label = "ADC_5";
+			#io-channel-cells = <1>;
+		};
 	};
 };

--- a/dts/arm/st/g4/stm32g491.dtsi
+++ b/dts/arm/st/g4/stm32g491.dtsi
@@ -40,5 +40,15 @@
 		dmamux1: dmamux@40020800 {
 			dma-channels = <16>;
 		};
+
+		adc3: adc@50000400 {
+			compatible = "st,stm32-adc";
+			reg = <0x50000400 0x100>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00004000>;
+			interrupts = <47 0>;
+			status = "disabled";
+			label = "ADC_3";
+			#io-channel-cells = <1>;
+		};
 	};
 };

--- a/dts/arm/st/g4/stm32g4a1.dtsi
+++ b/dts/arm/st/g4/stm32g4a1.dtsi
@@ -40,5 +40,15 @@
 		dmamux1: dmamux@40020800 {
 			dma-channels = <16>;
 		};
+
+		adc3: adc@50000400 {
+			compatible = "st,stm32-adc";
+			reg = <0x50000400 0x100>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00004000>;
+			interrupts = <47 0>;
+			status = "disabled";
+			label = "ADC_3";
+			#io-channel-cells = <1>;
+		};
 	};
 };


### PR DESCRIPTION
Add DTS information for ADCs 3, 4, and 5 for stm32g4

Signed-off-by: Pete Dietl <petedietl@gmail.com>