### PR TITLE
pm: fix c++ header guards

### DIFF
--- a/include/pm/device_runtime.h
+++ b/include/pm/device_runtime.h
@@ -185,6 +185,10 @@ static inline void pm_device_runtime_init_suspended(const struct device *dev) { 
 static inline void pm_device_runtime_init_off(const struct device *dev) { }
 #endif
 
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif
+
 /** @} */
 
 #ifdef __cplusplus


### PR DESCRIPTION
Fixes missing closing `}` which causes issues in C++ code that includes this header 