### PR TITLE
wifi: esp_at: free socket on close

### DIFF
--- a/drivers/wifi/esp_at/esp_offload.c
+++ b/drivers/wifi/esp_at/esp_offload.c
@@ -526,6 +526,9 @@ void esp_close_work(struct k_work *work)
 		}
 		k_mutex_unlock(&sock->lock);
 	}
+
+	/* Mark socket as free to use again */
+	esp_socket_flags_clear(sock, ESP_SOCK_IN_USE);
 }
 
 static int esp_recv(struct net_context *context,


### PR DESCRIPTION
Clear the `ESP_SOCK_IN_USE` flag when the socket is closed. This allows
the socket to be allocated again at a later time.

Fixes #43512.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>