### PR TITLE
Fixes for missing/bad bt_conn_ref and disconnect cleanups

### DIFF
--- a/samples/bluetooth/iso_connected_benchmark/src/main.c
+++ b/samples/bluetooth/iso_connected_benchmark/src/main.c
@@ -426,7 +426,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 		default_conn = NULL;
 		return;
 	} else if (role == ROLE_PERIPHERAL) {
-		default_conn = conn;
+		default_conn = bt_conn_ref(conn);
 	}
 
 	LOG_INF("Connected: %s", addr);

--- a/samples/bluetooth/peripheral_past/src/main.c
+++ b/samples/bluetooth/peripheral_past/src/main.c
@@ -79,7 +79,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (default_conn == NULL) {
-		default_conn = conn;
+		default_conn = bt_conn_ref(conn);
 	}
 
 	if (conn != default_conn) {

--- a/samples/bluetooth/unicast_audio_server/src/main.c
+++ b/samples/bluetooth/unicast_audio_server/src/main.c
@@ -222,7 +222,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 	}
 
 	printk("Connected: %s\n", addr);
-	default_conn = conn;
+	default_conn = bt_conn_ref(conn);
 }
 
 static void disconnected(struct bt_conn *conn, uint8_t reason)

--- a/subsys/bluetooth/audio/stream.c
+++ b/subsys/bluetooth/audio/stream.c
@@ -40,7 +40,11 @@ void bt_audio_stream_attach(struct bt_conn *conn,
 {
 	BT_DBG("conn %p stream %p ep %p codec %p", conn, stream, ep, codec);
 
-	stream->conn = conn;
+	if (conn != NULL) {
+		__ASSERT(stream->conn == NULL || stream->conn == conn,
+			 "stream->conn already attached");
+		stream->conn = bt_conn_ref(conn);
+	}
 	stream->codec = codec;
 	stream->ep = ep;
 	ep->stream = stream;
@@ -217,7 +221,10 @@ void bt_audio_stream_detach(struct bt_audio_stream *stream)
 
 	BT_DBG("stream %p", stream);
 
-	stream->conn = NULL;
+	if (stream->conn != NULL) {
+		bt_conn_unref(stream->conn);
+		stream->conn = NULL;
+	}
 	stream->codec = NULL;
 	stream->ep->stream = NULL;
 	stream->ep = NULL;

--- a/subsys/bluetooth/audio/vcs_client.c
+++ b/subsys/bluetooth/audio/vcs_client.c
@@ -677,10 +677,8 @@ static void vocs_discover_cb(struct bt_vocs *inst, int err)
 }
 #endif /* CONFIG_BT_VCS_CLIENT_VOCS */
 
-static void vcs_client_reset(struct bt_conn *conn)
+static void vcs_client_reset(struct bt_vcs *vcs_inst)
 {
-	struct bt_vcs *vcs_inst = &vcs_insts[bt_conn_index(conn)];
-
 	memset(&vcs_inst->cli.state, 0, sizeof(vcs_inst->cli.state));
 	vcs_inst->cli.flags = 0;
 	vcs_inst->cli.start_handle = 0;
@@ -693,10 +691,35 @@ static void vcs_client_reset(struct bt_conn *conn)
 
 	memset(&vcs_inst->cli.discover_params, 0, sizeof(vcs_inst->cli.discover_params));
 
-	/* It's okay if these fail */
-	(void)bt_gatt_unsubscribe(conn, &vcs_inst->cli.state_sub_params);
-	(void)bt_gatt_unsubscribe(conn, &vcs_inst->cli.flag_sub_params);
+	if (vcs_inst->cli.conn != NULL) {
+		struct bt_conn *conn = vcs_inst->cli.conn;
+
+		/* It's okay if these fail. In case of disconnect, we can't
+		 * unsubscribe and they will just fail.
+		 * In case that we reset due to another call of the discover
+		 * function, we will unsubscribe (regardless of bonding state)
+		 * to accommodate the new discovery values.
+		 */
+		(void)bt_gatt_unsubscribe(conn, &vcs_inst->cli.state_sub_params);
+		(void)bt_gatt_unsubscribe(conn, &vcs_inst->cli.flag_sub_params);
+
+		bt_conn_unref(conn);
+		vcs_inst->cli.conn = NULL;
+	}
 }
+
+static void disconnected(struct bt_conn *conn, uint8_t reason)
+{
+	struct bt_vcs *vcs_inst = &vcs_insts[bt_conn_index(conn)];
+
+	if (vcs_inst->cli.conn == conn) {
+		vcs_client_reset(vcs_inst);
+	}
+}
+
+BT_CONN_CB_DEFINE(conn_callbacks) = {
+	.disconnected = disconnected,
+};
 
 static void bt_vcs_client_init(void)
 {
@@ -765,12 +788,12 @@ int bt_vcs_discover(struct bt_conn *conn, struct bt_vcs **vcs)
 		initialized = true;
 	}
 
-	vcs_client_reset(conn);
+	vcs_client_reset(vcs_inst);
 
 	memcpy(&vcs_inst->cli.uuid, BT_UUID_VCS, sizeof(vcs_inst->cli.uuid));
 
 	vcs_inst->client_instance = true;
-	vcs_inst->cli.conn = conn;
+	vcs_inst->cli.conn = bt_conn_ref(conn);
 	vcs_inst->cli.discover_params.func = primary_discover_func;
 	vcs_inst->cli.discover_params.uuid = &vcs_inst->cli.uuid.uuid;
 	vcs_inst->cli.discover_params.type = BT_GATT_DISCOVER_PRIMARY;

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/common.h
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/common.h
@@ -57,6 +57,7 @@
 
 #define AD_SIZE 1
 extern const struct bt_data ad[AD_SIZE];
+extern struct bt_conn *default_conn;
 
 void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 		  struct net_buf_simple *ad);

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/csis_client_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/csis_client_test.c
@@ -99,6 +99,8 @@ static void connected(struct bt_conn *conn, uint8_t err)
 	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err != 0) {
+		bt_conn_unref(default_conn);
+		default_conn = NULL;
 		FAIL("Failed to connect to %s (%u)\n", addr, err);
 		return;
 	}

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/mcc_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/mcc_test.c
@@ -29,7 +29,6 @@
 
 extern enum bst_result_t bst_result;
 
