### PR TITLE
soc: intel_adsp: update UUIDs of BRNGUP and BASEFW

### DIFF
--- a/soc/xtensa/intel_adsp/common/rimage_modules.c
+++ b/soc/xtensa/intel_adsp/common/rimage_modules.c
@@ -5,19 +5,24 @@
 #include <cavs-mem.h>
 #include <toolchain.h>
 
-/* These data structures define "module manifest" headers.  They
- * aren't runtime data used by Zephyr, but instead act as input
- * parameters to rimage and later to the ROM loader on the DSP.  As it
- * happens most of the data here is ignored by both layers, but it's
- * left unchanged for historical purposes.
+/* These two modules defined here aren't runtime data used by Zephyr or
+ * SOF with IPC3, but instead are inserted to *MANIFEST* of the final
+ * firmware binary by rimage and later will be used by ROM loader on the
+ * DSP. As it happens most of the data here is ignored by both layers,
+ * but it's left unchanged for historical purposes.
+ *
+ * For each module here, two UUIDs are allowed, one used on APL, and the
+ * other used on cAVS 1.8+ platforms. Because SOF with IPC4 requires the
+ * module UUID in manifest must be identical with the one in firmware code,
+ * and there will be *NO* IPC4 support for APL, we have to use UUIDs used
+ * on cAVS 1.8+ platforms here.
  */
-
 __attribute__((section(".module.boot")))
 const struct sof_man_module_manifest boot_manifest = {
 	.module = {
 		     .name = "BRNGUP",
-		     .uuid = { 0xcc, 0x48, 0x7b, 0x0d, 0xa9, 0x1e, 0x0a, 0x47,
-			       0xa8, 0xc1, 0x53, 0x34, 0x24, 0x52, 0x8a, 0x17 },
+		     .uuid = {0xf3, 0xe4, 0x79, 0x2b, 0x75, 0x46, 0x49, 0xf6,
+			      0x89, 0xdf, 0x3b, 0xc1, 0x94, 0xa9, 0x1a, 0xeb},
 		     .entry_point = IMR_BOOT_LDR_TEXT_ENTRY_BASE,
 		     .type = { .load_type = SOF_MAN_MOD_TYPE_MODULE,
 			       .domain_ll = 1, },
@@ -28,9 +33,9 @@ const struct sof_man_module_manifest boot_manifest = {
 __attribute__((section(".module.main")))
 const struct sof_man_module_manifest main_manifest = {
 	.module = {
-		     .name	= "BASEFW",
-		     .uuid	= { 0x2e, 0x9e, 0x86, 0xfc, 0xf8, 0x45, 0x45, 0x40,
-				    0xa4, 0x16, 0x89, 0x88, 0x0a, 0xe3, 0x20, 0xa9 },
+		     .name = "BASEFW",
+		     .uuid = {0x32, 0x8c, 0x39, 0x0e, 0xde, 0x5a, 0x4b, 0xba,
+			      0x93, 0xb1, 0xc5, 0x04, 0x32, 0x28, 0x0e, 0xe4},
 		     .entry_point = RAM_BASE,
 		     .type = { .load_type = SOF_MAN_MOD_TYPE_MODULE,
 			       .domain_ll = 1 },


### PR DESCRIPTION
The SOF ipc4 driver and Windows driver can't work with
SOF built with zephyr and ipc4 configuration on cAVS 1.8+
platforms. Because the UUIDs of BRNGUP and BASEFW are
copied from APL (cAVS 1.5), which is incompatible with
cAVS 1.8+ platforms.

This patch updates BRNGUP and BASEFW to use cAVS 1.8+ UUIDs.

Signed-off-by: Rander Wang <rander.wang@intel.com>