### PR TITLE
Bluetooth: L2CAP: Add `ing` to the bt_l2cap (dis)connect-ing state

### DIFF
--- a/include/bluetooth/l2cap.h
+++ b/include/bluetooth/l2cap.h
@@ -98,13 +98,13 @@ typedef enum bt_l2cap_chan_state {
 	/** Channel disconnected */
 	BT_L2CAP_DISCONNECTED,
 	/** Channel in connecting state */
-	BT_L2CAP_CONNECT,
+	BT_L2CAP_CONNECTING,
 	/** Channel in config state, BR/EDR specific */
 	BT_L2CAP_CONFIG,
 	/** Channel ready for upper layer traffic on it */
 	BT_L2CAP_CONNECTED,
 	/** Channel in disconnecting state */
-	BT_L2CAP_DISCONNECT,
+	BT_L2CAP_DISCONNECTING,
 
 } __packed bt_l2cap_chan_state_t;
 

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -171,14 +171,14 @@ const char *bt_l2cap_chan_state_str(bt_l2cap_chan_state_t state)
 	switch (state) {
 	case BT_L2CAP_DISCONNECTED:
 		return "disconnected";
-	case BT_L2CAP_CONNECT:
-		return "connect";
+	case BT_L2CAP_CONNECTING:
+		return "connecting";
 	case BT_L2CAP_CONFIG:
 		return "config";
 	case BT_L2CAP_CONNECTED:
 		return "connected";
-	case BT_L2CAP_DISCONNECT:
-		return "disconnect";
+	case BT_L2CAP_DISCONNECTING:
+		return "disconnecting";
 	default:
 		return "unknown";
 	}
