### PR TITLE
doc: spinlock: ensure spinlock api is added to doxygen

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -209,6 +209,7 @@ cpp_id_attributes = [
     "__DEPRECATED_MACRO",
     "FUNC_NORETURN",
     "__subsystem",
+    "ALWAYS_INLINE",
 ]
 c_id_attributes = cpp_id_attributes
 

--- a/doc/reference/kernel/smp/smp.rst
+++ b/doc/reference/kernel/smp/smp.rst
@@ -297,3 +297,8 @@ Note that while SMP requires :kconfig:`CONFIG_USE_SWITCH`, the reverse is not
 true.  A uniprocessor architecture built with :kconfig:`CONFIG_SMP` set to No might
 still decide to implement its context switching using
 :c:func:`arch_switch`.
+
+API Reference
+**************
+
+.. doxygengroup:: spinlock_apis

--- a/include/spinlock.h
+++ b/include/spinlock.h
@@ -3,6 +3,12 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Public interface for spinlocks
+ */
+
 #ifndef ZEPHYR_INCLUDE_SPINLOCK_H_
 #define ZEPHYR_INCLUDE_SPINLOCK_H_
 
@@ -14,6 +20,13 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @brief Spinlock APIs
+ * @defgroup spinlock_apis Spinlock APIs
+ * @ingroup kernel_apis
+ * @{
+ */
 
 struct z_spinlock_key {
 	int key;
@@ -198,6 +211,8 @@ static ALWAYS_INLINE void k_spin_release(struct k_spinlock *l)
 	atomic_clear(&l->locked);
 #endif
 }
+
+/** @} */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Previously, `k_spin_lock()` and friends had broken links in html docs.

Fixes #42373

<img width="1552" alt="Screen Shot 2022-02-01 at 4 42 10 PM" src="https://user-images.githubusercontent.com/983494/152056246-0f8e39a8-fc48-4d1e-9229-d1e65b42ecc2.png">

