### PR TITLE
core: z_data_copy does not depend on CONFIG_XIP

### DIFF
--- a/arch/nios2/core/prep_c.c
+++ b/arch/nios2/core/prep_c.c
@@ -31,11 +31,11 @@
 void _PrepC(void)
 {
 	z_bss_zero();
-#ifdef CONFIG_XIP
 	z_data_copy();
 	/* In most XIP scenarios we copy the exception code into RAM, so need
 	 * to flush instruction cache.
 	 */
+#ifdef CONFIG_XIP
 	z_nios2_icache_flush_all();
 #if ALT_CPU_ICACHE_SIZE > 0
 	/* Only need to flush the data cache here if there actually is an

--- a/arch/riscv/core/prep_c.c
+++ b/arch/riscv/core/prep_c.c
@@ -30,9 +30,7 @@
 void _PrepC(void)
 {
 	z_bss_zero();
-#ifdef CONFIG_XIP
 	z_data_copy();
-#endif
 #if defined(CONFIG_RISCV_SOC_INTERRUPT_INIT)
 	soc_interrupt_init();
 #endif

--- a/arch/sparc/core/prep_c.c
+++ b/arch/sparc/core/prep_c.c
@@ -19,9 +19,7 @@
 
 void _PrepC(void)
 {
-#ifdef CONFIG_XIP
 	z_data_copy();
-#endif
 	z_cstart();
 	CODE_UNREACHABLE;
 }

--- a/arch/x86/core/intel64/cpu.c
+++ b/arch/x86/core/intel64/cpu.c
@@ -169,9 +169,7 @@ FUNC_NORETURN void z_x86_cpu_init(struct x86_cpuboot *cpuboot)
 	if (cpu_num == 0U) {
 		/* Only need to do these once per boot */
 		z_bss_zero();
-#ifdef CONFIG_XIP
 		z_data_copy();
-#endif
 	}
 
 	z_loapic_enable(cpu_num);


### PR DESCRIPTION
When XIP is not enabled, z_data_copy() already falls back to an empty
function. No need to ifdef it.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>