### PR TITLE
Agilex shell example

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -622,6 +622,7 @@
 /samples/basic/servo_motor/boards/*microbit* @jhe
 /samples/bluetooth/                       @jhedberg @Vudentz @alwa-nordic
 /samples/boards/intel_s1000_crb/          @sathishkuttan @dcpleung @nashif
+/samples/boards/intel_socfpga/intel_socfpga_agilex_socdk/ @siclim @ngboonkhai
 /samples/compression/                     @Navin-Sankar
 /samples/drivers/can/                     @alexanderwachter
 /samples/drivers/clock_control_litex/     @mateusz-holenko @kgugala @pgielda

--- a/samples/boards/intel_socfpga/intel_socfpga_agilex_socdk/shell/CMakeLists.txt
+++ b/samples/boards/intel_socfpga/intel_socfpga_agilex_socdk/shell/CMakeLists.txt
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(shell)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/samples/boards/intel_socfpga/intel_socfpga_agilex_socdk/shell/README.rst
+++ b/samples/boards/intel_socfpga/intel_socfpga_agilex_socdk/shell/README.rst
@@ -1,0 +1,10 @@
+.. shell:
+
+Shell
+###########
+
+Overview
+********
+
+A simple shell program that provide the command line interface
+at the Intel SoC FPGA Agilex board

--- a/samples/boards/intel_socfpga/intel_socfpga_agilex_socdk/shell/prj.conf
+++ b/samples/boards/intel_socfpga/intel_socfpga_agilex_socdk/shell/prj.conf
@@ -1,0 +1,15 @@
+# Copyright (c) 2021, Intel Corporation. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Enable Shell
+CONFIG_SHELL=y
+CONFIG_SHELL_MINIMAL=y
+CONFIG_SHELL_CMD_BUFF_SIZE=4096
+CONFIG_SHELL_BACKEND_SERIAL=y
+CONFIG_SHELL_PROMPT_UART="agilex$ "
+CONFIG_SHELL_HELP=y
+CONFIG_SHELL_HISTORY=y
+CONFIG_SHELL_HISTORY_BUFFER=1024
+
+# Enable Device Shell to Access Basic Device Data
+CONFIG_DEVICE_SHELL=y

--- a/samples/boards/intel_socfpga/intel_socfpga_agilex_socdk/shell/sample.yaml
+++ b/samples/boards/intel_socfpga/intel_socfpga_agilex_socdk/shell/sample.yaml
@@ -1,0 +1,11 @@
+sample:
+  description: Shell sample, this is to provide command line interface
+    for Intel SoC FPGA Agilex boards.
+  name: shell
+tests:
+  sample.board.intel_socfpga_agilex_socdk:
+    platform_allow: intel_socfpga_agilex_socdk
+    integration_platforms:
+      - intel_socfpga_agilex_socdk
+    build_only: true
+    tags: agilex

--- a/samples/boards/intel_socfpga/intel_socfpga_agilex_socdk/shell/src/main.c
+++ b/samples/boards/intel_socfpga/intel_socfpga_agilex_socdk/shell/src/main.c
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2021, Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <sys/printk.h>
+
+void main(void)
+{
+	printk("%s: Starting Shell...\n", CONFIG_BOARD);
+}


### PR DESCRIPTION
Add example design with "shell" command line for intel_socfpga_agilex_socdk board. We will support shell command for all supported drivers and features for our customer through this example design.