### PR TITLE
dts: rt11xx: Fix invalid SAI4 address

### DIFF
--- a/dts/arm/nxp/nxp_rt1160_cm4.dtsi
+++ b/dts/arm/nxp/nxp_rt1160_cm4.dtsi
@@ -76,7 +76,7 @@
 			nxp,rx-dma-channel = <6>;
 		};
 
-		sai4: sai@40c0000 {
+		sai4: sai@40c40000 {
 			dmas = <&edma_lpsr0 0 60>, <&edma_lpsr0 0 61>;
 			dma-names = "rx", "tx";
 			nxp,tx-dma-channel = <7>;

--- a/dts/arm/nxp/nxp_rt1160_cm7.dtsi
+++ b/dts/arm/nxp/nxp_rt1160_cm7.dtsi
@@ -84,7 +84,7 @@
 			nxp,rx-dma-channel = <6>;
 		};
 
-		sai4: sai@40c0000 {
+		sai4: sai@40c40000 {
 			dmas = <&edma0 0 60>, <&edma0 0 61>;
 			dma-names = "rx", "tx";
 			nxp,tx-dma-channel = <7>;

--- a/dts/arm/nxp/nxp_rt1170_cm4.dtsi
+++ b/dts/arm/nxp/nxp_rt1170_cm4.dtsi
@@ -76,7 +76,7 @@
 			nxp,rx-dma-channel = <6>;
 		};
 
-		sai4: sai@40c0000 {
+		sai4: sai@40c40000 {
 			dmas = <&edma_lpsr0 0 60>, <&edma_lpsr0 0 61>;
 			dma-names = "rx", "tx";
 			nxp,tx-dma-channel = <7>;

--- a/dts/arm/nxp/nxp_rt1170_cm7.dtsi
+++ b/dts/arm/nxp/nxp_rt1170_cm7.dtsi
@@ -84,7 +84,7 @@
 			nxp,rx-dma-channel = <6>;
 		};
 
-		sai4: sai@40c0000 {
+		sai4: sai@40c40000 {
 			dmas = <&edma0 0 60>, <&edma0 0 61>;
 			dma-names = "rx", "tx";
 			nxp,tx-dma-channel = <7>;

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -960,12 +960,12 @@
 			label = "I2S_2";
 		};
 
-		sai4: sai@40c0000 {
+		sai4: sai@40c40000 {
 			compatible = "nxp,mcux-i2s";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			#pinmux-cells = <2>;
-			reg = <0x40c0000 0x4000>;
+			reg = <0x40c40000 0x4000>;
 			clocks = <&ccm IMX_CCM_SAI4_CLK 0x2184 6>;
 			pre-div = <0>;
 			podf = <63>;


### PR DESCRIPTION
Register address definition for SAI4 was incorrect.

Fixes: #42435

Signed-off-by: David Leach <david.leach@nxp.com>