### PR TITLE
subsys/mgmt/hawkbit: Kconfig: Add HAWKBIT_DDI_SECURITY to choice

### DIFF
--- a/subsys/mgmt/hawkbit/Kconfig
+++ b/subsys/mgmt/hawkbit/Kconfig
@@ -52,7 +52,7 @@ config HAWKBIT_PORT
 	help
 	  Configure the hawkbit port number.
 
-choice
+choice HAWKBIT_DDI_SECURITY
 	prompt "Hawkbit DDI API authentication modes"
 	default HAWKBIT_DDI_NO_SECURITY
 


### PR DESCRIPTION
Add a name for the choice of authentication modes so that it
can be default to a certain type in project's Kconfig.