### PR TITLE
ztest: run before function in test thread

### DIFF
--- a/subsys/testsuite/ztest/src/ztest_new.c
+++ b/subsys/testsuite/ztest/src/ztest_new.c
@@ -369,6 +369,10 @@ static void test_cb(void *a, void *b, void *c)
 	struct ztest_unit_test *test = b;
 
 	test_result = 1;
+	if (suite->before) {
+		suite->before(/*data=*/c);
+	}
+	run_test_rules(/*is_before=*/true, test, /*data=*/c);
 	run_test_functions(suite, test, c);
 	test_result = 0;
 }
@@ -380,10 +384,6 @@ static int run_test(struct ztest_suite_node *suite, struct ztest_unit_test *test
 	TC_START(test->name);
 
 	phase = TEST_PHASE_BEFORE;
-	if (suite->before) {
-		suite->before(data);
-	}
-	run_test_rules(/*is_before=*/true, test, data);
 
 	if (IS_ENABLED(CONFIG_MULTITHREADING)) {
 		k_thread_create(&ztest_thread, ztest_thread_stack,
@@ -399,6 +399,10 @@ static int run_test(struct ztest_suite_node *suite, struct ztest_unit_test *test
 		k_thread_join(&ztest_thread, K_FOREVER);
 	} else {
 		test_result = 1;
+		if (suite->before) {
+			suite->before(data);
+		}
+		run_test_rules(/*is_before=*/true, test, data);
 		run_test_functions(suite, test, data);
 	}
 


### PR DESCRIPTION
A lot of tests need to be able to get their current tid and do some
action with it. It makes sense for the `before` function/rule to be
able to run in the same thread as the test. Note that the `after`
function does not run in the same thread because we need to guarantee
that it will run.

Signed-off-by: Yuval Peress <peress@google.com>