### PR TITLE
cmake: test CMake version and issue error if using 3.22.1 / 3.22.2 from PyPI

### DIFF
--- a/cmake/modules/zephyr_default.cmake
+++ b/cmake/modules/zephyr_default.cmake
@@ -31,6 +31,21 @@ find_package(ZephyrBuildConfiguration
   NO_CMAKE_SYSTEM_PACKAGE_REGISTRY
 )
 
+# Test and error-out if we are affected by the PyPI CMake 3.22.1 / 3.22.2 bug
+if(${CMAKE_VERSION} VERSION_EQUAL 3.22.1 OR ${CMAKE_VERSION} VERSION_EQUAL 3.22.2)
+  # It seems only pip-installed builds are affected so we test to see if we are affected
+  cmake_path(GET ZEPHYR_BASE PARENT_PATH test_cmake_path)
+  if(ZEPHYR_BASE STREQUAL test_cmake_path)
+    message(FATAL_ERROR "The CMake version ${CMAKE_VERSION} installed suffers"
+            " the \n 'cmake_path(... PARENT_PATH)' bug, see: \n"
+	    "https://gitlab.kitware.com/cmake/cmake/-/issues/23187\n"
+	    "https://github.com/scikit-build/cmake-python-distributions/issues/221\n"
+	    "Please install another CMake version or use a build of CMake that"
+	    " does not come from PyPI."
+    )
+  endif()
+endif()
+
 # Prepare user cache
 list(APPEND zephyr_cmake_modules python)
 list(APPEND zephyr_cmake_modules user_cache)


### PR DESCRIPTION
Fixes: #43099

The CMake 3.22.1 / 3.22.2 PyPI suffers a bug in the
 `cmake_path(... PARENT_PATH)` implementation.

Therefore, when CMake version 3.22.1 / 3.22.2 is detected, test if the CMake
version is suffering from the bug, and in case the bug is present, fail
with an error regarding the issue.

The reason for failing, and not implementing work arounds is that Zephyr
already uses `cmake_path()` at two locations, and we cannot prevent
contributors from adding code which uses this function.

Secondly, Zephyr modules may also use `cmake_path()`, and thus be
affected by said bug.
It is impractical to implement work arounds at all possible locations
for something that is a CMake bug.

Therefore the safest solution is to test CMake itself, to check if the
version in use suffers said bug, and fail with a proper error message
if an affected CMake version is used.

See more here:
https://gitlab.kitware.com/cmake/cmake/-/issues/23187
https://github.com/scikit-build/cmake-python-distributions/issues/221

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>