### PR TITLE
drivers: can: mcan: Add one-shot send option

### DIFF
--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -355,6 +355,10 @@ int can_mcan_init(const struct device *dev, const struct can_mcan_config *cfg,
 		       CAN_MCAN_CCCR_ASM);
 	can->test &= ~(CAN_MCAN_TEST_LBCK);
 
+	if (cfg->one_shot) {
+		can->cccr |= CAN_MCAN_CCCR_DAR;
+	}
+
 #if defined(CONFIG_CAN_DELAY_COMP) && defined(CONFIG_CAN_FD_MODE)
 	can->dbtp |= CAN_MCAN_DBTP_TDC;
 	can->tdcr |=  cfg->tx_delay_comp_offset << CAN_MCAN_TDCR_TDCO_POS;

--- a/drivers/can/can_mcan.h
+++ b/drivers/can/can_mcan.h
@@ -193,6 +193,7 @@ struct can_mcan_config {
 	uint16_t sample_point;
 	uint16_t prop_ts1;
 	uint16_t ts2;
+	bool one_shot;
 #ifdef CONFIG_CAN_FD_MODE
 	uint16_t sample_point_data;
 	uint8_t sjw_data;

--- a/drivers/can/can_mcux_mcan.c
+++ b/drivers/can/can_mcux_mcan.c
@@ -215,7 +215,8 @@ static const struct can_driver_api mcux_mcan_driver_api = {
 			DT_INST_PROP_OR(n, phase_seg1_data, 0),		\
 		.ts2_data = DT_INST_PROP_OR(n, phase_seg2_data, 0),	\
 		.tx_delay_comp_offset =					\
-			DT_INST_PROP(n, tx_delay_comp_offset)		\
+			DT_INST_PROP(n, tx_delay_comp_offset),		\
+		.one_shot = DT_INST_PROP(inst, one_shot),		\
 	}
 #else /* CONFIG_CAN_FD_MODE */
 #define MCUX_MCAN_MCAN_INIT(n)						\
@@ -227,6 +228,7 @@ static const struct can_driver_api mcux_mcan_driver_api = {
 		.prop_ts1 = DT_INST_PROP_OR(n, prop_seg, 0) +		\
 			DT_INST_PROP_OR(n, phase_seg1, 0),		\
 		.ts2 = DT_INST_PROP_OR(n, phase_seg2, 0),		\
+		.one_shot = DT_INST_PROP(inst, one_shot),		\
 	}
 #endif /* !CONFIG_CAN_FD_MODE */
 

--- a/drivers/can/can_sam.c
+++ b/drivers/can/can_sam.c
@@ -223,7 +223,8 @@ static void config_can_##inst##_irq(void)                                       
 	.prop_ts1_data = DT_INST_PROP_OR(inst, prop_seg_data, 0) +                             \
 			 DT_INST_PROP_OR(inst, phase_seg1_data, 0),                            \
 	.ts2_data = DT_INST_PROP_OR(inst, phase_seg2_data, 0),                                 \
-	.tx_delay_comp_offset = DT_INST_PROP(inst, tx_delay_comp_offset)                       \
+	.tx_delay_comp_offset = DT_INST_PROP(inst, tx_delay_comp_offset),                      \
+	.one_shot = DT_INST_PROP(inst, one_shot),                                              \
 }
 #else /* CONFIG_CAN_FD_MODE */
 #define CAN_SAM_MCAN_CFG(inst)                                                                 \
@@ -233,6 +234,7 @@ static void config_can_##inst##_irq(void)                                       
 	.sample_point = DT_INST_PROP_OR(inst, sample_point, 0),                                \
 	.prop_ts1 = DT_INST_PROP_OR(inst, prop_seg, 0) + DT_INST_PROP_OR(inst, phase_seg1, 0), \
 	.ts2 = DT_INST_PROP_OR(inst, phase_seg2, 0),                                           \
+	.one_shot = DT_INST_PROP(inst, one_shot),                                              \
 }
 #endif /* CONFIG_CAN_FD_MODE */
 

--- a/drivers/can/can_stm32fd.c
+++ b/drivers/can/can_stm32fd.c
@@ -263,7 +263,8 @@ static const struct can_stm32fd_config can_stm32fd_cfg_##inst = {              \
 				DT_INST_PROP_OR(inst, phase_seg1_data, 0),     \
 		.ts2_data = DT_INST_PROP_OR(inst, phase_seg2_data, 0),         \
 		.tx_delay_comp_offset =                                        \
-			DT_INST_PROP(inst, tx_delay_comp_offset)               \
+			DT_INST_PROP(inst, tx_delay_comp_offset),              \
+		.one_shot = DT_INST_PROP(inst, one_shot),                      \
 	},                                                                     \
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),                          \
 };
@@ -287,6 +288,7 @@ static const struct can_stm32fd_config can_stm32fd_cfg_##inst = {              \
 		.prop_ts1 = DT_INST_PROP_OR(inst, prop_seg, 0) +               \
 			    DT_INST_PROP_OR(inst, phase_seg1, 0),              \
 		.ts2 = DT_INST_PROP_OR(inst, phase_seg2, 0),                   \
+		.one_shot = DT_INST_PROP(inst, one_shot),                      \
 	},                                                                     \
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),                          \
 };

--- a/drivers/can/can_stm32h7.c
+++ b/drivers/can/can_stm32h7.c
@@ -265,7 +265,8 @@ static const struct can_driver_api can_api_funcs = {
 			DT_INST_PROP_OR(n, phase_seg1_data, 0),		\
 		.ts2_data = DT_INST_PROP_OR(n, phase_seg2_data, 0),	\
 		.tx_delay_comp_offset =					\
-			DT_INST_PROP(n, tx_delay_comp_offset)		\
+			DT_INST_PROP(n, tx_delay_comp_offset),		\
+		.one_shot = DT_INST_PROP(n, one_shot),			\
 	}
 #else /* CONFIG_CAN_FD_MODE */
 #define CAN_STM32H7_MCAN_MCAN_INIT(n)					\
@@ -277,6 +278,7 @@ static const struct can_driver_api can_api_funcs = {
 		.prop_ts1 = DT_INST_PROP_OR(n, prop_seg, 0) +		\
 			DT_INST_PROP_OR(n, phase_seg1, 0),		\
 		.ts2 = DT_INST_PROP_OR(n, phase_seg2, 0),		\
+		.one_shot = DT_INST_PROP(n, one_shot),			\
 	}
 #endif /* !CONFIG_CAN_FD_MODE */
 

--- a/dts/bindings/can/bosch,m-can.yaml
+++ b/dts/bindings/can/bosch,m-can.yaml
@@ -10,3 +10,11 @@ properties:
 
     interrupts:
       required: true
+
+    one-shot:
+      type: boolean
+      required: false
+      description: |
+        Disable automatic retransmissions. A CAN frame will only be transmitted
+        once, independently of the transmission result (successful, error, or
+        arbitration lost).


### PR DESCRIPTION
Adds one-shot option to Bosch M_CAN-based CAN driver.

Sets the DAR bit in the CCCR register, which disables automatic retransmission of frames. With DAR set, frames that aren't ACK'd by the bus are not retransmitted.