### PR TITLE
Bluetooth: Mesh: Re-enable pb_adv_reprovision test

### DIFF
--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/_mesh_test.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/_mesh_test.sh
@@ -9,7 +9,7 @@ function Execute(){
  compile it?)\e[39m"
     exit 1
   fi
-  timeout 20 $@ & process_ids="$process_ids $!"
+  timeout 300 $@ & process_ids="$process_ids $!"
 }
 
 function Skip(){

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_provision.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_provision.c
@@ -28,7 +28,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
  */
 
 #define PROV_MULTI_COUNT 3
-#define PROV_REPROV_COUNT 10
+#define PROV_REPROV_COUNT 3
 #define WAIT_TIME 80 /*seconds*/
 
 enum test_flags {

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/tests_scripts/provision/pb_adv_reprovision.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/tests_scripts/provision/pb_adv_reprovision.sh
@@ -4,7 +4,6 @@
 
 source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
 
-# TODO: Disabled as a hotfix
-# RunTest mesh_provision_pb_adv_reprovision \
-# 	prov_device_pb_adv_reprovision \
-# 	prov_provisioner_pb_adv_reprovision
+RunTest mesh_provision_pb_adv_reprovision \
+	prov_device_pb_adv_reprovision \
+	prov_provisioner_pb_adv_reprovision


### PR DESCRIPTION
Re-enables the pb_adv_reprovision test that was disabled in #43070, with the following improvements to fix the failing test:
* Increases the wallclock timeout for the mesh tests from 20 to 60 seconds. 

  The wallclock time timeout of the test execution is limited to let CI
  abandon hanging test cases. Increase this timeout to account for
  additional tests running in parallel in CI, which has caused enough
  resource contention to make CI break the time limit.
* Bluetooth: Mesh: Reduce number of reprovision runs in test

  The pb_adv_reprovision test takes a long time to execute, as it's
  running 10 provisioning sessions in a row. Any side effects from the
  provisioning process should come into play already on the first
  reprovisioning, so we can safely reduce this to only 3 provisioning runs
  without losing any test coverage.