### PR TITLE
MAINTAINERS.yml: Remove myself as maintainer

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -234,7 +234,6 @@ Build system:
     collaborators:
         - jeremybettis
         - nashif
-        - SebastianBoe
     files:
         - cmake/
         - CMakeLists.txt
@@ -1680,7 +1679,7 @@ TF-M Integration:
     maintainers:
         - microbuilder
     collaborators:
-        - SebastianBoe
+        - joerchan
     files:
         - samples/tfm_integration/
         - modules/trusted-firmware-m/


### PR DESCRIPTION
Remove myself as maintainer due to planned sabbatical and add Joakim
as TF-M maintainer in my place.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>