### PR TITLE
Updated PSoC 6 implementation to use hal_infineon/mtb-pdl-cat1

### DIFF
--- a/drivers/serial/Kconfig.psoc6
+++ b/drivers/serial/Kconfig.psoc6
@@ -9,5 +9,6 @@ config UART_PSOC6
 	depends on SOC_FAMILY_PSOC6
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
+	select USE_INFINEON_UART
 	help
 	  This option enables the SCB[UART] driver for PSoC-6 SoC family.

--- a/drivers/spi/Kconfig.psoc6
+++ b/drivers/spi/Kconfig.psoc6
@@ -6,5 +6,6 @@
 config SPI_PSOC6
 	bool "PSoC-6 MCU SCB spi driver"
 	depends on SOC_FAMILY_PSOC6
+	select USE_INFINEON_SPI
 	help
 	  This option enables the SCB[SPI] driver for PSoC-6 SoC family.

--- a/modules/hal_infineon/CMakeLists.txt
+++ b/modules/hal_infineon/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Copyright (c) 2020 Linumiz
+# Copyright (c) 2022 Cypress Semiconductor Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library_named(modules_hal_infineon)
+
+## Add PDL sources for XMC devices
+if (CONFIG_HAS_XMCLIB)
+  add_subdirectory(${ZEPHYR_HAL_INFINEON_MODULE_DIR}/XMCLib XMCLib)
+endif()
+
+if (CONFIG_SOC_FAMILY_PSOC6)
+  ## Add core-lib sources for CAT1 devices
+  add_subdirectory(core-lib)
+
+  ## Add mtb-pdl-cat1 sources for CAT1 devices
+  add_subdirectory(mtb-pdl-cat1)
+endif()

--- a/modules/hal_infineon/Kconfig
+++ b/modules/hal_infineon/Kconfig
@@ -1,0 +1,63 @@
+# Copyright (c) 2022 Cypress Semiconductor Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+config ZEPHYR_HAL_INFINEON_MODULE
+	bool
+
+if SOC_FAMILY_PSOC6
+
+config USE_INFINEON_ADC
+	bool
+	help
+	  Enable Analog-to-Digital Converter (ADC) HAL module driver for Infineon devices
+
+config USE_INFINEON_I2C
+	bool
+	help
+	  Enable Inter-Integrated Circuit Interface (I2C) HAL module driver for Infineon devices
+
+config USE_INFINEON_RTC
+	bool
+	help
+	  Enable Real-Time Clock (RTC) HAL module driver for Infineon devices
+
+config USE_INFINEON_SDIO
+	bool
+	help
+	  Enable Secure Digital Input/Output interface (SDIO) HAL module for Infineon devices
+	  driver
+
+config USE_INFINEON_SPI
+	bool
+	help
+	  Enable Serial Peripheral Interface (SPI) HAL module driver for Infineon devices
+
+
+config USE_INFINEON_TIMER
+	bool
+	help
+	  Enable Timer (Timer/Counter) HAL module driver for Infineon devices
+
+config USE_INFINEON_LPTIMER
+	bool
+	help
+	  Enable Low-Power Timer (LPTimer) HAL module driver for Infineon devices
+
+config USE_INFINEON_TRNG
+	bool
+	help
+	  Enable True Random Number Generator (TRNG) HAL module driver for Infineon devices
+
+config USE_INFINEON_UART
+	bool
+	help
+	  Enable Universal Asynchronous Receiver/Transmitter (UART) HAL module
+	  driver for Infineon devices
+
+config USE_INFINEON_PWM
+	bool
+	help
+	  Enable Pulse Width Modulator (PWM) HAL module
+	  driver for Infineon devices
+
+endif # SOC_FAMILY_PSOC6

--- a/modules/hal_infineon/core-lib/CMakeLists.txt
+++ b/modules/hal_infineon/core-lib/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Copyright (c) 2022 Cypress Semiconductor Corporation.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Add core-lib
+zephyr_include_directories(${ZEPHYR_HAL_INFINEON_MODULE_DIR}/core-lib/include)

