### PR TITLE
Bluetooth: df: Fixes for issues related with direction finding

### DIFF
--- a/samples/bluetooth/direction_finding_central/src/main.c
+++ b/samples/bluetooth/direction_finding_central/src/main.c
@@ -35,9 +35,9 @@ static struct bt_conn *default_conn;
 static const struct bt_le_conn_param conn_params = BT_LE_CONN_PARAM_INIT(
 	BT_GAP_INIT_CONN_INT_MIN, BT_GAP_INIT_CONN_INT_MAX, CONN_LATENCY, CONN_TIMEOUT);
 
-#if defined(CONFIG_BT_CTLR_DF_ANT_SWITCH_RX)
+#if defined(CONFIG_BT_DF_CTE_RX_AOA)
 static const uint8_t ant_patterns[] = { 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xA };
-#endif /* CONFIG_BT_CTLR_DF_ANT_SWITCH_RX */
+#endif /* CONFIG_BT_DF_CTE_RX_AOA */
 
 static void start_scan(void);
 
@@ -129,24 +129,24 @@ static void enable_cte_reqest(void)
 	int err;
 
 	const struct bt_df_conn_cte_rx_param cte_rx_params = {
-#if defined(CONFIG_BT_CTLR_DF_ANT_SWITCH_RX)
+#if defined(CONFIG_BT_DF_CTE_RX_AOA)
 		.cte_types = BT_DF_CTE_TYPE_ALL,
 		.slot_durations = 0x2,
 		.num_ant_ids = ARRAY_SIZE(ant_patterns),
 		.ant_ids = ant_patterns,
 #else
 		.cte_types = BT_DF_CTE_TYPE_AOD_1US | BT_DF_CTE_TYPE_AOD_2US,
-#endif /* CONFIG_BT_CTLR_DF_ANT_SWITCH_RX */
+#endif /* CONFIG_BT_DF_CTE_RX_AOA */
 	};
 
 	const struct bt_df_conn_cte_req_params cte_req_params = {
 		.interval = CTE_REQ_INTERVAL,
 		.cte_length = CTE_LEN,
-#if defined(CONFIG_BT_CTLR_DF_ANT_SWITCH_RX)
+#if defined(CONFIG_BT_DF_CTE_RX_AOA)
 		.cte_type = BT_DF_CTE_TYPE_AOA,
 #else
 		.cte_type = BT_DF_CTE_TYPE_AOD_2US,
-#endif /* CONFIG_BT_CTLR_DF_ANT_SWITCH_TX */
+#endif /* CONFIG_BT_DF_CTE_RX_AOA */
 	};
 
 	printk("Enable receiving of CTE...\n");

--- a/samples/bluetooth/direction_finding_connectionless_rx/src/main.c
+++ b/samples/bluetooth/direction_finding_connectionless_rx/src/main.c
@@ -40,10 +40,10 @@ static K_SEM_DEFINE(sem_per_adv, 0, 1);
 static K_SEM_DEFINE(sem_per_sync, 0, 1);
 static K_SEM_DEFINE(sem_per_sync_lost, 0, 1);
 
-#if defined(CONFIG_BT_CTLR_DF_ANT_SWITCH_RX)
+#if defined(CONFIG_BT_DF_CTE_RX_AOA)
 const static uint8_t ant_patterns[] = { 0x1, 0x2, 0x3, 0x4, 0x5,
 					0x6, 0x7, 0x8, 0x9, 0xA };
-#endif /* CONFIG_BT_CTLR_DF_ANT_SWITCH_RX */
+#endif /* CONFIG_BT_DF_CTE_RX_AOA */
 
 static bool data_cb(struct bt_data *data, void *user_data);
 static void create_sync(void);
