### PR TITLE
Bluetooth: Host: Avoid address copy for PA list

### DIFF
--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -1300,6 +1300,7 @@ struct bt_le_per_adv_sync_param {
 	 * @brief Periodic Advertiser Address
 	 *
 	 * Only valid if not using the periodic advertising list
+	 * (BT_LE_PER_ADV_SYNC_OPT_USE_PER_ADV_LIST)
 	 */
 	bt_addr_le_t addr;
 
@@ -1307,6 +1308,7 @@ struct bt_le_per_adv_sync_param {
 	 * @brief Advertiser SID
 	 *
 	 * Only valid if not using the periodic advertising list
+	 * (BT_LE_PER_ADV_SYNC_OPT_USE_PER_ADV_LIST)
 	 */
 	uint8_t sid;
 

--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -1359,14 +1359,19 @@ int bt_le_per_adv_sync_create(const struct bt_le_per_adv_sync_param *param,
 	cp = net_buf_add(buf, sizeof(*cp));
 	(void)memset(cp, 0, sizeof(*cp));
 
-
-	bt_addr_le_copy(&cp->addr, &param->addr);
-
 	if (param->options & BT_LE_PER_ADV_SYNC_OPT_USE_PER_ADV_LIST) {
 		atomic_set_bit(per_adv_sync->flags,
 			       BT_PER_ADV_SYNC_SYNCING_USE_LIST);
 
 		cp->options |= BT_HCI_LE_PER_ADV_CREATE_SYNC_FP_USE_LIST;
+	} else {
+		/* If BT_LE_PER_ADV_SYNC_OPT_USE_PER_ADV_LIST is set, then the
+		 * address and SID are ignored by the controller, so we only
+		 * copy/assign them in case that the periodic advertising list
+		 * is not used.
+		 */
+		bt_addr_le_copy(&cp->addr, &param->addr);
+		cp->sid = param->sid;
 	}
 
 	if (param->options &
@@ -1401,7 +1406,6 @@ int bt_le_per_adv_sync_create(const struct bt_le_per_adv_sync_param *param,
 		cp->cte_type |= BT_HCI_LE_PER_ADV_CREATE_SYNC_CTE_TYPE_ONLY_CTE;
 	}
 
-	cp->sid = param->sid;
 	cp->skip = sys_cpu_to_le16(param->skip);
 	cp->sync_timeout = sys_cpu_to_le16(param->timeout);
 


### PR DESCRIPTION
Avoids copying the address and assigning the SID if the
PA list is used, as the values are ignored by the
controller, and thus there is no reason to copy
or assign the values.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>