### PR TITLE
drivers: can: unify CAN controller configuration in devicetree

### DIFF
--- a/boards/arm/nucleo_f303re/nucleo_f303re.dts
+++ b/boards/arm/nucleo_f303re/nucleo_f303re.dts
@@ -86,9 +86,5 @@
 	pinctrl-0 = <&can_rx_pb8 &can_tx_pb9>;
 	pinctrl-names = "default";
 	bus-speed = <125000>;
-	sjw = <1>;
-	prop-seg = <0>;
-	phase-seg1 = <6>;
-	phase-seg2 = <5>;
 	status = "okay";
 };

--- a/boards/arm/nucleo_f446re/nucleo_f446re.dts
+++ b/boards/arm/nucleo_f446re/nucleo_f446re.dts
@@ -121,10 +121,6 @@
 	pinctrl-0 = <&can1_rx_pb8 &can1_tx_pb9>;
 	pinctrl-names = "default";
 	bus-speed = <125000>;
-	sjw = <1>;
-	prop-seg = <0>;
-	phase-seg1 = <6>;
-	phase-seg2 = <5>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f446ze/nucleo_f446ze.dts
+++ b/boards/arm/nucleo_f446ze/nucleo_f446ze.dts
@@ -169,10 +169,6 @@ zephyr_udc0: &usbotg_fs {
 	pinctrl-0 = <&can1_rx_pd0 &can1_tx_pd1>;
 	pinctrl-names = "default";
 	bus-speed = <125000>;
-	sjw = <1>;
-	prop-seg = <0>;
-	phase-seg1 = <6>;
-	phase-seg2 = <5>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f746zg/nucleo_f746zg.dts
+++ b/boards/arm/nucleo_f746zg/nucleo_f746zg.dts
@@ -148,10 +148,6 @@ zephyr_udc0: &usbotg_fs {
 	pinctrl-0 = <&can1_rx_pd0 &can1_tx_pd1>;
 	pinctrl-names = "default";
 	bus-speed = <125000>;
-	sjw = <1>;
-	prop-seg = <0>;
-	phase-seg1 = <6>;
-	phase-seg2 = <5>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f767zi/nucleo_f767zi.dts
+++ b/boards/arm/nucleo_f767zi/nucleo_f767zi.dts
@@ -155,10 +155,6 @@ zephyr_udc0: &usbotg_fs {
 	pinctrl-0 = <&can1_rx_pd0 &can1_tx_pd1>;
 	pinctrl-names = "default";
 	bus-speed = <125000>;
-	sjw = <1>;
-	prop-seg = <0>;
-	phase-seg1 = <6>;
-	phase-seg2 = <5>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_g474re/nucleo_g474re.dts
+++ b/boards/arm/nucleo_g474re/nucleo_g474re.dts
@@ -177,10 +177,6 @@
 	pinctrl-0 = <&fdcan1_rx_pa11 &fdcan1_tx_pa12>;
 	pinctrl-names = "default";
 	bus-speed = <125000>;
-	sjw = <1>;
-	sample-point = <875>;
 	bus-speed-data = <1000000>;
-	sjw-data = <1>;
-	sample-point-data = <875>;
 	status = "okay";
 };

--- a/boards/arm/olimexino_stm32/olimexino_stm32.dts
+++ b/boards/arm/olimexino_stm32/olimexino_stm32.dts
@@ -152,9 +152,5 @@ zephyr_udc0: &usb {
 	pinctrl-0 = <&can_rx_pb8 &can_tx_pb9>;
 	pinctrl-names = "default";
 	bus-speed = <125000>;
-	sjw = <1>;
-	prop-seg = <0>;
-	phase-seg1 = <5>;
-	phase-seg2 = <6>;
 	status = "okay";
 };

--- a/boards/arm/rcar_h3ulcb/rcar_h3ulcb_cr7.dts
+++ b/boards/arm/rcar_h3ulcb/rcar_h3ulcb_cr7.dts
@@ -55,6 +55,7 @@
 	pinctrl-0 = <&can0_data_a_tx_default &can0_data_a_rx_default>;
 	pinctrl-names = "default";
 	status = "okay";
+	bus-speed = <125000>;
 };
 
 &scif1 {

--- a/boards/arm/sam_e70_xplained/sam_e70_xplained-common.dtsi
+++ b/boards/arm/sam_e70_xplained/sam_e70_xplained-common.dtsi
@@ -156,9 +156,5 @@ zephyr_udc0: &usbhs {
 	status = "okay";
 	pinctrl-0 = <&pb3a_can0_rx0 &pb2a_can0_tx0>;
 	bus-speed = <125000>;
-	sjw = <1>;
-	sample-point = <875>;
 	bus-speed-data = <1000000>;
-	sjw-data = <1>;
-	sample-point-data = <875>;
 };

--- a/boards/arm/sam_v71_xult/sam_v71_xult-common.dtsi
+++ b/boards/arm/sam_v71_xult/sam_v71_xult-common.dtsi
@@ -290,11 +290,7 @@ zephyr_udc0: &usbhs {
 	status = "okay";
 	pinctrl-0 = <&pc12c_can1_rx1 &pc14c_can1_tx1>;
 	bus-speed = <125000>;
-	sjw = <1>;
-	sample-point = <875>;
 	bus-speed-data = <1000000>;
-	sjw-data = <1>;
-	sample-point-data = <875>;
 };
 
 ext1_spi: &spi0 {

--- a/boards/arm/stm32f3_disco/stm32f3_disco.dts
+++ b/boards/arm/stm32f3_disco/stm32f3_disco.dts
@@ -169,6 +169,7 @@ zephyr_udc0: &usb {
 	pinctrl-0 = <&can_rx_pd0 &can_tx_pd1>;
 	pinctrl-names = "default";
 	status = "okay";
+	bus-speed = <125000>;
 };
 
 &flash0 {

--- a/boards/arm/waveshare_open103z/waveshare_open103z.dts
+++ b/boards/arm/waveshare_open103z/waveshare_open103z.dts
@@ -148,10 +148,6 @@
 	 */
 	status = "disabled";
 	bus-speed = <125000>;
-	sjw = <1>;
-	prop-seg = <0>;
-	phase-seg1 = <5>;
-	phase-seg2 = <6>;
 };
 
 zephyr_udc0: &usb {

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -467,6 +467,10 @@
 				interrupts = <35 0>, <36 0>;
 				interrupt-names = "LINE_0", "LINE_1";
 				peripheral-id = <35>;
+				sjw = <1>;
+				sample-point = <875>;
+				sjw-data = <1>;
+				sample-point-data = <875>;
 				status = "disabled";
 				label = "CAN_0";
 			};
@@ -480,6 +484,10 @@
 				interrupts = <37 0>, <38 0>;
 				interrupt-names = "LINE_0", "LINE_1";
 				peripheral-id = <37>;
+				sjw = <1>;
+				sample-point = <875>;
+				sjw-data = <1>;
+				sample-point-data = <875>;
 				status = "disabled";
 				label = "CAN_1";
 			};

--- a/dts/arm/nxp/nxp_k66.dtsi
+++ b/dts/arm/nxp/nxp_k66.dtsi
@@ -32,9 +32,7 @@
 			clk-source = <1>;
 			label = "CAN_1";
 			sjw = <1>;
-			prop-seg = <1>;
-			phase-seg1 = <3>;
-			phase-seg2 = <2>;
+			sample-point = <875>;
 			status = "disabled";
 		  };
 	};

