### PR TITLE
boards: esp_wrover_kit: fix missing DTS flash input values

### DIFF
--- a/boards/xtensa/esp_wrover_kit/esp_wrover_kit.dts
+++ b/boards/xtensa/esp_wrover_kit/esp_wrover_kit.dts
@@ -137,9 +137,34 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		storage_partition: partition@9000 {
+		/* Reserve 60kB for the bootloader */
+		boot_partition: partition@1000 {
+			label = "mcuboot";
+			reg = <0x00001000 0x0000F000>;
+			read-only;
+		};
+
+		/* Reserve 1024kB for the application in slot 0 */
+		slot0_partition: partition@10000 {
+			label = "image-0";
+			reg = <0x00010000 0x00100000>;
+		};
+
+		/* Reserve 1024kB for the application in slot 1 */
+		slot1_partition: partition@110000 {
+			label = "image-1";
+			reg = <0x00110000 0x00100000>;
+		};
+
+		/* Reserve 256kB for the scratch partition */
+		scratch_partition: partition@210000 {
+			   label = "image-scratch";
+			   reg = <0x00210000 0x00040000>;
+		};
+
+		storage_partition: partition@250000 {
 			label = "storage";
-			reg = <0x00009000 0x00006000>;
+			reg = <0x00250000 0x00006000>;
 		};
 	};
 };


### PR DESCRIPTION
Last wrover_kit board update was missing latest
DTS flash areas, causing build to fail.

Closes #41938

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>