### PR TITLE
manifest: littlefs: update pull/9/head to SHA

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -157,7 +157,7 @@ manifest:
       path: modules/fs/littlefs
       groups:
         - fs
-      revision: pull/9/head
+      revision: 7b2cf4ba759bd530b543644e2790b07cf20cd6aa
     - name: loramac-node
       revision: 12019623bbad9eb54fe51066847a7cbd4b4eac57
       path: modules/lib/loramac-node


### PR DESCRIPTION
The PR #41729 and https://github.com/zephyrproject-rtos/littlefs/pull/9
was merged in wrong order.

This PR updates the manifest to point to the SHA instead of the PR.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>