### PR TITLE
samples: grove_display: Exclude ip_k66f from sample build

### DIFF
--- a/samples/subsys/display/grove_display/sample.yaml
+++ b/samples/subsys/display/grove_display/sample.yaml
@@ -5,3 +5,4 @@ tests:
     tags: drivers
     harness: grove
     depends_on: i2c
+    platform_exclude: ip_k66f


### PR DESCRIPTION
The ip_k66f doesn't have I2C_0 status set to OKAY so the build of
this sample generates warnings in the nightly build. Root problem
is that the groove display is not ported to the device tree so
there isn't a standard way of filtering on the display being
part of the platform.

fixes #41523

Signed-off-by: David Leach <david.leach@nxp.com>