### PR TITLE
Bluetooth: Mesh: Don't replace destination of segmented message

### DIFF
--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -96,6 +96,7 @@ static struct seg_tx {
 	uint64_t              seq_auth;
 	uint16_t              src;
 	uint16_t              dst;
+	uint16_t              ack_src;
 	uint16_t              len;
 	uint8_t               hdr;
 	uint8_t               xmit;
@@ -263,6 +264,7 @@ static void seg_tx_reset(struct seg_tx *tx)
 	tx->sub = NULL;
 	tx->src = BT_MESH_ADDR_UNASSIGNED;
 	tx->dst = BT_MESH_ADDR_UNASSIGNED;
+	tx->ack_src = BT_MESH_ADDR_UNASSIGNED;
 	tx->blocked = false;
 
 	for (i = 0; i <= tx->seg_n && tx->nack_count; i++) {
@@ -798,8 +800,8 @@ static struct seg_tx *seg_tx_lookup(uint16_t seq_zero, uint8_t obo, uint16_t add
 		 * acknowledgement, assume it's a Friend that's
 		 * responding and therefore accept the message.
 		 */
-		if (obo && tx->nack_count == tx->seg_n + 1) {
-			tx->dst = addr;
+		if (obo && (tx->nack_count == tx->seg_n + 1 || tx->ack_src == addr)) {
+			tx->ack_src = addr;
 			return tx;
 		}
 	}


### PR DESCRIPTION
Don't replace destination of segmented message when acknowledgement is
received from a friend node, otherwise, when segments are retransmitted,
the destination will be used and the friend node will treat it as a new
segmented message.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>