### PR TITLE
devicetree: clocks: fix a docstring

### DIFF
--- a/include/devicetree/clocks.h
+++ b/include/devicetree/clocks.h
@@ -61,9 +61,8 @@ extern "C" {
 
 /**
  * @brief Get the node identifier for the controller phandle from a
- *        clocks phandle-array property at an index
+ *        clocks phandle-array property by name
  *
-
  * Example devicetree fragment:
  *
  *     clk1: clock-controller@... { ... };


### PR DESCRIPTION
Fix the formatting and what looks like a copy/paste error
in the DT_CLOCKS_CTLR_BY_NAME doxygen docstring.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>