### PR TITLE
Bluetooth: Mesh: Kconfig option to exclude RPL from settings storing

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -814,8 +814,15 @@ config BT_MESH_SEQ_STORE_RATE
 	  off with a value that's guaranteed to be larger than the last
 	  one used before power off.
 
+config BT_MESH_RPL_STORE
+	bool "Enable storing RPL entries"
+	default y
+	help
+	  Enable storing RPL in persistent memory using settings subsystem.
+
 config BT_MESH_RPL_STORE_TIMEOUT
 	int "Minimum interval after which unsaved RPL entries are updated in storage"
+	depends on BT_MESH_RPL_STORE
 	range -1 1000000
 	default 5
 	help

--- a/subsys/bluetooth/mesh/rpl.h
+++ b/subsys/bluetooth/mesh/rpl.h
@@ -27,3 +27,5 @@ bool bt_mesh_rpl_check(struct bt_mesh_net_rx *rx,
 void bt_mesh_rpl_clear(void);
 void bt_mesh_rpl_update(struct bt_mesh_rpl *rpl,
 			struct bt_mesh_net_rx *rx);
+size_t bt_mesh_rpl_get(void (*cb)(const struct bt_mesh_rpl *rpl_entry));
+int bt_mesh_rpl_set(struct bt_mesh_rpl *rpl_entry);


### PR DESCRIPTION
Configuration option to exclude the replay protection list
from storing to persistent memory using settings subsystem.
Some BLE Mesh deployment requires low latency storing of
RPL due to an emergency situation. Settings subsystem cannot
guarantee an exact time. This option will allow using
custom persistent storage approaches.

Signed-off-by: Aleksandr Khromykh <aleksandr.khromykh@nordicsemi.no>