### PR TITLE
maintainers: Add danieldegrasse as collaborator to disk subsystem

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -381,6 +381,8 @@ Disk:
     status: maintained
     maintainers:
         - jfischer-no
+    collaborators:
+        - danieldegrasse
     files:
         - include/storage/disk_access.h
         - include/drivers/disk.h


### PR DESCRIPTION
Adding myself as a collaborator to the disk subsystem

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>