### PR TITLE
doc: fix incorrect usage of envvar role

### DIFF
--- a/boards/riscv/neorv32/doc/index.rst
+++ b/boards/riscv/neorv32/doc/index.rst
@@ -170,7 +170,7 @@ automatically generate a :file:`zephyr.vhd` file suitable for initialising the
 internal instruction memory of the NEORV32.
 
 In order for the build system to automatically detect the ``image_gen`` binary
-it needs to be in the :envvar:`PATH` environment variable. If not, the path
+it needs to be in the ``PATH`` environment variable. If not, the path
 can be passed at build time:
 
 .. zephyr-app-commands::

--- a/boards/riscv/rv32m1_vega/doc/index.rst
+++ b/boards/riscv/rv32m1_vega/doc/index.rst
@@ -432,7 +432,7 @@ For simplicity, this guide assumes:
 You can put them elsewhere, but be aware:
 
 - If you put the toolchain somewhere else, you will need to change
-  the :envvar:`CROSS_COMPILE` value described below accordingly.
+  the ``CROSS_COMPILE`` value described below accordingly.
 - If you put OpenOCD somewhere else, you will need to change the
   OpenOCD path in the flashing and debugging instructions below.
 - Don't use installation directories with spaces anywhere in the path;
@@ -774,9 +774,9 @@ instructions in the ``rv32m1_gnu_toolchain_patch`` repository's
 
 If you set ``<toolchain-installation-dir>`` to
 :file:`~/riscv32-unknown-elf-gcc`, you can use the above instructions
-for setting :envvar:`CROSS_COMPILE` when building Zephyr
+for setting ``CROSS_COMPILE`` when building Zephyr
 applications. If you set it to something else, you will need to update
-your :envvar:`CROSS_COMPILE` setting accordingly.
+your ``CROSS_COMPILE`` setting accordingly.
 
 .. note::
 

--- a/doc/application/index.rst
+++ b/doc/application/index.rst
@@ -923,7 +923,7 @@ again.
 
    If the (Linux only) :ref:`Zephyr SDK <zephyr_sdk>` is installed, the ``run``
    target will use the SDK's QEMU binary by default. To use another version of
-   QEMU, :ref:`set the environment variable <env_vars>` :envvar:`QEMU_BIN_PATH`
+   QEMU, :ref:`set the environment variable <env_vars>` ``QEMU_BIN_PATH``
    to the path of the QEMU binary you want to use instead.
 
 .. note::
@@ -1381,7 +1381,7 @@ Create a Debugger Configuration
 
      - GDB Client Setup
 
-       - Executable path example (use your :envvar:`GNUARMEMB_TOOLCHAIN_PATH`):
+       - Executable path example (use your ``GNUARMEMB_TOOLCHAIN_PATH``):
          :file:`C:\\gcc-arm-none-eabi-6_2017-q2-update\\bin\\arm-none-eabi-gdb.exe`
 
    - In the SVD Path tab:

--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -138,7 +138,7 @@ The current minimum required version for the main dependencies are:
 
       These instructions rely on `Chocolatey`_. If Chocolatey isn't an option,
       you can install dependencies from their respective websites and ensure
