### PR TITLE
mgmt: smp: Fix NULL pointer dereferences in UDP transport

### DIFF
--- a/subsys/mgmt/mcumgr/smp_udp.c
+++ b/subsys/mgmt/mcumgr/smp_udp.c
@@ -44,11 +44,13 @@ static struct configs configs = {
 #if CONFIG_MCUMGR_SMP_UDP_IPV4
 	.ipv4 = {
 		.proto = "IPv4",
+		.sock  = -1,
 	},
 #endif
 #if CONFIG_MCUMGR_SMP_UDP_IPV6
 	.ipv6 = {
 		.proto = "IPv6",
+		.sock  = -1,
 	},
 #endif
 };
@@ -204,7 +206,7 @@ int smp_udp_open(void)
 	memset(&addr4, 0, sizeof(addr4));
 	addr4.sin_family = AF_INET;
 	addr4.sin_port = htons(CONFIG_MCUMGR_SMP_UDP_PORT);
-	inet_pton(AF_INET, INADDR_ANY, &addr4.sin_addr);
+	addr4.sin_addr.s_addr = htonl(INADDR_ANY);
 
 	conf = &configs.ipv4;
 	conf->sock = create_socket((struct sockaddr *)&addr4, conf->proto);
@@ -240,13 +242,19 @@ int smp_udp_open(void)
 int smp_udp_close(void)
 {
 #if CONFIG_MCUMGR_SMP_UDP_IPV4
-	k_thread_abort(&(configs.ipv4.thread));
-	close(configs.ipv4.sock);
+	if (configs.ipv4.sock >= 0) {
+		k_thread_abort(&(configs.ipv4.thread));
+		close(configs.ipv4.sock);
+		configs.ipv4.sock = -1;
+	}
 #endif
 
 #if CONFIG_MCUMGR_SMP_UDP_IPV6
-	k_thread_abort(&(configs.ipv6.thread));
-	close(configs.ipv6.sock);
+	if (configs.ipv6.sock >= 0) {
+		k_thread_abort(&(configs.ipv6.thread));
+		close(configs.ipv6.sock);
+		configs.ipv6.sock = -1;
+	}
 #endif
 
 	return MGMT_ERR_EOK;


### PR DESCRIPTION
This PR fixes two `NULL` pointer dereferences in the SMP UDP transport. The first one occurs if the network manager sends `NET_EVENT_L4_DISCONNECTED` _before_ `NET_EVENT_L4_CONNECTED` (because, for example, another service has called `net_conn_mgr_resend_status()` during its initialization), which leads to `smp_udp_close()` attempting to `k_thread_abort()` an as-of-yet-uninitialized thread. The second one is due to an improper use of `inet_pton()` where `INADDR_ANY` is passed as if it's a dotted-decimal string, which leads to a `strlen()` call on `0`.
