### PR TITLE
ci: run full twister twice a week

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -8,8 +8,8 @@ on:
     branches:
       - main
   schedule:
-    # Run at 00:00 on Saturday
-    - cron: '0 0 * * 6'
+    # Run at 00:00 on Wednesday and Saturday
+    - cron: '0 0 * * 3,6'
 
 jobs:
   twister-build-cleanup:


### PR DESCRIPTION
Now that we are stable in CI, run full twister twice a week for better
coverage.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
