### PR TITLE
Bluetooth: Controller: Fix Periodic Sync memq link leak

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -1439,6 +1439,12 @@ void ll_rx_mem_release(void **node_rx)
 				ull_sync_setup_complete(scan);
 
 				if (status != BT_HCI_ERR_SUCCESS) {
+					memq_link_t *link_sync_lost;
+
+					link_sync_lost =
+						sync->node_rx_lost.hdr.link;
+					ll_rx_link_release(link_sync_lost);
+
 					ull_sync_release(sync);
 				}
 


### PR DESCRIPTION
Fix memq link buffer leak on Periodic Sync failed to be
established.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>