### PR TITLE
stm32: pwm driver enables complementary output for timer channel

### DIFF
--- a/dts/bindings/pwm/st,stm32-pwm.yaml
+++ b/dts/bindings/pwm/st,stm32-pwm.yaml
@@ -26,9 +26,15 @@ properties:
 
     "#pwm-cells":
       const: 3
+      description: |
+        Number of items to expect in a PWM
+        - channel of the timer used for PWM
+        - period to set in ns
+        - flags : combination of standard flags like PWM_POLARITY_NORMAL
+          or specific flags like PWM_STM32_COMPLEMENTARY. As an example for channel2:
+           <&pwm1 2 100 (PWM_POLARITY_NORMAL | PWM_STM32_COMPLEMENTARY)>;
 
 pwm-cells:
   - channel
-# period in terms of nanoseconds
   - period
   - flags

--- a/include/drivers/pwm.h
+++ b/include/drivers/pwm.h
@@ -64,8 +64,12 @@ extern "C" {
 
 /**
  * @brief Provides a type to hold PWM configuration flags.
+ *
+ * The lower 8 bits are used for standard flags.
+ * The upper 8 bits are reserved for SoC specific flags.
  */
-typedef uint8_t pwm_flags_t;
+
+typedef uint16_t pwm_flags_t;
 
 /**
  * @typedef pwm_pin_set_t

--- a/include/dt-bindings/pwm/pwm.h
+++ b/include/dt-bindings/pwm/pwm.h
@@ -11,6 +11,7 @@
  * The `PWM_POLARITY_*` flags are used with pwm_pin_set_cycles(),
  * pwm_pin_set_usec(), pwm_pin_set_nsec() or pwm_pin_configure_capture() to
  * specify the polarity of a PWM pin.
+ * The flags are on the lower 8bits of the pwm_flags_t
  * @{
  */
 /** PWM pin normal polarity (active-high pulse). */

--- a/include/dt-bindings/pwm/stm32_pwm.h
+++ b/include/dt-bindings/pwm/stm32_pwm.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PWM_STM32_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_PWM_STM32_H_
+
+/**
+ * @name custom PWM complementary flags for output pins
+ * This flag can be used with any of the `pwm_pin_set_*` API calls to indicate
+ * that the PWM signal has to be routed to the complementary output channel.
+ * This feature is only available on certain SoC families, refer to the
+ * binding's documentation for more details.
+ * The custom flags are on the upper 8bits of the pwm_flags_t
+ * @{
+ */
+/** PWM complementary output pin is enabled */
+#define PWM_STM32_COMPLEMENTARY	(1U << 8)
+
+/** @cond INTERNAL_HIDDEN */
+#define PWM_STM32_COMPLEMENTARY_MASK	0x100
+/** @endcond */
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_PWM_STM32_H_ */

--- a/samples/basic/blinky_pwm/boards/nucleo_l4r5zi.overlay
+++ b/samples/basic/blinky_pwm/boards/nucleo_l4r5zi.overlay
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2022 STMicroelectronics
+ */
+
+#include <dt-bindings/pwm/pwm.h>
+#include <dt-bindings/pwm/stm32_pwm.h>
+
+/ {
+	pwmleds {
+		compatible = "pwm-leds";
+
+		red_pwm_led: red_pwm_led {
+			pwms = <&pwm1 2 4 (PWM_POLARITY_NORMAL | PWM_STM32_COMPLEMENTARY)>;
+		};
+	};
+
+	aliases {
+		pwm-led0 = &red_pwm_led;
+	};
+};
+
+&timers1 {
+	status = "okay";
+
+	pwm1: pwm {
+		status = "okay";
+		pinctrl-0 = <&tim1_ch2n_pb14>;
+		pinctrl-names = "default";
+	};
+};


### PR DESCRIPTION
with this PR, the complementary PWM output is enabled when the pin is choosen in the DTS of the target

Using a newly defined PWM_COMPLEMENTARY flag in the target board DTS as follows:
```
		red_pwm_led: red_pwm_led {
			pwms = <&pwm1 2 4 (PWM_POLARITY_NORMAL | PWM_COMPLEMENTARY)>;
		};
```

- At this time, only used by the stm32 mcus
- Does not impact the PWM input capture.


Fixes https://github.com/zephyrproject-rtos/zephyr/issues/40657

Signed-off-by: Francois Ramu <francois.ramu@st.com>

