### PR TITLE
dts: Add child bindings to ADC controller for channel configurations

### DIFF
--- a/drivers/adc/adc_nrfx_adc.c
+++ b/drivers/adc/adc_nrfx_adc.c
@@ -7,12 +7,24 @@
 #define ADC_CONTEXT_USES_KERNEL_TIMER
 #include "adc_context.h"
 #include <nrfx_adc.h>
+#include <zephyr/dt-bindings/adc/nrf-adc.h>
 
 #define LOG_LEVEL CONFIG_ADC_LOG_LEVEL
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(adc_nrfx_adc);
 
 #define DT_DRV_COMPAT nordic_nrf_adc
+
+/* Ensure that definitions in nrf-adc.h match MDK. */
+BUILD_ASSERT((NRF_ADC_AIN0 == NRF_ADC_CONFIG_INPUT_0) &&
+	     (NRF_ADC_AIN1 == NRF_ADC_CONFIG_INPUT_1) &&
+	     (NRF_ADC_AIN2 == NRF_ADC_CONFIG_INPUT_2) &&
+	     (NRF_ADC_AIN3 == NRF_ADC_CONFIG_INPUT_3) &&
+	     (NRF_ADC_AIN4 == NRF_ADC_CONFIG_INPUT_4) &&
+	     (NRF_ADC_AIN5 == NRF_ADC_CONFIG_INPUT_5) &&
+	     (NRF_ADC_AIN6 == NRF_ADC_CONFIG_INPUT_6) &&
+	     (NRF_ADC_AIN7 == NRF_ADC_CONFIG_INPUT_7),
+	     "Definitions from nrf-adc.h do not match those from nrf_adc.h");
 
 struct driver_data {
 	struct adc_context ctx;

--- a/drivers/adc/adc_nrfx_saadc.c
+++ b/drivers/adc/adc_nrfx_saadc.c
@@ -7,12 +7,28 @@
 #define ADC_CONTEXT_USES_KERNEL_TIMER
 #include "adc_context.h"
 #include <hal/nrf_saadc.h>
+#include <zephyr/dt-bindings/adc/nrf-adc.h>
 
 #define LOG_LEVEL CONFIG_ADC_LOG_LEVEL
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(adc_nrfx_saadc);
 
 #define DT_DRV_COMPAT nordic_nrf_saadc
+
+BUILD_ASSERT((NRF_SAADC_AIN0 == NRF_SAADC_INPUT_AIN0) &&
+	     (NRF_SAADC_AIN1 == NRF_SAADC_INPUT_AIN1) &&
+	     (NRF_SAADC_AIN2 == NRF_SAADC_INPUT_AIN2) &&
+	     (NRF_SAADC_AIN3 == NRF_SAADC_INPUT_AIN3) &&
+	     (NRF_SAADC_AIN4 == NRF_SAADC_INPUT_AIN4) &&
+	     (NRF_SAADC_AIN5 == NRF_SAADC_INPUT_AIN5) &&
+	     (NRF_SAADC_AIN6 == NRF_SAADC_INPUT_AIN6) &&
+	     (NRF_SAADC_AIN7 == NRF_SAADC_INPUT_AIN7) &&
+	     (NRF_SAADC_AIN7 == NRF_SAADC_INPUT_AIN7) &&
+#if defined(SAADC_CH_PSELP_PSELP_VDDHDIV5)
+	     (NRF_SAADC_VDDHDIV5 == NRF_SAADC_INPUT_VDDHDIV5) &&
+#endif
+	     (NRF_SAADC_VDD == NRF_SAADC_INPUT_VDD),
+	     "Definitions from nrf-adc.h do not match those from nrf_saadc.h");
 
 struct driver_data {
 	struct adc_context ctx;

--- a/dts/arm/nordic/nrf_common.dtsi
+++ b/dts/arm/nordic/nrf_common.dtsi
@@ -4,8 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/adc/nrf-adc.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/pinctrl/nrf-pinctrl.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 

--- a/dts/bindings/adc/adc-controller.yaml
+++ b/dts/bindings/adc/adc-controller.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) 2017, NXP
+# Copyright (c) 2022, Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
 # Common fields for ADC controllers
@@ -12,3 +13,146 @@ properties:
     "#io-channel-cells":
       type: int
       required: true
+
+    "#address-cells":
+      required: false
+      const: 1
+
+    "#size-cells":
+      required: false
+      const: 0
+
+child-binding:
+    description: |
+      Channel configuration.
+
+      All nodes using this binding must be named "channel", otherwise their
+      data will not be accessible for the ADC API macros.
+
+      This is based on Linux, documentation:
+        https://www.kernel.org/doc/Documentation/devicetree/bindings/iio/adc/adc.yaml
+
+    properties:
+      reg:
+        type: array
+        required: true
+        description: Channel identifier.
+
+      zephyr,gain:
+        type: string
+        required: true
+        description: |
+          Gain selection:
+          - ADC_GAIN_1_6: x 1/6
+          - ADC_GAIN_1_5: x 1/5
+          - ADC_GAIN_1_4: x 1/4
+          - ADC_GAIN_1_3: x 1/3
+          - ADC_GAIN_2_5: x 2/5
+          - ADC_GAIN_1_2: x 1/2
+          - ADC_GAIN_2_3: x 2/3
+          - ADC_GAIN_4_5: x 4/5
+          - ADC_GAIN_1:   x 1
+          - ADC_GAIN_2:   x 2
+          - ADC_GAIN_3:   x 3
+          - ADC_GAIN_4:   x 4
+          - ADC_GAIN_6:   x 6
+          - ADC_GAIN_8:   x 8
+          - ADC_GAIN_12:  x 12
+          - ADC_GAIN_16:  x 16
+          - ADC_GAIN_24:  x 24
+          - ADC_GAIN_32:  x 32
+          - ADC_GAIN_64:  x 64
+          - ADC_GAIN_128: x 128
+        enum:
+          - "ADC_GAIN_1_6"
+          - "ADC_GAIN_1_5"
+          - "ADC_GAIN_1_4"
+          - "ADC_GAIN_1_3"
+          - "ADC_GAIN_2_5"
+          - "ADC_GAIN_1_2"
+          - "ADC_GAIN_2_3"
+          - "ADC_GAIN_4_5"
+          - "ADC_GAIN_1"
+          - "ADC_GAIN_2"
+          - "ADC_GAIN_3"
+          - "ADC_GAIN_4"
+          - "ADC_GAIN_6"
+          - "ADC_GAIN_8"
+          - "ADC_GAIN_12"
+          - "ADC_GAIN_16"
+          - "ADC_GAIN_24"
+          - "ADC_GAIN_32"
+          - "ADC_GAIN_64"
+          - "ADC_GAIN_128"
+
+      zephyr,reference:
+        type: string
+        required: true
+        description: |
+          Reference selection:
+          - ADC_REF_VDD_1:     VDD
+          - ADC_REF_VDD_1_2:   VDD/2
+          - ADC_REF_VDD_1_3:   VDD/3
+          - ADC_REF_VDD_1_4:   VDD/4
+          - ADC_REF_INTERNAL:  Internal
+          - ADC_REF_EXTERNAL0: External, input 0
+          - ADC_REF_EXTERNAL1: External, input 1
+        enum:
+          - "ADC_REF_VDD_1"
+          - "ADC_REF_VDD_1_2"
+          - "ADC_REF_VDD_1_3"
+          - "ADC_REF_VDD_1_4"
+          - "ADC_REF_INTERNAL"
+          - "ADC_REF_EXTERNAL0"
+          - "ADC_REF_EXTERNAL1"
+
+      zephyr,vref-mv:
+        type: int
+        required: false
+        description: |
+          This property can be used to specify the voltage (in millivolts)
+          of the reference selected for this channel, so that applications
+          can get that value if needed for some calculations.
+          For the internal reference, the voltage can be usually obtained with
+          a dedicated ADC API call, so there is no need to use this property
+          in that case, but for other references this property can be useful.
+
+      zephyr,acquisition-time:
+        type: int
+        required: true
+        description: |
+          Acquisition time.
+          Use the ADC_ACQ_TIME macro to compose the value for this property
+          or pass ADC_ACQ_TIME_DEFAULT to use the default setting for a given
+          hardware (e.g. when the hardware does not allow to configure the
+          acquisition time).
+
+      zephyr,input-positive:
+        type: int
+        required: false
+        description: |
+          Positive ADC input. Used only for drivers that select
+          the ADC_CONFIGURABLE_INPUTS Kconfig option.
+
+      zephyr,input-negative:
+        type: int
+        required: false
+        description: |
+          Negative ADC input. Used only for drivers that select
+          the ADC_CONFIGURABLE_INPUTS Kconfig option.
+          When specified, the channel is to be used in differential input mode,
+          otherwise, single-ended mode is used.
+
+      zephyr,resolution:
+        type: int
+        required: false
+        description: |
+          ADC resolution to be used for the channel.
+
+      zephyr,oversampling:
+        type: int
+        required: false
+        description: |
+          Oversampling setting to be used for the channel.
+          When specified, each sample is averaged from 2^N conversion results
+          (where N is the provided value).

--- a/include/zephyr/dt-bindings/adc/nrf-adc.h
+++ b/include/zephyr/dt-bindings/adc/nrf-adc.h
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ADC_NRF_ADC_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_ADC_NRF_ADC_H_
+
+#include <zephyr/dt-bindings/dt-util.h>
+
+#define NRF_ADC_AIN0 BIT(0)
+#define NRF_ADC_AIN1 BIT(1)
+#define NRF_ADC_AIN2 BIT(2)
+#define NRF_ADC_AIN3 BIT(3)
+#define NRF_ADC_AIN4 BIT(4)
+#define NRF_ADC_AIN5 BIT(5)
+#define NRF_ADC_AIN6 BIT(6)
+#define NRF_ADC_AIN7 BIT(7)
+
+#define NRF_SAADC_AIN0     1
+#define NRF_SAADC_AIN1     2
+#define NRF_SAADC_AIN2     3
+#define NRF_SAADC_AIN3     4
+#define NRF_SAADC_AIN4     5
+#define NRF_SAADC_AIN5     6
+#define NRF_SAADC_AIN6     7
+#define NRF_SAADC_AIN7     8
+#define NRF_SAADC_VDD      9
+#define NRF_SAADC_VDDHDIV5 13
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ADC_NRF_ADC_H_ */

--- a/samples/drivers/adc/README.rst
+++ b/samples/drivers/adc/README.rst
@@ -8,20 +8,12 @@ Overview
 
 This sample demonstrates how to use the ADC driver API.
 
-Depending on the MCU type, it reads the ADC samples of one or two ADC channels
-and prints the readings to the console. If supported by the driver, the raw
-readings are converted to millivolts.
+Depending on the target board, it reads ADC samples from one or more channels
+and prints the readings on the console. If voltage of the used reference can
+be obtained, the raw readings are converted to millivolts.
 
 The pins of the ADC channels are board-specific. Please refer to the board
 or MCU datasheet for further details.
-
-.. note::
-
-   This sample does not work on Nordic platforms where there is a distinction
-   between channel and analog input that requires additional configuration. See
-   :zephyr_file:`samples/boards/nrf/battery` for an example of using the ADC
-   infrastructure on Nordic hardware.
-
 
 Building and Running
 ********************
@@ -32,7 +24,15 @@ sure that the ADC is enabled (``status = "okay";``).
 In addition to that, this sample requires an ADC channel specified in the
 ``io-channels`` property of the ``zephyr,user`` node. This is usually done with
 a devicetree overlay. The example overlay in the ``boards`` subdirectory for
-the :ref:`nucleo_l073rz_board` can be easily adjusted for other boards.
+the ``nucleo_l073rz`` board can be easily adjusted for other boards.
+
+Configuration of channels (settings like gain, reference, or acquisition time)
+can be specified in devicetree, in ADC controller child nodes. Also the ADC
+resolution and oversampling setting to be used for particular channels can
+be specified there. See :zephyr_file:`boards/nrf52840dk_nrf52840.overlay
+<samples/drivers/adc/boards/nrf52840dk_nrf52840.overlay>` for an example of
+such setup. If these parameters are not specified in devicetree, default values,
+supposed to be supported by most ADCs, are used instead.
 
 Building and Running for ST Nucleo L073RZ
 =========================================

--- a/samples/drivers/adc/boards/nrf51dk_nrf51422.overlay
+++ b/samples/drivers/adc/boards/nrf51dk_nrf51422.overlay
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ */
+
+
+/ {
+	zephyr,user {
+		io-channels = <&adc 0>;
+	};
+};
+
+&adc {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1_3";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_ADC_AIN2>; /* P0.01 */
+		zephyr,resolution = <10>;
+	};
+};

