### PR TITLE
Introduce a barrier API

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -29,4 +29,5 @@
 --ignore MULTISTATEMENT_MACRO_USE_DO_WHILE
 --ignore ENOSYS
 --ignore IS_ENABLED_CONFIG
+--ignore MEMORY_BARRIER
 --exclude ext

--- a/include/arch/arc/arch.h
+++ b/include/arch/arc/arch.h
@@ -31,6 +31,7 @@
 #include <arch/arc/v2/asm_inline.h>
 #include <arch/arc/arc_addr_types.h>
 #include <arch/arc/v2/error.h>
+#include <arch/arc/barrier.h>
 
 #ifdef CONFIG_ARC_CONNECT
 #include <arch/arc/v2/arc_connect.h>

--- a/include/arch/arc/barrier.h
+++ b/include/arch/arc/barrier.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2022 Carlo Caione <ccaione@baylibre.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_ARCH_ARC_BARRIER_H_
+#define ZEPHYR_INCLUDE_ARCH_ARC_BARRIER_H_
+
+#ifndef _ASMLANGUAGE
+
+/* Not implemented yet */
+
+#include <barrier.h>
+
+#endif /* !_ASMLANGUAGE */
+
+#endif /* ZEPHYR_INCLUDE_ARCH_ARC_BARRIER_H_ */

--- a/include/arch/arm/aarch32/arch.h
+++ b/include/arch/arm/aarch32/arch.h
@@ -27,6 +27,7 @@
 #include <arch/arm/aarch32/irq.h>
 #include <arch/arm/aarch32/error.h>
 #include <arch/arm/aarch32/misc.h>
+#include <arch/arm/aarch32/barrier.h>
 #include <arch/common/addr_types.h>
 #include <arch/common/ffs.h>
 #include <arch/arm/aarch32/nmi.h>

--- a/include/arch/arm/aarch32/barrier.h
+++ b/include/arch/arm/aarch32/barrier.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2022 Carlo Caione <ccaione@baylibre.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_ARCH_ARM_AARCH32_BARRIER_H_
+#define ZEPHYR_INCLUDE_ARCH_ARM_AARCH32_BARRIER_H_
+
+#ifndef _ASMLANGUAGE
+
+/*
+ * Fallback on CMSIS
+ */
+#if defined(CONFIG_CPU_CORTEX_M)
+#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#elif defined(CONFIG_CPU_CORTEX_R) || defined(CONFIG_CPU_AARCH32_CORTEX_A)
+#include <arch/arm/aarch32/cortex_a_r/cmsis.h>
+#endif
+
+#if !defined(isb)
+#define isb()		__ISB()
+#endif
+
+#if !defined(mb)
+#define mb()		__DSB()
+#endif
+
+#if !defined(rmb)
+#define rmb()		__DSB()
+#endif
+
+#if !defined(wmb)
+#define wmb()		__DSB()
+#endif
+
+#if !defined(smp_mb)
+#define smp_mb()	__DMB()
+#endif
+
+#if !defined(smp_rmb)
+#define smp_rmb()	__DMB()
+#endif
+
+#if !defined(smp_wmb)
+#define smp_wmb()	__DMB()
+#endif
+
+#include <barrier.h>
+
+#endif /* !_ASMLANGUAGE */
+
+#endif /* ZEPHYR_INCLUDE_ARCH_ARM_AARCH32_BARRIER_H_ */

--- a/include/arch/arm64/arch.h
+++ b/include/arch/arm64/arch.h
@@ -31,6 +31,7 @@
 #include <arch/arm64/error.h>
 #include <arch/arm64/mm.h>
 #include <arch/arm64/thread_stack.h>
+#include <arch/arm64/barrier.h>
 #include <arch/common/addr_types.h>
 #include <arch/common/sys_bitops.h>
 #include <arch/common/ffs.h>

--- a/include/arch/arm64/barrier.h
+++ b/include/arch/arm64/barrier.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022 Carlo Caione <ccaione@baylibre.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_ARCH_ARM64_BARRIER_H_
+#define ZEPHYR_INCLUDE_ARCH_ARM64_BARRIER_H_
+
+#ifndef _ASMLANGUAGE
+
+#if !defined(isb)
+#define isb()		__asm__ volatile ("isb")
+#endif
+
+#if !defined(mb)
+#define mb()		__asm__ volatile ("dsb sy" : : : "memory")
+#endif
+
+#if !defined(rmb)
+#define rmb()		__asm__ volatile ("dsb ld" : : : "memory")
+#endif
+
+#if !defined(wmb)
+#define wmb()		__asm__ volatile ("dsb st" : : : "memory")
+#endif
+
+#if !defined(smp_mb)
+#define smp_mb()	__asm__ volatile ("dmb ish" : : : "memory")
+#endif
+
+#if !defined(smp_rmb)
+#define smp_rmb()	__asm__ volatile ("dmb ishld" : : : "memory")
+#endif
+
+#if !defined(smp_wmb)
+#define smp_wmb()	__asm__ volatile ("dmb ishst" : : : "memory")
+#endif
+
+#include <barrier.h>
+
+#endif /* !_ASMLANGUAGE */
+
+#endif /* ZEPHYR_INCLUDE_ARCH_ARM64_BARRIER_H_ */

