### PR TITLE
Introduce the barrier API

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -34,6 +34,7 @@ config ARM
 	# is really only necessary for Cortex-M with ARM MPU!
 	select GEN_PRIV_STACKS
 	select ARCH_HAS_THREAD_LOCAL_STORAGE if CPU_AARCH32_CORTEX_R || CPU_CORTEX_M || CPU_AARCH32_CORTEX_A
+	select ARCH_HAS_MEMORY_BARRIER
 	help
 	  ARM architecture
 
@@ -47,6 +48,7 @@ config ARM64
 	select USE_SWITCH
 	select USE_SWITCH_SUPPORTED
 	select IRQ_OFFLOAD_NESTED if IRQ_OFFLOAD
+	select ARCH_HAS_MEMORY_BARRIER
 	help
 	  ARM64 (AArch64) architecture
 
@@ -112,6 +114,7 @@ config RISCV
 	select USE_SWITCH_SUPPORTED
 	select USE_SWITCH
 	select SCHED_IPI_SUPPORTED if SMP
+	select ARCH_HAS_MEMORY_BARRIER
 	imply XIP
 	help
 	  RISCV architecture

--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -885,3 +885,9 @@ config TOOLCHAIN_HAS_BUILTIN_FFS
 	default y if !(64BIT && RISCV)
 	help
 	  Hidden option to signal that toolchain has __builtin_ffs*().
+
+config ARCH_HAS_MEMORY_BARRIER
+	bool
+	help
+	  This option signifies that the architecture does support and implement the
+	  memory barrier functions.

--- a/include/arch/arm/aarch32/barrier.h
+++ b/include/arch/arm/aarch32/barrier.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022 Alexandre Mergnat <amergnat@baylibre.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_ARCH_ARM_AARCH32_BARRIER_H_
+#define ZEPHYR_INCLUDE_ARCH_ARM_AARCH32_BARRIER_H_
+
+#ifndef _ASMLANGUAGE
+
+#if defined(__clang__)
+
+#define z_full_mb()	__builtin_arm_dsb(0xF)
+#define z_read_mb()	__builtin_arm_dsb(0xF)
+#define z_write_mb()	__builtin_arm_dsb(0xF)
+
+#else
+
+#define z_full_mb()	__asm__ volatile ("dsb 0xF" : : : "memory")
+#define z_read_mb()	__asm__ volatile ("dsb 0xF" : : : "memory")
+#define z_write_mb()	__asm__ volatile ("dsb 0xF" : : : "memory")
+
+#endif /* __clang__ */
+
+#endif /* !_ASMLANGUAGE */
+
+#endif /* ZEPHYR_INCLUDE_ARCH_ARM_AARCH32_BARRIER_H_ */

--- a/include/arch/arm64/barrier.h
+++ b/include/arch/arm64/barrier.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022 Alexandre Mergnat <amergnat@baylibre.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_ARCH_ARM64_BARRIER_H_
+#define ZEPHYR_INCLUDE_ARCH_ARM64_BARRIER_H_
+
+#ifndef _ASMLANGUAGE
+
+#include <arch/arm64/lib_helpers.h>
+
+#define z_full_mb()	__dsb(sy)
+#define z_read_mb()	__dsb(ld)
+#define z_write_mb()	__dsb(st)
+
+#endif /* !_ASMLANGUAGE */
+
+#endif /* ZEPHYR_INCLUDE_ARCH_ARM64_BARRIER_H_ */

--- a/include/arch/riscv/barrier.h
+++ b/include/arch/riscv/barrier.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2022 Alexandre Mergnat <amergnat@baylibre.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_ARCH_RISCV_BARRIER_H_
+#define ZEPHYR_INCLUDE_ARCH_RISCV_BARRIER_H_
+
+#ifndef _ASMLANGUAGE
+
+#define z_full_mb()	__asm__ volatile ("fence iorw, iorw" : : : "memory")
+#define z_read_mb()	__asm__ volatile ("fence ir, ir" : : : "memory")
+#define z_write_mb()	__asm__ volatile ("fence ow, ow" : : : "memory")
+
+#endif /* !_ASMLANGUAGE */
+
+#endif /* ZEPHYR_INCLUDE_ARCH_RISCV_BARRIER_H_ */

