### PR TITLE
xcc: fix building errors related to logging

### DIFF
--- a/include/logging/log_msg2.h
+++ b/include/logging/log_msg2.h
@@ -12,6 +12,7 @@
 #include <sys/atomic.h>
 #include <sys/util.h>
 #include <string.h>
+#include <toolchain.h>
 
 #ifdef __GNUC__
 #ifndef alloca
@@ -323,7 +324,9 @@ do { \
  *
  * @param ...  Optional string with arguments (fmt, ...). It may be empty.
  */
-#ifdef CONFIG_LOG2_ALWAYS_RUNTIME
+#if defined(CONFIG_LOG2_ALWAYS_RUNTIME) || \
+	(!defined(CONFIG_LOG) && \
+		(!TOOLCHAIN_HAS_PRAGMA_DIAG || !TOOLCHAIN_HAS_C_AUTO_TYPE))
 #define Z_LOG_MSG2_CREATE2(_try_0cpy, _mode,  _cstr_cnt, _domain_id, _source,\
 			  _level, _data, _dlen, ...) \
 do {\
@@ -388,7 +391,9 @@ do { \
 			   _level, _data, _dlen, \
 			   FOR_EACH_IDX(Z_LOG_LOCAL_ARG_NAME, (,), __VA_ARGS__)); \
 } while (0)
-#endif /* CONFIG_LOG2_ALWAYS_RUNTIME */
+#endif /* CONFIG_LOG2_ALWAYS_RUNTIME ||
+	* (!LOG && (!TOOLCHAIN_HAS_PRAGMA_DIAG || !TOOLCHAIN_HAS_C_AUTO_TYPE))
+	*/
 
 
 #define Z_LOG_MSG2_CREATE(_try_0cpy, _mode,  _domain_id, _source,\

--- a/include/toolchain.h
+++ b/include/toolchain.h
@@ -52,6 +52,14 @@
 #error "Invalid/unknown toolchain configuration"
 #endif
 
+/**
+ * @def GCC_VERSION
+ * @brief GCC version in xxyyzz for xx.yy.zz. Zero if not GCC compatible.
+ */
+#ifndef GCC_VERSION
+#define GCC_VERSION 0
+#endif
+
 /*
  * Ensure that __BYTE_ORDER__ and related preprocessor definitions are defined,
  * as these are often used without checking for definition and doing so can

--- a/include/toolchain.h
+++ b/include/toolchain.h
@@ -92,6 +92,14 @@
 # endif
 #endif
 
+/**
+ * @def TOOLCHAIN_HAS_C_AUTO_TYPE
+ * @brief Indicate if toolchain supports C __auto_type.
+ */
+#ifndef TOOLCHAIN_HAS_C_AUTO_TYPE
+#define TOOLCHAIN_HAS_C_AUTO_TYPE 0
+#endif
+
 /*
  * Ensure that __BYTE_ORDER__ and related preprocessor definitions are defined,
  * as these are often used without checking for definition and doing so can

--- a/include/toolchain.h
+++ b/include/toolchain.h
@@ -76,6 +76,22 @@
 #define TOOLCHAIN_HAS_PRAGMA_DIAG 0
 #endif
 
+/**
+ * @def TOOLCHAIN_HAS_C_GENERIC
+ * @brief Indicate if toolchain supports C Generic.
+ */
+#if __STDC_VERSION__ >= 201112L
+/* _Generic is introduced in C11, so it is supported. */
+# ifdef TOOLCHAIN_HAS_C_GENERIC
+#  undef TOOLCHAIN_HAS_C_GENERIC
+# endif
+# define TOOLCHAIN_HAS_C_GENERIC 1
+#else
+# ifndef TOOLCHAIN_HAS_C_GENERIC
+#  define TOOLCHAIN_HAS_C_GENERIC 0
+# endif
+#endif
+
 /*
  * Ensure that __BYTE_ORDER__ and related preprocessor definitions are defined,
  * as these are often used without checking for definition and doing so can

--- a/include/toolchain.h
+++ b/include/toolchain.h
@@ -60,6 +60,14 @@
 #define GCC_VERSION 0
 #endif
 
+/**
+ * @def CLANG_VERSION
+ * @brief Clang version in xxyyzz for xx.yy.zz. Zero if not Clang compatible.
+ */
+#ifndef CLANG_VERSION
+#define CLANG_VERSION 0
+#endif
+
 /*
  * Ensure that __BYTE_ORDER__ and related preprocessor definitions are defined,
  * as these are often used without checking for definition and doing so can

--- a/include/toolchain.h
+++ b/include/toolchain.h
@@ -68,6 +68,14 @@
 #define CLANG_VERSION 0
 #endif
 
+/**
+ * @def TOOLCHAIN_HAS_PRAGMA_DIAG
+ * @brief Indicate if toolchain supports \#pragma diagnostics.
+ */
+#ifndef TOOLCHAIN_HAS_PRAGMA_DIAG
+#define TOOLCHAIN_HAS_PRAGMA_DIAG 0
+#endif
+
 /*
  * Ensure that __BYTE_ORDER__ and related preprocessor definitions are defined,
  * as these are often used without checking for definition and doing so can

--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -26,6 +26,10 @@
 #define TOOLCHAIN_HAS_C_GENERIC 1
 #endif
 
+#if !defined(TOOLCHAIN_HAS_C_AUTO_TYPE) && (GCC_VERSION >= 40900)
+#define TOOLCHAIN_HAS_C_AUTO_TYPE 1
+#endif
+
 /*
  * Older versions of GCC do not define __BYTE_ORDER__, so it must be manually
  * detected and defined using arch-specific definitions.

--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -17,6 +17,11 @@
 #define GCC_VERSION \
 	((__GNUC__ * 10000) + (__GNUC_MINOR__ * 100) + __GNUC_PATCHLEVEL__)
 
+/* GCC supports #pragma diagnostics since 4.6.0 */
+#if !defined(TOOLCHAIN_HAS_PRAGMA_DIAG) && (GCC_VERSION >= 40600)
+#define TOOLCHAIN_HAS_PRAGMA_DIAG 1
+#endif
+
 /*
  * Older versions of GCC do not define __BYTE_ORDER__, so it must be manually
  * detected and defined using arch-specific definitions.

--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -14,6 +14,9 @@
  * Macros to abstract compiler capabilities for GCC toolchain.
  */
 
