### PR TITLE
samples: task_wdt: generic watchdog channel

### DIFF
--- a/samples/subsys/task_wdt/sample.yaml
+++ b/samples/subsys/task_wdt/sample.yaml
@@ -12,7 +12,7 @@ tests:
         - "Control thread started."
         - "Main thread still alive..."
         - "Control thread getting stuck..."
-        - "Task watchdog channel 1 callback, thread: control"
+        - "Task watchdog channel (.*) callback, thread: control"
         - "Resetting device...(.*)"
         - "Task watchdog sample application."
     depends_on: watchdog


### PR DESCRIPTION
Some targets like stm32wb55 and their boards have watchdog mapped
on node 0 or 1 when using this sample.

Using a generic reference for the sample.yaml makes test complete successfully. 

Signed-off-by: Francois Ramu <francois.ramu@st.com>