### PR TITLE
Bluetooth: Mesh: Test secure beacon interval.

### DIFF
--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_beacon.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_beacon.c
@@ -254,7 +254,7 @@ static void test_tx_beacon_secure(void)
 	struct bt_mesh_subnet *sub;
 	
 	/* shift beaconing time line to avoid boundary cases. */
-	delay_time = get_device_nbr() * 0;
+	delay_time = get_device_nbr() * 100;
 	k_sleep(K_MSEC(delay_time));
 
 	bt_mesh_test_setup();

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/tests_scripts/beacon/beacon_time_limit.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/tests_scripts/beacon/beacon_time_limit.sh
@@ -8,5 +8,4 @@ RunTest mesh_beacon_time_limit \
         beacon_tx_beacon_secure \
         beacon_tx_beacon_secure \
         beacon_tx_beacon_secure \
-        beacon_tx_beacon_secure \
         beacon_rx_beacon_secure

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/tests_scripts/beacon/beacon_time_limit.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/tests_scripts/beacon/beacon_time_limit.sh
@@ -6,6 +6,4 @@ source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
 
 RunTest mesh_beacon_time_limit \
         beacon_tx_beacon_secure \
-        beacon_tx_beacon_secure \
-        beacon_tx_beacon_secure \
         beacon_rx_beacon_secure

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/tests_scripts/beacon/beacon_time_limit.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/tests_scripts/beacon/beacon_time_limit.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Copyright 2021 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
+
+RunTest mesh_beacon_time_limit \
+        beacon_tx_beacon_secure \
+        beacon_tx_beacon_secure \
+        beacon_tx_beacon_secure \
+        beacon_tx_beacon_secure \
+        beacon_rx_beacon_secure


### PR DESCRIPTION
Adding test for secure network beacon behavior.
Each node receives one beacon every 10 seconds for a given subnet.

Signed-off-by: Alperen Sener <alperen.sener@nordicsemi.no>