### PR TITLE
drivers: it8xxx2: fix GPIO interrupt enables

### DIFF
--- a/drivers/espi/espi_it8xxx2.c
+++ b/drivers/espi/espi_it8xxx2.c
@@ -1804,7 +1804,7 @@ static void espi_it8xxx2_enable_reset(void)
 	gpio_add_callback(ESPI_IT8XXX2_ESPI_RESET_PORT, &espi_reset_cb);
 	gpio_pin_interrupt_configure(ESPI_IT8XXX2_ESPI_RESET_PORT,
 					ESPI_IT8XXX2_ESPI_RESET_PIN,
-					GPIO_INT_TRIG_BOTH);
+					GPIO_INT_MODE_EDGE | GPIO_INT_TRIG_BOTH);
 }
 
 static struct espi_it8xxx2_data espi_it8xxx2_data_0;

--- a/drivers/serial/uart_ite_it8xxx2.c
+++ b/drivers/serial/uart_ite_it8xxx2.c
@@ -97,7 +97,7 @@ static inline int uart_it8xxx2_pm_action(const struct device *dev,
 	case PM_DEVICE_ACTION_SUSPEND:
 		/* Enable UART WUI */
 		ret = gpio_pin_interrupt_configure_dt(&config->gpio_wui,
-						      GPIO_INT_TRIG_LOW);
+						      GPIO_INT_MODE_EDGE | GPIO_INT_TRIG_LOW);
 		if (ret < 0) {
 			LOG_ERR("Failed to configure UART%d WUI (ret %d)",
 				config->port, ret);


### PR DESCRIPTION
gpio_pin_interrupt_configure asserts that one of GPIO_INT_ENABLE or
_DISABLE is specified by the caller, and also that GPIO_INT_EDGE is
requested if both states (GPIO_INT_TRIG_BOTH) should interrupt. This
change corrects the misuses in it8xxx2 drivers that cause assertion
failures.

When assertions are disabled the existing code works correctly because
the it8xxx2 GPIO driver assumes that a pin interrupt should be enabled
if _DISABLE is not requested, and the driver only supports edge
triggers but assumes the absence of GPIO_INT_MODE_LEVEL indicates
an edge trigger was requested.

Signed-off-by: Peter Marheine <pmarheine@chromium.org>