### PR TITLE
Remove some unused but set variables

### DIFF
--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -781,6 +781,10 @@ void z_phys_unmap(uint8_t *virt, size_t size)
 		 aligned_virt, aligned_size);
 
 	key = k_spin_lock(&z_mm_lock);
+
+	LOG_DBG("arch_mem_unmap(0x%lx, %zu) offset %lu",
+		aligned_virt, aligned_size, addr_offset);
+
 	arch_mem_unmap(UINT_TO_POINTER(aligned_virt), aligned_size);
 	virt_region_free(virt, size);
 	k_spin_unlock(&z_mm_lock, key);

--- a/lib/os/bitarray.c
+++ b/lib/os/bitarray.c
@@ -70,7 +70,6 @@ static bool match_region(sys_bitarray_t *bitarray, size_t offset,
 	int idx;
 	uint32_t bundle;
 	uint32_t mismatch_bundle;
-	uint32_t mismatch_mask;
 	size_t mismatch_bundle_idx;
 	size_t mismatch_bit_off;
 
@@ -86,7 +85,6 @@ static bool match_region(sys_bitarray_t *bitarray, size_t offset,
 			/* Not matching to mask. */
 			mismatch_bundle = ~bundle & bd->smask;
 			mismatch_bundle_idx = bd->sidx;
-			mismatch_mask = bd->smask;
 			goto mismatch;
 		} else {
 			/* Matching to mask. */
@@ -106,7 +104,6 @@ static bool match_region(sys_bitarray_t *bitarray, size_t offset,
 		/* Start bundle not matching to mask. */
 		mismatch_bundle = ~bundle & bd->smask;
 		mismatch_bundle_idx = bd->sidx;
-		mismatch_mask = bd->smask;
 		goto mismatch;
 	}
 
@@ -120,7 +117,6 @@ static bool match_region(sys_bitarray_t *bitarray, size_t offset,
 		/* End bundle not matching to mask. */
 		mismatch_bundle = ~bundle & bd->emask;
 		mismatch_bundle_idx = bd->eidx;
-		mismatch_mask = bd->emask;
 		goto mismatch;
 	}
 
@@ -138,7 +134,6 @@ static bool match_region(sys_bitarray_t *bitarray, size_t offset,
 			/* Bits in "between bundles" do not match */
 			mismatch_bundle = ~bundle;
 			mismatch_bundle_idx = idx;
-			mismatch_mask = ~0U;
 			goto mismatch;
 		}
 	}

--- a/tests/kernel/common/src/errno.c
+++ b/tests/kernel/common/src/errno.c
@@ -51,7 +51,7 @@ static void errno_thread(void *_n, void *_my_errno, void *_unused)
 
 	k_msleep(30 - (n * 10));
 	if (errno == my_errno) {
-		result[n].pass = 1;
+		result[n].pass = TC_PASS;
 	}
 
 	zassert_equal(errno, my_errno, NULL);
@@ -91,7 +91,7 @@ void test_thread_context(void)
 	for (int ii = 0; ii < N_THREADS; ii++) {
 		struct result *p = k_fifo_get(&fifo, K_MSEC(100));
 
-		if (!p || !p->pass) {
+		if (!p || (p->pass != TC_PASS)) {
 			rv = TC_FAIL;
 		}
 	}
@@ -105,6 +105,10 @@ void test_thread_context(void)
 	/* Make sure all the test thread end. */
 	for (int ii = 0; ii < N_THREADS; ii++) {
 		k_thread_join(&threads[ii], K_FOREVER);
+	}
+
+	if (rv != TC_PASS) {
+		ztest_test_fail();
 	}
 }
 


### PR DESCRIPTION
There are a few unused but set variables when trying to build with Clang. So fix them accordingly... see individual commits for more details.

(There could probably more set but unused variables, so need to tackle them one by one when found.)