### PR TITLE
drivers: gpio: esp32: fix gpio number range and pull up check

### DIFF
--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -91,7 +91,7 @@ static int gpio_esp32_config(const struct device *dev,
 {
 	const struct gpio_esp32_config *const cfg = dev->config;
 	struct gpio_esp32_data *data = dev->data;
-	uint32_t io_pin = (uint32_t) pin;
+	uint32_t io_pin = (uint32_t) pin + (cfg->gpio_port == 1 ? 32 : 0);
 	uint32_t key;
 	int ret = 0;
 
@@ -329,7 +329,7 @@ static int gpio_esp32_pin_interrupt_configure(const struct device *port,
 					      enum gpio_int_trig trig)
 {
 	const struct gpio_esp32_config *const cfg = port->config;
-	uint32_t io_pin = (uint32_t) pin;
+	uint32_t io_pin = (uint32_t) pin + (cfg->gpio_port == 1 ? 32 : 0);
 	int intr_trig_mode = convert_int_type(mode, trig);
 	uint32_t key;
 

--- a/drivers/pinmux/pinmux_esp32.c
+++ b/drivers/pinmux/pinmux_esp32.c
@@ -67,8 +67,15 @@ static int pinmux_pullup(const struct device *dev, uint32_t pin, uint8_t func)
 			gpio_ll_pulldown_en(&GPIO, pin);
 		} else {
 #if SOC_RTCIO_INPUT_OUTPUT_SUPPORTED
-			rtcio_hal_pullup_disable(rtc_io_num_map[pin]);
-			rtcio_hal_pulldown_enable(rtc_io_num_map[pin]);
+			int rtcio_num = rtc_io_num_map[pin];
+
+			if (rtc_io_desc[rtcio_num].pulldown) {
+				rtcio_hal_pulldown_disable(rtc_io_num_map[pin]);
+			} else if (rtc_io_desc[rtcio_num].pullup) {
+				rtcio_hal_pullup_enable(rtc_io_num_map[pin]);
+			} else {
+				return -ENOTSUP;
+			}
 #endif
 		}
 		break;
@@ -78,8 +85,15 @@ static int pinmux_pullup(const struct device *dev, uint32_t pin, uint8_t func)
 			gpio_ll_pullup_en(&GPIO, pin);
 		} else {
 #if SOC_RTCIO_INPUT_OUTPUT_SUPPORTED
-			rtcio_hal_pulldown_disable(rtc_io_num_map[pin]);
-			rtcio_hal_pullup_enable(rtc_io_num_map[pin]);
+			int rtcio_num = rtc_io_num_map[pin];
+
+			if (rtc_io_desc[rtcio_num].pulldown) {
+				rtcio_hal_pulldown_disable(rtc_io_num_map[pin]);
+			} else if (rtc_io_desc[rtcio_num].pullup) {
+				rtcio_hal_pullup_enable(rtc_io_num_map[pin]);
+			} else {
+				return -ENOTSUP;
+			}
 #endif
 		}
 		break;


### PR DESCRIPTION
This PR fixes 2 issues regarding ESP32 gpio/pinmux driver:

1) ESP32 has 2 GPIO instances, meaning that pin number for each GPIO needs to be in range [0,31], It means that selecting pin 32 should be noted as `gpio1 0` in DTS. However, GPIO driver was expecting number 32, which would not be possible due to DTS numbering.  
2) A few ESP32 pins do not support internal PU/PD. This PR adds error check in case of this specific pins gets configured with this feature.