### PR TITLE
RFC: new GPIO IRQ initialization helpers

### DIFF
--- a/drivers/adc/adc_lmp90xxx.c
+++ b/drivers/adc/adc_lmp90xxx.c
@@ -987,10 +987,9 @@ static int lmp90xxx_init(const struct device *dev)
 			return -EINVAL;
 		}
 
-		gpio_init_callback(&data->drdyb_cb, lmp90xxx_drdyb_callback,
-				   BIT(config->drdyb.pin));
-
-		err = gpio_add_callback(config->drdyb.port, &data->drdyb_cb);
+		err = gpio_pin_setup_callback_dt(&config->drdyb,
+						 &data->drdyb_cb,
+						 lmp90xxx_drdyb_callback);
 		if (err) {
 			LOG_ERR("failed to add DRDYB callback (err %d)", err);
 			return -EINVAL;

--- a/drivers/lora/sx126x_standalone.c
+++ b/drivers/lora/sx126x_standalone.c
@@ -72,10 +72,9 @@ int sx126x_variant_init(const struct device *dev)
 		return -EIO;
 	}
 
-	gpio_init_callback(&dev_data->dio1_irq_callback,
-			   sx126x_dio1_irq_callback, BIT(sx126x_gpio_dio1.pin));
-	if (gpio_add_callback(sx126x_gpio_dio1.port,
-			      &dev_data->dio1_irq_callback) < 0) {
+	if (gpio_pin_setup_callback_dt(&sx126x_gpio_dio1,
+				       &dev_data->dio1_irq_callback,
+				       sx126x_dio1_irq_callback) < 0) {
 		LOG_ERR("Could not set GPIO callback for DIO1 interrupt.");
 		return -EIO;
 	}

--- a/drivers/sensor/lm77/lm77.c
+++ b/drivers/sensor/lm77/lm77.c
@@ -347,10 +347,9 @@ static int lm77_init(const struct device *dev)
 			return err;
 		}
 
