### PR TITLE
BAP unicast group add/remove streams

### DIFF
--- a/include/bluetooth/audio/audio.h
+++ b/include/bluetooth/audio/audio.h
@@ -982,13 +982,14 @@ struct bt_audio_unicast_server_cb {
 	 *  be enabled to stream.
 	 *
 	 *  @param stream      Stream object being enabled.
-	 *  @param meta_count  Number of metadata entries
 	 *  @param meta        Metadata entries
+	 *  @param meta_count  Number of metadata entries
 	 *
 	 *  @return 0 in case of success or negative value in case of error.
 	 */
-	int (*enable)(struct bt_audio_stream *stream, size_t meta_count,
-		      const struct bt_codec_data *meta);
+	int (*enable)(struct bt_audio_stream *stream,
+		      const struct bt_codec_data *meta,
+		      size_t meta_count);
 
 	/** @brief Stream Start request callback
 	 *
@@ -1007,13 +1008,14 @@ struct bt_audio_unicast_server_cb {
 	 *  update its metadata.
 	 *
 	 *  @param stream       Stream object.
-	 *  @param meta_count   Number of metadata entries
 	 *  @param meta         Metadata entries
+	 *  @param meta_count   Number of metadata entries
 	 *
 	 *  @return 0 in case of success or negative value in case of error.
 	 */
-	int (*metadata)(struct bt_audio_stream *stream, size_t meta_count,
-			const struct bt_codec_data *meta);
+	int (*metadata)(struct bt_audio_stream *stream,
+			const struct bt_codec_data *meta,
+			size_t meta_count);
 
 	/** @brief Stream Disable request callback
 	 *
@@ -1410,7 +1412,8 @@ int bt_audio_stream_qos(struct bt_conn *conn,
  *  @return 0 in case of success or negative value in case of error.
  */
 int bt_audio_stream_enable(struct bt_audio_stream *stream,
-			   size_t meta_count, struct bt_codec_data *meta);
+			   struct bt_codec_data *meta,
+			   size_t meta_count);
 
 /** @brief Change Audio Stream Metadata
  *
@@ -1423,7 +1426,8 @@ int bt_audio_stream_enable(struct bt_audio_stream *stream,
  *  @return 0 in case of success or negative value in case of error.
  */
 int bt_audio_stream_metadata(struct bt_audio_stream *stream,
-			     size_t meta_count, struct bt_codec_data *meta);
+			     struct bt_codec_data *meta,
+			     size_t meta_count);
 
 /** @brief Disable Audio Stream
  *

--- a/include/bluetooth/audio/audio.h
+++ b/include/bluetooth/audio/audio.h
@@ -206,11 +206,11 @@ struct bt_codec {
 	/** Codec Company Vendor ID */
 	uint16_t vid;
 	/** Codec Specific Data count */
-	uint8_t  data_count;
+	size_t   data_count;
 	/** Codec Specific Data */
 	struct bt_codec_data data[CONFIG_BT_CODEC_MAX_DATA_COUNT];
 	/** Codec Specific Metadata count */
-	uint8_t  meta_count;
+	size_t   meta_count;
 	/** Codec Specific Metadata */
 	struct bt_codec_data meta[CONFIG_BT_CODEC_MAX_METADATA_COUNT];
 };
@@ -222,7 +222,7 @@ struct bt_audio_base_bis_data {
 	 *
 	 *  Only valid if the data_count of struct bt_codec in the subgroup is 0
 	 */
-	uint8_t  data_count;
+	size_t   data_count;
 	/** Codec Specific Data
 	 *
 	 *  Only valid if the data_count of struct bt_codec in the subgroup is 0
@@ -232,7 +232,7 @@ struct bt_audio_base_bis_data {
 
 struct bt_audio_base_subgroup {
 	/* Number of BIS in the subgroup */
-	uint8_t bis_count;
+	size_t bis_count;
 	/** Codec information for the subgroup
 	 *
 	 *  If the data_count of the codec is 0, then codec specific data may be
@@ -245,7 +245,7 @@ struct bt_audio_base_subgroup {
 
 struct bt_audio_base {
 	/* Number of subgroups in the BASE */
-	uint8_t subgroup_count;
+	size_t subgroup_count;
 	/* Array of subgroups in the BASE */
 	struct bt_audio_base_subgroup subgroups[BROADCAST_SUBGROUP_CNT];
 };
