### PR TITLE
scripts: size_report: Add support for TF-M and BL2 image size reports

### DIFF
--- a/cmake/reports/CMakeLists.txt
+++ b/cmake/reports/CMakeLists.txt
@@ -29,6 +29,44 @@ foreach(report ram_report rom_report footprint)
     )
 endforeach()
 
+if (CONFIG_BUILD_WITH_TFM)
+  foreach(report ram_report rom_report footprint)
+    add_custom_target(
+      tfm_${report}
+      ${PYTHON_EXECUTABLE}
+      ${ZEPHYR_BASE}/scripts/footprint/size_report
+      -k $<TARGET_PROPERTY:tfm,TFM_S_ELF_FILE>
+      -z ${ZEPHYR_BASE}
+      -o ${CMAKE_BINARY_DIR}
+      ${workspace_arg}
+      -d ${report_depth}
+      ${flag_for_${report}}
+      DEPENDS tfm
+      USES_TERMINAL
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+      )
+  endforeach()
+endif()
+
+if (CONFIG_TFM_BL2)
+  foreach(report ram_report rom_report footprint)
+  add_custom_target(
+    bl2_${report}
+    ${PYTHON_EXECUTABLE}
+    ${ZEPHYR_BASE}/scripts/footprint/size_report
+    -k $<TARGET_PROPERTY:tfm,BL2_ELF_FILE>
+    -z ${ZEPHYR_BASE}
+    -o ${CMAKE_BINARY_DIR}
+    ${workspace_arg}
+    -d ${report_depth}
+    ${flag_for_${report}}
+    DEPENDS tfm
+    USES_TERMINAL
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    )
+  endforeach()
+endif()
+
 find_program(PUNCOVER puncover)
 
 if(NOT ${PUNCOVER} STREQUAL PUNCOVER-NOTFOUND)

--- a/doc/guides/optimizations/tools.rst
+++ b/doc/guides/optimizations/tools.rst
@@ -79,17 +79,17 @@ which will generate something similar to the output below::
     z_idle_threads                                                                         128     2.65%
     z_interrupt_stacks                                                                    2048    42.36%
     z_main_thread                                                                          128     2.65%
-    arch                                                                                       1     0.02%
+    arch                                                                                     1     0.02%
     arm                                                                                      1     0.02%
-        core                                                                                   1     0.02%
+        core                                                                                 1     0.02%
         aarch32                                                                              1     0.02%
-            cortex_m                                                                           1     0.02%
+            cortex_m                                                                         1     0.02%
             mpu                                                                              1     0.02%
-                arm_mpu.c                                                                      1     0.02%
+                arm_mpu.c                                                                    1     0.02%
                 static_regions_num                                                           1     0.02%
-    drivers                                                                                  536    11.09%
+    drivers                                                                                536    11.09%
     clock_control                                                                          100     2.07%
-        nrf_power_clock.c                                                                    100     2.07%
+        nrf_power_clock.c                                                                  100     2.07%
         __device_clock_nrf                                                                  16     0.33%
         data                                                                                80     1.65%
         hfclk_users                                                                          4     0.08%
@@ -127,23 +127,23 @@ which will generate something similar to the output below::
     levels.8826                                                                             20     0.10%
     mpu_config                                                                               8     0.04%
     transitions.10558                                                                       12     0.06%
-    arch                                                                                    1194     5.74%
+    arch                                                                                  1194     5.74%
     arm                                                                                   1194     5.74%
-        core                                                                                1194     5.74%
+        core                                                                              1194     5.74%
         aarch32                                                                           1194     5.74%
-            cortex_m                                                                         852     4.09%
+            cortex_m                                                                       852     4.09%
             fault.c                                                                        400     1.92%
-                bus_fault.isra.0                                                              60     0.29%
-                mem_manage_fault.isra.0                                                       56     0.27%
-                usage_fault.isra.0                                                            36     0.17%
-                z_arm_fault                                                                  232     1.11%
-                z_arm_fault_init                                                              16     0.08%
+                bus_fault.isra.0                                                            60     0.29%
+                mem_manage_fault.isra.0                                                     56     0.27%
+                usage_fault.isra.0                                                          36     0.17%
+                z_arm_fault                                                                232     1.11%
+                z_arm_fault_init                                                            16     0.08%
             irq_init.c                                                                      24     0.12%
-                z_arm_interrupt_init                                                          24     0.12%
+                z_arm_interrupt_init                                                        24     0.12%
             mpu                                                                            352     1.69%
-                arm_core_mpu.c                                                                56     0.27%
+                arm_core_mpu.c                                                              56     0.27%
                 z_arm_configure_static_mpu_regions                                          56     0.27%
-                arm_mpu.c                                                                    296     1.42%
+                arm_mpu.c                                                                  296     1.42%
                 __init_sys_init_arm_mpu_init0                                                8     0.04%
                 arm_core_mpu_configure_static_mpu_regions                                   20     0.10%
                 arm_core_mpu_disable                                                        16     0.08%

--- a/doc/guides/tfm/build.rst
+++ b/doc/guides/tfm/build.rst
@@ -22,9 +22,9 @@ Images Created by the TF-M Build
 
 The TF-M build system creates the following executable files:
 
-* tfm_s - the secure firmware
+* tfm_s - TF-M secure firmware
 * tfm_ns - a nonsecure app which is discarded in favor of the Zephyr app
-* bl2 - mcuboot, if enabled
+* bl2 - TF-M MCUboot, if enabled
 
 For each of these, it creates .bin, .hex, .elf, and .axf files.
 
