### PR TITLE
drivers: can: add CAN transceiver support

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -517,6 +517,7 @@
 /include/drivers/*/*litex*                @mateusz-holenko @kgugala @pgielda
 /include/drivers/adc.h                    @anangl
 /include/drivers/can.h                    @alexanderwachter @henrikbrixandersen
+/include/drivers/can/                     @alexanderwachter @henrikbrixandersen
 /include/drivers/counter.h                @nordic-krch
 /include/drivers/dac.h                    @martinjaeger
 /include/drivers/espi.h                   @albertofloyd @franciscomunoz @sjvasanth1

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -566,6 +566,7 @@
 /include/debug/gdbstub.h                  @ceolin
 /include/device.h                         @tbursztyka @nashif
 /include/devicetree.h                     @galak
+/include/devicetree/can.h                 @henrikbrixandersen
 /include/dt-bindings/clock/kinetis_mcg.h  @henrikbrixandersen
 /include/dt-bindings/clock/kinetis_scg.h  @henrikbrixandersen
 /include/dt-bindings/ethernet/xlnx_gem.h  @ibirnbaum

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -495,6 +495,7 @@ Documentation:
         - subsys/net/l2/canbus/
         - tests/subsys/canbus/
         - dts/bindings/can/
+        - include/devicetree/can.h
         - include/drivers/can.h
         - samples/drivers/can/
         - tests/drivers/can/

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -497,6 +497,7 @@ Documentation:
         - dts/bindings/can/
         - include/devicetree/can.h
         - include/drivers/can.h
+        - include/drivers/can/
         - samples/drivers/can/
         - tests/drivers/can/
         - samples/subsys/canbus/

--- a/boards/arm/lpcxpresso55s16/lpcxpresso55s16_common.dtsi
+++ b/boards/arm/lpcxpresso55s16/lpcxpresso55s16_common.dtsi
@@ -136,6 +136,10 @@
 	status = "okay";
 	bus-speed = <125000>;
 	bus-speed-data = <1000000>;
+
+	can-transceiver {
+		max-bitrate = <5000000>;
+	};
 };
 
 &hs_lspi {

--- a/boards/arm/mimxrt1024_evk/mimxrt1024_evk.dts
+++ b/boards/arm/mimxrt1024_evk/mimxrt1024_evk.dts
@@ -97,6 +97,10 @@
 &flexcan1 {
 	status = "okay";
 	bus-speed = <125000>;
+
+	can-transceiver {
+		max-bitrate = <5000000>;
+	};
 };
 
 &wdog0 {

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -207,6 +207,10 @@ zephyr_udc0: &usb1 {
 &flexcan2 {
 	status = "okay";
 	bus-speed = <125000>;
+
+	can-transceiver {
+		max-bitrate = <5000000>;
+	};
 };
 
 &wdog0 {

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -273,6 +273,10 @@ zephyr_udc0: &usb1 {
 &flexcan2 {
 	status = "okay";
 	bus-speed = <125000>;
+
+	can-transceiver {
+		max-bitrate = <5000000>;
+	};
 };
 
 &wdog0 {

--- a/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm7.dts
+++ b/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm7.dts
@@ -40,6 +40,10 @@
 &flexcan3 {
 	status = "okay";
 	bus-speed = <125000>;
+
+	can-transceiver {
+		max-bitrate = <5000000>;
+	};
 };
 
 &lpi2c1 {

--- a/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm7.dts
+++ b/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm7.dts
@@ -40,6 +40,10 @@
 &flexcan3 {
 	status = "okay";
 	bus-speed = <125000>;
+
+	can-transceiver {
+		max-bitrate = <5000000>;
+	};
 };
 
 &lpspi1 {

--- a/boards/arm/olimex_stm32_p405/olimex_stm32_p405.dts
+++ b/boards/arm/olimex_stm32_p405/olimex_stm32_p405.dts
@@ -81,6 +81,10 @@
 	pinctrl-names = "default";
 	bus-speed = <125000>;
 	status = "okay";
+
+	can-transceiver {
+		max-bitrate = <1000000>;
+	};
 };
 
 &rng {

--- a/boards/arm/olimexino_stm32/olimexino_stm32.dts
+++ b/boards/arm/olimexino_stm32/olimexino_stm32.dts
@@ -40,6 +40,13 @@
 		};
 	};
 
+	transceiver0: can-phy0 {
+		compatible = "microchip,mcp2551", "can-transceiver-gpio";
+		max-bitrate = <1000000>;
+		standby-gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;
+		#phy-cells = <0>;
+	};
+
 	aliases {
 		led0 = &green_led_1;
 		led1 = &yellow_led_2;
@@ -152,5 +159,6 @@ zephyr_udc0: &usb {
 	pinctrl-0 = <&can_rx_pb8 &can_tx_pb9>;
 	pinctrl-names = "default";
 	bus-speed = <125000>;
+	phys = <&transceiver0>;
 	status = "okay";
 };

--- a/boards/arm/rcar_h3ulcb/rcar_h3ulcb_cr7.dts
+++ b/boards/arm/rcar_h3ulcb/rcar_h3ulcb_cr7.dts
@@ -56,6 +56,10 @@
 	pinctrl-names = "default";
 	status = "okay";
 	bus-speed = <125000>;
+
+	can-transceiver {
+		max-bitrate = <5000000>;
+	};
 };
 
 &scif1 {

--- a/boards/arm/rddrone_fmuk66/rddrone_fmuk66.dts
+++ b/boards/arm/rddrone_fmuk66/rddrone_fmuk66.dts
@@ -57,6 +57,20 @@
 			pwms = <&ftm3 5 15625000 PWM_POLARITY_INVERTED>;
 		};
 	};
+
+	transceiver0: can-phy0 {
+		compatible = "nxp,tja1042", "can-transceiver-gpio";
+		max-bitrate = <5000000>;
+		standby-gpios = <&gpioc 19 GPIO_ACTIVE_HIGH>;
+		#phy-cells = <0>;
+	};
+
+	transceiver1: can-phy1 {
+		compatible = "nxp,tja1042", "can-transceiver-gpio";
+		max-bitrate = <5000000>;
+		standby-gpios = <&gpioc 18 GPIO_ACTIVE_HIGH>;
+		#phy-cells = <0>;
+	};
 };
 
 &sim {
@@ -221,6 +235,7 @@ zephyr_udc0: &usbotg {
 	pinctrl-0 = <&flexcan0_default>;
 	pinctrl-names = "default";
 	bus-speed = <125000>;
+	phys = <&transceiver0>;
 };
 
 &flexcan1 {
@@ -228,6 +243,7 @@ zephyr_udc0: &usbotg {
 	pinctrl-0 = <&flexcan1_default>;
 	pinctrl-names = "default";
 	bus-speed = <125000>;
+	phys = <&transceiver1>;
 };
 
 /* external i2c port */

