### PR TITLE
intel_adsp: Use gpdma for all cAVS variants

### DIFF
--- a/boards/xtensa/intel_adsp_cavs15/Kconfig.defconfig
+++ b/boards/xtensa/intel_adsp_cavs15/Kconfig.defconfig
@@ -35,7 +35,7 @@ config 2ND_LVL_ISR_TBL_OFFSET
 config CAVS_ISR_TBL_OFFSET
 	default 2ND_LVL_ISR_TBL_OFFSET
 
-config DMA_DW
+config DMA_CAVS_GPDMA
 	default y
 	depends on DMA
 

--- a/boards/xtensa/intel_adsp_cavs18/Kconfig.defconfig
+++ b/boards/xtensa/intel_adsp_cavs18/Kconfig.defconfig
@@ -35,7 +35,7 @@ config 2ND_LVL_ISR_TBL_OFFSET
 config CAVS_ISR_TBL_OFFSET
 	default 2ND_LVL_ISR_TBL_OFFSET
 
-config DMA_DW
+config DMA_CAVS_GPDMA
 	default y
 	depends on DMA
 

--- a/boards/xtensa/intel_adsp_cavs20/Kconfig.defconfig
+++ b/boards/xtensa/intel_adsp_cavs20/Kconfig.defconfig
@@ -35,7 +35,7 @@ config 2ND_LVL_ISR_TBL_OFFSET
 config CAVS_ISR_TBL_OFFSET
 	default 2ND_LVL_ISR_TBL_OFFSET
 
-config DMA_DW
+config DMA_CAVS_GPDMA
 	default y
 	depends on DMA
 

--- a/dts/xtensa/intel/intel_cavs15.dtsi
+++ b/dts/xtensa/intel/intel_cavs15.dtsi
@@ -101,5 +101,29 @@
 			interrupts = <8 0 0>;
 			interrupt-parent = <&cavs0>;
 		};
+
+		lpgpdma0: dma@7c000 {
+			compatible = "intel,cavs-gpdma";
+			#dma-cells = <1>;
+			reg = <0x0007c000 0x1000>;
+			shim = <0x00078400 0x100>;
+			interrupts = <0x10 0 0>;
+			interrupt-parent = <&cavs3>;
+			label = "DMA_0";
+
+			status = "okay";
+		};
+
+		lpgpdma1: dma@7d000 {
+			compatible = "intel,cavs-gpdma";
+			#dma-cells = <1>;
+			reg = <0x0007d000 0x1000>;
+			shim = <0x00078500 0x100>;
+			interrupts = <0x0F 0 0>;
+			interrupt-parent = <&cavs3>;
+			label = "DMA_1";
+
+			status = "okay";
+		};
 	};
 };

--- a/dts/xtensa/intel/intel_cavs18.dtsi
+++ b/dts/xtensa/intel/intel_cavs18.dtsi
@@ -120,5 +120,29 @@
 			interrupts = <8 0 0>;
 			interrupt-parent = <&cavs0>;
 		};
+
+		lpgpdma0: dma@7c000 {
+			compatible = "intel,cavs-gpdma";
+			#dma-cells = <1>;
+			reg = <0x0007c000 0x1000>;
+			shim = <0x00078400 0x100>;
+			interrupts = <0x10 0 0>;
+			interrupt-parent = <&cavs3>;
+			label = "DMA_0";
+
+			status = "okay";
+		};
+
+		lpgpdma1: dma@7d000 {
+			compatible = "intel,cavs-gpdma";
+			#dma-cells = <1>;
+			reg = <0x0007d000 0x1000>;
+			shim = <0x00078500 0x100>;
+			interrupts = <0x0F 0 0>;
+			interrupt-parent = <&cavs3>;
+			label = "DMA_1";
+
+			status = "okay";
+		};
 	};
 };

--- a/dts/xtensa/intel/intel_cavs20.dtsi
+++ b/dts/xtensa/intel/intel_cavs20.dtsi
@@ -120,5 +120,29 @@
 			interrupts = <8 0 0>;
 			interrupt-parent = <&cavs0>;
 		};
+
+		lpgpdma0: dma@7c000 {
+			compatible = "intel,cavs-gpdma";
+			#dma-cells = <1>;
+			reg = <0x0007c000 0x1000>;
+			shim = <0x00078400 0x100>;
+			interrupts = <0x10 0 0>;
+			interrupt-parent = <&cavs3>;
+			label = "DMA_0";
+
+			status = "okay";
+		};
+
+		lpgpdma1: dma@7d000 {
+			compatible = "intel,cavs-gpdma";
+			#dma-cells = <1>;
+			reg = <0x0007d000 0x1000>;
+			shim = <0x00078500 0x100>;
+			interrupts = <0x0F 0 0>;
+			interrupt-parent = <&cavs3>;
+			label = "DMA_1";
+
+			status = "okay";
+		};
 	};
 };


### PR DESCRIPTION
Previous Kconfig designated designware dma but did not define
the node in device tree. This caused warning when building tests.
The warnings caused CI to fail.

Really though the devices do all depend on the gpdma derivative and not
the generic DesignWare driver.

Signed-off-by: Tom Burdick <thomas.burdick@intel.com>