### PR TITLE
usb: Handle USB_DC_RESET event notifications

### DIFF
--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -1184,10 +1184,10 @@ static void forward_status_cb(enum usb_dc_status_code status, const uint8_t *par
 		usb_reset_alt_setting();
 	}
 
-	if (status == USB_DC_DISCONNECTED || status == USB_DC_SUSPEND) {
+	if (status == USB_DC_DISCONNECTED || status == USB_DC_SUSPEND || status == USB_DC_RESET) {
 		if (usb_dev.configured) {
 			usb_cancel_transfers();
-			if (status == USB_DC_DISCONNECTED) {
+			if (status == USB_DC_DISCONNECTED || status == USB_DC_RESET) {
 				foreach_ep(disable_interface_ep);
 				usb_dev.configured = false;
 			}


### PR DESCRIPTION
This patch fixes an issue where mcux usb devices may stop
functioning after a reset event, because they do not
provide a USB_DC_DISCONNECTED event and USB_DC_RESET
events were not handled by the forward status callback.

Fixes #42278 

Signed-off-by: Jacob Caughfield <mlsvrts@protonmail.com>