### PR TITLE
driver: ADC: Add ADC voltage comparator feature for ITE

### DIFF
--- a/drivers/sensor/CMakeLists.txt
+++ b/drivers/sensor/CMakeLists.txt
@@ -102,6 +102,7 @@ add_subdirectory_ifdef(CONFIG_ITDS		wsen_itds)
 add_subdirectory_ifdef(CONFIG_MCUX_ACMP		mcux_acmp)
 add_subdirectory_ifdef(CONFIG_TACH_NPCX		nuvoton_tach_npcx)
 add_subdirectory_ifdef(CONFIG_TACH_IT8XXX2	ite_tach_it8xxx2)
+add_subdirectory_ifdef(CONFIG_ADC_ITE_IT8XXX2	ite_adc_cmp_it8xxx2)
 
 if(CONFIG_USERSPACE OR CONFIG_SENSOR_SHELL OR CONFIG_SENSOR_SHELL_BATTERY)
 # The above if() is needed or else CMake would complain about

--- a/drivers/sensor/Kconfig
+++ b/drivers/sensor/Kconfig
@@ -240,4 +240,6 @@ source "drivers/sensor/nuvoton_tach_npcx/Kconfig"
 
 source "drivers/sensor/ite_tach_it8xxx2/Kconfig"
 
+source "drivers/sensor/ite_adc_cmp_it8xxx2/Kconfig"
+
 endif # SENSOR

--- a/drivers/sensor/ite_adc_cmp_it8xxx2/CMakeLists.txt
+++ b/drivers/sensor/ite_adc_cmp_it8xxx2/CMakeLists.txt
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+
+zephyr_library_sources(adc_vcmp_ite_it8xxx2.c)

--- a/drivers/sensor/ite_adc_cmp_it8xxx2/Kconfig
+++ b/drivers/sensor/ite_adc_cmp_it8xxx2/Kconfig
@@ -1,0 +1,15 @@
+#  ADC CMP NPCX driver configuration options
+
+# Copyright (c) 2022 Intel Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+if ADC_ITE_IT8XXX2
+
+config ADC_VCMP_ITE_IT8XXX2
+	bool "ITE IT8XXX2 ADC threshold detection interruption"
+	default n
+	help
+	  This option enables threshold interruption using sensor
+	  trigger API.
+
+endif # ADC_CMP_ITE_IT8XXX2

