### PR TITLE
doc: releases: 3.0: add EEPROM related release notes

### DIFF
--- a/doc/releases/release-notes-3.0.rst
+++ b/doc/releases/release-notes-3.0.rst
@@ -274,6 +274,8 @@ Drivers and Sensors
 
 * EEPROM
 
+  * Added support for the EEPROM present in the TMP116 digital temperature
+    sensor.
 
 * Entropy
 


### PR DESCRIPTION
Add EEPROM related release notes for Zephyr v3.0.0.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>