### PR TITLE
drivers: Remove undesirable irq_enable calls from nrfx driver shims

### DIFF
--- a/drivers/audio/dmic_nrfx_pdm.c
+++ b/drivers/audio/dmic_nrfx_pdm.c
@@ -541,7 +541,6 @@ static const struct _dmic_ops dmic_ops = {
 	{								     \
 		IRQ_CONNECT(DT_IRQN(PDM(idx)), DT_IRQ(PDM(idx), priority),   \
 			    nrfx_isr, nrfx_pdm_irq_handler, 0);		     \
-		irq_enable(DT_IRQN(PDM(idx)));				     \
 		k_msgq_init(&dmic_nrfx_pdm_data##idx.rx_queue,		     \
 			    (char *)rx_msgs##idx, sizeof(void *),	     \
 			    ARRAY_SIZE(rx_msgs##idx));			     \

--- a/drivers/clock_control/clock_control_nrf.c
+++ b/drivers/clock_control/clock_control_nrf.c
@@ -643,7 +643,6 @@ static int clk_init(const struct device *dev)
 
 	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority),
 		    nrfx_isr, nrfx_power_clock_irq_handler, 0);
-	irq_enable(DT_INST_IRQN(0));
 
 	nrfx_err = nrfx_clock_init(clock_event_handler);
 	if (nrfx_err != NRFX_SUCCESS) {

--- a/drivers/i2s/i2s_nrfx.c
+++ b/drivers/i2s/i2s_nrfx.c
@@ -890,7 +890,6 @@ static const struct i2s_driver_api i2s_nrf_drv_api = {
 	{								     \
 		IRQ_CONNECT(DT_IRQN(I2S(idx)), DT_IRQ(I2S(idx), priority),   \
 			    nrfx_isr, nrfx_i2s_irq_handler, 0);		     \
-		irq_enable(DT_IRQN(I2S(idx)));				     \
 		k_msgq_init(&i2s_nrfx_data##idx.tx_queue,		     \
 			    (char *)tx_msgs##idx, sizeof(void *),	     \
 			    ARRAY_SIZE(tx_msgs##idx));			     \


### PR DESCRIPTION
Shims for nrfx drivers should only connect the related IRQ handlers,
they should not enable the IRQs, as this could lead to a situation
where the interrupt handler is called before the driver had a chance
to properly initialize the peripheral and install the provided event
handler. nrfx drivers will enable the interrupts appropriately on
their own by calling the NRFX_IRQ_ENABLE macro which is implemented
in nrfx_glue.h as a call to irq_enable().
This commit fixes the above issue spotted in the following shims:
- dmic_nrfx_pdm
- clock_control_nrf
- i2s_nrfx

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>