### PR TITLE
soc: xtensa/sample_controller: add snippets to linker script

### DIFF
--- a/soc/xtensa/sample_controller/linker.ld
+++ b/soc/xtensa/sample_controller/linker.ld
@@ -442,6 +442,11 @@ SECTIONS
     *(.rodata.*)
     *(.gnu.linkonce.r.*)
     *(.rodata1)
+
+    . = ALIGN(4);
+    #include <snippets-rodata.ld>
+    . = ALIGN(4);
+
     __XT_EXCEPTION_TABLE__ = ABSOLUTE(.);
     KEEP (*(.xt_except_table))
     KEEP (*(.gcc_except_table .gcc_except_table.*))
@@ -514,6 +519,8 @@ SECTIONS
     *(.noinit.*)
   } >sram0_seg :sram0_phdr
 
+#include <snippets-sections.ld>
+
   .data : ALIGN(4)
   {
     _data_start = ABSOLUTE(.);
@@ -529,8 +536,15 @@ SECTIONS
     *(.sdata2.*)
     *(.gnu.linkonce.s2.*)
     KEEP(*(.jcr))
+
+    . = ALIGN(4);
+    #include <snippets-rwdata.ld>
+    . = ALIGN(4);
+
     _data_end = ABSOLUTE(.);
   } >sram0_seg :sram0_phdr
+
+#include <snippets-data-sections.ld>
 
 #include <linker/common-ram.ld>
 
@@ -538,6 +552,8 @@ SECTIONS
   {
     *(.tm_clone_table)
   } >sram0_seg :sram0_phdr
+
+#include <snippets-ram-sections.ld>
 
   .bss (NOLOAD) : ALIGN(8)
   {


### PR DESCRIPTION
The xtensa/sample_controller linker script is missing the necessary
include statements for linker snippets. So add them.

Fixes #42477

Note that the linker scripts on other Xtensa boards are not updated since they are a bit sensitive to where things are placed. This PR is to unblock #38611 so CI can build and test with `qemu_xtensa`. If other Xtensa boards require snippets, they will need to make their own adjustments to their linker scripts.