### PR TITLE
Bluetooth spi hci: BlueNRG-MS: Chip Select  management reworked with full DT support

### DIFF
--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -154,7 +154,7 @@
 	pinctrl-0 = <&spi3_sck_pc10 &spi3_miso_pc11 &spi3_mosi_pc12>;
 	pinctrl-names = "default";
 
-	cs-gpios = <&gpiod 13 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>,
+	cs-gpios = <&gpiod 13 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
 		   <&gpioe 0 GPIO_ACTIVE_LOW>;
 
 	spbtle-rf@0 {

--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -116,8 +116,17 @@ struct bluenrg_aci_cmd_ll_param {
 static int bt_spi_send_aci_config_data_controller_mode(void);
 #endif /* CONFIG_BT_BLUENRG_ACI */
 
+#if defined(CONFIG_BT_SPI_BLUENRG)
+/* In case of BlueNRG-MS, it is necessary to prevent SPI driver to release CS,
+ * and instead, let current driver manage CS release. see kick_cs()/release_cs()
+ * So, add SPI_HOLD_ON_CS to operation field.
+ */
+static const struct spi_dt_spec bus = SPI_DT_SPEC_INST_GET(
+	0, SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB | SPI_WORD_SET(8) | SPI_HOLD_ON_CS, 0);
+#else
 static const struct spi_dt_spec bus = SPI_DT_SPEC_INST_GET(
 	0, SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB | SPI_WORD_SET(8), 0);
+#endif
 
 static struct spi_buf spi_tx_buf;
 static struct spi_buf spi_rx_buf;

--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -190,13 +190,13 @@ static int configure_cs(void)
 
 static void kick_cs(void)
 {
-	gpio_pin_set_dt(&bus.config.cs->gpio, 1);
 	gpio_pin_set_dt(&bus.config.cs->gpio, 0);
+	gpio_pin_set_dt(&bus.config.cs->gpio, 1);
 }
 
 static void release_cs(void)
 {
-	gpio_pin_set_dt(&bus.config.cs->gpio, 1);
+	gpio_pin_set_dt(&bus.config.cs->gpio, 0);
 }
 
 static bool irq_pin_high(void)


### PR DESCRIPTION
Bluetooth spi hci: BlueNRG-MS Chip Select  management reworked with full DT support
See detailed analysis in #43310

* disco_l475_iot1 DT should define CS as `GPIO_ACTIVE_LOW`
* `kick_cs()` and `release_cs()` should use logic instead of pin value as active low inversion is managed underneath in `gpio_pin_set_dt()`
* for BlueNRG-MS module, we should prevent SPI driver to release CS, and let bluetooth driver do the job, otherwise, for example, CS is released between sending Read command and effective read transaction, and this cause read failure.
This could be achieved by setting operation flag `SPI_HOLD_ON_CS`

Fixes #43310