### PR TITLE
sof: disable the System Agent

### DIFF
--- a/samples/subsys/audio/sof/prj.conf
+++ b/samples/subsys/audio/sof/prj.conf
@@ -1,6 +1,7 @@
 CONFIG_SOF=y
 CONFIG_LOG=y
 CONFIG_BUILD_OUTPUT_BIN=n
+CONFIG_HAVE_AGENT=n
 
 # Requires heap_info() be implemented, but no Zephyr wrapper
 CONFIG_DEBUG_MEMORY_USAGE_SCAN=n


### PR DESCRIPTION
The SOF System Agent is redundant under Zephyr, we're using different performance monitors there.
