### PR TITLE
subsys/pm: C99-legalize declaration of CPU power states

### DIFF
--- a/subsys/pm/state.c
+++ b/subsys/pm/state.c
@@ -40,11 +40,17 @@ BUILD_ASSERT(DT_NODE_EXISTS(DT_PATH(cpus)),
 DT_FOREACH_CHILD(DT_PATH(cpus), CHECK_POWER_STATES_CONSISTENCY)
 
 #define NUM_CPU_STATES(n) DT_NUM_CPU_POWER_STATES(n),
-#define CPU_STATES(n) (struct pm_state_info[])PM_STATE_INFO_LIST_FROM_DT_CPU(n),
+
+#define DEFINE_CPU_STATES(n) \
+	static const struct pm_state_info pmstates_##n[] \
+		= PM_STATE_INFO_LIST_FROM_DT_CPU(n);
+#define CPU_STATE_REF(n) pmstates_##n,
+
+DT_FOREACH_CHILD(DT_PATH(cpus), DEFINE_CPU_STATES);
 
 /** CPU power states information for each CPU */
 static const struct pm_state_info *cpus_states[] = {
-	DT_FOREACH_CHILD(DT_PATH(cpus), CPU_STATES)
+	DT_FOREACH_CHILD(DT_PATH(cpus), CPU_STATE_REF)
 };
 
 /** Number of states for each CPU */


### PR DESCRIPTION
The CPU power states were declared with a typecast array literal,
which is a GNU extension.

Unfortunately some compilers (xt-xcc even in very recent versions,
when used with -fdata-sections) will die with a compiler error when
those rvalues are used in an expression that also takes their address,
e.g.:

    /* this all by itself crashes xcc -fdata-sections */
    int *foo = (int[]){0};

Declare the array elments in two steps, making the code standard C.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>