### PR TITLE
Bluetooth: Host: Settings: Handle extra settings_load before bt_enable

### DIFF
--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -130,10 +130,13 @@ typedef void (*bt_ready_cb_t)(int err);
  * Enable Bluetooth. Must be the called before any calls that
  * require communication with the local Bluetooth hardware.
  *
- * When @kconfig{CONFIG_BT_SETTINGS} has been enabled and the application is not
- * managing identities of the stack itself then the application must call
- * @ref settings_load() before the stack is fully enabled.
- * See @ref bt_id_create() for more information.
+ * When @kconfig{CONFIG_BT_SETTINGS} is enabled, the application must load the
+ * Bluetooth settings after this API call successfully completes before
+ * Bluetooth APIs can be used. Loading the settings before calling this function
+ * is insufficient. Bluetooth settings can be loaded with settings_load() or
+ * settings_load_subtree() with argument "bt". The latter selectively loads only
+ * Bluetooth settings and is recommended if settings_load() has been called
+ * earlier.
  *
  * @param cb Callback to notify completion or NULL to perform the
  * enabling synchronously.

--- a/subsys/bluetooth/host/keys_br.c
+++ b/subsys/bluetooth/host/keys_br.c
@@ -205,13 +205,8 @@ static int link_key_set(const char *name, size_t len_rd,
 	return 0;
 }
 
-static int link_key_commit(void)
-{
-	return 0;
-}
-
 SETTINGS_STATIC_HANDLER_DEFINE(bt_link_key, "bt/link_key", NULL, link_key_set,
-			       link_key_commit, NULL);
+			       NULL, NULL);
 
 #if IS_ENABLED(CONFIG_BT_KEYS_OVERWRITE_OLDEST)
 void bt_keys_link_key_update_usage(const bt_addr_t *addr)

--- a/subsys/bluetooth/host/settings.c
+++ b/subsys/bluetooth/host/settings.c
@@ -119,6 +119,16 @@ static int set(const char *name, size_t len_rd, settings_read_cb read_cb,
 	ssize_t len;
 	const char *next;
 
+	if (!atomic_test_bit(bt_dev.flags, BT_DEV_ENABLE)) {
+		/* The Bluetooth settings loader needs to communicate with the Bluetooth
+		 * controller to setup identities. This will not work before
+		 * bt_enable(). The doc on @ref bt_enable requires the "bt/" settings
+		 * tree to be loaded after @ref bt_enable is completed, so this handler
+		 * will be called again later.
+		 */
+		return 0;
+	}
+
 	if (!name) {
 		BT_ERR("Insufficient number of arguments");
 		return -ENOENT;
@@ -234,6 +244,16 @@ static int commit(void)
 	int err;
 
 	BT_DBG("");
+
+	if (!atomic_test_bit(bt_dev.flags, BT_DEV_ENABLE)) {
+		/* The Bluetooth settings loader needs to communicate with the Bluetooth
+		 * controller to setup identities. This will not work before
+		 * bt_enable(). The doc on @ref bt_enable requires the "bt/" settings
+		 * tree to be loaded after @ref bt_enable is completed, so this handler
+		 * will be called again later.
+		 */
+		return 0;
+	}
 
 #if defined(CONFIG_BT_DEVICE_NAME_DYNAMIC)
 	if (bt_dev.name[0] == '\0') {


### PR DESCRIPTION
Before this change, enabling CONFIG_BT_SETTINGS and calling
settings_load(), but delaying / not calling bt_enable would trigger an
assertion error due to a timeout. The fault is that the settings load
handler for the Bluetooth host assumes bt_enable has already been called
and sends HCI commands to the controller. This times out if HCI is not
running.

The fix is to skip loading Bluetooth settings before bt_enable. The doc
is updated to guide the user on how to enable Bluetooth after settings
have been loaded before.

Fixes #39317.

Signed-off-by: Aleksander Wasaznik <aleksander.wasaznik@nordicsemi.no>