### PR TITLE
drivers: can: fix CAN frame priority inversion

### DIFF
--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -320,7 +320,8 @@ int can_mcan_init(const struct device *dev, const struct can_mcan_config *cfg,
 	can->txefc = (((uint32_t)msg_ram->tx_event_fifo - mrba) & CAN_MCAN_TXEFC_EFSA_MSK) |
 		(ARRAY_SIZE(msg_ram->tx_event_fifo) << CAN_MCAN_TXEFC_EFS_POS);
 	can->txbc = (((uint32_t)msg_ram->tx_buffer - mrba) & CAN_MCAN_TXBC_TBSA) |
-		(ARRAY_SIZE(msg_ram->tx_buffer) << CAN_MCAN_TXBC_TFQS_POS);
+		(ARRAY_SIZE(msg_ram->tx_buffer) << CAN_MCAN_TXBC_TFQS_POS) |
+		CAN_MCAN_TXBC_TFQM;
 
 	if (sizeof(msg_ram->tx_buffer[0].data) <= 24) {
 		can->txesc = (sizeof(msg_ram->tx_buffer[0].data) - 8) / 4;

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -839,15 +839,18 @@ static int mcp2515_init(const struct device *dev)
 {
 	const struct mcp2515_config *dev_cfg = dev->config;
 	struct mcp2515_data *dev_data = dev->data;
-	int ret;
 	struct can_timing timing;
+	int ret;
+	int i;
 
 	k_sem_init(&dev_data->int_sem, 0, 1);
 	k_mutex_init(&dev_data->mutex);
 	k_sem_init(&dev_data->tx_sem, MCP2515_TX_CNT, MCP2515_TX_CNT);
-	k_sem_init(&dev_data->tx_cb[0].sem, 0, 1);
-	k_sem_init(&dev_data->tx_cb[1].sem, 0, 1);
-	k_sem_init(&dev_data->tx_cb[2].sem, 0, 1);
+
+	for (i = 0; i < MCP2515_TX_CNT; i++) {
+		k_sem_init(&dev_data->tx_cb[i].sem, 0, 1);
+		dev_data->tx_cb[i].cb = NULL;
+	}
 
 	if (!spi_is_ready(&dev_cfg->bus)) {
 		LOG_ERR("SPI bus %s not ready", dev_cfg->bus.bus->name);
@@ -934,9 +937,6 @@ static K_KERNEL_STACK_DEFINE(mcp2515_int_thread_stack,
 
 static struct mcp2515_data mcp2515_data_1 = {
 	.int_thread_stack = mcp2515_int_thread_stack,
-	.tx_cb[0].cb = NULL,
-	.tx_cb[1].cb = NULL,
-	.tx_cb[2].cb = NULL,
 	.tx_busy_map = 0U,
 	.filter_usage = 0U,
 };

--- a/drivers/can/can_mcp2515.h
+++ b/drivers/can/can_mcp2515.h
@@ -11,7 +11,8 @@
 #include <drivers/can.h>
 
 #define MCP2515_RX_CNT                   2
-#define MCP2515_TX_CNT                   3
+/* Reduce the number of Tx buffers to 1 in order to avoid priority inversion. */
+#define MCP2515_TX_CNT                   1
 #define MCP2515_FRAME_LEN               13
 
 struct mcp2515_tx_cb {

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -52,8 +52,6 @@ LOG_MODULE_REGISTER(can_mcux_flexcan);
 	(FSL_FEATURE_FLEXCAN_HAS_MESSAGE_BUFFER_MAX_NUMBERn(0) \
 	- MCUX_FLEXCAN_MAX_RX)
 
-#define MCUX_N_TX_ALLOC_ELEM (1 + (MCUX_FLEXCAN_MAX_TX - 1) / ATOMIC_BITS)
-
 /*
  * Convert from RX message buffer index to allocated filter ID and
  * vice versa.
@@ -277,45 +275,6 @@ static void mcux_flexcan_copy_zfilter_to_mbconfig(const struct zcan_filter *src,
 	}
 }
 
-/* mcux_get_tx_alloc is a linear on array, and binary on atomic_val_t search
- * for the highest bit set in data->tx_allocs. 0 is returned in case of an empty
- * tx_alloc, the next free bit otherwise.
- * The reason to always use a higher buffer number than the current in use is
- * that a FIFO manner is kept. The Controller would otherwise send the frame
- * that is in the lowest buffer number first.
- */
-static int mcux_get_tx_alloc(struct mcux_flexcan_data *data)
-{
-	atomic_val_t *allocs = data->tx_allocs;
-	atomic_val_t pivot = ATOMIC_BITS / 2;
-	atomic_val_t alloc, mask;
-	int i;
-
-	for (i = MCUX_N_TX_ALLOC_ELEM - 1; i >= 0; i--) {
-		alloc = allocs[i];
-		if (alloc) {
-			for (atomic_val_t bits = ATOMIC_BITS / 2U;
-			    bits; bits >>= 1) {
-				mask = GENMASK(pivot + bits - 1, pivot);
-				if (alloc & mask) {
-					pivot += bits / 2U;
-				} else {
-					pivot -= bits / 2U;
-				}
-			}
-
-			if (!(alloc & mask)) {
-				pivot--;
-			}
-
-			break;
-		}
-	}
-
-	alloc = alloc ? (pivot + 1 + i * ATOMIC_BITS) : 0;
-	return alloc >= MCUX_FLEXCAN_MAX_TX ? -1 : alloc;
-}
-
 static int mcux_flexcan_get_state(const struct device *dev, enum can_state *state,
 				  struct can_bus_err_cnt *err_cnt)
 {
@@ -368,18 +327,13 @@ static int mcux_flexcan_send(const struct device *dev,
 		return -ENETDOWN;
 	}
 
-	while (true) {
-		alloc = mcux_get_tx_alloc(data);
-		if (alloc >= 0) {
-			if (atomic_test_and_set_bit(data->tx_allocs, alloc)) {
-				continue;
-			}
+	if (k_sem_take(&data->tx_allocs_sem, timeout) != 0) {
+		return -EAGAIN;
+	}
 
+	for (alloc = 0; alloc < MCUX_FLEXCAN_MAX_TX; alloc++) {
+		if (!atomic_test_and_set_bit(data->tx_allocs, alloc)) {
 			break;
-		}
-
-		if (k_sem_take(&data->tx_allocs_sem, timeout) != 0) {
-			return -EAGAIN;
 		}
 	}
 
@@ -711,7 +665,8 @@ static int mcux_flexcan_init(const struct device *dev)
 	int i;
 
 	k_mutex_init(&data->rx_mutex);
-	k_sem_init(&data->tx_allocs_sem, 0, 1);
+	k_sem_init(&data->tx_allocs_sem, MCUX_FLEXCAN_MAX_TX,
+		   MCUX_FLEXCAN_MAX_TX);
 
 	for (i = 0; i < ARRAY_SIZE(data->tx_cbs); i++) {
 		k_sem_init(&data->tx_cbs[i].done, 0, 1);

--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -481,11 +481,8 @@ static int can_stm32_init(const struct device *dev)
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(can2), okay)
 	master_can->FMR &= ~CAN_FMR_CAN2SB; /* Assign all filters to CAN2 */
 #endif
-
-	/* Set TX priority to chronological order */
-	can->MCR |= CAN_MCR_TXFP;
 	can->MCR &= ~CAN_MCR_TTCM & ~CAN_MCR_ABOM & ~CAN_MCR_AWUM &
-		    ~CAN_MCR_NART & ~CAN_MCR_RFLM;
+		    ~CAN_MCR_NART & ~CAN_MCR_RFLM & ~CAN_MCR_TXFP;
 #ifdef CONFIG_CAN_RX_TIMESTAMP
 	can->MCR |= CAN_MCR_TTCM;
 #endif

--- a/include/canbus/isotp.h
+++ b/include/canbus/isotp.h
@@ -391,6 +391,7 @@ struct isotp_send_ctx {
 	struct isotp_fc_opts opts;
 	uint8_t state;
 	uint8_t tx_backlog;
+	struct k_sem tx_sem;
 	struct isotp_msg_id rx_addr;
 	struct isotp_msg_id tx_addr;
 	uint8_t wft;

--- a/include/drivers/can.h
+++ b/include/drivers/can.h
@@ -597,10 +597,24 @@ static inline int can_set_bitrate(const struct device *dev,
  */
 
 /**
- * @brief Transmit a CAN frame on the CAN bus
+ * @brief Queue a CAN frame for transmission on the CAN bus
  *
- * Transmit a CAN frame on the CAN bus with optional timeout and completion
- * callback function.
+ * Queue a CAN frame for transmission on the CAN bus with optional timeout and
+ * completion callback function.
+ *
+ * Queued CAN frames are transmitted in order according to the their priority:
+ * - The lower the CAN-ID, the higher the priority.
+ * - Data frames have higher priority than Remote Transmission Request (RTR)
+ *   frames with identical CAN-IDs.
+ * - Frames with standard (11-bit) identifiers have higher priority than frames
+ *   with extended (29-bit) identifiers with identical base IDs (the higher 11
+ *   bits of the extended identifier).
+ * - Transmission order for queued frames with the same priority is hardware
+ *   dependent.
+ *
+ * @note If transmitting segmented messages spanning multiple CAN frames with
+ * identical CAN-IDs, the sender must ensure to only queue one frame at a time
+ * if FIFO order is required.
  *
  * By default, the CAN controller will automatically retry transmission in case
  * of lost bus arbitration or missing acknowledge. Some CAN controllers support


### PR DESCRIPTION
Fix the CAN drivers to not transmit frames in FIFO/chronological order but rather respect the priority specified by the CAN ID of the frame.

For now, this change has been verified for the following drivers:
- NXP FlexCAN (`twr_ke18f`, `mimxrt1024_evk`).
- Bosch M_CAN (`lpcxpresso55s16`).
- STM32 bxCAN (`stm32f3_disco`).
- Microchip MPC2515

Drivers yet to be fixed:
- Renesas R-Car CAN (I do not have access to the hardware for testing).

The driver changes require changes to some of the higher level in-tree CAN protocols with respect to segmented messages:
- ISO-TP (verified using `tests/subsys/canbus/isotp/implementation`, `tests/subsys/canbus/isotp/conformance`, and `samples/subsys/canbus/isotp` between two boards).
- 6LoCAN (will likely need something along the changes to ISO-TP, but I am unable to test it since #42559)

The following higher level CAN protocols already handle segmented messages correctly:
- CANopenNode (verified using `samples/modules/canopennode`).

Fixes: #26541

The next logical step is to add a CAN frame software priority queue for use in drivers with a limited amount of TX MBs (such as the MCP2515 after the changes in this PR). I am working on that.