### PR TITLE
samples/compression/l4z: Increase min_ram

### DIFF
--- a/samples/compression/lz4/sample.yaml
+++ b/samples/compression/lz4/sample.yaml
@@ -3,7 +3,7 @@ sample:
   description: lz4 data compression library
 common:
   tags: compression lz4
-  min_ram: 32
+  min_ram: 40
   filter: TOOLCHAIN_HAS_NEWLIB == 1
   harness: console
   harness_config:


### PR DESCRIPTION
Increase minimum RAM requirements on this test as it appears
that 32 is too low and 40 is verified ok.

Fixes #42161

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>