### PR TITLE
modem: hl7800: Make RSSI rate configurable

### DIFF
--- a/drivers/modem/Kconfig.hl7800
+++ b/drivers/modem/Kconfig.hl7800
@@ -357,4 +357,9 @@ config MODEM_HL7800_ALLOW_SLEEP_DELAY_MS
 	int "Milliseconds to delay before allowing modem to sleep"
 	default 5000
 
+config MODEM_HL7800_RSSI_RATE_SECONDS
+	int "Rate to automatically query RSSI"
+	default 0 if MODEM_HL7800_LOW_POWER_MODE
+	default 30
+
 endif # MODEM_HL7800

--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -294,7 +294,6 @@ static const struct mdm_control_pinconfig pinconfig[] = {
 #define MDM_RESET_HIGH_TIME K_MSEC(10)
 #define MDM_WAIT_FOR_DATA_RETRIES 3
 
-#define RSSI_TIMEOUT_SECS 30
 #define RSSI_UNKNOWN -999
 
 #define DNS_WORK_DELAY_SECS 1
@@ -593,6 +592,7 @@ static int write_apn(char *access_point_name);
 static void mark_sockets_for_reconfig(void);
 #endif
 static void hl7800_build_mac(struct hl7800_iface_ctx *ictx);
+static void rssi_query(void);
 
 #ifdef CONFIG_MODEM_HL7800_LOW_POWER_MODE
 static void initialize_sleep_level(void);
@@ -932,6 +932,10 @@ static void event_handler(enum mdm_hl7800_event event, void *event_data)
 
 void mdm_hl7800_get_signal_quality(int *rsrp, int *sinr)
 {
+	if (CONFIG_MODEM_HL7800_RSSI_RATE_SECONDS == 0) {
+		rssi_query();
+	}
+
 	*rsrp = ictx.mdm_rssi;
 	*sinr = ictx.mdm_sinr;
 }
@@ -2683,6 +2687,9 @@ static int hl7800_query_rssi(void)
 
 static void hl7800_start_rssi_work(void)
 {
+	/* Rate is not checked here to allow one reading
+	 * when going from network down->up
+	 */
 	k_work_reschedule_for_queue(&hl7800_workq, &ictx.rssi_query_work,
 				    K_NO_WAIT);
 }
@@ -2697,17 +2704,24 @@ static void hl7800_stop_rssi_work(void)
 	}
 }
 
-static void hl7800_rssi_query_work(struct k_work *work)
+static void rssi_query(void)
 {
 	hl7800_lock();
 	wakeup_hl7800();
 	hl7800_query_rssi();
 	allow_sleep(true);
 	hl7800_unlock();
+}
+
+static void hl7800_rssi_query_work(struct k_work *work)
+{
+	rssi_query();
 
 	/* re-start RSSI query work */
-	k_work_reschedule_for_queue(&hl7800_workq, &ictx.rssi_query_work,
-				    K_SECONDS(RSSI_TIMEOUT_SECS));
+	if (CONFIG_MODEM_HL7800_RSSI_RATE_SECONDS > 0) {
+		k_work_reschedule_for_queue(&hl7800_workq, &ictx.rssi_query_work,
+					    K_SECONDS(CONFIG_MODEM_HL7800_RSSI_RATE_SECONDS));
+	}
 }
 
 #ifdef CONFIG_MODEM_HL7800_GPS

--- a/include/drivers/modem/hl7800.h
+++ b/include/drivers/modem/hl7800.h
@@ -282,7 +282,11 @@ void mdm_hl7800_wakeup(bool awake);
 int32_t mdm_hl7800_send_at_cmd(const uint8_t *data);
 
 /**
- * @brief Get the signal quality of the HL7800
+ * @brief Get the signal quality of the HL7800.
+ * If CONFIG_MODEM_HL7800_RSSI_RATE_SECONDS is non-zero, then
+ * this function returns the value from the last periodic read.
+ * If CONFIG_MODEM_HL7800_RSSI_RATE_SECONDS is 0, then this
+ * may cause the modem to be woken so that the values can be queried.
  *
  * @param rsrp Reference Signals Received Power (dBm)
  *             Range = -140 dBm to -44 dBm


### PR DESCRIPTION
Improve ability to sleep by not needing to wake up to query network signal strength.