### PR TITLE
soc: riscv: sifive-freedom: Specify clocks in CPU DTS and allow custom FE310 CPU clock rate.

### DIFF
--- a/boards/riscv/hifive1/hifive1.dts
+++ b/boards/riscv/hifive1/hifive1.dts
@@ -46,18 +46,12 @@
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;
-	clock-frequency = <16000000>;
 	pinctrl-0 = <&uart0_rx_default &uart0_tx_default>;
 	pinctrl-names = "default";
 };
 
-&uart1 {
-	clock-frequency = <16000000>;
-};
-
 &spi0 {
 	status = "okay";
-	clock-frequency = <16000000>;
 
 	reg = <0x10014000 0x1000 0x20400000 0xc00000>;
 	flash0: flash@0 {
@@ -72,7 +66,6 @@
 
 &spi1 {
 	status = "okay";
-	clock-frequency = <16000000>;
 	pinctrl-0 = <&spi1_cs0_default &spi1_cs2_default &spi1_cs3_default
 		     &spi1_mosi_default &spi1_miso_default &spi1_sck_default>;
 	pinctrl-names = "default";
@@ -80,24 +73,20 @@
 
 &spi2 {
 	status = "okay";
-	clock-frequency = <16000000>;
 };
 
 &pwm0 {
 	status = "okay";
-	clock-frequency = <16000000>;
 };
 
 &pwm1 {
 	status = "okay";
-	clock-frequency = <16000000>;
 	pinctrl-0 = <&pwm1_1_default &pwm1_2_default &pwm1_3_default>;
 	pinctrl-names = "default";
 };
 
 &pwm2 {
 	status = "okay";
-	clock-frequency = <16000000>;
 	pinctrl-0 = <&pwm2_1_default &pwm2_2_default &pwm2_3_default>;
 	pinctrl-names = "default";
 };

--- a/boards/riscv/hifive1_revb/hifive1_revb.dts
+++ b/boards/riscv/hifive1_revb/hifive1_revb.dts
@@ -78,7 +78,6 @@
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;
-	clock-frequency = <16000000>;
 	pinctrl-0 = <&uart0_rx_default &uart0_tx_default>;
 	pinctrl-names = "default";
 };
@@ -86,12 +85,10 @@
 &uart1 {
 	status = "okay";
 	current-speed = <115200>;
-	clock-frequency = <16000000>;
 };
 
 &spi0 {
 	status = "okay";
-	clock-frequency = <16000000>;
 
 	reg = <0x10014000 0x1000 0x20010000 0x3c0900>;
 	flash0: flash@0 {
@@ -106,33 +103,27 @@
 
 &spi1 {
 	status = "okay";
-	clock-frequency = <16000000>;
 };
 
 &spi2 {
 	status = "okay";
-	clock-frequency = <16000000>;
 };
 
 &pwm0 {
 	status = "okay";
-	clock-frequency = <16000000>;
 };
 
 &pwm1 {
 	status = "okay";
-	clock-frequency = <16000000>;
 };
 
 &pwm2 {
 	status = "okay";
-	clock-frequency = <16000000>;
 };
 
 arduino_i2c: &i2c0 {
 	status = "okay";
 	label = "I2C_0";
-	input-frequency = <16000000>;
 	clock-frequency = <100000>;
 	pinctrl-0 = <&i2c0_0_default &i2c0_1_default>;
 	pinctrl-names = "default";

--- a/boards/riscv/hifive1_revb/hifive1_revb.dts
+++ b/boards/riscv/hifive1_revb/hifive1_revb.dts
@@ -71,6 +71,11 @@
 	};
 };
 
+&coreclk {
+	clock-frequency = <DT_FREQ_M(16)>;
+	status = "okay";
+};
+
 &gpio0 {
 	status = "okay";
 };

--- a/boards/riscv/hifive_unleashed/hifive_unleashed.dts
+++ b/boards/riscv/hifive_unleashed/hifive_unleashed.dts
@@ -44,12 +44,10 @@
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;
-	clock-frequency = <500000000>;
 };
 
 &spi0 {
 	status = "okay";
-	clock-frequency = <500000000>;
 
 	reg = <0x10040000 0x1000 0x20000000 0x2000000>;
 	flash0: flash@0 {
@@ -64,12 +62,10 @@
 
 &spi1 {
 	status = "okay";
-	clock-frequency = <500000000>;
 };
 
 &spi2 {
 	status = "okay";
-	clock-frequency = <500000000>;
 };
 
 &gpio0 {

--- a/boards/riscv/hifive_unmatched/hifive_unmatched.dts
+++ b/boards/riscv/hifive_unmatched/hifive_unmatched.dts
@@ -25,12 +25,10 @@
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;
-	clock-frequency = <125125000>;
 };
 
 &spi0 {
 	status = "okay";
-	clock-frequency = <125125000>;
 
 	reg = <0x10040000 0x1000 0x20000000 0x2000000>;
 	flash0: flash@0 {
@@ -45,10 +43,8 @@
 
 &spi1 {
 	status = "okay";
-	clock-frequency = <125125000>;
 };
 
 &spi2 {
 	status = "okay";
-	clock-frequency = <125125000>;
 };

--- a/boards/riscv/qemu_riscv32/qemu_riscv32_xip.dts
+++ b/boards/riscv/qemu_riscv32/qemu_riscv32_xip.dts
@@ -29,13 +29,8 @@
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;
-	clock-frequency = <16000000>;
 	pinctrl-0 = <&uart0_rx_default &uart0_tx_default>;
 	pinctrl-names = "default";
-};
-
-&uart1 {
-	clock-frequency = <16000000>;
 };
 
 &spi0 {

--- a/drivers/i2c/i2c_sifive.c
+++ b/drivers/i2c/i2c_sifive.c
@@ -12,6 +12,7 @@ LOG_MODULE_REGISTER(i2c_sifive);
 
 #include <device.h>
 #include <drivers/i2c.h>
+#include <soc.h>
 #include <sys/sys_io.h>
 
 #include "i2c-priv.h"
@@ -326,7 +327,7 @@ static struct i2c_driver_api i2c_sifive_api = {
 #define I2C_SIFIVE_INIT(n) \
 	static struct i2c_sifive_cfg i2c_sifive_cfg_##n = { \
 		.base = DT_INST_REG_ADDR(n), \
-		.f_sys = DT_INST_PROP(n, input_frequency), \
+		.f_sys = SIFIVE_PERIPHERAL_CLOCK_FREQUENCY, \
 		.f_bus = DT_INST_PROP(n, clock_frequency), \
 	}; \
 	I2C_DEVICE_DT_INST_DEFINE(n, \

--- a/drivers/pwm/pwm_sifive.c
+++ b/drivers/pwm/pwm_sifive.c
@@ -14,6 +14,7 @@ LOG_MODULE_REGISTER(pwm_sifive, CONFIG_PWM_LOG_LEVEL);
 #include <device.h>
 #include <drivers/pinctrl.h>
 #include <drivers/pwm.h>
+#include <soc.h>
 
 /* Macros */
 
@@ -237,7 +238,7 @@ static const struct pwm_driver_api pwm_sifive_api = {
 	static struct pwm_sifive_data pwm_sifive_data_##n;	\
 	static const struct pwm_sifive_cfg pwm_sifive_cfg_##n = {	\
 			.base = DT_INST_REG_ADDR(n),	\
-			.f_sys = DT_INST_PROP(n, clock_frequency),  \
+			.f_sys = SIFIVE_PERIPHERAL_CLOCK_FREQUENCY,  \
 			.cmpwidth = DT_INST_PROP(n, sifive_compare_width), \
 			.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),	\
 		};	\

--- a/drivers/serial/uart_sifive.c
+++ b/drivers/serial/uart_sifive.c
@@ -14,6 +14,7 @@
 #include <arch/cpu.h>
 #include <drivers/uart.h>
 #include <drivers/pinctrl.h>
+#include <soc.h>
 
 #define RXDATA_EMPTY   (1 << 31)   /* Receive FIFO Empty */
 #define RXDATA_MASK    0xFF        /* Receive Data Mask */
@@ -383,7 +384,7 @@ PINCTRL_DT_INST_DEFINE(0);
 
 static const struct uart_sifive_device_config uart_sifive_dev_cfg_0 = {
 	.port         = DT_INST_REG_ADDR(0),
-	.sys_clk_freq = DT_INST_PROP(0, clock_frequency),
+	.sys_clk_freq = SIFIVE_PERIPHERAL_CLOCK_FREQUENCY,
 	.baud_rate    = DT_INST_PROP(0, current_speed),
 	.rxcnt_irq    = CONFIG_UART_SIFIVE_PORT_0_RXCNT_IRQ,
 	.txcnt_irq    = CONFIG_UART_SIFIVE_PORT_0_TXCNT_IRQ,
@@ -426,7 +427,7 @@ PINCTRL_DT_INST_DEFINE(1);
 
 static const struct uart_sifive_device_config uart_sifive_dev_cfg_1 = {
 	.port         = DT_INST_REG_ADDR(1),
-	.sys_clk_freq = DT_INST_PROP(1, clock_frequency),
+	.sys_clk_freq = SIFIVE_PERIPHERAL_CLOCK_FREQUENCY,
 	.baud_rate    = DT_INST_PROP(1, current_speed),
 	.rxcnt_irq    = CONFIG_UART_SIFIVE_PORT_1_RXCNT_IRQ,
 	.txcnt_irq    = CONFIG_UART_SIFIVE_PORT_1_TXCNT_IRQ,

--- a/drivers/spi/spi_sifive.c
+++ b/drivers/spi/spi_sifive.c
@@ -12,6 +12,7 @@ LOG_MODULE_REGISTER(spi_sifive);
 
 #include "spi_sifive.h"
 
+#include <soc.h>
 #include <stdbool.h>
 
 /* Helper Functions */
@@ -270,7 +271,7 @@ static struct spi_driver_api spi_sifive_api = {
 	}; \
 	static struct spi_sifive_cfg spi_sifive_cfg_##n = { \
 		.base = DT_INST_REG_ADDR_BY_NAME(n, control), \
-		.f_sys = DT_INST_PROP(n, clock_frequency), \
+		.f_sys = SIFIVE_PERIPHERAL_CLOCK_FREQUENCY, \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n), \
 	}; \
 	DEVICE_DT_INST_DEFINE(n, \

--- a/dts/bindings/i2c/sifive,i2c0.yaml
+++ b/dts/bindings/i2c/sifive,i2c0.yaml
@@ -8,10 +8,5 @@ compatible: "sifive,i2c0"
 include: i2c-controller.yaml
 
 properties:
-    input-frequency:
-      type: int
-      required: false
-      description: Frequency of the peripheral input clock.
-
     reg:
       required: true

--- a/dts/bindings/pwm/sifive,pwm0.yaml
+++ b/dts/bindings/pwm/sifive,pwm0.yaml
@@ -8,11 +8,6 @@ compatible: "sifive,pwm0"
 include: [pwm-controller.yaml, pinctrl-device.yaml, base.yaml]
 
 properties:
-    clock-frequency:
-      type: int
-      required: false
-      description: Clock frequency information for PWM operation
-
     reg:
       required: true
 

--- a/dts/bindings/riscv/riscv,cpus.yaml
+++ b/dts/bindings/riscv/riscv,cpus.yaml
@@ -24,8 +24,3 @@ properties:
       - rv32imafcb
       - rv64imac
       - rv64imafdc
-
-  riscv,pmpregions:
-    description: Physical Memory Protection (PMP)
-    required: true
-    type: int

--- a/dts/bindings/riscv/riscv,sifive-e31.yaml
+++ b/dts/bindings/riscv/riscv,sifive-e31.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2022 Shawn Nematbakhsh <shawn@rivosinc.com>
+# SPDX-License-Identifier: Apache-2.0
+
+description: SiFive E31 Standard Core CPU
+
+compatible: "riscv,sifive-e31"
+
+include: riscv,sifive.yaml

--- a/dts/bindings/riscv/riscv,sifive-e51.yaml
+++ b/dts/bindings/riscv/riscv,sifive-e51.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2022 Shawn Nematbakhsh <shawn@rivosinc.com>
+# SPDX-License-Identifier: Apache-2.0
+
+description: SiFive E51 Standard Core CPU
+
+compatible: "riscv,sifive-e51"
+
+include: riscv,sifive.yaml

--- a/dts/bindings/riscv/riscv,sifive-s7.yaml
+++ b/dts/bindings/riscv/riscv,sifive-s7.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2022 Shawn Nematbakhsh <shawn@rivosinc.com>
+# SPDX-License-Identifier: Apache-2.0
+
+description: SiFive S7 Standard Core CPU
+
+compatible: "riscv,sifive-s7"
+
+include: riscv,sifive.yaml

--- a/dts/riscv/riscv32-fe310.dtsi
+++ b/dts/riscv/riscv32-fe310.dtsi
@@ -11,19 +11,11 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 		cpu: cpu@0 {
-			clock-frequency = <0>;
 			compatible = "sifive,rocket0", "riscv";
 			device_type = "cpu";
-			i-cache-block-size = <64>;
-			i-cache-sets = <128>;
-			i-cache-size = <16384>;
-			next-level-cache = <&modeselect &maskrom &otp &spi0>;
 			reg = <0>;
 			riscv,isa = "rv32imac";
-			sifive,dtim = <&dtim>;
-			sifive,itim = <&itim>;
 			status = "okay";
-			timebase-frequency = <32768>;
 			hlic: interrupt-controller {
 				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";

--- a/dts/riscv/riscv32-fe310.dtsi
+++ b/dts/riscv/riscv32-fe310.dtsi
@@ -11,7 +11,7 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 		cpu: cpu@0 {
-			compatible = "sifive,rocket0", "riscv";
+			compatible = "riscv,sifive-e31";
 			device_type = "cpu";
 			reg = <0>;
 			riscv,isa = "rv32imac";

--- a/dts/riscv/riscv32-fe310.dtsi
+++ b/dts/riscv/riscv32-fe310.dtsi
@@ -1,12 +1,27 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #include <dt-bindings/gpio/gpio.h>
+#include <freq.h>
 
 / {
 	#address-cells = <1>;
 	#size-cells = <1>;
 	compatible = "sifive,FE310G-0002-Z0-dev", "fe310-dev", "sifive-dev";
 	model = "SiFive,FE310G-0002-Z0";
+	clocks {
+		coreclk: core-clk {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <DT_FREQ_M(16)>;
+		};
+
+		tlclk: tl-clk {
+			#clock-cells = <0>;
+			compatible = "fixed-factor-clock";
+			clocks = <&coreclk>;
+			clock-div = <1>;
+		};
+	};
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/dts/riscv/riscv64-fu540.dtsi
+++ b/dts/riscv/riscv64-fu540.dtsi
@@ -17,7 +17,7 @@
 		#size-cells = <0>;
 
 		cpu: cpu@0 {
-			compatible = "sifive,e51", "riscv";
+			compatible = "riscv,sifive-e51";
 			device_type = "cpu";
 			reg = <0>;
 			riscv,isa = "rv64imac";

--- a/dts/riscv/riscv64-fu540.dtsi
+++ b/dts/riscv/riscv64-fu540.dtsi
@@ -5,12 +5,28 @@
  */
 
 #include <dt-bindings/gpio/gpio.h>
+#include <freq.h>
 
 / {
 	#address-cells = <1>;
 	#size-cells = <1>;
 	compatible = "sifive,FU540-C000", "fu540-dev", "sifive-dev";
 	model = "sifive,FU540";
+
+	clocks {
+		coreclk: core-clk {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <DT_FREQ_M(1000)>;
+		};
+
+		tlclk: tl-clk {
+			#clock-cells = <0>;
+			compatible = "fixed-factor-clock";
+			clocks = <&coreclk>;
+			clock-div = <2>;
+		};
+	};
 
 	cpus {
 		#address-cells = <1>;

--- a/dts/riscv/riscv64-fu740.dtsi
+++ b/dts/riscv/riscv64-fu740.dtsi
@@ -17,7 +17,7 @@
 		#size-cells = <0>;
 
 		cpu: cpu@0 {
-			compatible = "sifive,s7", "riscv";
+			compatible = "riscv,sifive-s7";
 			device_type = "cpu";
 			reg = <0>;
 			riscv,isa = "rv64imac";

--- a/dts/riscv/riscv64-fu740.dtsi
+++ b/dts/riscv/riscv64-fu740.dtsi
@@ -5,12 +5,27 @@
  */
 
 #include <dt-bindings/gpio/gpio.h>
+#include <freq.h>
 
 / {
 	#address-cells = <1>;
 	#size-cells = <1>;
 	compatible = "sifive,FU740-C000", "fu740-dev", "sifive-dev";
 	model = "sifive,FU740";
+
+	clocks {
+		coreclk: core-clk {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <DT_FREQ_M(1000)>;
+		};
+
+		pclk: p-clk {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <DT_FREQ_K(125125)>;
+		};
+	};
 
 	cpus {
 		#address-cells = <1>;

--- a/soc/riscv/riscv-privilege/sifive-freedom/fe310_clock.c
+++ b/soc/riscv/riscv-privilege/sifive-freedom/fe310_clock.c
@@ -8,6 +8,11 @@
 #include <init.h>
 #include "fe310_prci.h"
 
+BUILD_ASSERT(MHZ(16) == DT_PROP(DT_NODELABEL(coreclk), clock_frequency),
+	"Unsupported CORECLK frequency");
+BUILD_ASSERT(DT_PROP(DT_NODELABEL(tlclk), clock_div) == 1,
+	"Unsupported TLCLK divider");
+
 /* Selects the 16MHz oscillator on the HiFive1 board, which provides a clock
  * that's accurate enough to actually drive serial ports off of.
  */

--- a/soc/riscv/riscv-privilege/sifive-freedom/fe310_clock.c
+++ b/soc/riscv/riscv-privilege/sifive-freedom/fe310_clock.c
@@ -8,19 +8,50 @@
 #include <init.h>
 #include "fe310_prci.h"
 
-BUILD_ASSERT(MHZ(16) == DT_PROP(DT_NODELABEL(coreclk), clock_frequency),
-	"Unsupported CORECLK frequency");
+#define CORECLK_HZ (DT_PROP(DT_NODELABEL(coreclk), clock_frequency))
 BUILD_ASSERT(DT_PROP(DT_NODELABEL(tlclk), clock_div) == 1,
 	"Unsupported TLCLK divider");
 
-/* Selects the 16MHz oscillator on the HiFive1 board, which provides a clock
- * that's accurate enough to actually drive serial ports off of.
- */
 static int fe310_clock_init(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 
-	PRCI_REG(PRCI_PLLCFG) = PLL_REFSEL(1) | PLL_BYPASS(1);
+	/*
+	 * HFXOSC (16 MHz) is used to produce coreclk (and therefore tlclk /
+	 * peripheral clock). This code supports the following frequencies:
+	 * - 16 MHz (bypass HFPLL).
+	 * - 48 MHz - 320 MHz, in 8 MHz steps (use HFPLL).
+	 */
+	BUILD_ASSERT(MHZ(16) == CORECLK_HZ ||
+		(MHZ(48) <= CORECLK_HZ && MHZ(320) >= CORECLK_HZ &&
+		(CORECLK_HZ % MHZ(8)) == 0),
+		"Unsupported CORECLK frequency");
+
+	uint32_t prci;
+
+	if (MHZ(16) == CORECLK_HZ) {
+		/* Bypass HFPLL. */
+		prci = PLL_REFSEL(1) | PLL_BYPASS(1);
+	} else {
+		/* refr = 8 MHz. */
+		const int pll_r = 0x1;
+		int pll_q;
+
+		/* Select Q divisor to produce vco on [384 MHz, 768 MHz]. */
+		if (MHZ(768) / 8 >= CORECLK_HZ) {
+			pll_q = 0x3;
+		} else if (MHZ(768) / 4 >= CORECLK_HZ) {
+			pll_q = 0x2;
+		} else {
+			pll_q = 0x1;
+		}
+		/* Select F multiplier to produce vco target. */
+		const int pll_f = ((CORECLK_HZ / MHZ(1)) >> (4 - pll_q)) - 1;
+
+		prci = PLL_REFSEL(1) | PLL_R(pll_r) | PLL_F(pll_f) | PLL_Q(pll_q);
+	}
+
+	PRCI_REG(PRCI_PLLCFG) = prci;
 	PRCI_REG(PRCI_PLLDIV) = (PLL_FINAL_DIV_BY_1(1) | PLL_FINAL_DIV(0));
 	PRCI_REG(PRCI_PLLCFG) |= PLL_SEL(1);
 	PRCI_REG(PRCI_HFROSCCFG) &= ~ROSC_EN(1);

--- a/soc/riscv/riscv-privilege/sifive-freedom/fu540_clock.c
+++ b/soc/riscv/riscv-privilege/sifive-freedom/fu540_clock.c
@@ -7,6 +7,11 @@
 #include <init.h>
 #include "fu540_prci.h"
 
+BUILD_ASSERT(MHZ(1000) == DT_PROP(DT_NODELABEL(coreclk), clock_frequency),
+	"Unsupported CORECLK frequency");
+BUILD_ASSERT(DT_PROP(DT_NODELABEL(tlclk), clock_div) == 2,
+	"Unsupported TLCLK divider");
+
 /*
  * Switch the clock source to 1GHz PLL from 33.333MHz oscillator on the HiFive
  * Unleashed board.

--- a/soc/riscv/riscv-privilege/sifive-freedom/fu740_clock.c
+++ b/soc/riscv/riscv-privilege/sifive-freedom/fu740_clock.c
@@ -7,6 +7,11 @@
 #include <init.h>
 #include "fu740_prci.h"
 
+BUILD_ASSERT(MHZ(1000) == DT_PROP(DT_NODELABEL(coreclk), clock_frequency),
+	"Unsupported CORECLK frequency");
+BUILD_ASSERT(KHZ(125125) == DT_PROP(DT_NODELABEL(pclk), clock_frequency),
+	"Unsupported PCLK frequency");
+
 /*
  * Switch the clock source
  *   - core: to 1GHz PLL (CORE_PLL) from 26MHz oscillator (HFCLK)

--- a/soc/riscv/riscv-privilege/sifive-freedom/soc.h
+++ b/soc/riscv/riscv-privilege/sifive-freedom/soc.h
@@ -23,7 +23,7 @@
 #define SIFIVE_PINMUX_PINS            32
 
 /* Clock controller. */
-#define PRCI_BASE_ADDR               0x10008000
+#define PRCI_BASE_ADDR           0x10008000
 
 /* Always ON Domain */
 #define SIFIVE_PMUIE		     0x10000140
@@ -41,6 +41,26 @@
 
 /* PINMUX MAX PINS */
 #define SIFIVE_PINMUX_PINS           16
+
+#endif
+
+#if defined(CONFIG_SOC_RISCV_SIFIVE_FREEDOM) || defined(CONFIG_SOC_RISCV_SIFIVE_FU540)
+
+/*
+ * On FE310 and FU540, peripherals such as SPI, UART, I2C and PWM are clocked
+ * by TLCLK, which is derived from CORECLK.
+ */
+#define SIFIVE_TLCLK_BASE_FREQUENCY \
+	DT_PROP_BY_PHANDLE_IDX(DT_NODELABEL(tlclk), clocks, 0, clock_frequency)
+#define SIFIVE_TLCLK_DIVIDER DT_PROP(DT_NODELABEL(tlclk), clock_div)
+#define SIFIVE_PERIPHERAL_CLOCK_FREQUENCY \
+	(SIFIVE_TLCLK_BASE_FREQUENCY / SIFIVE_TLCLK_DIVIDER)
+
+#elif defined(CONFIG_SOC_RISCV_SIFIVE_FU740)
+
+/* On FU740, peripherals are clocked by PCLK. */
+#define SIFIVE_PERIPHERAL_CLOCK_FREQUENCY \
+	DT_PROP(DT_NODELABEL(pclk), clock_frequency)
 
 #endif
 


### PR DESCRIPTION
tlclk, which is the input clock for SPI, I2C, PWM, etc. is (mostly) a fixed
ratio of coreclk. Rather than specify input clock for each peripheral
individually, instead specify CPU clock (coreclk) and derive tlclk from
it.

This will enable easier support for non-default coreclk on fe310 in a
follow-up CL.

Signed-off-by: Shawn Nematbakhsh <shawn@rivosinc.com>