### PR TITLE
Extra fixups to sneak in before 3.0

### DIFF
--- a/soc/xtensa/intel_adsp/common/include/cavs-ipc-regs.h
+++ b/soc/xtensa/intel_adsp/common/include/cavs-ipc-regs.h
@@ -1,0 +1,91 @@
+/* Copyright (c) 2021 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_SOC_INTEL_ADSP_CAVS_IPC_REGS_H
+#define ZEPHYR_SOC_INTEL_ADSP_CAVS_IPC_REGS_H
+
+/* Inter Processor Communication: a distressingly heavyweight method
+ * for directing interrupts at software running on other processors.
+ * Used for sending interrupts to and receiving them from another
+ * device.  cAVS uses it to talk to the host and the CSME.  In general
+ * there is one of these blocks instantiated for each endpoint of a
+ * connection.
+ *
+ * There are actually three (!) interrupt channels on the link, all
+ * bidirectional, but they're somewhat nonorthogonal.  Each can be
+ * independently masked via the CTL register.
+ *
+ * 1. When the IDR register is written with the high ("BUSY") bit set,
+ *    the IDR value written is copied to the TDR register on the other
+ *    end of the connection, where the BUSY bit acts as a
+ *    level-triggered interrupt latch (and must therefore be cleared
+ *    by the handler by writing a 1).  The high bit ("DONE") also
+ *    becomes set on the TDA register of the other endpoint.
+ *    Additionally, the IDD register is copied to the TDD register on
+ *    the other side.  That data, and the remaining 31 bits of
+ *    IDR/TDR, are uninspected by the hardware and are intended to be
+ *    used as a "message" (but see below).
+ *
+ * 2. Writes to TDA on the receiving end of the connection with the
+ *    high bit ("DONE") set to zero and (!) when the IDR BUSY bit is
+ *    one on the other side of the connection (i.e. "when the other
+ *    side has sent a message") cause an interrupt to be triggered on
+ *    the other endpoint by setting its IDA high bit (which must be
+ *    cleared to acknowledge the interrupt, again by writing a one
+ *    bit).  At the same time, the peer's IDR.BUSY is cleared.  No
+ *    data is copied with this interrupt mechanism.
+ *
+ * 3. When the CST register is written with a non-zero value, the
+ *    value is copied to the CSR register on other side and an
+ *    interrupt is triggered (to be cleared by writing CSR to zero).
+ *    This is historically unused and unsupported by simulation tools.
+ *
+ * Note that while the scheme in #1 may look like an atomic message,
+ * there is no queuing in the hardware!  This is just a regular level
+ * triggered interrupt with some scratch registers on which mulitple
+ * contexts can race.  The design intent is that the sender polls the
+ * IDR.BUSY bit (or waits for a return interrupt via #2) to be sure
+ * the link is available.  And even then two independent initiators
+ * (cores, threads, whatever) trying to initiate a message may race if
+ * they have access to the same endpoint.  Use with care.
+ *
+ * Note also that the ancestral cAVS 1.5 version of this interface is
+ * very similar (the registers had different names, but that's been
+ * unified here), but with a different layout and with DONE signaled
+ * via bit 30 of the TDD register when BUSY is cleared in TDR on the
+ * other side and not via a separate TDA/IDA.  This means that it's
+ * not possible to defer completion of a message on cAVS 1.5 as the
+ * interrupt would remain active.
+ */
+struct cavs_ipc {
+#ifdef CONFIG_SOC_SERIES_INTEL_CAVS_V15
+	uint32_t tdr;
+	uint32_t tdd;
+	uint32_t idr;
+	uint32_t idd;
+	uint32_t ctl;
+	uint32_t ida; /* Fakes for source compatibility; these ...  */
+	uint32_t tda; /* ... two registers don't exist in hardware. */
+#else
+	uint32_t tdr;
+	uint32_t tda;
+	uint32_t tdd;
+	uint32_t unused0;
+	uint32_t idr;
+	uint32_t ida;
+	uint32_t idd;
+	uint32_t unused1;
+	uint32_t cst;
+	uint32_t csr;
+	uint32_t ctl;
+#endif
+};
+
+#define CAVS_IPC_BUSY BIT(31)
+#define CAVS_IPC_DONE BIT(31)
+#define CAVS_IPC_IDD15_DONE BIT(30) /* v1.5 way to signal done */
+
+#define CAVS_IPC_CTL_TBIE BIT(0)
+#define CAVS_IPC_CTL_IDIE BIT(1) /* yesthatiswhattheyreallynamedit */
+
+#endif /* ZEPHYR_SOC_INTEL_ADSP_CAVS_IPC_REGS_H */

