### PR TITLE
doc: application: tweak experimental features text

### DIFF
--- a/doc/application/index.rst
+++ b/doc/application/index.rst
@@ -533,13 +533,13 @@ at CMake configure time if any experimental feature is enabled.
 
    CONFIG_WARN_EXPERIMENTAL=y
 
-For example, enabling experimental warnings and building a sample which enables
-:kconfig:`CONFIG_BT_EXT_ADV` will print the following warning at CMake
-configure time.
+For example, if option ``CONFIG_FOO`` is experimental, then enabling it and
+:kconfig:`CONIG_WARN_EXPERIMENTAL` will print the following warning at CMake
+configure time when you build an application:
 
-.. code-block:: shell
+.. code-block:: none
 
-   warning: Experimental symbol BT_EXT_ADV is enabled.
+   warning: Experimental symbol FOO is enabled.
 
 Devicetree Overlays
 ===================


### PR DESCRIPTION
We use a specific experimental Kconfig option when describing the
behavior of CONFIG_WARN_EXPERIMENTAL.

However, this option may not be experimental forever. This therefore
may go stale. Rather than try to keep generic documentation about
experimental options up to date with whatever the bluetooth subsystem
happens to consider experimental or not, use a placeholder CONFIG_FOO
instead of a real option.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>