### PR TITLE
boards: efm32pg_stk3402a: Add minimal pwm support

### DIFF
--- a/boards/arm/efm32pg_stk3402a/efm32pg_stk3402a_common.dtsi
+++ b/boards/arm/efm32pg_stk3402a/efm32pg_stk3402a_common.dtsi
@@ -21,6 +21,7 @@
 	aliases {
 		led0 = &led0;
 		led1 = &led1;
+		pwm-led0 = &pwm_led0;
 		sw0 = &button0;
 		sw1 = &button1;
 	};
@@ -48,6 +49,14 @@
 			/* gpio flags need validation */
 			gpios = <&gpiof 7 GPIO_ACTIVE_LOW>;
 			label = "User Push Button 1";
+		};
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+		status = "okay";
+		pwm_led0: pwm_led0 {
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
 	};
 };
@@ -79,6 +88,16 @@
 &rtcc0 {
 	prescaler = <1>;
 	status = "okay";
+};
+
+&timer0 {
+	status = "okay";
+
+	pwm0: pwm {
+		status = "okay";
+		pin-location = <GECKO_LOCATION(28) GECKO_PORT_F GECKO_PIN(4)>;
+		prescaler = <1024>;
+	};
 };
 
 &gpio {

--- a/dts/arm/silabs/efm32_jg_pg_12b.dtsi
+++ b/dts/arm/silabs/efm32_jg_pg_12b.dtsi
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018 Christian Taedcke <hacking@taedcke.com>
  * Copyright (c) 2019 Lemonbeat GmbH
+ * Copyright (c) 2021 T-Mobile USA, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -251,6 +252,20 @@
 			interrupts = <49 0>;
 			label = "TRNG0";
 			status = "disabled";
+		};
+
+		timer0: timer@40018000 {
+			compatible = "silabs,gecko-timers";
+			reg = <0x40018000 0x400>;
+			label = "TIMER_0";
+			status = "disabled";
+
+			pwm {
+				compatible = "silabs,gecko-pwm";
+				status = "disabled";
+				label = "PWM_0";
+				#pwm-cells = <3>;
+			};
 		};
 	};
 };

--- a/dts/arm/silabs/efm32_jg_pg_12b.dtsi
+++ b/dts/arm/silabs/efm32_jg_pg_12b.dtsi
@@ -9,6 +9,7 @@
 #include <arm/armv7-m.dtsi>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 #include "gpio_gecko.h"
 
 / {

--- a/soc/arm/silabs_exx32/efm32jg12b/Kconfig.defconfig.efm32jg12b
+++ b/soc/arm/silabs_exx32/efm32jg12b/Kconfig.defconfig.efm32jg12b
@@ -28,3 +28,7 @@ config SOC_FLASH_GECKO
 config SPI_GECKO
 	default y
 	depends on SPI
+
+config PWM_GECKO
+	default y
+	depends on PWM

--- a/soc/arm/silabs_exx32/efm32pg12b/Kconfig.defconfig.efm32pg12b
+++ b/soc/arm/silabs_exx32/efm32pg12b/Kconfig.defconfig.efm32pg12b
@@ -28,3 +28,7 @@ config SOC_FLASH_GECKO
 config SPI_GECKO
 	default y
 	depends on SPI
+
+config PWM_GECKO
+	default y
+	depends on PWM


### PR DESCRIPTION
With this additions samples/basic/blinky_pwm works. LED0 is used as pwm output.

This is tested on hardware using both board variants:
```
west build -b efm32pg_stk3402a --pristine auto samples/basic/blinky_pwm
west build -b efm32pg_stk3402a_jg --pristine auto samples/basic/blinky_pwm
```