### PR TITLE
net: openthread: fix received frame flags

### DIFF
--- a/subsys/net/lib/openthread/platform/radio.c
+++ b/subsys/net/lib/openthread/platform/radio.c
@@ -346,6 +346,7 @@ static void openthread_handle_received_frame(otInstance *instance,
 					     struct net_pkt *pkt)
 {
 	otRadioFrame recv_frame;
+	memset(&recv_frame, 0, sizeof(otRadioFrame));
 
 	recv_frame.mPsdu = net_buf_frag_last(pkt->buffer)->data;
 	/* Length inc. CRC. */


### PR DESCRIPTION
Uninitialized memory would report wrong value for
`mAckedWithSecEnhAck` flag in the received frame, making the
OpenThread stack to update the frame counter for the neighbor
wrongly.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>