### PR TITLE
gpio: Add GPIO name support

### DIFF
--- a/drivers/gpio/CMakeLists.txt
+++ b/drivers/gpio/CMakeLists.txt
@@ -57,5 +57,6 @@ zephyr_library_sources_ifdef(CONFIG_GPIO_TEST       gpio_test.c)
 zephyr_library_sources_ifdef(CONFIG_GPIO_GD32       gpio_gd32.c)
 
 zephyr_library_sources_ifdef(CONFIG_GPIO_SHELL      gpio_shell.c)
+zephyr_library_sources_ifdef(CONFIG_GPIO_NAME       gpio_name.c)
 
 zephyr_library_sources_ifdef(CONFIG_USERSPACE   gpio_handlers.c)

--- a/drivers/gpio/Kconfig
+++ b/drivers/gpio/Kconfig
@@ -21,6 +21,12 @@ config GPIO_SHELL
 	help
 	  Enable GPIO Shell for testing.
 
+config GPIO_NAME
+	bool "Enable GPIO names"
+	default y if GPIO_SHELL
+	help
+	  Use gpio-line-names to display and select GPIOs.
+
 config GPIO_INIT_PRIORITY
 	int "GPIO init priority"
 	default KERNEL_INIT_PRIORITY_DEFAULT

--- a/drivers/gpio/gpio_name.c
+++ b/drivers/gpio/gpio_name.c
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2022 Google Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <devicetree.h>
+#include <drivers/gpio/gpio_name.h>
+#include <string.h>
+#include <logging/log.h>
+
+#ifdef CONFIG_GPIO_SHELL
+#include <shell/shell.h>
+#include <stdio.h>
+#endif
+
+/*
+ * Try to determine the base node containing the GPIO nodes.
+ * Mostly the GPIO controllers are child nodes of the
+ * 'soc' node.
+ * A node label 'gpio_controller_parent' may be set
+ * on the parent node.
+ */
+
+#if DT_NODE_EXISTS(DT_ALIAS(gpio_controller_parent))
+
+#define GPIO_BASE_NODE DT_ALIAS(gpio_controller_parent)
+
+#elif DT_NODE_EXISTS(DT_PATH(soc))
+
+#define GPIO_BASE_NODE DT_PATH(soc)
+
+#elif DT_HAS_COMPAT_STATUS_OKAY(zephyr_posix)
+
+#define GPIO_BASE_NODE DT_ROOT
+
+#else
+
+#error "Unable to determine node containing GPIO controllers"
+
+#endif
+
+/*
+ * For this GPIO controller node, create a string array containing the
+ * gpio-line-names strings, and name the array using the node ID.
+ */
+#define NAME_DEFN(id) \
+	static const char *const id[] = DT_PROP(id, gpio_line_names)
+
+/*
+ * For GPIO controller nodes that have the gpio-line-names property,
+ * create the string array for the names.
+ */
+#define NAME_ENTRY(id)					   \
+	COND_CODE_1(DT_NODE_HAS_PROP(id, gpio_line_names), \
+		    (NAME_DEFN(id);),			   \
+		    ())
+
+/*
+ * Walk through all the child nodes of the base node, and
+ * for each node that contains a gpio-line-names property,
+ * generated an array of names from this property.
+ */
+DT_FOREACH_CHILD_STATUS_OKAY(GPIO_BASE_NODE, NAME_ENTRY)
+
+/*
+ * Holds a summary of the GPIO controller data captured from DTS
+ * nodes that have the gpio-line-names property.
+ */
+struct gpio_names {
+	const struct device *port;      /* GPIO controller device */
+	const char *const *names;       /* pointer to array of names */
+	uint8_t name_count;             /* Count of names in array */
+};
+
+/*
+ * Init one entry for a GPIO controller.
+ */
+#define CONTR_ENTRY(id)						\
+	{							\
+		.port = DEVICE_DT_GET(id),			\
+		.names = id,					\
+		.name_count = DT_PROP_LEN(id, gpio_line_names),	\
+	},
+
+/*
+ * Conditionally create a gpio_names entry if the
+ * node has the gpio-line-names property.
+ */
+#define GPIO_CONTR(id)					   \
+	COND_CODE_1(DT_NODE_HAS_PROP(id, gpio_line_names), \
+		    (CONTR_ENTRY(id)),			   \
+		    ())
+
+/*
+ * Table of gpio_names, one entry for each GPIO controller.
+ */
+static const struct gpio_names gpio_names[] = {
+	DT_FOREACH_CHILD_STATUS_OKAY(GPIO_BASE_NODE, GPIO_CONTR)
+};
+
+/*
+ * Search for a name of a GPIO, and return the
+ * controller (port) and pin number. The pin number
+ * is the array index of the matching name within the
+ * controller.
+ * Return the index of the controller, or -1 if not
+ * found. Also store the pin number in the pointer passed.
+ */
+static int gpio_find_by_name(const char *name, gpio_pin_t *pin)
+{
+	for (int i = 0; i < ARRAY_SIZE(gpio_names); i++) {
+		const char *const *n = gpio_names[i].names;
+
+		for (int j = 0; j < gpio_names[i].name_count; j++) {
+			if (n[j] != NULL && strcmp(n[j], name) == 0) {
+				*pin = j;
+				return i;
+			}
+		}
+	}
+	*pin = 0;
+	return -1;
+}
+
+#ifdef CONFIG_GPIO_SHELL
+/*
+ * Array of last displayed values for GPIOs.
+ */
+static gpio_port_pins_t gpio_last_value[ARRAY_SIZE(gpio_names)];
+
+/*
+ * Print the details of this GPIO. The raw value is
+ * compared against the last value displayed, and '*' displayed
+ * for changed values. 'L' is displayed for inverted values (active low).
+ */
+static void gpio_print(const struct shell *sh, int index, gpio_pin_t pin)
+{
+	int value;
+	char changed, polarity;
+	uint32_t last = gpio_last_value[index];
+	const struct gpio_names *gp = &gpio_names[index];
+	struct gpio_driver_data *data;
+
+	if (pin >= gp->name_count) {
+		return;
+	}
+	data = (struct gpio_driver_data *)gp->port->data;
+	/* Get current state of GPIO */
+	value = gpio_pin_get_raw(gp->port, pin);
+	if (value != ((last >> pin) & 1)) {
+		changed = '*';
+		/* Update remembered value */
+		gpio_last_value[index] =
+			(last & ~(1 << pin)) | (value << pin);
+	} else {
+		changed = ' ';
+	}
+	/* Get the polarity (active low/high) of the pin */
+	polarity = (data->invert & (1 << pin)) ? 'L' : ' ';
+	shell_print(sh, " %d%c %c %s", value, changed, polarity, gp->names[pin]);
+}
+
+int cmd_gpio_name_show(const struct shell *sh, const char *name)
+{
+	/* Display a single GPIO */
+	gpio_pin_t pin;
+	int index = gpio_find_by_name(name, &pin);
+
+	if (index < 0) {
+		return -ENOENT;
+	}
+	gpio_print(sh, index, pin);
+	return 0;
+}
+
+void cmd_gpio_name_show_all(const struct shell *sh)
+{
+	/* Display all GPIOs with names */
+	for (int i = 0; i < ARRAY_SIZE(gpio_names); i++) {
+		for (int j = 0; j < gpio_names[i].name_count; j++) {
+			const char *np = gpio_names[i].names[j];
+			/* Don't attempt to print missing or empty names */
+			if (np != NULL && *np != 0) {
+				gpio_print(sh, i, j);
+			}
+		}
+	}
+}
+#endif
+
+const char *gpio_pin_get_name(const struct device *port, gpio_pin_t pin)
+{
+	const char *name;
+
+	/* Search table for matching port */
+	for (int i = 0; i < ARRAY_SIZE(gpio_names); i++) {
+		if (gpio_names[i].port == port) {
+			/* Check pin is within range */
+			if (pin >= gpio_names[i].name_count) {
+				return NULL;
+			}
+			name = gpio_names[i].names[pin];
+			/* Make sure it is not NULL or empty */
+			if (name != NULL && *name != 0) {
+				return name;
+			}
+			return NULL;
+		}
+	}
+	return NULL;
+}
+
+int gpio_pin_by_name(const char *name,
+		     const struct device **port, gpio_pin_t *pin)
+{
+	int index = gpio_find_by_name(name, pin);
+
+	if (index < 0) {
+		*port = NULL;
+		return -ENOENT;
+	}
+	*port = gpio_names[index].port;
+	return 0;
+}

