### PR TITLE
doc: getting_started: linux: reference to the 3rd party compilers page

### DIFF
--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -302,7 +302,7 @@ toolchains for all Zephyr target architectures, and does not require any extra
 flags when building applications or running tests. In addition to
 cross-compilers, the Zephyr SDK also provides prebuilt host tools. It is,
 however, possible to build without the SDK's toolchain by using another
-toolchain as as described in the main :ref:`getting_started` document.
+toolchain as as described in the :ref:`third_party_x_compilers` section.
 
 As already noted above, the SDK also includes prebuilt host tools.  To use the
 SDK's prebuilt host tools with a toolchain from another source, you must set the


### PR DESCRIPTION
The documentation was talking about not using Zephyr's SDK, but
referenced back to the GSG where only Zephyr SDK is covered in detail.
Refer to the 3rd party compilers page, where relevant information can be
found.

Fixes #42272