### PR TITLE
scripts: twister: harness: pytest: add support for custom cmd line args

### DIFF
--- a/doc/guides/test/twister.rst
+++ b/doc/guides/test/twister.rst
@@ -369,10 +369,13 @@ harness_config: <harness configuration options>
 
         Only one fixture can be defined per testcase.
 
-    pytest_root: <pytest dirctory> (default pytest)
+    pytest_root: <pytest directory> (default pytest)
         Specify a pytest directory which need to excute when test case begin to running,
         default pytest directory name is pytest, after pytest finished, twister will
         check if this case pass or fail according the pytest report.
+
+    pytest_args: <list of arguments> (default empty)
+        Specify a list of additional arguments to pass to ``pytest``.
 
     The following is an example yaml file with a few harness_config options.
 

--- a/samples/subsys/testsuite/pytest/pytest/conftest.py
+++ b/samples/subsys/testsuite/pytest/pytest/conftest.py
@@ -10,9 +10,18 @@ def pytest_addoption(parser):
     parser.addoption(
         '--cmdopt'
     )
+    parser.addoption(
+        '--custom-pytest-arg'
+    )
 
 # define fixture to return value of option "--cmdopt", this fixture
 # will be requested by other fixture of tests.
 @pytest.fixture()
 def cmdopt(request):
     return request.config.getoption('--cmdopt')
+
+# define fixture to return value of option "--custom-pytest-arg", this fixture
+# will be requested by other fixture of tests.
+@pytest.fixture()
+def custom_pytest_arg(request):
+    return request.config.getoption('--custom-pytest-arg')

--- a/samples/subsys/testsuite/pytest/pytest/test_sample.py
+++ b/samples/subsys/testsuite/pytest/pytest/test_sample.py
@@ -33,5 +33,10 @@ def test_case(cmdopt):
     print("run test cases in:")
     print(cmdopt)
 
+def test_custom_arg(custom_pytest_arg):
+    ''' Test passing of custom command line arguments to pytest.
+    '''
+    assert custom_pytest_arg == "foo"
+
 if __name__ == "__main__":
     pytest.main()

--- a/samples/subsys/testsuite/pytest/testcase.yaml
+++ b/samples/subsys/testsuite/pytest/testcase.yaml
@@ -2,4 +2,6 @@ tests:
   sample.twister.pytest:
     platform_allow: native_posix
     harness: pytest
+    harness_config:
+      pytest_args: [ "--custom-pytest-arg", "foo" ]
     tags: testing pytest

--- a/scripts/pylib/twister/harness.py
+++ b/scripts/pylib/twister/harness.py
@@ -131,11 +131,13 @@ class Pytest(Harness):
         self.running_dir = instance.build_dir
         self.source_dir = instance.testcase.source_dir
         self.pytest_root = 'pytest'
+        self.pytest_args = []
         self.is_pytest = True
         config = instance.testcase.harness_config
 
         if config:
             self.pytest_root = config.get('pytest_root', 'pytest')
+            self.pytest_args = config.get('pytest_args', [])
 
     def handle(self, line):
         ''' Test cases that make use of pytest more care about results given
@@ -163,6 +165,9 @@ class Pytest(Harness):
 			os.path.join(self.running_dir, 'report.xml'),
 			'-q'
         ]
+
+        for arg in self.pytest_args:
+            cmd.append(arg)
 
         log = open(log_file, "a")
         outs = []

--- a/scripts/schemas/twister/testcase-schema.yaml
+++ b/scripts/schemas/twister/testcase-schema.yaml
@@ -65,6 +65,11 @@ mapping:
           "pytest_root":
             type: str
             required: false
+          "pytest_args":
+            type: seq
+            required: false
+            sequence:
+              - type: str
           "regex":
             type: seq
             required: false
@@ -193,6 +198,11 @@ mapping:
               "pytest_root":
                 type: str
                 required: false
+              "pytest_args":
+                type: seq
+                required: false
+                sequence:
+                  - type: str
               "regex":
                 type: seq
                 required: false


### PR DESCRIPTION
Add support for passing custom command line arguments to a pytest harness in twister.
    
Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>
