### PR TITLE
stm32wl: Fix gpio irq handling

### DIFF
--- a/boards/arm/nucleo_wl55jc/doc/nucleo_wl55jc.rst
+++ b/boards/arm/nucleo_wl55jc/doc/nucleo_wl55jc.rst
@@ -291,6 +291,15 @@ You should see the following message on the console:
 
    Hello World! arm
 
+.. Note:
+
+   Nucleo WL55JC board is provided with a stock firmware which demonstrates
+   sleep mode. Unfortunately, default openocd configuration, which is debug
+   compatible, doesn't allow flashing when SoC is in sleep mode.
+   As a consequence, when flashing Nucleo WL55JC board over a stock firmware,
+   please update board's openocd.cfg configuration file to select sleep mode
+   compatible configuration.
+
 Debugging
 =========
 

--- a/boards/arm/nucleo_wl55jc/support/openocd.cfg
+++ b/boards/arm/nucleo_wl55jc/support/openocd.cfg
@@ -4,4 +4,8 @@ transport select hla_swd
 
 source [find target/stm32wlx.cfg]
 
-reset_config srst_only srst_nogate connect_assert_srst
+# Debug compatible reset configuration (default)
+reset_config srst_only srst_nogate
+
+# Sleep mode compatible reset configuration (stock firmware compatible)
+# reset_config srst_only srst_nogate connect_assert_srst

--- a/tests/drivers/gpio/gpio_basic_api/boards/nucleo_wl55jc.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nucleo_wl55jc.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2022 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	resources {
+		compatible = "test-gpio-basic-api";
+		out-gpios = <&arduino_header 0 0>; /* Arduino A0 */
+		in-gpios = <&arduino_header 1 0>;  /* Arduino A1 */
+	};
+};

--- a/west.yml
+++ b/west.yml
@@ -124,7 +124,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 91531028be0bfa554ae1dd9e2b5d3ed6fd7287c3
+      revision: 44cc276a484cf42536442b563f5f666ce96b987f
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
EXTI LL API was buggy and was not returning correct source input for some GPIO lines.

- Fix this 
- Add an overlay to enable gpio_basic_api test on nucleo_wl55jc
- Fix openocd configuration

Fixes #42218
