### PR TITLE
logging: printk: Fix LOG_PRINTK option and added test for it

### DIFF
--- a/include/logging/log.h
+++ b/include/logging/log.h
@@ -256,18 +256,16 @@ extern "C" {
  * @brief Writes an formatted string to the log.
  *
  * @details Conditionally compiled (see CONFIG_LOG_PRINTK). Function provides
- * printk functionality. It is inefficient compared to standard logging
- * because string formatting is performed in the call context and not deferred
- * to the log processing context (@ref log_process).
+ * printk functionality.
+ *
+ * It is less efficient compared to standard logging because static packaging
+ * cannot be used. When CONFIG_LOG1 is used string formatting is performed in the
+ * call context and not deferred to the log processing context (@ref log_process).
  *
  * @param fmt Formatted string to output.
  * @param ap  Variable parameters.
  */
-void z_log_printk(const char *fmt, va_list ap);
-static inline void log_printk(const char *fmt, va_list ap)
-{
-	z_log_printk(fmt, ap);
-}
+void z_log_vprintk(const char *fmt, va_list ap);
 
 /** @brief Copy transient string to a buffer from internal, logger pool.
  *

--- a/include/sys/printk.h
+++ b/include/sys/printk.h
@@ -12,9 +12,6 @@
 #include <stddef.h>
 #include <stdarg.h>
 #include <inttypes.h>
-#if defined(CONFIG_LOG_PRINTK) && defined(CONFIG_LOG2)
-#include <logging/log.h>
-#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -47,18 +44,8 @@ extern "C" {
  */
 #ifdef CONFIG_PRINTK
 
-#if defined(CONFIG_LOG_PRINTK) && defined(CONFIG_LOG2)
-#define printk(...) Z_LOG_PRINTK(__VA_ARGS__)
-static inline __printf_like(1, 0) void vprintk(const char *fmt, va_list ap)
-{
-	z_log_msg2_runtime_vcreate(CONFIG_LOG_DOMAIN_ID, NULL,
-				   LOG_LEVEL_INTERNAL_RAW_STRING, NULL, 0,
-				   fmt, ap);
-}
-#else
 extern __printf_like(1, 2) void printk(const char *fmt, ...);
 extern __printf_like(1, 0) void vprintk(const char *fmt, va_list ap);
-#endif /* defined(CONFIG_LOG_PRINTK) && defined(CONFIG_LOG) */
 
 #else
 static inline __printf_like(1, 2) void printk(const char *fmt, ...)

--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -22,6 +22,11 @@
 #include <sys/cbprintf.h>
 #include <sys/types.h>
 
+/* Option present only when CONFIG_USERSPACE enabled. */
+#ifndef CONFIG_PRINTK_BUFFER_SIZE
+#define CONFIG_PRINTK_BUFFER_SIZE 0
+#endif
+
 #if defined(CONFIG_PRINTK_SYNC) && \
 	!(defined(CONFIG_LOG_PRINTK) && defined(CONFIG_LOG2))
 static struct k_spinlock lock;
@@ -77,7 +82,6 @@ void *__printk_get_hook(void)
 
 #if defined(CONFIG_PRINTK) && \
 	!(defined(CONFIG_LOG_PRINTK) && defined(CONFIG_LOG2))
-#ifdef CONFIG_USERSPACE
 struct buf_out_context {
 	int count;
 	unsigned int buf_count;
@@ -102,7 +106,6 @@ static int buf_char_out(int c, void *ctx_p)
 
 	return c;
 }
-#endif /* CONFIG_USERSPACE */
 
 struct out_context {
 	int count;
@@ -116,7 +119,6 @@ static int char_out(int c, void *ctx_p)
 	return _char_out(c);
 }
 
-#ifdef CONFIG_USERSPACE
 void vprintk(const char *fmt, va_list ap)
 {
 	if (k_is_user_context()) {
@@ -140,21 +142,6 @@ void vprintk(const char *fmt, va_list ap)
 #endif
 	}
 }
-#else
-void vprintk(const char *fmt, va_list ap)
-{
-	struct out_context ctx = { 0 };
-#ifdef CONFIG_PRINTK_SYNC
-	k_spinlock_key_t key = k_spin_lock(&lock);
-#endif
-
-	cbvprintf(char_out, &ctx, fmt, ap);
-
-#ifdef CONFIG_PRINTK_SYNC
-	k_spin_unlock(&lock, key);
-#endif
-}
-#endif /* CONFIG_USERSPACE */
 
 void z_impl_k_str_out(char *c, size_t n)
 {

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -105,7 +105,10 @@ static int out_func(int c, void *ctx)
 
 	if (IS_ENABLED(CONFIG_LOG_MODE_IMMEDIATE)) {
 		/* Backend must be thread safe in synchronous operation. */
-		out_ctx->func((uint8_t *)&c, 1, out_ctx->control_block->ctx);
+		/* Need that step for big endian */
+		char x = (char)c;
+
+		out_ctx->func((uint8_t *)&x, 1, out_ctx->control_block->ctx);
 		return 0;
 	}
 

--- a/subsys/testsuite/include/tc_util.h
+++ b/subsys/testsuite/include/tc_util.h
@@ -16,6 +16,7 @@
 #include <shell/shell.h>
 #endif
 #include <sys/printk.h>
+#include <logging/log_ctrl.h>
 
 #if defined CONFIG_ZTEST_TC_UTIL_USER_OVERRIDE
 #include <tc_util_user_override.h>
@@ -174,7 +175,10 @@ static inline void test_time_ms(void)
 #endif
 
 #if defined(CONFIG_ARCH_POSIX)
-#define TC_END_POST(result) posix_exit(result)
+#define TC_END_POST(result) do { \
+	LOG_PANIC(); \
+	posix_exit(result); \
+} while (0)
 #else
 #define TC_END_POST(result)
 #endif /* CONFIG_ARCH_POSIX */

--- a/subsys/testsuite/ztest/src/ztest_new.c
+++ b/subsys/testsuite/ztest/src/ztest_new.c
@@ -605,6 +605,7 @@ void main(void)
 	z_init_mock();
 	test_main();
 	end_report();
+	LOG_PANIC();
 	if (IS_ENABLED(CONFIG_ZTEST_RETEST_IF_PASSED)) {
 		static __noinit struct {
 			uint32_t magic;

--- a/tests/subsys/logging/log_api/src/mock_backend.c
+++ b/tests/subsys/logging/log_api/src/mock_backend.c
@@ -221,6 +221,10 @@ static void put(const struct log_backend *const backend,
 	struct mock_log_backend *mock = backend->cb->ctx;
 	struct mock_log_backend_msg *exp = &mock->exp_msgs[mock->msg_proc_idx];
 
+	if (!mock->do_check) {
+		return;
+	}
+
 	mock->msg_proc_idx++;
 
 	if (!exp->check) {
@@ -264,6 +268,10 @@ static void process(const struct log_backend *const backend,
 	struct mock_log_backend *mock = backend->cb->ctx;
 	struct mock_log_backend_msg *exp = &mock->exp_msgs[mock->msg_proc_idx];
 
+	if (!mock->do_check) {
+		return;
+	}
+
 	mock->msg_proc_idx++;
 
 	if (!exp->check) {
@@ -280,11 +288,19 @@ static void process(const struct log_backend *const backend,
 	zassert_equal(msg->log.hdr.desc.level, exp->level, NULL);
 	zassert_equal(msg->log.hdr.desc.domain, exp->domain_id, NULL);
 
-	uint32_t source_id = IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ?
-		log_dynamic_source_id((struct log_source_dynamic_data *)msg->log.hdr.source) :
-		log_const_source_id((const struct log_source_const_data *)msg->log.hdr.source);
+	uint32_t source_id;
+	const void *source = msg->log.hdr.source;
 
-	zassert_equal(source_id, exp->source_id, NULL);
+	if (source == NULL) {
+		source_id = 0;
+	} else {
+		source_id = IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ?
+		    log_dynamic_source_id((struct log_source_dynamic_data *)source) :
+		    log_const_source_id((const struct log_source_const_data *)source);
+	}
+
+	zassert_equal(source_id, exp->source_id, "sourc_id:%p (exp: %d)",
+		      msg->log.hdr.source, exp->source_id);
 
 	size_t len;
 	uint8_t *data;
@@ -334,6 +350,10 @@ static void sync_string(const struct log_backend *const backend,
 	struct mock_log_backend *mock = backend->cb->ctx;
 	struct mock_log_backend_msg *exp = &mock->exp_msgs[mock->msg_proc_idx];
 
+	if (!mock->do_check) {
+		return;
+	}
+
 	mock->msg_proc_idx++;
 
 	if (!exp->check) {
@@ -359,6 +379,10 @@ static void sync_hexdump(const struct log_backend *const backend,
 {
 	struct mock_log_backend *mock = backend->cb->ctx;
 	struct mock_log_backend_msg *exp = &mock->exp_msgs[mock->msg_proc_idx];
+
+	if (!mock->do_check) {
+		return;
+	}
 
 	mock->msg_proc_idx++;
 

--- a/tests/subsys/logging/log_api/src/test.inc
+++ b/tests/subsys/logging/log_api/src/test.inc
@@ -641,6 +641,31 @@ static void test_log_panic(void)
 	process_and_validate(false, true);
 }
 
+static void test_log_printk(void)
+{
+	if (!IS_ENABLED(CONFIG_LOG_PRINTK)) {
+		ztest_test_skip();
+	}
+
+	log_timestamp_t exp_timestamp = TIMESTAMP_INIT_VAL;
+
+	log_setup(false);
+
+	mock_log_backend_record(&backend1, 0,
+				CONFIG_LOG_DOMAIN_ID, LOG_LEVEL_INTERNAL_RAW_STRING,
+				exp_timestamp++, "test 100");
+	printk("test %d", 100);
+
+	log_panic();
+
+	mock_log_backend_record(&backend1, 0,
+				CONFIG_LOG_DOMAIN_ID, LOG_LEVEL_INTERNAL_RAW_STRING,
+				exp_timestamp++, "test 101");
+	printk("test %d", 101);
+
+	process_and_validate(false, true);
+}
+
 /* Disable backends because same suite may be executed again but compiled by C++ */
 static void log_api_suite_teardown(void *data)
 {
@@ -711,3 +736,4 @@ WRAP_TEST(test_log_arguments, TEST_SUFFIX)
 WRAP_TEST(test_log_from_declared_module, TEST_SUFFIX)
 WRAP_TEST(test_log_msg_dropped_notification, TEST_SUFFIX)
 WRAP_TEST(test_log_panic, TEST_SUFFIX)
+WRAP_TEST(test_log_printk, TEST_SUFFIX)

--- a/tests/subsys/logging/log_api/src/test.inc
+++ b/tests/subsys/logging/log_api/src/test.inc
@@ -65,6 +65,25 @@ static int16_t log_source_id_get(const char *name)
 	return -1;
 }
 
+/**
+ * @brief Flush logs.
+ *
+ * If processing thread is enabled keep sleeping until there are no pending messages
+ * else process logs here.
+ */
+static void flush_log(void)
+{
+	if (IS_ENABLED(CONFIG_LOG_PROCESS_THREAD)) {
+		while (log_data_pending()) {
+			k_msleep(100);
+		}
+		k_msleep(100);
+	} else {
+		while (LOG_PROCESS()) {
+		}
+	}
+}
+
 static void log_setup(bool backend2_enable)
 {
 	stamp = TIMESTAMP_INIT_VAL;
@@ -89,6 +108,25 @@ static void log_setup(bool backend2_enable)
 
 	test_source_id = log_source_id_get(STRINGIFY(MODULE_NAME));
 	test_cxx_source_id = log_source_id_get(STRINGIFY(CXX_MODULE_NAME));
+}
+
+/**
+ * @brief Process and validate that backends got exepcted content.
+ *
+ * @param backend2_enable If true backend2 is also validated.
+ * @param panic True means that logging is in panic mode, flushing is skipped.
+ */
+static void process_and_validate(bool backend2_enable, bool panic)
+{
+	if (!panic) {
+		flush_log();
+	}
+
+	mock_log_backend_validate(&backend1, panic);
+
+	if (backend2_enable) {
+		mock_log_backend_validate(&backend2, panic);
+	}
 }
 
 static void test_log_various_messages(void)
@@ -177,10 +215,7 @@ static void test_log_various_messages(void)
 
 	LOG_ERR("err");
 
-	while (LOG_PROCESS()) {
-	}
-
-	mock_log_backend_validate(&backend1, false);
+	process_and_validate(false, false);
 }
 
 /*
@@ -197,7 +232,6 @@ static void test_log_backend_runtime_filtering(void)
 	}
 
 	log_setup(true);
-
 
 	if (IS_ENABLED(CONFIG_SAMPLE_MODULE_LOG_LEVEL_DBG)) {
 		char str[128];
@@ -230,11 +264,7 @@ static void test_log_backend_runtime_filtering(void)
 	LOG_DBG("test");
 	LOG_INF("test");
 
-	while (LOG_PROCESS()) {
-	}
-
-	mock_log_backend_validate(&backend1, false);
-	mock_log_backend_validate(&backend2, false);
+	process_and_validate(true, false);
 
 	log_filter_set(&backend2,
 			CONFIG_LOG_DOMAIN_ID,
@@ -276,11 +306,7 @@ static void test_log_backend_runtime_filtering(void)
 	LOG_WRN("test2");
 	LOG_HEXDUMP_WRN(data, sizeof(data), "hexdump");
 
-	while (LOG_PROCESS()) {
-	}
-
-	mock_log_backend_validate(&backend1, false);
-	mock_log_backend_validate(&backend2, false);
+	process_and_validate(true, false);
 }
 
 static size_t get_max_hexdump(void)
@@ -362,10 +388,7 @@ static void test_log_overflow(void)
 	LOG_HEXDUMP_INF(data, hexdump_len, "hexdump");
 	LOG_INF("test2");
 
-	while (LOG_PROCESS()) {
-	}
-
-	mock_log_backend_validate(&backend1, false);
+	process_and_validate(false, false);
 
 	log_setup(false);
 
@@ -390,10 +413,7 @@ static void test_log_overflow(void)
 	LOG_INF("test");
 	LOG_HEXDUMP_INF(data, hexdump_len+1, "test");
 
-	while (LOG_PROCESS()) {
-	}
-
-	mock_log_backend_validate(&backend1, false);
+	process_and_validate(false, false);
 }
 
 /*
@@ -418,29 +438,29 @@ static void test_log_arguments(void)
 	MOCK_LOG_BACKEND_RECORD("test 1 2 3");
 	MOCK_LOG_BACKEND_RECORD("test 1 2 3 4");
 	MOCK_LOG_BACKEND_RECORD("test 1 2 3 4 5");
-	MOCK_LOG_BACKEND_RECORD("test 1 2 3 4 5 6");
-	MOCK_LOG_BACKEND_RECORD("test 1 2 3 4 5 6 7");
-	MOCK_LOG_BACKEND_RECORD("test 1 2 3 4 5 6 7 8");
-	MOCK_LOG_BACKEND_RECORD("test 1 2 3 4 5 6 7 8 9");
-	MOCK_LOG_BACKEND_RECORD("test 1 2 3 4 5 6 7 8 9 10");
-	MOCK_LOG_BACKEND_RECORD("test 1 2 3 4 5 6 7 8 9 10 11");
-	MOCK_LOG_BACKEND_RECORD("test 1 2 3 4 5 6 7 8 9 10 11 12");
-	MOCK_LOG_BACKEND_RECORD("test 1 2 3 4 5 6 7 8 9 10 11 12 13");
-	MOCK_LOG_BACKEND_RECORD("test 1 2 3 4 5 6 7 8 9 10 11 12 13 14");
 
 	LOG_INF("test");
 	LOG_INF("test %d %d %d", 1, 2, 3);
 	LOG_INF("test %d %d %d %d", 1, 2, 3, 4);
 	LOG_INF("test %d %d %d %d %d", 1, 2, 3, 4, 5);
-	while (LOG_PROCESS()) {
-	}
+
+	process_and_validate(false, false);
+
+	MOCK_LOG_BACKEND_RECORD("test 1 2 3 4 5 6");
+	MOCK_LOG_BACKEND_RECORD("test 1 2 3 4 5 6 7");
+	MOCK_LOG_BACKEND_RECORD("test 1 2 3 4 5 6 7 8");
+	MOCK_LOG_BACKEND_RECORD("test 1 2 3 4 5 6 7 8 9");
 
 	LOG_INF("test %d %d %d %d %d %d", 1, 2, 3, 4, 5, 6);
 	LOG_INF("test %d %d %d %d %d %d %d", 1, 2, 3, 4, 5, 6, 7);
 	LOG_INF("test %d %d %d %d %d %d %d %d", 1, 2, 3, 4, 5, 6, 7,8);
 	LOG_INF("test %d %d %d %d %d %d %d %d %d", 1, 2, 3, 4, 5, 6, 7,8, 9);
-	while (LOG_PROCESS()) {
-	}
+
+	process_and_validate(false, false);
+
+	MOCK_LOG_BACKEND_RECORD("test 1 2 3 4 5 6 7 8 9 10");
+	MOCK_LOG_BACKEND_RECORD("test 1 2 3 4 5 6 7 8 9 10 11");
+	MOCK_LOG_BACKEND_RECORD("test 1 2 3 4 5 6 7 8 9 10 11 12");
 
 	LOG_INF("test %d %d %d %d %d %d %d %d %d %d",
 		1, 2, 3, 4, 5, 6, 7,8, 9, 10);
@@ -448,17 +468,17 @@ static void test_log_arguments(void)
 		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
 	LOG_INF("test %d %d %d %d %d %d %d %d %d %d %d %d",
 		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-	while (LOG_PROCESS()) {
-	}
 
+	process_and_validate(false, false);
+
+	MOCK_LOG_BACKEND_RECORD("test 1 2 3 4 5 6 7 8 9 10 11 12 13");
+	MOCK_LOG_BACKEND_RECORD("test 1 2 3 4 5 6 7 8 9 10 11 12 13 14");
 	LOG_INF("test %d %d %d %d %d %d %d %d %d %d %d %d %d",
 		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
 	LOG_INF("test %d %d %d %d %d %d %d %d %d %d %d %d %d %d",
 		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14);
-	while (LOG_PROCESS()) {
-	}
 
-	mock_log_backend_validate(&backend1, false);
+	process_and_validate(false, false);
 }
 
 /* Function comes from the file which is part of test module. It is
@@ -516,10 +536,7 @@ static void test_log_from_declared_module(void)
 
 	test_inline_func();
 
-	while (LOG_PROCESS()) {
-	}
-
-	mock_log_backend_validate(&backend1, false);
+	process_and_validate(false, false);
 }
 
 /** Calculate how many messages will fit in the buffer. Also calculate if
@@ -563,10 +580,7 @@ static void log_n_messages(uint32_t n_msg, uint32_t exp_dropped)
 
 	mock_log_backend_drop_record(&backend1, exp_dropped);
 
-	while (LOG_PROCESS()) {
-	}
-
-	mock_log_backend_validate(&backend1, false);
+	process_and_validate(false, false);
 	mock_log_backend_reset(&backend1);
 }
 
@@ -616,7 +630,7 @@ static void test_log_panic(void)
 	/* logs should be flushed in panic */
 	log_panic();
 
-	mock_log_backend_validate(&backend1, true);
+	process_and_validate(false, true);
 
 	/* messages processed where called */
 	mock_log_backend_record(&backend1, LOG_CURRENT_MODULE_ID(),
@@ -624,7 +638,7 @@ static void test_log_panic(void)
 				exp_timestamp++, "test");
 	LOG_WRN("test");
 
-	mock_log_backend_validate(&backend1, true);
+	process_and_validate(false, true);
 }
 
 /* Disable backends because same suite may be executed again but compiled by C++ */
@@ -649,14 +663,30 @@ static void *log_api_suite_setup(void)
 #if __cplusplus
 	PRINT("\t C++: yes\n");
 #endif
+	flush_log();
+
 	return NULL;
 }
 
 static void log_api_suite_before(void *data)
 {
 	ARG_UNUSED(data);
-	while(LOG_PROCESS()) {
-	}
+
+	/* Flush logs and enable test backends. */
+	flush_log();
+	mock_log_backend_check_enable(&backend1);
+	mock_log_backend_check_enable(&backend2);
+}
+
+static void log_api_suite_after(void *data)
+{
+
+	ARG_UNUSED(data);
+	/* Disable testing backends after the test. Otherwise test may fail due
+	 * to unexpected log message.
+	 */
+	mock_log_backend_check_disable(&backend1);
+	mock_log_backend_check_disable(&backend2);
 }
 
 #define WRAP_TEST(test_name, suffix)                       \
@@ -673,7 +703,7 @@ static void log_api_suite_before(void *data)
 #define TEST_SUITE_NAME UTIL_CAT(test_log_api_, TEST_SUFFIX)
 
 ZTEST_SUITE(TEST_SUITE_NAME, NULL, log_api_suite_setup,
-	    log_api_suite_before, NULL, log_api_suite_teardown);
+	    log_api_suite_before, log_api_suite_after, log_api_suite_teardown);
 WRAP_TEST(test_log_various_messages, TEST_SUFFIX)
 WRAP_TEST(test_log_backend_runtime_filtering, TEST_SUFFIX)
 WRAP_TEST(test_log_overflow, TEST_SUFFIX)

--- a/tests/subsys/logging/log_api/testcase.yaml
+++ b/tests/subsys/logging/log_api/testcase.yaml
@@ -81,6 +81,16 @@ tests:
       - CONFIG_LOG_MODE_DEFERRED=y
       - CONFIG_SAMPLE_MODULE_LOG_LEVEL_DBG=y
 
+  logging.log2_api_deferred_printk:
+    # FIXME:see #38041
+    platform_exclude: qemu_arc_hs6x
+    extra_configs:
+      - CONFIG_LOG_MODE_DEFERRED=y
+      - CONFIG_SAMPLE_MODULE_LOG_LEVEL_DBG=y
+      - CONFIG_LOG_PRINTK=y
+      #When LOG_PRINTK is enabled, thread must process otherwise test output would be lost.
+      - CONFIG_LOG_PROCESS_THREAD=y
+
   logging.log2_api_deferred_func_prefix:
     # FIXME:see #38041
     platform_exclude: qemu_arc_hs6x
@@ -101,6 +111,13 @@ tests:
     platform_exclude: qemu_arc_hs6x
     extra_configs:
       - CONFIG_LOG_MODE_IMMEDIATE=y
+
+  logging.log2_api_immediate_printk:
+    # FIXME: qemu_arc_hs6x excluded, see #38041
+    platform_exclude: qemu_arc_hs6x
+    extra_configs:
+      - CONFIG_LOG_MODE_IMMEDIATE=y
+      - CONFIG_LOG_PRINTK=y
 
   logging.log2_api_immediate_rt_filter:
     # FIXME: qemu_arc_hs6x excluded, see #38041

--- a/tests/subsys/logging/log_core_additional/src/log_test.c
+++ b/tests/subsys/logging/log_core_additional/src/log_test.c
@@ -160,6 +160,11 @@ static void sync_hexdump(const struct log_backend *const backend,
 	cb->sync++;
 }
 
+static void panic(const struct log_backend *const backend)
+{
+	ARG_UNUSED(backend);
+}
+
 const struct log_backend_api log_backend_test_api = {
 	.process = IS_ENABLED(CONFIG_LOG2) ? process : NULL,
 	.put = IS_ENABLED(CONFIG_LOG1_DEFERRED) ? put : NULL,
@@ -167,6 +172,7 @@ const struct log_backend_api log_backend_test_api = {
 			sync_string : NULL,
 	.put_sync_hexdump = IS_ENABLED(CONFIG_LOG1_IMMEDIATE) ?
 			sync_hexdump : NULL,
+	.panic = panic,
 };
 
 LOG_BACKEND_DEFINE(backend1, log_backend_test_api, false);


### PR DESCRIPTION
Removed logging dependency from printk.h and did cleanup in printk.c regarding logging (and userspace).
Extended `log_api` testsuite to check `CONFIG_LOG_PRINTK=y` option.

~~PR is based on #41969.~~

Fixes #41915.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>