### PR TITLE
Bluetooth: Controller: Add sampling and switching offset configuration

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.df
+++ b/subsys/bluetooth/controller/Kconfig.df
@@ -195,6 +195,61 @@ config BT_CTLR_DF_PER_SCAN_CTE_NUM_MAX
 	  periodic advertising chain. The range is taken from BT Core spec 5.1, Vol 4 Part E
 	  section 7.8.82 HCI_LE_Set_Connectionless_IQ_Sampling_Enable Max_Sampled_CTEs parameter.
 
+config BT_CTLR_DF_SWITCH_OFFSET
+	int "Antenna switch offset relative to end of CRC"
+	depends on SOC_COMPATIBLE_NRF
+	range -2048 2047
+	default 0
+	help
+	  Offset of start of antenna switching after end of the CRC. It is a signed value in number
+	  of 16M cycles. Decreasing the offset value beyond the trigger of the AoA/AoD procedure
+	  will have no effect.
+
+config BT_CTLR_DF_SAMPLE_OFFSET_PHY_1M_SAMPLING_1US
+	int "CTE sampling offset relative for PHY 1M and 1US samples spacing"
+	depends on SOC_COMPATIBLE_NRF
+	range -2048 2047
+	default 1
+	help
+	  Offset of sampling start from beginning of sampling slot. The value is a signed number
+	  of 16M cycles relative. It is used when PHY is set to PHY 1M and sampling slot duarion
+	  is 1 us. Decreasing the offset beyond the trigger of the AoA/AoD procedure will have
+	  no effect.
+
+config BT_CTLR_DF_SAMPLE_OFFSET_PHY_2M_SAMPLING_1US
+	int "CTE sampling offset relative for PHY 1M and 1US samples spacing"
+	depends on SOC_COMPATIBLE_NRF
+	range -2048 2047
+	default 15
+	help
+	  Offset of sampling start from beginning of sampling slot. The value is a signed number
+	  of 16M cycles relative. It is used when PHY is set to PHY 1M and sampling slot duarion
+	  is 1 us. Decreasing the offset beyond the trigger of the AoA/AoD procedure will have
+	  no effect.
+
+
+config BT_CTLR_DF_SAMPLE_OFFSET_PHY_1M_SAMPLING_2US
+	int "CTE sampling offset relative for PHY 1M and 2US samples spacing"
+	depends on SOC_COMPATIBLE_NRF
+	range -2048 2047
+	default 6
+	help
+	  Offset of sampling start from beginning of sampling slot. The value is a signed number
+	  of 16M cycles relative. It is used when PHY is set to PHY 1M and sampling slot duarion
+	  is 2 us. Decreasing the offset beyond the trigger of the AoA/AoD procedure will have
+	  no effect.
+
+config BT_CTLR_DF_SAMPLE_OFFSET_PHY_2M_SAMPLING_2US
+	int "CTE sampling offset relative for PHY 1M and 2US samples spacing"
+	depends on SOC_COMPATIBLE_NRF
+	range -2048 2047
+	default 20
+	help
+	  Offset of sampling start from beginning of sampling slot. The value is a signed number
+	  of 16M cycles relative. It is used when PHY is set to PHY 1M and sampling slot duarion
+	  is 2 us. Decreasing the offset beyond the trigger of the AoA/AoD procedure will have
+	  no effect.
+
 config BT_CTLR_DF_DEBUG_ENABLE
 	bool "Bluetooth Direction Finding debug support enable"
 	help

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_df.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_df.h
@@ -34,9 +34,9 @@ void radio_df_cte_tx_aod_4us_set(uint8_t cte_len);
 /* Configure CTE transmission with for AoA. */
 void radio_df_cte_tx_aoa_set(uint8_t cte_len);
 /* Configure CTE reception with optionall AoA mode and 2us antenna switching. */
