### PR TITLE
actions: add label for MIPS architecture area

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -60,6 +60,9 @@
 "area: ARM64":
   - "arch/arm64/**/*"
   - "include/arch/arm64/**/*"
+"area: MIPS":
+  - "arch/mips/**/*"
+  - "include/arch/mips/**/*"
 "area: NIOS2":
   - "arch/nios2/**/*"
   - "include/arch/nios2/**/*"


### PR DESCRIPTION
Add automatic labeling of the MIPS arch area.
