### PR TITLE
drivers: modem: gsm: add handler for +CME ERROR

### DIFF
--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -169,9 +169,19 @@ MODEM_CMD_DEFINE(gsm_cmd_error)
 	return 0;
 }
 
+/* Handler: +CME Error: <err>[0] */
+MODEM_CMD_DEFINE(gsm_cmd_exterror)
+{
+	/* TODO: map extended error codes to values */
+	modem_cmd_handler_set_error(data, -EIO);
+	k_sem_give(&gsm.sem_response);
+	return 0;
+}
+
 static const struct modem_cmd response_cmds[] = {
 	MODEM_CMD("OK", gsm_cmd_ok, 0U, ""),
 	MODEM_CMD("ERROR", gsm_cmd_error, 0U, ""),
+	MODEM_CMD("+CME ERROR: ", gsm_cmd_exterror, 1U, ""),
 	MODEM_CMD("CONNECT", gsm_cmd_ok, 0U, ""),
 };
 
@@ -427,12 +437,10 @@ static const struct setup_cmd setup_cmds[] = {
 	SETUP_CMD_NOHANDLE("ATE0"),
 	/* hang up */
 	SETUP_CMD_NOHANDLE("ATH"),
-	/* extender errors in numeric form */
+	/* extended errors in numeric form */
 	SETUP_CMD_NOHANDLE("AT+CMEE=1"),
-
 	/* disable unsolicited network registration codes */
 	SETUP_CMD_NOHANDLE("AT+CREG=0"),
-
 	/* create PDP context */
 	SETUP_CMD_NOHANDLE("AT+CGDCONT=1,\"IP\",\"" CONFIG_MODEM_GSM_APN "\""),
 };


### PR DESCRIPTION
The driver enabled extended error code (AT+CMEE=1, 5107691441abacf6ec12398bf2785deae2edec45) during setup but is missing a handler for the +CME ERROR, fix that. 