### PR TITLE
cmake: xcc: unset GCC_NO_G_FLAG	after use

### DIFF
--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -162,14 +162,12 @@ check_set_compiler_property(APPEND PROPERTY hosted -fno-freestanding)
 # gcc flag for a freestandingapplication
 set_compiler_property(PROPERTY freestanding -ffreestanding)
 
-if(NOT DEFINED GCC_NO_G_FLAG)
-  # Flag to enable debugging
-  set_compiler_property(PROPERTY debug -g)
+# Flag to enable debugging
+set_compiler_property(PROPERTY debug -g)
 
-  # GCC 11 by default emits DWARF version 5 which cannot be parsed by
-  # pyelftools. Can be removed once pyelftools supports v5.
-  check_set_compiler_property(APPEND PROPERTY debug -gdwarf-4)
-endif()
+# GCC 11 by default emits DWARF version 5 which cannot be parsed by
+# pyelftools. Can be removed once pyelftools supports v5.
+check_set_compiler_property(APPEND PROPERTY debug -gdwarf-4)
 
 set_compiler_property(PROPERTY no_common -fno-common)
 

--- a/cmake/compiler/xcc/compiler_flags.cmake
+++ b/cmake/compiler/xcc/compiler_flags.cmake
@@ -1,10 +1,6 @@
 # No special flags are needed for xcc.
 # Only select whether gcc or clang flags should be inherited.
 if(CC STREQUAL "clang")
-  if($ENV{XCC_NO_G_FLAG})
-    set(GCC_NO_G_FLAG 1)
-  endif()
-
   include(${ZEPHYR_BASE}/cmake/compiler/clang/compiler_flags.cmake)
 
   # Now, let's overwrite the flags that are different in xcc/clang.

--- a/cmake/compiler/xcc/compiler_flags.cmake
+++ b/cmake/compiler/xcc/compiler_flags.cmake
@@ -6,6 +6,14 @@ if(CC STREQUAL "clang")
   endif()
 
   include(${ZEPHYR_BASE}/cmake/compiler/clang/compiler_flags.cmake)
+
+  # Now, let's overwrite the flags that are different in xcc/clang.
+  if($ENV{XCC_NO_G_FLAG})
+    # Older xcc/clang cannot use "-g" due to this bug:
+    # https://bugs.llvm.org/show_bug.cgi?id=11740.
+    # Clear the related flag(s) here so it won't cause issues.
+    set_compiler_property(PROPERTY debug)
+  endif()
 else()
   include(${ZEPHYR_BASE}/cmake/compiler/gcc/compiler_flags.cmake)
 


### PR DESCRIPTION
GCC_NO_G_FLAG is used to skip "-g" to XCC Clang	as the older
version	of Clang has a bug with	"-g". This unsets the flag
after inclusion	of clang/compiler_flags.cmake to limit
the lifetime of the flags here.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>