### PR TITLE
boards: nucleo_wb55rg: Flash partition not compatible w/ BLE f/w 1.13

### DIFF
--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -198,9 +198,13 @@ zephyr_udc0: &usb {
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		/* Set all partitions with first 808K of flash */
-		/* last 216K are reseved for M0 usage */
-		/* Configure partitions to make use of the whole 808K */
+		/*
+		 * Configure partitions while leaving space for M0 BLE f/w
+		 * First 794K are configured for Zephyr to run on M4 core
+		 * Last 232K are left for BLE f/w on the M0 core
+		 * This partition set up is compatible with use of
+		 * stm32wb5x_BLE_Stack_full_fw.bin v1.13.x
+		 */
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
@@ -208,19 +212,19 @@ zephyr_udc0: &usb {
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x5c000>;
+			reg = <0x0000c000 0x5a000>;
 		};
-		slot1_partition: partition@68000 {
+		slot1_partition: partition@66000 {
 			label = "image-1";
-			reg = <0x00068000 0x5c000>;
+			reg = <0x00066000 0x5a000>;
 		};
-		scratch_partition: partition@c4000 {
+		scratch_partition: partition@c0000 {
 			label = "image-scratch";
-			reg = <0x000c4000 0x4000>;
+			reg = <0x000c0000 0x4000>;
 		};
-		storage_partition: partition@c8000 {
+		storage_partition: partition@c4000 {
 			label = "storage";
-			reg = <0x000c8000 0x2000>;
+			reg = <0x000c4000 0x2000>;
 		};
 
 	};


### PR DESCRIPTION
Update board flash partition to be compatible with v1.13.0 f/w.
This configuration is compatible with stm32wb5x_BLE_Stack_full_fw
which should be installed at 0x080C7000.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/43218

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>