### PR TITLE
bluetooth: Add bt_disable(), hci.close() and its implementation on stm32wb

### DIFF
--- a/drivers/bluetooth/hci/ipm_stm32wb.c
+++ b/drivers/bluetooth/hci/ipm_stm32wb.c
@@ -530,6 +530,13 @@ static int bt_ipm_open(void)
 {
 	int err;
 
+	/* Start RX thread */
+	k_thread_create(&ipm_rx_thread_data, ipm_rx_stack,
+			K_KERNEL_STACK_SIZEOF(ipm_rx_stack),
+			(k_thread_entry_t)bt_ipm_rx_thread, NULL, NULL, NULL,
+			K_PRIO_COOP(CONFIG_BT_DRIVER_RX_HIGH_PRIO),
+			0, K_NO_WAIT);
+
 	err = bt_ipm_ble_init();
 	if (err) {
 		return err;
@@ -555,13 +562,6 @@ static int _bt_ipm_init(const struct device *unused)
 	bt_hci_driver_register(&drv);
 
 	start_ble_rf();
-
-	/* Start RX thread */
-	k_thread_create(&ipm_rx_thread_data, ipm_rx_stack,
-			K_KERNEL_STACK_SIZEOF(ipm_rx_stack),
-			(k_thread_entry_t)bt_ipm_rx_thread, NULL, NULL, NULL,
-			K_PRIO_COOP(CONFIG_BT_DRIVER_RX_HIGH_PRIO),
-			0, K_NO_WAIT);
 
 	/* Take BLE out of reset */
 	ipcc_reset();

--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -146,6 +146,17 @@ typedef void (*bt_ready_cb_t)(int err);
 int bt_enable(bt_ready_cb_t cb);
 
 /**
+ * @brief Disable Bluetooth
+ *
+ * Disable Bluetooth. Can't be called before bt_enable has completed.
+ *
+ * Close and release HCI resources. Result is architecture dependent.
+ *
+ * @return Zero on success or (negative) error code otherwise.
+ */
+int bt_disable(void);
+
+/**
  * @brief Set Bluetooth Device Name
  *
  * Set Bluetooth GAP Device Name.

--- a/include/drivers/bluetooth/hci_driver.h
+++ b/include/drivers/bluetooth/hci_driver.h
@@ -173,6 +173,19 @@ struct bt_hci_driver {
 	int (*open)(void);
 
 	/**
+	 * @brief Close the HCI transport.
+	 *
+	 * Closes the HCI transport. This function must not return until the
+	 * transport is closed.
+	 *
+	 * If the driver uses its own RX thread, i.e.
+	 * CONFIG_BT_RECV_IS_RX_THREAD is set, then this
+	 * function is expected to abort that thread.
+	 * @return 0 on success or negative error number on failure.
+	 */
+	int (*close)(void);
+
+	/**
 	 * @brief Send HCI buffer to controller.
 	 *
 	 * Send an HCI command or ACL data to the controller. The exact

--- a/samples/boards/stm32/power_mgmt/stm32wb_ble/README.rst
+++ b/samples/boards/stm32/power_mgmt/stm32wb_ble/README.rst
@@ -11,6 +11,9 @@ Zephyr power management enabled (:kconfig:option:`CONFIG_PM`).
 
 After startup, a first 2 seconds beacon is performed, 1 second break and
 beacon is started again.
+BLE link is then disabled and started up again after 2 seconds, then same
+beacon sequence happens.
+
 Finally, platform shutdown is triggered. It can be restarted by pressing the
 board reset button.
 

--- a/samples/boards/stm32/power_mgmt/stm32wb_ble/src/main.c
+++ b/samples/boards/stm32/power_mgmt/stm32wb_ble/src/main.c
@@ -116,7 +116,12 @@ void main(void)
 
 	k_sleep(K_SECONDS(6));
 
-	printk("Device shutdown\n");
+	printk("BLE disable\n");
+	err = bt_disable();
+	if (err) {
+		printk("Bluetooth disable failed (err %d)\n", err);
+	}
 
+	printk("Shutdown\n");
 	pm_state_force(0u, &(struct pm_state_info){PM_STATE_SOFT_OFF, 0, 0});
 }

--- a/samples/boards/stm32/power_mgmt/stm32wb_ble/src/main.c
+++ b/samples/boards/stm32/power_mgmt/stm32wb_ble/src/main.c
@@ -98,6 +98,14 @@ static void bt_ready(int err)
 	}
 
 	printk("Beacon started\n");
+
+	err = bt_le_adv_stop();
+	if (err != 0) {
+		printk("Advertising failed to stop: %d", err);
+		return;
+	}
+
+	printk("Beacon stopped\n");
 }
 
 void main(void)
@@ -105,15 +113,31 @@ void main(void)
 	int err;
 
 	printk("Starting Beacon Demo\n");
-
-	k_sleep(K_MSEC(500));
-
 	/* Initialize the Bluetooth Subsystem */
 	err = bt_enable(bt_ready);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 	}
 
+	/* Give time to bt_ready sequence */
+	k_sleep(K_SECONDS(6));
+
+	printk("BLE disable\n");
+	err = bt_disable();
+	if (err) {
+		printk("Bluetooth disable failed (err %d)\n", err);
+	}
+
+	k_sleep(K_SECONDS(2));
+
+	printk("BLE restart\n");
+	/* Initialize the Bluetooth Subsystem */
+	err = bt_enable(bt_ready);
+	if (err) {
+		printk("Bluetooth init failed (err %d)\n", err);
+	}
+
+	/* Give time to bt_ready sequence */
 	k_sleep(K_SECONDS(6));
 
 	printk("BLE disable\n");

--- a/soc/arm/st_stm32/stm32wb/power.c
+++ b/soc/arm/st_stm32/stm32wb/power.c
@@ -16,8 +16,6 @@
 #include <clock_control/clock_stm32_ll_common.h>
 #include "stm32_hsem.h"
 
-#include <bluetooth/hci.h>
-
 #include <logging/log.h>
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
@@ -57,41 +55,10 @@ static void lpm_hsem_lock(void)
 	}
 }
 
