### PR TITLE
stm32: add more target boards to pwm samples application

### DIFF
--- a/boards/arm/nucleo_f091rc/doc/index.rst
+++ b/boards/arm/nucleo_f091rc/doc/index.rst
@@ -92,6 +92,8 @@ The Zephyr nucleo_f091rc board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | WATCHDOG  | on-chip    | independent watchdog                |
 +-----------+------------+-------------------------------------+
+| PWM       | on-chip    | pwm                                 |
++-----------+------------+-------------------------------------+
 | COUNTER   | on-chip    | rtc                                 |
 +-----------+------------+-------------------------------------+
 | I2C       | on-chip    | i2c controller                      |
@@ -136,8 +138,9 @@ Default Zephyr Peripheral Mapping:
 - SPI1 SCK/MISO/MOSI : PA5/PA6/PA7 (Arduino SPI)
 - SPI2 SCK/MISO/MOSI : PB13/PB14/PB15
 - USER_PB : PC13
-- LD1 : PA5
+- LD2 : PA5
 - DAC_OUT1 : PA4
+- PWM_2_CH1 : PA5 (might conflict with SPI1)
 
 For mode details please refer to `STM32 Nucleo-64 board User Manual`_.
 

--- a/boards/arm/nucleo_f091rc/nucleo_f091rc.yaml
+++ b/boards/arm/nucleo_f091rc/nucleo_f091rc.yaml
@@ -21,6 +21,7 @@ supported:
   - adc
   - dac
   - dma
+  - pwm
 testing:
   ignore_tags:
     - net

--- a/boards/arm/nucleo_g474re/doc/index.rst
+++ b/boards/arm/nucleo_g474re/doc/index.rst
@@ -163,6 +163,7 @@ Default Zephyr Peripheral Mapping:
 - SPI_3_SCK : PC10
 - SPI_3_MISO : PC11
 - SPI_3_MOSI : PC12
+- PWM_2_CH1 : PA5 (might conflict with SPI1)
 - PWM_3_CH1 : PB4
 - USER_PB : PC13
 - LD2 : PA5

--- a/boards/arm/nucleo_g474re/nucleo_g474re.dts
+++ b/boards/arm/nucleo_g474re/nucleo_g474re.dts
@@ -122,7 +122,7 @@
 
 	pwm2: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim2_ch3_pb10>;
+		pinctrl-0 = <&tim2_ch1_pa5>;
 		pinctrl-names = "default";
 	};
 };

--- a/boards/arm/nucleo_l073rz/doc/index.rst
+++ b/boards/arm/nucleo_l073rz/doc/index.rst
@@ -94,6 +94,8 @@ The Zephyr nucleo_l073rz board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | WATCHDOG  | on-chip    | independent watchdog                |
 +-----------+------------+-------------------------------------+
+| PWM       | on-chip    | pwm                                 |
++-----------+------------+-------------------------------------+
 | ADC       | on-chip    | ADC Controller                      |
 +-----------+------------+-------------------------------------+
 | DAC       | on-chip    | DAC Controller                      |
@@ -130,6 +132,7 @@ Default Zephyr Peripheral Mapping:
 - USER_PB   : PC13
 - LD2       : PA5
 - DAC       : PA4
+- PWM_2_CH1 : PA5 (might conflict with SPI1)
 
 For mode details please refer to `STM32 Nucleo-64 board User Manual`_.
 

--- a/boards/arm/nucleo_l073rz/nucleo_l073rz.yaml
+++ b/boards/arm/nucleo_l073rz/nucleo_l073rz.yaml
@@ -18,3 +18,4 @@ supported:
   - watchdog
   - adc
   - dac
+  - pwm

--- a/samples/basic/blinky_pwm/boards/nucleo_f091rc.overlay
+++ b/samples/basic/blinky_pwm/boards/nucleo_f091rc.overlay
@@ -1,0 +1,33 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2022 STMicroelectronics
+ */
+
+#include <dt-bindings/pwm/pwm.h>
+
+
+/ {
+	pwmleds {
+		compatible = "pwm-leds";
+
+		green_pwm_led: green_pwm_led {
+			pwms = <&pwm2 1 4 PWM_POLARITY_NORMAL>;
+		};
+	};
+
+	aliases {
+		pwm-led0 = &green_pwm_led;
+	};
+};
+
+&timers2 {
+	st,prescaler = <10000>;
+	status = "okay";
+
+	pwm2: pwm {
+		status = "okay";
+		pinctrl-0 = <&tim2_ch1_pa5>; /* might conflict with SPI1 */
+		pinctrl-names = "default";
+	};
+};