--- a/modules/hal_infineon/mtb-pdl-cat1/CMakeLists.txt
+++ b/modules/hal_infineon/mtb-pdl-cat1/CMakeLists.txt
@@ -1,0 +1,63 @@
+# Copyright (c) 2022 Cypress Semiconductor Corporation.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set(pdl_dir             ${ZEPHYR_HAL_INFINEON_MODULE_DIR}/mtb-pdl-cat1)
+set(pdl_drv_dir         ${ZEPHYR_HAL_INFINEON_MODULE_DIR}/mtb-pdl-cat1/drivers)
+set(pdl_dev_cat1a_dir   ${ZEPHYR_HAL_INFINEON_MODULE_DIR}/mtb-pdl-cat1/devices/COMPONENT_CAT1A)
+
+zephyr_compile_definitions(${CONFIG_SOC_PART_NUMBER})
+
+# Add mtb-pdl-cat1
+zephyr_include_directories(${pdl_drv_dir}/include)
+zephyr_include_directories(${pdl_dev_cat1a_dir}/include)
+zephyr_include_directories(${pdl_dev_cat1a_dir}/include/ip)
+zephyr_include_directories(${pdl_dev_cat1a_dir}/templates/COMPONENT_MTB)
+
+zephyr_library_sources(${pdl_dev_cat1a_dir}/source/cy_device.c)
+zephyr_library_sources(${pdl_drv_dir}/source/TOOLCHAIN_GCC_ARM/cy_syslib_gcc.S)
+
+zephyr_library_sources_ifdef(CONFIG_CPU_CORTEX_M4
+  ${pdl_dev_cat1a_dir}/templates/COMPONENT_MTB/COMPONENT_CM4/system_psoc6_cm4.c)
+zephyr_library_sources_ifdef(CONFIG_CPU_CORTEX_M0PLUS
+  ${pdl_dev_cat1a_dir}/templates/COMPONENT_MTB/COMPONENT_CM0P/system_psoc6_cm0plus.c)
+
+# Peripheral drivers
+zephyr_library_sources_ifdef(CONFIG_USE_INFINEON_UART     ${pdl_drv_dir}/source/cy_scb_uart.c)
+zephyr_library_sources_ifdef(CONFIG_USE_INFINEON_ADC      ${pdl_drv_dir}/source/cy_sar.c)
+zephyr_library_sources_ifdef(CONFIG_USE_INFINEON_I2C      ${pdl_drv_dir}/source/cy_scb_i2c.c)
+zephyr_library_sources_ifdef(CONFIG_USE_INFINEON_SPI      ${pdl_drv_dir}/source/cy_scb_spi.c)
+zephyr_library_sources_ifdef(CONFIG_USE_INFINEON_TIMER    ${pdl_drv_dir}/source/cy_tcpwm_counter.c)
+zephyr_library_sources_ifdef(CONFIG_USE_INFINEON_PWM      ${pdl_drv_dir}/source/cy_tcpwm_pwm.c)
+zephyr_library_sources_ifdef(CONFIG_USE_INFINEON_LPTIMER  ${pdl_drv_dir}/source/cy_mcwdt.c)
+zephyr_library_sources_ifdef(CONFIG_USE_INFINEON_RTC      ${pdl_drv_dir}/source/cy_rtc.c)
+zephyr_library_sources_ifdef(CONFIG_USE_INFINEON_SDIO     ${pdl_drv_dir}/source/cy_sd_host.c)
+zephyr_library_sources_ifdef(CONFIG_SOC_FAMILY_PSOC6      ${pdl_drv_dir}/source/cy_sysint.c)
+
+if(CONFIG_USE_INFINEON_TRNG)
+  zephyr_library_sources(${pdl_drv_dir}/source/cy_crypto.c)
+  zephyr_library_sources(${pdl_drv_dir}/source/cy_crypto_core_trng_v1.c)
+  zephyr_library_sources(${pdl_drv_dir}/source/cy_crypto_core_trng_v2.c)
+endif()
+
+if(CONFIG_USE_INFINEON_UART OR CONFIG_USE_INFINEON_I2C OR CONFIG_USE_INFINEON_SPI)
+  zephyr_library_sources(${pdl_drv_dir}/source/cy_scb_common.c)
+endif()
+
+if(CONFIG_USE_INFINEON_ADC)
+  zephyr_library_sources(${pdl_drv_dir}/source/cy_sysanalog.c)
+endif()
+
+# Common part
+zephyr_library_sources(${pdl_drv_dir}/source/cy_flash.c)
+zephyr_library_sources(${pdl_drv_dir}/source/cy_gpio.c)
+zephyr_library_sources(${pdl_drv_dir}/source/cy_ipc_drv.c)
+zephyr_library_sources(${pdl_drv_dir}/source/cy_ipc_pipe.c)
+zephyr_library_sources(${pdl_drv_dir}/source/cy_ipc_sema.c)
+zephyr_library_sources(${pdl_drv_dir}/source/cy_prot.c)
+zephyr_library_sources(${pdl_drv_dir}/source/cy_sysclk.c)
+zephyr_library_sources(${pdl_drv_dir}/source/cy_syslib.c)
+zephyr_library_sources(${pdl_drv_dir}/source/cy_syspm.c)
+zephyr_library_sources(${pdl_drv_dir}/source/cy_systick.c)
+zephyr_library_sources(${pdl_drv_dir}/source/cy_trigmux.c)
+zephyr_library_sources(${pdl_drv_dir}/source/cy_wdt.c)

