### PR TITLE
net: lwm2m: add missing optional resource to firmware object

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
@@ -395,6 +395,8 @@ static struct lwm2m_engine_obj_inst *firmware_create(uint16_t obj_inst_id)
 			     res_inst[obj_inst_id], j);
 	INIT_OBJ_RES_OPTDATA(FIRMWARE_PACKAGE_VERSION_ID, res[obj_inst_id], i,
 			     res_inst[obj_inst_id], j);
+	INIT_OBJ_RES_MULTI_OPTDATA(FIRMWARE_UPDATE_PROTO_SUPPORT_ID, res[obj_inst_id], i,
+				 res_inst[obj_inst_id], j, 1, false);
 	INIT_OBJ_RES_DATA(FIRMWARE_UPDATE_DELIV_METHOD_ID, res[obj_inst_id], i,
 			  res_inst[obj_inst_id], j, &(delivery_method[obj_inst_id]),
 			  sizeof(delivery_method[obj_inst_id]));


### PR DESCRIPTION
Firmware Update Protocol Support resource initialization
has been left out in #41402.
Initialise the resource in object creation function.

Signed-off-by: Marin Jurjević <marin.jurjevic@hotmail.com>