### PR TITLE
drivers: spi_nrfx_spi: Fix compilation error

### DIFF
--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -286,7 +286,7 @@ static int spi_nrfx_pm_action(const struct device *dev,
 
 	case PM_DEVICE_ACTION_SUSPEND:
 		if (data->initialized) {
-			nrfx_spi_uninit(&config->spim);
+			nrfx_spi_uninit(&config->spi);
 			data->initialized = false;
 		}
 		break;


### PR DESCRIPTION
Fix a copy/paste mistake introduced by commit
fdc25cd44c2b693aecff96d3dfcd0ee088d48d5b.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>