### PR TITLE
it8xxx2: changing PLL sequence is high priority

### DIFF
--- a/drivers/interrupt_controller/intc_ite_it8xxx2.c
+++ b/drivers/interrupt_controller/intc_ite_it8xxx2.c
@@ -203,7 +203,7 @@ uint8_t get_irq(void *arg)
 	return intc_irq;
 }
 
-static int ite_intc_init(const struct device *dev)
+void ite_intc_init(void)
 {
 	/* Ensure interrupts of soc are disabled at default */
 	for (int i = 0; i < ARRAY_SIZE(reg_enable); i++)
@@ -211,8 +211,4 @@ static int ite_intc_init(const struct device *dev)
 
 	/* Enable M-mode external interrupt */
 	csr_set(mie, MIP_MEIP);
-
-	return 0;
 }
-
-SYS_INIT(ite_intc_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/soc/riscv/riscv-ite/common/soc_common.h
+++ b/soc/riscv/riscv-ite/common/soc_common.h
@@ -45,6 +45,7 @@ extern uint8_t ite_intc_get_irq_num(void);
 extern int ite_intc_irq_is_enable(unsigned int irq);
 extern void ite_intc_irq_polarity_set(unsigned int irq, unsigned int flags);
 extern void ite_intc_isr_clear(unsigned int irq);
+void ite_intc_init(void);
 #endif /* CONFIG_ITE_IT8XXX2_INTC */
 
 #ifdef CONFIG_SOC_IT8XXX2_PLL_FLASH_48M

--- a/soc/riscv/riscv-ite/it8xxx2/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-ite/it8xxx2/Kconfig.defconfig.series
@@ -68,6 +68,14 @@ config SOC_FLASH_ITE_IT8XXX2
 	default y
 	depends on FLASH
 
+config FLASH_INIT_PRIORITY
+	default 0
+
+config IT8XXX2_PLL_SEQUENCE_PRIORITY
+	int
+	default 1
+	depends on SOC_IT8XXX2_PLL_FLASH_48M
+
 config PWM_ITE_IT8XXX2
 	default y
 	depends on PWM
@@ -90,6 +98,9 @@ config GEN_IRQ_START_VECTOR
 	default 0
 
 config GEN_SW_ISR_TABLE
+	default y
+
+config RISCV_SOC_INTERRUPT_INIT
 	default y
 
 endif # ITE_IT8XXX2_INTC

--- a/soc/riscv/riscv-ite/it8xxx2/soc.c
+++ b/soc/riscv/riscv-ite/it8xxx2/soc.c
@@ -135,7 +135,9 @@ static int chip_change_pll(const struct device *dev)
 
 	return 0;
 }
-SYS_INIT(chip_change_pll, POST_KERNEL, 0);
+SYS_INIT(chip_change_pll, PRE_KERNEL_1, CONFIG_IT8XXX2_PLL_SEQUENCE_PRIORITY);
+BUILD_ASSERT(CONFIG_FLASH_INIT_PRIORITY < CONFIG_IT8XXX2_PLL_SEQUENCE_PRIORITY,
+	"CONFIG_FLASH_INIT_PRIORITY must be less than CONFIG_IT8XXX2_PLL_SEQUENCE_PRIORITY");
 #endif /* CONFIG_SOC_IT8XXX2_PLL_FLASH_48M */
 
 extern volatile int wait_interrupt_fired;
@@ -178,6 +180,11 @@ void arch_cpu_idle(void)
 void arch_cpu_atomic_idle(unsigned int key)
 {
 	riscv_idle(CHIP_PLL_DOZE, key);
+}
+
+void soc_interrupt_init(void)
+{
+	ite_intc_init();
 }
 
 static int ite_it8xxx2_init(const struct device *arg)

--- a/soc/riscv/riscv-ite/it8xxx2/soc.h
+++ b/soc/riscv/riscv-ite/it8xxx2/soc.h
@@ -14,4 +14,8 @@
 #define RISCV_RAM_BASE               CONFIG_SRAM_BASE_ADDRESS
 #define RISCV_RAM_SIZE               KB(CONFIG_SRAM_SIZE)
 
+#ifndef _ASMLANGUAGE
+void soc_interrupt_init(void);
+#endif
+
 #endif /* __RISCV_ITE_SOC_H_ */


### PR DESCRIPTION
This makes the sequence completed before hardware devices
initialization.

Signed-off-by: Dino Li <Dino.Li@ite.com.tw>