### PR TITLE
mgmt/mcumgr/lib: Remove unneeded return code check

### DIFF
--- a/subsys/mgmt/mcumgr/lib/smp/src/smp.c
+++ b/subsys/mgmt/mcumgr/lib/smp/src/smp.c
@@ -326,10 +326,7 @@ smp_process_request_packet(struct smp_streamer *streamer, void *req)
 			break;
 		}
 
-		rc = mgmt_streamer_init_writer(&streamer->mgmt_stmr, rsp);
-		if (rc != 0) {
-			break;
-		}
+		mgmt_streamer_init_writer(&streamer->mgmt_stmr, rsp);
 
 		/* Process the request payload and build the response. */
 		rc = smp_handle_single_req(streamer, &req_hdr, &handler_found);


### PR DESCRIPTION
The smp_process_request_packet has been checking return code from
mgmt_streamer_init_writer where Zephyr implementation of the
callback always returns 0.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>