### PR TITLE
drivers: sensor: iis3dhhc: convert to spi_dt_spec

### DIFF
--- a/drivers/sensor/iis3dhhc/iis3dhhc.c
+++ b/drivers/sensor/iis3dhhc/iis3dhhc.c
@@ -235,18 +235,8 @@ static const struct iis3dhhc_config iis3dhhc_config = {
 #endif /* CONFIG_IIS3DHHC_TRIGGER */
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
 	.bus_init = iis3dhhc_spi_init,
-	.spi_conf.frequency = DT_INST_PROP(0, spi_max_frequency),
-	.spi_conf.operation = (SPI_OP_MODE_MASTER | SPI_MODE_CPOL |
-			       SPI_MODE_CPHA | SPI_WORD_SET(8)),
-	.spi_conf.slave     = DT_INST_REG_ADDR(0),
-#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
-	.gpio_cs_port	    = DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
-	.cs_gpio	    = DT_INST_SPI_DEV_CS_GPIOS_PIN(0),
-
-	.spi_conf.cs        =  &iis3dhhc_data.cs_ctrl,
-#else
-	.spi_conf.cs        = NULL,
-#endif
+	.spi = SPI_DT_SPEC_INST_GET(0, SPI_OP_MODE_MASTER | SPI_MODE_CPOL |
+			       SPI_MODE_CPHA | SPI_WORD_SET(8), 0U),
 #else
 #error "BUS MACRO NOT DEFINED IN DTS"
 #endif

--- a/drivers/sensor/iis3dhhc/iis3dhhc.h
+++ b/drivers/sensor/iis3dhhc/iis3dhhc.h
@@ -28,23 +28,18 @@ struct iis3dhhc_config {
 	uint8_t int_flags;
 #endif
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
-	struct spi_config spi_conf;
-#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
-	const char *gpio_cs_port;
-	uint8_t cs_gpio;
-#endif
+	struct spi_dt_spec spi;
 #endif
 };
 
 struct iis3dhhc_data {
 	const struct device *bus;
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
+	const struct spi_dt_spec *spi;
+#endif
 	int16_t acc[3];
 
 	stmdev_ctx_t *ctx;
-
-#if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
-	stmdev_ctx_t ctx_spi;
-#endif
 
 #ifdef CONFIG_IIS3DHHC_TRIGGER
 	const struct device *gpio;
@@ -63,9 +58,6 @@ struct iis3dhhc_data {
 #endif
 
 #endif /* CONFIG_IIS3DHHC_TRIGGER */
-#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
-	struct spi_cs_control cs_ctrl;
-#endif
 };
 
 int iis3dhhc_spi_init(const struct device *dev);

--- a/drivers/sensor/iis3dhhc/iis3dhhc_spi.c
+++ b/drivers/sensor/iis3dhhc/iis3dhhc_spi.c
@@ -20,18 +20,9 @@
 
 LOG_MODULE_DECLARE(IIS3DHHC, CONFIG_SENSOR_LOG_LEVEL);
 
-static struct spi_config iis3dhhc_spi_conf = {
-	.frequency = DT_INST_PROP(0, spi_max_frequency),
-	.operation = (SPI_OP_MODE_MASTER | SPI_MODE_CPOL |
-		      SPI_MODE_CPHA | SPI_WORD_SET(8)),
-	.slave     = DT_INST_REG_ADDR(0),
-	.cs        = NULL,
-};
-
 static int iis3dhhc_spi_read(struct iis3dhhc_data *ctx, uint8_t reg,
 			    uint8_t *data, uint16_t len)
 {
-	struct spi_config *spi_cfg = &iis3dhhc_spi_conf;
 	uint8_t buffer_tx[2] = { reg | IIS3DHHC_SPI_READ, 0 };
 	const struct spi_buf tx_buf = {
 			.buf = buffer_tx,
@@ -56,7 +47,7 @@ static int iis3dhhc_spi_read(struct iis3dhhc_data *ctx, uint8_t reg,
 		.count = 2
 	};
 
-	if (spi_transceive(ctx->bus, spi_cfg, &tx, &rx)) {
+	if (spi_transceive_dt(ctx->spi, &tx, &rx)) {
 		return -EIO;
 	}
 
@@ -66,7 +57,6 @@ static int iis3dhhc_spi_read(struct iis3dhhc_data *ctx, uint8_t reg,
 static int iis3dhhc_spi_write(struct iis3dhhc_data *ctx, uint8_t reg,
 			     uint8_t *data, uint16_t len)
 {
-	struct spi_config *spi_cfg = &iis3dhhc_spi_conf;
 	uint8_t buffer_tx[1] = { reg & ~IIS3DHHC_SPI_READ };
 	const struct spi_buf tx_buf[2] = {
 		{
@@ -84,7 +74,7 @@ static int iis3dhhc_spi_write(struct iis3dhhc_data *ctx, uint8_t reg,
 	};
 
 
-	if (spi_write(ctx->bus, spi_cfg, &tx)) {
+	if (spi_write_dt(ctx->spi, &tx)) {
 		return -EIO;
 	}
 
@@ -99,29 +89,16 @@ stmdev_ctx_t iis3dhhc_spi_ctx = {
 int iis3dhhc_spi_init(const struct device *dev)
 {
 	struct iis3dhhc_data *data = dev->data;
+	const struct iis3dhhc_config *config = dev->config;
+
+	if (!spi_is_ready(&config->spi)) {
+		LOG_ERR("SPI bus is not ready");
+		return -ENODEV;
+	};
 
 	data->ctx = &iis3dhhc_spi_ctx;
 	data->ctx->handle = data;
-
-#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
-	/* handle SPI CS thru GPIO if it is the case */
-	data->cs_ctrl.gpio_dev = device_get_binding(
-		DT_INST_SPI_DEV_CS_GPIOS_LABEL(0));
-	if (!data->cs_ctrl.gpio_dev) {
-		LOG_ERR("Unable to get GPIO SPI CS device");
-		return -ENODEV;
-	}
-
-	data->cs_ctrl.gpio_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0);
-	data->cs_ctrl.gpio_dt_flags = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0);
-	data->cs_ctrl.delay = 0U;
-
-	iis3dhhc_spi_conf.cs = &data->cs_ctrl;
-
-	LOG_DBG("SPI GPIO CS configured on %s:%u",
-		    DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
-		    DT_INST_SPI_DEV_CS_GPIOS_PIN(0));
-#endif
+	data->spi = &config->spi;
 
 	return 0;
 }


### PR DESCRIPTION
Convert icm42605 driver to use spi_dt_spec helpers.

Signed-off-by: Bartosz Bilas <bartosz.bilas@hotmail.com>