### PR TITLE
Bluetooth: Audio: Add `sent` callback for audio streams

### DIFF
--- a/include/bluetooth/audio/audio.h
+++ b/include/bluetooth/audio/audio.h
@@ -1190,6 +1190,20 @@ struct bt_audio_stream_ops {
 	 */
 	void (*recv)(struct bt_audio_stream *stream, struct net_buf *buf);
 #endif /* CONFIG_BT_AUDIO_UNICAST || CONFIG_BT_AUDIO_BROADCAST_SINK */
+
+#if defined(CONFIG_BT_AUDIO_UNICAST) || defined(CONFIG_BT_AUDIO_BROADCAST_SOURCE)
+	/** @brief Stream audio HCI sent callback
+	 *
+	 *  If this callback is provided it will be called whenever a SDU has
+	 *  been completely sent, or otherwise flushed due to transmission
+	 *  issues.
+	 *  This callback is only used if the ISO data path is HCI.
+	 *
+	 *  @param chan The channel which has sent data.
+	 */
+	void (*sent)(struct bt_audio_stream *stream);
+#endif /* CONFIG_BT_AUDIO_UNICAST || CONFIG_BT_AUDIO_BROADCAST_SOURCE */
+
 };
 
 /** @brief Register Audio callbacks for a stream.

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -296,6 +296,18 @@ static void ascs_iso_recv(struct bt_iso_chan *chan,
 	}
 }
 
+static void ascs_iso_sent(struct bt_iso_chan *chan)
+{
+	struct bt_audio_ep *ep = CONTAINER_OF(chan, struct bt_audio_ep, iso);
+	struct bt_audio_stream_ops *ops = ep->stream->ops;
+
+	BT_DBG("stream %p ep %p", chan, ep);
+
+	if (ops != NULL && ops->sent != NULL) {
+		ops->sent(ep->stream);
+	}
+}
+
 static void ascs_iso_connected(struct bt_iso_chan *chan)
 {
 	struct bt_audio_ep *ep = CONTAINER_OF(chan, struct bt_audio_ep, iso);
@@ -336,6 +348,7 @@ static void ascs_iso_disconnected(struct bt_iso_chan *chan, uint8_t reason)
 
 static struct bt_iso_chan_ops ascs_iso_ops = {
 	.recv = ascs_iso_recv,
+	.sent = ascs_iso_sent,
 	.connected = ascs_iso_connected,
 	.disconnected = ascs_iso_disconnected,
 };

--- a/subsys/bluetooth/audio/broadcast_source.c
+++ b/subsys/bluetooth/audio/broadcast_source.c
@@ -114,6 +114,18 @@ static void broadcast_source_set_ep_state(struct bt_audio_ep *ep, uint8_t state)
 	}
 }
 
+static void broadcast_source_iso_sent(struct bt_iso_chan *chan)
+{
+	struct bt_audio_ep *ep = CONTAINER_OF(chan, struct bt_audio_ep, iso);
+	struct bt_audio_stream_ops *ops = ep->stream->ops;
+
+	BT_DBG("stream %p ep %p", chan, ep);
+
+	if (ops != NULL && ops->sent != NULL) {
+		ops->sent(ep->stream);
+	}
+}
+
 static void broadcast_source_iso_connected(struct bt_iso_chan *chan)
 {
 	struct bt_audio_ep *ep = CONTAINER_OF(chan, struct bt_audio_ep, iso);
@@ -148,6 +160,7 @@ static void broadcast_source_iso_disconnected(struct bt_iso_chan *chan, uint8_t 
 }
 
 static struct bt_iso_chan_ops broadcast_source_iso_ops = {
+	.sent		= broadcast_source_iso_sent,
 	.connected	= broadcast_source_iso_connected,
 	.disconnected	= broadcast_source_iso_disconnected,
 };

--- a/subsys/bluetooth/audio/unicast_client.c
+++ b/subsys/bluetooth/audio/unicast_client.c
@@ -80,6 +80,18 @@ static void unicast_client_ep_iso_recv(struct bt_iso_chan *chan,
 	}
 }
 
+static void unicast_client_ep_iso_sent(struct bt_iso_chan *chan)
+{
+	struct bt_audio_ep *ep = CONTAINER_OF(chan, struct bt_audio_ep, iso);
+	struct bt_audio_stream_ops *ops = ep->stream->ops;
+
+	BT_DBG("stream %p ep %p", chan, ep);
+
+	if (ops != NULL && ops->sent != NULL) {
+		ops->sent(ep->stream);
+	}
+}
+
 static void unicast_client_ep_iso_connected(struct bt_iso_chan *chan)
 {
 	struct bt_audio_ep *ep = EP_ISO(chan);
@@ -125,6 +137,7 @@ static void unicast_client_ep_iso_disconnected(struct bt_iso_chan *chan,
 
 static struct bt_iso_chan_ops unicast_client_iso_ops = {
 	.recv		= unicast_client_ep_iso_recv,
+	.sent		= unicast_client_ep_iso_sent,
 	.connected	= unicast_client_ep_iso_connected,
 	.disconnected	= unicast_client_ep_iso_disconnected,
 };


### PR DESCRIPTION
Add a sent callback that is used to notify applications
using the audio API when a SDU has been sent over HCI.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

fixes https://github.com/zephyrproject-rtos/zephyr/issues/43314