### PR TITLE
soc: esp32: Added rodata injection to esp32 build

### DIFF
--- a/soc/xtensa/esp32/linker.ld
+++ b/soc/xtensa/esp32/linker.ld
@@ -199,6 +199,11 @@ SECTIONS
 
     Z_LINK_ITERABLE_ALIGNED(tracing_backend, 4)
 
+    /* Located in generated directory. This file is populated by the
+    * zephyr_linker_sources() Cmake function.
+    */
+    #include <snippets-rodata.ld>
+
     __esp_shell_root_cmds_start = .;
     KEEP(*(SORT(.shell_root_cmd_*)));
     __esp_shell_root_cmds_end = .;


### PR DESCRIPTION
When building for ESP32, the linker scripts were not loaded by zephyr_linker_sources.
This PR fixes that and allows custom linker scripts to be added to the build.

Shoutout to Sylvio on Zephyr discord for the solution.

Signed-off-by: Kamel Makhloufi melka@blaste.net