### PR TITLE
testsuite: tc_util: Limit include range

### DIFF
--- a/subsys/testsuite/include/tc_util.h
+++ b/subsys/testsuite/include/tc_util.h
@@ -16,7 +16,6 @@
 #include <shell/shell.h>
 #endif
 #include <sys/printk.h>
-#include <logging/log_ctrl.h>
 
 #if defined CONFIG_ZTEST_TC_UTIL_USER_OVERRIDE
 #include <tc_util_user_override.h>
@@ -175,6 +174,7 @@ static inline void test_time_ms(void)
 #endif
 
 #if defined(CONFIG_ARCH_POSIX)
+#include <logging/log_ctrl.h>
 #define TC_END_POST(result) do { \
 	LOG_PANIC(); \
 	posix_exit(result); \


### PR DESCRIPTION
tc_util.h is also included by unit tests and in that case it
cannot have dependencies to subsystems. Including log_ctrl.h
only for ARCH_POSIX where it is needed to flush logs before
exit.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>