### PR TITLE
uart: logging: Add configurable log level to UART drivers

### DIFF
--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -37,6 +37,10 @@ config SERIAL_INIT_PRIORITY
 	help
 	  Serial driver device initialization priority.
 
+module = UART
+module-str = uart
+source "subsys/logging/Kconfig.template.log_config"
+
 config SERIAL_SUPPORT_WIDE_DATA
 	bool
 	help

--- a/drivers/serial/uart_hvc_xen.c
+++ b/drivers/serial/uart_hvc_xen.c
@@ -16,10 +16,10 @@
 #include <device.h>
 #include <init.h>
 #include <kernel.h>
-#include <logging/log.h>
 #include <sys/device_mmio.h>
 
-LOG_MODULE_REGISTER(uart_hvc_xen);
+#include <logging/log.h>
+LOG_MODULE_REGISTER(uart_hvc_xen, CONFIG_UART_LOG_LEVEL);
 
 static struct hvc_xen_data hvc_data = {0};
 

--- a/drivers/serial/uart_ite_it8xxx2.c
+++ b/drivers/serial/uart_ite_it8xxx2.c
@@ -16,7 +16,7 @@
 #include <soc.h>
 
 #include <logging/log.h>
-LOG_MODULE_REGISTER(uart_ite_it8xxx2, LOG_LEVEL_ERR);
+LOG_MODULE_REGISTER(uart_ite_it8xxx2, CONFIG_UART_LOG_LEVEL);
 
 #if defined(CONFIG_PM_DEVICE) && defined(CONFIG_UART_CONSOLE_INPUT_EXPIRED)
 static struct uart_it8xxx2_data *uart_console_data;

--- a/drivers/serial/uart_neorv32.c
+++ b/drivers/serial/uart_neorv32.c
@@ -13,7 +13,7 @@
 #include <sys/sys_io.h>
 
 #include <logging/log.h>
-LOG_MODULE_REGISTER(uart_neorv32, CONFIG_LOG_DEFAULT_LEVEL);
+LOG_MODULE_REGISTER(uart_neorv32, CONFIG_UART_LOG_LEVEL);
 
 /* NEORV32 UART registers offsets */
 #define NEORV32_UART_CTRL_OFFSET 0x00

--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -18,7 +18,7 @@
 #include "soc_power.h"
 
 #include <logging/log.h>
-LOG_MODULE_REGISTER(uart_npcx, LOG_LEVEL_ERR);
+LOG_MODULE_REGISTER(uart_npcx, CONFIG_UART_LOG_LEVEL);
 
 /* Driver config */
 struct uart_npcx_config {

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -15,9 +15,10 @@
 #include <sys/util.h>
 #include <kernel.h>
 #include <soc.h>
-#include <logging/log.h>
 #include <helpers/nrfx_gppi.h>
-LOG_MODULE_REGISTER(uart_nrfx_uarte, LOG_LEVEL_ERR);
+
+#include <logging/log.h>
+LOG_MODULE_REGISTER(uart_nrfx_uarte, CONFIG_UART_LOG_LEVEL);
 
 #ifdef CONFIG_PINCTRL
 #include <drivers/pinctrl.h>

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -36,7 +36,7 @@
 #include <stm32_ll_lpuart.h>
 
 #include <logging/log.h>
-LOG_MODULE_REGISTER(uart_stm32);
+LOG_MODULE_REGISTER(uart_stm32, CONFIG_UART_LOG_LEVEL);
 
 #define HAS_LPUART_1 (DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(lpuart1), \
 					 st_stm32_lpuart, okay))


### PR DESCRIPTION
This change adds compile-time selection of log level for
the UART drivers.

Signed-off-by: Pete Dietl <petedietl@gmail.com>