### PR TITLE
lis2dw12: add BW filter, low noise, threshold HP_REF and autoreset

### DIFF
--- a/drivers/sensor/lis2dw12/Kconfig
+++ b/drivers/sensor/lis2dw12/Kconfig
@@ -59,4 +59,16 @@ config LIS2DW12_TAP
 
 endif # LIS2DW12_TRIGGER
 
+config LIS2DW12_THRESHOLD
+	bool "Wakeup threshold trigger (via interrupt)"
+	help
+	  Enable the wakeup threshold trigger feature.
+	  The wake-up interrupt signal is generated if a certain number of
+	  consecutive data exceed the configured threshold (config in DT).
+	  The threshold is applied to both positive and negative data: for
+	  a wake-up interrupt generation at least one of the three axes must
+	  be bigger than the threshold. See ST AN5038 for more details about
+	  the feature.
+
+
 endif # LIS2DW12

--- a/drivers/sensor/lis2dw12/lis2dw12.c
+++ b/drivers/sensor/lis2dw12/lis2dw12.c
@@ -324,6 +324,22 @@ static int lis2dw12_init(const struct device *dev)
 	}
 #endif /* CONFIG_LIS2DW12_TRIGGER */
 
+	LOG_DBG("high pass reference mode is %d", (int)cfg->hp_ref_mode);
+	ret = lis2dw12_reference_mode_set(ctx, cfg->hp_ref_mode);
+	if (ret < 0) {
+		LOG_ERR("high pass reference mode config error %d", (int)cfg->hp_ref_mode);
+		return ret;
+	}
+
+	LOG_DBG("high pass filter path is %d", (int)cfg->hp_filter_path);
+	lis2dw12_fds_t fds = cfg->hp_filter_path ?
+		LIS2DW12_HIGH_PASS_ON_OUT : LIS2DW12_LPF_ON_OUT;
+	ret = lis2dw12_filter_path_set(ctx, fds);
+	if (ret < 0) {
+		LOG_ERR("filter path config error %d", (int)cfg->hp_filter_path);
+		return ret;
+	}
+
 	return 0;
 }
 
@@ -393,6 +409,8 @@ static int lis2dw12_init(const struct device *dev)
 		.range = DT_INST_PROP(inst, range),			\
 		.bw_filt = DT_INST_PROP(inst, bw_filt),      \
 		.low_noise = DT_INST_PROP(inst, low_noise),      \
+		.hp_filter_path = DT_INST_PROP(inst, hp_filter_path),      \
+		.hp_ref_mode = DT_INST_PROP(inst, hp_ref_mode), \
 		LIS2DW12_CONFIG_TAP(inst)				\
 		COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, irq_gpios),	\
 			(LIS2DW12_CFG_IRQ(inst)), ())			\
@@ -419,6 +437,8 @@ static int lis2dw12_init(const struct device *dev)
 		.range = DT_INST_PROP(inst, range),			\
 		.bw_filt = DT_INST_PROP(inst, bw_filt),      \
 		.low_noise = DT_INST_PROP(inst, low_noise),      \
+		.hp_filter_path = DT_INST_PROP(inst, hp_filter_path),      \
+		.hp_ref_mode = DT_INST_PROP(inst, hp_ref_mode), \
 		LIS2DW12_CONFIG_TAP(inst)				\
 		COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, irq_gpios),	\
 			(LIS2DW12_CFG_IRQ(inst)), ())			\

--- a/drivers/sensor/lis2dw12/lis2dw12.c
+++ b/drivers/sensor/lis2dw12/lis2dw12.c
@@ -503,6 +503,7 @@ static int lis2dw12_init(const struct device *dev)
 		.low_noise = DT_INST_PROP(inst, low_noise),      \
 		.hp_filter_path = DT_INST_PROP(inst, hp_filter_path),      \
 		.hp_ref_mode = DT_INST_PROP(inst, hp_ref_mode), \
+		.drdy_pulsed = DT_INST_PROP(inst, drdy_pulsed),      \
 		LIS2DW12_CONFIG_TAP(inst)				\
 		COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, irq_gpios),	\
 			(LIS2DW12_CFG_IRQ(inst)), ())			\
@@ -531,6 +532,7 @@ static int lis2dw12_init(const struct device *dev)
 		.low_noise = DT_INST_PROP(inst, low_noise),      \
 		.hp_filter_path = DT_INST_PROP(inst, hp_filter_path),      \
 		.hp_ref_mode = DT_INST_PROP(inst, hp_ref_mode), \
