### PR TITLE
Bluetooth: Controller: Only show one prompt for experimental configs

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -484,6 +484,12 @@ config BT_CTLR_ADV_EXT
 	prompt "LE Advertising Extensions [EXPERIMENTAL]" if BT_LL_SW_SPLIT
 	select EXPERIMENTAL if BT_LL_SW_SPLIT
 
+config PROMPT_ADJUSTMENT_WORKAROUND
+	bool
+	help
+	  Unused and hidden Kconfig symbol to allow prompt adjustment.
+	  Work around for https://github.com/ulfalizer/Kconfiglib/issues/117
+
 if BT_CTLR_ADV_EXT
 
 config BT_CTLR_ADV_SET
@@ -528,6 +534,9 @@ config BT_CTLR_ADV_PERIODIC
 	bool "LE Periodic Advertising in Advertising State [EXPERIMENTAL]" if BT_LL_SW_SPLIT
 	select EXPERIMENTAL if BT_LL_SW_SPLIT
 
+config PROMPT_ADJUSTMENT_WORKAROUND
+	bool
+
 config BT_CTLR_ADV_PERIODIC_ADI_SUPPORT
 	bool "Periodic Advertising ADI support"
 	depends on BT_CTLR_ADV_PERIODIC
@@ -547,6 +556,9 @@ config BT_CTLR_SYNC_PERIODIC
 config BT_CTLR_SYNC_PERIODIC
 	bool "LE Periodic Advertising in Synchronization State [EXPERIMENTAL]" if BT_LL_SW_SPLIT
 	select EXPERIMENTAL if BT_LL_SW_SPLIT
+
+config PROMPT_ADJUSTMENT_WORKAROUND
+	bool
 
 config BT_CTLR_SYNC_PERIODIC_ADV_LIST
 	bool "LE Periodic Advertiser List support"

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -481,7 +481,7 @@ config BT_CTLR_ADV_EXT
 	  Controller.
 
 config BT_CTLR_ADV_EXT
-	prompt "LE Advertising Extensions [EXPERIMENTAL]" if BT_LL_SW_SPLIT
+	prompt "LE Advertising Extensions (Split Link Layer) [EXPERIMENTAL]" if BT_LL_SW_SPLIT
 	select EXPERIMENTAL if BT_LL_SW_SPLIT
 
 config PROMPT_ADJUSTMENT_WORKAROUND
@@ -531,7 +531,7 @@ config BT_CTLR_ADV_PERIODIC
 	  Controller.
 
 config BT_CTLR_ADV_PERIODIC
-	bool "LE Periodic Advertising in Advertising State [EXPERIMENTAL]" if BT_LL_SW_SPLIT
+	bool "LE Periodic Advertising in Advertising State (Split Link Layer) [EXPERIMENTAL]" if BT_LL_SW_SPLIT
 	select EXPERIMENTAL if BT_LL_SW_SPLIT
 
 config PROMPT_ADJUSTMENT_WORKAROUND
@@ -554,7 +554,7 @@ config BT_CTLR_SYNC_PERIODIC
 	  Synchronization state in the Controller.
 
 config BT_CTLR_SYNC_PERIODIC
-	bool "LE Periodic Advertising in Synchronization State [EXPERIMENTAL]" if BT_LL_SW_SPLIT
+	bool "LE Periodic Advertising in Synchronization State (Split Link Layer) [EXPERIMENTAL]" if BT_LL_SW_SPLIT
 	select EXPERIMENTAL if BT_LL_SW_SPLIT
 
 config PROMPT_ADJUSTMENT_WORKAROUND
@@ -608,7 +608,7 @@ config BT_CTLR_ADV_ISO
 	  Controller.
 
 config BT_CTLR_ADV_ISO
-	bool "LE Broadcast Isochronous Channel advertising [EXPERIMENTAL]" if BT_LL_SW_SPLIT
+	bool "LE Broadcast Isochronous Channel advertising (Split Link Layer) [EXPERIMENTAL]" if BT_LL_SW_SPLIT
 	select EXPERIMENTAL if BT_LL_SW_SPLIT
 
 config BT_CTLR_SYNC_ISO
@@ -621,7 +621,7 @@ config BT_CTLR_SYNC_ISO
 	  the Controller.
 
 config BT_CTLR_SYNC_ISO
-	bool "LE Broadcast Isochronous Channel advertising sync [EXPERIMENTAL]" if BT_LL_SW_SPLIT
+	bool "LE Broadcast Isochronous Channel advertising sync (Split Link Layer) [EXPERIMENTAL]" if BT_LL_SW_SPLIT
 	select EXPERIMENTAL if BT_LL_SW_SPLIT
 
 config BT_CTLR_BROADCAST_ISO
@@ -699,7 +699,7 @@ config BT_CTLR_CENTRAL_ISO
 	  Central role in the Controller.
 
 config BT_CTLR_CENTRAL_ISO
-	bool "LE Connected Isochronous Stream Central [EXPERIMENTAL]" if BT_LL_SW_SPLIT
+	bool "LE Connected Isochronous Stream Central (Split Link Layer) [EXPERIMENTAL]" if BT_LL_SW_SPLIT
 	select BT_CTLR_SET_HOST_FEATURE
 	select EXPERIMENTAL if BT_LL_SW_SPLIT
 
@@ -711,7 +711,7 @@ config BT_CTLR_PERIPHERAL_ISO
 	  Peripheral role in the Controller.
 
 config BT_CTLR_PERIPHERAL_ISO
-	bool "LE Connected Isochronous Stream Peripheral [EXPERIMENTAL]" if BT_LL_SW_SPLIT
+	bool "LE Connected Isochronous Stream Peripheral (Split Link Layer) [EXPERIMENTAL]" if BT_LL_SW_SPLIT
 	select BT_CTLR_SET_HOST_FEATURE
 	select EXPERIMENTAL if BT_LL_SW_SPLIT
 


### PR DESCRIPTION
When browsing through the tree, you will now no longer see two entries
for each symbol that is experimental for BT_LL_SW_SPLIT

The prompt message for experimental messages have now been rephrased to
include (Split Link Layer)

See 
![image](https://user-images.githubusercontent.com/23234783/151816164-e5e9d362-95c3-4e9a-bfae-ad3dee70bf6c.png)
