### PR TITLE
scripts: enforce module name uniqueness

### DIFF
--- a/cmake/modules/zephyr_module.cmake
+++ b/cmake/modules/zephyr_module.cmake
@@ -146,7 +146,3 @@ else()
     )
 
 endif()
-
-if(DEFINED ZEPHYR_MODULE_NAMES)
-  list(REMOVE_DUPLICATES ZEPHYR_MODULE_NAMES)
-endif()


### PR DESCRIPTION
Although CMake scripts already support duplicated module names (by using ZEPHYR_${MODULE_NAME}_MODULE_DIR CMake variables and applying `list(REMOVE_DUPLICATES ZEPHYR_MODULE_NAMES)` in a different place), if two modules with the same name provide different Kconfig files, then both files will be loaded leading to potential conflicts.

Modify zephyr_module.py to enforce that all modules are uniquely named so that it is possible to override some of the built-in modules using ZEPHYR_EXTRA_MODULES variable.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>