### PR TITLE
include: sys: util_macro FIX BIT_MASK(32)

### DIFF
--- a/include/sys/util_macro.h
+++ b/include/sys/util_macro.h
@@ -65,7 +65,7 @@ extern "C" {
  * @brief Bit mask with bits 0 through <tt>n-1</tt> (inclusive) set,
  * or 0 if @p n is 0.
  */
-#define BIT_MASK(n) (BIT(n) - 1UL)
+#define BIT_MASK(n) (BIT64(n) - 1UL)
 
 /**
  * @brief 64-bit bit mask with bits 0 through <tt>n-1</tt> (inclusive) set,


### PR DESCRIPTION
When using BIT_MASK(32) on a arm 32bits processor, the macro
generate a warning:

warning: left shift count >= width of type [-Wshift-count-overflow]
44 | #define BIT(n) (1UL << (n))

To generate a bit mask we set the n bit to 1 and then do minus -1.
So we need an intermediate 33 bits variable to have a 32 bit mask.

fixes #42163

Signed-off-by: Julien Massot <julien.massot@iot.bzh>