### PR TITLE
boards: thingy53_nrf5340: Do not forward FEM SPI pins to cpunet

### DIFF
--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
@@ -101,9 +101,6 @@
 				<&gpio1 10 0>,
 				<&gpio0 30 0>;
 		};
-		fem-spi-if {
-			gpios = <&gpio0 24 0>;
-		};
 	};
 
 	aliases {
@@ -197,7 +194,7 @@
 
 	nrf_radio_fem_spi: fem_spi@2 {
 		compatible = "nordic,nrf21540-fem-spi";
-		status = "okay";
+		status = "disabled";
 		reg = <2>;
 		label = "FEM_SPI_IF";
 		spi-max-frequency = <8000000>;


### PR DESCRIPTION
The SPI cannot be shared between the cores. The MPSL running on the network core does not support SPI comminucation yet, so the application core sets FEM's CS to inactive state.