### PR TITLE
drivers: dma: dw_common: fix style issue

### DIFF
--- a/drivers/dma/dma_dw_common.c
+++ b/drivers/dma/dma_dw_common.c
@@ -39,12 +39,12 @@ LOG_MODULE_REGISTER(dma_dw_common);
 
 static ALWAYS_INLINE void dw_write(uint32_t dma_base, uint32_t reg, uint32_t value)
 {
-	*((volatile uint32_t*)(dma_base + reg)) = value;
+	*((volatile uint32_t *)(dma_base + reg)) = value;
 }
 
 static ALWAYS_INLINE uint32_t dw_read(uint32_t dma_base, uint32_t reg)
 {
-	return *((volatile uint32_t*)(dma_base + reg));
+	return *((volatile uint32_t *)(dma_base + reg));
 }
 
 void dw_dma_isr(const struct device *dev)


### PR DESCRIPTION
Fix a couple of issues reported by checkpatch:

ERROR:POINTER_LOCATION: "(foo*)" should be "(foo *)"