### PR TITLE
modbus: serial: Fix incomplete transmission issue

### DIFF
--- a/subsys/modbus/modbus_serial.c
+++ b/subsys/modbus/modbus_serial.c
@@ -43,6 +43,14 @@ static void modbus_serial_tx_off(struct modbus_context *ctx)
 {
 	struct modbus_serial_config *cfg = ctx->cfg;
 
+	/* Must wait till the transmission is complete or
+	 * tranceiver could be disabled before all data has
+	 * been transmitted and message will be corrupted.
+	 */
+	while (!uart_irq_tx_complete(cfg->dev)) {
+
+	}
+
 	uart_irq_tx_disable(cfg->dev);
 	if (cfg->de != NULL) {
 		gpio_pin_set(cfg->de->port, cfg->de->pin, 0);


### PR DESCRIPTION
This patch is to fix an issue where the transceiver chip is
disabled before it has transmitted all data. This causes the
message to be corrupted because the last few bytes are missing.

The fix adds a check to make sure the transmission is completed
before disabling the transceiver.

Signed-off-by: Marius Scholtz <mariuss@ricelectronics.com>

Note: This problem was observed on the atmel sam chips and there will be a separate PR later to fix hardware specific issue that also causes modbus to fail.