--- a/include/kernel_includes.h
+++ b/include/kernel_includes.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2018 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Header files included by kernel.h.
+ */
+
+#ifndef ZEPHYR_INCLUDE_KERNEL_INCLUDES_H_
+#define ZEPHYR_INCLUDE_KERNEL_INCLUDES_H_
+
+#include <stddef.h>
+#include <zephyr/types.h>
+#include <limits.h>
+#include <toolchain.h>
+#include <linker/sections.h>
+#include <sys/atomic.h>
+#include <sys/barrier.h>
+#include <sys/__assert.h>
+#include <kernel/sched_priq.h>
+#include <sys/dlist.h>
+#include <sys/slist.h>
+#include <sys/sflist.h>
+#include <sys/util.h>
+#include <kernel_structs.h>
+#include <kernel/mempool_heap.h>
+#include <kernel_version.h>
+#include <syscall.h>
+#include <sys/printk.h>
+#include <arch/cpu.h>
+#include <sys/rb.h>
+#include <sys_clock.h>
+#include <spinlock.h>
+#include <fatal.h>
+#include <irq.h>
+#include <kernel/thread_stack.h>
+#include <app_memory/mem_domain.h>
+#include <sys/kobject.h>
+#include <kernel/thread.h>
+
+#endif /* ZEPHYR_INCLUDE_KERNEL_INCLUDES_H_ */

--- a/include/zephyr/arch/arm64/lib_helpers.h
+++ b/include/zephyr/arch/arm64/lib_helpers.h
@@ -152,8 +152,10 @@ static ALWAYS_INLINE void disable_fiq(void)
 #define wfe()	__asm__ volatile("wfe" : : : "memory")
 #define wfi()	__asm__ volatile("wfi" : : : "memory")
 
-#define dsb()	__asm__ volatile ("dsb sy" ::: "memory")
-#define dmb()	__asm__ volatile ("dmb sy" ::: "memory")
+#define __dsb(opt)	__asm__ volatile("dsb " #opt : : : "memory")
+#define dsb()	__dsb(sy)
+#define __dmb(opt)	__asm__ volatile("dmb " #opt : : : "memory")
+#define dmb()	__dmb(sy)
 #define isb()	__asm__ volatile ("isb" ::: "memory")
 
 /* Zephyr needs these as well */

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -30,6 +30,7 @@
 #include <zephyr/linker/sections.h>
 #include <zephyr/sys/device_mmio.h>
 #include <zephyr/sys/util.h>
+#include <errno.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/kernel_includes.h
+++ b/include/zephyr/kernel_includes.h
@@ -20,6 +20,7 @@
 #include <zephyr/linker/sections.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/__assert.h>
+#include <zephyr/sys/barrier.h>
 #include <zephyr/kernel/sched_priq.h>
 #include <zephyr/sys/dlist.h>
 #include <zephyr/sys/slist.h>