-#define ACI_HAL_STACK_RESET 0xFC3B
-
-static void send_stack_reset(void)
-{
-	struct net_buf *rsp;
-	int err = 0;
-
-	err = bt_hci_cmd_send_sync(ACI_HAL_STACK_RESET, NULL, &rsp);
-
-	net_buf_unref(rsp);
-
-	if (err) {
-		LOG_ERR("M0 BLE stack reset issue");
-	}
-}
-
-
-static void shutdown_ble_stack(void)
-{
-	send_stack_reset();
-
-	/* Wait till C2DS set */
-	while (LL_PWR_IsActiveFlag_C2DS() == 0) {
-	};
-}
-
 /* Invoke Low Power/System Off specific Tasks */
 __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 {
 	if (state == PM_STATE_SOFT_OFF) {
-
-		if (IS_ENABLED(CONFIG_BT)) {
-			shutdown_ble_stack();
-		}
-
 		lpm_hsem_lock();
 
 		/* Clear all Wake-Up flags */

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3571,6 +3571,8 @@ int bt_enable(bt_ready_cb_t cb)
 		return -ENODEV;
 	}
 
+	atomic_clear_bit(bt_dev.flags, BT_DEV_DISABLE);
+
 	if (atomic_test_and_set_bit(bt_dev.flags, BT_DEV_ENABLE)) {
 		return -EALREADY;
 	}
@@ -3626,6 +3628,57 @@ int bt_enable(bt_ready_cb_t cb)
 	k_work_submit(&bt_dev.init);
 	return 0;
 }
+
+int bt_disable(void)
+{
+	int err;
+
+	if (!bt_dev.drv) {
+		BT_ERR("No HCI driver registered");
+		return -ENODEV;
+	}
+
+	if (!bt_dev.drv->close) {
+		return -ENOTSUP;
+	}
+
+	if (atomic_test_and_set_bit(bt_dev.flags, BT_DEV_DISABLE)) {
+		return -EALREADY;
+	}
+
+	/* Clear BT_DEV_READY before disabling HCI link */
+	atomic_clear_bit(bt_dev.flags, BT_DEV_READY);
+
+	err = bt_dev.drv->close();
+	if (err) {
+		BT_ERR("HCI driver close failed (%d)", err);
+
+		/* Re-enable BT_DEV_READY to avoid inconsistent stack state */
+		atomic_set_bit(bt_dev.flags, BT_DEV_READY);
+
+		return err;
+	}
+
+	/* Abort TX thread */
+	k_thread_abort(&tx_thread_data);
+
+#if !defined(CONFIG_BT_RECV_IS_RX_THREAD)
+	/* Abort RX thread */
+	k_thread_abort(&rx_thread_data);
+#endif
+
+	if (IS_ENABLED(CONFIG_BT_TINYCRYPT_ECC)) {
+		bt_hci_ecc_deinit();
+	}
+
+	bt_monitor_send(BT_MONITOR_CLOSE_INDEX, NULL, 0);
+
+	/* Clear BT_DEV_ENABLE here to prevent early bt_enable() calls */
+	atomic_clear_bit(bt_dev.flags, BT_DEV_ENABLE);
+
+	return 0;
+}
+
 
 #define DEVICE_NAME_LEN (sizeof(CONFIG_BT_DEVICE_NAME) - 1)
 #if defined(CONFIG_BT_DEVICE_NAME_DYNAMIC)

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -29,6 +29,7 @@ enum {
 /* bt_dev flags: the flags defined here represent BT controller state */
 enum {
 	BT_DEV_ENABLE,
+	BT_DEV_DISABLE,
 	BT_DEV_READY,
 	BT_DEV_PRESET_ID,
 	BT_DEV_HAS_PUB_KEY,

--- a/subsys/bluetooth/host/hci_ecc.c
+++ b/subsys/bluetooth/host/hci_ecc.c
@@ -359,3 +359,8 @@ void bt_hci_ecc_init(void)
 			NULL, NULL, NULL, K_PRIO_PREEMPT(10), 0, K_NO_WAIT);
 	k_thread_name_set(&ecc_thread_data, "BT ECC");
 }
+
+void bt_hci_ecc_deinit(void)
+{
+	k_thread_abort(&ecc_thread_data);
+}

--- a/subsys/bluetooth/host/hci_ecc.h
+++ b/subsys/bluetooth/host/hci_ecc.h
@@ -7,5 +7,6 @@
  */
 
 void bt_hci_ecc_init(void);
+void bt_hci_ecc_deinit(void);
 int bt_hci_ecc_send(struct net_buf *buf);
 void bt_hci_ecc_supported_commands(uint8_t *supported_commands);


### PR DESCRIPTION
In order to allow shuting down C2 core on stm32wb SoCs, an application callable function is required to properly executing the required procedure from HCI IPM driver (see #41944).

Propose a `bt_disable()` function, together with a hci `close()` implementation to achieve this.

STM32 dedicated sample has been updated to demonstrate:
- bt_disable() successful behavior
- bt_enable() could be successfully applied after bt_disable() was performed

Likely deserves some polishing:
- bt dedicated tests update
- API documentation clarification
- Check on the correctness of changes applied to BT_DEV_ENABLE/BT_DEV_DISABLE flags

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/41944 (Instead of https://github.com/zephyrproject-rtos/zephyr/pull/42309)

Based on:
- ~~#42274~~ (merged)
- ~~#42368~~ (merged)