### PR TITLE
Bluetooth: Controller: df: CP bit not cleared in DF conn mode RX 

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -723,7 +723,7 @@ void lll_conn_pdu_tx_prep(struct lll_conn *lll, struct pdu_data **pdu_data_tx)
 		if (lll->packet_tx_head_offset) {
 			p->ll_id = PDU_DATA_LLID_DATA_CONTINUE;
 
-#if defined(CONFIG_BT_CTLR_DF_CONN_CTE_TX)
+#if defined(CONFIG_BT_CTLR_DF_CONN_CTE_TX) || defined(CONFIG_BT_CTLR_DF_CONN_CTE_RX)
 			/* BT 5.3 Core Spec does not define handling of CP bit
 			 * for PDUs fragmented by Controller, hence the CP bit
 			 * is set to zero. The CTE should not be transmitted
@@ -731,7 +731,7 @@ void lll_conn_pdu_tx_prep(struct lll_conn *lll, struct pdu_data **pdu_data_tx)
 			 */
 			p->cp = 0U;
 			p->resv = 0U;
-#endif /* CONFIG_BT_CTLR_DF_CONN_CTE_TX */
+#endif /* CONFIG_BT_CTLR_DF_CONN_CTE_TX || CONFIG_BT_CTLR_DF_CONN_CTE_RX */
 		}
 
 		p->len = lll->packet_tx_head_len - lll->packet_tx_head_offset;
@@ -751,9 +751,9 @@ void lll_conn_pdu_tx_prep(struct lll_conn *lll, struct pdu_data **pdu_data_tx)
 		p->rfu = 0U;
 
 #if !defined(CONFIG_BT_CTLR_DATA_LENGTH_CLEAR)
-#if !defined(CONFIG_BT_CTLR_DF_CONN_CTE_TX)
+#if !defined(CONFIG_BT_CTLR_DF_CONN_CTE_TX) && !defined(CONFIG_BT_CTLR_DF_CONN_CTE_RX)
 		p->resv = 0U;
-#endif /* !CONFIG_BT_CTLR_DF_CONN_CTE_TX */
+#endif /* !CONFIG_BT_CTLR_DF_CONN_CTE_TX && !CONFIG_BT_CTLR_DF_CONN_CTE_RX */
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH_CLEAR */
 	}
 

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -2065,14 +2065,14 @@ uint16_t ull_conn_lll_max_tx_octets_get(struct lll_conn *lll)
 /**
  * @brief Initialize pdu_data members that are read only in lower link layer.
  *
- * @param pdu_tx Pointer to pdu_data object to be initialized
+ * @param pdu Pointer to pdu_data object to be initialized
  */
-void ull_pdu_data_init(struct pdu_data *pdu_tx)
+void ull_pdu_data_init(struct pdu_data *pdu)
 {
-#if defined(CONFIG_BT_CTLR_DF_CONN_CTE_TX)
-	pdu_tx->cp = 0U;
-	pdu_tx->resv = 0U;
-#endif /* CONFIG_BT_CTLR_DF_CONN_CTE_TX */
+#if defined(CONFIG_BT_CTLR_DF_CONN_CTE_TX) || defined(CONFIG_BT_CTLR_DF_CONN_CTE_RX)
+	pdu->cp = 0U;
+	pdu->resv = 0U;
+#endif /* CONFIG_BT_CTLR_DF_CONN_CTE_TX || CONFIG_BT_CTLR_DF_CONN_CTE_RX */
 }
 
 static int init_reset(void)

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_internal.h
@@ -37,7 +37,7 @@ void *ull_conn_ack_dequeue(void);
 void ull_conn_tx_ack(uint16_t handle, memq_link_t *link, struct node_tx *tx);
 uint8_t ull_conn_llcp_req(void *conn);
 
-void ull_pdu_data_init(struct pdu_data *pdu_tx);
+void ull_pdu_data_init(struct pdu_data *pdu);
 
 #if !defined(CONFIG_BT_LL_SW_LLCP_LEGACY)
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -188,10 +188,15 @@ void llcp_tx_alloc_unpeek(struct proc_ctx *ctx)
 
 struct node_tx *llcp_tx_alloc(struct ll_conn *conn, struct proc_ctx *ctx)
 {
+	struct pdu_data *pdu;
 	struct node_tx *tx;
 
 	ARG_UNUSED(conn);
 	tx = (struct node_tx *)mem_acquire(&mem_tx.free);
+
+	pdu = (struct pdu_data *)tx->pdu;
+	ull_pdu_data_init(pdu);
+
 	return tx;
 }
 #endif /* LLCP_TX_CTRL_BUF_QUEUE_ENABLE */


### PR DESCRIPTION
In direction finding connected mode there is a CP bit that is set
data PDU header. The bit was initialized only if CTE transmission
was enabled. In case of reception of a CTE the bit was available
in PDUs but not initialized.
That caused issues in connection maintenance if PDU memory buffers
were reused. PDU were malformed and connections were lost.

There was missing a PDU initialization. CP bit in data channel
PDU heder was not cleared. Also cte_info byte was not crelader.
That lead to malformed control procedures PDUs and issues
with connection maintenance.