### PR TITLE
boards: xtensa: Add XCC to list of toolchains for intel_adsp boards

### DIFF
--- a/boards/xtensa/intel_adsp_cavs15/intel_adsp_cavs15.yaml
+++ b/boards/xtensa/intel_adsp_cavs15/intel_adsp_cavs15.yaml
@@ -3,6 +3,7 @@ name: CAVS 1.5 Audio DSP (Connected Audio Voice and Speech)
 type: mcu
 arch: xtensa
 toolchain:
+  - xcc
   - zephyr
 testing:
   ignore_tags:

--- a/boards/xtensa/intel_adsp_cavs18/intel_adsp_cavs18.yaml
+++ b/boards/xtensa/intel_adsp_cavs18/intel_adsp_cavs18.yaml
@@ -3,6 +3,7 @@ name: CAVS 1.8 Audio DSP (Connected Audio Voice and Speech)
 type: mcu
 arch: xtensa
 toolchain:
+  - xcc
   - zephyr
 testing:
   ignore_tags:

--- a/boards/xtensa/intel_adsp_cavs20/intel_adsp_cavs20.yaml
+++ b/boards/xtensa/intel_adsp_cavs20/intel_adsp_cavs20.yaml
@@ -3,6 +3,7 @@ name: CAVS 2.0 Audio DSP (Connected Audio Voice and Speech)
 type: mcu
 arch: xtensa
 toolchain:
+  - xcc
   - zephyr
 testing:
   ignore_tags:

--- a/boards/xtensa/intel_adsp_cavs25/intel_adsp_cavs25.yaml
+++ b/boards/xtensa/intel_adsp_cavs25/intel_adsp_cavs25.yaml
@@ -3,6 +3,7 @@ name: CAVS 2.5 Audio DSP (Connected Audio Voice and Speech)
 type: mcu
 arch: xtensa
 toolchain:
+  - xcc
   - zephyr
 testing:
   ignore_tags:


### PR DESCRIPTION
This eliminates the need to use the "--force-toolchain" flag when
running twister with the XCC toolchain on intel_adsp.* boards.

Signed-off-by: Maureen Helm <maureen.helm@intel.com>

cc: @cgturner1 , @aborisovich 