### PR TITLE
Bluetooth: Controller: Fix allocations for chain reception

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -223,13 +223,12 @@
 /* Note: Need node for PDU and CTE sample */
 #define BT_CTLR_ADV_EXT_RX_CNT  (CONFIG_BT_CTLR_SCAN_AUX_SET * \
 				 CONFIG_BT_CTLR_DF_PER_SCAN_CTE_NUM_MAX * 2)
-#else
-/* Note: Assume up to 7 PDUs per advertising train (max data length) */
-#define BT_CTLR_ADV_EXT_RX_CNT  (CONFIG_BT_CTLR_SCAN_AUX_SET * 7)
-#endif /* CONFIG_BT_CTLR_DF_PER_SCAN_CTE_NUM_MAX */
-#else
+#else /* !CONFIG_BT_CTLR_DF_PER_SCAN_CTE_NUM_MAX */
+#define BT_CTLR_ADV_EXT_RX_CNT  1
+#endif /* !CONFIG_BT_CTLR_DF_PER_SCAN_CTE_NUM_MAX */
+#else /* !CONFIG_BT_CTLR_ADV_EXT || !CONFIG_BT_OBSERVER */
 #define BT_CTLR_ADV_EXT_RX_CNT  0
-#endif /* CONFIG_BT_CTLR_ADV_EXT && CONFIG_BT_OBSERVER */
+#endif /* !CONFIG_BT_CTLR_ADV_EXT || !CONFIG_BT_OBSERVER */
 
 #if !defined(TICKER_USER_LLL_VENDOR_OPS)
 #define TICKER_USER_LLL_VENDOR_OPS 0


### PR DESCRIPTION
Do not implicitly allocate Rx buffers for maximum chain PDU
reception. Instead let applications increase as required the
Kconfig CONFIG_BT_CTLR_RX_BUFFERS.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>