### PR TITLE
tests: settings: fix wrong test case names

### DIFF
--- a/tests/subsys/settings/fcb/src/settings_test_fcb.c
+++ b/tests/subsys/settings/fcb/src/settings_test_fcb.c
@@ -341,7 +341,7 @@ int c3_handle_export(int (*cb)(const char *name,
 	return 0;
 }
 
-void tests_settings_check_target(void)
+void test_settings_check_target(void)
 {
 	const struct flash_area *fap;
 	int rc;
@@ -381,14 +381,14 @@ void test_main(void)
 {
 	ztest_test_suite(test_config_fcb,
 			 /* Config tests */
-			 ztest_unit_test(config_empty_lookups),
+			 ztest_unit_test(test_config_empty_lookups),
 			 ztest_unit_test(test_config_insert),
 			 ztest_unit_test(test_config_getset_unknown),
 			 ztest_unit_test(test_config_getset_int),
 			 ztest_unit_test(test_config_getset_int64),
 			 ztest_unit_test(test_config_commit),
 			 /* FCB as backing storage*/
-			 ztest_unit_test(tests_settings_check_target),
+			 ztest_unit_test(test_settings_check_target),
 			 ztest_unit_test(test_config_save_fcb_unaligned),
 			 ztest_unit_test(test_config_empty_fcb),
 			 ztest_unit_test(test_config_save_1_fcb),

--- a/tests/subsys/settings/littlefs/src/settings_setup_littlefs.c
+++ b/tests/subsys/settings/littlefs/src/settings_setup_littlefs.c
@@ -18,7 +18,7 @@ static struct fs_mount_t littlefs_mnt = {
 	.mnt_point = TEST_FS_MPTR,
 };
 
-void config_setup_littlefs(void)
+void test_config_setup_littlefs(void)
 {
 	int rc;
 	const struct flash_area *fap;

--- a/tests/subsys/settings/littlefs/src/settings_test_littlefs.c
+++ b/tests/subsys/settings/littlefs/src/settings_test_littlefs.c
@@ -16,14 +16,14 @@ void test_main(void)
 {
 	ztest_test_suite(test_config,
 			 /* Config tests */
-			 ztest_unit_test(config_empty_lookups),
+			 ztest_unit_test(test_config_empty_lookups),
 			 ztest_unit_test(test_config_insert),
 			 ztest_unit_test(test_config_getset_unknown),
 			 ztest_unit_test(test_config_getset_int),
 			 ztest_unit_test(test_config_getset_int64),
 			 ztest_unit_test(test_config_commit),
 			 /* Littlefs as backing storage. */
-			 ztest_unit_test(config_setup_littlefs),
+			 ztest_unit_test(test_config_setup_littlefs),
 			 ztest_unit_test(test_config_empty_file),
 			 ztest_unit_test(test_config_small_file),
 			 ztest_unit_test(test_config_multiple_in_file),

--- a/tests/subsys/settings/nvs/src/settings_test_nvs.c
+++ b/tests/subsys/settings/nvs/src/settings_test_nvs.c
@@ -290,7 +290,7 @@ int c3_handle_export(int (*cb)(const char *name,
 	return 0;
 }
 
-void config_empty_lookups(void);
+void test_config_empty_lookups(void);
 void test_config_insert(void);
 void test_config_getset_unknown(void);
 void test_config_getset_int(void);
@@ -301,7 +301,7 @@ void test_main(void)
 {
 	ztest_test_suite(test_config_nvs,
 			 /* Config tests */
-			 ztest_unit_test(config_empty_lookups),
+			 ztest_unit_test(test_config_empty_lookups),
 			 ztest_unit_test(test_config_insert),
 			 ztest_unit_test(test_config_getset_unknown),
 			 ztest_unit_test(test_config_getset_int),

--- a/tests/subsys/settings/src/settings_empty_lookups.c
+++ b/tests/subsys/settings/src/settings_empty_lookups.c
@@ -7,7 +7,7 @@
 
 #include "settings_test.h"
 
-void config_empty_lookups(void)
+void test_config_empty_lookups(void)
 {
 	int rc;
 	char name[80];


### PR DESCRIPTION
Change test case names to proper ones, which start from "test_" characters.

This problem was detected during conducting this PR: https://github.com/zephyrproject-rtos/zephyr/pull/42482 