### PR TITLE
MAINTAINERS: gmarull for pinctrl

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -795,6 +795,18 @@ Documentation:
     labels:
         - "area: PECI"
 
+"Drivers: Pin Control":
+    status: maintained
+    maintainers:
+        - gmarull
+    files:
+        - doc/reference/pinctrl/
+        - include/drivers/pinctrl/
+        - include/drivers/pinctrl.h
+        - drivers/pinctrl/
+    labels:
+        - "area: Pinctrl"
+
 "Drivers: Pinmux":
     status: maintained
     maintainers:


### PR DESCRIPTION
We don't have a formal maintainer for this and we should.

I nominate gmarull as the original author and designer of the API,
especially given his continued work reviewing incoming
implementations.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>