### PR TITLE
drivers: spi_gecko: fix duplicated variable declaration

### DIFF
--- a/drivers/spi/spi_gecko.c
+++ b/drivers/spi/spi_gecko.c
@@ -173,7 +173,6 @@ static void spi_gecko_xfer(const struct device *dev,
 	struct spi_gecko_data *data = dev->data;
 	struct spi_context *ctx = &data->ctx;
 	const struct spi_gecko_config *gecko_config = dev->config;
-	struct spi_gecko_data *data = dev->data;
 
 	spi_context_cs_control(ctx, true);
 


### PR DESCRIPTION
The commit 44679c7bd86c5a7f7caf58f8ce66f30a360baf27 introduced this
duplicated declaration of the local variable data.

This commit fixes this issue.

Fixes #42117

Signed-off-by: Christian Taedcke <christian.taedcke@lemonbeat.com>