-      the command line tools are on your :envvar:`PATH` :ref:`environment
+      the command line tools are on your ``PATH`` :ref:`environment
       variable <env_vars>`.
 
       |p|
@@ -201,7 +201,7 @@ reason it is suggested to use `Python virtual environments`_.
          .. group-tab:: Install globally
 
             #. Install west, and make sure :file:`~/.local/bin` is on your
-               :envvar:`PATH` :ref:`environment variable <env_vars>`:
+               ``PATH`` :ref:`environment variable <env_vars>`:
 
                .. code-block:: bash
 
@@ -527,7 +527,7 @@ to build Zephyr applications.
       is not available on macOS.
 
       Do not forget to set the required :ref:`environment variables <env_vars>`
-      (:envvar:`ZEPHYR_TOOLCHAIN_VARIANT` and toolchain specific ones).
+      (``ZEPHYR_TOOLCHAIN_VARIANT`` and toolchain specific ones).
 
    .. group-tab:: Windows
 
@@ -535,7 +535,7 @@ to build Zephyr applications.
       is not available on Windows.
 
       Do not forget to set the required :ref:`environment variables <env_vars>`
-      (:envvar:`ZEPHYR_TOOLCHAIN_VARIANT` and toolchain specific ones).
+      (``ZEPHYR_TOOLCHAIN_VARIANT`` and toolchain specific ones).
 
 .. _getting_started_run_sample:
 

--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -278,10 +278,10 @@ installed it.
 
    If you install the Zephyr SDK outside any of those locations, then it is
    required to register the Zephyr SDK in the CMake package registry during
-   installation or set :envvar:`ZEPHYR_SDK_INSTALL_DIR` to point to the Zephyr
+   installation or set ``ZEPHYR_SDK_INSTALL_DIR`` to point to the Zephyr
    SDK installation folder.
 
-   :envvar:`ZEPHYR_SDK_INSTALL_DIR` can also be used for pointing to a folder
+   ``ZEPHYR_SDK_INSTALL_DIR`` can also be used for pointing to a folder
    containing multiple Zephyr SDKs, allowing for automatic toolchain selection,
    for example: ``ZEPHYR_SDK_INSTALL_DIR=/company/tools``
 
@@ -306,9 +306,9 @@ toolchain as as described in the :ref:`third_party_x_compilers` section.
 
 As already noted above, the SDK also includes prebuilt host tools.  To use the
 SDK's prebuilt host tools with a toolchain from another source, you must set the
-:envvar:`ZEPHYR_SDK_INSTALL_DIR` environment variable to the Zephyr SDK
+``ZEPHYR_SDK_INSTALL_DIR`` environment variable to the Zephyr SDK
 installation directory. To build without the Zephyr SDK's prebuilt host tools,
-the :envvar:`ZEPHYR_SDK_INSTALL_DIR` environment variable must be unset.
+the ``ZEPHYR_SDK_INSTALL_DIR`` environment variable must be unset.
 
 To make sure this variable is unset, run:
 

--- a/doc/getting_started/toolchain_3rd_party_x_compilers.rst
+++ b/doc/getting_started/toolchain_3rd_party_x_compilers.rst
@@ -31,13 +31,13 @@ GNU Arm Embedded
 
 #. :ref:`Set these environment variables <env_vars>`:
 
-   - Set :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``gnuarmemb``.
-   - Set :envvar:`GNUARMEMB_TOOLCHAIN_PATH` to the toolchain installation
+   - Set ``ZEPHYR_TOOLCHAIN_VARIANT`` to ``gnuarmemb``.
+   - Set ``GNUARMEMB_TOOLCHAIN_PATH`` to the toolchain installation
      directory.
 
 #. To check that you have set these variables correctly in your current
    environment, follow these example shell sessions (the
-   :envvar:`GNUARMEMB_TOOLCHAIN_PATH` values may be different on your system):
+   ``GNUARMEMB_TOOLCHAIN_PATH`` values may be different on your system):
 
    .. code-block:: console
 
@@ -58,8 +58,8 @@ GNU Arm Embedded
       On macOS, if you are having trouble with the suggested procedure, there is an unofficial package on brew that might help you.
       Run ``brew install gcc-arm-embedded`` and configure the variables
 
-      - Set :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``gnuarmemb``.
-      - Set :envvar:`GNUARMEMB_TOOLCHAIN_PATH` to the brew installation directory (something like ``/usr/local``)
+      - Set ``ZEPHYR_TOOLCHAIN_VARIANT`` to ``gnuarmemb``.
+      - Set ``GNUARMEMB_TOOLCHAIN_PATH`` to the brew installation directory (something like ``/usr/local``)
 
 .. _toolchain_armclang:
 
@@ -71,11 +71,11 @@ Arm Compiler 6
 
 #. :ref:`Set these environment variables <env_vars>`:
 
-   - Set :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``armclang``.
-   - Set :envvar:`ARMCLANG_TOOLCHAIN_PATH` to the toolchain installation
+   - Set ``ZEPHYR_TOOLCHAIN_VARIANT`` to ``armclang``.
+   - Set ``ARMCLANG_TOOLCHAIN_PATH`` to the toolchain installation
      directory.
 
-#. The Arm Compiler 6 needs the :envvar:`ARMLMD_LICENSE_FILE` environment
+#. The Arm Compiler 6 needs the ``ARMLMD_LICENSE_FILE`` environment
    variable to point to your license file or server.
 
 For example:
@@ -93,10 +93,10 @@ For example:
       > set ARMLMD_LICENSE_FILE=8224@myserver
 
 #. If the Arm Compiler 6 was installed as part of an Arm Development Studio, then
-   you must set the :envvar:`ARM_PRODUCT_DEF` to point to the product definition file:
+   you must set the ``ARM_PRODUCT_DEF`` to point to the product definition file:
    See also: `Product and toolkit configuration <https://developer.arm.com/tools-and-software/software-development-tools/license-management/resources/product-and-toolkit-configuration>`_.
    For example if the Arm Development Studio is installed in:
