### PR TITLE
twister: add fixtures given by --fixture option to each devices.

### DIFF
--- a/doc/guides/test/twister.rst
+++ b/doc/guides/test/twister.rst
@@ -618,6 +618,11 @@ and these tests will be executed on the boards that provide this fixture.
 .. figure:: fixtures.svg
    :figclass: align-center
 
+Fixtures can also be provided via twister command option ``--fixture``, this option
+can be used multiple times and all given fixtures will be appended as a list. And the
+given fixtures will be assigned to all boards, this means that all boards set by
+current twister command can run those testcases which request the same fixtures.
+
 Notes
 +++++
 

--- a/scripts/twister
+++ b/scripts/twister
@@ -979,6 +979,11 @@ def main():
                              --device-serial or --device-serial-pty,
                              only one platform is allowed""")
 
+    # the fixtures given by twister command explicitly should be assigned to each DUTs
+    if suite.fixtures:
+        for d in suite.duts:
+            d.fixtures.extend(suite.fixtures)
+
     if suite.load_errors:
         sys.exit(1)
 


### PR DESCRIPTION
fixtures could also be given by twister command with --fixture option
explicitly, not only hardware map file. In this case, we should
assign those fixtures to each devices too.

Signed-off-by: Chen Peng1 <peng1.chen@intel.com>