### PR TITLE
drivers: eth_sam_gmac: fix eth_sam_gmac_set_config()

### DIFF
--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -2030,6 +2030,8 @@ static int eth_sam_gmac_set_config(const struct device *dev,
 				   enum ethernet_config_type type,
 				   const struct ethernet_config *config)
 {
+	int result = 0;
+
 	switch (type) {
 #if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 1
 	case ETHERNET_CONFIG_TYPE_QAV_PARAM:
@@ -2057,12 +2059,14 @@ static int eth_sam_gmac_set_config(const struct device *dev,
 		net_if_set_link_addr(dev_data->iface, dev_data->mac_addr,
 				     sizeof(dev_data->mac_addr),
 				     NET_LINK_ETHERNET);
+		break;
 	}
 	default:
+		result = -ENOTSUP;
 		break;
 	}
 
-	return -ENOTSUP;
+	return result;
 }
 
 #if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 1


### PR DESCRIPTION
Fix handling of the return value by `eth_sam_gmac_set_config` function.
The function is used as a backend by
`net_mgmt(NET_REQUEST_ETHERNET_SET_MAC_ADDRESS, ...)` to change the
interface MAC address at run time.

Tested on sam_e70_xplained board.

Fixes #42151