### PR TITLE
dts: Add zephyr,memory-region compatible for MXRT5xx and MXRT6xx

### DIFF
--- a/dts/arm/nxp/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt5xx_common.dtsi
@@ -44,10 +44,10 @@
 	};
 
 	sram1: memory@40140000 {
-		compatible = "mmio-sram";
+		compatible =  "zephyr,memory-region", "mmio-sram";
 		reg = <0x40140000 DT_SIZE_K(16)>;
+		zephyr,memory-region = "SRAM1";
 	};
-
 };
 
 &systick {

--- a/dts/arm/nxp/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx_common.dtsi
@@ -44,10 +44,10 @@
 	};
 
 	sram1: memory@40140000 {
-		compatible = "mmio-sram";
+		compatible =  "zephyr,memory-region", "mmio-sram";
 		reg = <0x40140000 DT_SIZE_K(16)>;
+		zephyr,memory-region = "SRAM1";
 	};
-
 };
 
 &systick {


### PR DESCRIPTION
Add zephyr,memory-region compatible to SRAM1 nodes. These memory
regions are dedicated to the USB device controller for USB descriptors.

Fixes #43090