### PR TITLE
drivers: i2c: MEC15xx: Improved error handling

### DIFF
--- a/boards/arm/mec1501modular_assy6885/mec1501modular_assy6885.dts
+++ b/boards/arm/mec1501modular_assy6885/mec1501modular_assy6885.dts
@@ -60,12 +60,16 @@
 	status = "okay";
 	label = "I2C0";
 	port_sel = <0>;
+	sda-gpios = <&gpio_000_036 3 0>;
+	scl-gpios = <&gpio_000_036 4 0>;
 };
 
 &i2c_smb_1 {
 	status = "okay";
 	label = "I2C1";
 	port_sel = <1>;
+	sda-gpios = <&gpio_100_136 24 0>;
+	scl-gpios = <&gpio_100_136 25 0>;
 };
 
 &espi0 {

--- a/boards/arm/mec15xxevb_assy6853/mec15xxevb_assy6853.dts
+++ b/boards/arm/mec15xxevb_assy6853/mec15xxevb_assy6853.dts
@@ -88,6 +88,8 @@
 	status = "okay";
 	label = "I2C0";
 	port_sel = <0>;
+	sda-gpios = <&gpio_000_036 3 0>;
+	scl-gpios = <&gpio_000_036 4 0>;
 
 	pca9555@26 {
 		compatible = "nxp,pca95xx";
@@ -111,12 +113,16 @@
 	status = "okay";
 	label = "I2C1";
 	port_sel = <1>;
+	sda-gpios = <&gpio_100_136 24 0>;
+	scl-gpios = <&gpio_100_136 25 0>;
 };
 
 &i2c_smb_2 {
 	status = "okay";
 	label = "I2C7";
 	port_sel = <7>;
+	sda-gpios = <&gpio_000_036 10 0>;
+	scl-gpios = <&gpio_000_036 11 0>;
 };
 
 &espi0 {

--- a/dts/bindings/i2c/microchip,xec-i2c.yaml
+++ b/dts/bindings/i2c/microchip,xec-i2c.yaml
@@ -25,3 +25,17 @@ properties:
       type: int
       required: true
       description: Bit position in GIRQ for this device
+
+    sda-gpios:
+      type: phandle-array
+      required: true
+      description: |
+        The SDA pin for the selected port. Pin choice for port is
+        determined by chip and package.
+
+    scl-gpios:
+      type: phandle-array
+      required: true
+      description: |
+        The SCL pin for the selected port. Pin choice for port is
+        determined by chip and package.


### PR DESCRIPTION
Improved Error handling for MEC15xx i2c driver

1. Check I2C Clock and Data is high through GPIO driver instead of the I2C bitbang registers

2. i2c_xec_poll_write() and i2c_xec_poll_read() will poll to check I2C clock and data lines are high before initiating the
transaction. The polling will be every 25us for a cumulative max of 2.5ms

3. wait_completion() will not call recover_from_error() to reset the controller. Instead will poll for 10ms for the PIN bit to
clear before returning error.

4. wait_completion() will send STOP if the 9th bit is NACK

5. If any errors with current transaction:
(a) Set error_seen flag.
(b) In the next transaction do the recovery process (reset the i2c controller) if the clk and data lines are high.
Note: error_seen flag is set for Address NACK with Repeated Start as well.

6. If timeout error occurs in wait_completion():
(a) Set timeout_seen flag;
(b) Wait till the slave will release the clock.
(c) Once slave releases clock send STOP on the bus. 
     If the timeout occurred while master read, read the I2C DATA register for the hardware to proceed.

Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>