### PR TITLE
Bluetooth: Mesh: add heartbeat publication callback

### DIFF
--- a/include/bluetooth/mesh/heartbeat.h
+++ b/include/bluetooth/mesh/heartbeat.h
@@ -99,6 +99,14 @@ struct bt_mesh_hb_cb {
 	 *  @param sub Current Heartbeat subscription parameters.
 	 */
 	void (*sub_end)(const struct bt_mesh_hb_sub *sub);
+
+	/** @brief Publication sent callback for heartbeats.
+	 *
+	 *  Gets called when the heartbeat is successfully published.
+	 *
+	 *  @param pub Current Heartbeat publication parameters.
+	 */
+	void (*pub_sent)(const struct bt_mesh_hb_pub *pub);
 };
 
 /** @def BT_MESH_HB_CB_DEFINE

--- a/subsys/bluetooth/mesh/heartbeat.c
+++ b/subsys/bluetooth/mesh/heartbeat.c
@@ -33,6 +33,15 @@ static struct bt_mesh_hb_sub sub;
 static struct k_work_delayable sub_timer;
 static struct k_work_delayable pub_timer;
 
+static void notify_pub_sent(void)
+{
+	STRUCT_SECTION_FOREACH(bt_mesh_hb_cb, cb) {
+		if (cb->pub_sent) {
+			cb->pub_sent(&pub);
+		}
+	}
+}
+
 static int64_t sub_remaining(void)
 {
 	if (sub.dst == BT_MESH_ADDR_UNASSIGNED) {
@@ -53,6 +62,10 @@ static void hb_publish_end_cb(int err, void *cb_data)
 
 	if (pub.count != 0xffff) {
 		pub.count--;
+	}
+
+	if (!err) {
+		notify_pub_sent();
 	}
 }
 
@@ -338,8 +351,19 @@ void bt_mesh_hb_sub_get(struct bt_mesh_hb_sub *get)
 	get->remaining = sub_remaining();
 }
 
+static void hb_unsolicited_pub_end_cb(int err, void *cb_data)
+{
+	if (!err) {
+		notify_pub_sent();
+	}
+}
+
 void bt_mesh_hb_feature_changed(uint16_t features)
 {
+	static const struct bt_mesh_send_cb pub_cb = {
+		.end = hb_unsolicited_pub_end_cb,
+	};
+
 	if (pub.dst == BT_MESH_ADDR_UNASSIGNED) {
 		return;
 	}
@@ -348,7 +372,7 @@ void bt_mesh_hb_feature_changed(uint16_t features)
 		return;
 	}
 
-	heartbeat_send(NULL, NULL);
+	heartbeat_send(&pub_cb, NULL);
 }
 
 void bt_mesh_hb_init(void)

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_heartbeat.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_heartbeat.c
@@ -7,6 +7,7 @@
 #include "argparse.h"
 #include "mesh/net.h"
 #include "mesh/heartbeat.h"
+#include "mesh/lpn.h"
 
 #define LOG_MODULE_NAME test_heartbeat
 
@@ -19,7 +20,6 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define PUBLISHER_ADDR_START 0x0001
 #define PUBLISH_PERIOD_SEC 1
 #define PUBLISH_MSG_CNT 10
-#define PUBLISH_FEATURES_RANGE 0x0f
 #define PUBLISH_TTL 0
 #define EXPECTED_HB_HOPS 0x01
 
@@ -30,6 +30,8 @@ static const struct bt_mesh_test_cfg subscribe_cfg = {
 	.dev_key = { 0xff },
 };
 static struct bt_mesh_test_cfg pub_cfg;
+static int pub_cnt;
+struct k_sem sem;
 
 static void test_publish_init(void)
 {
@@ -63,7 +65,26 @@ static void sub_hb_recv_cb(const struct bt_mesh_hb_sub *sub, uint8_t hops, uint1
 	ASSERT_TRUE(sub->remaining <= SUBSCRIBE_PERIOD_SEC);
 	ASSERT_EQUAL(sub_ctx.count + 1, sub->count);
 	ASSERT_EQUAL(hops, EXPECTED_HB_HOPS);
-	ASSERT_TRUE(feat <= PUBLISH_FEATURES_RANGE);
+
+	uint16_t feature = 0;
+
+	if (bt_mesh_relay_get() == BT_MESH_RELAY_ENABLED) {
+		feature |= BT_MESH_FEAT_RELAY;
+	}
+
+	if (bt_mesh_gatt_proxy_get() == BT_MESH_GATT_PROXY_ENABLED) {
+		feature |= BT_MESH_FEAT_PROXY;
+	}
+
+	if (bt_mesh_friend_get() == BT_MESH_FRIEND_ENABLED) {
+		feature |= BT_MESH_FEAT_FRIEND;
+	}
+
+	if (bt_mesh_lpn_established()) {
+		feature |= BT_MESH_FEAT_LOW_POWER;
+	}
+
+	ASSERT_EQUAL(feature, feat);
 
 	sub_ctx.count++;
 	sub_ctx.min_hops = MIN(sub_ctx.min_hops, sub->min_hops);
@@ -84,9 +105,33 @@ static void sub_hb_end_cb(const struct bt_mesh_hb_sub *sub)
 	PASS();
 }
 
+static void pub_hb_sent_cb(const struct bt_mesh_hb_pub *pub)
+{
+	LOG_INF("Heartbeat publication has ended");
+
+	pub_cnt--;
+
+	ASSERT_EQUAL(pub_addr, pub->dst);
+	ASSERT_EQUAL(pub_cnt, pub->count);
+	ASSERT_EQUAL(PUBLISH_PERIOD_SEC, pub->period);
+	ASSERT_EQUAL(0, pub->net_idx);
+	ASSERT_EQUAL(PUBLISH_TTL, pub->ttl);
+	ASSERT_EQUAL(BT_MESH_FEAT_SUPPORTED, pub->feat);
+
+	if (pub_cnt == 0) {
+		k_sem_give(&sem);
+	}
+
+	if (pub_cnt < 0) {
+		LOG_ERR("Published more times than expected");
+		FAIL();
+	}
+}
+
 BT_MESH_HB_CB_DEFINE(hb_cb) = {
 	.recv = sub_hb_recv_cb,
 	.sub_end = sub_hb_end_cb,
+	.pub_sent = pub_hb_sent_cb
 };
 
 static void publish_common(void)
@@ -98,21 +143,37 @@ static void publish_common(void)
 		.period = PUBLISH_PERIOD_SEC,
 		.net_idx = 0,
 		.ttl = PUBLISH_TTL,
+		.feat = BT_MESH_FEAT_SUPPORTED
 	};
+
+	pub_cnt = PUBLISH_MSG_CNT;
 	bt_mesh_hb_pub_set(&new_pub);
+}
+
+static void publish_process(void)
+{
+	k_sem_init(&sem, 0, 1);
+	publish_common();
+	/* +1 to avoid boundary time rally */
+	if (k_sem_take(&sem, K_SECONDS(PUBLISH_PERIOD_SEC * (PUBLISH_MSG_CNT + 1)))) {
+		LOG_ERR("Publishing timed out");
+		FAIL();
+	}
 }
 
 static void test_publish_unicast(void)
 {
 	pub_addr = SUBSCRIBER_ADDR;
-	publish_common();
+	publish_process();
+
 	PASS();
 }
 
 static void test_publish_all(void)
 {
 	pub_addr = BT_MESH_ADDR_ALL_NODES;
-	publish_common();
+	publish_process();
+
 	PASS();
 }
 
@@ -134,8 +195,8 @@ static void test_subscribe_all(void)
 	subscribe_commmon();
 }
 
-#define TEST_CASE(role, name, description)                             \
-	{                                                                  \
+#define TEST_CASE(role, name, description)                                     \
+	{                                                                      \
 		.test_id = "heartbeat_" #role "_" #name,                       \
 		.test_descr = description,                                     \
 		.test_post_init_f = test_##role##_init,                        \


### PR DESCRIPTION
Heartbeat publication sent callback can be used as a watch mechanism to determine whether the mesh stack is still capable of sending messages or not.
Extend the existing bsim Heartbeat test to check the publication callback functionality.
