### PR TITLE
drivers: sensor: lis2dh: Allow power-down mode

### DIFF
--- a/drivers/sensor/lis2dh/lis2dh.c
+++ b/drivers/sensor/lis2dh/lis2dh.c
@@ -123,11 +123,6 @@ static int lis2dh_freq_to_odr_val(uint16_t freq)
 {
 	size_t i;
 
-	/* An ODR of 0 Hz is not allowed */
-	if (freq == 0U) {
-		return -EINVAL;
-	}
-
 	for (i = 0; i < ARRAY_SIZE(lis2dh_odr_map); i++) {
 		if (freq == lis2dh_odr_map[i]) {
 			return i;


### PR DESCRIPTION
Remove check if frequency is equal to zero. A value of `ODR = 0` is
explicitly allowed by manufacturer / datasheet.
This has prevented applications from using the lis2dh power-down-mode,
which is set via `ODR = 0`.

For reference see "Table 28. Data rate configuration" in datasheet p.33.

Fixes #35486.

Signed-off-by: Markus Brüx <markus.bruex@grandcentrix.net>