### PR TITLE
kernel: Use k_ticks_t for ticks to avoid conversions

### DIFF
--- a/include/kernel_structs.h
+++ b/include/kernel_structs.h
@@ -29,6 +29,7 @@
 #include <sys/sys_heap.h>
 #include <arch/structs.h>
 #include <kernel/stats.h>
+#include <sys_clock.h>
 #endif
 
 #ifdef __cplusplus
@@ -155,7 +156,7 @@ struct z_kernel {
 	struct _cpu cpus[CONFIG_MP_NUM_CPUS];
 
 #ifdef CONFIG_PM
-	int32_t idle; /* Number of ticks for kernel idling */
+	k_ticks_t idle; /* Number of ticks for kernel idling */
 #endif
 
 	/*

--- a/include/pm/policy.h
+++ b/include/pm/policy.h
@@ -10,6 +10,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include <sys_clock.h>
 #include <pm/state.h>
 #include <sys/slist.h>
 
@@ -55,7 +56,7 @@ struct pm_policy_latency_request {
  * @return The power state the system should use for the given cpu. The function
  * will return NULL if system should remain into PM_STATE_ACTIVE.
  */
-const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks);
+const struct pm_state_info *pm_policy_next_state(uint8_t cpu, k_ticks_t ticks);
 
 /** @endcond */
 

--- a/include/timeout_q.h
+++ b/include/timeout_q.h
@@ -13,7 +13,7 @@
  */
 
 #include <kernel.h>
-
+#include <sys_clock.h>
 #include <stdbool.h>
 
 #ifdef __cplusplus
@@ -56,7 +56,7 @@ static inline int z_abort_thread_timeout(struct k_thread *thread)
 
 int32_t z_get_next_timeout_expiry(void);
 
-void z_set_timeout_expiry(int32_t ticks, bool is_idle);
+void z_set_timeout_expiry(k_ticks_t ticks, bool is_idle);
 
 k_ticks_t z_timeout_remaining(const struct _timeout *timeout);
 

--- a/kernel/idle.c
+++ b/kernel/idle.c
@@ -62,7 +62,7 @@ void idle(void *unused1, void *unused2, void *unused3)
 		(void) arch_irq_lock();
 
 #ifdef CONFIG_PM
-		_kernel.idle = z_get_next_timeout_expiry();
+		_kernel.idle = (k_ticks_t)z_get_next_timeout_expiry();
 
 		/*
 		 * Call the suspend hook function of the soc interface
@@ -79,7 +79,8 @@ void idle(void *unused1, void *unused2, void *unused3)
 		 * which is essential for the kernel's scheduling
 		 * logic.
 		 */
-		if (k_is_pre_kernel() || !pm_system_suspend(_kernel.idle)) {
+		if (k_is_pre_kernel() ||
+		    !pm_system_suspend((int32_t)_kernel.idle)) {
 			k_cpu_idle();
 		}
 #else

--- a/kernel/idle.c
+++ b/kernel/idle.c
@@ -80,7 +80,7 @@ void idle(void *unused1, void *unused2, void *unused3)
 		 * logic.
 		 */
 		if (k_is_pre_kernel() ||
-		    !pm_system_suspend((int32_t)_kernel.idle)) {
+		    !pm_system_suspend(_kernel.idle)) {
 			k_cpu_idle();
 		}
 #else

--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -249,7 +249,7 @@ void z_mem_manage_boot_finish(void);
  *
  * @return True if the system suspended, otherwise return false
  */
-bool pm_system_suspend(int32_t ticks);
+bool pm_system_suspend(k_ticks_t ticks);
 
 /**
  * Notify exit from kernel idling after PM operations

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -18,6 +18,7 @@
 #include <sys/atomic.h>
 #include <sys/math_extras.h>
 #include <timing/timing.h>
+#include <sys_clock.h>
 
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
@@ -413,7 +414,7 @@ void z_reset_time_slice(struct k_thread *curr)
 	 */
 	if (slice_time(curr) != 0) {
 		_current_cpu->slice_ticks = slice_time(curr) + sys_clock_elapsed();
-		z_set_timeout_expiry(slice_time(curr), false);
+		z_set_timeout_expiry((k_ticks_t)slice_time(curr), false);
 	}
 }
 

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -212,12 +212,12 @@ int32_t z_get_next_timeout_expiry(void)
 	return ret;
 }
 
