### PR TITLE
Bluetooth: BAP: Unicast client sample accept EXT_ADV

### DIFF
--- a/samples/bluetooth/unicast_audio_client/src/main.c
+++ b/samples/bluetooth/unicast_audio_client/src/main.c
@@ -184,7 +184,9 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 	}
 
 	/* We're only interested in connectable events */
-	if (type != BT_GAP_ADV_TYPE_ADV_IND && type != BT_GAP_ADV_TYPE_ADV_DIRECT_IND) {
+	if (type != BT_GAP_ADV_TYPE_ADV_IND &&
+	    type != BT_GAP_ADV_TYPE_ADV_DIRECT_IND &&
+	    type != BT_GAP_ADV_TYPE_EXT_ADV) {
 		return;
 	}
 


### PR DESCRIPTION
Minor change to let the client accept EXT_ADV reports
when connecting.

fixes #42856

Signed-off-by: Casper Bonde <casper_bonde@bose.com>