### PR TITLE
debug: Remove deprecated CONFIG_OPENOCD_SUPPORT

### DIFF
--- a/doc/releases/release-notes-3.0.rst
+++ b/doc/releases/release-notes-3.0.rst
@@ -75,6 +75,9 @@ Removed APIs in this release:
   is changed so that it more closely mimics the real UART controller,
   option is no longer necessary.
 
+* Removed Kconfig option ``CONFIG_OPENOCD_SUPPORT`` in favor of
+  ``CONFIG_DEBUG_THREAD_INFO``.
+
 Deprecated in this release:
 
 * :c:macro:`USBD_CFG_DATA_DEFINE` is deprecated in favor of utilizing

--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -552,11 +552,9 @@ class ZephyrBinaryRunner(abc.ABC):
     @property
     def thread_info_enabled(self) -> bool:
         '''Returns True if self.build_conf has
-        CONFIG_DEBUG_THREAD_INFO enabled. This supports the
-        CONFIG_OPENOCD_SUPPORT fallback as well for now.
+        CONFIG_DEBUG_THREAD_INFO enabled.
         '''
-        return (self.build_conf.getboolean('CONFIG_DEBUG_THREAD_INFO') or
-                self.build_conf.getboolean('CONFIG_OPENOCD_SUPPORT'))
+        return self.build_conf.getboolean('CONFIG_DEBUG_THREAD_INFO')
 
     @classmethod
     def dev_id_help(cls) -> str:

--- a/subsys/debug/CMakeLists.txt
+++ b/subsys/debug/CMakeLists.txt
@@ -1,11 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-if(CONFIG_OPENOCD_SUPPORT)
-  message(WARNING "CONFIG_OPENOCD_SUPPORT is deprecated
-  Please use DEBUG_THREAD_INFO instead."
-)
-endif()
-
 zephyr_sources_ifdef(
   CONFIG_DEBUG_THREAD_INFO
   thread_info.c

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -322,12 +322,6 @@ config EXCEPTION_STACK_TRACE
 #
 # Miscellaneous debugging options
 #
-config OPENOCD_SUPPORT
-	bool "OpenOCD support (DEPRECATED)"
-	select DEBUG_THREAD_INFO
-	help
-	  This is deprecated, please use DEBUG_THREAD_INFO instead.
-
 config DEBUG_THREAD_INFO
 	bool "Thread awareness support"
 	depends on !SMP

--- a/subsys/debug/thread_info.c
+++ b/subsys/debug/thread_info.c
@@ -122,15 +122,9 @@ size_t _kernel_thread_info_offsets[] = {
 	 * checked with _kernel_thread_info_num_offsets.
 	 */
 };
-extern size_t __attribute__((alias("_kernel_thread_info_offsets")))
-		_kernel_openocd_offsets;
 
 __attribute__((used, section(".dbg_thread_info")))
 size_t _kernel_thread_info_num_offsets = ARRAY_SIZE(_kernel_thread_info_offsets);
-extern size_t __attribute__((alias("_kernel_thread_info_num_offsets")))
-		_kernel_openocd_num_offsets;
 
 __attribute__((used, section(".dbg_thread_info")))
 uint8_t _kernel_thread_info_size_t_size = (uint8_t)sizeof(size_t);
-extern uint8_t __attribute__((alias("_kernel_thread_info_size_t_size")))
-		_kernel_openocd_size_t_size;


### PR DESCRIPTION
CONFIG_OPENOCD_SUPPORT was deprecated in favor of
CONFIG_DEBUG_THREAD_INFO in Zephyr v2.6.0 and can now be removed.

Signed-off-by: Maureen Helm <maureen.helm@intel.com>