### PR TITLE
Bluetooth: Host: Non-discardable event buffer size is 255 for ext adv

### DIFF
--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -109,7 +109,7 @@ config BT_BUF_ACL_RX_COUNT
 
 config BT_BUF_EVT_RX_SIZE
 	int "Maximum supported HCI Event buffer length"
-	default 255 if (BT_EXT_ADV && !(BT_BUF_EVT_DISCARDABLE_COUNT > 0)) || BT_PER_ADV_SYNC || BT_DF_CONNECTION_CTE_RX
+	default 255 if (BT_EXT_ADV && BT_OBSERVER) || BT_PER_ADV_SYNC || BT_DF_CONNECTION_CTE_RX
 	# LE Read Supported Commands command complete event.
 	default 68
 	range 68 255
@@ -136,7 +136,7 @@ config BT_BUF_EVT_DISCARDABLE_SIZE
 	int "Maximum supported discardable HCI Event buffer length"
 	range 43 255
 	# LE Extended Advertising Report event
-	default 255 if BT_BREDR || BT_EXT_ADV
+	default 255 if BT_BREDR
 	# Le Advertising Report event
 	default 43
 	help


### PR DESCRIPTION
After https://github.com/zephyrproject-rtos/zephyr/pull/41337, extended
advertising reports are no longer discardable. Ensure the
non-discardable events are large enough.

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>