### PR TITLE
include/devicetree: clocks: Add DT_CLOCKS_HAS_FOO & DT_NUM_CLOCKS

### DIFF
--- a/include/devicetree.h
+++ b/include/devicetree.h
@@ -609,6 +609,37 @@
 	IS_ENABLED(DT_CAT6(node_id, _P_, prop, _IDX_, idx, _EXISTS))
 
 /**
+ * @brief Is name "name" available in a foo-names property?
+ *
+ * This property is handled as special case:
+ *
+ * - interrupts property: use DT_IRQ_HAS_NAME(node_id, idx) instead
+ *
+ * It is an error to use this macro with the interrupts property.
+ *
+ * Example devicetree fragment:
+ *
+ *	nx: node-x {
+ *		foos = <&bar xx yy>, <&baz xx zz>;
+ *		foo-names = "event", "error";
+ *		status = "okay";
+ *	};
+ *
+ * Example usage:
+ *
+ *     DT_PROP_HAS_NAME(nx, foos, event)    // 1
+ *     DT_PROP_HAS_NAME(nx, foos, failure)  // 0
+ *
+ * @param node_id node identifier
+ * @param prop a lowercase-and-underscores "prop-names" type property
+ * @param name a lowercase-and-underscores name to check
+ * @return An expression which evaluates to 1 if "name" is an available
+ *         name into the given property, and 0 otherwise.
+ */
+#define DT_PROP_HAS_NAME(node_id, prop, name) \
+	IS_ENABLED(DT_CAT6(node_id, _P_, prop, _NAME_, name, _EXISTS))
+
+/**
  * @brief Get the value at index "idx" in an array type property
  *
  * It might help to read the argument order as being similar to
@@ -2384,6 +2415,17 @@
  */
 #define DT_INST_PROP_HAS_IDX(inst, prop, idx) \
 	DT_PROP_HAS_IDX(DT_DRV_INST(inst), prop, idx)
+
+/**
+ * @brief Is name "name" available in a foo-names property?
+ * @param inst instance number
+ * @param prop a lowercase-and-underscores "prop-names" type property
+ * @param name a lowercase-and-underscores name to check
+ * @return An expression which evaluates to 1 if "name" is an available
+ *         name into the given property, and 0 otherwise.
+ */
+#define DT_INST_PROP_HAS_NAME(inst, prop, name) \
+	DT_PROP_HAS_NAME(DT_DRV_INST(inst), prop, name)
 
 /**
  * @brief Get a DT_DRV_COMPAT element value in an array property

--- a/include/devicetree/clocks.h
+++ b/include/devicetree/clocks.h
@@ -23,6 +23,92 @@ extern "C" {
  */
 
 /**
+ * @brief Test if a node has a clocks phandle-array property at a given index
+ *
+ * This expands to 1 if the given index is valid clocks property phandle-array index.
+ * Otherwise, it expands to 0.
+ *
+ * Example devicetree fragment:
+ *
+ *     n1: node-1 {
+ *             clocks = <...>, <...>;
+ *     };
+ *
+ *     n2: node-2 {
+ *             clocks = <...>;
+ *     };
+ *
+ * Example usage:
+ *
+ *     DT_CLOCKS_HAS_IDX(DT_NODELABEL(n1), 0) // 1
+ *     DT_CLOCKS_HAS_IDX(DT_NODELABEL(n1), 1) // 1
+ *     DT_CLOCKS_HAS_IDX(DT_NODELABEL(n1), 2) // 0
+ *     DT_CLOCKS_HAS_IDX(DT_NODELABEL(n2), 1) // 0
+ *
+ * @param node_id node identifier; may or may not have any clocks property
+ * @param idx index of a clocks property phandle-array whose existence to check
+ * @return 1 if the index exists, 0 otherwise
+ */
+#define DT_CLOCKS_HAS_IDX(node_id, idx) \
+	DT_PROP_HAS_IDX(node_id, clocks, idx)
+
+/**
+ * @brief Test if a node has a clock-names array property holds a given name
+ *
+ * This expands to 1 if the name is available as clocks-name array property cell.
+ * Otherwise, it expands to 0.
+ *
+ * Example devicetree fragment:
+ *
+ *     n1: node-1 {
+ *             clocks = <...>, <...>;
+ *             clock-names = "alpha", "beta";
+ *     };
+ *
+ *     n2: node-2 {
+ *             clocks = <...>;
+ *             clock-names = "alpha";
+ *     };
+ *
+ * Example usage:
+ *
+ *     DT_CLOCKS_HAS_NAME(DT_NODELABEL(n1), alpha) // 1
+ *     DT_CLOCKS_HAS_NAME(DT_NODELABEL(n1), beta)  // 1
+ *     DT_CLOCKS_HAS_NAME(DT_NODELABEL(n2), beta)  // 0
+ *
+ * @param node_id node identifier; may or may not have any clock-names property.
+ * @param name lowercase-and-underscores clock-names cell value name to check
+ * @return 1 if the clock name exists, 0 otherwise
+ */
+#define DT_CLOCKS_HAS_NAME(node_id, name) \
+	DT_PROP_HAS_NAME(node_id, clocks, name)
+
+/**
+ * @brief Get the number of elements in a clocks property
+ *
+ * Example devicetree fragment:
+ *
+ *     n1: node-1 {
+ *             clocks = <&foo>, <&bar>;
+ *     };
+ *
+ *     n2: node-2 {
+ *             clocks = <&foo>;
+ *     };
+ *
+ * Example usage:
+ *
+ *     DT_NUM_CLOCKS(DT_NODELABEL(n1)) // 2
+ *     DT_NUM_CLOCKS(DT_NODELABEL(n2)) // 1
+ *
+ * @param node_id node identifier with a clocks property
+ * @return number of elements in the property
+ */
+#define DT_NUM_CLOCKS(node_id) \
+	DT_PROP_LEN(node_id, clocks)
+
+
+/**
  * @brief Get the node identifier for the controller phandle from a
  *        "clocks" phandle-array property at an index
  *
@@ -165,6 +251,32 @@ extern "C" {
  * @see DT_CLOCKS_CELL_BY_IDX()
  */
 #define DT_CLOCKS_CELL(node_id, cell) DT_CLOCKS_CELL_BY_IDX(node_id, 0, cell)