-void radio_df_cte_rx_2us_switching(bool cte_info_in_s1);
+void radio_df_cte_rx_2us_switching(bool cte_info_in_s1, uint8_t phy);
 /* Configure CTE reception with optionall AoA mode and 4us antenna switching. */
-void radio_df_cte_rx_4us_switching(bool cte_info_in_s1);
+void radio_df_cte_rx_4us_switching(bool cte_info_in_s1, uint8_t phy);
 
 /* Clears antenna switch pattern. */
 void radio_df_ant_switch_pattern_clear(void);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -490,7 +490,8 @@ void lll_conn_isr_tx(void *param)
 		if (df_rx_params->is_enabled) {
 			lll_df_conf_cte_rx_enable(df_rx_params->slot_durations,
 						  df_rx_params->ant_sw_len, df_rx_params->ant_ids,
-						  df_rx_cfg->chan, CTE_INFO_IN_S1_BYTE);
+						  df_rx_cfg->chan, CTE_INFO_IN_S1_BYTE,
+						  lll->phy_rx);
 		} else {
 			lll_df_conf_cte_info_parsing_enable();
 		}

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df.c
@@ -217,22 +217,23 @@ struct lll_df_sync_cfg *lll_df_sync_cfg_latest_get(struct lll_df_sync *df_cfg,
  * @param chan_idx          Channel used to receive PDU with CTE
  * @param cte_info_in_s1    Inform if CTEInfo is in S1 byte for conn. PDU or in extended advertising
  *                          header of per. adv. PDU.
+ * @param phy               Current PHY
  *
  * In case of AoA mode ant_num and ant_ids parameters are not used.
  */
 void lll_df_conf_cte_rx_enable(uint8_t slot_duration, uint8_t ant_num, const uint8_t *ant_ids,
-			       uint8_t chan_idx, bool cte_info_in_s1)
+			       uint8_t chan_idx, bool cte_info_in_s1, uint8_t phy)
 {
 	struct node_rx_iq_report *node_rx;
 
 	/* ToDo change to appropriate HCI constant */
 #if defined(CONFIG_BT_CTLR_DF_ANT_SWITCH_1US)
 	if (slot_duration == 0x1) {
-		radio_df_cte_rx_2us_switching(cte_info_in_s1);
+		radio_df_cte_rx_2us_switching(cte_info_in_s1, phy);
 	} else
 #endif /* CONFIG_BT_CTLR_DF_ANT_SWITCH_1US */
 	{
-		radio_df_cte_rx_4us_switching(cte_info_in_s1);
+		radio_df_cte_rx_4us_switching(cte_info_in_s1, phy);
 	}
 
 #if defined(CONFIG_BT_CTLR_DF_ANT_SWITCH_RX)
@@ -261,8 +262,10 @@ void lll_df_conf_cte_info_parsing_enable(void)
 	/* Use of mandatory 2 us switching and sampling slots for CTEInfo parsing.
 	 * The configuration here does not matter for actual IQ sampling.
 	 * The collected data will not be reported to host.
+	 * Also sampling offset does not matter so, provided PHY is legacy to setup
+	 * the offset to default zero value.
 	 */
-	radio_df_cte_rx_4us_switching(true);
+	radio_df_cte_rx_4us_switching(true, PHY_LEGACY);
 
 #if defined(CONFIG_BT_CTLR_DF_ANT_SWITCH_RX)
 	/* Use PDU_ANTENNA so no actual antenna change will be done. */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df_internal.h
@@ -57,7 +57,7 @@ static inline uint8_t lll_df_sync_cfg_is_modified(struct lll_df_sync *df_cfg)
 
 /* Enables CTE reception according to provided configuration */
 void lll_df_conf_cte_rx_enable(uint8_t slot_duration, uint8_t ant_num, const uint8_t *ant_ids,
-			       uint8_t chan_idx, bool cte_info_in_s1);
+			       uint8_t chan_idx, bool cte_info_in_s1, uint8_t phy);
 
 /* Configure CTE transmission */
 void lll_df_cte_tx_configure(uint8_t cte_type, uint8_t cte_length, uint8_t num_ant_ids,

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral.c
@@ -229,7 +229,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 		if (df_rx_params->is_enabled == true) {
 			lll_df_conf_cte_rx_enable(df_rx_params->slot_durations,
 						  df_rx_params->ant_sw_len, df_rx_params->ant_ids,
-						  data_chan_use, CTE_INFO_IN_S1_BYTE);
+						  data_chan_use, CTE_INFO_IN_S1_BYTE, lll->phy_rx);
 			lll->df_rx_cfg.chan = data_chan_use;
 		} else {
 			lll_df_conf_cte_info_parsing_enable();

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -172,7 +172,7 @@ void lll_sync_aux_prepare_cb(struct lll_sync *lll,
 
 	if (cfg->is_enabled) {
 		lll_df_conf_cte_rx_enable(cfg->slot_durations, cfg->ant_sw_len, cfg->ant_ids,
-					  lll_aux->chan, CTE_INFO_IN_PAYLOAD);
+					  lll_aux->chan, CTE_INFO_IN_PAYLOAD, lll_aux->phy);
 		cfg->cte_count = 0;
 	}
 #endif /* CONFIG_BT_CTLR_DF_SCAN_CTE_RX */
@@ -280,7 +280,7 @@ static int create_prepare_cb(struct lll_prepare_param *p)
 	} else if (cfg->is_enabled) {
 
 		lll_df_conf_cte_rx_enable(cfg->slot_durations, cfg->ant_sw_len, cfg->ant_ids,
-					  chan_idx, CTE_INFO_IN_PAYLOAD);
+					  chan_idx, CTE_INFO_IN_PAYLOAD, lll->phy);
 		cfg->cte_count = 0;
 #endif /* CONFIG_BT_CTLR_DF_SCAN_CTE_RX */
 	} else if (IS_ENABLED(CONFIG_BT_CTLR_DF_SUPPORT)) {
@@ -339,7 +339,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 
 	if (cfg->is_enabled) {
 		lll_df_conf_cte_rx_enable(cfg->slot_durations, cfg->ant_sw_len, cfg->ant_ids,
-					  chan_idx, CTE_INFO_IN_PAYLOAD);
+					  chan_idx, CTE_INFO_IN_PAYLOAD, lll->phy);
 		cfg->cte_count = 0;
 	}
 #endif /* CONFIG_BT_CTLR_DF_SCAN_CTE_RX */
