### PR TITLE
cmake: Add xcc-clang toolchain

### DIFF
--- a/cmake/compiler/xcc-clang/compiler_flags.cmake
+++ b/cmake/compiler/xcc-clang/compiler_flags.cmake
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include(${ZEPHYR_BASE}/cmake/compiler/clang/compiler_flags.cmake)
+
+# Clear "nostdinc"
+set_compiler_property(PROPERTY nostdinc)
+set_compiler_property(PROPERTY nostdinc_include)
+
+if($ENV{XCC_NO_G_FLAG})
+  # Older xcc/clang cannot use "-g" due to this bug:
+  # https://bugs.llvm.org/show_bug.cgi?id=11740.
+  # Clear the related flag(s) here so it won't cause issues.
+  set_compiler_property(PROPERTY debug)
+endif()

--- a/cmake/compiler/xcc-clang/generic.cmake
+++ b/cmake/compiler/xcc-clang/generic.cmake
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include(${ZEPHYR_BASE}/cmake/compiler/xcc/generic.cmake)

--- a/cmake/compiler/xcc-clang/target.cmake
+++ b/cmake/compiler/xcc-clang/target.cmake
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include(${ZEPHYR_BASE}/cmake/compiler/xcc/target.cmake)

--- a/cmake/compiler/xcc/compiler_flags.cmake
+++ b/cmake/compiler/xcc/compiler_flags.cmake
@@ -1,23 +1,11 @@
-# No special flags are needed for xcc.
-# Only select whether gcc or clang flags should be inherited.
-if(CC STREQUAL "clang")
-  include(${ZEPHYR_BASE}/cmake/compiler/clang/compiler_flags.cmake)
+# SPDX-License-Identifier: Apache-2.0
 
-  # Now, let's overwrite the flags that are different in xcc/clang.
-  if($ENV{XCC_NO_G_FLAG})
-    # Older xcc/clang cannot use "-g" due to this bug:
-    # https://bugs.llvm.org/show_bug.cgi?id=11740.
-    # Clear the related flag(s) here so it won't cause issues.
-    set_compiler_property(PROPERTY debug)
-  endif()
-else()
-  include(${ZEPHYR_BASE}/cmake/compiler/gcc/compiler_flags.cmake)
+include(${ZEPHYR_BASE}/cmake/compiler/gcc/compiler_flags.cmake)
 
-  # XCC is based on GCC 4.2 which has a somewhat pedantic take on the
-  # fact that linkage semantics differed between C99 and GNU at the
-  # time.  Suppress the warning, it's the best we can do given that
-  # it's a legacy compiler.
-  set_compiler_property(APPEND PROPERTY warning_base "-fgnu89-inline")
+# XCC is based on GCC 4.2 which has a somewhat pedantic take on the
+# fact that linkage semantics differed between C99 and GNU at the
+# time.  Suppress the warning, it's the best we can do given that
+# it's a legacy compiler.
+set_compiler_property(APPEND PROPERTY warning_base "-fgnu89-inline")
 
-  set_compiler_property(PROPERTY warning_error_misra_sane)
-endif()
+set_compiler_property(PROPERTY warning_error_misra_sane)

--- a/cmake/modules/verify-toolchain.cmake
+++ b/cmake/modules/verify-toolchain.cmake
@@ -37,6 +37,13 @@ if("${ARCH}" STREQUAL "posix")
   return()
 endif()
 
+# Keep XCC_USE_CLANG behaviour for a while.
+if ("${ZEPHYR_TOOLCHAIN_VARIANT}" STREQUAL "xcc"
+    AND "$ENV{XCC_USE_CLANG}" STREQUAL "1")
+  set(ZEPHYR_TOOLCHAIN_VARIANT xcc-clang)
+  message(STATUS "XCC_USE_CLANG is deprecated. Please set ZEPHYR_TOOLCHAIN_VARIANT to 'xcc-clang'")
+endif()
+
 if(NOT ZEPHYR_TOOLCHAIN_VARIANT AND
    (CROSS_COMPILE OR (DEFINED ENV{CROSS_COMPILE})))
     set(ZEPHYR_TOOLCHAIN_VARIANT cross-compile)

