### PR TITLE
doc: release-notes: add GigaDevice changes

### DIFF
--- a/doc/releases/release-notes-3.0.rst
+++ b/doc/releases/release-notes-3.0.rst
@@ -166,6 +166,7 @@ Boards & SoC Support
 
 * Added support for these SoC series:
 
+  * GigaDevice GD32VF103, GD32F3X0, GD32F403 and GD32F450.
 
 * Removed support for these SoC series:
 
@@ -180,6 +181,9 @@ Boards & SoC Support
 
 * Added support for these ARM boards:
 
+  * GigaDevice GD32F350R-EVAL
+  * GigaDevice GD32F403Z-EVAL
+  * GigaDevice GD32F450I-EVAL
   * OLIMEX-STM32-H405
   * ST Nucleo G031K8
   * ST Nucleo H7A3ZI Q
@@ -193,6 +197,10 @@ Boards & SoC Support
 
 * Removed support for these X86 boards:
 
+* Added support for these RISC-V boards:
+
+  * GigaDevice GD32VF103V-EVAL
+  * Sipeed Longan Nano and Nano Lite
 
 * Made these changes in other boards:
 
@@ -226,6 +234,7 @@ Drivers and Sensors
 
 * DAC
 
+  * Added support for GigaDevice GD32 SoCs
   * Added support for stm32u5 series
 
 * Disk
@@ -268,12 +277,14 @@ Drivers and Sensors
 
 * GPIO
 
+  * Added driver for GigaDevice GD32 SoCs
 
 * Hardware Info
 
 
 * I2C
 
+  * Added driver for GigaDevice GD32 SoCs
 
 * I2S
 
@@ -283,6 +294,8 @@ Drivers and Sensors
 
 * Interrupt Controller
 
+  * Added ECLIC driver for GigaDevice RISC-V GD32 SoCs
+  * Added EXTI driver for GigaDevice GD32 SoCs
 
 * LED
 
@@ -306,6 +319,7 @@ Drivers and Sensors
   * stm32: DT bindings: `st,prescaler` property was moved from pwm
     to parent timer node.
   * stm32: Implemented PWM capture API
+  * Added driver for GigaDevice GD32 SoCs. Only PWM output is supported.
 
 * Sensor
 
@@ -314,6 +328,8 @@ Drivers and Sensors
 * Serial
 
   * stm32: Implemented half-duplex option.
+  * Added driver for GigaDevice GD32 SoCs. Polling and interrupt driven modes
+    are supported.
 
 * SPI
 
@@ -400,6 +416,8 @@ Build and Infrastructure
 
 * West (extensions)
 
+  * Added support for gd32isp runner
+
 
 Libraries / Subsystems
 **********************
@@ -446,6 +464,9 @@ HALs
   * stm32cube/stm32wb and its lib: Upgraded to version V1.12.1
   * stm32cube/stm32mp1: Upgraded to version V1.5.0
   * stm32cube/stm32u5: Upgraded to version V1.0.2
+
+* Added `GigaDevice HAL module
+  <https://github.com/zephyrproject-rtos/hal_gigadevice>`_
 
 MCUboot
 *******


### PR DESCRIPTION
Initial support for GigaDevice is now available upstream. This patch
lists relevant additions such as supported boards, drivers, etc.

cc: @cameled @soburi 