### PR TITLE
soc/intel_adsp: DMA Stability fix for cavstool

### DIFF
--- a/soc/xtensa/intel_adsp/tools/cavstool.py
+++ b/soc/xtensa/intel_adsp/tools/cavstool.py
@@ -256,11 +256,14 @@ def load_firmware(fw_file):
         log.warning(f"Load failed?  FW_STATUS = 0x{dsp.SRAM_FW_STATUS:x}")
 
     # Turn DMA off and reset the stream.  Clearing START first is a
-    # noop per the spec, but required for early versions (apparently
-    # the reset doesn't stop the stream and the next load fails), and
-    # makes the load on 2.5 unstable.  Go figure.
-    if not cavs25:
-        sd.CTL &= ~2 # clear START
+    # noop per the spec, but absolutely required for stability.
+    # Apparently the reset doesn't stop the stream, and the next load
+    # starts before it's ready and kills the load (and often the DSP).
+    # The sleep too is required, on at least one board (a fast
+    # chromebook) putting the two writes next each other also hangs
+    # the DSP!
+    sd.CTL &= ~2 # clear START
+    time.sleep(0.1)
     sd.CTL |= 1
     log.info(f"cAVS firmware load complete")
 


### PR DESCRIPTION
There is a hardware bug with stream reset, it won't stop the stream.
I thought it was limited to just the early versions, but it turns out
that 2.5 has it too in some variants.  Which is frustrating, because
the TGL chromebook I have doesn't like the START clear.  But all
systems work with an extra delay between them, so do that.

Fixes #41862

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>