### PR TITLE
net: sockets: tls: Fix ZSOCK_POLLHUP detection 

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -1364,6 +1364,10 @@ static int zsock_poll_update_ctx(struct net_context *ctx,
 		(*pev)++;
 	}
 
+	if (sock_is_eof(ctx)) {
+		pfd->revents |= ZSOCK_POLLHUP;
+	}
+
 	return 0;
 }
 

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -2176,8 +2176,6 @@ static int ztls_socket_data_check(struct tls_context *ctx)
 
 		/* Treat any other error as fatal. */
 		return -EIO;
-	} else if (ret == 0 && ctx->type == SOCK_STREAM) {
-		return -ENOTCONN;
 	}
 
 	return mbedtls_ssl_get_bytes_avail(&ctx->ssl);
@@ -2206,7 +2204,7 @@ static int ztls_poll_update_pollin(int fd, struct tls_context *ctx,
 	}
 
 	ret = ztls_socket_data_check(ctx);
-	if (ret == -ENOTCONN) {
+	if (ret == -ENOTCONN || (pfd->revents & ZSOCK_POLLHUP)) {
 		/* Datagram does not return 0 on consecutive recv, but an error
 		 * code, hence clear POLLIN.
 		 */


### PR DESCRIPTION
The previous approach to detect if the underlying transport was closed
(by checking the return value of `mbedtls_ssl_read()` was not right,
since the function call does not request any data - therefore 0 as a
return value is perfectly fine.

Instead, rely on the underlying transport ZSOCK_POLLHUP event - if it
reports that the connection ended, forward the event to the application.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>