### PR TITLE
Bluetooth: Host: df: Fix uninitialized periodic advertising sync and IQ report objects passed to an application by cte_report_cb

### DIFF
--- a/subsys/bluetooth/host/direction.c
+++ b/subsys/bluetooth/host/direction.c
@@ -368,16 +368,16 @@ static int hci_df_set_cl_cte_rx_enable(struct bt_le_per_adv_sync *sync, bool ena
 	return err;
 }
 
-void hci_df_prepare_connectionless_iq_report(struct net_buf *buf,
-					     struct bt_df_per_adv_sync_iq_samples_report *report,
-					     struct bt_le_per_adv_sync **per_adv_sync_to_report)
+int hci_df_prepare_connectionless_iq_report(struct net_buf *buf,
+					    struct bt_df_per_adv_sync_iq_samples_report *report,
+					    struct bt_le_per_adv_sync **per_adv_sync_to_report)
 {
 	struct bt_hci_evt_le_connectionless_iq_report *evt;
 	struct bt_le_per_adv_sync *per_adv_sync;
 
 	if (buf->len < sizeof(*evt)) {
 		BT_ERR("Unexpected end of buffer");
-		return;
+		return -EINVAL;
 	}
 
 	evt = net_buf_pull_mem(buf, sizeof(*evt));
@@ -387,17 +387,17 @@ void hci_df_prepare_connectionless_iq_report(struct net_buf *buf,
 	if (!per_adv_sync) {
 		BT_ERR("Unknown handle 0x%04X for iq samples report",
 		       sys_le16_to_cpu(evt->sync_handle));
-		return;
+		return -EINVAL;
 	}
 
 	if (!atomic_test_bit(per_adv_sync->flags, BT_PER_ADV_SYNC_CTE_ENABLED)) {
 		BT_ERR("Received PA CTE report when CTE receive disabled");
-		return;
+		return -EINVAL;
 	}
 
 	if (!(per_adv_sync->cte_types & BIT(evt->cte_type))) {
 		BT_DBG("CTE filtered out by cte_type: %u", evt->cte_type);
-		return;
+		return -EINVAL;
 	}
 
 	report->chan_idx = evt->chan_idx;
@@ -411,6 +411,8 @@ void hci_df_prepare_connectionless_iq_report(struct net_buf *buf,
 	report->sample = &evt->sample[0];
 
 	*per_adv_sync_to_report = per_adv_sync;
+
+	return 0;
 }
 #endif /* CONFIG_BT_DF_CONNECTIONLESS_CTE_RX */
 

--- a/subsys/bluetooth/host/direction_internal.h
+++ b/subsys/bluetooth/host/direction_internal.h
@@ -7,9 +7,9 @@
 /* Performs initialization of Direction Finding in Host */
 int le_df_init(void);
 
-void hci_df_prepare_connectionless_iq_report(struct net_buf *buf,
-					     struct bt_df_per_adv_sync_iq_samples_report *report,
-					     struct bt_le_per_adv_sync **per_adv_sync_to_report);
+int hci_df_prepare_connectionless_iq_report(struct net_buf *buf,
+					    struct bt_df_per_adv_sync_iq_samples_report *report,
+					    struct bt_le_per_adv_sync **per_adv_sync_to_report);
 int hci_df_prepare_connection_iq_report(struct net_buf *buf,
 					struct bt_df_conn_iq_samples_report *report,
 					struct bt_conn **conn_to_report);

--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -1088,11 +1088,17 @@ void bt_hci_le_biginfo_adv_report(struct net_buf *buf)
 #if defined(CONFIG_BT_DF_CONNECTIONLESS_CTE_RX)
 void bt_hci_le_df_connectionless_iq_report(struct net_buf *buf)
 {
+	int err;
+
 	struct bt_df_per_adv_sync_iq_samples_report cte_report;
 	struct bt_le_per_adv_sync *per_adv_sync;
 	struct bt_le_per_adv_sync_cb *listener;
 
-	hci_df_prepare_connectionless_iq_report(buf, &cte_report, &per_adv_sync);
+	err = hci_df_prepare_connectionless_iq_report(buf, &cte_report, &per_adv_sync);
+	if (err) {
+		BT_ERR("Prepare CTE conn IQ report failed %d", err);
+		return;
+	}
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&pa_sync_cbs, listener, node) {
 		if (listener->cte_report_cb) {


### PR DESCRIPTION
In case of error in hci_df_prepare_connectionless_iq_report function
e.g. due to wrong periodic advertising sync handle, uninitilized
per_adv_sync and IQ report object were passed by cte_report_cb callback
to an application.

Correct behavior in such situation is to not to cal cte_report_cb callback.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>