### PR TITLE
drivers: gpio: Add GPIO support for mimx8ml8_m7 (NXP i.MX8M Plus SoC)

### DIFF
--- a/boards/arm/mimx8mp_evk/mimx8mp_evk_ddr.dts
+++ b/boards/arm/mimx8mp_evk/mimx8mp_evk_ddr.dts
@@ -26,3 +26,7 @@
 	status = "okay";
 	current-speed = <115200>;
 };
+
+&gpio3 {
+	status = "okay";
+};

--- a/boards/arm/mimx8mp_evk/mimx8mp_evk_itcm.dts
+++ b/boards/arm/mimx8mp_evk/mimx8mp_evk_itcm.dts
@@ -26,3 +26,7 @@
 	status = "okay";
 	current-speed = <115200>;
 };
+
+&gpio3 {
+	status = "okay";
+};

--- a/drivers/gpio/gpio_mcux_igpio.c
+++ b/drivers/gpio/gpio_mcux_igpio.c
@@ -47,11 +47,11 @@ static int mcux_igpio_configure(const struct device *dev,
 	}
 
 	if (flags & GPIO_OUTPUT_INIT_HIGH) {
-		base->DR_SET = BIT(pin);
+		GPIO_WritePinOutput(base, pin, 1);
 	}
 
 	if (flags & GPIO_OUTPUT_INIT_LOW) {
-		base->DR_CLEAR = BIT(pin);
+		GPIO_WritePinOutput(base, pin, 0);
 	}
 
 	WRITE_BIT(base->GDIR, pin, flags & GPIO_OUTPUT);
@@ -87,7 +87,7 @@ static int mcux_igpio_port_set_bits_raw(const struct device *dev,
 	const struct mcux_igpio_config *config = dev->config;
 	GPIO_Type *base = config->base;
 
-	base->DR_SET = mask;
+	GPIO_PortSet(base, mask);
 
 	return 0;
 }
@@ -98,7 +98,7 @@ static int mcux_igpio_port_clear_bits_raw(const struct device *dev,
 	const struct mcux_igpio_config *config = dev->config;
 	GPIO_Type *base = config->base;
 
-	base->DR_CLEAR = mask;
+	GPIO_PortClear(base, mask);
 
 	return 0;
 }
@@ -109,7 +109,7 @@ static int mcux_igpio_port_toggle_bits(const struct device *dev,
 	const struct mcux_igpio_config *config = dev->config;
 	GPIO_Type *base = config->base;
 
-	base->DR_TOGGLE = mask;
+	GPIO_PortToggle(base, mask);
 
 	return 0;
 }

--- a/dts/arm/nxp/nxp_imx8ml_m7.dtsi
+++ b/dts/arm/nxp/nxp_imx8ml_m7.dtsi
@@ -87,6 +87,76 @@
 			#clock-cells = <3>;
 		};
 
