### PR TITLE
Bluetooth: Mesh: Extended advertiser should build without relay

### DIFF
--- a/subsys/bluetooth/mesh/adv_ext.c
+++ b/subsys/bluetooth/mesh/adv_ext.c
@@ -26,6 +26,10 @@
 /* Convert from ms to 0.625ms units */
 #define ADV_INT_FAST_MS    20
 
+#ifndef CONFIG_BT_MESH_RELAY_ADV_SETS
+#define CONFIG_BT_MESH_RELAY_ADV_SETS 0
+#endif
+
 enum {
 	/** Controller is currently advertising */
 	ADV_FLAG_ACTIVE,


### PR DESCRIPTION
The extended advertiser would fail to build due to a missing kconfig
option dependency when relay was disabled.

Fixes #43172.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>