### PR TITLE
dts: bindings: gpio: Introduce Arduino Nano header

### DIFF
--- a/boards/arm/arduino_nano_33_iot/arduino_nano_33_iot.dts
+++ b/boards/arm/arduino_nano_33_iot/arduino_nano_33_iot.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 #include <atmel/samd21.dtsi>
 #include "arduino_nano_33_iot-pinctrl.dtsi"
+#include "arduino_nano_r3_connector.dtsi"
 
 / {
 	model = "Arduino Nano 33 IOT";

--- a/boards/arm/arduino_nano_33_iot/arduino_nano_r3_connector.dtsi
+++ b/boards/arm/arduino_nano_33_iot/arduino_nano_r3_connector.dtsi
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022 Joylab AG
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	arduino_nano_header: connector {
+		compatible = "arduino-nano-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &portb 23 0>,  /* D0 / UART-RX */
+			   <1 0 &portb 22 0>,  /* D1 / UART-TX */
+			   <2 0 &portb 10 0>,  /* D2 */
+			   <3 0 &portb 11 0>,  /* D3 */
+			   <4 0 &porta 7 0>,   /* D4 */
+			   <5 0 &porta 5 0>,   /* D5 */
+			   <6 0 &porta 4 0>,   /* D6 */
+			   <7 0 &porta 6 0>,   /* D7 */
+			   <8 0 &porta 18 0>,  /* D8 */
+			   <9 0 &porta 20 0>,  /* D9 */
+			   <10 0 &porta 21 0>, /* D10 */
+			   <11 0 &porta 16 0>, /* D11 / SPI-MOSI */
+			   <12 0 &porta 19 0>, /* D12 / SPI-MISO */
+			   <13 0 &porta 17 0>, /* D13 / SPI-SCK */
+			   <14 0 &porta 2 0>,  /* D14 / A0 */
+			   <15 0 &portb 2 0>,  /* D15 / A1 */
+			   <16 0 &porta 11 0>, /* D16 / A2 */
+			   <17 0 &porta 10 0>, /* D17 / A3 */
+			   <18 0 &portb 8 0>,  /* D18 / A4 / I2C-SDA */
+			   <19 0 &portb 9 0>,  /* D19 / A5 / I2C-SCL */
+			   <20 0 &porta 9 0>,  /* D20 / A6 */
+			   <21 0 &portb 3 0>;  /* D21 / A7 */
+	};
+};
+
+arduino_nano_i2c: &sercom4 {};
+arduino_nano_spi: &sercom1 {};
+arduino_nano_serial: &sercom5 {};

--- a/boards/arm/nucleo_g031k8/arduino_nano_r3_connector.dtsi
+++ b/boards/arm/nucleo_g031k8/arduino_nano_r3_connector.dtsi
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022 Joylab AG
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	arduino_nano_header: connector {
+		compatible = "arduino-nano-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpiob 7 0>,   /* D0 / UART-RX */
+			   <1 0 &gpiob 6 0>,   /* D1 / UART-TX */
+			   <2 0 &gpioa 15 0>,  /* D2 */
+			   <3 0 &gpiob 1 0>,   /* D3 */
+			   <4 0 &gpioa 10 0>,  /* D4 */
+			   <5 0 &gpioa 9 0>,   /* D5 */
+			   <6 0 &gpiob 0 0>,   /* D6 */
+			   <7 0 &gpiob 2 0>,   /* D7 */
+			   <8 0 &gpiob 8 0>,   /* D8 */
+			   <9 0 &gpioa 8 0>,   /* D9 */
+			   <10 0 &gpiob 9 0>,  /* D10 */
+			   <11 0 &gpiob 5 0>,  /* D11 / SPI-MOSI */
+			   <12 0 &gpiob 4 0>,  /* D12 / SPI-MISO */
+			   <13 0 &gpiob 3 0>,  /* D13 / SPI-SCK */
+			   <14 0 &gpioa 0 0>,  /* D14 / A0 */
+			   <15 0 &gpioa 1 0>,  /* D15 / A1 */
+			   <16 0 &gpioa 4 0>,  /* D16 / A2 */
+			   <17 0 &gpioa 5 0>,  /* D17 / A3 */
+			   <18 0 &gpioa 12 0>, /* D18 / A4 / I2C-SDA */
+			   <19 0 &gpioa 11 0>, /* D19 / A5 / I2C-SCL */
+			   <20 0 &gpioa 6 0>,  /* D20 / A6 */
+			   <21 0 &gpioa 7 0>;  /* D21 / A7 */
+	};
+};
+
+arduino_nano_i2c: &i2c2 {};
+arduino_nano_spi: &spi1 {};
+arduino_nano_serial: &usart1 {};

