### PR TITLE
drivers: sensor: ism330dhcx: convert to spi_dt_spec

### DIFF
--- a/drivers/sensor/ism330dhcx/ism330dhcx.c
+++ b/drivers/sensor/ism330dhcx/ism330dhcx.c
@@ -742,19 +742,8 @@ static const struct ism330dhcx_config ism330dhcx_config = {
 	.gyro_range = DT_INST_PROP(0, gyro_range),
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
 	.bus_init = ism330dhcx_spi_init,
-	.spi_conf.frequency = DT_INST_PROP(0, spi_max_frequency),
-	.spi_conf.operation = (SPI_OP_MODE_MASTER | SPI_MODE_CPOL |
-			       SPI_MODE_CPHA | SPI_WORD_SET(8)),
-	.spi_conf.slave     = DT_INST_REG_ADDR(0),
-#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
-	.gpio_cs_port	    = DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
-	.cs_gpio	    = DT_INST_SPI_DEV_CS_GPIOS_PIN(0),
-	.cs_gpio_flags	    = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0),
-
-	.spi_conf.cs        =  &ism330dhcx_data.cs_ctrl,
-#else
-	.spi_conf.cs        = NULL,
-#endif
+	.spi = SPI_DT_SPEC_INST_GET(0, SPI_OP_MODE_MASTER | SPI_MODE_CPOL |
+				SPI_MODE_CPHA | SPI_WORD_SET(8), 0),
 #elif DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
 	.bus_init = ism330dhcx_i2c_init,
 	.i2c_slv_addr = DT_INST_REG_ADDR(0),

--- a/drivers/sensor/ism330dhcx/ism330dhcx.h
+++ b/drivers/sensor/ism330dhcx/ism330dhcx.h
@@ -47,12 +47,7 @@ struct ism330dhcx_config {
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
 	uint16_t i2c_slv_addr;
 #elif DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
-	struct spi_config spi_conf;
-#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
-	const char *gpio_cs_port;
-	uint8_t cs_gpio;
-	uint8_t cs_gpio_flags;
-#endif /* DT_INST_SPI_DEV_HAS_CS_GPIOS(0) */
+	struct spi_dt_spec spi;
 #endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c) */
 };
 
@@ -131,10 +126,6 @@ struct ism330dhcx_data {
 	struct k_work work;
 #endif
 #endif /* CONFIG_ISM330DHCX_TRIGGER */
-
-#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
-	struct spi_cs_control cs_ctrl;
-#endif
 };
 
 int ism330dhcx_spi_init(const struct device *dev);

--- a/drivers/sensor/ism330dhcx/ism330dhcx_spi.c
+++ b/drivers/sensor/ism330dhcx/ism330dhcx_spi.c
@@ -24,7 +24,6 @@ static int ism330dhcx_spi_read(struct ism330dhcx_data *data, uint8_t reg_addr,
 			       uint8_t *value, uint8_t len)
 {
 	const struct ism330dhcx_config *cfg = data->dev->config;
-	const struct spi_config *spi_cfg = &cfg->spi_conf;
 	uint8_t buffer_tx[2] = { reg_addr | ISM330DHCX_SPI_READ, 0 };
 	const struct spi_buf tx_buf = {
 			.buf = buffer_tx,
@@ -54,7 +53,7 @@ static int ism330dhcx_spi_read(struct ism330dhcx_data *data, uint8_t reg_addr,
 		return -EIO;
 	}
 
-	if (spi_transceive(data->bus, spi_cfg, &tx, &rx)) {
+	if (spi_transceive_dt(&cfg->spi, &tx, &rx)) {
 		return -EIO;
 	}
 
@@ -65,7 +64,6 @@ static int ism330dhcx_spi_write(struct ism330dhcx_data *data, uint8_t reg_addr,
 				uint8_t *value, uint8_t len)
 {
 	const struct ism330dhcx_config *cfg = data->dev->config;
-	const struct spi_config *spi_cfg = &cfg->spi_conf;
 	uint8_t buffer_tx[1] = { reg_addr & ~ISM330DHCX_SPI_READ };
 	const struct spi_buf tx_buf[2] = {
 		{
@@ -87,7 +85,7 @@ static int ism330dhcx_spi_write(struct ism330dhcx_data *data, uint8_t reg_addr,
 		return -EIO;
 	}
 
-	if (spi_write(data->bus, spi_cfg, &tx)) {
+	if (spi_write_dt(&cfg->spi, &tx)) {
 		return -EIO;
 	}
 
@@ -97,30 +95,18 @@ static int ism330dhcx_spi_write(struct ism330dhcx_data *data, uint8_t reg_addr,
 int ism330dhcx_spi_init(const struct device *dev)
 {
 	struct ism330dhcx_data *data = dev->data;
+	const struct ism330dhcx_config *cfg = dev->config;
+
+	if (!spi_is_ready(&cfg->spi)) {
+		LOG_ERR("SPI bus is not ready");
+		return -ENODEV;
+	};
 
 	data->ctx_spi.read_reg = (stmdev_read_ptr) ism330dhcx_spi_read,
 	data->ctx_spi.write_reg = (stmdev_write_ptr) ism330dhcx_spi_write,
 
 	data->ctx = &data->ctx_spi;
 	data->ctx->handle = data;
-
-#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
-	const struct ism330dhcx_config *cfg = dev->config;
-
-	/* handle SPI CS thru GPIO if it is the case */
-	data->cs_ctrl.gpio_dev = device_get_binding(cfg->gpio_cs_port);
-	if (!data->cs_ctrl.gpio_dev) {
-		LOG_ERR("Unable to get GPIO SPI CS device");
-		return -ENODEV;
-	}
-
-	data->cs_ctrl.gpio_pin = cfg->cs_gpio;
-	data->cs_ctrl.gpio_dt_flags = cfg->cs_gpio_flags;
-	data->cs_ctrl.delay = 0;
-
-	LOG_DBG("SPI GPIO CS configured on %s:%u",
-		cfg->gpio_cs_port, cfg->cs_gpio);
-#endif
 
 	return 0;
 }


### PR DESCRIPTION
Convert ism330dhcx driver to use spi_dt_spec helpers.

Signed-off-by: Bartosz Bilas <bartosz.bilas@hotmail.com>