### PR TITLE
arm64: cache: Fix data corruption issue on DCACHE range invalidation

### DIFF
--- a/arch/arm64/core/cache.c
+++ b/arch/arm64/core/cache.c
@@ -75,10 +75,41 @@ int arch_dcache_range(void *addr, size_t size, int op)
 
 	line_size = arch_dcache_line_size_get();
 
+	/*
+	 * For the data cache invalidate operation, clean and invalidate
+	 * the partial cache lines at both ends of the given range to
+	 * prevent data corruption.
+	 *
+	 * For example (assume cache line size is 64 bytes):
+	 * There are 2 consecutive 32-byte buffers, which can be cached in
+	 * one line like below.
+	 *			+------------------+------------------+
+	 *	 Cache line:	| buffer 0 (dirty) |     buffer 1     |
+	 *			+------------------+------------------+
+	 * For the start address not aligned case, when invalidate the
+	 * buffer 1, the full cache line will be invalidated, if the buffer
+	 * 0 is dirty, its data will be lost.
+	 * The same logic applies to the not aligned end address.
+	 */
+	if (op == K_CACHE_INVD) {
+		if (end_addr & (line_size - 1)) {
+			end_addr &= ~(line_size - 1);
+			dc_ops("civac", end_addr);
+		}
+
+		if (start_addr & (line_size - 1)) {
+			start_addr &= ~(line_size - 1);
+			if (start_addr == end_addr)
+				goto done;
+			dc_ops("civac", start_addr);
+			start_addr += line_size;
+		}
+	}
+
 	/* Align address to line size */
 	start_addr &= ~(line_size - 1);
 
-	do {
+	while (start_addr < end_addr) {
 		if (op == K_CACHE_INVD) {
 			dc_ops("ivac", start_addr);
 		} else if (op == K_CACHE_WB) {
@@ -88,8 +119,9 @@ int arch_dcache_range(void *addr, size_t size, int op)
 		}
 
 		start_addr += line_size;
-	} while (start_addr < end_addr);
+	}
 
+done:
 	dsb();
 
 	return 0;


### PR DESCRIPTION
Currently, the DCACHE range invalidation can cause data corruption when
the ends of the given range is not aligned to a full cache line.

Signed-off-by: Hou Zhiqiang <Zhiqiang.Hou@nxp.com>