### PR TITLE
Bluetooth: Controller: Use macro-defined sizes for array declarations

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_adv.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_adv.h
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "pdu.h"
+
 struct lll_adv_iso_stream {
 	uint8_t big_handle;
 
@@ -73,8 +75,8 @@ struct lll_adv_sync {
 	struct lll_hdr hdr;
 	struct lll_adv *adv;
 
-	uint8_t access_addr[4];
-	uint8_t crc_init[3];
+	uint8_t access_addr[PDU_ACCESS_ADDR_SIZE];
+	uint8_t crc_init[PDU_CRC_SIZE];
 
 	uint16_t latency_prepare;
 	uint16_t latency_event;

--- a/subsys/bluetooth/controller/ll_sw/lll_conn.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn.h
@@ -3,6 +3,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#include "pdu.h"
+
 #if defined(CONFIG_BT_CTLR_CONN_META)
 #include "lll_conn_meta.h"
 #endif /* CONFIG_BT_CTLR_CONN_META */
@@ -40,8 +43,8 @@ struct data_pdu_length {
 struct lll_conn {
 	struct lll_hdr hdr;
 
-	uint8_t access_addr[4];
-	uint8_t crc_init[3];
+	uint8_t access_addr[PDU_ACCESS_ADDR_SIZE];
+	uint8_t crc_init[PDU_CRC_SIZE];
 
 	uint16_t handle;
 	uint16_t interval;

--- a/subsys/bluetooth/controller/ll_sw/lll_sync.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_sync.h
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "pdu.h"
+
 /* Periodic advertisements synchronization status. */
 enum sync_status {
 	SYNC_STAT_ALLOWED,
@@ -14,8 +16,8 @@ enum sync_status {
 struct lll_sync {
 	struct lll_hdr hdr;
 
-	uint8_t access_addr[4];
-	uint8_t crc_init[3];
+	uint8_t access_addr[PDU_ACCESS_ADDR_SIZE];
+	uint8_t crc_init[PDU_CRC_SIZE];
 
 	uint8_t phy:3;
 	/* Bitmask providing not allowed types of CTE. */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
@@ -173,10 +173,10 @@ static int prepare_cb_common(struct lll_prepare_param *p)
 	uint32_t ticks_at_event;
 	uint32_t ticks_at_start;
 	uint16_t event_counter;
-	uint8_t access_addr[4];
+	uint8_t access_addr[PDU_ACCESS_ADDR_SIZE];
 	uint16_t data_chan_id;
 	uint8_t data_chan_use;
-	uint8_t crc_init[3];
+	uint8_t crc_init[PDU_CRC_SIZE];
 	struct pdu_bis *pdu;
 	struct ull_hdr *ull;
 	uint32_t remainder;
@@ -363,10 +363,10 @@ static void isr_tx_common(void *param,
 {
 	struct pdu_bis *pdu = NULL;
 	struct lll_adv_iso *lll;
-	uint8_t access_addr[4];
+	uint8_t access_addr[PDU_ACCESS_ADDR_SIZE];
 	uint16_t data_chan_id;
 	uint8_t data_chan_use;
-	uint8_t crc_init[3];
+	uint8_t crc_init[PDU_CRC_SIZE];
 	uint8_t bis;
 
 	lll = param;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
@@ -178,11 +178,11 @@ static int prepare_cb_common(struct lll_prepare_param *p)
 	uint32_t ticks_at_event;
 	uint32_t ticks_at_start;
 	uint16_t event_counter;
-	uint8_t access_addr[4];
+	uint8_t access_addr[PDU_ACCESS_ADDR_SIZE];
 	uint16_t data_chan_id;
 	uint8_t data_chan_use;
 	uint32_t remainder_us;
-	uint8_t crc_init[3];
+	uint8_t crc_init[PDU_CRC_SIZE];
 	struct ull_hdr *ull;
 	uint32_t remainder;
 	uint32_t hcto;
@@ -375,11 +375,11 @@ static void isr_rx(void *param)
 	struct node_rx_pdu *node_rx;
 	struct event_done_extra *e;
 	struct lll_sync_iso *lll;
-	uint8_t access_addr[4];
+	uint8_t access_addr[PDU_ACCESS_ADDR_SIZE];
 	uint16_t data_chan_id;
 	uint8_t data_chan_use;
 	uint8_t payload_index;
-	uint8_t crc_init[3];
+	uint8_t crc_init[PDU_CRC_SIZE];
 	uint8_t rssi_ready;
 	uint32_t start_us;
 	uint8_t new_burst;


### PR DESCRIPTION
This is a proposed implementation of enhancement
zephyrproject-rtos#40378

I've made declarations of access_addr uint8_t arrays use PDU_ACCESS_ADDR_SIZE for the array size; similarly, crc_init uint8_t arrray declarations now use PDU_CRC_SIZE as array size.  I've made the lll header files which use this include the pdu.h header or this definition.

Signed-off-by: Wolter HV <wolterhv@gmx.de>