### PR TITLE
LPCXPresso55S69-evk dtsi file incorrect

### DIFF
--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69.dtsi
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69.dtsi
@@ -16,17 +16,17 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led: led_1 {
-			gpios = <&gpio1 7 0>;
+			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
 			label = "User LD2";
 			status = "disabled";
 		};
 		blue_led: led_2 {
-			gpios = <&gpio1 4 0>;
+			gpios = <&gpio1 4 GPIO_ACTIVE_LOW>;
 			label = "User LD3";
 			status = "disabled";
 		};
 		red_led: led_3 {
-			gpios = <&gpio1 6 0>;
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
 			label = "User LD4";
 			status = "disabled";
 		};


### PR DESCRIPTION
Updated the active state for the LPCXpresso55S69 board LEDs to reflect their proper active state.

Fixes #43131