### PR TITLE
actions: west/devicetree: exclude python 3.6 on windows

### DIFF
--- a/.github/workflows/devicetree_checks.yml
+++ b/.github/workflows/devicetree_checks.yml
@@ -25,6 +25,8 @@ jobs:
         exclude:
           - os: macos-latest
             python-version: 3.6
+          - os: windows-latest
+            python-version: 3.6
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/west_cmds.yml
+++ b/.github/workflows/west_cmds.yml
@@ -26,6 +26,8 @@ jobs:
         exclude:
           - os: macos-latest
             python-version: 3.6
+          - os: windows-latest
+            python-version: 3.6
     steps:
     - name: checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
This version of python is not available anymore. Excluding for now to
unblock CI.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
