### PR TITLE
tests: settings: fcb: fix test prototype

### DIFF
--- a/tests/subsys/settings/fcb/src/settings_test_fcb.c
+++ b/tests/subsys/settings/fcb/src/settings_test_fcb.c
@@ -356,7 +356,7 @@ void test_settings_check_target(void)
 }
 
 void test_settings_encode(void);
-void config_empty_lookups(void);
+void test_config_empty_lookups(void);
 void test_config_insert(void);
 void test_config_getset_unknown(void);
 void test_config_getset_int(void);


### PR DESCRIPTION
Add prototypes for renamed test functions. Issue was introduced in
677ffc8.

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>