### PR TITLE
logging: Add log_frontend support to v2

### DIFF
--- a/boards/posix/native_posix/Kconfig.defconfig
+++ b/boards/posix/native_posix/Kconfig.defconfig
@@ -40,9 +40,6 @@ config UART_NATIVE_POSIX
 
 if LOG
 
-config LOG_BACKEND_NATIVE_POSIX
-	default y if !SERIAL
-
 # For native_posix we can log synchronously without any problem
 # Doing so will be nicer for debugging
 choice LOG_MODE

--- a/boards/posix/nrf52_bsim/Kconfig.defconfig
+++ b/boards/posix/nrf52_bsim/Kconfig.defconfig
@@ -20,10 +20,6 @@ config BT_CTLR
 
 if LOG
 
-# This board can reuse the native_posix logging backend
-config LOG_BACKEND_NATIVE_POSIX
-	default y if !SERIAL
-
 # For this board we can log synchronously without any problem
 # Doing so will be nicer for debugging
 choice LOG_MODE

--- a/doc/reference/logging/index.rst
+++ b/doc/reference/logging/index.rst
@@ -11,7 +11,6 @@ The logging API provides a common interface to process messages issued by
 developers. Messages are passed through a frontend and are then
 processed by active backends.
 Custom frontend and backends can be used if needed.
-Default configuration uses built-in frontend and UART backend.
 
 Summary of the logging features:
 
@@ -19,7 +18,7 @@ Summary of the logging features:
   consuming operations to a known context instead of processing and sending
   the log message when called.
 - Multiple backends supported (up to 9 backends).
-- Custom frontend supported.
+- Custom frontend support. When enabled no backends can be active.
 - Compile time filtering on module level.
 - Run time filtering independent for each backend.
 - Additional run time filtering on module instance level.
@@ -48,6 +47,7 @@ Logging v2 introduces following changes:
 - Slightly degrade performance in normal circumstances due to the fact that
   allocation from ring buffer is more complex than from memslab.
 - No change in logging API
+- Logging to frontend can be used together with backends.
 - Logging backend API exteded with function for processing v2 messages.
 
 .. note::
@@ -179,7 +179,9 @@ log_strdup().
 
 :kconfig:option:`CONFIG_LOG_DOMAIN_ID`: Domain ID. Valid in multi-domain systems.
 
-:kconfig:option:`CONFIG_LOG_FRONTEND`: Redirect logs to a custom frontend.
+:kconfig:option`CONFIG_LOG_FRONTEND`: Direct logs to a custom frontend.
+
+:kconfig:option`CONFIG_LOG_FRONTEND_ONLY`: No backends are used when messages goes to frontend.
 
 :kconfig:option:`CONFIG_LOG_TIMESTAMP_64BIT`: 64 bit timestamp.
 
@@ -518,11 +520,11 @@ particular source will be buffered.
 Custom Frontend
 ===============
 
-Custom frontend is enabled using :kconfig:option:`CONFIG_LOG_FRONTEND`. Logs are redirected
+Custom frontend is enabled using :kconfig:option:`CONFIG_LOG_FRONTEND`. Logs are directed
 to functions declared in :zephyr_file:`include/logging/log_frontend.h`.
-This may be required in very time-sensitive cases, but most of the logging
-features cannot be used then, which includes default frontend, core and all
-backends features.
+If option :kconfig:option:`CONFIG_LOG_FRONTEND_ONLY` is enabled then log message is not
+created and no backend is handled. Otherwise, custom frontend can coexist with
+backends (not available in v1).
 
 .. _logging_strings:
 

