### PR TITLE
spi: nrfx_spi*: only run uninit if configured

### DIFF
--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -285,8 +285,10 @@ static int spi_nrfx_pm_action(const struct device *dev,
 		break;
 
 	case PM_DEVICE_ACTION_SUSPEND:
-		nrfx_spi_uninit(&config->spi);
-		data->initialized = false;
+		if (data->initialized) {
+			nrfx_spi_uninit(&config->spim);
+			data->initialized = false;
+		}
 		break;
 
 	default:

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -443,8 +443,10 @@ static int spim_nrfx_pm_action(const struct device *dev,
 		break;
 
 	case PM_DEVICE_ACTION_SUSPEND:
-		nrfx_spim_uninit(&config->spim);
-		data->initialized = false;
+		if (data->initialized) {
+			nrfx_spim_uninit(&config->spim);
+			data->initialized = false;
+		}
 		break;
 
 	default:


### PR DESCRIPTION
Only run the `uninit` function if the SPI instance has previously been
configured. This stops an assertion in the HAL drivers from triggering
due to running `uninit` without a previous `init`.

Fixes #42299.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>