### PR TITLE
net: if: add default selection of first up interface

### DIFF
--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -874,6 +874,14 @@ struct net_if *net_if_get_default(void);
  */
 struct net_if *net_if_get_first_by_type(const struct net_l2 *l2);
 
+/**
+ * @brief Get the first network interface which is up.
+ *
+ * @return First network interface which is up or NULL if all
+ * interfaces are down.
+ */
+struct net_if *net_if_get_first_up(void);
+
 #if defined(CONFIG_NET_L2_IEEE802154)
 /**
  * @brief Get the first IEEE 802.15.4 network interface.

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -717,6 +717,9 @@ choice
 config NET_DEFAULT_IF_FIRST
 	bool "First available interface"
 
+config NET_DEFAULT_IF_UP
+	bool "First interface which is up"
+
 config NET_DEFAULT_IF_ETHERNET
 	bool "Ethernet"
 	depends on NET_L2_ETHERNET

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -584,6 +584,9 @@ struct net_if *net_if_get_default(void)
 #if defined(CONFIG_NET_DEFAULT_IF_PPP)
 	iface = net_if_get_first_by_type(&NET_L2_GET_NAME(PPP));
 #endif
+#if defined(CONFIG_NET_DEFAULT_IF_UP)
+	iface = net_if_get_first_up();
+#endif
 
 	return iface ? iface : _net_if_list_start;
 }
@@ -597,6 +600,17 @@ struct net_if *net_if_get_first_by_type(const struct net_l2 *l2)
 		}
 
 		if (net_if_l2(iface) == l2) {
+			return iface;
+		}
+	}
+
+	return NULL;
+}
+
+struct net_if *net_if_get_first_up(void)
+{
+	STRUCT_SECTION_FOREACH(net_if, iface) {
+		if (net_if_flag_is_set(iface, NET_IF_UP)) {
 			return iface;
 		}
 	}


### PR DESCRIPTION
Add the default selection of the first interface which is up.

Fixes #43525

Signed-off-by: Benedikt Schmidt <benedikt.schmidt@embedded-solutions.at>