### PR TITLE
pinmux: esp32: check only for pullup

### DIFF
--- a/drivers/pinmux/pinmux_esp32.c
+++ b/drivers/pinmux/pinmux_esp32.c
@@ -69,10 +69,10 @@ static int pinmux_pullup(const struct device *dev, uint32_t pin, uint8_t func)
 #if SOC_RTCIO_INPUT_OUTPUT_SUPPORTED
 			int rtcio_num = rtc_io_num_map[pin];
 
-			if (rtc_io_desc[rtcio_num].pulldown) {
-				rtcio_hal_pulldown_disable(rtc_io_num_map[pin]);
-			} else if (rtc_io_desc[rtcio_num].pullup) {
-				rtcio_hal_pullup_enable(rtc_io_num_map[pin]);
+			rtcio_hal_pulldown_enable(rtc_io_num_map[pin]);
+
+			if (rtc_io_desc[rtcio_num].pullup) {
+				rtcio_hal_pullup_disable(rtc_io_num_map[pin]);
 			} else {
 				return -ENOTSUP;
 			}
@@ -87,9 +87,9 @@ static int pinmux_pullup(const struct device *dev, uint32_t pin, uint8_t func)
 #if SOC_RTCIO_INPUT_OUTPUT_SUPPORTED
 			int rtcio_num = rtc_io_num_map[pin];
 
-			if (rtc_io_desc[rtcio_num].pulldown) {
-				rtcio_hal_pulldown_disable(rtc_io_num_map[pin]);
-			} else if (rtc_io_desc[rtcio_num].pullup) {
+			rtcio_hal_pulldown_disable(rtc_io_num_map[pin]);
+
+			if (rtc_io_desc[rtcio_num].pullup) {
 				rtcio_hal_pullup_enable(rtc_io_num_map[pin]);
 			} else {
 				return -ENOTSUP;


### PR DESCRIPTION
Current implementation checks for pulldown and
pullup. As pinmux configuration is related to PU only,
this PR checks for PU feature instead of PD.
This also fix missing PU check when PD is present.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>