### PR TITLE
bluetooth: hci_raw: avoid possible memory overflow in bt_buf_get_tx()

### DIFF
--- a/subsys/bluetooth/host/hci_raw.c
+++ b/subsys/bluetooth/host/hci_raw.c
@@ -159,6 +159,11 @@ struct net_buf *bt_buf_get_tx(enum bt_buf_type type, k_timeout_t timeout,
 	bt_buf_set_type(buf, type);
 
 	if (data && size) {
+		if (net_buf_tailroom(buf) < size) {
+			net_buf_unref(buf);
+			return NULL;
+		}
+
 		net_buf_add_mem(buf, data, size);
 	}
 

--- a/subsys/usb/class/bluetooth.c
+++ b/subsys/usb/class/bluetooth.c
@@ -248,11 +248,21 @@ static void acl_read_cb(uint8_t ep, int size, void *priv)
 		if (IS_ENABLED(CONFIG_USB_DEVICE_BLUETOOTH_VS_H4) &&
 		    bt_hci_raw_get_mode() == BT_HCI_RAW_MODE_H4) {
 			buf = bt_buf_get_tx(BT_BUF_H4, K_FOREVER, data, size);
+			if (!buf) {
+				LOG_ERR("Failed to allocate buffer");
+				goto restart_out_transfer;
+			}
+
 			pkt_len = hci_pkt_get_len(buf, &data[1], size - 1);
 			LOG_DBG("pkt_len %u, chunk %u", pkt_len, size);
 		} else {
 			buf = bt_buf_get_tx(BT_BUF_ACL_OUT, K_FOREVER,
 					    data, size);
+			if (!buf) {
+				LOG_ERR("Failed to allocate buffer");
+				goto restart_out_transfer;
+			}
+
 			pkt_len = hci_pkt_get_len(buf, data, size);
 			LOG_DBG("pkt_len %u, chunk %u", pkt_len, size);
 		}

--- a/subsys/usb/class/bluetooth.c
+++ b/subsys/usb/class/bluetooth.c
@@ -273,6 +273,13 @@ static void acl_read_cb(uint8_t ep, int size, void *priv)
 			buf = NULL;
 		}
 	} else {
+		if (net_buf_tailroom(buf) < size) {
+			LOG_ERR("Buffer tailroom too small");
+			net_buf_unref(buf);
+			buf = NULL;
+			goto restart_out_transfer;
+		}
+
 		/*
 		 * Take over the next chunk if HCI packet is
 		 * larger than USB_MAX_FS_BULK_MPS.


### PR DESCRIPTION
bluetooth: hci_raw: avoid possible memory overflow in bt_buf_get_tx()

Function bt_buf_get_tx(), which is used to allocate buffer from
fixed-size pool, does not check size argument before copying
the data with the length size into fixed-size buffer, wich may
not be large enough.

Check immediately before copying if the tailroom of the buffer
is large enough.

---

usb: bluetooth: check buffer tailroom before copying

If HCI packet length is greater than endpoint MPS or currently
received data block (over USB), next block could be larger
than allocated net_buf buffer.

Check buffer tailroom before copying data using net_buf_add_mem().