--- a/dts/arm/renesas/gen3/rcar_gen3_cr7.dtsi
+++ b/dts/arm/renesas/gen3/rcar_gen3_cr7.dtsi
@@ -99,11 +99,8 @@
 					IRQ_DEFAULT_PRIORITY>;
 			clocks = <&cpg CPG_MOD 916>,
 				<&cpg CPG_CORE CPG_CORE_CLK_CANFD>;
-			bus-speed = <125000>;
 			sjw = <1>;
-			prop-seg = <8>;
-			phase-seg1 = <8>;
-			phase-seg2 = <3>;
+			sample-point = <875>;
 			status = "disabled";
 			label = "can0";
 		};

--- a/dts/arm/st/f0/stm32f072.dtsi
+++ b/dts/arm/st/f0/stm32f072.dtsi
@@ -75,11 +75,8 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			status = "disabled";
 			label = "CAN_1";
-			bus-speed = <250000>;
 			sjw = <1>;
-			prop-seg = <0>;
-			phase-seg1 = <5>;
-			phase-seg2 = <6>;
+			sample-point = <875>;
 		};
 
 		dac1: dac@40007400 {

--- a/dts/arm/st/f1/stm32f103X8.dtsi
+++ b/dts/arm/st/f1/stm32f103X8.dtsi
@@ -56,6 +56,8 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			status = "disabled";
 			label = "CAN_1";
+			sjw = <1>;
+			sample-point = <875>;
 		};
 	};
 

