### PR TITLE
net: sockets: add shutdown() support in vtable and implement it for native and tls sockets

### DIFF
--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -471,7 +471,7 @@ static void http_timeout(struct k_work *work)
 	struct http_client_internal_data *data =
 		CONTAINER_OF(dwork, struct http_client_internal_data, work);
 
-	(void)zsock_close(data->sock);
+	(void)zsock_shutdown(data->sock, ZSOCK_SHUT_RD);
 }
 
 int http_client_req(int sock, struct http_request *req,

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -296,16 +296,31 @@ static inline int z_vrfy_zsock_close(int sock)
 
 int z_impl_zsock_shutdown(int sock, int how)
 {
-	/* shutdown() is described by POSIX as just disabling recv() and/or
-	 * send() operations on socket. Of course, real-world software mostly
-	 * calls it for side effects. We treat it as null operation so far.
-	 */
-	ARG_UNUSED(sock);
-	ARG_UNUSED(how);
+	const struct socket_op_vtable *vtable;
+	struct k_mutex *lock;
+	void *ctx;
+	int ret;
 
-	LOG_WRN("shutdown() not implemented");
+	ctx = get_sock_vtable(sock, &vtable, &lock);
+	if (ctx == NULL) {
+		errno = EBADF;
+		return -1;
+	}
 
-	return 0;
+	if (!vtable->shutdown) {
+		errno = ENOTSUP;
+		return -1;
+	}
+
+	(void)k_mutex_lock(lock, K_FOREVER);
+
+	NET_DBG("shutdown: ctx=%p, fd=%d, how=%d", ctx, sock, how);
+
+	ret = vtable->shutdown(ctx, how);
+
+	k_mutex_unlock(lock);
+
+	return ret;
 }
 
 #ifdef CONFIG_USERSPACE

--- a/subsys/net/lib/sockets/sockets_internal.h
+++ b/subsys/net/lib/sockets/sockets_internal.h
@@ -51,6 +51,7 @@ static inline bool net_socket_is_tls(void *obj)
 
 struct socket_op_vtable {
 	struct fd_op_vtable fd_vtable;
+	int (*shutdown)(void *obj, int how);
 	int (*bind)(void *obj, const struct sockaddr *addr, socklen_t addrlen);
 	int (*connect)(void *obj, const struct sockaddr *addr,
 		       socklen_t addrlen);

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -2669,6 +2669,13 @@ static int tls_sock_ioctl_vmeth(void *obj, unsigned int request, va_list args)
 	}
 }
 
+static int tls_sock_shutdown_vmeth(void *obj, int how)
+{
+	struct tls_context *ctx = obj;
+
+	return zsock_shutdown(ctx->sock, how);
+}
+
 static int tls_sock_bind_vmeth(void *obj, const struct sockaddr *addr,
 			       socklen_t addrlen)
 {
@@ -2752,6 +2759,7 @@ static const struct socket_op_vtable tls_sock_fd_op_vtable = {
 		.close = tls_sock_close_vmeth,
 		.ioctl = tls_sock_ioctl_vmeth,
 	},
+	.shutdown = tls_sock_shutdown_vmeth,
 	.bind = tls_sock_bind_vmeth,
 	.connect = tls_sock_connect_vmeth,
 	.listen = tls_sock_listen_vmeth,


### PR DESCRIPTION
Cherry picked from #38034, fixed the definitions of `SHUT_*` to `ZSOCK_SHUT_*`

> So far shutdown() implementation was a noop and just resulted in warning
> logs. Add shutdown() method into socket vtable. Call it if provided and
> fallback into returning -ENOTSUP if not.

> Add basic shutdown() implementation for net_context sockets, which
> handles only SHUT_RD as 'how' parameter and returns -ENOTSUP for SHUT_WR
> and SHUT_RDWR. The main use case to cover is to allow race-free wakeup
> of threads calling recv() on the same socket.

> 
> Add basic shutdown() implementation of TLS sockets, which basically
> calls shutdown() on underlying wrapped sockets.

> 
> Fix internal http_client timeout implementation by using shutdown(..., SHUT_RD)
> instead of close().

> 

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/37730