### PR TITLE
drivers: modem: gsm: Kconfig: Add MODEM_GSM_TYPE to choice

### DIFF
--- a/drivers/modem/Kconfig.gsm
+++ b/drivers/modem/Kconfig.gsm
@@ -11,7 +11,7 @@ config MODEM_GSM_PPP
 
 if MODEM_GSM_PPP
 
-choice
+choice MODEM_GSM_TYPE
 	prompt "Modem type"
 	default MODEM_GSM_GENERIC
 	help


### PR DESCRIPTION
Add a name for the choice of gsm modem so that it can be
default to a certain type in board's Kconfig.