### PR TITLE
gptp: fix endianness of correction field in sync follow up message

### DIFF
--- a/subsys/net/l2/ethernet/gptp/gptp_md.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_md.c
@@ -52,6 +52,7 @@ static void gptp_md_follow_up_prepare(struct net_pkt *pkt,
 	hdr->correction_field *= sync_send->rate_ratio;
 	hdr->correction_field += sync_send->follow_up_correction_field;
 	hdr->correction_field <<= 16;
+	hdr->correction_field = htonll(hdr->correction_field);
 
 	memcpy(&hdr->port_id.clk_id, &sync_send->src_port_id.clk_id,
 	       GPTP_CLOCK_ID_LEN);


### PR DESCRIPTION

#42799 

When gptp prepare sync follow up message, endianness of correction does not get converted to network endianness

Signed-off-by: Lu Ding <lucasdinglu@gmail.com>