### PR TITLE
drivers: esp32: Enable watchdog in wdt_setup

### DIFF
--- a/drivers/watchdog/wdt_esp32.c
+++ b/drivers/watchdog/wdt_esp32.c
@@ -181,6 +181,9 @@ static int wdt_esp32_set_config(const struct device *dev, uint8_t options)
 		return -EINVAL;
 	}
 
+	/* Enable the watchdog */
+	v |= BIT(TIMG_WDT_EN_S)	
+	
 	wdt_esp32_unseal(dev);
 	DEV_BASE(dev)->config0 = v;
 	adjust_timeout(dev, data->timeout);


### PR DESCRIPTION
This corrects ESP32's watchdog initialization:
Watchdog was only enabled once in `wdt_esp32_init` which makes impossible to reuse it after disabled by `wdt_disable`.
This fix enables watchdog also in `wdt_setup` thus enabling its reuse even after `wdt_disable`.