### PR TITLE
ITE: drivers/adc: implement ADC channels 13-16

### DIFF
--- a/dts/riscv/it8xxx2-alts-map.dtsi
+++ b/dts/riscv/it8xxx2-alts-map.dtsi
@@ -35,6 +35,18 @@
 		pinctrl_adc7: adc7 {
 			pinctrls = <&pinmuxi 7 IT8XXX2_PINMUX_FUNC_1>;
 		};
+		pinctrl_adc13: adc13 {
+			pinctrls = <&pinmuxl 0 IT8XXX2_PINMUX_FUNC_1>;
+		};
+		pinctrl_adc14: adc14 {
+			pinctrls = <&pinmuxl 1 IT8XXX2_PINMUX_FUNC_1>;
+		};
+		pinctrl_adc15: adc15 {
+			pinctrls = <&pinmuxl 2 IT8XXX2_PINMUX_FUNC_1>;
+		};
+		pinctrl_adc16: adc16 {
+			pinctrls = <&pinmuxl 3 IT8XXX2_PINMUX_FUNC_1>;
+		};
 
 		/* PWM alternate function */
 		pinctrl_pwm0: pwm0 {

--- a/dts/riscv/it8xxx2.dtsi
+++ b/dts/riscv/it8xxx2.dtsi
@@ -654,7 +654,11 @@
 				     &pinctrl_adc4   /* ADC4*/
 				     &pinctrl_adc5   /* ADC5*/
 				     &pinctrl_adc6   /* ADC6*/
-				     &pinctrl_adc7>; /* ADC7*/
+				     &pinctrl_adc7   /* ADC7*/
+				     &pinctrl_adc13  /* ADC13*/
+				     &pinctrl_adc14  /* ADC14*/
+				     &pinctrl_adc15  /* ADC15*/
+				     &pinctrl_adc16>;/* ADC16*/
 		};
 		i2c0: i2c@f01c40 {
 			compatible = "ite,it8xxx2-i2c";

--- a/soc/riscv/riscv-ite/common/check_regs.c
+++ b/soc/riscv/riscv-ite/common/check_regs.c
@@ -124,3 +124,11 @@ IT8XXX2_REG_OFFSET_CHECK(kscan_it8xxx2_regs, KBS_KSOCTRL, 0x02);
 IT8XXX2_REG_OFFSET_CHECK(kscan_it8xxx2_regs, KBS_KSI, 0x04);
 IT8XXX2_REG_OFFSET_CHECK(kscan_it8xxx2_regs, KBS_KSIGDAT, 0x08);
 IT8XXX2_REG_OFFSET_CHECK(kscan_it8xxx2_regs, KBS_KSOLGOEN, 0x0e);
+
+/* ADC register structure check */
+IT8XXX2_REG_SIZE_CHECK(adc_it8xxx2_regs, 0x6d);
+IT8XXX2_REG_OFFSET_CHECK(adc_it8xxx2_regs, ADCGCR, 0x03);
+IT8XXX2_REG_OFFSET_CHECK(adc_it8xxx2_regs, VCH0DATM, 0x19);
+IT8XXX2_REG_OFFSET_CHECK(adc_it8xxx2_regs, adc_vchs_ctrl[0].VCHCTL, 0x60);
+IT8XXX2_REG_OFFSET_CHECK(adc_it8xxx2_regs, adc_vchs_ctrl[2].VCHDATM, 0x67);
+IT8XXX2_REG_OFFSET_CHECK(adc_it8xxx2_regs, ADCDVSTS2, 0x6c);

--- a/soc/riscv/riscv-ite/common/chip_chipregs.h
+++ b/soc/riscv/riscv-ite/common/chip_chipregs.h
@@ -1550,21 +1550,52 @@ struct flash_it8xxx2_regs {
 #define IT8XXX2_GPIO_GPCRP0     ECREG(IT8XXX2_GPIO2_BASE + 0x18)
 #define IT8XXX2_GPIO_GPCRP1     ECREG(IT8XXX2_GPIO2_BASE + 0x19)
 
-/* Analog to Digital Converter (ADC) */
-
+/**
+ *
+ * (19xxh) Analog to Digital Converter (ADC) registers
+ *
+ */
 #ifndef __ASSEMBLER__
+
+/* Data structure to define ADC channel 13-16 control registers. */
+struct adc_vchs_ctrl_t {
+	/* 0x60: Voltage Channel Control */
+	volatile uint8_t VCHCTL;
+	/* 0x61: Voltage Channel Data Buffer MSB */
+	volatile uint8_t VCHDATM;
+	/* 0x62: Voltage Channel Data Buffer LSB */
+	volatile uint8_t VCHDATL;
+};
+
 struct adc_it8xxx2_regs {
+	/* 0x00: ADC Status */
 	volatile uint8_t ADCSTS;
+	/* 0x01: ADC Configuration */
 	volatile uint8_t ADCCFG;
+	/* 0x02: ADC Clock Control */
 	volatile uint8_t ADCCTL;
+	/* 0x03: General Control */
 	volatile uint8_t ADCGCR;
+	/* 0x04: Voltage Channel 0 Control */
 	volatile uint8_t VCH0CTL;
+	/* 0x05: Calibration Data Control */
 	volatile uint8_t KDCTL;
+	/* 0x06-0x17: Reserved1 */
 	volatile uint8_t reserved1[18];
+	/* 0x18: Voltage Channel 0 Data Buffer LSB */
 	volatile uint8_t VCH0DATL;
+	/* 0x19: Voltage Channel 0 Data Buffer MSB */
 	volatile uint8_t VCH0DATM;
+	/* 0x1a-0x43: Reserved2 */
 	volatile uint8_t reserved2[42];
+	/* 0x44: ADC Data Valid Status */
 	volatile uint8_t ADCDVSTS;
+	/* 0x45-0x5f: Reserved3 */
+	volatile uint8_t reserved3[27];
+	/* 0x60-0x6b: ADC channel 13~16 controller */
+	struct adc_vchs_ctrl_t adc_vchs_ctrl[4];
+	/* 0x6c: ADC Data Valid Status 2 */
+	volatile uint8_t ADCDVSTS2;
 };
 #endif /* !__ASSEMBLER__ */
 
@@ -1582,6 +1613,8 @@ struct adc_it8xxx2_regs {
 #define IT8XXX2_ADC_DATVAL			BIT(7)
 /* Data valid interrupt of adc */
 #define IT8XXX2_ADC_INTDVEN			BIT(5)
+/* Voltage channel enable (Channel 4~7 and 13~16) */
+#define IT8XXX2_ADC_VCHEN			BIT(4)
 /* Automatic hardware calibration enable */
 #define IT8XXX2_ADC_AHCE			BIT(7)
 


### PR DESCRIPTION
The ADC driver of IT81302 chip can support channels 0-7 & 13-16.
This PR adds to implement ADC channels 13-16.

Signed-off-by: Tim Lin <tim2.lin@ite.corp-partner.google.com>