### PR TITLE
doc: guides: Building the documentation

### DIFF
--- a/doc/guides/docs/index.rst
+++ b/doc/guides/docs/index.rst
@@ -117,7 +117,8 @@ as described below:
 
       .. code-block:: console
 
-         sudo pacman -S graphviz doxygen librsvg texlive-core texlive-bin
+         sudo pacman -S graphviz doxygen librsvg texlive-core texlive-bin \
+         texlive-latexextra texlive-fontsextra
 
    .. group-tab:: macOS
 


### PR DESCRIPTION
Add a couple of missing Arch packages for the .pdf build.

Fixes #41887.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>