### PR TITLE
lorawan: make unconfirmed message type explicit

### DIFF
--- a/doc/releases/release-notes-3.1.rst
+++ b/doc/releases/release-notes-3.1.rst
@@ -19,6 +19,10 @@ API Changes
 Changes in this release
 =======================
 
+* LoRaWAN: The message type parameter in :c:func:`lorawan_send` was changed
+  from ``uint8_t`` to ``enum lorawan_message_type``. If ``0`` was passed for
+  unconfirmed message, this has to be changed to ``LORAWAN_MSG_UNCONFIRMED``.
+
 Removed APIs in this release
 ============================
 

--- a/include/lorawan/lorawan.h
+++ b/include/lorawan/lorawan.h
@@ -60,11 +60,10 @@ enum lorawan_datarate {
 
 /**
  * @brief LoRaWAN message types.
- *
- * Note: The default message type is unconfirmed.
  */
 enum lorawan_message_type {
-	LORAWAN_MSG_CONFIRMED = BIT(0),
+	LORAWAN_MSG_UNCONFIRMED = 0,
+	LORAWAN_MSG_CONFIRMED,
 };
 
 /**
@@ -202,13 +201,12 @@ int lorawan_start(void);
  * @param len        Length of the buffer to be sent. Maximum length of this
  *                   buffer is 255 bytes but the actual payload size varies with
  *                   region and datarate.
- * @param flags      Flag used to determine the type of message being sent. It
- *                   could be one of the lorawan_message_type. The default
- *                   behaviour is unconfirmed message.
+ * @param type       Specifies if the message shall be confirmed or unconfirmed.
+ *                   Must be one of @ref lorawan_message_type.
  *
  * @return 0 if successful, negative errno code if failure
  */
-int lorawan_send(uint8_t port, uint8_t *data, uint8_t len, uint8_t flags);
+int lorawan_send(uint8_t port, uint8_t *data, uint8_t len, enum lorawan_message_type type);
 
 /**
  * @brief Set the current device class

--- a/subsys/lorawan/lorawan.c
+++ b/subsys/lorawan/lorawan.c
@@ -448,7 +448,7 @@ int lorawan_set_conf_msg_tries(uint8_t tries)
 	return 0;
 }
 
-int lorawan_send(uint8_t port, uint8_t *data, uint8_t len, uint8_t flags)
+int lorawan_send(uint8_t port, uint8_t *data, uint8_t len, enum lorawan_message_type type)
 {
 	LoRaMacStatus_t status;
 	McpsReq_t mcpsReq;
@@ -480,20 +480,18 @@ int lorawan_send(uint8_t port, uint8_t *data, uint8_t len, uint8_t flags)
 		mcpsReq.Req.Unconfirmed.fBufferSize = 0;
 		mcpsReq.Req.Unconfirmed.Datarate = DR_0;
 	} else {
-		if (flags & LORAWAN_MSG_CONFIRMED) {
-			mcpsReq.Type = MCPS_CONFIRMED;
-			mcpsReq.Req.Confirmed.fPort = port;
-			mcpsReq.Req.Confirmed.fBuffer = data;
-			mcpsReq.Req.Confirmed.fBufferSize = len;
-			mcpsReq.Req.Confirmed.Datarate = current_datarate;
-		} else {
-			/* default message type */
+		switch (type) {
+		case LORAWAN_MSG_UNCONFIRMED:
 			mcpsReq.Type = MCPS_UNCONFIRMED;
-			mcpsReq.Req.Unconfirmed.fPort = port;
-			mcpsReq.Req.Unconfirmed.fBuffer = data;
-			mcpsReq.Req.Unconfirmed.fBufferSize = len;
-			mcpsReq.Req.Unconfirmed.Datarate = current_datarate;
+			break;
+		case LORAWAN_MSG_CONFIRMED:
+			mcpsReq.Type = MCPS_CONFIRMED;
+			break;
 		}
+		mcpsReq.Req.Unconfirmed.fPort = port;
+		mcpsReq.Req.Unconfirmed.fBuffer = data;
+		mcpsReq.Req.Unconfirmed.fBufferSize = len;
+		mcpsReq.Req.Unconfirmed.Datarate = current_datarate;
 	}
 
 	status = LoRaMacMcpsRequest(&mcpsReq);


### PR DESCRIPTION
The enum did not contain an entry for unconfirmed messages. Instead, it was only mentioned in the comment that 0 is the default for unconfirmed messages.

This PR adds `LORAWAN_MSG_UNCONFIRMED` to the enum and clarifies some comments in the documentation.