### PR TITLE
soc: xilinx_zynq7000: fix VBAR, SCTLR contents when coming from u-boot

### DIFF
--- a/soc/arm/xilinx_zynq7000/Kconfig.defconfig
+++ b/soc/arm/xilinx_zynq7000/Kconfig.defconfig
@@ -21,4 +21,7 @@ config FLASH_SIZE
 config FLASH_BASE_ADDRESS
 	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
 
+config PLATFORM_SPECIFIC_INIT
+	default y
+
 endif # SOC_FAMILY_XILINX_ZYNQ7000

--- a/soc/arm/xilinx_zynq7000/xc7zxxx/soc.c
+++ b/soc/arm/xilinx_zynq7000/xc7zxxx/soc.c
@@ -91,3 +91,41 @@ static int soc_xlnx_zynq7000_init(const struct device *arg)
 
 SYS_INIT(soc_xlnx_zynq7000_init, PRE_KERNEL_1,
 	CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+
+/* Platform-specific early initialization */
+
+void z_arm_platform_init(void)
+{
+	/*
+	 * When coming out of u-boot rather than downloading the Zephyr binary
+	 * via JTAG, a few things modified by u-boot have to be re-set to a
+	 * suitable default value for Zephyr to run, namely:
+	 *
+	 * - u-boot places the exception vectors somewhere in RAM and then
+	 *   lets the VBAR register point to them. Zephyr uses the default
+	 *   vector table location at address zero (and maybe at some later
+	 *   time alternatively the HIVECS position). If VBAR isn't reset
+	 *   to zero, the system crashes during the first context switch when
+	 *   SVC is invoked.
+	 * - u-boot sets the following bits in the SCTLR register:
+	 *   - [I] ICache enable
+	 *   - [C] DCache enable
+	 *   - [Z] Branch prediction enable
+	 *   - [A] Enforce strict alignment enable
+	 *   [I] and [C] will be enabled during the MMU init -> disable them
+	 *   until then. [Z] is probably not harmful. [A] will cause a crash
+	 *   as early as z_mem_manage_init when an unaligned access is performed
+	 *   -> clear [A].
+	 */
+
+	uint32_t vbar = 0;
+
+	__set_VBAR(vbar);
+
+	uint32_t sctlr = __get_SCTLR();
+
+	sctlr &= ~SCTLR_I_Msk;
+	sctlr &= ~SCTLR_C_Msk;
+	sctlr &= ~SCTLR_A_Msk;
+	__set_SCTLR(sctlr);
+}

--- a/soc/arm/xilinx_zynq7000/xc7zxxxs/soc.c
+++ b/soc/arm/xilinx_zynq7000/xc7zxxxs/soc.c
@@ -91,3 +91,41 @@ static int soc_xlnx_zynq7000s_init(const struct device *arg)
 
 SYS_INIT(soc_xlnx_zynq7000s_init, PRE_KERNEL_1,
 	CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+
+/* Platform-specific early initialization */
+
+void z_arm_platform_init(void)
+{
+	/*
+	 * When coming out of u-boot rather than downloading the Zephyr binary
+	 * via JTAG, a few things modified by u-boot have to be re-set to a
+	 * suitable default value for Zephyr to run, namely:
+	 *
+	 * - u-boot places the exception vectors somewhere in RAM and then
+	 *   lets the VBAR register point to them. Zephyr uses the default
+	 *   vector table location at address zero (and maybe at some later
+	 *   time alternatively the HIVECS position). If VBAR isn't reset
+	 *   to zero, the system crashes during the first context switch when
+	 *   SVC is invoked.
+	 * - u-boot sets the following bits in the SCTLR register:
+	 *   - [I] ICache enable
+	 *   - [C] DCache enable
+	 *   - [Z] Branch prediction enable
+	 *   - [A] Enforce strict alignment enable
+	 *   [I] and [C] will be enabled during the MMU init -> disable them
+	 *   until then. [Z] is probably not harmful. [A] will cause a crash
+	 *   as early as z_mem_manage_init when an unaligned access is performed
+	 *   -> clear [A].
+	 */
+
+	uint32_t vbar = 0;
+
+	__set_VBAR(vbar);
+
+	uint32_t sctlr = __get_SCTLR();
+
+	sctlr &= ~SCTLR_I_Msk;
+	sctlr &= ~SCTLR_C_Msk;
+	sctlr &= ~SCTLR_A_Msk;
+	__set_SCTLR(sctlr);
+}


### PR DESCRIPTION
If a Zephyr binary is booted on the Zynq-7000 not via JTAG download,
but via u-boot's ELF boot function instead, Zephyr will have to revert
certain changes made by u-boot in order to boot properly:

- clear the ICache/DCache enable, branch prediction enable and
  strict alignment enforcement enable bits in the SCTLR register.
  By default, u-boot will also set up the MMU prior to Zephyr
  doing so as well, this can be avoided by changing the u-boot
  build configuration. Therefore, the MMU enable bit is not changed
  at this point.

- set the VBAR register to 0. U-boot moves the interrupt vector
  table to a non-standard location using the VBAR register (no
  change is made by u-boot for SCTLR.V, only VBAR is changed
  to a non-zero memory location).

Without these changes, Zephyr will crash upon the first context
switch at latest, when SVC is invoked and u-boot's vector table
is used rather than the vectors copied to address zero by Zephyr.

In order to perform these changes before coming anywhere near the
MMU / device driver / kernel initialization stages or even the
first context switch, the z_arm_platform_init hook is used, which
is now enabled for the Zynq via the Kconfig.defconfig file.

Signed-off-by: Immo Birnbaum <Immo.Birnbaum@weidmueller.com>