### PR TITLE
Renesas R-Car: Add PWM driver

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -358,6 +358,7 @@
 /drivers/pwm/*gecko*                      @sun681
 /drivers/pwm/*it8xxx2*                    @RuibinChang
 /drivers/pwm/*esp32*                      @LucasTambor
+/drivers/pwm/*rcar*                       @pmarzin
 /drivers/regulator/*pmic*                 @danieldegrasse
 /drivers/reset/                           @andrei-edward-popa
 /drivers/sensor/                          @MaureenHelm

--- a/boards/arm/rcar_h3ulcb/doc/rcar_h3ulcb.rst
+++ b/boards/arm/rcar_h3ulcb/doc/rcar_h3ulcb.rst
@@ -62,6 +62,8 @@ Here is the current supported features when running Zephyr Project on the R-Car 
 +-----------+------------------------------+--------------------------------+
 | I2C       | i2c                          | interrupt driven               |
 +-----------+------------------------------+--------------------------------+
+| PWM       | pwm                          | All channels                   |
++-----------+------------------------------+--------------------------------+
 
 It's also currently possible to write on the ram console.
 
@@ -165,6 +167,13 @@ H3ULCB board provides two I2C buses. Unfortunately direct access to these buses 
 I2C is mainly used to manage and power on multiple of onboard chips on the H3ULCB and Kingfisher daughter board.
 
 Embedded I2C devices and I/O expanders are not yet supported. The current I2C support therefore does not make any devices available to the user at this time.
+
+PWM
+---
+
+ULCB boards provide one PWM controller with a maximum of 7 channels [0..6]. H3ULCB does provide the pwm0 from test pin CP8 only.
+
+When plugged on a Kingfisher daughter board, pwm4 channel is available on CN7 LVDS connector.
 
 Programming and Debugging
 *************************

--- a/boards/arm/rcar_h3ulcb/rcar_h3ulcb_cr7-pinctrl.dtsi
+++ b/boards/arm/rcar_h3ulcb/rcar_h3ulcb_cr7-pinctrl.dtsi
@@ -30,4 +30,8 @@
 	scif2_data_a_rx_default: scif2_data_a_rx_default {
 		pin = <PIN_RX2_A FUNC_RX2_A>;
 	};
+
+	pwm0_default: pwm0_default {
+		pin = <PIN_PWM0 FUNC_PWM0>;
+	};
 };

--- a/boards/arm/rcar_h3ulcb/rcar_h3ulcb_cr7.dts
+++ b/boards/arm/rcar_h3ulcb/rcar_h3ulcb_cr7.dts
@@ -52,6 +52,11 @@
 	status = "okay";
 };
 
+&pwm0 {
+	pinctrl-0 = <&pwm0_default>;
+	pinctrl-names = "default";
+};
+
 &can0 {
 	pinctrl-0 = <&can0_data_a_tx_default &can0_data_a_rx_default>;
 	pinctrl-names = "default";

--- a/boards/arm/rcar_h3ulcb/rcar_h3ulcb_cr7.dts
+++ b/boards/arm/rcar_h3ulcb/rcar_h3ulcb_cr7.dts
@@ -37,6 +37,7 @@
 	};
 
 	aliases {
+		pwm-0 = &pwm0;
 		led0 = &user_led;
 		sw0 = &user_button;
 	};

--- a/drivers/clock_control/clock_control_r8a7795_cpg_mssr.c
+++ b/drivers/clock_control/clock_control_r8a7795_cpg_mssr.c
@@ -127,6 +127,9 @@ static int r8a7795_cpg_get_rate(const struct device *dev,
 	case R8A7795_CLK_S3D4:
 		*rate = S3D4_CLK_RATE;
 		break;
+	case R8A7795_CLK_S0D12:
+		*rate = S0D12_CLK_RATE;
+		break;
 	default:
 		ret = -ENOTSUP;
 		break;

--- a/drivers/clock_control/clock_control_renesas_cpg_mssr.h
+++ b/drivers/clock_control/clock_control_renesas_cpg_mssr.h
@@ -38,8 +38,9 @@ static const uint16_t srcr[] = {
 #define CANFDCKCR_PARENT_CLK_RATE 800000000
 #define CANFDCKCR_DIVIDER_MASK    0x1FF
 
-/* SCIF clock */
-#define S3D4_CLK_RATE             66600000
+/* Peripherals Clocks */
+#define S3D4_CLK_RATE             66600000	/* SCIF	*/
+#define S0D12_CLK_RATE            66600000	/* PWM	*/
 #endif /* CONFIG_SOC_SERIES_RCAR_GEN3 */
 
 void rcar_cpg_write(uint32_t base_address, uint32_t reg, uint32_t val);

