### PR TITLE
pthread: cond: fix pthread_cond_wait always returning ETIMEDOUT

### DIFF
--- a/lib/posix/pthread_cond.c
+++ b/lib/posix/pthread_cond.c
@@ -24,7 +24,7 @@ static int cond_wait(pthread_cond_t *cv, pthread_mutex_t *mut,
 	mut->lock_count = 0U;
 	mut->owner = NULL;
 	_ready_one_thread(&mut->wait_q);
-	ret = z_pend_curr(&z_pthread_spinlock, key, &cv->wait_q, timeout);
+	ret = z_sched_wait(&z_pthread_spinlock, key, &cv->wait_q, timeout, NULL);
 
 	/* FIXME: this extra lock (and the potential context switch it
 	 * can cause) could be optimized out.  At the point of the
@@ -39,37 +39,15 @@ static int cond_wait(pthread_cond_t *cv, pthread_mutex_t *mut,
 	return ret == -EAGAIN ? ETIMEDOUT : ret;
 }
 
-/* This implements a "fair" scheduling policy: at the end of a POSIX
- * thread call that might result in a change of the current maximum
- * priority thread, we always check and context switch if needed.
- * Note that there is significant dispute in the community over the
- * "right" way to do this and different systems do it differently by
- * default.  Zephyr is an RTOS, so we choose latency over
- * throughput.  See here for a good discussion of the broad issue:
- *
- * https://blog.mozilla.org/nfroyd/2017/03/29/on-mutex-performance-part-1/
- */
-
 int pthread_cond_signal(pthread_cond_t *cv)
 {
-	k_spinlock_key_t key = k_spin_lock(&z_pthread_spinlock);
-
-	_ready_one_thread(&cv->wait_q);
-	z_reschedule(&z_pthread_spinlock, key);
-
+	z_sched_wake(&cv->wait_q, 0, NULL);
 	return 0;
 }
 
 int pthread_cond_broadcast(pthread_cond_t *cv)
 {
-	k_spinlock_key_t key = k_spin_lock(&z_pthread_spinlock);
-
-	while (z_waitq_head(&cv->wait_q)) {
-		_ready_one_thread(&cv->wait_q);
-	}
-
-	z_reschedule(&z_pthread_spinlock, key);
-
+	z_sched_wake_all(&cv->wait_q, 0, NULL);
 	return 0;
 }
 

--- a/tests/posix/common/src/pthread.c
+++ b/tests/posix/common/src/pthread.c
@@ -97,7 +97,7 @@ void *thread_top_exec(void *p1)
 		 * scheduled and wait on cvar0.
 		 */
 		if (!(id == 0 && i == 0)) {
-			pthread_cond_wait(&cvar0, &lock);
+			zassert_equal(0, pthread_cond_wait(&cvar0, &lock), "");
 		} else {
 			pthread_mutex_unlock(&lock);
 			usleep(USEC_PER_MSEC * 500U);


### PR DESCRIPTION
It was noted that `pthread_cond_wait()` would always return `ETIMEDOUT`, even when successful (and no timeout should ever occur with `K_FOREVER`).

The `z_sched_wake()` / `z_sched_wake_all()` / `z_sched_wait()` API are used here with a swap return value of 0 to indicate success.
        
Fixes #41284