### PR TITLE
Bluetooth: Controller: Fix to stop Extended Auxiliary Scan context

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -1702,6 +1702,7 @@ int ull_ticker_stop_with_mark(uint8_t ticker_handle, void *param,
 	uint32_t volatile ret_cb;
 	uint32_t ret;
 	void *mark;
+	int err;
 
 	mark = ull_disable_mark(param);
 	if (mark != param) {
@@ -1722,14 +1723,15 @@ int ull_ticker_stop_with_mark(uint8_t ticker_handle, void *param,
 		return -EALREADY;
 	}
 
-	ret = ull_disable(lll_disable);
-	if (ret) {
-		return -EBUSY;
-	}
+	err = ull_disable(lll_disable);
 
 	mark = ull_disable_unmark(param);
 	if (mark != param) {
 		return -ENOLCK;
+	}
+
+	if (err && (err != -EALREADY)) {
+		return err;
 	}
 
 	return 0;
@@ -1761,8 +1763,8 @@ int ull_disable(void *lll)
 	uint32_t ret;
 
 	hdr = HDR_LLL2ULL(lll);
-	if (!hdr || !ull_ref_get(hdr)) {
-		return 0;
+	if (!ull_ref_get(hdr)) {
+		return -EALREADY;
 	}
 
 	k_sem_init(&sem, 0, 1);
@@ -1780,7 +1782,7 @@ int ull_disable(void *lll)
 	 * care.
 	 */
 	if (!ull_ref_get(hdr)) {
-		return 0;
+		return -EALREADY;
 	}
 
 	mfy.param = lll;

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -2523,8 +2523,9 @@ static inline uint8_t disable(uint8_t handle)
 {
 	uint32_t volatile ret_cb;
 	struct ll_adv_set *adv;
-	void *mark;
 	uint32_t ret;
+	void *mark;
+	int err;
 
 	adv = ull_adv_is_enabled_get(handle);
 	if (!adv) {
@@ -2585,8 +2586,8 @@ static inline uint8_t disable(uint8_t handle)
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
 
-	ret = ull_disable(&adv->lll);
-	LL_ASSERT(!ret);
+	err = ull_disable(&adv->lll);
+	LL_ASSERT(!err || (err == -EALREADY));
 
 	mark = ull_disable_unmark(adv);
 	LL_ASSERT(mark == adv);
@@ -2596,13 +2597,12 @@ static inline uint8_t disable(uint8_t handle)
 
 	if (lll_aux) {
 		struct ll_adv_aux_set *aux;
-		uint8_t err;
 
 		aux = HDR_LLL2ULL(lll_aux);
 
 		err = ull_adv_aux_stop(aux);
-		if (err) {
-			return err;
+		if (err && (err != -EALREADY)) {
+			return BT_HCI_ERR_CMD_DISALLOWED;
 		}
 	}
 #endif /* CONFIG_BT_CTLR_ADV_EXT && (CONFIG_BT_CTLR_ADV_AUX_SET > 0) */

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -1073,7 +1073,7 @@ uint32_t ull_adv_aux_start(struct ll_adv_aux_set *aux, uint32_t ticks_anchor,
 	return ret;
 }
 
-uint8_t ull_adv_aux_stop(struct ll_adv_aux_set *aux)
+int ull_adv_aux_stop(struct ll_adv_aux_set *aux)
 {
 	uint8_t aux_handle;
 	int err;
@@ -1084,7 +1084,7 @@ uint8_t ull_adv_aux_stop(struct ll_adv_aux_set *aux)
 					aux, &aux->lll);
 	LL_ASSERT(err == 0 || err == -EALREADY);
 	if (err) {
-		return BT_HCI_ERR_CMD_DISALLOWED;
+		return err;
 	}
 
 	aux->is_started = 0U;

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
@@ -83,7 +83,7 @@ uint32_t ull_adv_aux_start(struct ll_adv_aux_set *aux, uint32_t ticks_anchor,
 			   uint32_t ticks_slot_overhead);
 
 /* helper function to stop auxiliary advertising */
-uint8_t ull_adv_aux_stop(struct ll_adv_aux_set *aux);
+int ull_adv_aux_stop(struct ll_adv_aux_set *aux);
 
 /* helper function to acquire and initialize auxiliary advertising instance */
 struct ll_adv_aux_set *ull_adv_aux_acquire(struct lll_adv *lll);

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -355,13 +355,20 @@ void ull_scan_params_set(struct lll_scan *lll, uint8_t type, uint16_t interval,
 
 uint8_t ull_scan_enable(struct ll_scan_set *scan)
 {
-	struct lll_scan *lll = &scan->lll;
 	uint32_t ticks_slot_overhead;
 	uint32_t volatile ret_cb;
 	uint32_t ticks_interval;
 	uint32_t ticks_anchor;
+	struct lll_scan *lll;
 	uint32_t ret;
 
+#if defined(CONFIG_BT_CTLR_ADV_EXT)
+	/* Initialize extend scan stop request */
+	scan->is_stop = 0U;
+#endif /* CONFIG_BT_CTLR_ADV_EXT */
+
+	/* Initialize LLL scan context */
+	lll = &scan->lll;
 	lll->init_addr_type = scan->own_addr_type;
 	(void)ll_addr_read(lll->init_addr_type, lll->init_addr);
 	lll->chan = 0U;
@@ -462,12 +469,42 @@ uint8_t ull_scan_disable(uint8_t handle, struct ll_scan_set *scan)
 {
 	int err;
 
+#if defined(CONFIG_BT_CTLR_ADV_EXT)
+	/* Request Extended Scan stop */
+	scan->is_stop = 1U;
+	cpu_dmb();
+#endif /* CONFIG_BT_CTLR_ADV_EXT */
+
 	err = ull_ticker_stop_with_mark(TICKER_ID_SCAN_BASE + handle,
 					scan, &scan->lll);
 	LL_ASSERT(err == 0 || err == -EALREADY);
 	if (err) {
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
+
+#if defined(CONFIG_BT_CTLR_ADV_EXT)
+	/* Find and stop associated auxiliary scan contexts */
+	for (uint8_t aux_handle = 0; aux_handle < CONFIG_BT_CTLR_SCAN_AUX_SET;
+	     aux_handle++) {
+		struct lll_scan_aux *aux_scan_lll;
+		struct ll_scan_set *aux_scan;
+		struct ll_scan_aux_set *aux;
+
+		aux = ull_scan_aux_set_get(aux_handle);
+		aux_scan_lll = aux->parent;
+		if (!aux_scan_lll) {
+			continue;
+		}
+
+		aux_scan = HDR_LLL2ULL(aux_scan_lll);
+		if (aux_scan == scan) {
+			err = ull_scan_aux_stop(aux);
+			if (err && (err != -EALREADY)) {
+				return BT_HCI_ERR_CMD_DISALLOWED;
+			}
+		}
+	}
+#endif /* CONFIG_BT_CTLR_ADV_EXT */
 
 	return 0;
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_internal.h
@@ -80,6 +80,9 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx);
 /* Helper to clean up auxiliary channel scanning */
 void ull_scan_aux_done(struct node_rx_event_done *done);
 
+/* Return the scan aux set instance given the handle */
+struct ll_scan_aux_set *ull_scan_aux_set_get(uint8_t handle);
+
 /* Helper function to check and return if a valid aux scan context */
 struct ll_scan_aux_set *ull_scan_aux_is_valid_get(struct ll_scan_aux_set *aux);
 

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_types.h
@@ -11,6 +11,8 @@ struct ll_scan_set {
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 	uint16_t duration_lazy;
 	struct node_rx_hdr *node_rx_scan_term;
+
+	uint8_t is_stop:1;
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
 
 	uint8_t is_enabled:1;


### PR DESCRIPTION
Update ull_disable implementation to return -EALREADY if
LLL event is already disabled.

Fix any stray Extended Auxiliary PDU from being scanned
when disabling Extended Scanning.

Updated Extended Scan disable implementation to find any
active auxiliary scan context and stop them.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>