### PR TITLE
drivers: npcx/nct38xx: drop DRV_CONFIG/DRV_DATA usage

### DIFF
--- a/drivers/adc/adc_npcx.c
+++ b/drivers/adc/adc_npcx.c
@@ -67,17 +67,15 @@ struct adc_npcx_data {
 };
 
 /* Driver convenience defines */
-#define DRV_CONFIG(dev) ((const struct adc_npcx_config *)(dev)->config)
-
-#define DRV_DATA(dev) ((struct adc_npcx_data *)(dev)->data)
-
-#define HAL_INSTANCE(dev) ((struct adc_reg *)DRV_CONFIG(dev)->base)
+#define HAL_INSTANCE(dev) ((struct adc_reg *)((const struct adc_npcx_config *)(dev)->config)->base)
 
 /* ADC local functions */
 static void adc_npcx_isr(void *arg)
 {
-	struct adc_npcx_data *const data = DRV_DATA((const struct device *)arg);
-	struct adc_reg *const inst = HAL_INSTANCE((const struct device *)arg);
+	const struct device *dev = arg;
+	const struct adc_npcx_config *config = dev->config;
+	struct adc_npcx_data *const data = dev->data;
+	struct adc_reg *const inst = HAL_INSTANCE(dev);
 	uint16_t status = inst->ADCSTS;
 	uint16_t result, channel;
 
@@ -93,9 +91,7 @@ static void adc_npcx_isr(void *arg)
 		/* Get result for each ADC selected channel */
 		while (data->channels) {
 			channel = find_lsb_set(data->channels) - 1;
-			result = GET_FIELD(CHNDAT(DRV_CONFIG((const struct device *)arg)->base,
-						  channel),
-					   NPCX_CHNDAT_CHDAT_FIELD);
+			result = GET_FIELD(CHNDAT(config->base, channel), NPCX_CHNDAT_CHDAT_FIELD);
 			/*
 			 * Save ADC result and adc_npcx_validate_buffer_size()
 			 * already ensures that the buffer has enough space for
@@ -144,7 +140,7 @@ static int adc_npcx_validate_buffer_size(const struct device *dev,
 
 static void adc_npcx_start_scan(const struct device *dev)
 {
-	struct adc_npcx_data *const data = DRV_DATA(dev);
+	struct adc_npcx_data *const data = dev->data;
 	struct adc_reg *const inst = HAL_INSTANCE(dev);
 
 	/* Turn on ADC first */
@@ -170,7 +166,7 @@ static void adc_npcx_start_scan(const struct device *dev)
 static int adc_npcx_start_read(const struct device *dev,
 					const struct adc_sequence *sequence)
 {
-	struct adc_npcx_data *const data = DRV_DATA(dev);
+	struct adc_npcx_data *const data = dev->data;
 	int error = 0;
 
 	if (!sequence->channels ||
@@ -229,7 +225,7 @@ static void adc_context_update_buffer_pointer(struct adc_context *ctx,
 static int adc_npcx_channel_setup(const struct device *dev,
 				 const struct adc_channel_cfg *channel_cfg)
 {
-	const struct adc_npcx_config *const config = DRV_CONFIG(dev);
+	const struct adc_npcx_config *const config = dev->config;
 	uint8_t channel_id = channel_cfg->channel_id;
 
 	if (channel_id >= NPCX_ADC_CH_COUNT) {
@@ -270,7 +266,7 @@ static int adc_npcx_channel_setup(const struct device *dev,
 static int adc_npcx_read(const struct device *dev,
 			const struct adc_sequence *sequence)
 {
-	struct adc_npcx_data *const data = DRV_DATA(dev);
+	struct adc_npcx_data *const data = dev->data;
 	int error;
 
 	adc_context_lock(&data->ctx, false, NULL);
@@ -285,7 +281,7 @@ static int adc_npcx_read_async(const struct device *dev,
 			      const struct adc_sequence *sequence,
 			      struct k_poll_signal *async)
 {
-	struct adc_npcx_data *const data = DRV_DATA(dev);
+	struct adc_npcx_data *const data = dev->data;
 	int error;
 
 	adc_context_lock(&data->ctx, true, async);
@@ -331,8 +327,8 @@ DEVICE_DT_INST_DEFINE(0,
 
 static int adc_npcx_init(const struct device *dev)
 {
-	const struct adc_npcx_config *const config = DRV_CONFIG(dev);
-	struct adc_npcx_data *const data = DRV_DATA(dev);
+	const struct adc_npcx_config *const config = dev->config;
+	struct adc_npcx_data *const data = dev->data;
 	struct adc_reg *const inst = HAL_INSTANCE(dev);
 	const struct device *const clk_dev = DEVICE_DT_GET(NPCX_CLK_CTRL_NODE);
 	int prescaler = 0, ret;

--- a/drivers/adc/adc_npcx.c
+++ b/drivers/adc/adc_npcx.c
@@ -71,7 +71,7 @@ struct adc_npcx_data {
 
 #define DRV_DATA(dev) ((struct adc_npcx_data *)(dev)->data)
 
-#define HAL_INSTANCE(dev) (struct adc_reg *)(DRV_CONFIG(dev)->base)
+#define HAL_INSTANCE(dev) ((struct adc_reg *)DRV_CONFIG(dev)->base)
 
 /* ADC local functions */
 static void adc_npcx_isr(void *arg)

--- a/drivers/bbram/bbram_npcx.c
+++ b/drivers/bbram/bbram_npcx.c
@@ -27,9 +27,8 @@ struct bbram_npcx_config {
 #define NPCX_STATUS_VSBY BIT(1)
 #define NPCX_STATUS_VCC1 BIT(0)
 
-#define DRV_CONFIG(dev) ((const struct bbram_npcx_config *)(dev)->config)
 #define DRV_STATUS(dev)                                                        \
-	(*((volatile uint8_t *)DRV_CONFIG(dev)->status_reg_addr))
+	(*((volatile uint8_t *)((const struct bbram_npcx_config *)(dev)->config)->status_reg_addr))
 
 static int get_bit_and_reset(const struct device *dev, int mask)
 {
@@ -58,7 +57,7 @@ static int bbram_npcx_check_power(const struct device *dev)
 
 static int bbram_npcx_get_size(const struct device *dev, size_t *size)
 {
-	const struct bbram_npcx_config *config = DRV_CONFIG(dev);
+	const struct bbram_npcx_config *config = dev->config;
 
 	*size = config->size;
 	return 0;
@@ -67,7 +66,7 @@ static int bbram_npcx_get_size(const struct device *dev, size_t *size)
 static int bbram_npcx_read(const struct device *dev, size_t offset, size_t size,
 			   uint8_t *data)
 {
-	const struct bbram_npcx_config *config = DRV_CONFIG(dev);
+	const struct bbram_npcx_config *config = dev->config;
 
 	if (size < 1 || offset + size > config->size || bbram_npcx_check_invalid(dev)) {
 		return -EFAULT;
@@ -81,7 +80,7 @@ static int bbram_npcx_read(const struct device *dev, size_t offset, size_t size,
 static int bbram_npcx_write(const struct device *dev, size_t offset, size_t size,
 			    const uint8_t *data)
 {
-	const struct bbram_npcx_config *config = DRV_CONFIG(dev);
+	const struct bbram_npcx_config *config = dev->config;
 
 	if (size < 1 || offset + size > config->size || bbram_npcx_check_invalid(dev)) {
 		return -EFAULT;

--- a/drivers/clock_control/clock_control_npcx.c
+++ b/drivers/clock_control/clock_control_npcx.c
@@ -26,10 +26,10 @@ struct npcx_pcc_config {
 	((const struct npcx_pcc_config *)(dev)->config)
 
 #define HAL_CDCG_INST(dev) \
-	(struct cdcg_reg *)(DRV_CONFIG(dev)->base_cdcg)
+	((struct cdcg_reg *)DRV_CONFIG(dev)->base_cdcg)
 
 #define HAL_PMC_INST(dev) \
-	(struct pmc_reg *)(DRV_CONFIG(dev)->base_pmc)
+	((struct pmc_reg *)DRV_CONFIG(dev)->base_pmc)
 
 /* Clock controller local functions */
 static inline int npcx_clock_control_on(const struct device *dev,

--- a/drivers/clock_control/clock_control_npcx.c
+++ b/drivers/clock_control/clock_control_npcx.c
@@ -22,14 +22,11 @@ struct npcx_pcc_config {
 };
 
 /* Driver convenience defines */
-#define DRV_CONFIG(dev) \
-	((const struct npcx_pcc_config *)(dev)->config)
-
 #define HAL_CDCG_INST(dev) \
-	((struct cdcg_reg *)DRV_CONFIG(dev)->base_cdcg)
+	((struct cdcg_reg *)((const struct npcx_pcc_config *)(dev)->config)->base_cdcg)
 
 #define HAL_PMC_INST(dev) \
-	((struct pmc_reg *)DRV_CONFIG(dev)->base_pmc)
+	((struct pmc_reg *)((const struct npcx_pcc_config *)(dev)->config)->base_pmc)
 
 /* Clock controller local functions */
 static inline int npcx_clock_control_on(const struct device *dev,
@@ -37,7 +34,7 @@ static inline int npcx_clock_control_on(const struct device *dev,
 {
 	ARG_UNUSED(dev);
 	struct npcx_clk_cfg *clk_cfg = (struct npcx_clk_cfg *)(sub_system);
-	const uint32_t pmc_base = DRV_CONFIG(dev)->base_pmc;
+	const uint32_t pmc_base = ((const struct npcx_pcc_config *)dev->config)->base_pmc;
 
 	if (clk_cfg->ctrl >= NPCX_PWDWN_CTL_COUNT)
 		return -EINVAL;
@@ -52,7 +49,7 @@ static inline int npcx_clock_control_off(const struct device *dev,
 {
 	ARG_UNUSED(dev);
 	struct npcx_clk_cfg *clk_cfg = (struct npcx_clk_cfg *)(sub_system);
-	const uint32_t pmc_base = DRV_CONFIG(dev)->base_pmc;
+	const uint32_t pmc_base = ((const struct npcx_pcc_config *)dev->config)->base_pmc;
 
 	if (clk_cfg->ctrl >= NPCX_PWDWN_CTL_COUNT)
 		return -EINVAL;
@@ -174,7 +171,7 @@ BUILD_ASSERT(APBSRC_CLK / (APB4DIV_VAL + 1) <= MHZ(100) &&
 static int npcx_clock_control_init(const struct device *dev)
 {
 	struct cdcg_reg *const inst_cdcg = HAL_CDCG_INST(dev);
-	const uint32_t pmc_base = DRV_CONFIG(dev)->base_pmc;
+	const uint32_t pmc_base = ((const struct npcx_pcc_config *)dev->config)->base_pmc;
 
 	if (IS_ENABLED(CONFIG_CLOCK_CONTROL_NPCX_EXTERNAL_SRC)) {
 		inst_cdcg->LFCGCTL2 |= BIT(NPCX_LFCGCTL2_XT_OSC_SL_EN);

--- a/drivers/espi/espi_npcx.c
+++ b/drivers/espi/espi_npcx.c
@@ -46,7 +46,7 @@ struct espi_npcx_data {
 
 #define DRV_DATA(dev) ((struct espi_npcx_data *)(dev)->data)
 
-#define HAL_INSTANCE(dev) (struct espi_reg *)(DRV_CONFIG(dev)->base)
+#define HAL_INSTANCE(dev) ((struct espi_reg *)DRV_CONFIG(dev)->base)
 
 /* eSPI channels */
 #define NPCX_ESPI_CH_PC              0

--- a/drivers/espi/espi_npcx.c
+++ b/drivers/espi/espi_npcx.c
@@ -42,11 +42,8 @@ struct espi_npcx_data {
 };
 
 /* Driver convenience defines */
-#define DRV_CONFIG(dev) ((const struct espi_npcx_config *)(dev)->config)
-
-#define DRV_DATA(dev) ((struct espi_npcx_data *)(dev)->data)
-
-#define HAL_INSTANCE(dev) ((struct espi_reg *)DRV_CONFIG(dev)->base)
+#define HAL_INSTANCE(dev)                                                                          \
+	((struct espi_reg *)((const struct espi_npcx_config *)(dev)->config)->base)
 
 /* eSPI channels */
 #define NPCX_ESPI_CH_PC              0
@@ -208,7 +205,7 @@ static void espi_bus_cfg_update_isr(const struct device *dev)
 {
 	int chan;
 	struct espi_reg *const inst = HAL_INSTANCE(dev);
-	struct espi_npcx_data *const data = DRV_DATA(dev);
+	struct espi_npcx_data *const data = dev->data;
 	struct espi_event evt = { .evt_type = ESPI_BUS_EVENT_CHANNEL_READY,
 				  .evt_details = 0,
 				  .evt_data = 0 };
@@ -252,7 +249,7 @@ static void espi_bus_cfg_update_isr(const struct device *dev)
 #if defined(CONFIG_ESPI_OOB_CHANNEL)
 static void espi_bus_oob_rx_isr(const struct device *dev)
 {
-	struct espi_npcx_data *const data = DRV_DATA(dev);
+	struct espi_npcx_data *const data = dev->data;
 
 	LOG_DBG("%s", __func__);
 	k_sem_give(&data->oob_rx_lock);
@@ -338,7 +335,7 @@ static void espi_vw_config_output(const struct device *dev,
 static void espi_vw_notify_system_state(const struct device *dev,
 				enum espi_vwire_signal signal)
 {
-	struct espi_npcx_data *const data = DRV_DATA(dev);
+	struct espi_npcx_data *const data = dev->data;
 	struct espi_event evt = { ESPI_BUS_EVENT_VWIRE_RECEIVED, 0, 0 };
 	uint8_t wire = 0;
 
@@ -381,7 +378,7 @@ static void espi_vw_notify_host_warning(const struct device *dev,
 
 static void espi_vw_notify_plt_rst(const struct device *dev)
 {
-	struct espi_npcx_data *const data = DRV_DATA(dev);
+	struct espi_npcx_data *const data = dev->data;
 	struct espi_reg *const inst = HAL_INSTANCE(dev);
 	struct espi_event evt = { ESPI_BUS_EVENT_VWIRE_RECEIVED,
 		ESPI_VWIRE_SIGNAL_PLTRST, 0
@@ -457,7 +454,7 @@ static void espi_vw_generic_isr(const struct device *dev, struct npcx_wui *wui)
 static void espi_vw_espi_rst_isr(const struct device *dev, struct npcx_wui *wui)
 {
 	struct espi_reg *const inst = HAL_INSTANCE(dev);
-	struct espi_npcx_data *const data = DRV_DATA(dev);
+	struct espi_npcx_data *const data = dev->data;
 	struct espi_event evt = { ESPI_BUS_RESET, 0, 0 };
 
 	data->espi_rst_asserted = !IS_BIT_SET(inst->ESPISTS,
@@ -626,7 +623,7 @@ static int espi_npcx_receive_vwire(const struct device *dev,
 static int espi_npcx_manage_callback(const struct device *dev,
 				    struct espi_callback *callback, bool set)
 {
-	struct espi_npcx_data *const data = DRV_DATA(dev);
+	struct espi_npcx_data *const data = dev->data;
 
 	return espi_manage_callback(&data->callbacks, callback, set);
 }
@@ -722,7 +719,7 @@ static int espi_npcx_receive_oob(const struct device *dev,
 				struct espi_oob_packet *pckt)
 {
 	struct espi_reg *const inst = HAL_INSTANCE(dev);
-	struct espi_npcx_data *const data = DRV_DATA(dev);
+	struct espi_npcx_data *const data = dev->data;
 	uint8_t *oob_buf = pckt->buf;
 	uint32_t oob_data;
 	int idx_rx_buf, sz_oob_rx, ret;
@@ -850,8 +847,8 @@ DEVICE_DT_INST_DEFINE(0, &espi_npcx_init, NULL,
 
 static int espi_npcx_init(const struct device *dev)
 {
-	const struct espi_npcx_config *const config = DRV_CONFIG(dev);
-	struct espi_npcx_data *const data = DRV_DATA(dev);
+	const struct espi_npcx_config *const config = dev->config;
+	struct espi_npcx_data *const data = dev->data;
 	struct espi_reg *const inst = HAL_INSTANCE(dev);
 	const struct device *const clk_dev = DEVICE_DT_GET(NPCX_CLK_CTRL_NODE);
 	int i, ret;

--- a/drivers/gpio/gpio_nct38xx.c
+++ b/drivers/gpio/gpio_nct38xx.c
@@ -17,13 +17,9 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(gpio_ntc38xx, CONFIG_GPIO_LOG_LEVEL);
 
-/* Driver convenience defines */
-#define DRV_CONFIG(dev) ((const struct gpio_nct38xx_config *)(dev)->config)
-#define DRV_DATA(dev) ((struct gpio_nct38xx_data *)(dev)->data)
-
 void nct38xx_gpio_alert_handler(const struct device *dev)
 {
-	const struct gpio_nct38xx_config *const config = DRV_CONFIG(dev);
+	const struct gpio_nct38xx_config *const config = dev->config;
 
 	for (int i = 0; i < config->sub_gpio_port_num; i++) {
 		gpio_nct38xx_dispatch_port_isr(config->sub_gpio_dev[i]);
@@ -65,7 +61,7 @@ static int nct38xx_init_interrupt(const struct device *dev)
 
 static int nct38xx_gpio_init(const struct device *dev)
 {
-	const struct gpio_nct38xx_config *const config = DRV_CONFIG(dev);
+	const struct gpio_nct38xx_config *const config = dev->config;
 
 	/* Check I2C is ready  */
 	if (!device_is_ready(config->i2c_dev.bus)) {

--- a/drivers/gpio/gpio_nct38xx_alert.c
+++ b/drivers/gpio/gpio_nct38xx_alert.c
@@ -37,10 +37,6 @@ struct nct38xx_alert_data {
 	struct k_work alert_worker;
 };
 
-/* Driver convenience defines */
-#define DRV_CONFIG(dev) ((const struct nct38xx_alert_config *)(dev)->config)
-#define DRV_DATA(dev) ((struct nct38xx_alert_data *)(dev)->data)
-
 static void nct38xx_alert_callback(const struct device *dev, struct gpio_callback *cb,
 				   uint32_t pins)
 {
@@ -54,7 +50,7 @@ static void nct38xx_alert_worker(struct k_work *work)
 {
 	struct nct38xx_alert_data *const data =
 		CONTAINER_OF(work, struct nct38xx_alert_data, alert_worker);
-	const struct nct38xx_alert_config *const config = DRV_CONFIG(data->alert_dev);
+	const struct nct38xx_alert_config *const config = data->alert_dev->config;
 	uint16_t alert, mask;
 
 	do {
@@ -91,8 +87,8 @@ static void nct38xx_alert_worker(struct k_work *work)
 
 static int nct38xx_alert_init(const struct device *dev)
 {
-	const struct nct38xx_alert_config *const config = DRV_CONFIG(dev);
-	struct nct38xx_alert_data *const data = DRV_DATA(dev);
+	const struct nct38xx_alert_config *const config = dev->config;
+	struct nct38xx_alert_data *const data = dev->data;
 	int ret;
 
 	/* Check NCT38XX devices are all ready. */

--- a/drivers/gpio/gpio_nct38xx_port.c
+++ b/drivers/gpio/gpio_nct38xx_port.c
@@ -36,15 +36,11 @@ struct gpio_nct38xx_port_data {
 	struct k_sem lock;
 };
 
-/* Driver convenience defines */
-#define DRV_CONFIG(dev) ((const struct gpio_nct38xx_port_config *)(dev)->config)
-#define DRV_DATA(dev) ((struct gpio_nct38xx_port_data *)(dev)->data)
-
 /* GPIO api functions */
 static int gpio_nct38xx_pin_config(const struct device *dev, gpio_pin_t pin, gpio_flags_t flags)
 {
-	const struct gpio_nct38xx_port_config *const config = DRV_CONFIG(dev);
-	struct gpio_nct38xx_port_data *const data = DRV_DATA(dev);
+	const struct gpio_nct38xx_port_config *const config = dev->config;
+	struct gpio_nct38xx_port_data *const data = dev->data;
 	uint32_t mask = BIT(pin);
 	uint8_t reg, new_reg;
 	int ret;
@@ -152,7 +148,7 @@ done:
 
 static int gpio_nct38xx_port_get_raw(const struct device *dev, gpio_port_value_t *value)
 {
-	const struct gpio_nct38xx_port_config *const config = DRV_CONFIG(dev);
+	const struct gpio_nct38xx_port_config *const config = dev->config;
 
 	return nct38xx_reg_read_byte(config->nct38xx_dev,
 				     NCT38XX_REG_GPIO_DATA_IN(config->gpio_port), (uint8_t *)value);
@@ -161,8 +157,8 @@ static int gpio_nct38xx_port_get_raw(const struct device *dev, gpio_port_value_t
 static int gpio_nct38xx_port_set_masked_raw(const struct device *dev, gpio_port_pins_t mask,
 					    gpio_port_value_t value)
 {
-	const struct gpio_nct38xx_port_config *const config = DRV_CONFIG(dev);
-	struct gpio_nct38xx_port_data *const data = DRV_DATA(dev);
+	const struct gpio_nct38xx_port_config *const config = dev->config;
+	struct gpio_nct38xx_port_data *const data = dev->data;
 	uint8_t reg, new_reg;
 	int ret;
 
@@ -185,8 +181,8 @@ done:
 
 static int gpio_nct38xx_port_set_bits_raw(const struct device *dev, gpio_port_pins_t mask)
 {
-	const struct gpio_nct38xx_port_config *const config = DRV_CONFIG(dev);
-	struct gpio_nct38xx_port_data *const data = DRV_DATA(dev);
+	const struct gpio_nct38xx_port_config *const config = dev->config;
+	struct gpio_nct38xx_port_data *const data = dev->data;
 	uint8_t reg, new_reg;
 	int ret;
 
@@ -209,8 +205,8 @@ done:
 
 static int gpio_nct38xx_port_clear_bits_raw(const struct device *dev, gpio_port_pins_t mask)
 {
-	const struct gpio_nct38xx_port_config *const config = DRV_CONFIG(dev);
-	struct gpio_nct38xx_port_data *const data = DRV_DATA(dev);
+	const struct gpio_nct38xx_port_config *const config = dev->config;
+	struct gpio_nct38xx_port_data *const data = dev->data;
 	uint8_t reg, new_reg;
 	int ret;
 
@@ -233,8 +229,8 @@ done:
 
 static int gpio_nct38xx_port_toggle_bits(const struct device *dev, gpio_port_pins_t mask)
 {
-	const struct gpio_nct38xx_port_config *const config = DRV_CONFIG(dev);
-	struct gpio_nct38xx_port_data *const data = DRV_DATA(dev);
+	const struct gpio_nct38xx_port_config *const config = dev->config;
+	struct gpio_nct38xx_port_data *const data = dev->data;
 	uint8_t reg, new_reg;
 	int ret;
 
@@ -258,8 +254,8 @@ done:
 static int gpio_nct38xx_pin_interrupt_configure(const struct device *dev, gpio_pin_t pin,
 						enum gpio_int_mode mode, enum gpio_int_trig trig)
 {
-	const struct gpio_nct38xx_port_config *const config = DRV_CONFIG(dev);
-	struct gpio_nct38xx_port_data *const data = DRV_DATA(dev);
+	const struct gpio_nct38xx_port_config *const config = dev->config;
+	struct gpio_nct38xx_port_data *const data = dev->data;
 	uint8_t reg, new_reg, rise, new_rise, fall, new_fall;
 	int ret;
 	uint32_t mask = BIT(pin);
@@ -380,15 +376,15 @@ done:
 static int gpio_nct38xx_manage_callback(const struct device *dev, struct gpio_callback *callback,
 					bool set)
 {
-	struct gpio_nct38xx_port_data *const data = DRV_DATA(dev);
+	struct gpio_nct38xx_port_data *const data = dev->data;
 
 	return gpio_manage_callback(&data->cb_list_gpio, callback, set);
 }
 
 int gpio_nct38xx_dispatch_port_isr(const struct device *dev)
 {
-	const struct gpio_nct38xx_port_config *const config = DRV_CONFIG(dev);
-	struct gpio_nct38xx_port_data *const data = DRV_DATA(dev);
+	const struct gpio_nct38xx_port_config *const config = dev->config;
+	struct gpio_nct38xx_port_data *const data = dev->data;
 	uint8_t alert_pins, mask;
 	int ret;
 
@@ -445,8 +441,8 @@ static const struct gpio_driver_api gpio_nct38xx_driver = {
 
 static int gpio_nct38xx_port_init(const struct device *dev)
 {
-	const struct gpio_nct38xx_port_config *const config = DRV_CONFIG(dev);
-	struct gpio_nct38xx_port_data *const data = DRV_DATA(dev);
+	const struct gpio_nct38xx_port_config *const config = dev->config;
+	struct gpio_nct38xx_port_data *const data = dev->data;
 
 	if (!device_is_ready(config->nct38xx_dev)) {
 		LOG_ERR("%s is not ready", config->nct38xx_dev->name);

--- a/drivers/gpio/gpio_npcx.c
+++ b/drivers/gpio/gpio_npcx.c
@@ -43,11 +43,8 @@ struct gpio_npcx_data {
 };
 
 /* Driver convenience defines */
-#define DRV_CONFIG(dev) ((const struct gpio_npcx_config *)(dev)->config)
-
-#define DRV_DATA(dev) ((struct gpio_npcx_data *)(dev)->data)
-
-#define HAL_INSTANCE(dev) ((struct gpio_reg *)DRV_CONFIG(dev)->base)
+#define HAL_INSTANCE(dev)                                                                          \
+	((struct gpio_reg *)((const struct gpio_npcx_config *)(dev)->config)->base)
 
 /* Platform specific GPIO functions */
 const struct device *npcx_get_gpio_dev(int port)
@@ -60,7 +57,7 @@ const struct device *npcx_get_gpio_dev(int port)
 
 void npcx_gpio_enable_io_pads(const struct device *dev, int pin)
 {
-	const struct gpio_npcx_config *const config = DRV_CONFIG(dev);
+	const struct gpio_npcx_config *const config = dev->config;
 	const struct npcx_wui *io_wui = &config->wui_maps[pin];
 
 	/*
@@ -74,7 +71,7 @@ void npcx_gpio_enable_io_pads(const struct device *dev, int pin)
 
 void npcx_gpio_disable_io_pads(const struct device *dev, int pin)
 {
-	const struct gpio_npcx_config *const config = DRV_CONFIG(dev);
+	const struct gpio_npcx_config *const config = dev->config;
 	const struct npcx_wui *io_wui = &config->wui_maps[pin];
 
 	/*
@@ -90,7 +87,7 @@ void npcx_gpio_disable_io_pads(const struct device *dev, int pin)
 static int gpio_npcx_config(const struct device *dev,
 			     gpio_pin_t pin, gpio_flags_t flags)
 {
-	const struct gpio_npcx_config *const config = DRV_CONFIG(dev);
+	const struct gpio_npcx_config *const config = dev->config;
 	struct gpio_reg *const inst = HAL_INSTANCE(dev);
 	uint32_t mask = BIT(pin);
 
@@ -214,7 +211,7 @@ static int gpio_npcx_pin_interrupt_configure(const struct device *dev,
 					     enum gpio_int_mode mode,
 					     enum gpio_int_trig trig)
 {
-	const struct gpio_npcx_config *const config = DRV_CONFIG(dev);
+	const struct gpio_npcx_config *const config = dev->config;
 
 	if (config->wui_maps[pin].table == NPCX_MIWU_TABLE_NONE) {
 		LOG_ERR("Cannot configure GPIO(%x, %d)", config->port, pin);
@@ -272,7 +269,7 @@ static int gpio_npcx_pin_interrupt_configure(const struct device *dev,
 static int gpio_npcx_manage_callback(const struct device *dev,
 				      struct gpio_callback *callback, bool set)
 {
-	const struct gpio_npcx_config *const config = DRV_CONFIG(dev);
+	const struct gpio_npcx_config *const config = dev->config;
 	struct miwu_io_callback *miwu_cb = (struct miwu_io_callback *)callback;
 	int pin = find_lsb_set(callback->pin_mask) - 1;
 
@@ -311,8 +308,9 @@ int gpio_npcx_init(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 
-	__ASSERT(DRV_CONFIG(dev)->wui_size == NPCX_GPIO_PORT_PIN_NUM,
-			"wui_maps array size must equal to its pin number");
+	__ASSERT(((const struct gpio_npcx_config *)dev->config)->wui_size ==
+			 NPCX_GPIO_PORT_PIN_NUM,
+		 "wui_maps array size must equal to its pin number");
 	return 0;
 }
 

--- a/drivers/gpio/gpio_npcx.c
+++ b/drivers/gpio/gpio_npcx.c
@@ -47,7 +47,7 @@ struct gpio_npcx_data {
 
 #define DRV_DATA(dev) ((struct gpio_npcx_data *)(dev)->data)
 
-#define HAL_INSTANCE(dev) (struct gpio_reg *)(DRV_CONFIG(dev)->base)
+#define HAL_INSTANCE(dev) ((struct gpio_reg *)DRV_CONFIG(dev)->base)
 
 /* Platform specific GPIO functions */
 const struct device *npcx_get_gpio_dev(int port)

--- a/drivers/i2c/i2c_npcx_controller.c
+++ b/drivers/i2c/i2c_npcx_controller.c
@@ -154,10 +154,10 @@ struct i2c_ctrl_data {
 
 #define DRV_DATA(dev) ((struct i2c_ctrl_data *)(dev)->data)
 
-#define HAL_I2C_INSTANCE(dev) (struct smb_reg *)(DRV_CONFIG(dev)->base)
+#define HAL_I2C_INSTANCE(dev) ((struct smb_reg *)DRV_CONFIG(dev)->base)
 
 #define HAL_I2C_FIFO_INSTANCE(dev) \
-	(struct smb_fifo_reg *)(DRV_CONFIG(dev)->base)
+	((struct smb_fifo_reg *)DRV_CONFIG(dev)->base)
 
 /* Recommended I2C timing values are based on 15 MHz */
 static const struct npcx_i2c_timing_cfg npcx_15m_speed_confs[] = {

--- a/drivers/i2c/i2c_npcx_controller.c
+++ b/drivers/i2c/i2c_npcx_controller.c
@@ -150,14 +150,11 @@ struct i2c_ctrl_data {
 };
 
 /* Driver convenience defines */
-#define DRV_CONFIG(dev) ((const struct i2c_ctrl_config *)(dev)->config)
+#define HAL_I2C_INSTANCE(dev)                                                                      \
+	((struct smb_reg *)((const struct i2c_ctrl_config *)(dev)->config)->base)
 
-#define DRV_DATA(dev) ((struct i2c_ctrl_data *)(dev)->data)
-
-#define HAL_I2C_INSTANCE(dev) ((struct smb_reg *)DRV_CONFIG(dev)->base)
-
-#define HAL_I2C_FIFO_INSTANCE(dev) \
-	((struct smb_fifo_reg *)DRV_CONFIG(dev)->base)
+#define HAL_I2C_FIFO_INSTANCE(dev)                                                                 \
+	((struct smb_fifo_reg *)((const struct i2c_ctrl_config *)(dev)->config)->base)
 
 /* Recommended I2C timing values are based on 15 MHz */
 static const struct npcx_i2c_timing_cfg npcx_15m_speed_confs[] = {
@@ -207,7 +204,7 @@ static inline void i2c_ctrl_bank_sel(const struct device *dev, int bank)
 
 static inline void i2c_ctrl_irq_enable(const struct device *dev, int enable)
 {
-	const struct i2c_ctrl_config *const config = DRV_CONFIG(dev);
+	const struct i2c_ctrl_config *const config = dev->config;
 
 	if (enable) {
 		irq_enable(config->irq);
@@ -338,7 +335,7 @@ static void i2c_ctrl_config_bus_freq(const struct device *dev,
 						enum npcx_i2c_freq bus_freq)
 {
 	struct smb_reg *const inst = HAL_I2C_INSTANCE(dev);
-	struct i2c_ctrl_data *const data = DRV_DATA(dev);
+	struct i2c_ctrl_data *const data = dev->data;
 	const struct npcx_i2c_timing_cfg bus_cfg =
 						data->ptr_speed_confs[bus_freq];
 
@@ -423,7 +420,7 @@ static int i2c_ctrl_wait_idle_completed(const struct device *dev, int timeout)
 static int i2c_ctrl_recovery(const struct device *dev)
 {
 	struct smb_fifo_reg *const inst_fifo = HAL_I2C_FIFO_INSTANCE(dev);
-	struct i2c_ctrl_data *const data = DRV_DATA(dev);
+	struct i2c_ctrl_data *const data = dev->data;
 	int ret;
 
 	if (data->oper_state != NPCX_I2C_ERROR_RECOVERY) {
@@ -471,7 +468,7 @@ static int i2c_ctrl_recovery(const struct device *dev)
 
 static void i2c_ctrl_notify(const struct device *dev, int error)
 {
-	struct i2c_ctrl_data *const data = DRV_DATA(dev);
+	struct i2c_ctrl_data *const data = dev->data;
 
 	data->trans_err = error;
 	k_sem_give(&data->sync_sem);
@@ -479,7 +476,7 @@ static void i2c_ctrl_notify(const struct device *dev, int error)
 
 static int i2c_ctrl_wait_completion(const struct device *dev)
 {
-	struct i2c_ctrl_data *const data = DRV_DATA(dev);
+	struct i2c_ctrl_data *const data = dev->data;
 
 	if (k_sem_take(&data->sync_sem, I2C_TRANS_TIMEOUT) == 0) {
 		return data->trans_err;
@@ -490,7 +487,7 @@ static int i2c_ctrl_wait_completion(const struct device *dev)
 
 size_t i2c_ctrl_calculate_msg_remains(const struct device *dev)
 {
-	struct i2c_ctrl_data *const data = DRV_DATA(dev);
+	struct i2c_ctrl_data *const data = dev->data;
 	uint8_t *buf_end = data->msg->buf + data->msg->len;
 
 	return (buf_end > data->ptr_msg) ? (buf_end - data->ptr_msg) : 0;
@@ -498,7 +495,7 @@ size_t i2c_ctrl_calculate_msg_remains(const struct device *dev)
 
 static void i2c_ctrl_handle_write_int_event(const struct device *dev)
 {
-	struct i2c_ctrl_data *const data = DRV_DATA(dev);
+	struct i2c_ctrl_data *const data = dev->data;
 
 	/* START condition is issued */
 	if (data->oper_state == NPCX_I2C_WAIT_START) {
@@ -546,7 +543,7 @@ static void i2c_ctrl_handle_write_int_event(const struct device *dev)
 
 static void i2c_ctrl_handle_read_int_event(const struct device *dev)
 {
-	struct i2c_ctrl_data *const data = DRV_DATA(dev);
+	struct i2c_ctrl_data *const data = dev->data;
 
 	/* START or RESTART condition is issued */
 	if (data->oper_state == NPCX_I2C_WAIT_START ||
@@ -621,7 +618,7 @@ static void i2c_ctrl_handle_read_int_event(const struct device *dev)
 static int i2c_ctrl_proc_write_msg(const struct device *dev,
 							struct i2c_msg *msg)
 {
-	struct i2c_ctrl_data *const data = DRV_DATA(dev);
+	struct i2c_ctrl_data *const data = dev->data;
 
 	data->is_write = 1;
 	data->ptr_msg = msg->buf;
@@ -648,7 +645,7 @@ static int i2c_ctrl_proc_write_msg(const struct device *dev,
 
 static int i2c_ctrl_proc_read_msg(const struct device *dev, struct i2c_msg *msg)
 {
-	struct i2c_ctrl_data *const data = DRV_DATA(dev);
+	struct i2c_ctrl_data *const data = dev->data;
 
 	data->is_write = 0;
 	data->ptr_msg = msg->buf;
@@ -692,7 +689,7 @@ static int i2c_ctrl_proc_read_msg(const struct device *dev, struct i2c_msg *msg)
 static void i2c_ctrl_isr(const struct device *dev)
 {
 	struct smb_fifo_reg *const inst_fifo = HAL_I2C_FIFO_INSTANCE(dev);
-	struct i2c_ctrl_data *const data = DRV_DATA(dev);
+	struct i2c_ctrl_data *const data = dev->data;
 	uint8_t status, tmp;
 
 	status = inst_fifo->SMBST & NPCX_VALID_SMBST_MASK;
@@ -750,21 +747,21 @@ static void i2c_ctrl_isr(const struct device *dev)
 /* NPCX specific I2C controller functions */
 void npcx_i2c_ctrl_mutex_lock(const struct device *i2c_dev)
 {
-	struct i2c_ctrl_data *const data = DRV_DATA(i2c_dev);
+	struct i2c_ctrl_data *const data = i2c_dev->data;
 
 	k_sem_take(&data->lock_sem, K_FOREVER);
 }
 
 void npcx_i2c_ctrl_mutex_unlock(const struct device *i2c_dev)
 {
-	struct i2c_ctrl_data *const data = DRV_DATA(i2c_dev);
+	struct i2c_ctrl_data *const data = i2c_dev->data;
 
 	k_sem_give(&data->lock_sem);
 }
 
 int npcx_i2c_ctrl_configure(const struct device *i2c_dev, uint32_t dev_config)
 {
-	struct i2c_ctrl_data *const data = DRV_DATA(i2c_dev);
+	struct i2c_ctrl_data *const data = i2c_dev->data;
 
 	switch (I2C_SPEED_GET(dev_config)) {
 	case I2C_SPEED_STANDARD:
@@ -788,7 +785,7 @@ int npcx_i2c_ctrl_configure(const struct device *i2c_dev, uint32_t dev_config)
 
 int npcx_i2c_ctrl_get_speed(const struct device *i2c_dev, uint32_t *speed)
 {
-	struct i2c_ctrl_data *const data = DRV_DATA(i2c_dev);
+	struct i2c_ctrl_data *const data = i2c_dev->data;
 
 	if (!data->is_configured) {
 		return -EIO;
@@ -814,7 +811,7 @@ int npcx_i2c_ctrl_get_speed(const struct device *i2c_dev, uint32_t *speed)
 int npcx_i2c_ctrl_transfer(const struct device *i2c_dev, struct i2c_msg *msgs,
 			      uint8_t num_msgs, uint16_t addr, int port)
 {
-	struct i2c_ctrl_data *const data = DRV_DATA(i2c_dev);
+	struct i2c_ctrl_data *const data = i2c_dev->data;
 	int ret = 0;
 	uint8_t i;
 
@@ -887,8 +884,8 @@ int npcx_i2c_ctrl_transfer(const struct device *i2c_dev, struct i2c_msg *msgs,
 /* I2C controller driver registration */
 static int i2c_ctrl_init(const struct device *dev)
 {
-	const struct i2c_ctrl_config *const config = DRV_CONFIG(dev);
-	struct i2c_ctrl_data *const data = DRV_DATA(dev);
+	const struct i2c_ctrl_config *const config = dev->config;
+	struct i2c_ctrl_data *const data = dev->data;
 	const struct device *const clk_dev = DEVICE_DT_GET(NPCX_CLK_CTRL_NODE);
 	uint32_t i2c_rate;
 

--- a/drivers/i2c/i2c_npcx_port.c
+++ b/drivers/i2c/i2c_npcx_port.c
@@ -50,15 +50,11 @@ struct i2c_npcx_port_config {
 	const struct device *i2c_ctrl;
 };
 
-/* Driver convenience defines */
-#define DRV_CONFIG(dev) \
-	((const struct i2c_npcx_port_config *)(dev)->config)
-
 /* I2C api functions */
 static int i2c_npcx_port_configure(const struct device *dev,
 							uint32_t dev_config)
 {
-	const struct i2c_npcx_port_config *const config = DRV_CONFIG(dev);
+	const struct i2c_npcx_port_config *const config = dev->config;
 
 	if (config->i2c_ctrl == NULL) {
 		LOG_ERR("Cannot find i2c controller on port%02x!",
@@ -80,7 +76,7 @@ static int i2c_npcx_port_configure(const struct device *dev,
 
 static int i2c_npcx_port_get_config(const struct device *dev, uint32_t *dev_config)
 {
-	const struct i2c_npcx_port_config *const config = DRV_CONFIG(dev);
+	const struct i2c_npcx_port_config *const config = dev->config;
 	uint32_t speed;
 	int ret;
 
@@ -100,7 +96,7 @@ static int i2c_npcx_port_get_config(const struct device *dev, uint32_t *dev_conf
 static int i2c_npcx_port_transfer(const struct device *dev,
 		struct i2c_msg *msgs, uint8_t num_msgs, uint16_t addr)
 {
-	const struct i2c_npcx_port_config *const config = DRV_CONFIG(dev);
+	const struct i2c_npcx_port_config *const config = dev->config;
 	int ret = 0;
 	int idx_ctrl = (config->port & 0xF0) >> 4;
 	int idx_port = (config->port & 0x0F);
@@ -130,7 +126,7 @@ static int i2c_npcx_port_transfer(const struct device *dev,
 /* I2C driver registration */
 static int i2c_npcx_port_init(const struct device *dev)
 {
-	const struct i2c_npcx_port_config *const config = DRV_CONFIG(dev);
+	const struct i2c_npcx_port_config *const config = dev->config;
 	uint32_t i2c_config;
 	int ret;
 

--- a/drivers/ps2/ps2_npcx_channel.c
+++ b/drivers/ps2/ps2_npcx_channel.c
@@ -35,14 +35,11 @@ struct ps2_npcx_ch_config {
 	const struct device *ps2_ctrl;
 };
 
-/* Driver convenience defines */
-#define DRV_CONFIG(dev) ((const struct ps2_npcx_ch_config *)(dev)->config)
-
 /* PS/2 api functions */
 static int ps2_npcx_ch_configure(const struct device *dev,
 				 ps2_callback_t callback_isr)
 {
-	const struct ps2_npcx_ch_config *const config = DRV_CONFIG(dev);
+	const struct ps2_npcx_ch_config *const config = dev->config;
 	int ret;
 
 	ret = ps2_npcx_ctrl_configure(config->ps2_ctrl, config->channel_id,
@@ -56,14 +53,14 @@ static int ps2_npcx_ch_configure(const struct device *dev,
 
 static int ps2_npcx_ch_write(const struct device *dev, uint8_t value)
 {
-	const struct ps2_npcx_ch_config *const config = DRV_CONFIG(dev);
+	const struct ps2_npcx_ch_config *const config = dev->config;
 
 	return ps2_npcx_ctrl_write(config->ps2_ctrl, config->channel_id, value);
 }
 
 static int ps2_npcx_ch_enable_interface(const struct device *dev)
 {
-	const struct ps2_npcx_ch_config *const config = DRV_CONFIG(dev);
+	const struct ps2_npcx_ch_config *const config = dev->config;
 
 	return ps2_npcx_ctrl_enable_interface(config->ps2_ctrl,
 					      config->channel_id, 1);
@@ -71,7 +68,7 @@ static int ps2_npcx_ch_enable_interface(const struct device *dev)
 
 static int ps2_npcx_ch_inhibit_interface(const struct device *dev)
 {
-	const struct ps2_npcx_ch_config *const config = DRV_CONFIG(dev);
+	const struct ps2_npcx_ch_config *const config = dev->config;
 
 	return ps2_npcx_ctrl_enable_interface(config->ps2_ctrl,
 					      config->channel_id, 0);
@@ -80,7 +77,7 @@ static int ps2_npcx_ch_inhibit_interface(const struct device *dev)
 /* PS/2 driver registration */
 static int ps2_npcx_channel_init(const struct device *dev)
 {
-	const struct ps2_npcx_ch_config *const config = DRV_CONFIG(dev);
+	const struct ps2_npcx_ch_config *const config = dev->config;
 
 	if (!device_is_ready(config->ps2_ctrl)) {
 		LOG_ERR("%s device not ready", config->ps2_ctrl->name);

--- a/drivers/ps2/ps2_npcx_controller.c
+++ b/drivers/ps2/ps2_npcx_controller.c
@@ -65,11 +65,8 @@ struct ps2_npcx_ctrl_data {
 };
 
 /* Driver convenience defines */
-#define DRV_CONFIG(dev) ((const struct ps2_npcx_ctrl_config *)(dev)->config)
-
-#define DRV_DATA(dev) ((struct ps2_npcx_ctrl_data *)(dev)->data)
-
-#define HAL_PS2_INSTANCE(dev) ((struct ps2_reg *)DRV_CONFIG(dev)->base)
+#define HAL_PS2_INSTANCE(dev)                                                                      \
+	((struct ps2_reg *)((const struct ps2_npcx_ctrl_config *)(dev)->config)->base)
 
 static uint8_t ps2_npcx_ctrl_get_ch_clk_mask(uint8_t channel_id)
 {
@@ -79,7 +76,7 @@ static uint8_t ps2_npcx_ctrl_get_ch_clk_mask(uint8_t channel_id)
 int ps2_npcx_ctrl_configure(const struct device *dev, uint8_t channel_id,
 			    ps2_callback_t callback_isr)
 {
-	struct ps2_npcx_ctrl_data *const data = DRV_DATA(dev);
+	struct ps2_npcx_ctrl_data *const data = dev->data;
 
 	if (channel_id >= NPCX_PS2_CH_COUNT) {
 		LOG_ERR("unexpected channel ID: %d", channel_id);
@@ -100,7 +97,7 @@ int ps2_npcx_ctrl_configure(const struct device *dev, uint8_t channel_id,
 int ps2_npcx_ctrl_enable_interface(const struct device *dev, uint8_t channel_id,
 				   bool enable)
 {
-	struct ps2_npcx_ctrl_data *const data = DRV_DATA(dev);
+	struct ps2_npcx_ctrl_data *const data = dev->data;
 	struct ps2_reg *const inst = HAL_PS2_INSTANCE(dev);
 	uint8_t ch_clk_mask;
 
@@ -155,7 +152,7 @@ static int ps2_npcx_ctrl_bus_busy(const struct device *dev)
 int ps2_npcx_ctrl_write(const struct device *dev, uint8_t channel_id,
 			uint8_t value)
 {
-	struct ps2_npcx_ctrl_data *const data = DRV_DATA(dev);
+	struct ps2_npcx_ctrl_data *const data = dev->data;
 	struct ps2_reg *const inst = HAL_PS2_INSTANCE(dev);
 	int i = 0;
 
@@ -242,7 +239,7 @@ static void ps2_npcx_ctrl_isr(const struct device *dev)
 {
 	uint8_t active_ch, mask;
 	struct ps2_reg *const inst = HAL_PS2_INSTANCE(dev);
-	struct ps2_npcx_ctrl_data *const data = DRV_DATA(dev);
+	struct ps2_npcx_ctrl_data *const data = dev->data;
 
 	/*
 	 * ACH = 1 : Channel 0
@@ -326,8 +323,8 @@ DEVICE_DT_INST_DEFINE(0, &ps2_npcx_ctrl_init, NULL, &ps2_npcx_ctrl_data_0,
 
 static int ps2_npcx_ctrl_init(const struct device *dev)
 {
-	const struct ps2_npcx_ctrl_config *const config = DRV_CONFIG(dev);
-	struct ps2_npcx_ctrl_data *const data = DRV_DATA(dev);
+	const struct ps2_npcx_ctrl_config *const config = dev->config;
+	struct ps2_npcx_ctrl_data *const data = dev->data;
 	struct ps2_reg *const inst = HAL_PS2_INSTANCE(dev);
 	const struct device *clk_dev = DEVICE_DT_GET(NPCX_CLK_CTRL_NODE);
 	int ret;

--- a/drivers/ps2/ps2_npcx_controller.c
+++ b/drivers/ps2/ps2_npcx_controller.c
@@ -69,7 +69,7 @@ struct ps2_npcx_ctrl_data {
 
 #define DRV_DATA(dev) ((struct ps2_npcx_ctrl_data *)(dev)->data)
 
-#define HAL_PS2_INSTANCE(dev) (struct ps2_reg *)(DRV_CONFIG(dev)->base)
+#define HAL_PS2_INSTANCE(dev) ((struct ps2_reg *)DRV_CONFIG(dev)->base)
 
 static uint8_t ps2_npcx_ctrl_get_ch_clk_mask(uint8_t channel_id)
 {

--- a/drivers/pwm/pwm_npcx.c
+++ b/drivers/pwm/pwm_npcx.c
@@ -52,16 +52,12 @@ struct pwm_npcx_data {
 };
 
 /* Driver convenience defines */
-#define DRV_CONFIG(dev) ((const struct pwm_npcx_config *)(dev)->config)
-
-#define DRV_DATA(dev) ((struct pwm_npcx_data *)(dev)->data)
-
-#define HAL_INSTANCE(dev) ((struct pwm_reg *)DRV_CONFIG(dev)->base)
+#define HAL_INSTANCE(dev) ((struct pwm_reg *)((const struct pwm_npcx_config *)(dev)->config)->base)
 
 /* PWM local functions */
 static void pwm_npcx_configure(const struct device *dev, int clk_bus)
 {
-	const struct pwm_npcx_config *const config = DRV_CONFIG(dev);
+	const struct pwm_npcx_config *const config = dev->config;
 	struct pwm_reg *const inst = HAL_INSTANCE(dev);
 
 	/* Disable PWM for module configuration first */
@@ -98,7 +94,7 @@ static int pwm_npcx_pin_set(const struct device *dev, uint32_t pwm,
 {
 	/* Single channel for each pwm device */
 	ARG_UNUSED(pwm);
-	struct pwm_npcx_data *const data = DRV_DATA(dev);
+	struct pwm_npcx_data *const data = dev->data;
 	struct pwm_reg *const inst = HAL_INSTANCE(dev);
 	int prescaler;
 
@@ -151,7 +147,7 @@ static int pwm_npcx_get_cycles_per_sec(const struct device *dev, uint32_t pwm,
 {
 	/* Single channel for each pwm device */
 	ARG_UNUSED(pwm);
-	struct pwm_npcx_data *const data = DRV_DATA(dev);
+	struct pwm_npcx_data *const data = dev->data;
 
 	*cycles = data->cycles_per_sec;
 	return 0;
@@ -165,8 +161,8 @@ static const struct pwm_driver_api pwm_npcx_driver_api = {
 
 static int pwm_npcx_init(const struct device *dev)
 {
-	const struct pwm_npcx_config *const config = DRV_CONFIG(dev);
-	struct pwm_npcx_data *const data = DRV_DATA(dev);
+	const struct pwm_npcx_config *const config = dev->config;
+	struct pwm_npcx_data *const data = dev->data;
 	struct pwm_reg *const inst = HAL_INSTANCE(dev);
 	const struct device *const clk_dev = DEVICE_DT_GET(NPCX_CLK_CTRL_NODE);
 	int ret;

--- a/drivers/pwm/pwm_npcx.c
+++ b/drivers/pwm/pwm_npcx.c
@@ -56,7 +56,7 @@ struct pwm_npcx_data {
 
 #define DRV_DATA(dev) ((struct pwm_npcx_data *)(dev)->data)
 
-#define HAL_INSTANCE(dev) (struct pwm_reg *)(DRV_CONFIG(dev)->base)
+#define HAL_INSTANCE(dev) ((struct pwm_reg *)DRV_CONFIG(dev)->base)
 
 /* PWM local functions */
 static void pwm_npcx_configure(const struct device *dev, int clk_bus)

--- a/drivers/sensor/nuvoton_tach_npcx/tach_nuvoton_npcx.c
+++ b/drivers/sensor/nuvoton_tach_npcx/tach_nuvoton_npcx.c
@@ -79,7 +79,7 @@ struct tach_npcx_data {
 
 #define DRV_DATA(dev) ((struct tach_npcx_data *)(dev)->data)
 
-#define HAL_INSTANCE(dev) (struct tach_reg *)(DRV_CONFIG(dev)->base)
+#define HAL_INSTANCE(dev) ((struct tach_reg *)DRV_CONFIG(dev)->base)
 
 /* Maximum count of prescaler */
 #define NPCX_TACHO_PRSC_MAX 0xff

--- a/drivers/sensor/nuvoton_tach_npcx/tach_nuvoton_npcx.c
+++ b/drivers/sensor/nuvoton_tach_npcx/tach_nuvoton_npcx.c
@@ -75,11 +75,8 @@ struct tach_npcx_data {
 };
 
 /* Driver convenience defines */
-#define DRV_CONFIG(dev) ((const struct tach_npcx_config *)(dev)->config)
-
-#define DRV_DATA(dev) ((struct tach_npcx_data *)(dev)->data)
-
-#define HAL_INSTANCE(dev) ((struct tach_reg *)DRV_CONFIG(dev)->base)
+#define HAL_INSTANCE(dev)                                                                          \
+	((struct tach_reg *)((const struct tach_npcx_config *)(dev)->config)->base)
 
 /* Maximum count of prescaler */
 #define NPCX_TACHO_PRSC_MAX 0xff
@@ -94,7 +91,7 @@ struct tach_npcx_data {
 /* TACH inline local functions */
 static inline void tach_npcx_start_port_a(const struct device *dev)
 {
-	struct tach_npcx_data *const data = DRV_DATA(dev);
+	struct tach_npcx_data *const data = dev->data;
 	struct tach_reg *const inst = HAL_INSTANCE(dev);
 
 	/* Set the default value of counter and capture register of timer 1. */
@@ -119,7 +116,7 @@ static inline void tach_npcx_start_port_a(const struct device *dev)
 static inline void tach_npcx_start_port_b(const struct device *dev)
 {
 	struct tach_reg *const inst = HAL_INSTANCE(dev);
-	struct tach_npcx_data *const data = DRV_DATA(dev);
+	struct tach_npcx_data *const data = dev->data;
 
 	/* Set the default value of counter and capture register of timer 2. */
 	inst->TCNT2 = NPCX_TACHO_CNT_MAX;
@@ -142,7 +139,7 @@ static inline void tach_npcx_start_port_b(const struct device *dev)
 
 static inline bool tach_npcx_is_underflow(const struct device *dev)
 {
-	const struct tach_npcx_config *const config = DRV_CONFIG(dev);
+	const struct tach_npcx_config *const config = dev->config;
 	struct tach_reg *const inst = HAL_INSTANCE(dev);
 
 	LOG_DBG("port A is underflow %d, port b is underflow %d",
@@ -162,7 +159,7 @@ static inline bool tach_npcx_is_underflow(const struct device *dev)
 
 static inline void tach_npcx_clear_underflow_flag(const struct device *dev)
 {
-	const struct tach_npcx_config *const config = DRV_CONFIG(dev);
+	const struct tach_npcx_config *const config = dev->config;
 	struct tach_reg *const inst = HAL_INSTANCE(dev);
 
 	if (config->port == NPCX_TACH_PORT_A) {
@@ -174,7 +171,7 @@ static inline void tach_npcx_clear_underflow_flag(const struct device *dev)
 
 static inline bool tach_npcx_is_captured(const struct device *dev)
 {
-	const struct tach_npcx_config *const config = DRV_CONFIG(dev);
+	const struct tach_npcx_config *const config = dev->config;
 	struct tach_reg *const inst = HAL_INSTANCE(dev);
 
 	LOG_DBG("port A is captured %d, port b is captured %d",
@@ -194,7 +191,7 @@ static inline bool tach_npcx_is_captured(const struct device *dev)
 
 static inline void tach_npcx_clear_captured_flag(const struct device *dev)
 {
-	const struct tach_npcx_config *const config = DRV_CONFIG(dev);
+	const struct tach_npcx_config *const config = dev->config;
 	struct tach_reg *const inst = HAL_INSTANCE(dev);
 
 	if (config->port == NPCX_TACH_PORT_A) {
@@ -206,7 +203,7 @@ static inline void tach_npcx_clear_captured_flag(const struct device *dev)
 
 static inline uint16_t tach_npcx_get_captured_count(const struct device *dev)
 {
-	const struct tach_npcx_config *const config = DRV_CONFIG(dev);
+	const struct tach_npcx_config *const config = dev->config;
 	struct tach_reg *const inst = HAL_INSTANCE(dev);
 
 	if (config->port == NPCX_TACH_PORT_A) {
@@ -219,8 +216,8 @@ static inline uint16_t tach_npcx_get_captured_count(const struct device *dev)
 /* TACH local functions */
 static int tach_npcx_configure(const struct device *dev)
 {
-	const struct tach_npcx_config *const config = DRV_CONFIG(dev);
-	struct tach_npcx_data *const data = DRV_DATA(dev);
+	const struct tach_npcx_config *const config = dev->config;
+	struct tach_npcx_data *const data = dev->data;
 	struct tach_reg *const inst = HAL_INSTANCE(dev);
 
 	/* Set mode 5 to tachometer module */
@@ -256,7 +253,7 @@ static int tach_npcx_configure(const struct device *dev)
 int tach_npcx_sample_fetch(const struct device *dev, enum sensor_channel chan)
 {
 	ARG_UNUSED(chan);
-	struct tach_npcx_data *const data = DRV_DATA(dev);
+	struct tach_npcx_data *const data = dev->data;
 
 	/* Check whether underflow flag of tachometer is occurred */
 	if (tach_npcx_is_underflow(dev)) {
@@ -285,8 +282,8 @@ static int tach_npcx_channel_get(const struct device *dev,
 				enum sensor_channel chan,
 				struct sensor_value *val)
 {
-	const struct tach_npcx_config *const config = DRV_CONFIG(dev);
-	struct tach_npcx_data *const data = DRV_DATA(dev);
+	const struct tach_npcx_config *const config = dev->config;
+	struct tach_npcx_data *const data = dev->data;
 
 	if (chan != SENSOR_CHAN_RPM) {
 		return -ENOTSUP;
@@ -314,8 +311,8 @@ static int tach_npcx_channel_get(const struct device *dev,
 /* TACH driver registration */
 static int tach_npcx_init(const struct device *dev)
 {
-	const struct tach_npcx_config *const config = DRV_CONFIG(dev);
-	struct tach_npcx_data *const data = DRV_DATA(dev);
+	const struct tach_npcx_config *const config = dev->config;
+	struct tach_npcx_data *const data = dev->data;
 	const struct device *const clk_dev = DEVICE_DT_GET(NPCX_CLK_CTRL_NODE);
 	int ret;
 

--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -57,11 +57,8 @@ struct uart_npcx_data {
 };
 
 /* Driver convenience defines */
-#define DRV_CONFIG(dev) ((const struct uart_npcx_config *)(dev)->config)
-
-#define DRV_DATA(dev) ((struct uart_npcx_data *)(dev)->data)
-
-#define HAL_INSTANCE(dev) ((struct uart_reg *)DRV_CONFIG(dev)->uconf.base)
+#define HAL_INSTANCE(dev)                                                                          \
+	((struct uart_reg *)((const struct uart_npcx_config *)(dev)->config)->uconf.base)
 
 #if defined(CONFIG_PM) && defined(CONFIG_UART_INTERRUPT_DRIVEN)
 static void uart_npcx_pm_constraint_set(struct uart_npcx_data *data,
@@ -147,7 +144,7 @@ static int uart_npcx_fifo_fill(const struct device *dev, const uint8_t *tx_data,
 	while ((size - tx_bytes > 0) && uart_npcx_tx_fifo_ready(dev)) {
 		/* Put a character into Tx FIFO */
 #ifdef CONFIG_PM
-		struct uart_npcx_data *data = DRV_DATA(dev);
+		struct uart_npcx_data *data = dev->data;
 
 		uart_npcx_pm_constraint_set(data, UART_PM_CONSTRAINT_TX_FLAG);
 		inst->UTBUF = tx_data[tx_bytes++];
@@ -249,7 +246,7 @@ static int uart_npcx_irq_update(const struct device *dev)
 static void uart_npcx_irq_callback_set(const struct device *dev, uart_irq_callback_user_data_t cb,
 				       void *cb_data)
 {
-	struct uart_npcx_data *data = DRV_DATA(dev);
+	struct uart_npcx_data *data = dev->data;
 
 	data->user_cb = cb;
 	data->user_data = cb_data;
@@ -257,7 +254,7 @@ static void uart_npcx_irq_callback_set(const struct device *dev, uart_irq_callba
 
 static void uart_npcx_isr(const struct device *dev)
 {
-	struct uart_npcx_data *data = DRV_DATA(dev);
+	struct uart_npcx_data *data = dev->data;
 
 	/*
 	 * Set pm constraint to prevent the system enter suspend state within
@@ -364,7 +361,7 @@ static __unused void uart_npcx_rx_wk_isr(const struct device *dev, struct npcx_w
 	 * the CONFIG_UART_CONSOLE_INPUT_EXPIRED_TIMEOUT period.
 	 */
 #ifdef CONFIG_UART_CONSOLE_INPUT_EXPIRED
-	struct uart_npcx_data *data = DRV_DATA(dev);
+	struct uart_npcx_data *data = dev->data;
 	k_timeout_t delay = K_MSEC(CONFIG_UART_CONSOLE_INPUT_EXPIRED_TIMEOUT);
 
 	uart_npcx_pm_constraint_set(data, UART_PM_CONSTRAINT_RX_FLAG);
@@ -413,8 +410,8 @@ static const struct uart_driver_api uart_npcx_driver_api = {
 
 static int uart_npcx_init(const struct device *dev)
 {
-	const struct uart_npcx_config *const config = DRV_CONFIG(dev);
-	struct uart_npcx_data *const data = DRV_DATA(dev);
+	const struct uart_npcx_config *const config = dev->config;
+	struct uart_npcx_data *const data = dev->data;
 	struct uart_reg *const inst = HAL_INSTANCE(dev);
 	const struct device *const clk_dev = DEVICE_DT_GET(NPCX_CLK_CTRL_NODE);
 	uint32_t uart_rate;

--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -61,7 +61,7 @@ struct uart_npcx_data {
 
 #define DRV_DATA(dev) ((struct uart_npcx_data *)(dev)->data)
 
-#define HAL_INSTANCE(dev) (struct uart_reg *)(DRV_CONFIG(dev)->uconf.base)
+#define HAL_INSTANCE(dev) ((struct uart_reg *)DRV_CONFIG(dev)->uconf.base)
 
 #if defined(CONFIG_PM) && defined(CONFIG_UART_INTERRUPT_DRIVEN)
 static void uart_npcx_pm_constraint_set(struct uart_npcx_data *data,

--- a/drivers/spi/spi_npcx_fiu.c
+++ b/drivers/spi/spi_npcx_fiu.c
@@ -31,7 +31,7 @@ struct npcx_spi_fiu_data {
 /* Driver convenience defines */
 #define DRV_CONFIG(dev) ((const struct npcx_spi_fiu_config *)(dev)->config)
 #define DRV_DATA(dev) ((struct npcx_spi_fiu_data *)(dev)->data)
-#define HAL_INSTANCE(dev) (struct fiu_reg *)(DRV_CONFIG(dev)->base)
+#define HAL_INSTANCE(dev) ((struct fiu_reg *)DRV_CONFIG(dev)->base)
 
 static inline void spi_npcx_fiu_cs_level(const struct device *dev, int level)
 {

--- a/drivers/spi/spi_npcx_fiu.c
+++ b/drivers/spi/spi_npcx_fiu.c
@@ -29,9 +29,8 @@ struct npcx_spi_fiu_data {
 };
 
 /* Driver convenience defines */
-#define DRV_CONFIG(dev) ((const struct npcx_spi_fiu_config *)(dev)->config)
-#define DRV_DATA(dev) ((struct npcx_spi_fiu_data *)(dev)->data)
-#define HAL_INSTANCE(dev) ((struct fiu_reg *)DRV_CONFIG(dev)->base)
+#define HAL_INSTANCE(dev)                                                                          \
+	((struct fiu_reg *)((const struct npcx_spi_fiu_config *)(dev)->config)->base)
 
 static inline void spi_npcx_fiu_cs_level(const struct device *dev, int level)
 {
@@ -50,7 +49,7 @@ static inline void spi_npcx_fiu_exec_cmd(const struct device *dev, uint8_t code,
 	struct fiu_reg *const inst = HAL_INSTANCE(dev);
 
 #ifdef CONFIG_ASSERT
-	struct npcx_spi_fiu_data *data = DRV_DATA(dev);
+	struct npcx_spi_fiu_data *data = dev->data;
 	struct spi_context *ctx = &data->ctx;
 
 	/* Flash mutex must be held while executing UMA commands */
@@ -70,7 +69,7 @@ static int spi_npcx_fiu_transceive(const struct device *dev,
 				   const struct spi_buf_set *tx_bufs,
 				   const struct spi_buf_set *rx_bufs)
 {
-	struct npcx_spi_fiu_data *data = DRV_DATA(dev);
+	struct npcx_spi_fiu_data *data = dev->data;
 	struct fiu_reg *const inst = HAL_INSTANCE(dev);
 	struct spi_context *ctx = &data->ctx;
 	size_t cur_xfer_len;
@@ -129,7 +128,7 @@ static int spi_npcx_fiu_transceive(const struct device *dev,
 int spi_npcx_fiu_release(const struct device *dev,
 			 const struct spi_config *config)
 {
-	struct npcx_spi_fiu_data *data = DRV_DATA(dev);
+	struct npcx_spi_fiu_data *data = dev->data;
 	struct spi_context *ctx = &data->ctx;
 
 	if (!spi_context_configured(ctx, config)) {
@@ -142,7 +141,7 @@ int spi_npcx_fiu_release(const struct device *dev,
 
 static int spi_npcx_fiu_init(const struct device *dev)
 {
-	const struct npcx_spi_fiu_config *const config = DRV_CONFIG(dev);
+	const struct npcx_spi_fiu_config *const config = dev->config;
 	const struct device *clk_dev = DEVICE_DT_GET(NPCX_CLK_CTRL_NODE);
 	int ret;
 
@@ -160,7 +159,7 @@ static int spi_npcx_fiu_init(const struct device *dev)
 	}
 
 	/* Make sure the context is unlocked */
-	spi_context_unlock_unconditionally(&DRV_DATA(dev)->ctx);
+	spi_context_unlock_unconditionally(&((struct npcx_spi_fiu_data *)dev->data)->ctx);
 
 	return 0;
 }

--- a/drivers/watchdog/wdt_npcx.c
+++ b/drivers/watchdog/wdt_npcx.c
@@ -84,7 +84,7 @@ struct miwu_dev_callback miwu_cb;
 /* Driver convenience defines */
 #define DRV_CONFIG(dev) ((const struct wdt_npcx_config *)(dev)->config)
 #define DRV_DATA(dev) ((struct wdt_npcx_data *)(dev)->data)
-#define HAL_INSTANCE(dev) (struct twd_reg *)(DRV_CONFIG(dev)->base)
+#define HAL_INSTANCE(dev) ((struct twd_reg *)DRV_CONFIG(dev)->base)
 
 /* WDT local inline functions */
 static inline int wdt_t0out_reload(const struct device *dev)

--- a/drivers/watchdog/wdt_npcx.c
+++ b/drivers/watchdog/wdt_npcx.c
@@ -82,9 +82,7 @@ struct wdt_npcx_data {
 struct miwu_dev_callback miwu_cb;
 
 /* Driver convenience defines */
-#define DRV_CONFIG(dev) ((const struct wdt_npcx_config *)(dev)->config)
-#define DRV_DATA(dev) ((struct wdt_npcx_data *)(dev)->data)
-#define HAL_INSTANCE(dev) ((struct twd_reg *)DRV_CONFIG(dev)->base)
+#define HAL_INSTANCE(dev) ((struct twd_reg *)((const struct wdt_npcx_config *)(dev)->config)->base)
 
 /* WDT local inline functions */
 static inline int wdt_t0out_reload(const struct device *dev)
@@ -133,7 +131,7 @@ static inline int wdt_wait_stopped(const struct device *dev)
 /* WDT local functions */
 static void wdt_t0out_isr(const struct device *dev, struct npcx_wui *wui)
 {
-	struct wdt_npcx_data *const data = DRV_DATA(dev);
+	struct wdt_npcx_data *const data = dev->data;
 	ARG_UNUSED(wui);
 
 	LOG_DBG("WDT reset will issue after %d delay cycle! WUI(%d %d %d)",
@@ -147,7 +145,7 @@ static void wdt_t0out_isr(const struct device *dev, struct npcx_wui *wui)
 
 static void wdt_config_t0out_interrupt(const struct device *dev)
 {
-	const struct wdt_npcx_config *const config = DRV_CONFIG(dev);
+	const struct wdt_npcx_config *const config = dev->config;
 
 	/* Initialize a miwu device input and its callback function */
 	npcx_miwu_init_dev_callback(&miwu_cb, &config->t0out, wdt_t0out_isr,
@@ -166,7 +164,7 @@ static void wdt_config_t0out_interrupt(const struct device *dev)
 static int wdt_npcx_install_timeout(const struct device *dev,
 				   const struct wdt_timeout_cfg *cfg)
 {
-	struct wdt_npcx_data *const data = DRV_DATA(dev);
+	struct wdt_npcx_data *const data = dev->data;
 	struct twd_reg *const inst = HAL_INSTANCE(dev);
 
 	/* If watchdog is already running */
@@ -204,8 +202,8 @@ static int wdt_npcx_install_timeout(const struct device *dev,
 static int wdt_npcx_setup(const struct device *dev, uint8_t options)
 {
 	struct twd_reg *const inst = HAL_INSTANCE(dev);
-	const struct wdt_npcx_config *const config = DRV_CONFIG(dev);
-	struct wdt_npcx_data *const data = DRV_DATA(dev);
+	const struct wdt_npcx_config *const config = dev->config;
+	struct wdt_npcx_data *const data = dev->data;
 	int rv;
 
 	/* Disable irq of t0-out expired event first */
@@ -258,8 +256,8 @@ static int wdt_npcx_setup(const struct device *dev, uint8_t options)
 
 static int wdt_npcx_disable(const struct device *dev)
 {
-	const struct wdt_npcx_config *const config = DRV_CONFIG(dev);
-	struct wdt_npcx_data *const data = DRV_DATA(dev);
+	const struct wdt_npcx_config *const config = dev->config;
+	struct wdt_npcx_data *const data = dev->data;
 	struct twd_reg *const inst = HAL_INSTANCE(dev);
 
 	/*
@@ -289,7 +287,7 @@ static int wdt_npcx_disable(const struct device *dev)
 static int wdt_npcx_feed(const struct device *dev, int channel_id)
 {
 	ARG_UNUSED(channel_id);
-	struct wdt_npcx_data *const data = DRV_DATA(dev);
+	struct wdt_npcx_data *const data = dev->data;
 	struct twd_reg *const inst = HAL_INSTANCE(dev);
 
 	/* Feed watchdog by writing 5Ch to WDSDM */


### PR DESCRIPTION
Issue #37616 wants to make access to devise data and config consistent.
NPCX & NCT38XX use DRV_CONFIG/DRV_DATA macros to access config & data so npcx/nct38xx drivers don't modify at #41918.
This PR removes DRV_CONFIG/DRV_DATA to make access to devise data and config consistent.
