### PR TITLE
llvm: add __fallthrough macro for Clang

### DIFF
--- a/include/toolchain/llvm.h
+++ b/include/toolchain/llvm.h
@@ -9,6 +9,11 @@
 
 
 #define __no_optimization __attribute__((optnone))
+
+#if __clang_major__ >= 10
+#define __fallthrough __attribute__((fallthrough))
+#endif
+
 #include <toolchain/gcc.h>
 
 


### PR DESCRIPTION
LLVM defines __GNUC__ to 4 so the __fallthrough is nothing
through include/toolchain/gcc.h. So add a few lines for
a functional __fallthrough macro for LLVM. The fallthrough
attribute is supported since Clang 10.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>