### PR TITLE
Mcumgr lib reductions

### DIFF
--- a/subsys/mgmt/mcumgr/buf.c
+++ b/subsys/mgmt/mcumgr/buf.c
@@ -8,6 +8,7 @@
 #include <sys/byteorder.h>
 #include "net/buf.h"
 #include "mgmt/mcumgr/buf.h"
+#include <mgmt/mgmt.h>
 
 NET_BUF_POOL_DEFINE(pkt_pool, CONFIG_MCUMGR_BUF_COUNT, CONFIG_MCUMGR_BUF_SIZE,
 		    CONFIG_MCUMGR_BUF_USER_DATA_SIZE, NULL);
@@ -144,7 +145,10 @@ cbor_nb_write(struct cbor_encoder_writer *writer, const char *data, int len)
 void
 cbor_nb_writer_init(struct cbor_nb_writer *cnw, struct net_buf *nb)
 {
+	net_buf_reset(nb);
 	cnw->nb = nb;
-	cnw->enc.bytes_written = 0;
+	/* Reserve header space */
+	cnw->nb->len = sizeof(struct mgmt_hdr);
+	cnw->enc.bytes_written = sizeof(struct mgmt_hdr);
 	cnw->enc.write = &cbor_nb_write;
 }

--- a/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
@@ -142,21 +142,17 @@ typedef void (*mgmt_trim_front_fn)(void *buf, size_t len, void *arg);
 typedef void (*mgmt_reset_buf_fn)(void *buf, void *arg);
 
 /** @typedef mgmt_write_at_fn
- * @brief Writes data to a CBOR encoder.
+ * @brief Writes header at the beginning of buffer
  *
- * Any existing data at the specified offset is overwritten by the new data.
- * Any new data that extends past the buffer's current length is appended.
+ * Overwrites beginning of buffer with header; moves buffer data pointer so that next
+ * non-header writes would happen after header.
  *
  * @param writer	The encoder to write to.
- * @param offset	The byte offset to write to,
- * @param data		The data to write.
- * @param len		The number of bytes to write.
- * @param arg		Optional streamer argument.
+ * @param hdr		Header to write (struct mgmt_hdr);
  *
  * @return 0 on success, MGMT_ERR_[...] code on failure.
  */
-typedef int (*mgmt_write_at_fn)(struct cbor_encoder_writer *writer, size_t offset,
-	     const void *data, size_t len, void *arg);
+typedef int (*mgmt_write_hdr_fn)(struct cbor_encoder_writer *writer, const struct mgmt_hdr *hdr);
 
 /** @typedef mgmt_init_reader_fn
  * @brief Initializes a CBOR reader with the specified buffer.
@@ -195,7 +191,7 @@ struct mgmt_streamer_cfg {
 	mgmt_alloc_rsp_fn alloc_rsp;
 	mgmt_trim_front_fn trim_front;
 	mgmt_reset_buf_fn reset_buf;
-	mgmt_write_at_fn write_at;
+	mgmt_write_hdr_fn write_hdr;
 	mgmt_init_reader_fn init_reader;
 	mgmt_init_writer_fn init_writer;
 	mgmt_free_buf_fn free_buf;
@@ -291,21 +287,18 @@ void mgmt_streamer_trim_front(struct mgmt_streamer *streamer, void *buf, size_t 
 void mgmt_streamer_reset_buf(struct mgmt_streamer *streamer, void *buf);
 
 /**
- * @brief Uses the specified streamer to write data to a CBOR encoder.
+ * @brief Uses the specified streamer to write header to buffer.
  *
- * Any existing data at the specified offset is overwritten by the new data.
+ * Any existing data at the beginning buffer will be overwritten with header.
  * Any new data that extends past the buffer's current length is appended.
  *
  * @param streamer	The streamer providing the callback.
  * @param writer	The encoder to write to.
- * @param offset	The byte offset to write to,
- * @param data		The data to write.
- * @param len		The number of bytes to write.
+ * @param hdr		The mgmt_hdr struct to write.
  *
  * @return 0 on success, MGMT_ERR_[...] code on failure.
  */
-int mgmt_streamer_write_at(struct mgmt_streamer *streamer, size_t offset, const void *data,
-			   int len);
+int mgmt_streamer_write_hdr(struct mgmt_streamer *streamer, const struct mgmt_hdr *hdr);
 
 /**
  * @brief Uses the specified streamer to initialize a CBOR reader.

--- a/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
@@ -159,11 +159,10 @@ typedef int (*mgmt_write_hdr_fn)(struct cbor_encoder_writer *writer, const struc
  *
  * @param reader	The reader to initialize.
  * @param buf		The buffer to configure the reader with.
- * @param arg		Optional streamer argument.
  *
  * @return 0 on success, MGMT_ERR_[...] code on failure.
  */
-typedef int (*mgmt_init_reader_fn)(struct cbor_decoder_reader *reader, void *buf, void *arg);
+typedef int (*mgmt_init_reader_fn)(struct cbor_decoder_reader *reader, void *buf);
 
 /** @typedef mgmt_init_writer_fn
  * @brief Initializes a CBOR writer with the specified buffer.

--- a/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
@@ -169,11 +169,10 @@ typedef int (*mgmt_init_reader_fn)(struct cbor_decoder_reader *reader, void *buf
  *
  * @param writer	The writer to initialize.
  * @param buf		The buffer to configure the writer with.
- * @param arg		Optional streamer argument.
  *
  * @return 0 on success, MGMT_ERR_[...] code on failure.
  */
