### PR TITLE
net: sockets: Allow to build CAN sockets with offloading enabled

### DIFF
--- a/subsys/net/lib/sockets/CMakeLists.txt
+++ b/subsys/net/lib/sockets/CMakeLists.txt
@@ -13,9 +13,9 @@ zephyr_sources(
   getnameinfo.c
   sockets_misc.c
   )
-
-zephyr_sources_ifdef(CONFIG_NET_SOCKETS_CAN sockets_can.c)
 endif()
+
+zephyr_sources_ifdef(CONFIG_NET_SOCKETS_CAN         sockets_can.c)
 zephyr_sources_ifdef(CONFIG_NET_SOCKETS_PACKET      sockets_packet.c)
 zephyr_sources_ifdef(CONFIG_NET_SOCKETS_OFFLOAD     socket_offload.c)
 


### PR DESCRIPTION
There is no releavnce between CAN sockets and offloading that would
prevent one from working with another, therefore it's not right to
allow CAN sockets to be build only if offloading is disabled. Fix the
wrong dependency in socket CMakeLists.txt file.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>