### PR TITLE
include/atomics: doc: Clarify memory barrier behavior

### DIFF
--- a/doc/reference/kernel/other/atomic.rst
+++ b/doc/reference/kernel/other/atomic.rst
@@ -88,6 +88,17 @@ using an array of atomic variables.
         return (int)atomic_set_bit(flag_bits, bit_position);
     }
 
+Memory Ordering
+===============
+
+For consistency and correctness, all Zephyr atomic APIs are expected
+to include a full memory barrier (in the sense of e.g. "serializing"
+instructions on x86, "DMB" on ARM, or a "sequentially consistent"
+operation as defined by the C++ memory model) where needed by hardware
+to guarantee a reliable picture across contexts.  Any
+architecture-specific implementations are responsible for ensuring
+this behavior.
+
 Suggested Uses
 **************
 

--- a/include/sys/atomic.h
+++ b/include/sys/atomic.h
@@ -120,6 +120,9 @@ typedef atomic_ptr_t atomic_ptr_val_t;
  * This routine tests whether bit number @a bit of @a target is set or not.
  * The target may be a single atomic variable or an array of them.
  *
+ * @note As for all atomic APIs, includes a
+ * full/sequentially-consistent memory barrier (where applicable).
+ *
  * @param target Address of atomic variable or array.
  * @param bit Bit number (starting from 0).
  *
@@ -137,6 +140,9 @@ static inline bool atomic_test_bit(const atomic_t *target, int bit)
  *
  * Atomically clear bit number @a bit of @a target and return its old value.
  * The target may be a single atomic variable or an array of them.
+ *
+ * @note As for all atomic APIs, includes a
+ * full/sequentially-consistent memory barrier (where applicable).
  *
  * @param target Address of atomic variable or array.
  * @param bit Bit number (starting from 0).
@@ -159,6 +165,9 @@ static inline bool atomic_test_and_clear_bit(atomic_t *target, int bit)
  * Atomically set bit number @a bit of @a target and return its old value.
  * The target may be a single atomic variable or an array of them.
  *
+ * @note As for all atomic APIs, includes a
+ * full/sequentially-consistent memory barrier (where applicable).
+ *
  * @param target Address of atomic variable or array.
  * @param bit Bit number (starting from 0).
  *
@@ -180,6 +189,9 @@ static inline bool atomic_test_and_set_bit(atomic_t *target, int bit)
  * Atomically clear bit number @a bit of @a target.
  * The target may be a single atomic variable or an array of them.
  *
+ * @note As for all atomic APIs, includes a
+ * full/sequentially-consistent memory barrier (where applicable).
+ *
  * @param target Address of atomic variable or array.
  * @param bit Bit number (starting from 0).
  */
@@ -196,6 +208,9 @@ static inline void atomic_clear_bit(atomic_t *target, int bit)
  * Atomically set bit number @a bit of @a target.
  * The target may be a single atomic variable or an array of them.
  *
+ * @note As for all atomic APIs, includes a
+ * full/sequentially-consistent memory barrier (where applicable).
+ *
  * @param target Address of atomic variable or array.
  * @param bit Bit number (starting from 0).
  */
@@ -211,6 +226,9 @@ static inline void atomic_set_bit(atomic_t *target, int bit)
  *
  * Atomically set bit number @a bit of @a target to value @a val.
  * The target may be a single atomic variable or an array of them.
+ *
+ * @note As for all atomic APIs, includes a
+ * full/sequentially-consistent memory barrier (where applicable).
  *
  * @param target Address of atomic variable or array.
  * @param bit Bit number (starting from 0).

