### PR TITLE
drivers: adc: Set correct interrupt type and remove spurious interrupts

### DIFF
--- a/drivers/adc/adc_npcx.c
+++ b/drivers/adc/adc_npcx.c
@@ -153,8 +153,8 @@ static void adc_npcx_start_scan(const struct device *dev)
 	SET_FIELD(inst->ADCCNF, NPCX_ADCCNF_ADCMD_FIELD,
 			NPCX_ADC_SCAN_CONVERSION_MODE);
 
-	/* Select 'One-Shot' Repetitive mode */
-	inst->ADCCNF |= BIT(NPCX_ADCCNF_INTECEN);
+	/* Enable end of cyclic conversion event interrupt */
+	inst->ADCCNF |= BIT(NPCX_ADCCNF_INTECCEN);
 
 	/* Start conversion */
 	inst->ADCCNF |= BIT(NPCX_ADCCNF_START);

--- a/soc/arm/nuvoton_npcx/common/reg/reg_def.h
+++ b/soc/arm/nuvoton_npcx/common/reg/reg_def.h
@@ -527,11 +527,15 @@ static inline uint32_t npcx_chndat_offset(uint32_t ch)
 #define NPCX_ASCADD_SADDR_FIELD               FIELD(0, 5)
 #define NPCX_ADCSTS_EOCEV                     0
 #define NPCX_ADCSTS_EOCCEV                    1
+#define NPCX_ADCCNF_ADCEN                     0
 #define NPCX_ADCCNF_ADCMD_FIELD               FIELD(1, 2)
 #define NPCX_ADCCNF_ADCRPTC                   3
-#define NPCX_ADCCNF_INTECEN                   6
 #define NPCX_ADCCNF_START                     4
-#define NPCX_ADCCNF_ADCEN                     0
+#define NPCX_ADCCNF_ADCTTE                    5
+#define NPCX_ADCCNF_INTECEN                   6
+#define NPCX_ADCCNF_INTECCEN                  7
+#define NPCX_ADCCNF_INTETCEN                  8
+#define NPCX_ADCCNF_INTOVFEN                  9
 #define NPCX_ADCCNF_STOP                      11
 #define NPCX_CHNDAT_CHDAT_FIELD               FIELD(0, 10)
 #define NPCX_CHNDAT_NEW                       15


### PR DESCRIPTION
In npcx adc driver, we select 'Scan' (Multiple Channels Operation Mode)
mode by default. It means that selected channels in ADCCS will be
converted automatically. Then, read the measured data from CHNDAT
registers if EOCCEV (Event is set after all selected channels are
converted.) flag in ADCSTS is set.

But we enable the wrong interrupt type, INTECEN, during adc
initialization. Ec will send the interrupt after each channel in ADCCS
is converted. It has no harm to the current driver since the driver reads
all selected channels and turns off ADC converter only after EOCCEV is
set in ISR. But it does generate spurious interrupts.

This CL enables the correct interrupt type, INTECCEN, during adc
initialization. Ec only sends the interrupt after all of channels in
ADCCS are converted.

This PR has been verified on npcx7m6fb_evb, npcx9m6f_evb, laser, and volteer Chromebooks.
