### PR TITLE
boards/intel_adsp_cavs25: set different rimage target for IPC4

### DIFF
--- a/boards/xtensa/intel_adsp_cavs25/board.cmake
+++ b/boards/xtensa/intel_adsp_cavs25/board.cmake
@@ -3,4 +3,8 @@
 board_set_flasher_ifnset(misc-flasher)
 board_finalize_runner_args(misc-flasher)
 
-board_set_rimage_target(tgl)
+if (CONFIG_IPC_MAJOR_3)
+  board_set_rimage_target(tgl)
+elseif(CONFIG_IPC_MAJOR_4)
+  board_set_rimage_target(tgl-cavs)
+endif()


### PR DESCRIPTION
For SOF with IPC4 configuration, a different rimage
target should be used. Use tgl-cavs rimage target
if SOF is configured with IPC4.

Signed-off-by: Chao Song <chao.song@linux.intel.com>