### PR TITLE
Bluetooth: Host: Add auth_info_cb struct and remove fields in bt_auth_cb

### DIFF
--- a/doc/releases/release-notes-3.1.rst
+++ b/doc/releases/release-notes-3.1.rst
@@ -52,6 +52,9 @@ Bluetooth
   * The enum bt_l2cap_chan_state values BT_L2CAP_CONNECT and BT_L2CAP_DISCONNECT
     has been renamed to BT_L2CAP_CONNECTING and BT_L2CAP_DISCONNECTING.
 
+  * Moved the callbacks :c:func:`pairing_complete`, :c:func:`pairing_failed` and
+    :c:func:`bond_delete` from the `struct bt_auth_cb` to a newly created
+    informational-only callback `struct bt_auth_info_cb`.
 
 New APIs in this release
 ========================

--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -1307,6 +1307,41 @@ struct bt_conn_auth_cb {
 	 *  @param bonded Bond information has been distributed during the
 	 *                pairing procedure.
 	 */
+	__deprecated
+	void (*pairing_complete)(struct bt_conn *conn, bool bonded);
+
+	/** @brief notify that pairing process has failed.
+	 *
+	 *  @param conn Connection object.
+	 *  @param reason Pairing failed reason
+	 */
+	__deprecated
+	void (*pairing_failed)(struct bt_conn *conn,
+			       enum bt_security_err reason);
+
+	/** @brief Notify that bond has been deleted.
+	 *
+	 *  This callback notifies the application that the bond information
+	 *  for the remote peer has been deleted
+	 *
+	 *  @param id   Which local identity had the bond.
+	 *  @param peer Remote address.
+	 */
+	__deprecated
+	void (*bond_deleted)(uint8_t id, const bt_addr_le_t *peer);
+};
+
+/** Authenticated pairing information callback structure */
+struct bt_conn_auth_info_cb {
+	/** @brief notify that pairing procedure was complete.
+	 *
+	 *  This callback notifies the application that the pairing procedure
+	 *  has been completed.
+	 *
+	 *  @param conn Connection object.
+	 *  @param bonded Bond information has been distributed during the
+	 *                pairing procedure.
+	 */
 	void (*pairing_complete)(struct bt_conn *conn, bool bonded);
 
 	/** @brief notify that pairing process has failed.
@@ -1326,6 +1361,9 @@ struct bt_conn_auth_cb {
 	 *  @param peer Remote address.
 	 */
 	void (*bond_deleted)(uint8_t id, const bt_addr_le_t *peer);
+
+	/** Internally used field for list handling */
+	sys_snode_t node;
 };
 
 /** @brief Register authentication callbacks.
@@ -1338,6 +1376,27 @@ struct bt_conn_auth_cb {
  *  @return Zero on success or negative error code otherwise
  */
 int bt_conn_auth_cb_register(const struct bt_conn_auth_cb *cb);
+
+/** @brief Register authentication information callbacks.
+ *
+ *  Register callbacks to get authenticated pairing information. Multiple
+ *  registrations can be done.
+ *
+ *  @param cb Callback struct.
+ *
+ *  @return Zero on success or negative error code otherwise
+ */
+int bt_conn_auth_info_cb_register(struct bt_conn_auth_info_cb *cb);
+
+/** @brief Unregister authentication information callbacks.
+ *
+ *  Unregister callbacks to stop getting authenticated pairing information.
+ *
+ *  @param cb Callback struct.
+ *
+ *  @return Zero on success or negative error code otherwise
+ */
+int bt_conn_auth_info_cb_unregister(struct bt_conn_auth_info_cb *cb);
 
 /** @brief Reply with entered passkey.
  *

--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -1297,38 +1297,6 @@ struct bt_conn_auth_cb {
 	 */
 	void (*pincode_entry)(struct bt_conn *conn, bool highsec);
 #endif
-
-	/** @brief notify that pairing procedure was complete.
-	 *
-	 *  This callback notifies the application that the pairing procedure
-	 *  has been completed.
-	 *
-	 *  @param conn Connection object.
-	 *  @param bonded Bond information has been distributed during the
-	 *                pairing procedure.
-	 */
-	__deprecated
-	void (*pairing_complete)(struct bt_conn *conn, bool bonded);
-
-	/** @brief notify that pairing process has failed.
-	 *
-	 *  @param conn Connection object.
-	 *  @param reason Pairing failed reason
-	 */
-	__deprecated
-	void (*pairing_failed)(struct bt_conn *conn,
-			       enum bt_security_err reason);
-
-	/** @brief Notify that bond has been deleted.
-	 *
-	 *  This callback notifies the application that the bond information
-	 *  for the remote peer has been deleted
-	 *
-	 *  @param id   Which local identity had the bond.
-	 *  @param peer Remote address.
-	 */
-	__deprecated
-	void (*bond_deleted)(uint8_t id, const bt_addr_le_t *peer);
 };
 
 /** Authenticated pairing information callback structure */

