### PR TITLE
soc: xtensa: adsp: Fix i.MX8 hw_cycles_per_sec definition

### DIFF
--- a/soc/xtensa/nxp_adsp/imx8/Kconfig.defconfig.series
+++ b/soc/xtensa/nxp_adsp/imx8/Kconfig.defconfig.series
@@ -22,7 +22,7 @@ config XTENSA_TIMER
 	default y
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	default 400000000 if XTENSA_TIMER
+	default 666000000 if XTENSA_TIMER
 
 config SYS_CLOCK_TICKS_PER_SEC
 	default 50000

--- a/soc/xtensa/nxp_adsp/imx8m/Kconfig.defconfig.series
+++ b/soc/xtensa/nxp_adsp/imx8m/Kconfig.defconfig.series
@@ -22,7 +22,7 @@ config XTENSA_TIMER
 	default y
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	default 400000000 if XTENSA_TIMER
+	default 800000000 if XTENSA_TIMER
 
 config SYS_CLOCK_TICKS_PER_SEC
 	default 50000


### PR DESCRIPTION
Acorrding to RM, HIFI4 DSP default configured frequency is:
	- 666Mhz for i.MX8
	- 800Mhz for i.MX8M

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>