### PR TITLE
Disable some tests under XCC

### DIFF
--- a/samples/subsys/cpp/cpp_synchronization/sample.yaml
+++ b/samples/subsys/cpp/cpp_synchronization/sample.yaml
@@ -3,7 +3,7 @@ sample:
 tests:
   sample.cpp.synchronization:
     tags: cpp
-    toolchain_exclude: issm
+    toolchain_exclude: issm xcc
     arch_exclude: posix
     integration_platforms:
       - qemu_x86

--- a/tests/crypto/tinycrypt/testcase.yaml
+++ b/tests/crypto/tinycrypt/testcase.yaml
@@ -5,3 +5,4 @@ tests:
     timeout: 300
     integration_platforms:
       - native_posix
+    toolchain_exclude: xcc

--- a/tests/crypto/tinycrypt_hmac_prng/testcase.yaml
+++ b/tests/crypto/tinycrypt_hmac_prng/testcase.yaml
@@ -4,3 +4,4 @@ tests:
     platform_exclude: mec15xxevb_assy6853 mec1501modular_assy6885 m2gl025_miv
     integration_platforms:
       - native_posix
+    toolchain_exclude: xcc

--- a/tests/subsys/cpp/cxx/testcase.yaml
+++ b/tests/subsys/cpp/cxx/testcase.yaml
@@ -3,3 +3,4 @@ tests:
     integration_platforms:
       - mps2_an385
     tags: cpp
+    toolchain_exclude: xcc


### PR DESCRIPTION
XCC (based on GCC 4.2) can't properly build those tests.

For the C++ related ones, the XCC clang variant can help. #42971 can be of help to get those unfiltered.