### PR TITLE
drivers: qdec_sam: disable index signal

### DIFF
--- a/drivers/sensor/qdec_sam/qdec_sam.c
+++ b/drivers/sensor/qdec_sam/qdec_sam.c
@@ -81,7 +81,7 @@ static void qdec_sam_configure(const struct device *dev)
 
 	/* Clock, Trigger Edge, Trigger and Mode Selection */
 	tc_ch0->TC_CMR =  TC_CMR_TCCLKS_XC0
-			| TC_CMR_ETRGEDG_RISING
+			| TC_CMR_ETRGEDG_NONE
 			| TC_CMR_ABETRG;
 
 	/* Enable QDEC in Position Mode*/


### PR DESCRIPTION
`qdec_sam` driver supports currently only position measurement and does
not support reading of the index signal. Unfortunately, the index
signal was internally enabled in the driver. If the pin to which the
index signal was connected was used by another driver it could lead to
a false detection of the signal change. Detection of the index signal
change resets the position measurement.

Fixes #42199