### PR TITLE
uart_mcux_lpuart: Enable Asynchronous UART API.

### DIFF
--- a/drivers/dma/Kconfig.mcux_edma
+++ b/drivers/dma/Kconfig.mcux_edma
@@ -26,4 +26,11 @@ config DMA_MCUX_TEST_SLOT_START
 	help
 	  test slot start num
 
+config DMA_MCUX_USE_DTCM_FOR_DMA_DESCRIPTORS
+	bool "Use DTCM for DMA descriptors"
+	default n
+	help
+	  When this option is activated, the descriptors for DMA transfer are
+	  located in the DTCM (Data Tightly Coupled Memory).
+
 endif # DMA_MCUX_EDMA

--- a/drivers/dma/dma_mcux_edma.c
+++ b/drivers/dma/dma_mcux_edma.c
@@ -33,8 +33,42 @@ struct dma_mcux_edma_config {
 	void (*irq_config_func)(const struct device *dev);
 };
 
-static __aligned(32) edma_tcd_t
-	tcdpool[DT_INST_PROP(0, dma_channels)][CONFIG_DMA_TCD_QUEUE_SIZE];
+
+#ifdef CONFIG_HAS_MCUX_CACHE
+
+#ifdef CONFIG_DMA_MCUX_USE_DTCM_FOR_DMA_DESCRIPTORS
+
+#if DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_dtcm), okay)
+#define EDMA_TCDPOOL_CACHE_ATTR __dtcm_noinit_section
+#else /* DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_dtcm), okay) */
+#error Selected DTCM for MCUX DMA descriptors but no DTCM section.
+#endif /* DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_dtcm), okay) */
+
+#elif defined(CONFIG_NOCACHE_MEMORY)
+#define EDMA_TCDPOOL_CACHE_ATTR __nocache
+#else
+#error tcdpool could not be located in cacheable memory, a requirement for proper EDMA operation.
+#endif /* CONFIG_DMA_MCUX_USE_DTCM_FOR_DMA_DESCRIPTORS */
+
+#else /* CONFIG_HAS_MCUX_CACHE */
+
+#define EDMA_TCDPOOL_CACHE_ATTR
+
+#endif /* CONFIG_HAS_MCUX_CACHE */
+
+static __aligned(32) EDMA_TCDPOOL_CACHE_ATTR edma_tcd_t
+tcdpool[DT_INST_PROP(0, dma_channels)][CONFIG_DMA_TCD_QUEUE_SIZE];
+
+struct dma_mcux_channel_transfer_edma_settings {
+	uint32_t source_data_size;
+	uint32_t dest_data_size;
+	uint32_t source_burst_length;
+	uint32_t dest_burst_length;
+	enum dma_channel_direction direction;
+	edma_transfer_type_t transfer_type;
+	bool valid;
+};
+
 
 struct call_back {
 	edma_transfer_config_t transferConfig;
@@ -42,7 +76,7 @@ struct call_back {
 	const struct device *dev;
 	void *user_data;
 	dma_callback_t dma_callback;
-	enum dma_channel_direction dir;
+	struct dma_mcux_channel_transfer_edma_settings transfer_settings;
 	bool busy;
 };
 
@@ -53,91 +87,43 @@ struct dma_mcux_edma_data {
 	struct k_mutex dma_mutex;
 };
 
-#define DEV_BASE(dev) \
-	((DMA_Type *)((const struct dma_mcux_edma_config *const)dev->config)->base)
+#define DEV_CFG(dev) \
+	((const struct dma_mcux_edma_config *const)dev->config)
+#define DEV_DATA(dev) ((struct dma_mcux_edma_data *)dev->data)
+#define DEV_BASE(dev) ((DMA_Type *)DEV_CFG(dev)->base)
 
-#define DEV_DMAMUX_BASE(dev) \
-	((DMAMUX_Type *)((const struct dma_mcux_edma_config *const)dev->config)->dmamux_base)
+#define DEV_DMAMUX_BASE(dev) ((DMAMUX_Type *)DEV_CFG(dev)->dmamux_base)
 
-#define DEV_CHANNEL_DATA(dev, ch)                                              \
-	((struct call_back *)(&(((struct dma_mcux_edma_data *)dev->data)->data_cb[ch])))
+#define DEV_CHANNEL_DATA(dev, ch) \
+	((struct call_back *)(&(DEV_DATA(dev)->data_cb[ch])))
 
-#define DEV_EDMA_HANDLE(dev, ch)                                               \
+#define DEV_EDMA_HANDLE(dev, ch) \
 	((edma_handle_t *)(&(DEV_CHANNEL_DATA(dev, ch)->edma_handle)))
 
-static void nxp_edma_callback(edma_handle_t *handle, void *param,
-			      bool transferDone, uint32_t tcds)
+static bool data_size_valid(const size_t data_size)
+{
+	return (data_size == 4U || data_size == 2U ||
+		data_size == 1U || data_size == 8U ||
+		data_size == 16U ||
+		data_size == 32U);
+}
+
+static void nxp_edma_callback(edma_handle_t *handle, void *param, bool transferDone,
+			      uint32_t tcds)
 {
 	int ret = 1;
 	struct call_back *data = (struct call_back *)param;
 	uint32_t channel = handle->channel;
 
 	if (transferDone) {
-		data->busy = false;
+		/* DMA is no longer busy when there are no remaining TCDs to transfer */
+		data->busy = (handle->tcdPool != NULL) && (handle->tcdUsed > 0);
 		ret = 0;
 	}
 	LOG_DBG("transfer %d", tcds);
 	data->dma_callback(data->dev, data->user_data, channel, ret);
 }
 
-static void channel_irq(edma_handle_t *handle)
-{
-	bool transfer_done;
-
-	/* Clear EDMA interrupt flag */
-	handle->base->CINT = handle->channel;
-	/* Check if transfer is already finished. */
-	transfer_done = ((handle->base->TCD[handle->channel].CSR &
-			  DMA_CSR_DONE_MASK) != 0U);
-
-	if (handle->tcdPool == NULL) {
-		(handle->callback)(handle, handle->userData, transfer_done, 0);
-	} else {
-		uint32_t sga = handle->base->TCD[handle->channel].DLAST_SGA;
-		uint32_t sga_index;
-		int32_t tcds_done;
-		uint8_t new_header;
-
-		sga -= (uint32_t)handle->tcdPool;
-		sga_index = sga / sizeof(edma_tcd_t);
-		/* Adjust header positions. */
-		if (transfer_done) {
-			new_header = (uint8_t)sga_index;
-		} else {
-			new_header = sga_index != 0U ?
-					     (uint8_t)sga_index - 1U :
-					     (uint8_t)handle->tcdSize - 1U;
-		}
-		/* Calculate the number of finished TCDs */
-		if (new_header == (uint8_t)handle->header) {
-			int8_t tmpTcdUsed = handle->tcdUsed;
-			int8_t tmpTcdSize = handle->tcdSize;
-
-			if (tmpTcdUsed == tmpTcdSize) {
-				tcds_done = handle->tcdUsed;
-			} else {
-				tcds_done = 0;
-			}
-		} else {
-			tcds_done = (uint32_t)new_header - (uint32_t)handle->header;
-			if (tcds_done < 0) {
-				tcds_done += handle->tcdSize;
-			}
-		}
-
-		handle->header = (int8_t)new_header;
-		handle->tcdUsed -= (int8_t)tcds_done;
-		/* Invoke callback function. */
-		if (handle->callback != NULL) {
-			(handle->callback)(handle, handle->userData,
-					   transfer_done, tcds_done);
-		}
-
-		if (transfer_done) {
-			handle->base->CDNE = handle->channel;
-		}
-	}
-}
 
 static void dma_mcux_edma_irq_handler(const struct device *dev)
 {
@@ -149,7 +135,7 @@ static void dma_mcux_edma_irq_handler(const struct device *dev)
 
 		if ((flag & (uint32_t)kEDMA_InterruptFlag) != 0U) {
 			LOG_DBG("IRQ OCCURRED");
-			channel_irq(DEV_EDMA_HANDLE(dev, i));
+			EDMA_HandleIRQ(DEV_EDMA_HANDLE(dev, i));
 			LOG_DBG("IRQ DONE");
 #if defined __CORTEX_M && (__CORTEX_M == 4U)
 			__DSB();
@@ -194,6 +180,7 @@ static int dma_mcux_edma_configure(const struct device *dev, uint32_t channel,
 	uint32_t slot = config->dma_slot;
 	edma_transfer_type_t transfer_type;
 	int key;
+	int ret = 0;
 
 	if (slot > DT_INST_PROP(0, dma_requests)) {
 		LOG_ERR("source number is outof scope %d", slot);
@@ -205,7 +192,8 @@ static int dma_mcux_edma_configure(const struct device *dev, uint32_t channel,
 		return -EINVAL;
 	}
 
-	data->dir = config->channel_direction;
+	data->transfer_settings.valid = false;
+
 	switch (config->channel_direction) {
 	case MEMORY_TO_MEMORY:
 		transfer_type = kEDMA_MemoryToMemory;
@@ -223,6 +211,32 @@ static int dma_mcux_edma_configure(const struct device *dev, uint32_t channel,
 		LOG_ERR("not support transfer direction");
 		return -EINVAL;
 	}
+
+	if (!data_size_valid(config->source_data_size)) {
+		LOG_ERR("Source unit size error, %d", config->source_data_size);
+		return -EINVAL;
+	}
+
+	if (!data_size_valid(config->dest_data_size)) {
+		LOG_ERR("Dest unit size error, %d", config->dest_data_size);
+		return -EINVAL;
+	}
+
+	if (block_config->source_gather_en || block_config->dest_scatter_en) {
+		if (config->block_count > CONFIG_DMA_TCD_QUEUE_SIZE) {
+			LOG_ERR("please config DMA_TCD_QUEUE_SIZE as %d", config->block_count);
+			return -EINVAL;
+		}
+	}
+
+	data->transfer_settings.source_data_size = config->source_data_size;
+	data->transfer_settings.dest_data_size = config->dest_data_size;
+	data->transfer_settings.source_burst_length = config->source_burst_length;
+	data->transfer_settings.dest_burst_length = config->dest_burst_length;
+	data->transfer_settings.direction = config->channel_direction;
+	data->transfer_settings.transfer_type = transfer_type;
+	data->transfer_settings.valid = true;
+
 
 	/* Lock and page in the channel configuration */
 	key = irq_lock();
@@ -251,33 +265,10 @@ static int dma_mcux_edma_configure(const struct device *dev, uint32_t channel,
 	EDMA_SetCallback(p_handle, nxp_edma_callback, (void *)data);
 
 	LOG_DBG("channel is %d", p_handle->channel);
-
-	if (config->source_data_size != 4U && config->source_data_size != 2U &&
-	    config->source_data_size != 1U && config->source_data_size != 8U &&
-	    config->source_data_size != 16U &&
-	    config->source_data_size != 32U) {
-		LOG_ERR("Source unit size error, %d", config->source_data_size);
-		return -EINVAL;
-	}
-
-	if (config->dest_data_size != 4U && config->dest_data_size != 2U &&
-	    config->dest_data_size != 1U && config->dest_data_size != 8U &&
-	    config->dest_data_size != 16U && config->dest_data_size != 32U) {
-		LOG_ERR("Dest unit size error, %d", config->dest_data_size);
-		return -EINVAL;
-	}
-
-	EDMA_EnableChannelInterrupts(DEV_BASE(dev), channel,
-				     kEDMA_ErrorInterruptEnable);
+	EDMA_EnableChannelInterrupts(DEV_BASE(dev), channel, kEDMA_ErrorInterruptEnable);
 
 	if (block_config->source_gather_en || block_config->dest_scatter_en) {
-		if (config->block_count > CONFIG_DMA_TCD_QUEUE_SIZE) {
-			LOG_ERR("please config DMA_TCD_QUEUE_SIZE as %d",
-				config->block_count);
-			return -EINVAL;
-		}
-		EDMA_InstallTCDMemory(p_handle, tcdpool[channel],
-				      CONFIG_DMA_TCD_QUEUE_SIZE);
+		EDMA_InstallTCDMemory(p_handle, tcdpool[channel], CONFIG_DMA_TCD_QUEUE_SIZE);
 		while (block_config != NULL) {
 			EDMA_PrepareTransfer(
 				&(data->transferConfig),
@@ -287,12 +278,17 @@ static int dma_mcux_edma_configure(const struct device *dev, uint32_t channel,
 				config->dest_data_size,
 				config->source_burst_length,
 				block_config->block_size, transfer_type);
-			EDMA_SubmitTransfer(p_handle, &(data->transferConfig));
+
+			const status_t submit_status =
+				EDMA_SubmitTransfer(p_handle, &(data->transferConfig));
+			if (submit_status != kStatus_Success) {
+				LOG_ERR("Error submitting EDMA Transfer: 0x%x", submit_status);
+				ret = -EFAULT;
+			}
 			block_config = block_config->next_block;
 		}
 	} else {
 		/* block_count shall be 1 */
-		status_t ret;
 		LOG_DBG("block size is: %d", block_config->block_size);
 		EDMA_PrepareTransfer(&(data->transferConfig),
 				     (void *)block_config->source_address,
@@ -302,12 +298,13 @@ static int dma_mcux_edma_configure(const struct device *dev, uint32_t channel,
 				     config->source_burst_length,
 				     block_config->block_size, transfer_type);
 
-		ret = EDMA_SubmitTransfer(p_handle, &(data->transferConfig));
-		edma_tcd_t *tcdRegs =
-			(edma_tcd_t *)(uint32_t)&p_handle->base->TCD[channel];
-		if (ret != kStatus_Success) {
-			LOG_ERR("submit error 0x%x", ret);
+		const status_t submit_status =
+			EDMA_SubmitTransfer(p_handle, &(data->transferConfig));
+		if (submit_status != kStatus_Success) {
+			LOG_ERR("Error submitting EDMA Transfer: 0x%x", submit_status);
+			ret = -EFAULT;
 		}
+		edma_tcd_t *tcdRegs = (edma_tcd_t *)(uint32_t)&p_handle->base->TCD[channel];
 		LOG_DBG("data csr is 0x%x", tcdRegs->CSR);
 	}
 
@@ -332,7 +329,7 @@ static int dma_mcux_edma_configure(const struct device *dev, uint32_t channel,
 
 	irq_unlock(key);
 
-	return 0;
+	return ret;
 }
 
 static int dma_mcux_edma_start(const struct device *dev, uint32_t channel)
@@ -349,7 +346,9 @@ static int dma_mcux_edma_start(const struct device *dev, uint32_t channel)
 
 static int dma_mcux_edma_stop(const struct device *dev, uint32_t channel)
 {
-	struct dma_mcux_edma_data *data = dev->data;
+	struct dma_mcux_edma_data *data = DEV_DATA(dev);
+
+	data->data_cb[channel].transfer_settings.valid = false;
 
 	if (!data->data_cb[channel].busy) {
 		return 0;
@@ -357,7 +356,7 @@ static int dma_mcux_edma_stop(const struct device *dev, uint32_t channel)
 	EDMA_AbortTransfer(DEV_EDMA_HANDLE(dev, channel));
 	EDMA_ClearChannelStatusFlags(DEV_BASE(dev), channel,
 				     kEDMA_DoneFlag | kEDMA_ErrorFlag |
-					     kEDMA_InterruptFlag);
+				     kEDMA_InterruptFlag);
 	EDMA_ResetChannel(DEV_BASE(dev), channel);
 	data->data_cb[channel].busy = false;
 	return 0;
@@ -391,14 +390,47 @@ static int dma_mcux_edma_reload(const struct device *dev, uint32_t channel,
 {
 	struct call_back *data = DEV_CHANNEL_DATA(dev, channel);
 
-	if (data->busy) {
-		EDMA_AbortTransfer(DEV_EDMA_HANDLE(dev, channel));
+	/* Lock the channel configuration */
+	const int key = irq_lock();
+	int ret = 0;
+
+	if (!data->transfer_settings.valid) {
+		LOG_ERR("Invalid EDMA settings on initial config. Configure DMA before reload.");
+		ret = -EFAULT;
+		goto cleanup;
 	}
-	return 0;
+
+	/* If the tcdPool is not in use (no s/g) then only a single TCD can be active at once. */
+	if (data->busy && data->edma_handle.tcdPool == NULL) {
+		LOG_ERR("EDMA busy. Wait until the transfer completes before reloading.");
+		ret = -EBUSY;
+		goto cleanup;
+	}
+
+	EDMA_PrepareTransfer(
+		&(data->transferConfig),
+		(void *)src,
+		data->transfer_settings.source_data_size,
+		(void *)dst,
+		data->transfer_settings.dest_data_size,
+		data->transfer_settings.source_burst_length,
+		size,
+		data->transfer_settings.transfer_type);
+
+	const status_t submit_status =
+		EDMA_SubmitTransfer(DEV_EDMA_HANDLE(dev, channel), &(data->transferConfig));
+
+	if (submit_status != kStatus_Success) {
+		LOG_ERR("Error submitting EDMA Transfer: 0x%x", submit_status);
+		ret = -EFAULT;
+	}
+
+cleanup:
+	irq_unlock(key);
+	return ret;
 }
 
-static int dma_mcux_edma_get_status(const struct device *dev,
-				    uint32_t channel,
+static int dma_mcux_edma_get_status(const struct device *dev, uint32_t channel,
 				    struct dma_status *status)
 {
 	edma_tcd_t *tcdRegs;
@@ -411,7 +443,7 @@ static int dma_mcux_edma_get_status(const struct device *dev,
 		status->busy = false;
 		status->pending_length = 0;
 	}
-	status->dir = DEV_CHANNEL_DATA(dev, channel)->dir;
+	status->dir = DEV_CHANNEL_DATA(dev, channel)->transfer_settings.direction;
 	LOG_DBG("DMAMUX CHCFG 0x%x", DEV_DMAMUX_BASE(dev)->CHCFG[channel]);
 	LOG_DBG("DMA CR 0x%x", DEV_BASE(dev)->CR);
 	LOG_DBG("DMA INT 0x%x", DEV_BASE(dev)->INT);
@@ -425,7 +457,7 @@ static int dma_mcux_edma_get_status(const struct device *dev,
 }
 
 static bool dma_mcux_edma_channel_filter(const struct device *dev,
-				int channel_id, void *param)
+					 int channel_id, void *param)
 {
 	enum dma_channel_filter *filter = (enum dma_channel_filter *)param;
 
@@ -469,63 +501,63 @@ static int dma_mcux_edma_init(const struct device *dev)
 	return 0;
 }
 
-#define IRQ_CONFIG(n, idx, fn)						\
-	IF_ENABLED(DT_INST_IRQ_HAS_IDX(n, idx), (			\
-		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(n, idx, irq),		\
-		DT_INST_IRQ_BY_IDX(n, idx, priority),			\
-		fn,							\
-		DEVICE_DT_INST_GET(n), 0);				\
-		irq_enable(DT_INST_IRQ_BY_IDX(n, idx, irq));		\
-		))
+#define IRQ_CONFIG(n, idx, fn)						     \
+	IF_ENABLED(DT_INST_IRQ_HAS_IDX(n, idx), (			     \
+			   IRQ_CONNECT(DT_INST_IRQ_BY_IDX(n, idx, irq),	     \
+				       DT_INST_IRQ_BY_IDX(n, idx, priority), \
+				       fn,				     \
+				       DEVICE_DT_INST_GET(n), 0);	     \
+			   irq_enable(DT_INST_IRQ_BY_IDX(n, idx, irq));	     \
+			   ))
 
-#define DMA_MCUX_EDMA_CONFIG_FUNC(n)					\
-	static void dma_imx_config_func_##n(const struct device *dev)	\
-	{								\
-		ARG_UNUSED(dev);					\
-									\
-		IRQ_CONFIG(n, 0, dma_mcux_edma_irq_handler);		\
-		IRQ_CONFIG(n, 1, dma_mcux_edma_irq_handler);		\
-		IRQ_CONFIG(n, 2, dma_mcux_edma_irq_handler);		\
-		IRQ_CONFIG(n, 3, dma_mcux_edma_irq_handler);		\
-		IRQ_CONFIG(n, 4, dma_mcux_edma_irq_handler);		\
-		IRQ_CONFIG(n, 5, dma_mcux_edma_irq_handler);		\
-		IRQ_CONFIG(n, 6, dma_mcux_edma_irq_handler);		\
-		IRQ_CONFIG(n, 7, dma_mcux_edma_irq_handler);		\
-		IRQ_CONFIG(n, 8, dma_mcux_edma_irq_handler);		\
-		IRQ_CONFIG(n, 9, dma_mcux_edma_irq_handler);		\
-		IRQ_CONFIG(n, 10, dma_mcux_edma_irq_handler);		\
-		IRQ_CONFIG(n, 11, dma_mcux_edma_irq_handler);		\
-		IRQ_CONFIG(n, 12, dma_mcux_edma_irq_handler);		\
-		IRQ_CONFIG(n, 13, dma_mcux_edma_irq_handler);		\
-		IRQ_CONFIG(n, 14, dma_mcux_edma_irq_handler);		\
-		IRQ_CONFIG(n, 15, dma_mcux_edma_irq_handler);		\
-									\
-		IRQ_CONFIG(n, 16, dma_mcux_edma_error_irq_handler);	\
-									\
-		LOG_DBG("install irq done");				\
+#define DMA_MCUX_EDMA_CONFIG_FUNC(n)				      \
+	static void dma_imx_config_func_##n(const struct device *dev) \
+	{							      \
+		ARG_UNUSED(dev);				      \
+								      \
+		IRQ_CONFIG(n, 0, dma_mcux_edma_irq_handler);	      \
+		IRQ_CONFIG(n, 1, dma_mcux_edma_irq_handler);	      \
+		IRQ_CONFIG(n, 2, dma_mcux_edma_irq_handler);	      \
+		IRQ_CONFIG(n, 3, dma_mcux_edma_irq_handler);	      \
+		IRQ_CONFIG(n, 4, dma_mcux_edma_irq_handler);	      \
+		IRQ_CONFIG(n, 5, dma_mcux_edma_irq_handler);	      \
+		IRQ_CONFIG(n, 6, dma_mcux_edma_irq_handler);	      \
+		IRQ_CONFIG(n, 7, dma_mcux_edma_irq_handler);	      \
+		IRQ_CONFIG(n, 8, dma_mcux_edma_irq_handler);	      \
+		IRQ_CONFIG(n, 9, dma_mcux_edma_irq_handler);	      \
+		IRQ_CONFIG(n, 10, dma_mcux_edma_irq_handler);	      \
+		IRQ_CONFIG(n, 11, dma_mcux_edma_irq_handler);	      \
+		IRQ_CONFIG(n, 12, dma_mcux_edma_irq_handler);	      \
+		IRQ_CONFIG(n, 13, dma_mcux_edma_irq_handler);	      \
+		IRQ_CONFIG(n, 14, dma_mcux_edma_irq_handler);	      \
+		IRQ_CONFIG(n, 15, dma_mcux_edma_irq_handler);	      \
+								      \
+		IRQ_CONFIG(n, 16, dma_mcux_edma_error_irq_handler);   \
+								      \
+		LOG_DBG("install irq done");			      \
 	}
 
 /*
  * define the dma
  */
-#define DMA_INIT(n)							\
-	static void dma_imx_config_func_##n(const struct device *dev);	\
-	static const struct dma_mcux_edma_config dma_config_##n = {	\
-		.base = (DMA_Type *)DT_INST_REG_ADDR(n),		\
-		.dmamux_base =						\
-			(DMAMUX_Type *)DT_INST_REG_ADDR_BY_IDX(n, 1),	\
-		.dma_channels = DT_INST_PROP(n, dma_channels),		\
-		.irq_config_func = dma_imx_config_func_##n,		\
-	};								\
-									\
-	struct dma_mcux_edma_data dma_data_##n;				\
-									\
-	DEVICE_DT_INST_DEFINE(n,					\
-			    &dma_mcux_edma_init, NULL,			\
-			    &dma_data_##n, &dma_config_##n,		\
-			    POST_KERNEL, CONFIG_DMA_INIT_PRIORITY,	\
-			    &dma_mcux_edma_api);			\
-									\
+#define DMA_INIT(n)						       \
+	static void dma_imx_config_func_##n(const struct device *dev); \
+	static const struct dma_mcux_edma_config dma_config_##n = {    \
+		.base = (DMA_Type *)DT_INST_REG_ADDR(n),	       \
+		.dmamux_base =					       \
+			(DMAMUX_Type *)DT_INST_REG_ADDR_BY_IDX(n, 1),  \
+		.dma_channels = DT_INST_PROP(n, dma_channels),	       \
+		.irq_config_func = dma_imx_config_func_##n,	       \
+	};							       \
+								       \
+	struct dma_mcux_edma_data dma_data_##n;			       \
+								       \
+	DEVICE_DT_INST_DEFINE(n,				       \
+			      &dma_mcux_edma_init, NULL,	       \
+			      &dma_data_##n, &dma_config_##n,	       \
+			      PRE_KERNEL_1, CONFIG_DMA_INIT_PRIORITY,   \
+			      &dma_mcux_edma_api);		       \
+								       \
 	DMA_MCUX_EDMA_CONFIG_FUNC(n);
 
 DT_INST_FOREACH_STATUS_OKAY(DMA_INIT)

--- a/drivers/serial/Kconfig.mcux
+++ b/drivers/serial/Kconfig.mcux
@@ -8,5 +8,6 @@ config UART_MCUX
 	depends on HAS_MCUX && CLOCK_CONTROL
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
+	select SERIAL_SUPPORT_ASYNC
 	help
 	  Enable the MCUX uart driver.

--- a/drivers/serial/Kconfig.mcux_lpuart
+++ b/drivers/serial/Kconfig.mcux_lpuart
@@ -8,5 +8,7 @@ config UART_MCUX_LPUART
 	depends on HAS_MCUX_LPUART && CLOCK_CONTROL
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
+	select SERIAL_SUPPORT_ASYNC
+	select DMA if UART_ASYNC_API
 	help
 	  Enable the MCUX LPUART driver.

--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -17,6 +17,21 @@
 #ifdef CONFIG_PINCTRL
 #include <drivers/pinctrl.h>
 #endif
+#ifdef CONFIG_UART_ASYNC_API
+#include <drivers/dma.h>
+#endif
+
+
+#include <logging/log.h>
+LOG_MODULE_REGISTER(uart_mcux_lpuart, LOG_LEVEL_ERR);
+
+#ifdef CONFIG_UART_ASYNC_API
+struct lpuart_dma_config {
+	const struct device *dma_dev;
+	const uint32_t dma_channel;
+	struct dma_config dma_cfg;
+};
+#endif /* CONFIG_UART_ASYNC_API */
 
 struct mcux_lpuart_config {
 	LPUART_Type *base;
@@ -30,7 +45,42 @@ struct mcux_lpuart_config {
 #if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_PM)
 	void (*irq_config_func)(const struct device *dev);
 #endif
+#ifdef CONFIG_UART_ASYNC_API
+	const struct lpuart_dma_config rx_dma_config;
+	const struct lpuart_dma_config tx_dma_config;
+	void (*async_config_func)(const struct device *dev);
+#endif /* CONFIG_UART_ASYNC_API */
 };
+
+#ifdef CONFIG_UART_ASYNC_API
+struct mcux_lpuart_rx_dma_params {
+	struct dma_block_config active_dma_block;
+	uint8_t *buf;
+	size_t buf_len;
+	size_t offset;
+	size_t counter;
+	struct k_work_delayable timeout_work;
+	size_t timeout_us;
+};
+
+struct mcux_lpuart_tx_dma_params {
+	struct dma_block_config active_dma_block;
+	const uint8_t *buf;
+	size_t buf_len;
+	struct k_work_delayable timeout_work;
+	size_t timeout_us;
+};
+
+struct mcux_lpuart_async_data {
+	const struct device *uart_dev;
+	struct mcux_lpuart_tx_dma_params tx_dma_params;
+	struct mcux_lpuart_rx_dma_params rx_dma_params;
+	uint8_t *next_rx_buffer;
+	size_t next_rx_buffer_len;
+	uart_callback_t user_callback;
+	void *user_data;
+};
+#endif
 
 struct mcux_lpuart_data {
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
@@ -42,6 +92,9 @@ struct mcux_lpuart_data {
 	bool tx_poll_stream_on;
 	bool tx_int_stream_on;
 #endif /* CONFIG_PM */
+#ifdef CONFIG_UART_ASYNC_API
+	struct mcux_lpuart_async_data async;
+#endif
 	struct uart_config uart_config;
 };
 
@@ -342,8 +395,483 @@ static void mcux_lpuart_isr(const struct device *dev)
 }
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN || CONFIG_PM */
 
-static int mcux_lpuart_configure_init(const struct device *dev,
-				      const struct uart_config *cfg)
+#ifdef CONFIG_UART_ASYNC_API
+static inline void async_timer_start(struct k_work_delayable *work, size_t timeout_us)
+{
+	if ((timeout_us != SYS_FOREVER_US) && (timeout_us != 0)) {
+		LOG_DBG("async timer started for %d us", timeout_us);
+		k_work_reschedule(work, K_USEC(timeout_us));
+	}
+}
+
+static void mcux_lpuart_async_isr(const struct device *dev)
+{
+	struct mcux_lpuart_data *data = dev->data;
+	const struct mcux_lpuart_config *config = dev->config;
+	LPUART_Type *lpuart = config->base;
+	const uint32_t status = LPUART_GetStatusFlags(lpuart);
+
+	if (kLPUART_IdleLineFlag & status) {
+		async_timer_start(&data->async.rx_dma_params.timeout_work,
+				  data->async.rx_dma_params.timeout_us);
+		assert(LPUART_ClearStatusFlags(lpuart, kLPUART_IdleLineFlag) == 0U);
+	}
+}
+
+static void async_user_callback(const struct device *dev, struct uart_event *evt)
+{
+	const struct mcux_lpuart_data *data = dev->data;
+
+	if (data->async.user_callback) {
+		data->async.user_callback(dev, evt, data->async.user_data);
+	}
+}
+
+static void async_evt_tx_done(struct device *dev)
+{
+	struct mcux_lpuart_data *data = dev->data;
+
+	(void)k_work_cancel_delayable(&data->async.tx_dma_params.timeout_work);
+
+	LOG_DBG("TX done: %d", data->async.tx_dma_params.buf_len);
+	struct uart_event event = {
+		.type = UART_TX_DONE,
+		.data.tx.buf = data->async.tx_dma_params.buf,
+		.data.tx.len = data->async.tx_dma_params.buf_len
+	};
+
+	/* Reset TX Buffer */
+	data->async.tx_dma_params.buf = NULL;
+	data->async.tx_dma_params.buf_len = 0U;
+
+	async_user_callback(dev, &event);
+}
+
+static void async_evt_rx_rdy(const struct device *dev)
+{
+	struct mcux_lpuart_data *data = dev->data;
+	struct mcux_lpuart_rx_dma_params *dma_params = &data->async.rx_dma_params;
+
+	struct uart_event event = {
+		.type = UART_RX_RDY,
+		.data.rx.buf = dma_params->buf,
+		.data.rx.len = dma_params->counter - dma_params->offset,
+		.data.rx.offset = dma_params->offset
+	};
+
+	LOG_DBG("RX Ready: (len: %d off: %d buf: %x)", event.data.rx.len, event.data.rx.offset,
+		(uint32_t)event.data.rx.buf);
+
+	/* Update the current pos for new data */
+	dma_params->offset = dma_params->counter;
+
+	/* Only send event for new data */
+	if (event.data.rx.len > 0) {
+		async_user_callback(dev, &event);
+	}
+}
+
+static void async_evt_rx_buf_request(const struct device *dev)
+{
+	struct uart_event evt = {
+		.type = UART_RX_BUF_REQUEST,
+	};
+
+	async_user_callback(dev, &evt);
+}
+
+static void async_evt_rx_buf_release(const struct device *dev)
+{
+	struct mcux_lpuart_data *data = (struct mcux_lpuart_data *)dev->data;
+	struct uart_event evt = {
+		.type = UART_RX_BUF_RELEASED,
+		.data.rx_buf.buf = data->async.rx_dma_params.buf,
+	};
+
+	async_user_callback(dev, &evt);
+	data->async.rx_dma_params.buf = NULL;
+	data->async.rx_dma_params.buf_len = 0U;
+	data->async.rx_dma_params.offset = 0U;
+	data->async.rx_dma_params.counter = 0U;
+}
+
+static void mcux_lpuart_async_rx_flush(const struct device *dev)
+{
+	struct dma_status status;
+	struct mcux_lpuart_data *data = dev->data;
+	const struct mcux_lpuart_config *config = dev->config;
+
+	const int get_status_result = dma_get_status(config->rx_dma_config.dma_dev,
+						     config->rx_dma_config.dma_channel,
+						     &status);
+
+	if (get_status_result == 0) {
+		const size_t rx_rcv_len = data->async.rx_dma_params.buf_len -
+					  status.pending_length;
+
+		if (rx_rcv_len > data->async.rx_dma_params.counter) {
+			data->async.rx_dma_params.counter = rx_rcv_len;
+			async_evt_rx_rdy(dev);
+		}
+	} else {
+		LOG_ERR("Error getting DMA status");
+	}
+}
+
+static int mcux_lpuart_rx_disable(const struct device *dev)
+{
+	LOG_INF("Disabling UART RX DMA");
+	const struct mcux_lpuart_config *config = dev->config;
+	struct mcux_lpuart_data *data = (struct mcux_lpuart_data *)dev->data;
+	LPUART_Type *lpuart = config->base;
+	const int key = irq_lock();
+
+	LPUART_EnableRx(lpuart, false);
+	(void)k_work_cancel_delayable(&data->async.rx_dma_params.timeout_work);
+	LPUART_DisableInterrupts(lpuart, kLPUART_IdleLineInterruptEnable);
+	LPUART_ClearStatusFlags(lpuart, kLPUART_IdleLineFlag);
+	LPUART_EnableRxDMA(lpuart, false);
+
+	/* No active RX buffer, cannot disable */
+	if (!data->async.rx_dma_params.buf) {
+		LOG_ERR("No buffers to release from RX DMA!");
+	} else {
+		mcux_lpuart_async_rx_flush(dev);
+		async_evt_rx_buf_release(dev);
+		if (data->async.next_rx_buffer != NULL) {
+			data->async.rx_dma_params.buf = data->async.next_rx_buffer;
+			data->async.rx_dma_params.buf_len = data->async.next_rx_buffer_len;
+			data->async.next_rx_buffer = NULL;
+			data->async.next_rx_buffer_len = 0;
+			/* Release the next buffer as well */
+			async_evt_rx_buf_release(dev);
+		}
+	}
+	const int ret = dma_stop(config->rx_dma_config.dma_dev,
+				 config->rx_dma_config.dma_channel);
+
+	if (ret != 0) {
+		LOG_ERR("Error stopping rx DMA. Reason: %x", ret);
+	}
+	LOG_DBG("RX: Disabled");
+	struct uart_event disabled_event = {
+		.type = UART_RX_DISABLED
+	};
+
+	async_user_callback(dev, &disabled_event);
+	irq_unlock(key);
+	return ret;
+}
+
+static void prepare_rx_dma_block_config(const struct device *dev)
+{
+	struct mcux_lpuart_data *data = (struct mcux_lpuart_data *)dev->data;
+	const struct mcux_lpuart_config *config = dev->config;
+	LPUART_Type *lpuart = config->base;
+	struct mcux_lpuart_rx_dma_params *rx_dma_params = &data->async.rx_dma_params;
+
+	assert(rx_dma_params->buf != NULL);
+	assert(rx_dma_params->buf_len > 0);
+
+	struct dma_block_config *head_block_config = &rx_dma_params->active_dma_block;
+
+	head_block_config->dest_address = (uint32_t)rx_dma_params->buf;
+	head_block_config->source_address = LPUART_GetDataRegisterAddress(lpuart);
+	head_block_config->block_size = rx_dma_params->buf_len;
+	head_block_config->dest_scatter_en = true;
+}
+
+static int configure_and_start_rx_dma(
+	const struct mcux_lpuart_config *config, struct mcux_lpuart_data *data,
+	LPUART_Type *lpuart)
+{
+	LOG_DBG("Configuring and Starting UART RX DMA");
+	int ret = dma_config(config->rx_dma_config.dma_dev,
+			     config->rx_dma_config.dma_channel,
+			     (struct dma_config *)&config->rx_dma_config.dma_cfg);
+
+	if (ret != 0) {
+		LOG_ERR("Failed to Configure RX DMA: err: %d", ret);
+		return ret;
+	}
+	ret = dma_start(config->rx_dma_config.dma_dev, config->rx_dma_config.dma_channel);
+	if (ret < 0) {
+		LOG_ERR("Failed to start DMA(Rx) Ch %d(%d)",
+			config->rx_dma_config.dma_channel,
+			ret);
+	}
+	LPUART_EnableRxDMA(lpuart, true);
+	return ret;
+}
+
+static int uart_mcux_lpuart_dma_replace_rx_buffer(const struct device *dev)
+{
+	struct mcux_lpuart_data *data = (struct mcux_lpuart_data *)dev->data;
+	const struct mcux_lpuart_config *config = dev->config;
+	LPUART_Type *lpuart = config->base;
+
+	LOG_DBG("Replacing RX buffer, new length: %d", data->async.next_rx_buffer_len);
+	/* There must be a buffer to replace this one with */
+	assert(data->async.next_rx_buffer != NULL);
+	assert(data->async.next_rx_buffer_len != 0U);
+	const int success = dma_reload(config->rx_dma_config.dma_dev,
+				       config->rx_dma_config.dma_channel,
+				       LPUART_GetDataRegisterAddress(lpuart),
+				       (uint32_t)data->async.next_rx_buffer,
+				       data->async.next_rx_buffer_len);
+
+	if (success != 0) {
+		LOG_ERR("Error %d reloading DMA with next RX buffer", success);
+	}
+	return success;
+}
+
+static void dma_callback(const struct device *dma_dev, void *callback_arg, uint32_t channel,
+			 int error_code)
+{
+	struct device *dev = (struct device *)callback_arg;
+	const struct mcux_lpuart_config *config = dev->config;
+	LPUART_Type *lpuart = config->base;
+	struct mcux_lpuart_data *data = (struct mcux_lpuart_data *)dev->data;
+
+	LOG_DBG("DMA call back on channel %d", channel);
+	struct dma_status status;
+	const int get_status_result = dma_get_status(dma_dev, channel, &status);
+
+	if (get_status_result < 0) {
+		LOG_ERR("error on status get: %d", get_status_result);
+	} else {
+		LOG_DBG("DMA Status: b: %d dir: %d len_remain: %d", status.busy, status.dir,
+			status.pending_length);
+	}
+
+	if (error_code != 0) {
+		LOG_ERR("Got error : %d", error_code);
+	}
+
+
+	if (channel == config->tx_dma_config.dma_channel) {
+		LOG_DBG("TX Channel");
+		LPUART_EnableTxDMA(lpuart, false);
+		async_evt_tx_done(dev);
+	} else if (channel == config->rx_dma_config.dma_channel) {
+		LOG_DBG("RX Channel");
+		struct mcux_lpuart_rx_dma_params *rx_dma_params = &data->async.rx_dma_params;
+
+		/* The RX Event indicates DMA transfer is complete and full buffer is available. */
+		rx_dma_params->counter = rx_dma_params->buf_len;
+
+		LOG_DBG("Current Buf (%x) full, swapping to new buf: %x",
+			(uint32_t)rx_dma_params->buf,
+			(uint32_t)data->async.next_rx_buffer);
+		async_evt_rx_rdy(dev);
+		async_evt_rx_buf_release(dev);
+
+		rx_dma_params->buf = data->async.next_rx_buffer;
+		rx_dma_params->buf_len = data->async.next_rx_buffer_len;
+		data->async.next_rx_buffer = NULL;
+		data->async.next_rx_buffer_len = 0U;
+
+		/* A new buffer was available (and already loaded into the DMA engine) */
+		if (rx_dma_params->buf != NULL &&
+		    rx_dma_params->buf_len > 0) {
+			/* Request the next buffer */
+			async_evt_rx_buf_request(dev);
+		} else {
+			/* Buffer full without valid next buffer, disable RX DMA */
+			LOG_INF("Disabled RX DMA, no valid next buffer ");
+			mcux_lpuart_rx_disable(dev);
+		}
+	} else {
+		LOG_ERR("Got unexpected DMA Channel: %d", channel);
+	}
+}
+
+static int mcux_lpuart_callback_set(const struct device *dev, uart_callback_t callback,
+				    void *user_data)
+{
+	struct mcux_lpuart_data *data = dev->data;
+
+	data->async.user_callback = callback;
+	data->async.user_data = user_data;
+
+	return 0;
+}
+
+static int mcux_lpuart_tx(const struct device *dev, const uint8_t *buf, size_t len,
+			  int32_t timeout_us)
+{
+	struct mcux_lpuart_data *data = dev->data;
+	const struct mcux_lpuart_config *config = dev->config;
+	LPUART_Type *lpuart = config->base;
+
+	int key = irq_lock();
+
+	/* Check for an ongiong transfer and abort if it is pending */
+	struct dma_status status;
+	const int get_status_result = dma_get_status(config->tx_dma_config.dma_dev,
+						     config->tx_dma_config.dma_channel,
+						     &status);
+
+	if (get_status_result < 0 || status.busy) {
+		irq_unlock(key);
+		LOG_ERR("Unable to submit UART DMA Transfer.");
+		return get_status_result < 0 ? get_status_result : -EBUSY;
+	}
+
+	int ret;
+
+	LPUART_EnableTxDMA(lpuart, false);
+
+	data->async.tx_dma_params.buf = buf;
+	data->async.tx_dma_params.buf_len = len;
+	data->async.tx_dma_params.active_dma_block.source_address = (uint32_t)buf;
+	data->async.tx_dma_params.active_dma_block.dest_address =
+		LPUART_GetDataRegisterAddress(lpuart);
+	data->async.tx_dma_params.active_dma_block.block_size = len;
+	data->async.tx_dma_params.active_dma_block.next_block = NULL;
+
+	ret = dma_config(config->tx_dma_config.dma_dev,
+			 config->tx_dma_config.dma_channel,
+			 (struct dma_config *)&config->tx_dma_config.dma_cfg);
+
+	if (ret == 0) {
+		LOG_DBG("Starting UART DMA TX Ch %u", config->tx_dma_config.dma_channel);
+
+		ret = dma_start(config->tx_dma_config.dma_dev,
+				config->tx_dma_config.dma_channel);
+		LPUART_EnableTxDMA(lpuart, true);
+		if (ret != 0) {
+			LOG_ERR("Failed to start DMA(Tx) Ch %d",
+				config->tx_dma_config.dma_channel);
+		}
+		async_timer_start(&data->async.tx_dma_params.timeout_work, timeout_us);
+	} else {
+		LOG_ERR("Error configuring UART DMA: %x", ret);
+	}
+	irq_unlock(key);
+	return ret;
+}
+
+static int mcux_lpuart_tx_abort(const struct device *dev)
+{
+	struct mcux_lpuart_data *data = dev->data;
+	const struct mcux_lpuart_config *config = dev->config;
+	LPUART_Type *lpuart = config->base;
+
+	LPUART_EnableTxDMA(lpuart, false);
+	(void)k_work_cancel_delayable(&data->async.tx_dma_params.timeout_work);
+	struct dma_status status;
+	const int get_status_result = dma_get_status(config->tx_dma_config.dma_dev,
+						     config->tx_dma_config.dma_channel,
+						     &status);
+
+	if (get_status_result < 0) {
+		LOG_ERR("Error querying TX DMA Status during abort.");
+	}
+
+	const size_t bytes_transmitted = (get_status_result == 0) ?
+			 data->async.tx_dma_params.buf_len - status.pending_length : 0;
+
+	const int ret = dma_stop(config->tx_dma_config.dma_dev, config->tx_dma_config.dma_channel);
+
+	if (ret == 0) {
+		struct uart_event tx_aborted_event = {
+			.type = UART_TX_ABORTED,
+			.data.tx.buf = data->async.tx_dma_params.buf,
+			.data.tx.len = bytes_transmitted
+		};
+		async_user_callback(dev, &tx_aborted_event);
+	}
+	return ret;
+}
+
+static int mcux_lpuart_rx_enable(const struct device *dev, uint8_t *buf, const size_t len,
+				 const int32_t timeout_us)
+{
+	LOG_DBG("Enabling UART RX DMA");
+	struct mcux_lpuart_data *data = dev->data;
+	const struct mcux_lpuart_config *config = dev->config;
+	LPUART_Type *lpuart = config->base;
+
+	struct mcux_lpuart_rx_dma_params *rx_dma_params = &data->async.rx_dma_params;
+
+	int key = irq_lock();
+	struct dma_status status;
+	const int get_status_result = dma_get_status(config->rx_dma_config.dma_dev,
+						     config->rx_dma_config.dma_channel,
+						     &status);
+
+	if (get_status_result < 0 || status.busy) {
+		LOG_ERR("Unable to start receive on UART.");
+		irq_unlock(key);
+		return get_status_result < 0 ? get_status_result : -EBUSY;
+	}
+
+	rx_dma_params->timeout_us = timeout_us;
+	rx_dma_params->buf = buf;
+	rx_dma_params->buf_len = len;
+
+	LPUART_EnableInterrupts(config->base, kLPUART_IdleLineInterruptEnable);
+	prepare_rx_dma_block_config(dev);
+	const int ret = configure_and_start_rx_dma(config, data, lpuart);
+
+	/* Request the next buffer for when this buffer is full for continuous reception */
+	async_evt_rx_buf_request(dev);
+
+	/* Clear these status flags as they can prevent the UART device from receiving data */
+	LPUART_ClearStatusFlags(config->base, kLPUART_RxOverrunFlag |
+					      kLPUART_ParityErrorFlag |
+					      kLPUART_FramingErrorFlag);
+	LPUART_EnableRx(lpuart, true);
+	irq_unlock(key);
+	return ret;
+}
+
+static int mcux_lpuart_rx_buf_rsp(const struct device *dev, uint8_t *buf, size_t len)
+{
+	struct mcux_lpuart_data *data = dev->data;
+
+	assert(data->async.next_rx_buffer == NULL);
+	assert(data->async.next_rx_buffer_len == 0);
+	data->async.next_rx_buffer = buf;
+	data->async.next_rx_buffer_len = len;
+	uart_mcux_lpuart_dma_replace_rx_buffer(dev);
+
+	return 0;
+}
+
+static void mcux_lpuart_async_rx_timeout(struct k_work *work)
+{
+	struct mcux_lpuart_rx_dma_params *rx_params = CONTAINER_OF(work,
+								   struct mcux_lpuart_rx_dma_params,
+								   timeout_work);
+	struct mcux_lpuart_async_data *async_data = CONTAINER_OF(rx_params,
+								 struct mcux_lpuart_async_data,
+								 rx_dma_params);
+	const struct device *dev = async_data->uart_dev;
+
+	LOG_DBG("RX timeout");
+	mcux_lpuart_async_rx_flush(dev);
+}
+
+static void mcux_lpuart_async_tx_timeout(struct k_work *work)
+{
+	struct mcux_lpuart_tx_dma_params *tx_params = CONTAINER_OF(work,
+								   struct mcux_lpuart_tx_dma_params,
+								   timeout_work);
+	struct mcux_lpuart_async_data *async_data = CONTAINER_OF(tx_params,
+								 struct mcux_lpuart_async_data,
+								 tx_dma_params);
+	const struct device *dev = async_data->uart_dev;
+
+	LOG_DBG("TX timeout");
+	(void)mcux_lpuart_tx_abort(dev);
+}
+
+#endif /* CONFIG_UART_ASYNC_API */
+
+static int mcux_lpuart_configure_init(const struct device *dev, const struct uart_config *cfg)
 {
 	const struct mcux_lpuart_config *config = dev->config;
 	struct mcux_lpuart_data *data = dev->data;
@@ -415,9 +943,28 @@ static int mcux_lpuart_configure_init(const struct device *dev,
 		return -ENOTSUP;
 	}
 #endif
+
 	uart_config.baudRate_Bps = cfg->baudrate;
 	uart_config.enableTx = true;
 	uart_config.enableRx = true;
+
+#ifdef CONFIG_UART_ASYNC_API
+	uart_config.rxIdleType = kLPUART_IdleTypeStopBit;
+	uart_config.rxIdleConfig = kLPUART_IdleCharacter1;
+	data->async.next_rx_buffer = NULL;
+	data->async.next_rx_buffer_len = 0;
+	data->async.uart_dev = dev;
+	k_work_init_delayable(&data->async.rx_dma_params.timeout_work,
+			      mcux_lpuart_async_rx_timeout);
+	k_work_init_delayable(&data->async.tx_dma_params.timeout_work,
+			      mcux_lpuart_async_tx_timeout);
+
+	/* Disable the UART Receiver until the async API provides a buffer to
+	 * to receive into with rx_enable
+	 */
+	uart_config.enableRx = false;
+
+#endif /* CONFIG_UART_ASYNC_API */
 
 	LPUART_Init(config->base, &uart_config, clock_freq);
 
@@ -488,6 +1035,9 @@ static int mcux_lpuart_init(const struct device *dev)
 	data->tx_poll_stream_on = false;
 	data->tx_int_stream_on = false;
 #endif
+#ifdef CONFIG_UART_ASYNC_API
+	config->async_config_func(dev);
+#endif
 
 	return 0;
 }
@@ -516,6 +1066,14 @@ static const struct uart_driver_api mcux_lpuart_driver_api = {
 	.irq_update = mcux_lpuart_irq_update,
 	.irq_callback_set = mcux_lpuart_irq_callback_set,
 #endif
+#ifdef CONFIG_UART_ASYNC_API
+	.callback_set = mcux_lpuart_callback_set,
+	.tx = mcux_lpuart_tx,
+	.tx_abort = mcux_lpuart_tx_abort,
+	.rx_enable = mcux_lpuart_rx_enable,
+	.rx_buf_rsp = mcux_lpuart_rx_buf_rsp,
+	.rx_disable = mcux_lpuart_rx_disable,
+#endif /* CONFIG_UART_ASYNC_API */
 };
 
 
@@ -542,6 +1100,78 @@ static const struct uart_driver_api mcux_lpuart_driver_api = {
 #define MCUX_LPUART_IRQ_DEFINE(n)
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 
+#ifdef CONFIG_UART_ASYNC_API
+#define TX_DMA_CONFIG(id)								       \
+	.tx_dma_config = {								       \
+		.dma_dev =								       \
+			DEVICE_DT_GET(DT_INST_DMAS_CTLR_BY_NAME(id, tx)),		       \
+		.dma_channel =								       \
+			DT_INST_DMAS_CELL_BY_NAME(id, tx, mux),				       \
+		.dma_cfg = {								       \
+			.source_burst_length = 1,					       \
+			.dest_burst_length = 1,						       \
+			.source_data_size = 1,						       \
+			.dest_data_size = 1,						       \
+			.complete_callback_en = 1,					       \
+			.error_callback_en = 1,						       \
+			.block_count = 1,						       \
+			.head_block =							       \
+				&mcux_lpuart_##id##_data.async.tx_dma_params.active_dma_block, \
+			.channel_direction = MEMORY_TO_PERIPHERAL,			       \
+			.dma_slot = DT_INST_DMAS_CELL_BY_NAME(				       \
+				id, tx, source),					       \
+			.dma_callback = dma_callback,					       \
+			.user_data = (void *)DEVICE_DT_INST_GET(id)			       \
+		},									       \
+	},
+#define RX_DMA_CONFIG(id)								       \
+	.rx_dma_config = {								       \
+		.dma_dev =								       \
+			DEVICE_DT_GET(DT_INST_DMAS_CTLR_BY_NAME(id, rx)),		       \
+		.dma_channel =								       \
+			DT_INST_DMAS_CELL_BY_NAME(id, rx, mux),				       \
+		.dma_cfg = {								       \
+			.source_burst_length = 1,					       \
+			.dest_burst_length = 1,						       \
+			.source_data_size = 1,						       \
+			.dest_data_size = 1,						       \
+			.complete_callback_en = 1,					       \
+			.error_callback_en = 1,						       \
+			.block_count = 1,						       \
+			.head_block =							       \
+				&mcux_lpuart_##id##_data.async.rx_dma_params.active_dma_block, \
+			.channel_direction = PERIPHERAL_TO_MEMORY,			       \
+			.dma_slot = DT_INST_DMAS_CELL_BY_NAME(				       \
+				id, rx, source),					       \
+			.dma_callback = dma_callback,					       \
+			.user_data = (void *)DEVICE_DT_INST_GET(id)			       \
+		},									       \
+	},
+#define MCUX_LPUART_ASYNC_IRQ_INSTALL(n, i)				      \
+	do {								      \
+		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(n, i, irq),		      \
+			    DT_INST_IRQ_BY_IDX(n, i, priority),		      \
+			    mcux_lpuart_async_isr, DEVICE_DT_INST_GET(n), 0); \
+									      \
+		irq_enable(DT_INST_IRQ_BY_IDX(n, i, irq));		      \
+	} while (0)
+#define MCUX_LPUART_ASYNC_IRQ_DEFINE(n)					\
+	static void mcux_lpuart_async_config_func_##n(const struct device *dev)	\
+	{									\
+		MCUX_LPUART_ASYNC_IRQ_INSTALL(n, 0);				\
+										\
+		IF_ENABLED(DT_INST_IRQ_HAS_IDX(n, 1),			        \
+			   (MCUX_LPUART_ASYNC_IRQ_INSTALL(n, 1);))		\
+	}
+#define MCUX_LPUART_ASYNC_IRQ_INIT(n) \
+	.async_config_func = mcux_lpuart_async_config_func_##n,
+
+#else
+#define RX_DMA_CONFIG(n)
+#define TX_DMA_CONFIG(n)
+#define MCUX_LPUART_ASYNC_IRQ_INIT(n)
+#define MCUX_LPUART_ASYNC_IRQ_DEFINE(n)
+#endif /* CONFIG_UART_ASYNC_API */
 
 #if CONFIG_PINCTRL
 #define PINCTRL_DEFINE(n) PINCTRL_DT_INST_DEFINE(n);
@@ -561,6 +1191,9 @@ static const struct mcux_lpuart_config mcux_lpuart_##n##_config = {		\
 		UART_CFG_FLOW_CTRL_RTS_CTS : UART_CFG_FLOW_CTRL_NONE,		\
 	PINCTRL_INIT(n)								\
 	MCUX_LPUART_IRQ_INIT(n)							\
+	MCUX_LPUART_ASYNC_IRQ_INIT(n)						\
+	RX_DMA_CONFIG(n)							\
+	TX_DMA_CONFIG(n)							\
 };
 
 #define LPUART_MCUX_INIT(n)						\
@@ -569,6 +1202,7 @@ static const struct mcux_lpuart_config mcux_lpuart_##n##_config = {		\
 									\
 	PINCTRL_DEFINE(n)						\
 	MCUX_LPUART_IRQ_DEFINE(n)					\
+	MCUX_LPUART_ASYNC_IRQ_DEFINE(n)					\
 									\
 	LPUART_MCUX_DECLARE_CFG(n)					\
 									\

--- a/dts/arm/nxp/nxp_rt.dtsi
+++ b/dts/arm/nxp/nxp_rt.dtsi
@@ -22,6 +22,7 @@
 		cpu0: cpu@0 {
 			device_type = "cpu";
 			compatible = "arm,cortex-m7";
+			d-cache-line-size = <32>;
 			reg = <0>;
 			#address-cells = <1>;
 			#size-cells = <1>;


### PR DESCRIPTION
This PR enables the Ansynchronous UART API for using the MCUX drivers.
It is tested on the RT1062EVKB. In order to make this functionality
possible, the MCUX EDMA driver is also exteneded to enable the
dma_reload functionality.

Signed-off-by: Nickolas Lapp <nickolaslapp@gmail.com>