### PR TITLE
kernel/init.c: Initialise logging subsystem after arch

### DIFF
--- a/kernel/init.c
+++ b/kernel/init.c
@@ -400,10 +400,10 @@ FUNC_NORETURN void z_cstart(void)
 	/* gcov hook needed to get the coverage report.*/
 	gcov_static_init();
 
-	LOG_CORE_INIT();
-
 	/* perform any architecture-specific initialization */
 	arch_kernel_init();
+
+	LOG_CORE_INIT();
 
 #if defined(CONFIG_MULTITHREADING)
 	/* Note: The z_ready_thread() call in prepare_multithreading() requires

--- a/tests/kernel/obj_tracking/testcase.yaml
+++ b/tests/kernel/obj_tracking/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   kernel.objects.tracking:
     tags: kernel
-    platform_exclude: qemu_x86_tiny intel_adsp_cavs25
+    platform_exclude: qemu_x86_tiny


### PR DESCRIPTION
So that logging and "satellite" subsystems, such as tracing and object
tracking can count on kernel structs being properly initialised, such
as `_current_cpu`.

Fixes #42061.

Signed-off-by: Ederson de Souza <ederson.desouza@intel.com>