### PR TITLE
Bluetooth: Controller: DTM: Fix timer rollover

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_test.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_test.c
@@ -117,7 +117,11 @@ static void isr_tx(void *param)
 	if (transmit_time < sampled_time){
 		transmit_time+=((((sampled_time - transmit_time) / SCAN_INT_UNIT_US) + 1) * SCAN_INT_UNIT_US);
 	}
-	/* Handle rollover case here, timer is configured to 24-bits */
+	else{
+		/* Handle rollover case here, timer is configured to 24-bits */
+		transmit_time += ((((BIT(24) - transmit_time + sampled_time) / SCAN_INT_UNIT_US) + 1) * SCAN_INT_UNIT_US);	
+	}
+	
 	transmit_time=transmit_time&0xffffff;
 
 	/* Setup next Tx */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_test.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_test.c
@@ -113,8 +113,9 @@ static void isr_tx(void *param)
 	/* Set timer capture in the future. */
 	radio_tmr_sample();
 	s = radio_tmr_sample_get();
-	while (t < s) {
-		t += SCAN_INT_UNIT_US;
+	/*Previous calculation in while loop can take too long time and can rollout the timer*/
+	if (t < s){
+		t+=((((s - t) / SCAN_INT_UNIT_US) + 1) * SCAN_INT_UNIT_US);
 	}
 
 	/* Setup next Tx */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_test.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_test.c
@@ -130,7 +130,7 @@ static void isr_tx(void *param)
 
 #if defined(HAL_RADIO_GPIO_HAVE_PA_PIN)
 	radio_gpio_pa_setup();
-	radio_gpio_pa_lna_enable(t + radio_tx_ready_delay_get(test_phy,
+	radio_gpio_pa_lna_enable(transmit_time + radio_tx_ready_delay_get(test_phy,
 							      test_phy_flags) -
 				 HAL_RADIO_GPIO_PA_OFFSET);
 #endif /* HAL_RADIO_GPIO_HAVE_PA_PIN */


### PR DESCRIPTION
It changes the behaviour of while loop in lll_test.c in isr_tx() . When bug happens and t<s is quite big it can hapen that while loop will take a long time. This leads to setting up start of a radio timer before current timer value. This then leads to invocation of a timer after rollout and this will lead to very large delay in sending packet. 

Fixes #42534.

Signed-off-by: Piotr Parfeniuk [piotr.parfeniuk@magitech.pl](mailto:piotr.parfeniuk@magitech.pl)