### PR TITLE
lib: os: cbprintf: Use rodata section on sparc

### DIFF
--- a/lib/os/cbprintf_packaged.c
+++ b/lib/os/cbprintf_packaged.c
@@ -31,7 +31,7 @@ static inline bool ptr_in_rodata(const char *addr)
 #define RO_END 0
 #elif defined(CONFIG_ARC) || defined(CONFIG_ARM) || defined(CONFIG_X86) \
 	|| defined(CONFIG_RISCV) || defined(CONFIG_ARM64) \
-	|| defined(CONFIG_NIOS2) || defined(CONFIG_MIPS)
+	|| defined(CONFIG_NIOS2) || defined(CONFIG_MIPS) || defined(CONFIG_SPARC)
 	extern char __rodata_region_start[];
 	extern char __rodata_region_end[];
 #define RO_START __rodata_region_start

--- a/tests/subsys/logging/log_api/src/test.inc
+++ b/tests/subsys/logging/log_api/src/test.inc
@@ -321,7 +321,7 @@ static size_t get_max_hexdump(void)
 			    HEXDUMP_BYTES_CONT_MSG * (msgs_in_buf - 1);
 }
 
-#if defined(__sparc__) || defined(CONFIG_ARCH_POSIX)
+#if defined(CONFIG_ARCH_POSIX)
 #define STR_SIZE(s) (strlen(s) + 2 * sizeof(char))
 #else
 #define STR_SIZE(s) 0

--- a/tests/subsys/logging/log_msg2/src/main.c
+++ b/tests/subsys/logging/log_msg2/src/main.c
@@ -19,7 +19,7 @@
 #include <ztest.h>
 #include <sys/cbprintf.h>
 
-#if defined(__sparc__) || defined(CONFIG_ARCH_POSIX)
+#if defined(CONFIG_ARCH_POSIX)
 /* On some platforms all strings are considered RW, that impacts size of the
  * package.
  */


### PR DESCRIPTION
Use rodata region markers to detect if string is read only on
sparc. It was previously disabled but now can be used.

Fixes #42208.
