### PR TITLE
driver: entropy: stm32: Fix health dts properties

### DIFF
--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -481,15 +481,15 @@ static int entropy_stm32_rng_init(const struct device *dev)
 	__ASSERT_NO_MSG(res == 0);
 
 
-#if DT_INST_NODE_HAS_PROP(0, health-test-config)
-#if DT_INST_NODE_HAS_PROP(0, health-test-magic)
+#if DT_INST_NODE_HAS_PROP(0, health_test_config)
+#if DT_INST_NODE_HAS_PROP(0, health_test_magic)
 	/* Write Magic number before writing configuration
 	 * Not all stm32 series have a Magic number
 	 */
-	LL_RNG_SetHealthConfig(dev_data->rng, DT_INST_PROP(0, health-test-magic));
+	LL_RNG_SetHealthConfig(dev_data->rng, DT_INST_PROP(0, health_test_magic));
 #endif
 	/* Write RNG HTCR configuration */
-	LL_RNG_SetHealthConfig(dev_data->rng, DT_INST_PROP(0, health-test-config));
+	LL_RNG_SetHealthConfig(dev_data->rng, DT_INST_PROP(0, health_test_config));
 #endif
 
 	LL_RNG_EnableIT(dev_data->rng);


### PR DESCRIPTION
The properties from dts to driver were not translated
correctly from - to _. This PR fixes this

Signed-off-by: Wouter Cappelle <wouter.cappelle@crodeon.com>

This PR fixes #42385