### PR TITLE
linker: Introduce zephyr,memory-region compatible

### DIFF
--- a/boards/arm/arty/arty_a7_arm_designstart_m1.dts
+++ b/boards/arm/arty/arty_a7_arm_designstart_m1.dts
@@ -26,13 +26,13 @@
 
 	soc {
 		itcm: memory@0 {
-			compatible = "arm,itcm";
+			compatible = "zephyr,memory-region", "arm,itcm";
 			reg = <0x00000000 DT_SIZE_K(64)>;
 			zephyr,memory-region = "ITCM";
 		};
 
 		dtcm: memory@20000000 {
-			compatible = "arm,dtcm";
+			compatible = "zephyr,memory-region", "arm,dtcm";
 			reg = <0x20000000 DT_SIZE_K(32)>;
 			zephyr,memory-region = "DTCM";
 		};

--- a/boards/arm/arty/arty_a7_arm_designstart_m3.dts
+++ b/boards/arm/arty/arty_a7_arm_designstart_m3.dts
@@ -32,13 +32,13 @@
 
 	soc {
 		itcm: memory@0 {
-			compatible = "arm,itcm";
+			compatible = "zephyr,memory-region", "arm,itcm";
 			reg = <0x00000000 DT_SIZE_K(32)>;
 			zephyr,memory-region = "ITCM";
 		};
 
 		dtcm: memory@20000000 {
-			compatible = "arm,dtcm";
+			compatible = "zephyr,memory-region", "arm,dtcm";
 			reg = <0x20000000 DT_SIZE_K(32)>;
 			zephyr,memory-region = "DTCM";
 		};

--- a/boards/arm/mps2_an521/mps2_an521.dts
+++ b/boards/arm/mps2_an521/mps2_an521.dts
@@ -80,13 +80,13 @@
 	 */
 
 	sram1: memory@10000000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x10000000 DT_SIZE_M(4)>;
 		zephyr,memory-region = "SRAM1";
 	};
 
 	sram2_3: memory@38000000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x38000000 DT_SIZE_M(4)>;
 		zephyr,memory-region = "SRAM2_3";
 	};

--- a/boards/arm/mps2_an521/mps2_an521_ns.dts
+++ b/boards/arm/mps2_an521/mps2_an521_ns.dts
@@ -80,13 +80,13 @@
 	 */
 
 	sram1: memory@0 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x0 DT_SIZE_M(4)>;
 		zephyr,memory-region = "SRAM1";
 	};
 
 	sram2_3: memory@28000000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x28000000 DT_SIZE_M(4)>;
 		zephyr,memory-region = "SRAM2_3";
 	};

--- a/boards/arm/mps2_an521/mps2_an521_remote.dts
+++ b/boards/arm/mps2_an521/mps2_an521_remote.dts
@@ -80,13 +80,13 @@
 	 */
 
 	sram1: memory@0 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x0 DT_SIZE_M(4)>;
 		zephyr,memory-region = "SRAM1";
 	};
 
 	sram2_3: memory@28000000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x28000000 DT_SIZE_M(4)>;
 		zephyr,memory-region = "SRAM2_3";
 	};

--- a/boards/arm/mps3_an547/mps3_an547.dts
+++ b/boards/arm/mps3_an547/mps3_an547.dts
@@ -108,6 +108,7 @@
 	 * you'll get the non-secure alias
 	 */
 	itcm: itcm@10000000 {	/* alias @ 0x0 */
+		compatible = "zephyr,memory-region";
 		reg = <0x10000000 DT_SIZE_K(512)>;
 		zephyr,memory-region = "ITCM";
 	};
@@ -118,6 +119,7 @@
 	};
 
 	dtcm: dtcm@30000000 {	/* alias @ 0x20000000 */
+		compatible = "zephyr,memory-region";
 		reg = <0x30000000 DT_SIZE_K(512)>;
 		zephyr,memory-region = "DTCM";
 	};

--- a/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
+++ b/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
@@ -22,7 +22,7 @@
 	};
 
 	sdram2: sdram@d0000000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		device_type = "memory";
 		reg = <0xd0000000 DT_SIZE_M(8)>;
 		zephyr,memory-region = "SDRAM2";

--- a/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
+++ b/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
@@ -23,7 +23,7 @@
 	};
 
 	sdram1: sdram@c0000000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		device_type = "memory";
 		reg = <0xc0000000 DT_SIZE_M(16)>;
 		zephyr,memory-region = "SDRAM1";

--- a/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.dts
+++ b/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.dts
@@ -22,7 +22,7 @@
 	};
 
 	sdram2: sdram@d0000000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		device_type = "memory";
 		reg = <0xd0000000 DT_SIZE_M(32)>;
 		zephyr,memory-region = "SDRAM2";

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -2855,6 +2855,60 @@ function(dt_prop var)
   endif()
 endfunction()
 
+# Usage:
+#
+#   dt_comp_path(<var> COMPATIBLE <compatible> [INDEX <idx>])
+#
+# Get a list of paths for the nodes with the given compatible. The value will
+# be returned in the <var> parameter.
+# <var> will be undefined if no such compatible exists.
+#
+# For details and considerations about the format of <path> and the returned
+# parameter refer to dt_prop().
+#
+# <var>                  : Return variable where the property value will be stored
+# COMPATIBLE <compatible>: Compatible for which the list of paths should be
+#                          returned, as it appears in the DTS source
+# INDEX <idx>            : Optional index when retrieving a value in an array property
+
+function(dt_comp_path var)
+  set(req_single_args "COMPATIBLE")
+  set(single_args "INDEX")
+  cmake_parse_arguments(DT_COMP "" "${req_single_args};${single_args}" "" ${ARGN})
+
+  if(${ARGV0} IN_LIST req_single_args)
+    message(FATAL_ERROR "dt_comp_path(${ARGV0} ...) missing return parameter.")
+  endif()
+
+  foreach(arg ${req_single_args})
+    if(NOT DEFINED DT_COMP_${arg})
+      message(FATAL_ERROR "dt_comp_path(${ARGV0} ...) "
+                          "missing required argument: ${arg}"
+      )
+    endif()
+  endforeach()
+
+  get_property(exists TARGET devicetree_target
+      PROPERTY "DT_COMP|${DT_COMP_COMPATIBLE}"
+      SET
+  )
+
+  if(NOT exists)
+    set(${var} PARENT_SCOPE)
+    return()
+  endif()
+
+  get_target_property(val devicetree_target
+      "DT_COMP|${DT_COMP_COMPATIBLE}"
+  )
+
+  if(DEFINED DT_COMP_INDEX)
+    list(GET val ${DT_COMP_INDEX} element)
+    set(${var} "${element}" PARENT_SCOPE)
+  else()
+    set(${var} "${val}" PARENT_SCOPE)
+  endif()
+endfunction()
 
 # Usage:
 #   dt_num_regs(<var> PATH <path>)

