### PR TITLE
Bluetooth: audio: Fix BT_CODEC_LC3_CONFIG_48_3 definition

### DIFF
--- a/include/bluetooth/audio/lc3.h
+++ b/include/bluetooth/audio/lc3.h
@@ -346,7 +346,7 @@ struct bt_codec_lc3_frame_len {
  */
 #define BT_CODEC_LC3_CONFIG_48_3 \
 	BT_CODEC_LC3_CONFIG(BT_CODEC_CONFIG_LC3_FREQ_48KHZ, \
-			    BT_CODEC_LC3_DURATION_7_5, 90u, \
+			    BT_CODEC_CONFIG_LC3_DURATION_7_5, 90u, \
 			    BT_CODEC_META_CONTEXT_MEDIA)
 /** @def BT_CODEC_LC3_CONFIG_48_4
  *  @brief Helper to declare LC3 48.4 codec configuration


### PR DESCRIPTION
This fixes invalid codec configuration duration value.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>