### PR TITLE
ring buffer code revamp

### DIFF
--- a/doc/reference/data_structures/ring_buffers.rst
+++ b/doc/reference/data_structures/ring_buffers.rst
@@ -103,8 +103,8 @@ transfer; it will return an error in the case where the provided data
 does not fit in its entirety.
 
 The user can manage the capacity of a ring buffer without modifying it
-using the :c:func:`ring_buf_space_get` call (which returns a value of
-either bytes or items depending on how the ring buffer has been used),
+using either :c:func:`ring_buf_space_get` or :c:func:`ring_buf_item_space_get`
+which returns the number of free bytes or free items respectively,
 or by testing the :c:func:`ring_buf_is_empty` predicate.
 
 Finally, a :c:func:`ring_buf_reset` call exists to immediately empty a
@@ -213,7 +213,8 @@ Defining a Ring Buffer
 ======================
 
 A ring buffer is defined using a variable of type :c:type:`ring_buf`.
-It must then be initialized by calling :c:func:`ring_buf_init`.
+It must then be initialized by calling :c:func:`ring_buf_init` or
+c:func:`ring_buf_item_init`.
 
 The following code defines and initializes an empty **data item mode** ring
 buffer (which is part of a larger data structure). The ring buffer's data buffer
@@ -231,7 +232,7 @@ is capable of holding 64 words of data and metadata information.
     struct my_struct ms;
 
     void init_my_struct {
-        ring_buf_init(&ms.rb, MY_RING_BUF_WORDS, ms.buffer);
+        ring_buf_item_init(&ms.rb, MY_RING_BUF_WORDS, ms.buffer);
         ...
     }
 

