### PR TITLE
maintainers: Update ARM arch maintainer

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -129,7 +129,7 @@ ARC arch:
 ARM arch:
     status: maintained
     maintainers:
-        - ioannisg
+        - microbuilder
     collaborators:
         - carlocaione
         - galak


### PR DESCRIPTION
Updates the ARM arch maintainer as per TSC vote 16 Feb 2022.

Signed-off-by: Kevin Townsend <kevin.townsend@linaro.org>