### PR TITLE
twister: extend verification of test status by checking ztest suite name

### DIFF
--- a/scripts/pylib/twister/harness.py
+++ b/scripts/pylib/twister/harness.py
@@ -32,6 +32,7 @@ class Harness:
         self.fieldnames = []
         self.ztest = False
         self.is_pytest = False
+        self.detected_suite_names = []
 
     def configure(self, instance):
         config = instance.testcase.harness_config
@@ -219,8 +220,15 @@ class Pytest(Harness):
 class Test(Harness):
     RUN_PASSED = "PROJECT EXECUTION SUCCESSFUL"
     RUN_FAILED = "PROJECT EXECUTION FAILED"
+    test_suite_start_pattern = r"Running test suite (?P<suite_name>.*)"
 
     def handle(self, line):
+        test_suite_match = re.search(self.test_suite_start_pattern, line)
+        if test_suite_match:
+            suite_name = test_suite_match.group("suite_name")
+            self.detected_suite_names.append(suite_name)
+            self.ztest = True
+
         match = result_re.match(line)
         if match and match.group(2):
             name = "{}.{}".format(self.id, match.group(3))

--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -1765,9 +1765,8 @@ Tests should reference the category and subsystem with a dot as a separator.
                     )
         return unique
 
-    @staticmethod
-    def scan_file(inf_name):
-        suite_regex = re.compile(
+    def scan_file(self, inf_name):
+        regular_suite_regex = re.compile(
             # do not match until end-of-line, otherwise we won't allow
             # stc_regex below to catch the ones that are declared in the same
             # line--as we only search starting the end of this match
@@ -1776,6 +1775,9 @@ Tests should reference the category and subsystem with a dot as a separator.
         registered_suite_regex = re.compile(
             br"^\s*ztest_register_test_suite"
             br"\(\s*(?P<suite_name>[a-zA-Z0-9_]+)\s*,",
+            re.MULTILINE)
+        new_suite_regex = re.compile(
+            br"^\s*ZTEST_SUITE\(\s*(?P<suite_name>[a-zA-Z0-9_]+)\s*,",
             re.MULTILINE)
         # Checks if the file contains a definition of "void test_main(void)"
         # Since ztest provides a plain test_main implementation it is OK to:
@@ -1786,35 +1788,11 @@ Tests should reference the category and subsystem with a dot as a separator.
         test_main_regex = re.compile(
             br"^\s*void\s+test_main\(void\)",
             re.MULTILINE)
-        stc_regex = re.compile(
-            br"""^\s*  # empty space at the beginning is ok
-            # catch the case where it is declared in the same sentence, e.g:
-            #
-            # ztest_test_suite(mutex_complex, ztest_user_unit_test(TESTNAME));
-            # ztest_register_test_suite(n, p, ztest_user_unit_test(TESTNAME),
-            (?:ztest_
-              (?:test_suite\(|register_test_suite\([a-zA-Z0-9_]+\s*,\s*)
-              [a-zA-Z0-9_]+\s*,\s*
-            )?
-            # Catch ztest[_user]_unit_test-[_setup_teardown](TESTNAME)
-            ztest_(?:1cpu_)?(?:user_)?unit_test(?:_setup_teardown)?
-            # Consume the argument that becomes the extra testcase
-            \(\s*(?P<stc_name>[a-zA-Z0-9_]+)
-            # _setup_teardown() variant has two extra arguments that we ignore
-            (?:\s*,\s*[a-zA-Z0-9_]+\s*,\s*[a-zA-Z0-9_]+)?
-            \s*\)""",
-            # We don't check how it finishes; we don't care
-            re.MULTILINE | re.VERBOSE)
-        suite_run_regex = re.compile(
-            br"^\s*ztest_run_test_suite\((?P<suite_name>[a-zA-Z0-9_]+)\)",
-            re.MULTILINE)
         registered_suite_run_regex = re.compile(
             br"^\s*ztest_run_registered_test_suites\("
             br"(\*+|&)?(?P<state_identifier>[a-zA-Z0-9_]+)\)",
             re.MULTILINE)
-        achtung_regex = re.compile(
-            br"(#ifdef|#endif)",
-            re.MULTILINE)
+
         warnings = None
         has_registered_test_suites = False
         has_run_registered_test_suites = False
@@ -1828,10 +1806,12 @@ Tests should reference the category and subsystem with a dot as a separator.
                              'offset': 0}
 
             with contextlib.closing(mmap.mmap(**mmap_args)) as main_c:
-                suite_regex_matches = \
-                    [m for m in suite_regex.finditer(main_c)]
+                regular_suite_regex_matches = \
+                    [m for m in regular_suite_regex.finditer(main_c)]
                 registered_suite_regex_matches = \
                     [m for m in registered_suite_regex.finditer(main_c)]
+                new_suite_regex_matches = \
+                    [m for m in new_suite_regex.finditer(main_c)]
 
                 if registered_suite_regex_matches:
                     has_registered_test_suites = True
@@ -1840,58 +1820,140 @@ Tests should reference the category and subsystem with a dot as a separator.
                 if test_main_regex.search(main_c):
                     has_test_main = True
 
-                if not suite_regex_matches and not has_registered_test_suites:
+                if regular_suite_regex_matches:
+                    ztest_suite_names = \
+                        self._extract_ztest_suite_names(regular_suite_regex_matches)
+                    testcase_names, warnings = \
+                        self._find_regular_ztest_testcases(main_c, regular_suite_regex_matches, has_registered_test_suites)
+                elif registered_suite_regex_matches:
+                    ztest_suite_names = \
+                        self._extract_ztest_suite_names(registered_suite_regex_matches)
+                    testcase_names, warnings = \
+                        self._find_regular_ztest_testcases(main_c, registered_suite_regex_matches, has_registered_test_suites)
+                elif new_suite_regex_matches:
+                    ztest_suite_names = \
+                        self._extract_ztest_suite_names(new_suite_regex_matches)
+                    testcase_names, warnings = \
+                        self._find_new_ztest_testcases(main_c)
+                else:
                     # can't find ztest_test_suite, maybe a client, because
                     # it includes ztest.h
-                    return ScanPathResult(
-                        matches=None,
-                        warnings=None,
-                        has_registered_test_suites=has_registered_test_suites,
-                        has_run_registered_test_suites=has_run_registered_test_suites,
-                        has_test_main=has_test_main,
-                        ztest_suite_names=[])
+                    ztest_suite_names = []
+                    testcase_names, warnings = None, None
 
-                suite_run_match = suite_run_regex.search(main_c)
-                if suite_regex_matches and not suite_run_match:
-                    raise ValueError("can't find ztest_run_test_suite")
-
-                if suite_regex_matches:
-                    search_start = suite_regex_matches[0].end()
-                    ztest_suite_names = \
-                        [m.group("suite_name") for m in suite_regex_matches]
-                else:
-                    search_start = registered_suite_regex_matches[0].end()
-                    ztest_suite_names = \
-                        [m.group("suite_name") for m in registered_suite_regex_matches]
-                ztest_suite_names = \
-                    [name.decode("UTF-8") for name in ztest_suite_names]
-
-                if suite_run_match:
-                    search_end = suite_run_match.start()
-                else:
-                    search_end = re.compile(br"\);", re.MULTILINE) \
-                        .search(main_c, search_start) \
-                        .end()
-                achtung_matches = re.findall(
-                    achtung_regex,
-                    main_c[search_start:search_end])
-                if achtung_matches:
-                    warnings = "found invalid %s in ztest_test_suite()" \
-                               % ", ".join(sorted({match.decode() for match in achtung_matches},reverse = True))
-                _matches = re.findall(
-                    stc_regex,
-                    main_c[search_start:search_end])
-                for match in _matches:
-                    if not match.decode().startswith("test_"):
-                        warnings = "Found a test that does not start with test_"
-                matches = [match.decode().replace("test_", "", 1) for match in _matches]
                 return ScanPathResult(
-                    matches=matches,
+                    matches=testcase_names,
                     warnings=warnings,
                     has_registered_test_suites=has_registered_test_suites,
                     has_run_registered_test_suites=has_run_registered_test_suites,
                     has_test_main=has_test_main,
                     ztest_suite_names=ztest_suite_names)
+
+    @staticmethod
+    def _extract_ztest_suite_names(suite_regex_matches):
+        ztest_suite_names = \
+            [m.group("suite_name") for m in suite_regex_matches]
+        ztest_suite_names = \
+            [name.decode("UTF-8") for name in ztest_suite_names]
+        return ztest_suite_names
+
+    def _find_regular_ztest_testcases(self, search_area, suite_regex_matches, is_registered_test_suite):
+        """
+        Find regular ztest testcases like "ztest_unit_test" or similar. Return
+        testcases' names and eventually found warnings.
+        """
+        testcase_regex = re.compile(
+            br"""^\s*  # empty space at the beginning is ok
+            # catch the case where it is declared in the same sentence, e.g:
+            #
+            # ztest_test_suite(mutex_complex, ztest_user_unit_test(TESTNAME));
+            # ztest_register_test_suite(n, p, ztest_user_unit_test(TESTNAME),
+            (?:ztest_
+              (?:test_suite\(|register_test_suite\([a-zA-Z0-9_]+\s*,\s*)
+              [a-zA-Z0-9_]+\s*,\s*
+            )?
+            # Catch ztest[_user]_unit_test-[_setup_teardown](TESTNAME)
+            ztest_(?:1cpu_)?(?:user_)?unit_test(?:_setup_teardown)?
+            # Consume the argument that becomes the extra testcase
+            \(\s*(?P<testcase_name>[a-zA-Z0-9_]+)
+            # _setup_teardown() variant has two extra arguments that we ignore
+            (?:\s*,\s*[a-zA-Z0-9_]+\s*,\s*[a-zA-Z0-9_]+)?
+            \s*\)""",
+            # We don't check how it finishes; we don't care
+            re.MULTILINE | re.VERBOSE)
+        achtung_regex = re.compile(
+            br"(#ifdef|#endif)",
+            re.MULTILINE)
+
+        search_start, search_end = \
+            self._get_search_area_boundary(search_area, suite_regex_matches, is_registered_test_suite)
+        limited_search_area = search_area[search_start:search_end]
+        testcase_names, warnings = \
+            self._find_ztest_testcases(limited_search_area, testcase_regex)
+
+        achtung_matches = re.findall(achtung_regex, limited_search_area)
+        if achtung_matches and warnings is None:
+            achtung = ", ".join(sorted({match.decode() for match in achtung_matches},reverse = True))
+            warnings = f"found invalid {achtung} in ztest_test_suite()"
+
+        return testcase_names, warnings
+
+    @staticmethod
+    def _get_search_area_boundary(search_area, suite_regex_matches, is_registered_test_suite):
+        """
+        Get search area boundary based on "ztest_test_suite(...)",
+        "ztest_register_test_suite(...)" or "ztest_run_test_suite(...)"
+        functions occurrence.
+        """
+        suite_run_regex = re.compile(
+            br"^\s*ztest_run_test_suite\((?P<suite_name>[a-zA-Z0-9_]+)\)",
+            re.MULTILINE)
+
+        search_start = suite_regex_matches[0].end()
+
+        suite_run_match = suite_run_regex.search(search_area)
+        if suite_run_match:
+            search_end = suite_run_match.start()
+        elif not suite_run_match and not is_registered_test_suite:
+            raise ValueError("can't find ztest_run_test_suite")
+        else:
+            search_end = re.compile(br"\);", re.MULTILINE) \
+                .search(search_area, search_start) \
+                .end()
+
+        return search_start, search_end
+
+    def _find_new_ztest_testcases(self, search_area):
+        """
+        Find regular ztest testcases like "ZTEST" or "ZTEST_F". Return
+        testcases' names and eventually found warnings.
+        """
+        testcase_regex = re.compile(
+            br"^\s*(?:ZTEST|ZTEST_F)\(\s*(?P<suite_name>[a-zA-Z0-9_]+)\s*,"
+            br"\s*(?P<testcase_name>[a-zA-Z0-9_]+)\s*",
+            re.MULTILINE)
+
+        return self._find_ztest_testcases(search_area, testcase_regex)
+
+    @staticmethod
+    def _find_ztest_testcases(search_area, testcase_regex):
+        """
+        Parse search area and try to find testcases defined in testcase_regex
+        argument. Return testcase names and eventually found warnings.
+        """
+        testcase_regex_matches = \
+            [m for m in testcase_regex.finditer(search_area)]
+        testcase_names = \
+            [m.group("testcase_name") for m in testcase_regex_matches]
+        testcase_names = [name.decode("UTF-8") for name in testcase_names]
+        warnings = None
+        for testcase_name in testcase_names:
+            if not testcase_name.startswith("test_"):
+                warnings = "Found a test that does not start with test_"
+        testcase_names = \
+            [tc_name.replace("test_", "", 1) for tc_name in testcase_names]
+
+        return testcase_names, warnings
 
     def scan_path(self, path):
         subcases = []

--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -466,6 +466,45 @@ class Handler:
                 harness_testcase_result_skip in self.instance.results.values():
             self.instance.reason = "ztest skip"
 
+    def _verify_ztest_suite_name(self, harness_state, detected_suite_names, handler_time):
+        """
+        If test suite names was found in test's C source code, then verify if
+        detected suite names from output correspond to expected suite names
+        (and not in reverse).
+        """
+        expected_suite_names = self.instance.testcase.ztest_suite_names
+        if not expected_suite_names or \
+                not harness_state == "passed":
+            return
+        if not detected_suite_names:
+            self._missing_suite_name(expected_suite_names, handler_time)
+        for detected_suite_name in detected_suite_names:
+            if detected_suite_name not in expected_suite_names:
+                self._missing_suite_name(expected_suite_names, handler_time)
+                break
+
+    def _missing_suite_name(self, expected_suite_names, handler_time):
+        """
+        Change result of performed test if problem with missing or unpropper
+        suite name was occurred.
+        """
+        self.set_state("failed", handler_time)
+        for k in self.instance.testcase.cases:
+            self.instance.results[k] = "FAIL"
+        self.instance.reason = f"Testsuite mismatch"
+        logger.debug("Test suite names were not printed or some of them in " \
+                     "output do not correspond with expected: %s",
+                     str(expected_suite_names))
+
+    def _final_handle_actions(self, harness, handler_time):
+        self._set_skip_reason(harness.state)
+
+        harness_class_name = type(harness).__name__
+        if harness_class_name == "Test":  # only for ZTest tests
+            self._verify_ztest_suite_name(harness.state, harness.detected_suite_names, handler_time)
+
+        self.record(harness)
+
 
 class BinaryHandler(Handler):
     def __init__(self, instance, type_str):
@@ -622,9 +661,7 @@ class BinaryHandler(Handler):
             self.instance.reason = "Timeout"
             self.add_missing_testscases(harness)
 
-        self._set_skip_reason(harness.state)
-
-        self.record(harness)
+        self._final_handle_actions(harness, handler_time)
 
 
 class DeviceHandler(Handler):
@@ -922,13 +959,12 @@ class DeviceHandler(Handler):
         else:
             self.set_state(out_state, handler_time)
 
-        self._set_skip_reason(harness.state)
+        self._final_handle_actions(harness, handler_time)
 
         if post_script:
             self.run_custom_script(post_script, 30)
 
         self.make_device_available(serial_device)
-        self.record(harness)
 
 
 class QEMUHandler(Handler):
@@ -1080,8 +1116,6 @@ class QEMUHandler(Handler):
             harness.pytest_run(logfile)
             out_state = harness.state
 
-        handler.record(harness)
-
         handler_time = time.time() - start_time
         logger.debug(f"QEMU ({pid}) complete ({out_state}) after {handler_time} seconds")
 
@@ -1192,7 +1226,7 @@ class QEMUHandler(Handler):
                 self.instance.reason = "Exited with {}".format(self.returncode)
             self.add_missing_testscases(harness)
 
-        self._set_skip_reason(harness.state)
+        self._final_handle_actions(harness, 0)
 
     def get_fifo(self):
         return self.fifo_fn
@@ -1622,18 +1656,21 @@ class ScanPathResult:
                                          ztest_run_registered_test_suites.
         has_test_main                    Whether or not the path contains a
                                          definition of test_main(void)
+        ztest_suite_names                Names of found ztest suites
     """
     def __init__(self,
                  matches: List[str] = None,
                  warnings: str = None,
                  has_registered_test_suites: bool = False,
                  has_run_registered_test_suites: bool = False,
-                 has_test_main: bool = False):
+                 has_test_main: bool = False,
+                 ztest_suite_names: List[str] = []):
         self.matches = matches
         self.warnings = warnings
         self.has_registered_test_suites = has_registered_test_suites
         self.has_run_registered_test_suites = has_run_registered_test_suites
         self.has_test_main = has_test_main
+        self.ztest_suite_names = ztest_suite_names
 
     def __eq__(self, other):
         if not isinstance(other, ScanPathResult):
@@ -1644,7 +1681,9 @@ class ScanPathResult:
                  other.has_registered_test_suites) and
                 (self.has_run_registered_test_suites ==
                  other.has_run_registered_test_suites) and
-                self.has_test_main == other.has_test_main)
+                self.has_test_main == other.has_test_main and
+                (sorted(self.ztest_suite_names) ==
+                 sorted(other.ztest_suite_names)))
 
 
 class TestCase(DisablePyTestCollectionMixin):
@@ -1702,6 +1741,7 @@ class TestCase(DisablePyTestCollectionMixin):
         self.min_flash = -1
         self.extra_sections = None
         self.integration_platforms = []
+        self.ztest_suite_names = []
 
     @staticmethod
     def get_unique(testcase_root, workdir, name):
@@ -1788,18 +1828,19 @@ Tests should reference the category and subsystem with a dot as a separator.
                              'offset': 0}
 
             with contextlib.closing(mmap.mmap(**mmap_args)) as main_c:
-                suite_regex_match = suite_regex.search(main_c)
-                registered_suite_regex_match = registered_suite_regex.search(
-                    main_c)
+                suite_regex_matches = \
+                    [m for m in suite_regex.finditer(main_c)]
+                registered_suite_regex_matches = \
+                    [m for m in registered_suite_regex.finditer(main_c)]
 
-                if registered_suite_regex_match:
+                if registered_suite_regex_matches:
                     has_registered_test_suites = True
                 if registered_suite_run_regex.search(main_c):
                     has_run_registered_test_suites = True
                 if test_main_regex.search(main_c):
                     has_test_main = True
 
-                if not suite_regex_match and not has_registered_test_suites:
+                if not suite_regex_matches and not has_registered_test_suites:
                     # can't find ztest_test_suite, maybe a client, because
                     # it includes ztest.h
                     return ScanPathResult(
@@ -1807,16 +1848,23 @@ Tests should reference the category and subsystem with a dot as a separator.
                         warnings=None,
                         has_registered_test_suites=has_registered_test_suites,
                         has_run_registered_test_suites=has_run_registered_test_suites,
-                        has_test_main=has_test_main)
+                        has_test_main=has_test_main,
+                        ztest_suite_names=[])
 
                 suite_run_match = suite_run_regex.search(main_c)
-                if suite_regex_match and not suite_run_match:
+                if suite_regex_matches and not suite_run_match:
                     raise ValueError("can't find ztest_run_test_suite")
 
-                if suite_regex_match:
-                    search_start = suite_regex_match.end()
+                if suite_regex_matches:
+                    search_start = suite_regex_matches[0].end()
+                    ztest_suite_names = \
+                        [m.group("suite_name") for m in suite_regex_matches]
                 else:
-                    search_start = registered_suite_regex_match.end()
+                    search_start = registered_suite_regex_matches[0].end()
+                    ztest_suite_names = \
+                        [m.group("suite_name") for m in registered_suite_regex_matches]
+                ztest_suite_names = \
+                    [name.decode("UTF-8") for name in ztest_suite_names]
 
                 if suite_run_match:
                     search_end = suite_run_match.start()
@@ -1842,13 +1890,16 @@ Tests should reference the category and subsystem with a dot as a separator.
                     warnings=warnings,
                     has_registered_test_suites=has_registered_test_suites,
                     has_run_registered_test_suites=has_run_registered_test_suites,
-                    has_test_main=has_test_main)
+                    has_test_main=has_test_main,
+                    ztest_suite_names=ztest_suite_names)
 
     def scan_path(self, path):
         subcases = []
         has_registered_test_suites = False
         has_run_registered_test_suites = False
         has_test_main = False
+        ztest_suite_names = []
+
         for filename in glob.glob(os.path.join(path, "src", "*.c*")):
             try:
                 result: ScanPathResult = self.scan_file(filename)
@@ -1864,6 +1915,9 @@ Tests should reference the category and subsystem with a dot as a separator.
                     has_run_registered_test_suites = True
                 if result.has_test_main:
                     has_test_main = True
+                if result.ztest_suite_names:
+                    ztest_suite_names += result.ztest_suite_names
+
             except ValueError as e:
                 logger.error("%s: can't find: %s" % (filename, e))
 
@@ -1874,6 +1928,8 @@ Tests should reference the category and subsystem with a dot as a separator.
                     logger.error("%s: %s" % (filename, result.warnings))
                 if result.matches:
                     subcases += result.matches
+                if result.ztest_suite_names:
+                    ztest_suite_names += result.ztest_suite_names
             except ValueError as e:
                 logger.error("%s: can't find: %s" % (filename, e))
 
@@ -1885,16 +1941,18 @@ Tests should reference the category and subsystem with a dot as a separator.
             logger.error(warning)
             raise TwisterRuntimeError(warning)
 
-        return subcases
+        return subcases, ztest_suite_names
 
     def parse_subcases(self, test_path):
-        results = self.scan_path(test_path)
-        for sub in results:
+        subcases, ztest_suite_names = self.scan_path(test_path)
+        for sub in subcases:
             name = "{}.{}".format(self.id, sub)
             self.cases.append(name)
 
-        if not results:
+        if not subcases:
             self.cases.append(self.id)
+
+        self.ztest_suite_names = ztest_suite_names
 
     def __str__(self):
         return self.name

--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -1900,7 +1900,8 @@ Tests should reference the category and subsystem with a dot as a separator.
         has_test_main = False
         ztest_suite_names = []
 
-        for filename in glob.glob(os.path.join(path, "src", "*.c*")):
+        src_dir_path = self._find_src_dir_path(path)
+        for filename in glob.glob(os.path.join(src_dir_path, "*.c*")):
             try:
                 result: ScanPathResult = self.scan_file(filename)
                 if result.warnings:
@@ -1953,6 +1954,21 @@ Tests should reference the category and subsystem with a dot as a separator.
             self.cases.append(self.id)
 
         self.ztest_suite_names = ztest_suite_names
+
+    @staticmethod
+    def _find_src_dir_path(test_dir_path):
+        """
+        Try to find src directory with test source code. Sometimes due to the
+        optimization reasons it is placed in upper directory.
+        """
+        src_dir_name = "src"
+        src_dir_path = os.path.join(test_dir_path, src_dir_name)
+        if os.path.isdir(src_dir_path):
+            return src_dir_path
+        src_dir_path = os.path.join(test_dir_path, "..", src_dir_name)
+        if os.path.isdir(src_dir_path):
+            return src_dir_path
+        return ""
 
     def __str__(self):
         return self.name

--- a/scripts/tests/twister/test_testinstance.py
+++ b/scripts/tests/twister/test_testinstance.py
@@ -124,27 +124,31 @@ TESTDATA_5 = [
                   'user', 'last'],
          has_registered_test_suites=False,
          has_run_registered_test_suites=False,
-         has_test_main=False)),
+         has_test_main=False,
+         ztest_suite_names = ["test_api"])),
     ("testcases/tests/test_a/test_ztest_error.c",
      ScanPathResult(
          warnings="Found a test that does not start with test_",
          matches=['1a', '1c', '2a', '2b'],
          has_registered_test_suites=False,
          has_run_registered_test_suites=False,
-         has_test_main=True)),
+         has_test_main=True,
+         ztest_suite_names = ["feature1", "feature2"])),
     ("testcases/tests/test_a/test_ztest_error_1.c",
      ScanPathResult(
          warnings="found invalid #ifdef, #endif in ztest_test_suite()",
          matches=['unit_1a', 'unit_1b', 'Unit_1c'],
          has_registered_test_suites=False,
          has_run_registered_test_suites=False,
-         has_test_main=False)),
+         has_test_main=False,
+         ztest_suite_names = ["feature3"])),
     ("testcases/tests/test_d/test_ztest_error_register_test_suite.c",
      ScanPathResult(
          warnings=None, matches=['unit_1a', 'unit_1b'],
          has_registered_test_suites=True,
          has_run_registered_test_suites=False,
-         has_test_main=False)),
+         has_test_main=False,
+         ztest_suite_names = ["feature4"])),
 ]
 
 @pytest.mark.parametrize("test_file, expected", TESTDATA_5)
@@ -159,17 +163,26 @@ def test_scan_file(test_data, test_file, expected: ScanPathResult):
 
 
 TESTDATA_6 = [
-    ("testcases/tests", ['a', 'c', 'unit_a', 'newline', 'test_test_aa', 'user', 'last']),
-    ("testcases/tests/test_a", ['unit_1a', 'unit_1b', 'Unit_1c', '1a', '1c', '2a', '2b']),
+    (
+        "testcases/tests",
+        ['a', 'c', 'unit_a', 'newline', 'test_test_aa', 'user', 'last'],
+        ["test_api"]
+    ),
+    (
+        "testcases/tests/test_a",
+        ['unit_1a', 'unit_1b', 'Unit_1c', '1a', '1c', '2a', '2b'],
+        ["feature3", "feature1", "feature2"]
+    ),
 ]
 
-@pytest.mark.parametrize("test_path, expected_subcases", TESTDATA_6)
-def test_subcases(test_data, test_path, expected_subcases):
+@pytest.mark.parametrize("test_path, expected_subcases, expected_ztest_suite_names", TESTDATA_6)
+def test_subcases(test_data, test_path, expected_subcases, expected_ztest_suite_names):
     '''Testing scan path and parse subcases methods for expected subcases'''
     testcase = TestCase("/scripts/tests/twister/test_data/testcases/tests", ".", "test_a.check_1")
 
-    subcases = testcase.scan_path(os.path.join(test_data, test_path))
+    subcases, ztest_suite_names = testcase.scan_path(os.path.join(test_data, test_path))
     assert sorted(subcases) == sorted(expected_subcases)
+    assert sorted(ztest_suite_names) == sorted(expected_ztest_suite_names)
 
     testcase.id = "test_id"
     testcase.parse_subcases(test_data + test_path)


### PR DESCRIPTION
Test wirtten in ztest framework should print in output information about test suite name defined in test's source code (as a first argument of ztest_test_suite() function). Changes proposed in this PR make it possible to find such
test names in c files. Next they are used during test execution to verify if performed test was performed properly (verification can base not only on existance of "PROJECT EXECUTION SUCCESSFUL" info). 

So for example if test suites definition looks like this in file `tests/lib/gui/lvgl/src/main.c`:
```
ztest_test_suite(lvgl_screen, ztest_unit_test(test_get_default_screen),
	ztest_unit_test(test_add_delete_screen));
ztest_test_suite(lvgl_fs, ztest_user_unit_test_setup_teardown(
		test_add_img, setup_fs, teardown_fs));
```
Then Twister after parsing this file it will save defined ztest test suite names as `["lvgl_screen", "lvgl_fs"]`. Next during test execution harness will try to detect `"Running test suite (?P<suite_name>.*)"` regex in output, and save detected `suite_name` in `detected_suite_names` list. 

At the end if test has status pass and if expected test suite names list is not empty there is additionally verification if detected suite names correspond to expected ones.

I also tested this solution in situation when test suites are defined like this in file `tests/subsys/logging/log_core_additional/src/log_test.c` with `#ifdef` macro:
```
#ifdef CONFIG_USERSPACE
	ztest_test_suite(test_log_core_additional,
			 ztest_user_unit_test(test_log_from_user),
			 ztest_user_unit_test(test_log_hexdump_from_user),
			 ztest_user_unit_test(test_log_generic_user),
			 ztest_user_unit_test(test_log_filter_set),
			 ztest_user_unit_test(test_log_panic),
			 ztest_user_unit_test(test_log_msg2_create_user));
	ztest_run_test_suite(test_log_core_additional);
#else
	ztest_test_suite(test_log_core_additional,
			 ztest_unit_test(test_multiple_backends),
			 ztest_unit_test(test_log_generic),
			 ztest_unit_test(test_log_domain_id),
			 ztest_unit_test(test_log_severity),
			 ztest_unit_test(test_log_timestamping),
			 ztest_unit_test(test_log_early_logging),
			 ztest_unit_test(test_log_sync),
			 ztest_unit_test(test_log_thread),
			 ztest_unit_test(test_log_msg2_create)
			 );
	ztest_run_test_suite(test_log_core_additional);
#endif
```
In this situation c file parser will detect two test suites (they can have not the same name), but during execution test only one of them will be performed. Due to that fact I do not verify if all test suite names detected in c file will occur in output, but I rather verify if printed test suite name occur in expected suite names. I know that this is not ideal solution, but it will help to avoid situation when some test suite is intentionally skipped (by `#ifdef` macro) and even so Twister will assign to this test fail status. I described it also in added `_verify_ztest_suite_name` method's doc string.

As an effect of my changes situation described by @nvlsianpu in this issue: https://github.com/zephyrproject-rtos/zephyr/issues/42396 could be detected much more earlier.
With those proposed changes after run Twister by command:
```
scripts/twister --json-report -p native_posix -T tests/subsys/settings/functional/nvs/
```
The output from `native_posix` is like this:
```
2022-02-04 12:05:24,498 - twister - DEBUG - OUTPUT: *** Booting Zephyr OS build v3.0.0-rc1-234-g372a9f4918e5  ***
2022-02-04 12:05:24,499 - twister - DEBUG - OUTPUT: ===================================================================
2022-02-04 12:05:24,499 - twister - DEBUG - OUTPUT: PROJECT EXECUTION SUCCESSFUL
```
But the result in report is marked as fail with proper comment:
`twister.json` report:
```
{
    "testcase":"system.settings.functional.nvs.clear_settings",
    "arch":"posix",
    "platform":"native_posix",
    "status":"failed",
    "reason":"Test suite names were not printed or some of them in output do not correspond with expected: ['settings_test_suite']",
    "execution_time":2.007908821105957,
    "test_output":"*** Booting Zephyr OS build v3.0.0-rc1-234-g372a9f4918e5  ***\n===================================================================\nPROJECT EXECUTION SUCCESSFUL\n"
},
```
`twister_report.xml` report:
```
<testcase classname="system.settings" name="system.settings.functional.nvs.clear_settings" time="2.007909">
<failure type="failure" message="failed">
*** Booting Zephyr OS build v3.0.0-rc1-234-g372a9f4918e5 *** =================================================================== PROJECT EXECUTION SUCCESSFUL
</failure>
</testcase>
```

During adding this feature I also discover, that `scan_path` method in `TestCase` class in some cases wrongly choses `src` folder (with test source code). For example in those tests:

> tests/subsys/settings/fcb/raw
> tests/subsys/settings/littlefs/raw
> tests/subsys/settings/littlefs/base64
> tests/subsys/settings/nvs/raw
> tests/subsys/settings/functional/file
> tests/subsys/settings/functional/fcb
> tests/subsys/settings/functional/nvs

`src` folder is placed in "parent" directory (in context of `testcase.yaml` place). I add possibilities to detected such situation and correctly recognize `src` place. It should be discussed if in such situations occurrence of `src` directory should be unified, to be more predictable. Especially discussion about it should be conducted in case of this test (and its `src` directory placement): `tests/bluetooth/df` which also is problematic for Twister's c file parsing.

Moreover I also observed, that Twister is not prepared for parsing new ztest API available here:
`subsys/testsuite/ztest/src/ztest_new.c`
`subsys/testsuite/ztest/include/ztest_test_new.h`
I added special method for proper parsing of this API (`ZTEST_SUITE`, `ZTEST` and `ZTEST_F`)