### PR TITLE
Bluetooth: Controller: Fix missing ISO data packet receive

### DIFF
--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -387,9 +387,9 @@ static inline struct net_buf *encode_node(struct node_rx_pdu *node_rx,
 		stream = ull_sync_iso_stream_get(node_rx->hdr.handle);
 
 		/* Check validity of the data path sink. FIXME: A channel disconnect race
-		 * may cause ISO data pending with without valid data path.
+		 * may cause ISO data pending without valid data path.
 		 */
-		if (stream && stream->dp && stream->dp->sink_hdl) {
+		if (stream && stream->dp) {
 			isoal_rx.meta = &node_rx->hdr.rx_iso_meta;
 			isoal_rx.pdu = (void *)node_rx->pdu;
 			err = isoal_rx_pdu_recombine(stream->dp->sink_hdl, &isoal_rx);

--- a/subsys/bluetooth/controller/ll_sw/ull_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso.c
@@ -238,7 +238,7 @@ uint8_t ll_setup_iso_path(uint16_t handle, uint8_t path_dir, uint8_t path_id,
 	stream_handle = handle - BT_CTLR_SYNC_ISO_STREAM_HANDLE_BASE;
 
 	stream = ull_sync_iso_stream_get(stream_handle);
-	if (stream->dp) {
+	if (!stream || stream->dp) {
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
 #endif /* CONFIG_BT_CTLR_CONN_ISO */
@@ -406,6 +406,10 @@ uint8_t ll_remove_iso_path(uint16_t handle, uint8_t path_dir)
 	stream_handle = handle - BT_CTLR_SYNC_ISO_STREAM_HANDLE_BASE;
 
 	stream = ull_sync_iso_stream_get(stream_handle);
+	if (!stream) {
+		return BT_HCI_ERR_CMD_DISALLOWED;
+	}
+
 	dp = stream->dp;
 	if (dp) {
 		stream->dp = NULL;

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
@@ -268,7 +268,11 @@ struct ll_sync_iso_set *ull_sync_iso_by_stream_get(uint16_t handle)
 
 struct lll_sync_iso_stream *ull_sync_iso_stream_get(uint16_t handle)
 {
-	if (handle >= CONFIG_BT_CTLR_SYNC_ISO_STREAM_COUNT) {
+	struct ll_sync_iso_set *sync_iso;
+
+	/* Get the BIG Sync context and check for not being terminated */
+	sync_iso = ull_sync_iso_by_stream_get(handle);
+	if (!sync_iso || !sync_iso->sync) {
 		return NULL;
 	}
 
@@ -287,6 +291,7 @@ void ull_sync_iso_stream_release(struct ll_sync_iso_set *sync_iso)
 
 		handle = lll->stream_handle[lll->stream_count];
 		stream = ull_sync_iso_stream_get(handle);
+		LL_ASSERT(stream);
 
 		dp = stream->dp;
 		if (dp) {


### PR DESCRIPTION
Fix missing ISO Data packet received by Synchronized
Receiver due to incorrect check on sink handle that did
not permit handle value of 0.

Regression introduced in commit 7c89f1fe9f2e ("Bluetooth:
controller: Support for separate ISO RX data path").

Fixes #41894.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>