### PR TITLE
pm: Rework function prototypes

### DIFF
--- a/include/pm/pm.h
+++ b/include/pm/pm.h
@@ -77,7 +77,7 @@ struct pm_notifier {
  * @param info Power state which should be used in the ongoing
  *	suspend operation.
  */
-bool pm_power_state_force(uint8_t cpu, struct pm_state_info info);
+bool pm_power_state_force(uint8_t cpu, const struct pm_state_info *info);
 
 /**
  * @brief Register a power management notifier
@@ -111,7 +111,7 @@ int pm_notifier_unregister(struct pm_notifier *notifier);
  * @param cpu CPU index.
  * @return next pm_state_info that will be used
  */
-struct pm_state_info pm_power_state_next_get(uint8_t cpu);
+const struct pm_state_info *pm_power_state_next_get(uint8_t cpu);
 
 /**
  * @}
@@ -182,7 +182,7 @@ bool pm_constraint_get(enum pm_state state);
  * @param info Power state which should be used in the ongoing
  *	suspend operation.
  */
-void pm_power_state_set(struct pm_state_info info);
+void pm_power_state_set(struct pm_state_info *info);
 
 /**
  * @brief Do any SoC or architecture specific post ops after sleep state exits.
@@ -194,7 +194,7 @@ void pm_power_state_set(struct pm_state_info info);
  *
  * @param info Power state that the given cpu is leaving.
  */
-void pm_power_state_exit_post_ops(struct pm_state_info info);
+void pm_power_state_exit_post_ops(struct pm_state_info *info);
 
 /**
  * @}
@@ -212,7 +212,7 @@ void pm_power_state_exit_post_ops(struct pm_state_info info);
 #define pm_power_state_set(info)
 #define pm_power_state_exit_post_ops(info)
 #define pm_power_state_next_get(cpu) \
-	((struct pm_state_info){PM_STATE_ACTIVE, 0, 0})
+	(&(struct pm_state_info){PM_STATE_ACTIVE, 0, 0})
 
 #endif /* CONFIG_PM */
 

--- a/include/pm/pm.h
+++ b/include/pm/pm.h
@@ -179,10 +179,10 @@ bool pm_constraint_get(enum pm_state state);
  * This function implements the SoC specific details necessary
  * to put the processor into available power states.
  *
- * @param info Power state which should be used in the ongoing
- *	suspend operation.
+ * @param state Power state.
+ * @param substate_id Power substate id.
  */
-void pm_power_state_set(struct pm_state_info *info);
+void pm_power_state_set(enum pm_state state, uint8_t substate_id);
 
 /**
  * @brief Do any SoC or architecture specific post ops after sleep state exits.
@@ -192,9 +192,10 @@ void pm_power_state_set(struct pm_state_info *info);
  * interrupts after resuming from sleep state. In future, the enabling
  * of interrupts may be moved into the kernel.
  *
- * @param info Power state that the given cpu is leaving.
+ * @param state Power state.
+ * @param substate_id Power substate id.
  */
-void pm_power_state_exit_post_ops(struct pm_state_info *info);
+void pm_power_state_exit_post_ops(enum pm_state state, uint8_t substate_id);
 
 /**
  * @}
@@ -209,8 +210,8 @@ void pm_power_state_exit_post_ops(struct pm_state_info *info);
 #define pm_constraint_release(pm_state)
 #define pm_constraint_get(pm_state) (true)
 
-#define pm_power_state_set(info)
-#define pm_power_state_exit_post_ops(info)
+#define pm_power_state_set(state, substate_id)
+#define pm_power_state_exit_post_ops(state, substate_id)
 #define pm_power_state_next_get(cpu) \
 	(&(struct pm_state_info){PM_STATE_ACTIVE, 0, 0})
 

--- a/samples/boards/nrf/system_off/src/main.c
+++ b/samples/boards/nrf/system_off/src/main.c
@@ -91,7 +91,7 @@ void main(void)
 	 * controlled delay.  Here we need to override that, then
 	 * force entry to deep sleep on any delay.
 	 */
-	pm_power_state_force(0u, (struct pm_state_info){PM_STATE_SOFT_OFF, 0, 0});
+	pm_power_state_force(0u, &(struct pm_state_info){PM_STATE_SOFT_OFF, 0, 0});
 
 	printk("ERROR: System off failed\n");
 	while (true) {

--- a/samples/boards/stm32/power_mgmt/stm32wb_ble/src/main.c
+++ b/samples/boards/stm32/power_mgmt/stm32wb_ble/src/main.c
@@ -118,5 +118,5 @@ void main(void)
 
 	printk("Device shutdown\n");
 
-	pm_power_state_force(0u, (struct pm_state_info){PM_STATE_SOFT_OFF, 0, 0});
+	pm_power_state_force(0u, &(struct pm_state_info){PM_STATE_SOFT_OFF, 0, 0});
 }

--- a/samples/boards/ti/cc13x2_cc26x2/system_off/src/main.c
+++ b/samples/boards/ti/cc13x2_cc26x2/system_off/src/main.c
@@ -67,7 +67,7 @@ void main(void)
 	/*
 	 * Force the SOFT_OFF state.
 	 */
-	pm_power_state_force(0u, (struct pm_state_info){PM_STATE_SOFT_OFF, 0, 0});
+	pm_power_state_force(0u, &(struct pm_state_info){PM_STATE_SOFT_OFF, 0, 0});
 
 	printk("ERROR: System off failed\n");
 	while (true) {

--- a/soc/arm/microchip_mec/mec1501/power.c
+++ b/soc/arm/microchip_mec/mec1501/power.c
@@ -101,9 +101,9 @@ static void z_power_soc_sleep(void)
  * For deep sleep pm_system_suspend has executed all the driver
  * power management call backs.
  */
-__weak void pm_power_state_set(struct pm_state_info info)
+__weak void pm_power_state_set(struct pm_state_info *info)
 {
-	switch (info.state) {
+	switch (info->state) {
 	case PM_STATE_SUSPEND_TO_IDLE:
 		z_power_soc_sleep();
 		break;
@@ -123,9 +123,9 @@ __weak void pm_power_state_set(struct pm_state_info info)
  * an ISR on wake except for faults. We re-enable interrupts by setting PRIMASK
  * to 0.
  */
-__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
+__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
 {
-	switch (info.state) {
+	switch (info->state) {
 	case PM_STATE_SUSPEND_TO_IDLE:
 	case PM_STATE_SUSPEND_TO_RAM:
 		__set_PRIMASK(0);

--- a/soc/arm/microchip_mec/mec1501/power.c
+++ b/soc/arm/microchip_mec/mec1501/power.c
@@ -101,9 +101,11 @@ static void z_power_soc_sleep(void)
  * For deep sleep pm_system_suspend has executed all the driver
  * power management call backs.
  */
-__weak void pm_power_state_set(struct pm_state_info *info)
+__weak void pm_power_state_set(enum pm_state state, uint8_t substate_id)
 {
-	switch (info->state) {
+	ARG_UNUSED(substate_id);
+
+	switch (state) {
 	case PM_STATE_SUSPEND_TO_IDLE:
 		z_power_soc_sleep();
 		break;
@@ -123,9 +125,11 @@ __weak void pm_power_state_set(struct pm_state_info *info)
  * an ISR on wake except for faults. We re-enable interrupts by setting PRIMASK
  * to 0.
  */
-__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
+__weak void pm_power_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 {
-	switch (info->state) {
+	ARG_UNUSED(substate_id);
+
+	switch (state) {
 	case PM_STATE_SUSPEND_TO_IDLE:
 	case PM_STATE_SUSPEND_TO_RAM:
 		__set_PRIMASK(0);

--- a/soc/arm/nordic_nrf/nrf51/power.c
+++ b/soc/arm/nordic_nrf/nrf51/power.c
@@ -11,27 +11,27 @@
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
 /* Invoke Low Power/System Off specific Tasks */
-__weak void pm_power_state_set(struct pm_state_info info)
+__weak void pm_power_state_set(struct pm_state_info *info)
 {
-	switch (info.state) {
+	switch (info->state) {
 	case PM_STATE_SOFT_OFF:
 		nrf_power_system_off(NRF_POWER);
 		break;
 	default:
-		LOG_DBG("Unsupported power state %u", info.state);
+		LOG_DBG("Unsupported power state %u", info->state);
 		break;
 	}
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
+__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
 {
-	switch (info.state) {
+	switch (info->state) {
 	case PM_STATE_SOFT_OFF:
 		/* Nothing to do. */
 		break;
 	default:
-		LOG_DBG("Unsupported power state %u", info.state);
+		LOG_DBG("Unsupported power state %u", info->state);
 		break;
 	}
 

--- a/soc/arm/nordic_nrf/nrf51/power.c
+++ b/soc/arm/nordic_nrf/nrf51/power.c
@@ -11,27 +11,31 @@
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
 /* Invoke Low Power/System Off specific Tasks */
-__weak void pm_power_state_set(struct pm_state_info *info)
+__weak void pm_power_state_set(enum pm_state state, uint8_t substate_id)
 {
-	switch (info->state) {
+	ARG_UNUSED(substate_id);
+
+	switch (state) {
 	case PM_STATE_SOFT_OFF:
 		nrf_power_system_off(NRF_POWER);
 		break;
 	default:
-		LOG_DBG("Unsupported power state %u", info->state);
+		LOG_DBG("Unsupported power state %u", state);
 		break;
 	}
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
+__weak void pm_power_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 {
-	switch (info->state) {
+	ARG_UNUSED(substate_id);
+
+	switch (state) {
 	case PM_STATE_SOFT_OFF:
 		/* Nothing to do. */
 		break;
 	default:
-		LOG_DBG("Unsupported power state %u", info->state);
+		LOG_DBG("Unsupported power state %u", state);
 		break;
 	}
 

--- a/soc/arm/nordic_nrf/nrf52/power.c
+++ b/soc/arm/nordic_nrf/nrf52/power.c
@@ -11,27 +11,27 @@
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
 /* Invoke Low Power/System Off specific Tasks */
-__weak void pm_power_state_set(struct pm_state_info info)
+__weak void pm_power_state_set(struct pm_state_info *info)
 {
-	switch (info.state) {
+	switch (info->state) {
 	case PM_STATE_SOFT_OFF:
 		nrf_power_system_off(NRF_POWER);
 		break;
 	default:
-		LOG_DBG("Unsupported power state %u", info.state);
+		LOG_DBG("Unsupported power state %u", info->state);
 		break;
 	}
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
+__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
 {
-	switch (info.state) {
+	switch (info->state) {
 	case PM_STATE_SOFT_OFF:
 		/* Nothing to do. */
 		break;
 	default:
-		LOG_DBG("Unsupported power state %u", info.state);
+		LOG_DBG("Unsupported power state %u", info->state);
 		break;
 	}
 

--- a/soc/arm/nordic_nrf/nrf52/power.c
+++ b/soc/arm/nordic_nrf/nrf52/power.c
@@ -11,27 +11,31 @@
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
 /* Invoke Low Power/System Off specific Tasks */
-__weak void pm_power_state_set(struct pm_state_info *info)
+__weak void pm_power_state_set(enum pm_state state, uint8_t substate_id)
 {
-	switch (info->state) {
+	ARG_UNUSED(substate_id);
+
+	switch (state) {
 	case PM_STATE_SOFT_OFF:
 		nrf_power_system_off(NRF_POWER);
 		break;
 	default:
-		LOG_DBG("Unsupported power state %u", info->state);
+		LOG_DBG("Unsupported power state %u", state);
 		break;
 	}
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
+__weak void pm_power_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 {
-	switch (info->state) {
+	ARG_UNUSED(substate_id);
+
+	switch (state) {
 	case PM_STATE_SOFT_OFF:
 		/* Nothing to do. */
 		break;
 	default:
-		LOG_DBG("Unsupported power state %u", info->state);
+		LOG_DBG("Unsupported power state %u", state);
 		break;
 	}
 

--- a/soc/arm/nordic_nrf/nrf53/power.c
+++ b/soc/arm/nordic_nrf/nrf53/power.c
@@ -13,27 +13,31 @@
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
 /* Invoke Low Power/System Off specific Tasks */
-__weak void pm_power_state_set(struct pm_state_info *info)
+__weak void pm_power_state_set(enum pm_state state, uint8_t substate_id)
 {
-	switch (info->state) {
+	ARG_UNUSED(substate_id);
+
+	switch (state) {
 	case PM_STATE_SOFT_OFF:
 		nrf_regulators_system_off(NRF_REGULATORS);
 		break;
 	default:
-		LOG_DBG("Unsupported power state %u", info->state);
+		LOG_DBG("Unsupported power state %u", state);
 		break;
 	}
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
+__weak void pm_power_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 {
-	switch (info->state) {
+	ARG_UNUSED(substate_id);
+
+	switch (state) {
 	case PM_STATE_SOFT_OFF:
 		/* Nothing to do. */
 		break;
 	default:
-		LOG_DBG("Unsupported power state %u", info->state);
+		LOG_DBG("Unsupported power state %u", state);
 		break;
 	}
 

--- a/soc/arm/nordic_nrf/nrf53/power.c
+++ b/soc/arm/nordic_nrf/nrf53/power.c
@@ -13,27 +13,27 @@
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
 /* Invoke Low Power/System Off specific Tasks */
-__weak void pm_power_state_set(struct pm_state_info info)
+__weak void pm_power_state_set(struct pm_state_info *info)
 {
-	switch (info.state) {
+	switch (info->state) {
 	case PM_STATE_SOFT_OFF:
 		nrf_regulators_system_off(NRF_REGULATORS);
 		break;
 	default:
-		LOG_DBG("Unsupported power state %u", info.state);
+		LOG_DBG("Unsupported power state %u", info->state);
 		break;
 	}
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
+__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
 {
-	switch (info.state) {
+	switch (info->state) {
 	case PM_STATE_SOFT_OFF:
 		/* Nothing to do. */
 		break;
 	default:
-		LOG_DBG("Unsupported power state %u", info.state);
+		LOG_DBG("Unsupported power state %u", info->state);
 		break;
 	}
 

--- a/soc/arm/nordic_nrf/nrf91/power.c
+++ b/soc/arm/nordic_nrf/nrf91/power.c
@@ -12,27 +12,27 @@
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
 /* Invoke Low Power/System Off specific Tasks */
-__weak void pm_power_state_set(struct pm_state_info info)
+__weak void pm_power_state_set(struct pm_state_info *info)
 {
-	switch (info.state) {
+	switch (info->state) {
 	case PM_STATE_SOFT_OFF:
 		nrf_regulators_system_off(NRF_REGULATORS);
 		break;
 	default:
-		LOG_DBG("Unsupported power state %u", info.state);
+		LOG_DBG("Unsupported power state %u", info->state);
 		break;
 	}
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
+__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
 {
-	switch (info.state) {
+	switch (info->state) {
 	case PM_STATE_SOFT_OFF:
 		/* Nothing to do. */
 		break;
 	default:
-		LOG_DBG("Unsupported power state %u", info.state);
+		LOG_DBG("Unsupported power state %u", info->state);
 		break;
 	}
 

--- a/soc/arm/nordic_nrf/nrf91/power.c
+++ b/soc/arm/nordic_nrf/nrf91/power.c
@@ -12,27 +12,31 @@
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
 /* Invoke Low Power/System Off specific Tasks */
-__weak void pm_power_state_set(struct pm_state_info *info)
+__weak void pm_power_state_set(enum pm_state state, uint8_t substate_id)
 {
-	switch (info->state) {
+	ARG_UNUSED(substate_id);
+
+	switch (state) {
 	case PM_STATE_SOFT_OFF:
 		nrf_regulators_system_off(NRF_REGULATORS);
 		break;
 	default:
-		LOG_DBG("Unsupported power state %u", info->state);
+		LOG_DBG("Unsupported power state %u", state);
 		break;
 	}
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
+__weak void pm_power_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 {
-	switch (info->state) {
+	ARG_UNUSED(substate_id);
+
+	switch (state) {
 	case PM_STATE_SOFT_OFF:
 		/* Nothing to do. */
 		break;
 	default:
-		LOG_DBG("Unsupported power state %u", info->state);
+		LOG_DBG("Unsupported power state %u", state);
 		break;
 	}
 

--- a/soc/arm/nuvoton_npcx/common/power.c
+++ b/soc/arm/nuvoton_npcx/common/power.c
@@ -144,12 +144,12 @@ static void npcx_power_enter_system_sleep(int slp_mode, int wk_mode)
 }
 
 /* Invoke when enter "Suspend/Low Power" mode. */
-__weak void pm_power_state_set(struct pm_state_info info)
+__weak void pm_power_state_set(struct pm_state_info *info)
 {
-	if (info.state != PM_STATE_SUSPEND_TO_IDLE) {
-		LOG_DBG("Unsupported power state %u", info.state);
+	if (info->state != PM_STATE_SUSPEND_TO_IDLE) {
+		LOG_DBG("Unsupported power state %u", info->state);
 	} else {
-		switch (info.substate_id) {
+		switch (info->substate_id) {
 		case 0:	/* Sub-state 0: Deep sleep with instant wake-up */
 			npcx_power_enter_system_sleep(NPCX_DEEP_SLEEP,
 							NPCX_INSTANT_WAKE_UP);
@@ -166,19 +166,19 @@ __weak void pm_power_state_set(struct pm_state_info info)
 			break;
 		default:
 			LOG_DBG("Unsupported power substate-id %u",
-				info.substate_id);
+				info->substate_id);
 			break;
 		}
 	}
 }
 
 /* Handle soc specific activity after exiting "Suspend/Low Power" mode. */
-__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
+__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
 {
-	if (info.state != PM_STATE_SUSPEND_TO_IDLE) {
-		LOG_DBG("Unsupported power state %u", info.state);
+	if (info->state != PM_STATE_SUSPEND_TO_IDLE) {
+		LOG_DBG("Unsupported power state %u", info->state);
 	} else {
-		switch (info.substate_id) {
+		switch (info->substate_id) {
 		case 0:	/* Sub-state 0: Deep sleep with instant wake-up */
 			/* Restore interrupts */
 			__enable_irq();
@@ -189,7 +189,7 @@ __weak void pm_power_state_exit_post_ops(struct pm_state_info info)
 			break;
 		default:
 			LOG_DBG("Unsupported power substate-id %u",
-				info.substate_id);
+				info->substate_id);
 			break;
 		}
 	}

--- a/soc/arm/nuvoton_npcx/common/power.c
+++ b/soc/arm/nuvoton_npcx/common/power.c
@@ -144,12 +144,12 @@ static void npcx_power_enter_system_sleep(int slp_mode, int wk_mode)
 }
 
 /* Invoke when enter "Suspend/Low Power" mode. */
-__weak void pm_power_state_set(struct pm_state_info *info)
+__weak void pm_power_state_set(enum pm_state state, uint8_t substate_id)
 {
-	if (info->state != PM_STATE_SUSPEND_TO_IDLE) {
-		LOG_DBG("Unsupported power state %u", info->state);
+	if (state != PM_STATE_SUSPEND_TO_IDLE) {
+		LOG_DBG("Unsupported power state %u", state);
 	} else {
-		switch (info->substate_id) {
+		switch (substate_id) {
 		case 0:	/* Sub-state 0: Deep sleep with instant wake-up */
 			npcx_power_enter_system_sleep(NPCX_DEEP_SLEEP,
 							NPCX_INSTANT_WAKE_UP);
@@ -166,19 +166,19 @@ __weak void pm_power_state_set(struct pm_state_info *info)
 			break;
 		default:
 			LOG_DBG("Unsupported power substate-id %u",
-				info->substate_id);
+				substate_id);
 			break;
 		}
 	}
 }
 
 /* Handle soc specific activity after exiting "Suspend/Low Power" mode. */
-__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
+__weak void pm_power_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 {
-	if (info->state != PM_STATE_SUSPEND_TO_IDLE) {
-		LOG_DBG("Unsupported power state %u", info->state);
+	if (state != PM_STATE_SUSPEND_TO_IDLE) {
+		LOG_DBG("Unsupported power state %u", state);
 	} else {
-		switch (info->substate_id) {
+		switch (substate_id) {
 		case 0:	/* Sub-state 0: Deep sleep with instant wake-up */
 			/* Restore interrupts */
 			__enable_irq();
@@ -189,7 +189,7 @@ __weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
 			break;
 		default:
 			LOG_DBG("Unsupported power substate-id %u",
-				info->substate_id);
+				substate_id);
 			break;
 		}
 	}

--- a/soc/arm/nxp_imx/rt/power_rt11xx.c
+++ b/soc/arm/nxp_imx/rt/power_rt11xx.c
@@ -283,11 +283,13 @@ void cpu_mode_transition(gpc_cpu_mode_t mode, bool enable_standby)
  * SOC specific low power mode implementation
  * Drop to lowest power state possible given system's request
  */
-__weak void pm_power_state_set(struct pm_state_info *info)
+__weak void pm_power_state_set(enum pm_state state, uint8_t substate_id)
 {
+	ARG_UNUSED(state);
+
 	/* Extract set point and GPC mode from the substate ID */
-	uint8_t set_point = IMX_SPC(info->substate_id);
-	gpc_cpu_mode_t gpc_mode = IMX_GPC_MODE(info->substate_id);
+	uint8_t set_point = IMX_SPC(substate_id);
+	gpc_cpu_mode_t gpc_mode = IMX_GPC_MODE(substate_id);
 	uint8_t current_set_point = GPC_SP_GetCurrentSetPoint(GPC_SET_POINT_CTRL);
 
 	LOG_DBG("Switch to Set Point %d, GPC Mode %d requested", set_point, gpc_mode);
@@ -304,9 +306,11 @@ __weak void pm_power_state_set(struct pm_state_info *info)
 	}
 }
 
-__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
+__weak void pm_power_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 {
-	ARG_UNUSED(info);
+	ARG_UNUSED(state);
+	ARG_UNUSED(substate_id);
+
 	/* Clear PRIMASK */
 	__enable_irq();
 	LOG_DBG("Exiting LPM");

--- a/soc/arm/nxp_imx/rt/power_rt11xx.c
+++ b/soc/arm/nxp_imx/rt/power_rt11xx.c
@@ -283,11 +283,11 @@ void cpu_mode_transition(gpc_cpu_mode_t mode, bool enable_standby)
  * SOC specific low power mode implementation
  * Drop to lowest power state possible given system's request
  */
-__weak void pm_power_state_set(struct pm_state_info info)
+__weak void pm_power_state_set(struct pm_state_info *info)
 {
 	/* Extract set point and GPC mode from the substate ID */
-	uint8_t set_point = IMX_SPC(info.substate_id);
-	gpc_cpu_mode_t gpc_mode = IMX_GPC_MODE(info.substate_id);
+	uint8_t set_point = IMX_SPC(info->substate_id);
+	gpc_cpu_mode_t gpc_mode = IMX_GPC_MODE(info->substate_id);
 	uint8_t current_set_point = GPC_SP_GetCurrentSetPoint(GPC_SET_POINT_CTRL);
 
 	LOG_DBG("Switch to Set Point %d, GPC Mode %d requested", set_point, gpc_mode);
@@ -304,7 +304,7 @@ __weak void pm_power_state_set(struct pm_state_info info)
 	}
 }
 
-__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
+__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
 {
 	ARG_UNUSED(info);
 	/* Clear PRIMASK */

--- a/soc/arm/nxp_imx/rt6xx/power.c
+++ b/soc/arm/nxp_imx/rt6xx/power.c
@@ -22,7 +22,7 @@ LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 	APP_DEEPSLEEP_RAM_APD, APP_DEEPSLEEP_RAM_PPD}))
 
 /* Invoke Low Power/System Off specific Tasks */
-__weak void pm_power_state_set(struct pm_state_info info)
+__weak void pm_power_state_set(struct pm_state_info *info)
 {
 	/* FIXME: When this function is entered the Kernel has disabled
 	 * interrupts using BASEPRI register. This is incorrect as it prevents
@@ -36,7 +36,7 @@ __weak void pm_power_state_set(struct pm_state_info info)
 	/* Set BASEPRI to 0 */
 	irq_unlock(0);
 
-	switch (info.state) {
+	switch (info->state) {
 	case PM_STATE_RUNTIME_IDLE:
 		POWER_EnterSleep();
 		break;
@@ -44,13 +44,13 @@ __weak void pm_power_state_set(struct pm_state_info info)
 		POWER_EnterDeepSleep(APP_EXCLUDE_FROM_DEEPSLEEP);
 		break;
 	default:
-		LOG_DBG("Unsupported power state %u", info.state);
+		LOG_DBG("Unsupported power state %u", info->state);
 		break;
 	}
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
+__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
 {
 	ARG_UNUSED(info);
 

--- a/soc/arm/nxp_imx/rt6xx/power.c
+++ b/soc/arm/nxp_imx/rt6xx/power.c
@@ -22,8 +22,10 @@ LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 	APP_DEEPSLEEP_RAM_APD, APP_DEEPSLEEP_RAM_PPD}))
 
 /* Invoke Low Power/System Off specific Tasks */
-__weak void pm_power_state_set(struct pm_state_info *info)
+__weak void pm_power_state_set(enum pm_state state, uint8_t substate_id)
 {
+	ARG_UNUSED(substate_id);
+
 	/* FIXME: When this function is entered the Kernel has disabled
 	 * interrupts using BASEPRI register. This is incorrect as it prevents
 	 * waking up from any interrupt which priority is not 0. Work around the
@@ -36,7 +38,7 @@ __weak void pm_power_state_set(struct pm_state_info *info)
 	/* Set BASEPRI to 0 */
 	irq_unlock(0);
 
-	switch (info->state) {
+	switch (state) {
 	case PM_STATE_RUNTIME_IDLE:
 		POWER_EnterSleep();
 		break;
@@ -44,15 +46,16 @@ __weak void pm_power_state_set(struct pm_state_info *info)
 		POWER_EnterDeepSleep(APP_EXCLUDE_FROM_DEEPSLEEP);
 		break;
 	default:
-		LOG_DBG("Unsupported power state %u", info->state);
+		LOG_DBG("Unsupported power state %u", state);
 		break;
 	}
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
+__weak void pm_power_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 {
-	ARG_UNUSED(info);
+	ARG_UNUSED(state);
+	ARG_UNUSED(substate_id);
 
 	/* Clear PRIMASK */
 	__enable_irq();

--- a/soc/arm/nxp_kinetis/ke1xf/power.c
+++ b/soc/arm/nxp_kinetis/ke1xf/power.c
@@ -25,15 +25,15 @@ __ramfunc static void wait_for_flash_prefetch_and_idle(void)
 }
 #endif /* CONFIG_XIP */
 
-__weak void pm_power_state_set(struct pm_state_info info)
+__weak void pm_power_state_set(struct pm_state_info *info)
 {
-	switch (info.state) {
+	switch (info->state) {
 	case PM_STATE_RUNTIME_IDLE:
 		k_cpu_idle();
 		break;
 	case PM_STATE_SUSPEND_TO_IDLE:
 		/* Set partial stop mode and enable deep sleep */
-		SMC->STOPCTRL = SMC_STOPCTRL_PSTOPO(info.substate_id);
+		SMC->STOPCTRL = SMC_STOPCTRL_PSTOPO(info->substate_id);
 		SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
 #ifdef CONFIG_XIP
 		wait_for_flash_prefetch_and_idle();
@@ -46,16 +46,16 @@ __weak void pm_power_state_set(struct pm_state_info info)
 		}
 		break;
 	default:
-		LOG_WRN("Unsupported power state %u", info.state);
+		LOG_WRN("Unsupported power state %u", info->state);
 		break;
 	}
 }
 
-__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
+__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
 {
 	ARG_UNUSED(info);
 
-	if (info.state == PM_STATE_SUSPEND_TO_IDLE) {
+	if (info->state == PM_STATE_SUSPEND_TO_IDLE) {
 		/* Disable deep sleep upon exit */
 		SCB->SCR &= ~(SCB_SCR_SLEEPDEEP_Msk);
 	}

--- a/soc/arm/nxp_kinetis/ke1xf/power.c
+++ b/soc/arm/nxp_kinetis/ke1xf/power.c
@@ -25,15 +25,15 @@ __ramfunc static void wait_for_flash_prefetch_and_idle(void)
 }
 #endif /* CONFIG_XIP */
 
-__weak void pm_power_state_set(struct pm_state_info *info)
+__weak void pm_power_state_set(enum pm_state state, uint8_t substate_id)
 {
-	switch (info->state) {
+	switch (state) {
 	case PM_STATE_RUNTIME_IDLE:
 		k_cpu_idle();
 		break;
 	case PM_STATE_SUSPEND_TO_IDLE:
 		/* Set partial stop mode and enable deep sleep */
-		SMC->STOPCTRL = SMC_STOPCTRL_PSTOPO(info->substate_id);
+		SMC->STOPCTRL = SMC_STOPCTRL_PSTOPO(substate_id);
 		SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
 #ifdef CONFIG_XIP
 		wait_for_flash_prefetch_and_idle();
@@ -46,16 +46,16 @@ __weak void pm_power_state_set(struct pm_state_info *info)
 		}
 		break;
 	default:
-		LOG_WRN("Unsupported power state %u", info->state);
+		LOG_WRN("Unsupported power state %u", state);
 		break;
 	}
 }
 
-__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
+__weak void pm_power_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 {
-	ARG_UNUSED(info);
+	ARG_UNUSED(substate_id);
 
-	if (info->state == PM_STATE_SUSPEND_TO_IDLE) {
+	if (state == PM_STATE_SUSPEND_TO_IDLE) {
 		/* Disable deep sleep upon exit */
 		SCB->SCR &= ~(SCB_SCR_SLEEPDEEP_Msk);
 	}

--- a/soc/arm/silabs_exx32/common/soc_power.c
+++ b/soc/arm/silabs_exx32/common/soc_power.c
@@ -18,9 +18,9 @@ LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
  */
 
 /* Invoke Low Power/System Off specific Tasks */
-__weak void pm_power_state_set(struct pm_state_info info)
+__weak void pm_power_state_set(struct pm_state_info *info)
 {
-	LOG_DBG("SoC entering power state %d", info.state);
+	LOG_DBG("SoC entering power state %d", info->state);
 
 	/* FIXME: When this function is entered the Kernel has disabled
 	 * interrupts using BASEPRI register. This is incorrect as it prevents
@@ -34,7 +34,7 @@ __weak void pm_power_state_set(struct pm_state_info info)
 	/* Set BASEPRI to 0 */
 	irq_unlock(0);
 
-	switch (info.state) {
+	switch (info->state) {
 	case PM_STATE_RUNTIME_IDLE:
 		EMU_EnterEM1();
 		break;
@@ -45,18 +45,18 @@ __weak void pm_power_state_set(struct pm_state_info info)
 		EMU_EnterEM3(true);
 		break;
 	default:
-		LOG_DBG("Unsupported power state %u", info.state);
+		LOG_DBG("Unsupported power state %u", info->state);
 		break;
 	}
 
-	LOG_DBG("SoC leaving power state %d", info.state);
+	LOG_DBG("SoC leaving power state %d", info->state);
 
 	/* Clear PRIMASK */
 	__enable_irq();
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
+__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
 {
 	ARG_UNUSED(info);
 }

--- a/soc/arm/silabs_exx32/common/soc_power.c
+++ b/soc/arm/silabs_exx32/common/soc_power.c
@@ -18,9 +18,11 @@ LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
  */
 
 /* Invoke Low Power/System Off specific Tasks */
-__weak void pm_power_state_set(struct pm_state_info *info)
+__weak void pm_power_state_set(enum pm_state state, uint8_t substate_id)
 {
-	LOG_DBG("SoC entering power state %d", info->state);
+	ARG_UNUSED(substate_id);
+
+	LOG_DBG("SoC entering power state %d", state);
 
 	/* FIXME: When this function is entered the Kernel has disabled
 	 * interrupts using BASEPRI register. This is incorrect as it prevents
@@ -34,7 +36,7 @@ __weak void pm_power_state_set(struct pm_state_info *info)
 	/* Set BASEPRI to 0 */
 	irq_unlock(0);
 
-	switch (info->state) {
+	switch (state) {
 	case PM_STATE_RUNTIME_IDLE:
 		EMU_EnterEM1();
 		break;
@@ -45,18 +47,19 @@ __weak void pm_power_state_set(struct pm_state_info *info)
 		EMU_EnterEM3(true);
 		break;
 	default:
-		LOG_DBG("Unsupported power state %u", info->state);
+		LOG_DBG("Unsupported power state %u", state);
 		break;
 	}
 
-	LOG_DBG("SoC leaving power state %d", info->state);
+	LOG_DBG("SoC leaving power state %d", state);
 
 	/* Clear PRIMASK */
 	__enable_irq();
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
+__weak void pm_power_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 {
-	ARG_UNUSED(info);
+	ARG_UNUSED(state);
+	ARG_UNUSED(substate_id);
 }

--- a/soc/arm/st_stm32/stm32g0/power.c
+++ b/soc/arm/st_stm32/stm32g0/power.c
@@ -20,14 +20,14 @@
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
 /* Invoke Low Power/System Off specific Tasks */
-__weak void pm_power_state_set(struct pm_state_info *info)
+__weak void pm_power_state_set(enum pm_state state, uint8_t substate_id)
 {
 	if (info->state != PM_STATE_SUSPEND_TO_IDLE) {
-		LOG_DBG("Unsupported power state %u", info->state);
+		LOG_DBG("Unsupported power state %u", state);
 		return;
 	}
 
-	switch (info->substate_id) {
+	switch (substate_id) {
 	case 1: /* this corresponds to the STOP0 mode: */
 		/* enter STOP0 mode */
 		LL_PWR_SetPowerMode(LL_PWR_MODE_STOP0);
@@ -44,18 +44,18 @@ __weak void pm_power_state_set(struct pm_state_info *info)
 		break;
 	default:
 		LOG_DBG("Unsupported power state substate-id %u",
-			info->substate_id);
+			substate_id);
 		break;
 	}
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
+__weak void pm_power_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 {
-	if (info->state != PM_STATE_SUSPEND_TO_IDLE) {
-		LOG_DBG("Unsupported power substate %u", info->state);
+	if (state != PM_STATE_SUSPEND_TO_IDLE) {
+		LOG_DBG("Unsupported power substate %u", state);
 	} else {
-		switch (info->substate_id) {
+		switch (substate_id) {
 		case 1:	/* STOP0 */
 			__fallthrough;
 		case 2:	/* STOP1 */
@@ -65,7 +65,7 @@ __weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
 			break;
 		default:
 			LOG_DBG("Unsupported power substate-id %u",
-				info->substate_id);
+				substate_id);
 			break;
 		}
 		/* need to restore the clock */

--- a/soc/arm/st_stm32/stm32g0/power.c
+++ b/soc/arm/st_stm32/stm32g0/power.c
@@ -20,14 +20,14 @@
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
 /* Invoke Low Power/System Off specific Tasks */
-__weak void pm_power_state_set(struct pm_state_info info)
+__weak void pm_power_state_set(struct pm_state_info *info)
 {
-	if (info.state != PM_STATE_SUSPEND_TO_IDLE) {
-		LOG_DBG("Unsupported power state %u", info.state);
+	if (info->state != PM_STATE_SUSPEND_TO_IDLE) {
+		LOG_DBG("Unsupported power state %u", info->state);
 		return;
 	}
 
-	switch (info.substate_id) {
+	switch (info->substate_id) {
 	case 1: /* this corresponds to the STOP0 mode: */
 		/* enter STOP0 mode */
 		LL_PWR_SetPowerMode(LL_PWR_MODE_STOP0);
@@ -44,18 +44,18 @@ __weak void pm_power_state_set(struct pm_state_info info)
 		break;
 	default:
 		LOG_DBG("Unsupported power state substate-id %u",
-			info.substate_id);
+			info->substate_id);
 		break;
 	}
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
+__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
 {
-	if (info.state != PM_STATE_SUSPEND_TO_IDLE) {
-		LOG_DBG("Unsupported power substate %u", info.state);
+	if (info->state != PM_STATE_SUSPEND_TO_IDLE) {
+		LOG_DBG("Unsupported power substate %u", info->state);
 	} else {
-		switch (info.substate_id) {
+		switch (info->substate_id) {
 		case 1:	/* STOP0 */
 			__fallthrough;
 		case 2:	/* STOP1 */
@@ -65,7 +65,7 @@ __weak void pm_power_state_exit_post_ops(struct pm_state_info info)
 			break;
 		default:
 			LOG_DBG("Unsupported power substate-id %u",
-				info.substate_id);
+				info->substate_id);
 			break;
 		}
 		/* need to restore the clock */

--- a/soc/arm/st_stm32/stm32l0/power.c
+++ b/soc/arm/st_stm32/stm32l0/power.c
@@ -28,9 +28,11 @@ LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 #endif
 
 /* Invoke Low Power/System Off specific Tasks */
-__weak void pm_power_state_set(struct pm_state_info *info)
+__weak void pm_power_state_set(enum pm_state state, uint8_t substate_id)
 {
-	switch (info->state) {
+	ARG_UNUSED(substate_id);
+
+	switch (state) {
 	case PM_STATE_SUSPEND_TO_IDLE:
 		LL_RCC_SetClkAfterWakeFromStop(RCC_STOP_WAKEUPCLOCK_SELECTED);
 		LL_PWR_ClearFlag_WU();
@@ -46,15 +48,17 @@ __weak void pm_power_state_set(struct pm_state_info *info)
 		k_cpu_idle();
 		break;
 	default:
-		LOG_DBG("Unsupported power state %u", info->state);
+		LOG_DBG("Unsupported power state %u", state);
 		break;
 	}
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
+__weak void pm_power_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 {
-	switch (info->state) {
+	ARG_UNUSED(substate_id);
+
+	switch (state) {
 	case PM_STATE_SUSPEND_TO_IDLE:
 		LL_LPM_DisableSleepOnExit();
 		LL_LPM_EnableSleep();
@@ -66,7 +70,7 @@ __weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
 		/* Nothing to do. */
 		break;
 	default:
-		LOG_DBG("Unsupported power substate-id %u", info->state);
+		LOG_DBG("Unsupported power substate-id %u", state);
 		break;
 	}
 

--- a/soc/arm/st_stm32/stm32l0/power.c
+++ b/soc/arm/st_stm32/stm32l0/power.c
@@ -28,9 +28,9 @@ LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 #endif
 
 /* Invoke Low Power/System Off specific Tasks */
-__weak void pm_power_state_set(struct pm_state_info info)
+__weak void pm_power_state_set(struct pm_state_info *info)
 {
-	switch (info.state) {
+	switch (info->state) {
 	case PM_STATE_SUSPEND_TO_IDLE:
 		LL_RCC_SetClkAfterWakeFromStop(RCC_STOP_WAKEUPCLOCK_SELECTED);
 		LL_PWR_ClearFlag_WU();
@@ -46,15 +46,15 @@ __weak void pm_power_state_set(struct pm_state_info info)
 		k_cpu_idle();
 		break;
 	default:
-		LOG_DBG("Unsupported power state %u", info.state);
+		LOG_DBG("Unsupported power state %u", info->state);
 		break;
 	}
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
+__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
 {
-	switch (info.state) {
+	switch (info->state) {
 	case PM_STATE_SUSPEND_TO_IDLE:
 		LL_LPM_DisableSleepOnExit();
 		LL_LPM_EnableSleep();
@@ -66,7 +66,7 @@ __weak void pm_power_state_exit_post_ops(struct pm_state_info info)
 		/* Nothing to do. */
 		break;
 	default:
-		LOG_DBG("Unsupported power substate-id %u", info.state);
+		LOG_DBG("Unsupported power substate-id %u", info->state);
 		break;
 	}
 

--- a/soc/arm/st_stm32/stm32l4/power.c
+++ b/soc/arm/st_stm32/stm32l4/power.c
@@ -28,14 +28,14 @@ LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 #endif
 
 /* Invoke Low Power/System Off specific Tasks */
-__weak void pm_power_state_set(struct pm_state_info info)
+__weak void pm_power_state_set(struct pm_state_info *info)
 {
-	if (info.state != PM_STATE_SUSPEND_TO_IDLE) {
-		LOG_DBG("Unsupported power state %u", info.state);
+	if (info->state != PM_STATE_SUSPEND_TO_IDLE) {
+		LOG_DBG("Unsupported power state %u", info->state);
 		return;
 	}
 
-	switch (info.substate_id) {
+	switch (info->substate_id) {
 	case 1: /* this corresponds to the STOP0 mode: */
 		/* ensure the proper wake-up system clock */
 		LL_RCC_SetClkAfterWakeFromStop(RCC_STOP_WAKEUPCLOCK_SELECTED);
@@ -68,18 +68,18 @@ __weak void pm_power_state_set(struct pm_state_info info)
 		break;
 	default:
 		LOG_DBG("Unsupported power state substate-id %u",
-			info.substate_id);
+			info->substate_id);
 		break;
 	}
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
+__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
 {
-	if (info.state != PM_STATE_SUSPEND_TO_IDLE) {
-		LOG_DBG("Unsupported power substate-id %u", info.state);
+	if (info->state != PM_STATE_SUSPEND_TO_IDLE) {
+		LOG_DBG("Unsupported power substate-id %u", info->state);
 	} else {
-		switch (info.substate_id) {
+		switch (info->substate_id) {
 		case 1:	/* STOP0 */
 			__fallthrough;
 		case 2:	/* STOP1 */
@@ -90,7 +90,7 @@ __weak void pm_power_state_exit_post_ops(struct pm_state_info info)
 			break;
 		default:
 			LOG_DBG("Unsupported power substate-id %u",
-				info.substate_id);
+				info->substate_id);
 			break;
 		}
 		/* need to restore the clock */

--- a/soc/arm/st_stm32/stm32l4/power.c
+++ b/soc/arm/st_stm32/stm32l4/power.c
@@ -28,14 +28,14 @@ LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 #endif
 
 /* Invoke Low Power/System Off specific Tasks */
-__weak void pm_power_state_set(struct pm_state_info *info)
+__weak void pm_power_state_set(enum pm_state state, uint8_t substate_id)
 {
-	if (info->state != PM_STATE_SUSPEND_TO_IDLE) {
-		LOG_DBG("Unsupported power state %u", info->state);
+	if (state != PM_STATE_SUSPEND_TO_IDLE) {
+		LOG_DBG("Unsupported power state %u", state);
 		return;
 	}
 
-	switch (info->substate_id) {
+	switch (substate_id) {
 	case 1: /* this corresponds to the STOP0 mode: */
 		/* ensure the proper wake-up system clock */
 		LL_RCC_SetClkAfterWakeFromStop(RCC_STOP_WAKEUPCLOCK_SELECTED);
@@ -68,18 +68,18 @@ __weak void pm_power_state_set(struct pm_state_info *info)
 		break;
 	default:
 		LOG_DBG("Unsupported power state substate-id %u",
-			info->substate_id);
+			substate_id);
 		break;
 	}
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
+__weak void pm_power_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 {
-	if (info->state != PM_STATE_SUSPEND_TO_IDLE) {
-		LOG_DBG("Unsupported power substate-id %u", info->state);
+	if (state != PM_STATE_SUSPEND_TO_IDLE) {
+		LOG_DBG("Unsupported power substate-id %u", state);
 	} else {
-		switch (info->substate_id) {
+		switch (substate_id) {
 		case 1:	/* STOP0 */
 			__fallthrough;
 		case 2:	/* STOP1 */
@@ -90,7 +90,7 @@ __weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
 			break;
 		default:
 			LOG_DBG("Unsupported power substate-id %u",
-				info->substate_id);
+				substate_id);
 			break;
 		}
 		/* need to restore the clock */

--- a/soc/arm/st_stm32/stm32l5/power.c
+++ b/soc/arm/st_stm32/stm32l5/power.c
@@ -28,14 +28,14 @@ LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 #endif
 
 /* Invoke Low Power/System Off specific Tasks */
-__weak void pm_power_state_set(struct pm_state_info info)
+__weak void pm_power_state_set(struct pm_state_info *info)
 {
-	if (info.state != PM_STATE_SUSPEND_TO_IDLE) {
-		LOG_DBG("Unsupported power state %u", info.state);
+	if (info->state != PM_STATE_SUSPEND_TO_IDLE) {
+		LOG_DBG("Unsupported power state %u", info->state);
 		return;
 	}
 
-	switch (info.substate_id) {
+	switch (info->substate_id) {
 	case 1: /* this corresponds to the STOP0 mode: */
 		/* ensure the proper wake-up system clock */
 		LL_RCC_SetClkAfterWakeFromStop(RCC_STOP_WAKEUPCLOCK_SELECTED);
@@ -68,18 +68,18 @@ __weak void pm_power_state_set(struct pm_state_info info)
 		break;
 	default:
 		LOG_DBG("Unsupported power state substate-id %u",
-			info.substate_id);
+			info->substate_id);
 		break;
 	}
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
+__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
 {
-	if (info.state != PM_STATE_SUSPEND_TO_IDLE) {
-		LOG_DBG("Unsupported power substate-id %u", info.state);
+	if (info->state != PM_STATE_SUSPEND_TO_IDLE) {
+		LOG_DBG("Unsupported power substate-id %u", info->state);
 	} else {
-		switch (info.substate_id) {
+		switch (info->substate_id) {
 		case 1:	/* STOP0 */
 			__fallthrough;
 		case 2:	/* STOP1 */
@@ -90,7 +90,7 @@ __weak void pm_power_state_exit_post_ops(struct pm_state_info info)
 			break;
 		default:
 			LOG_DBG("Unsupported power substate-id %u",
-				info.substate_id);
+				info->substate_id);
 			break;
 		}
 		/* need to restore the clock */

--- a/soc/arm/st_stm32/stm32l5/power.c
+++ b/soc/arm/st_stm32/stm32l5/power.c
@@ -28,14 +28,14 @@ LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 #endif
 
 /* Invoke Low Power/System Off specific Tasks */
-__weak void pm_power_state_set(struct pm_state_info *info)
+__weak void pm_power_state_set(enum pm_state state, uint8_t substate_id)
 {
-	if (info->state != PM_STATE_SUSPEND_TO_IDLE) {
-		LOG_DBG("Unsupported power state %u", info->state);
+	if (state != PM_STATE_SUSPEND_TO_IDLE) {
+		LOG_DBG("Unsupported power state %u", state);
 		return;
 	}
 
-	switch (info->substate_id) {
+	switch (substate_id) {
 	case 1: /* this corresponds to the STOP0 mode: */
 		/* ensure the proper wake-up system clock */
 		LL_RCC_SetClkAfterWakeFromStop(RCC_STOP_WAKEUPCLOCK_SELECTED);
@@ -68,18 +68,18 @@ __weak void pm_power_state_set(struct pm_state_info *info)
 		break;
 	default:
 		LOG_DBG("Unsupported power state substate-id %u",
-			info->substate_id);
+			substate_id);
 		break;
 	}
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
+__weak void pm_power_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 {
-	if (info->state != PM_STATE_SUSPEND_TO_IDLE) {
-		LOG_DBG("Unsupported power substate-id %u", info->state);
+	if (state != PM_STATE_SUSPEND_TO_IDLE) {
+		LOG_DBG("Unsupported power substate-id %u", state);
 	} else {
-		switch (info->substate_id) {
+		switch (substate_id) {
 		case 1:	/* STOP0 */
 			__fallthrough;
 		case 2:	/* STOP1 */
@@ -90,7 +90,7 @@ __weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
 			break;
 		default:
 			LOG_DBG("Unsupported power substate-id %u",
-				info->substate_id);
+				substate_id);
 			break;
 		}
 		/* need to restore the clock */

--- a/soc/arm/st_stm32/stm32u5/power.c
+++ b/soc/arm/st_stm32/stm32u5/power.c
@@ -62,22 +62,21 @@ void set_mode_shutdown(uint8_t substate_id)
 }
 
 /* Invoke Low Power/System Off specific Tasks */
-__weak void pm_power_state_set(struct pm_state_info *info)
+__weak void pm_power_state_set(enum pm_state state, uint8_t substate_id)
 {
-
-	switch (info->state) {
+	switch (state) {
 	case PM_STATE_SUSPEND_TO_IDLE:
-		set_mode_stop(info->substate_id);
+		set_mode_stop(substate_id);
 		break;
 	case PM_STATE_STANDBY:
 		/* To be tested */
-		set_mode_standby(info->substate_id);
+		set_mode_standby(substate_id);
 		break;
 	case PM_STATE_SOFT_OFF:
-		set_mode_shutdown(info->substate_id);
+		set_mode_shutdown(substate_id);
 		break;
 	default:
-		LOG_DBG("Unsupported power state %u", info->state);
+		LOG_DBG("Unsupported power state %u", state);
 		return;
 	}
 
@@ -89,16 +88,16 @@ __weak void pm_power_state_set(struct pm_state_info *info)
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
+__weak void pm_power_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 {
-	switch (info->state) {
+	switch (state) {
 	case PM_STATE_SUSPEND_TO_IDLE:
-		if (info->substate_id <= 3) {
+		if (substate_id <= 3) {
 			LL_LPM_DisableSleepOnExit();
 			LL_LPM_EnableSleep();
 		} else {
 			LOG_DBG("Unsupported power substate-id %u",
-							info->substate_id);
+							substate_id);
 		}
 	case PM_STATE_STANDBY:
 		/* To be tested */
@@ -113,7 +112,7 @@ __weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
 	case PM_STATE_SUSPEND_TO_DISK:
 		__fallthrough;
 	default:
-		LOG_DBG("Unsupported power state %u", info->state);
+		LOG_DBG("Unsupported power state %u", state);
 		break;
 	}
 	/* need to restore the clock */

--- a/soc/arm/st_stm32/stm32u5/power.c
+++ b/soc/arm/st_stm32/stm32u5/power.c
@@ -62,22 +62,22 @@ void set_mode_shutdown(uint8_t substate_id)
 }
 
 /* Invoke Low Power/System Off specific Tasks */
-__weak void pm_power_state_set(struct pm_state_info info)
+__weak void pm_power_state_set(struct pm_state_info *info)
 {
 
-	switch (info.state) {
+	switch (info->state) {
 	case PM_STATE_SUSPEND_TO_IDLE:
-		set_mode_stop(info.substate_id);
+		set_mode_stop(info->substate_id);
 		break;
 	case PM_STATE_STANDBY:
 		/* To be tested */
-		set_mode_standby(info.substate_id);
+		set_mode_standby(info->substate_id);
 		break;
 	case PM_STATE_SOFT_OFF:
-		set_mode_shutdown(info.substate_id);
+		set_mode_shutdown(info->substate_id);
 		break;
 	default:
-		LOG_DBG("Unsupported power state %u", info.state);
+		LOG_DBG("Unsupported power state %u", info->state);
 		return;
 	}
 
@@ -89,16 +89,16 @@ __weak void pm_power_state_set(struct pm_state_info info)
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
+__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
 {
-	switch (info.state) {
+	switch (info->state) {
 	case PM_STATE_SUSPEND_TO_IDLE:
-		if (info.substate_id <= 3) {
+		if (info->substate_id <= 3) {
 			LL_LPM_DisableSleepOnExit();
 			LL_LPM_EnableSleep();
 		} else {
 			LOG_DBG("Unsupported power substate-id %u",
-							info.substate_id);
+							info->substate_id);
 		}
 	case PM_STATE_STANDBY:
 		/* To be tested */
@@ -113,7 +113,7 @@ __weak void pm_power_state_exit_post_ops(struct pm_state_info info)
 	case PM_STATE_SUSPEND_TO_DISK:
 		__fallthrough;
 	default:
-		LOG_DBG("Unsupported power state %u", info.state);
+		LOG_DBG("Unsupported power state %u", info->state);
 		break;
 	}
 	/* need to restore the clock */

--- a/soc/arm/st_stm32/stm32wb/power.c
+++ b/soc/arm/st_stm32/stm32wb/power.c
@@ -84,9 +84,9 @@ static void shutdown_ble_stack(void)
 }
 
 /* Invoke Low Power/System Off specific Tasks */
-__weak void pm_power_state_set(struct pm_state_info *info)
+__weak void pm_power_state_set(enum pm_state state, uint8_t substate_id)
 {
-	if (info->state == PM_STATE_SOFT_OFF) {
+	if (state == PM_STATE_SOFT_OFF) {
 
 		if (IS_ENABLED(CONFIG_BT)) {
 			shutdown_ble_stack();
@@ -99,14 +99,14 @@ __weak void pm_power_state_set(struct pm_state_info *info)
 
 		LL_PWR_SetPowerMode(LL_PWR_MODE_SHUTDOWN);
 
-	} else if (info->state == PM_STATE_SUSPEND_TO_IDLE) {
+	} else if (state == PM_STATE_SUSPEND_TO_IDLE) {
 
 		lpm_hsem_lock();
 
 		/* ensure HSI is the wake-up system clock */
 		LL_RCC_SetClkAfterWakeFromStop(LL_RCC_STOP_WAKEUPCLOCK_HSI);
 
-		switch (info->substate_id) {
+		switch (substate_id) {
 		case 1:
 			/* enter STOP0 mode */
 			LL_PWR_SetPowerMode(LL_PWR_MODE_STOP0);
@@ -122,12 +122,12 @@ __weak void pm_power_state_set(struct pm_state_info *info)
 		default:
 			/* Release RCC semaphore */
 			z_stm32_hsem_unlock(CFG_HW_RCC_SEMID);
-			LOG_DBG("Unsupported power substate-id %u", info->substate_id);
+			LOG_DBG("Unsupported power substate-id %u", substate_id);
 			return;
 		}
 
 	} else {
-		LOG_DBG("Unsupported power state %u", info->state);
+		LOG_DBG("Unsupported power state %u", state);
 		return;
 	}
 
@@ -141,17 +141,17 @@ __weak void pm_power_state_set(struct pm_state_info *info)
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
+__weak void pm_power_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 {
 	/* Implementation of STM32 AN5289 algorithm to enter/exit lowpower */
 	/* Release ENTRY_STOP_MODE semaphore */
 	LL_HSEM_ReleaseLock(HSEM, CFG_HW_ENTRY_STOP_MODE_SEMID, 0);
 	z_stm32_hsem_lock(CFG_HW_RCC_SEMID, HSEM_LOCK_WAIT_FOREVER);
 
-	if (info->state != PM_STATE_SUSPEND_TO_IDLE) {
-		LOG_DBG("Unsupported power state %u", info->state);
+	if (state != PM_STATE_SUSPEND_TO_IDLE) {
+		LOG_DBG("Unsupported power state %u", state);
 	} else {
-		switch (info->substate_id) {
+		switch (substate_id) {
 		case 1:	/* STOP0 */
 			__fallthrough;
 		case 2:	/* STOP1 */
@@ -162,7 +162,7 @@ __weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
 			break;
 		default:
 			LOG_DBG("Unsupported power substate-id %u",
-				info->substate_id);
+				substate_id);
 			break;
 		}
 		/* need to restore the clock */

--- a/soc/arm/st_stm32/stm32wb/power.c
+++ b/soc/arm/st_stm32/stm32wb/power.c
@@ -84,9 +84,9 @@ static void shutdown_ble_stack(void)
 }
 
 /* Invoke Low Power/System Off specific Tasks */
-__weak void pm_power_state_set(struct pm_state_info info)
+__weak void pm_power_state_set(struct pm_state_info *info)
 {
-	if (info.state == PM_STATE_SOFT_OFF) {
+	if (info->state == PM_STATE_SOFT_OFF) {
 
 		if (IS_ENABLED(CONFIG_BT)) {
 			shutdown_ble_stack();
@@ -99,14 +99,14 @@ __weak void pm_power_state_set(struct pm_state_info info)
 
 		LL_PWR_SetPowerMode(LL_PWR_MODE_SHUTDOWN);
 
-	} else if (info.state == PM_STATE_SUSPEND_TO_IDLE) {
+	} else if (info->state == PM_STATE_SUSPEND_TO_IDLE) {
 
 		lpm_hsem_lock();
 
 		/* ensure HSI is the wake-up system clock */
 		LL_RCC_SetClkAfterWakeFromStop(LL_RCC_STOP_WAKEUPCLOCK_HSI);
 
-		switch (info.substate_id) {
+		switch (info->substate_id) {
 		case 1:
 			/* enter STOP0 mode */
 			LL_PWR_SetPowerMode(LL_PWR_MODE_STOP0);
@@ -122,12 +122,12 @@ __weak void pm_power_state_set(struct pm_state_info info)
 		default:
 			/* Release RCC semaphore */
 			z_stm32_hsem_unlock(CFG_HW_RCC_SEMID);
-			LOG_DBG("Unsupported power substate-id %u", info.substate_id);
+			LOG_DBG("Unsupported power substate-id %u", info->substate_id);
 			return;
 		}
 
 	} else {
-		LOG_DBG("Unsupported power state %u", info.state);
+		LOG_DBG("Unsupported power state %u", info->state);
 		return;
 	}
 
@@ -141,17 +141,17 @@ __weak void pm_power_state_set(struct pm_state_info info)
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
+__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
 {
 	/* Implementation of STM32 AN5289 algorithm to enter/exit lowpower */
 	/* Release ENTRY_STOP_MODE semaphore */
 	LL_HSEM_ReleaseLock(HSEM, CFG_HW_ENTRY_STOP_MODE_SEMID, 0);
 	z_stm32_hsem_lock(CFG_HW_RCC_SEMID, HSEM_LOCK_WAIT_FOREVER);
 
-	if (info.state != PM_STATE_SUSPEND_TO_IDLE) {
-		LOG_DBG("Unsupported power state %u", info.state);
+	if (info->state != PM_STATE_SUSPEND_TO_IDLE) {
+		LOG_DBG("Unsupported power state %u", info->state);
 	} else {
-		switch (info.substate_id) {
+		switch (info->substate_id) {
 		case 1:	/* STOP0 */
 			__fallthrough;
 		case 2:	/* STOP1 */
@@ -162,7 +162,7 @@ __weak void pm_power_state_exit_post_ops(struct pm_state_info info)
 			break;
 		default:
 			LOG_DBG("Unsupported power substate-id %u",
-				info.substate_id);
+				info->substate_id);
 			break;
 		}
 		/* need to restore the clock */

--- a/soc/arm/st_stm32/stm32wl/power.c
+++ b/soc/arm/st_stm32/stm32wl/power.c
@@ -28,13 +28,13 @@ LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 #endif
 
 /* Invoke Low Power/System Off specific Tasks */
-__weak void pm_power_state_set(struct pm_state_info *info)
+__weak void pm_power_state_set(enum pm_state state, uint8_t substate_id)
 {
-	switch (info->state) {
+	switch (state) {
 	case PM_STATE_SUSPEND_TO_IDLE:
 		LL_RCC_SetClkAfterWakeFromStop(RCC_STOP_WAKEUPCLOCK_SELECTED);
 		LL_PWR_ClearFlag_WU();
-		switch (info->substate_id) {
+		switch (substate_id) {
 		case 1:
 			LL_PWR_SetPowerMode(LL_PWR_MODE_STOP0);
 			break;
@@ -45,7 +45,7 @@ __weak void pm_power_state_set(struct pm_state_info *info)
 			LL_PWR_SetPowerMode(LL_PWR_MODE_STOP2);
 			break;
 		default:
-			LOG_DBG("Unsupported power substate-id %u", info->substate_id);
+			LOG_DBG("Unsupported power substate-id %u", substate_id);
 			return;
 		}
 		LL_LPM_EnableDeepSleep();
@@ -53,7 +53,7 @@ __weak void pm_power_state_set(struct pm_state_info *info)
 		break;
 	case PM_STATE_SOFT_OFF:
 		LL_PWR_ClearFlag_WU();
-		switch (info->substate_id) {
+		switch (substate_id) {
 		case 0:
 			LL_PWR_SetPowerMode(LL_PWR_MODE_STANDBY);
 			break;
@@ -61,22 +61,24 @@ __weak void pm_power_state_set(struct pm_state_info *info)
 			LL_PWR_SetPowerMode(LL_PWR_MODE_SHUTDOWN);
 			break;
 		default:
-			LOG_DBG("Unsupported power substate-id %u", info->substate_id);
+			LOG_DBG("Unsupported power substate-id %u", substate_id);
 			return;
 		}
 		LL_LPM_EnableDeepSleep();
 		k_cpu_idle();
 		break;
 	default:
-		LOG_DBG("Unsupported power state %u", info->state);
+		LOG_DBG("Unsupported power state %u", state);
 		break;
 	}
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
+__weak void pm_power_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 {
-	switch (info->state) {
+	ARG_UNUSED(substate_id);
+
+	switch (state) {
 	case PM_STATE_SUSPEND_TO_IDLE:
 		LL_LPM_DisableSleepOnExit();
 		LL_LPM_EnableSleep();
@@ -87,7 +89,7 @@ __weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
 		/* Nothing to do. */
 		break;
 	default:
-		LOG_DBG("Unsupported power substate-id %u", info->state);
+		LOG_DBG("Unsupported power substate-id %u", state);
 		break;
 	}
 

--- a/soc/arm/st_stm32/stm32wl/power.c
+++ b/soc/arm/st_stm32/stm32wl/power.c
@@ -28,13 +28,13 @@ LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 #endif
 
 /* Invoke Low Power/System Off specific Tasks */
-__weak void pm_power_state_set(struct pm_state_info info)
+__weak void pm_power_state_set(struct pm_state_info *info)
 {
-	switch (info.state) {
+	switch (info->state) {
 	case PM_STATE_SUSPEND_TO_IDLE:
 		LL_RCC_SetClkAfterWakeFromStop(RCC_STOP_WAKEUPCLOCK_SELECTED);
 		LL_PWR_ClearFlag_WU();
-		switch (info.substate_id) {
+		switch (info->substate_id) {
 		case 1:
 			LL_PWR_SetPowerMode(LL_PWR_MODE_STOP0);
 			break;
@@ -45,7 +45,7 @@ __weak void pm_power_state_set(struct pm_state_info info)
 			LL_PWR_SetPowerMode(LL_PWR_MODE_STOP2);
 			break;
 		default:
-			LOG_DBG("Unsupported power substate-id %u", info.substate_id);
+			LOG_DBG("Unsupported power substate-id %u", info->substate_id);
 			return;
 		}
 		LL_LPM_EnableDeepSleep();
@@ -53,7 +53,7 @@ __weak void pm_power_state_set(struct pm_state_info info)
 		break;
 	case PM_STATE_SOFT_OFF:
 		LL_PWR_ClearFlag_WU();
-		switch (info.substate_id) {
+		switch (info->substate_id) {
 		case 0:
 			LL_PWR_SetPowerMode(LL_PWR_MODE_STANDBY);
 			break;
@@ -61,22 +61,22 @@ __weak void pm_power_state_set(struct pm_state_info info)
 			LL_PWR_SetPowerMode(LL_PWR_MODE_SHUTDOWN);
 			break;
 		default:
-			LOG_DBG("Unsupported power substate-id %u", info.substate_id);
+			LOG_DBG("Unsupported power substate-id %u", info->substate_id);
 			return;
 		}
 		LL_LPM_EnableDeepSleep();
 		k_cpu_idle();
 		break;
 	default:
-		LOG_DBG("Unsupported power state %u", info.state);
+		LOG_DBG("Unsupported power state %u", info->state);
 		break;
 	}
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
+__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
 {
-	switch (info.state) {
+	switch (info->state) {
 	case PM_STATE_SUSPEND_TO_IDLE:
 		LL_LPM_DisableSleepOnExit();
 		LL_LPM_EnableSleep();
@@ -87,7 +87,7 @@ __weak void pm_power_state_exit_post_ops(struct pm_state_info info)
 		/* Nothing to do. */
 		break;
 	default:
-		LOG_DBG("Unsupported power substate-id %u", info.state);
+		LOG_DBG("Unsupported power substate-id %u", info->state);
 		break;
 	}
 

--- a/soc/arm/ti_simplelink/cc13x2_cc26x2/power.c
+++ b/soc/arm/ti_simplelink/cc13x2_cc26x2/power.c
@@ -57,12 +57,14 @@ extern PowerCC26X2_ModuleState PowerCC26X2_module;
  */
 
 /* Invoke Low Power/System Off specific Tasks */
-__weak void pm_power_state_set(struct pm_state_info *info)
+__weak void pm_power_state_set(enum pm_state state, uint8_t substate_id)
 {
+	ARG_UNUSED(substate_id);
+
 	uint32_t modeVIMS;
 	uint32_t constraints;
 
-	LOG_DBG("SoC entering power state %d", info->state);
+	LOG_DBG("SoC entering power state %d", state);
 
 	/* Switch to using PRIMASK instead of BASEPRI register, since
 	 * we are only able to wake up from standby while using PRIMASK.
@@ -72,7 +74,7 @@ __weak void pm_power_state_set(struct pm_state_info *info)
 	/* Set BASEPRI to 0 */
 	irq_unlock(0);
 
-	switch (info->state) {
+	switch (state) {
 	case PM_STATE_SUSPEND_TO_IDLE:
 		/* query the declared constraints */
 		constraints = Power_getConstraintMask();
@@ -111,16 +113,19 @@ __weak void pm_power_state_set(struct pm_state_info *info)
 		Power_shutdown(0, 0);
 		break;
 	default:
-		LOG_DBG("Unsupported power state %u", info->state);
+		LOG_DBG("Unsupported power state %u", state);
 		break;
 	}
 
-	LOG_DBG("SoC leaving power state %d", info->state);
+	LOG_DBG("SoC leaving power state %d", state);
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
+__weak void pm_power_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 {
+	ARG_UNUSED(state);
+	ARG_UNUSED(substate_id);
+
 	/*
 	 * System is now in active mode. Reenable interrupts which were disabled
 	 * when OS started idling code.

--- a/soc/arm/ti_simplelink/cc13x2_cc26x2/power.c
+++ b/soc/arm/ti_simplelink/cc13x2_cc26x2/power.c
@@ -57,12 +57,12 @@ extern PowerCC26X2_ModuleState PowerCC26X2_module;
  */
 
 /* Invoke Low Power/System Off specific Tasks */
-__weak void pm_power_state_set(struct pm_state_info info)
+__weak void pm_power_state_set(struct pm_state_info *info)
 {
 	uint32_t modeVIMS;
 	uint32_t constraints;
 
-	LOG_DBG("SoC entering power state %d", info.state);
+	LOG_DBG("SoC entering power state %d", info->state);
 
 	/* Switch to using PRIMASK instead of BASEPRI register, since
 	 * we are only able to wake up from standby while using PRIMASK.
@@ -72,7 +72,7 @@ __weak void pm_power_state_set(struct pm_state_info info)
 	/* Set BASEPRI to 0 */
 	irq_unlock(0);
 
-	switch (info.state) {
+	switch (info->state) {
 	case PM_STATE_SUSPEND_TO_IDLE:
 		/* query the declared constraints */
 		constraints = Power_getConstraintMask();
@@ -111,15 +111,15 @@ __weak void pm_power_state_set(struct pm_state_info info)
 		Power_shutdown(0, 0);
 		break;
 	default:
-		LOG_DBG("Unsupported power state %u", info.state);
+		LOG_DBG("Unsupported power state %u", info->state);
 		break;
 	}
 
-	LOG_DBG("SoC leaving power state %d", info.state);
+	LOG_DBG("SoC leaving power state %d", info->state);
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
+__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
 {
 	/*
 	 * System is now in active mode. Reenable interrupts which were disabled

--- a/soc/riscv/riscv-ite/common/power.c
+++ b/soc/riscv/riscv-ite/common/power.c
@@ -17,9 +17,9 @@ static void ite_power_soc_deep_doze(void)
 }
 
 /* Invoke Low Power/System Off specific Tasks */
-__weak void pm_power_state_set(struct pm_state_info info)
+__weak void pm_power_state_set(struct pm_state_info *info)
 {
-	switch (info.state) {
+	switch (info->state) {
 	/* Deep doze mode */
 	case PM_STATE_STANDBY:
 		ite_power_soc_deep_doze();
@@ -30,7 +30,7 @@ __weak void pm_power_state_set(struct pm_state_info info)
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
+__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
 {
 	ARG_UNUSED(info);
 }

--- a/soc/riscv/riscv-ite/common/power.c
+++ b/soc/riscv/riscv-ite/common/power.c
@@ -17,9 +17,11 @@ static void ite_power_soc_deep_doze(void)
 }
 
 /* Invoke Low Power/System Off specific Tasks */
-__weak void pm_power_state_set(struct pm_state_info *info)
+__weak void pm_power_state_set(enum pm_state state, uint8_t substate_id)
 {
-	switch (info->state) {
+	ARG_UNUSED(substate_id);
+
+	switch (state) {
 	/* Deep doze mode */
 	case PM_STATE_STANDBY:
 		ite_power_soc_deep_doze();
@@ -30,7 +32,8 @@ __weak void pm_power_state_set(struct pm_state_info *info)
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-__weak void pm_power_state_exit_post_ops(struct pm_state_info *info)
+__weak void pm_power_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 {
-	ARG_UNUSED(info);
+	ARG_UNUSED(state);
+	ARG_UNUSED(substate_id);
 }

--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -105,10 +105,10 @@ static void pm_resume_devices(void)
 static inline void pm_exit_pos_ops(struct pm_state_info *info)
 {
 	extern __weak void
-		pm_power_state_exit_post_ops(struct pm_state_info *info);
+		pm_power_state_exit_post_ops(enum pm_state state, uint8_t substate_id);
 
 	if (pm_power_state_exit_post_ops != NULL) {
-		pm_power_state_exit_post_ops(info);
+		pm_power_state_exit_post_ops(info->state, info->substate_id);
 	} else {
 		/*
 		 * This function is supposed to be overridden to do SoC or
@@ -124,10 +124,10 @@ static inline void pm_exit_pos_ops(struct pm_state_info *info)
 static inline void pm_state_set(struct pm_state_info *info)
 {
 	extern __weak void
-		pm_power_state_set(struct pm_state_info *info);
+		pm_power_state_set(enum pm_state state, uint8_t substate_id);
 
 	if (pm_power_state_set != NULL) {
-		pm_power_state_set(info);
+		pm_power_state_set(info->state, info->substate_id);
 	}
 }
 

--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -102,7 +102,7 @@ static void pm_resume_devices(void)
 }
 #endif	/* CONFIG_PM_DEVICE */
 
-static inline void exit_pos_ops(struct pm_state_info *info)
+static inline void pm_exit_pos_ops(struct pm_state_info *info)
 {
 	extern __weak void
 		pm_power_state_exit_post_ops(struct pm_state_info *info);
@@ -173,7 +173,7 @@ void pm_system_resume(void)
 	 * and it may schedule another thread.
 	 */
 	if (atomic_test_and_clear_bit(z_post_ops_required, id)) {
-		exit_pos_ops(&z_cpus_pm_state[id]);
+		pm_exit_pos_ops(&z_cpus_pm_state[id]);
 		pm_state_notify(false);
 		z_cpus_pm_state[id] = (struct pm_state_info){PM_STATE_ACTIVE,
 			0, 0};

--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -102,10 +102,10 @@ static void pm_resume_devices(void)
 }
 #endif	/* CONFIG_PM_DEVICE */
 
-static inline void exit_pos_ops(struct pm_state_info info)
+static inline void exit_pos_ops(struct pm_state_info *info)
 {
 	extern __weak void
-		pm_power_state_exit_post_ops(struct pm_state_info info);
+		pm_power_state_exit_post_ops(struct pm_state_info *info);
 
 	if (pm_power_state_exit_post_ops != NULL) {
 		pm_power_state_exit_post_ops(info);
@@ -121,10 +121,10 @@ static inline void exit_pos_ops(struct pm_state_info info)
 	}
 }
 
-static inline void pm_state_set(struct pm_state_info info)
+static inline void pm_state_set(struct pm_state_info *info)
 {
 	extern __weak void
-		pm_power_state_set(struct pm_state_info info);
+		pm_power_state_set(struct pm_state_info *info);
 
 	if (pm_power_state_set != NULL) {
 		pm_power_state_set(info);
@@ -173,23 +173,23 @@ void pm_system_resume(void)
 	 * and it may schedule another thread.
 	 */
 	if (atomic_test_and_clear_bit(z_post_ops_required, id)) {
-		exit_pos_ops(z_cpus_pm_state[id]);
+		exit_pos_ops(&z_cpus_pm_state[id]);
 		pm_state_notify(false);
 		z_cpus_pm_state[id] = (struct pm_state_info){PM_STATE_ACTIVE,
 			0, 0};
 	}
 }
 
-bool pm_power_state_force(uint8_t cpu, struct pm_state_info info)
+bool pm_power_state_force(uint8_t cpu, const struct pm_state_info *info)
 {
 	bool ret = false;
 
-	__ASSERT(info.state < PM_STATE_COUNT,
-		 "Invalid power state %d!", info.state);
+	__ASSERT(info->state < PM_STATE_COUNT,
+		 "Invalid power state %d!", info->state);
 
 
 	if (!atomic_test_and_set_bit(z_cpus_pm_state_forced, cpu)) {
-		z_cpus_pm_state[cpu] = info;
+		z_cpus_pm_state[cpu] = *info;
 		ret = true;
 	}
 
@@ -259,7 +259,7 @@ bool pm_system_suspend(int32_t ticks)
 	/* Enter power state */
 	pm_state_notify(true);
 	atomic_set_bit(z_post_ops_required, id);
-	pm_state_set(z_cpus_pm_state[id]);
+	pm_state_set(&z_cpus_pm_state[id]);
 	pm_stats_stop();
 
 	/* Wake up sequence starts here */
@@ -301,7 +301,7 @@ int pm_notifier_unregister(struct pm_notifier *notifier)
 	return ret;
 }
 
-struct pm_state_info pm_power_state_next_get(uint8_t cpu)
+const struct pm_state_info *pm_power_state_next_get(uint8_t cpu)
 {
-	return z_cpus_pm_state[cpu];
+	return &z_cpus_pm_state[cpu];
 }

--- a/tests/subsys/pm/device_wakeup_api/src/main.c
+++ b/tests/subsys/pm/device_wakeup_api/src/main.c
@@ -16,11 +16,11 @@ static const struct device *dev;
 static uint8_t sleep_count;
 
 
-void pm_power_state_set(struct pm_state_info *info)
+void pm_power_state_set(enum pm_state state, uint8_t substate_id)
 {
-	ARG_UNUSED(info);
+	ARG_UNUSED(substate_id);
 
-	enum pm_device_state state;
+	enum pm_device_state dev_state;
 
 	switch (sleep_count) {
 	case 1:
@@ -28,10 +28,10 @@ void pm_power_state_set(struct pm_state_info *info)
 		 * Devices are suspended before SoC on PM_STATE_SUSPEND_TO_RAM, that is why
 		 * we can check the device state here.
 		 */
-		zassert_equal(info->state, PM_STATE_SUSPEND_TO_RAM, "Wrong system state");
+		zassert_equal(state, PM_STATE_SUSPEND_TO_RAM, "Wrong system state");
 
-		(void)pm_device_state_get(dev, &state);
-		zassert_equal(state, PM_DEVICE_STATE_SUSPENDED, "Wrong device state");
+		(void)pm_device_state_get(dev, &dev_state);
+		zassert_equal(dev_state, PM_DEVICE_STATE_SUSPENDED, "Wrong device state");
 
 		/* Enable wakeup source. Next time the system is called
 		 * to sleep, this device will still be active.
@@ -39,21 +39,24 @@ void pm_power_state_set(struct pm_state_info *info)
 		(void)pm_device_wakeup_enable((struct device *)dev, true);
 		break;
 	case 2:
-		zassert_equal(info->state, PM_STATE_SUSPEND_TO_RAM, "Wrong system state");
+		zassert_equal(state, PM_STATE_SUSPEND_TO_RAM, "Wrong system state");
 
 		/* Second time this function is called, the system is asked to standby
 		 * and devices were suspended.
 		 */
-		(void)pm_device_state_get(dev, &state);
-		zassert_equal(state, PM_DEVICE_STATE_ACTIVE, "Wrong device state");
+		(void)pm_device_state_get(dev, &dev_state);
+		zassert_equal(dev_state, PM_DEVICE_STATE_ACTIVE, "Wrong device state");
 		break;
 	default:
 		break;
 	}
 }
 
-void pm_power_state_exit_post_ops(struct pm_state_info *info)
+void pm_power_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 {
+	ARG_UNUSED(state);
+	ARG_UNUSED(substate_id);
+
 	irq_unlock(0);
 }
 

--- a/tests/subsys/pm/device_wakeup_api/src/main.c
+++ b/tests/subsys/pm/device_wakeup_api/src/main.c
@@ -16,7 +16,7 @@ static const struct device *dev;
 static uint8_t sleep_count;
 
 
-void pm_power_state_set(struct pm_state_info info)
+void pm_power_state_set(struct pm_state_info *info)
 {
 	ARG_UNUSED(info);
 
@@ -28,7 +28,7 @@ void pm_power_state_set(struct pm_state_info info)
 		 * Devices are suspended before SoC on PM_STATE_SUSPEND_TO_RAM, that is why
 		 * we can check the device state here.
 		 */
-		zassert_equal(info.state, PM_STATE_SUSPEND_TO_RAM, "Wrong system state");
+		zassert_equal(info->state, PM_STATE_SUSPEND_TO_RAM, "Wrong system state");
 
 		(void)pm_device_state_get(dev, &state);
 		zassert_equal(state, PM_DEVICE_STATE_SUSPENDED, "Wrong device state");
@@ -39,7 +39,7 @@ void pm_power_state_set(struct pm_state_info info)
 		(void)pm_device_wakeup_enable((struct device *)dev, true);
 		break;
 	case 2:
-		zassert_equal(info.state, PM_STATE_SUSPEND_TO_RAM, "Wrong system state");
+		zassert_equal(info->state, PM_STATE_SUSPEND_TO_RAM, "Wrong system state");
 
 		/* Second time this function is called, the system is asked to standby
 		 * and devices were suspended.
@@ -52,7 +52,7 @@ void pm_power_state_set(struct pm_state_info info)
 	}
 }
 
-void pm_power_state_exit_post_ops(struct pm_state_info info)
+void pm_power_state_exit_post_ops(struct pm_state_info *info)
 {
 	irq_unlock(0);
 }

--- a/tests/subsys/pm/power_mgmt/src/main.c
+++ b/tests/subsys/pm/power_mgmt/src/main.c
@@ -141,7 +141,7 @@ DEVICE_DT_DEFINE(DT_INST(2, test_device_pm), device_init,
 
 
 
-void pm_power_state_set(struct pm_state_info info)
+void pm_power_state_set(struct pm_state_info *info)
 {
 	enum pm_device_state device_power_state;
 
@@ -185,11 +185,11 @@ void pm_power_state_set(struct pm_state_info info)
 	/* this function is called when system entering low power state, so
 	 * parameter state should not be PM_STATE_ACTIVE
 	 */
-	zassert_false(info.state == PM_STATE_ACTIVE,
+	zassert_false(info->state == PM_STATE_ACTIVE,
 		      "Entering low power state with a wrong parameter");
 }
 
-void pm_power_state_exit_post_ops(struct pm_state_info info)
+void pm_power_state_exit_post_ops(struct pm_state_info *info)
 {
 	/* pm_system_suspend is entered with irq locked
 	 * unlock irq before leave pm_system_suspend

--- a/tests/subsys/pm/power_mgmt/src/main.c
+++ b/tests/subsys/pm/power_mgmt/src/main.c
@@ -141,8 +141,11 @@ DEVICE_DT_DEFINE(DT_INST(2, test_device_pm), device_init,
 
 
 
-void pm_power_state_set(struct pm_state_info *info)
+void pm_power_state_set(enum pm_state state, uint8_t substate_id)
 {
+	ARG_UNUSED(substate_id);
+	ARG_UNUSED(state);
+
 	enum pm_device_state device_power_state;
 
 	/* If testing device order this function does not need to anything */
@@ -185,12 +188,15 @@ void pm_power_state_set(struct pm_state_info *info)
 	/* this function is called when system entering low power state, so
 	 * parameter state should not be PM_STATE_ACTIVE
 	 */
-	zassert_false(info->state == PM_STATE_ACTIVE,
+	zassert_false(state == PM_STATE_ACTIVE,
 		      "Entering low power state with a wrong parameter");
 }
 
-void pm_power_state_exit_post_ops(struct pm_state_info *info)
+void pm_power_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 {
+	ARG_UNUSED(state);
+	ARG_UNUSED(substate_id);
+
 	/* pm_system_suspend is entered with irq locked
 	 * unlock irq before leave pm_system_suspend
 	 */

--- a/tests/subsys/pm/power_mgmt_multicore/src/main.c
+++ b/tests/subsys/pm/power_mgmt_multicore/src/main.c
@@ -30,21 +30,21 @@ BUILD_ASSERT(CONFIG_MP_NUM_CPUS == 2, "Invalid number of cpus");
 
 static enum pm_state state_testing[2];
 
-void pm_power_state_set(struct pm_state_info info)
+void pm_power_state_set(struct pm_state_info *info)
 {
 	switch (state_testing[_current_cpu->id]) {
 	case PM_STATE_ACTIVE:
-		zassert_equal(PM_STATE_ACTIVE, info.state, NULL);
+		zassert_equal(PM_STATE_ACTIVE, info->state, NULL);
 		break;
 	case  PM_STATE_RUNTIME_IDLE:
-		zassert_equal(PM_STATE_RUNTIME_IDLE, info.state, NULL);
+		zassert_equal(PM_STATE_RUNTIME_IDLE, info->state, NULL);
 		break;
 	case  PM_STATE_SUSPEND_TO_IDLE:
-		zassert_equal(PM_STATE_SUSPEND_TO_IDLE, info.state, NULL);
+		zassert_equal(PM_STATE_SUSPEND_TO_IDLE, info->state, NULL);
 		break;
 	case  PM_STATE_STANDBY:
 		zassert_equal(_current_cpu->id, 1U, NULL);
-		zassert_equal(PM_STATE_STANDBY, info.state, NULL);
+		zassert_equal(PM_STATE_STANDBY, info->state, NULL);
 		break;
 	default:
 		zassert_unreachable(NULL);
@@ -52,7 +52,7 @@ void pm_power_state_set(struct pm_state_info info)
 	}
 }
 
-void pm_power_state_exit_post_ops(struct pm_state_info info)
+void pm_power_state_exit_post_ops(struct pm_state_info *info)
 {
 	/* pm_system_suspend is entered with irq locked
 	 * unlock irq before leave pm_system_suspend

--- a/tests/subsys/pm/power_mgmt_multicore/src/main.c
+++ b/tests/subsys/pm/power_mgmt_multicore/src/main.c
@@ -30,21 +30,23 @@ BUILD_ASSERT(CONFIG_MP_NUM_CPUS == 2, "Invalid number of cpus");
 
 static enum pm_state state_testing[2];
 
-void pm_power_state_set(struct pm_state_info *info)
+void pm_power_state_set(enum pm_state state, uint8_t substate_id)
 {
+	ARG_UNUSED(substate_id);
+
 	switch (state_testing[_current_cpu->id]) {
 	case PM_STATE_ACTIVE:
-		zassert_equal(PM_STATE_ACTIVE, info->state, NULL);
+		zassert_equal(PM_STATE_ACTIVE, state, NULL);
 		break;
 	case  PM_STATE_RUNTIME_IDLE:
-		zassert_equal(PM_STATE_RUNTIME_IDLE, info->state, NULL);
+		zassert_equal(PM_STATE_RUNTIME_IDLE, state, NULL);
 		break;
 	case  PM_STATE_SUSPEND_TO_IDLE:
-		zassert_equal(PM_STATE_SUSPEND_TO_IDLE, info->state, NULL);
+		zassert_equal(PM_STATE_SUSPEND_TO_IDLE, state, NULL);
 		break;
 	case  PM_STATE_STANDBY:
 		zassert_equal(_current_cpu->id, 1U, NULL);
-		zassert_equal(PM_STATE_STANDBY, info->state, NULL);
+		zassert_equal(PM_STATE_STANDBY, state, NULL);
 		break;
 	default:
 		zassert_unreachable(NULL);
@@ -52,8 +54,11 @@ void pm_power_state_set(struct pm_state_info *info)
 	}
 }
 
-void pm_power_state_exit_post_ops(struct pm_state_info *info)
+void pm_power_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 {
+	ARG_UNUSED(state);
+	ARG_UNUSED(substate_id);
+
 	/* pm_system_suspend is entered with irq locked
 	 * unlock irq before leave pm_system_suspend
 	 */


### PR DESCRIPTION
It's unnecessary to move the pm_state_info around by value, just use a pointer or modify the function parameters when proper.