--- a/include/arch/nios2/arch.h
+++ b/include/arch/nios2/arch.h
@@ -24,6 +24,7 @@
 #include <arch/common/sys_bitops.h>
 #include <sys/sys_io.h>
 #include <arch/common/ffs.h>
+#include <arch/nios2/barrier.h>
 
 #define ARCH_STACK_PTR_ALIGN  4
 

--- a/include/arch/nios2/barrier.h
+++ b/include/arch/nios2/barrier.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2022 Carlo Caione <ccaione@baylibre.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_ARCH_NIOS2_BARRIER_H_
+#define ZEPHYR_INCLUDE_ARCH_NIOS2_BARRIER_H_
+
+#ifndef _ASMLANGUAGE
+
+/* Not implemented yet */
+
+#include <barrier.h>
+
+#endif /* !_ASMLANGUAGE */
+
+#endif /* ZEPHYR_INCLUDE_ARCH_NIOS2_BARRIER_H_ */

--- a/include/arch/posix/arch.h
+++ b/include/arch/posix/arch.h
@@ -27,6 +27,7 @@
 #include <board_irq.h> /* Each board must define this */
 #include <sw_isr_table.h>
 #include <arch/posix/posix_soc_if.h>
+#include <arch/posix/barrier.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/arch/posix/barrier.h
+++ b/include/arch/posix/barrier.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2022 Carlo Caione <ccaione@baylibre.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_ARCH_POSIX_BARRIER_H_
+#define ZEPHYR_INCLUDE_ARCH_POSIX_BARRIER_H_
+
+#ifndef _ASMLANGUAGE
+
+/* Not implemented yet */
+
+#include <barrier.h>
+
+#endif /* !_ASMLANGUAGE */
+
+#endif /* ZEPHYR_INCLUDE_ARCH_POSIX_BARRIER_H_ */

--- a/include/arch/riscv/arch.h
+++ b/include/arch/riscv/arch.h
@@ -28,6 +28,7 @@
 #include <soc.h>
 #include <devicetree.h>
 #include <arch/riscv/csr.h>
+#include <arch/riscv/barrier.h>
 
 /* stacks, for RISCV architecture stack should be 16byte-aligned */
 #define ARCH_STACK_PTR_ALIGN  16

--- a/include/arch/riscv/barrier.h
+++ b/include/arch/riscv/barrier.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2022 Carlo Caione <ccaione@baylibre.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_ARCH_RISCV_BARRIER_H_
+#define ZEPHYR_INCLUDE_ARCH_RISCV_BARRIER_H_
+
+#ifndef _ASMLANGUAGE
+
+/* Not implemented yet */
+
+#include <barrier.h>
+
+#endif /* !_ASMLANGUAGE */
+
+#endif /* ZEPHYR_INCLUDE_ARCH_RISCV_BARRIER_H_ */

--- a/include/arch/sparc/arch.h
+++ b/include/arch/sparc/arch.h
@@ -19,6 +19,7 @@
 #include <arch/common/sys_bitops.h>
 #include <arch/common/sys_io.h>
 #include <arch/common/ffs.h>
+#include <arch/sparc/barrier.h>
 
 #include <irq.h>
 #include <sw_isr_table.h>

--- a/include/arch/sparc/barrier.h
+++ b/include/arch/sparc/barrier.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2022 Carlo Caione <ccaione@baylibre.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_ARCH_SPARC_BARRIER_H_
+#define ZEPHYR_INCLUDE_ARCH_SPARC_BARRIER_H_
+
+#ifndef _ASMLANGUAGE
+
+/* Not implemented yet */
+
+#include <barrier.h>
+
+#endif /* !_ASMLANGUAGE */
+
+#endif /* ZEPHYR_INCLUDE_ARCH_SPARC_BARRIER_H_ */

--- a/include/arch/x86/arch.h
+++ b/include/arch/x86/arch.h
@@ -22,6 +22,7 @@
 #include <irq.h>
 #include <arch/x86/mmustructs.h>
 #include <arch/x86/thread_stack.h>
+#include <arch/x86/barrier.h>
 #include <linker/sections.h>
 
 #ifdef __cplusplus

--- a/include/arch/x86/barrier.h
+++ b/include/arch/x86/barrier.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2022 Carlo Caione <ccaione@baylibre.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_ARCH_X86_BARRIER_H_
+#define ZEPHYR_INCLUDE_ARCH_X86_BARRIER_H_
+
+#ifndef _ASMLANGUAGE
+
+/* Not implemented yet */
+
+#include <barrier.h>
+
+#endif /* !_ASMLANGUAGE */
+
+#endif /* ZEPHYR_INCLUDE_ARCH_X86_BARRIER_H_ */

--- a/include/arch/xtensa/arch.h
+++ b/include/arch/xtensa/arch.h
@@ -25,6 +25,7 @@
 #include <sw_isr_table.h>
 #include <arch/xtensa/thread.h>
 #include <arch/xtensa/irq.h>