--- a/drivers/pwm/CMakeLists.txt
+++ b/drivers/pwm/CMakeLists.txt
@@ -25,6 +25,7 @@ zephyr_library_sources_ifdef(CONFIG_PWM_XLNX_AXI_TIMER	pwm_xlnx_axi_timer.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_MCUX_PWT 	pwm_mcux_pwt.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_GECKO		pwm_gecko.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_GD32		pwm_gd32.c)
+zephyr_library_sources_ifdef(CONFIG_PWM_RCAR		pwm_rcar.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_TEST		pwm_test.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_RPI_PICO	pwm_rpi_pico.c)
 

--- a/drivers/pwm/Kconfig
+++ b/drivers/pwm/Kconfig
@@ -71,6 +71,8 @@ source "drivers/pwm/Kconfig.gecko"
 
 source "drivers/pwm/Kconfig.gd32"
 
+source "drivers/pwm/Kconfig.rcar"
+
 source "drivers/pwm/Kconfig.test"
 
 source "drivers/pwm/Kconfig.rpi_pico"

--- a/drivers/pwm/Kconfig.rcar
+++ b/drivers/pwm/Kconfig.rcar
@@ -1,0 +1,12 @@
+# Reneas R-Car PWM configuration options
+
+# Copyright (c) 2022 IoT.bzh
+# SPDX-License-Identifier: Apache-2.0
+
+config PWM_RCAR
+	bool "Renesas R-Car PWM Driver"
+	default y
+	depends on SOC_FAMILY_RCAR
+	depends on DT_HAS_RENESAS_PWM_RCAR_ENABLED
+	help
+	  Enable Renesas R-Car PWM Driver.

