### PR TITLE
drivers: flash: nrf: Support reading secure flash from nonsecure

### DIFF
--- a/drivers/flash/CMakeLists.txt
+++ b/drivers/flash/CMakeLists.txt
@@ -56,6 +56,12 @@ if(CONFIG_SOC_FLASH_STM32)
   endif()
 endif()
 
+if (CONFIG_BUILD_WITH_TFM)
+	zephyr_library_include_directories(
+      $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/install/interface/include
+	  )
+endif()
+
 zephyr_library_include_directories_ifdef(
   CONFIG_FLASH_MCUX_FLEXSPI_NOR
   ${ZEPHYR_BASE}/drivers/memc


### PR DESCRIPTION
Support reading secure flash from nonsecure.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>