--- a/cmake/linker_script/arm/linker.cmake
+++ b/cmake/linker_script/arm/linker.cmake
@@ -34,20 +34,11 @@ zephyr_linker_memory(NAME FLASH    FLAGS rx START ${FLASH_ADDR} SIZE ${FLASH_SIZ
 zephyr_linker_memory(NAME RAM      FLAGS wx START ${RAM_ADDR}   SIZE ${RAM_SIZE})
 zephyr_linker_memory(NAME IDT_LIST FLAGS wx START ${IDT_ADDR}   SIZE 2K)
 
-# TI CCFG Registers
-zephyr_linker_dts_memory(NODELABEL ti_ccfg_partition FLAGS rwx)
-
-# Data & Instruction Tightly Coupled Memory
-zephyr_linker_dts_memory(CHOSEN "zephyr,itcm"  FLAGS rw)
-zephyr_linker_dts_memory(CHOSEN "zephyr,dtcm"  FLAGS rw)
-
-zephyr_linker_dts_memory(NODELABEL sram1       FLAGS rw)
-zephyr_linker_dts_memory(NODELABEL sram2       FLAGS rw)
-zephyr_linker_dts_memory(NODELABEL sram3       FLAGS rw)
-zephyr_linker_dts_memory(NODELABEL sram4       FLAGS rw)
-zephyr_linker_dts_memory(NODELABEL sdram1      FLAGS rw)
-zephyr_linker_dts_memory(NODELABEL sdram2      FLAGS rw)
-zephyr_linker_dts_memory(NODELABEL backup_sram FLAGS rw)
+# Only use 'rw' as FLAGS. It's not used anyway.
+dt_comp_path(paths COMPATIBLE "zephyr,memory-region")
+foreach(path IN LISTS paths)
+  zephyr_linker_dts_memory(PATH ${path} FLAGS rw)
+endforeach()
 
 if(CONFIG_XIP)
   zephyr_linker_group(NAME ROM_REGION LMA FLASH)

--- a/dts/arm/atmel/sam4l.dtsi
+++ b/dts/arm/atmel/sam4l.dtsi
@@ -46,7 +46,7 @@
 	 * exclusive for USB descriptors
 	 */
 	sram1: memory@21000000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x21000000 DT_SIZE_K(4)>;
 		zephyr,memory-region = "SRAM1";
 	};

--- a/dts/arm/cypress/psoc6.dtsi
+++ b/dts/arm/cypress/psoc6.dtsi
@@ -57,13 +57,13 @@
 	};
 
 	sram1: memory@8023000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x08023000 DT_SIZE_K(4)>;
 		zephyr,memory-region = "SRAM1";
 	};
 
 	sram2: memory@8024000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x08024000 DT_SIZE_K(112)>;
 		zephyr,memory-region = "SRAM2";
 	};

--- a/dts/arm/nordic/nrf5340_cpunet.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet.dtsi
@@ -49,7 +49,7 @@
 		};
 
 		sram1: memory@21000000 {
-			compatible = "mmio-sram";
+			compatible = "zephyr,memory-region", "mmio-sram";
 			zephyr,memory-region = "SRAM1";
 		};
 

--- a/dts/arm/nxp/nxp_lpc11u6x.dtsi
+++ b/dts/arm/nxp/nxp_lpc11u6x.dtsi
@@ -24,13 +24,13 @@
 	};
 
 	sram1:memory@20000000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x20000000 0x800>;
 		zephyr,memory-region = "SRAM1";
 	};
 
 	sram2:memory@20004000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x20004000 0x800>;
 		zephyr,memory-region = "SRAM2";
 	};

--- a/dts/arm/nxp/nxp_lpc54xxx.dtsi
+++ b/dts/arm/nxp/nxp_lpc54xxx.dtsi
@@ -50,13 +50,13 @@
 		};
 
 		sram1:memory@20010000 {
-			compatible = "mmio-sram";
+			compatible = "zephyr,memory-region", "mmio-sram";
 			reg = <0x20010000 DT_SIZE_K(64)>;
 			zephyr,memory-region = "SRAM1";
 		};
 
 		sram2:memory@20020000 {
-			compatible = "mmio-sram";
+			compatible = "zephyr,memory-region", "mmio-sram";
 			reg = <0x20020000 DT_SIZE_K(32)>;
 			zephyr,memory-region = "SRAM2";
 		};

--- a/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
@@ -45,20 +45,20 @@
 	};
 
 	sram1: memory@20008000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x20008000 DT_SIZE_K(16)>;
 		zephyr,memory-region = "SRAM1";
 	};
 
 	sram2: memory@2000c000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x2000c000 DT_SIZE_K(16)>;
 		zephyr,memory-region = "SRAM2";
 	};
 
 	sram4: memory@20010000 {
 		/* Conencted to USB bus*/
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x20010000 DT_SIZE_K(16)>;
 		zephyr,memory-region = "SRAM4";
 	};

--- a/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
@@ -53,19 +53,19 @@
 	};
 
 	sram1: memory@20010000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x20010000 DT_SIZE_K(64)>;
 		zephyr,memory-region = "SRAM1";
 	};
 
 	sram2: memory@20020000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x20020000 DT_SIZE_K(64)>;
 		zephyr,memory-region = "SRAM2";
 	};
 
 	sram4: memory@20040000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x20040000 DT_SIZE_K(16)>;
 		zephyr,memory-region = "SRAM4";
 	};

--- a/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
@@ -57,25 +57,25 @@
 	};
 
 	sram1: memory@20010000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x20010000 DT_SIZE_K(32)>;
 		zephyr,memory-region = "SRAM1";
 	};
 
 	sram2: memory@20018000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x20018000 DT_SIZE_K(32)>;
 		zephyr,memory-region = "SRAM2";
 	};
 
 	sram3: memory@20020000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x20020000 DT_SIZE_K(32)>;
 		zephyr,memory-region = "SRAM3";
 	};
 
 	sram4: memory@40100000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x40100000 DT_SIZE_K(16)>;
 		zephyr,memory-region = "SRAM4";
 	};