--- a/tests/kernel/interrupt/src/prevent_irq.c
+++ b/tests/kernel/interrupt/src/prevent_irq.c
@@ -10,6 +10,9 @@
 #define DURATION	5
 #define HANDLER_TOKEN	0xDEADBEEF
 
+/* Long enough to be guaranteed a tick "should have fired" */
+#define TIMER_DELAY_US (128 * 1000000 / CONFIG_SYS_CLOCK_TICKS_PER_SEC)
+
 static struct k_timer irqlock_timer;
 volatile uint32_t handler_result;
 
@@ -46,14 +49,14 @@ void test_prevent_interruption(void)
 	 * locked -- but since they are, check_lock_new isn't updated.
 	 */
 	k_timer_start(&irqlock_timer, K_MSEC(DURATION), K_NO_WAIT);
-	k_busy_wait(MS_TO_US(1000));
+	k_busy_wait(TIMER_DELAY_US);
 	zassert_not_equal(handler_result, HANDLER_TOKEN,
 		"timer interrupt was serviced while interrupts are locked");
 
 	printk("unlocking interrupts\n");
 	irq_unlock(key);
 
-	k_busy_wait(MS_TO_US(1000));
+	k_busy_wait(TIMER_DELAY_US);
 
 	zassert_equal(handler_result, HANDLER_TOKEN,
 		"timer should have fired");

--- a/tests/kernel/mbox/mbox_api/src/main.c
+++ b/tests/kernel/mbox/mbox_api/src/main.c
@@ -35,25 +35,26 @@ extern void test_mbox_get_put_block_data(void);
 void test_main(void)
 {
 	ztest_test_suite(mbox_api,
-			 ztest_1cpu_unit_test(test_mbox_kinit),/*keep init first!*/
-			 ztest_1cpu_unit_test(test_mbox_kdefine),
+			 ztest_unit_test(test_mbox_kinit),/*keep init first!*/
+			 ztest_unit_test(test_mbox_kdefine),
 			 ztest_unit_test(test_enhance_capability),
 			 ztest_unit_test(test_define_multi_mbox),
-			 ztest_1cpu_unit_test(test_mbox_put_get_null),
+			 ztest_unit_test(test_mbox_put_get_null),
 			 ztest_unit_test(test_mbox_put_get_buffer),
-			 ztest_1cpu_unit_test(test_mbox_async_put_get_buffer),
+			 ztest_unit_test(test_mbox_async_put_get_buffer),
 			 ztest_unit_test(test_mbox_target_source_thread_buffer),
 			 ztest_unit_test(test_mbox_incorrect_receiver_tid),
-			 ztest_1cpu_unit_test(test_mbox_incorrect_transmit_tid),
-			 ztest_1cpu_unit_test(test_mbox_timed_out_mbox_get),
+			 ztest_unit_test(test_mbox_incorrect_transmit_tid),
+			 ztest_unit_test(test_mbox_timed_out_mbox_get),
 			 ztest_unit_test(test_mbox_msg_tid_mismatch),
-			 ztest_1cpu_unit_test(test_mbox_dispose_size_0_msg),
-			 ztest_1cpu_unit_test(test_mbox_async_put_to_waiting_get),
+			 ztest_unit_test(test_mbox_dispose_size_0_msg),
+			 ztest_unit_test(test_mbox_async_put_to_waiting_get),
 			 ztest_unit_test(
 				test_mbox_get_waiting_put_incorrect_tid),
-			 ztest_1cpu_unit_test(test_mbox_async_multiple_put),
+			 ztest_unit_test(test_mbox_async_multiple_put),
 			 ztest_unit_test(test_mbox_data_get_null),
 			 ztest_unit_test(test_mbox_get_put_block_data),
-			 ztest_1cpu_unit_test(test_mbox_multiple_waiting_get));
+			 ztest_unit_test(test_mbox_multiple_waiting_get)
+);
 	ztest_run_test_suite(mbox_api);
 }


### PR DESCRIPTION
Two fixes to tests that are interacting badly internally.

One extra register header extracted from the much larger #41828 that would be really nice to have upstream before the main PR merges.

All three are extremely low risk, I promise.