### PR TITLE
cmake: fix path in comment

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -563,7 +563,7 @@ else()
 endif()
 
 # Use SOC to search for a 'CMakeLists.txt' file.
-# e.g. zephyr/soc/xtense/intel_apl_adsp/CMakeLists.txt.
+# e.g. zephyr/soc/xtensa/intel_adsp/CMakeLists.txt.
 foreach(root ${SOC_ROOT})
   # Check that the root looks reasonable.
   if(NOT IS_DIRECTORY "${root}/soc")


### PR DESCRIPTION
Use correct path for soc in the comment.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
