### PR TITLE
uart: esp32: fix baudrate return value

### DIFF
--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -136,7 +136,7 @@ static int uart_esp32_config_get(const struct device *dev,
 	uart_word_length_t data_bit;
 	uart_hw_flowcontrol_t hw_flow;
 
-	uart_hal_get_baudrate(&data->hal, &cfg->baudrate);
+	cfg->baudrate = data->uart_config.baudrate;
 
 	uart_hal_get_parity(&data->hal, &parity);
 	switch (parity) {


### PR DESCRIPTION
HAL call used to retrieve configured baudrate
returns the real calculated value, which might not be exactly as
the confgiured. For baudrate of 115200, hal api
returns 115201, which then causes uart_basic_api test
to fail. Instead of returning the calculated baudrate value,
returns the configured one.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>