### PR TITLE
pm: Remove extraneous "info" statement left over from PR #42041

### DIFF
--- a/soc/arm/st_stm32/stm32g0/power.c
+++ b/soc/arm/st_stm32/stm32g0/power.c
@@ -22,7 +22,7 @@ LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 /* Invoke Low Power/System Off specific Tasks */
 __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 {
-	if (info->state != PM_STATE_SUSPEND_TO_IDLE) {
+	if (state != PM_STATE_SUSPEND_TO_IDLE) {
 		LOG_DBG("Unsupported power state %u", state);
 		return;
 	}


### PR DESCRIPTION
Remove extraneous "info" statement left over in file stm32g0/power.c

Signed-off-by: Sam Hurst <sbh1187@gmail.com>