### PR TITLE
dts: arm: nxp: kinetis: add zephyr,memory-region for lower SRAM

### DIFF
--- a/dts/arm/nxp/nxp_k2x.dtsi
+++ b/dts/arm/nxp/nxp_k2x.dtsi
@@ -42,8 +42,9 @@
 	 * https://sourceware.org/ml/binutils/2017-02/msg00250.html
 	 */
 	sram_l: memory@1fff0000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x1fff0000 DT_SIZE_K(64)>;
+		zephyr,memory-region = "SRAML";
 	};
 
 	sram0: memory@20000000 {

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -38,8 +38,9 @@
 	 * https://sourceware.org/ml/binutils/2017-02/msg00250.html
 	 */
 	sram_l: memory@1fff0000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x1fff0000 DT_SIZE_K(64)>;
+		zephyr,memory-region = "SRAML";
 	};
 
 	sram0: memory@20000000 {

--- a/dts/arm/nxp/nxp_k8xfn256vxx15.dtsi
+++ b/dts/arm/nxp/nxp_k8xfn256vxx15.dtsi
@@ -18,8 +18,9 @@
 	 * https://sourceware.org/ml/binutils/2017-02/msg00250.html
 	 */
 	sram_l: memory@1fff0000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x1fff0000 DT_SIZE_K(64)>;
+		zephyr,memory-region = "SRAML";
 	};
 
 	sram0: memory@20000000 {

--- a/dts/arm/nxp/nxp_ke1xf256vlx16.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf256vlx16.dtsi
@@ -18,8 +18,9 @@
 	 * https://sourceware.org/ml/binutils/2017-02/msg00250.html
 	 */
 	sram_l: memory@1fffc000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x1fffc000 DT_SIZE_K(16)>;
+		zephyr,memory-region = "SRAML";
 	};
 
 	sram0: memory@20000000 {

--- a/dts/arm/nxp/nxp_ke1xf512vlx16.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf512vlx16.dtsi
@@ -18,8 +18,9 @@
 	 * https://sourceware.org/ml/binutils/2017-02/msg00250.html
 	 */
 	sram_l: memory@1fff8000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x1fff8000 DT_SIZE_K(32)>;
+		zephyr,memory-region = "SRAML";
 	};
 
 	sram0: memory@20000000 {


### PR DESCRIPTION
Add zephyr,memory-region compatibles for the lower SRAM on NXP Kinetis SoCs.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>