### PR TITLE
logging: Fix tracking of buffered messages

### DIFF
--- a/include/logging/log_internal.h
+++ b/include/logging/log_internal.h
@@ -20,8 +20,12 @@ extern "C" {
  */
 
 /** @brief Indicate to the log core that one log message has been dropped.
+ *
+ * @param buffered True if dropped message was already buffered and it is being
+ * dropped to free space for another message. False if message is being dropped
+ * because allocation failed.
  */
-void z_log_dropped(void);
+void z_log_dropped(bool buffered);
 
 /** @brief Read and clear current drop indications counter.
  *

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -847,10 +847,12 @@ uint32_t z_vrfy_log_buffered_cnt(void)
 #include <syscalls/log_buffered_cnt_mrsh.c>
 #endif
 
-void z_log_dropped(void)
+void z_log_dropped(bool buffered)
 {
 	atomic_inc(&dropped_cnt);
-	atomic_dec(&buffered_cnt);
+	if (buffered) {
+		atomic_dec(&buffered_cnt);
+	}
 }
 
 uint32_t z_log_dropped_read_and_clear(void)
@@ -869,7 +871,7 @@ static void notify_drop(const struct mpsc_pbuf_buffer *buffer,
 	ARG_UNUSED(buffer);
 	ARG_UNUSED(item);
 
-	z_log_dropped();
+	z_log_dropped(true);
 }
 
 

--- a/subsys/logging/log_msg.c
+++ b/subsys/logging/log_msg.c
@@ -172,13 +172,13 @@ union log_msg_chunk *log_msg_no_space_handle(void)
 	if (IS_ENABLED(CONFIG_LOG_MODE_OVERFLOW)) {
 		do {
 			more = log_process(true);
-			z_log_dropped();
+			z_log_dropped(true);
 			err = k_mem_slab_alloc(&log_msg_pool,
 					       (void **)&msg,
 					       K_NO_WAIT);
 		} while ((err != 0) && more);
 	} else {
-		z_log_dropped();
+		z_log_dropped(false);
 	}
 	return msg;
 

--- a/subsys/logging/log_msg2.c
+++ b/subsys/logging/log_msg2.c
@@ -12,7 +12,7 @@ void z_log_msg2_finalize(struct log_msg2 *msg, const void *source,
 			 const struct log_msg2_desc desc, const void *data)
 {
 	if (!msg) {
-		z_log_dropped();
+		z_log_dropped(false);
 
 		return;
 	}


### PR DESCRIPTION
Algorithm was failing in case when overflow mode was enabled
but allocation of new message failed. It could happen if message
size exceeded buffer size. Losing track of buffered messages
can lead to logging processing freeze.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>