### PR TITLE
modules: lvgl: add stubs for Kconfig symbols overridden in-tree

### DIFF
--- a/modules/Kconfig.lvgl
+++ b/modules/Kconfig.lvgl
@@ -5,3 +5,45 @@ config LVGL
 	bool "LittlevGL GUI library"
 	help
 	  This option enables the LittlevGL GUI library.
+
+if !LVGL
+
+config LV_Z_POINTER_KSCAN
+	bool
+
+config LV_Z_POINTER_KSCAN_DEV_NAME
+	string
+	default "KSCAN"
+
+config LV_Z_POINTER_KSCAN_MSGQ_COUNT
+	int
+	default 10
+
+config LV_Z_POINTER_KSCAN_SWAP_XY
+	bool
+
+config LV_Z_POINTER_KSCAN_INVERT_X
+	bool
+
+config LV_Z_POINTER_KSCAN_INVERT_Y
+	bool
+
+choice LV_COLOR_DEPTH_BITS
+	default LV_COLOR_DEPTH_16
+	prompt "Color depth."
+	depends on LVGL
+
+	config LV_COLOR_DEPTH_32
+		bool "32: ARGB8888"
+	config LV_COLOR_DEPTH_16
+		bool "16: RGB565"
+	config LV_COLOR_DEPTH_8
+		bool "8: RGB232"
+	config LV_COLOR_DEPTH_1
+		bool "1: 1 byte per pixel"
+endchoice
+
+config LV_COLOR_16_SWAP
+	bool
+
+endif


### PR DESCRIPTION
There are several Kconfig symbols defined in the lvgl module that are referenced from various defconfigs in the zephyr tree. If the LVGL module is unavailable, they need to be redefined as stubs in Kconfig.lvgl.

Fixes: 6c190292c064 ("lvgl: move the lvgl glue out of the zephyr tree")
Signed-off-by: Bartosz Golaszewski <bartosz.golaszewski@huawei.com>