### PR TITLE
boards: xtensa: fix cAVS name: connected -> converged

### DIFF
--- a/boards/xtensa/intel_adsp_cavs15/intel_adsp_cavs15.yaml
+++ b/boards/xtensa/intel_adsp_cavs15/intel_adsp_cavs15.yaml
@@ -1,5 +1,5 @@
 identifier: intel_adsp_cavs15
-name: CAVS 1.5 Audio DSP (Connected Audio Voice and Speech)
+name: cAVS 1.5 Audio DSP (converged Audio Voice and Speech)
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/xtensa/intel_adsp_cavs18/intel_adsp_cavs18.yaml
+++ b/boards/xtensa/intel_adsp_cavs18/intel_adsp_cavs18.yaml
@@ -1,5 +1,5 @@
 identifier: intel_adsp_cavs18
-name: CAVS 1.8 Audio DSP (Connected Audio Voice and Speech)
+name: cAVS 1.8 Audio DSP (converged Audio Voice and Speech)
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/xtensa/intel_adsp_cavs20/intel_adsp_cavs20.yaml
+++ b/boards/xtensa/intel_adsp_cavs20/intel_adsp_cavs20.yaml
@@ -1,5 +1,5 @@
 identifier: intel_adsp_cavs20
-name: CAVS 2.0 Audio DSP (Connected Audio Voice and Speech)
+name: cAVS 2.0 Audio DSP (converged Audio Voice and Speech)
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/xtensa/intel_adsp_cavs25/intel_adsp_cavs25.yaml
+++ b/boards/xtensa/intel_adsp_cavs25/intel_adsp_cavs25.yaml
@@ -1,5 +1,5 @@
 identifier: intel_adsp_cavs25
-name: CAVS 2.5 Audio DSP (Connected Audio Voice and Speech)
+name: cAVS 2.5 Audio DSP (converged Audio Voice and Speech)
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/xtensa/intel_s1000_crb/intel_s1000_crb.yaml
+++ b/boards/xtensa/intel_s1000_crb/intel_s1000_crb.yaml
@@ -1,5 +1,5 @@
 identifier: intel_s1000_crb
-name: Intel S1000 using CAVS (Connected Audio Voice and Speech)
+name: Intel S1000 using cAVS (converged Audio Voice and Speech)
 type: mcu
 arch: xtensa
 toolchain:


### PR DESCRIPTION
cAVS is defined as "converged Audio, Voice and Speech" by the cAVS
team itself.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>