### PR TITLE
coredump: adjust mem_region find in gdbstub

### DIFF
--- a/scripts/coredump/gdbstubs/gdbstub.py
+++ b/scripts/coredump/gdbstubs/gdbstub.py
@@ -122,7 +122,7 @@ class GdbStub(abc.ABC):
 
         def get_mem_region(addr):
             for r in self.mem_regions:
-                if r['start'] <= addr <= r['end']:
+                if r['start'] <= addr < r['end']:
                     return r
 
             return None


### PR DESCRIPTION
Adjust get_mem_region to not return region when address == end
as there will be nothing to read there. Also, a subsequent region
may have that address as a start address and would be a more appropriate
selection.

Signed-off-by: Mark Holden <mholden@fb.com>