### PR TITLE
shell: fix history memory reclaim

### DIFF
--- a/subsys/shell/shell_history.c
+++ b/subsys/shell/shell_history.c
@@ -116,7 +116,7 @@ static bool remove_from_tail(struct shell_history *history)
 
 	total_len = offsetof(struct shell_history_item, data) +
 			h_item->len + h_item->padding;
-	ring_buf_get_finish(history->ring_buf, total_len);
+	ring_buf_get(history->ring_buf, NULL, total_len);
 
 	return true;
 }


### PR DESCRIPTION
No ring_buf_get_finish() should be performed on ring_buf memory that
wasn't claimed beforehand. Using ring_buf_get() with a NULL destination
does both the claim and the finish part without retrieving anything.

This is especially important with the ring_buffer revanp where the above
is enforced for proper operation.

Signed-off-by: Nicolas Pitre <npitre@baylibre.com>