--- a/samples/bluetooth/peripheral_sc_only/src/main.c
+++ b/samples/bluetooth/peripheral_sc_only/src/main.c
@@ -118,6 +118,9 @@ static struct bt_conn_auth_cb auth_cb_display = {
 	.passkey_display = auth_passkey_display,
 	.passkey_entry = NULL,
 	.cancel = auth_cancel,
+};
+
+static struct bt_conn_auth_info_cb auth_cb_info = {
 	.pairing_complete = pairing_complete,
 	.pairing_failed = pairing_failed,
 };
@@ -136,6 +139,7 @@ void main(void)
 
 
 	bt_conn_auth_cb_register(&auth_cb_display);
+	bt_conn_auth_info_cb_register(&auth_cb_info);
 
 	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err) {

--- a/samples/boards/reel_board/mesh_badge/src/main.c
+++ b/samples/boards/reel_board/mesh_badge/src/main.c
@@ -113,6 +113,9 @@ static void pairing_failed(struct bt_conn *conn, enum bt_security_err reason)
 const struct bt_conn_auth_cb auth_cb = {
 	.passkey_display = passkey_display,
 	.cancel = passkey_cancel,
+};
+
+static struct bt_conn_auth_info_cb auth_info_cb = {
 	.pairing_complete = pairing_complete,
 	.pairing_failed = pairing_failed,
 };
@@ -165,6 +168,7 @@ static void bt_ready(int err)
 	printk("Mesh initialized\n");
 
 	bt_conn_auth_cb_register(&auth_cb);
+	bt_conn_auth_info_cb_register(&auth_info_cb);
 
 	if (IS_ENABLED(CONFIG_SETTINGS)) {
 		settings_load();

--- a/subsys/bluetooth/audio/csis.c
+++ b/subsys/bluetooth/audio/csis.c
@@ -729,7 +729,7 @@ static struct bt_conn_cb conn_callbacks = {
 	.security_changed = csis_security_changed,
 };
 
-static const struct bt_conn_auth_cb auth_callbacks = {
+static struct bt_conn_auth_info_cb auth_callbacks = {
 	.pairing_complete = auth_pairing_complete,
 	.bond_deleted = csis_bond_deleted
 };
@@ -885,7 +885,7 @@ int bt_csis_register(const struct bt_csis_register_param *param,
 	instance_cnt++;
 
 	bt_conn_cb_register(&conn_callbacks);
-	bt_conn_auth_cb_register(&auth_callbacks);
+	bt_conn_auth_info_cb_register(&auth_callbacks);
 
 	err = bt_gatt_service_register(inst->srv.service_p);
 	if (err != 0) {

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -12,6 +12,7 @@
 #include <stdbool.h>
 #include <sys/atomic.h>
 #include <sys/byteorder.h>
+#include <sys/check.h>
 #include <sys/util.h>
 #include <sys/slist.h>
 #include <debug/stack.h>
@@ -78,6 +79,7 @@ NET_BUF_POOL_FIXED_DEFINE(frag_pool, CONFIG_BT_L2CAP_TX_FRAG_COUNT,
 
 #if defined(CONFIG_BT_SMP) || defined(CONFIG_BT_BREDR)
 const struct bt_conn_auth_cb *bt_auth;
+sys_slist_t bt_auth_info_cbs = SYS_SLIST_STATIC_INIT(&bt_auth_info_cbs);
 #endif /* CONFIG_BT_SMP || CONFIG_BT_BREDR */
 
 static struct bt_conn_cb *callback_list;
@@ -2779,6 +2781,30 @@ int bt_conn_auth_cb_register(const struct bt_conn_auth_cb *cb)
 	}
 
 	bt_auth = cb;
+	return 0;
+}
+
+int bt_conn_auth_info_cb_register(struct bt_conn_auth_info_cb *cb)
+{
+	CHECKIF(cb == NULL) {
+		return -EINVAL;
+	}
+
+	sys_slist_append(&bt_auth_info_cbs, &cb->node);
+
+	return 0;
+}
+
+int bt_conn_auth_info_cb_unregister(struct bt_conn_auth_info_cb *cb)
+{
+	CHECKIF(cb == NULL) {
+		return -EINVAL;
+	}
+
+	if (!sys_slist_find_and_remove(&bt_auth_info_cbs, &cb->node)) {
+		return -EALREADY;
+	}
+
 	return 0;
 }
 

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1654,10 +1654,6 @@ static void unpair(uint8_t id, const bt_addr_le_t *addr)
 #if defined(CONFIG_BT_SMP) || defined(CONFIG_BT_BREDR)
 	struct bt_conn_auth_info_cb *listener, *next;
 
-	if (bt_auth && bt_auth->bond_deleted) {
-		bt_auth->bond_deleted(id, addr);
-	}
-
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&bt_auth_info_cbs, listener,
 					  next, node) {
 		if (listener->bond_deleted) {

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1652,8 +1652,17 @@ static void unpair(uint8_t id, const bt_addr_le_t *addr)
 	bt_gatt_clear(id, addr);
 
 #if defined(CONFIG_BT_SMP) || defined(CONFIG_BT_BREDR)
+	struct bt_conn_auth_info_cb *listener, *next;
+
 	if (bt_auth && bt_auth->bond_deleted) {
 		bt_auth->bond_deleted(id, addr);
+	}
+
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&bt_auth_info_cbs, listener,
+					  next, node) {
+		if (listener->bond_deleted) {
+			listener->bond_deleted(id, addr);
+		}
 	}
 #endif /* defined(CONFIG_BT_SMP) || defined(CONFIG_BT_BREDR) */
 }

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -373,7 +373,7 @@ struct bt_dev {
 extern struct bt_dev bt_dev;
 #if defined(CONFIG_BT_SMP) || defined(CONFIG_BT_BREDR)
 extern const struct bt_conn_auth_cb *bt_auth;
-
+extern sys_slist_t bt_auth_info_cbs;
 enum bt_security_err bt_security_err_get(uint8_t hci_err);
 #endif /* CONFIG_BT_SMP || CONFIG_BT_BREDR */
 

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -1002,11 +1002,6 @@ static void smp_pairing_br_complete(struct bt_smp_br *smp, uint8_t status)
 			bt_keys_clear(keys);
 		}
 
-		if (bt_auth && bt_auth->pairing_failed) {
-			bt_auth->pairing_failed(smp->chan.chan.conn,
-						security_err_get(status));
-		}
-
 		SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&bt_auth_info_cbs, listener,
 						  next, node) {
 			if (listener->pairing_failed) {
@@ -1020,11 +1015,6 @@ static void smp_pairing_br_complete(struct bt_smp_br *smp, uint8_t status)
 
 		if (bond_flag && keys) {
 			bt_keys_store(keys);
-		}
-
-		if (bt_auth && bt_auth->pairing_complete) {
-			bt_auth->pairing_complete(smp->chan.chan.conn,
-						  bond_flag);
 		}
 
 		SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&bt_auth_info_cbs, listener,
@@ -1895,10 +1885,6 @@ static void smp_pairing_complete(struct bt_smp *smp, uint8_t status)
 			bt_keys_store(conn->le.keys);
 		}
 
-		if (bt_auth && bt_auth->pairing_complete) {
-			bt_auth->pairing_complete(conn, bond_flag);
-		}
-
 		SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&bt_auth_info_cbs, listener,
 						  next, node) {
 			if (listener->pairing_complete) {
@@ -1930,10 +1916,6 @@ static void smp_pairing_complete(struct bt_smp *smp, uint8_t status)
 		 */
 		if (atomic_test_bit(smp->flags, SMP_FLAG_PAIRING)) {
 			struct bt_conn_auth_info_cb *listener, *next;
-
-			if (bt_auth && bt_auth->pairing_failed) {
-				bt_auth->pairing_failed(conn, security_err);
-			}
 
 			SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&bt_auth_info_cbs,
 							  listener, next,

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -996,6 +996,8 @@ static void smp_pairing_br_complete(struct bt_smp_br *smp, uint8_t status)
 	keys = bt_keys_find_addr(conn->id, &addr);
 
 	if (status) {
+		struct bt_conn_auth_info_cb *listener, *next;
+
 		if (keys) {
 			bt_keys_clear(keys);
 		}
@@ -1004,8 +1006,17 @@ static void smp_pairing_br_complete(struct bt_smp_br *smp, uint8_t status)
 			bt_auth->pairing_failed(smp->chan.chan.conn,
 						security_err_get(status));
 		}
+
+		SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&bt_auth_info_cbs, listener,
+						  next, node) {
+			if (listener->pairing_failed) {
+				listener->pairing_failed(smp->chan.chan.conn,
+							 security_err_get(status));
+			}
+		}
 	} else {
 		bool bond_flag = atomic_test_bit(smp->flags, SMP_FLAG_BOND);
+		struct bt_conn_auth_info_cb *listener, *next;
 
 		if (bond_flag && keys) {
 			bt_keys_store(keys);
@@ -1014,6 +1025,14 @@ static void smp_pairing_br_complete(struct bt_smp_br *smp, uint8_t status)
 		if (bt_auth && bt_auth->pairing_complete) {
 			bt_auth->pairing_complete(smp->chan.chan.conn,
 						  bond_flag);
+		}
+
+		SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&bt_auth_info_cbs, listener,
+						  next, node) {
+			if (listener->pairing_complete) {
+				listener->pairing_complete(smp->chan.chan.conn,
+							   bond_flag);
+			}
 		}
 	}
 
@@ -1866,6 +1885,7 @@ static void smp_pairing_complete(struct bt_smp *smp, uint8_t status)
 		}
 #endif /* CONFIG_BT_BREDR */
 		bool bond_flag = atomic_test_bit(smp->flags, SMP_FLAG_BOND);
+		struct bt_conn_auth_info_cb *listener, *next;
 
 		if (IS_ENABLED(CONFIG_BT_LOG_SNIFFER_INFO)) {
 			bt_keys_show_sniffer_info(conn->le.keys, NULL);
@@ -1877,6 +1897,13 @@ static void smp_pairing_complete(struct bt_smp *smp, uint8_t status)
 
 		if (bt_auth && bt_auth->pairing_complete) {
 			bt_auth->pairing_complete(conn, bond_flag);
+		}
+
+		SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&bt_auth_info_cbs, listener,
+						  next, node) {
+			if (listener->pairing_complete) {
+				listener->pairing_complete(conn, bond_flag);
+			}
 		}
 	} else {
 		enum bt_security_err security_err = security_err_get(status);
@@ -1901,9 +1928,20 @@ static void smp_pairing_complete(struct bt_smp *smp, uint8_t status)
 		/* Check SMP_FLAG_PAIRING as bt_conn_security_changed may
 		 * have called the pairing_failed callback already.
 		 */
-		if (atomic_test_bit(smp->flags, SMP_FLAG_PAIRING) &&
-		    bt_auth && bt_auth->pairing_failed) {
-			bt_auth->pairing_failed(conn, security_err);
+		if (atomic_test_bit(smp->flags, SMP_FLAG_PAIRING)) {
+			struct bt_conn_auth_info_cb *listener, *next;
+
+			if (bt_auth && bt_auth->pairing_failed) {
+				bt_auth->pairing_failed(conn, security_err);
+			}
+
+			SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&bt_auth_info_cbs,
+							  listener, next,
+							  node) {
+				if (listener->pairing_failed) {
+					listener->pairing_failed(conn, security_err);
+				}
+			}
 		}
 	}
 

--- a/subsys/bluetooth/host/ssp.c
+++ b/subsys/bluetooth/host/ssp.c
@@ -214,13 +214,30 @@ static void ssp_pairing_complete(struct bt_conn *conn, uint8_t status)
 {
 	if (!status) {
 		bool bond = !atomic_test_bit(conn->flags, BT_CONN_BR_NOBOND);
+		struct bt_conn_auth_info_cb *listener, *next;
 
 		if (bt_auth && bt_auth->pairing_complete) {
 			bt_auth->pairing_complete(conn, bond);
 		}
+
+		SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&bt_auth_info_cbs, listener,
+						  next, node) {
+			if (listener->pairing_complete) {
+				listener->pairing_complete(conn, bond);
+			}
+		}
 	} else {
+		struct bt_conn_auth_info_cb *listener, *next;
+
 		if (bt_auth && bt_auth->pairing_failed) {
 			bt_auth->pairing_failed(conn, status);
+		}
+
+		SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&bt_auth_info_cbs, listener,
+						  next, node) {
+			if (listener->pairing_complete) {
+				listener->pairing_complete(conn, status);
+			}
 		}
 	}
 }

