### PR TITLE
dts: rt11xx: add missing GPIO7, GPIO8, GPIO12

### DIFF
--- a/dts/arm/nxp/nxp_rt1160_cm4.dtsi
+++ b/dts/arm/nxp/nxp_rt1160_cm4.dtsi
@@ -83,18 +83,32 @@
 			nxp,rx-dma-channel = <8>;
 		};
 	};
-
 };
 
-
-&gpio9 {
-	interrupts = <99 0>;
+&gpio1 {
+	interrupts = <100 0>, <101 0>;
 };
 
-&gpio11 {
-	/* GPIO 7-11 share the same interrupt on the CM4 */
-	interrupts = <99 0>;
-	status = "disabled";
+&gpio4 {
+	interrupts = <106 0>, <107 0>;
+};
+
+&gpio5 {
+	interrupts = <108 0>, <109 0>;
+};
+
+/*
+ * GPIO 7-11 share the same interrupt on the CM4.
+ * the gpio driver only supports one of these gpio devices having an interrupt
+ * populated.
+ */
+
+&gpio12 {
+	interrupts = <61 0>, <62 0>;
+};
+
+&gpio13 {
+	interrupts = <93 0>;
 };
 
 /* Set default power states for CM4 cpu */

--- a/dts/arm/nxp/nxp_rt1160_cm7.dtsi
+++ b/dts/arm/nxp/nxp_rt1160_cm7.dtsi
@@ -93,8 +93,24 @@
 	};
 };
 
+&gpio1 {
+	interrupts = <100 0>, <101 0>;
+};
+
+&gpio4 {
+	interrupts = <106 0>, <107 0>;
+};
+
+&gpio5 {
+	interrupts = <108 0>, <109 0>;
+};
+
 &gpio6 {
 	interrupts = <61 0>, <62 0>;
+};
+
+&gpio13 {
+	interrupts = <93 0>;
 };
 
 /* Set default power states for CM7 cpu */

--- a/dts/arm/nxp/nxp_rt1170_cm4.dtsi
+++ b/dts/arm/nxp/nxp_rt1170_cm4.dtsi
@@ -85,14 +85,30 @@
 	};
 };
 
-&gpio9 {
-	interrupts = <99 0>;
+&gpio1 {
+	interrupts = <100 0>, <101 0>;
 };
 
-&gpio11 {
-	/* GPIO 7-11 share the same interrupt on the CM4 */
-	interrupts = <99 0>;
-	status = "disabled";
+&gpio4 {
+	interrupts = <106 0>, <107 0>;
+};
+
+&gpio5 {
+	interrupts = <108 0>, <109 0>;
+};
+
+/*
+ * GPIO 7-11 share the same interrupt on the CM4.
+ * the gpio driver only supports one of these gpio devices having an interrupt
+ * populated.
+ */
+
+&gpio12 {
+	interrupts = <61 0>, <62 0>;
+};
+
+&gpio13 {
+	interrupts = <93 0>;
 };
 
 /* Set default power states for CM4 cpu */

--- a/dts/arm/nxp/nxp_rt1170_cm7.dtsi
+++ b/dts/arm/nxp/nxp_rt1170_cm7.dtsi
@@ -93,8 +93,24 @@
 	};
 };
 
+&gpio1 {
+	interrupts = <100 0>, <101 0>;
+};
+
+&gpio4 {
+	interrupts = <106 0>, <107 0>;
+};
+
+&gpio5 {
+	interrupts = <108 0>, <109 0>;
+};
+
 &gpio6 {
 	interrupts = <61 0>, <62 0>;
+};
+
+&gpio13 {
+	interrupts = <93 0>;
 };
 
 /* Set default power states for CM7 cpu */

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -213,6 +213,22 @@
 			#gpio-cells = <2>;
 		};
 
+		gpio7: gpio@40C5C000 {
+			compatible = "nxp,imx-gpio";
+			reg = <0x40C5C000 0x4000>;
+			label = "GPIO_7";
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		gpio8: gpio@40C60000 {
+			compatible = "nxp,imx-gpio";
+			reg = <0x40C60000 0x4000>;
+			label = "GPIO_8";
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
 		gpio9: gpio@40c64000 {
 			compatible = "nxp,imx-gpio";
 			reg = <0x40c64000 0x4000>;
@@ -233,6 +249,14 @@
 			compatible = "nxp,imx-gpio";
 			reg = <0x40c6c000 0x4000>;
 			label = "GPIO_11";
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		gpio12: gpio@40C70000 {
+			compatible = "nxp,imx-gpio";
+			reg = <0x40C70000 0x4000>;
+			label = "GPIO_12";
 			gpio-controller;
 			#gpio-cells = <2>;
 		};


### PR DESCRIPTION
added missing GPIO peripherals to devicetree

resolves #43292 