### PR TITLE
tests/lib/ringbuffer: Extend default twister timeout

### DIFF
--- a/tests/lib/ringbuffer/testcase.yaml
+++ b/tests/lib/ringbuffer/testcase.yaml
@@ -1,5 +1,6 @@
 common:
     tags: ring_buffer circular_buffer
+    timeout: 120
 
 tests:
   libraries.ring_buffer:


### PR DESCRIPTION
Normal test execution for this test is above default default
twister timeout, so it requires a specific timeout to avoid
systematic failures are reported by twister.

Fixes #42157

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>