### PR TITLE
drivers: usdhc: Fixes for teensy4

### DIFF
--- a/boards/arm/mimxrt1170_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1170_evk/Kconfig.defconfig
@@ -22,9 +22,6 @@ config DISK_DRIVER_SDMMC
 config SDMMC_USDHC_DAT3_PWR_TOGGLE
 	default y
 
-config SDMMC_USDHC_DAT3_PWR_DELAY
-	default 10
-
 endif # DISK_DRIVERS
 
 if FLASH

--- a/boards/arm/teensy4/teensy41.dts
+++ b/boards/arm/teensy4/teensy41.dts
@@ -28,5 +28,4 @@
 &usdhc1 {
 	status = "okay";
 	no-1-8-v;
-	detect-dat3;
 };

--- a/drivers/disk/Kconfig.usdhc
+++ b/drivers/disk/Kconfig.usdhc
@@ -12,7 +12,7 @@ config SDMMC_USDHC_DAT3_PWR_TOGGLE
 
 config SDMMC_USDHC_DAT3_PWR_DELAY
 	int
-	default 0
+	default 400
 	help
 	  Period in milliseconds to delay between powering off the SD card and
 	  applying power again, whenever the SD card power will be cycled.


### PR DESCRIPTION
Teensy4 does not support an SD card detection method, so the USDHC driver needs to be updated to assume that a card is present when no card detection method is present. This PR also fixes DAT3 card detection for boards using it, by updating the usdhc delay function to correctly use milliseconds for delay periods, rather than polling the system clock.