### PR TITLE
dtlib: Allow overlay files to have version

### DIFF
--- a/scripts/dts/python-devicetree/src/devicetree/dtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/dtlib.py
@@ -909,6 +909,11 @@ class DT:
                     self._parse_error("no root node defined")
                 return
 
+            elif tok.id == _T.DTS_V1:
+                # Overlay files may start with /dts-v1/; also, so allow it
+                # anywhere in the preprocessed file.
+                self._expect_token(";")
+
             else:
                 self._parse_error("expected '/' or label reference (&foo)")
 


### PR DESCRIPTION
According to the dts spec, all dts and dtsi files can have a /dts-v1/;
directive at the start of the file. However since zephyr uses the C
preprocessor to concatinate the files together, the version directive
can happen anywhere. Change dtlib to allow extra version directives
to appear anywhere in the file.

Change-Id: I3e227d09769f2f03f128ce6b18e7a51485b1a577