### PR TITLE
twister: verify platform names from quarantine

### DIFF
--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -451,6 +451,7 @@ class TestPlan:
                 plat = self.platform_names
             else:
                 plat = quar_dict['platforms']
+                self.verify_platforms_existence(plat, "quarantine-list")
             comment = quar_dict.get('comment', "NA")
             quarantine_list.append([{".".join([p, s]): comment}
                                    for p in plat for s in quar_dict['scenarios']])


### PR DESCRIPTION
Add verification of platform name from quarantine list.

Fixes: #43450

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>