### PR TITLE
Bluetooth: Mesh: test secure network beacon interval

### DIFF
--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/tests_scripts/beacon/minimun_beacon_interval.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/tests_scripts/beacon/minimun_beacon_interval.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Copyright 2021 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
+
+RunTest mesh_beacon_time_limit \
+        beacon_tx_beacon_secure \
+        beacon_tx_beacon_secure \
+        beacon_tx_beacon_secure \
+        beacon_tx_beacon_secure \
+        beacon_rx_beacon_secure 


### PR DESCRIPTION
the minimum time between two consecutive secure mesh beacons
should be approximately 10s

Signed-off-by: Alperen Sener <alperen.sener@nordicsemi.no>