### PR TITLE
doc: release: 3.0: Add release notes for networking

### DIFF
--- a/doc/releases/release-notes-3.0.rst
+++ b/doc/releases/release-notes-3.0.rst
@@ -575,9 +575,97 @@ Drivers and Sensors
 Networking
 **********
 
+* CoAP:
+
+  * Refactored ``coap_client``/``coap_server`` samples to make better use of
+    observe APIs.
+  * Added PATCH, iPATCH and FETCH methods.
+  * A few fixes for the block transfer handling.
+
+* DNS:
+
+  * Make mdns and llmnr responders join their multicast groups.
+  * Added support for mdns/dns_sd service type enumeration.
+
+* ICMPv6:
+
+  * Added support for Route Information option processing.
+
+* IPv4:
+
+  *  Add IPv4 support to multicast monitor.
+
+* LwM2M:
+
+  * Added a parameter to forcefully close the LwM2M session to
+    :c:func:`lwm2m_rd_client_stop` function.
+  * Replaced custom ``float32_value_t`` type with double.
+  * Added :kconfig:`LWM2M_FIRMWARE_PORT_NONSECURE`/:kconfig:`LWM2M_FIRMWARE_PORT_SECURE`
+    options, which allow to specify a custom port or firmware update.
+  * Added :c:func:`lwm2m_update_device_service_period` API function.
+  * Added observe callback for observe and notification events.
+  * Added support for multiple LwM2M Firmware Update object instances.
+  * Improved error handling in LwM2M content writers.
+  * Added unit tests for LwM2M content writers.
+  * Implmented LwM2M Security, Server, Connection Monitor objects in version 1.1.
+  * Multiple minor bugfixes in the LwM2M stack.
+  * Added support for the following objects:
+
+    * LWM2M Software Management (ID 9)
+    * LwM2M Gateway (ID 25)
+    * IPSO Current (ID 3317)
+    * uCIFI Battery (ID 3411)
+    * IPSO Filling level (ID 3435)
+
 * Misc:
 
   * gptp: clock sync ratio as double, not float
+  * Added support for route lifetime and preference.
+  * Refactored various packed structures across the networking stack, to avoid
+    unaliged access warnings from gcc.
+  * Added automatic loopback addresses registration to loopback interface.
+  * Fixed source address selection for ARP.
+  * Allow to implment a custom IEEE802154 L2 on top of existing drivers.
+  * Introduced a network packet filtering framework.
+
+* MQTT:
+
+  * Fixed incomplete :c:func:`zsock_sendmsg` writes handling.
+  * Fixed :c:func:`zsock_setsockopt` error handling in SOCKS5 transport.
+
+* OpenThread:
+
+  * Updated OpenThread revision up to commit ``ce77ab3c1d7ad91b284615112ae38c08527bf73e``.
+  * Fixed an overflow bug in the alarm implementation for Zephyr.
+  * Added crypto backend based on PSA API.
+  * Allow to store OpenThread settings in RAM.
+
+* Socket:
+
+  * Fixed :c:func:`zsock_sendmsg` when payload size exceeded network MTU.
+  * Added socket processing priority.
+  * Fixed possible crash in :c:func:`zsock_getaddrinfo` when DNS callback is
+    delayed.
+
+* Telnet:
+
+  * Fixed handling of multiple commands in a single packet.
+  * Enabled command handling by default.
+
+* TCP:
+
+  * Added support for sending our MSS to peer.
+  * Fixed packet sending to local addresses.
+  * Fixed possible deadlock between TCP and socket layer, when connection close
+    is initiated from both sides.
+  * Multiple other minor bugfixes and improvements in the TCP implementation.
+
+* TLS:
+
+  * Added support for ``TLS_CERT_NOCOPY`` socket option, which allows to
+    optimise mbed TLS heap usage.
+  * Fixed ``POLLHUP`` detection when underlying TCP connection is closed.
+  * Fixed mbedtls session reset on handshake errors.
 
 USB
 ***


### PR DESCRIPTION
Add networking release notes based on the commit history.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>