### PR TITLE
samples: nrf: system_off: Fix force state usage

### DIFF
--- a/samples/boards/nrf/system_off/src/main.c
+++ b/samples/boards/nrf/system_off/src/main.c
@@ -93,6 +93,12 @@ void main(void)
 	 */
 	pm_state_force(0u, &(struct pm_state_info){PM_STATE_SOFT_OFF, 0, 0});
 
+	/* Now we need to go sleep. This will let the idle thread runs and
+	 * the pm subsystem will use the forced state. To confirm that the
+	 * forced state is used, lets set the same timeout used previously.
+	 */
+	k_sleep(K_SECONDS(SLEEP_S));
+
 	printk("ERROR: System off failed\n");
 	while (true) {
 		/* spin to avoid fall-off behavior */


### PR DESCRIPTION
The sample cannot spin in an infinity loop because the idle thread will
not run and consequently the forced state will not be used.

Fixes #43285 

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>