### PR TITLE
sign.py: stop ignoring the -- -c foo.toml option passed to rimage

### DIFF
--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -404,15 +404,17 @@ class RimageSigner(Signer):
                 log.die('rimage not found; either install it',
                         'or provide --tool-path')
 
+        #### -c sof/rimage/config/signing_schema.toml  ####
+
         b = pathlib.Path(build_dir)
         cache = CMakeCache.from_build_dir(build_dir)
 
+        # warning: RIMAGE_TARGET is a duplicate of CONFIG_RIMAGE_SIGNING_SCHEMA
         target = cache.get('RIMAGE_TARGET')
         if not target:
             log.die('rimage target not defined')
 
-        conf = target + '.toml'
-        log.inf('Signing for SOC target ' + target + ' using ' + conf)
+        cmake_toml = target + '.toml'
 
         if not args.quiet:
             log.inf('Signing with tool {}'.format(tool_path))
@@ -428,17 +430,29 @@ class RimageSigner(Signer):
             out_bin = str(b / 'zephyr' / 'zephyr.ri')
             out_xman = str(b / 'zephyr' / 'zephyr.ri.xman')
             out_tmp = str(b / 'zephyr' / 'zephyr.rix')
+
         conf_path_cmd = []
-        if cache.get('RIMAGE_CONFIG_PATH') and not args.tool_data:
-            rimage_conf = pathlib.Path(cache['RIMAGE_CONFIG_PATH'])
-            conf_path = str(rimage_conf / conf)
-            conf_path_cmd = ['-c', conf_path]
+
+        if '-c' in args.tool_args:
+            # Precedence to the -- rimage command line
+            conf_path_cmd = []
+            if args.tool_data:
+                log.wrn('--tool-data ' + args.tool_data + ' ignored, overridden by -c')
+            # For logging only
+            conf_path = args.tool_args[args.tool_args.index('-c') + 1]
         elif args.tool_data:
             conf_dir = pathlib.Path(args.tool_data)
-            conf_path = str(conf_dir / conf)
+            conf_path = str(conf_dir / cmake_toml)
+            conf_path_cmd = ['-c', conf_path]
+        elif cache.get('RIMAGE_CONFIG_PATH'):
+            rimage_conf = pathlib.Path(cache['RIMAGE_CONFIG_PATH'])
+            conf_path = str(rimage_conf / cmake_toml)
             conf_path_cmd = ['-c', conf_path]
         else:
-            log.die('Configuration not found')
+            log.die('-c configuration not found')
+
+        log.inf('Signing for SOC target ' + target + ' using ' + conf_path)
+
         if '--no-manifest' in args.tool_args:
             no_manifest = True
             args.tool_args.remove('--no-manifest')
@@ -464,6 +478,8 @@ class RimageSigner(Signer):
             filenames = [out_bin]
         else:
             filenames = [out_xman, out_bin]
+        if not args.quiet:
+            log.inf('Prefixing ' + out_bin + ' with manifest ' + out_xman)
         with open(out_tmp, 'wb') as outfile:
             for fname in filenames:
                 with open(fname, 'rb') as infile:


### PR DESCRIPTION
The -c option points rimage at its main and mandatory configuration
file ("signing schema"). The -c option passed by sign.py to rimage comes
from _two_ different places:

A. From the command line, example:
```
   west sign -t rimage -- OTHER_ARGS_FOR_RIMAGE -c foo.toml
```
However passing -- -c signing_schema.toml on the west sign command line
has always been optional because:

B. west sign systematically adds another `-c bar.toml` option. The name
   'bar' is found in the CMakeCache. Right now 'bar' comes from
   a product specific `board.cmake` file.

There were two problems fixed by this commit:

1. The -c option from the command line was passed _first_ but the last
   -c wins with rimage. The command line should have precedence.

2. The "last -c wins" behavior is not documented/official, it's an
   rimage implementation deteail.

To fix both, simply scan the command line for a '-c' option. If any is
found then it takes precedence over the CMakeCache-based value which is
dropped.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>