### PR TITLE
net: lib: lwm2m: Correct path for update result

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
@@ -129,7 +129,7 @@ void lwm2m_firmware_set_update_state_inst(uint16_t obj_inst_id, uint8_t state)
 			update_state[obj_inst_id], state);
 	}
 
-	snprintf(path, sizeof(path), "5/%" PRIu16 "/3", obj_inst_id);
+	snprintk(path, sizeof(path), "5/%" PRIu16 "/3", obj_inst_id);
 
 	lwm2m_engine_set_u8(path, state);
 
@@ -211,7 +211,7 @@ void lwm2m_firmware_set_update_result_inst(uint16_t obj_inst_id, uint8_t result)
 			result, state);
 	}
 
-	snprintf(path, sizeof(path), "5/%" PRIu16 "/5", obj_inst_id);
+	snprintk(path, sizeof(path), "5/%" PRIu16 "/5", obj_inst_id);
 
 	lwm2m_engine_set_u8(path, result);
 

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
@@ -97,7 +97,7 @@ uint8_t lwm2m_firmware_get_update_state(void)
 void lwm2m_firmware_set_update_state_inst(uint16_t obj_inst_id, uint8_t state)
 {
 	bool error = false;
-	char path[sizeof("5/65535/5")];
+	char path[sizeof("5/65535/3")];
 
 	/* Check LWM2M SPEC appendix E.6.1 */
 	switch (state) {
@@ -211,7 +211,7 @@ void lwm2m_firmware_set_update_result_inst(uint16_t obj_inst_id, uint8_t result)
 			result, state);
 	}
 
-	snprintf(path, sizeof(path), "5/%" PRIu16 "/3", obj_inst_id);
+	snprintf(path, sizeof(path), "5/%" PRIu16 "/5", obj_inst_id);
 
 	lwm2m_engine_set_u8(path, result);
 


### PR DESCRIPTION
The path was erroneously pointing to update stateresource instead of update result causing a wrong
resource value to be updated.

Signed-off-by: Jarno Lamsa <jarno.lamsa@nordicsemi.no>