### PR TITLE
net: lwm2m: obj inst processing per formatter

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -3366,12 +3366,9 @@ static int lwm2m_perform_read_object_instance(struct lwm2m_message *msg,
 		/* update the obj_inst_id as we move through the instances */
 		msg->path.obj_inst_id = obj_inst->obj_inst_id;
 
-		if (msg->path.level <= LWM2M_PATH_LEVEL_OBJECT) {
-			/* start instance formatting */
-			ret = engine_put_begin_oi(&msg->out, &msg->path);
-			if (ret < 0) {
-				return ret;
-			}
+		ret = engine_put_begin_oi(&msg->out, &msg->path);
+		if (ret < 0) {
+			return ret;
 		}
 
 		for (int index = 0; index < obj_inst->resource_count; index++) {
@@ -3429,12 +3426,9 @@ static int lwm2m_perform_read_object_instance(struct lwm2m_message *msg,
 		}
 
 move_forward:
-		if (msg->path.level <= LWM2M_PATH_LEVEL_OBJECT) {
-			/* end instance formatting */
-			ret = engine_put_end_oi(&msg->out, &msg->path);
-			if (ret < 0) {
-				return ret;
-			}
+		ret = engine_put_end_oi(&msg->out, &msg->path);
+		if (ret < 0) {
+			return ret;
 		}
 
 		if (msg->path.level <= LWM2M_PATH_LEVEL_OBJECT) {

--- a/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
@@ -336,6 +336,11 @@ static int put_begin_oi(struct lwm2m_output_context *out,
 {
 	struct tlv_out_formatter_data *fd;
 
+	/* No need for oi level TLV constructs */
+	if (path->level > LWM2M_PATH_LEVEL_OBJECT) {
+		return 0;
+	}
+
 	fd = engine_get_out_user_data(out);
 	if (!fd) {
 		return -EINVAL;
@@ -348,6 +353,10 @@ static int put_end_oi(struct lwm2m_output_context *out,
 		      struct lwm2m_obj_path *path)
 {
 	struct tlv_out_formatter_data *fd;
+
+	if (path->level > LWM2M_PATH_LEVEL_OBJECT) {
+		return 0;
+	}
 
 	fd = engine_get_out_user_data(out);
 	if (!fd) {


### PR DESCRIPTION
It depends from a content formatter is there need to put constructs with a path level deeper than object instance. In other words with resource- or resource-instance-level. This became apparent when I started to implement the SenML CBOR support where I need gather all the data before doing encoding.

Signed-off-by: Veijo Pesonen <veijo.pesonen@nordicsemi.no>