### PR TITLE
xtensa: intel_adsp: use cavs_ipc driver only if enabled in Kconfig

### DIFF
--- a/soc/xtensa/intel_adsp/common/CMakeLists.txt
+++ b/soc/xtensa/intel_adsp/common/CMakeLists.txt
@@ -11,7 +11,7 @@ zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 
 zephyr_library_sources(soc.c)
 zephyr_library_sources(trace_out.c)
-zephyr_library_sources(cavs_ipc.c)
+zephyr_library_sources_ifdef(CONFIG_CAVS_IPC cavs_ipc.c)
 
 zephyr_library_sources_ifdef(CONFIG_INTEL_ADSP_CAVS
     rimage_modules.c


### PR DESCRIPTION
Commit bdce0a57424f ("soc/intel_adsp: Add a cavs_ipc driver to manage
host IPC") added a new driver for cAVS IPC. Although patch included the
CONFIG_CAVS_IPC option, in practise this had no effect and instead
driver was enabled whenever device tree included IPC hardware. This
caused IPC errors in SOF application builds where two drivers, one out
of tree in SOF and one in Zephyr, initialize the same hardware.

Fix the issue by enabling the driver only when CONFIG_CAVS_IPC is
enabled.

BugLink: https://github.com/thesofproject/sof/issues/5477
Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>