--- a/boards/arm/sam_e70_xplained/sam_e70_xplained-common.dtsi
+++ b/boards/arm/sam_e70_xplained/sam_e70_xplained-common.dtsi
@@ -157,4 +157,8 @@ zephyr_udc0: &usbhs {
 	pinctrl-0 = <&pb3a_can0_rx0 &pb2a_can0_tx0>;
 	bus-speed = <125000>;
 	bus-speed-data = <1000000>;
+
+	can-transceiver {
+		max-bitrate = <5000000>;
+	};
 };

--- a/boards/arm/sam_v71_xult/sam_v71_xult-common.dtsi
+++ b/boards/arm/sam_v71_xult/sam_v71_xult-common.dtsi
@@ -291,6 +291,10 @@ zephyr_udc0: &usbhs {
 	pinctrl-0 = <&pc12c_can1_rx1 &pc14c_can1_tx1>;
 	bus-speed = <125000>;
 	bus-speed-data = <1000000>;
+
+	can-transceiver {
+		max-bitrate = <5000000>;
+	};
 };
 
 ext1_spi: &spi0 {

--- a/boards/arm/twr_ke18f/twr_ke18f.dts
+++ b/boards/arm/twr_ke18f/twr_ke18f.dts
@@ -281,6 +281,10 @@
 	bus-speed = <125000>;
 	pinctrl-0 = <&flexcan0_default>;
 	pinctrl-names = "default";
+
+	can-transceiver {
+		max-bitrate = <1000000>;
+	};
 };
 
 &gpioa {

--- a/boards/shields/mcp2515/dfrobot_can_bus_v2_0.overlay
+++ b/boards/shields/mcp2515/dfrobot_can_bus_v2_0.overlay
@@ -19,6 +19,10 @@
 		bus-speed = <125000>;
 		sjw = <1>;
 		sample-point = <875>;
+
+		can-transceiver {
+			max-bitrate = <1000000>;
+		};
 	};
 };
 

--- a/boards/shields/mcp2515/keyestudio_can_bus_ks0411.overlay
+++ b/boards/shields/mcp2515/keyestudio_can_bus_ks0411.overlay
@@ -19,6 +19,10 @@
 		bus-speed = <125000>;
 		sjw = <1>;
 		sample-point = <875>;
+
+		can-transceiver {
+			max-bitrate = <1000000>;
+		};
 	};
 };
 

--- a/doc/reference/canbus/controller.rst
+++ b/doc/reference/canbus/controller.rst
@@ -341,7 +341,13 @@ We have two ready-to-build samples demonstrating use of the Zephyr CAN API
 :ref:`SocketCAN sample <socket-can-sample>`.
 
 
-API Reference
-*************
+CAN Controller API Reference
+****************************
 
 .. doxygengroup:: can_interface
+
+
+CAN Transceiver API Reference
+*****************************
+
+.. doxygengroup:: can_transceiver

--- a/doc/reference/devicetree/api.rst
+++ b/doc/reference/devicetree/api.rst
@@ -225,6 +225,16 @@ Hardware specific APIs
 The following APIs can also be used by including ``<devicetree.h>``;
 no additional include is needed.
 
+.. _devicetree-can-api:
+
+CAN
+===
+
+These conveniences may be used for nodes which describe CAN
+controllers/transceivers, and properties related to them.
+
+.. doxygengroup:: devicetree-can
+
 Clocks
 ======
 

--- a/drivers/can/CMakeLists.txt
+++ b/drivers/can/CMakeLists.txt
@@ -16,3 +16,5 @@ zephyr_library_sources_ifdef(CONFIG_CAN_RCAR         can_rcar.c)
 
 zephyr_library_sources_ifdef(CONFIG_USERSPACE        can_handlers.c)
 zephyr_library_sources_ifdef(CONFIG_CAN_SHELL        can_shell.c)
+
+add_subdirectory(transceiver)

--- a/drivers/can/Kconfig
+++ b/drivers/can/Kconfig
@@ -102,4 +102,6 @@ source "drivers/can/Kconfig.mcan"
 source "drivers/can/Kconfig.rcar"
 source "drivers/can/Kconfig.loopback"
 
+source "drivers/can/transceiver/Kconfig"
+
 endif # CAN

--- a/drivers/can/can_handlers.c
+++ b/drivers/can/can_handlers.c
@@ -22,13 +22,22 @@ static inline int z_vrfy_can_set_timing(const struct device *dev,
 static inline int z_vrfy_can_get_core_clock(const struct device *dev,
 					    uint32_t *rate)
 {
-
 	Z_OOPS(Z_SYSCALL_DRIVER_CAN(dev, get_core_clock));
 	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(rate, sizeof(rate)));
 
 	return z_impl_can_get_core_clock(dev, rate);
 }
 #include <syscalls/can_get_core_clock_mrsh.c>
