### PR TITLE
samples: Bluetooth: df: Add DF peripheral sample

### DIFF
--- a/samples/bluetooth/direction_finding_peripheral/CMakeLists.txt
+++ b/samples/bluetooth/direction_finding_peripheral/CMakeLists.txt
@@ -1,0 +1,14 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+project(direction_finding_peripheral)
+
+target_sources(app PRIVATE
+  src/main.c
+)

--- a/samples/bluetooth/direction_finding_peripheral/README.rst
+++ b/samples/bluetooth/direction_finding_peripheral/README.rst
@@ -1,0 +1,72 @@
+.. _bluetooth_direction_finding_peripheral:
+
+Bluetooth: Direction Finding Peripheral
+#######################################
+
+Overview
+********
+
+A simple application demonstrating the BLE Direction Finding CTE transmission in
+connected mode by response to a request received from connected peer device.
+
+Requirements
+************
+
+* Nordic nRF SoC based board with Direction Finding support (example boards:
+  :ref:`nrf52833dk_nrf52833`, :ref:`nrf52833dk_nrf52820`, :ref:`nrf5340dk_nrf5340`)
+* Antenna matrix for AoA (optional)
+
+Check your SoC's product specification for Direction Finding support if you are
+unsure.
+
+Building and Running
+********************
+
+By default the application supports Angle of Arrival and Angle of Departure mode.
+
+To use Angle of Arrival mode only, build this application as follows,
+changing ``nrf52833dk_nrf52833`` as needed for your board:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/direction_finding_peripheral
+   :host-os: unix
+   :board: nrf52833dk_nrf52833
+   :gen-args: -DOVERLAY_CONFIG=overlay-aoa.conf
+   :goals: build flash
+   :compact:
+
+To run the application on nRF5340DK, a Bluetooth controller application must
+also run on the network core. The :ref:`bluetooth-hci-rpmsg-sample` sample
+application may be used. To build this sample with direction finding support
+enabled:
+
+* Copy
+  :zephyr_file:`samples/bluetooth/direction_finding_peripheral/boards/nrf52833dk_nrf52833.overlay`
+  to a new file,
+  :file:`samples/bluetooth/hci_rpmsg/boards/nrf5340dk_nrf5340_cpunet.overlay`.
+* Copy
+  :zephyr_file:`samples/bluetooth/direction_finding_peripheral/boards/nrf52833dk_nrf52833.conf`
+  to a new file,
+  :file:`samples/bluetooth/hci_rpmsg/boards/nrf5340dk_nrf5340_cpunet.conf`.
+
+Antenna matrix configuration
+****************************
+
+To use this sample with Angle of Departure enabled on Nordic SoCs, additional
+configuration must be provided via :ref:`devicetree <dt-guide>` to enable
+control of the antenna array.
+
+An example devicetree overlay is in
+:zephyr_file:`samples/bluetooth/direction_finding_peripheral/boards/nrf52833dk_nrf52833.overlay`.
+You can customize this overlay when building for the same board, or create your
+own board-specific overlay in the same directory for a different board. See
+:dtcompatible:`nordic,nrf-radio` for documentation on the properties used in
+this overlay. See :ref:`set-devicetree-overlays` for information on setting up
+and using overlays.
+
+Note that antenna matrix configuration for the nRF5340 SoC is part of the
+network core application. When :ref:`bluetooth-hci-rpmsg-sample` is used as the
+network core application, the antenna matrix configuration should be stored in
+the file
+:file:`samples/bluetooth/hci_rpmsg/boards/nrf5340dk_nrf5340_cpunet.overlay`
+instead.

--- a/samples/bluetooth/direction_finding_peripheral/boards/nrf52833dk_nrf52820.conf
+++ b/samples/bluetooth/direction_finding_peripheral/boards/nrf52833dk_nrf52820.conf
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_BT_CTLR=y
+CONFIG_BT_LL_SW_SPLIT=y
+
+# Enable new implementation of LLCPs
+CONFIG_BT_LL_SW_LLCP=y
+
+# Enable Direction Finding Feature including AoA and AoD
+CONFIG_BT_CTLR_DF=y
+
+CONFIG_BT_CTLR_DF_CTE_TX=y
+CONFIG_BT_CTLR_DF_CONN_CTE_TX=y
+CONFIG_BT_CTLR_DF_ANT_SWITCH_TX=y
+CONFIG_BT_CTLR_DF_CONN_CTE_RSP=y
+
+# Ensure that there is enough control prcedure contexts to queue and execute all procedures
+CONFIG_BT_CTLR_ADVANCED_FEATURES=y
+CONFIG_BT_CTLR_LLCP_PROC_CTX_BUF_NUM=6

