### PR TITLE
drivers: can: rcar: add statistics support

### DIFF
--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -276,40 +276,39 @@ static void can_rcar_error(const struct device *dev)
 
 	if (eifr & RCAR_CAN_EIFR_BEIF) {
 
-		LOG_DBG("Bus error interrupt:\n");
 		ecsr = sys_read8(config->reg_addr + RCAR_CAN_ECSR);
 		if (ecsr & RCAR_CAN_ECSR_ADEF) {
-			LOG_DBG("ACK Delimiter Error\n");
+			CAN_STATS_ACK_ERROR_INC(dev);
 			sys_write8((uint8_t)~RCAR_CAN_ECSR_ADEF,
 				   config->reg_addr + RCAR_CAN_ECSR);
 		}
 		if (ecsr & RCAR_CAN_ECSR_BE0F) {
-			LOG_DBG("Bit Error (dominant)\n");
+			CAN_STATS_BIT0_ERROR_INC(dev);
 			sys_write8((uint8_t)~RCAR_CAN_ECSR_BE0F,
 				   config->reg_addr + RCAR_CAN_ECSR);
 		}
 		if (ecsr & RCAR_CAN_ECSR_BE1F) {
-			LOG_DBG("Bit Error (recessive)\n");
+			CAN_STATS_BIT1_ERROR_INC(dev);
 			sys_write8((uint8_t)~RCAR_CAN_ECSR_BE1F,
 				   config->reg_addr + RCAR_CAN_ECSR);
 		}
 		if (ecsr & RCAR_CAN_ECSR_CEF) {
-			LOG_DBG("CRC Error\n");
+			CAN_STATS_CRC_ERROR_INC(dev);
 			sys_write8((uint8_t)~RCAR_CAN_ECSR_CEF,
 				   config->reg_addr + RCAR_CAN_ECSR);
 		}
 		if (ecsr & RCAR_CAN_ECSR_AEF) {
-			LOG_DBG("ACK Error\n");
+			CAN_STATS_ACK_ERROR_INC(dev);
 			sys_write8((uint8_t)~RCAR_CAN_ECSR_AEF,
 				   config->reg_addr + RCAR_CAN_ECSR);
 		}
 		if (ecsr & RCAR_CAN_ECSR_FEF) {
-			LOG_DBG("Form Error\n");
+			CAN_STATS_FORM_ERROR_INC(dev);
 			sys_write8((uint8_t)~RCAR_CAN_ECSR_FEF,
 				   config->reg_addr + RCAR_CAN_ECSR);
 		}
 		if (ecsr & RCAR_CAN_ECSR_SEF) {
-			LOG_DBG("Stuff Error\n");
+			CAN_STATS_STUFF_ERROR_INC(dev);
 			sys_write8((uint8_t)~RCAR_CAN_ECSR_SEF,
 				   config->reg_addr + RCAR_CAN_ECSR);
 		}
@@ -1059,7 +1058,7 @@ static const struct can_driver_api can_rcar_driver_api = {
 	};									\
 	static struct can_rcar_data can_rcar_data_##n;				\
 										\
-	DEVICE_DT_INST_DEFINE(n, can_rcar_init,					\
+	CAN_DEVICE_DT_INST_DEFINE(n, can_rcar_init,				\
 			      NULL,						\
 			      &can_rcar_data_##n,				\
 			      &can_rcar_cfg_##n,				\


### PR DESCRIPTION
Add CAN controller statistics support to the Renesas R-Car CAN driver.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>