### PR TITLE
pcie: controller: rename xlate to translate

### DIFF
--- a/drivers/pcie/host/controller.c
+++ b/drivers/pcie/host/controller.c
@@ -133,8 +133,8 @@ static void generic_pcie_ctrl_type0_enumerate_bars(const struct device *ctrl_dev
 					      found_mem64, bar_size, &bar_bus_addr)) {
 			uintptr_t bar_phys_addr;
 
-			pcie_ctrl_region_xlate(ctrl_dev, bdf, found_mem,
-					      found_mem64, bar_bus_addr, &bar_phys_addr);
+			pcie_ctrl_region_translate(ctrl_dev, bdf, found_mem,
+						   found_mem64, bar_bus_addr, &bar_phys_addr);
 
 			LOG_INF("[%02x:%02x.%x] BAR%d size 0x%lx "
 				"assigned [%s 0x%lx-0x%lx -> 0x%lx-0x%lx]",

--- a/drivers/pcie/host/pcie.c
+++ b/drivers/pcie/host/pcie.c
@@ -178,12 +178,12 @@ bool pcie_get_mbar(pcie_bdf_t bdf,
 
 #ifdef CONFIG_PCIE_CONTROLLER
 	/* Translate to physical memory address from bus address */
-	if (!pcie_ctrl_region_xlate(dev, bdf, PCIE_CONF_BAR_MEM(phys_addr),
-				    PCIE_CONF_BAR_64(phys_addr),
-				    PCIE_CONF_BAR_MEM(phys_addr) ?
-					  PCIE_CONF_BAR_IO_ADDR(phys_addr)
-					: PCIE_CONF_BAR_ADDR(phys_addr),
-				    &mbar->phys_addr)) {
+	if (!pcie_ctrl_region_translate(dev, bdf, PCIE_CONF_BAR_MEM(phys_addr),
+					PCIE_CONF_BAR_64(phys_addr),
+					PCIE_CONF_BAR_MEM(phys_addr) ?
+						PCIE_CONF_BAR_IO_ADDR(phys_addr)
+						: PCIE_CONF_BAR_ADDR(phys_addr),
+					&mbar->phys_addr)) {
 		return false;
 	}
 #else

--- a/drivers/pcie/host/pcie_ecam.c
+++ b/drivers/pcie/host/pcie_ecam.c
@@ -240,9 +240,9 @@ static bool pcie_ecam_region_allocate(const struct device *dev, pcie_bdf_t bdf,
 	return pcie_ecam_region_allocate_type(data, bdf, bar_size, bar_bus_addr, type);
 }
 
-static bool pcie_ecam_region_xlate(const struct device *dev, pcie_bdf_t bdf,
-				   bool mem, bool mem64, uintptr_t bar_bus_addr,
-				   uintptr_t *bar_addr)
+static bool pcie_ecam_region_translate(const struct device *dev, pcie_bdf_t bdf,
+				       bool mem, bool mem64, uintptr_t bar_bus_addr,
+				       uintptr_t *bar_addr)
 {
 	struct pcie_ecam_data *data = (struct pcie_ecam_data *)dev->data;
 	enum pcie_region_type type;
@@ -270,7 +270,7 @@ static const struct pcie_ctrl_driver_api pcie_ecam_api = {
 	.conf_read = pcie_ecam_ctrl_conf_read,
 	.conf_write = pcie_ecam_ctrl_conf_write,
 	.region_allocate = pcie_ecam_region_allocate,
-	.region_xlate = pcie_ecam_region_xlate,
+	.region_translate = pcie_ecam_region_translate,
 };
 
 #define PCIE_ECAM_INIT(n)							\

--- a/include/drivers/pcie/controller.h
+++ b/include/drivers/pcie/controller.h
@@ -94,9 +94,9 @@ typedef bool (*pcie_ctrl_region_allocate_t)(const struct device *dev, pcie_bdf_t
  * @param bar_addr CPU-centric address translated from the bus-centric address
  * @return True if translation was possible, False if translation failed
  */
-typedef bool (*pcie_ctrl_region_xlate_t)(const struct device *dev, pcie_bdf_t bdf,
-					 bool mem, bool mem64, uintptr_t bar_bus_addr,
-					 uintptr_t *bar_addr);
+typedef bool (*pcie_ctrl_region_translate_t)(const struct device *dev, pcie_bdf_t bdf,
+					     bool mem, bool mem64, uintptr_t bar_bus_addr,
+					     uintptr_t *bar_addr);
 
 /**
  * @brief Read a 32-bit word from a Memory-Mapped endpoint's configuration space.
@@ -147,7 +147,7 @@ __subsystem struct pcie_ctrl_driver_api {
 	pcie_ctrl_conf_read_t conf_read;
 	pcie_ctrl_conf_write_t conf_write;
 	pcie_ctrl_region_allocate_t region_allocate;
-	pcie_ctrl_region_xlate_t region_xlate;
+	pcie_ctrl_region_translate_t region_translate;
 };
 
 /**
@@ -235,18 +235,18 @@ static inline bool pcie_ctrl_region_allocate(const struct device *dev, pcie_bdf_
  * @param bar_addr CPU-centric address translated from the bus-centric address
  * @return True if translation was possible, False if translation failed
  */
-static inline bool pcie_ctrl_region_xlate(const struct device *dev, pcie_bdf_t bdf,
+static inline bool pcie_ctrl_region_translate(const struct device *dev, pcie_bdf_t bdf,
 					  bool mem, bool mem64, uintptr_t bar_bus_addr,
 					  uintptr_t *bar_addr)
 {
 	const struct pcie_ctrl_driver_api *api =
 		(const struct pcie_ctrl_driver_api *)dev->api;
 
-	if (!api->region_xlate) {
+	if (!api->region_translate) {
 		*bar_addr = bar_bus_addr;
 		return true;
 	} else {
-		return api->region_xlate(dev, bdf, mem, mem64, bar_bus_addr, bar_addr);
+		return api->region_translate(dev, bdf, mem, mem64, bar_bus_addr, bar_addr);
 	}
 }
 


### PR DESCRIPTION
As suggested by Tomasz Bursztyka, translate is clearer than xlate in
the PCIe controller functions and callbacks names.

Signed-off-by: Neil Armstrong <narmstrong@baylibre.com>