-   ``/opt/armds-2020-1`` with a Gold license, then set :envvar:`ARM_PRODUCT_DEF`
+   ``/opt/armds-2020-1`` with a Gold license, then set ``ARM_PRODUCT_DEF``
    to point to ``/opt/armds-2020-1/gold.elmap``.
 
    .. note::
@@ -135,7 +135,7 @@ Intel oneAPI Toolkit
    The above will also change the python environment to the one used by the
    toolchain and might conflict with what Zephyr uses.
 
-#. Set :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``oneApi``.
+#. Set ``ZEPHYR_TOOLCHAIN_VARIANT`` to ``oneApi``.
 
 DesignWare ARC MetaWare Development Toolkit (MWDT)
 **************************************************
@@ -146,15 +146,15 @@ DesignWare ARC MetaWare Development Toolkit (MWDT)
 
 #. :ref:`Set these environment variables <env_vars>`:
 
-   - Set :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``arcmwdt``.
-   - Set :envvar:`ARCMWDT_TOOLCHAIN_PATH` to the toolchain installation
-     directory. MWDT installation provides :envvar:`METAWARE_ROOT` so simply set
-     :envvar:`ARCMWDT_TOOLCHAIN_PATH` to ``$METAWARE_ROOT/../`` (Linux)
+   - Set ``ZEPHYR_TOOLCHAIN_VARIANT`` to ``arcmwdt``.
+   - Set ``ARCMWDT_TOOLCHAIN_PATH`` to the toolchain installation
+     directory. MWDT installation provides ``METAWARE_ROOT`` so simply set
+     ``ARCMWDT_TOOLCHAIN_PATH`` to ``$METAWARE_ROOT/../`` (Linux)
      or ``%METAWARE_ROOT%\..\`` (Windows)
 
 #. To check that you have set these variables correctly in your current
    environment, follow these example shell sessions (the
-   :envvar:`ARCMWDT_TOOLCHAIN_PATH` values may be different on your system):
+   ``ARCMWDT_TOOLCHAIN_PATH`` values may be different on your system):
 
    .. code-block:: console
 
@@ -195,12 +195,12 @@ You can build toolchains from source code using crosstool-NG.
 
 #. :ref:`Set these environment variables <env_vars>`:
 
-   - Set :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``xtools``.
-   - Set :envvar:`XTOOLS_TOOLCHAIN_PATH` to the toolchain build directory.
+   - Set ``ZEPHYR_TOOLCHAIN_VARIANT`` to ``xtools``.
+   - Set ``XTOOLS_TOOLCHAIN_PATH`` to the toolchain build directory.
 
 #. To check that you have set these variables correctly in your current
    environment, follow these example shell sessions (the
-   :envvar:`XTOOLS_TOOLCHAIN_PATH` values may be different on your system):
+   ``XTOOLS_TOOLCHAIN_PATH`` values may be different on your system):
 
    .. code-block:: console
 

--- a/doc/getting_started/toolchain_custom_cmake.rst
+++ b/doc/getting_started/toolchain_custom_cmake.rst
@@ -6,8 +6,8 @@ Custom CMake Toolchains
 To use a custom toolchain defined in an external CMake file, :ref:`set these
 environment variables <env_vars>`:
 
-- Set :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to your toolchain's name
-- Set :envvar:`TOOLCHAIN_ROOT` to the path to the directory containing your
+- Set ``ZEPHYR_TOOLCHAIN_VARIANT`` to your toolchain's name
+- Set ``TOOLCHAIN_ROOT`` to the path to the directory containing your
   toolchain's CMake configuration files.
 
 Zephyr will then include the toolchain cmake files located in the
