### PR TITLE
include/devicetree.h: Add DT_STRING_TOKEN_OR macro

### DIFF
--- a/dts/bindings/test/vnd,string-token.yaml
+++ b/dts/bindings/test/vnd,string-token.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2022 Intel Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Test string token property container
+
+compatible: "vnd,string-token"
+
+properties:
+  val:
+    type: string
+    required: false
+    enum:
+      - token_zero
+      - token_one
+      - token_two

--- a/include/devicetree.h
+++ b/include/devicetree.h
@@ -800,6 +800,23 @@
 	DT_CAT4(node_id, _P_, prop, _STRING_TOKEN)
 
 /**
+ * @brief Like DT_STRING_TOKEN(), but with a fallback to default_value
+ *
+ * If the value exists, this expands to DT_STRING_TOKEN(node_id, prop).
+ * The default_value parameter is not expanded in this case.
+ *
+ * Otherwise, this expands to default_value.
+ *
+ * @param node_id node identifier
+ * @param prop lowercase-and-underscores property name
+ * @param default_value a fallback value to expand to
+ * @return the property's value or default_value
+ */
+#define DT_STRING_TOKEN_OR(node_id, prop, default_value) \
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, prop), \
+		(DT_STRING_TOKEN(node_id, prop)), (default_value))
+
+/**
  * @brief Like DT_STRING_TOKEN(), but uppercased.
  *
  * This removes "the quotes and capitalize" from string-valued properties, and
@@ -2695,6 +2712,17 @@
  *         0 otherwise
  */
 #define DT_INST_ON_BUS(inst, bus) DT_ON_BUS(DT_DRV_INST(inst), bus)
+
+/**
+ * @brief Tests if DT_DRV_COMPAT's has string property, returns string token if
+ *        found, otherwise returns default_value.
+ * @param inst instance number
+ * @param name lowercase-and-underscores property name
+ * @param default_value a fallback value to expand to
+ * @return the property's value or default_value
+ */
+#define DT_INST_STRING_TOKEN_OR(inst, name, default_value) \
+	DT_STRING_TOKEN_OR(DT_DRV_INST(inst), name, default_value)
 
 /**
  * @brief Test if any DT_DRV_COMPAT node is on a bus of a given type

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -475,5 +475,20 @@
 				         <0x0 0x10000000 0x0 0x10000000 0x2eff0000>;
 			};
 		};
+
+		test_string_token_0: string-token-0 {
+			compatible = "vnd,string-token";
+			val = "token_zero";
+		};
+
+		test_string_token_1: string-token-1 {
+			compatible = "vnd,string-token";
+			val = "token_one";
+		};
+
+		test_string_token_2: string-token-2 {
+			compatible = "vnd,string-token";
+			val = "token_two";
+		};
 	};
 };

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -2181,6 +2181,51 @@ static void test_mbox(void)
 				  DT_NODELABEL(test_mbox_zero_cell)), "");
 }
 
+static void test_string_token(void)
+{
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT vnd_string_token
+	enum {
+		token_zero,
+		token_one,
+		token_two,
+		token_max,
+		token_no_inst,
+	};
+	int i;
+
+	/* Test DT_INST_STRING_TOKEN_OR when property is found */
+	int array_inst[] = {
+#define STRING_TOKEN_TEST_INST_EXPANSION(inst)                                \
+	DT_INST_STRING_TOKEN_OR(inst, val, token_no_inst),
+	DT_INST_FOREACH_STATUS_OKAY(STRING_TOKEN_TEST_INST_EXPANSION)
+	};
+
+	for (i = 0; i < ARRAY_SIZE(array_inst); i++) {
+		zassert_true(array_inst[i] != token_no_inst, "");
+	}
+
+	/* Test DT_STRING_TOKEN_OR when property is found */
+	zassert_equal(DT_STRING_TOKEN_OR(DT_NODELABEL(test_string_token_0),
+		val, token_one), token_zero, "");
+	zassert_equal(DT_STRING_TOKEN_OR(DT_NODELABEL(test_string_token_1),
+		val, token_two), token_one, "");
+
+	/* Test DT_STRING_TOKEN_OR is not found */
+	zassert_equal(DT_STRING_TOKEN_OR(DT_NODELABEL(test_string_token_1),
+		no_inst, token_zero), token_zero, "");
+
+	/* Test DT_INST_STRING_TOKEN_OR when property is not found */
+	int array_no_inst[] = {
+#define STRING_TOKEN_TEST_NO_INST_EXPANSION(inst)                             \
+	DT_INST_STRING_TOKEN_OR(inst, no_inst, token_no_inst),
+	DT_INST_FOREACH_STATUS_OKAY(STRING_TOKEN_TEST_NO_INST_EXPANSION)
+	};
+	for (i = 0; i < ARRAY_SIZE(array_no_inst); i++) {
+		zassert_true(array_no_inst[i] == token_no_inst, "");
+	}
+}
+
 void test_main(void)
 {
 	ztest_test_suite(devicetree_api,
@@ -2227,7 +2272,8 @@ void test_main(void)
 			 ztest_unit_test(test_node_name),
 			 ztest_unit_test(test_same_node),
 			 ztest_unit_test(test_pinctrl),
-			 ztest_unit_test(test_mbox)
+			 ztest_unit_test(test_mbox),
+			 ztest_unit_test(test_string_token)
 		);
 	ztest_run_test_suite(devicetree_api);
 }


### PR DESCRIPTION
This macro expands to DT_STRING_TOKEN if property exists, otherwise
falls back to default value.
Helpful when a non-required enum binding doesn't mention a default
value, but a default value makes sense to be set in the code.

Including DT_INST_STRING_TOKEN_OR and test code.

Signed-off-by: Bernardo Perez Priego <bernardo.perez.priego@intel.com>