### PR TITLE
logging: Add prompt to LOG2_ALWAYS_RUNTIME option

### DIFF
--- a/subsys/logging/Kconfig.misc
+++ b/subsys/logging/Kconfig.misc
@@ -35,17 +35,17 @@ config LOG2_USE_VLA
 	  compile time so at runtime arrays have fixed size.
 
 config LOG2_ALWAYS_RUNTIME
-	bool
+	bool "Always use runtime message creation (v2)"
 	default y if NO_OPTIMIZATIONS
 	default y if LOG_MODE_IMMEDIATE
 	default y if "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "xcc"
 	help
 	  If enabled, runtime method is always used for message creation. Static
 	  creation relies on compiler being able to optimize and remove code
-	  based on information known at compile time. Runtime only approach is
-	  used when optimization is disabled because some compilers
+	  based on information known at compile time. Runtime only approach must
+	  be used when optimization is disabled because some compilers
 	  (seen on arm_cortex_m and x86) were using unrealistic amount of stack
-	  for dead code. It is also used in immediate mode since it requires
+	  for dead code. It is also required in immediate mode since it requires
 	  less stack than static message creation and speed has lower priority
 	  in that mode.
 

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -60,6 +60,13 @@ LOG_MODULE_REGISTER(log);
 #define CONFIG_LOG_BUFFER_SIZE 4
 #endif
 
+#ifndef CONFIG_LOG2_ALWAYS_RUNTIME
+BUILD_ASSERT(!IS_ENABLED(CONFIG_NO_OPTIMIZATIONS),
+	     "Option must be enabled when CONFIG_NO_OPTIMIZATIONS is set");
+BUILD_ASSERT(!IS_ENABLED(CONFIG_LOG_MODE_IMMEDIATE),
+	     "Option must be enabled when CONFIG_LOG_MODE_IMMEDIATE is set");
+#endif
+
 #ifndef CONFIG_LOG1
 static const log_format_func_t format_table[] = {
 	[LOG_OUTPUT_TEXT] = log_output_msg2_process,


### PR DESCRIPTION
Prompt was removed by 154ca8526 to ensure that it is not
disable when it is required. That removed possibility of
manually enabling that option my the user. Bringing prompt
back and adding check to code to fail compilation if
LOG2_ALWAYS_RUNTIME is not set but is required.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>
