### PR TITLE
dts: zynqmp: Add proper DT-based integration of On-Chip Memory

### DIFF
--- a/boards/arm/qemu_cortex_r5/qemu_cortex_r5.dts
+++ b/boards/arm/qemu_cortex_r5/qemu_cortex_r5.dts
@@ -17,6 +17,7 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
+		zephyr,ocm = &ocm;
 	};
 };
 

--- a/doc/reference/devicetree/api.rst
+++ b/doc/reference/devicetree/api.rst
@@ -387,6 +387,8 @@ device.
        interprocess-communication (IPC)
    * - zephyr,itcm
      - Instruction Tightly Coupled Memory node on some Arm SoCs
+   * - zephyr,ocm
+     - On-chip memory node on Xilinx Zynq-7000 and ZynqMP SoCs
    * - zephyr,ot-uart
      - Used by the OpenThread to specify UART device for Spinel protocol
    * - zephyr,pcie-controller

--- a/drivers/ethernet/eth_xlnx_gem_priv.h
+++ b/drivers/ethernet/eth_xlnx_gem_priv.h
@@ -512,15 +512,9 @@ struct eth_xlnx_dma_area_gem##port {\
 };
 
 /* DMA memory area instantiation macro */
-#ifdef CONFIG_SOC_FAMILY_XILINX_ZYNQ7000
 #define ETH_XLNX_GEM_DMA_AREA_INST(port) \
 static struct eth_xlnx_dma_area_gem##port eth_xlnx_gem##port##_dma_area\
 	__ocm_bss_section __aligned(4096);
-#else
-#define ETH_XLNX_GEM_DMA_AREA_INST(port) \
-static struct eth_xlnx_dma_area_gem##port eth_xlnx_gem##port##_dma_area\
-	__aligned(4096);
-#endif
 
 /* Interrupt configuration function macro */
 #define ETH_XLNX_GEM_CONFIG_IRQ_FUNC(port) \

--- a/dts/arm/xilinx/zynqmp.dtsi
+++ b/dts/arm/xilinx/zynqmp.dtsi
@@ -21,6 +21,12 @@
 			reg = <0 DT_SIZE_M(64)>;
 		};
 
+		ocm: memory@fffc0000 {
+			compatible = "zephyr,memory-region", "xlnx,zynq-ocm";
+			reg = <0xfffc0000 DT_SIZE_K(256)>;
+			zephyr,memory-region = "OCM";
+		};
+
 		uart0: uart@ff000000 {
 			compatible = "xlnx,xuartps";
 			reg = <0xff000000 0x4c>;


### PR DESCRIPTION
Just as the Xilinx Zynq-7000, the ZynqMP also comes with a 256 kB On-Chip Memory area.

Until now, this memory area is already properly configured for use as DMA memory when the MPU is enabled, but any use of this memory requires the use of raw pointers.

Identical to how the OCM has been integrated for the Zynq-7000, add a declaration for the ZynqMP's OCM to the device tree, so that the existing linker command file will place any data to whose declaration "__ocm_bss_section" or "__ocm_data_section" has been added there. For the OCM's DT node, the Zynq-7000's compatibility identifier "xlnx,zynq-ocm" is re-used, as it also matches the ZynqMP.

Supporting modifications:
* Add a matching 'chosen' entry to the device tree of the target qemu_cortex_r5 which is based on the ZynqMP.
* Remove the distinction between Zynq-7000 and ZynqMP for the GEM Ethernet driver, which until now has already been using the Zynq-7000's OCM as described above, but has been using regular memory on the ZynqMP, causing issues as soon as the MPU is enabled for the respective target.
* Add the "zephyr,ocm" entry added to the devicetree to the list of supported "chosen" entries in the devicetree reference docs.