### PR TITLE
net: tcp: Update receive window in other direct net_context users 

### DIFF
--- a/samples/bluetooth/ipsp/src/main.c
+++ b/samples/bluetooth/ipsp/src/main.c
@@ -226,7 +226,7 @@ static void tcp_received(struct net_context *context,
 {
 	static char dbg[MAX_DBG_PRINT + 1];
 	sa_family_t family;
-	int ret;
+	int ret, len;
 
 	if (!pkt) {
 		/* EOF condition */
@@ -234,6 +234,7 @@ static void tcp_received(struct net_context *context,
 	}
 
 	family = net_pkt_family(pkt);
+	len = net_pkt_remaining_data(pkt);
 
 	snprintf(dbg, MAX_DBG_PRINT, "TCP IPv%c",
 		 family == AF_INET6 ? '6' : '4');
@@ -244,6 +245,7 @@ static void tcp_received(struct net_context *context,
 		return;
 	}
 
+	(void)net_context_update_recv_wnd(context, len);
 	net_pkt_unref(pkt);
 
 	ret = net_context_send(context, buf_tx, ret, pkt_sent,

--- a/samples/net/zperf/src/zperf_tcp_receiver.c
+++ b/samples/net/zperf/src/zperf_tcp_receiver.c
@@ -42,6 +42,7 @@ static void tcp_received(struct net_context *context,
 	const struct shell *shell = tcp_shell;
 	struct session *session;
 	int64_t time;
+	int len = 0;
 
 	if (!shell) {
 		printk("Shell is not set!\n");
@@ -70,7 +71,8 @@ static void tcp_received(struct net_context *context,
 		session->counter++;
 
 		if (pkt) {
-			session->length += net_pkt_remaining_data(pkt);
+			len = net_pkt_remaining_data(pkt);
+			session->length += len;
 		}
 
 		if (pkt == NULL && status == 0) { /* EOF */
@@ -109,6 +111,11 @@ static void tcp_received(struct net_context *context,
 			net_context_unref(context);
 			session->state = STATE_NULL;
 		}
+
+		if (pkt) {
+			(void)net_context_update_recv_wnd(context, len);
+		}
+
 		break;
 	case STATE_LAST_PACKET_RECEIVED:
 		break;

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -4778,7 +4778,7 @@ static void tcp_recv_cb(struct net_context *context, struct net_pkt *pkt,
 			union net_proto_header *proto_hdr,
 			int status, void *user_data)
 {
-	int ret;
+	int ret, len;
 
 	if (pkt == NULL) {
 		if (!tcp_ctx || !net_context_is_used(tcp_ctx)) {
@@ -4797,6 +4797,10 @@ static void tcp_recv_cb(struct net_context *context, struct net_pkt *pkt,
 
 		return;
 	}
+
+	len = net_pkt_remaining_data(pkt);
+
+	(void)net_context_update_recv_wnd(context, len);
 
 	PR_SHELL(tcp_shell, "%zu bytes received\n", net_pkt_get_len(pkt));
 }

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -4803,6 +4803,8 @@ static void tcp_recv_cb(struct net_context *context, struct net_pkt *pkt,
 	(void)net_context_update_recv_wnd(context, len);
 
 	PR_SHELL(tcp_shell, "%zu bytes received\n", net_pkt_get_len(pkt));
+
+	net_pkt_unref(pkt);
 }
 #endif
 

--- a/subsys/shell/backends/shell_telnet.c
+++ b/subsys/shell/backends/shell_telnet.c
@@ -209,6 +209,8 @@ static void telnet_recv(struct net_context *client,
 
 	len = net_pkt_remaining_data(pkt);
 
+	(void)net_context_update_recv_wnd(client, len);
+
 	while (len >= TELNET_MIN_COMMAND_LEN) {
 		ret = telnet_handle_command(pkt);
 		if (ret > 0) {


### PR DESCRIPTION
As the receive window is now decreased at the TCP module level, other
direct net_context users are also responsible for acknowledging the
received data with net_context_update_recv_wnd() - otherwise, the
communication will stall.

Additionally, fix the net_pkt leak spotted in the net_shell module.