### PR TITLE
drivers: console: uart_mux: Make the nullity checks consistent

### DIFF
--- a/drivers/console/uart_mux.c
+++ b/drivers/console/uart_mux.c
@@ -229,6 +229,10 @@ static int uart_mux_init(const struct device *dev)
 {
 	struct uart_mux_dev_data *dev_data = dev->data;
 
+	if (dev == NULL || dev_data == NULL) {
+		return -EINVAL;
+	}
+
 	gsm_mux_init();
 
 	dev_data->dev = dev;
@@ -280,6 +284,10 @@ static void uart_mux_flush_isr(const struct device *dev)
 {
 	uint8_t c;
 
+	if (dev == NULL) {
+		return;
+	}
+
 	while (uart_fifo_read(dev, &c, 1) > 0) {
 		continue;
 	}
@@ -289,6 +297,10 @@ void uart_mux_disable(const struct device *dev)
 {
 	struct uart_mux_dev_data *dev_data = dev->data;
 	const struct device *uart = dev_data->real_uart->uart;
+
+	if (dev == NULL || dev_data == NULL || dev_data->real_uart == NULL) {
+		return;
+	}
 
 	uart_irq_rx_disable(uart);
 	uart_irq_tx_disable(uart);
@@ -301,6 +313,10 @@ void uart_mux_enable(const struct device *dev)
 {
 	struct uart_mux_dev_data *dev_data = dev->data;
 	struct uart_mux *real_uart = dev_data->real_uart;
+
+	if (dev == NULL || dev_data == NULL || dev_data->real_uart == NULL) {
+		return;
+	}
 
 	LOG_DBG("Claiming uart for uart_mux");
 
@@ -466,7 +482,7 @@ static void uart_mux_poll_out(const struct device *dev,
 {
 	struct uart_mux_dev_data *dev_data = dev->data;
 
-	if (dev_data->dev == NULL) {
+	if (dev == NULL || dev_data == NULL || dev_data->dev == NULL) {
 		return;
 	}
 
@@ -501,14 +517,13 @@ static int uart_mux_config_get(const struct device *dev,
 static int uart_mux_fifo_fill(const struct device *dev,
 			      const uint8_t *tx_data, int len)
 {
-	struct uart_mux_dev_data *dev_data;
+	struct uart_mux_dev_data *dev_data = dev->data;
 	size_t wrote;
 
-	if (dev == NULL) {
+	if (dev == NULL || dev_data == NULL) {
 		return -EINVAL;
 	}
 
-	dev_data = dev->data;
 	if (dev_data->dev == NULL) {
 		return -ENOENT;
 	}
@@ -545,14 +560,13 @@ static int uart_mux_fifo_fill(const struct device *dev,
 static int uart_mux_fifo_read(const struct device *dev, uint8_t *rx_data,
 			      const int size)
 {
-	struct uart_mux_dev_data *dev_data;
+	struct uart_mux_dev_data *dev_data = dev->data;
 	uint32_t len;
 
-	if (dev == NULL) {
+	if (dev == NULL || dev_data == NULL) {
 		return -EINVAL;
 	}
 
-	dev_data = dev->data;
 	if (dev_data->dev == NULL) {
 		return -ENOENT;
 	}
@@ -574,7 +588,7 @@ static void uart_mux_irq_tx_enable(const struct device *dev)
 {
 	struct uart_mux_dev_data *dev_data = dev->data;
 
-	if (dev_data == NULL || dev_data->dev == NULL) {
+	if (dev == NULL || dev_data == NULL || dev_data->dev == NULL) {
 		return;
 	}
 
@@ -589,7 +603,7 @@ static void uart_mux_irq_tx_disable(const struct device *dev)
 {
 	struct uart_mux_dev_data *dev_data = dev->data;
 
-	if (dev_data == NULL || dev_data->dev == NULL) {
+	if (dev == NULL || dev_data == NULL || dev_data->dev == NULL) {
 		return;
 	}
 
@@ -600,7 +614,7 @@ static int uart_mux_irq_tx_ready(const struct device *dev)
 {
 	struct uart_mux_dev_data *dev_data = dev->data;
 
-	if (dev_data == NULL) {
+	if (dev == NULL || dev_data == NULL) {
 		return -EINVAL;
 	}
 
@@ -615,7 +629,7 @@ static void uart_mux_irq_rx_enable(const struct device *dev)
 {
 	struct uart_mux_dev_data *dev_data = dev->data;
 
-	if (dev_data == NULL || dev_data->dev == NULL) {
+	if (dev == NULL || dev_data == NULL || dev_data->dev == NULL) {
 		return;
 	}
 
@@ -630,7 +644,7 @@ static void uart_mux_irq_rx_disable(const struct device *dev)
 {
 	struct uart_mux_dev_data *dev_data = dev->data;
 
-	if (dev_data == NULL || dev_data->dev == NULL) {
+	if (dev == NULL || dev_data == NULL || dev_data->dev == NULL) {
 		return;
 	}
 
@@ -648,7 +662,7 @@ static int uart_mux_irq_rx_ready(const struct device *dev)
 {
 	struct uart_mux_dev_data *dev_data = dev->data;
 
-	if (dev_data == NULL) {
+	if (dev == NULL || dev_data == NULL) {
 		return -EINVAL;
 	}
 
@@ -673,7 +687,7 @@ static int uart_mux_irq_is_pending(const struct device *dev)
 {
 	struct uart_mux_dev_data *dev_data = dev->data;
 
-	if (dev_data == NULL || dev_data->dev == NULL) {
+	if (dev == NULL || dev_data == NULL || dev_data->dev == NULL) {
 		return 0;
 	}
 
@@ -701,7 +715,7 @@ static void uart_mux_irq_callback_set(const struct device *dev,
 {
 	struct uart_mux_dev_data *dev_data = dev->data;
 
-	if (dev_data == NULL) {
+	if (dev == NULL || dev_data == NULL) {
 		return;
 	}
 
@@ -789,6 +803,14 @@ int uart_mux_send(const struct device *uart, const uint8_t *buf, size_t size)
 {
 	struct uart_mux_dev_data *dev_data = uart->data;
 
+	if (uart == NULL || dev_data == NULL) {
+		return -EINVAL;
+	}
+
+	if (dev_data->dev == NULL) {
+		return -ENOENT;
+	}
+
 	if (size == 0) {
 		return 0;
 	}
@@ -822,6 +844,14 @@ int uart_mux_recv(const struct device *mux, struct gsm_dlci *dlci,
 {
 	struct uart_mux_dev_data *dev_data = mux->data;
 	size_t wrote = 0;
+
+	if (mux == NULL || dev_data == NULL) {
+		return -EINVAL;
+	}
+
+	if (dev_data->dev == NULL) {
+		return -ENOENT;
+	}
 
 	LOG_DBG("%s: dlci %p data %p len %zd", mux->name, (void *)dlci,
 		data, len);


### PR DESCRIPTION
Make the nullity checks consistent across the UART APIs and other functions, prevent possible `NULL` pointer access