### PR TITLE
ci: clang: split workflow

### DIFF
--- a/.github/workflows/clang-publish.yaml
+++ b/.github/workflows/clang-publish.yaml
@@ -1,0 +1,56 @@
+name: Publish Clang/LLVM Build Results
+
+on:
+  workflow_run:
+    workflows: ["Build with Clang/LLVM"]
+    types:
+      - completed
+
+jobs:
+  clang-publish:
+    name: "Publish Clang/LLVM Build Results"
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion != 'skipped'
+
+    steps:
+      - name: Download artifacts
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: clang.yaml
+          path: artifacts
+          run_id: ${{ github.event.workflow_run.id }}
+
+      - name: Check for reports
+        id: check-reports
+        run: |
+          # Check if any report was generated
+          if find artifacts -name twister.xml | grep .; then
+            echo "::set-output name=report_needed::1";
+          else
+            echo "::set-output name=report_needed::0";
+          fi
+
+      - name: Merge Test Results
+        if: steps.check-reports.outputs.report_needed != 0
+        run: |
+          pip3 install junitparser junit2html
+          junitparser merge artifacts/*/twister.xml junit.xml
+          junit2html junit.xml junit-clang.html
+
+      - name: Upload Unit Test Results in HTML
+        if: steps.check-reports.outputs.report_needed != 0
+        uses: actions/upload-artifact@v2
+        with:
+          name: HTML Unit Test Results
+          path: junit-clang.html
+
+      - name: Publish Unit Test Results
+        if: steps.check-reports.outputs.report_needed != 0
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          check_name: Unit Test Results
+          comment_mode: off
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: artifacts/event/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          files: "**/twister.xml"

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -65,30 +65,6 @@ jobs:
           gcc --version
           ls -la
 
-      - name: Prepare ccache timestamp/data
-        id: ccache_cache_timestamp
-        shell: cmake -P {0}
-        run: |
-          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-          string(REPLACE "/" "_" repo ${{github.repository}})
-          string(REPLACE "-" "_" repo2 ${repo})
-          message("::set-output name=repo::${repo2}")
-      - name: use cache
-        id: cache-ccache
-        uses: nashif/action-s3-cache@master
-        with:
-          key: ${{ steps.ccache_cache_timestamp.outputs.repo }}-${{ github.ref_name }}-clang-${{ matrix.platform }}-ccache
-          path: /github/home/.ccache
-          aws-s3-bucket: ccache.zephyrproject.org
-          aws-access-key-id: ${{ secrets.CCACHE_S3_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.CCACHE_S3_SECRET_ACCESS_KEY }}
-          aws-region: us-east-2
-
-      - name: ccache stats initial
-        run: |
-          test -d github/home/.ccache && rm -rf /github/home/.ccache && mv github/home/.ccache /github/home/.ccache
-          ccache -M 10G -s
-
       - name: Run Tests with Twister
         id: twister
         run: |
@@ -107,10 +83,6 @@ jobs:
             # if nothing is run, skip reporting step
             echo "::set-output name=report_needed::0";
           fi
-
-      - name: ccache stats post
-        run: |
-          ccache -s
 
       - name: Upload Unit Test Results
         if: always() && steps.twister.outputs.report_needed != 0

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -1,6 +1,6 @@
 name: Build with Clang/LLVM
 
-on: pull_request_target
+on: pull_request
 
 jobs:
   clang-build-prep:
@@ -27,18 +27,14 @@ jobs:
       CLANG_ROOT_DIR: /usr/lib/llvm-12
       COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
       BASE_REF: ${{ github.base_ref }}
-    outputs:
-      report_needed: ${{ steps.twister.outputs.report_needed }}
     steps:
       - name: Cleanup
         run: |
           # hotfix, until we have a better way to deal with existing data
           rm -rf zephyr zephyr-testing
+
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
 
       - name: Environment Setup
         run: |
@@ -76,51 +72,22 @@ jobs:
 
           # We can limit scope to just what has changed
           if [ -s testplan.csv ]; then
-            echo "::set-output name=report_needed::1";
             # Full twister but with options based on changes
             ./scripts/twister --inline-logs -M -N -v --load-tests testplan.csv --retry-failed 2
-          else
-            # if nothing is run, skip reporting step
-            echo "::set-output name=report_needed::0";
           fi
 
       - name: Upload Unit Test Results
-        if: always() && steps.twister.outputs.report_needed != 0
+        if: always()
         uses: actions/upload-artifact@v2
         with:
           name: Unit Test Results (Subset ${{ matrix.platform }})
           path: twister-out/twister.xml
+          if-no-files-found: ignore
 
-  clang-build-results:
-    name: "Publish Unit Tests Results"
-    needs: clang-build
-    runs-on: ubuntu-20.04
-    if: (success() || failure() ) && needs.clang-build.outputs.report_needed != 0
-    steps:
-      - name: Download Artifacts
-        uses: actions/download-artifact@v2
-        with:
-          path: artifacts
-      - name: Merge Test Results
-        run: |
-          pip3 install junitparser junit2html
-          junitparser merge artifacts/*/twister.xml junit.xml
-          junit2html junit.xml junit-clang.html
-
-      - name: Upload Unit Test Results in HTML
+      - name: Upload Event Details
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: HTML Unit Test Results
-          if-no-files-found: ignore
+          name: event
           path: |
-            junit-clang.html
-
-      - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
-        if: always()
-        with:
-          check_name: Unit Test Results
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          files: "**/twister.xml"
-          comment_mode: off
+            ${{ github.event_path }}


### PR DESCRIPTION
This patch splits the clang workflow into 2:

- One that runs the tests
- A second one that processes the results and publishes them

It also removes usage of ccache until we find a way to handle AWS upload in a
`workflow_run` context.