### PR TITLE
drivers: can: use separate log modules for each driver

### DIFF
--- a/drivers/can/can_common.c
+++ b/drivers/can/can_common.c
@@ -7,10 +7,9 @@
 #include <drivers/can.h>
 #include <kernel.h>
 #include <sys/util.h>
-
-#define LOG_LEVEL CONFIG_CAN_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(can_driver);
+
+LOG_MODULE_REGISTER(can_common, CONFIG_CAN_LOG_LEVEL);
 
 #define CAN_SYNC_SEG 1
 

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -10,9 +10,9 @@
 #include <drivers/can.h>
 #include "can_mcan.h"
 #include "can_mcan_int.h"
-
 #include <logging/log.h>
-LOG_MODULE_DECLARE(can_driver, CONFIG_CAN_LOG_LEVEL);
+
+LOG_MODULE_REGISTER(can_mcan, CONFIG_CAN_LOG_LEVEL);
 
 #define CAN_INIT_TIMEOUT (100)
 #define CAN_DIV_CEIL(val, div) (((val) + (div) - 1) / (div))

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -10,10 +10,9 @@
 #include <device.h>
 #include <drivers/spi.h>
 #include <drivers/gpio.h>
-
-#define LOG_LEVEL CONFIG_CAN_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(mcp2515_can);
+
+LOG_MODULE_REGISTER(can_mcp2515, CONFIG_CAN_LOG_LEVEL);
 
 #include "can_mcp2515.h"
 #include "can_utils.h"

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -13,10 +13,9 @@
 #include <device.h>
 #include <sys/byteorder.h>
 #include <fsl_flexcan.h>
-
-#define LOG_LEVEL CONFIG_CAN_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(can_mcux_flexcan);
+
+LOG_MODULE_REGISTER(can_mcux_flexcan, CONFIG_CAN_LOG_LEVEL);
 
 #define SP_IS_SET(inst) DT_INST_NODE_HAS_PROP(inst, sample_point) ||
 

--- a/drivers/can/can_mcux_mcan.c
+++ b/drivers/can/can_mcux_mcan.c
@@ -11,7 +11,7 @@
 
 #include "can_mcan.h"
 
-LOG_MODULE_REGISTER(mcux_mcan, CONFIG_CAN_LOG_LEVEL);
+LOG_MODULE_REGISTER(can_mcux_mcan, CONFIG_CAN_LOG_LEVEL);
 
 #define DT_DRV_COMPAT nxp_lpc_mcan
 

--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -12,9 +12,9 @@
 #include <drivers/clock_control.h>
 #include <drivers/clock_control/rcar_clock_control.h>
 #include <drivers/pinctrl.h>
-
 #include <logging/log.h>
-LOG_MODULE_DECLARE(can_driver, CONFIG_CAN_LOG_LEVEL);
+
+LOG_MODULE_REGISTER(can_rcar, CONFIG_CAN_LOG_LEVEL);
 
 #include "can_utils.h"
 

--- a/drivers/can/can_sam.c
+++ b/drivers/can/can_sam.c
@@ -9,9 +9,10 @@
 #include <drivers/can.h>
 #include <soc.h>
 #include <kernel.h>
-
 #include <logging/log.h>
-LOG_MODULE_DECLARE(can_driver, CONFIG_CAN_LOG_LEVEL);
+
+LOG_MODULE_REGISTER(can_sam, CONFIG_CAN_LOG_LEVEL);
+
 #define DT_DRV_COMPAT atmel_sam_can
 
 struct can_sam_config {

--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -14,10 +14,11 @@
 #include <errno.h>
 #include <stdbool.h>
 #include <drivers/can.h>
+#include <logging/log.h>
+
 #include "can_stm32.h"
 
-#include <logging/log.h>
-LOG_MODULE_DECLARE(can_driver, CONFIG_CAN_LOG_LEVEL);
+LOG_MODULE_REGISTER(can_stm32, CONFIG_CAN_LOG_LEVEL);
 
 #define CAN_INIT_TIMEOUT  (10 * sys_clock_hw_cycles_per_sec() / MSEC_PER_SEC)
 

--- a/drivers/can/can_stm32fd.c
+++ b/drivers/can/can_stm32fd.c
@@ -9,10 +9,11 @@
 #include <kernel.h>
 #include <soc.h>
 #include <stm32_ll_rcc.h>
+#include <logging/log.h>
+
 #include "can_stm32fd.h"
 
-#include <logging/log.h>
-LOG_MODULE_DECLARE(can_driver, CONFIG_CAN_LOG_LEVEL);
+LOG_MODULE_REGISTER(can_stm32fd, CONFIG_CAN_LOG_LEVEL);
 
 #if CONFIG_CAN_STM32_CLOCK_DIVISOR != 1 && CONFIG_CAN_STM32_CLOCK_DIVISOR & 0x01
 #error CAN_STM32_CLOCK_DIVISOR invalid.\

--- a/drivers/can/can_stm32h7.c
+++ b/drivers/can/can_stm32h7.c
@@ -10,10 +10,11 @@
 #include <drivers/pinctrl.h>
 #include <kernel.h>
 #include <stm32_ll_rcc.h>
+#include <logging/log.h>
+
 #include "can_mcan.h"
 
-#include <logging/log.h>
-LOG_MODULE_DECLARE(can_driver, CONFIG_CAN_LOG_LEVEL);
+LOG_MODULE_REGISTER(can_stm32h7, CONFIG_CAN_LOG_LEVEL);
 
 #define DT_DRV_COMPAT st_stm32h7_fdcan
 


### PR DESCRIPTION
Use separate log modules for each CAN driver similar to other sub-systems/driver classes.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>