### PR TITLE
kconfig: mbedtls: Allow MBEDTLS_BUILTIN to be deselected

### DIFF
--- a/modules/mbedtls/Kconfig
+++ b/modules/mbedtls/Kconfig
@@ -27,6 +27,7 @@ choice MBEDTLS_IMPLEMENTATION
 
 config MBEDTLS_BUILTIN
 	bool "Use Zephyr in-tree mbedTLS version"
+	depends on ! DISABLE_MBEDTLS_BUILTIN
 	help
 	  Link with mbedTLS sources included with Zephyr distribution.
 	  Included mbedTLS version is well integrated with and supported
@@ -39,6 +40,11 @@ config MBEDTLS_LIBRARY
 	  users only.
 
 endchoice
+
+# subsystems cannot deselect MBEDTLS_BUILTIN, but they can select
+# DISABLE_MBEDTLS_BUILTIN.
+config DISABLE_MBEDTLS_BUILTIN
+	bool
 
 config CUSTOM_MBEDTLS_CFG_FILE
 	bool "Custom mbed TLS configuration file"


### PR DESCRIPTION
Out-of-tree crypto subsystems need to deselect MBEDTLS_BUILTIN, but
deselection is not supported. It is however supported to select a
dependency in a ! expression.

This patch gives out-of-tree mbedtls implementations the ability to
supplant the Zephyr mbedtls.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>