### PR TITLE
Bluetooth: Controller: Fix duplicate release of auxiliary context

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -796,7 +796,7 @@ isr_rx_do_close:
 		radio_isr_set(isr_done, NULL);
 	} else {
 		/* Send message to flush Auxiliary PDU list */
-		if (err != -ECANCELED) {
+		if (lll->is_aux_sched && err != -ECANCELED) {
 			struct node_rx_pdu *node_rx;
 
 			node_rx = ull_pdu_rx_alloc();


### PR DESCRIPTION
Fix duplicate release of auxiliary context when scanning
uses LLL scheduling for reception of auxiliary PDU but the
reception fails.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>