### PR TITLE
doc: devicetree: fix broken link in api.rst

### DIFF
--- a/doc/reference/devicetree/api.rst
+++ b/doc/reference/devicetree/api.rst
@@ -248,8 +248,7 @@ Fixed flash partitions
 
 These conveniences may be used for the special-purpose ``fixed-partitions``
 compatible used to encode information about flash memory partitions in the
-device tree. See :zephyr_file:`dts/bindings/mtd/partition.yaml` for this
-compatible's binding.
+device tree. See See :dtcompatible:`fixed-partition` for more details.
 
 .. doxygengroup:: devicetree-fixed-partition
 


### PR DESCRIPTION
The devicetree binding link for fixed-partitions is broken. I assumed the file is now called _fixed_partitions.yaml_. See https://docs.zephyrproject.org/latest/reference/devicetree/api.html#fixed-flash-partitions.