### PR TITLE
esp32: fix build issues after DEV_CFG and DEV_DATA removal

### DIFF
--- a/drivers/counter/counter_esp32.c
+++ b/drivers/counter/counter_esp32.c
@@ -51,8 +51,8 @@ LOG_MODULE_REGISTER(esp32_counter, CONFIG_COUNTER_LOG_LEVEL);
 #endif
 
 #define TIMX p_timer_obj[TIMG(dev)][TIDX(dev)]
-#define TIMG(dev) ((const struct counter_esp32_config *const)(dev->config)->group)
-#define TIDX(dev) ((const struct counter_esp32_config *const)(dev->config)->idx)
+#define TIMG(dev) (((const struct counter_esp32_config *const)(dev)->config))->group
+#define TIDX(dev) (((const struct counter_esp32_config *const)(dev)->config))->idx
 
 static void counter_esp32_isr(void *arg);
 
@@ -174,6 +174,7 @@ static int counter_esp32_set_alarm(const struct device *dev, uint8_t chan_id,
 				   const struct counter_alarm_cfg *alarm_cfg)
 {
 	ARG_UNUSED(chan_id);
+	struct counter_esp32_data *data = dev->data;
 	uint32_t now;
 
 	counter_esp32_get_value(dev, &now);

--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -89,7 +89,7 @@ static int gpio_esp32_config(const struct device *dev,
 			     gpio_pin_t pin,
 			     gpio_flags_t flags)
 {
-	struct gpio_esp32_config *const cfg = dev->config;
+	const struct gpio_esp32_config *const cfg = dev->config;
 	struct gpio_esp32_data *data = dev->data;
 	uint32_t io_pin = (uint32_t) pin;
 	uint32_t key;
@@ -206,7 +206,7 @@ end:
 
 static int gpio_esp32_port_get_raw(const struct device *port, uint32_t *value)
 {
-	struct gpio_esp32_config *const cfg = port->config;
+	const struct gpio_esp32_config *const cfg = port->config;
 
 	if (cfg->gpio_port == 0) {
 		*value = cfg->gpio_dev->in;
@@ -222,7 +222,7 @@ static int gpio_esp32_port_get_raw(const struct device *port, uint32_t *value)
 static int gpio_esp32_port_set_masked_raw(const struct device *port,
 					  uint32_t mask, uint32_t value)
 {
-	struct gpio_esp32_config *const cfg = port->config;
+	const struct gpio_esp32_config *const cfg = port->config;
 
 	uint32_t key = irq_lock();
 
@@ -242,7 +242,7 @@ static int gpio_esp32_port_set_masked_raw(const struct device *port,
 static int gpio_esp32_port_set_bits_raw(const struct device *port,
 					uint32_t pins)
 {
-	struct gpio_esp32_config *const cfg = port->config;
+	const struct gpio_esp32_config *const cfg = port->config;
 
 	if (cfg->gpio_port == 0) {
 		cfg->gpio_dev->out_w1ts = pins;
@@ -258,7 +258,7 @@ static int gpio_esp32_port_set_bits_raw(const struct device *port,
 static int gpio_esp32_port_clear_bits_raw(const struct device *port,
 					  uint32_t pins)
 {
-	struct gpio_esp32_config *const cfg = port->config;
+	const struct gpio_esp32_config *const cfg = port->config;
 
 	if (cfg->gpio_port == 0) {
 		cfg->gpio_dev->out_w1tc = pins;
@@ -274,7 +274,7 @@ static int gpio_esp32_port_clear_bits_raw(const struct device *port,
 static int gpio_esp32_port_toggle_bits(const struct device *port,
 				       uint32_t pins)
 {
-	struct gpio_esp32_config *const cfg = port->config;
+	const struct gpio_esp32_config *const cfg = port->config;
 	uint32_t key = irq_lock();
 
 	if (cfg->gpio_port == 0) {
@@ -328,7 +328,7 @@ static int gpio_esp32_pin_interrupt_configure(const struct device *port,
 					      enum gpio_int_mode mode,
 					      enum gpio_int_trig trig)
 {
-	struct gpio_esp32_config *const cfg = port->config;
+	const struct gpio_esp32_config *const cfg = port->config;
 	uint32_t io_pin = (uint32_t) pin;
 	int intr_trig_mode = convert_int_type(mode, trig);
 	uint32_t key;
@@ -356,7 +356,7 @@ static int gpio_esp32_manage_callback(const struct device *dev,
 
 static uint32_t gpio_esp32_get_pending_int(const struct device *dev)
 {
-	struct gpio_esp32_config *const cfg = dev->config;
+	const struct gpio_esp32_config *const cfg = dev->config;
 	uint32_t irq_status;
 	uint32_t const core_id = CPU_ID();
 
@@ -371,7 +371,7 @@ static uint32_t gpio_esp32_get_pending_int(const struct device *dev)
 
 static void IRAM_ATTR gpio_esp32_fire_callbacks(const struct device *dev)
 {
-	struct gpio_esp32_config *const cfg = dev->config;
+	const struct gpio_esp32_config *const cfg = dev->config;
 	struct gpio_esp32_data *data = dev->data;
 	uint32_t irq_status;
 	uint32_t const core_id = CPU_ID();

--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -57,7 +57,6 @@ struct uart_esp32_pin {
 };
 
 struct uart_esp32_config {
-	uart_hal_context_t hal;
 	const struct device *clock_dev;
 
 	const struct uart_esp32_pin tx;
@@ -73,6 +72,7 @@ struct uart_esp32_config {
 /* driver data */
 struct uart_esp32_data {
 	struct uart_config uart_config;
+	uart_hal_context_t hal;
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	uart_irq_callback_user_data_t irq_cb;
 	void *irq_cb_data;
@@ -91,36 +91,36 @@ static void uart_esp32_isr(void *arg);
 
 static int uart_esp32_poll_in(const struct device *dev, unsigned char *p_char)
 {
-	const struct uart_esp32_config *config = dev->config;
+	struct uart_esp32_data *data = dev->data;
 	int inout_rd_len = 1;
 
-	if (uart_hal_get_rxfifo_len(&config->hal) == 0) {
+	if (uart_hal_get_rxfifo_len(&data->hal) == 0) {
 		return -1;
 	}
 
-	uart_hal_read_rxfifo(&config->hal, p_char, &inout_rd_len);
+	uart_hal_read_rxfifo(&data->hal, p_char, &inout_rd_len);
 
 	return 0;
 }
 
 static void uart_esp32_poll_out(const struct device *dev, unsigned char c)
 {
-	const struct uart_esp32_config *config = dev->config;
+	struct uart_esp32_data *data = dev->data;
 	uint32_t written;
 
 	/* Wait for space in FIFO */
-	while (uart_hal_get_txfifo_len(&config->hal) == 0) {
+	while (uart_hal_get_txfifo_len(&data->hal) == 0) {
 		; /* Wait */
 	}
 
 	/* Send a character */
-	uart_hal_write_txfifo(&config->hal, &c, 1, &written);
+	uart_hal_write_txfifo(&data->hal, &c, 1, &written);
 }
 
 static int uart_esp32_err_check(const struct device *dev)
 {
-	const struct uart_esp32_config *config = dev->config;
-	uint32_t mask = uart_hal_get_intsts_mask(&config->hal);
+	struct uart_esp32_data *data = dev->data;
+	uint32_t mask = uart_hal_get_intsts_mask(&data->hal);
 	uint32_t err = mask & (UART_INTR_PARITY_ERR | UART_INTR_FRAM_ERR);
 
 	return err;
@@ -130,15 +130,15 @@ static int uart_esp32_err_check(const struct device *dev)
 static int uart_esp32_config_get(const struct device *dev,
 				 struct uart_config *cfg)
 {
-	const struct uart_esp32_config *config = dev->config;
+	struct uart_esp32_data *data = dev->data;
 	uart_parity_t parity;
 	uart_stop_bits_t stop_bit;
 	uart_word_length_t data_bit;
 	uart_hw_flowcontrol_t hw_flow;
 
-	uart_hal_get_baudrate(&config->hal, &cfg->baudrate);
+	uart_hal_get_baudrate(&data->hal, &cfg->baudrate);
 
-	uart_hal_get_parity(&config->hal, &parity);
+	uart_hal_get_parity(&data->hal, &parity);
 	switch (parity) {
 	case UART_PARITY_DISABLE:
 		cfg->parity = UART_CFG_PARITY_NONE;
@@ -153,7 +153,7 @@ static int uart_esp32_config_get(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	uart_hal_get_stop_bits(&config->hal, &stop_bit);
+	uart_hal_get_stop_bits(&data->hal, &stop_bit);
 	switch (stop_bit) {
 	case UART_STOP_BITS_1:
 		cfg->stop_bits = UART_CFG_STOP_BITS_1;
@@ -168,7 +168,7 @@ static int uart_esp32_config_get(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	uart_hal_get_data_bit_num(&config->hal, &data_bit);
+	uart_hal_get_data_bit_num(&data->hal, &data_bit);
 	switch (data_bit) {
 	case UART_DATA_5_BITS:
 		cfg->data_bits = UART_CFG_DATA_BITS_5;
@@ -186,7 +186,7 @@ static int uart_esp32_config_get(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	uart_hal_get_hw_flow_ctrl(&config->hal, &hw_flow);
+	uart_hal_get_hw_flow_ctrl(&data->hal, &hw_flow);
 	switch (hw_flow) {
 	case UART_HW_FLOWCTRL_DISABLE:
 		cfg->flow_ctrl = UART_CFG_FLOW_CTRL_NONE;
@@ -257,6 +257,7 @@ static int uart_esp32_configure_pins(const struct device *dev, const struct uart
 static int uart_esp32_configure(const struct device *dev, const struct uart_config *cfg)
 {
 	const struct uart_esp32_config *config = dev->config;
+	struct uart_esp32_data *data = dev->data;
 	int ret = uart_esp32_configure_pins(dev, cfg);
 
 	if (ret < 0) {
@@ -265,20 +266,20 @@ static int uart_esp32_configure(const struct device *dev, const struct uart_conf
 
 	clock_control_on(config->clock_dev, config->clock_subsys);
 
-	uart_hal_set_sclk(&config->hal, UART_SCLK_APB);
-	uart_hal_set_rxfifo_full_thr(&config->hal, UART_RX_FIFO_THRESH);
-	uart_hal_set_txfifo_empty_thr(&config->hal, UART_TX_FIFO_THRESH);
-	uart_hal_rxfifo_rst(&config->hal);
+	uart_hal_set_sclk(&data->hal, UART_SCLK_APB);
+	uart_hal_set_rxfifo_full_thr(&data->hal, UART_RX_FIFO_THRESH);
+	uart_hal_set_txfifo_empty_thr(&data->hal, UART_TX_FIFO_THRESH);
+	uart_hal_rxfifo_rst(&data->hal);
 
 	switch (cfg->parity) {
 	case UART_CFG_PARITY_NONE:
-		uart_hal_set_parity(&config->hal, UART_PARITY_DISABLE);
+		uart_hal_set_parity(&data->hal, UART_PARITY_DISABLE);
 		break;
 	case UART_CFG_PARITY_EVEN:
-		uart_hal_set_parity(&config->hal, UART_PARITY_EVEN);
+		uart_hal_set_parity(&data->hal, UART_PARITY_EVEN);
 		break;
 	case UART_CFG_PARITY_ODD:
-		uart_hal_set_parity(&config->hal, UART_PARITY_ODD);
+		uart_hal_set_parity(&data->hal, UART_PARITY_ODD);
 		break;
 	default:
 		return -ENOTSUP;
@@ -286,13 +287,13 @@ static int uart_esp32_configure(const struct device *dev, const struct uart_conf
 
 	switch (cfg->stop_bits) {
 	case UART_CFG_STOP_BITS_1:
-		uart_hal_set_stop_bits(&config->hal, UART_STOP_BITS_1);
+		uart_hal_set_stop_bits(&data->hal, UART_STOP_BITS_1);
 		break;
 	case UART_CFG_STOP_BITS_1_5:
-		uart_hal_set_stop_bits(&config->hal, UART_STOP_BITS_1_5);
+		uart_hal_set_stop_bits(&data->hal, UART_STOP_BITS_1_5);
 		break;
 	case UART_CFG_STOP_BITS_2:
-		uart_hal_set_stop_bits(&config->hal, UART_STOP_BITS_2);
+		uart_hal_set_stop_bits(&data->hal, UART_STOP_BITS_2);
 		break;
 	default:
 		return -ENOTSUP;
@@ -300,16 +301,16 @@ static int uart_esp32_configure(const struct device *dev, const struct uart_conf
 
 	switch (cfg->data_bits) {
 	case UART_CFG_DATA_BITS_5:
-		uart_hal_set_data_bit_num(&config->hal, UART_DATA_5_BITS);
+		uart_hal_set_data_bit_num(&data->hal, UART_DATA_5_BITS);
 		break;
 	case UART_CFG_DATA_BITS_6:
-		uart_hal_set_data_bit_num(&config->hal, UART_DATA_6_BITS);
+		uart_hal_set_data_bit_num(&data->hal, UART_DATA_6_BITS);
 		break;
 	case UART_CFG_DATA_BITS_7:
-		uart_hal_set_data_bit_num(&config->hal, UART_DATA_7_BITS);
+		uart_hal_set_data_bit_num(&data->hal, UART_DATA_7_BITS);
 		break;
 	case UART_CFG_DATA_BITS_8:
-		uart_hal_set_data_bit_num(&config->hal, UART_DATA_8_BITS);
+		uart_hal_set_data_bit_num(&data->hal, UART_DATA_8_BITS);
 		break;
 	default:
 		return -ENOTSUP;
@@ -317,18 +318,18 @@ static int uart_esp32_configure(const struct device *dev, const struct uart_conf
 
 	switch (cfg->flow_ctrl) {
 	case UART_CFG_FLOW_CTRL_NONE:
-		uart_hal_set_hw_flow_ctrl(&config->hal, UART_HW_FLOWCTRL_DISABLE, 0);
+		uart_hal_set_hw_flow_ctrl(&data->hal, UART_HW_FLOWCTRL_DISABLE, 0);
 		break;
 	case UART_CFG_FLOW_CTRL_RTS_CTS:
-		uart_hal_set_hw_flow_ctrl(&config->hal, UART_HW_FLOWCTRL_CTS_RTS, 10);
+		uart_hal_set_hw_flow_ctrl(&data->hal, UART_HW_FLOWCTRL_CTS_RTS, 10);
 		break;
 	default:
 		return -ENOTSUP;
 	}
 
-	uart_hal_set_baudrate(&config->hal, cfg->baudrate);
+	uart_hal_set_baudrate(&data->hal, cfg->baudrate);
 
-	uart_hal_set_rx_timeout(&config->hal, 0x16);
+	uart_hal_set_rx_timeout(&data->hal, 0x16);
 
 	return 0;
 }
@@ -357,102 +358,102 @@ static int uart_esp32_init(const struct device *dev)
 static int uart_esp32_fifo_fill(const struct device *dev,
 				const uint8_t *tx_data, int len)
 {
-	const struct uart_esp32_config *config = dev->config;
+	struct uart_esp32_data *data = dev->data;
 	uint32_t written = 0;
 
 	if (len < 0) {
 		return 0;
 	}
 
-	uart_hal_write_txfifo(&config->hal, tx_data, len, &written);
+	uart_hal_write_txfifo(&data->hal, tx_data, len, &written);
 	return written;
 }
 
 static int uart_esp32_fifo_read(const struct device *dev,
 				uint8_t *rx_data, const int len)
 {
-	const struct uart_esp32_config *config = dev->config;
-	const int num_rx = uart_hal_get_rxfifo_len(&config->hal);
+	struct uart_esp32_data *data = dev->data;
+	const int num_rx = uart_hal_get_rxfifo_len(&data->hal);
 	int read = MIN(len, num_rx);
 
 	if (!read) {
 		return 0;
 	}
 
-	uart_hal_read_rxfifo(&config->hal, rx_data, &read);
+	uart_hal_read_rxfifo(&data->hal, rx_data, &read);
 	return read;
 }
 
 static void uart_esp32_irq_tx_enable(const struct device *dev)
 {
-	const struct uart_esp32_config *config = dev->config;
+	struct uart_esp32_data *data = dev->data;
 
-	uart_hal_clr_intsts_mask(&config->hal, UART_INTR_TXFIFO_EMPTY);
-	uart_hal_ena_intr_mask(&config->hal, UART_INTR_TXFIFO_EMPTY);
+	uart_hal_clr_intsts_mask(&data->hal, UART_INTR_TXFIFO_EMPTY);
+	uart_hal_ena_intr_mask(&data->hal, UART_INTR_TXFIFO_EMPTY);
 }
 
 static void uart_esp32_irq_tx_disable(const struct device *dev)
 {
-	const struct uart_esp32_config *config = dev->config;
+	struct uart_esp32_data *data = dev->data;
 
-	uart_hal_disable_intr_mask(&config->hal, UART_INTR_TXFIFO_EMPTY);
+	uart_hal_disable_intr_mask(&data->hal, UART_INTR_TXFIFO_EMPTY);
 }
 
 static int uart_esp32_irq_tx_ready(const struct device *dev)
 {
-	const struct uart_esp32_config *config = dev->config;
+	struct uart_esp32_data *data = dev->data;
 
-	return (uart_hal_get_txfifo_len(&config->hal) > 0 &&
-			uart_hal_get_intr_ena_status(&config->hal) & UART_INTR_TXFIFO_EMPTY);
+	return (uart_hal_get_txfifo_len(&data->hal) > 0 &&
+			uart_hal_get_intr_ena_status(&data->hal) & UART_INTR_TXFIFO_EMPTY);
 }
 
 static void uart_esp32_irq_rx_enable(const struct device *dev)
 {
-	const struct uart_esp32_config *config = dev->config;
+	struct uart_esp32_data *data = dev->data;
 
-	uart_hal_clr_intsts_mask(&config->hal, UART_INTR_RXFIFO_FULL);
-	uart_hal_clr_intsts_mask(&config->hal, UART_INTR_RXFIFO_TOUT);
-	uart_hal_ena_intr_mask(&config->hal, UART_INTR_RXFIFO_FULL);
-	uart_hal_ena_intr_mask(&config->hal, UART_INTR_RXFIFO_TOUT);
+	uart_hal_clr_intsts_mask(&data->hal, UART_INTR_RXFIFO_FULL);
+	uart_hal_clr_intsts_mask(&data->hal, UART_INTR_RXFIFO_TOUT);
+	uart_hal_ena_intr_mask(&data->hal, UART_INTR_RXFIFO_FULL);
+	uart_hal_ena_intr_mask(&data->hal, UART_INTR_RXFIFO_TOUT);
 }
 
 static void uart_esp32_irq_rx_disable(const struct device *dev)
 {
-	const struct uart_esp32_config *config = dev->config;
+	struct uart_esp32_data *data = dev->data;
 
-	uart_hal_disable_intr_mask(&config->hal, UART_INTR_RXFIFO_FULL);
-	uart_hal_disable_intr_mask(&config->hal, UART_INTR_RXFIFO_TOUT);
+	uart_hal_disable_intr_mask(&data->hal, UART_INTR_RXFIFO_FULL);
+	uart_hal_disable_intr_mask(&data->hal, UART_INTR_RXFIFO_TOUT);
 }
 
 static int uart_esp32_irq_tx_complete(const struct device *dev)
 {
-	const struct uart_esp32_config *config = dev->config;
+	struct uart_esp32_data *data = dev->data;
 
-	return uart_hal_is_tx_idle(&config->hal);
+	return uart_hal_is_tx_idle(&data->hal);
 }
 
 static int uart_esp32_irq_rx_ready(const struct device *dev)
 {
-	const struct uart_esp32_config *config = dev->config;
+	struct uart_esp32_data *data = dev->data;
 
-	return (uart_hal_get_rxfifo_len(&config->hal) > 0);
+	return (uart_hal_get_rxfifo_len(&data->hal) > 0);
 }
 
 static void uart_esp32_irq_err_enable(const struct device *dev)
 {
-	const struct uart_esp32_config *config = dev->config;
+	struct uart_esp32_data *data = dev->data;
 
 	/* enable framing, parity */
-	uart_hal_ena_intr_mask(&config->hal, UART_INTR_FRAM_ERR);
-	uart_hal_ena_intr_mask(&config->hal, UART_INTR_PARITY_ERR);
+	uart_hal_ena_intr_mask(&data->hal, UART_INTR_FRAM_ERR);
+	uart_hal_ena_intr_mask(&data->hal, UART_INTR_PARITY_ERR);
 }
 
 static void uart_esp32_irq_err_disable(const struct device *dev)
 {
-	const struct uart_esp32_config *config = dev->config;
+	struct uart_esp32_data *data = dev->data;
 
-	uart_hal_disable_intr_mask(&config->hal, UART_INTR_FRAM_ERR);
-	uart_hal_disable_intr_mask(&config->hal, UART_INTR_PARITY_ERR);
+	uart_hal_disable_intr_mask(&data->hal, UART_INTR_FRAM_ERR);
+	uart_hal_disable_intr_mask(&data->hal, UART_INTR_PARITY_ERR);
 }
 
 static int uart_esp32_irq_is_pending(const struct device *dev)
@@ -462,11 +463,11 @@ static int uart_esp32_irq_is_pending(const struct device *dev)
 
 static int uart_esp32_irq_update(const struct device *dev)
 {
-	const struct uart_esp32_config *config = dev->config;
+	struct uart_esp32_data *data = dev->data;
 
-	uart_hal_clr_intsts_mask(&config->hal, UART_INTR_RXFIFO_FULL);
-	uart_hal_clr_intsts_mask(&config->hal, UART_INTR_RXFIFO_TOUT);
-	uart_hal_clr_intsts_mask(&config->hal, UART_INTR_TXFIFO_EMPTY);
+	uart_hal_clr_intsts_mask(&data->hal, UART_INTR_RXFIFO_FULL);
+	uart_hal_clr_intsts_mask(&data->hal, UART_INTR_RXFIFO_TOUT);
+	uart_hal_clr_intsts_mask(&data->hal, UART_INTR_TXFIFO_EMPTY);
 
 	return 1;
 }
@@ -483,15 +484,14 @@ static void uart_esp32_irq_callback_set(const struct device *dev,
 
 static void uart_esp32_isr(void *arg)
 {
-	const struct uart_esp32_config *config = dev->config;
 	const struct device *dev = (const struct device *)arg;
 	struct uart_esp32_data *data = dev->data;
-	uint32_t uart_intr_status = uart_hal_get_intsts_mask(&config->hal);
+	uint32_t uart_intr_status = uart_hal_get_intsts_mask(&data->hal);
 
 	if (uart_intr_status == 0) {
 		return;
 	}
-	uart_hal_clr_intsts_mask(&config->hal, uart_intr_status);
+	uart_hal_clr_intsts_mask(&data->hal, uart_intr_status);
 
 	/* Verify if the callback has been registered */
 	if (data->irq_cb) {
@@ -537,10 +537,6 @@ static const DRAM_ATTR struct uart_driver_api uart_esp32_api = {
 
 #define ESP32_UART_INIT(idx)						       \
 static const DRAM_ATTR struct uart_esp32_config uart_esp32_cfg_port_##idx = {	       \
-	.hal = {							       \
-		.dev =							       \
-		    (uart_dev_t *)DT_REG_ADDR(DT_NODELABEL(uart##idx)), \
-	},								       \
 	.clock_dev = DEVICE_DT_GET(DT_CLOCKS_CTLR(DT_NODELABEL(uart##idx))),		       \
 	.tx = {	\
 		.signal = U##idx##TXD_OUT_IDX,	\
@@ -576,7 +572,11 @@ static struct uart_esp32_data uart_esp32_data_##idx = {			       \
 		.flow_ctrl = IS_ENABLED(				       \
 			DT_PROP(DT_NODELABEL(uart##idx), hw_flow_control)) ?\
 			UART_CFG_FLOW_CTRL_RTS_CTS : UART_CFG_FLOW_CTRL_NONE   \
-	}								       \
+	},								       \
+	.hal = {							       \
+		.dev =							       \
+		    (uart_dev_t *)DT_REG_ADDR(DT_NODELABEL(uart##idx)), \
+	},								       \
 };									       \
 									       \
 DEVICE_DT_DEFINE(DT_NODELABEL(uart##idx),				       \


### PR DESCRIPTION
PR #41918 added changes that caused regression in ESP32 environment.  
This fixes broken counter driver and removes build warnings in uart and gpio drivers.