### PR TITLE
[backport2.7] logging: Fix tracking of active messages

### DIFF
--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -737,8 +737,12 @@ uint32_t log_get_strdup_pool_utilization(void);
 uint32_t log_get_strdup_longest_string(void);
 
 /** @brief Indicate to the log core that one log message has been dropped.
+ *
+ * @param buffered True if dropped message was already buffered and it is being
+ * dropped to free space for another message. False if message is being dropped
+ * because allocation failed.
  */
-void z_log_dropped(void);
+void z_log_dropped(bool buffered);
 
 /** @brief Read and clear current drop indications counter.
  *

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -847,6 +847,7 @@ uint32_t z_vrfy_log_buffered_cnt(void)
 void z_log_dropped(void)
 {
 	atomic_inc(&dropped_cnt);
+	atomic_dec(&buffered_cnt);
 }
 
 uint32_t z_log_dropped_read_and_clear(void)

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -844,10 +844,12 @@ uint32_t z_vrfy_log_buffered_cnt(void)
 #include <syscalls/log_buffered_cnt_mrsh.c>
 #endif
 
-void z_log_dropped(void)
+void z_log_dropped(bool buffered)
 {
 	atomic_inc(&dropped_cnt);
-	atomic_dec(&buffered_cnt);
+	if (buffered) {
+		atomic_dec(&buffered_cnt);
+	}
 }
 
 uint32_t z_log_dropped_read_and_clear(void)
@@ -866,7 +868,7 @@ static void notify_drop(const struct mpsc_pbuf_buffer *buffer,
 	ARG_UNUSED(buffer);
 	ARG_UNUSED(item);
 
-	z_log_dropped();
+	z_log_dropped(true);
 }
 
 

--- a/subsys/logging/log_msg.c
+++ b/subsys/logging/log_msg.c
@@ -172,13 +172,13 @@ union log_msg_chunk *log_msg_no_space_handle(void)
 	if (IS_ENABLED(CONFIG_LOG_MODE_OVERFLOW)) {
 		do {
 			more = log_process(true);
-			z_log_dropped();
+			z_log_dropped(true);
 			err = k_mem_slab_alloc(&log_msg_pool,
 					       (void **)&msg,
 					       K_NO_WAIT);
 		} while ((err != 0) && more);
 	} else {
-		z_log_dropped();
+		z_log_dropped(false);
 	}
 	return msg;
 

--- a/subsys/logging/log_msg2.c
+++ b/subsys/logging/log_msg2.c
@@ -13,7 +13,7 @@ void z_log_msg2_finalize(struct log_msg2 *msg, const void *source,
 			 const struct log_msg2_desc desc, const void *data)
 {
 	if (!msg) {
-		z_log_dropped();
+		z_log_dropped(false);
 
 		return;
 	}


### PR DESCRIPTION
Backporting #40735 and #41969 (added later as first fix was not complete).

Fixes #41488 for 2.7.