-void z_set_timeout_expiry(int32_t ticks, bool is_idle)
+void z_set_timeout_expiry(k_ticks_t ticks, bool is_idle)
 {
 	LOCKED(&timeout_lock) {
 		int next_to = next_timeout();
 		bool sooner = (next_to == K_TICKS_FOREVER)
-			      || (ticks <= next_to);
+			|| (ticks <= (k_ticks_t)next_to);
 		bool imminent = next_to <= 1;
 
 		/* Only set new timeouts when they are sooner than

--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -226,9 +226,9 @@ bool pm_system_suspend(k_ticks_t ticks)
 		 * We need to set the timer to interrupt a little bit early to
 		 * accommodate the time required by the CPU to fully wake up.
 		 */
-		z_set_timeout_expiry((int32_t)(uint32_t)(ticks -
-				k_us_to_ticks_ceil32(
-				z_cpus_pm_state[id].exit_latency_us)),
+		z_set_timeout_expiry(ticks -
+				(k_ticks_t)k_us_to_ticks_ceil32(
+				z_cpus_pm_state[id].exit_latency_us),
 				true);
 	}
 

--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -206,7 +206,7 @@ bool pm_system_suspend(k_ticks_t ticks)
 	if (!atomic_test_bit(z_cpus_pm_state_forced, id)) {
 		const struct pm_state_info *info;
 
-		info = pm_policy_next_state(id, (int32_t)ticks);
+		info = pm_policy_next_state(id, ticks);
 		if (info != NULL) {
 			z_cpus_pm_state[id] = *info;
 		}

--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -196,7 +196,7 @@ bool pm_state_force(uint8_t cpu, const struct pm_state_info *info)
 	return ret;
 }
 
-bool pm_system_suspend(int32_t ticks)
+bool pm_system_suspend(k_ticks_t ticks)
 {
 	bool ret = true;
 	uint8_t id = _current_cpu->id;
@@ -206,7 +206,7 @@ bool pm_system_suspend(int32_t ticks)
 	if (!atomic_test_bit(z_cpus_pm_state_forced, id)) {
 		const struct pm_state_info *info;
 
-		info = pm_policy_next_state(id, ticks);
+		info = pm_policy_next_state(id, (int32_t)ticks);
 		if (info != NULL) {
 			z_cpus_pm_state[id] = *info;
 		}
@@ -226,10 +226,10 @@ bool pm_system_suspend(int32_t ticks)
 		 * We need to set the timer to interrupt a little bit early to
 		 * accommodate the time required by the CPU to fully wake up.
 		 */
-		z_set_timeout_expiry(ticks -
-		     k_us_to_ticks_ceil32(
-			     z_cpus_pm_state[id].exit_latency_us),
-				     true);
+		z_set_timeout_expiry((int32_t)(uint32_t)(ticks -
+				k_us_to_ticks_ceil32(
+				z_cpus_pm_state[id].exit_latency_us)),
+				true);
 	}
 
 #if CONFIG_PM_DEVICE

--- a/subsys/pm/policy.c
+++ b/subsys/pm/policy.c
@@ -57,7 +57,7 @@ static void update_max_latency(void)
 }
 
 #ifdef CONFIG_PM_POLICY_DEFAULT
-const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks)
+const struct pm_state_info *pm_policy_next_state(uint8_t cpu, k_ticks_t ticks)
 {
 	uint8_t num_cpu_states;
 	const struct pm_state_info *cpu_states;
@@ -82,7 +82,7 @@ const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks)
 		}
 
 		if ((ticks == K_TICKS_FOREVER) ||
-		    (ticks >= (min_residency + exit_latency))) {
+		    (ticks >= (k_ticks_t)(min_residency + exit_latency))) {
 			return state;
 		}
 	}

--- a/subsys/pm/policy.c
+++ b/subsys/pm/policy.c
@@ -23,14 +23,14 @@ static struct k_spinlock latency_lock;
 /** List of maximum latency requests. */
 static sys_slist_t latency_reqs;
 /** Maximum CPU latency in ticks */
-static int32_t max_latency_ticks = K_TICKS_FOREVER;
+static k_ticks_t max_latency_ticks = K_TICKS_FOREVER;
 /** Callback to notify when maximum latency changes. */
 static pm_policy_latency_changed_cb_t latency_changed_cb;
 
 /** @brief Update maximum allowed latency. */
 static void update_max_latency(void)
 {
-	int32_t new_max_latency_ticks = K_TICKS_FOREVER;
+	k_ticks_t new_max_latency_ticks = K_TICKS_FOREVER;
 	struct pm_policy_latency_request *req;
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&latency_reqs, req, node) {

--- a/tests/subsys/pm/policy_api/src/main.c
+++ b/tests/subsys/pm/policy_api/src/main.c
@@ -226,7 +226,7 @@ static void test_pm_policy_next_state_default_latency(void)
 #endif /* CONFIG_PM_POLICY_DEFAULT */
 
 #ifdef CONFIG_PM_POLICY_CUSTOM
-const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks)
+const struct pm_state_info *pm_policy_next_state(uint8_t cpu, k_ticks_t ticks)
 {
 	static const struct pm_state_info state = {.state = PM_STATE_SOFT_OFF};
 


### PR DESCRIPTION
There are several types been used to hold ticks, for example, `int`, `int64_t`, `int32_t`, .... though ticks is supposed to be either `uint32_t` or `int64_t`.  Depending on the conversion that is done it can lead to bugs. If we don't use the proper type internally the behavior described in  https://docs.zephyrproject.org/latest/kconfig.html#CONFIG_TIMEOUT_64BIT may not be honored due internal conversions to types with lower precision.