### PR TITLE
Bluetooth: ISO: Add packet_sequence_number for each ISO channel

### DIFF
--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -122,6 +122,11 @@ struct bt_conn_iso {
 		uint8_t			bis_id;
 	};
 
+#if defined(CONFIG_BT_ISO_UNICAST) || defined(CONFIG_BT_ISO_BROADCASTER)
+	/** 16-bit sequence number that shall be incremented per SDU interval */
+	uint16_t seq_num;
+#endif /* CONFIG_BT_ISO_UNICAST) || CONFIG_BT_ISO_BROADCASTER */
+
 	/** Type of the ISO channel */
 	enum bt_iso_chan_type type;
 };

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -743,7 +743,7 @@ void bt_iso_recv(struct bt_conn *iso, struct net_buf *buf, uint8_t flags)
 int bt_iso_chan_send(struct bt_iso_chan *chan, struct net_buf *buf)
 {
 	struct bt_hci_iso_data_hdr *hdr;
-	static uint16_t sn;
+	struct bt_conn *iso_conn;
 
 	CHECKIF(!chan || !buf) {
 		BT_DBG("Invalid parameters: chan %p buf %p", chan, buf);
@@ -757,13 +757,15 @@ int bt_iso_chan_send(struct bt_iso_chan *chan, struct net_buf *buf)
 		return -ENOTCONN;
 	}
 
+	iso_conn = chan->iso;
+
 	hdr = net_buf_push(buf, sizeof(*hdr));
-	hdr->sn = sys_cpu_to_le16(sn++);
+	hdr->sn = sys_cpu_to_le16(iso_conn->iso.seq_num++);
 	hdr->slen = sys_cpu_to_le16(bt_iso_pkt_len_pack(net_buf_frags_len(buf)
 							- sizeof(*hdr),
 							BT_ISO_DATA_VALID));
 
-	return bt_conn_send_cb(chan->iso, buf, bt_iso_send_cb, NULL);
+	return bt_conn_send_cb(iso_conn, buf, bt_iso_send_cb, NULL);
 }
 
 static bool valid_chan_io_qos(const struct bt_iso_chan_io_qos *io_qos,
@@ -875,6 +877,9 @@ void hci_le_cis_established(struct net_buf *buf)
 	}
 
 	if (!evt->status) {
+		/* Reset sequence number */
+		iso->iso.seq_num = 0;
+
 		if (iso->role == BT_HCI_ROLE_PERIPHERAL) {
 			struct bt_iso_chan_io_qos *rx;
 			struct bt_iso_chan_io_qos *tx;
@@ -1934,8 +1939,11 @@ void hci_le_big_complete(struct net_buf *buf)
 
 	i = 0;
 	SYS_SLIST_FOR_EACH_CONTAINER(&big->bis_channels, bis, node) {
-		bis->iso->handle = sys_le16_to_cpu(evt->handle[i++]);
-		bt_conn_set_state(bis->iso, BT_CONN_CONNECTED);
+		struct bt_conn *iso_conn = bis->iso;
+
+		iso_conn->iso.seq_num = 0;
+		iso_conn->handle = sys_le16_to_cpu(evt->handle[i++]);
+		bt_conn_set_state(iso_conn, BT_CONN_CONNECTED);
 	}
 }
 


### PR DESCRIPTION
Instead of relying on a single globally increasing (but never
resetting) packet_sequence_number, it is now correctly
reset and incremented for each ISO channel.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

fixes https://github.com/zephyrproject-rtos/zephyr/issues/42083