### PR TITLE
libmetal: Bump to SHA 695d29ba60a5

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -149,7 +149,7 @@ manifest:
       groups:
         - hal
     - name: libmetal
-      revision: f237c9d420a51cc43bc37d744e41191ad613f348
+      revision: c6efe091dfe02704097586a522969b5a4cc197bd
       path: modules/hal/libmetal
       groups:
         - hal


### PR DESCRIPTION
Bump libmetal to SHA 695d29ba60a5

This will bring in support for IPC and OpenAMP on Xtensa and RISC-V.