### PR TITLE
ci: run apt-get update before install

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -149,6 +149,7 @@ jobs:
 
       - name: Merge coverage files
         run: |
+          sudo apt-get update
           sudo apt-get install -y lcov
           cd ./coverage/reports
           lcov ${{ steps.get-coverage-files.outputs.mergefiles }} -o merged.info --rc lcov_branch_coverage=1

--- a/.github/workflows/coding_guidelines.yml
+++ b/.github/workflows/coding_guidelines.yml
@@ -27,6 +27,7 @@ jobs:
 
     - name: Install Packages
       run: |
+        sudo apt-get update
         sudo apt-get install ocaml-base-nox
         wget https://launchpad.net/~npalix/+archive/ubuntu/coccinelle/+files/coccinelle_1.0.8~20.04npalix1_amd64.deb
         sudo dpkg -i coccinelle_1.0.8~20.04npalix1_amd64.deb

--- a/.github/workflows/issue_count.yml
+++ b/.github/workflows/issue_count.yml
@@ -24,6 +24,7 @@ jobs:
 
     - name: install-packages
       run: |
+        sudo apt-get update
         sudo apt-get install discount
 
     - uses: brcrista/summarize-issues@v3


### PR DESCRIPTION
Make sure sources are up-to-date before installing any package. This is
causing failures on some workflows.