### PR TITLE
boards: xtensa: Align testcase tags for intel_adsp boards

### DIFF
--- a/boards/xtensa/intel_adsp_cavs15/intel_adsp_cavs15.yaml
+++ b/boards/xtensa/intel_adsp_cavs15/intel_adsp_cavs15.yaml
@@ -4,3 +4,7 @@ type: mcu
 arch: xtensa
 toolchain:
   - zephyr
+testing:
+  ignore_tags:
+     - net
+     - bluetooth

--- a/boards/xtensa/intel_adsp_cavs20/intel_adsp_cavs20.yaml
+++ b/boards/xtensa/intel_adsp_cavs20/intel_adsp_cavs20.yaml
@@ -5,6 +5,6 @@ arch: xtensa
 toolchain:
   - zephyr
 testing:
-  only_tags:
-     - kernel
-     - sof
+  ignore_tags:
+     - net
+     - bluetooth

--- a/tests/drivers/build_all/modem/testcase.yaml
+++ b/tests/drivers/build_all/modem/testcase.yaml
@@ -1,6 +1,6 @@
 common:
   build_only: true
-  tags: drivers
+  tags: drivers net
 tests:
   drivers.modem.build:
     extra_args: CONF_FILE=modem.conf


### PR DESCRIPTION
Aligns intel_adsp boards to be consistent about which testcase tags to
ignore or apply. This reduces the number of tests for intel_adsp_cavs15
because we now ignore networking and Bluetooth tests.  It increases the
number of tests for intel_adsp_cavs20 because we're no longer limited to
only kernel and sof tests.

intel_adsp_cavs18 and intel_adsp_cavs25 already had these tags and don't
need to be modified.

Signed-off-by: Maureen Helm <maureen.helm@intel.com>