@@ -22,7 +22,7 @@ Zephyr will then include the toolchain cmake files located in the
   source code.
 
 Here <toolchain name> is the same as the name provided in
-:envvar:`ZEPHYR_TOOLCHAIN_VARIANT`
+``ZEPHYR_TOOLCHAIN_VARIANT``
 See the zephyr files :zephyr_file:`cmake/generic_toolchain.cmake` and
 :zephyr_file:`cmake/target_toolchain.cmake` for more details on what your
 :file:`generic.cmake` and :file:`target.cmake` files should contain.
@@ -58,7 +58,7 @@ When :makevar:`TOOLCHAIN_USE_CUSTOM` is set, the :file:`other.h` must be
 available out-of-tree and it must include the correct header for the custom
 toolchain.
 A good location for the :file:`other.h` header file, would be a
-directory under the directory specified in :envvar:`TOOLCHAIN_ROOT` as
+directory under the directory specified in ``TOOLCHAIN_ROOT`` as
 :file:`include/toolchain`.
 To get the toolchain header included in zephyr's build, the
 :makevar:`USERINCLUDE` can be set to point to the include directory, as shown

--- a/doc/getting_started/toolchain_host.rst
+++ b/doc/getting_started/toolchain_host.rst
@@ -7,6 +7,6 @@ In some specific configurations, like when building for non-MCU x86 targets on
 a Linux host, you may be able to re-use the native development tools provided
 by your operating system.
 
-To use your host gcc, set the :envvar:`ZEPHYR_TOOLCHAIN_VARIANT`
+To use your host gcc, set the ``ZEPHYR_TOOLCHAIN_VARIANT``
 :ref:`environment variable <env_vars>` to ``host``. To use clang, set
-:envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``llvm``.
+``ZEPHYR_TOOLCHAIN_VARIANT`` to ``llvm``.

--- a/doc/getting_started/toolchain_other_x_compilers.rst
+++ b/doc/getting_started/toolchain_other_x_compilers.rst
@@ -4,7 +4,7 @@ Other Cross Compilers
 ######################
 
 This toolchain variant is borrowed from the Linux kernel build system's
-mechanism of using a :envvar:`CROSS_COMPILE` environment variable to set up a
+mechanism of using a ``CROSS_COMPILE`` environment variable to set up a
 GNU-based cross toolchain.
 
 Examples of such "other cross compilers" are cross toolchains that your Linux
@@ -31,14 +31,14 @@ Follow these steps to use one of these toolchains.
 
 #. :ref:`Set these environment variables <env_vars>`:
 
-   - Set :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``cross-compile``.
-   - Set :envvar:`CROSS_COMPILE` to the common path prefix which your
+   - Set ``ZEPHYR_TOOLCHAIN_VARIANT`` to ``cross-compile``.
+   - Set ``CROSS_COMPILE`` to the common path prefix which your
      toolchain's binaries have, e.g. the path to the directory containing the
      compiler binaries plus the target triplet and trailing dash.
 
 #. To check that you have set these variables correctly in your current
    environment, follow these example shell sessions (the
-   :envvar:`CROSS_COMPILE` value may be different on your system):
+   ``CROSS_COMPILE`` value may be different on your system):
 
    .. code-block:: console
 

