### PR TITLE
boards: cavs15: a workaround for running cavs15 boards by twister

### DIFF
--- a/boards/xtensa/intel_adsp_cavs15/tools/adsplog.py
+++ b/boards/xtensa/intel_adsp_cavs15/tools/adsplog.py
@@ -29,6 +29,16 @@ WIN_IDX = 3
 WIN_SIZE = 0x20000
 LOG_OFFSET = WIN_OFFSET + WIN_IDX * WIN_SIZE
 
+# When this script was running by twister with --device-serial-pty,
+# it should wait for the rimage signed completedly then start to
+# download firmware into DSP. Have tried to receive signals such as
+# SIGUSR1 or SIGTERM here but it is not very reliable here.
+# So we use a quick workaround to just sleep 15 sec to wait for
+# rimage built and signed. Not smart but useful so far.
+#
+# FIXME: Need to use a better synchronization and switch here.
+time.sleep(15)
+
 mem = None
 sys_devices = "/sys/bus/pci/devices"
 
@@ -102,3 +112,4 @@ while True:
     (last_seq, output) = winstream_read(last_seq)
     if output:
         sys.stdout.write(output)
+        sys.stdout.flush()

--- a/boards/xtensa/intel_adsp_cavs15/tools/flash.sh
+++ b/boards/xtensa/intel_adsp_cavs15/tools/flash.sh
@@ -4,7 +4,7 @@
 
 BUILD=$1
 FIRMWARE=${BUILD}/zephyr/zephyr.ri
-FLASHER=${ZEPHYR_BASE}/boards/xtensa/intel_adsp_cavs15/tools/fw_loader.py
+FLASHER=${ZEPHYR_BASE}/boards/xtensa/intel_adsp_cavs15/tools/cavs-fw-v15.py
 
 if [ -z "$2" ]
   then
@@ -15,5 +15,9 @@ elif [ -n "$3" ] && [ -n "$4" ]
     echo "Signing with key " $key
     west sign -d ${BUILD} -t rimage -p $4 -D $3 -- -k $2 --no-manifest
 fi
-echo ${FLASHER} -f ${FIRMWARE}
-${FLASHER} -f ${FIRMWARE} || /bin/true  2>&1
+
+# Make the log output can be caught by non-root permission
+ssh root@localhost chmod 666 /sys/bus/pci/devices/0000:00:0e.0/resource4
+
+echo ${FLASHER} ${FIRMWARE}
+ssh root@localhost "${FLASHER} ${FIRMWARE}"


### PR DESCRIPTION
When this script was running by twister with --device-serial-pty,
it should wait for the rimage signed completedly then start to
download firmware into DSP. Have tried to receive signals such as
SIGUSR1 or SIGTERM here but it is not very reliable here.
So we use a quick workaround to just sleep 15 sec to wait for
rimage built and signed. Not smart but useful so far.

Fixes #41943 

Signed-off-by: Enjia Mai <enjia.mai@intel.com>

Will run twister command like this for intel_adsp_cavs15 or intel_adsp_cavs18 

twister -p intel_adsp_cavs18 --device-testing -T tests/kernel/threads/thread_apis --west-flash="/home/ztest/zephyrproject/zephyr/boards/xtensa/intel_adsp_cavs15/tools/flash.sh,/home/ztest/zephyrproject/modules/audio/sof/keys/otc_private_key.pem,/home/ztest/zephyrproject/modules/audio/sof/rimage/config,/home/ztest/zephyrproject/modules/audio/sof/rimage/build/rimage" --device-serial-pty="/home/ztest/zephyrproject/zephyr/boards/xtensa/intel_adsp_cavs15/tools/adsplog.py" -vv


