### PR TITLE
xcc: fix building C++ code

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -3939,12 +3939,16 @@ struct k_work_user {
  * INTERNAL_HIDDEN @endcond
  */
 
+#if defined(__cplusplus) && ((__cplusplus - 0) < 202002L)
+#define Z_WORK_USER_INITIALIZER(work_handler) { NULL, work_handler, 0 }
+#else
 #define Z_WORK_USER_INITIALIZER(work_handler) \
 	{ \
 	._reserved = NULL, \
 	.handler = work_handler, \
 	.flags = 0 \
 	}
+#endif
 
 /**
  * @brief Initialize a statically-defined user work item.

--- a/include/sys_clock.h
+++ b/include/sys_clock.h
@@ -79,7 +79,7 @@ typedef struct {
  */
 #define K_TIMEOUT_EQ(a, b) ((a).ticks == (b).ticks)
 
-#define Z_TIMEOUT_NO_WAIT ((k_timeout_t) {})
+#define Z_TIMEOUT_NO_WAIT ((k_timeout_t) {0})
 #if defined(__cplusplus) && ((__cplusplus - 0) < 202002L)
 #define Z_TIMEOUT_TICKS(t) ((k_timeout_t) { (t) })
 #else

--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -49,7 +49,7 @@
 
 
 /* C++11 has static_assert built in */
-#ifdef __cplusplus
+#if defined(__cplusplus) && (__cplusplus >= 201103L)
 #define BUILD_ASSERT(EXPR, MSG...) static_assert(EXPR, "" MSG)
 
 /*


### PR DESCRIPTION
This fixes a few issues when using XCC to build C++ code. See individual commits for details.

Note that the GCC part of XCC does not support anything newer than C++ 98. So the default C++ 11 would not work with the GCC part. However, the Clang part of XCC does support C++ 11. Without the ability to figure out if GCC-based or Clang-based XCC is being used, the default C++ standard kconfig cannot be set correctly.