### PR TITLE
driver: eth_mcux: fixing build error on rt11xx

### DIFF
--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -977,9 +977,15 @@ static void eth_tx_thread(void *arg1, void *unused1, void *unused2)
 				enet_handle_t *handle = &context->enet_handle;
 
 				if (handle->callback != NULL) {
+#if FSL_FEATURE_ENET_QUEUE > 1
+					handle->callback(context->base,
+						handle, 0, kENET_TxEvent,
+						NULL, handle->userData);
+#else
 					handle->callback(context->base,
 						handle, kENET_TxEvent,
 						NULL, handle->userData);
+#endif
 				}
 			}
 			ENET_EnableInterrupts(context->base,


### PR DESCRIPTION
in rt11xx series the ringbuffer is > 1

fixes #42793

Signed-off-by: Hake Huang <hake.huang@oss.nxp.com>