### PR TITLE
doc: add OTA section to device management

### DIFF
--- a/doc/guides/device_mgmt/index.rst
+++ b/doc/guides/device_mgmt/index.rst
@@ -9,3 +9,4 @@ Device Management
     mcumgr.rst
     mcumgr_backporting.rst
     dfu.rst
+    ota.rst

--- a/doc/guides/device_mgmt/ota.rst
+++ b/doc/guides/device_mgmt/ota.rst
@@ -1,0 +1,85 @@
+.. _ota:
+
+Over-the-Air Update
+###################
+
+Overview
+********
+
+Over-the-Air (OTA) Update is a method for delivering firmware updates to remote
+devices using a network connection. Although the name implies a wireless
+connection, updates received over a wired connection (such as Ethernet)
+are still commonly referred to as OTA updates. This approach requires server
+infrastructure to host the firmware binary and implement a method of signaling
+when an update is available. Security is a concern with OTA updates; firmware
+binaries should be cryptographically signed and verified before upgrading.
+
+The :ref:`dfu` section discusses upgrading Zephyr firmware using MCUboot. The
+same method can be used as part of OTA. The binary is first downloaded
+into an unoccupied code partition, usually named ``slot1_partition``, then
+upgraded using the :ref:`mcuboot` process.
+
+Examples of OTA
+***************
+
+Golioth
+=======
+
+`Golioth`_ is an IoT management platform that includes OTA updates. Devices are
+configured to observe your available firmware revisions on the Golioth Cloud.
+When a new version is available, the device downloads and flashes the binary. In
+this implementation, the connection between cloud and device is secured using
+TLS/DTLS, and the signed firmware binary is confirmed by MCUboot before the
+upgrade occurs.
+
+1. A working sample can be found on the `Golioth Zephyr-SDK repository`_
+2. The `Golioth OTA documentation`_ includes complete information about the
+   versioning process
+
+Eclipse hawkBit |trade|
+=======================
+
+`Eclipse hawkBit`_ |trade| is an update server framework that uses polling on a
+REST api to detect firmware updates. When a new update is detected, the binary
+is downloaded and installed. MCUboot can be used to verify the signature before
+upgrading the firmware.
+
+There is a :ref:`hawkbit-api-sample` included in the
+Zephyr :ref:`mgmt-samples` section.
+
+UpdateHub
+=========
+
+`UpdateHub`_ is a platform for remotely updating embedded devices. Updates can
+be manually triggered or monitored via polling. When a new update is detected,
+the binary is downloaded and installed. MCUboot can be used to verify the
+signature before upgrading the firmware.
+
+There is an :ref:`updatehub_fota_sample` included in the Zephyr
+:ref:`mgmt-samples` section.
+
+SMP Server
+==========
+
+A Simple Management Protocol (SMP) server can be used to update firmware via
+Bluetooth Low Energy (BLE) or UDP. :ref:`mcu_mgr` is used to send a signed
+firmware binary to the remote device where it is verified by MCUboot before the
+upgrade occurs.
+
+There is an :ref:`smp_svr_sample` included in the Zephyr :ref:`mgmt-samples`
+section.
+
+Lightweight M2M (LWM2M)
+=======================
+
+The :ref:`lwm2m_interface` protocol includes support for firmware update via
+:kconfig:`CONFIG_LWM2M_FIRMWARE_UPDATE_OBJ_SUPPORT`. Devices securely connect to
+an LwM2M server using DTLS. An :ref:`lwm2m-client-sample` sample is available
+but it does not demonstrate the firmware update feature.
+
+.. _MCUboot bootloader: https://mcuboot.com/
+.. _Golioth: https://golioth.io/
+.. _Golioth Zephyr-SDK repository: https://github.com/golioth/zephyr-sdk/tree/main/samples/dfu
+.. _Golioth OTA documentation: https://docs.golioth.io/cloud/services/ota
+.. _Eclipse hawkBit: https://www.eclipse.org/hawkbit/
+.. _UpdateHub: https://updatehub.io/

--- a/samples/subsys/mgmt/hawkbit/README.rst
+++ b/samples/subsys/mgmt/hawkbit/README.rst
@@ -1,3 +1,5 @@
+.. _hawkbit-api-sample:
+
 Hawkbit Direct Device Integration API sample
 ############################################
 


### PR DESCRIPTION
This adds an OTA page to the device management section of the docs and links to some examples.

Zephyr docs should mention OTA:
- Define Over-the-Air update
- Indicate OTA can be used with MCUboot
- Link to Golioth sample code and documentation of a working example of
OTA update process
- Closes #42240

Signed-off-by: Mike Szczys <mike@golioth.io>