### PR TITLE
modem: hl7800: CTS to monitor sleep

### DIFF
--- a/drivers/modem/Kconfig.hl7800
+++ b/drivers/modem/Kconfig.hl7800
@@ -362,4 +362,12 @@ config MODEM_HL7800_RSSI_RATE_SECONDS
 	default 0 if MODEM_HL7800_LOW_POWER_MODE
 	default 30
 
+config MODEM_HL7800_CTS_FILTER_US
+	int "Duration in microseconds between samples of CTS signal"
+	default 10
+
+config MODEM_HL7800_CTS_FILTER_MAX_ITERATIONS
+	int "Maximum filter loops"
+	default 5
+
 endif # MODEM_HL7800


### PR DESCRIPTION
Use CTS input to monitor HL7800 sleep state
when in SLEEP mode.
When CTS is high, shutdown the UART to
save power.