### PR TITLE
twister: ignore unencodable unicode of west flash command.

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -838,7 +838,8 @@ class DeviceHandler(Handler):
             with subprocess.Popen(command, stderr=subprocess.PIPE, stdout=subprocess.PIPE) as proc:
                 try:
                     (stdout, stderr) = proc.communicate(timeout=30)
-                    logger.debug(stdout.decode())
+                    # ignore unencodable unicode chars
+                    logger.debug(stdout.decode(errors = "ignore"))
 
                     if proc.returncode != 0:
                         self.instance.reason = "Device issue (Flash?)"


### PR DESCRIPTION
sometimes there are some unencodable unicode chars from output
of west flash command, need to ignore them rather than reporting
an error.

this fix is from zephyr side, add handler to handle unencodable unicode chars in twister. 

fix: #42098 

Signed-off-by: Chen Peng1 <peng1.chen@intel.com>