@@ -257,14 +257,14 @@ static void enable_cte_rx(void)
 
 	const struct bt_df_per_adv_sync_cte_rx_param cte_rx_params = {
 		.max_cte_count = 5,
-#if defined(CONFIG_BT_CTLR_DF_ANT_SWITCH_RX)
+#if defined(CONFIG_BT_DF_CTE_RX_AOA)
 		.cte_types = BT_DF_CTE_TYPE_ALL,
 		.slot_durations = 0x2,
 		.num_ant_ids = ARRAY_SIZE(ant_patterns),
 		.ant_ids = ant_patterns,
 #else
 		.cte_types = BT_DF_CTE_TYPE_AOD_1US | BT_DF_CTE_TYPE_AOD_2US,
-#endif /* CONFIG_BT_CTLR_DF_ANT_SWITCH_RX */
+#endif /* CONFIG_BT_DF_CTE_RX_AOA */
 	};
 
 	printk("Enable receiving of CTE...\n");

--- a/samples/bluetooth/direction_finding_connectionless_tx/prj.conf
+++ b/samples/bluetooth/direction_finding_connectionless_tx/prj.conf
@@ -7,3 +7,4 @@ CONFIG_BT_BROADCASTER=y
 
 # Enable Direction Finding Feature including AoA and AoD
 CONFIG_BT_DF=y
+CONFIG_BT_DF_CONNECTIONLESS_CTE_TX=y

--- a/samples/bluetooth/direction_finding_connectionless_tx/src/main.c
+++ b/samples/bluetooth/direction_finding_connectionless_tx/src/main.c
@@ -47,13 +47,13 @@ static struct bt_le_per_adv_param per_adv_param = {
 	.options = BT_LE_ADV_OPT_USE_TX_POWER,
 };
 
-#if defined(CONFIG_BT_CTLR_DF_ANT_SWITCH_TX)
+#if defined(CONFIG_BT_DF_CTE_TX_AOD)
 static uint8_t ant_patterns[] = {0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xA };
