### PR TITLE
Bluetooth: Controller: df: Fix missing node_rx release if wrong CTE type

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -837,6 +837,10 @@ void ull_sync_established_report(memq_link_t *link, struct node_rx_hdr *rx)
 		 */
 		rx->type = NODE_RX_TYPE_SYNC_REPORT;
 		ull_scan_aux_setup(link, rx);
+	} else {
+		rx->type = NODE_RX_TYPE_RELEASE;
+		ll_rx_put(link, rx);
+		ll_rx_sched();
 	}
 }
 


### PR DESCRIPTION
Periodic advertising sync may be created with CTE type filtering
enabled. When received AUX_SYNC_IND, there are HCI_LE_Periodic_-
Advertising_Sync_Established and HCI_LE_Periodic_Advertising_Report
events generated. In case received AUX_SYNC_IND has wrong CTE type,
HCI_LE_Periodic_Advertising_Sync_Established event is generated.
There may not be HCI_LE_Periodic_Advertising_Report event generated.
In this case node_rx, prepared by LLL, was not released in ULL.
It was lost in ull_sync_established_report.

Fixes #41465.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>