### PR TITLE
boards: arduino_due: Add arduino_i2c alias

### DIFF
--- a/boards/arm/arduino_due/arduino_due.dts
+++ b/boards/arm/arduino_due/arduino_due.dts
@@ -56,3 +56,5 @@
 &pa8a_uart_urxd {
 	bias-pull-up;
 };
+
+arduino_i2c: &twi1 { };

--- a/boards/arm/arduino_due/arduino_due.yaml
+++ b/boards/arm/arduino_due/arduino_due.yaml
@@ -11,3 +11,4 @@ toolchain:
 supported:
   - watchdog
   - gpio
+  - arduino_i2c


### PR DESCRIPTION
The arduino_i2c alias is needed to use the Arduino Due with some of the
examples. This is assigned to the twi1 interface, which is labelled as
SDA and SCL (20 and 21) on the board silkscreen and is the default
interface using the Arduino IDE.

Resolves #42881.

Signed-off-by: Ryan Armstrong <git@zerker.ca>