### PR TITLE
TF-M: Fix nRF53 SoC GPIO service for MCU selection

### DIFF
--- a/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp_common.dts
+++ b/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp_common.dts
@@ -65,6 +65,14 @@
 		};
 	};
 
+	gpio_fwd: nrf-gpio-forwarder {
+		compatible = "nordic,nrf-gpio-forwarder";
+		status = "okay";
+		uart {
+			gpios = <&gpio1 8 0>, <&gpio1 10 0>, <&gpio1 7 0>, <&gpio1 9 0>;
+		};
+	};
+
 	/* These aliases are provided for compatibility with samples */
 	aliases {
 		led0 = &led1;

--- a/boards/arm/bl5340_dvk/bl5340_dvk_cpunet_reset.c
+++ b/boards/arm/bl5340_dvk/bl5340_dvk_cpunet_reset.c
@@ -10,29 +10,11 @@
 #include <logging/log.h>
 
 #include <soc.h>
-#include <soc_secure.h>
 
 LOG_MODULE_REGISTER(bl5340_dvk_cpuapp, CONFIG_LOG_DEFAULT_LEVEL);
 
-/* TODO: This should come from DTS, possibly an overlay. */
-#define CPUNET_UARTE_PIN_TX 33
-#define CPUNET_UARTE_PIN_RX 32
-#define CPUNET_UARTE_PIN_RTS 11
-#define CPUNET_UARTE_PIN_CTS 10
-
 static void remoteproc_mgr_config(void)
 {
-#if !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) || defined(CONFIG_BUILD_WITH_TFM)
-	/* UARTE */
-	/* Assign specific GPIOs that will be used to get UARTE from
-	 * nRF5340 Network MCU.
-	 */
-	soc_secure_gpio_pin_mcu_select(CPUNET_UARTE_PIN_TX, NRF_GPIO_PIN_MCUSEL_NETWORK);
-	soc_secure_gpio_pin_mcu_select(CPUNET_UARTE_PIN_RX, NRF_GPIO_PIN_MCUSEL_NETWORK);
-	soc_secure_gpio_pin_mcu_select(CPUNET_UARTE_PIN_RTS, NRF_GPIO_PIN_MCUSEL_NETWORK);
-	soc_secure_gpio_pin_mcu_select(CPUNET_UARTE_PIN_CTS, NRF_GPIO_PIN_MCUSEL_NETWORK);
-#endif /* !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) || defined(CONFIG_BUILD_WITH_TFM) */
-
 #if !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
 	/* Retain nRF5340 Network MCU in Secure domain (bus
 	 * accesses by Network MCU will have Secure attribute set).

--- a/boards/arm/nrf5340dk_nrf5340/CMakeLists.txt
+++ b/boards/arm/nrf5340dk_nrf5340/CMakeLists.txt
@@ -5,4 +5,11 @@ if ((CONFIG_BOARD_NRF5340DK_NRF5340_CPUAPP OR CONFIG_BOARD_NRF5340DK_NRF5340_CPU
     AND CONFIG_BOARD_ENABLE_CPUNET)
 zephyr_library()
 zephyr_library_sources(nrf5340_cpunet_reset.c)
+
+if (CONFIG_BUILD_WITH_TFM)
+  zephyr_library_include_directories(
+    $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/install/interface/include
+  )
+endif()
+
 endif()

--- a/west.yml
+++ b/west.yml
@@ -223,7 +223,7 @@ manifest:
       groups:
         - debug
     - name: trusted-firmware-m
-      revision: 5d32c3e64b3d589548e881eeeeb37d84944c90af
+      revision: pull/68/head
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
Update trusted-firmware-m to include GPIO service fix.
This would otherwise result in an assert or GPIO pins not assigned to the network.
This was the root cause of https://github.com/zephyrproject-rtos/zephyr/issues/43476.

Fix the BL5340 DVK pin assignment using the nrf5340 DK pin.
Regression from: https://github.com/zephyrproject-rtos/zephyr/commit/e4260ac03fa6e2f1bc3770826e6dcb54021cab42.

This also aligns the BL5340 DVK to use the GPIO forward module.

Fix missing include path for TF-M installed headers.
When TF-M was enabled resulted in the following error:
"fatal error: tfm_ioctl_api.h: No such file or directory"
