### PR TITLE
soc: arm: ti_simplelink: drop custom constraint implementation

### DIFF
--- a/soc/arm/ti_simplelink/cc13x2_cc26x2/power.c
+++ b/soc/arm/ti_simplelink/cc13x2_cc26x2/power.c
@@ -184,57 +184,5 @@ void PowerCC26XX_schedulerRestore(void)
 	 */
 }
 
-#ifdef CONFIG_PM
-/* Constraint API hooks */
-
-void pm_constraint_set(enum pm_state state)
-{
-	switch (state) {
-	case PM_STATE_RUNTIME_IDLE:
-		Power_setConstraint(PowerCC26XX_DISALLOW_IDLE);
-		break;
-	case PM_STATE_STANDBY:
-		Power_setConstraint(PowerCC26XX_DISALLOW_STANDBY);
-		break;
-	default:
-		break;
-	}
-}
-
-void pm_constraint_release(enum pm_state state)
-{
-	switch (state) {
-	case PM_STATE_RUNTIME_IDLE:
-		Power_releaseConstraint(PowerCC26XX_DISALLOW_IDLE);
-		break;
-	case PM_STATE_STANDBY:
-		Power_releaseConstraint(PowerCC26XX_DISALLOW_STANDBY);
-		break;
-	default:
-		break;
-	}
-}
-
-bool pm_constraint_get(enum pm_state state)
-{
-	bool ret = true;
-	uint32_t constraints;
-
-	constraints = Power_getConstraintMask();
-	switch (state) {
-	case PM_STATE_RUNTIME_IDLE:
-		ret = (constraints & (1 << PowerCC26XX_DISALLOW_IDLE)) == 0;
-		break;
-	case PM_STATE_STANDBY:
-		ret = (constraints & (1 << PowerCC26XX_DISALLOW_STANDBY)) == 0;
-		break;
-	default:
-		break;
-	}
-
-	return ret;
-}
-#endif /* CONFIG_PM */
-
 SYS_INIT(power_initialize, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 SYS_INIT(unlatch_pins, POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY);

--- a/subsys/pm/constraint.c
+++ b/subsys/pm/constraint.c
@@ -15,7 +15,7 @@ LOG_MODULE_DECLARE(pm, CONFIG_PM_LOG_LEVEL);
 
 static atomic_t power_state_disable_count[PM_STATE_COUNT];
 
-__weak void pm_constraint_set(enum pm_state state)
+void pm_constraint_set(enum pm_state state)
 {
 	atomic_val_t v;
 
@@ -27,7 +27,7 @@ __weak void pm_constraint_set(enum pm_state state)
 	(void)(v);
 }
 
-__weak void pm_constraint_release(enum pm_state state)
+void pm_constraint_release(enum pm_state state)
 {
 	atomic_val_t v;
 
@@ -39,7 +39,7 @@ __weak void pm_constraint_release(enum pm_state state)
 	(void)(v);
 }
 
-__weak bool pm_constraint_get(enum pm_state state)
+bool pm_constraint_get(enum pm_state state)
 {
 	__ASSERT(state < PM_STATE_COUNT, "Invalid power state!");
 

--- a/west.yml
+++ b/west.yml
@@ -139,7 +139,7 @@ manifest:
       groups:
         - hal
     - name: hal_ti
-      revision: 1992a4c536554c4f409c36896eda6abdc414d277
+      revision: ba4823f6beb8629d94aab1426bd8afa8127a1da2
       path: modules/hal/ti
       groups:
         - hal


### PR DESCRIPTION
The constraints API offered by TI HAL is meant to be used externally,
for example, when implementing a policy using their policy mechanism
(not used on Zephyr). The API is likely designed for systems where a
thin RTOS is used (e.g., FreeRTOS, TI-RTOS?), places where you basically
get a Kernel and a few services around, but not a system like Zephyr
where you also get, for example, a power management subsystem. This
means that it gets difficult for an RTOS like Zephyr to use such HAL
APIs while using its own constraints API. The first question is why we
allowed such kind of HAL code to be part of upstream Zephyr. It
certainly does useful things, but it is also uses a HAL infrastructure
which is hardly exportable to an RTOS like Zephyr. Part of the
Power_init() code, for example, should likely be in a clock controller
driver, where Zephyr APIs can be used.

The _solution_ that was done to workaround this case was allowing custom
full re-implementations of the constraints API. So we are basically
overwriting a functional API with custom HAL code because of poor HAL
designs. This is in general a bad design principle. If we allow this, we
can hardly offer any guarantees to the API users. For example, is
re-implemented as thread-safe? What is the API behavior then? ...
Platforms like TI that have incomplete support in Zephyr tend to leverage
to HAL code certain functions that should be proper Zephyr
drivers. Such platforms should not influence the design of APIs because
they lack solid foundations.

This patch removes the custom implementation since the HAL has been
patched so that it forwards PM state constraints to Zephyr.