### PR TITLE
Add IN_RANGE macro

### DIFF
--- a/doc/releases/release-notes-3.1.rst
+++ b/doc/releases/release-notes-3.1.rst
@@ -33,6 +33,11 @@ Stable API changes in this release
 New APIs in this release
 ========================
 
+* Util
+
+  * Added :c:macro:`IN_RANGE` for checking if a value is in the range of two
+    other values.
+
 Kernel
 ******
 

--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -205,6 +205,20 @@ extern "C" {
 #endif
 
 /**
+ * @brief Checks if a value is within range.
+ *
+ * @note @p val is evaluated twice.
+ *
+ * @param val Value to be checked.
+ * @param min Lower bound (inclusive).
+ * @param max Upper bound (inclusive).
+ *
+ * @retval true If value is within range
+ * @retval false If the value is not within range
+ */
+#define IN_RANGE(val, min, max) ((val) >= (min) && (val) <= (max))
+
+/**
  * @brief Is @p x a power of two?
  * @param x value to check
  * @return true if @p x is a power of two, false otherwise

--- a/subsys/bluetooth/audio/stream.c
+++ b/subsys/bluetooth/audio/stream.c
@@ -54,9 +54,6 @@ void bt_audio_stream_attach(struct bt_conn *conn,
 	}
 }
 
-#define IN_RANGE(_min, _max, _value) \
-	(_value >= _min && _value <= _max)
-
 static int bt_audio_stream_iso_accept(const struct bt_iso_accept_info *info,
 				      struct bt_iso_chan **iso_chan)
 {
@@ -206,7 +203,7 @@ bool bt_audio_valid_stream_qos(const struct bt_audio_stream *stream,
 		return false;
 	}
 
-	if (!IN_RANGE(qos_pref->pd_min, qos_pref->pd_max, qos->pd)) {
+	if (!IN_RANGE(qos->pd, qos_pref->pd_min, qos_pref->pd_max)) {
 		BT_DBG("Presentation Delay not within range: min %u max %u pd %u",
 			qos_pref->pd_min, qos_pref->pd_max, qos->pd);
 		return false;

--- a/subsys/bluetooth/host/sdp.c
+++ b/subsys/bluetooth/host/sdp.c
@@ -29,8 +29,6 @@
 
 #define SDP_CHAN(_ch) CONTAINER_OF(_ch, struct bt_sdp, chan.chan)
 
-#define IN_RANGE(val, min, max) (val >= min && val <= max)
-
 #define SDP_DATA_MTU 200
 
 #define SDP_MTU (SDP_DATA_MTU + sizeof(struct bt_sdp_hdr))

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -539,7 +539,7 @@ static int exec_cmd(const struct shell *shell, size_t argc, const char **argv,
 		uint8_t opt8 = shell->ctx->active_cmd.args.optional;
 		uint32_t opt = (opt8 == SHELL_OPT_ARG_CHECK_SKIP) ?
 				UINT16_MAX : opt8;
-		bool in_range = (argc >= mand) && (argc <= (mand + opt));
+		const bool in_range = IN_RANGE(argc, mand, mand + opt);
 
 		/* Check if argc is within allowed range */
 		ret_val = cmd_precheck(shell, in_range);

--- a/tests/unit/util/test.inc
+++ b/tests/unit/util/test.inc
@@ -231,6 +231,24 @@ static void test_CLAMP(void)
 		      0xffffffffaULL, "Unexpected clamp result");
 }
 
+static void test_IN_RANGE(void)
+{
+	zassert_true(IN_RANGE(0, 0, 0), "Unexpected IN_RANGE result");
+	zassert_true(IN_RANGE(1, 0, 1), "Unexpected IN_RANGE result");
+	zassert_true(IN_RANGE(1, 0, 2), "Unexpected IN_RANGE result");
+	zassert_true(IN_RANGE(-1, -2, 2), "Unexpected IN_RANGE result");
+	zassert_true(IN_RANGE(-3, -5, -1), "Unexpected IN_RANGE result");
+	zassert_true(IN_RANGE(0, 0, UINT64_MAX), "Unexpected IN_RANGE result");
+	zassert_true(IN_RANGE(UINT64_MAX, 0, UINT64_MAX), "Unexpected IN_RANGE result");
+	zassert_true(IN_RANGE(0, INT64_MIN, INT64_MAX), "Unexpected IN_RANGE result");
+	zassert_true(IN_RANGE(INT64_MIN, INT64_MIN, INT64_MAX), "Unexpected IN_RANGE result");
+	zassert_true(IN_RANGE(INT64_MAX, INT64_MIN, INT64_MAX), "Unexpected IN_RANGE result");
+
+	zassert_false(IN_RANGE(5, 0, 2), "Unexpected IN_RANGE result");
+	zassert_false(IN_RANGE(5, 10, 0), "Unexpected IN_RANGE result");
+	zassert_false(IN_RANGE(-1, 0, 1), "Unexpected IN_RANGE result");
+}
+
 static void test_FOR_EACH(void)
 {
 	#define FOR_EACH_MACRO_TEST(arg) *buf++ = arg
@@ -453,6 +471,7 @@ void test_cc(void)
 			 ztest_unit_test(test_MACRO_MAP_CAT),
 			 ztest_unit_test(test_z_max_z_min_z_clamp),
 			 ztest_unit_test(test_CLAMP),
+			 ztest_unit_test(test_IN_RANGE),
 			 ztest_unit_test(test_FOR_EACH),
 			 ztest_unit_test(test_FOR_EACH_NONEMPTY_TERM),
 			 ztest_unit_test(test_FOR_EACH_FIXED_ARG),


### PR DESCRIPTION
Adds the IN_RANGE macro and add a few uses of it for reference. 

There is likely a lot more cases where the macro could be used, but decided to not pollute this PR with a large list of changes. 