### PR TITLE
net: lwm2m: Observation refactor and composite operation support

### DIFF
--- a/include/net/lwm2m.h
+++ b/include/net/lwm2m.h
@@ -546,14 +546,16 @@ struct lwm2m_objlnk {
  * LwM2M clients use this function to modify the pmin attribute
  * for an observation being made.
  * Example to update the pmin of a temperature sensor value being observed:
- * lwm2m_engine_update_observer_min_period("3303/0/5700",5);
+ * lwm2m_engine_update_observer_min_period("client_ctx, 3303/0/5700", 5);
  *
+ * @param[in] client_ctx LwM2M context
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res"
  * @param[in] period_s Value of pmin to be given (in seconds).
  *
  * @return 0 for success or negative in case of error.
  */
-int lwm2m_engine_update_observer_min_period(const char *pathstr, uint32_t period_s);
+int lwm2m_engine_update_observer_min_period(struct lwm2m_ctx *client_ctx, const char *pathstr,
+					    uint32_t period_s);
 
 /**
  * @brief Change an observer's pmax value.
@@ -561,14 +563,16 @@ int lwm2m_engine_update_observer_min_period(const char *pathstr, uint32_t period
  * LwM2M clients use this function to modify the pmax attribute
  * for an observation being made.
  * Example to update the pmax of a temperature sensor value being observed:
- * lwm2m_engine_update_observer_max_period("3303/0/5700",5);
+ * lwm2m_engine_update_observer_max_period("client_ctx, 3303/0/5700", 5);
  *
+ * @param[in] client_ctx LwM2M context
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res"
  * @param[in] period_s Value of pmax to be given (in seconds).
  *
  * @return 0 for success or negative in case of error.
  */
-int lwm2m_engine_update_observer_max_period(const char *pathstr, uint32_t period_s);
+int lwm2m_engine_update_observer_max_period(struct lwm2m_ctx *client_ctx, const char *pathstr,
+					    uint32_t period_s);
 
 /**
  * @brief Create an LwM2M object instance.

--- a/subsys/net/lib/lwm2m/lwm2m_engine.h
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.h
@@ -129,7 +129,10 @@ int lwm2m_register_payload_handler(struct lwm2m_message *msg);
 int lwm2m_perform_read_op(struct lwm2m_message *msg, uint16_t content_format);
 
 int lwm2m_perform_composite_read_op(struct lwm2m_message *msg, uint16_t content_format,
-				    sys_slist_t *lwm_path_list);
+				    sys_slist_t *lwm2m_path_list);
+
+int lwm2m_perform_composite_observation_op(struct lwm2m_message *msg, uint8_t *token,
+					   uint8_t token_length, sys_slist_t *lwm2m_path_list);
 
 int lwm2m_write_handler(struct lwm2m_engine_obj_inst *obj_inst,
 			struct lwm2m_engine_res *res,

--- a/subsys/net/lib/lwm2m/lwm2m_rw_senml_json.h
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_senml_json.h
@@ -20,8 +20,12 @@ int do_read_op_senml_json(struct lwm2m_message *msg);
 int do_write_op_senml_json(struct lwm2m_message *msg);
 
 /* Send opearation builder */
-int do_send_op_senml_json(struct lwm2m_message *msg, sys_slist_t *lwm_path_list);
+int do_send_op_senml_json(struct lwm2m_message *msg, sys_slist_t *lwm2m_path_list);
 /* API for call composite READ from engine */
 int do_composite_read_op_senml_json(struct lwm2m_message *msg);
+/* API for call composite READ path list from engine */
+int do_composite_observe_parse_path_senml_json(struct lwm2m_message *msg,
+					       sys_slist_t *lwm2m_path_list,
+					       sys_slist_t *lwm2m_path_free_list);
 
 #endif /* LWM2M_RW_SENML_JSON_H_ */


### PR DESCRIPTION
**Observation pmin and pmax refactor**

- Removed to store pmin and pmax at observation node structure and use attribute list store for calculate time for next Notification.
- Observation class use timestamp for triggering notification based on resource update which use pmin and default pmax behavior.
- Refactor function parameter naming from lwm_ to lwm2m

**Composite Observation support**

- Added support for Composite observation for LwM2M v1.1.
- Updated current Observation node to support linked path list.