### PR TITLE
Bluetooth: Opt ram for smp_null

### DIFF
--- a/include/linker/common-rom.ld
+++ b/include/linker/common-rom.ld
@@ -111,6 +111,8 @@
 
 	ITERABLE_SECTION_ROM(bt_l2cap_fixed_chan, 4)
 
+	ITERABLE_SECTION_ROM(bt_l2cap_monitor, 4)
+
 #if defined(CONFIG_BT_BREDR)
 	ITERABLE_SECTION_ROM(bt_l2cap_br_fixed_chan, 4)
 #endif

--- a/soc/xtensa/esp32/linker.ld
+++ b/soc/xtensa/esp32/linker.ld
@@ -157,6 +157,8 @@ SECTIONS
 
     Z_LINK_ITERABLE_ALIGNED(bt_l2cap_fixed_chan, 4);
 
+    Z_LINK_ITERABLE_ALIGNED(bt_l2cap_monitor, 4)
+
 #if defined(CONFIG_BT_BREDR)
     Z_LINK_ITERABLE_ALIGNED(bt_l2cap_br_fixed_chan, 4);
 #endif

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -2446,6 +2446,12 @@ void bt_l2cap_recv(struct bt_conn *conn, struct net_buf *buf, bool complete)
 
 	BT_DBG("Packet for CID %u len %u", cid, buf->len);
 
+	STRUCT_SECTION_FOREACH(bt_l2cap_monitor, mon) {
+		if (mon->cid == cid) {
+			mon->recv(conn, buf);
+		}
+	}
+
 	chan = bt_l2cap_le_lookup_rx_cid(conn, cid);
 	if (!chan) {
 		BT_WARN("Ignoring data for unknown channel ID 0x%04x", cid);

--- a/subsys/bluetooth/host/l2cap_internal.h
+++ b/subsys/bluetooth/host/l2cap_internal.h
@@ -252,6 +252,14 @@ struct bt_l2cap_br_fixed_chan {
 				.accept = _accept,		\
 			}
 
+struct bt_l2cap_monitor {
+	uint16_t cid;
+	void (*recv)(struct bt_conn *conn, struct net_buf *buf);
+};
+
+#define BT_L2CAP_CHANNEL_MONITOR(_name)				\
+	const STRUCT_SECTION_ITERABLE(bt_l2cap_monitor, _name)
+
 /* Notify L2CAP channels of a new connection */
 void bt_l2cap_connected(struct bt_conn *conn);
 


### PR DESCRIPTION
**Before:**
``` 
│   └── smp_null.c                           232  0.73%
│       └── bt_smp_pool                      232  0.73%
```
**After:**
```
│   └── smp_null.c                           0    0.00%
│       └── bt_smp_pool                      0    0.00%
```

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>