### PR TITLE
boards: teensy41: Enable DAT3 pull detection for USDHC

### DIFF
--- a/boards/arm/mimxrt1170_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1170_evk/Kconfig.defconfig
@@ -23,7 +23,7 @@ config SDMMC_USDHC_DAT3_PWR_TOGGLE
 	default y
 
 config SDMMC_USDHC_DAT3_PWR_DELAY
-	default 1000
+	default 10
 
 endif # DISK_DRIVERS
 

--- a/boards/arm/teensy4/Kconfig.defconfig
+++ b/boards/arm/teensy4/Kconfig.defconfig
@@ -21,4 +21,14 @@ endchoice
 config DISK_DRIVER_SDMMC
 	default y if DISK_DRIVERS
 
+if DISK_DRIVER_SDMMC
+
+config SDMMC_USDHC_DAT3_PWR_TOGGLE
+	default y
+
+config SDMMC_USDHC_DAT3_PWR_DELAY
+	default 10
+
+endif # DISK_DRIVER_SDMMC
+
 endif # BOARD_TEENSY40 || BOARD_TEENSY41

--- a/boards/arm/teensy4/pinmux.c
+++ b/boards/arm/teensy4/pinmux.c
@@ -55,7 +55,6 @@ static void teensy4_usdhc_pinmux(uint16_t nusdhc, bool init, uint32_t speed,
 	}
 
 	if (init) {
-		IOMUXC_SetPinMux(IOMUXC_GPIO_EMC_35_GPIO3_IO21, 0U);
 		IOMUXC_SetPinMux(IOMUXC_GPIO_EMC_41_USDHC1_VSELECT, 0U);
 		IOMUXC_SetPinMux(IOMUXC_GPIO_SD_B0_00_USDHC1_CMD, 0U);
 		IOMUXC_SetPinMux(IOMUXC_GPIO_SD_B0_01_USDHC1_CLK, 0U);
@@ -63,9 +62,6 @@ static void teensy4_usdhc_pinmux(uint16_t nusdhc, bool init, uint32_t speed,
 		IOMUXC_SetPinMux(IOMUXC_GPIO_SD_B0_03_USDHC1_DATA1, 0U);
 		IOMUXC_SetPinMux(IOMUXC_GPIO_SD_B0_04_USDHC1_DATA2, 0U);
 		IOMUXC_SetPinMux(IOMUXC_GPIO_SD_B0_05_USDHC1_DATA3, 0U);
-
-		/* SD0_CD_SW */
-		IOMUXC_SetPinConfig(IOMUXC_GPIO_EMC_35_GPIO3_IO21, 0x017089u);
 
 		/* SD0_VSELECT */
 		IOMUXC_SetPinConfig(IOMUXC_GPIO_EMC_41_USDHC1_VSELECT,
@@ -78,6 +74,25 @@ static void teensy4_usdhc_pinmux(uint16_t nusdhc, bool init, uint32_t speed,
 	IOMUXC_SetPinConfig(IOMUXC_GPIO_SD_B0_03_USDHC1_DATA1, cmd_data);
 	IOMUXC_SetPinConfig(IOMUXC_GPIO_SD_B0_04_USDHC1_DATA2, cmd_data);
 	IOMUXC_SetPinConfig(IOMUXC_GPIO_SD_B0_05_USDHC1_DATA3, cmd_data);
+}
+
+static void teensy4_usdhc_dat3_pull(bool pullup)
+{
+	if (pullup) {
+		/* Set pin config to pull up (47k Ohm) */
+		IOMUXC_SetPinConfig(IOMUXC_GPIO_SD_B0_05_USDHC1_DATA3,
+			IOMUXC_SW_PAD_CTL_PAD_SPEED(1) | IOMUXC_SW_PAD_CTL_PAD_SRE_MASK |
+			IOMUXC_SW_PAD_CTL_PAD_PKE_MASK | IOMUXC_SW_PAD_CTL_PAD_PUE_MASK |
+			IOMUXC_SW_PAD_CTL_PAD_HYS_MASK | IOMUXC_SW_PAD_CTL_PAD_PUS(1) |
+			IOMUXC_SW_PAD_CTL_PAD_DSE(1));
+	} else {
+		/* pull down (100k Ohm) */
+		IOMUXC_SetPinConfig(IOMUXC_GPIO_SD_B0_05_USDHC1_DATA3,
+			IOMUXC_SW_PAD_CTL_PAD_SPEED(1) | IOMUXC_SW_PAD_CTL_PAD_SRE_MASK |
+			IOMUXC_SW_PAD_CTL_PAD_PKE_MASK | IOMUXC_SW_PAD_CTL_PAD_PUE_MASK |
+			IOMUXC_SW_PAD_CTL_PAD_HYS_MASK | IOMUXC_SW_PAD_CTL_PAD_PUS(0) |
+			IOMUXC_SW_PAD_CTL_PAD_DSE(1));
+	}
 }
 #endif
 
@@ -393,6 +408,7 @@ static int teensy4_init(const struct device *dev)
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(usdhc1), okay) && CONFIG_DISK_DRIVER_SDMMC
 	teensy4_usdhc_pinmux(0, true, 2, 1);
 	imxrt_usdhc_pinmux_cb_register(teensy4_usdhc_pinmux);
+	imxrt_usdhc_dat3_cb_register(teensy4_usdhc_dat3_pull);
 #endif
 
 	return 0;

--- a/boards/arm/teensy4/teensy41.dts
+++ b/boards/arm/teensy4/teensy41.dts
@@ -27,4 +27,6 @@
 
 &usdhc1 {
 	status = "okay";
+	no-1-8-v;
+	detect-dat3;
 };

--- a/drivers/disk/usdhc.c
+++ b/drivers/disk/usdhc.c
@@ -2756,6 +2756,7 @@ static int usdhc_board_access_init(struct usdhc_priv *priv)
 	if (!priv->detect_gpio) {
 		LOG_INF("USDHC detection other than GPIO");
 		if (config->detect_dat3) {
+			LOG_INF("USDHC detection using DAT3 pull");
 			base->PROT_CTRL |= USDHC_PROT_CTRL_D3CD_MASK;
 			/* Pull down DAT3 */
 			usdhc_dat3_pull(USDHC_DAT3_PULL_DOWN, priv);

--- a/soc/arm/nxp_imx/rt/soc_rt10xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt10xx.c
@@ -174,12 +174,14 @@ static ALWAYS_INLINE void clock_init(void)
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(usdhc1), okay) && CONFIG_DISK_DRIVER_SDMMC
 	/* Configure USDHC clock source and divider */
+	CLOCK_InitSysPfd(kCLOCK_Pfd0, 24U);
 	CLOCK_SetDiv(kCLOCK_Usdhc1Div, 1U);
 	CLOCK_SetMux(kCLOCK_Usdhc1Mux, 1U);
 	CLOCK_EnableClock(kCLOCK_Usdhc1);
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(usdhc2), okay) && CONFIG_DISK_DRIVER_SDMMC
 	/* Configure USDHC clock source and divider */
+	CLOCK_InitSysPfd(kCLOCK_Pfd0, 24U);
 	CLOCK_SetDiv(kCLOCK_Usdhc2Div, 1U);
 	CLOCK_SetMux(kCLOCK_Usdhc2Mux, 1U);
 	CLOCK_EnableClock(kCLOCK_Usdhc2);


### PR DESCRIPTION
This PR started as fix for #42227, but when I tested the fix on an RT1060 the test itself also failed with a usage fault, so the PR fixes that too.
Details on the fix for #42227:
`teensy41` has no chip detect signal for SD slot. Use pull up resistor present on SD cards on DAT3 to detect card instead. Remove software defined chip detect IOMUXC selection that was used as a dummy chip detect pin.

Details on the fix for #42380:
The RT series does not set a default PLL PFD fractional divider, and without this configured the USDHC driver will encounter a usage fault when trying to calculate its source clock frequency. Explicitly set the PFD0 fractional divider for SYS PLL, so that this fault is avoided.

Fixes #42227
Fixes #42380