### PR TITLE
Bluetooth: Controller: Fix missing offset adjust field assignment

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -126,7 +126,7 @@
 #define OFFS_UNIT_VALUE_30_US  0
 #define OFFS_UNIT_VALUE_300_US 1
 /* Value specified in BT Spec. Vol 6, Part B, section 2.3.4.6 */
-#define OFFS_ADJUST_US         245760
+#define OFFS_ADJUST_US         2457600UL
 
 /* Advertiser's Sleep Clock Accuracy Value */
 #define SCA_500_PPM       500 /* 51 ppm to 500 ppm */

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -1734,6 +1734,12 @@ static inline void sync_info_offset_fill(struct pdu_adv_sync_info *si,
 	uint32_t offs;
 
 	offs = HAL_TICKER_TICKS_TO_US(ticks_offset) - start_us;
+
+	if (offs >= OFFS_ADJUST_US) {
+		offs -= OFFS_ADJUST_US;
+		si->offs_adjust = 1U;
+	}
+
 	offs = offs / OFFS_UNIT_30_US;
 	if (!!(offs >> OFFS_UNIT_BITS)) {
 		si->offs = sys_cpu_to_le16(offs / (OFFS_UNIT_300_US /


### PR DESCRIPTION
Fix missing offset adjust field assignment in the Periodic
Advertising's sync_info struct that is present in the
Extended Advertising PDU.

When the sync offset is equal or over 2.4576 seconds from
the Extended Advertising PDU, then the sync offset has to
be reduced by 2.4576 seconds and the offs_adjust flag be
set in the sync_info field.

This fixes a bug where Periodic Synchronization could not
be established for Periodic Advertisings with intervals
greater than 2.4576 seconds as the sync offset was
incorrect due to rollover in the 13-bit offset field.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>