### PR TITLE
scripts: add board revision help text for west build

### DIFF
--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -20,7 +20,7 @@ from zephyr_ext_common import Forceable
 _ARG_SEPARATOR = '--'
 
 BUILD_USAGE = '''\
-west build [-h] [-b BOARD] [-d BUILD_DIR]
+west build [-h] [-b BOARD[@REV]]] [-d BUILD_DIR]
            [-t TARGET] [-p {auto, always, never}] [-c] [--cmake-only]
            [-n] [-o BUILD_OPT] [-f]
            [source_dir] -- [cmake_opt [cmake_opt ...]]
@@ -98,7 +98,8 @@ class Build(Forceable):
         # Remember to update west-completion.bash if you add or remove
         # flags
 
-        parser.add_argument('-b', '--board', help='board to build for')
+        parser.add_argument('-b', '--board',
+                        help='board to build for with optional board revision')
         # Hidden option for backwards compatibility
         parser.add_argument('-s', '--source-dir', help=argparse.SUPPRESS)
         parser.add_argument('-d', '--build-dir',


### PR DESCRIPTION
west build supports specifying the board revision using `@revision`, but
it's not mentioned in the help text. This commit updates the help text
to describe how to specify the board revision.

The implementation details of the revision handling is in the `board_check_revision` function in cmake/extensions.cmake. The version syntax can vary from board to board, so the details probably belongs elsewhere.

Here is the output of the help text with this change:

```
usage: west build [-h] [-b BOARD[@REV]] [-d BUILD_DIR]
           [-t TARGET] [-p {auto, always, never}] [-c] [--cmake-only]
           [-n] [-o BUILD_OPT] [-f]
           [source_dir] -- [cmake_opt [cmake_opt ...]]

Convenience wrapper for building Zephyr applications.

If the build directory is not given, the default is build/ unless the
build.dir-fmt configuration variable is set. The current directory is
checked after that. If either is a Zephyr build directory, it is used.

positional arguments:
  source_dir            application source directory
  cmake_opt             extra options to pass to cmake; implies -c
                        (these must come after "--" as shown above)

optional arguments:
  -h, --help            show this help message and exit
  -b BOARD, --board BOARD
                        board to build for with optional board revision
  -d BUILD_DIR, --build-dir BUILD_DIR
                        build directory to create or use
  -f, --force           ignore any errors and try to proceed

cmake and build tool:
  -c, --cmake           force a cmake run
  --cmake-only          just run cmake; don't build (implies -c)
  -t TARGET, --target TARGET
                        run build system target TARGET (try "-t usage")
  -T TEST_ITEM, --test-item TEST_ITEM
                        Build based on test data in testcase.yaml or sample.yaml
  -o BUILD_OPT, --build-opt BUILD_OPT
                        options to pass to the build tool (make or ninja); may be given more than once
  -n, --just-print, --dry-run, --recon
                        just print build commands; don't run them

pristine builds:
  A "pristine" build directory is empty. The -p option controls
  whether the build directory is made pristine before the build
  is done. A bare '--pristine' with no value is the same as
  --pristine=always. Setting --pristine=auto uses heuristics to
  guess if a pristine build may be necessary.

  -p [{auto,always,never}], --pristine [{auto,always,never}]
                        pristine build folder setting
```

The change does not specify the `@REV` in the argument description. It is possible to change the help text to use `BOARD@REV` instead of only `BOARD` by using `metavar='BOARD[@REV]'`, but I'm not sure usage syntax belongs there. Instead I only updated the description to mention board revision.

If using `metavar` the board argument help would output:

```
  -b BOARD[@REV], --board BOARD[@REV]
                        board to build for with optional board revision
```