+
+/**
+ * @brief Equivalent to DT_CLOCKS_HAS_IDX(DT_DRV_INST(inst), idx)
+ * @param inst DT_DRV_COMPAT instance number; may or may not have any clocks property
+ * @param idx index of a clocks property phandle-array whose existence to check
+ * @return 1 if the index exists, 0 otherwise
+ */
+#define DT_INST_CLOCKS_HAS_IDX(inst, idx) \
+	DT_CLOCKS_HAS_IDX(DT_DRV_INST(inst), idx)
+
+/**
+ * @brief Equivalent to DT_CLOCK_HAS_NAME(DT_DRV_INST(inst), name)
+ * @param inst DT_DRV_COMPAT instance number; may or may not have any clock-names property.
+ * @param name lowercase-and-underscores clock-names cell value name to check
+ * @return 1 if the clock name exists, 0 otherwise
+ */
+#define DT_INST_CLOCKS_HAS_NAME(inst, name) \
+	DT_CLOCKS_HAS_NAME(DT_DRV_INST(inst), name)
+
+/**
+ * @brief Equivalent to DT_NUM_CLOCKS(DT_DRV_INST(inst))
+ * @param inst instance number
+ * @return number of elements in the clocks property
+ */
+#define DT_INST_NUM_CLOCKS(inst) \
+	DT_NUM_CLOCKS(DT_DRV_INST(inst))
 
 /**
  * @brief Get the node identifier for the controller phandle from a

--- a/include/devicetree/dma.h
+++ b/include/devicetree/dma.h
@@ -258,7 +258,7 @@ extern "C" {
  * @return 1 if the dmas property has the named element, 0 otherwise
  */
 #define DT_DMAS_HAS_NAME(node_id, name) \
