### PR TITLE
sensor: bq274xx: Support chips other than BQ27421

### DIFF
--- a/boards/arm/nrf9160_innblue22/nrf9160_innblue22_common.dts
+++ b/boards/arm/nrf9160_innblue22/nrf9160_innblue22_common.dts
@@ -95,8 +95,8 @@
 	clock-frequency = <I2C_BITRATE_FAST>;
 
 	bq27421@55 {
-		compatible = "ti,bq274xx";
-		label = "BQ274XX";
+		compatible = "ti,bq27421";
+		label = "BQ27421";
 		reg = <0x55>;
 		design-voltage = <3700>;
 		design-capacity = <1800>;

--- a/drivers/sensor/bq274xx/bq274xx.c
+++ b/drivers/sensor/bq274xx/bq274xx.c
@@ -4,135 +4,205 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT ti_bq274xx
-
 #include <drivers/i2c.h>
 #include <init.h>
 #include <drivers/sensor.h>
 #include <pm/device.h>
 #include <sys/__assert.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/byteorder.h>
 #include <drivers/gpio.h>
 
 #include "bq274xx.h"
 
-#define BQ274XX_SUBCLASS_DELAY 5 /* subclass 64 & 82 needs 5ms delay */
+/*** Time period definitions, all are in units of milliseconds. ***/
+/* Time for transferring data between command registers and data memory. */
+#define BQ274XX_SUBCLASS_DELAY 5
 /* Time to set pin in order to exit shutdown mode */
 #define PIN_DELAY_TIME 1U
 /* Time it takes device to initialize before doing any configuration */
 #define INIT_TIME 100U
+/* Time it takes before an unseal is allowed after sealing with CFG update. */
+#define UNSEAL_COOLDOWN 4000U
+/* Time to wait when polling for changes that generally take a long time. */
+#define SLOW_POLL_PERIOD 50U
 
 static int bq274xx_gauge_configure(const struct device *dev);
 
-static int bq274xx_command_reg_read(struct bq274xx_data *bq274xx, uint8_t reg_addr,
-				    int16_t *val)
+static int bq274xx_command_reg_read16(const struct device *dev, uint8_t command, int16_t *value)
 {
 	uint8_t i2c_data[2];
 	int status;
+	struct bq274xx_data *data = dev->data;
+	const struct bq274xx_config *const config = dev->config;
 
-	status = i2c_burst_read(bq274xx->i2c, DT_INST_REG_ADDR(0), reg_addr,
-				i2c_data, 2);
+	status = i2c_burst_read(data->i2c, config->reg_addr, command, i2c_data, 2);
 	if (status < 0) {
 		LOG_ERR("Unable to read register");
-		return -EIO;
+		return status;
 	}
 
-	*val = (i2c_data[1] << 8) | i2c_data[0];
+	*value = (i2c_data[1] << 8) | i2c_data[0];
 
 	return 0;
 }
 
-static int bq274xx_control_reg_write(struct bq274xx_data *bq274xx,
-				     uint16_t subcommand)
+static int bq274xx_command_reg_write8(const struct device *dev, uint8_t command, uint8_t value)
 {
-	uint8_t i2c_data, reg_addr;
 	int status = 0;
+	struct bq274xx_data *data = dev->data;
+	const struct bq274xx_config *const config = dev->config;
 
-	reg_addr = BQ274XX_COMMAND_CONTROL_LOW;
-	i2c_data = (uint8_t)((subcommand)&0x00FF);
-
-	status = i2c_reg_write_byte(bq274xx->i2c, DT_INST_REG_ADDR(0), reg_addr,
-				    i2c_data);
+	status = i2c_reg_write_byte(data->i2c, config->reg_addr, command, value);
 	if (status < 0) {
-		LOG_ERR("Failed to write into control low register");
-		return -EIO;
-	}
-
-	k_msleep(BQ274XX_SUBCLASS_DELAY);
-
-	reg_addr = BQ274XX_COMMAND_CONTROL_HIGH;
-	i2c_data = (uint8_t)((subcommand >> 8) & 0x00FF);
-
-	status = i2c_reg_write_byte(bq274xx->i2c, DT_INST_REG_ADDR(0), reg_addr,
-				    i2c_data);
-	if (status < 0) {
-		LOG_ERR("Failed to write into control high register");
-		return -EIO;
+		LOG_ERR("Failed to write command register");
+		return status;
 	}
 
 	return 0;
 }
 
-static int bq274xx_command_reg_write(struct bq274xx_data *bq274xx, uint8_t command,
-				     uint8_t data)
+static int bq274xx_command_reg_write16(const struct device *dev, uint8_t command, uint16_t value)
 {
-	uint8_t i2c_data, reg_addr;
+	uint8_t i2c_data[3];
 	int status = 0;
+	struct bq274xx_data *data = dev->data;
+	const struct bq274xx_config *const config = dev->config;
 
-	reg_addr = command;
-	i2c_data = data;
+	i2c_data[0] = command;
+	i2c_data[1] = value & 0xFF;
+	i2c_data[2] = value >> 8;
 
-	status = i2c_reg_write_byte(bq274xx->i2c, DT_INST_REG_ADDR(0), reg_addr,
-				    i2c_data);
+	status = i2c_write(data->i2c, i2c_data, sizeof(i2c_data), config->reg_addr);
 	if (status < 0) {
-		LOG_ERR("Failed to write into control register");
-		return -EIO;
+		LOG_ERR("Failed to write command register");
+		return status;
 	}
 
 	return 0;
 }
 
-static int bq274xx_read_data_block(struct bq274xx_data *bq274xx, uint8_t offset,
-				   uint8_t *data, uint8_t bytes)
+static int bq274xx_control_reg_write(const struct device *dev, uint16_t subcommand)
 {
-	uint8_t i2c_data;
+	return bq274xx_command_reg_write16(dev, BQ274XX_COMMAND_CONTROL, subcommand);
+}
+
+static int bq274xx_read_data_block(const struct device *dev, uint8_t offset, uint8_t *buffer,
+				   uint8_t num_bytes)
+{
+	uint8_t command;
 	int status = 0;
+	struct bq274xx_data *data = dev->data;
+	const struct bq274xx_config *const config = dev->config;
 
-	i2c_data = BQ274XX_EXTENDED_BLOCKDATA_START + offset;
+	command = BQ274XX_EXTENDED_BLOCKDATA_START + offset;
 
-	status = i2c_burst_read(bq274xx->i2c, DT_INST_REG_ADDR(0), i2c_data,
-				data, bytes);
+	status = i2c_burst_read(data->i2c, config->reg_addr, command, buffer, num_bytes);
 	if (status < 0) {
 		LOG_ERR("Failed to read block");
-		return -EIO;
+		return status;
 	}
-
-	k_msleep(BQ274XX_SUBCLASS_DELAY);
 
 	return 0;
 }
 
-static int bq274xx_get_device_type(struct bq274xx_data *bq274xx, uint16_t *val)
+static int bq274xx_read_control_status(const struct device *dev, uint16_t *value)
 {
 	int status;
 
-	status =
-		bq274xx_control_reg_write(bq274xx, BQ274XX_CONTROL_DEVICE_TYPE);
+	status = bq274xx_control_reg_write(dev, BQ274XX_CONTROL_CONTROL_STATUS);
 	if (status < 0) {
-		LOG_ERR("Unable to write control register");
-		return -EIO;
+		return status;
 	}
 
-	status = bq274xx_command_reg_read(bq274xx, BQ274XX_COMMAND_CONTROL_LOW,
-					  val);
+	status = bq274xx_command_reg_read16(dev, BQ274XX_COMMAND_CONTROL, value);
 
 	if (status < 0) {
-		LOG_ERR("Unable to read register");
-		return -EIO;
+		return status;
 	}
 
 	return 0;
+}
+
+static int bq274xx_read_device_type(const struct device *dev, uint16_t *value)
+{
+	int status;
+
+	status = bq274xx_control_reg_write(dev, BQ274XX_CONTROL_DEVICE_TYPE);
+	if (status < 0) {
+		return status;
+	}
+
+	status = bq274xx_command_reg_read16(dev, BQ274XX_COMMAND_CONTROL, value);
+
+	if (status < 0) {
+		return status;
+	}
+
+	return 0;
+}
+
+static int bq274xx_expected_device_type(enum bq274xx_part part, uint16_t *value)
+{
+	switch (part) {
+	case BQ27411:
+		*value = 0x0411;
+		return 0;
+	case BQ27421:
+		*value = 0x0421;
+		return 0;
+	case BQ27425:
+		*value = 0x0425;
+		return 0;
+	case BQ27426:
+		*value = 0x0426;
+		return 0;
+	case BQ27441:
+		*value = 0x0441;
+		return 0;
+	}
+
+	return -EINVAL;
+}
+
+static int bq274xx_read_chem_id(const struct device *dev, uint16_t *value)
+{
+	int status;
+
+	status = bq274xx_control_reg_write(dev, BQ274XX_CONTROL_CHEM_ID);
+	if (status < 0) {
+		return status;
+	}
+
+	status = bq274xx_command_reg_read16(dev, BQ274XX_COMMAND_CONTROL, value);
+	if (status < 0) {
+		return status;
+	}
+
+	return 0;
+}
+
+static int bq274xx_expected_chem_id(enum bq274xx_part part, enum bq274xx_chemistry chemistry,
+				    uint16_t *value)
+{
+	if (part == BQ27426) {
+		switch (chemistry) {
+		case CHEM_A:
+			*value = 0x3230;
+			return 0;
+		case CHEM_B:
+			*value = 0x1202;
+			return 0;
+		case CHEM_C:
+			*value = 0x3142;
+			return 0;
+		default:
+			break;
+		}
+	}
+
+	return -EINVAL;
 }
 
 /**
@@ -140,75 +210,73 @@ static int bq274xx_get_device_type(struct bq274xx_data *bq274xx, uint16_t *val)
  *
  * @return -ENOTSUP for unsupported channels
  */
-static int bq274xx_channel_get(const struct device *dev,
-			       enum sensor_channel chan,
+static int bq274xx_channel_get(const struct device *dev, enum sensor_channel chan,
 			       struct sensor_value *val)
 {
-	struct bq274xx_data *bq274xx = dev->data;
+	struct bq274xx_data *data = dev->data;
 	float int_temp;
 
 	switch (chan) {
 	case SENSOR_CHAN_GAUGE_VOLTAGE:
-		val->val1 = ((bq274xx->voltage / 1000));
-		val->val2 = ((bq274xx->voltage % 1000) * 1000U);
+		val->val1 = ((data->voltage / 1000));
+		val->val2 = ((data->voltage % 1000) * 1000U);
 		break;
 
 	case SENSOR_CHAN_GAUGE_AVG_CURRENT:
-		val->val1 = ((bq274xx->avg_current / 1000));
-		val->val2 = ((bq274xx->avg_current % 1000) * 1000U);
+		val->val1 = ((data->avg_current / 1000));
+		val->val2 = ((data->avg_current % 1000) * 1000U);
 		break;
 
 	case SENSOR_CHAN_GAUGE_STDBY_CURRENT:
-		val->val1 = ((bq274xx->stdby_current / 1000));
-		val->val2 = ((bq274xx->stdby_current % 1000) * 1000U);
+		val->val1 = ((data->stdby_current / 1000));
+		val->val2 = ((data->stdby_current % 1000) * 1000U);
 		break;
 
 	case SENSOR_CHAN_GAUGE_MAX_LOAD_CURRENT:
-		val->val1 = ((bq274xx->max_load_current / 1000));
-		val->val2 = ((bq274xx->max_load_current % 1000) * 1000U);
+		val->val1 = ((data->max_load_current / 1000));
+		val->val2 = ((data->max_load_current % 1000) * 1000U);
 		break;
 
 	case SENSOR_CHAN_GAUGE_TEMP:
-		int_temp = (bq274xx->internal_temperature * 0.1f);
+		int_temp = (data->internal_temperature * 0.1f);
 		int_temp = int_temp - 273.15f;
 		val->val1 = (int32_t)int_temp;
 		val->val2 = (int_temp - (int32_t)int_temp) * 1000000;
 		break;
 
 	case SENSOR_CHAN_GAUGE_STATE_OF_CHARGE:
-		val->val1 = bq274xx->state_of_charge;
+		val->val1 = data->state_of_charge;
 		val->val2 = 0;
 		break;
 
 	case SENSOR_CHAN_GAUGE_STATE_OF_HEALTH:
-		val->val1 = bq274xx->state_of_health;
+		val->val1 = data->state_of_health;
 		val->val2 = 0;
 		break;
 
 	case SENSOR_CHAN_GAUGE_FULL_CHARGE_CAPACITY:
-		val->val1 = (bq274xx->full_charge_capacity / 1000);
-		val->val2 = ((bq274xx->full_charge_capacity % 1000) * 1000U);
+		val->val1 = (data->full_charge_capacity / 1000);
+		val->val2 = ((data->full_charge_capacity % 1000) * 1000U);
 		break;
 
 	case SENSOR_CHAN_GAUGE_REMAINING_CHARGE_CAPACITY:
-		val->val1 = (bq274xx->remaining_charge_capacity / 1000);
-		val->val2 =
-			((bq274xx->remaining_charge_capacity % 1000) * 1000U);
+		val->val1 = (data->remaining_charge_capacity / 1000);
+		val->val2 = ((data->remaining_charge_capacity % 1000) * 1000U);
 		break;
 
 	case SENSOR_CHAN_GAUGE_NOM_AVAIL_CAPACITY:
-		val->val1 = (bq274xx->nom_avail_capacity / 1000);
-		val->val2 = ((bq274xx->nom_avail_capacity % 1000) * 1000U);
+		val->val1 = (data->nom_avail_capacity / 1000);
+		val->val2 = ((data->nom_avail_capacity % 1000) * 1000U);
 		break;
 
 	case SENSOR_CHAN_GAUGE_FULL_AVAIL_CAPACITY:
-		val->val1 = (bq274xx->full_avail_capacity / 1000);
-		val->val2 = ((bq274xx->full_avail_capacity % 1000) * 1000U);
+		val->val1 = (data->full_avail_capacity / 1000);
+		val->val2 = ((data->full_avail_capacity % 1000) * 1000U);
 		break;
 
 	case SENSOR_CHAN_GAUGE_AVG_POWER:
-		val->val1 = (bq274xx->avg_power / 1000);
-		val->val2 = ((bq274xx->avg_power % 1000) * 1000U);
+		val->val1 = (data->avg_power / 1000);
+		val->val2 = ((data->avg_power % 1000) * 1000U);
 		break;
 
 	default:
@@ -218,142 +286,130 @@ static int bq274xx_channel_get(const struct device *dev,
 	return 0;
 }
 
-static int bq274xx_sample_fetch(const struct device *dev,
-				enum sensor_channel chan)
+static int bq274xx_sample_fetch(const struct device *dev, enum sensor_channel chan)
 {
-	struct bq274xx_data *bq274xx = dev->data;
+	struct bq274xx_data *data = dev->data;
 	int status = 0;
 
 #ifdef CONFIG_BQ274XX_LAZY_CONFIGURE
-	if (!bq274xx->lazy_loaded) {
+	if (!data->lazy_loaded) {
 		status = bq274xx_gauge_configure(dev);
 
 		if (status < 0) {
 			return status;
 		}
-		bq274xx->lazy_loaded = true;
+		data->lazy_loaded = true;
 	}
 #endif
 
 	switch (chan) {
 	case SENSOR_CHAN_GAUGE_VOLTAGE:
-		status = bq274xx_command_reg_read(
-			bq274xx, BQ274XX_COMMAND_VOLTAGE, &bq274xx->voltage);
+		status = bq274xx_command_reg_read16(dev, BQ274XX_COMMAND_VOLTAGE, &data->voltage);
 		if (status < 0) {
 			LOG_ERR("Failed to read voltage");
-			return -EIO;
+			return status;
 		}
 		break;
 
 	case SENSOR_CHAN_GAUGE_AVG_CURRENT:
-		status = bq274xx_command_reg_read(bq274xx,
-						  BQ274XX_COMMAND_AVG_CURRENT,
-						  &bq274xx->avg_current);
+		status = bq274xx_command_reg_read16(dev, BQ274XX_COMMAND_AVG_CURRENT,
+						    &data->avg_current);
 		if (status < 0) {
 			LOG_ERR("Failed to read average current ");
-			return -EIO;
+			return status;
 		}
 		break;
 
 	case SENSOR_CHAN_GAUGE_TEMP:
-		status = bq274xx_command_reg_read(
-			bq274xx, BQ274XX_COMMAND_INT_TEMP,
-			&bq274xx->internal_temperature);
+		status = bq274xx_command_reg_read16(dev, BQ274XX_COMMAND_INT_TEMP,
+						    &data->internal_temperature);
 		if (status < 0) {
 			LOG_ERR("Failed to read internal temperature");
-			return -EIO;
+			return status;
 		}
 		break;
 
 	case SENSOR_CHAN_GAUGE_STDBY_CURRENT:
-		status = bq274xx_command_reg_read(bq274xx,
-						  BQ274XX_COMMAND_STDBY_CURRENT,
-						  &bq274xx->stdby_current);
+		status = bq274xx_command_reg_read16(dev, BQ274XX_COMMAND_STDBY_CURRENT,
+						    &data->stdby_current);
 		if (status < 0) {
 			LOG_ERR("Failed to read standby current");
-			return -EIO;
+			return status;
 		}
 		break;
 
 	case SENSOR_CHAN_GAUGE_MAX_LOAD_CURRENT:
-		status = bq274xx_command_reg_read(bq274xx,
-						  BQ274XX_COMMAND_MAX_CURRENT,
-						  &bq274xx->max_load_current);
+		status = bq274xx_command_reg_read16(dev, BQ274XX_COMMAND_MAX_CURRENT,
+						    &data->max_load_current);
 		if (status < 0) {
 			LOG_ERR("Failed to read maximum current");
-			return -EIO;
+			return status;
 		}
 		break;
 
 	case SENSOR_CHAN_GAUGE_STATE_OF_CHARGE:
-		status = bq274xx_command_reg_read(bq274xx, BQ274XX_COMMAND_SOC,
-						  &bq274xx->state_of_charge);
+		status = bq274xx_command_reg_read16(dev, BQ274XX_COMMAND_SOC,
+						    &data->state_of_charge);
 		if (status < 0) {
 			LOG_ERR("Failed to read state of charge");
-			return -EIO;
+			return status;
 		}
 		break;
 
 	case SENSOR_CHAN_GAUGE_FULL_CHARGE_CAPACITY:
-		status = bq274xx_command_reg_read(
-			bq274xx, BQ274XX_COMMAND_FULL_CAPACITY,
-			&bq274xx->full_charge_capacity);
+		status = bq274xx_command_reg_read16(dev, BQ274XX_COMMAND_FULL_CAPACITY,
+						    &data->full_charge_capacity);
 		if (status < 0) {
 			LOG_ERR("Failed to read full charge capacity");
-			return -EIO;
+			return status;
 		}
 		break;
 
 	case SENSOR_CHAN_GAUGE_REMAINING_CHARGE_CAPACITY:
-		status = bq274xx_command_reg_read(
-			bq274xx, BQ274XX_COMMAND_REM_CAPACITY,
-			&bq274xx->remaining_charge_capacity);
+		status = bq274xx_command_reg_read16(dev, BQ274XX_COMMAND_REM_CAPACITY,
+						    &data->remaining_charge_capacity);
 		if (status < 0) {
 			LOG_ERR("Failed to read remaining charge capacity");
-			return -EIO;
+			return status;
 		}
 		break;
 
 	case SENSOR_CHAN_GAUGE_NOM_AVAIL_CAPACITY:
-		status = bq274xx_command_reg_read(bq274xx,
-						  BQ274XX_COMMAND_NOM_CAPACITY,
-						  &bq274xx->nom_avail_capacity);
+		status = bq274xx_command_reg_read16(dev, BQ274XX_COMMAND_NOM_CAPACITY,
+						    &data->nom_avail_capacity);
 		if (status < 0) {
 			LOG_ERR("Failed to read nominal available capacity");
-			return -EIO;
+			return status;
 		}
 		break;
 
 	case SENSOR_CHAN_GAUGE_FULL_AVAIL_CAPACITY:
-		status =
-			bq274xx_command_reg_read(bq274xx,
-						 BQ274XX_COMMAND_AVAIL_CAPACITY,
-						 &bq274xx->full_avail_capacity);
+		status = bq274xx_command_reg_read16(dev, BQ274XX_COMMAND_AVAIL_CAPACITY,
+						    &data->full_avail_capacity);
 		if (status < 0) {
 			LOG_ERR("Failed to read full available capacity");
-			return -EIO;
+			return status;
 		}
 		break;
 
 	case SENSOR_CHAN_GAUGE_AVG_POWER:
-		status = bq274xx_command_reg_read(bq274xx,
-						  BQ274XX_COMMAND_AVG_POWER,
-						  &bq274xx->avg_power);
+		status = bq274xx_command_reg_read16(dev, BQ274XX_COMMAND_AVG_POWER,
+						    &data->avg_power);
 		if (status < 0) {
 			LOG_ERR("Failed to read battery average power");
-			return -EIO;
+			return status;
 		}
 		break;
 
 	case SENSOR_CHAN_GAUGE_STATE_OF_HEALTH:
-		status = bq274xx_command_reg_read(bq274xx, BQ274XX_COMMAND_SOH,
-						  &bq274xx->state_of_health);
+		status = bq274xx_command_reg_read16(dev, BQ274XX_COMMAND_SOH,
+						    &data->state_of_health);
 
-		bq274xx->state_of_health = (bq274xx->state_of_health) & 0x00FF;
+		data->state_of_health = (data->state_of_health) & 0x00FF;
 
 		if (status < 0) {
 			LOG_ERR("Failed to read state of health");
-			return -EIO;
+			return status;
 		}
 		break;
 
@@ -371,10 +427,10 @@ static int bq274xx_sample_fetch(const struct device *dev,
  */
 static int bq274xx_gauge_init(const struct device *dev)
 {
-	struct bq274xx_data *bq274xx = dev->data;
+	struct bq274xx_data *data = dev->data;
 	const struct bq274xx_config *const config = dev->config;
 	int status = 0;
-	uint16_t id;
+	uint16_t id, expected_id;
 
 #ifdef CONFIG_PM_DEVICE
 	if (!device_is_ready(config->int_gpios.port)) {
@@ -383,26 +439,31 @@ static int bq274xx_gauge_init(const struct device *dev)
 	}
 #endif
 
-	bq274xx->i2c = device_get_binding(config->bus_name);
-	if (bq274xx->i2c == NULL) {
-		LOG_ERR("Could not get pointer to %s device.",
-			config->bus_name);
+	data->i2c = device_get_binding(config->bus_name);
+	if (data->i2c == NULL) {
+		LOG_ERR("Could not get pointer to %s device.", config->bus_name);
 		return -EINVAL;
 	}
 
-	status = bq274xx_get_device_type(bq274xx, &id);
+	status = bq274xx_read_device_type(dev, &id);
 	if (status < 0) {
-		LOG_ERR("Unable to get device ID");
-		return -EIO;
+		LOG_ERR("Unable to read device ID");
+		return status;
 	}
 
-	if (id != BQ274XX_DEVICE_ID) {
-		LOG_ERR("Invalid Device");
+	status = bq274xx_expected_device_type(config->part, &expected_id);
+	if (status < 0) {
+		LOG_ERR("Unable to determine expected device ID");
+		return status;
+	}
+
+	if (id != expected_id) {
+		LOG_ERR("Invalid Device: 0x%02x", id);
 		return -EINVAL;
 	}
 
 #ifdef CONFIG_BQ274XX_LAZY_CONFIGURE
-	bq274xx->lazy_loaded = false;
+	data->lazy_loaded = false;
 #else
 	status = bq274xx_gauge_configure(dev);
 #endif
@@ -410,281 +471,466 @@ static int bq274xx_gauge_init(const struct device *dev)
 	return status;
 }
 
+static int bq274xx_unseal(const struct device *dev)
+{
+	int status;
+	uint16_t control_status;
+
+	/* Unseal the battery control register by writing the key twice. */
+	status = bq274xx_control_reg_write(dev, BQ274XX_UNSEAL_KEY);
+	if (status < 0) {
+		return status;
+	}
+
+	status = bq274xx_control_reg_write(dev, BQ274XX_UNSEAL_KEY);
+	if (status < 0) {
+		return status;
+	}
+
+	/* Check that it actually succeeded. */
+	status = bq274xx_read_control_status(dev, &control_status);
+	if (status < 0) {
+		return status;
+	}
+
+	if (control_status & BIT(BQ274XX_CONTROL_STATUS_SS)) {
+		return -EBUSY;
+	}
+
+	return 0;
+}
+
+static int bq274xx_unseal_with_retry(const struct device *dev)
+{
+	int status;
+
+	status = bq274xx_unseal(dev);
+	if (status == -EBUSY) {
+		/* There is a 4 second cooldown after sealing the device before
+		 * it can be unsealed. When writing the unseal register it will
+		 * reset the cooldown regardless of success, so the full
+		 * duration must elapse before we should try again.
+		 */
+		LOG_WRN("BQ274XX didn't unseal, trying again in 4s");
+		k_msleep(UNSEAL_COOLDOWN);
+		status = bq274xx_unseal(dev);
+	}
+
+	return status;
+}
+
+static int bq274xx_seal(const struct device *dev)
+{
+	int status;
+
+	status = bq274xx_control_reg_write(dev, BQ274XX_CONTROL_SEALED);
+	if (status < 0) {
+		return status;
+	}
+
+	return status;
+}
+
+static int bq274xx_enter_cfg_update(const struct device *dev)
+{
+	int status;
+	uint16_t flags = 0;
+
+	/* Send SET_CFGUPDATE to enter */
+	status = bq274xx_control_reg_write(dev, BQ274XX_CONTROL_SET_CFGUPDATE);
+	if (status < 0) {
+		return status;
+	}
+
+	/* Poll flags for completion. */
+	do {
+		status = bq274xx_command_reg_read16(dev, BQ274XX_COMMAND_FLAGS, &flags);
+		if (status < 0) {
+			return status;
+		}
+
+		if (!(flags & BIT(BQ274XX_FLAGS_CFGUPMODE))) {
+			k_msleep(SLOW_POLL_PERIOD);
+		}
+
+	} while (!(flags & BIT(BQ274XX_FLAGS_CFGUPMODE)));
+
+	return status;
+}
+
+static int bq274xx_exit_cfg_update(const struct device *dev)
+{
+	int status;
+	uint16_t flags = 0;
+
+	/* Send SOFT_RESET to exit. */
+	status = bq274xx_control_reg_write(dev, BQ274XX_CONTROL_SOFT_RESET);
+	if (status < 0) {
+		return status;
+	}
+
+	/* Poll flags for completion. */
+	do {
+		status = bq274xx_command_reg_read16(dev, BQ274XX_COMMAND_FLAGS, &flags);
+		if (status < 0) {
+			return status;
+		}
+
+		if (flags & BIT(BQ274XX_FLAGS_CFGUPMODE)) {
+			k_msleep(SLOW_POLL_PERIOD);
+		}
+	} while (flags & BIT(BQ274XX_FLAGS_CFGUPMODE));
+
+	return status;
+}
+
+static int bq274xx_load_data_memory(const struct device *dev, uint8_t subclass, uint8_t offset)
+{
+	int status;
+
+	status = bq274xx_command_reg_write8(dev, BQ274XX_EXTENDED_DATA_CONTROL, 0x00);
+	if (status < 0) {
+		return status;
+	}
+
+	status = bq274xx_command_reg_write8(dev, BQ274XX_EXTENDED_DATA_CLASS, subclass);
+	if (status < 0) {
+		return status;
+	}
+
+	status = bq274xx_command_reg_write8(dev, BQ274XX_EXTENDED_DATA_BLOCK, offset);
+	if (status < 0) {
+		return status;
+	}
+
+	/* Wait for block to be copied from data RAM to block data registers */
+	k_msleep(BQ274XX_SUBCLASS_DELAY);
+
+	return status;
+}
+
+static int bq274xx_commit_data_memory(const struct device *dev)
+{
+	int status;
+	uint8_t checksum;
+	uint8_t buffer[BQ274XX_BLOCKDATA_SIZE];
+
+	memset(buffer, 0, BQ274XX_BLOCKDATA_SIZE);
+
+	status = bq274xx_read_data_block(dev, 0x00, buffer, BQ274XX_BLOCKDATA_SIZE);
+	if (status < 0) {
+		return status;
+	}
+
+	checksum = 0;
+	for (uint8_t i = 0; i < BQ274XX_BLOCKDATA_SIZE; i++) {
+		checksum += buffer[i];
+	}
+	checksum = 255 - checksum;
+
+	status = bq274xx_command_reg_write8(dev, BQ274XX_EXTENDED_CHECKSUM, checksum);
+	if (status < 0) {
+		return status;
+	}
+
+	/* Wait for data to be committed to data RAM */
+	k_msleep(BQ274XX_SUBCLASS_DELAY);
+
+	return status;
+}
+
+static int bq274xx_set_chemistry(const struct device *dev, enum bq274xx_chemistry chemistry)
+{
+	uint16_t control_subcommand;
+
+	switch (chemistry) {
+	case CHEM_A:
+		control_subcommand = BQ274XX_CONTROL_CHEM_A;
+		break;
+	case CHEM_B:
+		control_subcommand = BQ274XX_CONTROL_CHEM_B;
+		break;
+	case CHEM_C:
+		control_subcommand = BQ274XX_CONTROL_CHEM_C;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return bq274xx_control_reg_write(dev, control_subcommand);
+}
+
+static int bq274xx_configure_chemistry(const struct device *dev)
+{
+	int status;
+	uint16_t control_status;
+	uint16_t current_chem_id, desired_chem_id;
+	const struct bq274xx_config *const config = dev->config;
+
+	if (config->chemistry == CHEM_DEFAULT) {
+		/* Don't need to do anything. */
+		return 0;
+	}
+
+	status = bq274xx_read_chem_id(dev, &current_chem_id);
+	if (status < 0) {
+		LOG_ERR("Unable to read CHEM_ID");
+		return status;
+	}
+
+	status = bq274xx_expected_chem_id(config->part, config->chemistry, &desired_chem_id);
+	if (status < 0) {
+		LOG_ERR("Unable to determine desired CHEM_ID");
+		return status;
+	}
+
+	if (current_chem_id != desired_chem_id) {
+		status = bq274xx_set_chemistry(dev, config->chemistry);
+		if (status < 0) {
+			LOG_ERR("Failed to update chemistry profile");
+			return status;
+		}
+
+		while (1) {
+			status = bq274xx_read_control_status(dev, &control_status);
+			if (status < 0) {
+				LOG_ERR("Unable to read CONTROL_STATUS register");
+				return status;
+			}
+
+			/* Wait until active chemistry table is updated. */
+			if ((control_status & BIT(BQ274XX_CONTROL_STATUS_CHEM_CHANGE)) == 0) {
+				break;
+			}
+
+			/* This usually takes ~500ms, so sleep for a while. */
+			k_msleep(SLOW_POLL_PERIOD);
+		}
+
+		status = bq274xx_read_chem_id(dev, &current_chem_id);
+		if (status < 0) {
+			LOG_ERR("Unable to read updated CHEM_ID");
+			return status;
+		}
+
+		if (current_chem_id != desired_chem_id) {
+			LOG_ERR("CHEM_ID failed to update");
+			return -EIO;
+		}
+	}
+
+	return 0;
+}
+
+struct bq274xx_blockdata_entry {
+	struct bq274xx_blockdata_address address;
+	uint16_t value;
+};
+
+static int bq274xx_compare_blockdata_addresses(struct bq274xx_blockdata_address arg1,
+					       struct bq274xx_blockdata_address arg2)
+{
+	uint8_t block_index1 = arg1.offset / BQ274XX_BLOCKDATA_SIZE;
+	uint8_t block_index2 = arg2.offset / BQ274XX_BLOCKDATA_SIZE;
+
+	/* Sort by subclass first. */
+	if (arg1.subclass < arg2.subclass) {
+		return -1;
+	}
+
+	if (arg1.subclass > arg2.subclass) {
+		return 1;
+	}
+
+	/* Then sort by block index. */
+	if (block_index1 < block_index2) {
+		return -1;
+	}
+
+	if (block_index1 > block_index2) {
+		return 1;
+	}
+
+	return 0;
+}
+
+static int bq274xx_compare_blockdata_entries(const void *arg1, const void *arg2)
+{
+	/* Sort by address. */
+	return bq274xx_compare_blockdata_addresses(
+		((const struct bq274xx_blockdata_entry *)arg1)->address,
+		((const struct bq274xx_blockdata_entry *)arg2)->address);
+}
+
+static void bq274xx_blockdata_entries_append(struct bq274xx_blockdata_entry *entries, int *size,
+					     struct bq274xx_blockdata_address address,
+					     uint16_t value)
+{
+	if (address.subclass != BQ274XX_SUBCLASS_INVALID) {
+		entries[*size].address = address;
+		entries[*size].value = value;
+		*size += 1;
+	}
+}
+
+static void bq274xx_blockdata_entries_initialize(const struct device *dev,
+						 struct bq274xx_blockdata_entry *entries, int *size)
+{
+	uint16_t design_energy, taper_rate;
+	const struct bq274xx_config *const config = dev->config;
+
+	design_energy = (uint16_t)(config->design_voltage * config->design_capacity / 1000);
+	taper_rate = (uint16_t)(config->design_capacity * 10 / config->taper_current);
+
+	bq274xx_blockdata_entries_append(entries, size, config->blockdata_addresses->design_cap,
+					 config->design_capacity);
+	bq274xx_blockdata_entries_append(entries, size, config->blockdata_addresses->design_enr,
+					 design_energy);
+	bq274xx_blockdata_entries_append(entries, size,
+					 config->blockdata_addresses->terminate_voltage,
+					 config->terminate_voltage);
+	bq274xx_blockdata_entries_append(entries, size, config->blockdata_addresses->taper_rate,
+					 taper_rate);
+	bq274xx_blockdata_entries_append(entries, size, config->blockdata_addresses->taper_current,
+					 config->taper_current);
+
+	qsort(entries, *size, sizeof(*entries), &bq274xx_compare_blockdata_entries);
+}
+
+static int bq274xx_write_blockdata_entry(const struct device *dev,
+					 struct bq274xx_blockdata_entry entry)
+{
+	uint8_t command;
+	uint16_t value;
+
+	command = BQ274XX_EXTENDED_BLOCKDATA_START + entry.address.offset % BQ274XX_BLOCKDATA_SIZE;
+	value = (entry.value >> 8) | (entry.value << 8);
+
+	return bq274xx_command_reg_write16(dev, command, value);
+}
+
+static int bq274xx_configure_data_memory(const struct device *dev)
+{
+	int status;
+	struct bq274xx_blockdata_entry blockdata_entries[MAX_BLOCKDATA_ENTRIES];
+	int num_entries = 0, index = 0;
+	struct bq274xx_blockdata_address current_block;
+
+	bq274xx_blockdata_entries_initialize(dev, blockdata_entries, &num_entries);
+
+	while (index < num_entries) {
+		current_block = blockdata_entries[index].address;
+		current_block.offset /= BQ274XX_BLOCKDATA_SIZE;
+		current_block.offset *= BQ274XX_BLOCKDATA_SIZE;
+
+		status =
+			bq274xx_load_data_memory(dev, current_block.subclass, current_block.offset);
+		if (status < 0) {
+			LOG_ERR("Unable to load data memory");
+			return status;
+		}
+
+		do {
+			status = bq274xx_write_blockdata_entry(dev, blockdata_entries[index]);
+			if (status < 0) {
+				LOG_ERR("Unable to write to data memory");
+				return status;
+			}
+
+			index++;
+		} while (index < num_entries &&
+			 bq274xx_compare_blockdata_addresses(blockdata_entries[index].address,
+							     current_block) == 0);
+
+		status = bq274xx_commit_data_memory(dev);
+		if (status < 0) {
+			LOG_ERR("Unable to commit data memory");
+			return status;
+		}
+	}
+
+	return 0;
+}
+
 static int bq274xx_gauge_configure(const struct device *dev)
 {
-	struct bq274xx_data *bq274xx = dev->data;
-	const struct bq274xx_config *const config = dev->config;
-	int status = 0;
-	uint8_t tmp_checksum = 0, checksum_old = 0, checksum_new = 0;
-	uint16_t flags = 0, designenergy_mwh = 0, taperrate = 0;
-	uint8_t designcap_msb, designcap_lsb, designenergy_msb, designenergy_lsb,
-		terminatevolt_msb, terminatevolt_lsb, taperrate_msb,
-		taperrate_lsb;
-	uint8_t block[32];
+	int status;
 
-	designenergy_mwh = (uint16_t)3.7 * config->design_capacity;
-	taperrate =
-		(uint16_t)config->design_capacity / (0.1 * config->taper_current);
-
-	/** Unseal the battery control register **/
-	status = bq274xx_control_reg_write(bq274xx, BQ274XX_UNSEAL_KEY);
+	status = bq274xx_unseal_with_retry(dev);
 	if (status < 0) {
-		LOG_ERR("Unable to unseal the battery");
-		return -EIO;
+		LOG_ERR("Unable to unseal the gauge");
+		return status;
 	}
 
-	status = bq274xx_control_reg_write(bq274xx, BQ274XX_UNSEAL_KEY);
+	status = bq274xx_enter_cfg_update(dev);
 	if (status < 0) {
-		LOG_ERR("Unable to unseal the battery");
-		return -EIO;
+		LOG_ERR("Unable to enter CFG update");
+		return status;
 	}
 
-	/* Send CFG_UPDATE */
-	status = bq274xx_control_reg_write(bq274xx,
-					   BQ274XX_CONTROL_SET_CFGUPDATE);
+	/* The chemistry change needs to be complete before data memory is
+	 * updated, otherwise the firmware can overwrite some settings.
+	 */
+	status = bq274xx_configure_chemistry(dev);
 	if (status < 0) {
-		LOG_ERR("Unable to set CFGUpdate");
-		return -EIO;
+		LOG_ERR("Unable to update chemistry");
+		return status;
 	}
 
-	/** Step to place the Gauge into CONFIG UPDATE Mode **/
-	do {
-		status = bq274xx_command_reg_read(
-			bq274xx, BQ274XX_COMMAND_FLAGS, &flags);
-		if (status < 0) {
-			LOG_ERR("Unable to read flags");
-			return -EIO;
-		}
-
-		if (!(flags & 0x0010)) {
-			k_msleep(BQ274XX_SUBCLASS_DELAY * 10);
-		}
-
-	} while (!(flags & 0x0010));
-
-	status = bq274xx_command_reg_write(bq274xx,
-					   BQ274XX_EXTENDED_DATA_CONTROL, 0x00);
+	status = bq274xx_configure_data_memory(dev);
 	if (status < 0) {
-		LOG_ERR("Failed to enable block data memory");
-		return -EIO;
+		LOG_ERR("Unable to update data memory");
+		return status;
 	}
 
-	/* Access State subclass */
-	status = bq274xx_command_reg_write(bq274xx, BQ274XX_EXTENDED_DATA_CLASS,
-					   0x52);
+	status = bq274xx_exit_cfg_update(dev);
 	if (status < 0) {
-		LOG_ERR("Failed to update state subclass");
-		return -EIO;
+		LOG_ERR("Unable to exit CFG update");
+		return status;
 	}
 
-	/* Write the block offset */
-	status = bq274xx_command_reg_write(bq274xx, BQ274XX_EXTENDED_DATA_BLOCK,
-					   0x00);
-	if (status < 0) {
-		LOG_ERR("Failed to update block offset");
-		return -EIO;
-	}
-
-	for (uint8_t i = 0; i < 32; i++) {
-		block[i] = 0;
-	}
-
-	status = bq274xx_read_data_block(bq274xx, 0x00, block, 32);
-	if (status < 0) {
-		LOG_ERR("Unable to read block data");
-		return -EIO;
-	}
-
-	tmp_checksum = 0;
-	for (uint8_t i = 0; i < 32; i++) {
-		tmp_checksum += block[i];
-	}
-	tmp_checksum = 255 - tmp_checksum;
-
-	/* Read the block checksum */
-	status = i2c_reg_read_byte(bq274xx->i2c, DT_INST_REG_ADDR(0),
-				   BQ274XX_EXTENDED_CHECKSUM, &checksum_old);
-	if (status < 0) {
-		LOG_ERR("Unable to read block checksum");
-		return -EIO;
-	}
-
-	designcap_msb = config->design_capacity >> 8;
-	designcap_lsb = config->design_capacity & 0x00FF;
-	designenergy_msb = designenergy_mwh >> 8;
-	designenergy_lsb = designenergy_mwh & 0x00FF;
-	terminatevolt_msb = config->terminate_voltage >> 8;
-	terminatevolt_lsb = config->terminate_voltage & 0x00FF;
-	taperrate_msb = taperrate >> 8;
-	taperrate_lsb = taperrate & 0x00FF;
-
-	status = i2c_reg_write_byte(bq274xx->i2c, DT_INST_REG_ADDR(0),
-				    BQ274XX_EXTENDED_BLOCKDATA_DESIGN_CAP_HIGH,
-				    designcap_msb);
-	if (status < 0) {
-		LOG_ERR("Failed to write designCAP MSB");
-		return -EIO;
-	}
-
-	status = i2c_reg_write_byte(bq274xx->i2c, DT_INST_REG_ADDR(0),
-				    BQ274XX_EXTENDED_BLOCKDATA_DESIGN_CAP_LOW,
-				    designcap_lsb);
-	if (status < 0) {
-		LOG_ERR("Failed to erite designCAP LSB");
-		return -EIO;
-	}
-
-	status = i2c_reg_write_byte(bq274xx->i2c, DT_INST_REG_ADDR(0),
-				    BQ274XX_EXTENDED_BLOCKDATA_DESIGN_ENR_HIGH,
-				    designenergy_msb);
-	if (status < 0) {
-		LOG_ERR("Failed to write designEnergy MSB");
-		return -EIO;
-	}
-
-	status = i2c_reg_write_byte(bq274xx->i2c, DT_INST_REG_ADDR(0),
-				    BQ274XX_EXTENDED_BLOCKDATA_DESIGN_ENR_LOW,
-				    designenergy_lsb);
-	if (status < 0) {
-		LOG_ERR("Failed to erite designEnergy LSB");
-		return -EIO;
-	}
-
-	status = i2c_reg_write_byte(
-		bq274xx->i2c, DT_INST_REG_ADDR(0),
-		BQ274XX_EXTENDED_BLOCKDATA_TERMINATE_VOLT_HIGH,
-		terminatevolt_msb);
-	if (status < 0) {
-		LOG_ERR("Failed to write terminateVolt MSB");
-		return -EIO;
-	}
-
-	status = i2c_reg_write_byte(
-		bq274xx->i2c, DT_INST_REG_ADDR(0),
-		BQ274XX_EXTENDED_BLOCKDATA_TERMINATE_VOLT_LOW,
-		terminatevolt_lsb);
-	if (status < 0) {
-		LOG_ERR("Failed to write terminateVolt LSB");
-		return -EIO;
-	}
-
-	status = i2c_reg_write_byte(bq274xx->i2c, DT_INST_REG_ADDR(0),
-				    BQ274XX_EXTENDED_BLOCKDATA_TAPERRATE_HIGH,
-				    taperrate_msb);
-	if (status < 0) {
-		LOG_ERR("Failed to write taperRate MSB");
-		return -EIO;
-	}
-
-	status = i2c_reg_write_byte(bq274xx->i2c, DT_INST_REG_ADDR(0),
-				    BQ274XX_EXTENDED_BLOCKDATA_TAPERRATE_LOW,
-				    taperrate_lsb);
-	if (status < 0) {
-		LOG_ERR("Failed to erite taperRate LSB");
-		return -EIO;
-	}
-
-	for (uint8_t i = 0; i < 32; i++) {
-		block[i] = 0;
-	}
-
-	status = bq274xx_read_data_block(bq274xx, 0x00, block, 32);
-	if (status < 0) {
-		LOG_ERR("Unable to read block data");
-		return -EIO;
-	}
-
-	checksum_new = 0;
-	for (uint8_t i = 0; i < 32; i++) {
-		checksum_new += block[i];
-	}
-	checksum_new = 255 - checksum_new;
-
-	status = bq274xx_command_reg_write(bq274xx, BQ274XX_EXTENDED_CHECKSUM,
-					   checksum_new);
-	if (status < 0) {
-		LOG_ERR("Failed to update new checksum");
-		return -EIO;
-	}
-
-	tmp_checksum = 0;
-	status = i2c_reg_read_byte(bq274xx->i2c, DT_INST_REG_ADDR(0),
-				   BQ274XX_EXTENDED_CHECKSUM, &tmp_checksum);
-	if (status < 0) {
-		LOG_ERR("Failed to read checksum");
-		return -EIO;
-	}
-
-	status = bq274xx_control_reg_write(bq274xx, BQ274XX_CONTROL_BAT_INSERT);
+	/* Force the battery to be detected. */
+	status = bq274xx_control_reg_write(dev, BQ274XX_CONTROL_BAT_INSERT);
 	if (status < 0) {
 		LOG_ERR("Unable to configure BAT Detect");
-		return -EIO;
+		return status;
 	}
 
-	status = bq274xx_control_reg_write(bq274xx, BQ274XX_CONTROL_SOFT_RESET);
+	status = bq274xx_seal(dev);
 	if (status < 0) {
-		LOG_ERR("Failed to soft reset the gauge");
-		return -EIO;
-	}
-
-	flags = 0;
-	/* Poll Flags   */
-	do {
-		status = bq274xx_command_reg_read(
-			bq274xx, BQ274XX_COMMAND_FLAGS, &flags);
-		if (status < 0) {
-			LOG_ERR("Unable to read flags");
-			return -EIO;
-		}
-
-		if (flags & 0x0010) {
-			k_msleep(BQ274XX_SUBCLASS_DELAY * 10);
-		}
-	} while (flags & 0x0010);
-
-	/* Seal the gauge */
-	status = bq274xx_control_reg_write(bq274xx, BQ274XX_CONTROL_SEALED);
-	if (status < 0) {
-		LOG_ERR("Failed to seal the gauge");
-		return -EIO;
+		LOG_ERR("Unable to seal the gauge");
+		return status;
 	}
 
 	return 0;
 }
 
 #ifdef CONFIG_PM_DEVICE
-static int bq274xx_enter_shutdown_mode(struct bq274xx_data *data)
+static int bq274xx_enter_shutdown_mode(const struct device *dev)
 {
 	int status;
 
-	status = bq274xx_control_reg_write(data, BQ274XX_UNSEAL_KEY);
+	status = bq274xx_unseal_with_retry(dev);
 	if (status < 0) {
-		LOG_ERR("Unable to unseal the battery");
+		LOG_ERR("Unable to unseal the gauge");
 		return status;
 	}
 
-	status = bq274xx_control_reg_write(data, BQ274XX_UNSEAL_KEY);
-	if (status < 0) {
-		LOG_ERR("Unable to unseal the battery");
-		return status;
-	}
-
-	status = bq274xx_control_reg_write(data,
-					   BQ274XX_CONTROL_SHUTDOWN_ENABLE);
+	status = bq274xx_control_reg_write(dev, BQ274XX_CONTROL_SHUTDOWN_ENABLE);
 	if (status < 0) {
 		LOG_ERR("Unable to enable shutdown mode");
 		return status;
 	}
 
-	status = bq274xx_control_reg_write(data, BQ274XX_CONTROL_SHUTDOWN);
+	status = bq274xx_control_reg_write(dev, BQ274XX_CONTROL_SHUTDOWN);
 	if (status < 0) {
 		LOG_ERR("Unable to enter shutdown mode");
 		return status;
 	}
 
-	status = bq274xx_control_reg_write(data, BQ274XX_CONTROL_SEALED);
+	status = bq274xx_seal(dev);
 	if (status < 0) {
-		LOG_ERR("Failed to seal the gauge");
+		LOG_ERR("Unable to seal the gauge");
 		return status;
 	}
 
@@ -696,8 +942,7 @@ static int bq274xx_exit_shutdown_mode(const struct device *dev)
 	const struct bq274xx_config *const config = dev->config;
 	int status = 0;
 
-	status = gpio_pin_configure_dt(&config->int_gpios,
-			   GPIO_OUTPUT | GPIO_OPEN_DRAIN);
+	status = gpio_pin_configure_dt(&config->int_gpios, GPIO_OUTPUT | GPIO_OPEN_DRAIN);
 	if (status < 0) {
 		LOG_ERR("Unable to configure interrupt pin to output and open drain");
 		return status;
@@ -728,15 +973,13 @@ static int bq274xx_exit_shutdown_mode(const struct device *dev)
 	return 0;
 }
 
-static int bq274xx_pm_action(const struct device *dev,
-			     enum pm_device_action action)
+static int bq274xx_pm_action(const struct device *dev, enum pm_device_action action)
 {
 	int ret;
-	struct bq274xx_data *data = dev->data;
 
 	switch (action) {
 	case PM_DEVICE_ACTION_TURN_OFF:
-		ret = bq274xx_enter_shutdown_mode(data);
+		ret = bq274xx_enter_shutdown_mode(dev);
 		break;
 	case PM_DEVICE_ACTION_RESUME:
 		ret = bq274xx_exit_shutdown_mode(dev);
@@ -755,32 +998,91 @@ static const struct sensor_driver_api bq274xx_battery_driver_api = {
 	.channel_get = bq274xx_channel_get,
 };
 
+__unused static const struct bq274xx_blockdata_addresses bq27411_blockdata_addresses = {
+	.design_cap = { BQ274XX_SUBCLASS_STATE, 10 },
+	.design_enr = { BQ274XX_SUBCLASS_STATE, 12 },
+	.terminate_voltage = { BQ274XX_SUBCLASS_STATE, 16 },
+	.taper_rate = { BQ274XX_SUBCLASS_STATE, 27 },
+};
+
+__unused static const struct bq274xx_blockdata_addresses bq27421_blockdata_addresses = {
+	.design_cap = { BQ274XX_SUBCLASS_STATE, 10 },
+	.design_enr = { BQ274XX_SUBCLASS_STATE, 12 },
+	.terminate_voltage = { BQ274XX_SUBCLASS_STATE, 16 },
+	.taper_rate = { BQ274XX_SUBCLASS_STATE, 27 },
+};
+
+__unused static const struct bq274xx_blockdata_addresses bq27425_blockdata_addresses = {
+	.design_cap = { BQ274XX_SUBCLASS_STATE, 12 },
+	.design_enr = { BQ274XX_SUBCLASS_STATE, 14 },
+	.terminate_voltage = { BQ274XX_SUBCLASS_STATE, 18 },
+	.taper_current = { BQ274XX_SUBCLASS_STATE, 30 },
+};
+
+__unused static const struct bq274xx_blockdata_addresses bq27426_blockdata_addresses = {
+	.design_cap = { BQ274XX_SUBCLASS_STATE, 6 },
+	.design_enr = { BQ274XX_SUBCLASS_STATE, 8 },
+	.terminate_voltage = { BQ274XX_SUBCLASS_STATE, 10 },
+	.taper_rate = { BQ274XX_SUBCLASS_STATE, 21 },
+};
+
+__unused static const struct bq274xx_blockdata_addresses bq27441_blockdata_addresses = {
+	.design_cap = { BQ274XX_SUBCLASS_STATE, 10 },
+	.design_enr = { BQ274XX_SUBCLASS_STATE, 12 },
+	.terminate_voltage = { BQ274XX_SUBCLASS_STATE, 16 },
+	.taper_rate = { BQ274XX_SUBCLASS_STATE, 27 },
+};
+
 #ifdef CONFIG_PM_DEVICE
-#define BQ274XX_INT_CFG(index)						      \
-	.int_gpios = GPIO_DT_SPEC_INST_GET(index, int_gpios),
+#define BQ274XX_INT_CFG(index) .int_gpios = GPIO_DT_SPEC_INST_GET(index, int_gpios),
 #else
 #define BQ274XX_INT_CFG(index)
 #endif
 
-#define BQ274XX_INIT(index)                                                    \
-	static struct bq274xx_data bq274xx_driver_##index;                     \
-									       \
-	static const struct bq274xx_config bq274xx_config_##index = {          \
-		BQ274XX_INT_CFG(index)                                         \
-		.bus_name = DT_INST_BUS_LABEL(index),                          \
-		.design_voltage = DT_INST_PROP(index, design_voltage),         \
-		.design_capacity = DT_INST_PROP(index, design_capacity),       \
-		.taper_current = DT_INST_PROP(index, taper_current),           \
-		.terminate_voltage = DT_INST_PROP(index, terminate_voltage),   \
-	};                                                                     \
-									       \
-	PM_DEVICE_DT_INST_DEFINE(index, bq274xx_pm_action);		       \
-									       \
-	DEVICE_DT_INST_DEFINE(index, &bq274xx_gauge_init,		       \
-			    PM_DEVICE_DT_INST_GET(index),		       \
-			    &bq274xx_driver_##index,                           \
-			    &bq274xx_config_##index, POST_KERNEL,              \
-			    CONFIG_SENSOR_INIT_PRIORITY,                       \
-			    &bq274xx_battery_driver_api);
+#define BQ274XX_INIT(index, PART_TYPE, part_type)						   \
+	static struct bq274xx_data part_type##_driver_##index;					   \
+												   \
+	static const struct bq274xx_config part_type##_config_##index = {			   \
+		BQ274XX_INT_CFG(index)								   \
+		.bus_name = DT_INST_BUS_LABEL(index),						   \
+		.reg_addr = DT_INST_REG_ADDR(index),						   \
+		.part = PART_TYPE,								   \
+		.blockdata_addresses = &part_type##_blockdata_addresses,			   \
+		.design_voltage = DT_INST_PROP(index, design_voltage),				   \
+		.design_capacity = DT_INST_PROP(index, design_capacity),			   \
+		.taper_current = DT_INST_PROP(index, taper_current),				   \
+		.terminate_voltage = DT_INST_PROP(index, terminate_voltage),			   \
+		.chemistry = DT_ENUM_IDX_OR(DT_DRV_INST(index), chemistry, CHEM_DEFAULT),	   \
+	};											   \
+												   \
+	PM_DEVICE_DT_INST_DEFINE(index, bq274xx_pm_action);					   \
+												   \
+	DEVICE_DT_INST_DEFINE(index, &bq274xx_gauge_init, PM_DEVICE_DT_INST_GET(index),		   \
+			      &part_type##_driver_##index, &part_type##_config_##index,		   \
+			      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,				   \
+			      &bq274xx_battery_driver_api);
 
-DT_INST_FOREACH_STATUS_OKAY(BQ274XX_INIT)
+#define BQ27411_INIT(index) BQ274XX_INIT(index, BQ27411, bq27411)
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT ti_bq27411
+DT_INST_FOREACH_STATUS_OKAY(BQ27411_INIT)
+
+#define BQ27421_INIT(index) BQ274XX_INIT(index, BQ27421, bq27421)
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT ti_bq27421
+DT_INST_FOREACH_STATUS_OKAY(BQ27421_INIT)
+
+#define BQ27425_INIT(index) BQ274XX_INIT(index, BQ27425, bq27425)
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT ti_bq27425
+DT_INST_FOREACH_STATUS_OKAY(BQ27425_INIT)
+
+#define BQ27426_INIT(index) BQ274XX_INIT(index, BQ27426, bq27426)
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT ti_bq27426
+DT_INST_FOREACH_STATUS_OKAY(BQ27426_INIT)
+
+#define BQ27441_INIT(index) BQ274XX_INIT(index, BQ27441, bq27441)
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT ti_bq27441
+DT_INST_FOREACH_STATUS_OKAY(BQ27441_INIT)

--- a/drivers/sensor/bq274xx/bq274xx.h
+++ b/drivers/sensor/bq274xx/bq274xx.h
@@ -12,34 +12,33 @@
 LOG_MODULE_REGISTER(bq274xx, CONFIG_SENSOR_LOG_LEVEL);
 
 /*** General Constant ***/
-#define BQ274XX_UNSEAL_KEY 0x8000 /* Secret code to unseal the BQ27441-G1A */
-#define BQ274XX_DEVICE_ID 0x0421 /* Default device ID */
+#define BQ274XX_UNSEAL_KEY 0x8000       /* Secret code to unseal the BQ274XX */
+#define BQ274XX_BLOCKDATA_SIZE 32       /* Number of bytes in a single block of data memory */
 
 /*** Standard Commands ***/
-#define BQ274XX_COMMAND_CONTROL_LOW 0x00 /* Control() low register */
-#define BQ274XX_COMMAND_CONTROL_HIGH 0x01 /* Control() high register */
-#define BQ274XX_COMMAND_TEMP 0x02 /* Temperature() */
-#define BQ274XX_COMMAND_VOLTAGE 0x04 /* Voltage() */
-#define BQ274XX_COMMAND_FLAGS 0x06 /* Flags() */
-#define BQ274XX_COMMAND_NOM_CAPACITY 0x08 /* NominalAvailableCapacity() */
-#define BQ274XX_COMMAND_AVAIL_CAPACITY 0x0A /* FullAvailableCapacity() */
-#define BQ274XX_COMMAND_REM_CAPACITY 0x0C /* RemainingCapacity() */
-#define BQ274XX_COMMAND_FULL_CAPACITY 0x0E /* FullChargeCapacity() */
-#define BQ274XX_COMMAND_AVG_CURRENT 0x10 /* AverageCurrent() */
-#define BQ274XX_COMMAND_STDBY_CURRENT 0x12 /* StandbyCurrent() */
-#define BQ274XX_COMMAND_MAX_CURRENT 0x14 /* MaxLoadCurrent() */
-#define BQ274XX_COMMAND_AVG_POWER 0x18 /* AveragePower() */
-#define BQ274XX_COMMAND_SOC 0x1C /* StateOfCharge() */
-#define BQ274XX_COMMAND_INT_TEMP 0x1E /* InternalTemperature() */
-#define BQ274XX_COMMAND_SOH 0x20 /* StateOfHealth() */
-#define BQ274XX_COMMAND_REM_CAP_UNFL 0x28 /* RemainingCapacityUnfiltered() */
-#define BQ274XX_COMMAND_REM_CAP_FIL 0x2A /* RemainingCapacityFiltered() */
-#define BQ274XX_COMMAND_FULL_CAP_UNFL 0x2C /* FullChargeCapacityUnfiltered() */
-#define BQ274XX_COMMAND_FULL_CAP_FIL 0x2E /* FullChargeCapacityFiltered() */
-#define BQ274XX_COMMAND_SOC_UNFL 0x30 /* StateOfChargeUnfiltered() */
+#define BQ274XX_COMMAND_CONTROL 0x00            /* Control() */
+#define BQ274XX_COMMAND_TEMP 0x02               /* Temperature() */
+#define BQ274XX_COMMAND_VOLTAGE 0x04            /* Voltage() */
+#define BQ274XX_COMMAND_FLAGS 0x06              /* Flags() */
+#define BQ274XX_COMMAND_NOM_CAPACITY 0x08       /* NominalAvailableCapacity() */
+#define BQ274XX_COMMAND_AVAIL_CAPACITY 0x0A     /* FullAvailableCapacity() */
+#define BQ274XX_COMMAND_REM_CAPACITY 0x0C       /* RemainingCapacity() */
+#define BQ274XX_COMMAND_FULL_CAPACITY 0x0E      /* FullChargeCapacity() */
+#define BQ274XX_COMMAND_AVG_CURRENT 0x10        /* AverageCurrent() */
+#define BQ274XX_COMMAND_STDBY_CURRENT 0x12      /* StandbyCurrent() */
+#define BQ274XX_COMMAND_MAX_CURRENT 0x14        /* MaxLoadCurrent() */
+#define BQ274XX_COMMAND_AVG_POWER 0x18          /* AveragePower() */
+#define BQ274XX_COMMAND_SOC 0x1C                /* StateOfCharge() */
+#define BQ274XX_COMMAND_INT_TEMP 0x1E           /* InternalTemperature() */
+#define BQ274XX_COMMAND_SOH 0x20                /* StateOfHealth() */
+#define BQ274XX_COMMAND_REM_CAP_UNFL 0x28       /* RemainingCapacityUnfiltered() */
+#define BQ274XX_COMMAND_REM_CAP_FIL 0x2A        /* RemainingCapacityFiltered() */
+#define BQ274XX_COMMAND_FULL_CAP_UNFL 0x2C      /* FullChargeCapacityUnfiltered() */
+#define BQ274XX_COMMAND_FULL_CAP_FIL 0x2E       /* FullChargeCapacityFiltered() */
+#define BQ274XX_COMMAND_SOC_UNFL 0x30           /* StateOfChargeUnfiltered() */
 
 /*** Control Sub-Commands ***/
-#define BQ274XX_CONTROL_STATUS 0x0000
+#define BQ274XX_CONTROL_CONTROL_STATUS 0x0000
 #define BQ274XX_CONTROL_DEVICE_TYPE 0x0001
 #define BQ274XX_CONTROL_FW_VERSION 0x0002
 #define BQ274XX_CONTROL_DM_CODE 0x0004
@@ -54,30 +53,97 @@ LOG_MODULE_REGISTER(bq274xx, CONFIG_SENSOR_LOG_LEVEL);
 #define BQ274XX_CONTROL_SHUTDOWN 0x001C
 #define BQ274XX_CONTROL_SEALED 0x0020
 #define BQ274XX_CONTROL_PULSE_SOC_INT 0x0023
+#define BQ274XX_CONTROL_CHEM_A 0x0030
+#define BQ274XX_CONTROL_CHEM_B 0x0031
+#define BQ274XX_CONTROL_CHEM_C 0x0032
 #define BQ274XX_CONTROL_RESET 0x0041
 #define BQ274XX_CONTROL_SOFT_RESET 0x0042
 #define BQ274XX_CONTROL_EXIT_CFGUPDATE 0x0043
 #define BQ274XX_CONTROL_EXIT_RESIM 0x0044
 
-/*** Extended Data Commands ***/
-#define BQ274XX_EXTENDED_OPCONFIG 0x3A /* OpConfig() */
-#define BQ274XX_EXTENDED_CAPACITY 0x3C /* DesignCapacity() */
-#define BQ274XX_EXTENDED_DATA_CLASS 0x3E /* DataClass() */
-#define BQ274XX_EXTENDED_DATA_BLOCK 0x3F /* DataBlock() */
-#define BQ274XX_EXTENDED_BLOCKDATA_START 0x40 /* BlockData_start() */
-#define BQ274XX_EXTENDED_BLOCKDATA_END 0x5F /* BlockData_end() */
-#define BQ274XX_EXTENDED_CHECKSUM 0x60 /* BlockDataCheckSum() */
-#define BQ274XX_EXTENDED_DATA_CONTROL 0x61 /* BlockDataControl() */
-#define BQ274XX_EXTENDED_BLOCKDATA_DESIGN_CAP_HIGH 0x4A /* BlockData */
-#define BQ274XX_EXTENDED_BLOCKDATA_DESIGN_CAP_LOW 0x4B
-#define BQ274XX_EXTENDED_BLOCKDATA_DESIGN_ENR_HIGH 0x4C
-#define BQ274XX_EXTENDED_BLOCKDATA_DESIGN_ENR_LOW 0x4D
-#define BQ274XX_EXTENDED_BLOCKDATA_TERMINATE_VOLT_HIGH 0x50
-#define BQ274XX_EXTENDED_BLOCKDATA_TERMINATE_VOLT_LOW 0x51
-#define BQ274XX_EXTENDED_BLOCKDATA_TAPERRATE_HIGH 0x5B
-#define BQ274XX_EXTENDED_BLOCKDATA_TAPERRATE_LOW 0x5C
+/*** Control().CONTROL_STATUS bit definitions ***/
+#define BQ274XX_CONTROL_STATUS_SHUTDOWNEN 15
+#define BQ274XX_CONTROL_STATUS_WDRESET 14
+#define BQ274XX_CONTROL_STATUS_SS 13
+#define BQ274XX_CONTROL_STATUS_CALMODE 12
+#define BQ274XX_CONTROL_STATUS_CCA 11
+#define BQ274XX_CONTROL_STATUS_BCA 10
+#define BQ274XX_CONTROL_STATUS_QMAX_UP 9
+#define BQ274XX_CONTROL_STATUS_RES_UP 8
+#define BQ274XX_CONTROL_STATUS_INITCOMP 7
+#define BQ274XX_CONTROL_STATUS_HIBERNATE 6
+#define BQ274XX_CONTROL_STATUS_SLEEP 4
+#define BQ274XX_CONTROL_STATUS_LDMD 3
+#define BQ274XX_CONTROL_STATUS_RUP_DIS 2
+#define BQ274XX_CONTROL_STATUS_VOK 1
+#define BQ274XX_CONTROL_STATUS_CHEM_CHANGE 0
 
-#define BQ274XX_DELAY 1000
+/*** Flags() bit definitions ***/
+#define BQ274XX_FLAGS_OT 15
+#define BQ274XX_FLAGS_UT 14
+#define BQ274XX_FLAGS_EEFAIL 10
+#define BQ274XX_FLAGS_FC 9
+#define BQ274XX_FLAGS_CHG 8
+#define BQ274XX_FLAGS_OCVTAKEN 7
+#define BQ274XX_FLAGS_DODCORRECT 6
+#define BQ274XX_FLAGS_ITPOR 5
+#define BQ274XX_FLAGS_CFGUPMODE 4
+#define BQ274XX_FLAGS_BAT_DET 3
+#define BQ274XX_FLAGS_SOC1 2
+#define BQ274XX_FLAGS_SOCF 1
+#define BQ274XX_FLAGS_DSG 0
+
+/*** Extended Data Commands ***/
+#define BQ274XX_EXTENDED_OPCONFIG 0x3A          /* OpConfig() */
+#define BQ274XX_EXTENDED_CAPACITY 0x3C          /* DesignCapacity() */
+#define BQ274XX_EXTENDED_DATA_CLASS 0x3E        /* DataClass() */
+#define BQ274XX_EXTENDED_DATA_BLOCK 0x3F        /* DataBlock() */
+#define BQ274XX_EXTENDED_BLOCKDATA_START 0x40   /* BlockData_start() */
+#define BQ274XX_EXTENDED_BLOCKDATA_END 0x5F     /* BlockData_end() */
+#define BQ274XX_EXTENDED_CHECKSUM 0x60          /* BlockDataCheckSum() */
+#define BQ274XX_EXTENDED_DATA_CONTROL 0x61      /* BlockDataControl() */
+
+/*** Extended Data Subclasses ***/
+#define BQ274XX_SUBCLASS_INVALID 0
+#define BQ274XX_SUBCLASS_SAFETY 2
+#define BQ274XX_SUBCLASS_CHARGE_TERMINATION 36
+#define BQ274XX_SUBCLASS_DISCHARGE 49
+#define BQ274XX_SUBCLASS_REGISTERS 64
+#define BQ274XX_SUBCLASS_IT_CFG 80
+#define BQ274XX_SUBCLASS_CURRENT_THRESHOLDS 81
+#define BQ274XX_SUBCLASS_STATE 82
+#define BQ274XX_SUBCLASS_CHEM_DATA 109
+
+struct bq274xx_blockdata_address {
+	uint8_t subclass;
+	uint8_t offset;
+};
+
+struct bq274xx_blockdata_addresses {
+	struct bq274xx_blockdata_address design_cap;
+	struct bq274xx_blockdata_address design_enr;
+	struct bq274xx_blockdata_address terminate_voltage;
+	struct bq274xx_blockdata_address taper_rate;
+	struct bq274xx_blockdata_address taper_current;
+};
+
+#define MAX_BLOCKDATA_ENTRIES                                                                      \
+	sizeof(struct bq274xx_blockdata_addresses) / sizeof(struct bq274xx_blockdata_address)
+
+enum bq274xx_part {
+	BQ27411,
+	BQ27421,
+	BQ27425,
+	BQ27426,
+	BQ27441,
+};
+
+enum bq274xx_chemistry {
+	CHEM_A,
+	CHEM_B,
+	CHEM_C,
+	CHEM_DEFAULT,
+};
 
 struct bq274xx_data {
 	const struct device *i2c;
@@ -100,6 +166,9 @@ struct bq274xx_data {
 
 struct bq274xx_config {
 	char *bus_name;
+	uint16_t reg_addr;
+	enum bq274xx_part part;
+	const struct bq274xx_blockdata_addresses *blockdata_addresses;
 	uint16_t design_voltage;
 	uint16_t design_capacity;
 	uint16_t taper_current;
@@ -107,6 +176,7 @@ struct bq274xx_config {
 #ifdef CONFIG_PM_DEVICE
 	struct gpio_dt_spec int_gpios;
 #endif
+	enum bq274xx_chemistry chemistry;
 };
 
 #endif

--- a/dts/bindings/sensor/ti,bq27411.yaml
+++ b/dts/bindings/sensor/ti,bq27411.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+description: TI BQ27411 Fuel Gauge
+
+compatible: "ti,bq27411"
+
+include: ti,bq274xx-common.yaml

--- a/dts/bindings/sensor/ti,bq27421.yaml
+++ b/dts/bindings/sensor/ti,bq27421.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+description: TI BQ27421 Fuel Gauge
+
+compatible: "ti,bq27421"
+
+include: ti,bq274xx-common.yaml

--- a/dts/bindings/sensor/ti,bq27425.yaml
+++ b/dts/bindings/sensor/ti,bq27425.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+description: TI BQ27425 Fuel Gauge
+
+compatible: "ti,bq27425"
+
+include: ti,bq274xx-common.yaml

--- a/dts/bindings/sensor/ti,bq27426.yaml
+++ b/dts/bindings/sensor/ti,bq27426.yaml
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+
+description: TI BQ27426 Fuel Gauge
+
+compatible: "ti,bq27426"
+
+include: ti,bq274xx-common.yaml
+
+properties:
+    chemistry:
+      type: string
+      required: false
+      description: |
+        Chemistry type to use for devices that support programmable chemistry.
+      enum:
+         - "CHEM_A"
+         - "CHEM_B"
+         - "CHEM_C"

--- a/dts/bindings/sensor/ti,bq27441.yaml
+++ b/dts/bindings/sensor/ti,bq27441.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+description: TI BQ27441 Fuel Gauge
+
+compatible: "ti,bq27441"
+
+include: ti,bq274xx-common.yaml

--- a/dts/bindings/sensor/ti,bq274xx-common.yaml
+++ b/dts/bindings/sensor/ti,bq274xx-common.yaml
@@ -6,8 +6,6 @@
 
 description: Texas Instruments BQ274xx Fuel Gauge
 
-compatible: "ti,bq274xx"
-
 include: i2c-device.yaml
 
 properties:

--- a/samples/sensor/bq274xx/README.rst
+++ b/samples/sensor/bq274xx/README.rst
@@ -25,7 +25,7 @@ from BQ274XX sensor and prints this information to the UART console.
 Requirements
 ************
 
-- nrf9160_innblue22 board with BQ274XX sensor `BQ274XX Sensor`_
+- nrf9160_innblue22 board with BQ27421 sensor `BQ274XX Sensor`_
 
 Building and Running
 ********************

--- a/samples/sensor/bq274xx/src/main.c
+++ b/samples/sensor/bq274xx/src/main.c
@@ -210,7 +210,7 @@ void main(void)
 {
 	const struct device *dev;
 
-	dev = device_get_binding(DT_LABEL(DT_INST(0, ti_bq274xx)));
+	dev = device_get_binding(DT_LABEL(DT_INST(0, ti_bq27421)));
 	if (!dev) {
 		printk("Failed to get device binding");
 		return;

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -557,9 +557,9 @@ test_i2c_tmp116: tmp116@46 {
 	reg = <0x46>;
 };
 
-test_i2c_bq274xx: bq27xx@47 {
-	compatible = "ti,bq274xx";
-	label = "BQ274XX";
+test_i2c_bq27441: bq2741@47 {
+	compatible = "ti,bq27441";
+	label = "BQ27441";
 	reg = <0x47>;
 	design-voltage = <3700>;
 	design-capacity = <1800>;


### PR DESCRIPTION
This adds support for the following:
    BQ27411
    BQ27425
    BQ27426
    BQ27441

It also fixes a few bugs and improves robustness of the driver.

Signed-off-by: Nick Ewalt <nicholasewalt@google.com>