### PR TITLE
cAVS twister fixups

### DIFF
--- a/tests/kernel/mp/prj.conf
+++ b/tests/kernel/mp/prj.conf
@@ -1,2 +1,6 @@
 CONFIG_ZTEST=y
 CONFIG_SMP=n
+
+# Must have this on where available, otherwise the linker will place
+# the shared variables in cached/incoherent memory.
+CONFIG_KERNEL_COHERENCE=y

--- a/tests/kernel/obj_tracking/testcase.yaml
+++ b/tests/kernel/obj_tracking/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   kernel.objects.tracking:
     tags: kernel
-    platform_exclude: qemu_x86_tiny
+    platform_exclude: qemu_x86_tiny intel_adsp_cavs25

--- a/tests/kernel/queue/src/main.c
+++ b/tests/kernel/queue/src/main.c
@@ -54,7 +54,7 @@ void test_main(void)
 			 ztest_unit_test(test_queue_alloc),
 			 ztest_1cpu_unit_test(test_queue_poll_race),
 			 ztest_unit_test(test_multiple_queues),
-			 ztest_unit_test(test_queue_multithread_competition),
+			 ztest_1cpu_unit_test(test_queue_multithread_competition),
 			 ztest_unit_test(test_queue_unique_append),
 			 ztest_unit_test(test_access_kernel_obj_with_priv_data),
 			 ztest_unit_test(test_queue_append_list_error),

--- a/tests/kernel/queue/src/test_queue_loop.c
+++ b/tests/kernel/queue/src/test_queue_loop.c
@@ -67,22 +67,16 @@ static void tqueue_find_and_remove(struct k_queue *pqueue)
 /*entry of contexts*/
 static void tIsr_entry(const void *p)
 {
-	TC_PRINT("isr queue find and remove\n");
 	tqueue_find_and_remove((struct k_queue *)p);
-	TC_PRINT("isr queue get\n");
 	tqueue_get((struct k_queue *)p);
-	TC_PRINT("isr queue append ---> ");
 	tqueue_append((struct k_queue *)p);
 }
 
 static void tThread_entry(void *p1, void *p2, void *p3)
 {
-	TC_PRINT("thread queue find and remove\n");
 	tqueue_find_and_remove((struct k_queue *)p1);
-	TC_PRINT("thread queue get\n");
 	tqueue_get((struct k_queue *)p1);
 	k_sem_give(&end_sema);
-	TC_PRINT("thread queue append ---> ");
 	tqueue_append((struct k_queue *)p1);
 	k_sem_give(&end_sema);
 }
@@ -96,18 +90,14 @@ static void tqueue_read_write(struct k_queue *pqueue)
 				      tThread_entry, pqueue, NULL, NULL,
 				      K_PRIO_PREEMPT(0), 0, K_NO_WAIT);
 
-	TC_PRINT("main queue append ---> ");
 	tqueue_append(pqueue);
 	irq_offload(tIsr_entry, (const void *)pqueue);
 	k_sem_take(&end_sema, K_FOREVER);
 	k_sem_take(&end_sema, K_FOREVER);
 
-	TC_PRINT("main queue find and remove\n");
 	tqueue_find_and_remove(pqueue);
-	TC_PRINT("main queue get\n");
 	tqueue_get(pqueue);
 	k_thread_abort(tid);
-	TC_PRINT("\n");
 }
 
 /*test cases*/

--- a/tests/kernel/semaphore/semaphore/src/main.c
+++ b/tests/kernel/semaphore/semaphore/src/main.c
@@ -988,6 +988,10 @@ void sem_multiple_take_and_timeouts_helper(void *p1, void *p2, void *p3)
  */
 void test_sem_multiple_take_and_timeouts(void)
 {
+	if (IS_ENABLED(CONFIG_KERNEL_COHERENCE)) {
+		ztest_test_skip();
+	}
+
 	static uint32_t timeout;
 	size_t bytes_read;
 
@@ -1052,6 +1056,10 @@ void sem_multi_take_timeout_diff_sem_helper(void *p1, void *p2, void *p3)
  */
 void test_sem_multi_take_timeout_diff_sem(void)
 {
+	if (IS_ENABLED(CONFIG_KERNEL_COHERENCE)) {
+		ztest_test_skip();
+	}
+
 	size_t bytes_read;
 	struct timeout_info seq_info[] = {
 		{ SEC2MS(2), &simple_sem },


### PR DESCRIPTION
Three fairly routine fixes to test code (two coherence issues and one SMP goof) exposed on the DSPs.

And one bizarre "filter this test because it blows up the whole system and we don't know why" case needed to stabilize validation runs while we debug.