### PR TITLE
net: openthread: remove `CONFIG_OPENTHREAD_CSL_SAMPLE_WINDOW`

### DIFF
--- a/subsys/net/l2/openthread/Kconfig.thread
+++ b/subsys/net/l2/openthread/Kconfig.thread
@@ -86,10 +86,6 @@ config OPENTHREAD_CSL_AUTO_SYNC
 	bool "Enable CSL autosync"
 	default y if OPENTHREAD_CSL_RECEIVER
 
-config OPENTHREAD_CSL_SAMPLE_WINDOW
-	int "CSL sample window in units of 10 symbols"
-	default 30
-
 config OPENTHREAD_CSL_RECEIVE_TIME_AHEAD
 	int "CSL receiver wake up margin in units of 10 symbols"
 	default 480

--- a/subsys/net/lib/openthread/platform/openthread-core-zephyr-config.h
+++ b/subsys/net/lib/openthread/platform/openthread-core-zephyr-config.h
@@ -295,17 +295,6 @@
 #endif /* CONFIG_OPENTHREAD_RADIO_LINK_TREL_ENABLE */
 
 /**
- * @def OPENTHREAD_CONFIG_CSL_SAMPLE_WINDOW
- *
- * CSL sample window in units of 10 symbols.
- *
- */
-#ifdef CONFIG_OPENTHREAD_CSL_SAMPLE_WINDOW
-#define OPENTHREAD_CONFIG_CSL_SAMPLE_WINDOW \
-	CONFIG_OPENTHREAD_CSL_SAMPLE_WINDOW
-#endif /* CONFIG_OPENTHREAD_CSL_SAMPLE_WINDOW */
-
-/**
  * @def OPENTHREAD_CONFIG_CSL_RECEIVE_TIME_AHEAD
  *
  * For some reasons, CSL receivers wake up a little later than expected. This


### PR DESCRIPTION
Remove obsolete configuration option.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>