### PR TITLE
Add IRQ_OFFLOAD_NESTED, with a portable (!) nested interrupt test

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -84,6 +84,7 @@ config X86
 	select ARCH_HAS_TIMING_FUNCTIONS
 	select ARCH_HAS_THREAD_LOCAL_STORAGE
 	select ARCH_HAS_DEMAND_PAGING
+	select IRQ_OFFLOAD_NESTED if IRQ_OFFLOAD
 	select NEED_LIBC_MEM_PARTITION if USERSPACE && TIMING_FUNCTIONS \
 					  && !BOARD_HAS_TIMING_FUNCTIONS \
 					  && !SOC_HAS_TIMING_FUNCTIONS
@@ -116,6 +117,7 @@ config XTENSA
 	select HAS_DTS
 	select USE_SWITCH
 	select USE_SWITCH_SUPPORTED
+	select IRQ_OFFLOAD_NESTED if IRQ_OFFLOAD
 	imply ATOMIC_OPERATIONS_ARCH
 	help
 	  Xtensa architecture
@@ -438,6 +440,14 @@ config IRQ_OFFLOAD
 	  run in interrupt context. Only useful for test cases that need
 	  to validate the correctness of kernel objects in IRQ context.
 
+config IRQ_OFFLOAD_NESTED
+	bool "irq_offload() supports nested IRQs"
+	depends on IRQ_OFFLOAD
+	help
+	  When set by the arch layer, indicates that irq_offload() may
+	  legally be called in interrupt context to cause a
+	  synchronous nested interrupt on the current CPU.  Not all
+	  hardware is capable.
 
 config EXTRA_EXCEPTION_INFO
 	bool "Collect extra exception info"

--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -6,18 +6,6 @@
 menu "XTENSA Options"
 	depends on XTENSA
 
-menu "Specific core configuration"
-
-config IRQ_OFFLOAD_INTNUM
-	int "IRQ offload SW interrupt index"
-	help
-	  The index of the software interrupt to be used for IRQ offload.
-
-	  Please note that in order for IRQ offload to work correctly the selected
-	  interrupt shall have its priority shall not exceed XCHAL_EXCM_LEVEL.
-
-endmenu
-
 config ARCH
 	default "xtensa"
 

--- a/arch/xtensa/core/irq_offload.c
+++ b/arch/xtensa/core/irq_offload.c
@@ -1,38 +1,37 @@
 /*
- * Copyright (c) 2016 Cadence Design Systems, Inc.
+ * Copyright (c) 2022 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <kernel.h>
 #include <irq_offload.h>
-#include <arch/xtensa/arch.h>
+#include <zsr.h>
 
-/*
- * Xtensa core should support software interrupt in order to allow using
- * irq_offload feature
- */
+#define CURR_CPU (IS_ENABLED(CONFIG_SMP) ? arch_curr_cpu()->id : 0)
 
-static irq_offload_routine_t offload_routine;
-static const void *offload_param;
+static struct {
+	irq_offload_routine_t fn;
+	const void *arg;
+} offload_params[CONFIG_MP_NUM_CPUS];
 
-/* Called by ISR dispatcher */
-void z_irq_do_offload(const void *unused)
+static void irq_offload_isr(const void *param)
 {
-	ARG_UNUSED(unused);
-	offload_routine(offload_param);
+	ARG_UNUSED(param);
+	offload_params[CURR_CPU].fn(offload_params[CURR_CPU].arg);
 }
 
 void arch_irq_offload(irq_offload_routine_t routine, const void *parameter)
 {
-	IRQ_CONNECT(CONFIG_IRQ_OFFLOAD_INTNUM, XCHAL_EXCM_LEVEL,
-		z_irq_do_offload, NULL, 0);
-	arch_irq_disable(CONFIG_IRQ_OFFLOAD_INTNUM);
-	offload_routine = routine;
-	offload_param = parameter;
-	z_xt_set_intset(BIT(CONFIG_IRQ_OFFLOAD_INTNUM));
-	/*
-	 * Enable the software interrupt, in case it is disabled, so that IRQ
-	 * offload is serviced.
-	 */
-	arch_irq_enable(CONFIG_IRQ_OFFLOAD_INTNUM);
+	IRQ_CONNECT(ZSR_IRQ_OFFLOAD_INT, 0, irq_offload_isr, NULL, 0);
+
+	unsigned int intenable, key = arch_irq_lock();
+
+	offload_params[CURR_CPU].fn = routine;
+	offload_params[CURR_CPU].arg = parameter;
+
+	__asm__ volatile("rsr %0, INTENABLE" : "=r"(intenable));
+	intenable |= BIT(ZSR_IRQ_OFFLOAD_INT);
+	__asm__ volatile("wsr %0, INTENABLE; wsr %0, INTSET; rsync"
+			 :: "r"(intenable), "r"(BIT(ZSR_IRQ_OFFLOAD_INT)));
+	arch_irq_unlock(key);
 }