+#define GCC_VERSION \
+	((__GNUC__ * 10000) + (__GNUC_MINOR__ * 100) + __GNUC_PATCHLEVEL__)
+
 /*
  * Older versions of GCC do not define __BYTE_ORDER__, so it must be manually
  * detected and defined using arch-specific definitions.

--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -22,6 +22,10 @@
 #define TOOLCHAIN_HAS_PRAGMA_DIAG 1
 #endif
 
+#if !defined(TOOLCHAIN_HAS_C_GENERIC) && (GCC_VERSION >= 40900)
+#define TOOLCHAIN_HAS_C_GENERIC 1
+#endif
+
 /*
  * Older versions of GCC do not define __BYTE_ORDER__, so it must be manually
  * detected and defined using arch-specific definitions.

--- a/include/toolchain/llvm.h
+++ b/include/toolchain/llvm.h
@@ -22,6 +22,7 @@
 
 #if CLANG_VERSION >= 30800
 #define TOOLCHAIN_HAS_C_GENERIC 1
+#define TOOLCHAIN_HAS_C_AUTO_TYPE 1
 #endif
 
 #include <toolchain/gcc.h>

--- a/include/toolchain/llvm.h
+++ b/include/toolchain/llvm.h
@@ -18,6 +18,8 @@
 	((__clang_major__ * 10000) + (__clang_minor__ * 100) + \
 	  __clang_patchlevel__)
 
+#define TOOLCHAIN_HAS_PRAGMA_DIAG 1
+
 #include <toolchain/gcc.h>
 
 

--- a/include/toolchain/llvm.h
+++ b/include/toolchain/llvm.h
@@ -14,6 +14,10 @@
 #define __fallthrough __attribute__((fallthrough))
 #endif
 
+#define CLANG_VERSION \
+	((__clang_major__ * 10000) + (__clang_minor__ * 100) + \
+	  __clang_patchlevel__)
+
 #include <toolchain/gcc.h>
 
 

--- a/include/toolchain/llvm.h
+++ b/include/toolchain/llvm.h
@@ -20,6 +20,10 @@
 
 #define TOOLCHAIN_HAS_PRAGMA_DIAG 1
 
+#if CLANG_VERSION >= 30800
+#define TOOLCHAIN_HAS_C_GENERIC 1
+#endif
+
 #include <toolchain/gcc.h>
 
 

--- a/subsys/logging/Kconfig.misc
+++ b/subsys/logging/Kconfig.misc
@@ -38,6 +38,7 @@ config LOG2_ALWAYS_RUNTIME
 	bool
 	default y if NO_OPTIMIZATIONS
 	default y if LOG_MODE_IMMEDIATE
+	default y if "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "xcc"
 	help
 	  If enabled, runtime method is always used for message creation. Static
 	  creation relies on compiler being able to optimize and remove code


### PR DESCRIPTION
XCC is based on very old GCC (sigh...) that there is no auto type, and _Pragma cannot be used within functions. The latest logging changes related to argument evaluation resulted in build errors regarding these. See individual commits for more details.