### PR TITLE
Bluetooth: Mesh: Disable pb_adv_reprovision

### DIFF
--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/tests_scripts/provision/pb_adv_reprovision.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/tests_scripts/provision/pb_adv_reprovision.sh
@@ -4,6 +4,7 @@
 
 source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
 
-RunTest mesh_provision_pb_adv_reprovision \
-	prov_device_pb_adv_reprovision \
-	prov_provisioner_pb_adv_reprovision
+# TODO: Disabled as a hotfix
+# RunTest mesh_provision_pb_adv_reprovision \
+# 	prov_device_pb_adv_reprovision \
+# 	prov_provisioner_pb_adv_reprovision


### PR DESCRIPTION
pb_adv_reprovision is failing in CI, but the error cannot be reproduced
locally. Disable the test as a hotfix for main, so we can determine the
issue and re-enable the test in a separate PR.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>