--- a/dts/arm/st/f1/stm32f105.dtsi
+++ b/dts/arm/st/f1/stm32f105.dtsi
@@ -39,11 +39,8 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			status = "disabled";
 			label = "CAN_1";
-			bus-speed = <250000>;
 			sjw = <1>;
-			prop-seg = <0>;
-			phase-seg1 = <5>;
-			phase-seg2 = <6>;
+			sample-point = <875>;
 		};
 
 		can2: can@40006800 {
@@ -54,11 +51,8 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x04000000>;
 			status = "disabled";
 			label = "CAN_2";
-			bus-speed = <250000>;
 			sjw = <1>;
-			prop-seg = <0>;
-			phase-seg1 = <5>;
-			phase-seg2 = <6>;
+			sample-point = <875>;
 		};
 
 		uart4: serial@40004c00 {

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -383,11 +383,8 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			status = "disabled";
 			label = "CAN_1";
-			bus-speed = <125000>;
 			sjw = <1>;
-			prop-seg = <0>;
-			phase-seg1 = <5>;
-			phase-seg2 = <6>;
+			sample-point = <875>;
 		};
 
 		dma1: dma@40020000 {

--- a/dts/arm/st/f4/stm32f405.dtsi
+++ b/dts/arm/st/f4/stm32f405.dtsi
@@ -217,11 +217,8 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			status = "disabled";
 			label = "CAN_1";
-			bus-speed = <125000>;
 			sjw = <1>;
-			prop-seg = <0>;
-			phase-seg1 = <5>;
-			phase-seg2 = <6>;
+			sample-point = <875>;
 		};
 
 		can2: can@40006800 {
@@ -233,11 +230,8 @@
 			master-can-reg = <0x40006400>;
 			status = "disabled";
 			label = "CAN_2";
-			bus-speed = <125000>;
 			sjw = <1>;
-			prop-seg = <0>;
-			phase-seg1 = <5>;
-			phase-seg2 = <6>;
+			sample-point = <875>;
 		};
 
 		rng: rng@50060800 {

--- a/dts/arm/st/f4/stm32f446.dtsi
+++ b/dts/arm/st/f4/stm32f446.dtsi
@@ -58,11 +58,8 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			status = "disabled";
 			label = "CAN_1";
-			bus-speed = <125000>;
 			sjw = <1>;
-			prop-seg = <0>;
-			phase-seg1 = <5>;
-			phase-seg2 = <6>;
+			sample-point = <875>;
 		};
 
 		can2: can@40006800 {
@@ -74,11 +71,8 @@
 			master-can-reg = <0x40006400>;
 			status = "disabled";
 			label = "CAN_2";
-			bus-speed = <125000>;
 			sjw = <1>;
-			prop-seg = <0>;
-			phase-seg1 = <5>;
-			phase-seg2 = <6>;
+			sample-point = <875>;
 		};
 
 		usbotg_fs: usb@50000000 {

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -400,6 +400,8 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			status = "disabled";
 			label = "CAN_1";
+			sjw = <1>;
+			sample-point = <875>;
 		};
 
 		timers1: timers@40010000 {

--- a/dts/arm/st/f7/stm32f745.dtsi
+++ b/dts/arm/st/f7/stm32f745.dtsi
@@ -75,6 +75,8 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x04000000>;
 			status = "disabled";
 			label = "CAN_2";
+			sjw = <1>;
+			sample-point = <875>;
 		};
 
 		mac: ethernet@40028000 {

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -367,6 +367,10 @@
 				interrupt-names = "LINE_0", "LINE_1";
 				status = "disabled";
 				label = "CAN_1";
+				sjw = <1>;
+				sample-point = <875>;
+				sjw-data = <1>;
+				sample-point-data = <875>;
 			};
 		};
 

