### PR TITLE
stm32: clock_control: Add test suite for stm32 

### DIFF
--- a/dts/bindings/clock/st,stm32g4-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32g4-pll-clock.yaml
@@ -26,6 +26,7 @@ include:
     property-blocklist:
       - div-m
       - mul-n
+      - div-p
 
 properties:
 
@@ -42,3 +43,10 @@ properties:
       description: |
           Main PLL multiplication factor for VCO
           Valid range: 8 - 127
+
+    div-p:
+      type: int
+      required: false
+      description: |
+          Main PLL division factor for ADC
+          Valid range: 2 - 31

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/CMakeLists.txt
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/CMakeLists.txt
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(stm32_clock_configuration_common)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/clear_clocks.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/clear_clocks.overlay
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay clears clocks back to a state equivalent to what could
+ * be found in stm32xx.dtsi
+ */
+
+&clk_hse {
+	status = "disabled";
+	/delete-property/ hse-bypass;
+	/delete-property/ clock-frequency;
+};
+
+&clk_hsi {
+	status = "disabled";
+	/delete-property/ hsi-div;
+};
+
+&clk_lse {
+	status = "disabled";
+};
+
+&clk_lsi {
+	status = "disabled";
+};
+
+&pll {
+	/delete-property/ div-m;
+	/delete-property/ mul-n;
+	/delete-property/ div-p;
+	/delete-property/ div-q;
+	/delete-property/ div-r;
+	/delete-property/ clocks;
+	status = "disabled";
+};
+
+&rcc {
+	/delete-property/ clocks;
+	/delete-property/ clock-frequency;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/clear_clocks_msi.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/clear_clocks_msi.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay clears the msi clock back to a state equivalent to what could
+ * be found in stm32xx.dtsi
+ */
+
+&clk_msi {
+	status = "disabled";
+	/delete-property/ msi-range;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/clear_f0_f1_f3_clocks.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/clear_f0_f1_f3_clocks.overlay
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay clears clocks back to a state equivalent to what could
+ * be found in stm32fxx.dtsi
+ */
+
+&clk_hse {
+	status = "disabled";
+	/delete-property/ hse-bypass;
+	/delete-property/ clock-frequency;
+};
+
+&clk_hsi {
+	status = "disabled";
+};
+
+&clk_lse {
+	status = "disabled";
+};
+
+&clk_lsi {
+	status = "disabled";
+};
+
+&pll {
+	/delete-property/ mul;
+	/delete-property/ div;
+	/delete-property/ prediv;
+	/delete-property/ xtpre;
+	/delete-property/ clocks;
+	status = "disabled";
+};
+
+&rcc {
+	/delete-property/ clocks;
+	/delete-property/ clock-frequency;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/clear_f2_f4_f7_clocks.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/clear_f2_f4_f7_clocks.overlay
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay clears clocks back to a state equivalent to what could
+ * be found in stm32fxx.dtsi
+ */
+
+&clk_hse {
+	status = "disabled";
+	/delete-property/ hse-bypass;
+	/delete-property/ clock-frequency;
+};
+
+&clk_hsi {
+	status = "disabled";
+};
+
+&clk_lse {
+	status = "disabled";
+};
+
+&clk_lsi {
+	status = "disabled";
+};
+
+&pll {
+	/delete-property/ mul-n;
+	/delete-property/ div-m;
+	/delete-property/ div-p;
+	/delete-property/ div-q;
+	/delete-property/ clocks;
+	status = "disabled";
+};
+
+&rcc {
+	/delete-property/ clocks;
+	/delete-property/ clock-frequency;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/f0_f3_pll_32_hse_8.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/f0_f3_pll_32_hse_8.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay performs configuration from clean sheet.
+ * It is assumed that it is applied after clear_clocks.overlay file.
+ */
+
+&clk_hse {
+	hse-bypass;
+	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */
+	status = "okay";
+};
+
+&pll {
+	prediv = <4>;
+	mul = <16>;
+	clocks = <&clk_hse>;
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&pll>;
+	clock-frequency = <DT_FREQ_M(32)>;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/f0_f3_pll_32_hsi_8.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/f0_f3_pll_32_hsi_8.overlay
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay performs configuration from clean sheet.
+ * It is assumed that it is applied after clear_clocks.overlay file.
+ */
+
+&clk_hsi {
+	clock-frequency = <DT_FREQ_M(8)>;
+	status = "okay";
+};
+
+&pll {
+	prediv = <2>;
+	mul = <8>;
+	clocks = <&clk_hsi>;
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&pll>;
+	clock-frequency = <DT_FREQ_M(32)>;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/f1_pll_64_hse_8.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/f1_pll_64_hse_8.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay performs configuration from clean sheet.
+ * It is assumed that it is applied after clear_clocks.overlay file.
+ */
+
+&clk_hse {
+	hse-bypass;
+	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */
+	status = "okay";
+};
+
+&pll {
+	xtpre;
+	mul = <16>;
+	clocks = <&clk_hse>;
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&pll>;
+	clock-frequency = <DT_FREQ_M(64)>;
+	/* apb1 prescaler is kept = 2 */
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/f1_pll_64_hsi_8.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/f1_pll_64_hsi_8.overlay
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay performs configuration from clean sheet.
+ * It is assumed that it is applied after clear_clocks.overlay file.
+ */
+
+&clk_hsi {
+	status = "okay";
+};
+
+&pll {
+	mul = <16>;
+	clocks = <&clk_hsi>;
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&pll>;
+	clock-frequency = <DT_FREQ_M(64)>;
+	/* apb1 prescaler is kept = 2 */
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/f2_f4_f7_pll_64_hse_8.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/f2_f4_f7_pll_64_hse_8.overlay
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay performs configuration from clean sheet.
+ * It is assumed that it is applied after clear_clocks.overlay file.
+ */
+
+&clk_hse {
+	hse-bypass;
+	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */
+	status = "okay";
+};
+
+&pll {
+	div-m = <4>;
+	mul-n = <192>;
+	div-p = <6>;
+	div-q = <8>;
+	clocks = <&clk_hse>;
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&pll>;
+	clock-frequency = <DT_FREQ_M(64)>;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/f2_f4_f7_pll_64_hsi_16.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/f2_f4_f7_pll_64_hsi_16.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay performs configuration from clean sheet.
+ * It is assumed that it is applied after clear_clocks.overlay file.
+ */
+
+&clk_hsi {
+	status = "okay";
+};
+
+&pll {
+	div-m = <8>;
+	mul-n = <192>;
+	div-p = <6>;
+	div-q = <8>;
+	clocks = <&clk_hsi>;
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&pll>;
+	clock-frequency = <DT_FREQ_M(64)>;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/hse_24.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/hse_24.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay performs configuration from clean sheet.
+ * It is assumed that it is applied after clear_clocks.overlay file.
+ */
+
+&clk_hse {
+	clock-frequency = <DT_FREQ_M(24)>; /* 24MHz clock */
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&clk_hse>;
+	clock-frequency = <DT_FREQ_M(24)>;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/hse_32.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/hse_32.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay performs configuration from clean sheet.
+ * It is assumed that it is applied after clear_clocks.overlay file.
+ */
+
+&clk_hse {
+	clock-frequency = <DT_FREQ_M(32)>; /* 32MHz oscillator */
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&clk_hse>;
+	clock-frequency = <DT_FREQ_M(32)>;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/hse_8.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/hse_8.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay performs configuration from clean sheet.
+ * It is assumed that it is applied after clear_clocks.overlay file.
+ */
+
+&clk_hse {
+	hse-bypass;
+	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&clk_hse>;
+	clock-frequency = <DT_FREQ_M(8)>;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/hse_8_bypass.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/hse_8_bypass.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay performs configuration from clean sheet.
+ * It is assumed that it is applied after clear_clocks.overlay file.
+ */
+
+&clk_hse {
+	hse-bypass;
+	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&clk_hse>;
+	clock-frequency = <DT_FREQ_M(8)>;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/hsi_16.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/hsi_16.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay performs configuration from clean sheet.
+ * It is assumed that it is applied after clear_clocks.overlay file.
+ */
+
+&clk_hsi {		/* HSI RC: 16MHz, hsi_clk = 16MHz */
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&clk_hsi>;
+	clock-frequency = <DT_FREQ_M(16)>;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/hsi_8.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/hsi_8.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay performs configuration from clean sheet.
+ * It is assumed that it is applied after clear_clocks.overlay file.
+ */
+
+&clk_hsi {		/* HSI RC: 8MHz, hsi_clk = 8MHz */
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&clk_hsi>;
+	clock-frequency = <DT_FREQ_M(8)>;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/msi_range11.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/msi_range11.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay performs configuration from clean sheet.
+ * It is assumed that applies after clear all clocks with .overlay file.
+ */
+
+&clk_msi {
+	status = "okay";
+	msi-range = <11>;
+};
+
+&rcc {
+	clocks = <&clk_msi>;
+	clock-frequency = <DT_FREQ_M(48)>;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/msi_range6.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/msi_range6.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay performs configuration from clean sheet.
+ * It is assumed that it is applied after clear_clocks.overlay file.
+ */
+
+&clk_msi {
+	status = "okay";
+	msi-range = <6>;
+};
+
+&rcc {
+	clocks = <&clk_msi>;
+	clock-frequency = <4194304>;
+	ahb-prescaler = <1>;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/pll_170_hse_24.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/pll_170_hse_24.overlay
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay performs configuration from clean sheet.
+ * It is assumed that it is applied after clear_clocks.overlay file.
+ */
+
+&clk_hse {
+	clock-frequency = <DT_FREQ_M(24)>;
+	status = "okay";
+};
+
+&pll {
+	div-m = <6>;
+	mul-n = <85>;
+	div-p = <7>;
+	div-q = <2>;
+	div-r = <2>;
+	clocks = <&clk_hse>;
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&pll>;
+	clock-frequency = <DT_FREQ_M(170)>;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/pll_32_hse_8.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/pll_32_hse_8.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay performs configuration from clean sheet.
+ * It is assumed that it is applied after clear_clocks.overlay file.
+ */
+
+&clk_hse {
+	hse-bypass;
+	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */
+	status = "okay";
+};
+
+&pll {
+	div = <2>;
+	mul = <8>;
+	clocks = <&clk_hse>;
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&pll>;
+	clock-frequency = <DT_FREQ_M(32)>;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/pll_32_hsi_16.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/pll_32_hsi_16.overlay
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay performs configuration from clean sheet.
+ * It is assumed that it is applied after clear_clocks.overlay file.
+ */
+
+&clk_hsi {
+	status = "okay";
+};
+
+&pll {
+	div = <2>;
+	mul = <4>;
+	clocks = <&clk_hsi>;
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&pll>;
+	clock-frequency = <DT_FREQ_M(32)>;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/pll_48_hsi_16.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/pll_48_hsi_16.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay performs configuration from clean sheet.
+ * It is assumed that it is applied after clear_clocks.overlay file.
+ */
+
+&clk_hsi {
+	status = "okay";
+};
+
+&pll {
+	div-m = <1>;
+	mul-n = <6>;
+	div-p = <2>;
+	div-q = <2>;
+	div-r = <2>;
+	clocks = <&clk_hsi>;
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&pll>;
+	clock-frequency = <DT_FREQ_M(48)>;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/pll_48_msi_4.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/pll_48_msi_4.overlay
@@ -6,25 +6,25 @@
 
 /*
  * Warning: This overlay performs configuration from clean sheet.
- * It is assumed that it is applied after clear_clocks.overlay file.
+ * It is assumed that it is applied after wb_clear_clocks.overlay file.
+ * It applies to the stm32xx where the msi is 4MHz
  */
 
-&clk_hse {
-	hse-bypass;
-	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */
+&clk_msi {
 	status = "okay";
+	msi-range = <6>; /* default value */
 };
 
 &pll {
 	div-m = <1>;
-	mul-n = <16>;
+	mul-n = <24>;
 	div-q = <2>;
 	div-r = <2>;
-	clocks = <&clk_hse>;
+	clocks = <&clk_msi>;
 	status = "okay";
 };
 
 &rcc {
 	clocks = <&pll>;
-	clock-frequency = <DT_FREQ_M(64)>;
+	clock-frequency = <DT_FREQ_M(48)>;
 };

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/pll_64_hse_8.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/pll_64_hse_8.overlay
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay performs configuration from clean sheet.
+ * It is assumed that it is applied after clear_clocks.overlay file.
+ */
+
+&clk_hse {
+	hse-bypass;
+	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */
+	status = "okay";
+};
+
+&pll {
+	div-m = <1>;
+	mul-n = <16>;
+	div-p = <2>;
+	div-q = <2>;
+	div-r = <2>;
+	clocks = <&clk_hse>;
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&pll>;
+	clock-frequency = <DT_FREQ_M(64)>;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/pll_64_hsi_16.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/pll_64_hsi_16.overlay
@@ -16,7 +16,6 @@
 &pll {
 	div-m = <1>;
 	mul-n = <8>;
-	div-p = <2>;
 	div-q = <2>;
 	div-r = <2>;
 	clocks = <&clk_hsi>;

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/pll_64_hsi_16.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/pll_64_hsi_16.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay performs configuration from clean sheet.
+ * It is assumed that it is applied after clear_clocks.overlay file.
+ */
+
+&clk_hsi {
+	status = "okay";
+};
+
+&pll {
+	div-m = <1>;
+	mul-n = <8>;
+	div-p = <2>;
+	div-q = <2>;
+	div-r = <2>;
+	clocks = <&clk_hsi>;
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&pll>;
+	clock-frequency = <DT_FREQ_M(64)>;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/wb_clear_clocks.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/wb_clear_clocks.overlay
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay clears clocks back to a state equivalent to what could
+ * be found in stm32wb.dtsi
+ */
+
+&clk_hse {
+	status = "disabled";
+	/delete-property/ hse-bypass;
+	/delete-property/ clock-frequency;
+};
+
+&clk_hsi {
+	status = "disabled";
+	/delete-property/ hsi-div;
+};
+
+&clk_lse {
+	status = "disabled";
+};
+
+&clk_lsi1 {
+	status = "disabled";
+};
+
+&clk_lsi2 {
+	status = "disabled";
+};
+
+&clk_msi {
+	status = "disabled";
+	/delete-property/ msi-range;
+};
+
+&pll {
+	/delete-property/ div-m;
+	/delete-property/ mul-n;
+	/delete-property/ div-p;
+	/delete-property/ div-q;
+	/delete-property/ div-r;
+	/delete-property/ clocks;
+	status = "disabled";
+};
+
+&rcc {
+	/delete-property/ clocks;
+	/delete-property/ clock-frequency;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/wb_pll_48_hsi_16.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/wb_pll_48_hsi_16.overlay
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay performs configuration from clean sheet.
+ * It is assumed that it is applied after clear_clocks.overlay file.
+ * It applies to the stm32wb
+ */
+
+&clk_hsi {
+	clock-frequency = <DT_FREQ_M(16)>;
+	status = "okay";
+};
+
+&pll {
+	div-m = <1>;
+	mul-n = <9>;
+	div-p = <2>;
+	div-q = <2>;
+	div-r = <3>;
+	clocks = <&clk_hsi>;
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&pll>;
+	clock-frequency = <DT_FREQ_M(48)>;
+	cpu1-prescaler = <1>;
+	cpu2-prescaler = <2>;
+	ahb4-prescaler = <2>;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/wb_pll_48_msi_4.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/wb_pll_48_msi_4.overlay
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay performs configuration from clean sheet.
+ * It is assumed that it is applied after wb_clear_clocks.overlay file.
+ * It applies to the stm32wb where the msi is 4MHz
+ */
+
+&clk_msi {
+	status = "okay";
+	msi-range = <6>; /* default value */
+};
+
+&pll {
+	div-m = <1>;
+	mul-n = <24>;
+	div-p = <2>;
+	div-q = <2>;
+	div-r = <2>;
+	clocks = <&clk_msi>;
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&pll>;
+	clock-frequency = <DT_FREQ_M(48)>;
+	cpu1-prescaler = <1>;
+	cpu2-prescaler = <2>;
+	ahb4-prescaler = <2>;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/wb_pll_64_hse_32.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/wb_pll_64_hse_32.overlay
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay performs configuration from clean sheet.
+ * It is assumed that it is applied after clear_clocks.overlay file.
+ * It applies to the stm32wb
+ */
+
+&clk_hse {
+	clock-frequency = <DT_FREQ_M(32)>; /* X1 32MHz oscillator */
+	status = "okay";
+};
+
+&pll {
+	div-m = <2>;
+	mul-n = <8>;
+	div-p = <2>;
+	div-q = <2>;
+	div-r = <2>;
+	clocks = <&clk_hse>;
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&pll>;
+	clock-frequency = <DT_FREQ_M(64)>;
+	cpu1-prescaler = <1>;
+	cpu2-prescaler = <2>;
+	ahb4-prescaler = <2>;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/wl_32_hse.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/wl_32_hse.overlay
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay performs configuration from clean sheet.
+ * It is assumed that it is applied after clear_clocks.overlay file.
+ * It applies to the stm32wl where the hse prescaler is 1 and by-passed
+ */
+
+&clk_hse {
+	hse-tcxo;
+	clock-frequency = <DT_FREQ_M(32)>; /* STLink 32MHz clock */
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&clk_hse>;
+	clock-frequency = <DT_FREQ_M(32)>;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/wl_clear_clocks.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/wl_clear_clocks.overlay
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay clears clocks back to a state equivalent to what could
+ * be found in stm32wl.dtsi
+ */
+
+&clk_hse {
+	status = "disabled";
+	/delete-property/ hse-tcxo;
+	/delete-property/ hse-div2;
+	/delete-property/ clock-frequency;
+};
+
+&clk_hsi {
+	status = "disabled";
+	/delete-property/ hsi-div;
+};
+
+&clk_lse {
+	status = "disabled";
+};
+
+&clk_lsi {
+	status = "disabled";
+};
+
+&clk_msi {
+	status = "disabled";
+	/delete-property/ msi-range;
+};
+
+&pll {
+	/delete-property/ div-m;
+	/delete-property/ mul-n;
+	/delete-property/ div-p;
+	/delete-property/ div-q;
+	/delete-property/ div-r;
+	/delete-property/ clocks;
+	status = "disabled";
+};
+
+&rcc {
+	/delete-property/ clocks;
+	/delete-property/ clock-frequency;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/wl_pll_48_hse_32.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/boards/wl_pll_48_hse_32.overlay
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay performs configuration from clean sheet.
+ * It is assumed that it is applied after clear_clocks.overlay file.
+ * It applies to the stm32wl where the hse prescaler is 2 and by-passed
+ */
+
+&clk_hse {
+	hse-tcxo;
+	hse-div2;
+	clock-frequency = <DT_FREQ_M(32)>; /* STLink 32MHz clock */
+	status = "okay";
+};
+
+&pll {
+	div-m = <2>;
+	mul-n = <12>;
+	div-p = <2>;
+	div-q = <2>;
+	div-r = <2>;
+	clocks = <&clk_hse>;
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&pll>;
+	clock-frequency = <DT_FREQ_M(48)>;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/prj.conf
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/src/test_stm32_clock_configuration.c
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/src/test_stm32_clock_configuration.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <ztest.h>
+#include <soc.h>
+#include <drivers/clock_control.h>
+#include <drivers/clock_control/stm32_clock_control.h>
+#include <logging/log.h>
+LOG_MODULE_REGISTER(test);
+
+
+static void test_sysclk_freq(void)
+{
+	uint32_t soc_sys_clk_freq;
+
+	soc_sys_clk_freq = HAL_RCC_GetSysClockFreq();
+
+	zassert_equal(CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC, soc_sys_clk_freq,
+			"Expected sysclockfreq: %d. Actual sysclockfreq: %d",
+			CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC, soc_sys_clk_freq);
+}
+
+static void test_sysclk_src(void)
+{
+	int sys_clk_src = __HAL_RCC_GET_SYSCLK_SOURCE();
+
+#if STM32_SYSCLK_SRC_PLL
+	zassert_equal(RCC_SYSCLKSOURCE_STATUS_PLLCLK, sys_clk_src,
+			"Expected sysclk src: PLL. Actual sysclk src: %d",
+			sys_clk_src);
+#elif STM32_SYSCLK_SRC_HSE
+	zassert_equal(RCC_SYSCLKSOURCE_STATUS_HSE, sys_clk_src,
+			"Expected sysclk src: HSE. Actual sysclk src: %d",
+			sys_clk_src);
+#elif STM32_SYSCLK_SRC_HSI
+	zassert_equal(RCC_SYSCLKSOURCE_STATUS_HSI, sys_clk_src,
+			"Expected sysclk src: HSI. Actual sysclk src: %d",
+			sys_clk_src);
+#elif STM32_SYSCLK_SRC_MSI
+	zassert_equal(RCC_SYSCLKSOURCE_STATUS_MSI, sys_clk_src,
+			"Expected sysclk src: MSI. Actual sysclk src: %d",
+			sys_clk_src);
+#else
+	/* Case not expected */
+	zassert_true((STM32_SYSCLK_SRC_PLL ||
+		      STM32_SYSCLK_SRC_HSE ||
+		      STM32_SYSCLK_SRC_HSI ||
+		      STM32_SYSCLK_SRC_MSI),
+		      "Not expected. sys_clk_src: %d\n", sys_clk_src);
+#endif
+
+}
+
+static void test_pll_src(void)
+{
+	uint32_t pll_src = __HAL_RCC_GET_PLL_OSCSOURCE();
+
+#if STM32_PLL_SRC_HSE
+	zassert_equal(RCC_PLLSOURCE_HSE, pll_src,
+			"Expected PLL src: HSE (%d). Actual PLL src: %d",
+			RCC_PLLSOURCE_HSE, pll_src);
+#elif STM32_PLL_SRC_HSI
+	zassert_equal(RCC_PLLSOURCE_HSI, pll_src,
+			"Expected PLL src: HSI (%d). Actual PLL src: %d",
+			RCC_PLLSOURCE_HSI, pll_src);
+#elif STM32_PLL_SRC_MSI
+	zassert_equal(RCC_PLLSOURCE_MSI, pll_src,
+			"Expected PLL src: MSI (%d). Actual PLL src: %d",
+			RCC_PLLSOURCE_MSI, pll_src);
+#else
+	zassert_equal(RCC_PLLSOURCE_NONE, pll_src,
+			"Expected PLL src: none (%d). Actual PLL src: %d",
+			RCC_PLLSOURCE_NONE, pll_src);
+#endif
+
+}
+
+void test_main(void)
+{
+	printk("testing clock config on %s\n", CONFIG_BOARD);
+	ztest_test_suite(test_stm32_syclck_config,
+		ztest_unit_test(test_sysclk_freq),
+		ztest_unit_test(test_sysclk_src),
+		ztest_unit_test(test_pll_src)
+			 );
+	ztest_run_test_suite(test_stm32_syclck_config);
+}

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/src/test_stm32_clock_configuration.c
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/src/test_stm32_clock_configuration.c
@@ -63,15 +63,24 @@ static void test_pll_src(void)
 			"Expected PLL src: HSE (%d). Actual PLL src: %d",
 			RCC_PLLSOURCE_HSE, pll_src);
 #elif STM32_PLL_SRC_HSI
+#if defined(CONFIG_SOC_SERIES_STM32F1X)
+	zassert_equal(RCC_PLLSOURCE_HSI_DIV2, pll_src,
+			"Expected PLL src: HSI (%d). Actual PLL src: %d",
+			RCC_PLLSOURCE_HSI_DIV2, pll_src);
+#else
 	zassert_equal(RCC_PLLSOURCE_HSI, pll_src,
 			"Expected PLL src: HSI (%d). Actual PLL src: %d",
 			RCC_PLLSOURCE_HSI, pll_src);
+#endif /* CONFIG_SOC_SERIES_STM32F1X */
 #elif STM32_PLL_SRC_MSI
 	zassert_equal(RCC_PLLSOURCE_MSI, pll_src,
 			"Expected PLL src: MSI (%d). Actual PLL src: %d",
 			RCC_PLLSOURCE_MSI, pll_src);
 #else /* --> RCC_PLLSOURCE_NONE */
-#if defined(CONFIG_SOC_SERIES_STM32L0X) || defined(CONFIG_SOC_SERIES_STM32L1X)
+#if defined(CONFIG_SOC_SERIES_STM32L0X) || defined(CONFIG_SOC_SERIES_STM32L1X) || \
+	defined(CONFIG_SOC_SERIES_STM32F0X) || defined(CONFIG_SOC_SERIES_STM32F1X) || \
+	defined(CONFIG_SOC_SERIES_STM32F2X) || defined(CONFIG_SOC_SERIES_STM32F3X) || \
+	defined(CONFIG_SOC_SERIES_STM32F4X) || defined(CONFIG_SOC_SERIES_STM32F7X)
 #define RCC_PLLSOURCE_NONE 0
 	/* check RCC_CR_PLLON bit to enable/disable the PLL, but no status function exist */
 	if (READ_BIT(RCC->CR, RCC_CR_PLLON) == RCC_CR_PLLON) {
@@ -81,7 +90,6 @@ static void test_pll_src(void)
 		pll_src = RCC_PLLSOURCE_NONE;
 	}
 #endif /* RCC_CR_PLLON */
-
 	zassert_equal(RCC_PLLSOURCE_NONE, pll_src,
 			"Expected PLL src: none (%d). Actual PLL src: %d",
 			RCC_PLLSOURCE_NONE, pll_src);

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/src/test_stm32_clock_configuration.c
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/src/test_stm32_clock_configuration.c
@@ -70,10 +70,22 @@ static void test_pll_src(void)
 	zassert_equal(RCC_PLLSOURCE_MSI, pll_src,
 			"Expected PLL src: MSI (%d). Actual PLL src: %d",
 			RCC_PLLSOURCE_MSI, pll_src);
-#else
+#else /* --> RCC_PLLSOURCE_NONE */
+#if defined(CONFIG_SOC_SERIES_STM32L0X) || defined(CONFIG_SOC_SERIES_STM32L1X)
+#define RCC_PLLSOURCE_NONE 0
+	/* check RCC_CR_PLLON bit to enable/disable the PLL, but no status function exist */
+	if (READ_BIT(RCC->CR, RCC_CR_PLLON) == RCC_CR_PLLON) {
+		/* should not happen : PLL must be disabled when not used */
+		pll_src = 0xFFFF; /* error code */
+	} else {
+		pll_src = RCC_PLLSOURCE_NONE;
+	}
+#endif /* RCC_CR_PLLON */
+
 	zassert_equal(RCC_PLLSOURCE_NONE, pll_src,
 			"Expected PLL src: none (%d). Actual PLL src: %d",
 			RCC_PLLSOURCE_NONE, pll_src);
+
 #endif
 
 }

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/testcase.yaml
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/testcase.yaml
@@ -1,0 +1,13 @@
+common:
+    timeout: 5
+    platform_exclude: nucleo_h723zg b_u585i_iot02a
+tests:
+  drivers.stm32_clock_configuration.common.sysclksrc_pll_64_hse_8:
+    extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/pll_64_hse_8.overlay"
+    platform_allow: nucleo_g071rb
+  drivers.stm32_clock_configuration.common.sysclksrc_pll_64_hsi_16:
+    extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/pll_64_hsi_16.overlay"
+    platform_allow: nucleo_g071rb
+  drivers.stm32_clock_configuration.common.sysclksrc_hsi_16:
+    extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/hsi_16.overlay"
+    platform_allow: nucleo_g071rb

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/testcase.yaml
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/testcase.yaml
@@ -4,6 +4,8 @@ tests:
   drivers.stm32_clock_configuration.common.sysclksrc_pll_64_hse_8:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/pll_64_hse_8.overlay"
     platform_allow: nucleo_g071rb
+    harness_config:
+      fixture: mco_sb_closed
   drivers.stm32_clock_configuration.common.sysclksrc_pll_64_hsi_16:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/pll_64_hsi_16.overlay"
     platform_allow: nucleo_g071rb nucleo_g474re

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/testcase.yaml
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/testcase.yaml
@@ -82,3 +82,39 @@ tests:
   drivers.stm32_clock_configuration.common.sysclksrc_msi_pll_48_msi_4:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/clear_clocks_msi.overlay;boards/pll_48_msi_4.overlay"
     platform_allow: nucleo_l496zg nucleo_l476rg nucleo_l452re nucleo_l432kc nucleo_l4r5zi nucleo_l552ze_q
+  drivers.stm32_clock_configuration.common.sysclksrc_f0_f3_hsi_8:
+    extra_args: DTC_OVERLAY_FILE="boards/clear_f0_f1_f3_clocks.overlay;boards/hsi_8.overlay"
+    platform_allow: nucleo_f091rc nucleo_f334r8
+  drivers.stm32_clock_configuration.common.sysclksrc_f0_f3_pll_32_hsi_8:
+    extra_args: DTC_OVERLAY_FILE="boards/clear_f0_f1_f3_clocks.overlay;boards/f0_f3_pll_32_hsi_8.overlay"
+    platform_allow: nucleo_f091rc nucleo_f334r8
+  drivers.stm32_clock_configuration.common.sysclksrc_f0_f3_hse_8:
+    extra_args: DTC_OVERLAY_FILE="boards/clear_f0_f1_f3_clocks.overlay;boards/hse_8_bypass.overlay"
+    platform_allow: nucleo_f091rc nucleo_f334r8
+  drivers.stm32_clock_configuration.common.sysclksrc_f0_f3_pll_32_hse_8:
+    extra_args: DTC_OVERLAY_FILE="boards/clear_f0_f1_f3_clocks.overlay;boards/f0_f3_pll_32_hse_8.overlay"
+    platform_allow: nucleo_f091rc nucleo_f334r8
+  drivers.stm32_clock_configuration.common.sysclksrc_f1_hsi_8:
+    extra_args: DTC_OVERLAY_FILE="boards/clear_f0_f1_f3_clocks.overlay;boards/hsi_16.overlay"
+    platform_allow: nucleo_f103rb
+  drivers.stm32_clock_configuration.common.sysclksrc_f1_pll_64_hsi_16:
+    extra_args: DTC_OVERLAY_FILE="boards/clear_f0_f1_f3_clocks.overlay;boards/f1_pll_64_hsi_8.overlay"
+    platform_allow: nucleo_f103rb
+  drivers.stm32_clock_configuration.common.sysclksrc_f1_hse_8:
+    extra_args: DTC_OVERLAY_FILE="boards/clear_f0_f1_f3_clocks.overlay;boards/hse_8.overlay"
+    platform_allow: nucleo_f103rb
+  drivers.stm32_clock_configuration.common.sysclksrc_f1_pll_64_hse_8:
+    extra_args: DTC_OVERLAY_FILE="boards/clear_f0_f1_f3_clocks.overlay;boards/f1_pll_64_hse_8.overlay"
+    platform_allow: nucleo_f103rb
+  drivers.stm32_clock_configuration.common.sysclksrc_f2_f4_f7_hsi_16:
+    extra_args: DTC_OVERLAY_FILE="boards/clear_f2_f4_f7_clocks.overlay;boards/hsi_16.overlay"
+    platform_allow: nucleo_f207zg nucleo_f411re nucleo_f429zi nucleo_f446re nucleo_f767zi
+  drivers.stm32_clock_configuration.common.sysclksrc_f2_f4_f7_pll_64_hsi_16:
+    extra_args: DTC_OVERLAY_FILE="boards/clear_f2_f4_f7_clocks.overlay;boards/f2_f4_f7_pll_64_hsi_16.overlay"
+    platform_allow: nucleo_f207zg nucleo_f411re nucleo_f429zi nucleo_f446re nucleo_f767zi
+  drivers.stm32_clock_configuration.common.sysclksrc_f2_f4_f7_hse_8:
+    extra_args: DTC_OVERLAY_FILE="boards/clear_f2_f4_f7_clocks.overlay;boards/hse_8.overlay"
+    platform_allow: nucleo_f207zg nucleo_f411re nucleo_f429zi nucleo_f446re nucleo_f767zi
+  drivers.stm32_clock_configuration.common.sysclksrc_f2_f4_f7_pll_64_hse_8:
+    extra_args: DTC_OVERLAY_FILE="boards/clear_f2_f4_f7_clocks.overlay;boards/f2_f4_f7_pll_64_hse_8.overlay"
+    platform_allow: nucleo_f207zg nucleo_f411re nucleo_f429zi nucleo_f446re nucleo_f767zi

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/testcase.yaml
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/testcase.yaml
@@ -1,13 +1,18 @@
 common:
     timeout: 5
-    platform_exclude: nucleo_h723zg b_u585i_iot02a
 tests:
   drivers.stm32_clock_configuration.common.sysclksrc_pll_64_hse_8:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/pll_64_hse_8.overlay"
     platform_allow: nucleo_g071rb
   drivers.stm32_clock_configuration.common.sysclksrc_pll_64_hsi_16:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/pll_64_hsi_16.overlay"
-    platform_allow: nucleo_g071rb
+    platform_allow: nucleo_g071rb nucleo_g474re
   drivers.stm32_clock_configuration.common.sysclksrc_hsi_16:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/hsi_16.overlay"
     platform_allow: nucleo_g071rb
+  drivers.stm32_clock_configuration.common.sysclksrc_hse_24:
+    extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/hse_24.overlay"
+    platform_allow: nucleo_g474re
+  drivers.stm32_clock_configuration.common.sysclksrc_pll_170_hse_24:
+    extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/hsi_16.overlay"
+    platform_allow: nucleo_g474re

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/testcase.yaml
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/testcase.yaml
@@ -6,18 +6,34 @@ tests:
     platform_allow: nucleo_g071rb
     harness_config:
       fixture: mco_sb_closed
+  drivers.stm32_clock_configuration.common.sysclksrc_msi_pll_64_hse_8:
+    extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/clear_clocks_msi.overlay;boards/pll_64_hse_8.overlay"
+    platform_allow: nucleo_l496zg nucleo_l476rg nucleo_l452re nucleo_l432kc nucleo_l4r5zi nucleo_l552ze_q
+    harness_config:
+      fixture: mco_sb_closed
   drivers.stm32_clock_configuration.common.sysclksrc_pll_64_hsi_16:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/pll_64_hsi_16.overlay"
     platform_allow: nucleo_g071rb nucleo_g474re
+  drivers.stm32_clock_configuration.common.sysclksrc_msi_pll_64_hsi_16:
+    extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;;boards/clear_clocks_msi.overlay;boards/pll_64_hsi_16.overlay"
+    platform_allow: nucleo_l496zg nucleo_l476rg nucleo_l452re nucleo_l432kc nucleo_l4r5zi nucleo_l552ze_q
   drivers.stm32_clock_configuration.common.sysclksrc_hsi_16:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/hsi_16.overlay"
     platform_allow: nucleo_g071rb nucleo_l152re nucleo_l073rz nucleo_wl55jc
+  drivers.stm32_clock_configuration.common.sysclksrc_msi_hsi_16:
+    extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/clear_clocks_msi.overlay;boards/hsi_16.overlay"
+    platform_allow: nucleo_l496zg nucleo_l476rg nucleo_l452re nucleo_l432kc nucleo_l4r5zi nucleo_l552ze_q
   drivers.stm32_clock_configuration.common.sysclksrc_hse_24:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/hse_24.overlay"
     platform_allow: nucleo_g474re
   drivers.stm32_clock_configuration.common.sysclksrc_hse_8:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/hse_8.overlay"
     platform_allow: nucleo_l152re nucleo_l073rz
+  drivers.stm32_clock_configuration.common.sysclksrc_msi_hse_8:
+    extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/clear_clocks_msi.overlay;boards/hse_8.overlay"
+    platform_allow: nucleo_l496zg nucleo_l476rg nucleo_l452re nucleo_l432kc nucleo_l4r5zi nucleo_l552ze_q
+    harness_config:
+      fixture: mco_sb_closed
   drivers.stm32_clock_configuration.common.sysclksrc_pll_170_hse_24:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/hsi_16.overlay"
     platform_allow: nucleo_g474re
@@ -36,12 +52,15 @@ tests:
   drivers.stm32_clock_configuration.common.sysclksrc_pll_48_hse_32:
     extra_args: DTC_OVERLAY_FILE="boards/wl_clear_clocks.overlay;boards/wl_pll_48_hse_32.overlay"
     platform_allow: nucleo_wl55jc
-  drivers.stm32_clock_configuration.common.sysclksrc_32_hse:
+  drivers.stm32_clock_configuration.common.sysclksrc_wl_32_hse:
     extra_args: DTC_OVERLAY_FILE="boards/wl_clear_clocks.overlay;boards/wl_32_hse.overlay"
     platform_allow: nucleo_wl55jc
-  drivers.stm32_clock_configuration.common.sysclksrc_48_msi:
+  drivers.stm32_clock_configuration.common.sysclksrc_wl_48_msi:
     extra_args: DTC_OVERLAY_FILE="boards/wl_clear_clocks.overlay;boards/msi_range11.overlay"
     platform_allow: nucleo_wl55jc
+  drivers.stm32_clock_configuration.common.sysclksrc_48_msi:
+    extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/clear_clocks_msi.overlay;boards/msi_range11.overlay"
+    platform_allow: nucleo_l496zg nucleo_l476rg nucleo_l452re nucleo_l432kc nucleo_l4r5zi nucleo_l552ze_q
   drivers.stm32_clock_configuration.common.sysclksrc_wb_48_msi:
     extra_args: DTC_OVERLAY_FILE="boards/wb_clear_clocks.overlay;boards/msi_range11.overlay"
     platform_allow: nucleo_wb55rg
@@ -60,3 +79,6 @@ tests:
   drivers.stm32_clock_configuration.common.sysclksrc_wb_pll_48_msi_4:
     extra_args: DTC_OVERLAY_FILE="boards/wb_clear_clocks.overlay;boards/wb_pll_48_msi_4.overlay"
     platform_allow: nucleo_wb55rg
+  drivers.stm32_clock_configuration.common.sysclksrc_msi_pll_48_msi_4:
+    extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/clear_clocks_msi.overlay;boards/pll_48_msi_4.overlay"
+    platform_allow: nucleo_l496zg nucleo_l476rg nucleo_l452re nucleo_l432kc nucleo_l4r5zi nucleo_l552ze_q

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/testcase.yaml
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/testcase.yaml
@@ -40,3 +40,21 @@ tests:
   drivers.stm32_clock_configuration.common.sysclksrc_48_msi:
     extra_args: DTC_OVERLAY_FILE="boards/wl_clear_clocks.overlay;boards/msi_range11.overlay"
     platform_allow: nucleo_wl55jc
+  drivers.stm32_clock_configuration.common.sysclksrc_wb_48_msi:
+    extra_args: DTC_OVERLAY_FILE="boards/wb_clear_clocks.overlay;boards/msi_range11.overlay"
+    platform_allow: nucleo_wb55rg
+  drivers.stm32_clock_configuration.common.sysclksrc_wb_hsi_16:
+    extra_args: DTC_OVERLAY_FILE="boards/wb_clear_clocks.overlay;boards/hsi_16.overlay"
+    platform_allow: nucleo_wb55rg
+  drivers.stm32_clock_configuration.common.sysclksrc_wb_hse_32:
+    extra_args: DTC_OVERLAY_FILE="boards/wb_clear_clocks.overlay;boards/hse_32.overlay"
+    platform_allow: nucleo_wb55rg
+  drivers.stm32_clock_configuration.common.sysclksrc_wb_pll_48_hsi_16:
+    extra_args: DTC_OVERLAY_FILE="boards/wb_clear_clocks.overlay;boards/wb_pll_48_hsi_16.overlay"
+    platform_allow: nucleo_wb55rg
+  drivers.stm32_clock_configuration.common.sysclksrc_wb_pll_64_hse_32:
+    extra_args: DTC_OVERLAY_FILE="boards/wb_clear_clocks.overlay;boards/wb_pll_64_hse_32.overlay"
+    platform_allow: nucleo_wb55rg
+  drivers.stm32_clock_configuration.common.sysclksrc_wb_pll_48_msi_4:
+    extra_args: DTC_OVERLAY_FILE="boards/wb_clear_clocks.overlay;boards/wb_pll_48_msi_4.overlay"
+    platform_allow: nucleo_wb55rg

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/testcase.yaml
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/testcase.yaml
@@ -9,10 +9,22 @@ tests:
     platform_allow: nucleo_g071rb nucleo_g474re
   drivers.stm32_clock_configuration.common.sysclksrc_hsi_16:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/hsi_16.overlay"
-    platform_allow: nucleo_g071rb
+    platform_allow: nucleo_g071rb nucleo_l152re nucleo_l073rz
   drivers.stm32_clock_configuration.common.sysclksrc_hse_24:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/hse_24.overlay"
     platform_allow: nucleo_g474re
+  drivers.stm32_clock_configuration.common.sysclksrc_hse_8:
+    extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/hse_8.overlay"
+    platform_allow: nucleo_l152re nucleo_l073rz
   drivers.stm32_clock_configuration.common.sysclksrc_pll_170_hse_24:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/hsi_16.overlay"
     platform_allow: nucleo_g474re
+  drivers.stm32_clock_configuration.common.sysclksrc_pll_32_hse_8:
+    extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/pll_32_hse_8.overlay"
+    platform_allow: nucleo_l152re nucleo_l073rz
+  drivers.stm32_clock_configuration.common.sysclksrc_pll_32_hsi_16:
+    extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/pll_32_hsi_16.overlay"
+    platform_allow: nucleo_l152re nucleo_l073rz
+  drivers.stm32_clock_configuration.common.sysclksrc_msi_range6:
+    extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/msi_range6.overlay"
+    platform_allow: nucleo_l152re nucleo_l073rz

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/testcase.yaml
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common/testcase.yaml
@@ -9,7 +9,7 @@ tests:
     platform_allow: nucleo_g071rb nucleo_g474re
   drivers.stm32_clock_configuration.common.sysclksrc_hsi_16:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/hsi_16.overlay"
-    platform_allow: nucleo_g071rb nucleo_l152re nucleo_l073rz
+    platform_allow: nucleo_g071rb nucleo_l152re nucleo_l073rz nucleo_wl55jc
   drivers.stm32_clock_configuration.common.sysclksrc_hse_24:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/hse_24.overlay"
     platform_allow: nucleo_g474re
@@ -28,3 +28,15 @@ tests:
   drivers.stm32_clock_configuration.common.sysclksrc_msi_range6:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/msi_range6.overlay"
     platform_allow: nucleo_l152re nucleo_l073rz
+  drivers.stm32_clock_configuration.common.sysclksrc_pll_48_hsi_16:
+    extra_args: DTC_OVERLAY_FILE="boards/wl_clear_clocks.overlay;boards/pll_48_hsi_16.overlay"
+    platform_allow: nucleo_wl55jc
+  drivers.stm32_clock_configuration.common.sysclksrc_pll_48_hse_32:
+    extra_args: DTC_OVERLAY_FILE="boards/wl_clear_clocks.overlay;boards/wl_pll_48_hse_32.overlay"
+    platform_allow: nucleo_wl55jc
+  drivers.stm32_clock_configuration.common.sysclksrc_32_hse:
+    extra_args: DTC_OVERLAY_FILE="boards/wl_clear_clocks.overlay;boards/wl_32_hse.overlay"
+    platform_allow: nucleo_wl55jc
+  drivers.stm32_clock_configuration.common.sysclksrc_48_msi:
+    extra_args: DTC_OVERLAY_FILE="boards/wl_clear_clocks.overlay;boards/msi_range11.overlay"
+    platform_allow: nucleo_wl55jc

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32h7/src/test_stm32_clock_configuration.c
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32h7/src/test_stm32_clock_configuration.c
@@ -67,7 +67,7 @@ static void test_pll_src(void)
 			RCC_PLLSOURCE_HSI, pll_src);
 #elif STM32_PLL_SRC_CSI
 	zassert_equal(RCC_PLLSOURCE_CSI, pll_src,
-			"Expected PLL src: MSI (%d). Actual PLL src: %d",
+			"Expected PLL src: CSI (%d). Actual PLL src: %d",
 			RCC_PLLSOURCE_CSI, pll_src);
 #else
 	zassert_equal(RCC_PLLSOURCE_NONE, pll_src,


### PR DESCRIPTION
Similarly to what was done for U5 in https://github.com/zephyrproject-rtos/zephyr/pull/40731 and H7 in https://github.com/zephyrproject-rtos/zephyr/pull/41391
add some tests dedicated to other stm32 clock_control driver configuration

- stm32g0 target board : nucleo_g071rb : with a **clear_clocks**  overlay to clear clocks then apply one config PLL 64MHz from HSI 16 MHz, PLL 64 MHz from HSE 8MHz.
  To set the PLL source to HSE, it is required to have the SB17 (MCO) closed to feed the stm32g071 HSE from the STLINK

- stm32g4 target board : nucleo_g474re : with a **clear_clocks**  overlay to clear clocks then apply one config PLL 64MHz from HSI 16 MHz, PLL 170 MHz from HSE 24MHz, 
  HSE 24MHz (no PLL) HSE is not bypassed. 

- stm32l1 and stm32l0 target board : nucleo_l152re and nucleo_l073rz : with a **clear_clocks**  overlay to clear clocks then apply one config PLL 32MHz from HSI 16 MHz, PLL 32MHz from HSE 8MHz (HSE is  bypassed),  HSE 8MHz (no PLL) HSE is  bypassed, HSI 16MHz, msi range 6 (also valid for other msi_range values).

- stm32wl55 target board : nucleo_wl55jc : with a **wl_clear_clocks**  overlay, config PLL 48MHz from HSI 16 MHz, PLL 48MHz from HSE 32MHz (HSE is  bypassed and HSE prescaler), HSE 32MHz (no PLL) (HSE is  bypassed), HSI 16MHz, msi range11 (also valid for other msi_range values).


- stm32wb55 target board : nucleo_wb55rg : with a **wb_clear_clocks**  overlay, config PLL 48MHz from HSI 16 MHz, PLL 64MHz from HSE 32MHz, PLL 32MHz from MSI 4MHz, HSE 32MHz (no PLL), HSI 16MHz, msi range11 (also valid for other msi_range values). Note that the hse prescaler is not avaible in the clock config.


- stm32l4 and stm32l5 target board : with a **clear_clocks**  overlay plus **clear_msi_clocks**  overlay to clear clocks then apply one config PLL 64MHz from HSI 16 MHz, PLL 48MHz from MSI 4 MHz, PLL  64MHz from HSE 8MHz (HSE is  bypassed),  HSE 8MHz (no PLL) HSE is  bypassed, HSI 16MHz, msi range 11 (also valid for other msi_range values).


- stm32f0/f1/f2/f3/f4/f7 target board : with a **clear_fx_clocks**  overlay overlay to clear clocks then apply one config PLL 64MHz from HSI 16 MHz or 8MHz, PLL  64MHz from HSE 8MHz (HSE is  bypassed),  HSI 8MHz or 16Mh, HSE 8MHz (no PLL) HSE is  bypassed.



Signed-off-by: Francois Ramu <francois.ramu@st.com>
