### PR TITLE
ISO TX HCI data path

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -221,15 +221,6 @@ config BT_CTLR_ISO_TX_BUFFERS
 	  Set the number of Isochronous Tx PDUs to be queued for transmission
 	  in the controller.
 
-config BT_CTLR_ISO_TX_BUFFER_SIZE
-	int "Isochronous Tx buffer size"
-	depends on BT_CTLR_ADV_ISO || BT_CTLR_CONN_ISO
-	range 1 4095
-	default 27
-	help
-	  Size of the Isochronous Tx buffers and the value returned in HCI LE
-	  Read Buffer Size V2 command response.
-
 config BT_CTLR_ISO_VENDOR_DATA_PATH
 	bool "Enable vendor-specific ISO data path"
 	depends on BT_CTLR_SYNC_ISO || BT_CTLR_CONN_ISO

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -1303,7 +1303,7 @@ static void le_read_buffer_size_v2(struct net_buf *buf, struct net_buf **evt)
 
 	rp->acl_max_len = sys_cpu_to_le16(LL_LENGTH_OCTETS_TX_MAX);
 	rp->acl_max_num = CONFIG_BT_BUF_ACL_TX_COUNT;
-	rp->iso_max_len = sys_cpu_to_le16(CONFIG_BT_CTLR_ISO_TX_BUFFER_SIZE);
+	rp->iso_max_len = sys_cpu_to_le16(ISO_TX_BUFFER_SIZE);
 	rp->iso_max_num = CONFIG_BT_CTLR_ISO_TX_BUFFERS;
 }
 #endif /* CONFIG_BT_CTLR_ADV_ISO || CONFIG_BT_CTLR_CONN_ISO */

--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -658,6 +658,22 @@ static int acl_handle(struct net_buf *buf)
 }
 #endif /* CONFIG_BT_CONN */
 
