### PR TITLE
wifi: esp_at: disable CWMODE auto connect

### DIFF
--- a/drivers/wifi/esp_at/esp.h
+++ b/drivers/wifi/esp_at/esp.h
@@ -107,8 +107,11 @@ extern "C" {
 #define ESP_MODE_AP		2
 #define ESP_MODE_STA_AP		3
 
-#define ESP_CMD_CWMODE(mode) \
-	"AT+"_CWMODE"="STRINGIFY(_CONCAT(ESP_MODE_, mode))
+#if defined(CONFIG_WIFI_ESP_AT_VERSION_1_7)
+#define ESP_CMD_CWMODE(mode) "AT+"_CWMODE"="STRINGIFY(_CONCAT(ESP_MODE_, mode))
+#else
+#define ESP_CMD_CWMODE(mode) "AT+"_CWMODE"="STRINGIFY(_CONCAT(ESP_MODE_, mode))",0"
+#endif
 
 #define ESP_CWDHCP_MODE_STATION		"1"
 #if defined(CONFIG_WIFI_ESP_AT_VERSION_1_7)


### PR DESCRIPTION
In the newer ESP32 AT command versions, the CWMODE command takes an
optional parameter (<auto_connect>) which controls whether the module
will automatically attempt to connect to an AP when switching modes.

This parameter defaults to enabling auto-connect if not specified.

Without this change, modules can successfully connect to an AP before
the `CWAUTOCONN=0` command is processed, resulting in a
`NET_EVENT_WIFI_CONNECT_RESULT` before `NET_EVENT_IF_UP`.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>

See: https://docs.espressif.com/projects/esp-at/en/latest/AT_Command_Set/Wi-Fi_AT_Commands.html#cmd-mode