### PR TITLE
drivers: serial: drop uart_device_config

### DIFF
--- a/drivers/serial/uart_altera_jtag_hal.c
+++ b/drivers/serial/uart_altera_jtag_hal.c
@@ -26,10 +26,7 @@ extern int altera_avalon_jtag_uart_write(altera_avalon_jtag_uart_state *sp,
 static void uart_altera_jtag_poll_out(const struct device *dev,
 					       unsigned char c)
 {
-	const struct uart_device_config *config;
 	altera_avalon_jtag_uart_state ustate;
-
-	config = dev->config;
 
 	ustate.base = JTAG_UART_0_BASE;
 	altera_avalon_jtag_uart_write(&ustate, &c, 1, 0);
@@ -51,12 +48,6 @@ static const struct uart_driver_api uart_altera_jtag_driver_api = {
 	.err_check = NULL,
 };
 
-static const struct uart_device_config uart_altera_jtag_dev_cfg_0 = {
-	.base = (void *)JTAG_UART_0_BASE,
-	.sys_clk_freq = 0, /* Unused */
-};
-
-DEVICE_DT_INST_DEFINE(0, uart_altera_jtag_init, NULL,
-		      NULL, &uart_altera_jtag_dev_cfg_0,
-		      PRE_KERNEL_1, CONFIG_SERIAL_INIT_PRIORITY,
+DEVICE_DT_INST_DEFINE(0, uart_altera_jtag_init, NULL, NULL, NULL, PRE_KERNEL_1,
+		      CONFIG_SERIAL_INIT_PRIORITY,
 		      &uart_altera_jtag_driver_api);

--- a/drivers/serial/uart_cc32xx.c
+++ b/drivers/serial/uart_cc32xx.c
@@ -17,6 +17,14 @@
 #include <driverlib/prcm.h>
 #include <driverlib/uart.h>
 
+struct uart_cc32xx_dev_config {
+	unsigned long base;
+	uint32_t sys_clk_freq;
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	uart_irq_config_func_t irq_config_func;
+#endif
+};
+
 struct uart_cc32xx_dev_data_t {
 	uint32_t prcm;
 	uint32_t baud_rate;
@@ -42,7 +50,7 @@ static void uart_cc32xx_isr(const struct device *dev);
  */
 static int uart_cc32xx_init(const struct device *dev)
 {
-	const struct uart_device_config *config = dev->config;
+	const struct uart_cc32xx_dev_config *config = dev->config;
 	const struct uart_cc32xx_dev_data_t *data = dev->data;
 
 	MAP_PRCMPeripheralClkEnable(data->prcm,
@@ -51,19 +59,18 @@ static int uart_cc32xx_init(const struct device *dev)
 	MAP_PRCMPeripheralReset(data->prcm);
 
 	/* This also calls MAP_UARTEnable() to enable the FIFOs: */
-	MAP_UARTConfigSetExpClk((unsigned long)config->base,
+	MAP_UARTConfigSetExpClk(config->base,
 				MAP_PRCMPeripheralClockGet(data->prcm),
 				data->baud_rate,
 				(UART_CONFIG_WLEN_8 | UART_CONFIG_STOP_ONE
 				 | UART_CONFIG_PAR_NONE));
-	MAP_UARTFlowControlSet((unsigned long)config->base,
-			       UART_FLOWCONTROL_NONE);
+	MAP_UARTFlowControlSet(config->base, UART_FLOWCONTROL_NONE);
 	/* Re-disable the FIFOs: */
-	MAP_UARTFIFODisable((unsigned long)config->base);
+	MAP_UARTFIFODisable(config->base);
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	/* Clear any pending UART RX interrupts: */
-	MAP_UARTIntClear((unsigned long)config->base, UART_INT_RX);
+	MAP_UARTIntClear(config->base, UART_INT_RX);
 
 	config->irq_config_func(dev);
 
@@ -71,17 +78,17 @@ static int uart_cc32xx_init(const struct device *dev)
 	 * with first tx fifo empty interrupt when they first call
 	 * uart_irq_tx_enable().
 	 */
-	MAP_UARTCharPutNonBlocking((unsigned long)config->base, PRIME_CHAR);
+	MAP_UARTCharPutNonBlocking(config->base, PRIME_CHAR);
 #endif
 	return 0;
 }
 
 static int uart_cc32xx_poll_in(const struct device *dev, unsigned char *c)
 {
-	const struct uart_device_config *config = dev->config;
+	const struct uart_cc32xx_dev_config *config = dev->config;
 
-	if (MAP_UARTCharsAvail((unsigned long)config->base)) {
-		*c = MAP_UARTCharGetNonBlocking((unsigned long)config->base);
+	if (MAP_UARTCharsAvail(config->base)) {
+		*c = MAP_UARTCharGetNonBlocking(config->base);
 	} else {
 		return (-1);
 	}
@@ -90,18 +97,18 @@ static int uart_cc32xx_poll_in(const struct device *dev, unsigned char *c)
 
 static void uart_cc32xx_poll_out(const struct device *dev, unsigned char c)
 {
-	const struct uart_device_config *config = dev->config;
+	const struct uart_cc32xx_dev_config *config = dev->config;
 
-	MAP_UARTCharPut((unsigned long)config->base, c);
+	MAP_UARTCharPut(config->base, c);
 }
 
 static int uart_cc32xx_err_check(const struct device *dev)
 {
-	const struct uart_device_config *config = dev->config;
+	const struct uart_cc32xx_dev_config *config = dev->config;
 	unsigned long cc32xx_errs = 0L;
 	unsigned int z_err = 0U;
 
-	cc32xx_errs = MAP_UARTRxErrorGet((unsigned long)config->base);
+	cc32xx_errs = MAP_UARTRxErrorGet(config->base);
 
 	/* Map cc32xx SDK uart.h defines to zephyr uart.h defines */
 	z_err = ((cc32xx_errs & UART_RXERROR_OVERRUN) ?
@@ -110,7 +117,7 @@ static int uart_cc32xx_err_check(const struct device *dev)
 		((cc32xx_errs & UART_RXERROR_PARITY) ? UART_ERROR_PARITY : 0) |
 		((cc32xx_errs & UART_RXERROR_FRAMING) ? UART_ERROR_FRAMING : 0);
 
-	MAP_UARTRxErrorClear((unsigned long)config->base);
+	MAP_UARTRxErrorClear(config->base);
 
 	return (int)z_err;
 }
@@ -121,13 +128,12 @@ static int uart_cc32xx_fifo_fill(const struct device *dev,
 				 const uint8_t *tx_data,
 				 int size)
 {
-	const struct uart_device_config *config = dev->config;
+	const struct uart_cc32xx_dev_config *config = dev->config;
 	unsigned int num_tx = 0U;
 
 	while ((size - num_tx) > 0) {
 		/* Send a character */
-		if (MAP_UARTCharPutNonBlocking((unsigned long)config->base,
-					       tx_data[num_tx])) {
+		if (MAP_UARTCharPutNonBlocking(config->base, tx_data[num_tx])) {
 			num_tx++;
 		} else {
 			break;
@@ -140,15 +146,15 @@ static int uart_cc32xx_fifo_fill(const struct device *dev,
 static int uart_cc32xx_fifo_read(const struct device *dev, uint8_t *rx_data,
 				 const int size)
 {
-	const struct uart_device_config *config = dev->config;
+	const struct uart_cc32xx_dev_config *config = dev->config;
 	unsigned int num_rx = 0U;
 
 	while (((size - num_rx) > 0) &&
-		MAP_UARTCharsAvail((unsigned long)config->base)) {
+		MAP_UARTCharsAvail(config->base)) {
 
 		/* Receive a character */
 		rx_data[num_rx++] =
-			MAP_UARTCharGetNonBlocking((unsigned long)config->base);
+			MAP_UARTCharGetNonBlocking(config->base);
 	}
 
 	return num_rx;
@@ -156,56 +162,56 @@ static int uart_cc32xx_fifo_read(const struct device *dev, uint8_t *rx_data,
 
 static void uart_cc32xx_irq_tx_enable(const struct device *dev)
 {
-	const struct uart_device_config *config = dev->config;
+	const struct uart_cc32xx_dev_config *config = dev->config;
 
-	MAP_UARTIntEnable((unsigned long)config->base, UART_INT_TX);
+	MAP_UARTIntEnable(config->base, UART_INT_TX);
 }
 
 static void uart_cc32xx_irq_tx_disable(const struct device *dev)
 {
-	const struct uart_device_config *config = dev->config;
+	const struct uart_cc32xx_dev_config *config = dev->config;
 
-	MAP_UARTIntDisable((unsigned long)config->base, UART_INT_TX);
+	MAP_UARTIntDisable(config->base, UART_INT_TX);
 }
 
 static int uart_cc32xx_irq_tx_ready(const struct device *dev)
 {
-	const struct uart_device_config *config = dev->config;
+	const struct uart_cc32xx_dev_config *config = dev->config;
 	unsigned int int_status;
 
-	int_status = MAP_UARTIntStatus((unsigned long)config->base, 1);
+	int_status = MAP_UARTIntStatus(config->base, 1);
 
 	return (int_status & UART_INT_TX);
 }
 
 static void uart_cc32xx_irq_rx_enable(const struct device *dev)
 {
-	const struct uart_device_config *config = dev->config;
+	const struct uart_cc32xx_dev_config *config = dev->config;
 
 	/* FIFOs are left disabled from reset, so UART_INT_RT flag not used. */
-	MAP_UARTIntEnable((unsigned long)config->base, UART_INT_RX);
+	MAP_UARTIntEnable(config->base, UART_INT_RX);
 }
 
 static void uart_cc32xx_irq_rx_disable(const struct device *dev)
 {
-	const struct uart_device_config *config = dev->config;
+	const struct uart_cc32xx_dev_config *config = dev->config;
 
-	MAP_UARTIntDisable((unsigned long)config->base, UART_INT_RX);
+	MAP_UARTIntDisable(config->base, UART_INT_RX);
 }
 
 static int uart_cc32xx_irq_tx_complete(const struct device *dev)
 {
-	const struct uart_device_config *config = dev->config;
+	const struct uart_cc32xx_dev_config *config = dev->config;
 
-	return (!MAP_UARTBusy((unsigned long)config->base));
+	return (!MAP_UARTBusy(config->base));
 }
 
 static int uart_cc32xx_irq_rx_ready(const struct device *dev)
 {
-	const struct uart_device_config *config = dev->config;
+	const struct uart_cc32xx_dev_config *config = dev->config;
 	unsigned int int_status;
 
-	int_status = MAP_UARTIntStatus((unsigned long)config->base, 1);
+	int_status = MAP_UARTIntStatus(config->base, 1);
 
 	return (int_status & UART_INT_RX);
 }
@@ -222,10 +228,10 @@ static void uart_cc32xx_irq_err_disable(const struct device *dev)
 
 static int uart_cc32xx_irq_is_pending(const struct device *dev)
 {
-	const struct uart_device_config *config = dev->config;
+	const struct uart_cc32xx_dev_config *config = dev->config;
 	unsigned int int_status;
 
-	int_status = MAP_UARTIntStatus((unsigned long)config->base, 1);
+	int_status = MAP_UARTIntStatus(config->base, 1);
 
 	return (int_status & (UART_INT_TX | UART_INT_RX));
 }
@@ -257,11 +263,10 @@ static void uart_cc32xx_irq_callback_set(const struct device *dev,
  */
 static void uart_cc32xx_isr(const struct device *dev)
 {
-	const struct uart_device_config *config = dev->config;
+	const struct uart_cc32xx_dev_config *config = dev->config;
 	struct uart_cc32xx_dev_data_t * const dev_data = dev->data;
 
-	unsigned long intStatus = MAP_UARTIntStatus((unsigned long)config->base,
-						    1);
+	unsigned long intStatus = MAP_UARTIntStatus(config->base, 1);
 
 	if (dev_data->cb) {
 		dev_data->cb(dev, dev_data->cb_data);
@@ -271,7 +276,7 @@ static void uart_cc32xx_isr(const struct device *dev)
 	 * clients calling uart_fifo_read() or uart_fifo_write().
 	 * Still, clear any error interrupts here, as they're not yet handled.
 	 */
-	MAP_UARTIntClear((unsigned long)config->base,
+	MAP_UARTIntClear(config->base,
 			 intStatus & ~(UART_INT_RX | UART_INT_TX));
 }
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
@@ -310,8 +315,8 @@ IF_ENABLED(CONFIG_UART_INTERRUPT_DRIVEN, \
 			irq_enable(DT_INST_IRQN(idx))) \
 		); \
 	})); \
-static const struct uart_device_config uart_cc32xx_dev_cfg_##idx = { \
-	.base = (void *)DT_INST_REG_ADDR(idx), \
+static const struct uart_cc32xx_dev_config uart_cc32xx_dev_cfg_##idx = { \
+	.base = DT_INST_REG_ADDR(idx), \
 	.sys_clk_freq = DT_INST_PROP_BY_PHANDLE(idx, clocks, clock_frequency),\
 	IF_ENABLED(CONFIG_UART_INTERRUPT_DRIVEN, \
 		    (.irq_config_func = uart_cc32xx_cfg_func_##idx,)) \

--- a/drivers/serial/uart_cmsdk_apb.c
+++ b/drivers/serial/uart_cmsdk_apb.c
@@ -60,6 +60,14 @@ struct uart_cmsdk_apb {
 #define UART_TX_OV_IN	(1 << 2)
 #define UART_RX_OV_IN	(1 << 3)
 
+struct uart_cmsdk_apb_config {
+	volatile struct uart_cmsdk_apb *uart;
+	uint32_t sys_clk_freq;
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	uart_irq_config_func_t irq_config_func;
+#endif
+};
+
 /* Device data structure */
 struct uart_cmsdk_apb_dev_data {
 	uint32_t baud_rate;	/* Baud rate */
@@ -75,10 +83,6 @@ struct uart_cmsdk_apb_dev_data {
 	const struct arm_clock_control_t uart_cc_dss;
 };
 
-#define UART_STRUCT(dev) \
-	((volatile struct uart_cmsdk_apb *) \
-	 ((const struct uart_device_config * const)(dev)->config)->base)
-
 static const struct uart_driver_api uart_cmsdk_apb_driver_api;
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 static void uart_cmsdk_apb_isr(const struct device *dev);
@@ -93,8 +97,7 @@ static void uart_cmsdk_apb_isr(const struct device *dev);
  */
 static void baudrate_set(const struct device *dev)
 {
-	volatile struct uart_cmsdk_apb *uart = UART_STRUCT(dev);
-	const struct uart_device_config * const dev_cfg = dev->config;
+	const struct uart_cmsdk_apb_config * const dev_cfg = dev->config;
 	struct uart_cmsdk_apb_dev_data *const dev_data = dev->data;
 	/*
 	 * If baudrate and/or sys_clk_freq are 0 the configuration remains
@@ -103,7 +106,7 @@ static void baudrate_set(const struct device *dev)
 	 */
 	if ((dev_data->baud_rate != 0U) && (dev_cfg->sys_clk_freq != 0U)) {
 		/* calculate baud rate divisor */
-		uart->bauddiv = (dev_cfg->sys_clk_freq / dev_data->baud_rate);
+		dev_cfg->uart->bauddiv = (dev_cfg->sys_clk_freq / dev_data->baud_rate);
 	}
 }
 
@@ -119,10 +122,7 @@ static void baudrate_set(const struct device *dev)
  */
 static int uart_cmsdk_apb_init(const struct device *dev)
 {
-	volatile struct uart_cmsdk_apb *uart = UART_STRUCT(dev);
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	const struct uart_device_config * const dev_cfg = dev->config;
-#endif
+	const struct uart_cmsdk_apb_config * const dev_cfg = dev->config;
 
 #ifdef CONFIG_CLOCK_CONTROL
 	/* Enable clock for subsystem */
@@ -142,7 +142,7 @@ static int uart_cmsdk_apb_init(const struct device *dev)
 	baudrate_set(dev);
 
 	/* Enable receiver and transmitter */
-	uart->ctrl = UART_RX_EN | UART_TX_EN;
+	dev_cfg->uart->ctrl = UART_RX_EN | UART_TX_EN;
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	dev_cfg->irq_config_func(dev);
@@ -162,15 +162,15 @@ static int uart_cmsdk_apb_init(const struct device *dev)
 
 static int uart_cmsdk_apb_poll_in(const struct device *dev, unsigned char *c)
 {
-	volatile struct uart_cmsdk_apb *uart = UART_STRUCT(dev);
+	const struct uart_cmsdk_apb_config *dev_cfg = dev->config;
 
 	/* If the receiver is not ready returns -1 */
-	if (!(uart->state & UART_RX_BF)) {
+	if (!(dev_cfg->uart->state & UART_RX_BF)) {
 		return -1;
 	}
 
 	/* got a character */
-	*c = (unsigned char)uart->data;
+	*c = (unsigned char)dev_cfg->uart->data;
 
 	return 0;
 }
@@ -187,15 +187,15 @@ static int uart_cmsdk_apb_poll_in(const struct device *dev, unsigned char *c)
 static void uart_cmsdk_apb_poll_out(const struct device *dev,
 					     unsigned char c)
 {
-	volatile struct uart_cmsdk_apb *uart = UART_STRUCT(dev);
+	const struct uart_cmsdk_apb_config *dev_cfg = dev->config;
 
 	/* Wait for transmitter to be ready */
-	while (uart->state & UART_TX_BF) {
+	while (dev_cfg->uart->state & UART_TX_BF) {
 		; /* Wait */
 	}
 
 	/* Send a character */
-	uart->data = (uint32_t)c;
+	dev_cfg->uart->data = (uint32_t)c;
 }
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
@@ -211,21 +211,21 @@ static void uart_cmsdk_apb_poll_out(const struct device *dev,
 static int uart_cmsdk_apb_fifo_fill(const struct device *dev,
 				    const uint8_t *tx_data, int len)
 {
-	volatile struct uart_cmsdk_apb *uart = UART_STRUCT(dev);
+	const struct uart_cmsdk_apb_config *dev_cfg = dev->config;
 
 	/*
 	 * No hardware FIFO present. Only 1 byte
 	 * to write if TX buffer is empty.
 	 */
-	if (len && !(uart->state & UART_TX_BF)) {
+	if (len && !(dev_cfg->uart->state & UART_TX_BF)) {
 		/*
 		 * Clear TX int. pending flag before pushing byte to "FIFO".
 		 * If TX interrupt is enabled the UART_TX_IN bit will be set
 		 * again automatically by the UART hardware machinery once
 		 * the "FIFO" becomes empty again.
 		 */
-		uart->intclear = UART_TX_IN;
-		uart->data = *tx_data;
+		dev_cfg->uart->intclear = UART_TX_IN;
+		dev_cfg->uart->data = *tx_data;
 		return 1;
 	}
 
@@ -244,21 +244,21 @@ static int uart_cmsdk_apb_fifo_fill(const struct device *dev,
 static int uart_cmsdk_apb_fifo_read(const struct device *dev,
 				    uint8_t *rx_data, const int size)
 {
-	volatile struct uart_cmsdk_apb *uart = UART_STRUCT(dev);
+	const struct uart_cmsdk_apb_config *dev_cfg = dev->config;
 
 	/*
 	 * No hardware FIFO present. Only 1 byte
 	 * to read if RX buffer is full.
 	 */
-	if (size && uart->state & UART_RX_BF) {
+	if (size && dev_cfg->uart->state & UART_RX_BF) {
 		/*
 		 * Clear RX int. pending flag before popping byte from "FIFO".
 		 * If RX interrupt is enabled the UART_RX_IN bit will be set
 		 * again automatically by the UART hardware machinery once
 		 * the "FIFO" becomes full again.
 		 */
-		uart->intclear = UART_RX_IN;
-		*rx_data = (unsigned char)uart->data;
+		dev_cfg->uart->intclear = UART_RX_IN;
+		*rx_data = (unsigned char)dev_cfg->uart->data;
 		return 1;
 	}
 
@@ -272,9 +272,10 @@ static int uart_cmsdk_apb_fifo_read(const struct device *dev,
  */
 static void uart_cmsdk_apb_irq_tx_enable(const struct device *dev)
 {
+	const struct uart_cmsdk_apb_config *dev_cfg = dev->config;
 	unsigned int key;
 
-	UART_STRUCT(dev)->ctrl |= UART_TX_IN_EN;
+	dev_cfg->uart->ctrl |= UART_TX_IN_EN;
 	/* The expectation is that TX is a level interrupt, active for as
 	 * long as TX buffer is empty. But in CMSDK UART it's an edge
 	 * interrupt, firing on a state change of TX buffer from full to
@@ -295,9 +296,11 @@ static void uart_cmsdk_apb_irq_tx_enable(const struct device *dev)
  */
 static void uart_cmsdk_apb_irq_tx_disable(const struct device *dev)
 {
-	UART_STRUCT(dev)->ctrl &= ~UART_TX_IN_EN;
+	const struct uart_cmsdk_apb_config *dev_cfg = dev->config;
+
+	dev_cfg->uart->ctrl &= ~UART_TX_IN_EN;
 	/* Clear any pending TX interrupt after disabling it */
-	UART_STRUCT(dev)->intclear = UART_TX_IN;
+	dev_cfg->uart->intclear = UART_TX_IN;
 }
 
 /**
@@ -309,7 +312,9 @@ static void uart_cmsdk_apb_irq_tx_disable(const struct device *dev)
  */
 static int uart_cmsdk_apb_irq_tx_ready(const struct device *dev)
 {
-	return !(UART_STRUCT(dev)->state & UART_TX_BF);
+	const struct uart_cmsdk_apb_config *dev_cfg = dev->config;
+
+	return !(dev_cfg->uart->state & UART_TX_BF);
 }
 
 /**
@@ -319,7 +324,9 @@ static int uart_cmsdk_apb_irq_tx_ready(const struct device *dev)
  */
 static void uart_cmsdk_apb_irq_rx_enable(const struct device *dev)
 {
-	UART_STRUCT(dev)->ctrl |= UART_RX_IN_EN;
+	const struct uart_cmsdk_apb_config *dev_cfg = dev->config;
+
+	dev_cfg->uart->ctrl |= UART_RX_IN_EN;
 }
 
 /**
@@ -329,9 +336,11 @@ static void uart_cmsdk_apb_irq_rx_enable(const struct device *dev)
  */
 static void uart_cmsdk_apb_irq_rx_disable(const struct device *dev)
 {
-	UART_STRUCT(dev)->ctrl &= ~UART_RX_IN_EN;
+	const struct uart_cmsdk_apb_config *dev_cfg = dev->config;
+
+	dev_cfg->uart->ctrl &= ~UART_RX_IN_EN;
 	/* Clear any pending RX interrupt after disabling it */
-	UART_STRUCT(dev)->intclear = UART_RX_IN;
+	dev_cfg->uart->intclear = UART_RX_IN;
 }
 
 /**
@@ -355,7 +364,9 @@ static int uart_cmsdk_apb_irq_tx_complete(const struct device *dev)
  */
 static int uart_cmsdk_apb_irq_rx_ready(const struct device *dev)
 {
-	return UART_STRUCT(dev)->state & UART_RX_BF;
+	const struct uart_cmsdk_apb_config *dev_cfg = dev->config;
+
+	return dev_cfg->uart->state & UART_RX_BF;
 }
 
 /**
@@ -387,7 +398,9 @@ static void uart_cmsdk_apb_irq_err_disable(const struct device *dev)
  */
 static int uart_cmsdk_apb_irq_is_pending(const struct device *dev)
 {
-	return (UART_STRUCT(dev)->intstatus & (UART_RX_IN | UART_TX_IN));
+	const struct uart_cmsdk_apb_config *dev_cfg = dev->config;
+
+	return (dev_cfg->uart->intstatus & (UART_RX_IN | UART_TX_IN));
 }
 
 /**
@@ -465,8 +478,8 @@ static const struct uart_driver_api uart_cmsdk_apb_driver_api = {
 static void uart_cmsdk_apb_irq_config_func_0(const struct device *dev);
 #endif
 
-static const struct uart_device_config uart_cmsdk_apb_dev_cfg_0 = {
-	.base = (uint8_t *)DT_INST_REG_ADDR(0),
+static const struct uart_cmsdk_apb_config uart_cmsdk_apb_dev_cfg_0 = {
+	.uart = (volatile struct uart_cmsdk_apb *)DT_INST_REG_ADDR(0),
 	.sys_clk_freq = DT_INST_PROP_BY_PHANDLE(0, clocks, clock_frequency),
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.irq_config_func = uart_cmsdk_apb_irq_config_func_0,
@@ -530,8 +543,8 @@ static void uart_cmsdk_apb_irq_config_func_0(const struct device *dev)
 static void uart_cmsdk_apb_irq_config_func_1(const struct device *dev);
 #endif
 
-static const struct uart_device_config uart_cmsdk_apb_dev_cfg_1 = {
-	.base = (uint8_t *)DT_INST_REG_ADDR(1),
+static const struct uart_cmsdk_apb_config uart_cmsdk_apb_dev_cfg_1 = {
+	.uart = (volatile struct uart_cmsdk_apb *)DT_INST_REG_ADDR(1),
 	.sys_clk_freq = DT_INST_PROP_BY_PHANDLE(1, clocks, clock_frequency),
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.irq_config_func = uart_cmsdk_apb_irq_config_func_1,
@@ -595,8 +608,8 @@ static void uart_cmsdk_apb_irq_config_func_1(const struct device *dev)
 static void uart_cmsdk_apb_irq_config_func_2(const struct device *dev);
 #endif
 
-static const struct uart_device_config uart_cmsdk_apb_dev_cfg_2 = {
-	.base = (uint8_t *)DT_INST_REG_ADDR(2),
+static const struct uart_cmsdk_apb_config uart_cmsdk_apb_dev_cfg_2 = {
+	.uart = (volatile struct uart_cmsdk_apb *)DT_INST_REG_ADDR(2),
 	.sys_clk_freq = DT_INST_PROP_BY_PHANDLE(2, clocks, clock_frequency),
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.irq_config_func = uart_cmsdk_apb_irq_config_func_2,
@@ -660,8 +673,8 @@ static void uart_cmsdk_apb_irq_config_func_2(const struct device *dev)
 static void uart_cmsdk_apb_irq_config_func_3(const struct device *dev);
 #endif
 
-static const struct uart_device_config uart_cmsdk_apb_dev_cfg_3 = {
-	.base = (uint8_t *)DT_INST_REG_ADDR(3),
+static const struct uart_cmsdk_apb_config uart_cmsdk_apb_dev_cfg_3 = {
+	.uart = (volatile struct uart_cmsdk_apb *)DT_INST_REG_ADDR(3),
 	.sys_clk_freq = DT_INST_PROP_BY_PHANDLE(3, clocks, clock_frequency),
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.irq_config_func = uart_cmsdk_apb_irq_config_func_3,
@@ -725,8 +738,8 @@ static void uart_cmsdk_apb_irq_config_func_3(const struct device *dev)
 static void uart_cmsdk_apb_irq_config_func_4(const struct device *dev);
 #endif
 
-static const struct uart_device_config uart_cmsdk_apb_dev_cfg_4 = {
-	.base = (uint8_t *)DT_INST_REG_ADDR(4),
+static const struct uart_cmsdk_apb_config uart_cmsdk_apb_dev_cfg_4 = {
+	.uart = (volatile struct uart_cmsdk_apb *)DT_INST_REG_ADDR(4),
 	.sys_clk_freq = DT_INST_PROP_BY_PHANDLE(4, clocks, clock_frequency),
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.irq_config_func = uart_cmsdk_apb_irq_config_func_4,

--- a/drivers/serial/uart_msp432p4xx.c
+++ b/drivers/serial/uart_msp432p4xx.c
@@ -19,6 +19,10 @@
 #include <driverlib/rom_map.h>
 #include <driverlib/uart.h>
 
+struct uart_msp432p4xx_config {
+	unsigned long base;
+};
+
 struct uart_msp432p4xx_dev_data_t {
 	/* UART config structure */
 	eUSCI_UART_Config uartConfig;
@@ -32,8 +36,8 @@ struct uart_msp432p4xx_dev_data_t {
 static void uart_msp432p4xx_isr(const struct device *dev);
 #endif
 
-static const struct uart_device_config uart_msp432p4xx_dev_cfg_0 = {
-	.base = (void *)DT_INST_REG_ADDR(0),
+static const struct uart_msp432p4xx_config uart_msp432p4xx_dev_cfg_0 = {
+	.base = DT_INST_REG_ADDR(0),
 };
 
 static struct uart_msp432p4xx_dev_data_t uart_msp432p4xx_dev_data_0 = {
@@ -112,7 +116,7 @@ static int baudrate_set(eUSCI_UART_Config *config, uint32_t baudrate)
 static int uart_msp432p4xx_init(const struct device *dev)
 {
 	int err;
-	const struct uart_device_config *config = dev->config;
+	const struct uart_msp432p4xx_config *config = dev->config;
 	eUSCI_UART_Config UartConfig;
 
 	/* Select P1.2 and P1.3 in UART mode */
@@ -132,10 +136,10 @@ static int uart_msp432p4xx_init(const struct device *dev)
 		return err;
 	}
 	/* Configure UART Module */
-	MAP_UART_initModule((unsigned long)config->base, &UartConfig);
+	MAP_UART_initModule(config->base, &UartConfig);
 
 	/* Enable UART module */
-	MAP_UART_enableModule((unsigned long)config->base);
+	MAP_UART_enableModule(config->base);
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	IRQ_CONNECT(DT_INST_IRQN(0),
@@ -150,9 +154,9 @@ static int uart_msp432p4xx_init(const struct device *dev)
 
 static int uart_msp432p4xx_poll_in(const struct device *dev, unsigned char *c)
 {
-	const struct uart_device_config *config = dev->config;
+	const struct uart_msp432p4xx_config *config = dev->config;
 
-	*c = MAP_UART_receiveData((unsigned long)config->base);
+	*c = MAP_UART_receiveData(config->base);
 
 	return 0;
 }
@@ -160,22 +164,21 @@ static int uart_msp432p4xx_poll_in(const struct device *dev, unsigned char *c)
 static void uart_msp432p4xx_poll_out(const struct device *dev,
 				     unsigned char c)
 {
-	const struct uart_device_config *config = dev->config;
+	const struct uart_msp432p4xx_config *config = dev->config;
 
-	MAP_UART_transmitData((unsigned long)config->base, c);
+	MAP_UART_transmitData(config->base, c);
 }
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 static int uart_msp432p4xx_fifo_fill(const struct device *dev,
 						const uint8_t *tx_data, int size)
 {
-	const struct uart_device_config *config = dev->config;
+	const struct uart_msp432p4xx_config *config = dev->config;
 	unsigned int num_tx = 0U;
 
 	while ((size - num_tx) > 0) {
-		MAP_UART_transmitData((unsigned long)config->base,
-							tx_data[num_tx]);
-		if (MAP_UART_getInterruptStatus((unsigned long)config->base,
+		MAP_UART_transmitData(config->base, tx_data[num_tx]);
+		if (MAP_UART_getInterruptStatus(config->base,
 			EUSCI_A_UART_TRANSMIT_COMPLETE_INTERRUPT_FLAG)) {
 			num_tx++;
 		} else {
@@ -190,15 +193,14 @@ static int uart_msp432p4xx_fifo_read(const struct device *dev,
 							uint8_t *rx_data,
 							const int size)
 {
-	const struct uart_device_config *config = dev->config;
+	const struct uart_msp432p4xx_config *config = dev->config;
 	unsigned int num_rx = 0U;
 
 	while (((size - num_rx) > 0) &&
-		MAP_UART_getInterruptStatus((unsigned long)config->base,
-					EUSCI_A_UART_RECEIVE_INTERRUPT_FLAG)) {
+		MAP_UART_getInterruptStatus(
+			config->base, EUSCI_A_UART_RECEIVE_INTERRUPT_FLAG)) {
 
-		rx_data[num_rx++] =
-			MAP_UART_receiveData((unsigned long)config->base);
+		rx_data[num_rx++] = MAP_UART_receiveData(config->base);
 	}
 
 	return num_rx;
@@ -206,62 +208,59 @@ static int uart_msp432p4xx_fifo_read(const struct device *dev,
 
 static void uart_msp432p4xx_irq_tx_enable(const struct device *dev)
 {
-	const struct uart_device_config *config = dev->config;
+	const struct uart_msp432p4xx_config *config = dev->config;
 
-	MAP_UART_enableInterrupt((unsigned long)config->base,
-					EUSCI_A_UART_TRANSMIT_INTERRUPT);
+	MAP_UART_enableInterrupt(config->base, EUSCI_A_UART_TRANSMIT_INTERRUPT);
 }
 
 static void uart_msp432p4xx_irq_tx_disable(const struct device *dev)
 {
-	const struct uart_device_config *config = dev->config;
+	const struct uart_msp432p4xx_config *config = dev->config;
 
-	MAP_UART_disableInterrupt((unsigned long)config->base,
-					EUSCI_A_UART_TRANSMIT_INTERRUPT);
+	MAP_UART_disableInterrupt(config->base,
+				  EUSCI_A_UART_TRANSMIT_INTERRUPT);
 }
 
 static int uart_msp432p4xx_irq_tx_ready(const struct device *dev)
 {
-	const struct uart_device_config *config = dev->config;
+	const struct uart_msp432p4xx_config *config = dev->config;
 	unsigned int int_status;
 
-	int_status =  MAP_UART_getInterruptStatus((unsigned long)config->base,
-					EUSCI_A_UART_TRANSMIT_INTERRUPT_FLAG);
+	int_status =  MAP_UART_getInterruptStatus(
+		config->base, EUSCI_A_UART_TRANSMIT_INTERRUPT_FLAG);
 
 	return (int_status & EUSCI_A_IE_TXIE);
 }
 
 static void uart_msp432p4xx_irq_rx_enable(const struct device *dev)
 {
-	const struct uart_device_config *config = dev->config;
+	const struct uart_msp432p4xx_config *config = dev->config;
 
-	MAP_UART_enableInterrupt((unsigned long)config->base,
-				EUSCI_A_UART_RECEIVE_INTERRUPT);
+	MAP_UART_enableInterrupt(config->base, EUSCI_A_UART_RECEIVE_INTERRUPT);
 }
 
 static void uart_msp432p4xx_irq_rx_disable(const struct device *dev)
 {
-	const struct uart_device_config *config = dev->config;
+	const struct uart_msp432p4xx_config *config = dev->config;
 
-	MAP_UART_disableInterrupt((unsigned long)config->base,
-				EUSCI_A_UART_RECEIVE_INTERRUPT);
+	MAP_UART_disableInterrupt(config->base, EUSCI_A_UART_RECEIVE_INTERRUPT);
 }
 
 static int uart_msp432p4xx_irq_tx_complete(const struct device *dev)
 {
-	const struct uart_device_config *config = dev->config;
+	const struct uart_msp432p4xx_config *config = dev->config;
 
-	return MAP_UART_getInterruptStatus((unsigned long)config->base,
-				EUSCI_A_UART_TRANSMIT_COMPLETE_INTERRUPT_FLAG);
+	return MAP_UART_getInterruptStatus(
+		config->base, EUSCI_A_UART_TRANSMIT_COMPLETE_INTERRUPT_FLAG);
 }
 
 static int uart_msp432p4xx_irq_rx_ready(const struct device *dev)
 {
-	const struct uart_device_config *config = dev->config;
+	const struct uart_msp432p4xx_config *config = dev->config;
 	unsigned int int_status;
 
-	int_status = MAP_UART_getInterruptStatus((unsigned long)config->base,
-					EUSCI_A_UART_RECEIVE_INTERRUPT_FLAG);
+	int_status = MAP_UART_getInterruptStatus(
+		config->base, EUSCI_A_UART_RECEIVE_INTERRUPT_FLAG);
 
 	return (int_status & EUSCI_A_IE_RXIE);
 }
@@ -278,11 +277,10 @@ static void uart_msp432p4xx_irq_err_disable(const struct device *dev)
 
 static int uart_msp432p4xx_irq_is_pending(const struct device *dev)
 {
-	const struct uart_device_config *config = dev->config;
+	const struct uart_msp432p4xx_config *config = dev->config;
 	unsigned int int_status;
 
-	int_status = MAP_UART_getEnabledInterruptStatus(
-						(unsigned long)config->base);
+	int_status = MAP_UART_getEnabledInterruptStatus(config->base);
 
 	return (int_status & (EUSCI_A_IE_TXIE | EUSCI_A_IE_RXIE));
 }
@@ -311,12 +309,11 @@ static void uart_msp432p4xx_irq_callback_set(const struct device *dev,
  */
 static void uart_msp432p4xx_isr(const struct device *dev)
 {
-	const struct uart_device_config *config = dev->config;
+	const struct uart_msp432p4xx_config *config = dev->config;
 	struct uart_msp432p4xx_dev_data_t * const dev_data = dev->data;
 	unsigned int int_status;
 
-	int_status = MAP_UART_getEnabledInterruptStatus(
-						(unsigned long)config->base);
+	int_status = MAP_UART_getEnabledInterruptStatus(config->base);
 
 	if (dev_data->cb) {
 		dev_data->cb(dev, dev_data->cb_data);
@@ -325,7 +322,7 @@ static void uart_msp432p4xx_isr(const struct device *dev)
 	 * Clear interrupts only after cb called, as Zephyr UART clients expect
 	 * to check interrupt status during the callback.
 	 */
-	MAP_UART_disableInterrupt((unsigned long)config->base, int_status);
+	MAP_UART_disableInterrupt(config->base, int_status);
 }
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 

--- a/drivers/serial/uart_msp432p4xx.c
+++ b/drivers/serial/uart_msp432p4xx.c
@@ -34,7 +34,6 @@ static void uart_msp432p4xx_isr(const struct device *dev);
 
 static const struct uart_device_config uart_msp432p4xx_dev_cfg_0 = {
 	.base = (void *)DT_INST_REG_ADDR(0),
-	.sys_clk_freq = DT_INST_PROP_BY_PHANDLE(0, clocks, clock_frequency),
 };
 
 static struct uart_msp432p4xx_dev_data_t uart_msp432p4xx_dev_data_0 = {

--- a/drivers/serial/uart_numicro.c
+++ b/drivers/serial/uart_numicro.c
@@ -11,12 +11,8 @@
 
 #define DT_DRV_COMPAT nuvoton_numicro_uart
 
-#define UART_STRUCT(dev)					\
-	((UART_T *)						\
-	 ((const struct uart_numicro_config * const)(dev)->config)->devcfg.base)
-
 struct uart_numicro_config {
-	struct uart_device_config devcfg;
+	UART_T *uart;
 	uint32_t id_rst;
 	uint32_t id_clk;
 };
@@ -28,9 +24,10 @@ struct uart_numicro_data {
 
 static int uart_numicro_poll_in(const struct device *dev, unsigned char *c)
 {
+	const struct uart_numicro_config *config = dev->config;
 	uint32_t count;
 
-	count = UART_Read(UART_STRUCT(dev), c, 1);
+	count = UART_Read(config->uart, c, 1);
 	if (!count) {
 		return -1;
 	}
@@ -40,7 +37,9 @@ static int uart_numicro_poll_in(const struct device *dev, unsigned char *c)
 
 static void uart_numicro_poll_out(const struct device *dev, unsigned char c)
 {
-	UART_Write(UART_STRUCT(dev), &c, 1);
+	const struct uart_numicro_config *config = dev->config;
+
+	UART_Write(config->uart, &c, 1);
 }
 
 static int uart_numicro_err_check(const struct device *dev)
@@ -99,6 +98,7 @@ static inline uint32_t uart_numicro_convert_parity(enum uart_config_parity parit
 static int uart_numicro_configure(const struct device *dev,
 				  const struct uart_config *cfg)
 {
+	const struct uart_numicro_config *config = dev->config;
 	struct uart_numicro_data *ddata = dev->data;
 	int32_t databits, stopbits;
 	uint32_t parity;
@@ -114,17 +114,17 @@ static int uart_numicro_configure(const struct device *dev,
 	}
 
 	if (cfg->flow_ctrl == UART_CFG_FLOW_CTRL_NONE) {
-		UART_DisableFlowCtrl(UART_STRUCT(dev));
+		UART_DisableFlowCtrl(config->uart);
 	} else if (cfg->flow_ctrl == UART_CFG_FLOW_CTRL_RTS_CTS) {
-		UART_EnableFlowCtrl(UART_STRUCT(dev));
+		UART_EnableFlowCtrl(config->uart);
 	} else {
 		return -ENOTSUP;
 	}
 
 	parity = uart_numicro_convert_parity(cfg->parity);
 
-	UART_SetLineConfig(UART_STRUCT(dev), cfg->baudrate, databits,
-			   parity, stopbits);
+	UART_SetLineConfig(config->uart, cfg->baudrate, databits, parity,
+			   stopbits);
 
 	memcpy(&ddata->ucfg, cfg, sizeof(*cfg));
 
@@ -165,7 +165,7 @@ static int uart_numicro_init(const struct device *dev)
 
 	SYS_LockReg();
 
-	UART_Open(UART_STRUCT(dev), ddata->ucfg.baudrate);
+	UART_Open(config->uart, ddata->ucfg.baudrate);
 
 	return 0;
 }
@@ -183,9 +183,7 @@ static const struct uart_driver_api uart_numicro_driver_api = {
 #define NUMICRO_INIT(index)						\
 									\
 static const struct uart_numicro_config uart_numicro_cfg_##index = {	\
-	.devcfg = {							\
-		.base = (uint8_t *)DT_INST_REG_ADDR(index),		\
-	},								\
+	.uart = (UART_T *)DT_INST_REG_ADDR(index),			\
 	.id_rst = UART##index##_RST,					\
 	.id_clk = UART##index##_MODULE,					\
 };									\

--- a/drivers/serial/uart_pl011.c
+++ b/drivers/serial/uart_pl011.c
@@ -39,6 +39,14 @@ struct pl011_regs {
 	uint32_t dmacr;
 };
 
+struct pl011_config {
+	volatile struct pl011_regs *uart;
+	uint32_t sys_clk_freq;
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	uart_irq_config_func_t irq_config_func;
+#endif
+};
+
 /* Device data structure */
 struct pl011_data {
 	uint32_t baud_rate;	/* Baud rate */
@@ -142,33 +150,39 @@ struct pl011_data {
 		PL011_IMSC_RXIM | PL011_IMSC_TXIM | \
 		PL011_IMSC_RTIM)
 
-#define PL011_REGS(dev) \
-	((volatile struct pl011_regs  *) \
-	 ((const struct uart_device_config * const)(dev)->config)->base)
-
 static void pl011_enable(const struct device *dev)
 {
-	PL011_REGS(dev)->cr |=  PL011_CR_UARTEN;
+	const struct pl011_config *config = dev->config;
+
+	config->uart->cr |=  PL011_CR_UARTEN;
 }
 
 static void pl011_disable(const struct device *dev)
 {
-	PL011_REGS(dev)->cr &= ~PL011_CR_UARTEN;
+	const struct pl011_config *config = dev->config;
+
+	config->uart->cr &= ~PL011_CR_UARTEN;
 }
 
 static void pl011_enable_fifo(const struct device *dev)
 {
-	PL011_REGS(dev)->lcr_h |= PL011_LCRH_FEN;
+	const struct pl011_config *config = dev->config;
+
+	config->uart->lcr_h |= PL011_LCRH_FEN;
 }
 
 static void pl011_disable_fifo(const struct device *dev)
 {
-	PL011_REGS(dev)->lcr_h &= ~PL011_LCRH_FEN;
+	const struct pl011_config *config = dev->config;
+
+	config->uart->lcr_h &= ~PL011_LCRH_FEN;
 }
 
 static int pl011_set_baudrate(const struct device *dev,
 			      uint32_t clk, uint32_t baudrate)
 {
+	const struct pl011_config *config = dev->config;
+
 	/* Avoiding float calculations, bauddiv is left shifted by 6 */
 	uint64_t bauddiv = (((uint64_t)clk) << PL011_FBRD_WIDTH)
 				/ (baudrate * 16U);
@@ -182,8 +196,8 @@ static int pl011_set_baudrate(const struct device *dev,
 		return -EINVAL;
 	}
 
-	PL011_REGS(dev)->ibrd = bauddiv >> PL011_FBRD_WIDTH;
-	PL011_REGS(dev)->fbrd = bauddiv & ((1u << PL011_FBRD_WIDTH) - 1u);
+	config->uart->ibrd = bauddiv >> PL011_FBRD_WIDTH;
+	config->uart->fbrd = bauddiv & ((1u << PL011_FBRD_WIDTH) - 1u);
 
 	__DMB();
 
@@ -191,56 +205,61 @@ static int pl011_set_baudrate(const struct device *dev,
 	 * lcr_h write must always be performed at the end
 	 * ARM DDI 0183F, Pg 3-13
 	 */
-	PL011_REGS(dev)->lcr_h = PL011_REGS(dev)->lcr_h;
+	config->uart->lcr_h = config->uart->lcr_h;
 
 	return 0;
 }
 
 static bool pl011_is_readable(const struct device *dev)
 {
+	const struct pl011_config *config = dev->config;
 	struct pl011_data *data = dev->data;
 
 	if (!data->sbsa &&
-	    (!(PL011_REGS(dev)->cr & PL011_CR_UARTEN) ||
-	     !(PL011_REGS(dev)->cr & PL011_CR_RXE)))
+	    (!(config->uart->cr & PL011_CR_UARTEN) ||
+	     !(config->uart->cr & PL011_CR_RXE)))
 		return false;
 
-	return (PL011_REGS(dev)->fr & PL011_FR_RXFE) == 0U;
+	return (config->uart->fr & PL011_FR_RXFE) == 0U;
 }
 
 static int pl011_poll_in(const struct device *dev, unsigned char *c)
 {
+	const struct pl011_config *config = dev->config;
+
 	if (!pl011_is_readable(dev)) {
 		return -1;
 	}
 
 	/* got a character */
-	*c = (unsigned char)PL011_REGS(dev)->dr;
+	*c = (unsigned char)config->uart->dr;
 
-	return PL011_REGS(dev)->rsr & PL011_RSR_ERROR_MASK;
+	return config->uart->rsr & PL011_RSR_ERROR_MASK;
 }
 
 static void pl011_poll_out(const struct device *dev,
 					     unsigned char c)
 {
+	const struct pl011_config *config = dev->config;
+
 	/* Wait for space in FIFO */
-	while (PL011_REGS(dev)->fr & PL011_FR_TXFF) {
+	while (config->uart->fr & PL011_FR_TXFF) {
 		; /* Wait */
 	}
 
 	/* Send a character */
-	PL011_REGS(dev)->dr = (uint32_t)c;
+	config->uart->dr = (uint32_t)c;
 }
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 static int pl011_fifo_fill(const struct device *dev,
 				    const uint8_t *tx_data, int len)
 {
+	const struct pl011_config *config = dev->config;
 	uint8_t num_tx = 0U;
 
-	while (!(PL011_REGS(dev)->fr & PL011_FR_TXFF) &&
-	       (len - num_tx > 0)) {
-		PL011_REGS(dev)->dr = tx_data[num_tx++];
+	while (!(config->uart->fr & PL011_FR_TXFF) && (len - num_tx > 0)) {
+		config->uart->dr = tx_data[num_tx++];
 	}
 	return num_tx;
 }
@@ -248,11 +267,11 @@ static int pl011_fifo_fill(const struct device *dev,
 static int pl011_fifo_read(const struct device *dev,
 				    uint8_t *rx_data, const int len)
 {
+	const struct pl011_config *config = dev->config;
 	uint8_t num_rx = 0U;
 
-	while ((len - num_rx > 0) &&
-	       !(PL011_REGS(dev)->fr & PL011_FR_RXFE)) {
-		rx_data[num_rx++] = PL011_REGS(dev)->dr;
+	while ((len - num_rx > 0) && !(config->uart->fr & PL011_FR_RXFE)) {
+		rx_data[num_rx++] = config->uart->dr;
 	}
 
 	return num_rx;
@@ -260,63 +279,77 @@ static int pl011_fifo_read(const struct device *dev,
 
 static void pl011_irq_tx_enable(const struct device *dev)
 {
-	PL011_REGS(dev)->imsc |= PL011_IMSC_TXIM;
+	const struct pl011_config *config = dev->config;
+
+	config->uart->imsc |= PL011_IMSC_TXIM;
 }
 
 static void pl011_irq_tx_disable(const struct device *dev)
 {
-	PL011_REGS(dev)->imsc &= ~PL011_IMSC_TXIM;
+	const struct pl011_config *config = dev->config;
+
+	config->uart->imsc &= ~PL011_IMSC_TXIM;
 }
 
 static int pl011_irq_tx_complete(const struct device *dev)
 {
+	const struct pl011_config *config = dev->config;
+
 	/* check for TX FIFO empty */
-	return PL011_REGS(dev)->fr & PL011_FR_TXFE;
+	return config->uart->fr & PL011_FR_TXFE;
 }
 
 static int pl011_irq_tx_ready(const struct device *dev)
 {
+	const struct pl011_config *config = dev->config;
 	struct pl011_data *data = dev->data;
 
-	if (!data->sbsa && !(PL011_REGS(dev)->cr & PL011_CR_TXE))
+	if (!data->sbsa && !(config->uart->cr & PL011_CR_TXE))
 		return false;
 
-	return ((PL011_REGS(dev)->imsc & PL011_IMSC_TXIM) &&
+	return ((config->uart->imsc & PL011_IMSC_TXIM) &&
 		pl011_irq_tx_complete(dev));
 }
 
 static void pl011_irq_rx_enable(const struct device *dev)
 {
-	PL011_REGS(dev)->imsc |= PL011_IMSC_RXIM |
-				 PL011_IMSC_RTIM;
+	const struct pl011_config *config = dev->config;
+
+	config->uart->imsc |= PL011_IMSC_RXIM | PL011_IMSC_RTIM;
 }
 
 static void pl011_irq_rx_disable(const struct device *dev)
 {
-	PL011_REGS(dev)->imsc &= ~(PL011_IMSC_RXIM |
-				   PL011_IMSC_RTIM);
+	const struct pl011_config *config = dev->config;
+
+	config->uart->imsc &= ~(PL011_IMSC_RXIM | PL011_IMSC_RTIM);
 }
 
 static int pl011_irq_rx_ready(const struct device *dev)
 {
+	const struct pl011_config *config = dev->config;
 	struct pl011_data *data = dev->data;
 
-	if (!data->sbsa && !(PL011_REGS(dev)->cr & PL011_CR_RXE))
+	if (!data->sbsa && !(config->uart->cr & PL011_CR_RXE))
 		return false;
 
-	return ((PL011_REGS(dev)->imsc & PL011_IMSC_RXIM) &&
-		(!(PL011_REGS(dev)->fr & PL011_FR_RXFE)));
+	return ((config->uart->imsc & PL011_IMSC_RXIM) &&
+		(!(config->uart->fr & PL011_FR_RXFE)));
 }
 
 static void pl011_irq_err_enable(const struct device *dev)
 {
+	const struct pl011_config *config = dev->config;
+
 	/* enable framing, parity, break, and overrun */
-	PL011_REGS(dev)->imsc |= PL011_IMSC_ERROR_MASK;
+	config->uart->imsc |= PL011_IMSC_ERROR_MASK;
 }
 
 static void pl011_irq_err_disable(const struct device *dev)
 {
-	PL011_REGS(dev)->imsc &= ~PL011_IMSC_ERROR_MASK;
+	const struct pl011_config *config = dev->config;
+
+	config->uart->imsc &= ~PL011_IMSC_ERROR_MASK;
 }
 
 static int pl011_irq_is_pending(const struct device *dev)
@@ -363,7 +396,7 @@ static const struct uart_driver_api pl011_driver_api = {
 
 static int pl011_init(const struct device *dev)
 {
-	const struct uart_device_config *config = dev->config;
+	const struct pl011_config *config = dev->config;
 	struct pl011_data *data = dev->data;
 	int ret;
 	uint32_t lcrh;
@@ -386,23 +419,23 @@ static int pl011_init(const struct device *dev)
 		}
 
 		/* Setting the default character format */
-		lcrh = PL011_REGS(dev)->lcr_h & ~(PL011_LCRH_FORMAT_MASK);
+		lcrh = config->uart->lcr_h & ~(PL011_LCRH_FORMAT_MASK);
 		lcrh &= ~(BIT(0) | BIT(7));
 		lcrh |= PL011_LCRH_WLEN_SIZE(8) << PL011_LCRH_WLEN_SHIFT;
-		PL011_REGS(dev)->lcr_h = lcrh;
+		config->uart->lcr_h = lcrh;
 
 		/* Enabling the FIFOs */
 		pl011_enable_fifo(dev);
 	}
 	/* initialize all IRQs as masked */
-	PL011_REGS(dev)->imsc = 0U;
-	PL011_REGS(dev)->icr = PL011_IMSC_MASK_ALL;
+	config->uart->imsc = 0U;
+	config->uart->icr = PL011_IMSC_MASK_ALL;
 
 	if (!data->sbsa) {
-		PL011_REGS(dev)->dmacr = 0U;
+		config->uart->dmacr = 0U;
 		__ISB();
-		PL011_REGS(dev)->cr &= ~(BIT(14) | BIT(15) | BIT(1));
-		PL011_REGS(dev)->cr |= PL011_CR_RXE | PL011_CR_TXE;
+		config->uart->cr &= ~(BIT(14) | BIT(15) | BIT(1));
+		config->uart->cr |= PL011_CR_RXE | PL011_CR_TXE;
 		__ISB();
 	}
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
@@ -433,8 +466,8 @@ void pl011_isr(const struct device *dev)
 static void pl011_irq_config_func_0(const struct device *dev);
 #endif
 
-static struct uart_device_config pl011_cfg_port_0 = {
-	.base = (uint8_t *)DT_INST_REG_ADDR(0),
+static struct pl011_config pl011_cfg_port_0 = {
+	.uart = (volatile struct pl011_regs *)DT_INST_REG_ADDR(0),
 	.sys_clk_freq = DT_INST_PROP_BY_PHANDLE(0, clocks, clock_frequency),
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.irq_config_func = pl011_irq_config_func_0,
@@ -496,8 +529,8 @@ static void pl011_irq_config_func_0(const struct device *dev)
 static void pl011_irq_config_func_1(const struct device *dev);
 #endif
 
-static struct uart_device_config pl011_cfg_port_1 = {
-	.base = (uint8_t *)DT_INST_REG_ADDR(1),
+static struct pl011_config pl011_cfg_port_1 = {
+	.uart = (volatile struct pl011_regs *)DT_INST_REG_ADDR(1),
 	.sys_clk_freq = DT_INST_PROP_BY_PHANDLE(1, clocks, clock_frequency),
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.irq_config_func = pl011_irq_config_func_1,
@@ -562,8 +595,8 @@ static void pl011_irq_config_func_1(const struct device *dev)
 static void pl011_irq_config_func_sbsa(const struct device *dev);
 #endif
 
-static struct uart_device_config pl011_cfg_sbsa = {
-	.base = (uint8_t *)DT_INST_REG_ADDR(0),
+static struct pl011_config pl011_cfg_sbsa = {
+	.uart = (volatile struct pl011_regs *)DT_INST_REG_ADDR(0),
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.irq_config_func = pl011_irq_config_func_sbsa,
 #endif

--- a/drivers/serial/uart_stellaris.c
+++ b/drivers/serial/uart_stellaris.c
@@ -67,6 +67,14 @@ struct _uart {
 	uint32_t p_cell_id3;
 };
 
+struct uart_stellaris_config {
+	volatile struct _uart *uart;
+	uint32_t sys_clk_freq;
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	uart_irq_config_func_t irq_config_func;
+#endif
+};
+
 /* Device data structure */
 struct uart_stellaris_dev_data_t {
 	uint32_t baud_rate;	/* Baud rate */
@@ -78,8 +86,7 @@ struct uart_stellaris_dev_data_t {
 };
 
 #define UART_STRUCT(dev) \
-	((volatile struct _uart *) \
-	 ((const struct uart_device_config * const)(dev)->config)->base)
+	(((const struct uart_stellaris_config * const)(dev)->config)->uart)
 
 /* registers */
 #define UARTDR(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0x000)))
@@ -155,7 +162,7 @@ static const struct uart_driver_api uart_stellaris_driver_api;
 static void baudrate_set(const struct device *dev,
 			 uint32_t baudrate, uint32_t sys_clk_freq_hz)
 {
-	volatile struct _uart *uart = UART_STRUCT(dev);
+	const struct uart_stellaris_config *config = dev->config;
 	uint32_t brdi, brdf, div, rem;
 
 	/* upon reset, the system clock uses the intenal OSC @ 12MHz */
@@ -176,8 +183,8 @@ static void baudrate_set(const struct device *dev,
 	 * those registers are 32-bit, but the reserved bits should be
 	 * preserved
 	 */
-	uart->ibrd = (uint16_t)(brdi & 0xffff); /* 16 bits */
-	uart->fbrd = (uint8_t)(brdf & 0x3f);    /* 6 bits */
+	config->uart->ibrd = (uint16_t)(brdi & 0xffff); /* 16 bits */
+	config->uart->fbrd = (uint8_t)(brdf & 0x3f);    /* 6 bits */
 }
 
 /**
@@ -189,9 +196,9 @@ static void baudrate_set(const struct device *dev,
  */
 static inline void enable(const struct device *dev)
 {
-	volatile struct _uart *uart = UART_STRUCT(dev);
+	const struct uart_stellaris_config *config = dev->config;
 
-	uart->ctl |= UARTCTL_UARTEN;
+	config->uart->ctl |= UARTCTL_UARTEN;
 }
 
 /**
@@ -203,16 +210,16 @@ static inline void enable(const struct device *dev)
  */
 static inline void disable(const struct device *dev)
 {
-	volatile struct _uart *uart = UART_STRUCT(dev);
+	const struct uart_stellaris_config *config = dev->config;
 
-	uart->ctl &= ~UARTCTL_UARTEN;
+	config->uart->ctl &= ~UARTCTL_UARTEN;
 
 	/* ensure transmissions are complete */
-	while (uart->fr & UARTFR_BUSY) {
+	while (config->uart->fr & UARTFR_BUSY) {
 	}
 
 	/* flush the FIFOs by disabling them */
-	uart->lcrh &= ~UARTLCRH_FEN;
+	config->uart->lcrh &= ~UARTLCRH_FEN;
 }
 
 /*
@@ -234,9 +241,9 @@ static inline void disable(const struct device *dev)
  */
 static inline void line_control_defaults_set(const struct device *dev)
 {
-	volatile struct _uart *uart = UART_STRUCT(dev);
+	const struct uart_stellaris_config *config = dev->config;
 
-	uart->lcrh = LINE_CONTROL_DEFAULTS;
+	config->uart->lcrh = LINE_CONTROL_DEFAULTS;
 }
 
 /**
@@ -252,7 +259,7 @@ static inline void line_control_defaults_set(const struct device *dev)
 static int uart_stellaris_init(const struct device *dev)
 {
 	struct uart_stellaris_dev_data_t *data = dev->data;
-	const struct uart_device_config *config = dev->config;
+	const struct uart_stellaris_config *config = dev->config;
 	disable(dev);
 	baudrate_set(dev, data->baud_rate,
 		     config->sys_clk_freq);
@@ -277,9 +284,9 @@ static int uart_stellaris_init(const struct device *dev)
  */
 static int poll_tx_ready(const struct device *dev)
 {
-	volatile struct _uart *uart = UART_STRUCT(dev);
+	const struct uart_stellaris_config *config = dev->config;
 
-	return (uart->fr & UARTFR_TXFE);
+	return (config->uart->fr & UARTFR_TXFE);
 }
 
 /**
@@ -293,14 +300,14 @@ static int poll_tx_ready(const struct device *dev)
 
 static int uart_stellaris_poll_in(const struct device *dev, unsigned char *c)
 {
-	volatile struct _uart *uart = UART_STRUCT(dev);
+	const struct uart_stellaris_config *config = dev->config;
 
-	if (uart->fr & UARTFR_RXFE) {
+	if (config->uart->fr & UARTFR_RXFE) {
 		return (-1);
 	}
 
 	/* got a character */
-	*c = (unsigned char)uart->dr;
+	*c = (unsigned char)config->uart->dr;
 
 	return 0;
 }
@@ -317,13 +324,13 @@ static int uart_stellaris_poll_in(const struct device *dev, unsigned char *c)
 static void uart_stellaris_poll_out(const struct device *dev,
 					     unsigned char c)
 {
-	volatile struct _uart *uart = UART_STRUCT(dev);
+	const struct uart_stellaris_config *config = dev->config;
 
 	while (!poll_tx_ready(dev)) {
 	}
 
 	/* send a character */
-	uart->dr = (uint32_t)c;
+	config->uart->dr = (uint32_t)c;
 }
 
 #if CONFIG_UART_INTERRUPT_DRIVEN
@@ -341,11 +348,11 @@ static int uart_stellaris_fifo_fill(const struct device *dev,
 				    const uint8_t *tx_data,
 				    int len)
 {
-	volatile struct _uart *uart = UART_STRUCT(dev);
+	const struct uart_stellaris_config *config = dev->config;
 	uint8_t num_tx = 0U;
 
-	while ((len - num_tx > 0) && ((uart->fr & UARTFR_TXFF) == 0U)) {
-		uart->dr = (uint32_t)tx_data[num_tx++];
+	while ((len - num_tx > 0) && ((config->uart->fr & UARTFR_TXFF) == 0U)) {
+		config->uart->dr = (uint32_t)tx_data[num_tx++];
 	}
 
 	return (int)num_tx;
@@ -364,11 +371,11 @@ static int uart_stellaris_fifo_read(const struct device *dev,
 				    uint8_t *rx_data,
 				    const int size)
 {
-	volatile struct _uart *uart = UART_STRUCT(dev);
+	const struct uart_stellaris_config *config = dev->config;
 	uint8_t num_rx = 0U;
 
-	while ((size - num_rx > 0) && ((uart->fr & UARTFR_RXFE) == 0U)) {
-		rx_data[num_rx++] = (uint8_t)uart->dr;
+	while ((size - num_rx > 0) && ((config->uart->fr & UARTFR_RXFE) == 0U)) {
+		rx_data[num_rx++] = (uint8_t)config->uart->dr;
 	}
 
 	return num_rx;
@@ -387,7 +394,7 @@ static void uart_stellaris_irq_tx_enable(const struct device *dev)
 	uint32_t saved_ibrd; /* saved UARTIBRD (integer baud rate) register */
 	uint32_t saved_fbrd; /* saved UARTFBRD (fractional baud rate) register
 				*/
-	volatile struct _uart *uart = UART_STRUCT(dev);
+	const struct uart_stellaris_config *config = dev->config;
 
 	if (first_time) {
 		/*
@@ -400,30 +407,30 @@ static void uart_stellaris_irq_tx_enable(const struct device *dev)
 		first_time = 0U;
 
 		/* save current control and baud rate settings */
-		saved_ctl = uart->ctl;
-		saved_ibrd = uart->ibrd;
-		saved_fbrd = uart->fbrd;
+		saved_ctl = config->uart->ctl;
+		saved_ibrd = config->uart->ibrd;
+		saved_fbrd = config->uart->fbrd;
 
 		/* send a character with default settings via loopback */
 		disable(dev);
-		uart->fbrd = 0U;
-		uart->ibrd = 1U;
-		uart->lcrh = 0U;
-		uart->ctl = (UARTCTL_UARTEN | UARTCTL_TXEN | UARTCTL_LBE);
-		uart->dr = 0U;
+		config->uart->fbrd = 0U;
+		config->uart->ibrd = 1U;
+		config->uart->lcrh = 0U;
+		config->uart->ctl = (UARTCTL_UARTEN | UARTCTL_TXEN | UARTCTL_LBE);
+		config->uart->dr = 0U;
 
-		while (uart->fr & UARTFR_BUSY) {
+		while (config->uart->fr & UARTFR_BUSY) {
 		}
 
 		/* restore control and baud rate settings */
 		disable(dev);
-		uart->ibrd = saved_ibrd;
-		uart->fbrd = saved_fbrd;
+		config->uart->ibrd = saved_ibrd;
+		config->uart->fbrd = saved_fbrd;
 		line_control_defaults_set(dev);
-		uart->ctl = saved_ctl;
+		config->uart->ctl = saved_ctl;
 	}
 
-	uart->im |= UARTTIM_TXIM;
+	config->uart->im |= UARTTIM_TXIM;
 }
 
 /**
@@ -433,9 +440,9 @@ static void uart_stellaris_irq_tx_enable(const struct device *dev)
  */
 static void uart_stellaris_irq_tx_disable(const struct device *dev)
 {
-	volatile struct _uart *uart = UART_STRUCT(dev);
+	const struct uart_stellaris_config *config = dev->config;
 
-	uart->im &= ~UARTTIM_TXIM;
+	config->uart->im &= ~UARTTIM_TXIM;
 }
 
 /**
@@ -447,9 +454,9 @@ static void uart_stellaris_irq_tx_disable(const struct device *dev)
  */
 static int uart_stellaris_irq_tx_ready(const struct device *dev)
 {
-	volatile struct _uart *uart = UART_STRUCT(dev);
+	const struct uart_stellaris_config *config = dev->config;
 
-	return ((uart->mis & UARTMIS_TXMIS) == UARTMIS_TXMIS);
+	return ((config->uart->mis & UARTMIS_TXMIS) == UARTMIS_TXMIS);
 }
 
 /**
@@ -459,9 +466,9 @@ static int uart_stellaris_irq_tx_ready(const struct device *dev)
  */
 static void uart_stellaris_irq_rx_enable(const struct device *dev)
 {
-	volatile struct _uart *uart = UART_STRUCT(dev);
+	const struct uart_stellaris_config *config = dev->config;
 
-	uart->im |= UARTTIM_RXIM;
+	config->uart->im |= UARTTIM_RXIM;
 }
 
 /**
@@ -471,9 +478,9 @@ static void uart_stellaris_irq_rx_enable(const struct device *dev)
  */
 static void uart_stellaris_irq_rx_disable(const struct device *dev)
 {
-	volatile struct _uart *uart = UART_STRUCT(dev);
+	const struct uart_stellaris_config *config = dev->config;
 
-	uart->im &= ~UARTTIM_RXIM;
+	config->uart->im &= ~UARTTIM_RXIM;
 }
 
 /**
@@ -485,9 +492,9 @@ static void uart_stellaris_irq_rx_disable(const struct device *dev)
  */
 static int uart_stellaris_irq_rx_ready(const struct device *dev)
 {
-	volatile struct _uart *uart = UART_STRUCT(dev);
+	const struct uart_stellaris_config *config = dev->config;
 
-	return ((uart->mis & UARTMIS_RXMIS) == UARTMIS_RXMIS);
+	return ((config->uart->mis & UARTMIS_RXMIS) == UARTMIS_RXMIS);
 }
 
 /**
@@ -497,10 +504,10 @@ static int uart_stellaris_irq_rx_ready(const struct device *dev)
  */
 static void uart_stellaris_irq_err_enable(const struct device *dev)
 {
-	volatile struct _uart *uart = UART_STRUCT(dev);
+	const struct uart_stellaris_config *config = dev->config;
 
-	uart->im |= (UARTTIM_RTIM | UARTTIM_FEIM | UARTTIM_PEIM |
-		      UARTTIM_BEIM | UARTTIM_OEIM);
+	config->uart->im |= (UARTTIM_RTIM | UARTTIM_FEIM | UARTTIM_PEIM |
+			     UARTTIM_BEIM | UARTTIM_OEIM);
 }
 
 /**
@@ -510,10 +517,10 @@ static void uart_stellaris_irq_err_enable(const struct device *dev)
  */
 static void uart_stellaris_irq_err_disable(const struct device *dev)
 {
-	volatile struct _uart *uart = UART_STRUCT(dev);
+	const struct uart_stellaris_config *config = dev->config;
 
-	uart->im &= ~(UARTTIM_RTIM | UARTTIM_FEIM | UARTTIM_PEIM |
-		       UARTTIM_BEIM | UARTTIM_OEIM);
+	config->uart->im &= ~(UARTTIM_RTIM | UARTTIM_FEIM | UARTTIM_PEIM |
+			      UARTTIM_BEIM | UARTTIM_OEIM);
 }
 
 /**
@@ -525,10 +532,10 @@ static void uart_stellaris_irq_err_disable(const struct device *dev)
  */
 static int uart_stellaris_irq_is_pending(const struct device *dev)
 {
-	volatile struct _uart *uart = UART_STRUCT(dev);
+	const struct uart_stellaris_config *config = dev->config;
 
 	/* Look only at Tx and Rx data interrupt flags */
-	return ((uart->mis & (UARTMIS_RXMIS | UARTMIS_TXMIS)) ? 1 : 0);
+	return ((config->uart->mis & (UARTMIS_RXMIS | UARTMIS_TXMIS)) ? 1 : 0);
 }
 
 /**
@@ -608,8 +615,8 @@ static const struct uart_driver_api uart_stellaris_driver_api = {
 static void irq_config_func_0(const struct device *port);
 #endif
 
-static const struct uart_device_config uart_stellaris_dev_cfg_0 = {
-	.base = (uint8_t *)DT_INST_REG_ADDR(0),
+static const struct uart_stellaris_config uart_stellaris_dev_cfg_0 = {
+	.uart = (volatile struct _uart *)DT_INST_REG_ADDR(0),
 	.sys_clk_freq = DT_INST_PROP_BY_PHANDLE(0, clocks, clock_frequency),
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
@@ -647,8 +654,8 @@ static void irq_config_func_0(const struct device *dev)
 static void irq_config_func_1(const struct device *port);
 #endif
 
-static struct uart_device_config uart_stellaris_dev_cfg_1 = {
-	.base = (uint8_t *)DT_INST_REG_ADDR(1),
+static struct uart_stellaris_config uart_stellaris_dev_cfg_1 = {
+	.uart = (volatile struct _uart *)DT_INST_REG_ADDR(1),
 	.sys_clk_freq = DT_INST_PROP_BY_PHANDLE(1, clocks, clock_frequency),
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
@@ -686,8 +693,8 @@ static void irq_config_func_1(const struct device *dev)
 static void irq_config_func_2(const struct device *port);
 #endif
 
-static const struct uart_device_config uart_stellaris_dev_cfg_2 = {
-	.base = (uint8_t *)DT_INST_REG_ADDR(2),
+static const struct uart_stellaris_config uart_stellaris_dev_cfg_2 = {
+	.uart = (volatile struct _uart *)DT_INST_REG_ADDR(2),
 	.sys_clk_freq = DT_INST_PROP_BY_PHANDLE(2, clocks, clock_frequency),
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN

--- a/drivers/serial/uart_stellaris.c
+++ b/drivers/serial/uart_stellaris.c
@@ -85,43 +85,6 @@ struct uart_stellaris_dev_data_t {
 #endif
 };
 
-#define UART_STRUCT(dev) \
-	(((const struct uart_stellaris_config * const)(dev)->config)->uart)
-
-/* registers */
-#define UARTDR(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0x000)))
-#define UARTSR(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0x004)))
-#define UARTCR(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0x004)))
-#define UARTFR(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0x018)))
-#define UARTILPR(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0x020)))
-#define UARTIBRD(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0x024)))
-#define UARTFBRD(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0x028)))
-#define UARTLCRH(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0x02C)))
-#define UARTCTL(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0x030)))
-#define UARTIFLS(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0x034)))
-#define UARTIM(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0x038)))
-#define UARTRIS(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0x03C)))
-#define UARTMIS(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0x040)))
-#define UARTICR(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0x044)))
-
-/* ID registers: UARTPID = UARTPeriphID, UARTPCID = UARTPCellId */
-#define UARTPID4(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0xFD0)))
-#define UARTPID5(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0xFD4)))
-#define UARTPID6(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0xFD8)))
-#define UARTPID7(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0xFDC)))
-#define UARTPID0(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0xFE0)))
-#define UARTPID1(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0xFE4)))
-#define UARTPID2(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0xFE8)))
-#define UARTPID3(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0xFEC)))
-#define UARTPCID0(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0xFF0)))
-#define UARTPCID1(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0xFF4)))
-#define UARTPCID2(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0xFF8)))
-#define UARTPCID3(dev) (*((volatile uint32_t *)(UART_STRUCT(dev) + 0xFFC)))
-
-/* muxed UART registers */
-#define sr u1._sr /* Read: receive status */
-#define cr u1._cr /* Write: receive error clear */
-
 /* bits */
 #define UARTFR_BUSY 0x00000008
 #define UARTFR_RXFE 0x00000010

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -41,10 +41,6 @@ LOG_MODULE_REGISTER(uart_stm32);
 #define HAS_LPUART_1 (DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(lpuart1), \
 					 st_stm32_lpuart, okay))
 
-#define UART_STRUCT(dev)					\
-	((USART_TypeDef *)					\
-	 ((const struct uart_stm32_config *const)(dev)->config)->uconf.base)
-
 #if HAS_LPUART_1
 #ifdef USART_PRESC_PRESCALER
 uint32_t lpuartdiv_calc(const uint64_t clock_rate, const uint16_t presc_idx,
@@ -102,7 +98,6 @@ static inline void uart_stm32_set_baudrate(const struct device *dev,
 {
 	const struct uart_stm32_config *config = dev->config;
 	struct uart_stm32_data *data = dev->data;
-	USART_TypeDef *UartInstance = UART_STRUCT(dev);
 
 	uint32_t clock_rate;
 
@@ -115,7 +110,7 @@ static inline void uart_stm32_set_baudrate(const struct device *dev,
 	}
 
 #if HAS_LPUART_1
-	if (IS_LPUART_INSTANCE(UartInstance)) {
+	if (IS_LPUART_INSTANCE(config->usart)) {
 		uint32_t lpuartdiv;
 #ifdef USART_PRESC_PRESCALER
 		uint8_t presc_idx;
@@ -135,7 +130,7 @@ static inline void uart_stm32_set_baudrate(const struct device *dev,
 
 		presc_val = presc_idx << USART_PRESC_PRESCALER_Pos;
 
-		LL_LPUART_SetPrescaler(UartInstance, presc_val);
+		LL_LPUART_SetPrescaler(config->usart, presc_val);
 #else
 		lpuartdiv = lpuartdiv_calc(clock_rate, baud_rate);
 		if (lpuartdiv < LPUART_BRR_MIN_VALUE || lpuartdiv > LPUART_BRR_MASK) {
@@ -143,7 +138,7 @@ static inline void uart_stm32_set_baudrate(const struct device *dev,
 			return;
 		}
 #endif /* USART_PRESC_PRESCALER */
-		LL_LPUART_SetBaudRate(UartInstance,
+		LL_LPUART_SetBaudRate(config->usart,
 				      clock_rate,
 #ifdef USART_PRESC_PRESCALER
 				      presc_val,
@@ -152,10 +147,10 @@ static inline void uart_stm32_set_baudrate(const struct device *dev,
 	} else {
 #endif /* HAS_LPUART_1 */
 #ifdef USART_CR1_OVER8
-		LL_USART_SetOverSampling(UartInstance,
+		LL_USART_SetOverSampling(config->usart,
 					 LL_USART_OVERSAMPLING_16);
 #endif
-		LL_USART_SetBaudRate(UartInstance,
+		LL_USART_SetBaudRate(config->usart,
 				     clock_rate,
 #ifdef USART_PRESC_PRESCALER
 				     LL_USART_PRESCALER_DIV1,
@@ -173,61 +168,61 @@ static inline void uart_stm32_set_baudrate(const struct device *dev,
 static inline void uart_stm32_set_parity(const struct device *dev,
 					 uint32_t parity)
 {
-	USART_TypeDef *UartInstance = UART_STRUCT(dev);
+	const struct uart_stm32_config *config = dev->config;
 
-	LL_USART_SetParity(UartInstance, parity);
+	LL_USART_SetParity(config->usart, parity);
 }
 
 static inline uint32_t uart_stm32_get_parity(const struct device *dev)
 {
-	USART_TypeDef *UartInstance = UART_STRUCT(dev);
+	const struct uart_stm32_config *config = dev->config;
 
-	return LL_USART_GetParity(UartInstance);
+	return LL_USART_GetParity(config->usart);
 }
 
 static inline void uart_stm32_set_stopbits(const struct device *dev,
 					   uint32_t stopbits)
 {
-	USART_TypeDef *UartInstance = UART_STRUCT(dev);
+	const struct uart_stm32_config *config = dev->config;
 
-	LL_USART_SetStopBitsLength(UartInstance, stopbits);
+	LL_USART_SetStopBitsLength(config->usart, stopbits);
 }
 
 static inline uint32_t uart_stm32_get_stopbits(const struct device *dev)
 {
-	USART_TypeDef *UartInstance = UART_STRUCT(dev);
+	const struct uart_stm32_config *config = dev->config;
 
-	return LL_USART_GetStopBitsLength(UartInstance);
+	return LL_USART_GetStopBitsLength(config->usart);
 }
 
 static inline void uart_stm32_set_databits(const struct device *dev,
 					   uint32_t databits)
 {
-	USART_TypeDef *UartInstance = UART_STRUCT(dev);
+	const struct uart_stm32_config *config = dev->config;
 
-	LL_USART_SetDataWidth(UartInstance, databits);
+	LL_USART_SetDataWidth(config->usart, databits);
 }
 
 static inline uint32_t uart_stm32_get_databits(const struct device *dev)
 {
-	USART_TypeDef *UartInstance = UART_STRUCT(dev);
+	const struct uart_stm32_config *config = dev->config;
 
-	return LL_USART_GetDataWidth(UartInstance);
+	return LL_USART_GetDataWidth(config->usart);
 }
 
 static inline void uart_stm32_set_hwctrl(const struct device *dev,
 					 uint32_t hwctrl)
 {
-	USART_TypeDef *UartInstance = UART_STRUCT(dev);
+	const struct uart_stm32_config *config = dev->config;
 
-	LL_USART_SetHWFlowCtrl(UartInstance, hwctrl);
+	LL_USART_SetHWFlowCtrl(config->usart, hwctrl);
 }
 
 static inline uint32_t uart_stm32_get_hwctrl(const struct device *dev)
 {
-	USART_TypeDef *UartInstance = UART_STRUCT(dev);
+	const struct uart_stm32_config *config = dev->config;
 
-	return LL_USART_GetHWFlowCtrl(UartInstance);
+	return LL_USART_GetHWFlowCtrl(config->usart);
 }
 
 static inline uint32_t uart_stm32_cfg2ll_parity(enum uart_config_parity parity)
@@ -395,8 +390,8 @@ static inline enum uart_config_flow_control uart_stm32_ll2cfg_hwctrl(uint32_t fc
 static int uart_stm32_configure(const struct device *dev,
 				const struct uart_config *cfg)
 {
+	const struct uart_stm32_config *config = dev->config;
 	struct uart_stm32_data *data = dev->data;
-	USART_TypeDef *UartInstance = UART_STRUCT(dev);
 	const uint32_t parity = uart_stm32_cfg2ll_parity(cfg->parity);
 	const uint32_t stopbits = uart_stm32_cfg2ll_stopbits(cfg->stop_bits);
 	const uint32_t databits = uart_stm32_cfg2ll_databits(cfg->data_bits,
@@ -416,7 +411,7 @@ static int uart_stm32_configure(const struct device *dev,
 	}
 
 #if defined(LL_USART_STOPBITS_0_5) && HAS_LPUART_1
-	if (IS_LPUART_INSTANCE(UartInstance) &&
+	if (IS_LPUART_INSTANCE(config->usart) &&
 	    (cfg->stop_bits == UART_CFG_STOP_BITS_0_5)) {
 		return -ENOTSUP;
 	}
@@ -427,7 +422,7 @@ static int uart_stm32_configure(const struct device *dev,
 #endif
 
 #if defined(LL_USART_STOPBITS_1_5) && HAS_LPUART_1
-	if (IS_LPUART_INSTANCE(UartInstance) &&
+	if (IS_LPUART_INSTANCE(config->usart) &&
 	    (cfg->stop_bits == UART_CFG_STOP_BITS_1_5)) {
 		return -ENOTSUP;
 	}
@@ -449,13 +444,13 @@ static int uart_stm32_configure(const struct device *dev,
 
 	/* Driver supports only RTS CTS flow control */
 	if (cfg->flow_ctrl != UART_CFG_FLOW_CTRL_NONE) {
-		if (!IS_UART_HWFLOW_INSTANCE(UartInstance) ||
+		if (!IS_UART_HWFLOW_INSTANCE(config->usart) ||
 		    UART_CFG_FLOW_CTRL_RTS_CTS != cfg->flow_ctrl) {
 			return -ENOTSUP;
 		}
 	}
 
-	LL_USART_Disable(UartInstance);
+	LL_USART_Disable(config->usart);
 
 	if (parity != uart_stm32_get_parity(dev)) {
 		uart_stm32_set_parity(dev, parity);
@@ -478,7 +473,7 @@ static int uart_stm32_configure(const struct device *dev,
 		data->baud_rate = cfg->baudrate;
 	}
 
-	LL_USART_Enable(UartInstance);
+	LL_USART_Enable(config->usart);
 	return 0;
 };
 
@@ -501,22 +496,22 @@ static int uart_stm32_config_get(const struct device *dev,
 
 static int uart_stm32_poll_in(const struct device *dev, unsigned char *c)
 {
-	USART_TypeDef *UartInstance = UART_STRUCT(dev);
+	const struct uart_stm32_config *config = dev->config;
 
 	/* Clear overrun error flag */
-	if (LL_USART_IsActiveFlag_ORE(UartInstance)) {
-		LL_USART_ClearFlag_ORE(UartInstance);
+	if (LL_USART_IsActiveFlag_ORE(config->usart)) {
+		LL_USART_ClearFlag_ORE(config->usart);
 	}
 
 	/*
 	 * On stm32 F4X, F1X, and F2X, the RXNE flag is affected (cleared) by
 	 * the uart_err_check function call (on errors flags clearing)
 	 */
-	if (!LL_USART_IsActiveFlag_RXNE(UartInstance)) {
+	if (!LL_USART_IsActiveFlag_RXNE(config->usart)) {
 		return -1;
 	}
 
-	*c = (unsigned char)LL_USART_ReceiveData8(UartInstance);
+	*c = (unsigned char)LL_USART_ReceiveData8(config->usart);
 
 	return 0;
 }
@@ -524,7 +519,7 @@ static int uart_stm32_poll_in(const struct device *dev, unsigned char *c)
 static void uart_stm32_poll_out(const struct device *dev,
 					unsigned char c)
 {
-	USART_TypeDef *UartInstance = UART_STRUCT(dev);
+	const struct uart_stm32_config *config = dev->config;
 #ifdef CONFIG_PM
 	struct uart_stm32_data *data = dev->data;
 #endif
@@ -536,9 +531,9 @@ static void uart_stm32_poll_out(const struct device *dev,
 	 * interlaced with the characters potentially send with interrupt transmission API
 	 */
 	while (1) {
-		if (LL_USART_IsActiveFlag_TXE(UartInstance)) {
+		if (LL_USART_IsActiveFlag_TXE(config->usart)) {
 			key = irq_lock();
-			if (LL_USART_IsActiveFlag_TXE(UartInstance)) {
+			if (LL_USART_IsActiveFlag_TXE(config->usart)) {
 				break;
 			}
 			irq_unlock(key);
@@ -561,17 +556,17 @@ static void uart_stm32_poll_out(const struct device *dev,
 		/* Enable TC interrupt so we can release suspend
 		 * constraint when done
 		 */
-		LL_USART_EnableIT_TC(UartInstance);
+		LL_USART_EnableIT_TC(config->usart);
 	}
 #endif /* CONFIG_PM */
 
-	LL_USART_TransmitData8(UartInstance, (uint8_t)c);
+	LL_USART_TransmitData8(config->usart, (uint8_t)c);
 	irq_unlock(key);
 }
 
 static int uart_stm32_err_check(const struct device *dev)
 {
-	USART_TypeDef *UartInstance = UART_STRUCT(dev);
+	const struct uart_stm32_config *config = dev->config;
 	uint32_t err = 0U;
 
 	/* Check for errors, then clear them.
@@ -579,25 +574,25 @@ static int uart_stm32_err_check(const struct device *dev)
 	 * one is cleared. (e.g. F4X, F1X, and F2X).
 	 * The stm32 F4X, F1X, and F2X also reads the usart DR when clearing Errors
 	 */
-	if (LL_USART_IsActiveFlag_ORE(UartInstance)) {
+	if (LL_USART_IsActiveFlag_ORE(config->usart)) {
 		err |= UART_ERROR_OVERRUN;
 	}
 
-	if (LL_USART_IsActiveFlag_PE(UartInstance)) {
+	if (LL_USART_IsActiveFlag_PE(config->usart)) {
 		err |= UART_ERROR_PARITY;
 	}
 
-	if (LL_USART_IsActiveFlag_FE(UartInstance)) {
+	if (LL_USART_IsActiveFlag_FE(config->usart)) {
 		err |= UART_ERROR_FRAMING;
 	}
 
 #if !defined(CONFIG_SOC_SERIES_STM32F0X) || defined(USART_LIN_SUPPORT)
-	if (LL_USART_IsActiveFlag_LBD(UartInstance)) {
+	if (LL_USART_IsActiveFlag_LBD(config->usart)) {
 		err |= UART_BREAK;
 	}
 
 	if (err & UART_BREAK) {
-		LL_USART_ClearFlag_LBD(UartInstance);
+		LL_USART_ClearFlag_LBD(config->usart);
 	}
 #endif
 	/* Clearing error :
@@ -606,20 +601,20 @@ static int uart_stm32_err_check(const struct device *dev)
 	 * --> so is the RXNE flag also cleared !
 	 */
 	if (err & UART_ERROR_OVERRUN) {
-		LL_USART_ClearFlag_ORE(UartInstance);
+		LL_USART_ClearFlag_ORE(config->usart);
 	}
 
 	if (err & UART_ERROR_PARITY) {
-		LL_USART_ClearFlag_PE(UartInstance);
+		LL_USART_ClearFlag_PE(config->usart);
 	}
 
 	if (err & UART_ERROR_FRAMING) {
-		LL_USART_ClearFlag_FE(UartInstance);
+		LL_USART_ClearFlag_FE(config->usart);
 	}
 	/* Clear noise error as well,
 	 * it is not represented by the errors enum
 	 */
-	LL_USART_ClearFlag_NE(UartInstance);
+	LL_USART_ClearFlag_NE(config->usart);
 
 	return err;
 }
@@ -638,11 +633,11 @@ static int uart_stm32_fifo_fill(const struct device *dev,
 				  const uint8_t *tx_data,
 				  int size)
 {
-	USART_TypeDef *UartInstance = UART_STRUCT(dev);
+	const struct uart_stm32_config *config = dev->config;
 	uint8_t num_tx = 0U;
 	int key;
 
-	if (!LL_USART_IsActiveFlag_TXE(UartInstance)) {
+	if (!LL_USART_IsActiveFlag_TXE(config->usart)) {
 		return num_tx;
 	}
 
@@ -650,11 +645,11 @@ static int uart_stm32_fifo_fill(const struct device *dev,
 	key = irq_lock();
 
 	while ((size - num_tx > 0) &&
-	       LL_USART_IsActiveFlag_TXE(UartInstance)) {
+	       LL_USART_IsActiveFlag_TXE(config->usart)) {
 		/* TXE flag will be cleared with byte write to DR|RDR register */
 
 		/* Send a character (8bit , parity none) */
-		LL_USART_TransmitData8(UartInstance, tx_data[num_tx++]);
+		LL_USART_TransmitData8(config->usart, tx_data[num_tx++]);
 	}
 
 	irq_unlock(key);
@@ -665,19 +660,19 @@ static int uart_stm32_fifo_fill(const struct device *dev,
 static int uart_stm32_fifo_read(const struct device *dev, uint8_t *rx_data,
 				  const int size)
 {
-	USART_TypeDef *UartInstance = UART_STRUCT(dev);
+	const struct uart_stm32_config *config = dev->config;
 	uint8_t num_rx = 0U;
 
 	while ((size - num_rx > 0) &&
-	       LL_USART_IsActiveFlag_RXNE(UartInstance)) {
+	       LL_USART_IsActiveFlag_RXNE(config->usart)) {
 		/* RXNE flag will be cleared upon read from DR|RDR register */
 
 		/* Receive a character (8bit , parity none) */
-		rx_data[num_rx++] = LL_USART_ReceiveData8(UartInstance);
+		rx_data[num_rx++] = LL_USART_ReceiveData8(config->usart);
 
 		/* Clear overrun error flag */
-		if (LL_USART_IsActiveFlag_ORE(UartInstance)) {
-			LL_USART_ClearFlag_ORE(UartInstance);
+		if (LL_USART_IsActiveFlag_ORE(config->usart)) {
+			LL_USART_ClearFlag_ORE(config->usart);
 		/*
 		 * On stm32 F4X, F1X, and F2X, the RXNE flag is affected (cleared) by
 		 * the uart_err_check function call (on errors flags clearing)
@@ -690,7 +685,7 @@ static int uart_stm32_fifo_read(const struct device *dev, uint8_t *rx_data,
 
 static void uart_stm32_irq_tx_enable(const struct device *dev)
 {
-	USART_TypeDef *UartInstance = UART_STRUCT(dev);
+	const struct uart_stm32_config *config = dev->config;
 #ifdef CONFIG_PM
 	struct uart_stm32_data *data = dev->data;
 	int key;
@@ -702,7 +697,7 @@ static void uart_stm32_irq_tx_enable(const struct device *dev)
 	data->tx_int_stream_on = true;
 	uart_stm32_pm_constraint_set(dev);
 #endif
-	LL_USART_EnableIT_TC(UartInstance);
+	LL_USART_EnableIT_TC(config->usart);
 
 #ifdef CONFIG_PM
 	irq_unlock(key);
@@ -711,7 +706,7 @@ static void uart_stm32_irq_tx_enable(const struct device *dev)
 
 static void uart_stm32_irq_tx_disable(const struct device *dev)
 {
-	USART_TypeDef *UartInstance = UART_STRUCT(dev);
+	const struct uart_stm32_config *config = dev->config;
 #ifdef CONFIG_PM
 	struct uart_stm32_data *data = dev->data;
 	int key;
@@ -719,7 +714,7 @@ static void uart_stm32_irq_tx_disable(const struct device *dev)
 	key = irq_lock();
 #endif
 
-	LL_USART_DisableIT_TC(UartInstance);
+	LL_USART_DisableIT_TC(config->usart);
 
 #ifdef CONFIG_PM
 	data->tx_int_stream_on = false;
@@ -733,83 +728,83 @@ static void uart_stm32_irq_tx_disable(const struct device *dev)
 
 static int uart_stm32_irq_tx_ready(const struct device *dev)
 {
-	USART_TypeDef *UartInstance = UART_STRUCT(dev);
+	const struct uart_stm32_config *config = dev->config;
 
-	return LL_USART_IsActiveFlag_TXE(UartInstance) &&
-		LL_USART_IsEnabledIT_TC(UartInstance);
+	return LL_USART_IsActiveFlag_TXE(config->usart) &&
+		LL_USART_IsEnabledIT_TC(config->usart);
 }
 
 static int uart_stm32_irq_tx_complete(const struct device *dev)
 {
-	USART_TypeDef *UartInstance = UART_STRUCT(dev);
+	const struct uart_stm32_config *config = dev->config;
 
-	return LL_USART_IsActiveFlag_TC(UartInstance);
+	return LL_USART_IsActiveFlag_TC(config->usart);
 }
 
 static void uart_stm32_irq_rx_enable(const struct device *dev)
 {
-	USART_TypeDef *UartInstance = UART_STRUCT(dev);
+	const struct uart_stm32_config *config = dev->config;
 
-	LL_USART_EnableIT_RXNE(UartInstance);
+	LL_USART_EnableIT_RXNE(config->usart);
 }
 
 static void uart_stm32_irq_rx_disable(const struct device *dev)
 {
-	USART_TypeDef *UartInstance = UART_STRUCT(dev);
+	const struct uart_stm32_config *config = dev->config;
 
-	LL_USART_DisableIT_RXNE(UartInstance);
+	LL_USART_DisableIT_RXNE(config->usart);
 }
 
 static int uart_stm32_irq_rx_ready(const struct device *dev)
 {
-	USART_TypeDef *UartInstance = UART_STRUCT(dev);
+	const struct uart_stm32_config *config = dev->config;
 	/*
 	 * On stm32 F4X, F1X, and F2X, the RXNE flag is affected (cleared) by
 	 * the uart_err_check function call (on errors flags clearing)
 	 */
-	return LL_USART_IsActiveFlag_RXNE(UartInstance);
+	return LL_USART_IsActiveFlag_RXNE(config->usart);
 }
 
 static void uart_stm32_irq_err_enable(const struct device *dev)
 {
-	USART_TypeDef *UartInstance = UART_STRUCT(dev);
+	const struct uart_stm32_config *config = dev->config;
 
 	/* Enable FE, ORE interruptions */
-	LL_USART_EnableIT_ERROR(UartInstance);
+	LL_USART_EnableIT_ERROR(config->usart);
 #if !defined(CONFIG_SOC_SERIES_STM32F0X) || defined(USART_LIN_SUPPORT)
 	/* Enable Line break detection */
-	if (IS_UART_LIN_INSTANCE(UartInstance)) {
-		LL_USART_EnableIT_LBD(UartInstance);
+	if (IS_UART_LIN_INSTANCE(config->usart)) {
+		LL_USART_EnableIT_LBD(config->usart);
 	}
 #endif
 	/* Enable parity error interruption */
-	LL_USART_EnableIT_PE(UartInstance);
+	LL_USART_EnableIT_PE(config->usart);
 }
 
 static void uart_stm32_irq_err_disable(const struct device *dev)
 {
-	USART_TypeDef *UartInstance = UART_STRUCT(dev);
+	const struct uart_stm32_config *config = dev->config;
 
 	/* Disable FE, ORE interruptions */
-	LL_USART_DisableIT_ERROR(UartInstance);
+	LL_USART_DisableIT_ERROR(config->usart);
 #if !defined(CONFIG_SOC_SERIES_STM32F0X) || defined(USART_LIN_SUPPORT)
 	/* Disable Line break detection */
-	if (IS_UART_LIN_INSTANCE(UartInstance)) {
-		LL_USART_DisableIT_LBD(UartInstance);
+	if (IS_UART_LIN_INSTANCE(config->usart)) {
+		LL_USART_DisableIT_LBD(config->usart);
 	}
 #endif
 	/* Disable parity error interruption */
-	LL_USART_DisableIT_PE(UartInstance);
+	LL_USART_DisableIT_PE(config->usart);
 }
 
 static int uart_stm32_irq_is_pending(const struct device *dev)
 {
-	USART_TypeDef *UartInstance = UART_STRUCT(dev);
+	const struct uart_stm32_config *config = dev->config;
 
-	return ((LL_USART_IsActiveFlag_RXNE(UartInstance) &&
-		 LL_USART_IsEnabledIT_RXNE(UartInstance)) ||
-		(LL_USART_IsActiveFlag_TC(UartInstance) &&
-		 LL_USART_IsEnabledIT_TC(UartInstance)));
+	return ((LL_USART_IsActiveFlag_RXNE(config->usart) &&
+		 LL_USART_IsEnabledIT_RXNE(config->usart)) ||
+		(LL_USART_IsActiveFlag_TC(config->usart) &&
+		 LL_USART_IsEnabledIT_TC(config->usart)));
 }
 
 static int uart_stm32_irq_update(const struct device *dev)
@@ -964,18 +959,18 @@ static void uart_stm32_isr(const struct device *dev)
 {
 	struct uart_stm32_data *data = dev->data;
 #if defined(CONFIG_PM) || defined(CONFIG_UART_ASYNC_API)
-	USART_TypeDef *UartInstance = UART_STRUCT(dev);
+	const struct uart_stm32_config *config = dev->config;
 #endif
 
 #ifdef CONFIG_PM
-	if (LL_USART_IsEnabledIT_TC(UartInstance) &&
-		LL_USART_IsActiveFlag_TC(UartInstance)) {
+	if (LL_USART_IsEnabledIT_TC(config->usart) &&
+		LL_USART_IsActiveFlag_TC(config->usart)) {
 
 		if (data->tx_poll_stream_on) {
 			/* A poll stream transmition just completed,
 			 * allow system to suspend
 			 */
-			LL_USART_DisableIT_TC(UartInstance);
+			LL_USART_DisableIT_TC(config->usart);
 			data->tx_poll_stream_on = false;
 			uart_stm32_pm_constraint_release(dev);
 		}
@@ -993,10 +988,10 @@ static void uart_stm32_isr(const struct device *dev)
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 
 #ifdef CONFIG_UART_ASYNC_API
-	if (LL_USART_IsEnabledIT_IDLE(UartInstance) &&
-			LL_USART_IsActiveFlag_IDLE(UartInstance)) {
+	if (LL_USART_IsEnabledIT_IDLE(config->usart) &&
+			LL_USART_IsActiveFlag_IDLE(config->usart)) {
 
-		LL_USART_ClearFlag_IDLE(UartInstance);
+		LL_USART_ClearFlag_IDLE(config->usart);
 
 		LOG_DBG("idle interrupt occurred");
 
@@ -1007,25 +1002,25 @@ static void uart_stm32_isr(const struct device *dev)
 		if (data->dma_rx.timeout == 0) {
 			uart_stm32_dma_rx_flush(dev);
 		}
-	} else if (LL_USART_IsEnabledIT_TC(UartInstance) &&
-			LL_USART_IsActiveFlag_TC(UartInstance)) {
+	} else if (LL_USART_IsEnabledIT_TC(config->usart) &&
+			LL_USART_IsActiveFlag_TC(config->usart)) {
 
-		LL_USART_DisableIT_TC(UartInstance);
-		LL_USART_ClearFlag_TC(UartInstance);
+		LL_USART_DisableIT_TC(config->usart);
+		LL_USART_ClearFlag_TC(config->usart);
 		/* Generate TX_DONE event when transmission is done */
 		async_evt_tx_done(data);
 
 #ifdef CONFIG_PM
 		uart_stm32_pm_constraint_release(dev);
 #endif
-	} else if (LL_USART_IsEnabledIT_RXNE(UartInstance) &&
-			LL_USART_IsActiveFlag_RXNE(UartInstance)) {
+	} else if (LL_USART_IsEnabledIT_RXNE(config->usart) &&
+			LL_USART_IsActiveFlag_RXNE(config->usart)) {
 #ifdef USART_SR_RXNE
 		/* clear the RXNE flag, because Rx data was not read */
-		LL_USART_ClearFlag_RXNE(UartInstance);
+		LL_USART_ClearFlag_RXNE(config->usart);
 #else
 		/* clear the RXNE by flushing the fifo, because Rx data was not read */
-		LL_USART_RequestRxDataFlush(UartInstance);
+		LL_USART_RequestRxDataFlush(config->usart);
 #endif /* USART_SR_RXNE */
 	}
 
@@ -1051,24 +1046,24 @@ static int uart_stm32_async_callback_set(const struct device *dev,
 
 static inline void uart_stm32_dma_tx_enable(const struct device *dev)
 {
-	USART_TypeDef *UartInstance = UART_STRUCT(dev);
+	const struct uart_stm32_config *config = dev->config;
 
-	LL_USART_EnableDMAReq_TX(UartInstance);
+	LL_USART_EnableDMAReq_TX(config->usart);
 }
 
 static inline void uart_stm32_dma_tx_disable(const struct device *dev)
 {
-	USART_TypeDef *UartInstance = UART_STRUCT(dev);
+	const struct uart_stm32_config *config = dev->config;
 
-	LL_USART_DisableDMAReq_TX(UartInstance);
+	LL_USART_DisableDMAReq_TX(config->usart);
 }
 
 static inline void uart_stm32_dma_rx_enable(const struct device *dev)
 {
-	USART_TypeDef *UartInstance = UART_STRUCT(dev);
+	const struct uart_stm32_config *config = dev->config;
 	struct uart_stm32_data *data = dev->data;
 
-	LL_USART_EnableDMAReq_RX(UartInstance);
+	LL_USART_EnableDMAReq_RX(config->usart);
 
 	data->dma_rx.enabled = true;
 }
@@ -1082,8 +1077,8 @@ static inline void uart_stm32_dma_rx_disable(const struct device *dev)
 
 static int uart_stm32_async_rx_disable(const struct device *dev)
 {
+	const struct uart_stm32_config *config = dev->config;
 	struct uart_stm32_data *data = dev->data;
-	USART_TypeDef *UartInstance = UART_STRUCT(dev);
 	struct uart_event disabled_event = {
 		.type = UART_RX_DISABLED
 	};
@@ -1093,7 +1088,7 @@ static int uart_stm32_async_rx_disable(const struct device *dev)
 		return -EFAULT;
 	}
 
-	LL_USART_DisableIT_IDLE(UartInstance);
+	LL_USART_DisableIT_IDLE(config->usart);
 
 	uart_stm32_dma_rx_flush(dev);
 
@@ -1109,7 +1104,7 @@ static int uart_stm32_async_rx_disable(const struct device *dev)
 	data->rx_next_buffer_len = 0;
 
 	/* When async rx is disabled, enable interruptable instance of uart to function normally*/
-	LL_USART_EnableIT_RXNE(UartInstance);
+	LL_USART_EnableIT_RXNE(config->usart);
 
 	LOG_DBG("rx: disabled");
 
@@ -1144,6 +1139,7 @@ void uart_stm32_dma_tx_cb(const struct device *dma_dev, void *user_data,
 
 static void uart_stm32_dma_replace_buffer(const struct device *dev)
 {
+	const struct uart_stm32_config *config = dev->config;
 	struct uart_stm32_data *data = dev->data;
 
 	/* Replace the buffer and relod the DMA */
@@ -1166,9 +1162,7 @@ static void uart_stm32_dma_replace_buffer(const struct device *dev)
 
 	dma_start(data->dma_rx.dma_dev, data->dma_rx.dma_channel);
 
-	USART_TypeDef *UartInstance = UART_STRUCT(dev);
-
-	LL_USART_ClearFlag_IDLE(UartInstance);
+	LL_USART_ClearFlag_IDLE(config->usart);
 
 	/* Request next buffer */
 	async_evt_rx_buf_request(data);
@@ -1214,8 +1208,8 @@ void uart_stm32_dma_rx_cb(const struct device *dma_dev, void *user_data,
 static int uart_stm32_async_tx(const struct device *dev,
 		const uint8_t *tx_data, size_t buf_size, int32_t timeout)
 {
+	const struct uart_stm32_config *config = dev->config;
 	struct uart_stm32_data *data = dev->data;
-	USART_TypeDef *UartInstance = UART_STRUCT(dev);
 	int ret;
 
 	if (data->dma_tx.dma_dev == NULL) {
@@ -1233,10 +1227,10 @@ static int uart_stm32_async_tx(const struct device *dev,
 	LOG_DBG("tx: l=%d", data->dma_tx.buffer_length);
 
 	/* Clear TC flag */
-	LL_USART_ClearFlag_TC(UartInstance);
+	LL_USART_ClearFlag_TC(config->usart);
 
 	/* Enable TC interrupt so we can signal correct TX done */
-	LL_USART_EnableIT_TC(UartInstance);
+	LL_USART_EnableIT_TC(config->usart);
 
 	/* set source address */
 	data->dma_tx.blk_cfg.source_address = (uint32_t)data->dma_tx.buffer;
@@ -1273,8 +1267,8 @@ static int uart_stm32_async_tx(const struct device *dev,
 static int uart_stm32_async_rx_enable(const struct device *dev,
 		uint8_t *rx_buf, size_t buf_size, int32_t timeout)
 {
+	const struct uart_stm32_config *config = dev->config;
 	struct uart_stm32_data *data = dev->data;
-	USART_TypeDef *UartInstance = UART_STRUCT(dev);
 	int ret;
 
 	if (data->dma_rx.dma_dev == NULL) {
@@ -1293,7 +1287,7 @@ static int uart_stm32_async_rx_enable(const struct device *dev,
 	data->dma_rx.timeout = timeout;
 
 	/* Disable RX interrupts to let DMA to handle it */
-	LL_USART_DisableIT_RXNE(UartInstance);
+	LL_USART_DisableIT_RXNE(config->usart);
 
 	data->dma_rx.blk_cfg.block_size = buf_size;
 	data->dma_rx.blk_cfg.dest_address = (uint32_t)data->dma_rx.buffer;
@@ -1317,10 +1311,10 @@ static int uart_stm32_async_rx_enable(const struct device *dev,
 	/* Enable IRQ IDLE to define the end of a
 	 * RX DMA transaction.
 	 */
-	LL_USART_ClearFlag_IDLE(UartInstance);
-	LL_USART_EnableIT_IDLE(UartInstance);
+	LL_USART_ClearFlag_IDLE(config->usart);
+	LL_USART_EnableIT_IDLE(config->usart);
 
-	LL_USART_EnableIT_ERROR(UartInstance);
+	LL_USART_EnableIT_ERROR(config->usart);
 
 	/* Request next buffer */
 	async_evt_rx_buf_request(data);
@@ -1398,8 +1392,8 @@ static int uart_stm32_async_rx_buf_rsp(const struct device *dev, uint8_t *buf,
 
 static int uart_stm32_async_init(const struct device *dev)
 {
+	const struct uart_stm32_config *config = dev->config;
 	struct uart_stm32_data *data = dev->data;
-	USART_TypeDef *UartInstance = UART_STRUCT(dev);
 
 	data->uart_dev = dev;
 
@@ -1432,10 +1426,10 @@ static int uart_stm32_async_init(const struct device *dev)
 	defined(CONFIG_SOC_SERIES_STM32F4X) || \
 	defined(CONFIG_SOC_SERIES_STM32L1X)
 	data->dma_rx.blk_cfg.source_address =
-				LL_USART_DMA_GetRegAddr(UartInstance);
+				LL_USART_DMA_GetRegAddr(config->usart);
 #else
 	data->dma_rx.blk_cfg.source_address =
-				LL_USART_DMA_GetRegAddr(UartInstance,
+				LL_USART_DMA_GetRegAddr(config->usart,
 						LL_USART_DMA_REG_DATA_RECEIVE);
 #endif
 
@@ -1471,10 +1465,10 @@ static int uart_stm32_async_init(const struct device *dev)
 	defined(CONFIG_SOC_SERIES_STM32F4X) || \
 	defined(CONFIG_SOC_SERIES_STM32L1X)
 	data->dma_tx.blk_cfg.dest_address =
-			LL_USART_DMA_GetRegAddr(UartInstance);
+			LL_USART_DMA_GetRegAddr(config->usart);
 #else
 	data->dma_tx.blk_cfg.dest_address =
-			LL_USART_DMA_GetRegAddr(UartInstance,
+			LL_USART_DMA_GetRegAddr(config->usart,
 					LL_USART_DMA_REG_DATA_TRANSMIT);
 #endif
 
@@ -1550,7 +1544,6 @@ static int uart_stm32_init(const struct device *dev)
 {
 	const struct uart_stm32_config *config = dev->config;
 	struct uart_stm32_data *data = dev->data;
-	USART_TypeDef *UartInstance = UART_STRUCT(dev);
 	uint32_t ll_parity;
 	uint32_t ll_datawidth;
 	int err;
@@ -1568,10 +1561,10 @@ static int uart_stm32_init(const struct device *dev)
 		return err;
 	}
 
-	LL_USART_Disable(UartInstance);
+	LL_USART_Disable(config->usart);
 
 	/* TX/RX direction */
-	LL_USART_SetTransferDirection(UartInstance,
+	LL_USART_SetTransferDirection(config->usart,
 				      LL_USART_DIRECTION_TX_RX);
 
 	/* Determine the datawidth and parity. If we use other parity than
@@ -1596,7 +1589,7 @@ static int uart_stm32_init(const struct device *dev)
 	}
 
 	/* Set datawidth and parity, 1 start bit, 1 stop bit  */
-	LL_USART_ConfigCharacter(UartInstance,
+	LL_USART_ConfigCharacter(config->usart,
 				 ll_datawidth,
 				 ll_parity,
 				 LL_USART_STOPBITS_1);
@@ -1610,20 +1603,20 @@ static int uart_stm32_init(const struct device *dev)
 
 	/* Enable the single wire / half-duplex mode */
 	if (config->single_wire) {
-		LL_USART_EnableHalfDuplex(UartInstance);
+		LL_USART_EnableHalfDuplex(config->usart);
 	}
 
-	LL_USART_Enable(UartInstance);
+	LL_USART_Enable(config->usart);
 
 #ifdef USART_ISR_TEACK
 	/* Wait until TEACK flag is set */
-	while (!(LL_USART_IsActiveFlag_TEACK(UartInstance))) {
+	while (!(LL_USART_IsActiveFlag_TEACK(config->usart))) {
 	}
 #endif /* !USART_ISR_TEACK */
 
 #ifdef USART_ISR_REACK
 	/* Wait until REACK flag is set */
-	while (!(LL_USART_IsActiveFlag_REACK(UartInstance))) {
+	while (!(LL_USART_IsActiveFlag_REACK(config->usart))) {
 	}
 #endif /* !USART_ISR_REACK */
 
@@ -1719,8 +1712,8 @@ STM32_UART_IRQ_HANDLER_DECL(index)					\
 PINCTRL_DT_INST_DEFINE(index);						\
 									\
 static const struct uart_stm32_config uart_stm32_cfg_##index = {	\
+	.usart = (USART_TypeDef *)DT_INST_REG_ADDR(index),		\
 	.uconf = {							\
-		.base = (uint8_t *)DT_INST_REG_ADDR(index),		\
 		STM32_UART_IRQ_HANDLER_FUNC(index)			\
 	},								\
 	.pclken = { .bus = DT_INST_CLOCKS_CELL(index, bus),		\

--- a/drivers/serial/uart_stm32.h
+++ b/drivers/serial/uart_stm32.h
@@ -14,8 +14,12 @@
 
 #include <drivers/pinctrl.h>
 
+#include <stm32_ll_usart.h>
+
 /* device config */
 struct uart_stm32_config {
+	/* USART instance */
+	USART_TypeDef *usart;
 	struct uart_device_config uconf;
 	/* clock subsystem driving this peripheral */
 	struct stm32_pclken pclken;

--- a/drivers/serial/uart_stm32.h
+++ b/drivers/serial/uart_stm32.h
@@ -20,7 +20,6 @@
 struct uart_stm32_config {
 	/* USART instance */
 	USART_TypeDef *usart;
-	struct uart_device_config uconf;
 	/* clock subsystem driving this peripheral */
 	struct stm32_pclken pclken;
 	/* initial hardware flow control, 1 for RTS/CTS */
@@ -30,9 +29,8 @@ struct uart_stm32_config {
 	/* switch to enable single wire / half duplex feature */
 	bool single_wire;
 	const struct pinctrl_dev_config *pcfg;
-#if defined(CONFIG_PM) \
-	&& !defined(CONFIG_UART_INTERRUPT_DRIVEN) \
-	&& !defined(CONFIG_UART_ASYNC_API)
+#if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API) || \
+	defined(CONFIG_PM)
 	uart_irq_config_func_t irq_config_func;
 #endif
 };

--- a/drivers/serial/uart_xlnx_ps.c
+++ b/drivers/serial/uart_xlnx_ps.c
@@ -133,7 +133,11 @@
 
 /** Device configuration structure */
 struct uart_xlnx_ps_dev_config {
-	struct uart_device_config uconf;
+	uint32_t reg;
+	uint32_t sys_clk_freq;
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	uart_irq_config_func_t irq_config_func;
+#endif
 	uint32_t baud_rate;
 };
 
@@ -225,7 +229,7 @@ static void set_baudrate(const struct device *dev, uint32_t baud_rate)
 	uint32_t reg_base;
 
 	baud = dev_cfg->baud_rate;
-	clk_freq = dev_cfg->uconf.sys_clk_freq;
+	clk_freq = dev_cfg->sys_clk_freq;
 
 	/* Calculate divisor and baud rate generator value */
 	if ((baud != 0) && (clk_freq != 0)) {
@@ -260,7 +264,7 @@ static void set_baudrate(const struct device *dev, uint32_t baud_rate)
 		 * be changed safely at this time.
 		 */
 
-		reg_base = dev_cfg->uconf.regs;
+		reg_base = dev_cfg->reg;
 		sys_write32(divisor, reg_base + XUARTPS_BAUDDIV_OFFSET);
 		sys_write32(generator, reg_base + XUARTPS_BAUDGEN_OFFSET);
 	}
@@ -281,7 +285,7 @@ static int uart_xlnx_ps_init(const struct device *dev)
 	uint32_t reg_val;
 	uint32_t reg_base;
 
-	reg_base = dev_cfg->uconf.regs;
+	reg_base = dev_cfg->reg;
 
 	/* Disable RX/TX before changing any configuration data */
 	xlnx_ps_disable_uart(reg_base);
@@ -309,7 +313,7 @@ static int uart_xlnx_ps_init(const struct device *dev)
 	sys_write32(XUARTPS_IXR_MASK, reg_base + XUARTPS_ISR_OFFSET);
 
 	/* Attach to & unmask the corresponding interrupt vector */
-	dev_cfg->uconf.irq_config_func(dev);
+	dev_cfg->irq_config_func(dev);
 
 #endif
 
@@ -332,7 +336,7 @@ static int uart_xlnx_ps_poll_in(const struct device *dev, unsigned char *c)
 	uint32_t reg_val;
 	uint32_t reg_base;
 
-	reg_base = dev_cfg->uconf.regs;
+	reg_base = dev_cfg->reg;
 	reg_val = sys_read32(reg_base + XUARTPS_SR_OFFSET);
 	if ((reg_val & XUARTPS_SR_RXEMPTY) == 0) {
 		*c = (unsigned char)sys_read32(reg_base +
@@ -363,7 +367,7 @@ static void uart_xlnx_ps_poll_out(const struct device *dev, unsigned char c)
 	uint32_t reg_val;
 	uint32_t reg_base;
 
-	reg_base = dev_cfg->uconf.regs;
+	reg_base = dev_cfg->reg;
 	/* wait for transmitter to ready to accept a character */
 	do {
 		reg_val = sys_read32(reg_base + XUARTPS_SR_OFFSET);
@@ -593,7 +597,7 @@ static int uart_xlnx_ps_configure(const struct device *dev,
 	struct uart_xlnx_ps_dev_config *dev_cfg =
 	(struct uart_xlnx_ps_dev_config *)dev->config;
 
-	uint32_t reg_base    = dev_cfg->uconf.regs;
+	uint32_t reg_base    = dev_cfg->reg;
 	uint32_t mode_reg    = 0;
 	uint32_t modemcr_reg = 0;
 
@@ -806,7 +810,7 @@ static int uart_xlnx_ps_config_get(const struct device *dev,
 	 * Control register).
 	 */
 
-	uint32_t reg_base    = dev_cfg->uconf.regs;
+	uint32_t reg_base    = dev_cfg->reg;
 	uint32_t mode_reg    = sys_read32(reg_base + XUARTPS_MR_OFFSET);
 	uint32_t modemcr_reg = sys_read32(reg_base + XUARTPS_MODEMCR_OFFSET);
 
@@ -836,7 +840,7 @@ static int uart_xlnx_ps_fifo_fill(const struct device *dev,
 				  int size)
 {
 	const struct uart_xlnx_ps_dev_config *dev_cfg = dev->config;
-	uint32_t reg_base = dev_cfg->uconf.regs;
+	uint32_t reg_base = dev_cfg->reg;
 	uint32_t data_iter = 0;
 
 	sys_write32(XUARTPS_IXR_TXEMPTY, reg_base + XUARTPS_IDR_OFFSET);
@@ -867,7 +871,7 @@ static int uart_xlnx_ps_fifo_read(const struct device *dev, uint8_t *rx_data,
 	uint32_t reg_base;
 	int inum = 0;
 
-	reg_base = dev_cfg->uconf.regs;
+	reg_base = dev_cfg->reg;
 	reg_val = sys_read32(reg_base + XUARTPS_SR_OFFSET);
 
 	while (inum < size && (reg_val & XUARTPS_SR_RXEMPTY) == 0) {
@@ -890,7 +894,7 @@ static void uart_xlnx_ps_irq_tx_enable(const struct device *dev)
 	const struct uart_xlnx_ps_dev_config *dev_cfg = dev->config;
 	uint32_t reg_base;
 
-	reg_base = dev_cfg->uconf.regs;
+	reg_base = dev_cfg->reg;
 	sys_write32(
 		(XUARTPS_IXR_TTRIG | XUARTPS_IXR_TXEMPTY),
 		reg_base + XUARTPS_IER_OFFSET);
@@ -906,7 +910,7 @@ static void uart_xlnx_ps_irq_tx_disable(const struct device *dev)
 	const struct uart_xlnx_ps_dev_config *dev_cfg = dev->config;
 	uint32_t reg_base;
 
-	reg_base = dev_cfg->uconf.regs;
+	reg_base = dev_cfg->reg;
 	sys_write32(
 		(XUARTPS_IXR_TTRIG | XUARTPS_IXR_TXEMPTY),
 		reg_base + XUARTPS_IDR_OFFSET);
@@ -922,7 +926,7 @@ static void uart_xlnx_ps_irq_tx_disable(const struct device *dev)
 static int uart_xlnx_ps_irq_tx_ready(const struct device *dev)
 {
 	const struct uart_xlnx_ps_dev_config *dev_cfg = dev->config;
-	uint32_t reg_base = dev_cfg->uconf.regs;
+	uint32_t reg_base = dev_cfg->reg;
 	uint32_t reg_val = sys_read32(reg_base + XUARTPS_SR_OFFSET);
 
 	if ((reg_val & (XUARTPS_SR_TTRIG | XUARTPS_SR_TXEMPTY)) == 0) {
@@ -945,7 +949,7 @@ static int uart_xlnx_ps_irq_tx_complete(const struct device *dev)
 	uint32_t reg_base;
 	uint32_t reg_val;
 
-	reg_base = dev_cfg->uconf.regs;
+	reg_base = dev_cfg->reg;
 	reg_val = sys_read32(reg_base + XUARTPS_SR_OFFSET);
 	if ((reg_val & XUARTPS_SR_TXEMPTY) == 0) {
 		return 0;
@@ -964,7 +968,7 @@ static void uart_xlnx_ps_irq_rx_enable(const struct device *dev)
 	const struct uart_xlnx_ps_dev_config *dev_cfg = dev->config;
 	uint32_t reg_base;
 
-	reg_base = dev_cfg->uconf.regs;
+	reg_base = dev_cfg->reg;
 	sys_write32(XUARTPS_IXR_RTRIG, reg_base + XUARTPS_IER_OFFSET);
 }
 
@@ -978,7 +982,7 @@ static void uart_xlnx_ps_irq_rx_disable(const struct device *dev)
 	const struct uart_xlnx_ps_dev_config *dev_cfg = dev->config;
 	uint32_t reg_base;
 
-	reg_base = dev_cfg->uconf.regs;
+	reg_base = dev_cfg->reg;
 	sys_write32(XUARTPS_IXR_RTRIG, reg_base + XUARTPS_IDR_OFFSET);
 }
 
@@ -992,7 +996,7 @@ static void uart_xlnx_ps_irq_rx_disable(const struct device *dev)
 static int uart_xlnx_ps_irq_rx_ready(const struct device *dev)
 {
 	const struct uart_xlnx_ps_dev_config *dev_cfg = dev->config;
-	uint32_t reg_base = dev_cfg->uconf.regs;
+	uint32_t reg_base = dev_cfg->reg;
 	uint32_t reg_val = sys_read32(reg_base + XUARTPS_ISR_OFFSET);
 
 	if ((reg_val & XUARTPS_IXR_RTRIG) == 0) {
@@ -1013,7 +1017,7 @@ static void uart_xlnx_ps_irq_err_enable(const struct device *dev)
 	const struct uart_xlnx_ps_dev_config *dev_cfg = dev->config;
 	uint32_t reg_base;
 
-	reg_base = dev_cfg->uconf.regs;
+	reg_base = dev_cfg->reg;
 	sys_write32(
 		  XUARTPS_IXR_TOVR    /* [12] Transmitter FIFO Overflow */
 		| XUARTPS_IXR_TOUT    /* [8]  Receiver Timerout */
@@ -1035,7 +1039,7 @@ static void uart_xlnx_ps_irq_err_disable(const struct device *dev)
 	const struct uart_xlnx_ps_dev_config *dev_cfg = dev->config;
 	uint32_t reg_base;
 
-	reg_base = dev_cfg->uconf.regs;
+	reg_base = dev_cfg->reg;
 	sys_write32(
 		  XUARTPS_IXR_TOVR    /* [12] Transmitter FIFO Overflow */
 		| XUARTPS_IXR_TOUT    /* [8]  Receiver Timerout */
@@ -1059,7 +1063,7 @@ static int uart_xlnx_ps_irq_is_pending(const struct device *dev)
 	uint32_t reg_imr;
 	uint32_t reg_isr;
 
-	reg_base = dev_cfg->uconf.regs;
+	reg_base = dev_cfg->reg;
 	reg_imr = sys_read32(reg_base + XUARTPS_IMR_OFFSET);
 	reg_isr = sys_read32(reg_base + XUARTPS_ISR_OFFSET);
 
@@ -1168,12 +1172,10 @@ static struct uart_xlnx_ps_dev_data_t uart_xlnx_ps_dev_data_##port
 
 #define UART_XLNX_PS_DEV_CFG(port) \
 static struct uart_xlnx_ps_dev_config uart_xlnx_ps_dev_cfg_##port = { \
-	.uconf = { \
-		.regs = DT_INST_REG_ADDR(port), \
-		.sys_clk_freq = DT_INST_PROP(port, clock_frequency), \
-		UART_XLNX_PS_IRQ_CONF_FUNC_SET(port) \
-	}, \
+	.reg = DT_INST_REG_ADDR(port), \
+	.sys_clk_freq = DT_INST_PROP(port, clock_frequency), \
 	.baud_rate = DT_INST_PROP(port, current_speed), \
+	UART_XLNX_PS_IRQ_CONF_FUNC_SET(port) \
 }
 
 #define UART_XLNX_PS_INIT(port) \

--- a/include/drivers/uart.h
+++ b/include/drivers/uart.h
@@ -343,28 +343,6 @@ typedef void (*uart_callback_t)(const struct device *dev,
  * For internal driver use only, skip these in public documentation.
  */
 
-/**
- * @brief UART device configuration.
- *
- * @param port Base port number
- * @param base Memory mapped base address
- * @param regs Register address
- * @param sys_clk_freq System clock frequency in Hz
- */
-struct uart_device_config {
-	union {
-		uint32_t port;
-		uint8_t *base;
-		uint32_t regs;
-	};
-
-	uint32_t sys_clk_freq;
-
-#if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API)
-	uart_irq_config_func_t	irq_config_func;
-#endif
-};
-
 /** @brief Driver API structure. */
 __subsystem struct uart_driver_api {
 


### PR DESCRIPTION
This PR removes `struct uart_device_config` from drivers using it, and does some cleanups thanks to this removal. The main points to remove this structure:

1. It is not used by all drivers (in fact, I think it's a minority using it)
2. It pretends to be generic, but it is not. For example, the field that stores the register base address is not suitable for most drivers.
3. No other subsystems are using this kind of inheritance mechanism (I think).
4. Some fields are not always used, wasting extra ROM space (e.g. sys_clk_freq).

Fixes #42130