### PR TITLE
soc: stm32l0: Clear LPSDSR when exiting STOP mode

### DIFF
--- a/soc/arm/st_stm32/stm32l0/power.c
+++ b/soc/arm/st_stm32/stm32l0/power.c
@@ -58,6 +58,7 @@ __weak void pm_power_state_exit_post_ops(struct pm_state_info info)
 	case PM_STATE_SUSPEND_TO_IDLE:
 		LL_LPM_DisableSleepOnExit();
 		LL_LPM_EnableSleep();
+		LL_PWR_SetRegulModeLP(LL_PWR_REGU_LPMODES_MAIN);
 
 		/* Restore the clock setup. */
 		stm32_clock_control_init(NULL);


### PR DESCRIPTION
Clear the LPSDSR bit of PWR_CR to restore the voltage regulator
mode when exiting from STOP mode. Leaving LPSDSR set can cause
cause stability issues because the MCU will enter low-power sleep mode
instead of normal sleep mode when the core idles and this is not what
the rest of the implementation expects.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/42092