### PR TITLE
Bluetooth: Controller: Fix per adv scheduling issue

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -695,7 +695,7 @@ void sw_switch(uint8_t dir_curr, uint8_t dir_next, uint8_t phy_curr, uint8_t fla
 			hal_radio_sw_switch_coded_tx_config_set(ppi_en, ppi_dis,
 				cc_s2, sw_tifs_toggle);
 
-		} else if (dir_curr == SW_SWITCH_RX) {
+		} else {
 			/* Switching to TX after RX on LE 1M/2M PHY.
 			 *
 			 * NOTE: PHYEND delay compensation and switching between Coded S2 and S8 PHY


### PR DESCRIPTION
sw_switch implementation uses two parallel groups of
PPIs connecting radio and timer tasks and events.
The groups are used interchaneably, one is set for
following radio TX/RX event while the other is in use
(enabled).

The group should be disabled by timer compare event that
starts Radio to TX/RX a PDU. The timer is responsible for
maintenance of TIFS/TMAFS. The disabled group collects
all PPIs required to maintain the TIFS/TMASF. After
the time is reached Radio is started and the group is
disabled. It will be enabled again by software radio
swich during next call.

If the group is not disabled then it will work in parallel
to other one. That causes issues in correct maintenance of
instant when radio shoudl be started for next TX/RX  event
e.g. radio may be enabled to early.

In case the PHY CODED was enabled and periodic advertising
included chained PDUs, that are transmitted back-to-back,
there was missing group delay disable. The missing case was
sw_switch function called with dir_curr and dir_next set
to SW_SWITCH_TX.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>