### PR TITLE
Bluetooth: Host: Add public way of getting bonding state of a connection

### DIFF
--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -297,6 +297,10 @@ struct bt_conn_le_info {
 	/* Connection maximum single fragment parameters */
 	const struct bt_conn_le_data_len_info *data_len;
 #endif /* defined(CONFIG_BT_USER_DATA_LEN_UPDATE) */
+#if defined(CONFIG_BT_SMP)
+	/** Whether or not the connection is bonded */
+	bool bonded;
+#endif /* CONFIG_BT_SMP */
 };
 
 /* Multiply bt 1.25 to get MS */

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -24,7 +24,6 @@
 #define LOG_MODULE_NAME bt_ascs
 #include "common/log.h"
 
-#include "../host/hci_core.h"
 #include "../host/conn_internal.h"
 
 #include "endpoint.h"
@@ -550,6 +549,19 @@ static void ascs_detach(struct bt_ascs *ascs)
 	ascs->conn = NULL;
 }
 
+static bool is_bonded(const struct bt_conn *conn)
+{
+	struct bt_conn_info info;
+	int err;
+
+	err = bt_conn_get_info(conn, &info);
+	if (err != 0) {
+		return false;
+	}
+
+	return info.le.bonded;
+}
+
 static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	int i;
@@ -562,7 +574,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		}
 
 		/* Release existing ASEs if not bonded */
-		if (!bt_addr_le_is_bonded(conn->id, &conn->le.dst)) {
+		if (!is_bonded(conn)) {
 			ascs_clear(&sessions[i]);
 		} else {
 			ascs_detach(&sessions[i]);

--- a/subsys/bluetooth/audio/csis.c
+++ b/subsys/bluetooth/audio/csis.c
@@ -62,6 +62,19 @@ struct csis_notify_foreach {
 	struct bt_csis *csis;
 };
 
+static bool is_bonded(const struct bt_conn *conn)
+{
+	struct bt_conn_info info;
+	int err;
+
+	err = bt_conn_get_info(conn, &info);
+	if (err != 0) {
+		return false;
+	}
+
+	return info.le.bonded;
+}
+
 static bool is_last_client_to_write(const struct bt_csis *csis,
 				    const struct bt_conn *conn)
 {
@@ -500,7 +513,7 @@ static void csis_security_changed(struct bt_conn *conn, bt_security_t level,
 		return;
 	}
 
-	if (!bt_addr_le_is_bonded(conn->id, &conn->le.dst)) {
+	if (!is_bonded(conn)) {
 		return;
 	}
 
@@ -606,7 +619,7 @@ static void csis_disconnected(struct bt_conn *conn, uint8_t reason)
 	 * If lock was taken by non-bonded device, set lock to released value,
 	 * and notify other connections.
 	 */
-	if (!bt_addr_le_is_bonded(conn->id, &conn->le.dst)) {
+	if (!is_bonded(conn)) {
 		return;
 	}
 

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2233,6 +2233,10 @@ int bt_conn_get_info(const struct bt_conn *conn, struct bt_conn_info *info)
 #if defined(CONFIG_BT_USER_DATA_LEN_UPDATE)
 		info->le.data_len = &conn->le.data_len;
 #endif
+#if defined(CONFIG_BT_SMP)
+		info->le.bonded = bt_addr_le_is_bonded(conn->id, &conn->le.dst);
+#endif /* CONFIG_BT_SMP */
+
 		return 0;
 #if defined(CONFIG_BT_BREDR)
 	case BT_CONN_TYPE_BR:

--- a/tests/bluetooth/tester/src/gap.c
+++ b/tests/bluetooth/tester/src/gap.c
@@ -19,8 +19,6 @@
 #include <sys/byteorder.h>
 #include <net/buf.h>
 
-#include <hci_core.h>
-
 #include <logging/log.h>
 #define LOG_MODULE_NAME bttester_gap
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
@@ -896,13 +894,26 @@ static void auth_cancel(struct bt_conn *conn)
 	/* TODO */
 }
 
+static bool is_bonded(const struct bt_conn *conn)
+{
+	struct bt_conn_info info;
+	int err;
+
+	err = bt_conn_get_info(conn, &info);
+	if (err != 0) {
+		return false;
+	}
+
+	return info.le.bonded;
+}
+
 enum bt_security_err auth_pairing_accept(struct bt_conn *conn,
 					 const struct bt_conn_pairing_feat *const feat)
 {
 	struct gap_bond_lost_ev ev;
 	const bt_addr_le_t *addr = bt_conn_get_dst(conn);
 
-	if (!bt_addr_le_is_bonded(BT_ID_DEFAULT, addr)) {
+	if (!is_bonded(conn)) {
 		return BT_SECURITY_ERR_SUCCESS;
 	}
 


### PR DESCRIPTION
Some used the internal function (bt_addr_le_is_bonded) from hci_core to get bonding information. 