--- a/drivers/sensor/ite_adc_cmp_it8xxx2/adc_vcmp_ite_it8xxx2.c
+++ b/drivers/sensor/ite_adc_cmp_it8xxx2/adc_vcmp_ite_it8xxx2.c
@@ -1,0 +1,306 @@
+#include <drivers/sensor.h>
+#include <drivers/adc/adc_vcmp_ite_it8xxx2.h>
+#include <logging/log.h>
+
+LOG_MODULE_REGISTER(adc_vcmp_itxxx82, LOG_LEVEL_INF);
+
+struct adc_vcmp_ite_it8xxx2_data {
+	/* Work queue to be notified when threshold assertion happens */
+	struct k_work work;
+	/* Sensor trigger hanlder to notify user of assetion */
+	sensor_trigger_handler_t handler;
+	/* ADC driver reference */
+	const struct device *dev;
+};
+
+struct adc_vcmp_ite_it8xxx2_config {
+	/*
+	 * Pointer of ADC device that will be performing measurement, this
+	 * must be provied by device tree.
+	 */
+	const struct device *adc;
+	/*
+	 * ADC channel that will be used to measure signal, this must be
+	 * provided by device tree.
+	 */
+	uint8_t csel;
+	/* Threshold selection number assigned during initialization */
+	uint8_t vcmp;
+	/* Threshold assert value in millivolts */
+	uint32_t thr_mv;
+	/*
+	 * Condition to be met between measured signal and threshold assert
+	 * value that will trigger event
+	 */
+	enum adc_vcmp_ite_it3xxx2_trigger_mode trig_mode;
+};
+
+#define DT_DRV_COMPAT ite_it8xxx2_adc_cmp
+
+#define ADC_VCMP_ITE_IT8xxx2_UNDEFINED		(-1)
+static void adc_vcmp_npcx_trigger_work_handler(struct k_work *item)
+{
+	struct adc_vcmp_ite_it8xxx2_data *data =
+		CONTAINER_OF(item, struct adc_vcmp_ite_it8xxx2_data, work);
+	struct sensor_trigger trigger = {
+		.type = SENSOR_TRIG_THRESHOLD,
+		.chan = SENSOR_CHAN_VOLTAGE
+	};
+
+	if (data->handler) {
+		data->handler(data->dev, &trigger);
+	}
+}
+
+#define ADC_VCMP_IT8XXX2_INIT_ADC_INST(node_id)                               \
+	{DEVICE_DT_GET(DT_PROP(node_id, adc)),                                \
+	DT_STRING_TOKEN(node_id, scan_period)},
+
+/**/
+static int adc_vcmp_init_adc(const struct device *dev)
+{
+	int i;
+	const struct adc_vcmp_init_adc_t {
+		const struct device *dev;
+		enum vcmp_scan_period scan_period;
+	} adc_nodes[] = {
+		DT_FOREACH_STATUS_OKAY(ite_it8xxx2_adc_cmp,
+			ADC_VCMP_IT8XXX2_INIT_ADC_INST)
+	};
+
+	for(i = 0; i < ARRAY_SIZE(adc_nodes); i++) {
+		adc_vcmp_it8xxx2_set_scan_period(adc_nodes->dev,
+						adc_nodes->scan_period);
+	}
+	return 0;
+}
+SYS_INIT(adc_vcmp_init_adc, PRE_KERNEL_1, CONFIG_SENSOR_INIT_PRIORITY);
+
+static int adc_vcmp_ite_it8xxx2_init(const struct device *dev)
+{
+	const struct adc_vcmp_ite_it8xxx2_config *const config = dev->config;
+	struct adc_vcmp_ite_it8xxx2_data *data = dev->data;
+	struct adc_vcmp_it8xxx2_vcmp_control_t control;
+	int ret;
+
+	LOG_DBG("Initialize ADC CMP threshold selection (%d)", config->vcmp);
+	/* Data must keep device reference for worker handler*/
+	data->dev = dev;
+
+	/* Set ADC channel selection */
+	control.param = ADC_VCMP_ITE_IT8XXX2_PARAM_CSELL;
+	control.val = (uint32_t)config->csel;
+	ret = adc_vcmp_it8xxx2_ctrl_set_param(config->adc, config->vcmp,
+						&control);
+	if (ret) {
+		goto init_error;
+	}
+
+	/* Init and set Worker queue to enable notifications */
+	k_work_init(&data->work, adc_vcmp_npcx_trigger_work_handler);
+	control.param = ADC_VCMP_ITE_IT8XXX2_PARAM_WORK;
+	control.val = (uint32_t)&data->work;
+	ret = adc_vcmp_it8xxx2_ctrl_set_param(config->adc, config->vcmp,
+						&control);
+	if (ret) {
+		goto init_error;
+	}
+
+	/* Set threshold value if set on device tree */
+	if (config->thr_mv != ADC_VCMP_ITE_IT8xxx2_UNDEFINED) {
+		control.param = ADC_VCMP_ITE_IT8XXX2_PARAM_THRDAT;
+#if 0
+		/* TODO: add function to convert mv to raw */
+		/* Convert from millivolts to ADC raw register value */
+		ret = adc_npcx_threshold_mv_to_thrval(config->thr_mv,
+						&control.val);
+		if (ret) {
+			goto init_error;
+		}
+#endif
+		ret = adc_vcmp_it8xxx2_ctrl_set_param(config->adc, config->vcmp,
+						&control);
+		if (ret) {
+			goto init_error;
+		}
+	}
+
+	/* Set threshold comparison if set on device tree */
+	if (config->trig_mode == VCMP_TRIGGER_MODE_LESS_OR_EQUAL ||
+	    config->trig_mode == VCMP_TRIGGER_MODE_GREATER) {
+		control.param = ADC_VCMP_ITE_IT8XXX2_PARAM_TMOD;
+		control.val = (uint32_t)config->trig_mode;
+		ret = adc_vcmp_it8xxx2_ctrl_set_param(config->adc,
+				config->vcmp, &control);
+	}
+
+init_error:
+	if (ret) {
+		LOG_ERR("Error setting parameter %d - value %d",
+			(uint32_t)control.param, control.val);
+	}
+
+	return ret;
+}
+
+static int adc_vcmp_ite_it8xxx2_attr_set(const struct device *dev,
+					 enum sensor_channel chan,
+					 enum sensor_attribute attr,
+					 const struct sensor_value *val)
+{
+	const struct adc_vcmp_ite_it8xxx2_config *const config = dev->config;
+	struct adc_vcmp_it8xxx2_vcmp_control_t control;
+	int ret;
+
+	if (chan != SENSOR_CHAN_VOLTAGE) {
+		return -ENOTSUP;
+	}
+
+	switch ((uint16_t)attr) {
+	case SENSOR_ATTR_LOWER_THRESH:
+	case SENSOR_ATTR_UPPER_THRESH:
+		/* Set threshold value first */
+		control.param = ADC_VCMP_ITE_IT8XXX2_PARAM_THRDAT;
+		control.val = val->val1;
+		ret = adc_vcmp_it8xxx2_ctrl_set_param(config->adc,
+						config->vcmp, &control);
+		if (ret) {
+			break;
+		}
+
+		/* Then set lower or higher threshold */
+		control.param = ADC_VCMP_ITE_IT8XXX2_PARAM_TMOD;
+		control.val = attr == SENSOR_ATTR_UPPER_THRESH ?
+			VCMP_TRIGGER_MODE_GREATER :
+			VCMP_TRIGGER_MODE_LESS_OR_EQUAL;
+		ret = adc_vcmp_it8xxx2_ctrl_set_param(config->adc,
+						config->vcmp, &control);
+		break;
+#if 0
+		/* TODO: add function to convert mv to raw */
+	case SENSOR_ATTR_LOWER_VOLTAGE_THRESH:
+	case SENSOR_ATTR_UPPER_VOLTAGE_THRESH:
+		/* Set threshold value first */
+		control.param = ADC_NPCX_THRESHOLD_PARAM_THVAL;
+		/* Convert from millivolts to ADC raw register value */
+		ret = adc_npcx_threshold_mv_to_thrval(val->val1,
+						&control.val);
+		if (ret) {
+			break;
+		}
+		ret = adc_vcmp_it8xxx2_ctrl_set_param(config->adc,
+						config->vcmp, &control);
+		if (ret) {
+			break;
+		}
+
+		/* Then set lower or higher threshold */
+		control.param = ADC_NPCX_THRESHOLD_PARAM_L_H;
+		control.val =
+			(uint16_t)attr == SENSOR_ATTR_UPPER_VOLTAGE_THRESH ?
+			ADC_NPCX_THRESHOLD_PARAM_L_H_HIGHER :
+			ADC_NPCX_THRESHOLD_PARAM_L_H_LOWER;
+
+		ret = adc_vcmp_it8xxx2_ctrl_set_param(config->adc,
+						config->vcmp, &control);
+		break;
+#endif
+	case SENSOR_ATTR_ALERT:
+		control.val = val->val1;
+		ret = adc_vcmp_it8xxx2_ctrl_enable(config->adc,
+						config->vcmp, !!control.val);
+		break;
+	default:
+		ret = -ENOTSUP;
+	}
+	return ret;
+}
+
+static int adc_vcmp_ite_it8xxx2_attr_get(const struct device *dev,
+					 enum sensor_channel chan,
+					 enum sensor_attribute attr,
+					 struct sensor_value *val)
+{
+	return -ENOTSUP;
+}
+
+static int adc_vcmp_ite_it8xxx2_trigger_set(const struct device *dev,
+					    const struct sensor_trigger *trig,
+					    sensor_trigger_handler_t handler)
+{
+	const struct adc_vcmp_ite_it8xxx2_config *const config = dev->config;
+	struct adc_vcmp_ite_it8xxx2_data *data = dev->data;
+	struct adc_vcmp_it8xxx2_vcmp_control_t control;
+
+	if (trig == NULL || handler == NULL) {
+		return -EINVAL;
+	}
+
+	if (trig->type != SENSOR_TRIG_THRESHOLD ||
+	    trig->chan != SENSOR_CHAN_VOLTAGE) {
+		return -ENOTSUP;
+	}
+
+	data->handler = handler;
+
+	control.param = ADC_VCMP_ITE_IT8XXX2_PARAM_WORK;
+	control.val = (uint32_t)&data->work;
+	return adc_vcmp_it8xxx2_ctrl_set_param(config->adc, config->vcmp,
+						&control);
+}
+
+static int adc_vcmp_it8xxx2_channel_get(const struct device *dev,
+					enum sensor_channel chan,
+					struct sensor_value *val)
+{
+	const struct adc_vcmp_ite_it8xxx2_config *const config = dev->config;
+
+	if (chan != SENSOR_CHAN_VOLTAGE) {
+		return -ENOTSUP;
+	}
+
+	if (val == NULL) {
+		return -EINVAL;
+	}
+
+	val->val1 = (uint32_t)&config->adc;
+	return 0;
+}
+
+static const struct sensor_driver_api adc_vcmp_ite_it8xxx2_api = {
+	.attr_set = adc_vcmp_ite_it8xxx2_attr_set,
+	.attr_get = adc_vcmp_ite_it8xxx2_attr_get,
+	.trigger_set = adc_vcmp_ite_it8xxx2_trigger_set,
+	.channel_get = adc_vcmp_it8xxx2_channel_get,
+};
+
+#define ADC_VCMP_IT8XXX2_INST_INIT(inst)                                      \
+	static struct adc_vcmp_ite_it8xxx2_data                               \
+		adc_vcmp_ite_it8xxx2_data_##inst;                             \
+	static const struct adc_vcmp_ite_it8xxx2_config                       \
+		adc_vcmp_ite_it8xxx2_config_##inst = {                        \
+		.adc = DEVICE_DT_GET(DT_PROP(DT_PARENT(inst), adc)),          \
+		.csel = DT_PROP(inst, adc_channel),                           \
+		.vcmp = (uint32_t)inst,                                       \
+		.thr_mv = DT_PROP_OR(inst, threshold_mv,                      \
+			ADC_VCMP_ITE_IT8xxx2_UNDEFINED),                      \
+		.trig_mode = DT_STRING_TOKEN_OR(inst, trigger_mode,           \
+			ADC_VCMP_ITE_IT8xxx2_UNDEFINED)                       \
+	};                                                                    \
+	DEVICE_DT_DEFINE(inst, adc_vcmp_ite_it8xxx2_init, NULL,               \
+			 &adc_vcmp_ite_it8xxx2_data_##inst,                   \
+			 &adc_vcmp_ite_it8xxx2_config_##inst,                 \
+			 PRE_KERNEL_2,                                        \
+			 CONFIG_SENSOR_INIT_PRIORITY,                         \
+			 &adc_vcmp_ite_it8xxx2_api);
+
+#define ADC_VCMP_IT8XXX2_ID_WITH_COMMA(inst )	inst,
+
+#define ADC_VCMP_IT8XXX2_NODE_INIT(node_id)                                   \
+	enum UTIL_CAT(adc_vcmp_ite_it8xxx2_node_, node_id) {                  \
+		DT_FOREACH_CHILD_STATUS_OKAY(node_id,                         \
+			ADC_VCMP_IT8XXX2_ID_WITH_COMMA)                       \
+	};                                                                    \
+	DT_FOREACH_CHILD_STATUS_OKAY(node_id, ADC_VCMP_IT8XXX2_INST_INIT)
+
+DT_FOREACH_STATUS_OKAY(ite_it8xxx2_adc_cmp, ADC_VCMP_IT8XXX2_NODE_INIT)

