### PR TITLE
Bluetooth: Mesh: Opt ram of transport segment message

### DIFF
--- a/include/bluetooth/mesh/access.h
+++ b/include/bluetooth/mesh/access.h
@@ -56,14 +56,35 @@ extern "C" {
 #define BT_MESH_IS_DEV_KEY(key) (key == BT_MESH_KEY_DEV_LOCAL || \
 				 key == BT_MESH_KEY_DEV_REMOTE)
 
-/** Maximum payload size of an access message (in octets). */
+/** Maximum size of an access message segment (in octets). */
 #define BT_MESH_APP_SEG_SDU_MAX   12
+
+/** Maximum payload size of an unsegmented access message (in octets). */
+#define BT_MESH_APP_UNSEG_SDU_MAX 15
+
+/** Maximum number of segments supported for incoming messages. */
+#if defined(CONFIG_BT_MESH_RX_SEG_MAX)
+#define BT_MESH_RX_SEG_MAX CONFIG_BT_MESH_RX_SEG_MAX
+#else
+#define BT_MESH_RX_SEG_MAX 0
+#endif
+
+/** Maximum number of segments supported for outgoing messages. */
+#if defined(CONFIG_BT_MESH_TX_SEG_MAX)
+#define BT_MESH_TX_SEG_MAX CONFIG_BT_MESH_TX_SEG_MAX
+#else
+#define BT_MESH_TX_SEG_MAX 0
+#endif
+
 /** Maximum possible payload size of an outgoing access message (in octets). */
-#define BT_MESH_TX_SDU_MAX        (CONFIG_BT_MESH_TX_SEG_MAX * \
-				  BT_MESH_APP_SEG_SDU_MAX)
+#define BT_MESH_TX_SDU_MAX        MAX((BT_MESH_TX_SEG_MAX *		\
+				       BT_MESH_APP_SEG_SDU_MAX),	\
+				      BT_MESH_APP_UNSEG_SDU_MAX)
+
 /** Maximum possible payload size of an incoming access message (in octets). */
-#define BT_MESH_RX_SDU_MAX        (CONFIG_BT_MESH_RX_SEG_MAX * \
-				  BT_MESH_APP_SEG_SDU_MAX)
+#define BT_MESH_RX_SDU_MAX        MAX((BT_MESH_RX_SEG_MAX *		\
+				       BT_MESH_APP_SEG_SDU_MAX),	\
+				      BT_MESH_APP_UNSEG_SDU_MAX)
 
 /** Helper to define a mesh element within an array.
  *

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -378,18 +378,26 @@ config BT_MESH_IVU_DIVIDER
 config BT_MESH_TX_SEG_MSG_COUNT
 	int "Maximum number of simultaneous outgoing segmented messages"
 	default 1
-	range 1 255
+	range 0 255
 	help
 	  Maximum number of simultaneous outgoing multi-segment and/or
 	  reliable messages.
 
+	  Note that: Since Mesh Segmentation/reassemblying is a mandatory
+	  feature of specification, set to zero will not allow send any
+	  Mesh Segment message.
+
 config BT_MESH_RX_SEG_MSG_COUNT
 	int "Maximum number of simultaneous incoming segmented messages"
 	default 1
-	range 1 255
+	range 0 255
 	help
 	  Maximum number of simultaneous incoming multi-segment and/or
 	  reliable messages.
+
+	  Note that: Since Mesh Segmentation/reassemblying is a mandatory
+	  feature of specification, set to zero will not allow receive any
+	  Mesh Segment message.
 
 config BT_MESH_SEG_BUFS
 	int "Number of segment buffers available"
@@ -411,7 +419,8 @@ config BT_MESH_SEG_BUFS
 config BT_MESH_RX_SEG_MAX
 	int "Maximum number of segments in incoming messages"
 	default 3
-	range 2 32
+	range 1 32
+	depends on BT_MESH_RX_SEG_MSG_COUNT > 0
 	help
 	  Maximum number of segments supported for incoming messages.
 	  This value should typically be fine-tuned based on what
@@ -430,7 +439,8 @@ config BT_MESH_RX_SEG_MAX
 config BT_MESH_TX_SEG_MAX
 	int "Maximum number of segments in outgoing messages"
 	default 3
-	range 2 32
+	range 1 32
+	depends on BT_MESH_TX_SEG_MSG_COUNT > 0
 	help
 	  Maximum number of segments supported for outgoing messages.
 	  This value should typically be fine-tuned based on what

--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -92,7 +92,7 @@ struct va_val {
 
 static struct seg_tx {
 	struct bt_mesh_subnet *sub;
-	void                  *seg[CONFIG_BT_MESH_TX_SEG_MAX];
+	void                  *seg[BT_MESH_TX_SEG_MAX];
 	uint64_t              seq_auth;
 	uint16_t              src;
 	uint16_t              dst;
@@ -118,7 +118,7 @@ static struct seg_tx {
 
 static struct seg_rx {
 	struct bt_mesh_subnet   *sub;
-	void                    *seg[CONFIG_BT_MESH_RX_SEG_MAX];
+	void                    *seg[BT_MESH_RX_SEG_MAX];
 	uint64_t                    seq_auth;
 	uint16_t                    src;
 	uint16_t                    dst;
@@ -1166,7 +1166,7 @@ static void seg_ack(struct k_work *work)
 
 static inline bool sdu_len_is_ok(bool ctl, uint8_t seg_n)
 {
-	return (seg_n < CONFIG_BT_MESH_RX_SEG_MAX);
+	return (seg_n < BT_MESH_RX_SEG_MAX);
 }
 
 static struct seg_rx *seg_rx_find(struct bt_mesh_net_rx *net_rx,

--- a/subsys/bluetooth/mesh/transport.h
+++ b/subsys/bluetooth/mesh/transport.h
@@ -7,8 +7,11 @@
 #define TRANS_SEQ_AUTH_NVAL            0xffffffffffffffff
 
 #define BT_MESH_SDU_UNSEG_MAX          11
-#define BT_MESH_CTL_SEG_SDU_MAX        8
-#define BT_MESH_RX_CTL_MAX (CONFIG_BT_MESH_RX_SEG_MAX * BT_MESH_CTL_SEG_SDU_MAX)
+#define BT_MESH_CTL_SEG_SDU_MAX	       8
+
+#define BT_MESH_RX_CTL_MAX	       MAX((BT_MESH_RX_SEG_MAX *	\
+					    BT_MESH_CTL_SEG_SDU_MAX),	\
+					     BT_MESH_SDU_UNSEG_MAX)
 
 #define TRANS_SEQ_ZERO_MASK            ((uint16_t)BIT_MASK(13))
 #define TRANS_CTL_OP_MASK              ((uint8_t)BIT_MASK(7))


### PR DESCRIPTION
As use for simple message with no-segment send or receive.

This will be useful for ram-resource-constrained device.
such as bbc-microbit-v1.

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>