### PR TITLE
Bluetooth: Mesh: Fix unable iv recovery when in iv update state

### DIFF
--- a/subsys/bluetooth/mesh/beacon.c
+++ b/subsys/bluetooth/mesh/beacon.c
@@ -49,6 +49,11 @@ static void cache_add(uint8_t data[21], struct bt_mesh_subnet *sub)
 	memcpy(sub->beacon_cache, data, 21);
 }
 
+void bt_mesh_beacon_cache_clear(struct bt_mesh_subnet *sub)
+{
+	(void)memset(sub->beacon_cache, 0, 21);
+}
+
 static void beacon_complete(int err, void *user_data)
 {
 	struct bt_mesh_subnet *sub = user_data;

--- a/subsys/bluetooth/mesh/beacon.h
+++ b/subsys/bluetooth/mesh/beacon.h
@@ -6,7 +6,7 @@
 
 void bt_mesh_beacon_enable(void);
 void bt_mesh_beacon_disable(void);
-
+void bt_mesh_beacon_cache_clear(struct bt_mesh_subnet *sub);
 void bt_mesh_beacon_ivu_initiator(bool enable);
 
 void bt_mesh_beacon_recv(struct net_buf_simple *buf);

--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -242,14 +242,58 @@ bool bt_mesh_iv_update(void)
 }
 #endif /* CONFIG_BT_MESH_IV_UPDATE_TEST */
 
+static bool is_iv_recovery(uint32_t iv_index, bool iv_update)
+{
+	if (iv_index < bt_mesh.iv_index ||
+	    iv_index > bt_mesh.iv_index + 42) {
+		BT_ERR("IV Index out of sync: 0x%08x != 0x%08x",
+			   iv_index, bt_mesh.iv_index);
+		return false;
+	}
+
+	if ((iv_index > bt_mesh.iv_index + 1) ||
+	    (iv_index == bt_mesh.iv_index + 1 &&
+	     (atomic_test_bit(bt_mesh.flags, BT_MESH_IVU_IN_PROGRESS) || !iv_update))) {
+		if (ivi_was_recovered &&
+		    (bt_mesh.ivu_duration < (2 * BT_MESH_IVU_MIN_HOURS))) {
+			BT_ERR("IV Index Recovery before minimum delay");
+			return false;
+		}
+
+		/* The Mesh profile specification allows to initiate an
+		 * IV Index Recovery procedure if previous IV update has
+		 * been missed. This allows the node to remain
+		 * functional.
+		 *
+		 * Upon receiving and successfully authenticating a
+		 * Secure Network beacon for a primary subnet whose
+		 * IV Index is 1 or more higher than the current known IV
+		 * Index, the node shall set its current IV Index and its
+		 * current IV Update procedure state from the values in
+		 * this Secure Network beacon.
+		 */
+		BT_WARN("Performing IV Index Recovery");
+		ivi_was_recovered = true;
+		bt_mesh_rpl_clear();
+		bt_mesh.iv_index = iv_index;
+		bt_mesh.seq = 0U;
+
+		return true;
+	}
+
+	return false;
+}
+
 bool bt_mesh_net_iv_update(uint32_t iv_index, bool iv_update)
 {
 	if (atomic_test_bit(bt_mesh.flags, BT_MESH_IVU_IN_PROGRESS)) {
 		/* We're currently in IV Update mode */
 
 		if (iv_index != bt_mesh.iv_index) {
-			BT_WARN("IV Index mismatch: 0x%08x != 0x%08x",
-				iv_index, bt_mesh.iv_index);
+			if (is_iv_recovery(iv_index, iv_update)) {
+				goto do_update;
+			}
+
 			return false;
 		}
 
@@ -261,36 +305,18 @@ bool bt_mesh_net_iv_update(uint32_t iv_index, bool iv_update)
 	} else {
 		/* We're currently in Normal mode */
 
-		if (iv_index == bt_mesh.iv_index) {
-			BT_DBG("Same IV Index in normal mode");
-			return false;
-		}
-
-		if (iv_index < bt_mesh.iv_index ||
-		    iv_index > bt_mesh.iv_index + 42) {
-			BT_ERR("IV Index out of sync: 0x%08x != 0x%08x",
-			       iv_index, bt_mesh.iv_index);
-			return false;
-		}
-
-		if ((iv_index > bt_mesh.iv_index + 1) ||
-		    (iv_index == bt_mesh.iv_index + 1 && !iv_update)) {
-			if (ivi_was_recovered &&
-			    (bt_mesh.ivu_duration < (2 * BT_MESH_IVU_MIN_HOURS))) {
-				BT_ERR("IV Index Recovery before minimum delay");
-				return false;
+		if (iv_index != bt_mesh.iv_index + 1) {
+			if (is_iv_recovery(iv_index, iv_update)) {
+				goto do_update;
 			}
-			/* The Mesh profile specification allows to initiate an
-			 * IV Index Recovery procedure if previous IV update has
-			 * been missed. This allows the node to remain
-			 * functional.
-			 */
-			BT_WARN("Performing IV Index Recovery");
-			ivi_was_recovered = true;
-			bt_mesh_rpl_clear();
-			bt_mesh.iv_index = iv_index;
-			bt_mesh.seq = 0U;
-			goto do_update;
+
+			return false;
+		}
+
+		if (!iv_update) {
+			/* Nothing to do */
+			BT_DBG("Already in IV normal mode");
+			return false;
 		}
 	}
 

--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -247,7 +247,7 @@ static bool is_iv_recovery(uint32_t iv_index, bool iv_update)
 	if (iv_index < bt_mesh.iv_index ||
 	    iv_index > bt_mesh.iv_index + 42) {
 		BT_ERR("IV Index out of sync: 0x%08x != 0x%08x",
-			   iv_index, bt_mesh.iv_index);
+			iv_index, bt_mesh.iv_index);
 		return false;
 	}
 
@@ -916,6 +916,14 @@ static void ivu_refresh(struct k_work *work)
 		}
 
 		goto end;
+	}
+
+	/* Because the beacon may be cached, iv update or iv recovery
+	 * cannot be performed after 96 hours or 192 hours.
+	 * So we need clear beacon cache.
+	 */
+	if (!(bt_mesh.ivu_duration % BT_MESH_IVU_MIN_HOURS)) {
+		bt_mesh_subnet_foreach(bt_mesh_beacon_cache_clear);
 	}
 
 	if (atomic_test_bit(bt_mesh.flags, BT_MESH_IVU_IN_PROGRESS)) {


### PR DESCRIPTION
According Mesh Profile 3.10.6 IV Index Recovery procedure

Upon receiving and successfully authenticating a Secure Network
beacon for a primary subnet whose IV Index is 1 or more higher
than the current known IV Index, the node shall set its current
IV Index and its current IV Update procedure state from the
values in this Secure Network beacon.

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>