### PR TITLE
posix: Add support for setting ethernet MAC address

### DIFF
--- a/drivers/ethernet/eth_native_posix.c
+++ b/drivers/ethernet/eth_native_posix.c
@@ -559,6 +559,12 @@ static int set_config(const struct device *dev,
 
 		ret = eth_promisc_mode(context->if_name,
 				       context->promisc_mode);
+	} else if (type == ETHERNET_CONFIG_TYPE_MAC_ADDRESS) {
+		struct eth_context *context = dev->data;
+
+		memcpy(context->mac_addr, config->mac_address.addr,
+		       sizeof(context->mac_addr));
+		ret = 0;
 	}
 
 	return ret;


### PR DESCRIPTION
If CONFIG_ETH_NATIVE_POSIX_RANDOM_MAC=n and
CONFIG_ETH_NATIVE_POSIX_MAC_ADDR="", the MAC address can be set with a
net_mgmt call before the driver is initialized.

Signed-off-by: Björn Stenberg <bjorn@haxx.se>