### PR TITLE
ethernet: w5500: recover w5500 driver from missed interrupt

### DIFF
--- a/drivers/ethernet/Kconfig.w5500
+++ b/drivers/ethernet/Kconfig.w5500
@@ -35,3 +35,13 @@ config ETH_W5500_TIMEOUT
 	  Given timeout in milliseconds. Maximum amount of time
 	  that the driver will wait from the IP stack to get
 	  a memory buffer before the Ethernet frame is dropped.
+
+config ETH_W5500_INT_TIMEOUT
+	int "Interrupt gpio timeout"
+	depends on ETH_W5500
+	default 100
+	help
+	  Maximum amount of time in milliseconds that the driver
+		will wait for an interrupt before manually checking
+		for incoming data. This adjusts how long before the driver
+		will recover from a missed interrupt.

--- a/drivers/ethernet/eth_w5500_priv.h
+++ b/drivers/ethernet/eth_w5500_priv.h
@@ -83,6 +83,7 @@ struct w5500_config {
 	void (*config_func)(void);
 	uint8_t full_duplex;
 	int32_t timeout;
+	int32_t int_timeout;
 };
 
 struct w5500_runtime {


### PR DESCRIPTION
The W5500 driver will hang if a RX data interrupt is missed. This
occurs when the ethernet module is under heavy load like a flood
ping. This fix sets up the driver to timeout after some period
and manually check if the interrupt pin is active. The timeout
is configurable by setting `ETH_W5500_INT_TIMEOUT` since there is
a tradeoff between driver overhead and max incoming latency.

See similar issue and resolution at https://github.com/espressif/esp-idf/issues/6233. 

The issue has been verified and the fix tested on an nRF52840 by using flood ping. 


Signed-off-by: Jaremy J. Creechley <jaremy.creechley@panthalassa.com>