### PR TITLE
drivers: uart_nrfx_uarte: Fix RX auto disabling routine

### DIFF
--- a/tests/drivers/uart/uart_async_api/src/main.c
+++ b/tests/drivers/uart/uart_async_api/src/main.c
@@ -24,6 +24,8 @@ void test_main(void)
 	ztest_test_suite(uart_async_test,
 			 ztest_unit_test(test_single_read_setup),
 			 ztest_user_unit_test(test_single_read),
+			 ztest_unit_test(test_multiple_rx_enable_setup),
+			 ztest_user_unit_test(test_multiple_rx_enable),
 			 ztest_unit_test(test_chained_read_setup),
 			 ztest_user_unit_test(test_chained_read),
 			 ztest_unit_test(test_double_buffer_setup),

--- a/tests/drivers/uart/uart_async_api/src/test_uart.h
+++ b/tests/drivers/uart/uart_async_api/src/test_uart.h
@@ -55,6 +55,7 @@
 void init_test(void);
 
 void test_single_read(void);
+void test_multiple_rx_enable(void);
 void test_chained_read(void);
 void test_double_buffer(void);
 void test_read_abort(void);
@@ -64,6 +65,7 @@ void test_long_buffers(void);
 void test_chained_write(void);
 
 void test_single_read_setup(void);
+void test_multiple_rx_enable_setup(void);
 void test_chained_read_setup(void);
 void test_double_buffer_setup(void);
 void test_read_abort_setup(void);


### PR DESCRIPTION
This is a follow-up to commit 11bbdb030def3b4a4b97ee380b1091913e61d371.

When RX is automatically disabled because all provided RX buffers have
been filled up, the rx_enabled flag needs to be cleared, otherwise it
will be impossible to enable RX again.

Add also a test case that will make sure that UART drivers properly handle disabling
and reenabling of RX in async API.

Fixes #42214.