@@ -987,7 +987,7 @@ struct bt_audio_unicast_server_cb {
 	 *
 	 *  @return 0 in case of success or negative value in case of error.
 	 */
-	int (*enable)(struct bt_audio_stream *stream, uint8_t meta_count,
+	int (*enable)(struct bt_audio_stream *stream, size_t meta_count,
 		      const struct bt_codec_data *meta);
 
 	/** @brief Stream Start request callback
@@ -1012,7 +1012,7 @@ struct bt_audio_unicast_server_cb {
 	 *
 	 *  @return 0 in case of success or negative value in case of error.
 	 */
-	int (*metadata)(struct bt_audio_stream *stream, uint8_t meta_count,
+	int (*metadata)(struct bt_audio_stream *stream, size_t meta_count,
 			const struct bt_codec_data *meta);
 
 	/** @brief Stream Disable request callback
@@ -1410,7 +1410,7 @@ int bt_audio_stream_qos(struct bt_conn *conn,
  *  @return 0 in case of success or negative value in case of error.
  */
 int bt_audio_stream_enable(struct bt_audio_stream *stream,
-			   uint8_t meta_count, struct bt_codec_data *meta);
+			   size_t meta_count, struct bt_codec_data *meta);
 
 /** @brief Change Audio Stream Metadata
  *
@@ -1423,7 +1423,7 @@ int bt_audio_stream_enable(struct bt_audio_stream *stream,
  *  @return 0 in case of success or negative value in case of error.
  */
 int bt_audio_stream_metadata(struct bt_audio_stream *stream,
-			     uint8_t meta_count, struct bt_codec_data *meta);
+			     size_t meta_count, struct bt_codec_data *meta);
 
 /** @brief Disable Audio Stream
  *
@@ -1511,7 +1511,7 @@ int bt_audio_stream_send(struct bt_audio_stream *stream, struct net_buf *buf);
  *  @return Zero on success or (negative) error code otherwise.
  */
 int bt_audio_unicast_group_create(struct bt_audio_stream *streams,
-				  uint8_t num_stream,
+				  size_t num_stream,
 				  struct bt_audio_unicast_group **unicast_group);
 
 /** @brief Add streams to a unicast group as a unicast client
@@ -1532,7 +1532,7 @@ int bt_audio_unicast_group_create(struct bt_audio_stream *streams,
  */
 int bt_audio_unicast_group_add_streams(struct bt_audio_unicast_group *unicast_group,
 				       struct bt_audio_stream *streams,
-				       uint8_t num_stream);
+				       size_t num_stream);
 
 /** @brief Remove streams from a unicast group as a unicast client
  *
@@ -1551,7 +1551,7 @@ int bt_audio_unicast_group_add_streams(struct bt_audio_unicast_group *unicast_gr
  */
 int bt_audio_unicast_group_remove_streams(struct bt_audio_unicast_group *unicast_group,
 					  struct bt_audio_stream *streams,
-					  uint8_t num_stream);
+					  size_t num_stream);
 
 /** @brief Delete audio unicast group.
  *
@@ -1586,7 +1586,7 @@ int bt_audio_unicast_group_delete(struct bt_audio_unicast_group *unicast_group);
  *  @return Zero on success or (negative) error code otherwise.
  */
 int bt_audio_broadcast_source_create(struct bt_audio_stream *streams,
-				     uint8_t num_stream,
+				     size_t num_stream,
 				     struct bt_codec *codec,
 				     struct bt_codec_qos *qos,
 				     struct bt_audio_broadcast_source **source);

--- a/include/bluetooth/audio/audio.h
+++ b/include/bluetooth/audio/audio.h
@@ -1514,6 +1514,45 @@ int bt_audio_unicast_group_create(struct bt_audio_stream *streams,
 				  uint8_t num_stream,
 				  struct bt_audio_unicast_group **unicast_group);
 
+/** @brief Add streams to a unicast group as a unicast client
+ *
+ *  This function can be used to add additional streams to a
+ *  bt_audio_unicast_group.
+ *
+ *  This can be called at any time before any of the streams in the
+ *  group has been started (see bt_audio_stream_ops.started()).
+ *  This can also be called after the streams have been stopped
+ *  (see bt_audio_stream_ops.stopped()).
+ *
+ *  @param unicast_group  Pointer to the unicast group
+ *  @param streams        Array of stream objects being added to the group.
+ *  @param num_stream     Number of streams in @p streams.
+ *
+ *  @return 0 in case of success or negative value in case of error.
+ */
+int bt_audio_unicast_group_add_streams(struct bt_audio_unicast_group *unicast_group,
+				       struct bt_audio_stream *streams,
+				       uint8_t num_stream);
+
+/** @brief Remove streams from a unicast group as a unicast client
+ *
+ *  This function can be used to remove streams from a bt_audio_unicast_group.
+ *
+ *  This can be called at any time before any of the streams in the
+ *  group has been started (see bt_audio_stream_ops.started()).
+ *  This can also be called after the streams have been stopped
+ *  (see bt_audio_stream_ops.stopped()).
+ *
+ *  @param unicast_group  Pointer to the unicast group
+ *  @param streams        Array of stream objects removed from the group.
+ *  @param num_stream     Number of streams in @p streams.
+ *
+ *  @return 0 in case of success or negative value in case of error.
+ */
+int bt_audio_unicast_group_remove_streams(struct bt_audio_unicast_group *unicast_group,
+					  struct bt_audio_stream *streams,
+					  uint8_t num_stream);
+
 /** @brief Delete audio unicast group.
  *
  *  Delete a audio unicast group as a client. All streams in the group shall

--- a/include/bluetooth/audio/capabilities.h
+++ b/include/bluetooth/audio/capabilities.h
@@ -155,8 +155,9 @@ struct bt_audio_capability_ops {
 	 *
 	 *  @return 0 in case of success or negative value in case of error.
 	 */
-	int (*enable)(struct bt_audio_stream *stream, size_t meta_count,
-		      struct bt_codec_data *meta);
+	int (*enable)(struct bt_audio_stream *stream,
+		      struct bt_codec_data *meta,
+		      size_t meta_count);
 
 	/** @brief Capability Start callback
 	 *
@@ -180,8 +181,9 @@ struct bt_audio_capability_ops {
 	 *
 	 *  @return 0 in case of success or negative value in case of error.
 	 */
-	int (*metadata)(struct bt_audio_stream *stream, size_t meta_count,
-			struct bt_codec_data *meta);
+	int (*metadata)(struct bt_audio_stream *stream,
+			struct bt_codec_data *meta,
+			size_t meta_count);
 
 	/** @brief Capability Disable callback
 	 *

--- a/include/bluetooth/audio/capabilities.h
+++ b/include/bluetooth/audio/capabilities.h
@@ -155,7 +155,7 @@ struct bt_audio_capability_ops {
 	 *
 	 *  @return 0 in case of success or negative value in case of error.
 	 */
