### PR TITLE
 Modules: Percepio TraceRecorder: Update TraceRecorder module from v4.5.2 to v4.6.0(RC1)

### DIFF
--- a/modules/TraceRecorder/CMakeLists.txt
+++ b/modules/TraceRecorder/CMakeLists.txt
@@ -10,36 +10,69 @@ if(CONFIG_PERCEPIO_TRACERECORDER)
   zephyr_library_sources_ifdef(
     CONFIG_PERCEPIO_TRACERECORDER
     ${TRACERECORDER_DIR}/kernelports/Zephyr/trcKernelPort.c
-    ${TRACERECORDER_DIR}/trcInternalBuffer.c
+    ${TRACERECORDER_DIR}/trcAssert.c
+    ${TRACERECORDER_DIR}/trcCounter.c
+    ${TRACERECORDER_DIR}/trcDiagnostics.c
+    ${TRACERECORDER_DIR}/trcEntryTable.c
+    ${TRACERECORDER_DIR}/trcError.c
+    ${TRACERECORDER_DIR}/trcEvent.c
+    ${TRACERECORDER_DIR}/trcEventBuffer.c
+    ${TRACERECORDER_DIR}/trcExtension.c
+    ${TRACERECORDER_DIR}/trcHardwarePort.c
+    ${TRACERECORDER_DIR}/trcHeap.c
+    ${TRACERECORDER_DIR}/trcInternalEventBuffer.c
+    ${TRACERECORDER_DIR}/trcInterval.c
+    ${TRACERECORDER_DIR}/trcISR.c
+    ${TRACERECORDER_DIR}/trcMultiCoreEventBuffer.c
+    ${TRACERECORDER_DIR}/trcObject.c
+    ${TRACERECORDER_DIR}/trcPrint.c
+    ${TRACERECORDER_DIR}/trcStackMonitor.c
+    ${TRACERECORDER_DIR}/trcStateMachine.c
+    ${TRACERECORDER_DIR}/trcStaticBuffer.c
     ${TRACERECORDER_DIR}/trcStreamingRecorder.c
-    ${TRACERECORDER_DIR}/extras/SDK/trcSDK.c
+    ${TRACERECORDER_DIR}/trcString.c
+    ${TRACERECORDER_DIR}/trcTask.c
+    ${TRACERECORDER_DIR}/trcTimestamp.c
     )
 
-  if(CONFIG_PERCEPIO_RECORDER_TRC_RECORDER_STREAM_PORT_RTT)
+  if(CONFIG_PERCEPIO_TRC_CFG_STREAM_PORT_RTT)
     zephyr_library_sources(
-      ${TRACERECORDER_DIR}/kernelports/Zephyr/streamports/Jlink_RTT/trcStreamingPort.c
+      ${TRACERECORDER_DIR}/streamports/Jlink_RTT/trcStreamPort.c
     )
 
     zephyr_include_directories(
-      ${TRACERECORDER_DIR}/kernelports/Zephyr/streamports/Jlink_RTT/include/
+      ${TRACERECORDER_DIR}/kernelports/Zephyr/streamports/Jlink_RTT/config/
+      ${TRACERECORDER_DIR}/streamports/Jlink_RTT/include/
     )
   endif()
 
-  if(CONFIG_PERCEPIO_RECORDER_TRC_RECORDER_STREAM_PORT_ITM)
+  if(CONFIG_PERCEPIO_TRC_CFG_STREAM_PORT_ITM)
     zephyr_library_sources(
-      ${TRACERECORDER_DIR}/kernelports/Zephyr/streamports/ARM_ITM/trcStreamingPort.c
+      ${TRACERECORDER_DIR}/streamports/ARM_ITM/trcStreamPort.c
     )
 
     zephyr_include_directories(
-      ${TRACERECORDER_DIR}/kernelports/Zephyr/streamports/ARM_ITM/include/
+      ${TRACERECORDER_DIR}/kernelports/Zephyr/streamports/ARM_ITM/config/
+      ${TRACERECORDER_DIR}/streamports/ARM_ITM/include/
+    )
+  endif()
+
+  if(CONFIG_PERCEPIO_TRC_CFG_STREAM_PORT_RINGBUFFER)
+    zephyr_library_sources(
+      ${TRACERECORDER_DIR}/streamports/RingBuffer/trcStreamPort.c
+    )
+
+    zephyr_include_directories(
+      ${TRACERECORDER_DIR}/kernelports/Zephyr/streamports/RingBuffer/config/
+      ${TRACERECORDER_DIR}/streamports/RingBuffer/include/
     )
   endif()
 
   zephyr_include_directories(
     ${TRACERECORDER_DIR}/kernelports/Zephyr/include
     ${TRACERECORDER_DIR}/kernelports/Zephyr/config
+    ${TRACERECORDER_DIR}/kernelports/Zephyr/config/core
     ${TRACERECORDER_DIR}/include
-    ${TRACERECORDER_DIR}/extras/SDK/include
     )
 
 endif()

--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       groups:
         - crypto
     - name: TraceRecorderSource
-      revision: 36c577727642457b0db7274298a4b96558374832
+      revision: e8ca3b6a83d19b2fc4738a0d9607190436e5e452
       path: modules/debug/TraceRecorder
       groups:
         - debug


### PR DESCRIPTION
This update updates the TraceRecorder module from version v4.5.2
to v4.6.0(RC1). The primary motivation for this update is to
fix some breaking trace hook changes introduced into Zephyr
v2.7.99, which resulted in compilation errors when using the
v4.5.2 TraceRecorder module.

The update to v4.6.0 also introduce Snapshot tracing support,
extended kernel object naming, and a reworked configuration
scheme with better naming and layout in guiconfig.

Signed-off-by: Torbjörn Leksell <torbjorn.leksell@percepio.com>