### PR TITLE
modbus: serial: Fix incomplete transmission issue

### DIFF
--- a/subsys/modbus/modbus_serial.c
+++ b/subsys/modbus/modbus_serial.c
@@ -393,7 +393,14 @@ static void cb_handler_tx(struct modbus_context *ctx)
 				   cfg->uart_buf_ctr);
 		cfg->uart_buf_ctr -= n;
 		cfg->uart_buf_ptr += n;
-	} else {
+		return;
+	}
+
+	/* Must wait till the transmission is complete or
+	 * RS-485 tranceiver could be disabled before all data has
+	 * been transmitted and message will be corrupted.
+	 */
+	if (uart_irq_tx_complete(cfg->dev)) {
 		/* Disable transmission */
 		cfg->uart_buf_ptr = &cfg->uart_buf[0];
 		modbus_serial_tx_off(ctx);


### PR DESCRIPTION
This patch is to fix an issue where the transceiver chip is
disabled before it has transmitted all data. This causes the
message to be corrupted because the last few bytes are missing.

The fix adds a check to make sure the transmission is completed
before disabling the transceiver.

Signed-off-by: Marius Scholtz <mariuss@ricelectronics.com>


@jfischer-no I do not have the permission to re-open the [PR ](https://github.com/zephyrproject-rtos/zephyr/pull/42051)

I have re-opened it here.