### PR TITLE
soc: arm: nordic: fix GPIO pin forwarder initialization

### DIFF
--- a/soc/arm/nordic_nrf/nrf53/soc.c
+++ b/soc/arm/nordic_nrf/nrf53/soc.c
@@ -48,8 +48,9 @@ extern void z_arm_nmi_init(void);
 #error "Unknown nRF53 SoC."
 #endif
 
-#if (!defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) || defined(CONFIG_BUILD_WITH_TFM)) && \
-	defined(CONFIG_SOC_NRF5340_CPUAPP) && DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_gpio_forwarder)
+#if DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_gpio_forwarder) && \
+	defined(CONFIG_BOARD_ENABLE_CPUNET) && \
+	(!defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) || defined(CONFIG_BUILD_WITH_TFM))
 #define NRF_GPIO_FORWARDER_FOR_NRF5340_CPUAPP_ENABLED
 #endif
 


### PR DESCRIPTION
nRF5340 application core should not attempt to pass control over any
pins to the nRF5340 network core if the latter is disabled.

This commit fixes https://github.com/zephyrproject-rtos/zephyr/issues/43476.

Signed-off-by: Jedrzej Ciupis <jedrzej.ciupis@nordicsemi.no>