### PR TITLE
net: lwm2m: Fix Server Object SSID access

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -2470,6 +2470,21 @@ static int lwm2m_write_handler_opaque(struct lwm2m_engine_obj_inst *obj_inst,
 	return opaque_ctx.len;
 }
 
+bool lwm2m_engine_bootstrap_override(struct lwm2m_ctx *client_ctx, struct lwm2m_obj_path *path)
+{
+	if (!client_ctx->bootstrap_mode) {
+		/* Bootstrap is not active override is not possible then */
+		return false;
+	}
+
+	if (path->obj_id == LWM2M_OBJECT_SECURITY_ID || path->obj_id == LWM2M_OBJECT_SERVER_ID) {
+		/* Bootstrap server have a access to Security and Server object */
+		return true;
+	}
+
+	return false;
+}
+
 /* This function is exposed for the content format writers */
 int lwm2m_write_handler(struct lwm2m_engine_obj_inst *obj_inst,
 			struct lwm2m_engine_res *res,

--- a/subsys/net/lib/lwm2m/lwm2m_engine.h
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.h
@@ -104,6 +104,8 @@ int lwm2m_write_handler(struct lwm2m_engine_obj_inst *obj_inst,
 			struct lwm2m_engine_obj_field *obj_field,
 			struct lwm2m_message *msg);
 
+bool lwm2m_engine_bootstrap_override(struct lwm2m_ctx *client_ctx, struct lwm2m_obj_path *path);
+
 int lwm2m_discover_handler(struct lwm2m_message *msg, bool is_bootstrap);
 
 enum coap_block_size lwm2m_default_block_size(void);

--- a/subsys/net/lib/lwm2m/lwm2m_obj_server.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_server.c
@@ -85,12 +85,7 @@ static char  transport_binding[MAX_INSTANCE_COUNT][TRANSPORT_BINDING_LEN];
 
 static struct lwm2m_engine_obj server;
 static struct lwm2m_engine_obj_field fields[] = {
-	/*
-	 * LwM2M TS "E.2 LwM2M Object: LwM2M Server" page 107, describes
-	 * Short Server ID as READ-ONLY, but BOOTSTRAP server will attempt
-	 * to write it, so it needs to be RW
-	 */
-	OBJ_FIELD_DATA(SERVER_SHORT_SERVER_ID, RW, U16),
+	OBJ_FIELD_DATA(SERVER_SHORT_SERVER_ID, R, U16),
 	OBJ_FIELD_DATA(SERVER_LIFETIME_ID, RW, U32),
 	OBJ_FIELD_DATA(SERVER_DEFAULT_MIN_PERIOD_ID, RW_OPT, U32),
 	OBJ_FIELD_DATA(SERVER_DEFAULT_MAX_PERIOD_ID, RW_OPT, U32),

--- a/subsys/net/lib/lwm2m/lwm2m_rw_json.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_json.c
@@ -929,7 +929,8 @@ int do_write_op_json(struct lwm2m_message *msg)
 			 * resources are ignored
 			 */
 
-			if (!LWM2M_HAS_PERM(obj_field, LWM2M_PERM_W)) {
+			if (!LWM2M_HAS_PERM(obj_field, LWM2M_PERM_W) &&
+			    !lwm2m_engine_bootstrap_override(msg->ctx, &msg->path)) {
 				ret = -EPERM;
 				break;
 			}

--- a/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
@@ -817,7 +817,8 @@ static int do_write_op_tlv_item(struct lwm2m_message *msg)
 		goto error;
 	}
 
-	if (!LWM2M_HAS_PERM(obj_field, LWM2M_PERM_W)) {
+	if (!LWM2M_HAS_PERM(obj_field, LWM2M_PERM_W) &&
+	    !lwm2m_engine_bootstrap_override(msg->ctx, &msg->path)) {
 		ret = -EPERM;
 		goto error;
 	}

--- a/subsys/net/lib/lwm2m/lwm2m_rw_plain_text.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_plain_text.c
@@ -417,7 +417,8 @@ int do_write_op_plain_text(struct lwm2m_message *msg)
 		return -ENOENT;
 	}
 
-	if (!LWM2M_HAS_PERM(obj_field, LWM2M_PERM_W)) {
+	if (!LWM2M_HAS_PERM(obj_field, LWM2M_PERM_W) &&
+	    !lwm2m_engine_bootstrap_override(msg->ctx, &msg->path)) {
 		return -EPERM;
 	}
 


### PR DESCRIPTION
 Bug Fix: Server Object SSID access rights
- Server Object SSID should only have Read access.
- LightweightM2M-1.1-int-256 conformance test validate that write operation to SSID should return error.
- Overwrite SSID affect dead block for lwm2m engine and only reset will heal.
- Fix by adding bootstrap overwrite access for Security and Server object when bootstrap is active.