--- a/cmake/toolchain/xcc-clang/generic.cmake
+++ b/cmake/toolchain/xcc-clang/generic.cmake
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include(${ZEPHYR_BASE}/cmake/toolchain/xcc/common.cmake)
+
+set(COMPILER xcc-clang)
+set(CC clang)
+set(C++ clang++)
+
+message(STATUS "Found toolchain: xcc-clang (${XTENSA_TOOLCHAIN_PATH})")

--- a/cmake/toolchain/xcc-clang/target.cmake
+++ b/cmake/toolchain/xcc-clang/target.cmake
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Intentionally left blank.

--- a/cmake/toolchain/xcc/common.cmake
+++ b/cmake/toolchain/xcc/common.cmake
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+
+set_ifndef(XTENSA_TOOLCHAIN_PATH "$ENV{XTENSA_TOOLCHAIN_PATH}")
+set(       XTENSA_TOOLCHAIN_PATH ${XTENSA_TOOLCHAIN_PATH} CACHE PATH "xtensa tools install directory")
+assert(    XTENSA_TOOLCHAIN_PATH "XTENSA_TOOLCHAIN_PATH is not set")
+
+if(NOT EXISTS ${XTENSA_TOOLCHAIN_PATH})
+  message(FATAL_ERROR "Nothing found at XTENSA_TOOLCHAIN_PATH: '${XTENSA_TOOLCHAIN_PATH}'")
+endif()
+
+set(TOOLCHAIN_HOME ${XTENSA_TOOLCHAIN_PATH}/$ENV{TOOLCHAIN_VER}/XtensaTools)
+
+set(LINKER ld)
+set(BINTOOLS gnu)
+
+set(CROSS_COMPILE_TARGET xt)
+set(SYSROOT_TARGET       xtensa-elf)
+
+set(CROSS_COMPILE  ${TOOLCHAIN_HOME}/bin/${CROSS_COMPILE_TARGET}-)
+set(SYSROOT_DIR    ${TOOLCHAIN_HOME}/${SYSROOT_TARGET})
+
+set(NOSYSDEF_CFLAG "")
+
+list(APPEND TOOLCHAIN_C_FLAGS -fms-extensions)
+
+set(TOOLCHAIN_HAS_NEWLIB OFF CACHE BOOL "True if toolchain supports newlib")

--- a/cmake/toolchain/xcc/generic.cmake
+++ b/cmake/toolchain/xcc/generic.cmake
@@ -1,54 +1,24 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set_ifndef(XTENSA_TOOLCHAIN_PATH "$ENV{XTENSA_TOOLCHAIN_PATH}")
-set(       XTENSA_TOOLCHAIN_PATH ${XTENSA_TOOLCHAIN_PATH} CACHE PATH "xtensa tools install directory")
-assert(    XTENSA_TOOLCHAIN_PATH "XTENSA_TOOLCHAIN_PATH is not set")
-
-if(NOT EXISTS ${XTENSA_TOOLCHAIN_PATH})
-  message(FATAL_ERROR "Nothing found at XTENSA_TOOLCHAIN_PATH: '${XTENSA_TOOLCHAIN_PATH}'")
-endif()
-
-set(TOOLCHAIN_HOME ${XTENSA_TOOLCHAIN_PATH}/$ENV{TOOLCHAIN_VER}/XtensaTools)
+include(${ZEPHYR_BASE}/cmake/toolchain/xcc/common.cmake)
 
 set(COMPILER xcc)
-set(LINKER ld)
-set(BINTOOLS gnu)
-
-set(CROSS_COMPILE_TARGET xt)
-set(SYSROOT_TARGET       xtensa-elf)
-
-set(CROSS_COMPILE  ${TOOLCHAIN_HOME}/bin/${CROSS_COMPILE_TARGET}-)
-set(SYSROOT_DIR    ${TOOLCHAIN_HOME}/${SYSROOT_TARGET})
-
-# xt-xcc does not support -Og, so make it -O0
 set(OPTIMIZE_FOR_DEBUG_FLAG "-O0")
+set(CC xcc)
+set(C++ xc++)
 
-if($ENV{XCC_USE_CLANG})
-  set(CC clang)
-  set(C++ clang++)
-else()
-  set(CC xcc)
-  set(C++ xc++)
+list(APPEND TOOLCHAIN_C_FLAGS
+  -imacros${ZEPHYR_BASE}/include/toolchain/xcc_missing_defs.h
+  )
 
