### PR TITLE
kconfig: fix (re)definitions in Kconfig.defconfig files

### DIFF
--- a/boards/arm/bl654_usb/Kconfig
+++ b/boards/arm/bl654_usb/Kconfig
@@ -8,3 +8,9 @@ config BOARD_ENABLE_DCDC
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_BL654_USB
+
+config BL654_USB_SERIAL_BACKEND_CDCACM
+	bool "Use CDC ACM UART as backend for BL654 USB adapter"
+	default y if !USB_DEVICE_BLUETOOTH
+	help
+	  Use CDC ACM UART as backend for console or shell.

--- a/boards/arm/bl654_usb/Kconfig.defconfig
+++ b/boards/arm/bl654_usb/Kconfig.defconfig
@@ -26,12 +26,6 @@ config FLASH_LOAD_OFFSET
 config USB_CDC_ACM
 	default n if USB_DEVICE_BLUETOOTH
 
-config BL654_USB_SERIAL_BACKEND_CDCACM
-	bool "Use CDC ACM UART as backend for BL654 USB adapter"
-	default y if !USB_DEVICE_BLUETOOTH
-	help
-	  Use CDC ACM UART as backend for console or shell.
-
 if BL654_USB_SERIAL_BACKEND_CDCACM
 
 config UART_CONSOLE

--- a/boards/arm/qemu_cortex_m0/Kconfig
+++ b/boards/arm/qemu_cortex_m0/Kconfig
@@ -1,0 +1,14 @@
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+config NRF_TIMER_TIMER
+	bool "nRF Timer Counter (NRF_TIMER0) Timer"
+	depends on CLOCK_CONTROL
+	depends on SOC_COMPATIBLE_NRF
+	depends on SYS_CLOCK_EXISTS
+	select TICKLESS_CAPABLE
+	default y
+	help
+	  This module implements a kernel device driver for the nRF Timer
+	  Counter NRF_TIMER0 and provides the standard "system clock driver"
+	  interfaces.

--- a/boards/arm/qemu_cortex_m0/Kconfig.defconfig
+++ b/boards/arm/qemu_cortex_m0/Kconfig.defconfig
@@ -8,23 +8,8 @@ if BOARD_QEMU_CORTEX_M0
 config BOARD
 	default "qemu_cortex_m0"
 
-if SYS_CLOCK_EXISTS
-
-config NRF_TIMER_TIMER
-	bool "nRF Timer Counter (NRF_TIMER0) Timer"
-	depends on CLOCK_CONTROL
-	depends on SOC_COMPATIBLE_NRF
-	select TICKLESS_CAPABLE
-	default y
-	help
-	  This module implements a kernel device driver for the nRF Timer
-	  Counter NRF_TIMER0 and provides the standard "system clock driver"
-	  interfaces.
-
 config NRF_RTC_TIMER
-	default n
-
-endif # SYS_CLOCK_EXISTS
+	default n if SYS_CLOCK_EXISTS
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 1000000

--- a/boards/arm64/xenvm/Kconfig.defconfig
+++ b/boards/arm64/xenvm/Kconfig.defconfig
@@ -6,12 +6,6 @@ if BOARD_XENVM
 config BUILD_OUTPUT_BIN
 	default y
 
-config XEN_INITIAL_DOMAIN
-	bool "Zephyr as Xen Domain 0"
-	default n
-	help
-	  Built binary will be used as Xen privileged domain.
-
 config BOARD
 	default "xenvm"
 

--- a/boards/riscv/rv32m1_vega/Kconfig.defconfig
+++ b/boards/riscv/rv32m1_vega/Kconfig.defconfig
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if BOARD_RV32M1_VEGA
-comment "RV32M1 board Kconfig.defconfig"
 
 config BOARD
 	default "rv32m1_vega_ri5cy" if SOC_OPENISA_RV32M1_RI5CY

--- a/boards/shields/ls0xx_generic/Kconfig.defconfig
+++ b/boards/shields/ls0xx_generic/Kconfig.defconfig
@@ -14,15 +14,12 @@ config LS0XX
 if LVGL
 
 config LVGL_VDB_SIZE
-	int "Display buffer percentage"
 	default 16
 
 config LVGL_DPI
-	int "Dots per inch"
 	default 150
 
 config LVGL_BITS_PER_PIXEL
-	int "Number of bits per pixel"
 	default 1
 
 choice LVGL_COLOR_DEPTH

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -231,6 +231,7 @@ class KconfigCheck(ComplianceTest):
         self.check_top_menu_not_too_long(kconf)
         self.check_no_pointless_menuconfigs(kconf)
         self.check_no_undef_within_kconfig(kconf)
+        self.check_no_redefined_in_defconfig(kconf)
         if full:
             self.check_no_undef_outside_kconfig(kconf)
 
