### PR TITLE
net: tcp: Fix possible deadlock in tcp_conn_unref()

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -403,8 +403,10 @@ static int tcp_conn_unref(struct tcp *conn)
 	}
 
 	if (conn->context->recv_cb) {
+		k_mutex_unlock(&tcp_lock);
 		conn->context->recv_cb(conn->context, NULL, NULL, NULL,
 					-ECONNRESET, conn->recv_user_data);
+		k_mutex_lock(&tcp_lock, K_FOREVER);
 	}
 
 	conn->context->tcp = NULL;


### PR DESCRIPTION
Hi, as I continue to stress our http server I have found a deadlock related to tcp stack and sockets.

Basically, when the http server is under a decent load racing keeps happening between my http connection thread and tcp stack's `rx_q` thread when they are both closing the connection at the same time. 

What happens is that http server calls `close()` on socket, which lock its socket lock in `z_impl_zsock_close()` and continues closing, but releases its processor time before setting the `context->recv_cb` to `NULL` . Now the `rx_q` comes by and proceeds to close the connection from tcp stack POV. Doing so will lock the `tcp_lock` in `tcp_conn_unref()` and because of `context->recv_cb` not being `NULL` it goes back to socket layer where it starts waiting for the socket lock.
Now the sleeping server thread wakes up and goes to `tcp_conn_unref()` where the `tcp_lock` is already taken by previous thread and here is the deadlock.

Solution is to:
Unlock tcp_lock when calling the recv_cb. In case when
a connection is being closed from both the tcp stack
and the application, a race condition can happen resulting
in locking each other out on tcp_lock and socket lock.

Please assess the fix as I am not 100% wether it didnt break anything else in tcp :)