### PR TITLE
drivers: timer: Set user RTC channel count conditionally

### DIFF
--- a/drivers/timer/Kconfig.nrf_rtc
+++ b/drivers/timer/Kconfig.nrf_rtc
@@ -18,7 +18,7 @@ if NRF_RTC_TIMER
 
 config NRF_RTC_TIMER_USER_CHAN_COUNT
 	int "Additional channels that can be used"
-	default 3 if SOC_SERIES_NRF52X
+	default 2 if NRF_802154_RADIO_DRIVER
 	default 0
 	help
 	  Use nrf_rtc_timer.h API. Driver is not managing allocation of channels.


### PR DESCRIPTION
The RTC user channel count is increased contitionally to 2 when
nrf_802154 radio driver is enabled.

Signed-off-by: Rafał Kuźnia <rafal.kuznia@nordicsemi.no>