### PR TITLE
[Backport v2.7-branch] net: route: Fix struct net_route_nexthop leak

### DIFF
--- a/subsys/net/ip/route.c
+++ b/subsys/net/ip/route.c
@@ -66,6 +66,13 @@ static inline struct net_nbr *get_nexthop_nbr(struct net_nbr *start, int idx)
 			((sizeof(struct net_nbr) + start->size) * idx));
 }
 
+static void release_nexthop_route(struct net_route_nexthop *route_nexthop)
+{
+	struct net_nbr *nbr = CONTAINER_OF(route_nexthop, struct net_nbr, __nbr);
+
+	net_nbr_unref(nbr);
+}
+
 static struct net_nbr *get_nexthop_route(void)
 {
 	int i;
@@ -469,6 +476,7 @@ int net_route_del(struct net_route_entry *route)
 		}
 
 		nbr_nexthop_put(nexthop_route->nbr);
+		release_nexthop_route(nexthop_route);
 	}
 
 	nbr_free(nbr);

--- a/subsys/net/ip/route.c
+++ b/subsys/net/ip/route.c
@@ -632,6 +632,10 @@ int net_route_foreach(net_route_cb_t cb, void *user_data)
 			continue;
 		}
 
+		if (!nbr->ref) {
+			continue;
+		}
+
 		route = net_route_data(nbr);
 		if (!route) {
 			continue;


### PR DESCRIPTION
When new route is allocated, a corresponding NBR entry (containing
`struct net_route_nexthop` data) is allocated from
`net_route_nexthop_pool`. When the route was deleted however, the entry
was not freed - only the "core" neighbor entry from the neighbor
management module (nbr.c) was dereferenced. This lead to a resource
leak, effecitevly leaking one `net_route_nexthop_pool` entry for each
deleted route.

Fix this, by defreferencing the NBR entry corresponding to the `struct
net_route_nexthop` data of the deleted route when route is removed.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>

Fixes #40985