### PR TITLE
boards: bl654_usb: use CDC ACM UART as serial backend

### DIFF
--- a/boards/arm/bl654_usb/Kconfig.defconfig
+++ b/boards/arm/bl654_usb/Kconfig.defconfig
@@ -23,12 +23,27 @@ config FLASH_LOAD_OFFSET
 	default 0x1000
 	depends on !USE_DT_CODE_PARTITION
 
-if USB_DEVICE_STACK
+config USB_CDC_ACM
+	default n if USB_DEVICE_BLUETOOTH
 
-config UART_LINE_CTRL
+config BL654_USB_SERIAL_BACKEND_CDCACM
+	bool "Use CDC ACM UART as backend for BL654 USB adapter"
+	default y if !USB_DEVICE_BLUETOOTH
+	help
+	  Use CDC ACM UART as backend for console or shell.
+
+if BL654_USB_SERIAL_BACKEND_CDCACM
+
+config UART_CONSOLE
+	default CONSOLE
+
+config USB_DEVICE_INITIALIZE_AT_BOOT
 	default y
 
-endif # USB_DEVICE_STACK
+config SHELL_BACKEND_SERIAL_CHECK_DTR
+	default SHELL
+
+endif #BL654_USB_SERIAL_BACKEND_CDCACM
 
 if IEEE802154
 

--- a/subsys/usb/Kconfig
+++ b/subsys/usb/Kconfig
@@ -152,6 +152,12 @@ config USB_WORKQUEUE_PRIORITY
 	  priority. This means that any work handler, once started, won't
 	  be preempted by any other thread until finished.
 
+config USB_DEVICE_INITIALIZE_AT_BOOT
+	bool "Initialize USB device support at boot"
+	depends on USB_CDC_ACM
+	help
+	  Use CDC ACM UART as backend for console, shell, or logging.
+
 source "subsys/usb/class/Kconfig"
 
 endif # USB_DEVICE_STACK

--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -1529,7 +1529,8 @@ int usb_enable(usb_dc_status_callback status_cb)
 	k_mutex_lock(&usb_enable_lock, K_FOREVER);
 
 	if (usb_dev.enabled == true) {
-		ret = 0;
+		LOG_WRN("USB device support already enabled");
+		ret = -EALREADY;
 		goto out;
 	}
 
@@ -1616,7 +1617,7 @@ static int usb_device_init(const struct device *dev)
 	uint8_t *device_descriptor;
 
 	if (usb_dev.enabled == true) {
-		return 0;
+		return -EALREADY;
 	}
 
 	/* register device descriptor */
@@ -1628,7 +1629,11 @@ static int usb_device_init(const struct device *dev)
 
 	usb_set_config(device_descriptor);
 
+	if (IS_ENABLED(CONFIG_USB_DEVICE_INITIALIZE_AT_BOOT)) {
+		return usb_enable(NULL);
+	}
+
 	return 0;
 }
 
-SYS_INIT(usb_device_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+SYS_INIT(usb_device_init, POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY);


### PR DESCRIPTION
usb: add option to initialize USB device support at boot

---

This patch adds new board specific Kconfig option
BL654_USB_SERIAL_BACKEND_CDCACM, which is enabled by
default except USB_DEVICE_BLUETOOTH class is used.
Applications that depend on usb_enable() or do not
require composite configuration cannot be used
with BL654 USB board without user intervention.

Fixes: #39904