### PR TITLE
modules: hal_nordic: 802.15.4 CSMA-CA feature disabled by default

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -449,6 +449,7 @@ static bool nrf5_tx_immediate(struct net_pkt *pkt, uint8_t *payload, bool cca)
 	return nrf_802154_transmit_raw(payload, &metadata);
 }
 
+#if NRF_802154_CSMA_CA_ENABLED
 static bool nrf5_tx_csma_ca(struct net_pkt *pkt, uint8_t *payload)
 {
 	nrf_802154_transmit_csma_ca_metadata_t metadata = {
@@ -460,6 +461,7 @@ static bool nrf5_tx_csma_ca(struct net_pkt *pkt, uint8_t *payload)
 
 	return nrf_802154_transmit_csma_ca_raw(payload, &metadata);
 }
+#endif
 
 #if IS_ENABLED(CONFIG_NET_PKT_TXTIME)
 static bool nrf5_tx_at(struct net_pkt *pkt, uint8_t *payload, bool cca)
@@ -509,9 +511,11 @@ static int nrf5_tx(const struct device *dev,
 		ret = nrf5_tx_immediate(pkt, nrf5_radio->tx_psdu,
 					mode == IEEE802154_TX_MODE_CCA);
 		break;
+#if NRF_802154_CSMA_CA_ENABLED
 	case IEEE802154_TX_MODE_CSMA_CA:
 		ret = nrf5_tx_csma_ca(pkt, nrf5_radio->tx_psdu);
 		break;
+#endif
 #if IS_ENABLED(CONFIG_NET_PKT_TXTIME)
 	case IEEE802154_TX_MODE_TXTIME:
 	case IEEE802154_TX_MODE_TXTIME_CCA:

--- a/modules/hal_nordic/nrf_802154/CMakeLists.txt
+++ b/modules/hal_nordic/nrf_802154/CMakeLists.txt
@@ -67,8 +67,6 @@ target_compile_definitions(zephyr-802154-interface
     # Number of buffers in receive queue.
     NRF_802154_RX_BUFFERS=${CONFIG_NRF_802154_RX_BUFFERS}
 
-    # Enable CSMA/CA
-    NRF_802154_CSMA_CA_ENABLED=1
     NRF_802154_TX_STARTED_NOTIFY_ENABLED=1
 
     # ACK timeout


### PR DESCRIPTION
In an opensource version of nrf-802154 CSMA-CA is not supported yet. Instead of asserting if started CSMA-CA should not be available at all.