### PR TITLE
drivers/flash: Remove the flash write protection API

### DIFF
--- a/doc/releases/release-notes-3.0.rst
+++ b/doc/releases/release-notes-3.0.rst
@@ -77,6 +77,9 @@ Removed APIs in this release
 * Removed Kconfig option ``CONFIG_OPENOCD_SUPPORT`` in favor of
   ``CONFIG_DEBUG_THREAD_INFO``.
 
+* Removed ``flash_write_protection_set()`` along with the flash write protection
+  implementation handler.
+
 Deprecated in this release
 ==========================
 
@@ -265,6 +268,12 @@ Drivers and Sensors
   * stm32_qspi: General enhancement (Generation of the reset pulse for SPI-NOR memory,
     Usage of 4IO for read / write (4READ/4PP), Support for different QSPI banks,
     Support for 4B addressing on spi-nor)
+
+  * ite_i8xxx2: The driver has been reworked so the write/erase protection
+    management has been moved to implementations of the flash_write()
+    and the flash_erase() calls. The driver was keeping the write protection API
+    which was designed to be removed since 2.6 release.
+
 
 * GPIO
 

--- a/drivers/flash/flash_handlers.c
+++ b/drivers/flash/flash_handlers.c
@@ -28,15 +28,6 @@ static inline int z_vrfy_flash_write(const struct device *dev, off_t offset,
 }
 #include <syscalls/flash_write_mrsh.c>
 
-static inline int z_vrfy_flash_write_protection_set(const struct device *dev,
-						    bool enable)
-{
-	Z_OOPS(Z_SYSCALL_DRIVER_FLASH(dev, write_protection));
-	return z_impl_flash_write_protection_set((const struct device *)dev,
-						 enable);
-}
-#include <syscalls/flash_write_protection_set_mrsh.c>
-
 static inline size_t z_vrfy_flash_get_write_block_size(const struct device *dev)
 {
 	Z_OOPS(Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_FLASH));

--- a/drivers/flash/flash_ite_it8xxx2.c
+++ b/drivers/flash/flash_ite_it8xxx2.c
@@ -34,7 +34,6 @@ extern char _ram_code_start;
 
 struct flash_it8xxx2_dev_data {
 	struct k_sem sem;
-	int all_protected;
 	int flash_static_cache_enabled;
 };
 
@@ -404,6 +403,22 @@ static int __ram_code flash_it8xxx2_read(const struct device *dev, off_t offset,
 	return 0;
 }
 
+/* Enable or disable the write protection */
+static void flash_it8xxx2_write_protection(bool enable)
+{
+	if (enable) {
+		/* Protect the entire flash */
+		flash_protect_banks(0, CHIP_FLASH_SIZE_BYTES /
+			CHIP_FLASH_BANK_SIZE, FLASH_WP_EC);
+	}
+
+	/*
+	 * bit[0], eflash protect lock register which can only be write 1 and
+	 * only be cleared by power-on reset.
+	 */
+	IT83XX_GCTRL_EPLR |= IT83XX_GCTRL_EPLR_ENABLE;
+}
+
 /* Write data to the flash, page by page */
 static int __ram_code flash_it8xxx2_write(const struct device *dev, off_t offset,
 					  const void *src_data, size_t len)
