### PR TITLE
pm: device: remove deprecated functions

### DIFF
--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -315,30 +315,6 @@ struct pm_device {
 const char *pm_device_state_str(enum pm_device_state state);
 
 /**
- * @brief Set the power state of a device.
- *
- * @deprecated Use pm_device_action_run() instead.
- *
- * This function calls the device PM control callback so that the device does
- * the necessary operations to put the device into the given state.
- *
- * @note Some devices may not support all device power states.
- *
- * @param dev Device instance.
- * @param state Device power state to be set.
- *
- * @retval 0 If successful.
- * @retval -ENOTSUP If requested state is not supported.
- * @retval -EALREADY If device is already at the requested state.
- * @retval -EBUSY If device is changing its state.
- * @retval -ENOSYS If device does not support PM.
- * @retval -EPERM If device has power state locked.
- * @retval Errno Other negative errno on failure.
- */
-__deprecated int pm_device_state_set(const struct device *dev,
-			enum pm_device_state state);
-
-/**
  * @brief Obtain the power state of a device.
  *
  * @param dev Device instance.
@@ -557,58 +533,6 @@ static inline bool pm_device_on_power_domain(const struct device *dev)
 	return false;
 }
 #endif /* CONFIG_PM_DEVICE */
-
-/**
- * Mark a device as busy.
- *
- * @deprecated Use pm_device_busy_set() instead
- *
- * @param dev Device instance.
- */
-__deprecated static inline void device_busy_set(const struct device *dev)
-{
-	pm_device_busy_set(dev);
-}
-
-/**
- * @brief Clear busy status of a device.
- *
- * @deprecated Use pm_device_busy_clear() instead
- *
- * @param dev Device instance.
- */
-__deprecated static inline void device_busy_clear(const struct device *dev)
-{
-	pm_device_busy_clear(dev);
-}
-
-/**
- * @brief Check if any device is busy.
- *
- * @deprecated Use pm_device_is_any_busy() instead
- *
- * @retval 0 No devices are busy.
- * @retval -EBUSY One or more devices are busy.
- */
-__deprecated static inline int device_any_busy_check(void)
-{
-	return pm_device_is_any_busy() ? -EBUSY : 0;
-}
-
-/**
- * @brief Check if a device is busy.
- *
- * @deprecated Use pm_device_is_busy() instead
- *
- * @param dev Device instance.
- *
- * @retval 0 Device is not busy.
- * @retval -EBUSY Device is busy.
- */
-__deprecated static inline int device_busy_check(const struct device *dev)
-{
-	return pm_device_is_busy(dev) ? -EBUSY : 0;
-}
 
 /** @} */
 

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -25,59 +25,6 @@ const char *pm_device_state_str(enum pm_device_state state)
 	}
 }
 
-int pm_device_state_set(const struct device *dev,
-			enum pm_device_state state)
-{
-	int ret;
-	enum pm_device_action action;
-	struct pm_device *pm = dev->pm;
-
-	if (pm == NULL) {
-		return -ENOSYS;
-	}
-
-	if (pm_device_state_is_locked(dev)) {
-		return -EPERM;
-	}
-
-	switch (state) {
-	case PM_DEVICE_STATE_SUSPENDED:
-		if (pm->state == PM_DEVICE_STATE_SUSPENDED) {
-			return -EALREADY;
-		} else if (pm->state == PM_DEVICE_STATE_OFF) {
-			return -ENOTSUP;
-		}
-
-		action = PM_DEVICE_ACTION_SUSPEND;
-		break;
-	case PM_DEVICE_STATE_ACTIVE:
-		if (pm->state == PM_DEVICE_STATE_ACTIVE) {
-			return -EALREADY;
-		}
-
-		action = PM_DEVICE_ACTION_RESUME;
-		break;
-	case PM_DEVICE_STATE_OFF:
-		if (pm->state == state) {
-			return -EALREADY;
-		}
-
-		action = PM_DEVICE_ACTION_TURN_OFF;
-		break;
-	default:
-		return -ENOTSUP;
-	}
-
-	ret = pm->action_cb(dev, action);
-	if (ret < 0) {
-		return ret;
-	}
-
-	pm->state = state;
-
-	return 0;
-}
-
 int pm_device_action_run(const struct device *dev,
 			 enum pm_device_action action)
 {


### PR DESCRIPTION
Remove deprecated functions in the previous release. Note that PM API is
not marked as stable.