### PR TITLE
tracing: add ram ring buffer backend

### DIFF
--- a/subsys/tracing/CMakeLists.txt
+++ b/subsys/tracing/CMakeLists.txt
@@ -37,6 +37,11 @@ zephyr_sources_ifdef(
   tracing_backend_ram.c
   )
 
+zephyr_sources_ifdef(
+  CONFIG_TRACING_BACKEND_RAM_RING
+  tracing_backend_ram_ring.c
+)
+
 endif()
 
 if(NOT CONFIG_PERCEPIO_TRACERECORDER AND NOT CONFIG_TRACING_CTF

--- a/subsys/tracing/Kconfig
+++ b/subsys/tracing/Kconfig
@@ -161,6 +161,15 @@ config TRACING_BACKEND_RAM
 	  be dumped to a file at runtime with a debugger.
 	  See gdb dump binary memory documentation for example.
 
+config TRACING_BACKEND_RAM_RING
+	bool "Enable RAM ring backend"
+	help
+	  Similar to TRACING_BACKEND_RAM, but older data is dropped
+	  in favor of newer data. GDB can be used to dump data,
+	  see gdb dump binary memory documentation for example.
+
+endchoice
+
 config RAM_TRACING_BUFFER_SIZE
 	int "Ram Tracing buffer size"
 	default 4096
@@ -169,7 +178,13 @@ config RAM_TRACING_BUFFER_SIZE
 	  Size of the RAM trace buffer. Trace will be discarded if the
 	  length is exceeded.
 
-endchoice
+config RAM_RING_TRACING_BUFFER_SIZE
+	int "Ram ring tracing buffer size"
+	default 4096
+	depends on TRACING_BACKEND_RAM_RING
+	help
+	  Size of the RAM ring trace buffer. When full, old data is
+	  discarded to make room for new data.
 
 config TRACING_BACKEND_UART_NAME
 	string "Device Name of UART Device for UART backend"

--- a/subsys/tracing/tracing_backend_ram_ring.c
+++ b/subsys/tracing/tracing_backend_ram_ring.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021 IoT.bzh
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <ctype.h>
+#include <kernel.h>
+#include <string.h>
+#include <tracing_core.h>
+#include <tracing_buffer.h>
+#include <tracing_backend.h>
+
+/*
+ * GDB can be used to dump data with following commands:
+ *
+ * set $start = ram_ring_tracing + ram_ring_tracing_write_head
+ * set $end = ram_ring_tracing + sizeof(ram_ring_tracing)
+ * dump binary memory /tmp/channel0_0.first $start $end
+ * dump binary memory /tmp/channel0_0.second ram_ring_tracing $start
+ */
+static uint8_t ram_ring_tracing[CONFIG_RAM_RING_TRACING_BUFFER_SIZE];
+static uint32_t ram_ring_tracing_write_head;
+
+static void tracing_backend_ram_ring_output(
+	const struct tracing_backend *backend,
+	uint8_t *data, uint32_t length)
+{
+	if (length > sizeof(ram_ring_tracing)) {
+		return;
+	}
+
+	uint32_t remaining_until_end = sizeof(ram_ring_tracing) - ram_ring_tracing_write_head;
+
+	if (length > remaining_until_end) {
+		memcpy(ram_ring_tracing + ram_ring_tracing_write_head, data, remaining_until_end);
+		data += remaining_until_end;
+		length -= remaining_until_end;
+		ram_ring_tracing_write_head = 0;
+	}
+
+	memcpy(ram_ring_tracing + ram_ring_tracing_write_head, data, length);
+	ram_ring_tracing_write_head += length;
+}
+
+static void tracing_backend_ram_ring_init(void)
+{
+	memset(ram_ring_tracing, 0, sizeof(ram_ring_tracing));
+	ram_ring_tracing_write_head = 0;
+}
+
+const struct tracing_backend_api tracing_backend_ram_ring_api = {
+	.init = tracing_backend_ram_ring_init,
+	.output = tracing_backend_ram_ring_output
+};
+
+TRACING_BACKEND_DEFINE(tracing_backend_ram_ring, tracing_backend_ram_ring_api);

--- a/subsys/tracing/tracing_core.c
+++ b/subsys/tracing/tracing_core.c
@@ -29,6 +29,8 @@
 #define TRACING_BACKEND_NAME "tracing_backend_posix"
 #elif defined CONFIG_TRACING_BACKEND_RAM
 #define TRACING_BACKEND_NAME "tracing_backend_ram"
+#elif defined CONFIG_TRACING_BACKEND_RAM_RING
+#define TRACING_BACKEND_NAME "tracing_backend_ram_ring"
 #else
 #define TRACING_BACKEND_NAME ""
 #endif


### PR DESCRIPTION
Adds a new tracing backend which is similar to the existing RAM backend, but new data replaces old. 

This is especially useful when using `CONFIG_TRACING_SYNC=y` and inspecting issues in fault handlers because we always have the most recent events available.

The buffer can be dumped with gdb using:

```
  set $start = ram_ring_tracing + ram_ring_tracing_write_head
  set $end = ram_ring_tracing + sizeof(ram_ring_tracing)
  dump binary memory /tmp/channel0_0.first $start $end
  dump binary memory /tmp/channel0_0.second ram_ring_tracing $start
```

The resulting two files need to be joined together:

```
cat /tmp/channel0_0.first /tmp/channel0_0.second > /tmp/merged_channel0_0
```

Because we're tracking bytes and not actual trace entries, the resulting file can start part way through an entry, and then fail to decode. I use the CTF backend and fix this by skipping between 0 and 31 (`TRACING_PACKET_MAX_SIZE - 1`) bytes at the start of a file until it can be decoded properly.  
