### PR TITLE
drivers: can: stm32: add statistics support

### DIFF
--- a/drivers/can/can_stm32.h
+++ b/drivers/can/can_stm32.h
@@ -62,6 +62,7 @@ struct can_stm32_data {
 	void *cb_arg[CONFIG_CAN_MAX_FILTER];
 	can_state_change_callback_t state_change_cb;
 	void *state_change_cb_data;
+	enum can_state state;
 };
 
 struct can_stm32_config {


### PR DESCRIPTION
Add CAN controller statistics support to the STM32 bxCAN driver. Rework the state change callback code a bit.
    
Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>