--- a/doc/guides/beyond-GSG.rst
+++ b/doc/guides/beyond-GSG.rst
@@ -24,7 +24,7 @@ documented throughout the instructions.
 See `Installing Packages`_ in the Python Packaging User Guide for more
 information about pip\ [#pip]_, including `information on -\\-user`_.
 
-- On Linux, make sure ``~/.local/bin`` is at the front of your :envvar:`PATH`
+- On Linux, make sure ``~/.local/bin`` is at the front of your ``PATH``
   :ref:`environment variable <env_vars>`, or programs installed with ``--user``
   won't be found. Installing with ``--user`` avoids conflicts between pip
   and the system package manager, and is the default on Debian-based
@@ -72,7 +72,7 @@ extracting a zip archive, etc.
 
 You configure the Zephyr build system to use a specific toolchain by
 setting :ref:`environment variables <env_vars>` such as
-:envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to a supported value, along with
+``ZEPHYR_TOOLCHAIN_VARIANT`` to a supported value, along with
 additional variable(s) specific to the toolchain variant.
 
 While the Zephyr SDK includes standard tool chains for all supported
@@ -158,7 +158,7 @@ supported by a CMake file with content like this:
    set(k64f_BOARD_ALIAS frdm_k64f)
    set(sltb004a_BOARD_ALIAS efr32mg_sltb004a)
 
-and specifying its location in :envvar:`ZEPHYR_BOARD_ALIASES`.  This
+and specifying its location in ``ZEPHYR_BOARD_ALIASES``.  This
 enables use of aliases ``pca10028`` in contexts like
 ``cmake -DBOARD=pca10028`` and ``west -b pca10028``.
 

--- a/doc/guides/env_vars.rst
+++ b/doc/guides/env_vars.rst
@@ -12,7 +12,7 @@ Setting Variables
 Option 1: Just Once
 -------------------
 
-To set the environment variable :envvar:`MY_VARIABLE` to ``foo`` for the
+To set the environment variable ``MY_VARIABLE`` to ``foo`` for the
 lifetime of your current terminal window:
 
 .. tabs::
@@ -56,7 +56,7 @@ Option 2: In all Terminals
       program.
 
       To use ``setx``, type this command, then close the terminal window. Any
-      new ``cmd.exe`` windows will have :envvar:`MY_VARIABLE` set to ``foo``.
+      new ``cmd.exe`` windows will have ``MY_VARIABLE`` set to ``foo``.
 
       .. code-block:: console
 
@@ -118,10 +118,10 @@ your environment when you are using Zephyr.
 
       These scripts:
 
-      - set :envvar:`ZEPHYR_BASE` (see below) to the location of the zephyr
+      - set ``ZEPHYR_BASE`` (see below) to the location of the zephyr
         repository
       - adds some Zephyr-specific locations (such as zephyr's :file:`scripts`
-        directory) to your :envvar:`PATH` environment variable
+        directory) to your ``PATH`` environment variable
       - loads any settings from the ``zephyrrc`` files described above in
         :ref:`env_vars_zephyrrc`.
 
@@ -153,10 +153,10 @@ zephyr repository:
 
 These scripts:
 
-- set :envvar:`ZEPHYR_BASE` (see below) to the location of the zephyr
+- set ``ZEPHYR_BASE`` (see below) to the location of the zephyr
   repository
 - adds some Zephyr-specific locations (such as zephyr's :file:`scripts`
-  directory) to your :envvar:`PATH` environment variable
+  directory) to your ``PATH`` environment variable
 - loads any settings from the ``zephyrrc`` files described above in
   :ref:`env_vars_zephyrrc`.
 
@@ -171,20 +171,20 @@ Some :ref:`important-build-vars` can also be set in the environment. Here
 is a description of some of these important environment variables. This is not
 a comprehensive list.
 
-- :envvar:`BOARD`
-- :envvar:`CONF_FILE`
-- :envvar:`SHIELD`
-- :envvar:`ZEPHYR_BASE`
-- :envvar:`ZEPHYR_EXTRA_MODULES`
-- :envvar:`ZEPHYR_MODULES`
+- ``BOARD``
+- ``CONF_FILE``
+- ``SHIELD``
+- ``ZEPHYR_BASE``
+- ``ZEPHYR_EXTRA_MODULES``
+- ``ZEPHYR_MODULES``
 
 The following additional environment variables are significant when configuring
 the :ref:`toolchain <gs_toolchain>` used to build Zephyr applications.
 
