### PR TITLE
logging: Kconfig: Let the user decide to redirect log to RTT backend,

### DIFF
--- a/subsys/logging/Kconfig.backends
+++ b/subsys/logging/Kconfig.backends
@@ -92,7 +92,6 @@ endif # LOG_BACKEND_SWO
 config LOG_BACKEND_RTT
 	bool "Enable Segger J-Link RTT backend"
 	depends on USE_SEGGER_RTT
-	default y if !SHELL_BACKEND_RTT
 	select SEGGER_RTT_CUSTOM_LOCKING
 	help
 	  When enabled, backend will use RTT for logging. This backend works on a per


### PR DESCRIPTION
fixes #42207, RTT was enabled by SYSTEMVIEW, and on my specific application
,SHELL was running on a UART backend thus, it has produced an issue

Signed-off-by: Manojkumar Subramaniam <manoj@electrolance.com>