### PR TITLE
Bluetooth: Controller: Fix missing reset of sync create association

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -1449,7 +1449,7 @@ void ll_rx_mem_release(void **node_rx)
 				 */
 				sync = scan->periodic.sync;
 
-				ull_sync_setup_complete(scan);
+				ull_sync_setup_reset(scan);
 
 				if (status != BT_HCI_ERR_SUCCESS) {
 					memq_link_t *link_sync_lost;

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -296,7 +296,7 @@ uint8_t ll_sync_create_cancel(void **rx)
 	/* It is safe to remove association with scanner as cancelled flag is
 	 * set and sync has not been established.
 	 */
-	scan->periodic.sync = NULL;
+	ull_sync_setup_reset(scan);
 
 	/* Mark the sync context as sync create cancelled */
 	if (IS_ENABLED(CONFIG_BT_CTLR_CHECK_SAME_PEER_SYNC)) {
@@ -733,7 +733,7 @@ void ull_sync_setup(struct ll_scan_set *scan, struct ll_scan_aux_set *aux,
 		  (ret == TICKER_STATUS_BUSY));
 }
 
-void ull_sync_setup_complete(struct ll_scan_set *scan)
+void ull_sync_setup_reset(struct ll_scan_set *scan)
 {
 	/* Remove the sync context from being associated with scan contexts */
 	scan->periodic.sync = NULL;

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_internal.h
@@ -14,7 +14,7 @@ void ull_sync_setup_addr_check(struct ll_scan_set *scan, uint8_t addr_type,
 bool ull_sync_setup_sid_match(struct ll_scan_set *scan, uint8_t sid);
 void ull_sync_setup(struct ll_scan_set *scan, struct ll_scan_aux_set *aux,
 		    struct node_rx_hdr *node_rx, struct pdu_adv_sync_info *si);
-void ull_sync_setup_complete(struct ll_scan_set *scan);
+void ull_sync_setup_reset(struct ll_scan_set *scan);
 void ull_sync_established_report(memq_link_t *link, struct node_rx_hdr *rx);
 void ull_sync_done(struct node_rx_event_done *done);
 void ull_sync_chm_update(uint8_t sync_handle, uint8_t *acad, uint8_t acad_len);


### PR DESCRIPTION
Fix missing reset of sync create association with scan
context when associated with both 1M and Coded PHY contexts,
and sync create cancel is called.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>