@@ -199,23 +199,23 @@ void bt_l2cap_chan_set_state_debug(struct bt_l2cap_chan *chan,
 	case BT_L2CAP_DISCONNECTED:
 		/* regardless of old state always allows this state */
 		break;
-	case BT_L2CAP_CONNECT:
+	case BT_L2CAP_CONNECTING:
 		if (chan->state != BT_L2CAP_DISCONNECTED) {
 			BT_WARN("%s()%d: invalid transition", func, line);
 		}
 		break;
 	case BT_L2CAP_CONFIG:
-		if (chan->state != BT_L2CAP_CONNECT) {
+		if (chan->state != BT_L2CAP_CONNECTING) {
 			BT_WARN("%s()%d: invalid transition", func, line);
 		}
 		break;
 	case BT_L2CAP_CONNECTED:
 		if (chan->state != BT_L2CAP_CONFIG &&
-		    chan->state != BT_L2CAP_CONNECT) {
+		    chan->state != BT_L2CAP_CONNECTING) {
 			BT_WARN("%s()%d: invalid transition", func, line);
 		}
 		break;
-	case BT_L2CAP_DISCONNECT:
+	case BT_L2CAP_DISCONNECTING:
 		if (chan->state != BT_L2CAP_CONFIG &&
 		    chan->state != BT_L2CAP_CONNECTED) {
 			BT_WARN("%s()%d: invalid transition", func, line);
@@ -345,7 +345,7 @@ static bool l2cap_chan_add(struct bt_conn *conn, struct bt_l2cap_chan *chan,
 	if (L2CAP_LE_CID_IS_DYN(ch->rx.cid)) {
 		k_work_init(&ch->rx_work, l2cap_rx_process);
 		k_fifo_init(&ch->rx_queue);
-		bt_l2cap_chan_set_state(chan, BT_L2CAP_CONNECT);
+		bt_l2cap_chan_set_state(chan, BT_L2CAP_CONNECTING);
 	}
 #endif /* CONFIG_BT_L2CAP_DYNAMIC_CHANNEL */
 
@@ -2419,7 +2419,7 @@ static void l2cap_chan_le_recv(struct bt_l2cap_le_chan *chan,
 static void l2cap_chan_recv_queue(struct bt_l2cap_le_chan *chan,
 				  struct net_buf *buf)
 {
-	if (chan->chan.state == BT_L2CAP_DISCONNECT) {
+	if (chan->chan.state == BT_L2CAP_DISCONNECTING) {
 		BT_WARN("Ignoring data received while disconnecting");
 		net_buf_unref(buf);
 		return;
@@ -2853,7 +2853,7 @@ int bt_l2cap_chan_disconnect(struct bt_l2cap_chan *chan)
 	req->scid = sys_cpu_to_le16(ch->rx.cid);
 
 	l2cap_chan_send_req(chan, buf, L2CAP_DISC_TIMEOUT);
-	bt_l2cap_chan_set_state(chan, BT_L2CAP_DISCONNECT);
+	bt_l2cap_chan_set_state(chan, BT_L2CAP_DISCONNECTING);
 
 	return 0;
 }

--- a/subsys/bluetooth/host/l2cap_br.c
+++ b/subsys/bluetooth/host/l2cap_br.c
@@ -185,8 +185,8 @@ static void l2cap_br_rtx_timeout(struct k_work *work)
 	case BT_L2CAP_CONFIG:
 		bt_l2cap_br_chan_disconnect(&chan->chan);
 		break;
-	case BT_L2CAP_DISCONNECT:
-	case BT_L2CAP_CONNECT:
+	case BT_L2CAP_DISCONNECTING:
+	case BT_L2CAP_CONNECTING:
 		l2cap_br_chan_cleanup(&chan->chan);
 		break;
 	default:
@@ -749,7 +749,7 @@ static void l2cap_br_conn_req(struct bt_l2cap_br *l2cap, uint8_t ident,
 	l2cap_br_chan_add(conn, chan, l2cap_br_chan_destroy);
 	BR_CHAN(chan)->tx.cid = scid;
 	chan->ident = ident;
-	bt_l2cap_chan_set_state(chan, BT_L2CAP_CONNECT);
+	bt_l2cap_chan_set_state(chan, BT_L2CAP_CONNECTING);
 	atomic_set_bit(BR_CHAN(chan)->flags, L2CAP_FLAG_CONN_ACCEPTOR);
 
 	/* Disable fragmentation of l2cap rx pdu */
@@ -1154,7 +1154,7 @@ int bt_l2cap_br_chan_disconnect(struct bt_l2cap_chan *chan)
 		return -ENOTCONN;
 	}
 
-	if (chan->state == BT_L2CAP_DISCONNECT) {
+	if (chan->state == BT_L2CAP_DISCONNECTING) {
 		return -EALREADY;
 	}
 
@@ -1175,7 +1175,7 @@ int bt_l2cap_br_chan_disconnect(struct bt_l2cap_chan *chan)
 	req->scid = sys_cpu_to_le16(ch->rx.cid);
 
 	l2cap_br_chan_send_req(ch, buf, L2CAP_BR_DISCONN_TIMEOUT);
-	bt_l2cap_chan_set_state(chan, BT_L2CAP_DISCONNECT);
+	bt_l2cap_chan_set_state(chan, BT_L2CAP_DISCONNECTING);
 
 	return 0;
 }
@@ -1242,7 +1242,7 @@ int bt_l2cap_br_chan_connect(struct bt_conn *conn, struct bt_l2cap_chan *chan,
 		/* Can connect */
 		break;
 	case BT_L2CAP_CONFIG:
-	case BT_L2CAP_DISCONNECT:
+	case BT_L2CAP_DISCONNECTING:
 	default:
 		/* Bad context */
 		return -EBUSY;
@@ -1253,7 +1253,7 @@ int bt_l2cap_br_chan_connect(struct bt_conn *conn, struct bt_l2cap_chan *chan,
 	}
 
 	chan->psm = psm;
-	bt_l2cap_chan_set_state(chan, BT_L2CAP_CONNECT);
+	bt_l2cap_chan_set_state(chan, BT_L2CAP_CONNECTING);
 	atomic_set_bit(BR_CHAN(chan)->flags, L2CAP_FLAG_CONN_PENDING);
 
 	switch (l2cap_br_conn_security(chan, psm)) {
@@ -1317,7 +1317,7 @@ static void l2cap_br_conn_rsp(struct bt_l2cap_br *l2cap, uint8_t ident,
 	/* Release RTX work since got the response */
 	k_work_cancel_delayable(&chan->rtx_work);
 
-	if (chan->state != BT_L2CAP_CONNECT) {
+	if (chan->state != BT_L2CAP_CONNECTING) {
 		BT_DBG("Invalid channel %p state %s", chan,
 		       bt_l2cap_chan_state_str(chan->state));
 		return;
@@ -1419,7 +1419,7 @@ static void l2cap_br_conn_pend(struct bt_l2cap_chan *chan, uint8_t status)
 	struct bt_l2cap_sig_hdr *hdr;
 	struct bt_l2cap_conn_req *req;
 
-	if (chan->state != BT_L2CAP_CONNECT) {
+	if (chan->state != BT_L2CAP_CONNECTING) {
 		return;
 	}
 


### PR DESCRIPTION
Add `ing` to the `BT_L2CAP_CONNECT` and `BT_L2CAP_DISCONNECT`
states, so that the name better matches the actual state.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

Similar changes to other APIs are done in https://github.com/zephyrproject-rtos/zephyr/pull/42540. L2CAP has been handled separately as it is a stable API change unlike the others. 