### PR TITLE
Bluetooth: iso: Fix Data Channel Path configuration

### DIFF
--- a/subsys/bluetooth/host/iso_internal.h
+++ b/subsys/bluetooth/host/iso_internal.h
@@ -11,8 +11,6 @@
 
 #include <bluetooth/iso.h>
 
-#define BT_ISO_DATA_PATH_DISABLED			0xFF
-
 struct iso_data {
 	/** BT_BUF_ISO_IN */
 	uint8_t  type;


### PR DESCRIPTION
This fixes the data path configuration parameters.

relates: #43190