### PR TITLE
drivers: display: st7789v: fix gpio_dt_spec initialization

### DIFF
--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -409,6 +409,10 @@ static const struct display_driver_api st7789v_api = {
 
 static const struct st7789v_config st7789v_config = {
 	.bus = SPI_DT_SPEC_INST_GET(0, SPI_OP_MODE_MASTER | SPI_WORD_SET(8), 0),
+	.cmd_data_gpio = GPIO_DT_SPEC_INST_GET(0, cmd_data_gpios),
+#if DT_INST_NODE_HAS_PROP(0, reset_gpios)
+	.reset_gpio = GPIO_DT_SPEC_INST_GET(0, reset_gpios),
+#endif
 };
 
 static struct st7789v_data st7789v_data = {


### PR DESCRIPTION
The `gpio_dt_spec` structures where never initialised, therefore the driver
would always fault with "E: Reset GPIO device not ready" printed to the
console.

Fixes: 069bf6be4497d194c5729926cfdf4b546174e893
("drivers: display: st7789v: use gpio_dt_spec")

Signed-off-by: Casper Meijn <casper@meijn.net>