### PR TITLE
i2c: fix shell commands and do not print colon when no description

### DIFF
--- a/drivers/i2c/i2c_shell.c
+++ b/drivers/i2c/i2c_shell.c
@@ -243,22 +243,24 @@ static void device_name_get(size_t idx, struct shell_static_entry *entry)
 }
 
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_i2c_cmds,
-			       SHELL_CMD(scan, &dsub_device_name,
-					 "Scan I2C devices", cmd_i2c_scan),
-			       SHELL_CMD(recover, &dsub_device_name,
-					 "Recover I2C bus", cmd_i2c_recover),
+			       SHELL_CMD_ARG(scan, &dsub_device_name,
+					     "Scan I2C devices",
+					     cmd_i2c_scan, 2, 0),
+			       SHELL_CMD_ARG(recover, &dsub_device_name,
+					     "Recover I2C bus",
+					     cmd_i2c_recover, 2, 0),
 			       SHELL_CMD_ARG(read, &dsub_device_name,
 					     "Read bytes from an I2C device",
-					     cmd_i2c_read, 3, MAX_I2C_BYTES),
+					     cmd_i2c_read, 4, MAX_I2C_BYTES),
 			       SHELL_CMD_ARG(read_byte, &dsub_device_name,
 					     "Read a byte from an I2C device",
-					     cmd_i2c_read_byte, 3, 1),
+					     cmd_i2c_read_byte, 4, 1),
 			       SHELL_CMD_ARG(write, &dsub_device_name,
 					     "Write bytes to an I2C device",
-					     cmd_i2c_write, 3, MAX_I2C_BYTES),
+					     cmd_i2c_write, 4, MAX_I2C_BYTES),
 			       SHELL_CMD_ARG(write_byte, &dsub_device_name,
 					     "Write a byte to an I2C device",
-					     cmd_i2c_write_byte, 4, 1),
+					     cmd_i2c_write_byte, 5, 0),
 			       SHELL_SUBCMD_SET_END     /* Array terminated. */
 			       );
 

--- a/subsys/shell/shell_help.c
+++ b/subsys/shell/shell_help.c
@@ -119,23 +119,27 @@ static void help_item_print(const struct shell *shell, const char *item_name,
 	if (!IS_ENABLED(CONFIG_NEWLIB_LIBC) &&
 	    !IS_ENABLED(CONFIG_ARCH_POSIX)) {
 		/* print option name */
-		z_shell_fprintf(shell, SHELL_NORMAL, "%s%-*s%s:", tabulator,
-				item_name_width, item_name, tabulator);
+		z_shell_fprintf(shell, SHELL_NORMAL, "%s%-*s", tabulator,
+				item_name_width, item_name);
 	} else {
 		uint16_t tmp = item_name_width - strlen(item_name);
 		char space = ' ';
 
 		z_shell_fprintf(shell, SHELL_NORMAL, "%s%s", tabulator,
 				item_name);
-		for (uint16_t i = 0; i < tmp; i++) {
-			z_shell_write(shell, &space, 1);
+
+		if (item_help) {
+			for (uint16_t i = 0; i < tmp; i++) {
+				z_shell_write(shell, &space, 1);
+			}
 		}
-		z_shell_fprintf(shell, SHELL_NORMAL, "%s:", tabulator);
 	}
 
 	if (item_help == NULL) {
 		z_cursor_next_line_move(shell);
 		return;
+	} else {
+		z_shell_fprintf(shell, SHELL_NORMAL, "%s:", tabulator);
 	}
 	/* print option help */
 	formatted_text_print(shell, item_help, offset, false);


### PR DESCRIPTION
First fix is for i2c shell commands. Scan and recovery commands wasn't declared using _ARG macro, which resulted in improper call and dereference of invalid object. Other functions didn't count the subcommand name which is sent as argv[0].

Second fix removes printing of colon in help, after command argument, when there is no description for this argument.