--- a/dts/arm/nxp/nxp_rt.dtsi
+++ b/dts/arm/nxp/nxp_rt.dtsi
@@ -50,13 +50,13 @@
 			#size-cells = <1>;
 
 			itcm: itcm@0 {
-				compatible = "nxp,imx-itcm";
+				compatible = "zephyr,memory-region", "nxp,imx-itcm";
 				reg = <0x00000000 DT_SIZE_K(128)>;
 				zephyr,memory-region = "ITCM";
 			};
 
 			dtcm: dtcm@20000000 {
-				compatible = "nxp,imx-dtcm";
+				compatible = "zephyr,memory-region", "nxp,imx-dtcm";
 				reg = <0x20000000 DT_SIZE_K(128)>;
 				zephyr,memory-region = "DTCM";
 			};

--- a/dts/arm/nxp/nxp_rt1160_cm4.dtsi
+++ b/dts/arm/nxp/nxp_rt1160_cm4.dtsi
@@ -28,7 +28,7 @@
 		};
 
 		sram1: memory@20000000 {
-			compatible = "mmio-sram";
+			compatible = "zephyr,memory-region", "mmio-sram";
 			reg = <0x20000000 DT_SIZE_K(128)>;
 			zephyr,memory-region = "SRAM1";
 		};

--- a/dts/arm/nxp/nxp_rt1160_cm7.dtsi
+++ b/dts/arm/nxp/nxp_rt1160_cm7.dtsi
@@ -29,13 +29,13 @@
 			#size-cells = <1>;
 
 			itcm: itcm@0 {
-				compatible = "nxp,imx-itcm";
+				compatible = "zephyr,memory-region", "nxp,imx-itcm";
 				reg = <0x00000000 DT_SIZE_K(256)>;
 				zephyr,memory-region = "ITCM";
 			};
 
 			dtcm: dtcm@20000000 {
-				compatible = "nxp,imx-dtcm";
+				compatible = "zephyr,memory-region", "nxp,imx-dtcm";
 				reg = <0x20000000 DT_SIZE_K(256)>;
 				zephyr,memory-region = "DTCM";
 			};

--- a/dts/arm/nxp/nxp_rt1170_cm4.dtsi
+++ b/dts/arm/nxp/nxp_rt1170_cm4.dtsi
@@ -28,7 +28,7 @@
 		};
 
 		sram1: memory@20000000 {
-			compatible = "mmio-sram";
+			compatible = "zephyr,memory-region", "mmio-sram";
 			reg = <0x20000000 DT_SIZE_K(128)>;
 			zephyr,memory-region = "SRAM1";
 		};

