### PR TITLE
kernel: consider the bss section in OCM memory in z_bss_zero

### DIFF
--- a/include/linker/linker-defs.h
+++ b/include/linker/linker-defs.h
@@ -307,6 +307,10 @@ extern char __dtcm_end[];
 #endif
 
 #if DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_ocm), okay)
+extern char __ocm_data_start[];
+extern char __ocm_data_end[];
+extern char __ocm_bss_start[];
+extern char __ocm_bss_end[];
 extern char __ocm_start[];
 extern char __ocm_end[];
 extern char __ocm_size[];

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -92,6 +92,10 @@ void z_bss_zero(void)
 	(void)memset(&__dtcm_bss_start, 0,
 		     ((uint32_t) &__dtcm_bss_end - (uint32_t) &__dtcm_bss_start));
 #endif
+#if DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_ocm), okay)
+	(void)memset(&__ocm_bss_start, 0,
+		     ((uint32_t) &__ocm_bss_end - (uint32_t) &__ocm_bss_start));
+#endif
 #ifdef CONFIG_CODE_DATA_RELOCATION
 	extern void bss_zeroing_relocation(void);
 


### PR DESCRIPTION
Add consideration of the bss section within a memory area of type OCM to z_bss_zero so that the bss section is properly zeroed at boot time.