-#endif /* CONFIG_BT_CTLR_DF_ANT_SWITCH_TX */
+#endif /* CONFIG_BT_DF_CTE_TX_AOD */
 
 struct bt_df_adv_cte_tx_param cte_params = { .cte_len = CTE_LEN,
 					     .cte_count = PER_ADV_EVENT_CTE_COUNT,
-#if defined(CONFIG_BT_CTLR_DF_ANT_SWITCH_TX)
+#if defined(CONFIG_BT_DF_CTE_TX_AOD)
 					     .cte_type = BT_DF_CTE_TYPE_AOD_2US,
 					     .num_ant_ids = ARRAY_SIZE(ant_patterns),
 					     .ant_ids = ant_patterns
@@ -61,7 +61,7 @@ struct bt_df_adv_cte_tx_param cte_params = { .cte_len = CTE_LEN,
 					     .cte_type = BT_DF_CTE_TYPE_AOA,
 					     .num_ant_ids = 0,
 					     .ant_ids = NULL
-#endif /* CONFIG_BT_CTLR_DF_ANT_SWITCH_TX */
+#endif /* CONFIG_BT_DF_CTE_TX_AOD */
 };
 
 static void adv_sent_cb(struct bt_le_ext_adv *adv,

--- a/samples/bluetooth/direction_finding_peripheral/src/main.c
+++ b/samples/bluetooth/direction_finding_peripheral/src/main.c
@@ -37,22 +37,22 @@ static const struct bt_data ad[] = {
 /* Length of CTE in unit of 8 us */
 #define CTE_LEN (0x14U)
 
-#if defined(CONFIG_BT_CTLR_DF_ANT_SWITCH_TX)
+#if defined(CONFIG_BT_DF_CTE_TX_AOD)
 static const uint8_t ant_patterns[] = { 0x2, 0x0, 0x5, 0x6, 0x1, 0x4, 0xC, 0x9, 0xE, 0xD, 0x8 };
-#endif /* CONFIG_BT_CTLR_DF_ANT_SWITCH_TX */
+#endif /* CONFIG_BT_DF_CTE_TX_AOD */
 
 static void enable_cte_response(struct bt_conn *conn)
 {
 	int err;
 
 	const struct bt_df_conn_cte_tx_param cte_tx_params = {
-#if defined(CONFIG_BT_CTLR_DF_ANT_SWITCH_TX)
+#if defined(CONFIG_BT_DF_CTE_TX_AOD)
 		.cte_types = BT_DF_CTE_TYPE_ALL,
 		.num_ant_ids = ARRAY_SIZE(ant_patterns),
 		.ant_ids = ant_patterns,
 #else
 		.cte_types = BT_DF_CTE_TYPE_AOA,
-#endif /* CONFIG_BT_CTLR_DF_ANT_SWITCH_TX */
+#endif /* CONFIG_BT_DF_CTE_TX_AOD */
 	};
 
 	printk("Set CTE transmission params...");

--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -109,7 +109,7 @@ config BT_BUF_ACL_RX_COUNT
 
 config BT_BUF_EVT_RX_SIZE
 	int "Maximum supported HCI Event buffer length"
-	default 255 if (BT_EXT_ADV && !(BT_BUF_EVT_DISCARDABLE_COUNT > 0)) || BT_PER_ADV_SYNC
+	default 255 if (BT_EXT_ADV && !(BT_BUF_EVT_DISCARDABLE_COUNT > 0)) || BT_PER_ADV_SYNC || BT_DF_CONNECTION_CTE_RX
 	# LE Read Supported Commands command complete event.
 	default 68
 	range 68 255

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -2916,9 +2916,14 @@ static void le_df_connection_iq_report(struct node_rx_pdu *node_rx, struct net_b
 
 	lll = iq_report->hdr.rx_ftr.param;
 
+#if defined(CONFIG_BT_CTLR_PHY)
 	phy_rx = lll->phy_rx;
+
 	/* Make sure the report is generated for connection on PHY UNCODED */
 	LL_ASSERT(phy_rx != PHY_CODED);
+#else
+	phy_rx = PHY_1M;
+#endif /* CONFIG_BT_CTLR_PHY */
 
 	/* TX LL thread has higher priority than RX thread. It may happen that host succefully
 	 * disables CTE sampling in the meantime. It should be verified here, to avoid reporing

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -473,7 +473,11 @@ void lll_conn_isr_tx(void *param)
 	enum radio_end_evt_delay_state end_evt_delay;
 #endif /* CONFIG_BT_CTLR_DF_PHYEND_OFFSET_COMPENSATION_ENABLE */
 
+#if defined(CONFIG_BT_CTLR_PHY)
 	if (lll->phy_rx != PHY_CODED) {
+#else
+	if (1) {
+#endif /* CONFIG_BT_CTLR_PHY */
 		struct lll_df_conn_rx_params *df_rx_params;
 		struct lll_df_conn_rx_cfg *df_rx_cfg;
 
@@ -1021,9 +1025,11 @@ static inline bool create_iq_report(struct lll_conn *lll, uint8_t rssi_ready, ui
 	struct lll_df_conn_rx_params *rx_params;
 	struct lll_df_conn_rx_cfg *rx_cfg;
 
+#if defined(CONFIG_BT_CTLR_PHY)
 	if (lll->phy_rx == PHY_CODED) {
 		return false;
 	}
+#endif /* CONFIG_BT_CTLR_PHY */
 
 	rx_cfg = &lll->df_rx_cfg;
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral.c
@@ -218,7 +218,11 @@ static int prepare_cb(struct lll_prepare_param *p)
 	enum radio_end_evt_delay_state end_evt_delay;
 #endif /* CONFIG_BT_CTLR_DF_PHYEND_OFFSET_COMPENSATION_ENABLE */
 
+#if defined(CONFIG_BT_CTLR_PHY)
 	if (lll->phy_rx != PHY_CODED) {
+#else
+	if (1) {
+#endif /* CONFIG_BT_CTLR_PHY */
 		df_rx_cfg = &lll->df_rx_cfg;
 		df_rx_params = dbuf_latest_get(&df_rx_cfg->hdr, NULL);
 

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -565,6 +565,12 @@ config BT_DF_CONNECTIONLESS_CTE_RX
 	  Enable support for reception and sampling of Constant Tone Extension
 	  in connectionless mode.
 
+config BT_DF_CONNECTIONLESS_CTE_TX
+	bool "Enable support for transmission of CTE in connectionless mode"
+	help
+	  Enable support for transmission of Constant Tone Extension in
+	  connectionless mode.
+
 config BT_DF_CONNECTION_CTE_RX
 	bool "Enable support for receive of CTE in connection mode"
 	help
@@ -590,6 +596,22 @@ config BT_DF_CONNECTION_CTE_RSP
 	help
 	  Enable support for request of Constant Tone Extension in connection
 	  mode.
+
+config BT_DF_CTE_RX_AOA
+	bool "Enable antenna switching during CTE reception (AoA) feature"
+	depends on BT_DF_CONNECTIONLESS_CTE_RX || BT_DF_CONNECTION_CTE_RX
+	default y
+	help
+	  Enable support for antenna switching during CTE reception.
+	  Also known as Angle of Arrival mode.
+
+config BT_DF_CTE_TX_AOD
+	bool "Enable antenna switching during CTE transmission (AoD) feature"
+	depends on BT_DF_CONNECTIONLESS_CTE_TX || BT_DF_CONNECTION_CTE_TX
+	default y
+	help
+	  Enable support for antenna switching during CTE transmission.
+	  Also known as Angle of Departure mode.
 
 config BT_DEBUG_DF
 	bool "Bluetooth Direction Finding debug"

--- a/subsys/bluetooth/host/direction.c
+++ b/subsys/bluetooth/host/direction.c
@@ -53,8 +53,8 @@ static bool valid_cte_rx_common_params(uint8_t cte_types, uint8_t slot_durations
 
 #if defined(CONFIG_BT_DF_CONNECTIONLESS_CTE_RX)
 static bool valid_cl_cte_rx_params(const struct bt_df_per_adv_sync_cte_rx_param *params);
-static void
-prepare_cl_cte_rx_enable_cmd_params(struct net_buf *buf, struct bt_le_per_adv_sync *sync,
+static int
+prepare_cl_cte_rx_enable_cmd_params(struct net_buf **buf, struct bt_le_per_adv_sync *sync,
 				    const struct bt_df_per_adv_sync_cte_rx_param *params,
 				    bool enable);
 static int hci_df_set_cl_cte_rx_enable(struct bt_le_per_adv_sync *sync, bool enable,
@@ -62,9 +62,9 @@ static int hci_df_set_cl_cte_rx_enable(struct bt_le_per_adv_sync *sync, bool ena
 #endif /* CONFIG_BT_DF_CONNECTIONLESS_CTE_RX */
 
 #if defined(CONFIG_BT_DF_CONNECTION_CTE_RX)
-static void prepare_conn_cte_rx_enable_cmd_params(struct net_buf *buf, struct bt_conn *conn,
-						  const struct bt_df_conn_cte_rx_param *params,
-						  bool enable);
+static int prepare_conn_cte_rx_enable_cmd_params(struct net_buf **buf, struct bt_conn *conn,
+						 const struct bt_df_conn_cte_rx_param *params,
+						 bool enable);
 static int hci_df_set_conn_cte_rx_enable(struct bt_conn *conn, bool enable,
 					 const struct bt_df_conn_cte_rx_param *params);
 #endif /* CONFIG_BT_DF_CONNECTION_CTE_RX */
@@ -273,28 +273,44 @@ static bool valid_cl_cte_rx_params(const struct bt_df_per_adv_sync_cte_rx_param 
 	return true;
 }
 
-static void
-prepare_cl_cte_rx_enable_cmd_params(struct net_buf *buf, struct bt_le_per_adv_sync *sync,
+static int
+prepare_cl_cte_rx_enable_cmd_params(struct net_buf **buf, struct bt_le_per_adv_sync *sync,
 				    const struct bt_df_per_adv_sync_cte_rx_param *params,
 				    bool enable)
 {
 	struct bt_hci_cp_le_set_cl_cte_sampling_enable *cp;
-	const uint8_t *ant_ids;
+	uint8_t switch_pattern_len;
 
-	cp = net_buf_add(buf, sizeof(*cp));
+	if (params->cte_types & BT_DF_CTE_TYPE_AOA) {
+		switch_pattern_len = cp->switch_pattern_len;
+	} else {
+		switch_pattern_len = ARRAY_SIZE(df_dummy_switch_pattern);
+	}
+
+	/* If CTE Rx is enabled, command parameters total length must include
+	 * antenna ids, so command size if extended by num_and_ids.
+	 */
+	*buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_CL_CTE_SAMPLING_ENABLE,
+				 (sizeof(struct bt_hci_cp_le_set_cl_cte_sampling_enable) +
+				 (enable ? switch_pattern_len : 0)));
+	if (!(*buf)) {
+		return -ENOBUFS;
+	}
+
+	cp = net_buf_add(*buf, sizeof(*cp));
 	(void)memset(cp, 0, sizeof(*cp));
 
 	cp->sync_handle = sys_cpu_to_le16(sync->handle);
 	cp->sampling_enable = enable ? 1 : 0;
 
 	if (enable) {
+		const uint8_t *ant_ids;
 		uint8_t *dest_ant_ids;
 
 		cp->max_sampled_cte = params->max_cte_count;
 
 		if (params->cte_types & BT_DF_CTE_TYPE_AOA) {
 			cp->slot_durations = params->slot_durations;
-			cp->switch_pattern_len = params->num_ant_ids;
 			ant_ids = params->ant_ids;
 		} else {
 			/* Those values are put here due to constraints from HCI command
@@ -303,13 +319,15 @@ prepare_cl_cte_rx_enable_cmd_params(struct net_buf *buf, struct bt_le_per_adv_sy
 			 * receive for AoD mode (e.g. device equipped with single antenna).
 			 */
 			cp->slot_durations = BT_HCI_LE_ANTENNA_SWITCHING_SLOT_2US;
-			cp->switch_pattern_len = ARRAY_SIZE(df_dummy_switch_pattern);
 			ant_ids = &df_dummy_switch_pattern[0];
 		}
 
-		dest_ant_ids =	net_buf_add(buf, params->num_ant_ids);
+		cp->switch_pattern_len = switch_pattern_len;
+		dest_ant_ids = net_buf_add(*buf, params->num_ant_ids);
 		memcpy(dest_ant_ids, ant_ids, cp->switch_pattern_len);
 	}
+
+	return 0;
 }
 
 static int hci_df_set_cl_cte_rx_enable(struct bt_le_per_adv_sync *sync, bool enable,
@@ -326,17 +344,10 @@ static int hci_df_set_cl_cte_rx_enable(struct bt_le_per_adv_sync *sync, bool ena
 		}
 	}
 
-	/* If CTE Rx is enabled, command parameters total length must include
-	 * antenna ids, so command size if extended by num_and_ids.
-	 */
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_CL_CTE_SAMPLING_ENABLE,
-				(sizeof(struct bt_hci_cp_le_set_cl_cte_sampling_enable) +
-				 (enable ? params->num_ant_ids : 0)));
-	if (!buf) {
-		return -ENOBUFS;
+	err = prepare_cl_cte_rx_enable_cmd_params(&buf, sync, params, enable);
+	if (err) {
+		return err;
 	}
-
-	prepare_cl_cte_rx_enable_cmd_params(buf, sync, params, enable);
 
 	bt_hci_cmd_state_set_init(buf, &state, sync->flags, BT_PER_ADV_SYNC_CTE_ENABLED, enable);
 
@@ -503,40 +514,60 @@ static int hci_df_set_conn_cte_tx_param(struct bt_conn *conn,
 #endif /* CONFIG_BT_DF_CONNECTION_CTE_TX */
 
 #if defined(CONFIG_BT_DF_CONNECTION_CTE_RX)
-static void prepare_conn_cte_rx_enable_cmd_params(struct net_buf *buf, struct bt_conn *conn,
-						  const struct bt_df_conn_cte_rx_param *params,
-						  bool enable)
+static int prepare_conn_cte_rx_enable_cmd_params(struct net_buf **buf, struct bt_conn *conn,
+						 const struct bt_df_conn_cte_rx_param *params,
+						 bool enable)
 {
 	struct bt_hci_cp_le_set_conn_cte_rx_params *cp;
-	const uint8_t *ant_ids;
+	uint8_t switch_pattern_len;
 
-	cp = net_buf_add(buf, sizeof(*cp));
+	if (params->cte_types & BT_DF_CTE_TYPE_AOA) {
+		switch_pattern_len = cp->switch_pattern_len;
+	} else {
+		switch_pattern_len = ARRAY_SIZE(df_dummy_switch_pattern);
+	}
+
+	/* If CTE Rx is enabled, command parameters total length must include
+	 * antenna ids, so command size if extended by num_and_ids.
+	 */
+	*buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_CONN_CTE_RX_PARAMS,
+				 (sizeof(struct bt_hci_cp_le_set_conn_cte_rx_params) +
+				 (enable ? switch_pattern_len : 0)));
+	if (!(*buf)) {
+		return -ENOBUFS;
+	}
+
+	cp = net_buf_add(*buf, sizeof(*cp));
 	(void)memset(cp, 0, sizeof(*cp));
 
 	cp->handle = sys_cpu_to_le16(conn->handle);
 	cp->sampling_enable = enable ? 1 : 0;
 
 	if (enable) {
+		const uint8_t *ant_ids;
 		uint8_t *dest_ant_ids;
 
 		if (params->cte_types & BT_DF_CTE_TYPE_AOA) {
 			cp->slot_durations = params->slot_durations;
-			cp->switch_pattern_len = params->num_ant_ids;
 			ant_ids = params->ant_ids;
 		} else {
 			/* Those values are put here due to constraints from HCI command
 			 * specification: Bluetooth Core Spec. 5.3 Vol 4,Part E, sec 7.8.85.
 			 * There is no right way to successfully send the command to enable CTE
 			 * receive for AoD mode (e.g. device equipped with single antenna).
+			 * There is no CTE type in the parameters list, so controller is forced
+			 * to check correctness of all parameters always.
 			 */
 			cp->slot_durations = BT_HCI_LE_ANTENNA_SWITCHING_SLOT_2US;
-			cp->switch_pattern_len = ARRAY_SIZE(df_dummy_switch_pattern);
 			ant_ids = &df_dummy_switch_pattern[0];
 		}
 
-		dest_ant_ids = net_buf_add(buf, cp->switch_pattern_len);
+		cp->switch_pattern_len = switch_pattern_len;
+		dest_ant_ids = net_buf_add(*buf, cp->switch_pattern_len);
 		(void)memcpy(dest_ant_ids, ant_ids, cp->switch_pattern_len);
 	}
+
+	return 0;
 }
 
 static int hci_df_set_conn_cte_rx_enable(struct bt_conn *conn, bool enable,
@@ -554,17 +585,10 @@ static int hci_df_set_conn_cte_rx_enable(struct bt_conn *conn, bool enable,
 		}
 	}
 
-	/* If CTE Rx is enabled, command parameters total length must include
-	 * antenna ids, so command size if extended by num_and_ids.
-	 */
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_CONN_CTE_RX_PARAMS,
-				(sizeof(struct bt_hci_rp_le_set_conn_cte_rx_params) +
-				 (enable ? params->num_ant_ids : 0)));
-	if (!buf) {
-		return -ENOBUFS;
+	err = prepare_conn_cte_rx_enable_cmd_params(&buf, conn, params, enable);
+	if (err) {
+		return err;
 	}
-
-	prepare_conn_cte_rx_enable_cmd_params(buf, conn, params, enable);
 
 	bt_hci_cmd_state_set_init(buf, &state, conn->flags, BT_CONN_CTE_RX_ENABLED, enable);
 


### PR DESCRIPTION
The PR provides fixes for following direction finding issues:
- problem with split building of DF samples (App + Host, Controller)
- event buffer (`CONFIG_BT_BUF_EVT_RX_SIZE`) for IQ samples reports in connected mode is to small to hold all IQ samples
- HCI commands `HCI_LE_Set_Connection_CTE_Receive_Parameters` and `HCI_LE_Set_Connectionless_IQ_Sampling_Enable` have wrong size set when created by `bt_hci_cmd_create` in case the Angle of Arrival mode is disabled (there is not antenna switching and antenna IDs are not provided by an application).
- Controller with enabled DF and disabled support for PHY update does not build.