### PR TITLE
drivers: pwm_stm32: enable complementary pwm channels

### DIFF
--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -274,6 +274,11 @@ static int pwm_stm32_pin_set(const struct device *dev, uint32_t pwm,
 		oc_init.CompareValue = pulse_cycles;
 		oc_init.OCPolarity = get_polarity(flags);
 
+#if !defined(CONFIG_SOC_SERIES_STM32L0X) && !defined(CONFIG_SOC_SERIES_STM32L1X)
+		oc_init.OCNState = LL_TIM_OCSTATE_ENABLE;
+		oc_init.OCNPolarity = get_polarity(flags);
+#endif
+
 #ifdef CONFIG_PWM_CAPTURE
 		if (IS_TIM_SLAVE_INSTANCE(cfg->timer)) {
 			LL_TIM_SetSlaveMode(cfg->timer,


### PR DESCRIPTION
Hi, bumped into this on a board (a WeAct STM32H730) with something connected to a complimentary PWM channel. The pinctrl definition is there but the output needs to be enabled on the PWM controller explicitly... Do you think we could just enable in all the time if supported?