### PR TITLE
drivers: net: ppp: asynch api: use microseconds

### DIFF
--- a/drivers/net/Kconfig
+++ b/drivers/net/Kconfig
@@ -111,11 +111,11 @@ config NET_PPP_ASYNC_UART_RX_RECOVERY_TIMEOUT
 	  when we cannot receive more data from UART.
 
 config NET_PPP_ASYNC_UART_RX_ENABLE_TIMEOUT
-	int "A timeout for uart_rx_enable()"
+	int "A timeout for uart_rx_enable() in milliseconds"
 	default 100
 
 config NET_PPP_ASYNC_UART_TX_TIMEOUT
-	int "A timeout for uart_tx()"
+	int "A timeout for uart_tx() in milliseconds"
 	default 100
 
 endif # NET_PPP_ASYNC_UART

--- a/drivers/net/ppp.c
+++ b/drivers/net/ppp.c
@@ -220,7 +220,7 @@ static int ppp_async_uart_rx_enable(struct ppp_driver_context *context)
 	}
 
 	err = uart_rx_enable(context->dev, context->buf, sizeof(context->buf),
-			     CONFIG_NET_PPP_ASYNC_UART_RX_ENABLE_TIMEOUT);
+			     CONFIG_NET_PPP_ASYNC_UART_RX_ENABLE_TIMEOUT * USEC_PER_MSEC);
 	if (err) {
 		LOG_ERR("uart_rx_enable() failed, err %d", err);
 	} else {
@@ -370,7 +370,8 @@ static int ppp_send_flush(struct ppp_driver_context *ppp, int off)
 
 		k_sem_take(&uarte_tx_finished, K_FOREVER);
 
-		ret = uart_tx(ppp->dev, buf, off, CONFIG_NET_PPP_ASYNC_UART_TX_TIMEOUT);
+		ret = uart_tx(ppp->dev, buf, off,
+			      CONFIG_NET_PPP_ASYNC_UART_TX_TIMEOUT * USEC_PER_MSEC);
 		if (ret) {
 			LOG_ERR("uart_tx() failed, err %d", ret);
 			k_sem_give(&uarte_tx_finished);


### PR DESCRIPTION
Updated uart_rx_enable() and uart_tx() to use timeout given
in microseconds. Previously argument was given in milliseconds.
API change was done in:
https://github.com/zephyrproject-rtos/zephyr/pull/39041

Signed-off-by: Jani Hirsimäki <jani.hirsimaki@nordicsemi.no>