--- a/drivers/console/ipm_console_receiver.c
+++ b/drivers/console/ipm_console_receiver.c
@@ -73,7 +73,7 @@ static void ipm_console_thread(void *arg1, void *arg2, void *arg3)
 		 * clearing the channel_disabled flag.
 		 */
 		if (driver_data->channel_disabled &&
-		    ring_buf_space_get(&driver_data->rb)) {
+		    ring_buf_item_space_get(&driver_data->rb)) {
 			key = irq_lock();
 			ipm_set_enabled(driver_data->ipm_device, 1);
 			driver_data->channel_disabled = 0;
@@ -104,7 +104,7 @@ static void ipm_console_receive_callback(const struct device *ipm_dev,
 	 * call with the wait flag enabled.  It blocks until the receiver side
 	 * re-enables the channel and consumes the data.
 	 */
-	if (ring_buf_space_get(&driver_data->rb) == 0) {
+	if (ring_buf_item_space_get(&driver_data->rb) == 0) {
 		ipm_set_enabled(ipm_dev, 0);
 		driver_data->channel_disabled = 1;
 	}
@@ -135,8 +135,8 @@ int ipm_console_receiver_init(const struct device *d)
 	driver_data->ipm_device = ipm;
 	driver_data->channel_disabled = 0;
 	k_sem_init(&driver_data->sem, 0, K_SEM_MAX_LIMIT);
-	ring_buf_init(&driver_data->rb, config_info->rb_size32,
-		      config_info->ring_buf_data);
+	ring_buf_item_init(&driver_data->rb, config_info->rb_size32,
+			   config_info->ring_buf_data);
 
 	ipm_register_callback(ipm, ipm_console_receive_callback, driver_data);
 

--- a/include/shell/shell_history.h
+++ b/include/shell/shell_history.h
@@ -36,7 +36,7 @@ struct shell_history {
 	static struct ring_buf _name##_ring_buf =		  \
 		{						  \
 			.size = _size,				  \
-			.buf =  { .buf8 = _name##_ring_buf_data } \
+			.buffer = _name##_ring_buf_data		  \
 		};						  \
 	static struct shell_history _name = {			  \
 		.ring_buf = &_name##_ring_buf			  \

--- a/include/sys/ring_buffer.h
+++ b/include/sys/ring_buffer.h
@@ -43,6 +43,17 @@ struct ring_buf {
 };
 
 /**
+ * @brief Function to force ring_buf internal states to given value
+ *
+ * Any value other than 0 makes sense only in validation testing context.
+ */
+static inline void ring_buf_internal_reset(struct ring_buf *buf, int32_t value)
+{
+	buf->put_head = buf->put_tail = buf->put_base = value;
+	buf->get_head = buf->get_tail = buf->get_base = value;
+}
+
+/**
  * @defgroup ring_buffer_apis Ring Buffer APIs
  * @ingroup datastructure_apis
  * @{
@@ -138,8 +149,7 @@ static inline void ring_buf_init(struct ring_buf *buf,
 
 	buf->size = size;
 	buf->buffer = data;
-	buf->put_head = buf->put_tail = buf->put_base = 0;
-	buf->get_head = buf->get_tail = buf->get_base = 0;
+	ring_buf_internal_reset(buf, 0);
 }
 
 /**
@@ -185,8 +195,7 @@ static inline bool ring_buf_is_empty(struct ring_buf *buf)
  */
 static inline void ring_buf_reset(struct ring_buf *buf)
 {
-	buf->put_head = buf->put_tail = buf->put_base = 0;
-	buf->get_head = buf->get_tail = buf->get_base = 0;
+	ring_buf_internal_reset(buf, 0);
 }
 
 /**

--- a/lib/os/ring_buffer.c
+++ b/lib/os/ring_buffer.c
@@ -9,16 +9,6 @@
 #include <sys/ring_buffer.h>
 #include <string.h>
 
-/* LCOV_EXCL_START */
-/* The weak function used to allow overwriting it in the test and trigger
- * rewinding earlier.
- */
-uint32_t __weak ring_buf_get_rewind_threshold(void)
-{
-	return RING_BUFFER_MAX_SIZE;
-}
-/* LCOV_EXCL_STOP */
-
 /**
  * Internal data structure for a buffer header.
  *
@@ -30,52 +20,6 @@ struct ring_element {
 	uint32_t  length :8;  /**< length in 32-bit chunks */
 	uint32_t  value  :8;  /**< Room for small integral values */
 };
-
-static uint32_t mod(struct ring_buf *buf, uint32_t val)
-{
-	return likely(buf->mask) ? val & buf->mask : val % buf->size;
-}
-
-static uint32_t get_rewind_value(uint32_t buf_size, uint32_t threshold)
-{
-	/* Rewind value is rounded to buffer size and decreased by buffer_size.
-	 * This is done to ensure that there will be no negative numbers after
-	 * subtraction. That could happen because tail is rewinded first and
-	 * head (which follows tail) is rewinded on next getting.
-	 */
-	return buf_size * (threshold / buf_size - 1);
-}
-
-int ring_buf_is_empty(struct ring_buf *buf)
-{
-	uint32_t tail = buf->tail;
-	uint32_t head = buf->head;
-
-	if (tail < head) {
-		tail += get_rewind_value(buf->size,
-					 ring_buf_get_rewind_threshold());
-	}
-
-	return (head == tail);
-}
-
-uint32_t ring_buf_size_get(struct ring_buf *buf)
-{
-	uint32_t tail = buf->tail;
-	uint32_t head = buf->head;
-
-	if (tail < head) {
-		tail += get_rewind_value(buf->size,
-					 ring_buf_get_rewind_threshold());
-	}
-
-	return tail - head;
-}
-
-uint32_t ring_buf_space_get(struct ring_buf *buf)
-{
-	return buf->size - ring_buf_size_get(buf);
-}
 
 int ring_buf_item_put(struct ring_buf *buf, uint16_t type, uint8_t value,
 		      uint32_t *data32, uint8_t size32)
@@ -163,52 +107,50 @@ int ring_buf_item_get(struct ring_buf *buf, uint16_t *type, uint8_t *value,
 
 uint32_t ring_buf_put_claim(struct ring_buf *buf, uint8_t **data, uint32_t size)
 {
-	uint32_t space, trail_size, allocated, tmp_trail_mod;
-	uint32_t head = buf->head;
-	uint32_t tmp_tail = buf->misc.byte_mode.tmp_tail;
+	uint32_t free_space, wrap_size;
+	int32_t base;
 
-	if (buf->misc.byte_mode.tmp_tail < head) {
-		/* Head is already rewinded but tail is not */
-		tmp_tail += get_rewind_value(buf->size, ring_buf_get_rewind_threshold());
+	base = buf->put_base;
+	wrap_size = buf->put_head - base;
+	if (unlikely(wrap_size >= buf->size)) {
+		/* put_base is not yet adjusted */
+		wrap_size -= buf->size;
+		base += buf->size;
 	}
+	wrap_size = buf->size - wrap_size;
 
-	tmp_trail_mod = mod(buf, buf->misc.byte_mode.tmp_tail);
-	space = (head + buf->size) - tmp_tail;
-	trail_size = buf->size - tmp_trail_mod;
+	free_space = ring_buf_space_get(buf);
+	size = MIN(size, free_space);
+	size = MIN(size, wrap_size);
 
-	/* Limit requested size to available size. */
-	size = MIN(size, space);
+	*data = &buf->buffer[buf->put_head - base];
+	buf->put_head += size;
 
-	trail_size = buf->size - (tmp_trail_mod);
-
-	/* Limit allocated size to trail size. */
-	allocated = MIN(trail_size, size);
-	*data = &buf->buffer[tmp_trail_mod];
-
-	buf->misc.byte_mode.tmp_tail =
-		buf->misc.byte_mode.tmp_tail + allocated;
-
-	return allocated;
+	return size;
 }
 
 int ring_buf_put_finish(struct ring_buf *buf, uint32_t size)
 {
-	uint32_t rew;
-	uint32_t threshold = ring_buf_get_rewind_threshold();
+	uint32_t finish_space, wrap_size;
 
-	if ((buf->tail + size) > (buf->head + buf->size)) {
+	if (unlikely(size == 0)) {
+		/* claim is cancelled */
+		buf->put_head = buf->put_tail;
+		return 0;
+	}
+
+	finish_space = buf->put_head - buf->put_tail;
+	if (unlikely(size > finish_space)) {
 		return -EINVAL;
 	}
 
-	/* Check if indexes shall be rewind. */
-	if (buf->tail > threshold) {
-		rew = get_rewind_value(buf->size, threshold);
-	} else {
-		rew = 0;
-	}
+	buf->put_tail += size;
 
-	buf->tail += (size - rew);
-	buf->misc.byte_mode.tmp_tail = buf->tail;
+	wrap_size = buf->put_tail - buf->put_base;
+	if (unlikely(wrap_size >= buf->size)) {
+		/* we wrapped: adjust put_base */
+		buf->put_base += buf->size;
+	}
 
 	return 0;
 }
@@ -236,54 +178,50 @@ uint32_t ring_buf_put(struct ring_buf *buf, const uint8_t *data, uint32_t size)
 
 uint32_t ring_buf_get_claim(struct ring_buf *buf, uint8_t **data, uint32_t size)
 {
-	uint32_t space, granted_size, trail_size, tmp_head_mod;
-	uint32_t tail = buf->tail;
+	uint32_t available_size, wrap_size;
+	int32_t base;
 
-	/* Tail is always ahead, if it is not, it's only because it got rewinded. */
-	if (tail < buf->misc.byte_mode.tmp_head) {
-		/* Locally, increment it to pre-rewind value */
-		tail += get_rewind_value(buf->size,
-					 ring_buf_get_rewind_threshold());
+	base = buf->get_base;
+	wrap_size = buf->get_head - base;
+	if (unlikely(wrap_size >= buf->size)) {
+		/* get_base is not yet adjusted */
+		wrap_size -= buf->size;
+		base += buf->size;
 	}
+	wrap_size = buf->size - wrap_size;
 
-	tmp_head_mod = mod(buf, buf->misc.byte_mode.tmp_head);
-	space = tail - buf->misc.byte_mode.tmp_head;
-	trail_size = buf->size - tmp_head_mod;
+	available_size = ring_buf_size_get(buf);
+	size = MIN(size, available_size);
+	size = MIN(size, wrap_size);
 
-	/* Limit requested size to available size. */
-	granted_size = MIN(size, space);
+	*data = &buf->buffer[buf->get_head - base];
+	buf->get_head += size;
 
-	/* Limit allocated size to trail size. */
-	granted_size = MIN(trail_size, granted_size);
-
-	*data = &buf->buffer[tmp_head_mod];
-	buf->misc.byte_mode.tmp_head += granted_size;
-
-	return granted_size;
+	return size;
 }
 
 int ring_buf_get_finish(struct ring_buf *buf, uint32_t size)
 {
-	uint32_t tail = buf->tail;
-	uint32_t rew;
+	uint32_t finish_space, wrap_size;
 
-	/* Tail is always ahead, if it is not, it's only because it got rewinded. */
-	if (tail < buf->misc.byte_mode.tmp_head) {
-		/* tail was rewinded. Locally, increment it to pre-rewind value */
-		rew = get_rewind_value(buf->size,
-				       ring_buf_get_rewind_threshold());
-		tail += rew;
-	} else {
-		rew = 0;
+	if (unlikely(size == 0)) {
+		/* claim is cancelled */
+		buf->get_head = buf->get_tail;
+		return 0;
 	}
 
-	if ((buf->head + size) > tail) {
+	finish_space = buf->get_head - buf->get_tail;
+	if (unlikely(size > finish_space)) {
 		return -EINVAL;
 	}
 
-	/* Include potential rewinding. */
-	buf->head += (size - rew);
-	buf->misc.byte_mode.tmp_head = buf->head;
+	buf->get_tail += size;
+
+	wrap_size = buf->get_tail - buf->get_base;
+	if (unlikely(wrap_size >= buf->size)) {
+		/* we wrapped: adjust get_base */
+		buf->get_base += buf->size;
+	}
 
 	return 0;
 }

--- a/subsys/shell/shell_history.c
+++ b/subsys/shell/shell_history.c
@@ -116,7 +116,7 @@ static bool remove_from_tail(struct shell_history *history)
 
 	total_len = offsetof(struct shell_history_item, data) +
 			h_item->len + h_item->padding;
-	ring_buf_get_finish(history->ring_buf, total_len);
+	ring_buf_get(history->ring_buf, NULL, total_len);
 
 	return true;
 }

--- a/tests/lib/ringbuffer/src/concurrent.c
+++ b/tests/lib/ringbuffer/src/concurrent.c
@@ -24,7 +24,7 @@
 #define TYPE				0xc
 
 static ZTEST_BMEM SYS_MUTEX_DEFINE(mutex);
-RING_BUF_ITEM_DECLARE_SIZE(ringbuf, RINGBUFFER);
+RING_BUF_ITEM_DECLARE(ringbuf, RINGBUFFER);
 static uint32_t output[LENGTH];
 static uint32_t databuffer1[LENGTH];
 static uint32_t databuffer2[LENGTH];
@@ -252,18 +252,14 @@ static bool consume(void *user_data, uint32_t iter_cnt, bool last, int prio)
 	return true;
 }
 
-extern uint32_t test_rewind_threshold;
-
 static void test_ztress(ztress_handler high_handler,
 			ztress_handler low_handler,
 			bool item_mode)
 {
 	uint8_t buf[32];
 	uint32_t buf32[32];
-	uint32_t old_rewind_threshold = test_rewind_threshold;
 	k_timeout_t timeout;
 
-	test_rewind_threshold = 256;
 	if (item_mode) {
 		ring_buf_item_init(&ringbuf, ARRAY_SIZE(buf32), buf32);
 	} else {
@@ -276,8 +272,6 @@ static void test_ztress(ztress_handler high_handler,
 	ztress_set_timeout(timeout);
 	ZTRESS_EXECUTE(ZTRESS_THREAD(high_handler, NULL, 0, 0, Z_TIMEOUT_TICKS(20)),
 		       ZTRESS_THREAD(low_handler, NULL, 0, 2000, Z_TIMEOUT_TICKS(20)));
-	test_rewind_threshold = old_rewind_threshold;
-
 }
 
 void test_ringbuffer_stress(ztress_handler produce_handler,

--- a/tests/lib/ringbuffer/src/concurrent.c
+++ b/tests/lib/ringbuffer/src/concurrent.c
@@ -265,7 +265,7 @@ static void test_ztress(ztress_handler high_handler,
 
 	test_rewind_threshold = 256;
 	if (item_mode) {
-		ring_buf_init(&ringbuf, ARRAY_SIZE(buf32), buf32);
+		ring_buf_item_init(&ringbuf, ARRAY_SIZE(buf32), buf32);
 	} else {
 		ring_buf_init(&ringbuf, ARRAY_SIZE(buf), buf);
 	}

--- a/tests/lib/ringbuffer/src/main.c
+++ b/tests/lib/ringbuffer/src/main.c
@@ -21,20 +21,6 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(test);
 
-/* Max size is used internally in the algorithm. Value is decreased in the test
- * to trigger rewind algorithm.
- */
-#undef RING_BUFFER_MAX_SIZE
-#define RING_BUFFER_MAX_SIZE 0x00000800
-
-/* Use global variable that can be modified by the test. */
-uint32_t test_rewind_threshold = RING_BUFFER_MAX_SIZE;
-
-uint32_t ring_buf_get_rewind_threshold(void)
-{
-	return test_rewind_threshold;
-}
-
 /**
  * @defgroup lib_ringbuffer_tests Ringbuffer
  * @ingroup all_tests
@@ -163,13 +149,13 @@ void test_ring_buffer_main(void)
 /**TESTPOINT: init via RING_BUF_ITEM_DECLARE_POW2*/
 RING_BUF_ITEM_DECLARE_POW2(ringbuf_pow2, POW);
 
-/**TESTPOINT: init via RING_BUF_ITEM_DECLARE_SIZE*/
+/**TESTPOINT: init via RING_BUF_ITEM_DECLARE*/
 /**
  * @brief define a ring buffer with arbitrary size
  *
- * @see RING_BUF_ITEM_DECLARE_SIZE(),RING_BUF_DECLARE()
+ * @see RING_BUF_ITEM_DECLARE(), RING_BUF_DECLARE()
  */
-RING_BUF_ITEM_DECLARE_SIZE(ringbuf_size, RINGBUFFER_SIZE);
+RING_BUF_ITEM_DECLARE(ringbuf_size, RINGBUFFER_SIZE);
 
 RING_BUF_DECLARE(ringbuf_raw, RINGBUFFER_SIZE);
 
@@ -402,7 +388,7 @@ void test_ringbuffer_pow2_put_get_thread_isr(void)
  *
  * @details
  * Test Objective:
- * - define and initialize a ring buffer by macro RING_BUF_ITEM_DECLARE_SIZE,
+ * - define and initialize a ring buffer by macro RING_BUF_ITEM_DECLARE,
  * then passing data by thread and isr to verify the ringbuffer
  * if it works to be placed in any user-controlled memory.
  *
@@ -412,7 +398,7 @@ void test_ringbuffer_pow2_put_get_thread_isr(void)
  * - Structural test coverage(entry points,statements,branches)
  *
  * Prerequisite Conditions:
- * - Define and initialize a ringbuffer by RING_BUF_ITEM_DECLARE_SIZE
+ * - Define and initialize a ringbuffer by RING_BUF_ITEM_DECLARE
  * - Define a pointer of ring buffer type.
  *
  * Input Specifications:

--- a/tests/lib/ringbuffer/src/main.c
+++ b/tests/lib/ringbuffer/src/main.c
@@ -791,19 +791,14 @@ void test_reset(void)
 	zassert_true(granted == RINGBUFFER_SIZE, NULL);
 }
 
-#ifdef CONFIG_64BIT
-static uint64_t ringbuf_stored[RINGBUFFER_SIZE];
-#else
 static uint32_t ringbuf_stored[RINGBUFFER_SIZE];
-#endif
 
 /**
  * @brief verify the array stored by ringbuf
  *
  * @details
  * Test Objective:
- * - Define a buffer stored by ringbuffer and keep that the buffer's size
- * is always equal to the pointer's size. Verify that the address
+ * - Define a buffer stored by ringbuffer. Verify that the address
  * of the buffer is contiguous.And also verify that data can pass
  * between buffer and ringbuffer.
  *
@@ -825,8 +820,6 @@ static uint32_t ringbuf_stored[RINGBUFFER_SIZE];
  * -# Check if the address stored by ringbuf is contiguous.
  * -# Get data from the ringbuffer and put them into output buffer
  * and check if getting data are successful.
- * -# Then check if the size of array stored by ringbuf is
- * equal to the size of pointer
  *
  * Expected Test Result:
  * - All assertions can pass.
@@ -848,7 +841,6 @@ void test_ringbuffer_array_perf(void)
 	uint32_t output[3] = {0};
 	uint16_t type = 0;
 	uint8_t value = 0, size = 3;
-	void *tp;
 
 	ring_buf_init(&buf_ii, RINGBUFFER_SIZE, ringbuf_stored);
 
@@ -868,9 +860,6 @@ void test_ringbuffer_array_perf(void)
 	for (int i = 0; i < 3; i++) {
 		zassert_equal(input[i], output[i], NULL);
 	}
-
-	/*The size of array stored by ringbuf is equal to the size of pointer*/
-	zassert_equal(sizeof(tp), sizeof(ringbuf_stored[0]), NULL);
 }
 
 void test_ringbuffer_partial_putting(void)

--- a/tests/lib/ringbuffer/src/main.c
+++ b/tests/lib/ringbuffer/src/main.c
@@ -674,9 +674,6 @@ void test_capacity(void)
 
 	ring_buf_init(&ringbuf_raw, RINGBUFFER_SIZE, ringbuf_raw.buf.buf8);
 
-	/* capacity equals buffer size dedicated for ring buffer - 1 because
-	 * 1 byte is used for distinguishing between full and empty state.
-	 */
 	capacity = ring_buf_capacity_get(&ringbuf_raw);
 	zassert_equal(RINGBUFFER_SIZE, capacity,
 			"Unexpected capacity");

--- a/tests/lib/ringbuffer/testcase.yaml
+++ b/tests/lib/ringbuffer/testcase.yaml
@@ -6,6 +6,7 @@ tests:
   libraries.ring_buffer:
     integration_platforms:
       - native_posix
+      - native_posix_64
     extra_configs:
       - CONFIG_MP_NUM_CPUS=1
 


### PR DESCRIPTION
I looked at that code... and I didn't like the way it stared back at me.

This PR culminates in a much nicer version IMHO.

The first 3 commits could be cherry-picked into stable release branches.
The remaining commits are definitely destined for the development branch.

Stats for the core changes:

Binary size:

```
ring_buffer.c.obj       before   after    diff
----------------------------------------------
frdm_k64f                 1224    1136     -88
m2gl025_miv               2485    2079    -406
mps2_an385                1228    1132     -96
mps2_an521                1228    1132     -96
native_posix              1546    1496     -50
native_posix_64           1598    1595      -3
nsim_hs_mpuv6             1252    1192     -60
nsim_hs_smp               1252    1192     -60
nsim_sem                  1252    1192     -60
qemu_arc_em               1324    1192    -132
qemu_arc_hs6x             1824    1620    -204
qemu_arc_hs               1252    1192     -60
qemu_cortex_a53_smp       2154    1888    -266
qemu_cortex_a53           2154    1888    -266
qemu_cortex_a9            1938    1792    -146
```

Execution time before (qemu_cortex_a53):

```
START - test_ringbuffer_performance
1 byte put-get, avg cycles: 52
4 byte put-get, avg cycles: 47
1 byte put claim-finish, avg cycles: 39
5 byte put claim-finish, avg cycles: 41
5 byte get claim-finish, avg cycles: 52
 PASS - test_ringbuffer_performance in 0.8 seconds
```

Execution time after (qemu_cortex_a53):

```
START - test_ringbuffer_performance
1 byte put-get, avg cycles: 34
4 byte put-get, avg cycles: 41
1 byte put claim-finish, avg cycles: 27
5 byte put claim-finish, avg cycles: 29
5 byte get claim-finish, avg cycles: 29
 PASS - test_ringbuffer_performance in 0.4 seconds
```
