### PR TITLE
adafruit_feather_m0_basic_proto: add zephyr_udc0 nodelabel

### DIFF
--- a/boards/arm/adafruit_feather_m0_basic_proto/adafruit_feather_m0_basic_proto.dts
+++ b/boards/arm/adafruit_feather_m0_basic_proto/adafruit_feather_m0_basic_proto.dts
@@ -97,6 +97,6 @@
 	};
 };
 
-&usb0 {
+zephyr_udc0: &usb0 {
 	status = "okay";
 };


### PR DESCRIPTION
Add zephyr_udc0 (USB device controller) nodelabel to the usb0 node
to allow USB samples to build.

That label was added to several boards in commit e4f894788a9,
but appears to have missed this board.

With this fix, samples/subsys/usb/cdc_acm works correctly on this board.
The board's documentation already suggested using that sample, but it
failed to build due to the missing nodelabel.

Signed-off-by: Joey Hess <id@joeyh.name>