### PR TITLE
include: drivers: clock_control: stm32: fix xtpre

### DIFF
--- a/include/drivers/clock_control/stm32_clock_control.h
+++ b/include/drivers/clock_control/stm32_clock_control.h
@@ -86,7 +86,7 @@
 #endif
 
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(pll), st_stm32f1_pll_clock, okay)
-#define STM32_PLL_XTPRE		DT_PROP(DT_NODELABEL(pll), xtre)
+#define STM32_PLL_XTPRE		DT_PROP(DT_NODELABEL(pll), xtpre)
 #define STM32_PLL_MULTIPLIER	DT_PROP(DT_NODELABEL(pll), mul)
 #elif DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(pll), st_stm32f0_pll_clock, okay) || \
 	DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(pll), st_stm32f100_pll_clock, okay) || \


### PR DESCRIPTION
Corrects used value in `DT_PROP` to set correct `STM32_PLL_XTPRE` value.
The driver bindings defined `xtpre` instead of used `xtre` in the `DT_PROP` macro.

Fixes #42581.

Signed-off-by: Georgij Cernysiov <geo.cgv@gmail.com>