### PR TITLE
tests: settings: provide correct test prototypes

### DIFF
--- a/tests/subsys/settings/fs/include/settings_test_fs.h
+++ b/tests/subsys/settings/fs/include/settings_test_fs.h
@@ -44,7 +44,7 @@ int settings_test_file_strstr(const char *fname, char const *string,
 			      size_t str_len);
 
 
-void config_empty_lookups(void);
+void test_config_empty_lookups(void);
 void test_config_insert(void);
 void test_config_getset_unknown(void);
 void test_config_getset_int(void);

--- a/tests/subsys/settings/littlefs/src/settings_test_littlefs.c
+++ b/tests/subsys/settings/littlefs/src/settings_test_littlefs.c
@@ -10,7 +10,7 @@
 #include "settings_test.h"
 #include "settings_priv.h"
 
-void config_setup_littlefs(void);
+void test_config_setup_littlefs(void);
 
 void test_main(void)
 {


### PR DESCRIPTION
Add prototypes for renamed test functions. Issue was introduced in
677ffc883a4.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
