### PR TITLE
I2C: add a define that can write a specified speed from dts

### DIFF
--- a/include/drivers/i2c.h
+++ b/include/drivers/i2c.h
@@ -45,6 +45,9 @@ extern "C" {
 /** I2C Ultra Fast Speed: 5 MHz */
 #define I2C_SPEED_ULTRA			(0x5U)
 
+/** Device Tree specified speed */
+#define I2C_SPEED_DT			(0x7U)
+
 #define I2C_SPEED_SHIFT			(1U)
 #define I2C_SPEED_SET(speed)		(((speed) << I2C_SPEED_SHIFT) \
 						& I2C_SPEED_MASK)


### PR DESCRIPTION
So far the I2C channel connected to the battery has chosen the option of Standard-mode 100KHz, but according to the SI(Signal Integrity) test report, the I2C channel doesn’t meet the tHD;DAT Margin/Threshold in the SI test. In fact, the timing could be adjusted by changing the settings in the related timing registers in EC, but unfortunately the limitation exists due to the fact that the timing registers have been currently occupied by another channel for the same reason, that is, adjusting the timing.
However, according to the I2C specification, the Standard-mode (Sm) has a bit rate up to 100 kbit/s, so far the battery use the option of standard mode 100KHz in the SMCLK setting register. This SMCLK setting register also provides standard mode 50KHz for usage. According to another SI test reports, so far the Standard-mode 50KHz setting looks good in the SI test. 

Therefore, add a #define I2C_SPEED_DT allows the device tree to write a specified speed without causing i2c_configure() and
i2c_get_config() to return error.

Signed-off-by: Tim Lin <tim2.lin@ite.corp-partner.google.com>