### PR TITLE
twister: for twister can run tests on ITE board.

### DIFF
--- a/boards/riscv/it8xxx2_evb/board.cmake
+++ b/boards/riscv/it8xxx2_evb/board.cmake
@@ -1,2 +1,4 @@
 set(SUPPORTED_EMU_PLATFORMS renode)
 set(RENODE_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/support/it8xxx2_evb.resc)
+board_set_flasher_ifnset(misc-flasher)
+board_finalize_runner_args(misc-flasher)

--- a/boards/riscv/it8xxx2_evb/it8xxx2_evb.yaml
+++ b/boards/riscv/it8xxx2_evb/it8xxx2_evb.yaml
@@ -9,3 +9,10 @@ testing:
   ignore_tags:
     - net
     - bluetooth
+supported:
+  - gpio
+  - adc
+  - i2c
+  - kscan
+  - pwm
+  - watchdog


### PR DESCRIPTION
Set board flasher, so twister can run tests on ITE(it8xxx2_evb) board.
Add supported drivers of it8xxx2_evb board, so twister could run driver
tests without skipping.

Signed-off-by: rainer754 <haolei.fu@intel.com>