@@ -343,6 +344,17 @@ Expected no more than {} potentially visible items (items with prompts) in the
 top-level Kconfig menu, found {} items. If you're deliberately adding new
 entries, then bump the 'max_top_items' variable in {}.
 """.format(max_top_items, n_top_items, __file__))
+
+    def check_no_redefined_in_defconfig(self, kconf):
+        # Checks that no symbols are (re)defined in defconfigs.
+
+        for node in kconf.node_iter():
+            if "defconfig" in node.filename and (node.prompt or node.help):
+                self.add_failure(f"""
+Kconfig node '{node.item.name}' found with prompt or help in {node.filename}.
+Options must not be defined in defconfig files.
+""")
+                continue
 
     def check_no_pointless_menuconfigs(self, kconf):
         # Checks that there are no pointless 'menuconfig' symbols without

--- a/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.series
+++ b/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.series
@@ -38,7 +38,5 @@ config CLOCK_CONTROL_MCHP_XEC
 
 config MCHP_ECIA_XEC
 	default y
-	help
-	  Enable support for Microchip XEC ECIA driver
 
 endif # SOC_SERIES_MEC172X

--- a/soc/arm/nuvoton_npcx/npcx7/Kconfig.defconfig.series
+++ b/soc/arm/nuvoton_npcx/npcx7/Kconfig.defconfig.series
@@ -13,104 +13,56 @@ config NUM_IRQS
 
 config CORTEX_M_SYSTICK
 	default !NPCX_ITIM_TIMER
-	help
-	  Disable Cortex-M system tick if NPCX_ITIM_TIMER is enabled.
 
 config CLOCK_CONTROL_NPCX
 	default y
 	depends on CLOCK_CONTROL
-	help
-	  Enable support for NPCX clock controller driver.
 
 config UART_NPCX
 	default y
 	depends on SERIAL
-	help
-	  Enable support for NPCX UART driver.
 
 config GPIO_NPCX
 	default y
 	depends on GPIO
-	help
-	  Enable support for NPCX GPIO driver.
 
 config PWM_NPCX
 	default y
 	depends on PWM
-	help
-	  Enable support for NPCX PWM driver.
 
 config ADC_NPCX
 	default y
 	depends on ADC
-	help
-	  Enable support for NPCX ADC driver. In NPCX7 series, it includes a
-	  10-bit resolution Analog-to-Digital Converter (ADC). Up to 10 voltage
-	  inputs can be measured and a internal voltage reference (VREF), 2.816V
-	  (typical) is used for measurement.
 
 config WDT_NPCX
 	default y
 	depends on WATCHDOG
-	help
-	  Enable support for NPCX Watchdog driver. Besides watchdog
-	  functionality, it also provides the protection mechanism over software
-	  execution. After setting the configuration registers, the software can
-	  lock it to provide a higher level of protection against subsequent
-	  erroneous software action. Once a section of the TWD is locked, only
-	  reset or the unlock sequence releases it.
 
 config ESPI_NPCX
 	default y
 	depends on ESPI
-	help
-	  Enable support for NPCX ESPI driver. The Intel Enhanced Serial
-	  Peripheral Interface (eSPI) provides a path for migrating host
-	  sub-devices via LPC to a lower pin count, higher bandwidth bus.
-	  So far, this driver supports all of functionalities beside flash
-	  channel support. It will be supported in the future. Please refer
-	  https://www.intel.com/content/www/us/en/support/articles/000020952/
-	  software/chipset-software.html for more detail.
 
 config I2C_NPCX
 	default y
 	depends on I2C
-	help
-	  Enable support for NPCX I2C driver. The NPCX SMB/I2C modules provides
-	  full support for a two-wire SMBus/I2C synchronous serial interface.
-	  Each interface is a two-wire serial interface that is compatible with
-	  both Intel SMBus and Philips I2C physical layer. There are 8 SMBus
-	  modules and 10 buses in NPCX7 series.
 
 config TACH_NPCX
 	default y
 	depends on SENSOR
-	help
-	  Enable support for NPCX tachometer sensor driver. The NPCX7 series
-	  contains two tachometer (TACH) modules that contains two counters
-	  (counter A and B). They are used to capture/compare a counter value
-	  when an event is generated on comparison of signals match.
 
 if SOC_POWER_MANAGEMENT
 
 config PM
 	default y if SYS_CLOCK_EXISTS
-	help
-	  Enable the kernel handles extra power management policies whenever
-	  system enters idle state.
 
 config PM_DEVICE
 	default y
-	help
-	  Enable device power management support.
 
 endif # SOC_POWER_MANAGEMENT
 
 config SPI_NPCX_FIU
 	default y
 	depends on SPI
-	help
-	  Enable support fot NPCX SPI (FIU) driver for the NOR SPI flash access.
 
 source "soc/arm/nuvoton_npcx/npcx7/Kconfig.defconfig.npcx7*"
 

--- a/soc/arm/nuvoton_npcx/npcx9/Kconfig.defconfig.series
+++ b/soc/arm/nuvoton_npcx/npcx9/Kconfig.defconfig.series
@@ -13,114 +13,56 @@ config NUM_IRQS
 
 config CORTEX_M_SYSTICK
 	default !NPCX_ITIM_TIMER
-	help
-	  Disable Cortex-M system tick if NPCX_ITIM_TIMER is enabled.
 
 config CLOCK_CONTROL_NPCX
 	default y
 	depends on CLOCK_CONTROL
-	help
-	  Enable support for NPCX clock controller driver. The NPCX clock
-	  controller generates both Low-Frequency clock domain (32.768 KHz,
-	  i.e. LFCLK clock signal) and High-Frequency clock signals (OFMCLK,
-	  AHB6_CLK, APBn_CLK, and FMCLK) for the Core domain modules.
 
 config UART_NPCX
 	default y
 	depends on SERIAL
-	help
-	  Enable support for NPCX UART driver. In NPCX9 series, it includes 4
-	  modules which support full-duplex asynchronous receiver-transmitter
-	  with 16-byte transmit and receive buffers.
 
 config GPIO_NPCX
 	default y
 	depends on GPIO
-	help
-	  Enable support for NPCX GPIO driver. In NPCX9 series, it includes 16
-	  ports that support input/output, input-only and output-only
-	  configurations.
 
 config PWM_NPCX
 	default y
 	depends on PWM
-	help
-	  Enable support for NPCX PWM driver. In NPCX9 series, it includes 8
-	  modules. Each module generates a single 16-bit PWM output. A 16-bit
-	  clock prescaler and a 16-bit counter determine the cycle time, the
-	  minimum possible pulse width and the duty cycle steps.
 
 config ADC_NPCX
 	default y
 	depends on ADC
-	help
-	  Enable support for NPCX ADC driver. In NPCX9 series, it includes a
-	  10-bit resolution Analog-to-Digital Converter (ADC). Up to 12 voltage
-	  inputs can be measured and a internal voltage reference (VREF), 2.816V
-	  (typical) is used for measurement.
 
 config WDT_NPCX
 	default y
 	depends on WATCHDOG
-	help
-	  Enable support for NPCX Watchdog driver. Besides watchdog
-	  functionality, it also provides the protection mechanism over software
-	  execution. After setting the configuration registers, the software can
-	  lock it to provide a higher level of protection against subsequent
-	  erroneous software action. Once a section of the TWD is locked, only
-	  reset or the unlock sequence releases it.
 
 config ESPI_NPCX
 	default y
 	depends on ESPI
-	help
-	  Enable support for NPCX ESPI driver. The Intel Enhanced Serial
-	  Peripheral Interface (eSPI) provides a path for migrating host
-	  sub-devices via LPC to a lower pin count, higher bandwidth bus.
-	  So far, this driver supports all of functionalities beside flash
-	  channel support. It will be supported in the future. Please refer
-	  https://www.intel.com/content/www/us/en/support/articles/000020952/
-	  software/chipset-software.html for more detail.
 
 config I2C_NPCX
 	default y
 	depends on I2C
-	help
-	  Enable support for NPCX I2C driver. The NPCX SMB/I2C modules provides
-	  full support for a two-wire SMBus/I2C synchronous serial interface.
-	  Each interface is a two-wire serial interface that is compatible with
-	  both Intel SMBus and Philips I2C physical layer. There are 8 SMBus
-	  modules and 10 buses in NPCX9 series.
 
 config TACH_NPCX
 	default y
 	depends on SENSOR
-	help
-	  Enable support for NPCX tachometer sensor driver. The NPCX9 series
-	  contains two tachometer (TACH) modules that contains two counters
-	  (counter A and B). They are used to capture/compare a counter value
-	  when an event is generated on comparison of signals match.
 
 if SOC_POWER_MANAGEMENT
 
 config PM
 	default y if SYS_CLOCK_EXISTS
-	help
-	  Enable the kernel handles extra power management policies whenever
-	  system enters idle state.
 
 config PM_DEVICE
 	default y
-	help
-	  Enable device power management support.
 
 endif # SOC_POWER_MANAGEMENT
 
 config SPI_NPCX_FIU
 	default y
 	depends on SPI
-	help
-	  Enable support fot NPCX SPI (FIU) driver for the NOR SPI flash access.
 
 source "soc/arm/nuvoton_npcx/npcx9/Kconfig.defconfig.npcx9*"
 

--- a/soc/arm64/xenvm/Kconfig.soc
+++ b/soc/arm64/xenvm/Kconfig.soc
@@ -7,3 +7,9 @@ config SOC_XENVM
 	select ARM_ARCH_TIMER
 	select GIC_V2
 	select CPU_CORTEX_A72
+
+config XEN_INITIAL_DOMAIN
+	bool "Zephyr as Xen Domain 0"
+	depends on SOC_XENVM
+	help
+	  Built binary will be used as Xen privileged domain.


### PR DESCRIPTION
Kconfig symbols must not be defined in Kconfig.defconfig.* files. Such
files are meant to change the default value of certain options.

This PR resolves such issues and introduces a new compliance check to prevent similar cases in the future.