### PR TITLE
Bluetooth: Audio: ASCS: do not fail on preferred value check

### DIFF
--- a/subsys/bluetooth/audio/stream.c
+++ b/subsys/bluetooth/audio/stream.c
@@ -197,9 +197,9 @@ bool bt_audio_valid_stream_qos(const struct bt_audio_stream *stream,
 	const struct bt_codec_qos_pref *qos_pref = &stream->ep->qos_pref;
 
 	if (qos_pref->latency < qos->latency) {
+		/* Latency is a preferred value. Print debug info but do not fail. */
 		BT_DBG("Latency %u higher than preferred max %u",
 			qos->latency, qos_pref->latency);
-		return false;
 	}
 
 	if (!IN_RANGE(qos_pref->pd_min, qos_pref->pd_max, qos->pd)) {


### PR DESCRIPTION
bt_audio_valid_stream_qos() is used to validate the QoS parameters
set by a client. It did a check of a preferred setting which is
ok to exceed (mandatory in some cases).
This change removes the statement that causes the check to fail,
but keeps the check for debug purposes.

Fixes #43359

Signed-off-by: Casper Bonde <casper_bonde@bose.com>