### PR TITLE
tests: lifo_usage: make it less susceptible to SMP races

### DIFF
--- a/tests/kernel/lifo/lifo_usage/src/main.c
+++ b/tests/kernel/lifo/lifo_usage/src/main.c
@@ -35,7 +35,7 @@ struct reply_packet {
 struct timeout_order_data {
 	void *link_in_lifo;
 	struct k_lifo *klifo;
-	k_ticks_t timeout;
+	int32_t timeout;
 	int32_t timeout_order;
 	int32_t q_order;
 };
@@ -43,23 +43,23 @@ struct timeout_order_data {
 static struct k_lifo lifo_timeout[2];
 
 struct timeout_order_data timeout_order_data[] = {
-	{0, &lifo_timeout[0], 20, 2, 0},
-	{0, &lifo_timeout[0], 40, 4, 1},
-	{0, &lifo_timeout[0], 0, 0, 2},
-	{0, &lifo_timeout[0], 10, 1, 3},
-	{0, &lifo_timeout[0], 30, 3, 4},
+	{0, &lifo_timeout[0], 200, 2, 0},
+	{0, &lifo_timeout[0], 400, 4, 1},
+	{0, &lifo_timeout[0],   0, 0, 2},
+	{0, &lifo_timeout[0], 100, 1, 3},
+	{0, &lifo_timeout[0], 300, 3, 4},
 };
 
 struct timeout_order_data timeout_order_data_mult_lifo[] = {
-	{0, &lifo_timeout[1], 0, 0, 0},
-	{0, &lifo_timeout[0], 30, 3, 1},
-	{0, &lifo_timeout[0], 50, 5, 2},
-	{0, &lifo_timeout[1], 80, 8, 3},
-	{0, &lifo_timeout[1], 70, 7, 4},
-	{0, &lifo_timeout[0], 10, 1, 5},
-	{0, &lifo_timeout[0], 60, 6, 6},
-	{0, &lifo_timeout[0], 20, 2, 7},
-	{0, &lifo_timeout[1], 40, 4, 8},
+	{0, &lifo_timeout[1],   0, 0, 0},
+	{0, &lifo_timeout[0], 300, 3, 1},
+	{0, &lifo_timeout[0], 500, 5, 2},
+	{0, &lifo_timeout[1], 800, 8, 3},
+	{0, &lifo_timeout[1], 700, 7, 4},
+	{0, &lifo_timeout[0], 100, 1, 5},
+	{0, &lifo_timeout[0], 600, 6, 6},
+	{0, &lifo_timeout[0], 200, 2, 7},
+	{0, &lifo_timeout[1], 400, 4, 8},
 };
 
 #define NUM_SCRATCH_LIFO_PACKETS 20
@@ -110,9 +110,7 @@ static bool is_timeout_in_range(uint32_t start_time, uint32_t timeout)
 	uint32_t stop_time, diff;
 
 	stop_time = k_cycle_get_32();
-	diff = (uint32_t)k_cyc_to_ns_floor64(stop_time -
-					start_time) / NSEC_PER_USEC;
-	diff = diff / USEC_PER_MSEC;
+	diff = k_cyc_to_ms_floor32(stop_time - start_time);
 	return timeout <= diff;
 }
 
@@ -266,7 +264,7 @@ static void test_timeout_empty_lifo(void)
 
 	uint32_t start_time, timeout;
 
-	timeout = 10U;
+	timeout = 100U;
 
 	start_time = k_cycle_get_32();
 


### PR DESCRIPTION
On SMP, and especially using qemu on a busy system, it is possible for
a thread with a later timeout to get ahead of another one with an
earlier timeout. The tight timeout value difference (10ms) makes it
possible albeit difficult to reproduce. The result is something like:

|START - test_timeout_threads_pend_on_lifo
| thread (q order: 2, t/o: 0, lifo 0x4001d350)
|
|    Assertion failed at main.c:140:
|test_multiple_threads_pending: (data->timeout_order not equal to ii)
| *** thread 2 woke up, expected 1

Let's make timeout values 10 times larger to make this unlikely race
even less likely.

While at it... The timeout field in struct timeout_order_data is some ms
value and not a number of ticks, so change the type accordingly.
And leverage k_cyc_to_ms_floor32() to simplify computation in
is_timeout_in_range().

Signed-off-by: Nicolas Pitre <npitre@baylibre.com>
