### PR TITLE
ci: disable cbprintf tag filtering

### DIFF
--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -61,7 +61,7 @@ posix:
     files:
         - lib/posix
 
-cbprintf:
-    files:
-        - lib/os/cbprintf*
-        - lib/posix
+# cbprintf:
+#    files:
+#        - lib/os/cbprintf*
+#        - lib/posix


### PR DESCRIPTION
Need a better way or tagging for this area, we have been introducing
regressions that were undetected due to those filters.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
