### PR TITLE
net: tcp: Fixed forever loop in tcp_resend_data

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -1126,9 +1126,8 @@ static void tcp_resend_data(struct k_work *work)
 	conn->unacked_len = 0;
 
 	ret = tcp_send_data(conn);
+	conn->send_data_retries++;
 	if (ret == 0) {
-		conn->send_data_retries++;
-
 		if (conn->in_close && conn->send_data_total == 0) {
 			NET_DBG("TCP connection in active close, "
 				"not disposing yet (waiting %dms)",


### PR DESCRIPTION
There is a infinite loop the code can enter when there are no free `net_bufs`.

`ret = tcp_send_data(conn)` can return value `-ENOBUFS`, which is not handled in any way in the current implementation. I propose to increment `conn->send_data_retries` every time after the `tcp_send_data(conn)` is called. That way even if `-ENOBUFS` is returned (which is perfectly acceptable) and the stack remains in the state of not having free `net_bufs`, the resend function can timeout after set amount of `tcp_retries`.