### PR TITLE
Bluetooth: Mesh: Change ERR to WARN

### DIFF
--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -720,7 +720,7 @@ static void bt_mesh_net_relay(struct net_buf_simple *sbuf,
 	buf = bt_mesh_adv_create(BT_MESH_ADV_DATA, BT_MESH_RELAY_ADV,
 				 transmit, K_NO_WAIT);
 	if (!buf) {
-		BT_ERR("Out of relay buffers");
+		BT_WARN("Out of relay buffers");
 		return;
 	}
 


### PR DESCRIPTION
Changes ERR to WARN message when relay buffers
run out, as this is not really an error but a
consequence of high traffic.

Signed-off-by: Omkar Kulkarni <omkar.kulkarni@nordicsemi.no>