+#include <arch/xtensa/barrier.h>
 #include <xtensa/config/core.h>
 #include <arch/common/addr_types.h>
 #include <arch/xtensa/gdbstub.h>

--- a/include/arch/xtensa/barrier.h
+++ b/include/arch/xtensa/barrier.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2022 Carlo Caione <ccaione@baylibre.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_ARCH_XTENSA_BARRIER_H_
+#define ZEPHYR_INCLUDE_ARCH_XTENSA_BARRIER_H_
+
+#ifndef _ASMLANGUAGE
+
+/* Not implemented yet */
+
+#include <barrier.h>
+
+#endif /* !_ASMLANGUAGE */
+
+#endif /* ZEPHYR_INCLUDE_ARCH_XTENSA_BARRIER_H_ */

--- a/include/barrier.h
+++ b/include/barrier.h
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2022 Carlo Caione <ccaione@baylibre.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Public interface for barriers.
+ */
+#ifndef ZEPHYR_INCLUDE_BARRIER_H_
+#define ZEPHYR_INCLUDE_BARRIER_H_
+
+#ifndef _ASMLANGUAGE
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @defgroup barrier_apis Barriers API
+ * @ingroup kernel_apis
+ * @{
+ */
+
+#if !defined(nop) || defined(__DOXYGEN__)
+/**
+ * @brief nop
+ *
+ * NOP instruction.
+ */
+#define nop()		__asm__ volatile ("nop")
+#endif /* !nop */
+
+#if !defined(isb) || defined(__DOXYGEN__)
+/**
+ * @brief isb
+ *
+ * This is used to guarantee that any subsequent instructions are fetched, so
+ * that privilege and access are checked with the current MMU configuration.
+ */
+#define isb()
+#endif /* !isb */
+
+#if !defined(mb) || defined(__DOXYGEN__)
+/**
+ * @brief mb - Memory Barrier
+ *
+ * A full system memory barrier. All memory operations before the mb() in the
+ * instruction stream will be committed before any operations after the mb()
+ * are committed.
+ */
+#define mb()		compiler_barrier()
+#endif /* !mb */
+
+#if !defined(rmb) || defined(__DOXYGEN__)
+/**
+ * @brief rmb - Read Memory Barrier
+ *
+ * Like mb(), but only guarantees ordering between read accesses. That is, all
+ * read operations before an rmb() will be committed before any read operations
+ * after the rmb().
+ */
+#define rmb()		mb()
+#endif /* !rmb */
+
+#if !defined(wmb) || defined(__DOXYGEN__)
+/**
+ * @brief wmb - Write Memory Barrier
+ *
+ * Like mb(), but only guarantees ordering between write accesses. That is, all
+ * write operations before a wmb() will be committed before any write
+ * operations after the wmb().
+ */
+#define wmb()		mb()
+#endif /* !wmb */
+
+#if defined(CONFIG_SMP) || defined(__DOXYGEN__)
+
+#if !defined(smp_mb) || defined(__DOXYGEN__)
+/**
+ * @brief smp_mb - SMP Memory Barrier
+ *
+ * Similar to mb(), but only guarantees ordering between cores/processors
+ * within an SMP system. All memory accesses before the smp_mb() will be
+ * visible to all cores within the SMP system before any accesses after the
+ * smp_mb().
+ */
+#define smp_mb()	mb()
+#endif /* !smp_mb */
+
+#if !defined(smp_rmb) || defined(__DOXYGEN__)
+/**
+ * @brief smp_rmb - SMP Read Memory Barrier
+ *
+ * Like smp_mb(), but only guarantees ordering between read accesses.
+ */
+#define smp_rmb()	rmb()
+#endif /* !smp_rmb */
+
+#if !defined(smp_wmb) || defined(__DOXYGEN__)
+/**
+ * @brief smp_wmb - SMP Write Memory Barrier
+ *
+ * Like smp_mb(), but only guarantees ordering between write accesses.
+ */
+#define smp_wmb()	wmb()
+#endif /* !smp_wmb */
+
+#else /* !CONFIG_SMP */
+
+#if !defined(smp_mb)
+#define smp_mb()	compiler_barrier()
+#endif /* !smp_mb */
+
+#if !defined(smp_rmb)
+#define smp_rmb()	compiler_barrier()
+#endif /* !smp_rmb */
+
+#if !defined(smp_wmb)
+#define smp_wmb()	compiler_barrier()
+#endif /* !smp_wmb */
+
+#endif /* CONFIG_SMP */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !_ASMLANGUAGE */
+
+#endif /* ZEPHYR_INCLUDE_BARRIER_H_ */


### PR DESCRIPTION
This is long due, so I'm taking a shot at this because this is becoming important especially for ARM64.

This PR is basically introducing support for the barrier operations (`mb`, `wmb`, `rmb` and the SMP equivalent). This is done introducing a generic fallback implementation in `include/barrier.h` to be specialized (if needed) by each arch. The name is taken from Linux but the implementation is slimmer.

In this PR I specialize the operations for ARM and ARM64 because I'm only familiar with these architectures.