### PR TITLE
boards: intel_adsp_cavs18: add test coverage

### DIFF
--- a/boards/xtensa/intel_adsp_cavs18/intel_adsp_cavs18.yaml
+++ b/boards/xtensa/intel_adsp_cavs18/intel_adsp_cavs18.yaml
@@ -5,6 +5,6 @@ arch: xtensa
 toolchain:
   - zephyr
 testing:
-  only_tags:
-     - kernel
-     - sof
+  ignore_tags:
+     - net
+     - bluetooth


### PR DESCRIPTION
Increase the test coverage for intel_adsp_cavs18. To keep its
test coverage as the same as cavs15 and cavs25.

Currently only one test sutite failed , See #42157.
with #42158 expend the time of ringbuffer testing, it can reach
100% pass rate.

Signed-off-by: Enjia Mai <enjia.mai@intel.com>