-  list(APPEND TOOLCHAIN_C_FLAGS
-    -imacros${ZEPHYR_BASE}/include/toolchain/xcc_missing_defs.h
-    )
-
-  # GCC-based XCC uses GNU Assembler (xt-as).
-  # However, CMake doesn't recognize it when invoking through xt-xcc.
-  # This results in CMake going through all possible combinations of
-  # command line arguments while invoking xt-xcc to determine
-  # assembler vendor. This multiple invocation of xt-xcc unnecessarily
-  # lengthens the CMake phase of build, especially when XCC needs to
-  # obtain license information from remote licensing servers. So here
-  # forces the assembler ID to be GNU to speed things up a bit.
-  set(CMAKE_ASM_COMPILER_ID "GNU")
-endif()
-
-set(NOSYSDEF_CFLAG "")
-
-list(APPEND TOOLCHAIN_C_FLAGS -fms-extensions)
-
-set(TOOLCHAIN_HAS_NEWLIB OFF CACHE BOOL "True if toolchain supports newlib")
+# GCC-based XCC uses GNU Assembler (xt-as).
+# However, CMake doesn't recognize it when invoking through xt-xcc.
+# This results in CMake going through all possible combinations of
+# command line arguments while invoking xt-xcc to determine
+# assembler vendor. This multiple invocation of xt-xcc unnecessarily
+# lengthens the CMake phase of build, especially when XCC needs to
+# obtain license information from remote licensing servers. So here
+# forces the assembler ID to be GNU to speed things up a bit.
+set(CMAKE_ASM_COMPILER_ID "GNU")
 
 message(STATUS "Found toolchain: xcc (${XTENSA_TOOLCHAIN_PATH})")

--- a/doc/getting_started/toolchain_3rd_party_x_compilers.rst
+++ b/doc/getting_started/toolchain_3rd_party_x_compilers.rst
@@ -233,14 +233,12 @@ Cadence Tensilica Xtensa C/C++ Compiler (XCC)
 
      * Clang-based compiler: ``xt-clang`` and its friends.
 
-     * By default, Zephyr would use GCC-based ``xt-xcc``.
-
 #. Make sure you have obtained a license to use the SDK, or has access to
    a remote licensing server.
 
 #. :ref:`Set these environment variables <env_vars>`:
 
-   * Set :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``xcc``.
+   * Set :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``xcc`` or ``xcc-clang``.
    * Set :envvar:`XTENSA_TOOLCHAIN_PATH` to the toolchain installation
      directory.
    * Set :envvar:`XTENSA_CORE` to the SoC ID where application is being
@@ -261,14 +259,7 @@ Cadence Tensilica Xtensa C/C++ Compiler (XCC)
 
 #. To use Clang-based compiler:
 
-   * Set :envvar:`XCC_USE_CLANG` to ``1``.
-
-     * For example:
-
-       .. code-block:: console
-
-          # Linux
-          export XCC_USE_CLANG=1
+   * Set :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``xcc-clang``.
 
    * Note that the Clang-based compiler may contain an old LLVM bug which
      results in the following error:
@@ -287,6 +278,10 @@ Cadence Tensilica Xtensa C/C++ Compiler (XCC)
 
           # Linux
           export XCC_NO_G_FLAG=1
+
+   * Also note that setting :envvar:`XCC_USE_CLANG` to ``1`` and
+     :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``xcc`` is deprecated.
+     Set :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``xcc-clang`` instead.
 
 .. _GNU Arm Embedded: https://developer.arm.com/open-source/gnu-toolchain/gnu-rm
 .. _crosstool-ng site: http://crosstool-ng.org


### PR DESCRIPTION
Instead of setting XCC_USE_CLANG=1, this patch adds xcc-clang toolchain
that is basically xcc using the clang compiler.

Initially, the new toolchain simply includes files from current xcc
toolchain and (re)sets some variables. This should be a more scalable
approach to diverge the toolchains in the future than placing
"if($ENV{XCC_USE_CLANG})" at several places.

It should also help to filter tests that run (or not) exclusively with
the clang variant of XCC on twister.

The XCC_USE_CLANG flag is documented as deprecated, and a message is
emitted during build if still in use. Its new behaviour is to instruct
Zephyr to use `xcc-clang` toolchain.