### PR TITLE
drivers: espi: xec: MEC172x Handle eSPI peripheral channel error

### DIFF
--- a/drivers/espi/espi_mchp_xec_v2.c
+++ b/drivers/espi/espi_mchp_xec_v2.c
@@ -852,6 +852,12 @@ static void espi_pc_isr(const struct device *dev)
 	struct espi_iom_regs *regs = ESPI_XEC_REG_BASE(dev);
 	uint32_t status = regs->PCSTS;
 
+	LOG_DBG("%s %x", __func__, status);
+	if (status & MCHP_ESPI_PC_STS_BUS_ERR) {
+		LOG_ERR("%s bus error", __func__);
+		regs->PCSTS = MCHP_ESPI_PC_STS_BUS_ERR;
+	}
+
 	if (status & MCHP_ESPI_PC_STS_EN_CHG) {
 		if (status & MCHP_ESPI_PC_STS_EN) {
 			setup_espi_io_config(dev, MCHP_ESPI_IOBAR_INIT_DFLT);


### PR DESCRIPTION
Handle eSPI periperal channel error to avoid continous interrupt
beyond the bus error.

Whenever an eSPI access causes an internal bus error,
PC_BUS_ERROR bit is set, it remains set until cleared by written
with an 1.

Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>