### PR TITLE
Bluetooth: Mesh: Fix missing add suffix `_COMMON`

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -110,9 +110,9 @@ config BT_MESH_GATT
 
 config BT_MESH_PROXY_MSG_LEN
 	int
-	depends on BT_MESH_GATT
-	default 66 if BT_MESH_PB_GATT
+	default 66 if BT_MESH_PB_GATT_COMMON
 	default 33 if BT_MESH_GATT_PROXY
+	depends on BT_MESH_GATT
 
 config BT_MESH_GATT_CLIENT
 	bool

--- a/subsys/bluetooth/mesh/prov_bearer.h
+++ b/subsys/bluetooth/mesh/prov_bearer.h
@@ -10,7 +10,7 @@
  *
  *  @brief Required headroom for the bearer packet buffers.
  */
-#if defined(CONFIG_BT_MESH_PB_GATT)
+#if defined(CONFIG_BT_MESH_PB_GATT_COMMON)
 #define PROV_BEARER_BUF_HEADROOM 5
 #else
 #define PROV_BEARER_BUF_HEADROOM 0


### PR DESCRIPTION
Since `CONFIG_BT_MESH_PB_GATT` represent to pb-gatt-srv.

We use `CONFIG_BT_MESH_PB_GATT_COMMON` to represent common.

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>