### PR TITLE
net: sockets: Fixes net_pkt leak in accept

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -331,6 +331,15 @@ static void zsock_accepted_cb(struct net_context *new_ctx,
 		k_condvar_init(&new_ctx->cond.recv);
 
 		k_fifo_put(&parent->accept_q, new_ctx);
+
+		/* TCP context is effectively owned by both application
+		 * and the stack: stack may detect that peer closed/aborted
+		 * connection, but it must not dispose of the context behind
+		 * the application back. Likewise, when application "closes"
+		 * context, it's not disposed of immediately - there's yet
+		 * closing handshake for stack to perform.
+		 */
+		net_context_ref(new_ctx);
 	}
 }
 
@@ -530,6 +539,8 @@ int zsock_accept_ctx(struct net_context *parent, struct sockaddr *addr,
 		if (net_pkt_eof(last_pkt)) {
 			sock_set_eof(ctx);
 			z_free_fd(fd);
+			zsock_flush_queue(ctx);
+			net_context_unref(ctx);
 			errno = ECONNABORTED;
 			return -1;
 		}
@@ -538,6 +549,8 @@ int zsock_accept_ctx(struct net_context *parent, struct sockaddr *addr,
 	if (net_context_is_closing(ctx)) {
 		errno = ECONNABORTED;
 		z_free_fd(fd);
+		zsock_flush_queue(ctx);
+		net_context_unref(ctx);
 		return -1;
 	}
 
@@ -558,18 +571,11 @@ int zsock_accept_ctx(struct net_context *parent, struct sockaddr *addr,
 		} else {
 			z_free_fd(fd);
 			errno = ENOTSUP;
+			zsock_flush_queue(ctx);
+			net_context_unref(ctx);
 			return -1;
 		}
 	}
-
-	/* TCP context is effectively owned by both application
-	 * and the stack: stack may detect that peer closed/aborted
-	 * connection, but it must not dispose of the context behind
-	 * the application back. Likewise, when application "closes"
-	 * context, it's not disposed of immediately - there's yet
-	 * closing handshake for stack to perform.
-	 */
-	net_context_ref(ctx);
 
 	NET_DBG("accept: ctx=%p, fd=%d", ctx, fd);
 


### PR DESCRIPTION
There is a net_pkt leak in sockets.c which can happen when the tcp stack is under stress and reuses net_context. 

The idea is that when zsock_accepted_cb() is called it installs callback zsock_received_cb which allows tcp stack to start putting net_pkts in the recv_q. However if the connection is closed by a peer when the connection is not yet accepted by the application, the reference count of the net_context is not increased, because zsock_accept_ctx() fails and returns -1 to the application.
Now that when tcp stack calls tcp_conn_unref(), the net_context has only reference count of 1, hence can be reused by another connection, without having the recv_q empty. And finally when the net_context is reused it just k_fifo_init() the recv_q leaking all the net_pkts in recv_q.

My solution simply increases the reference count earlier with instalment of the zsock_received_cb() callback. And consequently flushes recv_q and decrement reference count if zsock_accept_ctx() fails.

