### PR TITLE
Bluetooth: Controller: df: Fix IQ sample data saturation info drop

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -2846,8 +2846,8 @@ static void le_df_connectionless_iq_report(struct pdu_data *pdu_rx,
 		sep->sample_count = 0U;
 	} else {
 		for (uint8_t idx = 0U; idx < samples_cnt; ++idx) {
-			sep->sample[idx].i = IQ_SHIFT_12_TO_8_BIT(iq_report->sample[idx].i);
-			sep->sample[idx].q = IQ_SHIFT_12_TO_8_BIT(iq_report->sample[idx].q);
+			sep->sample[idx].i = IQ_CONVERT_12_TO_8_BIT(iq_report->sample[idx].i);
+			sep->sample[idx].q = IQ_CONVERT_12_TO_8_BIT(iq_report->sample[idx].q);
 		}
 
 		sep->sample_count = samples_cnt;
@@ -2969,8 +2969,8 @@ static void le_df_connection_iq_report(struct node_rx_pdu *node_rx, struct net_b
 		sep->sample_count = 0U;
 	} else {
 		for (uint8_t idx = 0U; idx < samples_cnt; ++idx) {
-			sep->sample[idx].i = IQ_SHIFT_12_TO_8_BIT(iq_report->sample[idx].i);
-			sep->sample[idx].q = IQ_SHIFT_12_TO_8_BIT(iq_report->sample[idx].q);
+			sep->sample[idx].i = IQ_CONVERT_12_TO_8_BIT(iq_report->sample[idx].i);
+			sep->sample[idx].q = IQ_CONVERT_12_TO_8_BIT(iq_report->sample[idx].q);
 		}
 		sep->sample_count = samples_cnt;
 	}

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df_types.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df_types.h
@@ -66,8 +66,22 @@ struct lll_df_adv_cfg {
 #define IQ_SAMPLE_CNT (PDU_DC_LL_HEADER_SIZE + LL_LENGTH_OCTETS_RX_MAX)
 
 #define RSSI_DBM_TO_DECI_DBM(x) (-(x) * 10)
-#define IQ_SHIFT_12_TO_8_BIT(x) ((int8_t)((x) >> 4))
+/* Macro that represents out of range IQ sample (saturated). Value provided by Radio specifications.
+ * It is not defined by Bluetooth Core specification. This is the vendor specific value.
+ *
+ * Nordic Semiconductor Radio peripheral provides 16 bit wide IQ samples.
+ * BT 5.3 Core specification Vol 4, Part E sectons 7.7.65.21 and 7.7.65.22 limit size of
+ * IQ samples to 8 bits.
+ * To mitigate the limited accuratcy and losing information about saturated IQ samples a 0x80 value
+ * is selected to serve the purpose.
+ */
+#define IQ_SAMPLE_STATURATED_16_BIT 0x8000
+#define IQ_SAMPLE_STATURATED_8_BIT 0x80
 
+#define IQ_SHIFT_12_TO_8_BIT(x) ((int8_t)((x) >> 4))
+#define IQ_CONVERT_12_TO_8_BIT(x)                                                                  \
+	(((x) == IQ_SAMPLE_STATURATED_16_BIT) ? IQ_SAMPLE_STATURATED_8_BIT :                       \
+						      IQ_SHIFT_12_TO_8_BIT((x)))
 /* Structure to store an single IQ sample */
 struct iq_sample {
 	int16_t i;


### PR DESCRIPTION
Nordic Semiconductor Radio peripheral provides IQ samples as
12 bits signed integer with sign extended to 16 bits.
Where out of range IQ samples (saturated) have value -32768.

Due to conversion of IQ samples to 8 bit signed integer, required by
BT 5.3 Core Vol 4, Part E sections 7.7.65.21 and 7.7.65.22 the
saturation information was lost.

The PR fixes that issue by use of value -128 to mark saturated
IQ samples. Note that BT 5.3 Core does not give any particular
value of IQ sample a special meaning.

This is a vendor specific solution and does not affect other
implementations of lower link layer.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>