### PR TITLE
tracing: add interrupt number to ctf

### DIFF
--- a/subsys/tracing/ctf/ctf_top.h
+++ b/subsys/tracing/ctf/ctf_top.h
@@ -183,7 +183,14 @@ static inline void ctf_top_thread_name_set(uint32_t thread_id,
 
 static inline void ctf_top_isr_enter(void)
 {
-	CTF_EVENT(CTF_LITERAL(uint8_t, CTF_EVENT_ISR_ENTER));
+	uint32_t interrupt_num;
+#ifdef CONFIG_CPU_CORTEX_M
+	interrupt_num = ((SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) >>
+		     SCB_ICSR_VECTACTIVE_Pos);
+#else
+	interrupt_num = 0;
+#endif
+	CTF_EVENT(CTF_LITERAL(uint8_t, CTF_EVENT_ISR_ENTER), interrupt_num);
 }
 
 static inline void ctf_top_isr_exit(void)

--- a/subsys/tracing/ctf/tsdl/metadata
+++ b/subsys/tracing/ctf/tsdl/metadata
@@ -136,6 +136,9 @@ event {
 event {
 	name = isr_enter;
 	id = 0x1B;
+	fields := struct {
+	    uint32_t interrupt_num;
+	};
 };
 
 event {


### PR DESCRIPTION
Add interrupt number to CTF traces. Copied code in `sysview_get_interrupt` so only works for CORTEX_M, otherwise 0 is used. 