+		.drdy_pulsed = DT_INST_PROP(inst, drdy_pulsed),      \
 		LIS2DW12_CONFIG_TAP(inst)				\
 		COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, irq_gpios),	\
 			(LIS2DW12_CFG_IRQ(inst)), ())			\

--- a/drivers/sensor/lis2dw12/lis2dw12.c
+++ b/drivers/sensor/lis2dw12/lis2dw12.c
@@ -289,6 +289,9 @@ static int lis2dw12_init(const struct device *dev)
 		return ret;
 	}
 
+	LOG_DBG("bandwidth filter is %u", (int)cfg->bw_filt);
+	lis2dw12_filter_bandwidth_set(ctx, cfg->bw_filt);
+
 #ifdef CONFIG_LIS2DW12_TRIGGER
 	if (lis2dw12_init_interrupt(dev) < 0) {
 		LOG_ERR("Failed to initialize interrupts");
@@ -363,6 +366,7 @@ static int lis2dw12_init(const struct device *dev)
 		},							\
 		.pm = DT_INST_PROP(inst, power_mode),			\
 		.range = DT_INST_PROP(inst, range),			\
+		.bw_filt = DT_INST_PROP(inst, bw_filt),      \
 		LIS2DW12_CONFIG_TAP(inst)				\
 		COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, irq_gpios),	\
 			(LIS2DW12_CFG_IRQ(inst)), ())			\
@@ -387,6 +391,7 @@ static int lis2dw12_init(const struct device *dev)
 		},							\
 		.pm = DT_INST_PROP(inst, power_mode),			\
 		.range = DT_INST_PROP(inst, range),			\
+		.bw_filt = DT_INST_PROP(inst, bw_filt),      \
 		LIS2DW12_CONFIG_TAP(inst)				\
 		COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, irq_gpios),	\
 			(LIS2DW12_CFG_IRQ(inst)), ())			\

