### PR TITLE
tests: skip arch_nop test for ARM platforms

### DIFF
--- a/tests/kernel/common/src/irq_offload.c
+++ b/tests/kernel/common/src/irq_offload.c
@@ -142,13 +142,6 @@ __no_optimization void test_nop(void)
 	 */
 	ztest_test_skip();
 #endif
-#elif defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE) || \
-	defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
-	/* do 4 nop instructions more to cost cycles */
-	arch_nop();
-	arch_nop();
-	arch_nop();
-	arch_nop();
 #elif defined(CONFIG_ARC)
 	/* do 7 nop instructions more to cost cycles */
 	arch_nop();
@@ -169,10 +162,10 @@ __no_optimization void test_nop(void)
 	arch_nop();
 	arch_nop();
 	arch_nop();
-
-#elif defined(CONFIG_ARMV8_A) || defined(CONFIG_BOARD_EHL_CRB)	\
-	|| (CONFIG_BOARD_UP_SQUARED) || (CONFIG_SOC_FAMILY_INTEL_ADSP)
-	/* the ARMv8-A ARM states the following:
+#elif defined(CONFIG_ARM) || defined(CONFIG_ARM64)			\
+	|| defined(CONFIG_BOARD_EHL_CRB) || (CONFIG_BOARD_UP_SQUARED)	\
+	|| (CONFIG_SOC_FAMILY_INTEL_ADSP)
+	/* ARM states the following:
 	 * No Operation does nothing, other than advance the value of
 	 * the program counter by 4. This instruction can be used for
 	 * instruction alignment purposes.


### PR DESCRIPTION
ARM does not the guarantee the timing effects of NOP Instruction on Cortex-M platforms. The ARMv6-M Architecture manual states the following:
No Operation does nothing. This instruction can be used for code alignment purposes.

NOTE: The timing effects of including a NOP instruction in code are not guaranteed. It can increase execution time, leave it unchanged, or even reduce it. NOP instructions are therefore not suitable for timing loops.

 A Similar statement can be found in the ARMv8-M Architecture Manual. Hence we skip this test.

Fixes #42666

Signed-off-by: Mahesh Mahadevan <mahesh.mahadevan@nxp.com>