### PR TITLE
Zephyr CMake package handling / Zephyr_DIR cache variable

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -13,8 +13,13 @@
 # inside the Zephyr repository.
 #
 # Loading of this file directly is deprecated and only kept for backward compatibility.
-message(WARNING "Loading of Zephyr boilerplate.cmake directly is deprecated, "
-        "please use 'find_package(Zephyr)'"
-)
 
-find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+if(NOT DEFINED Zephyr_DIR)
+  # When `find_package(Zephyr)` is used then `Zephyr_DIR` is defined, else
+  # old style inclusion is used. Warning is only printed in first invocation.
+  message(WARNING "Loading of Zephyr boilerplate.cmake directly is deprecated, "
+          "please use 'find_package(Zephyr)'"
+  )
+endif()
+
+find_package(Zephyr REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../.. NO_DEFAULT_PATH)

--- a/share/zephyr-package/cmake/ZephyrConfig.cmake
+++ b/share/zephyr-package/cmake/ZephyrConfig.cmake
@@ -11,6 +11,9 @@
 # It will be empty if not set in environment.
 
 macro(include_boilerplate location)
+  set(Zephyr_DIR ${ZEPHYR_BASE}/share/zephyr-package/cmake CACHE PATH
+      "The directory containing a CMake configuration file for Zephyr." FORCE
+  )
   list(PREPEND CMAKE_MODULE_PATH ${ZEPHYR_BASE}/cmake/modules)
   if(ZEPHYR_UNITTEST)
     message(WARNING "The ZephyrUnittest CMake package has been deprecated.\n"

--- a/share/zephyr-package/cmake/zephyr_package_search.cmake
+++ b/share/zephyr-package/cmake/zephyr_package_search.cmake
@@ -9,6 +9,21 @@ set(WORKSPACE_RELATIVE_DIR "../../../../..")
 # Relative directory of Zephyr dir as seen from Zephyr package file
 set(ZEPHYR_RELATIVE_DIR "../../../..")
 
+# This function updates Zephyr_DIR to the point to the candidate dir.
+# For Zephyr 3.0 and earlier, the Zephyr_DIR might in some cases be
+# `Zephyr_DIR-NOTFOUND` or pointing to the Zephyr package including the
+# boilerplate code instead of the Zephyr package of the included boilerplate.
+# This code ensures that when Zephyr releases <=3.0 is loaded, then Zephyr_DIR
+# will point correctly, see also #43094 which relates to this.
+function(set_zephyr_dir zephyr_candidate)
+  get_filename_component(zephyr_candidate_dir "${zephyr_candidate}" DIRECTORY)
+  if(NOT "${zephyr_candidate_dir}" STREQUAL "${Zephyr_DIR}")
+    set(Zephyr_DIR ${zephyr_candidate_dir} CACHE PATH
+        "The directory containing a CMake configuration file for Zephyr." FORCE
+    )
+  endif()
+endfunction()
+
 # This macro returns a list of parent folders to use for later searches.
 macro(get_search_paths START_PATH SEARCH_PATHS PREFERENCE_LIST)
   get_filename_component(SEARCH_PATH ${START_PATH} DIRECTORY)
@@ -79,6 +94,7 @@ macro(check_zephyr_package)
           return()
         else()
           include(${ZEPHYR_CANDIDATE} NO_POLICY_SCOPE)
+          set_zephyr_dir(${ZEPHYR_CANDIDATE})
           return()
         endif()
     endif()
@@ -99,6 +115,7 @@ macro(check_zephyr_package)
           return()
 	else()
           include(${ZEPHYR_CANDIDATE} NO_POLICY_SCOPE)
+          set_zephyr_dir(${ZEPHYR_CANDIDATE})
 	  return()
         endif()
       endif()


### PR DESCRIPTION
Fixes: #43094

This PR improves the handling of Zephyr CMake package by ensuring the `Zephyr_DIR` CMake cache variables is set correctly when loading the Zephyr CMake package.

Furthermore it improves handling when loading Zephyr CMake package in systems where both latest Zephyr and Zephyr versions <= 3.0.0 are installed side by side.

Both when they are registered in the CMake package registry, as well as when only a single installation is registered.
