### PR TITLE
mbox: Fix function syscall check

### DIFF
--- a/drivers/mbox/mbox_handlers.c
+++ b/drivers/mbox/mbox_handlers.c
@@ -21,7 +21,7 @@ static inline int z_vrfy_mbox_send(const struct mbox_channel *channel,
 
 static inline int z_vrfy_mbox_mtu_get(const struct device *dev)
 {
-	Z_OOPS(Z_SYSCALL_DRIVER_MBOX(dev, max_data_size_get));
+	Z_OOPS(Z_SYSCALL_DRIVER_MBOX(dev, mtu_get));
 
 	return z_impl_mbox_mtu_get(dev);
 }


### PR DESCRIPTION
The syscall check is done using a wrong function name. Fix it.

Fixes: #46749

Signed-off-by: Carlo Caione <ccaione@baylibre.com>