### PR TITLE
Add GPIO ports for NXP MXRT685 FOWLP249 package

### DIFF
--- a/dts/arm/nxp/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx_common.dtsi
@@ -116,6 +116,32 @@
 		port = <2>;
 	};
 
+	gpio3: gpio@3 {
+		compatible = "nxp,lpc-gpio";
+		reg = <0x100000 0x1000>;
+		label = "GPIO_3";
+		gpio-controller;
+		#gpio-cells = <2>;
+		port = <3>;
+	};
+
+	gpio4: gpio@4 {
+		compatible = "nxp,lpc-gpio";
+		reg = <0x100000 0x1000>;
+		label = "GPIO_4";
+		gpio-controller;
+		#gpio-cells = <2>;
+		port = <4>;
+	};
+
+	gpio7: gpio@7 {
+		compatible = "nxp,lpc-gpio";
+		reg = <0x100000 0x1000>;
+		label = "GPIO_7";
+		gpio-controller;
+		#gpio-cells = <2>;
+		port = <7>;
+	};
 
 	flexcomm0: flexcomm@106000 {
 		compatible = "nxp,lpc-flexcomm";

--- a/dts/bindings/gpio/nxp,lpc-gpio.yaml
+++ b/dts/bindings/gpio/nxp,lpc-gpio.yaml
@@ -29,6 +29,7 @@ properties:
         - 4
         - 5
         - 6
+        - 7
 
 gpio-cells:
   - pin


### PR DESCRIPTION
Add support for GPIO ports 3, 4 and 7 of FOWLP249 (249-pin) package variant of MXRT685 (MIMXRT685SFFOB).