### PR TITLE
drivers: flash: Introduce gd32 flash controller driver

### DIFF
--- a/boards/arm/gd32e103v_eval/gd32e103v_eval.dts
+++ b/boards/arm/gd32e103v_eval/gd32e103v_eval.dts
@@ -17,6 +17,7 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &usart0;
 		zephyr,shell-uart = &usart0;
+		zephyr,flash-controller = &fmc;
 	};
 
 	leds {

--- a/boards/arm/gd32e507v_start/gd32e507v_start.dts
+++ b/boards/arm/gd32e507v_start/gd32e507v_start.dts
@@ -17,6 +17,7 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &usart0;
 		zephyr,shell-uart = &usart0;
+		zephyr,flash-controller = &fmc;
 	};
 
 	leds {

--- a/boards/arm/gd32f350r_eval/gd32f350r_eval.dts
+++ b/boards/arm/gd32f350r_eval/gd32f350r_eval.dts
@@ -17,6 +17,7 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &usart0;
 		zephyr,shell-uart = &usart0;
+		zephyr,flash-controller = &fmc;
 	};
 };
 

--- a/boards/arm/gd32f403z_eval/gd32f403z_eval.dts
+++ b/boards/arm/gd32f403z_eval/gd32f403z_eval.dts
@@ -17,6 +17,7 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &usart0;
 		zephyr,shell-uart = &usart0;
