### PR TITLE
drivers: gpio: Fix NO_PINT_INT

### DIFF
--- a/drivers/gpio/gpio_mcux_lpc.c
+++ b/drivers/gpio/gpio_mcux_lpc.c
@@ -28,7 +28,16 @@
 #define PIN_TO_INPUT_MUX_CONNECTION(port, pin) \
 	((PINTSEL_PMUX_ID << PMUX_SHIFT) + (32 * port) + (pin))
 
-#define NO_PINT_INT ((1 << sizeof(pint_pin_int_t)) - 1)
+#ifndef FSL_FEATURE_PINT_NUMBER_OF_CONNECTED_OUTPUTS
+#define FSL_FEATURE_PINT_NUMBER_OF_CONNECTED_OUTPUTS 0
+#endif
+#ifndef FSL_FEATURE_SECPINT_NUMBER_OF_CONNECTED_OUTPUTS
+#define FSL_FEATURE_SECPINT_NUMBER_OF_CONNECTED_OUTPUTS 0
+#endif
+
+#define NO_PINT_INT                                                                                \
+	MAX(FSL_FEATURE_PINT_NUMBER_OF_CONNECTED_OUTPUTS,                                          \
+	    FSL_FEATURE_SECPINT_NUMBER_OF_CONNECTED_OUTPUTS)
 
 struct gpio_mcux_lpc_config {
 	/* gpio_driver_config needs to be first */


### PR DESCRIPTION
Fixed #41945
NO_PINT_INT can have the same value as a specific pin.
E.G. For 1 byte pint_pin_int_t it equaled interrupt1.
Now is instead always 1 higher than the highest pin.
Expects fsl to keep setting values from 0 to
(number of connected outputs - 1)

Signed-off-by: Martin Koehler <koehler@metratec.com>