### PR TITLE
samples: blinky_pwm: decreased min PWM period for blinky sample

### DIFF
--- a/samples/basic/blinky_pwm/README.rst
+++ b/samples/basic/blinky_pwm/README.rst
@@ -11,7 +11,7 @@ This application blinks a LED using the :ref:`PWM API <pwm_api>`. See
 :ref:`blinky-sample` for a GPIO-based sample.
 
 The LED starts blinking at a 1 Hz frequency. The frequency doubles every 4
-seconds until it reaches 64 Hz. The frequency will then be halved every 4
+seconds until it reaches 128 Hz. The frequency will then be halved every 4
 seconds until it returns to 1 Hz, completing a single blinking cycle. This
 faster-then-slower blinking cycle then repeats forever.
 

--- a/samples/basic/blinky_pwm/src/main.c
+++ b/samples/basic/blinky_pwm/src/main.c
@@ -27,7 +27,7 @@
 #define PWM_FLAGS	0
 #endif
 
-#define MIN_PERIOD_USEC	(USEC_PER_SEC / 64U)
+#define MIN_PERIOD_USEC	(USEC_PER_SEC / 128U)
 #define MAX_PERIOD_USEC	USEC_PER_SEC
 
 void main(void)


### PR DESCRIPTION
Blinky PWM sample minimum pwm period was too high for iMX.RT PWM module.
decrease the minimum pwm period so sample will pass pwm calibration
phase, and successfully run

Fixes #38954

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>