### PR TITLE
Bluetooth: df: Fix sample application build issues

### DIFF
--- a/samples/bluetooth/direction_finding_central/overlay-aod.conf
+++ b/samples/bluetooth/direction_finding_central/overlay-aod.conf
@@ -4,5 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-# Disable AoA Feature (antenna switching) in Rx mode
+# Disable AoA Feature (antenna switching) in Rx mode in Controller and Host
 CONFIG_BT_CTLR_DF_ANT_SWITCH_RX=n
+CONFIG_BT_DF_CTE_RX_AOA=n

--- a/samples/bluetooth/direction_finding_central/sample.yaml
+++ b/samples/bluetooth/direction_finding_central/sample.yaml
@@ -4,14 +4,18 @@ sample:
 tests:
   sample.bluetooth.direction_finding_connectionless_rx:
     harness: bluetooth
-    platform_allow: nrf52833dk_nrf52833
+    platform_allow: nrf52833dk_nrf52833 nrf52833dk_nrf52820 nrf5340dk_nrf5340_cpuapp
     tags: bluetooth
     integration_platforms:
-        - nrf52833dk_nrf52833
+      - nrf52833dk_nrf52833
+      - nrf52833dk_nrf52820
+      - nrf5340dk_nrf5340_cpuapp
   sample.bluetooth.direction_finding_connectionless_rx.aod:
     extra_args: OVERLAY_CONFIG="overlay-aod.conf"
     harness: bluetooth
-    platform_allow: nrf52833dk_nrf52833
+    platform_allow: nrf52833dk_nrf52833 nrf52833dk_nrf52820 nrf5340dk_nrf5340_cpuapp
     tags: bluetooth
     integration_platforms:
-        - nrf52833dk_nrf52833
+      - nrf52833dk_nrf52833
+      - nrf52833dk_nrf52820
+      - nrf5340dk_nrf5340_cpuapp

--- a/samples/bluetooth/direction_finding_connectionless_rx/boards/nrf52833dk_nrf52820.conf
+++ b/samples/bluetooth/direction_finding_connectionless_rx/boards/nrf52833dk_nrf52820.conf
@@ -10,3 +10,6 @@ CONFIG_BT_CTLR_DF=y
 # Disable Direction Fiding TX mode
 CONFIG_BT_CTLR_DF_ANT_SWITCH_TX=n
 CONFIG_BT_CTLR_DF_ADV_CTE_TX=n
+
+# Limit maximum number of CTEs to fit into nRF52820 SRAM size
+CONFIG_BT_CTLR_DF_PER_SCAN_CTE_NUM_MAX=1

--- a/samples/bluetooth/direction_finding_connectionless_rx/overlay-aod.conf
+++ b/samples/bluetooth/direction_finding_connectionless_rx/overlay-aod.conf
@@ -1,2 +1,9 @@
-# Disable AoD Feature (antenna switching) in Tx mode
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Disable AoA Feature (antenna switching) in Rx mode in Controller and Host
 CONFIG_BT_CTLR_DF_ANT_SWITCH_RX=n
+CONFIG_BT_DF_CTE_RX_AOA=n

--- a/samples/bluetooth/direction_finding_connectionless_rx/sample.yaml
+++ b/samples/bluetooth/direction_finding_connectionless_rx/sample.yaml
@@ -3,8 +3,16 @@ sample:
 tests:
   sample.bluetooth.direction_finding_connectionless_rx:
     harness: bluetooth
-    platform_allow: nrf52833dk_nrf52833
+    platform_allow: nrf52833dk_nrf52833 nrf52833dk_nrf52820 nrf5340dk_nrf5340_cpuapp
     tags: bluetooth
+    integration_platforms:
+      - nrf52833dk_nrf52833
+      - nrf52833dk_nrf52820
+      - nrf5340dk_nrf5340_cpuapp
   sample.bluetooth.direction_finding_connectionless_rx.aod:
     extra_args: OVERLAY_CONFIG="overlay-aod.conf"
-    platform_allow: nrf52833dk_nrf52833
+    platform_allow: nrf52833dk_nrf52833 nrf52833dk_nrf52820 nrf5340dk_nrf5340_cpuapp
+    integration_platforms:
+      - nrf52833dk_nrf52833
+      - nrf52833dk_nrf52820
+      - nrf5340dk_nrf5340_cpuapp

--- a/samples/bluetooth/direction_finding_connectionless_tx/overlay-aoa.conf
+++ b/samples/bluetooth/direction_finding_connectionless_tx/overlay-aoa.conf
@@ -1,2 +1,9 @@
-# Disable AoD Feature (antenna switching) in Tx mode
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Disable AoD Feature (antenna switching) in Tx mode in Controller and Host
 CONFIG_BT_CTLR_DF_ANT_SWITCH_TX=n
+CONFIG_BT_DF_CTE_TX_AOD=n

