### PR TITLE
espi: mec172x: updates based on chromium os tests

### DIFF
--- a/drivers/espi/Kconfig.xec_v2
+++ b/drivers/espi/Kconfig.xec_v2
@@ -154,3 +154,17 @@ config ESPI_PERIPHERAL_ACPI_EC_IBF_EVT_DATA
 	  to callback.
 
 endif #ESPI_XEC_V2
+
+if ESPI_PERIPHERAL_8042_KBC
+
+config ESPI_PERIPHERAL_KBC_IBF_EVT_DATA
+	bool "KBC event data format in IBF"
+	help
+	  Enable espi_evt_data_kbc format for encoding event in KBC IBF ISR
+
+config ESPI_PERIPHERAL_KBC_OBE_CBK
+	bool "KBC OBE Callback"
+	help
+	  Enable KBC OBE callback from OBE ISR
+
+endif #ESPI_PERIPHERAL_8042_KBC

--- a/drivers/espi/Kconfig.xec_v2
+++ b/drivers/espi/Kconfig.xec_v2
@@ -145,4 +145,12 @@ config ESPI_SAF_INIT_PRIORITY
 	help
 	  Driver initialization priority for eSPI SAF driver.
 
+config ESPI_PERIPHERAL_ACPI_EC_IBF_EVT_DATA
+	bool "Read ACPI EC Event Data in IBF ISR"
+	depends on ESPI_PERIPHERAL_CHANNEL
+	help
+	  Enable reading event data in ACPI EC IBF ISR. This is used in OS
+	  environment where application expects IBF ISR to read data and pass
+	  to callback.
+
 endif #ESPI_XEC_V2

--- a/drivers/espi/espi_mchp_xec_host_v2.c
+++ b/drivers/espi/espi_mchp_xec_host_v2.c
@@ -94,6 +94,16 @@ struct xec_acpi_ec_config {
 	uint32_t obe_ecia_info;
 };
 
+#ifdef CONFIG_ESPI_PERIPHERAL_EC_HOST_CMD
+
+#ifdef CONFIG_ESPI_PERIPHERAL_ACPI_SHM_REGION
+static uint8_t ec_host_cmd_sram[CONFIG_ESPI_XEC_PERIPHERAL_HOST_CMD_PARAM_SIZE +
+			CONFIG_ESPI_XEC_PERIPHERAL_ACPI_SHD_MEM_SIZE] __aligned(8);
+#else
+static uint8_t ec_host_cmd_sram[CONFIG_ESPI_XEC_PERIPHERAL_HOST_CMD_PARAM_SIZE] __aligned(8);
+#endif
+
+#endif /* CONFIG_ESPI_PERIPHERAL_EC_HOST_CMD */
 
 #ifdef CONFIG_ESPI_PERIPHERAL_XEC_MAILBOX
 
@@ -548,13 +558,6 @@ struct xec_emi_config {
 static const struct xec_emi_config xec_emi0_cfg = {
 	.regbase = DT_REG_ADDR(DT_NODELABEL(emi0)),
 };
-
-#ifdef CONFIG_ESPI_PERIPHERAL_ACPI_SHM_REGION
-static uint8_t ec_host_cmd_sram[CONFIG_ESPI_XEC_PERIPHERAL_HOST_CMD_PARAM_SIZE +
-						CONFIG_ESPI_XEC_PERIPHERAL_ACPI_SHD_MEM_SIZE];
-#else
-static uint8_t ec_host_cmd_sram[CONFIG_ESPI_XEC_PERIPHERAL_HOST_CMD_PARAM_SIZE];
-#endif
 
 static int init_emi0(const struct device *dev)
 {

--- a/drivers/espi/espi_mchp_xec_host_v2.c
+++ b/drivers/espi/espi_mchp_xec_host_v2.c
@@ -196,9 +196,9 @@ static void kbc0_ibf_isr(const struct device *dev)
 	 * and the lower byte speficies if the host sent
 	 * a command or data. 1 = Command.
 	 */
-	uint32_t isr_data = ((kbc_hw->EC_DATA & 0xFF) << E8042_ISR_DATA_POS) |
-				((kbc_hw->EC_KBC_STS & MCHP_KBC_STS_CD) <<
-				 E8042_ISR_CMD_DATA_POS);
+	uint32_t isr_data = ((kbc_hw->EC_KBC_STS & MCHP_KBC_STS_CD) <<
+				E8042_ISR_CMD_DATA_POS);
+	isr_data |= ((kbc_hw->EC_DATA & 0xFF) << E8042_ISR_DATA_POS);
 
 	struct espi_event evt = {
 		.evt_type = ESPI_BUS_PERIPHERAL_NOTIFICATION,

--- a/soc/arm/microchip_mec/mec172x/reg/mec172x_emi.h
+++ b/soc/arm/microchip_mec/mec172x/reg/mec172x_emi.h
@@ -25,9 +25,9 @@ struct emi_regs {
 	volatile uint8_t INTR_MSK_LSB;
 	volatile uint8_t INTR_MSK_MSB;
 	volatile uint8_t APPID;			/* +0x0C */
-	uint16_t RSVD1[3];
+	uint8_t RSVD1[3];
 	volatile uint8_t APPID_ASSGN;	/* +0x10 */
-	uint16_t RSVD2[3];
+	uint8_t RSVD2[3];
 	uint32_t RSVD3[(0x100 - 0x14) / 4];
 	volatile uint8_t HOST_TO_EC;	/* +0x100 */
 	volatile uint8_t EC_TO_HOST;


### PR DESCRIPTION
Multiple updates:
1. Rectify reserved fields size in MEC172x emi_regs structure
2. Make ec_host_cmd_sram[] buffer align on a 8-byte boundary
3. Add support for ACPI EC0 and custom opcodes
4. Handle ACPI EC0 and ACPI EC1 IBF ISR by reading input data in the ISR
5. Read KBC Status register before reading KBC Data register in kbc0_ibf_isr
6. Enable custom configs for KBC IBF event data and KBC OBF callback from ISR.

