### PR TITLE
Check if lwm2m attributes were previously set

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -2731,6 +2731,14 @@ static int lwm2m_write_attr_handler(struct lwm2m_engine_obj *obj,
 		return ret;
 	}
 
+	/* take default values, if not set before  */
+	if (nattrs.flags != BIT(LWM2M_ATTR_PMAX)) {
+		nattrs.pmax = lwm2m_server_get_pmax(msg->ctx->srv_obj_inst);
+	}
+	if (nattrs.flags != BIT(LWM2M_ATTR_PMIN)) {
+		nattrs.pmin = lwm2m_server_get_pmin(msg->ctx->srv_obj_inst);
+	}
+
 	/* loop through options to parse attribute */
 	for (i = 0; i < nr_opt; i++) {
 		int limit = MIN(options[i].len, 5), plen = 0, vlen;


### PR DESCRIPTION
When updating pmin/pmax values of an observation for the first time, the values for the pmin > pmax check are set to zero instead of the default values.
This leads to the problem, when updating only pmin -> pmin(=val) > pmax(=0) -> error

Signed-off-by: Paul Kajdewicz <paul.kajdewicz@grandcentrix.net>