### PR TITLE
fs: littlefs cleanup after adding sdcard support

### DIFF
--- a/subsys/fs/Kconfig.littlefs
+++ b/subsys/fs/Kconfig.littlefs
@@ -6,8 +6,6 @@
 config FILE_SYSTEM_LITTLEFS
 	bool "LittleFS support"
 	depends on FILE_SYSTEM
-	depends on FLASH_MAP
-	depends on FLASH_PAGE_LAYOUT
 	help
 	  Enables LittleFS file system support.
 
@@ -15,6 +13,22 @@ if FILE_SYSTEM_LITTLEFS
 
 menu "LittleFS Settings"
 	visible if FILE_SYSTEM_LITTLEFS
+
+config FS_LITTLEFS_FMP_DEV
+	bool "Enable support for littlefs on flash devices"
+	depends on FLASH_MAP
+	depends on FLASH_PAGE_LAYOUT
+	default y
+	help
+	  Enable this option to provide support for littlefs on flash devices
+	  (using the flash_map API).
+
+config FS_LITTLEFS_BLK_DEV
+	bool "Enable support for littlefs on block devices"
+	select DISK_ACCESS
+	help
+	  Enable this option to provide support for littlefs on the block
+	  devices (like for example SD card).
 
 config FS_LITTLEFS_NUM_FILES
 	int "Maximum number of opened files"
@@ -30,18 +44,21 @@ config FS_LITTLEFS_NUM_DIRS
 
 config FS_LITTLEFS_READ_SIZE
 	int "Minimum size of a block read"
+	default 512 if FS_LITTLEFS_BLK_DEV
 	default 16
 	help
 	  All read operations will be a multiple of this value.
 
 config FS_LITTLEFS_PROG_SIZE
 	int "Minimum size of a block program"
+	default 512 if FS_LITTLEFS_BLK_DEV
 	default 16
 	help
 	  All program operations will be a multiple of this value.
 
 config FS_LITTLEFS_CACHE_SIZE
 	int "Size of block caches in bytes"
+	default FS_LITTLEFS_PROG_SIZE if FS_LITTLEFS_BLK_DEV
 	default 64
 	help
 	  Each cache buffers a portion of a block in RAM.  The littlefs
@@ -103,11 +120,5 @@ config FS_LITTLEFS_HEAP_PER_ALLOC_OVERHEAD_SIZE
 	  by FS_LITTLEFS_NUM_FILES, try to increase the value.
 
 endif # FS_LITTLEFS_FC_HEAP_SIZE <= 0
-
-config FS_LITTLEFS_BLK_DEV
-	bool "Enable support for littlefs on block devices"
-	help
-	  Enable this option to provide support for littlefs on the block
-	  devices (like for example SD card).
 
 endif # FILE_SYSTEM_LITTLEFS


### PR DESCRIPTION
a. Enables the selection/deselection of flash backend,
b. Update config values for block devices,
c. Remove some configuration errors,
d. General cleanup,

Signed-off-by: Laczen JMS <laczenjms@gmail.com>