--- a/subsys/bluetooth/host/ssp.c
+++ b/subsys/bluetooth/host/ssp.c
@@ -216,10 +216,6 @@ static void ssp_pairing_complete(struct bt_conn *conn, uint8_t status)
 		bool bond = !atomic_test_bit(conn->flags, BT_CONN_BR_NOBOND);
 		struct bt_conn_auth_info_cb *listener, *next;
 
-		if (bt_auth && bt_auth->pairing_complete) {
-			bt_auth->pairing_complete(conn, bond);
-		}
-
 		SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&bt_auth_info_cbs, listener,
 						  next, node) {
 			if (listener->pairing_complete) {
@@ -228,10 +224,6 @@ static void ssp_pairing_complete(struct bt_conn *conn, uint8_t status)
 		}
 	} else {
 		struct bt_conn_auth_info_cb *listener, *next;
-
-		if (bt_auth && bt_auth->pairing_failed) {
-			bt_auth->pairing_failed(conn, status);
-		}
 
 		SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&bt_auth_info_cbs, listener,
 						  next, node) {

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -55,6 +55,10 @@ static struct bt_le_oob oob_remote;
 #endif /* CONFIG_BT_SMP || CONFIG_BT_BREDR) */
 #endif /* CONFIG_BT_CONN */
 
+#if defined(CONFIG_BT_SMP)
+static struct bt_conn_auth_info_cb auth_info_cb;
+#endif /* CONFIG_BT_SMP */
+
 #define NAME_LEN 30
 
 #define KEY_STR_LEN 33
@@ -628,6 +632,10 @@ static void bt_ready(int err)
 #if defined(CONFIG_BT_PER_ADV_SYNC)
 	bt_le_per_adv_sync_cb_register(&per_adv_sync_cb);
 #endif /* CONFIG_BT_PER_ADV_SYNC */
+
+#if defined(CONFIG_BT_SMP)
+	bt_conn_auth_info_cb_register(&auth_info_cb);
+#endif /* CONFIG_BT_SMP */
 }
 
 static int cmd_init(const struct shell *sh, size_t argc, char *argv[])