--- a/soc/arm/cypress/psoc6/noinit.ld
+++ b/soc/arm/cypress/psoc6/noinit.ld
@@ -15,3 +15,6 @@ KEEP(*(.heap))
 
 . = ALIGN(4);
 KEEP(*(.stack))
+
+. = ALIGN(4);
+KEEP(*(.cy_sharedmem))

--- a/soc/arm/cypress/psoc6/rwdata.ld
+++ b/soc/arm/cypress/psoc6/rwdata.ld
@@ -1,4 +1,3 @@
-
 /*
  * SPDX-License-Identifier: Apache-2.0
  * Extracted from:

--- a/soc/arm/cypress/psoc6/soc.c
+++ b/soc/arm/cypress/psoc6/soc.c
@@ -37,6 +37,14 @@
 #define CY_CFG_PWR_VDDA_MV 3300
 #define CY_CFG_PWR_USING_ULP 0
 
+/* Dummy symbols, requres for cy_sysint.c module.
+ * NOTE: in this PSoC 6 integration, PSoC 6 Zephyr drivers (uart, spi, gpio)
+ * do not use cy_sysint.c implementation to handle interrupt routine.
+ * Instead this they use IRQ_CONNECT to define ISR.
+ */
+uint32_t __ramVectors;
+uint32_t __Vectors;
+
 static const cy_stc_fll_manual_config_t srss_0__clock_0__fll_0__fllConfig = {
 	.fllMult = 500u,
 	.refDiv = 20u,

--- a/soc/arm/cypress/psoc6/soc.h
+++ b/soc/arm/cypress/psoc6/soc.h
@@ -19,9 +19,7 @@
 
 #ifndef _ASMLANGUAGE
 
-
 #include <cy_device_headers.h>
-
 #include "../common/soc_gpio.h"
 #include "../common/cypress_psoc6_dt.h"
 

--- a/west.yml
+++ b/west.yml
@@ -64,11 +64,6 @@ manifest:
       path: modules/hal/atmel
       groups:
         - hal
-    - name: hal_cypress
-      revision: 81a059f21435bc7e315bccd720da5a9b615bbb50
-      path: modules/hal/cypress
-      groups:
-        - hal
     - name: hal_espressif
       revision: a7dc3c72291a387e0eb3b268d07df6eb70811a84
       path: modules/hal/espressif
@@ -81,7 +76,7 @@ manifest:
       groups:
         - hal
     - name: hal_infineon
-      revision: f1fa8241f8786198ba41155413243de36ed878a5
+      revision: 4af06965f57ba1e7d170e6a97d24c33785543a8c
       path: modules/hal/infineon
       groups:
         - hal


### PR DESCRIPTION
Updated old PSoC 6 implementation to use hal_infineon/mtb-pdl-cat1

This PR is reflected changes according to Task#1 for RFC#42883

This PR depend on: https://github.com/zephyrproject-rtos/hal_infineon/pull/2
NOTE: after merge hal_infineon, the west.yaml should be finally updated.