+#if defined(CONFIG_BT_CTLR_ISO)
+static int iso_handle(struct net_buf *buf)
+{
+	struct net_buf *evt;
+	int err;
+
+	err = hci_iso_handle(buf, &evt);
+	if (evt) {
+		BT_DBG("Replying with event of %u bytes", evt->len);
+		bt_recv_prio(evt);
+	}
+
+	return err;
+}
+#endif /* CONFIG_BT_CTLR_ISO */
+
 static int hci_driver_send(struct net_buf *buf)
 {
 	uint8_t type;
@@ -680,6 +696,11 @@ static int hci_driver_send(struct net_buf *buf)
 	case BT_BUF_CMD:
 		err = cmd_handle(buf);
 		break;
+#if defined(CONFIG_BT_CTLR_ISO)
+	case BT_BUF_ISO_OUT:
+		err = iso_handle(buf);
+		break;
+#endif /* CONFIG_BT_CTLR_ISO */
 	default:
 		BT_ERR("Unknown HCI type %u", type);
 		return -EINVAL;

--- a/subsys/bluetooth/controller/hci/hci_internal.h
+++ b/subsys/bluetooth/controller/hci/hci_internal.h
@@ -44,6 +44,7 @@ void hci_acl_encode(struct node_rx_pdu *node_rx, struct net_buf *buf);
 void hci_num_cmplt_encode(struct net_buf *buf, uint16_t handle, uint8_t num);
 #endif
 #if defined(CONFIG_BT_CTLR_ISO)
+int hci_iso_handle(struct net_buf *acl, struct net_buf **evt);
 void hci_iso_encode(struct net_buf *buf, uint16_t handle, uint8_t flags);
 #endif
 int hci_vendor_cmd_handle(uint16_t ocf, struct net_buf *cmd,

--- a/subsys/bluetooth/controller/include/ll.h
+++ b/subsys/bluetooth/controller/include/ll.h
@@ -335,7 +335,8 @@ void ll_iso_rx_mem_release(void **node_rx);
 /* Downstream - ISO Data */
 void *ll_iso_tx_mem_acquire(void);
 void ll_iso_tx_mem_release(void *tx);
-int ll_iso_tx_mem_enqueue(uint16_t handle, void *tx);
+int ll_iso_tx_mem_enqueue(uint16_t handle, void *tx, memq_link_t *link);
+void ll_iso_link_tx_release(memq_link_t *link);
 
 /* External co-operation */
 void ll_timeslice_ticker_id_get(uint8_t * const instance_index,

--- a/subsys/bluetooth/controller/ll_sw/isoal.c
+++ b/subsys/bluetooth/controller/ll_sw/isoal.c
@@ -9,10 +9,19 @@
 #include <toolchain.h>
 #include <sys/util.h>
 
+#include <zephyr.h>
+
+#include <bluetooth/bluetooth.h>
+
 #include "util/memq.h"
 #include "pdu.h"
+
+
+#include "ll.h"
 #include "lll.h"
+#include "lll_conn_iso.h"
 #include "isoal.h"
+#include "ull_iso_types.h"
 
 #define LOG_MODULE_NAME bt_ctlr_isoal
 #include "common/log.h"
@@ -20,16 +29,19 @@
 
 /* TODO this must be taken from a Kconfig */
 #define ISOAL_SINKS_MAX   (4)
+#define ISOAL_SOURCES_MAX (4)
 
 /** Allocation state */
 typedef uint8_t isoal_alloc_state_t;
 #define ISOAL_ALLOC_STATE_FREE            ((isoal_alloc_state_t) 0x00)
 #define ISOAL_ALLOC_STATE_TAKEN           ((isoal_alloc_state_t) 0x01)
 
-static struct
+struct
 {
 	isoal_alloc_state_t  sink_allocated[ISOAL_SINKS_MAX];
+	isoal_alloc_state_t  source_allocated[ISOAL_SOURCES_MAX];
 	struct isoal_sink    sink_state[ISOAL_SINKS_MAX];
+	struct isoal_source  source_state[ISOAL_SOURCES_MAX];
 } isoal_global;
 
 
@@ -213,6 +225,110 @@ isoal_status_t isoal_sink_create(
 }
 
 /**
+ * @brief Find free source from statically-sized pool and allocate it
+ * @details Implemented as linear search since pool is very small
+ *
+ * @param hdl[out]  Handle to source
+ * @return ISOAL_STATUS_OK if we could allocate; otherwise ISOAL_STATUS_ERR_SOURCE_ALLOC
+ */
+static isoal_status_t isoal_source_allocate(isoal_source_handle_t *hdl)
+{
+	isoal_source_handle_t i;
+
+	/* Very small linear search to find first free */
+	for (i = 0; i < ISOAL_SOURCES_MAX; i++) {
+		if (isoal_global.source_allocated[i] == ISOAL_ALLOC_STATE_FREE) {
+			isoal_global.source_allocated[i] = ISOAL_ALLOC_STATE_TAKEN;
+			*hdl = i;
+			return ISOAL_STATUS_OK;
+		}
+	}
+
+	return ISOAL_STATUS_ERR_SOURCE_ALLOC; /* All entries were taken */
+}
+
+/**
+ * @brief Mark a source as being free to allocate again
+ * @param hdl[in]  Handle to source
+ */
+static void isoal_source_deallocate(isoal_source_handle_t hdl)
+{
+	isoal_global.source_allocated[hdl] = ISOAL_ALLOC_STATE_FREE;
+}
+
+/**
+ * @brief Create a new source
+ *
+ * @param handle[in]            Connection handle
+ * @param role[in]              Peripheral, Central or Broadcast
+ * @param burst_number[in]      Burst Number
+ * @param flush_timeout[in]     Flush timeout
+ * @param max_octets[in]        Maximum PDU size (Max_PDU_C_To_P / Max_PDU_P_To_C)
+ * @param sdu_interval[in]      SDU interval
+ * @param iso_interval[in]      ISO interval
+ * @param stream_sync_delay[in] CIS sync delay
+ * @param group_sync_delay[in]  CIG sync delay
+ * @param pdu_alloc[in]         Callback of PDU allocator
+ * @param pdu_write[in]         Callback of PDU byte writer
+ * @param pdu_emit[in]          Callback of PDU emitter
+ * @param pdu_release[in]       Callback of PDU deallocator
+ * @param hdl[out]              Handle to new source
+ *
+ * @return ISOAL_STATUS_OK if we could create a new sink; otherwise ISOAL_STATUS_ERR_SOURCE_ALLOC
+ */
+isoal_status_t isoal_source_create(
+	uint16_t                    handle,
+	uint8_t                     role,
+	uint8_t                     burst_number,
+	uint8_t                     flush_timeout,
+	uint8_t                     max_octets,
+	uint32_t                    sdu_interval,
+	uint16_t                    iso_interval,
+	uint32_t                    stream_sync_delay,
+	uint32_t                    group_sync_delay,
+	isoal_source_pdu_alloc_cb   pdu_alloc,
+	isoal_source_pdu_write_cb   pdu_write,
+	isoal_source_pdu_emit_cb    pdu_emit,
+	isoal_source_pdu_release_cb pdu_release,
+	isoal_source_handle_t       *hdl)
+{
+	isoal_status_t err;
+
+	/* Allocate a new source */
+	err = isoal_source_allocate(hdl);
+	if (err) {
+		return err;
+	}
+
+	struct isoal_source_session *session = &isoal_global.source_state[*hdl].session;
+
+	session->handle = handle;
+
+	/* Todo: Next section computing various constants, should potentially be a
+	 * function in itself as a number of the dependencies could be changed while
+	 * a connection is active.
+	 */
+
+	/* Note: sdu_interval unit is uS, iso_interval is a multiple of 1.25mS */
+	session->pdus_per_sdu = burst_number * (sdu_interval / (iso_interval * 1250));
+	/* Set maximum PDU size */
+	session->max_pdu_size = max_octets;
+
+	/* Remember the platform-specific callbacks */
+	session->pdu_alloc   = pdu_alloc;
+	session->pdu_write   = pdu_write;
+	session->pdu_emit    = pdu_emit;
+	session->pdu_release = pdu_release;
+
+	/* TODO: Constant need to be updated */
+
+	/* Initialize running seq number to zero */
+	session->seqn = 0;
+
+	return err;
+}
+
+/**
  * @brief Get reference to configuration struct
  *
  * @param hdl[in]   Handle to new sink
@@ -260,6 +376,56 @@ void isoal_sink_destroy(isoal_sink_handle_t hdl)
 
 	/* Permit allocation anew */
 	isoal_sink_deallocate(hdl);
+}
+
+/**
+ * @brief Get reference to configuration struct
+ *
+ * @param hdl[in]   Handle to new source
+ * @return Reference to parameter struct, to be configured by caller
+ */
+struct isoal_source_config *isoal_get_source_param_ref(isoal_source_handle_t hdl)
+{
+	LL_ASSERT(isoal_global.source_allocated[hdl] == ISOAL_ALLOC_STATE_TAKEN);
+
+	return &isoal_global.source_state[hdl].session.param;
+}
+
+/**
+ * @brief Atomically enable latch-in of packets and PDU production
+ * @param hdl[in]  Handle of existing instance
+ */
+void isoal_source_enable(isoal_source_handle_t hdl)
+{
+	/* Reset bookkeeping state */
+	memset(&isoal_global.source_state[hdl].pdu_production, 0,
+	       sizeof(isoal_global.source_state[hdl].pdu_production));
+
+	/* Atomically enable */
+	isoal_global.source_state[hdl].pdu_production.mode = ISOAL_PRODUCTION_MODE_ENABLED;
+}
+
+/**
+ * @brief Atomically disable latch-in of packets and PDU production
+ * @param hdl[in]  Handle of existing instance
+ */
+void isoal_source_disable(isoal_source_handle_t hdl)
+{
+	/* Atomically disable */
+	isoal_global.source_state[hdl].pdu_production.mode = ISOAL_PRODUCTION_MODE_DISABLED;
+}
+
+/**
+ * @brief Disable and deallocate existing source
+ * @param hdl[in]  Handle of existing instance
+ */
+void isoal_source_destroy(isoal_source_handle_t hdl)
+{
+	/* Atomic disable */
+	isoal_source_disable(hdl);
+
+	/* Permit allocation anew */
+	isoal_source_deallocate(hdl);
 }
 
 /* Obtain destination SDU */
@@ -774,4 +940,306 @@ isoal_status_t isoal_rx_pdu_recombine(isoal_sink_handle_t sink_hdl,
 	}
 
 	return err;
+}
+
+/**
+ * Queue the PDU in production in the relevant LL transmit queue. If the
+ * attmept to release the PDU fails, the buffer linked to the PDU will be released
+ * and it will not be possible to retry the emit operation on the same PDU.
+ * @param[in]  source_ctx   ISO-AL source reference for this CIS / BIS
+ * @param[in]  produced_pdu PDU in production
+ * @param[in]  pdu_ll_id    LLID to be set indicating the type of fragment
+ * @param[in]  payload_size Length of the data written to the PDU
+ * @return     Error status of the operation
+ */
+static isoal_status_t isoal_tx_pdu_emit(const struct isoal_source *source_ctx,
+					const struct isoal_pdu_produced *produced_pdu,
+					const uint8_t pdu_ll_id,
+					const isoal_pdu_len_t payload_size)
+{
+	struct node_tx_iso *node_tx;
+	isoal_status_t status;
+	uint16_t handle;
+
+	/* Retrieve CIS / BIS handle */
+	handle = bt_iso_handle(source_ctx->session.handle);
+
+	/* Retrieve Node handle */
+	node_tx = produced_pdu->contents.handle;
+	/* Set PDU LLID */
+	produced_pdu->contents.pdu->ll_id = pdu_ll_id;
+	/* Set PDU length */
+	produced_pdu->contents.pdu->length = (uint8_t)payload_size;
+
+	/* Attempt to enqueue the node towards the LL */
+	status = source_ctx->session.pdu_emit(node_tx, handle);
+
+	if (status != ISOAL_STATUS_OK) {
+		/* If it fails, the node will be released and no further attempt
+		 * will be possible
+		 */
+		BT_ERR("Failed to enqueue node (%p)", node_tx);
+		source_ctx->session.pdu_release(node_tx, handle, status);
+	}
+
+	return status;
+}
+
+/* Allocates a new PDU only if the previous PDU was emitted */
+static isoal_status_t isoal_tx_allocate_pdu(struct isoal_source *source,
+					    const struct isoal_sdu_tx *tx_sdu)
+{
+	struct isoal_source_session *session;
+	struct isoal_pdu_production *pp;
+	struct isoal_pdu_produced   *pdu;
+	isoal_status_t err;
+
+	err = ISOAL_STATUS_OK;
+	session = &source->session;
+	pp = &source->pdu_production;
+	pdu = &pp->pdu;
+
+	/* Allocate a PDU if the previous was filled (thus sent) */
+	const bool pdu_complete = (pp->pdu_available == 0);
+
+	if (pdu_complete) {
+		/* Allocate new PDU buffer */
+		err = session->pdu_alloc(
+			&pdu->contents  /* [out] Updated with pointer and size */
+		);
+
+		if (err) {
+			pdu->contents.handle = NULL;
+			pdu->contents.pdu    = NULL;
+			pdu->contents.size   = 0;
+		}
+
+		/* Get maximum buffer available */
+		const size_t available_len = MIN(
+			session->max_pdu_size,
+			pdu->contents.size
+		);
+
+		/* Nothing has been written into buffer yet */
+		pp->pdu_written   = 0;
+		pp->pdu_available = available_len;
+		LL_ASSERT(available_len > 0);
+
+		pp->pdu_cnt++;
+	}
+
+	return err;
+}
+
+/**
+ * Attempt to emit the PDU in production if it is complete.
+ * @param[in]  source     ISO-AL source reference
+ * @param[in]  end_of_sdu SDU end has been reached
+ * @param[in]  pdu_ll_id  LLID / PDU fragment type as Start, Cont, End, Single (Unframed) or Framed
+ * @return     Error status of operation
+ */
+static isoal_status_t isoal_tx_try_emit_pdu(struct isoal_source *source, bool end_of_sdu,
+					    uint8_t pdu_ll_id)
+{
+	struct isoal_pdu_production *pp;
+	struct isoal_pdu_produced   *pdu;
+	isoal_status_t err;
+
+	err = ISOAL_STATUS_OK;
+	pp = &source->pdu_production;
+	pdu = &pp->pdu;
+
+	/* Emit a PDU */
+	const bool pdu_complete = (pp->pdu_available == 0) || end_of_sdu;
+
+	if (end_of_sdu) {
+		pp->pdu_available = 0;
+	}
+
+	if (pdu_complete) {
+		err = isoal_tx_pdu_emit(source, pdu, pdu_ll_id, pp->pdu_written);
+	}
+
+	return err;
+}
+
+
+/**
+ * @brief Fragment received SDU and produce unframed PDUs
+ * @details Destination source may have an already partially built PDU
+ *
+ * @param source[in,out] Destination source with bookkeeping state
+ * @param tx_sdu[in]     SDU with packet boundary information
+ *
+ * @return Status
+ */
+static isoal_status_t isoal_tx_unframed_produce(struct isoal_source *source,
+						const struct isoal_sdu_tx *tx_sdu)
+{
+	struct isoal_source_session *session;
+	struct isoal_pdu_production *pp;
+	isoal_sdu_len_t packet_available;
+	const uint8_t   *sdu_payload;
+	isoal_status_t  err;
+	bool zero_length_sdu;
+	bool padding_pdu;
+	uint8_t ll_id;
+
+	session     = &source->session;
+	pp          = &source->pdu_production;
+	padding_pdu = false;
+	err         = ISOAL_STATUS_OK;
+
+	packet_available = tx_sdu->size;
+	sdu_payload = tx_sdu->dbuf;
+	LL_ASSERT(sdu_payload);
+
+	zero_length_sdu = (packet_available == 0 &&
+		tx_sdu->sdu_state == BT_ISO_SINGLE);
+
+	if (tx_sdu->sdu_state == BT_ISO_START ||
+		tx_sdu->sdu_state == BT_ISO_SINGLE) {
+		/* Start of a new SDU */
+
+		/* Update sequence number for received SDU
+		 *
+		 * BT Core V5.3 : Vol 6 Low Energy Controller : Part G IS0-AL:
+		 * 2 ISOAL Features :
+		 * SDUs received by the ISOAL from the upper layer shall be given a sequence number
+		 * which is initialized to 0 when the CIS or BIS is created.
+		 *
+		 * NOTE: The upper layer may synchronize its sequence number with the sequence
+		 * number in the ISOAL once the Datapath is configured and the link is established.
+		 */
+		session->seqn++;
+
+		/* Reset PDU fragmentation count for this SDU */
+		pp->pdu_cnt = 0;
+	}
+
+	/* PDUs should be created until the SDU fragment has been fragmented or if
+	 * this is the last fragment of the SDU, until the required padding PDU(s)
+	 * are sent.
+	 */
+	while ((err == ISOAL_STATUS_OK) &&
+		((packet_available > 0) || padding_pdu || zero_length_sdu)) {
+		const isoal_status_t err_alloc = isoal_tx_allocate_pdu(source, tx_sdu);
+		struct isoal_pdu_produced *pdu = &pp->pdu;
+
+		err |= err_alloc;
+
+		/*
+		 * For this PDU we can only consume of packet, bounded by:
+		 *   - What can fit in the destination PDU.
+		 *   - What remains of the packet.
+		 */
+		const size_t consume_len = MIN(
+			packet_available,
+			pp->pdu_available
+		);
+
+		if (consume_len > 0) {
+			err |= session->pdu_write(&pdu->contents,
+						  pp->pdu_written,
+						  sdu_payload,
+						  consume_len);
+			sdu_payload       += consume_len;
+			pp->pdu_written   += consume_len;
+			pp->pdu_available -= consume_len;
+			packet_available  -= consume_len;
+		}
+
+		/* End of the SDU is reached at the end of the last SDU fragment
+		 * or if this is a single fragment SDU
+		 */
+		bool end_of_sdu = (packet_available == 0) &&
+				((tx_sdu->sdu_state == BT_ISO_SINGLE) ||
+					(tx_sdu->sdu_state == BT_ISO_END));
+
+		/* Decide PDU type
+		 *
+		 * BT Core V5.3 : Vol 6 Low Energy Controller : Part G IS0-AL:
+		 * 2.1 Unframed PDU :
+		 * LLID 0b00 PDU_BIS_LLID_COMPLETE_END:
+		 * (1) When the payload of the ISO Data PDU contains the end fragment of an SDU.
+		 * (2) When the payload of the ISO Data PDU contains a complete SDU.
+		 * (3) When an SDU contains zero length data, the corresponding PDU shall be of zero
+		 *     length and the LLID field shall be set to 0b00.
+		 *
+		 * LLID 0b01 PDU_BIS_LLID_COMPLETE_END:
+		 * (1) When the payload of the ISO Data PDU contains a start or a continuation
+		 *     fragment of an SDU.
+		 * (2) When the ISO Data PDU is used as padding.
+		 */
+		ll_id = PDU_BIS_LLID_COMPLETE_END;
+		if (!end_of_sdu || padding_pdu) {
+			ll_id = PDU_BIS_LLID_START_CONTINUE;
+		}
+
+		const isoal_status_t err_emit = isoal_tx_try_emit_pdu(source, end_of_sdu, ll_id);
+
+		err |= err_emit;
+
+		/* Send padding PDU(s) if required
+		 *
+		 * BT Core V5.3 : Vol 6 Low Energy Controller : Part G IS0-AL:
+		 * 2.1 Unframed PDU :
+		 * Each SDU shall generate BN ÷ (ISO_Interval ÷ SDU_Interval) fragments.
+		 * If an SDU generates less than this number of fragments,
+		 * empty payloads shall be used to make up the number.
+		 */
+		padding_pdu = (end_of_sdu && (pp->pdu_cnt < session->pdus_per_sdu));
+		zero_length_sdu = false;
+	}
+
+	return err;
+}
+
+
+/**
+ * @brief Deep copy a SDU, fragment into PDU(s)
+ * @details Fragmentation will occur individually for every enabled source
+ *
+ * @param source_hdl[in] Handle of destination source
+ * @param tx_sdu[in]     SDU along with packet boudary state
+ * @return Status
+ */
+isoal_status_t isoal_tx_sdu_fragment(isoal_source_handle_t source_hdl,
+				      const struct isoal_sdu_tx *tx_sdu)
+{
+	struct isoal_source *source = &isoal_global.source_state[source_hdl];
+	isoal_status_t err = ISOAL_STATUS_ERR_PDU_ALLOC;
+
+	if (source->pdu_production.mode != ISOAL_PRODUCTION_MODE_DISABLED) {
+		/* TODO: consider how to separate framed and unframed production
+		 * BT Core V5.3 : Vol 6 Low Energy Controller : Part G IS0-AL:
+		 * 2 ISOAL Features :
+		 * (1) Unframed PDUs shall only be used when the ISO_Interval is equal to or an
+		 * integer multiple of the SDU_Interval and a constant time offset alignment is
+		 * maintained between the SDU generation and the timing in the isochronous
+		 * transport.
+		 * (2) When the Host requests the use of framed PDUs, the Controller shall use
+		 * framed PDUs.
+		 */
+		bool pdu_framed = false;
+
+		if (pdu_framed) {
+			/* TODO: add framed handling */
+		} else {
+			err = isoal_tx_unframed_produce(source, tx_sdu);
+		}
+	}
+
+	return err;
+}
+
+void isoal_tx_pdu_release(isoal_source_handle_t source_hdl,
+			  struct node_tx_iso *node_tx)
+{
+	struct isoal_source *source = &isoal_global.source_state[source_hdl];
+
+	if (source && source->session.pdu_release) {
+		source->session.pdu_release(node_tx, source->session.handle,
+					    ISOAL_STATUS_OK);
+	}
 }

--- a/subsys/bluetooth/controller/ll_sw/isoal.h
+++ b/subsys/bluetooth/controller/ll_sw/isoal.h
@@ -15,12 +15,17 @@ typedef uint8_t isoal_status_t;
 #define ISOAL_STATUS_ERR_SOURCE_ALLOC     ((isoal_status_t) 0x02) /* Source pool full */
 #define ISOAL_STATUS_ERR_SDU_ALLOC        ((isoal_status_t) 0x04) /* SDU allocation */
 #define ISOAL_STATUS_ERR_SDU_EMIT         ((isoal_status_t) 0x08) /* SDU emission */
-#define ISOAL_STATUS_ERR_UNSPECIFIED      ((isoal_status_t) 0x10) /* Unspecified error */
+#define ISOAL_STATUS_ERR_PDU_ALLOC        ((isoal_status_t) 0x10) /* PDU allocation */
+#define ISOAL_STATUS_ERR_PDU_EMIT         ((isoal_status_t) 0x20) /* PDU emission */
+#define ISOAL_STATUS_ERR_UNSPECIFIED      ((isoal_status_t) 0x80) /* Unspecified error */
 
 #define BT_ROLE_BROADCAST (BT_CONN_ROLE_PERIPHERAL + 1)
 
 /** Handle to a registered ISO Sub-System sink */
 typedef uint8_t  isoal_sink_handle_t;
+
+/** Handle to a registered ISO Sub-System source */
+typedef uint8_t  isoal_source_handle_t;
 
 /** Byte length of an ISO SDU */
 typedef uint16_t isoal_sdu_len_t;
@@ -74,6 +79,11 @@ struct isoal_rx_origin {
 	} inst;
 };
 
