### PR TITLE
mgmt: mcumgr: fs: Add checksum (CRC32), hash (SHA256) and file size handlers

### DIFF
--- a/doc/releases/release-notes-3.1.rst
+++ b/doc/releases/release-notes-3.1.rst
@@ -192,6 +192,21 @@ Libraries / Subsystems
   * Added support for MCUMGR Parameters command, which can be used to obtain
     MCUMGR parameters; :kconfig:option:`CONFIG_OS_MGMT_MCUMGR_PARAMS` enables
     the command.
+  * Added mcumgr fs handler for getting file status which returns file size;
+    controlled with :kconfig:option:`CONFIG_FS_MGMT_FILE_STATUS`
+  * Added mcumgr fs handler for getting file hash/checksum, with support for
+    IEEE CRC32 and SHA256, the following Kconfig options have been added to
+    control the addition:
+
+    * :kconfig:option:`CONFIG_FS_MGMT_CHECKSUM_HASH` to enable the command;
+    * :kconfig:option:`CONFIG_FS_MGMT_CHECKSUM_HASH_CHUNK_SIZE` that sets size
+      of buffer (stack memory) used for calculation:
+
+      * :kconfig:option:`CONFIG_FS_MGMT_CHECKSUM_IEEE_CRC32` enables support for
+        IEEE CRC32.
+      * :kconfig:option:`CONFIG_FS_MGMT_HASH_SHA256` enables SHA256 hash support.
+      * When hash/checksum query to mcumgr does not specify a type, then the order
+        of preference (most priority) is CRC32 followed by SHA256.
 
 HALs
 ****

--- a/subsys/mgmt/mcumgr/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/CMakeLists.txt
@@ -15,5 +15,10 @@ zephyr_library_link_libraries(MCUMGR)
 
 if (CONFIG_MCUMGR_SMP_SHELL OR CONFIG_MCUMGR_SMP_UART)
     zephyr_library_sources(serial_util.c)
+endif()
 
-endif ()
+if (CONFIG_FS_MGMT_CHECKSUM_HASH AND CONFIG_FS_MGMT_HASH_SHA256)
+    if (NOT CONFIG_TINYCRYPT)
+        zephyr_link_libraries(mbedTLS)
+    endif()
+endif()

--- a/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/CMakeLists.txt
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2018-2021 mcumgr authors
+# Copyright (c) 2022 Laird Connectivity
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -10,3 +11,7 @@ zephyr_library_sources(
 	src/zephyr_fs_mgmt.c
 	src/fs_mgmt.c
 )
+
+zephyr_library_sources_ifdef(CONFIG_FS_MGMT_CHECKSUM_HASH src/hash_checksum_mgmt.c)
+zephyr_library_sources_ifdef(CONFIG_FS_MGMT_CHECKSUM_IEEE_CRC32 src/hash_checksum_crc32.c)
+zephyr_library_sources_ifdef(CONFIG_FS_MGMT_HASH_SHA256 src/hash_checksum_sha256.c)

--- a/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/Kconfig
@@ -96,6 +96,38 @@ config FS_MGMT_FILE_STATUS
 	  This command allows a remote device to retrieve the status of a file,
 	  at present only the size of the file is returned (if it exists).
 
+config FS_MGMT_CHECKSUM_HASH
+	bool "Checksum/hash mcumgr functions"
+	help
+	  Enable this to support the hash/checksum mcumgr functionality,
+	  individual checksum and hash types need to be enabled below.
+	  Note that this requires enough stack space to buffer data
+	  from the file being read and generate the output hash/checksum.
+
+if FS_MGMT_CHECKSUM_HASH
+
+config FS_MGMT_CHECKSUM_HASH_CHUNK_SIZE
+	int "Checksum calculation buffer size"
+	range 32 16384
+	default 128
+	help
+	  Chunk size of buffer to use when calculating file checksum or hash
+	  (uses stack).
+
+config FS_MGMT_CHECKSUM_IEEE_CRC32
+	bool "IEEE CRC32 checksum support"
+	default y
+	help
+	  Enable IEEE CRC32 checksum support for mcumgr.
+
+config FS_MGMT_HASH_SHA256
+	bool "SHA256 hash support"
+	depends on TINYCRYPT_SHA256 || MBEDTLS_MAC_SHA256_ENABLED
+	help
+	  Enable SHA256 hash support for mcumgr.
+
+endif
+
 config FS_MGMT_PATH_SIZE
 	int "Maximum file path length"
 	default 64

