### PR TITLE
doc: release-notes: PM, device API, Devicetree and documentation

### DIFF
--- a/doc/releases/release-notes-3.0.rst
+++ b/doc/releases/release-notes-3.0.rst
@@ -80,6 +80,8 @@ Removed APIs in this release
 Deprecated in this release
 ==========================
 
+* Removed ``<power/reboot.h>`` and ``<power/power.h>`` deprecated headers.
+  ``<sys/reboot.h>`` and ``<pm/pm.h>`` should be used instead.
 * :c:macro:`USBD_CFG_DATA_DEFINE` is deprecated in favor of utilizing
   :c:macro:`USBD_DEFINE_CFG_DATA`
 
@@ -417,6 +419,23 @@ Libraries / Subsystems
 
 * Power management
 
+  * Power management resources are now manually allocated by devices using
+    :c:macro:`PM_DEVICE_DEFINE`, :c:macro:`PM_DEVICE_DT_DEFINE` or
+    :c:macro:`PM_DEVICE_DT_INST_DEFINE`. Device instantiation macros take now
+    a reference to the allocated resources. The reference can be obtained using
+    :c:macro:`PM_DEVICE_GET`, :c:macro:`PM_DEVICE_DT_GET` or
+    :c:macro:`PM_DEVICE_DT_INST_GET`. Thanks to this change, devices not
+    implementing support for device power management will not use unnecessary
+    memory.
+  * Device runtime power management API error handling has been simplified.
+  * :c:func:`pm_device_runtime_enable` suspends the target device if not already
+    suspended. This change makes sure device state is always kept in a
+    consistent state.
+  * Improved PM states Devicetree macros naming
+  * Added a new API call :c:func:`pm_state_cpu_get_all` to obtain information
+    about CPU power states.
+  * ``pm/device.h`` is no longer included by ``device.h``, since the device API
+    no longer depends on the PM API.
 
 * Logging
 

--- a/doc/releases/release-notes-3.0.rst
+++ b/doc/releases/release-notes-3.0.rst
@@ -309,10 +309,19 @@ Drivers and Sensors
 
 * Modem
 
+* Pin control
 
-* Pinctrl
+  * Introduced a new state-based pin control (``pinctrl``) API inspired by the
+    Linux design principles. The ``pinctrl`` API will replace the existing
+    pinmux API, so all platforms using pinmux are encouraged to migrate. A
+    detailed guide with design principles and implementation guidelines can be
+    found in :ref:`pinctrl-guide`.
+  * Platforms already supporting the ``pinctrl`` API:
 
-  * Added support for STM32
+    * GigaDevice GD32
+    * Nordic (preliminary support)
+    * Renesas R-Car
+    * STM32
 
 * PWM
 

--- a/doc/releases/release-notes-3.0.rst
+++ b/doc/releases/release-notes-3.0.rst
@@ -119,6 +119,13 @@ New APIs in this release
 
       * :c:func:`uart_fifo_read_u16` to read data from FIFO.
 
+* Devicetree
+
+  * Added new Devicetree helpers:
+
+    * :c:macro:`DT_INST_ENUM_IDX`
+    * :c:macro:`DT_INST_ENUM_IDX_OR`
+    * :c:macro:`DT_INST_PARENT`
 
 Kernel
 ******

--- a/doc/releases/release-notes-3.0.rst
+++ b/doc/releases/release-notes-3.0.rst
@@ -84,6 +84,10 @@ Deprecated in this release
   ``<sys/reboot.h>`` and ``<pm/pm.h>`` should be used instead.
 * :c:macro:`USBD_CFG_DATA_DEFINE` is deprecated in favor of utilizing
   :c:macro:`USBD_DEFINE_CFG_DATA`
+* :c:macro:`SYS_DEVICE_DEFINE` is deprecated in favor of utilizing
+  :c:macro:`SYS_INIT`.
+* :c:func:`device_usable_check` is deprecated in favor of utilizing
+  :c:func:`device_is_ready`.
 
 Stable API changes in this release
 ==================================

--- a/doc/releases/release-notes-3.0.rst
+++ b/doc/releases/release-notes-3.0.rst
@@ -500,6 +500,9 @@ Trusted Firmware-m
 Documentation
 *************
 
+* A new theme is used by the Doxygen HTML pages. It is based on
+  `doxygen-awesome-css <https://github.com/jothepro/doxygen-awesome-css>`_
+  theme.
 
 Tests and Samples
 *****************


### PR DESCRIPTION
Update release notes with relevant changes on the PM, device API, Devicetree, pin control and documentation areas.