### PR TITLE
doc: release notes: gptp clock sync ratio change

### DIFF
--- a/doc/releases/release-notes-3.0.rst
+++ b/doc/releases/release-notes-3.0.rst
@@ -278,6 +278,7 @@ Networking
 
 * Misc:
 
+  * gptp: clock sync ratio as double, not float
 
 * OpenThread:
 


### PR DESCRIPTION
Update release notes to mention that the gptp clock sync ratio is now a double instead of a float.

This pull request depends on https://github.com/zephyrproject-rtos/zephyr/pull/42216

Signed-off-by: Xabier Marquiegui <xmarquiegui@ainguraiiot.com>