### PR TITLE
syscon: Compile the generic driver only when selected

### DIFF
--- a/drivers/syscon/CMakeLists.txt
+++ b/drivers/syscon/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library()
-zephyr_library_sources_ifdef(CONFIG_SYSCON          syscon.c)
+zephyr_library_sources_ifdef(CONFIG_SYSCON_GENERIC          syscon.c)


### PR DESCRIPTION
Currently the generic driver is always unconditionally compiled. Fix
this by compiling it only when needed.

Fixes: #42502

Signed-off-by: Carlo Caione <ccaione@baylibre.com>