### PR TITLE
Bluetooth: Mesh: Add tinycrypt ecc for device provision

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -35,6 +35,13 @@ config BT_MESH_PROV_OOB_PUBLIC_KEY
 	help
 	  Enable this option if public key is to be exchanged via Out of Band (OOB) technology.
 
+config BT_MESH_PROV_USE_TINYCRYPT_ECC_DH
+	bool "Use Tinycrypt ECC for device provision"
+	select TINYCRYPT_ECC_DH
+	depends on BT_MESH_PROV_DEVICE
+	help
+	  Enable this option if use tinycrypt ecc dhkey for mesh provision.
+
 config BT_MESH_PB_ADV
 	bool "Provisioning support using the advertising bearer (PB-ADV)"
 	select BT_MESH_PROV

--- a/subsys/bluetooth/mesh/prov.c
+++ b/subsys/bluetooth/mesh/prov.c
@@ -38,23 +38,9 @@ const struct bt_mesh_prov *bt_mesh_prov;
 BUILD_ASSERT(sizeof(bt_mesh_prov_link.conf_inputs) == 145,
 	     "Confirmation inputs shall be 145 bytes");
 
-static void pub_key_ready(const uint8_t *pkey)
+int bt_mesh_prov_reset_state(void)
 {
-	if (!pkey) {
-		BT_WARN("Public key not available");
-		return;
-	}
-
-	BT_DBG("Local public key ready");
-}
-
-int bt_mesh_prov_reset_state(void (*func)(const uint8_t key[BT_PUB_KEY_LEN]))
-{
-	int err;
-	static struct bt_pub_key_cb pub_key_cb;
 	const size_t offset = offsetof(struct bt_mesh_prov_link, auth);
-
-	pub_key_cb.func = func ? func : pub_key_ready;
 
 	/* Disable Attention Timer if it was set */
 	if (bt_mesh_prov_link.conf_inputs.invite[0]) {
@@ -65,11 +51,22 @@ int bt_mesh_prov_reset_state(void (*func)(const uint8_t key[BT_PUB_KEY_LEN]))
 	(void)memset((uint8_t *)&bt_mesh_prov_link + offset, 0,
 		     sizeof(bt_mesh_prov_link) - offset);
 
+	return 0;
+}
+
+int bt_mesh_prov_pub_key_gen(void (*func)(const uint8_t key[BT_PUB_KEY_LEN]))
+{
+	int err;
+	static struct bt_pub_key_cb pub_key_cb;
+
+	pub_key_cb.func = func;
+
 	err = bt_pub_key_gen(&pub_key_cb);
 	if (err) {
 		BT_ERR("Failed to generate public key (%d)", err);
 		return err;
 	}
+
 	return 0;
 }
 
@@ -438,7 +435,7 @@ void bt_mesh_prov_reset(void)
 		pb_gatt_reset();
 	}
 
-	bt_mesh_prov_reset_state(NULL);
+	bt_mesh_prov_reset_state();
 
 	if (bt_mesh_prov->reset) {
 		bt_mesh_prov->reset();
@@ -462,5 +459,5 @@ int bt_mesh_prov_init(const struct bt_mesh_prov *prov_info)
 		pb_gatt_init();
 	}
 
-	return bt_mesh_prov_reset_state(NULL);
+	return bt_mesh_prov_reset_state();
 }

--- a/subsys/bluetooth/mesh/prov.h
+++ b/subsys/bluetooth/mesh/prov.h
@@ -149,7 +149,8 @@ static inline void bt_mesh_prov_buf_init(struct net_buf_simple *buf, uint8_t typ
 	net_buf_simple_add_u8(buf, type);
 }
 
-int bt_mesh_prov_reset_state(void (*func)(const uint8_t key[BT_PUB_KEY_LEN]));
+int bt_mesh_prov_reset_state(void);
+int bt_mesh_prov_pub_key_gen(void (*func)(const uint8_t key[BT_PUB_KEY_LEN]));
 
 bool bt_mesh_prov_active(void);
 

--- a/subsys/bluetooth/mesh/provisioner.c
+++ b/subsys/bluetooth/mesh/provisioner.c
@@ -55,7 +55,7 @@ static int reset_state(void)
 		bt_mesh_cdb_node_del(prov_device.node, false);
 	}
 
-	return bt_mesh_prov_reset_state(pub_key_ready);
+	return bt_mesh_prov_reset_state();
 }
 
 static void prov_link_close(enum prov_bearer_link_status status)
@@ -643,6 +643,11 @@ static void prov_link_closed(void)
 
 static void prov_link_opened(void)
 {
+	if (bt_mesh_prov_pub_key_gen(pub_key_ready)) {
+		prov_fail(PROV_ERR_UNEXP_ERR);
+		return;
+	}
+
 	send_invite();
 }
 


### PR DESCRIPTION
HCI ECC is used by default. Generally, if the controller does
not support ECC, the host needs to open a separate thread to
process it.

In this PR, try to generate by using tinycrypt ecc function
instead of relying on any task. This method is only applicable
to device provision.

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>