### PR TITLE
SPI: async methods update

### DIFF
--- a/drivers/spi/spi_b91.c
+++ b/drivers/spi/spi_b91.c
@@ -422,7 +422,7 @@ static int spi_b91_transceive_async(const struct device *dev,
 				    const struct spi_config *config,
 				    const struct spi_buf_set *tx_bufs,
 				    const struct spi_buf_set *rx_bufs,
-				    struct k_poll_signal *async)
+				    struct spi_async_method *async)
 {
 	ARG_UNUSED(dev);
 	ARG_UNUSED(config);

--- a/drivers/spi/spi_bitbang.c
+++ b/drivers/spi/spi_bitbang.c
@@ -208,7 +208,7 @@ static int spi_bitbang_transceive_async(const struct device *dev,
 				    const struct spi_config *spi_cfg,
 				    const struct spi_buf_set *tx_bufs,
 				    const struct spi_buf_set *rx_bufs,
-				    struct k_poll_signal *async)
+				    struct spi_async_method *async)
 {
 	return -ENOTSUP;
 }

--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -184,6 +184,18 @@ done:
 	return err;
 }
 
+#ifdef CONFIG_SPI_ASYNC
+static int spi_cc13xx_cc26xx_transceive_async(const struct device *dev,
+					      const struct spi_config *spi_cfg,
+					      const struct spi_buf_set *tx_bufs,
+					      const struct spi_buf_set *rx_bufs,
+					      struct spi_async_method *async)
+{
+	return -ENOTSUP;
+}
+#endif
+
+
 static int spi_cc13xx_cc26xx_release(const struct device *dev,
 				     const struct spi_config *config)
 {
@@ -240,6 +252,9 @@ static int spi_cc13xx_cc26xx_pm_action(const struct device *dev,
 
 static const struct spi_driver_api spi_cc13xx_cc26xx_driver_api = {
 	.transceive = spi_cc13xx_cc26xx_transceive,
+#ifdef CONFIG_SPI_ASYNC
+	.transceive_async = spi_cc13xx_cc26xx_transceive_async,
+#endif
 	.release = spi_cc13xx_cc26xx_release,
 };
 

--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -35,7 +35,7 @@ struct spi_context {
 	int sync_status;
 
 #ifdef CONFIG_SPI_ASYNC
-	struct k_poll_signal *signal;
+	struct spi_async_method *async;
 	bool asynchronous;
 #endif /* CONFIG_SPI_ASYNC */
 	const struct spi_buf *current_tx;
@@ -86,7 +86,7 @@ static inline bool spi_context_is_slave(struct spi_context *ctx)
 
 static inline void spi_context_lock(struct spi_context *ctx,
 				    bool asynchronous,
-				    struct k_poll_signal *signal,
+				    struct spi_asyn_method *async,
 				    const struct spi_config *spi_cfg)
 {
 	if ((spi_cfg->operation & SPI_LOCK_ON) &&
@@ -100,7 +100,7 @@ static inline void spi_context_lock(struct spi_context *ctx,
 
 #ifdef CONFIG_SPI_ASYNC
 	ctx->asynchronous = asynchronous;
-	ctx->signal = signal;
+	ctx->async = async;
 #endif /* CONFIG_SPI_ASYNC */
 }
 
@@ -178,7 +178,7 @@ static inline void spi_context_complete(struct spi_context *ctx, int status)
 		ctx->sync_status = status;
 		k_sem_give(&ctx->sync);
 	} else {
-		if (ctx->signal) {
+		if (ctx->async) {
 #ifdef CONFIG_SPI_SLAVE
 			if (spi_context_is_slave(ctx) && !status) {
 				/* Let's update the status so it tells

--- a/drivers/spi/spi_dw.c
+++ b/drivers/spi/spi_dw.c
@@ -339,7 +339,7 @@ static int transceive(const struct device *dev,
 		      const struct spi_buf_set *tx_bufs,
 		      const struct spi_buf_set *rx_bufs,
 		      bool asynchronous,
-		      struct k_poll_signal *signal)
+		      struct spi_async_method *async)
 {
 	const struct spi_dw_config *info = dev->config;
 	struct spi_dw_data *spi = dev->data;
@@ -347,7 +347,7 @@ static int transceive(const struct device *dev,
 	uint32_t reg_data;
 	int ret;
 
-	spi_context_lock(&spi->ctx, asynchronous, signal, config);
+	spi_context_lock(&spi->ctx, asynchronous, async, config);
 
 #ifdef CONFIG_PM_DEVICE
 	if (!pm_device_is_busy(dev)) {
@@ -460,7 +460,7 @@ static int spi_dw_transceive_async(const struct device *dev,
 				   const struct spi_config *config,
 				   const struct spi_buf_set *tx_bufs,
 				   const struct spi_buf_set *rx_bufs,
-				   struct k_poll_signal *async)
+				   struct spi_async_method *async)
 {
 	LOG_DBG("%p, %p, %p, %p", dev, tx_bufs, rx_bufs, async);
 

--- a/drivers/spi/spi_emul.c
+++ b/drivers/spi/spi_emul.c
@@ -84,6 +84,23 @@ static int spi_emul_io(const struct device *dev,
 	return api->io(emul, config, tx_bufs, rx_bufs);
 }
 
+#ifdef CONFIG_SPI_ASYNC
+static int spi_emul_io(const struct device *dev,
+		       const struct spi_config *config,
+		       const struct spi_buf_set *tx_bufs,
+		       const struct spi_buf_set *rx_bufs,
+		       struct spi_async_method *async)
+{
+	return -ENOTSUP;
+}
+#endif /* CONFIG_SPI_ASYNC */
+
+static int spi_emul_release(const struct device *dev,
+			    const struct spi_config *config)
+{
+	return -ENOTSUP;
+}
+
 /**
  * Set up a new emulator and add it to the list
  *
@@ -115,6 +132,10 @@ int spi_emul_register(const struct device *dev, const char *name,
 
 static struct spi_driver_api spi_emul_api = {
 	.transceive = spi_emul_io,
+#ifdef CONFIG_SPI_ASYNC
+	.transceive_async = spi_emul_io_async,
+#endif
+	.release = spi_emul_release
 };
 
 #define EMUL_LINK_AND_COMMA(node_id) {		\

--- a/drivers/spi/spi_esp32_spim.c
+++ b/drivers/spi/spi_esp32_spim.c
@@ -328,7 +328,7 @@ static int transceive(const struct device *dev,
 		      const struct spi_config *spi_cfg,
 		      const struct spi_buf_set *tx_bufs,
 		      const struct spi_buf_set *rx_bufs, bool asynchronous,
-		      struct k_poll_signal *signal)
+		      struct spi_async_method *async)
 {
 	const struct spi_esp32_config *cfg = dev->config;
 	struct spi_esp32_data *data = dev->data;
@@ -344,7 +344,7 @@ static int transceive(const struct device *dev,
 	}
 #endif
 
-	spi_context_lock(&data->ctx, asynchronous, signal, spi_cfg);
+	spi_context_lock(&data->ctx, asynchronous, async, spi_cfg);
 
 	ret = spi_esp32_configure(dev, spi_cfg);
 	if (ret) {
@@ -389,7 +389,7 @@ static int spi_esp32_transceive_async(const struct device *dev,
 				      const struct spi_config *spi_cfg,
 				      const struct spi_buf_set *tx_bufs,
 				      const struct spi_buf_set *rx_bufs,
-				      struct k_poll_signal *async)
+				      struct spi_async_method *async)
 {
 	return transceive(dev, spi_cfg, tx_bufs, rx_bufs, true, async);
 }

--- a/drivers/spi/spi_gecko.c
+++ b/drivers/spi/spi_gecko.c
@@ -271,7 +271,7 @@ static int spi_gecko_transceive_async(const struct device *dev,
 				      const struct spi_config *config,
 				      const struct spi_buf_set *tx_bufs,
 				      const struct spi_buf_set *rx_bufs,
-				      struct k_poll_signal *async)
+				      struct spi_async_method *async)
 {
 	return -ENOTSUP;
 }

--- a/drivers/spi/spi_litespi.c
+++ b/drivers/spi/spi_litespi.c
@@ -149,7 +149,7 @@ static int spi_litespi_transceive_async(const struct device *dev,
 					const struct spi_config *config,
 					const struct spi_buf_set *tx_bufs,
 					const struct spi_buf_set *rx_bufs,
-					struct k_poll_signal *async)
+					struct spi_async_method *async)
 {
 	return -ENOTSUP;
 }

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -598,7 +598,8 @@ static int transceive(const struct device *dev,
 		      const struct spi_config *config,
 		      const struct spi_buf_set *tx_bufs,
 		      const struct spi_buf_set *rx_bufs,
-		      bool asynchronous, struct k_poll_signal *signal)
+		      bool asynchronous,
+		      struct spi_async_method *async)
 {
 	const struct spi_stm32_config *cfg = dev->config;
 	struct spi_stm32_data *data = dev->data;
@@ -615,7 +616,7 @@ static int transceive(const struct device *dev,
 	}
 #endif
 
-	spi_context_lock(&data->ctx, asynchronous, signal, config);
+	spi_context_lock(&data->ctx, asynchronous, async, config);
 
 	ret = spi_stm32_configure(dev, config);
 	if (ret) {
@@ -697,7 +698,8 @@ static int transceive_dma(const struct device *dev,
 		      const struct spi_config *config,
 		      const struct spi_buf_set *tx_bufs,
 		      const struct spi_buf_set *rx_bufs,
-		      bool asynchronous, struct k_poll_signal *signal)
+		      bool asynchronous,
+			  struct spi_async_method *async)
 {
 	const struct spi_stm32_config *cfg = dev->config;
 	struct spi_stm32_data *data = dev->data;
@@ -712,7 +714,7 @@ static int transceive_dma(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	spi_context_lock(&data->ctx, asynchronous, signal, config);
+	spi_context_lock(&data->ctx, asynchronous, async, config);
 
 	k_sem_reset(&data->status_sem);
 
@@ -828,7 +830,7 @@ static int spi_stm32_transceive_async(const struct device *dev,
 				      const struct spi_config *config,
 				      const struct spi_buf_set *tx_bufs,
 				      const struct spi_buf_set *rx_bufs,
-				      struct k_poll_signal *async)
+				      struct spi_async_method *async)
 {
 	return transceive(dev, config, tx_bufs, rx_bufs, true, async);
 }

--- a/drivers/spi/spi_mcux_dspi.c
+++ b/drivers/spi/spi_mcux_dspi.c
@@ -668,7 +668,7 @@ static int transceive(const struct device *dev,
 		      const struct spi_buf_set *tx_bufs,
 		      const struct spi_buf_set *rx_bufs,
 		      bool asynchronous,
-		      struct k_poll_signal *signal)
+		      struct spi_async_method *async)
 {
 	struct spi_mcux_data *data = dev->data;
 	int ret;
@@ -677,7 +677,7 @@ static int transceive(const struct device *dev,
 	SPI_Type *base = config->base;
 #endif
 
-	spi_context_lock(&data->ctx, asynchronous, signal, spi_cfg);
+	spi_context_lock(&data->ctx, asynchronous, async, spi_cfg);
 
 	ret = spi_mcux_configure(dev, spi_cfg);
 	if (ret) {
@@ -732,7 +732,7 @@ static int spi_mcux_transceive_async(const struct device *dev,
 				     const struct spi_config *spi_cfg,
 				     const struct spi_buf_set *tx_bufs,
 				     const struct spi_buf_set *rx_bufs,
-				     struct k_poll_signal *async)
+				     struct spi_async_method *async)
 {
 	return transceive(dev, spi_cfg, tx_bufs, rx_bufs, true, async);
 }

--- a/drivers/spi/spi_mcux_flexcomm.c
+++ b/drivers/spi/spi_mcux_flexcomm.c
@@ -562,11 +562,11 @@ static int wait_dma_rx_tx_done(const struct device *dev)
 }
 
 static int transceive_dma(const struct device *dev,
-		      const struct spi_config *spi_cfg,
-		      const struct spi_buf_set *tx_bufs,
-		      const struct spi_buf_set *rx_bufs,
-		      bool asynchronous,
-		      struct k_poll_signal *signal)
+			  const struct spi_config *spi_cfg,
+			  const struct spi_buf_set *tx_bufs,
+			  const struct spi_buf_set *rx_bufs,
+			  bool asynchronous,
+			  struct spi_async_method *async)
 {
 	const struct spi_mcux_config *config = dev->config;
 	struct spi_mcux_data *data = dev->data;
@@ -574,7 +574,7 @@ static int transceive_dma(const struct device *dev,
 	int ret;
 	uint32_t word_size;
 
-	spi_context_lock(&data->ctx, asynchronous, signal, spi_cfg);
+	spi_context_lock(&data->ctx, asynchronous, async, spi_cfg);
 
 	ret = spi_mcux_configure(dev, spi_cfg);
 	if (ret) {
@@ -647,12 +647,12 @@ static int transceive(const struct device *dev,
 		      const struct spi_buf_set *tx_bufs,
 		      const struct spi_buf_set *rx_bufs,
 		      bool asynchronous,
-		      struct k_poll_signal *signal)
+		      struct spi_async_method *async)
 {
 	struct spi_mcux_data *data = dev->data;
 	int ret;
 
-	spi_context_lock(&data->ctx, asynchronous, signal, spi_cfg);
+	spi_context_lock(&data->ctx, asynchronous, async, spi_cfg);
 
 	ret = spi_mcux_configure(dev, spi_cfg);
 	if (ret) {
@@ -688,7 +688,7 @@ static int spi_mcux_transceive_async(const struct device *dev,
 				     const struct spi_config *spi_cfg,
 				     const struct spi_buf_set *tx_bufs,
 				     const struct spi_buf_set *rx_bufs,
-				     struct k_poll_signal *async)
+				     struct spi_async_method *async)
 {
 	return transceive(dev, spi_cfg, tx_bufs, rx_bufs, true, async);
 }

--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -366,11 +366,11 @@ static int wait_dma_rx_tx_done(const struct device *dev)
 }
 
 static int transceive_dma(const struct device *dev,
-		      const struct spi_config *spi_cfg,
-		      const struct spi_buf_set *tx_bufs,
-		      const struct spi_buf_set *rx_bufs,
-		      bool asynchronous,
-		      struct k_poll_signal *sig)
+			  const struct spi_config *spi_cfg,
+			  const struct spi_buf_set *tx_bufs,
+			  const struct spi_buf_set *rx_bufs,
+			  bool asynchronous,
+			  struct spi_async_method *async)
 {
 	const struct spi_mcux_config *config = dev->config;
 	struct spi_mcux_data *data = dev->data;
@@ -378,7 +378,7 @@ static int transceive_dma(const struct device *dev,
 	int ret;
 	size_t dma_size;
 
-	spi_context_lock(&data->ctx, asynchronous, sig, spi_cfg);
+	spi_context_lock(&data->ctx, asynchronous, async, spi_cfg);
 
 	ret = spi_mcux_configure(dev, spi_cfg);
 	if (ret) {
@@ -457,12 +457,12 @@ static int transceive(const struct device *dev,
 		      const struct spi_buf_set *tx_bufs,
 		      const struct spi_buf_set *rx_bufs,
 		      bool asynchronous,
-		      struct k_poll_signal *signal)
+		      struct spi_async_method *async)
 {
 	struct spi_mcux_data *data = dev->data;
 	int ret;
 
-	spi_context_lock(&data->ctx, asynchronous, signal, spi_cfg);
+	spi_context_lock(&data->ctx, asynchronous, async, spi_cfg);
 
 	ret = spi_mcux_configure(dev, spi_cfg);
 	if (ret) {
@@ -498,7 +498,7 @@ static int spi_mcux_transceive_async(const struct device *dev,
 				     const struct spi_config *spi_cfg,
 				     const struct spi_buf_set *tx_bufs,
 				     const struct spi_buf_set *rx_bufs,
-				     struct k_poll_signal *async)
+				     struct spi_async_method *async)
 {
 	return transceive(dev, spi_cfg, tx_bufs, rx_bufs, true, async);
 }

--- a/drivers/spi/spi_npcx_fiu.c
+++ b/drivers/spi/spi_npcx_fiu.c
@@ -125,6 +125,17 @@ static int spi_npcx_fiu_transceive(const struct device *dev,
 	return error;
 }
 
+#ifdef CONFIG_SPI_ASYNC
+static int spi_npcx_fiu_transceive_async(const struct device *dev,
+					 const struct spi_config *spi_cfg,
+					 const struct spi_buf_set *tx_bufs,
+					 const struct spi_buf_set *rx_bufs,
+					 struct spi_async_method *async)
+{
+	return -ENOTSUP;
+}
+#endif /* CONFIG_SPI_ASYNC */
+
 int spi_npcx_fiu_release(const struct device *dev,
 			 const struct spi_config *config)
 {
@@ -166,6 +177,9 @@ static int spi_npcx_fiu_init(const struct device *dev)
 
 static struct spi_driver_api spi_npcx_fiu_api = {
 	.transceive = spi_npcx_fiu_transceive,
+#ifdef CONFIG_SPI_ASYNC
+	.transceive_async = spi_npcx_fiu_transceive_async,
+#endif
 	.release = spi_npcx_fiu_release,
 };
 

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -202,12 +202,12 @@ static int transceive(const struct device *dev,
 		      const struct spi_buf_set *tx_bufs,
 		      const struct spi_buf_set *rx_bufs,
 		      bool asynchronous,
-		      struct k_poll_signal *signal)
+		      struct spi_async_method *async)
 {
 	struct spi_nrfx_data *dev_data = dev->data;
 	int error;
 
-	spi_context_lock(&dev_data->ctx, asynchronous, signal, spi_cfg);
+	spi_context_lock(&dev_data->ctx, asynchronous, async, spi_cfg);
 
 	error = configure(dev, spi_cfg);
 	if (error == 0) {
@@ -239,7 +239,7 @@ static int spi_nrfx_transceive_async(const struct device *dev,
 				     const struct spi_config *spi_cfg,
 				     const struct spi_buf_set *tx_bufs,
 				     const struct spi_buf_set *rx_bufs,
-				     struct k_poll_signal *async)
+				     struct spi_async_method *async)
 {
 	return transceive(dev, spi_cfg, tx_bufs, rx_bufs, true, async);
 }

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -361,12 +361,12 @@ static int transceive(const struct device *dev,
 		      const struct spi_buf_set *tx_bufs,
 		      const struct spi_buf_set *rx_bufs,
 		      bool asynchronous,
-		      struct k_poll_signal *signal)
+		      struct spi_async_method *async)
 {
 	struct spi_nrfx_data *dev_data = dev->data;
 	int error;
 
-	spi_context_lock(&dev_data->ctx, asynchronous, signal, spi_cfg);
+	spi_context_lock(&dev_data->ctx, asynchronous, async, spi_cfg);
 
 	error = configure(dev, spi_cfg);
 	if (error == 0) {
@@ -398,7 +398,7 @@ static int spi_nrfx_transceive_async(const struct device *dev,
 				     const struct spi_config *spi_cfg,
 				     const struct spi_buf_set *tx_bufs,
 				     const struct spi_buf_set *rx_bufs,
-				     struct k_poll_signal *async)
+				     struct spi_async_method *async)
 {
 	return transceive(dev, spi_cfg, tx_bufs, rx_bufs, true, async);
 }

--- a/drivers/spi/spi_nrfx_spis.c
+++ b/drivers/spi/spi_nrfx_spis.c
@@ -139,12 +139,12 @@ static int transceive(const struct device *dev,
 		      const struct spi_buf_set *tx_bufs,
 		      const struct spi_buf_set *rx_bufs,
 		      bool asynchronous,
-		      struct k_poll_signal *signal)
+		      struct spi_async_method *async)
 {
 	struct spi_nrfx_data *dev_data = dev->data;
 	int error;
 
-	spi_context_lock(&dev_data->ctx, asynchronous, signal, spi_cfg);
+	spi_context_lock(&dev_data->ctx, asynchronous, async, spi_cfg);
 
 	error = configure(dev, spi_cfg);
 	if (error != 0) {
@@ -185,7 +185,7 @@ static int spi_nrfx_transceive_async(const struct device *dev,
 				     const struct spi_config *spi_cfg,
 				     const struct spi_buf_set *tx_bufs,
 				     const struct spi_buf_set *rx_bufs,
-				     struct k_poll_signal *async)
+				     struct spi_async_method *async)
 {
 	return transceive(dev, spi_cfg, tx_bufs, rx_bufs, true, async);
 }

--- a/drivers/spi/spi_oc_simple.c
+++ b/drivers/spi/spi_oc_simple.c
@@ -165,7 +165,7 @@ static int spi_oc_simple_transceive_async(const struct device *dev,
 					  const struct spi_config *config,
 					  const struct spi_buf_set *tx_bufs,
 					  const struct spi_buf_set *rx_bufs,
-					  struct k_poll_signal *async)
+					  struct spi_async_method *async)
 {
 	return -ENOTSUP;
 }

--- a/drivers/spi/spi_psoc6.c
+++ b/drivers/spi/spi_psoc6.c
@@ -296,13 +296,13 @@ static int spi_psoc6_transceive(const struct device *dev,
 				const struct spi_buf_set *tx_bufs,
 				const struct spi_buf_set *rx_bufs,
 				bool asynchronous,
-				struct k_poll_signal *signal)
+				struct spi_async_method *async)
 {
 	const struct spi_psoc6_config *config = dev->config;
 	struct spi_psoc6_data *data = dev->data;
 	int ret;
 
-	spi_context_lock(&data->ctx, asynchronous, signal, spi_cfg);
+	spi_context_lock(&data->ctx, asynchronous, async, spi_cfg);
 
 	LOG_DBG("\n\n");
 
@@ -352,7 +352,7 @@ static int spi_psoc6_transceive_async(const struct device *dev,
 				      const struct spi_config *spi_cfg,
 				      const struct spi_buf_set *tx_bufs,
 				      const struct spi_buf_set *rx_bufs,
-				      struct k_poll_signal *async)
+				      struct spi_async_method *async)
 {
 	return spi_psoc6_transceive(dev, spi_cfg, tx_bufs,
 				    rx_bufs, true, async);

--- a/drivers/spi/spi_rv32m1_lpspi.c
+++ b/drivers/spi/spi_rv32m1_lpspi.c
@@ -203,12 +203,12 @@ static int transceive(const struct device *dev,
 		      const struct spi_buf_set *tx_bufs,
 		      const struct spi_buf_set *rx_bufs,
 		      bool asynchronous,
-		      struct k_poll_signal *signal)
+		      struct spi_async_method *async)
 {
 	struct spi_mcux_data *data = dev->data;
 	int ret;
 
-	spi_context_lock(&data->ctx, asynchronous, signal, spi_cfg);
+	spi_context_lock(&data->ctx, asynchronous, async, spi_cfg);
 
 	ret = spi_mcux_configure(dev, spi_cfg);
 	if (ret) {
@@ -241,7 +241,7 @@ static int spi_mcux_transceive_async(const struct device *dev,
 				     const struct spi_config *spi_cfg,
 				     const struct spi_buf_set *tx_bufs,
 				     const struct spi_buf_set *rx_bufs,
-				     struct k_poll_signal *async)
+				     struct spi_async_method *async)
 {
 	return transceive(dev, spi_cfg, tx_bufs, rx_bufs, true, async);
 }

--- a/drivers/spi/spi_sam.c
+++ b/drivers/spi/spi_sam.c
@@ -414,7 +414,7 @@ static int spi_sam_transceive_async(const struct device *dev,
 				     const struct spi_config *config,
 				     const struct spi_buf_set *tx_bufs,
 				     const struct spi_buf_set *rx_bufs,
-				     struct k_poll_signal *async)
+				     struct spi_async_method *async)
 {
 	/* TODO: implement asyc transceive */
 	return -ENOTSUP;

--- a/drivers/spi/spi_sam0.c
+++ b/drivers/spi/spi_sam0.c
@@ -622,7 +622,7 @@ static int spi_sam0_transceive_async(const struct device *dev,
 				     const struct spi_config *config,
 				     const struct spi_buf_set *tx_bufs,
 				     const struct spi_buf_set *rx_bufs,
-				     struct k_poll_signal *async)
+				     struct spi_async_method *async)
 {
 	const struct spi_sam0_config *cfg = dev->config;
 	struct spi_sam0_data *data = dev->data;

--- a/drivers/spi/spi_sifive.c
+++ b/drivers/spi/spi_sifive.c
@@ -237,6 +237,17 @@ int spi_sifive_transceive(const struct device *dev,
 	return rc;
 }
 
+#ifdef CONFIG_SPI_ASYNC
+int spi_sifive_transceive_async(const struct device *dev,
+				const struct spi_config *config,
+				const struct spi_buf_set *tx_bufs,
+				const struct spi_buf_set *rx_bufs,
+				struct spi_async_method *async)
+{
+	return -ENOTSUP;
+}
+#endif /* CONFIG_SPI_ASYNC */
+
 int spi_sifive_release(const struct device *dev,
 		       const struct spi_config *config)
 {
@@ -248,6 +259,9 @@ int spi_sifive_release(const struct device *dev,
 
 static struct spi_driver_api spi_sifive_api = {
 	.transceive = spi_sifive_transceive,
+#ifdef CONFIG_SPI_ASYNC
+	.transceive_async = spi_sifive_transceive_async,
+#endif
 	.release = spi_sifive_release,
 };
 

--- a/drivers/spi/spi_test.c
+++ b/drivers/spi/spi_test.c
@@ -27,7 +27,7 @@ static int vnd_spi_transceive_async(const struct device *dev,
 				    const struct spi_config *spi_cfg,
 				    const struct spi_buf_set *tx_bufs,
 				    const struct spi_buf_set *rx_bufs,
-				    struct k_poll_signal *async)
+				    struct spi_async_method *async)
 {
 	return -ENOTSUP;
 }

--- a/drivers/spi/spi_xec_qmspi.c
+++ b/drivers/spi/spi_xec_qmspi.c
@@ -588,7 +588,7 @@ static int qmspi_transceive_async(const struct device *dev,
 				  const struct spi_config *config,
 				  const struct spi_buf_set *tx_bufs,
 				  const struct spi_buf_set *rx_bufs,
-				  struct k_poll_signal *async)
+				  struct spi_async_method *async)
 {
 	return -ENOTSUP;
 }

--- a/drivers/spi/spi_xec_qmspi_ldma.c
+++ b/drivers/spi/spi_xec_qmspi_ldma.c
@@ -943,7 +943,7 @@ static int qmspi_transceive_async(const struct device *dev,
 				  const struct spi_config *config,
 				  const struct spi_buf_set *tx_bufs,
 				  const struct spi_buf_set *rx_bufs,
-				  struct k_poll_signal *async)
+				  struct spi_async_method *async)
 {
 	struct spi_qmspi_data *data = dev->data;
 

--- a/drivers/spi/spi_xlnx_axi_quadspi.c
+++ b/drivers/spi/spi_xlnx_axi_quadspi.c
@@ -315,14 +315,15 @@ static int xlnx_quadspi_transceive(const struct device *dev,
 				   const struct spi_config *spi_cfg,
 				   const struct spi_buf_set *tx_bufs,
 				   const struct spi_buf_set *rx_bufs,
-				   bool async, struct k_poll_signal *signal)
+				   bool asynchronous,
+				   struct spi_async_method *async)
 {
 	const struct xlnx_quadspi_config *config = dev->config;
 	struct xlnx_quadspi_data *data = dev->data;
 	struct spi_context *ctx = &data->ctx;
 	int ret;
 
-	spi_context_lock(ctx, async, signal, spi_cfg);
+	spi_context_lock(ctx, asynchronous, async, spi_cfg);
 
 	ret = xlnx_quadspi_configure(dev, spi_cfg);
 	if (ret) {
@@ -357,10 +358,10 @@ static int xlnx_quadspi_transceive_async(const struct device *dev,
 					 const struct spi_config *spi_cfg,
 					 const struct spi_buf_set *tx_bufs,
 					 const struct spi_buf_set *rx_bufs,
-					 struct k_poll_signal *signal)
+					 struct spi_async_method *async)
 {
 	return xlnx_quadspi_transceive(dev, spi_cfg, tx_bufs, rx_bufs, true,
-				       signal);
+				       async);
 }
 #endif /* CONFIG_SPI_ASYNC */
 

--- a/tests/drivers/spi/spi_loopback/src/spi.c
+++ b/tests/drivers/spi/spi_loopback/src/spi.c
@@ -487,7 +487,8 @@ static int spi_rx_every_4(const struct device *dev,
 }
 
 #if (CONFIG_SPI_ASYNC)
-static struct k_poll_signal async_sig = K_POLL_SIGNAL_INITIALIZER(async_sig);
+SPI_ASYNC_METHOD_SIGNAL_DEFINE(async_meth, async_sig);
+
 static struct k_poll_event async_evt =
 	K_POLL_EVENT_INITIALIZER(K_POLL_TYPE_SIGNAL,
 				 K_POLL_MODE_NOTIFY_ONLY,
@@ -544,7 +545,7 @@ static int spi_async_call(const struct device *dev,
 
 	LOG_INF("Start async call");
 
-	ret = spi_transceive_async(dev, spi_conf, &tx, &rx, &async_sig);
+	ret = spi_transceive_async(dev, spi_conf, &tx, &rx, &async_meth);
 	if (ret == -ENOTSUP) {
 		LOG_DBG("Not supported");
 		return 0;


### PR DESCRIPTION
Using only struct k_poll_signal has proven to be too limited. (It's an issue for sensor subsystem for instance)