-	int (*enable)(struct bt_audio_stream *stream, uint8_t meta_count,
+	int (*enable)(struct bt_audio_stream *stream, size_t meta_count,
 		      struct bt_codec_data *meta);
 
 	/** @brief Capability Start callback
@@ -180,7 +180,7 @@ struct bt_audio_capability_ops {
 	 *
 	 *  @return 0 in case of success or negative value in case of error.
 	 */
-	int (*metadata)(struct bt_audio_stream *stream, uint8_t meta_count,
+	int (*metadata)(struct bt_audio_stream *stream, size_t meta_count,
 			struct bt_codec_data *meta);
 
 	/** @brief Capability Disable callback

--- a/samples/bluetooth/unicast_audio_client/src/main.c
+++ b/samples/bluetooth/unicast_audio_client/src/main.c
@@ -537,8 +537,8 @@ static int enable_stream(struct bt_audio_stream *stream)
 {
 	int err;
 
-	err = bt_audio_stream_enable(stream, preset_16_2_1.codec.meta_count,
-				     preset_16_2_1.codec.meta);
+	err = bt_audio_stream_enable(stream, preset_16_2_1.codec.meta,
+				     preset_16_2_1.codec.meta_count);
 	if (err != 0) {
 		printk("Unable to enable stream: %d", err);
 		return err;

--- a/samples/bluetooth/unicast_audio_server/src/main.c
+++ b/samples/bluetooth/unicast_audio_server/src/main.c
@@ -139,8 +139,9 @@ static int lc3_qos(struct bt_audio_stream *stream, struct bt_codec_qos *qos)
 	return 0;
 }
 
-static int lc3_enable(struct bt_audio_stream *stream, size_t meta_count,
-		      struct bt_codec_data *meta)
+static int lc3_enable(struct bt_audio_stream *stream,
+		      struct bt_codec_data *meta,
+		      size_t meta_count)
 {
 	printk("Enable: stream %p meta_count %u\n", stream, meta_count);
 
@@ -154,8 +155,9 @@ static int lc3_start(struct bt_audio_stream *stream)
 	return 0;
 }
 
-static int lc3_metadata(struct bt_audio_stream *stream, size_t meta_count,
-			struct bt_codec_data *meta)
+static int lc3_metadata(struct bt_audio_stream *stream,
+			struct bt_codec_data *meta,
+			size_t meta_count)
 {
 	printk("Metadata: stream %p meta_count %u\n", stream, meta_count);
 

--- a/samples/bluetooth/unicast_audio_server/src/main.c
+++ b/samples/bluetooth/unicast_audio_server/src/main.c
@@ -139,7 +139,7 @@ static int lc3_qos(struct bt_audio_stream *stream, struct bt_codec_qos *qos)
 	return 0;
 }
 
-static int lc3_enable(struct bt_audio_stream *stream, uint8_t meta_count,
+static int lc3_enable(struct bt_audio_stream *stream, size_t meta_count,
 		      struct bt_codec_data *meta)
 {
 	printk("Enable: stream %p meta_count %u\n", stream, meta_count);
@@ -154,7 +154,7 @@ static int lc3_start(struct bt_audio_stream *stream)
 	return 0;
 }
 
-static int lc3_metadata(struct bt_audio_stream *stream, uint8_t meta_count,
+static int lc3_metadata(struct bt_audio_stream *stream, size_t meta_count,
 			struct bt_codec_data *meta)
 {
 	printk("Metadata: stream %p meta_count %u\n", stream, meta_count);

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -1373,8 +1373,8 @@ static int ase_metadata(struct bt_ascs_ase *ase, uint8_t op,
 
 	stream = ep->stream;
 	if (unicast_server_cb != NULL && unicast_server_cb->metadata != NULL) {
-		err = unicast_server_cb->metadata(stream, ep->codec.meta_count,
-						  ep->codec.meta);
+		err = unicast_server_cb->metadata(stream, ep->codec.meta,
+						  ep->codec.meta_count);
 	} else {
 		err = -ENOTSUP;
 	}
@@ -1429,8 +1429,8 @@ static int ase_enable(struct bt_ascs_ase *ase, struct bt_ascs_metadata *meta,
 
 	stream = ep->stream;
 	if (unicast_server_cb != NULL && unicast_server_cb->enable != NULL) {
-		err = unicast_server_cb->enable(stream, ep->codec.meta_count,
-						ep->codec.meta);
+		err = unicast_server_cb->enable(stream, ep->codec.meta,
+						ep->codec.meta_count);
 	} else {
 		err = -ENOTSUP;
 	}

--- a/subsys/bluetooth/audio/broadcast_source.c
+++ b/subsys/bluetooth/audio/broadcast_source.c
@@ -386,7 +386,7 @@ static void broadcast_source_cleanup(struct bt_audio_broadcast_source *source)
 }
 
 int bt_audio_broadcast_source_create(struct bt_audio_stream *streams,
-				     uint8_t num_stream,
+				     size_t num_stream,
 				     struct bt_codec *codec,
 				     struct bt_codec_qos *qos,
 				     struct bt_audio_broadcast_source **out_source)

--- a/subsys/bluetooth/audio/capabilities.c
+++ b/subsys/bluetooth/audio/capabilities.c
@@ -156,8 +156,8 @@ static int unicast_server_qos_cb(struct bt_audio_stream *stream,
 }
 
 static int unicast_server_enable_cb(struct bt_audio_stream *stream,
-				    size_t meta_count,
-				    const struct bt_codec_data *meta)
+				    const struct bt_codec_data *meta,
+				    size_t meta_count)
 {
 	struct bt_audio_capability *cap = stream->user_data;
 
@@ -165,8 +165,8 @@ static int unicast_server_enable_cb(struct bt_audio_stream *stream,
 		return -EACCES;
 	}
 
-	return cap->ops->enable(stream, meta_count,
-					(struct bt_codec_data *)meta);
+	return cap->ops->enable(stream, (struct bt_codec_data *)meta,
+				meta_count);
 }
 
 static int unicast_server_start_cb(struct bt_audio_stream *stream)
@@ -181,8 +181,8 @@ static int unicast_server_start_cb(struct bt_audio_stream *stream)
 }
 
 static int unicast_server_metadata_cb(struct bt_audio_stream *stream,
-				      size_t meta_count,
-				      const struct bt_codec_data *meta)
+				      const struct bt_codec_data *meta,
+				      size_t meta_count)
 {
 	struct bt_audio_capability *cap = stream->user_data;
 
@@ -190,8 +190,8 @@ static int unicast_server_metadata_cb(struct bt_audio_stream *stream,
 		return -EACCES;
 	}
 
-	return cap->ops->metadata(stream, meta_count,
-					  (struct bt_codec_data *)meta);
+	return cap->ops->metadata(stream, (struct bt_codec_data *)meta,
+				  meta_count);
 }
 
 static int unicast_server_disable_cb(struct bt_audio_stream *stream)

--- a/subsys/bluetooth/audio/capabilities.c
+++ b/subsys/bluetooth/audio/capabilities.c
@@ -156,7 +156,7 @@ static int unicast_server_qos_cb(struct bt_audio_stream *stream,
 }
 
 static int unicast_server_enable_cb(struct bt_audio_stream *stream,
-				    uint8_t meta_count,
+				    size_t meta_count,
 				    const struct bt_codec_data *meta)
 {
 	struct bt_audio_capability *cap = stream->user_data;
@@ -181,7 +181,7 @@ static int unicast_server_start_cb(struct bt_audio_stream *stream)
 }
 
 static int unicast_server_metadata_cb(struct bt_audio_stream *stream,
-				      uint8_t meta_count,
+				      size_t meta_count,
 				      const struct bt_codec_data *meta)
 {
 	struct bt_audio_capability *cap = stream->user_data;

--- a/subsys/bluetooth/audio/stream.c
+++ b/subsys/bluetooth/audio/stream.c
@@ -1070,6 +1070,121 @@ int bt_audio_unicast_group_create(struct bt_audio_stream *streams,
 	return 0;
 }
 
+int bt_audio_unicast_group_add_streams(struct bt_audio_unicast_group *unicast_group,
+				       struct bt_audio_stream *streams,
+				       uint8_t num_stream)
+{
+	struct bt_audio_stream *tmp_stream;
+	uint8_t total_stream_cnt;
+	struct bt_iso_cig *cig;
+
+	CHECKIF(unicast_group == NULL) {
+		BT_DBG("unicast_group is NULL");
+		return -EINVAL;
+	}
+
+	CHECKIF(streams == NULL) {
+		BT_DBG("streams is NULL");
+		return -EINVAL;
+	}
+
+	CHECKIF(num_stream == 0) {
+		BT_DBG("num_stream is 0");
+		return -EINVAL;
+	}
+
+	total_stream_cnt = num_stream;
+	SYS_SLIST_FOR_EACH_CONTAINER(&unicast_group->streams, tmp_stream, node) {
+		total_stream_cnt++;
+	}
+
+	if (total_stream_cnt > UNICAST_GROUP_STREAM_CNT) {
+		BT_DBG("Too many streams provided: %u/%u",
+		       total_stream_cnt, UNICAST_GROUP_STREAM_CNT);
+		return -EINVAL;
+
+	}
+
+	/* Validate input */
+	for (uint8_t i = 0; i < num_stream; i++) {
+		if (streams[i].group != NULL) {
+			BT_DBG("stream[%u] is already part of group %p",
+			       i, streams[i].group);
+			return -EINVAL;
+		}
+	}
+
+	/* We can just check the CIG state to see if any streams have started as
+	 * that would start the ISO connection procedure
+	 */
+	cig = unicast_group->cig;
+	if (cig != NULL && cig->state != BT_ISO_CIG_STATE_CONFIGURED) {
+		BT_DBG("At least one unicast group stream is started");
+		return -EBADMSG;
+	}
+
+	for (uint8_t i = 0; i < num_stream; i++) {
+		sys_slist_t *group_streams = &unicast_group->streams;
+		struct bt_audio_stream *stream = &streams[i];
+
+		stream->unicast_group = unicast_group;
+		sys_slist_append(group_streams, &stream->node);
+	}
+
+	return 0;
+}
+
+int bt_audio_unicast_group_remove_streams(struct bt_audio_unicast_group *unicast_group,
+					  struct bt_audio_stream *streams,
+					  uint8_t num_stream)
+{
+	struct bt_iso_cig *cig;
+
+	CHECKIF(unicast_group == NULL) {
+		BT_DBG("unicast_group is NULL");
+		return -EINVAL;
+	}
+
+	CHECKIF(streams == NULL) {
+		BT_DBG("streams is NULL");
+		return -EINVAL;
+	}
+
+	CHECKIF(num_stream == 0) {
+		BT_DBG("num_stream is 0");
+		return -EINVAL;
+	}
+
+	/* Validate input */
+	for (uint8_t i = 0; i < num_stream; i++) {
+		if (streams[i].group != unicast_group) {
+			BT_DBG("stream[%u] group %p is not group %p",
+			       i, streams[i].group, unicast_group);
+			return -EINVAL;
+		}
+	}
+
+	/* We can just check the CIG state to see if any streams have started as
+	 * that would start the ISO connection procedure
+	 */
+	cig = unicast_group->cig;
+	if (cig != NULL && cig->state != BT_ISO_CIG_STATE_CONFIGURED) {
+		BT_DBG("At least one unicast group stream is started");
+		return -EBADMSG;
+	}
+
+	for (uint8_t i = 0; i < num_stream; i++) {
+		sys_slist_t *group_streams = &unicast_group->streams;
+		struct bt_audio_stream *stream = &streams[i];
+
+		stream->unicast_group = NULL;
+		(void)sys_slist_find_and_remove(group_streams,
+						&streams->node);
+	}
+
+	return 0;
+}
+
 int bt_audio_unicast_group_delete(struct bt_audio_unicast_group *unicast_group)
 {
 	struct bt_audio_stream *stream;

--- a/subsys/bluetooth/audio/stream.c
+++ b/subsys/bluetooth/audio/stream.c
@@ -629,7 +629,7 @@ static bool bt_audio_stream_enabling(struct bt_audio_stream *stream)
 }
 
 int bt_audio_stream_enable(struct bt_audio_stream *stream,
-			   uint8_t meta_count, struct bt_codec_data *meta)
+			   size_t meta_count, struct bt_codec_data *meta)
 {
 	uint8_t role;
 	int err;
@@ -684,7 +684,7 @@ int bt_audio_stream_enable(struct bt_audio_stream *stream,
 }
 
 int bt_audio_stream_metadata(struct bt_audio_stream *stream,
-			     uint8_t meta_count, struct bt_codec_data *meta)
+			     size_t meta_count, struct bt_codec_data *meta)
 {
 	uint8_t role;
 	int err;
@@ -1001,7 +1001,7 @@ int bt_audio_stream_connect(struct bt_audio_stream *stream)
 }
 
 int bt_audio_unicast_group_create(struct bt_audio_stream *streams,
-				  uint8_t num_stream,
+				  size_t num_stream,
 				  struct bt_audio_unicast_group **out_unicast_group)
 {
 
@@ -1040,7 +1040,7 @@ int bt_audio_unicast_group_create(struct bt_audio_stream *streams,
 		return -ENOMEM;
 	}
 
-	for (uint8_t i = 0; i < num_stream; i++) {
+	for (size_t i = 0; i < num_stream; i++) {
 		sys_slist_t *group_streams = &unicast_group->streams;
 		struct bt_audio_stream *stream;
 
@@ -1051,7 +1051,7 @@ int bt_audio_unicast_group_create(struct bt_audio_stream *streams,
 			       i, stream, stream->group);
 
 			/* Cleanup */
-			for (uint8_t j = 0; j < i; j++) {
+			for (size_t j = 0; j < i; j++) {
 				stream = &streams[j];
 
 				(void)sys_slist_find_and_remove(group_streams,
@@ -1072,10 +1072,10 @@ int bt_audio_unicast_group_create(struct bt_audio_stream *streams,
 
 int bt_audio_unicast_group_add_streams(struct bt_audio_unicast_group *unicast_group,
 				       struct bt_audio_stream *streams,
-				       uint8_t num_stream)
+				       size_t num_stream)
 {
 	struct bt_audio_stream *tmp_stream;
-	uint8_t total_stream_cnt;
+	size_t total_stream_cnt;
 	struct bt_iso_cig *cig;
 
 	CHECKIF(unicast_group == NULL) {
@@ -1106,9 +1106,9 @@ int bt_audio_unicast_group_add_streams(struct bt_audio_unicast_group *unicast_gr
 	}
 
 	/* Validate input */
-	for (uint8_t i = 0; i < num_stream; i++) {
+	for (size_t i = 0; i < num_stream; i++) {
 		if (streams[i].group != NULL) {
-			BT_DBG("stream[%u] is already part of group %p",
+			BT_DBG("stream[%zu] is already part of group %p",
 			       i, streams[i].group);
 			return -EINVAL;
 		}
@@ -1123,7 +1123,7 @@ int bt_audio_unicast_group_add_streams(struct bt_audio_unicast_group *unicast_gr
 		return -EBADMSG;
 	}
 
-	for (uint8_t i = 0; i < num_stream; i++) {
+	for (size_t i = 0; i < num_stream; i++) {
 		sys_slist_t *group_streams = &unicast_group->streams;
 		struct bt_audio_stream *stream = &streams[i];
 
@@ -1136,7 +1136,7 @@ int bt_audio_unicast_group_add_streams(struct bt_audio_unicast_group *unicast_gr
 
 int bt_audio_unicast_group_remove_streams(struct bt_audio_unicast_group *unicast_group,
 					  struct bt_audio_stream *streams,
-					  uint8_t num_stream)
+					  size_t num_stream)
 {
 	struct bt_iso_cig *cig;
 
@@ -1156,9 +1156,9 @@ int bt_audio_unicast_group_remove_streams(struct bt_audio_unicast_group *unicast
 	}
 
 	/* Validate input */
-	for (uint8_t i = 0; i < num_stream; i++) {
+	for (size_t i = 0; i < num_stream; i++) {
 		if (streams[i].group != unicast_group) {
-			BT_DBG("stream[%u] group %p is not group %p",
+			BT_DBG("stream[%zu] group %p is not group %p",
 			       i, streams[i].group, unicast_group);
 			return -EINVAL;
 		}
@@ -1173,7 +1173,7 @@ int bt_audio_unicast_group_remove_streams(struct bt_audio_unicast_group *unicast
 		return -EBADMSG;
 	}
 
-	for (uint8_t i = 0; i < num_stream; i++) {
+	for (size_t i = 0; i < num_stream; i++) {
 		sys_slist_t *group_streams = &unicast_group->streams;
 		struct bt_audio_stream *stream = &streams[i];
 

--- a/subsys/bluetooth/audio/stream.c
+++ b/subsys/bluetooth/audio/stream.c
@@ -629,7 +629,8 @@ static bool bt_audio_stream_enabling(struct bt_audio_stream *stream)
 }
 
 int bt_audio_stream_enable(struct bt_audio_stream *stream,
-			   size_t meta_count, struct bt_codec_data *meta)
+			   struct bt_codec_data *meta,
+			   size_t meta_count)
 {
 	uint8_t role;
 	int err;
@@ -654,7 +655,7 @@ int bt_audio_stream_enable(struct bt_audio_stream *stream,
 		return -EBADMSG;
 	}
 
-	err = bt_unicast_client_enable(stream, meta_count, meta);
+	err = bt_unicast_client_enable(stream, meta, meta_count);
 	if (err != 0) {
 		BT_DBG("Failed to enable stream: %d", err);
 		return err;
@@ -684,7 +685,8 @@ int bt_audio_stream_enable(struct bt_audio_stream *stream,
 }
 
 int bt_audio_stream_metadata(struct bt_audio_stream *stream,
-			     size_t meta_count, struct bt_codec_data *meta)
+			     struct bt_codec_data *meta,
+			     size_t meta_count)
 {
 	uint8_t role;
 	int err;
@@ -714,7 +716,7 @@ int bt_audio_stream_metadata(struct bt_audio_stream *stream,
 		return -EBADMSG;
 	}
 
-	err = bt_unicast_client_metadata(stream, meta_count, meta);
+	err = bt_unicast_client_metadata(stream, meta, meta_count);
 	if (err != 0) {
 		BT_DBG("Updating metadata failed: %d", err);
 		return err;

--- a/subsys/bluetooth/audio/stream.c
+++ b/subsys/bluetooth/audio/stream.c
@@ -1188,18 +1188,23 @@ int bt_audio_unicast_group_remove_streams(struct bt_audio_unicast_group *unicast
 int bt_audio_unicast_group_delete(struct bt_audio_unicast_group *unicast_group)
 {
 	struct bt_audio_stream *stream;
+	struct bt_iso_cig *cig;
 
 	CHECKIF(unicast_group == NULL) {
 		BT_DBG("unicast_group is NULL");
 		return -EINVAL;
 	}
 
-	SYS_SLIST_FOR_EACH_CONTAINER(&unicast_group->streams, stream, node) {
-		if (stream->group == NULL) {
-			BT_DBG("stream %p not in a group", stream);
-			return -EINVAL;
-		}
+	/* We can just check the CIG state to see if any streams have started as
+	 * that would start the ISO connection procedure
+	 */
+	cig = unicast_group->cig;
+	if (cig != NULL && cig->state != BT_ISO_CIG_STATE_CONFIGURED) {
+		BT_DBG("At least one unicast group stream is started");
+		return -EBADMSG;
+	}
 
+	SYS_SLIST_FOR_EACH_CONTAINER(&unicast_group->streams, stream, node) {
 		stream->unicast_group = NULL;
 	}
 

--- a/subsys/bluetooth/audio/unicast_client.c
+++ b/subsys/bluetooth/audio/unicast_client.c
@@ -1092,8 +1092,8 @@ int bt_unicast_client_ep_qos(struct bt_audio_ep *ep, struct net_buf_simple *buf,
 
 static int unicast_client_ep_enable(struct bt_audio_ep *ep,
 				    struct net_buf_simple *buf,
-				    size_t meta_count,
-				    struct bt_codec_data *meta)
+				    struct bt_codec_data *meta,
+				    size_t meta_count)
 {
 	struct bt_ascs_metadata *req;
 
@@ -1123,8 +1123,8 @@ static int unicast_client_ep_enable(struct bt_audio_ep *ep,
 
 static int unicast_client_ep_metadata(struct bt_audio_ep *ep,
 				      struct net_buf_simple *buf,
-				      size_t meta_count,
-				      struct bt_codec_data *meta)
+				      struct bt_codec_data *meta,
+				      size_t meta_count)
 {
 	struct bt_ascs_metadata *req;
 
@@ -1371,8 +1371,9 @@ int bt_unicast_client_config(struct bt_audio_stream *stream,
 	return 0;
 }
 
-int bt_unicast_client_enable(struct bt_audio_stream *stream, size_t meta_count,
-			     struct bt_codec_data *meta)
+int bt_unicast_client_enable(struct bt_audio_stream *stream,
+			     struct bt_codec_data *meta,
+			     size_t meta_count)
 {
 	struct bt_audio_ep *ep = stream->ep;
 	struct net_buf_simple *buf;
@@ -1386,7 +1387,7 @@ int bt_unicast_client_enable(struct bt_audio_stream *stream, size_t meta_count,
 	req = net_buf_simple_add(buf, sizeof(*req));
 	req->num_ases = 0x01;
 
-	err = unicast_client_ep_enable(ep, buf, meta_count, meta);
+	err = unicast_client_ep_enable(ep, buf, meta, meta_count);
 	if (err) {
 		return err;
 	}
@@ -1395,8 +1396,8 @@ int bt_unicast_client_enable(struct bt_audio_stream *stream, size_t meta_count,
 }
 
 int bt_unicast_client_metadata(struct bt_audio_stream *stream,
-			       size_t meta_count,
-			       struct bt_codec_data *meta)
+			       struct bt_codec_data *meta,
+			       size_t meta_count)
 {
 	struct bt_audio_ep *ep = stream->ep;
 	struct net_buf_simple *buf;
@@ -1410,7 +1411,7 @@ int bt_unicast_client_metadata(struct bt_audio_stream *stream,
 	req = net_buf_simple_add(buf, sizeof(*req));
 	req->num_ases = 0x01;
 
-	err = unicast_client_ep_metadata(ep, buf, meta_count, meta);
+	err = unicast_client_ep_metadata(ep, buf, meta, meta_count);
 	if (err) {
 		return err;
 	}

--- a/subsys/bluetooth/audio/unicast_client.c
+++ b/subsys/bluetooth/audio/unicast_client.c
@@ -634,10 +634,10 @@ static void unicast_client_ep_set_status(struct bt_audio_ep *ep,
 
 static void unicast_client_codec_data_add(struct net_buf_simple *buf,
 					  const char *prefix,
-					  uint8_t num,
+					  size_t num,
 					  struct bt_codec_data *data)
 {
-	for (uint8_t i = 0; i < num; i++) {
+	for (size_t i = 0; i < num; i++) {
 		struct bt_data *d = &data[i].data;
 		struct bt_ascs_codec_config *cc;
 
@@ -1092,12 +1092,12 @@ int bt_unicast_client_ep_qos(struct bt_audio_ep *ep, struct net_buf_simple *buf,
 
 static int unicast_client_ep_enable(struct bt_audio_ep *ep,
 				    struct net_buf_simple *buf,
-				    uint8_t meta_count,
+				    size_t meta_count,
 				    struct bt_codec_data *meta)
 {
 	struct bt_ascs_metadata *req;
 
-	BT_DBG("ep %p buf %p metadata count %u", ep, buf, meta_count);
+	BT_DBG("ep %p buf %p metadata count %zu", ep, buf, meta_count);
 
 	if (!ep) {
 		return -EINVAL;
@@ -1123,12 +1123,12 @@ static int unicast_client_ep_enable(struct bt_audio_ep *ep,
 
 static int unicast_client_ep_metadata(struct bt_audio_ep *ep,
 				      struct net_buf_simple *buf,
-				      uint8_t meta_count,
+				      size_t meta_count,
 				      struct bt_codec_data *meta)
 {
 	struct bt_ascs_metadata *req;
 
-	BT_DBG("ep %p buf %p metadata count %u", ep, buf, meta_count);
+	BT_DBG("ep %p buf %p metadata count %zu", ep, buf, meta_count);
 
 	if (!ep) {
 		return -EINVAL;
@@ -1371,7 +1371,7 @@ int bt_unicast_client_config(struct bt_audio_stream *stream,
 	return 0;
 }
 
-int bt_unicast_client_enable(struct bt_audio_stream *stream, uint8_t meta_count,
+int bt_unicast_client_enable(struct bt_audio_stream *stream, size_t meta_count,
 			     struct bt_codec_data *meta)
 {
 	struct bt_audio_ep *ep = stream->ep;
@@ -1395,7 +1395,7 @@ int bt_unicast_client_enable(struct bt_audio_stream *stream, uint8_t meta_count,
 }
 
 int bt_unicast_client_metadata(struct bt_audio_stream *stream,
-			       uint8_t meta_count,
+			       size_t meta_count,
 			       struct bt_codec_data *meta)
 {
 	struct bt_audio_ep *ep = stream->ep;

--- a/subsys/bluetooth/audio/unicast_client_internal.h
+++ b/subsys/bluetooth/audio/unicast_client_internal.h
@@ -9,11 +9,11 @@
 int bt_unicast_client_config(struct bt_audio_stream *stream,
 		  struct bt_codec *codec);
 
-int bt_unicast_client_enable(struct bt_audio_stream *stream, uint8_t meta_count,
+int bt_unicast_client_enable(struct bt_audio_stream *stream, size_t meta_count,
 		  struct bt_codec_data *meta);
 
 int bt_unicast_client_metadata(struct bt_audio_stream *stream,
-		    uint8_t meta_count, struct bt_codec_data *meta);
+			       size_t meta_count, struct bt_codec_data *meta);
 
 int bt_unicast_client_disable(struct bt_audio_stream *stream);
 

--- a/subsys/bluetooth/audio/unicast_client_internal.h
+++ b/subsys/bluetooth/audio/unicast_client_internal.h
@@ -9,11 +9,13 @@
 int bt_unicast_client_config(struct bt_audio_stream *stream,
 		  struct bt_codec *codec);
 
-int bt_unicast_client_enable(struct bt_audio_stream *stream, size_t meta_count,
-		  struct bt_codec_data *meta);
+int bt_unicast_client_enable(struct bt_audio_stream *stream,
+			     struct bt_codec_data *meta,
+			     size_t meta_count);
 
 int bt_unicast_client_metadata(struct bt_audio_stream *stream,
-			       size_t meta_count, struct bt_codec_data *meta);
+			       struct bt_codec_data *meta,
+			       size_t meta_count);
 
 int bt_unicast_client_disable(struct bt_audio_stream *stream);
 

--- a/subsys/bluetooth/shell/audio.c
+++ b/subsys/bluetooth/shell/audio.c
@@ -362,9 +362,9 @@ static int lc3_qos(struct bt_audio_stream *stream, struct bt_codec_qos *qos)
 }
 
 static int lc3_enable(struct bt_audio_stream *stream,
-		      uint8_t meta_count, struct bt_codec_data *meta)
+		      size_t meta_count, struct bt_codec_data *meta)
 {
-	shell_print(ctx_shell, "Enable: stream %p meta_count %u", stream,
+	shell_print(ctx_shell, "Enable: stream %p meta_count %zu", stream,
 		    meta_count);
 
 	return 0;
@@ -378,9 +378,9 @@ static int lc3_start(struct bt_audio_stream *stream)
 }
 
 static int lc3_metadata(struct bt_audio_stream *stream,
-			uint8_t meta_count, struct bt_codec_data *meta)
+			size_t meta_count, struct bt_codec_data *meta)
 {
-	shell_print(ctx_shell, "Metadata: stream %p meta_count %u", stream,
+	shell_print(ctx_shell, "Metadata: stream %p meta_count %zu", stream,
 		    meta_count);
 
 	return 0;

--- a/subsys/bluetooth/shell/audio.c
+++ b/subsys/bluetooth/shell/audio.c
@@ -349,8 +349,8 @@ static int lc3_qos(struct bt_audio_stream *stream, struct bt_codec_qos *qos)
 		connecting = false;
 
 		err = bt_audio_stream_enable(stream,
-					     default_preset->preset.codec.meta_count,
-					     default_preset->preset.codec.meta);
+					     default_preset->preset.codec.meta,
+					     default_preset->preset.codec.meta_count);
 		if (err) {
 			shell_error(ctx_shell, "Unable to enable Channel");
 			return -ENOEXEC;
@@ -362,7 +362,8 @@ static int lc3_qos(struct bt_audio_stream *stream, struct bt_codec_qos *qos)
 }
 
 static int lc3_enable(struct bt_audio_stream *stream,
-		      size_t meta_count, struct bt_codec_data *meta)
+		      struct bt_codec_data *meta,
+		      size_t meta_count)
 {
 	shell_print(ctx_shell, "Enable: stream %p meta_count %zu", stream,
 		    meta_count);
@@ -378,7 +379,8 @@ static int lc3_start(struct bt_audio_stream *stream)
 }
 
 static int lc3_metadata(struct bt_audio_stream *stream,
-			size_t meta_count, struct bt_codec_data *meta)
+			struct bt_codec_data *meta,
+			size_t meta_count)
 {
 	shell_print(ctx_shell, "Metadata: stream %p meta_count %zu", stream,
 		    meta_count);
@@ -759,8 +761,8 @@ static int cmd_enable(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	err = bt_audio_stream_enable(default_stream,
-				     default_preset->preset.codec.meta_count,
-				     default_preset->preset.codec.meta);
+				     default_preset->preset.codec.meta,
+				     default_preset->preset.codec.meta_count);
 	if (err) {
 		shell_error(sh, "Unable to enable Channel");
 		return -ENOEXEC;
@@ -822,8 +824,8 @@ static int cmd_metadata(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	err = bt_audio_stream_metadata(default_stream,
-				       default_preset->preset.codec.meta_count,
-				       default_preset->preset.codec.meta);
+				       default_preset->preset.codec.meta,
+				       default_preset->preset.codec.meta_count);
 	if (err) {
 		shell_error(sh, "Unable to set Channel metadata");
 		return -ENOEXEC;

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/unicast_client_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/unicast_client_test.c
@@ -314,14 +314,45 @@ static void test_main(void)
 	}
 
 	printk("Creating unicast group\n");
-	err = bt_audio_unicast_group_create(g_streams, stream_cnt,
-					    &unicast_group);
+	err = bt_audio_unicast_group_create(g_streams, 1, &unicast_group);
 	if (err != 0) {
 		FAIL("Unable to create unicast group: %d", err);
 		return;
 	}
 
+	/* Test removing streams from group before adding them */
+	if (stream_cnt > 1) {
+		err = bt_audio_unicast_group_remove_streams(unicast_group,
+							    g_streams + 1,
+							    stream_cnt - 1);
+		if (err == 0) {
+			FAIL("Able to remove stream not in group");
+			return;
+		}
+
+		/* Test adding streams to group after creation */
+		err = bt_audio_unicast_group_add_streams(unicast_group,
+							 g_streams + 1,
+							 stream_cnt - 1);
+		if (err != 0) {
+			FAIL("Unable to add streams to unicast group: %d", err);
+			return;
+		}
+	}
+
 	/* TODO: When babblesim supports ISO setup Audio streams */
+
+	/* Test removing streams from group after creation */
+	if (stream_cnt > 1) {
+		err = bt_audio_unicast_group_remove_streams(unicast_group,
+							    g_streams + 1,
+							    stream_cnt - 1);
+		if (err != 0) {
+			FAIL("Unable to remove streams from unicast group: %d",
+			     err);
+			return;
+		}
+	}
 
 	printk("Deleting unicast group\n");
 	err = bt_audio_unicast_group_delete(unicast_group);

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/unicast_client_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/unicast_client_test.c
@@ -287,7 +287,7 @@ static int configure_stream(struct bt_audio_stream *stream,
 static void test_main(void)
 {
 	struct bt_audio_unicast_group *unicast_group;
-	uint8_t stream_cnt;
+	size_t stream_cnt;
 	int err;
 
 	init();
@@ -307,7 +307,7 @@ static void test_main(void)
 		err = configure_stream(&g_streams[stream_cnt],
 				       g_sinks[stream_cnt]);
 		if (err != 0) {
-			FAIL("Unable to configure stream[%u]: %d",
+			FAIL("Unable to configure stream[%zu]: %d",
 			     stream_cnt, err);
 			return;
 		}

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/unicast_server_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/unicast_server_test.c
@@ -73,8 +73,9 @@ static int lc3_qos(struct bt_audio_stream *stream, struct bt_codec_qos *qos)
 	return 0;
 }
 
-static int lc3_enable(struct bt_audio_stream *stream, size_t meta_count,
-		      struct bt_codec_data *meta)
+static int lc3_enable(struct bt_audio_stream *stream,
+		      struct bt_codec_data *meta,
+		      size_t meta_count)
 {
 	printk("Enable: stream %p meta_count %zu\n", stream, meta_count);
 
@@ -88,8 +89,9 @@ static int lc3_start(struct bt_audio_stream *stream)
 	return 0;
 }
 
-static int lc3_metadata(struct bt_audio_stream *stream, size_t meta_count,
-			struct bt_codec_data *meta)
+static int lc3_metadata(struct bt_audio_stream *stream,
+			struct bt_codec_data *meta,
+			size_t meta_count)
 {
 	printk("Metadata: stream %p meta_count %zu\n", stream, meta_count);
 

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/unicast_server_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/unicast_server_test.c
@@ -73,10 +73,10 @@ static int lc3_qos(struct bt_audio_stream *stream, struct bt_codec_qos *qos)
 	return 0;
 }
 
-static int lc3_enable(struct bt_audio_stream *stream, uint8_t meta_count,
+static int lc3_enable(struct bt_audio_stream *stream, size_t meta_count,
 		      struct bt_codec_data *meta)
 {
-	printk("Enable: stream %p meta_count %u\n", stream, meta_count);
+	printk("Enable: stream %p meta_count %zu\n", stream, meta_count);
 
 	return 0;
 }
@@ -88,10 +88,10 @@ static int lc3_start(struct bt_audio_stream *stream)
 	return 0;
 }
 
-static int lc3_metadata(struct bt_audio_stream *stream, uint8_t meta_count,
+static int lc3_metadata(struct bt_audio_stream *stream, size_t meta_count,
 			struct bt_codec_data *meta)
 {
-	printk("Metadata: stream %p meta_count %u\n", stream, meta_count);
+	printk("Metadata: stream %p meta_count %zu\n", stream, meta_count);
 
 	return 0;
 }


### PR DESCRIPTION
Add support for adding and removing streams to a non-started unicast group. 

Also fixes some check in the `bt_audio_unicast_group_delete` function. 

fixes https://github.com/zephyrproject-rtos/zephyr/issues/41196