### PR TITLE
mgmt/mcumgr/lib: Remove strnlen usage from OS cmd group and fix how  CONFIG_OS_MGMT_TASKSTAT_THREAD_NAME_LEN is used

### DIFF
--- a/subsys/mgmt/mcumgr/Kconfig
+++ b/subsys/mgmt/mcumgr/Kconfig
@@ -278,8 +278,8 @@ config OS_MGMT_TASKSTAT_THREAD_NAME_LEN
 	range 3 THREAD_MAX_NAME_LEN if THREAD_NAME
 	range 3 6 if !THREAD_NAME
 	help
-	  The length, including terminating 0, of the string that is sent in response
-	  to taskstat command, as a thread name.
+	  The length of the string that is sent in response to taskstat command,
+	  as a thread name.
 	  When THREAD_NAME is enabled then this defaults to THREAD_MAX_NAME_LEN.
 	  When THREAD_NAME is disabled the name is generated from thread priority,
 	  signed integer, and this number regulates how many digits will be used;

--- a/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/src/os_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/src/os_mgmt.c
@@ -42,16 +42,17 @@ os_mgmt_echo(struct mgmt_ctxt *ctxt)
 		}
 	};
 
-	echo_buf[CONFIG_OS_MGMT_ECHO_LENGTH] = '\0';
+	echo_buf[0] = '\0';
 
 	err = cbor_read_object(&ctxt->it, attrs);
 	if (err != 0) {
 		return MGMT_ERR_EINVAL;
 	}
 
+	echo_buf[sizeof(echo_buf) - 1] = '\0';
+
 	err = cbor_encode_text_stringz(&ctxt->encoder, "r")				||
-	      cbor_encode_text_string(&ctxt->encoder, echo_buf,
-				      strnlen(echo_buf, CONFIG_OS_MGMT_ECHO_LENGTH));
+	      cbor_encode_text_stringz(&ctxt->encoder, echo_buf);
 
 	return (err == 0) ? 0 : MGMT_ERR_ENOMEM;
 }

--- a/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/src/os_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/src/os_mgmt.c
@@ -65,50 +65,40 @@ static inline CborError
 os_mgmt_taskstat_encode_thread_name(struct CborEncoder *encoder, int idx,
 				    const struct k_thread *thread)
 {
-	int err = 0;
+	size_t name_len = strlen(thread->name);
 
 	ARG_UNUSED(idx);
 
-	err = cbor_encode_text_string(encoder, thread->name, strnlen(thread->name,
-				      CONFIG_OS_MGMT_TASKSTAT_THREAD_NAME_LEN - 1));
-	return err;
+	if (name_len > CONFIG_OS_MGMT_TASKSTAT_THREAD_NAME_LEN) {
+		name_len = CONFIG_OS_MGMT_TASKSTAT_THREAD_NAME_LEN;
+	}
+
+	return cbor_encode_text_string(encoder, thread->name, name_len);
 }
 
-#elif defined(CONFIG_OS_MGMT_TASKSTAT_USE_THREAD_PRIO_FOR_NAME)
+#else
 static inline CborError
 os_mgmt_taskstat_encode_thread_name(struct CborEncoder *encoder, int idx,
 				    const struct k_thread *thread)
 {
 	CborError err = 0;
-	char thread_name[CONFIG_OS_MGMT_TASKSTAT_THREAD_NAME_LEN];
+	char thread_name[CONFIG_OS_MGMT_TASKSTAT_THREAD_NAME_LEN + 1];
 
-	ARG_UNUSED(idx);
-
-	thread_name[sizeof(thread_name) - 1] = 0;
-	ll_to_s((int)thread->base.prio, sizeof(thread_name) - 1, thread_name);
-
-	err = cbor_encode_text_stringz(encoder, thread_name);
-	return err;
-}
-
+#if defined(CONFIG_OS_MGMT_TASKSTAT_USE_THREAD_PRIO_FOR_NAME)
+	idx = (int)thread->base.prio;
 #elif defined(CONFIG_OS_MGMT_TASKSTAT_USE_THREAD_IDX_FOR_NAME)
-static inline CborError
-os_mgmt_taskstat_encode_thread_name(struct CborEncoder *encoder, int idx,
-				    const struct k_thread *thread)
-{
-	CborError err = 0;
-	char thread_name[CONFIG_OS_MGMT_TASKSTAT_THREAD_NAME_LEN];
-
 	ARG_UNUSED(thread);
-
-	thread_name[sizeof(thread_name) - 1] = 0;
-	ll_to_s(idx, sizeof(thread_name) - 1, thread_name);
-
-	err = cbor_encode_text_stringz(encoder, thread_name);
-	return err;
-}
 #else
 #error Unsupported option for taskstat thread name
+#endif
+
+	ll_to_s(idx, sizeof(thread_name) - 1, thread_name);
+	thread_name[sizeof(thread_name) - 1] = 0;
+
+	err = cbor_encode_text_stringz(encoder, thread_name);
+	return err;
+}
+
 #endif
 
 static inline int


### PR DESCRIPTION
The PR contains three commits that:
 1) fix Kconfig information on what `CONFIG_OS_MGMT_TASKSTAT_THREAD_NAME_LEN` actually means, as previously it has been stated that it includes string terminating 0, which is not true as CBOR encoding does not include the 0 and the whole length could be used for thread name;
 2) Fixes echo command to not use strnlen making it C99 compliant;
 3) Fixes taskstat command to not use trnlen making it C99 compliant, fixes usage of `CONFIG_OS_MGMT_TASKSTAT_THREAD_NAME_LEN` and reduces duplicated code.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>