### PR TITLE
driver: uart: esp32: fix uart macro and initialization

### DIFF
--- a/boards/xtensa/esp32/esp32.dts
+++ b/boards/xtensa/esp32/esp32.dts
@@ -37,26 +37,18 @@
 	current-speed = <115200>;
 	tx-pin = <1>;
 	rx-pin = <3>;
-	rts-pin = <22>;
-	cts-pin = <19>;
 };
 
 &uart1 {
 	current-speed = <115200>;
 	tx-pin = <10>;
 	rx-pin = <9>;
-	rts-pin = <11>;
-	cts-pin = <6>;
-	hw-flow-control;
 };
 
 &uart2 {
 	current-speed = <115200>;
 	tx-pin = <17>;
 	rx-pin = <16>;
-	rts-pin = <7>;
-	cts-pin = <8>;
-	hw-flow-control;
 };
 
 &gpio0 {

--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -446,7 +446,7 @@ static const struct gpio_driver_api gpio_esp32_driver_api = {
 			NULL,							\
 			&gpio_data_##_id,					\
 			&gpio_config_##_id,					\
-			PRE_KERNEL_2,						\
+			PRE_KERNEL_1,						\
 			CONFIG_GPIO_INIT_PRIORITY,				\
 			&gpio_esp32_driver_api);
 

--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -584,7 +584,7 @@ DEVICE_DT_INST_DEFINE(idx,				       \
 		    NULL,				       \
 		    &uart_esp32_data_##idx,				       \
 		    &uart_esp32_cfg_port_##idx,				       \
-		    PRE_KERNEL_2,					       \
+		    PRE_KERNEL_1,					       \
 		    CONFIG_SERIAL_INIT_PRIORITY,			       \
 		    &uart_esp32_api);
 

--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -52,7 +52,6 @@
 
 struct uart_esp32_pin {
 	const char *gpio_name;
-	int signal;
 	int pin;
 };
 
@@ -66,6 +65,7 @@ struct uart_esp32_config {
 
 	const clock_control_subsys_t clock_subsys;
 
+	uint8_t uart_num;
 	int irq_source;
 };
 
@@ -217,7 +217,8 @@ static int uart_esp32_configure_pins(const struct device *dev, const struct uart
 			break;
 		gpio_pin_set(tx_dev, cfg->tx.pin, 1);
 		gpio_pin_configure(tx_dev, cfg->tx.pin, GPIO_OUTPUT);
-		esp_rom_gpio_matrix_out(cfg->tx.pin, cfg->tx.signal, 0, 0);
+		esp_rom_gpio_matrix_out(cfg->tx.pin,
+				uart_periph_signal[cfg->uart_num].tx_sig, 0, 0);
 
 		/* RX pin config */
 		const struct device *rx_dev = device_get_binding(cfg->rx.gpio_name);
@@ -225,7 +226,7 @@ static int uart_esp32_configure_pins(const struct device *dev, const struct uart
 		if (!rx_dev)
 			break;
 		gpio_pin_configure(rx_dev, cfg->rx.pin, GPIO_PULL_UP | GPIO_INPUT);
-		esp_rom_gpio_matrix_in(cfg->rx.pin, cfg->rx.signal, 0);
+		esp_rom_gpio_matrix_in(cfg->rx.pin, uart_periph_signal[cfg->uart_num].rx_sig, 0);
 
 		if (uart->flow_ctrl == UART_CFG_FLOW_CTRL_RTS_CTS) {
 			if (cfg->rts.gpio_name == NULL || cfg->cts.gpio_name == NULL)
@@ -237,7 +238,8 @@ static int uart_esp32_configure_pins(const struct device *dev, const struct uart
 			if (!cts_dev)
 				break;
 			gpio_pin_configure(cts_dev, cfg->cts.pin, GPIO_PULL_UP | GPIO_INPUT);
-			esp_rom_gpio_matrix_in(cfg->cts.pin, cfg->cts.signal, 0);
+			esp_rom_gpio_matrix_in(cfg->cts.pin,
+					uart_periph_signal[cfg->uart_num].cts_sig, 0);
 
 			/* RTS pin config */
 			const struct device *rts_dev = device_get_binding(cfg->rts.gpio_name);
@@ -245,7 +247,8 @@ static int uart_esp32_configure_pins(const struct device *dev, const struct uart
 			if (!rts_dev)
 				break;
 			gpio_pin_configure(rts_dev, cfg->rts.pin, GPIO_OUTPUT);
-			esp_rom_gpio_matrix_out(cfg->rts.pin, cfg->rts.signal, 0, 0);
+			esp_rom_gpio_matrix_out(cfg->rts.pin,
+					uart_periph_signal[cfg->uart_num].rts_sig, 0, 0);
 		}
 		return 0;
 
@@ -537,30 +540,27 @@ static const DRAM_ATTR struct uart_driver_api uart_esp32_api = {
 
 #define ESP32_UART_INIT(idx)						       \
 static const DRAM_ATTR struct uart_esp32_config uart_esp32_cfg_port_##idx = {	       \
-	.clock_dev = DEVICE_DT_GET(DT_CLOCKS_CTLR(DT_NODELABEL(uart##idx))),		       \
+	.uart_num = DT_INST_PROP(idx, peripheral),	\
+	.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(idx)),		       \
 	.tx = {	\
-		.signal = U##idx##TXD_OUT_IDX,	\
 		.pin = DT_INST_PROP(idx, tx_pin),	\
 		.gpio_name = DT_UART_ESP32_GPIO_NAME(idx, tx_pin),	\
 	},	\
 	.rx = {	\
-		.signal = U##idx##RXD_IN_IDX,	\
 		.pin = DT_INST_PROP(idx, rx_pin),	\
 		.gpio_name = DT_UART_ESP32_GPIO_NAME(idx, rx_pin),	\
 	},	\
-	IF_ENABLED(DT_PROP(DT_NODELABEL(uart##idx), hw_flow_control), (	\
+	IF_ENABLED(DT_NODE_HAS_PROP(idx, hw_flow_control), (	\
 	.rts = {	\
-		.signal = U##idx##RTS_OUT_IDX,	\
 		.pin = DT_INST_PROP(idx, rts_pin),	\
 		.gpio_name = DT_UART_ESP32_GPIO_NAME(idx, rts_pin),	\
 	},	\
 	.cts = {	\
-		.signal = U##idx##CTS_IN_IDX,	\
 		.pin = DT_INST_PROP(idx, cts_pin),	\
 		.gpio_name = DT_UART_ESP32_GPIO_NAME(idx, cts_pin),	\
 	},))	\
-	.clock_subsys = (clock_control_subsys_t)DT_CLOCKS_CELL(DT_NODELABEL(uart##idx), offset), \
-	.irq_source = DT_IRQN(DT_NODELABEL(uart##idx))			       \
+	.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(idx, offset), \
+	.irq_source = DT_INST_IRQN(idx)			       \
 };									       \
 									       \
 static struct uart_esp32_data uart_esp32_data_##idx = {			       \
@@ -569,9 +569,9 @@ static struct uart_esp32_data uart_esp32_data_##idx = {			       \
 		.parity = UART_CFG_PARITY_NONE,				       \
 		.stop_bits = UART_CFG_STOP_BITS_1,			       \
 		.data_bits = UART_CFG_DATA_BITS_8,			       \
-		.flow_ctrl = IS_ENABLED(				       \
-			DT_PROP(DT_NODELABEL(uart##idx), hw_flow_control)) ?\
-			UART_CFG_FLOW_CTRL_RTS_CTS : UART_CFG_FLOW_CTRL_NONE   \
+		.flow_ctrl =	\
+			COND_CODE_1(DT_NODE_HAS_PROP(idx, hw_flow_control),	\
+		    (UART_CFG_FLOW_CTRL_RTS_CTS), (UART_CFG_FLOW_CTRL_NONE))	\
 	},								       \
 	.hal = {							       \
 		.dev =							       \
@@ -579,7 +579,7 @@ static struct uart_esp32_data uart_esp32_data_##idx = {			       \
 	},								       \
 };									       \
 									       \
-DEVICE_DT_DEFINE(DT_NODELABEL(uart##idx),				       \
+DEVICE_DT_INST_DEFINE(idx,				       \
 		    &uart_esp32_init,					       \
 		    NULL,				       \
 		    &uart_esp32_data_##idx,				       \

--- a/dts/bindings/serial/espressif,esp32-uart.yaml
+++ b/dts/bindings/serial/espressif,esp32-uart.yaml
@@ -30,3 +30,9 @@ properties:
       type: int
       description: CTS pin
       required: false
+
+    peripheral:
+      type: int
+      required: true
+      description: |
+        The UART peripheral number

--- a/dts/riscv/espressif/esp32c3.dtsi
+++ b/dts/riscv/espressif/esp32c3.dtsi
@@ -120,6 +120,7 @@
 			interrupts = <UART0_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_UART0_MODULE>;
+			peripheral = <0>;
 		};
 
 		uart1: uart@60010000 {
@@ -131,6 +132,7 @@
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_UART1_MODULE>;
 			current-speed = <115200>;
+			peripheral = <1>;
 		};
 
 		timer0: counter@6001f000 {

--- a/dts/xtensa/espressif/esp32.dtsi
+++ b/dts/xtensa/espressif/esp32.dtsi
@@ -105,6 +105,7 @@
 			label = "UART_0";
 			clocks = <&rtc ESP32_UART0_MODULE>;
 			status = "disabled";
+			peripheral = <0>;
 		};
 
 		uart1: uart@3ff50000 {
@@ -115,6 +116,7 @@
 			label = "UART_1";
 			clocks = <&rtc ESP32_UART1_MODULE>;
 			status = "disabled";
+			peripheral = <1>;
 		};
 
 		uart2: uart@3ff6e000 {
@@ -125,6 +127,7 @@
 			label = "UART_2";
 			clocks = <&rtc ESP32_UART2_MODULE>;
 			status = "disabled";
+			peripheral = <2>;
 		};
 
 		pinmux: pinmux@3ff49000 {

--- a/dts/xtensa/espressif/esp32s2.dtsi
+++ b/dts/xtensa/espressif/esp32s2.dtsi
@@ -89,6 +89,7 @@
 			interrupts = <UART0_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_UART0_MODULE>;
+			peripheral = <0>;
 		};
 
 		uart1: uart@3f410000 {
@@ -100,6 +101,7 @@
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_UART1_MODULE>;
 			current-speed = <115200>;
+			peripheral = <1>;
 		};
 
 		pinmux: pinmux@3f409000 {

--- a/west.yml
+++ b/west.yml
@@ -67,7 +67,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: bd2e2d8dcdc19defdb1bf6e07fb94f62bc99c925
+      revision: bcd7565ffa390d5774dc2fbe71a002faa9a7d082
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
The main purpose of this PR is to fix a few uart issues:

Current uart driver implementation is uncompleted regarding the
usage of DT_INST_FOREACH_STATUS_OKAY. If uart0 and uart2 are selected,
build breaks due to peripheral number ordering, which would be
0 and 1 in this case. This fix PR fix this by re-working the macros
and setting proper uart peripheral instances in DTSI, required for signal
routing configuration.

Uart console cannot be installed due to its driver level initialization.
This was fixed be changing the level value.

Removed some unused pin defintion in DTS file.

Closes #41836