@@ -2869,12 +2877,9 @@ static struct bt_conn_auth_cb auth_cb_display = {
 	.oob_data_request = NULL,
 	.cancel = auth_cancel,
 	.pairing_confirm = auth_pairing_confirm,
-	.pairing_failed = auth_pairing_failed,
-	.pairing_complete = auth_pairing_complete,
 #if defined(CONFIG_BT_SMP_APP_PAIRING_ACCEPT)
 	.pairing_accept = pairing_accept,
 #endif
-	.bond_deleted = bond_deleted,
 };
 
 static struct bt_conn_auth_cb auth_cb_display_yes_no = {
@@ -2887,12 +2892,9 @@ static struct bt_conn_auth_cb auth_cb_display_yes_no = {
 	.oob_data_request = NULL,
 	.cancel = auth_cancel,
 	.pairing_confirm = auth_pairing_confirm,
-	.pairing_failed = auth_pairing_failed,
-	.pairing_complete = auth_pairing_complete,
 #if defined(CONFIG_BT_SMP_APP_PAIRING_ACCEPT)
 	.pairing_accept = pairing_accept,
 #endif
-	.bond_deleted = bond_deleted,
 };
 
 static struct bt_conn_auth_cb auth_cb_input = {
@@ -2905,12 +2907,9 @@ static struct bt_conn_auth_cb auth_cb_input = {
 	.oob_data_request = NULL,
 	.cancel = auth_cancel,
 	.pairing_confirm = auth_pairing_confirm,
-	.pairing_failed = auth_pairing_failed,
-	.pairing_complete = auth_pairing_complete,
 #if defined(CONFIG_BT_SMP_APP_PAIRING_ACCEPT)
 	.pairing_accept = pairing_accept,
 #endif
-	.bond_deleted = bond_deleted,
 };
 
 static struct bt_conn_auth_cb auth_cb_confirm = {
@@ -2920,12 +2919,9 @@ static struct bt_conn_auth_cb auth_cb_confirm = {
 	.oob_data_request = NULL,
 	.cancel = auth_cancel,
 	.pairing_confirm = auth_pairing_confirm,
-	.pairing_failed = auth_pairing_failed,
-	.pairing_complete = auth_pairing_complete,
 #if defined(CONFIG_BT_SMP_APP_PAIRING_ACCEPT)
 	.pairing_accept = pairing_accept,
 #endif
-	.bond_deleted = bond_deleted,
 };
 
 static struct bt_conn_auth_cb auth_cb_all = {
@@ -2938,12 +2934,9 @@ static struct bt_conn_auth_cb auth_cb_all = {
 	.oob_data_request = auth_pairing_oob_data_request,
 	.cancel = auth_cancel,
 	.pairing_confirm = auth_pairing_confirm,
-	.pairing_failed = auth_pairing_failed,
-	.pairing_complete = auth_pairing_complete,
 #if defined(CONFIG_BT_SMP_APP_PAIRING_ACCEPT)
 	.pairing_accept = pairing_accept,
 #endif
-	.bond_deleted = bond_deleted,
 };
 
 static struct bt_conn_auth_cb auth_cb_oob = {
@@ -2956,20 +2949,21 @@ static struct bt_conn_auth_cb auth_cb_oob = {
 	.oob_data_request = auth_pairing_oob_data_request,
 	.cancel = auth_cancel,
 	.pairing_confirm = NULL,
-	.pairing_failed = auth_pairing_failed,
-	.pairing_complete = auth_pairing_complete,
 #if defined(CONFIG_BT_SMP_APP_PAIRING_ACCEPT)
 	.pairing_accept = pairing_accept,
 #endif
-	.bond_deleted = bond_deleted,
 };
 
 static struct bt_conn_auth_cb auth_cb_status = {
-	.pairing_failed = auth_pairing_failed,
-	.pairing_complete = auth_pairing_complete,
 #if defined(CONFIG_BT_SMP_APP_PAIRING_ACCEPT)
 	.pairing_accept = pairing_accept,
 #endif
+};
+
+static struct bt_conn_auth_info_cb auth_info_cb = {
+	.pairing_failed = auth_pairing_failed,
+	.pairing_complete = auth_pairing_complete,
+	.bond_deleted = bond_deleted,
 };
 
 static int cmd_auth(const struct shell *sh, size_t argc, char *argv[])

--- a/tests/bluetooth/bsim_bt/bsim_test_app/src/test_connect1.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_app/src/test_connect1.c
@@ -201,7 +201,7 @@ static void update_conn(struct bt_conn *conn, bool bonded)
 	}
 }
 
-static struct bt_conn_auth_cb auth_cb_success = {
+static struct bt_conn_auth_info_cb auth_cb_success = {
 	.pairing_complete = update_conn,
 };
 
@@ -225,7 +225,7 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 
 	if (encrypt_link) {
 		k_sleep(K_MSEC(500));
-		bt_conn_auth_cb_register(&auth_cb_success);
+		bt_conn_auth_info_cb_register(&auth_cb_success);
 		err = bt_conn_set_security(conn, BT_SECURITY_L2);
 		if (err) {
 			FAIL("bt_conn_set_security failed (err %d)\n", err);

--- a/tests/bluetooth/tester/src/gap.c
+++ b/tests/bluetooth/tester/src/gap.c
@@ -957,6 +957,11 @@ static void auth_pairing_complete(struct bt_conn *conn, bool bonded)
 #endif
 }
 
+static struct bt_conn_auth_info_cb auth_info_cb = {
+	.pairing_failed = auth_pairing_failed,
+	.pairing_complete = auth_pairing_complete,
+};
+
 static void set_io_cap(const uint8_t *data, uint16_t len)
 {
 	const struct gap_set_io_cap_cmd *cmd = (void *) data;
@@ -998,8 +1003,6 @@ static void set_io_cap(const uint8_t *data, uint16_t len)
 	}
 
 	cb.pairing_accept = auth_pairing_accept;
-	cb.pairing_failed = auth_pairing_failed;
-	cb.pairing_complete = auth_pairing_complete;
 
 	if (bt_conn_auth_cb_register(&cb)) {
 		status = BTP_STATUS_FAILED;
@@ -1362,6 +1365,7 @@ uint8_t tester_init_gap(void)
 	if (bt_conn_auth_cb_register(&cb)) {
 		return BTP_STATUS_FAILED;
 	}
+	bt_conn_auth_info_cb_register(&auth_info_cb);
 
 	err = bt_enable(tester_init_gap_cb);
 	if (err < 0) {


### PR DESCRIPTION
Add a new callback structure for Bluetooth authentication

This struct is meant to replace the information-only
callbacks in bt_conn_auth_cb. The reason for this is that
due to the nature of bt_conn_auth_cb, it can only be registered
once. To allow mulitple users gain information about pairing
and bond deletions, this new struct is needed.

Samples, tests, etc. are updated to use the new struct.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

fixes https://github.com/zephyrproject-rtos/zephyr/issues/42928

RFC: https://github.com/zephyrproject-rtos/zephyr/issues/43543