### PR TITLE
Correct channel selection for iso-subevents

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_chan.c
+++ b/subsys/bluetooth/controller/ll_sw/lll_chan.c
@@ -147,15 +147,9 @@ uint8_t lll_chan_iso_subevent(uint16_t chan_id, uint8_t *chan_map,
 		x = 0;
 	}
 
-	chan_idx = ((((uint32_t)prn_subevent_se * x) >> 16) +
-		    d + *remap_idx) % chan_count;
-
-	if ((chan_map[chan_idx >> 3] & (1 << (chan_idx % 8))) == 0U) {
-		*remap_idx = chan_idx;
-		chan_idx = chan_sel_remap(chan_map, *remap_idx);
-	} else {
-		*remap_idx = chan_idx;
-	}
+	*remap_idx = ((((uint32_t)prn_subevent_se * x) >> 16) +
+		         d + *remap_idx) % chan_count;
+	chan_idx = chan_sel_remap(chan_map, *remap_idx);
 
 	return chan_idx;
 }


### PR DESCRIPTION
Change to lll_chan.c included:
For iso subevents channel selection must use remap table always
-regardless of channel is a mapped or unmapped channel.

Signed-off-by: Henrik Møller <heml@demant.com>