--- a/drivers/timer/Kconfig.xtensa
+++ b/drivers/timer/Kconfig.xtensa
@@ -14,13 +14,12 @@ config XTENSA_TIMER
 
 config XTENSA_TIMER_ID
 	int "System timer CCOMPAREn register index"
-	default 1
+	default 0
 	depends on XTENSA_TIMER
 	help
 	  Index of the CCOMPARE register (and associated interrupt)
 	  used for the system timer.  Xtensa CPUs have hard-configured
 	  interrupt priorities associated with each timer, and some of
 	  them can be unmaskable (and thus not usable by OS code that
-	  need synchronization, like the timer subsystem!).  Choose
-	  carefully.  Generally you want the timer with the highest
-	  priority maskable interrupt.
+	  need synchronization, like the timer subsystem!).  In
+	  general timer zero is guaranteed to be present and usable.

--- a/include/irq_offload.h
+++ b/include/irq_offload.h
@@ -25,6 +25,13 @@ typedef void (*irq_offload_routine_t)(const void *parameter);
  * which needs to show that kernel objects work correctly in interrupt
  * context.
  *
+ * Additionally, when CONFIG_IRQ_OFFLOAD_NESTED is set by the
+ * architecture, this routine works to synchronously invoke a nested
+ * interrupt when called from an ISR context (i.e. when k_is_in_isr()
+ * is true).  Note that not all platforms will have hardware support
+ * for this capability, and even on those some interrupts may be
+ * running at unpreemptible priorities.
+ *
  * @param routine The function to run
  * @param parameter Argument to pass to the function when it is run as an
  * interrupt

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -890,9 +890,13 @@ K_SEM_DEFINE(offload_sem, 1, 1);
 
 void irq_offload(irq_offload_routine_t routine, const void *parameter)
 {
+#ifdef CONFIG_IRQ_OFFLOAD_NESTED
+	arch_irq_offload(routine, parameter);
+#else
 	k_sem_take(&offload_sem, K_FOREVER);
 	arch_irq_offload(routine, parameter);
 	k_sem_give(&offload_sem);
+#endif
 }
 #endif
 

--- a/soc/xtensa/esp32/Kconfig.defconfig
+++ b/soc/xtensa/esp32/Kconfig.defconfig
@@ -25,9 +25,6 @@ endif
 config SOC
 	default "esp32"
 
-config IRQ_OFFLOAD_INTNUM
-	default 7
-
 if SMP
 
 config SCHED_IPI_SUPPORTED

--- a/soc/xtensa/esp32s2/Kconfig.defconfig
+++ b/soc/xtensa/esp32s2/Kconfig.defconfig
@@ -23,9 +23,6 @@ config ISR_STACK_SIZE
 config HEAP_MEM_POOL_SIZE
 	default 32768
 
-config IRQ_OFFLOAD_INTNUM
-	default 7
-
 config MP_NUM_CPUS
 	default 1
 

--- a/soc/xtensa/intel_adsp/cavs_v15/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/cavs_v15/Kconfig.defconfig.series
@@ -52,9 +52,6 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config SYS_CLOCK_TICKS_PER_SEC
 	default 50000
 
-config IRQ_OFFLOAD_INTNUM
-	default 0
-
 config KERNEL_ENTRY
 	default "_MainEntry"
 

--- a/soc/xtensa/intel_adsp/cavs_v18/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/cavs_v18/Kconfig.defconfig.series
@@ -38,9 +38,6 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config SYS_CLOCK_TICKS_PER_SEC
 	default 50000
 
-config IRQ_OFFLOAD_INTNUM
-	default 0
-
 config KERNEL_ENTRY
 	default "_MainEntry"
 

--- a/soc/xtensa/intel_adsp/cavs_v20/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/cavs_v20/Kconfig.defconfig.series
@@ -38,9 +38,6 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config SYS_CLOCK_TICKS_PER_SEC
 	default 50000
 
-config IRQ_OFFLOAD_INTNUM
-	default 0
-
 config KERNEL_ENTRY
 	default "_MainEntry"
 

--- a/soc/xtensa/intel_adsp/cavs_v25/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/cavs_v25/Kconfig.defconfig.series
@@ -35,9 +35,6 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config SYS_CLOCK_TICKS_PER_SEC
 	default 50000
 
-config IRQ_OFFLOAD_INTNUM
-	default 0
-
 config KERNEL_ENTRY
 	default "_MainEntry"
 

