### PR TITLE
ITE drivers/pwm: support tests/drivers/pwm/pwm_api

### DIFF
--- a/boards/riscv/it8xxx2_evb/it8xxx2_evb.dts
+++ b/boards/riscv/it8xxx2_evb/it8xxx2_evb.dts
@@ -32,6 +32,7 @@
 		led0 = &led0;
 		kscan0 = &kscan0;
 		watchdog0 = &twd0;
+		pwm-0 = &pwm0;
 	};
 
 	leds {


### PR DESCRIPTION
Add pwm-0 to support tests/drivers/pwm/pwm_api.

Solve tests code runtime error on it8xxx2_evb:
1.If the pwm channel target frequency is < 1, then we will
   return an error code.
    
2.If the target_freq is <= 324Hz, we will configure that this pwm
   channel need to output in EC power saving mode.
   In test_pwm_cycle() case, the period is 64000, then the
   target_freq is 8000000 / 64000 = 125Hz and <= 324Hz, so we will
   switch the prescaler clock source from 8MHz to 32.768kHz.
   Then the target_freq is 32768 / 64000 = 0.512Hz and < 1Hz,
    this will return an error code. In order to get the same
    target_freq, we always return PWM_FREQ in
    pwm_it8xxx2_get_cycles_per_sec().

Signed-off-by: Ruibin Chang <Ruibin.Chang@ite.com.tw>