### PR TITLE
doc: Add LoRa and LoRaWAN sections

### DIFF
--- a/doc/reference/api/overview.rst
+++ b/doc/reference/api/overview.rst
@@ -197,6 +197,16 @@ current :ref:`stability level <api_lifecycle>`.
      - 1.13
      - 1.14
 
+   * - :ref:`lora_api`
+     - Experimental
+     - 2.2
+     - 2.2
+
+   * - :ref:`lorawan_api`
+     - Experimental
+     - 2.5
+     - 2.5
+
    * - :ref:`mqtt_socket_interface`
      - Unstable
      - 1.14

--- a/doc/reference/index.rst
+++ b/doc/reference/index.rst
@@ -26,6 +26,7 @@ API Reference
    memory_management/index.rst
    misc/index
    data_structures/index.rst
+   lora_lorawan/index.rst
    modbus/index.rst
    networking/index.rst
    peripherals/index.rst

--- a/doc/reference/lora_lorawan/index.rst
+++ b/doc/reference/lora_lorawan/index.rst
@@ -1,0 +1,92 @@
+.. _lora_api:
+.. _lorawan_api:
+
+LoRa and LoRaWAN
+################
+
+Overview
+********
+
+LoRa (abbrev. for Long Range) is a proprietary low-power wireless
+communication protocol developed by the `Semtech Corporation`_.
+
+LoRa acts as the physical layer (PHY) based on the chirp spread spectrum
+(CSS) modulation technique.
+
+LoRaWAN (for Long Range Wide Area Network) defines a networking layer
+on top of the LoRa PHY.
+
+Zephyr provides APIs for LoRa to send raw data packets directly over the
+wireless interface as well as APIs for LoRaWAN to connect the end device
+to the internet through a gateway.
+
+The Zephyr implementation is based on Semtech's `LoRaMac-node library`_, which
+is included as a Zephyr module.
+
+The LoRaWAN specification is published by the `LoRa Alliance`_.
+
+.. _`Semtech Corporation`: https://www.semtech.com/
+
+.. _`LoRaMac-node library`: https://github.com/Lora-net/LoRaMac-node
+
+.. _`LoRa Alliance`: https://lora-alliance.org/
+
+Configuration Options
+*********************
+
+LoRa PHY
+========
+
+Related configuration options can be found under
+:zephyr_file:`drivers/lora/Kconfig`.
+
+* :kconfig:option:`CONFIG_LORA`
+
+* :kconfig:option:`CONFIG_LORA_SHELL`
+
+* :kconfig:option:`CONFIG_LORA_INIT_PRIORITY`
+
+LoRaWAN
+=======
+
+Related configuration options can be found under
+:zephyr_file:`subsys/lorawan/Kconfig`.
+
+* :kconfig:option:`CONFIG_LORAWAN`
+
+* :kconfig:option:`CONFIG_LORAWAN_SYSTEM_MAX_RX_ERROR`
+
+* :kconfig:option:`CONFIG_LORAMAC_REGION_UNKNOWN`
+
+* :kconfig:option:`CONFIG_LORAMAC_REGION_AS923`
+
+* :kconfig:option:`CONFIG_LORAMAC_REGION_AU915`
+
+* :kconfig:option:`CONFIG_LORAMAC_REGION_CN470`
+
+* :kconfig:option:`CONFIG_LORAMAC_REGION_CN779`
+
+* :kconfig:option:`CONFIG_LORAMAC_REGION_EU433`
+
+* :kconfig:option:`CONFIG_LORAMAC_REGION_EU868`
+
+* :kconfig:option:`CONFIG_LORAMAC_REGION_KR920`
+
+* :kconfig:option:`CONFIG_LORAMAC_REGION_IN865`
+
+* :kconfig:option:`CONFIG_LORAMAC_REGION_US915`
+
+* :kconfig:option:`CONFIG_LORAMAC_REGION_RU864`
+
+API Reference
+*************
+
+LoRa PHY
+========
+
+.. doxygengroup:: lora_api
+
+LoRaWAN
+=======
+
+.. doxygengroup:: lorawan_api

--- a/include/drivers/lora.h
+++ b/include/drivers/lora.h
@@ -10,6 +10,9 @@
 /**
  * @file
  * @brief Public LoRa APIs
+ * @defgroup lora_api LoRa APIs
+ * @ingroup io_interfaces
+ * @{
  */
 
 #include <zephyr/types.h>
@@ -51,6 +54,12 @@ struct lora_modem_config {
 	int8_t tx_power;
 	bool tx;
 };
+
+/**
+ * @cond INTERNAL_HIDDEN
+ *
+ * For internal driver use only, skip these in public documentation.
+ */
 
 /**
  * @typedef lora_recv_cb()
@@ -125,6 +134,8 @@ struct lora_driver_api {
 	lora_api_recv_async recv_async;
 	lora_api_test_cw test_cw;
 };
+
+/** @endcond */
 
 /**
  * @brief Configure the LoRa modem
@@ -260,5 +271,9 @@ static inline int lora_test_cw(const struct device *dev, uint32_t frequency,
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif	/* ZEPHYR_INCLUDE_DRIVERS_LORA_H_ */

--- a/include/lorawan/lorawan.h
+++ b/include/lorawan/lorawan.h
@@ -10,6 +10,9 @@
 /**
  * @file
  * @brief Public LoRaWAN APIs
+ * @defgroup lorawan_api LoRaWAN APIs
+ * @ingroup subsystem
+ * @{
  */
 
 #include <device.h>
@@ -279,5 +282,9 @@ void lorawan_get_payload_sizes(uint8_t *max_next_payload_size,
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif /* ZEPHYR_INCLUDE_LORAWAN_LORAWAN_H_ */


### PR DESCRIPTION
So far we only had comments in the header files, but they were not rendered anywhere in the docs (as far as I can see).

This PR adds a new section `LoRa and LoRaWAN`. People often confuse both terms, so it makes sense to have them both in one section. The LoRa PHY is implemented under `drivers`, but does not really fit the `peripherals` section in the docs anyway.