### PR TITLE
debug: Add back openocd alias

### DIFF
--- a/subsys/debug/thread_info.c
+++ b/subsys/debug/thread_info.c
@@ -122,9 +122,15 @@ size_t _kernel_thread_info_offsets[] = {
 	 * checked with _kernel_thread_info_num_offsets.
 	 */
 };
+extern size_t __attribute__((alias("_kernel_thread_info_offsets")))
+		_kernel_openocd_offsets;
 
 __attribute__((used, section(".dbg_thread_info")))
 size_t _kernel_thread_info_num_offsets = ARRAY_SIZE(_kernel_thread_info_offsets);
+extern size_t __attribute__((alias("_kernel_thread_info_num_offsets")))
+		_kernel_openocd_num_offsets;
 
 __attribute__((used, section(".dbg_thread_info")))
 uint8_t _kernel_thread_info_size_t_size = (uint8_t)sizeof(size_t);
+extern uint8_t __attribute__((alias("_kernel_thread_info_size_t_size")))
+		_kernel_openocd_size_t_size;


### PR DESCRIPTION
OpenOCD is still using these alias, until we fix OpenOCD
upstream we should keep them.

This partially reverts commit
1a7bc060867aec90cf22fd23afcd5f33f1e1cce4.

Fix #42392

Signed-off-by: Julien Massot <julien.massot@iot.bzh>