### PR TITLE
bluetooth: ots: UTF-8 truncation of object name

### DIFF
--- a/subsys/bluetooth/services/ots/Kconfig
+++ b/subsys/bluetooth/services/ots/Kconfig
@@ -9,6 +9,7 @@ config BT_OTS
 	select BT_GATT_DYNAMIC_DB
 	select BT_SMP
 	select EXPERIMENTAL
+	select UTF8
 	help
 	  Enable Object Transfer Service.
 

--- a/subsys/bluetooth/services/ots/ots.c
+++ b/subsys/bluetooth/services/ots/ots.c
@@ -174,9 +174,10 @@ ssize_t ots_obj_name_write(struct bt_conn *conn,
 		return BT_GATT_ERR(BT_GATT_OTS_WRITE_REQUEST_REJECTED);
 	}
 
-	/* Construct a temporary name for duplication detection */
+	/* Construct a valid UTF-8 temporary name for duplication detection */
 	memcpy(name, buf, len);
 	name[len] = '\0';
+	utf8_trunc(name);
 
 	rc = bt_gatt_ots_obj_manager_first_obj_get(ots->obj_manager, &obj);
 	while (rc == 0) {


### PR DESCRIPTION
The OTS object names are UTF-8 encoded strings. Using the utf8_trunc
function ensures the name is properly truncated.

Signed-off-by: Abe Kohandel <abe.kohandel@gmail.com>