### PR TITLE
BAP Remove direction from codec

### DIFF
--- a/include/bluetooth/audio/audio.h
+++ b/include/bluetooth/audio/audio.h
@@ -253,7 +253,6 @@ struct bt_audio_base {
 /** @def BT_CODEC_QOS
  *  @brief Helper to declare elements of bt_codec_qos
  *
- *  @param _dir direction
  *  @param _interval SDU interval (usec)
  *  @param _framing Framing
  *  @param _phy Target PHY
@@ -262,10 +261,9 @@ struct bt_audio_base {
  *  @param _latency Maximum Transport Latency (msec)
  *  @param _pd Presentation Delay (usec)
  */
-#define BT_CODEC_QOS(_dir, _interval, _framing, _phy, _sdu, _rtn, _latency, \
+#define BT_CODEC_QOS(_interval, _framing, _phy, _sdu, _rtn, _latency, \
 		     _pd) \
 	{ \
-		.dir = _dir, \
 		.interval = _interval, \
 		.framing = _framing, \
 		.phy = _phy, \
@@ -274,13 +272,6 @@ struct bt_audio_base {
 		.latency = _latency, \
 		.pd = _pd, \
 	}
-
-/** @brief Audio QoS direction */
-enum {
-	BT_CODEC_QOS_IN,
-	BT_CODEC_QOS_OUT,
-	BT_CODEC_QOS_INOUT
-};
 
 /** @brief Codec QoS Framing */
 enum {
@@ -295,7 +286,7 @@ enum {
 	BT_CODEC_QOS_CODED = BIT(2),
 };
 
-/** @def BT_CODEC_QOS_IN_UNFRAMED
+/** @def BT_CODEC_QOS_UNFRAMED
  *  @brief Helper to declare Input Unframed bt_codec_qos
  *
  *  @param _interval SDU interval (usec)
@@ -304,36 +295,11 @@ enum {
  *  @param _latency Maximum Transport Latency (msec)
  *  @param _pd Presentation Delay (usec)
  */
-#define BT_CODEC_QOS_IN_UNFRAMED(_interval, _sdu, _rtn, _latency, _pd) \
-	BT_CODEC_QOS(BT_CODEC_QOS_IN, _interval, BT_CODEC_QOS_UNFRAMED, \
-		     BT_CODEC_QOS_2M, _sdu, _rtn, _latency, _pd)
+#define BT_CODEC_QOS_UNFRAMED(_interval, _sdu, _rtn, _latency, _pd) \
+	BT_CODEC_QOS(_interval, BT_CODEC_QOS_UNFRAMED, BT_CODEC_QOS_2M, _sdu, \
+		     _rtn, _latency, _pd)
 
-/** @def BT_CODEC_QOS_OUT_UNFRAMED
- *  @brief Helper to declare Output Unframed bt_code *
- *  @param _interval SDU interval (usec)
- *  @param _sdu Maximum SDU Size
- *  @param _rtn Retransmission number
- *  @param _latency Maximum Transport Latency (msec)
- *  @param _pd Presentation Delay (usec)
- */
-#define BT_CODEC_QOS_OUT_UNFRAMED(_interval, _sdu, _rtn, _latency, _pd) \
-	BT_CODEC_QOS(BT_CODEC_QOS_OUT, _interval, BT_CODEC_QOS_UNFRAMED, \
-		     BT_CODEC_QOS_2M, _sdu, _rtn, _latency, _pd)
-
-/** @def BT_CODEC_QOS_INOUT_UNFRAMED
- *  @brief Helper to declare Input/Output Unframed bt_codec_qos
- *
- *  @param _interval SDU interval (usec)
- *  @param _sdu Maximum SDU Size
- *  @param _rtn Retransmission number
- *  @param _latency Maximum Transport Latency (msec)
- *  @param _pd Presentation Delay (usec)
- */
-#define BT_CODEC_QOS_INOUT_UNFRAMED(_interval, _sdu, _rtn, _latency, _pd) \
-	BT_CODEC_QOS(BT_CODEC_QOS_INOUT, _interval, BT_CODEC_QOS_UNFRAMED, \
-		     BT_CODEC_QOS_2M, _sdu, _rtn, _latency, _pd)
-
-/** @def BT_CODEC_QOS_IN_FRAMED
+/** @def BT_CODEC_QOS_FRAMED
  *  @brief Helper to declare Input Framed bt_codec_qos
  *
  *  @param _interval SDU interval (usec)
@@ -342,45 +308,12 @@ enum {
  *  @param _latency Maximum Transport Latency (msec)
  *  @param _pd Presentation Delay (usec)
  */
-#define BT_CODEC_QOS_IN_FRAMED(_interval, _sdu, _rtn, _latency, _pd) \
-	BT_CODEC_QOS(BT_CODEC_QOS_IN, _interval, BT_CODEC_QOS_FRAMED, \
-		     BT_CODEC_QOS_2M, _sdu, _rtn, _latency, _pd)
-
-/** @def BT_CODEC_QOS_OUT_FRAMED
- *  @brief Helper to declare Output Framed bt_codec_qos
- *
- *  @param _interval SDU interval (usec)
- *  @param _sdu Maximum SDU Size
- *  @param _rtn Retransmission number
- *  @param _latency Maximum Transport Latency (msec)
- *  @param _pd Presentation Delay (usec)
- */
-#define BT_CODEC_QOS_OUT_FRAMED(_interval, _sdu, _rtn, _latency, _pd) \
-	BT_CODEC_QOS(BT_CODEC_QOS_OUT, _interval, BT_CODEC_QOS_FRAMED, \
-		     BT_CODEC_QOS_2M, _sdu, _rtn, _latency, _pd)
-
-/** @def BT_CODEC_QOS_INOUT_FRAMED
- *  @brief Helper to declare Output Framed bt_codec_qos
- *
- *  @param _interval SDU interval (usec)
- *  @param _sdu Maximum SDU Size
- *  @param _rtn Retransmission number
- *  @param _latency Maximum Transport Latency (msec)
- *  @param _pd Presentation Delay (usec)
- */
-#define BT_CODEC_QOS_INOUT_FRAMED(_interval, _sdu, _rtn, _latency, _pd) \
-	BT_CODEC_QOS(BT_CODEC_QOS_INOUT, _interval, BT_CODEC_QOS_FRAMED, \
-		     BT_CODEC_QOS_2M, _sdu, _rtn, _latency, _pd)
+#define BT_CODEC_QOS_FRAMED(_interval, _sdu, _rtn, _latency, _pd) \
+	BT_CODEC_QOS(_interval, BT_CODEC_QOS_FRAMED, BT_CODEC_QOS_2M, _sdu, \
+		     _rtn, _latency, _pd)
 
 /** @brief Codec QoS structure. */
 struct bt_codec_qos {
-	/** QoS direction
-	 *
-	 *  This shall be set to BT_CODEC_QOS_OUT for broadcast sources, and
-	 *  shall be set to BT_CODEC_QOS_IN for broadcast sinks.
-	 */
-	uint8_t  dir;
-
 	/** QoS PHY */
 	uint8_t  phy;
 
@@ -485,402 +418,402 @@ struct bt_audio_lc3_preset {
 #define BT_AUDIO_LC3_UNICAST_PRESET_8_1_1 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_8_1, \
-		BT_CODEC_LC3_QOS_7_5_INOUT_UNFRAMED(26u, 2u, 8u, 40000u) \
+		BT_CODEC_LC3_QOS_7_5_UNFRAMED(26u, 2u, 8u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_UNICAST_PRESET_8_2_1 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_8_2, \
-		BT_CODEC_LC3_QOS_10_INOUT_UNFRAMED(30u, 2u, 10u, 40000u) \
+		BT_CODEC_LC3_QOS_10_UNFRAMED(30u, 2u, 10u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_UNICAST_PRESET_16_1_1 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_16_1, \
-		BT_CODEC_LC3_QOS_7_5_INOUT_UNFRAMED(30u, 2u, 8u, 40000u) \
+		BT_CODEC_LC3_QOS_7_5_UNFRAMED(30u, 2u, 8u, 40000u) \
 	)
 
 /** Mandatory to support as both unicast client and server */
 #define BT_AUDIO_LC3_UNICAST_PRESET_16_2_1 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_16_2, \
-		BT_CODEC_LC3_QOS_10_INOUT_UNFRAMED(40u, 2u, 10u, 40000u) \
+		BT_CODEC_LC3_QOS_10_UNFRAMED(40u, 2u, 10u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_UNICAST_PRESET_24_1_1 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_24_1, \
-		BT_CODEC_LC3_QOS_7_5_INOUT_UNFRAMED(45u, 2u, 8u, 40000u) \
+		BT_CODEC_LC3_QOS_7_5_UNFRAMED(45u, 2u, 8u, 40000u) \
 	)
 
 /** Mandatory to support as unicast server */
 #define BT_AUDIO_LC3_UNICAST_PRESET_24_2_1 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_24_2, \
-		BT_CODEC_LC3_QOS_10_INOUT_UNFRAMED(60u, 2u, 10u, 40000u) \
+		BT_CODEC_LC3_QOS_10_UNFRAMED(60u, 2u, 10u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_UNICAST_PRESET_32_1_1 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_32_1, \
-		BT_CODEC_LC3_QOS_7_5_INOUT_UNFRAMED(60u, 2u, 8u, 40000u) \
+		BT_CODEC_LC3_QOS_7_5_UNFRAMED(60u, 2u, 8u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_UNICAST_PRESET_32_2_1 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_32_2, \
-		BT_CODEC_LC3_QOS_10_INOUT_UNFRAMED(80u, 2u, 10u, 40000u) \
+		BT_CODEC_LC3_QOS_10_UNFRAMED(80u, 2u, 10u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_UNICAST_PRESET_441_1_1 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_441_1, \
-		BT_CODEC_QOS(BT_CODEC_QOS_OUT, 8163u, BT_CODEC_QOS_FRAMED, \
+		BT_CODEC_QOS(8163u, BT_CODEC_QOS_FRAMED, \
 			     BT_CODEC_QOS_2M, 97u, 5u, 24u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_UNICAST_PRESET_441_2_1 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_441_2, \
-		BT_CODEC_QOS(BT_CODEC_QOS_OUT, 10884u, BT_CODEC_QOS_FRAMED, \
+		BT_CODEC_QOS(10884u, BT_CODEC_QOS_FRAMED, \
 			     BT_CODEC_QOS_2M, 130u, 5u, 31u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_UNICAST_PRESET_48_1_1 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_48_1, \
-		BT_CODEC_LC3_QOS_7_5_OUT_UNFRAMED(75u, 5u, 15u, 40000u) \
+		BT_CODEC_LC3_QOS_7_5_UNFRAMED(75u, 5u, 15u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_UNICAST_PRESET_48_2_1 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_48_2, \
-		BT_CODEC_LC3_QOS_10_OUT_UNFRAMED(100u, 5u, 20u, 40000u) \
+		BT_CODEC_LC3_QOS_10_UNFRAMED(100u, 5u, 20u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_UNICAST_PRESET_48_3_1 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_48_3, \
-		BT_CODEC_LC3_QOS_7_5_OUT_UNFRAMED(90u, 5u, 15u, 40000u) \
+		BT_CODEC_LC3_QOS_7_5_UNFRAMED(90u, 5u, 15u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_UNICAST_PRESET_48_4_1 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_48_4, \
-		BT_CODEC_LC3_QOS_10_OUT_UNFRAMED(120u, 5u, 20u, 40000u) \
+		BT_CODEC_LC3_QOS_10_UNFRAMED(120u, 5u, 20u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_UNICAST_PRESET_48_5_1 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_48_5, \
-		BT_CODEC_LC3_QOS_7_5_OUT_UNFRAMED(117u, 5u, 15u, 40000u) \
+		BT_CODEC_LC3_QOS_7_5_UNFRAMED(117u, 5u, 15u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_UNICAST_PRESET_48_6_1 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_48_6, \
-		BT_CODEC_LC3_QOS_10_OUT_UNFRAMED(155u, 5u, 20u, 40000u) \
+		BT_CODEC_LC3_QOS_10_UNFRAMED(155u, 5u, 20u, 40000u) \
 	)
 
 /* Following presets are for unicast high reliability audio data */
 #define BT_AUDIO_LC3_UNICAST_PRESET_8_1_2 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_8_1, \
-		BT_CODEC_LC3_QOS_7_5_INOUT_UNFRAMED(26u, 13u, 75u, 40000u) \
+		BT_CODEC_LC3_QOS_7_5_UNFRAMED(26u, 13u, 75u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_UNICAST_PRESET_8_2_2 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_8_2, \
-		BT_CODEC_LC3_QOS_10_INOUT_UNFRAMED(30u, 13u, 95u, 40000u) \
+		BT_CODEC_LC3_QOS_10_UNFRAMED(30u, 13u, 95u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_UNICAST_PRESET_16_1_2 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_16_1, \
-		BT_CODEC_LC3_QOS_7_5_INOUT_UNFRAMED(30u, 13u, 75u, 40000u) \
+		BT_CODEC_LC3_QOS_7_5_UNFRAMED(30u, 13u, 75u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_UNICAST_PRESET_16_2_2 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_16_2, \
-		BT_CODEC_LC3_QOS_10_INOUT_UNFRAMED(40u, 13u, 95u, 40000u) \
+		BT_CODEC_LC3_QOS_10_UNFRAMED(40u, 13u, 95u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_UNICAST_PRESET_24_1_2 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_24_1, \
-		BT_CODEC_LC3_QOS_7_5_INOUT_UNFRAMED(45u, 13u, 75u, 40000u) \
+		BT_CODEC_LC3_QOS_7_5_UNFRAMED(45u, 13u, 75u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_UNICAST_PRESET_24_2_2 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_24_2, \
-		BT_CODEC_LC3_QOS_10_INOUT_UNFRAMED(60u, 13u, 95u, 40000u) \
+		BT_CODEC_LC3_QOS_10_UNFRAMED(60u, 13u, 95u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_UNICAST_PRESET_32_1_2 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_32_1, \
-		BT_CODEC_LC3_QOS_7_5_INOUT_UNFRAMED(60u, 13u, 75u, 40000u) \
+		BT_CODEC_LC3_QOS_7_5_UNFRAMED(60u, 13u, 75u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_UNICAST_PRESET_32_2_2 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_32_2, \
-		BT_CODEC_LC3_QOS_10_INOUT_UNFRAMED(80u, 13u, 95u, 40000u) \
+		BT_CODEC_LC3_QOS_10_UNFRAMED(80u, 13u, 95u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_UNICAST_PRESET_441_1_2 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_441_1, \
-		BT_CODEC_QOS(BT_CODEC_QOS_OUT, 8163u, BT_CODEC_QOS_FRAMED, \
+		BT_CODEC_QOS(8163u, BT_CODEC_QOS_FRAMED, \
 			     BT_CODEC_QOS_2M, 97u, 13u, 80u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_UNICAST_PRESET_441_2_2 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_441_2, \
-		BT_CODEC_QOS(BT_CODEC_QOS_OUT, 10884u, BT_CODEC_QOS_FRAMED, \
+		BT_CODEC_QOS(10884u, BT_CODEC_QOS_FRAMED, \
 			     BT_CODEC_QOS_2M, 130u, 13u, 85u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_UNICAST_PRESET_48_1_2 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_48_1, \
-		BT_CODEC_LC3_QOS_7_5_OUT_UNFRAMED(75u, 13u, 75u, 40000u) \
+		BT_CODEC_LC3_QOS_7_5_UNFRAMED(75u, 13u, 75u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_UNICAST_PRESET_48_2_2 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_48_2, \
-		BT_CODEC_LC3_QOS_10_OUT_UNFRAMED(100u, 13u, 95u, 40000u) \
+		BT_CODEC_LC3_QOS_10_UNFRAMED(100u, 13u, 95u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_UNICAST_PRESET_48_3_2 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_48_3, \
-		BT_CODEC_LC3_QOS_7_5_OUT_UNFRAMED(90u, 13u, 75u, 40000u) \
+		BT_CODEC_LC3_QOS_7_5_UNFRAMED(90u, 13u, 75u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_UNICAST_PRESET_48_4_2 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_48_4, \
-	BT_CODEC_LC3_QOS_10_OUT_UNFRAMED(120u, 13u, 100u, 40000u) \
+	BT_CODEC_LC3_QOS_10_UNFRAMED(120u, 13u, 100u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_UNICAST_PRESET_48_5_2 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_48_5, \
-		BT_CODEC_LC3_QOS_7_5_OUT_UNFRAMED(117u, 13u, 75u, 40000u) \
+		BT_CODEC_LC3_QOS_7_5_UNFRAMED(117u, 13u, 75u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_UNICAST_PRESET_48_6_2 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_48_6, \
-		BT_CODEC_LC3_QOS_10_OUT_UNFRAMED(155u, 13u, 100u, 40000u) \
+		BT_CODEC_LC3_QOS_10_UNFRAMED(155u, 13u, 100u, 40000u) \
 	)
 
 /* LC3 Broadcast presets defined by table 6.4 in the BAP v1.0 specification */
 #define BT_AUDIO_LC3_BROADCAST_PRESET_8_1_1 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_8_1, \
-		BT_CODEC_LC3_QOS_7_5_INOUT_UNFRAMED(26u, 2u, 8u, 40000u) \
+		BT_CODEC_LC3_QOS_7_5_UNFRAMED(26u, 2u, 8u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_BROADCAST_PRESET_8_2_1 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_8_2, \
-		BT_CODEC_LC3_QOS_10_INOUT_UNFRAMED(30u, 2u, 10u, 40000u) \
+		BT_CODEC_LC3_QOS_10_UNFRAMED(30u, 2u, 10u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_BROADCAST_PRESET_16_1_1 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_16_1, \
-		BT_CODEC_LC3_QOS_7_5_INOUT_UNFRAMED(30u, 2u, 8u, 40000u) \
+		BT_CODEC_LC3_QOS_7_5_UNFRAMED(30u, 2u, 8u, 40000u) \
 	)
 
 /** Mandatory to support as both broadcast source and sink */
 #define BT_AUDIO_LC3_BROADCAST_PRESET_16_2_1 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_16_2, \
-		BT_CODEC_LC3_QOS_10_INOUT_UNFRAMED(40u, 2u, 10u, 40000u) \
+		BT_CODEC_LC3_QOS_10_UNFRAMED(40u, 2u, 10u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_BROADCAST_PRESET_24_1_1 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_24_1, \
-		BT_CODEC_LC3_QOS_7_5_INOUT_UNFRAMED(45u, 2u, 8u, 40000u) \
+		BT_CODEC_LC3_QOS_7_5_UNFRAMED(45u, 2u, 8u, 40000u) \
 	)
 
 /** Mandatory to support as broadcast sink */
 #define BT_AUDIO_LC3_BROADCAST_PRESET_24_2_1 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_24_2, \
-		BT_CODEC_LC3_QOS_10_INOUT_UNFRAMED(60u, 2u, 10u, 40000u) \
+		BT_CODEC_LC3_QOS_10_UNFRAMED(60u, 2u, 10u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_BROADCAST_PRESET_32_1_1 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_32_1, \
-		BT_CODEC_LC3_QOS_7_5_INOUT_UNFRAMED(60u, 2u, 8u, 40000u) \
+		BT_CODEC_LC3_QOS_7_5_UNFRAMED(60u, 2u, 8u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_BROADCAST_PRESET_32_2_1 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_32_2, \
-		BT_CODEC_LC3_QOS_10_INOUT_UNFRAMED(80u, 2u, 10u, 40000u) \
+		BT_CODEC_LC3_QOS_10_UNFRAMED(80u, 2u, 10u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_BROADCAST_PRESET_441_1_1 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_441_1, \
-		BT_CODEC_QOS(BT_CODEC_QOS_OUT, 8163u, BT_CODEC_QOS_FRAMED, \
+		BT_CODEC_QOS(8163u, BT_CODEC_QOS_FRAMED, \
 			     BT_CODEC_QOS_2M, 97u, 4u, 24u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_BROADCAST_PRESET_441_2_1 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_441_2, \
-		BT_CODEC_QOS(BT_CODEC_QOS_OUT, 10884u, BT_CODEC_QOS_FRAMED, \
+		BT_CODEC_QOS(10884u, BT_CODEC_QOS_FRAMED, \
 			     BT_CODEC_QOS_2M, 130u, 4u, 31u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_BROADCAST_PRESET_48_1_1 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_48_1, \
-		BT_CODEC_LC3_QOS_7_5_OUT_UNFRAMED(75u, 4u, 15u, 40000u) \
+		BT_CODEC_LC3_QOS_7_5_UNFRAMED(75u, 4u, 15u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_BROADCAST_PRESET_48_2_1 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_48_2, \
-		BT_CODEC_LC3_QOS_10_OUT_UNFRAMED(100u, 4u, 20u, 40000u) \
+		BT_CODEC_LC3_QOS_10_UNFRAMED(100u, 4u, 20u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_BROADCAST_PRESET_48_3_1 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_48_3, \
-		BT_CODEC_LC3_QOS_7_5_OUT_UNFRAMED(90u, 4u, 15u, 40000u) \
+		BT_CODEC_LC3_QOS_7_5_UNFRAMED(90u, 4u, 15u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_BROADCAST_PRESET_48_4_1 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_48_4, \
-		BT_CODEC_LC3_QOS_10_OUT_UNFRAMED(120u, 4u, 20u, 40000u) \
+		BT_CODEC_LC3_QOS_10_UNFRAMED(120u, 4u, 20u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_BROADCAST_PRESET_48_5_1 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_48_5, \
-		BT_CODEC_LC3_QOS_7_5_OUT_UNFRAMED(117u, 4u, 15u, 40000u) \
+		BT_CODEC_LC3_QOS_7_5_UNFRAMED(117u, 4u, 15u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_BROADCAST_PRESET_48_6_1 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_48_6, \
-		BT_CODEC_LC3_QOS_10_OUT_UNFRAMED(155u, 4u, 20u, 40000u) \
+		BT_CODEC_LC3_QOS_10_UNFRAMED(155u, 4u, 20u, 40000u) \
 	)
 
 /* Following presets are for broadcast high reliability audio data */
 #define BT_AUDIO_LC3_BROADCAST_PRESET_8_1_2 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_8_1, \
-		BT_CODEC_LC3_QOS_7_5_INOUT_UNFRAMED(26u, 4u, 45u, 40000u) \
+		BT_CODEC_LC3_QOS_7_5_UNFRAMED(26u, 4u, 45u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_BROADCAST_PRESET_8_2_2 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_8_2, \
-		BT_CODEC_LC3_QOS_10_INOUT_UNFRAMED(30u, 4u, 60u, 40000u) \
+		BT_CODEC_LC3_QOS_10_UNFRAMED(30u, 4u, 60u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_BROADCAST_PRESET_16_1_2 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_16_1, \
-		BT_CODEC_LC3_QOS_7_5_INOUT_UNFRAMED(30u, 4u, 45u, 40000u) \
+		BT_CODEC_LC3_QOS_7_5_UNFRAMED(30u, 4u, 45u, 40000u) \
 	)
 
 /** Mandatory to support as both broadcast source and sink */
 #define BT_AUDIO_LC3_BROADCAST_PRESET_16_2_2 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_16_2, \
-		BT_CODEC_LC3_QOS_10_INOUT_UNFRAMED(40u, 4u, 60u, 40000u) \
+		BT_CODEC_LC3_QOS_10_UNFRAMED(40u, 4u, 60u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_BROADCAST_PRESET_24_1_2 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_24_1, \
-		BT_CODEC_LC3_QOS_7_5_INOUT_UNFRAMED(45u, 4u, 45u, 40000u) \
+		BT_CODEC_LC3_QOS_7_5_UNFRAMED(45u, 4u, 45u, 40000u) \
 	)
 
 /** Mandatory to support as broadcast sink */
 #define BT_AUDIO_LC3_BROADCAST_PRESET_24_2_2 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_24_2, \
-		BT_CODEC_LC3_QOS_10_INOUT_UNFRAMED(60u, 4u, 60u, 40000u) \
+		BT_CODEC_LC3_QOS_10_UNFRAMED(60u, 4u, 60u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_BROADCAST_PRESET_32_1_2 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_32_1, \
-		BT_CODEC_LC3_QOS_7_5_INOUT_UNFRAMED(60u, 4u, 45u, 40000u) \
+		BT_CODEC_LC3_QOS_7_5_UNFRAMED(60u, 4u, 45u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_BROADCAST_PRESET_32_2_2 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_32_2, \
-		BT_CODEC_LC3_QOS_10_INOUT_UNFRAMED(80u, 4u, 60u, 40000u) \
+		BT_CODEC_LC3_QOS_10_UNFRAMED(80u, 4u, 60u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_BROADCAST_PRESET_441_1_2 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_441_1, \
-		BT_CODEC_QOS(BT_CODEC_QOS_OUT, 8163u, BT_CODEC_QOS_FRAMED, \
+		BT_CODEC_QOS(8163u, BT_CODEC_QOS_FRAMED, \
 			     BT_CODEC_QOS_2M, 97u, 4u, 54u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_BROADCAST_PRESET_441_2_2 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_441_2, \
-		BT_CODEC_QOS(BT_CODEC_QOS_OUT, 10884u, BT_CODEC_QOS_FRAMED, \
+		BT_CODEC_QOS(10884u, BT_CODEC_QOS_FRAMED, \
 			     BT_CODEC_QOS_2M, 130u, 4u, 60u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_BROADCAST_PRESET_48_1_2 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_48_1, \
-		BT_CODEC_LC3_QOS_7_5_OUT_UNFRAMED(75u, 4u, 50u, 40000u) \
+		BT_CODEC_LC3_QOS_7_5_UNFRAMED(75u, 4u, 50u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_BROADCAST_PRESET_48_2_2 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_48_2, \
-		BT_CODEC_LC3_QOS_10_OUT_UNFRAMED(100u, 4u, 65u, 40000u) \
+		BT_CODEC_LC3_QOS_10_UNFRAMED(100u, 4u, 65u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_BROADCAST_PRESET_48_3_2 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_48_3, \
-		BT_CODEC_LC3_QOS_7_5_OUT_UNFRAMED(90u, 4u, 50u, 40000u) \
+		BT_CODEC_LC3_QOS_7_5_UNFRAMED(90u, 4u, 50u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_BROADCAST_PRESET_48_4_2 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_48_4, \
-		BT_CODEC_LC3_QOS_10_OUT_UNFRAMED(120u, 4u, 65u, 40000u) \
+		BT_CODEC_LC3_QOS_10_UNFRAMED(120u, 4u, 65u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_BROADCAST_PRESET_48_5_2 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_48_5, \
-		BT_CODEC_LC3_QOS_7_5_OUT_UNFRAMED(117u, 4u, 50u, 40000u) \
+		BT_CODEC_LC3_QOS_7_5_UNFRAMED(117u, 4u, 50u, 40000u) \
 	)
 
 #define BT_AUDIO_LC3_BROADCAST_PRESET_48_6_2 \
 	BT_AUDIO_LC3_PRESET( \
 		BT_CODEC_LC3_CONFIG_48_6, \
-		BT_CODEC_LC3_QOS_10_OUT_UNFRAMED(155u, 4u, 65u, 40000u) \
+		BT_CODEC_LC3_QOS_10_UNFRAMED(155u, 4u, 65u, 40000u) \
 	)
 
 /** @brief Audio stream structure.

--- a/include/bluetooth/audio/lc3.h
+++ b/include/bluetooth/audio/lc3.h
@@ -372,45 +372,25 @@ struct bt_codec_lc3_frame_len {
 /** @def BT_CODEC_LC3_QOS_7_5
  *  @brief Helper to declare LC3 codec QoS for 7.5ms interval
  */
-#define BT_CODEC_LC3_QOS_7_5(_dir, _framing, _sdu, _rtn, _latency, _pd) \
-	BT_CODEC_QOS(_dir, 7500u, _framing, BT_CODEC_QOS_2M, _sdu, _rtn, \
+#define BT_CODEC_LC3_QOS_7_5(_framing, _sdu, _rtn, _latency, _pd) \
+	BT_CODEC_QOS(7500u, _framing, BT_CODEC_QOS_2M, _sdu, _rtn, \
 		     _latency, _pd)
-/** @def BT_CODEC_LC3_QOS_7_5_IN_UNFRAMED
+/** @def BT_CODEC_LC3_QOS_7_5_UNFRAMED
  *  @brief Helper to declare LC3 codec QoS for 7.5ms interval unframed input
  */
-#define BT_CODEC_LC3_QOS_7_5_IN_UNFRAMED(_sdu, _rtn, _latency, _pd) \
-	BT_CODEC_QOS_IN_UNFRAMED(7500u, _sdu, _rtn, _latency, _pd)
-/** @def BT_CODEC_LC3_QOS_7_5_OUT_UNFRAMED
- *  @brief Helper to declare LC3 codec QoS for 7.5ms interval unframed output
- */
-#define BT_CODEC_LC3_QOS_7_5_OUT_UNFRAMED(_sdu, _rtn, _latency, _pd) \
-	BT_CODEC_QOS_OUT_UNFRAMED(7500u, _sdu, _rtn, _latency, _pd)
-/** @def BT_CODEC_LC3_QOS_7_5_INOUT_UNFRAMED
- *  @brief Helper to declare LC3 codec QoS for 7.5ms interval unframed in/out
- */
-#define BT_CODEC_LC3_QOS_7_5_INOUT_UNFRAMED(_sdu, _rtn, _latency, _pd) \
-	BT_CODEC_QOS_INOUT_UNFRAMED(7500u, _sdu, _rtn, _latency, _pd)
+#define BT_CODEC_LC3_QOS_7_5_UNFRAMED(_sdu, _rtn, _latency, _pd) \
+	BT_CODEC_QOS_UNFRAMED(7500u, _sdu, _rtn, _latency, _pd)
 /** @def BT_CODEC_LC3_QOS_10
  *  @brief Helper to declare LC3 codec QoS for 10ms frame internal
  */
-#define BT_CODEC_LC3_QOS_10(_dir, _framing, _sdu, _rtn, _latency, _pd) \
-	BT_CODEC_QOS(_dir, 10000u, _framing, BT_CODEC_QOS_2M, _sdu, _rtn, \
+#define BT_CODEC_LC3_QOS_10(_framing, _sdu, _rtn, _latency, _pd) \
+	BT_CODEC_QOS(10000u, _framing, BT_CODEC_QOS_2M, _sdu, _rtn, \
 		     _latency, _pd)
-/** @def BT_CODEC_LC3_QOS_10_IN_UNFRAMED
+/** @def BT_CODEC_LC3_QOS_10_UNFRAMED
  *  @brief Helper to declare LC3 codec QoS for 10ms interval unframed input
  */
-#define BT_CODEC_LC3_QOS_10_IN_UNFRAMED(_sdu, _rtn, _latency, _pd) \
-	BT_CODEC_QOS_IN_UNFRAMED(10000u, _sdu, _rtn, _latency, _pd)
-/** @def BT_CODEC_LC3_QOS_10_OUT_UNFRAMED
- *  @brief Helper to declare LC3 codec QoS for 10ms interval unframed output
- */
-#define BT_CODEC_LC3_QOS_10_OUT_UNFRAMED(_sdu, _rtn, _latency, _pd) \
-	BT_CODEC_QOS_OUT_UNFRAMED(10000u, _sdu, _rtn, _latency, _pd)
-/** @def BT_CODEC_LC3_QOS_10_INOUT_UNFRAMED
- *  @brief Helper to declare LC3 codec QoS for 10ms interval unframed in/out
- */
-#define BT_CODEC_LC3_QOS_10_INOUT_UNFRAMED(_sdu, _rtn, _latency, _pd) \
-	BT_CODEC_QOS_INOUT_UNFRAMED(10000u, _sdu, _rtn, _latency, _pd)
+#define BT_CODEC_LC3_QOS_10_UNFRAMED(_sdu, _rtn, _latency, _pd) \
+	BT_CODEC_QOS_UNFRAMED(10000u, _sdu, _rtn, _latency, _pd)
 
 #ifdef __cplusplus
 }

--- a/samples/bluetooth/unicast_audio_server/src/main.c
+++ b/samples/bluetooth/unicast_audio_server/src/main.c
@@ -89,9 +89,9 @@ static void print_codec(const struct bt_codec *codec)
 
 static void print_qos(struct bt_codec_qos *qos)
 {
-	printk("QoS: dir 0x%02x interval %u framing 0x%02x phy 0x%02x sdu %u "
+	printk("QoS: interval %u framing 0x%02x phy 0x%02x sdu %u "
 	       "rtn %u latency %u pd %u\n",
-	       qos->dir, qos->interval, qos->framing, qos->phy, qos->sdu,
+	       qos->interval, qos->framing, qos->phy, qos->sdu,
 	       qos->rtn, qos->latency, qos->pd);
 }
 

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -143,7 +143,7 @@ static void ascs_ep_get_status_config(struct bt_audio_ep *ep,
 
 	BT_DBG("dir 0x%02x unframed_supported 0x%02x phy 0x%02x rtn %u "
 	       "latency %u pd_min %u pd_max %u codec 0x%02x",
-	       ASE_DIR(ep->status.id), pref->unframed_supported, pref->phy,
+	       ep->dir, pref->unframed_supported, pref->phy,
 	       pref->rtn, pref->latency, pref->pd_min, pref->pd_max,
 	       ep->stream->codec->id);
 
@@ -170,7 +170,7 @@ static void ascs_ep_get_status_qos(struct bt_audio_ep *ep,
 
 	BT_DBG("dir 0x%02x codec 0x%02x interval %u framing 0x%02x phy 0x%02x "
 	       "rtn %u latency %u pd %u",
-	       ASE_DIR(ep->status.id), ep->stream->codec->id,
+	       ep->dir, ep->stream->codec->id,
 	       ep->stream->qos->interval, ep->stream->qos->framing,
 	       ep->stream->qos->phy, ep->stream->qos->rtn,
 	       ep->stream->qos->latency, ep->stream->qos->pd);
@@ -190,7 +190,7 @@ static void ascs_ep_get_status_enable(struct bt_audio_ep *ep,
 	enable->metadata_len = buf->len - enable->metadata_len;
 
 	BT_DBG("dir 0x%02x cig 0x%02x cis 0x%02x",
-	       ASE_DIR(ep->status.id), ep->cig_id, ep->cis_id);
+	       ep->dir, ep->cig_id, ep->cis_id);
 }
 
 static int ascs_ep_get_status(struct bt_audio_ep *ep,
@@ -523,7 +523,7 @@ static void ase_disable(struct bt_ascs_ase *ase)
 	/* The ASE state machine goes into different states from this operation
 	 * based on whether it is a source or a sink ASE.
 	 */
-	if (ASE_DIR(ep->status.id) == BT_AUDIO_SOURCE) {
+	if (ep->dir == BT_AUDIO_SOURCE) {
 		ascs_ep_set_state(ep, BT_AUDIO_EP_STATE_DISABLING);
 	} else {
 		ascs_ep_set_state(ep, BT_AUDIO_EP_STATE_QOS_CONFIGURED);
@@ -980,7 +980,7 @@ static int ase_config(struct bt_ascs *ascs, struct bt_ascs_ase *ase,
 		if (unicast_server_cb != NULL &&
 		    unicast_server_cb->reconfig != NULL) {
 			err = unicast_server_cb->reconfig(ase->ep.stream,
-							  ASE_DIR(ase->ep.status.id),
+							  ase->ep.dir,
 							  &ase->ep.codec,
 							  &ase->ep.qos_pref);
 		} else {
@@ -1005,7 +1005,7 @@ static int ase_config(struct bt_ascs *ascs, struct bt_ascs_ase *ase,
 		if (unicast_server_cb != NULL &&
 		    unicast_server_cb->config != NULL) {
 			err = unicast_server_cb->config(ascs->conn, &ase->ep,
-							ASE_DIR(ase->ep.status.id),
+							ase->ep.dir,
 							&ase->ep.codec, &stream,
 							&ase->ep.qos_pref);
 		} else {
@@ -1446,7 +1446,7 @@ static int ase_enable(struct bt_ascs_ase *ase, struct bt_ascs_metadata *meta,
 	ascs_ep_set_state(ep, BT_AUDIO_EP_STATE_ENABLING);
 
 
-	if (ASE_DIR(ep->status.id) == BT_AUDIO_SINK) {
+	if (ep->dir == BT_AUDIO_SINK) {
 		/* SINK ASEs can autonomously go into the streaming state if
 		 * the CIS is connected
 		 */
@@ -1533,7 +1533,7 @@ static void ase_start(struct bt_ascs_ase *ase)
 	 * characteristic to the client, and the server shall set the
 	 * Response_Code value for that ASE to 0x05 (Invalid ASE direction).
 	 */
-	if (ASE_DIR(ep->status.id) == BT_AUDIO_SINK) {
+	if (ep->dir == BT_AUDIO_SINK) {
 		BT_ERR("Start failed: invalid operation for Sink");
 		ascs_cp_rsp_add(ASE_ID(ase), BT_ASCS_START_OP,
 				BT_ASCS_RSP_INVALID_DIR, BT_ASCS_REASON_NONE);
@@ -1657,7 +1657,7 @@ static void ase_stop(struct bt_ascs_ase *ase)
 	 * characteristic to the client, and the server shall set the
 	 * Response_Code value for that ASE to 0x05 (Invalid ASE direction).
 	 */
-	if (ASE_DIR(ase->ep.status.id) == BT_AUDIO_SINK) {
+	if (ase->ep.dir == BT_AUDIO_SINK) {
 		BT_ERR("Stop failed: invalid operation for Sink");
 		ascs_cp_rsp_add(ASE_ID(ase), BT_ASCS_STOP_OP,
 				BT_ASCS_RSP_INVALID_DIR, BT_ASCS_REASON_NONE);

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -731,6 +731,7 @@ void ascs_ep_init(struct bt_audio_ep *ep, uint8_t id)
 	ep->iso.qos = &ep->iso_qos;
 	ep->iso.qos->rx = &ep->iso_rx;
 	ep->iso.qos->tx = &ep->iso_tx;
+	ep->dir = ASE_DIR(id);
 }
 
 static void ase_init(struct bt_ascs_ase *ase, uint8_t id)

--- a/subsys/bluetooth/audio/broadcast_sink.c
+++ b/subsys/bluetooth/audio/broadcast_sink.c
@@ -771,6 +771,7 @@ static void broadcast_sink_ep_init(struct bt_audio_ep *ep)
 	ep->iso.qos = &ep->iso_qos;
 	ep->iso.qos->rx = &ep->iso_rx;
 	ep->iso.qos->tx = &ep->iso_tx;
+	ep->dir = BT_AUDIO_SINK;
 }
 
 static struct bt_audio_ep *broadcast_sink_new_ep(uint8_t index)
@@ -823,9 +824,8 @@ static int bt_audio_broadcast_sink_setup_stream(uint8_t index,
 	 */
 	stream->iso->qos->rx = &sink_chan_io_qos;
 	stream->iso->qos->tx = NULL;
-	codec_qos.dir = BT_CODEC_QOS_IN;
 	stream->qos = &codec_qos;
-	err = bt_audio_codec_qos_to_iso_qos(stream->iso->qos, &codec_qos);
+	err = bt_audio_codec_qos_to_iso_qos(stream, &codec_qos);
 	if (err) {
 		BT_ERR("Unable to convert codec QoS to ISO QoS");
 		return err;

--- a/subsys/bluetooth/audio/broadcast_sink.c
+++ b/subsys/bluetooth/audio/broadcast_sink.c
@@ -825,7 +825,7 @@ static int bt_audio_broadcast_sink_setup_stream(uint8_t index,
 	stream->iso->qos->rx = &sink_chan_io_qos;
 	stream->iso->qos->tx = NULL;
 	stream->qos = &codec_qos;
-	err = bt_audio_codec_qos_to_iso_qos(stream, &codec_qos);
+	err = bt_audio_codec_qos_to_iso_qos(stream->iso->qos->rx, &codec_qos);
 	if (err) {
 		BT_ERR("Unable to convert codec QoS to ISO QoS");
 		return err;

--- a/subsys/bluetooth/audio/broadcast_source.c
+++ b/subsys/bluetooth/audio/broadcast_source.c
@@ -237,7 +237,8 @@ static int bt_audio_broadcast_source_setup_stream(uint8_t index,
 
 	bt_audio_stream_attach(NULL, stream, ep, codec);
 	stream->qos = qos;
-	err = bt_audio_codec_qos_to_iso_qos(stream, qos);
+	stream->iso->qos->rx = NULL;
+	err = bt_audio_codec_qos_to_iso_qos(stream->iso->qos->tx, qos);
 	if (err) {
 		BT_ERR("Unable to convert codec QoS to ISO QoS");
 		return err;

--- a/subsys/bluetooth/audio/broadcast_source.c
+++ b/subsys/bluetooth/audio/broadcast_source.c
@@ -189,6 +189,7 @@ static void broadcast_source_ep_init(struct bt_audio_ep *ep)
 	ep->iso.qos = &ep->iso_qos;
 	ep->iso.qos->rx = &ep->iso_rx;
 	ep->iso.qos->tx = &ep->iso_tx;
+	ep->dir = BT_AUDIO_SOURCE;
 }
 
 static struct bt_audio_ep *broadcast_source_new_ep(uint8_t index)
@@ -236,7 +237,7 @@ static int bt_audio_broadcast_source_setup_stream(uint8_t index,
 
 	bt_audio_stream_attach(NULL, stream, ep, codec);
 	stream->qos = qos;
-	err = bt_audio_codec_qos_to_iso_qos(stream->iso->qos, qos);
+	err = bt_audio_codec_qos_to_iso_qos(stream, qos);
 	if (err) {
 		BT_ERR("Unable to convert codec QoS to ISO QoS");
 		return err;

--- a/subsys/bluetooth/audio/endpoint.h
+++ b/subsys/bluetooth/audio/endpoint.h
@@ -33,6 +33,7 @@ struct bt_audio_broadcast_sink;
 
 struct bt_audio_ep {
 	uint8_t  type;
+	uint8_t  dir;
 	uint16_t handle;
 	uint16_t cp_handle;
 	uint8_t  cig_id;

--- a/subsys/bluetooth/audio/stream.c
+++ b/subsys/bluetooth/audio/stream.c
@@ -668,7 +668,7 @@ int bt_audio_stream_enable(struct bt_audio_stream *stream,
 		return 0;
 	}
 
-	if (bt_unicast_client_ep_is_src(stream->ep)) {
+	if (stream->ep->dir == BT_AUDIO_SOURCE) {
 		return 0;
 	}
 
@@ -770,7 +770,7 @@ int bt_audio_stream_disable(struct bt_audio_stream *stream)
 
 	bt_unicast_client_ep_set_state(stream->ep, BT_AUDIO_EP_STATE_DISABLING);
 
-	if (bt_unicast_client_ep_is_src(stream->ep)) {
+	if (stream->ep->dir == BT_AUDIO_SOURCE) {
 		return 0;
 	}
 

--- a/subsys/bluetooth/audio/stream.c
+++ b/subsys/bluetooth/audio/stream.c
@@ -122,23 +122,9 @@ done:
 	return -ENOSPC;
 }
 
-int bt_audio_codec_qos_to_iso_qos(struct bt_audio_stream *stream,
+int bt_audio_codec_qos_to_iso_qos(struct bt_iso_chan_io_qos *io,
 				  const struct bt_codec_qos *codec)
 {
-	struct bt_iso_chan_qos *qos = stream->iso->qos;
-	struct bt_iso_chan_io_qos *io;
-
-	switch (stream->ep->dir) {
-	case BT_AUDIO_SINK:
-		io = qos->rx;
-		break;
-	case BT_AUDIO_SOURCE:
-		io = qos->tx;
-		break;
-	default:
-		return -EINVAL;
-	}
-
 	io->sdu = codec->sdu;
 	io->phy = codec->phy;
 	io->rtn = codec->rtn;
@@ -504,6 +490,9 @@ int bt_audio_stream_qos(struct bt_conn *conn,
 
 	/* Validate streams before starting the QoS execution */
 	SYS_SLIST_FOR_EACH_CONTAINER(&group->streams, stream, node) {
+		struct bt_iso_chan_io_qos *io;
+		struct bt_iso_chan_qos *iso_qos;
+
 		if (stream->ep == NULL) {
 			BT_DBG("stream->ep is NULL");
 			return -EINVAL;
@@ -537,7 +526,26 @@ int bt_audio_stream_qos(struct bt_conn *conn,
 			return -EINVAL;
 		}
 
-		err = bt_audio_codec_qos_to_iso_qos(stream, qos);
+		iso_qos = stream->iso->qos;
+		if (stream->ep->dir == BT_AUDIO_SINK) {
+			/* If the endpoint is a sink, then we need to
+			 * configure our TX parameters
+			 */
+			io = iso_qos->tx;
+			iso_qos->rx = NULL;
+		} else if (stream->ep->dir == BT_AUDIO_SOURCE) {
+			/* If the endpoint is a source, then we need to
+			 * configure our RX parameters
+			 */
+			io = iso_qos->rx;
+			iso_qos->tx = NULL;
+		} else {
+			__ASSERT(false, "invalid endpoint dir: %u",
+				 stream->ep->dir);
+			return -EINVAL;
+		}
+
+		err = bt_audio_codec_qos_to_iso_qos(io, qos);
 		if (err) {
 			BT_DBG("Unable to convert codec QoS to ISO QoS: %d",
 			       err);

--- a/subsys/bluetooth/audio/stream.c
+++ b/subsys/bluetooth/audio/stream.c
@@ -122,20 +122,18 @@ done:
 	return -ENOSPC;
 }
 
-int bt_audio_codec_qos_to_iso_qos(struct bt_iso_chan_qos *qos,
-				  struct bt_codec_qos *codec)
+int bt_audio_codec_qos_to_iso_qos(struct bt_audio_stream *stream,
+				  const struct bt_codec_qos *codec)
 {
+	struct bt_iso_chan_qos *qos = stream->iso->qos;
 	struct bt_iso_chan_io_qos *io;
 
-	switch (codec->dir) {
-	case BT_CODEC_QOS_IN:
+	switch (stream->ep->dir) {
+	case BT_AUDIO_SINK:
 		io = qos->rx;
 		break;
-	case BT_CODEC_QOS_OUT:
+	case BT_AUDIO_SOURCE:
 		io = qos->tx;
-		break;
-	case BT_CODEC_QOS_INOUT:
-		io = qos->rx = qos->tx;
 		break;
 	default:
 		return -EINVAL;
@@ -539,7 +537,7 @@ int bt_audio_stream_qos(struct bt_conn *conn,
 			return -EINVAL;
 		}
 
-		err = bt_audio_codec_qos_to_iso_qos(stream->iso->qos, qos);
+		err = bt_audio_codec_qos_to_iso_qos(stream, qos);
 		if (err) {
 			BT_DBG("Unable to convert codec QoS to ISO QoS: %d",
 			       err);

--- a/subsys/bluetooth/audio/stream.h
+++ b/subsys/bluetooth/audio/stream.h
@@ -45,7 +45,7 @@ void bt_audio_stream_attach(struct bt_conn *conn, struct bt_audio_stream *stream
 			    struct bt_audio_ep *ep,
 			    struct bt_codec *codec);
 
-int bt_audio_codec_qos_to_iso_qos(struct bt_audio_stream *stream,
+int bt_audio_codec_qos_to_iso_qos(struct bt_iso_chan_io_qos *io,
 				  const struct bt_codec_qos *codec);
 
 void bt_audio_stream_detach(struct bt_audio_stream *stream);

--- a/subsys/bluetooth/audio/stream.h
+++ b/subsys/bluetooth/audio/stream.h
@@ -45,8 +45,8 @@ void bt_audio_stream_attach(struct bt_conn *conn, struct bt_audio_stream *stream
 			    struct bt_audio_ep *ep,
 			    struct bt_codec *codec);
 
-int bt_audio_codec_qos_to_iso_qos(struct bt_iso_chan_qos *qos,
-				  struct bt_codec_qos *codec);
+int bt_audio_codec_qos_to_iso_qos(struct bt_audio_stream *stream,
+				  const struct bt_codec_qos *codec);
 
 void bt_audio_stream_detach(struct bt_audio_stream *stream);
 

--- a/subsys/bluetooth/audio/unicast_client.c
+++ b/subsys/bluetooth/audio/unicast_client.c
@@ -217,30 +217,6 @@ static struct bt_audio_ep *unicast_client_ep_new(struct bt_conn *conn,
 	return NULL;
 }
 
-static bool unicast_client_ep_is_snk(const struct bt_audio_ep *ep)
-{
-#if SNK_SIZE > 0
-	for (size_t i = 0; i < ARRAY_SIZE(snks); i++) {
-		if (PART_OF_ARRAY(snks[i], ep)) {
-			return true;
-		}
-	}
-#endif /* SNK_SIZE > 0 */
-	return false;
-}
-
-bool bt_unicast_client_ep_is_src(const struct bt_audio_ep *ep)
-{
-#if SRC_SIZE > 0
-	for (size_t i = 0; i < ARRAY_SIZE(srcs); i++) {
-		if (PART_OF_ARRAY(srcs[i], ep)) {
-			return true;
-		}
-	}
-#endif /* SRC_SIZE > 0 */
-	return false;
-}
-
 static struct bt_audio_ep *unicast_client_ep_get(struct bt_conn *conn,
 						 uint8_t dir, uint16_t handle)
 {
@@ -326,9 +302,8 @@ static void unicast_client_ep_config_state(struct bt_audio_ep *ep,
 
 	BT_DBG("dir 0x%02x unframed_supported 0x%02x phy 0x%02x rtn %u "
 	       "latency %u pd_min %u pd_max %u codec 0x%02x ",
-	       unicast_client_ep_is_snk(ep) ? BT_AUDIO_SINK : BT_AUDIO_SOURCE,
-	       pref->unframed_supported, pref->phy, pref->rtn, pref->latency,
-	       pref->pd_min, pref->pd_max, stream->codec->id);
+	       ep->dir, pref->unframed_supported, pref->phy, pref->rtn,
+	       pref->latency, pref->pd_min, pref->pd_max, stream->codec->id);
 
 	unicast_client_ep_set_codec(ep, cfg->codec.id,
 				    sys_le16_to_cpu(cfg->codec.cid),
@@ -376,8 +351,7 @@ static void unicast_client_ep_qos_state(struct bt_audio_ep *ep,
 
 	BT_DBG("dir 0x%02x cig 0x%02x cis 0x%02x codec 0x%02x interval %u "
 	       "framing 0x%02x phy 0x%02x rtn %u latency %u pd %u",
-	       unicast_client_ep_is_snk(ep) ? BT_AUDIO_SINK : BT_AUDIO_SOURCE,
-	       ep->cig_id, ep->cis_id, stream->codec->id,
+	       ep->dir, ep->cig_id, ep->cis_id, stream->codec->id,
 	       stream->qos->interval, stream->qos->framing,
 	       stream->qos->phy, stream->qos->rtn, stream->qos->latency,
 	       stream->qos->pd);
@@ -415,8 +389,7 @@ static void unicast_client_ep_enabling_state(struct bt_audio_ep *ep,
 	enable = net_buf_simple_pull_mem(buf, sizeof(*enable));
 
 	BT_DBG("dir 0x%02x cig 0x%02x cis 0x%02x",
-	       unicast_client_ep_is_snk(ep) ? BT_AUDIO_SINK : BT_AUDIO_SOURCE,
-	       ep->cig_id, ep->cis_id);
+	       ep->dir, ep->cig_id, ep->cis_id);
 
 	unicast_client_ep_set_metadata(ep, buf, enable->metadata_len, NULL);
 
@@ -448,8 +421,7 @@ static void unicast_client_ep_streaming_state(struct bt_audio_ep *ep,
 	stream_status = net_buf_simple_pull_mem(buf, sizeof(*stream_status));
 
 	BT_DBG("dir 0x%02x cig 0x%02x cis 0x%02x",
-	       unicast_client_ep_is_snk(ep) ? BT_AUDIO_SINK : BT_AUDIO_SOURCE,
-	       ep->cig_id, ep->cis_id);
+	       ep->dir, ep->cig_id, ep->cis_id);
 
 	/* Notify upper layer */
 	if (stream->ops != NULL && stream->ops->started != NULL) {
@@ -479,8 +451,7 @@ static void unicast_client_ep_disabling_state(struct bt_audio_ep *ep,
 	disable = net_buf_simple_pull_mem(buf, sizeof(*disable));
 
 	BT_DBG("dir 0x%02x cig 0x%02x cis 0x%02x",
-	       unicast_client_ep_is_snk(ep) ? BT_AUDIO_SINK : BT_AUDIO_SOURCE,
-	       ep->cig_id, ep->cis_id);
+	       ep->dir, ep->cig_id, ep->cis_id);
 
 	/* Notify upper layer */
 	if (stream->ops != NULL && stream->ops->disabled != NULL) {
@@ -501,8 +472,7 @@ static void unicast_client_ep_releasing_state(struct bt_audio_ep *ep,
 		return;
 	}
 
-	BT_DBG("dir 0x%02x",
-	       unicast_client_ep_is_snk(ep) ? BT_AUDIO_SINK : BT_AUDIO_SOURCE);
+	BT_DBG("dir 0x%02x", ep->dir);
 
 	/* Notify upper layer */
 	if (stream->ops != NULL && stream->ops->stopped != NULL) {
@@ -1027,8 +997,7 @@ static int unicast_client_ep_config(struct bt_audio_ep *ep,
 	}
 
 	BT_DBG("id 0x%02x dir 0x%02x codec 0x%02x", ep->status.id,
-	       unicast_client_ep_is_snk(ep) ? BT_AUDIO_SINK : BT_AUDIO_SOURCE,
-	       codec->id);
+	       ep->dir, codec->id);
 
 	req = net_buf_simple_add(buf, sizeof(*req));
 	req->ase = ep->status.id;
@@ -1451,7 +1420,7 @@ int bt_unicast_client_start(struct bt_audio_stream *stream)
 	/* When initiated by the client, valid only if Direction field
 	 * parameter value = 0x02 (Server is Audio Source)
 	 */
-	if (bt_unicast_client_ep_is_src(ep)) {
+	if (ep->dir == BT_AUDIO_SOURCE) {
 		err = unicast_client_ep_start(ep, buf);
 		if (err) {
 			return err;
@@ -1503,7 +1472,7 @@ int bt_unicast_client_stop(struct bt_audio_stream *stream)
 	/* When initiated by the client, valid only if Direction field
 	 * parameter value = 0x02 (Server is Audio Source)
 	 */
-	if (bt_unicast_client_ep_is_src(ep)) {
+	if (ep->dir == BT_AUDIO_SOURCE) {
 		err = unicast_client_ep_stop(ep, buf);
 		if (err) {
 			return err;

--- a/subsys/bluetooth/audio/unicast_client.c
+++ b/subsys/bluetooth/audio/unicast_client.c
@@ -137,7 +137,7 @@ static struct bt_iso_chan_ops unicast_client_iso_ops = {
 };
 
 static void unicast_client_ep_init(struct bt_audio_ep *ep, uint8_t type,
-				   uint16_t handle, uint8_t id)
+				   uint16_t handle, uint8_t id, uint8_t dir)
 {
 	BT_DBG("ep %p type 0x%02x handle 0x%04x id 0x%02x", ep, type, handle,
 	       id);
@@ -150,6 +150,7 @@ static void unicast_client_ep_init(struct bt_audio_ep *ep, uint8_t type,
 	ep->iso.qos = &ep->iso_qos;
 	ep->iso.qos->rx = &ep->iso_rx;
 	ep->iso.qos->tx = &ep->iso_tx;
+	ep->dir = dir;
 }
 
 static struct bt_audio_ep *unicast_client_ep_find(struct bt_conn *conn,
@@ -208,7 +209,7 @@ static struct bt_audio_ep *unicast_client_ep_new(struct bt_conn *conn,
 
 		if (!ep->handle) {
 			unicast_client_ep_init(ep, BT_AUDIO_EP_REMOTE, handle,
-					       0x00);
+					       0x00, dir);
 			return ep;
 		}
 	}

--- a/subsys/bluetooth/audio/unicast_client_internal.h
+++ b/subsys/bluetooth/audio/unicast_client_internal.h
@@ -23,7 +23,6 @@ int bt_unicast_client_stop(struct bt_audio_stream *stream);
 
 int bt_unicast_client_release(struct bt_audio_stream *stream);
 
-bool bt_unicast_client_ep_is_src(const struct bt_audio_ep *ep);
 
 void bt_unicast_client_ep_set_state(struct bt_audio_ep *ep, uint8_t state);
 

--- a/subsys/bluetooth/shell/audio.c
+++ b/subsys/bluetooth/shell/audio.c
@@ -239,9 +239,9 @@ static void set_stream(struct bt_audio_stream *stream)
 #if defined(CONFIG_BT_AUDIO_UNICAST)
 static void print_qos(struct bt_codec_qos *qos)
 {
-	shell_print(ctx_shell, "QoS: dir 0x%02x interval %u framing 0x%02x "
+	shell_print(ctx_shell, "QoS: interval %u framing 0x%02x "
 		    "phy 0x%02x sdu %u rtn %u latency %u pd %u",
-		    qos->dir, qos->interval, qos->framing, qos->phy, qos->sdu,
+		    qos->interval, qos->framing, qos->phy, qos->sdu,
 		    qos->rtn, qos->latency, qos->pd);
 }
 

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/unicast_common.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/unicast_common.c
@@ -42,8 +42,8 @@ void print_codec(const struct bt_codec *codec)
 
 void print_qos(const struct bt_codec_qos *qos)
 {
-	printk("QoS: dir 0x%02x interval %u framing 0x%02x phy 0x%02x sdu %u "
+	printk("QoS: interval %u framing 0x%02x phy 0x%02x sdu %u "
 	       "rtn %u latency %u pd %u\n",
-	       qos->dir, qos->interval, qos->framing, qos->phy, qos->sdu,
+	       qos->interval, qos->framing, qos->phy, qos->sdu,
 	       qos->rtn, qos->latency, qos->pd);
 }


### PR DESCRIPTION
Direction (dir) field has been moved to the endpoint instead. This cleans up a significant amount of functions and macros that otherwise determined the direction in other ways. 

The purpose is to avoid bidirectional audio streams as they are not defined by the BAP spec (audio streams are only unidirectional). 

fixes https://github.com/zephyrproject-rtos/zephyr/issues/41194