### PR TITLE
pcie: controller: rename generic_pcie_ to pcie_generic_

### DIFF
--- a/drivers/pcie/host/controller.c
+++ b/drivers/pcie/host/controller.c
@@ -43,7 +43,7 @@ void pcie_conf_write(pcie_bdf_t bdf, unsigned int reg, uint32_t data)
 	pcie_ctrl_conf_write(dev, bdf, reg, data);
 }
 
-uint32_t generic_pcie_ctrl_conf_read(mm_reg_t cfg_addr, pcie_bdf_t bdf, unsigned int reg)
+uint32_t pcie_generic_ctrl_conf_read(mm_reg_t cfg_addr, pcie_bdf_t bdf, unsigned int reg)
 {
 	volatile uint32_t *bdf_cfg_mem = (volatile uint32_t *)((uintptr_t)cfg_addr + (bdf << 4));
 
@@ -54,7 +54,7 @@ uint32_t generic_pcie_ctrl_conf_read(mm_reg_t cfg_addr, pcie_bdf_t bdf, unsigned
 	return bdf_cfg_mem[reg];
 }
 
-void generic_pcie_ctrl_conf_write(mm_reg_t cfg_addr, pcie_bdf_t bdf,
+void pcie_generic_ctrl_conf_write(mm_reg_t cfg_addr, pcie_bdf_t bdf,
 				 unsigned int reg, uint32_t data)
 {
 	volatile uint32_t *bdf_cfg_mem = (volatile uint32_t *)((uintptr_t)cfg_addr + (bdf << 4));
@@ -66,12 +66,12 @@ void generic_pcie_ctrl_conf_write(mm_reg_t cfg_addr, pcie_bdf_t bdf,
 	bdf_cfg_mem[reg] = data;
 }
 
-static void generic_pcie_ctrl_enumerate_type1(const struct device *ctrl_dev, pcie_bdf_t bdf)
+static void pcie_generic_ctrl_enumerate_type1(const struct device *ctrl_dev, pcie_bdf_t bdf)
 {
 	/* Not yet supported */
 }
 
-static void generic_pcie_ctrl_type0_enumerate_bars(const struct device *ctrl_dev, pcie_bdf_t bdf)
+static void pcie_generic_ctrl_type0_enumerate_bars(const struct device *ctrl_dev, pcie_bdf_t bdf)
 {
 	unsigned int bar, reg, data;
 	uintptr_t scratch, bar_bus_addr;
@@ -160,13 +160,13 @@ static void generic_pcie_ctrl_type0_enumerate_bars(const struct device *ctrl_dev
 	}
 }
 
-static void generic_pcie_ctrl_enumerate_type0(const struct device *ctrl_dev, pcie_bdf_t bdf)
+static void pcie_generic_ctrl_enumerate_type0(const struct device *ctrl_dev, pcie_bdf_t bdf)
 {
 	/* Setup Type0 BARs */
-	generic_pcie_ctrl_type0_enumerate_bars(ctrl_dev, bdf);
+	pcie_generic_ctrl_type0_enumerate_bars(ctrl_dev, bdf);
 }
 
-void generic_pcie_ctrl_enumerate(const struct device *ctrl_dev, pcie_bdf_t bdf_start)
+void pcie_generic_ctrl_enumerate(const struct device *ctrl_dev, pcie_bdf_t bdf_start)
 {
 	uint32_t data, class, id;
 	unsigned int dev = PCIE_BDF_TO_DEV(bdf_start),
@@ -203,9 +203,9 @@ void generic_pcie_ctrl_enumerate(const struct device *ctrl_dev, pcie_bdf_t bdf_s
 				multifunction_device ? "true" : "false");
 
 			if (layout_type_1) {
-				generic_pcie_ctrl_enumerate_type1(ctrl_dev, bdf);
+				pcie_generic_ctrl_enumerate_type1(ctrl_dev, bdf);
 			} else {
-				generic_pcie_ctrl_enumerate_type0(ctrl_dev, bdf);
+				pcie_generic_ctrl_enumerate_type0(ctrl_dev, bdf);
 			}
 
 			/* Do not enumerate sub-functions if not a multifunction device */

--- a/drivers/pcie/host/pcie_ecam.c
+++ b/drivers/pcie/host/pcie_ecam.c
@@ -157,7 +157,7 @@ static int pcie_ecam_init(const struct device *dev)
 			data->regions[PCIE_REGION_MEM64].size);
 	}
 
-	/* Map config space to be used by the generic_pcie_ctrl_conf_read/write callbacks */
+	/* Map config space to be used by the pcie_generic_ctrl_conf_read/write callbacks */
 	device_map(&data->cfg_addr, data->cfg_phys_addr, data->cfg_size, K_MEM_CACHE_NONE);
 
 	LOG_DBG("Config space [0x%lx - 0x%lx, size 0x%lx]",
@@ -165,7 +165,7 @@ static int pcie_ecam_init(const struct device *dev)
 	LOG_DBG("Config mapped [0x%lx - 0x%lx, size 0x%lx]",
 		data->cfg_addr, (data->cfg_addr + data->cfg_size - 1), data->cfg_size);
 
-	generic_pcie_ctrl_enumerate(dev, PCIE_BDF(0, 0, 0));
+	pcie_generic_ctrl_enumerate(dev, PCIE_BDF(0, 0, 0));
 
 	return 0;
 }
@@ -174,7 +174,7 @@ static uint32_t pcie_ecam_ctrl_conf_read(const struct device *dev, pcie_bdf_t bd
 {
 	struct pcie_ecam_data *data = (struct pcie_ecam_data *)dev->data;
 
-	return generic_pcie_ctrl_conf_read(data->cfg_addr, bdf, reg);
+	return pcie_generic_ctrl_conf_read(data->cfg_addr, bdf, reg);
 }
 
 static void pcie_ecam_ctrl_conf_write(const struct device *dev, pcie_bdf_t bdf, unsigned int reg,
@@ -182,7 +182,7 @@ static void pcie_ecam_ctrl_conf_write(const struct device *dev, pcie_bdf_t bdf, 
 {
 	struct pcie_ecam_data *data = (struct pcie_ecam_data *)dev->data;
 
-	generic_pcie_ctrl_conf_write(data->cfg_addr, bdf, reg, reg_data);
+	pcie_generic_ctrl_conf_write(data->cfg_addr, bdf, reg, reg_data);
 }
 
 static bool pcie_ecam_region_allocate_type(struct pcie_ecam_data *data, pcie_bdf_t bdf,

--- a/include/drivers/pcie/controller.h
+++ b/include/drivers/pcie/controller.h
@@ -110,7 +110,7 @@ typedef bool (*pcie_ctrl_region_xlate_t)(const struct device *dev, pcie_bdf_t bd
  * @param reg the configuration word index (not address)
  * @return the word read (0xFFFFFFFFU if nonexistent endpoint or word)
  */
-uint32_t generic_pcie_ctrl_conf_read(mm_reg_t cfg_addr, pcie_bdf_t bdf, unsigned int reg);
+uint32_t pcie_generic_ctrl_conf_read(mm_reg_t cfg_addr, pcie_bdf_t bdf, unsigned int reg);
 
 
 /**
@@ -125,7 +125,7 @@ uint32_t generic_pcie_ctrl_conf_read(mm_reg_t cfg_addr, pcie_bdf_t bdf, unsigned
  * @param reg the configuration word index (not address)
  * @param data the value to write
  */
-void generic_pcie_ctrl_conf_write(mm_reg_t cfg_addr, pcie_bdf_t bdf,
+void pcie_generic_ctrl_conf_write(mm_reg_t cfg_addr, pcie_bdf_t bdf,
 				  unsigned int reg, uint32_t data);
 
 /**
@@ -138,7 +138,7 @@ void generic_pcie_ctrl_conf_write(mm_reg_t cfg_addr, pcie_bdf_t bdf,
  * @param dev PCI Express Controller device pointer
  * @param bdf_start PCI(e) start endpoint (only bus & dev are used to start enumeration)
  */
-void generic_pcie_ctrl_enumerate(const struct device *dev, pcie_bdf_t bdf_start);
+void pcie_generic_ctrl_enumerate(const struct device *dev, pcie_bdf_t bdf_start);
 
 /** @brief Structure providing callbacks to be implemented for devices
  * that supports the PCI Express Controller API


### PR DESCRIPTION
As suggested by Tomasz Bursztyka, it's clearer to move generic after the
domain prefix, here pcie.

This conflits with #40720, either one would need to be fixed.

Signed-off-by: Neil Armstrong <narmstrong@baylibre.com>