### PR TITLE
boards: riscv: longan_nano: Add BOARD definition

### DIFF
--- a/boards/riscv/longan_nano/longan_nano_defconfig
+++ b/boards/riscv/longan_nano/longan_nano_defconfig
@@ -3,19 +3,16 @@
 # Copyright (c) 2021 Tokita, Hiroshi <tokita.hiroshi@gmail.com>
 #
 # SPDX-License-Identifier: Apache-2.0
-#
 
 CONFIG_SOC_SERIES_GD32VF103=y
 CONFIG_SOC_GD32VF103=y
-CONFIG_GD32_HXTAL_8MHZ=y
+CONFIG_BOARD_LONGAN_NANO=y
 
-# enable machine timer
+CONFIG_GD32_HXTAL_8MHZ=y
 CONFIG_RISCV_MACHINE_TIMER=y
 
-# enable uart driver
 CONFIG_SERIAL=y
 CONFIG_UART_INTERRUPT_DRIVEN=y
 
-# enable console
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y

--- a/boards/riscv/longan_nano/longan_nano_lite_defconfig
+++ b/boards/riscv/longan_nano/longan_nano_lite_defconfig
@@ -3,19 +3,16 @@
 # Copyright (c) 2021 Tokita, Hiroshi <tokita.hiroshi@gmail.com>
 #
 # SPDX-License-Identifier: Apache-2.0
-#
 
 CONFIG_SOC_SERIES_GD32VF103=y
 CONFIG_SOC_GD32VF103=y
-CONFIG_GD32_HXTAL_8MHZ=y
+CONFIG_BOARD_LONGAN_NANO_LITE=y
 
-# enable machine timer
+CONFIG_GD32_HXTAL_8MHZ=y
 CONFIG_RISCV_MACHINE_TIMER=y
 
-# enable uart driver
 CONFIG_SERIAL=y
 CONFIG_UART_INTERRUPT_DRIVEN=y
 
-# enable console
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y


### PR DESCRIPTION
This is a small bug fix.
The longan board's BOARD~ definition is not defined, Adding it.

Define missing definition BOARD_LONGAN_NANO to defconfig.
And cleaning up some verbose comments.

Signed-off-by: TOKITA Hiroshi <tokita.hiroshi@gmail.com>