### PR TITLE
built: uf2: Flexible UF2 offset selection.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1454,12 +1454,27 @@ if(CONFIG_BUILD_OUTPUT_BIN)
 endif()
 
 if(CONFIG_BUILD_OUTPUT_BIN AND CONFIG_BUILD_OUTPUT_UF2)
+  if(CONFIG_BUILD_OUTPUT_UF2_USE_FLASH_BASE)
+    set(flash_addr "${CONFIG_FLASH_BASE_ADDRESS}")
+  else()
+    set(flash_addr "0x0")
+  endif()
+
+  if(CONFIG_BUILD_OUTPUT_UF2_USE_FLASH_OFFSET)
+    # Note, the `+ 0` in formula below avoids errors in cases where a Kconfig
+    #       variable is undefined and thus expands to nothing.
+    math(EXPR flash_addr
+        "${flash_addr} + ${CONFIG_FLASH_LOAD_OFFSET} + 0"
+         OUTPUT_FORMAT HEXADECIMAL
+    )
+  endif()
+
   list(APPEND
     post_build_commands
     COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/uf2conv.py
             -c
             -f ${CONFIG_BUILD_OUTPUT_UF2_FAMILY_ID}
-            -b ${CONFIG_FLASH_LOAD_OFFSET}
+            -b ${flash_addr}
             -o ${KERNEL_UF2_NAME}
             ${KERNEL_BIN_NAME}
   )

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -486,6 +486,14 @@ config BUILD_OUTPUT_UF2_FAMILY_ID
 	  name string. If the SoC in use is known by UF2, the Family ID will
 	  be pre-filled with the known value.
 
+config BUILD_OUTPUT_UF2_USE_FLASH_BASE
+	bool
+	default y
+
+config BUILD_OUTPUT_UF2_USE_FLASH_OFFSET
+	bool
+	default y
+
 endif # BUILD_OUTPUT_UF2
 
 config BUILD_OUTPUT_STRIPPED


### PR DESCRIPTION
UF2 offset configurble to be either flash base reg + offset,
or simply the flash bare reg if the offset is configured
to be ignored.

Signed-off-by: Peter Johanson <peter@peterjohanson.com>

This tweaks the UF2 offset calculation based on the discussions in #34835 to allow properly incorporating the flash base addr (needed for RP2040 where this isn't 0x0) as well as the flash offset (needed for samd and nRF52 UF2 bootloaders).

On RP2040, we'll ignore the flash offset because even though the *code* is built to that offset, the second stage bootloader then gets bundled into the bin, and the UF2 by extension, so the UF2 needs to use an offset of *only* the tlash base address. There, I anticipate defaulting the new `BUILD_OUTPUT_UF2_IGNORE_FLASH_OFFSET` to `y` for the whole SoC.