### PR TITLE
backport2.7: logging: printk: Fix LOG_PRINTK option and added test for it

### DIFF
--- a/include/logging/log.h
+++ b/include/logging/log.h
@@ -256,18 +256,16 @@ extern "C" {
  * @brief Writes an formatted string to the log.
  *
  * @details Conditionally compiled (see CONFIG_LOG_PRINTK). Function provides
- * printk functionality. It is inefficient compared to standard logging
- * because string formatting is performed in the call context and not deferred
- * to the log processing context (@ref log_process).
+ * printk functionality.
+ *
+ * It is less efficient compared to standard logging because static packaging
+ * cannot be used in v2. When v1 is used string formatting is performed in the
+ * call context and not deferred to the log processing context (@ref log_process).
  *
  * @param fmt Formatted string to output.
  * @param ap  Variable parameters.
  */
-void z_log_printk(const char *fmt, va_list ap);
-static inline void log_printk(const char *fmt, va_list ap)
-{
-	z_log_printk(fmt, ap);
-}
+void z_log_vprintk(const char *fmt, va_list ap);
 
 /** @brief Copy transient string to a buffer from internal, logger pool.
  *

--- a/include/sys/printk.h
+++ b/include/sys/printk.h
@@ -12,9 +12,6 @@
 #include <stddef.h>
 #include <stdarg.h>
 #include <inttypes.h>
-#if defined(CONFIG_LOG_PRINTK) && defined(CONFIG_LOG2)
-#include <logging/log.h>
-#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -49,18 +46,8 @@ extern "C" {
  */
 #ifdef CONFIG_PRINTK
 
-#if defined(CONFIG_LOG_PRINTK) && defined(CONFIG_LOG2)
-#define printk(...) Z_LOG_PRINTK(__VA_ARGS__)
-static inline __printf_like(1, 0) void vprintk(const char *fmt, va_list ap)
-{
-	z_log_msg2_runtime_vcreate(CONFIG_LOG_DOMAIN_ID, NULL,
-				   LOG_LEVEL_INTERNAL_RAW_STRING, NULL, 0,
-				   fmt, ap);
-}
-#else
 extern __printf_like(1, 2) void printk(const char *fmt, ...);
 extern __printf_like(1, 0) void vprintk(const char *fmt, va_list ap);
-#endif /* defined(CONFIG_LOG_PRINTK) && defined(CONFIG_LOG) */
 
 #else
 static inline __printf_like(1, 2) void printk(const char *fmt, ...)

--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -22,6 +22,11 @@
 #include <sys/cbprintf.h>
 #include <sys/types.h>
 
+/* Option present only when CONFIG_USERSPACE enabled. */
+#ifndef CONFIG_PRINTK_BUFFER_SIZE
+#define CONFIG_PRINTK_BUFFER_SIZE 0
+#endif
+
 #if defined(CONFIG_PRINTK_SYNC) && \
 	!(defined(CONFIG_LOG_PRINTK) && defined(CONFIG_LOG2))
 static struct k_spinlock lock;
@@ -79,7 +84,6 @@ void *__printk_get_hook(void)
 
 #if defined(CONFIG_PRINTK) && \
 	!(defined(CONFIG_LOG_PRINTK) && defined(CONFIG_LOG2))
-#ifdef CONFIG_USERSPACE
 struct buf_out_context {
 	int count;
 	unsigned int buf_count;
@@ -104,7 +108,6 @@ static int buf_char_out(int c, void *ctx_p)
 
 	return c;
 }
-#endif /* CONFIG_USERSPACE */
 
 struct out_context {
 	int count;
@@ -118,7 +121,6 @@ static int char_out(int c, void *ctx_p)
 	return _char_out(c);
 }
 
-#ifdef CONFIG_USERSPACE
 void vprintk(const char *fmt, va_list ap)
 {
 	if (k_is_user_context()) {
@@ -142,21 +144,6 @@ void vprintk(const char *fmt, va_list ap)
 #endif
 	}
 }
-#else
-void vprintk(const char *fmt, va_list ap)
-{
-	struct out_context ctx = { 0 };
-#ifdef CONFIG_PRINTK_SYNC
-	k_spinlock_key_t key = k_spin_lock(&lock);
-#endif
-
-	cbvprintf(char_out, &ctx, fmt, ap);
-
-#ifdef CONFIG_PRINTK_SYNC
-	k_spin_unlock(&lock, key);
-#endif
-}
-#endif /* CONFIG_USERSPACE */
 
 void z_impl_k_str_out(char *c, size_t n)
 {

--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -27,8 +27,7 @@
 #define CONFIG_PRINTK_BUFFER_SIZE 0
 #endif
 
-#if defined(CONFIG_PRINTK_SYNC) && \
-	!(defined(CONFIG_LOG_PRINTK) && defined(CONFIG_LOG2))
+#if defined(CONFIG_PRINTK_SYNC)
 static struct k_spinlock lock;
 #endif
 
@@ -80,10 +79,7 @@ void *__printk_get_hook(void)
 {
 	return _char_out;
 }
-#endif /* CONFIG_PRINTK */
 
-#if defined(CONFIG_PRINTK) && \
-	!(defined(CONFIG_LOG_PRINTK) && defined(CONFIG_LOG2))
 struct buf_out_context {
 	int count;
 	unsigned int buf_count;
@@ -123,6 +119,11 @@ static int char_out(int c, void *ctx_p)
 
 void vprintk(const char *fmt, va_list ap)
 {
+	if (IS_ENABLED(CONFIG_LOG_PRINTK)) {
+		z_log_vprintk(fmt, ap);
+		return;
+	}
+
 	if (k_is_user_context()) {
 		struct buf_out_context ctx = { 0 };
 
@@ -199,16 +200,11 @@ void printk(const char *fmt, ...)
 
 	va_start(ap, fmt);
 
-	if (IS_ENABLED(CONFIG_LOG_PRINTK)) {
-		log_printk(fmt, ap);
-	} else {
-		vprintk(fmt, ap);
-	}
+	vprintk(fmt, ap);
+
 	va_end(ap);
 }
-#endif /* defined(CONFIG_PRINTK) && \
-	* !(defined(CONFIG_LOG_PRINTK) && defined(CONFIG_LOG2))
-	*/
+#endif /* defined(CONFIG_PRINTK) */
 
 struct str_context {
 	char *str;

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -362,42 +362,52 @@ void log_hexdump(const char *str, const void *data, uint32_t length,
 	}
 }
 
-void z_log_printk(const char *fmt, va_list ap)
+void z_log_vprintk(const char *fmt, va_list ap)
 {
-	if (IS_ENABLED(CONFIG_LOG_PRINTK)) {
-		union {
-			struct log_msg_ids structure;
-			uint32_t value;
-		} src_level_union = {
-			{
-				.level = LOG_LEVEL_INTERNAL_RAW_STRING
-			}
-		};
+	if (!IS_ENABLED(CONFIG_LOG_PRINTK)) {
+		return;
+	}
 
-		if (k_is_user_context()) {
-			uint8_t str[CONFIG_LOG_PRINTK_MAX_STRING_LENGTH + 1];
+	if (IS_ENABLED(CONFIG_LOG2)) {
+		z_log_msg2_runtime_vcreate(CONFIG_LOG_DOMAIN_ID, NULL,
+					   LOG_LEVEL_INTERNAL_RAW_STRING, NULL, 0,
+					   fmt, ap);
+		return;
+	}
 
-			vsnprintk(str, sizeof(str), fmt, ap);
 
-			z_log_string_from_user(src_level_union.value, str);
-		} else if (IS_ENABLED(CONFIG_LOG_IMMEDIATE)) {
-			log_generic(src_level_union.structure, fmt, ap,
-							LOG_STRDUP_SKIP);
-		} else {
-			uint8_t str[CONFIG_LOG_PRINTK_MAX_STRING_LENGTH + 1];
-			struct log_msg *msg;
-			int length;
-
-			length = vsnprintk(str, sizeof(str), fmt, ap);
-			length = MIN(length, sizeof(str));
-
-			msg = log_msg_hexdump_create(NULL, str, length);
-			if (msg == NULL) {
-				return;
-			}
-
-			msg_finalize(msg, src_level_union.structure);
+	union {
+		struct log_msg_ids structure;
+		uint32_t value;
+	} src_level_union = {
+		{
+			.level = LOG_LEVEL_INTERNAL_RAW_STRING
 		}
+	};
+
+	if (k_is_user_context()) {
+		uint8_t str[CONFIG_LOG_PRINTK_MAX_STRING_LENGTH + 1];
+
+		vsnprintk(str, sizeof(str), fmt, ap);
+
+		z_log_string_from_user(src_level_union.value, str);
+	} else if (IS_ENABLED(CONFIG_LOG_MODE_IMMEDIATE)) {
+		log_generic(src_level_union.structure, fmt, ap,
+						LOG_STRDUP_SKIP);
+	} else {
+		uint8_t str[CONFIG_LOG_PRINTK_MAX_STRING_LENGTH + 1];
+		struct log_msg *msg;
+		int length;
+
+		length = vsnprintk(str, sizeof(str), fmt, ap);
+		length = MIN(length, sizeof(str));
+
+		msg = log_msg_hexdump_create(NULL, str, length);
+		if (msg == NULL) {
+			return;
+		}
+
+		msg_finalize(msg, src_level_union.structure);
 	}
 }
 

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -101,7 +101,10 @@ static int out_func(int c, void *ctx)
 
 	if (IS_ENABLED(CONFIG_LOG_IMMEDIATE)) {
 		/* Backend must be thread safe in synchronous operation. */
-		out_ctx->func((uint8_t *)&c, 1, out_ctx->control_block->ctx);
+		/* Need that step for big endian */
+		char x = (char)c;
+
+		out_ctx->func((uint8_t *)&x, 1, out_ctx->control_block->ctx);
 		return 0;
 	}
 

--- a/tests/subsys/logging/log_api/src/mock_backend.c
+++ b/tests/subsys/logging/log_api/src/mock_backend.c
@@ -221,6 +221,10 @@ static void put(const struct log_backend *const backend,
 	struct mock_log_backend *mock = backend->cb->ctx;
 	struct mock_log_backend_msg *exp = &mock->exp_msgs[mock->msg_proc_idx];
 
+	if (!mock->do_check) {
+		return;
+	}
+
 	mock->msg_proc_idx++;
 
 	if (!exp->check) {
@@ -264,6 +268,10 @@ static void process(const struct log_backend *const backend,
 	struct mock_log_backend *mock = backend->cb->ctx;
 	struct mock_log_backend_msg *exp = &mock->exp_msgs[mock->msg_proc_idx];
 
+	if (!mock->do_check) {
+		return;
+	}
+
 	mock->msg_proc_idx++;
 
 	if (!exp->check) {
@@ -280,9 +288,16 @@ static void process(const struct log_backend *const backend,
 	zassert_equal(msg->log.hdr.desc.level, exp->level, NULL);
 	zassert_equal(msg->log.hdr.desc.domain, exp->domain_id, NULL);
 
-	uint32_t source_id = IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ?
-		log_dynamic_source_id((struct log_source_dynamic_data *)msg->log.hdr.source) :
-		log_const_source_id((const struct log_source_const_data *)msg->log.hdr.source);
+	uint32_t source_id;
+	const void *source = msg->log.hdr.source;
+
+	if (source == NULL) {
+		source_id = 0;
+	} else {
+		source_id = IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ?
+		    log_dynamic_source_id((struct log_source_dynamic_data *)source) :
+		    log_const_source_id((const struct log_source_const_data *)source);
+	}
 
 	zassert_equal(source_id, exp->source_id, NULL);
 
@@ -334,6 +349,10 @@ static void sync_string(const struct log_backend *const backend,
 	struct mock_log_backend *mock = backend->cb->ctx;
 	struct mock_log_backend_msg *exp = &mock->exp_msgs[mock->msg_proc_idx];
 
+	if (!mock->do_check) {
+		return;
+	}
+
 	mock->msg_proc_idx++;
 
 	if (!exp->check) {
@@ -359,6 +378,10 @@ static void sync_hexdump(const struct log_backend *const backend,
 {
 	struct mock_log_backend *mock = backend->cb->ctx;
 	struct mock_log_backend_msg *exp = &mock->exp_msgs[mock->msg_proc_idx];
+
+	if (!mock->do_check) {
+		return;
+	}
 
 	mock->msg_proc_idx++;
 

--- a/tests/subsys/logging/log_api/src/test.inc
+++ b/tests/subsys/logging/log_api/src/test.inc
@@ -627,11 +627,52 @@ static void test_log_panic(void)
 	mock_log_backend_validate(&backend1, true);
 }
 
+static void test_log_printk(void)
+{
+	if (!IS_ENABLED(CONFIG_LOG_MODE_IMMEDIATE) && !IS_ENABLED(CONFIG_LOG2_MODE_IMMEDIATE)) {
+		ztest_test_skip();
+	}
+
+	if (!IS_ENABLED(CONFIG_LOG_PRINTK)) {
+		ztest_test_skip();
+	}
+
+	log_timestamp_t exp_timestamp = TIMESTAMP_INIT_VAL;
+
+	log_setup(false);
+
+	mock_log_backend_record(&backend1, 0,
+				CONFIG_LOG_DOMAIN_ID, LOG_LEVEL_INTERNAL_RAW_STRING,
+				exp_timestamp++, "test 100\n");
+	printk("test %d\n", 100);
+
+	log_panic();
+
+	mock_log_backend_record(&backend1, 0,
+				CONFIG_LOG_DOMAIN_ID, LOG_LEVEL_INTERNAL_RAW_STRING,
+				exp_timestamp++, "test 101\n");
+	printk("test %d\n", 101);
+
+	mock_log_backend_validate(&backend1, true);
+}
+
 /* Disable backends because same suite may be excuted again but compiled by C++ */
 static void log_api_suite_teardown(void)
 {
 	log_backend_disable(&backend1);
 	log_backend_disable(&backend2);
+}
+
+static void setup(void)
+{
+	mock_log_backend_check_enable(&backend1);
+	mock_log_backend_check_enable(&backend2);
+}
+
+static void teardown(void)
+{
+	mock_log_backend_check_disable(&backend1);
+	mock_log_backend_check_disable(&backend2);
 }
 
 /*test case main entry*/
@@ -656,13 +697,17 @@ void test_cc(void)
 #endif
 
 	ztest_test_suite(test_log_api,
-			 ztest_unit_test(test_log_various_messages),
-			 ztest_unit_test(test_log_backend_runtime_filtering),
-			 ztest_unit_test(test_log_overflow),
-			 ztest_unit_test(test_log_arguments),
-			 ztest_unit_test(test_log_from_declared_module),
-			 ztest_unit_test(test_log_msg_dropped_notification),
-			 ztest_unit_test(test_log_panic)
+			 ztest_unit_test_setup_teardown(test_log_various_messages, setup, teardown),
+			 ztest_unit_test_setup_teardown(test_log_backend_runtime_filtering,
+							setup, teardown),
+			 ztest_unit_test_setup_teardown(test_log_overflow, setup, teardown),
+			 ztest_unit_test_setup_teardown(test_log_arguments, setup, teardown),
+			 ztest_unit_test_setup_teardown(test_log_from_declared_module,
+							setup, teardown),
+			 ztest_unit_test_setup_teardown(test_log_msg_dropped_notification,
+							setup, teardown),
+			 ztest_unit_test_setup_teardown(test_log_printk, setup, teardown),
+			 ztest_unit_test_setup_teardown(test_log_panic, setup, teardown)
 			);
 	ztest_run_test_suite(test_log_api);
 

--- a/tests/subsys/logging/log_api/testcase.yaml
+++ b/tests/subsys/logging/log_api/testcase.yaml
@@ -34,6 +34,11 @@ tests:
     extra_configs:
       - CONFIG_LOG_MODE_IMMEDIATE=y
 
+  logging.log_api_immediate_printk:
+    extra_configs:
+      - CONFIG_LOG_MODE_IMMEDIATE=y
+      - CONFIG_LOG_PRINTK=y
+
   logging.log_api_immediate_rt_filter:
     extra_configs:
       - CONFIG_LOG_MODE_IMMEDIATE=y
@@ -93,6 +98,13 @@ tests:
     platform_exclude: qemu_arc_hs6x
     extra_configs:
       - CONFIG_LOG2_MODE_IMMEDIATE=y
+
+  logging.log2_api_immediate_printk:
+    # FIXME: qemu_arc_hs6x excluded, see #38041
+    platform_exclude: qemu_arc_hs6x
+    extra_configs:
+      - CONFIG_LOG_MODE_IMMEDIATE=y
+      - CONFIG_LOG_PRINTK=y
 
   logging.log2_api_immediate_rt_filter:
     # FIXME: qemu_arc_hs6x excluded, see #38041

--- a/tests/subsys/logging/log_core_additional/src/log_test.c
+++ b/tests/subsys/logging/log_core_additional/src/log_test.c
@@ -156,6 +156,11 @@ static void sync_hexdump(const struct log_backend *const backend,
 	cb->sync++;
 }
 
+static void panic(const struct log_backend *const backend)
+{
+	ARG_UNUSED(backend);
+}
+
 const struct log_backend_api log_backend_test_api = {
 	.process = IS_ENABLED(CONFIG_LOG2) ? process : NULL,
 	.put = IS_ENABLED(CONFIG_LOG_MODE_DEFERRED) ? put : NULL,
@@ -163,6 +168,7 @@ const struct log_backend_api log_backend_test_api = {
 			sync_string : NULL,
 	.put_sync_hexdump = IS_ENABLED(CONFIG_LOG_IMMEDIATE) ?
 			sync_hexdump : NULL,
+	.panic = panic,
 };
 
 LOG_BACKEND_DEFINE(backend1, log_backend_test_api, false);


### PR DESCRIPTION
Backporting changes from #41971. 

Fixes #41915 on 2.7 branch
Fixes #42164 on 2.7 branch

Potentially it impact #42207 (to be checked).