-		gpio_init_callback(&data->int_gpio_cb, lm77_int_gpio_callback_handler,
-				   BIT(config->int_gpio.pin));
-
-		err = gpio_add_callback(config->int_gpio.port, &data->int_gpio_cb);
+		err = gpio_pin_setup_callback_dt(&config->int_gpio,
+						 &data->int_gpio_cb,
+						 lm77_int_gpio_callback_handler);
 		if (err < 0) {
 			LOG_ERR("failed to add INT GPIO callback (err %d)", err);
 			return err;

--- a/drivers/sensor/lps22hh/lps22hh_trigger.c
+++ b/drivers/sensor/lps22hh/lps22hh_trigger.c
@@ -171,11 +171,9 @@ int lps22hh_init_interrupt(const struct device *dev)
 	LOG_INF("%s: int on %s.%02u", dev->name, cfg->gpio_int.port->name,
 				      cfg->gpio_int.pin);
 
-	gpio_init_callback(&lps22hh->gpio_cb,
-			   lps22hh_gpio_callback,
-			   BIT(cfg->gpio_int.pin));
-
-	ret = gpio_add_callback(cfg->gpio_int.port, &lps22hh->gpio_cb);
+	ret = gpio_pin_setup_callback_dt(&cfg->gpio_int,
+					 &lps22hh->gpio_cb,
+					 lps22hh_gpio_callback);
 	if (ret < 0) {
 		LOG_ERR("Could not set gpio callback");
 		return ret;

--- a/drivers/sensor/lsm6dso/lsm6dso_trigger.c
+++ b/drivers/sensor/lsm6dso/lsm6dso_trigger.c
@@ -279,13 +279,12 @@ int lsm6dso_init_interrupt(const struct device *dev)
 		return ret;
 	}
 
-	gpio_init_callback(&lsm6dso->gpio_cb,
-			   lsm6dso_gpio_callback,
-			   BIT(cfg->gpio_drdy.pin));
-
-	if (gpio_add_callback(cfg->gpio_drdy.port, &lsm6dso->gpio_cb) < 0) {
+	ret = gpio_pin_setup_callback_dt(&cfg->gpio_drdy,
+					 &lsm6dso->gpio_cb,
+					 lsm6dso_gpio_callback);
+	if (ret < 0) {
 		LOG_DBG("Could not set gpio callback");
-		return -EIO;
+		return ret;
 	}
 
 	/* enable interrupt on int1/int2 in pulse mode */

--- a/drivers/sensor/mpu9250/mpu9250_trigger.c
+++ b/drivers/sensor/mpu9250/mpu9250_trigger.c
@@ -133,11 +133,9 @@ int mpu9250_init_interrupt(const struct device *dev)
 		return ret;
 	}
 
-	gpio_init_callback(&drv_data->gpio_cb,
-			   mpu9250_gpio_callback,
-			   BIT(cfg->int_pin.pin));
-
-	ret = gpio_add_callback(cfg->int_pin.port, &drv_data->gpio_cb);
+	ret = gpio_pin_setup_callback_dt(&cfg->int_pin,
+					 &drv_data->gpio_cb,
+					 mpu9250_gpio_callback);
 	if (ret < 0) {
 		LOG_ERR("Failed to set gpio callback.");
 		return ret;

--- a/drivers/sensor/ti_hdc20xx/ti_hdc20xx.c
+++ b/drivers/sensor/ti_hdc20xx/ti_hdc20xx.c
@@ -192,29 +192,13 @@ static int ti_hdc20xx_init(const struct device *dev)
 
 	/* Configure the interrupt GPIO if available */
 	if (config->gpio_int.port) {
-		if (!device_is_ready(config->gpio_int.port)) {
-			LOG_ERR("Cannot get pointer to gpio interrupt device");
-			return -ENODEV;
-		}
-
-		rc = gpio_pin_configure_dt(&config->gpio_int, GPIO_INPUT);
+		/* Initialize the interrupt */
+		rc = gpio_pin_setup_interrupt_dt(&config->gpio_int,
+						 &data->cb_int,
+						 ti_hdc20xx_int_callback,
+						 GPIO_INPUT | GPIO_INT_EDGE_TO_ACTIVE);
 		if (rc) {
-			LOG_ERR("Failed to configure interrupt pin");
-			return rc;
-		}
-
-		gpio_init_callback(&data->cb_int, ti_hdc20xx_int_callback,
-				   BIT(config->gpio_int.pin));
-
-		rc = gpio_add_callback(config->gpio_int.port, &data->cb_int);
-		if (rc) {
-			LOG_ERR("Failed to set interrupt callback");
-			return rc;
-		}
-
-		rc = gpio_pin_interrupt_configure_dt(&config->gpio_int, GPIO_INT_EDGE_TO_ACTIVE);
-		if (rc) {
-			LOG_ERR("Failed to configure interrupt");
+			LOG_ERR("Failed to configure GPIO interrupt");
 			return rc;
 		}
 

--- a/samples/basic/button/src/main.c
+++ b/samples/basic/button/src/main.c
@@ -42,29 +42,10 @@ void main(void)
 {
 	int ret;
 
-	if (!device_is_ready(button.port)) {
-		printk("Error: button device %s is not ready\n",
-		       button.port->name);
-		return;
-	}
-
-	ret = gpio_pin_configure_dt(&button, GPIO_INPUT);
-	if (ret != 0) {
-		printk("Error %d: failed to configure %s pin %d\n",
-		       ret, button.port->name, button.pin);
-		return;
-	}
-
-	gpio_init_callback(&button_cb_data, button_pressed, BIT(button.pin));
-	ret = gpio_add_callback(button.port, &button_cb_data);
-	if (ret != 0) {
-		printk("Error %d: failed to configure callback on %s pin %d\n",
-			ret, button.port->name, button.pin);
-		return;
-	}
-
-	ret = gpio_pin_interrupt_configure_dt(&button,
-					      GPIO_INT_EDGE_TO_ACTIVE);
+	ret = gpio_pin_setup_interrupt_dt(&button,
+					  button_cb_data,
+					  button_pressed,
+					  GPIO_INPUT | GPIO_INT_EDGE_TO_ACTIVE);
 	if (ret != 0) {
 		printk("Error %d: failed to configure interrupt on %s pin %d\n",
 			ret, button.port->name, button.pin);

--- a/samples/basic/button/src/main.c
+++ b/samples/basic/button/src/main.c
@@ -55,6 +55,14 @@ void main(void)
 		return;
 	}
 
+	gpio_init_callback(&button_cb_data, button_pressed, BIT(button.pin));
+	ret = gpio_add_callback(button.port, &button_cb_data);
+	if (ret != 0) {
+		printk("Error %d: failed to configure callback on %s pin %d\n",
+			ret, button.port->name, button.pin);
+		return;
+	}
+
 	ret = gpio_pin_interrupt_configure_dt(&button,
 					      GPIO_INT_EDGE_TO_ACTIVE);
 	if (ret != 0) {
@@ -63,8 +71,6 @@ void main(void)
 		return;
 	}
 
-	gpio_init_callback(&button_cb_data, button_pressed, BIT(button.pin));
-	gpio_add_callback(button.port, &button_cb_data);
 	printk("Set up button at %s pin %d\n", button.port->name, button.pin);
 
 	if (led.port && !device_is_ready(led.port)) {


### PR DESCRIPTION
The main point of this PR is to further "devicetree-ize" the GPIO API where IRQ initialization is concerned. I'm adding new helpers mainly to allow us to avoid typing so much boilerplate, but also because I think I noticed a race condition in the button sample and I'd like to provide helpers that don't have that issue .

To that end, add two convenience helpers which capture common patterns seen throughout the tree:

- gpio_pin_setup_callback_dt(): initialize a callback structure and   add a handler function
- gpio_pin_setup_interrupt_dt(): check a gpio_dt_spec port for readiness, configure the pin, initialize a callback structure,
  add a handler function, and enable the interrupt. Uses gpio_pin_setup_callback_dt() as an intermediate step.

And use them in the button sample as well as several sensor samples.

If this looks reasonable, I'll DT-ize the rest of the tree where the pattern emerges.