### PR TITLE
tests: ringbuffer: increase timeout

### DIFF
--- a/tests/lib/ringbuffer/testcase.yaml
+++ b/tests/lib/ringbuffer/testcase.yaml
@@ -1,6 +1,6 @@
 common:
     tags: ring_buffer circular_buffer
-    timeout: 90
+    timeout: 150
 
 tests:
   libraries.ring_buffer:


### PR DESCRIPTION
Increae timeout from 90 to 150 to make it pass on more slow boards.

Fixes #42756

Signed-off-by: Anas Nashif <anas.nashif@intel.com>