--- a/include/zephyr/sys/barrier.h
+++ b/include/zephyr/sys/barrier.h
@@ -19,7 +19,15 @@ extern "C" {
 
 #if defined(ARCH_HAS_MEMORY_BARRIER)
 
+#if defined(CONFIG_ARM)
+#include <arch/arm/aarch32/barrier.h>
+#elif defined(CONFIG_ARM64)
+#include <arch/arm64/barrier.h>
+#elif defined(CONFIG_RISCV)
+#include <arch/riscv/barrier.h>
+#else
 #error "Missing memory barrier definitions"
+#endif /* CONFIG_ARM */
 
 #elif defined(__GNUC__)
 

--- a/include/zephyr/sys/barrier.h
+++ b/include/zephyr/sys/barrier.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2022 Alexandre Mergnat <amergnat@baylibre.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Public interface for barriers.
+ */
+#ifndef ZEPHYR_INCLUDE_BARRIER_H_
+#define ZEPHYR_INCLUDE_BARRIER_H_
+
+#ifndef _ASMLANGUAGE
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(ARCH_HAS_MEMORY_BARRIER)
+
+#error "Missing memory barrier definitions"
+
+#elif defined(__GNUC__)
+
+/**
+ * @defgroup barrier_apis Barriers API
+ * @ingroup kernel_apis
+ * @{
+ */
+
+/**
+ * @brief z_full_mb - Memory Barrier
+ *
+ * A full system memory barrier. All memory operations before the z_full_mb()
+ * in the instruction stream will be committed before any operations after the
+ * z_full_mb() are committed. This ordering will be visible to all bus masters
+ * in the system. It will also ensure the order in which accesses from
+ * a single processor reaches slave devices.
+ */
+#define z_full_mb()	__atomic_thread_fence(__ATOMIC_SEQ_CST)
+
+/**
+ * @brief z_read_mb - Read Memory Barrier
+ *
+ * Like z_full_mb(), but only guarantees ordering between read accesses. That
+ * is, all read operations before an z_read_mb() will be committed before any
+ * read operations after the z_read_mb().
+ */
+#define z_read_mb()	__atomic_thread_fence(__ATOMIC_SEQ_CST)
+
+/**
+ * @brief z_write_mb - Write Memory Barrier
+ *
+ * Like z_full_mb(), but only guarantees ordering between write accesses. That
+ * is, all write operations before a z_write_mb() will be committed before any
+ * write operations after the z_write_mb().
+ */
+#define z_write_mb()	__atomic_thread_fence(__ATOMIC_SEQ_CST)
+
+/**
+ * @}
+ */
+
+#else
+
+#error "Missing memory barrier definitions"
+
+#endif /* ARCH_HAS_MEMORY_BARRIER */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !_ASMLANGUAGE */
+
+#endif /* ZEPHYR_INCLUDE_BARRIER_H_ */

--- a/tests/kernel/common/CMakeLists.txt
+++ b/tests/kernel/common/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(app PRIVATE
 endif()
 target_sources(app PRIVATE
 	src/atomic.c
+	src/barrier.c
 	src/bitarray.c
 	src/byteorder.c
 	src/clock.c

--- a/tests/kernel/common/src/barrier.c
+++ b/tests/kernel/common/src/barrier.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022 Alexandre Mergnat <amergnat@baylibre.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <ztest.h>
+#include <kernel.h>
+
+/**
+ * @brief Test to verify API functions
+ *
+ * @ingroup kernel_mem_barrier_tests
+ *
+ * @details
+ * Test Objective:
+ * - To verify if all memory barrier API are defined
+ *   to catch build regression.
+ *
+ * Testing techniques:
+ * - Call all memory barrier API functions.
+ *
+ */
+ZTEST(mb_api, test_mb_api)
+{
+	z_full_mb();
+	z_read_mb();
+	z_write_mb();
+}

--- a/tests/kernel/common/src/main.c
+++ b/tests/kernel/common/src/main.c
@@ -108,3 +108,5 @@ ZTEST_SUITE(printk, NULL, common_setup, NULL, NULL, NULL);
 
 ZTEST_SUITE(common_1cpu, NULL, common_setup,
 		ztest_simple_1cpu_before, ztest_simple_1cpu_after, NULL);
+
+ZTEST_SUITE(mb_api, NULL, common_setup, NULL, NULL, NULL);


### PR DESCRIPTION
This PR is the continuity of @carlocaione work: https://github.com/zephyrproject-rtos/zephyr/pull/41977
Then all comments have been taken into account before push this version.
For now, SMP is no longer include in the barrier API

It is basically introducing support for the barrier operations (mb, wmb, rmb). This is done introducing a generic fallback implementation in include/barrier.h to be specialized (if needed) by each arch. The name is taken from Linux but the implementation is slimmer.

In this PR I specialize the operations for ARM, ARM64 and RISC-V because I'm only familiar with these architectures.