### PR TITLE
tests: kernel/events/event_api: memory coherence fixes

### DIFF
--- a/tests/kernel/events/event_api/src/test_event_apis.c
+++ b/tests/kernel/events/event_api/src/test_event_apis.c
@@ -56,7 +56,7 @@ static void entry_extra2(void *p1, void *p2, void *p3)
 
 void test_k_event_init(void)
 {
-	struct k_event  event;
+	static struct k_event  event;
 	struct k_thread *thread;
 
 	k_event_init(&event);
@@ -338,7 +338,7 @@ void test_wake_multiple_threads(void)
 
 void test_event_deliver(void)
 {
-	struct k_event  event;
+	static struct k_event  event;
 	uint32_t  events;
 
 	k_event_init(&event);


### PR DESCRIPTION
When CONFIG_KERNEL_COHERENCE=y, the k_event struct objects
cannot be declared on stacks since they are incoherent among
CPUs in the system.

So mark them as static to place them in global data section
and thus are coherence between CPUs.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>