-	IS_ENABLED(DT_CAT(node_id, _P_dmas_NAME_##name##_EXISTS))
+	DT_PROP_HAS_NAME(node_id, dmas, name)
 
 /**
  * @brief Does a DT_DRV_COMPAT instance's dmas property have a named element?

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -640,6 +640,13 @@ static void test_phandles(void)
 	zassert_true(DT_PROP_HAS_IDX(TEST_PH, gpios, 1), "");
 	zassert_false(DT_PROP_HAS_IDX(TEST_PH, gpios, 2), "");
 
+	/* DT_PROP_HAS_NAME */
+	zassert_false(DT_PROP_HAS_NAME(TEST_PH, foos, A), "");
+	zassert_true(DT_PROP_HAS_NAME(TEST_PH, foos, a), "");
+	zassert_false(DT_PROP_HAS_NAME(TEST_PH, foos, b-c), "");
+	zassert_true(DT_PROP_HAS_NAME(TEST_PH, foos, b_c), "");
+	zassert_false(DT_PROP_HAS_NAME(TEST_PH, bazs, jane), "");
+
 	/* DT_PHA_HAS_CELL_AT_IDX */
 	zassert_true(DT_PHA_HAS_CELL_AT_IDX(TEST_PH, gpios, 1, pin), "");
 	zassert_true(DT_PHA_HAS_CELL_AT_IDX(TEST_PH, gpios, 1, flags), "");
@@ -736,6 +743,13 @@ static void test_phandles(void)
 	zassert_true(DT_INST_PROP_HAS_IDX(0, gpios, 0), "");
 	zassert_true(DT_INST_PROP_HAS_IDX(0, gpios, 1), "");
 	zassert_false(DT_INST_PROP_HAS_IDX(0, gpios, 2), "");
+
+	/* DT_INST_PROP_HAS_NAME */
+	zassert_false(DT_INST_PROP_HAS_NAME(0, foos, A), "");
+	zassert_true(DT_INST_PROP_HAS_NAME(0, foos, a), "");
+	zassert_false(DT_INST_PROP_HAS_NAME(0, foos, b-c), "");
+	zassert_true(DT_INST_PROP_HAS_NAME(0, foos, b_c), "");
+	zassert_false(DT_INST_PROP_HAS_NAME(0, bazs, jane), "");
 
 	/* DT_INST_PHA_HAS_CELL_AT_IDX */
 	zassert_true(DT_INST_PHA_HAS_CELL_AT_IDX(0, gpios, 1, pin), "");

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -1484,6 +1484,17 @@ static void test_clocks(void)
 	zassert_true(DT_SAME_NODE(DT_CLOCKS_CTLR_BY_NAME(TEST_TEMP, clk_b),
 				  DT_NODELABEL(test_clk)), "");
 
+	/* DT_NUM_CLOCKS */
+	zassert_equal(DT_NUM_CLOCKS(TEST_TEMP), 3, "");
+
+	/* DT_CLOCKS_HAS_IDX */
+	zassert_true(DT_CLOCKS_HAS_IDX(TEST_TEMP, 2), "");
+	zassert_false(DT_CLOCKS_HAS_IDX(TEST_TEMP, 3), "");
+
+	/* DT_CLOCKS_HAS_NAME */
+	zassert_true(DT_CLOCKS_HAS_NAME(TEST_TEMP, clk_a), "");
+	zassert_false(DT_CLOCKS_HAS_NAME(TEST_TEMP, clk_z), "");
+
 	/* DT_CLOCKS_CELL_BY_IDX */
 	zassert_equal(DT_CLOCKS_CELL_BY_IDX(TEST_TEMP, 2, bits), 2, "");
 	zassert_equal(DT_CLOCKS_CELL_BY_IDX(TEST_TEMP, 2, bus), 8, "");
@@ -1515,6 +1526,17 @@ static void test_clocks(void)
 	/* DT_INST_CLOCKS_CTLR_BY_NAME */
 	zassert_true(DT_SAME_NODE(DT_INST_CLOCKS_CTLR_BY_NAME(0, clk_b),
 				  DT_NODELABEL(test_clk)), "");
+
+	/* DT_INST_NUM_CLOCKS */
+	zassert_equal(DT_INST_NUM_CLOCKS(0), 3, "");
+
+	/* DT_INST_CLOCKS_HAS_IDX */
+	zassert_true(DT_INST_CLOCKS_HAS_IDX(0, 2), "");
+	zassert_false(DT_INST_CLOCKS_HAS_IDX(0, 3), "");
+
+	/* DT_INST_CLOCKS_HAS_NAME */
+	zassert_true(DT_INST_CLOCKS_HAS_NAME(0, clk_a), "");
+	zassert_false(DT_INST_CLOCKS_HAS_NAME(0, clk_z), "");
 
 	/* DT_INST_CLOCKS_CELL_BY_IDX */
 	zassert_equal(DT_INST_CLOCKS_CELL_BY_IDX(0, 2, bits), 2, "");


### PR DESCRIPTION
include/devicetree: clocks: Add DT_CLOCKS_HAS_FOO & DT_NUM_CLOCKS
    
Add macros DT_CLOCKS_HAS_NAME and DT_CLOCKS_HAS_IDX.
These macros allow to check the presence of a specific clock name or a specific cell at a given index in a clocks property.
Matching _INST_ macro variants are also provided.
    
Also add DT_NUM_CLOCKS and its _INST_ variant that counts the number of clocks available for a given node.

Add matching tests.