### PR TITLE
drivers: rcar: drop DEV_DATA/DEV_CFG usage

### DIFF
--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -205,11 +205,6 @@ struct can_rcar_data {
 	enum can_state state;
 };
 
-#define DEV_CAN_CFG(dev) \
-	((const struct can_rcar_cfg *)(dev)->config)
-
-#define DEV_CAN_DATA(dev) ((struct can_rcar_data *const)(dev)->data)
-
 static inline uint16_t can_rcar_read16(const struct can_rcar_cfg *config,
 				       uint32_t offs)
 {
@@ -224,7 +219,7 @@ static inline void can_rcar_write16(const struct can_rcar_cfg *config,
 
 static void can_rcar_tx_done(const struct device *dev)
 {
-	struct can_rcar_data *data = DEV_CAN_DATA(dev);
+	struct can_rcar_data *data = dev->data;
 	struct can_rcar_tx_cb *tx_cb;
 
 	tx_cb =	&data->tx_cb[data->tx_tail];
@@ -251,8 +246,8 @@ static void can_rcar_get_error_count(const struct can_rcar_cfg *config,
 
 static void can_rcar_state_change(const struct device *dev, uint32_t newstate)
 {
-	const struct can_rcar_cfg *config = DEV_CAN_CFG(dev);
-	struct can_rcar_data *data = DEV_CAN_DATA(dev);
+	const struct can_rcar_cfg *config = dev->config;
+	struct can_rcar_data *data = dev->data;
 	const can_state_change_callback_t cb = data->state_change_cb;
 	void *state_change_cb_data = data->state_change_cb_data;
 	struct can_bus_err_cnt err_cnt;
@@ -274,7 +269,7 @@ static void can_rcar_state_change(const struct device *dev, uint32_t newstate)
 
 static void can_rcar_error(const struct device *dev)
 {
-	const struct can_rcar_cfg *config = DEV_CAN_CFG(dev);
+	const struct can_rcar_cfg *config = dev->config;
 	uint8_t eifr, ecsr;
 
 	eifr = sys_read8(config->reg_addr + RCAR_CAN_EIFR);
@@ -394,8 +389,8 @@ static void can_rcar_rx_filter_isr(struct can_rcar_data *data,
 
 static void can_rcar_rx_isr(const struct device *dev)
 {
-	struct can_rcar_data *data = DEV_CAN_DATA(dev);
-	const struct can_rcar_cfg *config = DEV_CAN_CFG(dev);
+	const struct can_rcar_cfg *config = dev->config;
+	struct can_rcar_data *data = dev->data;
 	struct zcan_frame frame;
 	uint32_t val;
 	int i;
@@ -445,8 +440,8 @@ static void can_rcar_rx_isr(const struct device *dev)
 
 static void can_rcar_isr(const struct device *dev)
 {
-	const struct can_rcar_cfg *config = DEV_CAN_CFG(dev);
-	struct can_rcar_data *data = DEV_CAN_DATA(dev);
+	const struct can_rcar_cfg *config = dev->config;
+	struct can_rcar_data *data = dev->data;
 	uint8_t isr, unsent;
 
 	isr = sys_read8(config->reg_addr + RCAR_CAN_ISR);
@@ -570,8 +565,8 @@ static int can_rcar_enter_operation_mode(const struct can_rcar_cfg *config)
 
 int can_rcar_set_mode(const struct device *dev, enum can_mode mode)
 {
-	const struct can_rcar_cfg *config = DEV_CAN_CFG(dev);
-	struct can_rcar_data *data = DEV_CAN_DATA(dev);
+	const struct can_rcar_cfg *config = dev->config;
+	struct can_rcar_data *data = dev->data;
 	uint8_t tcr = 0;
 	int ret = 0;
 
@@ -637,8 +632,8 @@ int can_rcar_set_timing(const struct device *dev,
 			const struct can_timing *timing,
 			const struct can_timing *timing_data)
 {
-	const struct can_rcar_cfg *config = DEV_CAN_CFG(dev);
-	struct can_rcar_data *data = DEV_CAN_DATA(dev);
+	const struct can_rcar_cfg *config = dev->config;
+	struct can_rcar_data *data = dev->data;
 	int ret = 0;
 
 	ARG_UNUSED(timing_data);
@@ -665,7 +660,7 @@ static void can_rcar_set_state_change_callback(const struct device *dev,
 					       can_state_change_callback_t cb,
 					       void *user_data)
 {
-	struct can_rcar_data *data = DEV_CAN_DATA(dev);
+	struct can_rcar_data *data = dev->data;
 
 	data->state_change_cb = cb;
 	data->state_change_cb_data = user_data;
@@ -674,8 +669,8 @@ static void can_rcar_set_state_change_callback(const struct device *dev,
 static int can_rcar_get_state(const struct device *dev, enum can_state *state,
 			      struct can_bus_err_cnt *err_cnt)
 {
-	const struct can_rcar_cfg *config = DEV_CAN_CFG(dev);
-	struct can_rcar_data *data = DEV_CAN_DATA(dev);
+	const struct can_rcar_cfg *config = dev->config;
+	struct can_rcar_data *data = dev->data;
 
 	if (state != NULL) {
 		*state = data->state;
@@ -691,8 +686,8 @@ static int can_rcar_get_state(const struct device *dev, enum can_state *state,
 #ifndef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY
 int can_rcar_recover(const struct device *dev, k_timeout_t timeout)
 {
-	const struct can_rcar_cfg *config = DEV_CAN_CFG(dev);
-	struct can_rcar_data *data = DEV_CAN_DATA(dev);
+	const struct can_rcar_cfg *config = dev->config;
+	struct can_rcar_data *data = dev->data;
 	int64_t start_time;
 	int ret;
 
@@ -728,8 +723,8 @@ int can_rcar_send(const struct device *dev, const struct zcan_frame *frame,
 		  k_timeout_t timeout, can_tx_callback_t callback,
 		  void *user_data)
 {
-	const struct can_rcar_cfg *config = DEV_CAN_CFG(dev);
-	struct can_rcar_data *data = DEV_CAN_DATA(dev);
+	const struct can_rcar_cfg *config = dev->config;
+	struct can_rcar_data *data = dev->data;
 	struct can_rcar_tx_cb *tx_cb;
 	uint32_t identifier;
 	int i;
@@ -809,7 +804,7 @@ static inline int can_rcar_add_rx_filter_unlocked(const struct device *dev,
 						  void *cb_arg,
 						  const struct zcan_filter *filter)
 {
-	struct can_rcar_data *data = DEV_CAN_DATA(dev);
+	struct can_rcar_data *data = dev->data;
 	int i;
 
 	for (i = 0; i < CONFIG_CAN_RCAR_MAX_FILTER; i++) {
@@ -828,7 +823,7 @@ static inline int can_rcar_add_rx_filter_unlocked(const struct device *dev,
 int can_rcar_add_rx_filter(const struct device *dev, can_rx_callback_t cb,
 			   void *cb_arg, const struct zcan_filter *filter)
 {
-	struct can_rcar_data *data = DEV_CAN_DATA(dev);
+	struct can_rcar_data *data = dev->data;
 	int filter_id;
 
 	k_mutex_lock(&data->rx_mutex, K_FOREVER);
@@ -839,7 +834,7 @@ int can_rcar_add_rx_filter(const struct device *dev, can_rx_callback_t cb,
 
 void can_rcar_remove_rx_filter(const struct device *dev, int filter_id)
 {
-	struct can_rcar_data *data = DEV_CAN_DATA(dev);
+	struct can_rcar_data *data = dev->data;
 
 	if (filter_id >= CONFIG_CAN_RCAR_MAX_FILTER) {
 		return;
@@ -853,8 +848,8 @@ void can_rcar_remove_rx_filter(const struct device *dev, int filter_id)
 
 static int can_rcar_init(const struct device *dev)
 {
-	const struct can_rcar_cfg *config = DEV_CAN_CFG(dev);
-	struct can_rcar_data *data = DEV_CAN_DATA(dev);
+	const struct can_rcar_cfg *config = dev->config;
+	struct can_rcar_data *data = dev->data;
 	struct can_timing timing;
 	int ret;
 	uint16_t ctlr;
@@ -994,7 +989,7 @@ static int can_rcar_init(const struct device *dev)
 
 static int can_rcar_get_core_clock(const struct device *dev, uint32_t *rate)
 {
-	const struct can_rcar_cfg *config = DEV_CAN_CFG(dev);
+	const struct can_rcar_cfg *config = dev->config;
 
 	*rate = config->bus_clk.rate;
 	return 0;

--- a/drivers/gpio/gpio_rcar.c
+++ b/drivers/gpio/gpio_rcar.c
@@ -47,12 +47,6 @@ struct gpio_rcar_data {
 #define OUTDTSEL 0x40   /* Output Data Select Register */
 #define BOTHEDGE 0x4c   /* One Edge/Both Edge Select Register */
 
-/* Helper macros for GPIO */
-#define DEV_GPIO_CFG(dev) \
-	((const struct gpio_rcar_cfg *)(dev)->config)
-#define DEV_GPIO_DATA(dev) \
-	((struct gpio_rcar_data *)(dev)->data)
-
 static inline uint32_t gpio_rcar_read(const struct gpio_rcar_cfg *config,
 				      uint32_t offs)
 {
@@ -82,8 +76,8 @@ static void gpio_rcar_modify_bit(const struct gpio_rcar_cfg *config,
 static void gpio_rcar_port_isr(void *arg)
 {
 	const struct device *dev = (const struct device *)arg;
-	const struct gpio_rcar_cfg *config = DEV_GPIO_CFG(dev);
-	struct gpio_rcar_data *data = DEV_GPIO_DATA(dev);
+	const struct gpio_rcar_cfg *config = dev->config;
+	struct gpio_rcar_data *data = dev->data;
 	uint32_t pending, fsb, mask;
 
 	pending = gpio_rcar_read(config, INTDT);
@@ -125,7 +119,7 @@ static void gpio_rcar_config_general_input_output_mode(
 static int gpio_rcar_configure(const struct device *dev,
 			       gpio_pin_t pin, gpio_flags_t flags)
 {
-	const struct gpio_rcar_cfg *config = DEV_GPIO_CFG(dev);
+	const struct gpio_rcar_cfg *config = dev->config;
 
 	if ((flags & GPIO_OUTPUT) && (flags & GPIO_INPUT)) {
 		/* Pin cannot be configured as input and output */
@@ -152,7 +146,7 @@ static int gpio_rcar_configure(const struct device *dev,
 static int gpio_rcar_port_get_raw(const struct device *dev,
 				  gpio_port_value_t *value)
 {
-	const struct gpio_rcar_cfg *config = DEV_GPIO_CFG(dev);
+	const struct gpio_rcar_cfg *config = dev->config;
 
 	*value = gpio_rcar_read(config, INDT);
 	return 0;
@@ -162,7 +156,7 @@ static int gpio_rcar_port_set_masked_raw(const struct device *dev,
 					 gpio_port_pins_t mask,
 					 gpio_port_value_t value)
 {
-	const struct gpio_rcar_cfg *config = DEV_GPIO_CFG(dev);
+	const struct gpio_rcar_cfg *config = dev->config;
 	uint32_t port_val;
 
 	port_val = gpio_rcar_read(config, OUTDT);
@@ -175,7 +169,7 @@ static int gpio_rcar_port_set_masked_raw(const struct device *dev,
 static int gpio_rcar_port_set_bits_raw(const struct device *dev,
 				       gpio_port_pins_t pins)
 {
-	const struct gpio_rcar_cfg *config = DEV_GPIO_CFG(dev);
+	const struct gpio_rcar_cfg *config = dev->config;
 	uint32_t port_val;
 
 	port_val = gpio_rcar_read(config, OUTDT);
@@ -188,12 +182,12 @@ static int gpio_rcar_port_set_bits_raw(const struct device *dev,
 static int gpio_rcar_port_clear_bits_raw(const struct device *dev,
 					 gpio_port_pins_t pins)
 {
-	const struct gpio_rcar_cfg *gpio_config = DEV_GPIO_CFG(dev);
+	const struct gpio_rcar_cfg *config = dev->config;
 	uint32_t port_val;
 
-	port_val = gpio_rcar_read(gpio_config, OUTDT);
+	port_val = gpio_rcar_read(config, OUTDT);
 	port_val &= ~pins;
-	gpio_rcar_write(gpio_config, OUTDT, port_val);
+	gpio_rcar_write(config, OUTDT, port_val);
 
 	return 0;
 }
@@ -201,12 +195,12 @@ static int gpio_rcar_port_clear_bits_raw(const struct device *dev,
 static int gpio_rcar_port_toggle_bits(const struct device *dev,
 				      gpio_port_pins_t pins)
 {
-	const struct gpio_rcar_cfg *gpio_config = DEV_GPIO_CFG(dev);
+	const struct gpio_rcar_cfg *config = dev->config;
 	uint32_t port_val;
 
-	port_val = gpio_rcar_read(gpio_config, OUTDT);
+	port_val = gpio_rcar_read(config, OUTDT);
 	port_val ^= pins;
-	gpio_rcar_write(gpio_config, OUTDT, port_val);
+	gpio_rcar_write(config, OUTDT, port_val);
 
 	return 0;
 }
@@ -216,42 +210,42 @@ static int gpio_rcar_pin_interrupt_configure(const struct device *dev,
 					     enum gpio_int_mode mode,
 					     enum gpio_int_trig trig)
 {
-	const struct gpio_rcar_cfg *gpio_config = DEV_GPIO_CFG(dev);
+	const struct gpio_rcar_cfg *config = dev->config;
 
 	if (mode == GPIO_INT_MODE_DISABLED) {
 		return -ENOTSUP;
 	}
 
 	/* Configure positive or negative logic in POSNEG */
-	gpio_rcar_modify_bit(gpio_config, POSNEG, pin,
+	gpio_rcar_modify_bit(config, POSNEG, pin,
 			     (trig == GPIO_INT_TRIG_LOW));
 
 	/* Configure edge or level trigger in EDGLEVEL */
 	if (mode == GPIO_INT_MODE_EDGE) {
-		gpio_rcar_modify_bit(gpio_config, EDGLEVEL, pin, true);
+		gpio_rcar_modify_bit(config, EDGLEVEL, pin, true);
 	} else {
-		gpio_rcar_modify_bit(gpio_config, EDGLEVEL, pin, false);
+		gpio_rcar_modify_bit(config, EDGLEVEL, pin, false);
 	}
 
 	if (trig == GPIO_INT_TRIG_BOTH) {
-		gpio_rcar_modify_bit(gpio_config, BOTHEDGE, pin, true);
+		gpio_rcar_modify_bit(config, BOTHEDGE, pin, true);
 	}
 
-	gpio_rcar_modify_bit(gpio_config, IOINTSEL, pin, true);
+	gpio_rcar_modify_bit(config, IOINTSEL, pin, true);
 
 	if (mode == GPIO_INT_MODE_EDGE) {
 		/* Write INTCLR in case of edge trigger */
-		gpio_rcar_write(gpio_config, INTCLR, BIT(pin));
+		gpio_rcar_write(config, INTCLR, BIT(pin));
 	}
 
-	gpio_rcar_write(gpio_config, MSKCLR, BIT(pin));
+	gpio_rcar_write(config, MSKCLR, BIT(pin));
 
 	return 0;
 }
 
 static int gpio_rcar_init(const struct device *dev)
 {
-	const struct gpio_rcar_cfg *config = DEV_GPIO_CFG(dev);
+	const struct gpio_rcar_cfg *config = dev->config;
 	int ret;
 
 	ret = clock_control_on(config->clock_dev,
@@ -269,7 +263,7 @@ static int gpio_rcar_manage_callback(const struct device *dev,
 				     struct gpio_callback *callback,
 				     bool set)
 {
-	struct gpio_rcar_data *data = DEV_GPIO_DATA(dev);
+	struct gpio_rcar_data *data = dev->data;
 
 	return gpio_manage_callback(&data->cb, callback, set);
 }

--- a/drivers/i2c/i2c_rcar.c
+++ b/drivers/i2c/i2c_rcar.c
@@ -75,12 +75,6 @@ struct i2c_rcar_data {
 
 #define MAX_WAIT_US 100
 
-/* Helper macros for I2C */
-#define DEV_I2C_CFG(dev) \
-	((const struct i2c_rcar_cfg *)(dev)->config)
-#define DEV_I2C_DATA(dev) \
-	((struct i2c_rcar_data *)(dev)->data)
-
 static uint32_t i2c_rcar_read(const struct i2c_rcar_cfg *config,
 			      uint32_t offs)
 {
@@ -95,8 +89,8 @@ static void i2c_rcar_write(const struct i2c_rcar_cfg *config,
 
 static void i2c_rcar_isr(const struct device *dev)
 {
-	const struct i2c_rcar_cfg *config = DEV_I2C_CFG(dev);
-	struct i2c_rcar_data *data = DEV_I2C_DATA(dev);
+	const struct i2c_rcar_cfg *config = dev->config;
+	struct i2c_rcar_data *data = dev->data;
 
 	if (((i2c_rcar_read(config, RCAR_I2C_ICMSR)) & data->status_mask) ==
 	    data->status_mask) {
@@ -107,8 +101,8 @@ static void i2c_rcar_isr(const struct device *dev)
 
 static int i2c_rcar_wait_for_state(const struct device *dev, uint8_t mask)
 {
-	const struct i2c_rcar_cfg *config = DEV_I2C_CFG(dev);
-	struct i2c_rcar_data *data = DEV_I2C_DATA(dev);
+	const struct i2c_rcar_cfg *config = dev->config;
+	struct i2c_rcar_data *data = dev->data;
 
 	data->status_mask = mask;
 
@@ -124,7 +118,7 @@ static int i2c_rcar_wait_for_state(const struct device *dev, uint8_t mask)
 
 static int i2c_rcar_finish(const struct device *dev)
 {
-	const struct i2c_rcar_cfg *config = DEV_I2C_CFG(dev);
+	const struct i2c_rcar_cfg *config = dev->config;
 	int ret;
 
 	/* Enable STOP generation */
@@ -144,7 +138,7 @@ static int i2c_rcar_finish(const struct device *dev)
 static int i2c_rcar_set_addr(const struct device *dev,
 			     uint8_t chip, uint8_t read)
 {
-	const struct i2c_rcar_cfg *config = DEV_I2C_CFG(dev);
+	const struct i2c_rcar_cfg *config = dev->config;
 
 	/* Set slave address & transfer mode */
 	i2c_rcar_write(config, RCAR_I2C_ICMAR, (chip << 1) | read);
@@ -163,7 +157,7 @@ static int i2c_rcar_set_addr(const struct device *dev,
 
 static int i2c_rcar_transfer_msg(const struct device *dev, struct i2c_msg *msg)
 {
-	const struct i2c_rcar_cfg *config = DEV_I2C_CFG(dev);
+	const struct i2c_rcar_cfg *config = dev->config;
 	uint32_t i, reg;
 	int ret = 0;
 
@@ -217,7 +211,7 @@ static int i2c_rcar_transfer(const struct device *dev,
 			     struct i2c_msg *msgs, uint8_t num_msgs,
 			     uint16_t addr)
 {
-	const struct i2c_rcar_cfg *config = DEV_I2C_CFG(dev);
+	const struct i2c_rcar_cfg *config = dev->config;
 	uint16_t timeout = 0;
 	int ret;
 
@@ -272,7 +266,7 @@ static int i2c_rcar_transfer(const struct device *dev,
 
 static int i2c_rcar_configure(const struct device *dev, uint32_t dev_config)
 {
-	const struct i2c_rcar_cfg *config = DEV_I2C_CFG(dev);
+	const struct i2c_rcar_cfg *config = dev->config;
 	uint8_t cdf, scgd;
 
 	/* We only support Master mode */
@@ -320,8 +314,8 @@ static int i2c_rcar_configure(const struct device *dev, uint32_t dev_config)
 
 static int i2c_rcar_init(const struct device *dev)
 {
-	const struct i2c_rcar_cfg *config = DEV_I2C_CFG(dev);
-	struct i2c_rcar_data *data = DEV_I2C_DATA(dev);
+	const struct i2c_rcar_cfg *config = dev->config;
+	struct i2c_rcar_data *data = dev->data;
 	uint32_t bitrate_cfg;
 	int ret;
 

--- a/drivers/serial/uart_rcar.c
+++ b/drivers/serial/uart_rcar.c
@@ -102,12 +102,6 @@ struct uart_rcar_data {
 #define SCLSR_TO        BIT(2)  /* Timeout */
 #define SCLSR_ORER      BIT(0)  /* Overrun Error */
 
-/* Helper macros for UART */
-#define DEV_UART_CFG(dev) \
-	((const struct uart_rcar_cfg *)(dev)->config)
-#define DEV_UART_DATA(dev) \
-	((struct uart_rcar_data *)(dev)->data)
-
 static void uart_rcar_write_8(const struct uart_rcar_cfg *config,
 			      uint32_t offs, uint8_t value)
 {
@@ -129,8 +123,8 @@ static void uart_rcar_write_16(const struct uart_rcar_cfg *config,
 static void uart_rcar_set_baudrate(const struct device *dev,
 				   uint32_t baud_rate)
 {
-	const struct uart_rcar_cfg *config = DEV_UART_CFG(dev);
-	struct uart_rcar_data *data = DEV_UART_DATA(dev);
+	const struct uart_rcar_cfg *config = dev->config;
+	struct uart_rcar_data *data = dev->data;
 	uint8_t reg_val;
 
 	reg_val = ((data->clk_rate + 16 * baud_rate) / (32 * baud_rate) - 1);
@@ -139,8 +133,8 @@ static void uart_rcar_set_baudrate(const struct device *dev,
 
 static int uart_rcar_poll_in(const struct device *dev, unsigned char *p_char)
 {
-	const struct uart_rcar_cfg *config = DEV_UART_CFG(dev);
-	struct uart_rcar_data *data = DEV_UART_DATA(dev);
+	const struct uart_rcar_cfg *config = dev->config;
+	struct uart_rcar_data *data = dev->data;
 	uint16_t reg_val;
 	int ret = 0;
 
@@ -166,8 +160,8 @@ unlock:
 
 static void uart_rcar_poll_out(const struct device *dev, unsigned char out_char)
 {
-	const struct uart_rcar_cfg *config = DEV_UART_CFG(dev);
-	struct uart_rcar_data *data = DEV_UART_DATA(dev);
+	const struct uart_rcar_cfg *config = dev->config;
+	struct uart_rcar_data *data = dev->data;
 	uint16_t reg_val;
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
 
@@ -187,8 +181,8 @@ static void uart_rcar_poll_out(const struct device *dev, unsigned char out_char)
 static int uart_rcar_configure(const struct device *dev,
 			       const struct uart_config *cfg)
 {
-	const struct uart_rcar_cfg *config = DEV_UART_CFG(dev);
-	struct uart_rcar_data *data = DEV_UART_DATA(dev);
+	const struct uart_rcar_cfg *config = dev->config;
+	struct uart_rcar_data *data = dev->data;
 
 	uint16_t reg_val;
 	k_spinlock_key_t key;
@@ -259,7 +253,7 @@ static int uart_rcar_configure(const struct device *dev,
 static int uart_rcar_config_get(const struct device *dev,
 				struct uart_config *cfg)
 {
-	struct uart_rcar_data *data = DEV_UART_DATA(dev);
+	struct uart_rcar_data *data = dev->data;
 
 	*cfg = data->current_config;
 
@@ -269,8 +263,8 @@ static int uart_rcar_config_get(const struct device *dev,
 
 static int uart_rcar_init(const struct device *dev)
 {
-	const struct uart_rcar_cfg *config = DEV_UART_CFG(dev);
-	struct uart_rcar_data *data = DEV_UART_DATA(dev);
+	const struct uart_rcar_cfg *config = dev->config;
+	struct uart_rcar_data *data = dev->data;
 	int ret;
 
 	/* Configure dt provided device signals when available */
@@ -309,7 +303,7 @@ static int uart_rcar_init(const struct device *dev)
 static bool uart_rcar_irq_is_enabled(const struct device *dev,
 				     uint32_t irq)
 {
-	const struct uart_rcar_cfg *config = DEV_UART_CFG(dev);
+	const struct uart_rcar_cfg *config = dev->config;
 
 	return !!(uart_rcar_read_16(config, SCSCR) & irq);
 }
@@ -318,8 +312,8 @@ static int uart_rcar_fifo_fill(const struct device *dev,
 			       const uint8_t *tx_data,
 			       int len)
 {
-	const struct uart_rcar_cfg *config = DEV_UART_CFG(dev);
-	struct uart_rcar_data *data = DEV_UART_DATA(dev);
+	const struct uart_rcar_cfg *config = dev->config;
+	struct uart_rcar_data *data = dev->data;
 	int num_tx = 0;
 	uint16_t reg_val;
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
@@ -344,8 +338,8 @@ static int uart_rcar_fifo_fill(const struct device *dev,
 static int uart_rcar_fifo_read(const struct device *dev, uint8_t *rx_data,
 			       const int size)
 {
-	const struct uart_rcar_cfg *config = DEV_UART_CFG(dev);
-	struct uart_rcar_data *data = DEV_UART_DATA(dev);
+	const struct uart_rcar_cfg *config = dev->config;
+	struct uart_rcar_data *data = dev->data;
 	int num_rx = 0;
 	uint16_t reg_val;
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
@@ -368,8 +362,8 @@ static int uart_rcar_fifo_read(const struct device *dev, uint8_t *rx_data,
 
 static void uart_rcar_irq_tx_enable(const struct device *dev)
 {
-	const struct uart_rcar_cfg *config = DEV_UART_CFG(dev);
-	struct uart_rcar_data *data = DEV_UART_DATA(dev);
+	const struct uart_rcar_cfg *config = dev->config;
+	struct uart_rcar_data *data = dev->data;
 
 	uint16_t reg_val;
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
@@ -383,8 +377,8 @@ static void uart_rcar_irq_tx_enable(const struct device *dev)
 
 static void uart_rcar_irq_tx_disable(const struct device *dev)
 {
-	const struct uart_rcar_cfg *config = DEV_UART_CFG(dev);
-	struct uart_rcar_data *data = DEV_UART_DATA(dev);
+	const struct uart_rcar_cfg *config = dev->config;
+	struct uart_rcar_data *data = dev->data;
 
 	uint16_t reg_val;
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
@@ -398,15 +392,15 @@ static void uart_rcar_irq_tx_disable(const struct device *dev)
 
 static int uart_rcar_irq_tx_ready(const struct device *dev)
 {
-	const struct uart_rcar_cfg *config = DEV_UART_CFG(dev);
+	const struct uart_rcar_cfg *config = dev->config;
 
 	return !!(uart_rcar_read_16(config, SCFSR) & SCFSR_TDFE);
 }
 
 static void uart_rcar_irq_rx_enable(const struct device *dev)
 {
-	const struct uart_rcar_cfg *config = DEV_UART_CFG(dev);
-	struct uart_rcar_data *data = DEV_UART_DATA(dev);
+	const struct uart_rcar_cfg *config = dev->config;
+	struct uart_rcar_data *data = dev->data;
 
 	uint16_t reg_val;
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
@@ -420,8 +414,8 @@ static void uart_rcar_irq_rx_enable(const struct device *dev)
 
 static void uart_rcar_irq_rx_disable(const struct device *dev)
 {
-	const struct uart_rcar_cfg *config = DEV_UART_CFG(dev);
-	struct uart_rcar_data *data = DEV_UART_DATA(dev);
+	const struct uart_rcar_cfg *config = dev->config;
+	struct uart_rcar_data *data = dev->data;
 
 	uint16_t reg_val;
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
@@ -435,15 +429,15 @@ static void uart_rcar_irq_rx_disable(const struct device *dev)
 
 static int uart_rcar_irq_rx_ready(const struct device *dev)
 {
-	const struct uart_rcar_cfg *config = DEV_UART_CFG(dev);
+	const struct uart_rcar_cfg *config = dev->config;
 
 	return !!(uart_rcar_read_16(config, SCFSR) & SCFSR_RDF);
 }
 
 static void uart_rcar_irq_err_enable(const struct device *dev)
 {
-	const struct uart_rcar_cfg *config = DEV_UART_CFG(dev);
-	struct uart_rcar_data *data = DEV_UART_DATA(dev);
+	const struct uart_rcar_cfg *config = dev->config;
+	struct uart_rcar_data *data = dev->data;
 
 	uint16_t reg_val;
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
@@ -457,8 +451,8 @@ static void uart_rcar_irq_err_enable(const struct device *dev)
 
 static void uart_rcar_irq_err_disable(const struct device *dev)
 {
-	const struct uart_rcar_cfg *config = DEV_UART_CFG(dev);
-	struct uart_rcar_data *data = DEV_UART_DATA(dev);
+	const struct uart_rcar_cfg *config = dev->config;
+	struct uart_rcar_data *data = dev->data;
 
 	uint16_t reg_val;
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
@@ -485,7 +479,7 @@ static void uart_rcar_irq_callback_set(const struct device *dev,
 				       uart_irq_callback_user_data_t cb,
 				       void *cb_data)
 {
-	struct uart_rcar_data *data = DEV_UART_DATA(dev);
+	struct uart_rcar_data *data = dev->data;
 
 	data->callback = cb;
 	data->cb_data = cb_data;
@@ -500,7 +494,7 @@ static void uart_rcar_irq_callback_set(const struct device *dev,
  */
 void uart_rcar_isr(const struct device *dev)
 {
-	struct uart_rcar_data *data = DEV_UART_DATA(dev);
+	struct uart_rcar_data *data = dev->data;
 
 	if (data->callback) {
 		data->callback(dev, data->cb_data);


### PR DESCRIPTION
Applying #41918 for renesas rcar drivers.

Make device driver data and configuration access more uniform across drivers.