### PR TITLE
Update NXP LCDIF driver

### DIFF
--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -156,6 +156,17 @@ arduino_serial: &lpuart3 {};
 
 &lcdif {
 	status = "okay";
+	width = <480>;
+	height = <272>;
+	hsync = <41>;
+	hfp = <4>;
+	hbp = <8>;
+	vsync = <10>;
+	vfp = <4>;
+	vbp = <2>;
+	polarity = <3>;
+	pixel-format = "bgr-565";
+	data-buswidth = "16-bit";
 	port {
 		lcd_panel_out: endpoint {
 			remote-endpoint = <&lcd_panel_in>;

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -143,6 +143,17 @@ arduino_serial: &lpuart3 {};
 
 &lcdif {
 	status = "okay";
+	width = <480>;
+	height = <272>;
+	hsync = <41>;
+	hfp = <4>;
+	hbp = <8>;
+	vsync = <10>;
+	vfp = <4>;
+	vbp = <2>;
+	polarity = <3>;
+	pixel-format = "bgr-565";
+	data-buswidth = "16-bit";
 	port {
 		lcd_panel_out: endpoint {
 			remote-endpoint = <&lcd_panel_in>;

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -106,6 +106,17 @@ arduino_i2c: &lpi2c1 {};
 
 &lcdif {
 	status = "okay";
+	width = <480>;
+	height = <272>;
+	hsync = <41>;
+	hfp = <4>;
+	hbp = <8>;
+	vsync = <10>;
+	vfp = <4>;
+	vbp = <2>;
+	polarity = <3>;
+	pixel-format = "bgr-565";
+	data-buswidth = "16-bit";
 	port {
 		lcd_panel_out: endpoint {
 			remote-endpoint = <&lcd_panel_in>;

--- a/drivers/display/Kconfig.mcux_elcdif
+++ b/drivers/display/Kconfig.mcux_elcdif
@@ -33,13 +33,4 @@ config MCUX_ELCDIF_POOL_BLOCK_ALIGN
 	help
 	  Byte alignment in the frame buffer memory pool.
 
-choice MCUX_ELCDIF_PANEL
-	prompt "Panel selection"
-	default MCUX_ELCDIF_PANEL_RK043FN02H
-
-config MCUX_ELCDIF_PANEL_RK043FN02H
-	bool "Rocktech rk043fn02h-ct"
-
-endchoice
-
 endif # DISPLAY_MCUX_ELCDIF

--- a/drivers/display/display_mcux_elcdif.c
+++ b/drivers/display/display_mcux_elcdif.c
@@ -17,6 +17,10 @@
 
 LOG_MODULE_REGISTER(display_mcux_elcdif, CONFIG_DISPLAY_LOG_LEVEL);
 
+/* Pixel formats */
+#define MCUX_ELCDIF_PIXEL_FORMAT_RGB888 0U
+#define MCUX_ELCDIF_PIXEL_FORMAT_BGR565 1U
+
 K_HEAP_DEFINE(mcux_elcdif_pool,
 	      CONFIG_MCUX_ELCDIF_POOL_BLOCK_MAX *
 	      CONFIG_MCUX_ELCDIF_POOL_BLOCK_NUM);
@@ -25,8 +29,7 @@ struct mcux_elcdif_config {
 	LCDIF_Type *base;
 	void (*irq_config_func)(const struct device *dev);
 	elcdif_rgb_mode_config_t rgb_mode;
-	enum display_pixel_format pixel_format;
-	uint8_t bits_per_pixel;
+	uint8_t pixel_format;
 };
 
 struct mcux_mem_block {
@@ -39,6 +42,7 @@ struct mcux_elcdif_data {
 	size_t pixel_bytes;
 	size_t fb_bytes;
 	uint8_t write_idx;
+	enum display_pixel_format pixel_format;
 };
 
 static int mcux_elcdif_write(const struct device *dev, const uint16_t x,
@@ -47,44 +51,44 @@ static int mcux_elcdif_write(const struct device *dev, const uint16_t x,
 			     const void *buf)
 {
 	const struct mcux_elcdif_config *config = dev->config;
-	struct mcux_elcdif_data *data = dev->data;
+	struct mcux_elcdif_data *dev_data = dev->data;
 
-	uint8_t write_idx = data->write_idx;
+	uint8_t write_idx = dev_data->write_idx;
 	uint8_t read_idx = !write_idx;
 
 	int h_idx;
 	const uint8_t *src;
 	uint8_t *dst;
 
-	__ASSERT((data->pixel_bytes * desc->pitch * desc->height) <=
+	__ASSERT((dev_data->pixel_bytes * desc->pitch * desc->height) <=
 		 desc->buf_size, "Input buffer too small");
 
 	LOG_DBG("W=%d, H=%d, @%d,%d", desc->width, desc->height, x, y);
 
-	k_sem_take(&data->sem, K_FOREVER);
+	k_sem_take(&dev_data->sem, K_FOREVER);
 
-	memcpy(data->fb[write_idx].data, data->fb[read_idx].data,
-	       data->fb_bytes);
+	memcpy(dev_data->fb[write_idx].data, dev_data->fb[read_idx].data,
+	       dev_data->fb_bytes);
 
 	src = buf;
-	dst = data->fb[data->write_idx].data;
-	dst += data->pixel_bytes * (y * config->rgb_mode.panelWidth + x);
+	dst = dev_data->fb[dev_data->write_idx].data;
+	dst += dev_data->pixel_bytes * (y * config->rgb_mode.panelWidth + x);
 
 	for (h_idx = 0; h_idx < desc->height; h_idx++) {
-		memcpy(dst, src, data->pixel_bytes * desc->width);
-		src += data->pixel_bytes * desc->pitch;
-		dst += data->pixel_bytes * config->rgb_mode.panelWidth;
+		memcpy(dst, src, dev_data->pixel_bytes * desc->width);
+		src += dev_data->pixel_bytes * desc->pitch;
+		dst += dev_data->pixel_bytes * config->rgb_mode.panelWidth;
 	}
 
 #ifdef CONFIG_HAS_MCUX_CACHE
-	DCACHE_CleanByRange((uint32_t) data->fb[write_idx].data,
-			    data->fb_bytes);
+	DCACHE_CleanByRange((uint32_t) dev_data->fb[write_idx].data,
+			    dev_data->fb_bytes);
 #endif
 
 	ELCDIF_SetNextBufferAddr(config->base,
-				 (uint32_t) data->fb[write_idx].data);
+				 (uint32_t) dev_data->fb[write_idx].data);
 
-	data->write_idx = read_idx;
+	dev_data->write_idx = read_idx;
 
 	return 0;
 }
@@ -134,9 +138,9 @@ static int mcux_elcdif_set_pixel_format(const struct device *dev,
 					const enum display_pixel_format
 					pixel_format)
 {
-	const struct mcux_elcdif_config *config = dev->config;
+	struct mcux_elcdif_data *dev_data = dev->data;
 
-	if (pixel_format == config->pixel_format) {
+	if (pixel_format == dev_data->pixel_format) {
 		return 0;
 	}
 	LOG_ERR("Pixel format change not implemented");
@@ -157,52 +161,66 @@ static void mcux_elcdif_get_capabilities(const struct device *dev,
 		struct display_capabilities *capabilities)
 {
 	const struct mcux_elcdif_config *config = dev->config;
+	struct mcux_elcdif_data *dev_data = dev->data;
 
 	memset(capabilities, 0, sizeof(struct display_capabilities));
 	capabilities->x_resolution = config->rgb_mode.panelWidth;
 	capabilities->y_resolution = config->rgb_mode.panelHeight;
-	capabilities->supported_pixel_formats = config->pixel_format;
-	capabilities->current_pixel_format = config->pixel_format;
+	capabilities->supported_pixel_formats = dev_data->pixel_format;
+	capabilities->current_pixel_format = dev_data->pixel_format;
 	capabilities->current_orientation = DISPLAY_ORIENTATION_NORMAL;
 }
 
 static void mcux_elcdif_isr(const struct device *dev)
 {
 	const struct mcux_elcdif_config *config = dev->config;
-	struct mcux_elcdif_data *data = dev->data;
+	struct mcux_elcdif_data *dev_data = dev->data;
 	uint32_t status;
 
 	status = ELCDIF_GetInterruptStatus(config->base);
 	ELCDIF_ClearInterruptStatus(config->base, status);
 
-	k_sem_give(&data->sem);
+	k_sem_give(&dev_data->sem);
 }
 
 static int mcux_elcdif_init(const struct device *dev)
 {
 	const struct mcux_elcdif_config *config = dev->config;
-	struct mcux_elcdif_data *data = dev->data;
+	struct mcux_elcdif_data *dev_data = dev->data;
 	int i;
 
 	elcdif_rgb_mode_config_t rgb_mode = config->rgb_mode;
 
-	data->pixel_bytes = config->bits_per_pixel / 8U;
-	data->fb_bytes = data->pixel_bytes *
-			 rgb_mode.panelWidth * rgb_mode.panelHeight;
-	data->write_idx = 1U;
+	/* Shift the polarity bits to the appropriate location in the register */
+	rgb_mode.polarityFlags = rgb_mode.polarityFlags << LCDIF_VDCTRL0_ENABLE_POL_SHIFT;
 
-	for (i = 0; i < ARRAY_SIZE(data->fb); i++) {
-		data->fb[i].data = k_heap_alloc(&mcux_elcdif_pool,
-						data->fb_bytes, K_NO_WAIT);
-		if (data->fb[i].data == NULL) {
+	/* Set the Pixel format */
+	if (config->pixel_format == MCUX_ELCDIF_PIXEL_FORMAT_BGR565) {
+		rgb_mode.pixelFormat = kELCDIF_PixelFormatRGB565;
+		dev_data->pixel_format = PIXEL_FORMAT_BGR_565;
+		dev_data->pixel_bytes = 2;
+	} else if (config->pixel_format == MCUX_ELCDIF_PIXEL_FORMAT_RGB888) {
+		rgb_mode.pixelFormat = kELCDIF_PixelFormatRGB888;
+		dev_data->pixel_format = PIXEL_FORMAT_RGB_888;
+		dev_data->pixel_bytes = 3;
+	}
+
+	dev_data->fb_bytes = dev_data->pixel_bytes *
+			 rgb_mode.panelWidth * rgb_mode.panelHeight;
+	dev_data->write_idx = 1U;
+
+	for (i = 0; i < ARRAY_SIZE(dev_data->fb); i++) {
+		dev_data->fb[i].data = k_heap_alloc(&mcux_elcdif_pool,
+						dev_data->fb_bytes, K_NO_WAIT);
+		if (dev_data->fb[i].data == NULL) {
 			LOG_ERR("Could not allocate frame buffer %d", i);
 			return -ENOMEM;
 		}
-		memset(data->fb[i].data, 0, data->fb_bytes);
+		memset(dev_data->fb[i].data, 0, dev_data->fb_bytes);
 	}
-	rgb_mode.bufferAddr = (uint32_t) data->fb[0].data;
+	rgb_mode.bufferAddr = (uint32_t) dev_data->fb[0].data;
 
-	k_sem_init(&data->sem, 1, 1);
+	k_sem_init(&dev_data->sem, 1, 1);
 
 	config->irq_config_func(dev);
 
@@ -227,47 +245,43 @@ static const struct display_driver_api mcux_elcdif_api = {
 	.set_orientation = mcux_elcdif_set_orientation,
 };
 
-static void mcux_elcdif_config_func_1(const struct device *dev);
+#define MCUX_ELDCIF_DEVICE(id)							\
+	static void mcux_elcdif_config_func_##id(const struct device *dev);	\
+	static const struct mcux_elcdif_config mcux_elcdif_config_##id = {	\
+		.base = (LCDIF_Type *) DT_INST_REG_ADDR(id),			\
+		.irq_config_func = mcux_elcdif_config_func_##id,		\
+		.rgb_mode = {							\
+			.panelWidth = DT_INST_PROP(id, width),			\
+			.panelHeight = DT_INST_PROP(id, height),		\
+			.hsw = DT_INST_PROP(id, hsync),				\
+			.hfp = DT_INST_PROP(id, hfp),				\
+			.hbp = DT_INST_PROP(id, hbp),				\
+			.vsw = DT_INST_PROP(id, vsync),				\
+			.vfp = DT_INST_PROP(id, vfp),				\
+			.vbp = DT_INST_PROP(id, vbp),				\
+			.polarityFlags = DT_INST_PROP(id, polarity),		\
+			.dataBus = LCDIF_CTRL_LCD_DATABUS_WIDTH(		\
+					DT_INST_ENUM_IDX(id, data_buswidth)),	\
+		},								\
+		.pixel_format = DT_INST_ENUM_IDX(id, pixel_format),		\
+	};									\
+	static struct mcux_elcdif_data mcux_elcdif_data_##id;			\
+	DEVICE_DT_INST_DEFINE(id,						\
+			    &mcux_elcdif_init,					\
+			    NULL,						\
+			    &mcux_elcdif_data_##id,				\
+			    &mcux_elcdif_config_##id,				\
+			    POST_KERNEL,					\
+			    CONFIG_DISPLAY_INIT_PRIORITY,			\
+			    &mcux_elcdif_api);					\
+	static void mcux_elcdif_config_func_##id(const struct device *dev)	\
+	{									\
+		IRQ_CONNECT(DT_INST_IRQN(id),					\
+			    DT_INST_IRQ(id, priority),				\
+			    mcux_elcdif_isr,					\
+			    DEVICE_DT_INST_GET(id),				\
+			    0);							\
+		irq_enable(DT_INST_IRQN(id));					\
+	}
 
-static struct mcux_elcdif_config mcux_elcdif_config_1 = {
-	.base = (LCDIF_Type *) DT_INST_REG_ADDR(0),
-	.irq_config_func = mcux_elcdif_config_func_1,
-#ifdef CONFIG_MCUX_ELCDIF_PANEL_RK043FN02H
-	.rgb_mode = {
-		.panelWidth = 480,
-		.panelHeight = 272,
-		.hsw = 41,
-		.hfp = 4,
-		.hbp = 8,
-		.vsw = 10,
-		.vfp = 4,
-		.vbp = 2,
-		.polarityFlags = kELCDIF_DataEnableActiveHigh |
-				 kELCDIF_VsyncActiveLow |
-				 kELCDIF_HsyncActiveLow |
-				 kELCDIF_DriveDataOnRisingClkEdge,
-		.pixelFormat = kELCDIF_PixelFormatRGB565,
-		.dataBus = kELCDIF_DataBus16Bit,
-	},
-	.pixel_format = PIXEL_FORMAT_BGR_565,
-	.bits_per_pixel = 16,
-#endif
-};
-
-static struct mcux_elcdif_data mcux_elcdif_data_1;
-
-DEVICE_DT_INST_DEFINE(0,
-		    &mcux_elcdif_init,
-		    NULL,
-		    &mcux_elcdif_data_1, &mcux_elcdif_config_1,
-		    POST_KERNEL, CONFIG_DISPLAY_INIT_PRIORITY,
-		    &mcux_elcdif_api);
-
-static void mcux_elcdif_config_func_1(const struct device *dev)
-{
-	IRQ_CONNECT(DT_INST_IRQN(0),
-		    DT_INST_IRQ(0, priority),
-		    mcux_elcdif_isr, DEVICE_DT_INST_GET(0), 0);
-
-	irq_enable(DT_INST_IRQN(0));
-}
+DT_INST_FOREACH_STATUS_OKAY(MCUX_ELDCIF_DEVICE)

--- a/drivers/display/display_mcux_elcdif.c
+++ b/drivers/display/display_mcux_elcdif.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT fsl_imx6sx_lcdif
+#define DT_DRV_COMPAT nxp_imx_elcdif
 
 #include <drivers/display.h>
 #include <fsl_elcdif.h>

--- a/dts/arm/nxp/nxp_rt.dtsi
+++ b/dts/arm/nxp/nxp_rt.dtsi
@@ -237,7 +237,7 @@
 		};
 
 		lcdif: display-controller@402b8000 {
-			compatible = "fsl,imx6sx-lcdif";
+			compatible = "nxp,imx-elcdif";
 			reg = <0x402b8000 0x4000>;
 			interrupts = <42 0>;
 			label = "ELCDIF_1";

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -318,7 +318,7 @@
 		};
 
 		lcdif: display-controller@40804000 {
-			compatible = "fsl,imx6sx-lcdif";
+			compatible = "nxp,imx-elcdif";
 			reg = <0x40804000 0x4000>;
 			interrupts = <54 0>;
 			label = "ELCDIF_1";

--- a/dts/bindings/display/nxp,imx-elcdif.yaml
+++ b/dts/bindings/display/nxp,imx-elcdif.yaml
@@ -1,9 +1,9 @@
-# Copyright (c) 2019, NXP
+# Copyright (c) 2022, NXP
 # SPDX-License-Identifier: Apache-2.0
 
 description: NXP i.MX eLCDIF (Enhanced LCD Interface) controller
 
-compatible: "fsl,imx6sx-lcdif"
+compatible: "nxp,imx-elcdif"
 
 include: base.yaml
 

--- a/dts/bindings/display/nxp,imx-elcdif.yaml
+++ b/dts/bindings/display/nxp,imx-elcdif.yaml
@@ -5,7 +5,7 @@ description: NXP i.MX eLCDIF (Enhanced LCD Interface) controller
 
 compatible: "nxp,imx-elcdif"
 
-include: base.yaml
+include: display-controller.yaml
 
 properties:
     reg:
@@ -14,5 +14,91 @@ properties:
     interrupts:
       required: true
 
-    label:
+    hsync:
+      type: int
       required: true
+      description: HSYNC pulse width in display clock cycles
+
+    hfp:
+      type: int
+      required: true
+      description: Horizontal front porch in display clock cycles
+
+    hbp:
+      type: int
+      required: true
+      description: Horizontal back porch in display clock cycles
+
+    vsync:
+      type: int
+      required: true
+      description: VSYNC pulse width in display clock cycles
+
+    vfp:
+      type: int
+      required: true
+      description: Vertical front porch in display clock cycles
+
+    vbp:
+      type: int
+      required: true
+      description: Vertical back porch in display clock cycles
+
+    polarity:
+      type: int
+      required: true
+      enum:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+        - 9
+        - 10
+        - 11
+        - 12
+        - 13
+        - 14
+        - 15
+      description:
+        OR'ed value of elcdif_polarity_flags, used to control the signal polarity.
+        0000 VSYNC active low, HSYNC active low, Drive data on falling edge, Data enable active low.
+        0001 VSYNC active low, HSYNC active low, Drive data on falling edge, Data enable active high.
+        0010 VSYNC active low, HSYNC active low, Drive data on rising edge, Data enable active low.
+        0011 VSYNC active low, HSYNC active low, Drive data on rising edge, Data enable active high.
+        0100 VSYNC active low, HSYNC active high, Drive data on falling edge, Data enable active low.
+        0101 VSYNC active low, HSYNC active high, Drive data on falling edge, Data enable active high.
+        0110 VSYNC active low, HSYNC active high, Drive data on rising edge, Data enable active low.
+        0111 VSYNC active low, HSYNC active high, Drive data on rising edge, Data enable active high.
+        1000 VSYNC active high, HSYNC active low, Drive data on falling edge, Data enable active low.
+        1001 VSYNC active high, HSYNC active low, Drive data on falling edge, Data enable active high.
+        1010 VSYNC active high, HSYNC active low, Drive data on rising edge, Data enable active low.
+        1011 VSYNC active high, HSYNC active low, Drive data on rising edge, Data enable active high.
+        1100 VSYNC active high, HSYNC active high, Drive data on falling edge, Data enable active low.
+        1101 VSYNC active high, HSYNC active high, Drive data on falling edge, Data enable active high.
+        1110 VSYNC active high, HSYNC active high, Drive data on rising edge, Data enable active low.
+        1111 VSYNC active high, HSYNC active high, Drive data on rising edge, Data enable active high.
+
+    pixel-format:
+      type: string
+      required: true
+      enum:
+        - "rgb-888"
+        - "bgr-565"
+      description:
+        Display pixel format.
+
+    data-buswidth:
+      type: string
+      default: "16-bit"
+      enum:
+        - "16-bit"
+        - "8-bit"
+        - "18-bit"
+        - "24-bit"
+      description:
+        LCD data bus width. The default is set to the reset value of 16-bit


### PR DESCRIPTION
1. Rename device data to dev_data to fix variable name clash
2. Use Device Tree properties to setup the display
3. Delete unused Kconfigs