### PR TITLE
drivers: espi: xec: mec172x: Fix compilation when OOB RX async is ena…

### DIFF
--- a/drivers/espi/espi_mchp_xec_v2.c
+++ b/drivers/espi/espi_mchp_xec_v2.c
@@ -910,7 +910,7 @@ static void espi_oob_down_isr(const struct device *dev)
 #ifndef CONFIG_ESPI_OOB_CHANNEL_RX_ASYNC
 		k_sem_give(&data->rx_lock);
 #else
-		evt.evt_details = ESPI_OOB_REGS->RX_LEN &
+		evt.evt_details = regs->OOBRXL &
 				  MCHP_ESPI_OOB_RX_LEN_MASK;
 		espi_send_callbacks(&data->callbacks, dev, evt);
 #endif


### PR DESCRIPTION
Re-submitting https://github.com/zephyrproject-rtos/zephyr/pull/42802 due to automation failures

Correct MEC172x OOB register access that causes compilation error,
Use device-tree-based register access instead of HAL access
This occurs whenever CONFIG_ESPI_OOB_CHANNEL_RX_ASYNC is
enabled.

Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>