### PR TITLE
scripts: volatile declarations checkpatch.pl

### DIFF
--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -3527,7 +3527,7 @@ sub process {
 			# known declaration macros
 		      $sline =~ /^\+\s+$declaration_macros/ ||
 			# start of struct or union or enum
-		      $sline =~ /^\+\s+(?:static\s+)?(?:const\s+)?(?:union|struct|enum|typedef)\b/ ||
+		      $sline =~ /^\+\s+(?:volatile\s+)?(?:static\s+)?(?:const\s+)?(?:union|struct|enum|typedef)\b/ ||
 			# start or end of block or continuation of declaration
 		      $sline =~ /^\+\s+(?:$|[\{\}\.\#\"\?\:\(\[])/ ||
 			# bitfield continuation


### PR DESCRIPTION
checkpatch.pl would react to the following:
-:81: WARNING: Missing a blank line after declarations
+	int err;
+	volatile struct segment_header *hdr = (volatile struct segment_header *)ctrl->shared_memory;

This patch allows for volatile struct declarations.

Signed-off-by: Måns Ansgariusson <Mansgariusson@gmail.com>