-typedef int (*mgmt_init_writer_fn)(struct cbor_encoder_writer *writer, void *buf, void *arg);
+typedef int (*mgmt_init_writer_fn)(struct cbor_encoder_writer *writer, void *buf);
 
 /** @typedef mgmt_init_writer_fn
  * @brief Frees the specified buffer.

--- a/subsys/mgmt/mcumgr/lib/mgmt/src/mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/mgmt/src/mgmt.c
@@ -33,10 +33,9 @@ mgmt_streamer_reset_buf(struct mgmt_streamer *streamer, void *buf)
 }
 
 int
-mgmt_streamer_write_at(struct mgmt_streamer *streamer, size_t offset,
-					   const void *data, int len)
+mgmt_streamer_write_hdr(struct mgmt_streamer *streamer, const struct mgmt_hdr *hdr)
 {
-	return streamer->cfg->write_at(streamer->writer, offset, data, len, streamer->cb_arg);
+	return streamer->cfg->write_hdr(streamer->writer, hdr);
 }
 
 int

--- a/subsys/mgmt/mcumgr/lib/mgmt/src/mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/mgmt/src/mgmt.c
@@ -47,7 +47,7 @@ mgmt_streamer_init_reader(struct mgmt_streamer *streamer, void *buf)
 int
 mgmt_streamer_init_writer(struct mgmt_streamer *streamer, void *buf)
 {
-	return streamer->cfg->init_writer(streamer->writer, buf, streamer->cb_arg);
+	return streamer->cfg->init_writer(streamer->writer, buf);
 }
 
 void

--- a/subsys/mgmt/mcumgr/lib/mgmt/src/mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/mgmt/src/mgmt.c
@@ -41,7 +41,7 @@ mgmt_streamer_write_hdr(struct mgmt_streamer *streamer, const struct mgmt_hdr *h
 int
 mgmt_streamer_init_reader(struct mgmt_streamer *streamer, void *buf)
 {
-	return streamer->cfg->init_reader(streamer->reader, buf, streamer->cb_arg);
+	return streamer->cfg->init_reader(streamer->reader, buf);
 }
 
 int

--- a/subsys/mgmt/mcumgr/smp.c
+++ b/subsys/mgmt/mcumgr/smp.c
@@ -199,8 +199,7 @@ zephyr_smp_init_reader(struct cbor_decoder_reader *reader, void *buf)
 }
 
 static int
-zephyr_smp_init_writer(struct cbor_encoder_writer *writer, void *buf,
-		       void *arg)
+zephyr_smp_init_writer(struct cbor_encoder_writer *writer, void *buf)
 {
 	struct cbor_nb_writer *czw;
 

--- a/subsys/mgmt/mcumgr/smp.c
+++ b/subsys/mgmt/mcumgr/smp.c
@@ -188,8 +188,7 @@ zephyr_smp_tx_rsp(struct smp_streamer *ns, void *rsp, void *arg)
 }
 
 static int
-zephyr_smp_init_reader(struct cbor_decoder_reader *reader, void *buf,
-		       void *arg)
+zephyr_smp_init_reader(struct cbor_decoder_reader *reader, void *buf)
 {
 	struct cbor_nb_reader *czr;
 

--- a/subsys/mgmt/mcumgr/smp.c
+++ b/subsys/mgmt/mcumgr/smp.c
@@ -122,8 +122,7 @@ zephyr_smp_reset_buf(void *buf, void *arg)
 }
 
 static int
-zephyr_smp_write_at(struct cbor_encoder_writer *writer, size_t offset,
-		    const void *data, size_t len, void *arg)
+zephyr_smp_write_hdr(struct cbor_encoder_writer *writer, const struct mgmt_hdr *hdr)
 {
 	struct cbor_nb_writer *czw;
 	struct net_buf *nb;
@@ -131,19 +130,7 @@ zephyr_smp_write_at(struct cbor_encoder_writer *writer, size_t offset,
 	czw = (struct cbor_nb_writer *)writer;
 	nb = czw->nb;
 
-	if (offset > nb->len) {
-		return MGMT_ERR_EINVAL;
-	}
-
-	if ((offset + len) > (nb->size - net_buf_headroom(nb))) {
-		return MGMT_ERR_EINVAL;
-	}
-
-	memcpy(nb->data + offset, data, len);
-	if (nb->len < offset + len) {
-		nb->len = offset + len;
-		writer->bytes_written = nb->len;
-	}
+	memcpy(nb->data, hdr, sizeof(*hdr));
 
 	return 0;
 }
@@ -270,7 +257,7 @@ static const struct mgmt_streamer_cfg zephyr_smp_cbor_cfg = {
 	.alloc_rsp = zephyr_smp_alloc_rsp,
 	.trim_front = zephyr_smp_trim_front,
 	.reset_buf = zephyr_smp_reset_buf,
-	.write_at = zephyr_smp_write_at,
+	.write_hdr = zephyr_smp_write_hdr,
 	.init_reader = zephyr_smp_init_reader,
 	.init_writer = zephyr_smp_init_writer,
 	.free_buf = zephyr_smp_free_buf,


### PR DESCRIPTION
The PR contains commits that:
 1) change response buffer initialization to reserve SMP header space; previously the header space have been allocated on first write to buffer and then re-used to write final buffer; the mgmt_streamer_write_at has been replaced with mgmt_streamer_write_hdr as it is only used to write header at the beginning of a buffer.
 2) changes smp_init_rps_header function into smp_make_rsp_hdr that prepares SMP response header and writes it at the beginning of buffer;
 3) Removes never used parameter arg from mgmt_init_reader_fn prototype and implementations;
 4) Removes never used parameter arg from mgmt_initi_writer_fn prototype and implementations.