### PR TITLE
net: http_client: Set body_start pointer unconditionally

### DIFF
--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -264,8 +264,8 @@ static int on_body(struct http_parser *parser, const char *at, size_t length)
 		req->internal.response.http_cb->on_body(parser, at, length);
 	}
 
-	if (!req->internal.response.body_start &&
-	    (uint8_t *)at != (uint8_t *)req->internal.response.recv_buf) {
+	/* Reset the body_start pointer for each fragment. */
+	if (!req->internal.response.body_start) {
 		req->internal.response.body_start = (uint8_t *)at;
 	}
 


### PR DESCRIPTION
Set `body_start` pointer regardless of the body position in the recv
buffer. In result, the pointer shall indicate correctly position of the
body for each fragment, it's also explicit now that if the pointer is
not set for a fragment, there's no body in that particular fragment.

Fixes #41683

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>