### PR TITLE
Assorted XCC fixes

### DIFF
--- a/cmake/compiler/xcc/compiler_flags.cmake
+++ b/cmake/compiler/xcc/compiler_flags.cmake
@@ -18,4 +18,6 @@ else()
   # time.  Suppress the warning, it's the best we can do given that
   # it's a legacy compiler.
   set_compiler_property(APPEND PROPERTY warning_base "-fgnu89-inline")
+
+  set_compiler_property(PROPERTY warning_error_misra_sane)
 endif()

--- a/include/net/socket.h
+++ b/include/net/socket.h
@@ -918,7 +918,7 @@ struct net_socket_register {
 #define NET_SOCKET_DEFAULT_PRIO CONFIG_NET_SOCKETS_PRIORITY_DEFAULT
 
 #define NET_SOCKET_GET_NAME(socket_name, prio)	\
-	(__net_socket_register_##prio##_##socket_name)
+	__net_socket_register_##prio##_##socket_name
 
 #define NET_SOCKET_REGISTER(socket_name, prio, _family, _is_supported, _handler) \
 	static const STRUCT_SECTION_ITERABLE(net_socket_register,	\

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -2101,6 +2101,18 @@ static void test_pinctrl(void)
 	zassert_equal(DT_INST_PINCTRL_HAS_NAME(0, f_o_o2), 0, "");
 }
 
+static int test_mbox_init(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	return 0;
+}
+
+DEVICE_DT_DEFINE(DT_NODELABEL(test_mbox), test_mbox_init, NULL,
+		 NULL, NULL, POST_KERNEL, 90, NULL);
+DEVICE_DT_DEFINE(DT_NODELABEL(test_mbox_zero_cell), test_mbox_init, NULL,
+		 NULL, NULL, POST_KERNEL, 90, NULL);
+
 static void test_mbox(void)
 {
 #undef DT_DRV_COMPAT

--- a/tests/misc/test_build/testcase.yaml
+++ b/tests/misc/test_build/testcase.yaml
@@ -6,6 +6,7 @@ tests:
     tags: debug
     integration_platforms:
       - native_posix
+    filter: CONFIG_CONSOLE_HAS_DRIVER
   bootloader.mcuboot.build:
     tags: mcuboot
     build_only: true


### PR DESCRIPTION
This series address some of the issues one using XCC (based on GCC 4.2) faces when running Zephyr tests.