### PR TITLE
doc: extensions: doxyrunner: do not modify extension config

### DIFF
--- a/doc/_extensions/zephyr/doxyrunner.py
+++ b/doc/_extensions/zephyr/doxyrunner.py
@@ -185,6 +185,7 @@ def process_doxyfile(
             raise ValueError("Invalid formatting pattern or variables")
 
         if outdir_var:
+            fmt_vars = fmt_vars.copy()
             fmt_vars[outdir_var] = outdir.as_posix()
 
         for var, value in fmt_vars.items():


### PR DESCRIPTION
After the introduction of #41688, doxyrunner extension modifies the
fmt_vars content (from a variable defined in `conf.py`) when the output
directory variable is defined. This means that Sphinx will always get an
outdated environment and so will always perform a full build instead of
an incremental build. This patch makes a copy first to prevent this
situation.