+enum isoal_mode {
+	ISOAL_MODE_CIS,
+	ISOAL_MODE_BIS
+};
+
 /**
  * @brief ISO frame SDU buffer - typically an Audio frame buffer
  *
@@ -92,6 +102,23 @@ struct isoal_sdu_buffer {
 	/** Number of bytes accessible behind the dbuf pointer */
 	isoal_sdu_len_t  size;
 };
+
+
+/**
+ * @brief ISO frame PDU buffer
+ */
+struct isoal_pdu_buffer {
+	/** Additional handle for the provided pdu */
+	void             *handle;
+	/** PDU contents */
+	struct pdu_iso   *pdu;
+	/** Maximum size of the data buffer allocated for the payload in the PDU.
+	 *  Should be at least Max_PDU_C_To_P / Max_PDU_P_To_C depending on
+	 *  the role.
+	 */
+	isoal_pdu_len_t  size;
+};
+
 
 /** @brief Produced ISO SDU frame with associated meta data */
 struct isoal_sdu_produced {
@@ -112,6 +139,13 @@ struct isoal_sdu_produced {
 };
 
 
+/** @brief Produced ISO PDU encapsulation */
+struct isoal_pdu_produced {
+	/** Contents information provided at PDU allocation */
+	struct isoal_pdu_buffer contents;
+};
+
+
 /** @brief Received ISO PDU with associated meta data */
 struct isoal_pdu_rx {
 	/** Meta */
@@ -120,9 +154,25 @@ struct isoal_pdu_rx {
 	struct pdu_iso           *pdu;
 };
 
+/** @brief Received ISO SDU with associated meta data */
+struct isoal_sdu_tx {
+	/** Code word buffer
+	 *  Type, location and alignment decided by ISO sub system
+	 */
+	void *dbuf;
+	/** Number of bytes accessible behind the dbuf pointer */
+	isoal_sdu_len_t  size;
+	/** SDU packet boundary flags from HCI indicating the fragment type
+	 *  can be directly assigned to the SDU state
+	 */
+	uint8_t sdu_state;
+};
+
+
 
 /* Forward declaration */
 struct isoal_sink;
+struct node_tx_iso;
 
 /**
  * @brief  Callback: Request memory for a new ISO SDU buffer
@@ -169,10 +219,7 @@ typedef isoal_status_t (*isoal_sink_sdu_write_cb)(
 
 
 struct isoal_sink_config {
-	enum {
-		ISOAL_MODE_CIS,
-		ISOAL_MODE_BIS
-	} mode;
+	enum isoal_mode mode;
 	/* TODO add SDU and PDU max length etc. */
 };
 
@@ -215,6 +262,104 @@ struct isoal_sink {
 	struct isoal_sdu_production sdu_production;
 };
 
+/* Forward declaration */
+struct isoal_source;
+
+/**
+ * @brief  Callback: Request memory for a new ISO PDU buffer
+ *
+ * Proprietary ISO sub systems may have
+ * specific requirements or opinions on where to locate ISO PDUs; some
+ * memories may be faster, may be dynamically mapped in, etc.
+ *
+ * @return ISOAL_STATUS_ERR_ALLOC if size_request could not be fulfilled, otherwise
+ *         ISOAL_STATUS_OK.
+ */
+typedef isoal_status_t (*isoal_source_pdu_alloc_cb)(
+	/*!< [out] Struct is modified. Must not be NULL */
+	struct isoal_pdu_buffer *pdu_buffer
+);
+
+/**
+ * @brief  Callback: Release an ISO PDU
+ */
+typedef isoal_status_t (*isoal_source_pdu_release_cb)(
+	/*!< [in]  PDU to be released */
+	struct node_tx_iso *node_tx,
+	/*!< [in]  CIS/BIS handle */
+	const uint16_t handle,
+	/*!< [in]  Cause of release. ISOAL_STATUS_OK means PDU was enqueued towards
+	 *         LLL and sent or flushed, and may need further handling before
+	 *         memory is released, e.g. forwarded to HCI thread for complete-
+	 *         counting. Any other status indicates cause of error during SDU
+	 *         fragmentation/segmentation, in which case the PDU will not be
+	 *         produced.
+	 */
+	const isoal_status_t status
+);
+
+/**
+ * @brief  Callback: Write a number of bytes to PDU buffer
+ */
+typedef isoal_status_t (*isoal_source_pdu_write_cb)(
+	/*!< [out]  PDU under production */
+	struct isoal_pdu_buffer *pdu_buffer,
+	/*!< [in]  Offset within PDU buffer */
+	const size_t offset,
+	/*!< [in]  Source data */
+	const uint8_t *sdu_payload,
+	/*!< [in]  Number of bytes to be copied */
+	const size_t consume_len
+);
+
+/**
+ * @brief  Callback: Enqueue an ISO PDU
+ */
+typedef isoal_status_t (*isoal_source_pdu_emit_cb)(
+	/*!< [in]  PDU to be enqueued */
+	struct node_tx_iso *node_tx,
+	/*!< [in]  CIS/BIS handle */
+	const uint16_t handle
+);
+
+struct isoal_source_config {
+	enum isoal_mode mode;
+	/* TODO add SDU and PDU max length etc. */
+};
+
+struct isoal_source_session {
+	isoal_source_pdu_alloc_cb   pdu_alloc;
+	isoal_source_pdu_write_cb   pdu_write;
+	isoal_source_pdu_emit_cb    pdu_emit;
+	isoal_source_pdu_release_cb pdu_release;
+
+	struct isoal_source_config param;
+	isoal_sdu_cnt_t            seqn;
+	uint16_t                   handle;
+	uint8_t                    pdus_per_sdu;
+	uint8_t                    max_pdu_size;
+	uint32_t                   latency_unframed;
+	uint32_t                   latency_framed;
+};
+
+struct isoal_pdu_production {
+	/* Permit atomic enable/disable of PDU production */
+	volatile isoal_production_mode_t  mode;
+	/* We are constructing an PDU from {<1 or =1 or >1} SDUs */
+	struct isoal_pdu_produced pdu;
+	/* PDUs produced for current SDU */
+	uint8_t                   pdu_cnt;
+	isoal_pdu_len_t           pdu_written;
+	isoal_pdu_len_t           pdu_available;
+};
+
+struct isoal_source {
+	/* Session-constant */
+	struct isoal_source_session session;
+
+	/* State for PDU production */
+	struct isoal_pdu_production pdu_production;
+};
 
 isoal_status_t isoal_init(void);
 
@@ -253,3 +398,32 @@ isoal_status_t sink_sdu_emit_hci(const struct isoal_sink         *sink_ctx,
 isoal_status_t sink_sdu_write_hci(void *dbuf,
 				  const uint8_t *pdu_payload,
 				  const size_t consume_len);
+
+isoal_status_t isoal_source_create(uint16_t handle,
+				   uint8_t  role,
+				   uint8_t  burst_number,
+				   uint8_t  flush_timeout,
+				   uint8_t  max_octets,
+				   uint32_t sdu_interval,
+				   uint16_t iso_interval,
+				   uint32_t stream_sync_delay,
+				   uint32_t group_sync_delay,
+				   isoal_source_pdu_alloc_cb pdu_alloc,
+				   isoal_source_pdu_write_cb pdu_write,
+				   isoal_source_pdu_emit_cb pdu_emit,
+				   isoal_source_pdu_release_cb pdu_release,
+				   isoal_source_handle_t *hdl);
+
+struct isoal_source_config *isoal_get_source_param_ref(isoal_source_handle_t hdl);
+
+void isoal_source_enable(isoal_source_handle_t hdl);
+
+void isoal_source_disable(isoal_source_handle_t hdl);
+
+void isoal_source_destroy(isoal_source_handle_t hdl);
+
+isoal_status_t isoal_tx_sdu_fragment(isoal_source_handle_t source_hdl,
+				      const struct isoal_sdu_tx *tx_sdu);
+
+void isoal_tx_pdu_release(isoal_source_handle_t source_hdl,
+			  struct node_tx_iso *node_tx);

--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -511,6 +511,8 @@ static inline void lll_hdr_init(void *lll, void *parent)
 #define iso_rx_sched() ll_rx_sched()
 #endif /* CONFIG_BT_CTLR_ISO_VENDOR_DATA_PATH */
 
+struct node_tx_iso;
+
 void lll_done_score(void *param, uint8_t result);
 
 int lll_init(void);
@@ -549,6 +551,8 @@ void ull_rx_sched(void);
 void ull_rx_sched_done(void);
 void ull_iso_rx_put(memq_link_t *link, void *rx);
 void ull_iso_rx_sched(void);
+void *ull_iso_tx_ack_dequeue(void);
+void ull_iso_lll_ack_enqueue(uint16_t handle, struct node_tx_iso *tx);
 struct event_done_extra *ull_event_done_extra_get(void);
 struct event_done_extra *ull_done_extra_type_set(uint8_t type);
 void *ull_event_done(void *param);

--- a/subsys/bluetooth/controller/ll_sw/lll_conn_iso.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn_iso.h
@@ -43,6 +43,7 @@ struct lll_conn_iso_stream {
 	uint8_t sn:1;               /* Sequence number */
 	uint8_t nesn:1;             /* Next expected sequence number */
 	uint8_t cie:1;              /* Close isochronous event */
+	uint8_t flushed:1;          /* 1 if CIS LLL has been flushed */
 
 	/* Resumption information */
 	uint8_t next_subevent;      /* Next subevent to schedule */
@@ -70,3 +71,4 @@ int lll_conn_iso_reset(void);
 void lll_conn_iso_done(struct lll_conn_iso_group *cig, uint8_t trx_cnt,
 		       uint16_t prog_to_anchor_us, uint8_t mic_state);
 void lll_conn_iso_flush(uint16_t handle, struct lll_conn_iso_stream *lll);
+

--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -903,6 +903,15 @@ struct pdu_iso_sdu_sh {
 #endif /* __BYTE_ORDER__ */
 } __packed;
 
+enum pdu_cis_llid {
+	/** Unframed complete or end fragment */
+	PDU_CIS_LLID_COMPLETE_END = 0x00,
+	/** Unframed start or continuation fragment */
+	PDU_CIS_LLID_START_CONTINUE = 0x01,
+	/** Framed; one or more segments of a SDU */
+	PDU_CIS_LLID_FRAMED = 0x02
+};
+
 struct pdu_cis {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 	uint8_t ll_id:2;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
@@ -10,9 +10,11 @@
 #include "util/mem.h"
 #include "util/memq.h"
 #include "util/mayfly.h"
+#include "util/mfifo.h"
 #include "ticker/ticker.h"
 #include "hal/ccm.h"
 #include "hal/ticker.h"
+#include "hal/cpu.h"
 
 #include "pdu.h"
 #include "lll.h"
@@ -32,6 +34,16 @@
 #include "common/log.h"
 #include "hal/debug.h"
 
+/* Used by UTIL_LISTIFY */
+#define _INIT_MAYFLY_ARRAY(_i, _l, _fp) \
+	{ ._link = &_l[_i], .fp = _fp },
+
+/* Declare static initialized array of mayflies with associated link element */
+#define DECLARE_MAYFLY_ARRAY(_name, _fp, _cnt) \
+	static memq_link_t _links[_cnt]; \
+	static struct mayfly _name[_cnt] = \
+		{ UTIL_LISTIFY(_cnt, _INIT_MAYFLY_ARRAY, _links, _fp) }
+
 
 static int init_reset(void);
 static void ticker_update_cig_op_cb(uint32_t status, void *param);
@@ -43,6 +55,8 @@ static void cis_disabled_cb(void *param);
 static void ticker_stop_op_cb(uint32_t status, void *param);
 static void cig_disable(void *param);
 static void cig_disabled_cb(void *param);
+static void disable(uint16_t handle);
+static void cis_tx_lll_flush(void *param);
 
 static struct ll_conn_iso_stream cis_pool[CONFIG_BT_CTLR_CONN_ISO_STREAMS];
 static void *cis_free;
@@ -295,6 +309,7 @@ void ull_conn_iso_cis_stop(struct ll_conn_iso_stream *cis,
 		/* Teardown already started */
 		return;
 	}
+
 	cis->teardown = 1;
 	cis->released_cb = cis_released_cb;
 	cis->terminate_reason = reason;
@@ -496,15 +511,32 @@ static void cis_disabled_cb(void *param)
 		cis = ll_conn_iso_stream_get_by_group(cig, &handle_iter);
 		LL_ASSERT(cis);
 
-		if (cis->teardown) {
+		if (cis->lll.flushed) {
 			ll_iso_stream_released_cb_t cis_released_cb;
-			struct node_rx_pdu *node_terminate;
 			struct ll_conn *conn;
 
 			conn = ll_conn_get(cis->lll.acl_handle);
 			cis_released_cb = cis->released_cb;
 
-			/* Create and enqueue termination node */
+			ll_conn_iso_stream_release(cis);
+			cig->lll.num_cis--;
+
+			/* Check if removed CIS has an ACL disassociation callback. Invoke
+			 * the callback to allow cleanup.
+			 */
+			if (cis_released_cb) {
+				/* CIS removed - notify caller */
+				cis_released_cb(conn);
+			}
+		} else if (cis->teardown) {
+			DECLARE_MAYFLY_ARRAY(mfys, cis_tx_lll_flush,
+				CONFIG_BT_CTLR_CONN_ISO_GROUPS);
+			struct node_rx_pdu *node_terminate;
+			uint32_t ret;
+
+			/* Create and enqueue termination node. This shall prevent
+			 * further enqueuing of TX nodes for terminating CIS.
+			 */
 			node_terminate = ull_pdu_rx_alloc();
 			LL_ASSERT(node_terminate);
 			node_terminate->hdr.handle = cis->lll.handle;
@@ -514,16 +546,27 @@ static void cis_disabled_cb(void *param)
 			ll_rx_put(node_terminate->hdr.link, node_terminate);
 			ll_rx_sched();
 
-			ll_conn_iso_stream_release(cis);
-			cig->lll.num_cis--;
+			if (cig->lll.resume_cis == cis->lll.handle) {
+				/* Resume pending for terminating CIS - stop ticker */
+				(void)ticker_stop(TICKER_INSTANCE_ID_CTLR,
+						  TICKER_USER_ID_ULL_HIGH,
+						  TICKER_ID_CONN_ISO_RESUME_BASE +
+						  ll_conn_iso_group_handle_get(cig),
+						  NULL, NULL);
 
-			/* Check if removed CIS had an ACL disassociation callback. Invoke
-			 * the callback to allow cleanup.
-			 */
-			if (cis_released_cb) {
-				/* CIS removed - notify caller */
-				cis_released_cb(conn);
+				cig->lll.resume_cis = LLL_HANDLE_INVALID;
 			}
+
+			/* We need to flush TX nodes in LLL before releasing the stream.
+			 * More than one CIG may be terminating at the same time, so
+			 * enqueue a mayfly instance for this CIG.
+			 */
+			mfys[cig->lll.handle].param = &cis->lll;
+			ret = mayfly_enqueue(TICKER_USER_ID_ULL_HIGH,
+					     TICKER_USER_ID_LLL, 1, &mfys[cig->lll.handle]);
+			LL_ASSERT(!ret);
+
+			return;
 		}
 	}
 
@@ -541,6 +584,44 @@ static void cis_disabled_cb(void *param)
 		LL_ASSERT((ticker_status == TICKER_STATUS_SUCCESS) ||
 			  (ticker_status == TICKER_STATUS_BUSY));
 	}
+}
+
+static void cis_tx_lll_flush(void *param)
+{
+	DECLARE_MAYFLY_ARRAY(mfys, cis_disabled_cb, CONFIG_BT_CTLR_CONN_ISO_GROUPS);
+
+	struct lll_conn_iso_stream *lll;
+	struct ll_conn_iso_stream *cis;
+	struct ll_conn_iso_group *cig;
+	struct node_tx *tx;
+	memq_link_t *link;
+	uint32_t ret;
+
+	lll = param;
+	lll->flushed = 1;
+
+	cis = ll_conn_iso_stream_get(lll->handle);
+	cig = cis->group;
+
+	/* Flush in LLL - may return TX nodes to ack queue */
+	lll_conn_iso_flush(lll->handle, lll);
+
+	link = memq_dequeue(lll->memq_tx.tail, &lll->memq_tx.head, (void **)&tx);
+	while (link) {
+		/* Create instant NACK */
+		ll_tx_ack_put(lll->handle, tx);
+		link->next = tx->next;
+		tx->next = link;
+
+		link = memq_dequeue(lll->memq_tx.tail, &lll->memq_tx.head,
+				    (void **)&tx);
+	}
+
+	/* Resume CIS teardown in ULL_HIGH context */
+	mfys[cig->lll.handle].param = &cig->lll;
+	ret = mayfly_enqueue(TICKER_USER_ID_LLL,
+			     TICKER_USER_ID_ULL_HIGH, 1, &mfys[cig->lll.handle]);
+	LL_ASSERT(!ret);
 }
 
 static void ticker_stop_op_cb(uint32_t status, void *param)
@@ -598,6 +679,4 @@ static void cig_disabled_cb(void *param)
 	cig = HDR_LLL2ULL(param);
 
 	ll_conn_iso_group_release(cig);
-
-	/* TODO: Flush pending TX in LLL */
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
@@ -6,6 +6,7 @@
 
 #include <zephyr.h>
 #include <sys/byteorder.h>
+#include <bluetooth/bluetooth.h>
 
 #include "util/mem.h"
 #include "util/memq.h"
@@ -28,6 +29,8 @@
 #include "ull_conn_iso_internal.h"
 #include "ull_internal.h"
 #include "lll/lll_vendor.h"
+
+#include "ll.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_ull_conn_iso
@@ -518,6 +521,12 @@ static void cis_disabled_cb(void *param)
 			conn = ll_conn_get(cis->lll.acl_handle);
 			cis_released_cb = cis->released_cb;
 
+			/* Remove data path and ISOAL sink/source associated with this CIS
+			 * for both directions.
+			 */
+			ll_remove_iso_path(cis->lll.handle, BT_HCI_DATAPATH_DIR_CTLR_TO_HOST);
+			ll_remove_iso_path(cis->lll.handle, BT_HCI_DATAPATH_DIR_HOST_TO_CTLR);
+	
 			ll_conn_iso_stream_release(cis);
 			cig->lll.num_cis--;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso.c
@@ -55,6 +55,19 @@
 
 static int init_reset(void);
 
+#if defined(CONFIG_BT_CTLR_CONN_ISO)
+static isoal_status_t ll_iso_pdu_alloc(struct isoal_pdu_buffer *pdu_buffer);
+static isoal_status_t ll_iso_pdu_write(struct isoal_pdu_buffer *pdu_buffer,
+				       const size_t   offset,
+				       const uint8_t *sdu_payload,
+				       const size_t   consume_len);
+static isoal_status_t ll_iso_pdu_emit(struct node_tx_iso *node_tx,
+				      const uint16_t handle);
+static isoal_status_t ll_iso_pdu_release(struct node_tx_iso *node_tx,
+					 const uint16_t handle,
+					 const isoal_status_t status);
+#endif /* CONFIG_BT_CTLR_CONN_ISO */
+
 /* Allocate data path pools for RX/TX directions for each stream */
 #define BT_CTLR_ISO_STREAMS ((2 * (BT_CTLR_CONN_ISO_STREAMS)) + \
 			     BT_CTLR_SYNC_ISO_STREAMS)
@@ -148,6 +161,21 @@ __weak bool ll_data_path_sink_create(struct ll_iso_datapath *datapath,
 	return false;
 }
 
+/* Could be implemented by vendor */
+__weak bool ll_data_path_source_create(struct ll_iso_datapath *datapath,
+				       isoal_source_pdu_alloc_cb *pdu_alloc,
+				       isoal_source_pdu_write_cb *pdu_write,
+				       isoal_source_pdu_emit_cb *pdu_emit,
+				       isoal_source_pdu_release_cb *pdu_release)
+{
+	ARG_UNUSED(datapath);
+	ARG_UNUSED(pdu_alloc);
+	ARG_UNUSED(pdu_write);
+	ARG_UNUSED(pdu_release);
+
+	return false;
+}
+
 static inline bool path_is_vendor_specific(uint8_t path_id)
 {
 	return (path_id >= BT_HCI_DATAPATH_ID_VS &&
@@ -163,6 +191,10 @@ uint8_t ll_setup_iso_path(uint16_t handle, uint8_t path_dir, uint8_t path_id,
 	ARG_UNUSED(codec_config_len);
 	ARG_UNUSED(codec_config);
 
+#if defined(CONFIG_BT_CTLR_CONN_ISO)
+	isoal_source_handle_t source_handle;
+	uint8_t max_octets;
+#endif /* CONFIG_BT_CTLR_CONN_ISO */
 	isoal_sink_handle_t sink_handle;
 	uint32_t stream_sync_delay;
 	uint32_t group_sync_delay;
@@ -177,6 +209,7 @@ uint8_t ll_setup_iso_path(uint16_t handle, uint8_t path_dir, uint8_t path_id,
 		return 0;
 	}
 
+#if defined(CONFIG_BT_CTLR_SYNC_ISO)
 	if (path_dir != BT_HCI_DATAPATH_DIR_CTLR_TO_HOST) {
 		/* FIXME: workaround to succeed datapath setup for ISO
 		 *        broadcaster until Tx datapath is implemented, in the
@@ -184,6 +217,7 @@ uint8_t ll_setup_iso_path(uint16_t handle, uint8_t path_dir, uint8_t path_id,
 		 */
 		return BT_HCI_ERR_SUCCESS;
 	}
+#endif /* CONFIG_BT_CTLR_SYNC_ISO */
 
 #if defined(CONFIG_BT_CTLR_CONN_ISO)
 	struct ll_iso_datapath *dp_in = NULL;
@@ -266,22 +300,11 @@ uint8_t ll_setup_iso_path(uint16_t handle, uint8_t path_dir, uint8_t path_id,
 	stream_sync_delay = cis->sync_delay;
 	group_sync_delay = cig->sync_delay;
 
-	if (path_dir == BT_HCI_DATAPATH_DIR_HOST_TO_CTLR) {
-		burst_number  = cis->lll.tx.burst_number;
-		flush_timeout = cis->lll.tx.flush_timeout;
-
-		if (role) {
-			/* peripheral */
-			sdu_interval = cig->p_sdu_interval;
-		} else {
-			/* central */
-			sdu_interval = cig->c_sdu_interval;
-		}
-
-		cis->hdr.datapath_in = dp;
-	} else {
-		burst_number =  cis->lll.rx.burst_number;
+	if (path_dir == BT_HCI_DATAPATH_DIR_CTLR_TO_HOST) {
+		/* Create sink for RX data path */
+		burst_number  = cis->lll.rx.burst_number;
 		flush_timeout = cis->lll.rx.flush_timeout;
+		max_octets    = cis->lll.rx.max_octets;
 
 		if (role) {
 			/* peripheral */
@@ -292,8 +315,91 @@ uint8_t ll_setup_iso_path(uint16_t handle, uint8_t path_dir, uint8_t path_id,
 		}
 
 		cis->hdr.datapath_out = dp;
+
+		if (path_id == BT_HCI_DATAPATH_ID_HCI) {
+			/* Not vendor specific, thus alloc and emit functions known */
+			err = isoal_sink_create(handle, role,
+						burst_number, flush_timeout,
+						sdu_interval, iso_interval,
+						stream_sync_delay, group_sync_delay,
+						sink_sdu_alloc_hci, sink_sdu_emit_hci,
+						sink_sdu_write_hci, &sink_handle);
+		} else {
+			/* Set up vendor specific data path */
+			isoal_sink_sdu_alloc_cb sdu_alloc;
+			isoal_sink_sdu_emit_cb  sdu_emit;
+			isoal_sink_sdu_write_cb sdu_write;
+
+			/* Request vendor sink callbacks for path */
+			if (ll_data_path_sink_create(dp, &sdu_alloc, &sdu_emit, &sdu_write)) {
+				err = isoal_sink_create(handle, role,
+							burst_number, flush_timeout,
+							sdu_interval, iso_interval,
+							stream_sync_delay, group_sync_delay,
+							sdu_alloc, sdu_emit, sdu_write,
+							&sink_handle);
+			} else {
+				return BT_HCI_ERR_CMD_DISALLOWED;
+			}
+		}
+
+		if (!err) {
+			dp->sink_hdl = sink_handle;
+			isoal_sink_enable(sink_handle);
+		} else {
+			return BT_HCI_ERR_CMD_DISALLOWED;
+		}
+	} else  {
+		burst_number  = cis->lll.tx.burst_number;
+		flush_timeout = cis->lll.tx.flush_timeout;
+		max_octets    = cis->lll.tx.max_octets;
+
+		if (role) {
+			/* peripheral */
+			sdu_interval = cig->p_sdu_interval;
+		} else {
+			/* central */
+			sdu_interval = cig->c_sdu_interval;
+		}
+
+		cis->hdr.datapath_in = dp;
+
+		/* Create source for TX data path */
+		isoal_source_pdu_alloc_cb   pdu_alloc;
+		isoal_source_pdu_write_cb   pdu_write;
+		isoal_source_pdu_emit_cb    pdu_emit;
+		isoal_source_pdu_release_cb pdu_release;
+
+		/* Set default callbacks assuming not vendor specific
+		 * or that the vendor specific path is the same.
+		 */
+		pdu_alloc   = ll_iso_pdu_alloc;
+		pdu_write   = ll_iso_pdu_write;
+		pdu_emit    = ll_iso_pdu_emit;
+		pdu_release = ll_iso_pdu_release;
+
+		if (path_is_vendor_specific(path_id)) {
+			if (!ll_data_path_source_create(dp, &pdu_alloc, &pdu_write,
+							&pdu_emit, &pdu_release)) {
+				return BT_HCI_ERR_CMD_DISALLOWED;
+			}
+		}
+
+		err = isoal_source_create(handle, role,
+					  burst_number, flush_timeout, max_octets,
+					  sdu_interval, iso_interval,
+					  stream_sync_delay, group_sync_delay,
+					  pdu_alloc, pdu_write, pdu_emit,
+					  pdu_release, &source_handle);
+
+		if (!err) {
+			dp->source_hdl = source_handle;
+			isoal_source_enable(source_handle);
+		} else {
+			return BT_HCI_ERR_CMD_DISALLOWED;
+		}
 	}
-#endif
+#endif /* CONFIG_BT_CTLR_CONN_ISO */
 
 #if defined(CONFIG_BT_CTLR_SYNC_ISO)
 	struct ll_sync_iso_set *sync_iso;
@@ -306,7 +412,6 @@ uint8_t ll_setup_iso_path(uint16_t handle, uint8_t path_dir, uint8_t path_id,
 	burst_number = lll_iso->bn;
 	sdu_interval = lll_iso->sdu_interval;
 	iso_interval = lll_iso->iso_interval;
-#endif /* CONFIG_BT_CTLR_SYNC_ISO */
 
 	if (path_id == BT_HCI_DATAPATH_ID_HCI) {
 		/* Not vendor specific, thus alloc and emit functions known */
@@ -338,9 +443,7 @@ uint8_t ll_setup_iso_path(uint16_t handle, uint8_t path_dir, uint8_t path_id,
 	}
 
 	if (!err) {
-#if defined(CONFIG_BT_CTLR_SYNC_ISO)
 		stream->dp = dp;
-#endif /* CONFIG_BT_CTLR_SYNC_ISO */
 
 		dp->sink_hdl = sink_handle;
 		isoal_sink_enable(sink_handle);
@@ -349,7 +452,7 @@ uint8_t ll_setup_iso_path(uint16_t handle, uint8_t path_dir, uint8_t path_id,
 
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
-
+#endif /* CONFIG_BT_CTLR_SYNC_ISO */
 	return 0;
 }
 
@@ -731,6 +834,62 @@ void ull_iso_datapath_release(struct ll_iso_datapath *dp)
 {
 	mem_release(dp, &datapath_free);
 }
+
+#if defined(CONFIG_BT_CTLR_CONN_ISO)
+/**
+ * Allocate a PDU from the LL and store the details in the given buffer. Allocation
+ * is not expected to fail as there must always be sufficient PDU buffers. Any
+ * failure will trigger the assert.
+ * @param[in]  pdu_buffer Buffer to store PDU details in
+ * @return     Error status of operation
+ */
+static isoal_status_t ll_iso_pdu_alloc(struct isoal_pdu_buffer *pdu_buffer)
+{
+	return ISOAL_STATUS_OK;
+}
+
+/**
+ * Write the given SDU payload to the target PDU buffer at the given offset.
+ * @param[in,out]  pdu_buffer  Target PDU buffer
+ * @param[in]      pdu_offset  Offset / current write position within PDU
+ * @param[in]      sdu_payload Location of source data
+ * @param[in]      consume_len Length of data to copy
+ * @return         Error status of write operation
+ */
+static isoal_status_t ll_iso_pdu_write(struct isoal_pdu_buffer *pdu_buffer,
+				       const size_t  pdu_offset,
+				       const uint8_t *sdu_payload,
+				       const size_t  consume_len)
+{
+	return ISOAL_STATUS_OK;
+}
+
+/**
+ * Emit the encoded node to the transmission queue
+ * @param node_tx TX node to enqueue
+ * @param handle  CIS/BIS handle
+ * @return        Error status of enqueue operation
+ */
+static isoal_status_t ll_iso_pdu_emit(struct node_tx_iso *node_tx,
+				      const uint16_t handle)
+{
+	return ISOAL_STATUS_OK;
+}
+
+/**
+ * Release the given payload back to the memory pool.
+ * @param node_tx TX node to release or forward
+ * @param handle  CIS/BIS handle
+ * @param status  Reason for release
+ * @return        Error status of release operation
+ */
+static isoal_status_t ll_iso_pdu_release(struct node_tx_iso *node_tx,
+					 const uint16_t handle,
+					 const isoal_status_t status)
+{
+	return ISOAL_STATUS_OK;
+}
+#endif /* CONFIG_BT_CTLR_CONN_ISO */
 
 static int init_reset(void)
 {

--- a/subsys/bluetooth/controller/ll_sw/ull_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso.c
@@ -488,12 +488,16 @@ uint8_t ll_remove_iso_path(uint16_t handle, uint8_t path_dir)
 	if (path_dir == BT_HCI_DATAPATH_DIR_HOST_TO_CTLR) {
 		dp = hdr->datapath_in;
 		if (dp) {
+			isoal_source_destroy(dp->source_hdl);
+
 			hdr->datapath_in = NULL;
 			ull_iso_datapath_release(dp);
 		}
 	} else if (path_dir == BT_HCI_DATAPATH_DIR_CTLR_TO_HOST) {
 		dp = hdr->datapath_out;
 		if (dp) {
+			isoal_sink_destroy(dp->sink_hdl);
+
 			hdr->datapath_out = NULL;
 			ull_iso_datapath_release(dp);
 		}
@@ -523,6 +527,8 @@ uint8_t ll_remove_iso_path(uint16_t handle, uint8_t path_dir)
 
 	dp = stream->dp;
 	if (dp) {
+		isoal_sink_destroy(dp->sink_hdl);
+
 		stream->dp = NULL;
 		ull_iso_datapath_release(dp);
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_iso_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso_types.h
@@ -37,4 +37,5 @@ struct ll_iso_datapath {
 	uint8_t  coding_format;
 	uint16_t company_id;
 	isoal_sink_handle_t sink_hdl;
+	isoal_source_handle_t source_hdl;
 };

--- a/subsys/bluetooth/controller/ll_sw/ull_iso_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso_types.h
@@ -25,6 +25,9 @@
 #define IS_CIS_HANDLE(_handle) 0
 #endif /* CONFIG_BT_CTLR_CONN_ISO */
 
+/* ISO LL conformance tests require a PDU size of maximum 251 bytes */
+#define ISO_TX_BUFFER_SIZE 251
+
 /* Common memebers for ll_conn_iso_stream and ll_broadcast_iso_stream */
 struct ll_iso_stream_hdr {
 	struct ll_iso_datapath *datapath_in;

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
@@ -143,6 +143,7 @@ uint8_t ull_peripheral_iso_acquire(struct ll_conn *acl,
 	cis->lll.sn = 0;
 	cis->lll.nesn = 0;
 	cis->lll.cie = 0;
+	cis->lll.flushed = 0;
 
 	cis->lll.rx.phy = req->c_phy;
 	cis->lll.rx.burst_number = req->c_bn;

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
@@ -154,6 +154,14 @@ uint8_t ull_peripheral_iso_acquire(struct ll_conn *acl,
 	cis->lll.tx.flush_timeout = req->p_ft;
 	cis->lll.tx.max_octets = sys_le16_to_cpu(req->p_max_pdu);
 
+	if (!cis->lll.link_tx_free) {
+		cis->lll.link_tx_free = &cis->lll.link_tx;
+	}
+
+	memq_init(cis->lll.link_tx_free, &cis->lll.memq_tx.head,
+		  &cis->lll.memq_tx.tail);
+	cis->lll.link_tx_free = NULL;
+
 	*cis_handle = ll_conn_iso_stream_handle_get(cis);
 	cig->lll.num_cis++;
 

--- a/tests/bluetooth/bsim_bt/bsim_test_advx/src/main.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_advx/src/main.c
@@ -15,6 +15,7 @@
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/hci.h>
 
+#include "../util/memq.h"
 #include "ll.h"
 
 #include "bs_types.h"

--- a/tests/bluetooth/bsim_bt/bsim_test_iso/src/main.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_iso/src/main.c
@@ -17,8 +17,8 @@
 #include <bluetooth/iso.h>
 
 #include "subsys/bluetooth/host/hci_core.h"
-#include "subsys/bluetooth/controller/include/ll.h"
 #include "subsys/bluetooth/controller/util/memq.h"
+#include "subsys/bluetooth/controller/include/ll.h"
 #include "subsys/bluetooth/controller/ll_sw/lll.h"
 
 #include "bs_types.h"


### PR DESCRIPTION
**tests: bluetooth: Includes modified for new type in ll.h**

memq_link_t is now used in LL prototypes, and must be defined prior to
including ll.h.

**bluetooth: controller: Remove ISO data path when releasing a CIS**

Remove associated ISO data path when releasing a CIS. This includes
deallocation of ISOAL sink/source instances.

**Bluetooth: controller: ISO TX flush handling**

Implements staged flushing of ISO TX nodes in LLL, with hand-off to ULL
upon completion.

**Bluetooth: controller: Implemented ISO TX HCI data path**

- Implements data path from HCI to LL by providing the ISOAL callbacks
  for the path, and implementing CIS specific handling.
- Removes BT_CTLR_ISO_TX_BUFFER_SIZE, and defines ISO TX buffer size to
  hard-coded value of 251, as per spec requirements.
- Uses ACL TX ack handling for ISO TX ack.

**Bluetooth: controller: Add ISO-AL TX unframed fragmentation**

- Implemented ISO-AL TX interface functions for fragmentation of
  unframed PDUs
- Implemented ISO-AL source construct and its creation for an input
  data path
- Routed ISO SDUs from HCI to ISO-AL unframed fragmentation