### PR TITLE
bmi160: Fix I2C support

### DIFF
--- a/drivers/sensor/bmi160/Kconfig
+++ b/drivers/sensor/bmi160/Kconfig
@@ -5,7 +5,7 @@
 
 menuconfig BMI160
 	bool "Bosch BMI160 inertial measurement unit"
-	depends on SPI
+	depends on SPI || I2C
 	help
 	  Enable Bosch BMI160 inertial measurement unit that provides acceleration
 	  and angular rate measurements.

--- a/dts/bindings/sensor/bosch,bmi160-i2c.yaml
+++ b/dts/bindings/sensor/bosch,bmi160-i2c.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2018, Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+description: BMI160 inertial measurement unit
+
+compatible: "bosch,bmi160"
+
+include: [i2c-device.yaml, "bosch,bmi160.yaml"]

--- a/dts/bindings/sensor/bosch,bmi160-spi.yaml
+++ b/dts/bindings/sensor/bosch,bmi160-spi.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2018, Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+description: BMI160 inertial measurement unit
+
+compatible: "bosch,bmi160"
+
+include: [spi-device.yaml, "bosch,bmi160.yaml"]

--- a/dts/bindings/sensor/bosch,bmi160.yaml
+++ b/dts/bindings/sensor/bosch,bmi160.yaml
@@ -3,10 +3,6 @@
 
 description: BMI160 inertial measurement unit
 
-compatible: "bosch,bmi160"
-
-include: spi-device.yaml
-
 properties:
     int-gpios:
       type: phandle-array


### PR DESCRIPTION
bmi160 driver code supports i2c, but is not selectable by Kconfig
Also, previous yaml supported only spi configuration, so added support for both, depending on dts

Signed-off-by: Avi Green <avigreen1978@yandex.com>