### PR TITLE
First attempt to mcumgr group 0 tests

### DIFF
--- a/tests/subsys/mgmt/mcumgr/smp_group_0/CMakeLists.txt
+++ b/tests/subsys/mgmt/mcumgr/smp_group_0/CMakeLists.txt
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(mcumgr_smp_group_0)
+
+FILE(GLOB app_sources
+	src/*.c
+)
+#zephyr_library_include_directories(${ZEPHYR_BASE}/subsys/mgmt/mcumgr/)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/subsys/mgmt/mcumgr/smp_group_0/prj.conf
+++ b/tests/subsys/mgmt/mcumgr/smp_group_0/prj.conf
@@ -1,0 +1,14 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+CONFIG_ZTEST=y
+# THis is annoying
+CONFIG_TINYCBOR=y
+CONFIG_MCUMGR=y
+#CONFIG_MCUMGR_BUF_COUNT=2
+CONFIG_MCUMGR_CMD_OS_MGMT=y
+CONFIG_OS_MGMT_ECHO=y
+# TODO: remove
+CONFIG_COMPILER_COLOR_DIAGNOSTICS=n

--- a/tests/subsys/mgmt/mcumgr/smp_group_0/src/main.c
+++ b/tests/subsys/mgmt/mcumgr/smp_group_0/src/main.c
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <ztest.h>
+#include <sys/byteorder.h>
+#include <net/buf.h>
+#include <mgmt/mgmt.h>
+#include "os_mgmt/os_mgmt.h"
+
+
+/* Request/response buffers */
+extern struct net_buf_simple ut_mcumgr_req_buf;
+extern struct net_buf_simple ut_mcumgr_rsp_buf;
+
+/* The callback that is given to the ut_smp_req_mcumgr to be called when
+ * response buffer is ready for processing. Function should access response
+ * buffer via global pointer ut_mcumgr_res_buf and return EMGMT_ error
+ * code.
+ */
+typedef int (*mcumgr_rsp_callback)(void);
+
+/* The function directly returns result of calling smp_process_request_packet */
+int ut_smp_req_to_mcumgr(struct net_buf_simple *nb, mcumgr_rsp_callback rps_cb);
+
+static void dump_hex(char *title, uint8_t *p, size_t len)
+{
+	uint8_t *end = p + len;
+	int i = 0;
+
+	if (len == 0) {
+		return;
+	}
+	TC_PRINT("HEX DUMP START: %s %p + %d\n", title, p, len);
+	TC_PRINT("    | +0 +1 +2 +3 +4 +5 +6 +7 +8 +9 +a +b +c +d +e +f\n");
+	while (end != p) {
+		if (i % 16 == 0) {
+			TC_PRINT("%04x| ", i);
+		}
+		TC_PRINT("%02x ", *p);
+		++i;
+		++p;
+		if (i % 16 == 0) {
+			TC_PRINT("\n");
+		}
+	}
+	if (i % 16) {
+		TC_PRINT("\n");
+	}
+	TC_PRINT("HEX DUMP END: %s\n", title);
+}
+
+/* This is callback that will be called by MCUMGR lib to pass response */
+static int response_from_mcumgr(void)
+{
+	int rc = 0;
+
+	return rc;
+}
+
+/* Not really a test, group registration */
+void test_register_group_0(void)
+{
+	TC_PRINT("Registering group 0\n");
+	os_mgmt_register_group();
+}
+
+/* Check response header against request header */
+void check_mgmt_hdr_req_vs_res(void)
+{
+	const struct mgmt_hdr *req = (struct mgmt_hdr *)ut_mcumgr_req_buf.data;
+	const struct mgmt_hdr *rsp = (struct mgmt_hdr *)ut_mcumgr_rsp_buf.data;
+
+	zassert_true(ut_mcumgr_rsp_buf.len >= 8, "Response header too short");
+	/* res.nh_op range is not checked on purpose: we assume that test sends correct one */
+	zassert_equal(req->nh_op + 1, rsp->nh_op, "Expected opcode %d, got %d", req->nh_op + 1,
+		     rsp->nh_op);
+	zassert_equal(rsp->nh_flags, 0, "Expected 0 flags, got 0x%02x", rsp->nh_flags);
+	zassert_equal(req->nh_group, rsp->nh_group, "Expected group %d, got %d", req->nh_group,
+		     rsp->nh_group);
+	zassert_equal(req->nh_seq, rsp->nh_seq, "Expected sequence number %d, got %d",
+		     req->nh_seq, rsp->nh_seq);
+	zassert_equal(req->nh_id, rsp->nh_id, "Expected sequence number %d, got %d", req->nh_id,
+		     rsp->nh_id);
+}
+
+/* 0 length packet */
+void test_nothing(void)
+{
+	const uint8_t too_short[] = { 0 };
+
+	net_buf_simple_reset(&ut_mcumgr_req_buf);
+	net_buf_simple_reset(&ut_mcumgr_rsp_buf);
+	net_buf_simple_add_mem(&ut_mcumgr_req_buf, (void *)too_short, 0);
+
+	int ret = ut_smp_req_to_mcumgr(&ut_mcumgr_req_buf, response_from_mcumgr);
+
+	zassert_equal(MGMT_ERR_EOK, ret, "Expected MGMT_ERR_EOK (0) got %d", ret);
+	zassert_equal(ut_mcumgr_rsp_buf.len, 0, "Unexpected modification of response buffer");
+	dump_hex("response", ut_mcumgr_rsp_buf.data, ut_mcumgr_rsp_buf.len);
+}
+
+/* Too short to even parse header */
+void test_too_short(void)
+{
+	const uint8_t too_short[] = { 0x02, 0x00, 0x00, 0x09 };
+
+	net_buf_simple_reset(&ut_mcumgr_req_buf);
+	net_buf_simple_reset(&ut_mcumgr_rsp_buf);
+	net_buf_simple_add_mem(&ut_mcumgr_req_buf, (void *)too_short, ARRAY_SIZE(too_short));
+
+	int ret = ut_smp_req_to_mcumgr(&ut_mcumgr_req_buf, response_from_mcumgr);
+
+	zassert_equal(MGMT_ERR_ECORRUPT, ret, "Expected MGMT_ERR_ECORRUPT (9) got %d", ret);
+	zassert_equal(ut_mcumgr_rsp_buf.len, 0, "Unexpected modification of response buffer");
+	dump_hex("response", ut_mcumgr_rsp_buf.data, ut_mcumgr_rsp_buf.len);
+}
+
+/* Received Header only but with expected payload */
+void test_header_only(void)
+{
+	const uint8_t header_only[] = { 0x02, 0x00, 0x00, 0x09, 0x00, 0x00, 0x42, 0x00 };
+
+	net_buf_simple_reset(&ut_mcumgr_req_buf);
+	net_buf_simple_reset(&ut_mcumgr_rsp_buf);
+	net_buf_simple_add_mem(&ut_mcumgr_req_buf, (void *)header_only, ARRAY_SIZE(header_only));
+
+	int ret = ut_smp_req_to_mcumgr(&ut_mcumgr_req_buf, response_from_mcumgr);
+
+	zassert_equal(MGMT_ERR_ECORRUPT, ret, "Expected MGMT_ERR_ECORRUPT (9) got %d", ret);
+	check_mgmt_hdr_req_vs_res();
+	dump_hex("response", ut_mcumgr_rsp_buf.data, ut_mcumgr_rsp_buf.len);
+}
+
+/* TODO: Test for valid header with no payload */
+
+/* Valid frame but command not registered */
+void test_unregistered(void)
+{
+	const uint8_t group_0_echo[] = {
+		0x02, 0x00, 0x00, 0x09, 0x00, 0x00, 0x42, 0x00, 0xa1, 0x61, 0x64, 0x65, 0x68, 0x65,
+		0x6c, 0x6c, 0x6c };
+
+	net_buf_simple_reset(&ut_mcumgr_req_buf);
+	net_buf_simple_reset(&ut_mcumgr_rsp_buf);
+	net_buf_simple_add_mem(&ut_mcumgr_req_buf, (void *)group_0_echo, ARRAY_SIZE(group_0_echo));
+
+	int ret = ut_smp_req_to_mcumgr(&ut_mcumgr_req_buf, response_from_mcumgr);
+
+	zassert_equal(MGMT_ERR_ENOTSUP, ret, "Expected MGMT_ERR_ENOTSUP (8) got %d", ret);
+	check_mgmt_hdr_req_vs_res();
+	dump_hex("response", ut_mcumgr_rsp_buf.data, ut_mcumgr_rsp_buf.len);
+}
+
+/* Valid echo */
+void test_echo(void)
+{
+	const uint8_t group_0_echo[] = {
+		0x02, 0x00, 0x00, 0x09, 0x00, 0x00, 0x42, 0x00, 0xa1, 0x61, 0x64, 0x65, 0x68, 0x65,
+		0x6c, 0x6c, 0x6c };
+
+	net_buf_simple_reset(&ut_mcumgr_req_buf);
+	net_buf_simple_reset(&ut_mcumgr_rsp_buf);
+	net_buf_simple_add_mem(&ut_mcumgr_req_buf, (void *)group_0_echo, ARRAY_SIZE(group_0_echo));
+
+	int ret = ut_smp_req_to_mcumgr(&ut_mcumgr_req_buf, response_from_mcumgr);
+
+	zassert_equal(0, ret, "Expected success (0) got %d", ret);
+	check_mgmt_hdr_req_vs_res();
+	dump_hex("response", ut_mcumgr_rsp_buf.data, ut_mcumgr_rsp_buf.len);
+	/* TODO: Container parsing */
+}
+
+void test_main(void)
+{
+	ztest_test_suite(
+		mcumgr_smp_group_0,
+		ztest_unit_test(test_nothing),
+		ztest_unit_test(test_too_short),
+		ztest_unit_test(test_header_only),
+		ztest_unit_test(test_unregistered),
+		ztest_unit_test(test_register_group_0),
+		ztest_unit_test(test_echo)
+		);
+
+	ztest_run_test_suite(mcumgr_smp_group_0);
+}

--- a/tests/subsys/mgmt/mcumgr/smp_group_0/src/ut_cbor_stream.c
+++ b/tests/subsys/mgmt/mcumgr/smp_group_0/src/ut_cbor_stream.c
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <ztest.h>
+#include <string.h>
+#include <sys/util.h>
+#include <sys/byteorder.h>
+#include <net/buf.h>
+#include "mgmt/mcumgr/buf.h"
+
+extern struct net_buf_simple ut_mcumgr_req_buf;
+extern struct net_buf_simple ut_mcumgr_rsp_buf;
+NET_BUF_SIMPLE_DEFINE(ut_mcumgr_req_buf, CONFIG_MCUMGR_BUF_SIZE);
+NET_BUF_SIMPLE_DEFINE(ut_mcumgr_rsp_buf, CONFIG_MCUMGR_BUF_SIZE);
+
+struct cbor_decoder_reader ut_cbor_reader;
+struct cbor_encoder_writer ut_cbor_writer;
+
+static uint8_t
+ut_cbor_reader_get8(struct cbor_decoder_reader *d, int offset)
+{
+	__ASSERT(offset >= 0, "Offset can not be negative");
+	return ut_mcumgr_req_buf.data[offset];
+}
+
+static uint16_t
+ut_cbor_reader_get16(struct cbor_decoder_reader *d, int offset)
+{
+	return sys_get_be16(&ut_mcumgr_req_buf.data[offset]);
+}
+
+static uint32_t
+ut_cbor_reader_get32(struct cbor_decoder_reader *d, int offset)
+{
+	return sys_get_be32(&ut_mcumgr_req_buf.data[offset]);
+}
+
+static uint64_t
+ut_cbor_reader_get64(struct cbor_decoder_reader *d, int offset)
+{
+	return sys_get_be64(&ut_mcumgr_req_buf.data[offset]);
+}
+
+static uintptr_t
+ut_cbor_reader_cmp(struct cbor_decoder_reader *d, char *buf, int offset,
+		   size_t len)
+{
+	return memcmp(&ut_mcumgr_req_buf.data[offset], buf, len);
+}
+
+static uintptr_t
+ut_cbor_reader_cpy(struct cbor_decoder_reader *d, char *dst, int offset,
+		   size_t len)
+{
+	return (uintptr_t)memcpy(dst, &ut_mcumgr_req_buf.data[offset], len);
+}
+
+void ut_cbor_reader_init(void)
+{
+	ut_cbor_reader.get8 = &ut_cbor_reader_get8;
+	ut_cbor_reader.get16 = &ut_cbor_reader_get16;
+	ut_cbor_reader.get32 = &ut_cbor_reader_get32;
+	ut_cbor_reader.get64 = &ut_cbor_reader_get64;
+	ut_cbor_reader.cmp = &ut_cbor_reader_cmp;
+	ut_cbor_reader.cpy = &ut_cbor_reader_cpy;
+
+	ut_cbor_reader.message_size = ut_mcumgr_req_buf.len;
+}
+
+static int ut_cbor_write(struct cbor_encoder_writer *cew, const char *data, int len)
+{
+	ARG_UNUSED(cew);
+	__ASSERT(net_buf_simple_tailroom(&ut_mcumgr_rsp_buf) >= len,
+		 "Not enough space in ut_mcumgr_rsp_buf for %d len bytes", len);
+
+	net_buf_simple_add_mem(&ut_mcumgr_rsp_buf, data, len);
+	ut_cbor_writer.bytes_written += len;
+
+	return CborNoError;
+}
+
+void ut_cbor_writer_init(void)
+{
+	ut_cbor_writer.bytes_written = 0;
+	ut_cbor_writer.write = &ut_cbor_write;
+}
+
+void ut_cbor_reader_trim_front(size_t len)
+{
+	net_buf_simple_pull(&ut_mcumgr_req_buf, len);
+}
+
+void *ut_cbor_writer_alloc_rsp(void)
+{
+	return &ut_mcumgr_rsp_buf;
+}
+
+void ut_cbor_reader_free_buf(void *p)
+{
+	/* Note: free should probably always receive non-NULL buffer, there is no reason
+	 * for logic that would possibly call free in case where it fails allocation,
+	 * as it could be avoided.
+	 */
+	if (p != NULL) {
+		net_buf_simple_reset(p);
+	} else {
+		TC_PRINT("??: ut_cbor_writer_alloc_rsp called for NULL\n");
+	}
+}
+
+void ut_cbor_writer_reset_buf(struct net_buf_simple *p)
+{
+	ARG_UNUSED(p);
+	net_buf_simple_reset(&ut_mcumgr_rsp_buf);
+}
+
+/* Returns total number of bytes rsp buffer */
+int ut_cbor_writer_write_at(size_t off, const void *p, size_t len)
+{
+	/* Hidden logic: if write would cross ut_mcumgr_rsp_buf.len then the len will be modified
+	 * to have value off + len of written data.
+	 */
+	__ASSERT(off <= ut_mcumgr_rsp_buf.len, "off(%d) < ut_mcumgr_rsp_buf.len(%d)", off, len);
+	__ASSERT((off + len) <=
+		   (ut_mcumgr_rsp_buf.size - net_buf_simple_headroom(&ut_mcumgr_rsp_buf)),
+		 "off(%d) + len(%d) will not fit into buffer (ut_mcumgr_rsp_buf.size(%d) - "
+		  "net_buf_simple_headroom(&ut_mcumgr_rsp_buf)(%d))", off, len,
+		   ut_mcumgr_rsp_buf.size, net_buf_simple_headroom(&ut_mcumgr_rsp_buf));
+
+	memcpy(&(ut_mcumgr_rsp_buf.data[off]), p, len);
+	if (ut_mcumgr_rsp_buf.len < off + len) {
+		ut_mcumgr_rsp_buf.len = off + len;
+	}
+
+	return 0;
+}

--- a/tests/subsys/mgmt/mcumgr/smp_group_0/src/ut_cbor_stream.h
+++ b/tests/subsys/mgmt/mcumgr/smp_group_0/src/ut_cbor_stream.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef UT_CBOR_STREAM_H_
+#define UT_CBOR_STREAM_H_
+
+#include <inttypes.h>
+#include "tinycbor/cbor.h"
+#include "tinycbor/cbor_buf_writer.h"
+struct net_buf;
+
+struct cbor_nb_reader {
+	struct cbor_decoder_reader reader
+	struct net_buf *nb;
+};
+
+struct cbor_nb_writer {
+	struct cbor_encoder_writer enc;
+	struct net_buf *nb;
+};
+
+/**
+ * @brief Allocates a net_buf for holding an mcumgr request or response.
+ *
+ * @return                      A newly-allocated buffer net_buf on success;
+ *                              NULL on failure.
+ */
+struct net_buf *mcumgr_buf_alloc(void);
+
+/**
+ * @brief Frees an mcumgr net_buf
+ *
+ * @param nb                    The net_buf to free.
+ */
+void mcumgr_buf_free(struct net_buf *nb);
+
+/**
+ * @brief Initializes a CBOR writer with the specified net_buf.
+ *
+ * @param cnw                   The writer to initialize.
+ * @param nb                    The net_buf that the writer will write to.
+ */
+void cbor_nb_writer_init(struct cbor_nb_writer *cnw,
+			 struct net_buf *nb);
+
+/**
+ * @brief Initializes a CBOR reader with the specified net_buf.
+ *
+ * @param cnr                   The reader to initialize.
+ * @param nb                    The net_buf that the reader will read from.
+ */
+void cbor_nb_reader_init(struct cbor_nb_reader *cnr,
+			 struct net_buf *nb);
+
+#endif

--- a/tests/subsys/mgmt/mcumgr/smp_group_0/src/ut_smp.c
+++ b/tests/subsys/mgmt/mcumgr/smp_group_0/src/ut_smp.c
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <ztest.h>
+#include <sys/byteorder.h>
+#include <net/buf.h>
+#include <mgmt/mcumgr/smp.h>
+#include <mgmt/mcumgr/buf.h>
+#include <mgmt/mgmt.h>
+#include "os_mgmt/os_mgmt.h"
+#include "../../../../../../subsys/mgmt/mcumgr/lib/smp/include/smp/smp.h"
+
+typedef int (*mcumgr_rsp_callback)(void);
+
+/* CBOR encoder/decoder streams that are used by CBOR lib to write/read data */
+extern struct cbor_decoder_reader ut_cbor_reader;
+extern struct cbor_encoder_writer ut_cbor_writer;
+
+/* Request/response buffers */
+extern struct net_buf_simple ut_mcumgr_req_buf;
+extern struct net_buf_simple ut_mcumgr_rsp_buf;
+
+/* Provided by ut_cbor_stream.c */
+void ut_cbor_reader_init(void);
+void ut_cbor_writer_init(void);
+void ut_cbor_writer_init(void);
+void ut_cbor_reader_trim_front(size_t len);
+void *ut_cbor_writer_alloc_rsp(void);
+void ut_cbor_reader_free_buf(void *buf);
+void ut_cbor_writer_reset_buf(struct net_buf_simple *p);
+int ut_cbor_writer_write_at(size_t off, const void *p, size_t len);
+
+static void *ut_smp_alloc_rsp(const void *rsp, void *arg)
+{
+	return ut_cbor_writer_alloc_rsp();
+}
+
+static void ut_smp_free_buf(void *buf, void *arg)
+{
+	ut_cbor_reader_free_buf(buf);
+}
+
+static void ut_smp_reader_trim_front(void *buf, size_t len, void *arg)
+{
+	ut_cbor_reader_trim_front(len);
+}
+
+static void ut_smp_writer_reset_buf(void *buf, void *arg)
+{
+	ut_cbor_writer_reset_buf(buf);
+}
+
+static int ut_smp_writer_write_at(struct cbor_encoder_writer *writer,
+		size_t offset, const void *data, size_t len, void *arg)
+{
+	/* The call will return error or number of bytes in output, or rather
+	 * index of lst byte in output from the beginning of buffer.
+	 */
+	ut_cbor_writer_write_at(offset, data, len);
+	writer->bytes_written = ut_mcumgr_rsp_buf.len;
+	return 0;
+}
+
+static int
+ut_smp_reader_init(struct cbor_decoder_reader *r, void *buf, void *arg)
+{
+	ut_cbor_reader_init();
+
+	return 0;
+}
+
+static int
+ut_smp_writer_init(struct cbor_encoder_writer *w, void *buf, void *arg)
+{
+	ut_cbor_writer_init();
+
+	return 0;
+}
+
+static const struct mgmt_streamer_cfg ut_smp_mgmt_streamer_cfg = {
+		.alloc_rsp = ut_smp_alloc_rsp,
+		.trim_front = ut_smp_reader_trim_front,
+		.reset_buf = ut_smp_writer_reset_buf,
+		.write_at = ut_smp_writer_write_at,
+		.init_reader = ut_smp_reader_init,
+		.init_writer = ut_smp_writer_init,
+		.free_buf = ut_smp_free_buf,
+};
+
+static int ut_smp_rsp_callback(struct smp_streamer *ns, void *rsp, void *arg)
+{
+	mcumgr_rsp_callback rsp_cb = (mcumgr_rsp_callback)arg;
+
+	printk("Making callback\n");
+	return rsp_cb();
+}
+
+int ut_smp_req_to_mcumgr(struct net_buf_simple *nb, mcumgr_rsp_callback rsp_cb)
+{
+	struct smp_streamer streamer;
+	int rc;
+
+	streamer = (struct smp_streamer) {
+		.mgmt_stmr = {
+			.cfg = &ut_smp_mgmt_streamer_cfg,
+			.reader = &ut_cbor_reader,
+			.writer = &ut_cbor_writer,
+			.cb_arg = rsp_cb,
+		},
+		.tx_rsp_cb = ut_smp_rsp_callback,
+	};
+
+	rc = smp_process_request_packet(&streamer, nb);
+	return rc;
+}

--- a/tests/subsys/mgmt/mcumgr/smp_group_0/testcase.yaml
+++ b/tests/subsys/mgmt/mcumgr/smp_group_0/testcase.yaml
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+tests:
+  mcumgr.smp_group_0:
+    platform_allow: native_posix
+    tags: mcumgr, smp


### PR DESCRIPTION
The problem with this approach is that tests never end because
queue keeps on spining.
Need to switch to direct approach.

Implements #40962

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

- [ ] All testcases for group 0
- [ ] Complete parsing of reposnses