### PR TITLE
lib: os: cbprintf: Fix clang guard for _Generic support

### DIFF
--- a/include/sys/cbprintf.h
+++ b/include/sys/cbprintf.h
@@ -17,9 +17,11 @@
 #endif /* CONFIG_CBPRINTF_LIBC_SUBSTS */
 
 /* Determine if _Generic is supported.
- * In general it's a C11 feature but it was added also in:
+ * In general it's a C11 feature but it is supported in releases after:
  * - GCC 4.9.0 https://gcc.gnu.org/gcc-4.9/changes.html
- * - Clang 3.0 https://releases.llvm.org/3.0/docs/ClangReleaseNotes.html
+ * - Clang 3.8 Introduced in 3.0 (https://releases.llvm.org/3.0/docs/ClangReleaseNotes.html)
+ *   but with bug (http://www.open-std.org/jtc1/sc22/wg14/www/docs/summary.htm#dr_481)
+ *   that was fixed in 3.8.
  *
  * @note Z_C_GENERIC is also set for C++ where functionality is implemented
  * using overloading and templates.
@@ -27,7 +29,7 @@
 #ifndef Z_C_GENERIC
 #if defined(__cplusplus) || (((__STDC_VERSION__ >= 201112L) || \
 	((__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) >= 40900) || \
-	((__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__) >= 30000)))
+	((__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__) >= 30800)))
 #define Z_C_GENERIC 1
 #else
 #define Z_C_GENERIC 0


### PR DESCRIPTION
Clang introduced _Generic support in 3.0 but it was buggy until
3.8. Updated guard to not use _Generic in clang < 3.8.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>