### PR TITLE
Bluetooth: Host: Remove experimental tag from periodic adv and sync

### DIFF
--- a/subsys/bluetooth/Kconfig.adv
+++ b/subsys/bluetooth/Kconfig.adv
@@ -45,8 +45,7 @@ config BT_EXT_ADV_MAX_ADV_SET
 	  supported.
 
 config BT_PER_ADV
-	bool "Periodic Advertising and Scanning support [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "Periodic Advertising and Scanning support"
 	help
 	  Select this to enable Periodic Advertising API support. This allows
 	  the device to send advertising data periodically at deterministic
@@ -54,9 +53,8 @@ config BT_PER_ADV
 	  to periodically get the data.
 
 config BT_PER_ADV_SYNC
-	bool "Periodic advertising sync support [EXPERIMENTAL]"
+	bool "Periodic advertising sync support"
 	depends on BT_OBSERVER
-	select EXPERIMENTAL
 	help
 	  Select this to enable Periodic Advertising Sync API support.
 	  Syncing with a periodic advertiser allows the device to periodically


### PR DESCRIPTION
We have done sufficient testing to claim that the host is no longer
experimental.
