### PR TITLE
Release notes: add entry for change to bt_l2cap_chan_state

### DIFF
--- a/doc/releases/release-notes-3.1.rst
+++ b/doc/releases/release-notes-3.1.rst
@@ -30,6 +30,15 @@ Deprecated in this release
 Stable API changes in this release
 ==================================
 
+Bluetooth
+*********
+
+* Host
+
+  * The enum bt_l2cap_chan_state values BT_L2CAP_CONNECT and BT_L2CAP_DISCONNECT
+    has been renamed to BT_L2CAP_CONNECTING and BT_L2CAP_DISCONNECTING.
+
+
 New APIs in this release
 ========================
 


### PR DESCRIPTION
Add for the BT stable API change. 