### PR TITLE
Bluetooth: PACS: Add PAC data to pac_notify

### DIFF
--- a/include/bluetooth/audio/audio.h
+++ b/include/bluetooth/audio/audio.h
@@ -1057,6 +1057,11 @@ struct bt_audio_unicast_server_cb {
 	 *  is returned, the previously returned @p codec values (if any) will
 	 *  be sent to the client that requested the value.
 	 *
+	 *  @param conn   The connection that requests the capabilities.
+	 *                Will be NULL if the capabilities is requested for
+	 *                sending a notification, as a result of callling
+	 *                bt_audio_capability_register() or
+	 *                bt_audio_capability_unregister().
 	 *  @param type   Type of the endpoint.
 	 *  @param index  Index of the codec object requested. Multiple objects
 	 *                may be returned, and this value keep tracks of how

--- a/subsys/bluetooth/audio/pacs.c
+++ b/subsys/bluetooth/audio/pacs.c
@@ -347,21 +347,28 @@ static void pac_notify(struct k_work *work)
 {
 #if defined(CONFIG_BT_PAC_SNK) || defined(CONFIG_BT_PAC_SRC)
 	struct bt_uuid *uuid;
+	uint8_t type;
 	int err;
 
 #if defined(CONFIG_BT_PAC_SNK)
 	if (work == &snks_work.work) {
+		type = BT_AUDIO_SINK;
 		uuid = BT_UUID_PACS_SNK;
 	}
 #endif /* CONFIG_BT_PAC_SNK */
 
 #if defined(CONFIG_BT_PAC_SRC)
 	if (work == &srcs_work.work) {
+		type = BT_AUDIO_SOURCE;
 		uuid = BT_UUID_PACS_SRC;
 	}
 #endif /* CONFIG_BT_PAC_SRC */
 
-	err = bt_gatt_notify_uuid(NULL, uuid, pacs_svc.attrs, NULL, 0);
+	/* TODO: We can skip this if we are not connected to any devices */
+	get_pac_records(NULL, type, &read_buf);
+
+	err = bt_gatt_notify_uuid(NULL, uuid, pacs_svc.attrs, read_buf.data,
+				  read_buf.len);
 	if (err != 0) {
 		BT_WARN("PACS notify failed: %d", err);
 	}


### PR DESCRIPTION
This fixes the pac_notify (formerly pac_indicate) to actually notify the PAC records to the connected clients. 

fixes https://github.com/zephyrproject-rtos/zephyr/issues/41191
fixes https://github.com/zephyrproject-rtos/zephyr/issues/41192