### PR TITLE
fs: littlefs: Use flash map macro in automount

### DIFF
--- a/subsys/fs/littlefs_fs.c
+++ b/subsys/fs/littlefs_fs.c
@@ -904,6 +904,7 @@ static const struct fs_file_system_t littlefs_fs = {
 
 #define DT_DRV_COMPAT zephyr_fstab_littlefs
 #define FS_PARTITION(inst) DT_PHANDLE_BY_IDX(DT_DRV_INST(inst), partition, 0)
+#define FS_PARTITION_LABEL(inst) DT_STRING_TOKEN(FS_PARTITION(inst), label)
 
 #define DEFINE_FS(inst) \
 static uint8_t __aligned(4) \
@@ -936,7 +937,7 @@ struct fs_mount_t FS_FSTAB_ENTRY(DT_DRV_INST(inst)) = { \
 	.type = FS_LITTLEFS, \
 	.mnt_point = DT_INST_PROP(inst, mount_point), \
 	.fs_data = &fs_data_##inst, \
-	.storage_dev = (void *)DT_FIXED_PARTITION_ID(FS_PARTITION(inst)), \
+	.storage_dev = (void *)FLASH_AREA_ID(FS_PARTITION_LABEL(inst)), \
 	.flags = FSTAB_ENTRY_DT_MOUNT_FLAGS(DT_DRV_INST(inst)), \
 };
 


### PR DESCRIPTION
To identify the flash partition id, the macro DT_FIXED_PARTITION_ID()
was used previously.

Now the macro FLASH_AREA_ID() is used. This also supports the usecase
when a different flash map implementation is used that redefines the
macros in include/storage/flash_map.h, e.g. the nordic partition
manager.

Signed-off-by: Christian Taedcke <christian.taedcke@lemonbeat.com>