### PR TITLE
tests: k_heap_api: make alloc pending tests a bit more robust

### DIFF
--- a/tests/kernel/mem_heap/k_heap_api/src/test_kheap_api.c
+++ b/tests/kernel/mem_heap/k_heap_api/src/test_kheap_api.c
@@ -30,21 +30,35 @@ static void tIsr_kheap_alloc_nowait(void *data)
 
 static void thread_alloc_heap(void *p1, void *p2, void *p3)
 {
+	char *p;
+
 	k_timeout_t timeout = Z_TIMEOUT_MS(200);
 
-	char *p = (char *)k_heap_alloc(&k_heap_test, ALLOC_SIZE_2, timeout);
+	p = (char *)k_heap_alloc(&k_heap_test, ALLOC_SIZE_2, K_NO_WAIT);
 
-	zassert_not_null(p, "k_heap_alloc operation failed");
+	zassert_is_null(p, "k_heap_alloc should fail but did not");
+
+	p = (char *)k_heap_alloc(&k_heap_test, ALLOC_SIZE_2, timeout);
+
+	zassert_not_null(p, "k_heap_alloc failed to allocate memory");
+
 	k_heap_free(&k_heap_test, p);
 }
 
 static void thread_alloc_heap_null(void *p1, void *p2, void *p3)
 {
+	char *p;
+
 	k_timeout_t timeout = Z_TIMEOUT_MS(200);
 
-	char *p = (char *)k_heap_alloc(&k_heap_test, ALLOC_SIZE_2, timeout);
+	p = (char *)k_heap_alloc(&k_heap_test, ALLOC_SIZE_2, K_NO_WAIT);
 
-	zassert_is_null(p, "k_heap_alloc_null operation failed");
+	zassert_is_null(p, "k_heap_alloc should fail but did not");
+
+	p = (char *)k_heap_alloc(&k_heap_test, ALLOC_SIZE_2, timeout);
+
+	zassert_is_null(p, "k_heap_alloc should fail but did not");
+
 	k_heap_free(&k_heap_test, p);
 }
 
@@ -186,16 +200,26 @@ void test_kheap_alloc_in_isr_nowait(void)
  */
 void test_k_heap_alloc_pending(void)
 {
-	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
-					thread_alloc_heap, NULL, NULL, NULL,
-					K_PRIO_PREEMPT(5), 0, K_NO_WAIT);
-
+	/*
+	 * Allocate first to make sure subsequent allocations
+	 * either fail (K_NO_WAIT) or pend.
+	 */
 	char *p = (char *)k_heap_alloc(&k_heap_test, ALLOC_SIZE_2, K_NO_WAIT);
 
 	zassert_not_null(p, "k_heap_alloc operation failed");
 
-	/* make the child thread run */
-	k_msleep(1);
+	/* Create a thread which will pend on allocation */
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
+				      thread_alloc_heap, NULL, NULL, NULL,
+				      K_PRIO_PREEMPT(5), 0, K_NO_WAIT);
+
+	/* Sleep long enough for child thread to go into pending */
+	k_msleep(5);
+
+	/*
+	 * Free memory so the child thread can finish memory allocation
+	 * without failing.
+	 */
 	k_heap_free(&k_heap_test, p);
 
 	k_thread_join(tid, K_FOREVER);
@@ -213,19 +237,31 @@ void test_k_heap_alloc_pending(void)
  */
 void test_k_heap_alloc_pending_null(void)
 {
-	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
-					thread_alloc_heap_null, NULL, NULL, NULL,
-					K_PRIO_PREEMPT(5), 0, K_NO_WAIT);
-
+	/*
+	 * Allocate first to make sure subsequent allocations
+	 * either fail (K_NO_WAIT) or pend.
+	 */
 	char *p = (char *)k_heap_alloc(&k_heap_test, ALLOC_SIZE_1, K_NO_WAIT);
 	char *q = (char *)k_heap_alloc(&k_heap_test, 512, K_NO_WAIT);
 
 	zassert_not_null(p, "k_heap_alloc operation failed");
 	zassert_not_null(q, "k_heap_alloc operation failed");
-	/* make the child thread run */
-	k_msleep(1);
+
+	/* Create a thread which will pend on allocation */
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
+				      thread_alloc_heap_null, NULL, NULL, NULL,
+				      K_PRIO_PREEMPT(5), 0, K_NO_WAIT);
+
+	/* Sleep long enough for child thread to go into pending */
+	k_msleep(5);
+
+	/*
+	 * Free some memory but new thread will still not be able
+	 * to finish memory allocation without error.
+	 */
 	k_heap_free(&k_heap_test, q);
 
 	k_thread_join(tid, K_FOREVER);
+
 	k_heap_free(&k_heap_test, p);
 }


### PR DESCRIPTION
Both alloc_pending tests requires the main thread to utilize
the heap so that child threads must pend on memory allocations.
However, the previous implementation was not SMP friendly where
the child threads could run and succeeded in memory allocation
on other CPUs while the main thread continued to allocate
memory. The main thread would fail to allocate memory if
the child thread (on other CPU) has not freed the memory yet.
Not to mention that, in this scenario, the child thread was not
pending on memory allocation which defeated the purpose of
the test. So to fix this, make sure the main thread allocates
enough memory so future allocations must go into pending.
Also, check that the child thread cannot allocation memory
when first entered so it is actually going into pending.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>