### PR TITLE
west: spdx: Fix missing field in build results

### DIFF
--- a/scripts/west_commands/zspdx/writer.py
+++ b/scripts/west_commands/zspdx/writer.py
@@ -54,14 +54,17 @@ SPDXID: {pkg.cfg.spdxID}
 PackageDownloadLocation: NOASSERTION
 PackageLicenseConcluded: {pkg.concludedLicense}
 """)
-    for licFromFiles in pkg.licenseInfoFromFiles:
-        f.write(f"PackageLicenseInfoFromFiles: {licFromFiles}\n")
     f.write(f"""PackageLicenseDeclared: {pkg.cfg.declaredLicense}
 PackageCopyrightText: {pkg.cfg.copyrightText}
 """)
 
     # flag whether files analyzed / any files present
     if len(pkg.files) > 0:
+        if len(pkg.licenseInfoFromFiles) > 0:
+            for licFromFiles in pkg.licenseInfoFromFiles:
+                f.write(f"PackageLicenseInfoFromFiles: {licFromFiles}\n")
+        else:
+            f.write(f"PackageLicenseInfoFromFiles: NOASSERTION\n")
         f.write(f"FilesAnalyzed: true\nPackageVerificationCode: {pkg.verificationCode}\n\n")
     else:
         f.write(f"FilesAnalyzed: false\nPackageComment: Utility target; no files\n\n")


### PR DESCRIPTION
When using the west spdx functionality to create an SPDX SBOM
during a build, several SPDX Documents are created. In some
instances, the SPDX metadata field PackageLicenseInfoFromFiles
is required to be present according to the SPDX 2.2 spec, but is
being omitted from the build.spdx Document if no licenses were
detected.

This commit fixes this bug so that a NOASSERTION value is written
for this field for Packages that do not contain any detected
licenses.

Additionally, this ensures that Packages with a FilesAnalyzed
value of false do not have this field written, also in accordance
with the spec.

Fixes #42070

Signed-off-by: Steve Winslow <steve@swinslow.net>