--- a/soc/xtensa/intel_s1000/Kconfig.defconfig
+++ b/soc/xtensa/intel_s1000/Kconfig.defconfig
@@ -16,9 +16,6 @@ config SOC_TOOLCHAIN_NAME
 	string
 	default "intel_s1000"
 
-config IRQ_OFFLOAD_INTNUM
-	default 0
-
 config SPI_DW_FIFO_DEPTH
 	default 32
 

--- a/soc/xtensa/nxp_adsp/imx8/Kconfig.defconfig.series
+++ b/soc/xtensa/nxp_adsp/imx8/Kconfig.defconfig.series
@@ -27,9 +27,6 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config SYS_CLOCK_TICKS_PER_SEC
 	default 50000
 
-config IRQ_OFFLOAD_INTNUM
-	default 0
-
 config KERNEL_ENTRY
 	default "__start"
 

--- a/soc/xtensa/nxp_adsp/imx8m/Kconfig.defconfig.series
+++ b/soc/xtensa/nxp_adsp/imx8m/Kconfig.defconfig.series
@@ -27,9 +27,6 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config SYS_CLOCK_TICKS_PER_SEC
 	default 50000
 
-config IRQ_OFFLOAD_INTNUM
-	default 0
-
 config KERNEL_ENTRY
 	default "__start"
 

--- a/soc/xtensa/sample_controller/Kconfig.defconfig
+++ b/soc/xtensa/sample_controller/Kconfig.defconfig
@@ -13,9 +13,6 @@ config SOC_TOOLCHAIN_NAME
 	string
 	default "sample_controller"
 
-config IRQ_OFFLOAD_INTNUM
-	default 7
-
 config LOG_BACKEND_XTENSA_SIM
 	default LOG
 

--- a/tests/kernel/common/src/irq_offload.c
+++ b/tests/kernel/common/src/irq_offload.c
@@ -199,3 +199,46 @@ __no_optimization void test_nop(void)
 	zassert_true(diff > 0,
 			"arch_nop() takes %d cpu cycles", diff);
 }
+
+static struct k_timer nestoff_timer;
+static bool timer_executed, nested_executed;
+
+void nestoff_offload(const void *parameter)
+{
+	nested_executed = true;
+}
+
+
+static void nestoff_timer_fn(struct k_timer *timer)
+{
+	zassert_false(nested_executed, "nested irq_offload ran too soon");
+	irq_offload(nestoff_offload, NULL);
+	zassert_true(nested_executed, "nested irq_offload did not run");
+
+	/* Set this last, to be sure we return to this context and not
+	 * the enclosing interrupt
+	 */
+	timer_executed = true;
+}
+
+
+/* Invoke irq_offload() from an interrupt and verify that the
+ * resulting nested interrupt doesn't explode
+ */
+void test_nested_irq_offload(void)
+{
+	if (!IS_ENABLED(CONFIG_IRQ_OFFLOAD_NESTED)) {
+		ztest_test_skip();
+	}
+
+	k_timer_init(&nestoff_timer, nestoff_timer_fn, NULL);
+
+	zassert_false(timer_executed, "timer ran too soon");
+	zassert_false(nested_executed, "nested irq_offload ran too soon");
+
+	k_timer_start(&nestoff_timer, K_TICKS(1), K_FOREVER);
+	k_timer_status_sync(&nestoff_timer);
+
+	zassert_true(timer_executed, "timer did not run");
+	zassert_true(nested_executed, "nested irq_offload did not run");
+}

--- a/tests/kernel/common/src/main.c
+++ b/tests/kernel/common/src/main.c
@@ -45,6 +45,7 @@ extern void test_multilib(void);
 extern void test_thread_context(void);
 extern void test_bootdelay(void);
 extern void test_irq_offload(void);
+extern void test_nested_irq_offload(void);
 extern void test_bitarray_declare(void);
 extern void test_bitarray_set_clear(void);
 extern void test_bitarray_alloc_free(void);
@@ -125,6 +126,7 @@ void test_main(void)
 	ztest_test_suite(common,
 			 ztest_unit_test(test_bootdelay),
 			 ztest_unit_test(test_irq_offload),
+			 ztest_unit_test(test_nested_irq_offload),
 			 ztest_unit_test(test_byteorder_memcpy_swap),
 			 ztest_unit_test(test_byteorder_mem_swap),
 			 ztest_unit_test(test_sys_get_be64),


### PR DESCRIPTION
Nested interrupts on xtensa weren't being exercised due to bitrot (I wrote a test long ago that fell out of the suite, and the nested interrupt test was always arch-specific and never got a port).  This extends the irq_offload() API to be able to interrupt an ISR on supported architectures (just x86 and xtensa for now), and adds a trivially small case to tests/kernel/common to validate it.