--- a/dts/bindings/adc/ite,it8xxx2-adc-cmp.yaml
+++ b/dts/bindings/adc/ite,it8xxx2-adc-cmp.yaml
@@ -1,0 +1,60 @@
+# Copyright (c) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    This will perform signal comparision with threshold established.
+
+compatible: "ite,it8xxx2-adc-cmp"
+
+properties:
+  adc:
+    type: phandle
+    required: true
+    description: |
+      ADC port that will be performing measurement.
+
+  scan-period:
+    type: string
+    required: false
+    default: VCMP_SCAN_PERIOD_1MS
+    description: |
+      Define interval at which ADC scan will me performed.
+    enum:
+      - VCMP_SCAN_PERIOD_100US
+      - VCMP_SCAN_PERIOD_200US
+      - VCMP_SCAN_PERIOD_400US
+      - VCMP_SCAN_PERIOD_600US
+      - VCMP_SCAN_PERIOD_800US
+      - VCMP_SCAN_PERIOD_1MS
+      - VCMP_SCAN_PERIOD_1_5MS
+      - VCMP_SCAN_PERIOD_2MS
+      - VCMP_SCAN_PERIOD_2_5MS
+      - VCMP_SCAN_PERIOD_3MS
+      - VCMP_SCAN_PERIOD_4MS
+      - VCMP_SCAN_PERIOD_5MS
+
+child-binding:
+  description: |
+    Define each individual voltage comparator with parameters.
+  properties:
+    adc-channel:
+      type: int
+      required: true
+      description: |
+        ADC channel that will perform signal measurement.
+
+    threshold-mv:
+      type: int
+      required: false
+      description: |
+        Value in millivolts present on ADC data as threshold assert.
+
+    trigger-mode:
+      type: string
+      required: false
+      description: |
+        Determines the condition to be met between ADC data and
+        threshold assert value that will trigger comparator event.
+      enum:
+      - VCMP_TRIGGER_MODE_LESS_OR_EQUAL
+      - VCMP_TRIGGER_MODE_GREATER

