### PR TITLE
drivers: can: remove CAN_BUS_UNKNOWN CAN controller state

### DIFF
--- a/drivers/can/can_handlers.c
+++ b/drivers/can/can_handlers.c
@@ -81,20 +81,23 @@ static inline void z_vrfy_can_remove_rx_filter(const struct device *dev, int fil
 #include <syscalls/can_remove_rx_filter_mrsh.c>
 
 static inline
-enum can_state z_vrfy_can_get_state(const struct device *dev,
-				    struct can_bus_err_cnt *err_cnt)
+int z_vrfy_can_get_state(const struct device *dev, enum can_state *state,
+			 struct can_bus_err_cnt *err_cnt)
 {
 
 	Z_OOPS(Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_CAN));
 
-	if (err_cnt) {
-		Z_OOPS(Z_SYSCALL_MEMORY_WRITE(err_cnt, sizeof(err_cnt)));
+	if (state != NULL) {
+		Z_OOPS(Z_SYSCALL_MEMORY_WRITE(state, sizeof(enum can_state)));
 	}
 
-	return z_impl_can_get_state(dev, err_cnt);
+	if (err_cnt != NULL) {
+		Z_OOPS(Z_SYSCALL_MEMORY_WRITE(err_cnt, sizeof(struct can_bus_err_cnt)));
+	}
+
+	return z_impl_can_get_state(dev, state, err_cnt);
 }
 #include <syscalls/can_get_state_mrsh.c>
-
 
 #ifndef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY
 static inline int z_vrfy_can_recover(const struct device *dev,

--- a/drivers/can/can_loopback.c
+++ b/drivers/can/can_loopback.c
@@ -212,17 +212,21 @@ int can_loopback_set_timing(const struct device *dev,
 	return 0;
 }
 
-static enum can_state can_loopback_get_state(const struct device *dev,
-					     struct can_bus_err_cnt *err_cnt)
+static int can_loopback_get_state(const struct device *dev, enum can_state *state,
+				  struct can_bus_err_cnt *err_cnt)
 {
 	ARG_UNUSED(dev);
+
+	if (state != NULL) {
+		*state = CAN_ERROR_ACTIVE;
+	}
 
 	if (err_cnt) {
 		err_cnt->tx_err_cnt = 0;
 		err_cnt->rx_err_cnt = 0;
 	}
 
-	return CAN_ERROR_ACTIVE;
+	return 0;
 }
 
 #ifndef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY

--- a/drivers/can/can_mcan.h
+++ b/drivers/can/can_mcan.h
@@ -238,7 +238,7 @@ int can_mcan_add_rx_filter(struct can_mcan_data *data,
 void can_mcan_remove_rx_filter(struct can_mcan_data *data,
 			       struct can_mcan_msg_sram *msg_ram, int filter_id);
 
-enum can_state can_mcan_get_state(const struct can_mcan_config *cfg,
-				  struct can_bus_err_cnt *err_cnt);
+int can_mcan_get_state(const struct can_mcan_config *cfg, enum can_state *state,
+		       struct can_bus_err_cnt *err_cnt);
 
 #endif /* ZEPHYR_DRIVERS_CAN_MCAN_H_ */

--- a/drivers/can/can_mcux_mcan.c
+++ b/drivers/can/can_mcux_mcan.c
@@ -72,12 +72,12 @@ static void mcux_mcan_remove_rx_filter(const struct device *dev, int filter_id)
 	can_mcan_remove_rx_filter(&data->mcan, &data->msg_ram, filter_id);
 }
 
-static enum can_state mcux_mcan_get_state(const struct device *dev,
-					  struct can_bus_err_cnt *err_cnt)
+static int mcux_mcan_get_state(const struct device *dev, enum can_state *state,
+			       struct can_bus_err_cnt *err_cnt)
 {
 	const struct mcux_mcan_config *config = dev->config;
 
-	return can_mcan_get_state(&config->mcan, err_cnt);
+	return can_mcan_get_state(&config->mcan, state, err_cnt);
 }
 
 static void mcux_mcan_set_state_change_callback(const struct device *dev,

--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -671,16 +671,21 @@ static void can_rcar_set_state_change_callback(const struct device *dev,
 	data->state_change_cb_data = user_data;
 }
 
-static enum can_state can_rcar_get_state(const struct device *dev,
-					 struct can_bus_err_cnt *err_cnt)
+static int can_rcar_get_state(const struct device *dev, enum can_state *state,
+			      struct can_bus_err_cnt *err_cnt)
 {
 	const struct can_rcar_cfg *config = DEV_CAN_CFG(dev);
 	struct can_rcar_data *data = DEV_CAN_DATA(dev);
 
+	if (state != NULL) {
+		*state = data->state;
+	}
+
 	if (err_cnt != NULL) {
 		can_rcar_get_error_count(config, err_cnt);
 	}
-	return data->state;
+
+	return 0;
 }
 
 #ifndef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY

--- a/drivers/can/can_sam.c
+++ b/drivers/can/can_sam.c
@@ -71,12 +71,13 @@ static int can_sam_init(const struct device *dev)
 	return ret;
 }
 
-static enum can_state can_sam_get_state(const struct device *dev, struct can_bus_err_cnt *err_cnt)
+static int can_sam_get_state(const struct device *dev, enum can_state *state,
+			     struct can_bus_err_cnt *err_cnt)
 {
 	const struct can_sam_config *cfg = dev->config;
 	const struct can_mcan_config *mcan_cfg = &cfg->mcan_cfg;
 
-	return can_mcan_get_state(mcan_cfg, err_cnt);
+	return can_mcan_get_state(mcan_cfg, state, err_cnt);
 }
 
 static int can_sam_send(const struct device *dev, const struct zcan_frame *frame,

--- a/drivers/can/can_stm32fd.c
+++ b/drivers/can/can_stm32fd.c
@@ -90,13 +90,13 @@ static int can_stm32fd_init(const struct device *dev)
 	return ret;
 }
 
-static enum can_state can_stm32fd_get_state(const struct device *dev,
-					    struct can_bus_err_cnt *err_cnt)
+static int can_stm32fd_get_state(const struct device *dev, enum can_state *state,
+				 struct can_bus_err_cnt *err_cnt)
 {
 	const struct can_stm32fd_config *cfg = dev->config;
 	const struct can_mcan_config *mcan_cfg = &cfg->mcan_cfg;
 
-	return can_mcan_get_state(mcan_cfg, err_cnt);
+	return can_mcan_get_state(mcan_cfg, state, err_cnt);
 }
 
 static int can_stm32fd_send(const struct device *dev, const struct zcan_frame *frame,

--- a/drivers/can/can_stm32h7.c
+++ b/drivers/can/can_stm32h7.c
@@ -120,12 +120,12 @@ static int can_stm32h7_init(const struct device *dev)
 	return 0;
 }
 
-static enum can_state can_stm32h7_get_state(const struct device *dev,
-					    struct can_bus_err_cnt *err_cnt)
+static int can_stm32h7_get_state(const struct device *dev, enum can_state *state,
+				 struct can_bus_err_cnt *err_cnt)
 {
 	const struct can_stm32h7_config *cfg = dev->config;
 
-	return can_mcan_get_state(&cfg->mcan_cfg, err_cnt);
+	return can_mcan_get_state(&cfg->mcan_cfg, state, err_cnt);
 }
 
 static int can_stm32h7_send(const struct device *dev,

--- a/include/drivers/can.h
+++ b/include/drivers/can.h
@@ -104,8 +104,6 @@ enum can_state {
 	CAN_ERROR_PASSIVE,
 	/** Bus-off state (RX/TX error count >= 256). */
 	CAN_BUS_OFF,
-	/** Bus state unknown. */
-	CAN_BUS_UNKNOWN
 };
 
 /**
@@ -347,8 +345,8 @@ typedef int (*can_recover_t)(const struct device *dev, k_timeout_t timeout);
  * @brief Callback API upon getting the CAN controller state
  * See @a can_get_state() for argument description
  */
-typedef enum can_state (*can_get_state_t)(const struct device *dev,
-					  struct can_bus_err_cnt *err_cnt);
+typedef int (*can_get_state_t)(const struct device *dev, enum can_state *state,
+			       struct can_bus_err_cnt *err_cnt);
 
 /**
  * @typedef can_set_state_change_callback_t
@@ -826,19 +824,21 @@ static inline int z_impl_can_get_max_filters(const struct device *dev, enum can_
  * controller.
  *
  * @param dev          Pointer to the device structure for the driver instance.
+ * @param[out] state   Pointer to the state destination enum or NULL.
  * @param[out] err_cnt Pointer to the err_cnt destination structure or NULL.
  *
- * @retval  state
+ * @retval 0 If successful.
+ * @retval -EIO General input/output error, failed to get state.
  */
-__syscall enum can_state can_get_state(const struct device *dev,
-				       struct can_bus_err_cnt *err_cnt);
+__syscall int can_get_state(const struct device *dev, enum can_state *state,
+			    struct can_bus_err_cnt *err_cnt);
 
-static inline enum can_state z_impl_can_get_state(const struct device *dev,
-						  struct can_bus_err_cnt *err_cnt)
+static inline int z_impl_can_get_state(const struct device *dev, enum can_state *state,
+				       struct can_bus_err_cnt *err_cnt)
 {
 	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
 
-	return api->get_state(dev, err_cnt);
+	return api->get_state(dev, state, err_cnt);
 }
 
 /**

--- a/modules/canopennode/CO_driver.c
+++ b/modules/canopennode/CO_driver.c
@@ -406,6 +406,7 @@ void CO_CANverifyErrors(CO_CANmodule_t *CANmodule)
 	enum can_state state;
 	uint8_t rx_overflows;
 	uint32_t errors;
+	int err;
 
 	/*
 	 * TODO: Zephyr lacks an API for reading the rx mailbox
@@ -413,7 +414,11 @@ void CO_CANverifyErrors(CO_CANmodule_t *CANmodule)
 	 */
 	rx_overflows  = 0;
 
-	state = can_get_state(CANmodule->dev, &err_cnt);
+	err = can_get_state(CANmodule->dev, &state, &err_cnt);
+	if (err != 0) {
+		LOG_ERR("failed to get CAN controller state (err %d)", err);
+		return;
+	}
 
 	errors = ((uint32_t)err_cnt.tx_err_cnt << 16) |
 		 ((uint32_t)err_cnt.rx_err_cnt << 8) |

--- a/samples/drivers/can/src/main.c
+++ b/samples/drivers/can/src/main.c
@@ -127,9 +127,16 @@ void poll_state_thread(void *unused1, void *unused2, void *unused3)
 	struct can_bus_err_cnt err_cnt_prev = {0, 0};
 	enum can_state state_prev = CAN_ERROR_ACTIVE;
 	enum can_state state;
+	int err;
 
 	while (1) {
-		state = can_get_state(can_dev, &err_cnt);
+		err = can_get_state(can_dev, &state, &err_cnt);
+		if (err != 0) {
+			printk("Failed to get CAN controller state: %d", err);
+			k_sleep(K_MSEC(100));
+			continue;
+		}
+
 		if (err_cnt.tx_err_cnt != err_cnt_prev.tx_err_cnt ||
 		    err_cnt.rx_err_cnt != err_cnt_prev.rx_err_cnt ||
 		    state_prev != state) {


### PR DESCRIPTION
The CAN_BUS_UNKNOWN CAN controller state is only used to indicate that the current CAN controller state could not be read.

Remove it and change the signature of the can_get_state() API function to return an integer indicating success or failure.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>