--- a/include/sys/atomic_builtin.h
+++ b/include/sys/atomic_builtin.h
@@ -29,6 +29,9 @@ extern "C" {
  * If the current value of @a target does not equal @a old_value, @a target
  * is left unchanged.
  *
+ * @note As for all atomic APIs, includes a
+ * full/sequentially-consistent memory barrier (where applicable).
+ *
  * @param target Address of atomic variable.
  * @param old_value Original value to compare against.
  * @param new_value New value to store.
@@ -50,6 +53,9 @@ static inline bool atomic_cas(atomic_t *target, atomic_val_t old_value,
  * If the current value of @a target does not equal @a old_value, @a target
  * is left unchanged.
  *
+ * @note As for all atomic APIs, includes a
+ * full/sequentially-consistent memory barrier (where applicable).
+ *
  * @param target Address of atomic variable.
  * @param old_value Original value to compare against.
  * @param new_value New value to store.
@@ -69,6 +75,9 @@ static inline bool atomic_ptr_cas(atomic_ptr_t *target, atomic_ptr_val_t old_val
  *
  * This routine performs an atomic addition on @a target.
  *
+ * @note As for all atomic APIs, includes a
+ * full/sequentially-consistent memory barrier (where applicable).
+ *
  * @param target Address of atomic variable.
  * @param value Value to add.
  *
@@ -84,6 +93,9 @@ static inline atomic_val_t atomic_add(atomic_t *target, atomic_val_t value)
  * @brief Atomic subtraction.
  *
  * This routine performs an atomic subtraction on @a target.
+ *
+ * @note As for all atomic APIs, includes a
+ * full/sequentially-consistent memory barrier (where applicable).
  *
  * @param target Address of atomic variable.
  * @param value Value to subtract.
@@ -101,6 +113,9 @@ static inline atomic_val_t atomic_sub(atomic_t *target, atomic_val_t value)
  *
  * This routine performs an atomic increment by 1 on @a target.
  *
+ * @note As for all atomic APIs, includes a
+ * full/sequentially-consistent memory barrier (where applicable).
+ *
  * @param target Address of atomic variable.
  *
  * @return Previous value of @a target.
@@ -115,6 +130,9 @@ static inline atomic_val_t atomic_inc(atomic_t *target)
  * @brief Atomic decrement.
  *
  * This routine performs an atomic decrement by 1 on @a target.
+ *
+ * @note As for all atomic APIs, includes a
+ * full/sequentially-consistent memory barrier (where applicable).
  *
  * @param target Address of atomic variable.
  *
@@ -131,6 +149,9 @@ static inline atomic_val_t atomic_dec(atomic_t *target)
  *
  * This routine performs an atomic read on @a target.
  *
+ * @note As for all atomic APIs, includes a
+ * full/sequentially-consistent memory barrier (where applicable).
+ *
  * @param target Address of atomic variable.
  *
  * @return Value of @a target.
@@ -145,6 +166,9 @@ static inline atomic_val_t atomic_get(const atomic_t *target)
  * @brief Atomic get a pointer value
  *
  * This routine performs an atomic read on @a target.
+ *
+ * @note As for all atomic APIs, includes a
+ * full/sequentially-consistent memory barrier (where applicable).
  *
  * @param target Address of pointer variable.
  *
@@ -161,6 +185,9 @@ static inline atomic_ptr_val_t atomic_ptr_get(const atomic_ptr_t *target)
  *
  * This routine atomically sets @a target to @a value and returns
  * the previous value of @a target.
+ *
+ * @note As for all atomic APIs, includes a
+ * full/sequentially-consistent memory barrier (where applicable).
  *
  * @param target Address of atomic variable.
  * @param value Value to write to @a target.
@@ -183,6 +210,9 @@ static inline atomic_val_t atomic_set(atomic_t *target, atomic_val_t value)
  * This routine atomically sets @a target to @a value and returns
  * the previous value of @a target.
  *
+ * @note As for all atomic APIs, includes a
+ * full/sequentially-consistent memory barrier (where applicable).
+ *
  * @param target Address of atomic variable.
  * @param value Value to write to @a target.
  *
@@ -200,6 +230,9 @@ static inline atomic_ptr_val_t atomic_ptr_set(atomic_ptr_t *target, atomic_ptr_v
  * This routine atomically sets @a target to zero and returns its previous
  * value. (Hence, it is equivalent to atomic_set(target, 0).)
  *
+ * @note As for all atomic APIs, includes a
+ * full/sequentially-consistent memory barrier (where applicable).
+ *
  * @param target Address of atomic variable.
  *
  * @return Previous value of @a target.
@@ -215,6 +248,9 @@ static inline atomic_val_t atomic_clear(atomic_t *target)
  *
  * This routine atomically sets @a target to zero and returns its previous
  * value. (Hence, it is equivalent to atomic_set(target, 0).)
+ *
+ * @note As for all atomic APIs, includes a
+ * full/sequentially-consistent memory barrier (where applicable).
  *
  * @param target Address of atomic variable.
  *
@@ -232,6 +268,9 @@ static inline atomic_ptr_val_t atomic_ptr_clear(atomic_ptr_t *target)
  * This routine atomically sets @a target to the bitwise inclusive OR of
  * @a target and @a value.
  *
+ * @note As for all atomic APIs, includes a
+ * full/sequentially-consistent memory barrier (where applicable).
+ *
  * @param target Address of atomic variable.
  * @param value Value to OR.
  *
@@ -245,6 +284,9 @@ static inline atomic_val_t atomic_or(atomic_t *target, atomic_val_t value)
 /**
  *
  * @brief Atomic bitwise exclusive OR (XOR).
+ *
+ * @note As for all atomic APIs, includes a
+ * full/sequentially-consistent memory barrier (where applicable).
  *
  * This routine atomically sets @a target to the bitwise exclusive OR (XOR) of
  * @a target and @a value.
@@ -266,6 +308,9 @@ static inline atomic_val_t atomic_xor(atomic_t *target, atomic_val_t value)
  * This routine atomically sets @a target to the bitwise AND of @a target
  * and @a value.
  *
+ * @note As for all atomic APIs, includes a
+ * full/sequentially-consistent memory barrier (where applicable).
+ *
  * @param target Address of atomic variable.
  * @param value Value to AND.
  *
@@ -282,6 +327,9 @@ static inline atomic_val_t atomic_and(atomic_t *target, atomic_val_t value)
  *
  * This routine atomically sets @a target to the bitwise NAND of @a target
  * and @a value. (This operation is equivalent to target = ~(target & value).)
+ *
+ * @note As for all atomic APIs, includes a
+ * full/sequentially-consistent memory barrier (where applicable).
  *
  * @param target Address of atomic variable.
  * @param value Value to NAND.


### PR DESCRIPTION
Zephyr is migrating into hardware where memory ordering is starting to
matter.  The existing gcc-based defaults have always been specifying
__ATOMIC_SEQ_CST, which is safe and correct.  And all the
arch-specific assembly we have currently are either safe or for
platforms where barriers aren't needed.

Discussion in #42831 made the case that it would be nice if we were to
formally promise this, and require it from future implementations.  So
let's do that.

Fixes: #42831

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>