### PR TITLE
i2c_emul: init i2c config

### DIFF
--- a/drivers/i2c/i2c_emul.c
+++ b/drivers/i2c/i2c_emul.c
@@ -20,12 +20,15 @@ LOG_MODULE_REGISTER(i2c_emul_ctlr);
 #include <drivers/i2c.h>
 #include <drivers/i2c_emul.h>
 
+#include "i2c-priv.h"
+
 /** Working data for the device */
 struct i2c_emul_data {
 	/* List of struct i2c_emul associated with the device */
 	sys_slist_t emuls;
 	/* I2C host configuration */
 	uint32_t config;
+	uint32_t bitrate;
 };
 
 /**
@@ -65,10 +68,6 @@ static int i2c_emul_configure(const struct device *dev, uint32_t dev_config)
 static int i2c_emul_get_config(const struct device *dev, uint32_t *dev_config)
 {
 	struct i2c_emul_data *data = dev->data;
-
-	if (data->config == -1) {
-		return -EIO;
-	}
 
 	*dev_config = data->config;
 
@@ -115,7 +114,7 @@ static int i2c_emul_init(const struct device *dev)
 	rc = emul_init_for_bus_from_list(dev, list);
 
 	/* Set config to an uninitialized state */
-	data->config = -1;
+	data->config = (I2C_MODE_MASTER | i2c_map_dt_bitrate(data->bitrate));
 
 	return rc;
 }
@@ -152,7 +151,9 @@ static struct i2c_driver_api i2c_emul_api = {
 		.children = emuls_##n, \
 		.num_children = ARRAY_SIZE(emuls_##n), \
 	}; \
-	static struct i2c_emul_data i2c_emul_data_##n; \
+	static struct i2c_emul_data i2c_emul_data_##n = { \
+		.bitrate = DT_INST_PROP(n, clock_frequency), \
+	}; \
 	I2C_DEVICE_DT_INST_DEFINE(n, \
 			    i2c_emul_init, \
 			    NULL, \


### PR DESCRIPTION
Initialize the i2c config of the emulator based on the clock_frequency
property.

The emulator can be used without calling the i2c_configure function, but
the i2c_get_config would return an error. With this change, it is
possible to get the config prior to the i2c_configure call.

Signed-off-by: Dawid Niedzwiecki <dn@semihalf.com>