### PR TITLE
net: openthread: bring back `LOG_MODE_MINIMAL` support

### DIFF
--- a/subsys/net/lib/openthread/platform/logging.c
+++ b/subsys/net/lib/openthread/platform/logging.c
@@ -39,13 +39,35 @@ static inline int log_translate(otLogLevel aLogLevel)
 	return -1;
 }
 
+#if defined(CONFIG_LOG)
+static uint32_t count_args(const char *fmt)
+{
+	uint32_t args = 0U;
+	bool prev = false; /* if previous char was a modificator. */
+
+	while (*fmt != '\0') {
+		if (*fmt == '%') {
+			prev = !prev;
+		} else if (prev) {
+			args++;
+			prev = false;
+		} else {
+			; /* standard character, continue walk */
+		}
+		fmt++;
+	}
+
+	return args;
+}
+#endif
+
 void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, ...)
 {
 	ARG_UNUSED(aLogRegion);
 
 #if defined(CONFIG_LOG)
 	int level = log_translate(aLogLevel);
-	uint32_t args_num = log_count_args(aFormat);
+	uint32_t args_num = count_args(aFormat);
 	va_list param_list;
 
 	if (level < 0) {


### PR DESCRIPTION
A previous commit fixed OpenThread logging when `LOG=n`, but
introduced regression when `LOG_MODE_MINIMAL=y`. This commit
fixes the latest.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>