### PR TITLE
Use DEVICE_DT_GET to obtain chosen entropy device

### DIFF
--- a/include/devicetree/zephyr.h
+++ b/include/devicetree/zephyr.h
@@ -12,6 +12,8 @@
 #ifndef ZEPHYR_INCLUDE_DEVICETREE_ZEPHYR_H_
 #define ZEPHYR_INCLUDE_DEVICETREE_ZEPHYR_H_
 
+#include <toolchain.h>
+
 /**
  * @defgroup devicetree-zephyr Zephyr's /chosen nodes
  * @ingroup devicetree
@@ -32,6 +34,10 @@
 /**
  * @def DT_CHOSEN_ZEPHYR_ENTROPY_LABEL
  *
+ * @deprecated Use @c DT_LABEL(DT_CHOSEN(zephyr_entropy)) instead. If used to
+ * to obtain a device instance with device_get_binding(), consider using
+ * @c DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy)).
+ *
  * @brief If there is a chosen node zephyr,entropy property which has
  *        a label property, that property's value. Undefined otherwise.
  */
@@ -48,7 +54,8 @@
 #endif /* DT_DOXYGEN */
 
 #if DT_NODE_HAS_PROP(DT_CHOSEN(zephyr_entropy), label)
-#define DT_CHOSEN_ZEPHYR_ENTROPY_LABEL DT_LABEL(DT_CHOSEN(zephyr_entropy))
+#define DT_CHOSEN_ZEPHYR_ENTROPY_LABEL \
+	__DEPRECATED_MACRO DT_LABEL(DT_CHOSEN(zephyr_entropy))
 #endif
 
 #if DT_NODE_HAS_PROP(DT_CHOSEN(zephyr_flash_controller), label)

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -363,10 +363,10 @@ void z_early_boot_rand_get(uint8_t *buf, size_t length)
 {
 	int n = sizeof(uint32_t);
 #ifdef CONFIG_ENTROPY_HAS_DRIVER
-	const struct device *entropy = device_get_binding(DT_CHOSEN_ZEPHYR_ENTROPY_LABEL);
+	const struct device *entropy = DEVICE_DT_GET_OR_NULL(DT_CHOSEN(zephyr_entropy));
 	int rc;
 
-	if (entropy == NULL) {
+	if (!device_is_ready(entropy)) {
 		goto sys_rand_fallback;
 	}
 

--- a/modules/hal_nordic/nrf_802154/radio/platform/nrf_802154_random_zephyr.c
+++ b/modules/hal_nordic/nrf_802154/radio/platform/nrf_802154_random_zephyr.c
@@ -20,11 +20,10 @@ static uint32_t next(void)
 
 void nrf_802154_random_init(void)
 {
-	const struct device *dev;
+	const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
 	int err;
 
-	dev = device_get_binding(DT_CHOSEN_ZEPHYR_ENTROPY_LABEL);
-	__ASSERT_NO_MSG(dev != NULL);
+	__ASSERT_NO_MSG(device_is_ready(dev));
 
 	do {
 		err = entropy_get_entropy(dev, (uint8_t *)&state, sizeof(state));

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll.c
@@ -52,7 +52,7 @@ static struct {
 } event;
 
 /* Entropy device */
-static const struct device *dev_entropy;
+static const struct device *dev_entropy = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
 
 static int init_reset(void);
 #if defined(CONFIG_BT_CTLR_LOW_LAT_ULL_DONE)
@@ -123,9 +123,8 @@ int lll_init(void)
 {
 	int err;
 
-	/* Get reference to entropy device */
-	dev_entropy = device_get_binding(DT_CHOSEN_ZEPHYR_ENTROPY_LABEL);
-	if (!dev_entropy) {
+	/* Check if entropy device is ready */
+	if (!device_is_ready(dev_entropy)) {
 		return -ENODEV;
 	}
 

--- a/subsys/net/lib/openthread/platform/entropy.c
+++ b/subsys/net/lib/openthread/platform/entropy.c
@@ -19,22 +19,19 @@ LOG_MODULE_REGISTER(net_otPlat_entropy, CONFIG_OPENTHREAD_L2_LOG_LEVEL);
 #error OpenThread requires an entropy source for a TRNG
 #endif
 
+static const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
+
 otError otPlatEntropyGet(uint8_t *aOutput, uint16_t aOutputLength)
 {
-	/* static to obtain it once in a first call */
-	static const struct device *dev;
 	int err;
 
 	if ((aOutput == NULL) || (aOutputLength == 0)) {
 		return OT_ERROR_INVALID_ARGS;
 	}
 
-	if (dev == NULL) {
-		dev = device_get_binding(DT_CHOSEN_ZEPHYR_ENTROPY_LABEL);
-		if (dev == NULL) {
-			LOG_ERR("Failed to obtain entropy device");
-			return OT_ERROR_FAILED;
-		}
+	if (!device_is_ready(dev)) {
+		LOG_ERR("Entropy device not ready");
+		return OT_ERROR_FAILED;
 	}
 
 	err = entropy_get_entropy(dev, aOutput, aOutputLength);

--- a/subsys/random/rand32_entropy_device.c
+++ b/subsys/random/rand32_entropy_device.c
@@ -9,28 +9,18 @@
 #include <drivers/entropy.h>
 #include <string.h>
 
-static const struct device *entropy_driver;
+static const struct device *entropy_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
 
 #if defined(CONFIG_ENTROPY_DEVICE_RANDOM_GENERATOR)
 uint32_t z_impl_sys_rand32_get(void)
 {
-	const struct device *dev = entropy_driver;
 	uint32_t random_num;
 	int ret;
 
-	if (unlikely(!dev)) {
-		/* Only one entropy device exists, so this is safe even
-		 * if the whole operation isn't atomic.
-		 */
-		dev = device_get_binding(DT_CHOSEN_ZEPHYR_ENTROPY_LABEL);
-		__ASSERT((dev != NULL),
-			"Device driver for %s (DT_CHOSEN_ZEPHYR_ENTROPY_LABEL) not found. "
-			"Check your build configuration!",
-			DT_CHOSEN_ZEPHYR_ENTROPY_LABEL);
-		entropy_driver = dev;
-	}
+	__ASSERT(device_is_ready(entropy_dev), "Entropy device %s not ready",
+		 entropy_dev->name);
 
-	ret = entropy_get_entropy(dev, (uint8_t *)&random_num,
+	ret = entropy_get_entropy(entropy_dev, (uint8_t *)&random_num,
 				  sizeof(random_num));
 	if (unlikely(ret < 0)) {
 		/* Use system timer in case the entropy device couldn't deliver
@@ -48,23 +38,13 @@ uint32_t z_impl_sys_rand32_get(void)
 
 static int rand_get(uint8_t *dst, size_t outlen, bool csrand)
 {
-	const struct device *dev = entropy_driver;
 	uint32_t random_num;
 	int ret;
 
-	if (unlikely(!dev)) {
-		/* Only one entropy device exists, so this is safe even
-		 * if the whole operation isn't atomic.
-		 */
-		dev = device_get_binding(DT_CHOSEN_ZEPHYR_ENTROPY_LABEL);
-		__ASSERT((dev != NULL),
-			"Device driver for %s (DT_CHOSEN_ZEPHYR_ENTROPY_LABEL) not found. "
-			"Check your build configuration!",
-			DT_CHOSEN_ZEPHYR_ENTROPY_LABEL);
-		entropy_driver = dev;
-	}
+	__ASSERT(device_is_ready(entropy_dev), "Entropy device %s not ready",
+		 entropy_dev->name);
 
-	ret = entropy_get_entropy(dev, dst, outlen);
+	ret = entropy_get_entropy(entropy_dev, dst, outlen);
 
 	if (unlikely(ret < 0)) {
 		/* Don't try to fill the buffer in case of

--- a/subsys/random/rand32_xoshiro128.c
+++ b/subsys/random/rand32_xoshiro128.c
@@ -41,9 +41,9 @@ static inline uint32_t rotl(const uint32_t x, int k)
 
 static int xoshiro128_initialize(const struct device *dev)
 {
-	dev = device_get_binding(DT_CHOSEN_ZEPHYR_ENTROPY_LABEL);
-	if (!dev) {
-		return -EINVAL;
+	dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
+	if (!device_is_ready(dev)) {
+		return -ENODEV;
 	}
 
 	int32_t rc = entropy_get_entropy_isr(dev, (uint8_t *)&state,

--- a/tests/drivers/clock_control/nrf_onoff_and_bt/src/main.c
+++ b/tests/drivers/clock_control/nrf_onoff_and_bt/src/main.c
@@ -20,11 +20,14 @@ static bool test_end;
 
 #include <hal/nrf_gpio.h>
 
+static const struct device *entropy = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
 static struct onoff_manager *hf_mgr;
 static uint32_t iteration;
 
 static void setup(void)
 {
+	zassert_true(device_is_ready(entropy), NULL);
+
 	hf_mgr = z_nrf_clock_control_get_onoff(CLOCK_CONTROL_NRF_SUBSYS_HF);
 	zassert_true(hf_mgr, NULL);
 
@@ -101,8 +104,6 @@ static void test_onoff_interrupted(void)
 {
 	const struct device *clock_dev =
 		device_get_binding(DT_LABEL(DT_INST(0, nordic_nrf_clock)));
-	const struct device *entropy =
-		device_get_binding(DT_CHOSEN_ZEPHYR_ENTROPY_LABEL);
 	struct onoff_client cli;
 	uint64_t start_time = k_uptime_get();
 	uint64_t elapsed;
@@ -196,8 +197,6 @@ static void test_bt_interrupted(void)
 {
 	const struct device *clock_dev =
 		device_get_binding(DT_LABEL(DT_INST(0, nordic_nrf_clock)));
-	const struct device *entropy =
-		device_get_binding(DT_CHOSEN_ZEPHYR_ENTROPY_LABEL);
 	uint64_t start_time = k_uptime_get();
 	uint64_t elapsed;
 	uint64_t checkpoint = 1000;

--- a/tests/drivers/entropy/api/src/main.c
+++ b/tests/drivers/entropy/api/src/main.c
@@ -67,13 +67,12 @@ static int random_entropy(const struct device *dev, char *buffer, char num)
  */
 static int get_entropy(void)
 {
-	const struct device *dev;
+	const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
 	uint8_t buffer[BUFFER_LENGTH] = { 0 };
 	int ret;
 
-	dev = device_get_binding(DT_CHOSEN_ZEPHYR_ENTROPY_LABEL);
-	if (!dev) {
-		TC_PRINT("error: no random device\n");
+	if (!device_is_ready(dev)) {
+		TC_PRINT("error: random device not ready\n");
 		return TC_FAIL;
 	}
 


### PR DESCRIPTION
A reference to the CHOSEN entropy device can be obtained at compile time, so
avoid using device_get_binding(). As a result of the changes, `DT_CHOSEN_ZEPHYR_ENTROPY_LABEL` is no longer needed and so has been dropped.

Resolves https://github.com/zephyrproject-rtos/zephyr/issues/43230