### PR TITLE
Allow use of bash outside of /bin

### DIFF
--- a/boards/x86/common/scripts/build_grub.sh
+++ b/boards/x86/common/scripts/build_grub.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Originally from the Galileo port in contiki
 # https://github.com/otcshare/contiki-x86

--- a/scripts/checkpatch/check_known_checkpatch_issues.sh
+++ b/scripts/checkpatch/check_known_checkpatch_issues.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (c) 2015 Intel Corporation.

--- a/scripts/checkpatch/maintainer-checkpatch.bash
+++ b/scripts/checkpatch/maintainer-checkpatch.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (c) 2015 Wind River Systems, Inc.

--- a/scripts/checkpatch/timestamp
+++ b/scripts/checkpatch/timestamp
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (c) 2015 Wind River Systems, Inc.

--- a/scripts/coccicheck
+++ b/scripts/coccicheck
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-2.0
 #
 

--- a/tests/net/all/check_net_options.sh
+++ b/tests/net/all/check_net_options.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2019 Intel Corporation.
 #


### PR DESCRIPTION
Even though bash is commonly available as /bin/bash there are
exceptions (e.g NixOS). This commit allow the use of the scripts in my
environment and is generic.

Cc: @theotherjimmy
