### PR TITLE
Bluetooth: Controller: df: Do not send IQ rep for PDU without CTE

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -1000,7 +1000,6 @@ static inline int create_iq_report(struct lll_sync *lll, uint8_t rssi_ready,
 	struct node_rx_iq_report *iq_report;
 	struct lll_df_sync_cfg *cfg;
 	struct node_rx_ftr *ftr;
-	uint8_t sample_cnt;
 	uint8_t cte_info;
 	uint8_t ant;
 
@@ -1008,19 +1007,17 @@ static inline int create_iq_report(struct lll_sync *lll, uint8_t rssi_ready,
 
 	if (cfg->is_enabled) {
 		if (is_max_cte_reached(cfg->max_cte_count, cfg->cte_count)) {
-			sample_cnt = radio_df_iq_samples_amount_get();
-
-			/* If there are no samples available, the CTEInfo was
+			/* If the CTEPRESENT event didn't fire, the CTEInfo was
 			 * not detected and sampling was not started.
 			 */
-			if (sample_cnt > 0) {
+			if (radio_df_cte_ready()) {
 				cte_info = radio_df_cte_status_get();
 				ant = radio_df_pdu_antenna_switch_pattern_get();
 				iq_report = ull_df_iq_report_alloc();
 				LL_ASSERT(iq_report);
 
 				iq_report->hdr.type = NODE_RX_TYPE_SYNC_IQ_SAMPLE_REPORT;
-				iq_report->sample_count = sample_cnt;
+				iq_report->sample_count = radio_df_iq_samples_amount_get();
 				iq_report->packet_status = packet_status;
 				iq_report->rssi_ant_id = ant;
 				iq_report->cte_info = *(struct pdu_cte_info *)&cte_info;


### PR DESCRIPTION
Check if the CTE was discovered by Radio peripheral should be
done with use of CTEPRESENT event. Samples count should not
be used for that purpose. If samples count is a value different
than zero for PDUs that don't have CTE, unwanted IQ samples
report will be generated. CTEPRESENT event is set only in case the
CTEInfo filed was correctly parsed by Radio peripheral during
PDU reception.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>