### PR TITLE
ci: use concurrency group feature to automatically cancel

### DIFF
--- a/.github/workflows/bluetooth.yaml
+++ b/.github/workflows/bluetooth.yaml
@@ -11,16 +11,8 @@ on:
       - "arch/posix/**"
 
 jobs:
-  bluetooth-test-prep:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
   bluetooth-test-build:
     runs-on: ubuntu-latest
-    needs: bluetooth-test-prep
     container:
       image: zephyrprojectrtos/ci:v0.21.0
       options: '--entrypoint /bin/bash'
@@ -32,6 +24,10 @@ jobs:
       BSIM_COMPONENTS_PATH: /opt/bsim/components
       EDTT_PATH: ../tools/edtt
       bsim_bt_test_results_file: ./bsim_bt_out/bsim_results.xml
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
     steps:
       - name: Update PATH for west
         run: |

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -3,16 +3,8 @@ name: Build with Clang/LLVM
 on: pull_request_target
 
 jobs:
-  clang-build-prep:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
   clang-build:
     runs-on: zephyr_runner
-    needs: clang-build-prep
     container:
       image: zephyrprojectrtos/ci:v0.21.0
       options: '--entrypoint /bin/bash'
@@ -29,6 +21,10 @@ jobs:
       BASE_REF: ${{ github.base_ref }}
     outputs:
       report_needed: ${{ steps.twister.outputs.report_needed }}
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
     steps:
       - name: Cleanup
         run: |

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -5,15 +5,6 @@ on:
     - cron: '25 */3 * * 1-5'
 
 jobs:
-  codecov-prep:
-    runs-on: ubuntu-latest
-    if: github.repository == 'zephyrproject-rtos/zephyr'
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
-
   codecov:
     runs-on: zephyr_runner
     needs: codecov-prep
@@ -27,6 +18,10 @@ jobs:
     env:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.13.2
       CLANG_ROOT_DIR: /usr/lib/llvm-12
+    concurrency:
+      group: ${{ github.workflow }}
+      cancel-in-progress: true
+
     steps:
       - name: Update PATH for west
         run: |

--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -14,18 +14,9 @@ on:
       - 'v*'
 
 jobs:
-  footprint-tracking-cancel:
-    runs-on: ubuntu-latest
-    if: github.repository == 'zephyrproject-rtos/zephyr'
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
   footprint-tracking:
     runs-on: ubuntu-latest
     if: github.repository == 'zephyrproject-rtos/zephyr'
-    needs: footprint-tracking-cancel
     container:
       image: zephyrprojectrtos/ci:v0.21.0
       options: '--entrypoint /bin/bash'
@@ -35,6 +26,9 @@ jobs:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.13.2
       CLANG_ROOT_DIR: /usr/lib/llvm-12
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.run_id }}
+      cancel-in-progress: true
     steps:
       - name: Update PATH for west
         run: |

--- a/.github/workflows/footprint.yml
+++ b/.github/workflows/footprint.yml
@@ -3,18 +3,9 @@ name: Footprint Delta
 on: pull_request
 
 jobs:
-  footprint-cancel:
-    runs-on: ubuntu-latest
-    if: github.repository == 'zephyrproject-rtos/zephyr'
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
   footprint-delta:
     runs-on: ubuntu-latest
     if: github.repository == 'zephyrproject-rtos/zephyr'
-    needs: footprint-cancel
     container:
       image: zephyrprojectrtos/ci:v0.21.0
       options: '--entrypoint /bin/bash'
@@ -24,11 +15,11 @@ jobs:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.13.2
       CLANG_ROOT_DIR: /usr/lib/llvm-12
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
       - name: Update PATH for west
         run: |
           echo "$HOME/.local/bin" >> $GITHUB_PATH

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -12,18 +12,9 @@ on:
     - cron: '0 0 * * 6'
 
 jobs:
-  twister-build-cleanup:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
-
   twister-build-prep:
 
     runs-on: zephyr_runner
-    needs: twister-build-cleanup
     container:
       image: zephyrprojectrtos/ci:v0.21.0
       options: '--entrypoint /bin/bash'
@@ -41,6 +32,10 @@ jobs:
       TESTS_PER_BUILDER: 700
       COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
       BASE_REF: ${{ github.base_ref }}
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+      cancel-in-progress: true
+
     steps:
       - name: Cleanup
         run: |


### PR DESCRIPTION
Concurrency groups can be used to automatically cancel builds. Since
this is a native feature, there is no need to use external actions.

Jobs that run on pull requests use the github.ref variable, so that
cancel happens at PR level. Jobs that run on both pull requests or
scheduled/push events combine github.ref with github.run_id to work on
both cases. Workflows running on events/push only just use the workflow
name so that next events supersede the previous one.

Ref. https://docs.github.com/en/actions/using-jobs/using-concurrency