### PR TITLE
Bluetooth: host: crypto: Add a config to select how random is generated

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -109,16 +109,29 @@ config BT_DRIVER_RX_HIGH_PRIO
 if BT_HCI_HOST
 
 config BT_HOST_CRYPTO
-	# Hidden option that compiles in random number generation and AES
-	# encryption support using TinyCrypt library if this is not provided
-	# by the controller implementation.
+	# Hidden option that compiles in AES encryption support using TinyCrypt
+	# library if this is not provided by the controller implementation.
 	bool
 	default y if !BT_CTLR_CRYPTO
 	select TINYCRYPT
 	select TINYCRYPT_AES
+
+config BT_HOST_CRYPTO_PRNG
+	bool "Use Tinycrypt library for random number generation"
+	default y
 	select TINYCRYPT_SHA256
 	select TINYCRYPT_SHA256_HMAC
 	select TINYCRYPT_SHA256_HMAC_PRNG
+	depends on BT_HOST_CRYPTO
+	help
+	  When selected, will use tinycrypt library for random number generation.
+	  This will consume additional ram, but may speed up the generation of random
+	  numbers.
+
+	  Otherwise, random numbers will be generated through multiple HCI calls,
+	  which will not consume additional resources, but may take a long time,
+	  depending on the length of the random data.
+	  This method is generally recommended within 16 bytes.
 
 config BT_SETTINGS
 	bool "Store Bluetooth state and configuration persistently"

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2656,7 +2656,7 @@ static int common_init(void)
 	read_supported_commands_complete(rsp);
 	net_buf_unref(rsp);
 
-	if (IS_ENABLED(CONFIG_BT_HOST_CRYPTO)) {
+	if (IS_ENABLED(CONFIG_BT_HOST_CRYPTO_PRNG)) {
 		/* Initialize the PRNG so that it is safe to use it later
 		 * on in the initialization process.
 		 */


### PR DESCRIPTION
Considering that in most scenarios, `bt_rand` will not be called frequently, 
but the current implementation of tinycrypt will occupy more than 300 bytes
of RAM space. Its existence is to optimize the frequent call of `bt_rand`. 

Therefore, it is considered to put it into a config(`BT_HOST_CRYPTO_RANDOM`),
when this config has been selected, will use tinycrypt library for random.
Otherwise will call bt random hci command.


Signed-off-by: Lingao Meng <menglingao@xiaomi.com>