### PR TITLE
twister: yaml: run flash test on it8xxx2_evb board

### DIFF
--- a/tests/drivers/flash/testcase.yaml
+++ b/tests/drivers/flash/testcase.yaml
@@ -12,7 +12,7 @@ tests:
     integration_platforms:
       - nrf52840dk_nrf52840
   drivers.flash.default:
-    platform_allow: mimxrt1060_evk
+    platform_allow: mimxrt1060_evk it8xxx2_evb
     tags: mcux
     integration_platforms:
       - mimxrt1060_evk


### PR DESCRIPTION
Add it8xxx2_evb board to flash test platform_allow, so twister
won't skip it.

Signed-off-by: Fu Haolei <haolei.fu@intel.com>