### PR TITLE
doc: remove @return doc for void functions

### DIFF
--- a/include/bluetooth/audio/audio.h
+++ b/include/bluetooth/audio/audio.h
@@ -1274,8 +1274,6 @@ enum bt_audio_pac_type {
  *
  *  @param stream Stream object.
  *  @param ops    Stream operations structure.
- *
- *  @return 0 in case of success or negative value in case of error.
  */
 void bt_audio_stream_cb_register(struct bt_audio_stream *stream,
 				 struct bt_audio_stream_ops *ops);

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -4839,8 +4839,6 @@ __syscall size_t k_pipe_write_avail(struct k_pipe *pipe);
  * writers that were previously pended become unpended.
  *
  * @param pipe Address of the pipe.
- *
- * @return N/A
  */
 __syscall void k_pipe_flush(struct k_pipe *pipe);
 
@@ -4854,8 +4852,6 @@ __syscall void k_pipe_flush(struct k_pipe *pipe);
  * up the pipe's emptied buffer.
  *
  * @param pipe Address of the pipe.
- *
- * @return N/A
  */
 __syscall void k_pipe_buffer_flush(struct k_pipe *pipe);
 
@@ -5853,8 +5849,6 @@ extern int k_thread_runtime_stats_disable(k_tid_t thread);
  * This routine enables the gathering of system runtime statistics. Note that
  * it does not affect the gathering of similar statistics for individual
  * threads.
- *
- * @return N/A
  */
 extern void k_sys_runtime_stats_enable(void);
 
@@ -5864,8 +5858,6 @@ extern void k_sys_runtime_stats_enable(void);
  * This routine disables the gathering of system runtime statistics. Note that
  * it does not affect the gathering of similar statistics for individual
  * threads.
- *
- * @return N/A
  */
 extern void k_sys_runtime_stats_disable(void);
 


### PR DESCRIPTION
For functions returning nothing, there is no need to document with @return, as Doxgen complains about "documented empty return type of ...".