--- a/samples/drivers/adc/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/drivers/adc/boards/nrf52840dk_nrf52840.overlay
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ */
+
+
+/ {
+	zephyr,user {
+		io-channels = <&adc 0>, <&adc 1>, <&adc 7>;
+	};
+};
+
+&adc {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1_6";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_AIN1>; /* P0.03 */
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1_6";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_VDD>;
+		zephyr,resolution = <14>;
+		zephyr,oversampling = <8>;
+	};
+
+	channel@7 {
+		reg = <7>;
+		zephyr,gain = "ADC_GAIN_1_5";
+		zephyr,reference = "ADC_REF_VDD_1_4";
+		zephyr,vref-mv = <750>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_AIN6>; /* P0.30 */
+		zephyr,input-negative = <NRF_SAADC_AIN7>; /* P0.31 */
+	};
+};

--- a/samples/drivers/adc/sample.yaml
+++ b/samples/drivers/adc/sample.yaml
@@ -5,7 +5,10 @@ tests:
     tags: ADC
     depends_on: adc
     platform_allow: nucleo_l073rz disco_l475_iot1 cc3220sf_launchxl
-        cc3235sf_launchxl stm32l496g_disco
+        cc3235sf_launchxl stm32l496g_disco nrf51dk_nrf51422 nrf52840dk_nrf52840
+    integration_platforms:
+      - nucleo_l073rz
+      - nrf52840dk_nrf52840
     harness: console
     timeout: 10
     harness_config:

--- a/samples/drivers/adc/sample.yaml
+++ b/samples/drivers/adc/sample.yaml
@@ -9,6 +9,7 @@ tests:
     harness: console
     timeout: 10
     harness_config:
-      type: one_line
+      type: multi_line
       regex:
-        - "ADC reading: (.*)"
+        - "ADC reading:"
+        - " - .+, channel \\d+: \\d+"


### PR DESCRIPTION
Extend the common ADC controller binding with a child binding that allows specifying ADC channel configurations.

Update the drivers/adc sample to use this added possibility and to support properly boards based on nRF SoCs (overlay for nRF52840 DK is added to the sample).

---

This is an attempt to implement the idea from https://github.com/zephyrproject-rtos/zephyr/pull/25590#pullrequestreview-518296792.