### PR TITLE
logging: Add common api for getting memory usage

### DIFF
--- a/include/logging/log_ctrl.h
+++ b/include/logging/log_ctrl.h
@@ -220,6 +220,32 @@ static inline bool log_data_pending(void)
  */
 int log_set_tag(const char *tag);
 
+/**
+ * @brief Get current memory usage.
+ *
+ * @param[out] buf_size Capacity of the buffer used for storing log messages.
+ * @param[out] usage Number of bytes currently containing pending log messages.
+ *
+ * @retval -EINVAL if logging mode does not use the buffer.
+ * @retval 0 successfully collected usage data.
+ */
+int log_mem_get_usage(uint32_t *buf_size, uint32_t *usage);
+
+/**
+ * @brief Get maximum memory usage.
+ *
+ * Requires CONFIG_LOG_MEM_UTILIZATION option.
+ *
+ * @param[out] max Maximum number of bytes used for pending log messages.
+ *
+ * @retval -EINVAL if logging mode does not use the buffer.
+ * @retval -ENOTSUP if instrumentation is not enabled.
+ * not been enabled.
+ *
+ * @retval 0 successfully collected usage data.
+ */
+int log_mem_get_max_usage(uint32_t *max);
+
 #if defined(CONFIG_LOG) && !defined(CONFIG_LOG_MODE_MINIMAL)
 #define LOG_CORE_INIT() log_core_init()
 #define LOG_INIT() log_init()

--- a/include/logging/log_msg.h
+++ b/include/logging/log_msg.h
@@ -482,7 +482,12 @@ uint32_t log_msg_mem_get_used(void);
  */
 uint32_t log_msg_mem_get_max_used(void);
 
-
+/**
+ * @brief Get slab size
+ *
+ * @return Size of a slab used in slab pool for log messages.
+ */
+size_t log_msg_get_slab_size(void);
 /**
  * @}
  */

