### PR TITLE
fs: nvs: introduce nvs_mount and deprecate nvs_init

### DIFF
--- a/doc/reference/storage/nvs/nvs.rst
+++ b/doc/reference/storage/nvs/nvs.rst
@@ -41,6 +41,7 @@ For NVS the file system is declared as:
 .. code-block:: c
 
 	static struct nvs_fs fs = {
+	.flash_device = NVS_FLASH_DEVICE,
 	.sector_size = NVS_SECTOR_SIZE,
 	.sector_count = NVS_SECTOR_COUNT,
 	.offset = NVS_STORAGE_OFFSET,
@@ -48,6 +49,8 @@ For NVS the file system is declared as:
 
 where
 
+- ``NVS_FLASH_DEVICE`` is a reference to the flash device that will be used. The
+  device needs to be operational.
 - ``NVS_SECTOR_SIZE`` is the sector size, it has to be a multiple of
   the flash erase page size and a power of 2.
 - ``NVS_SECTOR_COUNT`` is the number of sectors, it is at least 2, one

--- a/doc/releases/release-notes-3.1.rst
+++ b/doc/releases/release-notes-3.1.rst
@@ -1,0 +1,173 @@
+:orphan:
+
+.. _zephyr_3.1:
+
+Zephyr 3.1.0 (Working Draft)
+############################
+
+The following sections provide detailed lists of changes by component.
+
+Security Vulnerability Related
+******************************
+
+Known issues
+************
+
+API Changes
+***********
+
+Changes in this release
+=======================
+
+Removed APIs in this release
+============================
+
+Deprecated in this release
+==========================
+
+* :c:func:`nvs_init` is deprecated in favor of utilizing :c:func:`nvs_mount`.
+
+Stable API changes in this release
+==================================
+
+New APIs in this release
+========================
+
+Kernel
+******
+
+Architectures
+*************
+
+* ARM
+
+  * AARCH32
+
+  * AARCH64
+
+* Xtensa
+
+Bluetooth
+*********
+
+* Audio
+
+* Direction Finding
+
+* Host
+
+* Mesh
+
+* Controller
+
+* HCI Driver
+
+Boards & SoC Support
+********************
+
+* Added support for these SoC series:
+
+* Removed support for these SoC series:
+
+* Made these changes in other SoC series:
+
+* Changes for ARC boards:
+
+* Added support for these ARM boards:
+
+* Added support for these ARM64 boards:
+
+* Removed support for these ARM boards:
+
+* Removed support for these X86 boards:
+
+* Added support for these RISC-V boards:
+
+* Made these changes in other boards:
+
+* Added support for these following shields:
+
+
+Drivers and Sensors
+*******************
+
+* ADC
+
+* CAN
+
+* Counter
+
+* DAC
+
+* Disk
+
+* DMA
+
+* EEPROM
+
+* Entropy
+
+* Ethernet
+
+* Flash
+
+* GPIO
+
+* I2C
+
+* I2S
+
+* Interrupt Controller
+
+* MBOX
+
+* MEMC
+
+* Pin control
+
+* PWM
+
+* Sensor
+
+* Serial
+
+* SPI
+
+* Timer
+
+* USB
+
+* Watchdog
+
+Networking
+**********
+
+USB
+***
+
+Build and Infrastructure
+************************
+
+Libraries / Subsystems
+**********************
+
+HALs
+****
+
+MCUboot
+*******
+
+Trusted Firmware-m
+******************
+
+Documentation
+*************
+
+Tests and Samples
+*****************
+
+Issue Related Items
+*******************
+
+These GitHub issues were addressed since the previous 3.0.0 tagged
+release:

--- a/include/fs/nvs.h
+++ b/include/fs/nvs.h
@@ -10,6 +10,7 @@
 #include <sys/types.h>
 #include <kernel.h>
 #include <device.h>
+#include <toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -68,16 +69,15 @@ struct nvs_fs {
  */
 
 /**
- * @brief nvs_init
+ * @brief nvs_mount
  *
- * Initializes a NVS file system in flash.
+ * Mount a NVS file system onto the flash device specified in @p fs.
  *
  * @param fs Pointer to file system
- * @param dev_name Pointer to flash device name
  * @retval 0 Success
  * @retval -ERRNO errno code if error
  */
-int nvs_init(struct nvs_fs *fs, const char *dev_name);
+int nvs_mount(struct nvs_fs *fs);
 
 /**
  * @brief nvs_clear
@@ -164,6 +164,28 @@ ssize_t nvs_read_hist(struct nvs_fs *fs, uint16_t id, void *data, size_t len, ui
  * especially on spi flash. On error, returns negative value of errno.h defined error codes.
  */
 ssize_t nvs_calc_free_space(struct nvs_fs *fs);
+
+/**
+ * @brief nvs_init
+ *
+ * Initializes a NVS file system in flash.
+ *
+ * @deprecated Use nvs_mount() instead.
+ *
+ * @param fs Pointer to file system
+ * @param dev_name Pointer to flash device name
+ * @retval 0 Success
+ * @retval -ERRNO errno code if error
+ */
+__deprecated static inline int nvs_init(struct nvs_fs *fs, const char *dev_name)
+{
+	fs->flash_device = device_get_binding(dev_name);
+	if (fs->flash_device == NULL) {
+		return -ENODEV;
+	}
+
+	return nvs_mount(fs);
+}
 
 /**
  * @}

--- a/samples/subsys/nvs/README.rst
+++ b/samples/subsys/nvs/README.rst
@@ -42,9 +42,9 @@ Sample Output
    ***** Booting Zephyr OS v1.12.0-rc1-176-gf091be783 *****
    [fs/nvs] [DBG] nvs_reinit: (Re)Initializing sectors
    [fs/nvs] [DBG] _nvs_sector_init: f->write_location set to c
-   [fs/nvs] [INF] nvs_init: maximum storage length 256 byte
-   [fs/nvs] [INF] nvs_init: write-align: 1, write-addr: c
-   [fs/nvs] [INF] nvs_init: entry sector: 0, entry sector ID: 1
+   [fs/nvs] [INF] nvs_mount: maximum storage length 256 byte
+   [fs/nvs] [INF] nvs_mount: write-align: 1, write-addr: c
+   [fs/nvs] [INF] nvs_mount: entry sector: 0, entry sector ID: 1
    No address found, adding 192.168.1.1 at id 1
    No key found, adding it at id 2
    No Reboot counter found, adding it at id 3
@@ -54,9 +54,9 @@ Sample Output
    Oldest reboot counter: 0
    Rebooting in ...5...4...3...2...1
    ***** Booting Zephyr OS v1.12.0-rc1-176-gf091be783 *****
-   [fs/nvs] [INF] nvs_init: maximum storage length 256 byte
-   [fs/nvs] [INF] nvs_init: write-align: 1, write-addr: c7
-   [fs/nvs] [INF] nvs_init: entry sector: 0, entry sector ID: 1
+   [fs/nvs] [INF] nvs_mount: maximum storage length 256 byte
+   [fs/nvs] [INF] nvs_mount: write-align: 1, write-addr: c7
+   [fs/nvs] [INF] nvs_mount: entry sector: 0, entry sector ID: 1
    Entry: 1, Address: 192.168.1.1
    Id: 2, Key: ff fe fd fc fb fa f9 f8
    Id: 3, Reboot_counter: 1

--- a/samples/subsys/nvs/src/main.c
+++ b/samples/subsys/nvs/src/main.c
@@ -70,20 +70,19 @@ void main(void)
 	uint8_t key[8], longarray[128];
 	uint32_t reboot_counter = 0U, reboot_counter_his;
 	struct flash_pages_info info;
-	const struct device *flash_dev;
 
 	/* define the nvs file system by settings with:
 	 *	sector_size equal to the pagesize,
 	 *	3 sectors
 	 *	starting at FLASH_AREA_OFFSET(storage)
 	 */
-	flash_dev = FLASH_AREA_DEVICE(STORAGE_NODE_LABEL);
-	if (!device_is_ready(flash_dev)) {
-		printk("Flash device %s is not ready\n", flash_dev->name);
+	fs.flash_device = FLASH_AREA_DEVICE(STORAGE_NODE_LABEL);
+	if (!device_is_ready(fs.flash_device)) {
+		printk("Flash device %s is not ready\n", fs.flash_device->name);
 		return;
 	}
 	fs.offset = FLASH_AREA_OFFSET(storage);
-	rc = flash_get_page_info_by_offs(flash_dev, fs.offset, &info);
+	rc = flash_get_page_info_by_offs(fs.flash_device, fs.offset, &info);
 	if (rc) {
 		printk("Unable to get page info\n");
 		return;
@@ -91,7 +90,7 @@ void main(void)
 	fs.sector_size = info.size;
 	fs.sector_count = 3U;
 
-	rc = nvs_init(&fs, flash_dev->name);
+	rc = nvs_mount(&fs);
 	if (rc) {
 		printk("Flash Init failed\n");
 		return;

--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -623,7 +623,7 @@ static int nvs_startup(struct nvs_fs *fs)
 	struct nvs_ate last_ate;
 	size_t ate_size, empty_len;
 	/* Initialize addr to 0 for the case fs->sector_count == 0. This
-	 * should never happen as this is verified in nvs_init() but both
+	 * should never happen as this is verified in nvs_mount() but both
 	 * Coverity and GCC believe the contrary.
 	 */
 	uint32_t addr = 0U;
@@ -847,7 +847,7 @@ int nvs_clear(struct nvs_fs *fs)
 	return 0;
 }
 
-int nvs_init(struct nvs_fs *fs, const char *dev_name)
+int nvs_mount(struct nvs_fs *fs)
 {
 
 	int rc;
@@ -855,12 +855,6 @@ int nvs_init(struct nvs_fs *fs, const char *dev_name)
 	size_t write_block_size;
 
 	k_mutex_init(&fs->nvs_lock);
-
-	fs->flash_device = device_get_binding(dev_name);
-	if (!fs->flash_device) {
-		LOG_ERR("No valid flash device found");
-		return -ENXIO;
-	}
 
 	fs->flash_parameters = flash_get_parameters(fs->flash_device);
 	if (fs->flash_parameters == NULL) {

--- a/subsys/settings/src/settings_nvs.c
+++ b/subsys/settings/src/settings_nvs.c
@@ -245,7 +245,12 @@ int settings_nvs_backend_init(struct settings_nvs *cf)
 	int rc;
 	uint16_t last_name_id;
 
-	rc = nvs_init(&cf->cf_nvs, cf->flash_dev_name);
+	cf->cf_nvs.flash_device = device_get_binding(cf->flash_dev_name);
+	if (cf->cf_nvs.flash_device == NULL) {
+		return -ENODEV;
+	}
+
+	rc = nvs_mount(&cf->cf_nvs);
 	if (rc) {
 		return rc;
 	}

--- a/tests/subsys/fs/nvs/src/main.c
+++ b/tests/subsys/fs/nvs/src/main.c
@@ -58,7 +58,7 @@ void teardown(void)
 	}
 }
 
-void test_nvs_init(void)
+void test_nvs_mount(void)
 {
 	int err;
 	const struct flash_area *fa;
@@ -74,9 +74,10 @@ void test_nvs_init(void)
 
 	fs.sector_size = info.size;
 	fs.sector_count = TEST_SECTOR_COUNT;
+	fs.flash_device = flash_area_get_device(fa);
 
-	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
-	zassert_true(err == 0,  "nvs_init call failure: %d", err);
+	err = nvs_mount(&fs);
+	zassert_true(err == 0,  "nvs_mount call failure: %d", err);
 }
 
 static void execute_long_pattern_write(uint16_t id)
@@ -108,8 +109,8 @@ void test_nvs_write(void)
 {
 	int err;
 
-	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
-	zassert_true(err == 0,  "nvs_init call failure: %d", err);
+	err = nvs_mount(&fs);
+	zassert_true(err == 0,  "nvs_mount call failure: %d", err);
 
 	execute_long_pattern_write(TEST_DATA_ID);
 }
@@ -148,8 +149,8 @@ void test_nvs_corrupted_write(void)
 	uint32_t *flash_write_stat;
 	uint32_t *flash_max_write_calls;
 
-	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
-	zassert_true(err == 0,  "nvs_init call failure: %d", err);
+	err = nvs_mount(&fs);
+	zassert_true(err == 0,  "nvs_mount call failure: %d", err);
 
 	err = nvs_read(&fs, TEST_DATA_ID, rd_buf, sizeof(rd_buf));
 	zassert_true(err == -ENOENT,  "nvs_read unexpected failure: %d", err);
@@ -192,7 +193,7 @@ void test_nvs_corrupted_write(void)
 
 	/* Reinitialize the NVS. */
 	memset(&fs, 0, sizeof(fs));
-	test_nvs_init();
+	test_nvs_mount();
 
 	len = nvs_read(&fs, TEST_DATA_ID, rd_buf, sizeof(rd_buf));
 	zassert_true(len == sizeof(rd_buf),  "nvs_read unexpected failure: %d",
@@ -218,8 +219,8 @@ void test_nvs_gc(void)
 
 	fs.sector_count = 2;
 
-	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
-	zassert_true(err == 0,  "nvs_init call failure: %d", err);
+	err = nvs_mount(&fs);
+	zassert_true(err == 0,  "nvs_mount call failure: %d", err);
 
 	for (uint16_t i = 0; i < max_writes; i++) {
 		uint8_t id = (i % max_id);
@@ -245,8 +246,8 @@ void test_nvs_gc(void)
 
 	}
 
-	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
-	zassert_true(err == 0,  "nvs_init call failure: %d", err);
+	err = nvs_mount(&fs);
+	zassert_true(err == 0,  "nvs_mount call failure: %d", err);
 
 	for (uint16_t id = 0; id < max_id; id++) {
 		len = nvs_read(&fs, id, rd_buf, sizeof(buf));
@@ -320,8 +321,8 @@ void test_nvs_gc_3sectors(void)
 
 	fs.sector_count = 3;
 
-	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
-	zassert_true(err == 0,  "nvs_init call failure: %d", err);
+	err = nvs_mount(&fs);
+	zassert_true(err == 0,  "nvs_mount call failure: %d", err);
 	zassert_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 0,
 		     "unexpected write sector");
 
@@ -333,8 +334,8 @@ void test_nvs_gc_3sectors(void)
 		     "unexpected write sector");
 	check_content(max_id, &fs);
 
-	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
-	zassert_true(err == 0,  "nvs_init call failure: %d", err);
+	err = nvs_mount(&fs);
+	zassert_true(err == 0,  "nvs_mount call failure: %d", err);
 
 	zassert_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 2,
 		     "unexpected write sector");
@@ -348,8 +349,8 @@ void test_nvs_gc_3sectors(void)
 		     "unexpected write sector");
 	check_content(max_id, &fs);
 
-	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
-	zassert_true(err == 0,  "nvs_init call failure: %d", err);
+	err = nvs_mount(&fs);
+	zassert_true(err == 0,  "nvs_mount call failure: %d", err);
 
 	zassert_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 0,
 		     "unexpected write sector");