-static struct bt_conn *default_conn;
 static struct bt_mcc_cb mcc_cb;
 
 static uint64_t g_icon_object_id;
@@ -570,11 +569,12 @@ static void connected(struct bt_conn *conn, uint8_t err)
 	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err) {
+		bt_conn_unref(default_conn);
+		default_conn = NULL;
 		FAIL("Failed to connect to %s (%u)\n", addr, err);
 		return;
 	}
 
-	default_conn = conn;
 	SET_FLAG(ble_link_is_ready);
 }
 

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/mcs_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/mcs_test.c
@@ -25,8 +25,6 @@
 
 extern enum bst_result_t bst_result;
 
-static struct bt_conn *default_conn;
-
 CREATE_FLAG(ble_link_is_ready);
 
 /* Callback after Bluetoot initialization attempt */
@@ -58,7 +56,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 	if (err) {
 		FAIL("Failed to connect to %s (%u)\n", addr, err);
 	} else {
-		default_conn = conn;
+		default_conn = bt_conn_ref(conn);
 		printk("Connected: %s\n", addr);
 		SET_FLAG(ble_link_is_ready);
 	}

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/media_controller_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/media_controller_test.c
@@ -79,8 +79,6 @@ static struct media_player *local_player;
 static struct media_player *remote_player;
 static struct media_player *current_player;
 
-static struct bt_conn *default_conn;
-
 static void local_player_instance_cb(struct media_player *player, int err)
 {
 	if (err) {
@@ -588,7 +586,6 @@ static void connected(struct bt_conn *conn, uint8_t err)
 		return;
 	}
 
-	default_conn = conn;
 	printk("Connected: %s\n", addr);
 	SET_FLAG(ble_link_is_ready);
 }

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/mics_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/mics_test.c
@@ -30,7 +30,6 @@ static volatile uint8_t g_aics_gain_min;
 static volatile bool g_aics_active = true;
 static char g_aics_desc[AICS_DESC_SIZE];
 static volatile bool g_cb;
-static struct bt_conn *g_conn;
 static bool g_is_connected;
 
 static void mics_mute_cb(struct bt_mics *mics, int err, uint8_t mute)
@@ -133,7 +132,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 	}
 
 	printk("Connected to %s\n", addr);
-	g_conn = conn;
+	default_conn = bt_conn_ref(conn);
 	g_is_connected = true;
 }
 

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_test.c
@@ -41,7 +41,6 @@ static volatile uint8_t g_aics_gain_min;
 static volatile bool g_aics_active = 1;
 static char g_aics_desc[AICS_DESC_SIZE];
 static volatile bool g_cb;
-static struct bt_conn *g_conn;
 static bool g_is_connected;
 
 static void vcs_state_cb(struct bt_vcs *vcs, int err, uint8_t volume,
@@ -197,7 +196,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 		return;
 	}
 	printk("Connected to %s\n", addr);
-	g_conn = conn;
+	default_conn = bt_conn_ref(conn);
 	g_is_connected = true;
 }
 

--- a/tests/bluetooth/bsim_bt/bsim_test_gatt/src/gatt_server_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_gatt/src/gatt_server_test.c
@@ -25,7 +25,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 
 	printk("Connected to %s\n", addr);
 
-	g_conn = conn;
+	g_conn = bt_conn_ref(conn);
 	SET_FLAG(flag_is_connected);
 }
 


### PR DESCRIPTION
For LE Audio there was some missing handling of bt_conn_ref as well as missing cleanup. 

For BSIM tests the connection pointer was not handled uniformly. 

There were also a few samples that had bad handling of bt_conn_ref. 

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/42680