+
+static inline int z_vrfy_can_get_max_bitrate(const struct device *dev,
+					     uint32_t *max_bitrate)
+{
+	Z_OOPS(Z_SYSCALL_DRIVER_CAN(dev, get_max_bitrate));
+	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(max_bitrate, sizeof(*max_bitrate)));
+
+	return z_impl_can_get_max_bitrate(dev, max_bitrate);
+}
+#include <syscalls/can_get_max_bitrate_mrsh.c>
 
 static inline int z_vrfy_can_send(const struct device *dev,
 				  const struct zcan_frame *frame,
@@ -73,7 +82,6 @@ static inline int z_vrfy_can_add_rx_filter_msgq(const struct device *dev,
 
 static inline void z_vrfy_can_remove_rx_filter(const struct device *dev, int filter_id)
 {
-
 	Z_OOPS(Z_SYSCALL_DRIVER_CAN(dev, remove_rx_filter));
 
 	z_impl_can_remove_rx_filter((const struct device *)dev, (int)filter_id);
@@ -84,7 +92,6 @@ static inline
 int z_vrfy_can_get_state(const struct device *dev, enum can_state *state,
 			 struct can_bus_err_cnt *err_cnt)
 {
-
 	Z_OOPS(Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_CAN));
 
 	if (state != NULL) {
@@ -103,7 +110,6 @@ int z_vrfy_can_get_state(const struct device *dev, enum can_state *state,
 static inline int z_vrfy_can_recover(const struct device *dev,
 				     k_timeout_t timeout)
 {
-
 	Z_OOPS(Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_CAN));
 
 	return z_impl_can_recover(dev, k_timeout_t timeout);

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <kernel.h>
 #include <drivers/can.h>
+#include <drivers/can/transceiver.h>
 #include "can_mcan.h"
 #include "can_mcan_int.h"
 #include <logging/log.h>
@@ -212,9 +213,23 @@ int can_mcan_set_mode(const struct can_mcan_config *cfg, enum can_mode mode)
 	struct can_mcan_reg *can = cfg->can;
 	int ret;
 
+	if (cfg->phy != NULL) {
+		ret = can_transceiver_enable(cfg->phy);
+		if (ret != 0) {
+			LOG_ERR("failed to enable CAN transceiver (err %d)", ret);
+			return ret;
+		}
+	}
+
 	ret = can_enter_init_mode(can, K_MSEC(CAN_INIT_TIMEOUT));
 	if (ret) {
 		LOG_ERR("Failed to enter init mode");
+
+		if (cfg->phy != NULL) {
+			/* Attempt to disable the CAN transceiver in case of error */
+			(void)can_transceiver_disable(cfg->phy);
+		}
+
 		return -EIO;
 	}
 
@@ -252,6 +267,11 @@ int can_mcan_set_mode(const struct can_mcan_config *cfg, enum can_mode mode)
 	ret = can_leave_init_mode(can, K_MSEC(CAN_INIT_TIMEOUT));
 	if (ret) {
 		LOG_ERR("Failed to leave init mode");
+
+		if (cfg->phy != NULL) {
+			/* Attempt to disable the CAN transceiver in case of error */
+			(void)can_transceiver_disable(cfg->phy);
+		}
 	}
 
 	return 0;
@@ -275,16 +295,31 @@ int can_mcan_init(const struct device *dev, const struct can_mcan_config *cfg,
 		k_sem_init(&data->tx_fin_sem[i], 0, 1);
 	}
 
+	if (cfg->phy != NULL) {
+		if (!device_is_ready(cfg->phy)) {
+			LOG_ERR("CAN transceiver not ready");
+			return -ENODEV;
+		}
+
+		ret = can_transceiver_enable(cfg->phy);
+		if (ret != 0) {
+			LOG_ERR("failed to enable CAN transceiver (err %d)", ret);
+			return -EIO;
+		}
+	}
+
 	ret = can_exit_sleep_mode(can);
 	if (ret) {
 		LOG_ERR("Failed to exit sleep mode");
-		return -EIO;
+		ret = -EIO;
+		goto done;
 	}
 
 	ret = can_enter_init_mode(can, K_MSEC(CAN_INIT_TIMEOUT));
 	if (ret) {
 		LOG_ERR("Failed to enter init mode");
-		return -EIO;
+		ret = -EIO;
+		goto done;
 	}
 
 	/* Configuration Change Enable */
@@ -376,7 +411,8 @@ int can_mcan_init(const struct device *dev, const struct can_mcan_config *cfg,
 				      cfg->sample_point);
 		if (ret == -EINVAL) {
 			LOG_ERR("Can't find timing for given param");
-			return -EIO;
+			ret = -EIO;
+			goto done;
 		}
 		LOG_DBG("Presc: %d, TS1: %d, TS2: %d",
 			timing.prescaler, timing.phase_seg1, timing.phase_seg2);
@@ -397,7 +433,8 @@ int can_mcan_init(const struct device *dev, const struct can_mcan_config *cfg,
 					   cfg->sample_point_data);
 		if (ret == -EINVAL) {
 			LOG_ERR("Can't find timing for given dataphase param");
-			return -EIO;
+			ret = -EIO;
+			goto done;
 		}
 
 		LOG_DBG("Sample-point err data phase: %d", ret);
@@ -441,10 +478,17 @@ int can_mcan_init(const struct device *dev, const struct can_mcan_config *cfg,
 	ret = can_leave_init_mode(can, K_MSEC(CAN_INIT_TIMEOUT));
 	if (ret) {
 		LOG_ERR("Failed to leave init mode");
-		return -EIO;
+		ret = -EIO;
+		goto done;
 	}
 
-	return 0;
+done:
+	if (ret != 0 && cfg->phy != NULL) {
+		/* Attempt to disable the CAN transceiver in case of error */
+		(void)can_transceiver_disable(cfg->phy);
+	}
+
+	return ret;
 }
 
 static void can_mcan_state_change_handler(const struct can_mcan_config *cfg,

--- a/drivers/can/can_mcan.h
+++ b/drivers/can/can_mcan.h
@@ -200,6 +200,8 @@ struct can_mcan_config {
 	uint8_t ts2_data;
 	uint8_t tx_delay_comp_offset;
 #endif
+	const struct device *phy;
+	uint32_t max_bitrate;
 };
 
 struct can_mcan_reg;

--- a/drivers/can/can_mcp2515.h
+++ b/drivers/can/can_mcp2515.h
@@ -65,6 +65,10 @@ struct mcp2515_config {
 	uint32_t bus_speed;
 	uint32_t osc_freq;
 	uint16_t sample_point;
+
+	/* CAN transceiver */
+	const struct device *phy;
+	uint32_t max_bitrate;
 };
 
 /*

--- a/drivers/can/can_mcux_mcan.c
+++ b/drivers/can/can_mcux_mcan.c
@@ -6,6 +6,7 @@
 
 #include <device.h>
 #include <drivers/can.h>
+#include <drivers/can/transceiver.h>
 #include <drivers/clock_control.h>
 #include <logging/log.h>
 
@@ -98,6 +99,15 @@ static int mcux_mcan_get_core_clock(const struct device *dev, uint32_t *rate)
 				      rate);
 }
 
+int mcux_mcan_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
+{
+	const struct mcux_mcan_config *config = dev->config;
+
+	*max_bitrate = config->mcan.max_bitrate;
+
+	return 0;
+}
+
 static void mcux_mcan_line_0_isr(const struct device *dev)
 {
 	const struct mcux_mcan_config *config = dev->config;
@@ -149,6 +159,7 @@ static const struct can_driver_api mcux_mcan_driver_api = {
 	.get_state = mcux_mcan_get_state,
 	.set_state_change_callback = mcux_mcan_set_state_change_callback,
 	.get_core_clock = mcux_mcan_get_core_clock,
+	.get_max_bitrate = mcux_mcan_get_max_bitrate,
 	/*
 	 * MCUX MCAN timing limits are specified in the "Nominal bit timing and
 	 * prescaler register (NBTP)" table in the SoC reference manual.
@@ -215,7 +226,9 @@ static const struct can_driver_api mcux_mcan_driver_api = {
 			DT_INST_PROP_OR(n, phase_seg1_data, 0),		\
 		.ts2_data = DT_INST_PROP_OR(n, phase_seg2_data, 0),	\
 		.tx_delay_comp_offset =					\
-			DT_INST_PROP(n, tx_delay_comp_offset)		\
+			DT_INST_PROP(n, tx_delay_comp_offset),		\
+		.phy = DEVICE_DT_GET_OR_NULL(DT_INST_PHANDLE(n, phys)),	\
+		.max_bitrate = DT_INST_CAN_TRANSCEIVER_MAX_BITRATE(n, 5000000), \
 	}
 #else /* CONFIG_CAN_FD_MODE */
 #define MCUX_MCAN_MCAN_INIT(n)						\
@@ -227,6 +240,8 @@ static const struct can_driver_api mcux_mcan_driver_api = {
 		.prop_ts1 = DT_INST_PROP_OR(n, prop_seg, 0) +		\
 			DT_INST_PROP_OR(n, phase_seg1, 0),		\
 		.ts2 = DT_INST_PROP_OR(n, phase_seg2, 0),		\
+		.phy = DEVICE_DT_GET_OR_NULL(DT_INST_PHANDLE(n, phys)),	\
+		.max_bitrate = DT_INST_CAN_TRANSCEIVER_MAX_BITRATE(n, 1000000), \
 	}
 #endif /* !CONFIG_CAN_FD_MODE */
 

--- a/drivers/can/can_sam.c
+++ b/drivers/can/can_sam.c
@@ -7,6 +7,7 @@
 #include "can_mcan.h"
 
 #include <drivers/can.h>
+#include <drivers/can/transceiver.h>
 #include <soc.h>
 #include <kernel.h>
 #include <logging/log.h>
@@ -129,6 +130,15 @@ static int can_sam_set_timing(const struct device *dev, const struct can_timing 
 	return can_mcan_set_timing(mcan_cfg, timing, timing_data);
 }
 
+int can_sam_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
+{
+	const struct can_sam_config *cfg = dev->config;
+
+	*max_bitrate = cfg->mcan_cfg.max_bitrate;
+
+	return 0;
+}
+
 static void can_sam_line_0_isr(const struct device *dev)
 {
 	const struct can_sam_config *cfg = dev->config;
@@ -162,6 +172,7 @@ static const struct can_driver_api can_api_funcs = {
 	.recover = can_mcan_recover,
 #endif
 	.get_core_clock = can_sam_get_core_clock,
+	.get_max_bitrate = can_sam_get_max_bitrate,
 	.set_state_change_callback =  can_sam_set_state_change_callback,
 	.timing_min = {
 		.sjw = 0x1,
@@ -223,7 +234,9 @@ static void config_can_##inst##_irq(void)                                       
 	.prop_ts1_data = DT_INST_PROP_OR(inst, prop_seg_data, 0) +                             \
 			 DT_INST_PROP_OR(inst, phase_seg1_data, 0),                            \
 	.ts2_data = DT_INST_PROP_OR(inst, phase_seg2_data, 0),                                 \
-	.tx_delay_comp_offset = DT_INST_PROP(inst, tx_delay_comp_offset)                       \
+	.tx_delay_comp_offset = DT_INST_PROP(inst, tx_delay_comp_offset),                      \
+	.phy = DEVICE_DT_GET_OR_NULL(DT_INST_PHANDLE(inst, phys)),                             \
+	.max_bitrate = DT_INST_CAN_TRANSCEIVER_MAX_BITRATE(inst, 5000000),                     \
 }
 #else /* CONFIG_CAN_FD_MODE */
 #define CAN_SAM_MCAN_CFG(inst)                                                                 \
@@ -233,6 +246,8 @@ static void config_can_##inst##_irq(void)                                       
 	.sample_point = DT_INST_PROP_OR(inst, sample_point, 0),                                \
 	.prop_ts1 = DT_INST_PROP_OR(inst, prop_seg, 0) + DT_INST_PROP_OR(inst, phase_seg1, 0), \
 	.ts2 = DT_INST_PROP_OR(inst, phase_seg2, 0),                                           \
+	.phy = DEVICE_DT_GET_OR_NULL(DT_INST_PHANDLE(inst, phys)),                             \
+	.max_bitrate = DT_INST_CAN_TRANSCEIVER_MAX_BITRATE(inst, 1000000),                     \
 }
 #endif /* CONFIG_CAN_FD_MODE */
 

--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <drivers/can/transceiver.h>
 #include <drivers/clock_control/stm32_clock_control.h>
 #include <drivers/clock_control.h>
 #include <drivers/pinctrl.h>
@@ -325,6 +326,15 @@ int can_stm32_set_mode(const struct device *dev, enum can_mode mode)
 	LOG_DBG("Set mode %d", mode);
 
 	k_mutex_lock(&data->inst_mutex, K_FOREVER);
+
+	if (cfg->phy != NULL) {
+		ret = can_transceiver_enable(cfg->phy);
+		if (ret != 0) {
+			LOG_ERR("failed to enable CAN transceiver (err %d)", ret);
+			goto done;
+		}
+	}
+
 	ret = can_enter_init_mode(can);
 	if (ret) {
 		LOG_ERR("Failed to enter init mode");
@@ -354,8 +364,15 @@ done:
 	ret = can_leave_init_mode(can);
 	if (ret) {
 		LOG_ERR("Failed to leave init mode");
+
+		if (cfg->phy != NULL) {
+			/* Attempt to disable the CAN transceiver in case of error */
+			(void)can_transceiver_disable(cfg->phy);
+		}
 	}
+
 	k_mutex_unlock(&data->inst_mutex);
+
 	return ret;
 }
 
@@ -425,6 +442,15 @@ int can_stm32_get_max_filters(const struct device *dev, enum can_ide id_type)
 	return CONFIG_CAN_MAX_FILTER;
 }
 
+int can_stm32_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
+{
+	const struct can_stm32_config *config = dev->config;
+
+	*max_bitrate = config->max_bitrate;
+
+	return 0;
+}
+
 static int can_stm32_init(const struct device *dev)
 {
 	const struct can_stm32_config *cfg = dev->config;
@@ -451,6 +477,13 @@ static int can_stm32_init(const struct device *dev)
 	data->filter_usage = (1ULL << CAN_MAX_NUMBER_OF_FILTERS) - 1ULL;
 	(void)memset(data->rx_cb, 0, sizeof(data->rx_cb));
 	(void)memset(data->cb_arg, 0, sizeof(data->cb_arg));
+
+	if (cfg->phy != NULL) {
+		if (!device_is_ready(cfg->phy)) {
+			LOG_ERR("CAN transceiver not ready");
+			return -ENODEV;
+		}
+	}
 
 	clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
@@ -1125,6 +1158,7 @@ static const struct can_driver_api can_api_funcs = {
 	.set_state_change_callback = can_stm32_set_state_change_callback,
 	.get_core_clock = can_stm32_get_core_clock,
 	.get_max_filters = can_stm32_get_max_filters,
+	.get_max_bitrate = can_stm32_get_max_bitrate,
 	.timing_min = {
 		.sjw = 0x1,
 		.prop_seg = 0x00,
@@ -1162,7 +1196,9 @@ static const struct can_stm32_config can_stm32_cfg_1 = {
 		.bus = DT_CLOCKS_CELL(DT_NODELABEL(can1), bus),
 	},
 	.config_irq = config_can_1_irq,
-	.pcfg = PINCTRL_DT_DEV_CONFIG_GET(DT_NODELABEL(can1))
+	.pcfg = PINCTRL_DT_DEV_CONFIG_GET(DT_NODELABEL(can1)),
+	.phy = DEVICE_DT_GET_OR_NULL(DT_PHANDLE(DT_NODELABEL(can1), phys)),
+	.max_bitrate = DT_CAN_TRANSCEIVER_MAX_BITRATE(DT_NODELABEL(can1), 1000000),
 };
 
 static struct can_stm32_data can_stm32_dev_data_1;
@@ -1260,7 +1296,9 @@ static const struct can_stm32_config can_stm32_cfg_2 = {
 		.bus = DT_CLOCKS_CELL(DT_NODELABEL(can2), bus),
 	},
 	.config_irq = config_can_2_irq,
-	.pcfg = PINCTRL_DT_DEV_CONFIG_GET(DT_NODELABEL(can2))
+	.pcfg = PINCTRL_DT_DEV_CONFIG_GET(DT_NODELABEL(can2)),
+	.phy = DEVICE_DT_GET_OR_NULL(DT_PHANDLE(DT_NODELABEL(can2), phys)),
+	.max_bitrate = DT_CAN_TRANSCEIVER_MAX_BITRATE(DT_NODELABEL(can2), 1000000),
 };
 
 static struct can_stm32_data can_stm32_dev_data_2;

--- a/drivers/can/can_stm32.h
+++ b/drivers/can/can_stm32.h
@@ -76,6 +76,8 @@ struct can_stm32_config {
 	struct stm32_pclken pclken;
 	void (*config_irq)(CAN_TypeDef *can);
 	const struct pinctrl_dev_config *pcfg;
+	const struct device *phy;
+	uint32_t max_bitrate;
 };
 
 #endif /*ZEPHYR_DRIVERS_CAN_STM32_CAN_H_*/

--- a/drivers/can/can_stm32fd.c
+++ b/drivers/can/can_stm32fd.c
@@ -5,6 +5,7 @@
  */
 
 #include <drivers/can.h>
+#include <drivers/can/transceiver.h>
 #include <drivers/pinctrl.h>
 #include <kernel.h>
 #include <soc.h>
@@ -153,6 +154,15 @@ static int can_stm32fd_set_timing(const struct device *dev,
 	return can_mcan_set_timing(mcan_cfg, timing, timing_data);
 }
 
+int can_stm32fd_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
+{
+	const struct can_stm32fd_config *cfg = dev->config;
+
+	*max_bitrate = cfg->mcan.max_bitrate;
+
+	return 0;
+}
+
 static void can_stm32fd_line_0_isr(void *arg)
 {
 	struct device *dev = (struct device *)arg;
@@ -188,6 +198,7 @@ static const struct can_driver_api can_api_funcs = {
 	.recover = can_mcan_recover,
 #endif
 	.get_core_clock = can_stm32fd_get_core_clock,
+	.get_max_bitrate = can_stm32fd_get_max_bitrate,
 	.get_max_filters = can_stm32fd_get_max_filters,
 	.set_state_change_callback = can_stm32fd_set_state_change_callback,
 	.timing_min = {
@@ -263,7 +274,10 @@ static const struct can_stm32fd_config can_stm32fd_cfg_##inst = {              \
 				DT_INST_PROP_OR(inst, phase_seg1_data, 0),     \
 		.ts2_data = DT_INST_PROP_OR(inst, phase_seg2_data, 0),         \
 		.tx_delay_comp_offset =                                        \
-			DT_INST_PROP(inst, tx_delay_comp_offset)               \
+			DT_INST_PROP(inst, tx_delay_comp_offset),              \
+		.phy = DEVICE_DT_GET_OR_NULL(DT_INST_PHANDLE(inst, phys)),     \
+		.max_bitrate =                                                 \
+			DT_INST_CAN_TRANSCEIVER_MAX_BITRATE(inst, 5000000),    \
 	},                                                                     \
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),                          \
 };
@@ -287,6 +301,9 @@ static const struct can_stm32fd_config can_stm32fd_cfg_##inst = {              \
 		.prop_ts1 = DT_INST_PROP_OR(inst, prop_seg, 0) +               \
 			    DT_INST_PROP_OR(inst, phase_seg1, 0),              \
 		.ts2 = DT_INST_PROP_OR(inst, phase_seg2, 0),                   \
+		.phy = DEVICE_DT_GET_OR_NULL(DT_INST_PHANDLE(inst, phys)),     \
+		.max_bitrate =                                                 \
+			DT_INST_CAN_TRANSCEIVER_MAX_BITRATE(inst, 1000000),    \
 	},                                                                     \
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),                          \
 };

--- a/drivers/can/transceiver/CMakeLists.txt
+++ b/drivers/can/transceiver/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Copyright (c) 2022 Vestas Wind Systems A/S
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+zephyr_library_property(ALLOW_EMPTY TRUE)
+zephyr_library_sources_ifdef(CONFIG_CAN_TRANSCEIVER_GPIO can_transceiver_gpio.c)

--- a/drivers/can/transceiver/Kconfig
+++ b/drivers/can/transceiver/Kconfig
@@ -1,0 +1,21 @@
+# CAN transceiver configuration options
+
+# Copyright (c) 2022 Vestas Wind Systems A/S
+# SPDX-License-Identifier: Apache-2.0
+
+menu "CAN transceiver drivers"
+
+config CAN_TRANSCEIVER_INIT_PRIORITY
+	int "CAN transceiver driver init priority"
+	default 70
+	help
+	  CAN transceiver device driver initialization priority.
+
+config CAN_TRANSCEIVER_GPIO
+	bool "GPIO controlled CAN transceiver"
+	depends on GPIO
+	default $(dt_compat_enabled,can-transceiver-gpio)
+	help
+	  Enable support for GPIO controlled CAN transceivers.
+
+endmenu

--- a/drivers/can/transceiver/can_transceiver_gpio.c
+++ b/drivers/can/transceiver/can_transceiver_gpio.c
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2022 Vestas Wind Systems A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT can_transceiver_gpio
+
+#include <device.h>
+#include <drivers/can/transceiver.h>
+#include <drivers/gpio.h>
+#include <logging/log.h>
+
+LOG_MODULE_REGISTER(can_transceiver_gpio, CONFIG_CAN_LOG_LEVEL);
+
+/* Does any devicetree instance have an enable-gpios property? */
+#define INST_HAS_ENABLE_GPIOS_OR(inst) DT_INST_NODE_HAS_PROP(inst, enable_gpios) ||
+#define ANY_INST_HAS_ENABLE_GPIOS DT_INST_FOREACH_STATUS_OKAY(INST_HAS_ENABLE_GPIOS_OR) 0
+
+/* Does any devicetree instance have a standby-gpios property? */
+#define INST_HAS_STANDBY_GPIOS_OR(inst) DT_INST_NODE_HAS_PROP(inst, standby_gpios) ||
+#define ANY_INST_HAS_STANDBY_GPIOS DT_INST_FOREACH_STATUS_OKAY(INST_HAS_STANDBY_GPIOS_OR) 0
+
+struct can_transceiver_gpio_config {
+#if ANY_INST_HAS_ENABLE_GPIOS
+	struct gpio_dt_spec enable_gpio;
+#endif /* ANY_INST_HAS_ENABLE_GPIOS */
+#if ANY_INST_HAS_STANDBY_GPIOS
+	struct gpio_dt_spec standby_gpio;
+#endif /* ANY_INST_HAS_STANDBY_GPIOS */
+};
+
+static int can_transceiver_gpio_set_state(const struct device *dev, bool enabled)
+{
+	const struct can_transceiver_gpio_config *config = dev->config;
+	int err;
+
+#if ANY_INST_HAS_ENABLE_GPIOS
+	if (config->enable_gpio.port != NULL) {
+		err = gpio_pin_set_dt(&config->enable_gpio, enabled ? 1 : 0);
+		if (err != 0) {
+			LOG_ERR("failed to set enable GPIO pin (err %d)", err);
+			return -EIO;
+		}
+	}
+#endif /* ANY_INST_HAS_ENABLE_GPIOS */
+
+#if ANY_INST_HAS_STANDBY_GPIOS
+	if (config->standby_gpio.port != NULL) {
+		err = gpio_pin_set_dt(&config->standby_gpio, enabled ? 0 : 1);
+		if (err != 0) {
+			LOG_ERR("failed to set standby GPIO pin (err %d)", err);
+			return -EIO;
+		}
+	}
+#endif /* ANY_INST_HAS_STANDBY_GPIOS */
+
+	return 0;
+}
+
+static int can_transceiver_gpio_enable(const struct device *dev)
+{
+	return can_transceiver_gpio_set_state(dev, true);
+}
+
+static int can_transceiver_gpio_disable(const struct device *dev)
+{
+	return can_transceiver_gpio_set_state(dev, false);
+}
+
+static int can_transceiver_gpio_init(const struct device *dev)
+{
+	const struct can_transceiver_gpio_config *config = dev->config;
+	int err;
+
+#if ANY_INST_HAS_ENABLE_GPIOS
+	if (config->enable_gpio.port != NULL) {
+		if (!device_is_ready(config->enable_gpio.port)) {
+			LOG_ERR("enable pin GPIO device not ready");
+			return -EINVAL;
+		}
+
+		/* CAN transceiver is disabled during initialization */
+		err = gpio_pin_configure_dt(&config->enable_gpio, GPIO_OUTPUT_INACTIVE);
+		if (err != 0) {
+			LOG_ERR("failed to configure enable GPIO pin (err %d)", err);
+			return err;
+		}
+	}
+#endif /* ANY_INST_HAS_ENABLE_GPIOS */
+
+#if ANY_INST_HAS_STANDBY_GPIOS
+	if (config->standby_gpio.port != NULL) {
+		if (!device_is_ready(config->standby_gpio.port)) {
+			LOG_ERR("standby pin GPIO device not ready");
+			return -EINVAL;
+		}
+
+		/* CAN transceiver is put in standby during initialization */
+		err = gpio_pin_configure_dt(&config->standby_gpio, GPIO_OUTPUT_ACTIVE);
+		if (err != 0) {
+			LOG_ERR("failed to configure standby GPIO pin (err %d)", err);
+			return err;
+		}
+	}
+#endif /* ANY_INST_HAS_STANDBY_GPIOS */
+
+	return 0;
+}
+
+static const struct can_transceiver_driver_api can_transceiver_gpio_driver_api = {
+	.enable = can_transceiver_gpio_enable,
+	.disable = can_transceiver_gpio_disable,
+};
+
+#define CAN_TRANSCEIVER_GPIO_COND(inst, name)				\
+	IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, name##_gpios),		\
+		   (.name##_gpio = GPIO_DT_SPEC_INST_GET(inst, name##_gpios),))
+
+#define CAN_TRANSCEIVER_GPIO_INIT(inst)					\
+	static const struct can_transceiver_gpio_config	can_transceiver_gpio_config_##inst = { \
+		CAN_TRANSCEIVER_GPIO_COND(inst, enable)			\
+		CAN_TRANSCEIVER_GPIO_COND(inst, standby)		\
+	};								\
+									\
+	DEVICE_DT_INST_DEFINE(inst, &can_transceiver_gpio_init,		\
+			NULL, NULL, &can_transceiver_gpio_config_##inst,\
+			POST_KERNEL, CONFIG_CAN_TRANSCEIVER_INIT_PRIORITY, \
+			&can_transceiver_gpio_driver_api);		\
+
+DT_INST_FOREACH_STATUS_OKAY(CAN_TRANSCEIVER_GPIO_INIT)

--- a/dts/bindings/can/can-controller.yaml
+++ b/dts/bindings/can/can-controller.yaml
@@ -30,3 +30,42 @@ properties:
         Sample point in permille.
         This param is required if segments are not given.
         If the sample point is given, the segments are ignored.
+    phys:
+      type: phandle
+      required: false
+      description: |
+        Actively controlled CAN transceiver.
+
+        Example:
+          transceiver0: can-phy0 {
+            compatible = "nxp,tja1040", "can-transceiver-gpio";
+            standby-gpios = <gpioa 0 GPIO_ACTIVE_HIGH>;
+            max-bitrate = <1000000>;
+            #phy-cells = <0>;
+          };
+
+          &can0 {
+            status = "okay";
+
+            phys = <&transceiver0>;
+          };
+
+child-binding:
+    description: |
+      Passive CAN transceiver. The child node must be named "can-transceiver".
+
+      Example:
+        &can0 {
+          status = "okay";
+
+          can-transceiver {
+            max-bitrate = <1000000>;
+          };
+        };
+
+    properties:
+      max-bitrate:
+        type: int
+        required: true
+        description: |
+          The maximum bitrate supported by the CAN transceiver in bits/s.

--- a/dts/bindings/phy/can-transceiver-gpio.yaml
+++ b/dts/bindings/phy/can-transceiver-gpio.yaml
@@ -1,0 +1,25 @@
+# Copyright (c) 2022 Vestas Wind Systems A/S
+# SPDX-License-Identifier: Apache-2.0
+
+description: Simple GPIO controlled CAN transceiver
+
+compatible: "can-transceiver-gpio"
+
+include: can-transceiver.yaml
+
+properties:
+    enable-gpios:
+      type: phandle-array
+      required: false
+      description: |
+        GPIO to use to enable/disable the CAN transceiver. This GPIO is driven
+        active when the CAN transceiver is enabled and inactive when the CAN
+        transceiver is disabled.
+
+    standby-gpios:
+      type: phandle-array
+      required: false
+      description: |
+        GPIO to use to put the CAN transceiver into standby. This GPIO is driven
+        inactive when the CAN transceiver is enabled and active when the CAN
+        transceiver is disabled.

--- a/dts/bindings/phy/can-transceiver.yaml
+++ b/dts/bindings/phy/can-transceiver.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2022 Vestas Wind Systems A/S
+# SPDX-License-Identifier: Apache-2.0
+
+# Common fields for CAN transceivers
+
+include: phy-controller.yaml
+
+properties:
+    max-bitrate:
+      type: int
+      required: true
+      description: |
+        The maximum bitrate supported by the CAN transceiver in bits/s.
+
+    "#phy-cells":
+      const: 0

--- a/dts/bindings/test/vnd,can-controller.yaml
+++ b/dts/bindings/test/vnd,can-controller.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2020 Vestas Wind Systems A/S
+# SPDX-License-Identifier: Apache-2.0
+
+description: Test CAN controller node
+
+compatible: "vnd,can-controller"
+
+include: can-controller.yaml

--- a/dts/bindings/test/vnd,can-transceiver.yaml
+++ b/dts/bindings/test/vnd,can-transceiver.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2020 Vestas Wind Systems A/S
+# SPDX-License-Identifier: Apache-2.0
+
+description: Test CAN transceiver node
+
+compatible: "vnd,can-transceiver"
+
+include: can-transceiver.yaml

--- a/include/devicetree.h
+++ b/include/devicetree.h
@@ -2972,5 +2972,6 @@
 #include <devicetree/zephyr.h>
 #include <devicetree/ordinals.h>
 #include <devicetree/pinctrl.h>
+#include <devicetree/can.h>
 
 #endif /* DEVICETREE_H */

--- a/include/devicetree/can.h
+++ b/include/devicetree/can.h
@@ -1,0 +1,86 @@
+/**
+ * @file
+ * @brief CAN devicetree macro public API header file.
+ */
+
+/*
+ * Copyright (c) 2022 Vestas Wind Systems A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DEVICETREE_CAN_H_
+#define ZEPHYR_INCLUDE_DEVICETREE_CAN_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @defgroup devicetree-can Devicetree CAN API
+ * @ingroup devicetree
+ * @{
+ */
+
+/**
+ * @brief Get the maximum transceiver bitrate for a CAN controller
+ *
+ * The bitrate will be limited to the maximum bitrate supported by the CAN
+ * controller. If no CAN transceiver is present in the devicetree, the maximum
+ * bitrate will be that of the CAN controller.
+ *
+ * Example devicetree fragment:
+ *
+ *     transceiver0: can-phy0 {
+ *             compatible = "vnd,can-transceiver";
+ *             max-bitrate = <1000000>;
+ *             #phy-cells = <0>;
+ *     };
+ *
+ *     can0: can@... {
+ *             compatible = "vnd,can-controller";
+ *             phys = <&transceiver0>;
+ *     };
+ *
+ *     can1: can@... {
+ *             compatible = "vnd,can-controller";
+ *
+ *             can-transceiver {
+ *                     max-bitrate = <2000000>;
+ *             };
+ *     };
+ *
+ * Example usage:
+ *
+ *     DT_CAN_TRANSCEIVER_MAX_BITRATE(DT_NODELABEL(can0), 5000000) // 1000000
+ *     DT_CAN_TRANSCEIVER_MAX_BITRATE(DT_NODELABEL(can1), 5000000) // 2000000
+ *     DT_CAN_TRANSCEIVER_MAX_BITRATE(DT_NODELABEL(can1), 1000000) // 1000000
+ *
+ * @param node_id node identifier
+ * @param max maximum bitrate supported by the CAN controller
+ * @return the maximum bitrate supported by the CAN controller/transceiver combination
+ */
+#define DT_CAN_TRANSCEIVER_MAX_BITRATE(node_id, max)				\
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, phys),					\
+		    MIN(DT_PROP(DT_PHANDLE(node_id, phys), max_bitrate), max),		\
+		    MIN(DT_PROP_OR(DT_CHILD(node_id, can_transceiver), max_bitrate, max), max))
+
+/**
+ * @brief Get the maximum transceiver bitrate for a DT_DRV_COMPAT CAN controller
+ * @param inst DT_DRV_COMPAT instance number
+ * @param max maximum bitrate supported by the CAN controller
+ * @return the maximum bitrate supported by the CAN controller/transceiver combination
+ * @see DT_CAN_TRANSCEIVER_MAX_BITRATE()
+ */
+#define DT_INST_CAN_TRANSCEIVER_MAX_BITRATE(inst, max) \
+	DT_CAN_TRANSCEIVER_MAX_BITRATE(DT_DRV_INST(inst), max)
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DEVICETREE_CAN_H_ */

--- a/include/drivers/can.h
+++ b/include/drivers/can.h
@@ -791,53 +791,7 @@ static inline int z_impl_can_set_mode(const struct device *dev, enum can_mode mo
  * @retval -EINVAL bitrate cannot be met.
  * @retval -EIO General input/output error, failed to set bitrate.
  */
-static inline int can_set_bitrate(const struct device *dev,
-				  uint32_t bitrate,
-				  uint32_t bitrate_data)
-{
-	struct can_timing timing;
-#ifdef CONFIG_CAN_FD_MODE
-	struct can_timing timing_data;
-#endif
-	uint32_t max_bitrate;
-	int ret;
-
-	ret = can_get_max_bitrate(dev, &max_bitrate);
-	if (ret == -ENOSYS) {
-		/* Maximum bitrate unknown */
-		max_bitrate = 0;
-	} else if (ret < 0) {
-		return ret;
-	}
-
-	if ((max_bitrate > 0) && (bitrate > max_bitrate)) {
-		return -ENOTSUP;
-	}
-
-	ret = can_calc_timing(dev, &timing, bitrate, 875);
-	if (ret < 0) {
-		return -EINVAL;
-	}
-
-	timing.sjw = CAN_SJW_NO_CHANGE;
-
-#ifdef CONFIG_CAN_FD_MODE
-	if ((max_bitrate > 0) && (bitrate_data > max_bitrate)) {
-		return -ENOTSUP;
-	}
-
-	ret = can_calc_timing_data(dev, &timing_data, bitrate_data, 875);
-	if (ret < 0) {
-		return -EINVAL;
-	}
-
-	timing_data.sjw = CAN_SJW_NO_CHANGE;
-
-	return can_set_timing(dev, &timing, &timing_data);
-#else /* CONFIG_CAN_FD_MODE */
-	return can_set_timing(dev, &timing, NULL);
-#endif /* !CONFIG_CAN_FD_MODE */
-}
+int can_set_bitrate(const struct device *dev, uint32_t bitrate, uint32_t bitrate_data);
 
 /** @} */
 

--- a/include/drivers/can/transceiver.h
+++ b/include/drivers/can/transceiver.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2022 Vestas Wind Systems A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_CAN_TRANSCEIVER_H_
+#define ZEPHYR_INCLUDE_DRIVERS_CAN_TRANSCEIVER_H_
+
+#include <device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief CAN Transceiver Driver APIs
+ * @defgroup can_transceiver CAN Transceiver
+ * @ingroup io_interfaces
+ * @{
+ */
+
+/**
+ * @cond INTERNAL_HIDDEN
+ *
+ * For internal driver use only, skip these in public documentation.
+ */
+
+/**
+ * @typedef can_transceiver_enable_t
+ * @brief Callback API upon enabling CAN transceiver
+ * See @a can_transceiver_enable() for argument description
+ */
+typedef int (*can_transceiver_enable_t)(const struct device *dev);
+
+/**
+ * @typedef can_transceiver_disable_t
+ * @brief Callback API upon disabling CAN transceiver
+ * See @a can_transceiver_disable() for argument description
+ */
+typedef int (*can_transceiver_disable_t)(const struct device *dev);
+
+__subsystem struct can_transceiver_driver_api {
+	can_transceiver_enable_t enable;
+	can_transceiver_disable_t disable;
+};
+
+/** @endcond */
+
+/**
+ * @brief Enable CAN transceiver
+ *
+ * Enable the CAN transceiver.
+ *
+ * @note The CAN transceiver is controlled by the CAN controller driver and
+ *       should not normally be controlled by the application.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ *
+ * @retval 0 If successful.
+ * @retval -EIO General input/output error, failed to enable device.
+ */
+static inline int can_transceiver_enable(const struct device *dev)
+{
+	const struct can_transceiver_driver_api *api =
+		(const struct can_transceiver_driver_api *)dev->api;
+
+	return api->enable(dev);
+}
+
+/**
+ * @brief Disable CAN transceiver
+ *
+ * Disable the CAN transceiver.
+
+ * @note The CAN transceiver is controlled by the CAN controller driver and
+ *       should not normally be controlled by the application.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ *
+ * @retval 0 If successful.
+ * @retval -EIO General input/output error, failed to disable device.
+ */
+static inline int can_transceiver_disable(const struct device *dev)
+{
+	const struct can_transceiver_driver_api *api =
+		(const struct can_transceiver_driver_api *)dev->api;
+
+	return api->disable(dev);
+}
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_CAN_TRANSCEIVER_H_ */

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -421,6 +421,39 @@
 			status = "okay";
 		};
 
+		test_transceiver0: can-phy0 {
+			compatible = "vnd,can-transceiver";
+			label = "TEST_TRANSCEIVER_0";
+			status = "okay";
+			#phy-cells = <0>;
+			max-bitrate = <5000000>;
+		};
+
+		test_can0: can@55553333 {
+			compatible = "vnd,can-controller";
+			reg = < 0x55553333 0x1000 >;
+			sjw = <1>;
+			sample-point = <875>;
+			bus-speed = <125000>;
+			label = "TEST_CAN_CTRL_0";
+			status = "okay";
+			phys = <&test_transceiver0>;
+		};
+
+		test_can1: can@55554444 {
+			compatible = "vnd,can-controller";
+			reg = < 0x55554444 0x1000 >;
+			sjw = <1>;
+			sample-point = <875>;
+			bus-speed = <125000>;
+			label = "TEST_CAN_CTRL_1";
+			status = "okay";
+
+			can-transceiver {
+				max-bitrate = <2000000>;
+			};
+		};
+
 		/* there should only be one of these */
 		test_children: test-children {
 			compatible = "vnd,child-bindings";

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -46,6 +46,9 @@
 #define TEST_PWM_CTLR_1 DT_NODELABEL(test_pwm1)
 #define TEST_PWM_CTLR_2 DT_NODELABEL(test_pwm2)
 
+#define TEST_CAN_CTRL_0 DT_NODELABEL(test_can0)
+#define TEST_CAN_CTRL_1 DT_NODELABEL(test_can1)
+
 #define TEST_DMA_CTLR_1 DT_NODELABEL(test_dma1)
 #define TEST_DMA_CTLR_2 DT_NODELABEL(test_dma2)
 
@@ -1093,6 +1096,27 @@ static void test_pwms(void)
 
 	/* DT_INST_PWMS_FLAGS */
 	zassert_equal(DT_INST_PWMS_FLAGS(0), 3, "");
+}
+
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT vnd_can_controller
+static void test_can(void)
+{
+	/* DT_CAN_TRANSCEIVER_MAX_BITRATE */
+	zassert_equal(DT_CAN_TRANSCEIVER_MAX_BITRATE(TEST_CAN_CTRL_0, 1000000), 1000000, "");
+	zassert_equal(DT_CAN_TRANSCEIVER_MAX_BITRATE(TEST_CAN_CTRL_0, 5000000), 5000000, "");
+	zassert_equal(DT_CAN_TRANSCEIVER_MAX_BITRATE(TEST_CAN_CTRL_0, 8000000), 5000000, "");
+	zassert_equal(DT_CAN_TRANSCEIVER_MAX_BITRATE(TEST_CAN_CTRL_1, 1250000), 1250000, "");
+	zassert_equal(DT_CAN_TRANSCEIVER_MAX_BITRATE(TEST_CAN_CTRL_1, 2000000), 2000000, "");
+	zassert_equal(DT_CAN_TRANSCEIVER_MAX_BITRATE(TEST_CAN_CTRL_1, 5000000), 2000000, "");
+
+	/* DT_INST_CAN_TRANSCEIVER_MAX_BITRATE */
+	zassert_equal(DT_INST_CAN_TRANSCEIVER_MAX_BITRATE(0, 1000000), 1000000, "");
+	zassert_equal(DT_INST_CAN_TRANSCEIVER_MAX_BITRATE(0, 5000000), 5000000, "");
+	zassert_equal(DT_INST_CAN_TRANSCEIVER_MAX_BITRATE(0, 8000000), 5000000, "");
+	zassert_equal(DT_INST_CAN_TRANSCEIVER_MAX_BITRATE(1, 1250000), 1250000, "");
+	zassert_equal(DT_INST_CAN_TRANSCEIVER_MAX_BITRATE(1, 2000000), 2000000, "");
+	zassert_equal(DT_INST_CAN_TRANSCEIVER_MAX_BITRATE(1, 5000000), 2000000, "");
 }
 
 static void test_macro_names(void)
@@ -2203,6 +2227,7 @@ void test_main(void)
 			 ztest_unit_test(test_io_channels),
 			 ztest_unit_test(test_dma),
 			 ztest_unit_test(test_pwms),
+			 ztest_unit_test(test_can),
 			 ztest_unit_test(test_macro_names),
 			 ztest_unit_test(test_arrays),
 			 ztest_unit_test(test_foreach_status_okay),


### PR DESCRIPTION
Add support for CAN transceivers:
- Added new devicetree bindings for CAN transceivers. These bindings are in-line with how CAN transceivers are represented in upstream Linux DTS.
- Added CAN transceivers to all relevant in-tree board devicetrees.
- Added new device driver API for CAN transceivers.
- Added generic GPIO-controlled CAN transceiver with support for a combination of enable and standby GPIOs.
- Updated all in-tree CAN drivers with CAN transceiver support.
- Added API support for determining the maximum bitrate supported by a CAN controller and attached CAN transceiver.
- Guard against setting a too high bitrate.