### PR TITLE
drivers: dma: mcux_lpc_dma: Fix data variable name

### DIFF
--- a/drivers/dma/dma_mcux_lpc.c
+++ b/drivers/dma/dma_mcux_lpc.c
@@ -380,7 +380,7 @@ static int dma_mcux_lpc_reload(const struct device *dev, uint32_t channel,
 			       uint32_t src, uint32_t dst, size_t size)
 {
 	struct dma_mcux_lpc_dma_data *dev_data = dev->data;
-	uint32_t virtual_channel = data->channel_index[channel];
+	uint32_t virtual_channel = dev_data->channel_index[channel];
 	struct call_back *data = DEV_CHANNEL_DATA(dev, virtual_channel);
 	uint8_t src_inc, dst_inc;
 	uint32_t xferConfig = 0U;


### PR DESCRIPTION
Device 'data' variable name was incorrect due to recent treewide naming
cleanups. Fix variable name to fix build error.

Fixes #42118

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>