### PR TITLE
i2c: Adds a context object for i2c

### DIFF
--- a/drivers/i2c/CMakeLists.txt
+++ b/drivers/i2c/CMakeLists.txt
@@ -3,6 +3,7 @@
 zephyr_library()
 
 zephyr_library_sources(i2c_common.c)
+zephyr_library_sources(i2c_context.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_SHELL		i2c_shell.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_BITBANG		i2c_bitbang.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_TELINK_B91		i2c_b91.c)

--- a/drivers/i2c/i2c_b91.c
+++ b/drivers/i2c/i2c_b91.c
@@ -12,7 +12,7 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(i2c_telink);
 
-#include <drivers/i2c.h>
+#include "i2c_context.h"
 #include "i2c-priv.h"
 #include <drivers/pinmux.h>
 #include <dt-bindings/pinctrl/b91-pinctrl.h>
@@ -177,7 +177,7 @@ BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) <= 1,
 		.pinctrl_list = i2c_pins_##inst			  \
 	};							  \
 								  \
-	I2C_DEVICE_DT_INST_DEFINE(inst, i2c_b91_init,		  \
+	DEVICE_DT_INST_DEFINE(inst, i2c_b91_init,		  \
 			      NULL,				  \
 			      &i2c_b91_data_##inst,		  \
 			      &i2c_b91_cfg_##inst,		  \

--- a/drivers/i2c/i2c_bitbang.c
+++ b/drivers/i2c/i2c_bitbang.c
@@ -19,7 +19,7 @@
 
 #include <errno.h>
 #include <kernel.h>
-#include <drivers/i2c.h>
+#include "i2c_context.h"
 #include "i2c_bitbang.h"
 
 /*

--- a/drivers/i2c/i2c_cc13xx_cc26xx.c
+++ b/drivers/i2c/i2c_cc13xx_cc26xx.c
@@ -7,7 +7,7 @@
 #define DT_DRV_COMPAT ti_cc13xx_cc26xx_i2c
 
 #include <kernel.h>
-#include <drivers/i2c.h>
+#include "i2c_context.h"
 #include <pm/device.h>
 #include <pm/pm.h>
 
@@ -437,7 +437,7 @@ static struct i2c_cc13xx_cc26xx_data i2c_cc13xx_cc26xx_data = {
 
 PM_DEVICE_DT_INST_DEFINE(0, i2c_cc13xx_cc26xx_pm_action);
 
-I2C_DEVICE_DT_INST_DEFINE(0,
+DEVICE_DT_INST_DEFINE(0,
 		i2c_cc13xx_cc26xx_init,
 		PM_DEVICE_DT_INST_GET(0),
 		&i2c_cc13xx_cc26xx_data, &i2c_cc13xx_cc26xx_config,

--- a/drivers/i2c/i2c_cc32xx.c
+++ b/drivers/i2c/i2c_cc32xx.c
@@ -10,7 +10,7 @@
 
 #include <kernel.h>
 #include <errno.h>
-#include <drivers/i2c.h>
+#include "i2c_context.h"
 #include <soc.h>
 
 /* Driverlib includes */
@@ -378,7 +378,7 @@ static const struct i2c_cc32xx_config i2c_cc32xx_config = {
 
 static struct i2c_cc32xx_data i2c_cc32xx_data;
 
-I2C_DEVICE_DT_INST_DEFINE(0, i2c_cc32xx_init, NULL,
+DEVICE_DT_INST_DEFINE(0, i2c_cc32xx_init, NULL,
 		    &i2c_cc32xx_data, &i2c_cc32xx_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &i2c_cc32xx_driver_api);

--- a/drivers/i2c/i2c_common.c
+++ b/drivers/i2c/i2c_common.c
@@ -8,7 +8,7 @@
 
 #include <stdio.h>
 
-#include <drivers/i2c.h>
+#include "i2c_context.h"
 
 #define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
 #include <logging/log.h>

--- a/drivers/i2c/i2c_context.c
+++ b/drivers/i2c/i2c_context.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "i2c_context.h"
+
+/**
+ * @brief Implements the i2c stats for i2c transfers
+ *
+ * @param dev I2C device to update stats for
+ * @param msgs Array of struct i2c_msg
+ * @param num_msgs Number of i2c_msgs
+ */
+void z_i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs,
+				  uint8_t num_msgs)
+{
+#ifdef CONFIG_I2C_STATS
+	struct i2c_device_state *state =
+		CONTAINER_OF(dev->state, struct i2c_device_state, devstate);
+
+	/* Check if the magic exists so we can use the common data */
+	if (state->magic != Z_I2C_MAGIC) {
+		return;
+	}
+
+	uint32_t bytes_read = 0U;
+	uint32_t bytes_written = 0U;
+
+	STATS_INC(state->stats, transfer_call_count);
+	STATS_INCN(state->stats, message_count, num_msgs);
+	for (uint8_t i = 0U; i < num_msgs; i++) {
+		if (msgs[i].flags & I2C_MSG_READ) {
+			bytes_read += msgs[i].len;
+		}
+		if (msgs[i].flags & I2C_MSG_WRITE) {
+			bytes_written += msgs[i].len;
+		}
+	}
+	STATS_INCN(state->stats, bytes_read, bytes_read);
+	STATS_INCN(state->stats, bytes_written, bytes_written);
+#endif
+}

--- a/drivers/i2c/i2c_context.h
+++ b/drivers/i2c/i2c_context.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2022 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_I2C_CONTEXT_H
+#define ZEPHYR_DRIVERS_I2C_CONTEXT_H
+
+/* check if device.h was already included before i2c.h */
+#ifdef ZEPHYR_INCLUDE_DEVICE_H
+#error Only include i2c_context.h in drivers
+#endif
+
+#include <stdint.h>
+#include <device_structs.h>
+
+#if defined(CONFIG_I2C_STATS) || defined(__DOXYGEN__)
+#include <stats/stats.h>
+
+/** @cond INTERNAL_HIDDEN */
+
+STATS_SECT_START(i2c)
+STATS_SECT_ENTRY32(bytes_read)
+STATS_SECT_ENTRY32(bytes_written)
+STATS_SECT_ENTRY32(message_count)
+STATS_SECT_ENTRY32(transfer_call_count)
+STATS_SECT_END;
+
+STATS_NAME_START(i2c)
+STATS_NAME(i2c, bytes_read)
+STATS_NAME(i2c, bytes_written)
+STATS_NAME(i2c, message_count)
+STATS_NAME(i2c, transfer_call_count)
+STATS_NAME_END(i2c);
+
+#endif
+/** @endcond */
+
+
+struct i2c_msg;
+
+/**
+ * @brief I2C specific device state which allows for i2c device class common data
+ */
+struct i2c_device_state {
+	struct device_state devstate;
+	int magic;
+#if defined(CONFIG_I2C_STATS) || defined(__DOXYGEN__)
+	struct stats_i2c stats;
+#endif
+};
+
+/**
+ * @brief Define a statically allocated and section assigned i2c device state
+ */
+#define Z_DEVICE_STATE_TYPE struct i2c_device_state
+
+
+/* When needed initialize the stats part of device state */
+#ifdef CONFIG_I2C_STATS
+#define Z_I2C_STATS_INIT(dev, state)					\
+	do {								\
+		stats_init(&state->stats.s_hdr, STATS_SIZE_32, 4,	\
+			   STATS_NAME_INIT_PARMS(i2c));			\
+		stats_register(dev->name, &(state->stats.s_hdr));	\
+	} while (0)
+#else
+#define Z_I2C_STATS_INIT(dev, state)
+#endif
+
+
+/**
+ * @brief Define an i2c device init wrapper function
+ *
+ * This does device instance specific initialization of common data (such as stats)
+ * and calls the given init_fn
+ */
+#define Z_DEVICE_INIT_WRAPPER(dev_name, init_fn) UTIL_CAT(dev_name, _init)
+
+#define Z_DEVICE_INIT_WRAPPER_DEFINE(dev_name, init_fn)			\
+	static int Z_DEVICE_INIT_WRAPPER(dev_name, _init)(const struct device *dev)	\
+	{								\
+		struct i2c_device_state *state =			\
+			CONTAINER_OF(dev->state, struct i2c_device_state, devstate); \
+		state->magic = Z_I2C_MAGIC;				\
+		Z_I2C_STATS_INIT(dev, state);				\
+		return init_fn(dev);					\
+	}
+
+#include <device.h>
+#include <drivers/i2c.h>
+
+#endif /* I2C_CONTEXT_H */

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -10,7 +10,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
-#include <drivers/i2c.h>
+#include "i2c_context.h"
 #include <kernel.h>
 #include <init.h>
 #include <pm/device.h>
@@ -729,7 +729,7 @@ static int i2c_dw_initialize(const struct device *dev)
 		I2C_DW_INIT_PCIE(n)                                           \
 	};                                                                    \
 	static struct i2c_dw_dev_config i2c_##n##_runtime;                    \
-	I2C_DEVICE_DT_INST_DEFINE(n, i2c_dw_initialize, NULL,                    \
+	DEVICE_DT_INST_DEFINE(n, i2c_dw_initialize, NULL,                    \
 			      &i2c_##n##_runtime, &i2c_config_dw_##n,         \
 			      POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,          \
 			      &funcs);                                        \

--- a/drivers/i2c/i2c_emul.c
+++ b/drivers/i2c/i2c_emul.c
@@ -15,9 +15,8 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(i2c_emul_ctlr);
 
-#include <device.h>
+#include "i2c_context.h"
 #include <drivers/emul.h>
-#include <drivers/i2c.h>
 #include <drivers/i2c_emul.h>
 
 /** Working data for the device */
@@ -153,7 +152,7 @@ static struct i2c_driver_api i2c_emul_api = {
 		.num_children = ARRAY_SIZE(emuls_##n), \
 	}; \
 	static struct i2c_emul_data i2c_emul_data_##n; \
-	I2C_DEVICE_DT_INST_DEFINE(n, \
+	DEVICE_DT_INST_DEFINE(n, \
 			    i2c_emul_init, \
 			    NULL, \
 			    &i2c_emul_data_##n, \

--- a/drivers/i2c/i2c_esp32.c
+++ b/drivers/i2c/i2c_esp32.c
@@ -18,7 +18,7 @@
 #include <soc.h>
 #include <errno.h>
 #include <drivers/gpio.h>
-#include <drivers/i2c.h>
+#include "i2c_context.h"
 #include <drivers/interrupt_controller/intc_esp32.h>
 #include <drivers/clock_control.h>
 #include <sys/util.h>
@@ -710,7 +710,7 @@ static int IRAM_ATTR i2c_esp32_init(const struct device *dev)
 	.bitrate = I2C_FREQUENCY(idx),	\
 	.default_config = I2C_MODE_MASTER,				\
 	};								       \
-	I2C_DEVICE_DT_DEFINE(DT_NODELABEL(i2c##idx),					       \
+	DEVICE_DT_DEFINE(DT_NODELABEL(i2c##idx),					       \
 		      i2c_esp32_init,					       \
 		      NULL,				       \
 		      &i2c_esp32_data_##idx,				       \

--- a/drivers/i2c/i2c_gd32.c
+++ b/drivers/i2c/i2c_gd32.c
@@ -10,7 +10,7 @@
 #include <kernel.h>
 #include <devicetree.h>
 #include <drivers/pinctrl.h>
-#include <drivers/i2c.h>
+#include "i2c_context.h"
 #include <soc.h>
 
 #include <logging/log.h>
@@ -715,7 +715,7 @@ static int i2c_gd32_init(const struct device *dev)
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),			\
 		.irq_cfg_func = i2c_gd32_irq_cfg_func_##inst,			\
 	};									\
-	I2C_DEVICE_DT_INST_DEFINE(inst,						\
+	DEVICE_DT_INST_DEFINE(inst,						\
 				  i2c_gd32_init, NULL,				\
 				  &i2c_gd32_data_##inst, &i2c_gd32_cfg_##inst,	\
 				  POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,	\

--- a/drivers/i2c/i2c_gecko.c
+++ b/drivers/i2c/i2c_gecko.c
@@ -7,7 +7,7 @@
 #define DT_DRV_COMPAT silabs_gecko_i2c
 
 #include <errno.h>
-#include <drivers/i2c.h>
+#include "i2c_context.h"
 #include <sys/util.h>
 #include <em_cmu.h>
 #include <em_i2c.h>
@@ -222,7 +222,7 @@ static const struct i2c_gecko_config i2c_gecko_config_##idx = { \
 \
 static struct i2c_gecko_data i2c_gecko_data_##idx; \
 \
-I2C_DEVICE_DT_INST_DEFINE(idx, i2c_gecko_init, \
+DEVICE_DT_INST_DEFINE(idx, i2c_gecko_init, \
 		 NULL, \
 		 &i2c_gecko_data_##idx, &i2c_gecko_config_##idx, \
 		 POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \

--- a/drivers/i2c/i2c_gpio.c
+++ b/drivers/i2c/i2c_gpio.c
@@ -26,10 +26,9 @@
  * SCL pin may be a push/pull output.
  */
 
-#include <device.h>
+#include "i2c_context.h"
 #include <errno.h>
 #include <drivers/gpio.h>
-#include <drivers/i2c.h>
 
 #include <logging/log.h>
 LOG_MODULE_REGISTER(i2c_gpio);
@@ -182,7 +181,7 @@ static const struct i2c_gpio_config i2c_gpio_dev_cfg_##_num = {		\
 	.bitrate	= DT_INST_PROP(_num, clock_frequency),		\
 };									\
 									\
-I2C_DEVICE_DT_INST_DEFINE(_num,						\
+DEVICE_DT_INST_DEFINE(_num,						\
 	    i2c_gpio_init,						\
 	    NULL,							\
 	    &i2c_gpio_dev_data_##_num,					\

--- a/drivers/i2c/i2c_handlers.c
+++ b/drivers/i2c/i2c_handlers.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <drivers/i2c.h>
+#include "i2c_context.h"
 #include <string.h>
 #include <syscall_handler.h>
 

--- a/drivers/i2c/i2c_imx.c
+++ b/drivers/i2c/i2c_imx.c
@@ -7,7 +7,7 @@
 #define DT_DRV_COMPAT fsl_imx21_i2c
 
 #include <errno.h>
-#include <drivers/i2c.h>
+#include "i2c_context.h"
 #include <soc.h>
 #include <i2c_imx.h>
 #include <sys/util.h>
@@ -367,7 +367,7 @@ static const struct i2c_driver_api i2c_imx_driver_api = {
 									\
 	static struct i2c_imx_data i2c_imx_data_##n;			\
 									\
-	I2C_DEVICE_DT_INST_DEFINE(n,					\
+	DEVICE_DT_INST_DEFINE(n,					\
 				i2c_imx_init,				\
 				NULL,					\
 				&i2c_imx_data_##n, &i2c_imx_config_##n,	\

--- a/drivers/i2c/i2c_ite_it8xxx2.c
+++ b/drivers/i2c/i2c_ite_it8xxx2.c
@@ -7,7 +7,7 @@
 #define DT_DRV_COMPAT ite_it8xxx2_i2c
 
 #include <drivers/gpio.h>
-#include <drivers/i2c.h>
+#include "i2c_context.h"
 #include <drivers/pinmux.h>
 #include <errno.h>
 #include <logging/log.h>
@@ -1077,7 +1077,7 @@ static const struct i2c_driver_api i2c_it8xxx2_driver_api = {
 	\
 	static struct i2c_it8xxx2_data i2c_it8xxx2_data_##idx;	               \
 	\
-	I2C_DEVICE_DT_INST_DEFINE(idx,				               \
+	DEVICE_DT_INST_DEFINE(idx,				               \
 			i2c_it8xxx2_init, NULL,				       \
 			&i2c_it8xxx2_data_##idx,	                       \
 			&i2c_it8xxx2_cfg_##idx, POST_KERNEL,		       \

--- a/drivers/i2c/i2c_litex.c
+++ b/drivers/i2c/i2c_litex.c
@@ -6,8 +6,8 @@
 
 #define DT_DRV_COMPAT litex_i2c
 
-#include <device.h>
-#include <drivers/i2c.h>
+#include "i2c_context.h"
+#include "i2c_context.h"
 #include "i2c_bitbang.h"
 
 #define SCL_BIT_POS                0
@@ -124,7 +124,7 @@ static const struct i2c_driver_api i2c_litex_driver_api = {
 									       \
 	static struct i2c_bitbang i2c_bitbang_##n;			       \
 									       \
-	I2C_DEVICE_DT_INST_DEFINE(n,					       \
+	DEVICE_DT_INST_DEFINE(n,					       \
 			   i2c_litex_init,				       \
 			   NULL,					       \
 			   &i2c_bitbang_##n,	                               \

--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -13,7 +13,7 @@
 #include <stm32_ll_i2c.h>
 #include <stm32_ll_rcc.h>
 #include <errno.h>
-#include <drivers/i2c.h>
+#include "i2c_context.h"
 #include <drivers/pinctrl.h>
 #include "i2c_ll_stm32.h"
 
@@ -343,7 +343,7 @@ static const struct i2c_stm32_config i2c_stm32_cfg_##name = {		\
 									\
 static struct i2c_stm32_data i2c_stm32_dev_data_##name;			\
 									\
-I2C_DEVICE_DT_DEFINE(DT_NODELABEL(name), i2c_stm32_init,		\
+DEVICE_DT_DEFINE(DT_NODELABEL(name), i2c_stm32_init,		\
 		    NULL, &i2c_stm32_dev_data_##name,			\
 		    &i2c_stm32_cfg_##name,				\
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\

--- a/drivers/i2c/i2c_ll_stm32_v1.c
+++ b/drivers/i2c/i2c_ll_stm32_v1.c
@@ -15,7 +15,7 @@
 #include <soc.h>
 #include <stm32_ll_i2c.h>
 #include <errno.h>
-#include <drivers/i2c.h>
+#include "i2c_context.h"
 #include "i2c_ll_stm32.h"
 
 #define LOG_LEVEL CONFIG_I2C_LOG_LEVEL

--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -16,7 +16,7 @@
 #include <soc.h>
 #include <stm32_ll_i2c.h>
 #include <errno.h>
-#include <drivers/i2c.h>
+#include "i2c_context.h"
 #include "i2c_ll_stm32.h"
 
 #define LOG_LEVEL CONFIG_I2C_LOG_LEVEL

--- a/drivers/i2c/i2c_lpc11u6x.c
+++ b/drivers/i2c/i2c_lpc11u6x.c
@@ -7,7 +7,7 @@
 #define DT_DRV_COMPAT nxp_lpc11u6x_i2c
 
 #include <kernel.h>
-#include <drivers/i2c.h>
+#include "i2c_context.h"
 #include <drivers/pinmux.h>
 #include <drivers/clock_control.h>
 #include <dt-bindings/pinctrl/lpc11u6x-pinctrl.h>
@@ -400,7 +400,7 @@ static const struct lpc11u6x_i2c_config i2c_cfg_##idx = {		      \
 									      \
 static struct lpc11u6x_i2c_data i2c_data_##idx;			              \
 									      \
-I2C_DEVICE_DT_INST_DEFINE(idx,						      \
+DEVICE_DT_INST_DEFINE(idx,						      \
 		    lpc11u6x_i2c_init,					      \
 		    NULL,						      \
 		    &i2c_data_##idx, &i2c_cfg_##idx,			      \

--- a/drivers/i2c/i2c_mchp_xec.c
+++ b/drivers/i2c/i2c_mchp_xec.c
@@ -10,7 +10,7 @@
 #include <kernel.h>
 #include <soc.h>
 #include <errno.h>
-#include <drivers/i2c.h>
+#include "i2c_context.h"
 #include <logging/log.h>
 LOG_MODULE_REGISTER(i2c_mchp, CONFIG_I2C_LOG_LEVEL);
 

--- a/drivers/i2c/i2c_mchp_xec_v2.c
+++ b/drivers/i2c/i2c_mchp_xec_v2.c
@@ -12,7 +12,7 @@
 #include <errno.h>
 #include <drivers/clock_control.h>
 #include <drivers/gpio.h>
-#include <drivers/i2c.h>
+#include "i2c_context.h"
 #include <drivers/interrupt_controller/intc_mchp_xec_ecia.h>
 #include <drivers/pinmux.h>
 #include <sys/printk.h>
@@ -1163,7 +1163,7 @@ static int i2c_xec_init(const struct device *dev)
 		.pcr_bitpos = DT_INST_PROP_BY_IDX(n, pcrs, 1),		\
 		.irq_config_func = i2c_xec_irq_config_func_##n,		\
 	};								\
-	I2C_DEVICE_DT_INST_DEFINE(n, i2c_xec_init, NULL,		\
+	DEVICE_DT_INST_DEFINE(n, i2c_xec_init, NULL,		\
 		&i2c_xec_data_##n, &i2c_xec_config_##n,			\
 		POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,			\
 		&i2c_xec_driver_api);					\

--- a/drivers/i2c/i2c_mcux.c
+++ b/drivers/i2c/i2c_mcux.c
@@ -7,7 +7,7 @@
 #define DT_DRV_COMPAT nxp_kinetis_i2c
 
 #include <errno.h>
-#include <drivers/i2c.h>
+#include "i2c_context.h"
 #include <soc.h>
 #include <fsl_i2c.h>
 #include <fsl_clock.h>
@@ -226,7 +226,7 @@ static const struct i2c_driver_api i2c_mcux_driver_api = {
 									\
 	static struct i2c_mcux_data i2c_mcux_data_ ## n;		\
 									\
-	I2C_DEVICE_DT_INST_DEFINE(n,					\
+	DEVICE_DT_INST_DEFINE(n,					\
 			i2c_mcux_init, NULL,				\
 			&i2c_mcux_data_ ## n,				\
 			&i2c_mcux_config_ ## n, POST_KERNEL,		\

--- a/drivers/i2c/i2c_mcux_flexcomm.c
+++ b/drivers/i2c/i2c_mcux_flexcomm.c
@@ -8,7 +8,7 @@
 #define DT_DRV_COMPAT nxp_lpc_i2c
 
 #include <errno.h>
-#include <drivers/i2c.h>
+#include "i2c_context.h"
 #include <drivers/clock_control.h>
 #include <fsl_i2c.h>
 
@@ -225,7 +225,7 @@ static const struct i2c_driver_api mcux_flexcomm_driver_api = {
 		.bitrate = DT_INST_PROP(id, clock_frequency),		\
 	};								\
 	static struct mcux_flexcomm_data mcux_flexcomm_data_##id;	\
-	I2C_DEVICE_DT_INST_DEFINE(id,					\
+	DEVICE_DT_INST_DEFINE(id,					\
 			    mcux_flexcomm_init,				\
 			    NULL,					\
 			    &mcux_flexcomm_data_##id,			\

--- a/drivers/i2c/i2c_mcux_lpi2c.c
+++ b/drivers/i2c/i2c_mcux_lpi2c.c
@@ -8,7 +8,7 @@
 #define DT_DRV_COMPAT nxp_imx_lpi2c
 
 #include <errno.h>
-#include <drivers/i2c.h>
+#include "i2c_context.h"
 #include <drivers/clock_control.h>
 #include <fsl_lpi2c.h>
 
@@ -260,7 +260,7 @@ static const struct i2c_driver_api mcux_lpi2c_driver_api = {
 									\
 	static struct mcux_lpi2c_data mcux_lpi2c_data_##n;		\
 									\
-	I2C_DEVICE_DT_INST_DEFINE(n, mcux_lpi2c_init, NULL,		\
+	DEVICE_DT_INST_DEFINE(n, mcux_lpi2c_init, NULL,		\
 			    &mcux_lpi2c_data_##n,			\
 			    &mcux_lpi2c_config_##n, POST_KERNEL,	\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\

--- a/drivers/i2c/i2c_nios2.c
+++ b/drivers/i2c/i2c_nios2.c
@@ -7,7 +7,7 @@
 #define DT_DRV_COMPAT altr_nios2_i2c
 
 #include <errno.h>
-#include <drivers/i2c.h>
+#include "i2c_context.h"
 #include <soc.h>
 #include <sys/util.h>
 #include <altera_common.h>
@@ -162,7 +162,7 @@ static struct i2c_nios2_config i2c_nios2_cfg = {
 	},
 };
 
-I2C_DEVICE_DT_INST_DEFINE(0, i2c_nios2_init, NULL,
+DEVICE_DT_INST_DEFINE(0, i2c_nios2_init, NULL,
 		    NULL, &i2c_nios2_cfg,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &i2c_nios2_driver_api);

--- a/drivers/i2c/i2c_npcx_controller.c
+++ b/drivers/i2c/i2c_npcx_controller.c
@@ -68,7 +68,7 @@
 
 #include <assert.h>
 #include <drivers/clock_control.h>
-#include <drivers/i2c.h>
+#include "i2c_context.h"
 #include <soc.h>
 
 #include <logging/log.h>
@@ -961,7 +961,7 @@ static int i2c_ctrl_init(const struct device *dev)
 									       \
 	static struct i2c_ctrl_data i2c_ctrl_data_##inst;                      \
 									       \
-	I2C_DEVICE_DT_INST_DEFINE(inst,                                        \
+	DEVICE_DT_INST_DEFINE(inst,                                        \
 			    NPCX_I2C_CTRL_INIT_FUNC(inst),                     \
 			    NULL,                                              \
 			    &i2c_ctrl_data_##inst, &i2c_ctrl_cfg_##inst,       \

--- a/drivers/i2c/i2c_npcx_controller.h
+++ b/drivers/i2c/i2c_npcx_controller.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_DRIVERS_I2C_I2C_NPCX_CONTROLLER_H_
 #define ZEPHYR_DRIVERS_I2C_I2C_NPCX_CONTROLLER_H_
 
-#include <device.h>
+#include <i2c_context.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/drivers/i2c/i2c_npcx_port.c
+++ b/drivers/i2c/i2c_npcx_port.c
@@ -30,7 +30,7 @@
 
 #include <assert.h>
 #include <drivers/clock_control.h>
-#include <drivers/i2c.h>
+#include "i2c_context.h"
 #include <dt-bindings/i2c/i2c.h>
 #include <soc.h>
 

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -5,7 +5,7 @@
  */
 
 
-#include <drivers/i2c.h>
+#include "i2c_context.h"
 #include <dt-bindings/i2c/i2c.h>
 #include <pm/device.h>
 #include <nrfx_twi.h>
@@ -281,7 +281,7 @@ static int twi_nrfx_pm_action(const struct device *dev,
 		}							       \
 	};								       \
 	PM_DEVICE_DT_DEFINE(I2C(idx), twi_nrfx_pm_action);		       \
-	I2C_DEVICE_DT_DEFINE(I2C(idx),					       \
+	DEVICE_DT_DEFINE(I2C(idx),					       \
 		      twi_##idx##_init,					       \
 		      PM_DEVICE_DT_GET(I2C(idx)),			       \
 		      &twi_##idx##_data,				       \

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -5,7 +5,7 @@
  */
 
 
-#include <drivers/i2c.h>
+#include "i2c_context.h"
 #include <dt-bindings/i2c/i2c.h>
 #include <pm/device.h>
 #include <nrfx_twim.h>
@@ -393,7 +393,7 @@ static int twim_nrfx_pm_action(const struct device *dev,
 		.flash_buf_max_size = FLASH_BUF_MAX_SIZE(idx),		       \
 	};								       \
 	PM_DEVICE_DT_DEFINE(I2C(idx), twim_nrfx_pm_action);		       \
-	I2C_DEVICE_DT_DEFINE(I2C(idx),					       \
+	DEVICE_DT_DEFINE(I2C(idx),					       \
 		      twim_##idx##_init,				       \
 		      PM_DEVICE_DT_GET(I2C(idx)),			       \
 		      &twim_##idx##_data,				       \

--- a/drivers/i2c/i2c_rcar.c
+++ b/drivers/i2c/i2c_rcar.c
@@ -7,10 +7,10 @@
 #define DT_DRV_COMPAT renesas_rcar_i2c
 
 #include <errno.h>
-#include <device.h>
+#include "i2c_context.h"
 #include <devicetree.h>
 #include <soc.h>
-#include <drivers/i2c.h>
+#include "i2c_context.h"
 #include <drivers/clock_control.h>
 #include <drivers/clock_control/rcar_clock_control.h>
 
@@ -367,7 +367,7 @@ static const struct i2c_driver_api i2c_rcar_driver_api = {
 									       \
 	static struct i2c_rcar_data i2c_rcar_data_##n;			       \
 									       \
-	I2C_DEVICE_DT_INST_DEFINE(n,					       \
+	DEVICE_DT_INST_DEFINE(n,					       \
 			      i2c_rcar_init,				       \
 			      NULL,					       \
 			      &i2c_rcar_data_##n,			       \

--- a/drivers/i2c/i2c_rv32m1_lpi2c.c
+++ b/drivers/i2c/i2c_rv32m1_lpi2c.c
@@ -10,7 +10,7 @@
 
 #define DT_DRV_COMPAT openisa_rv32m1_lpi2c
 
-#include <drivers/i2c.h>
+#include "i2c_context.h"
 #include <drivers/clock_control.h>
 #include <fsl_lpi2c.h>
 #include <logging/log.h>
@@ -264,7 +264,7 @@ static const struct i2c_driver_api rv32m1_lpi2c_driver_api = {
 		.completion_sync = Z_SEM_INITIALIZER(                          \
 			rv32m1_lpi2c_##id##_data.completion_sync, 0, 1),       \
 	};                                                                     \
-	I2C_DEVICE_DT_INST_DEFINE(id,                                          \
+	DEVICE_DT_INST_DEFINE(id,                                          \
 			    rv32m1_lpi2c_init,                                 \
 			    NULL,                                              \
 			    &rv32m1_lpi2c_##id##_data,                         \

--- a/drivers/i2c/i2c_sam0.c
+++ b/drivers/i2c/i2c_sam0.c
@@ -7,10 +7,10 @@
 #define DT_DRV_COMPAT atmel_sam0_i2c
 
 #include <errno.h>
-#include <device.h>
+#include "i2c_context.h"
 #include <init.h>
 #include <soc.h>
-#include <drivers/i2c.h>
+#include "i2c_context.h"
 #include <drivers/dma.h>
 
 #include <logging/log.h>
@@ -808,7 +808,7 @@ static const struct i2c_sam0_dev_config i2c_sam0_dev_config_##n = {	\
 	static void i2c_sam0_irq_config_##n(const struct device *dev);	\
 	I2C_SAM0_CONFIG(n);						\
 	static struct i2c_sam0_dev_data i2c_sam0_dev_data_##n;		\
-	I2C_DEVICE_DT_INST_DEFINE(n,					\
+	DEVICE_DT_INST_DEFINE(n,					\
 			    i2c_sam0_initialize,			\
 			    NULL,					\
 			    &i2c_sam0_dev_data_##n,			\

--- a/drivers/i2c/i2c_sam4l_twim.c
+++ b/drivers/i2c/i2c_sam4l_twim.c
@@ -18,10 +18,10 @@
 #include <errno.h>
 #include <sys/__assert.h>
 #include <kernel.h>
-#include <device.h>
+#include "i2c_context.h"
 #include <init.h>
 #include <soc.h>
-#include <drivers/i2c.h>
+#include "i2c_context.h"
 
 #define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
 #include <logging/log.h>
@@ -624,7 +624,7 @@ static const struct i2c_driver_api i2c_sam_twim_driver_api = {
 									\
 	static struct i2c_sam_twim_dev_data i2c##n##_sam_data;		\
 									\
-	I2C_DEVICE_DT_INST_DEFINE(n, i2c_sam_twim_initialize,		\
+	DEVICE_DT_INST_DEFINE(n, i2c_sam_twim_initialize,		\
 			    NULL,					\
 			    &i2c##n##_sam_data, &i2c##n##_sam_config,	\
 			    POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,	\

--- a/drivers/i2c/i2c_sam_twi.c
+++ b/drivers/i2c/i2c_sam_twi.c
@@ -18,10 +18,10 @@
 #include <sys/__assert.h>
 #include <stdbool.h>
 #include <kernel.h>
-#include <device.h>
+#include "i2c_context.h"
 #include <init.h>
 #include <soc.h>
-#include <drivers/i2c.h>
+#include "i2c_context.h"
 
 #define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
 #include <logging/log.h>
@@ -354,7 +354,7 @@ static const struct i2c_driver_api i2c_sam_twi_driver_api = {
 									\
 	static struct i2c_sam_twi_dev_data i2c##n##_sam_data;		\
 									\
-	I2C_DEVICE_DT_INST_DEFINE(n, i2c_sam_twi_initialize,		\
+	DEVICE_DT_INST_DEFINE(n, i2c_sam_twi_initialize,		\
 			    NULL,					\
 			    &i2c##n##_sam_data, &i2c##n##_sam_config,	\
 			    POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,	\

--- a/drivers/i2c/i2c_sam_twihs.c
+++ b/drivers/i2c/i2c_sam_twihs.c
@@ -16,10 +16,9 @@
 #include <errno.h>
 #include <sys/__assert.h>
 #include <kernel.h>
-#include <device.h>
+#include "i2c_context.h"
 #include <init.h>
 #include <soc.h>
-#include <drivers/i2c.h>
 
 #define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
 #include <logging/log.h>
@@ -343,7 +342,7 @@ static const struct i2c_driver_api i2c_sam_twihs_driver_api = {
 									\
 	static struct i2c_sam_twihs_dev_data i2c##n##_sam_data;		\
 									\
-	I2C_DEVICE_DT_INST_DEFINE(n, i2c_sam_twihs_initialize,	\
+	DEVICE_DT_INST_DEFINE(n, i2c_sam_twihs_initialize,	\
 			    NULL,					\
 			    &i2c##n##_sam_data, &i2c##n##_sam_config,	\
 			    POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,	\

--- a/drivers/i2c/i2c_sbcon.c
+++ b/drivers/i2c/i2c_sbcon.c
@@ -14,9 +14,8 @@
  * hardware state of two-bit serial interfaces like I2C.
  */
 
-#include <device.h>
+#include "i2c_context.h"
 #include <errno.h>
-#include <drivers/i2c.h>
 #include "i2c_bitbang.h"
 
 /* SBCon hardware registers layout */
@@ -116,7 +115,7 @@ static const struct i2c_sbcon_config i2c_sbcon_dev_cfg_##_num = {	\
 	.sbcon		= (void *)DT_INST_REG_ADDR(_num), \
 };									\
 									\
-I2C_DEVICE_DT_INST_DEFINE(_num,						\
+DEVICE_DT_INST_DEFINE(_num,						\
 	    i2c_sbcon_init,						\
 	    NULL,							\
 	    &i2c_sbcon_dev_data_##_num,					\

--- a/drivers/i2c/i2c_shell.c
+++ b/drivers/i2c/i2c_shell.c
@@ -6,7 +6,7 @@
 
 #include <shell/shell.h>
 #include <stdlib.h>
-#include <drivers/i2c.h>
+#include "i2c_context.h"
 #include <string.h>
 #include <sys/util.h>
 #include <stdlib.h>

--- a/drivers/i2c/i2c_sifive.c
+++ b/drivers/i2c/i2c_sifive.c
@@ -10,8 +10,7 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(i2c_sifive);
 
-#include <device.h>
-#include <drivers/i2c.h>
+#include "i2c_context.h"
 #include <sys/sys_io.h>
 
 #include "i2c-priv.h"
@@ -329,7 +328,7 @@ static struct i2c_driver_api i2c_sifive_api = {
 		.f_sys = DT_INST_PROP(n, input_frequency), \
 		.f_bus = DT_INST_PROP(n, clock_frequency), \
 	}; \
-	I2C_DEVICE_DT_INST_DEFINE(n, \
+	DEVICE_DT_INST_DEFINE(n, \
 			    i2c_sifive_init, \
 			    NULL, \
 			    NULL, \

--- a/drivers/i2c/i2c_tca954x.c
+++ b/drivers/i2c/i2c_tca954x.c
@@ -5,10 +5,9 @@
  */
 
 #include <zephyr.h>
-#include <device.h>
+#include "i2c_context.h"
 #include <devicetree.h>
 #include <drivers/gpio.h>
-#include <drivers/i2c.h>
 #include <logging/log.h>
 #include <stdint.h>
 
@@ -182,7 +181,7 @@ const struct i2c_driver_api tca954x_api_funcs = {
 	static struct tca954x_root_data tca##n##a_data_##inst = {		  \
 		.lock = Z_MUTEX_INITIALIZER(tca##n##a_data_##inst.lock),	  \
 	};									  \
-	I2C_DEVICE_DT_DEFINE(DT_INST(inst, ti_tca##n##a),			  \
+	DEVICE_DT_DEFINE(DT_INST(inst, ti_tca##n##a),			  \
 			      tca954x_root_init, NULL,				  \
 			      &tca##n##a_data_##inst, &tca##n##a_cfg_##inst,	  \
 			      POST_KERNEL, CONFIG_I2C_TCA954X_ROOT_INIT_PRIO,	  \

--- a/drivers/i2c/i2c_test.c
+++ b/drivers/i2c/i2c_test.c
@@ -10,7 +10,7 @@
  */
 
 #include <zephyr.h>
-#include <drivers/i2c.h>
+#include "i2c_context.h"
 
 #define DT_DRV_COMPAT vnd_i2c
 
@@ -38,7 +38,7 @@ static int vnd_i2c_init(const struct device *dev)
 }
 
 #define VND_I2C_INIT(n)						\
-	I2C_DEVICE_DT_INST_DEFINE(n, vnd_i2c_init, NULL,			\
+	DEVICE_DT_INST_DEFINE(n, vnd_i2c_init, NULL,			\
 			      NULL, NULL, POST_KERNEL,			\
 			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\
 			      &vnd_i2c_api);

--- a/include/device_structs.h
+++ b/include/device_structs.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+#ifndef ZEPHYR_INCLUDE_DEVICE_STRUCTS_H_
+#define ZEPHYR_INCLUDE_DEVICE_STRUCTS_H_
+
+/**
+ * @brief Device Model Structures
+ * @defgroup device_model Device Model Structures
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include <stdbool.h>
+
+/**
+ * @brief Type used to represent a "handle" for a device.
+ *
+ * Every struct device has an associated handle. You can get a pointer
+ * to a device structure from its handle and vice versa, but the
+ * handle uses less space than a pointer. The device.h API mainly uses
+ * handles to store lists of multiple devices in a compact way.
+ *
+ * The extreme values and zero have special significance. Negative
+ * values identify functionality that does not correspond to a Zephyr
+ * device, such as the system clock or a SYS_INIT() function.
+ *
+ * @see device_handle_get()
+ * @see device_from_handle()
+ */
+typedef int16_t device_handle_t;
+
+/**
+ * @brief Runtime device dynamic structure (in RAM) per driver instance
+ *
+ * Fields in this are expected to be default-initialized to zero. The
+ * kernel driver infrastructure and driver access functions are
+ * responsible for ensuring that any non-zero initialization is done
+ * before they are accessed.
+ */
+struct device_state {
+	/** Non-negative result of initializing the device.
+	 *
+	 * The absolute value returned when the device initialization
+	 * function was invoked, or `UINT8_MAX` if the value exceeds
+	 * an 8-bit integer. If initialized is also set, a zero value
+	 * indicates initialization succeeded.
+	 */
+	unsigned int init_res : 8;
+
+	/** Indicates the device initialization function has been
+	 * invoked.
+	 */
+	bool initialized : 1;
+};
+
+struct pm_device;
+
+/**
+ * @brief Runtime device structure (in ROM) per driver instance
+ */
+struct device {
+	/** Name of the device instance */
+	const char *name;
+	/** Address of device instance config information */
+	const void *config;
+	/** Address of the API structure exposed by the device instance */
+	const void *api;
+	/** Address of the common device state */
+	struct device_state * const state;
+	/** Address of the device instance private data */
+	void * const data;
+	/** optional pointer to handles associated with the device.
+	 *
+	 * This encodes a sequence of sets of device handles that have
+	 * some relationship to this node. The individual sets are
+	 * extracted with dedicated API, such as
+	 * device_required_handles_get().
+	 */
+	const device_handle_t *const handles;
+#ifdef CONFIG_PM_DEVICE
+	/** Reference to the device PM resources. */
+	struct pm_device * const pm;
+#endif
+};
+
+#endif /* ZEPHYR_INCLUDE_DEVICE_STRUCTS_H */

--- a/include/drivers/i2c.h
+++ b/include/drivers/i2c.h
@@ -192,6 +192,12 @@ struct i2c_slave_driver_api {
 	i2c_slave_api_unregister_t driver_unregister;
 };
 
+void z_i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs,
+			     uint8_t num_msgs);
+
+/* magic word value for detecting if common data is setup for driver */
+#define Z_I2C_MAGIC 0x1221EFFE
+
 /**
  * @endcond
  */
@@ -282,6 +288,7 @@ typedef int (*i2c_slave_read_requested_cb_t)(
 typedef int (*i2c_slave_read_processed_cb_t)(
 		struct i2c_slave_config *config, uint8_t *val);
 
+
 /** @brief Function called when a stop condition is observed after a
  * start condition addressed to a particular device.
  *
@@ -337,161 +344,9 @@ struct i2c_slave_config {
 	const struct i2c_slave_callbacks *callbacks;
 };
 
-#if defined(CONFIG_I2C_STATS) || defined(__DOXYGEN__)
-
-#include <stats/stats.h>
-
-/** @cond INTERNAL_HIDDEN */
-
-STATS_SECT_START(i2c)
-STATS_SECT_ENTRY32(bytes_read)
-STATS_SECT_ENTRY32(bytes_written)
-STATS_SECT_ENTRY32(message_count)
-STATS_SECT_ENTRY32(transfer_call_count)
-STATS_SECT_END;
-
-STATS_NAME_START(i2c)
-STATS_NAME(i2c, bytes_read)
-STATS_NAME(i2c, bytes_written)
-STATS_NAME(i2c, message_count)
-STATS_NAME(i2c, transfer_call_count)
-STATS_NAME_END(i2c);
-
-/** @endcond */
 
 
-/**
- * @brief I2C specific device state which allows for i2c device class specific additions
- */
-struct i2c_device_state {
-	struct device_state devstate;
-	struct stats_i2c stats;
-};
-
-/**
- * @brief Updates the i2c stats for i2c transfers
- *
- * @param dev I2C device to update stats for
- * @param msgs Array of struct i2c_msg
- * @param num_msgs Number of i2c_msgs
- */
-static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs,
-				  uint8_t num_msgs)
-{
-	struct i2c_device_state *state =
-		CONTAINER_OF(dev->state, struct i2c_device_state, devstate);
-	uint32_t bytes_read = 0U;
-	uint32_t bytes_written = 0U;
-
-	STATS_INC(state->stats, transfer_call_count);
-	STATS_INCN(state->stats, message_count, num_msgs);
-	for (uint8_t i = 0U; i < num_msgs; i++) {
-		if (msgs[i].flags & I2C_MSG_READ) {
-			bytes_read += msgs[i].len;
-		}
-		if (msgs[i].flags & I2C_MSG_WRITE) {
-			bytes_written += msgs[i].len;
-		}
-	}
-	STATS_INCN(state->stats, bytes_read, bytes_read);
-	STATS_INCN(state->stats, bytes_written, bytes_written);
-}
-
-/** @cond INTERNAL_HIDDEN */
-
-/**
- * @brief Define a statically allocated and section assigned i2c device state
- */
-#define Z_I2C_DEVICE_STATE_DEFINE(node_id, dev_name)	\
-	static struct i2c_device_state Z_DEVICE_STATE_NAME(dev_name)	\
-	__attribute__((__section__(".z_devstate")));
-
-/**
- * @brief Define an i2c device init wrapper function
- *
- * This does device instance specific initialization of common data (such as stats)
- * and calls the given init_fn
- */
-#define Z_I2C_INIT_FN(dev_name, init_fn)					\
-	static inline int UTIL_CAT(dev_name, _init)(const struct device *dev) \
-	{								\
-		struct i2c_device_state *state =			\
-			CONTAINER_OF(dev->state, struct i2c_device_state, devstate); \
-		stats_init(&state->stats.s_hdr, STATS_SIZE_32, 4,	\
-			   STATS_NAME_INIT_PARMS(i2c));			\
-		stats_register(dev->name, &(state->stats.s_hdr));	\
-		return init_fn(dev);					\
-	}
-
-/** @endcond */
-
-/**
- * @brief Like DEVICE_DT_DEFINE() with I2C specifics.
- *
- * @details Defines a device which implements the I2C API. May
- * generate a custom device_state container struct and init_fn
- * wrapper when needed depending on I2C @kconfig{CONFIG_I2C_STATS}.
- *
- * @param node_id The devicetree node identifier.
- *
- * @param init_fn Name of the init function of the driver.
- *
- * @param pm_device PM device resources reference (NULL if device does not use PM).
- *
- * @param data_ptr Pointer to the device's private data.
- *
- * @param cfg_ptr The address to the structure containing the
- * configuration information for this instance of the driver.
- *
- * @param level The initialization level. See SYS_INIT() for
- * details.
- *
- * @param prio Priority within the selected initialization level. See
- * SYS_INIT() for details.
- *
- * @param api_ptr Provides an initial pointer to the API function struct
- * used by the driver. Can be NULL.
- */
-#define I2C_DEVICE_DT_DEFINE(node_id, init_fn, pm_device,		\
-			     data_ptr, cfg_ptr, level, prio,		\
-			     api_ptr, ...)				\
-	Z_I2C_DEVICE_STATE_DEFINE(node_id, Z_DEVICE_DT_DEV_NAME(node_id)); \
-	Z_I2C_INIT_FN(Z_DEVICE_DT_DEV_NAME(node_id), init_fn)		\
-	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_NAME(node_id),		\
-			DEVICE_DT_NAME(node_id),			\
-			&UTIL_CAT(Z_DEVICE_DT_DEV_NAME(node_id), _init), \
-			pm_device,					\
-			data_ptr, cfg_ptr, level, prio,			\
-			api_ptr,					\
-			&(Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_NAME(node_id)).devstate), \
-			__VA_ARGS__)
-
-#else /* CONFIG_I2C_STATS */
-
-static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs,
-				  uint8_t num_msgs)
-{
-}
-
-#define I2C_DEVICE_DT_DEFINE(node_id, init_fn, pm_device,		\
-			     data_ptr, cfg_ptr, level, prio,		\
-			     api_ptr, ...)				\
-	DEVICE_DT_DEFINE(node_id, &init_fn, pm_device,			\
-			     data_ptr, cfg_ptr, level, prio,		\
-			     api_ptr, __VA_ARGS__)
-
-#endif /* CONFIG_I2C_STATS */
-
-/**
- * @brief Like I2C_DEVICE_DT_DEFINE() for an instance of a DT_DRV_COMPAT compatible
- *
- * @param inst instance number. This is replaced by
- * <tt>DT_DRV_COMPAT(inst)</tt> in the call to I2C_DEVICE_DT_DEFINE().
- *
- * @param ... other parameters as expected by I2C_DEVICE_DT_DEFINE().
- */
-#define I2C_DEVICE_DT_INST_DEFINE(inst, ...)		\
-	I2C_DEVICE_DT_DEFINE(DT_DRV_INST(inst), __VA_ARGS__)
+#include <device.h>
 
 
 /**
@@ -588,7 +443,7 @@ static inline int z_impl_i2c_transfer(const struct device *dev,
 
 	int res =  api->transfer(dev, msgs, num_msgs, addr);
 
-	i2c_xfer_stats(dev, msgs, num_msgs);
+	z_i2c_xfer_stats(dev, msgs, num_msgs);
 
 	return res;
 }


### PR DESCRIPTION
Rather than a custom I2C_DEVICE_DT define macro use include
ordering and hooks into the original DEVICE_ macros to create a
common i2c context object used as a container type for the
device state.

This eliminates the need for any i2c driver to understand how to use
the context, initialize the context, or allocate the context.

It may be opted out of by not including i2c_context as there is
a magic word placed in memory to enable runtime checks, when needed,
if the driver has opted in to using the common code and data.

try it out with a frdm board if interested

```
west build -p always -b frdm_k64f samples/sensor/fxos8700 -- -DCONFIG_I2C_STATS=y -DCONFIG_STATS_NAMES=y -DCONFIG_SHELL=y -DCONFIG_STATS_SHELL=y -DCONFIG_STATS=y 
```

Signed-off-by: Tom Burdick <thomas.burdick@intel.com>