### PR TITLE
Bluetooth: controller: llcp: update CMake version for unittesting

### DIFF
--- a/tests/bluetooth/controller/ctrl_api/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_api/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.20.0)
 
 if (NOT BOARD STREQUAL unit_testing)
   message(FATAL_ERROR "This project can only be used with '-DBOARD=unit_testing'.")

--- a/tests/bluetooth/controller/ctrl_chmu/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_chmu/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.20.0)
 
 if (NOT BOARD STREQUAL unit_testing)
   message(FATAL_ERROR "This project can only be used with '-DBOARD=unit_testing'.")

--- a/tests/bluetooth/controller/ctrl_conn_update/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_conn_update/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.20.0)
 
 if (NOT BOARD STREQUAL unit_testing)
   message(FATAL_ERROR "This project can only be used with '-DBOARD=unit_testing'.")

--- a/tests/bluetooth/controller/ctrl_cte_req/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_cte_req/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.20.0)
 
 if (NOT BOARD STREQUAL unit_testing)
   message(FATAL_ERROR "This project can only be used with '-DBOARD=unit_testing'.")

--- a/tests/bluetooth/controller/ctrl_data_length_update/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_data_length_update/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.20.0)
 
 if (NOT BOARD STREQUAL unit_testing)
   message(FATAL_ERROR "This project can only be used with '-DBOARD=unit_testing'.")

--- a/tests/bluetooth/controller/ctrl_encrypt/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_encrypt/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.20.0)
 
 if (NOT BOARD STREQUAL unit_testing)
   message(FATAL_ERROR "This project can only be used with '-DBOARD=unit_testing'.")

--- a/tests/bluetooth/controller/ctrl_feature_exchange/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_feature_exchange/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.20.0)
 
 if (NOT BOARD STREQUAL unit_testing)
   message(FATAL_ERROR "This project can only be used with '-DBOARD=unit_testing'.")

--- a/tests/bluetooth/controller/ctrl_hci/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_hci/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.20.0)
 
 if (NOT BOARD STREQUAL unit_testing)
   message(FATAL_ERROR "This project can only be used with '-DBOARD=unit_testing'.")

--- a/tests/bluetooth/controller/ctrl_le_ping/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_le_ping/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.20.0)
 
 if (NOT BOARD STREQUAL unit_testing)
   message(FATAL_ERROR "This project can only be used with '-DBOARD=unit_testing'.")

--- a/tests/bluetooth/controller/ctrl_min_used_chans/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_min_used_chans/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.20.0)
 
 if (NOT BOARD STREQUAL unit_testing)
 	message(FATAL_ERROR "This project can only be used with '-DBOARD=unit_testing'.")

--- a/tests/bluetooth/controller/ctrl_phy_update/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_phy_update/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.20.0)
 
 if (NOT BOARD STREQUAL unit_testing)
   message(FATAL_ERROR "This project can only be used with '-DBOARD=unit_testing'.")

--- a/tests/bluetooth/controller/ctrl_terminate/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_terminate/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.20.0)
 
 if (NOT BOARD STREQUAL unit_testing)
 	message(FATAL_ERROR "This project can only be used with '-DBOARD=unit_testing'.")

--- a/tests/bluetooth/controller/ctrl_tx_buffer_alloc/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_tx_buffer_alloc/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.20.0)
 
 if (NOT BOARD STREQUAL unit_testing)
   message(FATAL_ERROR "This project can only be used with '-DBOARD=unit_testing'.")

--- a/tests/bluetooth/controller/ctrl_tx_queue/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_tx_queue/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.20.0)
 
 if (NOT BOARD STREQUAL unit_testing)
   message(FATAL_ERROR "This project can only be used with '-DBOARD=unit_testing'.")

--- a/tests/bluetooth/controller/ctrl_version/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_version/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.20.0)
 
 if (NOT BOARD STREQUAL unit_testing)
   message(FATAL_ERROR "This project can only be used with '-DBOARD=unit_testing'.")


### PR DESCRIPTION
The minimum CMake version required is 3.20.0, but the unittests
for the LLCP controller still referred to 3.13.1 as the minimum

Signed-off-by: Andries Kruithof <Andries.Kruithof@nordicsemi.no>