### PR TITLE
Bluetooth: Controller: Fix Extended Scanning and Periodic Synchronization assertions

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_scan.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_scan.h
@@ -86,3 +86,4 @@ int lll_scan_reset(void);
 void lll_scan_prepare(void *param);
 
 extern uint8_t ull_scan_lll_handle_get(struct lll_scan *lll);
+extern struct lll_scan *ull_scan_lll_is_valid_get(struct lll_scan *lll);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -375,9 +375,14 @@ void lll_done_ull_inc(void)
 }
 #endif /* CONFIG_BT_CTLR_LOW_LAT_ULL_DONE */
 
-bool lll_is_done(void *param)
+bool lll_is_done(void *param, bool *is_resume)
 {
-	/* FIXME: use param to check */
+	/* NOTE: Current radio event when preempted could put itself in resume
+	 *       into the prepare pipeline in which case event.curr.param would
+	 *       be set to NULL.
+	 */
+	*is_resume = (param != event.curr.param);
+
 	return !event.curr.abort_cb;
 }
 
@@ -731,6 +736,10 @@ static struct lll_event *resume_enqueue(lll_prepare_cb_t resume_cb)
 {
 	struct lll_prepare_param prepare_param = {0};
 
+	/* Enqueue into prepare pipeline as resume radio event, and remove
+	 * parameter assignment from currently active radio event so that
+	 * done event is not generated.
+	 */
 	prepare_param.param = event.curr.param;
 	event.curr.param = NULL;
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_internal.h
@@ -6,7 +6,7 @@
 
 int lll_prepare_done(void *param);
 int lll_done(void *param);
-bool lll_is_done(void *param);
+bool lll_is_done(void *param, bool *is_resume);
 int lll_is_abort_cb(void *next, void *curr, lll_prepare_cb_t *resume_cb);
 void lll_abort_cb(struct lll_prepare_param *prepare_param, void *param);
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -1015,6 +1015,8 @@ static void isr_done_cleanup(void *param)
 	if (lll->is_aux_sched) {
 		struct node_rx_pdu *node_rx;
 
+		lll->is_aux_sched = 0U;
+
 		node_rx = ull_pdu_rx_alloc();
 		LL_ASSERT(node_rx);
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -79,7 +79,6 @@ static void isr_abort(void *param);
 	* (EVENT_OVERHEAD_PREEMPT_US <= EVENT_OVERHEAD_PREEMPT_MIN_US)
 	*/
 static void isr_done_cleanup(void *param);
-static void isr_cleanup(void *param);
 
 static inline int isr_rx_pdu(struct lll_scan *lll, struct pdu_adv *pdu_adv_rx,
 			     uint8_t devmatch_ok, uint8_t devmatch_id,
@@ -620,11 +619,8 @@ static void abort_cb(struct lll_prepare_param *prepare_param, void *param)
 				cpu_sleep();
 			}
 #endif /* CONFIG_BT_CENTRAL */
-		} else if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT)) {
-			radio_isr_set(isr_done_cleanup, param);
-			radio_disable();
 		} else {
-			radio_isr_set(isr_cleanup, param);
+			radio_isr_set(isr_done_cleanup, param);
 			radio_disable();
 		}
 		return;
@@ -640,10 +636,17 @@ static void abort_cb(struct lll_prepare_param *prepare_param, void *param)
 }
 
 static void ticker_stop_cb(uint32_t ticks_at_expire, uint32_t ticks_drift,
-			   uint32_t remainder, uint16_t lazy, uint8_t force, void *param)
+			   uint32_t remainder, uint16_t lazy, uint8_t force,
+			   void *param)
 {
-	radio_isr_set(isr_done_cleanup, param);
-	radio_disable();
+	static memq_link_t link;
+	static struct mayfly mfy = {0, 0, &link, NULL, lll_disable};
+	uint32_t ret;
+
+	mfy.param = param;
+	ret = mayfly_enqueue(TICKER_USER_ID_ULL_HIGH, TICKER_USER_ID_LLL, 0,
+			     &mfy);
+	LL_ASSERT(!ret);
 }
 
 static void ticker_op_start_cb(uint32_t status, void *param)
