### PR TITLE
samples: lora: Add harnesses for execution with twister

### DIFF
--- a/samples/drivers/lora/receive/sample.yaml
+++ b/samples/drivers/lora/receive/sample.yaml
@@ -6,3 +6,8 @@ sample:
 tests:
    sample.driver.lora.receive:
      platform_allow: 96b_wistrio rak4631_nrf52840 nucleo_wl55jc
+     harness: console
+     harness_config:
+      type: one_line
+      regex:
+        - "<inf> lora_receive: Synchronous reception"

--- a/samples/drivers/lora/send/sample.yaml
+++ b/samples/drivers/lora/send/sample.yaml
@@ -6,3 +6,8 @@ sample:
 tests:
    sample.driver.lora.send:
      platform_allow: 96b_wistrio rak4631_nrf52840 nucleo_wl55jc
+     harness: console
+     harness_config:
+      type: one_line
+      regex:
+        - "<inf> lora_send: Data sent!"

--- a/samples/subsys/lorawan/class_a/sample.yaml
+++ b/samples/subsys/lorawan/class_a/sample.yaml
@@ -6,3 +6,8 @@ sample:
 tests:
    samples.lorawan.class_a:
      platform_allow: 96b_wistrio nucleo_wl55jc
+     harness: console
+     harness_config:
+      type: one_line
+      regex:
+        - "<inf> lorawan_class_a: Joining network over OTAA"


### PR DESCRIPTION
Lora samples are missing harnesses and hence are reported
failed by default by twister.
Add required harnesses to be able to detect correct and faulty
test executions.

Fixes #42159

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>