--- a/include/drivers/adc/adc_vcmp_ite_it8xxx2.h
+++ b/include/drivers/adc/adc_vcmp_ite_it8xxx2.h
@@ -1,0 +1,86 @@
+#ifndef _ADC_VCMP_ITE_IT8XXX2_H_
+#define _ADC_VCMP_ITE_IT8XXX2_H_
+
+#include <device.h>
+
+enum vcmp_scan_period {
+	VCMP_SCAN_PERIOD_100US = 0x10,
+	VCMP_SCAN_PERIOD_200US = 0x20,
+	VCMP_SCAN_PERIOD_400US = 0x30,
+	VCMP_SCAN_PERIOD_600US = 0x40,
+	VCMP_SCAN_PERIOD_800US = 0x50,
+	VCMP_SCAN_PERIOD_1MS   = 0x60,
+	VCMP_SCAN_PERIOD_1_5MS = 0x70,
+	VCMP_SCAN_PERIOD_2MS   = 0x80,
+	VCMP_SCAN_PERIOD_2_5MS = 0x90,
+	VCMP_SCAN_PERIOD_3MS   = 0xA0,
+	VCMP_SCAN_PERIOD_4MS   = 0xB0,
+	VCMP_SCAN_PERIOD_5MS   = 0xC0,
+};
+
+enum adc_vcmp_ite_it3xxx2_control_param {
+	/* Selects ADC channel to be used for measurement */
+	ADC_VCMP_ITE_IT8XXX2_PARAM_CSELL,
+	/* Sets relation between measured value and assetion threshold value.*/
+	ADC_VCMP_ITE_IT8XXX2_PARAM_TMOD,
+	/* Sets the threshol value to which measured data is compared. */
+	ADC_VCMP_ITE_IT8XXX2_PARAM_THRDAT,
+	/* Sets worker queue thread to be notified */
+	ADC_VCMP_ITE_IT8XXX2_PARAM_WORK,
+
+	ADC_VCMP_ITE_IT8XXX2_PARAM_MAX,
+};
+
+enum adc_vcmp_ite_it3xxx2_trigger_mode {
+	VCMP_TRIGGER_MODE_LESS_OR_EQUAL,
+	VCMP_TRIGGER_MODE_GREATER
+};
+
+struct adc_vcmp_it8xxx2_vcmp_control_t {
+	/* Voltage comparator control parameter */
+	enum adc_vcmp_ite_it3xxx2_control_param param;
+	/* Parameter value */
+	uint32_t val;
+};
+
+/**
+ * @brief Set ADC voltage comparator parameter.
+ *
+ * @note This function is available only if @kconfig{CONFIG}
+ * is selected.
+ *
+ * @param dev       Pointer to the device structure for the driver instance.
+ * @param th_sel    Threshold selected.
+ * @param control   Pointer of control parameter structure.
+ *                  See struct adc_npcx_threshold_control_t for supported
+ *                  parameters.
+ *
+ * @returns 0 on success, negative error code otherwise.
+ */
+int adc_vcmp_it8xxx2_ctrl_set_param(const struct device *dev,
+				    const uint8_t vcmp,
+				    const struct adc_vcmp_it8xxx2_vcmp_control_t
+				    *control);
+
+/**
+ * @brief Enables/Disables ADC threshold interruption.
+ *
+ * @note This function is available only if @kconfig{CONFIG_ADC_CMP_NPCX}
+ * is selected.
+ *
+ * @param dev       Pointer to the device structure for the driver instance.
+ * @param th_sel    Threshold selected.
+ * @param enable    Enable or disables threshold interruption.
+ *
+ * @returns 0 on success, negative error code otherwise.
+ *            all parameters must be configure prior enabling threshold
+ *            interruption, otherwhise error will be returned.
+ */
+int adc_vcmp_it8xxx2_ctrl_enable(const struct device *dev, uint8_t vcmp,
+				 const bool enable);
+
+
+int adc_vcmp_it8xxx2_set_scan_period(const struct device *dev,
+				     enum vcmp_scan_period scan_period);
+
+#endif /* _ADC_VCMP_IT8XXX2_H_ */

