### PR TITLE
Cmake cleanups

### DIFF
--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -320,7 +320,7 @@ if (CONFIG_BUILD_WITH_TFM)
     ${TFM_GENERATED_INCLUDES}
     )
 
-  target_include_directories(tfm_api PRIVATE
+  target_include_directories(tfm_api PUBLIC
     ${TFM_BINARY_DIR}/install/interface/include
     )
 

--- a/samples/tfm_integration/psa_crypto/CMakeLists.txt
+++ b/samples/tfm_integration/psa_crypto/CMakeLists.txt
@@ -16,9 +16,7 @@ target_sources(app PRIVATE
   src/util_sformat.c
   )
 
-target_include_directories(app PRIVATE
-  $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/install/interface/include
-)
+zephyr_library_link_libraries(tfm_api)
 
 # In TF-M, default value of CRYPTO_ENGINE_BUF_SIZE is 0x2080. It causes
 # insufficient memory failure while verifying signature. Increase it to 0x2400.

--- a/samples/tfm_integration/psa_crypto/CMakeLists.txt
+++ b/samples/tfm_integration/psa_crypto/CMakeLists.txt
@@ -6,14 +6,15 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(tfm_psa_crypto)
 
-# Source files in this sample
-target_sources(app PRIVATE src/main.c)
-target_sources(app PRIVATE src/psa_attestation.c)
-target_sources(app PRIVATE src/psa_crypto.c)
-target_sources(app PRIVATE src/shell.c)
-target_sources(app PRIVATE src/util_app_cfg.c)
-target_sources(app PRIVATE src/util_app_log.c)
-target_sources(app PRIVATE src/util_sformat.c)
+target_sources(app PRIVATE
+  src/main.c
+  src/psa_attestation.c
+  src/psa_crypto.c
+  src/shell.c
+  src/util_app_cfg.c
+  src/util_app_log.c
+  src/util_sformat.c
+  )
 
 target_include_directories(app PRIVATE
   $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/install/interface/include
@@ -26,4 +27,4 @@ set_property(TARGET zephyr_property_target
              -DCRYPTO_ENGINE_BUF_SIZE=0x2400
 )
 
-zephyr_include_directories(${APPLICATION_SOURCE_DIR}/src/tls_config)
+zephyr_include_directories(src/tls_config)

--- a/samples/tfm_integration/psa_protected_storage/CMakeLists.txt
+++ b/samples/tfm_integration/psa_protected_storage/CMakeLists.txt
@@ -12,6 +12,4 @@ project(protected_storage)
 
 target_sources(app PRIVATE src/main.c)
 
-target_include_directories(app PRIVATE
-  $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/install/interface/include
-)
+zephyr_library_link_libraries(tfm_api)

--- a/samples/tfm_integration/tfm_ipc/CMakeLists.txt
+++ b/samples/tfm_integration/tfm_ipc/CMakeLists.txt
@@ -8,6 +8,4 @@ project(tfm_ipc)
 
 target_sources(app PRIVATE src/main.c)
 
-target_include_directories(app PRIVATE
-  $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/install/interface/include
-)
+zephyr_library_link_libraries(tfm_api)

--- a/samples/tfm_integration/tfm_psa_test/CMakeLists.txt
+++ b/samples/tfm_integration/tfm_psa_test/CMakeLists.txt
@@ -12,6 +12,4 @@ project(tfm_psa_storage_test)
 
 target_sources(app PRIVATE src/main.c)
 
-target_include_directories(app PRIVATE
-  $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/install/interface/include
-)
+zephyr_library_link_libraries(tfm_api)

--- a/samples/tfm_integration/tfm_secure_partition/CMakeLists.txt
+++ b/samples/tfm_integration/tfm_secure_partition/CMakeLists.txt
@@ -8,7 +8,9 @@ cmake_minimum_required(VERSION 3.20)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
+# TFM_BINARY_DIR is used by configure_file
 get_target_property(TFM_BINARY_DIR tfm TFM_BINARY_DIR)
+
 configure_file(
   ${CMAKE_CURRENT_LIST_DIR}/dummy_partition/tfm_manifest_list.yaml.in
   ${CMAKE_CURRENT_BINARY_DIR}/dummy_partition/tfm_manifest_list.yaml
@@ -22,7 +24,7 @@ set_property(TARGET zephyr_property_target
 
 project(tfm_secure_partition)
 
-target_sources(app PRIVATE
+zephyr_library_sources(
   src/main.c
   src/dummy_partition.c
 )
@@ -31,6 +33,6 @@ target_include_directories(app PRIVATE
   $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/install/interface/include
 )
 
-target_compile_definitions(app
-    PRIVATE TFM_PARTITION_DUMMY_PARTITION
+zephyr_library_compile_definitions(
+  TFM_PARTITION_DUMMY_PARTITION
 )

--- a/samples/tfm_integration/tfm_secure_partition/CMakeLists.txt
+++ b/samples/tfm_integration/tfm_secure_partition/CMakeLists.txt
@@ -29,9 +29,7 @@ zephyr_library_sources(
   src/dummy_partition.c
 )
 
-target_include_directories(app PRIVATE
-  $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/install/interface/include
-)
+zephyr_library_link_libraries(tfm_api)
 
 zephyr_library_compile_definitions(
   TFM_PARTITION_DUMMY_PARTITION

--- a/soc/arm/nordic_nrf/nrf53/CMakeLists.txt
+++ b/soc/arm/nordic_nrf/nrf53/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_sources(
+zephyr_library_sources(
   soc.c
   )
 

--- a/soc/arm/nordic_nrf/nrf53/CMakeLists.txt
+++ b/soc/arm/nordic_nrf/nrf53/CMakeLists.txt
@@ -13,7 +13,5 @@ zephyr_library_sources_ifdef(CONFIG_NRF53_SYNC_RTC
   )
 
 if (CONFIG_BUILD_WITH_TFM)
-  zephyr_library_include_directories(
-    $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/install/interface/include
-  )
+  zephyr_library_link_libraries(tfm_api)
 endif()

--- a/tests/arch/arm/arm_thread_swap_tz/CMakeLists.txt
+++ b/tests/arch/arm/arm_thread_swap_tz/CMakeLists.txt
@@ -13,7 +13,5 @@ FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
 
 if (CONFIG_BUILD_WITH_TFM)
-  target_include_directories(app PRIVATE
-    $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/install/interface/include
-  )
+  zephyr_library_link_libraries(tfm_api)
 endif()


### PR DESCRIPTION
- Misc. CMake refactoring to follow best practices.
- Put soc.c in the same library as power.c instead of the catch-all
library. I can't see any reason they should be in different libraries
and inspecting the git history it did not seem to be done for any
particularly good reason.
- To avoid hardcoding the include path install/interface/include which
may change, we add this path to the public API of the zephyr library
tfm_api and link with it instead.