--- a/boards/arm/nucleo_g031k8/nucleo_g031k8.dts
+++ b/boards/arm/nucleo_g031k8/nucleo_g031k8.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 #include <st/g0/stm32g031X8.dtsi>
 #include <st/g0/stm32g031k(4-6-8)tx-pinctrl.dtsi>
+#include "arduino_nano_r3_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32G031K8-NUCLEO board";

--- a/boards/arm/nucleo_l031k6/arduino_nano_r3_connector.dtsi
+++ b/boards/arm/nucleo_l031k6/arduino_nano_r3_connector.dtsi
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022 Joylab AG
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	arduino_nano_header: connector {
+		compatible = "arduino-nano-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpioa 10 0>,  /* D0 */
+			   <1 0 &gpioa 9 0>,   /* D1 */
+			   <2 0 &gpioa 12 0>,  /* D2 */
+			   <3 0 &gpiob 0 0>,   /* D3 */
+			   <4 0 &gpiob 7 0>,   /* D4 */
+			   <5 0 &gpioa 6 0>,   /* D5 */
+			   <6 0 &gpiob 1 0>,   /* D6 */
+			   <7 0 &gpioc 14 0>,  /* D7 */
+			   <8 0 &gpioc 15 0>,  /* D8 */
+			   <9 0 &gpioa 8 0>,   /* D9 */
+			   <10 0 &gpioa 11 0>, /* D10 */
+			   <11 0 &gpiob 5 0>,  /* D11 */
+			   <12 0 &gpiob 4 0>,  /* D12 */
+			   <13 0 &gpiob 3 0>,  /* D13 */
+			   <14 0 &gpioa 0 0>,  /* D14 / A0 */
+			   <15 0 &gpioa 1 0>,  /* D15 / A1 */
+			   <16 0 &gpioa 3 0>,  /* D16 / A2 */
+			   <17 0 &gpioa 4 0>,  /* D17 / A3 */
+			   <18 0 &gpioa 5 0>,  /* D18 / A4 */
+			   <19 0 &gpioa 6 0>,  /* D19 / A5 */
+			   <20 0 &gpioa 7 0>,  /* D20 / A6 */
+			   <21 0 &gpioa 2 0>;  /* D21 / A7 */
+	};
+};

--- a/boards/arm/nucleo_l031k6/nucleo_l031k6.dts
+++ b/boards/arm/nucleo_l031k6/nucleo_l031k6.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 #include <st/l0/stm32l031X6.dtsi>
 #include <st/l0/stm32l031k(4-6)tx-pinctrl.dtsi>
+#include "arduino_nano_r3_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32L031K6-NUCLEO board";

--- a/dts/bindings/gpio/arduino-nano-header-r3.yaml
+++ b/dts/bindings/gpio/arduino-nano-header-r3.yaml
@@ -1,0 +1,38 @@
+# Copyright (c) 2022 Joylab AG
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    GPIO pins exposed on Arduino Nano (R3) headers.
+
+    The Arduino Nano layout provides two headers on opposite edges of the board.
+
+    * A 15-pin header with mostly digital signals. The additional NRST (pin3)
+      and GND (pin 4) pins are not exposed by this binding.
+    * A 15-pin Analog Input and power supply header. This has analog input
+      signals labeled from A0 through A7, as well a digital signal D13. The
+      power supply and reset pins are not exposed by this binding.
+
+    This binding provides a nexus mapping for 22 pins where parent pins 0
+    through 13 correspond to D0 through D13, and parent pins 14 through 21
+    correspond to A0 through A7, as depicted below.
+
+        1  D1                   VIN    -
+        0  D0                   GND    -
+        -  RESET                RESET  -
+        -  GND                  5V     -
+        2  D2                   A7/D21 21
+        3  D3                   A6/D20 20
+        4  D4                   A5/D19 19
+        5  D5                   A4/D18 18
+        6  D6                   A3/D17 17
+        7  D7                   A2/D16 16
+        8  D8                   A1/D15 15
+        9  D9                   A0/D14 14
+        10 D10                  AREF   -
+        11 D11                  3V3    -
+        12 D12                  D13    13
+
+
+compatible: "arduino-nano-header-r3"
+
+include: [gpio-nexus.yaml, base.yaml]


### PR DESCRIPTION
Add Nano header connector defined by Arduino. This allows
hardware with compatible headers to define the related GPIOs.