### PR TITLE
ITE: drivers/i2c: disable pre-defined of hardware slave A

### DIFF
--- a/drivers/i2c/i2c_ite_it8xxx2.c
+++ b/drivers/i2c/i2c_ite_it8xxx2.c
@@ -902,6 +902,13 @@ static int i2c_it8xxx2_init(const struct device *dev)
 	uint32_t bitrate_cfg, offset = 0;
 	int error;
 
+	/*
+	 * This register is a pre-define hardware slave A and can
+	 * be accessed through I2C0. It is not currently used, so
+	 * it can be disabled to avoid illegal access.
+	 */
+	IT8XXX2_SMB_SFFCTL &= ~IT8XXX2_SMB_HSAPE;
+
 	/* Initialize mutex and semaphore */
 	k_mutex_init(&data->mutex);
 	k_sem_init(&data->device_sync_sem, 0, K_SEM_MAX_LIMIT);

--- a/soc/riscv/riscv-ite/common/chip_chipregs.h
+++ b/soc/riscv/riscv-ite/common/chip_chipregs.h
@@ -1613,6 +1613,7 @@ enum chip_pll_mode {
 #define IT83XX_SMB_CHSEF		ECREG(IT83XX_SMB_BASE+0x11)
 #define IT83XX_SMB_CHSAB		ECREG(IT83XX_SMB_BASE+0x20)
 #define IT83XX_SMB_CHSCD		ECREG(IT83XX_SMB_BASE+0x21)
+#define IT8XXX2_SMB_SFFCTL		ECREG(IT83XX_SMB_BASE+0x55)
 #define IT83XX_SMB_HOSTA(base)	ECREG(base+0x00)
 #define IT83XX_SMB_HOCTL(base)	ECREG(base+0x01)
 #define IT83XX_SMB_HOCMD(base)	ECREG(base+0x02)
@@ -1653,6 +1654,8 @@ enum chip_pll_mode {
 #define IT83XX_I2C_CMD_ADDH2(base)	ECREG(base+0x52)
 
 /* SMBus/I2C register fields */
+/* 0x55: Slave A FIFO Control */
+#define IT8XXX2_SMB_HSAPE		BIT(1)
 /* 0x07: Time Out Status */
 #define IT8XXX2_I2C_SCL_IN		BIT(2)
 #define IT8XXX2_I2C_SDA_IN		BIT(0)


### PR DESCRIPTION
This register is a pre-define hardware slave A and can be accessed
through I2C0. It is not currently used, so it can be disabled to
avoid illegal access.

Signed-off-by: Tim Lin <tim2.lin@ite.corp-partner.google.com>