### PR TITLE
tests: x86/info and counter/counter_seconds: only tests PC compatible platforms

### DIFF
--- a/tests/arch/x86/info/testcase.yaml
+++ b/tests/arch/x86/info/testcase.yaml
@@ -1,15 +1,14 @@
 tests:
   arch.x86.info:
     arch_allow: x86
-    platform_allow: qemu_x86 ehl_crb up_squared
     harness: console
     harness_config:
         type: one_line
         regex:
           - "info: complete"
+    filter: CONFIG_X86_PC_COMPATIBLE
   arch.x86.info.userspace:
     arch_allow: x86
-    platform_allow: qemu_x86 ehl_crb up_squared
     extra_configs:
       - CONFIG_TEST_USERSPACE=y
     harness: console
@@ -17,3 +16,4 @@ tests:
         type: one_line
         regex:
           - "info: complete"
+    filter: CONFIG_X86_PC_COMPATIBLE

--- a/tests/drivers/counter/counter_seconds/testcase.yaml
+++ b/tests/drivers/counter/counter_seconds/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     arch_allow: x86
     extra_configs:
       - CONFIG_COUNTER_CMOS=y
+    filter: CONFIG_X86_PC_COMPATIBLE
 
   drivers.counter.mcux.snvs.rtc:
     tags: drivers


### PR DESCRIPTION
This adds a filter to only tests platforms that has
CONFIG_X86_PC_COMPATIBLE enabled. ACPI, multiboot and
CMOS RTC are usually all present on PC compatible and
not embedded ones. So limit the scope here.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>