### PR TITLE
samples: tests task wdt on some stm32 nucleo target boards

### DIFF
--- a/boards/arm/nucleo_wl55jc/nucleo_wl55jc.dts
+++ b/boards/arm/nucleo_wl55jc/nucleo_wl55jc.dts
@@ -166,6 +166,10 @@
 	status = "okay";
 };
 
+&iwdg {
+	status = "okay";
+};
+
 &subghzspi {
 	status = "okay";
 	lora: radio@0 {

--- a/boards/arm/nucleo_wl55jc/nucleo_wl55jc.yaml
+++ b/boards/arm/nucleo_wl55jc/nucleo_wl55jc.yaml
@@ -19,3 +19,4 @@ supported:
   - dac
   - pwm
   - dma
+  - watchdog

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -55,8 +55,9 @@
 
 		clk_lsi: clk-lsi {
 			#clock-cells = <0>;
-			compatible = "fixed-clock";
+			compatible = "st,stm32-lsi-clock";
 			clock-frequency = <DT_FREQ_K(40)>;
+			max-clock-frequency = <DT_FREQ_K(50)>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -55,7 +55,7 @@
 
 		clk_lsi: clk-lsi {
 			#clock-cells = <0>;
-			compatible = "fixed-clock";
+			compatible = "st,stm32-lsi-clock";
 			clock-frequency = <DT_FREQ_K(40)>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -56,7 +56,7 @@
 
 		clk_lsi: clk-lsi {
 			#clock-cells = <0>;
-			compatible = "fixed-clock";
+			compatible = "st,stm32-lsi-clock";
 			clock-frequency = <DT_FREQ_K(32)>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -56,7 +56,7 @@
 
 		clk_lsi: clk-lsi {
 			#clock-cells = <0>;
-			compatible = "fixed-clock";
+			compatible = "st,stm32-lsi-clock";
 			clock-frequency = <DT_FREQ_K(40)>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -55,8 +55,9 @@
 
 		clk_lsi: clk-lsi {
 			#clock-cells = <0>;
-			compatible = "fixed-clock";
+			compatible = "st,stm32-lsi-clock";
 			clock-frequency = <DT_FREQ_K(32)>;
+			max-clock-frequency = <DT_FREQ_K(47)>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -61,7 +61,7 @@
 
 		clk_lsi: clk-lsi {
 			#clock-cells = <0>;
-			compatible = "fixed-clock";
+			compatible = "st,stm32-lsi-clock";
 			clock-frequency = <DT_FREQ_K(32)>;
 			status = "disabled";
 		};

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -58,7 +58,7 @@
 
 		clk_lsi: clk-lsi {
 			#clock-cells = <0>;
-			compatible = "fixed-clock";
+			compatible = "st,stm32-lsi-clock";
 			clock-frequency = <DT_FREQ_K(32)>;
 			status = "disabled";
 		};

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -57,7 +57,7 @@
 
 		clk_lsi: clk-lsi {
 			#clock-cells = <0>;
-			compatible = "fixed-clock";
+			compatible = "st,stm32-lsi-clock";
 			clock-frequency = <DT_FREQ_K(32)>;
 			status = "disabled";
 		};

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -72,7 +72,7 @@
 
 		clk_lsi: clk-lsi {
 			#clock-cells = <0>;
-			compatible = "fixed-clock";
+			compatible = "st,stm32-lsi-clock";
 			clock-frequency = <DT_FREQ_K(32)>;
 			status = "disabled";
 		};

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -62,8 +62,9 @@
 
 		clk_lsi: clk-lsi {
 			#clock-cells = <0>;
-			compatible = "fixed-clock";
+			compatible = "st,stm32-lsi-clock";
 			clock-frequency = <DT_FREQ_K(37)>;
+			max-clock-frequency = <DT_FREQ_K(56)>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -62,8 +62,9 @@
 
 		clk_lsi: clk-lsi {
 			#clock-cells = <0>;
-			compatible = "fixed-clock";
+			compatible = "st,stm32-lsi-clock";
 			clock-frequency = <DT_FREQ_K(37)>;
+			max-clock-frequency = <DT_FREQ_K(56)>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -64,7 +64,7 @@
 
 		clk_lsi: clk-lsi {
 			#clock-cells = <0>;
-			compatible = "fixed-clock";
+			compatible = "st,stm32-lsi-clock";
 			clock-frequency = <DT_FREQ_K(32)>;
 			status = "disabled";
 		};

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -72,7 +72,7 @@
 
 		clk_lsi: clk-lsi {
 			#clock-cells = <0>;
-			compatible = "fixed-clock";
+			compatible = "st,stm32-lsi-clock";
 			clock-frequency = <DT_FREQ_K(32)>;
 			status = "disabled";
 		};

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -70,7 +70,7 @@
 
 		clk_lsi: clk-lsi {
 			#clock-cells = <0>;
-			compatible = "fixed-clock";
+			compatible = "st,stm32-lsi-clock";
 			clock-frequency = <DT_FREQ_K(32)>;
 			status = "disabled";
 		};

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -75,9 +75,9 @@
 			status = "disabled";
 		};
 
-		clk_lsi1: clk-lsi1 {
+		clk_lsi: clk_lsi1: clk-lsi1 {
 			#clock-cells = <0>;
-			compatible = "fixed-clock";
+			compatible = "st,stm32-lsi-clock";
 			clock-frequency = <DT_FREQ_K(32)>;
 			status = "disabled";
 		};

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -65,7 +65,7 @@
 
 		clk_lsi: clk-lsi {
 			#clock-cells = <0>;
-			compatible = "fixed-clock";
+			compatible = "st,stm32-lsi-clock";
 			clock-frequency = <DT_FREQ_K(32)>;
 			status = "disabled";
 		};

--- a/dts/bindings/clock/st,stm32-lsi-clock.yaml
+++ b/dts/bindings/clock/st,stm32-lsi-clock.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2022, STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+description: STM32 LSI Clock
+
+compatible: "st,stm32-lsi-clock"
+
+include: [fixed-clock.yaml]
+
+properties:
+    max-clock-frequency:
+      type: int
+      required: false
+      description: |
+        LSI RC oscillator max frequency as stated by the stm32 datasheet
+        This characteristic in Hz is higher than <clock-frequency> and maybe
+        used by any driver when the (typical) LSI <clock-frequency> is too low.

--- a/include/drivers/clock_control/stm32_clock_control.h
+++ b/include/drivers/clock_control/stm32_clock_control.h
@@ -164,11 +164,15 @@
 #define STM32_CSI_FREQ		0
 #endif
 
-#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(clk_lsi), fixed_clock, okay)
-#define STM32_LSI_ENABLED	1
+/* the STM32_LSI_FREQ is given by the LSI RC oscillator, even if not enabled */
+#if DT_PROP(DT_NODELABEL(clk_lsi), clock_frequency)
 #define STM32_LSI_FREQ		DT_PROP(DT_NODELABEL(clk_lsi), clock_frequency)
 #else
-#define STM32_LSI_FREQ		0
+/* LSI clock freq should be in device tree, not from stm32Cube LSI_VALUE */
+#define STM32_LSI_FREQ		LSI_VALUE
+#endif
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(clk_lsi), fixed_clock, okay)
+#define STM32_LSI_ENABLED	1
 #endif
 
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(clk_hsi), st_stm32h7_hsi_clock, okay)


### PR DESCRIPTION
The IWDG timeout depends on the actual LSI clock frequency which feeds the watchdog timer.
On the stm32l152, stm32f091, stm32l073, stmf429, due to manufacturing the LSI clock is given with a typical value and a min-Max range. The IWDT is clocked by the LSI which has a frequency of 40kHz for those stm32 devices. The LSI freq must be adjusted to its real value to give the IWDG timeout.
We add an overlay for this sample on the target board to set a more accurate LSI freq. higher than the default 37kHz and this should be updated for any board
once the actual LSI freq differs from the  LSI default value set by the clk_lsi node of the DTS:
```
 		clk_lsi: clk-lsi {
			#clock-cells = <0>;
			compatible = "fixed-clock";
			clock-frequency = <DT_FREQ_K(37)>;
			status = "disabled";
		};

```
Other changes are applied coming from the stm32Cube example.
The driver should enable the IWDG just before changing the prescaler and reload registers, else it starts running immediately.
After updating the IDT prescaler and reload registers, the IWDT SR gives the position of the PVU and the RVU bits thanks to a LL function. LL_IWDG_IsReady() returns 1 when the update is completed, so the driver should wait until LL_IWDG_IsReady is not 0 anymore. There is no need to include a timeout.
The RefMan of stm32l073, stm32l152, stm32f091, stm32f429 is confusing because it explicitly mentions "5 RC 40kHz cycles" 
The correct formula is **t_IWDG(ms) = t_LSI(ms) x 4 x 2^(IWDG_PR[2:0]) x (IWDG_RLR[11:0] + 1**)
There is no need to enable the LSI explicitely in the iwdt driver.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/43024

Signed-off-by: Francois Ramu <francois.ramu@st.com>