### PR TITLE
Bluetooth: Controller: Fix out-of-bound memory write

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso.c
@@ -65,7 +65,9 @@ static int init_reset(void);
 /* Allocate data path pools for RX/TX directions for each stream */
 #define BT_CTLR_ISO_STREAMS ((2 * (BT_CTLR_CONN_ISO_STREAMS)) + \
 			     BT_CTLR_SYNC_ISO_STREAMS)
+#if BT_CTLR_ISO_STREAMS
 static struct ll_iso_datapath datapath_pool[BT_CTLR_ISO_STREAMS];
+#endif /* BT_CTLR_ISO_STREAMS */
 
 static void *datapath_free;
 
@@ -838,9 +840,11 @@ static int init_reset(void)
 		 CONFIG_BT_CTLR_ISO_TX_BUFFERS, &mem_link_tx.free);
 #endif /* CONFIG_BT_CTLR_ADV_ISO || CONFIG_BT_CTLR_CONN_ISO */
 
+#if BT_CTLR_ISO_STREAMS
 	/* Initialize ISO Datapath pool */
 	mem_init(datapath_pool, sizeof(struct ll_iso_datapath),
 		 sizeof(datapath_pool) / sizeof(struct ll_iso_datapath), &datapath_free);
+#endif /* BT_CTLR_ISO_STREAMS */
 
 	return 0;
 }


### PR DESCRIPTION
Fix out-of-bound memory write during mem_init due to
regression introduced in commit c6750de9c191 ("Bluetooth:
Controller: Fix missing ISOAL sink destroy").'

Fixes #43392.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>