### PR TITLE
dts: arm: npcx: refactor the RAM configuration

### DIFF
--- a/dts/arm/nuvoton/npcx7m6fb.dtsi
+++ b/dts/arm/nuvoton/npcx7m6fb.dtsi
@@ -21,6 +21,12 @@
 		reg = <0x200C0000 DT_SIZE_K(62)>;
 	};
 
+	/* RAM space used by Booter */
+	bootloader_ram: memory@200cf800 {
+		compatible = "mmio-sram";
+		reg = <0x200CF800 DT_SIZE_K(2)>;
+	};
+
 	soc-id {
 		device-id = <0x21>;
 	};

--- a/dts/arm/nuvoton/npcx7m6fc.dtsi
+++ b/dts/arm/nuvoton/npcx7m6fc.dtsi
@@ -21,6 +21,12 @@
 		reg = <0x200C0000 DT_SIZE_K(62)>;
 	};
 
+	/* RAM space used by Booter */
+	bootloader_ram: memory@200cf800 {
+		compatible = "mmio-sram";
+		reg = <0x200CF800 DT_SIZE_K(2)>;
+	};
+
 	soc-id {
 		device-id = <0x29>;
 	};

--- a/dts/arm/nuvoton/npcx7m7fc.dtsi
+++ b/dts/arm/nuvoton/npcx7m7fc.dtsi
@@ -9,16 +9,26 @@
 
 / {
 	flash0: flash@10070000 {
-		reg = <0x10070000 DT_SIZE_K(320)>;
+		/*
+		 * Reallocate the last 64 KB of code RAM for use as data RAM
+		 * because the internal flash size is 512 KB.
+		 */
+		reg = <0x10070000 DT_SIZE_K(256)>;
 	};
 
 	flash1: flash@64000000 {
 		reg = <0x64000000 DT_SIZE_K(512)>;
 	};
 
-	sram0: memory@200c0000 {
+	sram0: memory@200b0000 {
 		compatible = "mmio-sram";
-		reg = <0x200C0000 DT_SIZE_K(62)>;
+		reg = <0x200B0000 DT_SIZE_K(126)>;
+	};
+
+	/* RAM space used by Booter */
+	bootloader_ram: memory@200cf800 {
+		compatible = "mmio-sram";
+		reg = <0x200CF800 DT_SIZE_K(2)>;
 	};
 
 	soc-id {


### PR DESCRIPTION
The last 2k bytes of the data RAM is used by the booter in some npcx EC
chips. This commit adds a bootloader_ramDT node to describe this additional
layout of the RAM. As a result, we can determine the total RAM size by
adding the size of flash0, sram0, and bootloader_ram.

Also, this commit moves 64k bytes from the code RAM (flash0) to the data
RAM (sram0) for npcx7m7fc because its internal flash is 512K bytes.
(In the Chromebook application, we need the code RAM size <= half of the
flash size.)

Signed-off-by: Jun Lin <CHLin56@nuvoton.com>