### PR TITLE
toolchain: drop the old Z_ prefixed iterables macro

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -3683,7 +3683,7 @@ endmacro()
 #
 #
 # Define an output section which will set up an iterable area
-# of equally-sized data structures. For use with Z_STRUCT_SECTION_ITERABLE.
+# of equally-sized data structures. For use with STRUCT_SECTION_ITERABLE.
 # Input sections will be sorted by name in lexicographical order.
 #
 # Each list for an input section will define the following linker symbols:

--- a/include/linker/linker-defs.h
+++ b/include/linker/linker-defs.h
@@ -78,9 +78,6 @@
 		Z_LINK_ITERABLE(struct_type); \
 	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
-#define Z_ITERABLE_SECTION_ROM(struct_type, subalign) \
-	ITERABLE_SECTION_ROM(struct_type, subalign)
-
 /**
  * @brief Define a garbage collectable read-only iterable section output.
  *
@@ -98,9 +95,6 @@
 	{ \
 		Z_LINK_ITERABLE_GC_ALLOWED(struct_type); \
 	} GROUP_LINK_IN(ROMABLE_REGION)
-
-#define Z_ITERABLE_SECTION_ROM_GC_ALLOWED(struct_type, subalign) \
-	ITERABLE_SECTION_ROM_GC_ALLOWED(struct_type, subalign)
 
 /**
  * @brief Define a read-write iterable section output.
@@ -122,9 +116,6 @@
 		Z_LINK_ITERABLE(struct_type); \
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
-#define Z_ITERABLE_SECTION_RAM(struct_type, subalign) \
-	ITERABLE_SECTION_RAM(struct_type, subalign)
-
 /**
  * @brief Define a garbage collectable read-write iterable section output.
  *
@@ -142,9 +133,6 @@
 	{ \
 		Z_LINK_ITERABLE_GC_ALLOWED(struct_type); \
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
-
-#define Z_ITERABLE_SECTION_RAM_GC_ALLOWED(struct_type, subalign) \
-	ITERABLE_SECTION_RAM_GC_ALLOWED(struct_type, subalign)
 
 /**
  * @}

--- a/include/toolchain/common.h
+++ b/include/toolchain/common.h
@@ -211,10 +211,6 @@
 	Z_DECL_ALIGN(struct struct_type) name \
 	__in_section(_##struct_type, static, name) __used
 
-#define Z_STRUCT_SECTION_ITERABLE(struct_type, name) \
-	__DEPRECATED_MACRO \
-	STRUCT_SECTION_ITERABLE(struct_type, name)
-
 /**
  * @brief Defines an alternate data type iterable section.
  *
@@ -226,10 +222,6 @@
 #define STRUCT_SECTION_ITERABLE_ALTERNATE(out_type, struct_type, name) \
 	Z_DECL_ALIGN(struct struct_type) name \
 	__in_section(_##out_type, static, name) __used
-
-#define Z_STRUCT_SECTION_ITERABLE_ALTERNATE(out_type, struct_type, name) \
-	__DEPRECATED_MACRO \
-	STRUCT_SECTION_ITERABLE_ALTERNATE(out_type, struct_type, name)
 
 /**
  * @brief Iterate over a specified iterable section.
@@ -250,10 +242,6 @@
 			 "unexpected list end location"); \
 		iterator < _CONCAT(_##struct_type, _list_end); }); \
 	     iterator++)
-
-#define Z_STRUCT_SECTION_FOREACH(struct_type, iterator) \
-	__DEPRECATED_MACRO \
-	STRUCT_SECTION_FOREACH(struct_type, iterator)
 
 /**
  * @}


### PR DESCRIPTION
Hi, wrapping the work on de-Z_fying the iterables section macros, the rename and deprecation flags went in during the 2.7 merge window, this is dropping the old ones now that 3.0 has been cut.
 
(sent this originally as #39634 but that was too early for the two cycle removal, this is the same patch rebased)