### PR TITLE
tests: modbus: correct test fixture description

### DIFF
--- a/tests/subsys/modbus/src/test_modbus.h
+++ b/tests/subsys/modbus/src/test_modbus.h
@@ -21,8 +21,8 @@
 /*
  * Integration platform for this test is FRDM-K64F.
  * The board must be prepared accordingly:
- * UART1(PTB16)-RX <-> UART2(PTD3)-TX pins and
- * UART1(PTB17)-TX <-> UART2(PTD2)-RX pins have to be connected.
+ * UART3(PTC16)-RX <-> UART2(PTD3)-TX pins and
+ * UART3(PTC17)-TX <-> UART2(PTD2)-RX pins have to be connected.
  */
 
 uint8_t test_get_client_iface(void);

--- a/tests/subsys/modbus/testcase.yaml
+++ b/tests/subsys/modbus/testcase.yaml
@@ -4,8 +4,8 @@ tests:
     platform_allow: frdm_k64f
     harness_config:
       # MODBUS test fixture for FRDM-K64F:
-      # UART1(PTB16)-RX <-> UART2(PTD3)-TX
-      # UART1(PTB17)-TX <-> UART2(PTD2)-RX
+      # UART3(PTC16)-RX <-> UART2(PTD3)-TX
+      # UART3(PTC17)-TX <-> UART2(PTD2)-RX
       fixture: uart_loopback
   subsys.modbus.rtu.build_only:
     build_only: true


### PR DESCRIPTION
Correct test fixture description for FRDM-K64F board.
