### PR TITLE
bmi160: bmi160_bus union bugfix

### DIFF
--- a/drivers/sensor/bmi160/bmi160.c
+++ b/drivers/sensor/bmi160/bmi160.c
@@ -8,8 +8,6 @@
  * http://ae-bst.resource.bosch.com/media/_tech/media/datasheets/BST-BMI160-DS000-07.pdf
  */
 
-#define DT_DRV_COMPAT bosch_bmi160
-
 #include <init.h>
 #include <drivers/i2c.h>
 #include <drivers/sensor.h>

--- a/drivers/sensor/bmi160/bmi160.h
+++ b/drivers/sensor/bmi160/bmi160.h
@@ -8,6 +8,8 @@
 #ifndef ZEPHYR_DRIVERS_SENSOR_BMI160_BMI160_H_
 #define ZEPHYR_DRIVERS_SENSOR_BMI160_BMI160_H_
 
+#define DT_DRV_COMPAT bosch_bmi160
+
 #include <drivers/i2c.h>
 #include <drivers/gpio.h>
 #include <drivers/sensor.h>


### PR DESCRIPTION
bmi160.c module defines DT_DRV_COMPAT, but bmi160_trigger.c doesn't.
This causes a catastrophic chain of events.
The bmi160.c module includes bmi160.h,
in which the macro DT_ANY_INST_ON_BUS_STATUS_OKAY
affects the size of bmi160_bus union.
So bmi160.c defines a bmi160_cfg struct which contains that union.
Now, in bmi160_trigger_init we get a pointer to that config struct.
The fact that this module now includes bmi160.h without
DT_DRV_COMPAT, causes it to think the union is empty.

That doesn't cause compilation error, just undefined behaviour,
In which you address an empty struct fields.

In general, I suggest that someone makes sure it doesn't happen
in other drivers as well. The problem presented here is general,
meaning that if an h file assumes someone defined DT_DRV_COMPAT
before and it doesn't,
it may lead to some weird behaviour, like the one described.

Signed-off-by: Avi Green <avigreen1978@yandex.com>