### PR TITLE
drivers: grio: Pull ups and disabling interrupts.

### DIFF
--- a/boards/arm/rpi_pico/rpi_pico.dts
+++ b/boards/arm/rpi_pico/rpi_pico.dts
@@ -23,7 +23,7 @@
 	leds {
 		compatible = "gpio-leds";
 		led0: led_0 {
-			gpios = <&gpio0 25 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio0 25 GPIO_ACTIVE_HIGH>;
 			label = "LED";
 		};
 	};

--- a/dts/arm/rpi_pico/rp2040.dtsi
+++ b/dts/arm/rpi_pico/rp2040.dtsi
@@ -66,6 +66,7 @@
 			#gpio-cells = <2>;
 			label = "GPIO_0";
 			status = "disabled";
+			ngpios = <30>;
 		};
 
 		uart0: uart@40034000 {


### PR DESCRIPTION
The initial RPi Pico GPIO driver has a couple small issues that need correcting. This was originally identified by @protobits

* Configuring of pulls needs to set both pull flags at once.
* Need the ability to also *disable* interrupts for a given pin.

Tested on Adafruit KB2040 and Adafruit QT Py RP2040.