@@ -118,3 +118,42 @@ following CMake snippet in your CMakeLists.txt file.
    The ``TFM_CMAKE_OPTIONS`` is a list so it is possible to append multiple
    options. Also CMake generator expressions are supported, such as
    ``$<1:-DFOO=bar>``
+
+Footprint and Memory Usage
+**************************
+
+The build system offers targets to view and analyse RAM and ROM usage in generated images.
+The tools run on the final images and give information about size of symbols and code being used in both RAM and ROM.
+For more information on these tools look here: :ref:`footprint_tools`
+
+Use the ``tfm_ram_report`` to get the RAM report for TF-M secure firmware (tfm_s).
+
+.. zephyr-app-commands::
+    :tool: all
+    :app: samples/hello_world
+    :board: mps2_an521_ns
+    :goals: tfm_ram_report
+
+Use the ``tfm_rom_report`` to get the ROM report for TF-M secure firmware (tfm_s).
+
+.. zephyr-app-commands::
+    :tool: all
+    :app: samples/hello_world
+    :board: mps2_an521_ns
+    :goals: tfm_rom_report
+
+Use the ``bl2_ram_report`` to get the RAM report for TF-M MCUboot, if enabled.
+
+.. zephyr-app-commands::
+    :tool: all
+    :app: samples/hello_world
+    :board: mps2_an521_ns
+    :goals: bl2_ram_report
+
+Use the ``bl2_rom_report`` to get the ROM report for TF-M MCUboot, if enabled.
+
+.. zephyr-app-commands::
+    :tool: all
+    :app: samples/hello_world
+    :board: mps2_an521_ns
+    :goals: bl2_rom_report

--- a/doc/guides/tfm/build.rst
+++ b/doc/guides/tfm/build.rst
@@ -23,7 +23,7 @@ Images Created by the TF-M Build
 The TF-M build system creates the following executable files:
 
 * tfm_s - TF-M secure firmware
-* tfm_ns - a nonsecure app which is discarded in favor of the Zephyr app
+* tfm_ns - TF-M non-secure app (only used by regression tests).
 * bl2 - TF-M MCUboot, if enabled
 
 For each of these, it creates .bin, .hex, .elf, and .axf files.
@@ -37,7 +37,10 @@ file which combines them:
 
 For each of these, only .bin files are created.
 
-The Zephyr build system usually signs both tfm_s and the Zephyr ns app itself.
+The TF-M non-secure app is discarded in favor of Zephyr non-secure app except
+when running the TF-M regression test suite.
+
+The Zephyr build system usually signs both tfm_s and the Zephyr non-secure app itself.
 See below for details.
 
 The 'tfm' target contains properties for all these paths.

--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -162,9 +162,11 @@ if (CONFIG_BUILD_WITH_TFM)
   endif()
 
   if(CONFIG_TFM_BL2)
+    set(BL2_ELF_FILE ${TFM_BINARY_DIR}/bin/bl2.elf)
     set(BL2_BIN_FILE ${TFM_BINARY_DIR}/bin/bl2.bin)
     set(BL2_HEX_FILE ${TFM_BINARY_DIR}/bin/bl2.hex)
   endif()
+  set(TFM_S_ELF_FILE ${TFM_BINARY_DIR}/bin/tfm_s.elf)
   set(TFM_S_BIN_FILE ${TFM_BINARY_DIR}/bin/tfm_s.bin)
   set(TFM_S_HEX_FILE ${TFM_BINARY_DIR}/bin/tfm_s.hex)
   set(TFM_NS_BIN_FILE ${TFM_BINARY_DIR}/bin/tfm_ns.bin)
@@ -181,8 +183,10 @@ if (CONFIG_BUILD_WITH_TFM)
     ${PSA_TEST_PAL_FILE}
     ${PSA_TEST_COMBINE_FILE}
     ${PLATFORM_NS_FILE}
+    ${BL2_ELF_FILE}
     ${BL2_BIN_FILE}
     ${BL2_HEX_FILE}
+    ${TFM_S_ELF_FILE}
     ${TFM_S_BIN_FILE}
     ${TFM_S_HEX_FILE}
     ${TFM_NS_BIN_FILE}
@@ -287,6 +291,7 @@ if (CONFIG_BUILD_WITH_TFM)
   # These files are produced by the TFM build system.
   if(CONFIG_TFM_BL2)
     set_target_properties(tfm PROPERTIES
+      BL2_ELF_FILE ${BL2_ELF_FILE}
       BL2_BIN_FILE ${BL2_BIN_FILE}
       BL2_HEX_FILE ${BL2_HEX_FILE}
       )
@@ -297,6 +302,7 @@ if (CONFIG_BUILD_WITH_TFM)
   # Note that the Nonsecure FW is replaced by the Zephyr app in regular Zephyr
   # builds.
   set_target_properties(tfm PROPERTIES
+    TFM_S_ELF_FILE ${TFM_S_ELF_FILE}
     TFM_S_BIN_FILE ${TFM_S_BIN_FILE} # TFM Secure FW (unsigned)
     TFM_S_HEX_FILE ${TFM_S_HEX_FILE} # TFM Secure FW (unsigned)
     TFM_NS_BIN_FILE ${TFM_NS_BIN_FILE} # TFM Nonsecure FW (unsigned)


### PR DESCRIPTION
Add support for TF-M and BL2 image size reports.
This adds the following targets when TF-M or BL2 is enabled:
tfm_rom_report, tfm_ram_report, tfm_footprint
bl2_rom_report, bl2_ram_report, bl2_footprint

Example:
west build -t tfm_rom_report

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>