### PR TITLE
npcx: Set default status of node vsby-psl-in-list to disable 

### DIFF
--- a/boards/arm/npcx7m6fb_evb/npcx7m6fb_evb.dts
+++ b/boards/arm/npcx7m6fb_evb/npcx7m6fb_evb.dts
@@ -52,6 +52,7 @@
 
 	vsby-psl-in-list {
 		psl-in-pads = <&psl_in1>; /* Use PSL_IN1 as detection pins */
+		status = "okay";
 	};
 };
 

--- a/boards/arm/npcx9m6f_evb/npcx9m6f_evb.dts
+++ b/boards/arm/npcx9m6f_evb/npcx9m6f_evb.dts
@@ -64,6 +64,7 @@
 
 	vsby-psl-in-list {
 		psl-in-pads = <&psl_in1>; /* Use PSL_IN1 as detection pins */
+		status = "okay";
 	};
 };
 

--- a/dts/arm/nuvoton/npcx.dtsi
+++ b/dts/arm/nuvoton/npcx.dtsi
@@ -66,6 +66,7 @@
 		 *   flag = <NPCX_PSL_FALLING_EDGE>;
 		 */
 		psl-in-pads = <>;
+		status = "disabled";
 	};
 
 	soc {

--- a/soc/arm/nuvoton_npcx/common/scfg.c
+++ b/soc/arm/nuvoton_npcx/common/scfg.c
@@ -38,7 +38,9 @@ static const struct npcx_alt def_alts[] =
 
 static const struct npcx_lvol def_lvols[] = NPCX_DT_IO_LVOL_ITEMS_DEF_LIST;
 
+#if DT_HAS_COMPAT_STATUS_OKAY(nuvoton_npcx_pslctrl_def)
 static const struct npcx_psl_in psl_in_confs[] = NPCX_DT_PSL_IN_ITEMS_LIST;
+#endif
 
 static const struct npcx_scfg_config npcx_scfg_cfg = {
 	.base_scfg = DT_REG_ADDR_BY_NAME(DT_NODELABEL(scfg), scfg),
@@ -72,17 +74,6 @@ static void npcx_pinctrl_alt_sel(const struct npcx_alt *alt, int alt_func)
 		NPCX_DEVALT(scfg_base, alt->group) |=  alt_mask;
 	} else {
 		NPCX_DEVALT(scfg_base, alt->group) &= ~alt_mask;
-	}
-}
-
-static void npcx_pinctrl_psl_detect_mode_sel(uint32_t offset, bool edge_mode)
-{
-	struct glue_reg *const inst_glue = HAL_GLUE_INST();
-
-	if (edge_mode) {
-		inst_glue->PSL_CTS |= NPCX_PSL_CTS_MODE_BIT(offset);
-	} else {
-		inst_glue->PSL_CTS &= ~NPCX_PSL_CTS_MODE_BIT(offset);
 	}
 }
 
@@ -179,6 +170,18 @@ void npcx_pinctrl_psl_output_set_inactive(void)
 	inst->PDOUT |= BIT(pin);
 }
 
+#if DT_HAS_COMPAT_STATUS_OKAY(nuvoton_npcx_pslctrl_def)
+static void npcx_pinctrl_psl_detect_mode_sel(uint32_t offset, bool edge_mode)
+{
+	struct glue_reg *const inst_glue = HAL_GLUE_INST();
+
+	if (edge_mode) {
+		inst_glue->PSL_CTS |= NPCX_PSL_CTS_MODE_BIT(offset);
+	} else {
+		inst_glue->PSL_CTS &= ~NPCX_PSL_CTS_MODE_BIT(offset);
+	}
+}
+
 bool npcx_pinctrl_psl_input_asserted(uint32_t i)
 {
 	struct glue_reg *const inst_glue = HAL_GLUE_INST();
@@ -208,6 +211,7 @@ void npcx_pinctrl_psl_input_configure(void)
 		npcx_pinctrl_alt_sel(&psl_in_confs[i].pinctrl, 1);
 	}
 }
+#endif
 
 void npcx_host_interface_sel(enum npcx_hif_type hif_type)
 {


### PR DESCRIPTION
The application may not always use the PSL mode. Change the status of  node vsby-psl-in-list to default disabled. The application can override it when it wants to use PSL hibernate. With the change, we can guard the psl-in related code, which reduce a little RAM/flash size.

Signed-off-by: Jun Lin <CHLin56@nuvoton.com>