### PR TITLE
net: http_client: Add official null response behavior

### DIFF
--- a/include/net/http_client.h
+++ b/include/net/http_client.h
@@ -124,15 +124,19 @@ struct http_response {
 	 * did not set the response callback. If the callback
 	 * is set, then the HTTP client API will call response
 	 * callback many times so that all the data is
-	 * delivered to the user.
+	 * delivered to the user. Will be zero in the event of
+	 * a null response.
 	 */
 	size_t data_len;
 
-	/** HTTP Content-Length field value */
+	/** HTTP Content-Length field value. Will be set to zero
+	 * in the event of a null response.
+	 */
 	size_t content_length;
 
 	/** Content length parsed. This should be the same as
-	 * the content_length field if parsing was ok.
+	 * the content_length field if parsing was ok. Will be
+	 * zero if a null response is given.
 	 */
 	size_t processed;
 
@@ -143,11 +147,15 @@ struct http_response {
 	 * purpose of providing a textual description
 	 * associated with the numeric status code. A client
 	 * SHOULD ignore the reason-phrase content.
+	 *
+	 * Will be blank if a null HTTP response is given.
 	 */
 	char http_status[HTTP_STATUS_STR_SIZE];
 
 	/** Numeric HTTP status code which corresponds to the
-	 * textual description.
+	 * textual description. Set to zero if null response is
+	 * given. Otherwise, will be a 3-digit integer code if
+	 * valid HTTP response is given.
 	 */
 	uint16_t http_status_code;
 

--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -396,7 +396,19 @@ static int http_wait_data(int sock, struct http_request *req)
 			ret = total_received;
 
 			if (req->internal.response.cb) {
-				NET_DBG("Calling callback for closed connection");
+				NET_DBG("Calling callback for closed connection "
+					"(NULL HTTP response)");
+
+				/* Status code 0 representing a null response */
+				req->internal.response.http_status_code = 0;
+
+				/* Zero out related response metrics */
+				req->internal.response.processed = 0;
+				req->internal.response.data_len = 0;
+				req->internal.response.content_length = 0;
+				req->internal.response.body_start = NULL;
+				memset(req->internal.response.http_status, 0,
+				       HTTP_STATUS_STR_SIZE);
 
 				req->internal.response.cb(&req->internal.response,
 							  HTTP_DATA_FINAL,


### PR DESCRIPTION
Adds an official behavior in response to null response from HTTP
endpoint.

Fixes #42988

Signed-off-by: Georges Oates_Larsen <georges.larsen@nordicsemi.no>