### PR TITLE
modules: hal_gigadevice: fix GD32_REMAP_MSK error.

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -73,7 +73,7 @@ manifest:
       groups:
         - hal
     - name: hal_gigadevice
-      revision: cc85acbd635f02122c54df11fa55458269ce1bdd
+      revision: 63a72ca90b7e0d7257211ddc5c79e8c0b940371b
       path: modules/hal/gigadevice
       groups:
         - hal


### PR DESCRIPTION
update hal_gigadevice to
- https://github.com/zephyrproject-rtos/hal_gigadevice/pull/18

----

fix pin remap config error.
GD32_REMAP is 10bit, origin 0x1ff is not correct.change to 0x3ff.
