### PR TITLE
Bluetooth: Controller: Fix Periodic Adv Report to scan max data length

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -6366,7 +6366,7 @@ static void le_per_adv_sync_report(struct pdu_data *pdu_data,
 	uint8_t cte_type = BT_HCI_LE_NO_CTE;
 	struct pdu_adv_com_ext_adv *p;
 	struct pdu_adv_ext_hdr *h;
-	uint8_t data_status = 0U;
+	uint16_t data_len_total;
 	struct net_buf *evt_buf;
 	uint8_t data_len = 0U;
 	uint8_t acad_len = 0U;
@@ -6533,13 +6533,20 @@ no_ext_hdr:
 	data_len_max = ADV_REPORT_EVT_MAX_LEN -
 		       sizeof(struct bt_hci_evt_le_meta_event) -
 		       sizeof(struct bt_hci_evt_le_per_advertising_report);
+	data_len_total = node_rx->hdr.rx_ftr.aux_data_len;
 
 	evt_buf = buf;
 
-	if ((le_event_mask & BT_EVT_MASK_LE_PER_ADVERTISING_REPORT) && accept) {
+	if ((le_event_mask & BT_EVT_MASK_LE_PER_ADVERTISING_REPORT) && accept &&
+	    ((data_len_total - data_len) < CONFIG_BT_CTLR_SCAN_DATA_LEN_MAX)) {
+
+		data_len = MIN(data_len, (CONFIG_BT_CTLR_SCAN_DATA_LEN_MAX +
+					  data_len - data_len_total));
+
 		do {
 			struct bt_hci_evt_le_per_advertising_report *sep;
 			uint8_t data_len_frag;
+			uint8_t data_status;
 
 			data_len_frag = MIN(data_len, data_len_max);
 
@@ -6548,17 +6555,30 @@ no_ext_hdr:
 				       BT_HCI_EVT_LE_PER_ADVERTISING_REPORT,
 				       sizeof(*sep) + data_len_frag);
 
+			sep->handle = sys_cpu_to_le16(node_rx->hdr.handle);
+			sep->tx_power = tx_pwr;
+			sep->rssi = rssi;
+			sep->cte_type = cte_type;
+			sep->length = data_len_frag;
 			memcpy(&sep->data[0], data, data_len_frag);
+
 			data += data_len_frag;
 			data_len -= data_len_frag;
 
 			if (data_len > 0) {
 				/* Some data left in PDU, mark as partial data. */
 				data_status = BT_HCI_LE_ADV_EVT_TYPE_DATA_STATUS_PARTIAL;
-			} else if (!aux_ptr) {
+
+				evt_buf = bt_buf_get_rx(BT_BUF_EVT, K_FOREVER);
+				net_buf_frag_add(buf, evt_buf);
+
+				tx_pwr = BT_HCI_LE_ADV_TX_POWER_NO_PREF;
+			} else if (!aux_ptr &&
+				   (data_len_total <= CONFIG_BT_CTLR_SCAN_DATA_LEN_MAX)) {
 				/* No data left, no AuxPtr, mark as complete data. */
 				data_status = BT_HCI_LE_ADV_EVT_TYPE_DATA_STATUS_COMPLETE;
-			} else if (ftr->aux_w4next) {
+			} else if (ftr->aux_sched &&
+				   (data_len_total < CONFIG_BT_CTLR_SCAN_DATA_LEN_MAX)) {
 				/* No data left, but have AuxPtr and scheduled aux scan,
 				 * mark as partial data.
 				 */
@@ -6570,22 +6590,7 @@ no_ext_hdr:
 				data_status = BT_HCI_LE_ADV_EVT_TYPE_DATA_STATUS_INCOMPLETE;
 			}
 
-			sep->handle = sys_cpu_to_le16(node_rx->hdr.handle);
-			/* TODO: use actual TX power only on 1st report, subsequent
-			 *       reports can use 0x7F
-			 */
-			sep->tx_power = tx_pwr;
-			sep->rssi = rssi;
-			sep->cte_type = cte_type;
 			sep->data_status = data_status;
-			sep->length = data_len_frag;
-
-			if (data_len > 0) {
-				evt_buf = bt_buf_get_rx(BT_BUF_EVT, K_FOREVER);
-				net_buf_frag_add(buf, evt_buf);
-
-				tx_pwr = BT_HCI_LE_ADV_TX_POWER_NO_PREF;
-			}
 		} while (data_len > 0);
 
 		evt_buf = NULL;

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -6338,17 +6338,17 @@ static void le_per_adv_sync_established(struct pdu_data *pdu_data,
 
 	scan = node_rx->hdr.rx_ftr.param;
 
-	dup_periodic_adv_reset(scan->per_scan.adv_addr_type,
-			       scan->per_scan.adv_addr,
-			       scan->per_scan.sid);
+	dup_periodic_adv_reset(scan->periodic.adv_addr_type,
+			       scan->periodic.adv_addr,
+			       scan->periodic.sid);
 
 	sep->handle = sys_cpu_to_le16(node_rx->hdr.handle);
 
 	/* Resolved address, if private, has been populated in ULL */
-	sep->adv_addr.type = scan->per_scan.adv_addr_type;
-	memcpy(&sep->adv_addr.a.val[0], scan->per_scan.adv_addr, BDADDR_SIZE);
+	sep->adv_addr.type = scan->periodic.adv_addr_type;
+	(void)memcpy(sep->adv_addr.a.val, scan->periodic.adv_addr, BDADDR_SIZE);
 
-	sep->sid = scan->per_scan.sid;
+	sep->sid = scan->periodic.sid;
 	sep->phy = find_lsb_set(se->phy);
 	sep->interval = sys_cpu_to_le16(se->interval);
 	sep->clock_accuracy = se->sca;

--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -327,21 +327,24 @@ struct node_rx_ftr {
 #endif /* CONFIG_BT_CTLR_EXT_SCAN_FP */
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT) && defined(CONFIG_BT_OBSERVER)
+	uint8_t  phy_flags:1;
+	uint8_t  scan_req:1;
+	uint8_t  scan_rsp:1;
+
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 	uint8_t  direct_resolved:1;
 #endif /* CONFIG_BT_CTLR_PRIVACY */
 
-	uint8_t  aux_lll_sched:1;
-	uint8_t  aux_w4next:1;
-	uint8_t  aux_failed:1;
 #if defined(CONFIG_BT_CTLR_SYNC_PERIODIC)
 	uint8_t  sync_status:2;
 	uint8_t  sync_rx_enabled:1;
 #endif /* CONFIG_BT_CTLR_SYNC_PERIODIC */
 
-	uint8_t  phy_flags:1;
-	uint8_t  scan_req:1;
-	uint8_t  scan_rsp:1;
+	uint8_t  aux_sched:1;
+	uint8_t  aux_lll_sched:1;
+	uint8_t  aux_failed:1;
+
+	uint16_t aux_data_len;
 #endif /* CONFIG_BT_CTLR_ADV_EXT && CONFIG_BT_OBSERVER */
 
 #if defined(CONFIG_BT_HCI_MESH_EXT)

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -1468,7 +1468,7 @@ isr_rx_do_close:
 
 		radio_isr_set(lll_scan_isr_resume, lll);
 	} else {
-		radio_isr_set(isr_done, lll_aux);
+		radio_isr_set(isr_done, NULL);
 	}
 
 	radio_disable();

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -1434,7 +1434,7 @@ void ll_rx_mem_release(void **node_rx)
 				/* pick the sync context before scan context
 				 * is cleanup of sync context association.
 				 */
-				sync = scan->per_scan.sync;
+				sync = scan->periodic.sync;
 
 				ull_sync_setup_complete(scan);
 

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -621,7 +621,7 @@ uint32_t ull_scan_is_enabled(uint8_t handle)
 #if defined(CONFIG_BT_CTLR_SYNC_PERIODIC)
 		scan = ull_scan_set_get(handle);
 
-		return scan->per_scan.sync ? ULL_SCAN_IS_SYNC : 0U;
+		return scan->periodic.sync ? ULL_SCAN_IS_SYNC : 0U;
 #else
 		return 0U;
 #endif
@@ -632,7 +632,7 @@ uint32_t ull_scan_is_enabled(uint8_t handle)
 		(scan->lll.conn ? ULL_SCAN_IS_INITIATOR : 0U) |
 #endif
 #if defined(CONFIG_BT_CTLR_SYNC_PERIODIC)
-		(scan->per_scan.sync ? ULL_SCAN_IS_SYNC : 0U) |
+		(scan->periodic.sync ? ULL_SCAN_IS_SYNC : 0U) |
 #endif
 		0U);
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -290,7 +290,7 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 #if defined(CONFIG_BT_CTLR_SYNC_PERIODIC)
 		/* Check if Periodic Advertising Synchronization to be created
 		 */
-		if (sync && (scan->per_scan.state != LL_SYNC_STATE_CREATED)) {
+		if (sync && (scan->periodic.state != LL_SYNC_STATE_CREATED)) {
 			/* Check address and update internal state */
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 			ull_sync_setup_addr_check(scan, pdu->tx_addr, ptr,
@@ -553,8 +553,8 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 
 ull_scan_aux_rx_flush:
 #if defined(CONFIG_BT_CTLR_SYNC_PERIODIC)
-	if (sync && (scan->per_scan.state != LL_SYNC_STATE_CREATED)) {
-		scan->per_scan.state = LL_SYNC_STATE_IDLE;
+	if (sync && (scan->periodic.state != LL_SYNC_STATE_CREATED)) {
+		scan->periodic.state = LL_SYNC_STATE_IDLE;
 	}
 #endif /* CONFIG_BT_CTLR_SYNC_PERIODIC */
 
@@ -794,7 +794,7 @@ static inline uint8_t aux_handle_get(struct ll_scan_aux_set *aux)
 static inline struct ll_sync_set *sync_create_get(struct ll_scan_set *scan)
 {
 #if defined(CONFIG_BT_CTLR_SYNC_PERIODIC)
-	return scan->per_scan.sync;
+	return scan->periodic.sync;
 #else /* !CONFIG_BT_CTLR_SYNC_PERIODIC */
 	return NULL;
 #endif /* !CONFIG_BT_CTLR_SYNC_PERIODIC */

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -117,12 +117,11 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 	is_scan_req = false;
 	ftr = &rx->rx_ftr;
 
-	sync_lll = NULL;
-
 	switch (rx->type) {
 	case NODE_RX_TYPE_EXT_1M_REPORT:
 		lll_aux = NULL;
 		aux = NULL;
+		sync_lll = NULL;
 		sync_iso = NULL;
 		lll = ftr->param;
 		scan = HDR_LLL2ULL(lll);
@@ -132,6 +131,7 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 	case NODE_RX_TYPE_EXT_CODED_REPORT:
 		lll_aux = NULL;
 		aux = NULL;
+		sync_lll = NULL;
 		sync_iso = NULL;
 		lll = ftr->param;
 		scan = HDR_LLL2ULL(lll);
@@ -141,6 +141,8 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 	case NODE_RX_TYPE_EXT_AUX_REPORT:
 		sync_iso = NULL;
 		if (ull_scan_aux_is_valid_get(HDR_LLL2ULL(ftr->param))) {
+			sync_lll = NULL;
+
 			/* Node has valid aux context so its scan was scheduled
 			 * from ULL.
 			 */
@@ -149,7 +151,10 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 
 			/* aux parent will be NULL for periodic sync */
 			lll = aux->parent;
+
 		} else if (ull_scan_is_valid_get(HDR_LLL2ULL(ftr->param))) {
+			sync_lll = NULL;
+
 			/* Node that does not have valid aux context but has
 			 * valid scan set was scheduled from LLL. We can
 			 * retrieve aux context from lll_scan as it was stored
@@ -162,10 +167,12 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 
 			aux = HDR_LLL2ULL(lll_aux);
 			LL_ASSERT(lll == aux->parent);
+
 		} else {
+			lll = NULL;
+
 			/* If none of the above, node is part of sync scanning
 			 */
-			lll = NULL;
 			sync_lll = ftr->param;
 
 			lll_aux = sync_lll->lll_aux;
@@ -634,23 +641,27 @@ void ull_scan_aux_done(struct node_rx_event_done *done)
 
 uint8_t ull_scan_aux_lll_handle_get(struct lll_scan_aux *lll)
 {
-	return aux_handle_get((void *)lll->hdr.parent);
+	struct ll_scan_aux_set *aux;
+
+	aux = HDR_LLL2ULL(lll);
+
+	return aux_handle_get(aux);
 }
 
 void *ull_scan_aux_lll_parent_get(struct lll_scan_aux *lll,
 				  uint8_t *is_lll_scan)
 {
-	struct ll_scan_aux_set *aux_set;
-	struct ll_scan_set *scan_set;
+	struct ll_scan_aux_set *aux;
+	struct ll_scan_set *scan;
 
-	aux_set = HDR_LLL2ULL(lll);
-	scan_set = HDR_LLL2ULL(aux_set->parent);
+	aux = HDR_LLL2ULL(lll);
+	scan = HDR_LLL2ULL(aux->parent);
 
 	if (is_lll_scan) {
-		*is_lll_scan = !!ull_scan_is_valid_get(scan_set);
+		*is_lll_scan = !!ull_scan_is_valid_get(scan);
 	}
 
-	return aux_set->parent;
+	return aux->parent;
 }
 
 struct ll_scan_aux_set *ull_scan_aux_is_valid_get(struct ll_scan_aux_set *aux)

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_types.h
@@ -44,4 +44,6 @@ struct ll_scan_aux_set {
 
 	struct node_rx_hdr *rx_head;
 	struct node_rx_hdr *rx_last;
+
+	uint16_t data_len;
 };

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_types.h
@@ -31,7 +31,7 @@ struct ll_scan_set {
 		 * cancelling sync create, hence the volatile keyword.
 		 */
 		struct ll_sync_set *volatile sync;
-	} per_scan;
+	} periodic;
 #endif
 };
 

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -477,6 +477,9 @@ void ull_sync_release(struct ll_sync_set *sync)
 	/* Mark sync context not sync established */
 	sync->timeout_reload = 0U;
 
+	/* reset accumulated data len */
+	sync->data_len = 0U;
+
 	mem_release(sync, &sync_free);
 }
 

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -792,7 +792,7 @@ void ull_sync_established_report(memq_link_t *link, struct node_rx_hdr *rx)
 
 #if !defined(CONFIG_BT_CTLR_CTEINLINE_SUPPORT)
 		/* Notify done event handler to terminate sync scan if required. */
-		ull_sync->sync_term = sync_status == SYNC_STAT_TERM;
+		ull_sync->is_term = (sync_status == SYNC_STAT_TERM);
 #endif /* !CONFIG_BT_CTLR_CTEINLINE_SUPPORT */
 #else
 		se->status = BT_HCI_ERR_SUCCESS;
@@ -846,7 +846,7 @@ void ull_sync_done(struct node_rx_event_done *done)
 #if defined(CONFIG_BT_CTLR_CTEINLINE_SUPPORT)
 	if (done->extra.sync_term) {
 #else
-	if (sync->sync_term) {
+	if (sync->is_term) {
 #endif /* CONFIG_BT_CTLR_CTEINLINE_SUPPORT */
 		/* Stop periodic advertising scan ticker */
 		sync_ticker_cleanup(sync, NULL);

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_types.h
@@ -40,7 +40,7 @@ struct ll_sync_set {
 	/* Member used to notify event done handler to terminate sync scanning.
 	 * Used only when no HW support for parsing PDU for CTEInfo.
 	 */
-	uint8_t sync_term:1;
+	uint8_t is_term:1;
 #endif /* CONFIG_BT_CTLR_SYNC_PERIODIC_CTE_TYPE_FILTERING && !CONFIG_BT_CTLR_CTEINLINE_SUPPORT */
 
 	uint8_t sync_expire:3; /* countdown of 6 before fail to establish */

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_types.h
@@ -74,6 +74,8 @@ struct ll_sync_set {
 		struct ll_sync_iso_set *volatile sync_iso;
 	} iso;
 #endif /* CONFIG_BT_CTLR_SYNC_ISO */
+
+	uint16_t data_len;
 };
 
 struct node_rx_sync {


### PR DESCRIPTION
Fix implementation to limit Periodic Advertising data to a
configurable maximum length when generating HCI reports.

Fixes couple of qualification test cases related to Periodic
Periodic Synchronization that required the Controller to
restrict Periodic Advertising data to Scan data length max
set in the IXIT.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>