### PR TITLE
tests: USe drivers instead of driver

### DIFF
--- a/tests/drivers/can/api/testcase.yaml
+++ b/tests/drivers/can/api/testcase.yaml
@@ -1,7 +1,7 @@
 tests:
   drivers.can:
-    tags: driver can
+    tags: drivers can
     depends_on: can
   drivers.can.loopback:
-    tags: driver can
+    tags: drivers can
     platform_allow: native_posix native_posix_64

--- a/tests/drivers/can/canfd/testcase.yaml
+++ b/tests/drivers/can/canfd/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   drivers.canfd:
-    tags: driver can
+    tags: drivers can
     depends_on: canfd

--- a/tests/drivers/can/stm32/testcase.yaml
+++ b/tests/drivers/can/stm32/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
   drivers.can.stm32:
-    tags: driver can
+    tags: drivers can
     depends_on: can
     filter: dt_compat_enabled("st,stm32-can")

--- a/tests/drivers/can/timing/testcase.yaml
+++ b/tests/drivers/can/timing/testcase.yaml
@@ -1,7 +1,7 @@
 tests:
   drivers.can.timing:
-    tags: driver can
+    tags: drivers can
     depends_on: can
   drivers.can.timing_loopback:
-    tags: driver can
+    tags: drivers can
     platform_allow: native_posix native_posix_64

--- a/tests/drivers/entropy/api/testcase.yaml
+++ b/tests/drivers/entropy/api/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   drivers.entropy:
     filter: CONFIG_ENTROPY_HAS_DRIVER
-    tags: driver entropy
+    tags: drivers entropy

--- a/tests/drivers/flash_simulator/testcase.yaml
+++ b/tests/drivers/flash_simulator/testcase.yaml
@@ -1,16 +1,16 @@
 tests:
   drivers.flash.flash_simulator:
     platform_allow: qemu_x86 native_posix native_posix_64
-    tags: driver
+    tags: drivers
   drivers.flash.flash_simulator.qemu_erase_value_0x00:
     extra_args: DTC_OVERLAY_FILE=boards/qemu_x86_ev_0x00.overlay
     platform_allow: qemu_x86
-    tags: driver
+    tags: drivers
   drivers.flash.flash_simulator.posix_erase_value_0x00:
     extra_args: DTC_OVERLAY_FILE=boards/native_posix_ev_0x00.overlay
     platform_allow: native_posix
-    tags: driver
+    tags: drivers
   drivers.flash.flash_simulator.posix_64_erase_value_0x00:
     extra_args: DTC_OVERLAY_FILE=boards/native_posix_64_ev_0x00.overlay
     platform_allow: native_posix_64
-    tags: driver
+    tags: drivers

--- a/tests/drivers/hwinfo/api/testcase.yaml
+++ b/tests/drivers/hwinfo/api/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
   drivers.hwinfo.api:
-    tags: driver
+    tags: drivers

--- a/tests/drivers/pinctrl/api/testcase.yaml
+++ b/tests/drivers/pinctrl/api/testcase.yaml
@@ -5,7 +5,7 @@ tests:
   drivers.pinctrl.api:
     tags: drivers pinctrl
     platform_allow: native_posix native_posix_64
-  derivers.pinctrl.api_reg:
+  drivers.pinctrl.api_reg:
     tags: drivers pinctrl
     platform_allow: native_posix native_posix_64
     extra_args: CONF_FILE="prj.conf;reg.conf"

--- a/tests/drivers/sensor/accel/testcase.yaml
+++ b/tests/drivers/sensor/accel/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  driver.sensor:
-    tags: driver sensor subsys
+  drivers.sensor:
+    tags: drivers sensor subsys
     platform_allow: native_posix

--- a/tests/drivers/sensor/generic/testcase.yaml
+++ b/tests/drivers/sensor/generic/testcase.yaml
@@ -3,8 +3,8 @@ common:
     - qemu_x86
     - mps2_an385
 tests:
-  driver.sensor:
-    tags: driver sensor
-  driver.sensor.fpu:
+  drivers.sensor:
+    tags: drivers sensor
+  drivers.sensor.fpu:
     extra_args: CONF_FILE=prj_fpu.conf
-    tags: driver sensor
+    tags: drivers sensor

--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -9,7 +9,7 @@ tests:
     filter: not CONFIG_SOC_FAMILY_STM32
     harness_config:
       fixture: spi_loopback
-  driver.spi.loopback.internal:
+  drivers.spi.loopback.internal:
     filter: CONFIG_SPI_LOOPBACK_MODE_LOOP
   drivers.mcux_dspi_dma.loopback:
     tags: dma


### PR DESCRIPTION
By convention most drivers tests are using name "drivers" and tag "drivers". Just make it consistent.