### PR TITLE
Bluetooth: Controller: Fix extended scan rx flush for continous scan

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -635,6 +635,7 @@ ull_scan_aux_rx_flush:
 		 */
 		if (aux->rx_last) {
 			aux->rx_last->rx_ftr.extra = rx;
+			aux->rx_last = rx;
 		} else {
 			LL_ASSERT(sync_lll);
 


### PR DESCRIPTION
Fix missing progression of the rx_last pointer when
appending rx buffers before flushing them towards Host.
Under continuous scanning, as the disabled_cb would only
be called when reference count reaches zero, the rx_last
pointer needs to progress when appending the rx buffers.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>