### PR TITLE
ci: twister: split workflow

### DIFF
--- a/.github/workflows/twister-publish.yml
+++ b/.github/workflows/twister-publish.yml
@@ -1,0 +1,56 @@
+name: Publish Twister Results
+
+on:
+  workflow_run:
+    workflows: ["Run tests with twister"]
+    types:
+      - completed
+
+jobs:
+  twister-publish:
+    name: "Publish Twister Results"
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion != 'skipped'
+
+    steps:
+      - name: Download artifacts
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: twister.yaml
+          path: artifacts
+          run_id: ${{ github.event.workflow_run.id }}
+
+      - name: Check for reports
+        id: check-reports
+        run: |
+          # Check if any report was generated
+          if find artifacts -name twister.xml | grep .; then
+            echo "::set-output name=report_needed::1";
+          else
+            echo "::set-output name=report_needed::0";
+          fi
+
+      - name: Merge Test Results
+        if: steps.check-reports.outputs.report_needed != 0
+        run: |
+          pip3 install junitparser junit2html
+          junitparser merge artifacts/*/twister.xml junit.xml
+          junit2html junit.xml junit.html
+
+      - name: Upload Unit Test Results in HTML
+        if: steps.check-reports.outputs.report_needed != 0
+        uses: actions/upload-artifact@v2
+        with:
+          name: HTML Unit Test Results
+          path: junit.html
+
+      - name: Publish Unit Test Results
+        if: steps.check-reports.outputs.report_needed != 0
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          check_name: Unit Test Results
+          comment_mode: off
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: artifacts/event/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          files: "**/twister.xml"

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     branches:
       - main
   schedule:
@@ -49,14 +49,11 @@ jobs:
           rm -rf zephyr zephyr-testing
 
       - name: Checkout
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request'
         uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
 
       - name: Environment Setup
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request'
         run: |
           pip3 install GitPython
           git config --global user.email "bot@zephyrproject.org"
@@ -68,7 +65,7 @@ jobs:
           # no need for west update here
 
       - name: Generate Test Plan with Twister
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request'
         id: test-plan
         run: |
           export ZEPHYR_BASE=${PWD}
@@ -84,7 +81,7 @@ jobs:
       - name: Determine matrix size
         id: output-services
         run: |
-          if [ "${{github.event_name}}" = "pull_request_target" ]; then
+          if [ "${{github.event_name}}" = "pull_request" ]; then
             if [ -n "${TWISTER_NODES}" ]; then
               subset="[$(seq -s',' 1 ${TWISTER_NODES})]"
             else
@@ -134,14 +131,11 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
 
       - name: Environment Setup
         run: |
           pip3 install GitPython
-          if [ "${{github.event_name}}" = "pull_request_target" ]; then
+          if [ "${{github.event_name}}" = "pull_request" ]; then
             git config --global user.email "bot@zephyrproject.org"
             git config --global user.name "Zephyr Builder"
             rm -fr ".git/rebase-apply"
@@ -178,7 +172,7 @@ jobs:
             fi
           fi
 
-      - if: github.event_name == 'pull_request_target'
+      - if: github.event_name == 'pull_request'
         name: Run Tests with Twister (Pull Request)
         run: |
           rm -f testplan.csv
@@ -215,39 +209,3 @@ jobs:
           path: |
             twister-out/twister.xml
             testplan.csv
-
-  twister-test-results:
-    name: "Publish Unit Tests Results"
-    needs: twister-build
-    runs-on: ubuntu-latest
-      # the build-and-test job might be skipped, we don't need to run this job then
-    if: success() || failure()
-
-    steps:
-      - name: Download Artifacts
-        uses: actions/download-artifact@v2
-        with:
-          path: artifacts
-
-      - name: Merge Test Results
-        run: |
-          pip3 install junitparser junit2html
-          junitparser merge artifacts/*/*/twister.xml junit.xml
-          junit2html junit.xml junit.html
-
-      - name: Upload Unit Test Results in HTML
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: HTML Unit Test Results
-          if-no-files-found: ignore
-          path: |
-            junit.html
-
-      - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
-        with:
-          check_name: Unit Test Results
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          files: "**/twister.xml"
-          comment_mode: off

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -165,31 +165,6 @@ jobs:
           echo "github.base_ref: ${{ github.base_ref }}"
           echo "github.ref_name: ${{ github.ref_name }}"
 
-      - name: Prepare ccache timestamp/data
-        id: ccache_cache_timestamp
-        shell: cmake -P {0}
-        run: |
-          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-          string(REPLACE "/" "_" repo ${{github.repository}})
-          string(REPLACE "-" "_" repo2 ${repo})
-          message("::set-output name=repo::${repo2}")
-
-      - name: use cache
-        id: cache-ccache
-        uses: nashif/action-s3-cache@master
-        with:
-          key: ${{ steps.ccache_cache_timestamp.outputs.repo }}-${{ github.ref_name }}-${{github.event_name}}-${{ matrix.subset }}-ccache
-          path: /github/home/.ccache
-          aws-s3-bucket: ccache.zephyrproject.org
-          aws-access-key-id: ${{ secrets.CCACHE_S3_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.CCACHE_S3_SECRET_ACCESS_KEY }}
-          aws-region: us-east-2
-
-      - name: ccache stats initial
-        run: |
-          test -d github/home/.ccache && rm -rf /github/home/.ccache && mv github/home/.ccache /github/home/.ccache
-          ccache -M 10G -s
-
       - if: github.event_name == 'push'
         name: Run Tests with Twister (Push)
         run: |
@@ -230,10 +205,6 @@ jobs:
               ./scripts/twister +module_tests.args --outdir module_tests ${TWISTER_COMMON} ${DAILY_OPTIONS}
             fi
           fi
-
-      - name: ccache stats post
-        run: |
-          ccache -s
 
       - name: Upload Unit Test Results
         if: always()


### PR DESCRIPTION
This patch splits the twister workflow into 2:

- One that runs the tests
- A second one that processes the results and publishes them

Usage of ccache has been removed until we find a way to handle AWS upload in a
`workflow_run` context.