### PR TITLE
soc: arm: nxp: kinetis: fix pinctrl compilation for ke1xf SoC series

### DIFF
--- a/soc/arm/nxp_kinetis/common/pinctrl_soc.h
+++ b/soc/arm/nxp_kinetis/common/pinctrl_soc.h
@@ -23,11 +23,18 @@ extern "C" {
 
 typedef uint32_t pinctrl_soc_pin_t;
 
-/* Kinetis KW/KL series does not support open drain. Define macros to have no effect */
-#if defined(CONFIG_SOC_SERIES_KINETIS_KWX) ||	\
-	defined(CONFIG_SOC_SERIES_KINETIS_KL2X)
+/* Kinetis KW/KL/KE series does not support open drain. Define macros to have no effect */
+#if defined(CONFIG_SOC_SERIES_KINETIS_KWX) ||		\
+	defined(CONFIG_SOC_SERIES_KINETIS_KL2X) ||	\
+	defined(CONFIG_SOC_SERIES_KINETIS_KE1XF)
 #define PORT_PCR_ODE(x) 0x0
 #define PORT_PCR_ODE_MASK 0x0
+#endif
+
+/* Kinetis KE series does not support slew rate. Define macros to have no effect */
+#if defined(CONFIG_SOC_SERIES_KINETIS_KE1XF)
+#define PORT_PCR_SRE(x) 0x0
+#define PORT_PCR_SRE_MASK 0x0
 #endif
 
 #define Z_PINCTRL_KINETIS_PINCFG(node_id)					\


### PR DESCRIPTION
The NXP KE1xF SoC series does not support neither slew rate nor open drain PORT configuration registers.

Fix pinctrl compilation for the KE1xF by defining dummy register macros for the SRE and ODE registers.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>