### PR TITLE
manifest: mcuboot update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -173,7 +173,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 89936c338e46f43cb177a8b928cd80b90f3ace8f
+      revision: 7b9e4eecaa2547ba34cd40a13530f10dd70c92ca
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Synch up to the upstream:
mcu-tools/mcuboot@4c0f6c177fc5a562bd971849c5ebfd3029673850

Update to the 1.9.0
- boot: Allow larger minimum flash write
- boot_serial: zephyr: Add optional timeout to enter serial recovery
- boot_serial: Adapted to Zephyr's new CRC APIs
- zephyr: Use a smaller sha256 implementation
- boot_serial: Added support for the  echo command
- single loader: fixed image decryption for any SoC flash of the pages size which not fitted in 1024 B

Plus a few fixes
- serial recovery: fixed echo command
- serial recovery: fixed possible output buffer overflow

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>