### PR TITLE
dts: bindings: can: remove unused bus from CAN controller binding

### DIFF
--- a/dts/bindings/can/can-controller.yaml
+++ b/dts/bindings/can/can-controller.yaml
@@ -2,8 +2,6 @@
 
 include: base.yaml
 
-bus: can
-
 properties:
     bus-speed:
       type: int


### PR DESCRIPTION
Remove the unused bus statement from the common CAN controller devicetree binding.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>