### PR TITLE
pm: Do not suspend during kernel initialization

### DIFF
--- a/kernel/idle.c
+++ b/kernel/idle.c
@@ -79,7 +79,7 @@ void idle(void *unused1, void *unused2, void *unused3)
 		 * which is essential for the kernel's scheduling
 		 * logic.
 		 */
-		if (pm_system_suspend(_kernel.idle) == false) {
+		if (k_is_pre_kernel() || !pm_system_suspend(_kernel.idle)) {
 			k_cpu_idle();
 		}
 #else


### PR DESCRIPTION
Check if the kernel has fully initialized before take any action that
may suspend the system.


Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>