### PR TITLE
build: Extend zephyr repo to be module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,6 @@ add_library(zephyr_interface INTERFACE)
 zephyr_library_named(zephyr)
 
 zephyr_include_directories(
-  include
   ${PROJECT_BINARY_DIR}/include/generated
   ${USERINCLUDE}
   ${STDINCLUDE}
@@ -479,39 +478,6 @@ endforeach()
 if (DISCOVERED_FIXUP_FILES)
   message(WARNING "One or more dts_fixup.h files detected:\n${DISCOVERED_FIXUP_FILES}Use of these files is deprecated; use the devicetree.h API instead.")
 endif()
-
-# Unfortunately, the order in which CMakeLists.txt code is processed
-# matters so we need to be careful about how we order the processing
-# of subdirectories. One example is "Compiler flags added late in the
-# build are not exported to external build systems #5605"; when we
-# integrate with an external build system we read out all compiler
-# flags when the external project is created. So an external project
-# defined in subsys or ext will not get global flags added by drivers/
-# or tests/ as the subdirectories are ordered now.
-#
-# Another example of when the order matters is the reading and writing
-# of global properties such as ZEPHYR_LIBS or
-# GENERATED_KERNEL_OBJECT_FILES.
-#
-# Arch is placed early because it defines important compiler flags
-# that must be exported to external build systems defined in
-# e.g. subsys/.
-add_subdirectory(arch)
-add_subdirectory(lib)
-# We use include instead of add_subdirectory to avoid creating a new directory scope.
-# This is because source file properties are directory scoped, including the GENERATED
-# property which is set implicitly for custom command outputs
-include(misc/generated/CMakeLists.txt)
-
-if(EXISTS ${SOC_DIR}/${ARCH}/CMakeLists.txt)
-  add_subdirectory(${SOC_DIR}/${ARCH} soc/${ARCH})
-else()
-  add_subdirectory(${SOC_DIR}/${ARCH}/${SOC_PATH} soc/${ARCH}/${SOC_PATH})
-endif()
-
-add_subdirectory(boards)
-add_subdirectory(subsys)
-add_subdirectory(drivers)
 
 # Include zephyr modules generated CMake file.
 foreach(module_name ${ZEPHYR_MODULE_NAMES})

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -777,6 +777,7 @@
 /tests/subsys/fs/                         @nashif @nvlsianpu @de-nordic
 /tests/subsys/settings/                   @nvlsianpu
 /tests/subsys/shell/                      @jakub-uC @nordic-krch
+/zephyr/                                  @tejlmand @nashif
 # Get all docs reviewed
 *.rst                                     @nashif
 /doc/reference/kernel/                    @andyross @nashif

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -34,15 +34,6 @@ source "modules/Kconfig"
 
 endmenu
 
-source "boards/Kconfig"
-source "soc/Kconfig"
-source "arch/Kconfig"
-source "kernel/Kconfig"
-source "dts/Kconfig"
-source "drivers/Kconfig"
-source "lib/Kconfig"
-source "subsys/Kconfig"
-
 osource "$(TOOLCHAIN_KCONFIG_DIR)/Kconfig"
 
 menu "Build and Link Features"

--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -2742,6 +2742,12 @@ class TestSuite(DisablePyTestCollectionMixin):
         else:
             self.board_roots = board_root_list
 
+        unique_board_roots = []
+        [unique_board_roots.append(os.path.realpath(x))
+                for x in self.board_roots
+                if os.path.realpath(x) not in unique_board_roots]
+        self.board_roots = unique_board_roots
+
         # Testsuite Options
         self.coverage_platform = []
         self.build_only = False

--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -392,6 +392,9 @@ def parse_modules(zephyr_base, modules=None, extra_modules=None):
     if modules is None:
         modules = []
 
+    if (zephyr_base not in modules) and (zephyr_base is not None):
+        modules.insert(0, zephyr_base)
+
     if extra_modules is None:
         extra_modules = []
 
@@ -404,10 +407,6 @@ def parse_modules(zephyr_base, modules=None, extra_modules=None):
     sorted_modules = []
 
     for project in modules + extra_modules:
-        # Avoid including Zephyr base project as module.
-        if project == zephyr_base:
-            continue
-
         meta = process_module(project)
         if meta:
             section = meta.get('build', dict())

--- a/tests/cmake/zephyr_as_module/CMakeLists.txt
+++ b/tests/cmake/zephyr_as_module/CMakeLists.txt
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+project(zephyr_as_module_test)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/cmake/zephyr_as_module/foo/prj.conf
+++ b/tests/cmake/zephyr_as_module/foo/prj.conf
@@ -1,0 +1,1 @@
+# intentionally empty

--- a/tests/cmake/zephyr_as_module/src/main.c
+++ b/tests/cmake/zephyr_as_module/src/main.c
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2022 Legrand North America, LLC.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+void test_main(void)
+{
+	/* Intentionally left empty, we are testing CMake. */
+}

--- a/tests/cmake/zephyr_as_module/testcase.yaml
+++ b/tests/cmake/zephyr_as_module/testcase.yaml
@@ -1,0 +1,4 @@
+tests:
+  cmake.zephyr_as_module:
+    platform_allow: native_posix
+    build_only: true

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# The Zephyr repository must use the repository-root CMakeLists.txt
+# root to hook the build system into the application-provided CMakeLists.txt.
+#
+# The module-interface CMakeLists.txt (this file) is located in
+# the same directory as `module.yml` to help indicate scope.
+# Because the Zephyr directory tree is located above the location
+# of the module-interface CMakeLists.txt all the `add_subdirectory()`
+# calls must provide an path to the binary output directory.
+
+zephyr_include_directories(../include)
+
+# Unfortunately, the order in which CMakeLists.txt code is processed
+# matters so we need to be careful about how we order the processing
+# of subdirectories. One example is "Compiler flags added late in the
+# build are not exported to external build systems #5605"; when we
+# integrate with an external build system we read out all compiler
+# flags when the external project is created. So an external project
+# defined in subsys or ext will not get global flags added by drivers/
+# or tests/ as the subdirectories are ordered now.
+#
+# Another example of when the order matters is the reading and writing
+# of global properties such as ZEPHYR_LIBS or
+# GENERATED_KERNEL_OBJECT_FILES.
+#
+# Arch is placed early because it defines important compiler flags
+# that must be exported to external build systems defined in
+# e.g. subsys/.
+add_subdirectory(../arch ${__build_dir}/arch)
+add_subdirectory(../lib ${__build_dir}/lib)
+# We use include instead of add_subdirectory to avoid creating a new directory scope.
+# This is because source file properties are directory scoped, including the GENERATED
+# property which is set implicitly for custom command outputs
+include(../misc/generated/CMakeLists.txt)
+
+if(EXISTS ${SOC_DIR}/${ARCH}/CMakeLists.txt)
+  add_subdirectory(${SOC_DIR}/${ARCH} ${__build_dir}/soc/${ARCH})
+else()
+  add_subdirectory(${SOC_DIR}/${ARCH}/${SOC_PATH} ${__build_dir}/soc/${ARCH}/${SOC_PATH})
+endif()
+
+add_subdirectory(../boards ${__build_dir}/boards)
+add_subdirectory(../drivers ${__build_dir}/drivers)
+add_subdirectory(../subsys ${__build_dir}/subsys)

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -1,0 +1,14 @@
+# General configuration options
+
+# Copyright (c) 2022 Legrand North America, LLC.
+# SPDX-License-Identifier: Apache-2.0
+
+
+source "boards/Kconfig"
+source "soc/Kconfig"
+source "arch/Kconfig"
+source "kernel/Kconfig"
+source "dts/Kconfig"
+source "drivers/Kconfig"
+source "lib/Kconfig"
+source "subsys/Kconfig"

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2022 Legrand North America, LLC.
+#
+# Zephyr module interface file
+#
+# This file enforces that the name of this module is not changeable.
+# Since the mounting location is controlled by manifest files,
+# explicitly setting the name here is necessary to support constructing
+# absolute references to files in this repository via
+# `${ZEPHYR_ZEPHYR_MODULE_DIR}`.
+#
+name: zephyr
+build:
+  cmake: zephyr             # contains CMakeLists.txt for module
+  kconfig: zephyr/Kconfig
+  settings:
+    board_root: .
+    dts_root: .
+tests:
+  - tests
+samples:
+  - samples
+boards:
+  - boards


### PR DESCRIPTION
Extend the Zephyr repository to also be a module.  The module
portion covers the following sub-trees:
  - boards
  - soc
  - arch
  - kernel
  - dts
  - drivers
  - lib
  - subsys

Fix #42700

Signed-off-by: Gregory SHUE <gregory.shue@legrand.us>