### PR TITLE
doc: doxygen: generate and expose Doxygen tag file

### DIFF
--- a/doc/_extensions/zephyr/doxyrunner.py
+++ b/doc/_extensions/zephyr/doxyrunner.py
@@ -185,6 +185,7 @@ def process_doxyfile(
             raise ValueError("Invalid formatting pattern or variables")
 
         if outdir_var:
+            fmt_vars = fmt_vars.copy()
             fmt_vars[outdir_var] = outdir.as_posix()
 
         for var, value in fmt_vars.items():

--- a/doc/_extensions/zephyr/doxyrunner.py
+++ b/doc/_extensions/zephyr/doxyrunner.py
@@ -31,6 +31,9 @@ Configuration options
 - ``doxyrunner_doxyfile``: Path to Doxyfile.
 - ``doxyrunner_outdir``: Doxygen build output directory (inserted to
   ``OUTPUT_DIRECTORY``)
+- ``doxyrunner_outdir_var``: Variable representing the Doxygen build output
+  directory, as used by ``OUTPUT_DIRECTORY``. This can be useful if other
+  Doxygen variables reference to the output directory.
 - ``doxyrunner_fmt``: Flag to indicate if Doxyfile should be formatted.
 - ``doxyrunner_fmt_vars``: Format variables dictionary (name: value).
 - ``doxyrunner_fmt_pattern``: Format pattern.
@@ -132,6 +135,7 @@ def process_doxyfile(
     fmt: bool = False,
     fmt_pattern: Optional[str] = None,
     fmt_vars: Optional[Dict[str, str]] = None,
+    outdir_var: Optional[str] = None,
 ) -> str:
     """Process Doxyfile.
 
@@ -146,6 +150,7 @@ def process_doxyfile(
         fmt: If Doxyfile should be formatted.
         fmt_pattern: Format pattern.
         fmt_vars: Format variables.
+        outdir_var: Variable representing output directory.
 
      Returns:
         Processed Doxyfile content.
@@ -178,6 +183,9 @@ def process_doxyfile(
     if fmt:
         if not fmt_pattern or not fmt_vars:
             raise ValueError("Invalid formatting pattern or variables")
+
+        if outdir_var:
+            fmt_vars[outdir_var] = outdir.as_posix()
 
         for var, value in fmt_vars.items():
             content = content.replace(fmt_pattern.format(var), value)
@@ -349,6 +357,7 @@ def doxygen_build(app: Sphinx) -> None:
         app.config.doxyrunner_fmt,
         app.config.doxyrunner_fmt_pattern,
         app.config.doxyrunner_fmt_vars,
+        app.config.doxyrunner_outdir_var,
     )
 
     logger.info("Checking if Doxygen needs to be run...")
@@ -374,6 +383,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_config_value("doxyrunner_doxygen", "doxygen", "env")
     app.add_config_value("doxyrunner_doxyfile", None, "env")
     app.add_config_value("doxyrunner_outdir", None, "env")
+    app.add_config_value("doxyrunner_outdir_var", None, "env")
     app.add_config_value("doxyrunner_fmt", False, "env")
     app.add_config_value("doxyrunner_fmt_vars", {}, "env")
     app.add_config_value("doxyrunner_fmt_pattern", "@{}@", "env")

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -180,6 +180,7 @@ doxyrunner_doxyfile = ZEPHYR_BASE / "doc" / "zephyr.doxyfile.in"
 doxyrunner_outdir = ZEPHYR_BUILD / "doxygen"
 doxyrunner_fmt = True
 doxyrunner_fmt_vars = {"ZEPHYR_BASE": str(ZEPHYR_BASE)}
+doxyrunner_outdir_var = "DOXY_OUT"
 
 # -- Options for Breathe plugin -------------------------------------------
 

--- a/doc/guides/docs/index.rst
+++ b/doc/guides/docs/index.rst
@@ -261,7 +261,21 @@ or invoke make with the following target::
    # To generate HTML output without detailed Kconfig
    make html-fast
 
+Linking external Doxygen projects against Zephyr
+************************************************
+
+External projects that build upon Zephyr functionality and wish to refer to
+Zephyr documentation in Doxygen (through the use of @ref), can utilize the
+tag file exported at `zephyr.tag </doxygen/html/zephyr.tag>`_
+
+Once downloaded, the tag file can be used in a custom ``doxyfile.in`` as follows::
+
+   TAGFILES = "/path/to/zephyr.tag=https://docs.zephyrproject.org/latest/doxygen/html/"
+
+For additional information refer to `Doxygen External Documentation`_.
+
 
 .. _reStructuredText: http://sphinx-doc.org/rest.html
 .. _Sphinx: http://sphinx-doc.org/
 .. _Windows Python Path: https://docs.python.org/3/using/windows.html#finding-the-python-executable
+.. _Doxygen External Documentation: https://www.doxygen.nl/manual/external.html

--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -2064,7 +2064,7 @@ TAGFILES               =
 # tag file that is based on the input files it reads. See section "Linking to
 # external documentation" for more information about the usage of tag files.
 
-GENERATE_TAGFILE       =
+GENERATE_TAGFILE       = @DOXY_OUT@/html/zephyr.tag
 
 # If the ALLEXTERNALS tag is set to YES, all external class will be listed in
 # the class index. If set to NO, only the inherited external classes will be


### PR DESCRIPTION
Generate the doxygen tag file when building documentation and expose it on the website for external projects to link against.
See https://www.doxygen.nl/manual/external.html

IMO it makes sense to enable external users to link to the LTS docs over the next few years, hence the backport.

Backport of #41688 and #41530

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/41529