### PR TITLE
fs: nvs: initialize using device reference

### DIFF
--- a/include/fs/nvs.h
+++ b/include/fs/nvs.h
@@ -73,11 +73,11 @@ struct nvs_fs {
  * Initializes a NVS file system in flash.
  *
  * @param fs Pointer to file system
- * @param dev_name Pointer to flash device name
+ * @param dev Pointer to flash device
  * @retval 0 Success
  * @retval -ERRNO errno code if error
  */
-int nvs_init(struct nvs_fs *fs, const char *dev_name);
+int nvs_init(struct nvs_fs *fs, const struct device *dev);
 
 /**
  * @brief nvs_clear

--- a/samples/subsys/nvs/src/main.c
+++ b/samples/subsys/nvs/src/main.c
@@ -91,7 +91,7 @@ void main(void)
 	fs.sector_size = info.size;
 	fs.sector_count = 3U;
 
-	rc = nvs_init(&fs, flash_dev->name);
+	rc = nvs_init(&fs, flash_dev);
 	if (rc) {
 		printk("Flash Init failed\n");
 		return;

--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -847,7 +847,7 @@ int nvs_clear(struct nvs_fs *fs)
 	return 0;
 }
 
-int nvs_init(struct nvs_fs *fs, const char *dev_name)
+int nvs_init(struct nvs_fs *fs, const struct device *dev)
 {
 
 	int rc;
@@ -856,11 +856,7 @@ int nvs_init(struct nvs_fs *fs, const char *dev_name)
 
 	k_mutex_init(&fs->nvs_lock);
 
-	fs->flash_device = device_get_binding(dev_name);
-	if (!fs->flash_device) {
-		LOG_ERR("No valid flash device found");
-		return -ENXIO;
-	}
+	fs->flash_device = dev;
 
 	fs->flash_parameters = flash_get_parameters(fs->flash_device);
 	if (fs->flash_parameters == NULL) {

--- a/subsys/mgmt/hawkbit/hawkbit.c
+++ b/subsys/mgmt/hawkbit/hawkbit.c
@@ -617,6 +617,10 @@ int hawkbit_init(void)
 	const struct device *flash_dev;
 
 	flash_dev = DEVICE_DT_GET(FLASH_NODE);
+	if (!device_is_ready(flash_dev)) {
+		LOG_ERR("Flash device not ready");
+		return -ENODEV;
+	}
 
 	fs.offset = FLASH_AREA_OFFSET(storage);
 	rc = flash_get_page_info_by_offs(flash_dev, fs.offset, &info);
@@ -628,10 +632,10 @@ int hawkbit_init(void)
 	fs.sector_size = info.size;
 	fs.sector_count = 3U;
 
-	rc = nvs_init(&fs, flash_dev->name);
+	rc = nvs_init(&fs, flash_dev);
 	if (rc) {
 		LOG_ERR("Storage flash init failed: %d", rc);
-		return -ENODEV;
+		return rc;
 	}
 
 	rc = nvs_read(&fs, ADDRESS_ID, &action_id, sizeof(action_id));

--- a/subsys/settings/include/settings/settings_nvs.h
+++ b/subsys/settings/include/settings/settings_nvs.h
@@ -37,7 +37,7 @@ struct settings_nvs {
 	struct settings_store cf_store;
 	struct nvs_fs cf_nvs;
 	uint16_t last_name_id;
-	const char *flash_dev_name;
+	const struct device *flash_dev;
 };
 
 /* register nvs to be a source of settings */

--- a/subsys/settings/src/settings_nvs.c
+++ b/subsys/settings/src/settings_nvs.c
@@ -245,7 +245,7 @@ int settings_nvs_backend_init(struct settings_nvs *cf)
 	int rc;
 	uint16_t last_name_id;
 
-	rc = nvs_init(&cf->cf_nvs, cf->flash_dev_name);
+	rc = nvs_init(&cf->cf_nvs, cf->flash_dev);
 	if (rc) {
 		return rc;
 	}
@@ -304,7 +304,11 @@ int settings_backend_init(void)
 	default_settings_nvs.cf_nvs.sector_size = nvs_sector_size;
 	default_settings_nvs.cf_nvs.sector_count = cnt;
 	default_settings_nvs.cf_nvs.offset = fa->fa_off;
-	default_settings_nvs.flash_dev_name = fa->fa_dev_name;
+
+	default_settings_nvs.flash_dev = device_get_binding(fa->fa_dev_name);
+	if (default_settings_nvs.flash_dev == NULL) {
+		return -ENODEV;
+	}
 
 	rc = settings_nvs_backend_init(&default_settings_nvs);
 	if (rc) {

--- a/tests/subsys/fs/nvs/src/main.c
+++ b/tests/subsys/fs/nvs/src/main.c
@@ -30,12 +30,15 @@
 #define TEST_DATA_ID			1
 #define TEST_SECTOR_COUNT		5U
 
+static const struct device *flash_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
 static struct nvs_fs fs;
 struct stats_hdr *sim_stats;
 struct stats_hdr *sim_thresholds;
 
 void setup(void)
 {
+	zassert_true(device_is_ready(flash_dev), NULL);
+
 	sim_stats = stats_group_find("flash_sim_stats");
 	sim_thresholds = stats_group_find("flash_sim_thresholds");
 
@@ -75,7 +78,7 @@ void test_nvs_init(void)
 	fs.sector_size = info.size;
 	fs.sector_count = TEST_SECTOR_COUNT;
 
-	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
+	err = nvs_init(&fs, flash_dev);
 	zassert_true(err == 0,  "nvs_init call failure: %d", err);
 }
 
@@ -108,7 +111,7 @@ void test_nvs_write(void)
 {
 	int err;
 
-	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
+	err = nvs_init(&fs, flash_dev);
 	zassert_true(err == 0,  "nvs_init call failure: %d", err);
 
 	execute_long_pattern_write(TEST_DATA_ID);
@@ -148,7 +151,7 @@ void test_nvs_corrupted_write(void)
 	uint32_t *flash_write_stat;
 	uint32_t *flash_max_write_calls;
 
-	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
+	err = nvs_init(&fs, flash_dev);
 	zassert_true(err == 0,  "nvs_init call failure: %d", err);
 
 	err = nvs_read(&fs, TEST_DATA_ID, rd_buf, sizeof(rd_buf));
@@ -218,7 +221,7 @@ void test_nvs_gc(void)
 
 	fs.sector_count = 2;
 
-	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
+	err = nvs_init(&fs, flash_dev);
 	zassert_true(err == 0,  "nvs_init call failure: %d", err);
 
 	for (uint16_t i = 0; i < max_writes; i++) {
@@ -245,7 +248,7 @@ void test_nvs_gc(void)
 
 	}
 
-	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
+	err = nvs_init(&fs, flash_dev);
 	zassert_true(err == 0,  "nvs_init call failure: %d", err);
 
 	for (uint16_t id = 0; id < max_id; id++) {
@@ -320,7 +323,7 @@ void test_nvs_gc_3sectors(void)
 
 	fs.sector_count = 3;
 
-	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
+	err = nvs_init(&fs, flash_dev);
 	zassert_true(err == 0,  "nvs_init call failure: %d", err);
 	zassert_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 0,
 		     "unexpected write sector");
@@ -333,7 +336,7 @@ void test_nvs_gc_3sectors(void)
 		     "unexpected write sector");
 	check_content(max_id, &fs);
 
-	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
+	err = nvs_init(&fs, flash_dev);
 	zassert_true(err == 0,  "nvs_init call failure: %d", err);
 
 	zassert_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 2,
@@ -348,7 +351,7 @@ void test_nvs_gc_3sectors(void)
 		     "unexpected write sector");
 	check_content(max_id, &fs);
 
-	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
+	err = nvs_init(&fs, flash_dev);
 	zassert_true(err == 0,  "nvs_init call failure: %d", err);
 
 	zassert_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 0,
@@ -363,7 +366,7 @@ void test_nvs_gc_3sectors(void)
 		     "unexpected write sector");
 	check_content(max_id, &fs);
 
