### PR TITLE
drivers: serial: atmel_sam: Fix api to work with modbus

### DIFF
--- a/drivers/serial/uart_sam.c
+++ b/drivers/serial/uart_sam.c
@@ -219,7 +219,11 @@ static int uart_sam_irq_tx_ready(const struct device *dev)
 {
 	volatile Uart * const uart = DEV_CFG(dev)->regs;
 
-	return (uart->UART_SR & UART_SR_TXRDY);
+	/* Check that the transmitter is ready but only
+	 * return true if the interrupt is also enabled
+	 */
+	return (uart->UART_SR & UART_SR_TXRDY &&
+		uart->UART_IMR & UART_IMR_TXRDY);
 }
 
 static void uart_sam_irq_rx_enable(const struct device *dev)
@@ -240,7 +244,8 @@ static int uart_sam_irq_tx_complete(const struct device *dev)
 {
 	volatile Uart * const uart = DEV_CFG(dev)->regs;
 
-	return !(uart->UART_SR & UART_SR_TXRDY);
+	return (uart->UART_SR & UART_SR_TXRDY &&
+		uart->UART_IMR & UART_IMR_TXEMPTY);
 }
 
 static int uart_sam_irq_rx_ready(const struct device *dev)

--- a/drivers/serial/usart_sam.c
+++ b/drivers/serial/usart_sam.c
@@ -220,7 +220,11 @@ static int usart_sam_irq_tx_ready(const struct device *dev)
 {
 	volatile Usart * const usart = DEV_CFG(dev)->regs;
 
-	return (usart->US_CSR & US_CSR_TXRDY);
+	/* Check that the transmitter is ready but only
+	 * return true if the interrupt is also enabled
+	 */
+	return (usart->US_CSR & US_CSR_TXRDY &&
+		usart->US_IMR & US_IMR_TXRDY);
 }
 
 static void usart_sam_irq_rx_enable(const struct device *dev)
@@ -241,7 +245,8 @@ static int usart_sam_irq_tx_complete(const struct device *dev)
 {
 	volatile Usart * const usart = DEV_CFG(dev)->regs;
 
-	return !(usart->US_CSR & US_CSR_TXRDY);
+	return (usart->US_CSR & US_CSR_TXRDY &&
+		usart->US_CSR & US_CSR_TXEMPTY);
 }
 
 static int usart_sam_irq_rx_ready(const struct device *dev)


### PR DESCRIPTION
This patch adds fixes to the api so that it behaves as expected.
1 - The irq_tx_ready now only returns true if the tx interrupt is
enabled.
2 - The irq_tx_complete now functions as expected and returns true
only once all characters have been transmitted

Signed-off-by: Marius Scholtz <mariuss@ricelectronics.com>

Note that this patch in combination with this [patch](https://github.com/zephyrproject-rtos/zephyr/pull/42051) enable modbus to work correctly on atmel sam devices.