### PR TITLE
Bluetooth: Controller: Fix missing Periodic Advertising incomplete report 

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -429,16 +429,14 @@ static int prepare_cb(struct lll_prepare_param *p)
 	lll_aux = p->param;
 	lll = ull_scan_aux_lll_parent_get(lll_aux, &is_lll_scan);
 
-#if defined(CONFIG_BT_CTLR_SYNC_PERIODIC)
 	/* Check if this aux scan is for periodic advertising train */
-	if (!is_lll_scan) {
+	if (IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC) && !is_lll_scan) {
 		lll_sync_aux_prepare_cb((void *)lll, lll_aux);
 
 		lll = NULL;
 
 		goto sync_aux_prepare_done;
 	}
-#endif /* CONFIG_BT_CTLR_SYNC_PERIODIC */
 
 #if defined(CONFIG_BT_CENTRAL)
 	/* Check if stopped (on connection establishment race between
@@ -519,9 +517,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 				       (uint8_t *)fal->bdaddr);
 	}
 
-#if defined(CONFIG_BT_CTLR_SYNC_PERIODIC)
 sync_aux_prepare_done:
-#endif
 	/* Calculate event timings, coarse and fine */
 	ticks_at_event = p->ticks_at_expire;
 	ull = HDR_LLL2ULL(lll_aux);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -656,6 +656,8 @@ static int isr_rx(struct lll_sync *lll, uint8_t node_type, uint8_t crc_ok, uint8
 			ull_rx_put(node_rx->hdr.link, node_rx);
 
 			sched = true;
+		} else if (node_type == NODE_RX_TYPE_EXT_AUX_REPORT) {
+			err = -ENOMEM;
 		} else {
 			err = 0;
 		}
@@ -834,6 +836,7 @@ static void isr_rx_aux_chain(void *param)
 		lll_isr_status_reset();
 
 		crc_ok =  0U;
+		err = 0;
 
 		goto isr_rx_aux_chain_done;
 	}
@@ -854,6 +857,9 @@ static void isr_rx_aux_chain(void *param)
 	if (!trx_done) {
 		/* TODO: Combine the early exit with above if-then-else block
 		 */
+
+		err = 0;
+
 		goto isr_rx_aux_chain_done;
 	}
 
@@ -869,7 +875,7 @@ static void isr_rx_aux_chain(void *param)
 	}
 
 isr_rx_aux_chain_done:
