### PR TITLE
drivers: eth: native_posix: Read back ethernet interface name

### DIFF
--- a/drivers/ethernet/eth_native_posix_adapt.c
+++ b/drivers/ethernet/eth_native_posix_adapt.c
@@ -52,7 +52,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 /* Note that we cannot create the TUN/TAP device from the setup script
  * as we need to get a file descriptor to communicate with the interface.
  */
-int eth_iface_create(const char *if_name, bool tun_only)
+int eth_iface_create(char *if_name, size_t if_name_size, bool tun_only)
 {
 	struct ifreq ifr;
 	int fd, ret = -EINVAL;
@@ -75,6 +75,8 @@ int eth_iface_create(const char *if_name, bool tun_only)
 		close(fd);
 		return ret;
 	}
+	strncpy(if_name, ifr.ifr_name, if_name_size - 1);
+	if_name[if_name_size - 1] = 0;
 #endif
 
 	return fd;

--- a/drivers/ethernet/eth_native_posix_priv.h
+++ b/drivers/ethernet/eth_native_posix_priv.h
@@ -25,7 +25,7 @@
 #define ETH_NATIVE_POSIX_STARTUP_SCRIPT_USER ""
 #endif
 
-int eth_iface_create(const char *if_name, bool tun_only);
+int eth_iface_create(char *if_name, size_t if_name_size, bool tun_only);
 int eth_iface_remove(int fd);
 int eth_setup_host(const char *if_name);
 int eth_start_script(const char *if_name);


### PR DESCRIPTION
This enables use of automatically-unique interface names such as "zeth%d",
making it possible to run multiple Zephyr instances on a network without
having to build one binary per instance.

This greatly simplifies https://docs.zephyrproject.org/latest/guides/networking/networking_with_multiple_instances.html

Example config:

CONFIG_ETH_NATIVE_POSIX_DRV_NAME="zeth%d"
CONFIG_ETH_NATIVE_POSIX_SETUP_SCRIPT="false"
CONFIG_ETH_NATIVE_POSIX_STARTUP_SCRIPT="brctl addif zeth-br"

This gives every Zephyr instance started a unique interface name and
automatically adds it to the zeth-br bridge.

Signed-off-by: Björn Stenberg <bjorn@haxx.se>