### PR TITLE
ci: clang: do not persist git credentials

### DIFF
--- a/.github/workflows/bsim-publish.yaml
+++ b/.github/workflows/bsim-publish.yaml
@@ -1,0 +1,29 @@
+name: Publish Bluetooth Tests Results
+
+on:
+  workflow_run:
+    workflows: ["Bluetooth Tests"]
+    types:
+      - completed
+jobs:
+  bluetooth-test-results:
+    name: "Publish Bluetooth Test Results"
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion != 'skipped'
+
+    steps:
+      - name: Download artifacts
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: bluetooth-tests.yaml
+          run_id: ${{ github.event.workflow_run.id }}
+
+      - name: Publish Bluetooth Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          check_name: Bluetooth Test Results
+          comment_mode: off
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: event/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          files: "bluetooth-test-results/**/bsim_results.xml"

--- a/.github/workflows/bsim.yaml
+++ b/.github/workflows/bsim.yaml
@@ -1,7 +1,7 @@
 name: Bluetooth Tests
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - "west.yml"
       - "subsys/bluetooth/**"
@@ -39,9 +39,6 @@ jobs:
 
       - name: checkout
         uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
 
       - name: west setup
         run: |
@@ -60,26 +57,13 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: Bluetooth Test Results
+          name: bluetooth-test-results
           path: ./bsim_bt_out/bsim_results.xml
 
-  publish-test-results:
-    name: "Publish Unit Tests Results"
-    needs: bsim-build
-    runs-on: ubuntu-20.04
-      # the build-and-test job might be skipped, we don't need to run this job then
-    if: success() || failure()
-
-    steps:
-      - name: Download Artifacts
-        uses: actions/download-artifact@v2
+      - name: Upload Event Details
+        if: always()
+        uses: actions/upload-artifact@v2
         with:
-          path: artifacts
-
-      - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1.12
-        with:
-          check_name: Bluetooth Test Results
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          files: "**/bsim_results.xml"
-          comment_on_pr: false
+          name: event
+          path: |
+            ${{ github.event_path }}

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -38,6 +38,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: west setup
         run: |

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -15,6 +15,7 @@ jobs:
           path: zephyrproject/zephyr
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Manifest
         uses: zephyrproject-rtos/action-manifest@v1.1.0


### PR DESCRIPTION
[ci: clang: do not persist git credentials](https://github.com/zephyrproject-rtos/zephyr/commit/9641f1ecdb49ae54033276ac9ad3b17e6341afee)[](https://github.com/gmarull) 

With this setting enabled, Git credentials are not kept after checkout.
Credentials are not necessary after the checkout step, since we do not
do any further manual push/pull operations.
  
[ci: bsim: split workflow](https://github.com/zephyrproject-rtos/zephyr/commit/d3e7d132db489467cf7a6921d480f62f90d622b3) 

Split workflow into 2 chunks:

- One that runs tests
- A second one that publishes results