### PR TITLE
dts: pwm : flag to enable a complementary output of a pwm channel pin

### DIFF
--- a/include/drivers/pwm.h
+++ b/include/drivers/pwm.h
@@ -64,8 +64,12 @@ extern "C" {
 
 /**
  * @brief Provides a type to hold PWM configuration flags.
+ *
+ * The lower 8 bits are used for standard flags.
+ * The upper 8 bits are reserved for SoC specific flags.
  */
-typedef uint8_t pwm_flags_t;
+
+typedef uint16_t pwm_flags_t;
 
 /**
  * @typedef pwm_pin_set_t

--- a/include/dt-bindings/pwm/pwm.h
+++ b/include/dt-bindings/pwm/pwm.h
@@ -11,6 +11,7 @@
  * The `PWM_POLARITY_*` flags are used with pwm_pin_set_cycles(),
  * pwm_pin_set_usec(), pwm_pin_set_nsec() or pwm_pin_configure_capture() to
  * specify the polarity of a PWM pin.
+ * The flags are on the lower 8bits of the pwm_flags_t
  * @{
  */
 /** PWM pin normal polarity (active-high pulse). */


### PR DESCRIPTION
Depending on the mcus and the timer instance, several channels
can enable the complementary output for the PWM signal
This flag completes the PWM_POLARITY for a PWM channel.

Signed-off-by: Francois Ramu <francois.ramu@st.com>