### PR TITLE
lorawan: Run LoraMacProcess on system work queue

### DIFF
--- a/subsys/lorawan/lorawan.c
+++ b/subsys/lorawan/lorawan.c
@@ -75,6 +75,9 @@ static LoRaMacEventInfoStatus_t last_mlme_indication_status;
 static uint8_t (*getBatteryLevelUser)(void);
 static void (*dr_change_cb)(enum lorawan_datarate dr);
 
+static void mac_process_work_handler(struct k_work *work);
+static K_WORK_DEFINE(mac_process_work, mac_process_work_handler);
+
 void BoardGetUniqueId(uint8_t *id)
 {
 	/* Do not change the default value */
@@ -89,9 +92,16 @@ static uint8_t getBatteryLevelLocal(void)
 	return 255;
 }
 
+static void mac_process_work_handler(struct k_work *work)
+{
+	ARG_UNUSED(work);
+
+	LoRaMacProcess();
+}
+
 static void OnMacProcessNotify(void)
 {
-	LoRaMacProcess();
+	k_work_submit(&mac_process_work);
 }
 
 static void datarate_observe(bool force_notification)


### PR DESCRIPTION
Submit a work item to run LoraMacProcess on the system work queue
when signalled through OnMacProcessNotify, instead of executing
it directly.

The MacProcessNotify callback of LoraMacCallback_t carries this warning:
"Runs in a IRQ context. Should only change variables state."
The first part is not strictly true in the Zephyr integration as the
"IRQ context" in this case is executed on the system work queue,
but the second sentence should still be heeded.

Signed-off-by: Alexander Mihajlovic <a@abxy.se>