### PR TITLE
board: gd32e103v_eval: add prescaler to timer.

### DIFF
--- a/boards/arm/gd32e103v_eval/gd32e103v_eval.dts
+++ b/boards/arm/gd32e103v_eval/gd32e103v_eval.dts
@@ -102,6 +102,7 @@
 
 &timer0 {
 	status = "okay";
+	prescaler = <128>;
 
 	pwm0: pwm {
 		status = "okay";


### PR DESCRIPTION
I find I had a mistake in #36833 that default timer clock source is too fast,
so add prescaler to timer, samples can work without patch feilongfl@4093c50 .

tested with `samples/basic/fade_led`