@@ -982,6 +985,7 @@ static void isr_abort(void *param)
 static void isr_done_cleanup(void *param)
 {
 	struct lll_scan *lll;
+	bool is_resume;
 
 	/* Clear radio status and events */
 	lll_isr_status_reset();
@@ -989,7 +993,7 @@ static void isr_done_cleanup(void *param)
 	/* Under race between duration expire, is_stop is set in this function,
 	 * and event preemption, prevent generating duplicate scan done events.
 	 */
-	if (lll_is_done(param)) {
+	if (lll_is_done(param, &is_resume)) {
 		return;
 	}
 
@@ -1009,14 +1013,47 @@ static void isr_done_cleanup(void *param)
 	ticker_stop(TICKER_INSTANCE_ID_CTLR, TICKER_USER_ID_LLL,
 		    TICKER_ID_SCAN_STOP, NULL, NULL);
 
-#if defined(CONFIG_BT_CTLR_ADV_EXT)
-	struct event_done_extra *extra;
+#if defined(CONFIG_BT_CTLR_SCAN_INDICATION)
+	struct node_rx_hdr *node_rx;
 
-	/* Generate Scan done events so that duration and max expiry is
-	 * detected in ULL.
+	/* Check if there are enough free node rx available:
+	 * 1. For generating this scan indication
+	 * 2. Keep one available free for reception of ACL connection Rx data
+	 * 3. Keep one available free for reception on ACL connection to NACK
+	 *    the PDU
 	 */
-	extra = ull_done_extra_type_set(EVENT_DONE_EXTRA_TYPE_SCAN);
-	LL_ASSERT(extra);
+	node_rx = ull_pdu_rx_alloc_peek(3);
+	if (node_rx) {
+		ull_pdu_rx_alloc();
+
+		/* TODO: add other info by defining a payload struct */
+		node_rx->type = NODE_RX_TYPE_SCAN_INDICATION;
+
+		ull_rx_put(node_rx->link, node_rx);
+		ull_rx_sched();
+	}
+#endif /* CONFIG_BT_CTLR_SCAN_INDICATION */
+
+#if defined(CONFIG_BT_HCI_MESH_EXT)
+	if (_radio.advertiser.is_enabled && _radio.advertiser.is_mesh &&
+	    !_radio.advertiser.retry) {
+		mayfly_mesh_stop(NULL);
+	}
+#endif /* CONFIG_BT_HCI_MESH_EXT */
+
+#if defined(CONFIG_BT_CTLR_ADV_EXT)
+	/* If continuous scan then do not generate scan done when radio event
+	 * has been placed into prepare pipeline as a resume radio event.
+	 */
+	if (!is_resume) {
+		struct event_done_extra *extra;
+
+		/* Generate Scan done events so that duration and max expiry is
+		 * detected in ULL.
+		 */
+		extra = ull_done_extra_type_set(EVENT_DONE_EXTRA_TYPE_SCAN);
+		LL_ASSERT(extra);
+	}
 
 	/* Prevent scan events in pipeline from being scheduled if duration has
 	 * expired.
@@ -1041,77 +1078,6 @@ static void isr_done_cleanup(void *param)
 		ull_rx_sched();
 	}
 #endif  /* CONFIG_BT_CTLR_ADV_EXT */
-
-	lll_isr_cleanup(param);
-}
-
-static void isr_cleanup(void *param)
-{
-	/* Clear radio status and events */
-	lll_isr_status_reset();
-
-	/* Do not generate done event for connection initiation, ULL will
-	 * disable the event when establishing/setting up the connection.
-	 * Also, do not generate done event when duration expire, as ULL
-	 * will disable the event.
-	 * As it was transmission of CONNECT_IND, there is not filters to
-	 * disable either.
-	 */
-	if (lll_is_done(param)) {
-		return;
-	}
-
-	/* Disable Rx filters, if cleanup after being in Rx state */
-	radio_filter_disable();
-
-	/* Scanner stop can expire while here in this ISR.
-	 * Deferred attempt to stop can fail as it would have
-	 * expired, hence ignore failure.
-	 */
-	ticker_stop(TICKER_INSTANCE_ID_CTLR, TICKER_USER_ID_LLL,
-		    TICKER_ID_SCAN_STOP, NULL, NULL);
-
-#if defined(CONFIG_BT_HCI_MESH_EXT)
-	if (_radio.advertiser.is_enabled && _radio.advertiser.is_mesh &&
-	    !_radio.advertiser.retry) {
-		mayfly_mesh_stop(NULL);
-	}
-#endif /* CONFIG_BT_HCI_MESH_EXT */
-
-#if defined(CONFIG_BT_CTLR_SCAN_INDICATION)
-	struct node_rx_hdr *node_rx = ull_pdu_rx_alloc_peek(3);
-
-	if (node_rx) {
-		ull_pdu_rx_alloc();
-
-		/* TODO: add other info by defining a payload struct */
-		node_rx->type = NODE_RX_TYPE_SCAN_INDICATION;
-
-		ull_rx_put(node_rx->link, node_rx);
-		ull_rx_sched();
-	}
-#endif /* CONFIG_BT_CTLR_SCAN_INDICATION */
-
-#if defined(CONFIG_BT_CTLR_ADV_EXT)
-	struct lll_scan *lll = param;
-
-	if (lll->is_aux_sched) {
-		struct node_rx_pdu *node_rx;
-
-		lll->is_aux_sched = 0U;
-
-		node_rx = ull_pdu_rx_alloc();
-		LL_ASSERT(node_rx);
-
-		node_rx->hdr.type = NODE_RX_TYPE_EXT_AUX_RELEASE;
-
-		node_rx->hdr.rx_ftr.param = lll;
-
-		ull_rx_put(node_rx->hdr.link, node_rx);
-		ull_rx_sched();
-	}
-#endif  /* CONFIG_BT_CTLR_ADV_EXT */
-
 
 	lll_isr_cleanup(param);
 }
@@ -1206,7 +1172,7 @@ static inline int isr_rx_pdu(struct lll_scan *lll, struct pdu_adv *pdu_adv_rx,
 			lll_prof_cputime_capture();
 		}
 
-		radio_isr_set(isr_cleanup, lll);
+		radio_isr_set(isr_done_cleanup, lll);
 
 #if defined(HAL_RADIO_GPIO_HAVE_PA_PIN)
 		if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -925,7 +925,7 @@ isr_rx_aux_chain_done:
 
 		isr_rx_done_cleanup(lll, 1U, false);
 	} else {
-		lll_isr_cleanup(lll);
+		lll_isr_cleanup(lll_aux);
 	}
 }
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -990,6 +990,7 @@ static inline int create_iq_report(struct lll_sync *lll, uint8_t rssi_ready,
 				cte_info = radio_df_cte_status_get();
 				ant = radio_df_pdu_antenna_switch_pattern_get();
 				iq_report = ull_df_iq_report_alloc();
+				LL_ASSERT(iq_report);
 
 				iq_report->hdr.type = NODE_RX_TYPE_SYNC_IQ_SAMPLE_REPORT;
 				iq_report->sample_count = sample_cnt;

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -625,6 +625,19 @@ struct ll_scan_set *ull_scan_is_valid_get(struct ll_scan_set *scan)
 	return scan;
 }
 
