### PR TITLE
drivers: can:can_mcan.h : add back macro NUM_TX_EVENT_FIFO_ELEMENTS

### DIFF
--- a/drivers/can/can_mcan.h
+++ b/drivers/can/can_mcan.h
@@ -26,6 +26,8 @@
 #define NUM_RX_FIFO0_ELEMENTS   DT_PROP(MCAN_DT_PATH, rx_fifo0_elements)
 #define NUM_RX_FIFO1_ELEMENTS   DT_PROP(MCAN_DT_PATH, rx_fifo0_elements)
 #define NUM_RX_BUF_ELEMENTS     DT_PROP(MCAN_DT_PATH, rx_buffer_elements)
+#define NUM_TX_EVENT_FIFO_ELEMENTS \
+				DT_PROP(MCAN_DT_PATH, tx_event_fifo_elements)
 #define NUM_TX_BUF_ELEMENTS     DT_PROP(MCAN_DT_PATH, tx_buffer_elements)
 
 #ifdef CONFIG_CAN_STM32FD
@@ -161,7 +163,7 @@ struct can_mcan_msg_sram {
 	volatile struct can_mcan_rx_fifo rx_fifo0[NUM_RX_FIFO0_ELEMENTS];
 	volatile struct can_mcan_rx_fifo rx_fifo1[NUM_RX_FIFO1_ELEMENTS];
 	volatile struct can_mcan_rx_fifo rx_buffer[NUM_RX_BUF_ELEMENTS];
-	volatile struct can_mcan_tx_event_fifo tx_event_fifo[NUM_TX_BUF_ELEMENTS];
+	volatile struct can_mcan_tx_event_fifo tx_event_fifo[NUM_TX_EVENT_FIFO_ELEMENTS];
 	volatile struct can_mcan_tx_buffer tx_buffer[NUM_TX_BUF_ELEMENTS];
 } __packed __aligned(4);
 

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -457,6 +457,7 @@
 			rx-fifo1-elements = <3>;
 			rx-buffer-elements = <0>;
 			tx-buffer-elements = <1>;
+			tx-event-fifo-elements = <1>;
 
 			can0: can@40030000 {
 				compatible = "atmel,sam-can";

--- a/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
@@ -227,6 +227,7 @@
 		rx-fifo1-elements = <64>;
 		rx-buffer-elements = <64>;
 		tx-buffer-elements = <32>;
+		tx-event-fifo-elements = <32>;
 		sjw = <1>;
 		sample-point = <875>;
 		sjw-data = <1>;

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -358,6 +358,7 @@
 			rx-fifo1-elements = <3>;
 			rx-buffer-elements = <0>;
 			tx-buffer-elements = <3>;
+			tx-event-fifo-elements = <3>;
 
 			can1: can@40006400 {
 				compatible = "st,stm32-fdcan";

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -451,6 +451,7 @@
 			rx-fifo1-elements = <3>;
 			rx-buffer-elements = <3>;
 			tx-buffer-elements = <3>;
+			tx-event-fifo-elements = <3>;
 
 			can1: can@4000a000 {
 				compatible = "st,stm32h7-fdcan";

--- a/dts/bindings/can/bosch,m-can-base.yaml
+++ b/dts/bindings/can/bosch,m-can-base.yaml
@@ -23,6 +23,10 @@ properties:
       type: int
       required: true
 
+    tx-event-fifo-elements:
+      type: int
+      required: true
+
     tx-buffer-elements:
       type: int
       required: true


### PR DESCRIPTION
From [can_mcan.h](https://github.com/zephyrproject-rtos/zephyr/blob/e4da3e528088a34a9989f5a50e7ed3149d57de92/drivers/can/can_mcan.h#L16) in zephyr-v2.7.1, there is helper macro for `NUM_TX_EVENT_FIFO_ELEMENTS` which seems like should be used for size of [can_mcan_tx_event_fifo tx_event_fifo](https://github.com/zephyrproject-rtos/zephyr/blob/e4da3e528088a34a9989f5a50e7ed3149d57de92/drivers/can/can_mcan.h#L154)

Not sure whether that was a typo or meant to be using same size of `NUM_TX_BUF_ELEMENTS` for both `can_mcan_tx_event_fifo tx_event_fifo` and `can_mcan_tx_buffer tx_buffer`

This pull request is just trying to add back the helper macro and add on the missing dts property for `tx-event-fifo-elements`

The value of `tx-event-fifo-elements` in .dtsi files is set to be the same with `tx-buffer-elements` for now to avoid unintended changes

Signed-off-by: Pin Loon Lee <pinloon_0428@hotmail.com>