+		zephyr,flash-controller = &fmc;
 	};
 
 	leds {

--- a/boards/arm/gd32f450i_eval/gd32f450i_eval.dts
+++ b/boards/arm/gd32f450i_eval/gd32f450i_eval.dts
@@ -17,6 +17,7 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &usart0;
 		zephyr,shell-uart = &usart0;
+		zephyr,flash-controller = &fmc;
 	};
 
 	leds {

--- a/boards/arm/gd32f450z_eval/gd32f450z_eval.dts
+++ b/boards/arm/gd32f450z_eval/gd32f450z_eval.dts
@@ -17,6 +17,7 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &usart0;
 		zephyr,shell-uart = &usart0;
+		zephyr,flash-controller = &fmc;
 	};
 
 	leds {

--- a/boards/arm/gd32f470i_eval/gd32f470i_eval.dts
+++ b/boards/arm/gd32f470i_eval/gd32f470i_eval.dts
@@ -17,6 +17,7 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &usart0;
 		zephyr,shell-uart = &usart0;
+		zephyr,flash-controller = &fmc;
 	};
 
 	leds {

--- a/boards/riscv/gd32vf103c_starter/gd32vf103c_starter.dts
+++ b/boards/riscv/gd32vf103c_starter/gd32vf103c_starter.dts
@@ -17,6 +17,7 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &usart0;
 		zephyr,shell-uart = &usart0;
+		zephyr,flash-controller = &fmc;
 	};
 
 	leds {

--- a/boards/riscv/gd32vf103v_eval/gd32vf103v_eval.dts
+++ b/boards/riscv/gd32vf103v_eval/gd32vf103v_eval.dts
@@ -17,6 +17,7 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &usart0;
 		zephyr,shell-uart = &usart0;
+		zephyr,flash-controller = &fmc;
 	};
 
 	leds {

--- a/drivers/flash/CMakeLists.txt
+++ b/drivers/flash/CMakeLists.txt
@@ -61,6 +61,14 @@ if(CONFIG_SOC_FLASH_STM32)
   endif()
 endif()
 
+if(CONFIG_SOC_FLASH_GD32)
+  zephyr_library_sources(flash_gd32.c)
+
+  zephyr_library_sources_ifdef(CONFIG_GD32_NV_FLASH_V1 flash_gd32_v1.c)
+  zephyr_library_sources_ifdef(CONFIG_GD32_NV_FLASH_V2 flash_gd32_v2.c)
+  zephyr_library_sources_ifdef(CONFIG_GD32_NV_FLASH_V3 flash_gd32_v3.c)
+endif()
+
 zephyr_library_include_directories_ifdef(
   CONFIG_FLASH_MCUX_FLEXSPI_NOR
   ${ZEPHYR_BASE}/drivers/memc

--- a/drivers/flash/Kconfig
+++ b/drivers/flash/Kconfig
@@ -108,4 +108,6 @@ source "drivers/flash/Kconfig.smartbond"
 
 source "drivers/flash/Kconfig.cadence_qspi_nor"
 
+source "drivers/flash/Kconfig.gd32"
+
 endif # FLASH

--- a/drivers/flash/Kconfig.gd32
+++ b/drivers/flash/Kconfig.gd32
@@ -1,0 +1,33 @@
+# Copyright (c) 2022 BrainCo Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC_FLASH_GD32
+	bool "GigaDevice GD32 flash driver"
+	default y
+	depends on (GD32_NV_FLASH_V1 || GD32_NV_FLASH_V2 || GD32_NV_FLASH_V3)
+	select FLASH_HAS_DRIVER_ENABLED
+	select FLASH_HAS_PAGE_LAYOUT
+	select MPU_ALLOW_FLASH_WRITE if ARM_MPU
+	help
+	  Enable the GigaDevice GD32 flash driver.
+
+config GD32_NV_FLASH_V1
+	bool
+	default y
+	depends on DT_HAS_GD_GD32_NV_FLASH_V1_ENABLED
+	help
+	  Enable the generic backend for GD32 FMC v1 flash driver.
+
+config GD32_NV_FLASH_V2
+	bool
+	default y
+	depends on DT_HAS_GD_GD32_NV_FLASH_V2_ENABLED
+	help
+	  Enable the generic backend for GD32 FMC v2 flash driver.
+
+config GD32_NV_FLASH_V3
+	bool
+	default y
+	depends on DT_HAS_GD_GD32_NV_FLASH_V3_ENABLED
+	help
+	  Enable the generic backend for GD32 FMC v3 flash driver.

--- a/drivers/flash/flash_gd32.c
+++ b/drivers/flash/flash_gd32.c
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2022 BrainCo Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT gd_gd32_flash_controller
+
+#include "flash_gd32.h"
+
+#include <zephyr/kernel.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/flash.h>
+#include <zephyr/logging/log.h>
+
+#include <gd32_fmc.h>
+
+LOG_MODULE_REGISTER(flash_gd32, CONFIG_FLASH_LOG_LEVEL);
+
+struct flash_gd32_data {
+	struct k_sem mutex;
+};
+
+static struct flash_gd32_data flash_data;
+
+static const struct flash_parameters flash_gd32_parameters = {
+	.write_block_size = SOC_NV_FLASH_PRG_SIZE,
+	.erase_value = 0xff,
+};
+
+static int flash_gd32_read(const struct device *dev, off_t offset,
+			   void *data, size_t len)
+{
+	if ((offset > SOC_NV_FLASH_SIZE) ||
+	    ((offset + len) > SOC_NV_FLASH_SIZE)) {
+		return -EINVAL;
+	}
+
+	if (len == 0U) {
+		return 0;
+	}
+
+	memcpy(data, (uint8_t *)SOC_NV_FLASH_ADDR + offset, len);
+
+	return 0;
+}
+
+static int flash_gd32_write(const struct device *dev, off_t offset,
+			    const void *data, size_t len)
+{
+	struct flash_gd32_data *dev_data = dev->data;
+	int ret = 0;
+
+	if (!flash_gd32_valid_range(offset, len, true)) {
+		return -EINVAL;
+	}
+
+	if (len == 0U) {
+		return 0;
+	}
+
+	k_sem_take(&dev_data->mutex, K_FOREVER);
+
+	ret = flash_gd32_write_range(offset, data, len);
+
+	k_sem_give(&dev_data->mutex);
+
+	return ret;
+}
+
+static int flash_gd32_erase(const struct device *dev, off_t offset, size_t size)
+{
+	struct flash_gd32_data *data = dev->data;
+	int ret = 0;
+
+	if (size == 0U) {
+		return 0;
+	}
+
+	if (!flash_gd32_valid_range(offset, size, false)) {
+		return -EINVAL;
+	}
+
+	k_sem_take(&data->mutex, K_FOREVER);
+
+	ret = flash_gd32_erase_block(offset, size);
+
+	k_sem_give(&data->mutex);
+
+	return ret;
+}
+
+static const struct flash_parameters*
+flash_gd32_get_parameters(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	return &flash_gd32_parameters;
+}
+
+static const struct flash_driver_api flash_gd32_driver_api = {
+	.read = flash_gd32_read,
+	.write = flash_gd32_write,
+	.erase = flash_gd32_erase,
+	.get_parameters = flash_gd32_get_parameters,
+#ifdef CONFIG_FLASH_PAGE_LAYOUT
+	.page_layout = flash_gd32_pages_layout,
+#endif
+};
+
+static int flash_gd32_init(const struct device *dev)
+{
+	struct flash_gd32_data *data = dev->data;
+
+	k_sem_init(&data->mutex, 1, 1);
+
+	return 0;
+}
+
+DEVICE_DT_INST_DEFINE(0, flash_gd32_init, NULL,
+		      &flash_data, NULL, POST_KERNEL,
+		      CONFIG_FLASH_INIT_PRIORITY, &flash_gd32_driver_api);

--- a/drivers/flash/flash_gd32.h
+++ b/drivers/flash/flash_gd32.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022 BrainCo Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_FLASH_FLASH_GD32_H_
+#define ZEPHYR_DRIVERS_FLASH_FLASH_GD32_H_
+
+#include <stdint.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/flash.h>
+
+#define SOC_NV_FLASH_NODE	DT_INST(0, soc_nv_flash)
+#define SOC_NV_FLASH_SIZE	DT_REG_SIZE(SOC_NV_FLASH_NODE)
+#define SOC_NV_FLASH_ADDR	DT_REG_ADDR(SOC_NV_FLASH_NODE)
+#define SOC_NV_FLASH_PRG_SIZE	DT_PROP(SOC_NV_FLASH_NODE, write_block_size)
+
+#if (4 == SOC_NV_FLASH_PRG_SIZE)
+typedef uint32_t flash_prg_t;
+#elif (2 == SOC_NV_FLASH_PRG_SIZE)
+typedef uint16_t flash_prg_t;
+#elif (1 == SOC_NV_FLASH_PRG_SIZE)
+typedef uint8_t flash_prg_t;
+#else
+#error "Invalid write-block-size value in FMC DTS"
+#endif
+
+/* Helper for conditional compilation directives, KB cannot be used because it has type casting. */
+#define PRE_KB(x) ((x) << 10)
+
+bool flash_gd32_valid_range(off_t offset, uint32_t len, bool write);
+
+int flash_gd32_write_range(off_t offset, const void *data, size_t len);
+
+int flash_gd32_erase_block(off_t offset, size_t size);
+
+#ifdef CONFIG_FLASH_PAGE_LAYOUT
+void flash_gd32_pages_layout(const struct device *dev,
+			     const struct flash_pages_layout **layout,
+			     size_t *layout_size);
+#endif
+#endif /* ZEPHYR_DRIVERS_FLASH_FLASH_GD32_H_ */

--- a/drivers/flash/flash_gd32_v1.c
+++ b/drivers/flash/flash_gd32_v1.c
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2022 BrainCo Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "flash_gd32.h"
+
+#include <zephyr/logging/log.h>
+
+#include <gd32_fmc.h>
+
+LOG_MODULE_DECLARE(flash_gd32);
+
+#define GD32_NV_FLASH_V1_NODE		DT_INST(0, gd_gd32_nv_flash_v1)
+#define GD32_NV_FLASH_V1_TIMEOUT	DT_PROP(GD32_NV_FLASH_V1_NODE, max_erase_time_ms)
+#define GD32_NV_FLASH_V1_PAGE_SIZE	DT_PROP(GD32_NV_FLASH_V1_NODE, page_size)
+
+#if defined(CONFIG_SOC_SERIES_GD32E10X) || \
+	defined(CONFIG_SOC_SERIES_GD32E50X)
+/* Some GD32 FMC v1 series require offset and len to word aligned. */
+#define GD32_FMC_V1_WORK_ALIGNED
+#endif
+
+#ifdef FLASH_GD32_FMC_WORK_ALIGNED
+#define GD32_FMC_V1_WRITE_ERR	(FMC_STAT_PGERR | FMC_STAT_WPERR | FMC_STAT_PGAERR)
+#else
+#define GD32_FMC_V1_WRITE_ERR	(FMC_STAT_PGERR | FMC_STAT_WPERR)
+#endif
+#define GD32_FMC_V1_ERASE_ERR	FMC_STAT_WPERR
+
+#ifdef CONFIG_FLASH_PAGE_LAYOUT
+static const struct flash_pages_layout gd32_fmc_v1_layout[] = {
+	{
+	.pages_size = GD32_NV_FLASH_V1_PAGE_SIZE,
+	.pages_count = SOC_NV_FLASH_SIZE / GD32_NV_FLASH_V1_PAGE_SIZE
+	}
+};
+#endif
+
+static inline void gd32_fmc_v1_unlock(void)
+{
+	FMC_KEY = UNLOCK_KEY0;
+	FMC_KEY = UNLOCK_KEY1;
+}
+
+static inline void gd32_fmc_v1_lock(void)
+{
+	FMC_CTL |= FMC_CTL_LK;
+}
+
+static int gd32_fmc_v1_wait_idle(void)
+{
+	const int64_t expired_time = k_uptime_get() + GD32_NV_FLASH_V1_TIMEOUT;
+
+	while (FMC_STAT & FMC_STAT_BUSY) {
+		if (k_uptime_get() > expired_time) {
+			return -ETIMEDOUT;
+		}
+	}
+
+	return 0;
+}
+
+bool flash_gd32_valid_range(off_t offset, uint32_t len, bool write)
+{
+	if ((offset > SOC_NV_FLASH_SIZE) ||
+	    ((offset + len) > SOC_NV_FLASH_SIZE)) {
+		return false;
+	}
+
+	if (write) {
+		/* Check offset and len is flash_prg_t aligned. */
+		if ((offset % sizeof(flash_prg_t)) ||
+		    (len % sizeof(flash_prg_t))) {
+			return false;
+		}
+
+#ifdef FLASH_GD32_FMC_WORK_ALIGNED
+		/* Check offset and len is word aligned. */
+		if ((offset % sizeof(uint32_t)) ||
+		    (len % sizeof(uint32_t))) {
+			return false;
+		}
+#endif
+
+	} else {
+		if ((offset % GD32_NV_FLASH_V1_PAGE_SIZE) ||
+		    (len % GD32_NV_FLASH_V1_PAGE_SIZE)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+int flash_gd32_write_range(off_t offset, const void *data, size_t len)
+{
+	flash_prg_t *prg_flash = (flash_prg_t *)((uint8_t *)SOC_NV_FLASH_ADDR + offset);
+	flash_prg_t *prg_data = (flash_prg_t *)data;
+	int ret = 0;
+
+	gd32_fmc_v1_unlock();
+
+	if (FMC_STAT & FMC_STAT_BUSY) {
+		return -EBUSY;
+	}
+
+	FMC_CTL |= FMC_CTL_PG;
+
+	for (size_t i = 0U; i < (len / sizeof(flash_prg_t)); i++) {
+		*prg_flash++ = *prg_data++;
+	}
+
+	ret = gd32_fmc_v1_wait_idle();
+	if (ret < 0) {
+		goto expired_out;
+	}
+
+	if (FMC_STAT & GD32_FMC_V1_WRITE_ERR) {
+		ret = -EIO;
+		FMC_STAT |= GD32_FMC_V1_WRITE_ERR;
+		LOG_ERR("FMC programming failed");
+	}
+
+expired_out:
+	FMC_CTL &= ~FMC_CTL_PG;
+
+	gd32_fmc_v1_lock();
+
+	return ret;
+}
+
+static int gd32_fmc_v1_page_erase(uint32_t page_addr)
+{
+	int ret = 0;
+
+	gd32_fmc_v1_unlock();
+
+	if (FMC_STAT & FMC_STAT_BUSY) {
+		return -EBUSY;
+	}
+
+	FMC_CTL |= FMC_CTL_PER;
+
+	FMC_ADDR = page_addr;
+
+	FMC_CTL |= FMC_CTL_START;
+
+	ret = gd32_fmc_v1_wait_idle();
+	if (ret < 0) {
+		goto expired_out;
+	}
+
+	if (FMC_STAT & GD32_FMC_V1_ERASE_ERR) {
+		ret = -EIO;
+		FMC_STAT |= GD32_FMC_V1_ERASE_ERR;
+		LOG_ERR("FMC page %u erase failed", page_addr);
+	}
+
+expired_out:
+	FMC_CTL &= ~FMC_CTL_PER;
+
+	gd32_fmc_v1_lock();
+
+	return ret;
+}
+
+int flash_gd32_erase_block(off_t offset, size_t size)
+{
+	uint32_t page_addr = SOC_NV_FLASH_ADDR + offset;
+	int ret = 0;
+
+	while (size > 0U) {
+		ret = gd32_fmc_v1_page_erase(page_addr);
+		if (ret < 0) {
+			return ret;
+		}
+
+		size -= GD32_NV_FLASH_V1_PAGE_SIZE;
+		page_addr += GD32_NV_FLASH_V1_PAGE_SIZE;
+	}
+
+	return 0;
+}
+
+#ifdef CONFIG_FLASH_PAGE_LAYOUT
+void flash_gd32_pages_layout(const struct device *dev,
+			     const struct flash_pages_layout **layout,
+			     size_t *layout_size)
+{
+	ARG_UNUSED(dev);
+
+	*layout = gd32_fmc_v1_layout;
+	*layout_size = ARRAY_SIZE(gd32_fmc_v1_layout);
+}
+#endif /* CONFIG_FLASH_PAGE_LAYOUT */

--- a/drivers/flash/flash_gd32_v2.c
+++ b/drivers/flash/flash_gd32_v2.c
@@ -1,0 +1,419 @@
+/*
+ * Copyright (c) 2022 BrainCo Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "flash_gd32.h"
+
+#include <zephyr/logging/log.h>
+
+#include <gd32_fmc.h>
+
+LOG_MODULE_DECLARE(flash_gd32);
+
+#define GD32_NV_FLASH_V2_NODE		DT_INST(0, gd_gd32_nv_flash_v2)
+#define GD32_NV_FLASH_V2_TIMEOUT	DT_PROP(GD32_NV_FLASH_V2_NODE, max_erase_time_ms)
+
+/**
+ * @brief GD32 FMC v2 flash memory has 2 banks.
+ * Bank0 holds the first 512KB, bank1 is used give capacity for reset.
+ * The page size is the same within the same bank, but not equal for all banks.
+ */
+#if (PRE_KB(512) >= SOC_NV_FLASH_SIZE)
+#define GD32_NV_FLASH_V2_BANK0_SIZE		SOC_NV_FLASH_SIZE
+#define GD32_NV_FLASH_V2_BANK0_PAGE_SIZE	DT_PROP(GD32_NV_FLASH_V2_NODE, bank0_page_size)
+#else
+#define GD32_NV_FLASH_V2_BANK0_SIZE		KB(512)
+#define GD32_NV_FLASH_V2_BANK0_PAGE_SIZE	DT_PROP(GD32_NV_FLASH_V2_NODE, bank0_page_size)
+#define GD32_NV_FLASH_V2_BANK1_SIZE		(SOC_NV_FLASH_SIZE - KB(512))
+#define GD32_NV_FLASH_V2_BANK1_PAGE_SIZE	DT_PROP(GD32_NV_FLASH_V2_NODE, bank1_page_size)
+#endif
+
+#define GD32_FMC_V2_BANK0_WRITE_ERR (FMC_STAT0_PGERR | FMC_STAT0_WPERR)
+#define GD32_FMC_V2_BANK0_ERASE_ERR FMC_STAT0_WPERR
+
+#define GD32_FMC_V2_BANK1_WRITE_ERR (FMC_STAT1_PGERR | FMC_STAT1_WPERR)
+#define GD32_FMC_V2_BANK1_ERASE_ERR FMC_STAT1_WPERR
+
+#ifdef CONFIG_FLASH_PAGE_LAYOUT
+static struct flash_pages_layout gd32_fmc_v2_layout[] = {
+	{
+	.pages_size = GD32_NV_FLASH_V2_BANK0_PAGE_SIZE,
+	.pages_count = GD32_NV_FLASH_V2_BANK0_SIZE / GD32_NV_FLASH_V2_BANK0_PAGE_SIZE
+	},
+#ifdef FLASH_GD32_BANK1_SIZE
+	{
+	.pages_size = GD32_NV_FLASH_V2_BANK1_PAGE_SIZE,
+	.pages_count = GD32_NV_FLASH_V2_BANK1_SIZE / GD32_NV_FLASH_V2_BANK1_PAGE_SIZE
+	}
+#endif
+};
+#endif
+
+static inline void gd32_fmc_v2_bank0_unlock(void)
+{
+	FMC_KEY0 = UNLOCK_KEY0;
+	FMC_KEY0 = UNLOCK_KEY1;
+}
+
+static inline void gd32_fmc_v2_bank0_lock(void)
+{
+	FMC_CTL0 |= FMC_CTL0_LK;
+}
+
+static int gd32_fmc_v2_bank0_wait_idle(void)
+{
+	const int64_t expired_time = k_uptime_get() + GD32_NV_FLASH_V2_TIMEOUT;
+
+	while (FMC_STAT0 & FMC_STAT0_BUSY) {
+		if (k_uptime_get() > expired_time) {
+			return -ETIMEDOUT;
+		}
+	}
+
+	return 0;
+}
+
+static int gd32_fmc_v2_bank0_write(off_t offset, const void *data, size_t len)
+{
+	flash_prg_t *prg_flash = (flash_prg_t *)((uint8_t *)SOC_NV_FLASH_SIZE + offset);
+	flash_prg_t *prg_data = (flash_prg_t *)data;
+	int ret = 0;
+
+	gd32_fmc_v2_bank0_unlock();
+
+	if (FMC_STAT0 & FMC_STAT0_BUSY) {
+		return -EBUSY;
+	}
+
+	FMC_CTL0 |= FMC_CTL0_PG;
+
+	for (size_t i = 0U; i < (len / sizeof(flash_prg_t)); i++) {
+		*prg_flash++ = *prg_data++;
+	}
+
+	ret = gd32_fmc_v2_bank0_wait_idle();
+	if (ret < 0) {
+		goto expired_out;
+	}
+
+	if (FMC_STAT0 & GD32_FMC_V2_BANK0_WRITE_ERR) {
+		ret = -EIO;
+		FMC_STAT0 |= GD32_FMC_V2_BANK0_WRITE_ERR;
+		LOG_ERR("FMC bank0 programming failed");
+	}
+
+expired_out:
+	FMC_CTL0 &= ~FMC_CTL0_PG;
+
+	gd32_fmc_v2_bank0_lock();
+
+	return ret;
+}
+
+static int gd32_fmc_v2_bank0_page_erase(uint32_t page_addr)
+{
+	int ret = 0;
+
+	gd32_fmc_v2_bank0_unlock();
+
+	if (FMC_STAT0 & FMC_STAT0_BUSY) {
+		return -EBUSY;
+	}
+
+	FMC_CTL0 |= FMC_CTL0_PER;
+
+	FMC_ADDR0 = page_addr;
+
+	FMC_CTL0 |= FMC_CTL0_START;
+
+	ret = gd32_fmc_v2_bank0_wait_idle();
+	if (ret < 0) {
+		goto expired_out;
+	}
+
+	if (FMC_STAT0 & GD32_FMC_V2_BANK0_ERASE_ERR) {
+		ret = -EIO;
+		FMC_STAT0 |= GD32_FMC_V2_BANK0_ERASE_ERR;
+		LOG_ERR("FMC bank0 page %u erase failed", page_addr);
+	}
+
+expired_out:
+	FMC_CTL0 &= ~FMC_CTL0_PER;
+
+	gd32_fmc_v2_bank0_lock();
+
+	return ret;
+}
+
+static int gd32_fmc_v2_bank0_erase_block(off_t offset, size_t size)
+{
+	uint32_t page_addr = SOC_NV_FLASH_ADDR + offset;
+	int ret = 0;
+
+	while (size > 0U) {
+		ret = gd32_fmc_v2_bank0_page_erase(page_addr);
+		if (ret < 0) {
+			return ret;
+		}
+
+		size -= GD32_NV_FLASH_V2_BANK0_SIZE;
+		page_addr += GD32_NV_FLASH_V2_BANK0_SIZE;
+	}
+
+	return 0;
+}
+
+#ifdef FLASH_GD32_BANK1_SIZE
+static inline void gd32_fmc_v2_bank1_unlock(void)
+{
+	FMC_KEY1 = UNLOCK_KEY0;
+	FMC_KEY1 = UNLOCK_KEY1;
+}
+
+static inline void gd32_fmc_v2_bank1_lock(void)
+{
+	FMC_CTL1 |= FMC_CTL1_LK;
+}
+
+static int gd32_fmc_v2_bank1_wait_idle(void)
+{
+	const int64_t expired_time = k_uptime_get() + FLASH_GD32_TIMEOUT;
+
+	while (FMC_STAT1 & FMC_STAT1_BUSY) {
+		if (k_uptime_get() > expired_time) {
+			return -ETIMEDOUT;
+		}
+	}
+
+	return 0;
+}
+
+static int gd32_fmc_v2_bank1_write(off_t offset, const void *data, size_t len)
+{
+	flash_prg_t *prg_flash = (flash_prg_t *)((uint8_t *)SOC_NV_FLASH_ADDR + offset);
+	flash_prg_t *prg_data = (flash_prg_t *)data;
+	int ret = 0;
+
+	gd32_fmc_v2_bank1_unlock();
+
+	if (FMC_STAT1 & FMC_STAT1_BUSY) {
+		return -EBUSY;
+	}
+
+	FMC_CTL1 |= FMC_CTL1_PG;
+
+	for (size_t i = 0U; i < (len / sizeof(flash_prg_t)); i++) {
+		*prg_flash++ = *prg_data++;
+	}
+
+	ret = gd32_fmc_v2_bank1_wait_idle();
+	if (ret < 0) {
+		goto expired_out;
+	}
+
+	if (FMC_STAT1 & GD32_FMC_V2_BANK1_WRITE_ERR) {
+		ret = -EIO;
+		FMC_STAT1 |= GD32_FMC_V2_BANK1_WRITE_ERR;
+		LOG_ERR("FMC bank1 programming failed");
+	}
+
+expired_out:
+	FMC_CTL1 &= ~FMC_CTL1_PG;
+
+	gd32_fmc_v2_bank1_lock();
+
+	return ret;
+}
+
+static int gd32_fmc_v2_bank1_page_erase(uint32_t page_addr)
+{
+	int ret = 0;
+
+	gd32_fmc_v2_bank1_unlock();
+
+	if (FMC_STAT1 & FMC_STAT1_BUSY) {
+		return -EBUSY;
+	}
+
+	FMC_CTL1 |= FMC_CTL1_PER;
+
+	FMC_ADDR1 = page_addr;
+
+	FMC_CTL1 |= FMC_CTL1_START;
+
+	ret = gd32_fmc_v2_bank1_wait_idle();
+	if (ret < 0) {
+		goto expired_out;
+	}
+
+	if (FMC_STAT1 & GD32_FMC_V2_BANK1_ERASE_ERR) {
+		ret = -EIO;
+		FMC_STAT1 |= GD32_FMC_V2_BANK1_ERASE_ERR;
+		LOG_ERR("FMC bank1 page %u erase failed", page_addr);
+	}
+
+expired_out:
+	FMC_CTL1 &= ~FMC_CTL1_PER;
+
+	gd32_fmc_v2_bank1_lock();
+
+	return ret;
+}
+
+static int gd32_fmc_v2_bank1_erase_block(off_t offset, size_t size)
+{
+	uint32_t page_addr = SOC_NV_FLASH_ADDR + offset;
+	int ret = 0;
+
+	while (size > 0U) {
+		ret = gd32_fmc_v2_bank1_page_erase(page_addr);
+		if (ret < 0) {
+			return ret;
+		}
+
+		size -= GD32_NV_FLASH_V2_BANK0_SIZE;
+		page_addr += GD32_NV_FLASH_V2_BANK0_SIZE;
+	}
+
+	return 0;
+}
+#endif /* FLASH_GD32_BANK1_SIZE */
+
+bool flash_gd32_valid_range(off_t offset, uint32_t len, bool write)
+{
+	if ((offset > SOC_NV_FLASH_SIZE) ||
+	    ((offset + len) > SOC_NV_FLASH_SIZE)) {
+		return false;
+	}
+
+	if (write) {
+		/* Check offset and len is flash_prg_t aligned. */
+		if ((offset % sizeof(flash_prg_t)) ||
+		    (len % sizeof(flash_prg_t))) {
+			return false;
+		}
+
+	} else {
+		if (offset < GD32_NV_FLASH_V2_BANK0_SIZE) {
+			if (offset % GD32_NV_FLASH_V2_BANK0_SIZE) {
+				return false;
+			}
+
+			if (((offset + len) <= GD32_NV_FLASH_V2_BANK0_SIZE) &&
+			    (len % GD32_NV_FLASH_V2_BANK0_SIZE)) {
+				return false;
+			}
+		}
+
+#ifdef FLASH_GD32_BANK1_SIZE
+		/* Remove bank0 info from offset and len. */
+		if ((offset < GD32_NV_FLASH_V2_BANK0_SIZE) &&
+		    ((offset + len) > GD32_NV_FLASH_V2_BANK0_SIZE))  {
+			len -= (GD32_NV_FLASH_V2_BANK0_SIZE - offset);
+			offset = GD32_NV_FLASH_V2_BANK0_SIZE;
+		}
+
+		if (offset >= GD32_NV_FLASH_V2_BANK0_SIZE) {
+			if ((offset % GD32_NV_FLASH_V2_BANK1_SIZE) ||
+			    (len % GD32_NV_FLASH_V2_BANK1_SIZE)) {
+				return false;
+			}
+		}
+#endif
+	}
+
+	return true;
+}
+
+int flash_gd32_write_range(off_t offset, const void *data, size_t len)
+{
+	size_t len0 = 0U;
+	int ret = 0;
+
+	if (offset < GD32_NV_FLASH_V2_BANK0_SIZE) {
+		if ((offset + len) > GD32_NV_FLASH_V2_BANK0_SIZE) {
+			len0 = GD32_NV_FLASH_V2_BANK0_SIZE - offset;
+		} else {
+			len0 = len;
+		}
+
+		ret = gd32_fmc_v2_bank0_write(offset, data, len0);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+#ifdef FLASH_GD32_BANK1_SIZE
+	size_t len1 = len - len0;
+
+	if (len1 == 0U) {
+		return 0;
+	}
+
+	/* Will programming bank1, remove bank0 offset. */
+	if (offset < GD32_NV_FLASH_V2_BANK0_SIZE)  {
+		offset = GD32_NV_FLASH_V2_BANK0_SIZE;
+	}
+
+	ret = gd32_fmc_v2_bank1_write(offset, data, len1);
+	if (ret < 0) {
+		return ret;
+	}
+#endif
+
+	return 0;
+}
+
+int flash_gd32_erase_block(off_t offset, size_t size)
+{
+	size_t size0 = 0U;
+	int ret = 0;
+
+	if (offset < GD32_NV_FLASH_V2_BANK0_SIZE) {
+		if ((offset + size0) > GD32_NV_FLASH_V2_BANK0_SIZE) {
+			size0 = GD32_NV_FLASH_V2_BANK0_SIZE - offset;
+		} else {
+			size0 = size;
+		}
+
+		ret = gd32_fmc_v2_bank0_erase_block(offset, size0);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+#ifdef FLASH_GD32_BANK1_SIZE
+	size_t size1 = size - size0;
+
+	if (size1 == 0U) {
+		return 0;
+	}
+
+	/* Will programming bank1, remove bank0 info from offset. */
+	if (offset < GD32_NV_FLASH_V2_BANK0_SIZE)  {
+		offset = GD32_NV_FLASH_V2_BANK0_SIZE;
+	}
+
+	ret = gd32_fmc_v2_bank1_erase_block(offset, size1);
+	if (ret < 0) {
+		return ret;
+	}
+#endif
+
+	return 0;
+}
+
+#ifdef CONFIG_FLASH_PAGE_LAYOUT
+void flash_gd32_pages_layout(const struct device *dev,
+			     const struct flash_pages_layout **layout,
+			     size_t *layout_size)
+{
+	ARG_UNUSED(dev);
+
+	*layout = gd32_fmc_v2_layout;
+	*layout_size = ARRAY_SIZE(gd32_fmc_v2_layout);
+
+}
+#endif /* CONFIG_FLASH_PAGE_LAYOUT */

--- a/drivers/flash/flash_gd32_v3.c
+++ b/drivers/flash/flash_gd32_v3.c
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2022 BrainCo Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "flash_gd32.h"
+
+#include <zephyr/logging/log.h>
+
+#include <gd32_fmc.h>
+
+LOG_MODULE_DECLARE(flash_gd32);
+
+#define GD32_NV_FLASH_V3_NODE		DT_INST(0, gd_gd32_nv_flash_v3)
+#define GD32_NV_FLASH_V3_TIMEOUT	DT_PROP(GD32_NV_FLASH_V3_NODE, max_erase_time_ms)
+
+/**
+ * @brief GD32 FMC v3 flash memory layout for GD32F4xx series.
+ */
+#if defined(CONFIG_FLASH_PAGE_LAYOUT) && \
+	defined(CONFIG_SOC_SERIES_GD32F4XX)
+#if (PRE_KB(512) == SOC_NV_FLASH_SIZE)
+static const struct flash_pages_layout gd32_fmc_v3_layout[] = {
+	{.pages_count = 4, .pages_size = KB(16)},
+	{.pages_count = 1, .pages_size = KB(64)},
+	{.pages_count = 3, .pages_size = KB(128)},
+};
+#elif (PRE_KB(1024) == SOC_NV_FLASH_SIZE)
+static const struct flash_pages_layout gd32_fmc_v3_layout[] = {
+	{.pages_count = 4, .pages_size = KB(16)},
+	{.pages_count = 1, .pages_size = KB(64)},
+	{.pages_count = 7, .pages_size = KB(128)},
+};
+#elif (PRE_KB(2048) == SOC_NV_FLASH_SIZE)
+static const struct flash_pages_layout gd32_fmc_v3_layout[] = {
+	{.pages_count = 4, .pages_size = KB(16)},
+	{.pages_count = 1, .pages_size = KB(64)},
+	{.pages_count = 7, .pages_size = KB(128)},
+	{.pages_count = 4, .pages_size = KB(16)},
+	{.pages_count = 1, .pages_size = KB(64)},
+	{.pages_count = 7, .pages_size = KB(128)},
+};
+#elif (PRE_KB(3072) == SOC_NV_FLASH_SIZE)
+static const struct flash_pages_layout gd32_fmc_v3_layout[] = {
+	{.pages_count = 4, .pages_size = KB(16)},
+	{.pages_count = 1, .pages_size = KB(64)},
+	{.pages_count = 7, .pages_size = KB(128)},
+	{.pages_count = 4, .pages_size = KB(16)},
+	{.pages_count = 1, .pages_size = KB(64)},
+	{.pages_count = 7, .pages_size = KB(128)},
+	{.pages_count = 4, .pages_size = KB(256)},
+};
+#else
+#error "Unknown FMC layout for GD32F4xx series."
+#endif
+#endif /* CONFIG_FLASH_PAGE_LAYOUT */
+
+#define gd32_fmc_v3_WRITE_ERR (FMC_STAT_PGMERR | FMC_STAT_PGSERR | FMC_STAT_WPERR)
+#define gd32_fmc_v3_ERASE_ERR FMC_STAT_OPERR
+
+/* SN bits in FMC_CTL are not continue values, use table below to map them. */
+static uint8_t gd32_fmc_v3_sectors[] = {
+	0U, 1U, 2U, 3U, 4U, 5U, 6U, 7U, 8U, 9U, 10U, 11U,
+	16U, 17U, 18U, 19U, 20U, 21U, 22U, 23U, 24U, 25U, 26U, 27U,
+	12U, 13U, 14U, 15U
+};
+
+static inline void gd32_fmc_v3_unlock(void)
+{
+	FMC_KEY = UNLOCK_KEY0;
+	FMC_KEY = UNLOCK_KEY1;
+}
+
+static inline void gd32_fmc_v3_lock(void)
+{
+	FMC_CTL |= FMC_CTL_LK;
+}
+
+static int gd32_fmc_v3_wait_idle(void)
+{
+	const int64_t expired_time = k_uptime_get() + GD32_NV_FLASH_V3_TIMEOUT;
+
+	while (FMC_STAT & FMC_STAT_BUSY) {
+		if (k_uptime_get() > expired_time) {
+			return -ETIMEDOUT;
+		}
+	}
+
+	return 0;
+}
+
+bool flash_gd32_valid_range(off_t offset, uint32_t len, bool write)
+{
+	const struct flash_pages_layout *page_layout;
+	uint32_t cur = 0U, next = 0U;
+
+	if ((offset > SOC_NV_FLASH_SIZE) ||
+	    ((offset + len) > SOC_NV_FLASH_SIZE)) {
+		return false;
+	}
+
+	if (write) {
+		/* Check offset and len aligned to write-block-size. */
+		if ((offset % sizeof(flash_prg_t)) ||
+		    (len % sizeof(flash_prg_t))) {
+			return false;
+		}
+
+	} else {
+		for (size_t i = 0; i < ARRAY_SIZE(gd32_fmc_v3_layout); i++) {
+			page_layout = &gd32_fmc_v3_layout[i];
+
+			for (size_t j = 0; j < page_layout->pages_count; j++) {
+				cur = next;
+
+				next += page_layout->pages_size;
+
+				/* Check bad offset. */
+				if ((offset > cur) && (offset < next)) {
+					return false;
+				}
+
+				/* Check bad len. */
+				if (((offset + len) > cur) &&
+				    ((offset + len) < next)) {
+					return false;
+				}
+
+				if ((offset + len) == next) {
+					return true;
+				}
+			}
+		}
+	}
+
+	return true;
+}
+
+int flash_gd32_write_range(off_t offset, const void *data, size_t len)
+{
+	flash_prg_t *prg_flash = (flash_prg_t *)((uint8_t *)SOC_NV_FLASH_ADDR + offset);
+	flash_prg_t *prg_data = (flash_prg_t *)data;
+	int ret = 0;
+
+	gd32_fmc_v3_unlock();
+
+	if (FMC_STAT & FMC_STAT_BUSY) {
+		return -EBUSY;
+	}
+
+	FMC_CTL |= FMC_CTL_PG;
+
+	FMC_CTL &= ~FMC_CTL_PSZ;
+	FMC_CTL |= CTL_PSZ(sizeof(flash_prg_t) - 1);
+
+	for (size_t i = 0U; i < (len / sizeof(flash_prg_t)); i++) {
+		*prg_flash++ = *prg_data++;
+	}
+
+	ret = gd32_fmc_v3_wait_idle();
+	if (ret < 0) {
+		goto expired_out;
+	}
+
+	if (FMC_STAT & gd32_fmc_v3_WRITE_ERR) {
+		ret = -EIO;
+		FMC_STAT |= gd32_fmc_v3_WRITE_ERR;
+		LOG_ERR("FMC programming failed");
+	}
+
+expired_out:
+	FMC_CTL &= ~FMC_CTL_PG;
+
+	gd32_fmc_v3_lock();
+
+	return ret;
+}
+
+static int gd32_fmc_v3_sector_erase(uint8_t sector)
+{
+	int ret = 0;
+
+	gd32_fmc_v3_unlock();
+
+	if (FMC_STAT & FMC_STAT_BUSY) {
+		return -EBUSY;
+	}
+
+	FMC_CTL |= FMC_CTL_SER;
+
+	FMC_CTL &= ~FMC_CTL_SN;
+	FMC_CTL |= CTL_SN(sector);
+
+	FMC_CTL |= FMC_CTL_START;
+
+	ret = gd32_fmc_v3_wait_idle();
+	if (ret < 0) {
+		goto expired_out;
+	}
+
+	if (FMC_STAT & gd32_fmc_v3_ERASE_ERR) {
+		ret = -EIO;
+		FMC_STAT |= gd32_fmc_v3_ERASE_ERR;
+		LOG_ERR("FMC sector %u erase failed", sector);
+	}
+
+expired_out:
+	FMC_CTL &= ~FMC_CTL_SER;
+
+	gd32_fmc_v3_lock();
+
+	return ret;
+}
+
+int flash_gd32_erase_block(off_t offset, size_t size)
+{
+	const struct flash_pages_layout *page_layout;
+	uint32_t erase_offset = 0U;
+	uint8_t counter = 0U;
+	int ret = 0;
+
+	for (size_t i = 0; i < ARRAY_SIZE(gd32_fmc_v3_layout); i++) {
+		page_layout = &gd32_fmc_v3_layout[i];
+
+		for (size_t j = 0; j < page_layout->pages_count; j++) {
+			if (erase_offset < offset) {
+				counter++;
+				erase_offset += page_layout->pages_size;
+
+				continue;
+			}
+
+			uint8_t sector = gd32_fmc_v3_sectors[counter++];
+
+			ret = gd32_fmc_v3_sector_erase(sector);
+			if (ret < 0) {
+				return ret;
+			}
+
+			erase_offset += page_layout->pages_size;
+
+			if (erase_offset - offset >= size) {
+				return 0;
+			}
+		}
+	}
+
+	return 0;
+}
+
+#ifdef CONFIG_FLASH_PAGE_LAYOUT
+void flash_gd32_pages_layout(const struct device *dev,
+			     const struct flash_pages_layout **layout,
+			     size_t *layout_size)
+{
+	ARG_UNUSED(dev);
+
+	*layout = gd32_fmc_v3_layout;
+	*layout_size = ARRAY_SIZE(gd32_fmc_v3_layout);
+}
+#endif /* CONFIG_FLASH_PAGE_LAYOUT */

--- a/dts/arm/gigadevice/gd32e10x/gd32e10x.dtsi
+++ b/dts/arm/gigadevice/gd32e10x/gd32e10x.dtsi
@@ -56,7 +56,10 @@
 			#size-cells = <1>;
 
 			flash0: flash@8000000 {
-				compatible = "soc-nv-flash";
+				compatible = "gd,gd32-nv-flash-v1", "soc-nv-flash";
+				write-block-size = <2>;
+				max-erase-time-ms = <4>;
+				page-size = <DT_SIZE_K(1)>;
 			};
 		};
 

--- a/dts/arm/gigadevice/gd32e50x/gd32e50x.dtsi
+++ b/dts/arm/gigadevice/gd32e50x/gd32e50x.dtsi
@@ -57,7 +57,17 @@
 			#size-cells = <1>;
 
 			flash0: flash@8000000 {
-				compatible = "soc-nv-flash";
+				compatible = "gd,gd32-nv-flash-v1", "soc-nv-flash";
+				write-block-size = <2>;
+				/* GD32E50x DataSheet not defined the maximum page erase time
+				 * for flash memory.
+				 * From other GD32 DataSheets, we can find 1KB page normally have a
+				 * 300ms max time.
+				 * Assume GD32E50x use the worst implementation, set the max erase
+				 * time to 8 times of 1KB page.
+				 */
+				max-erase-time-ms = <2400>;
+				page-size = <DT_SIZE_K(8)>;
 			};
 		};
 

--- a/dts/arm/gigadevice/gd32f3x0/gd32f3x0.dtsi
+++ b/dts/arm/gigadevice/gd32f3x0/gd32f3x0.dtsi
@@ -54,7 +54,10 @@
 			#size-cells = <1>;
 
 			flash0: flash@8000000 {
-				compatible = "soc-nv-flash";
+				compatible = "gd,gd32-nv-flash-v1", "soc-nv-flash";
+				write-block-size = <2>;
+				max-erase-time-ms = <300>;
+				page-size = <DT_SIZE_K(1)>;
 			};
 		};
 

--- a/dts/arm/gigadevice/gd32f403/gd32f403.dtsi
+++ b/dts/arm/gigadevice/gd32f403/gd32f403.dtsi
@@ -62,7 +62,11 @@
 			#size-cells = <1>;
 
 			flash0: flash@8000000 {
-				compatible = "soc-nv-flash";
+				compatible = "gd,gd32-nv-flash-v2", "soc-nv-flash";
+				write-block-size = <2>;
+				max-erase-time-ms = <300>;
+				bank0-page-size = <DT_SIZE_K(2)>;
+				bank1-page-size = <DT_SIZE_K(4)>;
 			};
 		};
 

--- a/dts/arm/gigadevice/gd32f4xx/gd32f4xx.dtsi
+++ b/dts/arm/gigadevice/gd32f4xx/gd32f4xx.dtsi
@@ -62,7 +62,9 @@
 			#size-cells = <1>;
 
 			flash0: flash@8000000 {
-				compatible = "soc-nv-flash";
+				compatible = "gd,gd32-nv-flash-v3", "soc-nv-flash";
+				write-block-size = <2>;
+				max-erase-time-ms = <8000>;
 			};
 		};
 

--- a/dts/bindings/flash_controller/gd,gd32-flash-controller.yaml
+++ b/dts/bindings/flash_controller/gd,gd32-flash-controller.yaml
@@ -1,7 +1,18 @@
 # Copyright (c) 2022 Teslabs Engineering S.L.
 # SPDX-License-Identifier: Apache-2.0
 
-description: GD32 flash controller
+description: |
+  There are three types GD32 FMC.
+
+  GD32 FMC v1: its flash memory has 1 bank, page size is equal in the bank,
+  flash size is smaller than 512KB.
+
+  GD32 FMC v2: its flash memory has 2 banks. Page size equal within the same bank but
+  different between banks. Flash size can be up to 3072KB. FMC v2 has two
+  registers to control bank0 and bank1 separately.
+
+  GD32 FMC v3: its flash memory has 2 banks, use sector size as the minimum operating
+  unit, the sector size is not equal.
 
 compatible: "gd,gd32-flash-controller"
 

--- a/dts/bindings/mtd/gd,gd32-nv-flash-v1.yaml
+++ b/dts/bindings/mtd/gd,gd32-nv-flash-v1.yaml
@@ -1,0 +1,32 @@
+# Copyright (c) 2022 BrainCo Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Flash memory binding of GD32 FMC v1.
+
+  GD32 series use this type flash memory:
+    - GD32C10x
+    - GD32C11x
+    - GD32E10x
+    - GD32E11x
+    - GD32E50x
+    - GD32F3x0
+    - GD32F1x0
+    - GD32E23x
+    - GD32VF103
+    - GD32L23x
+
+include: soc-nv-flash.yaml
+
+compatible: gd,gd32-nv-flash-v1
+
+properties:
+  max-erase-time-ms:
+    type: int
+    required: true
+    description: Max erase time(millisecond) of a flash page
+
+  page-size:
+    type: int
+    required: true
+    description: Flash memory page size

--- a/dts/bindings/mtd/gd,gd32-nv-flash-v2.yaml
+++ b/dts/bindings/mtd/gd,gd32-nv-flash-v2.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) 2022 BrainCo Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Flash memory binding of GD32 FMC v2.
+
+  GD32 series use this type flash memory:
+    - GD32F10x
+    - GD32F20x
+    - GD32F30x
+    - GD32F403
+
+include: soc-nv-flash.yaml
+
+compatible: gd,gd32-nv-flash-v2
+
+properties:
+  max-erase-time-ms:
+    type: int
+    required: true
+    description: Max erase time(millisecond) of a flash page
+
+  bank0-page-size:
+    type: int
+    required: true
+    description: Flash memory page size for bank0
+
+  bank1-page-size:
+    type: int
+    required: true
+    description: Flash memory page size for bank1

--- a/dts/bindings/mtd/gd,gd32-nv-flash-v3.yaml
+++ b/dts/bindings/mtd/gd,gd32-nv-flash-v3.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2022 BrainCo Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Flash memory binding of GD32 FMC v3.
+
+  GD32 series use this type flash memory:
+    - GD32F4xx
+
+include: soc-nv-flash.yaml
+
+compatible: gd,gd32-nv-flash-v3
+
+properties:
+  max-erase-time-ms:
+    type: int
+    required: true
+    description: max erase time(millisecond) of a flash sector

--- a/dts/riscv/gigadevice/gd32vf103.dtsi
+++ b/dts/riscv/gigadevice/gd32vf103.dtsi
@@ -82,8 +82,10 @@
 			#size-cells = <1>;
 
 			flash0: flash@8000000 {
-				compatible = "soc-nv-flash";
+				compatible = "gd,gd32-nv-flash-v1", "soc-nv-flash";
 				write-block-size = <2>;
+				max-erase-time-ms = <300>;
+				page-size = <DT_SIZE_K(1)>;
 			};
 		};
 

