### PR TITLE
sign.py: pass west -v flag(s) to rimage

### DIFF
--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -464,9 +464,15 @@ class RimageSigner(Signer):
         else:
             extra_ri_args = ['-i', '3', '-e']
 
+        sign_base = [tool_path]
+
+        # Sub-command arg '-q' takes precedence over west '-v'
+        if not args.quiet and args.verbose:
+            sign_base += ['-v'] * args.verbose
+
         components = [ ] if (target in ('imx8', 'imx8m')) else [ bootloader ]
         components += [ kernel ]
-        sign_base = ([tool_path] + args.tool_args +
+        sign_base += (args.tool_args +
                      ['-o', out_bin] + conf_path_cmd + extra_ri_args +
                      components)
 


### PR DESCRIPTION
Give rimage the same number of -v that were given to west.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>