--- a/drivers/gpio/gpio_name_shell.h
+++ b/drivers/gpio/gpio_name_shell.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022 Google Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file Header for accessing GPIO name functions for shell.
+ */
+
+#ifndef ZEPHYR_DRIVERS_GPIO_GPIO_NAME_SHELL_H_
+#define ZEPHYR_DRIVERS_GPIO_GPIO_NAME_SHELL_H_
+
+/**
+ * @brief Function to display the details of a single named GPIO.
+ *
+ * @param shell A pointer to the shell instance.
+ * @param name A pointer to the name string identifying the GPIO.
+ *
+ * @return 0 on success, negative errno otherwise.
+ */
+int cmd_gpio_name_show(const struct shell *shell, const char *name);
+
+/**
+ * @brief Function to display all the named GPIOs.
+ *
+ * @param shell A pointer to the shell instance.
+ */
+void cmd_gpio_name_show_all(const struct shell *shell);
+
+#endif /* ZEPHYR_DRIVERS_GPIO_GPIO_NAME_SHELL_H_ */

--- a/drivers/gpio/gpio_shell.c
+++ b/drivers/gpio/gpio_shell.c
@@ -13,57 +13,93 @@
 #include <string.h>
 #include <stdio.h>
 #include <drivers/gpio.h>
