### PR TITLE
samples: spi: bitbang: Fix missing pass conditions

### DIFF
--- a/samples/drivers/spi_bitbang/sample.yaml
+++ b/samples/drivers/spi_bitbang/sample.yaml
@@ -5,3 +5,18 @@ tests:
     tags: drivers spi gpio
     platform_allow: nrf52840dk_nrf52840
     depends_on: gpio
+    harness: console
+    harness_config:
+      fixture: gpio_loopback
+      type: multi_line
+      ordered: true
+      regex:
+        - "basic_write_9bit_words; ret: 0"
+        - "wrote 0101 00ff 00a5 0000 0102"
+        - "9bit_loopback_partial; ret: 0"
+        - "tx [(]i[)]  : 0101 0102"
+        - "tx [(]ii[)] : 0003 0004 0105"
+        - "rx [(]ii[)] : 0003 0004 0105"
+        - "8bit_loopback_partial; ret: 0"
+        - "tx [(]i[)]  : 01 02 03 04 05"
+        - "rx [(]i[)]  : 01 02 03 04 05"


### PR DESCRIPTION
The sample did not have defined pass condition and was failing
due to a timeout. Add harness: consol and an explicit regex matching
the sample's output so it can pass on a hw. In addition, a requirement
for a gpio_loopback fixture was added to the sample.yaml.

fixes: https://github.com/zephyrproject-rtos/zephyr/issues/45229

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>