### PR TITLE
tests/kernel/fatal/exception: Remove legacy irq_lock() usage

### DIFF
--- a/tests/kernel/fatal/exception/src/main.c
+++ b/tests/kernel/fatal/exception/src/main.c
@@ -126,28 +126,20 @@ void entry_cpu_exception_extend(void *p1, void *p2, void *p3)
 
 void entry_oops(void *p1, void *p2, void *p3)
 {
-	unsigned int key;
-
 	expected_reason = K_ERR_KERNEL_OOPS;
 
-	key = irq_lock();
 	k_oops();
 	TC_ERROR("SHOULD NEVER SEE THIS\n");
 	rv = TC_FAIL;
-	irq_unlock(key);
 }
 
 void entry_panic(void *p1, void *p2, void *p3)
 {
-	unsigned int key;
-
 	expected_reason = K_ERR_KERNEL_PANIC;
 
-	key = irq_lock();
 	k_panic();
 	TC_ERROR("SHOULD NEVER SEE THIS\n");
 	rv = TC_FAIL;
-	irq_unlock(key);
 }
 
 void entry_zephyr_assert(void *p1, void *p2, void *p3)
@@ -160,28 +152,20 @@ void entry_zephyr_assert(void *p1, void *p2, void *p3)
 
 void entry_arbitrary_reason(void *p1, void *p2, void *p3)
 {
-	unsigned int key;
-
 	expected_reason = INT_MAX;
 
-	key = irq_lock();
 	z_except_reason(INT_MAX);
 	TC_ERROR("SHOULD NEVER SEE THIS\n");
 	rv = TC_FAIL;
-	irq_unlock(key);
 }
 
 void entry_arbitrary_reason_negative(void *p1, void *p2, void *p3)
 {
-	unsigned int key;
-
 	expected_reason = -2;
 
-	key = irq_lock();
 	z_except_reason(-2);
 	TC_ERROR("SHOULD NEVER SEE THIS\n");
 	rv = TC_FAIL;
-	irq_unlock(key);
 }
 
 #ifndef CONFIG_ARCH_POSIX
@@ -242,12 +226,10 @@ void stack_sentinel_timer(void *p1, void *p2, void *p3)
 
 void stack_sentinel_swap(void *p1, void *p2, void *p3)
 {
-	unsigned int key = irq_lock();
-
 	/* Test that stack overflow check due to swap works */
 	blow_up_stack();
 	TC_PRINT("swapping...\n");
-	z_swap_irqlock(key);
+	z_swap_unlocked();
 	TC_ERROR("should never see this\n");
 	rv = TC_FAIL;
 }


### PR DESCRIPTION
The irq_lock() API is a legacy API not to be used for synchronization
by new code, and in any case is only being used in cargo-cult fashion
here.  These test cases all do synchronous exceptions, there's
literally nothing to synchronize against.

    (And in this case they're exposing a legacy wart.  On platforms where:

    1. SMP=y, which causes irq_lock() to be implemented as a somewhat
       complicated global lock

    2. No ARCH_EXCEPT() macro is defined, which causes the kernel to
       use a fallback that simply aborts the current thread.

    ...this test will then abort a thread holding the lock, which will
    cause it to be orphaned (if it weren't a legacy API, the kernel
    should probably attempt to clean it up in k_thread_abort(), but it
    is, and it doesn't), so the next attempt to lock it will hang.
    And it's even worse, because this test builds with SMP=y and
    MP_NUM_CPUS=1, so the hand will happen with interrupts masked on a
    system with only one CPU, and everything will lock up solid.)

Fixes #41877

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>