### PR TITLE
ITE: drivers/i2c: I2C setting frequency adjustment

### DIFF
--- a/drivers/i2c/Kconfig.it8xxx2
+++ b/drivers/i2c/Kconfig.it8xxx2
@@ -8,3 +8,19 @@ config I2C_ITE_IT8XXX2
 	  Enable I2C support on it8xxx2_evb.
 	  Supported Speeds: 100kHz, 400kHz and 1MHz.
 	  This driver supports repeated start.
+
+config I2C_ITE_ADJUST_SCL_LOW_PSC
+	int "Adjust SCL low period prescale"
+	depends on I2C_ITE_IT8XXX2
+	default 0
+	range 0 255
+	help
+	  This option is used to configure the I2C speed prescaler
+	  for the SCL low period. It only applies to I2C3/4/5 ports.
+	  When set to >= 1, it will increase the low period of the
+	  SCL clock and so reduce the signal frequency.
+	  The resulting SCL cycle time is given by the following
+	  formula:
+	  SCL cycle =
+	  2 * (psr + I2C_ADJUST_SCL_LOW_PRESCALE + 2) *
+	  SMBus clock cycle

--- a/drivers/i2c/i2c_ite_it8xxx2.c
+++ b/drivers/i2c/i2c_ite_it8xxx2.c
@@ -242,10 +242,10 @@ static void i2c_standard_port_timing_regs_400khz(uint8_t port)
 	/* Port clock frequency depends on setting of timing registers. */
 	IT83XX_SMB_SCLKTS(port) = 0;
 	/* Suggested setting of timing registers of 400kHz. */
-	IT83XX_SMB_4P7USL = 0x6;
+	IT83XX_SMB_4P7USL = 0x3;
 	IT83XX_SMB_4P0USL = 0;
 	IT83XX_SMB_300NS = 0x1;
-	IT83XX_SMB_250NS = 0x2;
+	IT83XX_SMB_250NS = 0x5;
 	IT83XX_SMB_45P3USL = 0x6a;
 	IT83XX_SMB_45P3USH = 0x1;
 	IT83XX_SMB_4P7A4P0H = 0;

--- a/drivers/i2c/i2c_ite_it8xxx2.c
+++ b/drivers/i2c/i2c_ite_it8xxx2.c
@@ -302,6 +302,9 @@ static void i2c_enhanced_port_set_frequency(const struct device *dev,
 			psr = 0xFD;
 		}
 
+		/* Adjust SCL low period prescale */
+		psr += CONFIG_I2C_ITE_ADJUST_SCL_LOW_PSC;
+
 		/* Set I2C Speed */
 		IT83XX_I2C_PSR(base) = psr & 0xFF;
 		IT83XX_I2C_HSPR(base) = psr & 0xFF;


### PR DESCRIPTION
In order to pass the SI (Signal Integrity) test, the timing registers of  I2C 0/1/2 port
can be used to adjust tHD; DAT and tSU;DAT to pass it, and I2C 3/4/5 port can add
a config of CONFIG_I2C_ADJUST_SCL_LOW_PRESCALE to adjust the low period of
SCL clock to pass tLOW test.

Signed-off-by: Tim Lin <tim2.lin@ite.corp-partner.google.com>