### PR TITLE
doc: requirements: disallow breathe 4.33.0

### DIFF
--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -1,6 +1,6 @@
 # DOC: used to generate docs
 
-breathe>=4.30
+breathe>=4.30,!=4.33
 sphinx~=4.0
 sphinx_rtd_theme~=1.0
 sphinx-tabs


### PR DESCRIPTION
Sphinx 4.33.0 introduces Graphviz support, but the Graphviz
configuration value names clash with the Sphinx built-in Graphviz
extension.

Issue: https://github.com/michaeljones/breathe/issues/803