### PR TITLE
samples: Bluetooth: df: Forward GPIO pins from app to network core

### DIFF
--- a/samples/bluetooth/direction_finding_central/README.rst
+++ b/samples/bluetooth/direction_finding_central/README.rst
@@ -45,6 +45,9 @@ enabled:
   :zephyr_file:`samples/bluetooth/direction_finding_central/boards/nrf52833dk_nrf52833.overlay`
   to a new file,
   :file:`samples/bluetooth/hci_rpmsg/boards/nrf5340dk_nrf5340_cpunet.overlay`.
+* Make sure the same GPIO pins are assigned to Direction Finding Extension in file
+  :zephyr_file:`samples/bluetooth/direction_finding_central/boards/nrf5340dk_nrf5340_cpuapp.overlay`.
+  as those in the created file  :file:`samples/bluetooth/hci_rpmsg/boards/nrf5340dk_nrf5340_cpunet.overlay`.
 * Copy
   :zephyr_file:`samples/bluetooth/direction_finding_central/boards/nrf52833dk_nrf52833.conf`
   to a new file,

--- a/samples/bluetooth/direction_finding_central/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/bluetooth/direction_finding_central/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ /* Enable pin forwarding to network core. The selected pins will be used by
+  * Radio Direction Finding Extension for antenna switching purposes.
+  *
+  * Note: Pay attention to assign the same GPIO pins as those provided in
+  * network core DTS overlay.
+  */
+&gpio_fwd {
+	dfe-gpio-if {
+		gpios = <&gpio0 0 0>,
+			<&gpio0 1 0>,
+			<&gpio0 2 0>,
+			<&gpio0 3 0>;
+		};
+};

--- a/samples/bluetooth/direction_finding_connectionless_rx/README.rst
+++ b/samples/bluetooth/direction_finding_connectionless_rx/README.rst
@@ -45,6 +45,9 @@ enabled:
   :zephyr_file:`samples/bluetooth/direction_finding_connectionless_rx/boards/nrf52833dk_nrf52833.overlay`
   to a new file,
   :file:`samples/bluetooth/hci_rpmsg/boards/nrf5340dk_nrf5340_cpunet.overlay`.
+* Make sure the same GPIO pins are assigned to Direction Finding Extension in file
+  :zephyr_file:`samples/bluetooth/direction_finding_connectionless_rx/boards/nrf5340dk_nrf5340_cpuapp.overlay`.
+  as those in the created file :file:`samples/bluetooth/hci_rpmsg/boards/nrf5340dk_nrf5340_cpunet.overlay`.
 * Copy
   :zephyr_file:`samples/bluetooth/direction_finding_connectionless_rx/boards/nrf52833dk_nrf52833.conf`
   to a new file,

--- a/samples/bluetooth/direction_finding_connectionless_rx/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/bluetooth/direction_finding_connectionless_rx/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ /* Enable pin forwarding to network core. The selected pins will be used by
+  * Radio Direction Finding Extension for antenna switching purposes.
+  *
+  * Note: Pay attention to assign the same GPIO pins as those provided in
+  * network core DTS overlay.
+  */
+&gpio_fwd {
+	dfe-gpio-if {
+		gpios = <&gpio0 0 0>,
+			<&gpio0 1 0>,
+			<&gpio0 2 0>,
+			<&gpio0 3 0>;
+		};
+};

--- a/samples/bluetooth/direction_finding_connectionless_tx/README.rst
+++ b/samples/bluetooth/direction_finding_connectionless_tx/README.rst
@@ -45,6 +45,9 @@ support enabled:
   :zephyr_file:`samples/bluetooth/direction_finding_connectionless_tx/boards/nrf52833dk_nrf52833.overlay`
   to a new file,
   :file:`samples/bluetooth/hci_rpmsg/boards/nrf5340dk_nrf5340_cpunet.overlay`.
+* Make sure the same GPIO pins are assigned to Direction Finding Extension in file
+  :zephyr_file:`samples/bluetooth/direction_finding_connectionless_tx/boards/nrf5340dk_nrf5340_cpuapp.overlay`.
+  as those in the created file :file:`samples/bluetooth/hci_rpmsg/boards/nrf5340dk_nrf5340_cpunet.overlay`.
 * Copy
   :zephyr_file:`samples/bluetooth/direction_finding_connectionless_tx/boards/nrf52833dk_nrf52833.conf`
   to a new file,

--- a/samples/bluetooth/direction_finding_connectionless_tx/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/bluetooth/direction_finding_connectionless_tx/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ /* Enable pin forwarding to network core. The selected pins will be used by
+  * Radio Direction Finding Extension for antenna switching purposes.
+  *
+  * Note: Pay attention to assign the same GPIO pins as those provided in
+  * network core DTS overlay.
+  */
+&gpio_fwd {
+	dfe-gpio-if {
+		gpios = <&gpio0 0 0>,
+			<&gpio0 1 0>,
+			<&gpio0 2 0>,
+			<&gpio0 3 0>;
+		};
+};

--- a/samples/bluetooth/direction_finding_peripheral/README.rst
+++ b/samples/bluetooth/direction_finding_peripheral/README.rst
@@ -44,6 +44,9 @@ enabled:
   :zephyr_file:`samples/bluetooth/direction_finding_peripheral/boards/nrf52833dk_nrf52833.overlay`
   to a new file,
   :file:`samples/bluetooth/hci_rpmsg/boards/nrf5340dk_nrf5340_cpunet.overlay`.
+* Make sure the same GPIO pins are assigned to Direction Finding Extension in file
+  :zephyr_file:`samples/bluetooth/direction_finding_peripheral/boards/nrf5340dk_nrf5340_cpuapp.overlay`.
+  as those in the created file :file:`samples/bluetooth/hci_rpmsg/boards/nrf5340dk_nrf5340_cpunet.overlay`.
 * Copy
   :zephyr_file:`samples/bluetooth/direction_finding_peripheral/boards/nrf52833dk_nrf52833.conf`
   to a new file,

--- a/samples/bluetooth/direction_finding_peripheral/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/bluetooth/direction_finding_peripheral/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ /* Enable pin forwarding to network core. The selected pins will be used by
+  * Radio Direction Finding Extension for antenna switching purposes.
+  *
+  * Note: Pay attention to assign the same GPIO pins as those provided in
+  * network core DTS overlay.
+  */
+&gpio_fwd {
+	dfe-gpio-if {
+		gpios = <&gpio0 0 0>,
+			<&gpio0 1 0>,
+			<&gpio0 2 0>,
+			<&gpio0 3 0>;
+		};
+};


### PR DESCRIPTION
To give control over GPIO pins for Direction Finding Extension of
Radio peripheral when build for nRF53 network core, the application
core has to assign those pins to network core.

There is a mechanism that uses a device tree overlay to get
information about GPIO pins to be assigned to network core.

The commit adds overlays with appropriate configuration
to assign GPIO pins in all DF related samples.

The change uses GPIO forwarding functionality provided by: #43047.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>