### PR TITLE
linker: add a utility func to check if an addr is in RO section

### DIFF
--- a/include/linker/utils.h
+++ b/include/linker/utils.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_LINKER_UTILS_H_
+#define ZEPHYR_INCLUDE_LINKER_UTILS_H_
+
+#include <stdbool.h>
+
+/**
+ * @brief Check if address is in read only section.
+ *
+ * Note that this may return false if the address lies outside
+ * the compiler's default read only sections (e.g. .rodata
+ * section), depending on the linker script used. This also
+ * applies to constants with explicit section attributes.
+ *
+ * @param addr Address.
+ *
+ * @return True if address identified within read only section.
+ */
+static inline bool linker_is_in_rodata(const void *addr)
+{
+#if defined(CONFIG_LINKER_USE_PINNED_SECTION)
+	extern const char lnkr_pinned_rodata_start[];
+	extern const char lnkr_pinned_rodata_end[];
+
+	if (((const char *)addr >= (const char *)lnkr_pinned_rodata_start) &&
+	    ((const char *)addr < (const char *)lnkr_pinned_rodata_end)) {
+		return true;
+	}
+#endif
+
+#if defined(CONFIG_ARM) || defined(CONFIG_ARC) || defined(CONFIG_X86) || \
+	defined(CONFIG_ARM64) || defined(CONFIG_NIOS2) || \
+	defined(CONFIG_RISCV) || defined(CONFIG_SPARC) || defined(CONFIG_MIPS)
+	extern char __rodata_region_start[];
+	extern char __rodata_region_end[];
+	#define RO_START __rodata_region_start
+	#define RO_END __rodata_region_end
+#elif defined(CONFIG_XTENSA)
+	extern const char _rodata_start[];
+	extern const char _rodata_end[];
+	#define RO_START _rodata_start
+	#define RO_END _rodata_end
+#else
+	#define RO_START 0
+	#define RO_END 0
+#endif
+
+	return (((const char *)addr >= (const char *)RO_START) &&
+		((const char *)addr < (const char *)RO_END));
+
+	#undef RO_START
+	#undef RO_END
+}
+
+#endif /* ZEPHYR_INCLUDE_LINKER_UTILS_H_ */

--- a/lib/os/cbprintf_packaged.c
+++ b/lib/os/cbprintf_packaged.c
@@ -8,6 +8,7 @@
 #include <stdarg.h>
 #include <stdint.h>
 #include <string.h>
+#include <linker/utils.h>
 #include <sys/cbprintf.h>
 #include <sys/types.h>
 #include <sys/util.h>
@@ -27,27 +28,10 @@ static inline bool ptr_in_rodata(const char *addr)
 	/* Unit test is X86 (or other host) but not using Zephyr
 	 * linker scripts.
 	 */
-#define RO_START 0
-#define RO_END 0
-#elif defined(CONFIG_ARC) || defined(CONFIG_ARM) || defined(CONFIG_X86) \
-	|| defined(CONFIG_RISCV) || defined(CONFIG_ARM64) \
-	|| defined(CONFIG_NIOS2) || defined(CONFIG_MIPS) || defined(CONFIG_SPARC)
-	extern char __rodata_region_start[];
-	extern char __rodata_region_end[];
-#define RO_START __rodata_region_start
-#define RO_END __rodata_region_end
-#elif defined(CONFIG_XTENSA)
-	extern char _rodata_start[];
-	extern char _rodata_end[];
-#define RO_START _rodata_start
-#define RO_END _rodata_end
+	return false;
 #else
-#define RO_START 0
-#define RO_END 0
+	return linker_is_in_rodata(addr);
 #endif
-
-	return ((addr >= (const char *)RO_START) &&
-		(addr < (const char *)RO_END));
 }
 
 /*


### PR DESCRIPTION
This adds a utility function to check if an address is within
read only section. This is extracted from logging subsys so
use the new func in logging. The one is cbprintf_packaged is
also replaced.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>