-	if (!crc_ok) {
+	if (!crc_ok || err) {
 		struct node_rx_pdu *node_rx;
 
 		node_rx = ull_pdu_rx_alloc();

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -606,7 +606,13 @@ static int isr_rx(struct lll_sync *lll, uint8_t node_type, uint8_t crc_ok, uint8
 	if (crc_ok) {
 		struct node_rx_pdu *node_rx;
 
-		node_rx = ull_pdu_rx_alloc_peek(3);
+		/* Verify if there are free RX buffers for:
+		 * - reporting just received PDU
+		 * - allocating an extra node_rx for periodic report incomplete
+		 * - a buffer for receiving data in a connection
+		 * - a buffer for receiving empty PDU
+		 */
+		node_rx = ull_pdu_rx_alloc_peek(4);
 		if (node_rx) {
 			struct node_rx_ftr *ftr;
 			struct pdu_adv *pdu;
@@ -626,6 +632,10 @@ static int isr_rx(struct lll_sync *lll, uint8_t node_type, uint8_t crc_ok, uint8
 								     1);
 			ftr->sync_status = status;
 			ftr->sync_rx_enabled = lll->is_rx_enabled;
+
+			if (node_type != NODE_RX_TYPE_EXT_AUX_REPORT) {
+				ftr->extra = ull_pdu_rx_alloc();
+			}
 
 			pdu = (void *)node_rx->pdu;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -50,7 +50,6 @@ static inline uint8_t aux_handle_get(struct ll_scan_aux_set *aux);
 static inline struct ll_sync_set *sync_create_get(struct ll_scan_set *scan);
 static inline struct ll_sync_iso_set *
 	sync_iso_create_get(struct ll_sync_set *sync);
-static void last_disabled_cb(void *param);
 static void done_disabled_cb(void *param);
 static void flush(void *param);
 
@@ -168,7 +167,8 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 			/* aux parent will be NULL for periodic sync */
 			lll = aux->parent;
 
-		} else if (ull_scan_is_valid_get(HDR_LLL2ULL(ftr->param))) {
+		} else if (!IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC) ||
+			   ull_scan_is_valid_get(HDR_LLL2ULL(ftr->param))) {
 			sync_lll = NULL;
 
 			/* Node that does not have valid aux context but has
@@ -195,7 +195,7 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 			aux = HDR_LLL2ULL(lll_aux);
 		}
 
-		if (lll) {
+		if (!IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC) || lll) {
 			scan = HDR_LLL2ULL(lll);
 			sync = (void *)scan;
 			scan = ull_scan_is_valid_get(scan);
@@ -208,7 +208,7 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 		}
 
 		phy = lll_aux->phy;
-		if (scan) {
+		if (!IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC) || scan) {
 			/* Here we are scanner context */
 			sync = sync_create_get(scan);
 
@@ -305,7 +305,7 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 			data_len = 0U;
 		}
 
-		if (sync_lll) {
+		if (IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC) && sync_lll) {
 			struct ll_sync_set *sync;
 
 			sync = HDR_LLL2ULL(sync_lll);
@@ -378,15 +378,14 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 		si = (void *)ptr;
 		ptr += sizeof(*si);
 
-#if defined(CONFIG_BT_CTLR_SYNC_PERIODIC)
 		/* Check if Periodic Advertising Synchronization to be created.
 		 * Setup synchronization if address and SID match in the
 		 * Periodic Advertiser List or with the explicitly supplied.
 		 */
-		if (sync && adi && ull_sync_setup_sid_match(scan, adi->sid)) {
+		if (IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC) && sync && adi &&
+		    ull_sync_setup_sid_match(scan, adi->sid)) {
 			ull_sync_setup(scan, aux, rx, si);
 		}
-#endif /* CONFIG_BT_CTLR_SYNC_PERIODIC */
 	}
 
 	if (h->tx_pwr) {
@@ -432,7 +431,7 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 	 */
 	if (!aux_ptr || !aux_ptr->offs || is_scan_req ||
 	    (aux_ptr->phy > EXT_ADV_AUX_PHY_LE_CODED)) {
-		if (sync_lll) {
+		if (IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC) && sync_lll) {
 			struct ll_sync_set *sync;
 
 			sync = HDR_LLL2ULL(sync_lll);
@@ -460,7 +459,8 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 	if (!aux) {
 		aux = aux_acquire();
 		if (!aux) {
-			if (sync_lll) {
+			if (IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC) &&
+			    sync_lll) {
 				struct ll_sync_set *sync;
 
 				sync = HDR_LLL2ULL(sync_lll);
@@ -494,16 +494,12 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 	/* In sync context we can dispatch rx immediately, in scan context we
 	 * enqueue rx in aux context and will flush them after scan is complete.
 	 */
-	if (0) {
-#if defined(CONFIG_BT_CTLR_SYNC_PERIODIC)
-	} else if (sync_lll) {
+	if (IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC) && sync_lll) {
 		struct ll_sync_set *sync;
 
 		sync = HDR_LLL2ULL(sync_lll);
 		sync->data_len += data_len;
 		ftr->aux_data_len = sync->data_len;
-
-#endif /* CONFIG_BT_CTLR_SYNC_PERIODIC */
 	} else {
 		if (aux->rx_last) {
 			aux->rx_last->rx_ftr.extra = rx;
@@ -528,16 +524,12 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 		/* AUX_ADV_IND/AUX_CHAIN_IND PDU reception is being setup */
 		ftr->aux_sched = 1U;
 
-		if (0) {
-#if defined(CONFIG_BT_CTLR_SYNC_PERIODIC)
-		} else if (sync_lll) {
+		if (IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC) && sync_lll) {
 			sync_lll->lll_aux = lll_aux;
 
 			/* In sync context, dispatch immediately */
 			ll_rx_put(link, rx);
 			ll_rx_sched();
-
-#endif /* CONFIG_BT_CTLR_SYNC_PERIODIC */
 		} else {
 			lll->lll_aux = lll_aux;
 		}
@@ -551,7 +543,7 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 	}
 
 	/* Switching to ULL scheduling to receive auxiliary PDUs */
-	if (lll) {
+	if (!IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC) || lll) {
 		lll->lll_aux = NULL;
 	} else {
 		LL_ASSERT(sync_lll &&
@@ -664,7 +656,7 @@ ull_scan_aux_rx_flush:
 		/* Enqueue last rx in aux context if possible, otherwise send
 		 * immediately since we are in sync context.
 		 */
-		if (aux->rx_last) {
+		if (!IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC) || aux->rx_last) {
 			aux->rx_last->rx_ftr.extra = rx;
 		} else {
 			LL_ASSERT(sync_lll);
@@ -690,7 +682,7 @@ ull_scan_aux_rx_flush:
 			LL_ASSERT(!hdr->disabled_cb);
 
 			hdr->disabled_param = aux;
-			hdr->disabled_cb = last_disabled_cb;
+			hdr->disabled_cb = done_disabled_cb;
 		}
 
 		return;
@@ -715,9 +707,8 @@ void ull_scan_aux_done(struct node_rx_event_done *done)
 	/* Get reference to ULL context */
 	aux = CONTAINER_OF(done->param, struct ll_scan_aux_set, ull);
 
-	if (0) {
-#if defined(CONFIG_BT_CTLR_SYNC_PERIODIC)
-	} else if (!ull_scan_aux_is_valid_get(aux)) {
+	if (IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC) &&
+	    !ull_scan_aux_is_valid_get(aux)) {
 		struct ll_sync_set *sync;
 
 		sync = CONTAINER_OF(done->param, struct ll_sync_set, ull);
@@ -729,7 +720,6 @@ void ull_scan_aux_done(struct node_rx_event_done *done)
 		}
 
 		aux = HDR_LLL2ULL(sync->lll.lll_aux);
-#endif /* CONFIG_BT_CTLR_SYNC_PERIODIC */
 	} else {
 		/* Setup the disabled callback to flush the auxiliary PDUs */
 		hdr = &aux->ull;
@@ -792,12 +782,14 @@ void ull_scan_aux_release(memq_link_t *link, struct node_rx_hdr *rx)
 
 		lll = rx->rx_ftr.param;
 		lll_aux = lll->lll_aux;
-	} else if (ull_scan_aux_is_valid_get(param_ull)) {
+
+	} else if (!IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC) ||
+		   ull_scan_aux_is_valid_get(param_ull)) {
 		/* Mark for buffer for release */
 		rx->type = NODE_RX_TYPE_RELEASE;
 
 		lll_aux = rx->rx_ftr.param;
-#if defined(CONFIG_BT_CTLR_SYNC_PERIODIC)
+
 	} else if (ull_sync_is_valid_get(param_ull)) {
 		struct ll_sync_set *sync;
 		struct lll_sync *lll;
@@ -820,7 +812,7 @@ void ull_scan_aux_release(memq_link_t *link, struct node_rx_hdr *rx)
 		 * pointer to NULL.
 		 */
 		rx->rx_ftr.extra = NULL;
-#endif /* CONFIG_BT_CTLR_SYNC_PERIODIC */
+
 	} else {
 		LL_ASSERT(0);
 		lll_aux = NULL;
@@ -842,7 +834,7 @@ void ull_scan_aux_release(memq_link_t *link, struct node_rx_hdr *rx)
 			LL_ASSERT(!hdr->disabled_cb);
 
 			hdr->disabled_param = aux;
-			hdr->disabled_cb = last_disabled_cb;
+			hdr->disabled_cb = done_disabled_cb;
 		}
 	}
 
@@ -928,30 +920,9 @@ static inline struct ll_sync_iso_set *
 #endif /* !CONFIG_BT_CTLR_SYNC_ISO */
 }
 
-static void last_disabled_cb(void *param)
-{
-	flush(param);
-}
-
 static void done_disabled_cb(void *param)
 {
-	struct ll_scan_aux_set *aux;
-
-	aux = param;
-	LL_ASSERT(ull_scan_aux_is_valid_get(aux));
-
-	aux = ull_scan_aux_is_valid_get(aux);
-#if defined(CONFIG_BT_CTLR_SYNC_PERIODIC)
-	if (!aux) {
-		struct lll_sync *sync_lll;
-
-		sync_lll = param;
-		LL_ASSERT(sync_lll->lll_aux);
-		aux = HDR_LLL2ULL(sync_lll->lll_aux);
-	}
-#endif /* CONFIG_BT_CTLR_SYNC_PERIODIC */
-
-	flush(aux);
+	flush(param);
 }
 
 static void flush(void *param)
@@ -983,7 +954,7 @@ static void flush(void *param)
 	lll = aux->parent;
 	scan = HDR_LLL2ULL(lll);
 	scan = ull_scan_is_valid_get(scan);
-	if (scan) {
+	if (!IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC) || scan) {
 		lll->lll_aux = NULL;
 	} else {
 		struct lll_sync *sync_lll;

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_types.h
@@ -46,4 +46,8 @@ struct ll_scan_aux_set {
 	struct node_rx_hdr *rx_last;
 
 	uint16_t data_len;
+
+#if defined(CONFIG_BT_CTLR_SYNC_PERIODIC)
+	struct node_rx_hdr *rx_incomplete;
+#endif
 };


### PR DESCRIPTION
Fix Periodic Advertising Report data status when ULL
scheduling to receive auxiliary PDU fails. Defer the
dispatch of Periodic Advertising Report until ULL
scheduling status is comfirmed and assign the correct
value to aux_sched flag.

Fix Controller implementation to release auxiliary context
when there is no node rx buffer available to receive
Periodic Advertising Sync AUX_CHAIN_IND PDUs.

Fix missing Periodic Advertising Report with incomplete
data status when LLL scheduled chain reception is aborted.

Fix missing Periodic Advertising Report with incomplete
data status when ULL scheduled chain reception is aborted.

Relates to #39438.
Relates to #40317.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>