### PR TITLE
net: ipv4: Rejoin IPv4 multicast groups when iface is brought up

### DIFF
--- a/include/net/igmp.h
+++ b/include/net/igmp.h
@@ -38,7 +38,14 @@ extern "C" {
 #if defined(CONFIG_NET_IPV4_IGMP)
 int net_ipv4_igmp_join(struct net_if *iface, const struct in_addr *addr);
 #else
-#define net_ipv4_igmp_join(iface, addr) -ENOSYS
+static inline int net_ipv4_igmp_join(struct net_if *iface,
+				     const struct in_addr *addr)
+{
+	ARG_UNUSED(iface);
+	ARG_UNUSED(addr);
+
+	return -ENOSYS;
+}
 #endif
 
 /**
@@ -52,7 +59,14 @@ int net_ipv4_igmp_join(struct net_if *iface, const struct in_addr *addr);
 #if defined(CONFIG_NET_IPV4_IGMP)
 int net_ipv4_igmp_leave(struct net_if *iface, const struct in_addr *addr);
 #else
-#define net_ipv4_igmp_leave(iface, addr) -ENOSYS
+static inline int net_ipv4_igmp_leave(struct net_if *iface,
+				      const struct in_addr *addr)
+{
+	ARG_UNUSED(iface);
+	ARG_UNUSED(addr);
+
+	return -ENOSYS;
+}
 #endif
 
 #ifdef __cplusplus

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -14,6 +14,7 @@ LOG_MODULE_REGISTER(net_if, CONFIG_NET_IF_LOG_LEVEL);
 #include <syscall_handler.h>
 #include <stdlib.h>
 #include <string.h>
+#include <net/igmp.h>
 #include <net/net_core.h>
 #include <net/net_pkt.h>
 #include <net/net_if.h>
@@ -3791,7 +3792,27 @@ static void iface_ipv4_init(int if_count)
 	}
 }
 
+static void leave_ipv4_mcast_all(struct net_if *iface)
+{
+	struct net_if_ipv4 *ipv4 = iface->config.ip.ipv4;
+	int i;
+
+	if (!ipv4) {
+		return;
+	}
+
+	for (i = 0; i < NET_IF_MAX_IPV4_MADDR; i++) {
+		if (!ipv4->mcast[i].is_used ||
+		    !ipv4->mcast[i].is_joined) {
+			continue;
+		}
+
+		net_ipv4_igmp_leave(iface, &ipv4->mcast[i].address.in_addr);
+	}
+}
+
 #else
+#define leave_ipv4_mcast_all(...)
 #define iface_ipv4_init(...)
 
 struct net_if_mcast_addr *net_if_ipv4_maddr_lookup(const struct in_addr *addr,
@@ -4065,6 +4086,7 @@ int net_if_down(struct net_if *iface)
 	k_mutex_lock(&lock, K_FOREVER);
 
 	leave_mcast_all(iface);
+	leave_ipv4_mcast_all(iface);
 
 	if (net_if_is_ip_offloaded(iface)) {
 		goto done;

--- a/subsys/net/lib/dns/Kconfig
+++ b/subsys/net/lib/dns/Kconfig
@@ -191,6 +191,8 @@ config LLMNR_RESPONDER
 	bool "LLMNR responder"
 	select NET_IPV4_IGMP if NET_IPV4
 	select NET_IPV6_MLD if NET_IPV6
+	select NET_MGMT
+	select NET_MGMT_EVENT
 	depends on NET_HOSTNAME_ENABLE
 	help
 	  This option enables the LLMNR responder support for Zephyr.

--- a/subsys/net/lib/dns/Kconfig
+++ b/subsys/net/lib/dns/Kconfig
@@ -126,6 +126,8 @@ config MDNS_RESPONDER
 	bool "mDNS responder"
 	select NET_IPV4_IGMP if NET_IPV4
 	select NET_IPV6_MLD if NET_IPV6
+	select NET_MGMT
+	select NET_MGMT_EVENT
 	depends on NET_HOSTNAME_ENABLE
 	help
 	  This option enables the mDNS responder support for Zephyr.

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -39,10 +39,13 @@ LOG_MODULE_REGISTER(net_mdns_responder, CONFIG_MDNS_RESPONDER_LOG_LEVEL);
 
 #if defined(CONFIG_NET_IPV4)
 static struct net_context *ipv4;
+static struct sockaddr_in local_addr4;
 #endif
 #if defined(CONFIG_NET_IPV6)
 static struct net_context *ipv6;
 #endif
+
+static struct net_mgmt_event_callback mgmt_cb;
 
 #define BUF_ALLOC_TIMEOUT K_MSEC(100)
 
@@ -77,6 +80,22 @@ static void create_ipv4_addr(struct sockaddr_in *addr)
 
 	/* Well known IPv4 224.0.0.251 address */
 	addr->sin_addr.s_addr = htonl(0xE00000FB);
+}
+
+static void mdns_iface_event_handler(struct net_mgmt_event_callback *cb,
+				     uint32_t mgmt_event, struct net_if *iface)
+
+{
+	if (mgmt_event == NET_EVENT_IF_UP) {
+#if defined(CONFIG_NET_IPV4)
+		int ret = net_ipv4_igmp_join(iface, &local_addr4.sin_addr);
+
+		if (ret < 0) {
+			NET_DBG("Cannot add IPv4 multicast address to iface %p",
+				iface);
+		}
+#endif /* defined(CONFIG_NET_IPV4) */
+	}
 }
 
 int setup_dst_addr(struct net_context *ctx, struct net_pkt *pkt,
@@ -631,14 +650,12 @@ ipv6_out:
 
 #if defined(CONFIG_NET_IPV4)
 	do {
-		static struct sockaddr_in local_addr;
-
-		setup_ipv4_addr(&local_addr);
+		setup_ipv4_addr(&local_addr4);
 
 		ipv4 = get_ctx(AF_INET);
 
-		ret = bind_ctx(ipv4, (struct sockaddr *)&local_addr,
-			       sizeof(local_addr));
+		ret = bind_ctx(ipv4, (struct sockaddr *)&local_addr4,
+			       sizeof(local_addr4));
 		if (ret < 0) {
 			net_context_put(ipv4);
 			goto ipv4_out;
@@ -665,6 +682,11 @@ ipv4_out:
 static int mdns_responder_init(const struct device *dev)
 {
 	ARG_UNUSED(dev);
+
+	net_mgmt_init_event_callback(&mgmt_cb, mdns_iface_event_handler,
+				     NET_EVENT_IF_UP);
+
+	net_mgmt_add_event_callback(&mgmt_cb);
 
 	return init_listener();
 }


### PR DESCRIPTION
Make sure IPv4 multicast groups are rejoined when interface is brought up (and left when it goes down).

Fixes #39096