### PR TITLE
Bluetooth: Kconfig: Increase default RX stack size for LE Audio

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -85,6 +85,7 @@ config BT_RX_STACK_SIZE
 	depends on BT_HCI_HOST || BT_RECV_IS_RX_THREAD
 	default 512 if BT_HCI_RAW
 	default 2048 if BT_MESH
+	default 2048 if BT_AUDIO
 	default 2200 if BT_SETTINGS
 	default 1024
 	help


### PR DESCRIPTION
LE Audio builds on top of the BT Host stack, and will
thus require a higher amount of stack size. Even simple
applications using BAP will likely reach the 1024 default
size with the default BAP configurations, and when
we start adding CAP and even TMAP/HAP on top of it, it
will likely increase even further.

The default value of 2048 is unlikely to be reached,
and applications that want to optimize can likely
reduce it, depending on the configuration.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>