### PR TITLE
include/posix: mark unused variables

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1042,7 +1042,7 @@ Twister:
         - nashif
     files:
         - scripts/twister
-        - scripts/pylib/twister
+        - scripts/pylib/twister/
     labels:
         - "area: Twister"
 

--- a/include/posix/pthread.h
+++ b/include/posix/pthread.h
@@ -98,6 +98,7 @@ static inline int pthread_cond_init(pthread_cond_t *cv,
  */
 static inline int pthread_cond_destroy(pthread_cond_t *cv)
 {
+	ARG_UNUSED(cv);
 	return 0;
 }
 
@@ -139,6 +140,7 @@ int pthread_cond_timedwait(pthread_cond_t *cv, pthread_mutex_t *mut,
  */
 static inline int pthread_condattr_init(pthread_condattr_t *att)
 {
+	ARG_UNUSED(att);
 	return 0;
 }
 
@@ -151,6 +153,7 @@ static inline int pthread_condattr_init(pthread_condattr_t *att)
  */
 static inline int pthread_condattr_destroy(pthread_condattr_t *att)
 {
+	ARG_UNUSED(att);
 	return 0;
 }
 
@@ -464,6 +467,7 @@ static inline int pthread_equal(pthread_t pt1, pthread_t pt2)
  */
 static inline int pthread_rwlockattr_destroy(pthread_rwlockattr_t *attr)
 {
+	ARG_UNUSED(attr);
 	return 0;
 }
 
@@ -474,6 +478,7 @@ static inline int pthread_rwlockattr_destroy(pthread_rwlockattr_t *attr)
  */
 static inline int pthread_rwlockattr_init(pthread_rwlockattr_t *attr)
 {
+	ARG_UNUSED(attr);
 	return 0;
 }
 


### PR DESCRIPTION
empty inline pthread.h functions should mark
unused parameters accordingly

Signed-off-by: Nicholas Lowell <nlowell@lexmark.com>