### PR TITLE
soc: arm: microchip: Add SoC MEC150x device ID macros

### DIFF
--- a/drivers/espi/Kconfig
+++ b/drivers/espi/Kconfig
@@ -54,7 +54,7 @@ config ESPI_AUTOMATIC_WARNING_ACKNOWLEDGE
 	depends on ESPI_VWIRE_CHANNEL
 	depends on ESPI_SLAVE
 	help
-	  Enable automatic acknowledge from eSPI slave towards eSPI host
+	  Enable automatic acknowledgent from eSPI slave towards eSPI host
 	  whenever it receives suspend or reset warning.
 	  If this is disabled, it means the app wants to be give the opportunity
 	  to prepare for either HOST suspend or reset.
@@ -65,7 +65,7 @@ config ESPI_AUTOMATIC_BOOT_DONE_ACKNOWLEDGE
 	depends on ESPI_VWIRE_CHANNEL
 	depends on ESPI_SLAVE
 	help
-	  Enable automatic acknowledge of slave basic configuration been
+	  Enable automatic acknowledgment from slave basic configuration been
 	  completed by sending a virtual wire message to the eSPI master.
 	  This depends on SPI boot configuration. It could be either very
 	  early in the flow after the VW channel is configured. Or it could be

--- a/soc/arm/microchip_mec/mec1501/soc.c
+++ b/soc/arm/microchip_mec/mec1501/soc.c
@@ -11,6 +11,9 @@
 #include <arch/cpu.h>
 #include <arch/arm/aarch32/cortex_m/cmsis.h>
 
+/* MEC devices IDs with special PLL handling */
+#define MCHP_GCFG_DID_DEV_ID_MEC150x    0x0020U
+#define MCHP_TRIM_ENABLE_INT_OSCILLATOR 0x06U
 
 /*
  * Make sure PCR sleep enables are clear except for crypto
@@ -79,9 +82,9 @@ static int soc_clk32_init(void)
 	/* Use internal 32KHz +/-2% silicon oscillator
 	 * if required performed OTP value override
 	 */
-	if (MCHP_DEVICE_ID() == 0x0020U) { /* MEC150x ? */
+	if (MCHP_DEVICE_ID() == MCHP_GCFG_DID_DEV_ID_MEC150x) {
 		if (MCHP_REVISION_ID() == MCHP_GCFG_REV_B0) {
-			VBATR_REGS->CKK32_TRIM = 0x06U;
+			VBATR_REGS->CKK32_TRIM = MCHP_TRIM_ENABLE_INT_OSCILLATOR;
 		}
 	}
 


### PR DESCRIPTION
Add SoC MEC150x device ID macros to avoid magic numbers into the code

Correct typo in comment for eSPI driver 