### PR TITLE
ci: make git credentials non-persistent

### DIFF
--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -39,6 +39,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Environment Setup
         run: |

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -15,6 +15,7 @@ jobs:
           path: zephyrproject/zephyr
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Manifest
         uses: zephyrproject-rtos/action-manifest@2f1ad2908599d4fe747f886f9d733dd7eebae4ef

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -54,6 +54,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Environment Setup
         if: github.event_name == 'pull_request_target'
@@ -137,6 +138,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Environment Setup
         run: |


### PR DESCRIPTION
With this setting enabled, Git credentials are not kept after checkout.
Credentials are not necessary after the checkout step, since we do not
do any further manual push/pull operations.