### PR TITLE
drivers/flash/nrf_qspi_nor: Set custom QE bit

### DIFF
--- a/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.dts
+++ b/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.dts
@@ -101,8 +101,9 @@
 		 */
 		compatible = "nordic,qspi-nor";
 		reg = <0>;
-		writeoc = "pp2o";
-		readoc = "read2io";
+		writeoc = "pp4o";
+		readoc = "read4o";
+		quad-enable-bit = < 9 >;
 		sck-frequency = <16000000>;
 		label = "GD25Q16";
 		jedec-id = [c8 40 15];

--- a/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.dts
+++ b/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.dts
@@ -103,7 +103,7 @@
 		reg = <0>;
 		writeoc = "pp4o";
 		readoc = "read4o";
-		quad-enable-bit = < 9 >;
+		quad-enable-bit-mask = < 512 >;
 		sck-frequency = <16000000>;
 		label = "GD25Q16";
 		jedec-id = [c8 40 15];

--- a/dts/bindings/mtd/nordic,qspi-nor.yaml
+++ b/dts/bindings/mtd/nordic,qspi-nor.yaml
@@ -27,6 +27,37 @@ properties:
   quad-enable-requirements:
     default: "S1B6"
 
+  # Some chips don't put the Quad Enable bit in the same register while
+  # otherwise being completely compatible, give option for override
+  quad-enable-bit:
+    default: 2
+    type: int
+    enum:
+      - 0
+      - 1
+      - 2
+      - 3
+      - 4
+      - 5
+      - 6
+      - 7
+      - 8
+      - 9
+      - 10
+      - 11
+      - 12
+      - 13
+      - 14
+      - 15
+    description: |
+      Some flash chips put the quad enable bit in a different bit/register
+      than the jedec spec. This property allows overriding which bit will
+      be used to set Quad mode. Bits 0-7 correspond to register 1 and 8-15
+      correspond to register 2. WARNING setting the wrong bit could end up
+      setting your board PERMANENTLY in read-only mode. Only change this if
+      you are confident. Defaults to bit 2 of S1B6 spec as supported by this
+      driver.
+
   readoc:
     type: string
     required: false

--- a/dts/bindings/mtd/nordic,qspi-nor.yaml
+++ b/dts/bindings/mtd/nordic,qspi-nor.yaml
@@ -29,34 +29,20 @@ properties:
 
   # Some chips don't put the Quad Enable bit in the same register while
   # otherwise being completely compatible, give option for override
-  quad-enable-bit:
-    default: 2
+  quad-enable-bit-mask:
+    default: 64
     type: int
-    enum:
-      - 0
-      - 1
-      - 2
-      - 3
-      - 4
-      - 5
-      - 6
-      - 7
-      - 8
-      - 9
-      - 10
-      - 11
-      - 12
-      - 13
-      - 14
-      - 15
     description: |
       Some flash chips put the quad enable bit in a different bit/register
-      than the jedec spec. This property allows overriding which bit will
-      be used to set Quad mode. Bits 0-7 correspond to register 1 and 8-15
-      correspond to register 2. WARNING setting the wrong bit could end up
-      setting your board PERMANENTLY in read-only mode. Only change this if
-      you are confident. Defaults to bit 2 of S1B6 spec as supported by this
-      driver.
+      than the jedec spec. This property allows overriding the bitmask that
+      will be used to enable quad mode. This should be a value
+      corresponding a 16 bit wide number. The 8 bits will be used as a quad
+      enable bit mask in the first register (values 0 - 255), the later 8
+      bits will be used as a mask for a second register (values 256-65280)
+      these bits will be a no-op the later 8 bits are zero. WARNING setting
+      the wrong bit could end up setting your board PERMANENTLY in
+      read-only mode. Only change this if you are confident. Defaults to
+      64 (bit 6) of S1B6 spec as supported by this driver.
 
   readoc:
     type: string


### PR DESCRIPTION
Modify the nordic flash driver to allow specifying which bit
corresponds to the quad enable bit. This is needed because not
all NOR chips conform to having QE on the 6th bit, as was hard
coded. Now it is possible to set any bit in the first register, as
well as bit a second register if the flash chip needs.

This is motivated by the adafrut feather nrf52840 board being unable
to write to the on-board "external" flash using existing DT bindings.