### PR TITLE
dts: arm: stm32l0 LSI clock freq is 37kHz

### DIFF
--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -63,7 +63,7 @@
 		clk_lsi: clk-lsi {
 			#clock-cells = <0>;
 			compatible = "fixed-clock";
-			clock-frequency = <DT_FREQ_K(32)>;
+			clock-frequency = <DT_FREQ_K(37)>;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
Corrects the LSI clock freq for stm32l0x mcus
especially stm32l0x0 stm32l0x1 stm32l0x2 stm32l0x3 series

Refer to the RefMan for each device

Signed-off-by: Francois Ramu <francois.ramu@st.com>