### PR TITLE
Bluetooth: ATT: Fix conn parameter to req cb in att_reset

### DIFF
--- a/doc/releases/release-notes-3.0.rst
+++ b/doc/releases/release-notes-3.0.rst
@@ -47,6 +47,11 @@ Changes in this release
   CRC-16-ANSI checksum. A new function, :c:func:`crc16_reflect`, has been
   introduced to calculated reflected CRCs.
 
+* GATT callbacks ``bt_gatt_..._func_t`` would previously be called with argument
+  ``conn = NULL`` in the event of a disconnect. This was not documented as part
+  of the API. This behavior is changed so the ``conn`` argument is provided as
+  normal when a disconnect occurs.
+
 Removed APIs in this release
 ============================
 

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -2630,8 +2630,6 @@ static void att_reset(struct bt_att *att)
 		net_buf_unref(buf);
 	}
 
-	att->conn = NULL;
-
 	/* Notify pending requests */
 	while (!sys_slist_is_empty(&att->reqs)) {
 		struct bt_att_req *req;
@@ -2640,13 +2638,17 @@ static void att_reset(struct bt_att *att)
 		node = sys_slist_get_not_empty(&att->reqs);
 		req = CONTAINER_OF(node, struct bt_att_req, node);
 		if (req->func) {
-			req->func(NULL, BT_ATT_ERR_UNLIKELY, NULL, 0,
+			req->func(att->conn, BT_ATT_ERR_UNLIKELY, NULL, 0,
 				  req->user_data);
 		}
 
 		bt_att_req_free(req);
 	}
 
+	/* FIXME: `att->conn` is not reference counted. Consider using `bt_conn_ref`
+	 * and `bt_conn_unref` to follow convention.
+	 */
+	att->conn = NULL;
 	k_mem_slab_free(&att_slab, (void **)&att);
 }
 


### PR DESCRIPTION
The conn pointer is still valid / not reused at this time and can be
used further up the stack as an identifer. This simplifies the API of
ATT, and fixes callbacks in GATT that pass on this value directly since
their API does not allow conn to be NULL.

Fixes #41794

Signed-off-by: Aleksander Wasaznik <aleksander.wasaznik@nordicsemi.no>