--- a/dts/arm/st/g4/stm32g474.dtsi
+++ b/dts/arm/st/g4/stm32g474.dtsi
@@ -17,6 +17,10 @@
 				interrupt-names = "LINE_0", "LINE_1";
 				status = "disabled";
 				label = "CAN_2";
+				sjw = <1>;
+				sample-point = <875>;
+				sjw-data = <1>;
+				sample-point-data = <875>;
 			};
 
 			can3: can@40006C00 {
@@ -27,6 +31,10 @@
 				interrupt-names = "LINE_0", "LINE_1";
 				status = "disabled";
 				label = "CAN_3";
+				sjw = <1>;
+				sample-point = <875>;
+				sjw-data = <1>;
+				sample-point-data = <875>;
 			};
 		};
 

--- a/dts/arm/st/l4/stm32l432.dtsi
+++ b/dts/arm/st/l4/stm32l432.dtsi
@@ -38,11 +38,8 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>; //RCC_APB1ENR1_CAN1EN
 			status = "disabled";
 			label = "CAN_1";
-			bus-speed = <125000>;
 			sjw = <1>;
-			prop-seg = <0>;
-			phase-seg1 = <4>;
-			phase-seg2 = <5>;
+			sample-point = <875>;
 		};
 
 		usb: usb@40006800 {

--- a/dts/arm/st/l4/stm32l452.dtsi
+++ b/dts/arm/st/l4/stm32l452.dtsi
@@ -143,11 +143,8 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>; //RCC_APB1ENR1_CAN1EN
 			status = "disabled";
 			label = "CAN_1";
-			bus-speed = <125000>;
 			sjw = <1>;
-			prop-seg = <0>;
-			phase-seg1 = <4>;
-			phase-seg2 = <5>;
+			sample-point = <875>;
 		};
 	};
 

--- a/dts/arm/st/l4/stm32l471.dtsi
+++ b/dts/arm/st/l4/stm32l471.dtsi
@@ -218,11 +218,8 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>; //RCC_APB1ENR1_CAN1EN
 			status = "disabled";
 			label = "CAN_1";
-			bus-speed = <125000>;
 			sjw = <1>;
-			prop-seg = <0>;
-			phase-seg1 = <4>;
-			phase-seg2 = <5>;
+			sample-point = <875>;
 		};
 
 		sdmmc1: sdmmc@40012800 {

--- a/dts/arm/st/l4/stm32l4r5.dtsi
+++ b/dts/arm/st/l4/stm32l4r5.dtsi
@@ -248,11 +248,8 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>; //RCC_APB1ENR1_CAN1EN
 			status = "disabled";
 			label = "CAN_1";
-			bus-speed = <125000>;
 			sjw = <1>;
-			prop-seg = <0>;
-			phase-seg1 = <4>;
-			phase-seg2 = <5>;
+			sample-point = <875>;
 		};
 
 		usbotg_fs: otgfs@50000000 {

--- a/tests/drivers/build_all/sensor/spi.dtsi
+++ b/tests/drivers/build_all/sensor/spi.dtsi
@@ -137,9 +137,7 @@ test_spi_mcp2515: mcp2515@12 {
 	int-gpios = <&test_gpio 0 0>;
 	bus-speed = <0>;
 	sjw = <0>;
-	prop-seg = <0>;
-	phase-seg1 = <0>;
-	phase-seg2 = <0>;
+	sample-point = <875>;
 };
 
 test_spi_mcr20a: mcr20a@13 {


### PR DESCRIPTION
Unify the CAN controller configuration done in Zephyr devicetrees:

- Specify a resynchronization jump width (sjw) of 1 time quanta in SoC devicetrees as this is the most common. Boards can override this if needed.
- Specify a sample point of 87.5% as recommended by CAN in Automation (CiA) in SoC devicetrees. Boards can override this if needed.
- Specify a bus speed of 125 kbits/second (arbitration phase) and 1 Mbits/second (CAN-FD data phase) in board devicetrees as this is what is used by all Zephyr CAN samples.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>