### PR TITLE
drivers: ieee802154_nrf5: add log for rx failure

### DIFF
--- a/drivers/ieee802154/Kconfig.nrf5
+++ b/drivers/ieee802154/Kconfig.nrf5
@@ -83,4 +83,14 @@ config IEEE802154_NRF5_DELAY_TRX_ACC
 	  Accuracy of the clock used for scheduling radio delayed operations (delayed transmission
 	  or delayed reception), in ppm.
 
+config IEEE802154_NRF5_LOG_RX_FAILURES
+	bool "Frame reception failures logging"
+	help
+	  There are few cases where the frame reception failure can happen because of
+	  internal cause. These cases are reported forward by general code error.
+
+	  This options enables logging the reason of frame reception failure.
+	  It can be helpful for the network traffic analyze but it generates also
+	  a lot of log records in a stress environment.
+
 endif

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -1005,7 +1005,9 @@ void nrf_802154_receive_failed(nrf_802154_rx_error_t error, uint32_t id)
 	if ((id == DRX_SLOT_PH) || (id == DRX_SLOT_RX)) {
 		__ASSERT_NO_MSG(nrf5_data.event_handler);
 		nrf5_data.event_handler(dev, IEEE802154_EVENT_SLEEP, NULL);
-		return;
+		if (error == NRF_802154_RX_ERROR_DELAYED_TIMEOUT) {
+			return;
+		}
 	}
 #else
 	ARG_UNUSED(id);

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -1032,6 +1032,10 @@ void nrf_802154_receive_failed(nrf_802154_rx_error_t error, uint32_t id)
 		break;
 	}
 
+	if (IS_ENABLED(CONFIG_IEEE802154_NRF5_LOG_RX_FAILURES)) {
+		LOG_INF("Rx failed, error = %d", error);
+	}
+
 	nrf5_data.last_frame_ack_fpb = false;
 	if (nrf5_data.event_handler) {
 		nrf5_data.event_handler(dev, IEEE802154_EVENT_RX_FAILED, (void *)&reason);


### PR DESCRIPTION
Some failures are possible and expected from fime to time e.g.
NRF_802154_RX_ERROR_TIMESLOT_ENDED. Add informational log for the frame
reception failure to differentiate the specific case.
It can be helpful for analizing failure in network trafic.

Signed-off-by: Lukasz Maciejonczyk <lukasz.maciejonczyk@nordicsemi.no>