### PR TITLE
tests: logging: log_api: Skip message dropping test for SMP

### DIFF
--- a/subsys/testsuite/ztest/include/ztest_test_new.h
+++ b/subsys/testsuite/ztest/include/ztest_test_new.h
@@ -103,14 +103,15 @@ extern struct ztest_suite_node _ztest_suite_node_list_end[];
  * @param after_fn The function to call after each unit test in this suite
  * @param teardown_fn The function to call after running all the tests in this suite
  */
-#define ZTEST_SUITE(SUITE_NAME, PREDICATE, setup_fn, before_fn, after_fn, teardown_fn)		\
-	static STRUCT_SECTION_ITERABLE(ztest_suite_node, z_ztest_test_node_ ## SUITE_NAME) = {	\
-		.name = STRINGIFY(SUITE_NAME),							\
-		.setup = (setup_fn),								\
-		.before = (before_fn),								\
-		.after = (after_fn),								\
-		.teardown = (teardown_fn),							\
-		.predicate = PREDICATE,								\
+#define ZTEST_SUITE(SUITE_NAME, PREDICATE, setup_fn, before_fn, after_fn, teardown_fn)	\
+	static STRUCT_SECTION_ITERABLE(ztest_suite_node,				\
+				       UTIL_CAT(z_ztest_test_node_, SUITE_NAME)) = {	\
+		.name = STRINGIFY(SUITE_NAME),						\
+		.setup = (setup_fn),							\
+		.before = (before_fn),							\
+		.after = (after_fn),							\
+		.teardown = (teardown_fn),						\
+		.predicate = PREDICATE,							\
 	}
 
 /**

--- a/tests/subsys/logging/log_api/src/test.inc
+++ b/tests/subsys/logging/log_api/src/test.inc
@@ -703,15 +703,27 @@ static void log_api_suite_before(void *data)
 	mock_log_backend_check_enable(&backend2);
 }
 
+static void log_api_suite_before_1cpu(void *data)
+{
+	ztest_simple_1cpu_before(data);
+	log_api_suite_before(data);
+}
+
 static void log_api_suite_after(void *data)
 {
-
 	ARG_UNUSED(data);
+
 	/* Disable testing backends after the test. Otherwise test may fail due
 	 * to unexpected log message.
 	 */
 	mock_log_backend_check_disable(&backend1);
 	mock_log_backend_check_disable(&backend2);
+}
+
+static void log_api_suite_after_1cpu(void *data)
+{
+	log_api_suite_after(data);
+	ztest_simple_1cpu_after(data);
 }
 
 #if __cplusplus
@@ -731,6 +743,10 @@ static void log_api_suite_after(void *data)
 ZTEST_SUITE(SUFFIXED_NAME(test_log_api), NULL, log_api_suite_setup,
 	    log_api_suite_before, log_api_suite_after, log_api_suite_teardown);
 
+/* Suite dedicated for tests that need to run on 1 cpu only. */
+ZTEST_SUITE(SUFFIXED_NAME(test_log_api_1cpu), NULL, log_api_suite_setup,
+	    log_api_suite_before_1cpu, log_api_suite_after_1cpu, log_api_suite_teardown);
+
 WRAP_TEST(test_log_various_messages, test_log_api)
 WRAP_TEST(test_log_backend_runtime_filtering, test_log_api)
 WRAP_TEST(test_log_overflow, test_log_api)
@@ -738,4 +754,8 @@ WRAP_TEST(test_log_arguments, test_log_api)
 WRAP_TEST(test_log_from_declared_module, test_log_api)
 WRAP_TEST(test_log_panic, test_log_api)
 WRAP_TEST(test_log_printk, test_log_api)
-WRAP_TEST(test_log_msg_dropped_notification, test_log_api)
+
+/* With multiple cpus you may not get consistent message dropping
+ * as other core may process logs. Executing on 1 cpu only.
+ */
+WRAP_TEST(test_log_msg_dropped_notification, test_log_api_1cpu)

--- a/tests/subsys/logging/log_api/src/test.inc
+++ b/tests/subsys/logging/log_api/src/test.inc
@@ -714,26 +714,28 @@ static void log_api_suite_after(void *data)
 	mock_log_backend_check_disable(&backend2);
 }
 
-#define WRAP_TEST(test_name, suffix)                       \
-	ZTEST(UTIL_CAT(test_log_api_, suffix), UTIL_CAT(test_name, UTIL_CAT(_,suffix))) \
-	{                                                  \
-		test_name();                               \
-	}
-
 #if __cplusplus
 #define TEST_SUFFIX cxx
 #else
 #define TEST_SUFFIX cc
 #endif
-#define TEST_SUITE_NAME UTIL_CAT(test_log_api_, TEST_SUFFIX)
 
-ZTEST_SUITE(TEST_SUITE_NAME, NULL, log_api_suite_setup,
+#define SUFFIXED_NAME(_name) UTIL_CAT(_name, UTIL_CAT(_, TEST_SUFFIX))
+
+#define WRAP_TEST(test_name, suite_name)                   \
+	ZTEST(SUFFIXED_NAME(suite_name), SUFFIXED_NAME(test_name)) \
+	{                                                  \
+		test_name();                               \
+	}
+
+ZTEST_SUITE(SUFFIXED_NAME(test_log_api), NULL, log_api_suite_setup,
 	    log_api_suite_before, log_api_suite_after, log_api_suite_teardown);
-WRAP_TEST(test_log_various_messages, TEST_SUFFIX)
-WRAP_TEST(test_log_backend_runtime_filtering, TEST_SUFFIX)
-WRAP_TEST(test_log_overflow, TEST_SUFFIX)
-WRAP_TEST(test_log_arguments, TEST_SUFFIX)
-WRAP_TEST(test_log_from_declared_module, TEST_SUFFIX)
-WRAP_TEST(test_log_msg_dropped_notification, TEST_SUFFIX)
-WRAP_TEST(test_log_panic, TEST_SUFFIX)
-WRAP_TEST(test_log_printk, TEST_SUFFIX)
+
+WRAP_TEST(test_log_various_messages, test_log_api)
+WRAP_TEST(test_log_backend_runtime_filtering, test_log_api)
+WRAP_TEST(test_log_overflow, test_log_api)
+WRAP_TEST(test_log_arguments, test_log_api)
+WRAP_TEST(test_log_from_declared_module, test_log_api)
+WRAP_TEST(test_log_panic, test_log_api)
+WRAP_TEST(test_log_printk, test_log_api)
+WRAP_TEST(test_log_msg_dropped_notification, test_log_api)


### PR DESCRIPTION
When SMP is used other core may process logging and we won't
get expected number of dropped messages. Skipping test when
SMP is enabled.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>