### PR TITLE
net: openthread: blank `otPlatLog` when logging is disabled

### DIFF
--- a/subsys/net/lib/openthread/platform/logging.c
+++ b/subsys/net/lib/openthread/platform/logging.c
@@ -39,35 +39,14 @@ static inline int log_translate(otLogLevel aLogLevel)
 	return -1;
 }
 
-void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion,
-	       const char *aFormat, ...)
+void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, ...)
 {
-	/*
-	 * The following speed optimization have been used:
-	 * - arguments are counted at compile time
-	 * - for none arguments aFormat is not checked for %s
-	 * - for up to three arguments program uses fast path
-	 * - time consuming string formatting is posponed to idle time
-	 * TODO : add support for ll (problem for 32 bit processors)
-	 */
-
-
-#ifdef OPENTHREAD_CONFIG_PLAT_LOG_MACRO_NAME__COUNT_ARGS
-	/* The arguments number has been counted by macro at compile time,
-	 * and the value has been passed in unused (now) aLogRegion.
-	 * If LogRegion value from OT is needed, rewrite macro
-	 * OPENTHREAD_CONFIG_PLAT_LOG_MACRO_NAME__COUNT_ARGS and use higher
-	 * bits to pass args_num.
-	 */
-	uint32_t args_num = (uint32_t) aLogRegion;
-#else
 	ARG_UNUSED(aLogRegion);
 
-	uint32_t args_num = log_count_args(aFormat);
-#endif
-
-	va_list param_list;
+#if defined(CONFIG_LOG)
 	int level = log_translate(aLogLevel);
+	uint32_t args_num = log_count_args(aFormat);
+	va_list param_list;
 
 	if (level < 0) {
 		return;
@@ -82,4 +61,9 @@ void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion,
 	 */
 	Z_LOG_VA(level, aFormat, param_list, args_num, LOG_STRDUP_EXEC);
 	va_end(param_list);
+#else
+	ARG_UNUSED(aLogLevel);
+	ARG_UNUSED(aFormat);
+#endif
+
 }


### PR DESCRIPTION
Implement an empty `otPlatLog` function when `CONFIG_LOG` is not
enabled. This also fixes the issue with `log_count_args` not being
available when logging is disabled.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>