### PR TITLE
manifest: Fix psa-arch-tests manifest entry

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -228,7 +228,7 @@ manifest:
       groups:
         - tee
     - name: psa-arch-tests
-      revision: pull/2/head
+      revision: 0aab24602cbef30f6422e7ef1066a8473073e586
       path: modules/tee/tf-m/psa-arch-tests
       groups:
         - tee


### PR DESCRIPTION
Fix manifest entry for psa-arch-tests not set to a SHA.
Regression from: 453fbe2593e69242a919fe3e774951b43c6c4b8e

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>