### PR TITLE
tests: skip kernel_timer_interrupts when CONFIG_TICKLESS_KERNEL=n.

### DIFF
--- a/tests/kernel/context/src/main.c
+++ b/tests/kernel/context/src/main.c
@@ -557,7 +557,7 @@ static void test_kernel_interrupts(void)
 {
 	/* IRQ locks don't prevent ticks from advancing in tickless mode */
 	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return;
+		ztest_test_skip();
 	}
 
 	_test_kernel_interrupts(irq_lock_wrapper, irq_unlock_wrapper, -1);
@@ -620,7 +620,7 @@ static void test_kernel_interrupts(void)
  */
 static void test_kernel_timer_interrupts(void)
 {
-#ifdef TICK_IRQ
+#if (defined(TICK_IRQ) && defined(CONFIG_TICKLESS_KERNEL))
 	/* Disable interrupts coming from the timer. */
 	_test_kernel_interrupts(irq_disable_wrapper, irq_enable_wrapper, TICK_IRQ);
 #else


### PR DESCRIPTION
Skip kernel_timer_interrupts when CONFIG_TICKLESS_KERNEL
is disabled, because timer won't generate interrupts
anymore after invoking irq_disable and irq_enable
to enable timer interrupt again in TICK mode.

In TICK mode, after we disable timer interrupt, the timer interrupt handler
won't be executed and it won't set comparator value for next tick interrupt,
even we enable timer interrupt again later, it won't generate interrupt, the
counter value already beyond comparator value.

Signed-off-by: Chen Peng1 <peng1.chen@intel.com>