### PR TITLE
Bluetooth: host: Optimize L2CAP resource usage

### DIFF
--- a/include/bluetooth/l2cap.h
+++ b/include/bluetooth/l2cap.h
@@ -135,19 +135,8 @@ struct bt_l2cap_chan {
 	const struct bt_l2cap_chan_ops	*ops;
 	sys_snode_t			node;
 	bt_l2cap_chan_destroy_t		destroy;
-	/* Response Timeout eXpired (RTX) timer */
-	struct k_work_delayable		rtx_work;
-	struct k_work_sync              rtx_sync;
-	ATOMIC_DEFINE(status, BT_L2CAP_NUM_STATUS);
 
-#if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
-	bt_l2cap_chan_state_t		state;
-	/** Remote PSM to be connected */
-	uint16_t				psm;
-	/** Helps match request context during CoC */
-	uint8_t				ident;
-	bt_security_t			required_sec_level;
-#endif /* CONFIG_BT_L2CAP_DYNAMIC_CHANNEL */
+	ATOMIC_DEFINE(status, BT_L2CAP_NUM_STATUS);
 };
 
 /** @brief LE L2CAP Endpoint structure. */
@@ -191,10 +180,23 @@ struct bt_l2cap_le_chan {
 	struct k_work			tx_work;
 	/** Segment SDU packet from upper layer */
 	struct net_buf			*_sdu;
-	uint16_t				_sdu_len;
+	uint16_t			_sdu_len;
 
 	struct k_work			rx_work;
 	struct k_fifo			rx_queue;
+
+#if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
+	bt_l2cap_chan_state_t		state;
+	/** Remote PSM to be connected */
+	uint16_t			psm;
+	/** Helps match request context during CoC */
+	uint8_t				ident;
+	bt_security_t			required_sec_level;
+
+	/* Response Timeout eXpired (RTX) timer */
+	struct k_work_delayable		rtx_work;
+	struct k_work_sync		rtx_sync;
+#endif
 };
 
 /** @def BT_L2CAP_LE_CHAN(_ch)
@@ -226,6 +228,17 @@ struct bt_l2cap_br_chan {
 	struct bt_l2cap_br_endpoint	tx;
 	/* For internal use only */
 	atomic_t			flags[1];
