### PR TITLE
net: lib: lwm2m: add lwm2m_engine_is_observed function

### DIFF
--- a/include/net/lwm2m.h
+++ b/include/net/lwm2m.h
@@ -1063,6 +1063,19 @@ int lwm2m_engine_update_service_period(k_work_handler_t service, uint32_t period
 int lwm2m_update_device_service_period(uint32_t period_ms);
 
 /**
+ * @brief Check whether a path is observed
+ *
+ * @param[in] pathstr LwM2M path string to check, e.g. "3/0/1"
+ *
+ * @return true when there exists an observation of the same level
+ *         or lower as the given path, false if it doesn't or path is not a
+ *         valid LwM2M-path.
+ *         E.g. true if path refers to a resource and the parent object has an
+ *         observation, false for the inverse.
+ */
+bool lwm2m_engine_path_is_observed(const char *pathstr);
+
+/**
  * @brief Start the LwM2M engine
  *
  * LwM2M clients normally do not need to call this function as it is called


### PR DESCRIPTION
add helper function to check wether a specific lwm2m path is observed.

useful for the application to check if specific observations have been established
that are expected for correct function by e.g. an end-user

currently this can be done via the observe_cb, but requires the application to mirror state that already exists within
the engine (which objects have been observed, needs to be reset on re-registration, etc...), which can be error prone and requires extra memory.