### PR TITLE
libc: minimal: inttypes: add specifier for off_t type

### DIFF
--- a/drivers/eeprom/eeprom_lpc11u6x.c
+++ b/drivers/eeprom/eeprom_lpc11u6x.c
@@ -52,8 +52,8 @@ static int eeprom_lpc11u6x_read(const struct device *dev,
 	ret = iap_cmd(cmd);
 
 	if (ret != IAP_STATUS_CMD_SUCCESS) {
-		LOG_ERR("failed to read EEPROM (offset=%08x len=%d err=%d)",
-			(unsigned int) offset, len, ret);
+		LOG_ERR("failed to read EEPROM (offset=%" LOCAL_PRIxOFF " len=%d err=%d)",
+			(ssize_t) offset, len, ret);
 		return -EINVAL;
 	}
 
@@ -85,8 +85,8 @@ static int eeprom_lpc11u6x_write(const struct device *dev,
 	ret = iap_cmd(cmd);
 
 	if (ret != IAP_STATUS_CMD_SUCCESS) {
-		LOG_ERR("failed to write EEPROM (offset=%08x len=%d err=%d)",
-			(unsigned int) offset, len, ret);
+		LOG_ERR("failed to write EEPROM (offset=%" LOCAL_PRIxOFF " len=%d err=%d)",
+			(ssize_t) offset, len, ret);
 		return -EINVAL;
 	}
 

--- a/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
+++ b/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
@@ -236,7 +236,7 @@ static int flash_flexspi_nor_erase_sector(const struct device *dev,
 		.dataSize = 0,
 	};
 
-	LOG_DBG("Erasing sector at 0x%08zx", (ssize_t) offset);
+	LOG_DBG("Erasing sector at 0x%" LOCAL_PRIxOFF, (ssize_t) offset);
 
 	return memc_flexspi_transfer(data->controller, &transfer);
 }
@@ -277,7 +277,7 @@ static int flash_flexspi_nor_page_program(const struct device *dev,
 		.dataSize = len,
 	};
 
-	LOG_DBG("Page programming %d bytes to 0x%08zx", len, (ssize_t) offset);
+	LOG_DBG("Page programming %d bytes to 0x%" LOCAL_PRIxOFF, len, (ssize_t) offset);
 
 	return memc_flexspi_transfer(data->controller, &transfer);
 }

--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -252,7 +252,7 @@ static int flash_flexspi_nor_erase_sector(const struct device *dev,
 		.dataSize = 0,
 	};
 
-	LOG_DBG("Erasing sector at 0x%08zx", (ssize_t) offset);
+	LOG_DBG("Erasing sector at 0x%" LOCAL_PRIxOFF, (ssize_t) offset);
 
 	return memc_flexspi_transfer(data->controller, &transfer);
 }
@@ -293,7 +293,7 @@ static int flash_flexspi_nor_page_program(const struct device *dev,
 		.dataSize = len,
 	};
 
-	LOG_DBG("Page programming %d bytes to 0x%08zx", len, (ssize_t) offset);
+	LOG_DBG("Page programming %d bytes to 0x%" LOCAL_PRIxOFF, len, (ssize_t) offset);
 
 	return memc_flexspi_transfer(data->controller, &transfer);
 }

--- a/lib/libc/minimal/include/inttypes.h
+++ b/lib/libc/minimal/include/inttypes.h
@@ -46,4 +46,12 @@
 #define	PRIX64			"llX"		/* uint64_t */
 #define	PRIXPTR			"lX"		/* uintptr_t */
 
+#if SIZE_MAX == UINT32_MAX
+#define LOCAL_PRIxOFF		"08zx"		/* off_t */
+#elif SIZE_MAX == UIN64_MAX
+#define LOCAL_PRIxOFF		"16zx"		/* off_t */
+#else
+#error Formatting undefined for this size of ssize_t/off_t
+#endif
+
 #endif


### PR DESCRIPTION
Add a `LOCAL_PRIxOFF` specifier suitable to be used with a specific `off_t` type and switch to that accordingly.

Suggested-by: Dominik Ermel <dominik.ermel@nordicsemi.no>
Signed-off-by: Bartosz Bilas <bartosz.bilas@hotmail.com>