--- a/dts/arm/nxp/nxp_rt1170_cm7.dtsi
+++ b/dts/arm/nxp/nxp_rt1170_cm7.dtsi
@@ -29,13 +29,13 @@
 			#size-cells = <1>;
 
 			itcm: itcm@0 {
-				compatible = "nxp,imx-itcm";
+				compatible = "zephyr,memory-region", "nxp,imx-itcm";
 				reg = <0x00000000 DT_SIZE_K(256)>;
 				zephyr,memory-region = "ITCM";
 			};
 
 			dtcm: dtcm@20000000 {
-				compatible = "nxp,imx-dtcm";
+				compatible = "zephyr,memory-region", "nxp,imx-dtcm";
 				reg = <0x20000000 DT_SIZE_K(256)>;
 				zephyr,memory-region = "DTCM";
 			};

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -549,7 +549,7 @@
 		};
 
 		backup_sram: memory@40024000 {
-			compatible = "st,stm32-backup-sram";
+			compatible = "zephyr,memory-region", "st,stm32-backup-sram";
 			reg = <0x40024000 DT_SIZE_K(4)>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00040000>;
 			label = "BACKUP_SRAM";

--- a/dts/arm/st/f3/stm32f303X8.dtsi
+++ b/dts/arm/st/f3/stm32f303X8.dtsi
@@ -9,7 +9,7 @@
 
 / {
 	ccm0: memory@10000000 {
-		compatible = "st,stm32-ccm";
+		compatible = "zephyr,memory-region", "st,stm32-ccm";
 		reg = <0x10000000 DT_SIZE_K(8)>;
 		zephyr,memory-region = "CCM";
 	};

--- a/dts/arm/st/f3/stm32f303Xc.dtsi
+++ b/dts/arm/st/f3/stm32f303Xc.dtsi
@@ -9,7 +9,7 @@
 
 / {
 	ccm0: memory@10000000 {
-		compatible = "st,stm32-ccm";
+		compatible = "zephyr,memory-region", "st,stm32-ccm";
 		reg = <0x10000000 DT_SIZE_K(8)>;
 		zephyr,memory-region = "CCM";
 	};

--- a/dts/arm/st/f3/stm32f303Xe.dtsi
+++ b/dts/arm/st/f3/stm32f303Xe.dtsi
@@ -9,7 +9,7 @@
 
 / {
 	ccm0: memory@10000000 {
-		compatible = "st,stm32-ccm";
+		compatible = "zephyr,memory-region", "st,stm32-ccm";
 		reg = <0x10000000 DT_SIZE_K(16)>;
 		zephyr,memory-region = "CCM";
 	};

--- a/dts/arm/st/f3/stm32f334X8.dtsi
+++ b/dts/arm/st/f3/stm32f334X8.dtsi
@@ -9,7 +9,7 @@
 
 / {
 	ccm0: memory@10000000 {
-		compatible = "st,stm32-ccm";
+		compatible = "zephyr,memory-region", "st,stm32-ccm";
 		reg = <0x10000000 DT_SIZE_K(4)>;
 		zephyr,memory-region = "CCM";
 	};

--- a/dts/arm/st/f4/stm32f405.dtsi
+++ b/dts/arm/st/f4/stm32f405.dtsi
@@ -250,7 +250,7 @@
 		};
 
 		backup_sram: memory@40024000 {
-			compatible = "st,stm32-backup-sram";
+			compatible = "zephyr,memory-region", "st,stm32-backup-sram";
 			reg = <0x40024000 DT_SIZE_K(4)>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00040000>;
 			label = "BACKUP_SRAM";

--- a/dts/arm/st/f4/stm32f405Xg.dtsi
+++ b/dts/arm/st/f4/stm32f405Xg.dtsi
@@ -9,7 +9,7 @@
 
 / {
 	ccm0: memory@10000000 {
-		compatible = "st,stm32-ccm";
+		compatible = "zephyr,memory-region", "st,stm32-ccm";
 		reg = <0x10000000 DT_SIZE_K(64)>;
 		zephyr,memory-region = "CCM";
 	};

--- a/dts/arm/st/f4/stm32f407Xe.dtsi
+++ b/dts/arm/st/f4/stm32f407Xe.dtsi
@@ -9,7 +9,7 @@
 
 / {
 	ccm0: memory@10000000 {
-		compatible = "st,stm32-ccm";
+		compatible = "zephyr,memory-region", "st,stm32-ccm";
 		reg = <0x10000000 DT_SIZE_K(64)>;
 		zephyr,memory-region = "CCM";
 	};

--- a/dts/arm/st/f4/stm32f407Xg.dtsi
+++ b/dts/arm/st/f4/stm32f407Xg.dtsi
@@ -9,7 +9,7 @@
 
 / {
 	ccm0: memory@10000000 {
-		compatible = "st,stm32-ccm";
+		compatible = "zephyr,memory-region", "st,stm32-ccm";
 		reg = <0x10000000 DT_SIZE_K(64)>;
 		zephyr,memory-region = "CCM";
 	};

--- a/dts/arm/st/f4/stm32f415Rg.dtsi
+++ b/dts/arm/st/f4/stm32f415Rg.dtsi
@@ -9,7 +9,7 @@
 
 / {
 	ccm0: memory@10000000 {
-		compatible = "st,stm32-ccm";
+		compatible = "zephyr,memory-region", "st,stm32-ccm";
 		reg = <0x10000000 DT_SIZE_K(64)>;
 		zephyr,memory-region = "CCM";
 	};

--- a/dts/arm/st/f4/stm32f417Xe.dtsi
+++ b/dts/arm/st/f4/stm32f417Xe.dtsi
@@ -9,7 +9,7 @@
 
 / {
 	ccm0: memory@10000000 {
-		compatible = "st,stm32-ccm";
+		compatible = "zephyr,memory-region", "st,stm32-ccm";
 		reg = <0x10000000 DT_SIZE_K(64)>;
 		zephyr,memory-region = "CCM";
 	};

--- a/dts/arm/st/f4/stm32f417Xg.dtsi
+++ b/dts/arm/st/f4/stm32f417Xg.dtsi
@@ -9,7 +9,7 @@
 
 / {
 	ccm0: memory@10000000 {
-		compatible = "st,stm32-ccm";
+		compatible = "zephyr,memory-region", "st,stm32-ccm";
 		reg = <0x10000000 DT_SIZE_K(64)>;
 		zephyr,memory-region = "CCM";
 	};

--- a/dts/arm/st/f4/stm32f427Xi.dtsi
+++ b/dts/arm/st/f4/stm32f427Xi.dtsi
@@ -9,7 +9,7 @@
 
 / {
 	ccm0: memory@10000000 {
-		compatible = "st,stm32-ccm";
+		compatible = "zephyr,memory-region", "st,stm32-ccm";
 		reg = <0x10000000 DT_SIZE_K(64)>;
 		zephyr,memory-region = "CCM";
 	};

--- a/dts/arm/st/f4/stm32f427vi.dtsi
+++ b/dts/arm/st/f4/stm32f427vi.dtsi
@@ -9,7 +9,7 @@
 
 / {
 	ccm0: memory@10000000 {
-		compatible = "st,stm32-ccm";
+		compatible = "zephyr,memory-region", "st,stm32-ccm";
 		reg = <0x10000000 DT_SIZE_K(64)>;
 		zephyr,memory-region = "CCM";
 	};

--- a/dts/arm/st/f4/stm32f429Xi.dtsi
+++ b/dts/arm/st/f4/stm32f429Xi.dtsi
@@ -9,7 +9,7 @@
 
 / {
 	ccm0: memory@10000000 {
-		compatible = "st,stm32-ccm";
+		compatible = "zephyr,memory-region", "st,stm32-ccm";
 		reg = <0x10000000 DT_SIZE_K(64)>;
 		zephyr,memory-region = "CCM";
 	};

--- a/dts/arm/st/f4/stm32f429vi.dtsi
+++ b/dts/arm/st/f4/stm32f429vi.dtsi
@@ -9,7 +9,7 @@
 
 / {
 	ccm0: memory@10000000 {
-		compatible = "st,stm32-ccm";
+		compatible = "zephyr,memory-region", "st,stm32-ccm";
 		reg = <0x10000000 DT_SIZE_K(64)>;
 		zephyr,memory-region = "CCM";
 	};

--- a/dts/arm/st/f4/stm32f437Xi.dtsi
+++ b/dts/arm/st/f4/stm32f437Xi.dtsi
@@ -9,7 +9,7 @@
 
 / {
 	ccm0: memory@10000000 {
-		compatible = "st,stm32-ccm";
+		compatible = "zephyr,memory-region", "st,stm32-ccm";
 		reg = <0x10000000 DT_SIZE_K(64)>;
 		zephyr,memory-region = "CCM";
 	};

--- a/dts/arm/st/f4/stm32f446.dtsi
+++ b/dts/arm/st/f4/stm32f446.dtsi
@@ -100,7 +100,7 @@
 		};
 
 		backup_sram: memory@40024000 {
-			compatible = "st,stm32-backup-sram";
+			compatible = "zephyr,memory-region", "st,stm32-backup-sram";
 			reg = <0x40024000 DT_SIZE_K(4)>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00040000>;
 			label = "BACKUP_SRAM";

--- a/dts/arm/st/f4/stm32f469Xi.dtsi
+++ b/dts/arm/st/f4/stm32f469Xi.dtsi
@@ -9,7 +9,7 @@
 
 / {
 	ccm0: memory@10000000 {
-		compatible = "st,stm32-ccm";
+		compatible = "zephyr,memory-region", "st,stm32-ccm";
 		reg = <0x10000000 DT_SIZE_K(64)>;
 		zephyr,memory-region = "CCM";
 	};

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -737,7 +737,7 @@
 		};
 
 		backup_sram: memory@40024000 {
-			compatible = "st,stm32-backup-sram";
+			compatible = "zephyr,memory-region", "st,stm32-backup-sram";
 			reg = <0x40024000 DT_SIZE_K(4)>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00040000>;
 			label = "BACKUP_SRAM";

--- a/dts/arm/st/f7/stm32f723.dtsi
+++ b/dts/arm/st/f7/stm32f723.dtsi
@@ -15,7 +15,7 @@
 	};
 
 	dtcm: memory@20000000 {
-		compatible = "arm,dtcm";
+		compatible = "zephyr,memory-region", "arm,dtcm";
 		reg = <0x20000000 DT_SIZE_K(64)>;
 		zephyr,memory-region = "DTCM";
 	};

--- a/dts/arm/st/f7/stm32f745.dtsi
+++ b/dts/arm/st/f7/stm32f745.dtsi
@@ -15,7 +15,7 @@
 	};
 
 	dtcm: memory@20000000 {
-		compatible = "arm,dtcm";
+		compatible = "zephyr,memory-region", "arm,dtcm";
 		reg = <0x20000000 DT_SIZE_K(64)>;
 		zephyr,memory-region = "DTCM";
 	};

--- a/dts/arm/st/f7/stm32f767.dtsi
+++ b/dts/arm/st/f7/stm32f767.dtsi
@@ -17,7 +17,7 @@
 	};
 
 	dtcm: memory@20000000 {
-		compatible = "arm,dtcm";
+		compatible = "zephyr,memory-region", "arm,dtcm";
 		reg = <0x20000000 DT_SIZE_K(128)>;
 		zephyr,memory-region = "DTCM";
 	};

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -871,7 +871,7 @@
 		};
 
 		backup_sram: memory@38800000 {
-			compatible = "st,stm32-backup-sram";
+			compatible = "zephyr,memory-region", "st,stm32-backup-sram";
 			reg = <0x38800000 DT_SIZE_K(4)>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB4 0x10000000>;
 			label = "BACKUP_SRAM";

--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -44,7 +44,7 @@
 
 	/* DTCM memory directly coppled to CPU */
 	dtcm: memory@20000000 {
-		compatible = "arm,dtcm";
+		compatible = "zephyr,memory-region", "arm,dtcm";
 		reg = <0x20000000 DT_SIZE_K(128)>;
 		zephyr,memory-region = "DTCM";
 	};

--- a/dts/arm/st/h7/stm32h735.dtsi
+++ b/dts/arm/st/h7/stm32h735.dtsi
@@ -60,26 +60,26 @@
 	/* System data RAM accessible over AHB bus: SRAM1 in D2 domain */
 	sram1: memory@30000000 {
 		reg = <0x30000000 DT_SIZE_K(16)>;
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		zephyr,memory-region = "SRAM1";
 	};
 
 	/* System data RAM accessible over AHB bus: SRAM2 in D2 domain */
 	sram2: memory@30040000 {
 		reg = <0x30040000 DT_SIZE_K(16)>;
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		zephyr,memory-region = "SRAM2";
 	};
 
 	/* System data RAM accessible over AHB bus: SRAM4 in D3 domain  */
 	sram4: memory@38000000 {
 		reg = <0x38000000 DT_SIZE_K(16)>;
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		zephyr,memory-region = "SRAM4";
 	};
 
 	dtcm: memory@20000000 {
-		compatible = "arm,dtcm";
+		compatible = "zephyr,memory-region", "arm,dtcm";
 		reg = <0x20000000 DT_SIZE_K(128)>;
 		zephyr,memory-region = "DTCM";
 	};

--- a/dts/arm/st/h7/stm32h743.dtsi
+++ b/dts/arm/st/h7/stm32h743.dtsi
@@ -43,20 +43,20 @@
 	/* System data RAM accessible over AHB bus: SRAM1 in D2 domain */
 	sram1: memory@30000000 {
 		reg = <0x30000000 DT_SIZE_K(128)>;
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		zephyr,memory-region = "SRAM1";
 	};
 
 	/* System data RAM accessible over AHB bus: SRAM2 in D2 domain */
 	sram2: memory@30020000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x30020000 DT_SIZE_K(128)>;
 		zephyr,memory-region = "SRAM2";
 	};
 
 	/* System data RAM accessible over AHB bus: SRAM3 in D2 domain */
 	sram3: memory@30040000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x30040000 DT_SIZE_K(32)>;
 		zephyr,memory-region = "SRAM3";
 	};
@@ -64,12 +64,12 @@
 	/* System data RAM accessible over AHB bus: SRAM4 in D3 domain  */
 	sram4: memory@38000000 {
 		reg = <0x38000000 DT_SIZE_K(64)>;
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		zephyr,memory-region = "SRAM4";
 	};
 
 	dtcm: memory@20000000 {
-		compatible = "arm,dtcm";
+		compatible = "zephyr,memory-region", "arm,dtcm";
 		reg = <0x20000000 DT_SIZE_K(128)>;
 		zephyr,memory-region = "DTCM";
 	};

--- a/dts/arm/st/h7/stm32h745.dtsi
+++ b/dts/arm/st/h7/stm32h745.dtsi
@@ -40,20 +40,20 @@
 	/* System data RAM accessible over AHB bus: SRAM1 in D2 domain */
 	sram1: memory@30000000 {
 		reg = <0x30000000 DT_SIZE_K(128)>;
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		zephyr,memory-region = "SRAM1";
 	};
 
 	/* System data RAM accessible over AHB bus: SRAM2 in D2 domain */
 	sram2: memory@30020000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x30020000 DT_SIZE_K(128)>;
 		zephyr,memory-region = "SRAM2";
 	};
 
 	/* System data RAM accessible over AHB bus: SRAM3 in D2 domain */
 	sram3: memory@30040000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x30040000 DT_SIZE_K(32)>;
 		zephyr,memory-region = "SRAM3";
 	};
@@ -61,7 +61,7 @@
 	/* System data RAM accessible over AHB bus: SRAM4 in D3 domain  */
 	sram4: memory@38000000 {
 		reg = <0x38000000 DT_SIZE_K(64)>;
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		zephyr,memory-region = "SRAM4";
 	};
 };

--- a/dts/arm/st/h7/stm32h745Xi_m7.dtsi
+++ b/dts/arm/st/h7/stm32h745Xi_m7.dtsi
@@ -15,7 +15,7 @@
 	};
 
 	dtcm: memory@20000000 {
-		compatible = "arm,dtcm";
+		compatible = "zephyr,memory-region", "arm,dtcm";
 		reg = <0x20000000 DT_SIZE_K(128)>;
 		zephyr,memory-region = "DTCM";
 	};

--- a/dts/arm/st/h7/stm32h750.dtsi
+++ b/dts/arm/st/h7/stm32h750.dtsi
@@ -22,20 +22,20 @@
 	/* System data RAM accessible over AHB bus: SRAM1 in D2 domain */
 	sram1: memory@30000000 {
 		reg = <0x30000000 DT_SIZE_K(128)>;
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		zephyr,memory-region = "SRAM1";
 	};
 
 	/* System data RAM accessible over AHB bus: SRAM2 in D2 domain */
 	sram2: memory@30020000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x30020000 DT_SIZE_K(128)>;
 		zephyr,memory-region = "SRAM2";
 	};
 
 	/* System data RAM accessible over AHB bus: SRAM3 in D2 domain */
 	sram3: memory@30040000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x30040000 DT_SIZE_K(32)>;
 		zephyr,memory-region = "SRAM3";
 	};
@@ -43,12 +43,12 @@
 	/* System data RAM accessible over AHB bus: SRAM4 in D3 domain  */
 	sram4: memory@38000000 {
 		reg = <0x38000000 DT_SIZE_K(64)>;
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		zephyr,memory-region = "SRAM4";
 	};
 
 	dtcm: memory@20000000 {
-		compatible = "arm,dtcm";
+		compatible = "zephyr,memory-region", "arm,dtcm";
 		reg = <0x20000000 DT_SIZE_K(128)>;
 		zephyr,memory-region = "DTCM";
 	};

--- a/dts/arm/st/h7/stm32h7a3.dtsi
+++ b/dts/arm/st/h7/stm32h7a3.dtsi
@@ -29,41 +29,41 @@
 
 	/* System data RAM accessible over AXI bus: AXI SRAM2 in CD domain */
 	sram1: memory@24040000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x24040000 DT_SIZE_K(384)>;
 		zephyr,memory-region = "SRAM1";
 	};
 
 	/* System data RAM accessible over AXI bus: AXI SRAM3 in CD domain */
 	sram2: memory@240A0000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x240A0000 DT_SIZE_K(384)>;
 		zephyr,memory-region = "SRAM2";
 	};
 
 	/* System data RAM accessible over AHB bus: SRAM1 in CD domain */
 	sram3: memory@30000000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x30000000 DT_SIZE_K(64)>;
 		zephyr,memory-region = "SRAM3";
 	};
 
 	/* System data RAM accessible over AHB bus: SRAM2 in CD domain  */
 	sram4: memory@30010000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x30010000 DT_SIZE_K(64)>;
 		zephyr,memory-region = "SRAM4";
 	};
 
 	/* System data RAM accessible over AHB bus: SRD SRAM in SRD domain  */
 	sram5: memory@38000000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x38000000 DT_SIZE_K(32)>;
 		zephyr,memory-region = "SRAM5";
 	};
 
 	dtcm: memory@20000000 {
-		compatible = "arm,dtcm";
+		compatible = "zephyr,memory-region", "arm,dtcm";
 		reg = <0x20000000 DT_SIZE_K(128)>;
 		zephyr,memory-region = "DTCM";
 	};

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -34,13 +34,13 @@
 	};
 
 	sram1: memory@20030000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x20030000 0x2800>;
 		zephyr,memory-region = "SRAM1";
 	};
 
 	sram2: memory@20038000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x20038000 0x5000>;
 		zephyr,memory-region = "SRAM2";
 	};

