### PR TITLE
net: lwm2m: fixed "LwM2M message is invalid"

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -918,6 +918,8 @@ void lwm2m_reset_message(struct lwm2m_message *msg, bool release)
 		coap_reply_clear(msg->reply);
 	}
 
+	sys_slist_find_and_remove(&msg->ctx->pending_sends, &msg->node);
+
 	if (release) {
 		(void)memset(msg, 0, sizeof(*msg));
 	} else {


### PR DESCRIPTION
Do not retransmit a message that just has been sent successfully.

This case can in particular happen quite frequently if the modem
connection/throughput is quite bad and so there is a high latency.

A message that has to be acknowledged is scheduled for retransmission.
Before retransmission a ack for this message is received that will
cause a reset of the original message. In this case you see a
"LwM2M message is invalid" error message.

Signed-off-by: Andreas Chmielewski <andreas.chmielewski@grandcentrix.net>