### PR TITLE
manifest: update canopennode

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -26,7 +26,7 @@ manifest:
   # Please add items below based on alphabetical order
   projects:
     - name: canopennode
-      revision: 1052dae561497bef901f931ef75e117c9224aecd
+      revision: 53d3415c14d60f8f4bfca54bfbc5d5a667d7e724
       path: modules/lib/canopennode
     - name: civetweb
       revision: 094aeb41bb93e9199d24d665ee43e9e05d6d7b1c


### PR DESCRIPTION
Pull latest canopennode module version. The last revision changes module
name from CANopenNode to canopennode.