### PR TITLE
drivers: can: m_can: fix reconfiguring bitrate

### DIFF
--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -193,6 +193,9 @@ int can_mcan_set_timing(const struct can_mcan_config *cfg,
 		return -EIO;
 	}
 
+	/* Configuration Change Enable */
+	can->cccr |= CAN_MCAN_CCCR_CCE;
+
 	can_mcan_configure_timing(can, timing, timing_data);
 
 	ret = can_leave_init_mode(can, K_MSEC(CAN_INIT_TIMEOUT));


### PR DESCRIPTION
Previously, if an application tried to change the CAN bitrate with `can_set_bitrate()` it would return success, but the bitrate wouldn't change.

The issue is that we were putting the CAN peripheral into init mode, but we also need to set the CCE (Configuration Change Enable) bit in order to make the bit timing registers writable.

The CCE bit is automatically cleared when the part is taken out of init mode.

This fix applies to all CAN devices which use the m_can drivers.