@@ -363,8 +364,8 @@ void test_nvs_gc_3sectors(void)
 		     "unexpected write sector");
 	check_content(max_id, &fs);
 
-	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
-	zassert_true(err == 0,  "nvs_init call failure: %d", err);
+	err = nvs_mount(&fs);
+	zassert_true(err == 0,  "nvs_mount call failure: %d", err);
 
 	zassert_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 1,
 		     "unexpected write sector");
@@ -378,8 +379,8 @@ void test_nvs_gc_3sectors(void)
 		     "unexpected write sector");
 	check_content(max_id, &fs);
 
-	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
-	zassert_true(err == 0,  "nvs_init call failure: %d", err);
+	err = nvs_mount(&fs);
+	zassert_true(err == 0,  "nvs_mount call failure: %d", err);
 
 	zassert_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 2,
 		     "unexpected write sector");
@@ -444,8 +445,8 @@ void test_nvs_corrupted_sector_close_operation(void)
 	stats_walk(sim_stats, flash_sim_write_calls_find, &flash_write_stat);
 	stats_walk(sim_stats, flash_sim_erase_calls_find, &flash_erase_stat);
 
-	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
-	zassert_true(err == 0,  "nvs_init call failure: %d", err);
+	err = nvs_mount(&fs);
+	zassert_true(err == 0,  "nvs_mount call failure: %d", err);
 
 	for (uint16_t i = 0; i < max_writes; i++) {
 		uint8_t id = (i % max_id);
@@ -476,8 +477,8 @@ void test_nvs_corrupted_sector_close_operation(void)
 	*flash_max_erase_calls = 0;
 	*flash_max_len = 0;
 
-	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
-	zassert_true(err == 0,  "nvs_init call failure: %d", err);
+	err = nvs_mount(&fs);
+	zassert_true(err == 0,  "nvs_mount call failure: %d", err);
 
 	check_content(max_id, &fs);
 
@@ -497,8 +498,8 @@ void test_nvs_full_sector(void)
 
 	fs.sector_count = 3;
 
-	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
-	zassert_true(err == 0,  "nvs_init call failure: %d", err);
+	err = nvs_mount(&fs);
+	zassert_true(err == 0,  "nvs_mount call failure: %d", err);
 
 	while (1) {
 		len = nvs_write(&fs, filling_id, &filling_id,
@@ -516,8 +517,8 @@ void test_nvs_full_sector(void)
 	zassert_true(err == 0,  "nvs_delete call failure: %d", err);
 
 	/* the last sector is full now, test re-initialization */
-	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
-	zassert_true(err == 0,  "nvs_init call failure: %d", err);
+	err = nvs_mount(&fs);
+	zassert_true(err == 0,  "nvs_mount call failure: %d", err);
 
 	len = nvs_write(&fs, filling_id, &filling_id, sizeof(filling_id));
 	zassert_true(len == sizeof(filling_id), "nvs_write failed: %d", len);
@@ -548,8 +549,8 @@ void test_delete(void)
 
 	fs.sector_count = 3;
 
-	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
-	zassert_true(err == 0,  "nvs_init call failure: %d", err);
+	err = nvs_mount(&fs);
+	zassert_true(err == 0,  "nvs_mount call failure: %d", err);
 
 	for (filling_id = 0; filling_id < 10; filling_id++) {
 		len = nvs_write(&fs, filling_id, &filling_id,
@@ -650,8 +651,8 @@ void test_nvs_gc_corrupt_close_ate(void)
 
 	fs.sector_count = 3;
 
-	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
-	zassert_true(err == 0,  "nvs_init call failure: %d", err);
+	err = nvs_mount(&fs);
+	zassert_true(err == 0,  "nvs_mount call failure: %d", err);
 
 	data = 0;
 	len = nvs_read(&fs, 1, &data, sizeof(data));
@@ -702,14 +703,14 @@ void test_nvs_gc_corrupt_ate(void)
 
 	fs.sector_count = 3;
 
-	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
-	zassert_true(err == 0,  "nvs_init call failure: %d", err);
+	err = nvs_mount(&fs);
+	zassert_true(err == 0,  "nvs_mount call failure: %d", err);
 }
 
 void test_main(void)
 {
 	ztest_test_suite(test_nvs,
-			 ztest_unit_test_setup_teardown(test_nvs_init, setup,
+			 ztest_unit_test_setup_teardown(test_nvs_mount, setup,
 				 teardown),
 			 ztest_unit_test_setup_teardown(test_nvs_write, setup,
 				 teardown),


### PR DESCRIPTION
Add a new API call to replace nvs_init: nvs_mount. The new API does the
same as nvs_init except that it assumes to be provided with a valid
flash device via `struct nvs_fs` `flash_device` field. Previously, it
was not possible to avoid the runtime overhead of device_get_binding()
even if the flash device was known at compile time.

Resolves https://github.com/zephyrproject-rtos/zephyr/issues/43229
Alternative to https://github.com/zephyrproject-rtos/zephyr/pull/43220
