### PR TITLE
MAINTAINERS: Add Bluetooth Audio section

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -183,13 +183,15 @@ Bluetooth:
         - subsys/bluetooth/host/
         - subsys/bluetooth/services/
         - subsys/bluetooth/shell/
-        - subsys/bluetooth/audio/
         - tests/bluetooth/
     files-exclude:
         - include/bluetooth/mesh/
         - subsys/bluetooth/controller/
         - subsys/bluetooth/mesh/
         - samples/bluetooth/mesh/
+        - subsys/bluetooth/audio/
+        - include/bluetooth/audio/
+        - tests/bluetooth/bsim_bt/bsim_test_audio/
     labels:
         - "area: Bluetooth"
 
@@ -225,6 +227,25 @@ Bluetooth Mesh:
         - tests/bluetooth/mesh*/
     labels:
         - "area: Bluetooth Mesh"
+        - "area: Bluetooth"
+
+Bluetooth Audio:
+    status: maintained
+    maintainers:
+        - Thalley
+        - asbjornsabo
+    collaborators:
+        - Vudentz
+        - jhedberg
+        - Casper-Bonde-Bose
+        - MariuszSkamra
+        - rymanluk
+    files:
+        - subsys/bluetooth/audio/
+        - include/bluetooth/audio/
+        - tests/bluetooth/bsim_bt/bsim_test_audio/
+    labels:
+        - "area: Bluetooth Audio"
         - "area: Bluetooth"
 
 Build system:


### PR DESCRIPTION
Add a Bluetooth Audio section in the maintainers
file for the Bluetooth Audio (sub)subsystem.

The Bluetooth Audio stack is a significant size, and
there's a signficant amount of people working on it,
where many do not have proper review rights and
many that do not get automatically assigned
for reviews.

I've included Vudentz as he has been very active in
the early days.

I've excluded szymon-czapracki as he has not yet
contributed a significant amount, even if he is
involved.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>