+
+	bt_l2cap_chan_state_t		state;
+	/** Remote PSM to be connected */
+	uint16_t			psm;
+	/** Helps match request context during CoC */
+	uint8_t				ident;
+	bt_security_t			required_sec_level;
+
+	/* Response Timeout eXpired (RTX) timer */
+	struct k_work_delayable		rtx_work;
+	struct k_work_sync		rtx_sync;
 };
 
 /** @brief L2CAP Channel operations structure. */

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -2740,31 +2740,31 @@ static void att_chan_attach(struct bt_att *att, struct bt_att_chan *chan)
 static void bt_att_connected(struct bt_l2cap_chan *chan)
 {
 	struct bt_att_chan *att_chan = ATT_CHAN(chan);
-	struct bt_l2cap_le_chan *ch = BT_L2CAP_LE_CHAN(chan);
+	struct bt_l2cap_le_chan *le_chan = BT_L2CAP_LE_CHAN(chan);
 
-	BT_DBG("chan %p cid 0x%04x", ch, ch->tx.cid);
+	BT_DBG("chan %p cid 0x%04x", le_chan, le_chan->tx.cid);
 
 	atomic_set_bit(att_chan->flags, ATT_CONNECTED);
 
 	if (!atomic_test_bit(att_chan->flags, ATT_ENHANCED)) {
-		ch->tx.mtu = BT_ATT_DEFAULT_LE_MTU;
-		ch->rx.mtu = BT_ATT_DEFAULT_LE_MTU;
+		le_chan->tx.mtu = BT_ATT_DEFAULT_LE_MTU;
+		le_chan->rx.mtu = BT_ATT_DEFAULT_LE_MTU;
 	}
 
 	att_chan_mtu_updated(att_chan);
 
 	k_work_init_delayable(&att_chan->timeout_work, att_timeout);
 
-	bt_gatt_connected(ch->chan.conn);
+	bt_gatt_connected(le_chan->chan.conn);
 }
 
 static void bt_att_disconnected(struct bt_l2cap_chan *chan)
 {
 	struct bt_att_chan *att_chan = ATT_CHAN(chan);
 	struct bt_att *att = att_chan->att;
-	struct bt_l2cap_le_chan *ch = BT_L2CAP_LE_CHAN(chan);
+	struct bt_l2cap_le_chan *le_chan = BT_L2CAP_LE_CHAN(chan);
 
-	BT_DBG("chan %p cid 0x%04x", ch, ch->tx.cid);
+	BT_DBG("chan %p cid 0x%04x", le_chan, le_chan->tx.cid);
 
 	if (!att_chan->att) {
 		BT_DBG("Ignore disconnect on detached ATT chan");
@@ -2780,7 +2780,7 @@ static void bt_att_disconnected(struct bt_l2cap_chan *chan)
 
 	att_reset(att);
 
-	bt_gatt_disconnected(ch->chan.conn);
+	bt_gatt_disconnected(le_chan->chan.conn);
 }
 
 #if defined(CONFIG_BT_SMP)
@@ -2818,12 +2818,12 @@ static void bt_att_encrypt_change(struct bt_l2cap_chan *chan,
 				  uint8_t hci_status)
 {
 	struct bt_att_chan *att_chan = ATT_CHAN(chan);
-	struct bt_l2cap_le_chan *ch = BT_L2CAP_LE_CHAN(chan);
-	struct bt_conn *conn = ch->chan.conn;
+	struct bt_l2cap_le_chan *le_chan = BT_L2CAP_LE_CHAN(chan);
+	struct bt_conn *conn = le_chan->chan.conn;
 	uint8_t err;
 
-	BT_DBG("chan %p conn %p handle %u sec_level 0x%02x status 0x%02x", ch,
-	       conn, conn->handle, conn->sec_level, hci_status);
+	BT_DBG("chan %p conn %p handle %u sec_level 0x%02x status 0x%02x",
+	       le_chan, conn, conn->handle, conn->sec_level, hci_status);
 
 	if (!att_chan->att) {
 		BT_DBG("Ignore encrypt change on detached ATT chan");

--- a/subsys/bluetooth/host/avdtp.c
+++ b/subsys/bluetooth/host/avdtp.c
@@ -204,7 +204,7 @@ int bt_avdtp_connect(struct bt_conn *conn, struct bt_avdtp *session)
 	}
 
 	session->br_chan.chan.ops = &ops;
-	session->br_chan.chan.required_sec_level = BT_SECURITY_L2;
+	session->br_chan.required_sec_level = BT_SECURITY_L2;
 
 	return bt_l2cap_chan_connect(conn, &session->br_chan.chan,
 				     BT_L2CAP_PSM_AVDTP);

--- a/subsys/bluetooth/host/l2cap_br.c
+++ b/subsys/bluetooth/host/l2cap_br.c
@@ -30,7 +30,6 @@
 #include "rfcomm_internal.h"
 #include "sdp_internal.h"
 
-#define BR_CHAN(_ch) CONTAINER_OF(_ch, struct bt_l2cap_br_chan, chan)
 #define BR_CHAN_RTX(_w) CONTAINER_OF(_w, struct bt_l2cap_br_chan, rtx_work)
 
 #define L2CAP_BR_PSM_START	0x0001

--- a/subsys/bluetooth/host/l2cap_br.c
+++ b/subsys/bluetooth/host/l2cap_br.c
@@ -31,7 +31,7 @@
 #include "sdp_internal.h"
 
 #define BR_CHAN(_ch) CONTAINER_OF(_ch, struct bt_l2cap_br_chan, chan)
-#define BR_CHAN_RTX(_w) CONTAINER_OF(_w, struct bt_l2cap_br_chan, chan.rtx_work)
+#define BR_CHAN_RTX(_w) CONTAINER_OF(_w, struct bt_l2cap_br_chan, rtx_work)
 
 #define L2CAP_BR_PSM_START	0x0001
 #define L2CAP_BR_PSM_END	0xffff
@@ -121,15 +121,15 @@ struct bt_l2cap_chan *bt_l2cap_br_lookup_tx_cid(struct bt_conn *conn,
 static struct bt_l2cap_br_chan*
 l2cap_br_chan_alloc_cid(struct bt_conn *conn, struct bt_l2cap_chan *chan)
 {
-	struct bt_l2cap_br_chan *ch = BR_CHAN(chan);
+	struct bt_l2cap_br_chan *br_chan = BR_CHAN(chan);
 	uint16_t cid;
 
 	/*
 	 * No action needed if there's already a CID allocated, e.g. in
 	 * the case of a fixed channel.
 	 */
-	if (ch->rx.cid > 0) {
-		return ch;
+	if (br_chan->rx.cid > 0) {
+		return br_chan;
 	}
 
 	/*
@@ -138,8 +138,8 @@ l2cap_br_chan_alloc_cid(struct bt_conn *conn, struct bt_l2cap_chan *chan)
 	 */
 	for (cid = L2CAP_BR_CID_DYN_START; cid; cid++) {
 		if (!bt_l2cap_br_lookup_rx_cid(conn, cid)) {
-			ch->rx.cid = cid;
-			return ch;
+			br_chan->rx.cid = cid;
+			return br_chan;
 		}
 	}
 
@@ -154,13 +154,15 @@ static void l2cap_br_chan_cleanup(struct bt_l2cap_chan *chan)
 
 static void l2cap_br_chan_destroy(struct bt_l2cap_chan *chan)
 {
-	BT_DBG("chan %p cid 0x%04x", BR_CHAN(chan), BR_CHAN(chan)->rx.cid);
+	struct bt_l2cap_br_chan *br_chan = BR_CHAN(chan);
+
+	BT_DBG("chan %p cid 0x%04x", br_chan, br_chan->rx.cid);
 
 	/* Cancel ongoing work. Since the channel can be re-used after this
 	 * we need to sync to make sure that the kernel does not have it
 	 * in its queue anymore.
 	 */
-	k_work_cancel_delayable_sync(&chan->rtx_work, &chan->rtx_sync);
+	k_work_cancel_delayable_sync(&br_chan->rtx_work, &br_chan->rtx_sync);
 
 	atomic_clear(BR_CHAN(chan)->flags);
 }
@@ -178,10 +180,10 @@ static void l2cap_br_rtx_timeout(struct k_work *work)
 	}
 
 	BT_DBG("chan %p %s scid 0x%04x", chan,
-	       bt_l2cap_chan_state_str(chan->chan.state),
+	       bt_l2cap_chan_state_str(chan->state),
 	       chan->rx.cid);
 
-	switch (chan->chan.state) {
+	switch (chan->state) {
 	case BT_L2CAP_CONFIG:
 		bt_l2cap_br_chan_disconnect(&chan->chan);
 		break;
@@ -210,7 +212,7 @@ static bool l2cap_br_chan_add(struct bt_conn *conn, struct bt_l2cap_chan *chan,
 	 * disconnected handler is always called from the workqueue itself so
 	 * canceling from there should always succeed.
 	 */
-	k_work_init_delayable(&chan->rtx_work, l2cap_br_rtx_timeout);
+	k_work_init_delayable(&ch->rtx_work, l2cap_br_rtx_timeout);
 	bt_l2cap_chan_add(conn, chan, destroy);
 
 	return true;
@@ -259,7 +261,7 @@ static void l2cap_br_chan_send_req(struct bt_l2cap_br_chan *chan,
 	 * final expiration, when the response is received, or the physical
 	 * link is lost.
 	 */
-	k_work_reschedule(&chan->chan.rtx_work, timeout);
+	k_work_reschedule(&chan->rtx_work, timeout);
 }
 
 static void l2cap_br_get_info(struct bt_l2cap_br *l2cap, uint16_t info_type)
@@ -341,7 +343,7 @@ static int l2cap_br_info_rsp(struct bt_l2cap_br *l2cap, uint8_t ident,
 		 * Release RTX timer since got the response & there's pending
 		 * command request.
 		 */
-		k_work_cancel_delayable(&l2cap->chan.chan.rtx_work);
+		k_work_cancel_delayable(&l2cap->chan.rtx_work);
 	}
 
 	if (buf->len < sizeof(*rsp)) {
@@ -467,7 +469,7 @@ void bt_l2cap_br_connected(struct bt_conn *conn)
 	struct bt_l2cap_chan *chan;
 
 	STRUCT_SECTION_FOREACH(bt_l2cap_br_fixed_chan, fchan) {
-		struct bt_l2cap_br_chan *ch;
+		struct bt_l2cap_br_chan *br_chan;
 
 		if (!fchan->accept) {
 			continue;
@@ -477,10 +479,10 @@ void bt_l2cap_br_connected(struct bt_conn *conn)
 			continue;
 		}
 
-		ch = BR_CHAN(chan);
+		br_chan = BR_CHAN(chan);
 
-		ch->rx.cid = fchan->cid;
-		ch->tx.cid = fchan->cid;
+		br_chan->rx.cid = fchan->cid;
+		br_chan->tx.cid = fchan->cid;
 
 		if (!l2cap_br_chan_add(conn, chan, NULL)) {
 			return;
@@ -493,9 +495,9 @@ void bt_l2cap_br_connected(struct bt_conn *conn)
 		if (fchan->cid == BT_L2CAP_CID_BR_SIG) {
 			struct bt_l2cap_br *sig_ch;
 
-			connect_fixed_channel(ch);
+			connect_fixed_channel(br_chan);
 
-			sig_ch = CONTAINER_OF(ch, struct bt_l2cap_br, chan);
+			sig_ch = CONTAINER_OF(br_chan, struct bt_l2cap_br, chan);
 			l2cap_br_get_info(sig_ch, BT_L2CAP_INFO_FEAT_MASK);
 		}
 	}
@@ -577,9 +579,10 @@ static enum l2cap_br_conn_security_result
 l2cap_br_conn_security(struct bt_l2cap_chan *chan, const uint16_t psm)
 {
 	int check;
+	struct bt_l2cap_br_chan *br_chan = BR_CHAN(chan);
 
 	/* For SDP PSM there's no need to change existing security on link */
-	if (chan->required_sec_level == BT_SECURITY_L0) {
+	if (br_chan->required_sec_level == BT_SECURITY_L0) {
 		return L2CAP_CONN_SECURITY_PASSED;
 	}
 
@@ -587,12 +590,12 @@ l2cap_br_conn_security(struct bt_l2cap_chan *chan, const uint16_t psm)
 	 * No link key needed for legacy devices (pre 2.1) and when low security
 	 * level is required.
 	 */
-	if (chan->required_sec_level == BT_SECURITY_L1 &&
+	if (br_chan->required_sec_level == BT_SECURITY_L1 &&
 	    !BT_FEAT_HOST_SSP(chan->conn->br.features)) {
 		return L2CAP_CONN_SECURITY_PASSED;
 	}
 
-	switch (chan->required_sec_level) {
+	switch (br_chan->required_sec_level) {
 	case BT_SECURITY_L4:
 	case BT_SECURITY_L3:
 	case BT_SECURITY_L2:
@@ -605,12 +608,12 @@ l2cap_br_conn_security(struct bt_l2cap_chan *chan, const uint16_t psm)
 		 * local to MEDIUM security to trigger it if needed.
 		 */
 		if (BT_FEAT_HOST_SSP(chan->conn->br.features)) {
-			chan->required_sec_level = BT_SECURITY_L2;
+			br_chan->required_sec_level = BT_SECURITY_L2;
 		}
 		break;
 	}
 
-	check = bt_conn_set_security(chan->conn, chan->required_sec_level);
+	check = bt_conn_set_security(chan->conn, br_chan->required_sec_level);
 
 	/*
 	 * Check case when on existing connection security level already covers
@@ -619,7 +622,7 @@ l2cap_br_conn_security(struct bt_l2cap_chan *chan, const uint16_t psm)
 	 * need to trigger authentication.
 	 */
 	if (check == 0 &&
-	    chan->conn->sec_level >= chan->required_sec_level) {
+	    chan->conn->sec_level >= br_chan->required_sec_level) {
 		return L2CAP_CONN_SECURITY_PASSED;
 	}
 
@@ -676,8 +679,8 @@ static int l2cap_br_conn_req_reply(struct bt_l2cap_chan *chan, uint16_t result)
 	}
 
 	l2cap_br_send_conn_rsp(chan->conn, BR_CHAN(chan)->tx.cid,
-			       BR_CHAN(chan)->rx.cid, chan->ident, result);
-	chan->ident = 0U;
+			       BR_CHAN(chan)->rx.cid, BR_CHAN(chan)->ident, result);
+	BR_CHAN(chan)->ident = 0U;
 
 	return 0;
 }
@@ -690,6 +693,7 @@ static void l2cap_br_conn_req(struct bt_l2cap_br *l2cap, uint8_t ident,
 	struct bt_l2cap_server *server;
 	struct bt_l2cap_conn_req *req = (void *)buf->data;
 	uint16_t psm, scid, result;
+	struct bt_l2cap_br_chan *br_chan;
 
 	if (buf->len < sizeof(*req)) {
 		BT_ERR("Too small L2CAP conn req packet size");
@@ -734,6 +738,8 @@ static void l2cap_br_conn_req(struct bt_l2cap_br *l2cap, uint8_t ident,
 		goto no_chan;
 	}
 
+	br_chan = BR_CHAN(chan);
+
 	/*
 	 * Request server to accept the new connection and allocate the
 	 * channel. If no free channels available for PSM server reply with
@@ -744,11 +750,11 @@ static void l2cap_br_conn_req(struct bt_l2cap_br *l2cap, uint8_t ident,
 		goto no_chan;
 	}
 
-	chan->required_sec_level = server->sec_level;
+	br_chan->required_sec_level = server->sec_level;
 
 	l2cap_br_chan_add(conn, chan, l2cap_br_chan_destroy);
 	BR_CHAN(chan)->tx.cid = scid;
-	chan->ident = ident;
+	br_chan->ident = ident;
 	bt_l2cap_chan_set_state(chan, BT_L2CAP_CONNECTING);
 	atomic_set_bit(BR_CHAN(chan)->flags, L2CAP_FLAG_CONN_ACCEPTOR);
 
@@ -795,6 +801,7 @@ static void l2cap_br_conf_rsp(struct bt_l2cap_br *l2cap, uint8_t ident,
 	struct bt_l2cap_chan *chan;
 	struct bt_l2cap_conf_rsp *rsp = (void *)buf->data;
 	uint16_t flags, scid, result, opt_len;
+	struct bt_l2cap_br_chan *br_chan;
 
 	if (buf->len < sizeof(*rsp)) {
 		BT_ERR("Too small L2CAP conf rsp packet size");
@@ -815,8 +822,10 @@ static void l2cap_br_conf_rsp(struct bt_l2cap_br *l2cap, uint8_t ident,
 		return;
 	}
 
+	br_chan = BR_CHAN(chan);
+
 	/* Release RTX work since got the response */
-	k_work_cancel_delayable(&chan->rtx_work);
+	k_work_cancel_delayable(&br_chan->rtx_work);
 
 	/*
 	 * TODO: handle other results than success and parse response data if
@@ -824,14 +833,13 @@ static void l2cap_br_conf_rsp(struct bt_l2cap_br *l2cap, uint8_t ident,
 	 */
 	switch (result) {
 	case BT_L2CAP_CONF_SUCCESS:
-		atomic_set_bit(BR_CHAN(chan)->flags, L2CAP_FLAG_CONN_LCONF_DONE);
+		atomic_set_bit(br_chan->flags, L2CAP_FLAG_CONN_LCONF_DONE);
 
-		if (chan->state == BT_L2CAP_CONFIG &&
-		    atomic_test_bit(BR_CHAN(chan)->flags,
+		if (br_chan->state == BT_L2CAP_CONFIG &&
+		    atomic_test_bit(br_chan->flags,
 				    L2CAP_FLAG_CONN_RCONF_DONE)) {
 			BT_DBG("scid 0x%04x rx MTU %u dcid 0x%04x tx MTU %u",
-			       BR_CHAN(chan)->rx.cid, BR_CHAN(chan)->rx.mtu,
-			       BR_CHAN(chan)->tx.cid, BR_CHAN(chan)->tx.mtu);
+			       br_chan->rx.cid, br_chan->rx.mtu, br_chan->tx.cid, br_chan->tx.mtu);
 
 			bt_l2cap_chan_set_state(chan, BT_L2CAP_CONNECTED);
 			if (chan->ops && chan->ops->connected) {
@@ -1041,7 +1049,7 @@ send_rsp:
 	atomic_set_bit(BR_CHAN(chan)->flags, L2CAP_FLAG_CONN_RCONF_DONE);
 
 	if (atomic_test_bit(BR_CHAN(chan)->flags, L2CAP_FLAG_CONN_LCONF_DONE) &&
-	    chan->state == BT_L2CAP_CONFIG) {
+	    BR_CHAN(chan)->state == BT_L2CAP_CONFIG) {
 		BT_DBG("scid 0x%04x rx MTU %u dcid 0x%04x tx MTU %u",
 		       BR_CHAN(chan)->rx.cid, BR_CHAN(chan)->rx.mtu,
 		       BR_CHAN(chan)->tx.cid, BR_CHAN(chan)->tx.mtu);
@@ -1130,15 +1138,17 @@ static void l2cap_br_connected(struct bt_l2cap_chan *chan)
 
 static void l2cap_br_disconnected(struct bt_l2cap_chan *chan)
 {
-	BT_DBG("ch %p cid 0x%04x", BR_CHAN(chan), BR_CHAN(chan)->rx.cid);
+	struct bt_l2cap_br_chan *br_chan = BR_CHAN(chan);
 
-	if (atomic_test_and_clear_bit(BR_CHAN(chan)->flags,
+	BT_DBG("ch %p cid 0x%04x", br_chan, br_chan->rx.cid);
+
+	if (atomic_test_and_clear_bit(br_chan->flags,
 				      L2CAP_FLAG_SIG_INFO_PENDING)) {
 		/* Cancel RTX work on signal channel.
 		 * Disconnected callback is always called from system workqueue
 		 * so this should always succeed.
 		 */
-		(void)k_work_cancel_delayable(&chan->rtx_work);
+		(void)k_work_cancel_delayable(&br_chan->rtx_work);
 	}
 }
 
@@ -1148,20 +1158,20 @@ int bt_l2cap_br_chan_disconnect(struct bt_l2cap_chan *chan)
 	struct net_buf *buf;
 	struct bt_l2cap_disconn_req *req;
 	struct bt_l2cap_sig_hdr *hdr;
-	struct bt_l2cap_br_chan *ch;
+	struct bt_l2cap_br_chan *br_chan;
 
 	if (!conn) {
 		return -ENOTCONN;
 	}
 
-	if (chan->state == BT_L2CAP_DISCONNECTING) {
+	br_chan = BR_CHAN(chan);
+
+	if (br_chan->state == BT_L2CAP_DISCONNECTING) {
 		return -EALREADY;
 	}
 
-	ch = BR_CHAN(chan);
-
-	BT_DBG("chan %p scid 0x%04x dcid 0x%04x", chan, ch->rx.cid,
-	       ch->tx.cid);
+	BT_DBG("chan %p scid 0x%04x dcid 0x%04x", chan, br_chan->rx.cid,
+	       br_chan->tx.cid);
 
 	buf = bt_l2cap_create_pdu(&br_sig_pool, 0);
 
@@ -1171,10 +1181,10 @@ int bt_l2cap_br_chan_disconnect(struct bt_l2cap_chan *chan)
 	hdr->len = sys_cpu_to_le16(sizeof(*req));
 
 	req = net_buf_add(buf, sizeof(*req));
-	req->dcid = sys_cpu_to_le16(ch->tx.cid);
-	req->scid = sys_cpu_to_le16(ch->rx.cid);
+	req->dcid = sys_cpu_to_le16(br_chan->tx.cid);
+	req->scid = sys_cpu_to_le16(br_chan->rx.cid);
 
-	l2cap_br_chan_send_req(ch, buf, L2CAP_BR_DISCONN_TIMEOUT);
+	l2cap_br_chan_send_req(br_chan, buf, L2CAP_BR_DISCONN_TIMEOUT);
 	bt_l2cap_chan_set_state(chan, BT_L2CAP_DISCONNECTING);
 
 	return 0;
@@ -1213,12 +1223,13 @@ int bt_l2cap_br_chan_connect(struct bt_conn *conn, struct bt_l2cap_chan *chan,
 	struct net_buf *buf;
 	struct bt_l2cap_sig_hdr *hdr;
 	struct bt_l2cap_conn_req *req;
+	struct bt_l2cap_br_chan *br_chan = BR_CHAN(chan);
 
 	if (!psm) {
 		return -EINVAL;
 	}
 
-	if (chan->psm) {
+	if (br_chan->psm) {
 		return -EEXIST;
 	}
 
@@ -1227,14 +1238,14 @@ int bt_l2cap_br_chan_connect(struct bt_conn *conn, struct bt_l2cap_chan *chan,
 		return -EINVAL;
 	}
 
-	if (chan->required_sec_level > BT_SECURITY_L4) {
+	if (br_chan->required_sec_level > BT_SECURITY_L4) {
 		return -EINVAL;
-	} else if (chan->required_sec_level == BT_SECURITY_L0 &&
+	} else if (br_chan->required_sec_level == BT_SECURITY_L0 &&
 		   psm != L2CAP_BR_PSM_SDP) {
-		chan->required_sec_level = BT_SECURITY_L1;
+		br_chan->required_sec_level = BT_SECURITY_L1;
 	}
 
-	switch (chan->state) {
+	switch (br_chan->state) {
 	case BT_L2CAP_CONNECTED:
 		/* Already connected */
 		return -EISCONN;
@@ -1252,7 +1263,7 @@ int bt_l2cap_br_chan_connect(struct bt_conn *conn, struct bt_l2cap_chan *chan,
 		return -ENOMEM;
 	}
 
-	chan->psm = psm;
+	br_chan->psm = psm;
 	bt_l2cap_chan_set_state(chan, BT_L2CAP_CONNECTING);
 	atomic_set_bit(BR_CHAN(chan)->flags, L2CAP_FLAG_CONN_PENDING);
 
@@ -1294,6 +1305,7 @@ static void l2cap_br_conn_rsp(struct bt_l2cap_br *l2cap, uint8_t ident,
 	struct bt_l2cap_chan *chan;
 	struct bt_l2cap_conn_rsp *rsp = (void *)buf->data;
 	uint16_t dcid, scid, result, status;
+	struct bt_l2cap_br_chan *br_chan;
 
 	if (buf->len < sizeof(*rsp)) {
 		BT_ERR("Too small L2CAP conn rsp packet size");
@@ -1314,25 +1326,27 @@ static void l2cap_br_conn_rsp(struct bt_l2cap_br *l2cap, uint8_t ident,
 		return;
 	}
 
-	/* Release RTX work since got the response */
-	k_work_cancel_delayable(&chan->rtx_work);
+	br_chan = BR_CHAN(chan);
 
-	if (chan->state != BT_L2CAP_CONNECTING) {
+	/* Release RTX work since got the response */
+	k_work_cancel_delayable(&br_chan->rtx_work);
+
+	if (br_chan->state != BT_L2CAP_CONNECTING) {
 		BT_DBG("Invalid channel %p state %s", chan,
-		       bt_l2cap_chan_state_str(chan->state));
+		       bt_l2cap_chan_state_str(br_chan->state));
 		return;
 	}
 
 	switch (result) {
 	case BT_L2CAP_BR_SUCCESS:
-		chan->ident = 0U;
+		br_chan->ident = 0U;
 		BR_CHAN(chan)->tx.cid = dcid;
 		l2cap_br_conf(chan);
 		bt_l2cap_chan_set_state(chan, BT_L2CAP_CONFIG);
 		atomic_clear_bit(BR_CHAN(chan)->flags, L2CAP_FLAG_CONN_PENDING);
 		break;
 	case BT_L2CAP_BR_PENDING:
-		k_work_reschedule(&chan->rtx_work, L2CAP_BR_CONN_TIMEOUT);
+		k_work_reschedule(&br_chan->rtx_work, L2CAP_BR_CONN_TIMEOUT);
 		break;
 	default:
 		l2cap_br_chan_cleanup(chan);
@@ -1342,13 +1356,13 @@ static void l2cap_br_conn_rsp(struct bt_l2cap_br *l2cap, uint8_t ident,
 
 int bt_l2cap_br_chan_send(struct bt_l2cap_chan *chan, struct net_buf *buf)
 {
-	struct bt_l2cap_br_chan *ch = BR_CHAN(chan);
+	struct bt_l2cap_br_chan *br_chan = BR_CHAN(chan);
 
-	if (buf->len > ch->tx.mtu) {
+	if (buf->len > br_chan->tx.mtu) {
 		return -EMSGSIZE;
 	}
 
-	return bt_l2cap_send_cb(ch->chan.conn, ch->tx.cid, buf, NULL, NULL);
+	return bt_l2cap_send_cb(br_chan->chan.conn, br_chan->tx.cid, buf, NULL, NULL);
 }
 
 static int l2cap_br_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
@@ -1419,7 +1433,7 @@ static void l2cap_br_conn_pend(struct bt_l2cap_chan *chan, uint8_t status)
 	struct bt_l2cap_sig_hdr *hdr;
 	struct bt_l2cap_conn_req *req;
 
-	if (chan->state != BT_L2CAP_CONNECTING) {
+	if (BR_CHAN(chan)->state != BT_L2CAP_CONNECTING) {
 		return;
 	}
 
@@ -1467,7 +1481,7 @@ static void l2cap_br_conn_pend(struct bt_l2cap_chan *chan, uint8_t status)
 		hdr->len = sys_cpu_to_le16(sizeof(*req));
 
 		req = net_buf_add(buf, sizeof(*req));
-		req->psm = sys_cpu_to_le16(chan->psm);
+		req->psm = sys_cpu_to_le16(BR_CHAN(chan)->psm);
 		req->scid = sys_cpu_to_le16(BR_CHAN(chan)->rx.cid);
 
 		l2cap_br_chan_send_req(BR_CHAN(chan), buf,

--- a/subsys/bluetooth/host/l2cap_internal.h
+++ b/subsys/bluetooth/host/l2cap_internal.h
@@ -254,6 +254,8 @@ struct bt_l2cap_br_fixed_chan {
 				.accept = _accept,		\
 			}
 
+#define BR_CHAN(_ch) CONTAINER_OF(_ch, struct bt_l2cap_br_chan, chan)
+
 /* Notify L2CAP channels of a new connection */
 void bt_l2cap_connected(struct bt_conn *conn);
 

--- a/subsys/bluetooth/host/rfcomm.c
+++ b/subsys/bluetooth/host/rfcomm.c
@@ -46,7 +46,6 @@
 #define RFCOMM_IDLE_TIMEOUT     K_SECONDS(2)
 
 #define DLC_RTX(_w) CONTAINER_OF(_w, struct bt_rfcomm_dlc, rtx_work)
-#define BR_CHAN(_ch) CONTAINER_OF(_ch, struct bt_l2cap_br_chan, chan)
 #define SESSION_RTX(_w) CONTAINER_OF(_w, struct bt_rfcomm_session, rtx_work)
 
 static struct bt_rfcomm_server *servers;

--- a/subsys/bluetooth/host/rfcomm.c
+++ b/subsys/bluetooth/host/rfcomm.c
@@ -46,7 +46,7 @@
 #define RFCOMM_IDLE_TIMEOUT     K_SECONDS(2)
 
 #define DLC_RTX(_w) CONTAINER_OF(_w, struct bt_rfcomm_dlc, rtx_work)
-
+#define BR_CHAN(_ch) CONTAINER_OF(_ch, struct bt_l2cap_br_chan, chan)
 #define SESSION_RTX(_w) CONTAINER_OF(_w, struct bt_rfcomm_session, rtx_work)
 
 static struct bt_rfcomm_server *servers;
@@ -1647,7 +1647,7 @@ int bt_rfcomm_dlc_connect(struct bt_conn *conn, struct bt_rfcomm_dlc *dlc,
 			break;
 		}
 		chan = &session->br_chan.chan;
-		chan->required_sec_level = dlc->required_sec_level;
+		BR_CHAN(chan)->required_sec_level = dlc->required_sec_level;
 		ret = bt_l2cap_chan_connect(conn, chan, BT_L2CAP_PSM_RFCOMM);
 		if (ret < 0) {
 			session->state = BT_RFCOMM_STATE_IDLE;

--- a/subsys/bluetooth/shell/l2cap.c
+++ b/subsys/bluetooth/shell/l2cap.c
@@ -297,7 +297,7 @@ static int cmd_connect(const struct shell *sh, size_t argc, char *argv[])
 
 		sec = *argv[2] - '0';
 
-		l2ch_chan.ch.chan.required_sec_level = sec;
+		l2ch_chan.ch.required_sec_level = sec;
 	}
 
 	err = bt_l2cap_chan_connect(default_conn, &l2ch_chan.ch.chan, psm);

--- a/subsys/net/l2/bluetooth/bluetooth.c
+++ b/subsys/net/l2/bluetooth/bluetooth.c
@@ -134,7 +134,7 @@ static int net_bt_enable(struct net_if *iface, bool state)
 
 	NET_DBG("iface %p %s", iface, state ? "up" : "down");
 
-	if (state && conn->ipsp_chan.chan.state != BT_L2CAP_CONNECTED) {
+	if (state && conn->ipsp_chan.state != BT_L2CAP_CONNECTED) {
 		return -ENETDOWN;
 	}
 

--- a/tests/bluetooth/tester/src/l2cap.c
+++ b/tests/bluetooth/tester/src/l2cap.c
@@ -259,7 +259,7 @@ static void connect(uint8_t *data, uint16_t len)
 fail:
 	for (i = 0U; i < ARRAY_SIZE(allocated_channels); i++) {
 		if (allocated_channels[i]) {
-			channels[allocated_channels[i]->ident].in_use = false;
+			channels[BT_L2CAP_LE_CHAN(allocated_channels[i])->ident].in_use = false;
 		}
 	}
 	tester_rsp(BTP_SERVICE_ID_L2CAP, L2CAP_CONNECT, CONTROLLER_INDEX,


### PR DESCRIPTION
Making sure struct bt_l2cap_chan has absolutely no members related
to dynamic channels.

That way we ensure that there is no overhead for a build where only
fixed channels are used.

It's not enough that the dynamic channel-related members are put behind
ifdefs - they should be completely moved out from the struct definition.

Furthermore, the public l2cap.h header file already has a struct
that's meant to be used for dynamic channels: struct bt_l2cap_le_chan!

However, currently dynamic channel support is a mess - it's a mix
between these two structs. The bt_l2cap_le_chan struct should really
be an extension of the bt_l2cap_chan struct, i.e. the former should
contain as a member the latter.

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>