### PR TITLE
drivers: gpio_pcal6408a: Fix handling of the GPIO_INT_DEBOUNCE flag

### DIFF
--- a/drivers/gpio/gpio_pcal6408a.c
+++ b/drivers/gpio/gpio_pcal6408a.c
@@ -124,11 +124,9 @@ static int pcal6408a_pin_configure(const struct device *dev,
 	int rc;
 
 	/* This device does not support open-source outputs, and open-drain
-	 * outputs can be only configured port-wise. It also does not support
-	 * debouncing.
+	 * outputs can be only configured port-wise.
 	 */
-	if ((flags & GPIO_SINGLE_ENDED) != 0 ||
-	    (flags & GPIO_INT_DEBOUNCE) != 0) {
+	if ((flags & GPIO_SINGLE_ENDED) != 0) {
 		return -ENOTSUP;
 	}
 


### PR DESCRIPTION
Ignore the flag instead of rejecting it with -ENOTSUP, as this is what
the GPIO API expects from drivers that do not support debouncing.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>