### PR TITLE
doc: mention MIPS architecture support

### DIFF
--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -224,6 +224,8 @@ following target architectures:
 
 * :abbr:`ARC (Argonaut RISC Core)`
 
+* :abbr:`MIPS (Microprocessor without Interlocked Pipeline Stages)`
+
 * :abbr:`Nios II`
 
 * :abbr:`RISC-V`

--- a/doc/introduction/index.rst
+++ b/doc/introduction/index.rst
@@ -14,11 +14,11 @@ The Zephyr kernel supports multiple architectures, including:
  - ARMv7-A and ARMv8-A (Cortex-A, 32- and 64-bit)
  - ARMv7-R, ARMv8-R (Cortex-R, 32- and 64-bit)
  - Intel x86 (32- and 64-bit)
+ - MIPS (MIPS32 Release 1 specification)
  - NIOS II Gen 2
  - RISC-V (32- and 64-bit)
  - SPARC V8
  - Tensilica Xtensa
- - MIPS (MIPS32 Release 1 specification)
 
 The full list of supported boards based on these architectures can be found :ref:`here <boards>`.
 


### PR DESCRIPTION
MIPS architecture support was introduced in 0369998e612a ('arch: add MIPS architecture support') but at the moment MIPS support is not mentioned in docs.