### PR TITLE
net: buf: buffer recovery function

### DIFF
--- a/include/net/buf.h
+++ b/include/net/buf.h
@@ -1333,6 +1333,23 @@ struct net_buf * __must_check net_buf_alloc_with_data(struct net_buf_pool *pool,
 #endif
 
 /**
+ * @brief Recover a buffer pointer from a data pointer
+ *
+ * This function is intended to be used from callbacks where buffers are used
+ * as a method to ensure memory is valid for the duration of asynchronous calls,
+ * but the callback only provides the raw data pointer.
+ *
+ * @note This function does NOT increment the buffer reference count.
+ *
+ * @param pool Pool that the buffer was potentially allocated from.
+ * @param ptr Pointer to some data address in the buffer.
+ *
+ * @return Buffer that contains the data pointer or NULL if no buffer found.
+ */
+struct net_buf *net_buf_recover_from_ptr(struct net_buf_pool *pool,
+					 const void *ptr);
+
+/**
  * @brief Get a buffer from a FIFO.
  *
  * This function is NOT thread-safe if the buffers in the FIFO contain

--- a/subsys/net/buf.c
+++ b/subsys/net/buf.c
@@ -405,6 +405,27 @@ struct net_buf *net_buf_alloc_with_data(struct net_buf_pool *pool,
 	return buf;
 }
 
+struct net_buf *net_buf_recover_from_ptr(struct net_buf_pool *pool,
+					 const void *ptr)
+{
+	const uint8_t *p = ptr;
+	struct net_buf *buf;
+
+	for (int i = 0; i < pool->buf_count; i++) {
+		buf = &pool->__bufs[i];
+		/* If its not referenced, it can't be the buffer we're looking for */
+		if (buf->ref == 0) {
+			continue;
+		}
+		/* Pointer is in buffer range */
+		if ((buf->__buf <= p) &&
+		    (p < (buf->__buf + buf->size))) {
+			return buf;
+		}
+	}
+	return NULL;
+}
+
 #if defined(CONFIG_NET_BUF_LOG)
 struct net_buf *net_buf_get_debug(struct k_fifo *fifo, k_timeout_t timeout,
 				  const char *func, int line)


### PR DESCRIPTION
  Implements a method to recover a net_buf pointer from a data pointer
  that points to the memory held by an active net_buf.

  net_buf's are a natural solution when working with asynchronous API's to
  ensure that memory is valid for the duration of the call, calling
  `net_buf_unref` inside a done callback to free the memory. However many
  APIs only provide the raw data pointer in their done callbacks, making
  it difficult to recover the net_buf to call `net_buf_unref`.

  An example of how this can be used:
  ```
  NET_BUF_POOL_DEFINE(pool, 5, 100, 0, NULL);

  void send_uart_async(void *mem, size_t len)
  {
    struct net_buf *buf = net_buf_alloc(&pool, K_FOREVER);
    net_buf_add_mem(buf, mem, len);
    uart_tx(uart_driver, buf->data, buf->len, SYS_FOREVER_MS);
  }

  void cb(const struct device *dev, struct uart_event *evt, void *ud)
  {
    struct net_buf *buf;
    if (evt->type == UART_TX_DONE) {
      buf = net_buf_recover_from_ptr(&pool, evt->data.tx.buf);
      if (buf) {
        net_buf_unref(buf);
      }
    }
  }
  ```