### PR TITLE
shell: Fix dictionary command naming

### DIFF
--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -416,7 +416,8 @@ struct shell_static_entry {
 
 /* Internal macro used for creating handlers for dictionary commands. */
 #define Z_SHELL_CMD_DICT_HANDLER_CREATE(_data, _handler)		\
-static int UTIL_CAT(cmd_dict_, GET_ARG_N(1, __DEBRACKET _data))(	\
+static int UTIL_CAT(UTIL_CAT(cmd_dict_, UTIL_CAT(_handler, _)),		\
+			GET_ARG_N(1, __DEBRACKET _data))(		\
 		const struct shell *shell, size_t argc, char **argv)	\
 {									\
 	return _handler(shell, argc, argv,				\
@@ -424,9 +425,10 @@ static int UTIL_CAT(cmd_dict_, GET_ARG_N(1, __DEBRACKET _data))(	\
 }
 
 /* Internal macro used for creating dictionary commands. */
-#define SHELL_CMD_DICT_CREATE(_data)					\
+#define SHELL_CMD_DICT_CREATE(_data, _handler)				\
 	SHELL_CMD_ARG(GET_ARG_N(1, __DEBRACKET _data), NULL, NULL,	\
-		UTIL_CAT(cmd_dict_, GET_ARG_N(1, __DEBRACKET _data)), 1, 0)
+		UTIL_CAT(UTIL_CAT(cmd_dict_, UTIL_CAT(_handler, _)),	\
+			GET_ARG_N(1, __DEBRACKET _data)), 1, 0)
 
 /**
  * @brief Initializes shell dictionary commands.
@@ -462,7 +464,7 @@ static int UTIL_CAT(cmd_dict_, GET_ARG_N(1, __DEBRACKET _data))(	\
 	FOR_EACH_FIXED_ARG(Z_SHELL_CMD_DICT_HANDLER_CREATE, (),		\
 			   _handler, __VA_ARGS__)			\
 	SHELL_STATIC_SUBCMD_SET_CREATE(_name,				\
-		FOR_EACH(SHELL_CMD_DICT_CREATE, (,), __VA_ARGS__),	\
+		FOR_EACH_FIXED_ARG(SHELL_CMD_DICT_CREATE, (,), _handler, __VA_ARGS__),	\
 		SHELL_SUBCMD_SET_END					\
 	)
 

--- a/tests/subsys/shell/shell/src/main.c
+++ b/tests/subsys/shell/shell/src/main.c
@@ -389,6 +389,36 @@ static void test_max_argc(void)
 	test_shell_execute_cmd("dummy 1 2 3 4 5 6 7 8 9 10 11 12", -ENOEXEC);
 }
 
+
+static int cmd_handler_dict_1(const struct shell *sh, size_t argc, char **argv, void *data)
+{
+	int n = (intptr_t)data;
+
+	return n;
+}
+
+static int cmd_handler_dict_2(const struct shell *sh, size_t argc, char **argv, void *data)
+{
+	int n = (intptr_t)data;
+
+	return n + n;
+}
+
+SHELL_SUBCMD_DICT_SET_CREATE(dict1, cmd_handler_dict_1, (one, 1), (two, 2));
+SHELL_SUBCMD_DICT_SET_CREATE(dict2, cmd_handler_dict_2, (one, 1), (two, 2));
+
+SHELL_CMD_REGISTER(dict1, &dict1, NULL, NULL);
+SHELL_CMD_REGISTER(dict2, &dict2, NULL, NULL);
+
+static void test_cmd_dict(void)
+{
+	test_shell_execute_cmd("dict1 one", 1);
+	test_shell_execute_cmd("dict1 two", 2);
+
+	test_shell_execute_cmd("dict2 one", 2);
+	test_shell_execute_cmd("dict2 two", 4);
+}
+
 void test_main(void)
 {
 	ztest_test_suite(shell_test_suite,
@@ -404,7 +434,8 @@ void test_main(void)
 			ztest_unit_test(test_shell_fprintf),
 			ztest_unit_test(test_set_root_cmd),
 			ztest_unit_test(test_raw_arg),
-			ztest_unit_test(test_max_argc)
+			ztest_unit_test(test_max_argc),
+			ztest_unit_test(test_cmd_dict)
 			);
 
 	/* Let the shell backend initialize. */


### PR DESCRIPTION
Add the handler function's name to the generated
sub command handler. Without it, it's not possible
to generate to dictionary matching items in a file.

Fixes #42398

Signed-off-by: Guillaume Lager <g.lager@innoseis.com>