--- a/include/sys/mpsc_pbuf.h
+++ b/include/sys/mpsc_pbuf.h
@@ -58,6 +58,9 @@ extern "C" {
  */
 #define MPSC_PBUF_MODE_OVERWRITE BIT(1)
 
+/** @brief Flag indicating that maximum buffer usage is tracked. */
+#define MPSC_PBUF_MAX_UTILIZATION BIT(2)
+
 /**@} */
 
 /* Forward declaration */
@@ -111,6 +114,9 @@ struct mpsc_pbuf_buffer {
 
 	/* Buffer size in 32 bit words. */
 	uint32_t size;
+
+	/* Store max buffer usage. */
+	uint32_t max_usage;
 
 	struct k_sem sem;
 };
@@ -237,6 +243,24 @@ void mpsc_pbuf_free(struct mpsc_pbuf_buffer *buffer,
  */
 bool mpsc_pbuf_is_pending(struct mpsc_pbuf_buffer *buffer);
 
+/** @brief Get current memory utilization.
+ *
+ * @param[in, out] buffer Buffer.
+ * @param[out]     size   Buffer size in bytes.
+ * @param[out]     now    Current buffer usage in bytes.
+ */
+void mpsc_pbuf_get_utilization(struct mpsc_pbuf_buffer *buffer,
+			       uint32_t *size, uint32_t *now);
+
+/** @brief Get maximum memory utilization.
+ *
+ * @param[in, out] buffer Buffer.
+ * @param[out]     max    Maximum buffer usage in bytes.
+ *
+ * retval 0 if utilization data collected successfully.
+ * retval -ENOTSUP if Collecting utilization data is not supported.
+ */
+int mpsc_pbuf_get_max_utilization(struct mpsc_pbuf_buffer *buffer, uint32_t *max);
 /**
  * @}
  */

--- a/lib/os/mpsc_pbuf.c
+++ b/lib/os/mpsc_pbuf.c
@@ -35,6 +35,7 @@ void mpsc_pbuf_init(struct mpsc_pbuf_buffer *buffer,
 	buffer->notify_drop = cfg->notify_drop;
 	buffer->buf = cfg->buf;
 	buffer->size = cfg->size;
+	buffer->max_usage = 0;
 	buffer->flags = cfg->flags;
 
 	if (is_power_of_two(buffer->size)) {
@@ -72,6 +73,26 @@ static inline bool available(struct mpsc_pbuf_buffer *buffer, uint32_t *res)
 	*res = buffer->size - buffer->tmp_rd_idx;
 
 	return true;
+}
+
+static inline uint32_t get_usage(struct mpsc_pbuf_buffer *buffer)
+{
+	uint32_t f;
+
+	if (free_space(buffer, &f)) {
+		f += (buffer->rd_idx - 1);
+	}
+
+	return buffer->size - 1 - f;
+}
+
+static inline void max_utilization_update(struct mpsc_pbuf_buffer *buffer)
+{
+	if (!(buffer->flags & MPSC_PBUF_MAX_UTILIZATION)) {
+		return;
+	}
+
+	buffer->max_usage = MAX(buffer->max_usage, get_usage(buffer));
 }
 
 static inline bool is_valid(union mpsc_pbuf_generic *item)
@@ -190,6 +211,7 @@ void mpsc_pbuf_put_word(struct mpsc_pbuf_buffer *buffer,
 			buffer->tmp_wr_idx = idx_inc(buffer,
 						     buffer->tmp_wr_idx, 1);
 			buffer->wr_idx = idx_inc(buffer, buffer->wr_idx, 1);
+			max_utilization_update(buffer);
 		} else {
 			bool user_drop = buffer->flags & MPSC_PBUF_MODE_OVERWRITE;
 
@@ -288,6 +310,7 @@ void mpsc_pbuf_commit(struct mpsc_pbuf_buffer *buffer,
 
 	item->hdr.valid = 1;
 	buffer->wr_idx = idx_inc(buffer, buffer->wr_idx, wlen);
+	max_utilization_update(buffer);
 	k_spin_unlock(&buffer->lock, key);
 	MPSC_PBUF_DBG(buffer, "committed %p ", item);
 }
@@ -320,6 +343,7 @@ void mpsc_pbuf_put_word_ext(struct mpsc_pbuf_buffer *buffer,
 			buffer->tmp_wr_idx =
 				idx_inc(buffer, buffer->tmp_wr_idx, l);
 			buffer->wr_idx = idx_inc(buffer, buffer->wr_idx, l);
+			max_utilization_update(buffer);
 		} else if (wrap) {
 			add_skip_item(buffer, free_wlen);
 			cont = true;
@@ -363,6 +387,7 @@ void mpsc_pbuf_put_data(struct mpsc_pbuf_buffer *buffer, const uint32_t *data,
 			buffer->tmp_wr_idx =
 				idx_inc(buffer, buffer->tmp_wr_idx, wlen);
 			buffer->wr_idx = idx_inc(buffer, buffer->wr_idx, wlen);
+			max_utilization_update(buffer);
 		} else if (wrap) {
 			add_skip_item(buffer, free_wlen);
 			cont = true;
@@ -459,4 +484,23 @@ bool mpsc_pbuf_is_pending(struct mpsc_pbuf_buffer *buffer)
 	(void)available(buffer, &a);
 
 	return a ? true : false;
+}
+
+void mpsc_pbuf_get_utilization(struct mpsc_pbuf_buffer *buffer,
+			       uint32_t *size, uint32_t *now)
+{
+	/* One byte is left for full/empty distinction. */
+	*size = (buffer->size - 1) * sizeof(int);
+	*now = get_usage(buffer) * sizeof(int);
+}
+
+int mpsc_pbuf_get_max_utilization(struct mpsc_pbuf_buffer *buffer, uint32_t *max)
+{
+
+	if (!(buffer->flags & MPSC_PBUF_MAX_UTILIZATION)) {
+		return -ENOTSUP;
+	}
+
+	*max = buffer->max_usage * sizeof(int);
+	return 0;
 }

--- a/subsys/logging/Kconfig.misc
+++ b/subsys/logging/Kconfig.misc
@@ -53,4 +53,13 @@ config LOG2_FMT_SECTION
 	  removing strings from final binary and should be used for dictionary
 	  logging.
 
+config LOG_MEM_UTILIZATION
+	bool "Enable tracking maximum memory utilization"
+	depends on LOG_MODE_DEFERRED
+	default y if LOG_CMDS
+	select MEM_SLAB_TRACE_MAX_UTILIZATION if LOG1
+	help
+	  When enabled, maximum usage of memory used for log messages in deferred
+	  mode is tracked. It can be used to trim LOG_BUFFER_SIZE.
+
 endmenu

--- a/subsys/logging/log_cmds.c
+++ b/subsys/logging/log_cmds.c
@@ -404,25 +404,27 @@ static int cmd_log_strdup_utilization(const struct shell *shell,
 	return 0;
 }
 
-static int cmd_log_memory_slabs(const struct shell *sh, size_t argc, char **argv)
+static int cmd_log_mem(const struct shell *sh, size_t argc, char **argv)
 {
-	uint32_t slabs_free;
+	uint32_t size;
 	uint32_t used;
 	uint32_t max;
+	int err;
 
-	slabs_free = log_msg_mem_get_free();
-	used = log_msg_mem_get_used();
-
-	shell_print(sh, "Blocks used:\t%d", used);
-	shell_print(sh, "Blocks free:\t%d", slabs_free);
-	if (IS_ENABLED(CONFIG_MEM_SLAB_TRACE_MAX_UTILIZATION)) {
-		max = log_msg_mem_get_max_used();
-		shell_print(sh, "Blocks max:\t%d", max);
-	} else {
-		shell_print(
-			sh,
-			"Enable CONFIG_MEM_SLAB_TRACE_MAX_UTILIZATION to get max memory utilization");
+	err = log_mem_get_usage(&size, &used);
+	if (err < 0) {
+		shell_error(sh, "Failed to get usage (mode does not support it?)");
 	}
+
+	shell_print(sh, "Log message buffer utilization report:");
+	shell_print(sh, "\tCapacity: %u bytes", size);
+	shell_print(sh, "\tCurrently in use: %u bytes", used);
+	err = log_mem_get_max_usage(&max);
+	if (err < 0) {
+		shell_print(sh, "Enable CONFIG_LOG_MEM_UTILIZATION to get maximum usage");
+	}
+
+	shell_print(sh, "\tMaximum usage: %u bytes", max);
 
 	return 0;
 }
@@ -479,7 +481,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 			   "Get utilization of string duplicates pool", cmd_log_strdup_utilization,
 			   1, 0),
 	SHELL_COND_CMD(CONFIG_LOG_MODE_DEFERRED, mem, NULL, "Logger memory usage",
-		       cmd_log_memory_slabs),
+		       cmd_log_mem),
 	SHELL_SUBCMD_SET_END);
 
 SHELL_CMD_REGISTER(log, &sub_log_stat, "Commands for controlling logger",

--- a/subsys/logging/log_msg.c
+++ b/subsys/logging/log_msg.c
@@ -498,3 +498,8 @@ uint32_t log_msg_mem_get_max_used(void)
 {
 	return k_mem_slab_max_used_get(&log_msg_pool);
 }
+
+size_t log_msg_get_slab_size(void)
+{
+	return MSG_SIZE;
+}

--- a/tests/lib/mpsc_pbuf/src/main.c
+++ b/tests/lib/mpsc_pbuf/src/main.c
@@ -1068,6 +1068,129 @@ void test_pending_alloc(void)
 	k_thread_priority_set(k_current_get(), prio);
 }
 
+static void check_usage(struct mpsc_pbuf_buffer *buffer,
+			uint32_t now, int exp_err, uint32_t max, uint32_t line)
+{
+	uint32_t size;
+	uint32_t usage;
+	int err;
+
+	mpsc_pbuf_get_utilization(buffer, &size, &usage);
+	zassert_equal(size / sizeof(int), buffer->size - 1, "%d: got:%d, exp:%d",
+			line, size / sizeof(int), buffer->size - 1);
+	zassert_equal(usage, now, "%d: got:%d, exp:%d", line, usage, now);
+
+	err = mpsc_pbuf_get_max_utilization(buffer, &usage);
+	zassert_equal(err, exp_err, NULL);
+	if (err == 0) {
+		zassert_equal(usage, max, "%d: got:%d, exp:%d", line, usage, max);
+	}
+}
+
+#define CHECK_USAGE(buffer, now, max) \
+	check_usage(buffer, (now) * sizeof(int), 0, (max) * sizeof(int), __LINE__)
+
+static void ignore_drop(const struct mpsc_pbuf_buffer *buffer,
+			const union mpsc_pbuf_generic *item)
+{
+	ARG_UNUSED(buffer);
+	ARG_UNUSED(item);
+}
+
+void test_utilization(void)
+{
+	struct mpsc_pbuf_buffer buffer;
+	struct mpsc_pbuf_buffer_config config = {
+		.buf = buf32,
+		.size = ARRAY_SIZE(buf32),
+		.notify_drop = ignore_drop,
+		.get_wlen = get_wlen,
+		.flags = 0 /* Utilization not supported. */
+	};
+
+	mpsc_pbuf_init(&buffer, &config);
+
+	check_usage(&buffer, 0, -ENOTSUP, 0, __LINE__);
+
+	/* Initialize with max utilization support. */
+	config.flags = MPSC_PBUF_MAX_UTILIZATION;
+	mpsc_pbuf_init(&buffer, &config);
+
+	CHECK_USAGE(&buffer, 0, 0);
+
+	union test_item test_1word = {.data = {.valid = 1, .len = 1 }};
+	union test_item test_ext_item = {
+		.data = {
+			.valid = 1,
+			.len = PUT_EXT_LEN
+		}
+	};
+	union test_item *t;
+
+	mpsc_pbuf_put_word(&buffer, test_1word.item);
+
+	CHECK_USAGE(&buffer, 1, 1);
+
+	mpsc_pbuf_put_word_ext(&buffer, test_ext_item.item, NULL);
+
+	CHECK_USAGE(&buffer, 1 + PUT_EXT_LEN, 1 + PUT_EXT_LEN);
+
+	t = (union test_item *)mpsc_pbuf_claim(&buffer);
+
+	zassert_true(t != NULL, NULL);
+	CHECK_USAGE(&buffer, 1 + PUT_EXT_LEN, 1 + PUT_EXT_LEN);
+	mpsc_pbuf_free(&buffer, &t->item);
+
+	t = (union test_item *)mpsc_pbuf_claim(&buffer);
+	zassert_true(t != NULL, NULL);
+
+	CHECK_USAGE(&buffer, PUT_EXT_LEN, 1 + PUT_EXT_LEN);
+
+	mpsc_pbuf_free(&buffer, &t->item);
+
+	CHECK_USAGE(&buffer, 0, 1 + PUT_EXT_LEN);
+
+	union test_item test_ext_item2 = {
+		.data_ext = {
+			.hdr = {
+				.valid = 1,
+				.len = PUT_EXT_LEN
+			},
+			.data = NULL
+		}
+	};
+
+	mpsc_pbuf_put_data(&buffer, (uint32_t *)&test_ext_item2, PUT_EXT_LEN);
+
+	CHECK_USAGE(&buffer, PUT_EXT_LEN, 1 + PUT_EXT_LEN);
+
+	t = (union test_item *)mpsc_pbuf_claim(&buffer);
+	zassert_true(t != NULL, NULL);
+	mpsc_pbuf_free(&buffer, &t->item);
+
+	CHECK_USAGE(&buffer, 0, 1 + PUT_EXT_LEN);
+
+	memset(&buffer, 0, sizeof(buffer));
+	/* Initialize to reset indexes. */
+	mpsc_pbuf_init(&buffer, &config);
+
+	struct test_data_var *packet;
+	uint32_t len = 5;
+	uint32_t i;
+
+	for (i = 0; i < (buffer.size - 1) / len; i++) {
+		packet = (struct test_data_var *)mpsc_pbuf_alloc(&buffer, len, K_NO_WAIT);
+		packet->hdr.len = len;
+
+		mpsc_pbuf_commit(&buffer, (union mpsc_pbuf_generic *)packet);
+		CHECK_USAGE(&buffer, len * (i + 1), len * (i + 1));
+	}
+
+	packet = (struct test_data_var *)mpsc_pbuf_alloc(&buffer, len, K_NO_WAIT);
+
+	zassert_true(packet == NULL, NULL);
+}
+
 /*test case main entry*/
 void test_main(void)
 {
@@ -1090,7 +1213,8 @@ void test_main(void)
 		ztest_unit_test(test_overwrite_while_claimed),
 		ztest_unit_test(test_overwrite_while_claimed2),
 		ztest_unit_test(test_overwrite_consistency),
-		ztest_unit_test(test_pending_alloc)
+		ztest_unit_test(test_pending_alloc),
+		ztest_unit_test(test_utilization)
 		);
 	ztest_run_test_suite(test_log_buffer);
 }

--- a/tests/subsys/logging/log_msg2/src/main.c
+++ b/tests/subsys/logging/log_msg2/src/main.c
@@ -189,11 +189,11 @@ void test_log_msg2_0_args_msg(void)
 	test_init();
 	printk("Test string:%s\n", TEST_MSG);
 
-	Z_LOG_MSG2_CREATE2(1, mode, 0, domain, source, level,
+	Z_LOG_MSG2_CREATE3(1, mode, 0, domain, source, level,
 			  NULL, 0, TEST_MSG);
 	zassert_equal(mode, EXP_MODE(ZERO_COPY), NULL);
 
-	Z_LOG_MSG2_CREATE2(0, mode, 0, domain, source, level,
+	Z_LOG_MSG2_CREATE3(0, mode, 0, domain, source, level,
 			  NULL, 0, TEST_MSG);
 	zassert_equal(mode, EXP_MODE(FROM_STACK), NULL);
 
@@ -222,11 +222,11 @@ void test_log_msg2_various_args(void)
 	test_init();
 	printk("Test string:%s\n", TEST_MSG);
 
-	Z_LOG_MSG2_CREATE2(1, mode, 0, domain, source, level, NULL, 0,
+	Z_LOG_MSG2_CREATE3(1, mode, 0, domain, source, level, NULL, 0,
 			TEST_MSG, s8, u, lld, (void *)str, lld, (void *)iarray);
 	zassert_equal(mode, EXP_MODE(ZERO_COPY), NULL);
 
-	Z_LOG_MSG2_CREATE2(0, mode, 0, domain, source, level, NULL, 0,
+	Z_LOG_MSG2_CREATE3(0, mode, 0, domain, source, level, NULL, 0,
 			TEST_MSG, s8, u, lld, (void *)str, lld, (void *)iarray);
 	zassert_equal(mode, EXP_MODE(FROM_STACK), NULL);
 
@@ -249,11 +249,11 @@ void test_log_msg2_only_data(void)
 
 	test_init();
 
-	Z_LOG_MSG2_CREATE2(1, mode, 0, domain, source, level, array,
+	Z_LOG_MSG2_CREATE3(1, mode, 0, domain, source, level, array,
 			   sizeof(array));
 	zassert_equal(mode, EXP_MODE(FROM_STACK), NULL);
 
-	Z_LOG_MSG2_CREATE2(0, mode, 0, domain, source, level, array,
+	Z_LOG_MSG2_CREATE3(0, mode, 0, domain, source, level, array,
 			   sizeof(array));
 	zassert_equal(mode, EXP_MODE(FROM_STACK), NULL);
 
@@ -278,11 +278,11 @@ void test_log_msg2_string_and_data(void)
 
 	test_init();
 
-	Z_LOG_MSG2_CREATE2(1, mode, 0, domain, source, level, array,
+	Z_LOG_MSG2_CREATE3(1, mode, 0, domain, source, level, array,
 			   sizeof(array), TEST_MSG);
 	zassert_equal(mode, EXP_MODE(FROM_STACK), NULL);
 
-	Z_LOG_MSG2_CREATE2(0, mode, 0, domain, source, level, array,
+	Z_LOG_MSG2_CREATE3(0, mode, 0, domain, source, level, array,
 			   sizeof(array), TEST_MSG);
 	zassert_equal(mode, EXP_MODE(FROM_STACK), NULL);
 
@@ -315,11 +315,11 @@ void test_log_msg2_fp(void)
 
 	test_init();
 
-	Z_LOG_MSG2_CREATE2(1, mode, 0, domain, source, level, NULL, 0,
+	Z_LOG_MSG2_CREATE3(1, mode, 0, domain, source, level, NULL, 0,
 			TEST_MSG, i, lli, (double)f, &i, d, source);
 	zassert_equal(mode, EXP_MODE(ZERO_COPY), NULL);
 
-	Z_LOG_MSG2_CREATE2(0, mode, 0, domain, source, level, NULL, 0,
+	Z_LOG_MSG2_CREATE3(0, mode, 0, domain, source, level, NULL, 0,
 			TEST_MSG, i, lli, (double)f, &i, d, source);
 	zassert_equal(mode, EXP_MODE(FROM_STACK), NULL);
 
@@ -354,12 +354,12 @@ void test_mode_size_plain_string(void)
 	uint32_t exp_len;
 	int mode;
 
-	Z_LOG_MSG2_CREATE2(1, mode, 0, domain, source, level, NULL, 0,
+	Z_LOG_MSG2_CREATE3(1, mode, 0, domain, source, level, NULL, 0,
 			"test str");
 	zassert_equal(mode, EXP_MODE(ZERO_COPY),
 			"Unexpected creation mode");
 
-	Z_LOG_MSG2_CREATE2(0, mode, 0, domain, source, level, NULL, 0,
+	Z_LOG_MSG2_CREATE3(0, mode, 0, domain, source, level, NULL, 0,
 			"test str");
 	zassert_equal(mode, EXP_MODE(FROM_STACK),
 			"Unexpected creation mode");
@@ -393,7 +393,7 @@ void test_mode_size_data_only(void)
 	 */
 	uint8_t data[] = {1, 2, 3};
 
-	Z_LOG_MSG2_CREATE2(1, mode, 0, domain, source, level,
+	Z_LOG_MSG2_CREATE3(1, mode, 0, domain, source, level,
 			   data, sizeof(data));
 	zassert_equal(mode, EXP_MODE(FROM_STACK),
 			"Unexpected creation mode");
@@ -421,7 +421,7 @@ void test_mode_size_plain_str_data(void)
 	 */
 	uint8_t data[] = {1, 2, 3};
 
-	Z_LOG_MSG2_CREATE2(1, mode, 0, domain, source, level,
+	Z_LOG_MSG2_CREATE3(1, mode, 0, domain, source, level,
 			   data, sizeof(data), "test");
 	zassert_equal(mode, EXP_MODE(FROM_STACK),
 			"Unexpected creation mode");
@@ -450,13 +450,13 @@ void test_mode_size_str_with_strings(void)
 	int mode;
 	static const char *prefix = "prefix";
 
-	Z_LOG_MSG2_CREATE2(1, mode,
+	Z_LOG_MSG2_CREATE3(1, mode,
 			   1 /* accept one string pointer*/,
 			   domain, source, level,
 			   NULL, 0, "test %s", prefix);
 	zassert_equal(mode, EXP_MODE(ZERO_COPY),
 			"Unexpected creation mode");
-	Z_LOG_MSG2_CREATE2(0, mode,
+	Z_LOG_MSG2_CREATE3(0, mode,
 			   1 /* accept one string pointer*/,
 			   domain, source, level,
 			   NULL, 0, "test %s", prefix);
@@ -489,13 +489,13 @@ void test_mode_size_str_with_2strings(void)
 	int mode;
 	static const char *prefix = "prefix";
 
-	Z_LOG_MSG2_CREATE2(1, mode,
+	Z_LOG_MSG2_CREATE3(1, mode,
 			   1 /* accept one string pointer*/,
 			   domain, source, level,
 			   NULL, 0, TEST_STR, prefix, "sufix");
 	zassert_equal(mode, EXP_MODE(RUNTIME),
 			"Unexpected creation mode");
-	Z_LOG_MSG2_CREATE2(0, mode,
+	Z_LOG_MSG2_CREATE3(0, mode,
 			   1 /* accept one string pointer*/,
 			   domain, source, level,
 			   NULL, 0, TEST_STR, prefix, "sufix");
@@ -546,14 +546,14 @@ void test_saturate(void)
 	log_set_timestamp_func(timestamp_get_inc, 0);
 
 	for (int i = 0; i < exp_capacity; i++) {
-		Z_LOG_MSG2_CREATE2(1, mode, 0, 0, (void *)1, 2, NULL, 0, "test");
+		Z_LOG_MSG2_CREATE3(1, mode, 0, 0, (void *)1, 2, NULL, 0, "test");
 	}
 
 	zassert_equal(z_log_dropped_read_and_clear(), 0, "No dropped messages.");
 
 	/* Message should not fit in and be dropped. */
-	Z_LOG_MSG2_CREATE2(1, mode, 0, 0, (void *)1, 2, NULL, 0, "test");
-	Z_LOG_MSG2_CREATE2(0, mode, 0, 0, (void *)1, 2, NULL, 0, "test");
+	Z_LOG_MSG2_CREATE3(1, mode, 0, 0, (void *)1, 2, NULL, 0, "test");
+	Z_LOG_MSG2_CREATE3(0, mode, 0, 0, (void *)1, 2, NULL, 0, "test");
 	z_log_msg2_runtime_create(0, (void *)1, 2, NULL, 0, "test");
 
 	zassert_equal(z_log_dropped_read_and_clear(), 3, "No dropped messages.");


### PR DESCRIPTION
Logging v2 did not support getting memory usage data. Adding this
support by creating common api for getting current and maximum
usage. Tracking of maximum usage is optional and can be enabled
using CONFIG_LOG_MEM_UTILIZATION.
    
Updated shell command to use common API.

In order to achieve that `mpsc_pbuf` has been extended:

**lib: os: mpsc_pbuf: Add usage tracking**

Add API to fetch current buffer usage. Add option to track
maximum buffer usage and API to fetch that value.

Fixes #42360.