--- a/samples/bluetooth/direction_finding_connectionless_tx/sample.yaml
+++ b/samples/bluetooth/direction_finding_connectionless_tx/sample.yaml
@@ -3,8 +3,16 @@ sample:
 tests:
   sample.bluetooth.direction_finding_connectionless:
     harness: bluetooth
-    platform_allow: nrf52833dk_nrf52833
+    platform_allow: nrf52833dk_nrf52833 nrf52833dk_nrf52820 nrf5340dk_nrf5340_cpuapp
     tags: bluetooth
+    integration_platforms:
+      - nrf52833dk_nrf52833
+      - nrf52833dk_nrf52820
+      - nrf5340dk_nrf5340_cpuapp
   sample.bluetooth.direction_finding_connectionless.aoa:
     extra_args: OVERLAY_CONFIG="overlay-aoa.conf"
-    platform_allow: nrf52833dk_nrf52833
+    platform_allow: nrf52833dk_nrf52833 nrf52833dk_nrf52820 nrf5340dk_nrf5340_cpuapp
+    integration_platforms:
+      - nrf52833dk_nrf52833
+      - nrf52833dk_nrf52820
+      - nrf5340dk_nrf5340_cpuapp

--- a/samples/bluetooth/direction_finding_peripheral/overlay-aoa.conf
+++ b/samples/bluetooth/direction_finding_peripheral/overlay-aoa.conf
@@ -4,5 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-# Disable AoD Feature (antenna switching) in Tx mode
+# Disable AoD Feature (antenna switching) in Tx mode in Controller and Host
 CONFIG_BT_CTLR_DF_ANT_SWITCH_TX=n
+CONFIG_BT_DF_CTE_TX_AOD=n

--- a/samples/bluetooth/direction_finding_peripheral/sample.yaml
+++ b/samples/bluetooth/direction_finding_peripheral/sample.yaml
@@ -4,14 +4,18 @@ sample:
 tests:
   sample.bluetooth.direction_finding_connectionless_rx:
     harness: bluetooth
-    platform_allow: nrf52833dk_nrf52833
+    platform_allow: nrf52833dk_nrf52833 nrf52833dk_nrf52820 nrf5340dk_nrf5340_cpuapp
     tags: bluetooth
     integration_platforms:
-        - nrf52833dk_nrf52833
+      - nrf52833dk_nrf52833
+      - nrf52833dk_nrf52820
+      - nrf5340dk_nrf5340_cpuapp
   sample.bluetooth.direction_finding_connectionless_rx.aod:
     extra_args: OVERLAY_CONFIG="overlay-aoa.conf"
     harness: bluetooth
-    platform_allow: nrf52833dk_nrf52833
+    platform_allow: nrf52833dk_nrf52833 nrf52833dk_nrf52820 nrf5340dk_nrf5340_cpuapp
     tags: bluetooth
     integration_platforms:
-        - nrf52833dk_nrf52833
+      - nrf52833dk_nrf52833
+      - nrf52833dk_nrf52820
+      - nrf5340dk_nrf5340_cpuapp

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -219,17 +219,17 @@
 #endif
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT) && defined(CONFIG_BT_OBSERVER)
-#if defined(CONFIG_BT_CTLR_DF_CTE_RX)
+#if defined(CONFIG_BT_CTLR_DF_PER_SCAN_CTE_NUM_MAX)
 /* Note: Need node for PDU and CTE sample */
 #define BT_CTLR_ADV_EXT_RX_CNT  (CONFIG_BT_CTLR_SCAN_AUX_SET * \
 				 CONFIG_BT_CTLR_DF_PER_SCAN_CTE_NUM_MAX * 2)
 #else
 /* Note: Assume up to 7 PDUs per advertising train (max data length) */
 #define BT_CTLR_ADV_EXT_RX_CNT  (CONFIG_BT_CTLR_SCAN_AUX_SET * 7)
-#endif
+#endif /* CONFIG_BT_CTLR_DF_PER_SCAN_CTE_NUM_MAX */
 #else
 #define BT_CTLR_ADV_EXT_RX_CNT  0
-#endif /* CONFIG_BT_CTLR_DF_CTE_RX */
+#endif /* CONFIG_BT_CTLR_ADV_EXT && CONFIG_BT_OBSERVER */
 
 #if !defined(TICKER_USER_LLL_VENDOR_OPS)
 #define TICKER_USER_LLL_VENDOR_OPS 0


### PR DESCRIPTION
Fix problem with building sample applications where Host is
split from Controller into separate binaries. In that situation
samples does not have access to controllers Kconfig options.
To allow memory optimization on Host site disable unwanted
features (angle of arrival or angle of departure).

CONFIG_BT_CTLR_DF_CTE_RX is enabled by default if CONFIG_BT_CLTR_DF
is enabled and there is support for DF in given SOC.
If CONFIG_BT_CTLR_DF_SCAN_CTE_RX is disabled then the CONFIG_BT_CTLR-
_PER_SCAN_CTE_NUM_MAX is not available.
It causes build errors if that particular configuration is used by
an application. It was a case for e.g. split builds of direction
finding connectionless TX sample application were periodic advertising
was enabled.
