### PR TITLE
nrf: soc: nrf53: Add option for doubling the app core's CPU clock

### DIFF
--- a/soc/arm/nordic_nrf/nrf53/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf53/Kconfig.soc
@@ -208,8 +208,12 @@ config SOC_HFXO_CAP_INT_VALUE_X2
 
 endif # !TRUSTED_EXECUTION_NONSECURE || BUILD_WITH_TFM
 
-endif # SOC_NRF5340_CPUAPP
+config NRF_DOUBLE_CPU_SPEED
+	bool "Run the CPU at double the default clock frequency."
+	help
+	  May increase overall energy consumption.
 
+endif # SOC_NRF5340_CPUAPP
 
 config NRF_ENABLE_CACHE
 	bool "Enable cache"

--- a/soc/arm/nordic_nrf/nrf53/soc.c
+++ b/soc/arm/nordic_nrf/nrf53/soc.c
@@ -23,6 +23,7 @@
 #include <hal/nrf_gpio.h>
 #include <hal/nrf_oscillators.h>
 #include <hal/nrf_regulators.h>
+#include <hal/nrf_clock.h>
 #elif defined(CONFIG_SOC_NRF5340_CPUNET)
 #include <hal/nrf_nvmc.h>
 #endif
@@ -56,6 +57,20 @@ static int nordicsemi_nrf53_init(const struct device *arg)
 	ARG_UNUSED(arg);
 
 	key = irq_lock();
+
+#if defined(CONFIG_SOC_NRF5340_CPUAPP) && defined(NRF_DOUBLE_CPU_SPEED)
+#if defined(CONFIG_BUILD_WITH_TFM)
+	/*
+	 * When TF-M is enabled we rely on it having configured this for us already.
+	 */
+#else
+	/* Configure the CPU for full speed (128MHz). */
+	nrf_clock_hfclk_div_set(NRF_CLOCK, NRF_CLOCK_HFCLK_DIV_1);
+
+	/* Update the SystemCoreClock variable in case anyone relies on it. */
+	SystemCoreClockUpdate();
+#endif
+#endif
 
 #if defined(CONFIG_SOC_NRF5340_CPUAPP) && defined(CONFIG_NRF_ENABLE_CACHE)
 #if !defined(CONFIG_BUILD_WITH_TFM)


### PR DESCRIPTION
Make it configurable whether to double the app core's CPU clock speed
at boot.

We retain the HW reset value of half-speed execution because:

1. There is a concern that due to the 11% decrease in energy
efficiency for coremark on 128MHz that overall power consumption will
increase for 128MHz on most applications[0].

2. This would be a breaking change and therefore it must be beyond
reasonable doubt that energy efficiency does not significantly
regress.

[0] nrf53 PS 1.2