--- a/drivers/sensor/lis2dw12/lis2dw12.h
+++ b/drivers/sensor/lis2dw12/lis2dw12.h
@@ -69,6 +69,7 @@ struct lis2dw12_device_config {
 	lis2dw12_mode_t pm;
 	uint8_t range;
 	uint8_t bw_filt;
+	bool low_noise;
 #ifdef CONFIG_LIS2DW12_TRIGGER
 	struct gpio_dt_spec gpio_int;
 	uint8_t int_pin;

--- a/drivers/sensor/lis2dw12/lis2dw12.h
+++ b/drivers/sensor/lis2dw12/lis2dw12.h
@@ -70,6 +70,8 @@ struct lis2dw12_device_config {
 	uint8_t range;
 	uint8_t bw_filt;
 	bool low_noise;
+	bool hp_filter_path;
+	bool hp_ref_mode;
 #ifdef CONFIG_LIS2DW12_TRIGGER
 	struct gpio_dt_spec gpio_int;
 	uint8_t int_pin;

--- a/drivers/sensor/lis2dw12/lis2dw12.h
+++ b/drivers/sensor/lis2dw12/lis2dw12.h
@@ -72,6 +72,7 @@ struct lis2dw12_device_config {
 	bool low_noise;
 	bool hp_filter_path;
 	bool hp_ref_mode;
+	bool drdy_pulsed;
 #ifdef CONFIG_LIS2DW12_TRIGGER
 	struct gpio_dt_spec gpio_int;
 	uint8_t int_pin;

--- a/drivers/sensor/lis2dw12/lis2dw12.h
+++ b/drivers/sensor/lis2dw12/lis2dw12.h
@@ -101,6 +101,9 @@ struct lis2dw12_data {
 	sensor_trigger_handler_t tap_handler;
 	sensor_trigger_handler_t double_tap_handler;
 #endif /* CONFIG_LIS2DW12_TAP */
+#ifdef CONFIG_LIS2DW12_THRESHOLD
+	sensor_trigger_handler_t threshold_handler;
+#endif /* CONFIG_LIS2DW12_THRESHOLD */
 #if defined(CONFIG_LIS2DW12_TRIGGER_OWN_THREAD)
 	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_LIS2DW12_THREAD_STACK_SIZE);
 	struct k_thread thread;

--- a/drivers/sensor/lis2dw12/lis2dw12.h
+++ b/drivers/sensor/lis2dw12/lis2dw12.h
@@ -68,6 +68,7 @@ struct lis2dw12_device_config {
 	} stmemsc_cfg;
 	lis2dw12_mode_t pm;
 	uint8_t range;
+	uint8_t bw_filt;
 #ifdef CONFIG_LIS2DW12_TRIGGER
 	struct gpio_dt_spec gpio_int;
 	uint8_t int_pin;

--- a/drivers/sensor/lis2dw12/lis2dw12_trigger.c
+++ b/drivers/sensor/lis2dw12/lis2dw12_trigger.c
@@ -422,9 +422,14 @@ int lis2dw12_init_interrupt(const struct device *dev)
 		return -EIO;
 	}
 
-	/* enable interrupt on int1/int2 in pulse mode */
-	if (lis2dw12_int_notification_set(ctx, LIS2DW12_INT_PULSED)) {
-		return -EIO;
+	/* set interrupt notification mode on int1/int2 */
+	LOG_DBG("drdy_pulsed is %d", (int)cfg->drdy_pulsed);
+	lis2dw12_lir_t mode = cfg->drdy_pulsed ? LIS2DW12_INT_PULSED : LIS2DW12_INT_LATCHED;
+
+	ret = lis2dw12_int_notification_set(ctx, mode);
+	if (ret < 0) {
+		LOG_ERR("drdy_pulsed config error %d", (int)cfg->drdy_pulsed);
+		return ret;
 	}
 
 #ifdef CONFIG_LIS2DW12_TAP

--- a/dts/bindings/sensor/st,lis2dw12-common.yaml
+++ b/dts/bindings/sensor/st,lis2dw12-common.yaml
@@ -48,6 +48,24 @@ properties:
         -  4
         -  2
 
+    bw-filt:
+      type: int
+      required: false
+      default: 0
+      description: |
+        Digital filtering cutoff bandwidth. Default is power-up configuration.
+
+           3 # ODR/20 (HP/LP)
+           2 # ODR/10 (HP/LP)
+           1 # ODR/ 4 (HP/LP)
+           0 # ODR/ 2 (up to ODR = 800 Hz, 400 Hz when ODR = 1600 Hz)
+
+      enum:
+        - 3
+        - 2
+        - 1
+        - 0
+
     power-mode:
       type: int
       required: false

--- a/dts/bindings/sensor/st,lis2dw12-common.yaml
+++ b/dts/bindings/sensor/st,lis2dw12-common.yaml
@@ -164,3 +164,26 @@ properties:
         Enables the LOW_NOISE flag in the CTRL6 register.
         This influences the noise density and the current consumption.
         See the datasheet for more information.
+
+    hp-filter-path:
+      type: boolean
+      required: false
+      description: |
+        Sets the Filtered Data Selection bit in the CTRL6 register.
+        When enabled, the high-pass filter path is selected.
+        When disabled, the low-pass filter path is selected.
+        Note that this influences the OUT_REG / FIFO values,
+        but not the Wakeup function.
+
+    hp-ref-mode:
+      type: boolean
+      required: false
+      description: |
+        Enables the high-pass filter reference mode in the CTRL7 register.
+        When the high-pass filter is configured in reference mode,
+        the output data is calculated as the difference between the input
+        acceleration and the values captured when reference mode was enabled.
+        In this way only the difference is applied without any filtering
+        of the LIS2DW12.
+        Note that this influences both the OUT_REG / FIFO values,
+        as well as the Wakeup function.

--- a/dts/bindings/sensor/st,lis2dw12-common.yaml
+++ b/dts/bindings/sensor/st,lis2dw12-common.yaml
@@ -187,3 +187,11 @@ properties:
         of the LIS2DW12.
         Note that this influences both the OUT_REG / FIFO values,
         as well as the Wakeup function.
+
+    drdy-pulsed:
+      type: boolean
+      required: false
+      description: |
+        Selects the pulsed mode for data-ready interrupt when enabled,
+        and the latched mode when disabled.
+        Sets the corresponding DRDY_PULSED bit in the CTRL7 register.

--- a/dts/bindings/sensor/st,lis2dw12-common.yaml
+++ b/dts/bindings/sensor/st,lis2dw12-common.yaml
@@ -156,3 +156,11 @@ properties:
         This register represents the time after the first detected tap in which
         there must not be any overthreshold event. Where 0 equals 2*1/ODR
         and 1LSB = 4*1/ODR.
+
+    low-noise:
+      type: boolean
+      required: false
+      description: |
+        Enables the LOW_NOISE flag in the CTRL6 register.
+        This influences the noise density and the current consumption.
+        See the datasheet for more information.


### PR DESCRIPTION
Added support for a few of the more advanced features present in the LIS2DW12 accelero:
* Digital filtering bandwidth selection
* Wakeup threshold trigger
* High-Pass reference mode
* High-Pass reference auto-reset on wakeup interrupt

Let me know if the split between DeviceTree config (like the bw_filt value) and the Kconfig defines is okay.