--- a/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/Kconfig
@@ -89,6 +89,13 @@ config FS_MGMT_DL_CHUNK_SIZE
 
 endif
 
+config FS_MGMT_FILE_STATUS
+	bool "File status command"
+	default y
+	help
+	  This command allows a remote device to retrieve the status of a file,
+	  at present only the size of the file is returned (if it exists).
+
 config FS_MGMT_PATH_SIZE
 	int "Maximum file path length"
 	default 64
@@ -96,4 +103,5 @@ config FS_MGMT_PATH_SIZE
 	  Limits the maximum path length for file operations, in bytes.  A buffer
 	  of this size gets allocated on the stack during handling of file upload
 	  and download commands.
+
 endif

--- a/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/include/fs_mgmt/fs_mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/include/fs_mgmt/fs_mgmt.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 mcumgr authors
+ * Copyright (c) 2018-2022 mcumgr authors
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -14,8 +14,9 @@ extern "C" {
 /**
  * Command IDs for file system management group.
  */
-#define FS_MGMT_ID_FILE		 0
-#define FS_MGMT_ID_STAT		 1
+#define FS_MGMT_ID_FILE			 0
+#define FS_MGMT_ID_STAT			 1
+#define FS_MGMT_ID_HASH_CHECKSUM	 2
 
 /**
  * @brief Registers the file system management command handler group.

--- a/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/include/fs_mgmt/fs_mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/include/fs_mgmt/fs_mgmt.h
@@ -14,7 +14,8 @@ extern "C" {
 /**
  * Command IDs for file system management group.
  */
-#define FS_MGMT_ID_FILE	 0
+#define FS_MGMT_ID_FILE		 0
+#define FS_MGMT_ID_STAT		 1
 
 /**
  * @brief Registers the file system management command handler group.

--- a/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/include/fs_mgmt/hash_checksum_crc32.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/include/fs_mgmt/hash_checksum_crc32.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022 Laird Connectivity
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef H_HASH_CHECKSUM_CRC32_
+#define H_HASH_CHECKSUM_CRC32_
+
+#include <zephyr.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Registers the IEEE CRC32 checksum mcumgr handler.
+ */
+void fs_hash_checksum_mgmt_register_crc32(void);
+
+/**
+ * @brief Un-registers the IEEE CRC32 checksum mcumgr handler.
+ */
+void fs_hash_checksum_mgmt_unregister_crc32(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/include/fs_mgmt/hash_checksum_mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/include/fs_mgmt/hash_checksum_mgmt.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2018-2022 mcumgr authors
+ * Copyright (c) 2022 Laird Connectivity
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef H_HASH_CHECKSUM_MGMT_
+#define H_HASH_CHECKSUM_MGMT_
+
+#include <zephyr.h>
+#include <fs/fs.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @typedef hash_checksum_mgmt_handler_fn
+ * @brief Function that gets called to generate a hash or checksum.
+ *
+ * @param file		Opened file context
+ * @param output	Output buffer for hash/checksum
+ * @param out_len	Updated with size of input data
+ * @param len		Maximum length of data to perform hash/checksum on
+ *
+ * @return 0 on success, negative error code on failure.
+ */
+typedef int (*hash_checksum_mgmt_handler_fn)(struct fs_file_t *file,
+					     uint8_t *output, uint32_t *out_len,
+					     size_t len);
+
+/**
+ * @brief A collection of handlers for an entire hash/checksum group.
+ */
+struct hash_checksum_mgmt_group {
+	/** Entry list node. */
+	sys_snode_t node;
+
+	/** Array of handlers; one entry per name. */
+	const char *group_name;
+
+	/** Byte string or numerical output. */
+	bool byte_string;
+
+	/** Size (in bytes) of output. */
+	uint8_t output_size;
+
+	/** Hash/checksum function pointer. */
+	hash_checksum_mgmt_handler_fn function;
+};
+
+/**
+ * @brief Registers a full hash/checksum group.
+ *
+ * @param group The group to register.
+ */
+void hash_checksum_mgmt_register_group(struct hash_checksum_mgmt_group *group);
+
+/**
+ * @brief Unregisters a full hash/checksum group.
+ *
+ * @param group The group to register.
+ */
+void hash_checksum_mgmt_unregister_group(struct hash_checksum_mgmt_group *group);
+
+/**
+ * @brief Finds a registered hash/checksum handler.
+ *
+ * @param name	The name of the hash/checksum group to find.
+ *
+ * @return	The requested hash/checksum handler on success;
+ *		NULL on failure.
+ */
+const struct hash_checksum_mgmt_group *hash_checksum_mgmt_find_handler(const char *name);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/include/fs_mgmt/hash_checksum_sha256.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/include/fs_mgmt/hash_checksum_sha256.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022 Laird Connectivity
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef H_HASH_CHECKSUM_SHA256_
+#define H_HASH_CHECKSUM_SHA256_
+
+#include <zephyr.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Registers the SHA256 hash mcumgr handler.
+ */
+void fs_hash_checksum_mgmt_register_sha256(void);
+
+/**
+ * @brief Un-registers the SHA256 hash mcumgr handler.
+ */
+void fs_hash_checksum_mgmt_unregister_sha256(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/src/fs_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/src/fs_mgmt.c
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <assert.h>
+#include <zephyr.h>
 #include <limits.h>
 #include <string.h>
 #include <sys/util.h>
@@ -13,10 +15,45 @@
 #include <zcbor_encode.h>
 #include "zcbor_bulk/zcbor_bulk_priv.h"
 #include <mgmt/mcumgr/buf.h>
+#include <fs/fs.h>
 #include "mgmt/mgmt.h"
 #include "fs_mgmt/fs_mgmt.h"
 #include "fs_mgmt/fs_mgmt_impl.h"
 #include "fs_mgmt/fs_mgmt_config.h"
+#include "fs_mgmt/hash_checksum_mgmt.h"
+
+#if defined(CONFIG_FS_MGMT_CHECKSUM_IEEE_CRC32)
+#include "fs_mgmt/hash_checksum_crc32.h"
+#endif
+
+#if defined(CONFIG_FS_MGMT_HASH_SHA256)
+#include "fs_mgmt/hash_checksum_sha256.h"
+#endif
+
+
+#ifdef CONFIG_FS_MGMT_CHECKSUM_HASH
+/* Define default hash/checksum */
+#if defined(CONFIG_FS_MGMT_CHECKSUM_IEEE_CRC32)
+#define FS_MGMT_CHECKSUM_HASH_DEFAULT "crc32"
+#elif defined(CONFIG_FS_MGMT_HASH_SHA256)
+#define FS_MGMT_CHECKSUM_HASH_DEFAULT "sha256"
+#else
+#error "Missing mcumgr fs checksum/hash algorithm selection?"
+#endif
+
+/* Define largest hach/checksum output size (bytes) */
+#if defined(CONFIG_FS_MGMT_HASH_SHA256)
+#define FS_MGMT_CHECKSUM_HASH_LARGEST_OUTPUT_SIZE 32
+#elif defined(CONFIG_FS_MGMT_CHECKSUM_IEEE_CRC32)
+#define FS_MGMT_CHECKSUM_HASH_LARGEST_OUTPUT_SIZE 4
+#endif
+#endif
+
+#define LOG_LEVEL CONFIG_MCUMGR_LOG_LEVEL
+#include <logging/log.h>
+LOG_MODULE_REGISTER(fs_mgmt);
+
+#define HASH_CHECKSUM_TYPE_SIZE 8
 
 static struct {
 	/** Whether an upload is currently in progress. */
@@ -241,6 +278,147 @@ fs_mgmt_file_status(struct mgmt_ctxt *ctxt)
 }
 #endif
 
+#if defined(CONFIG_FS_MGMT_CHECKSUM_HASH)
+/**
+ * Command handler: fs hash/checksum (read)
+ */
+static int
+fs_mgmt_file_hash_checksum(struct mgmt_ctxt *ctxt)
+{
+	char path[CONFIG_FS_MGMT_PATH_SIZE + 1];
+	char type_arr[HASH_CHECKSUM_TYPE_SIZE + 1] = FS_MGMT_CHECKSUM_HASH_DEFAULT;
+	char output[FS_MGMT_CHECKSUM_HASH_LARGEST_OUTPUT_SIZE];
+	uint64_t len = ULLONG_MAX;
+	uint64_t off = 0;
+	size_t file_len;
+	int rc;
+	zcbor_state_t *zse = ctxt->cnbe->zs;
+	zcbor_state_t *zsd = ctxt->cnbd->zs;
+	bool ok;
+	struct zcbor_string type = { 0 };
+	struct zcbor_string name = { 0 };
+	size_t decoded;
+	struct fs_file_t file;
+	const struct hash_checksum_mgmt_group *group = NULL;
+
+	struct zcbor_map_decode_key_val fs_hash_checksum_decode[] = {
+		ZCBOR_MAP_DECODE_KEY_VAL(type, zcbor_tstr_decode, &type),
+		ZCBOR_MAP_DECODE_KEY_VAL(name, zcbor_tstr_decode, &name),
+		ZCBOR_MAP_DECODE_KEY_VAL(off, zcbor_uint64_decode, &off),
+		ZCBOR_MAP_DECODE_KEY_VAL(len, zcbor_uint64_decode, &len),
+	};
+
+	ok = zcbor_map_decode_bulk(zsd, fs_hash_checksum_decode,
+		ARRAY_SIZE(fs_hash_checksum_decode), &decoded) == 0;
+
+	if (!ok || name.len == 0 || name.len > (sizeof(path) - 1) ||
+	    type.len > (sizeof(type_arr) - 1) || len == 0) {
+		return MGMT_ERR_EINVAL;
+	}
+
+	/* Copy strings and ensure they are null-teminated */
+	memcpy(path, name.value, name.len);
+	path[name.len] = '\0';
+
+	if (type.len != 0) {
+		memcpy(type_arr, type.value, type.len);
+		type_arr[type.len] = '\0';
+	}
+
+	/* Search for supported hash/checksum */
+	group = hash_checksum_mgmt_find_handler(type_arr);
+
+	if (group == NULL) {
+		return MGMT_ERR_EINVAL;
+	}
+
+	/* Check provided offset is valid for target file */
+	rc = fs_mgmt_impl_filelen(path, &file_len);
+
+	if (rc != 0) {
+		return MGMT_ERR_ENOENT;
+	}
+
+	if (file_len <= off) {
+		/* Requested offset is larger than target file size */
+		return MGMT_ERR_EINVAL;
+	}
+
+	/* Open file for reading and pass to hash/checksum generation function */
+	fs_file_t_init(&file);
+	rc = fs_open(&file, path, FS_O_READ);
+
+	if (rc != 0) {
+		return MGMT_ERR_ENOENT;
+	}
+
+	/* Seek to file's desired offset, if parameter was provided */
+	if (off != 0) {
+		rc = fs_seek(&file, off, FS_SEEK_SET);
+
+		if (rc != 0) {
+			fs_close(&file);
+			return MGMT_ERR_EINVAL;
+		}
+	}
+
+	/* Calculate hash/checksum using function */
+	file_len = 0;
+	rc = group->function(&file, output, &file_len, len);
+
+	fs_close(&file);
+
+	/* Encode the response */
+	if (rc != 0) {
+		ok = zcbor_tstr_put_lit(zse, "rc")	&&
+		     zcbor_int32_put(zse, rc);
+	} else {
+		ok = zcbor_tstr_put_lit(zse, "type")	&&
+		     zcbor_tstr_put_term(zse, type_arr);
+
+		if (off != 0) {
+			ok &= zcbor_tstr_put_lit(zse, "off")	&&
+			      zcbor_uint64_put(zse, off);
+		}
+
+		ok &= zcbor_tstr_put_lit(zse, "len")	&&
+		      zcbor_uint64_put(zse, file_len)	&&
+		      zcbor_tstr_put_lit(zse, "output");
+
+		if (group->byte_string == true) {
+			/* Output is a byte string */
+			ok &= zcbor_bstr_encode_ptr(zse, output, group->output_size);
+		} else {
+			/* Output is a number */
+			uint64_t tmp_val = 0;
+
+			if (group->output_size == sizeof(uint8_t)) {
+				tmp_val = (uint64_t)(*(uint8_t *)output);
+			} else if (group->output_size == sizeof(uint16_t)) {
+				tmp_val = (uint64_t)(*(uint16_t *)output);
+			} else if (group->output_size == sizeof(uint32_t)) {
+				tmp_val = (uint64_t)(*(uint32_t *)output);
+			} else if (group->output_size == sizeof(uint64_t)) {
+				tmp_val = (*(uint64_t *)output);
+			} else {
+				LOG_ERR("Unable to handle numerical checksum size %u",
+					group->output_size);
+
+				return MGMT_ERR_EUNKNOWN;
+			}
+
+			ok &= zcbor_uint64_put(zse, tmp_val);
+		}
+	}
+
+	if (!ok) {
+		return MGMT_ERR_ENOMEM;
+	}
+
+	return MGMT_ERR_EOK;
+}
+#endif
+
 static const struct mgmt_handler fs_mgmt_handlers[] = {
 	[FS_MGMT_ID_FILE] = {
 		.mh_read = fs_mgmt_file_download,
@@ -249,6 +427,12 @@ static const struct mgmt_handler fs_mgmt_handlers[] = {
 #if defined(CONFIG_FS_MGMT_FILE_STATUS)
 	[FS_MGMT_ID_STAT] = {
 		.mh_read = fs_mgmt_file_status,
+		.mh_write = NULL,
+	},
+#endif
+#if defined(CONFIG_FS_MGMT_CHECKSUM_HASH)
+	[FS_MGMT_ID_HASH_CHECKSUM] = {
+		.mh_read = fs_mgmt_file_hash_checksum,
 		.mh_write = NULL,
 	},
 #endif
@@ -266,4 +450,15 @@ void
 fs_mgmt_register_group(void)
 {
 	mgmt_register_group(&fs_mgmt_group);
+
+#if defined(CONFIG_FS_MGMT_CHECKSUM_HASH)
+	/* Register any supported hash or checksum functions */
+#if defined(CONFIG_FS_MGMT_CHECKSUM_IEEE_CRC32)
+	fs_hash_checksum_mgmt_register_crc32();
+#endif
+
+#if defined(CONFIG_FS_MGMT_HASH_SHA256)
+	fs_hash_checksum_mgmt_register_sha256();
+#endif
+#endif
 }

--- a/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/src/hash_checksum_crc32.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/src/hash_checksum_crc32.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2022 Laird Connectivity
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <string.h>
+#include <sys/crc.h>
+#include <fs/fs.h>
+#include <mgmt/mgmt.h>
+#include <fs_mgmt/fs_mgmt_config.h>
+#include <fs_mgmt/fs_mgmt_impl.h>
+#include "fs_mgmt/hash_checksum_mgmt.h"
+#include "fs_mgmt/hash_checksum_crc32.h"
+
+#define CRC32_SIZE 4
+
+static int fs_hash_checksum_mgmt_crc32(struct fs_file_t *file, uint8_t *output,
+				       size_t *out_len, size_t len)
+{
+	/* Calculate IEEE CRC32 checksum of target file */
+	uint8_t buffer[CONFIG_FS_MGMT_CHECKSUM_HASH_CHUNK_SIZE];
+	ssize_t bytes_read = 0;
+	size_t read_size = CONFIG_FS_MGMT_CHECKSUM_HASH_CHUNK_SIZE;
+	uint32_t crc32 = 0;
+
+	/* Clear length prior to calculation */
+	*out_len = 0;
+
+	do {
+		if ((read_size + *out_len) >= len) {
+			/* Limit read size to size of requested data */
+			read_size = len - *out_len;
+		}
+
+		bytes_read = fs_read(file, buffer, read_size);
+
+		if (bytes_read < 0) {
+			/* Failed to read file data, pass generic unknown error back */
+			return MGMT_ERR_EUNKNOWN;
+		} else if (bytes_read > 0) {
+			crc32 = crc32_ieee_update(crc32, buffer, bytes_read);
+			*out_len += bytes_read;
+		}
+	} while (bytes_read > 0 && *out_len < len);
+
+	memcpy(output, &crc32, sizeof(crc32));
+
+	return 0;
+}
+
+struct hash_checksum_mgmt_group crc32 = {
+	.group_name = "crc32",
+	.byte_string = false,
+	.output_size = CRC32_SIZE,
+	.function = fs_hash_checksum_mgmt_crc32,
+};
+
+void fs_hash_checksum_mgmt_register_crc32(void)
+{
+	hash_checksum_mgmt_register_group(&crc32);
+}
+
+void fs_hash_checksum_mgmt_unregister_crc32(void)
+{
+	hash_checksum_mgmt_unregister_group(&crc32);
+}

--- a/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/src/hash_checksum_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/src/hash_checksum_mgmt.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022 Laird Connectivity
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <string.h>
+#include "mgmt/mgmt.h"
+#include "fs_mgmt/hash_checksum_mgmt.h"
+
+static sys_slist_t hash_checksum_mgmt_group_list =
+	SYS_SLIST_STATIC_INIT(&hash_checksum_mgmt_group_list);
+
+void hash_checksum_mgmt_unregister_group(struct hash_checksum_mgmt_group *group)
+{
+	(void)sys_slist_find_and_remove(&hash_checksum_mgmt_group_list, &group->node);
+}
+
+void hash_checksum_mgmt_register_group(struct hash_checksum_mgmt_group *group)
+{
+	sys_slist_append(&hash_checksum_mgmt_group_list, &group->node);
+}
+
+const struct hash_checksum_mgmt_group *hash_checksum_mgmt_find_handler(const char *name)
+{
+	/* Find the group with the specified group name */
+	struct hash_checksum_mgmt_group *group = NULL;
+	sys_snode_t *snp, *sns;
+
+	SYS_SLIST_FOR_EACH_NODE_SAFE(&hash_checksum_mgmt_group_list, snp, sns) {
+		struct hash_checksum_mgmt_group *loop_group =
+			CONTAINER_OF(snp, struct hash_checksum_mgmt_group, node);
+		if (strcmp(loop_group->group_name, name) == 0) {
+			group = loop_group;
+			break;
+		}
+	}
+
+	return group;
+}

--- a/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/src/hash_checksum_sha256.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/src/hash_checksum_sha256.c
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2022 Laird Connectivity
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <string.h>
+#include <fs/fs.h>
+#include <mgmt/mgmt.h>
+#include <fs_mgmt/fs_mgmt_config.h>
+#include <fs_mgmt/fs_mgmt_impl.h>
+#include "fs_mgmt/hash_checksum_mgmt.h"
+#include "fs_mgmt/hash_checksum_sha256.h"
+
+#if defined(CONFIG_TINYCRYPT_SHA256)
+#include <tinycrypt/constants.h>
+#include <tinycrypt/sha256.h>
+#else
+#include <mbedtls/md.h>
+#include <mbedtls/sha256.h>
+#endif
+
+#define SHA256_DIGEST_SIZE 32
+
+#if defined(CONFIG_TINYCRYPT_SHA256)
+/* Tinycrypt SHA256 implementation */
+static int fs_hash_checksum_mgmt_sha256(struct fs_file_t *file, uint8_t *output,
+					size_t *out_len, size_t len)
+{
+	int rc = 0;
+	ssize_t bytes_read = 0;
+	size_t read_size = CONFIG_FS_MGMT_CHECKSUM_HASH_CHUNK_SIZE;
+	uint8_t buffer[CONFIG_FS_MGMT_CHECKSUM_HASH_CHUNK_SIZE];
+	struct tc_sha256_state_struct sha;
+
+	/* Clear variables prior to calculation */
+	*out_len = 0;
+	memset(output, 0, SHA256_DIGEST_SIZE);
+
+	if (tc_sha256_init(&sha) != TC_CRYPTO_SUCCESS) {
+		return MGMT_ERR_EUNKNOWN;
+	}
+
+	/* Read all data from file and add to SHA256 hash calculation */
+	do {
+		if ((read_size + *out_len) >= len) {
+			/* Limit read size to size of requested data */
+			read_size = len - *out_len;
+		}
+
+		bytes_read = fs_read(file, buffer, read_size);
+
+		if (bytes_read < 0) {
+			/* Failed to read file data, pass generic unknown error back */
+			return MGMT_ERR_EUNKNOWN;
+		} else if (bytes_read > 0) {
+			if (tc_sha256_update(&sha, buffer, bytes_read) != TC_CRYPTO_SUCCESS) {
+				return MGMT_ERR_EUNKNOWN;
+			}
+
+			*out_len += bytes_read;
+		}
+	} while (bytes_read > 0 && *out_len < len);
+
+	/* Finalise SHA256 hash calculation and store output in provided output buffer */
+	if (tc_sha256_final(output, &sha) != TC_CRYPTO_SUCCESS) {
+		rc = MGMT_ERR_EUNKNOWN;
+	}
+
+	return rc;
+}
+#else
+/* mbedtls SHA256 implementation */
+static int fs_hash_checksum_mgmt_sha256(struct fs_file_t *file, uint8_t *output,
+					size_t *out_len, size_t len)
+{
+	int rc = 0;
+	ssize_t bytes_read = 0;
+	size_t read_size = CONFIG_FS_MGMT_CHECKSUM_HASH_CHUNK_SIZE;
+	uint8_t buffer[CONFIG_FS_MGMT_CHECKSUM_HASH_CHUNK_SIZE];
+	mbedtls_md_context_t mbed_hash_ctx;
+	const mbedtls_md_info_t *mbed_hash_info;
+
+	/* Clear variables prior to calculation */
+	*out_len = 0;
+	memset(output, 0, SHA256_DIGEST_SIZE);
+
+	mbed_hash_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
+	mbedtls_md_init(&mbed_hash_ctx);
+
+	if (mbedtls_md_setup(&mbed_hash_ctx, mbed_hash_info, 0) != 0) {
+		return MGMT_ERR_EUNKNOWN;
+	}
+
+	if (mbedtls_md_starts(&mbed_hash_ctx)) {
+		rc = MGMT_ERR_EUNKNOWN;
+		goto error;
+	}
+
+	/* Read all data from file and add to SHA256 hash calculation */
+	do {
+		if ((read_size + *out_len) >= len) {
+			/* Limit read size to size of requested data */
+			read_size = len - *out_len;
+		}
+
+		bytes_read = fs_read(file, buffer, read_size);
+
+		if (bytes_read < 0) {
+			/* Failed to read file data, pass generic unknown error back */
+			rc = MGMT_ERR_EUNKNOWN;
+			goto error;
+		} else if (bytes_read > 0) {
+			if (mbedtls_md_update(&mbed_hash_ctx, buffer, bytes_read) != 0) {
+				rc = MGMT_ERR_EUNKNOWN;
+				goto error;
+			}
+
+			*out_len += bytes_read;
+		}
+	} while (bytes_read > 0 && *out_len < len);
+
+	/* Finalise SHA256 hash calculation and store output in provided output buffer */
+	if (mbedtls_md_finish(&mbed_hash_ctx, output) != 0) {
+		rc = MGMT_ERR_EUNKNOWN;
+	}
+
+error:
+	mbedtls_md_free(&mbed_hash_ctx);
+
+	return rc;
+}
+#endif
+
+struct hash_checksum_mgmt_group sha256 = {
+	.group_name = "sha256",
+	.byte_string = true,
+	.output_size = SHA256_DIGEST_SIZE,
+	.function = fs_hash_checksum_mgmt_sha256,
+};
+
+void fs_hash_checksum_mgmt_register_sha256(void)
+{
+	hash_checksum_mgmt_register_group(&sha256);
+}
+
+void fs_hash_checksum_mgmt_unregister_sha256(void)
+{
+	hash_checksum_mgmt_unregister_group(&sha256);
+}

--- a/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/src/zephyr_fs_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/src/zephyr_fs_mgmt.c
@@ -17,7 +17,12 @@ fs_mgmt_impl_filelen(const char *path, size_t *out_len)
 	int rc;
 
 	rc = fs_stat(path, &dirent);
-	if (rc != 0) {
+
+	if (rc == -EINVAL) {
+		return MGMT_ERR_EINVAL;
+	} else if (rc == -ENOENT) {
+		return MGMT_ERR_ENOENT;
+	} else if (rc != 0) {
 		return MGMT_ERR_EUNKNOWN;
 	}
 


### PR DESCRIPTION
    doc: release-notes: Add mcumgr file status, file hash/checksum details
    
    This adds release notes for the new file status and file hash/checksum
    mcumgr fs commands.
    
    doc: guides: device_mgmt: smp: fs: Add hash/checksum/status details
    
    This adds documentation which explains fs mcumgr commands for the status
    and hash/checksum commands.
    
    mgmt: mcumgr: fs: Add hash/checksum (with CRC32/SHA256) handler
    
    This adds a hash/checksum mcumgr handler to the file management commands
    which can be used to get a hask or checksum of a file, and includes
    handler implementations for IEEE CRC32 and SHA256.
    
    mgmt: mcumgr: fs: Add file status handler
    
    This adds a command handler to the file management mcumgr system to get
    the status of a file without needing to return file data (currently
    reporting the file size).