### PR TITLE
kconfig: fix dt_node_has_prop

### DIFF
--- a/doc/guides/build/kconfig/preprocessor-functions.rst
+++ b/doc/guides/build/kconfig/preprocessor-functions.rst
@@ -38,8 +38,10 @@ while the ``*_hex`` version returns a hexadecimal value starting with ``0x``.
    $(dt_node_reg_size_hex,<node path>[,<index>,<unit>])
    $(dt_compat_enabled,<compatible string>)
    $(dt_chosen_enabled,<property in /chosen>)
-   $(dt_node_has_bool_prop,<node path>,<prop>)
+   $(dt_node_bool_prop,<node path>,<prop>)
+   $(dt_nodelabel_bool_prop,<node label>,<prop>)
    $(dt_node_has_prop,<node path>,<prop>)
+   $(dt_nodelabel_has_prop,<node label>,<prop>)
 
 
 Example Usage

--- a/doc/guides/build/kconfig/preprocessor-functions.rst
+++ b/doc/guides/build/kconfig/preprocessor-functions.rst
@@ -28,6 +28,14 @@ while the ``*_hex`` version returns a hexadecimal value starting with ``0x``.
 
 .. code-block:: none
 
+   $(dt_compat_enabled,<compatible string>)
+   $(dt_compat_on_bus,<compatible string>,<bus>)
+   $(dt_chosen_label,<property in /chosen>)
+   $(dt_chosen_enabled,<property in /chosen>)
+   $(dt_chosen_path,<property in /chosen>)
+   $(dt_path_enabled,<node path>)
+   $(dt_alias_enabled,<node alias>)
+   $(dt_nodelabel_enabled,<node label>)
    $(dt_chosen_reg_addr_int,<property in /chosen>[,<index>,<unit>])
    $(dt_chosen_reg_addr_hex,<property in /chosen>[,<index>,<unit>])
    $(dt_chosen_reg_size_int,<property in /chosen>[,<index>,<unit>])
@@ -42,6 +50,12 @@ while the ``*_hex`` version returns a hexadecimal value starting with ``0x``.
    $(dt_nodelabel_bool_prop,<node label>,<prop>)
    $(dt_node_has_prop,<node path>,<prop>)
    $(dt_nodelabel_has_prop,<node label>,<prop>)
+   $(dt_node_int_prop_int,<node path>,<prop>[,<unit>])
+   $(dt_node_int_prop_hex,<node path>,<prop>[,<unit>])
+   $(dt_node_str_prop_equals,<node path>,<prop>,<value>)
+   $(dt_nodelabel_has_compat,<node label>,<compatible string>)
+   $(dt_nodelabel_path,<node label>)
+   $(shields_list_contains,<shield name>)
 
 
 Example Usage

--- a/drivers/counter/Kconfig.nrfx
+++ b/drivers/counter/Kconfig.nrfx
@@ -97,14 +97,14 @@ config COUNTER_RTC2_ZLI
 
 # Internal flag which detects if PPI wrap feature is enabled for any instance
 config COUNTER_RTC_WITH_PPI_WRAP
-	def_bool ($(dt_node_has_bool_prop,rtc-0,ppi-wrap) && COUNTER_RTC0) || \
-		 ($(dt_node_has_bool_prop,rtc-1,ppi-wrap) && COUNTER_RTC1) || \
-		 ($(dt_node_has_bool_prop,rtc-2,ppi-wrap) && COUNTER_RTC2)
+	def_bool ($(dt_node_bool_prop,rtc-0,ppi-wrap) && COUNTER_RTC0) || \
+		 ($(dt_node_bool_prop,rtc-1,ppi-wrap) && COUNTER_RTC1) || \
+		 ($(dt_node_bool_prop,rtc-2,ppi-wrap) && COUNTER_RTC2)
 	select NRFX_PPI if HAS_HW_NRF_PPI
 	select NRFX_DPPI if HAS_HW_NRF_DPPIC
 
 # Internal flag which detects if fixed top feature is enabled for any instance
 config COUNTER_RTC_CUSTOM_TOP_SUPPORT
-	def_bool (!$(dt_node_has_bool_prop,rtc-0,fixed-top) && COUNTER_RTC0) || \
-		 (!$(dt_node_has_bool_prop,rtc-1,fixed-top) && COUNTER_RTC1) || \
-		 (!$(dt_node_has_bool_prop,rtc-2,fixed-top) && COUNTER_RTC2)
+	def_bool (!$(dt_node_bool_prop,rtc-0,fixed-top) && COUNTER_RTC0) || \
+		 (!$(dt_node_bool_prop,rtc-1,fixed-top) && COUNTER_RTC1) || \
+		 (!$(dt_node_bool_prop,rtc-2,fixed-top) && COUNTER_RTC2)

--- a/drivers/flash/Kconfig.stm32_qspi
+++ b/drivers/flash/Kconfig.stm32_qspi
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 DT_COMPAT_ST_STM32_QSPI_NOR := st,stm32-qspi-nor
-DT_STM32_QUADSPI_HAS_DMA := $(dt_node_has_prop,quadspi,dmas)
+DT_STM32_QUADSPI_HAS_DMA := $(dt_nodelabel_has_prop,quadspi,dmas)
 
 config FLASH_STM32_QSPI
 	bool "STM32 Quad SPI Flash driver"

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -310,19 +310,15 @@ def dt_node_reg(kconf, name, path, index=0, unit=None):
     if name == "dt_node_reg_addr_hex":
         return hex(_dt_node_reg_addr(kconf, path, index, unit))
 