--- a/dts/arm/ti/cc1352r.dtsi
+++ b/dts/arm/ti/cc1352r.dtsi
@@ -22,6 +22,7 @@
 
 			/* CCFG registers occupy the last 88 bytes of flash */
 			ti_ccfg_partition: partition@57fa8 {
+				compatible = "zephyr,memory-region";
 				label = "ti_ccfg";
 				reg = <0x57fa8 88>;
 				zephyr,memory-region = "FLASH_CCFG";

--- a/dts/arm/ti/cc13x2_cc26x2.dtsi
+++ b/dts/arm/ti/cc13x2_cc26x2.dtsi
@@ -30,7 +30,7 @@
 
 	/* VIMS RAM configurable in CCFG as GPRAM or cache for FLASH (default) */
 	sram1: memory@11000000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x11000000 0x2000>;
 		zephyr,memory-region = "SRAM1";
 	};

--- a/dts/arm/ti/cc2652r.dtsi
+++ b/dts/arm/ti/cc2652r.dtsi
@@ -22,6 +22,7 @@
 
 			/* CCFG registers occupy the last 88 bytes of flash */
 			ti_ccfg_partition: partition@57fa8 {
+				compatible = "zephyr,memory-region";
 				label = "ti_ccfg";
 				reg = <0x57fa8 88>;
 				zephyr,memory-region = "FLASH_CCFG";

--- a/dts/arm/xilinx/zynq7000.dtsi
+++ b/dts/arm/xilinx/zynq7000.dtsi
@@ -13,13 +13,13 @@
 		interrupt-parent = <&gic>;
 
 		ocm_low: memory@1000 {
-			compatible = "xlnx,zynq-ocm";
+			compatible = "zephyr,memory-region", "xlnx,zynq-ocm";
 			reg = <0x00001000 DT_SIZE_K(188)>;
 			zephyr,memory-region = "OCM_LOW";
 		};
 
 		ocm_high: memory@fffc0000 {
-			compatible = "xlnx,zynq-ocm";
+			compatible = "zephyr,memory-region", "xlnx,zynq-ocm";
 			reg = <0xFFFC0000 DT_SIZE_K(256)>;
 			zephyr,memory-region = "OCM_HIGH";
 		};

--- a/dts/bindings/arm/arm,dtcm.yaml
+++ b/dts/bindings/arm/arm,dtcm.yaml
@@ -4,7 +4,7 @@ description: Cortex-M DTCM (Data Tightly Coupled Memory)
 
 compatible: "arm,dtcm"
 
-include: [base.yaml, mem-region.yaml]
+include: base.yaml
 
 properties:
     reg:

--- a/dts/bindings/arm/arm,itcm.yaml
+++ b/dts/bindings/arm/arm,itcm.yaml
@@ -4,7 +4,7 @@ description: Cortex-M ITCM (Instruction Tightly Coupled Memory)
 
 compatible: "arm,itcm"
 
-include: [base.yaml, mem-region.yaml]
+include: base.yaml
 
 properties:
     reg:

--- a/dts/bindings/arm/nxp,imx-dtcm.yaml
+++ b/dts/bindings/arm/nxp,imx-dtcm.yaml
@@ -5,7 +5,7 @@ description: i.MX DTCM (Data Tightly Coupled Memory)
 
 compatible: "nxp,imx-dtcm"
 
-include: [base.yaml, mem-region.yaml]
+include: base.yaml
 
 properties:
     reg:

--- a/dts/bindings/arm/nxp,imx-itcm.yaml
+++ b/dts/bindings/arm/nxp,imx-itcm.yaml
@@ -5,7 +5,7 @@ description: i.MX ITCM (Instruction Tightly Coupled Memory)
 
 compatible: "nxp,imx-itcm"
 
-include: [base.yaml, mem-region.yaml]
+include: base.yaml
 
 properties:
     reg:

--- a/dts/bindings/arm/st,stm32-ccm.yaml
+++ b/dts/bindings/arm/st,stm32-ccm.yaml
@@ -4,7 +4,7 @@ description: STM32 CCM (Core Coupled Memory)
 
 compatible: "st,stm32-ccm"
 
-include: [base.yaml, mem-region.yaml]
+include: base.yaml
 
 properties:
     reg:

--- a/dts/bindings/arm/xlnx,zynq-ocm.yaml
+++ b/dts/bindings/arm/xlnx,zynq-ocm.yaml
@@ -4,7 +4,7 @@ description: Xilinx Zynq OCM (On-Chip Memory)
 
 compatible: "xlnx,zynq-ocm"
 
-include: [base.yaml, mem-region.yaml]
+include: base.yaml
 
 properties:
     reg:

--- a/dts/bindings/base/zephyr,memory-region.yaml
+++ b/dts/bindings/base/zephyr,memory-region.yaml
@@ -1,11 +1,16 @@
 # Copyright (c) 2021, CSIRO
 # SPDX-License-Identifier: Apache-2.0
-# Common fields for devices resulting in linker memory regions
+
+description: Compatible for devices resulting in linker memory regions
+
+compatible: "zephyr,memory-region"
+
+include: base.yaml
 
 properties:
   zephyr,memory-region:
     type: string
-    required: false
+    required: true
     description: |
       Signify that this node should result in a dedicated linker script
       memory region in the final executable. The region address and size

--- a/dts/bindings/memory-controllers/st,stm32-backup-sram.yaml
+++ b/dts/bindings/memory-controllers/st,stm32-backup-sram.yaml
@@ -9,7 +9,7 @@ description: |
 
 compatible: "st,stm32-backup-sram"
 
-include: [base.yaml, mem-region.yaml]
+include: base.yaml
 
 properties:
   label:

--- a/dts/bindings/memory-controllers/st,stm32-fmc-sdram.yaml
+++ b/dts/bindings/memory-controllers/st,stm32-fmc-sdram.yaml
@@ -56,14 +56,14 @@ description: |
   memory device/s in DeviceTree:
 
   sdram1: sdram@c0000000 {
-      compatible = "mmio-sram";
+      compatible = "zephyr,memory-region", "mmio-sram";
       device_type = "memory";
       reg = <0xc000000 DT_SIZE_M(X)>;
       zephyr,memory-region = "SDRAM1";
   };
 
   sdram2: sdram@d0000000 {
-      compatible = "mmio-sram";
+      compatible = "zephyr,memory-region", "mmio-sram";
       device_type = "memory";
       reg = <0xd000000 DT_SIZE_M(X)>;
       zephyr,memory-region = "SDRAM2";

--- a/dts/bindings/mtd/fixed-partitions.yaml
+++ b/dts/bindings/mtd/fixed-partitions.yaml
@@ -28,12 +28,3 @@ child-binding:
           type: array
           description: register space
           required: true
-       zephyr,memory-region:
-          type: string
-          required: false
-          description: |
-            Signify that this node should result in a dedicated linker script
-            memory region in the final executable. The region address and size
-            is taken from the <reg> property, while the name is the value of
-            this property. This must only be added to memory-mapped partitions,
-            not partitions on external flash.

--- a/dts/bindings/sram/mmio-sram.yaml
+++ b/dts/bindings/sram/mmio-sram.yaml
@@ -5,7 +5,7 @@ description: Generic on-chip SRAM description
 
 compatible: "mmio-sram"
 
-include: [base.yaml, mem-region.yaml]
+include: base.yaml
 
 properties:
     reg:

--- a/include/arch/arm/aarch32/cortex_a_r/scripts/linker.ld
+++ b/include/arch/arm/aarch32/cortex_a_r/scripts/linker.ld
@@ -81,7 +81,7 @@ MEMORY
 {
     FLASH    (rx) : ORIGIN = ROM_ADDR, LENGTH = ROM_SIZE
     SRAM     (wx) : ORIGIN = RAM_ADDR, LENGTH = RAM_SIZE
-    LINKER_DT_REGION_FROM_NODE(DT_CHOSEN(zephyr_ocm), rw)
+    LINKER_DT_REGIONS()
     /* Used by and documented in include/linker/intlist.ld */
     IDT_LIST (wx) : ORIGIN = 0xFFFFF7FF, LENGTH = 2K
 }

--- a/include/arch/arm/aarch32/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/aarch32/cortex_m/scripts/linker.ld
@@ -81,22 +81,7 @@ MEMORY
     {
     FLASH (rx) : ORIGIN = ROM_ADDR, LENGTH = ROM_SIZE
     SRAM  (wx) : ORIGIN = RAM_ADDR, LENGTH = RAM_SIZE
-    /* TI CCFG Registers */
-    LINKER_DT_REGION_FROM_NODE(DT_NODELABEL(ti_ccfg_partition), rwx)
-    /* Data & Instruction Tightly Coupled Memory */
-    LINKER_DT_REGION_FROM_NODE(DT_CHOSEN(zephyr_itcm), rw)
-    LINKER_DT_REGION_FROM_NODE(DT_CHOSEN(zephyr_dtcm), rw)
-    /* STM32 Core Coupled Memory */
-    LINKER_DT_REGION_FROM_NODE(DT_CHOSEN(zephyr_ccm), rw)
-    /* STM32WB IPC RAM */
-    LINKER_DT_REGION_FROM_NODE(DT_NODELABEL(sram1), rw)
-    LINKER_DT_REGION_FROM_NODE(DT_NODELABEL(sram2), rw)
-    /* STM32 alternate RAM configurations */
-    LINKER_DT_REGION_FROM_NODE(DT_NODELABEL(sram3), rw)
-    LINKER_DT_REGION_FROM_NODE(DT_NODELABEL(sram4), rw)
-    LINKER_DT_REGION_FROM_NODE(DT_NODELABEL(sdram1), rw)
-    LINKER_DT_REGION_FROM_NODE(DT_NODELABEL(sdram2), rw)
-    LINKER_DT_REGION_FROM_NODE(DT_NODELABEL(backup_sram), rw)
+    LINKER_DT_REGIONS()
     /* Used by and documented in include/linker/intlist.ld */
     IDT_LIST (wx) : ORIGIN = 0xFFFFF7FF, LENGTH = 2K
     }

--- a/include/arch/riscv/common/linker.ld
+++ b/include/arch/riscv/common/linker.ld
@@ -81,9 +81,7 @@ MEMORY
 #endif
     RAM (rwx) : ORIGIN = RAM_BASE, LENGTH = RAM_SIZE
 
-    /* Data & Instruction Tightly Coupled Memory */
-    LINKER_DT_REGION_FROM_NODE(DT_CHOSEN(zephyr_itcm), rw)
-    LINKER_DT_REGION_FROM_NODE(DT_CHOSEN(zephyr_dtcm), rw)
+    LINKER_DT_REGIONS()
 
     /* Used by and documented in include/linker/intlist.ld */
     IDT_LIST  (wx)      : ORIGIN = 0xFFFFF7FF, LENGTH = 2K

--- a/include/linker/devicetree_regions.h
+++ b/include/linker/devicetree_regions.h
@@ -37,27 +37,28 @@
 
 /** @cond INTERNAL_HIDDEN */
 
+#define _DT_COMPATIBLE	zephyr_memory_region
+
 /**
  * @brief Declare a memory region
  *
  * @param node_id devicetree node identifier
  * @param attr region attributes
  */
-#define _REGION_DECLARE(node_id, attr)		    \
-	LINKER_DT_NODE_REGION_NAME(node_id)(attr) : \
-	ORIGIN = DT_REG_ADDR(node_id),		    \
+#define _REGION_DECLARE(node_id)	      \
+	LINKER_DT_NODE_REGION_NAME(node_id) : \
+	ORIGIN = DT_REG_ADDR(node_id),	      \
 	LENGTH = DT_REG_SIZE(node_id)
 
 /** @endcond */
 
 /**
- * @brief Generate a linker memory region from a devicetree node
+ * @brief Generate linker memory regions from the device tree nodes with
+ *        compatible 'zephyr,memory-region'
  *
- * @param node_id devicetree node identifier with a \<reg\> property defining
- *                region location and size
- * @param attr region attributes to use (rx, rw, ...)
+ * Note: for now we do not deal with MEMORY attributes since those are
+ * optional, not actually used by Zephyr and they will likely conflict with the
+ * MPU configuration.
  */
-#define LINKER_DT_REGION_FROM_NODE(node_id, attr)      \
-	COND_CODE_1(DT_NODE_HAS_STATUS(node_id, okay), \
-		    (_REGION_DECLARE(node_id, attr)),  \
-		    ())
+#define LINKER_DT_REGIONS() \
+	DT_FOREACH_STATUS_OKAY(_DT_COMPATIBLE, _REGION_DECLARE)

--- a/scripts/dts/gen_dts_cmake.py
+++ b/scripts/dts/gen_dts_cmake.py
@@ -43,6 +43,7 @@ import argparse
 import os
 import pickle
 import sys
+from collections import defaultdict
 
 sys.path.append(os.path.join(os.path.dirname(__file__), 'python-devicetree',
                              'src'))
@@ -95,6 +96,7 @@ def main():
         for alias in node.aliases:
             cmake_props.append(f'"DT_ALIAS|{alias}" "{path}"')
 
+    compatible2paths = defaultdict(list)
     for node in edt.nodes:
         cmake_props.append(f'"DT_NODE|{node.path}" TRUE')
 
@@ -117,6 +119,11 @@ def main():
                 cmake_prop = f'DT_PROP|{node.path}|{item}'
                 cmake_props.append(f'"{cmake_prop}" "{cmake_value}"')
 
+                if item == 'compatible':
+                    # compatibles is always an array
+                    for comp in node.props[item].val:
+                        compatible2paths[comp].append(node.path)
+
         if node.regs is not None:
             cmake_props.append(f'"DT_REG|{node.path}|NUM" "{len(node.regs)}"')
             cmake_addr = ''
@@ -135,6 +142,14 @@ def main():
 
             cmake_props.append(f'"DT_REG|{node.path}|ADDR" "{cmake_addr}"')
             cmake_props.append(f'"DT_REG|{node.path}|SIZE" "{cmake_size}"')
+
+    for comp in compatible2paths.keys():
+        cmake_path = ''
+        for path in compatible2paths[comp]:
+            cmake_path = f'{cmake_path}{path};'
+
+        cmake_comp = f'DT_COMP|{comp}'
+        cmake_props.append(f'"{cmake_comp}" "{cmake_path}"')
 
     with open(args.cmake_out, "w", encoding="utf-8") as cmake_file:
         print('add_custom_target(devicetree_target)', file=cmake_file)

--- a/soc/riscv/riscv-privilege/andes_v5/ae350/linker.ld
+++ b/soc/riscv/riscv-privilege/andes_v5/ae350/linker.ld
@@ -87,9 +87,7 @@ MEMORY
 #endif
     RAM (rwx) : ORIGIN = RAM_BASE, LENGTH = RAM_SIZE
 
-    /* Data & Instruction Tightly Coupled Memory */
-    LINKER_DT_REGION_FROM_NODE(DT_CHOSEN(zephyr_itcm), rw)
-    LINKER_DT_REGION_FROM_NODE(DT_CHOSEN(zephyr_dtcm), rw)
+    LINKER_DT_REGIONS()
 
     /* Used by and documented in include/linker/intlist.ld */
     IDT_LIST  (wx)      : ORIGIN = 0xFFFFF7FF, LENGTH = 2K

--- a/tests/lib/devicetree/api_ext/app.overlay
+++ b/tests/lib/devicetree/api_ext/app.overlay
@@ -17,7 +17,7 @@
 		#size-cells = < 0x1 >;
 
 		test_sram1: sram@20000000 {
-			compatible = "mmio-sram";
+			compatible = "zephyr,memory-region", "mmio-sram";
 			reg = < 0x20000000 0x1000 >;
 			zephyr,memory-region = "SRAM_REGION";
 		};


### PR DESCRIPTION
Introduce a new `zephyr,memory-region` compatible to be used when a new memory region must be created in the linker script from the devicetree node using the compatible.

Remove also the `LINKER_DT_REGION_FROM_NODE` macro and add a new `LINKER_DT_REGION` macro to cycle through all the compatible regions.

This is a preparatory work to be integrated with #41223 so that under one single compatible we have all the properties to create a new region in the linker script and set the MPU properties of the region using the info coming from the DT.