--- a/samples/bluetooth/direction_finding_peripheral/boards/nrf52833dk_nrf52820.overlay
+++ b/samples/bluetooth/direction_finding_peripheral/boards/nrf52833dk_nrf52820.overlay
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&radio {
+	status = "okay";
+	/* This is an example number of antennas that may be available
+	 * on antenna matrix board.
+	 */
+	dfe-antenna-num = <10>;
+	/* This is an example switch pattern that will be used to set an
+	 * antenna for Tx PDU (period before start of Tx CTE).
+	 */
+	dfe-pdu-antenna = <0x1>;
+
+	/* These are example GPIO pin numbers that are provided to
+	 * Radio peripheral. The pins will be acquired by Radio to
+	 * drive antenna switching when AoD is enabled.
+	 */
+	dfegpio0-gpios = <&gpio0 1 0>;
+	dfegpio1-gpios = <&gpio0 2 0>;
+	dfegpio2-gpios = <&gpio0 3 0>;
+	dfegpio3-gpios = <&gpio0 4 0>;
+};

--- a/samples/bluetooth/direction_finding_peripheral/boards/nrf52833dk_nrf52833.conf
+++ b/samples/bluetooth/direction_finding_peripheral/boards/nrf52833dk_nrf52833.conf
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_BT_CTLR=y
+CONFIG_BT_LL_SW_SPLIT=y
+
+# Enable new implementation of LLCPs
+CONFIG_BT_LL_SW_LLCP=y
+
+# Enable Direction Finding Feature including AoA and AoD
+CONFIG_BT_CTLR_DF=y
+
+CONFIG_BT_CTLR_DF_CTE_TX=y
+CONFIG_BT_CTLR_DF_CONN_CTE_TX=y
+CONFIG_BT_CTLR_DF_ANT_SWITCH_TX=y
+CONFIG_BT_CTLR_DF_CONN_CTE_RSP=y
+
+# Ensure that there is enough control prcedure contexts to queue and execute all procedures
+CONFIG_BT_CTLR_ADVANCED_FEATURES=y
+CONFIG_BT_CTLR_LLCP_PROC_CTX_BUF_NUM=6

--- a/samples/bluetooth/direction_finding_peripheral/boards/nrf52833dk_nrf52833.overlay
+++ b/samples/bluetooth/direction_finding_peripheral/boards/nrf52833dk_nrf52833.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&radio {
+	status = "okay";
+	/* This is a number of antennas that are available on antenna matrix
+	 * designed by Nordic. For more information see README.rst.
+	 */
+	dfe-antenna-num = <12>;
+	/* This is a setting that enables antenna 12 (in antenna matrix designed
+	 * by Nordic) for Rx PDU. For more information see README.rst.
+	 */
+	dfe-pdu-antenna = <0x0>;
+
+	/* These are GPIO pin numbers that are provided to
+	 * Radio peripheral. The pins will be acquired by Radio to
+	 * drive antenna switching when AoA is enabled.
+	 * Pin numbers are selected to drive switches on antenna matrix
+	 * desinged by Nordic. For more information see README.rst.
+	 */
+	dfegpio0-gpios = <&gpio0 3 0>;
+	dfegpio1-gpios = <&gpio0 4 0>;
+	dfegpio2-gpios = <&gpio0 28 0>;
+	dfegpio3-gpios = <&gpio0 29 0>;
+};

--- a/samples/bluetooth/direction_finding_peripheral/overlay-aoa.conf
+++ b/samples/bluetooth/direction_finding_peripheral/overlay-aoa.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Disable AoD Feature (antenna switching) in Tx mode
+CONFIG_BT_CTLR_DF_ANT_SWITCH_TX=n

--- a/samples/bluetooth/direction_finding_peripheral/prj.conf
+++ b/samples/bluetooth/direction_finding_peripheral/prj.conf
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_BT=y
+CONFIG_BT_DEBUG_LOG=y
+CONFIG_BT_DEVICE_NAME="DF Conn App"
+CONFIG_BT_SMP=y
+
+CONFIG_BT_PERIPHERAL=y
+CONFIG_BT_DEVICE_APPEARANCE=833
+
+# Enable Direction Finding Feature RX in connected mode
+CONFIG_BT_DF=y
+CONFIG_BT_DF_CONNECTION_CTE_TX=y
+CONFIG_BT_DF_CONNECTION_CTE_RSP=y

