### PR TITLE
lsm6dso: Add FIFO and LPF capabilities

### DIFF
--- a/drivers/sensor/lsm6dso/Kconfig
+++ b/drivers/sensor/lsm6dso/Kconfig
@@ -85,4 +85,7 @@ config LSM6DSO_EXT_LPS22HB
 
 endif # LSM6DSO_SENSORHUB
 
+config LSM6DSO_ENABLE_FIFO
+	bool "Use FIFO MODE"
+
 endif # LSM6DSO

--- a/drivers/sensor/lsm6dso/lsm6dso.h
+++ b/drivers/sensor/lsm6dso/lsm6dso.h
@@ -57,10 +57,15 @@ struct lsm6dso_config {
 	uint8_t gyro_odr;
 	uint8_t gyro_range;
 #ifdef CONFIG_LSM6DSO_TRIGGER
-	const struct gpio_dt_spec gpio_drdy;
+	const struct gpio_dt_spec gpio_intr;
 	uint8_t int_pin;
 	bool trig_enabled;
 #endif /* CONFIG_LSM6DSO_TRIGGER */
+#ifdef CONFIG_LSM6DSO_ENABLE_FIFO
+	uint16_t batch_cnt_thr;
+	uint8_t accel_bdr;
+	uint8_t gyro_bdr;
+#endif /* CONFIG_LSM6DSO_ENABLE_FIFO */
 };
 
 union samples {
@@ -106,6 +111,9 @@ struct lsm6dso_data {
 	sensor_trigger_handler_t handler_drdy_acc;
 	sensor_trigger_handler_t handler_drdy_gyr;
 	sensor_trigger_handler_t handler_drdy_temp;
+#if defined(CONFIG_LSM6DSO_ENABLE_FIFO)
+	sensor_trigger_handler_t handler_fifo_bdr_cnt;
+#endif
 
 #if defined(CONFIG_LSM6DSO_TRIGGER_OWN_THREAD)
 	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_LSM6DSO_THREAD_STACK_SIZE);

--- a/dts/bindings/sensor/st,lsm6dso-common.yaml
+++ b/dts/bindings/sensor/st,lsm6dso-common.yaml
@@ -114,3 +114,53 @@ properties:
         - 8  # 1667Hz
         - 9  # 3333Hz
         - 10 # 6667Hz
+
+    accel-bdr:
+      type: int
+      required: false
+      default: 0
+      description: |
+        Specify the default accel batch data rate expressed in samples per second (Hz).
+        Default is not batched.
+      enum:
+        - 0  # Not batched
+        - 1  # 12.5Hz
+        - 2  # 26Hz
+        - 3  # 52Hz
+        - 4  # 104Hz
+        - 5  # 208Hz
+        - 6  # 417Hz
+        - 7  # 833Hz
+        - 8  # 1667Hz
+        - 9  # 3333Hz
+        - 10 # 6667Hz
+        - 11 # 1.6Hz
+
+    gyro-bdr:
+      type: int
+      required: false
+      default: 0
+      description: |
+        Specify the default gyro batch data rate expressed in samples per second (Hz).
+        Default is not batched.
+      enum:
+        - 0  # Not batched
+        - 1  # 12.5Hz
+        - 2  # 26Hz
+        - 3  # 52Hz
+        - 4  # 104Hz
+        - 5  # 208Hz
+        - 6  # 417Hz
+        - 7  # 833Hz
+        - 8  # 1667Hz
+        - 9  # 3333Hz
+        - 10 # 6667Hz
+        - 11 # 6.5Hz
+
+    batch-cnt-thr:
+      type: int
+      required: false
+      default: 0
+      description: |
+        Specify the default batch count threshold to trigger interrupt.
+        max value is 2047

--- a/include/drivers/sensor/lsm6dso.h
+++ b/include/drivers/sensor/lsm6dso.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022, Linus Reitmayr
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Datasheet:
+ * https://www.st.com/resource/en/datasheet/lsm6dso.pdf
+ */
+
+/**
+ * @file
+ * @brief Extended public API for the lsm6dso driver
+ *
+ * This exposes one attribute for the lsm6dso which can be used for
+ * setting the low pass filter cut-off frequency.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_LSM6DSO_H_
+#define ZEPHYR_INCLUDE_DRIVERS_SENSOR_LSM6DSO_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <drivers/sensor.h>
+
+/** @brief Sensor specific attributes of LSM6DSO */
+enum sensor_attribute_lsm6dso {
+	/** Sensor CPI for both X and Y axes. */
+	SENSOR_ATTR_LPF_FREQ = SENSOR_ATTR_PRIV_START,
+};
+
+#if defined(CONFIG_LSM6DSO_ENABLE_FIFO)
+enum sensor_trigger_type_lsm6dso {
+	/** Counter batch data rate trigger */
+	SENSOR_TRIG_LSM6DSO_CNT_BDR = SENSOR_TRIG_PRIV_START,
+};
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_LSM6DSO_H_ */


### PR DESCRIPTION
- Add LSM6DSO_ENABLE_FIFO to Kconfig to enable fifo output in prj.conf
- New dts variables for fifo batch mode config:
  - accel and gyro batch data rate: rate of data written to fifo
  - batch count threshold: interrupt triggered when threshold reached
- New public API for lsm6dso sensor specific triggers and attributes:
  - Trigger SENSOR_TRIG_LSM6DSO_CNT_BDR for bdr count threshold reached
  - Attribute SENSOR_ATTR_LPF_FREQ for setting low pass filter cut-off
    frequency for either accel or gyro
- Ability to enable LPF for accel and gyro by configuring cut-off via
  sensor attribute set API
- Function to fetch all data in fifo:
  - Only handles accel and gyro data with tagged with LSM6DSO_GYRO_NC_TAG
    and LSM6DSO_XL_NC_TAG
  - Called with channel SENSOR_CHAN_ALL if fifo enabled
- Initialise FIFO with optional batch mode:
  - Threshold, accel and gyro batch data rate configured in devicetree
- Rename interrupt GPIO pin to be more generic term
- New trigger and handler for fifo bdr count threshold reached:
  - Initialise interrupt on either int1 or 2 line
  - Clear FIFO when trigger gets enabled
  - Use accel or gyro for batch counter based on trigger channel

Signed-off-by: Linus Reitmayr <linus.reitmayr@gaitq.com>