### PR TITLE
arm64: make use of IRQ stacks

### DIFF
--- a/arch/arm64/core/isr_wrapper.S
+++ b/arch/arm64/core/isr_wrapper.S
@@ -38,6 +38,14 @@ SECTION_FUNC(TEXT, _isr_wrapper)
 	add	w1, w1, #1
 	str	w1, [x0, #___cpu_t_nested_OFFSET]
 
+	/* If not nested: switch to IRQ stack and save current sp on it. */
+	cmp	w1, #1
+	bne	1f
+	ldr	x1, [x0, #___cpu_t_irq_stack_OFFSET]
+	mov	x2, sp
+	mov	sp, x1
+	str	x2, [sp, #-16]!
+1:
 #ifdef CONFIG_SCHED_THREAD_USAGE
 	bl	z_sched_usage_stop
 #endif
@@ -106,6 +114,10 @@ spurious_continue:
 	subs	w1, w1, #1
 	str	w1, [x0, #___cpu_t_nested_OFFSET]
 	bne	exit
+
+	/* No more nested: retrieve the task's stack. */
+	ldr	x0, [sp]
+	mov	sp, x0
 
 	/*
 	 * z_arch_get_next_switch_handle() is returning:

--- a/arch/arm64/core/isr_wrapper.S
+++ b/arch/arm64/core/isr_wrapper.S
@@ -32,8 +32,11 @@ GDATA(_sw_isr_table)
 GTEXT(_isr_wrapper)
 SECTION_FUNC(TEXT, _isr_wrapper)
 
-	/* ++(_kernel->nested) to be checked by arch_is_in_isr() */
-	inc_nest_counter x0, x1
+	/* ++_current_cpu->nested to be checked by arch_is_in_isr() */
+	get_cpu	x0
+	ldr	w1, [x0, #___cpu_t_nested_OFFSET]
+	add	w1, w1, #1
+	str	w1, [x0, #___cpu_t_nested_OFFSET]
 
 #ifdef CONFIG_SCHED_THREAD_USAGE
 	bl	z_sched_usage_stop
@@ -97,9 +100,11 @@ spurious_continue:
 	bl	sys_trace_isr_exit
 #endif
 
-	/* if (--(_kernel->nested) != 0) exit */
-	dec_nest_counter x0, x1
-
+	/* if (--_current_cpu->nested != 0) exit */
+	get_cpu	x0
+	ldr	w1, [x0, #___cpu_t_nested_OFFSET]
+	subs	w1, w1, #1
+	str	w1, [x0, #___cpu_t_nested_OFFSET]
 	bne	exit
 
 	/*

--- a/arch/arm64/core/macro_priv.inc
+++ b/arch/arm64/core/macro_priv.inc
@@ -30,28 +30,6 @@
 	and	\xreg0, \xreg0, #TPIDRROEL0_CURR_CPU
 .endm
 
-/*
- * Increment nested counter
- */
-
-.macro inc_nest_counter xreg0, xreg1
-	get_cpu	\xreg0
-	ldr	\xreg1, [\xreg0, #___cpu_t_nested_OFFSET]
-	add	\xreg1, \xreg1, #1
-	str	\xreg1, [\xreg0, #___cpu_t_nested_OFFSET]
-.endm
-
-/*
- * Decrement nested counter and update condition flags
- */
-
-.macro dec_nest_counter xreg0, xreg1
-	get_cpu	\xreg0
-	ldr	\xreg1, [\xreg0, #___cpu_t_nested_OFFSET]
-	subs	\xreg1, \xreg1, #1
-	str	\xreg1, [\xreg0, #___cpu_t_nested_OFFSET]
-.endm
-
 #endif /* _ASMLANGUAGE */
 
 #endif /* _MACRO_PRIV_INC_ */

--- a/arch/arm64/core/switch.S
+++ b/arch/arm64/core/switch.S
@@ -147,19 +147,24 @@ SECTION_FUNC(TEXT, z_arm64_sync_exc)
 	beq	offload
 	b	inv
 offload:
-	/* ++_current_cpu->nested to be checked by arch_is_in_isr() */
+	/* _current_cpu->nested=1, to be checked by arch_is_in_isr() */
 	get_cpu x0
-	ldr	w1, [x0, #___cpu_t_nested_OFFSET]
-	add	w1, w1, #1
+	mov	w1, #1
 	str	w1, [x0, #___cpu_t_nested_OFFSET]
+	/* switch to IRQ stack and save current sp on it. */
+	ldr	x1, [x0, #___cpu_t_irq_stack_OFFSET]
+	mov	x2, sp
+	mov	sp, x1
+	str	x2, [sp, #-16]!
 
 	bl	z_irq_do_offload
 
-	/* --_current_cpu->nested */
+	/* _current_cpu->nested=0 */
 	get_cpu x0
-	ldr	w1, [x0, #___cpu_t_nested_OFFSET]
-	sub	w1, w1, #1
-	str	w1, [x0, #___cpu_t_nested_OFFSET]
+	str	wzr, [x0, #___cpu_t_nested_OFFSET]
+	/* restore original stack pointer. */
+	ldr	x1, [sp]
+	mov	sp, x1
 	b	z_arm64_exit_exc
 #endif
 	b	inv

--- a/arch/arm64/core/switch.S
+++ b/arch/arm64/core/switch.S
@@ -147,13 +147,19 @@ SECTION_FUNC(TEXT, z_arm64_sync_exc)
 	beq	offload
 	b	inv
 offload:
-	/* ++(_kernel->nested) to be checked by arch_is_in_isr() */
-	inc_nest_counter x0, x1
+	/* ++_current_cpu->nested to be checked by arch_is_in_isr() */
+	get_cpu x0
+	ldr	w1, [x0, #___cpu_t_nested_OFFSET]
+	add	w1, w1, #1
+	str	w1, [x0, #___cpu_t_nested_OFFSET]
 
 	bl	z_irq_do_offload
 
-	/* --(_kernel->nested) */
-	dec_nest_counter x0, x1
+	/* --_current_cpu->nested */
+	get_cpu x0
+	ldr	w1, [x0, #___cpu_t_nested_OFFSET]
+	sub	w1, w1, #1
+	str	w1, [x0, #___cpu_t_nested_OFFSET]
 	b	z_arm64_exit_exc
 #endif
 	b	inv


### PR DESCRIPTION
Currently, the ARM64 architecture doesn't use dedicated IRQ stacks.
Let's fix that, plus some related minor fixes.