@@ -570,7 +570,7 @@ static void isr_aux_setup(void *param)
 
 	if (cfg->is_enabled && is_max_cte_reached(cfg->max_cte_count, cfg->cte_count)) {
 		lll_df_conf_cte_rx_enable(cfg->slot_durations, cfg->ant_sw_len, cfg->ant_ids,
-					  aux_ptr->chan_idx, CTE_INFO_IN_PAYLOAD);
+					  aux_ptr->chan_idx, CTE_INFO_IN_PAYLOAD, aux_ptr->phy);
 	}
 #endif /* CONFIG_BT_CTLR_DF_SCAN_CTE_RX */
 	radio_switch_complete_and_disable();


### PR DESCRIPTION
Start of the antenna switching and sampling CTE is configured by use
of DFECTRL2 register in Nodric Radio peripheral. As of now the
configuration was set to defaults, so antenna switching has started
immediately after CTE procedure was started (end of CRC).

Sampling was started at the very beginning of a sampling slot.
It should be delayed for at least 125 ns from beginning of sampling
slot and not more than 125 ns to the end of sampling slot. This is a
requirement from BT 5.3 Core specification Vol 6, Part B section 2.5.4
IQ sampling.

Although it seems to me that when samples are taken depends on
implementation and used hardware. Taking that into account
there is provided a set of KConfig options to configure samples
offset for PHY 1M, PHY 2M and sapling slots 1 us and 2us separetely.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>