### PR TITLE
drivers: spi: spi_gecko: fix compile error

### DIFF
--- a/drivers/spi/spi_gecko.c
+++ b/drivers/spi/spi_gecko.c
@@ -173,7 +173,6 @@ static void spi_gecko_xfer(const struct device *dev,
 	struct spi_gecko_data *data = dev->data;
 	struct spi_context *ctx = &data->ctx;
 	const struct spi_gecko_config *gecko_config = dev->config;
-	struct spi_gecko_data *data = dev->data;
 
 	spi_context_cs_control(ctx, true);
 


### PR DESCRIPTION
Removing double instance of
struct spi_gecko_data *data = dev->data;

Signed-off-by: Jimmy Johnson <james.johnson672@t-mobile.com>