-- :envvar:`ZEPHYR_TOOLCHAIN_VARIANT`: the name of the toolchain to use
-- :envvar:`<TOOLCHAIN>_TOOLCHAIN_PATH`: path to the toolchain specified by
-  :envvar:`ZEPHYR_TOOLCHAIN_VARIANT`. For example, if
-  ``ZEPHYR_TOOLCHAIN_VARIANT=llvm``, use :envvar:`LLVM_TOOLCHAIN_PATH`. (Note
+- ``ZEPHYR_TOOLCHAIN_VARIANT``: the name of the toolchain to use
+- ``<TOOLCHAIN>_TOOLCHAIN_PATH``: path to the toolchain specified by
+  ``ZEPHYR_TOOLCHAIN_VARIANT``. For example, if
+  ``ZEPHYR_TOOLCHAIN_VARIANT=llvm``, use ``LLVM_TOOLCHAIN_PATH``. (Note
   the capitalization when forming the environment variable name.)
 
 Emulators and boards may also depend on additional programs. The build system

--- a/doc/guides/west/basics.rst
+++ b/doc/guides/west/basics.rst
@@ -53,7 +53,7 @@ topdir
   The topdir contains the :file:`.west` directory. When west needs to find
   the topdir, it searches for :file:`.west`, and uses its parent directory.
   The search starts from the current working directory (and starts again from
-  the location in the :envvar:`ZEPHYR_BASE` environment variable as a
+  the location in the ``ZEPHYR_BASE`` environment variable as a
   fallback if that fails).
 
 configuration file

--- a/doc/guides/west/build-flash-debug.rst
+++ b/doc/guides/west/build-flash-debug.rst
@@ -64,7 +64,7 @@ can force CMake to run again with ``--cmake``.
 
 You don't need to use the ``--board`` option if you've already got an existing
 build directory; ``west build`` can figure out the board from the CMake cache.
-For new builds, the ``--board`` option, :envvar:`BOARD` environment variable,
+For new builds, the ``--board`` option, ``BOARD`` environment variable,
 or ``build.board`` configuration option are checked (in that order).
 
 Examples
@@ -328,7 +328,7 @@ You can :ref:`configure <west-config-cmd>` ``west build`` using these options.
      - Description
    * - ``build.board``
      - String. If given, this the board used by :ref:`west build
-       <west-building>` when ``--board`` is not given and :envvar:`BOARD`
+       <west-building>` when ``--board`` is not given and ``BOARD``
        is unset in the environment.
    * - ``build.board_warn``
      - Boolean, default ``true``. If ``false``, disables warnings when

--- a/doc/guides/west/config.rst
+++ b/doc/guides/west/config.rst
@@ -38,11 +38,11 @@ There are three types of configuration file:
 
    - All platforms: the default is :file:`.westconfig` in the user's home
      directory.
-   - Linux note: if the environment variable :envvar:`XDG_CONFIG_HOME` is set,
+   - Linux note: if the environment variable ``XDG_CONFIG_HOME`` is set,
      then :file:`$XDG_CONFIG_HOME/west/config` is used.
    - Windows note: the following environment variables are tested to find the
-     home directory: :envvar:`%HOME%`, then :envvar:`%USERPROFILE%`, then a
-     combination of :envvar:`%HOMEDRIVE%` and :envvar:`%HOMEPATH%`.
+     home directory: ``%HOME%``, then ``%USERPROFILE%``, then a
+     combination of ``%HOMEDRIVE%`` and ``%HOMEPATH%``.
 
 3. **Local**: Settings in this file affect west's behavior for the
    current :term:`west workspace`. The file is :file:`.west/config`, relative
@@ -169,14 +169,14 @@ commands are documented in the pages for those commands.
      - Boolean. If ``true`` (the default), :ref:`west-update` will synchronize
        Git submodules before updating them.
    * - ``zephyr.base``
-     - String, default value to set for the :envvar:`ZEPHYR_BASE` environment
+     - String, default value to set for the ``ZEPHYR_BASE`` environment
        variable while the west command is running. By default, this is set to
        the path to the manifest project with path :file:`zephyr` (if there is
        one) during ``west init``. If the variable is already set, then this
        setting is ignored unless ``zephyr.base-prefer`` is ``"configfile"``.
    * - ``zephyr.base-prefer``
      - String, one the values ``"env"`` and ``"configfile"``. If set to
-       ``"env"`` (the default), setting :envvar:`ZEPHYR_BASE` in the calling
+       ``"env"`` (the default), setting ``ZEPHYR_BASE`` in the calling
        environment overrides the value of the ``zephyr.base`` configuration
        option. If set to ``"configfile"``, the configuration option wins
        instead.

--- a/doc/guides/west/release-notes.rst
+++ b/doc/guides/west/release-notes.rst
@@ -48,7 +48,7 @@ Bug fixes:
   in a detached HEAD state. This has been fixed by using ``git clone`` internally
   instead of ``git init`` and ``git fetch``. See `issue #522`_ for details.
 
-- The :envvar:`WEST_CONFIG_LOCAL` environment variable now correctly
+- The ``WEST_CONFIG_LOCAL`` environment variable now correctly
   overrides the default location, :file:`<workspace topdir>/.west/config`.
 
 - ``west update --fetch=smart`` (``smart`` is the default) now correctly skips
@@ -245,7 +245,7 @@ features and fixes.
   See :ref:`west-manifest-ex3.4` for an example.
 - The west command line application can now also be run using ``python3 -m
   west``. This makes it easier to run west under a particular Python
-  interpreter without modifying the :envvar:`PATH` environment variable.
+  interpreter without modifying the ``PATH`` environment variable.
 - :ref:`west manifest --path <west-manifest-path>` prints the absolute path to
   west.yml
 - ``west init`` now supports an ``--mf foo.yml`` option, which initializes the

--- a/doc/guides/west/troubleshooting.rst
+++ b/doc/guides/west/troubleshooting.rst
@@ -44,7 +44,7 @@ update`` without entering your password in that same shell.
 "'west' is not recognized as an internal or external command, operable program or batch file.'
 **********************************************************************************************
 
-On Windows, this means that either west is not installed, or your :envvar:`PATH`
+On Windows, this means that either west is not installed, or your ``PATH``
 environment variable does not contain the directory where pip installed
 :file:`west.exe`.
 
@@ -53,7 +53,7 @@ running ``west`` from a new ``cmd.exe`` window. If that still doesn't work,
 keep reading.
 
 You need to find the directory containing :file:`west.exe`, then add it to your
-:envvar:`PATH`. (This :envvar:`PATH` change should have been done for you when
+``PATH``. (This ``PATH`` change should have been done for you when
 you installed Python and pip, so ordinarily you should not need to follow these
 steps.)
 
@@ -74,7 +74,7 @@ Then:
       Notice how ``lib\site-packages`` in the ``pip3 show`` output was changed
       to ``scripts``!
 #. If you see ``west.exe`` in the ``scripts`` directory, add the full path to
-   ``scripts`` to your :envvar:`PATH` using a command like this::
+   ``scripts`` to your ``PATH`` using a command like this::
 
      setx PATH "%PATH%;C:\foo\python\python38\scripts"
 
@@ -151,8 +151,8 @@ To fix this, you have two choices:
    For example, create your build directory inside the workspace, or run ``west
    flash --build-dir YOUR_BUILD_DIR`` from inside the workspace.
 
-#. Set the :envvar:`ZEPHYR_BASE` :ref:`environment variable <env_vars>` and re-run
-   the west extension command. If set, west will use :envvar:`ZEPHYR_BASE` to
+#. Set the ``ZEPHYR_BASE`` :ref:`environment variable <env_vars>` and re-run
+   the west extension command. If set, west will use ``ZEPHYR_BASE`` to
    find your workspace.
 
 If you're unsure whether a command is built-in or an extension, run ``west
@@ -214,10 +214,10 @@ You may see this error when running ``west init`` with west 0.6:
    FATAL ERROR: already in an installation (<some directory>), aborting
 
 If this is unexpected and you're really trying to create a new west workspace,
-then it's likely that west is using the :envvar:`ZEPHYR_BASE` :ref:`environment
+then it's likely that west is using the ``ZEPHYR_BASE`` :ref:`environment
 variable <env_vars>` to locate a workspace elsewhere on your system.
 
 This is intentional; it allows you to put your Zephyr applications in
 any directory and still use west to build, flash, and debug them, for example.
 
-To resolve this issue, unset :envvar:`ZEPHYR_BASE` and try again.
+To resolve this issue, unset ``ZEPHYR_BASE`` and try again.

--- a/doc/guides/zephyr_cmake_package.rst
+++ b/doc/guides/zephyr_cmake_package.rst
@@ -162,7 +162,7 @@ To do this, use the following ``find_package()`` syntax:
    find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 This syntax instructs CMake to first search for Zephyr using the Zephyr base environment setting
-:envvar:`ZEPHYR_BASE` and then use the normal search paths.
+``ZEPHYR_BASE`` and then use the normal search paths.
 
 .. _zephyr_cmake_search_order:
 


### PR DESCRIPTION
:envvar: is currently used to tag environment variables, however,
:envvar: role expects a matching .. envvar:: directive where the
environment variable is defined (pretty much like how Kconfig works
today). Replaced all :envvar: roles with literals.

Ref. https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-envvar
Ref. https://github.com/zephyrproject-rtos/zephyr/pull/42389

