### PR TITLE
doc: fix some Kconfig references

### DIFF
--- a/doc/guides/pm/power_domain.rst
+++ b/doc/guides/pm/power_domain.rst
@@ -11,7 +11,7 @@ that device B is on the same power domain and should also be configured into a
 low power state.
 
 Power domains are optional on Zephyr, to enable this feature the
-option :kconfig:`PM_DEVICE_POWER_DOMAIN` has to be set.
+option :kconfig:`CONFIG_PM_DEVICE_POWER_DOMAIN` has to be set.
 
 When a power domain turns itself on or off, it is the responsibilty of the
 power domain to notify all devices using it through their power management

--- a/doc/releases/release-notes-1.14.rst
+++ b/doc/releases/release-notes-1.14.rst
@@ -969,7 +969,7 @@ Libraries / Subsystems
   - Removed sys_log, which has been replaced by the new logging subsystem
     introduced in v1.13
   - Refactored log modules registration macros
-  - Improved synchronous operation (see :kconfig:`CONFIG_LOG_IMMEDIATE`)
+  - Improved synchronous operation (see ``CONFIG_LOG_IMMEDIATE``)
   - Added commands to control the logger using shell
   - Added :c:macro:`LOG_PANIC()` call to the fault handlers to ensure that
     logs are output on fault


### PR DESCRIPTION
- Fix a reference that was missing `CONFIG_`
- Remove reference to deleted Kconfig option