### PR TITLE
tests: drivers: clock_control: Fix tests for nrf52832

### DIFF
--- a/tests/drivers/clock_control/clock_control_api/src/test_clock_control.c
+++ b/tests/drivers/clock_control/clock_control_api/src/test_clock_control.c
@@ -23,24 +23,34 @@ struct device_data {
 	uint32_t subsys_cnt;
 };
 
+#if DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_clock)
+static const struct device_subsys_data subsys_data[] = {
+	{
+		.subsys = CLOCK_CONTROL_NRF_SUBSYS_HF,
+		.startup_us =
+			IS_ENABLED(CONFIG_SOC_SERIES_NRF91X) ?
+				3000 : 500
+	},
+#ifndef CONFIG_SOC_NRF52832
+	/* On nrf52832 LF clock cannot be stopped because it leads
+	 * to RTC COUNTER register reset and that is unexpected by
+	 * system clock which is disrupted and may hang in the test.
+	 */
+	{
+		.subsys = CLOCK_CONTROL_NRF_SUBSYS_LF,
+		.startup_us = (CLOCK_CONTROL_NRF_K32SRC ==
+			NRF_CLOCK_LFCLK_RC) ? 1000 : 500000
+	}
+#endif /* !CONFIG_SOC_NRF52832 */
+};
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_clock) */
+
 static const struct device_data devices[] = {
 #if DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_clock)
 	{
 		.name = DT_LABEL(DT_INST(0, nordic_nrf_clock)),
-		.subsys_data =  (const struct device_subsys_data[]){
-			{
-				.subsys = CLOCK_CONTROL_NRF_SUBSYS_HF,
-				.startup_us =
-					IS_ENABLED(CONFIG_SOC_SERIES_NRF91X) ?
-						3000 : 400
-			},
-			{
-				.subsys = CLOCK_CONTROL_NRF_SUBSYS_LF,
-				.startup_us = (CLOCK_CONTROL_NRF_K32SRC ==
-					NRF_CLOCK_LFCLK_RC) ? 1000 : 500000
-			}
-		},
-		.subsys_cnt = CLOCK_CONTROL_NRF_TYPE_COUNT
+		.subsys_data =  subsys_data,
+		.subsys_cnt = ARRAY_SIZE(subsys_data)
 	}
 #endif
 };

--- a/tests/drivers/clock_control/nrf_clock_calibration/src/test_nrf_clock_calibration.c
+++ b/tests/drivers/clock_control/nrf_clock_calibration/src/test_nrf_clock_calibration.c
@@ -112,6 +112,14 @@ static void test_basic_clock_calibration(void)
 /* Test checks if calibration happens just after clock is enabled. */
 static void test_calibration_after_enabling_lfclk(void)
 {
+	if (IS_ENABLED(CONFIG_SOC_NRF52832)) {
+		/* On nrf52832 LF clock cannot be stopped because it leads
+		 * to RTC COUNTER register reset and that is unexpected by
+		 * system clock which is disrupted and may hang in the test.
+		 */
+		ztest_test_skip();
+	}
+
 	const struct device *clk_dev =
 		device_get_binding(DT_LABEL(DT_INST(0, nordic_nrf_clock)));
 	struct sensor_value value = { .val1 = 0, .val2 = 0 };


### PR DESCRIPTION
Fixes (actually disabling) tests which were failing on nrf52832. The root cause is in different HW behavior on nrf52832 where restarting LF clock clears RTC COUNTER register. It is unexpected and disrupts system clock leading to hanging.

Fixes #41806.