--- a/samples/drivers/flash_shell/boards/gd32vf103c_starter.conf
+++ b/samples/drivers/flash_shell/boards/gd32vf103c_starter.conf
@@ -1,0 +1,2 @@
+# This board only has 32KB SRAM, can not afford 16 KB memory pool, use 8KB instead.
+CONFIG_HEAP_MEM_POOL_SIZE=8192

--- a/samples/drivers/flash_shell/boards/gd32vf103v_eval.conf
+++ b/samples/drivers/flash_shell/boards/gd32vf103v_eval.conf
@@ -1,0 +1,2 @@
+# This board only has 32KB SRAM, can not afford 16 KB memory pool, use 8KB instead.
+CONFIG_HEAP_MEM_POOL_SIZE=8192

--- a/samples/drivers/flash_shell/sample.yaml
+++ b/samples/drivers/flash_shell/sample.yaml
@@ -6,6 +6,6 @@ tests:
   sample.drivers.flash.shell:
     tags: flash shell
     filter: CONFIG_FLASH_HAS_DRIVER_ENABLED
-    platform_exclude: nucleo_h745zi_q_m4 stm32h747i_disco_m4
+    platform_exclude: nucleo_h745zi_q_m4 stm32h747i_disco_m4 gd32f350r_eval
     harness: keyboard
     min_ram: 12


