### PR TITLE
gen_relocate_app: Create files from scratch, do not append

### DIFF
--- a/scripts/gen_relocate_app.py
+++ b/scripts/gen_relocate_app.py
@@ -293,13 +293,13 @@ def generate_linker_script(linker_file, sram_data_linker_file, sram_bss_linker_f
             gen_string += string_create_helper("bss", memory_type, full_list_of_sections, 0)
 
     # finally writing to the linker file
-    with open(linker_file, "a+") as file_desc:
+    with open(linker_file, "w") as file_desc:
         file_desc.write(gen_string)
 
-    with open(sram_data_linker_file, "a+") as file_desc:
+    with open(sram_data_linker_file, "w") as file_desc:
         file_desc.write(gen_string_sram_data)
 
-    with open(sram_bss_linker_file, "a+") as file_desc:
+    with open(sram_bss_linker_file, "w") as file_desc:
         file_desc.write(gen_string_sram_bss)
 
 


### PR DESCRIPTION
The problem with append is that when doing incremental (non-clean)
build, the content of these files are appended each time to the previous
leftover content.

Example:
```
 # west build -p -b qemu_cortex_m3 \
 	samples/application_development/code_relocation/

 #   // disable for example CONFIG_XIP

 # west build -b qemu_cortex_m3 \
        samples/application_development/code_relocation/
```
at this point the content of the generated files (i.e.
linker_relocate.ld) is wrong.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>