### PR TITLE
drivers: modem: gsm_ppp: Enable hooking the setup process

### DIFF
--- a/drivers/modem/Kconfig.gsm
+++ b/drivers/modem/Kconfig.gsm
@@ -110,4 +110,12 @@ config MODEM_GSM_FACTORY_RESET_AT_BOOT
 	  helpful if your modem has a tendency to get stuck due to cached
 	  state.
 
+config GSM_PPP_SETUP_HOOKS
+	bool "Enable app to hook the PPP setup"
+	help
+	  If this is enabled, the application can hook into the setup procedure at
+      two points: right before activating PDP context (after populating
+      potentially useful modem metadata) and right before enabling PPP. See
+      prototypes in include/drivers/modem/gsm_ppp.h for details.
+
 endif

--- a/include/drivers/modem/gsm_ppp.h
+++ b/include/drivers/modem/gsm_ppp.h
@@ -28,8 +28,13 @@ struct gsm_ppp_modem_info {
 
 /** @cond INTERNAL_HIDDEN */
 struct device;
+struct modem_context;
 typedef void (*gsm_modem_power_cb)(const struct device *, void *);
+typedef int (*gsm_setup_cb)(const struct modem_context *, struct k_sem *);
 
+void gsm_ppp_register_setup_hooks(const struct device *dev,
+				  gsm_setup_cb setup_hook,
+				  gsm_setup_cb pre_connect_hook);
 void gsm_ppp_start(const struct device *dev);
 void gsm_ppp_stop(const struct device *dev);
 /** @endcond */


### PR DESCRIPTION
This enables quirky modems, non-standard radio techs etc to work under
Zephyr without forcing developers to maintain huge patches. Previously,
there was no interface for:

- configuring NB-IoT or LTE CAT-M1,
- specifying the bandmask,
- disabling 3G

or a whole slew of other things that one might have to do to accomodate
modems that require slightly non-standard setup steps. This commit
should solve this problem, at least for most modems.

Signed-off-by: Benjamin Lindqvist <benjamin.lindqvist@endian.se>