### PR TITLE
net: gptp: Fix sync_receipt_time calculation in gptp_mi

### DIFF
--- a/subsys/net/l2/ethernet/gptp/gptp_mi.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_mi.c
@@ -706,9 +706,9 @@ static void gptp_mi_clk_slave_sync_compute(void)
 
 	pss = &state->pss_rcv_ptr->sync_info;
 
-	sync_receipt_time = pss->rate_ratio;
+	sync_receipt_time = port_ds->neighbor_prop_delay;
+	sync_receipt_time *= pss->rate_ratio;
 	sync_receipt_time /= port_ds->neighbor_rate_ratio;
-	sync_receipt_time *= port_ds->neighbor_prop_delay;
 	sync_receipt_time += pss->follow_up_correction_field;
 	sync_receipt_time += port_ds->delay_asymmetry;
 


### PR DESCRIPTION
Fix #42800
Both pss->rate_ratio and port_ds->neighbor_rate_ratio are double type but sync_receipt_time is uint64_t. If pss->rate_ratio is less than 1 or sync_receipt_time * port_ds->neighbor_rate_ratio is less than 1, sync_receipt_time becomes 0 due to double to uint64_t cast.

Signed-off-by: Lu Ding <lucasdinglu@gmail.com>