--- a/samples/bluetooth/direction_finding_peripheral/sample.yaml
+++ b/samples/bluetooth/direction_finding_peripheral/sample.yaml
@@ -1,0 +1,17 @@
+sample:
+  name: Direction Finding Peripheral
+  description: Sample application showing peripheral role of Direction Finding in connected mode
+tests:
+  sample.bluetooth.direction_finding_connectionless_rx:
+    harness: bluetooth
+    platform_allow: nrf52833dk_nrf52833
+    tags: bluetooth
+    integration_platforms:
+        - nrf52833dk_nrf52833
+  sample.bluetooth.direction_finding_connectionless_rx.aod:
+    extra_args: OVERLAY_CONFIG="overlay-aoa.conf"
+    harness: bluetooth
+    platform_allow: nrf52833dk_nrf52833
+    tags: bluetooth
+    integration_platforms:
+        - nrf52833dk_nrf52833

--- a/samples/bluetooth/direction_finding_peripheral/src/main.c
+++ b/samples/bluetooth/direction_finding_peripheral/src/main.c
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/types.h>
+#include <stddef.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/printk.h>
+#include <sys/byteorder.h>
+#include <zephyr.h>
+
+#include <bluetooth/bluetooth.h>
+#include <bluetooth/hci.h>
+#include <bluetooth/conn.h>
+#include <bluetooth/uuid.h>
+#include <bluetooth/gatt.h>
+#include <bluetooth/services/bas.h>
+#include <bluetooth/services/hrs.h>
+#include <bluetooth/direction.h>
+
+#define DF_FEAT_ENABLED BIT64(BT_LE_FEAT_BIT_CONN_CTE_RESP)
+
+static const struct bt_data ad[] = {
+	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
+	BT_DATA_BYTES(BT_DATA_LE_SUPPORTED_FEATURES, BT_LE_SUPP_FEAT_24_ENCODE(DF_FEAT_ENABLED)),
+};
+
+/* Latency set to zero, to enforce PDU exchange every connection event */
+#define CONN_LATENCY 0U
+/* Inteval used to run CTE request procedure periodically.
+ * Value is a number of connection events.
+ */
+#define CTE_REQ_INTERVAL (CONN_LATENCY + 10U)
+/* Length of CTE in unit of 8 us */
+#define CTE_LEN (0x14U)
+
+#if defined(CONFIG_BT_CTLR_DF_ANT_SWITCH_TX)
+static const uint8_t ant_patterns[] = { 0x2, 0x0, 0x5, 0x6, 0x1, 0x4, 0xC, 0x9, 0xE, 0xD, 0x8 };
+#endif /* CONFIG_BT_CTLR_DF_ANT_SWITCH_TX */
+
+static void enable_cte_response(struct bt_conn *conn)
+{
+	int err;
+
+	const struct bt_df_conn_cte_tx_param cte_tx_params = {
+#if defined(CONFIG_BT_CTLR_DF_ANT_SWITCH_TX)
+		.cte_types = BT_DF_CTE_TYPE_ALL,
+		.num_ant_ids = ARRAY_SIZE(ant_patterns),
+		.ant_ids = ant_patterns,
+#else
+		.cte_types = BT_DF_CTE_TYPE_AOA,
+#endif /* CONFIG_BT_CTLR_DF_ANT_SWITCH_TX */
+	};
+
+	printk("Set CTE transmission params...");
+	err = bt_df_set_conn_cte_tx_param(conn, &cte_tx_params);
+	if (err) {
+		printk("failed (err %d)\n", err);
+		return;
+	}
+	printk("success.\n");
+
+	printk("Set CTE response enable...");
+	err = bt_df_conn_cte_rsp_enable(conn);
+	if (err) {
+		printk("failed (err %d).\n", err);
+		return;
+	}
+	printk("success.\n");
+}
+
+static void connected(struct bt_conn *conn, uint8_t err)
+{
+	if (err) {
+		printk("Connection failed (err 0x%02x)\n", err);
+	} else {
+		printk("Connected\n");
+	}
+
+	enable_cte_response(conn);
+}
+
+static void disconnected(struct bt_conn *conn, uint8_t reason)
+{
+	printk("Disconnected (reason 0x%02x)\n", reason);
+}
+
+BT_CONN_CB_DEFINE(conn_callbacks) = {
+	.connected = connected,
+	.disconnected = disconnected,
+};
+
+static void bt_ready(void)
+{
+	int err;
+
+	printk("Bluetooth initialized\n");
+
+	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+	if (err) {
+		printk("Advertising failed to start (err %d)\n", err);
+		return;
+	}
+
+	printk("Advertising successfully started\n");
+}
+
+void main(void)
+{
+	int err;
+
+	err = bt_enable(NULL);
+	if (err) {
+		printk("Bluetooth init failed (err %d)\n", err);
+		return;
+	}
+
+	bt_ready();
+}


### PR DESCRIPTION
Add new sample application for direction finding to show
how the functionality works in connected mode for peripheral role.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>