### PR TITLE
mgmg/mcumgr/lib: Image upload size no longer needs flash alignment

### DIFF
--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/zephyr_img_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/zephyr_img_mgmt.c
@@ -526,9 +526,7 @@ img_mgmt_impl_upload_inspect(const struct img_mgmt_upload_req *req,
 				 struct img_mgmt_upload_action *action, const char **errstr)
 {
 	const struct image_header *hdr;
-	const struct flash_area *fa;
 	struct image_version cur_ver;
-	uint8_t rem_bytes;
 	bool empty;
 	int rc;
 
@@ -643,27 +641,9 @@ img_mgmt_impl_upload_inspect(const struct img_mgmt_upload_req *req,
 		}
 	}
 
-	/* Calculate size of flash write. */
 	action->write_bytes = req->data_len;
-	if (req->off + req->data_len < action->size) {
-		/*
-		 * Respect flash write alignment if not in the last block
-		 */
-		rc = flash_area_open(action->area_id, &fa);
-		if (rc) {
-			*errstr = img_mgmt_err_str_flash_open_failed;
-			return MGMT_ERR_EUNKNOWN;
-		}
-
-		rem_bytes = req->data_len % flash_area_align(fa);
-		flash_area_close(fa);
-
-		if (rem_bytes) {
-			action->write_bytes -= rem_bytes;
-		}
-	}
-
 	action->proceed = true;
+
 	return 0;
 }
 


### PR DESCRIPTION
The mcumgr image upload uses buffed flash writes with use of stream
flash, which makes flash alignment check unneded.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>