### PR TITLE
Bluetooth: Controller: Collision resolution to use ticks_slot_window

### DIFF
--- a/subsys/bluetooth/controller/ticker/ticker.h
+++ b/subsys/bluetooth/controller/ticker/ticker.h
@@ -178,7 +178,7 @@ struct ticker_ext {
 				    * reservation may be re-scheduled
 				    * to avoid collision
 				    */
-	int32_t ticks_drift;	   /* Applied drift since last expiry */
+	uint32_t ticks_drift;      /* Actual drift since last expiry */
 	uint8_t reschedule_state;  /* State of re-scheduling of the
 				    * node. See defines
 				    * TICKER_RESCHEDULE_STATE_XXX


### PR DESCRIPTION
When resolving collision if ticks_slot_window is set for
either of the ticker then skip and such ticker be
rescheduled outside the collision within the
ticks_slot_window.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>