### PR TITLE
Bluetooth: Controller: Fix Periodic Sync LLL scheduling flag

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -634,7 +634,10 @@ static int isr_rx(struct lll_sync *lll, uint8_t node_type, uint8_t crc_ok, uint8
 								isr_aux_setup,
 								lll);
 			if (ftr->aux_lll_sched) {
-				lll->is_aux_sched = 1U;
+				if (node_type != NODE_RX_TYPE_EXT_AUX_REPORT) {
+					lll->is_aux_sched = 1U;
+				}
+
 				err = -EBUSY;
 			} else {
 				err = 0;


### PR DESCRIPTION
Fix Periodic Advertising Sync LLL scheduling flag to not be
set when chain PDUs use LLL scheduling, only set when
primary AUX_SYNC_IND PDU received use LLL scheduling.

Without the fix, spurious EVENT_DONE_EXTRA_TYPE_SYNC would
be generated when chain PDUs are failed to be received. This
can cause Sync Lost message to be generated.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>