### PR TITLE
arch: arm: core: aarch32: Fix Cortex-M userspace regression

### DIFF
--- a/arch/arm/core/aarch32/userspace.S
+++ b/arch/arm/core/aarch32/userspace.S
@@ -524,9 +524,6 @@ dispatch_syscall:
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
     /* set stack back to unprivileged stack */
     ldr ip, [sp,#12]
-#endif
-
-#if !defined(CONFIG_ARMV7_R)
     msr PSP, ip
 #endif
 


### PR DESCRIPTION
This was introduced when trying to fix a previous merge conflict.  It
broke userspace tests on nucleo_l073rz.

This fixes #39963

Fixes #42627

Signed-off-by: Bradley Bolen <bbolen@lexmark.com>