--- a/drivers/pwm/pwm_rcar.c
+++ b/drivers/pwm/pwm_rcar.c
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) 2022 IoT.bzh
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT renesas_pwm_rcar
+
+#include <errno.h>
+
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/clock_control/renesas_cpg_mssr.h>
+#include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/pwm.h>
+
+#include <soc.h>
+
+#define LOG_LEVEL CONFIG_PWM_LOG_LEVEL
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(pwm_rcar);
+
+/* PWM Controller capabilities */
+#define RCAR_PWM_MAX_CYCLE   1023U
+#define RCAR_PWM_MAX_DIV     24U
+#define RCAR_PWM_MAX_CHANNEL 6
+
+/* Registers */
+#define RCAR_PWM_REG_SHIFT 0x1000
+#define RCAR_PWM_CR(channel)                                                                       \
+	((uint32_t)((channel * RCAR_PWM_REG_SHIFT)) + 0x00) /* PWM Control Register */
+#define RCAR_PWM_CNT(channel)                                                                      \
+	((uint32_t)((channel * RCAR_PWM_REG_SHIFT)) + 0x04) /* PWM Count Register */
+
+/* PWMCR (PWM Control Register) */
+#define RCAR_PWM_CR_CC_MASK  0x000f0000 /* Clock Control */
+#define RCAR_PWM_CR_CC_SHIFT 16
+#define RCAR_PWM_CR_CCMD     BIT(15) /* Frequency Division Mode */
+#define RCAR_PWM_CR_SYNC     BIT(11)
+#define RCAR_PWM_CR_SS	     BIT(4) /* Single Pulse Output */
+#define RCAR_PWM_CR_EN	     BIT(0) /* Channel Enable */
+
+/* PWM Diviser is on 5 bits (CC combined with CCMD) */
+#define RCAR_PWM_DIVISER_MASK  (RCAR_PWM_CR_CC_MASK | RCAR_PWM_CR_CCMD)
+#define RCAR_PWM_DIVISER_SHIFT 15
+
+/* PWMCNT (PWM Count Register) */
+#define RCAR_PWM_CNT_CYC_MASK  0x03ff0000 /* PWM Cycle */
+#define RCAR_PWM_CNT_CYC_SHIFT 16
+#define RCAR_PWM_CNT_PH_MASK   0x000003ff /* PWM High-Level Period */
+#define RCAR_PWM_CNT_PH_SHIFT  0
+
+struct pwm_rcar_cfg {
+	uint32_t reg_addr;
+	const struct device *clock_dev;
+	struct rcar_cpg_clk core_clk;
+	struct rcar_cpg_clk mod_clk;
+	const struct pinctrl_dev_config *pcfg;
+};
+
+struct pwm_rcar_data {
+	uint32_t clk_rate;
+};
+
+static uint32_t pwm_rcar_read(const struct pwm_rcar_cfg *config, uint32_t offs)
+{
+	return sys_read32(config->reg_addr + offs);
+}
+
+static void pwm_rcar_write(const struct pwm_rcar_cfg *config, uint32_t offs, uint32_t value)
+{
+	sys_write32(value, config->reg_addr + offs);
+}
+
+static void pwm_rcar_write_bit(const struct pwm_rcar_cfg *config, uint32_t offs, uint32_t bits,
+			       bool value)
+{
+	uint32_t reg_val = pwm_rcar_read(config, offs);
+
+	if (value) {
+		reg_val |= bits;
+	} else {
+		reg_val &= ~(bits);
+	}
+
+	pwm_rcar_write(config, offs, reg_val);
+}
+
+static int pwm_rcar_update_clk(const struct pwm_rcar_cfg *config, uint32_t channel,
+			       uint32_t *period_cycles, uint32_t *pulse_cycles)
+{
+	uint32_t reg_val, power, diviser;
+
+	power = pwm_rcar_read(config, RCAR_PWM_CR(channel)) & RCAR_PWM_DIVISER_MASK;
+	power = power >> RCAR_PWM_DIVISER_SHIFT;
+	diviser = 1 << power;
+
+	LOG_DBG("Found old diviser : 2^%d=%d", power, diviser);
+
+	/* Looking for the best possible clock diviser */
+	if (*period_cycles > RCAR_PWM_MAX_CYCLE) {
+		/* Reducing clock speed */
+		while (*period_cycles > RCAR_PWM_MAX_CYCLE) {
+			diviser *= 2;
+			*period_cycles /= 2;
+			*pulse_cycles /= 2;
+			power++;
+			if (power > RCAR_PWM_MAX_DIV) {
+				return -ENOTSUP;
+			}
+		}
+	} else {
+		/* Increasing clock speed */
+		while (*period_cycles < (RCAR_PWM_MAX_CYCLE / 2)) {
+			if (power == 0) {
+				return -ENOTSUP;
+			}
+			diviser /= 2;
+			*period_cycles *= 2;
+			*pulse_cycles *= 2;
+			power--;
+		}
+	}
+	LOG_DBG("Found new diviser : 2^%d=%d\n", power, diviser);
+
+	/* Set new clock Diviser */
+	reg_val = pwm_rcar_read(config, RCAR_PWM_CR(channel));
+	reg_val &= ~RCAR_PWM_DIVISER_MASK;
+	reg_val |= (power << RCAR_PWM_DIVISER_SHIFT);
+	pwm_rcar_write(config, RCAR_PWM_CR(channel), reg_val);
+
+	return 0;
+}
+
+static int pwm_rcar_set_cycles(const struct device *dev, uint32_t channel, uint32_t period_cycles,
+			       uint32_t pulse_cycles, pwm_flags_t flags)
+{
+	const struct pwm_rcar_cfg *config = dev->config;
+	uint32_t reg_val;
+	int ret = 0;
+
+	if (channel > RCAR_PWM_MAX_CHANNEL) {
+		return -ENOTSUP;
+	}
+
+	if (flags != PWM_POLARITY_NORMAL) {
+		return -ENOTSUP;
+	}
+
+	/* Prohibited values */
+	if (period_cycles == 0U || pulse_cycles == 0U || pulse_cycles > period_cycles) {
+		return -EINVAL;
+	}
+
+	LOG_DBG("base_reg=0x%x, pulse_cycles=%d, period_cycles=%d,"
+		" duty_cycle=%d",
+		config->reg_addr, pulse_cycles, period_cycles,
+		(pulse_cycles * 100U / period_cycles));
+
+	/* Disable PWM */
+	pwm_rcar_write_bit(config, RCAR_PWM_CR(channel), RCAR_PWM_CR_EN, false);
+
+	/* Set continuous mode */
+	pwm_rcar_write_bit(config, RCAR_PWM_CR(channel), RCAR_PWM_CR_SS, false);
+
+	/* Enable SYNC mode */
+	pwm_rcar_write_bit(config, RCAR_PWM_CR(channel), RCAR_PWM_CR_SYNC, true);
+
+	/*
+	 * Set clock counter according to the requested period_cycles
+	 * if period_cycles is less than half of the counter, then the
+	 * clock diviser could be updated as the diviser is a modulo 2.
+	 */
+	if (period_cycles > RCAR_PWM_MAX_CYCLE || period_cycles < (RCAR_PWM_MAX_CYCLE / 2)) {
+		LOG_DBG("Adapting frequency diviser...");
+		ret = pwm_rcar_update_clk(config, channel, &period_cycles, &pulse_cycles);
+		if (ret != 0) {
+			return ret;
+		}
+	}
+
+	/* Set total period cycle */
+	reg_val = pwm_rcar_read(config, RCAR_PWM_CNT(channel));
+	reg_val &= ~(RCAR_PWM_CNT_CYC_MASK);
+	reg_val |= (period_cycles << RCAR_PWM_CNT_CYC_SHIFT);
+	pwm_rcar_write(config, RCAR_PWM_CNT(channel), reg_val);
+
+	/* Set high level period cycle */
+	reg_val = pwm_rcar_read(config, RCAR_PWM_CNT(channel));
+	reg_val &= ~(RCAR_PWM_CNT_PH_MASK);
+	reg_val |= (pulse_cycles << RCAR_PWM_CNT_PH_SHIFT);
+	pwm_rcar_write(config, RCAR_PWM_CNT(channel), reg_val);
+
+	/* Enable PWM */
+	pwm_rcar_write_bit(config, RCAR_PWM_CR(channel), RCAR_PWM_CR_EN, true);
+
+	return ret;
+}
+
+static int pwm_rcar_get_cycles_per_sec(const struct device *dev, uint32_t channel, uint64_t *cycles)
+{
+	const struct pwm_rcar_cfg *config = dev->config;
+	struct pwm_rcar_data *data = dev->data;
+	uint32_t diviser;
+
+	if (channel > RCAR_PWM_MAX_CHANNEL) {
+		return -ENOTSUP;
+	}
+
+	diviser = pwm_rcar_read(config, RCAR_PWM_CR(channel)) & RCAR_PWM_DIVISER_MASK;
+	diviser = diviser >> RCAR_PWM_DIVISER_SHIFT;
+	*cycles = data->clk_rate >> diviser;
+
+	LOG_DBG("Actual division: %d and Frequency: %d Hz", diviser, (uint32_t)*cycles);
+
+	return 0;
+}
+
+static int pwm_rcar_init(const struct device *dev)
+{
+	const struct pwm_rcar_cfg *config = dev->config;
+	struct pwm_rcar_data *data = dev->data;
+	int ret;
+
+	/* Configure dt provided device signals when available */
+	ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = clock_control_on(config->clock_dev, (clock_control_subsys_t *)&config->mod_clk);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = clock_control_get_rate(config->clock_dev, (clock_control_subsys_t *)&config->core_clk,
+				     &data->clk_rate);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	return 0;
+}
+
+static const struct pwm_driver_api pwm_rcar_driver_api = {
+	.set_cycles = pwm_rcar_set_cycles,
+	.get_cycles_per_sec = pwm_rcar_get_cycles_per_sec,
+};
+
+/* Device Instantiation */
+#define PWM_DEVICE_RCAR_INIT(n)                                                                    \
+	PINCTRL_DT_INST_DEFINE(n);                                                                 \
+	static const struct pwm_rcar_cfg pwm_rcar_cfg_##n = {                                      \
+		.reg_addr = DT_INST_REG_ADDR(n),                                                   \
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                         \
+		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),                                \
+		.mod_clk.module = DT_INST_CLOCKS_CELL_BY_IDX(n, 0, module),                        \
+		.mod_clk.domain = DT_INST_CLOCKS_CELL_BY_IDX(n, 0, domain),                        \
+		.core_clk.module = DT_INST_CLOCKS_CELL_BY_IDX(n, 1, module),                       \
+		.core_clk.domain = DT_INST_CLOCKS_CELL_BY_IDX(n, 1, domain),                       \
+	};                                                                                         \
+	static struct pwm_rcar_data pwm_rcar_data_##n;                                             \
+	DEVICE_DT_INST_DEFINE(n, pwm_rcar_init, NULL, &pwm_rcar_data_##n, &pwm_rcar_cfg_##n,       \
+			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,                     \
+			      &pwm_rcar_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(PWM_DEVICE_RCAR_INIT)

--- a/dts/arm/renesas/gen3/r8a77951.dtsi
+++ b/dts/arm/renesas/gen3/r8a77951.dtsi
@@ -20,6 +20,11 @@
 			<&cpg CPG_CORE R8A7795_CLK_CANFD>;
 		};
 
