### PR TITLE
Bluetooth: host: Document skip range in bt_le_per_adv_sync_param

### DIFF
--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -1317,7 +1317,8 @@ struct bt_le_per_adv_sync_param {
 	 * @brief Maximum event skip
 	 *
 	 * Maximum number of periodic advertising events that can be
-	 * skipped after a successful receive
+	 * skipped after a successful receive.
+	 * Range: 0x0000 to 0x01F3
 	 */
 	uint16_t skip;
 


### PR DESCRIPTION
The skip field in the bt_le_per_adv_sync_param structure did not
document the acceptable range. Add it, directly from the
specification.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>