### PR TITLE
pm: Remove waiting in idle thread when switching to PM_STATE_SOFT_OFF

### DIFF
--- a/soc/arm/st_stm32/stm32wb/power.c
+++ b/soc/arm/st_stm32/stm32wb/power.c
@@ -61,12 +61,9 @@ static void lpm_hsem_lock(void)
 
 static void send_stack_reset(void)
 {
-	struct net_buf *rsp;
 	int err = 0;
 
-	err = bt_hci_cmd_send_sync(ACI_HAL_STACK_RESET, NULL, &rsp);
-
-	net_buf_unref(rsp);
+	err = bt_hci_cmd_send(ACI_HAL_STACK_RESET, NULL);
 
 	if (err) {
 		LOG_ERR("M0 BLE stack reset issue");


### PR DESCRIPTION
The present STM32WB implementation of switching to PM_STATE_SOFT_OFF
uses synchronous call for sending HCI command.
This causes triggering of assertion because waiting is not allowed
in the idle thread.

Fixes #41944

Signed-off-by: Artur Lipowski <Artur.Lipowski@hidglobal.com>