+		pwm0: pwm@e6e30000 {
+			clocks = <&cpg CPG_MOD 523>,
+			<&cpg CPG_CORE R8A7795_CLK_S0D12>;
+		};
+
 		scif1: serial@e6e68000 {
 			clocks = <&cpg CPG_MOD 206>,
 			<&cpg CPG_CORE R8A7795_CLK_S3D4>;

--- a/dts/arm/renesas/gen3/rcar_gen3_cr7.dtsi
+++ b/dts/arm/renesas/gen3/rcar_gen3_cr7.dtsi
@@ -10,6 +10,7 @@
 #include <zephyr/dt-bindings/clock/renesas_cpg_mssr.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 
 / {
 	cpus {
@@ -65,6 +66,13 @@
 		pfc: pin-controller@e6060000 {
 			compatible = "renesas,rcar-pfc";
 			reg = <0xe6060000 0x50c>;
+		};
+
+		pwm0: pwm@e6e30000 {
+			compatible = "renesas,pwm-rcar";
+			reg = <0xe6e30000 0x8>;
+			#pwm-cells = <3>;
+			status = "disabled";
 		};
 
 		cmt0: timer@e60f0500 {

--- a/dts/bindings/pwm/renesas,pwm-rcar.yaml
+++ b/dts/bindings/pwm/renesas,pwm-rcar.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2022, IoT.bzh
+# SPDX-License-Identifier: Apache-2.0
+
+description: Renesas R-Car PWM controller
+
+compatible: "renesas,pwm-rcar"
+
+include: [pwm-controller.yaml, pinctrl-device.yaml, base.yaml]
+
+properties:
+    "#pwm-cells":
+      const: 3
+
+pwm-cells:
+  - channel
+  # period in terms of nanoseconds
+  - period
+  - flags

--- a/samples/basic/blinky_pwm/boards/rcar_h3ulcb_cr7.overlay
+++ b/samples/basic/blinky_pwm/boards/rcar_h3ulcb_cr7.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022 IoT.bzh
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+    pwmleds {
+        compatible = "pwm-leds";
+        pwm_led_0: pwm_led_0 {
+            pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+            label = "PWM LED 0";
+        };
+    };
+
+    aliases {
+        pwm-led0 = &pwm_led_0;
+        pwm-0 = &pwm0;
+    };
+
+};
+
+&pwm0 {
+    status = "okay";
+};

--- a/tests/drivers/pwm/pwm_api/boards/rcar_h3ulcb_cr7.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/rcar_h3ulcb_cr7.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2022 IoT.bzh
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pwm0 {
+    status = "okay";
+};


### PR DESCRIPTION
This PR adds the PWM driver to support the PWM controller of R-Car SoC family.

The dts has been kept as much close as Linux as possible.
Unlike the dts, the driver is slightly different as the Zephyr pwm api differs.
Clock divider is updated only when possible.

Actually, the api driver test for the pwm (tests/drivers/pwm/pwm_api/src/test_pwm.c) does not work on R-Car as the test is using prohibited values (0% of duty cycle and cycle value > 1023 are not supported by the R-Car PWM controller).
Nevertheless, it has been tested on H3ULCB with the blinky pwm sample with success.

[UPDATE]
For the pwm_api test, a proposal is to adapt the test in order to not test pwm API with prohibited values. See the related PR here : https://github.com/zephyrproject-rtos/zephyr/pull/48834