### PR TITLE
twister: footprints: Fix missing memory footprints

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -2045,7 +2045,7 @@ class TestInstance(DisablePyTestCollectionMixin):
         """
         fns = glob.glob(os.path.join(self.build_dir, "zephyr", "*.elf"))
         fns.extend(glob.glob(os.path.join(self.build_dir, "zephyr", "*.exe")))
-        fns = [x for x in fns if not x.endswith('_prebuilt.elf')]
+        fns = [x for x in fns if '_pre' not in x]
         if len(fns) != 1:
             raise BuildError("Missing/multiple output ELF binary")
 


### PR DESCRIPTION
Commit 28b2e5532190653d1daf441c89e62b2eaf69c9dd introduced a regression
into twister workflow, breaking memory footprint calculation.
The commit changed name of produced .elf files.
There is no more zephyr_prebuilt.elf and instead we have
zephyr_pre0.elf and zephyr_pre1.elf. This commit fixes a filter
telling which files to exclude when calculating memory footprints,
to match the current status.

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>