+struct lll_scan *ull_scan_lll_is_valid_get(struct lll_scan *lll)
+{
+	struct ll_scan_set *scan;
+
+	scan = HDR_LLL2ULL(lll);
+	scan = ull_scan_is_valid_get(scan);
+	if (scan) {
+		return &scan->lll;
+	}
+
+	return NULL;
+}
+
 struct ll_scan_set *ull_scan_is_enabled_get(uint8_t handle)
 {
 	struct ll_scan_set *scan;

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -268,6 +268,8 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 			 * passed in the node rx footer field.
 			 */
 			sync_lll = ftr->param;
+			LL_ASSERT(!sync_lll->lll_aux);
+
 			ull_sync = HDR_LLL2ULL(sync_lll);
 			rx->handle = ull_sync_handle_get(ull_sync);
 

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -247,8 +247,6 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 			rx->type = NODE_RX_TYPE_SYNC_REPORT;
 			rx->handle = ull_sync_handle_get(sync);
 
-			sync_lll = &sync->lll;
-
 			/* Check if we need to create BIG sync */
 			sync_iso = sync_iso_create_get(sync);
 

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -163,6 +163,7 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 
 			/* aux parent will be NULL for periodic sync */
 			lll = aux->parent;
+			LL_ASSERT(lll);
 
 		} else if (!IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC) ||
 			   ull_scan_is_valid_get(HDR_LLL2ULL(ftr->param))) {
@@ -190,6 +191,7 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 
 			lll_aux = sync_lll->lll_aux;
 			aux = HDR_LLL2ULL(lll_aux);
+			LL_ASSERT(sync_lll == aux->parent);
 		}
 
 		if (!IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC) || lll) {
@@ -756,8 +758,12 @@ void ull_scan_aux_done(struct node_rx_event_done *done)
 		aux = HDR_LLL2ULL(sync->lll.lll_aux);
 	} else {
 		struct ll_scan_set *scan;
+		struct lll_scan *lll;
 
-		scan = HDR_LLL2ULL(aux->parent);
+		lll = aux->parent;
+		LL_ASSERT(lll);
+
+		scan = HDR_LLL2ULL(lll);
 		LL_ASSERT(ull_scan_is_valid_get(scan));
 
 		/* Auxiliary context will be flushed by ull_scan_aux_stop() */
@@ -800,12 +806,17 @@ void *ull_scan_aux_lll_parent_get(struct lll_scan_aux *lll,
 				  uint8_t *is_lll_scan)
 {
 	struct ll_scan_aux_set *aux;
-	struct ll_scan_set *scan;
 
 	aux = HDR_LLL2ULL(lll);
-	scan = HDR_LLL2ULL(aux->parent);
 
 	if (is_lll_scan) {
+		struct ll_scan_set *scan;
+		struct lll_scan *lll;
+
+		lll = aux->parent;
+		LL_ASSERT(lll);
+
+		scan = HDR_LLL2ULL(lll);
 		*is_lll_scan = !!ull_scan_is_valid_get(scan);
 	}
 
@@ -884,6 +895,8 @@ void ull_scan_aux_release(memq_link_t *link, struct node_rx_hdr *rx)
 
 		aux = HDR_LLL2ULL(lll_aux);
 		lll = aux->parent;
+		LL_ASSERT(lll);
+
 		scan = HDR_LLL2ULL(lll);
 		scan = ull_scan_is_valid_get(scan);
 		if (scan) {
@@ -975,6 +988,8 @@ int ull_scan_aux_stop(struct ll_scan_aux_set *aux)
 		struct lll_scan *lll;
 
 		lll = aux->parent;
+		LL_ASSERT(lll);
+
 		scan = HDR_LLL2ULL(lll);
 		scan = ull_scan_is_valid_get(scan);
 		if (scan) {
@@ -1016,14 +1031,10 @@ static inline struct ll_scan_aux_set *aux_acquire(void)
 
 static inline void aux_release(struct ll_scan_aux_set *aux)
 {
-	/* Debug check that parent was assigned when allocated for reception of
-	 * auxiliary channel PDUs.
-	 */
-	LL_ASSERT(aux->parent);
-
 	/* Clear the parent so that when scan is being disabled then this
 	 * auxiliary context shall not associate itself from being disable.
 	 */
+	LL_ASSERT(aux->parent);
 	aux->parent = NULL;
 
 	mem_release(aux, &scan_aux_free);
@@ -1067,7 +1078,12 @@ static void flush(void *param)
 	struct lll_scan *lll;
 	bool sched = false;
 
+	/* Debug check that parent was assigned when allocated for reception of
+	 * auxiliary channel PDUs.
+	 */
 	aux = param;
+	LL_ASSERT(aux->parent);
+
 	rx = aux->rx_head;
 	if (rx) {
 		ll_rx_put(rx->link, rx);
@@ -1143,6 +1159,7 @@ static void aux_sync_incomplete(void *param)
 
 		/* get reference to sync context */
 		lll = aux->parent;
+		LL_ASSERT(lll);
 		sync = HDR_LLL2ULL(lll);
 
 		/* reset data len total */
@@ -1168,6 +1185,8 @@ static void aux_sync_incomplete(void *param)
 		/* add to rx list, will be flushed */
 		aux->rx_head = rx;
 	}
+
+	LL_ASSERT(!ull_ref_get(&aux->ull));
 
 	flush(aux);
 #endif /* CONFIG_BT_CTLR_SYNC_PERIODIC */
@@ -1219,6 +1238,8 @@ static void ticker_op_cb(uint32_t status, void *param)
 
 		aux = param;
 		sync_lll = aux->parent;
+		LL_ASSERT(sync_lll);
+
 		sync = HDR_LLL2ULL(sync_lll);
 		sync = ull_sync_is_valid_get(sync);
 	} else {

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -133,7 +133,10 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 		sync_lll = NULL;
 		sync_iso = NULL;
 		rx_incomplete = NULL;
+
 		lll = ftr->param;
+		LL_ASSERT(!lll->lll_aux);
+
 		scan = HDR_LLL2ULL(lll);
 		sync = sync_create_get(scan);
 		phy = BT_HCI_LE_EXT_SCAN_PHY_1M;
@@ -144,7 +147,10 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 		sync_lll = NULL;
 		sync_iso = NULL;
 		rx_incomplete = NULL;
+
 		lll = ftr->param;
+		LL_ASSERT(!lll->lll_aux);
+
 		scan = HDR_LLL2ULL(lll);
 		sync = sync_create_get(scan);
 		phy = BT_HCI_LE_EXT_SCAN_PHY_CODED;
@@ -190,6 +196,8 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 			sync_lll = ftr->param;
 
 			lll_aux = sync_lll->lll_aux;
+			LL_ASSERT(lll_aux);
+
 			aux = HDR_LLL2ULL(lll_aux);
 			LL_ASSERT(sync_lll == aux->parent);
 		}

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -746,7 +746,6 @@ ull_scan_aux_rx_flush:
 void ull_scan_aux_done(struct node_rx_event_done *done)
 {
 	struct ll_scan_aux_set *aux;
-	struct ull_hdr *hdr;
 
 	/* Get reference to ULL context */
 	aux = CONTAINER_OF(done->param, struct ll_scan_aux_set, ull);
@@ -757,8 +756,8 @@ void ull_scan_aux_done(struct node_rx_event_done *done)
 
 		sync = CONTAINER_OF(done->param, struct ll_sync_set, ull);
 		LL_ASSERT(ull_sync_is_valid_get(sync));
-		hdr = &sync->ull;
 
+		/* Auxiliary context will be flushed by ull_scan_aux_stop() */
 		if (unlikely(sync->is_stop) || !sync->lll.lll_aux) {
 			return;
 		}
@@ -778,18 +777,9 @@ void ull_scan_aux_done(struct node_rx_event_done *done)
 		if (unlikely(scan->is_stop)) {
 			return;
 		}
-
-		/* Setup the disabled callback to flush the auxiliary PDUs */
-		hdr = &aux->ull;
 	}
 
-	if (ull_ref_get(hdr) == 0U) {
-		flush(aux);
-	} else {
-		LL_ASSERT(!hdr->disabled_cb);
-		hdr->disabled_param = aux;
-		hdr->disabled_cb = done_disabled_cb;
-	}
+	flush(aux);
 }
 
 struct ll_scan_aux_set *ull_scan_aux_set_get(uint8_t handle)


### PR DESCRIPTION
Fix reset of is_aux_sched flag when closing the primary and
auxiliary PDU reception. Without this fix when scan window
is closed there would be duplicate auxiliary release message
generated causing memory corruption.

Fix auxiliary context release on scan done, do not wait for
reference count to reduce when Periodic Sync events overlap.

Fix missing use of auxiliary context to generate done event
which caused leak in release of auxiliary context being not
release when reference count that should decrease to zero.

Fix missing auxiliary context release message on abort of
LLL scheduling scheduling used by scan context.

Fix race condition in setting up ISR callback and parameter
caused between ULL_HIGH and LLL context. As LLL IRQ is not
disabled the parameter and ISR callback would get out of
sync causing incorrect parameter supplied to callback and
hence leading to development assert in ull_scan_done().

Fixes #39438.
Fixes #40317.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>

