### PR TITLE
Bluetooth: Audio: Align time-outs in babblesim tests

### DIFF
--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/common.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/common.c
@@ -70,7 +70,7 @@ void disconnected(struct bt_conn *conn, uint8_t reason)
 void test_tick(bs_time_t HW_device_time)
 {
 	if (bst_result != Passed) {
-		FAIL("test failed (not passed after %i seconds)\n", WAIT_TIME);
+		FAIL("test failed (not passed after %i seconds)\n", WAIT_SECONDS);
 	}
 }
 

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/common.h
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/common.h
@@ -21,6 +21,7 @@
 #include <stddef.h>
 #include <errno.h>
 #include <zephyr.h>
+#include <sys_clock.h>
 
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/hci.h>
@@ -28,7 +29,8 @@
 #include <bluetooth/uuid.h>
 #include <bluetooth/gatt.h>
 
-#define WAIT_TIME (30 * 1e6) /*seconds*/
+#define WAIT_SECONDS 30                         /* seconds */
+#define WAIT_TIME (WAIT_SECONDS * USEC_PER_SEC) /* microseconds*/
 
 #define WAIT_FOR(cond) while (!(cond)) { k_sleep(K_MSEC(1)); }
 

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/test_scripts/csis.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/test_scripts/csis.sh
@@ -44,6 +44,7 @@ Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=3 -testid=csis \
   -RealEncryption=1 -rs=4 -argstest rank 3
 
+# Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
   -D=4 -sim_length=60e6 $@
 
@@ -71,6 +72,7 @@ Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=3 -testid=csis_release \
   -RealEncryption=1 -rs=4 -argstest rank 3
 
+# Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
   -D=4 -sim_length=60e6 $@
 
@@ -96,6 +98,7 @@ Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=3 -testid=csis_enc \
   -RealEncryption=1 -rs=4 -argstest rank 3
 
+# Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
   -D=4 -sim_length=60e6 $@
 

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/test_scripts/mcs_mcc.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/test_scripts/mcs_mcc.sh
@@ -32,8 +32,9 @@ Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_audio_prj_conf \
 Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=mcs -rs=23
 
+# Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
-  -D=2 -sim_length=20e6 $@
+  -D=2 -sim_length=60e6 $@
 
 for PROCESS_ID in $PROCESS_IDS; do
   wait $PROCESS_ID || let "EXIT_CODE=$?"

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/test_scripts/media_controller.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/test_scripts/media_controller.sh
@@ -29,8 +29,9 @@ printf "\n\n======== Running media controller local_player test =========\n\n"
 Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=media_controller_local_player -rs=23
 
+# Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
-  -D=1 -sim_length=20e6 $@
+  -D=1 -sim_length=60e6 $@
 
 for PROCESS_ID in $PROCESS_IDS; do
   wait $PROCESS_ID || let "EXIT_CODE=$?"
@@ -44,8 +45,9 @@ Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_audio_prj_conf \
 Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=media_controller_server -rs=23
 
+# Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
-  -D=2 -sim_length=20e6 $@
+  -D=2 -sim_length=60e6 $@
 
 for PROCESS_ID in $PROCESS_IDS; do
   wait $PROCESS_ID || let "EXIT_CODE=$?"

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/test_scripts/mics.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/test_scripts/mics.sh
@@ -29,8 +29,9 @@ printf "\n\n======== Running MICS Server Only (API) test =========\n\n"
 Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=mics_server_only -rs=23
 
+# Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
-  -D=1 -sim_length=20e6 $@
+  -D=1 -sim_length=60e6 $@
 
 for PROCESS_ID in $PROCESS_IDS; do
   wait $PROCESS_ID || let "EXIT_CODE=$?"
@@ -44,8 +45,9 @@ Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_audio_prj_conf \
 Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=mics_client -rs=46
 
+# Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
-  -D=2 -sim_length=20e6 $@
+  -D=2 -sim_length=60e6 $@
 
 for PROCESS_ID in $PROCESS_IDS; do
   wait $PROCESS_ID || let "EXIT_CODE=$?"

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/test_scripts/vcs.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/test_scripts/vcs.sh
@@ -29,8 +29,9 @@ printf "\n\n======== Running VCS standalone (API) test =========\n\n"
 Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=vcs_standalone -rs=23
 
+# Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
-  -D=1 -sim_length=20e6 $@
+  -D=1 -sim_length=60e6 $@
 
 for PROCESS_ID in $PROCESS_IDS; do
   wait $PROCESS_ID || let "EXIT_CODE=$?"
@@ -44,8 +45,9 @@ Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_audio_prj_conf \
 Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=vcs_client -rs=46
 
+# Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
-  -D=2 -sim_length=20e6 $@
+  -D=2 -sim_length=60e6 $@
 
 for PROCESS_ID in $PROCESS_IDS; do
   wait $PROCESS_ID || let "EXIT_CODE=$?"


### PR DESCRIPTION
Increase the simulation lengths in the test scripts (where needed) to
be longer than the WAIT_TIME defined in common.h, so that simulations
will not end before the test has a chance to do proper time out.

Fix output of elapsed time in timeout message.

Signed-off-by: Asbjørn Sæbø <asbjorn.sabo@nordicsemi.no>