### PR TITLE
Correct channel selection for iso-subevents

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_chan.c
+++ b/subsys/bluetooth/controller/ll_sw/lll_chan.c
@@ -360,6 +360,8 @@ void lll_chan_sel_2_ut(void)
 	LL_ASSERT(m == 6U);
 
 	m = lll_chan_sel_2(3, chan_id, chan_map_1, chan_map_1_37_used);
+//heml trigger failing ztest
+//    LL_ASSERT(m == 22U);
 	LL_ASSERT(m == 21U);
 
 	/* Section 3.1 Sample Data 2 (9 used channels) */

--- a/subsys/bluetooth/controller/ll_sw/lll_chan.c
+++ b/subsys/bluetooth/controller/ll_sw/lll_chan.c
@@ -147,15 +147,9 @@ uint8_t lll_chan_iso_subevent(uint16_t chan_id, uint8_t *chan_map,
 		x = 0;
 	}
 
-	chan_idx = ((((uint32_t)prn_subevent_se * x) >> 16) +
-		    d + *remap_idx) % chan_count;
-
-	if ((chan_map[chan_idx >> 3] & (1 << (chan_idx % 8))) == 0U) {
-		*remap_idx = chan_idx;
-		chan_idx = chan_sel_remap(chan_map, *remap_idx);
-	} else {
-		*remap_idx = chan_idx;
-	}
+	*remap_idx = ((((uint32_t)prn_subevent_se * x) >> 16) +
+		         d + *remap_idx) % chan_count;
+	chan_idx = chan_sel_remap(chan_map, *remap_idx);
 
 	return chan_idx;
 }

--- a/subsys/bluetooth/controller/ll_sw/lll_chan.c
+++ b/subsys/bluetooth/controller/ll_sw/lll_chan.c
@@ -360,9 +360,7 @@ void lll_chan_sel_2_ut(void)
 	LL_ASSERT(m == 6U);
 
 	m = lll_chan_sel_2(3, chan_id, chan_map_1, chan_map_1_37_used);
-//heml trigger failing ztest
-//    LL_ASSERT(m == 21U);
-	LL_ASSERT(m == 22U);
+	LL_ASSERT(m == 21U);
 
 	/* Section 3.1 Sample Data 2 (9 used channels) */
 	m = lll_chan_sel_2(6, chan_id, chan_map_2, chan_map_2_9_used);

--- a/subsys/bluetooth/controller/ll_sw/lll_chan.c
+++ b/subsys/bluetooth/controller/ll_sw/lll_chan.c
@@ -361,8 +361,8 @@ void lll_chan_sel_2_ut(void)
 
 	m = lll_chan_sel_2(3, chan_id, chan_map_1, chan_map_1_37_used);
 //heml trigger failing ztest
-//    LL_ASSERT(m == 22U);
-	LL_ASSERT(m == 21U);
+//    LL_ASSERT(m == 21U);
+	LL_ASSERT(m == 22U);
 
 	/* Section 3.1 Sample Data 2 (9 used channels) */
 	m = lll_chan_sel_2(6, chan_id, chan_map_2, chan_map_2_9_used);

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -674,8 +674,6 @@ int ll_init(struct k_sem *sem_rx)
 	lll_chan_sel_2_ut();
 #endif /* CONFIG_BT_CTLR_TEST */
 
-    LL_ASSERT(0);
-
 	return  0;
 }
 

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -674,6 +674,8 @@ int ll_init(struct k_sem *sem_rx)
 	lll_chan_sel_2_ut();
 #endif /* CONFIG_BT_CTLR_TEST */
 
+    LL_ASSERT(0);
+
 	return  0;
 }
 


### PR DESCRIPTION
Change to lll_chan.c included:
For iso subevents channel selection must use remap table always
-regardless of channel is a mapped or unmapped channel.

Signed-off-by: Henrik Møller <heml@demant.com>