### PR TITLE
mgmt: mcumgr: Allow custom CBOR encoder for response

### DIFF
--- a/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
@@ -234,10 +234,12 @@ typedef int (*mgmt_handler_fn)(struct mgmt_ctxt *ctxt);
 
 /**
  * @brief Read handler and write handler for a single command ID.
+ * Set use_custom_cbor_encoder to true when using zcbor.
  */
 struct mgmt_handler {
 	mgmt_handler_fn mh_read;
 	mgmt_handler_fn mh_write;
+	bool use_custom_cbor_encoder;
 };
 
 /**

--- a/subsys/mgmt/mcumgr/lib/smp/src/smp.c
+++ b/subsys/mgmt/mcumgr/lib/smp/src/smp.c
@@ -139,10 +139,13 @@ smp_handle_single_payload(struct mgmt_ctxt *cbuf, const struct mgmt_hdr *req_hdr
 	/* Begin response payload.  Response fields are inserted into the root
 	 * map as key value pairs.
 	 */
-	rc = cbor_encoder_create_map(&cbuf->encoder, &payload_encoder, CborIndefiniteLength);
-	rc = mgmt_err_from_cbor(rc);
-	if (rc != 0) {
-		return rc;
+	if (!handler->use_custom_cbor_encoder) {
+		rc = cbor_encoder_create_map(&cbuf->encoder, &payload_encoder,
+					     CborIndefiniteLength);
+		rc = mgmt_err_from_cbor(rc);
+		if (rc != 0) {
+			return rc;
+		}
 	}
 
 	switch (req_hdr->nh_op) {
@@ -172,7 +175,9 @@ smp_handle_single_payload(struct mgmt_ctxt *cbuf, const struct mgmt_hdr *req_hdr
 	}
 
 	/* End response payload. */
-	rc = cbor_encoder_close_container(&cbuf->encoder, &payload_encoder);
+	if (!handler->use_custom_cbor_encoder) {
+		rc = cbor_encoder_close_container(&cbuf->encoder, &payload_encoder);
+	}
 	return mgmt_err_from_cbor(rc);
 }
 


### PR DESCRIPTION
Prevent generation of response payload in SMP layer 
to allow management handler to use zcbor.

Signed-off-by: Andrew Hedin <andrew.hedin@lairdconnect.com>