### PR TITLE
doc: formatted_output: update header field descriptions

### DIFF
--- a/doc/reference/misc/formatted_output.rst
+++ b/doc/reference/misc/formatted_output.rst
@@ -95,7 +95,9 @@ formatting since address changes whenever package is copied.
 +------------------+-------------------------------------------------------------------------+
 | Header           | 1 byte: Argument list size including header and *fmt* (in 32 bit words) |
 |                  +-------------------------------------------------------------------------+
-| | sizeof(void \*)| 1 byte: Number of appended strings                                      |
+| | sizeof(void \*)| 1 byte: Number of appended strings in writable memory                   |
+|                  +-------------------------------------------------------------------------+
+|                  | 1 byte: Number of appended strings in read-only memory                  |
 |                  +-------------------------------------------------------------------------+
 |                  | platform specific padding to sizeof(void \*)                            |
 +------------------+-------------------------------------------------------------------------+


### PR DESCRIPTION
The second and third bytes of the packaged string headers
have new meanings after support for fully self-contained
(fsc) packaged string was added in commit
5d80cbae590afeb1a0ee62854a2fead6bdbf70f7. So update
the document to reflect this.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>