### PR TITLE
Bluetooth: Audio: Update bt_audio_stream_ops 

### DIFF
--- a/include/bluetooth/audio/audio.h
+++ b/include/bluetooth/audio/audio.h
@@ -1158,6 +1158,7 @@ struct bt_audio_broadcast_sink_cb {
 
 /** @brief Stream operation. */
 struct bt_audio_stream_ops {
+#if defined(CONFIG_BT_AUDIO_UNICAST)
 	/** @brief Stream configured callback
 	 *
 	 *  Configured callback is called whenever an Audio Stream has been
@@ -1187,15 +1188,6 @@ struct bt_audio_stream_ops {
 	 */
 	void (*enabled)(struct bt_audio_stream *stream);
 
-	/** @brief Stream started callback
-	 *
-	 *  Started callback is called whenever an Audio Stream has been started
-	 *  and will be usable for streaming.
-	 *
-	 *  @param stream Stream object that has been started.
-	 */
-	void (*started)(struct bt_audio_stream *stream);
-
 	/** @brief Stream metadata updated callback
 	 *
 	 *  Metadata Updated callback is called whenever an Audio Stream's
@@ -1214,15 +1206,6 @@ struct bt_audio_stream_ops {
 	 */
 	void (*disabled)(struct bt_audio_stream *stream);
 
-	/** @brief Stream stopped callback
-	 *
-	 *  Stopped callback is called whenever an Audio Stream has been
-	 *  stopped.
-	 *
-	 *  @param stream Stream object that has been stopped.
-	 */
-	void (*stopped)(struct bt_audio_stream *stream);
-
 	/** @brief Stream released callback
 	 *
 	 *  Released callback is called whenever a Audio Stream has been
@@ -1231,6 +1214,25 @@ struct bt_audio_stream_ops {
 	 *  @param stream Stream object that has been released.
 	 */
 	void (*released)(struct bt_audio_stream *stream);
+#endif /* CONFIG_BT_AUDIO_UNICAST */
+
+	/** @brief Stream started callback
+	 *
+	 *  Started callback is called whenever an Audio Stream has been started
+	 *  and will be usable for streaming.
+	 *
+	 *  @param stream Stream object that has been started.
+	 */
+	void (*started)(struct bt_audio_stream *stream);
+
+	/** @brief Stream stopped callback
+	 *
+	 *  Stopped callback is called whenever an Audio Stream has been
+	 *  stopped.
+	 *
+	 *  @param stream Stream object that has been stopped.
+	 */
+	void (*stopped)(struct bt_audio_stream *stream);
 
 	/** @brief Stream audio HCI receive callback.
 	 *

--- a/include/bluetooth/audio/audio.h
+++ b/include/bluetooth/audio/audio.h
@@ -1234,6 +1234,7 @@ struct bt_audio_stream_ops {
 	 */
 	void (*stopped)(struct bt_audio_stream *stream);
 
+#if defined(CONFIG_BT_AUDIO_UNICAST) || defined(CONFIG_BT_AUDIO_BROADCAST_SINK)
 	/** @brief Stream audio HCI receive callback.
 	 *
 	 *  This callback is only used if the ISO data path is HCI.
@@ -1242,6 +1243,7 @@ struct bt_audio_stream_ops {
 	 *  @param buf  Buffer containing incoming audio data.
 	 */
 	void (*recv)(struct bt_audio_stream *stream, struct net_buf *buf);
+#endif /* CONFIG_BT_AUDIO_UNICAST || CONFIG_BT_AUDIO_BROADCAST_SINK */
 };
 
 /** @brief Audio Capability type */

--- a/include/bluetooth/audio/audio.h
+++ b/include/bluetooth/audio/audio.h
@@ -1232,26 +1232,6 @@ struct bt_audio_stream_ops {
 	 */
 	void (*released)(struct bt_audio_stream *stream);
 
-	/** @brief Stream connected callback
-	 *
-	 *  If this callback is provided it will be called when the
-	 *  isochronous stream is connected.
-	 *
-	 *  @param stream The stream that has been connected
-	 */
-	void (*connected)(struct bt_audio_stream *stream);
-
-	/** @brief Stream disconnected callback
-	 *
-	 *  If this callback is provided it will be called when the
-	 *  isochronous stream is disconnected, including when a connection gets
-	 *  rejected.
-	 *
-	 *  @param stream The stream that has been Disconnected
-	 *  @param reason HCI reason for the disconnection.
-	 */
-	void (*disconnected)(struct bt_audio_stream *stream, uint8_t reason);
-
 	/** @brief Stream audio HCI receive callback.
 	 *
 	 *  This callback is only used if the ISO data path is HCI.

--- a/samples/bluetooth/unicast_audio_client/src/main.c
+++ b/samples/bluetooth/unicast_audio_client/src/main.c
@@ -258,23 +258,14 @@ static void stream_disabled(struct bt_audio_stream *stream)
 static void stream_stopped(struct bt_audio_stream *stream)
 {
 	printk("Audio Stream %p stopped\n", stream);
+
+	/* Stop send timer */
+	k_work_cancel_delayable(&audio_send_work);
 }
 
 static void stream_released(struct bt_audio_stream *stream)
 {
 	printk("Audio Stream %p released\n", stream);
-}
-
-static void stream_connected(struct bt_audio_stream *stream)
-{
-	printk("Audio Stream %p connected, start sending\n", stream);
-}
-
-static void stream_disconnected(struct bt_audio_stream *stream, uint8_t reason)
-{
-	printk("Audio Stream %p disconnected (reason 0x%02x)\n",
-	       stream, reason);
-	k_work_cancel_delayable(&audio_send_work);
 }
 
 static struct bt_audio_stream_ops stream_ops = {
@@ -286,8 +277,6 @@ static struct bt_audio_stream_ops stream_ops = {
 	.disabled = stream_disabled,
 	.stopped = stream_stopped,
 	.released = stream_released,
-	.connected = stream_connected,
-	.disconnected = stream_disconnected,
 };
 
 static void add_remote_sink(struct bt_audio_ep *ep, uint8_t index)

--- a/samples/bluetooth/unicast_audio_server/src/main.c
+++ b/samples/bluetooth/unicast_audio_server/src/main.c
@@ -195,24 +195,12 @@ static struct bt_audio_capability_ops lc3_ops = {
 	.release = lc3_release,
 };
 
-static void stream_connected(struct bt_audio_stream *stream)
-{
-	printk("Audio Stream %p connected\n", stream);
-}
-
-static void stream_disconnected(struct bt_audio_stream *stream, uint8_t reason)
-{
-	printk("Audio Stream %p disconnected (reason 0x%02x)\n", stream, reason);
-}
-
 static void stream_recv(struct bt_audio_stream *stream, struct net_buf *buf)
 {
 	printk("Incoming audio on stream %p len %u\n", stream, buf->len);
 }
 
 static struct bt_audio_stream_ops stream_ops = {
-	.connected = stream_connected,
-	.disconnected = stream_disconnected,
 	.recv = stream_recv
 };
 

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -256,15 +256,8 @@ static void ascs_iso_recv(struct bt_iso_chan *chan,
 static void ascs_iso_connected(struct bt_iso_chan *chan)
 {
 	struct bt_audio_ep *ep = CONTAINER_OF(chan, struct bt_audio_ep, iso);
-	struct bt_audio_stream_ops *ops = ep->stream->ops;
 
 	BT_DBG("stream %p ep %p type %u", chan, ep, ep != NULL ? ep->type : 0);
-
-	if (ops != NULL && ops->connected != NULL) {
-		ops->connected(ep->stream);
-	} else {
-		BT_WARN("No callback for connected set");
-	}
 
 	if (ep->status.state != BT_AUDIO_EP_STATE_ENABLING) {
 		BT_DBG("endpoint not in enabling state: %s",
@@ -284,10 +277,10 @@ static void ascs_iso_disconnected(struct bt_iso_chan *chan, uint8_t reason)
 
 	BT_DBG("stream %p ep %p reason 0x%02x", chan, ep, reason);
 
-	if (ops != NULL && ops->disconnected != NULL) {
-		ops->disconnected(stream, reason);
+	if (ops != NULL && ops->stopped != NULL) {
+		ops->stopped(stream);
 	} else {
-		BT_WARN("No callback for disconnected set");
+		BT_WARN("No callback for stopped set");
 	}
 
 	ascs_ep_set_state(ep, BT_AUDIO_EP_STATE_QOS_CONFIGURED);

--- a/subsys/bluetooth/audio/broadcast_sink.c
+++ b/subsys/bluetooth/audio/broadcast_sink.c
@@ -114,8 +114,8 @@ static void broadcast_sink_iso_connected(struct bt_iso_chan *chan)
 
 	broadcast_sink_set_ep_state(ep, BT_AUDIO_EP_STATE_STREAMING);
 
-	if (ops != NULL && ops->connected != NULL) {
-		ops->connected(ep->stream);
+	if (ops != NULL && ops->started != NULL) {
+		ops->started(ep->stream);
 	} else {
 		BT_WARN("No callback for connected set");
 	}
@@ -132,10 +132,10 @@ static void broadcast_sink_iso_disconnected(struct bt_iso_chan *chan,
 
 	broadcast_sink_set_ep_state(ep, BT_AUDIO_EP_STATE_IDLE);
 
-	if (ops != NULL && ops->disconnected != NULL) {
-		ops->disconnected(stream, reason);
+	if (ops != NULL && ops->stopped != NULL) {
+		ops->stopped(stream);
 	} else {
-		BT_WARN("No callback for disconnected set");
+		BT_WARN("No callback for stopped set");
 	}
 }
 

--- a/subsys/bluetooth/audio/broadcast_source.c
+++ b/subsys/bluetooth/audio/broadcast_source.c
@@ -139,8 +139,8 @@ static void broadcast_source_iso_connected(struct bt_iso_chan *chan)
 
 	broadcast_source_set_ep_state(ep, BT_AUDIO_EP_STATE_STREAMING);
 
-	if (ops != NULL && ops->connected != NULL) {
-		ops->connected(ep->stream);
+	if (ops != NULL && ops->started != NULL) {
+		ops->started(ep->stream);
 	} else {
 		BT_WARN("No callback for connected set");
 	}
@@ -156,10 +156,10 @@ static void broadcast_source_iso_disconnected(struct bt_iso_chan *chan, uint8_t 
 
 	broadcast_source_set_ep_state(ep, BT_AUDIO_EP_STATE_IDLE);
 
-	if (ops != NULL && ops->disconnected != NULL) {
-		ops->disconnected(stream, reason);
+	if (ops != NULL && ops->stopped != NULL) {
+		ops->stopped(stream);
 	} else {
-		BT_WARN("No callback for disconnected set");
+		BT_WARN("No callback for stopped set");
 	}
 }
 

--- a/subsys/bluetooth/audio/broadcast_source.c
+++ b/subsys/bluetooth/audio/broadcast_source.c
@@ -114,22 +114,6 @@ static void broadcast_source_set_ep_state(struct bt_audio_ep *ep, uint8_t state)
 	}
 }
 
-static void broadcast_source_iso_recv(struct bt_iso_chan *chan,
-				    const struct bt_iso_recv_info *info,
-				    struct net_buf *buf)
-{
-	struct bt_audio_ep *ep = CONTAINER_OF(chan, struct bt_audio_ep, iso);
-	struct bt_audio_stream_ops *ops = ep->stream->ops;
-
-	BT_DBG("stream %p ep %p len %zu", chan, ep, net_buf_frags_len(buf));
-
-	if (ops != NULL && ops->recv != NULL) {
-		ops->recv(ep->stream, buf);
-	} else {
-		BT_WARN("No callback for recv set");
-	}
-}
-
 static void broadcast_source_iso_connected(struct bt_iso_chan *chan)
 {
 	struct bt_audio_ep *ep = CONTAINER_OF(chan, struct bt_audio_ep, iso);
@@ -164,7 +148,6 @@ static void broadcast_source_iso_disconnected(struct bt_iso_chan *chan, uint8_t 
 }
 
 static struct bt_iso_chan_ops broadcast_source_iso_ops = {
-	.recv		= broadcast_source_iso_recv,
 	.connected	= broadcast_source_iso_connected,
 	.disconnected	= broadcast_source_iso_disconnected,
 };

--- a/subsys/bluetooth/audio/unicast_client.c
+++ b/subsys/bluetooth/audio/unicast_client.c
@@ -83,15 +83,8 @@ static void unicast_client_ep_iso_recv(struct bt_iso_chan *chan,
 static void unicast_client_ep_iso_connected(struct bt_iso_chan *chan)
 {
 	struct bt_audio_ep *ep = EP_ISO(chan);
-	struct bt_audio_stream_ops *ops = ep->stream->ops;
 
 	BT_DBG("stream %p ep %p type %u", chan, ep, ep != NULL ? ep->type : 0);
-
-	if (ops != NULL && ops->connected != NULL) {
-		ops->connected(ep->stream);
-	} else {
-		BT_WARN("No callback for connected set");
-	}
 
 	if (ep->status.state != BT_AUDIO_EP_STATE_ENABLING) {
 		BT_DBG("endpoint not in enabling state: %s",
@@ -112,10 +105,10 @@ static void unicast_client_ep_iso_disconnected(struct bt_iso_chan *chan,
 
 	BT_DBG("stream %p ep %p reason 0x%02x", chan, ep, reason);
 
-	if (ops != NULL && ops->disconnected != NULL) {
-		ops->disconnected(stream, reason);
+	if (ops != NULL && ops->stopped != NULL) {
+		ops->stopped(stream);
 	} else {
-		BT_WARN("No callback for disconnected set");
+		BT_WARN("No callback for stopped set");
 	}
 
 	if (ep->type != BT_AUDIO_EP_LOCAL) {
@@ -502,13 +495,6 @@ static void unicast_client_ep_releasing_state(struct bt_audio_ep *ep,
 
 	BT_DBG("dir 0x%02x",
 	       unicast_client_ep_is_snk(ep) ? BT_AUDIO_SINK : BT_AUDIO_SOURCE);
-
-	/* Notify upper layer */
-	if (stream->ops != NULL && stream->ops->stopped != NULL) {
-		stream->ops->stopped(stream);
-	} else {
-		BT_WARN("No callback for stopped set");
-	}
 
 	/* The Unicast Client shall terminate any CIS established for that ASE
 	 * by following the Connected Isochronous Stream Terminate procedure

--- a/subsys/bluetooth/shell/audio.c
+++ b/subsys/bluetooth/shell/audio.c
@@ -1078,6 +1078,7 @@ static struct bt_audio_broadcast_sink_cb sink_cbs = {
 };
 #endif /* CONFIG_BT_AUDIO_BROADCAST_SINK */
 
+#if defined(CONFIG_BT_AUDIO_UNICAST) || defined(CONFIG_BT_AUDIO_BROADCAST_SINK)
 static void audio_recv(struct bt_audio_stream *stream, struct net_buf *buf)
 {
 	shell_print(ctx_shell, "Incoming audio on stream %p len %u\n", stream, buf->len);
@@ -1086,7 +1087,7 @@ static void audio_recv(struct bt_audio_stream *stream, struct net_buf *buf)
 static struct bt_audio_stream_ops stream_ops = {
 	.recv = audio_recv
 };
-
+#endif /* CONFIG_BT_AUDIO_UNICAST || CONFIG_BT_AUDIO_BROADCAST_SINK */
 
 #if defined(CONFIG_BT_AUDIO_BROADCAST_SOURCE)
 static int cmd_select_broadcast_source(const struct shell *sh, size_t argc,
@@ -1340,13 +1341,6 @@ static int cmd_init(const struct shell *sh, size_t argc, char *argv[])
 		bt_audio_stream_cb_register(&streams[i], &stream_ops);
 	}
 #endif /* CONFIG_BT_AUDIO_UNICAST */
-
-#if defined(CONFIG_BT_AUDIO_BROADCAST_SOURCE)
-	for (i = 0; i < ARRAY_SIZE(broadcast_source_streams); i++) {
-		bt_audio_stream_cb_register(&broadcast_source_streams[i],
-					    &stream_ops);
-	}
-#endif /* CONFIG_BT_AUDIO_BROADCAST_SOURCE */
 
 #if defined(CONFIG_BT_AUDIO_BROADCAST_SINK)
 	bt_audio_broadcast_sink_register_cb(&sink_cbs);

--- a/subsys/bluetooth/shell/audio.c
+++ b/subsys/bluetooth/shell/audio.c
@@ -1078,25 +1078,12 @@ static struct bt_audio_broadcast_sink_cb sink_cbs = {
 };
 #endif /* CONFIG_BT_AUDIO_BROADCAST_SINK */
 
-static void audio_connected(struct bt_audio_stream *stream)
-{
-	shell_print(ctx_shell, "Channel %p connected\n", stream);
-}
-
-static void audio_disconnected(struct bt_audio_stream *stream, uint8_t reason)
-{
-	shell_print(ctx_shell, "Channel %p disconnected with reason 0x%2x\n",
-		    stream, reason);
-}
-
 static void audio_recv(struct bt_audio_stream *stream, struct net_buf *buf)
 {
 	shell_print(ctx_shell, "Incoming audio on stream %p len %u\n", stream, buf->len);
 }
 
 static struct bt_audio_stream_ops stream_ops = {
-	.connected = audio_connected,
-	.disconnected = audio_disconnected,
 	.recv = audio_recv
 };
 

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/unicast_client_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/unicast_client_test.c
@@ -80,17 +80,6 @@ static void stream_released(struct bt_audio_stream *stream)
 	printk("Released stream %p\n", stream);
 }
 
-static void stream_connected(struct bt_audio_stream *stream)
-{
-	printk("Audio Stream %p connected\n", stream);
-}
-
-static void stream_disconnected(struct bt_audio_stream *stream, uint8_t reason)
-{
-	printk("Audio Stream %p disconnected (reason 0x%02x)\n",
-	       stream, reason);
-}
-
 static struct bt_audio_stream_ops stream_ops = {
 	.configured = stream_configured,
 	.qos_set = stream_qos_set,
@@ -100,8 +89,6 @@ static struct bt_audio_stream_ops stream_ops = {
 	.disabled = stream_disabled,
 	.stopped = stream_stopped,
 	.released = stream_released,
-	.connected = stream_connected,
-	.disconnected = stream_disconnected,
 };
 
 static void add_remote_sink(struct bt_audio_ep *ep, uint8_t index)

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/unicast_server_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/unicast_server_test.c
@@ -129,25 +129,12 @@ static struct bt_audio_capability_ops lc3_ops = {
 	.release = lc3_release,
 };
 
-static void stream_connected(struct bt_audio_stream *stream)
-{
-	printk("Audio Stream %p connected\n", stream);
-}
-
-static void stream_disconnected(struct bt_audio_stream *stream, uint8_t reason)
-{
-	printk("Audio Stream %p disconnected (reason 0x%02x)\n",
-	       stream, reason);
-}
-
 static void stream_recv(struct bt_audio_stream *stream, struct net_buf *buf)
 {
 	printk("Incoming audio on stream %p len %u\n", stream, buf->len);
 }
 
 static struct bt_audio_stream_ops stream_ops = {
-	.connected = stream_connected,
-	.disconnected = stream_disconnected,
 	.recv = stream_recv
 };
 


### PR DESCRIPTION
Removes the connected and disconnected callbacks.
Removes the recv callback for broadcast source. 
Guards the callbacks to only exist for specific roles. 

fixes https://github.com/zephyrproject-rtos/zephyr/issues/41188