### PR TITLE
Bluetooth: Kconfig menu cleanup

### DIFF
--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -96,28 +96,18 @@ config BT_CENTRAL
 	help
 	  Select this for LE Central role support.
 
-menu "Broadcaster"
-	visible if !BT_PERIPHERAL
-
 config BT_BROADCASTER
 	bool "Broadcaster Role support"
 	default y if !BT_OBSERVER
 	help
 	  Select this for LE Broadcaster role support.
 
-endmenu
-
-rsource "Kconfig.adv"
-
-menu "Observer"
-	visible if !BT_CENTRAL
-
 config BT_OBSERVER
 	bool "Observer Role support"
 	help
 	  Select this for LE Observer role support.
 
-endmenu
+rsource "Kconfig.adv"
 
 config BT_CONN
 	bool

--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -185,7 +185,4 @@ config BT_COMPANY_ID
 	  Company Identifiers can be found here:
 	  https://www.bluetooth.com/specifications/assigned-numbers/company-identifiers
 
-rsource "mesh/Kconfig"
-rsource "audio/Kconfig"
-
 endif # BT

--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -119,8 +119,6 @@ config BT_OBSERVER
 
 endmenu
 
-rsource "services/Kconfig"
-
 config BT_CONN
 	bool
 

--- a/subsys/bluetooth/Kconfig.adv
+++ b/subsys/bluetooth/Kconfig.adv
@@ -4,16 +4,6 @@
 # Copyright (c) 2021 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-config BT_LIM_ADV_TIMEOUT
-	int "Timeout for limited advertising in 1s units"
-	default 30
-	range 1 180
-	help
-	  After this timeout is reached, advertisement with BT_LE_AD_LIMITED flag
-	  set shall be terminated. As per BT Core Spec 5.2, Vol 3, Part C,
-	  Appendix A (NORMATIVE): TIMERS AND CONSTANTS it's required to be no more
-	  than 180s.
-
 config BT_EXT_ADV
 	bool "Extended Advertising and Scanning support [EXPERIMENTAL]"
 	select EXPERIMENTAL

--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -4,6 +4,8 @@
 # Copyright (c) 2016 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+menu "Bluetooth buffer configuration"
+
 config BT_BUF_ACL_TX_SIZE
 	int "Maximum supported ACL size for outgoing data"
 	range 27 65535
@@ -185,6 +187,8 @@ config BT_BUF_CMD_TX_COUNT
 	range 2 64
 	help
 	  Number of buffers available for outgoing HCI commands from the Host.
+
+endmenu
 
 config BT_HAS_HCI_VS
 	bool

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -3,8 +3,6 @@
 # Copyright (c) 2016-2017 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-comment "BLE Controller support"
-
 # The following symbols are enabled depending if the controller actually
 # supports the respective features.
 

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -110,6 +110,9 @@ menu "Bluetooth Host"
 
 if BT_HCI_HOST
 
+rsource "../mesh/Kconfig"
+rsource "../audio/Kconfig"
+
 config BT_HOST_CRYPTO
 	# Hidden option that compiles in random number generation and AES
 	# encryption support using TinyCrypt library if this is not provided

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -4,8 +4,6 @@
 # Copyright (c) 2015-2016 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-comment "Host Stack Configuration"
-
 config BT_HCI_HOST
 	# Hidden option to make the conditions more intuitive
 	bool
@@ -107,6 +105,8 @@ config BT_DRIVER_RX_HIGH_PRIO
 	# Hidden option for Co-Operative HCI driver RX thread priority
 	int
 	default 6
+
+menu "Bluetooth Host"
 
 if BT_HCI_HOST
 
@@ -882,3 +882,5 @@ config BT_HCI_VS_EVT_USER
 	help
 	  Enable registering a callback for delegating to the user the handling of
 	  VS events that are not known to the stack
+
+endmenu

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -193,6 +193,17 @@ config BT_FILTER_ACCEPT_LIST
 	  This options deprecates the bt_le_set_auto_conn API in favor of the
 	  bt_conn_create_aute_le API.
 
+config BT_LIM_ADV_TIMEOUT
+	int "Timeout for limited advertising in 1s units"
+	default 30
+	range 1 180
+	depends on BT_BROADCASTER
+	help
+	  After this timeout is reached, advertisement with BT_LE_AD_LIMITED flag
+	  set shall be terminated. As per BT Core Spec 5.2, Vol 3, Part C,
+	  Appendix A (NORMATIVE): TIMERS AND CONSTANTS it's required to be no more
+	  than 180s.
+
 if BT_CONN
 
 config BT_CONN_TX_MAX

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -443,6 +443,7 @@ endif # BT_SMP
 
 rsource "Kconfig.l2cap"
 rsource "Kconfig.gatt"
+rsource "../services/Kconfig"
 
 config BT_MAX_PAIRED
 	int "Maximum number of paired devices"


### PR DESCRIPTION
The number of options presented to the user is becoming quite large, which can be quite intimidating at first. By grouping them it makes it easier to get an overview of what can be configured.