### PR TITLE
Bluetooth: ISO: Fix missing ISO type for peripheral ISO

### DIFF
--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -876,9 +876,13 @@ void hci_le_cis_established(struct net_buf *buf)
 
 	if (!evt->status) {
 		if (iso->role == BT_HCI_ROLE_PERIPHERAL) {
-			struct bt_iso_chan *chan = iso->iso.chan;
 			struct bt_iso_chan_io_qos *rx;
 			struct bt_iso_chan_io_qos *tx;
+			struct bt_conn_iso *iso_conn;
+			struct bt_iso_chan *chan;
+
+			iso_conn = &iso->iso;
+			chan = iso_conn->chan;
 
 			__ASSERT(chan != NULL && chan->qos != NULL,
 				 "Invalid ISO chan");
@@ -895,6 +899,8 @@ void hci_le_cis_established(struct net_buf *buf)
 				tx->phy = evt->p_phy;
 				tx->sdu = evt->p_max_pdu;
 			}
+
+			iso_conn->type = BT_ISO_CHAN_TYPE_CONNECTED;
 		} /* values are already set for central */
 
 		/* TODO: Add CIG sync delay */


### PR DESCRIPTION
For the peripheral ISO role, the iso->type was never set,
causing setup data path to fail.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>