-	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
+	err = nvs_init(&fs, flash_dev);
 	zassert_true(err == 0,  "nvs_init call failure: %d", err);
 
 	zassert_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 1,
@@ -378,7 +381,7 @@ void test_nvs_gc_3sectors(void)
 		     "unexpected write sector");
 	check_content(max_id, &fs);
 
-	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
+	err = nvs_init(&fs, flash_dev);
 	zassert_true(err == 0,  "nvs_init call failure: %d", err);
 
 	zassert_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 2,
@@ -444,7 +447,7 @@ void test_nvs_corrupted_sector_close_operation(void)
 	stats_walk(sim_stats, flash_sim_write_calls_find, &flash_write_stat);
 	stats_walk(sim_stats, flash_sim_erase_calls_find, &flash_erase_stat);
 
-	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
+	err = nvs_init(&fs, flash_dev);
 	zassert_true(err == 0,  "nvs_init call failure: %d", err);
 
 	for (uint16_t i = 0; i < max_writes; i++) {
@@ -476,7 +479,7 @@ void test_nvs_corrupted_sector_close_operation(void)
 	*flash_max_erase_calls = 0;
 	*flash_max_len = 0;
 
-	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
+	err = nvs_init(&fs, flash_dev);
 	zassert_true(err == 0,  "nvs_init call failure: %d", err);
 
 	check_content(max_id, &fs);
@@ -497,7 +500,7 @@ void test_nvs_full_sector(void)
 
 	fs.sector_count = 3;
 
-	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
+	err = nvs_init(&fs, flash_dev);
 	zassert_true(err == 0,  "nvs_init call failure: %d", err);
 
 	while (1) {
@@ -516,7 +519,7 @@ void test_nvs_full_sector(void)
 	zassert_true(err == 0,  "nvs_delete call failure: %d", err);
 
 	/* the last sector is full now, test re-initialization */
-	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
+	err = nvs_init(&fs, flash_dev);
 	zassert_true(err == 0,  "nvs_init call failure: %d", err);
 
 	len = nvs_write(&fs, filling_id, &filling_id, sizeof(filling_id));
@@ -548,7 +551,7 @@ void test_delete(void)
 
 	fs.sector_count = 3;
 
-	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
+	err = nvs_init(&fs, flash_dev);
 	zassert_true(err == 0,  "nvs_init call failure: %d", err);
 
 	for (filling_id = 0; filling_id < 10; filling_id++) {
@@ -607,13 +610,11 @@ void test_delete(void)
 void test_nvs_gc_corrupt_close_ate(void)
 {
 	struct nvs_ate ate, close_ate;
-	const struct device *flash_dev;
 	uint32_t data;
 	ssize_t len;
 	int err;
 
-	flash_dev = device_get_binding(DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
-	zassert_true(flash_dev != NULL,  "device_get_binding failure");
+	zassert_true(device_is_ready(flash_dev), "flash device not ready");
 
 	close_ate.id = 0xffff;
 	close_ate.offset = fs.sector_size - sizeof(struct nvs_ate) * 5;
@@ -650,7 +651,7 @@ void test_nvs_gc_corrupt_close_ate(void)
 
 	fs.sector_count = 3;
 
-	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
+	err = nvs_init(&fs, flash_dev);
 	zassert_true(err == 0,  "nvs_init call failure: %d", err);
 
 	data = 0;
@@ -666,11 +667,7 @@ void test_nvs_gc_corrupt_close_ate(void)
 void test_nvs_gc_corrupt_ate(void)
 {
 	struct nvs_ate corrupt_ate, close_ate;
-	const struct device *flash_dev;
 	int err;
-
-	flash_dev = device_get_binding(DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
-	zassert_true(flash_dev != NULL,  "device_get_binding failure");
 
 	close_ate.id = 0xffff;
 	close_ate.offset = fs.sector_size / 2;
@@ -702,7 +699,7 @@ void test_nvs_gc_corrupt_ate(void)
 
 	fs.sector_count = 3;
 
-	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
+	err = nvs_init(&fs, flash_dev);
 	zassert_true(err == 0,  "nvs_init call failure: %d", err);
 }
 


### PR DESCRIPTION
Instead of accepting a device name, thus requiring runtime device
fetching, accept a device reference. This allows API users to obtain a
device reference at compile time using DEVICE_DT_GET. nvs_init() API
assumes the device is operational now, so checking for device readiness
is responsability of the API clients.

Resolves https://github.com/zephyrproject-rtos/zephyr/issues/43229