### PR TITLE
Bluetooth: conn: Expose simplified connection state in get_info

### DIFF
--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -312,6 +312,17 @@ enum {
 	BT_CONN_ROLE_PERIPHERAL = 1,
 };
 
+enum bt_conn_state {
+	/** Channel disconnected */
+	BT_CONN_STATE_DISCONNECTED,
+	/** Channel in connecting state */
+	BT_CONN_STATE_CONNECTING,
+	/** Channel connected and ready for upper layer traffic on it */
+	BT_CONN_STATE_CONNECTED,
+	/** Channel in disconnecting state */
+	BT_CONN_STATE_DISCONNECTING,
+};
+
 /** Connection role (central or peripheral) */
 #define BT_CONN_ROLE_MASTER __DEPRECATED_MACRO BT_CONN_ROLE_CENTRAL
 #define BT_CONN_ROLE_SLAVE __DEPRECATED_MACRO BT_CONN_ROLE_PERIPHERAL
@@ -331,6 +342,8 @@ struct bt_conn_info {
 		/** BR/EDR Connection specific Info. */
 		struct bt_conn_br_info br;
 	};
+
+	enum bt_conn_state state;
 };
 
 /** LE Connection Remote Info Structure */

--- a/include/bluetooth/iso.h
+++ b/include/bluetooth/iso.h
@@ -89,13 +89,13 @@ extern "C" {
  */
 enum {
 	/** Channel disconnected */
-	BT_ISO_DISCONNECTED,
+	BT_ISO_STATE_DISCONNECTED,
 	/** Channel in connecting state */
-	BT_ISO_CONNECTING,
+	BT_ISO_STATE_CONNECTING,
 	/** Channel ready for upper layer traffic on it */
-	BT_ISO_CONNECTED,
+	BT_ISO_STATE_CONNECTED,
 	/** Channel in disconnecting state */
-	BT_ISO_DISCONNECTING,
+	BT_ISO_STATE_DISCONNECTING,
 };
 
 

--- a/include/bluetooth/iso.h
+++ b/include/bluetooth/iso.h
@@ -87,7 +87,7 @@ extern "C" {
  *  dealing with setting channel to proper state depending on operational
  *  context.
  */
-enum {
+enum bt_iso_state {
 	/** Channel disconnected */
 	BT_ISO_STATE_DISCONNECTED,
 	/** Channel in connecting state */
@@ -114,7 +114,7 @@ struct bt_iso_chan {
 	struct bt_iso_chan_ops		*ops;
 	/** Channel QoS reference */
 	struct bt_iso_chan_qos		*qos;
-	uint8_t				state;
+	enum bt_iso_state		state;
 	bt_security_t			required_sec_level;
 	/** Node used internally by the stack */
 	sys_snode_t node;

--- a/include/bluetooth/iso.h
+++ b/include/bluetooth/iso.h
@@ -91,11 +91,11 @@ enum {
 	/** Channel disconnected */
 	BT_ISO_DISCONNECTED,
 	/** Channel in connecting state */
-	BT_ISO_CONNECT,
+	BT_ISO_CONNECTING,
 	/** Channel ready for upper layer traffic on it */
 	BT_ISO_CONNECTED,
 	/** Channel in disconnecting state */
-	BT_ISO_DISCONNECT,
+	BT_ISO_DISCONNECTING,
 };
 
 

--- a/samples/bluetooth/iso_connected_benchmark/src/main.c
+++ b/samples/bluetooth/iso_connected_benchmark/src/main.c
@@ -310,7 +310,7 @@ static int iso_accept(const struct bt_iso_accept_info *info,
 	LOG_INF("Incoming ISO request from %p", (void *)info->acl);
 
 	for (int i = 0; i < ARRAY_SIZE(iso_chans); i++) {
-		if (iso_chans[i].chan.state == BT_ISO_DISCONNECTED) {
+		if (iso_chans[i].chan.state == BT_ISO_STATE_DISCONNECTED) {
 			LOG_INF("Returning instance %d", i);
 			*chan = &iso_chans[i].chan;
 			cig_create_param.num_cis++;

--- a/subsys/bluetooth/audio/stream.c
+++ b/subsys/bluetooth/audio/stream.c
@@ -989,11 +989,11 @@ int bt_audio_stream_connect(struct bt_audio_stream *stream)
 	param.iso_chan = stream->iso;
 
 	switch (stream->iso->state) {
-	case BT_ISO_DISCONNECTED:
+	case BT_ISO_STATE_DISCONNECTED:
 		return bt_iso_chan_connect(&param, 1);
-	case BT_ISO_CONNECTING:
+	case BT_ISO_STATE_CONNECTING:
 		return 0;
-	case BT_ISO_CONNECTED:
+	case BT_ISO_STATE_CONNECTED:
 		return -EALREADY;
 	default:
 		return bt_iso_chan_connect(&param, 1);

--- a/subsys/bluetooth/audio/stream.c
+++ b/subsys/bluetooth/audio/stream.c
@@ -991,7 +991,7 @@ int bt_audio_stream_connect(struct bt_audio_stream *stream)
 	switch (stream->iso->state) {
 	case BT_ISO_DISCONNECTED:
 		return bt_iso_chan_connect(&param, 1);
-	case BT_ISO_CONNECT:
+	case BT_ISO_CONNECTING:
 		return 0;
 	case BT_ISO_CONNECTED:
 		return -EALREADY;

--- a/subsys/bluetooth/audio/unicast_client.c
+++ b/subsys/bluetooth/audio/unicast_client.c
@@ -382,7 +382,7 @@ static void unicast_client_ep_qos_state(struct bt_audio_ep *ep,
 	       stream->qos->pd);
 
 	/* Disconnect ISO if connected */
-	if (stream->iso->state == BT_ISO_CONNECTED) {
+	if (stream->iso->state == BT_ISO_STATE_CONNECTED) {
 		bt_audio_stream_disconnect(stream);
 	}
 

--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -872,7 +872,7 @@ static int le_adv_start_add_conn(const struct bt_le_ext_adv *adv,
 			return -ENOMEM;
 		}
 
-		bt_conn_set_state(conn, BT_CONN_CONNECT_ADV);
+		bt_conn_set_state(conn, BT_CONN_CONNECTING_ADV);
 		*out_conn = conn;
 		return 0;
 	}
@@ -886,7 +886,7 @@ static int le_adv_start_add_conn(const struct bt_le_ext_adv *adv,
 		return -ENOMEM;
 	}
 
-	bt_conn_set_state(conn, BT_CONN_CONNECT_DIR_ADV);
+	bt_conn_set_state(conn, BT_CONN_CONNECTING_DIR_ADV);
 	*out_conn = conn;
 	return 0;
 }
@@ -897,10 +897,10 @@ static void le_adv_stop_free_conn(const struct bt_le_ext_adv *adv, uint8_t statu
 
 	if (!bt_addr_le_cmp(&adv->target_addr, BT_ADDR_LE_ANY)) {
 		conn = bt_conn_lookup_state_le(adv->id, BT_ADDR_LE_NONE,
-					       BT_CONN_CONNECT_ADV);
+					       BT_CONN_CONNECTING_ADV);
 	} else {
 		conn = bt_conn_lookup_state_le(adv->id, &adv->target_addr,
-					       BT_CONN_CONNECT_DIR_ADV);
+					       BT_CONN_CONNECTING_DIR_ADV);
 	}
 
 	if (conn) {

--- a/subsys/bluetooth/host/br.c
+++ b/subsys/bluetooth/host/br.c
@@ -118,7 +118,7 @@ static void bt_esco_conn_req(struct bt_hci_evt_conn_request *evt)
 	}
 
 	sco_conn->role = BT_HCI_ROLE_PERIPHERAL;
-	bt_conn_set_state(sco_conn, BT_CONN_CONNECT);
+	bt_conn_set_state(sco_conn, BT_CONN_CONNECTING);
 	bt_conn_unref(sco_conn);
 }
 
@@ -143,7 +143,7 @@ void bt_hci_conn_req(struct net_buf *buf)
 
 	accept_conn(&evt->bdaddr);
 	conn->role = BT_HCI_ROLE_PERIPHERAL;
-	bt_conn_set_state(conn, BT_CONN_CONNECT);
+	bt_conn_set_state(conn, BT_CONN_CONNECTING);
 	bt_conn_unref(conn);
 }
 

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1558,7 +1558,8 @@ static void deferred_work(struct k_work *work)
 			struct bt_iso_chan *chan = iso->iso.chan;
 
 			if (chan != NULL) {
-				bt_iso_chan_set_state(chan, BT_ISO_DISCONNECT);
+				bt_iso_chan_set_state(chan,
+						      BT_ISO_DISCONNECTING);
 			}
 
 			bt_iso_cleanup_acl(iso);

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1559,7 +1559,7 @@ static void deferred_work(struct k_work *work)
 
 			if (chan != NULL) {
 				bt_iso_chan_set_state(chan,
-						      BT_ISO_DISCONNECTING);
+						      BT_ISO_STATE_DISCONNECTING);
 			}
 
 			bt_iso_cleanup_acl(iso);

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -134,20 +134,20 @@ static inline const char *state2str(bt_conn_state_t state)
 		return "disconnected";
 	case BT_CONN_DISCONNECT_COMPLETE:
 		return "disconnect-complete";
-	case BT_CONN_CONNECT_SCAN:
-		return "connect-scan";
-	case BT_CONN_CONNECT_DIR_ADV:
-		return "connect-dir-adv";
-	case BT_CONN_CONNECT_ADV:
-		return "connect-adv";
-	case BT_CONN_CONNECT_AUTO:
-		return "connect-auto";
-	case BT_CONN_CONNECT:
-		return "connect";
+	case BT_CONN_CONNECTING_SCAN:
+		return "connecting-scan";
+	case BT_CONN_CONNECTING_DIR_ADV:
+		return "connecting-dir-adv";
+	case BT_CONN_CONNECTING_ADV:
+		return "connecting-adv";
+	case BT_CONN_CONNECTING_AUTO:
+		return "connecting-auto";
+	case BT_CONN_CONNECTING:
+		return "connecting";
 	case BT_CONN_CONNECTED:
 		return "connected";
-	case BT_CONN_DISCONNECT:
-		return "disconnect";
+	case BT_CONN_DISCONNECTING:
+		return "disconnecting";
 	default:
 		return "(unknown)";
 	}
@@ -837,7 +837,7 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 			bt_conn_ref(conn);
 		}
 		break;
-	case BT_CONN_CONNECT:
+	case BT_CONN_CONNECTING:
 		if (IS_ENABLED(CONFIG_BT_CENTRAL) &&
 		    conn->type == BT_CONN_TYPE_LE) {
 			k_work_cancel_delayable(&conn->deferred_work);
@@ -899,7 +899,7 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 			k_poll_signal_raise(&conn_change, 0);
 			/* The last ref will be dropped during cleanup */
 			break;
-		case BT_CONN_CONNECT:
+		case BT_CONN_CONNECTING:
 			/* LE Create Connection command failed. This might be
 			 * directly from the API, don't notify application in
 			 * this case.
@@ -910,7 +910,7 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 
 			bt_conn_unref(conn);
 			break;
-		case BT_CONN_CONNECT_SCAN:
+		case BT_CONN_CONNECTING_SCAN:
 			/* this indicate LE Create Connection with peer address
 			 * has been stopped. This could either be triggered by
 			 * the application through bt_conn_disconnect or by
@@ -922,7 +922,7 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 
 			bt_conn_unref(conn);
 			break;
-		case BT_CONN_CONNECT_DIR_ADV:
+		case BT_CONN_CONNECTING_DIR_ADV:
 			/* this indicate Directed advertising stopped */
 			if (conn->err) {
 				notify_connected(conn);
@@ -930,36 +930,36 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 
 			bt_conn_unref(conn);
 			break;
-		case BT_CONN_CONNECT_AUTO:
+		case BT_CONN_CONNECTING_AUTO:
 			/* this indicates LE Create Connection with filter
 			 * policy has been stopped. This can only be triggered
 			 * by the application, so don't notify.
 			 */
 			bt_conn_unref(conn);
 			break;
-		case BT_CONN_CONNECT_ADV:
+		case BT_CONN_CONNECTING_ADV:
 			/* This can only happen when application stops the
 			 * advertiser, conn->err is never set in this case.
 			 */
 			bt_conn_unref(conn);
 			break;
 		case BT_CONN_CONNECTED:
-		case BT_CONN_DISCONNECT:
+		case BT_CONN_DISCONNECTING:
 		case BT_CONN_DISCONNECTED:
 			/* Cannot happen. */
 			BT_WARN("Invalid (%u) old state", state);
 			break;
 		}
 		break;
-	case BT_CONN_CONNECT_AUTO:
+	case BT_CONN_CONNECTING_AUTO:
 		break;
-	case BT_CONN_CONNECT_ADV:
+	case BT_CONN_CONNECTING_ADV:
 		break;
-	case BT_CONN_CONNECT_SCAN:
+	case BT_CONN_CONNECTING_SCAN:
 		break;
-	case BT_CONN_CONNECT_DIR_ADV:
+	case BT_CONN_CONNECTING_DIR_ADV:
 		break;
-	case BT_CONN_CONNECT:
+	case BT_CONN_CONNECTING:
 		if (conn->type == BT_CONN_TYPE_SCO) {
 			break;
 		}
@@ -974,7 +974,7 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 		}
 
 		break;
-	case BT_CONN_DISCONNECT:
+	case BT_CONN_DISCONNECTING:
 		break;
 #endif /* CONFIG_BT_CONN */
 	case BT_CONN_DISCONNECT_COMPLETE:
@@ -1233,7 +1233,7 @@ static int conn_disconnect(struct bt_conn *conn, uint8_t reason)
 	}
 
 	if (conn->state == BT_CONN_CONNECTED) {
-		bt_conn_set_state(conn, BT_CONN_DISCONNECT);
+		bt_conn_set_state(conn, BT_CONN_DISCONNECTING);
 	}
 
 	return 0;
@@ -1254,14 +1254,14 @@ int bt_conn_disconnect(struct bt_conn *conn, uint8_t reason)
 #endif /* !defined(CONFIG_BT_FILTER_ACCEPT_LIST) */
 
 	switch (conn->state) {
-	case BT_CONN_CONNECT_SCAN:
+	case BT_CONN_CONNECTING_SCAN:
 		conn->err = reason;
 		bt_conn_set_state(conn, BT_CONN_DISCONNECTED);
 		if (IS_ENABLED(CONFIG_BT_CENTRAL)) {
 			bt_le_scan_update(false);
 		}
 		return 0;
-	case BT_CONN_CONNECT:
+	case BT_CONN_CONNECTING:
 #if defined(CONFIG_BT_BREDR)
 		if (conn->type == BT_CONN_TYPE_BR) {
 			return bt_hci_connect_br_cancel(conn);
@@ -1276,7 +1276,7 @@ int bt_conn_disconnect(struct bt_conn *conn, uint8_t reason)
 		return 0;
 	case BT_CONN_CONNECTED:
 		return conn_disconnect(conn, reason);
-	case BT_CONN_DISCONNECT:
+	case BT_CONN_DISCONNECTING:
 		return 0;
 	case BT_CONN_DISCONNECTED:
 	default:
@@ -1642,7 +1642,7 @@ struct bt_conn *bt_conn_create_br(const bt_addr_t *peer,
 	conn = bt_conn_lookup_addr_br(peer);
 	if (conn) {
 		switch (conn->state) {
-		case BT_CONN_CONNECT:
+		case BT_CONN_CONNECTING:
 		case BT_CONN_CONNECTED:
 			return conn;
 		default:
@@ -1677,7 +1677,7 @@ struct bt_conn *bt_conn_create_br(const bt_addr_t *peer,
 		return NULL;
 	}
 
-	bt_conn_set_state(conn, BT_CONN_CONNECT);
+	bt_conn_set_state(conn, BT_CONN_CONNECTING);
 	conn->role = BT_CONN_ROLE_CENTRAL;
 
 	return conn;
@@ -1693,7 +1693,7 @@ struct bt_conn *bt_conn_create_sco(const bt_addr_t *peer)
 	sco_conn = bt_conn_lookup_addr_sco(peer);
 	if (sco_conn) {
 		switch (sco_conn->state) {
-		case BT_CONN_CONNECT:
+		case BT_CONN_CONNECTING:
 		case BT_CONN_CONNECTED:
 			return sco_conn;
 		default:
@@ -1739,7 +1739,7 @@ struct bt_conn *bt_conn_create_sco(const bt_addr_t *peer)
 		return NULL;
 	}
 
-	bt_conn_set_state(sco_conn, BT_CONN_CONNECT);
+	bt_conn_set_state(sco_conn, BT_CONN_CONNECTING);
 
 	return sco_conn;
 }
@@ -2213,15 +2213,15 @@ static enum bt_conn_state conn_internal_to_public_state(bt_conn_state_t state)
 	case BT_CONN_DISCONNECTED:
 	case BT_CONN_DISCONNECT_COMPLETE:
 		return BT_CONN_STATE_DISCONNECTED;
-	case BT_CONN_CONNECT_SCAN:
-	case BT_CONN_CONNECT_AUTO:
-	case BT_CONN_CONNECT_ADV:
-	case BT_CONN_CONNECT_DIR_ADV:
-	case BT_CONN_CONNECT:
+	case BT_CONN_CONNECTING_SCAN:
+	case BT_CONN_CONNECTING_AUTO:
+	case BT_CONN_CONNECTING_ADV:
+	case BT_CONN_CONNECTING_DIR_ADV:
+	case BT_CONN_CONNECTING:
 		return BT_CONN_STATE_CONNECTING;
 	case BT_CONN_CONNECTED:
 		return BT_CONN_STATE_CONNECTED;
-	case BT_CONN_DISCONNECT:
+	case BT_CONN_DISCONNECTING:
 		return BT_CONN_STATE_DISCONNECTING;
 	default:
 		__ASSERT(false, "Invalid conn state %u", state);
@@ -2511,7 +2511,7 @@ int bt_conn_le_create_auto(const struct bt_conn_le_create_param *create_param,
 	}
 
 	conn = bt_conn_lookup_state_le(BT_ID_DEFAULT, BT_ADDR_LE_NONE,
-				       BT_CONN_CONNECT_AUTO);
+				       BT_CONN_CONNECTING_AUTO);
 	if (conn) {
 		bt_conn_unref(conn);
 		return -EALREADY;
@@ -2541,7 +2541,7 @@ int bt_conn_le_create_auto(const struct bt_conn_le_create_param *create_param,
 	create_param_setup(create_param);
 
 	atomic_set_bit(conn->flags, BT_CONN_AUTO_CONNECT);
-	bt_conn_set_state(conn, BT_CONN_CONNECT_AUTO);
+	bt_conn_set_state(conn, BT_CONN_CONNECTING_AUTO);
 
 	err = bt_le_create_conn(conn);
 	if (err) {
@@ -2569,7 +2569,7 @@ int bt_conn_create_auto_stop(void)
 	}
 
 	conn = bt_conn_lookup_state_le(BT_ID_DEFAULT, BT_ADDR_LE_NONE,
-				       BT_CONN_CONNECT_AUTO);
+				       BT_CONN_CONNECTING_AUTO);
 	if (!conn) {
 		return -EINVAL;
 	}
@@ -2647,7 +2647,7 @@ int bt_conn_le_create(const bt_addr_le_t *peer,
 
 #if defined(CONFIG_BT_SMP)
 	if (!bt_dev.le.rl_size || bt_dev.le.rl_entries > bt_dev.le.rl_size) {
-		bt_conn_set_state(conn, BT_CONN_CONNECT_SCAN);
+		bt_conn_set_state(conn, BT_CONN_CONNECTING_SCAN);
 
 		err = bt_le_scan_update(true);
 		if (err) {
@@ -2662,7 +2662,7 @@ int bt_conn_le_create(const bt_addr_le_t *peer,
 	}
 #endif
 
-	bt_conn_set_state(conn, BT_CONN_CONNECT);
+	bt_conn_set_state(conn, BT_CONN_CONNECTING);
 
 	err = bt_le_create_conn(conn);
 	if (err) {
@@ -2716,7 +2716,7 @@ int bt_le_set_auto_conn(const bt_addr_le_t *addr,
 		if (atomic_test_and_clear_bit(conn->flags,
 					      BT_CONN_AUTO_CONNECT)) {
 			bt_conn_unref(conn);
-			if (conn->state == BT_CONN_CONNECT_SCAN) {
+			if (conn->state == BT_CONN_CONNECTING_SCAN) {
 				bt_conn_set_state(conn, BT_CONN_DISCONNECTED);
 			}
 		}
@@ -2725,7 +2725,7 @@ int bt_le_set_auto_conn(const bt_addr_le_t *addr,
 	if (conn->state == BT_CONN_DISCONNECTED &&
 	    atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
 		if (param) {
-			bt_conn_set_state(conn, BT_CONN_CONNECT_SCAN);
+			bt_conn_set_state(conn, BT_CONN_CONNECTING_SCAN);
 		}
 		bt_le_scan_update(false);
 	}
@@ -2927,7 +2927,8 @@ int bt_conn_init(void)
 					    BT_CONN_AUTO_CONNECT)) {
 				/* Only the default identity is supported */
 				conn->id = BT_ID_DEFAULT;
-				bt_conn_set_state(conn, BT_CONN_CONNECT_SCAN);
+				bt_conn_set_state(conn,
+						  BT_CONN_CONNECTING_SCAN);
 			}
 #endif /* !defined(CONFIG_BT_FILTER_ACCEPT_LIST) */
 

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2207,11 +2207,34 @@ const bt_addr_le_t *bt_conn_get_dst(const struct bt_conn *conn)
 	return &conn->le.dst;
 }
 
+static enum bt_conn_state conn_internal_to_public_state(bt_conn_state_t state)
+{
+	switch (state) {
+	case BT_CONN_DISCONNECTED:
+	case BT_CONN_DISCONNECT_COMPLETE:
+		return BT_CONN_STATE_DISCONNECTED;
+	case BT_CONN_CONNECT_SCAN:
+	case BT_CONN_CONNECT_AUTO:
+	case BT_CONN_CONNECT_ADV:
+	case BT_CONN_CONNECT_DIR_ADV:
+	case BT_CONN_CONNECT:
+		return BT_CONN_STATE_CONNECTING;
+	case BT_CONN_CONNECTED:
+		return BT_CONN_STATE_CONNECTED;
+	case BT_CONN_DISCONNECT:
+		return BT_CONN_STATE_DISCONNECTING;
+	default:
+		__ASSERT(false, "Invalid conn state %u", state);
+		return 0;
+	}
+}
+
 int bt_conn_get_info(const struct bt_conn *conn, struct bt_conn_info *info)
 {
 	info->type = conn->type;
 	info->role = conn->role;
 	info->id = conn->id;
+	info->state = conn_internal_to_public_state(conn->state);
 
 	switch (conn->type) {
 	case BT_CONN_TYPE_LE:

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -14,13 +14,13 @@
 typedef enum __packed {
 	BT_CONN_DISCONNECTED,
 	BT_CONN_DISCONNECT_COMPLETE,
-	BT_CONN_CONNECT_SCAN,
-	BT_CONN_CONNECT_AUTO,
-	BT_CONN_CONNECT_ADV,
-	BT_CONN_CONNECT_DIR_ADV,
-	BT_CONN_CONNECT,
+	BT_CONN_CONNECTING_SCAN,
+	BT_CONN_CONNECTING_AUTO,
+	BT_CONN_CONNECTING_ADV,
+	BT_CONN_CONNECTING_DIR_ADV,
+	BT_CONN_CONNECTING,
 	BT_CONN_CONNECTED,
-	BT_CONN_DISCONNECT,
+	BT_CONN_DISCONNECTING,
 } bt_conn_state_t;
 
 /* bt_conn flags: the flags defined here represent connection parameters */
@@ -300,10 +300,10 @@ static inline bool bt_conn_is_handle_valid(struct bt_conn *conn)
 {
 	switch (conn->state) {
 	case BT_CONN_CONNECTED:
-	case BT_CONN_DISCONNECT:
+	case BT_CONN_DISCONNECTING:
 	case BT_CONN_DISCONNECT_COMPLETE:
 		return true;
-	case BT_CONN_CONNECT:
+	case BT_CONN_CONNECTING:
 		/* ISO connection handle assigned at connect state */
 		if (IS_ENABLED(CONFIG_BT_ISO) &&
 		    conn->type == BT_CONN_TYPE_ISO) {

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -194,7 +194,7 @@ void bt_hci_host_num_completed_packets(struct net_buf *buf)
 	}
 
 	if (conn->state != BT_CONN_CONNECTED &&
-	    conn->state != BT_CONN_DISCONNECT) {
+	    conn->state != BT_CONN_DISCONNECTING) {
 		BT_WARN("Not reporting packet for non-connected conn");
 		bt_conn_unref(conn);
 		return;
@@ -763,7 +763,7 @@ static void hci_disconn_complete(struct net_buf *buf)
 
 #if defined(CONFIG_BT_CENTRAL) && !defined(CONFIG_BT_FILTER_ACCEPT_LIST)
 	if (atomic_test_bit(conn->flags, BT_CONN_AUTO_CONNECT)) {
-		bt_conn_set_state(conn, BT_CONN_CONNECT_SCAN);
+		bt_conn_set_state(conn, BT_CONN_CONNECTING_SCAN);
 		bt_le_scan_update(false);
 	}
 #endif /* defined(CONFIG_BT_CENTRAL) && !defined(CONFIG_BT_FILTER_ACCEPT_LIST) */
@@ -896,11 +896,11 @@ static struct bt_conn *find_pending_connect(uint8_t role, bt_addr_le_t *peer_add
 	 */
 	if (IS_ENABLED(CONFIG_BT_CENTRAL) && role == BT_HCI_ROLE_CENTRAL) {
 		conn = bt_conn_lookup_state_le(BT_ID_DEFAULT, peer_addr,
-					       BT_CONN_CONNECT);
+					       BT_CONN_CONNECTING);
 		if (IS_ENABLED(CONFIG_BT_FILTER_ACCEPT_LIST) && !conn) {
 			conn = bt_conn_lookup_state_le(BT_ID_DEFAULT,
 						       BT_ADDR_LE_NONE,
-						       BT_CONN_CONNECT_AUTO);
+						       BT_CONN_CONNECTING_AUTO);
 		}
 
 		return conn;
@@ -908,11 +908,11 @@ static struct bt_conn *find_pending_connect(uint8_t role, bt_addr_le_t *peer_add
 
 	if (IS_ENABLED(CONFIG_BT_PERIPHERAL) && role == BT_HCI_ROLE_PERIPHERAL) {
 		conn = bt_conn_lookup_state_le(bt_dev.adv_conn_id, peer_addr,
-					       BT_CONN_CONNECT_DIR_ADV);
+					       BT_CONN_CONNECTING_DIR_ADV);
 		if (!conn) {
 			conn = bt_conn_lookup_state_le(bt_dev.adv_conn_id,
 						       BT_ADDR_LE_NONE,
-						       BT_CONN_CONNECT_ADV);
+						       BT_CONN_CONNECTING_ADV);
 		}
 
 		return conn;
@@ -1038,7 +1038,7 @@ static void le_conn_complete_cancel(void)
 		/* Check if device is marked for autoconnect. */
 		if (atomic_test_bit(conn->flags, BT_CONN_AUTO_CONNECT)) {
 			/* Restart passive scanner for device */
-			bt_conn_set_state(conn, BT_CONN_CONNECT_SCAN);
+			bt_conn_set_state(conn, BT_CONN_CONNECTING_SCAN);
 		}
 	} else {
 		if (atomic_test_bit(conn->flags, BT_CONN_AUTO_CONNECT)) {

--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -453,7 +453,7 @@ static void rpa_timeout(struct k_work *work)
 	if (IS_ENABLED(CONFIG_BT_CENTRAL)) {
 		struct bt_conn *conn =
 			bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL,
-						BT_CONN_CONNECT_SCAN);
+						BT_CONN_CONNECTING_SCAN);
 
 		if (conn) {
 			bt_conn_unref(conn);
@@ -711,7 +711,7 @@ void bt_id_add(struct bt_keys *keys)
 		return;
 	}
 
-	conn = bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL, BT_CONN_CONNECT);
+	conn = bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL, BT_CONN_CONNECTING);
 	if (conn) {
 		bt_id_pending_keys_update_set(keys, BT_KEYS_ID_PENDING_ADD);
 		bt_conn_unref(conn);
@@ -853,7 +853,7 @@ void bt_id_del(struct bt_keys *keys)
 		return;
 	}
 
-	conn = bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL, BT_CONN_CONNECT);
+	conn = bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL, BT_CONN_CONNECTING);
 	if (conn) {
 		bt_id_pending_keys_update_set(keys, BT_KEYS_ID_PENDING_DEL);
 		bt_conn_unref(conn);
@@ -1614,7 +1614,7 @@ int bt_le_oob_get_local(uint8_t id, struct bt_le_oob *oob)
 			struct bt_conn *conn;
 
 			conn = bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL,
-						       BT_CONN_CONNECT_SCAN);
+						       BT_CONN_CONNECTING_SCAN);
 			if (conn) {
 				/* Cannot set new RPA while creating
 				 * connections.
@@ -1686,7 +1686,7 @@ int bt_le_ext_adv_oob_get_local(struct bt_le_ext_adv *adv,
 
 				conn = bt_conn_lookup_state_le(
 					BT_ID_DEFAULT, NULL,
-					BT_CONN_CONNECT_SCAN);
+					BT_CONN_CONNECTING_SCAN);
 
 				if (conn) {
 					/* Cannot set new RPA while creating

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -519,7 +519,8 @@ const char *bt_iso_chan_state_str(uint8_t state)
 	}
 }
 
-void bt_iso_chan_set_state_debug(struct bt_iso_chan *chan, uint8_t state,
+void bt_iso_chan_set_state_debug(struct bt_iso_chan *chan,
+				 enum bt_iso_state state,
 				 const char *func, int line)
 {
 	BT_DBG("chan %p iso %p %s -> %s", chan, chan->iso,
@@ -554,7 +555,7 @@ void bt_iso_chan_set_state_debug(struct bt_iso_chan *chan, uint8_t state,
 	chan->state = state;
 }
 #else
-void bt_iso_chan_set_state(struct bt_iso_chan *chan, uint8_t state)
+void bt_iso_chan_set_state(struct bt_iso_chan *chan, enum bt_iso_state state)
 {
 	chan->state = state;
 }

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -463,7 +463,7 @@ static void bt_iso_chan_disconnected(struct bt_iso_chan *chan, uint8_t reason)
 			is_chan_connected = false;
 			SYS_SLIST_FOR_EACH_CONTAINER(&cig->cis_channels, cis_chan, node) {
 				if (cis_chan->state == BT_ISO_CONNECTED ||
-				    cis_chan->state == BT_ISO_CONNECT) {
+				    cis_chan->state == BT_ISO_CONNECTING) {
 					is_chan_connected = true;
 					break;
 				}
@@ -508,12 +508,12 @@ const char *bt_iso_chan_state_str(uint8_t state)
 	switch (state) {
 	case BT_ISO_DISCONNECTED:
 		return "disconnected";
-	case BT_ISO_CONNECT:
-		return "connect";
+	case BT_ISO_CONNECTING:
+		return "connecting";
 	case BT_ISO_CONNECTED:
 		return "connected";
-	case BT_ISO_DISCONNECT:
-		return "disconnect";
+	case BT_ISO_DISCONNECTING:
+		return "disconnecting";
 	default:
 		return "unknown";
 	}
@@ -531,17 +531,17 @@ void bt_iso_chan_set_state_debug(struct bt_iso_chan *chan, uint8_t state,
 	case BT_ISO_DISCONNECTED:
 		/* regardless of old state always allows this states */
 		break;
-	case BT_ISO_CONNECT:
+	case BT_ISO_CONNECTING:
 		if (chan->state != BT_ISO_DISCONNECTED) {
 			BT_WARN("%s()%d: invalid transition", func, line);
 		}
 		break;
 	case BT_ISO_CONNECTED:
-		if (chan->state != BT_ISO_CONNECT) {
+		if (chan->state != BT_ISO_CONNECTING) {
 			BT_WARN("%s()%d: invalid transition", func, line);
 		}
 		break;
-	case BT_ISO_DISCONNECT:
+	case BT_ISO_DISCONNECTING:
 		if (chan->state != BT_ISO_CONNECTED) {
 			BT_WARN("%s()%d: invalid transition", func, line);
 		}
@@ -817,7 +817,7 @@ static int iso_accept(struct bt_conn *acl, struct bt_conn *iso)
 	}
 
 	bt_iso_chan_add(iso, chan);
-	bt_iso_chan_set_state(chan, BT_ISO_CONNECT);
+	bt_iso_chan_set_state(chan, BT_ISO_CONNECTING);
 
 	return 0;
 }
@@ -1580,7 +1580,7 @@ int bt_iso_chan_connect(const struct bt_iso_connect_param *param, size_t count)
 
 		iso_chan->iso->iso.acl = bt_conn_ref(param[i].acl);
 		bt_conn_set_state(iso_chan->iso, BT_CONN_CONNECTING);
-		bt_iso_chan_set_state(iso_chan, BT_ISO_CONNECT);
+		bt_iso_chan_set_state(iso_chan, BT_ISO_CONNECTING);
 
 		cig = get_cig(iso_chan);
 		__ASSERT(cig != NULL, "CIG was NULL");
@@ -1789,7 +1789,7 @@ static int hci_le_create_big(struct bt_le_ext_adv *padv, struct bt_iso_big *big,
 	}
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&big->bis_channels, bis, node) {
-		bt_iso_chan_set_state(bis, BT_ISO_CONNECT);
+		bt_iso_chan_set_state(bis, BT_ISO_CONNECTING);
 	}
 
 	return err;
@@ -2030,7 +2030,7 @@ int bt_iso_big_terminate(struct bt_iso_big *big)
 		 */
 		if (!err) {
 			SYS_SLIST_FOR_EACH_CONTAINER(&big->bis_channels, bis, node) {
-				bt_iso_chan_set_state(bis, BT_ISO_DISCONNECT);
+				bt_iso_chan_set_state(bis, BT_ISO_DISCONNECTING);
 			}
 		}
 	} else if (IS_ENABLED(CONFIG_BT_ISO_SYNC_RECEIVER)) {
@@ -2248,7 +2248,7 @@ int bt_iso_big_sync(struct bt_le_per_adv_sync *sync, struct bt_iso_big_sync_para
 
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&big->bis_channels, bis, node) {
-		bt_iso_chan_set_state(bis, BT_ISO_CONNECT);
+		bt_iso_chan_set_state(bis, BT_ISO_CONNECTING);
 	}
 
 	*out_big = big;

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -1014,7 +1014,7 @@ void hci_le_cis_req(struct net_buf *buf)
 
 	iso->handle = cis_handle;
 	iso->role = BT_HCI_ROLE_PERIPHERAL;
-	bt_conn_set_state(iso, BT_CONN_CONNECT);
+	bt_conn_set_state(iso, BT_CONN_CONNECTING);
 
 	err = hci_le_accept_cis(cis_handle);
 	if (err) {
@@ -1579,7 +1579,7 @@ int bt_iso_chan_connect(const struct bt_iso_connect_param *param, size_t count)
 		struct bt_iso_cig *cig;
 
 		iso_chan->iso->iso.acl = bt_conn_ref(param[i].acl);
-		bt_conn_set_state(iso_chan->iso, BT_CONN_CONNECT);
+		bt_conn_set_state(iso_chan->iso, BT_CONN_CONNECTING);
 		bt_iso_chan_set_state(iso_chan, BT_ISO_CONNECT);
 
 		cig = get_cig(iso_chan);

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -376,7 +376,7 @@ void bt_iso_connected(struct bt_conn *iso)
 		return;
 	}
 
-	bt_iso_chan_set_state(chan, BT_ISO_CONNECTED);
+	bt_iso_chan_set_state(chan, BT_ISO_STATE_CONNECTED);
 
 	if (chan->ops->connected) {
 		chan->ops->connected(chan);
@@ -432,7 +432,7 @@ static void bt_iso_chan_disconnected(struct bt_iso_chan *chan, uint8_t reason)
 
 	__ASSERT(chan->iso != NULL, "NULL conn for iso chan %p", chan);
 
-	bt_iso_chan_set_state(chan, BT_ISO_DISCONNECTED);
+	bt_iso_chan_set_state(chan, BT_ISO_STATE_DISCONNECTED);
 
 	/* The peripheral does not have the concept of a CIG, so once a CIS
 	 * disconnects it is completely freed by unref'ing it
@@ -462,8 +462,8 @@ static void bt_iso_chan_disconnected(struct bt_iso_chan *chan, uint8_t reason)
 
 			is_chan_connected = false;
 			SYS_SLIST_FOR_EACH_CONTAINER(&cig->cis_channels, cis_chan, node) {
-				if (cis_chan->state == BT_ISO_CONNECTED ||
-				    cis_chan->state == BT_ISO_CONNECTING) {
+				if (cis_chan->state == BT_ISO_STATE_CONNECTED ||
+				    cis_chan->state == BT_ISO_STATE_CONNECTING) {
 					is_chan_connected = true;
 					break;
 				}
@@ -506,13 +506,13 @@ void bt_iso_disconnected(struct bt_conn *iso)
 const char *bt_iso_chan_state_str(uint8_t state)
 {
 	switch (state) {
-	case BT_ISO_DISCONNECTED:
+	case BT_ISO_STATE_DISCONNECTED:
 		return "disconnected";
-	case BT_ISO_CONNECTING:
+	case BT_ISO_STATE_CONNECTING:
 		return "connecting";
-	case BT_ISO_CONNECTED:
+	case BT_ISO_STATE_CONNECTED:
 		return "connected";
-	case BT_ISO_DISCONNECTING:
+	case BT_ISO_STATE_DISCONNECTING:
 		return "disconnecting";
 	default:
 		return "unknown";
@@ -528,21 +528,21 @@ void bt_iso_chan_set_state_debug(struct bt_iso_chan *chan, uint8_t state,
 
 	/* check transitions validness */
 	switch (state) {
-	case BT_ISO_DISCONNECTED:
+	case BT_ISO_STATE_DISCONNECTED:
 		/* regardless of old state always allows this states */
 		break;
-	case BT_ISO_CONNECTING:
-		if (chan->state != BT_ISO_DISCONNECTED) {
+	case BT_ISO_STATE_CONNECTING:
+		if (chan->state != BT_ISO_STATE_DISCONNECTED) {
 			BT_WARN("%s()%d: invalid transition", func, line);
 		}
 		break;
-	case BT_ISO_CONNECTED:
-		if (chan->state != BT_ISO_CONNECTING) {
+	case BT_ISO_STATE_CONNECTED:
+		if (chan->state != BT_ISO_STATE_CONNECTING) {
 			BT_WARN("%s()%d: invalid transition", func, line);
 		}
 		break;
-	case BT_ISO_DISCONNECTING:
-		if (chan->state != BT_ISO_CONNECTED) {
+	case BT_ISO_STATE_DISCONNECTING:
+		if (chan->state != BT_ISO_STATE_CONNECTED) {
 			BT_WARN("%s()%d: invalid transition", func, line);
 		}
 		break;
@@ -752,7 +752,7 @@ int bt_iso_chan_send(struct bt_iso_chan *chan, struct net_buf *buf)
 
 	BT_DBG("chan %p len %zu", chan, net_buf_frags_len(buf));
 
-	if (chan->state != BT_ISO_CONNECTED) {
+	if (chan->state != BT_ISO_STATE_CONNECTED) {
 		BT_DBG("Not connected");
 		return -ENOTCONN;
 	}
@@ -817,7 +817,7 @@ static int iso_accept(struct bt_conn *acl, struct bt_conn *iso)
 	}
 
 	bt_iso_chan_add(iso, chan);
-	bt_iso_chan_set_state(chan, BT_ISO_CONNECTING);
+	bt_iso_chan_set_state(chan, BT_ISO_STATE_CONNECTING);
 
 	return 0;
 }
@@ -1560,8 +1560,8 @@ int bt_iso_chan_connect(const struct bt_iso_connect_param *param, size_t count)
 			return -EINVAL;
 		}
 
-		if (param[i].iso_chan->state != BT_ISO_DISCONNECTED) {
-			BT_DBG("[%zu]: ISO is not in the BT_ISO_DISCONNECTED state: %u",
+		if (param[i].iso_chan->state != BT_ISO_STATE_DISCONNECTED) {
+			BT_DBG("[%zu]: ISO is not in the BT_ISO_STATE_DISCONNECTED state: %u",
 			       i, param[i].iso_chan->state);
 			return -EINVAL;
 		}
@@ -1580,7 +1580,7 @@ int bt_iso_chan_connect(const struct bt_iso_connect_param *param, size_t count)
 
 		iso_chan->iso->iso.acl = bt_conn_ref(param[i].acl);
 		bt_conn_set_state(iso_chan->iso, BT_CONN_CONNECTING);
-		bt_iso_chan_set_state(iso_chan, BT_ISO_CONNECTING);
+		bt_iso_chan_set_state(iso_chan, BT_ISO_STATE_CONNECTING);
 
 		cig = get_cig(iso_chan);
 		__ASSERT(cig != NULL, "CIG was NULL");
@@ -1789,7 +1789,7 @@ static int hci_le_create_big(struct bt_le_ext_adv *padv, struct bt_iso_big *big,
 	}
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&big->bis_channels, bis, node) {
-		bt_iso_chan_set_state(bis, BT_ISO_CONNECTING);
+		bt_iso_chan_set_state(bis, BT_ISO_STATE_CONNECTING);
 	}
 
 	return err;
@@ -2030,7 +2030,7 @@ int bt_iso_big_terminate(struct bt_iso_big *big)
 		 */
 		if (!err) {
 			SYS_SLIST_FOR_EACH_CONTAINER(&big->bis_channels, bis, node) {
-				bt_iso_chan_set_state(bis, BT_ISO_DISCONNECTING);
+				bt_iso_chan_set_state(bis, BT_ISO_STATE_DISCONNECTING);
 			}
 		}
 	} else if (IS_ENABLED(CONFIG_BT_ISO_SYNC_RECEIVER)) {
@@ -2248,7 +2248,7 @@ int bt_iso_big_sync(struct bt_le_per_adv_sync *sync, struct bt_iso_big_sync_para
 
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&big->bis_channels, bis, node) {
-		bt_iso_chan_set_state(bis, BT_ISO_CONNECTING);
+		bt_iso_chan_set_state(bis, BT_ISO_STATE_CONNECTING);
 	}
 
 	*out_big = big;

--- a/subsys/bluetooth/host/iso_internal.h
+++ b/subsys/bluetooth/host/iso_internal.h
@@ -150,12 +150,13 @@ struct net_buf *bt_iso_create_frag_timeout(size_t reserve, k_timeout_t timeout);
 #endif
 
 #if defined(CONFIG_BT_DEBUG_ISO)
-void bt_iso_chan_set_state_debug(struct bt_iso_chan *chan, uint8_t state,
+void bt_iso_chan_set_state_debug(struct bt_iso_chan *chan,
+				 enum bt_iso_state state,
 				 const char *func, int line);
 #define bt_iso_chan_set_state(_chan, _state) \
 	bt_iso_chan_set_state_debug(_chan, _state, __func__, __LINE__)
 #else
-void bt_iso_chan_set_state(struct bt_iso_chan *chan, uint8_t state);
+void bt_iso_chan_set_state(struct bt_iso_chan *chan, enum bt_iso_state state);
 #endif /* CONFIG_BT_DEBUG_ISO */
 
 /* Process incoming data for a connection */

--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -330,14 +330,14 @@ int bt_le_scan_update(bool fast_scan)
 
 		/* don't restart scan if we have pending connection */
 		conn = bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL,
-					       BT_CONN_CONNECT);
+					       BT_CONN_CONNECTING);
 		if (conn) {
 			bt_conn_unref(conn);
 			return 0;
 		}
 
 		conn = bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL,
-					       BT_CONN_CONNECT_SCAN);
+					       BT_CONN_CONNECTING_SCAN);
 		if (conn) {
 			atomic_set_bit(bt_dev.flags, BT_DEV_SCAN_FILTER_DUP);
 
@@ -373,7 +373,7 @@ static void check_pending_conn(const bt_addr_le_t *id_addr,
 	}
 
 	conn = bt_conn_lookup_state_le(BT_ID_DEFAULT, id_addr,
-				       BT_CONN_CONNECT_SCAN);
+				       BT_CONN_CONNECTING_SCAN);
 	if (!conn) {
 		return;
 	}
@@ -388,7 +388,7 @@ static void check_pending_conn(const bt_addr_le_t *id_addr,
 		goto failed;
 	}
 
-	bt_conn_set_state(conn, BT_CONN_CONNECT);
+	bt_conn_set_state(conn, BT_CONN_CONNECTING);
 	bt_conn_unref(conn);
 	return;
 


### PR DESCRIPTION
Add a state field in struct bt_conn_info that is a simplified
version of the internal state value (bt_conn_state_t).

This should provide an application to better determine the state
of the connection whne calling bt_conn_get_info, in case the
application does not keep track of the state itself.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

fixes https://github.com/zephyrproject-rtos/zephyr/issues/28009