### PR TITLE
cmake: fix DEPENDS issues for kobject hash targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1026,7 +1026,7 @@ if(CONFIG_USERSPACE)
     --rodata ${CONFIG_KOBJECT_RODATA_AREA_EXTRA_BYTES}
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
     DEPENDS
-    kobj_prebuilt_hash_output_lib
+    kobj_prebuilt_hash_output_lib $<TARGET_OBJECTS:kobj_prebuilt_hash_output_lib>
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
 
@@ -1153,7 +1153,7 @@ if(CONFIG_USERSPACE)
   # Use gperf to generate C code (KOBJECT_HASH_OUTPUT_SRC_PRE) which implements a
   # perfect hashtable based on KOBJECT_HASH_LIST
   add_custom_command(
-    OUTPUT ${KOBJECT_HASH_OUTPUT_SRC_PRE}
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${KOBJECT_HASH_OUTPUT_SRC_PRE}
     COMMAND
     ${GPERF}
     --output-file ${KOBJECT_HASH_OUTPUT_SRC_PRE}
@@ -1181,7 +1181,7 @@ if(CONFIG_USERSPACE)
     -o ${KOBJECT_HASH_OUTPUT_SRC}
     -p "struct z_object"
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
-    DEPENDS kobj_hash_output_src_pre ${KOBJECT_HASH_OUTPUT_SRC_PRE}
+    DEPENDS kobj_hash_output_src_pre ${CMAKE_CURRENT_BINARY_DIR}/${KOBJECT_HASH_OUTPUT_SRC_PRE}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
   add_custom_target(
@@ -1224,7 +1224,7 @@ if(CONFIG_USERSPACE)
             $<TARGET_PROPERTY:bintools,elfconvert_flag_infile>$<TARGET_OBJECTS:kobj_hash_output_lib>
             $<TARGET_PROPERTY:bintools,elfconvert_flag_outfile>${KOBJECT_HASH_OUTPUT_OBJ_RENAMED}
             $<TARGET_PROPERTY:bintools,elfconvert_flag_final>
-    DEPENDS kobj_hash_output_lib
+    DEPENDS kobj_hash_output_lib $<TARGET_OBJECTS:kobj_hash_output_lib>
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMAND_EXPAND_LISTS
     )


### PR DESCRIPTION
Fixes: #42184

This commit fixes dependency issues related to kobject hash generation.

Absolute path is ensured in cases where OUTPUT was provided with
absolute path, as `${CMAKE_CURRENT_BINARY_DIR}`.
DEPENDS referring to same file has been updated to also use
`${CMAKE_CURRENT_BINARY_DIR}` to ensure they reference identical
locations.

The custom command renaming sections in kobject_hash.o and creating
kobject_hash_renamed.o has been updated to depends on the target objects
of kobj_hash_output_lib in addition to the library itself.
This is needed because kobj_hash_output_lib is not a real library, and
thus no library is updated when this target rebuilds.
Instead the dependency must be on the object files created by
kobj_hash_outplut_lib. This ensures that when object files gets rebuilt
then the section renaming will also take place.
The reason why both the object library itself, and its object files are
required as dependencies has to do with build generators.
The library is needed to ensure Makefiles can correctly have a target to
invoke when the output of the custom command is missing. The object
files dependency is required to ensure that custom commands are
correctly brought up-to-date when the objects changes.

Similar, the custom command executing gen_kobject_placeholders.py
depending of kobj_prebuilt_hash_output_lib has been updated to also
depend on the object files created by kobj_prebuilt_hash_output_lib.


Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>