### PR TITLE
drivers: ieee802154_nrf5: Align shim layer to 64-bit time

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.h
+++ b/drivers/ieee802154/ieee802154_nrf5.h
@@ -17,7 +17,7 @@
 struct nrf5_802154_rx_frame {
 	void *fifo_reserved; /* 1st word reserved for use by fifo. */
 	uint8_t *psdu; /* Pointer to a received frame. */
-	uint32_t time; /* RX timestamp. */
+	uint64_t time; /* RX timestamp. */
 	uint8_t lqi; /* Last received frame LQI value. */
 	int8_t rssi; /* Last received frame RSSI value. */
 	bool ack_fpb; /* FPB value in ACK sent for the received frame. */

--- a/drivers/timer/Kconfig.nrf_rtc
+++ b/drivers/timer/Kconfig.nrf_rtc
@@ -18,6 +18,7 @@ if NRF_RTC_TIMER
 
 config NRF_RTC_TIMER_USER_CHAN_COUNT
 	int "Additional channels that can be used"
+	default 3 if SOC_SERIES_NRF52X
 	default 0
 	help
 	  Use nrf_rtc_timer.h API. Driver is not managing allocation of channels.

--- a/west.yml
+++ b/west.yml
@@ -88,7 +88,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: eab07c9d86341b9f249afe8188cceab3b0dc90ef
+      revision: 1f9145e8c8359f103b4ac5085c6f5d2e66a2557d
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
The updated nrf_802154 API accepts 64-bit time in microseconds.
The shim layer is updated to use 64-bit time.

Signed-off-by: Rafał Kuźnia <rafal.kuznia@nordicsemi.no>

To be done:

- [x] hal_nordic update