### PR TITLE
drivers: Add support for pinctrl in nRF SPI and I2C drivers

### DIFF
--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -8,6 +8,8 @@
 #include <drivers/i2c.h>
 #include <dt-bindings/i2c/i2c.h>
 #include <pm/device.h>
+#include <drivers/pinctrl.h>
+#include <soc.h>
 #include <nrfx_twi.h>
 
 #include <logging/log.h>
@@ -25,6 +27,9 @@ struct i2c_nrfx_twi_data {
 struct i2c_nrfx_twi_config {
 	nrfx_twi_t twi;
 	nrfx_twi_config_t config;
+#ifdef CONFIG_PINCTRL
+	const struct pinctrl_dev_config *pcfg;
+#endif
 };
 
 static int i2c_nrfx_twi_transfer(const struct device *dev,
@@ -228,6 +233,13 @@ static int twi_nrfx_pm_action(const struct device *dev,
 
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
+#ifdef CONFIG_PINCTRL
+		ret = pinctrl_apply_state(config->pcfg,
+					  PINCTRL_STATE_DEFAULT);
+		if (ret < 0) {
+			return ret;
+		}
+#endif
 		init_twi(dev);
 		if (data->dev_config) {
 			i2c_nrfx_twi_configure(dev, data->dev_config);
@@ -236,6 +248,14 @@ static int twi_nrfx_pm_action(const struct device *dev,
 
 	case PM_DEVICE_ACTION_SUSPEND:
 		nrfx_twi_uninit(&config->twi);
+
+#ifdef CONFIG_PINCTRL
+		ret = pinctrl_apply_state(config->pcfg,
+					  PINCTRL_STATE_SLEEP);
+		if (ret < 0) {
+			return ret;
+		}
+#endif
 		break;
 
 	default:
@@ -256,14 +276,30 @@ static int twi_nrfx_pm_action(const struct device *dev,
 #define I2C_FREQUENCY(idx)						       \
 	I2C_NRFX_TWI_FREQUENCY(DT_PROP(I2C(idx), clock_frequency))
 
+#define I2C_NRFX_TWI_PIN_CFG(idx)			\
+	COND_CODE_1(CONFIG_PINCTRL,			\
+		(.skip_gpio_cfg = true,			\
+		 .skip_psel_cfg = true,),		\
+		(.scl = DT_PROP(I2C(idx), scl_pin),	\
+		 .sda = DT_PROP(I2C(idx), sda_pin),))
+
 #define I2C_NRFX_TWI_DEVICE(idx)					       \
+	NRF_DT_ENSURE_PINS_ASSIGNED(I2C(idx), scl_pin);			       \
 	BUILD_ASSERT(I2C_FREQUENCY(idx)	!=				       \
 		     I2C_NRFX_TWI_INVALID_FREQUENCY,			       \
 		     "Wrong I2C " #idx " frequency setting in dts");	       \
-	static int twi_##idx##_init(const struct device *dev)		\
+	static int twi_##idx##_init(const struct device *dev)		       \
 	{								       \
 		IRQ_CONNECT(DT_IRQN(I2C(idx)), DT_IRQ(I2C(idx), priority),     \
 			    nrfx_isr, nrfx_twi_##idx##_irq_handler, 0);	       \
+		IF_ENABLED(CONFIG_PINCTRL, (				       \
+			const struct i2c_nrfx_twi_config *config = dev->config;\
+			int err = pinctrl_apply_state(config->pcfg,	       \
+						      PINCTRL_STATE_DEFAULT);  \
+			if (err < 0) {					       \
+				return err;				       \
+			}						       \
+		))							       \
 		return init_twi(dev);					       \
 	}								       \
 	static struct i2c_nrfx_twi_data twi_##idx##_data = {		       \
@@ -272,13 +308,15 @@ static int twi_nrfx_pm_action(const struct device *dev,
 		.completion_sync = Z_SEM_INITIALIZER(                          \
 			twi_##idx##_data.completion_sync, 0, 1)		       \
 	};								       \
+	IF_ENABLED(CONFIG_PINCTRL, (PINCTRL_DT_DEFINE(I2C(idx))));	       \
 	static const struct i2c_nrfx_twi_config twi_##idx##z_config = {	       \
 		.twi = NRFX_TWI_INSTANCE(idx),				       \
 		.config = {						       \
-			.scl       = DT_PROP(I2C(idx), scl_pin),	       \
-			.sda       = DT_PROP(I2C(idx), sda_pin),	       \
+			I2C_NRFX_TWI_PIN_CFG(idx)			       \
 			.frequency = I2C_FREQUENCY(idx),		       \
-		}							       \
+		},							       \
+		IF_ENABLED(CONFIG_PINCTRL,				       \
+			(.pcfg = PINCTRL_DT_DEV_CONFIG_GET(I2C(idx)),))	       \
 	};								       \
 	PM_DEVICE_DT_DEFINE(I2C(idx), twi_nrfx_pm_action);		       \
 	I2C_DEVICE_DT_DEFINE(I2C(idx),					       \

--- a/drivers/pinctrl/pinctrl_nrf.c
+++ b/drivers/pinctrl/pinctrl_nrf.c
@@ -106,11 +106,13 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 #if defined(NRF_PSEL_SPIM)
 		case NRF_FUN_SPIM_SCK:
 			NRF_PSEL_SPIM(reg, SCK) = NRF_GET_PIN(pins[i]);
+			nrf_gpio_pin_write(NRF_GET_PIN(pins[i]), 0);
 			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_OUTPUT,
 					  NRF_GPIO_PIN_INPUT_CONNECT);
 			break;
 		case NRF_FUN_SPIM_MOSI:
 			NRF_PSEL_SPIM(reg, MOSI) = NRF_GET_PIN(pins[i]);
+			nrf_gpio_pin_write(NRF_GET_PIN(pins[i]), 0);
 			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_OUTPUT,
 					  NRF_GPIO_PIN_INPUT_DISCONNECT);
 			break;

--- a/drivers/pinctrl/pinctrl_nrf.c
+++ b/drivers/pinctrl/pinctrl_nrf.c
@@ -33,6 +33,26 @@ BUILD_ASSERT(((NRF_DRIVE_S0S1 == NRF_GPIO_PIN_S0S1) &&
 #define NRF_PSEL_UART(reg, line) ((NRF_UARTE_Type *)reg)->PSEL.line
 #endif
 
+#if DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_spi)
+#define NRF_PSEL_SPIM(reg, line) ((NRF_SPI_Type *)reg)->PSEL##line
+#elif DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_spim)
+#define NRF_PSEL_SPIM(reg, line) ((NRF_SPIM_Type *)reg)->PSEL.line
+#endif
+
+#if DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_spis)
+#if defined(NRF51)
+#define NRF_PSEL_SPIS(reg, line) ((NRF_SPIS_Type *)reg)->PSEL##line
+#else
+#define NRF_PSEL_SPIS(reg, line) ((NRF_SPIS_Type *)reg)->PSEL.line
+#endif
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_spis) */
+
+#if DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_twi)
+#define NRF_PSEL_TWIM(reg, line) ((NRF_TWI_Type *)reg)->PSEL##line
+#elif DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_twim)
+#define NRF_PSEL_TWIM(reg, line) ((NRF_TWIM_Type *)reg)->PSEL.line
+#endif
+
 /**
  * @brief Configure pin settings.
  *
@@ -83,6 +103,57 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 					  NRF_GPIO_PIN_INPUT_CONNECT);
 			break;
 #endif /* defined(NRF_PSEL_UART) */
+#if defined(NRF_PSEL_SPIM)
+		case NRF_FUN_SPIM_SCK:
+			NRF_PSEL_SPIM(reg, SCK) = NRF_GET_PIN(pins[i]);
+			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_OUTPUT,
+					  NRF_GPIO_PIN_INPUT_CONNECT);
+			break;
+		case NRF_FUN_SPIM_MOSI:
+			NRF_PSEL_SPIM(reg, MOSI) = NRF_GET_PIN(pins[i]);
+			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_OUTPUT,
+					  NRF_GPIO_PIN_INPUT_DISCONNECT);
+			break;
+		case NRF_FUN_SPIM_MISO:
+			NRF_PSEL_SPIM(reg, MISO) = NRF_GET_PIN(pins[i]);
+			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
+					  NRF_GPIO_PIN_INPUT_CONNECT);
+			break;
+#endif /* defined(NRF_PSEL_SPIM) */
+#if defined(NRF_PSEL_SPIS)
+		case NRF_FUN_SPIS_SCK:
+			NRF_PSEL_SPIS(reg, SCK) = NRF_GET_PIN(pins[i]);
+			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
+					  NRF_GPIO_PIN_INPUT_CONNECT);
+			break;
+		case NRF_FUN_SPIS_MOSI:
+			NRF_PSEL_SPIS(reg, MOSI) = NRF_GET_PIN(pins[i]);
+			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
+					  NRF_GPIO_PIN_INPUT_CONNECT);
+			break;
+		case NRF_FUN_SPIS_MISO:
+			NRF_PSEL_SPIS(reg, MISO) = NRF_GET_PIN(pins[i]);
+			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
+					  NRF_GPIO_PIN_INPUT_DISCONNECT);
+			break;
+		case NRF_FUN_SPIS_CSN:
+			NRF_PSEL_SPIS(reg, CSN) = NRF_GET_PIN(pins[i]);
+			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
+					  NRF_GPIO_PIN_INPUT_CONNECT);
+			break;
+#endif /* defined(NRF_PSEL_SPIS) */
+#if defined(NRF_PSEL_TWIM)
+		case NRF_FUN_TWIM_SCL:
+			NRF_PSEL_TWIM(reg, SCL) = NRF_GET_PIN(pins[i]);
+			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
+					  NRF_GPIO_PIN_INPUT_CONNECT);
+			break;
+		case NRF_FUN_TWIM_SDA:
+			NRF_PSEL_TWIM(reg, SDA) = NRF_GET_PIN(pins[i]);
+			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
+					  NRF_GPIO_PIN_INPUT_CONNECT);
+			break;
+#endif /* defined(NRF_PSEL_TWIM) */
 		default:
 			return -ENOTSUP;
 		}

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -10,6 +10,7 @@
 
 #include <drivers/uart.h>
 #include <pm/device.h>
