### PR TITLE
edtlib: Add support for retrieving nodes by property labels

### DIFF
--- a/samples/subsys/display/grove_display/sample.yaml
+++ b/samples/subsys/display/grove_display/sample.yaml
@@ -5,3 +5,4 @@ tests:
     tags: drivers
     harness: grove
     depends_on: i2c
+    filter: dt_proplabel_enabled("I2C_0")

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -448,6 +448,7 @@ class EDT:
         # Initialize node lookup tables (LUTs).
 
         self.label2node = OrderedDict()
+        self.prop_label2node = OrderedDict()
         self.dep_ord2node = OrderedDict()
         self.compat2nodes = defaultdict(list)
         self.compat2okay = defaultdict(list)
@@ -455,6 +456,10 @@ class EDT:
         for node in self.nodes:
             for label in node.labels:
                 self.label2node[label] = node
+
+            nlabel = node.props.get('label')
+            if nlabel:
+                self.prop_label2node[nlabel.val_as_token] = node
 
             for compat in node.compats:
                 self.compat2nodes[compat].append(node)

--- a/scripts/pylib/twister/expr_parser.py
+++ b/scripts/pylib/twister/expr_parser.py
@@ -285,6 +285,14 @@ def ast_expr(ast, env, edt):
         if node and node.status == "okay":
             return True
         return False
+    elif ast[0] == "dt_proplabel_enabled":
+        # Checks to see if the DT has an enabled node with a matching
+        # property 'label'
+        prop_label = ast[1][0]
+        node = edt.prop_label2node.get(prop_label)
+        if node and node.status == "okay":
+            return True
+        return False
 
 def ast_handle_dt_enabled_alias_with_parent_compat(edt, alias, compat):
     # Helper shared with the now deprecated


### PR DESCRIPTION
Some DT nodes have a 'label' property that is useful to filter on. Add an OrderedDict of prop_label2node containing nodes that have a 'label' property. The key will be the 'label' value.

Fixes #41523