### PR TITLE
boards: arm: mec172xevb_assy6906: Reduce SPI image size

### DIFF
--- a/boards/arm/mec172xevb_assy6906/support/spi_cfg.txt
+++ b/boards/arm/mec172xevb_assy6906/support/spi_cfg.txt
@@ -1,6 +1,6 @@
 ; Everglades SPI Image Generator configuration file
 [SPI]
-SPISizeMegabits = 128
+SPISizeMegabits = 4
 Flashmap = false
 FlshmapAddr = 0
 


### PR DESCRIPTION
Reduce SPI size to maximum FLASH ram size supported
This also speed up flashing process.

Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>