### PR TITLE
board: thingy53_nrf5340: Add option to set PMIC to PWM mode

### DIFF
--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
@@ -59,6 +59,15 @@
 		};
 	};
 
+	npm1100_force_pwm_mode: npm1100_force_pwm_mode {
+		compatible = "regulator-fixed-sync", "regulator-fixed";
+		label = "npm1100_force_pwm_mode";
+		regulator-name = "npm1100_force_pwm_mode";
+		enable-gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
+		status = "disabled";
+		regulator-boot-on;
+	};
+
 	vbatt {
 		compatible = "voltage-divider";
 		io-channels = <&adc 2>;


### PR DESCRIPTION
Add Kconfig option for thingy53 board to set PMIC to PWM mode
by setting GPIO pin high.

Signed-off-by: Jan Zyczkowski <jan.zyczkowski@nordicsemi.no>