### PR TITLE
LoRaWAN: Allow setting of DevNonce for OTAA re-join

### DIFF
--- a/include/lorawan/lorawan.h
+++ b/include/lorawan/lorawan.h
@@ -76,9 +76,20 @@ enum lorawan_message_type {
  * case the values stored in the secure element will be used instead.
  */
 struct lorawan_join_otaa {
+	/** Join EUI */
 	uint8_t *join_eui;
+	/** Network Key */
 	uint8_t *nwk_key;
+	/** Application Key */
 	uint8_t *app_key;
+	/**
+	 * Device Nonce
+	 *
+	 * Starting with LoRaWAN 1.0.4 the DevNonce must be monotonically
+	 * increasing for each OTAA join with the same EUI. The DevNonce
+	 * should be stored in non-volatile memory by the application.
+	 */
+	uint32_t dev_nonce;
 };
 
 struct lorawan_join_abp {

--- a/subsys/lorawan/lorawan.c
+++ b/subsys/lorawan/lorawan.c
@@ -212,6 +212,14 @@ static LoRaMacStatus_t lorawan_join_otaa(
 	mlme_req.Req.Join.Datarate = default_datarate;
 	mlme_req.Req.Join.NetworkActivation = ACTIVATION_TYPE_OTAA;
 
+	/* Retrieve the NVM context to store device nonce */
+	mib_req.Type = MIB_NVM_CTXS;
+	if (LoRaMacMibGetRequestConfirm(&mib_req) != LORAMAC_STATUS_OK) {
+		LOG_ERR("Could not get NVM context");
+		return -EINVAL;
+	}
+	mib_req.Param.Contexts->Crypto.DevNonce = join_cfg->otaa.dev_nonce;
+
 	mib_req.Type = MIB_DEV_EUI;
 	mib_req.Param.DevEui = join_cfg->dev_eui;
 	LoRaMacMibSetRequestConfirm(&mib_req);


### PR DESCRIPTION
This PR suggests a simplified approach to allow re-joining networks according to LoRaWAN standard 1.0.4 and above.

Some background regarding the spec change: https://www.thethingsnetwork.org/article/whats-new-in-lorawan-104-1

Compared to #41903, where the DevNonce is stored in the NVS using the settings API, this approach leaves storing the previous DevNonce to the application. In my applications I am using a different way to store configuration data already, so I'd like to reuse that and avoid having to pull NVS + storage drivers additionally.

I think it would be good to have both possibilities:
1. Let the Zephyr LoRaWAN subsystem handle NVM storage in the background (as suggested in #41903).
2. Let the application store the DevNonce for the next join and avoid pulling in the settings subsystem.

Fixes #41773