### PR TITLE
[Backport v2.7-branch] spi: nrfx_spi*: only run uninit if configured

### DIFF
--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -288,8 +288,10 @@ static int spi_nrfx_pm_control(const struct device *dev,
 		break;
 
 	case PM_DEVICE_ACTION_SUSPEND:
-		nrfx_spi_uninit(&config->spi);
-		data->initialized = false;
+		if (data->initialized) {
+			nrfx_spi_uninit(&config->spim);
+			data->initialized = false;
+		}
 		break;
 
 	default:

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -289,7 +289,7 @@ static int spi_nrfx_pm_control(const struct device *dev,
 
 	case PM_DEVICE_ACTION_SUSPEND:
 		if (data->initialized) {
-			nrfx_spi_uninit(&config->spim);
+			nrfx_spi_uninit(&config->spi);
 			data->initialized = false;
 		}
 		break;

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -345,8 +345,10 @@ static int spim_nrfx_pm_control(const struct device *dev,
 		break;
 
 	case PM_DEVICE_ACTION_SUSPEND:
-		nrfx_spim_uninit(&config->spim);
-		data->initialized = false;
+		if (data->initialized) {
+			nrfx_spim_uninit(&config->spim);
+			data->initialized = false;
+		}
 		break;
 
 	default:


### PR DESCRIPTION
Manual copy of #42348 that contains the fix from #42579

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/42299