+#include <soc.h>
 #include <hal/nrf_uart.h>
 
 #ifdef CONFIG_PINCTRL
@@ -1191,6 +1192,8 @@ static int uart_nrfx_pm_action(const struct device *dev,
 #ifdef CONFIG_PINCTRL
 PINCTRL_DT_INST_DEFINE(0);
 #endif /* CONFIG_PINCTRL */
+
+NRF_DT_ENSURE_PINS_ASSIGNED(DT_DRV_INST(0), tx_pin, rx_pin);
 
 static const struct uart_nrfx_config uart_nrfx_uart0_config = {
 #ifdef CONFIG_PINCTRL

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -14,6 +14,7 @@
 #include <nrfx_timer.h>
 #include <sys/util.h>
 #include <kernel.h>
+#include <soc.h>
 #include <logging/log.h>
 #include <helpers/nrfx_gppi.h>
 LOG_MODULE_REGISTER(uart_nrfx_uarte, LOG_LEVEL_ERR);
@@ -2047,6 +2048,7 @@ static int uarte_nrfx_pm_action(const struct device *dev,
 #endif /* CONFIG_PINCTRL */
 
 #define UART_NRF_UARTE_DEVICE(idx)					       \
+	NRF_DT_ENSURE_PINS_ASSIGNED(UARTE(idx), tx_pin, rx_pin);	       \
 	UARTE_INT_DRIVEN(idx);						       \
 	UARTE_ASYNC(idx);						       \
 	IF_ENABLED(CONFIG_PINCTRL, (PINCTRL_DT_DEFINE(UARTE(idx));))	       \

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -6,6 +6,8 @@
 
 #include <drivers/spi.h>
 #include <pm/device.h>
+#include <drivers/pinctrl.h>
+#include <soc.h>
 #ifdef CONFIG_SOC_NRF52832_ALLOW_SPIM_DESPITE_PAN_58
 #include <nrfx_gpiote.h>
 #include <nrfx_ppi.h>
@@ -40,8 +42,11 @@ struct spi_nrfx_config {
 	size_t		   max_chunk_len;
 	uint32_t	   max_freq;
 	nrfx_spim_config_t def_config;
+#ifdef CONFIG_PINCTRL
+	const struct pinctrl_dev_config *pcfg;
+#endif
 #ifdef CONFIG_SOC_NRF52832_ALLOW_SPIM_DESPITE_PAN_58
-	bool		   anomaly_58_workaround;
+	bool anomaly_58_workaround;
 #endif
 };
 
@@ -435,8 +440,15 @@ static int spim_nrfx_pm_action(const struct device *dev,
 
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
-		/* No action needed at this point, nrfx_spim_init() will be
-		 * called at configuration before the next transfer.
+#ifdef CONFIG_PINCTRL
+		ret = pinctrl_apply_state(dev_config->pcfg,
+					  PINCTRL_STATE_DEFAULT);
+		if (ret < 0) {
+			return ret;
+		}
+#endif
+		/* nrfx_spim_init() will be called at configuration before
+		 * the next transfer.
 		 */
 		break;
 
@@ -445,6 +457,14 @@ static int spim_nrfx_pm_action(const struct device *dev,
 			nrfx_spim_uninit(&dev_config->spim);
 			dev_data->initialized = false;
 		}
+
+#ifdef CONFIG_PINCTRL
+		ret = pinctrl_apply_state(dev_config->pcfg,
+					  PINCTRL_STATE_SLEEP);
+		if (ret < 0) {
+			return ret;
+		}
+#endif
 		break;
 
 	default:
@@ -468,11 +488,11 @@ static int spim_nrfx_pm_action(const struct device *dev,
 #define SPIM_NRFX_MISO_PULL_UP(idx) DT_PROP(SPIM(idx), miso_pull_up)
 
 #define SPIM_NRFX_MISO_PULL(idx)			\
-	(SPIM_NRFX_MISO_PULL_UP(idx)			\
-		? SPIM_NRFX_MISO_PULL_DOWN(idx)		\
+	(SPIM_PROP(idx, miso_pull_up)			\
+		? SPIM_PROP(idx, miso_pull_down)	\
 			? -1 /* invalid configuration */\
 			: NRF_GPIO_PIN_PULLUP		\
-		: SPIM_NRFX_MISO_PULL_DOWN(idx)		\
+		: SPIM_PROP(idx, miso_pull_down)	\
 			? NRF_GPIO_PIN_PULLDOWN		\
 			: NRF_GPIO_PIN_NOPULL)
 
@@ -483,9 +503,22 @@ static int spim_nrfx_pm_action(const struct device *dev,
 			(.rx_delay = CONFIG_SPI_##idx##_NRF_RX_DELAY,))	\
 		))
 
+#define SPI_NRFX_SPIM_PIN_CFG(idx)					\
+	COND_CODE_1(CONFIG_PINCTRL,					\
+		(.skip_gpio_cfg = true,					\
+		 .skip_psel_cfg = true,),				\
+		(.sck_pin   = SPIM_PROP(idx, sck_pin),			\
+		 .mosi_pin  = DT_PROP_OR(SPIM(idx), mosi_pin,		\
+					 NRFX_SPIM_PIN_NOT_USED),	\
+		 .miso_pin  = DT_PROP_OR(SPIM(idx), miso_pin,		\
+					 NRFX_SPIM_PIN_NOT_USED),	\
+		 .miso_pull = SPIM_NRFX_MISO_PULL(idx),))
+
 #define SPI_NRFX_SPIM_DEVICE(idx)					       \
-	BUILD_ASSERT(							       \
-		!SPIM_NRFX_MISO_PULL_UP(idx) || !SPIM_NRFX_MISO_PULL_DOWN(idx),\
+	NRF_DT_ENSURE_PINS_ASSIGNED(SPIM(idx), sck_pin);		       \
+	BUILD_ASSERT(IS_ENABLED(CONFIG_PINCTRL) ||			       \
+		     !(SPIM_PROP(idx, miso_pull_up) &&			       \
+		       SPIM_PROP(idx, miso_pull_down)),			       \
 		"SPIM"#idx						       \
 		": cannot enable both pull-up and pull-down on MISO line");    \
 	static int spi_##idx##_init(const struct device *dev)		       \
@@ -495,6 +528,14 @@ static int spim_nrfx_pm_action(const struct device *dev,
 		IRQ_CONNECT(NRFX_IRQ_NUMBER_GET(NRF_SPIM##idx),		       \
 			    DT_IRQ(SPIM(idx), priority),		       \
 			    nrfx_isr, nrfx_spim_##idx##_irq_handler, 0);       \
+		IF_ENABLED(CONFIG_PINCTRL, (				       \
+			const struct spi_nrfx_config *dev_config = dev->config;\
+			err = pinctrl_apply_state(dev_config->pcfg,	       \
+						  PINCTRL_STATE_DEFAULT);      \
+			if (err < 0) {					       \
+				return err;				       \
+			}						       \
+		))							       \
 		err = spi_context_cs_configure_all(&dev_data->ctx);	       \
 		if (err < 0) {						       \
 			return err;					       \
@@ -511,23 +552,23 @@ static int spim_nrfx_pm_action(const struct device *dev,
 		.dev  = DEVICE_DT_GET(SPIM(idx)),			       \
 		.busy = false,						       \
 	};								       \
+	IF_ENABLED(CONFIG_PINCTRL, (PINCTRL_DT_DEFINE(SPIM(idx))));	       \
 	static const struct spi_nrfx_config spi_##idx##z_config = {	       \
 		.spim = NRFX_SPIM_INSTANCE(idx),			       \
 		.max_chunk_len = (1 << SPIM##idx##_EASYDMA_MAXCNT_SIZE) - 1,   \
 		.max_freq = SPIM##idx##_MAX_DATARATE * 1000000,		       \
 		.def_config = {						       \
-			.sck_pin   = SPIM_PROP(idx, sck_pin),		       \
-			.mosi_pin  = SPIM_PROP(idx, mosi_pin),		       \
-			.miso_pin  = SPIM_PROP(idx, miso_pin),		       \
-			.ss_pin    = NRFX_SPIM_PIN_NOT_USED,		       \
-			.orc       = CONFIG_SPI_##idx##_NRF_ORC,	       \
-			.miso_pull = SPIM_NRFX_MISO_PULL(idx),		       \
+			SPI_NRFX_SPIM_PIN_CFG(idx)			       \
+			.ss_pin = NRFX_SPIM_PIN_NOT_USED,		       \
+			.orc    = CONFIG_SPI_##idx##_NRF_ORC,		       \
 			SPI_NRFX_SPIM_EXTENDED_CONFIG(idx)		       \
 		},							       \
 		COND_CODE_1(CONFIG_SOC_NRF52832_ALLOW_SPIM_DESPITE_PAN_58,     \
 			(.anomaly_58_workaround =			       \
 				SPIM_PROP(idx, anomaly_58_workaround),),       \
 			())						       \
+		IF_ENABLED(CONFIG_PINCTRL,				       \
+			(.pcfg = PINCTRL_DT_DEV_CONFIG_GET(SPIM(idx)),))       \
 	};								       \
 	PM_DEVICE_DT_DEFINE(SPIM(idx), spim_nrfx_pm_action);		       \
 	DEVICE_DT_DEFINE(SPIM(idx),					       \

--- a/drivers/spi/spi_nrfx_spis.c
+++ b/drivers/spi/spi_nrfx_spis.c
@@ -5,6 +5,8 @@
  */
 
 #include <drivers/spi.h>
+#include <drivers/pinctrl.h>
+#include <soc.h>
 #include <nrfx_spis.h>
 
 #include <logging/log.h>
@@ -19,6 +21,9 @@ struct spi_nrfx_data {
 struct spi_nrfx_config {
 	nrfx_spis_t spis;
 	size_t      max_buf_len;
+#ifdef CONFIG_PINCTRL
+	const struct pinctrl_dev_config *pcfg;
+#endif
 };
 
 static inline nrf_spis_mode_t get_nrf_spis_mode(uint16_t operation)
@@ -208,7 +213,6 @@ static const struct spi_driver_api spi_nrfx_driver_api = {
 	.release = spi_nrfx_release,
 };
 
-
 static void event_handler(const nrfx_spis_evt_t *p_event, void *p_context)
 {
 	struct spi_nrfx_data *dev_data = p_context;
@@ -251,32 +255,52 @@ static int init_spis(const struct device *dev,
 #define SPIS(idx) DT_NODELABEL(spi##idx)
 #define SPIS_PROP(idx, prop) DT_PROP(SPIS(idx), prop)
 
+#define SPI_NRFX_SPIS_PIN_CFG(idx)					\
+	COND_CODE_1(CONFIG_PINCTRL,					\
+		(.skip_gpio_cfg = true,					\
+		 .skip_psel_cfg = true,),				\
+		(.sck_pin    = SPIS_PROP(idx, sck_pin),			\
+		 .mosi_pin   = DT_PROP_OR(SPIS(idx), mosi_pin,		\
+					  NRFX_SPIS_PIN_NOT_USED),	\
+		 .miso_pin   = DT_PROP_OR(SPIS(idx), miso_pin,		\
+					  NRFX_SPIS_PIN_NOT_USED),	\
+		 .csn_pin    = SPIS_PROP(idx, csn_pin),			\
+		 .csn_pullup = NRF_GPIO_PIN_NOPULL,			\
+		 .miso_drive = NRF_GPIO_PIN_S0S1,))
+
 #define SPI_NRFX_SPIS_DEVICE(idx)					       \
+	NRF_DT_ENSURE_PINS_ASSIGNED(SPIS(idx), sck_pin);		       \
 	static int spi_##idx##_init(const struct device *dev)		       \
 	{								       \
 		IRQ_CONNECT(DT_IRQN(SPIS(idx)), DT_IRQ(SPIS(idx), priority),   \
 			    nrfx_isr, nrfx_spis_##idx##_irq_handler, 0);       \
 		const nrfx_spis_config_t config = {			       \
-			.sck_pin    = SPIS_PROP(idx, sck_pin),		       \
-			.mosi_pin   = SPIS_PROP(idx, mosi_pin),		       \
-			.miso_pin   = SPIS_PROP(idx, miso_pin),		       \
-			.csn_pin    = SPIS_PROP(idx, csn_pin),		       \
-			.mode       = NRF_SPIS_MODE_0,			       \
-			.bit_order  = NRF_SPIS_BIT_ORDER_MSB_FIRST,	       \
-			.csn_pullup = NRF_GPIO_PIN_NOPULL,		       \
-			.miso_drive = NRF_GPIO_PIN_S0S1,		       \
-			.orc        = CONFIG_SPI_##idx##_NRF_ORC,	       \
-			.def        = SPIS_PROP(idx, def_char),		       \
+			SPI_NRFX_SPIS_PIN_CFG(idx)			       \
+			.mode      = NRF_SPIS_MODE_0,			       \
+			.bit_order = NRF_SPIS_BIT_ORDER_MSB_FIRST,	       \
+			.orc       = CONFIG_SPI_##idx##_NRF_ORC,	       \
+			.def       = SPIS_PROP(idx, def_char),		       \
 		};							       \
+		IF_ENABLED(CONFIG_PINCTRL, (				       \
+			const struct spi_nrfx_config *dev_config = dev->config;\
+			int err = pinctrl_apply_state(dev_config->pcfg,	       \
+						      PINCTRL_STATE_DEFAULT);  \
+			if (err < 0) {					       \
+				return err;				       \
+			}						       \
+		))							       \
 		return init_spis(dev, &config);				       \
 	}								       \
 	static struct spi_nrfx_data spi_##idx##_data = {		       \
 		SPI_CONTEXT_INIT_LOCK(spi_##idx##_data, ctx),		       \
 		SPI_CONTEXT_INIT_SYNC(spi_##idx##_data, ctx),		       \
 	};								       \
+	IF_ENABLED(CONFIG_PINCTRL, (PINCTRL_DT_DEFINE(SPIS(idx))));	       \
 	static const struct spi_nrfx_config spi_##idx##z_config = {	       \
 		.spis = NRFX_SPIS_INSTANCE(idx),			       \
 		.max_buf_len = BIT_MASK(SPIS##idx##_EASYDMA_MAXCNT_SIZE),      \
+		IF_ENABLED(CONFIG_PINCTRL,				       \
+			(.pcfg = PINCTRL_DT_DEV_CONFIG_GET(SPIS(idx)),))       \
 	};								       \
 	DEVICE_DT_DEFINE(SPIS(idx),					       \
 			    spi_##idx##_init,				       \

--- a/drivers/spi/spi_nrfx_spis.c
+++ b/drivers/spi/spi_nrfx_spis.c
@@ -7,10 +7,8 @@
 #include <drivers/spi.h>
 #include <nrfx_spis.h>
 
-#define LOG_DOMAIN "spi_nrfx_spis"
-#define LOG_LEVEL CONFIG_SPI_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(spi_nrfx_spis);
+LOG_MODULE_REGISTER(spi_nrfx_spis, CONFIG_SPI_LOG_LEVEL);
 
 #include "spi_context.h"
 
@@ -52,9 +50,9 @@ static inline nrf_spis_bit_order_t get_nrf_spis_bit_order(uint16_t operation)
 static int configure(const struct device *dev,
 		     const struct spi_config *spi_cfg)
 {
-	const struct spi_nrfx_config *config = dev->config;
-	struct spi_nrfx_data *data = dev->data;
-	struct spi_context *ctx = &data->ctx;
+	const struct spi_nrfx_config *dev_config = dev->config;
+	struct spi_nrfx_data *dev_data = dev->data;
+	struct spi_context *ctx = &dev_data->ctx;
 
 	if (spi_context_configured(ctx, spi_cfg)) {
 		/* Already configured. No need to do it again. */
@@ -94,7 +92,7 @@ static int configure(const struct device *dev,
 
 	ctx->config = spi_cfg;
 
-	nrf_spis_configure(config->spis.p_reg,
+	nrf_spis_configure(dev_config->spis.p_reg,
 			   get_nrf_spis_mode(spi_cfg->operation),
 			   get_nrf_spis_bit_order(spi_cfg->operation));
 

--- a/dts/bindings/i2c/nordic,nrf-twi-common.yaml
+++ b/dts/bindings/i2c/nordic,nrf-twi-common.yaml
@@ -4,7 +4,7 @@
 
 # Common fields for Nordic nRF family TWI peripherals
 
-include: i2c-controller.yaml
+include: [i2c-controller.yaml, pinctrl-device.yaml]
 
 properties:
     reg:
@@ -15,8 +15,11 @@ properties:
 
     sda-pin:
       type: int
-      required: true
+      required: false
       description: |
+        IMPORTANT: This option will only be used if the new pin control driver
+        is not enabled. It will be deprecated in the future.
+
         The SDA pin to use.
 
         For pins P0.0 through P0.31, use the pin number. For example,
@@ -31,7 +34,10 @@ properties:
 
     scl-pin:
       type: int
-      required: true
+      required: false
       description: |
+        IMPORTANT: This option will only be used if the new pin control driver
+        is not enabled. It will be deprecated in the future.
+
         The SCL pin to use. The pin numbering scheme is the same as
         the sda-pin property's.

--- a/dts/bindings/spi/nordic,nrf-spi-common.yaml
+++ b/dts/bindings/spi/nordic,nrf-spi-common.yaml
@@ -3,7 +3,7 @@
 
 # Common fields for Nordic nRF family SPI peripherals
 
-include: spi-controller.yaml
+include: [spi-controller.yaml, pinctrl-device.yaml]
 
 properties:
     reg:
@@ -14,8 +14,11 @@ properties:
 
     sck-pin:
       type: int
-      required: true
+      required: false
       description: |
+        IMPORTANT: This option will only be used if the new pin control driver
+        is not enabled. It will be deprecated in the future.
+
         The SCK pin to use.
 
         For pins P0.0 through P0.31, use the pin number. For example,
@@ -30,14 +33,20 @@ properties:
 
     mosi-pin:
       type: int
-      required: true
+      required: false
       description: |
+        IMPORTANT: This option will only be used if the new pin control driver
+        is not enabled. It will be deprecated in the future.
+
         The MOSI pin to use. The pin numbering scheme is the same as
         the sck-pin property's.
 
     miso-pin:
       type: int
-      required: true
+      required: false
       description: |
+        IMPORTANT: This option will only be used if the new pin control driver
+        is not enabled. It will be deprecated in the future.
+
         The MISO pin to use. The pin numbering scheme is the same as
         the sck-pin property's.

--- a/dts/bindings/spi/nordic,nrf-spis.yaml
+++ b/dts/bindings/spi/nordic,nrf-spis.yaml
@@ -10,10 +10,13 @@ include: nordic,nrf-spi-common.yaml
 properties:
     csn-pin:
       type: int
-      required: true
-      description:  |
-          The CSN pin to use. The pin numbering scheme is the same as
-          the sck-pin property's.
+      required: false
+      description: |
+        IMPORTANT: This option will only be used if the new pin control driver
+        is not enabled. It will be deprecated in the future.
+
+        The CSN pin to use. The pin numbering scheme is the same as
+        the sck-pin property's.
 
     def-char:
       type: int

--- a/include/dt-bindings/pinctrl/nrf-pinctrl.h
+++ b/include/dt-bindings/pinctrl/nrf-pinctrl.h
@@ -59,6 +59,24 @@
 #define NRF_FUN_UART_RTS 2U
 /** UART CTS */
 #define NRF_FUN_UART_CTS 3U
+/** SPI master SCK */
+#define NRF_FUN_SPIM_SCK 4U
+/** SPI master MOSI */
+#define NRF_FUN_SPIM_MOSI 5U
+/** SPI master MISO */
+#define NRF_FUN_SPIM_MISO 6U
+/** SPI slave SCK */
+#define NRF_FUN_SPIS_SCK 7U
+/** SPI slave MOSI */
+#define NRF_FUN_SPIS_MOSI 8U
+/** SPI slave MISO */
+#define NRF_FUN_SPIS_MISO 9U
+/** SPI slave CSN */
+#define NRF_FUN_SPIS_CSN 10U
+/** TWI master SCL */
+#define NRF_FUN_TWIM_SCL 11U
+/** TWI master SDA */
+#define NRF_FUN_TWIM_SDA 12U
 
 /** @} */
 

--- a/samples/boards/nrf/dynamic_pinctrl/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/boards/nrf/dynamic_pinctrl/boards/nrf52840dk_nrf52840.overlay
@@ -17,6 +17,12 @@
 	pinctrl-names = "default", "sleep";
 };
 
+/* Disable uart1 so that it is not left without any pins assigned. */
+/* TODO: remove once all boards enable pinctrl by default */
+&uart1 {
+	status = "disabled";
+};
+
 &pinctrl {
 	/* pin configuration for UART0 */
 	/* TODO: move to board dts once all boards enable pinctrl by default */

--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -4726,6 +4726,13 @@ sub process {
 						$ok = 1;
 					}
 
+					# some macros require a separator
+					# argument to be in parentheses,
+					# e.g. (||).
+					if ($ca =~ /\($/ || $cc =~ /^\)/) {
+						$ok = 1;
+					}
+
 					# messages are ERROR, but ?: are CHK
 					if ($ok == 0) {
 						my $msg_level = \&ERROR;

--- a/soc/arm/nordic_nrf/common/soc_nrf_common.h
+++ b/soc/arm/nordic_nrf/common/soc_nrf_common.h
@@ -179,6 +179,42 @@
 				  "NRF_DT_CHECK_GPIO_CTLR_IS_SOC: OK")))
 /* Note: allow a trailing ";" either way */
 
+/**
+ * @brief Helper macro for NRF_DT_ENSURE_PINS_ASSIGNED
+ *
+ * This macro is neeeded only because the order of parameters taken by
+ * DT_NODE_HAS_PROP is different than that required for a macro to be
+ * invoked by FOR_EACH_FIXED_ARG.
+ *
+ * @param prop lowercase-and-underscores property name
+ * @param node_id node identifier
+ * @return 1 if the node has the property, 0 otherwise.
+ */
+#define NRF_DT_ENSURE_NODE_HAS_PROP(prop, node_id) \
+	DT_NODE_HAS_PROP(node_id, prop)
+
+/**
+ * Error out the build if PINCTRL is enabled and the specified node does not
+ * have the required pinctrl-N properties defined (pinctrl-0 always, pinctrl-1
+ * when PM_DEVICE is enabled) or if PINCTRL is not enabled and the node does
+ * not have at least one of the specified legacy pin properties defined.
+ *
+ * @param node_id node identifier
+ * @param ... list of lowercase-and-underscores legacy pin properties from
+ *            which at least one needs to be defined if PINCTRL is not enabled
+ */
+#define NRF_DT_ENSURE_PINS_ASSIGNED(node_id, ...)			\
+	BUILD_ASSERT((IS_ENABLED(CONFIG_PINCTRL) &&			\
+		      DT_PINCTRL_HAS_IDX(node_id, 0) &&			\
+		      (DT_PINCTRL_HAS_IDX(node_id, 1) ||		\
+		       !IS_ENABLED(CONFIG_PM_DEVICE)))			\
+		     ||							\
+		     (!IS_ENABLED(CONFIG_PINCTRL) &&			\
+		      (FOR_EACH_FIXED_ARG(NRF_DT_ENSURE_NODE_HAS_PROP,	\
+					  (||), node_id, __VA_ARGS__))),\
+		DT_NODE_PATH(node_id)					\
+			" defined without required pin configuration")
+
 #endif /* !_ASMLANGUAGE */
 
 #endif


### PR DESCRIPTION
Add support for the new pinctrl API to the SPI and I2C drivers that handle the following nRF peripherals: SPI, SPIM, SPIS, TWI, and TWIM.
Add also build assertions in the nRF UART drivers that will ensure that every peripheral for which a driver instance is created has some pins assigned to it.