### PR TITLE
drivers: mbox: Add configurable priority

### DIFF
--- a/drivers/mbox/Kconfig
+++ b/drivers/mbox/Kconfig
@@ -9,6 +9,12 @@ menuconfig MBOX
 
 if MBOX
 
+config MBOX_INIT_PRIORITY
+	int "MBOX init priority"
+	default KERNEL_INIT_PRIORITY_DEVICE
+	help
+	  MBOX driver device initialization priority.
+
 config MBOX_NRFX_IPC
 	bool "MBOX NRF IPC driver"
 	depends on HAS_HW_NRF_IPC

--- a/drivers/mbox/mbox_nrfx_ipc.c
+++ b/drivers/mbox/mbox_nrfx_ipc.c
@@ -202,5 +202,5 @@ static const struct mbox_driver_api mbox_nrf_driver_api = {
 };
 
 DEVICE_DT_INST_DEFINE(0, mbox_nrf_init, NULL, &nrfx_mbox_data, &nrfx_mbox_conf,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    POST_KERNEL, CONFIG_MBOX_INIT_PRIORITY,
 		    &mbox_nrf_driver_api);

--- a/soc/arm/nordic_nrf/nrf53/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf53/Kconfig.soc
@@ -240,6 +240,12 @@ module = SYNC_RTC
 module-str = Synchronized RTC
 source "subsys/logging/Kconfig.template.log_config"
 
+config NRF53_SYNC_RTC_INIT_PRIORITY
+	int "nRF53 Synchronized RTC init priority"
+	default APPLICATION_INIT_PRIORITY
+	help
+	  nRF53 Synchronized RTC initialization priority.
+
 config NRF_RTC_TIMER_USER_CHAN_COUNT
 	default 1
 

--- a/soc/arm/nordic_nrf/nrf53/sync_rtc.c
+++ b/soc/arm/nordic_nrf/nrf53/sync_rtc.c
@@ -306,4 +306,9 @@ bail:
 	return rv;
 }
 
-SYS_INIT(sync_rtc_setup, POST_KERNEL, 0);
+#if defined(CONFIG_MBOX_INIT_PRIORITY)
+BUILD_ASSERT(CONFIG_NRF53_SYNC_RTC_INIT_PRIORITY > CONFIG_MBOX_INIT_PRIORITY,
+		"RTC Sync must be initialized after MBOX driver.");
+#endif
+
+SYS_INIT(sync_rtc_setup, POST_KERNEL, CONFIG_NRF53_SYNC_RTC_INIT_PRIORITY);


### PR DESCRIPTION
Add init priority for mbox and nrf53 synchronized RTC.
nrf53_sync_rtc is relying on mbox and must be initialized later.