--- a/include/logging/log.h
+++ b/include/logging/log.h
@@ -287,7 +287,9 @@ void z_log_vprintk(const char *fmt, va_list ap);
 char *z_log_strdup(const char *str);
 static inline char *log_strdup(const char *str)
 {
-	if (IS_ENABLED(CONFIG_LOG_MODE_MINIMAL) || IS_ENABLED(CONFIG_LOG2)) {
+	if (IS_ENABLED(CONFIG_LOG_MODE_MINIMAL) ||
+	    IS_ENABLED(CONFIG_LOG_FRONTEND) ||
+	    IS_ENABLED(CONFIG_LOG2)) {
 		return (char *)str;
 	}
 

--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -201,7 +201,9 @@ extern "C" {
 
 #define Z_LOG_INTERNAL2(is_user_context, _src_level, ...) do { \
 	if (is_user_context) { \
-		log_from_user(_src_level, __VA_ARGS__); \
+		if (!IS_ENABLED(CONFIG_LOG_FRONTEND)) { \
+			log_from_user(_src_level, __VA_ARGS__); \
+		} \
 	} else if (IS_ENABLED(CONFIG_LOG_MODE_IMMEDIATE)) { \
 		log_string_sync(_src_level, __VA_ARGS__); \
 	} else { \
@@ -334,8 +336,8 @@ static inline char z_log_minimal_level_to_char(int level)
 	bool is_user_context = k_is_user_context(); \
 	uint32_t filters = IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
 						(_dsource)->filters : 0;\
-	if (IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) && !is_user_context && \
-	    _level > Z_LOG_RUNTIME_FILTER(filters)) { \
+	if (!IS_ENABLED(CONFIG_LOG_FRONTEND) && IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) && \
+	    !is_user_context && _level > Z_LOG_RUNTIME_FILTER(filters)) { \
 		break; \
 	} \
 	if (IS_ENABLED(CONFIG_LOG2)) { \
@@ -414,8 +416,8 @@ static inline char z_log_minimal_level_to_char(int level)
 					    (const char *)_data, _len);\
 		break; \
 	} \
-	if (IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) && !is_user_context && \
-	    _level > Z_LOG_RUNTIME_FILTER(filters)) { \
+	if (!IS_ENABLED(CONFIG_LOG_FRONTEND) && IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) && \
+	    !is_user_context && _level > Z_LOG_RUNTIME_FILTER(filters)) { \
 		break; \
 	} \
 	if (IS_ENABLED(CONFIG_LOG2)) { \
@@ -440,8 +442,9 @@ static inline char z_log_minimal_level_to_char(int level)
 		.source_id = src_id, \
 	}; \
 	if (is_user_context) { \
-		log_hexdump_from_user(src_level, _str, \
-				      (const char *)_data, _len); \
+		if (!IS_ENABLED(CONFIG_LOG_FRONTEND)) { \
+			log_hexdump_from_user(src_level, _str, (const char *)_data, _len); \
+		} \
 	} else if (IS_ENABLED(CONFIG_LOG_MODE_IMMEDIATE)) { \
 		log_hexdump_sync(src_level, _str, (const char *)_data, _len); \
 	} else { \

--- a/include/logging/log_ctrl.h
+++ b/include/logging/log_ctrl.h
@@ -263,7 +263,7 @@ int log_mem_get_usage(uint32_t *buf_size, uint32_t *usage);
  */
 int log_mem_get_max_usage(uint32_t *max);
 
-#if defined(CONFIG_LOG) && !defined(CONFIG_LOG_MODE_MINIMAL)
+#if defined(CONFIG_LOG) && !defined(CONFIG_LOG_MODE_MINIMAL) && !defined(CONFIG_LOG_FRONTEND_ONLY)
 #define LOG_CORE_INIT() log_core_init()
 #define LOG_INIT() log_init()
 #define LOG_PANIC() log_panic()

--- a/include/logging/log_frontend.h
+++ b/include/logging/log_frontend.h
@@ -79,5 +79,27 @@ void log_frontend_hexdump(const char *str,
 			  uint32_t length,
 			  struct log_msg_ids src_level);
 
+/** @brief Log message.
+ *
+ * Message details does not contain timestamp. Since function is called in the
+ * context of log message call, implementation can use its own timestamping scheme.
+ *
+ * @param source Pointer to a structure associated with given source. It points to
+ * static structure or dynamic structure if runtime filtering is enabled.
+ * @ref log_const_source_id or @ref log_dynamic_source_id can be used to determine
+ * source id.
+ *
+ * @param desc Message descriptor.
+ *
+ * @param package Cbprintf package containing logging formatted string. Length s in @p desc.
+ *
+ * @param data Hexdump data. Length is in @p desc.
+ */
+void log_frontend_msg(const void *source,
+		      const struct log_msg2_desc desc,
+		      uint8_t *package, const void *data);
+
+/** @brief Panic state notification. */
+void log_frontend_panic(void);
 
 #endif /* LOG_FRONTEND_H_ */

--- a/soc/xtensa/sample_controller/Kconfig.defconfig
+++ b/soc/xtensa/sample_controller/Kconfig.defconfig
@@ -13,7 +13,4 @@ config SOC_TOOLCHAIN_NAME
 	string
 	default "sample_controller"
 
-config LOG_BACKEND_XTENSA_SIM
-	default LOG
-
 endif

--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -14,7 +14,7 @@ rsource "Kconfig.mode"
 
 rsource "Kconfig.filtering"
 
-if !LOG_FRONTEND && !LOG_MODE_MINIMAL
+if !LOG_FRONTEND_ONLY && !LOG_MODE_MINIMAL
 
 rsource "Kconfig.formatting"
 
@@ -22,7 +22,7 @@ rsource "Kconfig.processing"
 
 rsource "Kconfig.backends"
 
-endif # !LOG_FRONTEND && !LOG_MODE_MINIMAL
+endif # !LOG_FRONTEND_ONLY && !LOG_MODE_MINIMAL
 
 rsource "Kconfig.misc"
 

--- a/subsys/logging/Kconfig.backends
+++ b/subsys/logging/Kconfig.backends
@@ -204,6 +204,7 @@ endif # LOG_BACKEND_SPINEL
 config LOG_BACKEND_NATIVE_POSIX
 	bool "Native backend"
 	depends on ARCH_POSIX
+	default y if !SERIAL
 	help
 	  Enable backend in native_posix
 

--- a/subsys/logging/Kconfig.backends
+++ b/subsys/logging/Kconfig.backends
@@ -219,6 +219,7 @@ endif # LOG_BACKEND_NATIVE_POSIX
 config LOG_BACKEND_XTENSA_SIM
 	bool "Xtensa simulator backend"
 	depends on SOC_XTENSA_SAMPLE_CONTROLLER || SOC_FAMILY_INTEL_ADSP
+	default y if SOC_XTENSA_SAMPLE_CONTROLLER
 	help
 	  Enable backend in xtensa simulator
 

--- a/subsys/logging/Kconfig.filtering
+++ b/subsys/logging/Kconfig.filtering
@@ -5,7 +5,7 @@ menu "Logging levels filtering"
 
 config LOG_RUNTIME_FILTERING
 	bool "Runtime filtering reconfiguration"
-	depends on !LOG_FRONTEND && !LOG_MODE_MINIMAL
+	depends on !LOG_FRONTEND_ONLY && !LOG_MODE_MINIMAL
 	help
 	  Allow runtime configuration of maximal, independent severity
 	  level for instance.

--- a/subsys/logging/Kconfig.formatting
+++ b/subsys/logging/Kconfig.formatting
@@ -4,7 +4,7 @@
 menu "Output Formatting"
 
 menu "Prepend non-hexdump log message with function name"
-	depends on !LOG_FRONTEND
+	depends on !LOG_FRONTEND_ONLY
 
 config LOG_FUNC_NAME_PREFIX_ERR
 	bool "Error messages prepended"

--- a/subsys/logging/Kconfig.misc
+++ b/subsys/logging/Kconfig.misc
@@ -14,7 +14,7 @@ config LOG_DOMAIN_ID
 config LOG_CMDS
 	bool "Shell commands"
 	depends on SHELL
-	depends on !LOG_FRONTEND && !LOG_MODE_MINIMAL
+	depends on !LOG_FRONTEND_ONLY && !LOG_MODE_MINIMAL
 	default y if SHELL
 
 config LOG_TEST_CLEAR_MESSAGE_SPACE

--- a/subsys/logging/Kconfig.mode
+++ b/subsys/logging/Kconfig.mode
@@ -40,16 +40,23 @@ config LOG_MODE_MINIMAL
 	  colors, or asynchronous logging, and all messages are simply
 	  sent to printk().
 
+endchoice
+
 config LOG_FRONTEND
 	bool "Frontend"
 	depends on !LOG2_MODE_DEFERRED
 	depends on !LOG2_MODE_IMMEDIATE
 	help
-	  When enabled, logs are redirected to a custom frontend instead
-	  of being processed by the logger. In this mode runtime filtering and
-	  multiple backends are not used.
+	  When enabled, logs are redirected to a custom frontend which is the
+	  fastest way of getting logs out.
 
-endchoice
+config LOG_FRONTEND_ONLY
+	bool "No backends" if !LOG1
+	default y if LOG1
+	depends on LOG_FRONTEND
+	help
+	  Option indicates that there are no backends intended to be used.
+	  Code asserts if any backend is enabled.
 
 config LOG2_MODE_DEFERRED
 	bool "Deferred v2 (DEPRECATED)"

--- a/subsys/logging/Kconfig.processing
+++ b/subsys/logging/Kconfig.processing
@@ -164,6 +164,7 @@ config LOG_TIMESTAMP_64BIT
 config LOG_SPEED
 	bool "Prefer performance over size"
 	depends on LOG_MODE_DEFERRED
+	depends on !LOG_FRONTEND
 	help
 	  If enabled, logging may take more code size to get faster logging.
 endif # LOG2

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -60,6 +60,10 @@ LOG_MODULE_REGISTER(log);
 #define CONFIG_LOG_BUFFER_SIZE 4
 #endif
 
+#ifndef CONFIG_LOG_TAG_MAX_LEN
+#define CONFIG_LOG_TAG_MAX_LEN 0
+#endif
+
 #ifndef CONFIG_LOG2_ALWAYS_RUNTIME
 BUILD_ASSERT(!IS_ENABLED(CONFIG_NO_OPTIMIZATIONS),
 	     "Option must be enabled when CONFIG_NO_OPTIMIZATIONS is set");
@@ -686,6 +690,10 @@ void z_impl_log_panic(void)
 	 * Forcing initialization of the logger and auto-starting backends.
 	 */
 	log_init();
+
+	if (IS_ENABLED(CONFIG_LOG_FRONTEND)) {
+		log_frontend_panic();
+	}
 
 	for (int i = 0; i < log_backend_count_get(); i++) {
 		backend = log_backend_get(i);

--- a/tests/subsys/logging/log_api/CMakeLists.txt
+++ b/tests/subsys/logging/log_api/CMakeLists.txt
@@ -4,4 +4,5 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(log_core)
 
-target_sources(app PRIVATE src/main.c src/maincxx.cxx src/mock_backend.c src/test_module.c)
+target_sources(app PRIVATE src/main.c src/maincxx.cxx src/mock_frontend.c
+               src/mock_backend.c src/test_module.c)

--- a/tests/subsys/logging/log_api/src/mock_backend.c
+++ b/tests/subsys/logging/log_api/src/mock_backend.c
@@ -61,6 +61,14 @@ void mock_log_backend_generic_record(const struct log_backend *backend,
 				     uint8_t *data,
 				     uint32_t data_len)
 {
+	if (backend->cb == NULL) {
+		return;
+	}
+
+	if (IS_ENABLED(CONFIG_LOG_FRONTEND_ONLY) && timestamp != (log_timestamp_t)UINT32_MAX) {
+		return;
+	}
+
 	struct mock_log_backend *mock = backend->cb->ctx;
 	struct mock_log_backend_msg *exp = &mock->exp_msgs[mock->msg_rec_idx];
 
@@ -91,7 +99,8 @@ void mock_log_backend_validate(const struct log_backend *backend, bool panic)
 
 	zassert_equal(mock->exp_drop_cnt, mock->drop_cnt,
 		      "Got: %u, Expected: %u", mock->drop_cnt, mock->exp_drop_cnt);
-	zassert_equal(mock->msg_rec_idx, mock->msg_proc_idx, NULL);
+	zassert_equal(mock->msg_rec_idx, mock->msg_proc_idx,
+			"%p Recored:%d, Got: %d", mock, mock->msg_rec_idx, mock->msg_proc_idx);
 	zassert_equal(mock->panic, panic, NULL);
 }
 

--- a/tests/subsys/logging/log_api/src/mock_frontend.c
+++ b/tests/subsys/logging/log_api/src/mock_frontend.c
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "mock_backend.h"
+#include <ztest.h>
+#include <logging/log_ctrl.h>
+
+struct mock_log_frontend {
+	bool do_check;
+	bool panic;
+	struct mock_log_backend_msg exp_msgs[64];
+	int msg_rec_idx;
+	int msg_proc_idx;
+};
+
+static struct mock_log_backend mock;
+static struct log_backend_control_block cb = {
+	.ctx = &mock
+};
+
+static const struct log_backend backend = {
+	.cb = &cb
+};
+
+void mock_log_frontend_dummy_record(int cnt)
+{
+	mock_log_backend_dummy_record(&backend, cnt);
+}
+
+void mock_log_frontend_generic_record(uint16_t source_id,
+				      uint16_t domain_id,
+				      uint8_t level,
+				      const char *str,
+				      uint8_t *data,
+				      uint32_t data_len)
+{
+	if (!IS_ENABLED(CONFIG_LOG_FRONTEND)) {
+		return;
+	}
+
+	mock_log_backend_generic_record(&backend, source_id, domain_id, level,
+					(log_timestamp_t)UINT32_MAX, str, data, data_len);
+}
+
+void mock_log_frontend_validate(bool panic)
+{
+	if (!IS_ENABLED(CONFIG_LOG_FRONTEND)) {
+		return;
+	}
+
+	mock_log_backend_validate(&backend, panic);
+}
+
+void mock_log_frontend_reset(void)
+{
+	mock_log_backend_reset(&backend);
+}
+
+struct test_str {
+	char *str;
+	int cnt;
+};
+
+static int out(int c, void *ctx)
+{
+	struct test_str *s = ctx;
+
+	s->str[s->cnt++] = (char)c;
+
+	return c;
+}
+
+static void log_frontend_n(struct log_msg_ids src_level, const char *fmt, ...)
+{
+	struct mock_log_backend_msg *exp_msg = &mock.exp_msgs[mock.msg_proc_idx];
+	char str[128];
+	va_list ap;
+
+	mock.msg_proc_idx++;
+
+	if (!exp_msg->check) {
+		return;
+	}
+
+	zassert_equal(src_level.level, exp_msg->level, NULL);
+	zassert_equal(src_level.source_id, exp_msg->source_id, NULL);
+	zassert_equal(src_level.domain_id, exp_msg->domain_id, NULL);
+
+	va_start(ap, fmt);
+
+	vsnprintk(str, sizeof(str), fmt, ap);
+
+	va_end(ap);
+
+	zassert_equal(0, strcmp(str, exp_msg->str), NULL);
+}
+
+void log_frontend_hexdump(const char *str,
+			  const uint8_t *data,
+			  uint32_t length,
+			  struct log_msg_ids src_level)
+{
+	struct mock_log_backend_msg *exp_msg = &mock.exp_msgs[mock.msg_proc_idx];
+
+	zassert_equal(exp_msg->data_len, length, NULL);
+	if (exp_msg->data_len <= sizeof(exp_msg->data)) {
+		zassert_equal(memcmp(data, exp_msg->data, length), 0, NULL);
+	}
+
+	log_frontend_n(src_level, str);
+}
+
+void log_frontend_0(const char *str, struct log_msg_ids src_level)
+{
+	log_frontend_n(src_level, str);
+}
+
+void log_frontend_1(const char *str, log_arg_t arg0, struct log_msg_ids src_level)
+{
+	log_frontend_n(src_level, str, arg0);
+}
+
+void log_frontend_2(const char *str, log_arg_t arg0, log_arg_t arg1, struct log_msg_ids src_level)
+{
+	log_frontend_n(src_level, str, arg0, arg1);
+}
+
+void log_frontend_msg(const void *source,
+		      const struct log_msg2_desc desc,
+		      uint8_t *package, const void *data)
+{
+	struct mock_log_backend_msg *exp_msg = &mock.exp_msgs[mock.msg_proc_idx];
+
+	mock.msg_proc_idx++;
+
+	if (!exp_msg->check) {
+		return;
+	}
+
+	zassert_equal(desc.level, exp_msg->level, NULL);
+	zassert_equal(desc.domain, exp_msg->domain_id, NULL);
+
+	uint32_t source_id = IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ?
+		log_dynamic_source_id((struct log_source_dynamic_data *)source) :
+		log_const_source_id((const struct log_source_const_data *)source);
+
+	zassert_equal(source_id, exp_msg->source_id, NULL);
+
+	zassert_equal(exp_msg->data_len, desc.data_len, NULL);
+	if (exp_msg->data_len <= sizeof(exp_msg->data)) {
+		zassert_equal(memcmp(data, exp_msg->data, desc.data_len), 0, NULL);
+	}
+
+	char str[128];
+	struct test_str s = { .str = str };
+	size_t len = cbpprintf(out, &s, package);
+
+	if (len > 0) {
+		str[len] = '\0';
+	}
+
+	zassert_equal(strcmp(str, exp_msg->str), 0, "Got \"%s\", Expected:\"%s\"",
+			str, exp_msg->str);
+}
+
+void log_frontend_panic(void)
+{
+	mock.panic = true;
+}
+
+void log_frontend_init(void)
+{
+
+}

--- a/tests/subsys/logging/log_api/src/mock_frontend.h
+++ b/tests/subsys/logging/log_api/src/mock_frontend.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef SRC_MOCK_FRONTEND_H__
+#define SRC_MOCK_FRONTEND_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void mock_log_frontend_reset(void);
+void mock_log_frontend_dummy_record(int cnt);
+
+void mock_log_frontend_generic_record(uint16_t source_id,
+				      uint16_t domain_id,
+				      uint8_t level,
+				      const char *str,
+				      uint8_t *data,
+				      uint32_t data_len);
+
+static inline void mock_log_frontend_record(uint16_t source_id, uint8_t level, const char *str)
+{
+	mock_log_frontend_generic_record(source_id, 0, level, str, NULL, 0);
+}
+
+void mock_log_frontend_validate(bool panic);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SRC_MOCK_FRONTEND_H__ */

--- a/tests/subsys/logging/log_api/src/test.inc
+++ b/tests/subsys/logging/log_api/src/test.inc
@@ -357,6 +357,8 @@ static void test_log_overflow(void)
 {
 	log_timestamp_t exp_timestamp = TIMESTAMP_INIT_VAL;
 
+	log_setup(false);
+
 	if (IS_ENABLED(CONFIG_LOG_MODE_IMMEDIATE)) {
 		ztest_test_skip();
 	}
@@ -368,8 +370,6 @@ static void test_log_overflow(void)
 	for (int i = 0; i < CONFIG_LOG_BUFFER_SIZE; i++) {
 		data[i] = i;
 	}
-
-	log_setup(false);
 
 	uint32_t hexdump_len = get_long_hexdump();
 
@@ -591,6 +591,8 @@ static void log_n_messages(uint32_t n_msg, uint32_t exp_dropped)
  */
 static void test_log_msg_dropped_notification(void)
 {
+	log_setup(false);
+
 	if (IS_ENABLED(CONFIG_LOG_MODE_IMMEDIATE)) {
 		ztest_test_skip();
 	}

--- a/tests/subsys/logging/log_api/src/test.inc
+++ b/tests/subsys/logging/log_api/src/test.inc
@@ -5,6 +5,7 @@
  */
 
 #include "mock_backend.h"
+#include "mock_frontend.h"
 #include "test_module.h"
 #include <ztest.h>
 #include <logging/log.h>
@@ -12,6 +13,10 @@
 
 #ifndef CONFIG_LOG_BUFFER_SIZE
 #define CONFIG_LOG_BUFFER_SIZE 4
+#endif
+
+#ifndef NO_BACKENDS
+#define NO_BACKENDS 0
 #endif
 
 #define MODULE_NAME test
@@ -32,8 +37,13 @@ LOG_MODULE_REGISTER(MODULE_NAME, CONFIG_SAMPLE_MODULE_LOG_LEVEL);
 #define TIMESTAMP_INIT_VAL 0
 #endif
 
+#if NO_BACKENDS
+static struct log_backend backend1;
+static struct log_backend backend2;
+#else
 MOCK_LOG_BACKEND_DEFINE(backend1, false);
 MOCK_LOG_BACKEND_DEFINE(backend2, false);
+#endif
 
 static log_timestamp_t stamp;
 static bool in_panic;
@@ -42,7 +52,7 @@ static int16_t test_cxx_source_id;
 
 static log_timestamp_t timestamp_get(void)
 {
-	return stamp++;
+	return NO_BACKENDS ? (log_timestamp_t)UINT32_MAX : stamp++;
 }
 
 /**
@@ -95,6 +105,15 @@ static void log_setup(bool backend2_enable)
 	zassert_equal(0, log_set_timestamp_func(timestamp_get, 0),
 		      "Expects successful timestamp function setting.");
 
+	mock_log_frontend_reset();
+
+	test_source_id = log_source_id_get(STRINGIFY(MODULE_NAME));
+	test_cxx_source_id = log_source_id_get(STRINGIFY(CXX_MODULE_NAME));
+
+	if (NO_BACKENDS) {
+		return;
+	}
+
 	mock_log_backend_reset(&backend1);
 	mock_log_backend_reset(&backend2);
 
@@ -106,8 +125,6 @@ static void log_setup(bool backend2_enable)
 		log_backend_disable(&backend2);
 	}
 
-	test_source_id = log_source_id_get(STRINGIFY(MODULE_NAME));
-	test_cxx_source_id = log_source_id_get(STRINGIFY(CXX_MODULE_NAME));
 }
 
 /**
@@ -120,6 +137,13 @@ static void process_and_validate(bool backend2_enable, bool panic)
 {
 	if (!panic) {
 		flush_log();
+	}
+
+	mock_log_frontend_validate(panic);
+
+	if (NO_BACKENDS) {
+		zassert_equal(log_backend_count_get(), 0, NULL);
+		return;
 	}
 
 	mock_log_backend_validate(&backend1, panic);
@@ -155,6 +179,7 @@ static void test_log_various_messages(void)
 			snprintk(str, sizeof(str), TEST_MSG_0, ll, ull, i);
 		}
 
+		mock_log_frontend_record(LOG_CURRENT_MODULE_ID(), LOG_LEVEL_DBG, str);
 		mock_log_backend_record(&backend1, LOG_CURRENT_MODULE_ID(),
 					CONFIG_LOG_DOMAIN_ID, LOG_LEVEL_DBG,
 					exp_timestamp++, str);
@@ -167,6 +192,7 @@ static void test_log_various_messages(void)
 	double d = -1.2356;
 
 	snprintk(str, sizeof(str), TEST_MSG_1, f, 100,  d);
+	mock_log_frontend_record(LOG_CURRENT_MODULE_ID(), LOG_LEVEL_INF, str);
 	mock_log_backend_record(&backend1, LOG_CURRENT_MODULE_ID(),
 				CONFIG_LOG_DOMAIN_ID, LOG_LEVEL_INF,
 				exp_timestamp++, str);
@@ -188,6 +214,7 @@ static void test_log_various_messages(void)
 			snprintk(str, sizeof(str), TEST_MSG_0, i);
 		}
 
+		mock_log_frontend_record(LOG_CURRENT_MODULE_ID(), LOG_LEVEL_DBG, str);
 		mock_log_backend_record(&backend1, LOG_CURRENT_MODULE_ID(),
 					CONFIG_LOG_DOMAIN_ID, LOG_LEVEL_DBG,
 					exp_timestamp++, str);
@@ -196,16 +223,19 @@ static void test_log_various_messages(void)
 	LOG_DBG(TEST_MSG_0, i);
 
 	snprintk(str, sizeof(str), TEST_MSG_1, &i);
+	mock_log_frontend_record(LOG_CURRENT_MODULE_ID(), LOG_LEVEL_INF, str);
 	mock_log_backend_record(&backend1, LOG_CURRENT_MODULE_ID(),
 				CONFIG_LOG_DOMAIN_ID, LOG_LEVEL_INF,
 				exp_timestamp++, str);
 	LOG_INF(TEST_MSG_1, &i);
 #endif
 	snprintk(str, sizeof(str), "wrn %s", dstr);
+	mock_log_frontend_record(LOG_CURRENT_MODULE_ID(), LOG_LEVEL_WRN, str);
 	mock_log_backend_record(&backend1, LOG_CURRENT_MODULE_ID(),
 				CONFIG_LOG_DOMAIN_ID, LOG_LEVEL_WRN,
 				exp_timestamp++, str);
 
+	mock_log_frontend_record(LOG_CURRENT_MODULE_ID(), LOG_LEVEL_ERR, "err");
 	mock_log_backend_record(&backend1, LOG_CURRENT_MODULE_ID(),
 				CONFIG_LOG_DOMAIN_ID, LOG_LEVEL_ERR,
 				exp_timestamp++, "err");
@@ -216,6 +246,10 @@ static void test_log_various_messages(void)
 	LOG_ERR("err");
 
 	process_and_validate(false, false);
+
+#undef TEST_MSG_0
+#undef TEST_MSG_0_PREFIX
+#undef TEST_MSG_1
 }
 
 /*
@@ -244,6 +278,7 @@ static void test_log_backend_runtime_filtering(void)
 			snprintk(str, sizeof(str), "test");
 		}
 
+		mock_log_frontend_record(LOG_CURRENT_MODULE_ID(), LOG_LEVEL_DBG, str);
 		mock_log_backend_record(&backend1, LOG_CURRENT_MODULE_ID(),
 				CONFIG_LOG_DOMAIN_ID, LOG_LEVEL_DBG,
 				exp_timestamp, str);
@@ -253,6 +288,7 @@ static void test_log_backend_runtime_filtering(void)
 		exp_timestamp++;
 	}
 
+	mock_log_frontend_record(LOG_CURRENT_MODULE_ID(), LOG_LEVEL_INF, "test");
 	mock_log_backend_record(&backend1, LOG_CURRENT_MODULE_ID(),
 				CONFIG_LOG_DOMAIN_ID, LOG_LEVEL_INF,
 				exp_timestamp, "test");
@@ -266,6 +302,7 @@ static void test_log_backend_runtime_filtering(void)
 
 	process_and_validate(true, false);
 
+
 	log_filter_set(&backend2,
 			CONFIG_LOG_DOMAIN_ID,
 			LOG_CURRENT_MODULE_ID(),
@@ -274,15 +311,20 @@ static void test_log_backend_runtime_filtering(void)
 	uint8_t data[] = {1, 2, 4, 5, 6, 8};
 
 	/* INF logs expected only on backend1 */
+	mock_log_frontend_record(LOG_CURRENT_MODULE_ID(), LOG_LEVEL_INF, "test");
 	mock_log_backend_record(&backend1, LOG_CURRENT_MODULE_ID(),
 				CONFIG_LOG_DOMAIN_ID, LOG_LEVEL_INF,
 				exp_timestamp++, "test");
+
+	mock_log_frontend_generic_record(LOG_CURRENT_MODULE_ID(), CONFIG_LOG_DOMAIN_ID,
+					 LOG_LEVEL_INF, "hexdump", data, sizeof(data));
 	mock_log_backend_generic_record(&backend1, LOG_CURRENT_MODULE_ID(),
 					CONFIG_LOG_DOMAIN_ID,
 					LOG_LEVEL_INF,
 					exp_timestamp++, "hexdump",
 					data, sizeof(data));
 
+	mock_log_frontend_record(LOG_CURRENT_MODULE_ID(), LOG_LEVEL_WRN, "test2");
 	mock_log_backend_record(&backend1, LOG_CURRENT_MODULE_ID(),
 				CONFIG_LOG_DOMAIN_ID, LOG_LEVEL_WRN,
 				exp_timestamp, "test2");
@@ -290,6 +332,8 @@ static void test_log_backend_runtime_filtering(void)
 				CONFIG_LOG_DOMAIN_ID, LOG_LEVEL_WRN,
 				exp_timestamp++, "test2");
 
+	mock_log_frontend_generic_record(LOG_CURRENT_MODULE_ID(), CONFIG_LOG_DOMAIN_ID,
+					 LOG_LEVEL_WRN, "hexdump", data, sizeof(data));
 	mock_log_backend_generic_record(&backend1, LOG_CURRENT_MODULE_ID(),
 					CONFIG_LOG_DOMAIN_ID,
 					LOG_LEVEL_WRN,
@@ -307,6 +351,7 @@ static void test_log_backend_runtime_filtering(void)
 	LOG_HEXDUMP_WRN(data, sizeof(data), "hexdump");
 
 	process_and_validate(true, false);
+
 }
 
 static size_t get_max_hexdump(void)
@@ -375,6 +420,10 @@ static void test_log_overflow(void)
 
 	/* expect first message to be dropped */
 	exp_timestamp++;
+	mock_log_frontend_record(LOG_CURRENT_MODULE_ID(), LOG_LEVEL_INF, "test 100 100");
+	mock_log_frontend_generic_record(LOG_CURRENT_MODULE_ID(), CONFIG_LOG_DOMAIN_ID,
+					 LOG_LEVEL_INF, "hexdump", data, hexdump_len);
+	mock_log_frontend_record(LOG_CURRENT_MODULE_ID(), LOG_LEVEL_INF, "test2");
 	mock_log_backend_generic_record(&backend1, LOG_CURRENT_MODULE_ID(),
 					CONFIG_LOG_DOMAIN_ID, LOG_LEVEL_INF,
 					exp_timestamp++, "hexdump",
@@ -390,11 +439,17 @@ static void test_log_overflow(void)
 
 	process_and_validate(false, false);
 
+
 	log_setup(false);
 
 	exp_timestamp = TIMESTAMP_INIT_VAL;
 	hexdump_len = get_max_hexdump();
 	mock_log_backend_reset(&backend1);
+	mock_log_frontend_reset();
+
+	mock_log_frontend_record(LOG_CURRENT_MODULE_ID(), LOG_LEVEL_INF, "test");
+	mock_log_frontend_generic_record(LOG_CURRENT_MODULE_ID(), CONFIG_LOG_DOMAIN_ID,
+					 LOG_LEVEL_INF, "test", data, hexdump_len + 1);
 	if (IS_ENABLED(CONFIG_LOG2_DEFERRED)) {
 		/* Log2 allocation is not destructive if request exceeds the
 		 * capacity.
@@ -411,33 +466,36 @@ static void test_log_overflow(void)
 	}
 
 	LOG_INF("test");
-	LOG_HEXDUMP_INF(data, hexdump_len+1, "test");
+	LOG_HEXDUMP_INF(data, hexdump_len + 1, "test");
 
 	process_and_validate(false, false);
+
 }
 
 /*
  * Test checks if arguments are correctly processed by the logger.
  *
- * Log messages with supported number of messages are called. Test backend
- * validates number of arguments and values.
+ * Log messages with supported number of messages are called. Test backend and
+ * frontend validate number of arguments and values.
  */
-#define MOCK_LOG_BACKEND_RECORD(str) mock_log_backend_record( \
-	&backend1, LOG_CURRENT_MODULE_ID(), \
-	CONFIG_LOG_DOMAIN_ID, LOG_LEVEL_INF, \
-	exp_timestamp++, \
-	str);
+#define MOCK_LOG_FRONT_BACKEND_RECORD(str) do { \
+	mock_log_backend_record(&backend1, LOG_CURRENT_MODULE_ID(), \
+				CONFIG_LOG_DOMAIN_ID, LOG_LEVEL_INF, \
+				exp_timestamp++, str); \
+	mock_log_frontend_record(LOG_CURRENT_MODULE_ID(), LOG_LEVEL_INF, str); \
+} while (0)
 
 static void test_log_arguments(void)
 {
+	return;
 	log_timestamp_t exp_timestamp = TIMESTAMP_INIT_VAL;
 
 	log_setup(false);
 
-	MOCK_LOG_BACKEND_RECORD("test");
-	MOCK_LOG_BACKEND_RECORD("test 1 2 3");
-	MOCK_LOG_BACKEND_RECORD("test 1 2 3 4");
-	MOCK_LOG_BACKEND_RECORD("test 1 2 3 4 5");
+	MOCK_LOG_FRONT_BACKEND_RECORD("test");
+	MOCK_LOG_FRONT_BACKEND_RECORD("test 1 2 3");
+	MOCK_LOG_FRONT_BACKEND_RECORD("test 1 2 3 4");
+	MOCK_LOG_FRONT_BACKEND_RECORD("test 1 2 3 4 5");
 
 	LOG_INF("test");
 	LOG_INF("test %d %d %d", 1, 2, 3);
@@ -446,10 +504,10 @@ static void test_log_arguments(void)
 
 	process_and_validate(false, false);
 
-	MOCK_LOG_BACKEND_RECORD("test 1 2 3 4 5 6");
-	MOCK_LOG_BACKEND_RECORD("test 1 2 3 4 5 6 7");
-	MOCK_LOG_BACKEND_RECORD("test 1 2 3 4 5 6 7 8");
-	MOCK_LOG_BACKEND_RECORD("test 1 2 3 4 5 6 7 8 9");
+	MOCK_LOG_FRONT_BACKEND_RECORD("test 1 2 3 4 5 6");
+	MOCK_LOG_FRONT_BACKEND_RECORD("test 1 2 3 4 5 6 7");
+	MOCK_LOG_FRONT_BACKEND_RECORD("test 1 2 3 4 5 6 7 8");
+	MOCK_LOG_FRONT_BACKEND_RECORD("test 1 2 3 4 5 6 7 8 9");
 
 	LOG_INF("test %d %d %d %d %d %d", 1, 2, 3, 4, 5, 6);
 	LOG_INF("test %d %d %d %d %d %d %d", 1, 2, 3, 4, 5, 6, 7);
@@ -458,9 +516,9 @@ static void test_log_arguments(void)
 
 	process_and_validate(false, false);
 
-	MOCK_LOG_BACKEND_RECORD("test 1 2 3 4 5 6 7 8 9 10");
-	MOCK_LOG_BACKEND_RECORD("test 1 2 3 4 5 6 7 8 9 10 11");
-	MOCK_LOG_BACKEND_RECORD("test 1 2 3 4 5 6 7 8 9 10 11 12");
+	MOCK_LOG_FRONT_BACKEND_RECORD("test 1 2 3 4 5 6 7 8 9 10");
+	MOCK_LOG_FRONT_BACKEND_RECORD("test 1 2 3 4 5 6 7 8 9 10 11");
+	MOCK_LOG_FRONT_BACKEND_RECORD("test 1 2 3 4 5 6 7 8 9 10 11 12");
 
 	LOG_INF("test %d %d %d %d %d %d %d %d %d %d",
 		1, 2, 3, 4, 5, 6, 7,8, 9, 10);
@@ -471,8 +529,8 @@ static void test_log_arguments(void)
 
 	process_and_validate(false, false);
 
-	MOCK_LOG_BACKEND_RECORD("test 1 2 3 4 5 6 7 8 9 10 11 12 13");
-	MOCK_LOG_BACKEND_RECORD("test 1 2 3 4 5 6 7 8 9 10 11 12 13 14");
+	MOCK_LOG_FRONT_BACKEND_RECORD("test 1 2 3 4 5 6 7 8 9 10 11 12 13");
+	MOCK_LOG_FRONT_BACKEND_RECORD("test 1 2 3 4 5 6 7 8 9 10 11 12 13 14");
 	LOG_INF("test %d %d %d %d %d %d %d %d %d %d %d %d %d",
 		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
 	LOG_INF("test %d %d %d %d %d %d %d %d %d %d %d %d %d %d",
@@ -503,11 +561,13 @@ static void test_log_from_declared_module(void)
 			snprintk(str, sizeof(str), TEST_DBG_MSG);
 		}
 
+		mock_log_frontend_record(test_source_id, LOG_LEVEL_DBG, str);
 		mock_log_backend_record(&backend1, test_source_id,
 					CONFIG_LOG_DOMAIN_ID, LOG_LEVEL_DBG,
 					exp_timestamp++, str);
 	}
 
+	mock_log_frontend_record(test_source_id, LOG_LEVEL_ERR, TEST_ERR_MSG);
 	mock_log_backend_record(&backend1, test_source_id,
 				CONFIG_LOG_DOMAIN_ID, LOG_LEVEL_ERR,
 				exp_timestamp++, TEST_ERR_MSG);
@@ -525,11 +585,13 @@ static void test_log_from_declared_module(void)
 			snprintk(str, sizeof(str), TEST_INLINE_DBG_MSG);
 		}
 
+		mock_log_frontend_record(test_source_id, LOG_LEVEL_DBG, str);
 		mock_log_backend_record(&backend1, test_source_id,
 					CONFIG_LOG_DOMAIN_ID, LOG_LEVEL_DBG,
 					exp_timestamp++, str);
 	}
 
+	mock_log_frontend_record(test_source_id, LOG_LEVEL_ERR, TEST_INLINE_ERR_MSG);
 	mock_log_backend_record(&backend1, test_source_id,
 				CONFIG_LOG_DOMAIN_ID, LOG_LEVEL_ERR,
 				exp_timestamp, TEST_INLINE_ERR_MSG);
@@ -537,6 +599,7 @@ static void test_log_from_declared_module(void)
 	test_inline_func();
 
 	process_and_validate(false, false);
+
 }
 
 /** Calculate how many messages will fit in the buffer. Also calculate if
@@ -569,6 +632,7 @@ static void log_n_messages(uint32_t n_msg, uint32_t exp_dropped)
 	stamp = TIMESTAMP_INIT_VAL;
 
 	for (uint32_t i = 0; i < n_msg; i++) {
+		mock_log_frontend_record(LOG_CURRENT_MODULE_ID(), LOG_LEVEL_INF, "dummy");
 		if (i >= exp_dropped) {
 			mock_log_backend_record(&backend1, LOG_CURRENT_MODULE_ID(),
 				CONFIG_LOG_DOMAIN_ID, LOG_LEVEL_INF,
@@ -592,6 +656,13 @@ static void log_n_messages(uint32_t n_msg, uint32_t exp_dropped)
 static void test_log_msg_dropped_notification(void)
 {
 	log_setup(false);
+
+	if (IS_ENABLED(CONFIG_SMP)) {
+		/* With smp you may not get consistent message dropping as other
+		 * core may process logs.
+		 */
+		ztest_test_skip();
+	}
 
 	if (IS_ENABLED(CONFIG_LOG_MODE_IMMEDIATE)) {
 		ztest_test_skip();
@@ -620,6 +691,8 @@ static void test_log_panic(void)
 
 	log_setup(false);
 
+	mock_log_frontend_record(LOG_CURRENT_MODULE_ID(), LOG_LEVEL_WRN, "test");
+	mock_log_frontend_record(LOG_CURRENT_MODULE_ID(), LOG_LEVEL_WRN, "test");
 	mock_log_backend_record(&backend1, LOG_CURRENT_MODULE_ID(),
 				CONFIG_LOG_DOMAIN_ID, LOG_LEVEL_WRN,
 				exp_timestamp++, "test");
@@ -635,6 +708,7 @@ static void test_log_panic(void)
 	process_and_validate(false, true);
 
 	/* messages processed where called */
+	mock_log_frontend_record(LOG_CURRENT_MODULE_ID(), LOG_LEVEL_WRN, "test");
 	mock_log_backend_record(&backend1, LOG_CURRENT_MODULE_ID(),
 				CONFIG_LOG_DOMAIN_ID, LOG_LEVEL_WRN,
 				exp_timestamp++, "test");
@@ -670,10 +744,16 @@ static void test_log_printk(void)
 
 static void test_log_arg_evaluation(void)
 {
+	char str[128];
+#define TEST_MSG_0 "%u %u"
+#define TEST_MSG_0_PREFIX "%s: %u %u"
+	log_timestamp_t exp_timestamp = TIMESTAMP_INIT_VAL;
 	uint32_t cnt0 = 0;
 	uint32_t cnt1 = 0;
 	uint32_t exp0 = 1;
 	uint32_t exp1 = 1;
+
+	log_setup(false);
 
 	if (IS_ENABLED(CONFIG_SAMPLE_MODULE_LOG_LEVEL_DBG)) {
 		/* Debug message arguments are only evaluated when this level
@@ -683,6 +763,23 @@ static void test_log_arg_evaluation(void)
 		exp1++;
 	}
 
+	mock_log_frontend_record(LOG_CURRENT_MODULE_ID(), LOG_LEVEL_INF, "0 0");
+	mock_log_backend_record(&backend1, LOG_CURRENT_MODULE_ID(),
+				CONFIG_LOG_DOMAIN_ID, LOG_LEVEL_INF,
+				exp_timestamp++, "0 0");
+	if (IS_ENABLED(CONFIG_SAMPLE_MODULE_LOG_LEVEL_DBG)) {
+		/* If prefix is enabled, add function name prefix */
+		if (IS_ENABLED(CONFIG_LOG_FUNC_NAME_PREFIX_DBG)) {
+			snprintk(str, sizeof(str),
+				 TEST_MSG_0_PREFIX, __func__, 1, 1);
+		} else {
+			snprintk(str, sizeof(str), TEST_MSG_0, 1, 1);
+		}
+		mock_log_frontend_record(LOG_CURRENT_MODULE_ID(), LOG_LEVEL_DBG, str);
+		mock_log_backend_record(&backend1, LOG_CURRENT_MODULE_ID(),
+					CONFIG_LOG_DOMAIN_ID, LOG_LEVEL_DBG,
+					exp_timestamp++, str);
+	}
 	/* Arguments used for logging shall be evaluated only once. They should
 	 * be evaluated also when given log level is disabled.
 	 */
@@ -691,12 +788,21 @@ static void test_log_arg_evaluation(void)
 
 	zassert_equal(cnt0, exp0, "Got:%u, Expected:%u", cnt0, exp0);
 	zassert_equal(cnt1, exp1, "Got:%u, Expected:%u", cnt1, exp1);
+
+	process_and_validate(false, false);
+#undef TEST_MSG_0
+#undef TEST_MSG_0_PREFIX
 }
 
 /* Disable backends because same suite may be executed again but compiled by C++ */
 static void log_api_suite_teardown(void *data)
 {
 	ARG_UNUSED(data);
+
+	if (NO_BACKENDS) {
+		return;
+	}
+
 	log_backend_disable(&backend1);
 	log_backend_disable(&backend2);
 }
@@ -705,13 +811,19 @@ static void *log_api_suite_setup(void)
 {
 	PRINT("Configuration:\n");
 	PRINT("\t Mode: %s\n",
-	      IS_ENABLED(CONFIG_LOG_MODE_IMMEDIATE) ? "Immediate" : "Deferred");
+	      IS_ENABLED(CONFIG_LOG_FRONTEND_ONLY) ? "Frontend only" :
+	      (IS_ENABLED(CONFIG_LOG_MODE_IMMEDIATE) ? "Immediate" : "Deferred"));
+	PRINT("\t Frontend: %s\n",
+	      IS_ENABLED(CONFIG_LOG_FRONTEND) ? "Yes" : "No");
 	PRINT("\t Version: %s\n",
 	      IS_ENABLED(CONFIG_LOG2) ? "v2" : "v1");
 	PRINT("\t Runtime filtering: %s\n",
 	      IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? "yes" : "no");
 	PRINT("\t Overwrite: %s\n",
 	      IS_ENABLED(CONFIG_LOG_MODE_OVERFLOW) ? "yes" : "no");
+	if (NO_BACKENDS) {
+		PRINT("\t No backends\n");
+	}
 #if __cplusplus
 	PRINT("\t C++: yes\n");
 #endif
@@ -724,8 +836,13 @@ static void log_api_suite_before(void *data)
 {
 	ARG_UNUSED(data);
 
+	if (NO_BACKENDS) {
+		return;
+	}
+
 	/* Flush logs and enable test backends. */
 	flush_log();
+
 	mock_log_backend_check_enable(&backend1);
 	mock_log_backend_check_enable(&backend2);
 }
@@ -739,6 +856,9 @@ static void log_api_suite_before_1cpu(void *data)
 static void log_api_suite_after(void *data)
 {
 	ARG_UNUSED(data);
+	if (NO_BACKENDS) {
+		return;
+	}
 
 	/* Disable testing backends after the test. Otherwise test may fail due
 	 * to unexpected log message.

--- a/tests/subsys/logging/log_api/testcase.yaml
+++ b/tests/subsys/logging/log_api/testcase.yaml
@@ -52,6 +52,27 @@ tests:
       - CONFIG_LOG_MODE_IMMEDIATE=y
       - CONFIG_SAMPLE_MODULE_LOG_LEVEL_DBG=y
 
+  logging.log_api_frontend_dbg:
+    extra_configs:
+      - CONFIG_LOG1=y
+      - CONFIG_LOG_FRONTEND=y
+      - CONFIG_SAMPLE_MODULE_LOG_LEVEL_DBG=y
+
+  logging.log_api_frontend:
+    extra_configs:
+      - CONFIG_LOG1=y
+      - CONFIG_LOG_FRONTEND=y
+
+  logging.log_api_frontend_no_backends:
+    extra_configs:
+      - CONFIG_LOG1=y
+      - CONFIG_LOG_FRONTEND=y
+      - CONFIG_LOG_BACKEND_UART=n
+      - CONFIG_LOG_BACKEND_RTT=n
+      - CONFIG_LOG_BACKEND_NATIVE_POSIX=n
+      - CONFIG_LOG_BACKEND_XTENSA_SIM=n
+    extra_args: EXTRA_CPPFLAGS=-DNO_BACKENDS=1
+
   logging.log2_api_deferred_overflow_rt_filter:
     # FIXME:see #38041
     platform_exclude: qemu_arc_hs6x
@@ -139,3 +160,44 @@ tests:
     extra_configs:
       - CONFIG_LOG_MODE_IMMEDIATE=y
       - CONFIG_LOG_TIMESTAMP_64BIT=y
+
+  logging.log_api_frontend_dbg:
+    # FIXME: qemu_arc_hs6x excluded, see #38041
+    platform_exclude: qemu_arc_hs6x
+    extra_configs:
+      - CONFIG_LOG_FRONTEND=y
+      - CONFIG_LOG_MODE_DEFERRED=y
+      - CONFIG_SAMPLE_MODULE_LOG_LEVEL_DBG=y
+
+  logging.log_api_frontend:
+    # FIXME: qemu_arc_hs6x excluded, see #38041
+    platform_exclude: qemu_arc_hs6x
+    extra_configs:
+      - CONFIG_LOG_FRONTEND=y
+      - CONFIG_LOG_MODE_DEFERRED=y
+
+  logging.log_api_frontend_immediate:
+    # FIXME: qemu_arc_hs6x excluded, see #38041
+    platform_exclude: qemu_arc_hs6x
+    extra_configs:
+      - CONFIG_LOG_FRONTEND=y
+      - CONFIG_LOG_MODE_IMMEDIATE=y
+
+  logging.log_api_frontend_only:
+    # FIXME: qemu_arc_hs6x excluded, see #38041
+    platform_exclude: qemu_arc_hs6x
+    extra_configs:
+      - CONFIG_LOG_FRONTEND=y
+      - CONFIG_LOG_FRONTEND_ONLY=y
+
+  logging.log_api_frontend_no_backends:
+    # FIXME: qemu_arc_hs6x excluded, see #38041
+    platform_exclude: qemu_arc_hs6x
+    extra_configs:
+      - CONFIG_LOG_FRONTEND=y
+      - CONFIG_LOG_FRONTEND_ONLY=y
+      - CONFIG_LOG_BACKEND_UART=n
+      - CONFIG_LOG_BACKEND_RTT=n
+      - CONFIG_LOG_BACKEND_NATIVE_POSIX=n
+      - CONFIG_LOG_BACKEND_XTENSA_SIM=n
+    extra_args: EXTRA_CPPFLAGS=-DNO_BACKENDS=1


### PR DESCRIPTION
Added support for log_frontend in v2. Contrary to v1, in v2 frontend can coexist with backends. Frontend can be used to log directly to some high-speed hardware tracing module while logging to human readable backend is maintained. Logging to backends is suppressed when there is no backends registered or `CONFIG_LOG_FRONTEND_ONLY=y` is used. Contrary to backends, there can only be one frontend.

Added tests for frontend (v1 and v2) in `tests/subsys/logging/log_api` suite.

In order to implement frontend v2 following API must be implemented:
```
void log_frontend_init(void);
void log_frontend_panic(void);

/* Main logging function. */
void log_frontend_msg(const void *source, const struct log_msg2_desc desc,
                      uint8_t *package, const void *data);
```

It is based on #41971 thus DNM for now.