### PR TITLE
net: openthread: add assert which checks settings wipe failure

### DIFF
--- a/subsys/net/lib/openthread/platform/settings.c
+++ b/subsys/net/lib/openthread/platform/settings.c
@@ -306,9 +306,15 @@ otError otPlatSettingsDelete(otInstance *aInstance, uint16_t aKey, int aIndex)
 
 void otPlatSettingsWipe(otInstance *aInstance)
 {
+	int ret;
+
 	ARG_UNUSED(aInstance);
 
-	(void)ot_setting_delete_subtree(-1, -1);
+	ret = ot_setting_delete_subtree(-1, -1);
+	if (ret != 0) {
+		LOG_ERR("Failed to delete OT subtree");
+		__ASSERT_NO_MSG(false);
+	}
 }
 
 void otPlatSettingsDeinit(otInstance *aInstance)


### PR DESCRIPTION
If settings wipe fails we are not informed about this what can lead to
bugs which are hard to investigate.
This commit adds assert which checks the possible failure.

Signed-off-by: Lukasz Maciejonczyk <lukasz.maciejonczyk@nordicsemi.no>