### PR TITLE
boards: arm: gd32e103v_eval: fix Kconfig reference

### DIFF
--- a/boards/arm/gd32e103v_eval/doc/index.rst
+++ b/boards/arm/gd32e103v_eval/doc/index.rst
@@ -68,7 +68,7 @@ The board configuration supports the following hardware features:
      - N/A
      - N/A
    * - USART
-     - :kconfig:`CONFIG_SERIAL`
+     - :kconfig:option:`CONFIG_SERIAL`
      - :dtcompatible:`gd,gd32-usart`
 
 


### PR DESCRIPTION
`CONFIG_SERIAL` reference was not updated to the new Kconfig role.