### PR TITLE
pm: Fix state_force functionality

### DIFF
--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -270,12 +270,12 @@ bool pm_system_suspend(int32_t ticks)
 #endif
 	pm_stats_update(z_cpus_pm_state[id].state);
 	pm_system_resume();
+	atomic_clear_bit(z_cpus_pm_state_forced, id);
 	k_sched_unlock();
 	SYS_PORT_TRACING_FUNC_EXIT(pm, system_suspend, ticks,
 				   z_cpus_pm_state[id].state);
 
 end:
-	atomic_clear_bit(z_cpus_pm_state_forced, id);
 	return ret;
 }
 

--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -203,7 +203,7 @@ bool pm_system_suspend(int32_t ticks)
 
 	SYS_PORT_TRACING_FUNC_ENTER(pm, system_suspend, ticks);
 
-	if (!atomic_test_and_set_bit(z_cpus_pm_state_forced, id)) {
+	if (!atomic_test_bit(z_cpus_pm_state_forced, id)) {
 		const struct pm_state_info *info;
 
 		info = pm_policy_next_state(id, ticks);

--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -217,6 +217,7 @@ bool pm_system_suspend(int32_t ticks)
 		SYS_PORT_TRACING_FUNC_EXIT(pm, system_suspend, ticks,
 				   z_cpus_pm_state[id].state);
 		ret = false;
+		atomic_clear_bit(z_cpus_pm_state_forced, id);
 		goto end;
 	}
 
@@ -241,6 +242,7 @@ bool pm_system_suspend(int32_t ticks)
 			SYS_PORT_TRACING_FUNC_EXIT(pm, system_suspend, ticks,
 						   z_cpus_pm_state[id].state);
 			ret = false;
+			atomic_clear_bit(z_cpus_pm_state_forced, id);
 			goto end;
 		}
 	}


### PR DESCRIPTION
The "state forced" flag has to be cleared with the scheduler locked,
otherwise the idle thread can be scheduled out without clear it and
the next call to force a state will fail.

With the forced flag been cleared with the kernel locked in the
suspend path, we need to clear it out when the suspend process fails.

This is mow done before jump to the end label because in the
successful path the flag is already cleared.

Fixes #41911