-
-def dt_node_has_bool_prop(kconf, _, path, prop):
+def _dt_node_bool_prop_generic(node_search_function, search_arg, prop):
     """
-    This function takes a 'path' and looks for an EDT node at that path. If it
-    finds an EDT node, it will look to see if that node has a boolean property
-    by the name of 'prop'.  If the 'prop' exists it will return "y" otherwise
-    we return "n".
+    This function takes the 'node_search_function' and uses it to search for
+    a node with 'search_arg' and if node exists, checks if 'prop' exists
+    inside the node and is a boolean, if it is true, returns "y".
+    Otherwise, it returns "n".
     """
-    if doc_mode or edt is None:
-        return "n"
-
     try:
-        node = edt.get_node(path)
+        node = node_search_function(search_arg)
     except edtlib.EDTError:
         return "n"
 
@@ -337,19 +333,38 @@ def dt_node_has_bool_prop(kconf, _, path, prop):
 
     return "n"
 
-def dt_node_has_prop(kconf, _, label, prop):
+def dt_node_bool_prop(kconf, _, path, prop):
     """
-    This function takes a 'label' and looks for an EDT node for that label. If
-    it finds an EDT node, it will look to see if that node has a property
+    This function takes a 'path' and looks for an EDT node at that path. If it
+    finds an EDT node, it will look to see if that node has a boolean property
     by the name of 'prop'.  If the 'prop' exists it will return "y" otherwise
     we return "n".
     """
-
     if doc_mode or edt is None:
         return "n"
 
+    return _dt_node_bool_prop_generic(edt.get_node, path, prop)
+
+def dt_nodelabel_bool_prop(kconf, _, label, prop):
+    """
+    This function takes a 'label' and looks for an EDT node with that label.
+    If it finds an EDT node, it will look to see if that node has a boolean
+    property by the name of 'prop'.  If the 'prop' exists it will return "y"
+    otherwise we return "n".
+    """
+    if doc_mode or edt is None:
+        return "n"
+
+    return _dt_node_bool_prop_generic(edt.label2node.get, label, prop)
+
+def _dt_node_has_prop_generic(node_search_function, search_arg, prop):
+    """
+    This function takes the 'node_search_function' and uses it to search for
+    a node with 'search_arg' and if node exists, then checks if 'prop'
+    exists inside the node and returns "y". Otherwise, it returns "n".
+    """
     try:
-        node = edt.label2node.get(label)
+        node = node_search_function(search_arg)
     except edtlib.EDTError:
         return "n"
 
@@ -360,6 +375,30 @@ def dt_node_has_prop(kconf, _, label, prop):
         return "y"
 
     return "n"
+
+def dt_node_has_prop(kconf, _, path, prop):
+    """
+    This function takes a 'path' and looks for an EDT node at that path. If it
+    finds an EDT node, it will look to see if that node has a property
+    by the name of 'prop'.  If the 'prop' exists it will return "y" otherwise
+    it returns "n".
+    """
+    if doc_mode or edt is None:
+        return "n"
+
+    return _dt_node_has_prop_generic(edt.get_node, path, prop)
+
+def dt_nodelabel_has_prop(kconf, _, label, prop):
+    """
+    This function takes a 'label' and looks for an EDT node with that label.
+    If it finds an EDT node, it will look to see if that node has a property
+    by the name of 'prop'.  If the 'prop' exists it will return "y" otherwise
+    it returns "n".
+    """
+    if doc_mode or edt is None:
+        return "n"
+
+    return _dt_node_has_prop_generic(edt.label2node.get, label, prop)
 
 def dt_node_int_prop(kconf, name, path, prop, unit=None):
     """
@@ -513,8 +552,10 @@ functions = {
         "dt_node_reg_addr_hex": (dt_node_reg, 1, 3),
         "dt_node_reg_size_int": (dt_node_reg, 1, 3),
         "dt_node_reg_size_hex": (dt_node_reg, 1, 3),
-        "dt_node_has_bool_prop": (dt_node_has_bool_prop, 2, 2),
+        "dt_node_bool_prop": (dt_node_bool_prop, 2, 2),
+        "dt_nodelabel_bool_prop": (dt_nodelabel_bool_prop, 2, 2),
         "dt_node_has_prop": (dt_node_has_prop, 2, 2),
+        "dt_nodelabel_has_prop": (dt_nodelabel_has_prop, 2, 2),
         "dt_node_int_prop_int": (dt_node_int_prop, 2, 3),
         "dt_node_int_prop_hex": (dt_node_int_prop, 2, 3),
         "dt_node_str_prop_equals": (dt_node_str_prop_equals, 3, 3),

--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -6,7 +6,7 @@
 if BT_LL_SW_SPLIT
 
 DT_PATH_NORDIC_RADIO := $(dt_nodelabel_path,radio)
-DT_NORDIC_RADIO_DFE_SUPPORTED := $(dt_node_has_bool_prop,$(DT_PATH_NORDIC_RADIO),dfe-supported)
+DT_NORDIC_RADIO_DFE_SUPPORTED := $(dt_node_bool_prop,$(DT_PATH_NORDIC_RADIO),dfe-supported)
 
 config BT_LLL_VENDOR_NORDIC
 	bool "Use Nordic LLL"


### PR DESCRIPTION
The Kconfig function "dt_node_has_prop" was using label as its
parameter, where other functions use either chosen or path.
The documentation says that the parameter is path, so this patch
makes the function as documentation says and as other functions
in the file.

Signed-off-by: Michał Barnaś <mb@semihalf.com>