### PR TITLE
soc: esp32: use PYTHON_EXECUTABLE from build system

### DIFF
--- a/boards/riscv/esp32c3_devkitm/CMakeLists.txt
+++ b/boards/riscv/esp32c3_devkitm/CMakeLists.txt
@@ -24,6 +24,7 @@ if(CONFIG_BOOTLOADER_ESP_IDF)
     -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
     -DCMAKE_ASM_COMPILER=${CMAKE_ASM_COMPILER}
     -DCMAKE_SYSTEM_NAME=${CMAKE_SYSTEM_NAME}
+    -DPYTHON=${PYTHON_EXECUTABLE}
     BUILD_COMMAND
     ${CMAKE_COMMAND} --build .
     INSTALL_COMMAND ""      # This particular build system has no install command
@@ -35,14 +36,14 @@ if(CONFIG_BOOTLOADER_ESP_IDF)
     BINARY_DIR ${espidf_build_dir}
     CONFIGURE_COMMAND ""
     BUILD_COMMAND
-    python ${ESP_IDF_PATH}/components/partition_table/gen_esp32part.py -q
+    ${PYTHON_EXECUTABLE} ${ESP_IDF_PATH}/components/partition_table/gen_esp32part.py -q
     --offset 0x1000 --flash-size 4MB ${ESP_IDF_PATH}/components/partition_table/partitions_singleapp.csv ${espidf_build_dir}/partitions_singleapp.bin
     INSTALL_COMMAND ""
     )
 
   if(CONFIG_BUILD_OUTPUT_BIN)
     set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
-      COMMAND python ${ESP_IDF_PATH}/components/esptool_py/esptool/esptool.py
+      COMMAND ${PYTHON_EXECUTABLE} ${ESP_IDF_PATH}/components/esptool_py/esptool/esptool.py
       ARGS --chip esp32c3 elf2image --flash_mode dio --flash_freq 40m
       -o ${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.bin
       ${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.elf)

--- a/boards/xtensa/esp32/CMakeLists.txt
+++ b/boards/xtensa/esp32/CMakeLists.txt
@@ -23,6 +23,7 @@ if(CONFIG_BOOTLOADER_ESP_IDF)
     -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
     -DCMAKE_ASM_COMPILER=${CMAKE_ASM_COMPILER}
     -DCMAKE_SYSTEM_NAME=${CMAKE_SYSTEM_NAME}
+    -DPYTHON=${PYTHON_EXECUTABLE}
     BUILD_COMMAND
     ${CMAKE_COMMAND} --build .
     INSTALL_COMMAND ""      # This particular build system has no install command
@@ -34,14 +35,14 @@ if(CONFIG_BOOTLOADER_ESP_IDF)
     BINARY_DIR ${espidf_build_dir}
     CONFIGURE_COMMAND ""
     BUILD_COMMAND
-    python ${ESP_IDF_PATH}/components/partition_table/gen_esp32part.py -q
+    ${PYTHON_EXECUTABLE} ${ESP_IDF_PATH}/components/partition_table/gen_esp32part.py -q
     --offset 0x1000 --flash-size 4MB ${ESP_IDF_PATH}/components/partition_table/partitions_singleapp.csv ${espidf_build_dir}/partitions_singleapp.bin
     INSTALL_COMMAND ""
     )
 
   if(CONFIG_BUILD_OUTPUT_BIN)
     set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
-      COMMAND python ${ESP_IDF_PATH}/components/esptool_py/esptool/esptool.py
+      COMMAND ${PYTHON_EXECUTABLE} ${ESP_IDF_PATH}/components/esptool_py/esptool/esptool.py
       ARGS --chip esp32 elf2image --flash_mode dio --flash_freq 40m
       -o ${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.bin
       ${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.elf)

--- a/boards/xtensa/esp32s2_saola/CMakeLists.txt
+++ b/boards/xtensa/esp32s2_saola/CMakeLists.txt
@@ -23,6 +23,7 @@ if(CONFIG_BOOTLOADER_ESP_IDF)
     -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
     -DCMAKE_ASM_COMPILER=${CMAKE_ASM_COMPILER}
     -DCMAKE_SYSTEM_NAME=${CMAKE_SYSTEM_NAME}
+    -DPYTHON=${PYTHON_EXECUTABLE}
     BUILD_COMMAND
     ${CMAKE_COMMAND} --build .
     INSTALL_COMMAND ""      # This particular build system has no install command
@@ -34,14 +35,14 @@ if(CONFIG_BOOTLOADER_ESP_IDF)
     BINARY_DIR ${espidf_build_dir}
     CONFIGURE_COMMAND ""
     BUILD_COMMAND
-    python ${ESP_IDF_PATH}/components/partition_table/gen_esp32part.py -q
+    ${PYTHON_EXECUTABLE} ${ESP_IDF_PATH}/components/partition_table/gen_esp32part.py -q
     --offset 0x1000 --flash-size 4MB ${ESP_IDF_PATH}/components/partition_table/partitions_singleapp.csv ${espidf_build_dir}/partitions_singleapp.bin
     INSTALL_COMMAND ""
     )
 
   if(CONFIG_BUILD_OUTPUT_BIN)
     set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
-      COMMAND python ${ESP_IDF_PATH}/components/esptool_py/esptool/esptool.py
+      COMMAND ${PYTHON_EXECUTABLE} ${ESP_IDF_PATH}/components/esptool_py/esptool/esptool.py
       ARGS --chip esp32s2 elf2image --flash_mode dio --flash_freq 40m
       -o ${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.bin
       ${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.elf)


### PR DESCRIPTION
ESP32 build is failing after f-string was added into python
files. This sets esp32 build to use Zephyr's build system python
version.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/45873