### PR TITLE
Branch fix npcx9 data ram size

### DIFF
--- a/dts/arm/nuvoton/npcx9m3f.dtsi
+++ b/dts/arm/nuvoton/npcx9m3f.dtsi
@@ -18,7 +18,7 @@
 
 	sram0: memory@200c0000 {
 		compatible = "mmio-sram";
-		reg = <0x200C0000 DT_SIZE_K(62)>;
+		reg = <0x200C0000 DT_SIZE_K(64)>;
 	};
 
 	soc-id {

--- a/dts/arm/nuvoton/npcx9m6f.dtsi
+++ b/dts/arm/nuvoton/npcx9m6f.dtsi
@@ -18,7 +18,7 @@
 
 	sram0: memory@200c0000 {
 		compatible = "mmio-sram";
-		reg = <0x200C0000 DT_SIZE_K(62)>;
+		reg = <0x200C0000 DT_SIZE_K(64)>;
 	};
 
 	soc-id {


### PR DESCRIPTION
This PR fixes the data RAM size from 62KB to 64KB for npcx9.