### PR TITLE
samples: modules: canopennode: Add stm32f072b_disco support

### DIFF
--- a/samples/modules/canopennode/README.rst
+++ b/samples/modules/canopennode/README.rst
@@ -61,6 +61,25 @@ The sample can be built and executed for the FRDM-K64F as follows:
 Pressing the button labelled ``SW3`` will increment the button press
 counter object at index ``0x2102`` in the object dictionary.
 
+Building and Running for STM32F072RB Discovery
+==============================================
+The :ref:`stm32f072b_disco_board` board does not come with an onboard CAN
+transceiver. In order to use the CAN bus on the STM32F072RB Discovery board, an
+external CAN bus tranceiver must be connected to ``PB8`` (``CAN_RX``) and
+``PB9`` (``CAN_TX``). This board supports CANopen LED indicators (red and green
+LEDs)
+
+The sample can be built and executed for the STM32F072RB Discovery as follows:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/modules/canopennode
+   :board: stm32f072b_disco
+   :goals: build flash
+   :compact:
+
+Pressing the button labelled ``USER`` will increment the button press counter
+object at index ``0x2102`` in the object dictionary.
+
 Building and Running for STM32F3 Discovery
 ==========================================
 The :ref:`stm32f3_disco_board` board does not come with an onboard CAN

--- a/samples/modules/canopennode/boards/stm32f072b_disco.overlay
+++ b/samples/modules/canopennode/boards/stm32f072b_disco.overlay
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2022 Google LLC.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		green-led = &green_right_led_5;
+		red-led = &red_up_led_3;
+	};
+};

--- a/samples/modules/canopennode/sample.yaml
+++ b/samples/modules/canopennode/sample.yaml
@@ -14,7 +14,7 @@ tests:
     tags: introduction
   sample.modules.canopennode.program_download:
     build_only: true
-    platform_exclude: stm32f3_disco
+    platform_exclude: stm32f3_disco stm32f072b_disco
     extra_configs:
       - CONFIG_BOOTLOADER_MCUBOOT=y
   sample.modules.canopennode.no_storage:


### PR DESCRIPTION
Add support for the stm32f072rb discovery board.

Signed-off-by: Moritz Fischer <moritzf@google.com>