### PR TITLE
doc: silent filtered warnings

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -221,7 +221,6 @@ html_redirect_pages = redirects.REDIRECTS
 # -- Options for zephyr.warnings_filter -----------------------------------
 
 warnings_filter_config = str(ZEPHYR_BASE / "doc" / "known-warnings.txt")
-warnings_filter_silent = False
 
 # -- Options for notfound.extension ---------------------------------------
 


### PR DESCRIPTION
The filtered warnings are warnings we can't fix due to Sphinx
limitations, so showing them just adds noise to the doc build process.
The extension already defaults to silent mode.