### PR TITLE
boards/intel_adsp_cavs25: Improve test coverage

### DIFF
--- a/boards/xtensa/intel_adsp_cavs25/intel_adsp_cavs25.yaml
+++ b/boards/xtensa/intel_adsp_cavs25/intel_adsp_cavs25.yaml
@@ -5,6 +5,6 @@ arch: xtensa
 toolchain:
   - zephyr
 testing:
-  only_tags:
-     - kernel
-     - sof
+  ignore_tags:
+     - net
+     - bluetooth

--- a/samples/userspace/hello_world_user/sample.yaml
+++ b/samples/userspace/hello_world_user/sample.yaml
@@ -14,4 +14,5 @@ common:
         - "Hello World from UserSpace! (.*)"
 tests:
   sample.helloworld:
+    filter: CONFIG_ARCH_HAS_USERSPACE
     tags: introduction


### PR DESCRIPTION
Remove the only_tags filter for the board and add ignore_tags for net
and bt.

Adds a filter to a userspace sample that didn't correctly filter on
usermode being Kconfiged.

Depends on #42020 and #42022 as I ran it, only 3 test failures now on cavs25

Signed-off-by: Tom Burdick <thomas.burdick@intel.com>