### PR TITLE
drivers: serial: fix typos

### DIFF
--- a/drivers/serial/uart_imx.c
+++ b/drivers/serial/uart_imx.c
@@ -73,7 +73,7 @@ static int uart_imx_init(const struct device *dev)
 
 	UART_Init(uart, &initConfig);
 
-	/* Set UART build-in hardware FIFO Watermark. */
+	/* Set UART built-in hardware FIFO Watermark. */
 	UART_SetTxFifoWatermark(uart, 2);
 	UART_SetRxFifoWatermark(uart, 1);
 

--- a/drivers/serial/uart_lpc11u6x.h
+++ b/drivers/serial/uart_lpc11u6x.h
@@ -165,7 +165,7 @@ struct lpc11u6x_uartx_regs {
 	volatile uint32_t brg;               /* Baud rate generator */
 	volatile const uint32_t int_stat;    /* Interrupt status */
 	volatile uint32_t osr;               /* Oversample selection */
-	volatile uint32_t addr;              /* Address regiser*/
+	volatile uint32_t addr;              /* Address register*/
 };
 
 struct lpc11u6x_uartx_config {
@@ -195,7 +195,7 @@ struct lpc11u6x_uartx_data {
 
 /* Since UART1 and UART4 share the same IRQ (as well as UART2 and UART3),
  * we need to give the ISR a way to know all the devices that should be
- * notified when said IRQ is raied
+ * notified when said IRQ is raised
  */
 struct lpc11u6x_uartx_shared_irq {
 	const struct device *devices[LPC11U6X_UARTX_DEVICE_PER_IRQ];

--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -91,8 +91,8 @@ static void mcux_lpuart_poll_out(const struct device *dev, unsigned char c)
 #ifdef CONFIG_PM
 	/*
 	 * We must keep the part from entering lower power mode until the
-	 * tranmission completes. Set the power constraint, and enable
-	 * the tranmission complete interrupt so we know when tranmission is
+	 * transmission completes. Set the power constraint, and enable
+	 * the transmission complete interrupt so we know when transmission is
 	 * completed.
 	 */
 	if (!data->tx_poll_stream_on && !data->tx_int_stream_on) {

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1077,7 +1077,7 @@ static void rx_timeout(struct k_timer *timer)
 	}
 
 	/* Check for current buffer being full.
-	 * if the UART receives characters before the the ENDRX is handled
+	 * if the UART receives characters before the ENDRX is handled
 	 * and the 'next' buffer is set up, then the SHORT between ENDRX and
 	 * STARTRX will mean that data will be going into to the 'next' buffer
 	 * until the ENDRX event gets a chance to be handled.
@@ -1102,7 +1102,7 @@ static void rx_timeout(struct k_timer *timer)
 				data->async->rx_timeout_slab;
 		}
 
-		/* If theres nothing left to report until the buffers are
+		/* If there's nothing left to report until the buffers are
 		 * switched then the timer can be stopped
 		 */
 		if (clipped) {

--- a/drivers/serial/uart_pl011.c
+++ b/drivers/serial/uart_pl011.c
@@ -79,7 +79,7 @@ struct pl011_data {
 
 /* PL011 Receive status register / error clear register */
 #define PL011_RSR_ECR_FE	BIT(0)	/* framing error */
-#define PL011_RSR_ECR_PE	BIT(1)	/* parity erorr */
+#define PL011_RSR_ECR_PE	BIT(1)	/* parity error */
 #define PL011_RSR_ECR_BE	BIT(2)	/* break error */
 #define PL011_RSR_ECR_OE	BIT(3)	/* overrun error */
 
@@ -108,7 +108,7 @@ struct pl011_data {
 
 /* PL011 Control Register */
 #define PL011_CR_UARTEN		BIT(0)	/* enable uart operations */
-#define PL011_CR_SIREN		BIT(1)	/* enable  IrDA SIR */
+#define PL011_CR_SIREN		BIT(1)	/* enable IrDA SIR */
 #define PL011_CR_SIRLP		BIT(2)	/* IrDA SIR low power mode */
 #define PL011_CR_LBE		BIT(7)	/* loop back enable */
 #define PL011_CR_TXE		BIT(8)	/* transmit enable */
@@ -134,10 +134,10 @@ struct pl011_data {
 #define PL011_IMSC_RXIM		BIT(4)	/* receive interrupt mask */
 #define PL011_IMSC_TXIM		BIT(5)	/* transmit interrupt mask */
 #define PL011_IMSC_RTIM		BIT(6)	/* receive timeout interrupt mask */
-#define PL011_IMSC_FEIM		BIT(7)	/* framine error interrupt mask */
+#define PL011_IMSC_FEIM		BIT(7)	/* framing error interrupt mask */
 #define PL011_IMSC_PEIM		BIT(8)	/* parity error interrupt mask */
 #define PL011_IMSC_BEIM		BIT(9)	/* break error interrupt mask */
-#define PL011_IMSC_OEIM		BIT(10)	/* overrun error interrutpt mask */
+#define PL011_IMSC_OEIM		BIT(10)	/* overrun error interrupt mask */
 
 #define PL011_IMSC_ERROR_MASK	(PL011_IMSC_FEIM | \
 		PL011_IMSC_PEIM | PL011_IMSC_BEIM | \

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -967,14 +967,14 @@ static void uart_stm32_isr(const struct device *dev)
 		LL_USART_IsActiveFlag_TC(config->usart)) {
 
 		if (data->tx_poll_stream_on) {
-			/* A poll stream transmition just completed,
+			/* A poll stream transmission just completed,
 			 * allow system to suspend
 			 */
 			LL_USART_DisableIT_TC(config->usart);
 			data->tx_poll_stream_on = false;
 			uart_stm32_pm_constraint_release(dev);
 		}
-		/* Stream transmition was either async or IRQ based,
+		/* Stream transmission was either async or IRQ based,
 		 * constraint will be released at the same time TC IT
 		 * is disabled
 		 */
@@ -1103,7 +1103,7 @@ static int uart_stm32_async_rx_disable(const struct device *dev)
 	data->rx_next_buffer = NULL;
 	data->rx_next_buffer_len = 0;
 
-	/* When async rx is disabled, enable interruptable instance of uart to function normally*/
+	/* When async rx is disabled, enable interruptible instance of uart to function normally */
 	LL_USART_EnableIT_RXNE(config->usart);
 
 	LOG_DBG("rx: disabled");
@@ -1142,7 +1142,7 @@ static void uart_stm32_dma_replace_buffer(const struct device *dev)
 	const struct uart_stm32_config *config = dev->config;
 	struct uart_stm32_data *data = dev->data;
 
-	/* Replace the buffer and relod the DMA */
+	/* Replace the buffer and reload the DMA */
 	LOG_DBG("Replacing RX buffer: %d", data->rx_next_buffer_len);
 
 	/* reload DMA */


### PR DESCRIPTION
Typos were found with codespell utility.

Signed-off-by: Yegor Yefremov <yegorslists@googlemail.com>