### PR TITLE
doc: requirements: stick to breathe < 4.33

### DIFF
--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -1,6 +1,6 @@
 # DOC: used to generate docs
 
-breathe>=4.30,!=4.33
+breathe>=4.30,<4.33 # 4.33: disabled due to #803 and #805 issues
 sphinx~=4.0
 sphinx_rtd_theme~=1.0
 sphinx-tabs


### PR DESCRIPTION
Looks like the 4.33 release has some more issues, so let's wait until
everything gets fixed before allowing future versions.

Ref. https://github.com/michaeljones/breathe/issues/805