### PR TITLE
driver: i2c: npcx: Don't print the err log when SMBST is zero

### DIFF
--- a/drivers/i2c/i2c_npcx_controller.c
+++ b/drivers/i2c/i2c_npcx_controller.c
@@ -739,9 +739,11 @@ static void i2c_ctrl_isr(const struct device *dev)
 	}
 
 	/* Clear unexpected status bits */
-	inst_fifo->SMBST = status;
-	LOG_ERR("Unexpected  SMBST 0x%02x occurred on i2c port%02x!", status,
-								data->port);
+	if (status != 0) {
+		inst_fifo->SMBST = status;
+		LOG_ERR("Unexpected  SMBST 0x%02x occurred on i2c port%02x!",
+			status, data->port);
+	}
 }
 
 /* NPCX specific I2C controller functions */


### PR DESCRIPTION
In the I2C ISR, it prints the error message when SMBST is set to an
unexpected value. However, we found a spurious interrupt which caused
the SoC to enter the ISR with SMBST=0. Because the spurious interrupt
will not break the I2C operation, this commit limits the error log to
print if SMBST is not equivalent to 0 to prevent a false alert.

Signed-off-by: Andrew McRae <amcrae@google.com>
Signed-off-by: Jun Lin <CHLin56@nuvoton.com>