### PR TITLE
fs: Add fs_is_open and fs_is_opendir functions

### DIFF
--- a/include/fs/fs.h
+++ b/include/fs/fs.h
@@ -274,6 +274,18 @@ static inline void fs_dir_t_init(struct fs_dir_t *zdp)
 int fs_open(struct fs_file_t *zfp, const char *file_name, fs_mode_t flags);
 
 /**
+ * @brief Check if file is open
+ *
+ * @param zfp Pointer to a file object
+ *
+ * @return true if @p zfp describes open file.
+ */
+static inline bool fs_is_open(const struct fs_file_t *zfp)
+{
+	return (zfp->mp != NULL);
+}
+
+/**
  * @brief Close file
  *
  * Flushes the associated stream and closes the file.
@@ -474,6 +486,18 @@ int fs_mkdir(const char *path);
  * @retval <0 a negative errno code on error.
  */
 int fs_opendir(struct fs_dir_t *zdp, const char *path);
+
+/**
+ * @brief Check if directory is open
+ *
+ * @param zdp Pointer to the directory object
+ *
+ * @return true if @p zdp describes open directly
+ */
+static inline bool fs_is_opendir(const struct fs_dir_t *zdp)
+{
+	return (zdp->mp != NULL || zdp->dirp != NULL);
+}
 
 /**
  * @brief Directory read entry

--- a/tests/subsys/fs/fs_api/src/main.c
+++ b/tests/subsys/fs/fs_api/src/main.c
@@ -90,6 +90,7 @@ void test_main(void)
 			 ztest_unit_test(test_file_rename),
 			 ztest_unit_test(test_file_stat),
 			 ztest_unit_test(test_file_unlink),
+			 ztest_unit_test(test_is_open),
 			 ztest_unit_test(test_unmount),
 			 ztest_unit_test_setup_teardown(test_mount_flags,
 							dummy_setup,

--- a/tests/subsys/fs/fs_api/src/test_fs.h
+++ b/tests/subsys/fs/fs_api/src/test_fs.h
@@ -56,4 +56,5 @@ void test_file_stat(void);
 void test_file_unlink(void);
 void test_unmount(void);
 void test_mount_flags(void);
+void test_is_open(void);
 #endif

--- a/tests/subsys/fs/fs_api/src/test_fs_dir_file.c
+++ b/tests/subsys/fs/fs_api/src/test_fs_dir_file.c
@@ -1031,3 +1031,51 @@ void test_file_unlink(void)
 
 	TC_PRINT("File (%s) deleted successfully!\n", TEST_FILE_RN);
 }
+
+void test_is_open(void)
+{
+	struct fs_dir_t diro;
+	struct fs_file_t fso;
+	int ret;
+
+	fs_dir_t_init(&diro);
+	fs_file_t_init(&fso);
+
+	zassert_false(fs_is_opendir(&diro), "Expected dir to be unopened");
+	zassert_false(fs_is_open(&fso), "Expected file to be unopened");
+
+	/* Open should fail */
+	ret = fs_open(&fso, NULL, FS_O_READ);
+	zassert_true(ret != 0, "Open should have failed");
+
+	/* File should remain unopened */
+	zassert_false(fs_is_open(&fso), "Expected file to remain closed");
+
+	ret = fs_open(&fso, TEST_FILE, FS_O_READ);
+	zassert_equal(ret, 0, "Fail to open file");
+	zassert_true(fs_is_open(&fso), "Expected file to be open");
+
+	fs_close(&fso);
+	zassert_false(fs_is_open(&fso), "Expected file to be closed");
+
+	/* Open should fail */
+	ret = fs_opendir(&diro, NULL);
+	zassert_not_equal(ret, 0, "Open dir with NULL pointer parameter");
+
+	/* Expected dir to remain unopened */
+	zassert_false(fs_is_opendir(&diro), "Expected dir to remain closed");
+
+	ret = fs_opendir(&diro, "/");
+	zassert_equal(ret, 0, "Fail to open root dir");
+
+	zassert_true(fs_is_opendir(&diro), "Expected dir to be opened");
+
+	fs_closedir(&diro);
+	zassert_false(fs_is_opendir(&diro), "Expected dir to be unopened");
+
+	ret = fs_opendir(&diro, TEST_DIR);
+	zassert_equal(ret, 0, "Fail to open dir");
+
+	zassert_true(fs_is_opendir(&diro), "Expected dir to be opened");
+	fs_closedir(&diro);
+}


### PR DESCRIPTION
The commit adds functions that allow to check whether file or dir
described by provided object is already open.
These functions allow user to check whether given file/dir object
is already tied with file/dir without need for additional state
variables.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>