### PR TITLE
boards: shields: Add Semtech SX1262MB2DAS board

### DIFF
--- a/boards/shields/semtech_sx1262mb2das/Kconfig.defconfig
+++ b/boards/shields/semtech_sx1262mb2das/Kconfig.defconfig
@@ -1,0 +1,13 @@
+# Copyright (c) 2022 Konstantinos Papadopoulos <kostas.papadopulos@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+if SHIELD_SEMTECH_SX1262MB2DAS
+
+if LORA
+
+config SPI
+	default y
+
+endif # LORA
+
+endif # SHIELD_SEMTECH_SX1262MB2DAS

--- a/boards/shields/semtech_sx1262mb2das/Kconfig.shield
+++ b/boards/shields/semtech_sx1262mb2das/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright (c) 2022 Konstantinos Papadopoulos <kostas.papadopulos@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+config SHIELD_SEMTECH_SX1262MB2DAS
+	def_bool $(shields_list_contains,semtech_sx1262mb2das)

--- a/boards/shields/semtech_sx1262mb2das/doc/index.rst
+++ b/boards/shields/semtech_sx1262mb2das/doc/index.rst
@@ -1,0 +1,58 @@
+.. _semtech_sx1262mb2das:
+
+Semtech SX1262MB2DAS LoRa Shield
+################################
+
+Overview
+********
+
+The Semtech SX1262MB2DAS LoRa shield is an Arduino
+compatible shield based on the SX1262 LoRa transceiver
+from Semtech.
+
+More information about the shield can be found
+at the `mbed SX1262MB2xAS website`_.
+
+Pins Assignment of the Semtech SX1262MB2DAS LoRa Shield
+=======================================================
+
++-----------------------+-----------------+
+| Shield Connector Pin  | Function        |
++=======================+=================+
+| A0                    | SX1262 RESET    |
++-----------------------+-----------------+
+| D3                    | SX1262 BUSY     |
++-----------------------+-----------------+
+| D5                    | SX1262 DIO1     |
++-----------------------+-----------------+
+| D7                    | SX1262 SPI NSS  |
++-----------------------+-----------------+
+| D8                    | SX1262 ANT SW   |
++-----------------------+-----------------+
+| D11                   | SX1262 SPI MOSI |
++-----------------------+-----------------+
+| D12                   | SX1262 SPI MISO |
++-----------------------+-----------------+
+| D13                   | SX1262 SPI SCK  |
++-----------------------+-----------------+
+
+The SX1262 signals DIO2 and DIO3 are not available at the shield connector.
+
+Requirements
+************
+
+This shield can only be used with a board which provides a configuration
+for Arduino connectors and defines node aliases for SPI and GPIO interfaces
+(see :ref:`shields` for more details).
+
+Programming
+***********
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/subsys/lorawan/class_a
+   :board: nucleo_f429zi
+   :shield: semtech_sx1262mb2das
+   :goals: build
+
+.. _mbed SX1262MB2xAS website:
+   https://os.mbed.com/components/SX126xMB2xAS/

--- a/boards/shields/semtech_sx1262mb2das/semtech_sx1262mb2das.overlay
+++ b/boards/shields/semtech_sx1262mb2das/semtech_sx1262mb2das.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022 Konstantinos Papadopoulos <kostas.papadopulos@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		lora0 = &lora;
+	};
+};
+
+&arduino_spi {
+	status = "okay";
+
+	cs-gpios = <&arduino_header 13 GPIO_ACTIVE_LOW>;
+
+	lora: sx1262@0 {
+		compatible = "semtech,sx1262";
+		reg = <0>;
+		spi-max-frequency = <16000000>;
+		label = "SX1262";
+		reset-gpios = <&arduino_header 0 GPIO_ACTIVE_LOW>;
+		busy-gpios = <&arduino_header 9 GPIO_ACTIVE_HIGH>;
+		antenna-enable-gpios = <&arduino_header 18 GPIO_ACTIVE_HIGH>;
+		dio1-gpios = <&arduino_header 11 GPIO_ACTIVE_HIGH>;
+		dio2-tx-enable;
+		tcxo-power-startup-delay-ms = <5>;
+	};
+};


### PR DESCRIPTION
Added the board but I cannot verify that is working.
Building with west build -p auto -b nucleo_l476rg samples/drivers/lora/send/ -DSHIELD=semtech_sx1262mb2das
This gives me this warning 

> warning: HAS_SEMTECH_RADIO_DRIVERS (defined at modules/loramac-node/Kconfig:10) has direct dependencies 0 with value n, but is currently being y-selected by the following symbols:
>  - LORA_SX12XX (defined at drivers/lora/Kconfig.sx12xx:13), with value y, direct dependencies SPI && LORA (value: y), and select condition SPI && LORA (value: y)
> 
> warning: HAS_SEMTECH_SX1272 (defined at modules/loramac-node/Kconfig:15) has direct dependencies HAS_SEMTECH_RADIO_DRIVERS && 0 with value n, but is currently being y-selected by the following symbols:
>  - LORA_SX127X (defined at drivers/lora/Kconfig.sx12xx:34), with value y, direct dependencies <choice> (value: y), and select condition <choice> (value: y)

Do I miss something ? I'm trying on fresh main branch and also tried with  -DSHIELD=semtech_sx1272mb2das