### PR TITLE
Minor checkpatch fixes

### DIFF
--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -4970,6 +4970,7 @@ sub process {
 #	only fix matches surrounded by parentheses to avoid incorrect
 #	conversions like "FOO < baz() + 5" being "misfixed" to "baz() > FOO + 5"
 		if ($perl_version_ok &&
+		    $line !~ /^\+.*\b[A-Z_][A-Z0-9_]*\s*$Compare\s*\b$Constant|[A-Z_][A-Z0-9_]*/ &&
 		    $line =~ /^\+(.*)\b($Constant|[A-Z_][A-Z0-9_]*)\s*($Compare)\s*($LvalOrFunc)/) {
 			my $lead = $1;
 			my $const = $2;

--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -4977,7 +4977,7 @@ sub process {
 			my $to = $4;
 			my $newcomp = $comp;
 			if ($lead !~ /(?:$Operators|\.)\s*$/ &&
-			    $to !~ /^(?:Constant|[A-Z_][A-Z0-9_]*)$/ &&
+			    $to !~ /^(?:$Constant|[A-Z_][A-Z0-9_]*)$/ &&
 			    WARN("CONSTANT_COMPARISON",
 				 "Comparisons should place the constant on the right side of the test\n" . $herecurr) &&
 			    $fix) {


### PR DESCRIPTION
Fixes to CONSTANT_COMPARISON:
 1) there has been missing $ in variable reference;
 2) added check that allows conditional statements that have constants (literals) on both sides of am operator to pass through, without warning.

This should let PRs like here: https://github.com/zephyrproject-rtos/zephyr/pull/42049 go through