+#include <drivers/gpio/gpio_name.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <logging/log.h>
+
+#ifdef CONFIG_GPIO_NAME
+#include "gpio_name_shell.h"
+#endif
 
 #define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
 
 LOG_MODULE_REGISTER(gpio_shell);
 
-struct args_index {
-	uint8_t port;
-	uint8_t index;
-	uint8_t mode;
-	uint8_t value;
+enum arg_idx {
+	ARG_PORT_OR_NAME        = 1,    /* Port or name argument */
+	ARG_INDEX               = 2,    /* pin index argument (after port) */
+	ARG_NAME_NEXT           = 2,    /* Next argument after name */
+	ARG_PORT_NEXT           = 3,    /* Next argument after port and index */
 };
 
-static const struct args_index args_indx = {
-	.port = 1,
-	.index = 2,
-	.mode = 3,
-	.value = 3,
-};
+/*
+ * Decode arguments 1 and optionally 2 as either a
+ * name, or as device and separate pin index.
+ * Return the next argument index (2 or 3), and set the
+ * port and index, or -1 for error.
+ */
+static int cmd_gpio_port_index(size_t argc, char **argv,
+			       const struct device **dev, gpio_pin_t *index)
+{
+#ifdef CONFIG_GPIO_NAME
+	/* Must be at least one argument */
+	if (argc < 2) {
+		return -1;
+	}
+	/* Check and see if the name is a match.  */
+	if (gpio_pin_by_name(argv[ARG_PORT_OR_NAME], dev, index) == 0) {
+		/* Matched name, step to argument after name */
+		return ARG_NAME_NEXT;
+	}
+#endif
+	/* Must be at least 2 arguments */
+	if (argc < 3) {
+		return -1;
+	}
+	*dev = device_get_binding(argv[ARG_PORT_OR_NAME]);
+	if (*dev == NULL) {
+		/* unknown device */
+		*index = 0;
+		return -1;
+	}
+	*index = atoi(argv[ARG_INDEX]);
+	if (*index < 0) {
+		*dev = NULL;
+		*index = 0;
+		return -1;
+	}
+	/* Found GPIO port and index */
+	return ARG_PORT_NEXT;
+}
 
 static int cmd_gpio_conf(const struct shell *sh, size_t argc, char **argv)
 {
-	uint8_t index = 0U;
+	gpio_pin_t index;
+	int next_arg;
 	int type = GPIO_OUTPUT;
 	const struct device *dev;
 
-	if (isdigit((unsigned char)argv[args_indx.index][0]) &&
-	    isalpha((unsigned char)argv[args_indx.mode][0])) {
-		index = (uint8_t)atoi(argv[args_indx.index]);
-		if (!strcmp(argv[args_indx.mode], "in")) {
-			type = GPIO_INPUT;
-		} else if (!strcmp(argv[args_indx.mode], "out")) {
-			type = GPIO_OUTPUT;
-		} else {
-			return 0;
-		}
-	} else {
-		shell_error(sh, "Wrong parameters for conf");
+	next_arg = cmd_gpio_port_index(argc, argv, &dev, &index);
+	if (next_arg < 0) {
+		shell_error(sh, "Cannot find GPIO");
+		return -ENOENT;
+	}
+	/* Make sure there is a mode argument */
+	if (next_arg >= argc) {
+		shell_error(sh, "Missing 'in' or 'out' parameter");
 		return -ENOTSUP;
 	}
-
-	dev = device_get_binding(argv[args_indx.port]);
-
-	if (dev != NULL) {
-		index = (uint8_t)atoi(argv[args_indx.index]);
-		shell_print(sh, "Configuring %s pin %d",
-			    argv[args_indx.port], index);
-		gpio_pin_configure(dev, index, type);
+	if (!strcmp(argv[next_arg], "in")) {
+		type = GPIO_INPUT;
+	} else if (!strcmp(argv[next_arg], "out")) {
+		type = GPIO_OUTPUT;
+	} else {
+		return 0;
 	}
+
+	shell_print(sh, "Configuring %s pin %d", dev->name, index);
+	gpio_pin_configure(dev, index, type);
 
 	return 0;
 }
@@ -72,29 +108,36 @@ static int cmd_gpio_get(const struct shell *sh,
 			size_t argc, char **argv)
 {
 	const struct device *dev;
-	uint8_t index = 0U;
+	gpio_pin_t index;
 	int rc;
+	int next_arg;
 
-	if (isdigit((unsigned char)argv[args_indx.index][0])) {
-		index = (uint8_t)atoi(argv[args_indx.index]);
-	} else {
+#ifdef CONFIG_GPIO_NAME
+	/* No arguments, display all named GPIOs */
+	if (argc == 1) {
+		cmd_gpio_name_show_all(sh);
+		return 0;
+	}
+	/* Try the name */
+	if (argc == 2) {
+		if (cmd_gpio_name_show(sh, argv[ARG_PORT_OR_NAME]) == 0) {
+			return 0;
+		}
+	}
+#endif
+
+	next_arg = cmd_gpio_port_index(argc, argv, &dev, &index);
+	if (next_arg < 0) {
 		shell_error(sh, "Wrong parameters for get");
 		return -EINVAL;
 	}
-
-	dev = device_get_binding(argv[args_indx.port]);
-
-	if (dev != NULL) {
-		index = (uint8_t)atoi(argv[2]);
-		shell_print(sh, "Reading %s pin %d",
-			    argv[args_indx.port], index);
-		rc = gpio_pin_get(dev, index);
-		if (rc >= 0) {
-			shell_print(sh, "Value %d", rc);
-		} else {
-			shell_error(sh, "Error %d reading value", rc);
-			return -EIO;
-		}
+	shell_print(sh, "Reading %s pin %d", dev->name, index);
+	rc = gpio_pin_get(dev, index);
+	if (rc >= 0) {
+		shell_print(sh, "Value %d", rc);
+	} else {
+		shell_error(sh, "Error %d reading value", rc);
+		return -EIO;
 	}
 
 	return 0;
@@ -104,25 +147,28 @@ static int cmd_gpio_set(const struct shell *sh,
 			size_t argc, char **argv)
 {
 	const struct device *dev;
-	uint8_t index = 0U;
-	uint8_t value = 0U;
+	gpio_pin_t index;
+	int value;
+	int next_arg;
 
-	if (isdigit((unsigned char)argv[args_indx.index][0]) &&
-	    isdigit((unsigned char)argv[args_indx.value][0])) {
-		index = (uint8_t)atoi(argv[args_indx.index]);
-		value = (uint8_t)atoi(argv[args_indx.value]);
-	} else {
-		shell_print(sh, "Wrong parameters for set");
+	next_arg = cmd_gpio_port_index(argc, argv, &dev, &index);
+	if (next_arg < 0) {
+		shell_error(sh, "Wrong parameters for set");
 		return -EINVAL;
 	}
-	dev = device_get_binding(argv[args_indx.port]);
-
-	if (dev != NULL) {
-		index = (uint8_t)atoi(argv[2]);
-		shell_print(sh, "Writing to %s pin %d",
-			    argv[args_indx.port], index);
-		gpio_pin_set(dev, index, value);
+	/* Make sure there is a value argument */
+	if (next_arg >= argc) {
+		shell_error(sh, "Missing value parameter");
+		return -EINVAL;
 	}
+	value = atoi(argv[next_arg]);
+	if (value != 0 && value != 1) {
+		shell_error(sh, "Illegal value");
+		return -EINVAL;
+	}
+
+	shell_print(sh, "Writing to %s pin %d value %d", dev->name, index, value);
+	gpio_pin_set(dev, index, value);
 
 	return 0;
 }
@@ -135,45 +181,38 @@ static int cmd_gpio_blink(const struct shell *sh,
 			  size_t argc, char **argv)
 {
 	const struct device *dev;
-	uint8_t index = 0U;
-	uint8_t value = 0U;
+	gpio_pin_t index;
+	int value = 0U;
 	size_t count = 0;
 	char data;
 
-	if (isdigit((unsigned char)argv[args_indx.index][0])) {
-		index = (uint8_t)atoi(argv[args_indx.index]);
-	} else {
+	if (cmd_gpio_port_index(argc, argv, &dev, &index) < 0) {
 		shell_error(sh, "Wrong parameters for blink");
 		return -EINVAL;
 	}
-	dev = device_get_binding(argv[args_indx.port]);
+	shell_fprintf(sh, SHELL_NORMAL, "Blinking port %s index %d.", dev->name, index);
+	shell_fprintf(sh, SHELL_NORMAL, " Hit any key to exit");
 
-	if (dev != NULL) {
-		index = (uint8_t)atoi(argv[2]);
-		shell_fprintf(sh, SHELL_NORMAL, "Blinking port %s index %d.", argv[1], index);
-		shell_fprintf(sh, SHELL_NORMAL, " Hit any key to exit");
-
-		while (true) {
-			(void)sh->iface->api->read(sh->iface, &data, sizeof(data), &count);
-			if (count != 0) {
-				break;
-			}
-			gpio_pin_set(dev, index, value);
-			value = !value;
-			k_msleep(SLEEP_TIME_MS);
+	while (true) {
+		(void)sh->iface->api->read(sh->iface, &data, sizeof(data), &count);
+		if (count != 0) {
+			break;
 		}
-
-		shell_fprintf(sh, SHELL_NORMAL, "\n");
+		gpio_pin_set(dev, index, value);
+		value = !value;
+		k_msleep(SLEEP_TIME_MS);
 	}
+
+	shell_fprintf(sh, SHELL_NORMAL, "\n");
 
 	return 0;
 }
 
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_gpio,
-			       SHELL_CMD_ARG(conf, NULL, "Configure GPIO", cmd_gpio_conf, 4, 0),
-			       SHELL_CMD_ARG(get, NULL, "Get GPIO value", cmd_gpio_get, 3, 0),
-			       SHELL_CMD_ARG(set, NULL, "Set GPIO", cmd_gpio_set, 4, 0),
-			       SHELL_CMD_ARG(blink, NULL, "Blink GPIO", cmd_gpio_blink, 3, 0),
+			       SHELL_CMD_ARG(conf, NULL, "Configure GPIO", cmd_gpio_conf, 3, 1),
+			       SHELL_CMD_ARG(get, NULL, "Get GPIO value", cmd_gpio_get, 1, 2),
+			       SHELL_CMD_ARG(set, NULL, "Set GPIO", cmd_gpio_set, 3, 1),
+			       SHELL_CMD_ARG(blink, NULL, "Blink GPIO", cmd_gpio_blink, 2, 1),
 			       SHELL_SUBCMD_SET_END /* Array terminated. */
 			       );
 

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -20,6 +20,10 @@
 		zephyr,flash-controller = &flash;
 	};
 
+	aliases {
+		gpio-controller-parent = &pinctrl;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/include/drivers/gpio/gpio_name.h
+++ b/include/drivers/gpio/gpio_name.h
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2022 Google Inc
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Map GPIO name from gpio-line-names to/from GPIO spec.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_GPIO_GPIO_NAME_H_
+#define ZEPHYR_INCLUDE_DRIVERS_GPIO_GPIO_NAME_H_
+
+#include <zephyr/types.h>
+#include <drivers/gpio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief GPIO name API
+ * @defgroup gpio_name GPIO name
+ * @ingroup gpio_interface
+ * @{
+ *
+ * Maps GPIO names as defined in the gpio-line-names DTS
+ * configuration of GPIO controllers to/from a GPIO controller
+ * device and pin number.
+ *
+ * - Given a string, return the GPIO controller device and pin number
+ *   that corresponds to the matching string in gpio-line-names
+ *   for that GPIO controller.
+ * - Given a GPIO controller device pointer and a pin number,
+ *   return the corresponding GPIO name for this pin (as found
+ *   in the gpio-line-names device tree for that controller.
+ *
+ * The GPIO names are typically placed in a DTS overlay thus:
+ *
+ *  &gpioa {
+ *      gpio-line-names =
+ *        "turn-on-light",
+ *        "",
+ *        "check-level",
+ *        "user-button";
+ *  };
+ *
+ * To extract and store the GPIO names from the gpio-line-names
+ * property on each GPIO controller, the controller's device
+ * tree entries are scanned. To do this, the parent device tree
+ * node that contains the GPIO controllers must be known.
+ * By default, the 'soc' node is assumed to be the parent node,
+ * but some boards use a different node, in which case
+ * a device tree alias 'gpio-controller-parent' can be used
+ * to define the parent node of the GPIO controller.
+ *
+ * Example devicetree fragment:
+ *
+ *      aliases {
+ *          gpio-controller-parent = &pinctrl;
+ *      };
+ *
+ * If the GPIO shell is enabled, the names can be used to
+ * select the GPIOs for conf/get/set etc.
+ */
+
+/**
+ * @brief Get the name associated with this GPIO port and pin.
+ *
+ * @param port The GPIO port
+ * @param pin  The pin number of the GPIO
+ *
+ * @return GPIO name corresponding to port and pin.
+ * @return NULL No name is associated with this port and pin.
+ */
+const char *gpio_pin_get_name(const struct device *port, gpio_pin_t pin);
+
+/**
+ * @brief Get the GPIO port and pin associated with this name.
+ *
+ * @param name The name used to match against the gpio-line-names of the port.
+ * @param port A pointer where the port will be stored, NULL if none found.
+ * @param pin A pointer where the pin will be stored, 0 if none found.
+ *
+ * @return 0 on success
+ * @return -ENOENT if the name is not found.
+ */
+int gpio_pin_by_name(const char *name, const struct device **port,
+		     gpio_pin_t *pin);
+
+/**
+ * @brief Get the name associated with a GPIO spec.
+ *
+ * @param spec Pointer to the GPIO spec.
+ *
+ * @return Pointer to name associated with GPIO.
+ * @return NULL No name was found for this GPIO.
+ */
+static inline const char *
+gpio_pin_get_name_dt(const struct gpio_dt_spec *spec)
+{
+	return gpio_pin_get_name(spec->port, spec->pin);
+}
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_GPIO_GPIO_NAME_H_ */


### PR DESCRIPTION
Add support for capturing GPIO names
from the GPIO controller gpio-line-names property.

A GPIO name API is added to allow mapping to/from
the name and the GPIO port and pin.

The GPIO shell commands are enhanced to allow
display of the names, and to use the names to
identify GPIO pins.

Tested by creating an overlay for a STM Nucleo G071RB
and ensuring the GPIO names can be used to display and
retrieve the GPIO port and pin, and the GPIO shell
functionality is correct (e.g get/set/blink) for both
explicit port/pin and name.

Signed-off-by: Andrew McRae <amcrae@google.com>