### PR TITLE
net: buf: remove gcc dependency

### DIFF
--- a/include/net/buf.h
+++ b/include/net/buf.h
@@ -1045,16 +1045,17 @@ struct net_buf_pool {
 	}
 #endif /* CONFIG_NET_BUF_POOL_USAGE */
 
-#define _NET_BUF_ARRAY_DEFINE(_name, _count, _ud_size)                                    \
-	struct _net_buf_##_name {struct net_buf b; uint8_t ud[_ud_size]; };               \
-	BUILD_ASSERT(_ud_size <= UINT8_MAX);                                              \
-	BUILD_ASSERT(offsetof(struct net_buf, user_data) ==                               \
-		offsetof(struct _net_buf_##_name, ud), "Invalid offset");                 \
-	BUILD_ASSERT(__alignof__(struct net_buf) ==                                       \
-		__alignof__(struct _net_buf_##_name), "Invalid alignment");               \
-	BUILD_ASSERT(sizeof(struct _net_buf_##_name) ==                                   \
-		ROUND_UP(sizeof(struct net_buf) + _ud_size, __alignof__(struct net_buf)), \
-		"Size cannot be determined");                                             \
+#define _NET_BUF_ARRAY_DEFINE(_name, _count, _ud_size)					       \
+	struct _net_buf_##_name { uint8_t b[sizeof(struct net_buf)];			       \
+				  uint8_t ud[_ud_size]; } __net_buf_align;		       \
+	BUILD_ASSERT(_ud_size <= UINT8_MAX);						       \
+	BUILD_ASSERT(offsetof(struct net_buf, user_data) ==				       \
+		     offsetof(struct _net_buf_##_name, ud), "Invalid offset");		       \
+	BUILD_ASSERT(__alignof__(struct net_buf) ==					       \
+		     __alignof__(struct _net_buf_##_name), "Invalid alignment");	       \
+	BUILD_ASSERT(sizeof(struct _net_buf_##_name) ==					       \
+		     ROUND_UP(sizeof(struct net_buf) + _ud_size, __alignof__(struct net_buf)), \
+		     "Size cannot be determined");					       \
 	static struct _net_buf_##_name _net_buf_##_name[_count] __noinit
 
 extern const struct net_buf_data_alloc net_buf_heap_alloc;


### PR DESCRIPTION
Placing a struct with a flexible array member inside another struct not
as the last member is a GCC only extension. The offending macro is only
used to allocate enough space sufficient for a `struct net_buf`.
Therefore the dummy type declaration can simply use a byte array of the
same size as a `struct net_buf`, instead of the `struct net_buf` itself.

Fixes #42586.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>