### PR TITLE
drivers: timer: nrf_rtc_timer: Add Lock Zero Latency IRQs Kconfig

### DIFF
--- a/drivers/timer/Kconfig.nrf_rtc
+++ b/drivers/timer/Kconfig.nrf_rtc
@@ -27,7 +27,7 @@ config NRF_RTC_TIMER_LOCK_ZERO_LATENCY_IRQS
 	# hidden option
 	bool
 	depends on ZERO_LATENCY_IRQS
-	default y
+	default y if !BT_LL_SW_SPLIT
 	help
 	  Enable use of __disable_irq() to disable Zero Latency IRQs to prevent
 	  higher priority contexts (including ZLIs) that might preempt the

--- a/drivers/timer/Kconfig.nrf_rtc
+++ b/drivers/timer/Kconfig.nrf_rtc
@@ -23,6 +23,17 @@ config NRF_RTC_TIMER_USER_CHAN_COUNT
 	help
 	  Use nrf_rtc_timer.h API. Driver is not managing allocation of channels.
 
+config NRF_RTC_TIMER_LOCK_ZERO_LATENCY_IRQS
+	# hidden option
+	bool
+	depends on ZERO_LATENCY_IRQS
+	default y
+	help
+	  Enable use of __disable_irq() to disable Zero Latency IRQs to prevent
+	  higher priority contexts (including ZLIs) that might preempt the
+	  handler and call nrf_rtc_timer API from destroying the internal state
+	  in nrf_rtc_timer.
+
 choice
 	prompt "Clock startup policy"
 	default SYSTEM_CLOCK_WAIT_FOR_STABILITY

--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -98,7 +98,7 @@ static uint32_t full_int_lock(void)
 {
 	uint32_t mcu_critical_state;
 
-	if (IS_ENABLED(CONFIG_ZERO_LATENCY_IRQS)) {
+	if (IS_ENABLED(CONFIG_NRF_RTC_TIMER_LOCK_ZERO_LATENCY_IRQS)) {
 		mcu_critical_state = __get_PRIMASK();
 		__disable_irq();
 	} else {
@@ -110,7 +110,7 @@ static uint32_t full_int_lock(void)
 
 static void full_int_unlock(uint32_t mcu_critical_state)
 {
-	if (IS_ENABLED(CONFIG_ZERO_LATENCY_IRQS)) {
+	if (IS_ENABLED(CONFIG_NRF_RTC_TIMER_LOCK_ZERO_LATENCY_IRQS)) {
 		__set_PRIMASK(mcu_critical_state);
 	} else {
 		irq_unlock(mcu_critical_state);


### PR DESCRIPTION
Add an explicit Kconfig option to enable use of
__disable_irq() in nRF RTC timer driver to prevent higher
priority contexts (including ZLIs) that might preempt the
handler and call nrf_rtc_timer API from destroying the
internal state in nrf_rtc_timer.

Relates to commit https://github.com/zephyrproject-rtos/zephyr/commit/fcda8699cb8c26daaf1002508397f4b6321c78e3 ("drivers: timer: extend
nrf_rtc_timer").

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>