### PR DESCRIPTION
After read all gd32 series user manual, I get some conclusion for gd32 FMC. But remember, this is not an official document.

This implement GD32 FMC v1, GD32 FMC v2 and GD32F4xx FMC.

## GD32 FMC v1

There have some gd32 FMC only have 1 bank, and their size is smaller than 512K. This group called GD32 FMC v1. 

| GD32 SoC      | Max Flash Size | Bank0 Page Size |
| -----------   | -----------    | -----------     |
| GD32C10x      | 128K           | 1K              |
| GD32C11x      | 128K           | 1K              |
| GD32E10x      | 128K           | 1K              |
| GD32E11x      | 128K           | 1K              |
| GD32E50x      | 512K           | 8K              |
| GD32F3x0      | 128K           | 1K              |
| GD32F1x0      | 64K            | 1K              |
| GD32E23x      | 64K            | 1K              |
| GD32VF103     | 128K           | 1K              |
| GD32L23x      | 256K           | 4/2/1K          |

## GD32 FMC v2

There have some gd32 FMC have 2 bank, and their size can up to 3072K. This group called GD32 FMC v2.

| GD32 SoC    | Max Flash Size | Bank0 Page Size | Bank1 Page Size |
| ----------- | -----------    | -----------     | -----------     |
| GD32A503  | 384K             | 1K              |  1K             |
| GD32F10x    | 3072K          | 2K              | 4K              |
| GD32F20x    | 3072K          | 2K              | 4K              |
| GD32F30x    | 3072K          | 2K              | 4K              |
| GD32F403    | 3072K          | 2K              | 4K              |

For GD32 FMC v2, Bank0 hold the first 512K flash size, and Bank1 for the reset capacity. It have two register set to control Bank0 and Bank1 separately.

In this group, there have some concept called MD(Medium density), HD(High density), XD(Extra density), CL(Connectivity line). Only GD32F10x_MD have some effect for the page size, others can be ignored.

For GD32F10x series, their have some special case for GD32F101x and GD32F103x.

| GD32 SoC    | Flash Size Range | Page Size |
| ---         | ---              | ---       |
| GD32F10x_MD | 16K-256K         | 1K        |
| GD32F10x_HD | 256K-512K        | 2K        |
| GD32F10x_XD | 512K-3072K       | 4K        |

## GD32 FMC v3 (GD32F4xx)

GD32F4xx FMC use `sector` as the minimal operate unit. For GD32F425x, GD32F427x, GD32F470x, `page` are also supported, page size is 4K.

## GD32W51X
GD32W51x FMC is complex, it have FMC mode and QSPI mode. Future developer can pick some to implement, e.g. FMC mode.


## Reference
- [GD32 User Manual](https://gd32mcu.com/en/download/6?kw=)
- [GD32MCU Selection Guide](https://gd32mcu.com/en/download/9?kw=)