### PR TITLE
[CI fix] boards: arm: add missing memory-region compatible to stm32h7b3i_dk

### DIFF
--- a/boards/arm/stm32h7b3i_dk/stm32h7b3i_dk.dts
+++ b/boards/arm/stm32h7b3i_dk/stm32h7b3i_dk.dts
@@ -41,7 +41,7 @@
 	};
 
 	sdram2: sdram@d0000000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		device_type = "memory";
 		reg = <0xd0000000 DT_SIZE_M(16)>;
 		zephyr,memory-region = "SDRAM2";


### PR DESCRIPTION
Hi, quick fix for stm32h7b3i_dk dts, the board support and API change have been merged separately and the CI is currently broken. Tested with

`$ west build -p -b stm32h7b3i_dk tests/kernel/common` and `$ west build -p -b stm32h7b3i_dk samples/synchronization`.

-- 8< --

Add missing compatible = "zephyr,memory-region" to the sdram2 node for
stm32h7b3i_dk.dts. This is required since 18ffcdcf74.

Signed-off-by: Fabio Baltieri <fabiobaltieri@google.com>