### PR TITLE
Revert "net: tcp: Fix possible deadlock in tcp_conn_unref()"

### DIFF
--- a/lib/os/fdtable.c
+++ b/lib/os/fdtable.c
@@ -224,21 +224,37 @@ int z_alloc_fd(void *obj, const struct fd_op_vtable *vtable)
 
 ssize_t read(int fd, void *buf, size_t sz)
 {
+	ssize_t res;
+
 	if (_check_fd(fd) < 0) {
 		return -1;
 	}
 
-	return fdtable[fd].vtable->read(fdtable[fd].obj, buf, sz);
+	(void)k_mutex_lock(&fdtable[fd].lock, K_FOREVER);
+
+	res = fdtable[fd].vtable->read(fdtable[fd].obj, buf, sz);
+
+	k_mutex_unlock(&fdtable[fd].lock);
+
+	return res;
 }
 FUNC_ALIAS(read, _read, ssize_t);
 
 ssize_t write(int fd, const void *buf, size_t sz)
 {
+	ssize_t res;
+
 	if (_check_fd(fd) < 0) {
 		return -1;
 	}
 
-	return fdtable[fd].vtable->write(fdtable[fd].obj, buf, sz);
+	(void)k_mutex_lock(&fdtable[fd].lock, K_FOREVER);
+
+	res = fdtable[fd].vtable->write(fdtable[fd].obj, buf, sz);
+
+	k_mutex_unlock(&fdtable[fd].lock);
+
+	return res;
 }
 FUNC_ALIAS(write, _write, ssize_t);
 
@@ -250,7 +266,11 @@ int close(int fd)
 		return -1;
 	}
 
+	(void)k_mutex_lock(&fdtable[fd].lock, K_FOREVER);
+
 	res = fdtable[fd].vtable->close(fdtable[fd].obj);
+
+	k_mutex_unlock(&fdtable[fd].lock);
 
 	z_free_fd(fd);
 

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -377,14 +377,14 @@ static int tcp_conn_unref(struct tcp *conn)
 	}
 #endif /* CONFIG_NET_TEST_PROTOCOL */
 
-	k_mutex_lock(&tcp_lock, K_FOREVER);
-
 	ref_count = atomic_dec(&conn->ref_count) - 1;
-	if (ref_count) {
+	if (ref_count != 0) {
 		tp_out(net_context_get_family(conn->context), conn->iface,
 		       "TP_TRACE", "event", "CONN_DELETE");
-		goto unlock;
+		return ref_count;
 	}
+
+	k_mutex_lock(&tcp_lock, K_FOREVER);
 
 	/* If there is any pending data, pass that to application */
 	while ((pkt = k_fifo_get(&conn->recv_data, K_NO_WAIT)) != NULL) {
@@ -403,10 +403,8 @@ static int tcp_conn_unref(struct tcp *conn)
 	}
 
 	if (conn->context->recv_cb) {
-		k_mutex_unlock(&tcp_lock);
 		conn->context->recv_cb(conn->context, NULL, NULL, NULL,
 					-ECONNRESET, conn->recv_user_data);
-		k_mutex_lock(&tcp_lock, K_FOREVER);
 	}
 
 	conn->context->tcp = NULL;
@@ -431,7 +429,6 @@ static int tcp_conn_unref(struct tcp *conn)
 
 	k_mem_slab_free(&tcp_conns_slab, (void **)&conn);
 
-unlock:
 	k_mutex_unlock(&tcp_lock);
 out:
 	return ref_count;


### PR DESCRIPTION
Reverts zephyrproject-rtos/zephyr#42526

As I am testing this change, it seems that the net_ctx is getting leaked. So it seems it may not be the rightway to unlock the tcp_lock.

I would like to consider the option of manipulating `ctx->cond.lock` lock. For example get rid of `(void)k_mutex_lock(ctx->cond.lock, K_FOREVER);` in `static void zsock_received_cb()`. How do u feel about that? Because it seems to work better than the other way