+		gpio1: gpio@30200000 {
+			compatible = "nxp,imx-gpio";
+			reg = <0x30200000 DT_SIZE_K(64)>;
+			interrupts = <64 0>, <65 0>;
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M7_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
+			label = "GPIO_1";
+			gpio-controller;
+			#gpio-cells = <2>;
+			status = "disabled";
+		};
+
+		gpio2: gpio@30210000 {
+			compatible = "nxp,imx-gpio";
+			reg = <0x30210000 DT_SIZE_K(64)>;
+			interrupts = <66 0>, <67 0>;
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M7_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
+			label = "GPIO_2";
+			gpio-controller;
+			#gpio-cells = <2>;
+			status = "disabled";
+		};
+
+		gpio3: gpio@30220000 {
+			compatible = "nxp,imx-gpio";
+			reg = <0x30220000 DT_SIZE_K(64)>;
+			interrupts = <68 0>, <69 0>;
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M7_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
+			label = "GPIO_3";
+			gpio-controller;
+			#gpio-cells = <2>;
+			status = "disabled";
+		};
+
+		gpio4: gpio@30230000 {
+			compatible = "nxp,imx-gpio";
+			reg = <0x30230000 DT_SIZE_K(64)>;
+			interrupts = <70 0>, <71 0>;
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M7_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
+			label = "GPIO_4";
+			gpio-controller;
+			#gpio-cells = <2>;
+			status = "disabled";
+		};
+
+		gpio5: gpio@30240000 {
+			compatible = "nxp,imx-gpio";
+			reg = <0x30240000 DT_SIZE_K(64)>;
+			interrupts = <72 0>, <73 0>;
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M7_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
+			label = "GPIO_5";
+			gpio-controller;
+			#gpio-cells = <2>;
+			status = "disabled";
+		};
+
 		/*
 		 * For now only UART4 is supported and
 		 * tested with the serial driver

--- a/soc/arm/nxp_imx/mimx8ml8_m7/Kconfig.defconfig.mimx8ml8_m7
+++ b/soc/arm/nxp_imx/mimx8ml8_m7/Kconfig.defconfig.mimx8ml8_m7
@@ -27,6 +27,9 @@ config PINMUX_MCUX
 
 endif # PINMUX
 
+config GPIO
+	default y
+
 if SERIAL
 
 config UART_MCUX_IUART

--- a/soc/arm/nxp_imx/mimx8ml8_m7/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/mimx8ml8_m7/Kconfig.defconfig.series
@@ -13,6 +13,10 @@ config NUM_IRQS
 	# must be >= the highest interrupt number used
 	default 159
 
+config GPIO_MCUX_IGPIO
+	default y if HAS_MCUX_IGPIO
+	depends on GPIO
+
 source "soc/arm/nxp_imx/mimx8ml8_m7/Kconfig.defconfig.mimx8ml8_m7"
 
 endif # SOC_SERIES_IMX8ML_M7

--- a/soc/arm/nxp_imx/mimx8ml8_m7/Kconfig.soc
+++ b/soc/arm/nxp_imx/mimx8ml8_m7/Kconfig.soc
@@ -15,6 +15,7 @@ config SOC_MIMX8ML8
 	select CPU_HAS_ARM_MPU
 	select CPU_HAS_CUSTOM_FIXED_SOC_MPU_REGIONS
 	select ARM_MPU
+	select HAS_MCUX_IGPIO
 
 endchoice
 


### PR DESCRIPTION
The current MCUX IGPIO driver assumes that the target SoC supports the `DR_SET`, `DR_CLEAR`, and `DR_TOGGLE` functionality, but some do not (namely, the M7 core of the i.MX8M Plus SoC). Current releases of the MCUXpresso SDK IGPIO driver contain utility functions to set, clear, and toggle pins which include provisions to support SoCs with and without `DR_SET`, `DR_CLEAR`, and `DR_TOGGLE`, and this change switches to using these utility functions.

For reference, the MCUXpresso SDK IGPIO driver files at the current revision pulled in by the NXP HAL module can be found here:
* [fsl_gpio.c](https://github.com/zephyrproject-rtos/hal_nxp/blob/9629f15fd80169cc9669e3fbb1260467c3aeb175/mcux/mcux-sdk/drivers/igpio/fsl_gpio.c)
* [fsl_gpio.h](https://github.com/zephyrproject-rtos/hal_nxp/blob/9629f15fd80169cc9669e3fbb1260467c3aeb175/mcux/mcux-sdk/drivers/igpio/fsl_gpio.h)

As an example, the current driver uses:
```C
	base->DR_SET = mask;
```

The new change uses:
```c
	GPIO_PortSet(base, mask);
```

And the [`GPIO_PortSet()`](https://github.com/zephyrproject-rtos/hal_nxp/blob/9629f15fd80169cc9669e3fbb1260467c3aeb175/mcux/mcux-sdk/drivers/igpio/fsl_gpio.h#L112) function is:
```c
static inline void GPIO_PortSet(GPIO_Type *base, uint32_t mask)
{
#if (defined(FSL_FEATURE_IGPIO_HAS_DR_SET) && (FSL_FEATURE_IGPIO_HAS_DR_SET == 1))
    base->DR_SET = mask;
#else
    base->DR |= mask;
#endif /* FSL_FEATURE_IGPIO_HAS_DR_SET */
}
```

Additionally, this change enables GPIO support on the `mimx8ml8_m7` target.