### PR TITLE
Indicate delayed start option for `K_THREAD_DEFINE`

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -654,8 +654,8 @@ struct _static_thread_data {
  * @param p3 3rd entry point parameter.
  * @param prio Thread priority.
  * @param options Thread options.
- * @param delay Scheduling delay (in milliseconds), zero for no delay.
- *
+ * @param delay Scheduling delay (in milliseconds), zero for no delay and K_FOREVER_TICKS for
+ *              delayed start.
  *
  * @internal It has been observed that the x86 compiler by default aligns
  * these _static_thread_data structures to 32-byte boundaries, thereby


### PR DESCRIPTION
It is possible to define a thread that is suspended until `k_thread_start` is called using `K_THREAD_DEFINE`.  This change make this option clearer to the user.