### PR TITLE
CMake: net: pkt_filter: Only construct the library if enabled

### DIFF
--- a/subsys/net/pkt_filter/CMakeLists.txt
+++ b/subsys/net/pkt_filter/CMakeLists.txt
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
 
 if(CONFIG_NET_PKT_FILTER)
-
+zephyr_library()
 zephyr_library_sources(base.c)
 zephyr_library_sources_ifdef(CONFIG_NET_L2_ETHERNET ethernet.c)
 


### PR DESCRIPTION
This fixes "No SOURCES given to Zephyr library: subsys__net__pkt_filter"

Signed-off-by: Björn Stenberg <bjorn@haxx.se>