### PR TITLE
fixed I2S driver for SAI peripheral, and tested on mimxrt1170_evk

### DIFF
--- a/boards/arm/mimxrt1170_evk/mimxrt1170_evk-pinctrl.dtsi
+++ b/boards/arm/mimxrt1170_evk/mimxrt1170_evk-pinctrl.dtsi
@@ -225,10 +225,23 @@
 	pinmux_sai1: pinmux_sai1 {
 		group0 {
 			pinmux = <&iomuxc_gpio_ad_17_sai1_mclk>,
+				<&iomuxc_gpio_ad_18_sai1_rx_sync>,
+				<&iomuxc_gpio_ad_19_sai1_rx_bclk>,
 				<&iomuxc_gpio_ad_20_sai1_rx_data00>,
 				<&iomuxc_gpio_ad_21_sai1_tx_data00>,
 				<&iomuxc_gpio_ad_22_sai1_tx_bclk>,
 				<&iomuxc_gpio_ad_23_sai1_tx_sync>;
+			drive-strength = "high";
+			slew-rate = "fast";
+			input-enable;
+		};
+	};
+
+	pinmux_sai4: pinmux_sai4 {
+		group0 {
+			pinmux = <&iomuxc_lpsr_gpio_lpsr_09_sai4_tx_data>,
+				<&iomuxc_lpsr_gpio_lpsr_10_sai4_tx_sync>,
+				<&iomuxc_lpsr_gpio_lpsr_12_sai4_tx_bclk>;
 			drive-strength = "high";
 			slew-rate = "fast";
 			input-enable;

--- a/drivers/i2s/i2s_mcux_sai.c
+++ b/drivers/i2s/i2s_mcux_sai.c
@@ -59,9 +59,7 @@ struct stream {
 	struct dma_config dma_cfg;
 	struct dma_block_config dma_block;
 	struct k_msgq in_queue;
-	void *in_msgs[CONFIG_I2S_RX_BLOCK_COUNT];
 	struct k_msgq out_queue;
-	void *out_msgs[CONFIG_I2S_TX_BLOCK_COUNT];
 	uint32_t stream_starving;
 };
 
@@ -92,7 +90,11 @@ struct i2s_mcux_config {
 struct i2s_dev_data {
 	const struct device *dev_dma;
 	struct stream tx;
+	void *tx_in_msgs[CONFIG_I2S_TX_BLOCK_COUNT];
+	void *tx_out_msgs[CONFIG_I2S_TX_BLOCK_COUNT];
 	struct stream rx;
+	void *rx_in_msgs[CONFIG_I2S_RX_BLOCK_COUNT];
+	void *rx_out_msgs[CONFIG_I2S_RX_BLOCK_COUNT];
 };
 
 
@@ -1007,13 +1009,13 @@ static int i2s_mcux_initialize(const struct device *dev)
 	}
 
 	/* Initialize the buffer queues */
-	k_msgq_init(&dev_data->tx.in_queue, (char *)dev_data->tx.in_msgs,
+	k_msgq_init(&dev_data->tx.in_queue, (char *)dev_data->tx_in_msgs,
 		    sizeof(void *), CONFIG_I2S_TX_BLOCK_COUNT);
-	k_msgq_init(&dev_data->rx.in_queue, (char *)dev_data->rx.in_msgs,
+	k_msgq_init(&dev_data->rx.in_queue, (char *)dev_data->rx_in_msgs,
 		    sizeof(void *), CONFIG_I2S_RX_BLOCK_COUNT);
-	k_msgq_init(&dev_data->tx.out_queue, (char *)dev_data->tx.out_msgs,
+	k_msgq_init(&dev_data->tx.out_queue, (char *)dev_data->tx_out_msgs,
 		    sizeof(void *), CONFIG_I2S_TX_BLOCK_COUNT);
-	k_msgq_init(&dev_data->rx.out_queue, (char *)dev_data->rx.out_msgs,
+	k_msgq_init(&dev_data->rx.out_queue, (char *)dev_data->rx_out_msgs,
 		    sizeof(void *), CONFIG_I2S_RX_BLOCK_COUNT);
 
 	/* register ISR */

--- a/drivers/i2s/i2s_mcux_sai.c
+++ b/drivers/i2s/i2s_mcux_sai.c
@@ -604,6 +604,9 @@ static int i2s_mcux_config(const struct device *dev, enum i2s_dir dir,
 		dev_data->tx.dma_cfg.user_data = (void *)dev;
 		dev_data->tx.state = I2S_STATE_READY;
 	} else {
+		/* For RX, DMA reads from FIFO whenever data present */
+		config.fifo.fifoWatermark = 0;
+
 		memcpy(&dev_data->rx.cfg, i2s_cfg, sizeof(struct i2s_config));
 		LOG_DBG("rx slab free_list = 0x%x",
 			(uint32_t)i2s_cfg->mem_slab->free_list);

--- a/drivers/i2s/i2s_mcux_sai.c
+++ b/drivers/i2s/i2s_mcux_sai.c
@@ -466,8 +466,8 @@ static int i2s_mcux_config(const struct device *dev, enum i2s_dir dir,
 	config.bitClock.bclkInputDelay = false;
 
 	/* frame sync default configurations */
-#if defined(FSL_FEATURE_SAI_HAS_FRAME_SYNC_ON_DEMAND) &&		\
-	FSL_FEATURE_SAI_HAS_FRAME_SYNC_ON_DEMAND
+#if defined(FSL_FEATURE_SAI_HAS_ON_DEMAND_MODE) && \
+	FSL_FEATURE_SAI_HAS_ON_DEMAND_MODE
 	config.frameSync.frameSyncGenerateOnDemand = false;
 #endif
 

--- a/drivers/i2s/i2s_mcux_sai.c
+++ b/drivers/i2s/i2s_mcux_sai.c
@@ -98,23 +98,30 @@ struct i2s_dev_data {
 
 static void i2s_dma_tx_callback(const struct device *, void *,
 				uint32_t, int);
-static void i2s_tx_stream_disable(const struct device *);
-static void i2s_rx_stream_disable(const struct device *);
+static void i2s_tx_stream_disable(const struct device *, bool drop);
+static void i2s_rx_stream_disable(const struct device *,
+				  bool in_drop, bool out_drop);
 
 static inline void i2s_purge_stream_buffers(struct stream *strm,
-					    struct k_mem_slab *mem_slab)
+					    struct k_mem_slab *mem_slab,
+					    bool in_drop, bool out_drop)
 {
 	void *buffer;
 
-	while (k_msgq_get(&strm->in_queue, &buffer, K_NO_WAIT) == 0) {
-		k_mem_slab_free(mem_slab, &buffer);
+	if (in_drop) {
+		while (k_msgq_get(&strm->in_queue, &buffer, K_NO_WAIT) == 0) {
+			k_mem_slab_free(mem_slab, &buffer);
+		}
 	}
-	while (k_msgq_get(&strm->out_queue, &buffer, K_NO_WAIT) == 0) {
-		k_mem_slab_free(mem_slab, &buffer);
+
+	if (out_drop) {
+		while (k_msgq_get(&strm->out_queue, &buffer, K_NO_WAIT) == 0) {
+			k_mem_slab_free(mem_slab, &buffer);
+		}
 	}
 }
 
-static void i2s_tx_stream_disable(const struct device *dev)
+static void i2s_tx_stream_disable(const struct device *dev, bool drop)
 {
 	struct i2s_dev_data *dev_data = dev->data;
 	struct stream *strm = &dev_data->tx;
@@ -128,7 +135,10 @@ static void i2s_tx_stream_disable(const struct device *dev)
 	dev_cfg->base->TCR3 &= ~I2S_TCR3_TCE_MASK;
 
 	/* purge buffers queued in the stream */
-	i2s_purge_stream_buffers(strm, dev_data->tx.cfg.mem_slab);
+	if (drop) {
+		i2s_purge_stream_buffers(strm, dev_data->tx.cfg.mem_slab,
+					 true, true);
+	}
 
 	/* Disable DMA enable bit */
 	SAI_TxEnableDMA(dev_cfg->base, kSAI_FIFORequestDMAEnable,
@@ -147,7 +157,8 @@ static void i2s_tx_stream_disable(const struct device *dev)
 	}
 }
 
-static void i2s_rx_stream_disable(const struct device *dev)
+static void i2s_rx_stream_disable(const struct device *dev,
+				  bool in_drop, bool out_drop)
 {
 	struct i2s_dev_data *dev_data = dev->data;
 	struct stream *strm = &dev_data->rx;
@@ -168,7 +179,10 @@ static void i2s_rx_stream_disable(const struct device *dev)
 	SAI_RxEnable(dev_cfg->base, false);
 
 	/* purge buffers queued in the stream */
-	i2s_purge_stream_buffers(strm, dev_data->rx.cfg.mem_slab);
+	if (in_drop || out_drop) {
+		i2s_purge_stream_buffers(strm, dev_data->rx.cfg.mem_slab,
+					 in_drop, out_drop);
+	}
 
 	strm->stream_starving = false;
 
@@ -209,7 +223,7 @@ static void i2s_dma_tx_callback(const struct device *dma_dev,
 		/* get the next buffer from queue */
 		if (strm->in_queue.used_msgs == 0) {
 			LOG_DBG("tx no more in queue data");
-			i2s_tx_stream_disable(dev);
+			i2s_tx_stream_disable(dev, false);
 			/* stream is starving */
 			strm->stream_starving = true;
 			return;
@@ -242,13 +256,13 @@ static void i2s_dma_tx_callback(const struct device *dma_dev,
 			LOG_ERR("DMA status %08x chan %u get ret %d",
 				status, channel, ret);
 			strm->state = I2S_STATE_READY;
-			i2s_tx_stream_disable(dev);
+			i2s_tx_stream_disable(dev, false);
 		}
 
 		break;
 
 	case I2S_STATE_STOPPING:
-		i2s_tx_stream_disable(dev);
+		i2s_tx_stream_disable(dev, true);
 		strm->state = I2S_STATE_READY;
 		break;
 	}
@@ -289,7 +303,7 @@ static void i2s_dma_rx_callback(const struct device *dma_dev,
 			if (ret != 0) {
 				LOG_ERR("buffer alloc from slab %p err %d",
 					strm->cfg.mem_slab, ret);
-				i2s_rx_stream_disable(dev);
+				i2s_rx_stream_disable(dev, false, false);
 				strm->state = I2S_STATE_ERROR;
 			} else {
 				uint32_t data_path = strm->start_channel;
@@ -323,7 +337,7 @@ static void i2s_dma_rx_callback(const struct device *dma_dev,
 		}
 		break;
 	case I2S_STATE_ERROR:
-		i2s_rx_stream_disable(dev);
+		i2s_rx_stream_disable(dev, true, true);
 		break;
 	}
 }
@@ -783,9 +797,9 @@ static int i2s_mcux_trigger(const struct device *dev, enum i2s_dir dir,
 			break;
 		}
 		if (dir == I2S_DIR_TX) {
-			i2s_tx_stream_disable(dev);
+			i2s_tx_stream_disable(dev, true);
 		} else {
-			i2s_rx_stream_disable(dev);
+			i2s_rx_stream_disable(dev, true, true);
 		}
 		strm->state = I2S_STATE_READY;
 		break;
@@ -814,9 +828,9 @@ static int i2s_mcux_trigger(const struct device *dev, enum i2s_dir dir,
 		}
 		strm->state = I2S_STATE_READY;
 		if (dir == I2S_DIR_TX) {
-			i2s_tx_stream_disable(dev);
+			i2s_tx_stream_disable(dev, true);
 		} else {
-			i2s_rx_stream_disable(dev);
+			i2s_rx_stream_disable(dev, true, true);
 		}
 		break;
 
@@ -853,7 +867,7 @@ static int i2s_mcux_read(const struct device *dev, void **mem_block,
 
 	switch (strm->state) {
 	case I2S_STATE_STOPPING:
-		i2s_rx_stream_disable(dev);
+		i2s_rx_stream_disable(dev, true, false);
 		strm->state = I2S_STATE_READY;
 		break;
 	case I2S_STATE_RUNNING:

--- a/tests/drivers/i2s/i2s_speed/Readme.txt
+++ b/tests/drivers/i2s/i2s_speed/Readme.txt
@@ -1,0 +1,12 @@
+i2s_speed Test
+##################
+
+Board-specific details:
+
+MIMXRT1170_EVK:
+This board uses CONFIG_I2S_TEST_SEPARATE_DEVICES=y and connects two SAI peripherals by shorting
+signals externally on the EVK.  These are the HW changes required to run this test:
+	- Remove jumper J8 and resistor R78
+	- Short BCLK J9-pin1  (SAI1_RX_BCLK)  to J66-pin1  (SAI4_TX_BCLK)
+	- Short SYNC J9-pin5  (SAI1_RX_SYNC)  to J64-pin1  (SAI4_TX_SYNC)
+	- Short Data J61-pin1 (SAI1_RX_DATA)  to J63-pin1  (SAI4_TX_DATA)

--- a/tests/drivers/i2s/i2s_speed/boards/mimxrt1170_evk_cm7.conf
+++ b/tests/drivers/i2s/i2s_speed/boards/mimxrt1170_evk_cm7.conf
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2021, NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_I2S_MCUX_SAI=y
+
+# SAI peripheral does not have loopback mode.  Use 2 SAI peripherals connected
+# together externally.
+CONFIG_I2S_TEST_SEPARATE_DEVICES=y
+
+# CONFIG_DMA_TCD_QUEUE_SIZE sets size of queue used to chain DMA blocks (TCDs)
+# together, and should be sized as needed by the application.  If not large
+# enough, the DMA may starve.  Symptoms of this issue include transmit blocks
+# repeated, or RX blocks skipped. For I2S driver, queue size must be at least 3.
+CONFIG_DMA_TCD_QUEUE_SIZE=4
+
+# Repeat test continually to help find intermittent issues
+CONFIG_ZTEST_RETEST_IF_PASSED=y
+
+# I2S and DMA logging can occur in interrupt context, and interfere with I2S
+# stream timing.  If using either logging, set logging to deffered
+# CONFIG_LOG_MODE_DEFERRED=y
+
+CONFIG_DMA_LOG_LEVEL_OFF=y
+CONFIG_I2S_LOG_LEVEL_OFF=y

--- a/tests/drivers/i2s/i2s_speed/boards/mimxrt1170_evk_cm7.overlay
+++ b/tests/drivers/i2s/i2s_speed/boards/mimxrt1170_evk_cm7.overlay
@@ -1,0 +1,26 @@
+/* i2s_speed with CONFIG_I2S_TEST_SEPARATE_DEVICES=y uses two I2S peripherals:
+ *	I2S_0 is the receiver    - uses SAI1 peripheral on RT1170
+ *	I2S_1 is the transmitter - uses SAI4 peripheral
+ * Therefore, change labels from SoC defaults to SAI4 as I2S_1,
+ * and SAI2 becomes I2S_3
+ */
+&sai2 {
+	label = "I2S_3";
+};
+
+/* Enable SAI4, and set clocks to match SAI1 */
+&sai4 {
+	label = "I2S_1";
+	status = "okay";
+	clocks = < &ccm 0x2003 0x2184 0x6 >;
+	podf = < 0x4 >;
+	pinctrl-0 = <&pinmux_sai4>;
+	pinctrl-names = "default";
+};
+
+/* On MIMXRT1170-EVK, there is a conflict with signal SAI4_TX_BCLK shared with
+ * ENET_RST.  For i2s_speed test, disable ENET peripheral.
+ */
+&enet {
+	status = "disabled";
+};

--- a/tests/drivers/i2s/i2s_speed/src/test_i2s_speed.c
+++ b/tests/drivers/i2s/i2s_speed/src/test_i2s_speed.c
@@ -45,13 +45,29 @@ static int16_t data_r[SAMPLE_NO] = {
 
 #define BLOCK_SIZE (2 * sizeof(data_l))
 
+#ifdef CONFIG_NOCACHE_MEMORY
+	#define MEM_SLAB_CACHE_ATTR __nocache
+#else
+	#define MEM_SLAB_CACHE_ATTR
+#endif /* CONFIG_NOCACHE_MEMORY */
+
 /*
  * NUM_BLOCKS is the number of blocks used by the test. Some of the drivers,
  * e.g. i2s_mcux_flexcomm, permanently keep ownership of a few RX buffers. Add a few more
  * RX blocks to satisfy this requirement
  */
-K_MEM_SLAB_DEFINE(rx_0_mem_slab, BLOCK_SIZE, NUM_BLOCKS + 2, 32);
-K_MEM_SLAB_DEFINE(tx_0_mem_slab, BLOCK_SIZE, NUM_BLOCKS, 32);
+
+char MEM_SLAB_CACHE_ATTR __aligned(WB_UP(32))
+	_k_mem_slab_buf_rx_0_mem_slab[(NUM_BLOCKS + 2) * WB_UP(BLOCK_SIZE)];
+STRUCT_SECTION_ITERABLE(k_mem_slab, rx_0_mem_slab) =
+	Z_MEM_SLAB_INITIALIZER(rx_0_mem_slab, _k_mem_slab_buf_rx_0_mem_slab,
+				WB_UP(BLOCK_SIZE), NUM_BLOCKS + 2);
+
+char MEM_SLAB_CACHE_ATTR __aligned(WB_UP(32))
+	_k_mem_slab_buf_tx_0_mem_slab[(NUM_BLOCKS) * WB_UP(BLOCK_SIZE)];
+STRUCT_SECTION_ITERABLE(k_mem_slab, tx_0_mem_slab) =
+	Z_MEM_SLAB_INITIALIZER(tx_0_mem_slab, _k_mem_slab_buf_tx_0_mem_slab,
+				WB_UP(BLOCK_SIZE), NUM_BLOCKS);
 
 static const struct device *dev_i2s_rx;
 static const struct device *dev_i2s_tx;


### PR DESCRIPTION
Update includes several driver fixes.  Tested with Zephyr i2s_speed test application, and added board-specific files and readme to test to replicate the test setup.

test built with command:
`west build -b mimxrt1170_evk_cm7 tests\drivers\i2s\i2s_speed`

fixes #42434
fixes #42436

This branch is based on open PR [Update LPUART async support to fix build failures #44962 ](https://github.com/zephyrproject-rtos/zephyr/pull/44962)