### PR TITLE
kernel: workq: Fix type errors in delayable work handlers

### DIFF
--- a/drivers/console/gsm_mux.c
+++ b/drivers/console/gsm_mux.c
@@ -610,7 +610,8 @@ static void ctrl_msg_cleanup(struct gsm_control_msg *entry, bool pending)
 /* T2 timeout is for control message retransmits */
 static void gsm_mux_t2_timeout(struct k_work *work)
 {
-	struct gsm_mux *mux = CONTAINER_OF(work, struct gsm_mux, t2_timer);
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct gsm_mux *mux = CONTAINER_OF(dwork, struct gsm_mux, t2_timer);
 	uint32_t current_time = k_uptime_get_32();
 	struct gsm_control_msg *entry, *next;
 

--- a/drivers/ethernet/phy/phy_mii.c
+++ b/drivers/ethernet/phy/phy_mii.c
@@ -217,8 +217,9 @@ static void invoke_link_cb(const struct device *dev)
 
 static void monitor_work_handler(struct k_work *work)
 {
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 	struct phy_mii_dev_data *const data =
-		CONTAINER_OF(work, struct phy_mii_dev_data, monitor_work);
+		CONTAINER_OF(dwork, struct phy_mii_dev_data, monitor_work);
 	const struct device *dev = data->dev;
 	int rc;
 

--- a/drivers/serial/uart_sam0.c
+++ b/drivers/serial/uart_sam0.c
@@ -186,7 +186,8 @@ static int uart_sam0_tx_halt(struct uart_sam0_dev_data *dev_data)
 
 static void uart_sam0_tx_timeout(struct k_work *work)
 {
-	struct uart_sam0_dev_data *dev_data = CONTAINER_OF(work,
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct uart_sam0_dev_data *dev_data = CONTAINER_OF(dwork,
 							   struct uart_sam0_dev_data, tx_timeout_work);
 
 	uart_sam0_tx_halt(dev_data);

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1333,7 +1333,8 @@ static int uart_stm32_async_tx_abort(const struct device *dev)
 
 static void uart_stm32_async_rx_timeout(struct k_work *work)
 {
-	struct uart_dma_stream *rx_stream = CONTAINER_OF(work,
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct uart_dma_stream *rx_stream = CONTAINER_OF(dwork,
 			struct uart_dma_stream, timeout_work);
 	struct uart_stm32_data *data = CONTAINER_OF(rx_stream,
 			struct uart_stm32_data, dma_rx);
@@ -1350,7 +1351,8 @@ static void uart_stm32_async_rx_timeout(struct k_work *work)
 
 static void uart_stm32_async_tx_timeout(struct k_work *work)
 {
-	struct uart_dma_stream *tx_stream = CONTAINER_OF(work,
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct uart_dma_stream *tx_stream = CONTAINER_OF(dwork,
 			struct uart_dma_stream, timeout_work);
 	struct uart_stm32_data *data = CONTAINER_OF(tx_stream,
 			struct uart_stm32_data, dma_tx);

--- a/drivers/wifi/esp_at/esp.c
+++ b/drivers/wifi/esp_at/esp.c
@@ -430,7 +430,8 @@ MODEM_CMD_DEFINE(on_cmd_cipsta)
 
 static void esp_ip_addr_work(struct k_work *work)
 {
-	struct esp_data *dev = CONTAINER_OF(work, struct esp_data,
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct esp_data *dev = CONTAINER_OF(dwork, struct esp_data,
 					    ip_addr_work);
 	int ret;
 

--- a/drivers/wifi/eswifi/eswifi_socket.c
+++ b/drivers/wifi/eswifi/eswifi_socket.c
@@ -91,10 +91,11 @@ static void eswifi_off_read_work(struct k_work *work)
 	int next_timeout_ms = 100;
 	int err, len;
 	char *data;
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 
 	LOG_DBG("");
 
-	socket = CONTAINER_OF(work, struct eswifi_off_socket, read_work);
+	socket = CONTAINER_OF(dwork, struct eswifi_off_socket, read_work);
 	eswifi = eswifi_socket_to_dev(socket);
 
 	eswifi_lock(eswifi);

--- a/samples/net/sockets/echo_client/src/udp.c
+++ b/samples/net/sockets/echo_client/src/udp.c
@@ -62,8 +62,9 @@ static int compare_udp_data(struct data *data, const char *buf, uint32_t receive
 
 static void wait_reply(struct k_work *work)
 {
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 	/* This means that we did not receive response in time. */
-	struct data *data = CONTAINER_OF(work, struct data, udp.recv);
+	struct data *data = CONTAINER_OF(dwork, struct data, udp.recv);
 
 	LOG_ERR("UDP %s: Data packet not received", data->proto);
 
@@ -73,7 +74,8 @@ static void wait_reply(struct k_work *work)
 
 static void wait_transmit(struct k_work *work)
 {
-	struct data *data = CONTAINER_OF(work, struct data, udp.transmit);
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct data *data = CONTAINER_OF(dwork, struct data, udp.transmit);
 
 	send_udp_data(data);
 }

--- a/samples/net/sockets/echo_server/src/tcp.c
+++ b/samples/net/sockets/echo_server/src/tcp.c
@@ -347,7 +347,8 @@ static void process_tcp6(void)
 
 static void print_stats(struct k_work *work)
 {
-	struct data *data = CONTAINER_OF(work, struct data, tcp.stats_print);
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct data *data = CONTAINER_OF(dwork, struct data, tcp.stats_print);
 	int total_received = atomic_get(&data->tcp.bytes_received);
 
 	if (total_received) {

--- a/samples/net/sockets/echo_server/src/udp.c
+++ b/samples/net/sockets/echo_server/src/udp.c
@@ -188,7 +188,8 @@ static void process_udp6(void)
 
 static void print_stats(struct k_work *work)
 {
-	struct data *data = CONTAINER_OF(work, struct data, udp.stats_print);
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct data *data = CONTAINER_OF(dwork, struct data, udp.stats_print);
 	int total_received = atomic_get(&data->udp.bytes_received);
 
 	if (total_received) {

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -2665,7 +2665,8 @@ static void att_chan_detach(struct bt_att_chan *chan)
 
 static void att_timeout(struct k_work *work)
 {
-	struct bt_att_chan *chan = CONTAINER_OF(work, struct bt_att_chan,
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct bt_att_chan *chan = CONTAINER_OF(dwork, struct bt_att_chan,
 						timeout_work);
 
 	BT_ERR("ATT Timeout");

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1530,7 +1530,8 @@ static struct bt_conn *conn_lookup_iso(struct bt_conn *conn)
 
 static void deferred_work(struct k_work *work)
 {
-	struct bt_conn *conn = CONTAINER_OF(work, struct bt_conn, deferred_work);
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct bt_conn *conn = CONTAINER_OF(dwork, struct bt_conn, deferred_work);
 	const struct bt_le_conn_param *param;
 
 	BT_DBG("conn %p", conn);

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -990,7 +990,8 @@ static void sc_indicate_rsp(struct bt_conn *conn,
 
 static void sc_process(struct k_work *work)
 {
-	struct gatt_sc *sc = CONTAINER_OF(work, struct gatt_sc, work);
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct gatt_sc *sc = CONTAINER_OF(dwork, struct gatt_sc, work);
 	uint16_t sc_range[2];
 
 	__ASSERT(!atomic_test_bit(sc->flags, SC_INDICATE_PENDING),
@@ -1074,8 +1075,9 @@ static bool gatt_ccc_conn_queue_is_empty(void)
 
 static void ccc_delayed_store(struct k_work *work)
 {
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 	struct gatt_ccc_store *ccc_store =
-		CONTAINER_OF(work, struct gatt_ccc_store, work);
+		CONTAINER_OF(dwork, struct gatt_ccc_store, work);
 
 	for (size_t i = 0; i < CONFIG_BT_MAX_CONN; i++) {
 		struct bt_conn *conn = ccc_store->conn_list[i];

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -1022,7 +1022,8 @@ static void smp_pairing_br_complete(struct bt_smp_br *smp, uint8_t status)
 
 static void smp_br_timeout(struct k_work *work)
 {
-	struct bt_smp_br *smp = CONTAINER_OF(work, struct bt_smp_br, work);
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct bt_smp_br *smp = CONTAINER_OF(dwork, struct bt_smp_br, work);
 
 	BT_ERR("SMP Timeout");
 

--- a/subsys/bluetooth/mesh/proxy_msg.c
+++ b/subsys/bluetooth/mesh/proxy_msg.c
@@ -55,10 +55,11 @@ static struct bt_mesh_proxy_role roles[CONFIG_BT_MAX_CONN];
 static void proxy_sar_timeout(struct k_work *work)
 {
 	struct bt_mesh_proxy_role *role;
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 
 	BT_WARN("Proxy SAR timeout");
 
-	role = CONTAINER_OF(work, struct bt_mesh_proxy_role, sar_timer);
+	role = CONTAINER_OF(dwork, struct bt_mesh_proxy_role, sar_timer);
 	if (role->conn) {
 		bt_conn_disconnect(role->conn,
 				   BT_HCI_ERR_REMOTE_USER_TERM_CONN);

--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -449,7 +449,8 @@ end:
 
 static void seg_retransmit(struct k_work *work)
 {
-	struct seg_tx *tx = CONTAINER_OF(work, struct seg_tx, retransmit);
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct seg_tx *tx = CONTAINER_OF(dwork, struct seg_tx, retransmit);
 
 	seg_tx_send_unacked(tx);
 }
@@ -1129,7 +1130,8 @@ static void seg_rx_reset(struct seg_rx *rx, bool full_reset)
 
 static void seg_ack(struct k_work *work)
 {
-	struct seg_rx *rx = CONTAINER_OF(work, struct seg_rx, ack);
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct seg_rx *rx = CONTAINER_OF(dwork, struct seg_rx, ack);
 	int32_t timeout;
 
 	if (!rx->in_use || rx->block == BLOCK_COMPLETE(rx->seg_n)) {

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -507,7 +507,8 @@ out:
 
 static void tcp_send_process(struct k_work *work)
 {
-	struct tcp *conn = CONTAINER_OF(work, struct tcp, send_timer);
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct tcp *conn = CONTAINER_OF(dwork, struct tcp, send_timer);
 	bool unref;
 
 	k_mutex_lock(&conn->lock, K_FOREVER);
@@ -1089,7 +1090,8 @@ static int tcp_send_queued_data(struct tcp *conn)
 
 static void tcp_cleanup_recv_queue(struct k_work *work)
 {
-	struct tcp *conn = CONTAINER_OF(work, struct tcp, recv_queue_timer);
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct tcp *conn = CONTAINER_OF(dwork, struct tcp, recv_queue_timer);
 
 	k_mutex_lock(&conn->lock, K_FOREVER);
 
@@ -1105,7 +1107,8 @@ static void tcp_cleanup_recv_queue(struct k_work *work)
 
 static void tcp_resend_data(struct k_work *work)
 {
-	struct tcp *conn = CONTAINER_OF(work, struct tcp, send_data_timer);
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct tcp *conn = CONTAINER_OF(dwork, struct tcp, send_data_timer);
 	bool conn_unref = false;
 	int ret;
 
@@ -1162,7 +1165,8 @@ static void tcp_resend_data(struct k_work *work)
 
 static void tcp_timewait_timeout(struct k_work *work)
 {
-	struct tcp *conn = CONTAINER_OF(work, struct tcp, timewait_timer);
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct tcp *conn = CONTAINER_OF(dwork, struct tcp, timewait_timer);
 
 	NET_DBG("conn: %p %s", conn, log_strdup(tcp_conn_state(conn, NULL)));
 
@@ -1180,7 +1184,8 @@ static void tcp_establish_timeout(struct tcp *conn)
 
 static void tcp_fin_timeout(struct k_work *work)
 {
-	struct tcp *conn = CONTAINER_OF(work, struct tcp, fin_timer);
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct tcp *conn = CONTAINER_OF(dwork, struct tcp, fin_timer);
 
 	if (conn->state == TCP_SYN_RECEIVED) {
 		tcp_establish_timeout(conn);

--- a/subsys/net/ip/trickle.c
+++ b/subsys/net/ip/trickle.c
@@ -122,7 +122,8 @@ static void inteval_timeout(struct net_trickle *trickle)
 
 static void trickle_timeout(struct k_work *work)
 {
-	struct net_trickle *trickle = CONTAINER_OF(work,
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct net_trickle *trickle = CONTAINER_OF(dwork,
 						   struct net_trickle,
 						   timer);
 

--- a/subsys/net/l2/ieee802154/ieee802154_fragment.c
+++ b/subsys/net/l2/ieee802154/ieee802154_fragment.c
@@ -287,7 +287,8 @@ static inline void clear_reass_cache(uint16_t size, uint16_t tag)
  */
 static void reass_timeout(struct k_work *work)
 {
-	struct frag_cache *cache = CONTAINER_OF(work, struct frag_cache, timer);
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct frag_cache *cache = CONTAINER_OF(dwork, struct frag_cache, timer);
 
 	if (cache->pkt) {
 		net_pkt_unref(cache->pkt);

--- a/subsys/net/l2/ppp/fsm.c
+++ b/subsys/net/l2/ppp/fsm.c
@@ -95,7 +95,8 @@ static void fsm_send_configure_req(struct ppp_fsm *fsm, bool retransmit)
 
 static void ppp_fsm_timeout(struct k_work *work)
 {
-	struct ppp_fsm *fsm = CONTAINER_OF(work, struct ppp_fsm, timer);
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct ppp_fsm *fsm = CONTAINER_OF(dwork, struct ppp_fsm, timer);
 
 	NET_DBG("[%s/%p] Current state %s (%d)", fsm->name, fsm,
 		ppp_state_str(fsm->state), fsm->state);

--- a/subsys/net/l2/ppp/ppp_l2.c
+++ b/subsys/net/l2/ppp/ppp_l2.c
@@ -408,7 +408,8 @@ const struct ppp_protocol_handler *ppp_lcp_get(void)
 
 static void ppp_startup(struct k_work *work)
 {
-	struct ppp_context *ctx = CONTAINER_OF(work, struct ppp_context,
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct ppp_context *ctx = CONTAINER_OF(dwork, struct ppp_context,
 					       startup);
 	int count = 0;
 

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -1058,8 +1058,9 @@ int dns_resolve_cancel(struct dns_resolve_context *ctx, uint16_t dns_id)
 
 static void query_timeout(struct k_work *work)
 {
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 	struct dns_pending_query *pending_query =
-		CONTAINER_OF(work, struct dns_pending_query, timer);
+		CONTAINER_OF(dwork, struct dns_pending_query, timer);
 	int ret;
 
 	/* We have to take the lock as we're inspecting protected content

--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -467,8 +467,9 @@ static int http_wait_data(int sock, struct http_request *req)
 
 static void http_timeout(struct k_work *work)
 {
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 	struct http_client_internal_data *data =
-		CONTAINER_OF(work, struct http_client_internal_data, work);
+		CONTAINER_OF(dwork, struct http_client_internal_data, work);
 
 	(void)zsock_close(data->sock);
 }

--- a/subsys/net/lib/lwm2m/ipso_buzzer.c
+++ b/subsys/net/lib/lwm2m/ipso_buzzer.c
@@ -169,7 +169,8 @@ static int onoff_post_write_cb(uint16_t obj_inst_id,
 
 static void buzzer_work_cb(struct k_work *work)
 {
-	struct ipso_buzzer_data *buzzer = CONTAINER_OF(work,
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct ipso_buzzer_data *buzzer = CONTAINER_OF(dwork,
 						      struct ipso_buzzer_data,
 						      buzzer_work);
 	stop_buzzer(buzzer, false);

--- a/subsys/net/lib/lwm2m/ipso_timer.c
+++ b/subsys/net/lib/lwm2m/ipso_timer.c
@@ -255,7 +255,8 @@ static int trigger_counter_post_write_cb(uint16_t obj_inst_id,
 
 static void timer_work_cb(struct k_work *work)
 {
-	struct ipso_timer_data *timer = CONTAINER_OF(work,
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct ipso_timer_data *timer = CONTAINER_OF(dwork,
 						     struct ipso_timer_data,
 						     timer_work);
 	stop_timer(timer, false);

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -81,7 +81,8 @@ unlock:
 static void runtime_suspend_work(struct k_work *work)
 {
 	int ret;
-	struct pm_device *pm = CONTAINER_OF(work, struct pm_device, work);
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct pm_device *pm = CONTAINER_OF(dwork, struct pm_device, work);
 
 	ret = pm->action_cb(pm->dev, PM_DEVICE_ACTION_SUSPEND);
 

--- a/tests/net/socket/tcp/src/main.c
+++ b/tests/net/socket/tcp/src/main.c
@@ -717,8 +717,9 @@ struct test_msg_waitall_data {
 
 static void test_msg_waitall_tx_work_handler(struct k_work *work)
 {
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 	struct test_msg_waitall_data *test_data =
-		CONTAINER_OF(work, struct test_msg_waitall_data, tx_work);
+		CONTAINER_OF(dwork, struct test_msg_waitall_data, tx_work);
 
 	if (test_data->retries > 0) {
 		test_send(test_data->sock, test_data->data + test_data->offset, 1, 0);

--- a/tests/net/socket/tls/src/main.c
+++ b/tests/net/socket/tls/src/main.c
@@ -201,8 +201,9 @@ struct test_msg_waitall_data {
 
 static void test_msg_waitall_tx_work_handler(struct k_work *work)
 {
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 	struct test_msg_waitall_data *test_data =
-		CONTAINER_OF(work, struct test_msg_waitall_data, tx_work);
+		CONTAINER_OF(dwork, struct test_msg_waitall_data, tx_work);
 
 	if (test_data->retries > 0) {
 		test_send(test_data->sock, test_data->data + test_data->offset, 1, 0);
@@ -377,8 +378,9 @@ struct test_msg_trunc_data {
 
 static void test_msg_trunc_tx_work_handler(struct k_work *work)
 {
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 	struct test_msg_trunc_data *test_data =
-		CONTAINER_OF(work, struct test_msg_trunc_data, tx_work);
+		CONTAINER_OF(dwork, struct test_msg_trunc_data, tx_work);
 
 	test_send(test_data->sock, test_data->data, test_data->datalen, 0);
 }


### PR DESCRIPTION
The `struct k_work *work` argument of the work handler of a delayable_work should be converted using `k_work_delayable_from_work` before passing into `CONTAINER_OF` to derive the address of its parent struct.