--- a/soc/riscv/riscv-ite/common/chip_chipregs.h
+++ b/soc/riscv/riscv-ite/common/chip_chipregs.h
@@ -1536,8 +1536,16 @@ struct adc_it8xxx2_regs {
 	volatile uint8_t reserved1[18];
 	volatile uint8_t VCH0DATL;
 	volatile uint8_t VCH0DATM;
-	volatile uint8_t reserved2[42];
+	volatile uint8_t reserved2[29];
+	volatile uint8_t VCMPSCP;
+	volatile uint8_t reserved3[12];
 	volatile uint8_t ADCDVSTS;
+	volatile uint8_t VCMPSTS;
+	volatile uint8_t VCMP0CTL;
+	volatile uint8_t VCMP0THRDATM;
+	volatile uint8_t VCMP0THRDATL;
+	volatile uint8_t reserved4[46];
+	volatile uint8_t VCMP0CSELM;
 };
 #endif /* !__ASSEMBLER__ */
 


### PR DESCRIPTION
ADC voltage comparator will continuously monitor ADC channel and
compare its data with established threshold value. When the relation
between these two inputs matches with trigger mode, interruption will
be triggered.
Implementation is exported through sensor trigger API.
This will enable comparator functionality for ITE IT8XXX2 MUC's.

Signed-off-by: Bernardo Perez Priego <bernardo.perez.priego@intel.com>