### PR TITLE
Bluetooth: Controller: Fix Extended Advertising Power Amp setup

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -357,7 +357,7 @@ static void isr_tx_chain(void *param)
 	 */
 	radio_tmr_end_capture();
 
-#if defined(HAL_RADIO_GPIO_HAVE_LNA_PIN)
+#if defined(HAL_RADIO_GPIO_HAVE_PA_PIN)
 	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
 		/* PA/LNA enable is overwriting packet end used in ISR
 		 * profiling, hence back it up for later use.
@@ -365,12 +365,14 @@ static void isr_tx_chain(void *param)
 		lll_prof_radio_end_backup();
 	}
 
-	radio_gpio_lna_setup();
-	radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() + EVENT_B2B_MAFS_US -
-				 4 - radio_tx_chain_delay_get(lll->phy_s,
-							      lll->phy_flags) -
-				 HAL_RADIO_GPIO_LNA_OFFSET);
-#endif /* HAL_RADIO_GPIO_HAVE_LNA_PIN */
+	radio_gpio_pa_setup();
+	radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() +
+				 EVENT_B2B_MAFS_US -
+				 (EVENT_CLOCK_JITTER_US << 1U) -
+				 radio_tx_chain_delay_get(lll->phy_s,
+							  lll->phy_flags) -
+				 HAL_RADIO_GPIO_PA_OFFSET);
+#endif /* HAL_RADIO_GPIO_HAVE_PA_PIN */
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
 		lll_prof_send();


### PR DESCRIPTION
Fix Extended Advertising implementation to setup Power
Amplifier (PA) GPIO toggle for transmission instead of
incorrect Low Noise Amplifier (LNA) setup which is for
reception.

Relates to commit 4e5290948e45 ("Bluetooth: Controller: Fix
Periodic Advertising to setup Power Amp").

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>