### PR TITLE
Removing TODOs from Refactored LLCP 

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -622,7 +622,9 @@ uint8_t ull_cp_encryption_start(struct ll_conn *conn, const uint8_t rand[8], con
 {
 	struct proc_ctx *ctx;
 
-	/* TODO(thoh): Proper checks for role, parameters etc. */
+	if (conn->lll.role != BT_HCI_ROLE_CENTRAL) {
+		return BT_HCI_ERR_CMD_DISALLOWED;
+	}
 
 	ctx = llcp_create_local_procedure(PROC_ENCRYPTION_START);
 	if (!ctx) {
@@ -646,7 +648,9 @@ uint8_t ull_cp_encryption_pause(struct ll_conn *conn, const uint8_t rand[8], con
 {
 	struct proc_ctx *ctx;
 
-	/* TODO(thoh): Proper checks for role, parameters etc. */
+	if (conn->lll.role != BT_HCI_ROLE_CENTRAL) {
+		return BT_HCI_ERR_CMD_DISALLOWED;
+	}
 
 	ctx = llcp_create_local_procedure(PROC_ENCRYPTION_PAUSE);
 	if (!ctx) {

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -54,16 +54,13 @@ sys_slist_t tx_buffer_wait_list;
 static uint8_t common_tx_buffer_alloc;
 #endif /* LLCP_TX_CTRL_BUF_QUEUE_ENABLE */
 
-/* TODO: Determine 'correct' number of tx nodes */
 static uint8_t buffer_mem_tx[TX_CTRL_BUF_SIZE * LLCP_TX_CTRL_BUF_COUNT];
 static struct llcp_mem_pool mem_tx = { .pool = buffer_mem_tx };
 
-/* TODO: Determine 'correct' number of ctx */
 static uint8_t buffer_mem_local_ctx[PROC_CTX_BUF_SIZE *
 				    CONFIG_BT_CTLR_LLCP_LOCAL_PROC_CTX_BUF_NUM];
 static struct llcp_mem_pool mem_local_ctx = { .pool = buffer_mem_local_ctx };
 
-/* TODO(thoh-ot): Determine 'correct' number of ctx */
 static uint8_t buffer_mem_remote_ctx[PROC_CTX_BUF_SIZE *
 				     CONFIG_BT_CTLR_LLCP_REMOTE_PROC_CTX_BUF_NUM];
 static struct llcp_mem_pool mem_remote_ctx = { .pool = buffer_mem_remote_ctx };
@@ -693,8 +690,6 @@ uint8_t ull_cp_phy_update(struct ll_conn *conn, uint8_t tx, uint8_t flags, uint8
 {
 	struct proc_ctx *ctx;
 
-	/* TODO(thoh): Proper checks for role, parameters etc. */
-
 	ctx = llcp_create_local_procedure(PROC_PHY_UPDATE);
 	if (!ctx) {
 		return BT_HCI_ERR_CMD_DISALLOWED;
@@ -724,10 +719,6 @@ uint8_t ull_cp_terminate(struct ll_conn *conn, uint8_t error_code)
 
 	ctx->data.term.error_code = error_code;
 
-	/* TODO
-	 * Termination procedure may be initiated at any time, even if other
-	 * LLCP is active.
-	 */
 	llcp_lr_enqueue(conn, ctx);
 
 	return BT_HCI_ERR_SUCCESS;
@@ -865,9 +856,6 @@ uint8_t ull_cp_conn_update(struct ll_conn *conn, uint16_t interval_min, uint16_t
 		LL_ASSERT(0); /* Unknown procedure */
 	}
 
-	/* TODO(tosk): Check what to handle (ADV_SCHED) from this legacy fct. */
-	/* event_conn_upd_prep() (event_conn_upd_init()) */
-
 	llcp_lr_enqueue(conn, ctx);
 
 	return BT_HCI_ERR_SUCCESS;
@@ -971,7 +959,9 @@ static bool pdu_is_unknown(struct pdu_data *pdu, struct proc_ctx *ctx)
 
 static bool pdu_is_reject(struct pdu_data *pdu, struct proc_ctx *ctx)
 {
-	/* TODO(thoh): For LL_REJECT_IND check if the active procedure is supporting the PDU */
+	/* For LL_REJECT_IND there is no simple way of confirming protocol validity of the PDU
+	 * for the given procedure, so simply pass it on and let procedure engine deal with it
+	 */
 	return (((pdu->llctrl.opcode == PDU_DATA_LLCTRL_TYPE_REJECT_EXT_IND) &&
 		 (ctx->tx_opcode == pdu->llctrl.reject_ext_ind.reject_opcode)) ||
 		(pdu->llctrl.opcode == PDU_DATA_LLCTRL_TYPE_REJECT_IND));

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_chmu.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_chmu.c
@@ -74,16 +74,6 @@ enum {
 /*
  * LLCP Local Procedure Channel Map Update FSM
  */
-
-/* TODO should go into some utils file */
-static uint16_t lp_event_counter(struct ll_conn *conn)
-{
-	struct lll_conn *lll = &conn->lll;
-
-	/* Calculate current event counter */
-	return lll->event_counter + lll->latency_prepare;
-}
-
 static void lp_chmu_tx(struct ll_conn *conn, struct proc_ctx *ctx)
 {
 	struct node_tx *tx;
@@ -119,7 +109,7 @@ static void lp_chmu_send_channel_map_update_ind(struct ll_conn *conn, struct pro
 	} else {
 		llcp_rr_set_incompat(conn, INCOMPAT_RESOLVABLE);
 
-		ctx->data.chmu.instant = lp_event_counter(conn) + CHMU_INSTANT_DELTA;
+		ctx->data.chmu.instant = ull_conn_event_counter(conn) + CHMU_INSTANT_DELTA;
 
 		lp_chmu_tx(conn, ctx);
 
@@ -155,7 +145,7 @@ static void lp_chmu_st_wait_tx_chan_map_ind(struct ll_conn *conn, struct proc_ct
 static void lp_chmu_check_instant(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt,
 				  void *param)
 {
-	uint16_t event_counter = lp_event_counter(conn);
+	uint16_t event_counter = ull_conn_event_counter(conn);
 
 	if (is_instant_reached_or_passed(ctx->data.chmu.instant, event_counter)) {
 		llcp_rr_set_incompat(conn, INCOMPAT_NO_COLLISION);
@@ -210,16 +200,6 @@ void llcp_lp_chmu_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param)
 /*
  * LLCP Remote Procedure Channel Map Update FSM
  */
-
-/* TODO should go into some utils file */
-static uint16_t rp_event_counter(struct ll_conn *conn)
-{
-	struct lll_conn *lll = &conn->lll;
-
-	/* Calculate current event counter */
-	return lll->event_counter + lll->latency_prepare;
-}
-
 static void rp_chmu_complete(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	ull_conn_chan_map_set(conn, ctx->data.chmu.chm);
@@ -256,7 +236,7 @@ static void rp_chmu_st_wait_rx_channel_map_update_ind(struct ll_conn *conn, stru
 static void rp_chmu_check_instant(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt,
 				  void *param)
 {
-	uint16_t event_counter = rp_event_counter(conn);
+	uint16_t event_counter = ull_conn_event_counter(conn);
 
 	if (((event_counter - ctx->data.chmu.instant) & 0xFFFF) <= 0x7FFF) {
 		rp_chmu_complete(conn, ctx, evt, param);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_chmu.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_chmu.c
@@ -119,7 +119,6 @@ static void lp_chmu_send_channel_map_update_ind(struct ll_conn *conn, struct pro
 	} else {
 		llcp_rr_set_incompat(conn, INCOMPAT_RESOLVABLE);
 
-		/* TODO Hardcoded instant delta */
 		ctx->data.chmu.instant = lp_event_counter(conn) + CHMU_INSTANT_DELTA;
 
 		lp_chmu_tx(conn, ctx);
@@ -230,7 +229,6 @@ static void rp_chmu_complete(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t
 
 static void rp_chmu_st_idle(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
-	/* TODO */
 	switch (evt) {
 	case RP_CHMU_EVT_RUN:
 		ctx->state = RP_CHMU_STATE_WAIT_RX_CHAN_MAP_IND;

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
@@ -578,7 +578,6 @@ static void lp_comm_st_wait_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, u
 		/* Ignore other evts */
 		break;
 	}
-	/* TODO */
 }
 
 static void lp_comm_rx_decode(struct ll_conn *conn, struct proc_ctx *ctx, struct pdu_data *pdu)
@@ -644,7 +643,6 @@ static void lp_comm_st_wait_rx(struct ll_conn *conn, struct proc_ctx *ctx, uint8
 static void lp_comm_st_wait_ntf(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt,
 				void *param)
 {
-	/* TODO */
 	switch (evt) {
 	case LP_COMMON_EVT_RUN:
 		switch (ctx->proc) {

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_conn_upd.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_conn_upd.c
@@ -45,7 +45,7 @@
 #define CONN_UPDATE_INSTANT_DELTA 6U
 
 /* TODO: Known, missing items (missing implementation):
- *	LL/CON/MAS/BV-34-C [Accepting Connection Parameter Request – event masked]
+ *	LL/CON/MAS/BV-34-C [Accepting Connection Parameter Request ? event masked]
  */
 
 /* LLCP Local Procedure Connection Update FSM states */
@@ -423,7 +423,6 @@ static void lp_cu_check_instant(struct ll_conn *conn, struct proc_ctx *ctx, uint
 static void lp_cu_st_wait_instant(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt,
 				  void *param)
 {
-	/* TODO */
 	switch (evt) {
 	case LP_CU_EVT_RUN:
 		lp_cu_check_instant(conn, ctx, evt, param);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_conn_upd.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_conn_upd.c
@@ -336,7 +336,6 @@ static void lp_cu_st_wait_rx_conn_param_rsp(struct ll_conn *conn, struct proc_ct
 		lp_cu_send_conn_update_ind(conn, ctx, evt, param);
 		break;
 	case LP_CU_EVT_REJECT:
-		/* TODO(tosk): Select between LL_REJECT_IND and LL_REJECT_EXT_IND */
 		if (pdu->llctrl.reject_ext_ind.error_code == BT_HCI_ERR_UNSUPP_REMOTE_FEATURE) {
 			/* Remote legacy Host */
 			llcp_rr_set_incompat(conn, INCOMPAT_RESERVED);
@@ -547,7 +546,6 @@ static void rp_cu_tx(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t opcode)
 		break;
 #if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
 	case PDU_DATA_LLCTRL_TYPE_REJECT_EXT_IND:
-		/* TODO(thoh): Select between LL_REJECT_IND and LL_REJECT_EXT_IND */
 		llcp_pdu_encode_reject_ext_ind(pdu, PDU_DATA_LLCTRL_TYPE_CONN_PARAM_REQ,
 					       ctx->data.cu.error);
 		break;

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_enc.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_enc.c
@@ -339,7 +339,6 @@ static void lp_enc_send_start_enc_rsp(struct ll_conn *conn, struct proc_ctx *ctx
 static void lp_enc_st_unencrypted(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt,
 				  void *param)
 {
-	/* TODO */
 	switch (evt) {
 	case LP_ENC_EVT_RUN:
 		/* Pause Tx data */
@@ -462,7 +461,6 @@ static void lp_enc_st_wait_rx_start_enc_rsp(struct ll_conn *conn, struct proc_ct
 
 static void lp_enc_st_wait_ntf(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
-	/* TODO */
 	switch (evt) {
 	case LP_ENC_EVT_RUN:
 		lp_enc_complete(conn, ctx, evt, param);
@@ -476,7 +474,6 @@ static void lp_enc_st_wait_ntf(struct ll_conn *conn, struct proc_ctx *ctx, uint8
 static void lp_enc_state_encrypted(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt,
 				   void *param)
 {
-	/* TODO */
 	switch (evt) {
 	case LP_ENC_EVT_RUN:
 		/* Pause Tx data */
@@ -930,7 +927,6 @@ static void rp_enc_state_wait_rx_enc_req(struct ll_conn *conn, struct proc_ctx *
 static void rp_enc_state_wait_tx_enc_rsp(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt,
 					 void *param)
 {
-	/* TODO */
 	switch (evt) {
 	case RP_ENC_EVT_RUN:
 		rp_enc_send_enc_rsp(conn, ctx, evt, param);
@@ -944,7 +940,6 @@ static void rp_enc_state_wait_tx_enc_rsp(struct ll_conn *conn, struct proc_ctx *
 static void rp_enc_state_wait_ntf_ltk_req(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt,
 					  void *param)
 {
-	/* TODO */
 	switch (evt) {
 	case RP_ENC_EVT_RUN:
 		rp_enc_send_ltk_ntf(conn, ctx, evt, param);
@@ -958,7 +953,6 @@ static void rp_enc_state_wait_ntf_ltk_req(struct ll_conn *conn, struct proc_ctx 
 static void rp_enc_state_wait_ltk_reply(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt,
 					void *param)
 {
-	/* TODO */
 	switch (evt) {
 	case RP_ENC_EVT_LTK_REQ_REPLY:
 		rp_enc_send_start_enc_req(conn, ctx, evt, param);
@@ -975,7 +969,6 @@ static void rp_enc_state_wait_ltk_reply(struct ll_conn *conn, struct proc_ctx *c
 static void rp_enc_state_wait_tx_start_enc_req(struct ll_conn *conn, struct proc_ctx *ctx,
 					       uint8_t evt, void *param)
 {
-	/* TODO */
 	switch (evt) {
 	case RP_ENC_EVT_RUN:
 		rp_enc_send_start_enc_req(conn, ctx, evt, param);
@@ -989,7 +982,6 @@ static void rp_enc_state_wait_tx_start_enc_req(struct ll_conn *conn, struct proc
 static void rp_enc_state_wait_tx_reject_ind(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt,
 					    void *param)
 {
-	/* TODO */
 	switch (evt) {
 	case RP_ENC_EVT_RUN:
 		rp_enc_send_reject_ind(conn, ctx, evt, param);
@@ -1003,7 +995,6 @@ static void rp_enc_state_wait_tx_reject_ind(struct ll_conn *conn, struct proc_ct
 static void rp_enc_state_wait_rx_start_enc_rsp(struct ll_conn *conn, struct proc_ctx *ctx,
 					       uint8_t evt, void *param)
 {
-	/* TODO */
 	switch (evt) {
 	case RP_ENC_EVT_START_ENC_RSP:
 		rp_enc_complete(conn, ctx, evt, param);
@@ -1017,7 +1008,6 @@ static void rp_enc_state_wait_rx_start_enc_rsp(struct ll_conn *conn, struct proc
 static void rp_enc_state_wait_ntf(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt,
 				  void *param)
 {
-	/* TODO */
 	switch (evt) {
 	case RP_ENC_EVT_RUN:
 		rp_enc_complete(conn, ctx, evt, param);
@@ -1031,7 +1021,6 @@ static void rp_enc_state_wait_ntf(struct ll_conn *conn, struct proc_ctx *ctx, ui
 static void rp_enc_state_wait_tx_start_enc_rsp(struct ll_conn *conn, struct proc_ctx *ctx,
 					       uint8_t evt, void *param)
 {
-	/* TODO */
 	switch (evt) {
 	case RP_ENC_EVT_RUN:
 		rp_enc_send_start_enc_rsp(conn, ctx, evt, param);
@@ -1058,7 +1047,6 @@ static void rp_enc_state_encrypted(struct ll_conn *conn, struct proc_ctx *ctx, u
 static void rp_enc_state_wait_rx_pause_enc_req(struct ll_conn *conn, struct proc_ctx *ctx,
 					       uint8_t evt, void *param)
 {
-	/* TODO */
 	switch (evt) {
 	case RP_ENC_EVT_PAUSE_ENC_REQ:
 		/* Pause Tx data */
@@ -1080,7 +1068,6 @@ static void rp_enc_state_wait_rx_pause_enc_req(struct ll_conn *conn, struct proc
 static void rp_enc_state_wait_tx_pause_enc_rsp(struct ll_conn *conn, struct proc_ctx *ctx,
 					       uint8_t evt, void *param)
 {
-	/* TODO */
 	switch (evt) {
 	case RP_ENC_EVT_RUN:
 		rp_enc_send_pause_enc_rsp(conn, ctx, evt, param);
@@ -1094,7 +1081,6 @@ static void rp_enc_state_wait_tx_pause_enc_rsp(struct ll_conn *conn, struct proc
 static void rp_enc_state_wait_rx_pause_enc_rsp(struct ll_conn *conn, struct proc_ctx *ctx,
 					       uint8_t evt, void *param)
 {
-	/* TODO */
 	switch (evt) {
 	case RP_ENC_EVT_PAUSE_ENC_RSP:
 		/* Continue with an encapsulated Start Procedure */

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
@@ -56,14 +56,8 @@ struct llcp_enc {
 	/* NOTE: To save memory, SKD(m|s) and IV(m|s) are
 	 * generated just-in-time for PDU enqueuing and are
 	 * therefore not present in this structure.
-	 */
-
-	/* TODO(thoh): Do we want a version without JIT vector
-	 * generation?
-	 */
-
-	/* TODO(thoh): Optimize memory layout.
-	 *	* Overlay memory?
+	 * Further candidates for optimizing memory layout.
+	 *	* Overlay memory
 	 *	* Repurpose memory used by lll.ccm_tx/rx?
 	 */
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
@@ -293,7 +293,7 @@ static void lr_act_complete(struct ll_conn *conn)
 
 static void lr_act_connect(struct ll_conn *conn)
 {
-	/* TODO */
+	/* Empty on purpose */
 }
 
 static void lr_act_disconnect(struct ll_conn *conn)
@@ -459,7 +459,6 @@ void llcp_lr_abort(struct ll_conn *conn)
 		ctx = lr_dequeue(conn);
 	}
 
-	/* TODO(thoh): Whats missing here ??? */
 	ull_conn_prt_clear(conn);
 	llcp_rr_set_incompat(conn, 0U);
 	lr_set_state(conn, LR_STATE_IDLE);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_pdu.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_pdu.c
@@ -329,9 +329,12 @@ void llcp_pdu_encode_enc_req(struct proc_ctx *ctx, struct pdu_data *pdu)
 	memcpy(p->rand, ctx->data.enc.rand, sizeof(p->rand));
 	p->ediv[0] = ctx->data.enc.ediv[0];
 	p->ediv[1] = ctx->data.enc.ediv[1];
-	/* TODO(thoh): Optimize getting random data */
-	csrand_get(p->skdm, sizeof(p->skdm));
-	csrand_get(p->ivm, sizeof(p->ivm));
+	/* Optimal getting random data, p->ivm is packed right after p->skdm */
+	BUILD_ASSERT(offsetof(struct pdu_data_llctrl_enc_req, ivm) ==
+		     offsetof(struct pdu_data_llctrl_enc_req, skdm) + sizeof(p->skdm),
+		     "Member IVM must be after member SKDM");
+	csrand_get(p->skdm, sizeof(p->skdm) + sizeof(p->ivm));
+
 }
 #endif /* CONFIG_BT_CENTRAL */
 
@@ -361,9 +364,11 @@ void llcp_pdu_encode_enc_rsp(struct pdu_data *pdu)
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_ENC_RSP;
 
 	p = &pdu->llctrl.enc_rsp;
-	/* TODO(thoh): Optimize getting random data */
-	csrand_get(p->skds, sizeof(p->skds));
-	csrand_get(p->ivs, sizeof(p->ivs));
+	/* Optimal getting random data, p->ivs is packed right after p->skds */
+	BUILD_ASSERT(offsetof(struct pdu_data_llctrl_enc_rsp, ivs) ==
+		     offsetof(struct pdu_data_llctrl_enc_rsp, skds) + sizeof(p->skds),
+		     "Member IVS must be after member SKDS");
+	csrand_get(p->skds, sizeof(p->skds) + sizeof(p->ivs));
 }
 
 void llcp_pdu_encode_start_enc_req(struct pdu_data *pdu)

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
@@ -240,9 +240,6 @@ static uint8_t pu_apply_phy_update(struct ll_conn *conn, struct proc_ctx *ctx)
 	return (ctx->data.pu.c_to_p_phy || ctx->data.pu.p_to_c_phy);
 }
 
-/*
- * TODO: this is the same as calc_eff_time in ull_connections.c
- */
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 static uint16_t pu_calc_eff_time(uint8_t max_octets, uint8_t phy, uint16_t default_time)
 {
@@ -470,7 +467,6 @@ static void lp_pu_send_phy_update_ind(struct ll_conn *conn, struct proc_ctx *ctx
 
 static void lp_pu_st_idle(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
-	/* TODO */
 	switch (evt) {
 	case LP_PU_EVT_RUN:
 		lp_pu_send_phy_req(conn, ctx, evt, param);
@@ -500,7 +496,6 @@ static void lp_pu_st_wait_rx_phy_rsp(struct ll_conn *conn, struct proc_ctx *ctx,
 {
 	switch (evt) {
 	case LP_PU_EVT_PHY_RSP:
-		/* TODO: should we swap the function call with variable declaration? */
 		llcp_rr_set_incompat(conn, INCOMPAT_RESERVED);
 		/* 'Prefer' the phys from the REQ */
 		uint8_t tx_pref = ctx->data.pu.tx;
@@ -668,7 +663,6 @@ static void lp_pu_check_instant(struct ll_conn *conn, struct proc_ctx *ctx, uint
 static void lp_pu_st_wait_instant(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt,
 				  void *param)
 {
-	/* TODO */
 	switch (evt) {
 	case LP_PU_EVT_RUN:
 		lp_pu_check_instant(conn, ctx, evt, param);
@@ -875,7 +869,6 @@ static void rp_pu_send_phy_rsp(struct ll_conn *conn, struct proc_ctx *ctx, uint8
 
 static void rp_pu_st_idle(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
-	/* TODO */
 	switch (evt) {
 	case RP_PU_EVT_RUN:
 		ctx->state = RP_PU_STATE_WAIT_RX_PHY_REQ;
@@ -1035,7 +1028,6 @@ static void rp_pu_check_instant(struct ll_conn *conn, struct proc_ctx *ctx, uint
 static void rp_pu_st_wait_instant(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt,
 				  void *param)
 {
-	/* TODO */
 	switch (evt) {
 	case RP_PU_EVT_RUN:
 		rp_pu_check_instant(conn, ctx, evt, param);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
@@ -73,37 +73,23 @@ enum {
 
 static bool proc_with_instant(struct proc_ctx *ctx)
 {
-	/*
-	 * TODO: should we combine all the cases that return 0
-	 * and all the cases that return 1?
-	 */
 	switch (ctx->proc) {
 	case PROC_UNKNOWN:
-		return 0U;
 	case PROC_FEATURE_EXCHANGE:
-		return 0U;
 	case PROC_MIN_USED_CHANS:
-		return 0U;
 	case PROC_LE_PING:
-		return 0U;
 	case PROC_VERSION_EXCHANGE:
-		return 0U;
 	case PROC_ENCRYPTION_START:
 	case PROC_ENCRYPTION_PAUSE:
-		return 0U;
-	case PROC_PHY_UPDATE:
-		return 1U;
-	case PROC_CONN_UPDATE:
-	case PROC_CONN_PARAM_REQ:
-		return 1U;
 	case PROC_TERMINATE:
-		return 0U;
-	case PROC_CHAN_MAP_UPDATE:
-		return 1U;
 	case PROC_DATA_LENGTH_UPDATE:
-		return 0U;
 	case PROC_CTE_REQ:
 		return 0U;
+	case PROC_PHY_UPDATE:
+	case PROC_CONN_UPDATE:
+	case PROC_CONN_PARAM_REQ:
+	case PROC_CHAN_MAP_UPDATE:
+		return 1U;
 	default:
 		/* Unknown procedure */
 		LL_ASSERT(0);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
@@ -444,7 +444,7 @@ static void rr_act_complete(struct ll_conn *conn)
 
 static void rr_act_connect(struct ll_conn *conn)
 {
-	/* TODO */
+	/* Empty on purpose */
 }
 
 static void rr_act_disconnect(struct ll_conn *conn)
@@ -814,7 +814,6 @@ static void rr_abort(struct ll_conn *conn)
 		ctx = rr_dequeue(conn);
 	}
 
-	/* TODO(thoh): Whats missing here ??? */
 	rr_set_collision(conn, 0U);
 	rr_set_state(conn, RR_STATE_IDLE);
 }

--- a/tests/bluetooth/controller/common/include/helper_features.h
+++ b/tests/bluetooth/controller/common/include/helper_features.h
@@ -237,13 +237,8 @@
 
 /*
  * The following two are defined as per
- * Core Spec V5.2 Volume 6, Part B, chapter 4.6
- * LL_FEAT_BIT_MASK_VALID does not account for the bits
- * for the new features in V5.2
- * TODO: EXPECTED_FEAT_EXCH_VALID is not used at the moment
- *       but probably LL_FEAT_BIT_MASK_VALID should get this
- *       value in ll_feat.h
+ * Core Spec V5.3 Volume 6, Part B, chapter 4.6
  */
-#define EXPECTED_FEAT_EXCH_VALID 0x0000000FF787CF2F
+#define EXPECTED_FEAT_EXCH_VALID 0x000000EFF787CF2F
 #define FEAT_FILTER_OCTET0 0xFFFFFFFFFFFFFF00
 #define COMMON_FEAT_OCTET0(x) (FEAT_FILTER_OCTET0 | ((x) & ~FEAT_FILTER_OCTET0))

--- a/tests/bluetooth/controller/common/src/helper_util.c
+++ b/tests/bluetooth/controller/common/src/helper_util.c
@@ -39,7 +39,6 @@
 #include "helper_util.h"
 
 static uint32_t event_active;
-static uint16_t lazy;
 sys_slist_t ut_rx_q;
 static sys_slist_t lt_tx_q;
 static uint32_t no_of_ctx_buffers_at_test_setup;
@@ -223,7 +222,6 @@ void test_setup(struct ll_conn *conn)
 	ll_reset();
 	conn->lll.event_counter = 0;
 	event_active = 0;
-	lazy = 0;
 
 	no_of_ctx_buffers_at_test_setup = ctx_buffers_free();
 }
@@ -260,9 +258,6 @@ void event_prepare(struct ll_conn *conn)
 	lll->event_counter = event_counter + 1;
 
 	lll->latency_prepare = 0;
-
-	/* Rest lazy */
-	lazy = 0;
 }
 
 void event_tx_ack(struct ll_conn *conn, struct node_tx *tx)
@@ -289,15 +284,10 @@ void event_done(struct ll_conn *conn)
 
 uint16_t event_counter(struct ll_conn *conn)
 {
-	/* TODO(thoh): Mocked lll_conn */
-	struct lll_conn *lll;
 	uint16_t event_counter;
 
-	/**/
-	lll = &conn->lll;
-
 	/* Calculate current event counter */
-	event_counter = lll->event_counter + lll->latency_prepare + lazy;
+	event_counter = ull_conn_event_counter(conn);
 
 	/* If event_counter is called inside an event_prepare()/event_done() pair
 	 * return the current event counter value (i.e. -1);

--- a/tests/bluetooth/controller/ctrl_chmu/src/main.c
+++ b/tests/bluetooth/controller/ctrl_chmu/src/main.c
@@ -53,8 +53,7 @@ static bool is_instant_reached(struct ll_conn *conn, uint16_t instant)
 void test_channel_map_update_central_loc(void)
 {
 	uint8_t chm[5] = { 0x00, 0x04, 0x05, 0x06, 0x00 };
-	/* TODO should test setup set this to valid value? */
-	uint8_t defchm[5] = {};
+	uint8_t initial_chm[5];
 	uint8_t err;
 	struct node_tx *tx;
 	struct pdu_data *pdu;
@@ -63,6 +62,9 @@ void test_channel_map_update_central_loc(void)
 		.instant = 6,
 		.chm = { 0x00, 0x04, 0x05, 0x06, 0x00 },
 	};
+
+	/* Store initial channel map */
+	memcpy(initial_chm, conn.lll.data_chan_map, sizeof(conn.lll.data_chan_map));
 
 	/* Role */
 	test_set_role(&conn, BT_HCI_ROLE_CENTRAL);
@@ -104,8 +106,9 @@ void test_channel_map_update_central_loc(void)
 		/* There should NOT be a host notification */
 		ut_rx_q_is_empty();
 
-		/* check if using old channel map */
-		zassert_mem_equal(conn.lll.data_chan_map, defchm, sizeof(conn.lll.data_chan_map),
+		/* check if still using initial channel map */
+		zassert_mem_equal(conn.lll.data_chan_map, initial_chm,
+				  sizeof(conn.lll.data_chan_map),
 				  "Channel map invalid");
 	}
 
@@ -132,13 +135,15 @@ void test_channel_map_update_central_loc(void)
 void test_channel_map_update_periph_rem(void)
 {
 	uint8_t chm[5] = { 0x00, 0x04, 0x05, 0x06, 0x00 };
-	/* TODO should test setup set this to valid value? */
-	uint8_t defchm[5] = {};
+	uint8_t initial_chm[5];
 	struct pdu_data_llctrl_chan_map_ind chmu_ind = {
 		.instant = 6,
 		.chm = { 0x00, 0x04, 0x05, 0x06, 0x00 },
 	};
 	uint16_t instant = 6;
+
+	/* Store initial channel map */
+	memcpy(initial_chm, conn.lll.data_chan_map, sizeof(conn.lll.data_chan_map));
 
 	/* Role */
 	test_set_role(&conn, BT_HCI_ROLE_PERIPHERAL);
@@ -173,7 +178,8 @@ void test_channel_map_update_periph_rem(void)
 		ut_rx_q_is_empty();
 
 		/* check if using old channel map */
-		zassert_mem_equal(conn.lll.data_chan_map, defchm, sizeof(conn.lll.data_chan_map),
+		zassert_mem_equal(conn.lll.data_chan_map, initial_chm,
+				  sizeof(conn.lll.data_chan_map),
 				  "Channel map invalid");
 	}
 

--- a/tests/bluetooth/controller/ctrl_encrypt/src/main.c
+++ b/tests/bluetooth/controller/ctrl_encrypt/src/main.c
@@ -191,15 +191,10 @@ void test_encryption_start_central_loc(void)
 	/* Prepare LL_ENC_RSP */
 	struct pdu_data_llctrl_enc_rsp enc_rsp = { .skds = { SKDS }, .ivs = { IVS } };
 
-	/* Prepare mocked call(s) to lll_csrand_get */
-	/* First call for SKDm */
-	ztest_returns_value(lll_csrand_get, sizeof(exp_enc_req.skdm));
+	/* Prepare mocked call to lll_csrand_get */
+	ztest_returns_value(lll_csrand_get, sizeof(exp_enc_req.skdm) + sizeof(exp_enc_req.ivm));
 	ztest_return_data(lll_csrand_get, buf, exp_enc_req.skdm);
-	ztest_expect_value(lll_csrand_get, len, sizeof(exp_enc_req.skdm));
-	/* Second call for IVm */
-	ztest_returns_value(lll_csrand_get, sizeof(exp_enc_req.ivm));
-	ztest_return_data(lll_csrand_get, buf, exp_enc_req.ivm);
-	ztest_expect_value(lll_csrand_get, len, sizeof(exp_enc_req.ivm));
+	ztest_expect_value(lll_csrand_get, len, sizeof(exp_enc_req.skdm) + sizeof(exp_enc_req.ivm));
 
 	/* Prepare mocked call to ecb_encrypt */
 	ztest_expect_data(ecb_encrypt, key_le, ltk);
@@ -354,15 +349,10 @@ void test_encryption_start_central_loc_limited_memory(void)
 	/* Prepare LL_ENC_RSP */
 	struct pdu_data_llctrl_enc_rsp enc_rsp = { .skds = { SKDS }, .ivs = { IVS } };
 
-	/* Prepare mocked call(s) to lll_csrand_get */
-	/* First call for SKDm */
-	ztest_returns_value(lll_csrand_get, sizeof(exp_enc_req.skdm));
+	/* Prepare mocked call to lll_csrand_get */
+	ztest_returns_value(lll_csrand_get, sizeof(exp_enc_req.skdm) + sizeof(exp_enc_req.ivm));
 	ztest_return_data(lll_csrand_get, buf, exp_enc_req.skdm);
-	ztest_expect_value(lll_csrand_get, len, sizeof(exp_enc_req.skdm));
-	/* Second call for IVm */
-	ztest_returns_value(lll_csrand_get, sizeof(exp_enc_req.ivm));
-	ztest_return_data(lll_csrand_get, buf, exp_enc_req.ivm);
-	ztest_expect_value(lll_csrand_get, len, sizeof(exp_enc_req.ivm));
+	ztest_expect_value(lll_csrand_get, len, sizeof(exp_enc_req.skdm) + sizeof(exp_enc_req.ivm));
 
 	/* Prepare mocked call to ecb_encrypt */
 	ztest_expect_data(ecb_encrypt, key_le, ltk);
@@ -570,15 +560,10 @@ void test_encryption_start_central_loc_no_ltk(void)
 	/* Prepare LL_ENC_RSP */
 	struct pdu_data_llctrl_enc_rsp enc_rsp = { .skds = { SKDS }, .ivs = { IVS } };
 
-	/* Prepare mocked call(s) to lll_csrand_get */
-	/* First call for SKDm */
-	ztest_returns_value(lll_csrand_get, sizeof(exp_enc_req.skdm));
+	/* Prepare mocked call to lll_csrand_get */
+	ztest_returns_value(lll_csrand_get, sizeof(exp_enc_req.skdm) + sizeof(exp_enc_req.ivm));
 	ztest_return_data(lll_csrand_get, buf, exp_enc_req.skdm);
-	ztest_expect_value(lll_csrand_get, len, sizeof(exp_enc_req.skdm));
-	/* Second call for IVm */
-	ztest_returns_value(lll_csrand_get, sizeof(exp_enc_req.ivm));
-	ztest_return_data(lll_csrand_get, buf, exp_enc_req.ivm);
-	ztest_expect_value(lll_csrand_get, len, sizeof(exp_enc_req.ivm));
+	ztest_expect_value(lll_csrand_get, len, sizeof(exp_enc_req.skdm) + sizeof(exp_enc_req.ivm));
 
 	struct pdu_data_llctrl_reject_ind reject_ind = { .error_code =
 								 BT_HCI_ERR_PIN_OR_KEY_MISSING };
@@ -686,15 +671,10 @@ void test_encryption_start_central_loc_no_ltk_2(void)
 	/* Prepare LL_ENC_RSP */
 	struct pdu_data_llctrl_enc_rsp enc_rsp = { .skds = { SKDS }, .ivs = { IVS } };
 
-	/* Prepare mocked call(s) to lll_csrand_get */
-	/* First call for SKDm */
-	ztest_returns_value(lll_csrand_get, sizeof(exp_enc_req.skdm));
+	/* Prepare mocked call to lll_csrand_get */
+	ztest_returns_value(lll_csrand_get, sizeof(exp_enc_req.skdm) + sizeof(exp_enc_req.ivm));
 	ztest_return_data(lll_csrand_get, buf, exp_enc_req.skdm);
-	ztest_expect_value(lll_csrand_get, len, sizeof(exp_enc_req.skdm));
-	/* Second call for IVm */
-	ztest_returns_value(lll_csrand_get, sizeof(exp_enc_req.ivm));
-	ztest_return_data(lll_csrand_get, buf, exp_enc_req.ivm);
-	ztest_expect_value(lll_csrand_get, len, sizeof(exp_enc_req.ivm));
+	ztest_expect_value(lll_csrand_get, len, sizeof(exp_enc_req.skdm) + sizeof(exp_enc_req.ivm));
 
 	struct pdu_data_llctrl_reject_ind reject_ind = { .error_code =
 								 BT_HCI_ERR_PIN_OR_KEY_MISSING };
@@ -812,15 +792,10 @@ void test_encryption_start_periph_rem(void)
 		.ivs = { IVS },
 	};
 
-	/* Prepare mocked call(s) to lll_csrand_get */
-	/* First call for SKDs */
-	ztest_returns_value(lll_csrand_get, sizeof(exp_enc_rsp.skds));
+	/* Prepare mocked call to lll_csrand_get */
+	ztest_returns_value(lll_csrand_get, sizeof(exp_enc_rsp.skds) + sizeof(exp_enc_rsp.ivs));
 	ztest_return_data(lll_csrand_get, buf, exp_enc_rsp.skds);
-	ztest_expect_value(lll_csrand_get, len, sizeof(exp_enc_rsp.skds));
-	/* Second call for IVs */
-	ztest_returns_value(lll_csrand_get, sizeof(exp_enc_rsp.ivs));
-	ztest_return_data(lll_csrand_get, buf, exp_enc_rsp.ivs);
-	ztest_expect_value(lll_csrand_get, len, sizeof(exp_enc_rsp.ivs));
+	ztest_expect_value(lll_csrand_get, len, sizeof(exp_enc_rsp.skds) + sizeof(exp_enc_rsp.ivs));
 
 	/* Prepare mocked call to ecb_encrypt */
 	ztest_expect_data(ecb_encrypt, key_le, ltk);
@@ -1034,15 +1009,10 @@ void test_encryption_start_periph_rem_limited_memory(void)
 		.ivs = { IVS },
 	};
 
-	/* Prepare mocked call(s) to lll_csrand_get */
-	/* First call for SKDs */
-	ztest_returns_value(lll_csrand_get, sizeof(exp_enc_rsp.skds));
+	/* Prepare mocked call to lll_csrand_get */
+	ztest_returns_value(lll_csrand_get, sizeof(exp_enc_rsp.skds) + sizeof(exp_enc_rsp.ivs));
 	ztest_return_data(lll_csrand_get, buf, exp_enc_rsp.skds);
-	ztest_expect_value(lll_csrand_get, len, sizeof(exp_enc_rsp.skds));
-	/* Second call for IVs */
-	ztest_returns_value(lll_csrand_get, sizeof(exp_enc_rsp.ivs));
-	ztest_return_data(lll_csrand_get, buf, exp_enc_rsp.ivs);
-	ztest_expect_value(lll_csrand_get, len, sizeof(exp_enc_rsp.ivs));
+	ztest_expect_value(lll_csrand_get, len, sizeof(exp_enc_rsp.skds) + sizeof(exp_enc_rsp.ivs));
 
 	/* Prepare mocked call to ecb_encrypt */
 	ztest_expect_data(ecb_encrypt, key_le, ltk);
@@ -1317,15 +1287,10 @@ void test_encryption_start_periph_rem_no_ltk(void)
 		.error_code = BT_HCI_ERR_PIN_OR_KEY_MISSING
 	};
 
-	/* Prepare mocked call(s) to lll_csrand_get */
-	/* First call for SKDs */
-	ztest_returns_value(lll_csrand_get, sizeof(exp_enc_rsp.skds));
+	/* Prepare mocked call to lll_csrand_get */
+	ztest_returns_value(lll_csrand_get, sizeof(exp_enc_rsp.skds) + sizeof(exp_enc_rsp.ivs));
 	ztest_return_data(lll_csrand_get, buf, exp_enc_rsp.skds);
-	ztest_expect_value(lll_csrand_get, len, sizeof(exp_enc_rsp.skds));
-	/* Second call for IVs */
-	ztest_returns_value(lll_csrand_get, sizeof(exp_enc_rsp.ivs));
-	ztest_return_data(lll_csrand_get, buf, exp_enc_rsp.ivs);
-	ztest_expect_value(lll_csrand_get, len, sizeof(exp_enc_rsp.ivs));
+	ztest_expect_value(lll_csrand_get, len, sizeof(exp_enc_rsp.skds) + sizeof(exp_enc_rsp.ivs));
 
 	/* Role */
 	test_set_role(&conn, BT_HCI_ROLE_PERIPHERAL);
@@ -1443,15 +1408,10 @@ void test_encryption_pause_central_loc(void)
 	/* Prepare LL_ENC_RSP */
 	struct pdu_data_llctrl_enc_rsp enc_rsp = { .skds = { SKDS }, .ivs = { IVS } };
 
-	/* Prepare mocked call(s) to lll_csrand_get */
-	/* First call for SKDm */
-	ztest_returns_value(lll_csrand_get, sizeof(exp_enc_req.skdm));
+	/* Prepare mocked call to lll_csrand_get */
+	ztest_returns_value(lll_csrand_get, sizeof(exp_enc_req.skdm) + sizeof(exp_enc_req.ivm));
 	ztest_return_data(lll_csrand_get, buf, exp_enc_req.skdm);
-	ztest_expect_value(lll_csrand_get, len, sizeof(exp_enc_req.skdm));
-	/* Second call for IVm */
-	ztest_returns_value(lll_csrand_get, sizeof(exp_enc_req.ivm));
-	ztest_return_data(lll_csrand_get, buf, exp_enc_req.ivm);
-	ztest_expect_value(lll_csrand_get, len, sizeof(exp_enc_req.ivm));
+	ztest_expect_value(lll_csrand_get, len, sizeof(exp_enc_req.skdm) + sizeof(exp_enc_req.ivm));
 
 	/* Prepare mocked call to ecb_encrypt */
 	ztest_expect_data(ecb_encrypt, key_le, ltk);
@@ -1593,15 +1553,10 @@ void test_encryption_pause_periph_rem(void)
 		.ivs = { IVS },
 	};
 
-	/* Prepare mocked call(s) to lll_csrand_get */
-	/* First call for SKDs */
-	ztest_returns_value(lll_csrand_get, sizeof(exp_enc_rsp.skds));
+	/* Prepare mocked call to lll_csrand_get */
+	ztest_returns_value(lll_csrand_get, sizeof(exp_enc_rsp.skds) + sizeof(exp_enc_rsp.ivs));
 	ztest_return_data(lll_csrand_get, buf, exp_enc_rsp.skds);
-	ztest_expect_value(lll_csrand_get, len, sizeof(exp_enc_rsp.skds));
-	/* Second call for IVs */
-	ztest_returns_value(lll_csrand_get, sizeof(exp_enc_rsp.ivs));
-	ztest_return_data(lll_csrand_get, buf, exp_enc_rsp.ivs);
-	ztest_expect_value(lll_csrand_get, len, sizeof(exp_enc_rsp.ivs));
+	ztest_expect_value(lll_csrand_get, len, sizeof(exp_enc_rsp.skds) + sizeof(exp_enc_rsp.ivs));
 
 	/* Prepare mocked call to ecb_encrypt */
 	ztest_expect_data(ecb_encrypt, key_le, ltk);

--- a/tests/bluetooth/controller/ctrl_hci/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_hci/testcase.yaml
@@ -2,5 +2,4 @@ common:
     tags: test_framework bluetooth bt_ctrl_hci bt_ull_llcp
 tests:
   bluetooth.controller.ctrl_hci.test:
-     skip: true
      type: unit

--- a/tests/bluetooth/controller/ctrl_min_used_chans/src/main.c
+++ b/tests/bluetooth/controller/ctrl_min_used_chans/src/main.c
@@ -126,10 +126,6 @@ void test_min_used_chans_central_rem(void)
 {
 	struct pdu_data_llctrl_min_used_chans_ind remote_muc_ind = { .phys = 1,
 		.min_used_chans = 2 };
-	struct pdu_data_llctrl_chan_map_ind ch_map_ind = { .chm = { 0xff, 0xff, 0xff, 0xff, 0x1f },
-		.instant = 7 };
-
-	struct node_tx *tx;
 
 	/* Role */
 	test_set_role(&conn, BT_HCI_ROLE_CENTRAL);
@@ -143,17 +139,13 @@ void test_min_used_chans_central_rem(void)
 	/* Rx */
 	lt_tx(LL_MIN_USED_CHANS_IND, &conn,  &remote_muc_ind);
 
-	/* Emulate a phy to trigger channel map update */
-	conn.lll.phy_tx = 0x7;
-
 	/* Done */
 	event_done(&conn);
 
 	/* Prepare */
 	event_prepare(&conn);
 
-	/* Tx Queue should have one LL Control PDU */
-	lt_rx(LL_CHAN_MAP_UPDATE_IND, &conn,  &tx, &ch_map_ind);
+	/* Tx Queue should have no LL Control PDU */
 	lt_rx_q_is_empty(&conn);
 
 	/* Done */
@@ -162,7 +154,7 @@ void test_min_used_chans_central_rem(void)
 	/* There should not be a host notifications */
 	ut_rx_q_is_empty();
 
-	zassert_equal(ctx_buffers_free(), test_ctx_buffers_cnt() - 1,
+	zassert_equal(ctx_buffers_free(), test_ctx_buffers_cnt(),
 		      "Free CTX buffers %d", ctx_buffers_free());
 }
 

--- a/tests/bluetooth/controller/mock_ctrl/src/util.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/util.c
@@ -17,9 +17,6 @@
 
 /**
  * @brief Population count: Count the number of bits set to 1
- * @details
- * TODO: Faster methods available at [1].
- * [1] http://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetParallel
  *
  * @param octets     Data to count over
  * @param octets_len Must not be bigger than 255/8 = 31 bytes


### PR DESCRIPTION
This removes a bunch of TODOs ranging in complexity from no-brainers to minor modifications.