### PR TITLE
tests: Bluetooth: Mesh: Add some improvements to mesh BabbleSim tests

### DIFF
--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/mesh_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/mesh_test.c
@@ -339,10 +339,22 @@ int bt_mesh_test_recv_clear(void)
 	return count;
 }
 
+struct sync_send_ctx {
+	struct k_sem sem;
+	int err;
+};
+
 static void tx_started(uint16_t dur, int err, void *data)
 {
+	struct sync_send_ctx *send_ctx = data;
+
 	if (err) {
-		FAIL("Couldn't start sending (err: %d)", err);
+		LOG_ERR("Couldn't start sending (err: %d)", err);
+
+		send_ctx->err = err;
+		k_sem_give(&send_ctx->sem);
+
+		return;
 	}
 
 	LOG_INF("Sending started");
@@ -350,15 +362,17 @@ static void tx_started(uint16_t dur, int err, void *data)
 
 static void tx_ended(int err, void *data)
 {
-	struct k_sem *sem = data;
+	struct sync_send_ctx *send_ctx = data;
+
+	send_ctx->err = err;
 
 	if (err) {
-		FAIL("Send failed (%d)", err);
+		LOG_ERR("Send failed (%d)", err);
+	} else {
+		LOG_INF("Sending ended");
 	}
 
-	LOG_INF("Sending ended");
-
-	k_sem_give(sem);
+	k_sem_give(&send_ctx->sem);
 }
 
 int bt_mesh_test_send_async(uint16_t addr, size_t len,
@@ -424,19 +438,23 @@ int bt_mesh_test_send(uint16_t addr, size_t len,
 		.end = tx_ended,
 	};
 	int64_t uptime = k_uptime_get();
-	struct k_sem sem;
+	struct sync_send_ctx send_ctx;
 	int err;
 
-	k_sem_init(&sem, 0, 1);
-	err = bt_mesh_test_send_async(addr, len, flags, &send_cb, &sem);
+	k_sem_init(&send_ctx.sem, 0, 1);
+	err = bt_mesh_test_send_async(addr, len, flags, &send_cb, &send_ctx);
 	if (err) {
 		return err;
 	}
 
-	err = k_sem_take(&sem, timeout);
+	err = k_sem_take(&send_ctx.sem, timeout);
 	if (err) {
 		LOG_ERR("Send timed out");
 		return err;
+	}
+
+	if (send_ctx.err) {
+		return send_ctx.err;
 	}
 
 	LOG_INF("Sending completed (%lld ms)", k_uptime_delta(&uptime));

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/mesh_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/mesh_test.c
@@ -297,14 +297,12 @@ int bt_mesh_test_recv(uint16_t len, uint16_t dst, k_timeout_t timeout)
 	}
 
 	if (len != msg->len) {
-		FAIL("Recv: Invalid message length (%u, expected %u)", msg->len,
-		     len);
+		LOG_ERR("Recv: Invalid message length (%u, expected %u)", msg->len, len);
 		return -EINVAL;
 	}
 
 	if (dst != BT_MESH_ADDR_UNASSIGNED && dst != msg->ctx.recv_dst) {
-		FAIL("Recv: Invalid dst 0x%04x, expected 0x%04x",
-		     msg->ctx.recv_dst, dst);
+		LOG_ERR("Recv: Invalid dst 0x%04x, expected 0x%04x", msg->ctx.recv_dst, dst);
 		return -EINVAL;
 	}
 

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_persistence.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_persistence.c
@@ -20,6 +20,8 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #define WAIT_TIME 60 /*seconds*/
 
+static bool provisioner_ready;
+
 extern const struct bt_mesh_comp comp;
 
 struct test_va_t {
@@ -265,6 +267,12 @@ static void unprovisioned_beacon(uint8_t uuid[16], bt_mesh_prov_oob_info_t oob_i
 {
 	static bool once;
 
+	/* Subnet may not be ready yet when provisioner receives a beacon. */
+	if (!provisioner_ready) {
+		LOG_INF("Provisioner is not ready yet");
+		return;
+	}
+
 	if (once) {
 		return;
 	}
@@ -404,6 +412,8 @@ static void provisioner_setup(void)
 	if (err || status) {
 		FAIL("Failed to add test_netkey (err: %d, status: %d)", err, status);
 	}
+
+	provisioner_ready = true;
 }
 
 static void test_provisioning_data_save(void)


### PR DESCRIPTION
This PR adds the following improvements:
- If segmented message transmission fails, the error code is passed back to caller. This helps in debugging test failure;
- If message reception fails, the error code is passed back to caller. This helps in debugging test failure;
- In provisioning tests prevents the provisioner from provisioning a device before the provisioner is configured.