--- a/samples/basic/blinky_pwm/boards/nucleo_l073rz.overlay
+++ b/samples/basic/blinky_pwm/boards/nucleo_l073rz.overlay
@@ -1,0 +1,33 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2022 STMicroelectronics
+ */
+
+#include <dt-bindings/pwm/pwm.h>
+
+
+/ {
+	pwmleds {
+		compatible = "pwm-leds";
+
+		green_pwm_led: green_pwm_led {
+			pwms = <&pwm2 1 4 PWM_POLARITY_NORMAL>;
+		};
+	};
+
+	aliases {
+		pwm-led0 = &green_pwm_led;
+	};
+};
+
+&timers2 {
+	st,prescaler = <10000>;
+	status = "okay";
+
+	pwm2: pwm {
+		status = "okay";
+		pinctrl-0 = <&tim2_ch1_pa5>; /* might conflict with SPI1 */
+		pinctrl-names = "default";
+	};
+};

--- a/samples/drivers/led_pwm/boards/nucleo_f091rc.overlay
+++ b/samples/drivers/led_pwm/boards/nucleo_f091rc.overlay
@@ -1,0 +1,33 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2022 STMicroelectronics
+ */
+
+#include <dt-bindings/pwm/pwm.h>
+
+
+/ {
+	pwmleds {
+		compatible = "pwm-leds";
+
+		green_pwm_led: green_pwm_led {
+			pwms = <&pwm2 1 4 PWM_POLARITY_NORMAL>;
+		};
+	};
+
+	aliases {
+		pwm-led0 = &green_pwm_led;
+	};
+};
+
+&timers2 {
+	st,prescaler = <10000>;
+	status = "okay";
+
+	pwm2: pwm {
+		status = "okay";
+		pinctrl-0 = <&tim2_ch1_pa5>; /* might conflict with SPI1 */
+		pinctrl-names = "default";
+	};
+};

--- a/samples/drivers/led_pwm/boards/nucleo_l073rz.overlay
+++ b/samples/drivers/led_pwm/boards/nucleo_l073rz.overlay
@@ -1,0 +1,33 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2022 STMicroelectronics
+ */
+
+#include <dt-bindings/pwm/pwm.h>
+
+
+/ {
+	pwmleds {
+		compatible = "pwm-leds";
+
+		green_pwm_led: green_pwm_led {
+			pwms = <&pwm2 1 4 PWM_POLARITY_NORMAL>;
+		};
+	};
+
+	aliases {
+		pwm-led0 = &green_pwm_led;
+	};
+};
+
+&timers2 {
+	st,prescaler = <10000>;
+	status = "okay";
+
+	pwm2: pwm {
+		status = "okay";
+		pinctrl-0 = <&tim2_ch1_pa5>; /* might conflict with SPI1 */
+		pinctrl-names = "default";
+	};
+};

--- a/tests/drivers/pwm/pwm_api/boards/nucleo_f091rc.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/nucleo_f091rc.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2021 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&timers2 {
+	st,prescaler = <10000>;
+	status = "okay";
+
+	pwm2: pwm {
+		status = "okay";
+		pinctrl-0 = <&tim2_ch3_pb10>;
+		pinctrl-names = "default";
+	};
+};

--- a/tests/drivers/pwm/pwm_api/boards/nucleo_l073rz.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/nucleo_l073rz.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2021 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&timers2 {
+	st,prescaler = <10000>;
+	status = "okay";
+
+	pwm2: pwm {
+		status = "okay";
+		pinctrl-0 = <&tim2_ch3_pb10>;
+		pinctrl-names = "default";
+	};
+};


### PR DESCRIPTION
This adds the configuration to run tests and sample applications:

-  samples/basic/blinky_pwm/boards
-  samples/drivers/led_pwm
-  tests/drivers/pwm/pwm_api
 on the nucleo_l073rz and nucleo_f091rc plus the nucleo_g474re
All those 64-pin nucleo boards have the user led on the PA5 so that PWM must output on PA5 

Signed-off-by: Francois Ramu <francois.ramu@st.com>