### PR TITLE
MAINTAINERS: mbolivar-nordic for Devicetree

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -363,9 +363,9 @@ DFU:
 Devicetree:
     status: maintained
     maintainers:
-        - galak
-    collaborators:
         - mbolivar-nordic
+    collaborators:
+        - galak
     files:
         - scripts/dts/
         - dts/bindings/


### PR DESCRIPTION
While Kumar (@galak) is away, I'm de facto DT maintainer. Might as
well make it official. Kumar can always take the reins again when he
returns, if he wants them back.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>