### PR TITLE
Fix bluetooth-tests workflow

### DIFF
--- a/.github/workflows/bluetooth-tests.yaml
+++ b/.github/workflows/bluetooth-tests.yaml
@@ -3,6 +3,7 @@ name: Bluetooth Tests
 on:
   pull_request:
     paths:
+      - ".github/workflows/bluetooth-test*.yaml"
       - "west.yml"
       - "subsys/bluetooth/**"
       - "tests/bluetooth/bsim_bt/**"

--- a/.github/workflows/bluetooth-tests.yaml
+++ b/.github/workflows/bluetooth-tests.yaml
@@ -40,6 +40,8 @@ jobs:
 
       - name: checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: west setup
         env:


### PR DESCRIPTION
This commit updates the Bluetooth test workflow to fetch all branches
during checkout by specifying the fetch depth of 0, in order to allow
rebasing onto the latest main branch before running the workflow.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

This fixes the bug introduced in the PR #43327:
```
fatal: invalid upstream 'origin/main'
Error: Process completed with exit code 128.
```