### PR TITLE
modem: gsm: some command handler shouldn't give `sem_response` & set error

### DIFF
--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -396,8 +396,6 @@ MODEM_CMD_DEFINE(on_cmd_atcmdinfo_rssi_csq)
 		LOG_INF("RSSI: %d", rssi);
 	}
 
-	k_sem_give(&gsm.sem_response);
-
 	return 0;
 }
 #endif

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -439,16 +439,10 @@ static const struct setup_cmd setup_cmds[] = {
 
 MODEM_CMD_DEFINE(on_cmd_atcmdinfo_attached)
 {
-	int error = -EAGAIN;
-
 	/* Expected response is "+CGATT: 0|1" so simply look for '1' */
 	if (argc && atoi(argv[0]) == 1) {
-		error = 0;
 		LOG_INF("Attached to packet service!");
 	}
-
-	modem_cmd_handler_set_error(data, error);
-	k_sem_give(&gsm.sem_response);
 
 	return 0;
 }


### PR DESCRIPTION
The response `+CGATT:` & +`CSQ:` are followed by `OK` or `ERROR`, so they shouldn't give the `sem_response` nor set error code, since these are done by the `OK` & `ERROR` handler.

See [Ublox SARA](https://github.com/zephyrproject-rtos/zephyr/blob/main/drivers/modem/ublox-sara-r4.c#L679), [simcom](https://github.com/zephyrproject-rtos/zephyr/blob/main/drivers/modem/simcom-sim7080.c#L1043)

[AT+CGATT documentation](https://m2msupport.net/m2msupport/atcgatt-ps-attach-or-detach/)
[AT+CSQ documentation](https://m2msupport.net/m2msupport/atcsq-signal-quality/)