### PR TITLE
Bluetooth: Controller: Fix Sync Failed to be Established on no memory

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_sync_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_types.h
@@ -21,6 +21,8 @@ struct ll_sync_set {
 	uint16_t volatile timeout_reload; /* Non-zero when sync established */
 	uint16_t timeout_expire;
 
+	void (*lll_sync_prepare)(void *param);
+
 #if defined(CONFIG_BT_CTLR_CHECK_SAME_PEER_SYNC) || \
 	defined(CONFIG_BT_CTLR_SYNC_PERIODIC_ADI_SUPPORT)
 	uint8_t peer_id_addr[BDADDR_SIZE];

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_types.h
@@ -21,6 +21,10 @@ struct ll_sync_set {
 	uint16_t volatile timeout_reload; /* Non-zero when sync established */
 	uint16_t timeout_expire;
 
+	/* Member to store periodic advertising sync prepare.
+	 * Also serves as a flag to inform if sync established was
+	 * already generated.
+	 */
 	void (*lll_sync_prepare)(void *param);
 
 #if defined(CONFIG_BT_CTLR_CHECK_SAME_PEER_SYNC) || \


### PR DESCRIPTION
Update implementation to generate Periodic Sync Failed to be
Established when Sync Established message could not be
generate due to lack of free node rx buffers and when there
is sync lost before sync established message could be
generated.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>