### PR TITLE
debug: thread_analyzer: Add option to print ISR stack usage

### DIFF
--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -160,6 +160,9 @@ K_KERNEL_PINNED_STACK_ARRAY_EXTERN(z_interrupt_stacks, CONFIG_MP_NUM_CPUS,
 extern uint8_t *z_priv_stack_find(k_thread_stack_t *stack);
 #endif
 
+/* Calculate stack usage. */
+int z_stack_space_get(const uint8_t *stack_start, size_t size, size_t *unused_ptr);
+
 #ifdef CONFIG_USERSPACE
 bool z_stack_is_user_capable(k_thread_stack_t *stack);
 

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -901,18 +901,15 @@ void irq_offload(irq_offload_routine_t routine, const void *parameter)
 #error "Unsupported configuration for stack analysis"
 #endif
 
-int z_impl_k_thread_stack_space_get(const struct k_thread *thread,
-				    size_t *unused_ptr)
+int z_stack_space_get(const uint8_t *stack_start, size_t size, size_t *unused_ptr)
 {
-	const uint8_t *start = (uint8_t *)thread->stack_info.start;
-	size_t size = thread->stack_info.size;
 	size_t unused = 0;
-	const uint8_t *checked_stack = start;
+	const uint8_t *checked_stack = stack_start;
 	/* Take the address of any local variable as a shallow bound for the
 	 * stack pointer.  Addresses above it are guaranteed to be
 	 * accessible.
 	 */
-	const uint8_t *stack_pointer = (const uint8_t *)&start;
+	const uint8_t *stack_pointer = (const uint8_t *)&stack_start;
 
 	/* If we are currently running on the stack being analyzed, some
 	 * memory management hardware will generate an exception if we
@@ -921,7 +918,7 @@ int z_impl_k_thread_stack_space_get(const struct k_thread *thread,
 	 * This never happens when invoked from user mode, as user mode
 	 * will always run this function on the privilege elevation stack.
 	 */
-	if ((stack_pointer > start) && (stack_pointer <= (start + size)) &&
+	if ((stack_pointer > stack_start) && (stack_pointer <= (stack_start + size)) &&
 	    IS_ENABLED(CONFIG_NO_UNUSED_STACK_INSPECTION)) {
 		/* TODO: We could add an arch_ API call to temporarily
 		 * disable the stack checking in the CPU, but this would
@@ -953,6 +950,13 @@ int z_impl_k_thread_stack_space_get(const struct k_thread *thread,
 	*unused_ptr = unused;
 
 	return 0;
+}
+
+int z_impl_k_thread_stack_space_get(const struct k_thread *thread,
+				    size_t *unused_ptr)
+{
+	return z_stack_space_get((const uint8_t *)thread->stack_info.start,
+				 thread->stack_info.size, unused_ptr);
 }
 
 #ifdef CONFIG_USERSPACE

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -39,6 +39,10 @@ config THREAD_ANALYZER_USE_PRINTK
 
 endchoice
 
+config THREAD_ANALYZER_ISR_STACK_USAGE
+	bool "Analyze interrupt stacks usage"
+	default y
+
 config THREAD_ANALYZER_RUN_UNLOCKED
 	bool "Run analysis with interrupts unlocked"
 	default y

--- a/subsys/debug/thread_analyzer.c
+++ b/subsys/debug/thread_analyzer.c
@@ -9,6 +9,7 @@
  */
 
 #include <kernel.h>
+#include <kernel_internal.h>
 #include <debug/thread_analyzer.h>
 #include <debug/stack.h>
 #include <kernel.h>
@@ -125,12 +126,38 @@ static void thread_analyze_cb(const struct k_thread *cthread, void *user_data)
 	cb(&info);
 }
 
+extern K_KERNEL_STACK_ARRAY_DEFINE(z_interrupt_stacks, CONFIG_MP_NUM_CPUS,
+				   CONFIG_ISR_STACK_SIZE);
+
+static void isr_stacks(void)
+{
+	for (int i = 0; i < CONFIG_MP_NUM_CPUS; i++) {
+		const uint8_t *buf = Z_KERNEL_STACK_BUFFER(z_interrupt_stacks[i]);
+		size_t size = K_KERNEL_STACK_SIZEOF(z_interrupt_stacks[i]);
+		size_t unused;
+		int err;
+
+		err = z_stack_space_get(buf, size, &unused);
+		if (err == 0) {
+			THREAD_ANALYZER_PRINT(
+				THREAD_ANALYZER_FMT(
+					" %s%-17d: STACK: unused %zu usage %zu / %zu (%zu %%)"),
+					THREAD_ANALYZER_VSTR("ISR"), i, unused,
+					size - unused, size, (100 * (size - unused)) / size);
+		}
+	}
+}
+
 void thread_analyzer_run(thread_analyzer_cb cb)
 {
 	if (IS_ENABLED(CONFIG_THREAD_ANALYZER_RUN_UNLOCKED)) {
 		k_thread_foreach_unlocked(thread_analyze_cb, cb);
 	} else {
 		k_thread_foreach(thread_analyze_cb, cb);
+	}
+
+	if (IS_ENABLED(CONFIG_THREAD_ANALYZER_ISR_STACK_USAGE)) {
+		isr_stacks();
 	}
 }
 

--- a/subsys/shell/modules/kernel_service.c
+++ b/subsys/shell/modules/kernel_service.c
@@ -14,6 +14,7 @@
 #include <device.h>
 #include <drivers/timer/system_timer.h>
 #include <kernel.h>
+#include <kernel_internal.h>
 
 static int cmd_kernel_version(const struct shell *shell,
 			      size_t argc, char **argv)
@@ -187,9 +188,6 @@ extern K_KERNEL_STACK_ARRAY_DEFINE(z_interrupt_stacks, CONFIG_MP_NUM_CPUS,
 static int cmd_kernel_stacks(const struct shell *shell,
 			     size_t argc, char **argv)
 {
-	uint8_t *buf;
-	size_t size, unused;
-
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 	k_thread_foreach(shell_stack_dump, (void *)shell);
@@ -199,17 +197,13 @@ static int cmd_kernel_stacks(const struct shell *shell,
 	 * stack buffers.
 	 */
 	for (int i = 0; i < CONFIG_MP_NUM_CPUS; i++) {
-		buf = Z_KERNEL_STACK_BUFFER(z_interrupt_stacks[i]);
-		size = K_KERNEL_STACK_SIZEOF(z_interrupt_stacks[i]);
+		size_t unused;
+		const uint8_t *buf = Z_KERNEL_STACK_BUFFER(z_interrupt_stacks[i]);
+		size_t size = K_KERNEL_STACK_SIZEOF(z_interrupt_stacks[i]);
+		int err = z_stack_space_get(buf, size, &unused);
 
-		unused = 0;
-		for (size_t i = 0; i < size; i++) {
-			if (buf[i] == 0xAAU) {
-				unused++;
-			} else {
-				break;
-			}
-		}
+		(void)err;
+		__ASSERT_NO_MSG(err == 0);
 
 		shell_print(shell,
 			"%p IRQ %02d     (real size %zu):\tunused %zu\tusage %zu / %zu (%zu %%)",


### PR DESCRIPTION
Extracting stack usage calculation from `k_thread_stack_space_get` to `z_stack_space_get` so it can be used also for interrupt stack.

Updated thread analyzer to use it and include information about isr stack(s) usage in the report.
Updated shell kernel_service to use that function as well.