### PR TITLE
settings: Add support for overriding NVS/FCB settings partition

### DIFF
--- a/doc/reference/devicetree/api.rst
+++ b/doc/reference/devicetree/api.rst
@@ -392,6 +392,9 @@ device.
      - Used by the OpenThread to specify UART device for Spinel protocol
    * - zephyr,pcie-controller
      - The node corresponding to the PCIe Controller
+   * - zephyr,settings-partition
+     - Fixed partition node. If defined this selects the partition used
+       by the NVS and FCB settings backends.
    * - zephyr,shell-uart
      - Sets UART device used by serial shell backend
    * - zephyr,sram

--- a/doc/reference/settings/index.rst
+++ b/doc/reference/settings/index.rst
@@ -102,6 +102,17 @@ Non-volatile storage read target is registered using
 ``settings_nvs_src()``, and write target by using
 ``settings_nvs_dst()``.
 
+Storage Location
+****************
+
+The FCB and non-volatile storage (NVS) backends both look for a fixed
+partition with label "storage" by default. A different partition can be
+selected by setting the ``zephyr,settings-partition`` property of the
+chosen node in the devicetree.
+
+The file path used by the file system backend to store settings
+is selected via the option ``CONFIG_SETTINGS_FS_FILE``.
+
 Loading data from persisted storage
 ***********************************
 

--- a/subsys/settings/src/settings_fcb.c
+++ b/subsys/settings/src/settings_fcb.c
@@ -17,6 +17,12 @@
 #include <logging/log.h>
 LOG_MODULE_DECLARE(settings, CONFIG_SETTINGS_LOG_LEVEL);
 
+#if DT_HAS_CHOSEN(zephyr_settings_partition)
+#define SETTINGS_PARTITION DT_FIXED_PARTITION_ID(DT_CHOSEN(zephyr_settings_partition))
+#else
+#define SETTINGS_PARTITION FLASH_AREA_ID(storage)
+#endif
+
 #define SETTINGS_FCB_VERS		1
 
 int settings_backend_init(void);
@@ -40,7 +46,7 @@ int settings_fcb_src(struct settings_fcb *cf)
 	cf->cf_fcb.f_scratch_cnt = 1;
 
 	while (1) {
-		rc = fcb_init(FLASH_AREA_ID(storage), &cf->cf_fcb);
+		rc = fcb_init(SETTINGS_PARTITION, &cf->cf_fcb);
 		if (rc) {
 			return -EINVAL;
 		}
@@ -389,7 +395,7 @@ int settings_backend_init(void)
 	int rc;
 	const struct flash_area *fap;
 
-	rc = flash_area_get_sectors(FLASH_AREA_ID(storage), &cnt,
+	rc = flash_area_get_sectors(SETTINGS_PARTITION, &cnt,
 				    settings_fcb_area);
 	if (rc == -ENODEV) {
 		return rc;
@@ -402,7 +408,7 @@ int settings_backend_init(void)
 	rc = settings_fcb_src(&config_init_settings_fcb);
 
 	if (rc != 0) {
-		rc = flash_area_open(FLASH_AREA_ID(storage), &fap);
+		rc = flash_area_open(SETTINGS_PARTITION, &fap);
 
 		if (rc == 0) {
 			rc = flash_area_erase(fap, 0, fap->fa_size);

--- a/subsys/settings/src/settings_nvs.c
+++ b/subsys/settings/src/settings_nvs.c
@@ -16,6 +16,12 @@
 #include <logging/log.h>
 LOG_MODULE_DECLARE(settings, CONFIG_SETTINGS_LOG_LEVEL);
 
+#if DT_HAS_CHOSEN(zephyr_settings_partition)
+#define SETTINGS_PARTITION DT_FIXED_PARTITION_ID(DT_CHOSEN(zephyr_settings_partition))
+#else
+#define SETTINGS_PARTITION FLASH_AREA_ID(storage)
+#endif
+
 struct settings_nvs_read_fn_arg {
 	struct nvs_fs *fs;
 	uint16_t id;
@@ -272,12 +278,12 @@ int settings_backend_init(void)
 	struct flash_sector hw_flash_sector;
 	uint32_t sector_cnt = 1;
 
-	rc = flash_area_open(FLASH_AREA_ID(storage), &fa);
+	rc = flash_area_open(SETTINGS_PARTITION, &fa);
 	if (rc) {
 		return rc;
 	}
 
-	rc = flash_area_get_sectors(FLASH_AREA_ID(storage), &sector_cnt,
+	rc = flash_area_get_sectors(SETTINGS_PARTITION, &sector_cnt,
 				    &hw_flash_sector);
 	if (rc == -ENODEV) {
 		return rc;

--- a/tests/subsys/settings/functional/fcb/chosen.overlay
+++ b/tests/subsys/settings/functional/fcb/chosen.overlay
@@ -1,0 +1,13 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,settings-partition = &storage_partition;
+	};
+};
+
+&storage_partition {
+	label = "chosen_partition";
+};

--- a/tests/subsys/settings/functional/fcb/testcase.yaml
+++ b/tests/subsys/settings/functional/fcb/testcase.yaml
@@ -2,3 +2,7 @@ tests:
   system.settings.functional.fcb:
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 native_posix native_posix_64
     tags: settings_fcb
+  system.settings.functional.fcb.chosen:
+    extra_args: DTC_OVERLAY_FILE=./chosen.overlay
+    platform_allow: native_posix native_posix_64
+    tags: settings_fcb

--- a/tests/subsys/settings/functional/nvs/chosen.overlay
+++ b/tests/subsys/settings/functional/nvs/chosen.overlay
@@ -1,0 +1,13 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,settings-partition = &storage_partition;
+	};
+};
+
+&storage_partition {
+	label = "chosen_partition";
+};

--- a/tests/subsys/settings/functional/nvs/testcase.yaml
+++ b/tests/subsys/settings/functional/nvs/testcase.yaml
@@ -2,6 +2,10 @@ tests:
   system.settings.functional.nvs:
     platform_allow: qemu_x86 native_posix native_posix_64
     tags: settings_nvs
+  system.settings.functional.nvs.chosen:
+    extra_args: DTC_OVERLAY_FILE=./chosen.overlay
+    platform_allow: native_posix native_posix_64
+    tags: settings_nvs
   system.settings.functional.nvs.dk:
     extra_args: OVERLAY_CONFIG=mpu.conf
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832

--- a/tests/subsys/settings/functional/src/settings_basic_test.c
+++ b/tests/subsys/settings/functional/src/settings_basic_test.c
@@ -31,7 +31,13 @@ static void test_clear_settings(void)
 {
 #if IS_ENABLED(CONFIG_SETTINGS_FCB) || IS_ENABLED(CONFIG_SETTINGS_NVS)
 	const struct flash_area *fap;
-	int rc = flash_area_open(FLASH_AREA_ID(storage), &fap);
+	int rc;
+
+#if DT_HAS_CHOSEN(zephyr_settings_partition)
+	rc = flash_area_open(FLASH_AREA_ID(chosen_partition), &fap);
+#else
+	rc = flash_area_open(FLASH_AREA_ID(storage), &fap);
+#endif
 
 	if (rc == 0) {
 		rc = flash_area_erase(fap, 0, fap->fa_size);


### PR DESCRIPTION
Change settings NVS and FCB backend to looks for chosen `zephyr,settings-partition`
in the first place, or fall back to partition "storage" if the chosen is not set.

This should fix https://github.com/zephyrproject-rtos/zephyr/issues/30152.
