### PR TITLE
cmake: Use Zephyr SDK by default on all host operating systems

### DIFF
--- a/cmake/modules/verify-toolchain.cmake
+++ b/cmake/modules/verify-toolchain.cmake
@@ -52,10 +52,10 @@ endif()
 # Verify Zephyr SDK Toolchain.
 # There are three scenarios where Zephyr SDK should be looked up:
 # 1) Zephyr specified as toolchain (ZEPHYR_SDK_INSTALL_DIR still used if defined)
-# 2) No toolchain specified == Default to Zephyr toolchain (Linux only)
+# 2) No toolchain specified == Default to Zephyr toolchain
 # Until we completely deprecate it
 if(("zephyr" STREQUAL ${ZEPHYR_TOOLCHAIN_VARIANT}) OR
-   ((NOT DEFINED ZEPHYR_TOOLCHAIN_VARIANT) AND (${CMAKE_HOST_SYSTEM_NAME} STREQUAL Linux)) OR
+   (NOT DEFINED ZEPHYR_TOOLCHAIN_VARIANT) OR
    (DEFINED ZEPHYR_SDK_INSTALL_DIR))
 
   # No toolchain was specified, so inform user that we will be searching.


### PR DESCRIPTION
This commit updates the Zephyr build system to use the Zephyr SDK by
default for all host operating systems, when `ZEPHYR_TOOLCHAIN_VARIANT`
environment variable is not explicitly set.

Note that the Zephyr SDK is now available on all three major host
operating systems (i.e. Linux, macOS, Windows), and there is no reason
to exclude this behaviour for non-Linux hosts anymore.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>