### PR TITLE
Bluetooth: MPL: Fix use of uninitialized command.param value

### DIFF
--- a/subsys/bluetooth/audio/mpl.c
+++ b/subsys/bluetooth/audio/mpl.c
@@ -2586,7 +2586,12 @@ void send_command(struct mpl_cmd command)
 {
 	struct mpl_cmd_ntf ntf;
 
-	BT_DBG("opcode: %d, param: %d", command.opcode, command.param);
+	if (command.use_param) {
+		BT_DBG("opcode: %d, param: %d", command.opcode, command.param);
+	} else {
+		command.param = 0; /* ensure that is set to 0 if not used */
+		BT_DBG("opcode: %d", command.opcode);
+	}
 
 	if (pl.state < BT_MCS_MEDIA_STATE_LAST) {
 		ntf.requested_opcode = command.opcode;


### PR DESCRIPTION
The command.param may not always be set in send_command
depending on whether command.use_param is set.

If command.use_param is not set, the command.param is
not logged, and is set to 0.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>