### PR TITLE
soc: esp32c3: fix device-tree information

### DIFF
--- a/drivers/clock_control/clock_control_esp32.c
+++ b/drivers/clock_control/clock_control_esp32.c
@@ -21,7 +21,7 @@
 #include <dt-bindings/clock/esp32s2_clock.h>
 #include "esp32s2/rom/rtc.h"
 #elif CONFIG_IDF_TARGET_ESP32C3
-#define DT_CPU_COMPAT esp_riscv
+#define DT_CPU_COMPAT espressif_riscv
 #include <dt-bindings/clock/esp32c3_clock.h>
 #include "esp32c3/rom/rtc.h"
 #include <soc/soc_caps.h>

--- a/dts/bindings/cpu/espressif,riscv.yml
+++ b/dts/bindings/cpu/espressif,riscv.yml
@@ -3,7 +3,7 @@
 
 description: Espressif RISC-V CPU
 
-compatible: "esp,riscv"
+compatible: "espressif,riscv"
 
 include: cpu.yaml
 

--- a/dts/riscv/espressif/esp32c3.dtsi
+++ b/dts/riscv/espressif/esp32c3.dtsi
@@ -24,7 +24,7 @@
 
 		cpu0: cpu@0 {
 			device_type = "cpu";
-			compatible = "esp,riscv";
+			compatible = "espressif,riscv";
 			reg = <0>;
 		};
 	};

--- a/dts/riscv/espressif/esp32c3.dtsi
+++ b/dts/riscv/espressif/esp32c3.dtsi
@@ -133,7 +133,7 @@
 			current-speed = <115200>;
 		};
 
-		timer0: counter@6001F000 {
+		timer0: counter@6001f000 {
 			compatible = "espressif,esp32-timer";
 			reg = <0x6001F000 DT_SIZE_K(4)>;
 			interrupts = <TG0_T0_LEVEL_INTR_SOURCE>;


### PR DESCRIPTION
There are 2 build warnings related to case sensitive address and
also a wrong CPU vendor name, which triggers those warnings.
This PR fixes both.