### PR TITLE
[hotfix] soc: nrf: remove use of NRF_GPIO_PIN_MAP

### DIFF
--- a/soc/arm/nordic_nrf/common/soc_nrf_common.h
+++ b/soc/arm/nordic_nrf/common/soc_nrf_common.h
@@ -127,9 +127,8 @@
  *     NRF_DT_GPIOS_TO_PSEL_BY_IDX(DT_NODELABEL(foo), rx_gpios, 1) // 32 + 5 = 37
  */
 #define NRF_DT_GPIOS_TO_PSEL_BY_IDX(node_id, prop, idx)			\
-	NRF_GPIO_PIN_MAP(						\
-		DT_PROP_BY_PHANDLE_IDX(node_id, prop, idx, port),	\
-		DT_GPIO_PIN_BY_IDX(node_id, prop, idx))
+	((DT_PROP_BY_PHANDLE_IDX(node_id, prop, idx, port) << 5) |	\
+	 (DT_GPIO_PIN_BY_IDX(node_id, prop, idx) & 0x1F))
 
 
 /**


### PR DESCRIPTION
Commit 7cdd10bf89ff2512f5d12ee2658ff8dc31d30b85
("soc: arm: nordic: add NRF_DT_GPIOS_TO_PSEL_BY_IDX") added a use of
NRF_GPIO_PIN_MAP to soc_nrf_common.h without including the relevant
HAL header where it is defined, hal/nrf_gpio.h.

Unfortunately, including that header causes even more problems, since
it causes undefined NRFX_ASSERT() calls to appear elsewhere in the
tree.

It's not really worth bothering to use this macro. Just expand it
inline instead.