@@ -425,9 +440,6 @@ static int __ram_code flash_it8xxx2_write(const struct device *dev, off_t offset
 	if (data->flash_static_cache_enabled == 0) {
 		return -EACCES;
 	}
-	if (data->all_protected) {
-		return -EACCES;
-	}
 
 	k_sem_take(&data->sem, K_FOREVER);
 	/*
@@ -437,11 +449,15 @@ static int __ram_code flash_it8xxx2_write(const struct device *dev, off_t offset
 	 */
 	key = irq_lock();
 
+	flash_it8xxx2_write_protection(false);
+
 	ramcode_flash_write(offset, len, src_data);
 	ramcode_reset_i_cache();
 	/* Get the ILM address of a flash offset. */
 	offset |= CHIP_MAPPED_STORAGE_BASE;
 	ret = ramcode_flash_verify(offset, len, src_data);
+
+	flash_it8xxx2_write_protection(true);
 
 	irq_unlock(key);
 
@@ -471,9 +487,6 @@ static int __ram_code flash_it8xxx2_erase(const struct device *dev,
 	if (data->flash_static_cache_enabled == 0) {
 		return -EACCES;
 	}
-	if (data->all_protected) {
-		return -EACCES;
-	}
 
 	k_sem_take(&data->sem, K_FOREVER);
 	/*
@@ -482,6 +495,8 @@ static int __ram_code flash_it8xxx2_erase(const struct device *dev,
 	 * disabled.
 	 */
 	key = irq_lock();
+
+	flash_it8xxx2_write_protection(false);
 
 	/* Always use sector erase command */
 	for (; len > 0; len -= FLASH_ERASE_BLK_SZ) {
@@ -493,35 +508,13 @@ static int __ram_code flash_it8xxx2_erase(const struct device *dev,
 	v_addr |= CHIP_MAPPED_STORAGE_BASE;
 	ret = ramcode_flash_verify(v_addr, v_size, NULL);
 
+	flash_it8xxx2_write_protection(true);
+
 	irq_unlock(key);
 
 	k_sem_give(&data->sem);
 
 	return ret;
-}
-
-/* Enable or disable the write protection */
-static int flash_it8xxx2_write_protection(const struct device *dev,
-					  bool enable)
-{
-	struct flash_it8xxx2_dev_data *data = dev->data;
-
-	if (enable) {
-		/* Protect the entire flash */
-		flash_protect_banks(0, CHIP_FLASH_SIZE_BYTES /
-			CHIP_FLASH_BANK_SIZE, FLASH_WP_EC);
-		data->all_protected = 1;
-	} else {
-		data->all_protected = 0;
-	}
-
-	/*
-	 * bit[0], eflash protect lock register which can only be write 1 and
-	 * only be cleared by power-on reset.
-	 */
-	IT83XX_GCTRL_EPLR |= IT83XX_GCTRL_EPLR_ENABLE;
-
-	return 0;
 }
 
 static const struct flash_parameters *
@@ -608,7 +601,6 @@ static void flash_it8xxx2_pages_layout(const struct device *dev,
 #endif /* CONFIG_FLASH_PAGE_LAYOUT */
 
 static const struct flash_driver_api flash_it8xxx2_api = {
-	.write_protection = flash_it8xxx2_write_protection,
 	.erase = flash_it8xxx2_erase,
 	.write = flash_it8xxx2_write,
 	.read = flash_it8xxx2_read,

--- a/tests/subsys/fs/multi-fs/src/test_ram_backend.c
+++ b/tests/subsys/fs/multi-fs/src/test_ram_backend.c
@@ -19,12 +19,6 @@ static int test_ram_flash_init(const struct device *dev)
 	return 0;
 }
 
-static int test_flash_ram_write_protection(const struct device *dev,
-					   bool enable)
-{
-	return 0;
-}
-
 static int test_flash_ram_erase(const struct device *dev, off_t offset,
 				size_t len)
 {
@@ -85,7 +79,6 @@ static void test_flash_ram_pages_layout(const struct device *dev,
 }
 
 static const struct flash_driver_api flash_ram_api = {
-	.write_protection = test_flash_ram_write_protection,
 	.erase = test_flash_ram_erase,
 	.write = test_flash_ram_write,
 	.read = test_flash_ram_read,


### PR DESCRIPTION
This API was designed to be removed in Zephyr 2.8

As preparation:
The ite_i8xx3 driver was reworked to serve protection by itself.
In its case the `write_protection` handler was introduced despite that the API had been
already deprecated at the addition time.