### PR TITLE
tests: drivers: modem: Increase minimum RAM requirement for test

### DIFF
--- a/tests/drivers/build_all/modem/testcase.yaml
+++ b/tests/drivers/build_all/modem/testcase.yaml
@@ -5,7 +5,7 @@ tests:
   drivers.modem.build:
     extra_args: CONF_FILE=modem.conf
     platform_exclude: serpente particle_boron rak5010_nrf52840 litex_vexriscv ip_k66f
-    min_ram: 36
+    min_ram: 68
   drivers.modem.ublox_sara.build:
     extra_args: CONF_FILE=modem_ublox_sara.conf
     platform_exclude: serpente pinnacle_100_dvk litex_vexriscv ip_k66f


### PR DESCRIPTION
The actual RAM consumption of the general test case is higher then the
minimum RAM requirement specified by the test, therefore it fails with
RAM overflow for certain platforms (nrf52dk_nrf52832 for example).

Increase the minimum RAM required by the test to reflect the actual
state.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>