### PR TITLE
drivers: nios2: constify the driver config

### DIFF
--- a/drivers/dma/dma_nios2_msgdma.c
+++ b/drivers/dma/dma_nios2_msgdma.c
@@ -17,12 +17,11 @@
 #include "altera_msgdma_descriptor_regs.h"
 #include "altera_msgdma.h"
 
-#define LOG_LEVEL CONFIG_DMA_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(dma_nios2);
+LOG_MODULE_REGISTER(dma_nios2, CONFIG_DMA_LOG_LEVEL);
 
 /* Device configuration parameters */
-struct nios2_msgdma_dev_cfg {
+struct nios2_msgdma_dev_data {
 	const struct device *dev;
 	alt_msgdma_dev *msgdma_dev;
 	alt_msgdma_standard_descriptor desc;
@@ -37,20 +36,20 @@ struct nios2_msgdma_dev_cfg {
 static void nios2_msgdma_isr(void *arg)
 {
 	const struct device *dev = (const struct device *)arg;
-	struct nios2_msgdma_dev_cfg *cfg = (struct nios2_msgdma_dev_cfg *)dev->config;
+	struct nios2_msgdma_dev_data *dev_data = (struct nios2_msgdma_dev_data *)dev->data;
 
 	/* Call Altera HAL driver ISR */
-	alt_handle_irq(cfg->msgdma_dev, DT_INST_IRQN(0));
+	alt_handle_irq(dev_data->msgdma_dev, DT_INST_IRQN(0));
 }
 
 static void nios2_msgdma_callback(void *context)
 {
-	struct nios2_msgdma_dev_cfg *dev_cfg =
-		(struct nios2_msgdma_dev_cfg *)context;
+	struct nios2_msgdma_dev_data *dev_data =
+		(struct nios2_msgdma_dev_data *)context;
 	int err_code;
 	uint32_t status;
 
-	status = IORD_ALTERA_MSGDMA_CSR_STATUS(dev_cfg->msgdma_dev->csr_base);
+	status = IORD_ALTERA_MSGDMA_CSR_STATUS(dev_data->msgdma_dev->csr_base);
 
 	if (status & ALTERA_MSGDMA_CSR_STOPPED_ON_ERROR_MASK) {
 		err_code = -EIO;
@@ -62,13 +61,13 @@ static void nios2_msgdma_callback(void *context)
 
 	LOG_DBG("msgdma csr status Reg: 0x%x", status);
 
-	dev_cfg->dma_callback(dev_cfg->dev, dev_cfg->user_data, 0, err_code);
+	dev_data->dma_callback(dev_data->dev, dev_data->user_data, 0, err_code);
 }
 
 static int nios2_msgdma_config(const struct device *dev, uint32_t channel,
 			       struct dma_config *cfg)
 {
-	struct nios2_msgdma_dev_cfg *dev_cfg = (struct nios2_msgdma_dev_cfg *)dev->config;
+	struct nios2_msgdma_dev_data *dev_data = (struct nios2_msgdma_dev_data *)dev->data;
 	struct dma_block_config *dma_block;
 	int status;
 	uint32_t control;
@@ -102,30 +101,30 @@ static int nios2_msgdma_config(const struct device *dev, uint32_t channel,
 		return -EINVAL;
 	}
 
-	k_sem_take(&dev_cfg->sem_lock, K_FOREVER);
-	dev_cfg->dma_callback = cfg->dma_callback;
-	dev_cfg->user_data = cfg->user_data;
-	dev_cfg->direction = cfg->channel_direction;
+	k_sem_take(&dev_data->sem_lock, K_FOREVER);
+	dev_data->dma_callback = cfg->dma_callback;
+	dev_data->user_data = cfg->user_data;
+	dev_data->direction = cfg->channel_direction;
 	dma_block = cfg->head_block;
 	control =  ALTERA_MSGDMA_DESCRIPTOR_CONTROL_TRANSFER_COMPLETE_IRQ_MASK |
 		  ALTERA_MSGDMA_DESCRIPTOR_CONTROL_EARLY_TERMINATION_IRQ_MASK;
 
-	if (dev_cfg->direction == MEMORY_TO_MEMORY) {
+	if (dev_data->direction == MEMORY_TO_MEMORY) {
 		status = alt_msgdma_construct_standard_mm_to_mm_descriptor(
-			dev_cfg->msgdma_dev, &dev_cfg->desc,
+			dev_data->msgdma_dev, &dev_data->desc,
 			(alt_u32 *)dma_block->source_address,
 			(alt_u32 *)dma_block->dest_address,
 			dma_block->block_size,
 			control);
-	} else if (dev_cfg->direction == MEMORY_TO_PERIPHERAL) {
+	} else if (dev_data->direction == MEMORY_TO_PERIPHERAL) {
 		status = alt_msgdma_construct_standard_mm_to_st_descriptor(
-			dev_cfg->msgdma_dev, &dev_cfg->desc,
+			dev_data->msgdma_dev, &dev_data->desc,
 			(alt_u32 *)dma_block->source_address,
 			dma_block->block_size,
 			control);
-	} else if (dev_cfg->direction == PERIPHERAL_TO_MEMORY) {
+	} else if (dev_data->direction == PERIPHERAL_TO_MEMORY) {
 		status = alt_msgdma_construct_standard_st_to_mm_descriptor(
-			dev_cfg->msgdma_dev, &dev_cfg->desc,
+			dev_data->msgdma_dev, &dev_data->desc,
 			(alt_u32 *)dma_block->dest_address,
 			dma_block->block_size,
 			control);
@@ -135,17 +134,17 @@ static int nios2_msgdma_config(const struct device *dev, uint32_t channel,
 	}
 
 	/* Register msgdma callback */
-	alt_msgdma_register_callback(dev_cfg->msgdma_dev,
+	alt_msgdma_register_callback(dev_data->msgdma_dev,
 			nios2_msgdma_callback,
 			ALTERA_MSGDMA_CSR_GLOBAL_INTERRUPT_MASK |
 			ALTERA_MSGDMA_CSR_STOP_ON_ERROR_MASK |
 			ALTERA_MSGDMA_CSR_STOP_ON_EARLY_TERMINATION_MASK,
-			dev_cfg);
+			dev_data);
 
 	/* Clear the IRQ status */
-	IOWR_ALTERA_MSGDMA_CSR_STATUS(dev_cfg->msgdma_dev->csr_base,
+	IOWR_ALTERA_MSGDMA_CSR_STATUS(dev_data->msgdma_dev->csr_base,
 				      ALTERA_MSGDMA_CSR_IRQ_SET_MASK);
-	k_sem_give(&dev_cfg->sem_lock);
+	k_sem_give(&dev_data->sem_lock);
 
 	return status;
 }
@@ -153,7 +152,7 @@ static int nios2_msgdma_config(const struct device *dev, uint32_t channel,
 static int nios2_msgdma_transfer_start(const struct device *dev,
 				       uint32_t channel)
 {
-	struct nios2_msgdma_dev_cfg *cfg = (struct nios2_msgdma_dev_cfg *)dev->config;
+	struct nios2_msgdma_dev_data *cfg = (struct nios2_msgdma_dev_data *)dev->data;
 	int status;
 
 	/* Nios-II mSGDMA supports only one channel per DMA core */
@@ -177,7 +176,7 @@ static int nios2_msgdma_transfer_start(const struct device *dev,
 static int nios2_msgdma_transfer_stop(const struct device *dev,
 				      uint32_t channel)
 {
-	struct nios2_msgdma_dev_cfg *cfg = (struct nios2_msgdma_dev_cfg *)dev->config;
+	struct nios2_msgdma_dev_data *cfg = (struct nios2_msgdma_dev_data *)dev->data;
 	int ret = -EIO;
 	uint32_t status;
 
@@ -207,14 +206,14 @@ static const struct dma_driver_api nios2_msgdma_driver_api = {
 
 static int nios2_msgdma0_initialize(const struct device *dev)
 {
-	struct nios2_msgdma_dev_cfg *dev_cfg = (struct nios2_msgdma_dev_cfg *)dev->config;
+	struct nios2_msgdma_dev_data *dev_data = (struct nios2_msgdma_dev_data *)dev->data;
 
-	dev_cfg->dev = dev;
+	dev_data->dev = dev;
 
 	/* Initialize semaphore */
-	k_sem_init(&dev_cfg->sem_lock, 1, 1);
+	k_sem_init(&dev_data->sem_lock, 1, 1);
 
-	alt_msgdma_init(dev_cfg->msgdma_dev, 0, DT_INST_IRQN(0));
+	alt_msgdma_init(dev_data->msgdma_dev, 0, DT_INST_IRQN(0));
 
 	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority),
 		    nios2_msgdma_isr, DEVICE_DT_INST_GET(0), 0);
@@ -227,10 +226,10 @@ static int nios2_msgdma0_initialize(const struct device *dev)
 ALTERA_MSGDMA_CSR_DESCRIPTOR_SLAVE_INSTANCE(MSGDMA_0, MSGDMA_0_CSR,
 				MSGDMA_0_DESCRIPTOR_SLAVE, msgdma_dev0)
 
-static struct nios2_msgdma_dev_cfg dma0_nios2_config = {
+static struct nios2_msgdma_dev_data dma0_nios2_data = {
 	.msgdma_dev = &msgdma_dev0,
 };
 
 DEVICE_DT_INST_DEFINE(0, &nios2_msgdma0_initialize,
-		NULL, NULL, &dma0_nios2_config, POST_KERNEL,
+		NULL, &dma0_nios2_data, NULL, POST_KERNEL,
 		CONFIG_DMA_INIT_PRIORITY, &nios2_msgdma_driver_api);

--- a/drivers/i2c/i2c_nios2.c
+++ b/drivers/i2c/i2c_nios2.c
@@ -19,18 +19,20 @@ LOG_MODULE_REGISTER(i2c_nios2);
 
 #define NIOS2_I2C_TIMEOUT_USEC		1000
 
-struct i2c_nios2_config {
-	ALT_AVALON_I2C_DEV_t	i2c_dev;
-	IRQ_DATA_t		irq_data;
-	struct k_sem		sem_lock;
+struct i2c_nios2_data {
+	ALT_AVALON_I2C_DEV_t i2c_dev;
+	IRQ_DATA_t irq_data;
+	struct k_sem sem_lock;
 };
 
-static int i2c_nios2_configure(const struct device *dev, uint32_t dev_config)
+static int
+i2c_nios2_configure(const struct device *dev, uint32_t dev_config)
 {
-	struct i2c_nios2_config *config = (struct i2c_nios2_config *)dev->config;
+	struct i2c_nios2_data *data = (struct i2c_nios2_data *)dev->data;
+
 	int32_t rc = 0;
 
-	k_sem_take(&config->sem_lock, K_FOREVER);
+	k_sem_take(&data->sem_lock, K_FOREVER);
 	if (!(I2C_MODE_MASTER & dev_config)) {
 		LOG_ERR("i2c config mode error\n");
 		rc = -EINVAL;
@@ -49,25 +51,25 @@ static int i2c_nios2_configure(const struct device *dev, uint32_t dev_config)
 		goto i2c_cfg_err;
 	}
 
-	alt_avalon_i2c_init(&config->i2c_dev);
+	alt_avalon_i2c_init(&data->i2c_dev);
 
 i2c_cfg_err:
-	k_sem_give(&config->sem_lock);
+	k_sem_give(&data->sem_lock);
 	return rc;
 }
 
 static int i2c_nios2_transfer(const struct device *dev, struct i2c_msg *msgs,
 			      uint8_t num_msgs, uint16_t addr)
 {
-	struct i2c_nios2_config *config = (struct i2c_nios2_config *)dev->config;
+	struct i2c_nios2_data *data = (struct i2c_nios2_data *)dev->data;
 	ALT_AVALON_I2C_STATUS_CODE status;
 	uint32_t restart, stop;
 	int32_t i, timeout, rc = 0;
 
-	k_sem_take(&config->sem_lock, K_FOREVER);
+	k_sem_take(&data->sem_lock, K_FOREVER);
 	/* register the optional interrupt callback */
 	alt_avalon_i2c_register_optional_irq_handler(
-			&config->i2c_dev, &config->irq_data);
+			&data->i2c_dev, &data->irq_data);
 
 	/* Iterate over all the messages */
 	for (i = 0; i < num_msgs; i++) {
@@ -87,17 +89,17 @@ static int i2c_nios2_transfer(const struct device *dev, struct i2c_msg *msgs,
 		}
 
 		/* Set the slave device address */
-		alt_avalon_i2c_master_target_set(&config->i2c_dev, addr);
+		alt_avalon_i2c_master_target_set(&data->i2c_dev, addr);
 
 		/* Start the transfer */
 		if (msgs->flags & I2C_MSG_READ) {
 			status = alt_avalon_i2c_master_receive_using_interrupts(
-							&config->i2c_dev,
+							&data->i2c_dev,
 							msgs->buf, msgs->len,
 							restart, stop);
 		} else {
 			status = alt_avalon_i2c_master_transmit_using_interrupts
-							(&config->i2c_dev,
+							(&data->i2c_dev,
 							msgs->buf, msgs->len,
 							restart, stop);
 		}
@@ -115,7 +117,7 @@ static int i2c_nios2_transfer(const struct device *dev, struct i2c_msg *msgs,
 		while (timeout) {
 			k_busy_wait(1);
 			status = alt_avalon_i2c_interrupt_transaction_status(
-							&config->i2c_dev);
+							&data->i2c_dev);
 			if (status == ALT_AVALON_I2C_SUCCESS) {
 				break;
 			}
@@ -133,17 +135,17 @@ static int i2c_nios2_transfer(const struct device *dev, struct i2c_msg *msgs,
 	}
 
 i2c_transfer_err:
-	alt_avalon_i2c_disable(&config->i2c_dev);
-	k_sem_give(&config->sem_lock);
+	alt_avalon_i2c_disable(&data->i2c_dev);
+	k_sem_give(&data->sem_lock);
 	return rc;
 }
 
 static void i2c_nios2_isr(const struct device *dev)
 {
-	struct i2c_nios2_config *config = (struct i2c_nios2_config *)dev->config;
+	struct i2c_nios2_data *data = (struct i2c_nios2_data *)dev->data;
 
 	/* Call Altera HAL driver ISR */
-	alt_handle_irq(&config->i2c_dev, DT_INST_IRQN(0));
+	alt_handle_irq(&data->i2c_dev, DT_INST_IRQN(0));
 }
 
 static int i2c_nios2_init(const struct device *dev);
@@ -153,7 +155,7 @@ static struct i2c_driver_api i2c_nios2_driver_api = {
 	.transfer = i2c_nios2_transfer,
 };
 
-static struct i2c_nios2_config i2c_nios2_cfg = {
+static struct i2c_nios2_data i2c_nios2_dev_data = {
 	.i2c_dev = {
 		.i2c_base = (alt_u32 *)DT_INST_REG_ADDR(0),
 		.irq_controller_ID = I2C_0_IRQ_INTERRUPT_CONTROLLER_ID,
@@ -162,18 +164,13 @@ static struct i2c_nios2_config i2c_nios2_cfg = {
 	},
 };
 
-I2C_DEVICE_DT_INST_DEFINE(0, i2c_nios2_init, NULL,
-		    NULL, &i2c_nios2_cfg,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
-		    &i2c_nios2_driver_api);
-
 static int i2c_nios2_init(const struct device *dev)
 {
-	struct i2c_nios2_config *config = (struct i2c_nios2_config *)dev->config;
+	struct i2c_nios2_data *data = (struct i2c_nios2_data *)dev->data;
 	int rc;
 
 	/* initialize semaphore */
-	k_sem_init(&config->sem_lock, 1, 1);
+	k_sem_init(&data->sem_lock, 1, 1);
 
 	rc = i2c_nios2_configure(dev,
 			I2C_MODE_MASTER |
@@ -184,10 +181,15 @@ static int i2c_nios2_init(const struct device *dev)
 	}
 
 	/* clear ISR register content */
-	alt_avalon_i2c_int_clear(&config->i2c_dev,
+	alt_avalon_i2c_int_clear(&data->i2c_dev,
 			ALT_AVALON_I2C_ISR_ALL_CLEARABLE_INTS_MSK);
 	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority),
 			i2c_nios2_isr, DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQN(0));
 	return 0;
 }
+
+I2C_DEVICE_DT_INST_DEFINE(0, i2c_nios2_init, NULL,
+		    &i2c_nios2_dev_data, NULL,
+		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    &i2c_nios2_driver_api);


### PR DESCRIPTION
Moves the previous assigned device config structs to data structs as they were being used for mutable driver data.

Fixes #41924