### PR TITLE
Bluetooth: L2CAP: Fix checking if LTK is present

### DIFF
--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -1054,9 +1054,9 @@ static uint16_t l2cap_check_security(struct bt_conn *conn,
 
 	if (keys) {
 		if (conn->role == BT_HCI_ROLE_CENTRAL) {
-			ltk_present = keys->id & (BT_KEYS_LTK_P256 | BT_KEYS_PERIPH_LTK);
+			ltk_present = keys->keys & (BT_KEYS_LTK_P256 | BT_KEYS_PERIPH_LTK);
 		} else {
-			ltk_present = keys->id & (BT_KEYS_LTK_P256 | BT_KEYS_LTK);
+			ltk_present = keys->keys & (BT_KEYS_LTK_P256 | BT_KEYS_LTK);
 		}
 	} else {
 		ltk_present = false;


### PR DESCRIPTION
This fix a typo where incorrect member of bt_keys was used for
checking if LTK is present. This was resulting in bogus results
depending on connection role and current identity used.

This was affecting L2CAP/LE/CFC/BV-25-C qualification test case.

Fixes: #42862

Signed-off-by: Szymon Janc <szymon.janc@codecoup.pl>