### PR TITLE
boards: cc{1352|26x2}r1_launchxl: remove unnecessary openocd workaround

### DIFF
--- a/boards/arm/cc1352r1_launchxl/support/openocd.cfg
+++ b/boards/arm/cc1352r1_launchxl/support/openocd.cfg
@@ -1,4 +1,1 @@
 source [find board/ti_cc13x2_launchpad.cfg]
-# Workaround for #21372. This allows OpenOCD to flash correctly
-# with newer 3.x XDS firmware
-adapter_khz 1500

--- a/boards/arm/cc26x2r1_launchxl/support/openocd.cfg
+++ b/boards/arm/cc26x2r1_launchxl/support/openocd.cfg
@@ -1,4 +1,1 @@
 source [find board/ti_cc26x2_launchpad.cfg]
-# Workaround for #21372. This allows OpenOCD to flash correctly
-# with newer 3.x XDS firmware
-adapter_khz 1500


### PR DESCRIPTION
The adapter speed workaround doesn't seem to be necessary when using latest XDS110
firmware (3.0.0.13).
